### PR TITLE
Do not use exact chown path

### DIFF
--- a/debian/clickhouse-server.service
+++ b/debian/clickhouse-server.service
@@ -8,7 +8,7 @@ Group=clickhouse
 PermissionsStartOnly=true
 Restart=always
 RestartSec=30
-ExecStartPre=/usr/bin/chown clickhouse:clickhouse -R /etc/clickhouse-server
+ExecStartPre=chown clickhouse:clickhouse -R /etc/clickhouse-server
 ExecStart=/usr/bin/clickhouse-server --config=/etc/clickhouse-server/config.xml
 LimitCORE=infinity
 LimitNOFILE=500000


### PR DESCRIPTION
We've faced with the problem that chown is located in ``/bin/chown`` instead of ``/usr/bin/chown``. We've created symlink in order to bypass the problem, but it seems it would be nice to fix the script.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
