### PR TITLE
Fast path for stringifying float point numbers

### DIFF
--- a/dbms/src/IO/BufferBase.h
+++ b/dbms/src/IO/BufferBase.h
@@ -77,6 +77,9 @@ public:
     /// offset in bytes of the cursor from the beginning of the buffer
     inline size_t offset() const { return size_t(pos - working_buffer.begin()); }
 
+    /// How many bytes are availeble for read/write
+    inline size_t available() const { return size_t(working_buffer.end() - pos); }
+
     /** How many bytes have been read/written, counting those that are still in the buffer. */
     size_t count() const
     {

--- a/dbms/src/IO/BufferBase.h
+++ b/dbms/src/IO/BufferBase.h
@@ -77,7 +77,7 @@ public:
     /// offset in bytes of the cursor from the beginning of the buffer
     inline size_t offset() const { return size_t(pos - working_buffer.begin()); }
 
-    /// How many bytes are availeble for read/write
+    /// How many bytes are available for read/write
     inline size_t available() const { return size_t(working_buffer.end() - pos); }
 
     /** How many bytes have been read/written, counting those that are still in the buffer. */


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Performance test `float_parsing` is used.

Without this patch
```
[
{
    "hostname": "dell123",
    "main_metric": "avg_rows_per_second",
    "num_cores": 20,
    "num_threads": 40,
    "parameters": {
        "expr": ["toString(1 / rand())", "toString(rand() / 0xFFFFFFFF)", "toString(0xFFFFFFFF / rand())", "toString(number)", "toString(number % 10)", "toString(rand())", "toString(rand64())", "concat(toString(rand(1)), '.', toString(rand(2)))", "concat(toString(rand(1)), 'e', toString(rand(2) % 100))", "concat(toString(rand64(1)), toString(rand64(2)), toString(rand64(3)))"]
    },
    "ram": 134774140928,
    "runs": [
        {
            "avg_rows_per_second": 5492364.093416,
            "parameters": {
                "expr": "toString(1 / rand())"
            },
            "query": "SELECT count() FROM system.numbers WHERE NOT ignore(toFloat64(toString(1 / rand())))"
        },
        {
            "avg_rows_per_second": 5613593.130320,
            "parameters": {
                "expr": "toString(rand() / 0xFFFFFFFF)"
            },
            "query": "SELECT count() FROM system.numbers WHERE NOT ignore(toFloat64(toString(rand() / 0xFFFFFFFF)))"
        },
        {
            "avg_rows_per_second": 5378318.817115,
            "parameters": {
                "expr": "toString(0xFFFFFFFF / rand())"
            },
            "query": "SELECT count() FROM system.numbers WHERE NOT ignore(toFloat64(toString(0xFFFFFFFF / rand())))"
        },
        {
            "avg_rows_per_second": 31540174.865385,
            "parameters": {
                "expr": "toString(number)"
            },
            "query": "SELECT count() FROM system.numbers WHERE NOT ignore(toFloat64(toString(number)))"
        },
        {
            "avg_rows_per_second": 58654804.116776,
            "parameters": {
                "expr": "toString(number % 10)"
            },
            "query": "SELECT count() FROM system.numbers WHERE NOT ignore(toFloat64(toString(number % 10)))"
        },
        {
            "avg_rows_per_second": 24805574.955150,
            "parameters": {
                "expr": "toString(rand())"
            },
            "query": "SELECT count() FROM system.numbers WHERE NOT ignore(toFloat64(toString(rand())))"
        },
        {
            "avg_rows_per_second": 14271656.427017,
            "parameters": {
                "expr": "toString(rand64())"
            },
            "query": "SELECT count() FROM system.numbers WHERE NOT ignore(toFloat64(toString(rand64())))"
        },
        {
            "avg_rows_per_second": 9723083.398888,
            "parameters": {
                "expr": "concat(toString(rand(1)), '.', toString(rand(2)))"
            },
            "query": "SELECT count() FROM system.numbers WHERE NOT ignore(toFloat64(concat(toString(rand(1)), '.', toString(rand(2)))))"
        },
        {
            "avg_rows_per_second": 12161248.746597,
            "parameters": {
                "expr": "concat(toString(rand(1)), 'e', toString(rand(2) % 100))"
            },
            "query": "SELECT count() FROM system.numbers WHERE NOT ignore(toFloat64(concat(toString(rand(1)), 'e', toString(rand(2) % 100))))"
        },
        {
            "avg_rows_per_second": 4682649.135879,
            "parameters": {
                "expr": "concat(toString(rand64(1)), toString(rand64(2)), toString(rand64(3)))"
            },
            "query": "SELECT count() FROM system.numbers WHERE NOT ignore(toFloat64(concat(toString(rand64(1)), toString(rand64(2)), toString(rand64(3)))))"
        }
    ],
    "server_version": "1.1.54394",
    "test_name": "float_parsing",
    "time": "2018-07-17 19:50:48"
}
]
```

With this patch:

```
[
{
    "hostname": "dell123",
    "main_metric": "avg_rows_per_second",
    "num_cores": 20,
    "num_threads": 40,
    "parameters": {
        "expr": ["toString(1 / rand())", "toString(rand() / 0xFFFFFFFF)", "toString(0xFFFFFFFF / rand())", "toString(number)", "toString(number % 10)", "toString(rand())", "toString(rand64())", "concat(toString(rand(1)), '.', toString(rand(2)))", "concat(toString(rand(1)), 'e', toString(rand(2) % 100))", "concat(toString(rand64(1)), toString(rand64(2)), toString(rand64(3)))"]
    },
    "ram": 134774140928,
    "runs": [
        {
            "avg_rows_per_second": 5787884.707826,
            "parameters": {
                "expr": "toString(1 / rand())"
            },
            "query": "SELECT count() FROM system.numbers WHERE NOT ignore(toFloat64(toString(1 / rand())))"
        },
        {
            "avg_rows_per_second": 6120520.732772,
            "parameters": {
                "expr": "toString(rand() / 0xFFFFFFFF)"
            },
            "query": "SELECT count() FROM system.numbers WHERE NOT ignore(toFloat64(toString(rand() / 0xFFFFFFFF)))"
        },
        {
            "avg_rows_per_second": 5718844.456722,
            "parameters": {
                "expr": "toString(0xFFFFFFFF / rand())"
            },
            "query": "SELECT count() FROM system.numbers WHERE NOT ignore(toFloat64(toString(0xFFFFFFFF / rand())))"
        },
        {
            "avg_rows_per_second": 32744994.161772,
            "parameters": {
                "expr": "toString(number)"
            },
            "query": "SELECT count() FROM system.numbers WHERE NOT ignore(toFloat64(toString(number)))"
        },
        {
            "avg_rows_per_second": 56835546.048325,
            "parameters": {
                "expr": "toString(number % 10)"
            },
            "query": "SELECT count() FROM system.numbers WHERE NOT ignore(toFloat64(toString(number % 10)))"
        },
        {
            "avg_rows_per_second": 26416653.881761,
            "parameters": {
                "expr": "toString(rand())"
            },
            "query": "SELECT count() FROM system.numbers WHERE NOT ignore(toFloat64(toString(rand())))"
        },
        {
            "avg_rows_per_second": 14899093.542744,
            "parameters": {
                "expr": "toString(rand64())"
            },
            "query": "SELECT count() FROM system.numbers WHERE NOT ignore(toFloat64(toString(rand64())))"
        },
        {
            "avg_rows_per_second": 9866366.888363,
            "parameters": {
                "expr": "concat(toString(rand(1)), '.', toString(rand(2)))"
            },
            "query": "SELECT count() FROM system.numbers WHERE NOT ignore(toFloat64(concat(toString(rand(1)), '.', toString(rand(2)))))"
        },
        {
            "avg_rows_per_second": 12581788.724010,
            "parameters": {
                "expr": "concat(toString(rand(1)), 'e', toString(rand(2) % 100))"
            },
            "query": "SELECT count() FROM system.numbers WHERE NOT ignore(toFloat64(concat(toString(rand(1)), 'e', toString(rand(2) % 100))))"
        },
        {
            "avg_rows_per_second": 5093015.983612,
            "parameters": {
                "expr": "concat(toString(rand64(1)), toString(rand64(2)), toString(rand64(3)))"
            },
            "query": "SELECT count() FROM system.numbers WHERE NOT ignore(toFloat64(concat(toString(rand64(1)), toString(rand64(2)), toString(rand64(3)))))"
        }
    ],
    "server_version": "1.1.54394",
    "test_name": "float_parsing",
    "time": "2018-07-17 20:17:14"
}
]
```

The only degradation SQL is `SELECT count() FROM system.numbers WHERE NOT ignore(toFloat64(toString(number % 10)))`