### PR TITLE
fix typo of struct name

### DIFF
--- a/dbms/src/Parsers/ASTShowProcesslistQuery.h
+++ b/dbms/src/Parsers/ASTShowProcesslistQuery.h
@@ -6,12 +6,12 @@
 namespace DB
 {
 
-struct ASTShowProcesslisIDAndQueryNames
+struct ASTShowProcesslistIDAndQueryNames
 {
     static constexpr auto ID = "ShowProcesslistQuery";
     static constexpr auto Query = "SHOW PROCESSLIST";
 };
 
-using ASTShowProcesslistQuery = ASTQueryWithOutputImpl<ASTShowProcesslisIDAndQueryNames>;
+using ASTShowProcesslistQuery = ASTQueryWithOutputImpl<ASTShowProcesslistIDAndQueryNames>;
 
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
