### PR TITLE
Make malformed `array join` statement fail early

### DIFF
--- a/dbms/src/Parsers/ParserTablesInSelectQuery.cpp
+++ b/dbms/src/Parsers/ParserTablesInSelectQuery.cpp
@@ -120,13 +120,13 @@ bool ParserTablesInSelectQueryElement::parseImpl(Pos & pos, ASTPtr & node, Expec
 {
     auto res = std::make_shared<ASTTablesInSelectQueryElement>();
 
-    if (ParserArrayJoin().parse(pos, res->array_join, expected))
-    {
-    }
-    else if (is_first)
+    if (is_first)
     {
         if (!ParserTableExpression().parse(pos, res->table_expression, expected))
             return false;
+    }
+    else if (ParserArrayJoin().parse(pos, res->array_join, expected))
+    {
     }
     else
     {


### PR DESCRIPTION
Currently array join clause that have no parent table can go through the parser and generates some confusing error. (due to the missing of first table, system.one is used)
```
create table aa (a Array(UInt64)) Engine=Memory;
select * from array join aa;

Received exception from server (version 1.1.54311):
Code: 208. DB::Exception: Received from localhost:9000, ::1. DB::Exception: No columns in nested table aa.
```

This patch makes it fail at client side. 
```
Syntax error: failed at position 21:

select * from array join aa;

Expected one of: SAMPLE, INNER, WITH, HAVING, SETTINGS, identifier, Dot, ORDER BY, AS, GROUP BY, INTO OUTFILE, UNION ALL, LEFT ARRAY JOIN, ARRAY JOIN, table, table function, subquery or list of joined tables, array join, alias, FINAL, PREWHERE, WHERE, token, FORMAT, LIMIT
```

However I'm not sure if `ParserCompoundIdentifier` should be stricter so that `array` wouldn't be consider as a table name.