### PR TITLE
Использование произвольного ключа партиционирования для таблицы лога запросов

### DIFF
--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -1429,7 +1429,7 @@ QueryLog & Context::getQueryLog()
         size_t flush_interval_milliseconds = config.getUInt64(
                 "query_log.flush_interval_milliseconds", DEFAULT_QUERY_LOG_FLUSH_INTERVAL_MILLISECONDS);
         
-        String engine = "ENGINE = MergeTree() PARTITION BY (" + partition_by + ") ORDER BY (event_date, event_time) SETTINGS index_granularity = 1024";
+        String engine = "ENGINE = MergeTree PARTITION BY (" + partition_by + ") ORDER BY (event_date, event_time) SETTINGS index_granularity = 1024";
 
         system_logs->query_log = std::make_unique<QueryLog>(*global_context, database, table, engine, flush_interval_milliseconds);
     }

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -1425,20 +1425,11 @@ QueryLog & Context::getQueryLog()
 
         String database     = config.getString("query_log.database",     "system");
         String table        = config.getString("query_log.table",        "query_log");
-        String partition_by = config.getString("query_log.partition_by", "month");
+        String partition_by = config.getString("query_log.partition_by", "toYYYYMM(event_date)");
         size_t flush_interval_milliseconds = config.getUInt64(
                 "query_log.flush_interval_milliseconds", DEFAULT_QUERY_LOG_FLUSH_INTERVAL_MILLISECONDS);
         
-        String engine;
-
-        if (partition_by == "day")
-            engine = "ENGINE = MergeTree() PARTITION BY (event_date) ORDER BY (event_time) SETTINGS index_granularity = 1024";
-        else if (partition_by == "week") 
-            engine = "ENGINE = MergeTree() PARTITION BY (toMonday(event_date)) ORDER BY (event_date, event_time) SETTINGS index_granularity = 1024";
-        else if (partition_by == "month")
-            engine = "ENGINE = MergeTree(event_date, event_time, 1024)";
-        else
-            throw Exception("Logical error: invalid value for query_log.partition_by", ErrorCodes::LOGICAL_ERROR);
+        String engine = "ENGINE = MergeTree() PARTITION BY (" + partition_by + ") ORDER BY (event_date, event_time) SETTINGS index_granularity = 1024";
 
         system_logs->query_log = std::make_unique<QueryLog>(*global_context, database, table, engine, flush_interval_milliseconds);
     }

--- a/dbms/src/Server/config.xml
+++ b/dbms/src/Server/config.xml
@@ -226,7 +226,15 @@
         -->
         <database>system</database>
         <table>query_log</table>
-        <partition_by>month</partition_by> <!-- possible values day, month, week -->
+        <!-- 
+            PARTITION BY expr https://clickhouse.yandex/docs/en/table_engines/custom_partitioning_key.html 
+            Example: 
+                event_date
+                toMonday(event_date)
+                toYYYYMM(event_date)
+                toStartOfHour(event_time)
+        -->
+        <partition_by>toYYYYMM(event_date)</partition_by>
         <!-- Interval of flushing data. -->
         <flush_interval_milliseconds>7500</flush_interval_milliseconds>
     </query_log>

--- a/dbms/src/Server/config.xml
+++ b/dbms/src/Server/config.xml
@@ -226,7 +226,7 @@
         -->
         <database>system</database>
         <table>query_log</table>
-
+        <partition_by>month</partition_by> <!-- possible values day, month, week -->
         <!-- Interval of flushing data. -->
         <flush_interval_milliseconds>7500</flush_interval_milliseconds>
     </query_log>

--- a/docs/en/operations/server_settings/settings.md
+++ b/docs/en/operations/server_settings/settings.md
@@ -518,6 +518,7 @@ Use the following parameters to configure logging:
 
 - database – Name of the database.
 - table – Name of the table.
+- partition_by - Sets the partition key, possible values: day, week, month.
 - flush_interval_milliseconds – Interval for flushing data from memory to the disk.
 
 **Example**
@@ -526,6 +527,7 @@ Use the following parameters to configure logging:
 <part_log>
     <database>system</database>
     <table>part_log</table>
+    <partition_by>day</partition_by>
     <flush_interval_milliseconds>7500</flush_interval_milliseconds>
 </part_log>
 ```
@@ -560,6 +562,7 @@ Use the following parameters to configure logging:
 
 - database – Name of the database.
 - table – Name of the table.
+- partition_by - Sets the partition key, possible values: day, week, month.
 - flush_interval_milliseconds – Interval for flushing data from memory to the disk.
 
 If the table doesn't exist, ClickHouse will create it. If the structure of the query log changed when the ClickHouse server was updated, the table with the old structure is renamed, and a new table is created automatically.
@@ -570,6 +573,7 @@ If the table doesn't exist, ClickHouse will create it. If the structure of the q
 <query_log>
     <database>system</database>
     <table>query_log</table>
+    <partition_by>day</partition_by>
     <flush_interval_milliseconds>7500</flush_interval_milliseconds>
 </query_log>
 ```

--- a/docs/en/operations/server_settings/settings.md
+++ b/docs/en/operations/server_settings/settings.md
@@ -518,7 +518,7 @@ Use the following parameters to configure logging:
 
 - database – Name of the database.
 - table – Name of the table.
-- partition_by - Sets the partition key, possible values: day, week, month.
+- partition_by - Sets the [custom partition key](../../table_engines/custom_partitioning_key.md#custom-partitioning-key).
 - flush_interval_milliseconds – Interval for flushing data from memory to the disk.
 
 **Example**
@@ -527,7 +527,7 @@ Use the following parameters to configure logging:
 <part_log>
     <database>system</database>
     <table>part_log</table>
-    <partition_by>day</partition_by>
+    <partition_by>toMonday(event_date)</partition_by>
     <flush_interval_milliseconds>7500</flush_interval_milliseconds>
 </part_log>
 ```
@@ -562,7 +562,7 @@ Use the following parameters to configure logging:
 
 - database – Name of the database.
 - table – Name of the table.
-- partition_by - Sets the partition key, possible values: day, week, month.
+- partition_by - Sets the [custom partition key](../../table_engines/custom_partitioning_key.md#custom-partitioning-key).
 - flush_interval_milliseconds – Interval for flushing data from memory to the disk.
 
 If the table doesn't exist, ClickHouse will create it. If the structure of the query log changed when the ClickHouse server was updated, the table with the old structure is renamed, and a new table is created automatically.
@@ -573,7 +573,7 @@ If the table doesn't exist, ClickHouse will create it. If the structure of the q
 <query_log>
     <database>system</database>
     <table>query_log</table>
-    <partition_by>day</partition_by>
+    <partition_by>toMonday(event_date)</partition_by>
     <flush_interval_milliseconds>7500</flush_interval_milliseconds>
 </query_log>
 ```

--- a/docs/ru/operations/server_settings/settings.md
+++ b/docs/ru/operations/server_settings/settings.md
@@ -520,7 +520,7 @@ ClickHouse проверит условия `min_part_size` и `min_part_size_rat
 
 - database - Имя базы данных.
 - table - Имя таблицы.
-- partition_by - Устанавливает ключ партиционирования, доступные значения: day, week, month.
+- partition_by - Устанавливает [произвольный ключ партиционирования](../../table_engines/custom_partitioning_key.md#custom-partitioning-key).
 - flush_interval_milliseconds - Период сброса данных из оперативной памяти на диск.
 
 
@@ -530,7 +530,7 @@ ClickHouse проверит условия `min_part_size` и `min_part_size_rat
 <part_log>
     <database>system</database>
     <table>part_log</table>
-    <partition_by>day</partition_by>
+    <partition_by>toMonday(event_date)</partition_by>
     <flush_interval_milliseconds>7500</flush_interval_milliseconds>
 </part_log>
 ```
@@ -565,7 +565,7 @@ ClickHouse проверит условия `min_part_size` и `min_part_size_rat
 
 - database - Имя базы данных.
 - table - Имя таблицы.
-- partition_by - Устанавливает ключ партиционирования, доступные значения: day, week, month.
+- partition_by - Устанавливает [произвольный ключ партиционирования](../../table_engines/custom_partitioning_key.md#custom-partitioning-key).
 - flush_interval_milliseconds - Период сброса данных из оперативной памяти на диск.
 
 Если таблица не существует, то ClickHouse создаст её. Если структура журнала запросов изменилась при обновлении сервера ClickHouse, то таблица со старой структурой переименовывается, а новая таблица создается автоматически.
@@ -576,7 +576,7 @@ ClickHouse проверит условия `min_part_size` и `min_part_size_rat
 <query_log>
     <database>system</database>
     <table>query_log</table>
-    <partition_by>day</partition_by>
+    <partition_by>toMonday(event_date)</partition_by>
     <flush_interval_milliseconds>7500</flush_interval_milliseconds>
 </query_log>
 ```

--- a/docs/ru/operations/server_settings/settings.md
+++ b/docs/ru/operations/server_settings/settings.md
@@ -520,6 +520,7 @@ ClickHouse проверит условия `min_part_size` и `min_part_size_rat
 
 - database - Имя базы данных.
 - table - Имя таблицы.
+- partition_by - Устанавливает ключ партиционирования, доступные значения: day, week, month.
 - flush_interval_milliseconds - Период сброса данных из оперативной памяти на диск.
 
 
@@ -529,6 +530,7 @@ ClickHouse проверит условия `min_part_size` и `min_part_size_rat
 <part_log>
     <database>system</database>
     <table>part_log</table>
+    <partition_by>day</partition_by>
     <flush_interval_milliseconds>7500</flush_interval_milliseconds>
 </part_log>
 ```
@@ -563,6 +565,7 @@ ClickHouse проверит условия `min_part_size` и `min_part_size_rat
 
 - database - Имя базы данных.
 - table - Имя таблицы.
+- partition_by - Устанавливает ключ партиционирования, доступные значения: day, week, month.
 - flush_interval_milliseconds - Период сброса данных из оперативной памяти на диск.
 
 Если таблица не существует, то ClickHouse создаст её. Если структура журнала запросов изменилась при обновлении сервера ClickHouse, то таблица со старой структурой переименовывается, а новая таблица создается автоматически.
@@ -573,6 +576,7 @@ ClickHouse проверит условия `min_part_size` и `min_part_size_rat
 <query_log>
     <database>system</database>
     <table>query_log</table>
+    <partition_by>day</partition_by>
     <flush_interval_milliseconds>7500</flush_interval_milliseconds>
 </query_log>
 ```


### PR DESCRIPTION
Добавил опцию `partition_by` для `query_log`, допустипые значения: day, week, month. В зависимости от настроек будет выбран ключ партиционирования. Это нужно для удобного удаления логов с сервера, т.к. за месяц их может скапливаться достаточное количество и, зачастую, они через пару дней уже не нужны. 