### PR TITLE
Freebsd: unbundled: do not use libcpuid from ports

### DIFF
--- a/cmake/find_cpuid.cmake
+++ b/cmake/find_cpuid.cmake
@@ -1,5 +1,13 @@
+# Freebsd: /usr/local/include/libcpuid/libcpuid_types.h:61:29: error: conflicting declaration 'typedef long long int int64_t'
+# TODO: test new libcpuid - maybe already fixed
+
 if (NOT ARCH_ARM)
-    option (USE_INTERNAL_CPUID_LIBRARY "Set to FALSE to use system cpuid library instead of bundled" ${NOT_UNBUNDLED})
+    if (ARCH_FREEBSD)
+        set (DEFAULT_USE_INTERNAL_CPUID_LIBRARY 1)
+    else ()
+        set (DEFAULT_USE_INTERNAL_CPUID_LIBRARY ${NOT_UNBUNDLED})
+    endif ()
+    option (USE_INTERNAL_CPUID_LIBRARY "Set to FALSE to use system cpuid library instead of bundled" ${DEFAULT_USE_INTERNAL_CPUID_LIBRARY})
 endif ()
 
 #if (USE_INTERNAL_CPUID_LIBRARY AND NOT EXISTS "${ClickHouse_SOURCE_DIR}/contrib/libcpuid/include/cpuid/libcpuid.h")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
