### PR TITLE
Improvements to MergeTreeSettings exception messages

### DIFF
--- a/dbms/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeSettings.h
@@ -2,12 +2,15 @@
 
 #include <Poco/Util/AbstractConfiguration.h>
 #include <Core/Types.h>
-#include <IO/ReadHelpers.h>
 
 
 namespace DB
 {
 
+namespace ErrorCodes
+{
+    extern const int INVALID_CONFIG_PARAMETER;
+}
 
 /** Advanced settings of MergeTree.
   * Could be loaded from config.
@@ -114,47 +117,52 @@ struct MergeTreeSettings
 
     void loadFromConfig(const String & config_elem, Poco::Util::AbstractConfiguration & config)
     {
-    #define SET_DOUBLE(NAME) \
-        NAME = config.getDouble(config_elem + "." #NAME, NAME);
+    #define SET(NAME, GETTER) \
+        try \
+        { \
+            NAME = config.GETTER(config_elem + "." #NAME, NAME); \
+        } \
+        catch (const Poco::Exception & e) \
+        { \
+            throw Exception( \
+                    "Invalid config parameter: " + config_elem + "/" #NAME + ": " + e.message() + ".", \
+                    ErrorCodes::INVALID_CONFIG_PARAMETER); \
+        }
 
-    #define SET_SIZE_T(NAME) \
-        if (config.has(config_elem + "." #NAME)) NAME = parse<size_t>(config.getString(config_elem + "." #NAME));
+        SET(max_bytes_to_merge_at_max_space_in_pool, getUInt);
+        SET(max_bytes_to_merge_at_min_space_in_pool, getUInt);
+        SET(max_replicated_merges_in_queue, getUInt);
+        SET(old_parts_lifetime, getUInt);
+        SET(temporary_directories_lifetime, getUInt);
+        SET(parts_to_delay_insert, getUInt);
+        SET(parts_to_throw_insert, getUInt);
+        SET(max_delay_to_insert, getUInt);
+        SET(replicated_deduplication_window, getUInt);
+        SET(replicated_logs_to_keep, getUInt);
+        SET(prefer_fetch_merged_part_time_threshold, getUInt);
+        SET(prefer_fetch_merged_part_size_threshold, getUInt);
+        SET(max_suspicious_broken_parts, getUInt);
+        SET(max_files_to_modify_in_alter_columns, getUInt);
+        SET(max_files_to_remove_in_alter_columns, getUInt);
+        SET(replicated_max_unexpected_parts, getUInt);
+        SET(replicated_max_unexpectedly_merged_parts, getUInt);
+        SET(replicated_max_missing_obsolete_parts, getUInt);
+        SET(replicated_max_missing_active_parts, getUInt);
+        SET(replicated_max_parallel_fetches, getUInt);
+        SET(replicated_max_parallel_fetches_for_table, getUInt);
+        SET(replicated_max_parallel_sends, getUInt);
+        SET(replicated_max_parallel_sends_for_table, getUInt);
+        SET(replicated_max_ratio_of_wrong_parts, getDouble);
+        SET(zookeeper_session_expiration_check_period, getUInt);
+        SET(check_delay_period, getUInt);
+        SET(min_relative_delay_to_yield_leadership, getUInt);
+        SET(min_relative_delay_to_close, getUInt);
+        SET(min_absolute_delay_to_close, getUInt);
+        SET(enable_vertical_merge_algorithm, getUInt);
+        SET(vertical_merge_algorithm_min_rows_to_activate, getUInt);
+        SET(vertical_merge_algorithm_min_columns_to_activate, getUInt);
 
-        SET_SIZE_T(max_bytes_to_merge_at_max_space_in_pool);
-        SET_SIZE_T(max_bytes_to_merge_at_min_space_in_pool);
-        SET_SIZE_T(max_replicated_merges_in_queue);
-        SET_SIZE_T(old_parts_lifetime);
-        SET_SIZE_T(temporary_directories_lifetime);
-        SET_SIZE_T(parts_to_delay_insert);
-        SET_SIZE_T(parts_to_throw_insert);
-        SET_SIZE_T(max_delay_to_insert);
-        SET_SIZE_T(replicated_deduplication_window);
-        SET_SIZE_T(replicated_logs_to_keep);
-        SET_SIZE_T(prefer_fetch_merged_part_time_threshold);
-        SET_SIZE_T(prefer_fetch_merged_part_size_threshold);
-        SET_SIZE_T(max_suspicious_broken_parts);
-        SET_SIZE_T(max_files_to_modify_in_alter_columns);
-        SET_SIZE_T(max_files_to_remove_in_alter_columns);
-        SET_SIZE_T(replicated_max_unexpected_parts);
-        SET_SIZE_T(replicated_max_unexpectedly_merged_parts);
-        SET_SIZE_T(replicated_max_missing_obsolete_parts);
-        SET_SIZE_T(replicated_max_missing_active_parts);
-        SET_SIZE_T(replicated_max_parallel_fetches);
-        SET_SIZE_T(replicated_max_parallel_fetches_for_table);
-        SET_SIZE_T(replicated_max_parallel_sends);
-        SET_SIZE_T(replicated_max_parallel_sends_for_table);
-        SET_DOUBLE(replicated_max_ratio_of_wrong_parts);
-        SET_SIZE_T(zookeeper_session_expiration_check_period);
-        SET_SIZE_T(check_delay_period);
-        SET_SIZE_T(min_relative_delay_to_yield_leadership);
-        SET_SIZE_T(min_relative_delay_to_close);
-        SET_SIZE_T(min_absolute_delay_to_close);
-        SET_SIZE_T(enable_vertical_merge_algorithm);
-        SET_SIZE_T(vertical_merge_algorithm_min_rows_to_activate);
-        SET_SIZE_T(vertical_merge_algorithm_min_columns_to_activate);
-
-    #undef SET_SIZE_T
-    #undef SET_DOUBLE
+    #undef SET
     }
 };
 


### PR DESCRIPTION
* Throw an exception when MergeTreeSettings config parameter is invalid.
* More descriptive exception message for max_files_to_modify/remove safeguard.