### PR TITLE
documentation kafka per topic configuration

### DIFF
--- a/docs/en/operations/table_engines/kafka.md
+++ b/docs/en/operations/table_engines/kafka.md
@@ -119,7 +119,7 @@ If you want to change the target table by using `ALTER`, we recommend disabling 
 
 ## Configuration
 
-Similar to GraphiteMergeTree, the Kafka engine supports extended configuration using the ClickHouse config file. There are two configuration keys that you can use: global (`kafka`) and topic-level (`kafka_topic_*`). The global configuration is applied first, and then the topic-level configuration is applied (if it exists).
+Similar to GraphiteMergeTree, the Kafka engine supports extended configuration using the ClickHouse config file. There are two configuration keys that you can use: global (`kafka`) and topic-level (`kafka_*`). The global configuration is applied first, and then the topic-level configuration is applied (if it exists).
 
 ```xml
   <!--  Global configuration options for all tables of Kafka engine type -->
@@ -129,10 +129,10 @@ Similar to GraphiteMergeTree, the Kafka engine supports extended configuration u
   </kafka>
 
   <!-- Configuration specific for topic "logs" -->
-  <kafka_topic_logs>
+  <kafka_logs>
     <retry_backoff_ms>250</retry_backoff_ms>
     <fetch_min_bytes>100000</fetch_min_bytes>
-  </kafka_topic_logs>
+  </kafka_logs>
 ```
 
 For a list of possible configuration options, see the [librdkafka configuration reference](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md). Use the underscore (`_`) instead of a dot in the ClickHouse configuration. For example, `check.crcs=true` will be `<check_crcs>true</check_crcs>`.

--- a/docs/ru/operations/table_engines/kafka.md
+++ b/docs/ru/operations/table_engines/kafka.md
@@ -119,7 +119,7 @@ Kafka SETTINGS
 
 ## Конфигурация
 
-Аналогично GraphiteMergeTree, движок Kafka поддерживает расширенную конфигурацию с помощью конфигурационного файла ClickHouse. Существует два конфигурационных ключа, которые можно использовать - глобальный (`kafka`) и по топикам (`kafka_topic_*`). Сначала применяется глобальная конфигурация, затем конфигурация по топикам (если она существует).
+Аналогично GraphiteMergeTree, движок Kafka поддерживает расширенную конфигурацию с помощью конфигурационного файла ClickHouse. Существует два конфигурационных ключа, которые можно использовать - глобальный (`kafka`) и по топикам (`kafka_*`). Сначала применяется глобальная конфигурация, затем конфигурация по топикам (если она существует).
 
 ```xml
   <!--  Global configuration options for all tables of Kafka engine type -->
@@ -129,10 +129,10 @@ Kafka SETTINGS
   </kafka>
 
   <!-- Configuration specific for topic "logs" -->
-  <kafka_topic_logs>
+  <kafka_logs>
     <retry_backoff_ms>250</retry_backoff_ms>
     <fetch_min_bytes>100000</fetch_min_bytes>
-  </kafka_topic_logs>
+  </kafka_logs>
 ```
 
 В документе [librdkafka configuration reference](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md) можно увидеть список возможных опций конфигурации. Используйте подчёркивания (`_`) вместо точек в конфигурации ClickHouse, например, `check.crcs=true` будет соответствовать `<check_crcs>true</check_crcs>`.


### PR DESCRIPTION
It doensn't actualy search for kafka topic configuration with key kafka_topic_* but by: kafka_*
```
/// Configuration prefix
static const String CONFIG_PREFIX = "kafka";
---
for (const auto & topic : topics)
    {
        const auto topic_config_key = CONFIG_PREFIX + "_" + topic;
        if (config.has(topic_config_key))
            loadFromConfig(conf, config, topic_config_key);
    }
```

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
