### PR TITLE
[DOC] Remove invalid statement about Zookeeper

### DIFF
--- a/doc/reference_en.html
+++ b/doc/reference_en.html
@@ -2798,7 +2798,7 @@ You can specify any existing ZooKeeper cluster - the system will use a directory
 
 If ZooKeeper isn&#39;t set in the config file, you can&#39;t create replicated tables, and any existing replicated tables will be read-only.
 
-ZooKeeper isn&#39;t used for SELECT queries. In other words, replication doesn&#39;t affect the productivity of SELECT queries - they work just as fast as for non-replicated tables.
+Replication doesn&#39;t affect the productivity of SELECT queries - they work just as fast as for non-replicated tables.
 
 For each INSERT query (more precisely, for each inserted block of data; the INSERT query contains a single block, or per block for every max_insert_block_size = 1048576 rows), approximately ten entries are made in ZooKeeper in several transactions. This leads to slightly longer latencies for INSERT compared to non-replicated tables. But if you follow the recommendations to insert data in batches of no more than one INSERT per second, it doesn&#39;t create any problems. The entire ClickHouse cluster used for coordinating one ZooKeeper cluster has a total of several hundred INSERTs per second. The throughput on data inserts (the number of rows per second) is just as high as for non-replicated data.
 


### PR DESCRIPTION
FWIU, Zookeeper is not just for replication, it's also used for distributed tables. Clickhouse stores metadata in Zookeeper and query them when a SELECT statement is executed so this statement is invalid.
