### PR TITLE
Fix the way clickhouse reads the request body over HTTP.

### DIFF
--- a/dbms/src/Interpreters/executeQuery.cpp
+++ b/dbms/src/Interpreters/executeQuery.cpp
@@ -391,23 +391,30 @@ void executeQuery(
     if (istr.buffer().size() == 0)
         istr.next();
 
-    size_t max_query_size = context.getSettingsRef().max_query_size;
+    size_t bytes_copied = 0;
 
-    if (istr.buffer().end() - istr.position() >= static_cast<ssize_t>(max_query_size))
+    do
     {
-        /// If remaining buffer space in 'istr' is enough to parse query up to 'max_query_size' bytes, then parse inplace.
-        begin = istr.position();
-        end = istr.buffer().end();
-        istr.position() += end - begin;
+        ssize_t buffer_size = istr.buffer().end() - istr.position();
+
+        if(buffer_size == 0)
+            break;
+
+        size_t new_size = bytes_copied + buffer_size;
+
+        //should we protect here against malicious code ? checking for max_query_size seems not ok as
+        //time for inserts the values are ignored
+        //size_t max_query_size = context.getSettingsRef().max_query_size;
+        //if(max_query_size && new_size > max_query_size)
+        //    throw Exception("Query is too large exceeding max_query_size of " + toString(max_query_size), ErrorCodes::QUERY_IS_TOO_LARGE);
+
+        parse_buf.resize(new_size);
+        bytes_copied += istr.read(&parse_buf[bytes_copied], buffer_size);
     }
-    else
-    {
-        /// If not - copy enough data into 'parse_buf'.
-        parse_buf.resize(max_query_size);
-        parse_buf.resize(istr.read(&parse_buf[0], max_query_size));
-        begin = &parse_buf[0];
-        end = begin + parse_buf.size();
-    }
+    while(istr.next());
+
+    begin = &parse_buf[0];
+    end = begin + bytes_copied;
 
     ASTPtr ast;
     BlockIO streams;


### PR DESCRIPTION
Current implementation it's not working properly. This can be tested with any select query that's large than max_query_size. Only up to max_query_size size is read and sent to the parser which leads to an invalid query.