### PR TITLE
Fixed segfault in case of WHERE <non-UInt8 type expression>

### DIFF
--- a/dbms/src/DataStreams/FilterBlockInputStream.cpp
+++ b/dbms/src/DataStreams/FilterBlockInputStream.cpp
@@ -33,19 +33,18 @@ FilterBlockInputStream::FilterBlockInputStream(const BlockInputStreamPtr & input
     expression->execute(header);
 
     filter_column = header.getPositionByName(filter_column_name);
+    auto & column_elem = header.safeGetByPosition(filter_column);
 
     /// Isn't the filter already constant?
-    ColumnPtr column = header.safeGetByPosition(filter_column).column;
-
-    if (column)
-        constant_filter_description = ConstantFilterDescription(*column);
+    if (column_elem.column)
+        constant_filter_description = ConstantFilterDescription(*column_elem.column);
 
     if (!constant_filter_description.always_false
         && !constant_filter_description.always_true)
     {
         /// Replace the filter column to a constant with value 1.
-        auto & header_filter_elem = header.getByPosition(filter_column);
-        header_filter_elem.column = header_filter_elem.type->createColumnConst(header.rows(), UInt64(1));
+        FilterDescription filter_description_check(*column_elem.column);
+        column_elem.column = column_elem.type->createColumnConst(header.rows(), UInt64(1));
     }
 }
 

--- a/dbms/src/Parsers/ASTKillQueryQuery.cpp
+++ b/dbms/src/Parsers/ASTKillQueryQuery.cpp
@@ -10,12 +10,12 @@ String ASTKillQueryQuery::getID() const
 
 void ASTKillQueryQuery::formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    settings.ostr << "KILL QUERY WHERE ";
+    settings.ostr << (settings.hilite ? hilite_keyword : "") << "KILL QUERY WHERE " << (settings.hilite ? hilite_none : "");
 
     if (where_expression)
         where_expression->formatImpl(settings, state, frame);
 
-    settings.ostr << " " << (test ? "TEST" : (sync ? "SYNC" : "ASYNC"));
+    settings.ostr << " " << (settings.hilite ? hilite_keyword : "") << (test ? "TEST" : (sync ? "SYNC" : "ASYNC")) << (settings.hilite ? hilite_none : "");
 }
 
 }


### PR DESCRIPTION
Prohibited non-UInt8 constants in WHERE expressions.
Fixed KILL QUERY syntax highlighting.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
