### PR TITLE
Fixed build_osx.md (added THREADS)

### DIFF
--- a/doc/build_osx.md
+++ b/doc/build_osx.md
@@ -57,6 +57,12 @@ export CXX=g++-6
 export DISABLE_MONGODB=1
 ```
 
+## Detect number of threads
+
+```
+export THREADS=$(sysctl -n hw.ncpu)
+```
+
 # Build ClickHouse
 
 ```


### PR DESCRIPTION
Note: `hw.ncpu` returns a total number of cores (physical+logical, i.e. including HyperThreading); `hw.physicalcpu` returns a number of physical cores respectively.

Not sure if the `export` is needed since it's only used once, but I decided to stick to the original `build.md` format.