### PR TITLE
Fixed Debug build.

### DIFF
--- a/dbms/src/Server/ConfigReloader.cpp
+++ b/dbms/src/Server/ConfigReloader.cpp
@@ -16,6 +16,9 @@ namespace DB
 namespace ErrorCodes { extern const int FILE_DOESNT_EXIST; }
 
 
+constexpr decltype(ConfigReloader::reload_interval) ConfigReloader::reload_interval;
+
+
 ConfigReloader::ConfigReloader(const std::string & main_config_path_, const std::string & users_config_path_,
 							   const std::string & include_from_path_, Context * context_)
 	: main_config_path(main_config_path_), users_config_path(users_config_path_),


### PR DESCRIPTION
Fixed error:

```
Linking CXX executable clickhouse-server
CMakeFiles/clickhouse-server.dir/ConfigReloader.cpp.o: In function `DB::ConfigReloader::run()':
/home/vludv/dev/ClickHouse/dbms/src/Server/ConfigReloader.cpp:60: undefined reference to `DB::ConfigReloader::reload_interval'
collect2: error: ld returned 1 exit status
```
