### PR TITLE
Zero-initialize Field::storage so that gcc 7.3.0 doesn't complain

### DIFF
--- a/dbms/src/Core/Field.h
+++ b/dbms/src/Core/Field.h
@@ -330,7 +330,7 @@ public:
 private:
     std::aligned_union_t<DBMS_MIN_FIELD_SIZE - sizeof(Types::Which),
         Null, UInt64, UInt128, Int64, Float64, String, Array, Tuple
-        > storage;
+        > storage = {};
 
     Types::Which which;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
