### PR TITLE
Fixed usage of query scope in TCPHandler #2482

### DIFF
--- a/dbms/programs/server/HTTPHandler.cpp
+++ b/dbms/programs/server/HTTPHandler.cpp
@@ -213,9 +213,7 @@ void HTTPHandler::processQuery(
     Context context = server.context();
     context.setGlobalContext(server.context());
 
-    /// It will forcibly detach query even if unexpected error ocurred and detachQuery() was not called
-    /// Normal detaching is happen in BlockIO callbacks
-    CurrentThread::QueryScope query_scope_holder(context);
+    CurrentThread::QueryScope query_scope(context);
 
     LOG_TRACE(log, "Request URI: " << request.getURI());
 

--- a/dbms/programs/server/TCPHandler.cpp
+++ b/dbms/programs/server/TCPHandler.cpp
@@ -130,6 +130,9 @@ void TCPHandler::runImpl()
         Stopwatch watch;
         state.reset();
 
+        /// Initialized later.
+        std::optional<CurrentThread::QueryScope> query_scope;
+
         /** An exception during the execution of request (it must be sent over the network to the client).
          *  The client will be able to accept it, if it did not happen while sending another packet and the client has not disconnected yet.
          */
@@ -152,7 +155,7 @@ void TCPHandler::runImpl()
             if (!receivePacket())
                 continue;
 
-            CurrentThread::initializeQuery();
+            query_scope.emplace(query_context);
 
             send_exception_with_stack_trace = query_context.getSettingsRef().calculate_text_stack_trace;
 
@@ -197,6 +200,8 @@ void TCPHandler::runImpl()
             sendLogs();
 
             sendEndOfStream();
+
+            query_scope.reset();
             state.reset();
         }
         catch (const Exception & e)
@@ -265,9 +270,7 @@ void TCPHandler::runImpl()
 
         try
         {
-            /// It will forcibly detach query even if unexpected error ocсurred and detachQuery() was not called
-            CurrentThread::detachQueryIfNotDetached();
-
+            query_scope.reset();
             state.reset();
         }
         catch (...)


### PR DESCRIPTION
Without this fix, `current_thread` may point to freed query variables from previous connections.
