### PR TITLE
Add docs about Tabix in  reference_en.html

### DIFF
--- a/dbms/src/Dictionaries/Embedded/RegionsHierarchy.cpp
+++ b/dbms/src/Dictionaries/Embedded/RegionsHierarchy.cpp
@@ -38,7 +38,7 @@ void RegionsHierarchy::reload()
 	LOG_DEBUG(log, "Reloading regions hierarchy");
 
 	const size_t initial_size = 10000;
-	const size_t max_size = 1000000;
+	const size_t max_size = 15000000;
 
 	RegionParents new_parents(initial_size);
 	RegionParents new_city(initial_size);

--- a/dbms/src/Dictionaries/Embedded/RegionsNames.cpp
+++ b/dbms/src/Dictionaries/Embedded/RegionsNames.cpp
@@ -56,7 +56,7 @@ void RegionsNames::reload(const std::string & directory)
 		DB::ReadBufferFromFile in(path);
 
 		const size_t initial_size = 10000;
-		const size_t max_size = 1000000;
+		const size_t max_size = 15000000;
 
 		Chars new_chars;
 		StringRefs new_names_refs(initial_size, StringRef("", 0));

--- a/doc/reference_en.html
+++ b/doc/reference_en.html
@@ -783,7 +783,7 @@ Libraries was not tested by us. Ordering is arbitrary.
 
 ==Third-party GUI==
 
-There are <a href="https://github.com/smi2/tabix.ui">open source project Tabix</a> campaign of SMI2, which implements a graphical web interface for ClickHouse.
+There are <a href="https://github.com/smi2/tabix.ui">open source project Tabix</a> company of SMI2, which implements a graphical web interface for ClickHouse.
 
 Tabix key features:
 - works with ClickHouse from the browser directly, without installing additional software;

--- a/doc/reference_en.html
+++ b/doc/reference_en.html
@@ -783,8 +783,17 @@ Libraries was not tested by us. Ordering is arbitrary.
 
 ==Third-party GUI==
 
-There exist minimalistic web UI for ClickHouse by <a href="https://github.com/smi2/clickhouse-frontend">SMI2</a>.
+There are <a href="https://github.com/smi2/tabix.ui">open source project Tabix</a> campaign of SMI2, which implements a graphical web interface for ClickHouse.
 
+Tabix key features:
+- works with ClickHouse from the browser directly, without installing additional software;
+- query editor that supports highlighting of SQL syntax ClickHouse, auto-completion for all objects, including dictionaries and context-sensitive help for built-in functions.
+- graphs, charts and geo-referenced for mapping query results;
+- interactive designer PivotTables (pivot) for query results;
+- graphical tools for analysis ClickHouse;
+- two color theme: light and dark.
+
+<a href="https://tabix.io/doc/">Tabix documentation</a>
 
 ==Native interface (TCP)==
 

--- a/doc/reference_ru.html
+++ b/doc/reference_ru.html
@@ -805,7 +805,7 @@ curl -sS 'http://localhost:8123/?max_result_bytes=4000000&amp;buffer_size=300000
 
 ==GUI от сторонних разработчиков==
 
-Существует <a href="https://github.com/smi2/tabix.ui">open source проект Tabix</a> от кампании СМИ2, в котором реализован графический веб-интерфейс для работы с ClickHouse.
+Существует <a href="https://github.com/smi2/tabix.ui">open source проект Tabix</a> от компании СМИ2, в котором реализован графический веб-интерфейс для работы с ClickHouse.
 
 Ключевые возможности Tabix:
 - работа с ClickHouse из браузера напрямую, без установки дополнительного ПО;


### PR DESCRIPTION
Добавил перевод о Tabix в reference_en и поправил слово кампании=> компании 