### PR TITLE
Don't rewrite parts not touched by mutations

### DIFF
--- a/dbms/src/DataStreams/PushingToViewsBlockOutputStream.cpp
+++ b/dbms/src/DataStreams/PushingToViewsBlockOutputStream.cpp
@@ -71,7 +71,7 @@ void PushingToViewsBlockOutputStream::write(const Block & block)
         try
         {
             BlockInputStreamPtr from = std::make_shared<OneBlockInputStream>(block);
-            InterpreterSelectQuery select(view.query, *views_context, {}, QueryProcessingStage::Complete, 0, from);
+            InterpreterSelectQuery select(view.query, *views_context, from);
             BlockInputStreamPtr in = std::make_shared<MaterializingBlockInputStream>(select.execute().in);
             /// Squashing is needed here because the materialized view query can generate a lot of blocks
             /// even when only one block is inserted into the parent table (e.g. if the query is a GROUP BY

--- a/dbms/src/Interpreters/ClusterProxy/SelectStreamFactory.cpp
+++ b/dbms/src/Interpreters/ClusterProxy/SelectStreamFactory.cpp
@@ -44,7 +44,7 @@ namespace
 
 BlockInputStreamPtr createLocalStream(const ASTPtr & query_ast, const Context & context, QueryProcessingStage::Enum processed_stage)
 {
-    InterpreterSelectQuery interpreter{query_ast, context, {}, processed_stage};
+    InterpreterSelectQuery interpreter{query_ast, context, Names{}, processed_stage};
     BlockInputStreamPtr stream = interpreter.execute().in;
 
     /** Materialization is needed, since from remote servers the constants come materialized.

--- a/dbms/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterSelectQuery.cpp
@@ -63,23 +63,23 @@ namespace ErrorCodes
 InterpreterSelectQuery::InterpreterSelectQuery(
     const ASTPtr & query_ptr_,
     const Context & context_,
-    const Names & required_result_column_names_,
+    const Names & required_result_column_names,
     QueryProcessingStage::Enum to_stage_,
     size_t subquery_depth_,
-    const BlockInputStreamPtr & input,
-    bool only_analyze)
-    : query_ptr(query_ptr_->clone())    /// Note: the query is cloned because it will be modified during analysis.
-    , query(typeid_cast<ASTSelectQuery &>(*query_ptr))
-    , context(context_)
-    , to_stage(to_stage_)
-    , subquery_depth(subquery_depth_)
-    , only_analyze(only_analyze)
-    , input(input)
-    , log(&Logger::get("InterpreterSelectQuery"))
+    bool only_analyze_)
+    : InterpreterSelectQuery(query_ptr_, context_, nullptr, nullptr, required_result_column_names, to_stage_, subquery_depth_, only_analyze_)
 {
-    init(required_result_column_names_);
 }
 
+InterpreterSelectQuery::InterpreterSelectQuery(
+    const ASTPtr & query_ptr_,
+    const Context & context_,
+    const BlockInputStreamPtr & input_,
+    QueryProcessingStage::Enum to_stage_,
+    bool only_analyze_)
+    : InterpreterSelectQuery(query_ptr_, context_, input_, nullptr, Names{}, to_stage_, 0, only_analyze_)
+{
+}
 
 InterpreterSelectQuery::~InterpreterSelectQuery() = default;
 
@@ -99,8 +99,24 @@ static Context getSubqueryContext(const Context & context)
     return subquery_context;
 }
 
-
-void InterpreterSelectQuery::init(const Names & required_result_column_names)
+InterpreterSelectQuery::InterpreterSelectQuery(
+    const ASTPtr & query_ptr_,
+    const Context & context_,
+    const BlockInputStreamPtr & input_,
+    const StoragePtr & storage_,
+    const Names & required_result_column_names,
+    QueryProcessingStage::Enum to_stage_,
+    size_t subquery_depth_,
+    bool only_analyze_)
+    : query_ptr(query_ptr_->clone())    /// Note: the query is cloned because it will be modified during analysis.
+    , query(typeid_cast<ASTSelectQuery &>(*query_ptr))
+    , context(context_)
+    , to_stage(to_stage_)
+    , subquery_depth(subquery_depth_)
+    , only_analyze(only_analyze_)
+    , storage(storage_)
+    , input(input_)
+    , log(&Logger::get("InterpreterSelectQuery"))
 {
     if (!context.hasQueryContext())
         context.setQueryContext(context);

--- a/dbms/src/Interpreters/InterpreterSelectQuery.h
+++ b/dbms/src/Interpreters/InterpreterSelectQuery.h
@@ -60,6 +60,14 @@ public:
         QueryProcessingStage::Enum to_stage_ = QueryProcessingStage::Complete,
         bool only_analyze_ = false);
 
+    /// Read data not from the table specified in the query, but from the specified `storage_`.
+    InterpreterSelectQuery(
+        const ASTPtr & query_ptr_,
+        const Context & context_,
+        const StoragePtr & storage_,
+        QueryProcessingStage::Enum to_stage_ = QueryProcessingStage::Complete,
+        bool only_analyze_ = false);
+
     ~InterpreterSelectQuery() override;
 
     /// Execute a query. Get the stream of blocks to read.

--- a/dbms/src/Interpreters/InterpreterSelectQuery.h
+++ b/dbms/src/Interpreters/InterpreterSelectQuery.h
@@ -38,9 +38,6 @@ public:
      * - to control the limit on the depth of nesting of subqueries. For subqueries, a value that is incremented by one is passed;
      *   for INSERT SELECT, a value 1 is passed instead of 0.
      *
-     * input
-     * - if given - read not from the table specified in the query, but from prepared source.
-     *
      * required_result_column_names
      * - don't calculate all columns except the specified ones from the query
      *  - it is used to remove calculation (and reading) of unnecessary columns from subqueries.
@@ -53,8 +50,15 @@ public:
         const Names & required_result_column_names = Names{},
         QueryProcessingStage::Enum to_stage_ = QueryProcessingStage::Complete,
         size_t subquery_depth_ = 0,
-        const BlockInputStreamPtr & input = nullptr,
-        bool only_analyze = false);
+        bool only_analyze_ = false);
+
+    /// Read data not from the table specified in the query, but from the prepared source `input`.
+    InterpreterSelectQuery(
+        const ASTPtr & query_ptr_,
+        const Context & context_,
+        const BlockInputStreamPtr & input_,
+        QueryProcessingStage::Enum to_stage_ = QueryProcessingStage::Complete,
+        bool only_analyze_ = false);
 
     ~InterpreterSelectQuery() override;
 
@@ -69,6 +73,17 @@ public:
     void ignoreWithTotals();
 
 private:
+    InterpreterSelectQuery(
+        const ASTPtr & query_ptr_,
+        const Context & context_,
+        const BlockInputStreamPtr & input_,
+        const StoragePtr & storage_,
+        const Names & required_result_column_names,
+        QueryProcessingStage::Enum to_stage_,
+        size_t subquery_depth_,
+        bool only_analyze_);
+
+
     struct Pipeline
     {
         /** Streams of data.
@@ -101,8 +116,6 @@ private:
             return streams.size() + (stream_with_non_joined_data ? 1 : 0) > 1;
         }
     };
-
-    void init(const Names & required_result_column_names);
 
     void executeImpl(Pipeline & pipeline, const BlockInputStreamPtr & input, bool dry_run);
 
@@ -179,7 +192,7 @@ private:
     ASTSelectQuery & query;
     Context context;
     QueryProcessingStage::Enum to_stage;
-    size_t subquery_depth;
+    size_t subquery_depth = 0;
     std::unique_ptr<ExpressionAnalyzer> query_analyzer;
 
     /// How many streams we ask for storage to produce, and in how many threads we will do further processing.

--- a/dbms/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
@@ -57,7 +57,7 @@ InterpreterSelectWithUnionQuery::InterpreterSelectWithUnionQuery(
         /// We use it to determine positions of 'required_result_column_names' in SELECT clause.
 
         Block full_result_header = InterpreterSelectQuery(
-            ast.list_of_selects->children.at(0), context, Names(), to_stage, subquery_depth, nullptr, true).getSampleBlock();
+            ast.list_of_selects->children.at(0), context, Names(), to_stage, subquery_depth, true).getSampleBlock();
 
         std::vector<size_t> positions_of_required_result_columns(required_result_column_names.size());
         for (size_t required_result_num = 0, size = required_result_column_names.size(); required_result_num < size; ++required_result_num)
@@ -66,7 +66,7 @@ InterpreterSelectWithUnionQuery::InterpreterSelectWithUnionQuery(
         for (size_t query_num = 1; query_num < num_selects; ++query_num)
         {
             Block full_result_header_for_current_select = InterpreterSelectQuery(
-                ast.list_of_selects->children.at(query_num), context, Names(), to_stage, subquery_depth, nullptr, true).getSampleBlock();
+                ast.list_of_selects->children.at(query_num), context, Names(), to_stage, subquery_depth, true).getSampleBlock();
 
             if (full_result_header_for_current_select.columns() != full_result_header.columns())
                 throw Exception("Different number of columns in UNION ALL elements", ErrorCodes::UNION_ALL_RESULT_STRUCTURES_MISMATCH);
@@ -84,7 +84,7 @@ InterpreterSelectWithUnionQuery::InterpreterSelectWithUnionQuery(
             : required_result_column_names_for_other_selects[query_num];
 
         nested_interpreters.emplace_back(std::make_unique<InterpreterSelectQuery>(
-            ast.list_of_selects->children.at(query_num), context, current_required_result_column_names, to_stage, subquery_depth, nullptr, only_analyze));
+            ast.list_of_selects->children.at(query_num), context, current_required_result_column_names, to_stage, subquery_depth, only_analyze));
     }
 
     /// Determine structure of result.

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -2356,9 +2356,9 @@ MergeTreeData::MutableDataPartPtr MergeTreeData::cloneAndLoadDataPart(const Merg
 {
     String dst_part_name;
     if (format_version < MERGE_TREE_DATA_MIN_FORMAT_VERSION_WITH_CUSTOM_PARTITIONING)
-            dst_part_name = dst_part_info.getPartNameV0(src_part->getMinDate(), src_part->getMaxDate());
-        else
-            dst_part_name = dst_part_info.getPartName();
+        dst_part_name = dst_part_info.getPartNameV0(src_part->getMinDate(), src_part->getMaxDate());
+    else
+        dst_part_name = dst_part_info.getPartName();
 
     String tmp_dst_part_name = tmp_part_prefix + dst_part_name;
 

--- a/dbms/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
@@ -92,6 +92,7 @@ public:
         MergeListEntry & merge_entry,
         size_t aio_threshold, time_t time_of_merge, DiskSpaceMonitor::Reservation * disk_reservation, bool deduplication);
 
+    /// Mutate a single data part with the specified commands. Will create and return a temporary part.
     MergeTreeData::MutableDataPartPtr mutatePartToTemporaryPart(
         const FuturePart & future_part,
         const std::vector<MutationCommand> & commands,

--- a/dbms/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -140,9 +140,22 @@ BlockInputStreams MergeTreeDataSelectExecutor::read(
     const unsigned num_streams,
     Int64 max_block_number_to_read) const
 {
-    size_t part_index = 0;
+    return readFromParts(
+        data.getDataPartsVector(), column_names_to_return, query_info, context, processed_stage,
+        max_block_size, num_streams, max_block_number_to_read);
+}
 
-    MergeTreeData::DataPartsVector parts = data.getDataPartsVector();
+BlockInputStreams MergeTreeDataSelectExecutor::readFromParts(
+    MergeTreeData::DataPartsVector parts,
+    const Names & column_names_to_return,
+    const SelectQueryInfo & query_info,
+    const Context & context,
+    QueryProcessingStage::Enum & processed_stage,
+    const size_t max_block_size,
+    const unsigned num_streams,
+    Int64 max_block_number_to_read) const
+{
+    size_t part_index = 0;
 
     /// If query contains restrictions on the virtual column `_part` or `_part_index`, select only parts suitable for it.
     /// The virtual column `_sample_factor` (which is equal to 1 / used sample rate) can be requested in the query.

--- a/dbms/src/Storages/MergeTree/MergeTreeDataSelectExecutor.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataSelectExecutor.h
@@ -31,6 +31,16 @@ public:
         unsigned num_streams,
         Int64 max_block_number_to_read) const;
 
+    BlockInputStreams readFromParts(
+        MergeTreeData::DataPartsVector parts,
+        const Names & column_names,
+        const SelectQueryInfo & query_info,
+        const Context & context,
+        QueryProcessingStage::Enum & processed_stage,
+        size_t max_block_size,
+        unsigned num_streams,
+        Int64 max_block_number_to_read) const;
+
 private:
     MergeTreeData & data;
 

--- a/dbms/src/Storages/MergeTree/StorageFromMergeTreeDataPart.h
+++ b/dbms/src/Storages/MergeTree/StorageFromMergeTreeDataPart.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <Storages/IStorage.h>
+#include <Storages/MergeTree/MergeTreeDataPart.h>
+#include <Storages/MergeTree/MergeTreeDataSelectExecutor.h>
+#include <Core/Defines.h>
+
+#include <ext/shared_ptr_helper.h>
+
+
+namespace DB
+{
+
+/// A Storage that allows reading from a single MergeTree data part.
+class StorageFromMergeTreeDataPart : public ext::shared_ptr_helper<StorageFromMergeTreeDataPart>, public IStorage
+{
+public:
+    String getName() const override { return "FromMergeTreeDataPart"; }
+    String getTableName() const override { return part->storage.getTableName() + " (part " + part->name + ")"; }
+
+    BlockInputStreams read(
+        const Names & column_names,
+        const SelectQueryInfo & query_info,
+        const Context & context,
+        QueryProcessingStage::Enum & processed_stage,
+        size_t max_block_size,
+        unsigned num_streams) override
+    {
+        return MergeTreeDataSelectExecutor(part->storage).readFromParts(
+            {part}, column_names, query_info, context, processed_stage, max_block_size, num_streams, 0);
+    }
+
+protected:
+    StorageFromMergeTreeDataPart(const MergeTreeData::DataPartPtr & part_)
+        : IStorage(part_->storage.getColumns()), part(part_)
+    {}
+
+private:
+    MergeTreeData::DataPartPtr part;
+};
+
+}

--- a/dbms/src/Storages/StorageBuffer.cpp
+++ b/dbms/src/Storages/StorageBuffer.cpp
@@ -135,7 +135,7 @@ BlockInputStreams StorageBuffer::read(
       */
     if (processed_stage > QueryProcessingStage::FetchColumns)
         for (auto & stream : streams_from_buffers)
-            stream = InterpreterSelectQuery(query_info.query, context, {}, processed_stage, 0, stream).execute().in;
+            stream = InterpreterSelectQuery(query_info.query, context, stream, processed_stage).execute().in;
 
     streams_from_dst.insert(streams_from_dst.end(), streams_from_buffers.begin(), streams_from_buffers.end());
     return streams_from_dst;

--- a/dbms/src/Storages/StorageDistributed.cpp
+++ b/dbms/src/Storages/StorageDistributed.cpp
@@ -213,7 +213,7 @@ BlockInputStreams StorageDistributed::read(
     const auto & modified_query_ast = rewriteSelectQuery(
         query_info.query, remote_database, remote_table);
 
-    Block header = materializeBlock(InterpreterSelectQuery(query_info.query, context, {}, processed_stage).getSampleBlock());
+    Block header = materializeBlock(InterpreterSelectQuery(query_info.query, context, Names{}, processed_stage).getSampleBlock());
 
     ClusterProxy::SelectStreamFactory select_stream_factory(
         header, processed_stage, QualifiedTableName{remote_database, remote_table}, context.getExternalTables());

--- a/dbms/src/Storages/StorageMerge.cpp
+++ b/dbms/src/Storages/StorageMerge.cpp
@@ -241,12 +241,10 @@ BlockInputStreams StorageMerge::read(
                         header = getSampleBlockForColumns(column_names);
                         break;
                     case QueryProcessingStage::WithMergeableState:
-                        header = materializeBlock(InterpreterSelectQuery(query_info.query, context, {}, QueryProcessingStage::WithMergeableState, 0,
-                            std::make_shared<OneBlockInputStream>(getSampleBlockForColumns(column_names)), true).getSampleBlock());
-                        break;
                     case QueryProcessingStage::Complete:
-                        header = materializeBlock(InterpreterSelectQuery(query_info.query, context, {}, QueryProcessingStage::Complete, 0,
-                            std::make_shared<OneBlockInputStream>(getSampleBlockForColumns(column_names)), true).getSampleBlock());
+                        header = materializeBlock(InterpreterSelectQuery(
+                            query_info.query, context, std::make_shared<OneBlockInputStream>(getSampleBlockForColumns(column_names)),
+                            processed_stage_in_source_table, true).getSampleBlock());
                         break;
                 }
             }


### PR DESCRIPTION
Apparently the easiest way to use MergeTree indexes when mutating parts is to use the full InterpreterSelectQuery machinery. For that to work a fake storage was implemented that reads only from a single MergeTree part (`StorageFromMergeTreeDataPart`).

The parts that are not touched are copied using `localBackup()` and not simply renamed to avoid difficulties when status of the part commit operation in ZooKeeper is unknown.