### PR TITLE
Keep config in context to avoid Application singleton usages

### DIFF
--- a/dbms/src/Dictionaries/Embedded/RegionsHierarchies.cpp
+++ b/dbms/src/Dictionaries/Embedded/RegionsHierarchies.cpp
@@ -1,20 +1,19 @@
 #include <Dictionaries/Embedded/RegionsHierarchies.h>
-#include <Poco/DirectoryIterator.h>
-#include <Poco/Util/Application.h>
-#include <Poco/Util/AbstractConfiguration.h>
+
 #include <common/logger_useful.h>
+
+#include <Poco/DirectoryIterator.h>
 
 
 static constexpr auto config_key = "path_to_regions_hierarchy_file";
 
 
-RegionsHierarchies::RegionsHierarchies()
-: RegionsHierarchies(Poco::Util::Application::instance().config().getString(config_key))
+void RegionsHierarchies::reload(const Poco::Util::AbstractConfiguration & config)
 {
+    reload(config.getString(config_key));
 }
 
-
-RegionsHierarchies::RegionsHierarchies(const std::string & path)
+void RegionsHierarchies::reload(const std::string & path)
 {
     Logger * log = &Logger::get("RegionsHierarchies");
 
@@ -47,10 +46,12 @@ RegionsHierarchies::RegionsHierarchies(const std::string & path)
                 std::forward_as_tuple(dir_it->path()));
         }
     }
+
+    reload();
 }
 
 
-bool RegionsHierarchies::isConfigured()
+bool RegionsHierarchies::isConfigured(const Poco::Util::AbstractConfiguration & config)
 {
-    return Poco::Util::Application::instance().config().has(config_key);
+    return config.has(config_key);
 }

--- a/dbms/src/Dictionaries/Embedded/RegionsHierarchies.h
+++ b/dbms/src/Dictionaries/Embedded/RegionsHierarchies.h
@@ -1,7 +1,10 @@
 #pragma once
 
 #include <Dictionaries/Embedded/RegionsHierarchy.h>
+
+#include <Poco/Util/AbstractConfiguration.h>
 #include <Poco/Exception.h>
+
 #include <unordered_map>
 
 
@@ -24,11 +27,11 @@ public:
       * For example, if /opt/geo/regions_hierarchy.txt is specified,
       *  then the /opt/geo/regions_hierarchy_ua.txt file will also be loaded, if any, it will be accessible by the `ua` key.
       */
-    RegionsHierarchies();
-    explicit RegionsHierarchies(const std::string & path_to_regions_hierarchy_file);
+    void reload(const Poco::Util::AbstractConfiguration & config);
+    void reload(const std::string & directory);
 
     /// Has corresponding section in configuration file.
-    static bool isConfigured();
+    static bool isConfigured(const Poco::Util::AbstractConfiguration & config);
 
 
     /** Reloads, if necessary, all hierarchies of regions.

--- a/dbms/src/Dictionaries/Embedded/RegionsHierarchy.cpp
+++ b/dbms/src/Dictionaries/Embedded/RegionsHierarchy.cpp
@@ -12,13 +12,6 @@
 #include <IO/WriteHelpers.h>
 
 
-static constexpr auto config_key = "path_to_regions_hierarchy_file";
-
-
-RegionsHierarchy::RegionsHierarchy()
-{
-    path = Poco::Util::Application::instance().config().getString(config_key);
-}
 
 RegionsHierarchy::RegionsHierarchy(const std::string & path_)
 {

--- a/dbms/src/Dictionaries/Embedded/RegionsHierarchy.h
+++ b/dbms/src/Dictionaries/Embedded/RegionsHierarchy.h
@@ -3,7 +3,6 @@
 #include <vector>
 #include <boost/noncopyable.hpp>
 #include <common/Types.h>
-#include <ext/singleton.h>
 
 
 #define REGION_TYPE_CITY       6
@@ -61,7 +60,6 @@ private:
     std::string path;
 
 public:
-    RegionsHierarchy();
     RegionsHierarchy(const std::string & path_);
 
     /// Reloads, if necessary, the hierarchy of regions. Not threadsafe.
@@ -140,15 +138,5 @@ public:
         if (region >= populations.size())
             return 0;
         return populations[region];
-    }
-};
-
-
-class RegionsHierarchySingleton : public ext::singleton<RegionsHierarchySingleton>, public RegionsHierarchy
-{
-friend class ext::singleton<RegionsHierarchySingleton>;
-protected:
-    RegionsHierarchySingleton()
-    {
     }
 };

--- a/dbms/src/Dictionaries/Embedded/RegionsNames.cpp
+++ b/dbms/src/Dictionaries/Embedded/RegionsNames.cpp
@@ -28,10 +28,9 @@ std::string RegionsNames::dumpSupportedLanguagesNames()
     return res;
 }
 
-void RegionsNames::reload()
+void RegionsNames::reload(const Poco::Util::AbstractConfiguration & config)
 {
-    std::string directory = Poco::Util::Application::instance().config().getString(config_key);
-    reload(directory);
+    reload(config.getString(config_key));
 }
 
 void RegionsNames::reload(const std::string & directory)
@@ -110,7 +109,7 @@ void RegionsNames::reload(const std::string & directory)
 }
 
 
-bool RegionsNames::isConfigured()
+bool RegionsNames::isConfigured(const Poco::Util::AbstractConfiguration & config)
 {
-    return Poco::Util::Application::instance().config().has(config_key);
+    return config.has(config_key);
 }

--- a/dbms/src/Dictionaries/Embedded/RegionsNames.h
+++ b/dbms/src/Dictionaries/Embedded/RegionsNames.h
@@ -1,10 +1,13 @@
 #pragma once
 
-#include <string>
-#include <vector>
+#include <Poco/Util/AbstractConfiguration.h>
 #include <Poco/Exception.h>
+
 #include <common/Types.h>
 #include <common/StringRef.h>
+
+#include <string>
+#include <vector>
 
 
 /** A class that allows you to recognize by region id its text name in one of the supported languages: ru, en, ua, by, kz, tr.
@@ -67,11 +70,11 @@ private:
 public:
     /** Reboot, if necessary, the names of regions.
       */
-    void reload();
+    void reload(const Poco::Util::AbstractConfiguration & config);
     void reload(const std::string & directory);
 
     /// Has corresponding section in configuration file.
-    static bool isConfigured();
+    static bool isConfigured(const Poco::Util::AbstractConfiguration & config);
 
 
     StringRef getRegionName(RegionID region_id, Language language = Language::RU) const

--- a/dbms/src/Dictionaries/Embedded/TechDataHierarchy.cpp
+++ b/dbms/src/Dictionaries/Embedded/TechDataHierarchy.cpp
@@ -10,10 +10,9 @@
 static constexpr auto config_key = "mysql_metrica";
 
 
-void TechDataHierarchy::reload()
+void TechDataHierarchy::reload(const Poco::Util::AbstractConfiguration & config)
 {
     Logger * log = &Logger::get("TechDataHierarchy");
-
     LOG_DEBUG(log, "Loading tech data hierarchy.");
 
     mysqlxx::PoolWithFailover pool(config_key);
@@ -53,9 +52,9 @@ void TechDataHierarchy::reload()
 }
 
 
-bool TechDataHierarchy::isConfigured()
+bool TechDataHierarchy::isConfigured(const Poco::Util::AbstractConfiguration & config)
 {
-    return Poco::Util::Application::instance().config().has(config_key);
+    return config.has(config_key);
 }
 
 #endif

--- a/dbms/src/Dictionaries/Embedded/TechDataHierarchy.h
+++ b/dbms/src/Dictionaries/Embedded/TechDataHierarchy.h
@@ -1,7 +1,11 @@
 #pragma once
 
-#include <ext/singleton.h>
+#include <Poco/Util/AbstractConfiguration.h>
+#include <Poco/Exception.h>
+
 #include <common/Types.h>
+
+#include <ext/singleton.h>
 
 
 /** @brief Class that lets you know if a search engine or operating system belongs
@@ -15,10 +19,10 @@ private:
     UInt8 se_parent[256] {};
 
 public:
-    void reload();
+    void reload(const Poco::Util::AbstractConfiguration & config);
 
     /// Has corresponding section in configuration file.
-    static bool isConfigured();
+    static bool isConfigured(const Poco::Util::AbstractConfiguration & config);
 
 
     /// The "belongs" relation.

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -104,6 +104,8 @@ struct ContextShared
     String path;                                            /// Path to the data directory, with a slash at the end.
     String tmp_path;                                        /// The path to the temporary files that occur when processing the request.
     String flags_path;                                      /// Path to the directory with some control flags for server maintenance.
+    ConfigurationPtr config;                                /// Global configuration settings.
+
     Databases databases;                                    /// List of databases and tables in them.
     FormatFactory format_factory;                           /// Formats.
     mutable std::shared_ptr<EmbeddedDictionaries> embedded_dictionaries;    /// Metrica's dictionaeis. Have lazy initialization.
@@ -483,6 +485,23 @@ void Context::setFlagsPath(const String & path)
     shared->flags_path = path;
 }
 
+void Context::setConfig(const ConfigurationPtr & config)
+{
+    auto lock = getLock();
+    shared->config = config;
+}
+
+ConfigurationPtr Context::getConfig() const
+{
+    auto lock = getLock();
+    return shared->config;
+}
+
+Poco::Util::AbstractConfiguration & Context::getConfigRef() const
+{
+    auto lock = getLock();
+    return shared->config ? *shared->config : Poco::Util::Application::instance().config();
+}
 
 void Context::setUsersConfig(const ConfigurationPtr & config)
 {
@@ -497,7 +516,6 @@ ConfigurationPtr Context::getUsersConfig()
     auto lock = getLock();
     return shared->users_config;
 }
-
 
 void Context::calculateUserSettings()
 {
@@ -1020,7 +1038,7 @@ const EmbeddedDictionaries & Context::getEmbeddedDictionariesImpl(const bool thr
     std::lock_guard<std::mutex> lock(shared->embedded_dictionaries_mutex);
 
     if (!shared->embedded_dictionaries)
-        shared->embedded_dictionaries = std::make_shared<EmbeddedDictionaries>(throw_on_error);
+        shared->embedded_dictionaries = std::make_shared<EmbeddedDictionaries>(*this->global_context, throw_on_error);
 
     return *shared->embedded_dictionaries;
 }
@@ -1207,7 +1225,10 @@ std::pair<String, UInt16> Context::getInterserverIOAddress() const
 
 UInt16 Context::getTCPPort() const
 {
-    return Poco::Util::Application::instance().config().getInt("tcp_port");
+    auto lock = getLock();
+
+    auto & config = getConfigRef();
+    return config.getInt("tcp_port");
 }
 
 
@@ -1234,7 +1255,7 @@ Clusters & Context::getClusters() const
         std::lock_guard<std::mutex> lock(shared->clusters_mutex);
         if (!shared->clusters)
         {
-            auto & config = shared->clusters_config ? *shared->clusters_config : Poco::Util::Application::instance().config();
+            auto & config = shared->clusters_config ? *shared->clusters_config : getConfigRef();
             shared->clusters = std::make_unique<Clusters>(config, settings);
         }
     }
@@ -1280,7 +1301,7 @@ QueryLog & Context::getQueryLog()
         if (!global_context)
             throw Exception("Logical error: no global context for query log", ErrorCodes::LOGICAL_ERROR);
 
-        auto & config = Poco::Util::Application::instance().config();
+        auto & config = getConfigRef();
 
         String database = config.getString("query_log.database", "system");
         String table = config.getString("query_log.table", "query_log");
@@ -1299,7 +1320,7 @@ PartLog * Context::getPartLog(const String & database, const String & table)
 {
     auto lock = getLock();
 
-    auto & config = Poco::Util::Application::instance().config();
+    auto & config = getConfigRef();
     if (!config.has("part_log"))
         return nullptr;
 
@@ -1340,7 +1361,7 @@ CompressionMethod Context::chooseCompressionMethod(size_t part_size, double part
     if (!shared->compression_method_selector)
     {
         constexpr auto config_name = "compression";
-        auto & config = Poco::Util::Application::instance().config();
+        auto & config = getConfigRef();
 
         if (config.has(config_name))
             shared->compression_method_selector = std::make_unique<CompressionMethodSelector>(config, "compression");
@@ -1358,7 +1379,7 @@ const MergeTreeSettings & Context::getMergeTreeSettings()
 
     if (!shared->merge_tree_settings)
     {
-        auto & config = Poco::Util::Application::instance().config();
+        auto & config = getConfigRef();
         shared->merge_tree_settings = std::make_unique<MergeTreeSettings>();
         shared->merge_tree_settings->loadFromConfig("merge_tree", config);
     }

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -128,12 +128,16 @@ public:
 
     using ConfigurationPtr = Poco::AutoPtr<Poco::Util::AbstractConfiguration>;
 
+    /// Global application configuration settings.
+    void setConfig(const ConfigurationPtr & config);
+    ConfigurationPtr getConfig() const;
+    Poco::Util::AbstractConfiguration & getConfigRef() const;
+
     /** Take the list of users, quotas and configuration profiles from this config.
       * The list of users is completely replaced.
       * The accumulated quota values are not reset if the quota is not deleted.
       */
     void setUsersConfig(const ConfigurationPtr & config);
-
     ConfigurationPtr getUsersConfig();
 
     /// Must be called before getClientInfo.

--- a/dbms/src/Interpreters/EmbeddedDictionaries.h
+++ b/dbms/src/Interpreters/EmbeddedDictionaries.h
@@ -23,6 +23,9 @@ class Context;
 class EmbeddedDictionaries
 {
 private:
+    Poco::Logger * log;
+    Context & context;
+
     MultiVersion<RegionsHierarchies> regions_hierarchies;
     MultiVersion<TechDataHierarchy> tech_data_hierarchy;
     MultiVersion<RegionsNames> regions_names;
@@ -34,8 +37,6 @@ private:
 
     std::thread reloading_thread;
     Poco::Event destroy;
-
-    Poco::Logger * log;
 
 
     void handleException(const bool throw_on_error) const;
@@ -54,9 +55,7 @@ private:
 
 public:
     /// Every reload_period seconds directories are updated inside a separate thread.
-    EmbeddedDictionaries(const bool throw_on_error, const int reload_period_);
-
-    EmbeddedDictionaries(const bool throw_on_error);
+    EmbeddedDictionaries(Context & context, const bool throw_on_error);
 
     ~EmbeddedDictionaries();
 

--- a/dbms/src/Interpreters/ExternalDictionaries.cpp
+++ b/dbms/src/Interpreters/ExternalDictionaries.cpp
@@ -1,4 +1,5 @@
 #include <Interpreters/ExternalDictionaries.h>
+#include <Interpreters/Context.h>
 #include <Dictionaries/DictionaryFactory.h>
 #include <Dictionaries/DictionaryStructure.h>
 #include <Dictionaries/IDictionarySource.h>
@@ -95,7 +96,7 @@ std::set<std::string> getDictionariesConfigPaths(const Poco::Util::AbstractConfi
 
 void ExternalDictionaries::reloadImpl(const bool throw_on_error)
 {
-    const auto config_paths = getDictionariesConfigPaths(Poco::Util::Application::instance().config());
+    const auto config_paths = getDictionariesConfigPaths(context.getConfigRef());
 
     for (const auto & config_path : config_paths)
     {

--- a/dbms/src/Server/HTTPHandler.cpp
+++ b/dbms/src/Server/HTTPHandler.cpp
@@ -130,9 +130,10 @@ static Poco::Net::HTTPResponse::HTTPStatus exceptionCodeToHTTPStatus(int excepti
 }
 
 
-static std::chrono::steady_clock::duration parseSessionTimeout(const HTMLForm & params)
+static std::chrono::steady_clock::duration parseSessionTimeout(
+    const Poco::Util::AbstractConfiguration & config,
+    const HTMLForm & params)
 {
-    const auto & config = Poco::Util::Application::instance().config();
     unsigned session_timeout = config.getInt("default_session_timeout", 60);
 
     if (params.has("session_timeout"))
@@ -245,7 +246,7 @@ void HTTPHandler::processQuery(
     if (session_is_set)
     {
         session_id = params.get("session_id");
-        session_timeout = parseSessionTimeout(params);
+        session_timeout = parseSessionTimeout(server.config(), params);
         std::string session_check = params.get("session_check", "");
 
         session = context.acquireSession(session_id, session_timeout, session_check == "1");

--- a/dbms/src/Server/MetricsTransmitter.cpp
+++ b/dbms/src/Server/MetricsTransmitter.cpp
@@ -1,15 +1,21 @@
 #include "MetricsTransmitter.h"
 
-#include <Poco/Util/Application.h>
-#include <Poco/Util/LayeredConfiguration.h>
-#include <daemon/BaseDaemon.h>
+#include <Interpreters/AsynchronousMetrics.h>
+#include <Interpreters/Context.h>
+
 #include <Common/CurrentMetrics.h>
 #include <Common/Exception.h>
 #include <Common/setThreadName.h>
-#include <Interpreters/AsynchronousMetrics.h>
+
+#include <daemon/BaseDaemon.h>
+
+#include <Poco/Util/Application.h>
+#include <Poco/Util/LayeredConfiguration.h>
+
 
 namespace DB
 {
+
 MetricsTransmitter::~MetricsTransmitter()
 {
     try
@@ -32,7 +38,7 @@ MetricsTransmitter::~MetricsTransmitter()
 
 void MetricsTransmitter::run()
 {
-    auto & config = Poco::Util::Application::instance().config();
+    const auto & config = context.getConfigRef();
     auto interval = config.getInt(config_name + ".interval", 60);
 
     const std::string thread_name = "MericsTrns " + std::to_string(interval) + "s";
@@ -63,7 +69,7 @@ void MetricsTransmitter::run()
 
 void MetricsTransmitter::transmit(std::vector<ProfileEvents::Count> & prev_counters)
 {
-    auto & config = Poco::Util::Application::instance().config();
+    const auto & config = context.getConfigRef();
     auto async_metrics_values = async_metrics.getValues();
 
     GraphiteWriter::KeyValueVector<ssize_t> key_vals{};

--- a/dbms/src/Server/MetricsTransmitter.h
+++ b/dbms/src/Server/MetricsTransmitter.h
@@ -10,7 +10,10 @@
 
 namespace DB
 {
+
 class AsynchronousMetrics;
+class Context;
+
 
 /**    Automatically sends
   * - difference of ProfileEvents;
@@ -21,8 +24,12 @@ class AsynchronousMetrics;
 class MetricsTransmitter
 {
 public:
-    MetricsTransmitter(const AsynchronousMetrics & async_metrics, const std::string & config_name)
-        : async_metrics{async_metrics}, config_name{config_name}
+    MetricsTransmitter(Context & context_,
+                       const AsynchronousMetrics & async_metrics_,
+                       const std::string & config_name_)
+        : context(context_)
+        , async_metrics(async_metrics_)
+        , config_name(config_name_)
     {
     }
     ~MetricsTransmitter();
@@ -30,6 +37,8 @@ public:
 private:
     void run();
     void transmit(std::vector<ProfileEvents::Count> & prev_counters);
+
+    Context & context;
 
     const AsynchronousMetrics & async_metrics;
     const std::string config_name;
@@ -43,4 +52,5 @@ private:
     static constexpr auto current_metrics_path_prefix = "ClickHouse.Metrics.";
     static constexpr auto asynchronous_metrics_path_prefix = "ClickHouse.AsynchronousMetrics.";
 };
+
 }

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -530,7 +530,8 @@ int Server::main(const std::vector<std::string> & args)
         std::vector<std::unique_ptr<MetricsTransmitter>> metrics_transmitters;
         for (const auto & graphite_key : DB::getMultipleKeysFromConfig(config(), "", "graphite"))
         {
-            metrics_transmitters.emplace_back(std::make_unique<MetricsTransmitter>(async_metrics, graphite_key));
+            metrics_transmitters.emplace_back(std::make_unique<MetricsTransmitter>(
+                *global_context, async_metrics, graphite_key));
         }
 
         SessionCleaner session_cleaner(*global_context);

--- a/dbms/src/Storages/StorageFactory.cpp
+++ b/dbms/src/Storages/StorageFactory.cpp
@@ -195,7 +195,7 @@ static void appendGraphitePattern(const Context & context,
 static void setGraphitePatternsFromConfig(const Context & context,
     const String & config_element, Graphite::Params & params)
 {
-    const Poco::Util::AbstractConfiguration & config = Poco::Util::Application::instance().config();
+    const auto & config = context.getConfigRef();
 
     if (!config.has(config_element))
         throw Exception("No '" + config_element + "' element in configuration file",


### PR DESCRIPTION
In a hosted scenario I have no Application instance available.
So I would like to rework code to use Context::getConfigRef() instead of Application::instance()::config()
Also I have found that isLocalAddress function uses tcp_port setting - it looks strange to me.
