### PR TITLE
Test: fill CLICKHOUSE_CONFIG from args.configserver

### DIFF
--- a/dbms/tests/clickhouse-test
+++ b/dbms/tests/clickhouse-test
@@ -76,6 +76,7 @@ def main(args):
     # Keep same default values as in queries/0_stateless/00000_sh_lib.sh
     os.environ.setdefault("CLICKHOUSE_BINARY", args.binary)
     os.environ.setdefault("CLICKHOUSE_CLIENT", args.client)
+    os.environ.setdefault("CLICKHOUSE_CONFIG", args.configserver)
     os.environ.setdefault("CLICKHOUSE_TMP", tmp_dir)
 
     # TODO ! use clickhouse-extract-from-config here:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
