### PR TITLE
fix typo in BaseDaemon doc

### DIFF
--- a/libs/libdaemon/include/daemon/BaseDaemon.h
+++ b/libs/libdaemon/include/daemon/BaseDaemon.h
@@ -34,7 +34,7 @@ namespace Poco { class TaskManager; }
 /// #    --config-file или --config - имя файла конфигурации. По умолчанию - config.xml
 /// #    --pid-file - имя PID файла. По умолчанию - pid
 /// #    --log-file - имя лог файла
-/// #    --error-file - имя лог файла, в который будут помещаться только ошибки
+/// #    --errorlog-file - имя лог файла, в который будут помещаться только ошибки
 /// #    --daemon - запустить в режиме демона; если не указан - логгирование будет вестись на консоль
 /// <daemon_name> --daemon --config-file=localfile.xml --pid-file=pid.pid --log-file=log.log --errorlog-file=error.log
 /// \endcode


### PR DESCRIPTION
daemon has --errorlog-file cmd option, not --error-file

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
