### PR TITLE
Better commands to install ClickHouse

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -390,7 +390,7 @@
 <pre>
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv E0C56BD4    # optional
 
-sudo apt-add-repository "deb http://repo.yandex.ru/clickhouse/deb/stable/ main/"
+sudo echo "deb http://repo.yandex.ru/clickhouse/deb/stable/ main/" > /etc/apt/sources.list.d/clickhouse.list
 sudo apt-get update
 
 sudo apt-get install -y clickhouse-server clickhouse-client


### PR DESCRIPTION
There is no `apt-add-repository` in Docker Ubuntu images by default.
