### PR TITLE
Reduce number of places where partitioning by month is assumed

### DIFF
--- a/dbms/src/Interpreters/AsynchronousMetrics.cpp
+++ b/dbms/src/Interpreters/AsynchronousMetrics.cpp
@@ -174,12 +174,12 @@ void AsynchronousMetrics::update()
                             "Cannot get replica delay for table: " + backQuoteIfNeed(db.first) + "." + backQuoteIfNeed(iterator->name()));
                     }
 
-                    calculateMax(max_part_count_for_partition, table_replicated_merge_tree->getData().getMaxPartsCountForMonth());
+                    calculateMax(max_part_count_for_partition, table_replicated_merge_tree->getData().getMaxPartsCountForPartition());
                 }
 
                 if (table_merge_tree)
                 {
-                    calculateMax(max_part_count_for_partition, table_merge_tree->getData().getMaxPartsCountForMonth());
+                    calculateMax(max_part_count_for_partition, table_merge_tree->getData().getMaxPartsCountForPartition());
                 }
             }
         }

--- a/dbms/src/Storages/MergeTree/ActiveDataPartSet.cpp
+++ b/dbms/src/Storages/MergeTree/ActiveDataPartSet.cpp
@@ -25,7 +25,7 @@ void ActiveDataPartSet::addImpl(const String & name)
     if (!getContainingPartImpl(part_info).empty())
         return;
 
-    /// Parts contained in `part` are located contiguously inside `data_parts`, overlapping with the place where the part itself would be inserted.
+    /// Parts contained in `part` are located contiguously in `part_info_to_name`, overlapping with the place where the part itself would be inserted.
     auto it = part_info_to_name.lower_bound(part_info);
 
     /// Let's go left.
@@ -59,7 +59,7 @@ String ActiveDataPartSet::getContainingPart(const String & part_name) const
 
 String ActiveDataPartSet::getContainingPartImpl(const MergeTreePartInfo & part_info) const
 {
-    /// A part can only be covered/overlapped by the previous or next one in `parts`.
+    /// A part can only be covered/overlapped by the previous or next one in `part_info_to_name`.
     auto it = part_info_to_name.lower_bound(part_info);
 
     if (it != part_info_to_name.end())

--- a/dbms/src/Storages/MergeTree/ActiveDataPartSet.h
+++ b/dbms/src/Storages/MergeTree/ActiveDataPartSet.h
@@ -4,7 +4,7 @@
 #include <mutex>
 #include <common/DateLUT.h>
 #include <Core/Types.h>
-#include <set>
+#include <map>
 
 
 namespace DB
@@ -21,16 +21,6 @@ public:
     ActiveDataPartSet() {}
     ActiveDataPartSet(const Strings & names);
 
-    struct Part
-    {
-        String name;
-        MergeTreePartInfo info;
-
-        bool operator<(const Part & rhs) const { return info < rhs.info; }
-
-        bool contains(const Part & rhs) const { return info.contains(rhs.info); }
-    };
-
     void add(const String & name);
 
     /// If not found, returns an empty string.
@@ -41,14 +31,12 @@ public:
     size_t size() const;
 
 private:
-    using Parts = std::set<Part>;
-
     mutable std::mutex mutex;
-    Parts parts;
+    std::map<MergeTreePartInfo, String> part_info_to_name;
 
     /// Do not block mutex.
     void addImpl(const String & name);
-    String getContainingPartImpl(const String & name) const;
+    String getContainingPartImpl(const MergeTreePartInfo & part_info) const;
 };
 
 }

--- a/dbms/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/dbms/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -265,7 +265,8 @@ MergeTreeData::MutableDataPartPtr Fetcher::fetchPartImpl(
 
     assertEOF(in);
 
-    ActiveDataPartSet::parsePartName(part_name, *new_data_part);
+    new_data_part->info = MergeTreePartInfo::fromPartName(part_name);
+    MergeTreePartInfo::parseMinMaxDatesFromPartName(part_name, new_data_part->min_date, new_data_part->max_date);
     new_data_part->modification_time = time(nullptr);
     new_data_part->loadColumns(true);
     new_data_part->loadChecksums(true);

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1483,26 +1483,25 @@ void MergeTreeData::delayInsertIfNeeded(Poco::Event * until)
 
 MergeTreeData::DataPartPtr MergeTreeData::getActiveContainingPart(const String & part_name)
 {
-    MutableDataPartPtr tmp_part(new DataPart(*this));
-    tmp_part->info = MergeTreePartInfo::fromPartName(part_name);
+    auto part_info = MergeTreePartInfo::fromPartName(part_name);
 
     std::lock_guard<std::mutex> lock(data_parts_mutex);
 
     /// The part can be covered only by the previous or the next one in data_parts.
-    auto it = data_parts.lower_bound(tmp_part);
+    auto it = data_parts.lower_bound(part_info);
 
     if (it != data_parts.end())
     {
         if ((*it)->name == part_name)
             return *it;
-        if ((*it)->contains(*tmp_part))
+        if ((*it)->info.contains(part_info))
             return *it;
     }
 
     if (it != data_parts.begin())
     {
         --it;
-        if ((*it)->contains(*tmp_part))
+        if ((*it)->info.contains(part_info))
             return *it;
     }
 
@@ -1511,11 +1510,10 @@ MergeTreeData::DataPartPtr MergeTreeData::getActiveContainingPart(const String &
 
 MergeTreeData::DataPartPtr MergeTreeData::getPartIfExists(const String & part_name)
 {
-    MutableDataPartPtr tmp_part(new DataPart(*this));
-    tmp_part->info = MergeTreePartInfo::fromPartName(part_name);
+    auto part_info = MergeTreePartInfo::fromPartName(part_name);
 
     std::lock_guard<std::mutex> lock(all_data_parts_mutex);
-    auto it = all_data_parts.lower_bound(tmp_part);
+    auto it = all_data_parts.lower_bound(part_info);
     if (it != all_data_parts.end() && (*it)->name == part_name)
         return *it;
 

--- a/dbms/src/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.h
@@ -90,7 +90,16 @@ public:
     using MutableDataPartPtr = std::shared_ptr<DataPart>;
     /// After the DataPart is added to the working set, it cannot be changed.
     using DataPartPtr = std::shared_ptr<const DataPart>;
-    struct DataPartPtrLess { bool operator() (const DataPartPtr & lhs, const DataPartPtr & rhs) const { return lhs->info < rhs->info; } };
+
+    struct DataPartPtrLess
+    {
+        using is_transparent = void;
+
+        bool operator()(const DataPartPtr & lhs, const MergeTreePartInfo & rhs) const { return lhs->info < rhs; }
+        bool operator()(const MergeTreePartInfo & lhs, const DataPartPtr & rhs) const { return lhs < rhs->info; }
+        bool operator()(const DataPartPtr & lhs, const DataPartPtr & rhs) const { return lhs->info < rhs->info; }
+    };
+
     using DataParts = std::set<DataPartPtr, DataPartPtrLess>;
     using DataPartsVector = std::vector<DataPartPtr>;
 

--- a/dbms/src/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.h
@@ -5,7 +5,7 @@
 #include <Interpreters/Context.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Storages/IStorage.h>
-#include <Storages/MergeTree/ActiveDataPartSet.h>
+#include <Storages/MergeTree/MergeTreePartInfo.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/WriteBufferFromFile.h>
@@ -90,7 +90,7 @@ public:
     using MutableDataPartPtr = std::shared_ptr<DataPart>;
     /// After the DataPart is added to the working set, it cannot be changed.
     using DataPartPtr = std::shared_ptr<const DataPart>;
-    struct DataPartPtrLess { bool operator() (const DataPartPtr & lhs, const DataPartPtr & rhs) const { return *lhs < *rhs; } };
+    struct DataPartPtrLess { bool operator() (const DataPartPtr & lhs, const DataPartPtr & rhs) const { return lhs->info < rhs->info; } };
     using DataParts = std::set<DataPartPtr, DataPartPtrLess>;
     using DataPartsVector = std::vector<DataPartPtr>;
 
@@ -294,7 +294,7 @@ public:
     /// Total size of active parts in bytes.
     size_t getTotalActiveSizeInBytes() const;
 
-    size_t getMaxPartsCountForMonth() const;
+    size_t getMaxPartsCountForPartition() const;
 
     /// If the table contains too many active parts, sleep for a while to give them time to merge.
     /// If until is non-null, wake up from the sleep earlier if the event happened.
@@ -404,7 +404,7 @@ public:
     void freezePartition(const std::string & prefix, const String & with_name);
 
     /// Returns the size of partition in bytes.
-    size_t getPartitionSize(const std::string & partition_name) const;
+    size_t getPartitionSize(const std::string & partition_id) const;
 
     struct ColumnSize
     {
@@ -452,12 +452,7 @@ public:
     }
 
     /// For ATTACH/DETACH/DROP/RESHARD PARTITION.
-    static String getMonthName(const Field & partition);
-    static String getMonthName(DayNum_t month);
-    static DayNum_t getMonthDayNum(const Field & partition);
-    static DayNum_t getMonthFromName(const String & month_name);
-    /// Get month from the part name or a sufficient prefix.
-    static DayNum_t getMonthFromPartPrefix(const String & part_prefix);
+    static String getPartitionID(const Field & partition);
 
     Context & context;
     const String date_column_name;

--- a/dbms/src/Storages/MergeTree/MergeTreeDataMerger.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataMerger.cpp
@@ -69,12 +69,12 @@ std::string createMergedPartName(const MergeTreeData::DataPartsVector & parts)
 
     for (const MergeTreeData::DataPartPtr & part : parts)
     {
-        level = std::max(level, part->level);
-        left_date = std::min(left_date, part->left_date);
-        right_date = std::max(right_date, part->right_date);
+        level = std::max(level, part->info.level);
+        left_date = std::min(left_date, part->min_date);
+        right_date = std::max(right_date, part->max_date);
     }
 
-    return ActiveDataPartSet::getPartName(left_date, right_date, parts.front()->left, parts.back()->right, level + 1);
+    return MergeTreePartInfo::getPartName(left_date, right_date, parts.front()->info.min_block, parts.back()->info.max_block, level + 1);
 }
 
 }
@@ -146,28 +146,29 @@ bool MergeTreeDataMerger::selectPartsToMerge(
 
     IMergeSelector::Partitions partitions;
 
-    DayNum_t prev_month = DayNum_t(-1);
+    const String * prev_partition_id = nullptr;
     const MergeTreeData::DataPartPtr * prev_part = nullptr;
     for (const MergeTreeData::DataPartPtr & part : data_parts)
     {
-        DayNum_t month = part->month;
-        if (month != prev_month || (prev_part && !can_merge_callback(*prev_part, part)))
+        const String & partition_id = part->info.partition_id;
+        if (!prev_partition_id || partition_id != *prev_partition_id || (prev_part && !can_merge_callback(*prev_part, part)))
         {
             if (partitions.empty() || !partitions.back().empty())
                 partitions.emplace_back();
-            prev_month = month;
+            prev_partition_id = &partition_id;
         }
 
         IMergeSelector::Part part_info;
         part_info.size = part->size_in_bytes;
         part_info.age = current_time - part->modification_time;
-        part_info.level = part->level;
+        part_info.level = part->info.level;
         part_info.data = &part;
 
         partitions.back().emplace_back(part_info);
 
-        /// Check for consistenty of data parts. If assertion is failed, it requires immediate investigation.
-        if (prev_part && part->month == (*prev_part)->month && part->left < (*prev_part)->right)
+        /// Check for consistency of data parts. If assertion is failed, it requires immediate investigation.
+        if (prev_part && part->info.partition_id == (*prev_part)->info.partition_id
+            && part->info.min_block < (*prev_part)->info.max_block)
         {
             LOG_ERROR(log, "Part " << part->name << " intersects previous part " << (*prev_part)->name);
         }
@@ -206,13 +207,13 @@ bool MergeTreeDataMerger::selectPartsToMerge(
 
         parts.push_back(part);
 
-        level = std::max(level, part->level);
-        left_date = std::min(left_date, part->left_date);
-        right_date = std::max(right_date, part->right_date);
+        level = std::max(level, part->info.level);
+        left_date = std::min(left_date, part->min_date);
+        right_date = std::max(right_date, part->max_date);
     }
 
-    merged_name = ActiveDataPartSet::getPartName(
-        left_date, right_date, parts.front()->left, parts.back()->right, level + 1);
+    merged_name = MergeTreePartInfo::getPartName(
+        left_date, right_date, parts.front()->info.min_block, parts.back()->info.max_block, level + 1);
 
     LOG_DEBUG(log, "Selected " << parts.size() << " parts from " << parts.front()->name << " to " << parts.back()->name);
     return true;
@@ -224,10 +225,10 @@ bool MergeTreeDataMerger::selectAllPartsToMergeWithinPartition(
     String & merged_name,
     size_t available_disk_space,
     const AllowedMergingPredicate & can_merge,
-    DayNum_t partition,
+    const String & partition_id,
     bool final)
 {
-    MergeTreeData::DataPartsVector parts = selectAllPartsFromPartition(partition);
+    MergeTreeData::DataPartsVector parts = selectAllPartsFromPartition(partition_id);
 
     if (parts.empty())
         return false;
@@ -249,9 +250,9 @@ bool MergeTreeDataMerger::selectAllPartsToMergeWithinPartition(
             && !can_merge(*prev_it, *it))
             return false;
 
-        level = std::max(level, (*it)->level);
-        left_date = std::min(left_date, (*it)->left_date);
-        right_date = std::max(right_date, (*it)->right_date);
+        level = std::max(level, (*it)->info.level);
+        left_date = std::min(left_date, (*it)->min_date);
+        right_date = std::max(right_date, (*it)->max_date);
 
         sum_bytes += (*it)->size_in_bytes;
 
@@ -279,15 +280,15 @@ bool MergeTreeDataMerger::selectAllPartsToMergeWithinPartition(
     }
 
     what = parts;
-    merged_name = ActiveDataPartSet::getPartName(
-        left_date, right_date, parts.front()->left, parts.back()->right, level + 1);
+    merged_name = MergeTreePartInfo::getPartName(
+        left_date, right_date, parts.front()->info.min_block, parts.back()->info.max_block, level + 1);
 
     LOG_DEBUG(log, "Selected " << parts.size() << " parts from " << parts.front()->name << " to " << parts.back()->name);
     return true;
 }
 
 
-MergeTreeData::DataPartsVector MergeTreeDataMerger::selectAllPartsFromPartition(DayNum_t partition)
+MergeTreeData::DataPartsVector MergeTreeDataMerger::selectAllPartsFromPartition(const String & partition_id)
 {
     MergeTreeData::DataPartsVector parts_from_partition;
 
@@ -296,11 +297,10 @@ MergeTreeData::DataPartsVector MergeTreeDataMerger::selectAllPartsFromPartition(
     for (MergeTreeData::DataParts::iterator it = data_parts.cbegin(); it != data_parts.cend(); ++it)
     {
         const MergeTreeData::DataPartPtr & current_part = *it;
-        DayNum_t month = current_part->month;
-        if (month != partition)
+        if (current_part->info.partition_id != partition_id)
             continue;
 
-        parts_from_partition.push_back(*it);
+        parts_from_partition.push_back(current_part);
     }
 
     return parts_from_partition;
@@ -516,7 +516,8 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataMerger::mergePartsToTemporaryPart
         gathering_columns, gathering_column_names, merging_columns, merging_column_names);
 
     MergeTreeData::MutableDataPartPtr new_data_part = std::make_shared<MergeTreeData::DataPart>(data);
-    ActiveDataPartSet::parsePartName(merged_name, *new_data_part);
+    new_data_part->info = MergeTreePartInfo::fromPartName(merged_name);
+    MergeTreePartInfo::parseMinMaxDatesFromPartName(merged_name, new_data_part->min_date, new_data_part->max_date);
     new_data_part->name = merged_name;
     new_data_part->relative_path = TMP_PREFIX + merged_name;
     new_data_part->is_temp = true;
@@ -855,8 +856,8 @@ MergeTreeData::PerShardDataParts MergeTreeDataMerger::reshardPartition(
     size_t aio_threshold = data.context.getSettings().min_bytes_to_use_direct_io;
 
     /// Assemble all parts of the partition.
-    DayNum_t month = MergeTreeData::getMonthFromName(job.partition);
-    MergeTreeData::DataPartsVector parts = selectAllPartsFromPartition(month);
+    String partition_id = MergeTreeData::getPartitionID(job.partition);
+    MergeTreeData::DataPartsVector parts = selectAllPartsFromPartition(partition_id);
 
     /// Create a temporary folder name.
     std::string merged_name = createMergedPartName(parts);
@@ -951,12 +952,12 @@ MergeTreeData::PerShardDataParts MergeTreeDataMerger::reshardPartition(
         data_part->name = merged_name;
         data_part->relative_path = "reshard/" + toString(shard_no) + "/tmp_" + merged_name;
         data_part->is_temp = true;
-        data_part->left_date = std::numeric_limits<UInt16>::max();
-        data_part->right_date = std::numeric_limits<UInt16>::min();
-        data_part->month = month;
-        data_part->left = temp_index;
-        data_part->right = temp_index;
-        data_part->level = 0;
+        data_part->min_date = std::numeric_limits<UInt16>::max();
+        data_part->max_date = std::numeric_limits<UInt16>::min();
+        data_part->info.partition_id = partition_id;
+        data_part->info.min_block = temp_index;
+        data_part->info.max_block = temp_index;
+        data_part->info.level = 0;
 
         String new_part_tmp_path = data_part->getFullPath();
         Poco::File(new_part_tmp_path).createDirectories();
@@ -1045,10 +1046,10 @@ MergeTreeData::PerShardDataParts MergeTreeDataMerger::reshardPartition(
             rows_written += block_with_dates.block.rows();
             output_stream->write(block_with_dates.block);
 
-            if (block_with_dates.min_date < data_part->left_date)
-                data_part->left_date = block_with_dates.min_date;
-            if (block_with_dates.max_date > data_part->right_date)
-                data_part->right_date = block_with_dates.max_date;
+            if (block_with_dates.min_date < data_part->min_date)
+                data_part->min_date = block_with_dates.min_date;
+            if (block_with_dates.max_date > data_part->max_date)
+                data_part->max_date = block_with_dates.max_date;
 
             merge_entry->rows_written = merged_stream->getProfileInfo().rows;
             merge_entry->bytes_written_uncompressed = merged_stream->getProfileInfo().bytes;
@@ -1092,8 +1093,8 @@ MergeTreeData::PerShardDataParts MergeTreeDataMerger::reshardPartition(
         size_t shard_no = entry.first;
         MergeTreeData::MutableDataPartPtr & part_from_shard = entry.second;
 
-        std::string new_name = ActiveDataPartSet::getPartName(part_from_shard->left_date,
-            part_from_shard->right_date, part_from_shard->left, part_from_shard->right, part_from_shard->level);
+        std::string new_name = MergeTreePartInfo::getPartName(part_from_shard->min_date,
+            part_from_shard->max_date, part_from_shard->info.min_block, part_from_shard->info.max_block, part_from_shard->info.level);
         std::string new_relative_path = "reshard/" + toString(shard_no) + "/" + new_name;
 
         part_from_shard->renameTo(new_relative_path);

--- a/dbms/src/Storages/MergeTree/MergeTreeDataMerger.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataMerger.h
@@ -58,7 +58,7 @@ public:
         String & merged_name,
         size_t available_disk_space,
         const AllowedMergingPredicate & can_merge,
-        DayNum_t partition,
+        const String & partition_id,
         bool final);
 
     /** Merge the parts.
@@ -93,7 +93,7 @@ public:
 private:
     /** Select all parts belonging to the same partition.
       */
-    MergeTreeData::DataPartsVector selectAllPartsFromPartition(DayNum_t partition);
+    MergeTreeData::DataPartsVector selectAllPartsFromPartition(const String & partition_id);
 
     /** Temporarily cancel merges.
       */

--- a/dbms/src/Storages/MergeTree/MergeTreeDataPart.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataPart.h
@@ -2,7 +2,7 @@
 
 #include <Core/Field.h>
 #include <Core/NamesAndTypes.h>
-#include <Storages/MergeTree/ActiveDataPartSet.h>
+#include <Storages/MergeTree/MergeTreePartInfo.h>
 #include <Columns/IColumn.h>
 #include <shared_mutex>
 
@@ -83,7 +83,7 @@ class MergeTreeData;
 
 
 /// Description of the data part.
-struct MergeTreeDataPart : public ActiveDataPartSet::Part
+struct MergeTreeDataPart
 {
     using Checksums = MergeTreeDataPartChecksums;
     using Checksum = MergeTreeDataPartChecksums::Checksum;
@@ -110,8 +110,16 @@ struct MergeTreeDataPart : public ActiveDataPartSet::Part
     /// Returns part->name with prefixes like 'tmp_<name>'
     String getNameWithPrefix() const;
 
+    bool contains(const MergeTreeDataPart & other) const { return info.contains(other.info); }
+
 
     MergeTreeData & storage;
+
+    String name;
+    MergeTreePartInfo info;
+
+    DayNum_t min_date;
+    DayNum_t max_date;
 
     /// A directory path (realative to storage's path) where part data is actually stored
     /// Examples: 'detached/tmp_fetch_<name>', 'tmp_<name>', '<name>'

--- a/dbms/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -234,13 +234,13 @@ BlockInputStreams MergeTreeDataSelectExecutor::read(
             if (part_values.find(part->name) == part_values.end())
                 continue;
 
-            Field left = static_cast<UInt64>(part->left_date);
-            Field right = static_cast<UInt64>(part->right_date);
+            Field left = static_cast<UInt64>(part->min_date);
+            Field right = static_cast<UInt64>(part->max_date);
 
             if (!date_condition.mayBeTrueInRange(1, &left, &right, data_types_date))
                 continue;
 
-            if (max_block_number_to_read && part->right > max_block_number_to_read)
+            if (max_block_number_to_read && part->info.max_block > max_block_number_to_read)
                 continue;
 
             parts.push_back(part);

--- a/dbms/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -105,7 +105,7 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataWriter::writeTempPart(BlockWithDa
     /// This will generate unique name in scope of current server process.
     Int64 temp_index = data.insert_increment.get();
 
-    String part_name = ActiveDataPartSet::getPartName(DayNum_t(min_date), DayNum_t(max_date), temp_index, temp_index, 0);
+    String part_name = MergeTreePartInfo::getPartName(DayNum_t(min_date), DayNum_t(max_date), temp_index, temp_index, 0);
 
     MergeTreeData::MutableDataPartPtr new_data_part = std::make_shared<MergeTreeData::DataPart>(data);
     new_data_part->name = part_name;
@@ -157,14 +157,14 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataWriter::writeTempPart(BlockWithDa
     out.writeWithPermutation(block, perm_ptr);
     MergeTreeData::DataPart::Checksums checksums = out.writeSuffixAndGetChecksums();
 
-    new_data_part->left_date = DayNum_t(min_date);
-    new_data_part->right_date = DayNum_t(max_date);
-    new_data_part->left = temp_index;
-    new_data_part->right = temp_index;
-    new_data_part->level = 0;
+    new_data_part->info.partition_id = toString(date_lut.toNumYYYYMM(min_month));
+    new_data_part->info.min_block = temp_index;
+    new_data_part->info.max_block = temp_index;
+    new_data_part->info.level = 0;
+    new_data_part->min_date = DayNum_t(min_date);
+    new_data_part->max_date = DayNum_t(max_date);
     new_data_part->size = part_size;
     new_data_part->modification_time = time(nullptr);
-    new_data_part->month = min_month;
     new_data_part->columns = columns;
     new_data_part->checksums = checksums;
     new_data_part->index.swap(out.getIndex());

--- a/dbms/src/Storages/MergeTree/MergeTreeDataWriter.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataWriter.h
@@ -44,7 +44,7 @@ public:
     MergeTreeDataWriter(MergeTreeData & data_) : data(data_), log(&Logger::get(data.getLogName() + " (Writer)")) {}
 
     /** Split the block to blocks, each of them must be written as separate part.
-      *  (split rows by months)
+      *  (split rows by partition)
       * Works deterministically: if same block was passed, function will return same result in same order.
       */
     BlocksWithDateIntervals splitBlockIntoParts(const Block & block);

--- a/dbms/src/Storages/MergeTree/MergeTreePartInfo.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreePartInfo.cpp
@@ -1,0 +1,119 @@
+#include <Storages/MergeTree/MergeTreePartInfo.h>
+#include <IO/ReadBufferFromString.h>
+#include <IO/ReadHelpers.h>
+#include <IO/WriteHelpers.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int BAD_DATA_PART_NAME;
+}
+
+
+MergeTreePartInfo MergeTreePartInfo::fromPartName(const String & dir_name)
+{
+    MergeTreePartInfo part_info;
+    if (!tryParsePartName(dir_name, &part_info))
+        throw Exception("Unexpected part name: " + dir_name, ErrorCodes::BAD_DATA_PART_NAME);
+    return part_info;
+}
+
+bool MergeTreePartInfo::tryParsePartName(const String & dir_name, MergeTreePartInfo * part_info)
+{
+    UInt32 min_yyyymmdd = 0;
+    UInt32 max_yyyymmdd = 0;
+    Int64 min_block_num = 0;
+    Int64 max_block_num = 0;
+    UInt32 level = 0;
+
+    ReadBufferFromString in(dir_name);
+
+    if (!tryReadIntText(min_yyyymmdd, in)
+        || !checkChar('_', in)
+        || !tryReadIntText(max_yyyymmdd, in)
+        || !checkChar('_', in)
+        || !tryReadIntText(min_block_num, in)
+        || !checkChar('_', in)
+        || !tryReadIntText(max_block_num, in)
+        || !checkChar('_', in)
+        || !tryReadIntText(level, in)
+        || !in.eof())
+    {
+        return false;
+    }
+
+    if (part_info)
+    {
+        part_info->partition_id = dir_name.substr(0, strlen("YYYYMM"));
+        part_info->min_block = min_block_num;
+        part_info->max_block = max_block_num;
+        part_info->level = level;
+    }
+
+    return true;
+}
+
+
+void MergeTreePartInfo::parseMinMaxDatesFromPartName(const String & dir_name, DayNum_t & min_date, DayNum_t & max_date)
+{
+    UInt32 min_yyyymmdd = 0;
+    UInt32 max_yyyymmdd = 0;
+
+    ReadBufferFromString in(dir_name);
+
+    if (!tryReadIntText(min_yyyymmdd, in)
+        || !checkChar('_', in)
+        || !tryReadIntText(max_yyyymmdd, in))
+    {
+        throw Exception("Unexpected part name: " + dir_name, ErrorCodes::BAD_DATA_PART_NAME);
+    }
+
+    const auto & date_lut = DateLUT::instance();
+
+    DayNum_t min_month = date_lut.toFirstDayNumOfMonth(min_date);
+    DayNum_t max_month = date_lut.toFirstDayNumOfMonth(max_date);
+
+    if (min_month != max_month)
+        throw Exception("Part name " + dir_name + " contains different months", ErrorCodes::BAD_DATA_PART_NAME);
+
+    min_date = date_lut.YYYYMMDDToDayNum(min_yyyymmdd);
+    max_date = date_lut.YYYYMMDDToDayNum(max_yyyymmdd);
+}
+
+
+bool MergeTreePartInfo::contains(const String & outer_part_name, const String & inner_part_name)
+{
+    MergeTreePartInfo outer = fromPartName(outer_part_name);
+    MergeTreePartInfo inner = fromPartName(inner_part_name);
+    return outer.contains(inner);
+}
+
+
+String MergeTreePartInfo::getPartName(DayNum_t left_date, DayNum_t right_date, Int64 left_id, Int64 right_id, UInt64 level)
+{
+    const auto & date_lut = DateLUT::instance();
+
+    /// Directory name for the part has form: `YYYYMMDD_YYYYMMDD_N_N_L`.
+
+    unsigned left_date_id = date_lut.toNumYYYYMMDD(left_date);
+    unsigned right_date_id = date_lut.toNumYYYYMMDD(right_date);
+
+    WriteBufferFromOwnString wb;
+
+    writeIntText(left_date_id, wb);
+    writeChar('_', wb);
+    writeIntText(right_date_id, wb);
+    writeChar('_', wb);
+    writeIntText(left_id, wb);
+    writeChar('_', wb);
+    writeIntText(right_id, wb);
+    writeChar('_', wb);
+    writeIntText(level, wb);
+
+    return wb.str();
+}
+
+
+}

--- a/dbms/src/Storages/MergeTree/MergeTreePartInfo.h
+++ b/dbms/src/Storages/MergeTree/MergeTreePartInfo.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <Core/Types.h>
+#include <common/DateLUT.h>
+
+namespace DB
+{
+
+/// Information about partition and the range of blocks contained in the part.
+/// Allows determining if parts are disjoint or one part fully contains the other.
+struct MergeTreePartInfo
+{
+    String partition_id;
+    Int64 min_block;
+    Int64 max_block;
+    UInt32 level;
+
+    bool operator<(const MergeTreePartInfo & rhs) const
+    {
+        return std::forward_as_tuple(partition_id, min_block, max_block, level)
+            < std::forward_as_tuple(rhs.partition_id, rhs.min_block, rhs.max_block, rhs.level);
+    }
+
+    /// Contains another part (obtained after merging another part with some other)
+    bool contains(const MergeTreePartInfo & rhs) const
+    {
+        return partition_id == rhs.partition_id        /// Parts for different partitions are not merged
+            && min_block <= rhs.min_block
+            && max_block >= rhs.max_block
+            && level >= rhs.level;
+    }
+
+    static MergeTreePartInfo fromPartName(const String & part_name);
+
+    static bool tryParsePartName(const String & dir_name, MergeTreePartInfo * part_info);
+
+    static void parseMinMaxDatesFromPartName(const String & dir_name, DayNum_t & min_date, DayNum_t & max_date);
+
+    static bool contains(const String & outer_part_name, const String & inner_part_name);
+
+    static String getPartName(DayNum_t left_date, DayNum_t right_date, Int64 left_id, Int64 right_id, UInt64 level);
+};
+
+}

--- a/dbms/src/Storages/MergeTree/MergedBlockOutputStream.h
+++ b/dbms/src/Storages/MergeTree/MergedBlockOutputStream.h
@@ -91,7 +91,7 @@ private:
 
 
 /** To write one part.
-  * The data refers to one month, and are written in one part.
+  * The data refers to one partition, and is written in one part.
   */
 class MergedBlockOutputStream : public IMergedBlockOutputStream
 {

--- a/dbms/src/Storages/MergeTree/ReplicatedMergeTreeBlockOutputStream.cpp
+++ b/dbms/src/Storages/MergeTree/ReplicatedMergeTreeBlockOutputStream.cpp
@@ -166,17 +166,16 @@ void ReplicatedMergeTreeBlockOutputStream::commitPart(zkutil::ZooKeeperPtr & zoo
     /// Obtain incremental block number and lock it. The lock holds our intention to add the block to the filesystem.
     /// We remove the lock just after renaming the part. In case of exception, block number will be marked as abandoned.
 
-    String month_name = toString(DateLUT::instance().toNumYYYYMMDD(DayNum_t(part->left_date)) / 100);
-    AbandonableLockInZooKeeper block_number_lock = storage.allocateBlockNumber(month_name, zookeeper);    /// 2 RTT
-    Int64 part_number = block_number_lock.getNumber();
+    AbandonableLockInZooKeeper block_number_lock = storage.allocateBlockNumber(part->info.partition_id, zookeeper);    /// 2 RTT
+    Int64 block_number = block_number_lock.getNumber();
 
     /// Set part attributes according to part_number. Prepare an entry for log.
 
-    part->left = part_number;
-    part->right = part_number;
-    part->level = 0;
+    part->info.min_block = block_number;
+    part->info.max_block = block_number;
+    part->info.level = 0;
 
-    String part_name = ActiveDataPartSet::getPartName(part->left_date, part->right_date, part->left, part->right, part->level);
+    String part_name = MergeTreePartInfo::getPartName(part->min_date, part->max_date, block_number, block_number, 0);
 
     part->name = part_name;
 
@@ -198,7 +197,7 @@ void ReplicatedMergeTreeBlockOutputStream::commitPart(zkutil::ZooKeeperPtr & zoo
         ops.emplace_back(
             std::make_unique<zkutil::Op::Create>(
                 storage.zookeeper_path + "/blocks/" + block_id,
-                toString(part_number),  /// We will able to know original part number for duplicate blocks, if we want.
+                toString(block_number),  /// We will able to know original part number for duplicate blocks, if we want.
                 acl,
                 zkutil::CreateMode::Persistent));
 
@@ -303,13 +302,13 @@ void ReplicatedMergeTreeBlockOutputStream::commitPart(zkutil::ZooKeeperPtr & zoo
             {
                 /// if the node with the quorum existed, but was quickly removed.
 
-                throw Exception("Unexpected ZNODEEXISTS while adding block " + toString(part_number) + " with ID '" + block_id + "': "
+                throw Exception("Unexpected ZNODEEXISTS while adding block " + toString(block_number) + " with ID '" + block_id + "': "
                     + zkutil::ZooKeeper::error2string(code), ErrorCodes::UNEXPECTED_ZOOKEEPER_ERROR);
             }
         }
         else
         {
-            throw Exception("Unexpected error while adding block " + toString(part_number) + " with ID '" + block_id + "': "
+            throw Exception("Unexpected error while adding block " + toString(block_number) + " with ID '" + block_id + "': "
                 + zkutil::ZooKeeper::error2string(code), ErrorCodes::UNEXPECTED_ZOOKEEPER_ERROR);
         }
     }

--- a/dbms/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.h
+++ b/dbms/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.h
@@ -34,7 +34,7 @@ struct ReplicatedMergeTreeLogEntryData
         EMPTY,          /// Not used.
         GET_PART,       /// Get the part from another replica.
         MERGE_PARTS,    /// Merge the parts.
-        DROP_RANGE,     /// Delete the parts in the specified month in the specified number range.
+        DROP_RANGE,     /// Delete the parts in the specified partition in the specified number range.
         ATTACH_PART,    /// Move a part from the `detached` directory. Obsolete. TODO: Remove after half year.
         CLEAR_COLUMN,   /// Drop specific column from specified partition.
     };

--- a/dbms/src/Storages/MergeTree/ReshardingWorker.cpp
+++ b/dbms/src/Storages/MergeTree/ReshardingWorker.cpp
@@ -174,10 +174,10 @@ std::string computeHashFromPartition(const std::string & data_path, const std::s
 
     for (Poco::DirectoryIterator it(data_path); it != end; ++it)
     {
-        const auto filename = it.name();
-        if (!ActiveDataPartSet::isPartDirectory(filename))
+        MergeTreePartInfo part_info;
+        if (!MergeTreePartInfo::tryParsePartName(it.name(), &part_info))
             continue;
-        if (!startsWith(filename, partition_name))
+        if (part_info.partition_id != partition_name)
             continue;
 
         const auto part_path = it.path().absolute().toString();

--- a/dbms/src/Storages/MergeTree/ShardedPartitionUploader.cpp
+++ b/dbms/src/Storages/MergeTree/ShardedPartitionUploader.cpp
@@ -104,7 +104,8 @@ void Service::processQuery(const Poco::Net::HTMLForm & params, ReadBuffer & body
 
     assertEOF(body);
 
-    ActiveDataPartSet::parsePartName(part_name, *data_part);
+    data_part->info = MergeTreePartInfo::fromPartName(part_name);
+    MergeTreePartInfo::parseMinMaxDatesFromPartName(part_name, data_part->min_date, data_part->max_date);
     data_part->modification_time = time(nullptr);
     data_part->loadColumns(true);
     data_part->loadChecksums(true);

--- a/dbms/src/Storages/StorageMergeTree.cpp
+++ b/dbms/src/Storages/StorageMergeTree.cpp
@@ -12,6 +12,7 @@
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTSelectQuery.h>
 #include <Storages/MergeTree/MergeTreeData.h>
+#include <Storages/MergeTree/ActiveDataPartSet.h>
 
 #include <Poco/DirectoryIterator.h>
 #include <Poco/File.h>
@@ -320,8 +321,7 @@ bool StorageMergeTree::merge(
         }
         else
         {
-            DayNum_t month = MergeTreeData::getMonthFromName(partition);
-            selected = merger.selectAllPartsToMergeWithinPartition(parts, merged_name, disk_space, can_merge, month, final);
+            selected = merger.selectAllPartsToMergeWithinPartition(parts, merged_name, disk_space, can_merge, partition, final);
         }
 
         if (!selected)
@@ -406,7 +406,7 @@ void StorageMergeTree::clearColumnInPartition(const ASTPtr & query, const Field 
     auto lock_read_structure = lockStructure(false);
     auto lock_write_data = lockDataForAlter();
 
-    DayNum_t month = MergeTreeData::getMonthDayNum(partition);
+    String partition_id = MergeTreeData::getPartitionID(partition);
     MergeTreeData::DataParts parts = data.getDataParts();
 
     std::vector<MergeTreeData::AlterDataPartTransactionPtr> transactions;
@@ -428,7 +428,7 @@ void StorageMergeTree::clearColumnInPartition(const ASTPtr & query, const Field 
 
     for (const auto & part : parts)
     {
-        if (part->month != month)
+        if (part->info.partition_id != partition_id)
             continue;
 
         if (auto transaction = data.alterDataPart(part, columns_for_parts, data.primary_expr_ast, false))
@@ -455,14 +455,14 @@ void StorageMergeTree::dropPartition(const ASTPtr & query, const Field & partiti
     /// Waits for completion of merge and does not start new ones.
     auto lock = lockForAlter();
 
-    DayNum_t month = MergeTreeData::getMonthDayNum(partition);
+    String partition_id = MergeTreeData::getPartitionID(partition);
 
     size_t removed_parts = 0;
     MergeTreeData::DataParts parts = data.getDataParts();
 
     for (const auto & part : parts)
     {
-        if (part->month != month)
+        if (part->info.partition_id != partition_id)
             continue;
 
         LOG_DEBUG(log, "Removing part " << part->name);
@@ -485,7 +485,7 @@ void StorageMergeTree::attachPartition(const ASTPtr & query, const Field & field
     if (part)
         partition = field.getType() == Field::Types::UInt64 ? toString(field.get<UInt64>()) : field.safeGet<String>();
     else
-        partition = MergeTreeData::getMonthName(field);
+        partition = MergeTreeData::getPartitionID(field);
 
     String source_dir = "detached/";
 
@@ -502,10 +502,12 @@ void StorageMergeTree::attachPartition(const ASTPtr & query, const Field & field
         for (Poco::DirectoryIterator it = Poco::DirectoryIterator(full_path + source_dir); it != Poco::DirectoryIterator(); ++it)
         {
             String name = it.name();
-            if (!ActiveDataPartSet::isPartDirectory(name))
+            MergeTreePartInfo part_info;
+            if (!MergeTreePartInfo::tryParsePartName(name, &part_info)
+                || part_info.partition_id != partition)
+            {
                 continue;
-            if (name.substr(0, partition.size()) != partition)
-                continue;
+            }
             LOG_DEBUG(log, "Found part " << name);
             active_parts.add(name);
         }

--- a/dbms/src/Storages/StorageReplicatedMergeTree.h
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.h
@@ -131,7 +131,7 @@ public:
 
     BlockOutputStreamPtr write(const ASTPtr & query, const Settings & settings) override;
 
-    bool optimize(const ASTPtr & query, const String & partition, bool final, bool deduplicate, const Settings & settings) override;
+    bool optimize(const ASTPtr & query, const String & partition_id, bool final, bool deduplicate, const Settings & settings) override;
 
     void alter(const AlterCommands & params, const String & database_name, const String & table_name, const Context & context) override;
 
@@ -449,7 +449,7 @@ private:
     /// With the quorum being tracked, add a replica to the quorum for the part.
     void updateQuorum(const String & part_name);
 
-    AbandonableLockInZooKeeper allocateBlockNumber(const String & month_name, zkutil::ZooKeeperPtr & zookeeper);
+    AbandonableLockInZooKeeper allocateBlockNumber(const String & partition_id, zkutil::ZooKeeperPtr & zookeeper);
 
     /** Wait until all replicas, including this, execute the specified action from the log.
       * If replicas are added at the same time, it can not wait the added replica .
@@ -467,8 +467,8 @@ private:
     void assertNotReadonly() const;
 
     /// The name of an imaginary part covering all parts in the specified partition (at the call moment).
-    /// Returns empty string if partition is empy.
-    String getFakePartNameCoveringAllPartsInPartition(const String & month_name);
+    /// Returns empty string if partition is empty.
+    String getFakePartNameCoveringAllPartsInPartition(const String & partition_id);
 
     /// Check for a node in ZK. If it is, remember this information, and then immediately answer true.
     std::unordered_set<std::string> existing_nodes_cache;

--- a/dbms/src/Storages/System/StorageSystemParts.cpp
+++ b/dbms/src/Storages/System/StorageSystemParts.cpp
@@ -201,11 +201,8 @@ BlockInputStreams StorageSystemParts::read(
         /// Finally, we'll go through the list of parts.
         for (const MergeTreeData::DataPartPtr & part : all_parts)
         {
-            LocalDate partition_date {part->month};
-            String partition = toString(partition_date.year()) + (partition_date.month() < 10 ? "0" : "") + toString(partition_date.month());
-
             size_t i = 0;
-            block.getByPosition(i++).column->insert(partition);
+            block.getByPosition(i++).column->insert(part->info.partition_id);
             block.getByPosition(i++).column->insert(part->name);
             block.getByPosition(i++).column->insert(static_cast<UInt64>(active_parts.count(part)));
             block.getByPosition(i++).column->insert(part->size);
@@ -228,11 +225,11 @@ BlockInputStreams StorageSystemParts::read(
             /// For convenience, in returned refcount, don't add references that was due to local variables in this method: all_parts, active_parts.
             block.getByPosition(i++).column->insert(part.use_count() - (active_parts.count(part) ? 2 : 1));
 
-            block.getByPosition(i++).column->insert(static_cast<UInt64>(part->left_date));
-            block.getByPosition(i++).column->insert(static_cast<UInt64>(part->right_date));
-            block.getByPosition(i++).column->insert(part->left);
-            block.getByPosition(i++).column->insert(part->right);
-            block.getByPosition(i++).column->insert(static_cast<UInt64>(part->level));
+            block.getByPosition(i++).column->insert(static_cast<UInt64>(part->min_date));
+            block.getByPosition(i++).column->insert(static_cast<UInt64>(part->max_date));
+            block.getByPosition(i++).column->insert(part->info.min_block);
+            block.getByPosition(i++).column->insert(part->info.max_block);
+            block.getByPosition(i++).column->insert(static_cast<UInt64>(part->info.level));
             block.getByPosition(i++).column->insert(part->getIndexSizeInBytes());
             block.getByPosition(i++).column->insert(part->getIndexSizeInAllocatedBytes());
 

--- a/dbms/src/Storages/tests/part_name.cpp
+++ b/dbms/src/Storages/tests/part_name.cpp
@@ -1,5 +1,5 @@
 #include <IO/ReadHelpers.h>
-#include <Storages/MergeTree/ActiveDataPartSet.h>
+#include <Storages/MergeTree/MergeTreePartInfo.h>
 #include <common/LocalDateTime.h>
 
 
@@ -9,7 +9,7 @@ int main(int argc, char ** argv)
 
     for (DayNum_t date = today; DayNum_t(date + 10) > today; --date)
     {
-        std::string name = DB::ActiveDataPartSet::getPartName(date, date, 0, 0, 0);
+        std::string name = DB::MergeTreePartInfo::getPartName(date, date, 0, 0, 0);
         std::cerr << name << '\n';
 
         time_t time = DateLUT::instance().YYYYMMDDToDate(DB::parse<UInt32>(name));


### PR DESCRIPTION
This is the first step towards arbitrary partitioning.
`git grep -i month dbms/src | wc -l` went down from 184 to 83 as a result of this patch :)