### PR TITLE
use exp10 and cbrt from vectorclass when enabled

### DIFF
--- a/dbms/src/Functions/FunctionsMath.h
+++ b/dbms/src/Functions/FunctionsMath.h
@@ -484,18 +484,17 @@ using FunctionExp = FunctionMathUnaryFloat64<UnaryFunctionVectorized<ExpName, ex
 using FunctionLog = FunctionMathUnaryFloat64<UnaryFunctionVectorized<LogName, log>>;
 using FunctionExp2 = FunctionMathUnaryFloat64<UnaryFunctionVectorized<Exp2Name, exp2>>;
 using FunctionLog2 = FunctionMathUnaryFloat64<UnaryFunctionVectorized<Log2Name, log2>>;
-using FunctionExp10 = FunctionMathUnaryFloat64<UnaryFunctionVectorized<Exp10Name, preciseExp10>>;
-using FunctionLog10 = FunctionMathUnaryFloat64<UnaryFunctionVectorized<Log10Name, log10>>;
-using FunctionSqrt = FunctionMathUnaryFloat64<UnaryFunctionVectorized<SqrtName, sqrt>>;
-
-using FunctionCbrt = FunctionMathUnaryFloat64<UnaryFunctionVectorized<CbrtName,
+using FunctionExp10 = FunctionMathUnaryFloat64<UnaryFunctionVectorized<Exp10Name, 
 #if USE_VECTORCLASS
-    Power_rational<1, 3>::pow
+    exp10
 #else
-    cbrt
+    preciseExp10
 #endif
 >>;
 
+using FunctionLog10 = FunctionMathUnaryFloat64<UnaryFunctionVectorized<Log10Name, log10>>;
+using FunctionSqrt = FunctionMathUnaryFloat64<UnaryFunctionVectorized<SqrtName, sqrt>>;
+using FunctionCbrt = FunctionMathUnaryFloat64<UnaryFunctionVectorized<CbrtName,cbrt>>;
 using FunctionSin = FunctionMathUnaryFloat64<UnaryFunctionVectorized<SinName, sin>>;
 using FunctionCos = FunctionMathUnaryFloat64<UnaryFunctionVectorized<CosName, cos>>;
 using FunctionTan = FunctionMathUnaryFloat64<UnaryFunctionVectorized<TanName, tan>>;

--- a/dbms/src/Functions/FunctionsMath.h
+++ b/dbms/src/Functions/FunctionsMath.h
@@ -494,7 +494,7 @@ using FunctionExp10 = FunctionMathUnaryFloat64<UnaryFunctionVectorized<Exp10Name
 
 using FunctionLog10 = FunctionMathUnaryFloat64<UnaryFunctionVectorized<Log10Name, log10>>;
 using FunctionSqrt = FunctionMathUnaryFloat64<UnaryFunctionVectorized<SqrtName, sqrt>>;
-using FunctionCbrt = FunctionMathUnaryFloat64<UnaryFunctionVectorized<CbrtName,cbrt>>;
+using FunctionCbrt = FunctionMathUnaryFloat64<UnaryFunctionVectorized<CbrtName, cbrt>>;
 using FunctionSin = FunctionMathUnaryFloat64<UnaryFunctionVectorized<SinName, sin>>;
 using FunctionCos = FunctionMathUnaryFloat64<UnaryFunctionVectorized<CosName, cos>>;
 using FunctionTan = FunctionMathUnaryFloat64<UnaryFunctionVectorized<TanName, tan>>;


### PR DESCRIPTION
Hello, 
 I tried to compile ClikHouse with vector class suport enabled  and it failed at two places :

```
ClickHouse/dbms/src/Functions/FunctionsMath.h:489:5: error: could not convert template argument ‘preciseExp10’ from ‘double(double) noexcept’ to ‘Vec2d (*)(const Vec2d&)’
     preciseExp10
     ^~~~~~~~~~~~

```
```
ClickHouse/dbms/src/Functions/FunctionsMath.h:500:28: error: could not convert template argument ‘ Power_rational<1, 3>::pow<VTYPE>’ from ‘<unresolved overloaded function type>’ to ‘Vec2d (*)(const Vec2d&)’
     Power_rational<1, 3>::pow
```
Power_rational::pow function is non static (even the specialized functions). I don't understand how it was compiling but i'm maybe missing something here. 
So i changed the code to call the vectorized version of cbrt and exp10 when vectorclass is Enabled. 

Compiled with gcc-7:
gcc-7 --version
gcc-7 (Ubuntu 7.2.0-1ubuntu1~16.04) 7.2.0


I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
