### PR TITLE
Dockerfile: "sh: 1: ulimit: error setting limit (Operation not permitted)" error fixing

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -11,7 +11,6 @@ RUN chown -R metrika /etc/clickhouse-server/
 USER metrika
 EXPOSE 9000 8123 9009
 
-ENV FILE_DESCRIPTORS_LIMIT 262144
 ENV CLICKHOUSE_CONFIG /etc/clickhouse-server/config.xml
 
-CMD ["sh", "-c", "ulimit -n ${FILE_DESCRIPTORS_LIMIT} && /usr/bin/clickhouse-server --config=${CLICKHOUSE_CONFIG}"]
+CMD ["sh", "-c", "/usr/bin/clickhouse-server --config=${CLICKHOUSE_CONFIG}"]

--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -12,7 +12,7 @@ For more information and documentation see https://clickhouse.yandex/.
 
 ### start server instance
 ```bash
-$ docker run -d --name some-clickhouse-server yandex/clickhouse-server
+$ docker run -d --name some-clickhouse-server --ulimit nofile=262144:262144 yandex/clickhouse-server
 ```
 
 ### connect to it from a native client
@@ -30,7 +30,7 @@ ClickHouse configuration represented with a file "config.xml" ([documentation](h
 
 ### start server instance with custom configuration
 ```bash
-$ docker run -d --name some-clickhouse-server -v /path/to/your/config.xml:/etc/clickhouse-server/config.xml yandex/clickhouse-server
+$ docker run -d --name some-clickhouse-server --ulimit nofile=262144:262144 -v /path/to/your/config.xml:/etc/clickhouse-server/config.xml yandex/clickhouse-server
 ```
 
 ## License


### PR DESCRIPTION
I cannot run container on the latest Docker (1.12.0, build 8eab29e) because of **"sh: 1: ulimit: error setting limit (Operation not permitted)"** error. The latest docker supports setting ulimits through the command line --ulimit nofile=262144:262144.
