### PR TITLE
Fix runtime compilation of groupArray function.

### DIFF
--- a/dbms/src/AggregateFunctions/AggregateFunctionGroupArray.cpp
+++ b/dbms/src/AggregateFunctions/AggregateFunctionGroupArray.cpp
@@ -24,9 +24,9 @@ inline AggregateFunctionPtr createAggregateFunctionGroupArrayImpl(const DataType
         return AggregateFunctionPtr(res);
 
     if (typeid_cast<const DataTypeString *>(argument_type.get()))
-        return std::make_shared<GroupArrayGeneralListImpl<NodeString, has_limit::value>>(std::forward<TArgs>(args)...);
+        return std::make_shared<GroupArrayGeneralListImpl<GroupArrayListNodeString, has_limit::value>>(std::forward<TArgs>(args)...);
 
-    return std::make_shared<GroupArrayGeneralListImpl<NodeGeneral, has_limit::value>>(std::forward<TArgs>(args)...);
+    return std::make_shared<GroupArrayGeneralListImpl<GroupArrayListNodeGeneral, has_limit::value>>(std::forward<TArgs>(args)...);
 };
 
 

--- a/dbms/src/AggregateFunctions/AggregateFunctionGroupArray.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionGroupArray.h
@@ -31,9 +31,6 @@ namespace ErrorCodes
 }
 
 
-namespace
-{
-
 /// A particular case is an implementation for numeric types.
 template <typename T>
 struct GroupArrayNumericData
@@ -146,12 +143,10 @@ public:
 /// General case
 
 
-/// Nodes used to implement linked list for stoarge of groupArray states
-struct NodeString;
-struct NodeGeneral;
+/// Nodes used to implement a linked list for storage of groupArray states
 
 template <typename Node>
-struct NodeBase
+struct GroupArrayListNodeBase
 {
     Node * next;
     UInt64 size; // size of payload
@@ -159,7 +154,7 @@ struct NodeBase
     /// Returns pointer to actual payload
     char * data()
     {
-        static_assert(sizeof(NodeBase) == sizeof(Node));
+        static_assert(sizeof(GroupArrayListNodeBase) == sizeof(Node));
         return reinterpret_cast<char *>(this) + sizeof(Node);
     }
 
@@ -189,9 +184,9 @@ struct NodeBase
     }
 };
 
-struct NodeString : public NodeBase<NodeString>
+struct GroupArrayListNodeString : public GroupArrayListNodeBase<GroupArrayListNodeString>
 {
-    using Node = NodeString;
+    using Node = GroupArrayListNodeString;
 
     /// Create node from string
     static Node * allocate(const IColumn & column, size_t row_num, Arena * arena)
@@ -212,9 +207,9 @@ struct NodeString : public NodeBase<NodeString>
     }
 };
 
-struct NodeGeneral : public NodeBase<NodeGeneral>
+struct GroupArrayListNodeGeneral : public GroupArrayListNodeBase<GroupArrayListNodeGeneral>
 {
-    using Node = NodeGeneral;
+    using Node = GroupArrayListNodeGeneral;
 
     static Node * allocate(const IColumn & column, size_t row_num, Arena * arena)
     {
@@ -267,7 +262,7 @@ public:
     void setParameters(const Array & params) override
     {
         if (!limit_num_elems && !params.empty())
-            throw Exception("This instatintion of " + getName() + "aggregate function doesn't accept any parameters. It is a bug.", ErrorCodes::LOGICAL_ERROR);
+            throw Exception("This instantiation of " + getName() + "aggregate function doesn't accept any parameters. It is a bug.", ErrorCodes::LOGICAL_ERROR);
     }
 
     void setArgument(const DataTypePtr & argument)
@@ -395,7 +390,7 @@ public:
 
         auto & column_data = column_array.getData();
 
-        if (std::is_same<Node, NodeString>::value)
+        if (std::is_same<Node, GroupArrayListNodeString>::value)
         {
             auto & string_offsets = static_cast<ColumnString &>(column_data).getOffsets();
             string_offsets.reserve(string_offsets.size() + data(place).elems);
@@ -414,9 +409,6 @@ public:
         return true;
     }
 };
-
-}
-
 
 #undef AGGREGATE_FUNCTION_GROUP_ARRAY_MAX_ARRAY_SIZE
 

--- a/dbms/src/AggregateFunctions/AggregateFunctionStatistics.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionStatistics.h
@@ -155,12 +155,9 @@ public:
     }
 };
 
-namespace
-{
-
 /** Implementing the varSamp function.
   */
-struct VarSampImpl
+struct AggregateFunctionVarSampImpl
 {
     static constexpr auto name = "varSamp";
 
@@ -175,19 +172,19 @@ struct VarSampImpl
 
 /** Implementing the stddevSamp function.
   */
-struct StdDevSampImpl
+struct AggregateFunctionStdDevSampImpl
 {
     static constexpr auto name = "stddevSamp";
 
     static inline Float64 apply(Float64 m2, UInt64 count)
     {
-        return sqrt(VarSampImpl::apply(m2, count));
+        return sqrt(AggregateFunctionVarSampImpl::apply(m2, count));
     }
 };
 
 /** Implementing the varPop function.
   */
-struct VarPopImpl
+struct AggregateFunctionVarPopImpl
 {
     static constexpr auto name = "varPop";
 
@@ -204,17 +201,15 @@ struct VarPopImpl
 
 /** Implementing the stddevPop function.
   */
-struct StdDevPopImpl
+struct AggregateFunctionStdDevPopImpl
 {
     static constexpr auto name = "stddevPop";
 
     static inline Float64 apply(Float64 m2, UInt64 count)
     {
-        return sqrt(VarPopImpl::apply(m2, count));
+        return sqrt(AggregateFunctionVarPopImpl::apply(m2, count));
     }
 };
-
-}
 
 /** If `compute_marginal_moments` flag is set this class provides the successor
   * CovarianceData support of marginal moments for calculating the correlation.
@@ -423,12 +418,9 @@ public:
     }
 };
 
-namespace
-{
-
 /** Implementing the covarSamp function.
   */
-struct CovarSampImpl
+struct AggregateFunctionCovarSampImpl
 {
     static constexpr auto name = "covarSamp";
 
@@ -443,7 +435,7 @@ struct CovarSampImpl
 
 /** Implementing the covarPop function.
   */
-struct CovarPopImpl
+struct AggregateFunctionCovarPopImpl
 {
     static constexpr auto name = "covarPop";
 
@@ -460,7 +452,7 @@ struct CovarPopImpl
 
 /** `corr` function implementation.
   */
-struct CorrImpl
+struct AggregateFunctionCorrImpl
 {
     static constexpr auto name = "corr";
 
@@ -473,27 +465,25 @@ struct CorrImpl
     }
 };
 
-}
+template<typename T>
+using AggregateFunctionVarSamp = AggregateFunctionVariance<T, AggregateFunctionVarSampImpl>;
 
 template<typename T>
-using AggregateFunctionVarSamp = AggregateFunctionVariance<T, VarSampImpl>;
+using AggregateFunctionStdDevSamp = AggregateFunctionVariance<T, AggregateFunctionStdDevSampImpl>;
 
 template<typename T>
-using AggregateFunctionStdDevSamp = AggregateFunctionVariance<T, StdDevSampImpl>;
+using AggregateFunctionVarPop = AggregateFunctionVariance<T, AggregateFunctionVarPopImpl>;
 
 template<typename T>
-using AggregateFunctionVarPop = AggregateFunctionVariance<T, VarPopImpl>;
-
-template<typename T>
-using AggregateFunctionStdDevPop = AggregateFunctionVariance<T, StdDevPopImpl>;
+using AggregateFunctionStdDevPop = AggregateFunctionVariance<T, AggregateFunctionStdDevPopImpl>;
 
 template<typename T, typename U>
-using AggregateFunctionCovarSamp = AggregateFunctionCovariance<T, U, CovarSampImpl>;
+using AggregateFunctionCovarSamp = AggregateFunctionCovariance<T, U, AggregateFunctionCovarSampImpl>;
 
 template<typename T, typename U>
-using AggregateFunctionCovarPop = AggregateFunctionCovariance<T, U, CovarPopImpl>;
+using AggregateFunctionCovarPop = AggregateFunctionCovariance<T, U, AggregateFunctionCovarPopImpl>;
 
 template<typename T, typename U>
-using AggregateFunctionCorr = AggregateFunctionCovariance<T, U, CorrImpl, true>;
+using AggregateFunctionCorr = AggregateFunctionCovariance<T, U, AggregateFunctionCorrImpl, true>;
 
 }

--- a/dbms/src/AggregateFunctions/IAggregateFunction.h
+++ b/dbms/src/AggregateFunctions/IAggregateFunction.h
@@ -41,6 +41,9 @@ namespace ErrorCodes
   * The data resulting from the aggregation (intermediate computing states) is stored in other objects
   *  (which can be created in some pool),
   *  and IAggregateFunction is the external interface for manipulating them.
+  *
+  * NOTE: If you add a new aggregate function, don't forget to add it to Interpreters/SpecializedAggregator.h
+  *  so that the new function works with runtime compilation.
   */
 class IAggregateFunction
 {

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -356,7 +356,8 @@ void Aggregator::compileIfPossible(AggregatedDataVariants::Type type)
       *  at the end of which `on_ready` callback is called.
       */
     SharedLibraryPtr lib = params.compiler->getOrCount(key, params.min_count_to_compile,
-        "-include " INTERNAL_COMPILER_HEADERS "/dbms/src/Interpreters/SpecializedAggregator.h",
+        "-include " INTERNAL_COMPILER_HEADERS "/dbms/src/Interpreters/SpecializedAggregator.h "
+        "-Wno-unused-function",
         get_code, on_ready);
 
     /// If the result is already ready.

--- a/dbms/src/Interpreters/SpecializedAggregator.h
+++ b/dbms/src/Interpreters/SpecializedAggregator.h
@@ -1,21 +1,30 @@
 #include <Interpreters/Aggregator.h>
 
-#include <AggregateFunctions/AggregateFunctionCount.h>
-#include <AggregateFunctions/AggregateFunctionSum.h>
-#include <AggregateFunctions/AggregateFunctionAvg.h>
-#include <AggregateFunctions/AggregateFunctionMinMaxAny.h>
 #include <AggregateFunctions/AggregateFunctionArgMinMax.h>
+#include <AggregateFunctions/AggregateFunctionArray.h>
+#include <AggregateFunctions/AggregateFunctionAvg.h>
+#include <AggregateFunctions/AggregateFunctionCount.h>
+#include <AggregateFunctions/AggregateFunctionForEach.h>
+#include <AggregateFunctions/AggregateFunctionGroupArray.h>
+#include <AggregateFunctions/AggregateFunctionGroupArrayInsertAt.h>
+#include <AggregateFunctions/AggregateFunctionGroupUniqArray.h>
+#include <AggregateFunctions/AggregateFunctionIf.h>
+#include <AggregateFunctions/AggregateFunctionMerge.h>
+#include <AggregateFunctions/AggregateFunctionMinMaxAny.h>
+#include <AggregateFunctions/AggregateFunctionNull.h>
+#include <AggregateFunctions/AggregateFunctionQuantileDeterministic.h>
+#include <AggregateFunctions/AggregateFunctionQuantileExact.h>
+#include <AggregateFunctions/AggregateFunctionQuantileExactWeighted.h>
+#include <AggregateFunctions/AggregateFunctionQuantile.h>
+#include <AggregateFunctions/AggregateFunctionQuantileTDigest.h>
+#include <AggregateFunctions/AggregateFunctionQuantileTiming.h>
+#include <AggregateFunctions/AggregateFunctionSequenceMatch.h>
+#include <AggregateFunctions/AggregateFunctionState.h>
+#include <AggregateFunctions/AggregateFunctionStatistics.h>
+#include <AggregateFunctions/AggregateFunctionSum.h>
+#include <AggregateFunctions/AggregateFunctionTopK.h>
 #include <AggregateFunctions/AggregateFunctionUniq.h>
 #include <AggregateFunctions/AggregateFunctionUniqUpTo.h>
-#include <AggregateFunctions/AggregateFunctionGroupArray.h>
-#include <AggregateFunctions/AggregateFunctionGroupUniqArray.h>
-#include <AggregateFunctions/AggregateFunctionQuantile.h>
-#include <AggregateFunctions/AggregateFunctionQuantileTiming.h>
-#include <AggregateFunctions/AggregateFunctionIf.h>
-#include <AggregateFunctions/AggregateFunctionArray.h>
-#include <AggregateFunctions/AggregateFunctionState.h>
-#include <AggregateFunctions/AggregateFunctionMerge.h>
-#include <AggregateFunctions/AggregateFunctionNull.h>
 
 
 namespace DB


### PR DESCRIPTION
Demangled symbols from anonymous namespace contain "::(anonymous namespace)::" string
and thus cannot be used with runtime compilation of aggregation functions.