### PR TITLE
NonJoinedBlockInputStream generates duplicate records across block.

### DIFF
--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -1148,7 +1148,10 @@ private:
 
             ++rows_added;
             if (rows_added == max_block_size)
+            {
+                ++it;
                 break;
+            }
         }
 
         return rows_added;


### PR DESCRIPTION
This patch fixes the iterator incrementation.