### PR TITLE
Don't enable tests when -DENABLE_TESTS is OFF

### DIFF
--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -216,9 +216,8 @@ endif ()
 # also for copy_headers.sh:
 target_include_directories (clickhouse_common_io BEFORE PRIVATE ${COMMON_INCLUDE_DIR})
 
-add_subdirectory (tests)
-
 if (ENABLE_TESTS)
+    add_subdirectory (tests)
     # attach all dbms gtest sources
     grep_gtest_sources(${ClickHouse_SOURCE_DIR}/dbms dbms_gtest_sources)
     add_executable(unit_tests_dbms ${dbms_gtest_sources})


### PR DESCRIPTION
Commit f9d3c01a01 "Add package clickhouse-test" by @proller introduced a regression in dbms/CMakeLists.txt by enabling dbms/tests directory even if -DENABLE_TESTS option is explicitly disabled. This problem doesn't allow to build ClickHouse without bundled googletest submodule.

Fix -DENABLE_TESTS=OFF to work as expected.

  