### PR TITLE
Add missing UInt128 (UUID) field visitors

### DIFF
--- a/dbms/src/Common/FieldVisitors.cpp
+++ b/dbms/src/Common/FieldVisitors.cpp
@@ -155,6 +155,13 @@ void FieldVisitorHash::operator() (const UInt64 & x) const
     hash.update(x);
 }
 
+void FieldVisitorHash::operator() (const UInt128 & x) const
+{
+    UInt8 type = Field::Types::UInt128;
+    hash.update(type);
+    hash.update(x);
+}
+
 void FieldVisitorHash::operator() (const Int64 & x) const
 {
     UInt8 type = Field::Types::Int64;

--- a/dbms/src/Common/FieldVisitors.h
+++ b/dbms/src/Common/FieldVisitors.h
@@ -38,6 +38,7 @@ typename std::decay_t<Visitor>::ResultType applyVisitor(Visitor && visitor, F &&
     {
         case Field::Types::Null:    return visitor(field.template get<Null>());
         case Field::Types::UInt64:  return visitor(field.template get<UInt64>());
+        case Field::Types::UInt128: return visitor(field.template get<UInt128>());
         case Field::Types::Int64:   return visitor(field.template get<Int64>());
         case Field::Types::Float64: return visitor(field.template get<Float64>());
         case Field::Types::String:  return visitor(field.template get<String>());
@@ -57,6 +58,7 @@ static typename std::decay_t<Visitor>::ResultType applyBinaryVisitorImpl(Visitor
     {
         case Field::Types::Null:    return visitor(field1, field2.template get<Null>());
         case Field::Types::UInt64:  return visitor(field1, field2.template get<UInt64>());
+        case Field::Types::UInt128: return visitor(field1, field2.template get<UInt128>());
         case Field::Types::Int64:   return visitor(field1, field2.template get<Int64>());
         case Field::Types::Float64: return visitor(field1, field2.template get<Float64>());
         case Field::Types::String:  return visitor(field1, field2.template get<String>());
@@ -79,6 +81,9 @@ typename std::decay_t<Visitor>::ResultType applyVisitor(Visitor && visitor, F1 &
         case Field::Types::UInt64:
             return applyBinaryVisitorImpl(
                 std::forward<Visitor>(visitor), field1.template get<UInt64>(), std::forward<F2>(field2));
+        case Field::Types::UInt128:
+            return applyBinaryVisitorImpl(
+                std::forward<Visitor>(visitor), field1.template get<UInt128>(), std::forward<F2>(field2));
         case Field::Types::Int64:
             return applyBinaryVisitorImpl(
                 std::forward<Visitor>(visitor), field1.template get<Int64>(), std::forward<F2>(field2));
@@ -107,6 +112,7 @@ class FieldVisitorToString : public StaticVisitor<String>
 public:
     String operator() (const Null & x) const;
     String operator() (const UInt64 & x) const;
+    String operator() (const UInt128 & x) const;
     String operator() (const Int64 & x) const;
     String operator() (const Float64 & x) const;
     String operator() (const String & x) const;
@@ -121,6 +127,7 @@ class FieldVisitorDump : public StaticVisitor<String>
 public:
     String operator() (const Null & x) const;
     String operator() (const UInt64 & x) const;
+    String operator() (const UInt128 & x) const;
     String operator() (const Int64 & x) const;
     String operator() (const Float64 & x) const;
     String operator() (const String & x) const;
@@ -155,6 +162,7 @@ public:
     }
 
     T operator() (const UInt64 & x) const { return x; }
+    T operator() (const UInt128 & x) const { return x; }
     T operator() (const Int64 & x) const { return x; }
     T operator() (const Float64 & x) const { return x; }
 };
@@ -170,6 +178,7 @@ public:
 
     void operator() (const Null & x) const;
     void operator() (const UInt64 & x) const;
+    void operator() (const UInt128 & x) const;
     void operator() (const Int64 & x) const;
     void operator() (const Float64 & x) const;
     void operator() (const String & x) const;
@@ -186,38 +195,52 @@ class FieldVisitorAccurateEquals : public StaticVisitor<bool>
 public:
     bool operator() (const Null &, const Null &)        const { return true; }
     bool operator() (const Null &, const UInt64 &)      const { return false; }
+    bool operator() (const Null &, const UInt128 &)     const { return false; }
     bool operator() (const Null &, const Int64 &)       const { return false; }
     bool operator() (const Null &, const Float64 &)     const { return false; }
     bool operator() (const Null &, const String &)      const { return false; }
     bool operator() (const Null &, const Array &)       const { return false; }
     bool operator() (const Null &, const Tuple &)       const { return false; }
 
-    bool operator() (const UInt64 &, const Null &)      const { return false; }
+    bool operator() (const UInt64 &, const Null &)          const { return false; }
     bool operator() (const UInt64 & l, const UInt64 & r)    const { return l == r; }
+    bool operator() (const UInt64 &, const UInt128)         const { return false; }
     bool operator() (const UInt64 & l, const Int64 & r)     const { return accurate::equalsOp(l, r); }
     bool operator() (const UInt64 & l, const Float64 & r)   const { return accurate::equalsOp(l, r); }
-    bool operator() (const UInt64 &, const String &)    const { return false; }
-    bool operator() (const UInt64 &, const Array &)     const { return false; }
-    bool operator() (const UInt64 &, const Tuple &)     const { return false; }
+    bool operator() (const UInt64 &, const String &)        const { return false; }
+    bool operator() (const UInt64 &, const Array &)         const { return false; }
+    bool operator() (const UInt64 &, const Tuple &)         const { return false; }
 
-    bool operator() (const Int64 &, const Null &)       const { return false; }
+    bool operator() (const UInt128 &, const Null &)          const { return false; }
+    bool operator() (const UInt128 &, const UInt64)          const { return false; }
+    bool operator() (const UInt128 & l, const UInt128 & r)   const { return l == r; }
+    bool operator() (const UInt128 &, const Int64)           const { return false; }
+    bool operator() (const UInt128 &, const Float64)         const { return false; }
+    bool operator() (const UInt128 &, const String &)        const { return false; }
+    bool operator() (const UInt128 &, const Array &)         const { return false; }
+    bool operator() (const UInt128 &, const Tuple &)         const { return false; }
+
+    bool operator() (const Int64 &, const Null &)           const { return false; }
     bool operator() (const Int64 & l, const UInt64 & r)     const { return accurate::equalsOp(l, r); }
+    bool operator() (const Int64 &, const UInt128)          const { return false; }
     bool operator() (const Int64 & l, const Int64 & r)      const { return l == r; }
     bool operator() (const Int64 & l, const Float64 & r)    const { return accurate::equalsOp(l, r); }
-    bool operator() (const Int64 &, const String &)     const { return false; }
-    bool operator() (const Int64 &, const Array &)      const { return false; }
-    bool operator() (const Int64 &, const Tuple &)      const { return false; }
+    bool operator() (const Int64 &, const String &)         const { return false; }
+    bool operator() (const Int64 &, const Array &)          const { return false; }
+    bool operator() (const Int64 &, const Tuple &)          const { return false; }
 
-    bool operator() (const Float64 &, const Null &)     const { return false; }
+    bool operator() (const Float64 &, const Null &)         const { return false; }
     bool operator() (const Float64 & l, const UInt64 & r)   const { return accurate::equalsOp(l, r); }
+    bool operator() (const Float64 &, const UInt128)        const { return false; }
     bool operator() (const Float64 & l, const Int64 & r)    const { return accurate::equalsOp(l, r); }
     bool operator() (const Float64 & l, const Float64 & r)  const { return l == r; }
-    bool operator() (const Float64 &, const String &)   const { return false; }
-    bool operator() (const Float64 &, const Array &)    const { return false; }
-    bool operator() (const Float64 &, const Tuple &)    const { return false; }
+    bool operator() (const Float64 &, const String &)       const { return false; }
+    bool operator() (const Float64 &, const Array &)        const { return false; }
+    bool operator() (const Float64 &, const Tuple &)        const { return false; }
 
     bool operator() (const String &, const Null &)      const { return false; }
     bool operator() (const String &, const UInt64 &)    const { return false; }
+    bool operator() (const String &, const UInt128 &)   const { return false; }
     bool operator() (const String &, const Int64 &)     const { return false; }
     bool operator() (const String &, const Float64 &)   const { return false; }
     bool operator() (const String & l, const String & r)    const { return l == r; }
@@ -226,6 +249,7 @@ public:
 
     bool operator() (const Array &, const Null &)       const { return false; }
     bool operator() (const Array &, const UInt64 &)     const { return false; }
+    bool operator() (const Array &, const UInt128 &)    const { return false; }
     bool operator() (const Array &, const Int64 &)      const { return false; }
     bool operator() (const Array &, const Float64 &)    const { return false; }
     bool operator() (const Array &, const String &)     const { return false; }
@@ -234,6 +258,7 @@ public:
 
     bool operator() (const Tuple &, const Null &)       const { return false; }
     bool operator() (const Tuple &, const UInt64 &)     const { return false; }
+    bool operator() (const Tuple &, const UInt128 &)    const { return false; }
     bool operator() (const Tuple &, const Int64 &)      const { return false; }
     bool operator() (const Tuple &, const Float64 &)    const { return false; }
     bool operator() (const Tuple &, const String &)     const { return false; }
@@ -247,45 +272,60 @@ public:
     bool operator() (const Null &, const Null &)        const { return false; }
     bool operator() (const Null &, const UInt64 &)      const { return true; }
     bool operator() (const Null &, const Int64 &)       const { return true; }
+    bool operator() (const Null &, const UInt128 &)     const { return true; }
     bool operator() (const Null &, const Float64 &)     const { return true; }
     bool operator() (const Null &, const String &)      const { return true; }
     bool operator() (const Null &, const Array &)       const { return true; }
     bool operator() (const Null &, const Tuple &)       const { return true; }
 
-    bool operator() (const UInt64 &, const Null &)      const { return false; }
+    bool operator() (const UInt64 &, const Null &)        const { return false; }
     bool operator() (const UInt64 & l, const UInt64 & r)  const { return l < r; }
+    bool operator() (const UInt64 &, const UInt128 &)     const { return false; }
     bool operator() (const UInt64 & l, const Int64 & r)   const { return accurate::lessOp(l, r); }
     bool operator() (const UInt64 & l, const Float64 & r) const { return accurate::lessOp(l, r); }
-    bool operator() (const UInt64 &, const String &)    const { return true; }
-    bool operator() (const UInt64 &, const Array &)     const { return true; }
-    bool operator() (const UInt64 &, const Tuple &)     const { return true; }
+    bool operator() (const UInt64 &, const String &)      const { return true; }
+    bool operator() (const UInt64 &, const Array &)       const { return true; }
+    bool operator() (const UInt64 &, const Tuple &)       const { return true; }
 
-    bool operator() (const Int64 &, const Null &)       const { return false; }
+    bool operator() (const UInt128 &, const Null &)          const { return false; }
+    bool operator() (const UInt128 &, const UInt64)          const { return false; }
+    bool operator() (const UInt128 & l, const UInt128 & r)   const { return l < r; }
+    bool operator() (const UInt128 &, const Int64)           const { return false; }
+    bool operator() (const UInt128 &, const Float64)         const { return false; }
+    bool operator() (const UInt128 &, const String &)        const { return false; }
+    bool operator() (const UInt128 &, const Array &)         const { return false; }
+    bool operator() (const UInt128 &, const Tuple &)         const { return false; }
+
+    bool operator() (const Int64 &, const Null &)        const { return false; }
     bool operator() (const Int64 & l, const UInt64 & r)  const { return accurate::lessOp(l, r); }
+    bool operator() (const Int64 &, const UInt128 &)     const { return false; }
     bool operator() (const Int64 & l, const Int64 & r)   const { return l < r; }
     bool operator() (const Int64 & l, const Float64 & r) const { return accurate::lessOp(l, r); }
-    bool operator() (const Int64 &, const String &)     const { return true; }
-    bool operator() (const Int64 &, const Array &)      const { return true; }
-    bool operator() (const Int64 &, const Tuple &)      const { return true; }
+    bool operator() (const Int64 &, const String &)      const { return true; }
+    bool operator() (const Int64 &, const Array &)       const { return true; }
+    bool operator() (const Int64 &, const Tuple &)       const { return true; }
 
-    bool operator() (const Float64 &, const Null &)     const { return false; }
+    bool operator() (const Float64 &, const Null &)        const { return false; }
     bool operator() (const Float64 & l, const UInt64 & r)  const { return accurate::lessOp(l, r); }
+    bool operator() (const Float64, const UInt128 &)       const { return false; }
     bool operator() (const Float64 & l, const Int64 & r)   const { return accurate::lessOp(l, r); }
     bool operator() (const Float64 & l, const Float64 & r) const { return l < r; }
-    bool operator() (const Float64 &, const String &)   const { return true; }
-    bool operator() (const Float64 &, const Array &)    const { return true; }
-    bool operator() (const Float64 &, const Tuple &)    const { return true; }
+    bool operator() (const Float64 &, const String &)      const { return true; }
+    bool operator() (const Float64 &, const Array &)       const { return true; }
+    bool operator() (const Float64 &, const Tuple &)       const { return true; }
 
-    bool operator() (const String &, const Null &)      const { return false; }
-    bool operator() (const String &, const UInt64 &)    const { return false; }
-    bool operator() (const String &, const Int64 &)     const { return false; }
-    bool operator() (const String &, const Float64 &)   const { return false; }
+    bool operator() (const String &, const Null &)       const { return false; }
+    bool operator() (const String &, const UInt64 &)     const { return false; }
+    bool operator() (const String &, const UInt128 &)    const { return false; }
+    bool operator() (const String &, const Int64 &)      const { return false; }
+    bool operator() (const String &, const Float64 &)    const { return false; }
     bool operator() (const String & l, const String & r) const { return l < r; }
-    bool operator() (const String &, const Array &)     const { return true; }
-    bool operator() (const String &, const Tuple &)     const { return true; }
+    bool operator() (const String &, const Array &)      const { return true; }
+    bool operator() (const String &, const Tuple &)      const { return true; }
 
     bool operator() (const Array &, const Null &)       const { return false; }
     bool operator() (const Array &, const UInt64 &)     const { return false; }
+    bool operator() (const Array &, const UInt128 &)    const { return false; }
     bool operator() (const Array &, const Int64 &)      const { return false; }
     bool operator() (const Array &, const Float64 &)    const { return false; }
     bool operator() (const Array &, const String &)     const { return false; }
@@ -294,6 +334,7 @@ public:
 
     bool operator() (const Tuple &, const Null &)       const { return false; }
     bool operator() (const Tuple &, const UInt64 &)     const { return false; }
+    bool operator() (const Tuple &, const UInt128 &)    const { return false; }
     bool operator() (const Tuple &, const Int64 &)      const { return false; }
     bool operator() (const Tuple &, const Float64 &)    const { return false; }
     bool operator() (const Tuple &, const String &)     const { return false; }
@@ -318,6 +359,7 @@ public:
     bool operator() (Null &) const { throw Exception("Cannot sum Nulls", ErrorCodes::LOGICAL_ERROR); }
     bool operator() (String &) const { throw Exception("Cannot sum Strings", ErrorCodes::LOGICAL_ERROR); }
     bool operator() (Array &) const { throw Exception("Cannot sum Arrays", ErrorCodes::LOGICAL_ERROR); }
+    bool operator() (UInt128 &) const { throw Exception("Cannot sum UUIDs", ErrorCodes::LOGICAL_ERROR); }
 };
 
 }

--- a/dbms/src/DataTypes/FieldToDataType.cpp
+++ b/dbms/src/DataTypes/FieldToDataType.cpp
@@ -34,6 +34,11 @@ DataTypePtr FieldToDataType::operator() (const UInt64 & x) const
     return std::make_shared<DataTypeUInt64>();
 }
 
+DataTypePtr FieldToDataType::operator() (const Uint128 & x) const
+{
+    return std::make_shared<DataTypeUInt128>();
+}
+
 DataTypePtr FieldToDataType::operator() (const Int64 & x) const
 {
     if (x <= std::numeric_limits<Int8>::max() && x >= std::numeric_limits<Int8>::min())   return std::make_shared<DataTypeInt8>();

--- a/dbms/src/DataTypes/FieldToDataType.h
+++ b/dbms/src/DataTypes/FieldToDataType.h
@@ -19,6 +19,7 @@ class FieldToDataType : public StaticVisitor<DataTypePtr>
 public:
     DataTypePtr operator() (const Null & x) const;
     DataTypePtr operator() (const UInt64 & x) const;
+    DataTypePtr operator() (const UInt128 & x) const;
     DataTypePtr operator() (const Int64 & x) const;
     DataTypePtr operator() (const Float64 & x) const;
     DataTypePtr operator() (const String & x) const;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

TBH, I have just a little idea what I have done here but I tried to address those https://github.com/yandex/ClickHouse/issues/1770, https://github.com/yandex/ClickHouse/issues/2611

It is not possible to use UUID in WHERE condition. I tried to implement it but need help with that. Not sure if the way I have tried to do this is the right way and whether I should continue, until I resolve all errors or whether it needs another solution.