### PR TITLE
Fixed 'intersects previous part' due to blind OPTIMIZE

### DIFF
--- a/dbms/src/Common/ErrorCodes.cpp
+++ b/dbms/src/Common/ErrorCodes.cpp
@@ -364,6 +364,7 @@ namespace ErrorCodes
     extern const int MULTIPLE_STREAMS_REQUIRED = 385;
     extern const int NO_COMMON_TYPE = 386;
     extern const int EXTERNAL_LOADABLE_ALREADY_EXISTS = 387;
+    extern const int CANNOT_ASSIGN_OPTIMIZE = 388;
 
     extern const int KEEPER_EXCEPTION = 999;
     extern const int POCO_EXCEPTION = 1000;

--- a/dbms/src/Interpreters/Settings.h
+++ b/dbms/src/Interpreters/Settings.h
@@ -305,6 +305,7 @@ struct Settings
     M(SettingSeconds, http_connection_timeout, DEFAULT_HTTP_READ_BUFFER_CONNECTION_TIMEOUT, "HTTP connection timeout.") \
     M(SettingSeconds, http_send_timeout, DEFAULT_HTTP_READ_BUFFER_TIMEOUT, "HTTP send timeout") \
     M(SettingSeconds, http_receive_timeout, DEFAULT_HTTP_READ_BUFFER_TIMEOUT, "HTTP receive timeout") \
+    M(SettingBool, optimize_throw_if_noop, false, "If setting is enabled and OPTIMIZE query didn't actually assign a merge then an explanatory exception is thrown")
 
 
     /// Possible limits for query execution.

--- a/dbms/src/Storages/MergeTree/MergeTreeDataMerger.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataMerger.cpp
@@ -157,7 +157,8 @@ bool MergeTreeDataMerger::selectPartsToMerge(
 
     if (data_parts.empty())
     {
-        if (out_disable_reason) *out_disable_reason = "There are no parts in the table";
+        if (out_disable_reason)
+            *out_disable_reason = "There are no parts in the table";
         return false;
     }
 
@@ -210,7 +211,8 @@ bool MergeTreeDataMerger::selectPartsToMerge(
 
     if (parts_to_merge.empty())
     {
-        if (out_disable_reason) *out_disable_reason = "There are no need to merge parts according to merge selector algorithm";
+        if (out_disable_reason)
+            *out_disable_reason = "There are no need to merge parts according to merge selector algorithm";
         return false;
     }
 
@@ -246,7 +248,8 @@ bool MergeTreeDataMerger::selectAllPartsToMergeWithinPartition(
 
     if (!final && parts.size() == 1)
     {
-        if (out_disable_reason) *out_disable_reason = "There is only one part inside partition";
+        if (out_disable_reason)
+            *out_disable_reason = "There is only one part inside partition";
         return false;
     }
 
@@ -286,7 +289,8 @@ bool MergeTreeDataMerger::selectAllPartsToMergeWithinPartition(
                 << "% on overhead); suppressing similar warnings for the next hour");
         }
 
-        if (out_disable_reason) *out_disable_reason = "Insufficient available disk space, required " +
+        if (out_disable_reason)
+            *out_disable_reason = "Insufficient available disk space, required " +
                 formatReadableSizeWithDecimalSuffix(required_disk_space);
 
         return false;

--- a/dbms/src/Storages/MergeTree/MergeTreeDataMerger.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataMerger.h
@@ -20,7 +20,7 @@ class MergeTreeDataMerger
 {
 public:
     using CancellationHook = std::function<void()>;
-    using AllowedMergingPredicate = std::function<bool (const MergeTreeData::DataPartPtr &, const MergeTreeData::DataPartPtr &)>;
+    using AllowedMergingPredicate = std::function<bool (const MergeTreeData::DataPartPtr &, const MergeTreeData::DataPartPtr &, String * reason)>;
 
     struct FuturePart
     {
@@ -65,7 +65,8 @@ public:
         FuturePart & future_part,
         bool aggressive,
         size_t max_total_size_to_merge,
-        const AllowedMergingPredicate & can_merge);
+        const AllowedMergingPredicate & can_merge,
+        String * out_disable_reason = nullptr);
 
     /** Select all the parts in the specified partition for merge, if possible.
       * final - choose to merge even a single part - that is, allow to merge one part "with itself".
@@ -75,7 +76,8 @@ public:
         size_t available_disk_space,
         const AllowedMergingPredicate & can_merge,
         const String & partition_id,
-        bool final);
+        bool final,
+        String * out_disable_reason = nullptr);
 
     /** Merge the parts.
       * If `reservation != nullptr`, now and then reduces the size of the reserved space

--- a/dbms/src/Storages/StorageMergeTree.cpp
+++ b/dbms/src/Storages/StorageMergeTree.cpp
@@ -27,6 +27,7 @@ namespace ErrorCodes
     extern const int ABORTED;
     extern const int BAD_ARGUMENTS;
     extern const int INCORRECT_DATA;
+    extern const int CANNOT_ASSIGN_OPTIMIZE;
 }
 
 
@@ -286,7 +287,8 @@ bool StorageMergeTree::merge(
     bool aggressive,
     const String & partition_id,
     bool final,
-    bool deduplicate)
+    bool deduplicate,
+    String * out_disable_reason)
 {
     /// Clear old parts. It does not matter to do it more frequently than each second.
     if (auto lock = time_after_previous_cleanup.lockTestAndRestartAfter(1))
@@ -307,7 +309,7 @@ bool StorageMergeTree::merge(
     {
         std::lock_guard<std::mutex> lock(currently_merging_mutex);
 
-        auto can_merge = [this] (const MergeTreeData::DataPartPtr & left, const MergeTreeData::DataPartPtr & right)
+        auto can_merge = [this] (const MergeTreeData::DataPartPtr & left, const MergeTreeData::DataPartPtr & right, String *)
         {
             return !currently_merging.count(left) && !currently_merging.count(right);
         };
@@ -318,11 +320,11 @@ bool StorageMergeTree::merge(
         {
             size_t max_parts_size_for_merge = merger.getMaxPartsSizeForMerge();
             if (max_parts_size_for_merge > 0)
-                selected = merger.selectPartsToMerge(future_part, aggressive, max_parts_size_for_merge, can_merge);
+                selected = merger.selectPartsToMerge(future_part, aggressive, max_parts_size_for_merge, can_merge, out_disable_reason);
         }
         else
         {
-            selected = merger.selectAllPartsToMergeWithinPartition(future_part, disk_space, can_merge, partition_id, final);
+            selected = merger.selectAllPartsToMergeWithinPartition(future_part, disk_space, can_merge, partition_id, final, out_disable_reason);
         }
 
         if (!selected)
@@ -454,7 +456,16 @@ bool StorageMergeTree::optimize(
     String partition_id;
     if (partition)
         partition_id = data.getPartitionIDFromQuery(partition, context);
-    return merge(context.getSettingsRef().min_bytes_to_use_direct_io, true, partition_id, final, deduplicate);
+
+    String disable_reason;
+    if (!merge(context.getSettingsRef().min_bytes_to_use_direct_io, true, partition_id, final, deduplicate, &disable_reason))
+    {
+        if (context.getSettingsRef().optimize_throw_if_noop)
+            throw Exception(disable_reason.empty() ? "Can't OPTIMIZE by some reason" : disable_reason, ErrorCodes::CANNOT_ASSIGN_OPTIMIZE);
+        return false;
+    }
+
+    return true;
 }
 
 

--- a/dbms/src/Storages/StorageMergeTree.h
+++ b/dbms/src/Storages/StorageMergeTree.h
@@ -114,7 +114,8 @@ private:
       * If aggressive - when selects parts don't takes into account their ratio size and novelty (used for OPTIMIZE query).
       * Returns true if merge is finished successfully.
       */
-    bool merge(size_t aio_threshold, bool aggressive, const String & partition_id, bool final, bool deduplicate);
+    bool merge(size_t aio_threshold, bool aggressive, const String & partition_id, bool final, bool deduplicate,
+               String * out_disable_reason = nullptr);
 
     bool mergeTask();
 

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1602,7 +1602,8 @@ namespace
 
             if (left->info.max_block <= part_info.min_block && right->info.min_block >= part_info.max_block)
             {
-                if (out_reason) *out_reason = "Quorum status condition is unsatisfied";
+                if (out_reason)
+                    *out_reason = "Quorum status condition is unsatisfied";
                 return false;
             }
         }
@@ -1619,7 +1620,8 @@ namespace
 
             if (left->info.max_block <= part_info.min_block && right->info.min_block >= part_info.max_block)
             {
-                if (out_reason) *out_reason = "Quorum 'last part' condition is unsatisfied";
+                if (out_reason) 
+                    *out_reason = "Quorum 'last part' condition is unsatisfied";
                 return false;
             }
         }

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1646,7 +1646,7 @@ namespace
     }
 
 
-    /// If any of the parts is already going to be merge into a larger one, do not agree to merge it.
+    /// If any of the parts is already going to be merged into a larger one, do not agree to merge it.
     bool partsWillNotBeMergedOrDisabled(const MergeTreeData::DataPartPtr & left, const MergeTreeData::DataPartPtr & right,
                                         ReplicatedMergeTreeQueue & queue, String * out_reason = nullptr)
     {

--- a/dbms/src/Storages/StorageReplicatedMergeTree.h
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.h
@@ -256,7 +256,11 @@ private:
     /// A thread that selects parts to merge.
     std::thread merge_selecting_thread;
     Poco::Event merge_selecting_event;
-    std::mutex merge_selecting_mutex; /// It is taken for each iteration of the selection of parts to merge.
+    /// It is acquired for each iteration of the selection of parts to merge or each OPTIMIZE query.
+    std::mutex merge_selecting_mutex;
+    /// If true then new entries might added to the queue, so we must pull logs before selecting parts for merge.
+    /// Is used only to avoid superfluous pullLogsToQueue() calls
+    bool merge_selecting_logs_pulling_is_required = true;
 
     /// A thread that removes old parts, log entries, and blocks.
     std::unique_ptr<ReplicatedMergeTreeCleanupThread> cleanup_thread;


### PR DESCRIPTION
Add `optimize_throw_if_noop` setting to control OPTIMIZE execution.