### PR TITLE
signal handling in docker

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -13,4 +13,4 @@ EXPOSE 9000 8123 9009
 
 ENV CLICKHOUSE_CONFIG /etc/clickhouse-server/config.xml
 
-CMD ["sh", "-c", "/usr/bin/clickhouse-server --config=${CLICKHOUSE_CONFIG}"]
+ENTRYPOINT exec /usr/bin/clickhouse-server --config=${CLICKHOUSE_CONFIG}


### PR DESCRIPTION
Changed entrypoint from sh to exec for clickhouse-server process to get SIGTERM and stop correctly.

Otherwise get in logs the following message:
StatusFile: Status file /opt/clickhouse/status already exists - unclean restart. Contents:
PID: 17
