### PR TITLE
Use core tap since dupes was deprecated

### DIFF
--- a/docs/en/development/build_osx.md
+++ b/docs/en/development/build_osx.md
@@ -12,7 +12,7 @@ With appropriate changes, it should also work on any other Linux distribution.
 ## Install required compilers, tools, and libraries
 
 ```bash
-brew install cmake gcc icu4c mysql openssl unixodbc libtool gettext homebrew/dupes/zlib readline boost --cc=gcc-7
+brew install cmake gcc icu4c mysql openssl unixodbc libtool gettext zlib readline boost --cc=gcc-7
 ```
 
 ## Checkout ClickHouse sources


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
