### PR TITLE
Kafka engine improvements from #1331

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "contrib/librdkafka"]
-	path = contrib/librdkafka
-	url = https://github.com/edenhill/librdkafka.git
 [submodule "contrib/zookeeper"]
 	path = contrib/zookeeper
 	url = https://github.com/ClickHouse-Extras/zookeeper.git
@@ -13,3 +10,6 @@
 [submodule "contrib/lz4"]
 	path = contrib/lz4
 	url = https://github.com/lz4/lz4.git
+[submodule "contrib/librdkafka"]
+	path = contrib/librdkafka
+	url = https://github.com/edenhill/librdkafka.git

--- a/dbms/src/DataStreams/JSONEachRowRowInputStream.cpp
+++ b/dbms/src/DataStreams/JSONEachRowRowInputStream.cpp
@@ -61,7 +61,14 @@ static void skipColonDelimeter(ReadBuffer & istr)
 bool JSONEachRowRowInputStream::read(Block & block)
 {
     skipWhitespaceIfAny(istr);
-    if (!istr.eof() && (*istr.position() == ',' || *istr.position() == ';'))    /// Semicolon is added for convenience as it could be used at end of INSERT query.
+    
+    /// We consume ;, or \n before scanning a new row, instead scanning to next row at the end.
+    /// The reason is that if we want an exact number of rows read with LIMIT x 
+    /// from a streaming table engine with text data format, like File or Kafka
+    /// then seeking to next ;, or \n would trigger reading of an extra row at the end.
+    
+    /// Semicolon is added for convenience as it could be used at end of INSERT query.
+    if (!istr.eof() && (*istr.position() == ',' || *istr.position() == ';'))
         ++istr.position();
 
     skipWhitespaceIfAny(istr);

--- a/dbms/src/DataStreams/JSONEachRowRowInputStream.cpp
+++ b/dbms/src/DataStreams/JSONEachRowRowInputStream.cpp
@@ -61,6 +61,10 @@ static void skipColonDelimeter(ReadBuffer & istr)
 bool JSONEachRowRowInputStream::read(Block & block)
 {
     skipWhitespaceIfAny(istr);
+    if (!istr.eof() && (*istr.position() == ',' || *istr.position() == ';'))    /// Semicolon is added for convenience as it could be used at end of INSERT query.
+        ++istr.position();
+
+    skipWhitespaceIfAny(istr);
     if (istr.eof())
         return false;
 
@@ -122,10 +126,6 @@ bool JSONEachRowRowInputStream::read(Block & block)
         auto & col = block.getByPosition(index);
         col.type->deserializeTextJSON(*col.column, istr);
     }
-
-    skipWhitespaceIfAny(istr);
-    if (!istr.eof() && (*istr.position() == ',' || *istr.position() == ';'))    /// Semicolon is added for convenience as it could be used at end of INSERT query.
-        ++istr.position();
 
     /// Fill non-visited columns with the default values.
     for (size_t i = 0; i < columns; ++i)

--- a/dbms/src/Interpreters/Settings.h
+++ b/dbms/src/Interpreters/Settings.h
@@ -308,7 +308,7 @@ struct Settings
     /* Timeout for flushing data from streaming storages. */ \
     M(SettingMilliseconds, stream_flush_interval_ms, DEFAULT_QUERY_LOG_FLUSH_INTERVAL_MILLISECONDS) \
     /* Schema identifier (used by schema-based formats) */ \
-    M(SettingString, schema, "")
+    M(SettingString, format_schema, "")
 
 
     /// Possible limits for query execution.

--- a/dbms/src/Storages/StorageKafka.cpp
+++ b/dbms/src/Storages/StorageKafka.cpp
@@ -123,7 +123,7 @@ public:
         Context context = context_;
         context.setSetting("input_format_skip_unknown_fields", UInt64(1));
         if (schema.size() > 0)
-            context.setSetting("schema", schema);
+            context.setSetting("format_schema", schema);
         // Create a formatted reader on Kafka messages
         LOG_TRACE(storage.log, "Creating formatted reader");
         read_buf = std::make_unique<ReadBufferFromKafkaConsumer>(storage.consumer, max_block_size, storage.log);

--- a/dbms/src/Storages/StorageKafka.cpp
+++ b/dbms/src/Storages/StorageKafka.cpp
@@ -191,15 +191,15 @@ StorageKafka::StorageKafka(
     std::vector<char> errstr(512);
 
     LOG_TRACE(log, "Setting brokers: " << brokers_);
-    if (rd_kafka_conf_set(conf, "metadata.broker.list", brokers_.c_str(), errstr.data(), errstr.capacity()) != RD_KAFKA_CONF_OK)
+    if (rd_kafka_conf_set(conf, "metadata.broker.list", brokers_.c_str(), errstr.data(), errstr.size()) != RD_KAFKA_CONF_OK)
         throw Exception(String(errstr.data()), ErrorCodes::INCORRECT_DATA);
 
     LOG_TRACE(log, "Setting Group ID: " << group_ << " Client ID: clickhouse");
 
-    if (rd_kafka_conf_set(conf, "group.id", group_.c_str(), errstr.data(), errstr.capacity()) != RD_KAFKA_CONF_OK)
+    if (rd_kafka_conf_set(conf, "group.id", group_.c_str(), errstr.data(), errstr.size()) != RD_KAFKA_CONF_OK)
         throw Exception(String(errstr.data()), ErrorCodes::INCORRECT_DATA);
 
-    if (rd_kafka_conf_set(conf, "client.id", VERSION_FULL, errstr.data(), errstr.capacity()) != RD_KAFKA_CONF_OK)
+    if (rd_kafka_conf_set(conf, "client.id", VERSION_FULL, errstr.data(), errstr.size()) != RD_KAFKA_CONF_OK)
         throw Exception(String(errstr.data()), ErrorCodes::INCORRECT_DATA);
 
     // Don't store offsets of messages before they're processed
@@ -243,7 +243,7 @@ void StorageKafka::startup()
     std::vector<char> errstr(512);
 
     // Create a consumer from saved configuration
-    consumer = rd_kafka_new(RD_KAFKA_CONSUMER, conf, errstr.data(), errstr.capacity());
+    consumer = rd_kafka_new(RD_KAFKA_CONSUMER, conf, errstr.data(), errstr.size());
     if (consumer == nullptr)
         throw Exception("Failed to create consumer handle: " + String(errstr.data()), ErrorCodes::UNKNOWN_EXCEPTION);
 

--- a/dbms/src/Storages/StorageKafka.cpp
+++ b/dbms/src/Storages/StorageKafka.cpp
@@ -1,4 +1,5 @@
 #include <Common/config.h>
+#include <Common/config_version.h>
 #if USE_RDKAFKA
 
 #include <thread>
@@ -199,7 +200,7 @@ StorageKafka::StorageKafka(
     if (rd_kafka_conf_set(conf, "group.id", group_.c_str(), errstr.data(), errstr.capacity()) != RD_KAFKA_CONF_OK)
         throw Exception(String(errstr.data()), ErrorCodes::INCORRECT_DATA);
 
-    if (rd_kafka_conf_set(conf, "client.id", "clickhouse", errstr.data(), errstr.capacity()) != RD_KAFKA_CONF_OK)
+    if (rd_kafka_conf_set(conf, "client.id", VERSION_FULL, errstr.data(), errstr.capacity()) != RD_KAFKA_CONF_OK)
         throw Exception(String(errstr.data()), ErrorCodes::INCORRECT_DATA);
 
     // Don't store offsets of messages before they're processed

--- a/dbms/src/Storages/StorageKafka.cpp
+++ b/dbms/src/Storages/StorageKafka.cpp
@@ -188,8 +188,7 @@ StorageKafka::StorageKafka(
     columns(columns_), topics(topics_), format_name(format_name_), schema_name(schema_name_),
     conf(rd_kafka_conf_new()), log(&Logger::get("StorageKafka (" + table_name_ + ")"))
 {
-    std::vector<char> errstr;
-    errstr.reserve(512);
+    std::vector<char> errstr(512);
 
     LOG_TRACE(log, "Setting brokers: " << brokers_);
     if (rd_kafka_conf_set(conf, "metadata.broker.list", brokers_.c_str(), errstr.data(), errstr.capacity()) != RD_KAFKA_CONF_OK)
@@ -241,8 +240,7 @@ BlockInputStreams StorageKafka::read(
 
 void StorageKafka::startup()
 {
-    std::vector<char> errstr;
-    errstr.reserve(512);
+    std::vector<char> errstr(512);
 
     // Create a consumer from saved configuration
     consumer = rd_kafka_new(RD_KAFKA_CONSUMER, conf, errstr.data(), errstr.capacity());


### PR DESCRIPTION
This addresses a few comments from #1331:
* Renamed `schema` to `format_schema`
* Uses `std::vector<char>` for error string buffers instead of stack arrays
* Updated librdkafka to latest version with build fixes from @proller 

This changes `JSONEachRowInputStream` to consume `;` or `\n` before scanning a new row, instead scanning to next row at the end. The reason is that if we want an exact number of rows read with `LIMIT x` for example, seeking to next `;` or `\n` would trigger reading of an extra row at the end.