### PR TITLE
Use NULL to check only realine without c++11

### DIFF
--- a/cmake/find_readline_edit.cmake
+++ b/cmake/find_readline_edit.cmake
@@ -46,8 +46,8 @@ if (LINE_EDITING_LIBS AND READLINE_INCLUDE_DIR)
         #include <readline/readline.h>
         #include <readline/history.h>
         int main() {
-            add_history(nullptr);
-            append_history(1,nullptr);
+            add_history(NULL);
+            append_history(1,NULL);
             return 0;
         }
     " HAVE_READLINE_HISTORY)


### PR DESCRIPTION
This check always fails on centos 6 with clang 6. c++ standard flag never gets passed into the compilation command.