### PR TITLE
Dont use tcmalloc TCMALLOC_AGGRESSIVE_DECOMMIT patch

### DIFF
--- a/contrib/libtcmalloc/src/static_vars.cc
+++ b/contrib/libtcmalloc/src/static_vars.cc
@@ -99,7 +99,7 @@ void Static::InitStaticVars() {
 
   bool aggressive_decommit =
     tcmalloc::commandlineflags::StringToBool(
-      TCMallocGetenvSafe("TCMALLOC_AGGRESSIVE_DECOMMIT"), false);
+      TCMallocGetenvSafe("TCMALLOC_AGGRESSIVE_DECOMMIT"), true);
 
   pageheap_->SetAggressiveDecommit(aggressive_decommit);
 

--- a/dbms/src/Server/main.cpp
+++ b/dbms/src/Server/main.cpp
@@ -1,3 +1,6 @@
+#ifndef NO_TCMALLOC
+#include <gperftools/malloc_extension.h>
+#endif
 #include "Server.h"
 #include "LocalServer.h"
 #include <DB/Common/StringUtils.h>
@@ -33,6 +36,10 @@ static bool isClickhouseApp(const std::string & app_suffix, std::vector<char *> 
 
 int main(int argc_, char ** argv_)
 {
+#ifndef NO_TCMALLOC
+	MallocExtension::instance()->SetNumericProperty("tcmalloc.aggressive_memory_decommit", false);
+#endif
+
 	std::vector<char *> argv(argv_, argv_ + argc_);
 
 	auto main_func = mainEntryClickHouseServer;


### PR DESCRIPTION
Ugly version, not good place.
also tried place it to dbms/src/Interpreters/AsynchronousMetrics.cpp: MallocExtensionInitializer, but no result.

