### PR TITLE
http server: allow custom root response

### DIFF
--- a/dbms/src/IO/HTTPCommon.cpp
+++ b/dbms/src/IO/HTTPCommon.cpp
@@ -31,7 +31,7 @@ void clientSSLInit()
 {
 	// http://stackoverflow.com/questions/18315472/https-request-in-c-using-poco
 	Poco::Net::initializeSSL();
-	bool insecure = Poco::Util::Application::instance().config().getInt("https_client_insecure", false);
+	bool insecure = Poco::Util::Application::instance().config().getBool("https_client_insecure", false);
 	Poco::SharedPtr<Poco::Net::InvalidCertificateHandler> ptr_handler(insecure
 			? dynamic_cast<Poco::Net::InvalidCertificateHandler *>(new Poco::Net::AcceptCertificateHandler(true))
 			: dynamic_cast<Poco::Net::InvalidCertificateHandler *>(new Poco::Net::RejectCertificateHandler(true)));

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -75,7 +75,7 @@ public:
 	}
 };
 
-/// Response with custom string. Can be used for browser
+/// Response with custom string. Can be used for browser.
 class RootRequestHandler : public Poco::Net::HTTPRequestHandler
 {
 public:

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -75,6 +75,26 @@ public:
 	}
 };
 
+/// Response with custom string. Can be used for browser
+class RootRequestHandler : public Poco::Net::HTTPRequestHandler
+{
+public:
+	void handleRequest(Poco::Net::HTTPServerRequest & request, Poco::Net::HTTPServerResponse & response) override
+	{
+		try
+		{
+			setResponseDefaultHeaders(response);
+			response.setContentType("text/html; charset=UTF-8");
+			const std::string data = Poco::Util::Application::instance().config().getString("http_server_default_responce", "Ok.\n");
+			response.sendBuffer(data.data(), data.size());
+		}
+		catch (...)
+		{
+			tryLogCurrentException("RootRequestHandler");
+		}
+	}
+};
+
 
 /// Response with 404 and verbose description.
 class NotFoundHandler : public Poco::Net::HTTPRequestHandler
@@ -132,7 +152,9 @@ public:
 
 		if (request.getMethod() == Poco::Net::HTTPRequest::HTTP_GET || request.getMethod() == Poco::Net::HTTPRequest::HTTP_HEAD)
 		{
-			if (uri == "/" || uri == "/ping")
+			if (uri == "/")
+				return new RootRequestHandler;
+			if (uri == "/ping")
 				return new PingRequestHandler;
 			else if (startsWith(uri, "/replicas_status"))
 				return new ReplicasStatusHandler(*server.global_context);

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -85,7 +85,7 @@ public:
 		{
 			setResponseDefaultHeaders(response);
 			response.setContentType("text/html; charset=UTF-8");
-			const std::string data = Poco::Util::Application::instance().config().getString("http_server_default_responce", "Ok.\n");
+			const std::string data = Poco::Util::Application::instance().config().getString("http_server_default_response", "Ok.\n");
 			response.sendBuffer(data.data(), data.size());
 		}
 		catch (...)

--- a/dbms/src/Server/config.xml
+++ b/dbms/src/Server/config.xml
@@ -151,6 +151,8 @@
 	-->
 	<dictionaries_config>*_dictionary.xml</dictionaries_config>
 
+	<!-- Allow connect to self-signed https servers -->
+	<!-- <https_client_insecure>true</https_client_insecure> -->
 
 	<!-- Uncomment if you want data to be compressed 30-100% better.
 		 Don't do that if you just started using ClickHouse.


### PR DESCRIPTION
sample usage:
```
<http_server_default_responce><![CDATA[<!doctype html><html ng-app="SMI2"><head><meta charset="utf-8"><title>СМИ2 clickhouse</title><meta name="viewport" content="width=device-width"><meta http-equiv="X-UA-Compatible" content="IE=edge"><base href="http://guiclickhouse.smi2.ru/"><link rel="stylesheet" href="styles/vendor-2980914725.css"><link rel="stylesheet" href="styles/app-9c669350e7.css"></head><body><script type="text/javascript">window.clickhouseGuiVersion="1.4.8";</script><div ui-view="" class="content-ui"></div><script src="scripts/vendor-a21f1c52b1.js"></script><script src="scripts/app-c4e6a1076e.js"></script></body></html>]]></http_server_default_responce>
```
http://localhost:8123 