### PR TITLE
terminate sends SIGTERM instead of SIGINT

### DIFF
--- a/dbms/include/DB/IO/CompressedReadBufferBase.h
+++ b/dbms/include/DB/IO/CompressedReadBufferBase.h
@@ -124,7 +124,7 @@ protected:
 			if (!qlz_state)
 				qlz_state = std::make_unique<qlz_state_decompress>();
 
-			qlz_decompress(&compressed_buffer[0], to, qlz_state);
+			qlz_decompress(&compressed_buffer[0], to, qlz_state.get());
 		#else
 			throw Exception("QuickLZ compression method is disabled", ErrorCodes::UNKNOWN_COMPRESSION_METHOD);
 		#endif

--- a/libs/libdaemon/src/BaseDaemon.cpp
+++ b/libs/libdaemon/src/BaseDaemon.cpp
@@ -537,7 +537,7 @@ void BaseDaemon::terminate()
 	getTaskManager().cancelAll();
 	if (::kill(Poco::Process::id(), SIGTERM) != 0)
 	{
-		Poco::SystemException("cannot terminate process");
+		throw Poco::SystemException("cannot terminate process");
 	}
 }
 

--- a/libs/libdaemon/src/BaseDaemon.cpp
+++ b/libs/libdaemon/src/BaseDaemon.cpp
@@ -535,7 +535,10 @@ BaseDaemon::~BaseDaemon()
 void BaseDaemon::terminate()
 {
 	getTaskManager().cancelAll();
-	ServerApplication::terminate();
+	if (::kill(Poco::Process::id(), SIGTERM) != 0)
+	{
+		Poco::SystemException("cannot terminate process");
+	}
 }
 
 void BaseDaemon::kill()


### PR DESCRIPTION
gdb catches SIGINT and by default doesn't pass it to process. But it passes SIGTERM
