### PR TITLE
avoid cmake compatible behavior for better linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project (ClickHouse)
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.3)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${ClickHouse_SOURCE_DIR}/cmake/Modules/")
 


### PR DESCRIPTION
https://cmake.org/cmake/help/v3.9/policy/CMP0060.html#policy:CMP0060

Link fails when libraries like `ICU` reside in `/usr/local/` while cmake uses old policy of linking, which adds `-l<SONAME>` directly without the actual library paths.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
