### PR TITLE
Fix compilation without SSE 4.2

### DIFF
--- a/dbms/src/Common/UInt128.h
+++ b/dbms/src/Common/UInt128.h
@@ -173,15 +173,7 @@ struct UInt256HashCRC32
 #else
 
 /// We do not need to use CRC32 on other platforms. NOTE This can be confusing.
-struct UInt256HashCRC32
-{
-    DefaultHash<UInt64> hash64;
-    size_t operator()(UInt256 x) const
-    {
-        /// TODO This is not optimal.
-        return hash64(hash64(hash64(hash64(x.a) ^ x.b) ^ x.c) ^ x.d);
-    }
-};
+struct UInt256HashCRC32 : public UInt256Hash {};
 
 #endif
 }


### PR DESCRIPTION
Fixes "'hash64' was not declared in this scope" on aarch64:

```
/home/roman/~rpmbuild/BUILD/ClickHouse-1.1.54326-testing/dbms/src/Common/UInt128.h: At global scope:
/home/roman/~rpmbuild/BUILD/ClickHouse-1.1.54326-testing/dbms/src/Common/UInt128.h:178:5: error: 'DefaultHash' does not name a type
     DefaultHash<UInt64> hash64;
     ^~~~~~~~~~~
/home/roman/~rpmbuild/BUILD/ClickHouse-1.1.54326-testing/dbms/src/Common/UInt128.h: In member function 'size_t DB::UInt256HashCRC32::operator()(DB::UInt256) const':
/home/roman/~rpmbuild/BUILD/ClickHouse-1.1.54326-testing/dbms/src/Common/UInt128.h:182:37: error: 'hash64' was not declared in this scope
         return hash64(hash64(hash64(hash64(x.a) ^ x.b) ^ x.c) ^ x.d);
                                     ^~~~~~
/home/roman/~rpmbuild/BUILD/ClickHouse-1.1.54326-testing/dbms/src/Common/UInt128.h:182:30: error: 'hash64' was not declared in this scope
         return hash64(hash64(hash64(hash64(x.a) ^ x.b) ^ x.c) ^ x.d);
                              ^~~~~~
/home/roman/~rpmbuild/BUILD/ClickHouse-1.1.54326-testing/dbms/src/Common/UInt128.h:182:23: error: 'hash64' was not declared in this scope
         return hash64(hash64(hash64(hash64(x.a) ^ x.b) ^ x.c) ^ x.d);
                       ^~~~~~
/home/roman/~rpmbuild/BUILD/ClickHouse-1.1.54326-testing/dbms/src/Common/UInt128.h:182:16: error: 'hash64' was not declared in this scope
         return hash64(hash64(hash64(hash64(x.a) ^ x.b) ^ x.c) ^ x.d);
                ^~~~~~
In file included from /home/roman/~rpmbuild/BUILD/ClickHouse-1.1.54326-testing/dbms/src/IO/WriteHelpers.h:19:0,
                 from /home/roman/~rpmbuild/BUILD/ClickHouse-1.1.54326-testing/dbms/src/Common/Exception.cpp:9:
```

I can't ind hash64() in `git log`, so probably `hash64(hash64(hash64(hash64(x.a) ^ x.b) ^ x.c) ^ x.d)` is just an artifact. I fixed it in the same way as UInt128HashCRC32:

```
 93 #else                                                                                                                
 94                                                                                                                      
 95 /// On other platforms we do not use CRC32. NOTE This can be confusing.                                              
 96 struct UInt128HashCRC32 : public UInt128Hash {};                                                                     
 97                                                                                                                      
 98 #endif  
```
