### PR TITLE
Fixed typo in docs format

### DIFF
--- a/docs/ru/table_engines/aggregatingmergetree.rst
+++ b/docs/ru/table_engines/aggregatingmergetree.rst
@@ -48,6 +48,7 @@ AggregatingMergeTree
 Создаём материализованное представление типа AggregatingMergeTree, следящее за таблицей test.visits:
 
 .. code-block:: sql
+
   CREATE MATERIALIZED VIEW test.basic
   ENGINE = AggregatingMergeTree(StartDate, (CounterID, StartDate), 8192)
   AS SELECT


### PR DESCRIPTION
Parse error without newline after sql block definition.