### PR TITLE
Limit read buffer fix

### DIFF
--- a/dbms/src/IO/LimitReadBuffer.h
+++ b/dbms/src/IO/LimitReadBuffer.h
@@ -8,52 +8,47 @@ namespace DB
 
 /** Allows to read from another ReadBuffer no more than the specified number of bytes.
   */
-    class LimitReadBuffer : public ReadBuffer
+class LimitReadBuffer : public ReadBuffer
+{
+private:
+    ReadBuffer & in;
+    size_t limit;
+
+    bool nextImpl() override
     {
-    private:
-        ReadBuffer & in;
-        size_t limit;
+        /// Let underlying buffer calculate read bytes in `next()` call.
+        in.position() = position();
 
-        bool nextImpl() override
-        {
-            /// Let underlying buffer calculate read bytes in `next()` call.
+        if (bytes >= limit || !in.next())
+            return false;
+
+        working_buffer = in.buffer();
+
+        if (limit - count() < working_buffer.size())
+            working_buffer.resize(limit - count());
+
+        return true;
+    }
+
+public:
+    LimitReadBuffer(ReadBuffer & in_, size_t limit_) : ReadBuffer(in_.position(), 0), in(in_), limit(limit_)
+    {
+        working_buffer = in.buffer();
+
+        size_t bytes_in_buffer = working_buffer.end() - position();
+
+        working_buffer = Buffer(position(), working_buffer.end());
+
+        if (limit < bytes_in_buffer)
+            working_buffer.resize(limit);
+    }
+    
+    virtual ~LimitReadBuffer() override
+    {
+        /// Update underlying buffer's position in case when limit wasn't reached.
+        if (working_buffer.size() != 0)
             in.position() = position();
-
-            if (bytes >= limit || !in.next())
-            {
-                return false;
-            }
-
-            position() = in.position();
-
-            working_buffer = in.buffer();
-
-            if (limit - count() < working_buffer.size())
-            {
-                working_buffer.resize(limit - count());
-            }
-
-            return true;
-        }
-
-    public:
-        LimitReadBuffer(ReadBuffer & in_, size_t limit_) : ReadBuffer(in_.position(), 0), in(in_), limit(limit_)
-        {
-            working_buffer = in.buffer();
-
-            size_t bytes_in_buffer = working_buffer.end() - position();
-
-            working_buffer = Buffer(position(), working_buffer.end());
-
-            if (limit < bytes_in_buffer)
-                working_buffer.resize(limit);
-        }
-        virtual ~LimitReadBuffer() override
-        {
-            /// Update underlying buffer's position in case when limit wasn't reached.
-            if (working_buffer.size() != 0)
-                in.position() = position();
-        }
-    };
+    }
+};
 
 }

--- a/dbms/src/IO/LimitReadBuffer.h
+++ b/dbms/src/IO/LimitReadBuffer.h
@@ -31,9 +31,7 @@ private:
     }
 
 public:
-    LimitReadBuffer(ReadBuffer & in_, size_t limit_) : ReadBuffer(nullptr, 0), in(in_), limit(limit_)
-    {
-    }
+    LimitReadBuffer(ReadBuffer & in_, size_t limit_) : ReadBuffer(nullptr, 0), in(in_), limit(limit_) {}
     
     ~LimitReadBuffer() override
     {

--- a/dbms/src/IO/LimitReadBuffer.h
+++ b/dbms/src/IO/LimitReadBuffer.h
@@ -33,17 +33,9 @@ private:
 public:
     LimitReadBuffer(ReadBuffer & in_, size_t limit_) : ReadBuffer(in_.position(), 0), in(in_), limit(limit_)
     {
-        working_buffer = in.buffer();
-
-        size_t bytes_in_buffer = working_buffer.end() - position();
-
-        working_buffer = Buffer(position(), working_buffer.end());
-
-        if (limit < bytes_in_buffer)
-            working_buffer.resize(limit);
     }
     
-    virtual ~LimitReadBuffer() override
+    ~LimitReadBuffer() override
     {
         /// Update underlying buffer's position in case when limit wasn't reached.
         if (working_buffer.size() != 0)

--- a/dbms/src/IO/LimitReadBuffer.h
+++ b/dbms/src/IO/LimitReadBuffer.h
@@ -31,7 +31,7 @@ private:
     }
 
 public:
-    LimitReadBuffer(ReadBuffer & in_, size_t limit_) : ReadBuffer(in_.position(), 0), in(in_), limit(limit_)
+    LimitReadBuffer(ReadBuffer & in_, size_t limit_) : ReadBuffer(nullptr, 0), in(in_), limit(limit_)
     {
     }
     

--- a/dbms/src/IO/LimitReadBuffer.h
+++ b/dbms/src/IO/LimitReadBuffer.h
@@ -8,26 +8,52 @@ namespace DB
 
 /** Lets read from another ReadBuffer no more than the specified number of bytes.
   */
-class LimitReadBuffer : public ReadBuffer
-{
-private:
-    ReadBuffer & in;
-    size_t limit;
-
-    bool nextImpl() override
+    class LimitReadBuffer : public ReadBuffer
     {
-        if (count() >= limit || !in.next())
-            return false;
+    private:
+        ReadBuffer & in;
+        size_t limit;
 
-        working_buffer = in.buffer();
-        if (limit - count() < working_buffer.size())
-            working_buffer.resize(limit - count());
+        bool nextImpl() override
+        {
+            /// Let underlying buffer calculate read bytes in `next()` call.
+            in.position() = position();
 
-        return true;
-    }
+            if (bytes >= limit || !in.next())
+            {
+                return false;
+            }
 
-public:
-    LimitReadBuffer(ReadBuffer & in_, size_t limit_) : ReadBuffer(nullptr, 0), in(in_), limit(limit_) {}
-};
+            position() = in.position();
+
+            working_buffer = in.buffer();
+
+            if (limit - count() < working_buffer.size())
+            {
+                working_buffer.resize(limit - count());
+            }
+
+            return true;
+        }
+
+    public:
+        LimitReadBuffer(ReadBuffer & in_, size_t limit_) : ReadBuffer(in_.position(), 0), in(in_), limit(limit_)
+        {
+            working_buffer = in.buffer();
+
+            size_t bytes_in_buffer = working_buffer.end() - position();
+
+            working_buffer = Buffer(position(), working_buffer.end());
+
+            if (limit < bytes_in_buffer)
+                working_buffer.resize(limit);
+        }
+        virtual ~LimitReadBuffer() override
+        {
+            /// Update underlying buffer's position in case when limit wasn't reached.
+            if (working_buffer.size() != 0)
+                in.position() = position();
+        }
+    };
 
 }

--- a/dbms/src/IO/LimitReadBuffer.h
+++ b/dbms/src/IO/LimitReadBuffer.h
@@ -6,7 +6,7 @@
 namespace DB
 {
 
-/** Lets read from another ReadBuffer no more than the specified number of bytes.
+/** Allows to read from another ReadBuffer no more than the specified number of bytes.
   */
     class LimitReadBuffer : public ReadBuffer
     {

--- a/dbms/src/IO/tests/CMakeLists.txt
+++ b/dbms/src/IO/tests/CMakeLists.txt
@@ -76,3 +76,6 @@ target_link_libraries (zlib_buffers dbms)
 
 add_executable (remote_read_write_buffer remote_read_write_buffer.cpp ${SRCS})
 target_link_libraries (remote_read_write_buffer dbms)
+
+add_executable (limit_read_buffer limit_read_buffer.cpp ${SRCS})
+target_link_libraries (limit_read_buffer dbms)

--- a/dbms/src/IO/tests/limit_read_buffer.cpp
+++ b/dbms/src/IO/tests/limit_read_buffer.cpp
@@ -1,0 +1,132 @@
+#include <sstream>
+
+
+#include <IO/LimitReadBuffer.h>
+#include <IO/copyData.h>
+#include <IO/WriteBufferFromString.h>
+#include <IO/ReadHelpers.h>
+
+
+int main(int argc, char ** argv)
+{
+    try
+    {
+        std::stringstream s;
+
+        {
+            std::string src = "1";
+
+            std::string dst;
+
+            DB::ReadBuffer in(&src[0], src.size(), 0);
+
+            DB::LimitReadBuffer limit_in(in, 1);
+
+            {
+                DB::WriteBufferFromString out(dst);
+
+                DB::copyData(limit_in, out);
+            }
+
+            if (limit_in.count() != 1)
+            {
+                s << "Failed!, incorrect count(): " << limit_in.count();
+                throw DB::Exception(s.str());
+            }
+
+            if (in.count() != limit_in.count())
+            {
+                s << "Failed!, incorrect underlying buffer's count(): " << in.count();
+                throw DB::Exception(s.str());
+            }
+            if (src != dst)
+            {
+                s << "Failed!, incorrect destination value, read: " << dst << ", expected: " << src;
+                throw DB::Exception(s.str());
+            }
+        }
+        {
+            std::string src = "abc";
+            DB::ReadBuffer in(&src[0], src.size(), 0);
+
+            std::string dst;
+
+            {
+                DB::WriteBufferFromString out(dst);
+
+                char x;
+                DB::readChar(x, in);
+
+                DB::LimitReadBuffer limit_in(in, 1);
+
+                DB::copyData(limit_in, out);
+
+
+                if (in.count() != 2)
+                {
+                    s << "Failed!, Incorrect underlying buffer's count: " << in.count() << ", expected: " << 2;
+                    throw DB::Exception(s.str());
+                }
+
+                if (limit_in.count() != 1)
+                {
+                    s << "Failed!, Incorrect count: " << limit_in.count() << ", expected: " << 1;
+                    throw DB::Exception(s.str());
+                }
+            }
+
+            if (dst != "b")
+            {
+                s << "Failed!, Incorrect destination value: " << dst << ", expected 'b'";
+                throw DB::Exception(dst);
+            }
+
+            char y;
+            DB::readChar(y, in);
+            if (y != 'c')
+            {
+                s << "Failed!, Read incorrect value from underlying buffer: " << y << ", expected 'c'";
+                throw DB::Exception(s.str());
+            }
+            while (!in.eof())
+                in.ignore();
+            if (in.count() != 3)
+            {
+                s << "Failed!, Incorrect final count from underlying buffer: " << in.count() << ", expected: 3";
+                throw DB::Exception(s.str());
+            }
+        }
+
+        {
+            std::string src = "abc";
+            DB::ReadBuffer in(&src[0], src.size(), 0);
+
+            {
+                DB::LimitReadBuffer limit_in(in, 1);
+
+                char x;
+                DB::readChar(x, limit_in);
+
+                if (limit_in.count() != 1)
+                {
+                    s << "Failed!, Incorrect count: " << limit_in.count() << ", expected: " << 1;
+                    throw DB::Exception(s.str());
+                }
+            }
+
+            if (in.count() != 1)
+            {
+                s << "Failed!, Incorrect final count from underlying buffer: " << in.count() << ", expected: 1";
+                throw DB::Exception(s.str());
+            }
+        }
+
+    }
+    catch (const DB::Exception & e)
+    {
+        std::cerr << e.what() << ", " << e.displayText() << std::endl;
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This code need to pass added tests.
The changes let use LimitReadBuffer next way:
It's allowed to read no more than limit of bytes.
LimitReadBuffer.count() will return exact number of bytes that was read from.
After LimitReadBuffer is destroyed, underlying ReadBuffer's count() will be updated as if one was read directly from ReadBuffer.
The read from underlying ReadBuffer will continue from where read from LimitReadBuffer has stopped.
