### PR TITLE
Output format json quote denormals

### DIFF
--- a/dbms/src/DataStreams/FormatFactory.cpp
+++ b/dbms/src/DataStreams/FormatFactory.cpp
@@ -29,7 +29,7 @@
 #include <DataStreams/CSVRowOutputStream.h>
 #include <DataStreams/MaterializingBlockOutputStream.h>
 #include <DataStreams/FormatFactory.h>
-
+#include <DataTypes/FormatSettingsJSON.h>
 
 namespace DB
 {
@@ -121,6 +121,7 @@ static BlockOutputStreamPtr getOutputImpl(const String & name, WriteBuffer & buf
     const Block & sample, const Context & context)
 {
     const Settings & settings = context.getSettingsRef();
+    FormatSettingsJSON json_settings(settings.output_format_json_quote_64bit_integers, true);
 
     if (name == "Native")
         return std::make_shared<NativeBlockOutputStream>(buf);
@@ -163,14 +164,14 @@ static BlockOutputStreamPtr getOutputImpl(const String & name, WriteBuffer & buf
     else if (name == "Values")
         return std::make_shared<BlockOutputStreamFromRowOutputStream>(std::make_shared<ValuesRowOutputStream>(buf));
     else if (name == "JSON")
-        return std::make_shared<BlockOutputStreamFromRowOutputStream>(std::make_shared<JSONRowOutputStream>(buf, sample,
-            settings.output_format_write_statistics, settings.output_format_json_quote_64bit_integers));
+        return std::make_shared<BlockOutputStreamFromRowOutputStream>(std::make_shared<JSONRowOutputStream>(
+            buf, sample, settings.output_format_write_statistics, json_settings));
     else if (name == "JSONCompact")
-        return std::make_shared<BlockOutputStreamFromRowOutputStream>(std::make_shared<JSONCompactRowOutputStream>(buf, sample,
-            settings.output_format_write_statistics, settings.output_format_json_quote_64bit_integers));
+        return std::make_shared<BlockOutputStreamFromRowOutputStream>(std::make_shared<JSONCompactRowOutputStream>(
+            buf, sample, settings.output_format_write_statistics, json_settings));
     else if (name == "JSONEachRow")
-        return std::make_shared<BlockOutputStreamFromRowOutputStream>(std::make_shared<JSONEachRowRowOutputStream>(buf, sample,
-            settings.output_format_json_quote_64bit_integers));
+        return std::make_shared<BlockOutputStreamFromRowOutputStream>(std::make_shared<JSONEachRowRowOutputStream>(
+            buf, sample, json_settings));
     else if (name == "XML")
         return std::make_shared<BlockOutputStreamFromRowOutputStream>(std::make_shared<XMLRowOutputStream>(buf, sample,
             settings.output_format_write_statistics));

--- a/dbms/src/DataStreams/FormatFactory.cpp
+++ b/dbms/src/DataStreams/FormatFactory.cpp
@@ -121,7 +121,7 @@ static BlockOutputStreamPtr getOutputImpl(const String & name, WriteBuffer & buf
     const Block & sample, const Context & context)
 {
     const Settings & settings = context.getSettingsRef();
-    FormatSettingsJSON json_settings(settings.output_format_json_quote_64bit_integers, true);
+    FormatSettingsJSON json_settings(settings.output_format_json_quote_64bit_integers, settings.output_format_json_quote_denormals);
 
     if (name == "Native")
         return std::make_shared<NativeBlockOutputStream>(buf);

--- a/dbms/src/DataStreams/JSONCompactRowOutputStream.h
+++ b/dbms/src/DataStreams/JSONCompactRowOutputStream.h
@@ -5,16 +5,17 @@
 #include <IO/WriteBufferValidUTF8.h>
 #include <DataStreams/JSONRowOutputStream.h>
 
-
 namespace DB
 {
+
+class FormatSettingsJSON;
 
 /** The stream for outputting data in the JSONCompact format.
   */
 class JSONCompactRowOutputStream : public JSONRowOutputStream
 {
 public:
-    JSONCompactRowOutputStream(WriteBuffer & ostr_, const Block & sample_, bool write_statistics_, bool force_quoting_64bit_integers_ = true);
+    JSONCompactRowOutputStream(WriteBuffer & ostr_, const Block & sample_, bool write_statistics_, const FormatSettingsJSON & settings);
 
     void writeField(const IColumn & column, const IDataType & type, size_t row_num) override;
     void writeFieldDelimiter() override;

--- a/dbms/src/DataStreams/JSONEachRowRowInputStream.h
+++ b/dbms/src/DataStreams/JSONEachRowRowInputStream.h
@@ -4,7 +4,6 @@
 #include <DataStreams/IRowInputStream.h>
 #include <Common/HashTable/HashMap.h>
 
-
 namespace DB
 {
 

--- a/dbms/src/DataStreams/JSONEachRowRowOutputStream.cpp
+++ b/dbms/src/DataStreams/JSONEachRowRowOutputStream.cpp
@@ -7,8 +7,8 @@ namespace DB
 {
 
 
-JSONEachRowRowOutputStream::JSONEachRowRowOutputStream(WriteBuffer & ostr_, const Block & sample, bool force_quoting_64bit_integers_)
-    : ostr(ostr_), force_quoting_64bit_integers(force_quoting_64bit_integers_)
+JSONEachRowRowOutputStream::JSONEachRowRowOutputStream(WriteBuffer & ostr_, const Block & sample, const FormatSettingsJSON & settings_)
+    : ostr(ostr_), settings(settings_)
 {
     size_t columns = sample.columns();
     fields.resize(columns);
@@ -25,7 +25,7 @@ void JSONEachRowRowOutputStream::writeField(const IColumn & column, const IDataT
 {
     writeString(fields[field_number], ostr);
     writeChar(':', ostr);
-    type.serializeTextJSON(column, row_num, ostr, force_quoting_64bit_integers);
+    type.serializeTextJSON(column, row_num, ostr, settings);
     ++field_number;
 }
 

--- a/dbms/src/DataStreams/JSONEachRowRowOutputStream.h
+++ b/dbms/src/DataStreams/JSONEachRowRowOutputStream.h
@@ -3,6 +3,7 @@
 #include <Core/Block.h>
 #include <IO/WriteBuffer.h>
 #include <DataStreams/IRowOutputStream.h>
+#include <DataTypes/FormatSettingsJSON.h>
 
 
 namespace DB
@@ -14,7 +15,7 @@ namespace DB
 class JSONEachRowRowOutputStream : public IRowOutputStream
 {
 public:
-    JSONEachRowRowOutputStream(WriteBuffer & ostr_, const Block & sample, bool force_quoting_64bit_integers_ = true);
+    JSONEachRowRowOutputStream(WriteBuffer & ostr_, const Block & sample, const FormatSettingsJSON & settings);
 
     void writeField(const IColumn & column, const IDataType & type, size_t row_num) override;
     void writeFieldDelimiter() override;
@@ -31,6 +32,8 @@ private:
     size_t field_number = 0;
     Names fields;
     bool force_quoting_64bit_integers;
+
+    FormatSettingsJSON settings;
 };
 
 }

--- a/dbms/src/DataStreams/JSONRowOutputStream.cpp
+++ b/dbms/src/DataStreams/JSONRowOutputStream.cpp
@@ -6,9 +6,8 @@
 namespace DB
 {
 
-
-JSONRowOutputStream::JSONRowOutputStream(WriteBuffer & ostr_, const Block & sample_, bool write_statistics_, bool force_quoting_64bit_integers_)
-    : dst_ostr(ostr_), write_statistics(write_statistics_), force_quoting_64bit_integers(force_quoting_64bit_integers_)
+JSONRowOutputStream::JSONRowOutputStream(WriteBuffer & ostr_, const Block & sample_, bool write_statistics_, const FormatSettingsJSON & settings_)
+    : dst_ostr(ostr_), write_statistics(write_statistics_), settings(settings_)
 {
     NamesAndTypesList columns(sample_.getColumnsList());
     fields.assign(columns.begin(), columns.end());
@@ -72,7 +71,7 @@ void JSONRowOutputStream::writeField(const IColumn & column, const IDataType & t
     writeCString("\t\t\t", *ostr);
     writeString(fields[field_number].name, *ostr);
     writeCString(": ", *ostr);
-    type.serializeTextJSON(column, row_num, *ostr, force_quoting_64bit_integers);
+    type.serializeTextJSON(column, row_num, *ostr, settings);
     ++field_number;
 }
 
@@ -152,7 +151,7 @@ void JSONRowOutputStream::writeTotals()
             writeCString("\t\t", *ostr);
             writeJSONString(column.name, *ostr);
             writeCString(": ", *ostr);
-            column.type->serializeTextJSON(*column.column.get(), 0, *ostr, force_quoting_64bit_integers);
+            column.type->serializeTextJSON(*column.column.get(), 0, *ostr, settings);
         }
 
         writeChar('\n', *ostr);
@@ -161,7 +160,7 @@ void JSONRowOutputStream::writeTotals()
 }
 
 
-static void writeExtremesElement(const char * title, const Block & extremes, size_t row_num, WriteBuffer & ostr, bool force_quoting_64bit_integers)
+static void writeExtremesElement(const char * title, const Block & extremes, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON & settings)
 {
     writeCString("\t\t\"", ostr);
     writeCString(title, ostr);
@@ -179,7 +178,7 @@ static void writeExtremesElement(const char * title, const Block & extremes, siz
         writeCString("\t\t\t", ostr);
         writeJSONString(column.name, ostr);
         writeCString(": ", ostr);
-        column.type->serializeTextJSON(*column.column.get(), row_num, ostr, force_quoting_64bit_integers);
+        column.type->serializeTextJSON(*column.column.get(), row_num, ostr, settings);
     }
 
     writeChar('\n', ostr);
@@ -195,9 +194,9 @@ void JSONRowOutputStream::writeExtremes()
         writeCString("\t\"extremes\":\n", *ostr);
         writeCString("\t{\n", *ostr);
 
-        writeExtremesElement("min", extremes, 0, *ostr, force_quoting_64bit_integers);
+        writeExtremesElement("min", extremes, 0, *ostr, settings);
         writeCString(",\n", *ostr);
-        writeExtremesElement("max", extremes, 1, *ostr, force_quoting_64bit_integers);
+        writeExtremesElement("max", extremes, 1, *ostr, settings);
 
         writeChar('\n', *ostr);
         writeCString("\t}", *ostr);

--- a/dbms/src/DataStreams/JSONRowOutputStream.h
+++ b/dbms/src/DataStreams/JSONRowOutputStream.h
@@ -5,7 +5,7 @@
 #include <IO/WriteBuffer.h>
 #include <Common/Stopwatch.h>
 #include <DataStreams/IRowOutputStream.h>
-
+#include <DataTypes/FormatSettingsJSON.h>
 
 namespace DB
 {
@@ -16,7 +16,7 @@ class JSONRowOutputStream : public IRowOutputStream
 {
 public:
     JSONRowOutputStream(WriteBuffer & ostr_, const Block & sample_,
-        bool write_statistics_, bool force_quoting_64bit_integers_ = true);
+                        bool write_statistics_, const FormatSettingsJSON & settings_);
 
     void writeField(const IColumn & column, const IDataType & type, size_t row_num) override;
     void writeFieldDelimiter() override;
@@ -68,7 +68,7 @@ protected:
     Progress progress;
     Stopwatch watch;
     bool write_statistics;
-    bool force_quoting_64bit_integers;
+    FormatSettingsJSON settings;
 };
 
 }

--- a/dbms/src/DataTypes/DataTypeAggregateFunction.cpp
+++ b/dbms/src/DataTypes/DataTypeAggregateFunction.cpp
@@ -195,7 +195,7 @@ void DataTypeAggregateFunction::deserializeTextQuoted(IColumn & column, ReadBuff
 }
 
 
-void DataTypeAggregateFunction::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, bool) const
+void DataTypeAggregateFunction::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON &) const
 {
     writeJSONString(serializeToString(function, column, row_num), ostr);
 }

--- a/dbms/src/DataTypes/DataTypeAggregateFunction.h
+++ b/dbms/src/DataTypes/DataTypeAggregateFunction.h
@@ -54,7 +54,7 @@ public:
     void deserializeTextEscaped(IColumn & column, ReadBuffer & istr) const override;
     void serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;
     void deserializeTextQuoted(IColumn & column, ReadBuffer & istr) const override;
-    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, bool) const override;
+    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON &) const override;
     void deserializeTextJSON(IColumn & column, ReadBuffer & istr) const override;
     void serializeTextXML(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;
     void serializeTextCSV(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;

--- a/dbms/src/DataTypes/DataTypeArray.cpp
+++ b/dbms/src/DataTypes/DataTypeArray.cpp
@@ -304,7 +304,7 @@ void DataTypeArray::deserializeTextQuoted(IColumn & column, ReadBuffer & istr) c
 }
 
 
-void DataTypeArray::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, bool force_quoting_64bit_integers) const
+void DataTypeArray::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON & settings) const
 {
     const ColumnArray & column_array = static_cast<const ColumnArray &>(column);
     const ColumnArray::Offsets_t & offsets = column_array.getOffsets();
@@ -319,7 +319,7 @@ void DataTypeArray::serializeTextJSON(const IColumn & column, size_t row_num, Wr
     {
         if (i != offset)
             writeChar(',', ostr);
-        nested->serializeTextJSON(nested_column, i, ostr, force_quoting_64bit_integers);
+        nested->serializeTextJSON(nested_column, i, ostr, settings);
     }
     writeChar(']', ostr);
 }

--- a/dbms/src/DataTypes/DataTypeArray.h
+++ b/dbms/src/DataTypes/DataTypeArray.h
@@ -46,7 +46,7 @@ public:
     void serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;
     void deserializeTextQuoted(IColumn & column, ReadBuffer & istr) const override;
 
-    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, bool) const override;
+    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON & settings) const override;
     void deserializeTextJSON(IColumn & column, ReadBuffer & istr) const override;
 
     void serializeTextXML(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;

--- a/dbms/src/DataTypes/DataTypeDate.cpp
+++ b/dbms/src/DataTypes/DataTypeDate.cpp
@@ -46,7 +46,7 @@ void DataTypeDate::deserializeTextQuoted(IColumn & column, ReadBuffer & istr) co
     static_cast<ColumnUInt16 &>(column).getData().push_back(x);    /// It's important to do this at the end - for exception safety.
 }
 
-void DataTypeDate::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, bool, bool) const
+void DataTypeDate::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON &) const
 {
     writeChar('"', ostr);
     serializeText(column, row_num, ostr);

--- a/dbms/src/DataTypes/DataTypeDate.cpp
+++ b/dbms/src/DataTypes/DataTypeDate.cpp
@@ -46,7 +46,7 @@ void DataTypeDate::deserializeTextQuoted(IColumn & column, ReadBuffer & istr) co
     static_cast<ColumnUInt16 &>(column).getData().push_back(x);    /// It's important to do this at the end - for exception safety.
 }
 
-void DataTypeDate::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, bool) const
+void DataTypeDate::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, bool, bool) const
 {
     writeChar('"', ostr);
     serializeText(column, row_num, ostr);

--- a/dbms/src/DataTypes/DataTypeDate.h
+++ b/dbms/src/DataTypes/DataTypeDate.h
@@ -19,7 +19,7 @@ public:
     void deserializeTextEscaped(IColumn & column, ReadBuffer & istr) const override;
     void serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;
     void deserializeTextQuoted(IColumn & column, ReadBuffer & istr) const override;
-    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, bool) const override;
+    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON &) const override;
     void deserializeTextJSON(IColumn & column, ReadBuffer & istr) const override;
     void serializeTextCSV(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;
     void deserializeTextCSV(IColumn & column, ReadBuffer & istr, const char delimiter) const override;

--- a/dbms/src/DataTypes/DataTypeDateTime.cpp
+++ b/dbms/src/DataTypes/DataTypeDateTime.cpp
@@ -46,7 +46,7 @@ void DataTypeDateTime::deserializeTextQuoted(IColumn & column, ReadBuffer & istr
     static_cast<ColumnUInt32 &>(column).getData().push_back(x);    /// It's important to do this at the end - for exception safety.
 }
 
-void DataTypeDateTime::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, bool) const
+void DataTypeDateTime::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON &) const
 {
     writeChar('"', ostr);
     serializeText(column, row_num, ostr);

--- a/dbms/src/DataTypes/DataTypeDateTime.h
+++ b/dbms/src/DataTypes/DataTypeDateTime.h
@@ -19,7 +19,7 @@ public:
     void deserializeTextEscaped(IColumn & column, ReadBuffer & istr) const override;
     void serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;
     void deserializeTextQuoted(IColumn & column, ReadBuffer & istr) const override;
-    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, bool) const override;
+    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON &) const override;
     void deserializeTextJSON(IColumn & column, ReadBuffer & istr) const override;
     void serializeTextCSV(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;
     void deserializeTextCSV(IColumn & column, ReadBuffer & istr, const char delimiter) const override;

--- a/dbms/src/DataTypes/DataTypeEnum.cpp
+++ b/dbms/src/DataTypes/DataTypeEnum.cpp
@@ -171,7 +171,7 @@ void DataTypeEnum<Type>::deserializeTextQuoted(IColumn & column, ReadBuffer & is
 }
 
 template <typename Type>
-void DataTypeEnum<Type>::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, bool) const
+void DataTypeEnum<Type>::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON &) const
 {
     writeJSONString(getNameForValue(static_cast<const ColumnType &>(column).getData()[row_num]), ostr);
 }

--- a/dbms/src/DataTypes/DataTypeEnum.h
+++ b/dbms/src/DataTypes/DataTypeEnum.h
@@ -93,7 +93,7 @@ public:
     void deserializeTextEscaped(IColumn & column, ReadBuffer & istr) const override;
     void serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;
     void deserializeTextQuoted(IColumn & column, ReadBuffer & istr) const override;
-    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, bool) const override;
+    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON &) const override;
     void deserializeTextJSON(IColumn & column, ReadBuffer & istr) const override;
     void serializeTextXML(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;
     void serializeTextCSV(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;

--- a/dbms/src/DataTypes/DataTypeFixedString.cpp
+++ b/dbms/src/DataTypes/DataTypeFixedString.cpp
@@ -159,7 +159,7 @@ void DataTypeFixedString::deserializeTextQuoted(IColumn & column, ReadBuffer & i
 }
 
 
-void DataTypeFixedString::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, bool) const
+void DataTypeFixedString::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON &) const
 {
     const char * pos = reinterpret_cast<const char *>(&static_cast<const ColumnFixedString &>(column).getChars()[n * row_num]);
     writeJSONString(pos, pos + n, ostr);

--- a/dbms/src/DataTypes/DataTypeFixedString.h
+++ b/dbms/src/DataTypes/DataTypeFixedString.h
@@ -52,7 +52,7 @@ public:
     void serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;
     void deserializeTextQuoted(IColumn & column, ReadBuffer & istr) const override;
 
-    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, bool) const override;
+    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON &) const override;
     void deserializeTextJSON(IColumn & column, ReadBuffer & istr) const override;
 
     void serializeTextXML(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;

--- a/dbms/src/DataTypes/DataTypeNull.cpp
+++ b/dbms/src/DataTypes/DataTypeNull.cpp
@@ -108,8 +108,7 @@ void DataTypeNull::serializeText(const IColumn & column, size_t row_num, WriteBu
     writeCString("NULL", ostr);
 }
 
-void DataTypeNull::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr,
-    bool force_quoting_64bit_integers) const
+void DataTypeNull::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON &) const
 {
     writeCString("null", ostr);
 }

--- a/dbms/src/DataTypes/DataTypeNull.h
+++ b/dbms/src/DataTypes/DataTypeNull.h
@@ -60,7 +60,7 @@ public:
     void serializeTextCSV(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;
     void deserializeTextCSV(IColumn & column, ReadBuffer & istr, const char delimiter) const override;
     void serializeText(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;
-    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, bool force_quoting_64bit_integers) const override;
+    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON &) const override;
     void deserializeTextJSON(IColumn & column, ReadBuffer & istr) const override;
 };
 

--- a/dbms/src/DataTypes/DataTypeNullable.cpp
+++ b/dbms/src/DataTypes/DataTypeNullable.cpp
@@ -192,16 +192,14 @@ void DataTypeNullable::serializeText(const IColumn & column, size_t row_num, Wri
         nested_data_type->serializeText(*col.getNestedColumn(), row_num, ostr);
 }
 
-void DataTypeNullable::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr,
-    bool force_quoting_64bit_integers) const
+void DataTypeNullable::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON & settings) const
 {
     const ColumnNullable & col = static_cast<const ColumnNullable &>(column);
 
     if (col.isNullAt(row_num))
         writeCString("null", ostr);
     else
-        nested_data_type->serializeTextJSON(*col.getNestedColumn(), row_num, ostr,
-            force_quoting_64bit_integers);
+        nested_data_type->serializeTextJSON(*col.getNestedColumn(), row_num, ostr, settings);
 }
 
 void DataTypeNullable::deserializeTextJSON(IColumn & column, ReadBuffer & istr) const

--- a/dbms/src/DataTypes/DataTypeNullable.h
+++ b/dbms/src/DataTypes/DataTypeNullable.h
@@ -45,8 +45,7 @@ public:
       */
     void deserializeTextCSV(IColumn & column, ReadBuffer & istr, const char delimiter) const override;
 
-    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr,
-        bool force_quoting_64bit_integers) const override;
+    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON &) const override;
     void deserializeTextJSON(IColumn & column, ReadBuffer & istr) const override;
     void serializeText(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;
     void serializeTextXML(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;

--- a/dbms/src/DataTypes/DataTypeNumberBase.cpp
+++ b/dbms/src/DataTypes/DataTypeNumberBase.cpp
@@ -4,6 +4,7 @@
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
 #include <Common/NaNUtils.h>
+#include <FormatSettingsJSON.h>
 
 
 namespace DB
@@ -62,9 +63,9 @@ void DataTypeNumberBase<T>::deserializeTextQuoted(IColumn & column, ReadBuffer &
 }
 
 template <typename T>
-void DataTypeNumberBase<T>::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, bool force_quoting_64bit_integers) const
+void DataTypeNumberBase<T>::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON & settings) const
 {
-    const bool need_quote = std::is_integral<T>::value && (sizeof(T) == 8) && force_quoting_64bit_integers;
+    const bool need_quote = std::is_integral<T>::value && (sizeof(T) == 8) && settings.force_quoting_64bit_integers;
 
     if (need_quote)
         writeChar('"', ostr);

--- a/dbms/src/DataTypes/DataTypeNumberBase.cpp
+++ b/dbms/src/DataTypes/DataTypeNumberBase.cpp
@@ -65,7 +65,6 @@ void DataTypeNumberBase<T>::deserializeTextQuoted(IColumn & column, ReadBuffer &
 template <typename T>
 void DataTypeNumberBase<T>::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON & settings) const
 {
-    writeCString(settings.output_format_json_quote_denormals ? "1" : "0", ostr);
     auto x = static_cast<const ColumnVector<T> &>(column).getData()[row_num];
     bool is_finite = isFinite(x);
 

--- a/dbms/src/DataTypes/DataTypeNumberBase.h
+++ b/dbms/src/DataTypes/DataTypeNumberBase.h
@@ -25,7 +25,7 @@ public:
     void deserializeTextEscaped(IColumn & column, ReadBuffer & istr) const override;
     void serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;
     void deserializeTextQuoted(IColumn & column, ReadBuffer & istr) const override;
-    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, bool) const override;
+    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON & settings) const override;
     void deserializeTextJSON(IColumn & column, ReadBuffer & istr) const override;
     void serializeTextCSV(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;
     void deserializeTextCSV(IColumn & column, ReadBuffer & istr, const char delimiter) const override;

--- a/dbms/src/DataTypes/DataTypeString.cpp
+++ b/dbms/src/DataTypes/DataTypeString.cpp
@@ -266,7 +266,7 @@ void DataTypeString::deserializeTextQuoted(IColumn & column, ReadBuffer & istr) 
 }
 
 
-void DataTypeString::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, bool) const
+void DataTypeString::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON &) const
 {
     writeJSONString(static_cast<const ColumnString &>(column).getDataAt(row_num), ostr);
 }

--- a/dbms/src/DataTypes/DataTypeString.h
+++ b/dbms/src/DataTypes/DataTypeString.h
@@ -39,7 +39,7 @@ public:
     void serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;
     void deserializeTextQuoted(IColumn & column, ReadBuffer & istr) const override;
 
-    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, bool) const override;
+    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON &) const override;
     void deserializeTextJSON(IColumn & column, ReadBuffer & istr) const override;
 
     void serializeTextXML(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;

--- a/dbms/src/DataTypes/DataTypeTuple.cpp
+++ b/dbms/src/DataTypes/DataTypeTuple.cpp
@@ -144,14 +144,14 @@ void DataTypeTuple::deserializeTextQuoted(IColumn & column, ReadBuffer & istr) c
     deserializeText(column, istr);
 }
 
-void DataTypeTuple::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, bool force_quoting_64bit_integers) const
+void DataTypeTuple::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON & settings) const
 {
     writeChar('[', ostr);
     for (const auto i : ext::range(0, ext::size(elems)))
     {
         if (i != 0)
             writeChar(',', ostr);
-        elems[i]->serializeTextJSON(extractElementColumn(column, i), row_num, ostr, force_quoting_64bit_integers);
+        elems[i]->serializeTextJSON(extractElementColumn(column, i), row_num, ostr, settings);
     }
     writeChar(']', ostr);
 }

--- a/dbms/src/DataTypes/DataTypeTuple.h
+++ b/dbms/src/DataTypes/DataTypeTuple.h
@@ -31,7 +31,7 @@ public:
     void deserializeTextEscaped(IColumn & column, ReadBuffer & istr) const override;
     void serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;
     void deserializeTextQuoted(IColumn & column, ReadBuffer & istr) const override;
-    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, bool) const override;
+    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON & settings) const override;
     void deserializeTextJSON(IColumn & column, ReadBuffer & istr) const override;
     void serializeTextXML(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;
 

--- a/dbms/src/DataTypes/FormatSettingsJSON.h
+++ b/dbms/src/DataTypes/FormatSettingsJSON.h
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace DB
+{
+
+struct FormatSettingsJSON
+{
+    bool force_quoting_64bit_integers = true;
+    bool output_format_json_quote_denormals = true;
+
+    FormatSettingsJSON() = default;
+
+    FormatSettingsJSON(bool force_quoting_64bit_integers_, bool output_format_json_quote_denormals_)
+        : force_quoting_64bit_integers(force_quoting_64bit_integers_), output_format_json_quote_denormals(output_format_json_quote_denormals_) {}
+};
+
+}

--- a/dbms/src/DataTypes/IDataType.h
+++ b/dbms/src/DataTypes/IDataType.h
@@ -13,6 +13,7 @@ class ReadBuffer;
 class WriteBuffer;
 
 class IDataType;
+class FormatSettingsJSON;
 
 using DataTypePtr = std::shared_ptr<IDataType>;
 using DataTypes = std::vector<DataTypePtr>;
@@ -115,7 +116,7 @@ public:
     /** Text serialization intended for using in JSON format.
       * force_quoting_64bit_integers parameter forces to brace UInt64 and Int64 types into quotes.
       */
-    virtual void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, bool force_quoting_64bit_integers) const = 0;
+    virtual void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON & settings) const = 0;
     virtual void deserializeTextJSON(IColumn & column, ReadBuffer & istr) const = 0;
 
     /** Text serialization for putting into the XML format.

--- a/dbms/src/DataTypes/IDataTypeDummy.h
+++ b/dbms/src/DataTypes/IDataTypeDummy.h
@@ -43,7 +43,7 @@ public:
     void serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override     { throwNoSerialization(); }
     void deserializeTextQuoted(IColumn & column, ReadBuffer & istr) const override                          { throwNoSerialization(); }
 
-    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, bool) const override { throwNoSerialization(); }
+    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettingsJSON &) const override { throwNoSerialization(); }
     void deserializeTextJSON(IColumn & column, ReadBuffer & istr) const override                            { throwNoSerialization(); }
 
     void serializeTextCSV(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override        { throwNoSerialization(); }

--- a/dbms/src/Interpreters/Limits.h
+++ b/dbms/src/Interpreters/Limits.h
@@ -171,6 +171,19 @@ struct Limits
     #undef TRY_SET
     }
 
+    bool tryGet(const String & name, String & value) const
+    {
+    #define TRY_GET(TYPE, NAME, DEFAULT) \
+        else if (name == #NAME) { value = NAME.toString(); return true; }
+
+        if (false) {}
+        APPLY_FOR_LIMITS(TRY_GET)
+
+        return false;
+
+    #undef TRY_GET
+    }
+
 private:
     friend struct Settings;
 

--- a/dbms/src/Interpreters/Settings.cpp
+++ b/dbms/src/Interpreters/Settings.cpp
@@ -69,6 +69,37 @@ void Settings::set(const String & name, const String & value)
 #undef TRY_SET
 }
 
+String Settings::get(const String & name) const
+{
+#define GET(TYPE, NAME, DEFAULT) \
+    else if (name == #NAME) return NAME.toString();
+
+    if (false) {}
+    APPLY_FOR_SETTINGS(GET)
+    else
+    {
+        String value;
+        if (!limits.tryGet(name, value))
+            throw Exception("Unknown setting " + name, ErrorCodes::UNKNOWN_SETTING);
+        return value;
+    }
+
+#undef GET
+}
+
+bool Settings::tryGet(const String & name, String & value) const
+{
+#define TRY_GET(TYPE, NAME, DEFAULT) \
+    else if (name == #NAME) { value = NAME.toString(); return true; }
+
+    if (false) {}
+    APPLY_FOR_SETTINGS(TRY_GET)
+    else
+        return limits.tryGet(name, value);
+
+#undef TRY_GET
+}
+
 /** Set the settings from the profile (in the server configuration, many settings can be listed in one profile).
     * The profile can also be set using the `set` functions, like the `profile` setting.
     */

--- a/dbms/src/Interpreters/Settings.h
+++ b/dbms/src/Interpreters/Settings.h
@@ -233,6 +233,9 @@ struct Settings
     /** Controls quoting of 64-bit integers in JSON output format. */ \
     M(SettingBool, output_format_json_quote_64bit_integers, true) \
     \
+    /** Enables "+nan", "-nan", "+inf", "-inf" outputs in JSON output format. */ \
+    M(SettingBool, output_format_json_quote_denormals, false) \
+    \
     /** Rows limit for Pretty formats. */ \
     M(SettingUInt64, output_format_pretty_max_rows, 10000) \
     \
@@ -301,6 +304,11 @@ struct Settings
 
     /// Set setting by name. Read value in text form from string (for example, from configuration file or from URL parameter).
     void set(const String & name, const String & value);
+
+    /// Get setting by name. Converts value to String.
+    String get(const String & name) const;
+
+    bool tryGet(const String & name, String & value) const;
 
     /** Set multiple settings from "profile" (in server configuration file (users.xml), profiles contain groups of multiple settings).
       * The profile can also be set using the `set` functions, like the profile setting.

--- a/dbms/src/Server/HTTPHandler.cpp
+++ b/dbms/src/Server/HTTPHandler.cpp
@@ -429,6 +429,8 @@ void HTTPHandler::processQuery(
         "session_id", "session_timeout", "session_check"
     };
 
+    const Settings & settings = context.getSettingsRef();
+
     for (auto it = params.begin(); it != params.end(); ++it)
     {
         if (it->first == "database")
@@ -445,18 +447,19 @@ void HTTPHandler::processQuery(
         else
         {
             /// All other query parameters are treated as settings.
+            String value;
+            if (!settings.tryGet(it->first, value) || it->second != value)
+            {
+                if (readonly_before_query == 1)
+                    throw Exception("Cannot override setting (" + it->first + ") in readonly mode", ErrorCodes::READONLY);
 
-            if (readonly_before_query == 1)
-                throw Exception("Cannot override setting (" + it->first + ") in readonly mode", ErrorCodes::READONLY);
+                if (readonly_before_query && it->first == "readonly")
+                    throw Exception("Setting 'readonly' cannot be overrided in readonly mode", ErrorCodes::READONLY);
 
-            if (readonly_before_query && it->first == "readonly")
-                throw Exception("Setting 'readonly' cannot be overrided in readonly mode", ErrorCodes::READONLY);
-
-            context.setSetting(it->first, it->second);
+                context.setSetting(it->first, it->second);
+            }
         }
     }
-
-    const Settings & settings = context.getSettingsRef();
 
     /// HTTP response compression is turned on only if the client signalled that they support it
     /// (using Accept-Encoding header) and 'enable_http_compression' setting is turned on.


### PR DESCRIPTION
#### Added output_format_json_quote_denormals
default
```
$ curl 'http://localhost:8125/?query=SELECT+sqrt(-1),-sqrt(-1),1/0,-1/0+format+JSONEachRow'
{"sqrt(-1)":null,"negate(sqrt(-1))":null,"divide(1, 0)":null,"divide(-1, 0)":null}
```
output_format_json_quote_denormals=1
```
$ curl 'http://localhost:8125/?query=SELECT+sqrt(-1),-sqrt(-1),1/0,-1/0+format+JSONEachRow&output_format_json_quote_denormals=1'
{"sqrt(-1)":"-nan","negate(sqrt(-1))":"nan","divide(1, 0)":"inf","divide(-1, 0)":"-inf"}
```
#### Readonly mode:
changing setting to new value
```
$ curl 'http://localhost:8125/?query=SELECT+toInt64(pow(2,62))+format+JSONEachRow&output_format_json_quote_64bit_integers=0'
Code: 164, e.displayText() = DB::Exception: Cannot override setting (output_format_json_quote_64bit_integers) in readonly mode, e.what() = DB::Exception
```
changing setting to new value
```
$ curl 'http://localhost:8125/?query=SELECT+toInt64(pow(2,62))+format+JSONEachRow&output_format_json_quote_64bit_integers=1'
{"toInt64(pow(2, 62))":"4611686018427387904"}
```