### PR TITLE
Fix quantileTDigest

### DIFF
--- a/dbms/src/Common/RadixSort.h
+++ b/dbms/src/Common/RadixSort.h
@@ -54,7 +54,7 @@ struct RadixSortFloatTransform
 
     static KeyBits forward(KeyBits x)
     {
-        return x ^ (-(x >> (sizeof(KeyBits) * 8 - 1) | (KeyBits(1) << (sizeof(KeyBits) * 8 - 1))));
+        return x ^ ((-(x >> (sizeof(KeyBits) * 8 - 1))) | (KeyBits(1) << (sizeof(KeyBits) * 8 - 1)));
     }
 
     static KeyBits backward(KeyBits x)


### PR DESCRIPTION
RadixSort doesn't work on negative floats. So quantileTDigest doesn't work too.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
