### PR TITLE
Add Dockerfiles for client and server

### DIFF
--- a/docker/client/1.1.53981/Dockerfile
+++ b/docker/client/1.1.53981/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:14.04
+
+ENV CLICKHOUSE_VERSION 1.1.53981
+
+RUN mkdir -p /etc/apt/sources.list.d && \
+    echo "deb http://repo.yandex.ru/clickhouse/trusty/ dists/stable/main/binary-amd64/" | tee /etc/apt/sources.list.d/clickhouse.list && \
+    apt-get update && \
+    apt-get install --force-yes -y clickhouse-client="$CLICKHOUSE_VERSION" && \
+    rm -rf /var/lib/apt/lists/* /var/cache/
+
+ENV CLICKHOUSE_HOST localhost
+ENV CLICKHOUSE_PORT 9000
+
+CMD ["sh", "-c", "clickhouse-client --host ${CLICKHOUSE_HOST} --port ${CLICKHOUSE_PORT}"]

--- a/docker/server/1.1.53981/Dockerfile
+++ b/docker/server/1.1.53981/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:14.04
+
+ENV CLICKHOUSE_VERSION 1.1.53981
+
+RUN mkdir -p /etc/apt/sources.list.d && \
+    echo "deb http://repo.yandex.ru/clickhouse/trusty/ dists/stable/main/binary-amd64/" | tee /etc/apt/sources.list.d/clickhouse.list && \
+    apt-get update && \
+    apt-get install --force-yes -y clickhouse-server-common="$CLICKHOUSE_VERSION" && \
+    rm -rf /var/lib/apt/lists/* /var/cache/
+
+RUN chown -R metrika /etc/clickhouse-server/
+
+USER metrika
+EXPOSE 9000 8123 9009
+
+ENV FILE_DESCRIPTORS_LIMIT 262144
+ENV CLICKHOUSE_CONFIG /etc/clickhouse-server/config.xml
+
+CMD ["sh", "-c", "ulimit -n ${FILE_DESCRIPTORS_LIMIT} && /usr/bin/clickhouse-server --config=${CLICKHOUSE_CONFIG}"]


### PR DESCRIPTION
With this Docker images you can run clickhouse server and client like this:

```
docker build -t clickhouse-server docker/server/1.1.53981/Dockerfile
docker run -d --name=server clickhouse-server

docker build -t clickhouse-client docker/client/1.1.53981/Dockerfile
docker run -it --rm --link clickhouse-server -e "CLICKHOUSE_HOST=clickhouse-server" clickhouse-client
```
