### PR TITLE
Unbundle contrib/googletest

### DIFF
--- a/cmake/find_gtest.cmake
+++ b/cmake/find_gtest.cmake
@@ -1,0 +1,19 @@
+option (USE_INTERNAL_GTEST_LIBRARY "Set to FALSE to use system Google Test instead of bundled" ${NOT_UNBUNDLED})
+
+if (USE_INTERNAL_GTEST_LIBRARY AND NOT EXISTS "${ClickHouse_SOURCE_DIR}/contrib/googletest/googletets/CMakeLists.txt")
+   message (WARNING "submodule contrib/googletest is missing. to fix try run: \n git submodule update --init --recursive")
+   set (USE_INTERNAL_GTEST_LIBRARY 0)
+endif ()
+
+if (NOT USE_INTERNAL_GTEST_LIBRARY)
+    find_library (GTEST_LIBRARY gtest_main)
+    find_path (GTEST_INCLUDE_DIR NAMES /gtest/gtest.h PATHS ${GTEST_INCLUDE_PATHS})
+endif ()
+
+if (GTEST_LIBRARY AND GTEST_INCLUDE_DIR)
+else ()
+    set (USE_INTERNAL_GTEST_LIBRARY 1)
+    set (GTEST_LIBRARY gtest_main)
+endif ()
+
+message (STATUS "Using gtest: ${GTEST_INCLUDE_DIR} : ${GTEST_LIBRARY}")

--- a/dbms/tests/CMakeLists.txt
+++ b/dbms/tests/CMakeLists.txt
@@ -7,13 +7,15 @@ else ()
     include (${ClickHouse_SOURCE_DIR}/cmake/add_check.cmake)
 endif ()
 
+include (${PROJECT_SOURCE_DIR}/cmake/find_gtest.cmake)
 
-# Google Test from sources
-add_subdirectory(${ClickHouse_SOURCE_DIR}/contrib/googletest/googletest ${CMAKE_CURRENT_BINARY_DIR}/googletest)
-# avoid problems with <regexp.h>
-target_compile_definitions (gtest INTERFACE GTEST_HAS_POSIX_RE=0)
-target_include_directories (gtest INTERFACE ${ClickHouse_SOURCE_DIR}/contrib/googletest/include)
-
+if (USE_INTERNAL_GTEST_LIBRARY)
+    # Google Test from sources
+    add_subdirectory(${ClickHouse_SOURCE_DIR}/contrib/googletest/googletest ${CMAKE_CURRENT_BINARY_DIR}/googletest)
+    # avoid problems with <regexp.h>
+    target_compile_definitions (gtest INTERFACE GTEST_HAS_POSIX_RE=0)
+    target_include_directories (gtest INTERFACE ${ClickHouse_SOURCE_DIR}/contrib/googletest/include)
+endif ()
 
 macro(grep_gtest_sources BASE_DIR DST_VAR)
     # Cold match files that are not in tests/ directories


### PR DESCRIPTION
Allow to use system libgtest-dev/gtest-devel when -DUNBUNDLED is ON.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru