### PR TITLE
fix Exception in issue#2439

### DIFF
--- a/dbms/src/Storages/StorageKafka.cpp
+++ b/dbms/src/Storages/StorageKafka.cpp
@@ -409,6 +409,15 @@ void StorageKafka::streamThread()
                 auto dependencies = context.getDependencies(database_name, table_name);
                 if (dependencies.size() == 0)
                     break;
+                // Check the dependencies are ready?
+                bool ready = true;
+                for (const auto & db_tab : dependencies)
+                {
+                    if (!context.tryGetTable(db_tab.first, db_tab.second))
+                        ready = false;
+                }
+                if (!ready)
+                    break;
 
                 LOG_DEBUG(log, "Started streaming to " << dependencies.size() << " attached views");
                 streamToViews();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
In Issue#2439, there will be an Exception after creating a materialized view tab_view to kafka engine table. The reason is the materialized view will add dependencies before itself construct ready in context.