### PR TITLE
Add clang to Build-Depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,6 +3,7 @@ Priority: optional
 Maintainer: Alexey Milovidov <milovidov@yandex-team.ru>
 Build-Depends: debhelper (>= 9),
                cmake,
+               clang,
                gcc-6, g++-6,
                default-libmysqlclient-dev | libmysqlclient-dev,
                libicu-dev,


### PR DESCRIPTION
It is used by debian/copy_clang_binaries.sh