### PR TITLE
Fix escaping of columns starting with a number

### DIFF
--- a/dbms/src/Common/StringUtils.h
+++ b/dbms/src/Common/StringUtils.h
@@ -101,6 +101,12 @@ inline bool isWordCharASCII(char c)
         || c == '_';
 }
 
+inline bool isValidIdentifierBegin(char c)
+{
+    return isAlphaASCII(c)
+        || c == '_';
+}
+
 inline bool isWhitespaceASCII(char c)
 {
     return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';

--- a/dbms/src/IO/WriteHelpers.h
+++ b/dbms/src/IO/WriteHelpers.h
@@ -368,7 +368,7 @@ inline void writeBackQuotedString(const String & s, WriteBuffer & buf)
 /// То же самое, но обратные кавычки применяются только при наличии символов, не подходящих для идентификатора без обратных кавычек.
 inline void writeProbablyBackQuotedString(const String & s, WriteBuffer & buf)
 {
-    if (s.empty() || !isWordCharASCII(s[0]))
+    if (s.empty() || !isValidIdentifierBegin(s[0]))
         writeBackQuotedString(s, buf);
     else
     {


### PR DESCRIPTION
We have a table storing http requests having bad URL query string parameters. These parameters are stored as correspondent column names. So we have discovered several issues with column name escaping using ``back quotes``

This bugfix fixes the following problem:

`create table broken (``1`` String, date Date) Engine=MergeTree(date, date, 8192) `

will execute OK. But following 

alter table broken add column col2 String 

or a server restart leads to an exception.