### PR TITLE
Fix system libunwind test

### DIFF
--- a/libs/libdaemon/cmake/find_unwind.cmake
+++ b/libs/libdaemon/cmake/find_unwind.cmake
@@ -13,6 +13,7 @@ if (NOT USE_INTERNAL_UNWIND_LIBRARY)
     set(CMAKE_REQUIRED_LIBRARIES ${UNWIND_LIBRARY})
     check_cxx_source_compiles("
     #include <ucontext.h>
+    #define UNW_LOCAL_ONLY
     #include <libunwind.h>
     int main () {
        ucontext_t context;


### PR DESCRIPTION
`unw_init_local_signal` is provided as:

- `_ULx86_64_init_local_signal` in `libunwind`
- `_Ux86_64_init_local_signal` in `libunwind-generic`

`find_library (UNWIND_LIBRARY unwind)` looks for the first library;
`#define UNW_LOCAL_ONLY` before `#include <libunwind.h>` is necessary to select
this variant.