### PR TITLE
Fix libcommon build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,9 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
 
+include /usr/share/dpkg/pkg-info.mk
+export LIBCOMMON_REVISION=$(DEB_VERSION_UPSTREAM)
+
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 ifndef THREADS_COUNT

--- a/libs/libcommon/src/create_revision.sh
+++ b/libs/libcommon/src/create_revision.sh
@@ -26,7 +26,7 @@ then
 
 else
 	# берем последний тэг из текущего коммита
-	revision=$(get_revision)
+	revision=$(echo ${LIBCOMMON_REVISION} | cut -d '.' -f3)
 
 	if [[ "$revision" == "" ]]; then
 		# в крайнем случае выбирем любую версию как версию демона


### PR DESCRIPTION
libcommon revision is currently dynamicaly defined from `git tags` after a `fetch`.
This is a potential security issue if using forked repository with SSH access.
Instead, it cleaner to get revision from package version. Revision is exported from `debian/rules` and used in `libs/libcommon/src/create_revision.sh`