### PR TITLE
Fix DateTime vs DateTime('UTC') inconsistency on data read.

### DIFF
--- a/dbms/src/Storages/ITableDeclaration.cpp
+++ b/dbms/src/Storages/ITableDeclaration.cpp
@@ -198,7 +198,7 @@ void ITableDeclaration::check(const NamesAndTypesList & provided_columns, const 
             throw Exception("There is no column with name " + name + ". There are columns: "
                 + listOfColumns(available_columns), ErrorCodes::NO_SUCH_COLUMN_IN_TABLE);
 
-        if (it->second->getName() != jt->second->getName())
+        if (!it->second->equals(*jt->second))
             throw Exception("Type mismatch for column " + name + ". Column has type "
                 + jt->second->getName() + ", got type " + it->second->getName(), ErrorCodes::TYPE_MISMATCH);
 


### PR DESCRIPTION
Original problem was described in PR #1650 and partially fixed by
b5af4c95, however one place was forgotten and it was causing query
exceptions when trying to read DateTime column across parts with
different DateTime and DateTime('UTC') data type.

`DB::Exception: Type mismatch for column timeslot. Column has type DateTime, got type DateTime('UTC')`

cc @alexey-milovidov @bobrik @vavrusa @dqminh

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
