### PR TITLE
Fix build cause by libs/libcommon/include/ext/bit_cast.h

### DIFF
--- a/libs/libcommon/include/ext/bit_cast.h
+++ b/libs/libcommon/include/ext/bit_cast.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <string>
+#include <string.h>
+#include <algorithm>
 #include <type_traits>
 
 


### PR DESCRIPTION
Branch master(#4af5a9c) build failed, so I trace down to this file:
libs/libcommon/include/ext/bit_cast.h

1. Base on http://www.cplusplus.com/reference/cstring/memcpy,
    'memcpy' should be defined in [cstring] aka [string.h]

2. Base on http://www.cplusplus.com/reference/algorithm/min/,
    std::min should be defined in [algorithm], whitch this file do not include.

Here is my fix, build succeeded, please take a look.
Close it if I'm wrong.