### PR TITLE
AggregateFunctionTopK: read alphaMap for generic

### DIFF
--- a/dbms/src/AggregateFunctions/AggregateFunctionTopK.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionTopK.h
@@ -197,10 +197,11 @@ public:
         set.resize(reserved);
         set.clear();
 
-        // Specialised here because there's no deserialiser for StringRef
+        // Specialized here because there's no deserialiser for StringRef
         size_t count = 0;
         readVarUInt(count, buf);
-        for (size_t i = 0; i < count; ++i) {
+        for (size_t i = 0; i < count; ++i)
+        {
             auto ref = readStringBinaryInto(*arena, buf);
             UInt64 count, error;
             readVarUInt(count, buf);
@@ -215,7 +216,8 @@ public:
     void addImpl(AggregateDataPtr place, const IColumn & column, size_t row_num, Arena * arena) const
     {
         auto & set = this->data(place).value;
-        if (set.capacity() != reserved) {
+        if (set.capacity() != reserved)
+        {
             set.resize(reserved);
         }
 

--- a/dbms/src/AggregateFunctions/AggregateFunctionTopK.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionTopK.h
@@ -194,8 +194,8 @@ public:
     void deserialize(AggregateDataPtr place, ReadBuffer & buf, Arena * arena) const override
     {
         auto & set = this->data(place).value;
-        set.resize(reserved);
         set.clear();
+        set.resize(reserved);
 
         // Specialized here because there's no deserialiser for StringRef
         size_t count = 0;

--- a/dbms/src/AggregateFunctions/AggregateFunctionTopK.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionTopK.h
@@ -195,7 +195,9 @@ public:
     {
         auto & set = this->data(place).value;
         set.resize(reserved);
+        set.clear();
 
+        // Specialised here because there's no deserialiser for StringRef
         size_t count = 0;
         readVarUInt(count, buf);
         for (size_t i = 0; i < count; ++i) {
@@ -206,6 +208,8 @@ public:
             set.insert(ref, count, error);
             arena->rollback(ref.size);
         }
+
+        set.readAlphaMap(buf);
     }
 
     void addImpl(AggregateDataPtr place, const IColumn & column, size_t row_num, Arena * arena) const

--- a/dbms/src/Common/SpaceSaving.h
+++ b/dbms/src/Common/SpaceSaving.h
@@ -130,6 +130,11 @@ public:
         return m_capacity;
     }
 
+    void clear()
+    {
+        return destroyElements();
+    }
+
     void resize(size_t new_capacity)
     {
         counter_list.reserve(new_capacity);
@@ -255,6 +260,8 @@ public:
         writeVarUInt(size(), wb);
         for (auto counter : counter_list)
             counter->write(wb);
+
+        writeVarUInt(alpha_map.size(), wb);
         for (auto alpha : alpha_map)
             writeVarUInt(alpha, wb);
     }
@@ -273,7 +280,14 @@ public:
             push(counter);
         }
 
-        for (size_t i = 0; i < nextAlphaSize(m_capacity); ++i)
+        readAlphaMap(rb);
+    }
+
+    void readAlphaMap(ReadBuffer & rb)
+    {
+        size_t alpha_size = 0;
+        readVarUInt(alpha_size, rb);
+        for (size_t i = 0; i < alpha_size; ++i)
         {
             UInt64 alpha = 0;
             readVarUInt(alpha, rb);


### PR DESCRIPTION
I think this should fix #1283, the generic variant didn't read alphaMap state from wire, which I guess caused problems for the reader as it interpreted the following bytes as the header of a next packet. The crash in cancelation is probably exposed because of that.

* the alpha_map vector always (de)serialises
  the actual version (could empty sometimes)
* AggregateFunctionTopK generic variant deserialises
  it as well instead of ignoring it
* AggregateFunctionTopK generic variant clears the
  array before deserialising

refs #1283