### PR TITLE
IO: Added ProfileEvents to Open/Read/Write failures

### DIFF
--- a/dbms/src/Common/ProfileEvents.cpp
+++ b/dbms/src/Common/ProfileEvents.cpp
@@ -7,10 +7,13 @@
 	M(SelectQuery) \
 	M(InsertQuery) \
 	M(FileOpen) \
+	M(FileOpenFailed) \
 	M(Seek) \
 	M(ReadBufferFromFileDescriptorRead) \
+	M(ReadBufferFromFileDescriptorReadFailed) \
 	M(ReadBufferFromFileDescriptorReadBytes) \
 	M(WriteBufferFromFileDescriptorWrite) \
+	M(WriteBufferFromFileDescriptorWriteFailed) \
 	M(WriteBufferFromFileDescriptorWriteBytes) \
 	M(ReadBufferAIORead) \
 	M(ReadBufferAIOReadBytes) \

--- a/dbms/src/IO/ReadBufferAIO.cpp
+++ b/dbms/src/IO/ReadBufferAIO.cpp
@@ -12,6 +12,7 @@
 namespace ProfileEvents
 {
 	extern const Event FileOpen;
+	extern const Event FileOpenFailed;
 	extern const Event ReadBufferAIORead;
 	extern const Event ReadBufferAIOReadBytes;
 }
@@ -49,6 +50,7 @@ ReadBufferAIO::ReadBufferAIO(const std::string & filename_, size_t buffer_size_,
 	fd = ::open(filename.c_str(), open_flags);
 	if (fd == -1)
 	{
+		ProfileEvents::increment(ProfileEvents::FileOpenFailed);
 		auto error_code = (errno == ENOENT) ? ErrorCodes::FILE_DOESNT_EXIST : ErrorCodes::CANNOT_OPEN_FILE;
 		throwFromErrno("Cannot open file " + filename, error_code);
 	}

--- a/dbms/src/IO/ReadBufferFromFile.cpp
+++ b/dbms/src/IO/ReadBufferFromFile.cpp
@@ -8,6 +8,7 @@
 namespace ProfileEvents
 {
 	extern const Event FileOpen;
+	extern const Event FileOpenFailed;
 }
 
 
@@ -41,11 +42,19 @@ ReadBufferFromFile::ReadBufferFromFile(
 	fd = open(file_name.c_str(), flags == -1 ? O_RDONLY : flags);
 
 	if (-1 == fd)
+	{
+		ProfileEvents::increment(ProfileEvents::FileOpenFailed);
 		throwFromErrno("Cannot open file " + file_name, errno == ENOENT ? ErrorCodes::FILE_DOESNT_EXIST : ErrorCodes::CANNOT_OPEN_FILE);
+	}
 #ifdef __APPLE__
 	if (o_direct)
+	{
 		if (fcntl(fd, F_NOCACHE, 1) == -1)
+		{
+			ProfileEvents::increment(ProfileEvents::FileOpenFailed);
 			throwFromErrno("Cannot set F_NOCACHE on file " + file_name, ErrorCodes::CANNOT_OPEN_FILE);
+		}
+	}
 #endif
 }
 

--- a/dbms/src/IO/ReadBufferFromFileDescriptor.cpp
+++ b/dbms/src/IO/ReadBufferFromFileDescriptor.cpp
@@ -16,6 +16,7 @@
 namespace ProfileEvents
 {
 	extern const Event ReadBufferFromFileDescriptorRead;
+	extern const Event ReadBufferFromFileDescriptorReadFailed;
 	extern const Event ReadBufferFromFileDescriptorReadBytes;
 	extern const Event Seek;
 }
@@ -63,7 +64,10 @@ bool ReadBufferFromFileDescriptor::nextImpl()
 			break;
 
 		if (-1 == res && errno != EINTR)
+		{
+			ProfileEvents::increment(ProfileEvents::ReadBufferFromFileDescriptorReadFailed);
 			throwFromErrno("Cannot read from file " + getFileName(), ErrorCodes::CANNOT_READ_FROM_FILE_DESCRIPTOR);
+		}
 
 		if (res > 0)
 			bytes_read += res;

--- a/dbms/src/IO/WriteBufferAIO.cpp
+++ b/dbms/src/IO/WriteBufferAIO.cpp
@@ -9,6 +9,7 @@
 namespace ProfileEvents
 {
 	extern const Event FileOpen;
+	extern const Event FileOpenFailed;
 	extern const Event WriteBufferAIOWrite;
 	extern const Event WriteBufferAIOWriteBytes;
 }
@@ -58,6 +59,7 @@ WriteBufferAIO::WriteBufferAIO(const std::string & filename_, size_t buffer_size
 	fd = ::open(filename.c_str(), open_flags, mode_);
 	if (fd == -1)
 	{
+		ProfileEvents::increment(ProfileEvents::FileOpenFailed);
 		auto error_code = (errno == ENOENT) ? ErrorCodes::FILE_DOESNT_EXIST : ErrorCodes::CANNOT_OPEN_FILE;
 		throwFromErrno("Cannot open file " + filename, error_code);
 	}

--- a/dbms/src/IO/WriteBufferFromFileDescriptor.cpp
+++ b/dbms/src/IO/WriteBufferFromFileDescriptor.cpp
@@ -12,6 +12,7 @@
 namespace ProfileEvents
 {
 	extern const Event WriteBufferFromFileDescriptorWrite;
+	extern const Event WriteBufferFromFileDescriptorWriteFailed;
 	extern const Event WriteBufferFromFileDescriptorWriteBytes;
 }
 
@@ -49,7 +50,10 @@ void WriteBufferFromFileDescriptor::nextImpl()
 		}
 
 		if ((-1 == res || 0 == res) && errno != EINTR)
+		{
+			ProfileEvents::increment(ProfileEvents::WriteBufferFromFileDescriptorWriteFailed);
 			throwFromErrno("Cannot write to file " + getFileName(), ErrorCodes::CANNOT_WRITE_TO_FILE_DESCRIPTOR);
+		}
 
 		if (res > 0)
 			bytes_written += res;


### PR DESCRIPTION
I've added metrics for file Open/Read/Write failures:

* `ProfileEvents::FileOpenFailed`
* `ProfileEvents::ReadBufferFromFileDescriptorReadFailed`
* `ProfileEvents::WriteBufferFromFileDescriptorWriteFailed`

The reason is detecting disk failures from metrics is easier than parsing logs.