### PR TITLE
Init.d issue

### DIFF
--- a/tools/etc/init.d/clickhouse-server
+++ b/tools/etc/init.d/clickhouse-server
@@ -95,19 +95,6 @@ wait_for_done()
 	done
 }
 
-
- running_processes()
- {
-     pidfiles=$(find_pid_files)
-     running=0
-     for pidfile in $pidfiles; do
-         if is_running $pidfile; then
-             running=$(($running + 1))
-         fi
-     done
-     echo $running
- }
-
 initdb()
 {
 	if ! getent group ${CLICKHOUSE_USER} >/dev/null; then

--- a/tools/etc/init.d/clickhouse-server
+++ b/tools/etc/init.d/clickhouse-server
@@ -28,6 +28,9 @@ RETVAL=0
 CLICKHOUSE_PIDDIR=/var/run/$PROGRAM
 CLICKHOUSE_PIDFILE="$CLICKHOUSE_PIDDIR/$PROGRAM.pid"
 
+PIDDIR=/var/run/$PROGRAM
+PIDFILE_PREFIX=$PIDDIR/$PROGRAM
+PIDFILE_RE="$PIDFILE_PREFIX[0-9]*.pid"
 
 # Override defaults from optional config file
 test -f /etc/default/clickhouse && . /etc/default/clickhouse
@@ -68,6 +71,22 @@ is_running()
 	[ -r "$CLICKHOUSE_PIDFILE" ] && pgrep -s $(cat "$CLICKHOUSE_PIDFILE") 1> /dev/null 2> /dev/null
 }
 
+find_pid_files()
+{
+    	[ -e $PIDDIR ] && find $PIDDIR -regex "$PIDFILE_RE"
+}
+
+running_processes()
+{
+     pidfiles=$(find_pid_files)
+     running=0
+     for pidfile in $pidfiles; do
+         if is_running $pidfile; then
+             running=$(($running + 1))
+         fi
+     done
+     echo $running
+}
 
 wait_for_done()
 {
@@ -76,6 +95,18 @@ wait_for_done()
 	done
 }
 
+
+ running_processes()
+ {
+     pidfiles=$(find_pid_files)
+     running=0
+     for pidfile in $pidfiles; do
+         if is_running $pidfile; then
+             running=$(($running + 1))
+         fi
+     done
+     echo $running
+ }
 
 initdb()
 {
@@ -299,3 +330,4 @@ esac
 		echo "Init script is already running" && exit 1
 	fi
 ) 9> $LOCKFILE
+


### PR DESCRIPTION
tools/etc/init.d/clickhouse-server status failed 
running_processes, find_pid_files are missed 