### PR TITLE
#2095 Make sure to split the topics args list on ','

### DIFF
--- a/dbms/src/Storages/StorageKafka.cpp
+++ b/dbms/src/Storages/StorageKafka.cpp
@@ -578,11 +578,11 @@ void registerStorageKafka(StorageFactory & factory)
 
         // Parse topic list
         Names topics;
-        String topicArg = static_cast<const ASTLiteral &>(*engine_args[1]).value.safeGet<String>();
-        boost::split(topics, topicArg , [](char c){return c == ',';});
-        for(String & topic : topics) {
+        String topic_arg = static_cast<const ASTLiteral &>(*engine_args[1]).value.safeGet<String>();
+        boost::split(topics, topic_arg , [](char c){ return c == ','; });
+        for(String & topic : topics)
             boost::trim(topic);
-        }
+
         // Parse consumer group
         String group = static_cast<const ASTLiteral &>(*engine_args[2]).value.safeGet<String>();
 

--- a/dbms/src/Storages/StorageKafka.cpp
+++ b/dbms/src/Storages/StorageKafka.cpp
@@ -578,7 +578,7 @@ void registerStorageKafka(StorageFactory & factory)
         // Parse topic list
         Names topics;
         String topicArg = static_cast<const ASTLiteral &>(*engine_args[1]).value.safeGet<String>();
-        boost::split(topics, topics , [](char c){return c == ',';});
+        boost::split(topics, topicArg , [](char c){return c == ',';});
         
         // Parse consumer group
         String group = static_cast<const ASTLiteral &>(*engine_args[2]).value.safeGet<String>();

--- a/dbms/src/Storages/StorageKafka.cpp
+++ b/dbms/src/Storages/StorageKafka.cpp
@@ -4,6 +4,7 @@
 
 #include <thread>
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/algorithm/string/split.hpp>
 #include <Common/Exception.h>
 #include <Common/setThreadName.h>
 #include <Common/typeid_cast.h>
@@ -574,9 +575,12 @@ void registerStorageKafka(StorageFactory & factory)
                 throw Exception("Number of consumers must be a positive integer", ErrorCodes::BAD_ARGUMENTS);
         }
 
-        // Parse topic list and consumer group
+        // Parse topic list
         Names topics;
-        topics.push_back(static_cast<const ASTLiteral &>(*engine_args[1]).value.safeGet<String>());
+        String topicArg = static_cast<const ASTLiteral &>(*engine_args[1]).value.safeGet<String>();
+        boost::split(topics, topics , [](char c){return c == ',';});
+        
+        // Parse consumer group
         String group = static_cast<const ASTLiteral &>(*engine_args[2]).value.safeGet<String>();
 
         // Parse format from string

--- a/dbms/src/Storages/StorageKafka.cpp
+++ b/dbms/src/Storages/StorageKafka.cpp
@@ -5,6 +5,7 @@
 #include <thread>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/trim.hpp>
 #include <Common/Exception.h>
 #include <Common/setThreadName.h>
 #include <Common/typeid_cast.h>
@@ -579,7 +580,9 @@ void registerStorageKafka(StorageFactory & factory)
         Names topics;
         String topicArg = static_cast<const ASTLiteral &>(*engine_args[1]).value.safeGet<String>();
         boost::split(topics, topicArg , [](char c){return c == ',';});
-        
+        for(String & topic : topics) {
+            boost::trim(topic);
+        }
         // Parse consumer group
         String group = static_cast<const ASTLiteral &>(*engine_args[2]).value.safeGet<String>();
 


### PR DESCRIPTION
This fixes the issue where the Kafka Storage engine would try to subscribe to the configured names as one topic name.
Before if the configuration was like this
```
ENGINE = Kafka('kafka:9092', 'topic1,topic2', ...);
```
Then the storage engine would try to subscribe to a topic with name "topic1,topic2" instead of ["topic1","topic2"]

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
