### PR TITLE
PKCondition: infer index use with pk subexpression

### DIFF
--- a/dbms/src/Functions/FunctionsConversion.h
+++ b/dbms/src/Functions/FunctionsConversion.h
@@ -1049,12 +1049,12 @@ struct ToIntMonotonicity
 
         /// If type is expanding, then function is monotonic.
         if (sizeof(T) > size_of_type)
-            return { true };
+            return { true, true, true };
 
         /// If type is same, too. (Enum has separate case, because it is different data type)
         if (typeid_cast<const DataTypeNumber<T> *>(&type) ||
             typeid_cast<const DataTypeEnum<T> *>(&type))
-            return { true };
+            return { true, true, true };
 
         /// In other cases, if range is unbounded, we don't know, whether function is monotonic or not.
         if (left.isNull() || right.isNull())

--- a/dbms/src/Functions/FunctionsDateTime.h
+++ b/dbms/src/Functions/FunctionsDateTime.h
@@ -557,7 +557,10 @@ public:
         IFunction::Monotonicity is_not_monotonic;
 
         if (std::is_same<typename Transform::FactorTransform, ZeroTransform>::value)
+        {
+            is_monotonic.is_always_monotonic = true;
             return is_monotonic;
+        }
 
         /// This method is called only if the function has one argument. Therefore, we do not care about the non-local time zone.
         const DateLUTImpl & date_lut = DateLUT::instance();

--- a/dbms/src/Functions/FunctionsRound.h
+++ b/dbms/src/Functions/FunctionsRound.h
@@ -1139,7 +1139,7 @@ public:
 
     Monotonicity getMonotonicityForRange(const IDataType & type, const Field & left, const Field & right) const override
     {
-        return { true };
+        return { true, true, true };
     }
 };
 

--- a/dbms/src/Functions/IFunction.h
+++ b/dbms/src/Functions/IFunction.h
@@ -169,9 +169,10 @@ public:
     {
         bool is_monotonic = false;    /// Is the function monotonous (nondecreasing or nonincreasing).
         bool is_positive = true;    /// true if the function is nondecreasing, false, if notincreasing. If is_monotonic = false, then it does not matter.
+        bool is_always_monotonic = false; /// Is true if function is monotonic on the whole input range I
 
-        Monotonicity(bool is_monotonic_ = false, bool is_positive_ = true)
-            : is_monotonic(is_monotonic_), is_positive(is_positive_) {}
+        Monotonicity(bool is_monotonic_ = false, bool is_positive_ = true, bool is_always_monotonic_= false)
+            : is_monotonic(is_monotonic_), is_positive(is_positive_), is_always_monotonic(is_always_monotonic_) {}
     };
 
     /** Get information about monotonicity on a range of values. Call only if hasInformationAboutMonotonicity.

--- a/dbms/src/Functions/IFunction.h
+++ b/dbms/src/Functions/IFunction.h
@@ -171,7 +171,7 @@ public:
         bool is_positive = true;    /// true if the function is nondecreasing, false, if notincreasing. If is_monotonic = false, then it does not matter.
         bool is_always_monotonic = false; /// Is true if function is monotonic on the whole input range I
 
-        Monotonicity(bool is_monotonic_ = false, bool is_positive_ = true, bool is_always_monotonic_= false)
+        Monotonicity(bool is_monotonic_ = false, bool is_positive_ = true, bool is_always_monotonic_ = false)
             : is_monotonic(is_monotonic_), is_positive(is_positive_), is_always_monotonic(is_always_monotonic_) {}
     };
 

--- a/dbms/src/Storages/MergeTree/PKCondition.h
+++ b/dbms/src/Storages/MergeTree/PKCondition.h
@@ -3,6 +3,7 @@
 #include <sstream>
 
 #include <Interpreters/Context.h>
+#include <Interpreters/ExpressionActions.h>
 #include <Core/SortDescription.h>
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTSelectQuery.h>
@@ -203,7 +204,7 @@ class PKCondition
 public:
     /// Does not include the SAMPLE section. all_columns - the set of all columns of the table.
     PKCondition(const ASTPtr & query, const Context & context, const NamesAndTypesList & all_columns, const SortDescription & sort_descr,
-        const Block & pk_sample_block);
+        ExpressionActionsPtr pk_expr);
 
     /// Whether the condition is feasible in the key range.
     /// left_pk and right_pk must contain all fields in the sort_descr in the appropriate order.
@@ -313,11 +314,19 @@ private:
         DataTypePtr & out_primary_key_column_type,
         std::vector<const ASTFunction *> & out_functions_chain);
 
+    bool canConstantBeWrappedByMonotonicFunctions(
+        const ASTPtr & node,
+        const Context & context,
+        size_t & out_primary_key_column_num,
+        DataTypePtr & out_primary_key_column_type,
+        Field & out_value,
+        DataTypePtr & out_type);
+
     RPN rpn;
 
     SortDescription sort_descr;
     ColumnIndices pk_columns;
-    const Block & pk_sample_block;
+    ExpressionActionsPtr pk_expr;
 };
 
 }


### PR DESCRIPTION
Background: We have an index that looks like `(date, toStartOfHour(datetime), hostname, ...)` to get better compression and faster group-by of columns after second one. However the index is not used efficiently without explicitly filtering on `toStartOfHour(datetime)`, so I'm trying to optimise for this case.

By default only constraints explicitly matching primary key expression (or expression wrapped in a monotonic function) are eligible for part and range selection. So for example, if index is:

```
(toStartOfHour(dt), UserID)
```

Then a query such as this resorts to full scan:

```sql
SELECT count() FROM t WHERE dt = now()
```

Intuitively, only parts with `toStartOfHour(now())` could be selected, but it is less trivial to prove.
The primary key currently can be wrapped in a chain of monotonic functions, so following would work:

```sql
toStartOfHour(dt) = toStartOfHour(now()) AND dt = now()
```

It must be however explicitly stated, if we wanted to infer that we’d have to know the inverse function,
and prove that the inverse function is monotonic on given interval. This is not practical as there is no inverse function that for example undos rounding, it isn’t strictly monotonic. It's also slower as both expressions will be executed for each row.

There are however functions that don’t transform output range and preserve monotonicity on the complete input range, such as rounding or casts to a same or wider numeric type. This eliminates the need to find inverse function, as no check for monotonicity over arbitrary interval is needed, and thus makes this optimisation possible.