### PR TITLE
ISSUES-1827 Set correct permissions on configuration directory after installation

### DIFF
--- a/debian/clickhouse-server-base.postinst
+++ b/debian/clickhouse-server-base.postinst
@@ -3,6 +3,7 @@ set -e
 
 CLICKHOUSE_USER=clickhouse
 CLICKHOUSE_GROUP=${CLICKHOUSE_USER}
+CLICKHOUSE_CONFDIR=/etc/clickhouse-server
 CLICKHOUSE_DATADIR=/var/lib/clickhouse
 CLICKHOUSE_LOGDIR=/var/log/clickhouse-server
 
@@ -51,6 +52,10 @@ Please fix this and reinstall this package." >&2
         echo "The ${CLICKHOUSE_USER} system user must not have root as primary group.
 Please fix this and reinstall this package." >&2
         exit 1
+    fi
+
+    if [ -d ${CLICKHOUSE_CONFDIR} ]; then
+        su -s /bin/sh ${CLICKHOUSE_USER} -c "test -w ${CLICKHOUSE_CONFDIR}" || chown ${CLICKHOUSE_USER}:${CLICKHOUSE_GROUP} ${CLICKHOUSE_CONFDIR}
     fi
 
     if [ ! -d ${CLICKHOUSE_DATADIR} ]; then


### PR DESCRIPTION
Set correct permissions on configuration directory after installation. This is done in the postinstall phase.

This fixes #1827