### PR TITLE
mysqlxx transaction exception safety

### DIFF
--- a/libs/libmysqlxx/include/mysqlxx/Transaction.h
+++ b/libs/libmysqlxx/include/mysqlxx/Transaction.h
@@ -22,8 +22,14 @@ public:
 
     virtual ~Transaction()
     {
-        if (!finished)
-            rollback();
+        try
+        {
+            if (!finished)
+                rollback();
+        }
+        catch (...)
+        {
+        }
     }
 
     void commit()


### PR DESCRIPTION
Fix terminate on exception and rollback query fail.