### PR TITLE
Better handling urls when using "update_field" parameter

### DIFF
--- a/dbms/src/Dictionaries/HTTPDictionarySource.cpp
+++ b/dbms/src/Dictionaries/HTTPDictionarySource.cpp
@@ -32,9 +32,12 @@ HTTPDictionarySource::HTTPDictionarySource(const DictionaryStructure & dict_stru
     if (update_field.empty())
         return;
 
-    /// TODO This code is totally wrong and ignorant.
-    /// What if URL contains fragment (#). What if update_field contains characters that must be %-encoded.
-    std::string::size_type option = url.find("?");
+    std::string tmp_update_field;
+    Poco::URI::encode(update_field, "&", tmp_update_field);
+    update_field = tmp_update_field;
+
+    std::string::size_type option = url.substr(0, url.find("#", 0)).find("?");
+
     if (option == std::string::npos)
         update_field = '?' + update_field;
     else
@@ -66,12 +69,12 @@ std::string HTTPDictionarySource::getUpdateFieldAndDate()
         timeinfo = localtime (&hr_time);
         strftime(buffer, 80, "=%Y-%m-%d%%20%H:%M:%S", timeinfo);
         std::string str_time(buffer);
-        return url + update_field + str_time;
+        return url.substr(0, url.find("#", 0)) + update_field + str_time;
     }
     else
     {
         update_time = std::chrono::system_clock::now();
-        return url + update_field + "=0000-00-00%2000:00:00"; ///for initial load
+        return url.substr(0, url.find("#", 0)) + update_field + "=0000-00-00%2000:00:00"; ///for initial load
     }
 }
 

--- a/dbms/src/Dictionaries/HTTPDictionarySource.cpp
+++ b/dbms/src/Dictionaries/HTTPDictionarySource.cpp
@@ -29,19 +29,6 @@ HTTPDictionarySource::HTTPDictionarySource(const DictionaryStructure & dict_stru
     context(context),
     timeouts(ConnectionTimeouts::getHTTPTimeouts(context.getSettingsRef()))
 {
-    if (update_field.empty())
-        return;
-
-    std::string tmp_update_field;
-    Poco::URI::encode(update_field, "&", tmp_update_field);
-    update_field = tmp_update_field;
-
-    std::string::size_type option = url.substr(0, url.find("#", 0)).find("?");
-
-    if (option == std::string::npos)
-        update_field = '?' + update_field;
-    else
-        update_field = '&' + update_field;
 }
 
 HTTPDictionarySource::HTTPDictionarySource(const HTTPDictionarySource & other)
@@ -57,7 +44,7 @@ HTTPDictionarySource::HTTPDictionarySource(const HTTPDictionarySource & other)
 {
 }
 
-std::string HTTPDictionarySource::getUpdateFieldAndDate()
+void HTTPDictionarySource::getUpdateFieldAndDate(Poco::URI & uri)
 {
     if (update_time != std::chrono::system_clock::from_time_t(0))
     {
@@ -67,14 +54,14 @@ std::string HTTPDictionarySource::getUpdateFieldAndDate()
         char buffer [80];
         struct tm * timeinfo;
         timeinfo = localtime (&hr_time);
-        strftime(buffer, 80, "=%Y-%m-%d%%20%H:%M:%S", timeinfo);
+        strftime(buffer, 80, "%Y-%m-%d %H:%M:%S", timeinfo);
         std::string str_time(buffer);
-        return url.substr(0, url.find("#", 0)) + update_field + str_time;
+        uri.addQueryParameter(update_field, str_time);
     }
     else
     {
         update_time = std::chrono::system_clock::now();
-        return url.substr(0, url.find("#", 0)) + update_field + "=0000-00-00%2000:00:00"; ///for initial load
+        uri.addQueryParameter(update_field, "0000-00-00 00:00:00");
     }
 }
 
@@ -90,9 +77,9 @@ BlockInputStreamPtr HTTPDictionarySource::loadAll()
 
 BlockInputStreamPtr HTTPDictionarySource::loadUpdatedAll()
 {
-    std::string url_update = getUpdateFieldAndDate();
-    LOG_TRACE(log, "loadUpdatedAll " + url_update);
-    Poco::URI uri(url_update);
+    Poco::URI uri(url);
+    getUpdateFieldAndDate(uri);
+    LOG_TRACE(log, "loadUpdatedAll " + uri.toString());
     auto in_ptr = std::make_unique<ReadWriteBufferFromHTTP>(uri, Poco::Net::HTTPRequest::HTTP_GET,
                                                             ReadWriteBufferFromHTTP::OutStreamCallback(), timeouts);
     auto input_stream = context.getInputFormat(format, *in_ptr, sample_block, max_block_size);

--- a/dbms/src/Dictionaries/HTTPDictionarySource.h
+++ b/dbms/src/Dictionaries/HTTPDictionarySource.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Poco/URI.h>
 #include <Dictionaries/IDictionarySource.h>
 #include <Dictionaries/DictionaryStructure.h>
 #include <common/LocalDateTime.h>
@@ -43,7 +44,7 @@ public:
     std::string toString() const override;
 
 private:
-    std::string getUpdateFieldAndDate();
+    void getUpdateFieldAndDate(Poco::URI & uri);
 
     Poco::Logger * log;
 


### PR DESCRIPTION
Adds percent encoding for "update_field" parameter
Handles cases when url has fragment

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
