### PR TITLE
Propagate readPrefix in ParallelInputsProcessor (take 2)

### DIFF
--- a/dbms/src/DataStreams/ParallelInputsProcessor.h
+++ b/dbms/src/DataStreams/ParallelInputsProcessor.h
@@ -183,7 +183,8 @@ private:
 
         try
         {
-              while (!finish) {
+              while (!finish)
+              {
                 InputData unprepared_input;
                 {
                     std::lock_guard<std::mutex> lock(unprepared_inputs_mutex);


### PR DESCRIPTION
Both UnionBlockInputStream and ParallelAggregatingBlockInputStream rely on ParallelInputsProcessor to do stream preparation in parallel, which seems to be absent. This patch fixes it.

Fix thread unsafty issue in https://github.com/yandex/ClickHouse/pull/1516

Here is a list of inputstreams with meaningful work in readPrefix

```
IProfilingBlockInputStream

AsynchronousBlockInputStream
BlockInputStreamFromRowInputStream
CatBoostDatasetBlockInputStream
CreatingSetsBlockInputStream
CSVRowInputStream
DictionaryBlockInputStreamBase
InputStreamFromASTInsertQuery
KafkaBlockInputStream
MergingAggregatedMemoryEfficientBlockInputStream
RemoteBlockInputStream
StorageFileBlockInputStream
```