### PR TITLE
Fix missing messages in Kafka materialized views

### DIFF
--- a/dbms/src/DataStreams/IProfilingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/IProfilingBlockInputStream.cpp
@@ -38,6 +38,9 @@ Block IProfilingBlockInputStream::read()
     if (is_cancelled.load(std::memory_order_seq_cst))
         return res;
 
+    if (!checkLimits())
+        limit_exceeded_need_break = true;
+
     if (!limit_exceeded_need_break)
         res = readImpl();
 
@@ -47,9 +50,6 @@ Block IProfilingBlockInputStream::read()
 
         if (enabled_extremes)
             updateExtremes(res);
-
-        if (!checkLimits())
-            limit_exceeded_need_break = true;
 
         if (quota != nullptr)
             checkQuota(res);


### PR DESCRIPTION
This PR fixes three small issues:

*  IProfilingBlockInputStream checked limits after reading a block (which would be committed, but not used)
* Limits were applied on the UnionBlockInputStream instead of Kafka streams, which could cause an extra block to be read
* StorageKafka: make commit message only if messages are consumed (this is not an issue, but optimization)

refs #1690