### PR TITLE
Syslog logging support

### DIFF
--- a/docs/en/operations/server_settings/settings.md
+++ b/docs/en/operations/server_settings/settings.md
@@ -328,6 +328,28 @@ Keys:
 </logger>
 ```
 
+Also, logging to syslog is possible. Configuration example:
+```xml
+<logger>
+    <use_syslog>1</use_syslog>
+    <syslog>
+        <address>syslog.remote:10514</address>
+        <hostname>myhost.local</hostname> 
+        <facility>LOG_LOCAL6</facility>
+        <format>syslog</format>
+    </syslog>
+</logger>
+```
+
+Keys:
+- user_syslog - activation key, turning on syslog logging.
+- address - host[:port] of syslogd. If not specified, local one would be used.
+- hostname - optional, source host of logs
+- facility - [syslog facility](https://en.wikipedia.org/wiki/Syslog#Facility), 
+in uppercase, prefixed with "LOG_": (``LOG_USER``, ``LOG_DAEMON``, ``LOG_LOCAL3`` etc.). 
+Default values: when ``address`` is specified, then ``LOG_USER``, otherwise - ``LOG_DAEMON``
+- format - message format. Possible values are - ``bsd`` and ``syslog``
+
 <a name="server_settings-macros"></a>
 
 ## macros

--- a/docs/ru/operations/server_settings/settings.md
+++ b/docs/ru/operations/server_settings/settings.md
@@ -329,6 +329,29 @@ ClickHouse проверит условия `min_part_size` и `min_part_size_rat
 </logger>
 ```
 
+Также, существует поддержка записи в syslog. Пример конфига:
+```xml
+<logger>
+    <use_syslog>1</use_syslog>
+    <syslog>
+        <address>syslog.remote:10514</address>
+        <hostname>myhost.local</hostname> 
+        <facility>LOG_LOCAL6</facility>
+        <format>syslog</format>
+    </syslog>
+</logger>
+```
+
+Ключи:
+- user_syslog - обязательная настройка, если требуется запись в syslog
+- address - хост[:порт] демона syslogd. Если не указан, используется локальный
+- hostname - опционально, имя хоста, с которого отсылаются логи
+- facility - [категория syslog](https://en.wikipedia.org/wiki/Syslog#Facility), 
+записанная в верхнем регистре, с префиксом "LOG_": (``LOG_USER``, ``LOG_DAEMON``, ``LOG_LOCAL3`` и прочие). 
+Значения по-умолчанию: при указанном ``address`` - ``LOG_USER``, иначе - ``LOG_DAEMON``
+- format - формат сообщений. Возможные значения - ``bsd`` и ``syslog``
+
+ 
 <a name="server_settings-macros"></a>
 
 ## macros

--- a/libs/libdaemon/include/daemon/BaseDaemon.h
+++ b/libs/libdaemon/include/daemon/BaseDaemon.h
@@ -214,7 +214,7 @@ protected:
     /// Файлы с логами.
     Poco::AutoPtr<Poco::FileChannel> log_file;
     Poco::AutoPtr<Poco::FileChannel> error_log_file;
-    Poco::AutoPtr<Poco::SyslogChannel> syslog_channel;
+    Poco::AutoPtr<Poco::Channel> syslog_channel;
 
     std::map<std::string, std::unique_ptr<GraphiteWriter>> graphite_writers;
 

--- a/libs/libdaemon/src/BaseDaemon.cpp
+++ b/libs/libdaemon/src/BaseDaemon.cpp
@@ -763,7 +763,7 @@ void BaseDaemon::buildLoggers(Poco::Util::AbstractConfiguration & config)
         pf->setProperty("times", "local");
         Poco::AutoPtr<FormattingChannel> log = new FormattingChannel(pf);
 
-        const std::string &cmdName = commandName();
+        const std::string & cmd_name = commandName();
 
         if (config.has("logger.syslog.address"))
         {
@@ -780,7 +780,7 @@ void BaseDaemon::buildLoggers(Poco::Util::AbstractConfiguration & config)
         else
         {
             syslog_channel = new Poco::SyslogChannel();
-            syslog_channel->setProperty(Poco::SyslogChannel::PROP_NAME, cmdName);
+            syslog_channel->setProperty(Poco::SyslogChannel::PROP_NAME, cmd_name);
             syslog_channel->setProperty(Poco::SyslogChannel::PROP_OPTIONS, config.getString("logger.syslog.options", "LOG_CONS|LOG_PID"));
             syslog_channel->setProperty(Poco::SyslogChannel::PROP_FACILITY, config.getString("logger.syslog.facility", "LOG_DAEMON"));
         }

--- a/libs/libdaemon/src/BaseDaemon.cpp
+++ b/libs/libdaemon/src/BaseDaemon.cpp
@@ -62,6 +62,7 @@
 #include <Common/getMultipleKeysFromConfig.h>
 #include <Common/ClickHouseRevision.h>
 #include <daemon/OwnPatternFormatter.h>
+#include <Poco/Net/RemoteSyslogChannel.h>
 
 
 using Poco::Logger;
@@ -761,7 +762,29 @@ void BaseDaemon::buildLoggers(Poco::Util::AbstractConfiguration & config)
         Poco::AutoPtr<OwnPatternFormatter> pf = new OwnPatternFormatter(this, OwnPatternFormatter::ADD_LAYER_TAG);
         pf->setProperty("times", "local");
         Poco::AutoPtr<FormattingChannel> log = new FormattingChannel(pf);
-        syslog_channel = new Poco::SyslogChannel(commandName(), Poco::SyslogChannel::SYSLOG_CONS | Poco::SyslogChannel::SYSLOG_PID, Poco::SyslogChannel::SYSLOG_DAEMON);
+
+        const std::string &cmdName = commandName();
+
+        if (config.has("logger.syslog.address"))
+        {
+            syslog_channel = new Poco::Net::RemoteSyslogChannel();
+            // syslog address
+            syslog_channel->setProperty(Poco::Net::RemoteSyslogChannel::PROP_LOGHOST, config.getString("logger.syslog.address"));
+            if (config.has("logger.syslog.hostname"))
+            {
+                syslog_channel->setProperty(Poco::Net::RemoteSyslogChannel::PROP_HOST, config.getString("logger.syslog.hostname"));
+            }
+            syslog_channel->setProperty(Poco::Net::RemoteSyslogChannel::PROP_FORMAT, config.getString("logger.syslog.format", "syslog"));
+            syslog_channel->setProperty(Poco::Net::RemoteSyslogChannel::PROP_FACILITY, config.getString("logger.syslog.facility", "LOG_USER"));
+        }
+        else
+        {
+            syslog_channel = new Poco::SyslogChannel();
+            syslog_channel->setProperty(Poco::SyslogChannel::PROP_NAME, cmdName);
+            syslog_channel->setProperty(Poco::SyslogChannel::PROP_OPTIONS, config.getString("logger.syslog.options", "LOG_CONS|LOG_PID"));
+            syslog_channel->setProperty(Poco::SyslogChannel::PROP_FACILITY, config.getString("logger.syslog.facility", "LOG_DAEMON"));
+        }
+
         log->setChannel(syslog_channel);
         split->addChannel(log);
         syslog_channel->open();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

In this PR a logging to syslog has been implemented. For backward compatibility, it is turned on with currently hidden option ``use_syslog``.