### PR TITLE
Fix clang error on osx

### DIFF
--- a/libs/libcommon/src/mremap.cpp
+++ b/libs/libcommon/src/mremap.cpp
@@ -2,6 +2,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <sys/mman.h>
+#include <errno.h>
 #include <common/mremap.h>
 
 #if defined(MREMAP_FIXED)


### PR DESCRIPTION
Fix clang error on osx regression from a2b8ae3100d84741e69b59ab2ef4187969e17b50