### PR TITLE
Avoid many checks of sending parts if sendings fail due to network error.

### DIFF
--- a/dbms/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/dbms/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -24,6 +24,7 @@ namespace ErrorCodes
     extern const int ABORTED;
     extern const int BAD_SIZE_OF_FILE_IN_DATA_PART;
     extern const int TOO_MUCH_SIMULTANEOUS_QUERIES;
+    extern const int CANNOT_WRITE_TO_OSTREAM;
 }
 
 namespace DataPartsExchange
@@ -143,7 +144,7 @@ void Service::processQuery(const Poco::Net::HTMLForm & params, ReadBuffer & body
     }
     catch (const Exception & e)
     {
-        if (e.code() != ErrorCodes::ABORTED)
+        if (e.code() != ErrorCodes::ABORTED && e.code() != ErrorCodes::CANNOT_WRITE_TO_OSTREAM)
             typeid_cast<StorageReplicatedMergeTree &>(*owned_storage).enqueuePartForCheck(part_name);
         throw;
     }


### PR DESCRIPTION
The problem:
* many sendings https://nda.ya.ru/3TJGmJ
* failed sendings -> high disk usage https://nda.ya.ru/3TJGmL