### PR TITLE
Fix apt cache removing

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
          tee /etc/apt/sources.list.d/clickhouse.list && \
     apt-get update && \
     apt-get install --allow-unauthenticated -y clickhouse-client && \
-    rm -rf /var/lib/apt/lists/* /var/cache/
+    rm -rf /var/lib/apt/lists/* /var/cache/debconf && \
+    apt-get clean
 
 ENTRYPOINT ["/usr/bin/clickhouse-client"]

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get update && \
          tee /etc/apt/sources.list.d/clickhouse.list && \
     apt-get update && \
     apt-get install --allow-unauthenticated -y clickhouse-server-common && \
-    rm -rf /var/lib/apt/lists/* /var/cache/
+    rm -rf /var/lib/apt/lists/* /var/cache/debconf && \
+    apt-get clean
 
 RUN chown -R clickhouse /etc/clickhouse-server/
 


### PR DESCRIPTION
`/var/cache/debconf` is the only significant directory in cache (~2Mb of container size)