### PR TITLE
Add ssl options for MySQL connection  #1217

### DIFF
--- a/libs/libmysqlxx/include/mysqlxx/Connection.h
+++ b/libs/libmysqlxx/include/mysqlxx/Connection.h
@@ -43,6 +43,12 @@ private:
   * Or using socket:
   *        mysqlxx::Connection connection("Test", "localhost", "root", "qwerty", 0, "/path/to/socket/file.sock");
   *
+  * Or using custom certificate authority file:
+  *        mysqlxx::Connection connection("Test", "localhost", "root", "qwerty", 3306, "/path/to/ca/file.pem");
+  *
+  * Or using custom certificate and key file:
+  *        mysqlxx::Connection connection("Test", "localhost", "root", "qwerty", 3306, "", "/path/to/cert/file.pem", "/path/to/key/file.pem");
+  *
   * Attention! It's strictly recommended to use connection in thread where it was created.
   * In order to use connection in other thread, you should call MySQL C API function mysql_thread_init() before and
   * mysql_thread_end() after working with it.
@@ -62,6 +68,9 @@ public:
         const char * password = 0,
         unsigned port = 0,
         const char * socket = "",
+        const char * ssl_ca = "",
+        const char * ssl_cert = "",
+        const char * ssl_key = "",
         unsigned timeout = MYSQLXX_DEFAULT_TIMEOUT,
         unsigned rw_timeout = MYSQLXX_DEFAULT_RW_TIMEOUT);
 
@@ -78,6 +87,9 @@ public:
         const char * password,
         unsigned port,
         const char * socket,
+        const char* ssl_ca,
+        const char* ssl_cert,
+        const char* ssl_key,
         unsigned timeout = MYSQLXX_DEFAULT_TIMEOUT,
         unsigned rw_timeout = MYSQLXX_DEFAULT_RW_TIMEOUT);
 
@@ -91,6 +103,9 @@ public:
         std::string password = cfg.getString(config_name + ".password");
         unsigned port = cfg.getInt(config_name + ".port", 0);
         std::string socket = cfg.getString(config_name + ".socket", "");
+        std::string ssl_ca = cfg.getString(config_name + ".ssl_ca", "");
+        std::string ssl_cert = cfg.getString(config_name + ".ssl_cert", "");
+        std::string ssl_key = cfg.getString(config_name + ".ssl_key", "");
 
         unsigned timeout =
             cfg.getInt(config_name + ".connect_timeout",
@@ -102,7 +117,18 @@ public:
                 cfg.getInt("mysql_rw_timeout",
                     MYSQLXX_DEFAULT_RW_TIMEOUT));
 
-        connect(db.c_str(), server.c_str(), user.c_str(), password.c_str(), port, socket.c_str(), timeout, rw_timeout);
+        connect(
+                db.c_str(),
+                server.c_str(),
+                user.c_str(),
+                password.c_str(),
+                port,
+                socket.c_str(),
+                ssl_ca.c_str(),
+                ssl_cert.c_str(),
+                ssl_key.c_str(),
+                timeout,
+                rw_timeout);
     }
 
     /// If MySQL connection was established.

--- a/libs/libmysqlxx/include/mysqlxx/Pool.h
+++ b/libs/libmysqlxx/include/mysqlxx/Pool.h
@@ -231,6 +231,9 @@ private:
     std::string socket;
     unsigned connect_timeout;
     unsigned rw_timeout;
+    std::string ssl_ca;
+    std::string ssl_cert;
+    std::string ssl_key;
 
     /// True if connection was established at least once.
     bool was_successful{false};

--- a/libs/libmysqlxx/src/Connection.cpp
+++ b/libs/libmysqlxx/src/Connection.cpp
@@ -3,6 +3,10 @@
 #include <mysqlxx/Connection.h>
 #include <mysqlxx/Exception.h>
 
+static inline const char* ifNotEmpty(const char* s)
+{
+    return s && *s ? s : nullptr;
+}
 
 namespace mysqlxx
 {
@@ -35,12 +39,15 @@ Connection::Connection(
     const char* password,
     unsigned port,
     const char * socket,
+    const char* ssl_ca,
+    const char* ssl_cert,
+    const char* ssl_key,
     unsigned timeout,
     unsigned rw_timeout)
     : driver(std::make_unique<MYSQL>())
 {
     is_connected = false;
-    connect(db, server, user, password, port, socket, timeout, rw_timeout);
+    connect(db, server, user, password, port, socket, ssl_ca, ssl_cert, ssl_key, timeout, rw_timeout);
 }
 
 Connection::Connection(const std::string & config_name)
@@ -62,6 +69,9 @@ void Connection::connect(const char* db,
     const char* password,
     unsigned port,
     const char * socket,
+    const char* ssl_ca,
+    const char* ssl_cert,
+    const char* ssl_key,
     unsigned timeout,
     unsigned rw_timeout)
 {
@@ -88,7 +98,11 @@ void Connection::connect(const char* db,
     if (mysql_options(driver.get(), MYSQL_OPT_LOCAL_INFILE, nullptr))
         throw ConnectionFailed(errorMessage(driver.get()), mysql_errno(driver.get()));
 
-    if (!mysql_real_connect(driver.get(), server, user, password, db, port, *socket ? socket : nullptr, driver->client_flag))
+    /// Specifies particular ssl key and certificate if it needs
+    if (mysql_ssl_set(driver.get(), ifNotEmpty(ssl_key), ifNotEmpty(ssl_cert), ifNotEmpty(ssl_ca), nullptr, nullptr))
+        throw ConnectionFailed(errorMessage(driver.get()), mysql_errno(driver.get()));
+
+    if (!mysql_real_connect(driver.get(), server, user, password, db, port, ifNotEmpty(socket), driver->client_flag))
         throw ConnectionFailed(errorMessage(driver.get()), mysql_errno(driver.get()));
 
     /// Sets UTF-8 as default encoding.

--- a/libs/libmysqlxx/src/Pool.cpp
+++ b/libs/libmysqlxx/src/Pool.cpp
@@ -56,6 +56,15 @@ Pool::Pool(const Poco::Util::AbstractConfiguration & cfg, const std::string & co
         socket = cfg.has(config_name + ".socket")
             ? cfg.getString(config_name + ".socket")
             : cfg.getString(parent_config_name + ".socket", "");
+        ssl_ca = cfg.has(config_name + ".ssl_ca")
+            ? cfg.getString(config_name + ".ssl_ca")
+            : cfg.getString(parent_config_name + ".ssl_ca", "");
+        ssl_cert = cfg.has(config_name + ".ssl_cert")
+            ? cfg.getString(config_name + ".ssl_cert")
+            : cfg.getString(parent_config_name + ".ssl_cert", "");
+        ssl_key = cfg.has(config_name + ".ssl_key")
+            ? cfg.getString(config_name + ".ssl_key")
+            : cfg.getString(parent_config_name + ".ssl_key", "");
     }
     else
     {
@@ -68,6 +77,9 @@ Pool::Pool(const Poco::Util::AbstractConfiguration & cfg, const std::string & co
 
         port = cfg.getInt(config_name + ".port", 0);
         socket = cfg.getString(config_name + ".socket", "");
+        ssl_ca = cfg.getString(config_name + ".ssl_ca", "");
+        ssl_cert = cfg.getString(config_name + ".ssl_cert", "");
+        ssl_key = cfg.getString(config_name + ".ssl_key", "");
     }
 
     connect_timeout = cfg.getInt(config_name + ".connect_timeout",
@@ -167,13 +179,16 @@ void Pool::Entry::forceConnected() const
         app.logger().information("MYSQL: Reconnecting to " + pool->description);
         data->conn.connect(
             pool->db.c_str(),
-                           pool->server.c_str(),
-                           pool->user.c_str(),
-                           pool->password.c_str(),
-                           pool->port,
-                           pool->socket.c_str(),
-                     pool->connect_timeout,
-                     pool->rw_timeout);
+            pool->server.c_str(),
+            pool->user.c_str(),
+            pool->password.c_str(),
+            pool->port,
+            pool->socket.c_str(),
+            pool->ssl_ca.c_str(),
+            pool->ssl_cert.c_str(),
+            pool->ssl_key.c_str(),
+            pool->connect_timeout,
+            pool->rw_timeout);
     }
     while (!data->conn.ping());
 }
@@ -205,13 +220,16 @@ Pool::Connection * Pool::allocConnection(bool dont_throw_if_failed_first_time)
 
         conn->conn.connect(
             db.c_str(),
-                           server.c_str(),
-                           user.c_str(),
-                           password.c_str(),
-                           port,
-                           socket.c_str(),
-                     connect_timeout,
-                     rw_timeout);
+            server.c_str(),
+            user.c_str(),
+            password.c_str(),
+            port,
+            socket.c_str(),
+            ssl_ca.c_str(),
+            ssl_cert.c_str(),
+            ssl_key.c_str(),
+            connect_timeout,
+            rw_timeout);
     }
     catch (mysqlxx::ConnectionFailed & e)
     {


### PR DESCRIPTION
this patch adds the following options for mysql source in dictionary
 - ssl_ca - path to certificate authority file
 - ssl_cert - path to ssl certificate file
 - ssl_key - path to ssl key file

which can be used to specify particular certificate and key files for mysql connection.

example: 
```xml
  <dictionaries>
        <dictionary>
            <source>
                <mysql>
                    <ssl_cert>/path/to/cert/file.pem<ssl_cert>
                    <ssl_key>/path/to/key/file.pem<ssl_key>
                    ...
                </mysql>
            </source>
            ...
        </dictionary>
  </dictionaries>
```