### PR TITLE
ClickHouse 3970: Add setting min_merge_bytes_to_use_direct_io

### DIFF
--- a/dbms/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
@@ -609,8 +609,8 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataMergerMutator::mergePartsToTempor
     UInt64 watch_prev_elapsed = 0;
 
     /// Note: this is dirty hack, because MergeTreeBlockInputStream expects amount of bytes instead of flag.
-    /// But when we send `use_direct_io = 1 (bytes)`, it will enable direct_io in any case
-    /// because we can't read less then single byte
+    /// But when we send `use_direct_io = 1 (byte)`, it will enable O_DIRECT in any case
+    /// because stream can't read less then single byte
     size_t use_direct_io = 0;
     if (data.settings.min_merge_bytes_to_use_direct_io != 0)
     {
@@ -620,6 +620,7 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataMergerMutator::mergePartsToTempor
             total_size += part->bytes_on_disk;
             if (total_size >= data.settings.min_merge_bytes_to_use_direct_io)
             {
+                LOG_DEBUG(log, "Will merge parts reading files in O_DIRECT");
                 use_direct_io = 1;
                 break;
             }

--- a/dbms/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
@@ -89,8 +89,8 @@ public:
       */
     MergeTreeData::MutableDataPartPtr mergePartsToTemporaryPart(
         const FuturePart & future_part,
-        MergeListEntry & merge_entry,
-        size_t aio_threshold, time_t time_of_merge, DiskSpaceMonitor::Reservation * disk_reservation, bool deduplication);
+        MergeListEntry & merge_entry, time_t time_of_merge,
+        DiskSpaceMonitor::Reservation * disk_reservation, bool deduplication);
 
     /// Mutate a single data part with the specified commands. Will create and return a temporary part.
     MergeTreeData::MutableDataPartPtr mutatePartToTemporaryPart(

--- a/dbms/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeSettings.h
@@ -146,7 +146,10 @@ struct MergeTreeSettings
                                                                                                               \
     /** How many records about mutations that are done to keep.                                               \
      *  If zero, then keep all of them */                                                                     \
-    M(SettingUInt64, finished_mutations_to_keep, 100)
+    M(SettingUInt64, finished_mutations_to_keep, 100)                                                         \
+                                                                                                              \
+    /** Minimal amount of bytes to enable O_DIRECT in merge (0 - disabled) */                                 \
+    M(SettingUInt64, min_merge_bytes_to_use_direct_io, 0)
 
     /// Settings that should not change after the creation of a table.
 #define APPLY_FOR_IMMUTABLE_MERGE_TREE_SETTINGS(M)  \

--- a/dbms/src/Storages/StorageMergeTree.cpp
+++ b/dbms/src/Storages/StorageMergeTree.cpp
@@ -383,7 +383,6 @@ void StorageMergeTree::loadMutations()
 
 
 bool StorageMergeTree::merge(
-    size_t aio_threshold,
     bool aggressive,
     const String & partition_id,
     bool final,
@@ -618,9 +617,8 @@ bool StorageMergeTree::backgroundTask()
             clearOldMutations();
         }
 
-        size_t aio_threshold = context.getSettings().min_bytes_to_use_direct_io;
         ///TODO: read deduplicate option from table config
-        if (merge(aio_threshold, false /*aggressive*/, {} /*partition_id*/, false /*final*/, false /*deduplicate*/))
+        if (merge(false /*aggressive*/, {} /*partition_id*/, false /*final*/, false /*deduplicate*/))
             return true;
 
         return tryMutatePart();
@@ -751,7 +749,7 @@ bool StorageMergeTree::optimize(
 
         for (const String & partition_id : partition_ids)
         {
-            if (!merge(context.getSettingsRef().min_bytes_to_use_direct_io, true, partition_id, true, deduplicate, &disable_reason))
+            if (!merge(true, partition_id, true, deduplicate, &disable_reason))
             {
                 if (context.getSettingsRef().optimize_throw_if_noop)
                     throw Exception(disable_reason.empty() ? "Can't OPTIMIZE by some reason" : disable_reason, ErrorCodes::CANNOT_ASSIGN_OPTIMIZE);
@@ -761,7 +759,7 @@ bool StorageMergeTree::optimize(
     }
     else
     {
-        if (!merge(context.getSettingsRef().min_bytes_to_use_direct_io, true, partition_id, final, deduplicate, &disable_reason))
+        if (!merge(true, partition_id, final, deduplicate, &disable_reason))
         {
             if (context.getSettingsRef().optimize_throw_if_noop)
                 throw Exception(disable_reason.empty() ? "Can't OPTIMIZE by some reason" : disable_reason, ErrorCodes::CANNOT_ASSIGN_OPTIMIZE);

--- a/dbms/src/Storages/StorageMergeTree.cpp
+++ b/dbms/src/Storages/StorageMergeTree.cpp
@@ -477,7 +477,7 @@ bool StorageMergeTree::merge(
     try
     {
         new_part = merger_mutator.mergePartsToTemporaryPart(
-            future_part, *merge_entry, aio_threshold, time(nullptr),
+            future_part, *merge_entry, time(nullptr),
             merging_tagger->reserved_space.get(), deduplicate);
         merger_mutator.renameMergedTemporaryPart(new_part, future_part.parts, nullptr);
 

--- a/dbms/src/Storages/StorageMergeTree.h
+++ b/dbms/src/Storages/StorageMergeTree.h
@@ -132,7 +132,7 @@ private:
       * If aggressive - when selects parts don't takes into account their ratio size and novelty (used for OPTIMIZE query).
       * Returns true if merge is finished successfully.
       */
-    bool merge(size_t aio_threshold, bool aggressive, const String & partition_id, bool final, bool deduplicate,
+    bool merge(bool aggressive, const String & partition_id, bool final, bool deduplicate,
                String * out_disable_reason = nullptr);
 
     /// Try and find a single part to mutate and mutate it. If some part was successfully mutated, return true.

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1147,7 +1147,6 @@ bool StorageReplicatedMergeTree::tryExecuteMerge(const LogEntry & entry)
     auto table_lock = lockStructure(false, __PRETTY_FUNCTION__);
 
     MergeList::EntryPtr merge_entry = context.getMergeList().insert(database_name, table_name, entry.new_part_name, parts);
-    size_t aio_threshold = context.getSettings().min_bytes_to_use_direct_io;
 
     MergeTreeDataMergerMutator::FuturePart future_merged_part(parts);
     if (future_merged_part.name != entry.new_part_name)

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1171,7 +1171,7 @@ bool StorageReplicatedMergeTree::tryExecuteMerge(const LogEntry & entry)
     try
     {
         part = merger_mutator.mergePartsToTemporaryPart(
-            future_merged_part, *merge_entry, aio_threshold, entry.create_time, reserved_space.get(), entry.deduplicate);
+            future_merged_part, *merge_entry, entry.create_time, reserved_space.get(), entry.deduplicate);
 
         merger_mutator.renameMergedTemporaryPart(part, parts, &transaction);
 


### PR DESCRIPTION
Hack in code :(. But changes are very small. The only good solution is to split MergeTreeBlockInputStream, as said in comment https://github.com/yandex/ClickHouse/blob/master/dbms/src/Storages/MergeTree/MergeTreeBlockInputStream.h#L15. 


I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
