### PR TITLE
Fix older Darwin build [#DEVTOOLS-3381]

### DIFF
--- a/dbms/src/Common/Allocator.cpp
+++ b/dbms/src/Common/Allocator.cpp
@@ -9,6 +9,7 @@
 #include <Common/Exception.h>
 #include <Common/Allocator.h>
 
+/// Required for older Darwin builds, that lack definition of MAP_ANONYMOUS
 #ifndef MAP_ANONYMOUS
 #define MAP_ANONYMOUS MAP_ANON
 #endif

--- a/dbms/src/Common/Allocator.cpp
+++ b/dbms/src/Common/Allocator.cpp
@@ -9,6 +9,10 @@
 #include <Common/Exception.h>
 #include <Common/Allocator.h>
 
+#ifndef MAP_ANONYMOUS
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+
 
 namespace DB
 {

--- a/dbms/src/Common/ArrayCache.h
+++ b/dbms/src/Common/ArrayCache.h
@@ -15,6 +15,7 @@
 #include <Common/Exception.h>
 #include <Common/randomSeed.h>
 
+/// Required for older Darwin builds, that lack definition of MAP_ANONYMOUS
 #ifndef MAP_ANONYMOUS
 #define MAP_ANONYMOUS MAP_ANON
 #endif

--- a/dbms/src/Common/ArrayCache.h
+++ b/dbms/src/Common/ArrayCache.h
@@ -15,6 +15,10 @@
 #include <Common/Exception.h>
 #include <Common/randomSeed.h>
 
+#ifndef MAP_ANONYMOUS
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+
 
 namespace DB
 {


### PR DESCRIPTION
This is not needed at least since macOS 10.11, but it is necessary to build with older Darwin headers.