### PR TITLE
Add CORS hearder,param:add_http_cors_header and check request header

### DIFF
--- a/dbms/include/DB/IO/WriteBufferFromHTTPServerResponse.h
+++ b/dbms/include/DB/IO/WriteBufferFromHTTPServerResponse.h
@@ -35,7 +35,7 @@ class WriteBufferFromHTTPServerResponse : public BufferWithOwnMemory<WriteBuffer
 {
 private:
 	Poco::Net::HTTPServerResponse & response;
-
+	bool add_cors_header;
 	bool compress;
 	Poco::DeflatingStreamBuf::StreamType compression_method;
 	int compression_level = Z_DEFAULT_COMPRESSION;
@@ -48,6 +48,11 @@ private:
 	{
 		if (!ostr)
 		{
+			if (add_cors_header)
+			{
+				response.set("Access-Control-Allow-Origin","*");
+			}
+
 			if (compress && offset())	/// Пустой ответ сжимать не нужно.
 			{
 				if (compression_method == Poco::DeflatingStreamBuf::STREAM_GZIP)
@@ -118,6 +123,15 @@ public:
 	void setCompressionLevel(int level)
 	{
 		compression_level = level;
+	}
+
+	/** Включить или отключить CORS.
+	  * Работает только перед тем, как были отправлены HTTP заголовки.
+	  * Иначе - не имеет эффекта.
+	  */
+	void addHeaderCORS(bool enable_cors)
+	{
+		add_cors_header = enable_cors;
 	}
 
 	~WriteBufferFromHTTPServerResponse()

--- a/dbms/include/DB/Interpreters/Settings.h
+++ b/dbms/include/DB/Interpreters/Settings.h
@@ -220,8 +220,10 @@ struct Settings
 	\
 	/** Write statistics about read rows, bytes, time elapsed in suitable output formats */ \
 	M(SettingBool, output_format_write_statistics, true) \
-
-
+	\
+	/** Write add http CORS header */ \
+	M(SettingBool, add_http_cors_header, false) \
+	
 	/// Всевозможные ограничения на выполнение запроса.
 	Limits limits;
 

--- a/dbms/src/Server/HTTPHandler.cpp
+++ b/dbms/src/Server/HTTPHandler.cpp
@@ -246,6 +246,9 @@ void HTTPHandler::processQuery(
 	if (in_post_compressed && context.getSettingsRef().http_native_compression_disable_checksumming_on_decompress)
 		static_cast<CompressedReadBuffer &>(*in_post_maybe_compressed).disableChecksumming();
 
+	/// Добавить CORS header выставлена настройка, и если клиент передал заголовок Origin
+	used_output.out->addHeaderCORS( context.getSettingsRef().add_http_cors_header && !request.get("Origin", "").empty() );
+
 	context.setInterface(Context::Interface::HTTP);
 
 	Context::HTTPMethod http_method = Context::HTTPMethod::UNKNOWN;


### PR DESCRIPTION
В ответе HTTP сервера, отдавать заголовок :

```
Access-Control-Allow-Origin: *
```

Если:
- Указан параметр add_http_cors_header=1 в параметрах запроса
- Передан заголовок Origin

Пример:

```
curl -v "http://192.168.1.22:8123?query=show%20databases&add_http_cors_header=1" -H "Origin:smi2.ru"

...
> GET /?query=show%20databases&add_http_cors_header=1 HTTP/1.1
> Host: 192.168.1.22:8123
> User-Agent: curl/7.43.0
> Accept: */*
> Origin:smi2.ru
>
< HTTP/1.1 200 OK
< Date: Tue, 23 Aug 2016 18:36:41 GMT
< Connection: Keep-Alive
< Content-Type: text/tab-separated-values; charset=UTF-8
< Transfer-Encoding: chunked
< Access-Control-Allow-Origin: *
<
default
system


```

Без заголовка:

```
curl -v "http://192.168.1.22:8123?query=show%20databases&add_http_cors_header=1"
или 
curl -v "http://192.168.1.22:8123?query=show%20databases" -H "Origin:smi2.ru"
нет ACAO

```
