### PR TITLE
fix potential memory issue

### DIFF
--- a/dbms/src/Common/PODArray.h
+++ b/dbms/src/Common/PODArray.h
@@ -122,10 +122,12 @@ protected:
     void reserveForNextSize(TAllocatorParams ... allocator_params)
     {
         if (size() == 0)
+        {
             // The allocated memory should be multiplication of sizeof(T) to hold the element, otherwise,
             // memory issue such as corruption could appear in edge case.
-            realloc(std::max(((INITIAL_SIZE -1)/sizeof(T) + 1) * sizeof(T) , minimum_memory_for_elements(1)),
+            realloc(std::max(((INITIAL_SIZE - 1) / sizeof(T) + 1) * sizeof(T), minimum_memory_for_elements(1)),
                     std::forward<TAllocatorParams>(allocator_params)...);
+        }
         else
             realloc(allocated_bytes() * 2, std::forward<TAllocatorParams>(allocator_params)...);
     }

--- a/dbms/src/Common/PODArray.h
+++ b/dbms/src/Common/PODArray.h
@@ -122,7 +122,10 @@ protected:
     void reserveForNextSize(TAllocatorParams ... allocator_params)
     {
         if (size() == 0)
-            realloc(std::max(INITIAL_SIZE, minimum_memory_for_elements(1)), std::forward<TAllocatorParams>(allocator_params)...);
+            // The allocated memory should be multiplication of sizeof(T) to hold the element, otherwise,
+            // memory issue such as corruption could appear in edge case.
+            realloc(std::max(((INITIAL_SIZE -1)/sizeof(T) + 1) * sizeof(T) , minimum_memory_for_elements(1)),
+                    std::forward<TAllocatorParams>(allocator_params)...);
         else
             realloc(allocated_bytes() * 2, std::forward<TAllocatorParams>(allocator_params)...);
     }


### PR DESCRIPTION
In PODArray::push_back function or other similar function, c_end point is used to track whether the memory buffer is used up, and c_end is increased by step sizeof(T). however, if the memory buffer is not allocated based on such step, we could end up in corruption case that T object span over the residual piece.