### PR TITLE
add format_sources for kdevelop

### DIFF
--- a/format_sources
+++ b/format_sources
@@ -1,0 +1,2 @@
+# Settings -> Configure KDevelop -> Source Formatter -> C++ ; Custom Script Formatter ; Kdevelop: kdev_format_source
+*.cpp *.c *.h : mv $TMPFILE $TMPFILE.tmp; cat $TMPFILE.tmp | clang-format -style=file -assume-filename=`pwd`/.clang-format > $TMPFILE


### PR DESCRIPTION
Usage: Settings -> Configure KDevelop -> Source Formatter -> C++ ; Custom Script Formatter ; Kdevelop: kdev_format_source