### PR TITLE
Aggressive merge for ReplicatedMergeTree optimize.

### DIFF
--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -2363,7 +2363,7 @@ bool StorageReplicatedMergeTree::optimize(const ASTPtr & query, const ASTPtr & p
         if (!partition)
         {
             selected = merger.selectPartsToMerge(
-                future_merged_part, false, data.settings.max_bytes_to_merge_at_max_space_in_pool, can_merge);
+                future_merged_part, true, data.settings.max_bytes_to_merge_at_max_space_in_pool, can_merge);
         }
         else
         {


### PR DESCRIPTION
MergeTree optimize uses aggressive merge, do the same for ReplicatedMergeTree.

If there's no partition specified in OPTIMIZE query, clickhouse only merges one partition for ReplicatedMergeTree. Is this the expected behavior?