### PR TITLE
Fix Storage Kafka: Schema positional argument number

### DIFF
--- a/dbms/src/Storages/Kafka/StorageKafka.cpp
+++ b/dbms/src/Storages/Kafka/StorageKafka.cpp
@@ -727,7 +727,7 @@ void registerStorageKafka(StorageFactory & factory)
         String schema;
         if (args_count >= 6)
         {
-            engine_args[5] = evaluateConstantExpressionOrIdentifierAsLiteral(engine_args[4], args.local_context);
+            engine_args[5] = evaluateConstantExpressionOrIdentifierAsLiteral(engine_args[5], args.local_context);
 
             auto ast = typeid_cast<const ASTLiteral *>(engine_args[5].get());
             if (ast && ast->value.getType() == Field::Types::String)


### PR DESCRIPTION
Fix for Parse format schema, to read schema not row delimiter

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
