### PR TITLE
Fixed std::terminate on DROP of StorageReplicatedMergeTree

### DIFF
--- a/dbms/include/DB/Storages/StorageReplicatedMergeTree.h
+++ b/dbms/include/DB/Storages/StorageReplicatedMergeTree.h
@@ -248,6 +248,7 @@ private:
 	/** Является ли эта реплика "ведущей". Ведущая реплика выбирает куски для слияния.
 	  */
 	bool is_leader_node = false;
+	std::mutex leader_node_mutex;
 
 	InterserverIOEndpointHolderPtr endpoint_holder;
 	InterserverIOEndpointHolderPtr disk_space_monitor_endpoint_holder;

--- a/dbms/include/DB/Storages/StorageReplicatedMergeTree.h
+++ b/dbms/include/DB/Storages/StorageReplicatedMergeTree.h
@@ -200,6 +200,7 @@ private:
 	friend class ReplicatedMergeTreePartCheckThread;
 	friend class ReplicatedMergeTreeCleanupThread;
 	friend class ReplicatedMergeTreeAlterThread;
+	friend class ReplicatedMergeTreeRestartingThread;
 	friend struct ReplicatedMergeTreeLogEntry;
 	friend class ScopedPartitionMergeLock;
 

--- a/dbms/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/dbms/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -381,6 +381,16 @@ void ReplicatedMergeTreeRestartingThread::partialShutdown()
 
 	/// Yielding leadership only after finish of merge_selecting_thread.
 	/// Otherwise race condition with parallel run of merge selecting thread on different servers is possible.
+	///
+	/// On the other hand, leader_election colud call becomeLeader() from own thread after
+	/// merge_selecting_thread is finished and restarting_thread is destroyed.
+	/// becomeLeader() recreates merge_selecting_thread and it becomes joinable again, even restarting_thread is destroyed.
+	/// But restarting_thread is responisble to stop merge_selecting_thread.
+	/// It will lead to std::terminate in ~StorageReplicatedMergeTree().
+	/// Such behaviour was rarely observed on DROP queries.
+	/// Therefore we need either avoid becoming leader after first shutdown call (more deliberate choice),
+	/// either manually wait merge_selecting_thread.join() inside ~StorageReplicatedMergeTree(), either or something third.
+	/// So, shutdown check is added in becomeLeader().
 	storage.leader_election = nullptr;
 
 	LOG_TRACE(log, "Threads finished");

--- a/dbms/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/dbms/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -386,10 +386,10 @@ void ReplicatedMergeTreeRestartingThread::partialShutdown()
 	/// Yielding leadership only after finish of merge_selecting_thread.
 	/// Otherwise race condition with parallel run of merge selecting thread on different servers is possible.
 	///
-	/// On the other hand, leader_election colud call becomeLeader() from own thread after
+	/// On the other hand, leader_election could call becomeLeader() from own thread after
 	/// merge_selecting_thread is finished and restarting_thread is destroyed.
 	/// becomeLeader() recreates merge_selecting_thread and it becomes joinable again, even restarting_thread is destroyed.
-	/// But restarting_thread is responisble to stop merge_selecting_thread.
+	/// But restarting_thread is responsible to stop merge_selecting_thread.
 	/// It will lead to std::terminate in ~StorageReplicatedMergeTree().
 	/// Such behaviour was rarely observed on DROP queries.
 	/// Therefore we need either avoid becoming leader after first shutdown call (more deliberate choice),

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1872,6 +1872,9 @@ void StorageReplicatedMergeTree::removePartAndEnqueueFetch(const String & part_n
 
 void StorageReplicatedMergeTree::becomeLeader()
 {
+	if (shutdown_called)
+		return;
+
 	LOG_INFO(log, "Became leader");
 	is_leader_node = true;
 	merge_selecting_thread = std::thread(&StorageReplicatedMergeTree::mergeSelectingThread, this);

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1872,6 +1872,8 @@ void StorageReplicatedMergeTree::removePartAndEnqueueFetch(const String & part_n
 
 void StorageReplicatedMergeTree::becomeLeader()
 {
+	std::lock_guard<std::mutex> lock(leader_node_mutex);
+
 	if (shutdown_called)
 		return;
 


### PR DESCRIPTION
The easiest way to reproduce the resolved problem:

``` bash
#!/bin/bash

suspect=
while [[ -z $suspect ]]; do
    clickhouse-client --query "create table zoo (date Date, index UInt64, data String) ENGINE = ReplicatedMergeTree('/clickhouse/zoo', 'replica1', date, (index), 8192);" & clickhouse-client --query "drop table if exists zoo;"
    suspect=$(cat /var/log/clickhouse-server/clickhouse-server.log | grep Abort)
    echo -n $suspect
done
```

More comments in the code.
More sophisticated test https://gist.github.com/ludv1x/afb4b2ff5f07b6a840cc9ae5261413f3 

[#METR-22471]
