### PR TITLE
[clickhouse-yt] more consistent ISecurityManager interface

### DIFF
--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -543,7 +543,7 @@ void Context::calculateUserSettings()
 {
     auto lock = getLock();
 
-    String profile = shared->security_manager->getUser(client_info.current_user).profile;
+    String profile = shared->security_manager->getUser(client_info.current_user)->profile;
 
     /// 1) Set default settings (hardcoded values)
     /// NOTE: we ignore global_context settings (from which it is usually copied)
@@ -564,7 +564,7 @@ void Context::setUser(const String & name, const String & password, const Poco::
 {
     auto lock = getLock();
 
-    const User & user_props = shared->security_manager->authorizeAndGetUser(name, password, address.host());
+    auto user_props = shared->security_manager->authorizeAndGetUser(name, password, address.host());
 
     client_info.current_user = name;
     client_info.current_address = address;
@@ -574,7 +574,7 @@ void Context::setUser(const String & name, const String & password, const Poco::
 
     calculateUserSettings();
 
-    setQuota(user_props.quota, quota_key, name, address.host());
+    setQuota(user_props->quota, quota_key, name, address.host());
 }
 
 

--- a/dbms/src/Interpreters/ISecurityManager.h
+++ b/dbms/src/Interpreters/ISecurityManager.h
@@ -13,16 +13,18 @@ namespace DB
 class ISecurityManager
 {
 public:
+    using UserPtr = std::shared_ptr<const User>;
+
     virtual void loadFromConfig(Poco::Util::AbstractConfiguration & config) = 0;
 
     /// Find user and make authorize checks
-    virtual const User & authorizeAndGetUser(
+    virtual UserPtr authorizeAndGetUser(
         const String & user_name,
         const String & password,
         const Poco::Net::IPAddress & address) const = 0;
 
     /// Just find user
-    virtual const User & getUser(const String & user_name) const = 0;
+    virtual UserPtr getUser(const String & user_name) const = 0;
 
     /// Check if the user has access to the database.
     virtual bool hasAccessToDatabase(const String & user_name, const String & database_name) const = 0;

--- a/dbms/src/Interpreters/SecurityManager.h
+++ b/dbms/src/Interpreters/SecurityManager.h
@@ -13,18 +13,18 @@ namespace DB
 class SecurityManager : public ISecurityManager
 {
 private:
-    using Container = std::map<String, User>;
+    using Container = std::map<String, UserPtr>;
     Container users;
 
 public:
     void loadFromConfig(Poco::Util::AbstractConfiguration & config) override;
 
-    const User & authorizeAndGetUser(
+    UserPtr authorizeAndGetUser(
         const String & user_name,
         const String & password,
         const Poco::Net::IPAddress & address) const override;
 
-    const User & getUser(const String & user_name) const override;
+    UserPtr getUser(const String & user_name) const override;
 
     bool hasAccessToDatabase(const String & user_name, const String & database_name) const override;
 };


### PR DESCRIPTION
Сейчас `ISecurityManager` (бывший `Users`) возвращает пользователя по константной ссылке.

Есть мнение, что с таким интерфейсом невозможно предоставить свободную от гонок реализацию, поскольку при выполнении `reloadFromConfig` мы не можем продлить жизнь ссылкам, которые к этому времени были получены, но еще не прочитаны клиентами.

Сейчас КХ решает эту проблему с помощью внешней по отношению к security manager-y синхронизации в Context.

Предлагается возвращать `shared_ptr<const User>`