### PR TITLE
DataStreams: CapnProto uses <format_schema_path> config option

### DIFF
--- a/dbms/src/DataStreams/CapnProtoRowInputStream.h
+++ b/dbms/src/DataStreams/CapnProtoRowInputStream.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <Common/config.h>
+#if USE_CAPNP
 
 #include <Core/Block.h>
 #include <DataStreams/IRowInputStream.h>
@@ -26,10 +28,11 @@ public:
     };
     using NestedFieldList = std::vector<NestedField>;
 
-    /** schema_file - location of the capnproto schema, e.g. "schema.canpn"
+    /** schema_dir  - base path for schema files
+      * schema_file - location of the capnproto schema, e.g. "schema.canpn"
       * root_object - name to the root object, e.g. "Message"
       */
-    CapnProtoRowInputStream(ReadBuffer & istr_, const Block & sample_, const String & schema_file, const String & root_object);
+    CapnProtoRowInputStream(ReadBuffer & istr_, const Block & sample_, const String & schema_dir, const String & schema_file, const String & root_object);
 
     bool read(Block & block) override;
 
@@ -66,3 +69,5 @@ private:
 };
 
 }
+
+#endif // USE_CAPNP

--- a/dbms/src/DataStreams/FormatFactory.cpp
+++ b/dbms/src/DataStreams/FormatFactory.cpp
@@ -105,9 +105,10 @@ BlockInputStreamPtr FormatFactory::getInput(const String & name, ReadBuffer & bu
         auto schema_and_root = settings.format_schema.toString();
         boost::split(tokens, schema_and_root, boost::is_any_of(":"));
         if (tokens.size() != 2)
-            throw Exception("Format CapnProto requires 'format_schema' setting to have schema_file:root_object format, e.g. 'schema.capnp:Message'");
+            throw Exception("Format CapnProto requires 'format_schema' setting to have a schema_file:root_object format, e.g. 'schema.capnp:Message'");
 
-        return wrap_row_stream(std::make_shared<CapnProtoRowInputStream>(buf, sample, tokens[0], tokens[1]));
+        const String & schema_dir = context.getFormatSchemaPath();
+        return wrap_row_stream(std::make_shared<CapnProtoRowInputStream>(buf, sample, schema_dir, tokens[0], tokens[1]));
     }
 #endif
     else if (name == "TabSeparatedRaw"

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -133,6 +133,7 @@ struct ContextShared
     mutable std::unique_ptr<CompressionSettingsSelector> compression_settings_selector;
     std::unique_ptr<MergeTreeSettings> merge_tree_settings; /// Settings of MergeTree* engines.
     size_t max_table_size_to_drop = 50000000000lu;          /// Protects MergeTree tables from accidental DROP (50GB by default)
+    String format_schema_path;                              /// Path to a directory that contains schema files used by input formats.
 
 
     /// Named sessions. The user could specify session identifier to reuse settings and temporary tables in subsequent requests.
@@ -1564,6 +1565,16 @@ String Context::getDefaultProfileName() const
 void Context::setDefaultProfileName(const String & name)
 {
     shared->default_profile_name = name;
+}
+
+String Context::getFormatSchemaPath() const
+{
+    return shared->format_schema_path;
+}
+
+void Context::setFormatSchemaPath(const String & path)
+{
+    shared->format_schema_path = path;
 }
 
 

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -354,6 +354,10 @@ public:
     String getDefaultProfileName() const;
     void setDefaultProfileName(const String & name);
 
+    /// Base path for format schemas
+    String getFormatSchemaPath() const;
+    void setFormatSchemaPath(const String & path);
+
     /// User name and session identifier. Named sessions are local to users.
     using SessionKey = std::pair<String, String>;
 

--- a/dbms/src/Server/Server.cpp
+++ b/dbms/src/Server/Server.cpp
@@ -264,6 +264,11 @@ int Server::main(const std::vector<std::string> & args)
     global_context->setDefaultProfileName(default_profile_name);
     global_context->setSetting("profile", default_profile_name);
 
+    /// Set path for format schema files
+    auto format_schema_path = Poco::File(config().getString("format_schema_path", path + "format_schemas/"));
+    global_context->setFormatSchemaPath(format_schema_path.path() + "/");
+    format_schema_path.createDirectories();
+
     LOG_INFO(log, "Loading metadata.");
     loadMetadataSystem(*global_context);
     /// After the system database is created, attach virtual system tables (in addition to query_log and part_log)

--- a/dbms/src/Server/config.xml
+++ b/dbms/src/Server/config.xml
@@ -318,4 +318,9 @@
             </retention>
         </default>
     </graphite_rollup_example>
+
+    <!-- Directory in <clickhouse-path> containing schema files for various input formats.
+         The directory will be created if it doesn't exist.
+      -->
+    <format_schema_path>format_schemas/</format_schema_path>
 </yandex>

--- a/docs/en/formats/capnproto.rst
+++ b/docs/en/formats/capnproto.rst
@@ -5,9 +5,10 @@ Cap'n Proto is a binary message format. Like Protocol Buffers and Thrift (but un
 
 .. code-block:: sql
 
-  SELECT SearchPhrase, count() AS c FROM test.hits GROUP BY SearchPhrase FORMAT CapnProto SETTINGS schema = 'schema.capnp:Message'
+  SELECT SearchPhrase, count() AS c FROM test.hits
+  GROUP BY SearchPhrase FORMAT CapnProto SETTINGS schema = 'schema:Message'
 
-When the schema file looks like:
+When the `schema.capnp` schema file looks like:
 
 .. code-block:: text
 
@@ -15,6 +16,13 @@ When the schema file looks like:
     SearchPhrase @0 :Text;
     c @1 :Uint64;
   }
+
+The schema files are located in the path specified in the configuration file:
+
+.. code-block:: xml
+
+  <!-- Directory containing schema files for various input formats. -->
+  <format_schema_path>format_schemas/</format_schema_path>
 
 Deserialization is almost as efficient as the binary rows format, with typically zero allocation overhead per message.
 

--- a/docs/en/table_engines/kafka.rst
+++ b/docs/en/table_engines/kafka.rst
@@ -12,33 +12,76 @@ A table engine backed by Apache Kafka, a streaming platform having three key cap
   Kafka(broker_list, topic_list, group_name, format[, schema])
 
 Engine parameters:
-broker_list - A comma-separated list of brokers (``localhost:9092``).
-topic_list - List of Kafka topics to consume (``my_topic``).
-group_name - Kafka consumer group name (``group1``). Read offsets are tracked for each consumer group, if you want to consume messages exactly once across cluster, you should use the same group name.
-format - Name of the format used to deserialize messages. It accepts the same values as the ``FORMAT`` SQL statement, for example ``JSONEachRow``.
-schema - Optional schema value for formats that require a schema to interpret consumed messages, for example Cap'n Proto format requires a path to schema file and root object - ``schema.capnp:Message``. Self-describing formats such as JSON don't require any schema.
+
+broker_list
+  A comma-separated list of brokers (``localhost:9092``).
+
+topic_list
+  List of Kafka topics to consume (``my_topic``).
+
+group_name
+  Kafka consumer group name (``group1``). Read offsets are tracked for each consumer group, if you want to consume messages exactly once across cluster, you should use the same group name.
+
+format
+  Name of the format used to deserialize messages. It accepts the same values as the ``FORMAT`` SQL statement, for example ``JSONEachRow``.
+
+schema
+  Optional schema value for formats that require a schema to interpret consumed messages, for example Cap'n Proto format requires
+  a path to schema file and root object - ``schema:Message``. Self-describing formats such as JSON don't require any schema.
 
 Example:
 
 .. code-block:: sql
 
-  CREATE TABLE queue (timestamp UInt64, level String, message String) ENGINE = Kafka('localhost:9092', 'topic', 'group1', 'JSONEachRow');
-  SELECT * FROM queue LIMIT 5
+  CREATE TABLE queue (
+    timestamp UInt64,
+    level String,
+    message String
+  ) ENGINE = Kafka('localhost:9092', 'topic', 'group1', 'JSONEachRow');
 
-The consumed messages are tracked automatically in the background, so each message will be read exactly once in a single consumer group. If you want to consume the same set of messages twice, you can create a copy of the table with a different ``group_name``. The consumer group is elastic and synchronised across the cluster, for example if you have 10 topic/partitions and 5 instances of the table across cluster, it will automatically assign 2 topic/partitions per instace. If you detach a table, or add new instances, it will rebalance topic/partition allocations automatically. See http://kafka.apache.org/intro for more information about how this works.
+  SELECT * FROM queue LIMIT 5;
 
-Reading messages directly however is not very useful, the table engine is typically used to build real-time ingestion pipelines using MATERIALIZED VIEW. If a MATERIALIZED VIEW is attached to a Kafka table engine, it will start consuming messages in the background, and push them into the attached views. This allows you to continuously ingest messages from Kafka and transform them using the SELECT statement into appropriate format.
+The consumed messages are tracked automatically in the background, so each message will be read exactly once in a single consumer group. If you want to consume the same set of messages twice, you can create a copy of the table with a different ``group_name``. The consumer group is elastic and synchronised across the cluster. For example, if you have 10 topic/partitions and 5 instances of the table across cluster, it will automatically assign 2 topic/partitions per instace. If you detach a Kafka engine table (or create new), it will rebalance topic/partition assignments automatically. See `Kafka Introduction <https://kafka.apache.org/intro>`_ for more information about how this works.
+
+Reading messages using SELECT is not very useful (except for troubleshooting), because each message can be read only once.
+The table engine is typically used to build real-time ingestion pipelines using MATERIALIZED VIEW. It works like this:
+
+1. You create a Kafka consumer with a Kafka engine. This is the data stream.
+2. You create an arbitrary table with the desired data schema.
+3. You create a MATERIALIZED VIEW that transforms the data from Kafka, and materializes it into your desired table.
+
+
+When a MATERIALIZED VIEW is attached to a Kafka table engine, it will start automatically consuming messages in the background, and push them into the attached views. This allows you to continuously ingest messages from Kafka and transform them using the SELECT statement to describe transformation.
 
 Example:
 
 .. code-block:: sql
 
-  CREATE TABLE queue (timestamp UInt64, level String, message String) ENGINE = Kafka('localhost:9092', 'topic', 'group1', 'JSONEachRow');
+  CREATE TABLE queue (
+    timestamp UInt64,
+    level String,
+    message String
+  ) ENGINE = Kafka('localhost:9092', 'topic', 'group1', 'JSONEachRow');
 
-  CREATE MATERIALIZED VIEW daily ENGINE = SummingMergeTree(day, (day, level), 8192) AS
-  SELECT toDate(toDateTime(timestamp)) AS day, level, count() as total
-  FROM queue GROUP BY day, level;
+  CREATE TABLE daily (
+    day Date,
+    level String,
+    total UInt64
+  ) ENGINE = SummingMergeTree(day, (day, level), 8192);
+
+  CREATE MATERIALIZED VIEW consumer TO daily
+    AS SELECT toDate(toDateTime(timestamp)) AS day, level, count() as total
+    FROM queue GROUP BY day, level;
 
   SELECT level, sum(total) FROM daily GROUP BY level;
 
 The messages are streamed into the attached view immediately in the same way a continuous stream of INSERT statement would. To improve performance, consumed messages are squashed into batches of ``max_insert_block_size``. If the message batch cannot be completed within ``stream_flush_interval_ms`` period (by default 7500ms), it will be flushed to ensure time bounded insertion time.
+
+In order to stop topic consumption, or alter the transformation logc, you simply detach the MATERIALIZED VIEW:
+
+.. code-block:: sql
+
+  DETACH TABLE consumer;
+  ATTACH MATERIALIZED VIEW consumer;
+
+Note: When you're performing ALTERs on target table, it's recommended to detach materializing views to prevent a mismatch between the current schema and the result of MATERIALIZED VIEWS.


### PR DESCRIPTION
This addresses one of the remarks in the PR.

All format schemas are required to be in the <format_schema_path> directory.
This makes loading schema files less tedious, as the path can be omitted.