### PR TITLE
Better fix for missing unsigned long to Poco::UInt64 alias

### DIFF
--- a/dbms/src/AggregateFunctions/AggregateFunctionGroupArrayInsertAt.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionGroupArrayInsertAt.h
@@ -97,7 +97,7 @@ public:
 
         if (params.size() == 2)
         {
-            length_to_resize = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), params[1]);
+            length_to_resize = applyVisitor(FieldVisitorConvertToNumber<size_t>(), params[1]);
         }
     }
 

--- a/dbms/src/AggregateFunctions/AggregateFunctionTopK.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionTopK.h
@@ -66,7 +66,7 @@ public:
         if (params.size() != 1)
             throw Exception("Aggregate function " + getName() + " requires exactly one parameter.", ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
 
-        size_t k = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), params[0]);
+        size_t k = applyVisitor(FieldVisitorConvertToNumber<size_t>(), params[0]);
 
         if (k > TOP_K_MAX_SIZE)
             throw Exception("Too large parameter for aggregate function " + getName() + ". Maximum: " + toString(TOP_K_MAX_SIZE),
@@ -166,7 +166,7 @@ public:
         if (params.size() != 1)
             throw Exception("Aggregate function " + getName() + " requires exactly one parameter.", ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
 
-        size_t k = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), params[0]);
+        size_t k = applyVisitor(FieldVisitorConvertToNumber<size_t>(), params[0]);
 
         if (k > TOP_K_MAX_SIZE)
             throw Exception("Too large parameter for aggregate function " + getName() + ". Maximum: " + toString(TOP_K_MAX_SIZE),

--- a/dbms/src/Core/Field.h
+++ b/dbms/src/Core/Field.h
@@ -509,6 +509,16 @@ template <> struct NearestFieldType<Tuple>   { using Type = Tuple; };
 template <> struct NearestFieldType<bool>    { using Type = UInt64; };
 template <> struct NearestFieldType<Null>    { using Type = Null; };
 
+#if POCO_LONG_IS_64_BIT
+
+template <> struct Field::TypeToEnum<unsigned long> { static const Types::Which value = Types::UInt64; };
+template <> struct Field::TypeToEnum<long>          { static const Types::Which value = Types::Int64; };
+
+template <> struct NearestFieldType<unsigned long>  { using Type = UInt64; };
+template <> struct NearestFieldType<long>           { using Type = Int64; };
+
+#endif
+
 
 template <typename T>
 typename NearestFieldType<T>::Type nearestFieldType(const T & x)

--- a/dbms/src/Core/Types.h
+++ b/dbms/src/Core/Types.h
@@ -74,4 +74,15 @@ template <> struct TypeName<Float32> { static const char * get() { return "Float
 template <> struct TypeName<Float64> { static const char * get() { return "Float64"; } };
 template <> struct TypeName<String>  { static const char * get() { return "String";  } };
 
+/// When UInt64 is defined as std::uint64_t, but unsigned long is equivalent, alias it
+#if POCO_LONG_IS_64_BIT
+
+template <> struct IsNumber<unsigned long>  { static constexpr bool value = true; };
+template <> struct IsNumber<long>           { static constexpr bool value = true; };
+
+template <> struct TypeName<unsigned long>  { static const char * get() { return "UInt64";  } };
+template <> struct TypeName<long>           { static const char * get() { return "Int64";  } };
+
+#endif
+
 }

--- a/dbms/src/DataStreams/tests/aggregating_stream.cpp
+++ b/dbms/src/DataStreams/tests/aggregating_stream.cpp
@@ -98,7 +98,7 @@ int main(int argc, char ** argv)
             column_k.type = std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt16>());
             column_k.column = std::make_shared<ColumnArray>(std::make_shared<ColumnUInt16>());
 
-            for (UInt64 i = 0; i < n; ++i)
+            for (size_t i = 0; i < n; ++i)
             {
                 Array values = {i % 5, (i + 1) % 5, (i + 2) % 5};
                 column_k.column->insert(values);
@@ -112,7 +112,7 @@ int main(int argc, char ** argv)
             column_v.type = std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt64>());
             column_v.column = std::make_shared<ColumnArray>(std::make_shared<ColumnUInt64>());
 
-            for (UInt64 i = 0; i < n; ++i)
+            for (size_t i = 0; i < n; ++i)
             {
                 Array values = {i % 3, (i + 1) % 3, (i + 2) % 3};
                 column_v.column->insert(values);
@@ -128,7 +128,7 @@ int main(int argc, char ** argv)
                 column_v2.type = std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt64>());
                 column_v2.column = std::make_shared<ColumnArray>(std::make_shared<ColumnUInt64>());
 
-                for (UInt64 i = 0; i < n; ++i)
+                for (size_t i = 0; i < n; ++i)
                 {
                     Array values = {(i % 3) * 10, ((i + 1) % 3) * 10, ((i + 2) % 3) * 10};
                     column_v2.column->insert(values);
@@ -145,9 +145,9 @@ int main(int argc, char ** argv)
                 column_kid.type = std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt8>());
                 column_kid.column = std::make_shared<ColumnArray>(std::make_shared<ColumnUInt8>());
 
-                for (UInt64 i = 0; i < n; ++i)
+                for (size_t i = 0; i < n; ++i)
                 {
-                    Array values = {(i % 2) * 10, ((i + 1) % 2) * 10, UInt64(0)};
+                    Array values = {(i % 2) * 10, ((i + 1) % 2) * 10, 0UL};
                     column_kid.column->insert(values);
                 }
 

--- a/dbms/src/IO/VarInt.h
+++ b/dbms/src/IO/VarInt.h
@@ -103,7 +103,9 @@ inline void readVarInt(Int16 & x, ReadBuffer & istr)
     x = tmp;
 }
 
-inline void readVarUInt(size_t & x, ReadBuffer & istr)
+template <typename T>
+inline typename std::enable_if<!std::is_same<T, UInt64>::value, void>::type
+readVarUInt(T & x, ReadBuffer & istr)
 {
     UInt64 tmp;
     readVarUInt(tmp, istr);

--- a/dbms/src/Storages/StorageFactory.cpp
+++ b/dbms/src/Storages/StorageFactory.cpp
@@ -558,14 +558,14 @@ StoragePtr StorageFactory::get(
         String destination_database = static_cast<const ASTLiteral &>(*args[0]).value.safeGet<String>();
         String destination_table     = static_cast<const ASTLiteral &>(*args[1]).value.safeGet<String>();
 
-        size_t num_buckets = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[2]).value);
+        size_t num_buckets = applyVisitor(FieldVisitorConvertToNumber<size_t>(), typeid_cast<ASTLiteral &>(*args[2]).value);
 
-        time_t min_time = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[3]).value);
-        time_t max_time = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[4]).value);
-        size_t min_rows = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[5]).value);
-        size_t max_rows = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[6]).value);
-        size_t min_bytes = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[7]).value);
-        size_t max_bytes = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[8]).value);
+        time_t min_time = applyVisitor(FieldVisitorConvertToNumber<time_t>(), typeid_cast<ASTLiteral &>(*args[3]).value);
+        time_t max_time = applyVisitor(FieldVisitorConvertToNumber<time_t>(), typeid_cast<ASTLiteral &>(*args[4]).value);
+        size_t min_rows = applyVisitor(FieldVisitorConvertToNumber<size_t>(), typeid_cast<ASTLiteral &>(*args[5]).value);
+        size_t max_rows = applyVisitor(FieldVisitorConvertToNumber<size_t>(), typeid_cast<ASTLiteral &>(*args[6]).value);
+        size_t min_bytes = applyVisitor(FieldVisitorConvertToNumber<size_t>(), typeid_cast<ASTLiteral &>(*args[7]).value);
+        size_t max_bytes = applyVisitor(FieldVisitorConvertToNumber<size_t>(), typeid_cast<ASTLiteral &>(*args[8]).value);
 
         return StorageBuffer::create(
             table_name, columns,
@@ -606,14 +606,14 @@ StoragePtr StorageFactory::get(
         String destination_database = static_cast<const ASTLiteral &>(*args[0]).value.safeGet<String>();
         String destination_table    = static_cast<const ASTLiteral &>(*args[1]).value.safeGet<String>();
 
-        size_t num_blocks_to_deduplicate = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[2]).value);
+        size_t num_blocks_to_deduplicate = applyVisitor(FieldVisitorConvertToNumber<size_t>(), typeid_cast<ASTLiteral &>(*args[2]).value);
 
-        time_t min_time = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[3]).value);
-        time_t max_time = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[4]).value);
-        size_t min_rows = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[5]).value);
-        size_t max_rows = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[6]).value);
-        size_t min_bytes = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[7]).value);
-        size_t max_bytes = applyVisitor(FieldVisitorConvertToNumber<UInt64>(), typeid_cast<ASTLiteral &>(*args[8]).value);
+        time_t min_time = applyVisitor(FieldVisitorConvertToNumber<time_t>(), typeid_cast<ASTLiteral &>(*args[3]).value);
+        time_t max_time = applyVisitor(FieldVisitorConvertToNumber<time_t>(), typeid_cast<ASTLiteral &>(*args[4]).value);
+        size_t min_rows = applyVisitor(FieldVisitorConvertToNumber<size_t>(), typeid_cast<ASTLiteral &>(*args[5]).value);
+        size_t max_rows = applyVisitor(FieldVisitorConvertToNumber<size_t>(), typeid_cast<ASTLiteral &>(*args[6]).value);
+        size_t min_bytes = applyVisitor(FieldVisitorConvertToNumber<size_t>(), typeid_cast<ASTLiteral &>(*args[7]).value);
+        size_t max_bytes = applyVisitor(FieldVisitorConvertToNumber<size_t>(), typeid_cast<ASTLiteral &>(*args[8]).value);
 
         String path_in_zk_for_deduplication = static_cast<const ASTLiteral &>(*args[9]).value.safeGet<String>();
 

--- a/dbms/src/Storages/StorageKafka.cpp
+++ b/dbms/src/Storages/StorageKafka.cpp
@@ -121,7 +121,7 @@ public:
     {
         // Always skip unknown fields regardless of the context (JSON or TSKV)
         Context context = context_;
-        context.setSetting("input_format_skip_unknown_fields", UInt64(1));
+        context.setSetting("input_format_skip_unknown_fields", 1UL);
         if (schema.size() > 0)
             context.setSetting("schema", schema);
         // Create a formatted reader on Kafka messages


### PR DESCRIPTION
This partially reverts previous patch and adds conditional conversions for missing `unsigned long`.