### PR TITLE
Simply Self.

### DIFF
--- a/dbms/src/AggregateFunctions/AggregateFunctionMinMaxAny.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionMinMaxAny.h
@@ -24,7 +24,7 @@ template <typename T>
 struct SingleValueDataFixed
 {
 private:
-    using Self = SingleValueDataFixed<T>;
+    using Self = SingleValueDataFixed;
 
     bool has_value = false; /// We need to remember if at least one value has been passed. This is necessary for AggregateFunctionIf.
     T value;
@@ -563,7 +563,7 @@ public:
 template <typename Data>
 struct AggregateFunctionMinData : Data
 {
-    using Self = AggregateFunctionMinData<Data>;
+    using Self = AggregateFunctionMinData;
 
     bool changeIfBetter(const IColumn & column, size_t row_num, Arena * arena) { return this->changeIfLess(column, row_num, arena); }
     bool changeIfBetter(const Self & to, Arena * arena)                        { return this->changeIfLess(to, arena); }
@@ -574,7 +574,7 @@ struct AggregateFunctionMinData : Data
 template <typename Data>
 struct AggregateFunctionMaxData : Data
 {
-    using Self = AggregateFunctionMaxData<Data>;
+    using Self = AggregateFunctionMaxData;
 
     bool changeIfBetter(const IColumn & column, size_t row_num, Arena * arena) { return this->changeIfGreater(column, row_num, arena); }
     bool changeIfBetter(const Self & to, Arena * arena)                        { return this->changeIfGreater(to, arena); }
@@ -585,7 +585,7 @@ struct AggregateFunctionMaxData : Data
 template <typename Data>
 struct AggregateFunctionAnyData : Data
 {
-    using Self = AggregateFunctionAnyData<Data>;
+    using Self = AggregateFunctionAnyData;
 
     bool changeIfBetter(const IColumn & column, size_t row_num, Arena * arena) { return this->changeFirstTime(column, row_num, arena); }
     bool changeIfBetter(const Self & to, Arena * arena)                        { return this->changeFirstTime(to, arena); }
@@ -596,7 +596,7 @@ struct AggregateFunctionAnyData : Data
 template <typename Data>
 struct AggregateFunctionAnyLastData : Data
 {
-    using Self = AggregateFunctionAnyLastData<Data>;
+    using Self = AggregateFunctionAnyLastData;
 
     bool changeIfBetter(const IColumn & column, size_t row_num, Arena * arena) { return this->changeEveryTime(column, row_num, arena); }
     bool changeIfBetter(const Self & to, Arena * arena)                        { return this->changeEveryTime(to, arena); }
@@ -615,7 +615,7 @@ struct AggregateFunctionAnyHeavyData : Data
 {
     size_t counter = 0;
 
-    using Self = AggregateFunctionAnyHeavyData<Data>;
+    using Self = AggregateFunctionAnyHeavyData;
 
     bool changeIfBetter(const IColumn & column, size_t row_num, Arena * arena)
     {

--- a/dbms/src/Columns/ColumnDecimal.h
+++ b/dbms/src/Columns/ColumnDecimal.h
@@ -58,7 +58,7 @@ class ColumnDecimal final : public COWPtrHelper<IColumn, ColumnDecimal<T>>
     static_assert(IsDecimalNumber<T>);
 
 private:
-    using Self = ColumnDecimal<T>;
+    using Self = ColumnDecimal;
     friend class COWPtrHelper<IColumn, Self>;
 
 public:

--- a/dbms/src/Columns/ColumnVector.h
+++ b/dbms/src/Columns/ColumnVector.h
@@ -125,7 +125,7 @@ class ColumnVector final : public COWPtrHelper<IColumn, ColumnVector<T>>
     static_assert(!IsDecimalNumber<T>);
 
 private:
-    using Self = ColumnVector<T>;
+    using Self = ColumnVector;
     friend class COWPtrHelper<IColumn, Self>;
 
     struct less;

--- a/dbms/src/Common/HashTable/HashSet.h
+++ b/dbms/src/Common/HashTable/HashSet.h
@@ -27,7 +27,7 @@ template
 class HashSetTable : public HashTable<Key, TCell, Hash, Grower, Allocator>
 {
 public:
-    using Self = HashSetTable<Key, TCell, Hash, Grower, Allocator>;
+    using Self = HashSetTable;
     using Cell = TCell;
 
     void merge(const Self & rhs)

--- a/dbms/src/Common/HashTable/HashTable.h
+++ b/dbms/src/Common/HashTable/HashTable.h
@@ -269,7 +269,7 @@ protected:
     friend class TwoLevelHashTable;
 
     using HashValue = size_t;
-    using Self = HashTable<Key, Cell, Hash, Grower, Allocator>;
+    using Self = HashTable;
     using cell_type = Cell;
 
     size_t m_size = 0;        /// Amount of elements

--- a/dbms/src/Common/HashTable/SmallTable.h
+++ b/dbms/src/Common/HashTable/SmallTable.h
@@ -29,7 +29,7 @@ protected:
     friend class iterator;
     friend class Reader;
 
-    using Self = SmallTable<Key, Cell, capacity>;
+    using Self = SmallTable;
     using cell_type = Cell;
 
     size_t m_size = 0;        /// Amount of elements.

--- a/dbms/src/Common/HashTable/TwoLevelHashTable.h
+++ b/dbms/src/Common/HashTable/TwoLevelHashTable.h
@@ -43,7 +43,7 @@ protected:
     friend class iterator;
 
     using HashValue = size_t;
-    using Self = TwoLevelHashTable<Key, Cell, Hash, Grower, Allocator, ImplTable>;
+    using Self = TwoLevelHashTable;
 public:
     using Impl = ImplTable;
 

--- a/dbms/src/Common/SpaceSaving.h
+++ b/dbms/src/Common/SpaceSaving.h
@@ -83,7 +83,7 @@ private:
     }
 
 public:
-    using Self = SpaceSaving<TKey, Hash, Grower, Allocator>;
+    using Self = SpaceSaving;
 
     struct Counter
     {

--- a/dbms/src/DataStreams/UnionBlockInputStream.h
+++ b/dbms/src/DataStreams/UnionBlockInputStream.h
@@ -69,7 +69,7 @@ public:
     using ExceptionCallback = std::function<void()>;
 
 private:
-    using Self = UnionBlockInputStream<mode>;
+    using Self = UnionBlockInputStream;
 
 public:
     UnionBlockInputStream(BlockInputStreams inputs, BlockInputStreamPtr additional_input_at_end, size_t max_threads,

--- a/dbms/src/Interpreters/SystemLog.h
+++ b/dbms/src/Interpreters/SystemLog.h
@@ -76,7 +76,7 @@ class SystemLog : private boost::noncopyable
 {
 public:
 
-    using Self = SystemLog<SystemLog>;
+    using Self = SystemLog;
 
     /** Parameter: table name where to write log.
       * If table is not exists, then it get created with specified engine.

--- a/libs/libcommon/include/common/strong_typedef.h
+++ b/libs/libcommon/include/common/strong_typedef.h
@@ -12,7 +12,7 @@ struct StrongTypedef
                                , boost::totally_ordered2< StrongTypedef<T, Tag>, T> >
 {
 private:
-    using Self = StrongTypedef<T, Tag>;
+    using Self = StrongTypedef;
     T t;
 
 public:


### PR DESCRIPTION
> When the normal name of the template (i.e., the name from the enclosing scope, not the injected-class-name) is used, it always refers to the class template itself and not a specialization of the template

http://eel.is/c++draft/temp.local

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
