### PR TITLE
change the return type of funciton countEqual

### DIFF
--- a/dbms/src/Functions/FunctionsArray.h
+++ b/dbms/src/Functions/FunctionsArray.h
@@ -179,7 +179,7 @@ struct IndexIdentity
 /// For countEqual.
 struct IndexCount
 {
-    using ResultType = UInt32;
+    using ResultType = UInt64;
     static bool apply(size_t, ResultType & current) { ++current; return true; }
 };
 


### PR DESCRIPTION
the maximum length of the array is defined as UInt64.
the return type of the function `countEqual` is `UInt32` (4294967295), currently.

it's better to define the return type of the function `countEqual` as `UInt64`.


I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
