### PR TITLE
Prevent cron stdout

### DIFF
--- a/debian/clickhouse-server.cron.d
+++ b/debian/clickhouse-server.cron.d
@@ -1,1 +1,2 @@
-#*/10 * * * * root (which service && (service clickhouse-server condstart || true)) || /etc/init.d/clickhouse-server condstart 1>/dev/null 2>&1
+#*/10 * * * * root (which service > /dev/null && (service clickhouse-server condstart || true)) || /etc/init.d/clickhouse-server condstart 1>/dev/null 2>&1
+ to

--- a/debian/clickhouse-server.cron.d
+++ b/debian/clickhouse-server.cron.d
@@ -1,2 +1,1 @@
 #*/10 * * * * root (which service > /dev/null && (service clickhouse-server condstart || true)) || /etc/init.d/clickhouse-server condstart 1>/dev/null 2>&1
- to


### PR DESCRIPTION
This is bad idea to print something to stdout in cron jobs, because this messages can be sended via email