### PR TITLE
rename package clickhouse-common-dbg -> clickhouse-common-static-dbg, fix test references

### DIFF
--- a/dbms/tests/queries/0_stateless/00534_long_functions_bad_arguments8.reference
+++ b/dbms/tests/queries/0_stateless/00534_long_functions_bad_arguments8.reference
@@ -1,0 +1,1 @@
+Still alive

--- a/dbms/tests/queries/0_stateless/00534_long_functions_bad_arguments9.reference
+++ b/dbms/tests/queries/0_stateless/00534_long_functions_bad_arguments9.reference
@@ -1,0 +1,1 @@
+Still alive

--- a/debian/control
+++ b/debian/control
@@ -50,11 +50,14 @@ Description: Server binary for clickhouse
  .
  This package provides clickhouse common configuration files
 
-Package: clickhouse-common-dbg
+Package: clickhouse-common-static-dbg
 Architecture: any
 Section: debug
 Priority: extra
 Depends: ${misc:Depends}, clickhouse-common-static (= ${binary:Version})
+Replaces: clickhouse-common-dbg
+Provides: clickhouse-common-dbg
+Conflicts: clickhouse-common-dbg
 Description: debugging symbols for clickhouse-common-static
  This package contains the debugging symbols for clickhouse-common.
 

--- a/debian/rules
+++ b/debian/rules
@@ -70,7 +70,7 @@ override_dh_clean:
 	dh_clean
 
 override_dh_strip:
-	dh_strip -pclickhouse-common-static --dbg-package=clickhouse-common-dbg
+	dh_strip -pclickhouse-common-static --dbg-package=clickhouse-common-static-dbg
 
 override_dh_install:
 	# Making docs


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
