### PR TITLE
Docker containers improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "2"
+
+services:
+  builder:
+    image: yandex/clickhouse-builder
+    build: docker/builder
+  client:
+    image: yandex/clickhouse-client
+    build: docker/client
+    network_mode: host
+  server:
+    image: yandex/clickhouse-server
+    build: docker/server
+    network_mode: host

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -1,7 +1,10 @@
 FROM ubuntu:14.04
 
-RUN mkdir -p /etc/apt/sources.list.d && \
-    echo "deb http://repo.yandex.ru/clickhouse/trusty/ dists/stable/main/binary-amd64/" | tee /etc/apt/sources.list.d/clickhouse.list && \
+RUN apt-get update && \
+    apt-get install -y apt-transport-https && \
+    mkdir -p /etc/apt/sources.list.d && \
+    echo "deb https://repo.yandex.ru/clickhouse/trusty/ dists/stable/main/binary-amd64/" | \
+         tee /etc/apt/sources.list.d/clickhouse.list && \
     apt-get update && \
     apt-get install --allow-unauthenticated -y clickhouse-client && \
     rm -rf /var/lib/apt/lists/* /var/cache/

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,7 +1,10 @@
 FROM ubuntu:14.04
 
-RUN mkdir -p /etc/apt/sources.list.d && \
-    echo "deb http://repo.yandex.ru/clickhouse/trusty/ dists/stable/main/binary-amd64/" | tee /etc/apt/sources.list.d/clickhouse.list && \
+RUN apt-get update && \
+    apt-get install -y apt-transport-https && \
+    mkdir -p /etc/apt/sources.list.d && \
+    echo "deb https://repo.yandex.ru/clickhouse/trusty/ dists/stable/main/binary-amd64/" | \
+         tee /etc/apt/sources.list.d/clickhouse.list && \
     apt-get update && \
     apt-get install --allow-unauthenticated -y clickhouse-server-common && \
     rm -rf /var/lib/apt/lists/* /var/cache/


### PR DESCRIPTION
I have replaced `http` protocol schema to `https`. It is a good idea to use **at least** https(for security) if you have unsigned packages in your repository.
Also I have added a docker-compose configuration to build containers with ease.

But I can't confirm that containers builds successfully because `clickhouse-server-base` fails in post-install script:

> This is not related to my changes, got the same error on abfc150 in master.

```
Fetched 226 MB in 40s (5605 kB/s)
Selecting previously unselected package clickhouse-server-base.
(Reading database ... 12037 files and directories currently installed.)
Preparing to unpack .../clickhouse-server-base_1.1.54165_amd64.deb ...
Unpacking clickhouse-server-base (1.1.54165) ...
Selecting previously unselected package clickhouse-client.
Preparing to unpack .../clickhouse-client_1.1.54165_amd64.deb ...
Unpacking clickhouse-client (1.1.54165) ...
Processing triggers for ureadahead (0.100.0-16) ...
Setting up clickhouse-server-base (1.1.54165) ...
chown: cannot access '/etc/clickhouse-server': No such file or directory
dpkg: error processing package clickhouse-server-base (--configure):
 subprocess installed post-installation script returned error exit status 1
dpkg: dependency problems prevent configuration of clickhouse-client:
 clickhouse-client depends on clickhouse-server-base (= 1.1.54165); however:
  Package clickhouse-server-base is not configured yet.

dpkg: error processing package clickhouse-client (--configure):
 dependency problems - leaving unconfigured
Processing triggers for ureadahead (0.100.0-16) ...
Errors were encountered while processing:
 clickhouse-server-base
 clickhouse-client
E: Sub-process /usr/bin/dpkg returned an error code (1)
```