### PR TITLE
Use git HEAD hash as possible package name

### DIFF
--- a/release
+++ b/release
@@ -24,6 +24,9 @@ do
         gen_revision_author
         git push
         exit 0
+    elif [[ $1 == '--head' ]]; then
+        REVISION=`git rev-parse HEAD`
+        shift
     else
         echo "Unknown option $1"
         exit 2


### PR DESCRIPTION
Kind of silly addition to allow generating debian packages with the git hash as part of the packages name. This may be useful for a nightly build style for fast testing purposes.

I tested a simple execution like `./release --head` and to 'upgrade' the last packages with this one and worked fine.