### PR TITLE
Fixed alignment issues with AutoArray

### DIFF
--- a/dbms/programs/benchmark/Benchmark.cpp
+++ b/dbms/programs/benchmark/Benchmark.cpp
@@ -403,6 +403,10 @@ public:
 }
 
 
+#ifndef __clang__
+#pragma GCC optimize("-fno-var-tracking-assignments")
+#endif
+
 int mainEntryClickHouseBenchmark(int argc, char ** argv)
 {
     using namespace DB;

--- a/dbms/programs/performance-test/PerformanceTest.cpp
+++ b/dbms/programs/performance-test/PerformanceTest.cpp
@@ -31,6 +31,11 @@
 #include <Poco/XML/XMLStream.h>
 #include <Common/InterruptListener.h>
 
+#ifndef __clang__
+#pragma GCC optimize("-fno-var-tracking-assignments")
+#endif
+
+
 /** Tests launcher for ClickHouse.
   * The tool walks through given or default folder in order to find files with
   * tests' descriptions and launches it.
@@ -1386,6 +1391,7 @@ static void getFilesFromDir(const fs::path & dir, std::vector<String> & input_fi
             input_files.push_back(file.string());
     }
 }
+
 
 int mainEntryClickHousePerformanceTest(int argc, char ** argv)
 try


### PR DESCRIPTION
This fixes segfault in test `00679_uuid_in_key` if clickhouse-server is compiled by gcc-8.
This bug presented after introducing decimal data type, that requires to use __uint128_t in Field, that itself assumed by compiler to have 16 bytes alignment.
