### PR TITLE
MergeTree: do not load marks when reading the whole part

### DIFF
--- a/dbms/include/DB/Storages/MergeTree/MergeTreeReader.h
+++ b/dbms/include/DB/Storages/MergeTree/MergeTreeReader.h
@@ -73,10 +73,6 @@ private:
 
 		ReadBuffer * data_buffer;
 
-		/// NOTE: cur_mark_idx must be manually updated after reading from data_buffer.
-		/// It is assumed that the amount of data read from data_buffer always corresponds to an integer number of marks.
-		size_t cur_mark_idx = 0;
-
 	private:
 		Stream() = default;
 
@@ -106,7 +102,9 @@ private:
 	ValueSizeMap avg_value_size_hints;
 	String path;
 	MergeTreeData::DataPartPtr data_part;
+
 	FileStreams streams;
+	size_t cur_mark_idx = 0; /// Mark index corresponding to the current position for all streams.
 
 	/// Columns that are read.
 	NamesAndTypesList columns;
@@ -127,7 +125,7 @@ private:
 
 	void readData(
 			const String & name, const IDataType & type, IColumn & column,
-			size_t from_mark, size_t to_mark, size_t max_rows_to_read,
+			size_t from_mark, size_t max_rows_to_read,
 			size_t level = 0, bool read_offsets = true);
 
 	void fillMissingColumnsImpl(Block & res, const Names & ordered_names, bool always_reorder);

--- a/dbms/src/Storages/MergeTree/MergeTreeReader.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeReader.cpp
@@ -194,6 +194,8 @@ MergeTreeReader::Stream::Stream(
 	for (size_t i = 0; i < all_mark_ranges.size(); ++i)
 	{
 		size_t right = all_mark_ranges[i].end;
+		/// NOTE: if we are reading the whole file, then right == marks_count
+		/// and we will use max_read_buffer_size for buffer size, thus avoiding the need to load marks.
 
 		/// If the end of range is inside the block, we will need to read it too.
 		if (right < marks_count && getMark(right).offset_in_decompressed_block > 0)

--- a/utils/compressor/main.cpp
+++ b/utils/compressor/main.cpp
@@ -75,7 +75,7 @@ int main(int argc, char ** argv)
 
 	try
 	{
-		bool decompress = options.count("d");
+		bool decompress = options.count("decompress");
 
 	#ifdef USE_QUICKLZ
 		bool use_qlz = options.count("qlz");


### PR DESCRIPTION
Currently we seek to the start mark before reading each range. If after reading each mark range we remember the mark where we stopped, we can avoid unnecessary seeks and thus in some cases avoid loading the marks file entirely.

If we are not reading the whole file then loading marks file is still needed to:
* calculate the buffer size
* estimate the amount of compressed data to be read to determine if we need to switch to AIO