### PR TITLE
HTTPHandler: added support for X-ClickHouse-*

### DIFF
--- a/dbms/src/Server/HTTPHandler.cpp
+++ b/dbms/src/Server/HTTPHandler.cpp
@@ -91,8 +91,9 @@ void HTTPHandler::processQuery(
 		used_output.out_maybe_compressed = used_output.out;
 
 	/// Имя пользователя и пароль могут быть заданы как в параметрах URL, так и с помощью HTTP Basic authentification (и то, и другое не секъюрно).
-	std::string user = params.get("user", "default");
-	std::string password = params.get("password", "");
+	/// The user and password can be passed by headers (similar to X-Auth-*), which is used by load balancers to pass authentication information
+	std::string user = request.get("X-ClickHouse-User", params.get("user", "default"));
+	std::string password = request.get("X-ClickHouse-Key", params.get("password", ""));
 
 	if (request.hasCredentials())
 	{
@@ -102,7 +103,7 @@ void HTTPHandler::processQuery(
 		password = credentials.getPassword();
 	}
 
-	std::string quota_key = params.get("quota_key", "");
+	std::string quota_key = request.get("X-ClickHouse-Quota", params.get("quota_key", ""));
 	std::string query_id = params.get("query_id", "");
 
 	Context context = *server.global_context;

--- a/doc/reference_en.html
+++ b/doc/reference_en.html
@@ -728,6 +728,10 @@ echo &#39;SELECT 1&#39; | curl &#39;http://user:password@localhost:8123/&#39; -d
 <pre class="terminal">
 echo &#39;SELECT 1&#39; | curl &#39;http://localhost:8123/?user=user&amp;password=password&#39; -d @-
 </pre>
+3. Using &#39;X-ClickHouse-User&#39; and &#39;X-ClickHouse-Key&#39; headers. Example:
+<pre class="terminal">
+echo &#39;SELECT 1&#39; | curl -H "X-ClickHouse-User: user" -H "X-ClickHouse-Key: password"  &#39;http://localhost:8123/&#39; -d @-
+</pre>
 If the user name is not indicated, the username &#39;default&#39; is used. If the password is not indicated, an empty password is used.
 
 
@@ -757,7 +761,7 @@ In contrast to the native interface, the HTTP interface does not support the con
 
 The optional &#39;query_id&#39; parameter can be passed as the query ID (any string). For more information, see the section &quot;Settings, replace_running_query&quot;.
 
-The optional &#39;quota_key&#39; parameter can be passed as the quota key (any string). For more information, see the section &quot;Quotas&quot;.
+The optional &#39;quota_key&#39; parameter can be passed as the quota key (any string). It can also be passed as &#39;X-ClickHouse-Quota&#39; header. For more information, see the section &quot;Quotas&quot;.
 
 The HTTP interface allows passing external data (external temporary tables) for querying. For more information, see the section &quot;External data for query processing&quot;.
 


### PR DESCRIPTION
We use ClickHouse behind an LB to enforce authentication, and it's more convenient to pass headers to authenticated users than rewrite URL parameters. Not sure if this is something you want, but I'd thought this is also more idiomatic as APIs tend to pass authentication or state through headers instead of mixing it with the request parameters.

Changes:
Support X-ClickHouse-* to allow running behind authenticating LBs, that
pass through user information or enforce fixed user.
The format of the new options follows X-Auth-*

Supported headers are:

* X-ClickHouse-User (identical to "user" URL parameter)
* X-ClickHouse-Key (identical to "password" URL parameter)
* X-ClickHouse-Quota (identical to "quota_key" URL parameter)