### PR TITLE
MemoryTracker: fixed build with clang 9.0.0 not properly supporting thread_local

### DIFF
--- a/dbms/src/Common/MemoryTracker.cpp
+++ b/dbms/src/Common/MemoryTracker.cpp
@@ -149,8 +149,11 @@ void MemoryTracker::setOrRaiseLimit(Int64 value)
         ;
 }
 
-
+#if defined(__apple_build_version__) && __apple_build_version__ <= 9000038
+__thread MemoryTracker * current_memory_tracker = nullptr;
+#else
 thread_local MemoryTracker * current_memory_tracker = nullptr;
+#endif
 
 namespace CurrentMemoryTracker
 {

--- a/dbms/src/Common/MemoryTracker.h
+++ b/dbms/src/Common/MemoryTracker.h
@@ -108,7 +108,11 @@ public:
   * This pointer is set when memory consumption is monitored in current thread.
   * So, you just need to pass it to all the threads that handle one request.
   */
+#if defined(__apple_build_version__) && __apple_build_version__ <= 9000038
+extern __thread MemoryTracker * current_memory_tracker;
+#else
 extern thread_local MemoryTracker * current_memory_tracker;
+#endif
 
 /// Convenience methods, that use current_memory_tracker if it is available.
 namespace CurrentMemoryTracker


### PR DESCRIPTION
This fixes #1488.

XCode 9.0 added support for C++11 thread_local:
https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html

The 443088ce3134b1c61e9bc746ed9306bdf0f4c067 replaced __thread with C++11 thread_local, which
broke the compilation for this platform with an error on link time.

I can't reproduce this with a minimal example yet.