### PR TITLE
ZooKeeper: use seeded random device to shuffle node list #1149

### DIFF
--- a/dbms/src/Common/ZooKeeper/ZooKeeper.cpp
+++ b/dbms/src/Common/ZooKeeper/ZooKeeper.cpp
@@ -116,7 +116,9 @@ struct ZooKeeperArgs
         }
 
         /// Shuffle the hosts to distribute the load among ZooKeeper nodes.
-        std::random_shuffle(hosts_strings.begin(), hosts_strings.end());
+        std::random_device rd;
+        std::mt19937 g(rd());
+        std::shuffle(hosts_strings.begin(), hosts_strings.end(), g);
 
         for (auto & host : hosts_strings)
         {


### PR DESCRIPTION
std::random_shuffle() may or may not use std::rand() which isn't
seeded, and since configuration parsing runs predictably as one
of the first things after server startup, the list of ZK nodes
is shuffled the same way on all replicas.