### PR TITLE
Get rid of useless std::move to get NRVO

### DIFF
--- a/dbms/src/Columns/ColumnAggregateFunction.cpp
+++ b/dbms/src/Columns/ColumnAggregateFunction.cpp
@@ -66,7 +66,7 @@ MutableColumnPtr ColumnAggregateFunction::convertToValues() const
         auto res = createView();
         res->set(function_state->getNestedFunction());
         res->getData().assign(getData().begin(), getData().end());
-        return std::move(res);
+        return res;
     }
 
     MutableColumnPtr res = function->getReturnType()->createColumn();
@@ -137,7 +137,7 @@ ColumnPtr ColumnAggregateFunction::filter(const Filter & filter, ssize_t result_
     if (res_data.size() * 2 < res_data.capacity())
         res_data = Container(res_data.cbegin(), res_data.cend());
 
-    return std::move(res);
+    return res;
 }
 
 
@@ -159,7 +159,7 @@ ColumnPtr ColumnAggregateFunction::permute(const Permutation & perm, size_t limi
     for (size_t i = 0; i < limit; ++i)
         res->getData()[i] = getData()[perm[i]];
 
-    return std::move(res);
+    return res;
 }
 
 ColumnPtr ColumnAggregateFunction::index(const IColumn & indexes, size_t limit) const
@@ -176,7 +176,7 @@ ColumnPtr ColumnAggregateFunction::indexImpl(const PaddedPODArray<Type> & indexe
     for (size_t i = 0; i < limit; ++i)
         res->getData()[i] = getData()[indexes[i]];
 
-    return std::move(res);
+    return res;
 }
 
 INSTANTIATE_INDEX_IMPL(ColumnAggregateFunction);
@@ -368,7 +368,7 @@ ColumnPtr ColumnAggregateFunction::replicate(const IColumn::Offsets & offsets) c
             res_data.push_back(data[i]);
     }
 
-    return std::move(res);
+    return res;
 }
 
 MutableColumns ColumnAggregateFunction::scatter(IColumn::ColumnIndex num_columns, const IColumn::Selector & selector) const

--- a/dbms/src/Columns/ColumnArray.cpp
+++ b/dbms/src/Columns/ColumnArray.cpp
@@ -61,7 +61,7 @@ MutableColumnPtr ColumnArray::cloneResized(size_t to_size) const
     auto res = ColumnArray::create(getData().cloneEmpty());
 
     if (to_size == 0)
-        return std::move(res);
+        return res;
 
     size_t from_size = size();
 
@@ -89,7 +89,7 @@ MutableColumnPtr ColumnArray::cloneResized(size_t to_size) const
             res->getOffsets()[i] = offset;
     }
 
-    return std::move(res);
+    return res;
 }
 
 
@@ -421,7 +421,7 @@ ColumnPtr ColumnArray::filterNumber(const Filter & filt, ssize_t result_size_hin
     Offsets & res_offsets = res->getOffsets();
 
     filterArraysImpl<T>(static_cast<const ColumnVector<T> &>(*data).getData(), getOffsets(), res_elems, res_offsets, filt, result_size_hint);
-    return std::move(res);
+    return res;
 }
 
 ColumnPtr ColumnArray::filterString(const Filter & filt, ssize_t result_size_hint) const
@@ -489,7 +489,7 @@ ColumnPtr ColumnArray::filterString(const Filter & filt, ssize_t result_size_hin
         }
     }
 
-    return std::move(res);
+    return res;
 }
 
 ColumnPtr ColumnArray::filterGeneric(const Filter & filt, ssize_t result_size_hint) const
@@ -534,7 +534,7 @@ ColumnPtr ColumnArray::filterGeneric(const Filter & filt, ssize_t result_size_hi
         }
     }
 
-    return std::move(res);
+    return res;
 }
 
 ColumnPtr ColumnArray::filterNullable(const Filter & filt, ssize_t result_size_hint) const
@@ -623,7 +623,7 @@ ColumnPtr ColumnArray::permute(const Permutation & perm, size_t limit) const
     if (current_offset != 0)
         res->data = data->permute(nested_perm, current_offset);
 
-    return std::move(res);
+    return res;
 }
 
 ColumnPtr ColumnArray::index(const IColumn & indexes, size_t limit) const
@@ -659,7 +659,7 @@ ColumnPtr ColumnArray::indexImpl(const PaddedPODArray<T> & indexes, size_t limit
     if (current_offset != 0)
         res->data = data->index(*nested_indexes_column, current_offset);
 
-    return std::move(res);
+    return res;
 }
 
 INSTANTIATE_INDEX_IMPL(ColumnArray);

--- a/dbms/src/Columns/ColumnFixedString.cpp
+++ b/dbms/src/Columns/ColumnFixedString.cpp
@@ -228,7 +228,7 @@ ColumnPtr ColumnFixedString::filter(const IColumn::Filter & filt, ssize_t result
         data_pos += n;
     }
 
-    return std::move(res);
+    return res;
 }
 
 ColumnPtr ColumnFixedString::permute(const Permutation & perm, size_t limit) const
@@ -256,7 +256,7 @@ ColumnPtr ColumnFixedString::permute(const Permutation & perm, size_t limit) con
     for (size_t i = 0; i < limit; ++i, offset += n)
         memcpySmallAllowReadWriteOverflow15(&res_chars[offset], &chars[perm[i] * n], n);
 
-    return std::move(res);
+    return res;
 }
 
 
@@ -282,7 +282,7 @@ ColumnPtr ColumnFixedString::indexImpl(const PaddedPODArray<Type> & indexes, siz
     for (size_t i = 0; i < limit; ++i, offset += n)
         memcpySmallAllowReadWriteOverflow15(&res_chars[offset], &chars[indexes[i] * n], n);
 
-    return std::move(res);
+    return res;
 }
 
 ColumnPtr ColumnFixedString::replicate(const Offsets & offsets) const
@@ -294,7 +294,7 @@ ColumnPtr ColumnFixedString::replicate(const Offsets & offsets) const
     auto res = ColumnFixedString::create(n);
 
     if (0 == col_size)
-        return std::move(res);
+        return res;
 
     Chars_t & res_chars = res->chars;
     res_chars.resize(n * offsets.back());
@@ -304,7 +304,7 @@ ColumnPtr ColumnFixedString::replicate(const Offsets & offsets) const
         for (size_t next_offset = offsets[i]; curr_offset < next_offset; ++curr_offset)
             memcpySmallAllowReadWriteOverflow15(&res->chars[curr_offset * n], &chars[i * n], n);
 
-    return std::move(res);
+    return res;
 }
 
 void ColumnFixedString::gather(ColumnGathererStream & gatherer)

--- a/dbms/src/Columns/ColumnString.cpp
+++ b/dbms/src/Columns/ColumnString.cpp
@@ -21,7 +21,7 @@ MutableColumnPtr ColumnString::cloneResized(size_t to_size) const
     auto res = ColumnString::create();
 
     if (to_size == 0)
-        return std::move(res);
+        return res;
 
     size_t from_size = size();
 
@@ -56,7 +56,7 @@ MutableColumnPtr ColumnString::cloneResized(size_t to_size) const
         }
     }
 
-    return std::move(res);
+    return res;
 }
 
 
@@ -105,7 +105,7 @@ ColumnPtr ColumnString::filter(const Filter & filt, ssize_t result_size_hint) co
     Offsets & res_offsets = res->offsets;
 
     filterArraysImpl<UInt8>(chars, offsets, res_chars, res_offsets, filt, result_size_hint);
-    return std::move(res);
+    return res;
 }
 
 
@@ -155,7 +155,7 @@ ColumnPtr ColumnString::permute(const Permutation & perm, size_t limit) const
         res_offsets[i] = current_new_offset;
     }
 
-    return std::move(res);
+    return res;
 }
 
 
@@ -196,7 +196,7 @@ ColumnPtr ColumnString::indexImpl(const PaddedPODArray<Type> & indexes, size_t l
         res_offsets[i] = current_new_offset;
     }
 
-    return std::move(res);
+    return res;
 }
 
 
@@ -255,7 +255,7 @@ ColumnPtr ColumnString::replicate(const Offsets & replicate_offsets) const
     auto res = ColumnString::create();
 
     if (0 == col_size)
-        return std::move(res);
+        return res;
 
     Chars_t & res_chars = res->chars;
     Offsets & res_offsets = res->offsets;
@@ -285,7 +285,7 @@ ColumnPtr ColumnString::replicate(const Offsets & replicate_offsets) const
         prev_string_offset = offsets[i];
     }
 
-    return std::move(res);
+    return res;
 }
 
 

--- a/dbms/src/Columns/ColumnString.h
+++ b/dbms/src/Columns/ColumnString.h
@@ -111,7 +111,7 @@ public:
 #pragma GCC diagnostic pop
 #endif
 
-        void insertFrom(const IColumn & src_, size_t n) override
+    void insertFrom(const IColumn & src_, size_t n) override
     {
         const ColumnString & src = static_cast<const ColumnString &>(src_);
 

--- a/dbms/src/Columns/ColumnTuple.cpp
+++ b/dbms/src/Columns/ColumnTuple.cpp
@@ -54,7 +54,7 @@ ColumnTuple::Ptr ColumnTuple::create(const Columns & columns)
     auto column_tuple = ColumnTuple::create(MutableColumns());
     column_tuple->columns = columns;
 
-    return std::move(column_tuple);
+    return column_tuple;
 }
 
 MutableColumnPtr ColumnTuple::cloneEmpty() const

--- a/dbms/src/Columns/ColumnVector.cpp
+++ b/dbms/src/Columns/ColumnVector.cpp
@@ -121,7 +121,7 @@ MutableColumnPtr ColumnVector<T>::cloneResized(size_t size) const
             memset(static_cast<void *>(&new_col.data[count]), static_cast<int>(value_type()), (size - count) * sizeof(value_type));
     }
 
-    return std::move(res);
+    return res;
 }
 
 template <typename T>
@@ -208,7 +208,7 @@ ColumnPtr ColumnVector<T>::filter(const IColumn::Filter & filt, ssize_t result_s
         ++data_pos;
     }
 
-    return std::move(res);
+    return res;
 }
 
 template <typename T>
@@ -229,7 +229,7 @@ ColumnPtr ColumnVector<T>::permute(const IColumn::Permutation & perm, size_t lim
     for (size_t i = 0; i < limit; ++i)
         res_data[i] = data[perm[i]];
 
-    return std::move(res);
+    return res;
 }
 
 template <typename T>
@@ -262,7 +262,7 @@ ColumnPtr ColumnVector<T>::replicate(const IColumn::Offsets & offsets) const
             res_data.push_back(data[i]);
     }
 
-    return std::move(res);
+    return res;
 }
 
 template <typename T>

--- a/dbms/src/Columns/ColumnVector.h
+++ b/dbms/src/Columns/ColumnVector.h
@@ -363,7 +363,7 @@ ColumnPtr ColumnVector<T>::indexImpl(const PaddedPODArray<Type> & indexes, size_
     for (size_t i = 0; i < limit; ++i)
         res_data[i] = data[indexes[i]];
 
-    return std::move(res);
+    return res;
 }
 
 }

--- a/dbms/src/Columns/ColumnWithDictionary.cpp
+++ b/dbms/src/Columns/ColumnWithDictionary.cpp
@@ -42,7 +42,7 @@ namespace
             if (data[index[i]] != copy[i])
                 throw Exception("Expected " + toString(data[index[i]]) + ", but got " + toString(copy[i]), ErrorCodes::LOGICAL_ERROR);
 
-        return std::move(res_col);
+        return res_col;
     }
 
     template <typename T>
@@ -88,7 +88,7 @@ namespace
                 data[val] = static_cast<T>(i);
         }
 
-        return std::move(res_col);
+        return res_col;
     }
 
     /// Returns unique values of column. Write new index to column.

--- a/dbms/src/Columns/IColumn.h
+++ b/dbms/src/Columns/IColumn.h
@@ -122,7 +122,7 @@ public:
     {
         MutablePtr res = cloneEmpty();
         res->insertRangeFrom(*this, start, length);
-        return std::move(res);
+        return res;
     }
 
     /// Appends new value at the end of column (column's size is increased by 1).

--- a/dbms/src/Dictionaries/CatBoostModel.cpp
+++ b/dbms/src/Dictionaries/CatBoostModel.cpp
@@ -234,7 +234,7 @@ private:
             data += size;
         }
 
-        return std::move(data_column);
+        return data_column;
     }
 
     /// Place columns into buffer, returns data which was used for fixed string columns.
@@ -345,7 +345,7 @@ private:
 
                 throw Exception(error_msg + api->GetErrorString(), ErrorCodes::CANNOT_APPLY_CATBOOST_MODEL);
             }
-            return std::move(result);
+            return result;
         }
 
         /// Prepare cat features.
@@ -386,7 +386,7 @@ private:
             }
         }
 
-        return std::move(result);
+        return result;
     }
 };
 

--- a/dbms/src/Dictionaries/DictionaryBlockInputStream.h
+++ b/dbms/src/Dictionaries/DictionaryBlockInputStream.h
@@ -370,7 +370,7 @@ ColumnPtr DictionaryBlockInputStream<DictionaryType, Key>::getColumnFromAttribut
         size = keys.front()->size();
     auto column_vector = ColumnVector<AttributeType>::create(size);
     callGetter(getter, ids_to_fill, keys, data_types, column_vector->getData(), attribute, dict);
-    return std::move(column_vector);
+    return column_vector;
 }
 
 
@@ -384,7 +384,7 @@ ColumnPtr DictionaryBlockInputStream<DictionaryType, Key>::getColumnFromStringAt
     auto column_string = ColumnString::create();
     auto ptr = column_string.get();
     callGetter(getter, ids_to_fill, keys, data_types, ptr, attribute, dict);
-    return std::move(column_string);
+    return column_string;
 }
 
 
@@ -395,7 +395,7 @@ ColumnPtr DictionaryBlockInputStream<DictionaryType, Key>::getColumnFromIds(cons
     column_vector->getData().reserve(ids_to_fill.size());
     for (UInt64 id : ids_to_fill)
         column_vector->insert(id);
-    return std::move(column_vector);
+    return column_vector;
 }
 
 

--- a/dbms/src/Dictionaries/RangeDictionaryBlockInputStream.h
+++ b/dbms/src/Dictionaries/RangeDictionaryBlockInputStream.h
@@ -108,7 +108,7 @@ ColumnPtr RangeDictionaryBlockInputStream<DictionaryType, Key>::getColumnFromAtt
 {
     auto column_vector = ColumnVector<AttributeType>::create(ids_to_fill.size());
     (dictionary.*getter)(attribute.name, ids_to_fill, dates, column_vector->getData());
-    return std::move(column_vector);
+    return column_vector;
 }
 
 template <typename DictionaryType, typename Key>
@@ -118,7 +118,7 @@ ColumnPtr RangeDictionaryBlockInputStream<DictionaryType, Key>::getColumnFromAtt
 {
     auto column_string = ColumnString::create();
     dictionary.getString(attribute.name, ids_to_fill, dates, column_string.get());
-    return std::move(column_string);
+    return column_string;
 }
 
 template <typename DictionaryType, typename Key>
@@ -129,7 +129,7 @@ ColumnPtr RangeDictionaryBlockInputStream<DictionaryType, Key>::getColumnFromPOD
     column_vector->getData().reserve(array.size());
     for (T value : array)
         column_vector->insert(value);
-    return std::move(column_vector);
+    return column_vector;
 }
 
 

--- a/dbms/src/Functions/FunctionsHigherOrder.h
+++ b/dbms/src/Functions/FunctionsHigherOrder.h
@@ -143,7 +143,7 @@ struct ArrayCountImpl
                     pos = offsets[i];
                 }
 
-                return std::move(out_column);
+                return out_column;
             }
             else
                 return DataTypeUInt32().createColumnConst(array.size(), UInt64(0));
@@ -166,7 +166,7 @@ struct ArrayCountImpl
             out_counts[i] = count;
         }
 
-        return std::move(out_column);
+        return out_column;
     }
 };
 
@@ -205,7 +205,7 @@ struct ArrayExistsImpl
                     pos = offsets[i];
                 }
 
-                return std::move(out_column);
+                return out_column;
             }
             else
                 return DataTypeUInt8().createColumnConst(array.size(), UInt64(0));
@@ -232,7 +232,7 @@ struct ArrayExistsImpl
             out_exists[i] = exists;
         }
 
-        return std::move(out_column);
+        return out_column;
     }
 };
 
@@ -273,7 +273,7 @@ struct ArrayAllImpl
                     pos = offsets[i];
                 }
 
-                return std::move(out_column);
+                return out_column;
             }
         }
 
@@ -298,7 +298,7 @@ struct ArrayAllImpl
             out_all[i] = all;
         }
 
-        return std::move(out_column);
+        return out_column;
     }
 };
 
@@ -436,7 +436,7 @@ struct ArrayFirstImpl
                     pos = offsets[i];
                 }
 
-                return std::move(out);
+                return out;
             }
             else
             {
@@ -470,7 +470,7 @@ struct ArrayFirstImpl
                 out->insertDefault();
         }
 
-        return std::move(out);
+        return out;
     }
 };
 
@@ -509,7 +509,7 @@ struct ArrayFirstIndexImpl
                     pos = offsets[i];
                 }
 
-                return std::move(out_column);
+                return out_column;
             }
             else
                 return DataTypeUInt32().createColumnConst(array.size(), UInt64(0));
@@ -537,7 +537,7 @@ struct ArrayFirstIndexImpl
             out_index[i] = index;
         }
 
-        return std::move(out_column);
+        return out_column;
     }
 };
 

--- a/dbms/src/Functions/GeoUtils.h
+++ b/dbms/src/Functions/GeoUtils.h
@@ -563,7 +563,7 @@ ColumnPtr pointInPolygon(const ColumnVector<T> & x, const ColumnVector<U> & y, P
         data[i] = static_cast<UInt8>(impl.contains(x_data[i], y_data[i]));
     }
 
-    return std::move(result);
+    return result;
 }
 
 template <typename ... Types>

--- a/dbms/src/Interpreters/Set.cpp
+++ b/dbms/src/Interpreters/Set.cpp
@@ -326,7 +326,7 @@ ColumnPtr Set::execute(const Block & block, bool negative) const
             memset(&vec_res[0], 1, vec_res.size());
         else
             memset(&vec_res[0], 0, vec_res.size());
-        return std::move(res);
+        return res;
     }
 
     if (data_types.size() != num_key_columns)
@@ -367,7 +367,7 @@ ColumnPtr Set::execute(const Block & block, bool negative) const
 
     executeOrdinary(key_columns, vec_res, negative, null_map);
 
-    return std::move(res);
+    return res;
 }
 
 

--- a/dbms/src/Parsers/ASTAsterisk.cpp
+++ b/dbms/src/Parsers/ASTAsterisk.cpp
@@ -8,7 +8,7 @@ ASTPtr ASTAsterisk::clone() const
 {
     auto clone = std::make_shared<ASTAsterisk>(*this);
     clone->cloneChildren();
-    return std::move(clone);
+    return clone;
 }
 
 void ASTAsterisk::appendColumnName(WriteBuffer & ostr) const { ostr.write('*'); }

--- a/dbms/src/Parsers/ASTExpressionList.cpp
+++ b/dbms/src/Parsers/ASTExpressionList.cpp
@@ -8,7 +8,7 @@ ASTPtr ASTExpressionList::clone() const
 {
     auto clone = std::make_shared<ASTExpressionList>(*this);
     clone->cloneChildren();
-    return std::move(clone);
+    return clone;
 }
 
 void ASTExpressionList::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const

--- a/dbms/src/Parsers/ASTKillQueryQuery.h
+++ b/dbms/src/Parsers/ASTKillQueryQuery.h
@@ -17,7 +17,7 @@ public:
         auto clone = std::make_shared<ASTKillQueryQuery>(*this);
         clone->where_expression = where_expression->clone();
         clone->children = {clone->where_expression};
-        return std::move(clone);
+        return clone;
     }
 
     String getID() const override;

--- a/dbms/src/Parsers/ASTOrderByElement.h
+++ b/dbms/src/Parsers/ASTOrderByElement.h
@@ -36,7 +36,7 @@ public:
     {
         auto clone = std::make_shared<ASTOrderByElement>(*this);
         clone->cloneChildren();
-        return std::move(clone);
+        return clone;
     }
 
 protected:

--- a/dbms/src/Parsers/ASTQualifiedAsterisk.h
+++ b/dbms/src/Parsers/ASTQualifiedAsterisk.h
@@ -17,7 +17,7 @@ public:
     {
         auto clone = std::make_shared<ASTQualifiedAsterisk>(*this);
         clone->cloneChildren();
-        return std::move(clone);
+        return clone;
     }
     void appendColumnName(WriteBuffer & ostr) const override;
 


### PR DESCRIPTION
http://eel.is/c++draft/class.copy.elision#:constructor,copy,elision

Some quote:

> Speaking of RVO, return std::move(w); prohibits it. It means "use move constructor or fail to compile", whereas return w; means "use RVO, and if you can't, use move constructor, and if you can't, use copy constructor, and if you can't, fail to compile."

There is one exception to this rule:
```cpp
Block FilterBlockInputStream::removeFilterIfNeed(Block && block)
{
    if (block && remove_filter)
        block.erase(static_cast<size_t>(filter_column));

    return std::move(block);
}
```

because references are not eligible for NRVO, which is another rule "always move rvalue references and forward universal references" that takes precedence.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
