### PR TITLE
Add GCD and LCM functions

### DIFF
--- a/dbms/src/Functions/CMakeLists.txt
+++ b/dbms/src/Functions/CMakeLists.txt
@@ -24,6 +24,8 @@ generate_function_register(Arithmetic
   FunctionBitTest
   FunctionBitTestAny
   FunctionBitTestAll
+  FunctionGCD
+  FunctionLCM
 )
 
 generate_function_register(Array

--- a/dbms/src/Functions/FunctionsArithmetic.h
+++ b/dbms/src/Functions/FunctionsArithmetic.h
@@ -15,6 +15,7 @@
 #include <Common/typeid_cast.h>
 #include <IO/WriteHelpers.h>
 #include <ext/range.h>
+#include <boost/math/common_factor.hpp>
 
 
 namespace DB
@@ -429,6 +430,38 @@ struct AbsImpl
     static inline ResultType apply(T a, typename std::enable_if<std::is_floating_point<T>::value, void>::type * = nullptr)
     {
         return static_cast<ResultType>(std::abs(a));
+    }
+};
+
+template <typename A, typename B>
+struct GCDImpl
+{
+    using ResultType = typename NumberTraits::ResultOfGCD<A, B>::Type;
+
+    template <typename Result = ResultType>
+    static inline Result apply(A a, B b)
+    {
+        throwIfDivisionLeadsToFPE(typename NumberTraits::ToInteger<A>::Type(a), typename NumberTraits::ToInteger<A>::Type(b));
+        throwIfDivisionLeadsToFPE(typename NumberTraits::ToInteger<A>::Type(b), typename NumberTraits::ToInteger<A>::Type(a));
+        return boost::math::gcd(
+            typename NumberTraits::ToInteger<A>::Type(a),
+            typename NumberTraits::ToInteger<A>::Type(b));
+    }
+};
+
+template <typename A, typename B>
+struct LCMImpl
+{
+    using ResultType = typename NumberTraits::ResultOfLCM<A, B>::Type;
+
+    template <typename Result = ResultType>
+    static inline Result apply(A a, B b)
+    {
+        throwIfDivisionLeadsToFPE(typename NumberTraits::ToInteger<A>::Type(a), typename NumberTraits::ToInteger<A>::Type(b));
+        throwIfDivisionLeadsToFPE(typename NumberTraits::ToInteger<A>::Type(b), typename NumberTraits::ToInteger<A>::Type(a));
+        return boost::math::lcm(
+            typename NumberTraits::ToInteger<A>::Type(a),
+            typename NumberTraits::ToInteger<A>::Type(b));
     }
 };
 
@@ -1002,6 +1035,8 @@ struct NameBitTestAny           { static constexpr auto name = "bitTestAny"; };
 struct NameBitTestAll           { static constexpr auto name = "bitTestAll"; };
 struct NameLeast                { static constexpr auto name = "least"; };
 struct NameGreatest             { static constexpr auto name = "greatest"; };
+struct NameGCD                  { static constexpr auto name = "gcd"; };
+struct NameLCM                  { static constexpr auto name = "lcm"; };
 
 using FunctionPlus = FunctionBinaryArithmetic<PlusImpl, NamePlus>;
 using FunctionMinus = FunctionBinaryArithmetic<MinusImpl, NameMinus>;
@@ -1023,6 +1058,8 @@ using FunctionBitRotateRight = FunctionBinaryArithmetic<BitRotateRightImpl, Name
 using FunctionBitTest = FunctionBinaryArithmetic<BitTestImpl, NameBitTest>;
 using FunctionLeast = FunctionBinaryArithmetic<LeastImpl, NameLeast>;
 using FunctionGreatest = FunctionBinaryArithmetic<GreatestImpl, NameGreatest>;
+using FunctionGCD = FunctionBinaryArithmetic<GCDImpl, NameGCD>;
+using FunctionLCM = FunctionBinaryArithmetic<LCMImpl, NameLCM>;
 
 /// Monotonicity properties for some functions.
 

--- a/dbms/src/Functions/FunctionsArithmetic.h
+++ b/dbms/src/Functions/FunctionsArithmetic.h
@@ -436,7 +436,7 @@ struct AbsImpl
 template <typename A, typename B>
 struct GCDImpl
 {
-    using ResultType = typename NumberTraits::ResultOfGCD<A, B>::Type;
+    using ResultType = typename NumberTraits::ResultOfIntegerDivision<A, B>::Type;
 
     template <typename Result = ResultType>
     static inline Result apply(A a, B b)
@@ -452,7 +452,7 @@ struct GCDImpl
 template <typename A, typename B>
 struct LCMImpl
 {
-    using ResultType = typename NumberTraits::ResultOfLCM<A, B>::Type;
+    using ResultType = typename NumberTraits::ResultOfAdditionMultiplication<A, B>::Type;
 
     template <typename Result = ResultType>
     static inline Result apply(A a, B b)


### PR DESCRIPTION
Пример использования

```sql
SELECT 
    gcd(42, 56), 
    lcm(3, 14)

┌─gcd(42, 56)─┬─lcm(3, 14)─┐
│          14 │         42 │
└─────────────┴────────────┘
```

Кейс из веб аналитики - группировать по соотношению сторон экрана

```sql
:) CREATE TABLE IF NOT EXISTS screen_res
:-] (
:-]     width UInt32, 
:-]     height UInt32
:-] )
:-] ENGINE = Memory

CREATE TABLE IF NOT EXISTS screen_res
(
    width UInt32, 
    height UInt32
)
ENGINE = Memory

Ok.

0 rows in set. Elapsed: 0.003 sec. 

:) INSERT INTO screen_res (width, height) VALUES \
:-]     (160, 200), (256, 192), (320, 200), (320, 240), (320, 256), (400, 240), \
:-]     (400, 288), (640, 200), (480, 272), (512, 256), (466, 288), (480, 320), \
:-]     (640, 256), (640, 256), (640, 272), (512, 342), (640, 288), (512, 384), \
:-]     (640, 350), (720, 348), (720, 350), (640, 400), (720, 360), (640, 480), \
:-]     (640, 512), (800, 480), (854, 466), (854, 480), (800, 600), (784, 640), \
:-]     (800, 640), (960, 540), (1024, 576), (960, 640), (1024, 600), (1152, 648), \
:-]     (1024, 768), (1152, 720), (1200, 720), (1152, 768), (1280, 720), (1120, 832), \
:-]     (1280, 768), (1152, 864), (1280, 800), (1152, 900), (1366, 768), (1280, 854), \
:-]     (1280, 960), (1600, 768), (1440, 900), (1280, 1024), (1536, 864), (1440, 960), \
:-]     (1600, 900), (1400, 1050), (1440, 1080), (1600, 1024), (1680, 1050), (1600, 1200), \
:-]     (1920, 1080), (2048, 1080), (1920, 1200), (2048, 1152), (1920, 1280), (1920, 1440), \
:-]     (2048, 1536), (2560, 1080), (2560, 1440), (2560, 1600), (2880, 1800), (2560, 2048), \
:-]     (3200, 2048), (3280, 2048), (3200, 2400), (3840, 2160), (3840, 2400), (5120, 4096), \
:-]     (6400, 4096), (6400, 4800), (7680, 4320), (7680, 4800)

INSERT INTO screen_res (width, height) VALUES

Ok.

82 rows in set. Elapsed: 0.001 sec. 

:) SELECT 
:-]     greatest(width, height) / gcd(width, height) AS resX, 
:-]     least(width, height) / gcd(width, height) AS resY, 
:-]     count() AS c
:-] FROM screen_res 
:-] GROUP BY 
:-]     resX, 
:-]     resY
:-] ORDER BY c DESC

SELECT 
    greatest(width, height) / gcd(width, height) AS resX, 
    least(width, height) / gcd(width, height) AS resY, 
    count() AS c
FROM screen_res 
GROUP BY 
    resX, 
    resY
ORDER BY c DESC

┌─resX─┬─resY─┬──c─┐
│    4 │    3 │ 15 │
│    8 │    5 │ 11 │
│   16 │    9 │ 11 │
│    5 │    4 │  7 │
│    3 │    2 │  5 │
│    5 │    3 │  4 │
│   25 │   16 │  3 │
│    2 │    1 │  2 │
│    5 │    2 │  2 │
│  256 │  135 │  1 │
│   25 │   12 │  1 │
│  683 │  384 │  1 │
│   49 │   40 │  1 │
│  427 │  233 │  1 │
│   40 │   17 │  1 │
│  256 │  171 │  1 │
│   32 │   25 │  1 │
│   16 │    5 │  1 │
│  205 │  128 │  1 │
│   64 │   35 │  1 │
│   20 │    9 │  1 │
│  128 │   75 │  1 │
│  640 │  427 │  1 │
│   35 │   26 │  1 │
│  233 │  144 │  1 │
│  427 │  240 │  1 │
│   30 │   17 │  1 │
│   25 │   18 │  1 │
│   72 │   35 │  1 │
│   60 │   29 │  1 │
│   64 │   27 │  1 │
└──────┴──────┴────┘

31 rows in set. Elapsed: 0.002 sec. 
```

