### PR TITLE
Fix integration test.

### DIFF
--- a/dbms/tests/integration/helpers/cluster.py
+++ b/dbms/tests/integration/helpers/cluster.py
@@ -206,6 +206,7 @@ services:
             -  server
             -  --config-file=/etc/clickhouse-server/config.xml
             -  --log-file=/var/log/clickhouse-server/clickhouse-server.log
+            -  --errorlog-file=/var/log/clickhouse-server/clickhouse-server.err.log
         depends_on: {depends_on}
 '''
 


### PR DESCRIPTION
without specifying errorlog, I got

```
E               Logging trace to /var/log/clickhouse-server/clickhouse-server.log
E               Logging errors to clickhouse-server.err.log
E               Poco::Exception. Code: 1000, e.code() = 13, e.displayText() = Access to file denied: /clickhouse-server.err.log, e.what() = Access to file denied
```

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
