### PR TITLE
Ability to set server UID/GID in docker image.

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -4,7 +4,7 @@ ARG repository="deb http://repo.yandex.ru/clickhouse/deb/stable/ main/"
 ARG version=\*
 
 RUN apt-get update && \
-    apt-get install -y apt-transport-https && \
+    apt-get install -y apt-transport-https gosu && \
     mkdir -p /etc/apt/sources.list.d && \
     echo $repository | tee /etc/apt/sources.list.d/clickhouse.list && \
     apt-get update && \
@@ -15,10 +15,15 @@ RUN apt-get update && \
 COPY docker_related_config.xml /etc/clickhouse-server/config.d/
 RUN chown -R clickhouse /etc/clickhouse-server/
 
-USER clickhouse
 EXPOSE 9000 8123 9009
 VOLUME /var/lib/clickhouse
 
-ENV CLICKHOUSE_CONFIG /etc/clickhouse-server/config.xml
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
-ENTRYPOINT exec /usr/bin/clickhouse-server --config=${CLICKHOUSE_CONFIG}
+ENV \
+  CLICKHOUSE_CONFIG=/etc/clickhouse-server/config.xml \
+  \
+  USER_UID=105 \
+  USER_GID=106
+
+ENTRYPOINT /usr/local/bin/entrypoint.sh

--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+
+userdel clickhouse 2>/dev/null
+groupdel clickhouse 2>/dev/null
+groupadd -g $USER_GID clickhouse
+useradd -d /home/clickhouse -g clickhouse -u $USER_UID -s /nonexistent clickhouse
+
+chown -R clickhouse /etc/clickhouse-server
+chown -R clickhouse /var/log/clickhouse-server
+chown -R clickhouse /var/lib/clickhouse
+
+gosu clickhouse /usr/bin/clickhouse-server --config=${CLICKHOUSE_CONFIG} &
+child=$!
+
+trap "kill $child" INT TERM
+wait "$child"
+trap - INT TERM
+wait "$child"


### PR DESCRIPTION
Added environment variables to configure this behavior.
Default values is backward compatible.
Setting permissions to Clickhouse folders may be not fully backward compatible - because it changes ownership recursuvely.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
