### PR TITLE
Replacing SummingMergeTree implementation to use standard aggregation functions

### DIFF
--- a/dbms/src/AggregateFunctions/AggregateFunctionSumMap.cpp
+++ b/dbms/src/AggregateFunctions/AggregateFunctionSumMap.cpp
@@ -10,11 +10,16 @@ namespace
 
 AggregateFunctionPtr createAggregateFunctionSumMap(const std::string & name, const DataTypes & argument_types, const Array & parameters)
 {
-    if (argument_types.size() != 2)
-        throw Exception("Incorrect number of arguments for aggregate function " + name + ", should be 2",
+    if (argument_types.size() < 2)
+        throw Exception("Incorrect number of arguments for aggregate function " + name + ", should be at least 2",
             ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
 
-    return std::make_shared<AggregateFunctionSumMap>();
+    const auto * array_type = checkAndGetDataType<DataTypeArray>(argument_types[0].get());
+    if (!array_type)
+        throw Exception("First argument for function " + name + " must be an array.",
+                        ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+
+    return AggregateFunctionPtr(createWithNumericType<AggregateFunctionSumMap>(*array_type->getNestedType()));
 }
 
 }

--- a/dbms/src/AggregateFunctions/AggregateFunctionSumMap.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionSumMap.h
@@ -31,7 +31,7 @@ struct AggregateFunctionSumMapData
     std::map<T, Array> merged_maps;
 };
 
-/** Aggregate function, that takes at keast two arguments: keys and values, and as a result, builds a tuple of of at least 2 arrays -
+/** Aggregate function, that takes at least two arguments: keys and values, and as a result, builds a tuple of of at least 2 arrays -
   * ordered keys and variable number of argument values summed up  by corresponding keys.
   *
   * This function is the most useful when using SummingMergeTree to sum Nested columns, which name ends in "Map".

--- a/dbms/src/AggregateFunctions/AggregateFunctionSumMap.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionSumMap.h
@@ -109,7 +109,7 @@ public:
 
         // Columns 1..n contain arrays of numeric values to sum
         auto & merged_maps = this->data(place).merged_maps;
-        for (size_t col = 0; col < values_types.size(); ++col)
+        for (size_t col = 0, size = values_types.size(); col < size; ++col)
         {
             Field value;
             const ColumnArray & array_column = static_cast<const ColumnArray &>(*columns[col + 1]);

--- a/dbms/src/AggregateFunctions/AggregateFunctionSumMap.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionSumMap.h
@@ -72,7 +72,7 @@ public:
     void setArguments(const DataTypes & arguments) override
     {
         if (arguments.size() < 2)
-            throw Exception("Aggregate function " + getName() + "require at leasat two arguments of array type.",
+            throw Exception("Aggregate function " + getName() + " requires at least two arguments of Array type.",
                             ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
 
         const auto * array_type = checkAndGetDataType<DataTypeArray>(arguments[0].get());

--- a/dbms/src/AggregateFunctions/AggregateFunctionSumMap.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionSumMap.h
@@ -53,7 +53,7 @@ class AggregateFunctionSumMap final : public IAggregateFunctionHelper<AggregateF
 {
 private:
     DataTypePtr keys_type;
-    std::vector<DataTypePtr> values_types;
+    DataTypes values_types;
 
 public:
     String getName() const override { return "sumMap"; }

--- a/dbms/src/AggregateFunctions/AggregateFunctionSumMap.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionSumMap.h
@@ -12,7 +12,7 @@
 #include <Core/FieldVisitors.h>
 #include <AggregateFunctions/IBinaryAggregateFunction.h>
 #include <Functions/FunctionHelpers.h>
-#include <Common/HashTable/HashMap.h>
+#include <map>
 
 namespace DB
 {

--- a/dbms/src/AggregateFunctions/AggregateFunctionSumMap.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionSumMap.h
@@ -32,7 +32,7 @@ struct AggregateFunctionSumMapData
 };
 
 /** Aggregate function, that takes at least two arguments: keys and values, and as a result, builds a tuple of of at least 2 arrays -
-  * ordered keys and variable number of argument values summed up  by corresponding keys.
+  * ordered keys and variable number of argument values summed up by corresponding keys.
   *
   * This function is the most useful when using SummingMergeTree to sum Nested columns, which name ends in "Map".
   *

--- a/dbms/src/DataStreams/SummingSortedBlockInputStream.cpp
+++ b/dbms/src/DataStreams/SummingSortedBlockInputStream.cpp
@@ -1,11 +1,16 @@
 #include <DataStreams/SummingSortedBlockInputStream.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeNested.h>
 #include <DataTypes/DataTypeArray.h>
+#include <Columns/ColumnTuple.h>
 #include <Common/StringUtils.h>
 #include <Core/FieldVisitors.h>
 #include <common/logger_useful.h>
 #include <Common/typeid_cast.h>
 
+#include <AggregateFunctions/AggregateFunctionFactory.h>
+#include <Functions/FunctionFactory.h>
+#include <Interpreters/Context.h>
 
 namespace DB
 {
@@ -31,7 +36,20 @@ String SummingSortedBlockInputStream::getID() const
 
 void SummingSortedBlockInputStream::insertCurrentRow(ColumnPlainPtrs & merged_columns)
 {
-    for (size_t i = 0; i < num_columns; ++i)
+    for (auto & desc : columns_to_aggregate)
+    {
+        // Do not insert if the aggregation state hasn't been created
+        if (desc.created)
+        {
+            desc.function->insertResultInto(desc.state.data(), *desc.merged_column);
+            desc.function->destroy(desc.state.data());
+            desc.created = false;
+        }
+        else
+            desc.merged_column->insertDefault();
+    }
+
+    for (auto i : column_numbers_not_to_aggregate)
         merged_columns[i]->insert(current_row[i]);
 }
 
@@ -67,6 +85,8 @@ Block SummingSortedBlockInputStream::readImpl()
     /// Additional initialization.
     if (current_row.empty())
     {
+        auto & factory = AggregateFunctionFactory::instance();
+
         current_row.resize(num_columns);
         next_key.columns.resize(description.size());
 
@@ -88,7 +108,10 @@ Block SummingSortedBlockInputStream::readImpl()
                 const auto map_name = DataTypeNested::extractNestedTableName(column.name);
                 /// if nested table name ends with `Map` it is a possible candidate for special handling
                 if (map_name == column.name || !endsWith(map_name, "Map"))
+                {
+                    column_numbers_not_to_aggregate.push_back(i);
                     continue;
+                }
 
                 discovered_maps[map_name].emplace_back(i);
             }
@@ -100,17 +123,30 @@ Block SummingSortedBlockInputStream::readImpl()
                     column.type->getName() == "DateTime" ||
                     column.type->getName() == "Nullable(Date)" ||
                     column.type->getName() == "Nullable(DateTime)")
+                {
+                    column_numbers_not_to_aggregate.push_back(i);
                     continue;
+                }
 
                 /// Do they enter the PK?
                 if (isInPrimaryKey(description, column.name, i))
+                {
+                    column_numbers_not_to_aggregate.push_back(i);
                     continue;
+                }
 
                 if (column_names_to_sum.empty()
                     || column_names_to_sum.end() !=
                        std::find(column_names_to_sum.begin(), column_names_to_sum.end(), column.name))
                 {
-                    column_numbers_to_sum.push_back(i);
+                    // Create aggregator to sum this column
+                    auto desc = AggregateDescription{};
+                    desc.column_numbers = {i};
+                    desc.merged_column = column.column;
+                    desc.function = factory.get("sum", {column.type});
+                    desc.function->setArguments({column.type});
+                    desc.state.resize(desc.function->sizeOfData());
+                    columns_to_aggregate.emplace_back(std::move(desc));
                 }
             }
         }
@@ -130,8 +166,11 @@ Block SummingSortedBlockInputStream::readImpl()
             if (column_num_it != map.second.end())
                 continue;
 
-            /// collect key and value columns
-            MapDescription map_description;
+            // Wrap aggregated columns in a tuple to match function signature
+            DataTypes argument_types = {};
+            auto tuple = std::make_shared<ColumnTuple>();
+            auto & tuple_columns = tuple->getColumns();
+            auto desc = AggregateDescription{};
 
             column_num_it = map.second.begin();
             for (; column_num_it != map.second.end(); ++column_num_it)
@@ -150,20 +189,43 @@ Block SummingSortedBlockInputStream::readImpl()
                         || nested_type.getName() == "Float64")
                         break;
 
-                    map_description.key_col_nums.emplace_back(*column_num_it);
+                    desc.key_col_nums.push_back(*column_num_it);
                 }
                 else
                 {
                     if (!nested_type.behavesAsNumber())
                         break;
 
-                    map_description.val_col_nums.emplace_back(*column_num_it);
+                    desc.val_col_nums.push_back(*column_num_it);
                 }
+
+                // Add column to function arguments
+                desc.column_numbers.push_back(*column_num_it);
+                argument_types.push_back(key_col.type);
+                tuple_columns.push_back(key_col.column);
             }
+
             if (column_num_it != map.second.end())
                 continue;
 
-            maps_to_sum.emplace_back(std::move(map_description));
+            if (map.second.size() == 2)
+            {
+                // Create parametric aggregation for all columns in the map
+                desc.merged_column = static_cast<ColumnPtr>(tuple);
+                desc.function = factory.get("sumMap", argument_types);
+                desc.function->setArguments(argument_types);
+                desc.state.resize(desc.function->sizeOfData());
+                columns_to_aggregate.emplace_back(std::move(desc));
+            }
+            else
+            {
+                // Fall back to legacy mergeMaps for composite keys
+                for (auto i : desc.key_col_nums)
+                    column_numbers_not_to_aggregate.push_back(i);
+                for (auto i : desc.val_col_nums)
+                    column_numbers_not_to_aggregate.push_back(i);
+                maps_to_sum.emplace_back(std::move(desc));
+            }
         }
     }
 
@@ -219,11 +281,26 @@ void SummingSortedBlockInputStream::merge(ColumnPlainPtrs & merged_columns, std:
 
             setRow(current_row, current);
             current_row_is_zero = false;
+
+            /// Reset aggregation states for next row
+            for (auto & desc : columns_to_aggregate)
+            {
+                desc.function->create(desc.state.data());
+                desc.created = true;
+            }
         }
         else
         {
-            current_row_is_zero = !addRow(current_row, current);
+            // Merge maps only for same rows
+            for (auto & desc : maps_to_sum)
+            {
+                if(mergeMap(desc, current_row, current))
+                    current_row_is_zero = false;
+            }
         }
+
+        if (addRow(current_row, current))
+            current_row_is_zero = false;
 
         if (!current->isLast())
         {
@@ -249,21 +326,7 @@ void SummingSortedBlockInputStream::merge(ColumnPlainPtrs & merged_columns, std:
 }
 
 template <typename TSortCursor>
-bool SummingSortedBlockInputStream::mergeMaps(Row & row, TSortCursor & cursor)
-{
-    bool non_empty_map_present = false;
-
-    /// merge nested maps
-    for (const auto & map : maps_to_sum)
-        if (mergeMap(map, row, cursor))
-            non_empty_map_present = true;
-
-    return non_empty_map_present;
-}
-
-
-template <typename TSortCursor>
-bool SummingSortedBlockInputStream::mergeMap(const MapDescription & desc, Row & row, TSortCursor & cursor)
+bool SummingSortedBlockInputStream::mergeMap(const AggregateDescription & desc, Row & row, TSortCursor & cursor)
 {
     /// Strongly non-optimal.
 
@@ -349,13 +412,31 @@ bool SummingSortedBlockInputStream::mergeMap(const MapDescription & desc, Row & 
 template <typename TSortCursor>
 bool SummingSortedBlockInputStream::addRow(Row & row, TSortCursor & cursor)
 {
-    bool res = mergeMaps(row, cursor);    /// Is there at least one non-zero number or non-empty array
-
-    for (size_t i = 0, size = column_numbers_to_sum.size(); i < size; ++i)
+    bool res = false;
+    for (auto & desc : columns_to_aggregate)
     {
-        size_t j = column_numbers_to_sum[i];
-        if (applyVisitor(FieldVisitorSum((*cursor->all_columns[j])[cursor->pos]), row[j]))
-            res = true;
+        if (desc.created)
+        {
+            // Specialized case for unary functions
+            if (desc.column_numbers.size() == 1)
+            {
+                auto & col = cursor->all_columns[desc.column_numbers[0]];
+                desc.function->add(desc.state.data(), &col, cursor->pos, nullptr);
+                // This stream discards rows that are zero across all summed columns
+                if (!res)
+                    res = col->get64(cursor->pos) != 0;
+            }
+            else
+            {
+                // Gather all source columns into a vector
+                std::vector<const IColumn *> columns;
+                columns.resize(desc.column_numbers.size());
+                for (size_t i = 0; i < desc.column_numbers.size(); ++i)
+                    columns[i] = cursor->all_columns[desc.column_numbers[i]];
+
+                desc.function->add(desc.state.data(), columns.data(), cursor->pos, nullptr);
+            }
+        }
     }
 
     return res;

--- a/dbms/src/DataStreams/SummingSortedBlockInputStream.cpp
+++ b/dbms/src/DataStreams/SummingSortedBlockInputStream.cpp
@@ -128,7 +128,7 @@ Block SummingSortedBlockInputStream::readImpl()
                     continue;
                 }
 
-                /// Do they enter the PK?
+                /// Are they inside the PK?
                 if (isInPrimaryKey(description, column.name, i))
                 {
                     column_numbers_not_to_aggregate.push_back(i);

--- a/dbms/src/DataStreams/SummingSortedBlockInputStream.cpp
+++ b/dbms/src/DataStreams/SummingSortedBlockInputStream.cpp
@@ -429,8 +429,7 @@ bool SummingSortedBlockInputStream::addRow(Row & row, TSortCursor & cursor)
             else
             {
                 // Gather all source columns into a vector
-                std::vector<const IColumn *> columns;
-                columns.resize(desc.column_numbers.size());
+                ConstColumnPlainPtrs columns(desc.column_numbers.size());
                 for (size_t i = 0; i < desc.column_numbers.size(); ++i)
                     columns[i] = cursor->all_columns[desc.column_numbers[i]];
 

--- a/dbms/src/DataStreams/SummingSortedBlockInputStream.cpp
+++ b/dbms/src/DataStreams/SummingSortedBlockInputStream.cpp
@@ -208,9 +208,9 @@ Block SummingSortedBlockInputStream::readImpl()
             if (column_num_it != map.second.end())
                 continue;
 
-            if (map.second.size() == 2)
+            if (desc.key_col_nums.size() == 1)
             {
-                // Create parametric aggregation for all columns in the map
+                // Create summation for all value columns in the map
                 desc.merged_column = static_cast<ColumnPtr>(tuple);
                 desc.function = factory.get("sumMap", argument_types);
                 desc.function->setArguments(argument_types);

--- a/dbms/src/DataStreams/SummingSortedBlockInputStream.cpp
+++ b/dbms/src/DataStreams/SummingSortedBlockInputStream.cpp
@@ -294,7 +294,7 @@ void SummingSortedBlockInputStream::merge(ColumnPlainPtrs & merged_columns, std:
             // Merge maps only for same rows
             for (auto & desc : maps_to_sum)
             {
-                if(mergeMap(desc, current_row, current))
+                if (mergeMap(desc, current_row, current))
                     current_row_is_zero = false;
             }
         }

--- a/dbms/src/DataStreams/SummingSortedBlockInputStream.h
+++ b/dbms/src/DataStreams/SummingSortedBlockInputStream.h
@@ -69,6 +69,7 @@ private:
      *   and can be deleted at any time.
      */
 
+    /// Stores aggregation function, state, and columns to be used as function arguments
     struct AggregateDescription
     {
         AggregateFunctionPtr function;
@@ -79,6 +80,13 @@ private:
         /* Compatibility with the mergeMap */
         std::vector<size_t> key_col_nums;
         std::vector<size_t> val_col_nums;
+
+        /// Explicitly destroy aggregation state if the stream is terminated
+        ~AggregateDescription()
+        {
+            if (created)
+                function->destroy(state.data());
+        }
     };
 
     std::vector<AggregateDescription> columns_to_aggregate;

--- a/dbms/src/DataStreams/SummingSortedBlockInputStream.h
+++ b/dbms/src/DataStreams/SummingSortedBlockInputStream.h
@@ -77,9 +77,6 @@ private:
         ColumnPtr merged_column;
         std::vector<char> state;
         bool created = false;
-        /* Compatibility with the mergeMap */
-        std::vector<size_t> key_col_nums;
-        std::vector<size_t> val_col_nums;
 
         /// Explicitly destroy aggregation state if the stream is terminated
         ~AggregateDescription()
@@ -89,8 +86,15 @@ private:
         }
     };
 
+    /// Stores numbers of key-columns and value-columns.
+    struct MapDescription
+    {
+        std::vector<size_t> key_col_nums;
+        std::vector<size_t> val_col_nums;
+    };
+
     std::vector<AggregateDescription> columns_to_aggregate;
-    std::vector<AggregateDescription> maps_to_sum;
+    std::vector<MapDescription> maps_to_sum;
 
     RowRef current_key;        /// The current primary key.
     RowRef next_key;           /// The primary key of the next row.
@@ -110,7 +114,7 @@ private:
     void insertCurrentRow(ColumnPlainPtrs & merged_columns);
 
     template <typename TSortCursor>
-    bool mergeMap(const AggregateDescription & map, Row & row, TSortCursor & cursor);
+    bool mergeMap(const MapDescription & map, Row & row, TSortCursor & cursor);
 
     /** Add the row under the cursor to the `row`.
       * Returns false if the result is zero.

--- a/dbms/src/DataStreams/tests/CMakeLists.txt
+++ b/dbms/src/DataStreams/tests/CMakeLists.txt
@@ -27,7 +27,7 @@ add_executable (sorting_stream sorting_stream.cpp ${SRCS})
 target_link_libraries (sorting_stream dbms)
 
 add_executable (aggregating_stream aggregating_stream.cpp ${SRCS})
-target_link_libraries (aggregating_stream dbms)
+target_link_libraries (aggregating_stream dbms clickhouse_functions clickhouse_aggregate_functions clickhouse_table_functions)
 
 add_executable (union_stream union_stream.cpp ${SRCS})
 target_link_libraries (union_stream dbms clickhouse_storages_system)

--- a/dbms/src/DataStreams/tests/aggregating_stream.cpp
+++ b/dbms/src/DataStreams/tests/aggregating_stream.cpp
@@ -37,7 +37,7 @@ int main(int argc, char ** argv)
     try
     {
         size_t n = argc > 1 ? atoi(argv[1]) : 10;
-        bool nested = false, sum = false, composite = false;
+        bool nested = false, sum = false, composite = false, multivalue = false;
         for (size_t i = 2; i < argc; ++i)
         {
             if (strcmp(argv[i], "nested") == 0)
@@ -46,6 +46,8 @@ int main(int argc, char ** argv)
                 composite = true;
             else if (strcmp(argv[i], "sum") == 0)
                 sum = true;
+            else if (strcmp(argv[i], "multivalue") == 0)
+                multivalue = true;
         }
 
         Block block;
@@ -103,6 +105,7 @@ int main(int argc, char ** argv)
             }
 
             block.insert(column_k);
+            key_column_names.emplace_back(column_k.name);
 
             ColumnWithTypeAndName column_v;
             column_v.name = "testMap.v";
@@ -116,9 +119,24 @@ int main(int argc, char ** argv)
             }
 
             block.insert(column_v);
-
-            key_column_names.emplace_back(column_k.name);
             key_column_names.emplace_back(column_v.name);
+
+            if (multivalue)
+            {
+                ColumnWithTypeAndName column_v2;
+                column_v2.name = "testMap.v2";
+                column_v2.type = std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt64>());
+                column_v2.column = std::make_shared<ColumnArray>(std::make_shared<ColumnUInt64>());
+
+                for (size_t i = 0; i < n; ++i)
+                {
+                    Array values = {(i % 3) * 10, ((i + 1) % 3) * 10, ((i + 2) % 3) * 10};
+                    column_v2.column->insert(values);
+                }
+
+                block.insert(column_v2);
+                key_column_names.emplace_back(column_v2.name);
+            }
 
             if (composite)
             {


### PR DESCRIPTION
The issue with the current `SummingMergeTree` implementation is that merging is quite slow when the table contains nested structures ending with Map. The goal is to:

1. Reimplement `SummingSortedBlockInputStream` to use built-in aggregation functions (`sum` and `sumMap`)
2. Add specialized version for `sumMap()` for case with composite keys
3. Get rid of the custom `SummingSortedBlockInputStream::mergeMap()` implementation

I decided to split these into separate PRs, this first replaces numeric field summation and simple nested structure summation (single key, single value). When the nested structure contains a composite key, it falls back to existing implementation.