### PR TITLE
Mention "make install" in build steps

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -152,10 +152,12 @@ sudo service clickhouse-server start
 ```
 
 ## 2. Build to work with code.
+(if `make -j $THREADS` fails in your environment, use just `make` instead)
 ```
 mkdir build
 cd build
 cmake ..
 make -j $THREADS
+make install
 cd ..
 ```


### PR DESCRIPTION
Executables will be only built after "make install", not after "make all" as one could expect.