### PR TITLE
Fix missed dependency

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -4,7 +4,7 @@ ARG repository="deb https://repo.yandex.ru/clickhouse/xenial/ dists/stable/main/
 ARG version=\*
 
 RUN apt-get update && \
-    apt-get install -y apt-transport-https && \
+    apt-get install -y apt-transport-https tzdata && \
     mkdir -p /etc/apt/sources.list.d && \
     echo $repository | tee /etc/apt/sources.list.d/clickhouse.list && \
     apt-get update && \

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -4,7 +4,7 @@ ARG repository="deb https://repo.yandex.ru/clickhouse/xenial/ dists/stable/main/
 ARG version=\*
 
 RUN apt-get update && \
-    apt-get install -y apt-transport-https && \
+    apt-get install -y apt-transport-https tzdata && \
     mkdir -p /etc/apt/sources.list.d && \
     echo $repository | tee /etc/apt/sources.list.d/clickhouse.list && \
     apt-get update && \


### PR DESCRIPTION
Fixed error:
```
POCO ERROR: Exception: Could not determine local time zone: boost::filesystem::canonical: No such file or directory: "/usr/share/zoneinfo/"
terminate called after throwing an instance of 'Poco::Exception'
  what():  Exception
```