### PR TITLE
Improve performance for deserialization/serialization of UUID type

### DIFF
--- a/dbms/src/IO/ReadHelpers.h
+++ b/dbms/src/IO/ReadHelpers.h
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <limits>
 #include <algorithm>
+#include <iterator>
 
 #include <type_traits>
 
@@ -559,8 +560,10 @@ struct NullSink
 };
 
 void parseUUID(const UInt8 * src36, UInt8 * dst16);
-void parseUUID(const UInt8 * src36, UInt128 & uuid);
-void formatHex(const UInt8 * __restrict src, UInt8 * __restrict dst, const size_t num_bytes);
+void parseUUID(const UInt8 * src36, std::reverse_iterator<UInt8 *> dst16);
+
+template<class IteratorSrc, class IteratorDst>
+void formatHex(IteratorSrc __restrict src, IteratorDst __restrict dst, const size_t num_bytes);
 
 /// In YYYY-MM-DD format
 inline void readDateText(DayNum_t & date, ReadBuffer & buf)
@@ -606,7 +609,7 @@ inline void readUUIDText(UUID & uuid, ReadBuffer & buf)
         throw Exception(std::string("Cannot parse uuid ") + s, ErrorCodes::CANNOT_PARSE_UUID);
     }
 
-    parseUUID(reinterpret_cast<const UInt8 *>(s), uuid);
+    parseUUID(reinterpret_cast<const UInt8 *>(s), std::reverse_iterator<UInt8 *>(reinterpret_cast<UInt8 *>(&uuid) + 16));
 }
 
 

--- a/dbms/src/IO/WriteHelpers.h
+++ b/dbms/src/IO/WriteHelpers.h
@@ -4,6 +4,7 @@
 #include <cstdio>
 #include <limits>
 #include <algorithm>
+#include <iterator>
 
 #include <common/DateLUT.h>
 #include <common/LocalDate.h>
@@ -474,15 +475,16 @@ inline void writeXMLString(const StringRef & s, WriteBuffer & buf)
     writeXMLString(s.data, s.data + s.size, buf);
 }
 
-void formatHex(const UInt8 * __restrict src, UInt8 * __restrict dst, const size_t num_bytes);
+template <typename IteratorSrc, typename IteratorDst>
+void formatHex(IteratorSrc __restrict src, IteratorDst __restrict dst, const size_t num_bytes);
 void formatUUID(const UInt8 * src16, UInt8 * dst36);
-void formatUUID(const UInt128 & uuid, UInt8 * dst36);
+void formatUUID(std::reverse_iterator<const UInt8 *> dst16, UInt8 * dst36);
 
 inline void writeUUIDText(const UUID & uuid, WriteBuffer & buf)
 {
     char s[36];
 
-    formatUUID(uuid, reinterpret_cast<UInt8 *>(s));
+    formatUUID(std::reverse_iterator<const UInt8 *>(reinterpret_cast<const UInt8 *>(&uuid) + 16), reinterpret_cast<UInt8 *>(s));
     buf.write(s, sizeof(s));
 }
 


### PR DESCRIPTION
As @alexey-milovidov said on this [PR](https://github.com/yandex/ClickHouse/pull/945), the (de)serialization wasn't really efficient because it's used `strtoull` and `snprintf`.

On this version a reverse_iterator is use for handle the byte ordering on big endian architecture, with using the same method as `UUIDNumToString` function.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en