### PR TITLE
Add chown for config dir into systemd.service

### DIFF
--- a/debian/clickhouse-server.service
+++ b/debian/clickhouse-server.service
@@ -5,8 +5,10 @@ Description=ClickHouse Server (analytic DBMS for big data)
 Type=simple
 User=clickhouse
 Group=clickhouse
+PermissionsStartOnly=true
 Restart=always
 RestartSec=30
+ExecStartPre=/usr/bin/chown clickhouse:clickhouse -R /etc/clickhouse-server
 ExecStart=/usr/bin/clickhouse-server --config=/etc/clickhouse-server/config.xml
 LimitCORE=infinity
 LimitNOFILE=500000


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

This part is presented in debian/clickhouse-server.init, but omitted in systemd