### PR TITLE
Fix clang build

### DIFF
--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -225,7 +225,7 @@ if (USE_RDKAFKA)
 endif ()
 
 # only for copy_headers.sh:
-target_include_directories (dbms PRIVATE ${COMMON_INCLUDE_DIR})
+target_include_directories (dbms BEFORE PRIVATE ${COMMON_INCLUDE_DIR})
 target_include_directories (dbms BEFORE PRIVATE ${DOUBLE_CONVERSION_INCLUDE_DIR})
 
 

--- a/dbms/src/AggregateFunctions/AggregateFunctionGroupArrayInsertAt.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionGroupArrayInsertAt.h
@@ -97,7 +97,7 @@ public:
 
         if (params.size() == 2)
         {
-            length_to_resize = applyVisitor(FieldVisitorConvertToNumber<size_t>(), params[1]);
+            length_to_resize = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), params[1]);
         }
     }
 

--- a/dbms/src/AggregateFunctions/AggregateFunctionTopK.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionTopK.h
@@ -66,7 +66,7 @@ public:
         if (params.size() != 1)
             throw Exception("Aggregate function " + getName() + " requires exactly one parameter.", ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
 
-        size_t k = applyVisitor(FieldVisitorConvertToNumber<size_t>(), params[0]);
+        size_t k = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), params[0]);
 
         if (k > TOP_K_MAX_SIZE)
             throw Exception("Too large parameter for aggregate function " + getName() + ". Maximum: " + toString(TOP_K_MAX_SIZE),
@@ -166,7 +166,7 @@ public:
         if (params.size() != 1)
             throw Exception("Aggregate function " + getName() + " requires exactly one parameter.", ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
 
-        size_t k = applyVisitor(FieldVisitorConvertToNumber<size_t>(), params[0]);
+        size_t k = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), params[0]);
 
         if (k > TOP_K_MAX_SIZE)
             throw Exception("Too large parameter for aggregate function " + getName() + ". Maximum: " + toString(TOP_K_MAX_SIZE),

--- a/dbms/src/AggregateFunctions/CMakeLists.txt
+++ b/dbms/src/AggregateFunctions/CMakeLists.txt
@@ -28,4 +28,4 @@ list(REMOVE_ITEM clickhouse_aggregate_functions_headers
 
 add_library(clickhouse_aggregate_functions ${clickhouse_aggregate_functions_sources})
 target_link_libraries(clickhouse_aggregate_functions dbms)
-target_include_directories (clickhouse_aggregate_functions PRIVATE ${COMMON_INCLUDE_DIR})
+target_include_directories (clickhouse_aggregate_functions BEFORE PRIVATE ${COMMON_INCLUDE_DIR})

--- a/dbms/src/Common/ConfigProcessor.cpp
+++ b/dbms/src/Common/ConfigProcessor.cpp
@@ -325,7 +325,7 @@ void ConfigProcessor::doIncludesRecursive(
                     return nullptr;
 
                 /// Enclose contents into a fake <from_zk> tag to allow pure text substitutions.
-                zk_document = dom_parser.parseString("<from_zk>" + contents.value() + "</from_zk>");
+                zk_document = dom_parser.parseString("<from_zk>" + *contents + "</from_zk>");
                 return getRootNode(zk_document.get());
             };
 

--- a/dbms/src/Common/tests/int_hashes_perf.cpp
+++ b/dbms/src/Common/tests/int_hashes_perf.cpp
@@ -193,6 +193,11 @@ static inline size_t tabulation(UInt64 x)
     return res;
 }
 
+static inline size_t _intHash64(UInt64 x)
+{
+    return static_cast<size_t>(intHash64(x));
+}
+
 
 const size_t BUF_SIZE = 1024;
 
@@ -308,7 +313,7 @@ int main(int argc, char ** argv)
 
     if (!method || method == 1) test<identity>  (n, &data[0], "0: identity");
     if (!method || method == 2) test<intHash32> (n, &data[0], "1: intHash32");
-    if (!method || method == 3) test<intHash64> (n, &data[0], "2: intHash64");
+    if (!method || method == 3) test<_intHash64>(n, &data[0], "2: intHash64");
     if (!method || method == 4) test<hash3>     (n, &data[0], "3: two rounds");
     if (!method || method == 5) test<hash4>     (n, &data[0], "4: two rounds and two variables");
     if (!method || method == 6) test<hash5>     (n, &data[0], "5: two rounds with less ops");

--- a/dbms/src/DataStreams/NullableAdapterBlockInputStream.cpp
+++ b/dbms/src/DataStreams/NullableAdapterBlockInputStream.cpp
@@ -79,7 +79,7 @@ Block NullableAdapterBlockInputStream::readImpl()
             case NONE:
             {
                 if (rename[i])
-                    res.insert({elem.column, elem.type, rename[i].value()});
+                    res.insert({elem.column, elem.type, *rename[i]});
                 else
                     res.insert(elem);
                 break;

--- a/dbms/src/DataStreams/RemoteBlockInputStream.cpp
+++ b/dbms/src/DataStreams/RemoteBlockInputStream.cpp
@@ -63,7 +63,7 @@ RemoteBlockInputStream::RemoteBlockInputStream(
         std::vector<IConnectionPool::Entry> connections;
         if (main_table)
         {
-            auto try_results = pool->getManyChecked(&settings, pool_mode, main_table.value());
+            auto try_results = pool->getManyChecked(&settings, pool_mode, *main_table);
             connections.reserve(try_results.size());
             for (auto & try_result : try_results)
                 connections.emplace_back(std::move(try_result.entry));

--- a/dbms/src/DataStreams/tests/aggregating_stream.cpp
+++ b/dbms/src/DataStreams/tests/aggregating_stream.cpp
@@ -98,7 +98,7 @@ int main(int argc, char ** argv)
             column_k.type = std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt16>());
             column_k.column = std::make_shared<ColumnArray>(std::make_shared<ColumnUInt16>());
 
-            for (size_t i = 0; i < n; ++i)
+            for (UInt64 i = 0; i < n; ++i)
             {
                 Array values = {i % 5, (i + 1) % 5, (i + 2) % 5};
                 column_k.column->insert(values);
@@ -112,7 +112,7 @@ int main(int argc, char ** argv)
             column_v.type = std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt64>());
             column_v.column = std::make_shared<ColumnArray>(std::make_shared<ColumnUInt64>());
 
-            for (size_t i = 0; i < n; ++i)
+            for (UInt64 i = 0; i < n; ++i)
             {
                 Array values = {i % 3, (i + 1) % 3, (i + 2) % 3};
                 column_v.column->insert(values);
@@ -128,7 +128,7 @@ int main(int argc, char ** argv)
                 column_v2.type = std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt64>());
                 column_v2.column = std::make_shared<ColumnArray>(std::make_shared<ColumnUInt64>());
 
-                for (size_t i = 0; i < n; ++i)
+                for (UInt64 i = 0; i < n; ++i)
                 {
                     Array values = {(i % 3) * 10, ((i + 1) % 3) * 10, ((i + 2) % 3) * 10};
                     column_v2.column->insert(values);
@@ -145,9 +145,9 @@ int main(int argc, char ** argv)
                 column_kid.type = std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt8>());
                 column_kid.column = std::make_shared<ColumnArray>(std::make_shared<ColumnUInt8>());
 
-                for (size_t i = 0; i < n; ++i)
+                for (UInt64 i = 0; i < n; ++i)
                 {
-                    Array values = {(i % 2) * 10, ((i + 1) % 2) * 10, 0UL};
+                    Array values = {(i % 2) * 10, ((i + 1) % 2) * 10, UInt64(0)};
                     column_kid.column->insert(values);
                 }
 

--- a/dbms/src/DataStreams/tests/glue_streams.cpp
+++ b/dbms/src/DataStreams/tests/glue_streams.cpp
@@ -43,7 +43,7 @@ try
     loadMetadata(context);
 
     context.setCurrentDatabase("default");
-    context.setSetting("max_threads", 1UL);
+    context.setSetting("max_threads", UInt64(1));
 
     BlockIO io1 = executeQuery(
         "SELECT SearchPhrase, count()"

--- a/dbms/src/Dictionaries/ComplexKeyCacheDictionary.cpp
+++ b/dbms/src/Dictionaries/ComplexKeyCacheDictionary.cpp
@@ -170,7 +170,7 @@ void ComplexKeyCacheDictionary::has(const Columns & key_columns, const DataTypes
 
 
     const auto rows_num = key_columns.front()->size();
-    const auto keys_size = dict_struct.key.value().size();
+    const auto keys_size = dict_struct.key->size();
     StringRefs keys(keys_size);
     Arena temporary_keys_pool;
     PODArray<StringRef> keys_array(rows_num);

--- a/dbms/src/Dictionaries/ComplexKeyCacheDictionary.h
+++ b/dbms/src/Dictionaries/ComplexKeyCacheDictionary.h
@@ -296,7 +296,7 @@ private:
         auto & attribute_array = std::get<ContainerPtrType<AttributeType>>(attribute.arrays);
 
         const auto rows_num = key_columns.front()->size();
-        const auto keys_size = dict_struct.key.value().size();
+        const auto keys_size = dict_struct.key->size();
         StringRefs keys(keys_size);
         Arena temporary_keys_pool;
         PODArray<StringRef> keys_array(rows_num);
@@ -371,7 +371,7 @@ private:
         /// save on some allocations
         out->getOffsets().reserve(rows_num);
 
-        const auto keys_size = dict_struct.key.value().size();
+        const auto keys_size = dict_struct.key->size();
         StringRefs keys(keys_size);
         Arena temporary_keys_pool;
 
@@ -523,7 +523,7 @@ private:
             auto stream = source_ptr->loadKeys(in_key_columns, in_requested_rows);
             stream->readPrefix();
 
-            const auto keys_size = dict_struct.key.value().size();
+            const auto keys_size = dict_struct.key->size();
             StringRefs keys(keys_size);
 
             const auto attributes_size = attributes.size();

--- a/dbms/src/Dictionaries/ComplexKeyHashedDictionary.cpp
+++ b/dbms/src/Dictionaries/ComplexKeyHashedDictionary.cpp
@@ -229,7 +229,7 @@ void ComplexKeyHashedDictionary::loadData()
     stream->readPrefix();
 
     /// created upfront to avoid excess allocations
-    const auto keys_size = dict_struct.key.value().size();
+    const auto keys_size = dict_struct.key->size();
     StringRefs keys(keys_size);
 
     const auto attributes_size = attributes.size();

--- a/dbms/src/Dictionaries/DictionarySourceFactory.cpp
+++ b/dbms/src/Dictionaries/DictionarySourceFactory.cpp
@@ -49,7 +49,7 @@ Block createSampleBlock(const DictionaryStructure & dict_struct)
 
     if (dict_struct.id)
         block.insert(ColumnWithTypeAndName{
-            std::make_shared<ColumnUInt64>(1), std::make_shared<DataTypeUInt64>(), dict_struct.id.value().name});
+            std::make_shared<ColumnUInt64>(1), std::make_shared<DataTypeUInt64>(), dict_struct.id->name});
 
     if (dict_struct.key)
     {
@@ -65,7 +65,7 @@ Block createSampleBlock(const DictionaryStructure & dict_struct)
     if (dict_struct.range_min)
         for (const auto & attribute : { dict_struct.range_min, dict_struct.range_max })
             block.insert(ColumnWithTypeAndName{
-                std::make_shared<ColumnUInt16>(1), std::make_shared<DataTypeDate>(), attribute.value().name});
+                std::make_shared<ColumnUInt16>(1), std::make_shared<DataTypeDate>(), attribute->name});
 
     for (const auto & attribute : dict_struct.attributes)
     {

--- a/dbms/src/Dictionaries/DictionaryStructure.cpp
+++ b/dbms/src/Dictionaries/DictionaryStructure.cpp
@@ -170,7 +170,7 @@ DictionaryStructure::DictionaryStructure(const Poco::Util::AbstractConfiguration
 
 void DictionaryStructure::validateKeyTypes(const DataTypes & key_types) const
 {
-    if (key_types.size() != key.value().size())
+    if (key_types.size() != key->size())
         throw Exception{
             "Key structure does not match, expected " + getKeyDescription(),
             ErrorCodes::TYPE_MISMATCH};

--- a/dbms/src/Dictionaries/ExternalQueryBuilder.cpp
+++ b/dbms/src/Dictionaries/ExternalQueryBuilder.cpp
@@ -54,35 +54,35 @@ std::string ExternalQueryBuilder::composeLoadAllQuery() const
 
     if (dict_struct.id)
     {
-        if (!dict_struct.id.value().expression.empty())
+        if (!dict_struct.id->expression.empty())
         {
-            writeParenthesisedString(dict_struct.id.value().expression, out);
+            writeParenthesisedString(dict_struct.id->expression, out);
             writeString(" AS ", out);
         }
 
-        writeQuoted(dict_struct.id.value().name, out);
+        writeQuoted(dict_struct.id->name, out);
 
         if (dict_struct.range_min && dict_struct.range_max)
         {
             writeString(", ", out);
 
-            if (!dict_struct.range_min.value().expression.empty())
+            if (!dict_struct.range_min->expression.empty())
             {
-                writeParenthesisedString(dict_struct.range_min.value().expression, out);
+                writeParenthesisedString(dict_struct.range_min->expression, out);
                 writeString(" AS ", out);
             }
 
-            writeQuoted(dict_struct.range_min.value().name, out);
+            writeQuoted(dict_struct.range_min->name, out);
 
             writeString(", ", out);
 
-            if (!dict_struct.range_max.value().expression.empty())
+            if (!dict_struct.range_max->expression.empty())
             {
-                writeParenthesisedString(dict_struct.range_max.value().expression, out);
+                writeParenthesisedString(dict_struct.range_max->expression, out);
                 writeString(" AS ", out);
             }
 
-            writeQuoted(dict_struct.range_max.value().name, out);
+            writeQuoted(dict_struct.range_max->name, out);
         }
     }
     else if (dict_struct.key)
@@ -146,13 +146,13 @@ std::string ExternalQueryBuilder::composeLoadIdsQuery(const std::vector<UInt64> 
     WriteBufferFromOwnString out;
     writeString("SELECT ", out);
 
-    if (!dict_struct.id.value().expression.empty())
+    if (!dict_struct.id->expression.empty())
     {
-        writeParenthesisedString(dict_struct.id.value().expression, out);
+        writeParenthesisedString(dict_struct.id->expression, out);
         writeString(" AS ", out);
     }
 
-    writeQuoted(dict_struct.id.value().name, out);
+    writeQuoted(dict_struct.id->name, out);
 
     for (const auto & attr : dict_struct.attributes)
     {
@@ -183,7 +183,7 @@ std::string ExternalQueryBuilder::composeLoadIdsQuery(const std::vector<UInt64> 
         writeString(" AND ", out);
     }
 
-    writeQuoted(dict_struct.id.value().name, out);
+    writeQuoted(dict_struct.id->name, out);
     writeString(" IN (", out);
 
     auto first = true;

--- a/dbms/src/Dictionaries/MongoDBDictionarySource.cpp
+++ b/dbms/src/Dictionaries/MongoDBDictionarySource.cpp
@@ -212,7 +212,7 @@ BlockInputStreamPtr MongoDBDictionarySource::loadIds(const std::vector<UInt64> &
     for (const UInt64 id : ids)
         ids_array->add(DB::toString(id), Int32(id));
 
-    cursor->query().selector().addNewDocument(dict_struct.id.value().name)
+    cursor->query().selector().addNewDocument(dict_struct.id->name)
         .add("$in", ids_array);
 
     return std::make_shared<MongoDBBlockInputStream>(

--- a/dbms/src/Dictionaries/TrieDictionary.cpp
+++ b/dbms/src/Dictionaries/TrieDictionary.cpp
@@ -246,7 +246,7 @@ void TrieDictionary::loadData()
     stream->readPrefix();
 
     /// created upfront to avoid excess allocations
-    const auto keys_size = dict_struct.key.value().size();
+    const auto keys_size = dict_struct.key->size();
     StringRefs keys(keys_size);
 
     const auto attributes_size = attributes.size();

--- a/dbms/src/Functions/FunctionsHashing.h
+++ b/dbms/src/Functions/FunctionsHashing.h
@@ -589,7 +589,7 @@ public:
         if (arguments.empty())
         {
             /// Constant random number from /dev/urandom is used as a hash value of empty list of arguments.
-            vec_to.assign(rows, 0xe28dbde7fe22e41c);
+            vec_to.assign(rows, static_cast<UInt64>(0xe28dbde7fe22e41c));
         }
 
         /// The function supports arbitary number of arguments of arbitary types.

--- a/dbms/src/IO/VarInt.h
+++ b/dbms/src/IO/VarInt.h
@@ -73,7 +73,7 @@ inline const char * readVarT(UInt64 & x, const char * istr, size_t size) { retur
 inline const char * readVarT(Int64 & x, const char * istr, size_t size) { return readVarInt(x, istr, size); }
 
 
-/// For [U]Int32, [U]Int16.
+/// For [U]Int32, [U]Int16, size_t.
 
 inline void readVarUInt(UInt32 & x, ReadBuffer & istr)
 {
@@ -100,6 +100,13 @@ inline void readVarInt(Int16 & x, ReadBuffer & istr)
 {
     Int64 tmp;
     readVarInt(tmp, istr);
+    x = tmp;
+}
+
+inline void readVarUInt(size_t & x, ReadBuffer & istr)
+{
+    UInt64 tmp;
+    readVarUInt(tmp, istr);
     x = tmp;
 }
 

--- a/dbms/src/IO/WriteBufferFromHTTPServerResponse.cpp
+++ b/dbms/src/IO/WriteBufferFromHTTPServerResponse.cpp
@@ -102,8 +102,8 @@ void WriteBufferFromHTTPServerResponse::nextImpl()
 #endif
 
                 out_raw.emplace(*response_body_ostr);
-                deflating_buf.emplace(out_raw.value(), compression_method, compression_level, working_buffer.size(), working_buffer.begin());
-                out = &deflating_buf.value();
+                deflating_buf.emplace(*out_raw, compression_method, compression_level, working_buffer.size(), working_buffer.begin());
+                out = &*deflating_buf;
             }
             else
             {
@@ -112,7 +112,7 @@ void WriteBufferFromHTTPServerResponse::nextImpl()
 #endif
 
                 out_raw.emplace(*response_body_ostr, working_buffer.size(), working_buffer.begin());
-                out = &out_raw.value();
+                out = &*out_raw;
             }
         }
 

--- a/dbms/src/Interpreters/executeQuery.cpp
+++ b/dbms/src/Interpreters/executeQuery.cpp
@@ -425,7 +425,7 @@ void executeQuery(
 
                 const auto & out_file = typeid_cast<const ASTLiteral &>(*ast_query_with_output->out_file).value.safeGet<std::string>();
                 out_file_buf.emplace(out_file, DBMS_DEFAULT_BUFFER_SIZE, O_WRONLY | O_EXCL | O_CREAT);
-                out_buf = &out_file_buf.value();
+                out_buf = &*out_file_buf;
             }
 
             String format_name = ast_query_with_output && (ast_query_with_output->format != nullptr)

--- a/dbms/src/Server/CMakeLists.txt
+++ b/dbms/src/Server/CMakeLists.txt
@@ -41,7 +41,7 @@ add_library (clickhouse-compressor-lib Compressor.cpp)
 target_link_libraries (clickhouse-compressor-lib dbms ${Boost_PROGRAM_OPTIONS_LIBRARY})
 
 add_executable(clickhouse main.cpp)
-target_include_directories(clickhouse PRIVATE ${COMMON_INCLUDE_DIR})
+target_include_directories(clickhouse BEFORE PRIVATE ${COMMON_INCLUDE_DIR})
 target_link_libraries(clickhouse
     clickhouse-server
     clickhouse-client

--- a/dbms/src/Server/Client.cpp
+++ b/dbms/src/Server/Client.cpp
@@ -967,7 +967,7 @@ private:
                     const auto & out_file_node = typeid_cast<const ASTLiteral &>(*query_with_output->out_file);
                     const auto & out_file = out_file_node.value.safeGet<std::string>();
                     out_file_buf.emplace(out_file, DBMS_DEFAULT_BUFFER_SIZE, O_WRONLY | O_EXCL | O_CREAT);
-                    out_buf = &out_file_buf.value();
+                    out_buf = &*out_file_buf;
 
                     // We are writing to file, so default format is the same as in non-interactive mode.
                     if (is_interactive && is_default_format)

--- a/dbms/src/Storages/MergeTree/MergeTreeBaseBlockInputStream.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeBaseBlockInputStream.cpp
@@ -304,7 +304,7 @@ Block MergeTreeBaseBlockInputStream::readFromPart()
                         const auto & range = ranges_to_read[next_range_idx++];
                         task->current_range_reader = reader->readRange(range.begin, range.end);
                     }
-                    MergeTreeRangeReader & range_reader = task->current_range_reader.value();
+                    MergeTreeRangeReader & range_reader = *task->current_range_reader;
                     size_t current_range_rows_read = 0;
                     auto pre_filter_begin_pos = pre_filter_pos;
 

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1745,7 +1745,7 @@ void MergeTreeData::freezePartition(const ASTPtr & partition_ast, const String &
         partition_id = getPartitionIDFromQuery(partition_ast, context);
 
     if (prefix)
-        LOG_DEBUG(log, "Freezing parts with prefix " + prefix.value());
+        LOG_DEBUG(log, "Freezing parts with prefix " + *prefix);
     else
         LOG_DEBUG(log, "Freezing parts with partition ID " + partition_id);
 
@@ -1768,7 +1768,7 @@ void MergeTreeData::freezePartition(const ASTPtr & partition_ast, const String &
     {
         if (prefix)
         {
-            if (!startsWith(part->info.partition_id, prefix.value()))
+            if (!startsWith(part->info.partition_id, *prefix))
                 continue;
         }
         else if (part->info.partition_id != partition_id)

--- a/dbms/src/Storages/StorageFactory.cpp
+++ b/dbms/src/Storages/StorageFactory.cpp
@@ -558,14 +558,14 @@ StoragePtr StorageFactory::get(
         String destination_database = static_cast<const ASTLiteral &>(*args[0]).value.safeGet<String>();
         String destination_table     = static_cast<const ASTLiteral &>(*args[1]).value.safeGet<String>();
 
-        size_t num_buckets = applyVisitor(FieldVisitorConvertToNumber<size_t>(), typeid_cast<ASTLiteral &>(*args[2]).value);
+        size_t num_buckets = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[2]).value);
 
-        time_t min_time = applyVisitor(FieldVisitorConvertToNumber<size_t>(), typeid_cast<ASTLiteral &>(*args[3]).value);
-        time_t max_time = applyVisitor(FieldVisitorConvertToNumber<size_t>(), typeid_cast<ASTLiteral &>(*args[4]).value);
-        size_t min_rows = applyVisitor(FieldVisitorConvertToNumber<size_t>(), typeid_cast<ASTLiteral &>(*args[5]).value);
-        size_t max_rows = applyVisitor(FieldVisitorConvertToNumber<size_t>(), typeid_cast<ASTLiteral &>(*args[6]).value);
-        size_t min_bytes = applyVisitor(FieldVisitorConvertToNumber<size_t>(), typeid_cast<ASTLiteral &>(*args[7]).value);
-        size_t max_bytes = applyVisitor(FieldVisitorConvertToNumber<size_t>(), typeid_cast<ASTLiteral &>(*args[8]).value);
+        time_t min_time = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[3]).value);
+        time_t max_time = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[4]).value);
+        size_t min_rows = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[5]).value);
+        size_t max_rows = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[6]).value);
+        size_t min_bytes = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[7]).value);
+        size_t max_bytes = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[8]).value);
 
         return StorageBuffer::create(
             table_name, columns,
@@ -606,14 +606,14 @@ StoragePtr StorageFactory::get(
         String destination_database = static_cast<const ASTLiteral &>(*args[0]).value.safeGet<String>();
         String destination_table    = static_cast<const ASTLiteral &>(*args[1]).value.safeGet<String>();
 
-        size_t num_blocks_to_deduplicate = applyVisitor(FieldVisitorConvertToNumber<size_t>(), typeid_cast<ASTLiteral &>(*args[2]).value);
+        size_t num_blocks_to_deduplicate = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[2]).value);
 
-        time_t min_time = applyVisitor(FieldVisitorConvertToNumber<size_t>(), typeid_cast<ASTLiteral &>(*args[3]).value);
-        time_t max_time = applyVisitor(FieldVisitorConvertToNumber<size_t>(), typeid_cast<ASTLiteral &>(*args[4]).value);
-        size_t min_rows = applyVisitor(FieldVisitorConvertToNumber<size_t>(), typeid_cast<ASTLiteral &>(*args[5]).value);
-        size_t max_rows = applyVisitor(FieldVisitorConvertToNumber<size_t>(), typeid_cast<ASTLiteral &>(*args[6]).value);
-        size_t min_bytes = applyVisitor(FieldVisitorConvertToNumber<size_t>(), typeid_cast<ASTLiteral &>(*args[7]).value);
-        size_t max_bytes = applyVisitor(FieldVisitorConvertToNumber<size_t>(), typeid_cast<ASTLiteral &>(*args[8]).value);
+        time_t min_time = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[3]).value);
+        time_t max_time = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[4]).value);
+        size_t min_rows = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[5]).value);
+        size_t max_rows = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[6]).value);
+        size_t min_bytes = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[7]).value);
+        size_t max_bytes = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[8]).value);
 
         String path_in_zk_for_deduplication = static_cast<const ASTLiteral &>(*args[9]).value.safeGet<String>();
 

--- a/dbms/src/Storages/StorageKafka.cpp
+++ b/dbms/src/Storages/StorageKafka.cpp
@@ -33,7 +33,7 @@ static const auto READ_POLL_MS       = 1 * 1000;
 static const auto CLEANUP_TIMEOUT_MS = 2 * 1000;
 
 /// How many messages to pull out of internal queue at once
-static const auto BATCH_SIZE_MAX     = 16UL;
+static const UInt64 BATCH_SIZE_MAX   = 16;
 
 class ReadBufferFromKafkaConsumer : public ReadBuffer
 {
@@ -121,7 +121,7 @@ public:
     {
         // Always skip unknown fields regardless of the context (JSON or TSKV)
         Context context = context_;
-        context.setSetting("input_format_skip_unknown_fields", 1UL);
+        context.setSetting("input_format_skip_unknown_fields", UInt64(1));
         if (schema.size() > 0)
             context.setSetting("schema", schema);
         // Create a formatted reader on Kafka messages
@@ -353,7 +353,7 @@ void StorageKafka::streamToViews()
     // Execute the query
     InterpreterInsertQuery interpreter{insert, context};
     auto block_io = interpreter.execute();
-    copyData(*in, *block_io.out);
+    copyData(*in, *block_io.out, &is_cancelled);
 }
 
 

--- a/dbms/src/Storages/StorageMerge.cpp
+++ b/dbms/src/Storages/StorageMerge.cpp
@@ -221,7 +221,7 @@ BlockInputStreams StorageMerge::read(
 
             if (!processed_stage_in_source_tables)
                 processed_stage_in_source_tables.emplace(processed_stage_in_source_table);
-            else if (processed_stage_in_source_table != processed_stage_in_source_tables.value())
+            else if (processed_stage_in_source_table != *processed_stage_in_source_tables)
                 throw Exception("Source tables for Merge table are processing data up to different stages",
                     ErrorCodes::INCOMPATIBLE_SOURCE_TABLES);
 
@@ -250,7 +250,7 @@ BlockInputStreams StorageMerge::read(
                 if (!processed_stage_in_source_tables)
                     throw Exception("Logical error: unknown processed stage in source tables",
                         ErrorCodes::LOGICAL_ERROR);
-                else if (processed_stage_in_source_table != processed_stage_in_source_tables.value())
+                else if (processed_stage_in_source_table != *processed_stage_in_source_tables)
                     throw Exception("Source tables for Merge table are processing data up to different stages",
                         ErrorCodes::INCOMPATIBLE_SOURCE_TABLES);
 
@@ -281,12 +281,12 @@ BlockInputStreams StorageMerge::read(
     }
 
     if (processed_stage_in_source_tables)
-        processed_stage = processed_stage_in_source_tables.value();
+        processed_stage = *processed_stage_in_source_tables;
 
     res = narrowBlockInputStreams(res, num_streams);
 
     /// Added to avoid different block structure from different sources
-    if (!processed_stage_in_source_tables || processed_stage_in_source_tables.value() == QueryProcessingStage::FetchColumns)
+    if (!processed_stage_in_source_tables || *processed_stage_in_source_tables == QueryProcessingStage::FetchColumns)
     {
         for (auto & stream : res)
             stream = std::make_shared<FilterColumnsBlockInputStream>(stream, column_names, true);


### PR DESCRIPTION
Basically, in the current version of Poco, `unsigned long` no longer aliases to `UInt64` with LP64 https://github.com/pocoproject/poco/issues/1870 (or any other type, `unsigned long` is basically not convertible to anything).

The `size_t` aliases to `unsigned long` with clang, so all the uses of `size_t` instead of `UInt64` when interacting with Poco interfaces are gone https://github.com/pocoproject/poco/issues/1147. I replaced uses with `UInt64` where it makes sense, and added an overloaded function for `readVarUInt()` to support `size_t`.