### PR TITLE
Avoid creating multiple global contexts

### DIFF
--- a/dbms/src/Analyzers/tests/analyze_columns.cpp
+++ b/dbms/src/Analyzers/tests/analyze_columns.cpp
@@ -32,7 +32,7 @@ try
     ParserSelectQuery parser;
     ASTPtr ast = parseQuery(parser, query.data(), query.data() + query.size(), "query");
 
-    Context context;
+    Context context = Context::createGlobal();
 
     auto system_database = std::make_shared<DatabaseMemory>("system");
     context.addDatabase("system", system_database);

--- a/dbms/src/Analyzers/tests/analyze_result_of_query.cpp
+++ b/dbms/src/Analyzers/tests/analyze_result_of_query.cpp
@@ -28,7 +28,7 @@ try
     ParserSelectQuery parser;
     ASTPtr ast = parseQuery(parser, query.data(), query.data() + query.size(), "query");
 
-    Context context;
+    Context context = Context::createGlobal();
 
     auto system_database = std::make_shared<DatabaseMemory>("system");
     context.addDatabase("system", system_database);

--- a/dbms/src/Analyzers/tests/collect_tables.cpp
+++ b/dbms/src/Analyzers/tests/collect_tables.cpp
@@ -29,7 +29,7 @@ try
     ParserSelectQuery parser;
     ASTPtr ast = parseQuery(parser, query.data(), query.data() + query.size(), "query");
 
-    Context context;
+    Context context = Context::createGlobal();
 
     auto system_database = std::make_shared<DatabaseMemory>("system");
     context.addDatabase("system", system_database);

--- a/dbms/src/Analyzers/tests/optimize_group_order_limit_by.cpp
+++ b/dbms/src/Analyzers/tests/optimize_group_order_limit_by.cpp
@@ -35,7 +35,7 @@ try
     ParserSelectQuery parser;
     ASTPtr ast = parseQuery(parser, query.data(), query.data() + query.size(), "query");
 
-    Context context;
+    Context context = Context::createGlobal();
 
     auto system_database = std::make_shared<DatabaseMemory>("system");
     context.addDatabase("system", system_database);

--- a/dbms/src/Analyzers/tests/type_and_constant_inference.cpp
+++ b/dbms/src/Analyzers/tests/type_and_constant_inference.cpp
@@ -40,7 +40,7 @@ try
     ParserSelectQuery parser;
     ASTPtr ast = parseQuery(parser, query.data(), query.data() + query.size(), "query");
 
-    Context context;
+    Context context = Context::createGlobal();
 
     auto system_database = std::make_shared<DatabaseMemory>("system");
     context.addDatabase("system", system_database);

--- a/dbms/src/DataStreams/RemoteBlockInputStream.cpp
+++ b/dbms/src/DataStreams/RemoteBlockInputStream.cpp
@@ -17,8 +17,8 @@ namespace ErrorCodes
 
 
 RemoteBlockInputStream::RemoteBlockInputStream(Connection & connection_, const String & query_,
-    const Settings * settings_, ThrottlerPtr throttler_, const Tables & external_tables_,
-    QueryProcessingStage::Enum stage_, const Context & context_)
+    const Settings * settings_, const Context & context_, ThrottlerPtr throttler_,
+    const Tables & external_tables_, QueryProcessingStage::Enum stage_)
     : connection(&connection_), query(query_), throttler(throttler_), external_tables(external_tables_),
     stage(stage_), context(context_)
 {
@@ -26,8 +26,8 @@ RemoteBlockInputStream::RemoteBlockInputStream(Connection & connection_, const S
 }
 
 RemoteBlockInputStream::RemoteBlockInputStream(const ConnectionPoolWithFailoverPtr & pool_, const String & query_,
-    const Settings * settings_, ThrottlerPtr throttler_, const Tables & external_tables_,
-    QueryProcessingStage::Enum stage_, const Context & context_)
+    const Settings * settings_, const Context & context_, ThrottlerPtr throttler_,
+    const Tables & external_tables_, QueryProcessingStage::Enum stage_)
     : pool(pool_), query(query_), throttler(throttler_), external_tables(external_tables_),
     stage(stage_), context(context_)
 {
@@ -35,8 +35,8 @@ RemoteBlockInputStream::RemoteBlockInputStream(const ConnectionPoolWithFailoverP
 }
 
 RemoteBlockInputStream::RemoteBlockInputStream(ConnectionPoolWithFailoverPtrs && pools_, const String & query_,
-    const Settings * settings_, ThrottlerPtr throttler_, const Tables & external_tables_,
-    QueryProcessingStage::Enum stage_, const Context & context_)
+    const Settings * settings_, const Context & context_, ThrottlerPtr throttler_,
+    const Tables & external_tables_, QueryProcessingStage::Enum stage_)
     : pools(std::move(pools_)), query(query_), throttler(throttler_), external_tables(external_tables_),
     stage(stage_), context(context_)
 {

--- a/dbms/src/DataStreams/RemoteBlockInputStream.h
+++ b/dbms/src/DataStreams/RemoteBlockInputStream.h
@@ -22,21 +22,18 @@ class RemoteBlockInputStream : public IProfilingBlockInputStream
 public:
     /// Takes already set connection
     RemoteBlockInputStream(Connection & connection_, const String & query_, const Settings * settings_,
-        ThrottlerPtr throttler_ = nullptr, const Tables & external_tables_ = Tables(),
-        QueryProcessingStage::Enum stage_ = QueryProcessingStage::Complete,
-        const Context & context_ = getDefaultContext());
+        const Context & context_, ThrottlerPtr throttler_ = nullptr, const Tables & external_tables_ = Tables(),
+        QueryProcessingStage::Enum stage_ = QueryProcessingStage::Complete);
 
     /// Takes a pool and gets one or several connections from it
     RemoteBlockInputStream(const ConnectionPoolWithFailoverPtr & pool_, const String & query_, const Settings * settings_,
-        ThrottlerPtr throttler_ = nullptr, const Tables & external_tables_ = Tables(),
-        QueryProcessingStage::Enum stage_ = QueryProcessingStage::Complete,
-        const Context & context_ = getDefaultContext());
+        const Context & context_, ThrottlerPtr throttler_ = nullptr, const Tables & external_tables_ = Tables(),
+        QueryProcessingStage::Enum stage_ = QueryProcessingStage::Complete);
 
     /// Takes a pool for each shard and gets one or several connections from it
     RemoteBlockInputStream(ConnectionPoolWithFailoverPtrs && pools_, const String & query_, const Settings * settings_,
-        ThrottlerPtr throttler_ = nullptr, const Tables & external_tables_ = Tables(),
-        QueryProcessingStage::Enum stage_ = QueryProcessingStage::Complete,
-        const Context & context_ = getDefaultContext());
+        const Context & context_, ThrottlerPtr throttler_ = nullptr, const Tables & external_tables_ = Tables(),
+        QueryProcessingStage::Enum stage_ = QueryProcessingStage::Complete);
 
     ~RemoteBlockInputStream() override;
 
@@ -96,13 +93,6 @@ private:
 
     /// If wasn't sent yet, send request to cancell all connections to replicas
     void tryCancel(const char * reason);
-
-    /// ITable::read requires a Context, therefore we should create one if the user can't supply it
-    static Context & getDefaultContext()
-    {
-        static Context instance;
-        return instance;
-    }
 
 private:
     /// Already set connection

--- a/dbms/src/DataStreams/tests/collapsing_sorted_stream.cpp
+++ b/dbms/src/DataStreams/tests/collapsing_sorted_stream.cpp
@@ -75,7 +75,7 @@ try
     //CollapsingSortedBlockInputStream collapsed(inputs, descr, "Sign", 1048576);
     CollapsingFinalBlockInputStream collapsed(inputs, descr, "Sign");
 
-    Context context;
+    Context context = Context::createGlobal();
     WriteBufferFromFileDescriptor out_buf(STDERR_FILENO);
     BlockOutputStreamPtr output = context.getOutputFormat("TabSeparated", out_buf, block1);
 

--- a/dbms/src/DataStreams/tests/expression_stream.cpp
+++ b/dbms/src/DataStreams/tests/expression_stream.cpp
@@ -33,7 +33,7 @@ try
     ParserSelectQuery parser;
     ASTPtr ast = parseQuery(parser, input.data(), input.data() + input.size(), "");
 
-    Context context;
+    Context context = Context::createGlobal();
 
     ExpressionAnalyzer analyzer(ast, context, {}, {NameAndTypePair("number", std::make_shared<DataTypeUInt64>())});
     ExpressionActionsChain chain;

--- a/dbms/src/DataStreams/tests/filter_stream.cpp
+++ b/dbms/src/DataStreams/tests/filter_stream.cpp
@@ -39,7 +39,7 @@ try
     std::cerr << std::endl;
     std::cerr << ast->getTreeID() << std::endl;
 
-    Context context;
+    Context context = Context::createGlobal();
 
     ExpressionAnalyzer analyzer(ast, context, {}, {NameAndTypePair("number", std::make_shared<DataTypeUInt64>())});
     ExpressionActionsChain chain;

--- a/dbms/src/DataStreams/tests/filter_stream_hitlog.cpp
+++ b/dbms/src/DataStreams/tests/filter_stream_hitlog.cpp
@@ -93,7 +93,7 @@ int main(int argc, char ** argv)
             {"WithHash", std::make_shared<DataTypeUInt8>()},
         };
 
-        Context context;
+        Context context = Context::createGlobal();
 
         std::string input = "SELECT UniqID, URL, CounterID, IsLink WHERE URL = 'http://mail.yandex.ru/neo2/#inbox'";
         ParserSelectQuery parser;

--- a/dbms/src/DataStreams/tests/fork_streams.cpp
+++ b/dbms/src/DataStreams/tests/fork_streams.cpp
@@ -56,7 +56,7 @@ try
     formatAST(*ast, std::cerr);
     std::cerr << std::endl;
 
-    Context context;
+    Context context = Context::createGlobal();
 
     ExpressionAnalyzer analyzer(ast, context, {}, {NameAndTypePair("number", std::make_shared<DataTypeUInt64>())});
     ExpressionActionsChain chain;

--- a/dbms/src/DataStreams/tests/glue_streams.cpp
+++ b/dbms/src/DataStreams/tests/glue_streams.cpp
@@ -35,7 +35,7 @@ void forkThread(ForkPtr fork)
 int main(int argc, char ** argv)
 try
 {
-    Context context;
+    Context context = Context::createGlobal();
 
     context.setGlobalContext(context);
     context.setPath("./");

--- a/dbms/src/DataStreams/tests/native_streams.cpp
+++ b/dbms/src/DataStreams/tests/native_streams.cpp
@@ -103,7 +103,7 @@ try
     if (argc == 2 && 0 == strcmp(argv[1], "read"))
     {
         QueryProcessingStage::Enum stage;
-        BlockInputStreamPtr in = table->read(column_names, 0, Context{}, stage, 8192, 1)[0];
+        BlockInputStreamPtr in = table->read(column_names, 0, Context::createGlobal(), stage, 8192, 1)[0];
         WriteBufferFromFileDescriptor out1(STDOUT_FILENO);
         CompressedWriteBuffer out2(out1);
         NativeBlockOutputStream out3(out2, ClickHouseRevision::get());

--- a/dbms/src/DataStreams/tests/sorting_stream.cpp
+++ b/dbms/src/DataStreams/tests/sorting_stream.cpp
@@ -145,7 +145,7 @@ try
 
     QueryProcessingStage::Enum stage;
 
-    BlockInputStreamPtr in = table->read(column_names, 0, Context{}, stage, argc == 2 ? atoi(argv[1]) : 65536, 1)[0];
+    BlockInputStreamPtr in = table->read(column_names, 0, Context::createGlobal(), stage, argc == 2 ? atoi(argv[1]) : 65536, 1)[0];
     in = std::make_shared<PartialSortingBlockInputStream>(in, sort_columns);
     in = std::make_shared<MergeSortingBlockInputStream>(in, sort_columns, DEFAULT_BLOCK_SIZE, 0, 0, "");
     //in = std::make_shared<LimitBlockInputStream>(in, 10, 0);

--- a/dbms/src/DataStreams/tests/union_stream.cpp
+++ b/dbms/src/DataStreams/tests/union_stream.cpp
@@ -24,7 +24,7 @@ using namespace DB;
 
 void test1()
 {
-    Context context;
+    Context context = Context::createGlobal();
     StoragePtr table = StorageSystemNumbers::create("numbers", false);
 
     Names column_names;
@@ -54,7 +54,7 @@ void test1()
 
 void test2()
 {
-    Context context;
+    Context context = Context::createGlobal();
     StoragePtr table = StorageSystemNumbers::create("numbers", false);
 
     Names column_names;

--- a/dbms/src/DataStreams/tests/union_stream2.cpp
+++ b/dbms/src/DataStreams/tests/union_stream2.cpp
@@ -22,7 +22,7 @@ using namespace DB;
 int main(int argc, char ** argv)
 try
 {
-    Context context;
+    Context context = Context::createGlobal();
     Settings settings = context.getSettings();
 
     context.setPath("./");

--- a/dbms/src/Dictionaries/ClickHouseDictionarySource.cpp
+++ b/dbms/src/Dictionaries/ClickHouseDictionarySource.cpp
@@ -71,7 +71,7 @@ BlockInputStreamPtr ClickHouseDictionarySource::loadAll()
       */
     if (is_local)
         return executeQuery(load_all_query, context, true).in;
-    return std::make_shared<RemoteBlockInputStream>(pool, load_all_query, nullptr);
+    return std::make_shared<RemoteBlockInputStream>(pool, load_all_query, nullptr, context);
 }
 
 
@@ -101,7 +101,7 @@ BlockInputStreamPtr ClickHouseDictionarySource::createStreamForSelectiveLoad(con
 {
     if (is_local)
         return executeQuery(query, context, true).in;
-    return std::make_shared<RemoteBlockInputStream>(pool, query, nullptr);
+    return std::make_shared<RemoteBlockInputStream>(pool, query, nullptr, context);
 }
 
 }

--- a/dbms/src/Interpreters/ClusterProxy/AlterQueryConstructor.cpp
+++ b/dbms/src/Interpreters/ClusterProxy/AlterQueryConstructor.cpp
@@ -35,7 +35,7 @@ BlockInputStreamPtr AlterQueryConstructor::createRemote(
         const ConnectionPoolWithFailoverPtr & pool, const std::string & query,
         const Settings & settings, ThrottlerPtr throttler, const Context & context)
 {
-    auto stream = std::make_shared<RemoteBlockInputStream>(pool, query, &settings, throttler);
+    auto stream = std::make_shared<RemoteBlockInputStream>(pool, query, &settings, context, throttler);
     stream->setPoolMode(pool_mode);
     return stream;
 }
@@ -44,7 +44,7 @@ BlockInputStreamPtr AlterQueryConstructor::createRemote(
         ConnectionPoolWithFailoverPtrs && pools, const std::string & query,
         const Settings & settings, ThrottlerPtr throttler, const Context & context)
 {
-    auto stream = std::make_shared<RemoteBlockInputStream>(std::move(pools), query, &settings, throttler);
+    auto stream = std::make_shared<RemoteBlockInputStream>(std::move(pools), query, &settings, context, throttler);
     stream->setPoolMode(pool_mode);
     return stream;
 }

--- a/dbms/src/Interpreters/ClusterProxy/DescribeQueryConstructor.cpp
+++ b/dbms/src/Interpreters/ClusterProxy/DescribeQueryConstructor.cpp
@@ -46,7 +46,7 @@ BlockInputStreamPtr DescribeQueryConstructor::createRemote(
         const ConnectionPoolWithFailoverPtr & pool, const std::string & query,
         const Settings & settings, ThrottlerPtr throttler, const Context & context)
 {
-    auto stream = std::make_shared<RemoteBlockInputStream>(pool, query, &settings, throttler);
+    auto stream = std::make_shared<RemoteBlockInputStream>(pool, query, &settings, context, throttler);
     stream->setPoolMode(pool_mode);
     stream->appendExtraInfo();
     return stream;
@@ -56,7 +56,7 @@ BlockInputStreamPtr DescribeQueryConstructor::createRemote(
         ConnectionPoolWithFailoverPtrs && pools, const std::string & query,
         const Settings & settings, ThrottlerPtr throttler, const Context & context)
 {
-    auto stream =  std::make_shared<RemoteBlockInputStream>(std::move(pools), query, &settings, throttler);
+    auto stream =  std::make_shared<RemoteBlockInputStream>(std::move(pools), query, &settings, context, throttler);
     stream->setPoolMode(pool_mode);
     stream->appendExtraInfo();
     return stream;

--- a/dbms/src/Interpreters/ClusterProxy/SelectQueryConstructor.cpp
+++ b/dbms/src/Interpreters/ClusterProxy/SelectQueryConstructor.cpp
@@ -42,7 +42,7 @@ BlockInputStreamPtr SelectQueryConstructor::createRemote(
         const ConnectionPoolWithFailoverPtr & pool, const std::string & query,
         const Settings & settings, ThrottlerPtr throttler, const Context & context)
 {
-    auto stream = std::make_shared<RemoteBlockInputStream>(pool, query, &settings, throttler, external_tables, processed_stage, context);
+    auto stream = std::make_shared<RemoteBlockInputStream>(pool, query, &settings, context, throttler, external_tables, processed_stage);
     stream->setPoolMode(pool_mode);
     stream->setMainTable(main_table);
     return stream;
@@ -52,7 +52,7 @@ BlockInputStreamPtr SelectQueryConstructor::createRemote(
         ConnectionPoolWithFailoverPtrs && pools, const std::string & query,
         const Settings & settings, ThrottlerPtr throttler, const Context & context)
 {
-    auto stream = std::make_shared<RemoteBlockInputStream>(std::move(pools), query, &settings, throttler, external_tables, processed_stage, context);
+    auto stream = std::make_shared<RemoteBlockInputStream>(std::move(pools), query, &settings, context, throttler, external_tables, processed_stage);
     stream->setPoolMode(pool_mode);
     stream->setMainTable(main_table);
     return stream;

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -175,7 +175,7 @@ struct ContextShared
 
     ContextShared()
     {
-        /// TODO: make it SingleTon (?)
+        /// TODO: make it Singleton (?)
         static std::atomic<size_t> num_calls{0};
         if (++num_calls > 1)
         {

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -173,6 +173,18 @@ struct ContextShared
 
     std::mt19937_64 rng{randomSeed()};
 
+    ContextShared()
+    {
+        /// TODO: make it SingleTon (?)
+        static std::atomic<size_t> num_calls{0};
+        if (++num_calls > 1)
+        {
+            std::cerr << "Attempting to create multiple ContextShared instances. Stack trace:\n" << StackTrace().toString();
+            std::cerr.flush();
+            std::terminate();
+        }
+    }
+
 
     ~ContextShared()
     {
@@ -224,14 +236,6 @@ Context::Context() = default;
 
 Context Context::createGlobal()
 {
-    static std::atomic<size_t> num_calls{0};
-    if (++num_calls > 1)
-    {
-        std::cerr << "Attempting to create multiple default Context. Stack trace:\n" << StackTrace().toString();
-        std::cerr.flush();
-        std::terminate();
-    }
-
     Context res;
     res.shared = std::make_shared<ContextShared>();
     res.quota = std::make_shared<QuotaForIntervals>();

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -219,12 +219,26 @@ struct ContextShared
 };
 
 
-Context::Context()
-    : shared(std::make_shared<ContextShared>()),
-    quota(std::make_shared<QuotaForIntervals>()),
-    system_logs(std::make_shared<SystemLogs>())
+Context::Context() = default;
+
+
+Context Context::createGlobal()
 {
+    static std::atomic<size_t> num_calls{0};
+    if (++num_calls > 1)
+    {
+        std::cerr << "Attempting to create multiple default Context. Stack trace:\n" << StackTrace().toString();
+        std::cerr.flush();
+        std::terminate();
+    }
+
+    Context res;
+    res.shared = std::make_shared<ContextShared>();
+    res.quota = std::make_shared<QuotaForIntervals>();
+    res.system_logs = std::make_shared<SystemLogs>();
+    return res;
 }
+
 
 Context::~Context()
 {

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -110,8 +110,13 @@ private:
     using DatabasePtr = std::shared_ptr<IDatabase>;
     using Databases = std::map<String, std::shared_ptr<IDatabase>>;
 
-public:
+    /// Use copy constructor or createGlobal() instead
     Context();
+
+public:
+    /// Create initial Context with ContextShared and etc.
+    static Context createGlobal();
+
     ~Context();
 
     String getPath() const;

--- a/dbms/src/Interpreters/tests/create_query.cpp
+++ b/dbms/src/Interpreters/tests/create_query.cpp
@@ -78,7 +78,7 @@ try
     ParserCreateQuery parser;
     ASTPtr ast = parseQuery(parser, input.data(), input.data() + input.size(), "");
 
-    Context context;
+    Context context = Context::createGlobal();
 
     context.setPath("./");
     auto database = std::make_shared<DatabaseOrdinary>("test", "./metadata/test/");

--- a/dbms/src/Interpreters/tests/expression.cpp
+++ b/dbms/src/Interpreters/tests/expression.cpp
@@ -46,7 +46,7 @@ int main(int argc, char ** argv)
         formatAST(*ast, std::cerr);
         std::cerr << std::endl;
 
-        Context context;
+        Context context = Context::createGlobal();
         NamesAndTypesList columns
         {
             {"x", std::make_shared<DataTypeInt16>()},

--- a/dbms/src/Interpreters/tests/expression_analyzer.cpp
+++ b/dbms/src/Interpreters/tests/expression_analyzer.cpp
@@ -22,7 +22,7 @@ int main(int argc, char ** argv)
         return 1;
     }
 
-    Context context;
+    Context context = Context::createGlobal();
 
     NamesAndTypesList columns;
     for (int i = 2; i + 1 < argc; i += 2)

--- a/dbms/src/Interpreters/tests/in_join_subqueries_preprocessor.cpp
+++ b/dbms/src/Interpreters/tests/in_join_subqueries_preprocessor.cpp
@@ -1168,7 +1168,7 @@ TestResult check(const TestEntry & entry)
 {
     try
     {
-        DB::Context context;
+        DB::Context context = DB::Context::createGlobal();
 
         auto storage_distributed_visits = StorageDistributedFake::create("remote_db", "remote_visits", entry.shard_count);
         auto storage_distributed_hits = StorageDistributedFake::create("distant_db", "distant_hits", entry.shard_count);

--- a/dbms/src/Interpreters/tests/select_query.cpp
+++ b/dbms/src/Interpreters/tests/select_query.cpp
@@ -30,7 +30,7 @@ try
     /// Pre-initialize the `DateLUT` so that the first initialization does not affect the measured execution speed.
     DateLUT::instance();
 
-    Context context;
+    Context context = Context::createGlobal();
 
     context.setPath("./");
 

--- a/dbms/src/Server/Benchmark.cpp
+++ b/dbms/src/Server/Benchmark.cpp
@@ -67,7 +67,7 @@ public:
         concurrency(concurrency_), delay(delay_), queue(concurrency),
         connections(concurrency, host_, port_, default_database_, user_, password_),
         randomize(randomize_), max_iterations(max_iterations_), max_time(max_time_),
-        json_path(json_path_), settings(settings_), pool(concurrency)
+        json_path(json_path_), settings(settings_), global_context(Context::createGlobal()), pool(concurrency)
     {
         std::cerr << std::fixed << std::setprecision(3);
 
@@ -107,6 +107,7 @@ private:
     double max_time;
     String json_path;
     Settings settings;
+    Context global_context;
     QueryProcessingStage::Enum query_processing_stage;
 
     /// Don't execute new queries after timelimit or SIGINT or exception
@@ -295,7 +296,7 @@ private:
     void execute(ConnectionPool::Entry & connection, Query & query)
     {
         Stopwatch watch;
-        RemoteBlockInputStream stream(*connection, query, &settings, nullptr, Tables(), query_processing_stage);
+        RemoteBlockInputStream stream(*connection, query, &settings, global_context, nullptr, Tables(), query_processing_stage);
 
         Progress progress;
         stream.setProgressCallback([&progress](const Progress & value) { progress.incrementPiecewiseAtomically(value); });

--- a/dbms/src/Server/Client.cpp
+++ b/dbms/src/Server/Client.cpp
@@ -115,7 +115,7 @@ private:
 
     bool has_vertical_output_suffix = false; /// Is \G present at the end of the query string?
 
-    Context context;
+    Context context = Context::createGlobal();
 
     /// Buffer that reads from stdin in batch mode.
     ReadBufferFromFileDescriptor std_in {STDIN_FILENO};

--- a/dbms/src/Server/LocalServer.cpp
+++ b/dbms/src/Server/LocalServer.cpp
@@ -252,7 +252,7 @@ try
         config().add(processed_config.duplicate(), PRIO_DEFAULT, false);
     }
 
-    context = std::make_unique<Context>();
+    context = std::make_unique<Context>(Context::createGlobal());
     context->setGlobalContext(*context);
     context->setApplicationType(Context::ApplicationType::LOCAL_SERVER);
     tryInitPath();

--- a/dbms/src/Server/PerformanceTest.cpp
+++ b/dbms/src/Server/PerformanceTest.cpp
@@ -533,6 +533,7 @@ private:
     using Keys = std::vector<String>;
 
     Settings settings;
+    Context global_context = Context::createGlobal();
 
     InterruptListener interrupt_listener;
 
@@ -1083,7 +1084,7 @@ private:
     {
         statistics[statistic_index].watch_per_query.restart();
 
-        RemoteBlockInputStream stream(connection, query, &settings, nullptr, Tables() /*, query_processing_stage*/);
+        RemoteBlockInputStream stream(connection, query, &settings, global_context, nullptr, Tables() /*, query_processing_stage*/);
 
         Progress progress;
         stream.setProgressCallback([&progress, &stream, statistic_index, this](const Progress & value) {

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -222,7 +222,7 @@ int Server::main(const std::vector<std::string> & args)
     /** Context contains all that query execution is dependent:
       *  settings, available functions, data types, aggregate functions, databases...
       */
-    global_context = std::make_unique<Context>();
+    global_context = std::make_unique<Context>(Context::createGlobal());
     global_context->setGlobalContext(*global_context);
     global_context->setApplicationType(Context::ApplicationType::SERVER);
 

--- a/dbms/src/Storages/StorageMergeTree.cpp
+++ b/dbms/src/Storages/StorageMergeTree.cpp
@@ -23,6 +23,7 @@ namespace ErrorCodes
 {
     extern const int ABORTED;
     extern const int BAD_ARGUMENTS;
+    extern const int INCORRECT_DATA;
 }
 
 
@@ -56,7 +57,16 @@ StorageMergeTree::StorageMergeTree(
     log(&Logger::get(database_name_ + "." + table_name + " (StorageMergeTree)"))
 {
     data.loadDataParts(has_force_restore_data_flag);
-    data.clearOldParts();
+
+    if (!attach)
+    {
+        if (!data.getDataParts().empty())
+            throw Exception("Data directory for table already containing data parts - probably it was unclean DROP table or manual intervention. You must either clear directory by hand or use ATTACH TABLE instead of CREATE TABLE if you need to use that parts.", ErrorCodes::INCORRECT_DATA);
+    }
+    else
+    {
+        data.clearOldParts();
+    }
 
     /// Temporary directories contain incomplete results of merges (after forced restart)
     ///  and don't allow to reinitialize them, so delete each of them immediately

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -2615,7 +2615,7 @@ void StorageReplicatedMergeTree::dropPartition(
             leader_address.database,
             "", "", "ClickHouse replica");
 
-        RemoteBlockInputStream stream(connection, formattedAST(new_query), &settings);
+        RemoteBlockInputStream stream(connection, formattedAST(new_query), &settings, context);
         NullBlockOutputStream output;
 
         copyData(stream, output);

--- a/dbms/src/Storages/tests/hit_log.cpp
+++ b/dbms/src/Storages/tests/hit_log.cpp
@@ -132,7 +132,7 @@ try
 
         QueryProcessingStage::Enum stage;
 
-        BlockInputStreamPtr in = table->read(column_names, 0, Context{}, stage, 8192, 1)[0];
+        BlockInputStreamPtr in = table->read(column_names, 0, Context::createGlobal(), stage, 8192, 1)[0];
         RowOutputStreamPtr out_ = std::make_shared<TabSeparatedRowOutputStream>(out_buf, sample);
         BlockOutputStreamFromRowOutputStream out(out_);
         copyData(*in, out);

--- a/dbms/src/Storages/tests/merge_tree.cpp
+++ b/dbms/src/Storages/tests/merge_tree.cpp
@@ -22,7 +22,7 @@ try
 
     const size_t rows = 12345;
 
-    Context context;
+    Context context = Context::createGlobal();
 
     /// create a table with a pair of columns
 

--- a/dbms/src/Storages/tests/pk_condition.cpp
+++ b/dbms/src/Storages/tests/pk_condition.cpp
@@ -29,7 +29,7 @@ int main(int argc, const char ** argv)
     ParserSelectQuery parser;
     ASTPtr ast = parseQuery(parser, input.data(), input.data() + input.size(), "");
 
-    Context context;
+    Context context = Context::createGlobal();
     NamesAndTypesList columns{{"key", std::make_shared<DataTypeUInt64>()}};
     Block sample_block{{DataTypeUInt64{}.createColumn(), std::make_shared<DataTypeUInt64>(), "key"}};
     SortDescription sort_descr;

--- a/dbms/src/Storages/tests/storage_log.cpp
+++ b/dbms/src/Storages/tests/storage_log.cpp
@@ -68,7 +68,7 @@ try
 
         QueryProcessingStage::Enum stage;
 
-        BlockInputStreamPtr in = table->read(column_names, 0, Context{}, stage, 8192, 1)[0];
+        BlockInputStreamPtr in = table->read(column_names, 0, Context::createGlobal(), stage, 8192, 1)[0];
 
         Block sample;
         {

--- a/dbms/src/Storages/tests/system_numbers.cpp
+++ b/dbms/src/Storages/tests/system_numbers.cpp
@@ -29,7 +29,7 @@ try
 
     QueryProcessingStage::Enum stage;
 
-    LimitBlockInputStream input(table->read(column_names, 0, Context{}, stage, 10, 1)[0], 10, 96);
+    LimitBlockInputStream input(table->read(column_names, 0, Context::createGlobal(), stage, 10, 1)[0], 10, 96);
     RowOutputStreamPtr output_ = std::make_shared<TabSeparatedRowOutputStream>(out_buf, sample);
     BlockOutputStreamFromRowOutputStream output(output_);
 

--- a/dbms/src/TableFunctions/getStructureOfRemoteTable.cpp
+++ b/dbms/src/TableFunctions/getStructureOfRemoteTable.cpp
@@ -35,8 +35,8 @@ NamesAndTypesList getStructureOfRemoteTable(
         return context.getTable(database, table)->getColumnsList();
 
     BlockInputStreamPtr input = std::make_shared<RemoteBlockInputStream>(
-            shard_info.pool, query, &settings, nullptr,
-            Tables(), QueryProcessingStage::Complete, context);
+            shard_info.pool, query, &settings, context, nullptr,
+            Tables(), QueryProcessingStage::Complete);
     input->readPrefix();
 
     const DataTypeFactory & data_type_factory = DataTypeFactory::instance();


### PR DESCRIPTION
CREATE query of MergeTree checks that data dir is empty