### PR TITLE
return nan when quantileExact with empty float column

### DIFF
--- a/dbms/src/AggregateFunctions/QuantileExact.h
+++ b/dbms/src/AggregateFunctions/QuantileExact.h
@@ -77,7 +77,7 @@ struct QuantileExact
             return array[n];
         }
 
-        return Value();
+        return std::numeric_limits<Value>::quiet_NaN();
     }
 
     /// Get the `size` values of `levels` quantiles. Write `size` results starting with `result` address.

--- a/dbms/src/AggregateFunctions/QuantileExactWeighted.h
+++ b/dbms/src/AggregateFunctions/QuantileExactWeighted.h
@@ -72,7 +72,7 @@ struct QuantileExactWeighted
         size_t size = map.size();
 
         if (0 == size)
-            return Value();
+            return std::numeric_limits<Value>::quiet_NaN();
 
         /// Copy the data to a temporary array to get the element you need in order.
         using Pair = typename Map::value_type;

--- a/dbms/tests/queries/0_stateless/00181_aggregate_functions_statistics.reference
+++ b/dbms/tests/queries/0_stateless/00181_aggregate_functions_statistics.reference
@@ -19,3 +19,11 @@ nan
 nan
 nan
 0
+----quantile----
+45
+0
+nan
+nan
+nan
+nan
+nan

--- a/dbms/tests/queries/0_stateless/00181_aggregate_functions_statistics.sql
+++ b/dbms/tests/queries/0_stateless/00181_aggregate_functions_statistics.sql
@@ -139,4 +139,17 @@ SELECT corr(x_value, y_value) FROM (SELECT x_value, y_value FROM test.series LIM
 
 SELECT round(abs(corr(x_value, y_value) - covarPop(x_value, y_value) / (stddevPop(x_value) * stddevPop(y_value))), 6) FROM test.series;
 
+/* quantile AND quantileExact */
+SELECT '----quantile----';
+
+SELECT quantileExactIf(number, number > 0) FROM numbers(90);
+
+SELECT quantileExactIf(number, number > 100) FROM numbers(90);
+SELECT quantileExactIf(toFloat32(number) , number > 100) FROM numbers(90);
+SELECT quantileExactIf(toFloat64(number) , number > 100) FROM numbers(90);
+
+SELECT quantileIf(number, number > 100) FROM numbers(90);
+SELECT quantileIf(toFloat32(number) , number > 100) FROM numbers(90);
+SELECT quantileIf(toFloat64(number) , number > 100) FROM numbers(90);
+
 DROP TABLE test.series;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

I think `quantileExact` function should return nan when quantileExact with empty float column like `quantile` function.