### PR TITLE
Fixes StorageJoin's sample block order.

### DIFF
--- a/dbms/src/Storages/StorageJoin.cpp
+++ b/dbms/src/Storages/StorageJoin.cpp
@@ -43,7 +43,7 @@ StorageJoin::StorageJoin(
     /// NOTE StorageJoin doesn't use join_use_nulls setting.
 
     join = std::make_shared<Join>(key_names, key_names, false /* use_nulls */, Limits(), kind, strictness);
-    join->setSampleBlock(getSampleBlock());
+    join->setSampleBlock(getSampleBlock().sortColumns());
     restore();
 }
 


### PR DESCRIPTION
Here is a reproducible test case.
```
create table e (s UInt64, t UInt64) Engine = Memory;
create table v (s UInt64, w Float64, c UInt64) Engine = Join(Any, Inner, s);
insert into e values (1, 2), (1, 3), (1, 4), (2, 1), (2, 4), (3, 1), (4, 2), (4, 3);
insert into v values (1, 0.5, 3), (2, 0.5, 2), (3, 1, 1), (4, 0.5, 2);
select *, w, c from e any inner join v using (s);
```

# before this patch
```
┌─s─┬─t─┬─────w─┬──────────c─┐
│ 1 │ 2 │ 4e-45 │ 1051372192 │
│ 1 │ 3 │ 4e-45 │ 1051372192 │
│ 1 │ 4 │ 4e-45 │ 1051372192 │
│ 2 │ 1 │ 3e-45 │ 1056964608 │
│ 2 │ 4 │ 3e-45 │ 1056964608 │
│ 3 │ 1 │ 1e-45 │ 1065353216 │
│ 4 │ 2 │ 3e-45 │ 1056964608 │
│ 4 │ 3 │ 3e-45 │ 1056964608 │
└───┴───┴───────┴────────────┘
```
# after this patch
```
┌─s─┬─t─┬───w─┬─c─┐
│ 1 │ 2 │ 0.5 │ 3 │
│ 1 │ 3 │ 0.5 │ 3 │
│ 1 │ 4 │ 0.5 │ 3 │
│ 2 │ 1 │ 0.5 │ 2 │
│ 2 │ 4 │ 0.5 │ 2 │
│ 3 │ 1 │   1 │ 1 │
│ 4 │ 2 │ 0.5 │ 2 │
│ 4 │ 3 │ 0.5 │ 2 │
└───┴───┴─────┴───┘
```