### PR TITLE
Function try in destructor rethrows exceptions (Cap'n'Proto related code)

### DIFF
--- a/dbms/src/Formats/CapnProtoRowInputStream.h
+++ b/dbms/src/Formats/CapnProtoRowInputStream.h
@@ -43,10 +43,10 @@ private:
     /* Action for state machine for traversing nested structures. */
     struct Action
     {
-      enum Type { POP, PUSH, READ };
-      Type type;
-      capnp::StructSchema::Field field = {};
-      size_t column = 0;
+        enum Type { POP, PUSH, READ };
+        Type type;
+        capnp::StructSchema::Field field = {};
+        size_t column = 0;
     };
 
     // Wrapper for classes that could throw in destructor
@@ -54,10 +54,10 @@ private:
     template <typename T>
     struct DestructorCatcher
     {
-      T impl;
-      template <typename ... Arg>
-      DestructorCatcher(Arg && ... args) : impl(kj::fwd<Arg>(args)...) {}
-      ~DestructorCatcher() noexcept try { } catch (...) { }
+        T impl;
+        template <typename ... Arg>
+        DestructorCatcher(Arg && ... args) : impl(kj::fwd<Arg>(args)...) {}
+        ~DestructorCatcher() noexcept try { } catch (...) { return; }
     };
     using SchemaParser = DestructorCatcher<capnp::SchemaParser>;
 


### PR DESCRIPTION
According to https://en.cppreference.com/w/cpp/language/function-try-block , function try block used in destructor will rethrow exceptions if there isn't a return statement specified.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
