### PR TITLE
Add performance tester

### DIFF
--- a/dbms/src/Client/CMakeLists.txt
+++ b/dbms/src/Client/CMakeLists.txt
@@ -5,6 +5,9 @@ install (FILES config.xml DESTINATION ${CLICKHOUSE_ETC_DIR}/clickhouse-client CO
 add_library (clickhouse-benchmark Benchmark.cpp)
 target_link_libraries (clickhouse-benchmark dbms ${Boost_PROGRAM_OPTIONS_LIBRARY})
 
+add_library (clickhouse-performance-test PerformanceTest.cpp)
+target_link_libraries (clickhouse-performance-test dbms ${Boost_PROGRAM_OPTIONS_LIBRARY})
+
 if (ENABLE_TESTS)
     add_subdirectory (tests)
 endif ()

--- a/dbms/src/Client/PerformanceTest.cpp
+++ b/dbms/src/Client/PerformanceTest.cpp
@@ -1,0 +1,33 @@
+#include <iostream>
+
+/** Tests launcher for ClickHouse.
+  * The tool walks through given or default folder in order to find files with
+  * tests' description and launches it.
+  */
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+	extern const int POCO_EXCEPTION;
+	extern const int STD_EXCEPTION;
+	extern const int UNKNOWN_EXCEPTION;
+}
+
+class PerformanceTest
+{
+public:
+	PerformanceTest()
+	{
+		// std::cerr << std::fixed << std::setprecision(3);
+	}
+
+private:
+};
+
+}
+
+int mainEntryClickhousePerformanceTest(int argc, char ** argv) {
+    return 0;
+}

--- a/dbms/src/Client/PerformanceTest.cpp
+++ b/dbms/src/Client/PerformanceTest.cpp
@@ -1,16 +1,19 @@
 #include <iostream>
+#include <limits>
 
 #include <sys/stat.h>
 #include <boost/program_options.hpp>
 
 #include <DB/Client/ConnectionPool.h>
-#include <DB/Common/ThreadPool.h>
 #include <DB/Common/ConcurrentBoundedQueue.h>
+#include <DB/Common/Stopwatch.h>
+#include <DB/Common/ThreadPool.h>
 #include <DB/Core/Types.h>
 #include <DB/DataStreams/RemoteBlockInputStream.h>
 #include <DB/Interpreters/Settings.h>
 #include <DB/IO/ReadHelpers.h>
 #include <DB/IO/ReadBufferFromFileDescriptor.h>
+
 
 #include <Poco/AutoPtr.h>
 #include <Poco/XML/XMLStream.h>
@@ -32,6 +35,157 @@ namespace ErrorCodes
 	extern const int STD_EXCEPTION;
 	extern const int UNKNOWN_EXCEPTION;
 }
+
+struct criterionWithPriority {
+	std::string priority = "";
+	size_t      value    = 0;
+};
+
+/// Termination criterions. The running test will be terminated in either of two conditions:
+/// 1. All criterions marked 'min' are fulfilled
+/// or
+/// 2. Any criterion  marked 'max' is  fulfilled
+class StopCriterions {
+private:
+	using AbstractConfiguration = Poco::AutoPtr<Poco::Util::AbstractConfiguration>;
+	using Keys = std::vector<std::string>;
+
+	void initializeStruct(const std::string priority,
+						  const AbstractConfiguration & stopCriterionsView)
+	{
+		Keys keys;
+		stopCriterionsView->keys(priority, keys);
+
+		for (const std::string & key : keys) {
+			if (key == "timeout_ms") {
+				timeout_ms.value    = stopCriterionsView->getUInt64(priority + ".timeout_ms");
+				timeout_ms.priority = priority;
+			} else if (key == "read_rows") {
+				read_rows.value    = stopCriterionsView->getUInt64(priority + ".read_rows");
+				read_rows.priority = priority;
+			} else if (key == "bytes_read_uncompressed") {
+				bytes_read_uncompressed.value    = stopCriterionsView->getUInt64(priority + ".bytes_read_uncompressed");
+				bytes_read_uncompressed.priority = priority;
+			} else if (key == "iterations") {
+				iterations.value    = stopCriterionsView->getUInt64(priority + ".iterations");
+				iterations.priority = priority;
+			} else if (key == "min_time_not_changing_for_ms") {
+				min_time_not_changing_for_ms.value    = stopCriterionsView->getUInt64(priority + ".min_time_not_changing_for_ms");
+				min_time_not_changing_for_ms.priority = priority;
+			} else if (key == "max_speed_not_changing_for_ms") {
+				max_speed_not_changing_for_ms.value    = stopCriterionsView->getUInt64(priority + ".max_speed_not_changing_for_ms");
+				max_speed_not_changing_for_ms.priority = priority;
+			} else if (key == "average_speed_not_changing_for_ms") {
+				average_speed_not_changing_for_ms.value    = stopCriterionsView->getUInt64(priority + ".average_speed_not_changing_for_ms");
+				average_speed_not_changing_for_ms.priority = priority;
+			} else {
+				throw Poco::Exception("Met unkown stop criterion: " + key, 1);
+			}
+
+			if (priority == "min") { ++number_of_initialized_min; };
+			if (priority == "max") { ++number_of_initialized_max; };
+		}
+	}
+
+public:
+	StopCriterions()
+		: number_of_initialized_min(0), number_of_initialized_max(0),
+		  fulfilled_criterions_min(0), fulfilled_criterions_max(0) {}
+
+	void loadFromConfig(const AbstractConfiguration & stopCriterionsView)
+	{
+		if (stopCriterionsView->has("min")) {
+			initializeStruct("min", stopCriterionsView);
+		}
+
+		if (stopCriterionsView->has("max")) {
+			initializeStruct("max", stopCriterionsView);
+		}
+	}
+
+	struct criterionWithPriority timeout_ms;
+	struct criterionWithPriority read_rows;
+	struct criterionWithPriority bytes_read_uncompressed;
+	struct criterionWithPriority iterations;
+	struct criterionWithPriority min_time_not_changing_for_ms;
+	struct criterionWithPriority max_speed_not_changing_for_ms;
+	struct criterionWithPriority average_speed_not_changing_for_ms;
+
+    /// Hereafter 'min' and 'max', in context of critetions, mean a level of importance
+	/// Number of initialized properties met in configuration
+	std::atomic<size_t> number_of_initialized_min;
+	std::atomic<size_t> number_of_initialized_max;
+
+	std::atomic<size_t> fulfilled_criterions_min;
+	std::atomic<size_t> fulfilled_criterions_max;
+};
+
+struct Stats
+{
+	Stopwatch watch;
+	Stopwatch min_time_watch;
+	Stopwatch max_speed_watch;
+	Stopwatch average_speed_watch;
+	// size_t queries; TODO: Do I need this?
+	size_t read_rows;
+	size_t read_bytes;
+
+	/// min_time in ms
+	UInt64 min_time      = std::numeric_limits<UInt64>::max();
+	size_t max_speed     = 0;
+	size_t average_speed = 0;
+	size_t number_of_speed_info_batches = 0;
+
+	void update_min_time(const UInt64 min_time_candidate)
+	{
+		// TODO:
+		std::cout << "current min_time: " << min_time << std::endl;
+		std::cout << "min_time candidate: " << min_time_candidate << std::endl;
+		std::cout << std::endl;
+
+		if (min_time_candidate < min_time) {
+			min_time = min_time_candidate;
+			min_time_watch.restart();
+		}
+	}
+
+	void update_average_speed(const size_t new_speed_info)
+	{
+		size_t new_average_speed = ((average_speed * number_of_speed_info_batches)
+									+ new_speed_info);
+		new_average_speed /= (++number_of_speed_info_batches);
+		if (new_average_speed != average_speed) {
+			average_speed = new_average_speed;
+			average_speed_watch.restart();
+		}
+	}
+
+	void update_max_speed(const size_t max_speed_candidate)
+	{
+		if (max_speed_candidate > max_speed) {
+			max_speed = max_speed_candidate;
+			max_speed_watch.restart();
+		}
+	}
+
+	void add(size_t read_rows_inc, size_t read_bytes_inc)
+	{
+		read_rows  += read_rows_inc;
+		read_bytes += read_bytes_inc;
+
+		size_t new_speed = read_rows_inc / watch.elapsedSeconds();
+		update_max_speed(new_speed);
+		update_average_speed(new_speed);
+	}
+
+	void clear()
+	{
+		watch.restart();
+
+		read_rows  = 0;
+		read_bytes = 0;
+	}
+};
 
 class PerformanceTest
 {
@@ -66,7 +220,6 @@ public:
 
 private:
 	unsigned concurrency;
-	size_t   max_iterations = 1;
 
 	using Query   = std::string;
 	using Queries = std::vector<std::string>;
@@ -86,8 +239,19 @@ private:
 	using StringToVector    = std::map< std::string, std::vector<std::string> >;
 	std::vector<Config> testsConfigurations;
 
+	struct StopCriterions stopCriterions;
+
+	#define incFulfilledCriterions(CRITERION) \
+		stopCriterions.CRITERION.priority == "min" \
+				? ++stopCriterions.fulfilled_criterions_min \
+				: ++stopCriterions.fulfilled_criterions_max;
+
 	enum ExecutionType { loop, once };
 	ExecutionType execType;
+
+	Stats info_total;
+	std::mutex mutex;
+
 
 	void readTestsConfiguration(const Paths & input_files)
 	{
@@ -186,16 +350,74 @@ private:
 			throw Poco::Exception("Unknown type " + configExecType + " in :" +
 								  testName, 1);
 
-		for (const Query & query : queries) {
-			std::cout << query << std::endl;
+		if (testConfig->has("stop")) {
+			AbstractConfig stopCriterionsView(testConfig
+										      ->createView("stop"));
+			stopCriterions.loadFromConfig(stopCriterionsView);
+		} else {
+			throw Poco::Exception("No termination conditions were found", 1);
+		}
 
-			runQuery(query);
+		if (execType == loop) {
+			runLoopQuery(queries[0]);
+		} else {
+			runQueries(queries);
+		}
+
+	}
+
+	void runLoopQuery(const Query & query)
+	{
+		info_total.watch.restart();
+		info_total.min_time_watch.restart();
+
+		size_t max_iterations = stopCriterions.iterations.value;
+		size_t i = -1;
+
+		while (true) {
+			++i;
+
+			pool.schedule(std::bind(
+				&PerformanceTest::thread,
+				this,
+				connections.IConnectionPool::get()
+			));
+
+			queue.push(query);
+			queue.push(""); /// asking thread to stop
+			pool.wait();
+
+			/// check stop criterions
+			if (max_iterations && i >= max_iterations) {
+				incFulfilledCriterions(iterations);
+			}
+
+			if (stopCriterions.number_of_initialized_min &&
+				(stopCriterions.fulfilled_criterions_min >=
+				stopCriterions.number_of_initialized_min)) {
+				/// All 'min' criterions are fulfilled
+				// TODO:
+				std::cout << "All 'min' criterions are fulfilled" << std::endl;
+				break;
+			}
+
+			if (stopCriterions.number_of_initialized_max &&
+				stopCriterions.fulfilled_criterions_max) {
+				/// Some 'max' criterions are fulfilled
+
+				// TODO:
+				std::cout << stopCriterions.fulfilled_criterions_max
+						  << "'max' criterions are fulfilled" << std::endl;
+				break;
+			}
 		}
 	}
 
-	void runQuery(const Query & query)
+	void runQueries(const Queries & queries)
 	{
-		// TODO: proceed terminationConditions
+		info_total.watch.restart();
+		info_total.min_time_watch.restart();
+
 		for (size_t i = 0; i < concurrency; ++i) {
 			pool.schedule(std::bind(
 				&PerformanceTest::thread,
@@ -204,8 +426,7 @@ private:
 			));
 		}
 
-		for (size_t i = 0;  (execType == loop) || i < max_iterations; ++i) {
-			// TODO: start timer and terminate after time exceeds
+		for (const Query & query : queries) {
 			queue.push(query);
 		}
 
@@ -219,6 +440,8 @@ private:
 
 	void thread(ConnectionPool::Entry & connection)
 	{
+		Stats info_per_query;
+
 		Query query;
 
 		while (true) {
@@ -228,25 +451,44 @@ private:
 			if (query.empty())
 				break;
 
-			execute(connection, query);
+			execute(connection, query, info_per_query);
 		}
 	}
 
-	void execute(ConnectionPool::Entry & connection, const Query & query)
+	void execute(ConnectionPool::Entry & connection, const Query & query,
+													 Stats & info_per_query)
 	{
-		// Stopwatch watch;
+		// TODO:
+		std::cout << "execute? " << query << std::endl;
+
 		RemoteBlockInputStream stream(connection, query, &settings, nullptr,
 									  Tables()/*, query_processing_stage*/);
 
-		// Progress progress;
-		// stream.setProgressCallback([&progress](const Progress & value) { progress.incrementPiecewiseAtomically(value); });
+		Progress progress;
+		stream.setProgressCallback(
+			[&progress, &stream, &info_per_query, this]
+			(const Progress & value) {
+				// TODO:
+				std::cout << "got some progress" << std::endl;
+
+				progress.incrementPiecewiseAtomically(value);
+
+				this->checkFulfilledCriterionsAndUpdate(progress, stream, info_per_query);
+		});
+
+		info_per_query.watch.restart();
+		info_per_query.average_speed_watch.restart();
+		info_per_query.max_speed_watch.restart();
 
 		stream.readPrefix();
-		while (Block block = stream.read()) //{}
-			for (auto column : block.getColumns()) {
-				std::cout << column.name << std::endl;
-			}
+		while (Block block = stream.read())
+			;
 		stream.readSuffix();
+
+													// cast nanoseconds to ms
+		UInt64 queryExecutionTime = info_per_query.min_time_watch.elapsed()
+																/ (1000 * 1000);
+		info_total.update_min_time(queryExecutionTime);
 
 		// const BlockStreamProfileInfo & info = stream.getProfileInfo();
 
@@ -255,6 +497,99 @@ private:
 		// std::lock_guard<std::mutex> lock(mutex);
 		// info_per_interval.add(seconds, progress.rows, progress.bytes, info.rows, info.bytes);
 		// info_total.add(seconds, progress.rows, progress.bytes, info.rows, info.bytes);
+	}
+
+	void checkFulfilledCriterionsAndUpdate(const Progress & progress,
+										   RemoteBlockInputStream & stream,
+										   Stats & info_per_query)
+	{
+		// TODO:
+		std::cout << "im checking" << std::endl;
+
+		std::lock_guard<std::mutex> lock(mutex);
+
+		info_total.add(progress.rows, progress.bytes);
+		info_per_query.add(progress.rows, progress.bytes);
+
+		size_t max_rows_to_read = stopCriterions.read_rows.value;
+		if (max_rows_to_read && info_total.read_rows >= max_rows_to_read) {
+			incFulfilledCriterions(read_rows);
+		}
+
+		size_t max_bytes_to_read = stopCriterions.bytes_read_uncompressed.value;
+		if (max_bytes_to_read && info_total.read_bytes >= max_bytes_to_read) {
+			incFulfilledCriterions(bytes_read_uncompressed);
+		}
+
+		if (UInt64 max_timeout_ms = stopCriterions.timeout_ms.value) {
+			/// cast nanoseconds to ms
+			if ((info_total.watch.elapsed() / (1000 * 1000)) > max_timeout_ms) {
+				incFulfilledCriterions(timeout_ms);
+			}
+		}
+
+		size_t min_time_not_changing_for_ms = stopCriterions
+												.min_time_not_changing_for_ms.value;
+		if (min_time_not_changing_for_ms) {
+			// TODO:
+			std::cout << "min time is in attention" << std::endl;
+
+			size_t min_time_did_not_change_for = info_total
+													.min_time_watch
+													.elapsed() / (1000 * 1000);
+			// TODO:
+			std::cout << "min_time_did_not_change_for: " << min_time_did_not_change_for << std::endl;
+			std::cout << "min_time_not_changing_for_ms: " << min_time_not_changing_for_ms << std::endl;
+
+			if (min_time_did_not_change_for >= min_time_not_changing_for_ms) {
+				// TODO:
+				std::cout << "min time yeahh" << std::endl;
+				incFulfilledCriterions(min_time_not_changing_for_ms);
+			}
+		}
+
+		size_t max_speed_not_changing_for_ms = stopCriterions
+												.max_speed_not_changing_for_ms
+												.value;
+		if (max_speed_not_changing_for_ms) {
+			UInt64 speed_not_changing_time = info_per_query
+												.max_speed_watch
+												.elapsed() / (1000 * 1000);
+			if (speed_not_changing_time >= max_speed_not_changing_for_ms) {
+				incFulfilledCriterions(max_speed_not_changing_for_ms);
+			}
+		}
+
+		size_t average_speed_not_changing_for_ms = stopCriterions
+													.average_speed_not_changing_for_ms
+													.value;
+		if (average_speed_not_changing_for_ms) {
+			UInt64 speed_not_changing_time = info_per_query
+												.average_speed_watch
+												.elapsed() / (1000 * 1000);
+			if (speed_not_changing_time >= average_speed_not_changing_for_ms) {
+				incFulfilledCriterions(average_speed_not_changing_for_ms);
+			}
+		}
+
+		if (stopCriterions.number_of_initialized_min &&
+			(stopCriterions.fulfilled_criterions_min >=
+			stopCriterions.number_of_initialized_min)) {
+			/// All 'min' criterions are fulfilled
+			// TODO:
+			std::cout << "All 'min' criterions are fulfilled" << std::endl;
+			stream.cancel();
+		}
+
+		if (stopCriterions.number_of_initialized_max &&
+			stopCriterions.fulfilled_criterions_max) {
+			/// Some 'max' criterions are fulfilled
+
+			// TODO:
+			std::cout << stopCriterions.fulfilled_criterions_max
+					  << "'max' criterions are fulfilled" << std::endl;
+			stream.cancel();
+		}
 	}
 
 	void constructSubstitutions(AbstractConfig & substitutionsView,

--- a/dbms/src/Client/PerformanceTest.cpp
+++ b/dbms/src/Client/PerformanceTest.cpp
@@ -690,6 +690,8 @@ private:
 
     void runTest(Config & test_config)
     {
+        queries.clear();
+
         test_name = test_config->getString("name");
         std::cout << "Running: " << test_name << "\n";
 
@@ -768,19 +770,14 @@ private:
 
         if (test_config->has("substitutions"))
         {
+            if (queries.size() > 1)
+                throw Poco::Exception("Only one query is allowed when using substitutions", 1);
+
             /// Make "subconfig" of inner xml block
             AbstractConfig substitutions_view(test_config->createView("substitutions"));
             constructSubstitutions(substitutions_view, substitutions);
 
-            queries = formatQueries(query, substitutions);
-        }
-        else
-        {
-            // TODO: probably it will be a good practice to check if
-            // query string has {substitution pattern}, but no substitution field
-            // was found in xml configuration
-
-            queries.push_back(query);
+            queries = formatQueries(queries[0], substitutions);
         }
 
         if (!test_config->has("type"))

--- a/dbms/src/Client/PerformanceTest.cpp
+++ b/dbms/src/Client/PerformanceTest.cpp
@@ -951,7 +951,7 @@ private:
         statistics[statisticIndex].watch_per_query.restart();
 
         std::shared_ptr<RemoteBlockInputStream> stream
-            = std::make_shared<RemoteBlockInputStream>(connection, query, &settings, nullptr, Tables() /*, query_processing_stage*/
+            = std::make_shared<RemoteBlockInputStream>(*connection, query, &settings, nullptr, Tables() /*, query_processing_stage*/
                 );
 
         size_t stream_index;

--- a/dbms/src/Client/PerformanceTest.cpp
+++ b/dbms/src/Client/PerformanceTest.cpp
@@ -2,26 +2,26 @@
 #include <limits>
 #include <unistd.h>
 
-#include <sys/stat.h>
 #include <boost/program_options.hpp>
+#include <sys/stat.h>
 
-#include <DB/AggregateFunctions/ReservoirSampler.h>
-#include <DB/Client/ConnectionPool.h>
-#include <DB/Common/ConcurrentBoundedQueue.h>
-#include <DB/Common/Stopwatch.h>
-#include <DB/Common/ThreadPool.h>
-#include <DB/Core/Types.h>
-#include <DB/DataStreams/RemoteBlockInputStream.h>
-#include <DB/Interpreters/Settings.h>
-#include <DB/IO/ReadHelpers.h>
-#include <DB/IO/ReadBufferFromFileDescriptor.h>
+#include <AggregateFunctions/ReservoirSampler.h>
+#include <Client/ConnectionPool.h>
+#include <Common/ConcurrentBoundedQueue.h>
+#include <Common/Stopwatch.h>
+#include <Common/ThreadPool.h>
+#include <Core/Types.h>
+#include <DataStreams/RemoteBlockInputStream.h>
+#include <IO/ReadBufferFromFileDescriptor.h>
+#include <IO/ReadHelpers.h>
+#include <Interpreters/Settings.h>
 
 
 #include <Poco/AutoPtr.h>
-#include <Poco/XML/XMLStream.h>
+#include <Poco/Exception.h>
 #include <Poco/SAX/InputSource.h>
 #include <Poco/Util/XMLConfiguration.h>
-#include <Poco/Exception.h>
+#include <Poco/XML/XMLStream.h>
 
 #include "InterruptListener.h"
 
@@ -31,25 +31,31 @@
   */
 namespace DB
 {
-
 namespace ErrorCodes
 {
-	extern const int POCO_EXCEPTION;
-	extern const int STD_EXCEPTION;
-	extern const int UNKNOWN_EXCEPTION;
+    extern const int POCO_EXCEPTION;
+    extern const int STD_EXCEPTION;
+    extern const int UNKNOWN_EXCEPTION;
 }
 
-bool isNumber(const std::string & str) {
-    if (str.empty()) { return false; }
-
-    size_t dotsCounter = 0;
-
-    if (str[0] == '.' || str[str.size() - 1] == '.') {
+bool isNumber(const std::string & str)
+{
+    if (str.empty())
+    {
         return false;
     }
 
-    for (char chr : str) {
-        if (chr == '.') {
+    size_t dotsCounter = 0;
+
+    if (str[0] == '.' || str[str.size() - 1] == '.')
+    {
+        return false;
+    }
+
+    for (char chr : str)
+    {
+        if (chr == '.')
+        {
             if (dotsCounter)
                 return false;
             else
@@ -57,7 +63,8 @@ bool isNumber(const std::string & str) {
             continue;
         }
 
-        if (chr < '0' || chr > '9') {
+        if (chr < '0' || chr > '9')
+        {
             return false;
         }
     }
@@ -65,14 +72,16 @@ bool isNumber(const std::string & str) {
     return true;
 }
 
-class JSONString {
- private:
+class JSONString
+{
+private:
     std::map<std::string, std::string> content;
     std::string current_key;
     size_t _padding = 1;
- public:
-    JSONString() {};
-    JSONString(size_t padding): _padding(padding) {};
+
+public:
+    JSONString(){};
+    JSONString(size_t padding) : _padding(padding){};
 
     JSONString & operator[](const std::string & key)
     {
@@ -81,8 +90,7 @@ class JSONString {
     }
 
     template <typename T>
-	typename std::enable_if<std::is_arithmetic<T>::value, JSONString & >::type
-	operator[](const T key)
+    typename std::enable_if<std::is_arithmetic<T>::value, JSONString &>::type operator[](const T key)
     {
         current_key = std::to_string(key);
         return *this;
@@ -90,17 +98,20 @@ class JSONString {
 
     void set(std::string value)
     {
-        if (current_key.empty()) {
+        if (current_key.empty())
+        {
             throw "cannot use set without key";
         }
 
-        if (value.empty()) {
+        if (value.empty())
+        {
             value = "null";
         }
 
         bool reserved = (value[0] == '[' || value[0] == '{' || value == "null");
 
-        if (!reserved && !isNumber(value)) {
+        if (!reserved && !isNumber(value))
+        {
             value = '\"' + value + '\"';
         }
 
@@ -108,34 +119,39 @@ class JSONString {
         current_key = "";
     }
 
-	void set(const JSONString & innerJSON)
+    void set(const JSONString & innerJSON)
     {
-    	set(innerJSON.constructOutput());
+        set(innerJSON.constructOutput());
     }
 
-	void set(const std::vector<JSONString> & runInfos)
+    void set(const std::vector<JSONString> & runInfos)
     {
-        if (current_key.empty()) {
+        if (current_key.empty())
+        {
             throw "cannot use set without key";
         }
 
         content[current_key] = "[\n";
 
-        for (size_t i = 0; i < runInfos.size(); ++i) {
-        	for (size_t i = 0; i < _padding + 1; ++i) {
-        		content[current_key] += "\t";
-        	}
-        	content[current_key] += runInfos[i].constructOutput(_padding + 2);
+        for (size_t i = 0; i < runInfos.size(); ++i)
+        {
+            for (size_t i = 0; i < _padding + 1; ++i)
+            {
+                content[current_key] += "\t";
+            }
+            content[current_key] += runInfos[i].constructOutput(_padding + 2);
 
-        	if (i != runInfos.size() - 1) {
-        		content[current_key] += ',';
-        	}
+            if (i != runInfos.size() - 1)
+            {
+                content[current_key] += ',';
+            }
 
-        	content[current_key] += "\n";
+            content[current_key] += "\n";
         }
 
-        for (size_t i = 0; i < _padding; ++i) {
-        	content[current_key] += "\t";
+        for (size_t i = 0; i < _padding; ++i)
+        {
+            content[current_key] += "\t";
         }
         content[current_key] += ']';
         current_key = "";
@@ -148,7 +164,7 @@ class JSONString {
     }
     std::string constructOutput() const
     {
-    	return constructOutput(_padding);
+        return constructOutput(_padding);
     }
 
     std::string constructOutput(size_t padding) const
@@ -157,26 +173,32 @@ class JSONString {
 
         bool first = true;
 
-        for (auto it = content.begin(); it != content.end(); ++it) {
-            if (! first) {
+        for (auto it = content.begin(); it != content.end(); ++it)
+        {
+            if (!first)
+            {
                 output += ',';
-            } else {
+            }
+            else
+            {
                 first = false;
             }
 
             output += "\n";
-            for (size_t i = 0; i < padding; ++i) {
-	            output += "\t";
+            for (size_t i = 0; i < padding; ++i)
+            {
+                output += "\t";
             }
 
-            std::string key   = '\"' + it->first + '\"';
+            std::string key = '\"' + it->first + '\"';
             std::string value = it->second;
 
             output += key + ": " + value;
         }
 
         output += "\n";
-        for (size_t i = 0; i < padding - 1; ++i) {
+        for (size_t i = 0; i < padding - 1; ++i)
+        {
             output += "\t";
         }
         output += "}";
@@ -191,1134 +213,1201 @@ std::ostream & operator<<(std::ostream & stream, const JSONString & jsonObj)
     return stream;
 }
 
-enum PriorityType { min, max };
+enum PriorityType
+{
+    min,
+    max
+};
 
-struct CriterionWithPriority {
-	PriorityType priority;
-	size_t value;
-	bool   fulfilled;
+struct CriterionWithPriority
+{
+    PriorityType priority;
+    size_t value;
+    bool fulfilled;
 
-	CriterionWithPriority()
-		: value(0), fulfilled(false) {}
-	CriterionWithPriority(const CriterionWithPriority &) = default;
+    CriterionWithPriority() : value(0), fulfilled(false)
+    {
+    }
+    CriterionWithPriority(const CriterionWithPriority &) = default;
 };
 
 /// Termination criterions. The running test will be terminated in either of two conditions:
 /// 1. All criterions marked 'min' are fulfilled
 /// or
 /// 2. Any criterion  marked 'max' is  fulfilled
-class StopCriterions {
+class StopCriterions
+{
 private:
-	using AbstractConfiguration = Poco::AutoPtr<Poco::Util::AbstractConfiguration>;
-	using Keys = std::vector<std::string>;
+    using AbstractConfiguration = Poco::AutoPtr<Poco::Util::AbstractConfiguration>;
+    using Keys = std::vector<std::string>;
 
-	void initializeStruct(const std::string & priority,
-						  const AbstractConfiguration & stopCriterionsView)
-	{
-		Keys keys;
-		stopCriterionsView->keys(priority, keys);
+    void initializeStruct(const std::string & priority, const AbstractConfiguration & stopCriterionsView)
+    {
+        Keys keys;
+        stopCriterionsView->keys(priority, keys);
 
-		PriorityType priorityType = (priority == "min" ? min : max);
+        PriorityType priorityType = (priority == "min" ? min : max);
 
-		for (const std::string & key : keys) {
-			if (key == "timeout_ms") {
-				timeout_ms.value    = stopCriterionsView->getUInt64(priority + ".timeout_ms");
-				timeout_ms.priority = priorityType;
-			} else if (key == "rows_read") {
-				rows_read.value    = stopCriterionsView->getUInt64(priority + ".rows_read");
-				rows_read.priority = priorityType;
-			} else if (key == "bytes_read_uncompressed") {
-				bytes_read_uncompressed.value    = stopCriterionsView->getUInt64(priority + ".bytes_read_uncompressed");
-				bytes_read_uncompressed.priority = priorityType;
-			} else if (key == "iterations") {
-				iterations.value    = stopCriterionsView->getUInt64(priority + ".iterations");
-				iterations.priority = priorityType;
-			} else if (key == "min_time_not_changing_for_ms") {
-				min_time_not_changing_for_ms.value    = stopCriterionsView->getUInt64(priority + ".min_time_not_changing_for_ms");
-				min_time_not_changing_for_ms.priority = priorityType;
-			} else if (key == "max_speed_not_changing_for_ms") {
-				max_speed_not_changing_for_ms.value    = stopCriterionsView->getUInt64(priority + ".max_speed_not_changing_for_ms");
-				max_speed_not_changing_for_ms.priority = priorityType;
-			} else if (key == "average_speed_not_changing_for_ms") {
-				average_speed_not_changing_for_ms.value    = stopCriterionsView->getUInt64(priority + ".average_speed_not_changing_for_ms");
-				average_speed_not_changing_for_ms.priority = priorityType;
-			} else {
-				throw Poco::Exception("Met unkown stop criterion: " + key, 1);
-			}
+        for (const std::string & key : keys)
+        {
+            if (key == "timeout_ms")
+            {
+                timeout_ms.value = stopCriterionsView->getUInt64(priority + ".timeout_ms");
+                timeout_ms.priority = priorityType;
+            }
+            else if (key == "rows_read")
+            {
+                rows_read.value = stopCriterionsView->getUInt64(priority + ".rows_read");
+                rows_read.priority = priorityType;
+            }
+            else if (key == "bytes_read_uncompressed")
+            {
+                bytes_read_uncompressed.value = stopCriterionsView->getUInt64(priority + ".bytes_read_uncompressed");
+                bytes_read_uncompressed.priority = priorityType;
+            }
+            else if (key == "iterations")
+            {
+                iterations.value = stopCriterionsView->getUInt64(priority + ".iterations");
+                iterations.priority = priorityType;
+            }
+            else if (key == "min_time_not_changing_for_ms")
+            {
+                min_time_not_changing_for_ms.value = stopCriterionsView->getUInt64(priority + ".min_time_not_changing_for_ms");
+                min_time_not_changing_for_ms.priority = priorityType;
+            }
+            else if (key == "max_speed_not_changing_for_ms")
+            {
+                max_speed_not_changing_for_ms.value = stopCriterionsView->getUInt64(priority + ".max_speed_not_changing_for_ms");
+                max_speed_not_changing_for_ms.priority = priorityType;
+            }
+            else if (key == "average_speed_not_changing_for_ms")
+            {
+                average_speed_not_changing_for_ms.value = stopCriterionsView->getUInt64(priority + ".average_speed_not_changing_for_ms");
+                average_speed_not_changing_for_ms.priority = priorityType;
+            }
+            else
+            {
+                throw Poco::Exception("Met unkown stop criterion: " + key, 1);
+            }
 
-			if (priority == "min") { ++number_of_initialized_min; };
-			if (priority == "max") { ++number_of_initialized_max; };
-		}
-	}
+            if (priority == "min")
+            {
+                ++number_of_initialized_min;
+            };
+            if (priority == "max")
+            {
+                ++number_of_initialized_max;
+            };
+        }
+    }
 
 public:
-	StopCriterions()
-		: number_of_initialized_min(0), number_of_initialized_max(0),
-		  fulfilled_criterions_min(0), fulfilled_criterions_max(0) {}
+    StopCriterions() : number_of_initialized_min(0), number_of_initialized_max(0), fulfilled_criterions_min(0), fulfilled_criterions_max(0)
+    {
+    }
 
-	StopCriterions(const StopCriterions &anotherCriterions)
-		:
-		timeout_ms(anotherCriterions.timeout_ms),
-		rows_read(anotherCriterions.rows_read),
-		bytes_read_uncompressed(anotherCriterions.bytes_read_uncompressed),
-		iterations(anotherCriterions.iterations),
-		min_time_not_changing_for_ms(anotherCriterions.min_time_not_changing_for_ms),
-		max_speed_not_changing_for_ms(anotherCriterions.max_speed_not_changing_for_ms),
-		average_speed_not_changing_for_ms(anotherCriterions.average_speed_not_changing_for_ms),
+    StopCriterions(const StopCriterions & anotherCriterions)
+        : timeout_ms(anotherCriterions.timeout_ms),
+          rows_read(anotherCriterions.rows_read),
+          bytes_read_uncompressed(anotherCriterions.bytes_read_uncompressed),
+          iterations(anotherCriterions.iterations),
+          min_time_not_changing_for_ms(anotherCriterions.min_time_not_changing_for_ms),
+          max_speed_not_changing_for_ms(anotherCriterions.max_speed_not_changing_for_ms),
+          average_speed_not_changing_for_ms(anotherCriterions.average_speed_not_changing_for_ms),
 
-		number_of_initialized_min(anotherCriterions.number_of_initialized_min.load()),
-		number_of_initialized_max(anotherCriterions.number_of_initialized_max.load()),
-		fulfilled_criterions_min(anotherCriterions.fulfilled_criterions_min.load()),
-		fulfilled_criterions_max(anotherCriterions.fulfilled_criterions_max.load()) {}
+          number_of_initialized_min(anotherCriterions.number_of_initialized_min.load()),
+          number_of_initialized_max(anotherCriterions.number_of_initialized_max.load()),
+          fulfilled_criterions_min(anotherCriterions.fulfilled_criterions_min.load()),
+          fulfilled_criterions_max(anotherCriterions.fulfilled_criterions_max.load())
+    {
+    }
 
-	void loadFromConfig(const AbstractConfiguration & stopCriterionsView)
-	{
-		if (stopCriterionsView->has("min")) {
-			initializeStruct("min", stopCriterionsView);
-		}
+    void loadFromConfig(const AbstractConfiguration & stopCriterionsView)
+    {
+        if (stopCriterionsView->has("min"))
+        {
+            initializeStruct("min", stopCriterionsView);
+        }
 
-		if (stopCriterionsView->has("max")) {
-			initializeStruct("max", stopCriterionsView);
-		}
-	}
+        if (stopCriterionsView->has("max"))
+        {
+            initializeStruct("max", stopCriterionsView);
+        }
+    }
 
-	void reset()
-	{
-		timeout_ms.fulfilled                        = false;
-		rows_read.fulfilled                         = false;
-		bytes_read_uncompressed.fulfilled           = false;
-		iterations.fulfilled                        = false;
-		min_time_not_changing_for_ms.fulfilled      = false;
-		max_speed_not_changing_for_ms.fulfilled     = false;
-		average_speed_not_changing_for_ms.fulfilled = false;
+    void reset()
+    {
+        timeout_ms.fulfilled = false;
+        rows_read.fulfilled = false;
+        bytes_read_uncompressed.fulfilled = false;
+        iterations.fulfilled = false;
+        min_time_not_changing_for_ms.fulfilled = false;
+        max_speed_not_changing_for_ms.fulfilled = false;
+        average_speed_not_changing_for_ms.fulfilled = false;
 
-		fulfilled_criterions_min = 0;
-		fulfilled_criterions_max = 0;
-	}
+        fulfilled_criterions_min = 0;
+        fulfilled_criterions_max = 0;
+    }
 
-	CriterionWithPriority timeout_ms;
-	CriterionWithPriority rows_read;
-	CriterionWithPriority bytes_read_uncompressed;
-	CriterionWithPriority iterations;
-	CriterionWithPriority min_time_not_changing_for_ms;
-	CriterionWithPriority max_speed_not_changing_for_ms;
-	CriterionWithPriority average_speed_not_changing_for_ms;
+    CriterionWithPriority timeout_ms;
+    CriterionWithPriority rows_read;
+    CriterionWithPriority bytes_read_uncompressed;
+    CriterionWithPriority iterations;
+    CriterionWithPriority min_time_not_changing_for_ms;
+    CriterionWithPriority max_speed_not_changing_for_ms;
+    CriterionWithPriority average_speed_not_changing_for_ms;
 
     /// Hereafter 'min' and 'max', in context of critetions, mean a level of importance
-	/// Number of initialized properties met in configuration
-	std::atomic<size_t> number_of_initialized_min;
-	std::atomic<size_t> number_of_initialized_max;
+    /// Number of initialized properties met in configuration
+    std::atomic<size_t> number_of_initialized_min;
+    std::atomic<size_t> number_of_initialized_max;
 
-	std::atomic<size_t> fulfilled_criterions_min;
-	std::atomic<size_t> fulfilled_criterions_max;
+    std::atomic<size_t> fulfilled_criterions_min;
+    std::atomic<size_t> fulfilled_criterions_max;
 };
 
 struct Stats
 {
-	Stopwatch watch;
-	Stopwatch watch_per_query;
-	Stopwatch min_time_watch;
-	Stopwatch max_rows_speed_watch;
-	Stopwatch max_bytes_speed_watch;
-	Stopwatch avg_rows_speed_watch;
-	Stopwatch avg_bytes_speed_watch;
-	size_t queries;
-	size_t rows_read;
-	size_t bytes_read;
+    Stopwatch watch;
+    Stopwatch watch_per_query;
+    Stopwatch min_time_watch;
+    Stopwatch max_rows_speed_watch;
+    Stopwatch max_bytes_speed_watch;
+    Stopwatch avg_rows_speed_watch;
+    Stopwatch avg_bytes_speed_watch;
+    size_t queries;
+    size_t rows_read;
+    size_t bytes_read;
 
-	using Sampler = ReservoirSampler<double>;
-	Sampler sampler {1 << 16};
+    using Sampler = ReservoirSampler<double>;
+    Sampler sampler{1 << 16};
 
-	/// min_time in ms
-	UInt64 min_time   = std::numeric_limits<UInt64>::max();
-	double total_time = 0;
+    /// min_time in ms
+    UInt64 min_time = std::numeric_limits<UInt64>::max();
+    double total_time = 0;
 
-	double max_rows_speed  = 0;
-	double max_bytes_speed = 0;
+    double max_rows_speed = 0;
+    double max_bytes_speed = 0;
 
-	double avg_rows_speed_value = 0;
-	double avg_rows_speed_first = 0;
-	static double avg_rows_speed_precision;
+    double avg_rows_speed_value = 0;
+    double avg_rows_speed_first = 0;
+    static double avg_rows_speed_precision;
 
-	double avg_bytes_speed_value = 0;
-	double avg_bytes_speed_first = 0;
-	static double avg_bytes_speed_precision;
+    double avg_bytes_speed_value = 0;
+    double avg_bytes_speed_first = 0;
+    static double avg_bytes_speed_precision;
 
-	size_t number_of_rows_speed_info_batches  = 0;
-	size_t number_of_bytes_speed_info_batches = 0;
+    size_t number_of_rows_speed_info_batches = 0;
+    size_t number_of_bytes_speed_info_batches = 0;
 
-	bool ready = false; // check if a thread completed its work
+    bool ready = false; // check if a thread completed its work
 
-	std::string getStatisticByName(const std::string & statisticName) {
-	    if (statisticName == "min_time") {
-	    	return std::to_string(min_time) + "ms";
-	    }
-	    if (statisticName == "quantiles") {
-	    	std::string result = "\n";
+    std::string getStatisticByName(const std::string & statisticName)
+    {
+        if (statisticName == "min_time")
+        {
+            return std::to_string(min_time) + "ms";
+        }
+        if (statisticName == "quantiles")
+        {
+            std::string result = "\n";
 
-	    	for (double percent = 10; percent <= 90; percent += 10) {
-	    		result += "\t" + std::to_string((percent / 100));
-	    		result += ": " + std::to_string(sampler.quantileInterpolated(percent / 100.0));
-	    		result += "\n";
-	    	}
-			result += "\t0.95: "   + std::to_string(sampler.quantileInterpolated(95 / 100.0))   + "\n";
-			result += "\t0.99: "   + std::to_string(sampler.quantileInterpolated(99 / 100.0))   + "\n";
-			result += "\t0.999: "  + std::to_string(sampler.quantileInterpolated(99.9 / 100.))  + "\n";
-			result += "\t0.9999: " + std::to_string(sampler.quantileInterpolated(99.99 / 100.));
+            for (double percent = 10; percent <= 90; percent += 10)
+            {
+                result += "\t" + std::to_string((percent / 100));
+                result += ": " + std::to_string(sampler.quantileInterpolated(percent / 100.0));
+                result += "\n";
+            }
+            result += "\t0.95: " + std::to_string(sampler.quantileInterpolated(95 / 100.0)) + "\n";
+            result += "\t0.99: " + std::to_string(sampler.quantileInterpolated(99 / 100.0)) + "\n";
+            result += "\t0.999: " + std::to_string(sampler.quantileInterpolated(99.9 / 100.)) + "\n";
+            result += "\t0.9999: " + std::to_string(sampler.quantileInterpolated(99.99 / 100.));
 
-			return result;
-	    }
-	    if (statisticName == "total_time") {
-	    	return std::to_string(total_time) + "s";
-	    }
-	    if (statisticName == "queries_per_second") {
-	    	return std::to_string(queries / total_time);
-	    }
-	    if (statisticName == "rows_per_second") {
-	    	return std::to_string(rows_read / total_time);
-	    }
-	    if (statisticName == "bytes_per_second") {
-	    	return std::to_string(bytes_read / total_time);
-	    }
+            return result;
+        }
+        if (statisticName == "total_time")
+        {
+            return std::to_string(total_time) + "s";
+        }
+        if (statisticName == "queries_per_second")
+        {
+            return std::to_string(queries / total_time);
+        }
+        if (statisticName == "rows_per_second")
+        {
+            return std::to_string(rows_read / total_time);
+        }
+        if (statisticName == "bytes_per_second")
+        {
+            return std::to_string(bytes_read / total_time);
+        }
 
-	    if (statisticName == "max_rows_per_second") {
-	    	return std::to_string(max_rows_speed);
-	    }
-	    if (statisticName == "max_bytes_per_second") {
-	    	return std::to_string(max_bytes_speed);
-	    }
-	    if (statisticName == "avg_rows_per_second") {
-	    	return std::to_string(avg_rows_speed_value);
-	    }
-	    if (statisticName == "avg_bytes_per_second") {
-	    	return std::to_string(avg_bytes_speed_value);
-	    }
+        if (statisticName == "max_rows_per_second")
+        {
+            return std::to_string(max_rows_speed);
+        }
+        if (statisticName == "max_bytes_per_second")
+        {
+            return std::to_string(max_bytes_speed);
+        }
+        if (statisticName == "avg_rows_per_second")
+        {
+            return std::to_string(avg_rows_speed_value);
+        }
+        if (statisticName == "avg_bytes_per_second")
+        {
+            return std::to_string(avg_bytes_speed_value);
+        }
 
-	    return "";
-	}
+        return "";
+    }
 
-	void update_min_time(const UInt64 min_time_candidate)
-	{
-		if (min_time_candidate < min_time) {
-			min_time = min_time_candidate;
-			min_time_watch.restart();
-		}
-	}
+    void update_min_time(const UInt64 min_time_candidate)
+    {
+        if (min_time_candidate < min_time)
+        {
+            min_time = min_time_candidate;
+            min_time_watch.restart();
+        }
+    }
 
-	void update_average_speed(const double new_speed_info, Stopwatch & avg_speed_watch,
-							  size_t & number_of_info_batches, double precision,
-							  double & avg_speed_first, double & avg_speed_value)
-	{
-		avg_speed_value = ((avg_speed_value * number_of_info_batches)
-						   + new_speed_info);
-		avg_speed_value /= (++number_of_info_batches);
+    void update_average_speed(const double new_speed_info,
+        Stopwatch & avg_speed_watch,
+        size_t & number_of_info_batches,
+        double precision,
+        double & avg_speed_first,
+        double & avg_speed_value)
+    {
+        avg_speed_value = ((avg_speed_value * number_of_info_batches) + new_speed_info);
+        avg_speed_value /= (++number_of_info_batches);
 
-		if (avg_speed_first == 0) {
-			avg_speed_first = avg_speed_value;
-		}
+        if (avg_speed_first == 0)
+        {
+            avg_speed_first = avg_speed_value;
+        }
 
-		if (abs(avg_speed_value - avg_speed_first) >= precision) {
-			avg_speed_first = avg_speed_value;
-			avg_speed_watch.restart();
-		}
-	}
+        if (abs(avg_speed_value - avg_speed_first) >= precision)
+        {
+            avg_speed_first = avg_speed_value;
+            avg_speed_watch.restart();
+        }
+    }
 
-	void update_max_speed(const size_t max_speed_candidate, Stopwatch & max_speed_watch,
-						  double & max_speed)
-	{
-		if (max_speed_candidate > max_speed) {
-			max_speed = max_speed_candidate;
-			max_speed_watch.restart();
-		}
-	}
+    void update_max_speed(const size_t max_speed_candidate, Stopwatch & max_speed_watch, double & max_speed)
+    {
+        if (max_speed_candidate > max_speed)
+        {
+            max_speed = max_speed_candidate;
+            max_speed_watch.restart();
+        }
+    }
 
-	void add(size_t rows_read_inc, size_t bytes_read_inc)
-	{
-		rows_read  += rows_read_inc;
-		bytes_read += bytes_read_inc;
+    void add(size_t rows_read_inc, size_t bytes_read_inc)
+    {
+        rows_read += rows_read_inc;
+        bytes_read += bytes_read_inc;
 
-		double new_rows_speed  = rows_read_inc  / watch_per_query.elapsedSeconds();
-		double new_bytes_speed = bytes_read_inc / watch_per_query.elapsedSeconds();
+        double new_rows_speed = rows_read_inc / watch_per_query.elapsedSeconds();
+        double new_bytes_speed = bytes_read_inc / watch_per_query.elapsedSeconds();
 
-		/// Update rows speed
-		update_max_speed(new_rows_speed, max_rows_speed_watch, max_rows_speed);
-		update_average_speed(new_rows_speed, avg_rows_speed_watch,
-							 number_of_rows_speed_info_batches, avg_rows_speed_precision,
-							 avg_rows_speed_first, avg_rows_speed_value);
-		/// Update bytes speed
-		update_max_speed(new_bytes_speed, max_bytes_speed_watch, max_bytes_speed);
-		update_average_speed(new_bytes_speed, avg_bytes_speed_watch,
-							 number_of_bytes_speed_info_batches, avg_bytes_speed_precision,
-							 avg_bytes_speed_first, avg_bytes_speed_value);
-	}
+        /// Update rows speed
+        update_max_speed(new_rows_speed, max_rows_speed_watch, max_rows_speed);
+        update_average_speed(new_rows_speed,
+            avg_rows_speed_watch,
+            number_of_rows_speed_info_batches,
+            avg_rows_speed_precision,
+            avg_rows_speed_first,
+            avg_rows_speed_value);
+        /// Update bytes speed
+        update_max_speed(new_bytes_speed, max_bytes_speed_watch, max_bytes_speed);
+        update_average_speed(new_bytes_speed,
+            avg_bytes_speed_watch,
+            number_of_bytes_speed_info_batches,
+            avg_bytes_speed_precision,
+            avg_bytes_speed_first,
+            avg_bytes_speed_value);
+    }
 
-	void updateQueryInfo()
-	{
-		++queries;
-		sampler.insert(watch_per_query.elapsedSeconds());
-		update_min_time(watch_per_query.elapsed() / (1000 * 1000)); /// ns to ms
-	}
+    void updateQueryInfo()
+    {
+        ++queries;
+        sampler.insert(watch_per_query.elapsedSeconds());
+        update_min_time(watch_per_query.elapsed() / (1000 * 1000)); /// ns to ms
+    }
 
-	void setTotalTime()
-	{
-		total_time = watch.elapsedSeconds();
-	}
+    void setTotalTime()
+    {
+        total_time = watch.elapsedSeconds();
+    }
 
-	void clear()
-	{
-		watch.restart();
-		watch_per_query.restart();
-		min_time_watch.restart();
-		max_rows_speed_watch.restart();
-		max_bytes_speed_watch.restart();
-		avg_rows_speed_watch.restart();
-		avg_bytes_speed_watch.restart();
+    void clear()
+    {
+        watch.restart();
+        watch_per_query.restart();
+        min_time_watch.restart();
+        max_rows_speed_watch.restart();
+        max_bytes_speed_watch.restart();
+        avg_rows_speed_watch.restart();
+        avg_bytes_speed_watch.restart();
 
-		sampler.clear();
+        sampler.clear();
 
-		queries    = 0;
-		rows_read  = 0;
-		bytes_read = 0;
+        queries = 0;
+        rows_read = 0;
+        bytes_read = 0;
 
-		min_time   = std::numeric_limits<UInt64>::max();
-		total_time = 0;
-		max_rows_speed  = 0;
-		max_bytes_speed = 0;
-		avg_rows_speed_value  = 0;
-		avg_bytes_speed_value = 0;
-		avg_rows_speed_first  = 0;
-		avg_bytes_speed_first = 0;
-		avg_rows_speed_precision  = 0.001;
-		avg_bytes_speed_precision = 0.001;
-		number_of_rows_speed_info_batches  = 0;
-		number_of_bytes_speed_info_batches = 0;
-	}
+        min_time = std::numeric_limits<UInt64>::max();
+        total_time = 0;
+        max_rows_speed = 0;
+        max_bytes_speed = 0;
+        avg_rows_speed_value = 0;
+        avg_bytes_speed_value = 0;
+        avg_rows_speed_first = 0;
+        avg_bytes_speed_first = 0;
+        avg_rows_speed_precision = 0.001;
+        avg_bytes_speed_precision = 0.001;
+        number_of_rows_speed_info_batches = 0;
+        number_of_bytes_speed_info_batches = 0;
+    }
 };
 
-double Stats::avg_rows_speed_precision  = 0.001;
+double Stats::avg_rows_speed_precision = 0.001;
 double Stats::avg_bytes_speed_precision = 0.001;
 
 class PerformanceTest
 {
 public:
-	PerformanceTest(
-		const unsigned   concurrency_,
-		const String   & host_,
-		const UInt16     port_,
-		const String   & default_database_,
-		const String   & user_,
-		const String   & password_,
-		const std::vector<std::string> & input_files,
+    PerformanceTest(const unsigned concurrency_,
+        const String & host_,
+        const UInt16 port_,
+        const String & default_database_,
+        const String & user_,
+        const String & password_,
+        const std::vector<std::string> & input_files,
         const std::vector<std::string> & tags,
         const std::vector<std::string> & without_tags,
         const std::vector<std::string> & names,
         const std::vector<std::string> & without_names,
         const std::vector<std::string> & names_regexp,
-        const std::vector<std::string> & without_names_regexp
-	):
-	   concurrency(concurrency_), queue(concurrency_),
-	   connections(concurrency, host_, port_, default_database_, user_, password_),
-	   pool(concurrency),
-	   testsConfigurations(input_files.size()),
-	   gotSIGINT(false)
-	{
-		if (input_files.size() < 1) {
-			throw Poco::Exception("No tests were specified", 0);
-		}
+        const std::vector<std::string> & without_names_regexp)
+        : concurrency(concurrency_),
+          queue(concurrency_),
+          connections(concurrency, host_, port_, default_database_, user_, password_),
+          pool(concurrency),
+          testsConfigurations(input_files.size()),
+          gotSIGINT(false)
+    {
+        if (input_files.size() < 1)
+        {
+            throw Poco::Exception("No tests were specified", 0);
+        }
 
-		std::cerr << std::fixed << std::setprecision(3);
-		std::cout << std::fixed << std::setprecision(3);
-		readTestsConfiguration(input_files);
-	}
+        std::cerr << std::fixed << std::setprecision(3);
+        std::cout << std::fixed << std::setprecision(3);
+        readTestsConfiguration(input_files);
+    }
 
 private:
-	unsigned concurrency;
-	std::string testName;
-
-	using Query   = std::string;
-	using Queries = std::vector<Query>;
-	using QueriesWithIndexes = std::vector<std::pair<Query, size_t>>;
-	Queries queries;
-
-	using Queue = ConcurrentBoundedQueue<std::pair<Query, size_t>>;
-	Queue queue;
-
-	using Keys = std::vector<std::string>;
-
-	ConnectionPool connections;
-	ThreadPool     pool;
-	Settings       settings;
-
-	InterruptListener interrupt_listener;
-	std::vector<std::shared_ptr<RemoteBlockInputStream>> streams;
-
-	double average_speed_precision = 0.001;
-
-	using XMLConfiguration  = Poco::Util::XMLConfiguration;
-	using AbstractConfig    = Poco::AutoPtr<Poco::Util::AbstractConfiguration>;
-	using Config            = Poco::AutoPtr<XMLConfiguration>;
-	using Paths             = std::vector<std::string>;
-	using StringToVector    = std::map< std::string, std::vector<std::string> >;
-	StringToVector substitutions;
-	std::vector<Config> testsConfigurations;
-
-	using StringKeyValue = std::map<std::string, std::string>;
-	std::vector<StringKeyValue> substitutionsMaps;
-
-	std::atomic<bool> gotSIGINT;
-	std::vector<StopCriterions> stopCriterions;
-
-	// TODO: create enum class instead of string
-	#define incFulfilledCriterions(index, CRITERION) \
-		if (! stopCriterions[index].CRITERION.fulfilled) {\
-			stopCriterions[index].CRITERION.priority == min \
-					? ++stopCriterions[index].fulfilled_criterions_min \
-					: ++stopCriterions[index].fulfilled_criterions_max; \
-			stopCriterions[index].CRITERION.fulfilled = true; \
-		}
-
-	enum ExecutionType { loop, once };
-	ExecutionType execType;
-
-	size_t timesToRun = 1;
-	std::vector<Stats> statistics;
-	std::mutex mutex;
-
-	void readTestsConfiguration(const Paths & input_files)
-	{
-		testsConfigurations.resize(input_files.size());
-
-		for (size_t i = 0; i != input_files.size(); ++i) {
-			const std::string path = input_files[i];
-			testsConfigurations[i] = Config(new XMLConfiguration(path));
-		}
-
-		// TODO: here will be tests filter on tags, names, regexp matching, etc.
-		// { ... }
-
-		// for now let's launch one test only
-		if (testsConfigurations.size()) {
-			for (auto & testConfig : testsConfigurations) {
-				runTest(testConfig);
-			}
-		}
-	}
-
-	void runTest(Config & testConfig)
-	{
-		testName = testConfig->getString("name");
-		std::cout << "Running: " << testName << "\n";
-
-		/// Preprocess configuration file
-		if (testConfig->has("settings")) {
-			Keys configSettings;
-			testConfig->keys("settings", configSettings);
-
-			/// This macro goes through all settings in the Settings.h
-			/// and, if found any settings in test's xml configuration
-			/// with the same name, sets its value to settings
-			std::vector<std::string>::iterator it;
-			#define EXTRACT_SETTING(TYPE, NAME, DEFAULT) \
-				it = std::find(configSettings.begin(), configSettings.end(), #NAME); \
-				if (it != configSettings.end()) \
-					settings.set( \
-						#NAME, testConfig->getString("settings."#NAME) \
-					);
-				APPLY_FOR_SETTINGS(EXTRACT_SETTING)
-				APPLY_FOR_LIMITS(EXTRACT_SETTING)
-			#undef EXTRACT_SETTING
-
-			if (std::find(configSettings.begin(), configSettings.end(), "profile") !=
-				configSettings.end()) {
-				// TODO: proceed profile settings in a proper way
-			}
-
-			if (std::find(configSettings.begin(), configSettings.end(),
-						  "average_rows_speed_precision") != configSettings.end()) {
-				Stats::avg_rows_speed_precision = testConfig->getDouble("settings.average_rows_speed_precision");
-			}
-
-			if (std::find(configSettings.begin(), configSettings.end(),
-						  "average_bytes_speed_precision") != configSettings.end()) {
-				Stats::avg_bytes_speed_precision = testConfig->getDouble("settings.average_bytes_speed_precision");
-			}
-		}
-
-		Query query;
-
-		if (! testConfig->has("query")) {
-			throw Poco::Exception("Missing query field in test's config: " +
-								  testName, 1);
-		}
-
-		query = testConfig->getString("query");
-
-		if (query.empty()) {
-			throw Poco::Exception("The query is empty in test's config: " +
-								  testName, 1);
-		}
-
-		if (testConfig->has("substitutions")) {
-			/// Make "subconfig" of inner xml block
-			AbstractConfig substitutionsView(testConfig
-											 ->createView("substitutions"));
-			constructSubstitutions(substitutionsView, substitutions);
-
-			queries = formatQueries(query, substitutions);
-		} else {
-			// TODO: probably it will be a good practice to check if
-			// query string has {substitution pattern}, but no substitution field
-			// was found in xml configuration
-
-			queries.push_back(query);
-		}
-
-		if (! testConfig->has("type")) {
-			throw Poco::Exception("Missing type property in config: " +
-								  testName, 1);
-		}
-
-		std::string configExecType = testConfig->getString("type");
-		if (configExecType == "loop")
-			execType = loop;
-		else if (configExecType == "once")
-			execType = once;
-		else
-			throw Poco::Exception("Unknown type " + configExecType + " in :" +
-								  testName, 1);
-
-		if (testConfig->has("timesToRun")) {
-			timesToRun = testConfig->getUInt("timesToRun");
-		}
-
-		stopCriterions.resize(timesToRun * queries.size());
-
-		if (testConfig->has("stop")) {
-			AbstractConfig stopCriterionsView(testConfig
-										      ->createView("stop"));
-			for (StopCriterions & stopCriterion : stopCriterions) {
-				stopCriterion.loadFromConfig(stopCriterionsView);
-			}
-		} else {
-			throw Poco::Exception("No termination conditions were found in config", 1);
-		}
-
-		AbstractConfig metricsView(testConfig->createView("metric"));
-		Keys metrics;
-		metricsView->keys(metrics);
-		if (metrics.size() > 1) {
-			throw Poco::Exception("More than 1 main metric is not allowed", 1);
-		}
-
-		if (metrics.size() == 1) {
-			checkMetricInput(metrics[0]);
-		}
-
-		statistics.resize(timesToRun * queries.size());
-		for (size_t numberOfLaunch = 0; numberOfLaunch < timesToRun; ++numberOfLaunch) {
-			QueriesWithIndexes queriesWithIndexes;
-
-			for (size_t queryIndex = 0; queryIndex < queries.size(); ++queryIndex) {
-				size_t statisticIndex = numberOfLaunch * queries.size() + queryIndex;
-				stopCriterions[statisticIndex].reset();
-
-				queriesWithIndexes.push_back({queries[queryIndex], statisticIndex});
-			}
-
-			if (interrupt_listener.check()) {
-				gotSIGINT = true;
-			}
-
-			if (gotSIGINT) {
-				break;
-			}
-
-			runQueries(queriesWithIndexes);
-		}
-
-		if (metrics.size() == 1) {
-			minOutput(metrics[0]);
-		}
-		else {
-			constructTotalInfo();
-		}
-	}
-
-	void checkMetricInput(const std::string & main_metric) const {
-	    std::vector<std::string> loopMetrics = {
-	    	"min_time", "quantiles", "total_time", "queries_per_second",
-	    	"rows_per_second", "bytes_per_second"
-	    };
-
-	    std::vector<std::string> infiniteMetrics = {
-	    	"max_rows_per_second", "max_bytes_per_second", "avg_rows_per_second",
-	    	"avg_bytes_per_second"
-	    };
-
-	    if (execType == loop) {
-	    	if (std::find(infiniteMetrics.begin(), infiniteMetrics.end(), main_metric) != infiniteMetrics.end()) {
-	    		throw Poco::Exception("Wrong type of main metric for loop "
-						    		  "execution type", 1);
-	    	}
-	    } else {
-	    	if (std::find(loopMetrics.begin(), loopMetrics.end(), main_metric) != loopMetrics.end()) {
-	    		throw Poco::Exception("Wrong type of main metric for "
-	    							  "inifinite execution type", 1);
-	    	}
-	    }
-	}
-
-	void runQueries(const QueriesWithIndexes & queriesWithIndexes)
-	{
-		for (size_t i = 0; i < concurrency; ++i) {
-			pool.schedule(std::bind(
-				&PerformanceTest::thread,
-				this,
-				connections.IConnectionPool::get()
-			));
-		}
-
-		for (const std::pair<Query, const size_t> & queryAndIndex : queriesWithIndexes) {
-			Query query = queryAndIndex.first;
-			const size_t statisticIndex = queryAndIndex.second;
-
-			queue.push({query, statisticIndex});
-		}
-
-		for (size_t i = 0; i < concurrency; ++i) {
-			/// Genlty asking threads to stop
-			queue.push({"", std::numeric_limits<size_t>::max()});
-		}
-
-		pool.wait();
-	}
-
-	void thread(ConnectionPool::Entry & connection)
-	{
-		InterruptListener thread_interrupt_listener;
-
-		Query query;
-		size_t statisticIndex;
-
-		std::pair<Query, size_t> queryAndIndex;
-
-		while (true) {
-			queue.pop(queryAndIndex);
-			query = queryAndIndex.first;
-			statisticIndex = queryAndIndex.second;
-
-			/// Empty query means end of execution
-			if (query.empty())
-				break;
-
-			size_t max_iterations = stopCriterions[statisticIndex].iterations.value;
-			size_t iteration = 0;
-
-			statistics[statisticIndex].clear();
-			execute(connection, thread_interrupt_listener, query, statisticIndex);
-
-			if (execType == loop) {
-				while (! gotSIGINT) {
-					++iteration;
-
-					/// check stop criterions
-					if (max_iterations && iteration >= max_iterations) {
-						incFulfilledCriterions(statisticIndex, iterations);
-					}
-
-					if (stopCriterions[statisticIndex].number_of_initialized_min &&
-						(stopCriterions[statisticIndex].fulfilled_criterions_min >=
-						 stopCriterions[statisticIndex].number_of_initialized_min)) {
-						/// All 'min' criterions are fulfilled
-						break;
-					}
-
-					if (stopCriterions[statisticIndex].number_of_initialized_max &&
-						stopCriterions[statisticIndex].fulfilled_criterions_max) {
-						/// Some 'max' criterions are fulfilled
-						break;
-					}
-
-					execute(connection, thread_interrupt_listener, query, statisticIndex);
-				}
-			}
-
-			if (! gotSIGINT) {
-				statistics[statisticIndex].ready = true;
-			}
-		}
-	}
-
-	void execute(ConnectionPool::Entry & connection,
-				 InterruptListener & thread_interrupt_listener,
-				 const Query & query, const size_t statisticIndex)
-	{
-		statistics[statisticIndex].watch_per_query.restart();
-
-		std::shared_ptr<RemoteBlockInputStream> stream = std::make_shared<RemoteBlockInputStream>(
-			connection, query, &settings, nullptr, Tables()/*, query_processing_stage*/
-		);
-
-		size_t stream_index;
-		{
-			std::lock_guard<std::mutex> lock(mutex);
-			streams.push_back(stream);
-			stream_index = streams.size() - 1;
-		}
-
-		Progress progress;
-		stream->setProgressCallback(
-			[&progress, &stream, &thread_interrupt_listener, statisticIndex, this]
-			(const Progress & value) {
-				progress.incrementPiecewiseAtomically(value);
-
-				this->checkFulfilledCriterionsAndUpdate(
-					progress, stream, thread_interrupt_listener, statisticIndex
-				);
-		});
-
-		stream->readPrefix();
-		while (Block block = stream->read())
-			;
-		stream->readSuffix();
-
-		std::lock_guard<std::mutex> lock(mutex);
-		streams[stream_index].reset();
-
-		statistics[statisticIndex].updateQueryInfo();
-		statistics[statisticIndex].setTotalTime();
-	}
-
-	void checkFulfilledCriterionsAndUpdate(const Progress & progress,
-										   const std::shared_ptr<RemoteBlockInputStream> & stream,
-										   InterruptListener & thread_interrupt_listener,
-										   const size_t statisticIndex)
-	{
-		std::lock_guard<std::mutex> lock(mutex);
-
-		statistics[statisticIndex].add(progress.rows, progress.bytes);
-
-		size_t max_rows_to_read = stopCriterions[statisticIndex].rows_read.value;
-		if (max_rows_to_read && statistics[statisticIndex].rows_read >= max_rows_to_read) {
-			incFulfilledCriterions(statisticIndex, rows_read);
-		}
-
-		size_t max_bytes_to_read = stopCriterions[statisticIndex].bytes_read_uncompressed.value;
-		if (max_bytes_to_read && statistics[statisticIndex].bytes_read >= max_bytes_to_read) {
-			incFulfilledCriterions(statisticIndex, bytes_read_uncompressed);
-		}
-
-		if (UInt64 max_timeout_ms = stopCriterions[statisticIndex].timeout_ms.value) {
-			/// cast nanoseconds to ms
-			if ((statistics[statisticIndex].watch.elapsed() / (1000 * 1000)) > max_timeout_ms) {
-				incFulfilledCriterions(statisticIndex, timeout_ms);
-			}
-		}
-
-		size_t min_time_not_changing_for_ms = stopCriterions[statisticIndex]
-												.min_time_not_changing_for_ms.value;
-		if (min_time_not_changing_for_ms) {
-			size_t min_time_did_not_change_for = statistics[statisticIndex]
-													.min_time_watch
-													.elapsed() / (1000 * 1000);
-
-			if (min_time_did_not_change_for >= min_time_not_changing_for_ms) {
-				incFulfilledCriterions(statisticIndex, min_time_not_changing_for_ms);
-			}
-		}
-
-		size_t max_speed_not_changing_for_ms = stopCriterions[statisticIndex]
-												.max_speed_not_changing_for_ms
-												.value;
-		if (max_speed_not_changing_for_ms) {
-			UInt64 speed_not_changing_time = statistics[statisticIndex]
-												.max_rows_speed_watch
-												.elapsed() / (1000 * 1000);
-			if (speed_not_changing_time >= max_speed_not_changing_for_ms) {
-				incFulfilledCriterions(statisticIndex, max_speed_not_changing_for_ms);
-			}
-		}
-
-		size_t average_speed_not_changing_for_ms = stopCriterions[statisticIndex]
-													.average_speed_not_changing_for_ms
-													.value;
-		if (average_speed_not_changing_for_ms) {
-			UInt64 speed_not_changing_time = statistics[statisticIndex]
-												.avg_rows_speed_watch
-												.elapsed() / (1000 * 1000);
-			if (speed_not_changing_time >= average_speed_not_changing_for_ms) {
-				incFulfilledCriterions(statisticIndex, average_speed_not_changing_for_ms);
-			}
-		}
-
-		if (stopCriterions[statisticIndex].number_of_initialized_min &&
-			(stopCriterions[statisticIndex].fulfilled_criterions_min >=
-			stopCriterions[statisticIndex].number_of_initialized_min)) {
-			/// All 'min' criterions are fulfilled
-			stream->cancel();
-		}
-
-		if (stopCriterions[statisticIndex].number_of_initialized_max &&
-			stopCriterions[statisticIndex].fulfilled_criterions_max) {
-			/// Some 'max' criterions are fulfilled
-			stream->cancel();
-		}
-
-		if (thread_interrupt_listener.check()) { /// SIGINT
-			gotSIGINT = true;
-
-			for (const std::shared_ptr<RemoteBlockInputStream> & stream : streams) {
-				if (stream) {
-					stream->cancel();
-				}
-			}
-		}
-	}
-
-	void constructSubstitutions(AbstractConfig & substitutionsView,
-						        StringToVector & substitutions)
-	{
-		Keys xml_substitutions;
-		substitutionsView->keys(xml_substitutions);
-
-		for (size_t i = 0; i != xml_substitutions.size(); ++i) {
-			const AbstractConfig xml_substitution(
-				substitutionsView->createView("substitution[" +
-			   								  std::to_string(i) + "]")
-			);
-
-			/// Property values for substitution will be stored in a vector
-			/// accessible by property name
-			std::vector<std::string> xml_values;
-			xml_substitution->keys("values", xml_values);
-
-			std::string name = xml_substitution->getString("name");
-
-			for (size_t j = 0; j != xml_values.size(); ++j) {
-				substitutions[name].push_back(
-					xml_substitution->getString("values.value[" +
-											    std::to_string(j) + "]")
-				);
-			}
-		}
-	}
-
-	std::vector<std::string> formatQueries(const std::string & query,
-					   					   StringToVector substitutions)
-	{
-		std::vector<std::string> queries;
-
-		StringToVector::iterator substitutions_first = substitutions.begin();
-		StringToVector::iterator substitutions_last  = substitutions.end();
-		--substitutions_last;
-
-		std::map<std::string, std::string> substitutionsMap;
-
-		runThroughAllOptionsAndPush(
-			substitutions_first, substitutions_last, query, queries, substitutionsMap
-		);
-
-		return queries;
-	}
-
-	/// Recursive method which goes through all substitution blocks in xml
-	/// and replaces property {names} by their values
-	void runThroughAllOptionsAndPush(
-		StringToVector::iterator substitutions_left,
-		StringToVector::iterator substitutions_right,
-		const std::string & template_query,
-		std::vector<std::string> & queries,
-		const StringKeyValue & templateSubstitutionsMap = StringKeyValue()
-	)
-	{
-		std::string name = substitutions_left->first;
-		std::vector<std::string> values = substitutions_left->second;
-
-		for (const std::string & value : values) {
-			/// Copy query string for each unique permutation
-			Query query = template_query;
-			StringKeyValue substitutionsMap = templateSubstitutionsMap;
-			size_t substrPos  = 0;
-
-			while (substrPos != std::string::npos) {
-				substrPos = query.find("{" + name + "}");
-
-				if (substrPos != std::string::npos) {
-					query.replace(
-						substrPos, 1 + name.length() + 1,
-						value
-					);
-				}
-			}
-
-			substitutionsMap[name] = value;
-
-			/// If we've reached the end of substitution chain
-			if (substitutions_left == substitutions_right) {
-				queries.push_back(query);
-				substitutionsMaps.push_back(substitutionsMap);
-			} else {
-				StringToVector::iterator next_it = substitutions_left;
-				++next_it;
-
-				runThroughAllOptionsAndPush(
-					next_it, substitutions_right, query, queries, substitutionsMap
-				);
-			}
-		}
-	}
+    unsigned concurrency;
+    std::string testName;
+
+    using Query = std::string;
+    using Queries = std::vector<Query>;
+    using QueriesWithIndexes = std::vector<std::pair<Query, size_t>>;
+    Queries queries;
+
+    using Queue = ConcurrentBoundedQueue<std::pair<Query, size_t>>;
+    Queue queue;
+
+    using Keys = std::vector<std::string>;
+
+    ConnectionPool connections;
+    ThreadPool pool;
+    Settings settings;
+
+    InterruptListener interrupt_listener;
+    std::vector<std::shared_ptr<RemoteBlockInputStream>> streams;
+
+    double average_speed_precision = 0.001;
+
+    using XMLConfiguration = Poco::Util::XMLConfiguration;
+    using AbstractConfig = Poco::AutoPtr<Poco::Util::AbstractConfiguration>;
+    using Config = Poco::AutoPtr<XMLConfiguration>;
+    using Paths = std::vector<std::string>;
+    using StringToVector = std::map<std::string, std::vector<std::string>>;
+    StringToVector substitutions;
+    std::vector<Config> testsConfigurations;
+
+    using StringKeyValue = std::map<std::string, std::string>;
+    std::vector<StringKeyValue> substitutionsMaps;
+
+    std::atomic<bool> gotSIGINT;
+    std::vector<StopCriterions> stopCriterions;
+
+// TODO: create enum class instead of string
+#define incFulfilledCriterions(index, CRITERION)                                                            \
+    if (!stopCriterions[index].CRITERION.fulfilled)                                                         \
+    {                                                                                                       \
+        stopCriterions[index].CRITERION.priority == min ? ++stopCriterions[index].fulfilled_criterions_min  \
+                                                        : ++stopCriterions[index].fulfilled_criterions_max; \
+        stopCriterions[index].CRITERION.fulfilled = true;                                                   \
+    }
+
+    enum ExecutionType
+    {
+        loop,
+        once
+    };
+    ExecutionType execType;
+
+    size_t timesToRun = 1;
+    std::vector<Stats> statistics;
+    std::mutex mutex;
+
+    void readTestsConfiguration(const Paths & input_files)
+    {
+        testsConfigurations.resize(input_files.size());
+
+        for (size_t i = 0; i != input_files.size(); ++i)
+        {
+            const std::string path = input_files[i];
+            testsConfigurations[i] = Config(new XMLConfiguration(path));
+        }
+
+        // TODO: here will be tests filter on tags, names, regexp matching, etc.
+        // { ... }
+
+        // for now let's launch one test only
+        if (testsConfigurations.size())
+        {
+            for (auto & testConfig : testsConfigurations)
+            {
+                runTest(testConfig);
+            }
+        }
+    }
+
+    void runTest(Config & testConfig)
+    {
+        testName = testConfig->getString("name");
+        std::cout << "Running: " << testName << "\n";
+
+        /// Preprocess configuration file
+        if (testConfig->has("settings"))
+        {
+            Keys configSettings;
+            testConfig->keys("settings", configSettings);
+
+            /// This macro goes through all settings in the Settings.h
+            /// and, if found any settings in test's xml configuration
+            /// with the same name, sets its value to settings
+            std::vector<std::string>::iterator it;
+#define EXTRACT_SETTING(TYPE, NAME, DEFAULT)                             \
+    it = std::find(configSettings.begin(), configSettings.end(), #NAME); \
+    if (it != configSettings.end())                                      \
+        settings.set(#NAME, testConfig->getString("settings." #NAME));
+            APPLY_FOR_SETTINGS(EXTRACT_SETTING)
+            APPLY_FOR_LIMITS(EXTRACT_SETTING)
+#undef EXTRACT_SETTING
+
+            if (std::find(configSettings.begin(), configSettings.end(), "profile") != configSettings.end())
+            {
+                // TODO: proceed profile settings in a proper way
+            }
+
+            if (std::find(configSettings.begin(), configSettings.end(), "average_rows_speed_precision") != configSettings.end())
+            {
+                Stats::avg_rows_speed_precision = testConfig->getDouble("settings.average_rows_speed_precision");
+            }
+
+            if (std::find(configSettings.begin(), configSettings.end(), "average_bytes_speed_precision") != configSettings.end())
+            {
+                Stats::avg_bytes_speed_precision = testConfig->getDouble("settings.average_bytes_speed_precision");
+            }
+        }
+
+        Query query;
+
+        if (!testConfig->has("query"))
+        {
+            throw Poco::Exception("Missing query field in test's config: " + testName, 1);
+        }
+
+        query = testConfig->getString("query");
+
+        if (query.empty())
+        {
+            throw Poco::Exception("The query is empty in test's config: " + testName, 1);
+        }
+
+        if (testConfig->has("substitutions"))
+        {
+            /// Make "subconfig" of inner xml block
+            AbstractConfig substitutionsView(testConfig->createView("substitutions"));
+            constructSubstitutions(substitutionsView, substitutions);
+
+            queries = formatQueries(query, substitutions);
+        }
+        else
+        {
+            // TODO: probably it will be a good practice to check if
+            // query string has {substitution pattern}, but no substitution field
+            // was found in xml configuration
+
+            queries.push_back(query);
+        }
+
+        if (!testConfig->has("type"))
+        {
+            throw Poco::Exception("Missing type property in config: " + testName, 1);
+        }
+
+        std::string configExecType = testConfig->getString("type");
+        if (configExecType == "loop")
+            execType = loop;
+        else if (configExecType == "once")
+            execType = once;
+        else
+            throw Poco::Exception("Unknown type " + configExecType + " in :" + testName, 1);
+
+        if (testConfig->has("timesToRun"))
+        {
+            timesToRun = testConfig->getUInt("timesToRun");
+        }
+
+        stopCriterions.resize(timesToRun * queries.size());
+
+        if (testConfig->has("stop"))
+        {
+            AbstractConfig stopCriterionsView(testConfig->createView("stop"));
+            for (StopCriterions & stopCriterion : stopCriterions)
+            {
+                stopCriterion.loadFromConfig(stopCriterionsView);
+            }
+        }
+        else
+        {
+            throw Poco::Exception("No termination conditions were found in config", 1);
+        }
+
+        AbstractConfig metricsView(testConfig->createView("metric"));
+        Keys metrics;
+        metricsView->keys(metrics);
+        if (metrics.size() > 1)
+        {
+            throw Poco::Exception("More than 1 main metric is not allowed", 1);
+        }
+
+        if (metrics.size() == 1)
+        {
+            checkMetricInput(metrics[0]);
+        }
+
+        statistics.resize(timesToRun * queries.size());
+        for (size_t numberOfLaunch = 0; numberOfLaunch < timesToRun; ++numberOfLaunch)
+        {
+            QueriesWithIndexes queriesWithIndexes;
+
+            for (size_t queryIndex = 0; queryIndex < queries.size(); ++queryIndex)
+            {
+                size_t statisticIndex = numberOfLaunch * queries.size() + queryIndex;
+                stopCriterions[statisticIndex].reset();
+
+                queriesWithIndexes.push_back({queries[queryIndex], statisticIndex});
+            }
+
+            if (interrupt_listener.check())
+                gotSIGINT = true;
+
+            if (gotSIGINT)
+                break;
+
+            runQueries(queriesWithIndexes);
+        }
+
+        if (metrics.size() == 1)
+            minOutput(metrics[0]);
+        else
+            constructTotalInfo();
+    }
+
+    void checkMetricInput(const std::string & main_metric) const
+    {
+        std::vector<std::string> loopMetrics
+            = {"min_time", "quantiles", "total_time", "queries_per_second", "rows_per_second", "bytes_per_second"};
+
+        std::vector<std::string> infiniteMetrics
+            = {"max_rows_per_second", "max_bytes_per_second", "avg_rows_per_second", "avg_bytes_per_second"};
+
+        if (execType == loop)
+        {
+            if (std::find(infiniteMetrics.begin(), infiniteMetrics.end(), main_metric) != infiniteMetrics.end())
+            {
+                throw Poco::Exception("Wrong type of main metric for loop "
+                                      "execution type",
+                    1);
+            }
+        }
+        else
+        {
+            if (std::find(loopMetrics.begin(), loopMetrics.end(), main_metric) != loopMetrics.end())
+            {
+                throw Poco::Exception("Wrong type of main metric for "
+                                      "inifinite execution type",
+                    1);
+            }
+        }
+    }
+
+    void runQueries(const QueriesWithIndexes & queriesWithIndexes)
+    {
+        for (size_t i = 0; i < concurrency; ++i)
+        {
+            pool.schedule(std::bind(&PerformanceTest::thread, this, connections.IConnectionPool::get()));
+        }
+
+        for (const std::pair<Query, const size_t> & queryAndIndex : queriesWithIndexes)
+        {
+            Query query = queryAndIndex.first;
+            const size_t statisticIndex = queryAndIndex.second;
+
+            queue.push({query, statisticIndex});
+        }
+
+        for (size_t i = 0; i < concurrency; ++i)
+        {
+            /// Genlty asking threads to stop
+            queue.push({"", std::numeric_limits<size_t>::max()});
+        }
+
+        pool.wait();
+    }
+
+    void thread(ConnectionPool::Entry & connection)
+    {
+        InterruptListener thread_interrupt_listener;
+
+        Query query;
+        size_t statisticIndex;
+
+        std::pair<Query, size_t> queryAndIndex;
+
+        while (true)
+        {
+            queue.pop(queryAndIndex);
+            query = queryAndIndex.first;
+            statisticIndex = queryAndIndex.second;
+
+            /// Empty query means end of execution
+            if (query.empty())
+                break;
+
+            size_t max_iterations = stopCriterions[statisticIndex].iterations.value;
+            size_t iteration = 0;
+
+            statistics[statisticIndex].clear();
+            execute(connection, thread_interrupt_listener, query, statisticIndex);
+
+            if (execType == loop)
+            {
+                while (!gotSIGINT)
+                {
+                    ++iteration;
+
+                    /// check stop criterions
+                    if (max_iterations && iteration >= max_iterations)
+                    {
+                        incFulfilledCriterions(statisticIndex, iterations);
+                    }
+
+                    if (stopCriterions[statisticIndex].number_of_initialized_min
+                        && (stopCriterions[statisticIndex].fulfilled_criterions_min
+                               >= stopCriterions[statisticIndex].number_of_initialized_min))
+                    {
+                        /// All 'min' criterions are fulfilled
+                        break;
+                    }
+
+                    if (stopCriterions[statisticIndex].number_of_initialized_max && stopCriterions[statisticIndex].fulfilled_criterions_max)
+                    {
+                        /// Some 'max' criterions are fulfilled
+                        break;
+                    }
+
+                    execute(connection, thread_interrupt_listener, query, statisticIndex);
+                }
+            }
+
+            if (!gotSIGINT)
+            {
+                statistics[statisticIndex].ready = true;
+            }
+        }
+    }
+
+    void execute(
+        ConnectionPool::Entry & connection, InterruptListener & thread_interrupt_listener, const Query & query, const size_t statisticIndex)
+    {
+        statistics[statisticIndex].watch_per_query.restart();
+
+        std::shared_ptr<RemoteBlockInputStream> stream
+            = std::make_shared<RemoteBlockInputStream>(connection, query, &settings, nullptr, Tables() /*, query_processing_stage*/
+                );
+
+        size_t stream_index;
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            streams.push_back(stream);
+            stream_index = streams.size() - 1;
+        }
+
+        Progress progress;
+        stream->setProgressCallback([&progress, &stream, &thread_interrupt_listener, statisticIndex, this](const Progress & value) {
+            progress.incrementPiecewiseAtomically(value);
+
+            this->checkFulfilledCriterionsAndUpdate(progress, stream, thread_interrupt_listener, statisticIndex);
+        });
+
+        stream->readPrefix();
+        while (Block block = stream->read())
+            ;
+        stream->readSuffix();
+
+        std::lock_guard<std::mutex> lock(mutex);
+        streams[stream_index].reset();
+
+        statistics[statisticIndex].updateQueryInfo();
+        statistics[statisticIndex].setTotalTime();
+    }
+
+    void checkFulfilledCriterionsAndUpdate(const Progress & progress,
+        const std::shared_ptr<RemoteBlockInputStream> & stream,
+        InterruptListener & thread_interrupt_listener,
+        const size_t statisticIndex)
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+
+        statistics[statisticIndex].add(progress.rows, progress.bytes);
+
+        size_t max_rows_to_read = stopCriterions[statisticIndex].rows_read.value;
+        if (max_rows_to_read && statistics[statisticIndex].rows_read >= max_rows_to_read)
+        {
+            incFulfilledCriterions(statisticIndex, rows_read);
+        }
+
+        size_t max_bytes_to_read = stopCriterions[statisticIndex].bytes_read_uncompressed.value;
+        if (max_bytes_to_read && statistics[statisticIndex].bytes_read >= max_bytes_to_read)
+        {
+            incFulfilledCriterions(statisticIndex, bytes_read_uncompressed);
+        }
+
+        if (UInt64 max_timeout_ms = stopCriterions[statisticIndex].timeout_ms.value)
+        {
+            /// cast nanoseconds to ms
+            if ((statistics[statisticIndex].watch.elapsed() / (1000 * 1000)) > max_timeout_ms)
+            {
+                incFulfilledCriterions(statisticIndex, timeout_ms);
+            }
+        }
+
+        size_t min_time_not_changing_for_ms = stopCriterions[statisticIndex].min_time_not_changing_for_ms.value;
+        if (min_time_not_changing_for_ms)
+        {
+            size_t min_time_did_not_change_for = statistics[statisticIndex].min_time_watch.elapsed() / (1000 * 1000);
+
+            if (min_time_did_not_change_for >= min_time_not_changing_for_ms)
+            {
+                incFulfilledCriterions(statisticIndex, min_time_not_changing_for_ms);
+            }
+        }
+
+        size_t max_speed_not_changing_for_ms = stopCriterions[statisticIndex].max_speed_not_changing_for_ms.value;
+        if (max_speed_not_changing_for_ms)
+        {
+            UInt64 speed_not_changing_time = statistics[statisticIndex].max_rows_speed_watch.elapsed() / (1000 * 1000);
+            if (speed_not_changing_time >= max_speed_not_changing_for_ms)
+            {
+                incFulfilledCriterions(statisticIndex, max_speed_not_changing_for_ms);
+            }
+        }
+
+        size_t average_speed_not_changing_for_ms = stopCriterions[statisticIndex].average_speed_not_changing_for_ms.value;
+        if (average_speed_not_changing_for_ms)
+        {
+            UInt64 speed_not_changing_time = statistics[statisticIndex].avg_rows_speed_watch.elapsed() / (1000 * 1000);
+            if (speed_not_changing_time >= average_speed_not_changing_for_ms)
+            {
+                incFulfilledCriterions(statisticIndex, average_speed_not_changing_for_ms);
+            }
+        }
+
+        if (stopCriterions[statisticIndex].number_of_initialized_min
+            && (stopCriterions[statisticIndex].fulfilled_criterions_min >= stopCriterions[statisticIndex].number_of_initialized_min))
+        {
+            /// All 'min' criterions are fulfilled
+            stream->cancel();
+        }
+
+        if (stopCriterions[statisticIndex].number_of_initialized_max && stopCriterions[statisticIndex].fulfilled_criterions_max)
+        {
+            /// Some 'max' criterions are fulfilled
+            stream->cancel();
+        }
+
+        if (thread_interrupt_listener.check())
+        { /// SIGINT
+            gotSIGINT = true;
+
+            for (const std::shared_ptr<RemoteBlockInputStream> & stream : streams)
+            {
+                if (stream)
+                {
+                    stream->cancel();
+                }
+            }
+        }
+    }
+
+    void constructSubstitutions(AbstractConfig & substitutionsView, StringToVector & substitutions)
+    {
+        Keys xml_substitutions;
+        substitutionsView->keys(xml_substitutions);
+
+        for (size_t i = 0; i != xml_substitutions.size(); ++i)
+        {
+            const AbstractConfig xml_substitution(substitutionsView->createView("substitution[" + std::to_string(i) + "]"));
+
+            /// Property values for substitution will be stored in a vector
+            /// accessible by property name
+            std::vector<std::string> xml_values;
+            xml_substitution->keys("values", xml_values);
+
+            std::string name = xml_substitution->getString("name");
+
+            for (size_t j = 0; j != xml_values.size(); ++j)
+            {
+                substitutions[name].push_back(xml_substitution->getString("values.value[" + std::to_string(j) + "]"));
+            }
+        }
+    }
+
+    std::vector<std::string> formatQueries(const std::string & query, StringToVector substitutions)
+    {
+        std::vector<std::string> queries;
+
+        StringToVector::iterator substitutions_first = substitutions.begin();
+        StringToVector::iterator substitutions_last = substitutions.end();
+        --substitutions_last;
+
+        std::map<std::string, std::string> substitutionsMap;
+
+        runThroughAllOptionsAndPush(substitutions_first, substitutions_last, query, queries, substitutionsMap);
+
+        return queries;
+    }
+
+    /// Recursive method which goes through all substitution blocks in xml
+    /// and replaces property {names} by their values
+    void runThroughAllOptionsAndPush(StringToVector::iterator substitutions_left,
+        StringToVector::iterator substitutions_right,
+        const std::string & template_query,
+        std::vector<std::string> & queries,
+        const StringKeyValue & templateSubstitutionsMap = StringKeyValue())
+    {
+        std::string name = substitutions_left->first;
+        std::vector<std::string> values = substitutions_left->second;
+
+        for (const std::string & value : values)
+        {
+            /// Copy query string for each unique permutation
+            Query query = template_query;
+            StringKeyValue substitutionsMap = templateSubstitutionsMap;
+            size_t substrPos = 0;
+
+            while (substrPos != std::string::npos)
+            {
+                substrPos = query.find("{" + name + "}");
+
+                if (substrPos != std::string::npos)
+                {
+                    query.replace(substrPos, 1 + name.length() + 1, value);
+                }
+            }
+
+            substitutionsMap[name] = value;
+
+            /// If we've reached the end of substitution chain
+            if (substitutions_left == substitutions_right)
+            {
+                queries.push_back(query);
+                substitutionsMaps.push_back(substitutionsMap);
+            }
+            else
+            {
+                StringToVector::iterator next_it = substitutions_left;
+                ++next_it;
+
+                runThroughAllOptionsAndPush(next_it, substitutions_right, query, queries, substitutionsMap);
+            }
+        }
+    }
 
 public:
-	void constructTotalInfo()
-	{
-		JSONString jsonOutput;
-		std::string hostname;
+    void constructTotalInfo()
+    {
+        JSONString jsonOutput;
+        std::string hostname;
 
-		char hostname_buffer[256];
-		if (gethostname(hostname_buffer, 256) == 0) {
-			hostname = std::string(hostname_buffer);
-		}
+        char hostname_buffer[256];
+        if (gethostname(hostname_buffer, 256) == 0)
+        {
+            hostname = std::string(hostname_buffer);
+        }
 
-		jsonOutput["hostname"].set(hostname);
-		jsonOutput["Number of CPUs"].set(sysconf(_SC_NPROCESSORS_ONLN));
-		jsonOutput["test_name"].set(testName);
+        jsonOutput["hostname"].set(hostname);
+        jsonOutput["Number of CPUs"].set(sysconf(_SC_NPROCESSORS_ONLN));
+        jsonOutput["test_name"].set(testName);
 
-		if (substitutions.size()) {
-			JSONString jsonParameters(2); /// here, 2 is the size of \t padding
+        if (substitutions.size())
+        {
+            JSONString jsonParameters(2); /// here, 2 is the size of \t padding
 
-			for (auto it = substitutions.begin(); it != substitutions.end(); ++it) {
-				std::string parameter = it->first;
-				std::vector<std::string> values = it->second;
+            for (auto it = substitutions.begin(); it != substitutions.end(); ++it)
+            {
+                std::string parameter = it->first;
+                std::vector<std::string> values = it->second;
 
-				std::string arrayString = "[";
-				for (size_t i = 0; i != values.size(); ++i) {
-					arrayString += '\"' + values[i] + '\"';
-					if (i != values.size() - 1) {
-						arrayString += ", ";
-					}
-				}
-				arrayString += ']';
+                std::string arrayString = "[";
+                for (size_t i = 0; i != values.size(); ++i)
+                {
+                    arrayString += '\"' + values[i] + '\"';
+                    if (i != values.size() - 1)
+                    {
+                        arrayString += ", ";
+                    }
+                }
+                arrayString += ']';
 
-				jsonParameters[parameter].set(arrayString);
-			}
+                jsonParameters[parameter].set(arrayString);
+            }
 
-			jsonOutput["parameters"].set(jsonParameters);
-		}
+            jsonOutput["parameters"].set(jsonParameters);
+        }
 
-		std::vector<JSONString> runInfos;
-		for (size_t numberOfLaunch = 0; numberOfLaunch < statistics.size(); ++numberOfLaunch) {
-			if (!statistics[numberOfLaunch].ready)
-				continue;
+        std::vector<JSONString> runInfos;
+        for (size_t numberOfLaunch = 0; numberOfLaunch < statistics.size(); ++numberOfLaunch)
+        {
+            if (!statistics[numberOfLaunch].ready)
+                continue;
 
-			JSONString runJSON;
+            JSONString runJSON;
 
-			size_t queryIndex = numberOfLaunch % queries.size();
-			if (substitutionsMaps.size()) {
-				JSONString parameters(4);
+            size_t queryIndex = numberOfLaunch % queries.size();
+            if (substitutionsMaps.size())
+            {
+                JSONString parameters(4);
 
-				for (auto it = substitutionsMaps[queryIndex].begin();
-						  it != substitutionsMaps[queryIndex].end(); ++it) {
-					parameters[it->first].set(it->second);
-				}
+                for (auto it = substitutionsMaps[queryIndex].begin(); it != substitutionsMaps[queryIndex].end(); ++it)
+                {
+                    parameters[it->first].set(it->second);
+                }
 
-				runJSON["parameters"].set(parameters);
-			}
+                runJSON["parameters"].set(parameters);
+            }
 
-	        if (execType == loop) {
-	        	/// in seconds
-		    	runJSON["min_time"].set(statistics[numberOfLaunch].min_time / double(1000));
+            if (execType == loop)
+            {
+                /// in seconds
+                runJSON["min_time"].set(statistics[numberOfLaunch].min_time / double(1000));
 
-	    		JSONString quantiles(4); /// here, 4 is the size of \t padding
-		    	for (double percent = 10; percent <= 90; percent += 10) {
-		    		quantiles[percent / 100].set(statistics[numberOfLaunch].sampler.quantileInterpolated(percent / 100.0));
-		    	}
-				quantiles[ 0.95 ].set(statistics[numberOfLaunch].sampler.quantileInterpolated(95    / 100.0));
-				quantiles[ 0.99 ].set(statistics[numberOfLaunch].sampler.quantileInterpolated(99    / 100.0));
-				quantiles[ 0.999].set(statistics[numberOfLaunch].sampler.quantileInterpolated(99.9  / 100.0));
-				quantiles[0.9999].set(statistics[numberOfLaunch].sampler.quantileInterpolated(99.99 / 100.0));
+                JSONString quantiles(4); /// here, 4 is the size of \t padding
+                for (double percent = 10; percent <= 90; percent += 10)
+                {
+                    quantiles[percent / 100].set(statistics[numberOfLaunch].sampler.quantileInterpolated(percent / 100.0));
+                }
+                quantiles[0.95].set(statistics[numberOfLaunch].sampler.quantileInterpolated(95 / 100.0));
+                quantiles[0.99].set(statistics[numberOfLaunch].sampler.quantileInterpolated(99 / 100.0));
+                quantiles[0.999].set(statistics[numberOfLaunch].sampler.quantileInterpolated(99.9 / 100.0));
+                quantiles[0.9999].set(statistics[numberOfLaunch].sampler.quantileInterpolated(99.99 / 100.0));
 
-				runJSON["quantiles"].set(quantiles);
+                runJSON["quantiles"].set(quantiles);
 
-			    runJSON["total_time"].set(statistics[numberOfLaunch].total_time);
-			    runJSON["queries_per_second"].set(double(statistics[numberOfLaunch].queries)  / statistics[numberOfLaunch].total_time);
-			    runJSON["rows_per_second"].set(double(statistics[numberOfLaunch].rows_read)   / statistics[numberOfLaunch].total_time);
-			    runJSON["bytes_per_second"].set(double(statistics[numberOfLaunch].bytes_read) / statistics[numberOfLaunch].total_time);
-	        } else {
-			    runJSON["max_rows_per_second"].set(statistics[numberOfLaunch].max_rows_speed);
-			    runJSON["max_bytes_per_second"].set(statistics[numberOfLaunch].max_bytes_speed);
-			    runJSON["avg_rows_per_second"].set(statistics[numberOfLaunch].avg_rows_speed_value);
-			    runJSON["avg_bytes_per_second"].set(statistics[numberOfLaunch].avg_bytes_speed_value);
-	        }
+                runJSON["total_time"].set(statistics[numberOfLaunch].total_time);
+                runJSON["queries_per_second"].set(double(statistics[numberOfLaunch].queries) / statistics[numberOfLaunch].total_time);
+                runJSON["rows_per_second"].set(double(statistics[numberOfLaunch].rows_read) / statistics[numberOfLaunch].total_time);
+                runJSON["bytes_per_second"].set(double(statistics[numberOfLaunch].bytes_read) / statistics[numberOfLaunch].total_time);
+            }
+            else
+            {
+                runJSON["max_rows_per_second"].set(statistics[numberOfLaunch].max_rows_speed);
+                runJSON["max_bytes_per_second"].set(statistics[numberOfLaunch].max_bytes_speed);
+                runJSON["avg_rows_per_second"].set(statistics[numberOfLaunch].avg_rows_speed_value);
+                runJSON["avg_bytes_per_second"].set(statistics[numberOfLaunch].avg_bytes_speed_value);
+            }
 
-	        runInfos.push_back(runJSON);
-		}
+            runInfos.push_back(runJSON);
+        }
 
-		jsonOutput["runs"].set(runInfos);
+        jsonOutput["runs"].set(runInfos);
 
-		std::cout << jsonOutput << std::endl;
-	}
+        std::cout << jsonOutput << std::endl;
+    }
 
-	void minOutput(const std::string & main_metric)
-	{
-		for (size_t numberOfLaunch = 0; numberOfLaunch < timesToRun; ++numberOfLaunch) {
-			for (size_t queryIndex = 0; queryIndex < queries.size(); ++queryIndex) {
-				std::cout << testName << ", ";
+    void minOutput(const std::string & main_metric)
+    {
+        for (size_t numberOfLaunch = 0; numberOfLaunch < timesToRun; ++numberOfLaunch)
+        {
+            for (size_t queryIndex = 0; queryIndex < queries.size(); ++queryIndex)
+            {
+                std::cout << testName << ", ";
 
-				if (substitutionsMaps.size()) {
-					for (auto it = substitutionsMaps[queryIndex].begin();
-							  it != substitutionsMaps[queryIndex].end(); ++it) {
-						std::cout << it->first << " = " << it->second << ", ";
-					}
-				}
+                if (substitutionsMaps.size())
+                {
+                    for (auto it = substitutionsMaps[queryIndex].begin(); it != substitutionsMaps[queryIndex].end(); ++it)
+                    {
+                        std::cout << it->first << " = " << it->second << ", ";
+                    }
+                }
 
-				std::cout << "run " << numberOfLaunch + 1 << ": ";
-				std::cout << main_metric << " = ";
-				std::cout << statistics[numberOfLaunch * queries.size() + queryIndex]
-							     .getStatisticByName(main_metric);
-				std::cout << std::endl;
-			}
-		}
-	}
+                std::cout << "run " << numberOfLaunch + 1 << ": ";
+                std::cout << main_metric << " = ";
+                std::cout << statistics[numberOfLaunch * queries.size() + queryIndex].getStatisticByName(main_metric);
+                std::cout << std::endl;
+            }
+        }
+    }
 };
-
 }
 
 
-int mainEntryClickhousePerformanceTest(int argc, char ** argv) {
-	using namespace DB;
+int mainEntryClickhousePerformanceTest(int argc, char ** argv)
+{
+    using namespace DB;
 
-	try
-	{
-		using boost::program_options::value;
-		using Strings = std::vector<std::string>;
+    try
+    {
+        using boost::program_options::value;
+        using Strings = std::vector<std::string>;
 
-		boost::program_options::options_description desc("Allowed options");
-		desc.add_options()
-			("help", 																	"produce help message")
-			("concurrency,c",		value<unsigned>()->default_value(1),				"number of parallel queries")
-			("host,h",				value<std::string>()->default_value("localhost"),	"")
-			("port", 				value<UInt16>()->default_value(9000),				"")
-			("user", 				value<std::string>()->default_value("default"),		"")
-			("password",			value<std::string>()->default_value(""),			"")
-			("database",			value<std::string>()->default_value("default"),		"")
-			("tag",					value<Strings>(),									"Run only tests with tag")
-			("without-tag",			value<Strings>(),									"Do not run tests with tag")
-			("name",				value<Strings>(),									"Run tests with specific name")
-			("without-name",		value<Strings>(),									"Do not run tests with name")
-			("name-regexp",			value<Strings>(),									"Run tests with names matching regexp")
-			("without-name-regexp",	value<Strings>(),									"Do not run tests with names matching regexp")
-			;
+        boost::program_options::options_description desc("Allowed options");
+        desc.add_options()("help", "produce help message")("concurrency,c",
+            value<unsigned>()->default_value(1),
+            "number of parallel queries")("host,h", value<std::string>()->default_value("localhost"), "")(
+            "port", value<UInt16>()->default_value(9000), "")("user", value<std::string>()->default_value("default"), "")(
+            "password", value<std::string>()->default_value(""), "")("database", value<std::string>()->default_value("default"), "")(
+            "tag", value<Strings>(), "Run only tests with tag")("without-tag", value<Strings>(), "Do not run tests with tag")(
+            "name", value<Strings>(), "Run tests with specific name")("without-name", value<Strings>(), "Do not run tests with name")(
+            "name-regexp", value<Strings>(), "Run tests with names matching regexp")(
+            "without-name-regexp", value<Strings>(), "Do not run tests with names matching regexp");
 
-		/// These options will not be displayed in --help
-		boost::program_options::options_description hidden("Hidden options");
-		hidden.add_options()
-			("input-files", value< std::vector<std::string> >(), "")
-			;
+        /// These options will not be displayed in --help
+        boost::program_options::options_description hidden("Hidden options");
+        hidden.add_options()("input-files", value<std::vector<std::string>>(), "");
 
-		/// But they will be legit, though. And they must be given without name
-		boost::program_options::positional_options_description positional;
-		positional.add("input-files", -1);
+        /// But they will be legit, though. And they must be given without name
+        boost::program_options::positional_options_description positional;
+        positional.add("input-files", -1);
 
-		boost::program_options::options_description cmdline_options;
-		cmdline_options.add(desc).add(hidden);
+        boost::program_options::options_description cmdline_options;
+        cmdline_options.add(desc).add(hidden);
 
-		boost::program_options::variables_map options;
-		boost::program_options::store(
-			boost::program_options::command_line_parser(argc, argv)
-									.options(cmdline_options)
-									.positional(positional)
-									.run(),
-			options
-		);
-		boost::program_options::notify(options);
+        boost::program_options::variables_map options;
+        boost::program_options::store(
+            boost::program_options::command_line_parser(argc, argv).options(cmdline_options).positional(positional).run(), options);
+        boost::program_options::notify(options);
 
-		if (options.count("help"))
-		{
-			std::cout << "Usage: " << argv[0] << " [options] [test_file ...] [tests_folder]\n";
-			std::cout << desc << "\n";
-			return 1;
-		}
+        if (options.count("help"))
+        {
+            std::cout << "Usage: " << argv[0] << " [options] [test_file ...] [tests_folder]\n";
+            std::cout << desc << "\n";
+            return 1;
+        }
 
-		if (! options.count("input-files")) {
-			std::cerr << "No tests files were specified. See --help" << "\n";
-			return 1;
-		}
+        if (!options.count("input-files"))
+        {
+            std::cerr << "No tests files were specified. See --help"
+                      << "\n";
+            return 1;
+        }
 
-		Strings tests_tags;
-		Strings skip_tags;
-		Strings tests_names;
-		Strings skip_names;
-		Strings name_regexp;
-		Strings skip_matching_regexp;
+        Strings tests_tags;
+        Strings skip_tags;
+        Strings tests_names;
+        Strings skip_names;
+        Strings name_regexp;
+        Strings skip_matching_regexp;
 
-		if (options.count("tag")) {
-			tests_tags = options["tag"].as<Strings>();
-		}
+        if (options.count("tag"))
+        {
+            tests_tags = options["tag"].as<Strings>();
+        }
 
-		if (options.count("without-tag")) {
-			skip_tags = options["without-tag"].as<Strings>();
-		}
+        if (options.count("without-tag"))
+        {
+            skip_tags = options["without-tag"].as<Strings>();
+        }
 
-		if (options.count("name")) {
-			tests_names = options["name"].as<Strings>();
-		}
+        if (options.count("name"))
+        {
+            tests_names = options["name"].as<Strings>();
+        }
 
-		if (options.count("without-name")) {
-			skip_names = options["without-name"].as<Strings>();
-		}
+        if (options.count("without-name"))
+        {
+            skip_names = options["without-name"].as<Strings>();
+        }
 
-		if (options.count("name-regexp")) {
-			name_regexp = options["name-regexp"].as<Strings>();
-		}
+        if (options.count("name-regexp"))
+        {
+            name_regexp = options["name-regexp"].as<Strings>();
+        }
 
-		if (options.count("without-name-regexp")) {
-			skip_matching_regexp = options["without-name-regexp"].as<Strings>();
-		}
+        if (options.count("without-name-regexp"))
+        {
+            skip_matching_regexp = options["without-name-regexp"].as<Strings>();
+        }
 
-		PerformanceTest performanceTest(
-			options["concurrency"].as<unsigned>(),
-			options["host"       ].as<std::string>(),
-			options["port"       ].as<UInt16>(),
-			options["database"   ].as<std::string>(),
-			options["user"       ].as<std::string>(),
-			options["password"   ].as<std::string>(),
-			options["input-files"].as<Strings>(),
-			tests_tags,
-			skip_tags,
-			tests_names,
-			skip_names,
-			name_regexp,
-			skip_matching_regexp
-		);
-	}
-	catch (const Exception & e)
-	{
-		std::string text = e.displayText();
+        PerformanceTest performanceTest(options["concurrency"].as<unsigned>(),
+            options["host"].as<std::string>(),
+            options["port"].as<UInt16>(),
+            options["database"].as<std::string>(),
+            options["user"].as<std::string>(),
+            options["password"].as<std::string>(),
+            options["input-files"].as<Strings>(),
+            tests_tags,
+            skip_tags,
+            tests_names,
+            skip_names,
+            name_regexp,
+            skip_matching_regexp);
+    }
+    catch (const Exception & e)
+    {
+        std::string text = e.displayText();
 
-		std::cerr << "Code: " << e.code() << ". " << text << "\n\n";
+        std::cerr << "Code: " << e.code() << ". " << text << "\n\n";
 
-		/// Если есть стек-трейс на сервере, то не будем писать стек-трейс на клиенте.
-		if (std::string::npos == text.find("Stack trace"))
-			std::cerr << "Stack trace:\n"
-				<< e.getStackTrace().toString();
+        /// Если есть стек-трейс на сервере, то не будем писать стек-трейс на клиенте.
+        if (std::string::npos == text.find("Stack trace"))
+            std::cerr << "Stack trace:\n" << e.getStackTrace().toString();
 
-		return e.code();
-	}
-	catch (const Poco::Exception & e)
-	{
-		std::cerr << "Poco::Exception: " << e.displayText() << "\n";
-		return ErrorCodes::POCO_EXCEPTION;
-	}
-	catch (const std::exception & e)
-	{
-		std::cerr << "std::exception: " << e.what() << "\n";
-		return ErrorCodes::STD_EXCEPTION;
-	}
-	catch (...)
-	{
-		std::cerr << "Unknown exception\n";
-		return ErrorCodes::UNKNOWN_EXCEPTION;
-	}
+        return e.code();
+    }
+    catch (const Poco::Exception & e)
+    {
+        std::cerr << "Poco::Exception: " << e.displayText() << "\n";
+        return ErrorCodes::POCO_EXCEPTION;
+    }
+    catch (const std::exception & e)
+    {
+        std::cerr << "std::exception: " << e.what() << "\n";
+        return ErrorCodes::STD_EXCEPTION;
+    }
+    catch (...)
+    {
+        std::cerr << "Unknown exception\n";
+        return ErrorCodes::UNKNOWN_EXCEPTION;
+    }
 
-	return 0;
+    return 0;
 }

--- a/dbms/src/Client/PerformanceTest.cpp
+++ b/dbms/src/Client/PerformanceTest.cpp
@@ -753,17 +753,11 @@ private:
             ReadBufferFromFile query_file(filename);
             while (!query_file.eof())
             {
-                size_t bytes = 0;
-                while (query_file.position() + bytes != query_file.buffer().end()
-                       && (query_file.position()[bytes] == '\t' || query_file.position()[bytes] == '\n')) {
-                    std::cout << "shift" << std::endl;
-                    ++bytes;
-                }
-                query_file.position() += bytes;
+                tsv ? readEscapedString(query, query_file, true)
+                    : readString(query, query_file, true);
 
-                tsv ? readEscapedString(query, query_file)
-                    : readString(query, query_file);
-                queries.push_back(query);
+                if (!query.empty())
+                    queries.push_back(query);
             }
         }
 

--- a/dbms/src/Client/PerformanceTest.cpp
+++ b/dbms/src/Client/PerformanceTest.cpp
@@ -38,7 +38,7 @@ namespace ErrorCodes
     extern const int UNKNOWN_EXCEPTION;
 }
 
-const std::string four_spaces = "    ";
+const std::string FOUR_SPACES = "    ";
 
 bool isNumber(const std::string & str)
 {
@@ -47,7 +47,7 @@ bool isNumber(const std::string & str)
         return false;
     }
 
-    size_t dotsCounter = 0;
+    size_t dots_counter = 0;
 
     if (str[0] == '.' || str[str.size() - 1] == '.')
     {
@@ -58,10 +58,10 @@ bool isNumber(const std::string & str)
     {
         if (chr == '.')
         {
-            if (dotsCounter)
+            if (dots_counter)
                 return false;
             else
-                ++dotsCounter;
+                ++dots_counter;
             continue;
         }
 
@@ -121,12 +121,12 @@ public:
         current_key = "";
     }
 
-    void set(const JSONString & innerJSON)
+    void set(const JSONString & inner_json)
     {
-        set(innerJSON.constructOutput());
+        set(inner_json.constructOutput());
     }
 
-    void set(const std::vector<JSONString> & runInfos)
+    void set(const std::vector<JSONString> & run_infos)
     {
         if (current_key.empty())
         {
@@ -135,15 +135,15 @@ public:
 
         content[current_key] = "[\n";
 
-        for (size_t i = 0; i < runInfos.size(); ++i)
+        for (size_t i = 0; i < run_infos.size(); ++i)
         {
             for (size_t i = 0; i < _padding + 1; ++i)
             {
-                content[current_key] += four_spaces;
+                content[current_key] += FOUR_SPACES;
             }
-            content[current_key] += runInfos[i].constructOutput(_padding + 2);
+            content[current_key] += run_infos[i].constructOutput(_padding + 2);
 
-            if (i != runInfos.size() - 1)
+            if (i != run_infos.size() - 1)
             {
                 content[current_key] += ',';
             }
@@ -153,7 +153,7 @@ public:
 
         for (size_t i = 0; i < _padding; ++i)
         {
-            content[current_key] += four_spaces;
+            content[current_key] += FOUR_SPACES;
         }
         content[current_key] += ']';
         current_key = "";
@@ -189,7 +189,7 @@ public:
             output += "\n";
             for (size_t i = 0; i < padding; ++i)
             {
-                output += four_spaces;
+                output += FOUR_SPACES;
             }
 
             std::string key = '\"' + it->first + '\"';
@@ -201,16 +201,16 @@ public:
         output += "\n";
         for (size_t i = 0; i < padding - 1; ++i)
         {
-            output += four_spaces;
+            output += FOUR_SPACES;
         }
         output += "}";
         return output;
     }
 };
 
-std::ostream & operator<<(std::ostream & stream, const JSONString & jsonObj)
+std::ostream & operator<<(std::ostream & stream, const JSONString & json_obj)
 {
-    stream << jsonObj.constructOutput();
+    stream << json_obj.constructOutput();
 
     return stream;
 }
@@ -243,49 +243,49 @@ private:
     using AbstractConfiguration = Poco::AutoPtr<Poco::Util::AbstractConfiguration>;
     using Keys = std::vector<std::string>;
 
-    void initializeStruct(const std::string & priority, const AbstractConfiguration & stopCriterionsView)
+    void initializeStruct(const std::string & priority, const AbstractConfiguration & stop_criterions_view)
     {
         Keys keys;
-        stopCriterionsView->keys(priority, keys);
+        stop_criterions_view->keys(priority, keys);
 
-        PriorityType priorityType = (priority == "min" ? min : max);
+        PriorityType priority_type = (priority == "min" ? min : max);
 
         for (const std::string & key : keys)
         {
             if (key == "timeout_ms")
             {
-                timeout_ms.value = stopCriterionsView->getUInt64(priority + ".timeout_ms");
-                timeout_ms.priority = priorityType;
+                timeout_ms.value = stop_criterions_view->getUInt64(priority + ".timeout_ms");
+                timeout_ms.priority = priority_type;
             }
             else if (key == "rows_read")
             {
-                rows_read.value = stopCriterionsView->getUInt64(priority + ".rows_read");
-                rows_read.priority = priorityType;
+                rows_read.value = stop_criterions_view->getUInt64(priority + ".rows_read");
+                rows_read.priority = priority_type;
             }
             else if (key == "bytes_read_uncompressed")
             {
-                bytes_read_uncompressed.value = stopCriterionsView->getUInt64(priority + ".bytes_read_uncompressed");
-                bytes_read_uncompressed.priority = priorityType;
+                bytes_read_uncompressed.value = stop_criterions_view->getUInt64(priority + ".bytes_read_uncompressed");
+                bytes_read_uncompressed.priority = priority_type;
             }
             else if (key == "iterations")
             {
-                iterations.value = stopCriterionsView->getUInt64(priority + ".iterations");
-                iterations.priority = priorityType;
+                iterations.value = stop_criterions_view->getUInt64(priority + ".iterations");
+                iterations.priority = priority_type;
             }
             else if (key == "min_time_not_changing_for_ms")
             {
-                min_time_not_changing_for_ms.value = stopCriterionsView->getUInt64(priority + ".min_time_not_changing_for_ms");
-                min_time_not_changing_for_ms.priority = priorityType;
+                min_time_not_changing_for_ms.value = stop_criterions_view->getUInt64(priority + ".min_time_not_changing_for_ms");
+                min_time_not_changing_for_ms.priority = priority_type;
             }
             else if (key == "max_speed_not_changing_for_ms")
             {
-                max_speed_not_changing_for_ms.value = stopCriterionsView->getUInt64(priority + ".max_speed_not_changing_for_ms");
-                max_speed_not_changing_for_ms.priority = priorityType;
+                max_speed_not_changing_for_ms.value = stop_criterions_view->getUInt64(priority + ".max_speed_not_changing_for_ms");
+                max_speed_not_changing_for_ms.priority = priority_type;
             }
             else if (key == "average_speed_not_changing_for_ms")
             {
-                average_speed_not_changing_for_ms.value = stopCriterionsView->getUInt64(priority + ".average_speed_not_changing_for_ms");
-                average_speed_not_changing_for_ms.priority = priorityType;
+                average_speed_not_changing_for_ms.value = stop_criterions_view->getUInt64(priority + ".average_speed_not_changing_for_ms");
+                average_speed_not_changing_for_ms.priority = priority_type;
             }
             else
             {
@@ -308,32 +308,32 @@ public:
     {
     }
 
-    StopCriterions(const StopCriterions & anotherCriterions)
-        : timeout_ms(anotherCriterions.timeout_ms),
-          rows_read(anotherCriterions.rows_read),
-          bytes_read_uncompressed(anotherCriterions.bytes_read_uncompressed),
-          iterations(anotherCriterions.iterations),
-          min_time_not_changing_for_ms(anotherCriterions.min_time_not_changing_for_ms),
-          max_speed_not_changing_for_ms(anotherCriterions.max_speed_not_changing_for_ms),
-          average_speed_not_changing_for_ms(anotherCriterions.average_speed_not_changing_for_ms),
+    StopCriterions(const StopCriterions & another_criterions)
+        : timeout_ms(another_criterions.timeout_ms),
+          rows_read(another_criterions.rows_read),
+          bytes_read_uncompressed(another_criterions.bytes_read_uncompressed),
+          iterations(another_criterions.iterations),
+          min_time_not_changing_for_ms(another_criterions.min_time_not_changing_for_ms),
+          max_speed_not_changing_for_ms(another_criterions.max_speed_not_changing_for_ms),
+          average_speed_not_changing_for_ms(another_criterions.average_speed_not_changing_for_ms),
 
-          number_of_initialized_min(anotherCriterions.number_of_initialized_min),
-          number_of_initialized_max(anotherCriterions.number_of_initialized_max),
-          fulfilled_criterions_min(anotherCriterions.fulfilled_criterions_min),
-          fulfilled_criterions_max(anotherCriterions.fulfilled_criterions_max)
+          number_of_initialized_min(another_criterions.number_of_initialized_min),
+          number_of_initialized_max(another_criterions.number_of_initialized_max),
+          fulfilled_criterions_min(another_criterions.fulfilled_criterions_min),
+          fulfilled_criterions_max(another_criterions.fulfilled_criterions_max)
     {
     }
 
-    void loadFromConfig(const AbstractConfiguration & stopCriterionsView)
+    void loadFromConfig(const AbstractConfiguration & stop_criterions_view)
     {
-        if (stopCriterionsView->has("min"))
+        if (stop_criterions_view->has("min"))
         {
-            initializeStruct("min", stopCriterionsView);
+            initializeStruct("min", stop_criterions_view);
         }
 
-        if (stopCriterionsView->has("max"))
+        if (stop_criterions_view->has("max"))
         {
-            initializeStruct("max", stopCriterionsView);
+            initializeStruct("max", stop_criterions_view);
         }
     }
 
@@ -404,59 +404,59 @@ struct Stats
 
     bool ready = false; // check if a query wasn't interrupted by SIGINT
 
-    std::string getStatisticByName(const std::string & statisticName)
+    std::string getStatisticByName(const std::string & statistic_name)
     {
-        if (statisticName == "min_time")
+        if (statistic_name == "min_time")
         {
             return std::to_string(min_time) + "ms";
         }
-        if (statisticName == "quantiles")
+        if (statistic_name == "quantiles")
         {
             std::string result = "\n";
 
             for (double percent = 10; percent <= 90; percent += 10)
             {
-                result += four_spaces + std::to_string((percent / 100));
+                result += FOUR_SPACES + std::to_string((percent / 100));
                 result += ": " + std::to_string(sampler.quantileInterpolated(percent / 100.0));
                 result += "\n";
             }
-            result += four_spaces + "0.95:   " + std::to_string(sampler.quantileInterpolated(95 / 100.0)) + "\n";
-            result += four_spaces + "0.99: "   + std::to_string(sampler.quantileInterpolated(99 / 100.0)) + "\n";
-            result += four_spaces + "0.999: "  + std::to_string(sampler.quantileInterpolated(99.9 / 100.)) + "\n";
-            result += four_spaces + "0.9999: " + std::to_string(sampler.quantileInterpolated(99.99 / 100.));
+            result += FOUR_SPACES + "0.95:   " + std::to_string(sampler.quantileInterpolated(95 / 100.0)) + "\n";
+            result += FOUR_SPACES + "0.99: "   + std::to_string(sampler.quantileInterpolated(99 / 100.0)) + "\n";
+            result += FOUR_SPACES + "0.999: "  + std::to_string(sampler.quantileInterpolated(99.9 / 100.)) + "\n";
+            result += FOUR_SPACES + "0.9999: " + std::to_string(sampler.quantileInterpolated(99.99 / 100.));
 
             return result;
         }
-        if (statisticName == "total_time")
+        if (statistic_name == "total_time")
         {
             return std::to_string(total_time) + "s";
         }
-        if (statisticName == "queries_per_second")
+        if (statistic_name == "queries_per_second")
         {
             return std::to_string(queries / total_time);
         }
-        if (statisticName == "rows_per_second")
+        if (statistic_name == "rows_per_second")
         {
             return std::to_string(rows_read / total_time);
         }
-        if (statisticName == "bytes_per_second")
+        if (statistic_name == "bytes_per_second")
         {
             return std::to_string(bytes_read / total_time);
         }
 
-        if (statisticName == "max_rows_per_second")
+        if (statistic_name == "max_rows_per_second")
         {
             return std::to_string(max_rows_speed);
         }
-        if (statisticName == "max_bytes_per_second")
+        if (statistic_name == "max_bytes_per_second")
         {
             return std::to_string(max_bytes_speed);
         }
-        if (statisticName == "avg_rows_per_second")
+        if (statistic_name == "avg_rows_per_second")
         {
             return std::to_string(avg_rows_speed_value);
         }
-        if (statisticName == "avg_bytes_per_second")
+        if (statistic_name == "avg_bytes_per_second")
         {
             return std::to_string(avg_bytes_speed_value);
         }
@@ -594,7 +594,7 @@ public:
         const std::vector<std::string> & names_regexp,
         const std::vector<std::string> & without_names_regexp)
         : connection(host_, port_, default_database_, user_, password_),
-          testsConfigurations(input_files.size()),
+          tests_configurations(input_files.size()),
           gotSIGINT(false),
           lite_output(lite_output_)
     {
@@ -610,7 +610,7 @@ public:
 
 private:
     unsigned concurrency;
-    std::string testName;
+    std::string test_name;
 
     using Query = std::string;
     using Queries = std::vector<Query>;
@@ -633,23 +633,23 @@ private:
     using Paths = std::vector<std::string>;
     using StringToVector = std::map<std::string, std::vector<std::string>>;
     StringToVector substitutions;
-    std::vector<Config> testsConfigurations;
+    std::vector<Config> tests_configurations;
 
     using StringKeyValue = std::map<std::string, std::string>;
-    std::vector<StringKeyValue> substitutionsMaps;
+    std::vector<StringKeyValue> substitutions_maps;
 
     bool gotSIGINT;
-    std::vector<StopCriterions> stopCriterions;
+    std::vector<StopCriterions> stop_criterions;
     std::string main_metric;
     bool lite_output;
 
 // TODO: create enum class instead of string
 #define incFulfilledCriterions(index, CRITERION)                                                            \
-    if (!stopCriterions[index].CRITERION.fulfilled)                                                         \
+    if (!stop_criterions[index].CRITERION.fulfilled)                                                         \
     {                                                                                                       \
-        stopCriterions[index].CRITERION.priority == min ? ++stopCriterions[index].fulfilled_criterions_min  \
-                                                        : ++stopCriterions[index].fulfilled_criterions_max; \
-        stopCriterions[index].CRITERION.fulfilled = true;                                                   \
+        stop_criterions[index].CRITERION.priority == min ? ++stop_criterions[index].fulfilled_criterions_min  \
+                                                        : ++stop_criterions[index].fulfilled_criterions_max; \
+        stop_criterions[index].CRITERION.fulfilled = true;                                                   \
     }
 
     enum ExecutionType
@@ -657,92 +657,92 @@ private:
         loop,
         once
     };
-    ExecutionType execType;
+    ExecutionType exec_type;
 
     size_t times_to_run = 1;
     std::vector<Stats> statistics;
 
     void readTestsConfiguration(const Paths & input_files)
     {
-        testsConfigurations.resize(input_files.size());
+        tests_configurations.resize(input_files.size());
 
         for (size_t i = 0; i != input_files.size(); ++i)
         {
             const std::string path = input_files[i];
-            testsConfigurations[i] = Config(new XMLConfiguration(path));
+            tests_configurations[i] = Config(new XMLConfiguration(path));
         }
 
         // TODO: here will be tests filter on tags, names, regexp matching, etc.
         // { ... }
 
         // for now let's launch one test only
-        if (testsConfigurations.size())
+        if (tests_configurations.size())
         {
-            for (auto & testConfig : testsConfigurations)
+            for (auto & test_config : tests_configurations)
             {
-                runTest(testConfig);
+                runTest(test_config);
             }
         }
     }
 
-    void runTest(Config & testConfig)
+    void runTest(Config & test_config)
     {
-        testName = testConfig->getString("name");
-        std::cout << "Running: " << testName << "\n";
+        test_name = test_config->getString("name");
+        std::cout << "Running: " << test_name << "\n";
 
         /// Preprocess configuration file
-        if (testConfig->has("settings"))
+        if (test_config->has("settings"))
         {
-            Keys configSettings;
-            testConfig->keys("settings", configSettings);
+            Keys config_settings;
+            test_config->keys("settings", config_settings);
 
             /// This macro goes through all settings in the Settings.h
             /// and, if found any settings in test's xml configuration
             /// with the same name, sets its value to settings
             std::vector<std::string>::iterator it;
 #define EXTRACT_SETTING(TYPE, NAME, DEFAULT)                             \
-    it = std::find(configSettings.begin(), configSettings.end(), #NAME); \
-    if (it != configSettings.end())                                      \
-        settings.set(#NAME, testConfig->getString("settings." #NAME));
+    it = std::find(config_settings.begin(), config_settings.end(), #NAME); \
+    if (it != config_settings.end())                                      \
+        settings.set(#NAME, test_config->getString("settings." #NAME));
             APPLY_FOR_SETTINGS(EXTRACT_SETTING)
             APPLY_FOR_LIMITS(EXTRACT_SETTING)
 #undef EXTRACT_SETTING
 
-            if (std::find(configSettings.begin(), configSettings.end(), "profile") != configSettings.end())
+            if (std::find(config_settings.begin(), config_settings.end(), "profile") != config_settings.end())
             {
                 // TODO: proceed profile settings in a proper way
             }
 
-            if (std::find(configSettings.begin(), configSettings.end(), "average_rows_speed_precision") != configSettings.end())
+            if (std::find(config_settings.begin(), config_settings.end(), "average_rows_speed_precision") != config_settings.end())
             {
-                Stats::avg_rows_speed_precision = testConfig->getDouble("settings.average_rows_speed_precision");
+                Stats::avg_rows_speed_precision = test_config->getDouble("settings.average_rows_speed_precision");
             }
 
-            if (std::find(configSettings.begin(), configSettings.end(), "average_bytes_speed_precision") != configSettings.end())
+            if (std::find(config_settings.begin(), config_settings.end(), "average_bytes_speed_precision") != config_settings.end())
             {
-                Stats::avg_bytes_speed_precision = testConfig->getDouble("settings.average_bytes_speed_precision");
+                Stats::avg_bytes_speed_precision = test_config->getDouble("settings.average_bytes_speed_precision");
             }
         }
 
         Query query;
 
-        if (!testConfig->has("query"))
+        if (!test_config->has("query"))
         {
-            throw Poco::Exception("Missing query field in test's config: " + testName, 1);
+            throw Poco::Exception("Missing query field in test's config: " + test_name, 1);
         }
 
-        query = testConfig->getString("query");
+        query = test_config->getString("query");
 
         if (query.empty())
         {
-            throw Poco::Exception("The query is empty in test's config: " + testName, 1);
+            throw Poco::Exception("The query is empty in test's config: " + test_name, 1);
         }
 
-        if (testConfig->has("substitutions"))
+        if (test_config->has("substitutions"))
         {
             /// Make "subconfig" of inner xml block
-            AbstractConfig substitutionsView(testConfig->createView("substitutions"));
-            constructSubstitutions(substitutionsView, substitutions);
+            AbstractConfig substitutions_view(test_config->createView("substitutions"));
+            constructSubstitutions(substitutions_view, substitutions);
 
             queries = formatQueries(query, substitutions);
         }
@@ -755,32 +755,32 @@ private:
             queries.push_back(query);
         }
 
-        if (!testConfig->has("type"))
+        if (!test_config->has("type"))
         {
-            throw Poco::Exception("Missing type property in config: " + testName, 1);
+            throw Poco::Exception("Missing type property in config: " + test_name, 1);
         }
 
-        std::string configExecType = testConfig->getString("type");
-        if (configExecType == "loop")
-            execType = loop;
-        else if (configExecType == "once")
-            execType = once;
+        std::string config_exec_type = test_config->getString("type");
+        if (config_exec_type == "loop")
+            exec_type = loop;
+        else if (config_exec_type == "once")
+            exec_type = once;
         else
-            throw Poco::Exception("Unknown type " + configExecType + " in :" + testName, 1);
+            throw Poco::Exception("Unknown type " + config_exec_type + " in :" + test_name, 1);
 
-        if (testConfig->has("times_to_run"))
+        if (test_config->has("times_to_run"))
         {
-            times_to_run = testConfig->getUInt("times_to_run");
+            times_to_run = test_config->getUInt("times_to_run");
         }
 
-        stopCriterions.resize(times_to_run * queries.size());
+        stop_criterions.resize(times_to_run * queries.size());
 
-        if (testConfig->has("stop"))
+        if (test_config->has("stop"))
         {
-            AbstractConfig stopCriterionsView(testConfig->createView("stop"));
-            for (StopCriterions & stopCriterion : stopCriterions)
+            AbstractConfig stop_criterions_view(test_config->createView("stop"));
+            for (StopCriterions & stop_criterion : stop_criterions)
             {
-                stopCriterion.loadFromConfig(stopCriterionsView);
+                stop_criterion.loadFromConfig(stop_criterions_view);
             }
         }
         else
@@ -788,10 +788,10 @@ private:
             throw Poco::Exception("No termination conditions were found in config", 1);
         }
 
-        AbstractConfig metricsView(testConfig->createView("metrics"));
+        AbstractConfig metrics_view(test_config->createView("metrics"));
         Keys metrics;
-        metricsView->keys(metrics);
-        main_metric = testConfig->getString("main_metric", "");
+        metrics_view->keys(metrics);
+        main_metric = test_config->getString("main_metric", "");
 
         if (!main_metric.empty()) {
             if (std::find(metrics.begin(), metrics.end(), main_metric) == metrics.end())
@@ -805,16 +805,16 @@ private:
             checkMetricsInput(metrics);
 
         statistics.resize(times_to_run * queries.size());
-        for (size_t numberOfLaunch = 0; numberOfLaunch < times_to_run; ++numberOfLaunch)
+        for (size_t number_of_launch = 0; number_of_launch < times_to_run; ++number_of_launch)
         {
-            QueriesWithIndexes queriesWithIndexes;
+            QueriesWithIndexes queries_with_indexes;
 
-            for (size_t queryIndex = 0; queryIndex < queries.size(); ++queryIndex)
+            for (size_t query_index = 0; query_index < queries.size(); ++query_index)
             {
-                size_t statisticIndex = numberOfLaunch * queries.size() + queryIndex;
-                stopCriterions[statisticIndex].reset();
+                size_t statistic_index = number_of_launch * queries.size() + query_index;
+                stop_criterions[statistic_index].reset();
 
-                queriesWithIndexes.push_back({queries[queryIndex], statisticIndex});
+                queries_with_indexes.push_back({queries[query_index], statistic_index});
             }
 
             if (interrupt_listener.check())
@@ -823,7 +823,7 @@ private:
             if (gotSIGINT)
                 break;
 
-            runQueries(queriesWithIndexes);
+            runQueries(queries_with_indexes);
         }
 
         if (lite_output)
@@ -834,17 +834,17 @@ private:
 
     void checkMetricsInput(const Strings & metrics) const
     {
-        std::vector<std::string> loopMetrics
+        std::vector<std::string> loop_metrics
             = {"min_time", "quantiles", "total_time", "queries_per_second", "rows_per_second", "bytes_per_second"};
 
-        std::vector<std::string> nonLoopMetrics
+        std::vector<std::string> non_loop_metrics
             = {"max_rows_per_second", "max_bytes_per_second", "avg_rows_per_second", "avg_bytes_per_second"};
 
-        if (execType == loop)
+        if (exec_type == loop)
         {
             for (const std::string & metric : metrics)
             {
-                if (std::find(nonLoopMetrics.begin(), nonLoopMetrics.end(), metric) != nonLoopMetrics.end())
+                if (std::find(non_loop_metrics.begin(), non_loop_metrics.end(), metric) != non_loop_metrics.end())
                 {
                     throw Poco::Exception("Wrong type of metric for loop execution type (" + metric + ")", 1);
                 }
@@ -854,7 +854,7 @@ private:
         {
             for (const std::string & metric : metrics)
             {
-                if (std::find(loopMetrics.begin(), loopMetrics.end(), metric) != loopMetrics.end())
+                if (std::find(loop_metrics.begin(), loop_metrics.end(), metric) != loop_metrics.end())
                 {
                     throw Poco::Exception("Wrong type of metric for non-loop execution type (" + metric + ")", 1);
                 }
@@ -862,20 +862,20 @@ private:
         }
     }
 
-    void runQueries(const QueriesWithIndexes & queriesWithIndexes)
+    void runQueries(const QueriesWithIndexes & queries_with_indexes)
     {
-        for (const std::pair<Query, const size_t> & queryAndIndex : queriesWithIndexes)
+        for (const std::pair<Query, const size_t> & query_and_index : queries_with_indexes)
         {
-            Query query = queryAndIndex.first;
-            const size_t statisticIndex = queryAndIndex.second;
+            Query query = query_and_index.first;
+            const size_t statistic_index = query_and_index.second;
 
-            size_t max_iterations = stopCriterions[statisticIndex].iterations.value;
+            size_t max_iterations = stop_criterions[statistic_index].iterations.value;
             size_t iteration = 0;
 
-            statistics[statisticIndex].clear();
-            execute(query, statisticIndex);
+            statistics[statistic_index].clear();
+            execute(query, statistic_index);
 
-            if (execType == loop)
+            if (exec_type == loop)
             {
                 while (!gotSIGINT)
                 {
@@ -884,45 +884,45 @@ private:
                     /// check stop criterions
                     if (max_iterations && iteration >= max_iterations)
                     {
-                        incFulfilledCriterions(statisticIndex, iterations);
+                        incFulfilledCriterions(statistic_index, iterations);
                     }
 
-                    if (stopCriterions[statisticIndex].number_of_initialized_min
-                        && (stopCriterions[statisticIndex].fulfilled_criterions_min
-                               >= stopCriterions[statisticIndex].number_of_initialized_min))
+                    if (stop_criterions[statistic_index].number_of_initialized_min
+                        && (stop_criterions[statistic_index].fulfilled_criterions_min
+                               >= stop_criterions[statistic_index].number_of_initialized_min))
                     {
                         /// All 'min' criterions are fulfilled
                         break;
                     }
 
-                    if (stopCriterions[statisticIndex].number_of_initialized_max && stopCriterions[statisticIndex].fulfilled_criterions_max)
+                    if (stop_criterions[statistic_index].number_of_initialized_max && stop_criterions[statistic_index].fulfilled_criterions_max)
                     {
                         /// Some 'max' criterions are fulfilled
                         break;
                     }
 
-                    execute(query, statisticIndex);
+                    execute(query, statistic_index);
                 }
             }
 
             if (!gotSIGINT)
             {
-                statistics[statisticIndex].ready = true;
+                statistics[statistic_index].ready = true;
             }
         }
     }
 
-    void execute(const Query & query, const size_t statisticIndex)
+    void execute(const Query & query, const size_t statistic_index)
     {
-        statistics[statisticIndex].watch_per_query.restart();
+        statistics[statistic_index].watch_per_query.restart();
 
         RemoteBlockInputStream stream(connection, query, &settings, nullptr, Tables() /*, query_processing_stage*/);
 
         Progress progress;
-        stream.setProgressCallback([&progress, &stream, statisticIndex, this](const Progress & value) {
+        stream.setProgressCallback([&progress, &stream, statistic_index, this](const Progress & value) {
             progress.incrementPiecewiseAtomically(value);
 
-            this->checkFulfilledCriterionsAndUpdate(progress, stream, statisticIndex);
+            this->checkFulfilledCriterionsAndUpdate(progress, stream, statistic_index);
         });
 
         stream.readPrefix();
@@ -930,76 +930,76 @@ private:
             ;
         stream.readSuffix();
 
-        statistics[statisticIndex].updateQueryInfo();
-        statistics[statisticIndex].setTotalTime();
+        statistics[statistic_index].updateQueryInfo();
+        statistics[statistic_index].setTotalTime();
     }
 
     void checkFulfilledCriterionsAndUpdate(const Progress & progress,
         RemoteBlockInputStream & stream,
-        const size_t statisticIndex)
+        const size_t statistic_index)
     {
-        statistics[statisticIndex].add(progress.rows, progress.bytes);
+        statistics[statistic_index].add(progress.rows, progress.bytes);
 
-        size_t max_rows_to_read = stopCriterions[statisticIndex].rows_read.value;
-        if (max_rows_to_read && statistics[statisticIndex].rows_read >= max_rows_to_read)
+        size_t max_rows_to_read = stop_criterions[statistic_index].rows_read.value;
+        if (max_rows_to_read && statistics[statistic_index].rows_read >= max_rows_to_read)
         {
-            incFulfilledCriterions(statisticIndex, rows_read);
+            incFulfilledCriterions(statistic_index, rows_read);
         }
 
-        size_t max_bytes_to_read = stopCriterions[statisticIndex].bytes_read_uncompressed.value;
-        if (max_bytes_to_read && statistics[statisticIndex].bytes_read >= max_bytes_to_read)
+        size_t max_bytes_to_read = stop_criterions[statistic_index].bytes_read_uncompressed.value;
+        if (max_bytes_to_read && statistics[statistic_index].bytes_read >= max_bytes_to_read)
         {
-            incFulfilledCriterions(statisticIndex, bytes_read_uncompressed);
+            incFulfilledCriterions(statistic_index, bytes_read_uncompressed);
         }
 
-        if (UInt64 max_timeout_ms = stopCriterions[statisticIndex].timeout_ms.value)
+        if (UInt64 max_timeout_ms = stop_criterions[statistic_index].timeout_ms.value)
         {
             /// cast nanoseconds to ms
-            if ((statistics[statisticIndex].watch.elapsed() / (1000 * 1000)) > max_timeout_ms)
+            if ((statistics[statistic_index].watch.elapsed() / (1000 * 1000)) > max_timeout_ms)
             {
-                incFulfilledCriterions(statisticIndex, timeout_ms);
+                incFulfilledCriterions(statistic_index, timeout_ms);
             }
         }
 
-        size_t min_time_not_changing_for_ms = stopCriterions[statisticIndex].min_time_not_changing_for_ms.value;
+        size_t min_time_not_changing_for_ms = stop_criterions[statistic_index].min_time_not_changing_for_ms.value;
         if (min_time_not_changing_for_ms)
         {
-            size_t min_time_did_not_change_for = statistics[statisticIndex].min_time_watch.elapsed() / (1000 * 1000);
+            size_t min_time_did_not_change_for = statistics[statistic_index].min_time_watch.elapsed() / (1000 * 1000);
 
             if (min_time_did_not_change_for >= min_time_not_changing_for_ms)
             {
-                incFulfilledCriterions(statisticIndex, min_time_not_changing_for_ms);
+                incFulfilledCriterions(statistic_index, min_time_not_changing_for_ms);
             }
         }
 
-        size_t max_speed_not_changing_for_ms = stopCriterions[statisticIndex].max_speed_not_changing_for_ms.value;
+        size_t max_speed_not_changing_for_ms = stop_criterions[statistic_index].max_speed_not_changing_for_ms.value;
         if (max_speed_not_changing_for_ms)
         {
-            UInt64 speed_not_changing_time = statistics[statisticIndex].max_rows_speed_watch.elapsed() / (1000 * 1000);
+            UInt64 speed_not_changing_time = statistics[statistic_index].max_rows_speed_watch.elapsed() / (1000 * 1000);
             if (speed_not_changing_time >= max_speed_not_changing_for_ms)
             {
-                incFulfilledCriterions(statisticIndex, max_speed_not_changing_for_ms);
+                incFulfilledCriterions(statistic_index, max_speed_not_changing_for_ms);
             }
         }
 
-        size_t average_speed_not_changing_for_ms = stopCriterions[statisticIndex].average_speed_not_changing_for_ms.value;
+        size_t average_speed_not_changing_for_ms = stop_criterions[statistic_index].average_speed_not_changing_for_ms.value;
         if (average_speed_not_changing_for_ms)
         {
-            UInt64 speed_not_changing_time = statistics[statisticIndex].avg_rows_speed_watch.elapsed() / (1000 * 1000);
+            UInt64 speed_not_changing_time = statistics[statistic_index].avg_rows_speed_watch.elapsed() / (1000 * 1000);
             if (speed_not_changing_time >= average_speed_not_changing_for_ms)
             {
-                incFulfilledCriterions(statisticIndex, average_speed_not_changing_for_ms);
+                incFulfilledCriterions(statistic_index, average_speed_not_changing_for_ms);
             }
         }
 
-        if (stopCriterions[statisticIndex].number_of_initialized_min
-            && (stopCriterions[statisticIndex].fulfilled_criterions_min >= stopCriterions[statisticIndex].number_of_initialized_min))
+        if (stop_criterions[statistic_index].number_of_initialized_min
+            && (stop_criterions[statistic_index].fulfilled_criterions_min >= stop_criterions[statistic_index].number_of_initialized_min))
         {
             /// All 'min' criterions are fulfilled
             stream.cancel();
         }
 
-        if (stopCriterions[statisticIndex].number_of_initialized_max && stopCriterions[statisticIndex].fulfilled_criterions_max)
+        if (stop_criterions[statistic_index].number_of_initialized_max && stop_criterions[statistic_index].fulfilled_criterions_max)
         {
             /// Some 'max' criterions are fulfilled
             stream.cancel();
@@ -1012,14 +1012,14 @@ private:
         }
     }
 
-    void constructSubstitutions(AbstractConfig & substitutionsView, StringToVector & substitutions)
+    void constructSubstitutions(AbstractConfig & substitutions_view, StringToVector & substitutions)
     {
         Keys xml_substitutions;
-        substitutionsView->keys(xml_substitutions);
+        substitutions_view->keys(xml_substitutions);
 
         for (size_t i = 0; i != xml_substitutions.size(); ++i)
         {
-            const AbstractConfig xml_substitution(substitutionsView->createView("substitution[" + std::to_string(i) + "]"));
+            const AbstractConfig xml_substitution(substitutions_view->createView("substitution[" + std::to_string(i) + "]"));
 
             /// Property values for substitution will be stored in a vector
             /// accessible by property name
@@ -1043,9 +1043,9 @@ private:
         StringToVector::iterator substitutions_last = substitutions.end();
         --substitutions_last;
 
-        std::map<std::string, std::string> substitutionsMap;
+        std::map<std::string, std::string> substitutions_map;
 
-        runThroughAllOptionsAndPush(substitutions_first, substitutions_last, query, queries, substitutionsMap);
+        runThroughAllOptionsAndPush(substitutions_first, substitutions_last, query, queries, substitutions_map);
 
         return queries;
     }
@@ -1056,7 +1056,7 @@ private:
         StringToVector::iterator substitutions_right,
         const std::string & template_query,
         std::vector<std::string> & queries,
-        const StringKeyValue & templateSubstitutionsMap = StringKeyValue())
+        const StringKeyValue & template_substitutions_map = StringKeyValue())
     {
         std::string name = substitutions_left->first;
         std::vector<std::string> values = substitutions_left->second;
@@ -1065,33 +1065,33 @@ private:
         {
             /// Copy query string for each unique permutation
             Query query = template_query;
-            StringKeyValue substitutionsMap = templateSubstitutionsMap;
-            size_t substrPos = 0;
+            StringKeyValue substitutions_map = template_substitutions_map;
+            size_t substr_pos = 0;
 
-            while (substrPos != std::string::npos)
+            while (substr_pos != std::string::npos)
             {
-                substrPos = query.find("{" + name + "}");
+                substr_pos = query.find("{" + name + "}");
 
-                if (substrPos != std::string::npos)
+                if (substr_pos != std::string::npos)
                 {
-                    query.replace(substrPos, 1 + name.length() + 1, value);
+                    query.replace(substr_pos, 1 + name.length() + 1, value);
                 }
             }
 
-            substitutionsMap[name] = value;
+            substitutions_map[name] = value;
 
             /// If we've reached the end of substitution chain
             if (substitutions_left == substitutions_right)
             {
                 queries.push_back(query);
-                substitutionsMaps.push_back(substitutionsMap);
+                substitutions_maps.push_back(substitutions_map);
             }
             else
             {
                 StringToVector::iterator next_it = substitutions_left;
                 ++next_it;
 
-                runThroughAllOptionsAndPush(next_it, substitutions_right, query, queries, substitutionsMap);
+                runThroughAllOptionsAndPush(next_it, substitutions_right, query, queries, substitutions_map);
             }
         }
     }
@@ -1099,7 +1099,7 @@ private:
 public:
     void constructTotalInfo()
     {
-        JSONString jsonOutput;
+        JSONString json_output;
         std::string hostname;
 
         char hostname_buffer[256];
@@ -1108,52 +1108,52 @@ public:
             hostname = std::string(hostname_buffer);
         }
 
-        jsonOutput["hostname"].set(hostname);
-        jsonOutput["Number of CPUs"].set(sysconf(_SC_NPROCESSORS_ONLN));
-        jsonOutput["test_name"].set(testName);
-        jsonOutput["main_metric"].set(main_metric);
+        json_output["hostname"].set(hostname);
+        json_output["Number of CPUs"].set(sysconf(_SC_NPROCESSORS_ONLN));
+        json_output["test_name"].set(test_name);
+        json_output["main_metric"].set(main_metric);
 
         if (substitutions.size())
         {
-            JSONString jsonParameters(2); /// here, 2 is the size of \t padding
+            JSONString json_parameters(2); /// here, 2 is the size of \t padding
 
             for (auto it = substitutions.begin(); it != substitutions.end(); ++it)
             {
                 std::string parameter = it->first;
                 std::vector<std::string> values = it->second;
 
-                std::string arrayString = "[";
+                std::string array_string = "[";
                 for (size_t i = 0; i != values.size(); ++i)
                 {
-                    arrayString += '\"' + values[i] + '\"';
+                    array_string += '\"' + values[i] + '\"';
                     if (i != values.size() - 1)
                     {
-                        arrayString += ", ";
+                        array_string += ", ";
                     }
                 }
-                arrayString += ']';
+                array_string += ']';
 
-                jsonParameters[parameter].set(arrayString);
+                json_parameters[parameter].set(array_string);
             }
 
-            jsonOutput["parameters"].set(jsonParameters);
+            json_output["parameters"].set(json_parameters);
         }
 
-        std::vector<JSONString> runInfos;
-        for (size_t queryIndex = 0; queryIndex < queries.size(); ++queryIndex)
+        std::vector<JSONString> run_infos;
+        for (size_t query_index = 0; query_index < queries.size(); ++query_index)
         {
-            for (size_t numberOfLaunch = 0; numberOfLaunch < statistics.size(); ++numberOfLaunch)
+            for (size_t number_of_launch = 0; number_of_launch < statistics.size(); ++number_of_launch)
             {
-                if (!statistics[numberOfLaunch].ready)
+                if (!statistics[number_of_launch].ready)
                     continue;
 
                 JSONString runJSON;
 
-                if (substitutionsMaps.size())
+                if (substitutions_maps.size())
                 {
                     JSONString parameters(4);
 
-                    for (auto it = substitutionsMaps[queryIndex].begin(); it != substitutionsMaps[queryIndex].end(); ++it)
+                    for (auto it = substitutions_maps[query_index].begin(); it != substitutions_maps[query_index].end(); ++it)
                     {
                         parameters[it->first].set(it->second);
                     }
@@ -1161,64 +1161,64 @@ public:
                     runJSON["parameters"].set(parameters);
                 }
 
-                if (execType == loop)
+                if (exec_type == loop)
                 {
                     /// in seconds
-                    runJSON["min_time"].set(statistics[numberOfLaunch].min_time / double(1000));
+                    runJSON["min_time"].set(statistics[number_of_launch].min_time / double(1000));
 
                     JSONString quantiles(4); /// here, 4 is the size of \t padding
                     for (double percent = 10; percent <= 90; percent += 10)
                     {
-                        quantiles[percent / 100].set(statistics[numberOfLaunch].sampler.quantileInterpolated(percent / 100.0));
+                        quantiles[percent / 100].set(statistics[number_of_launch].sampler.quantileInterpolated(percent / 100.0));
                     }
-                    quantiles[0.95].set(statistics[numberOfLaunch].sampler.quantileInterpolated(95 / 100.0));
-                    quantiles[0.99].set(statistics[numberOfLaunch].sampler.quantileInterpolated(99 / 100.0));
-                    quantiles[0.999].set(statistics[numberOfLaunch].sampler.quantileInterpolated(99.9 / 100.0));
-                    quantiles[0.9999].set(statistics[numberOfLaunch].sampler.quantileInterpolated(99.99 / 100.0));
+                    quantiles[0.95].set(statistics[number_of_launch].sampler.quantileInterpolated(95 / 100.0));
+                    quantiles[0.99].set(statistics[number_of_launch].sampler.quantileInterpolated(99 / 100.0));
+                    quantiles[0.999].set(statistics[number_of_launch].sampler.quantileInterpolated(99.9 / 100.0));
+                    quantiles[0.9999].set(statistics[number_of_launch].sampler.quantileInterpolated(99.99 / 100.0));
 
                     runJSON["quantiles"].set(quantiles);
 
-                    runJSON["total_time"].set(statistics[numberOfLaunch].total_time);
-                    runJSON["queries_per_second"].set(double(statistics[numberOfLaunch].queries) / statistics[numberOfLaunch].total_time);
-                    runJSON["rows_per_second"].set(double(statistics[numberOfLaunch].rows_read) / statistics[numberOfLaunch].total_time);
-                    runJSON["bytes_per_second"].set(double(statistics[numberOfLaunch].bytes_read) / statistics[numberOfLaunch].total_time);
+                    runJSON["total_time"].set(statistics[number_of_launch].total_time);
+                    runJSON["queries_per_second"].set(double(statistics[number_of_launch].queries) / statistics[number_of_launch].total_time);
+                    runJSON["rows_per_second"].set(double(statistics[number_of_launch].rows_read) / statistics[number_of_launch].total_time);
+                    runJSON["bytes_per_second"].set(double(statistics[number_of_launch].bytes_read) / statistics[number_of_launch].total_time);
                 }
                 else
                 {
-                    runJSON["max_rows_per_second"].set(statistics[numberOfLaunch].max_rows_speed);
-                    runJSON["max_bytes_per_second"].set(statistics[numberOfLaunch].max_bytes_speed);
-                    runJSON["avg_rows_per_second"].set(statistics[numberOfLaunch].avg_rows_speed_value);
-                    runJSON["avg_bytes_per_second"].set(statistics[numberOfLaunch].avg_bytes_speed_value);
+                    runJSON["max_rows_per_second"].set(statistics[number_of_launch].max_rows_speed);
+                    runJSON["max_bytes_per_second"].set(statistics[number_of_launch].max_bytes_speed);
+                    runJSON["avg_rows_per_second"].set(statistics[number_of_launch].avg_rows_speed_value);
+                    runJSON["avg_bytes_per_second"].set(statistics[number_of_launch].avg_bytes_speed_value);
                 }
 
-                runInfos.push_back(runJSON);
+                run_infos.push_back(runJSON);
             }
         }
 
-        jsonOutput["runs"].set(runInfos);
+        json_output["runs"].set(run_infos);
 
-        std::cout << std::endl << jsonOutput << std::endl;
+        std::cout << std::endl << json_output << std::endl;
     }
 
     void minOutput(const std::string & main_metric)
     {
-        for (size_t queryIndex = 0; queryIndex < queries.size(); ++queryIndex)
+        for (size_t query_index = 0; query_index < queries.size(); ++query_index)
         {
-            for (size_t numberOfLaunch = 0; numberOfLaunch < times_to_run; ++numberOfLaunch)
+            for (size_t number_of_launch = 0; number_of_launch < times_to_run; ++number_of_launch)
             {
-                std::cout << testName << ", ";
+                std::cout << test_name << ", ";
 
-                if (substitutionsMaps.size())
+                if (substitutions_maps.size())
                 {
-                    for (auto it = substitutionsMaps[queryIndex].begin(); it != substitutionsMaps[queryIndex].end(); ++it)
+                    for (auto it = substitutions_maps[query_index].begin(); it != substitutions_maps[query_index].end(); ++it)
                     {
                         std::cout << it->first << " = " << it->second << ", ";
                     }
                 }
 
-                std::cout << "run " << numberOfLaunch + 1 << ": ";
+                std::cout << "run " << number_of_launch + 1 << ": ";
                 std::cout << main_metric << " = ";
-                std::cout << statistics[numberOfLaunch * queries.size() + queryIndex].getStatisticByName(main_metric);
+                std::cout << statistics[number_of_launch * queries.size() + query_index].getStatisticByName(main_metric);
                 std::cout << std::endl;
             }
         }

--- a/dbms/src/Client/PerformanceTest.cpp
+++ b/dbms/src/Client/PerformanceTest.cpp
@@ -64,9 +64,9 @@ private:
 			if (key == "timeout_ms") {
 				timeout_ms.value    = stopCriterionsView->getUInt64(priority + ".timeout_ms");
 				timeout_ms.priority = priority;
-			} else if (key == "read_rows") {
-				read_rows.value    = stopCriterionsView->getUInt64(priority + ".read_rows");
-				read_rows.priority = priority;
+			} else if (key == "rows_read") {
+				rows_read.value    = stopCriterionsView->getUInt64(priority + ".rows_read");
+				rows_read.priority = priority;
 			} else if (key == "bytes_read_uncompressed") {
 				bytes_read_uncompressed.value    = stopCriterionsView->getUInt64(priority + ".bytes_read_uncompressed");
 				bytes_read_uncompressed.priority = priority;
@@ -108,7 +108,7 @@ public:
 	}
 
 	struct CriterionWithPriority timeout_ms;
-	struct CriterionWithPriority read_rows;
+	struct CriterionWithPriority rows_read;
 	struct CriterionWithPriority bytes_read_uncompressed;
 	struct CriterionWithPriority iterations;
 	struct CriterionWithPriority min_time_not_changing_for_ms;
@@ -132,8 +132,8 @@ struct Stats
 	Stopwatch max_speed_watch;
 	Stopwatch average_speed_watch;
 	size_t queries;
-	size_t read_rows;
-	size_t read_bytes;
+	size_t rows_read;
+	size_t bytes_read;
 
 	using Sampler = ReservoirSampler<double>;
 	Sampler sampler {1 << 16};
@@ -179,12 +179,12 @@ struct Stats
 		}
 	}
 
-	void add(size_t read_rows_inc, size_t read_bytes_inc)
+	void add(size_t rows_read_inc, size_t bytes_read_inc)
 	{
-		read_rows  += read_rows_inc;
-		read_bytes += read_bytes_inc;
+		rows_read  += rows_read_inc;
+		bytes_read += bytes_read_inc;
 
-		double new_speed = read_rows_inc / watch_per_query.elapsedSeconds();
+		double new_speed = rows_read_inc / watch_per_query.elapsedSeconds();
 		update_max_speed(new_speed);
 		update_average_speed(new_speed);
 	}
@@ -212,8 +212,8 @@ struct Stats
 		sampler.clear();
 
 		queries    = 0;
-		read_rows  = 0;
-		read_bytes = 0;
+		rows_read  = 0;
+		bytes_read = 0;
 
 		min_time   = std::numeric_limits<UInt64>::max();
 		total_time = 0;
@@ -558,13 +558,13 @@ private:
 
 		info_total.add(progress.rows, progress.bytes);
 
-		size_t max_rows_to_read = stopCriterions.read_rows.value;
-		if (max_rows_to_read && info_total.read_rows >= max_rows_to_read) {
-			incFulfilledCriterions(read_rows);
+		size_t max_rows_to_read = stopCriterions.rows_read.value;
+		if (max_rows_to_read && info_total.rows_read >= max_rows_to_read) {
+			incFulfilledCriterions(rows_read);
 		}
 
 		size_t max_bytes_to_read = stopCriterions.bytes_read_uncompressed.value;
-		if (max_bytes_to_read && info_total.read_bytes >= max_bytes_to_read) {
+		if (max_bytes_to_read && info_total.bytes_read >= max_bytes_to_read) {
 			incFulfilledCriterions(bytes_read_uncompressed);
 		}
 
@@ -753,8 +753,8 @@ public:
 
 		    std::cout << "total_time: " << info_total.total_time << "s" << std::endl;
 		    std::cout << "queries_per_second: " << double(info_total.queries)    / info_total.total_time << std::endl;
-		    std::cout << "rows_per_second: "    << double(info_total.read_rows)  / info_total.total_time << std::endl;
-		    std::cout << "bytes_per_second: "   << double(info_total.read_bytes) / info_total.total_time << std::endl;
+		    std::cout << "rows_per_second: "    << double(info_total.rows_read)  / info_total.total_time << std::endl;
+		    std::cout << "bytes_per_second: "   << double(info_total.bytes_read) / info_total.total_time << std::endl;
         } else {
 		    std::cout << " max_rows_per_second: "  << info_total.max_speed << std::endl;
 		    // std::cout << " max_bytes_per_second: " <<  << std::endl;

--- a/dbms/src/Client/PerformanceTest.cpp
+++ b/dbms/src/Client/PerformanceTest.cpp
@@ -1,10 +1,25 @@
 #include <iostream>
 
+#include <sys/stat.h>
+#include <boost/program_options.hpp>
+
+#include <DB/Common/ThreadPool.h>
+#include <DB/Core/Types.h>
+#include <DB/Client/ConnectionPool.h>
+#include <DB/IO/ReadHelpers.h>
+#include <DB/IO/ReadBufferFromFileDescriptor.h>
+#include <DB/Interpreters/Settings.h>
+#include <Poco/AutoPtr.h>
+#include <Poco/XML/XMLStream.h>
+#include <Poco/SAX/InputSource.h>
+#include <Poco/Util/XMLConfiguration.h>
+#include <Poco/Exception.h>
+
+
 /** Tests launcher for ClickHouse.
   * The tool walks through given or default folder in order to find files with
   * tests' description and launches it.
   */
-
 namespace DB
 {
 
@@ -18,16 +33,229 @@ namespace ErrorCodes
 class PerformanceTest
 {
 public:
-	PerformanceTest()
+	PerformanceTest(
+		const unsigned   concurrency_,
+		const String   & host_,
+		const UInt16     port_,
+		const String   & default_database_,
+		const String   & user_,
+		const String   & password_,
+		const std::vector<std::string> & input_files,
+        const std::vector<std::string> & tags,
+        const std::vector<std::string> & without_tags,
+        const std::vector<std::string> & names,
+        const std::vector<std::string> & without_names,
+        const std::vector<std::string> & names_regexp,
+        const std::vector<std::string> & without_names_regexp,
+		const Settings & settings_
+	):
+	   concurrency(concurrency_),
+	   connections(concurrency, host_, port_, default_database_, user_, password_),
+	   pool(concurrency),
+	   testsConfigurations(input_files.size())
 	{
+		if (input_files.size() < 1) {
+			throw Poco::Exception("No tests were specified", 1);
+		}
+
 		// std::cerr << std::fixed << std::setprecision(3);
+		readTestsConfiguration(input_files);
 	}
 
 private:
+	unsigned concurrency;
+	ConnectionPool connections;
+	Settings settings;
+	ThreadPool pool;
+
+	using XMLConfiguration = Poco::Util::XMLConfiguration;
+	using Config = Poco::AutoPtr<XMLConfiguration>;
+	std::vector<Config> testsConfigurations;
+
+	void readTestsConfiguration(const std::vector<std::string> & input_files)
+	{
+		for (auto path : input_files) {
+			// testsConfigurations.emplace_back(new XMLConfiguration(path));
+			Poco::AutoPtr<XMLConfiguration> config(new XMLConfiguration(path));
+			std::cout << config->getString("name") << std::endl;
+		}
+
+		// here will be tests filtering on tags, names, regexp matching, etc.
+		// { ... }
+
+		// for now let's launch one test only
+		// if (testsConfigurations.size()) {
+		// 	for (auto testConfig : testsConfigurations) {
+		// 		runTest(testConfig);
+		// 	}
+		// }
+	}
+
+	// void runTest(const Config & testConfig)
+	// {
+	// 	std::cout << "Running: " << testConfig->getString("name") << "\n";
+
+	// 	std::cout << "Check behaviour when attribute does not exist: " << testConfig->getString("someAttr") << "\n";
+	// }
 };
 
 }
 
 int mainEntryClickhousePerformanceTest(int argc, char ** argv) {
-    return 0;
+	using namespace DB;
+
+	try
+	{
+		using boost::program_options::value;
+		using Strings = std::vector<std::string>;
+
+		boost::program_options::options_description desc("Allowed options");
+		desc.add_options()
+			("help", 																	"produce help message")
+			("concurrency,c",		value<unsigned>()->default_value(1),				"number of parallel queries")
+			("host,h",				value<std::string>()->default_value("localhost"),	"")
+			("port", 				value<UInt16>()->default_value(9000),				"")
+			("user", 				value<std::string>()->default_value("default"),		"")
+			("password",			value<std::string>()->default_value(""),			"")
+			("database",			value<std::string>()->default_value("default"),		"")
+			("tag",					value<Strings>(),									"Run only tests with tag")
+			("without-tag",			value<Strings>(),									"Do not run tests with tag")
+			("name",				value<Strings>(),									"Run tests with specific name")
+			("without-name",		value<Strings>(),									"Do not run tests with name")
+			("name-regexp",			value<Strings>(),									"Run tests with names matching regexp")
+			("without-name-regexp",	value<Strings>(),									"Do not run tests with names matching regexp")
+
+		#define DECLARE_SETTING(TYPE, NAME, DEFAULT) (#NAME, boost::program_options::value<std::string> (), "Settings.h")
+		#define   DECLARE_LIMIT(TYPE, NAME, DEFAULT) (#NAME, boost::program_options::value<std::string> (), "Limits.h")
+			APPLY_FOR_SETTINGS(DECLARE_SETTING)
+			APPLY_FOR_LIMITS(DECLARE_LIMIT)
+		#undef DECLARE_SETTING
+		#undef DECLARE_LIMIT
+		;
+
+		/// These options will not be displayed in --help
+		boost::program_options::options_description hidden("Hidden options");
+		hidden.add_options()
+			("input-files", value< std::vector<std::string> >(), "")
+			;
+
+		/// But they will be legit, though. And they must be given without name
+		boost::program_options::positional_options_description positional;
+		positional.add("input-files", -1);
+
+		boost::program_options::options_description cmdline_options;
+		cmdline_options.add(desc).add(hidden);
+
+		boost::program_options::variables_map options;
+		boost::program_options::store(
+			boost::program_options::command_line_parser(argc, argv)
+									.options(cmdline_options)
+									.positional(positional)
+									.run(),
+			options
+		);
+		boost::program_options::notify(options);
+
+		if (options.count("help"))
+		{
+			std::cout << "Usage: " << argv[0] << " [options] [test_file ...] [tests_folder]\n";
+			std::cout << desc << "\n";
+			return 1;
+		}
+
+		if (! options.count("input-files")) {
+			std::cerr << "No tests files were specified. See --help" << "\n";
+			return 1;
+		}
+
+		/// Extract settings and limits from given options
+		Settings settings;
+
+		#define EXTRACT_SETTING(TYPE, NAME, DEFAULT) \
+			if (options.count(#NAME)) \
+				settings.set(#NAME, options[#NAME].as<std::string>());
+			APPLY_FOR_SETTINGS(EXTRACT_SETTING)
+			APPLY_FOR_LIMITS(EXTRACT_SETTING)
+		#undef EXTRACT_SETTING
+
+		Strings tests_tags;
+		Strings skip_tags;
+		Strings tests_names;
+		Strings skip_names;
+		Strings name_regexp;
+		Strings skip_matching_regexp;
+
+		if (options.count("tag")) {
+			tests_tags = options["tag"].as<Strings>();
+		}
+
+		if (options.count("without-tag")) {
+			skip_tags = options["without-tag"].as<Strings>();
+		}
+
+		if (options.count("name")) {
+			tests_names = options["name"].as<Strings>();
+		}
+
+		if (options.count("without-name")) {
+			skip_names = options["without-name"].as<Strings>();
+		}
+
+		if (options.count("name-regexp")) {
+			name_regexp = options["name-regexp"].as<Strings>();
+		}
+
+		if (options.count("without-name-regexp")) {
+			skip_matching_regexp = options["without-name-regexp"].as<Strings>();
+		}
+
+
+
+		PerformanceTest performanceTest(
+			options["concurrency"].as<unsigned>(),
+			options["host"       ].as<std::string>(),
+			options["port"       ].as<UInt16>(),
+			options["database"   ].as<std::string>(),
+			options["user"       ].as<std::string>(),
+			options["password"   ].as<std::string>(),
+			options["input-files"].as<Strings>(),
+			tests_tags,
+			skip_tags,
+			tests_names,
+			skip_names,
+			name_regexp,
+			skip_matching_regexp,
+			settings
+		);
+	}
+	catch (const Exception & e)
+	{
+		std::string text = e.displayText();
+
+		std::cerr << "Code: " << e.code() << ". " << text << "\n\n";
+
+		/// Если есть стек-трейс на сервере, то не будем писать стек-трейс на клиенте.
+		if (std::string::npos == text.find("Stack trace"))
+			std::cerr << "Stack trace:\n"
+				<< e.getStackTrace().toString();
+
+		return e.code();
+	}
+	catch (const Poco::Exception & e)
+	{
+		std::cerr << "Poco::Exception: " << e.displayText() << "\n";
+		return ErrorCodes::POCO_EXCEPTION;
+	}
+	catch (const std::exception & e)
+	{
+		std::cerr << "std::exception: " << e.what() << "\n";
+		return ErrorCodes::STD_EXCEPTION;
+	}
+	catch (...)
+	{
+		std::cerr << "Unknown exception\n";
+		return ErrorCodes::UNKNOWN_EXCEPTION;
+	}
+
+	return 0;
 }

--- a/dbms/src/Client/profiles.xml
+++ b/dbms/src/Client/profiles.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<profiles>
+    <default></default>
+    <single_thread>
+        <max_threads>1</max_threads>
+    </single_thread>
+</profiles>

--- a/dbms/src/IO/ReadHelpers.h
+++ b/dbms/src/IO/ReadHelpers.h
@@ -483,9 +483,9 @@ inline void readFloatText(T & x, ReadBuffer & buf)
 }
 
 /// rough; all until '\n' or '\t'
-void readString(String & s, ReadBuffer & buf);
+void readString(String & s, ReadBuffer & buf, bool skip_whitespace = false);
 
-void readEscapedString(String & s, ReadBuffer & buf);
+void readEscapedString(String & s, ReadBuffer & buf, bool skip_whitespace = false);
 
 void readQuotedString(String & s, ReadBuffer & buf);
 
@@ -514,10 +514,10 @@ void readCSVString(String & s, ReadBuffer & buf, const char delimiter = ',');
 
 /// Read and append result to array of characters.
 template <typename Vector>
-void readStringInto(Vector & s, ReadBuffer & buf);
+void readStringInto(Vector & s, ReadBuffer & buf, bool skip_whitespace = false);
 
 template <typename Vector>
-void readEscapedStringInto(Vector & s, ReadBuffer & buf);
+void readEscapedStringInto(Vector & s, ReadBuffer & buf, bool skip_whitespace = false);
 
 template <typename Vector>
 void readQuotedStringInto(Vector & s, ReadBuffer & buf);

--- a/dbms/src/Server/CMakeLists.txt
+++ b/dbms/src/Server/CMakeLists.txt
@@ -22,9 +22,9 @@ target_link_libraries(clickhouse
     clickhouse-client
     clickhouse-local
     clickhouse-benchmark
+    clickhouse-performance-test
     clickhouse-extract-from-config)
 INSTALL(TARGETS clickhouse RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT clickhouse)
-
 # make symbolic links to concrete clickhouse applications
 macro(install_symlink_to_clickhouse app)
     INSTALL(CODE "execute_process(COMMAND ln -sf clickhouse ${app} WORKING_DIRECTORY \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}\" )" COMPONENT ${app})
@@ -34,6 +34,7 @@ install_symlink_to_clickhouse(clickhouse-server)
 install_symlink_to_clickhouse(clickhouse-client)
 install_symlink_to_clickhouse(clickhouse-local)
 install_symlink_to_clickhouse(clickhouse-benchmark)
+install_symlink_to_clickhouse(clickhouse-performance-test)
 
 INSTALL(
     FILES config.xml users.xml

--- a/dbms/src/Server/main.cpp
+++ b/dbms/src/Server/main.cpp
@@ -11,8 +11,8 @@ int mainEntryClickHouseServer(int argc, char ** argv);
 int mainEntryClickHouseClient(int argc, char ** argv);
 int mainEntryClickHouseLocal(int argc, char ** argv);
 int mainEntryClickHouseBenchmark(int argc, char ** argv);
+int mainEntryClickhousePerformanceTest(int argc, char ** argv);
 int mainEntryClickHouseExtractFromConfig(int argc, char ** argv);
-
 
 static bool isClickhouseApp(const std::string & app_suffix, std::vector<char *> & argv)
 {
@@ -54,6 +54,8 @@ int main(int argc_, char ** argv_)
         main_func = mainEntryClickHouseBenchmark;
     else if (isClickhouseApp("server", argv)) /// --server arg should be cut
         main_func = mainEntryClickHouseServer;
+    else if (isClickhouseApp("performance-test", argv))
+        main_func = mainEntryClickhousePerformanceTest;
     else if (isClickhouseApp("extract-from-config", argv))
         main_func = mainEntryClickHouseExtractFromConfig;
 


### PR DESCRIPTION
A tool for checking performance with tests description support.
See `clickhouse-performance-test --help` for additional information.

A test is written in XML and consists of:
- a name of a test
- how many times it should be processed
- tags/names for filtering
- preconditions for RAM size, cpu cache and data existing
- settings to apply to DBMS before running a test
- type of a query: `loop` or `once`
- stop criterions
- metrics for output
- substitutions for parametric queries

Main test (all metrics in JSON): https://gist.github.com/luc1ph3r/59aeeddb393e0a2c335f6477a34358dc

Test for mini-output (should be launched with `--lite` flag): https://gist.github.com/luc1ph3r/cae23cc9765f873c04706cb512bf0761

Test for average speed (default precision isn't big enough to stop. Kill it with SIGINT): https://gist.github.com/luc1ph3r/c019bda5e3dc6f472375cb0292128763

Test for preconditions (flushes CPU cache, checks for RAM size and data existence):
https://gist.github.com/luc1ph3r/619e953b9fca613a60711e0d5f525915
