### PR TITLE
ZooKeeper: fixed stack smashing with tryGet()

### DIFF
--- a/dbms/src/Common/ZooKeeper/ZooKeeper.cpp
+++ b/dbms/src/Common/ZooKeeper/ZooKeeper.cpp
@@ -454,14 +454,16 @@ bool ZooKeeper::existsWatch(const std::string & path, Stat * stat_, const WatchC
 
 int32_t ZooKeeper::getImpl(const std::string & path, std::string & res, Stat * stat_, WatchCallback watch_callback)
 {
-    char buffer[MAX_NODE_SIZE];
+    std::vector<char> buffer;
+    buffer.reserve(MAX_NODE_SIZE);
     int buffer_len = MAX_NODE_SIZE;
+
     int32_t code;
     Stat stat;
     watcher_fn watcher = watch_callback ? processCallback : nullptr;
     WatchContext * context = createContext(std::move(watch_callback));
 
-    code = zoo_wget(impl, path.c_str(), watcher, context, buffer, &buffer_len, &stat);
+    code = zoo_wget(impl, path.c_str(), watcher, context, buffer.data(), &buffer_len, &stat);
     ProfileEvents::increment(ProfileEvents::ZooKeeperGet);
     ProfileEvents::increment(ProfileEvents::ZooKeeperTransactions);
 
@@ -473,7 +475,7 @@ int32_t ZooKeeper::getImpl(const std::string & path, std::string & res, Stat * s
         if (buffer_len < 0)        /// This can happen if the node contains NULL. Do not distinguish it from the empty string.
             res.clear();
         else
-            res.assign(buffer, buffer_len);
+            res.assign(buffer.data(), buffer_len);
     }
     else
     {

--- a/dbms/src/Common/ZooKeeper/ZooKeeper.cpp
+++ b/dbms/src/Common/ZooKeeper/ZooKeeper.cpp
@@ -455,7 +455,7 @@ bool ZooKeeper::existsWatch(const std::string & path, Stat * stat_, const WatchC
 int32_t ZooKeeper::getImpl(const std::string & path, std::string & res, Stat * stat_, WatchCallback watch_callback)
 {
     std::vector<char> buffer;
-    buffer.reserve(MAX_NODE_SIZE);
+    buffer.resize(MAX_NODE_SIZE);
     int buffer_len = MAX_NODE_SIZE;
 
     int32_t code;


### PR DESCRIPTION
The `tryGet()` operation creates a 1MB buffer on stack. This may or may not work depending on the default stack size for threads, whether the stack protector is enabled or not, recursion depth, and the actual value size.

This is probably going to slow down some ZK operations, but I don't see how else this could work reliably with the existing API. We could make a bigger safe margin by using large stacks for threads, but that's not correct either and I don't think it's going to be supported in all Poco thread implementations.