### PR TITLE
Accept libtinfo for libtermcap

### DIFF
--- a/cmake/find_readline_edit.cmake
+++ b/cmake/find_readline_edit.cmake
@@ -10,7 +10,7 @@ endif ()
 
 list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES .so.2)
 
-find_library (TERMCAP_LIB NAMES termcap)
+find_library (TERMCAP_LIB NAMES termcap tinfo)
 find_library (EDIT_LIB NAMES edit)
 
 set(READLINE_INCLUDE_PATHS "/usr/local/opt/readline/include")


### PR DESCRIPTION
On Linux, `libtermcap.so` is a compatibility alias for `libtinfo.so`. For example, on Ubuntu 16.04 both libraries are provided by `libtinfo-dev` and its `libtermcap.so` is a text file with `GROUP( libtinfo.so )`. On NixOS, this alias is not present and ClickHouse needs this patch to compile with readline support.