### PR TITLE
Fix stack-use-after-scope in StackTrace.cpp

### DIFF
--- a/dbms/src/Common/StackTrace.cpp
+++ b/dbms/src/Common/StackTrace.cpp
@@ -15,13 +15,16 @@ StackTrace::StackTrace()
     frames_size = backtrace(frames, STACK_TRACE_MAX_DEPTH);
 }
 
+thread_local std::stringstream stack_trace_stream;
+
 std::string StackTrace::toString() const
 {
     char ** symbols = backtrace_symbols(frames, frames_size);
-    std::stringstream res;
 
     if (!symbols)
         return "Cannot get symbols for stack trace.\n";
+
+    stack_trace_stream.str(std::string());
 
     try
     {
@@ -45,17 +48,17 @@ std::string StackTrace::toString() const
 
             try
             {
-                res << i << ". ";
+                stack_trace_stream << i << ". ";
 
                 if (nullptr != demangled_name && 0 == status)
                 {
-                    res.write(symbols[i], name_start - symbols[i]);
-                    res << demangled_name << name_end;
+                    stack_trace_stream.write(symbols[i], name_start - symbols[i]);
+                    stack_trace_stream << demangled_name << name_end;
                 }
                 else
-                    res << symbols[i];
+                    stack_trace_stream << symbols[i];
 
-                res << std::endl;
+                stack_trace_stream << std::endl;
             }
             catch (...)
             {
@@ -72,5 +75,5 @@ std::string StackTrace::toString() const
     }
 
     free(symbols);
-    return res.str();
+    return stack_trace_stream.str();
 }


### PR DESCRIPTION
```
==893664==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7fffde029a78 at pc 0x7ffff48abf65 bp 0x7fffde029640 sp 0x7fffde029638
WRITE of size 4 at 0x7fffde029a78 thread T23
    #0 0x7ffff48abf64 in std::__cxx11::basic_stringbuf<char, std::char_traits<char>, std::allocator<char> >::basic_stringbuf(std::_Ios_Openmode) /usr/local/include/c++/7.1.0/sstream:101
    #1 0x7ffff48abf64 in std::__cxx11::basic_stringstream<char, std::char_traits<char>, std::allocator<char> >::basic_stringstream(std::_Ios_Openmode) /usr/local/include/c++/7.1.0/sstream:691
    #2 0x7ffff48abf64 in StackTrace::toString[abi:cxx11]() const ./dbms/src/Common/StackTrace.cpp:21
```