### PR TITLE
maxIntersections: add sorting by weight

### DIFF
--- a/dbms/src/AggregateFunctions/AggregateFunctionMaxIntersections.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionMaxIntersections.h
@@ -137,7 +137,10 @@ public:
         /// const_cast because we will sort the array
         auto & array = const_cast<typename MaxIntersectionsData<PointType>::Array &>(this->data(place).value);
 
-        std::sort(array.begin(), array.end(), [](const auto & a, const auto & b) { return a.first < b.first; });
+        std::sort(array.begin(), array.end(), [](const auto & a, const auto & b) {
+            return (a.first < b.first) ||                           //sort by position ascending
+                   ((a.first == b.first) && (a.second < b.second)); //sort by weight ascending
+        });
 
         for (const auto & point_weight : array)
         {

--- a/dbms/src/AggregateFunctions/AggregateFunctionMaxIntersections.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionMaxIntersections.h
@@ -137,10 +137,8 @@ public:
         /// const_cast because we will sort the array
         auto & array = const_cast<typename MaxIntersectionsData<PointType>::Array &>(this->data(place).value);
 
-        std::sort(array.begin(), array.end(), [](const auto & a, const auto & b) {
-            return (a.first < b.first) ||                           //sort by position ascending
-                   ((a.first == b.first) && (a.second < b.second)); //sort by weight ascending
-        });
+        /// Sort by position; for equal position, sort by weight to get deterministic result.
+        std::sort(array.begin(), array.end());
 
         for (const auto & point_weight : array)
         {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

add sorting by weight to fix dependence on the order of intervals when end of the one interval matches with start of the another interval

wrong behavior example:

```
CREATE TABLE test1(start Integer, end Integer) engine = Memory;
CREATE TABLE test2(start Integer, end Integer) engine = Memory;
INSERT INTO test1(start,end) VALUES (1,3),(3,5);
INSERT INTO test2(start,end) VALUES (3,5),(1,3);
```

```
void :) SELECT maxIntersections(start,end) from test1;

SELECT maxIntersections(start, end)
FROM test 

┌─maxIntersections(start, end)─┐
│                            1 │
└──────────────────────────────┘

1 rows in set. Elapsed: 0.002 sec. 

void :) SELECT maxIntersections(start,end) from test2;

SELECT maxIntersections(start, end)
FROM test2 

┌─maxIntersections(start, end)─┐
│                            2 │
└──────────────────────────────┘

1 rows in set. Elapsed: 0.003 sec.
```

expected to receive the same value 1 for both cases

patch fixes function by placing points with weight -1 before points with weight 1 and the same position