### PR TITLE
Fixing sitemaps (#2995)

### DIFF
--- a/docs/tools/build.py
+++ b/docs/tools/build.py
@@ -70,6 +70,7 @@ def build_for_lang(lang, args):
         cfg = config.load_config(
             config_file=config_path,
             site_name='ClickHouse Documentation' if lang == 'en' else 'Документация ClickHouse',
+			site_url='https://clickhouse.yandex/docs/en/' if lang == 'en' else 'https://clickhouse.yandex/docs/ru/',
             docs_dir=os.path.join(args.docs_dir, lang),
             site_dir=os.path.join(args.output_dir, lang),
             strict=True,

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -4,12 +4,9 @@
       <loc>https://clickhouse.yandex/docs/ru/sitemap.xml</loc>
    </sitemap>
    <sitemap>
-      <loc>https://clickhouse.yandex/docs/ru/single_page/sitemap.xml</loc>
-   </sitemap>
-   <sitemap>
       <loc>https://clickhouse.yandex/docs/en/sitemap.xml</loc>
    </sitemap>
    <sitemap>
-      <loc>https://clickhouse.yandex/docs/en/single_pabe/sitemap.xml</loc>
+      <loc>https://clickhouse.yandex/docs/sitemap_static.xml</loc>
    </sitemap>
 </sitemapindex>

--- a/website/sitemap_static.xml
+++ b/website/sitemap_static.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<url>
+  <loc>https://clickhouse.yandex/</loc> 
+  <changefreq>daily</changefreq>
+</url>
+<url>
+  <loc>https://clickhouse.yandex/benchmark.html</loc> 
+  <changefreq>daily</changefreq> 
+</url>
+<url>
+  <loc>https://clickhouse.yandex/tutorial.html</loc> 
+  <changefreq>daily</changefreq> 
+</url>
+<url>
+  <loc>https://clickhouse.yandex/blog/en</loc> 
+  <changefreq>daily</changefreq> 
+</url>
+<url>
+  <loc>https://clickhouse.yandex/blog/ru</loc> 
+  <changefreq>daily</changefreq> 
+</url>
+</urlset>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

if `site_url` exists in mk_docs config it produces correct sitemaps.

Also it affects a bit generated html (for example it adds tags like `<link rel="canonical" href="https://clickhouse.yandex/docs/en/changelog/">`) but it looks ok.
