### PR TITLE
add aggregate functions IntersectionsMax and IntersectionsMaxPos

### DIFF
--- a/dbms/src/AggregateFunctions/AggregateFunctionIntersectionsMax.cpp
+++ b/dbms/src/AggregateFunctions/AggregateFunctionIntersectionsMax.cpp
@@ -1,0 +1,145 @@
+#include <AggregateFunctions/AggregateFunctionFactory.h>
+#include <AggregateFunctions/AggregateFunctionIntersectionsMax.h>
+#include <AggregateFunctions/FactoryHelpers.h>
+
+#include <IO/ReadHelpers.h>
+#include <IO/WriteHelpers.h>
+
+namespace DB
+{
+
+template <typename T>
+typename Intersections<T>::PointsMap::iterator
+Intersections<T>::insert_point(const T &v)
+{
+    auto res = points.emplace(v,0);
+    auto &i = res.first;
+    if(!res.second) return i;
+    if(i==points.begin()) return i;
+    auto prev = i;
+    prev--;
+    i->second=prev->second;
+    return i;
+}
+
+template <typename T>
+void Intersections<T>::add(const T &start, const T &end, T weight)
+{
+    auto sp = insert_point(start);
+    auto ep = end ? insert_point(end) : points.end();
+    do {
+        sp->second+=weight;
+        if(sp->second > max_weight) {
+            max_weight = sp->second;
+            max_weight_pos = sp->first;
+        }
+    } while(++sp != ep);
+}
+
+template <typename T>
+void Intersections<T>::merge(const Intersections &other)
+{
+    if(other.points.empty())
+        return;
+
+    typename PointsMap::const_iterator prev, i = other.points.begin();
+    prev = i;
+    i++;
+
+    while(i != other.points.end()) {
+        add(prev->first,i->first,prev->second);
+        prev = i;
+        i++;
+    }
+
+    if(prev != other.points.end())
+        add(prev->first,0,prev->second);
+}
+
+template <typename T>
+void Intersections<T>::serialize(WriteBuffer & buf) const
+{
+    writeBinary(points.size(),buf);
+    for(const auto &p: points) {
+        writeBinary(p.first,buf);
+        writeBinary(p.second,buf);
+    }
+}
+
+template <typename T>
+void Intersections<T>::deserialize(ReadBuffer & buf)
+{
+    std::size_t size;
+    T point;
+    T weight;
+
+    readBinary(size, buf);
+    for (std::size_t i = 0; i < size; ++i) {
+        readBinary(point, buf);
+        readBinary(weight,buf);
+        points.emplace(point,weight);
+    }
+}
+
+void AggregateFunctionIntersectionsMax::_add(
+        AggregateDataPtr place,
+        const IColumn & column_start,
+        const IColumn & column_end,
+        size_t row_num) const
+{
+    PointType start_time, end_time;
+    Field tmp_start_time_field, tmp_end_time_field;
+
+    column_start.get(row_num,tmp_start_time_field);
+    if(tmp_start_time_field.isNull())
+        return;
+    start_time = tmp_start_time_field.template get<PointType>();
+    if(0==start_time)
+        return;
+
+    column_end.get(row_num,tmp_end_time_field);
+    if(tmp_end_time_field.isNull()) {
+        end_time = 0;
+    } else {
+        end_time = tmp_end_time_field.template get<PointType>();
+        if(0!=end_time) {
+            if(end_time==start_time) {
+                end_time = 0;
+            } else if(end_time < start_time) {
+                return;
+            }
+        }
+    }
+
+    data(place).add(start_time,end_time);
+}
+
+namespace
+{
+
+AggregateFunctionPtr createAggregateFunctionIntersectionsMax(const std::string & name, const DataTypes & argument_types, const Array & parameters)
+{
+    assertBinary(name, argument_types);
+    return std::make_shared<AggregateFunctionIntersectionsMax>(argument_types,parameters,false);
+}
+
+AggregateFunctionPtr createAggregateFunctionIntersectionsMaxPos(const std::string & name, const DataTypes & argument_types, const Array & parameters)
+{
+    assertBinary(name, argument_types);
+    return std::make_shared<AggregateFunctionIntersectionsMax>(argument_types,parameters,true);
+}
+
+}
+
+void registerAggregateFunctionIntersectionsMax(AggregateFunctionFactory & factory)
+{
+    factory.registerFunction("IntersectionsMax",
+        createAggregateFunctionIntersectionsMax,
+        AggregateFunctionFactory::CaseInsensitive);
+    factory.registerFunction("IntersectionsMaxPos",
+        createAggregateFunctionIntersectionsMaxPos,
+        AggregateFunctionFactory::CaseInsensitive);
+}
+
+}
+

--- a/dbms/src/AggregateFunctions/AggregateFunctionIntersectionsMax.cpp
+++ b/dbms/src/AggregateFunctions/AggregateFunctionIntersectionsMax.cpp
@@ -133,10 +133,10 @@ AggregateFunctionPtr createAggregateFunctionIntersectionsMaxPos(const std::strin
 
 void registerAggregateFunctionIntersectionsMax(AggregateFunctionFactory & factory)
 {
-    factory.registerFunction("IntersectionsMax",
+    factory.registerFunction("intersectionsMax",
         createAggregateFunctionIntersectionsMax,
         AggregateFunctionFactory::CaseInsensitive);
-    factory.registerFunction("IntersectionsMaxPos",
+    factory.registerFunction("intersectionsMaxPos",
         createAggregateFunctionIntersectionsMaxPos,
         AggregateFunctionFactory::CaseInsensitive);
 }

--- a/dbms/src/AggregateFunctions/AggregateFunctionIntersectionsMax.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionIntersectionsMax.h
@@ -1,0 +1,132 @@
+#pragma once
+
+#include <common/logger_useful.h>
+
+#include <DataTypes/DataTypesNumber.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeDate.h>
+#include <DataTypes/DataTypeDateTime.h>
+
+#include <Columns/ColumnNullable.h>
+
+#include <Common/Allocator.h>
+
+#include <AggregateFunctions/IAggregateFunction.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int AGGREGATE_FUNCTION_DOESNT_ALLOW_PARAMETERS;
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+    extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+}
+
+template <typename T>
+class Intersections final
+{
+
+    using PointsMap = std::map<T, T>;
+
+    PointsMap points;
+    T max_weight;
+    T max_weight_pos;
+
+    typename PointsMap::iterator insert_point(const T &v);
+  public:
+
+    Intersections()
+      : max_weight(0)
+    { }
+
+    void add(const T &start, const T &end, T weight = 1);
+    void merge(const Intersections &other);
+
+    void serialize(WriteBuffer & buf) const;
+    void deserialize(ReadBuffer & buf);
+
+    T max() const { return max_weight; }
+    T max_pos() const { return max_weight_pos; }
+};
+
+class AggregateFunctionIntersectionsMax final
+  : public IAggregateFunctionDataHelper<Intersections<UInt64>, AggregateFunctionIntersectionsMax>
+{
+    using PointType = UInt64;
+
+    bool return_position;
+    void _add(AggregateDataPtr place, const IColumn & column_start, const IColumn & column_end, size_t row_num) const;
+
+  public:
+    AggregateFunctionIntersectionsMax(const DataTypes & arguments, const Array & params, bool return_position)
+      : return_position(return_position)
+    {
+        if (!params.empty()) {
+            throw Exception(
+                "Aggregate function " + getName() + " does not allow paremeters.",
+                ErrorCodes::AGGREGATE_FUNCTION_DOESNT_ALLOW_PARAMETERS);
+        }
+
+        if (arguments.size() != 2)
+            throw Exception("Aggregate function " + getName() + " requires two arguments.", ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
+
+        if(!arguments[0]->isValueRepresentedByInteger())
+            throw Exception {
+                getName() + ": first argument must be represented by integer",
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT
+            };
+
+        if(!arguments[1]->isValueRepresentedByInteger())
+            throw Exception {
+                getName() + ": second argument must be represented by integer",
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT
+            };
+
+        if(!arguments[0]->equals(*arguments[1]))
+            throw Exception {
+                getName() + ": arguments must have the same type",
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT
+            };
+    }
+
+    String getName() const override { return "IntersectionsMax"; }
+
+    DataTypePtr getReturnType() const override
+    {
+        return std::make_shared<DataTypeUInt64>();
+    }
+
+    void add(AggregateDataPtr place, const IColumn ** columns, size_t row_num, Arena *) const override
+    {
+        _add(place,*columns[0],*columns[1],row_num);
+    }
+
+    void merge(AggregateDataPtr place, ConstAggregateDataPtr rhs, Arena *) const override
+    {
+        this->data(place).merge(data(rhs));
+    }
+
+    void serialize(ConstAggregateDataPtr place, WriteBuffer & buf) const override
+    {
+        this->data(place).serialize(buf);
+    }
+
+    void deserialize(AggregateDataPtr place, ReadBuffer & buf, Arena *) const override
+    {
+        this->data(place).deserialize(buf);
+    }
+
+    void insertResultInto(ConstAggregateDataPtr place, IColumn & to) const override
+    {
+        auto &ret = static_cast<ColumnUInt64 &>(to).getData();
+        ret.push_back(data(place).max());
+        if(return_position)
+            ret.push_back(data(place).max_pos());
+    }
+
+    const char * getHeaderFilePath() const override { return __FILE__; }
+};
+
+}
+

--- a/dbms/src/AggregateFunctions/registerAggregateFunctions.cpp
+++ b/dbms/src/AggregateFunctions/registerAggregateFunctions.cpp
@@ -23,6 +23,7 @@ void registerAggregateFunctionsUniq(AggregateFunctionFactory &);
 void registerAggregateFunctionUniqUpTo(AggregateFunctionFactory &);
 void registerAggregateFunctionTopK(AggregateFunctionFactory &);
 void registerAggregateFunctionsBitwise(AggregateFunctionFactory &);
+void registerAggregateFunctionIntersectionsMax(AggregateFunctionFactory &);
 
 void registerAggregateFunctionCombinatorIf(AggregateFunctionCombinatorFactory &);
 void registerAggregateFunctionCombinatorArray(AggregateFunctionCombinatorFactory &);
@@ -53,6 +54,7 @@ void registerAggregateFunctions()
         registerAggregateFunctionUniqUpTo(factory);
         registerAggregateFunctionTopK(factory);
         registerAggregateFunctionsBitwise(factory);
+        registerAggregateFunctionIntersectionsMax(factory);
     }
 
     {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

new aggregate functions:

*IntersectionsMax(start_column ,end_column)*
*IntersectionsMaxPos(start_column ,end_column)*

returns maximum count of the intersected intervals defined by start_column and end_column values

if start_column value is NULL or 0 then interval will be skipped
if end_column value is NULL or 0 then interval is considered to have no end (interval (3,0) in example below)

IntersectionsMaxPos in addition returns position where the maximum of intersected intervals found

typical application for this functions (and why they were implemented) is to count maximum active calls for the certain time frame by stored calls detailed records with timestamps for the calls start/end

example:

```sql
:) CREATE DATABASE test;
:) CREATE TABLE test(start Integer, end Integer) engine = Memory;
:) INSERT INTO test(start,end) VALUES (1,3),(2,7),(3,0),(4,7),(5,8);
```

intervals in the table after the insert:
```
1 2 3 4 5 6 7 8 9
------------------>
1---3
  2---------7
    3-------------
      4-----7
        5-----8
------------------>
1 2 3 3 4 4 4 2 1  //intersections count for each point
```

functions output:
```sql
:) SELECT IntersectionsMax(start,end) FROM test;

SELECT IntersectionsMax(start, end)
FROM test

┌─IntersectionsMax(start, end)─┐
│                            4 │
└──────────────────────────────┘

1 rows in set. Elapsed: 0.003 sec.

:) SELECT IntersectionsMaxPos(start,end) FROM test;

SELECT IntersectionsMaxPos(start, end)
FROM test 

┌─IntersectionsMaxPos(start, end)─┐
│                               4 │
│                               5 │
└─────────────────────────────────┘

2 rows in set. Elapsed: 0.003 sec. 
```