### PR TITLE
Fixed discrepancy between Query, SelectQuery, InsertQuery profile events.

### DIFF
--- a/dbms/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterInsertQuery.cpp
@@ -1,7 +1,6 @@
 #include <IO/ConcatReadBuffer.h>
 
 #include <Common/typeid_cast.h>
-#include <Common/ProfileEvents.h>
 
 #include <DataStreams/AddingDefaultBlockOutputStream.h>
 #include <DataStreams/CountingBlockOutputStream.h>
@@ -22,11 +21,6 @@
 #include <Parsers/ASTFunction.h>
 
 
-namespace ProfileEvents
-{
-    extern const Event InsertQuery;
-}
-
 namespace DB
 {
 
@@ -42,7 +36,6 @@ InterpreterInsertQuery::InterpreterInsertQuery(
     const ASTPtr & query_ptr_, const Context & context_, bool allow_materialized_)
     : query_ptr(query_ptr_), context(context_), allow_materialized(allow_materialized_)
 {
-    ProfileEvents::increment(ProfileEvents::InsertQuery);
 }
 
 

--- a/dbms/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterSelectQuery.cpp
@@ -45,11 +45,6 @@
 #include <Common/typeid_cast.h>
 
 
-namespace ProfileEvents
-{
-    extern const Event SelectQuery;
-}
-
 namespace DB
 {
 
@@ -103,8 +98,6 @@ InterpreterSelectQuery::~InterpreterSelectQuery() = default;
 
 void InterpreterSelectQuery::init(const Names & required_result_column_names)
 {
-    ProfileEvents::increment(ProfileEvents::SelectQuery);
-
     if (!context.hasQueryContext())
         context.setQueryContext(context);
 

--- a/dbms/src/Interpreters/executeQuery.cpp
+++ b/dbms/src/Interpreters/executeQuery.cpp
@@ -1,4 +1,3 @@
-#include <Common/ProfileEvents.h>
 #include <Common/formatReadable.h>
 #include <Common/typeid_cast.h>
 
@@ -25,11 +24,6 @@
 #include <Interpreters/executeQuery.h>
 #include "DNSCacheUpdater.h"
 
-
-namespace ProfileEvents
-{
-    extern const Event Query;
-}
 
 namespace DB
 {
@@ -137,7 +131,6 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
     bool internal,
     QueryProcessingStage::Enum stage)
 {
-    ProfileEvents::increment(ProfileEvents::Query);
     time_t current_time = time(nullptr);
 
     context.setQueryContext(context);


### PR DESCRIPTION
Query event was tracked only on user queries, but SelectQuery was tracked also for subqueries.
For this reason, SelectQuery counter could be larger than Query counter, and that leads to confusion.

Note: after these changes, Query event will not be tracked when query fails early due to syntax error, quota exceed or number of concurrent queries is too large. Although query is logged in query_log and in ordinary log in these cases.