### PR TITLE
Try to fix multiple definition of `explicit_bzero'

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -107,6 +107,7 @@ if (USE_INTERNAL_SSL_LIBRARY)
     endif ()
     set (USE_SHARED ${USE_STATIC_LIBRARIES})
     set (LIBRESSL_SKIP_INSTALL 1)
+    set (HAVE_EXPLICIT_BZERO 1) # already in libglibc-compatibility
     add_subdirectory (ssl)
     target_include_directories(${OPENSSL_CRYPTO_LIBRARY} SYSTEM PUBLIC ${OPENSSL_INCLUDE_DIR})
     target_include_directories(${OPENSSL_SSL_LIBRARY} SYSTEM PUBLIC ${OPENSSL_INCLUDE_DIR})


### PR DESCRIPTION
…multiple definition of `explicit_bzero'

contrib/ssl/crypto/libcrypto.a(explicit_bzero.c.o):../contrib/ssl/crypto/compat/explicit_bzero.c:16: first defined here

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
