### PR TITLE
make clean: remove debian/*.docs generated links

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -40,7 +40,7 @@ clean:
 	find ./debian/ -name "*.cron.d" -type f -delete
 	# Удалим созданные для dh_installlogrotate файлы
 	find ./debian/ -name "*.logrotate" -type f -delete
-	# Удалим созданные файлы документации
+	# Удалим созданные ссылки на файлы документации
 	find ./debian/ -name "*.docs" -type l -delete
 	rm ./debian/copyright
 	# Удалим созданные *.install файлы

--- a/debian/rules
+++ b/debian/rules
@@ -42,7 +42,7 @@ clean:
 	find ./debian/ -name "*.logrotate" -type f -delete
 	# Удалим созданные ссылки на файлы документации
 	find ./debian/ -name "*.docs" -type l -delete
-	rm ./debian/copyright
+	rm -f ./debian/copyright
 	# Удалим созданные *.install файлы
 	for DAEMON_PKG in ${DAEMONS}; do AUTO=`grep "# automatically created" debian/$$DAEMON_PKG-metrika-yandex.install`; if [ "x$$AUTO" != "x" ]; then rm -f debian/$$DAEMON_PKG-metrika-yandex.install; fi; done
 	dh_clean

--- a/debian/rules
+++ b/debian/rules
@@ -40,6 +40,9 @@ clean:
 	find ./debian/ -name "*.cron.d" -type f -delete
 	# Удалим созданные для dh_installlogrotate файлы
 	find ./debian/ -name "*.logrotate" -type f -delete
+	# Удалим созданные файлы документации
+	find ./debian/ -name "*.docs" -type l -delete
+	rm ./debian/copyright
 	# Удалим созданные *.install файлы
 	for DAEMON_PKG in ${DAEMONS}; do AUTO=`grep "# automatically created" debian/$$DAEMON_PKG-metrika-yandex.install`; if [ "x$$AUTO" != "x" ]; then rm -f debian/$$DAEMON_PKG-metrika-yandex.install; fi; done
 	dh_clean


### PR DESCRIPTION
Fix release build failure on existence of debian/*.docs links from previous build:

```
ln -s clickhouse-server.docs debian/clickhouse-server-base.docs
ln: failed to create symbolic link 'debian/clickhouse-server-base.docs': File exists
debian/rules:48: recipe for target 'install' failed
make: *** [install] Error 1
dpkg-buildpackage: error: fakeroot debian/rules binary gave error exit status 2
debuild: fatal error at line 1376:
dpkg-buildpackage -rfakeroot -D -us -uc -b failed
```
