### PR TITLE
Remove unused parameter from InterruptListener.h

### DIFF
--- a/dbms/src/Server/InterruptListener.h
+++ b/dbms/src/Server/InterruptListener.h
@@ -17,7 +17,7 @@ namespace ErrorCodes
 
 #ifdef __APPLE__
 // We only need to support timeout = {0, 0} at this moment
-static int sigtimedwait(const sigset_t *set, siginfo_t *info, const struct timespec *timeout) {
+static int sigtimedwait(const sigset_t *set, siginfo_t *info, const struct timespec * /*timeout*/) {
     sigset_t pending;
     int signo;
     sigpending(&pending);


### PR DESCRIPTION
This should fix the compile error:
```
ClickHouse/dbms/src/Server/InterruptListener.h:20:86: error: unused parameter 'timeout' [-Werror,-Wunused-parameter]
static int sigtimedwait(const sigset_t *set, siginfo_t *info, const struct timespec *timeout) {
                                                                                     ^
1 error generated.

```