### PR TITLE
Do not add lib prefix to dictionary_library plugins

### DIFF
--- a/dbms/tests/external_dictionaries/dictionary_library/CMakeLists.txt
+++ b/dbms/tests/external_dictionaries/dictionary_library/CMakeLists.txt
@@ -6,8 +6,8 @@ target_include_directories (dictionary_library_c PRIVATE ${DBMS_INCLUDE_DIR})
 add_library (dictionary_library_empty SHARED "dictionary_library_empty.cpp")
 target_include_directories (dictionary_library_empty PRIVATE ${DBMS_INCLUDE_DIR})
 
-# Don't change lib name in debug build
+# Don't add "lib" prefix, and don't change lib name in debug build
 # because result .so will be pointed in dictionary_*.xml
-set_target_properties(dictionary_library PROPERTIES DEBUG_POSTFIX "")
-set_target_properties(dictionary_library_c PROPERTIES DEBUG_POSTFIX "")
-set_target_properties(dictionary_library_empty PROPERTIES DEBUG_POSTFIX "")
+set_target_properties(dictionary_library PROPERTIES PREFIX "" DEBUG_POSTFIX "")
+set_target_properties(dictionary_library_c PROPERTIES PREFIX "" DEBUG_POSTFIX "")
+set_target_properties(dictionary_library_empty PROPERTIES PREFIX "" DEBUG_POSTFIX "")

--- a/dbms/tests/external_dictionaries/generate_and_test.py
+++ b/dbms/tests/external_dictionaries/generate_and_test.py
@@ -396,14 +396,14 @@ def generate_dictionaries(args):
     <library>
         <path>{filename}</path>
     </library>
-    '''.format(filename=os.path.abspath('../../../build/dbms/tests/external_dictionaries/dictionary_library/libdictionary_library.so'))
+    '''.format(filename=os.path.abspath('../../../build/dbms/tests/external_dictionaries/dictionary_library/dictionary_library.so'))
 
     # Todo?
     #source_library_c = '''
     #<library>
     #    <path>{filename}</path>
     #</library>
-    #'''.format(filename=os.path.abspath('../../../build/dbms/tests/external_dictionaries/dict_lib/libdict_library_c.so'))
+    #'''.format(filename=os.path.abspath('../../../build/dbms/tests/external_dictionaries/dictionary_library/dictionary_library_c.so'))
 
 
     layout_flat = '<flat />'


### PR DESCRIPTION
By convention plugins (libraries that are only meant for dlopen) do not have lib prefix.

I did not find a strong authority that supports this claim, but this is obviously expected on Linux, see e.g. https://stackoverflow.com/a/6561296/1687334 or search for "linux plugins lib prefix".

This change is needed to automatically represent dictionary_library plugins as plugins rather than possibly static libraries within `ya.make` build system.