### PR TITLE
Summing compaction fixes

### DIFF
--- a/dbms/src/AggregateFunctions/AggregateFunctionSum.cpp
+++ b/dbms/src/AggregateFunctions/AggregateFunctionSum.cpp
@@ -13,6 +13,19 @@ AggregateFunctionPtr createAggregateFunctionSum(const std::string & name, const 
     if (argument_types.size() != 1)
         throw Exception("Incorrect number of arguments for aggregate function " + name, ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
 
+    AggregateFunctionPtr res(createWithNumericTypeNearest<AggregateFunctionSum>(*argument_types[0]));
+
+    if (!res)
+        throw Exception("Illegal type " + argument_types[0]->getName() + " of argument for aggregate function " + name, ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+
+    return res;
+}
+
+AggregateFunctionPtr createAggregateFunctionSumWithOverflow(const std::string & name, const DataTypes & argument_types, const Array & parameters)
+{
+    if (argument_types.size() != 1)
+        throw Exception("Incorrect number of arguments for aggregate function " + name, ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
+
     AggregateFunctionPtr res(createWithNumericType<AggregateFunctionSum>(*argument_types[0]));
 
     if (!res)
@@ -26,6 +39,7 @@ AggregateFunctionPtr createAggregateFunctionSum(const std::string & name, const 
 void registerAggregateFunctionSum(AggregateFunctionFactory & factory)
 {
     factory.registerFunction("sum", createAggregateFunctionSum, AggregateFunctionFactory::CaseInsensitive);
+    factory.registerFunction("sumWithOverflow", createAggregateFunctionSumWithOverflow);
 }
 
 }

--- a/dbms/src/AggregateFunctions/AggregateFunctionSum.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionSum.h
@@ -20,15 +20,15 @@ struct AggregateFunctionSumData
 
 
 /// Counts the sum of the numbers.
-template <typename T>
-class AggregateFunctionSum final : public IUnaryAggregateFunction<AggregateFunctionSumData<typename NearestFieldType<T>::Type>, AggregateFunctionSum<T>>
+template <typename T, typename TResult = T>
+class AggregateFunctionSum final : public IUnaryAggregateFunction<AggregateFunctionSumData<TResult>, AggregateFunctionSum<T, TResult>>
 {
 public:
     String getName() const override { return "sum"; }
 
     DataTypePtr getReturnType() const override
     {
-        return std::make_shared<DataTypeNumber<typename NearestFieldType<T>::Type>>();
+        return std::make_shared<DataTypeNumber<TResult>>();
     }
 
     void setArgument(const DataTypePtr & argument)
@@ -61,7 +61,7 @@ public:
 
     void insertResultInto(ConstAggregateDataPtr place, IColumn & to) const override
     {
-        static_cast<ColumnVector<typename NearestFieldType<T>::Type> &>(to).getData().push_back(this->data(place).sum);
+        static_cast<ColumnVector<TResult> &>(to).getData().push_back(this->data(place).sum);
     }
 
     const char * getHeaderFilePath() const override { return __FILE__; }

--- a/dbms/src/AggregateFunctions/Helpers.h
+++ b/dbms/src/AggregateFunctions/Helpers.h
@@ -15,7 +15,7 @@ namespace DB
 
 /** Create an aggregate function with a numeric type in the template parameter, depending on the type of the argument.
   */
-template <template <typename> class AggregateFunctionTemplate>
+template <template <typename, typename ... TArgs> class AggregateFunctionTemplate>
 static IAggregateFunction * createWithNumericType(const IDataType & argument_type)
 {
          if (typeid_cast<const DataTypeUInt8 *>(&argument_type)) return new AggregateFunctionTemplate<UInt8>;
@@ -87,6 +87,26 @@ static IAggregateFunction * createWithNumericType(const IDataType & argument_typ
     else if (typeid_cast<const DataTypeFloat64 *>(&argument_type)) return new AggregateFunctionTemplate<Float64, Data<Float64>>;
     else if (typeid_cast<const DataTypeEnum8 *>(&argument_type)) return new AggregateFunctionTemplate<UInt8, Data<UInt8>>;
     else if (typeid_cast<const DataTypeEnum16 *>(&argument_type)) return new AggregateFunctionTemplate<UInt16, Data<UInt16>>;
+    else
+        return nullptr;
+}
+
+
+template <template <typename, typename> class AggregateFunctionTemplate>
+static IAggregateFunction * createWithNumericTypeNearest(const IDataType & argument_type)
+{
+         if (typeid_cast<const DataTypeUInt8 *>(&argument_type)) return new AggregateFunctionTemplate<UInt8, NearestFieldType<UInt8>::Type>;
+    else if (typeid_cast<const DataTypeUInt16 *>(&argument_type)) return new AggregateFunctionTemplate<UInt16, NearestFieldType<UInt16>::Type>;
+    else if (typeid_cast<const DataTypeUInt32 *>(&argument_type)) return new AggregateFunctionTemplate<UInt32, NearestFieldType<UInt32>::Type>;
+    else if (typeid_cast<const DataTypeUInt64 *>(&argument_type)) return new AggregateFunctionTemplate<UInt64, NearestFieldType<UInt64>::Type>;
+    else if (typeid_cast<const DataTypeInt8 *>(&argument_type)) return new AggregateFunctionTemplate<Int8, NearestFieldType<Int8>::Type>;
+    else if (typeid_cast<const DataTypeInt16 *>(&argument_type)) return new AggregateFunctionTemplate<Int16, NearestFieldType<Int16>::Type>;
+    else if (typeid_cast<const DataTypeInt32 *>(&argument_type)) return new AggregateFunctionTemplate<Int32, NearestFieldType<Int32>::Type>;
+    else if (typeid_cast<const DataTypeInt64 *>(&argument_type)) return new AggregateFunctionTemplate<Int64, NearestFieldType<Int64>::Type>;
+    else if (typeid_cast<const DataTypeFloat32 *>(&argument_type)) return new AggregateFunctionTemplate<Float32, NearestFieldType<Float32>::Type>;
+    else if (typeid_cast<const DataTypeFloat64 *>(&argument_type)) return new AggregateFunctionTemplate<Float64, NearestFieldType<Float64>::Type>;
+    else if (typeid_cast<const DataTypeEnum8 *>(&argument_type)) return new AggregateFunctionTemplate<UInt8, NearestFieldType<UInt8>::Type>;
+    else if (typeid_cast<const DataTypeEnum16 *>(&argument_type)) return new AggregateFunctionTemplate<UInt16, NearestFieldType<UInt16>::Type>;
     else
         return nullptr;
 }

--- a/dbms/src/DataStreams/SummingSortedBlockInputStream.cpp
+++ b/dbms/src/DataStreams/SummingSortedBlockInputStream.cpp
@@ -152,7 +152,7 @@ Block SummingSortedBlockInputStream::readImpl()
                     auto desc = AggregateDescription{};
                     desc.column_numbers = {i};
                     desc.merged_column = column.column;
-                    desc.function = factory.get("sum", {column.type});
+                    desc.function = factory.get("sumWithOverflow", {column.type});
                     desc.function->setArguments({column.type});
                     desc.state.resize(desc.function->sizeOfData());
                     columns_to_aggregate.emplace_back(std::move(desc));

--- a/dbms/src/DataStreams/tests/aggregating_stream.cpp
+++ b/dbms/src/DataStreams/tests/aggregating_stream.cpp
@@ -54,8 +54,8 @@ int main(int argc, char ** argv)
 
         ColumnWithTypeAndName column_x;
         column_x.name = "x";
-        column_x.type = std::make_shared<DataTypeUInt64>();
-        auto x = std::make_shared<ColumnUInt64>();
+        column_x.type = std::make_shared<DataTypeUInt32>();
+        auto x = std::make_shared<ColumnUInt32>();
         column_x.column = x;
         auto & vec_x = x->getData();
 

--- a/dbms/tests/queries/0_stateless/00043_summing_empty_part.sql
+++ b/dbms/tests/queries/0_stateless/00043_summing_empty_part.sql
@@ -10,6 +10,7 @@ SELECT * FROM test.empty_summing;
 
 INSERT INTO test.empty_summing VALUES ('2015-01-01', 1, 4),('2015-01-01', 2, -9),('2015-01-01', 3, -14);
 INSERT INTO test.empty_summing VALUES ('2015-01-01', 1, -2),('2015-01-01', 1, -2),('2015-01-01', 3, 14);
+INSERT INTO test.empty_summing VALUES ('2015-01-01', 1, 0),('2015-01-01', 3, 0);
 
 OPTIMIZE TABLE test.empty_summing;
 SELECT * FROM test.empty_summing;

--- a/dbms/tests/queries/0_stateless/00507_sumwithoverflow.reference
+++ b/dbms/tests/queries/0_stateless/00507_sumwithoverflow.reference
@@ -1,0 +1,6 @@
+UInt64
+UInt16
+Float64
+Float32
+4950
+4950

--- a/dbms/tests/queries/0_stateless/00507_sumwithoverflow.sql
+++ b/dbms/tests/queries/0_stateless/00507_sumwithoverflow.sql
@@ -1,0 +1,7 @@
+SELECT toTypeName(sum(n)) FROM (SELECT toUInt16(number) AS n FROM system.numbers LIMIT 100);
+SELECT toTypeName(sumWithOverflow(n)) FROM (SELECT toUInt16(number) AS n FROM system.numbers LIMIT 100);
+SELECT toTypeName(sum(n)) FROM (SELECT toFloat32(number) AS n FROM system.numbers LIMIT 100);
+SELECT toTypeName(sumWithOverflow(n)) FROM (SELECT toFloat32(number) AS n FROM system.numbers LIMIT 100);
+
+SELECT sum(n) FROM (SELECT toUInt16(number) AS n FROM system.numbers LIMIT 100);
+SELECT sumWithOverflow(n) FROM (SELECT toUInt16(number) AS n FROM system.numbers LIMIT 100);

--- a/docs/en/agg_functions/index.rst
+++ b/docs/en/agg_functions/index.rst
@@ -44,6 +44,10 @@ sum(x)
 Calculates the sum.
 Only works for numbers.
 
+sumWithOverflow(x)
+------------------
+Calculates the sum of numbers using the same data type as the input. If the sum of values is larger than the maximum value for given type, it will overflow. Only works for numbers.
+
 sumMap(key, value)
 ------
 Performs summation of array 'value' by corresponding keys of array 'key'.


### PR DESCRIPTION
This fixes several problems in test related to compaction:

* Keys with zero values are compacted in `sumMap`
* Fixed SummingMergeTree in case an explicit list of columns to sum is given in configuration
* Summation of non-UInt64 columns is fixed, the aggregation now uses `sumWithOverflow(x)` which is a variant of `sum(x)` function that uses same data type for return value as the input type
