### PR TITLE
More aggressively move files to broken/ when doing distributed batch inserts

### DIFF
--- a/dbms/src/Storages/Distributed/DirectoryMonitor.cpp
+++ b/dbms/src/Storages/Distributed/DirectoryMonitor.cpp
@@ -274,10 +274,16 @@ struct StorageDistributedDirectoryMonitor::Batch
     std::vector<UInt64> file_indices;
     size_t total_rows = 0;
     size_t total_bytes = 0;
+    bool recovered = false;
 
     StorageDistributedDirectoryMonitor & parent;
+    const std::map<UInt64, String> & file_index_to_path;
 
-    explicit Batch(StorageDistributedDirectoryMonitor & parent_) : parent(parent_) {}
+    Batch(
+        StorageDistributedDirectoryMonitor & parent_,
+        const std::map<UInt64, String> & file_index_to_path_)
+        : parent(parent_), file_index_to_path(file_index_to_path_)
+    {}
 
     bool isEnoughSize() const
     {
@@ -286,14 +292,14 @@ struct StorageDistributedDirectoryMonitor::Batch
             || (parent.min_batched_block_size_bytes && total_bytes >= parent.min_batched_block_size_bytes);
     }
 
-    void send(bool save, const std::map<UInt64, String> & file_index_to_path)
+    void send()
     {
         if (file_indices.empty())
             return;
 
         CurrentMetrics::Increment metric_increment{CurrentMetrics::DistributedSend};
 
-        if (save)
+        if (!recovered)
         {
             /// For deduplication in Replicated tables to work, in case of error
             /// we must try to re-send exactly the same batches.
@@ -305,31 +311,68 @@ struct StorageDistributedDirectoryMonitor::Batch
 
         auto connection = parent.pool->get();
 
-        String insert_query;
-        std::unique_ptr<RemoteBlockOutputStream> remote;
-        bool first = true;
-
-        for (UInt64 file_idx : file_indices)
+        bool batch_broken = false;
+        try
         {
-            ReadBufferFromFile in{file_index_to_path.at(file_idx)};
-            readStringBinary(insert_query, in); /// NOTE: all files must have the same insert_query
+            String insert_query;
+            std::unique_ptr<RemoteBlockOutputStream> remote;
+            bool first = true;
 
-            if (first)
+            for (UInt64 file_idx : file_indices)
             {
-                first = false;
-                remote = std::make_unique<RemoteBlockOutputStream>(*connection, insert_query);
-                remote->writePrefix();
+                auto file_path = file_index_to_path.find(file_idx);
+                if (file_path == file_index_to_path.end())
+                {
+                    LOG_ERROR(parent.log, "Failed to send batch: file with index " << file_idx << " is absent");
+                    batch_broken = true;
+                    break;
+                }
+
+                ReadBufferFromFile in(file_path->second);
+                readStringBinary(insert_query, in); /// NOTE: all files must have the same insert_query
+
+                if (first)
+                {
+                    first = false;
+                    remote = std::make_unique<RemoteBlockOutputStream>(*connection, insert_query);
+                    remote->writePrefix();
+                }
+
+                remote->writePrepared(in);
             }
 
-            remote->writePrepared(in);
+            remote->writeSuffix();
+        }
+        catch (const Exception & e)
+        {
+            if (isFileBrokenErrorCode(e.code()))
+            {
+                tryLogCurrentException(parent.log, "Failed to send batch due to");
+                batch_broken = true;
+            }
+            else
+                throw;
         }
 
-        remote->writeSuffix();
+        if (!batch_broken)
+        {
+            LOG_TRACE(parent.log, "Sent a batch of " << file_indices.size() << " files.");
 
-        LOG_TRACE(parent.log, "Sent a batch of " << file_indices.size() << " files.");
+            for (UInt64 file_index : file_indices)
+                Poco::File{file_index_to_path.at(file_index)}.remove();
+        }
+        else
+        {
+            LOG_ERROR(parent.log, "Marking a batch of " << file_indices.size() << " files as broken.");
 
-        for (UInt64 file_index : file_indices)
-            Poco::File{file_index_to_path.at(file_index)}.remove();
+            for (UInt64 file_idx : file_indices)
+            {
+                auto file_path = file_index_to_path.find(file_idx);
+                if (file_path != file_index_to_path.end())
+                    parent.markAsBroken(file_path->second);
+            }
+        }
+
         file_indices.clear();
         total_rows = 0;
         total_bytes = 0;
@@ -352,6 +395,7 @@ struct StorageDistributedDirectoryMonitor::Batch
             in >> idx >> "\n";
             file_indices.push_back(idx);
         }
+        recovered = true;
     }
 };
 
@@ -362,11 +406,11 @@ void StorageDistributedDirectoryMonitor::processFilesWithBatching(const std::map
     if (Poco::File{current_batch_file_path}.exists())
     {
         /// Possibly, we failed to send a batch on the previous iteration. Try to send exactly the same batch.
-        Batch batch{*this};
+        Batch batch(*this, files);
         ReadBufferFromFile in{current_batch_file_path};
         batch.readText(in);
         file_indices_to_skip.insert(batch.file_indices.begin(), batch.file_indices.end());
-        batch.send(/* save = */ false, files);
+        batch.send();
     }
 
     std::unordered_map<BatchHeader, Batch, BatchHeader::Hash> header_to_batch;
@@ -418,47 +462,54 @@ void StorageDistributedDirectoryMonitor::processFilesWithBatching(const std::map
         }
 
         BatchHeader batch_header(std::move(insert_query), std::move(sample_block));
-        Batch & batch = header_to_batch.try_emplace(batch_header, *this).first->second;
+        Batch & batch = header_to_batch.try_emplace(batch_header, *this, files).first->second;
 
         batch.file_indices.push_back(file_idx);
         batch.total_rows += total_rows;
         batch.total_bytes += total_bytes;
 
         if (batch.isEnoughSize())
-            batch.send(/* save = */ true, files);
+            batch.send();
     }
 
     for (auto & kv : header_to_batch)
     {
         Batch & batch = kv.second;
-        batch.send(/* save = */ true, files);
+        batch.send();
     }
 
     Poco::File{current_batch_file_path}.remove();
 }
 
 
-bool StorageDistributedDirectoryMonitor::maybeMarkAsBroken(const std::string & file_path, const Exception &e) const
+bool StorageDistributedDirectoryMonitor::isFileBrokenErrorCode(int code)
 {
-    const auto code = e.code();
-
-    /// mark file as broken if necessary
-    if (code == ErrorCodes::CHECKSUM_DOESNT_MATCH
+    return code == ErrorCodes::CHECKSUM_DOESNT_MATCH
         || code == ErrorCodes::TOO_LARGE_SIZE_COMPRESSED
         || code == ErrorCodes::CANNOT_READ_ALL_DATA
-        || code == ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF)
+        || code == ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF;
+}
+
+void StorageDistributedDirectoryMonitor::markAsBroken(const std::string & file_path) const
+{
+    const auto last_path_separator_pos = file_path.rfind('/');
+    const auto & path = file_path.substr(0, last_path_separator_pos + 1);
+    const auto & file_name = file_path.substr(last_path_separator_pos + 1);
+    const auto & broken_path = path + "broken/";
+    const auto & broken_file_path = broken_path + file_name;
+
+    Poco::File{broken_path}.createDirectory();
+    Poco::File{file_path}.renameTo(broken_file_path);
+
+    LOG_ERROR(log, "Renamed `" << file_path << "` to `" << broken_file_path << '`');
+}
+
+bool StorageDistributedDirectoryMonitor::maybeMarkAsBroken(const std::string & file_path, const Exception & e) const
+{
+    /// mark file as broken if necessary
+    if (isFileBrokenErrorCode(e.code()))
     {
-        const auto last_path_separator_pos = file_path.rfind('/');
-        const auto & path = file_path.substr(0, last_path_separator_pos + 1);
-        const auto & file_name = file_path.substr(last_path_separator_pos + 1);
-        const auto & broken_path = path + "broken/";
-        const auto & broken_file_path = broken_path + file_name;
-
-        Poco::File{broken_path}.createDirectory();
-        Poco::File{file_path}.renameTo(broken_file_path);
-
-        LOG_ERROR(log, "Renamed `" << file_path << "` to `" << broken_file_path << '`');
-
+        markAsBroken(file_path);
         return true;
     }
     else

--- a/dbms/src/Storages/Distributed/DirectoryMonitor.h
+++ b/dbms/src/Storages/Distributed/DirectoryMonitor.h
@@ -27,7 +27,11 @@ private:
     bool findFiles();
     void processFile(const std::string & file_path);
     void processFilesWithBatching(const std::map<UInt64, std::string> & files);
-    bool maybeMarkAsBroken(const std::string & file_path, const Exception &e) const;
+
+    static bool isFileBrokenErrorCode(int code);
+    void markAsBroken(const std::string & file_path) const;
+    bool maybeMarkAsBroken(const std::string & file_path, const Exception & e) const;
+
     std::string getLoggerName() const;
 
     StorageDistributed & storage;


### PR DESCRIPTION
* If a file is broken and we discover it when forming a batch, move it to the broken/ directory
* If we are trying to send an existing batch and some of the files in the batch are broken or missing, move the whole batch to the broken/ directory.