### PR TITLE
The lost information in the documentation for Kafka engine

### DIFF
--- a/docs/en/table_engines/kafka.md
+++ b/docs/en/table_engines/kafka.md
@@ -9,7 +9,7 @@ Kafka lets you:
 - Process streams as they become available.
 
 ```
-Kafka(broker_list, topic_list, group_name, format[, schema])
+Kafka(broker_list, topic_list, group_name, format[, schema, num_consumers])
 ```
 
 Parameters:
@@ -19,6 +19,7 @@ Parameters:
 - `group_name` – A group of Kafka consumers (`group1`). Reading margins are tracked for each group separately. If you don't want messages to be duplicated in the cluster, use the same group name everywhere.
 - `format` – Message format. Uses the same notation as the SQL ` FORMAT` function, such as ` JSONEachRow`. For more information, see the section "Formats".
 - `schema` – An optional parameter that must be used if the format requires a schema definition. For example, [Cap'n Proto](https://capnproto.org/)  requires the path to the schema file and the name of the root ` schema.capnp:Message` object.
+- `num_consumers` - Number of created consumers per engine. By default `1`. Create more consumers if the throughput of a single consumer is insufficient. The total number of consumers shouldn't exceed the number of partitions in given topic, as there can be at most 1 consumers assigned to any single partition.
 
 Example:
 
@@ -77,3 +78,23 @@ To stop receiving topic data or to change the conversion logic, detach the mater
 
 If you want to change the target table by using `ALTER` materialized view, we recommend disabling the material view to avoid discrepancies between the target table and the data from the view.
 
+
+## Configuration
+
+Similarly to GraphiteMergeTree, Kafka engine supports extended configuration through the ClickHouse config file. There are two configuration keys you can use - global (`kafka`), and per-topic (`kafka_topic_*`). The global configuration is applied first, then per-topic configuration (if exists).
+
+```xml
+  <!--  Global configuration options for all tables of Kafka engine type -->
+  <kafka>
+    <debug>cgrp</debug>
+    <auto_offset_reset>smallest</auto_offset_reset>
+  </kafka>
+
+  <!-- Configuration specific for topic "logs" -->
+  <kafka_topic_logs>
+    <retry_backoff_ms>250</retry_backoff_ms>
+    <fetch_min_bytes>100000</fetch_min_bytes>
+  </kafka_topic_logs>
+```
+
+See [librdkafka configuration reference](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md) for the list of possible configuration options. Use underscores instead of dots in the ClickHouse configuration, for example `check.crcs=true` would correspond to `<check_crcs>true</check_crcs>`.


### PR DESCRIPTION
The lost information in the Kafka engine documentation (from commit: https://github.com/yandex/ClickHouse/pull/1654/files#diff-c9ba89e2414c83b5dcc579233c5c80b5) has been restored, modified and translated.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
