### PR TITLE
Recreate format_version.txt when missing

### DIFF
--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -159,9 +159,9 @@ MergeTreeData::MergeTreeData(
     Poco::File(full_path + "detached").createDirectory();
 
     String version_file_path = full_path + "format_version.txt";
-    auto file_exists = Poco::File(version_file_path).exists();
+    auto version_file_exists = Poco::File(version_file_path).exists();
     // When data path or file not exists, ignore the format_version check
-    if (!attach || !path_exists || !file_exists)
+    if (!attach || !path_exists || !version_file_exists)
     {
         format_version = min_format_version;
         WriteBufferFromFile buf(version_file_path);

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -159,8 +159,9 @@ MergeTreeData::MergeTreeData(
     Poco::File(full_path + "detached").createDirectory();
 
     String version_file_path = full_path + "format_version.txt";
-    // When data path not exists, ignore the format_version check
-    if (!attach || !path_exists)
+    auto file_exists = Poco::File(version_file_path).exists();
+    // When data path or file not exists, ignore the format_version check
+    if (!attach || !path_exists || !file_exists)
     {
         format_version = min_format_version;
         WriteBufferFromFile buf(version_file_path);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

In some cases, after reboot, data is missing together with format_version.txt, but the parent dir is available. Because of this ClickHouse is unable to start.

Fixes #1569.