### PR TITLE
Fix build when using GCC 7.3.1: -Wmaybe-uninitialized error

### DIFF
--- a/dbms/src/Columns/ColumnString.h
+++ b/dbms/src/Columns/ColumnString.h
@@ -95,7 +95,7 @@ public:
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 
-        void insert(const Field & x) override
+    void insert(const Field & x) override
     {
         const String & s = DB::get<const String &>(x);
         const size_t old_size = chars.size();

--- a/dbms/src/Columns/ColumnString.h
+++ b/dbms/src/Columns/ColumnString.h
@@ -89,7 +89,13 @@ public:
         return StringRef(&chars[offsetAt(n)], sizeAt(n));
     }
 
-    void insert(const Field & x) override
+/// Suppress gcc7 warnings: '*((void*)&<anonymous> +8)' may be used uninitialized in this function
+#if !__clang__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
+        void insert(const Field & x) override
     {
         const String & s = DB::get<const String &>(x);
         const size_t old_size = chars.size();
@@ -101,7 +107,11 @@ public:
         offsets.push_back(new_size);
     }
 
-    void insertFrom(const IColumn & src_, size_t n) override
+#if !__clang__
+#pragma GCC diagnostic pop
+#endif
+
+        void insertFrom(const IColumn & src_, size_t n) override
     {
         const ColumnString & src = static_cast<const ColumnString &>(src_);
 

--- a/dbms/src/Columns/ColumnString.h
+++ b/dbms/src/Columns/ColumnString.h
@@ -89,7 +89,7 @@ public:
         return StringRef(&chars[offsetAt(n)], sizeAt(n));
     }
 
-/// Suppress gcc7 warnings: '*((void*)&<anonymous> +8)' may be used uninitialized in this function
+/// Suppress gcc 7.3.1 warning: '*((void*)&<anonymous> +8)' may be used uninitialized in this function
 #if !__clang__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"


### PR DESCRIPTION
Before adding this ignore you would receive the following when using GCC
7.3.1:

```
[ 82%] Building CXX object dbms/src/Storages/System/CMakeFiles/clickhouse_storages_system.dir/StorageSystemAsynchronousMetrics.cpp.o
In file included from /ClickHouse/dbms/src/Storages/System/StorageSystemAsynchronousMetrics.cpp:5:0:
/ClickHouse/dbms/src/Columns/ColumnString.h: In member function ‘virtual DB::BlockInputStreams DB::StorageSystemAsynchronousMetrics::read(const Names&, const DB::SelectQueryInfo&, const DB::Context&, DB::QueryProcessingStage::Enum&, size_t, unsigned int)’:
/ClickHouse/dbms/src/Columns/ColumnString.h:96:45: error: ‘*((void*)&<anonymous> +8)’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
         const size_t size_to_append = s.size() + 1;
                                       ~~~~~~^~
cc1plus: all warnings being treated as errors
make[2]: *** [dbms/src/Storages/System/CMakeFiles/clickhouse_storages_system.dir/build.make:63: dbms/src/Storages/System/CMakeFiles/clickhouse_storages_system.dir/StorageSystemAsynchronousMetrics.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:9105: dbms/src/Storages/System/CMakeFiles/clickhouse_storages_system.dir/all] Error 2
make: *** [Makefile:163: all] Error 2
```

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
