### PR TITLE
Stick to standard iterator invalidation rules

### DIFF
--- a/dbms/src/Core/Block.cpp
+++ b/dbms/src/Core/Block.cpp
@@ -174,7 +174,7 @@ void Block::eraseImpl(size_t position)
     for (auto it = index_by_name.begin(); it != index_by_name.end();)
     {
         if (it->second == position)
-            index_by_name.erase(it++);
+            it = index_by_name.erase(it);
         else
         {
             if (it->second > position)


### PR DESCRIPTION
It seems value computation of the expression is sequenced before the side effect of post-increment, value computation of an argument is sequenced before the function call, but there's no sequencing between the function call and the side effect of the post-increment. So when the ++ happens is indeterminate in c++ specification.