### PR TITLE
Updated docker-compose.yml #1025

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,9 @@ services:
   client:
     image: yandex/clickhouse-client
     build: docker/client
-    network_mode: host
+    command: ['--host', 'server']
   server:
     image: yandex/clickhouse-server
     build: docker/server
-    network_mode: host
+    ports:
+      - 8123:8123


### PR DESCRIPTION
Now you could start a server with `docker-compose up -d server` and connect a client with `docker-compose run client`. Also HTTP-API will be available on the host machine at port `8123`.