### PR TITLE
Docker sugar + permissions fix

### DIFF
--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -1,13 +1,32 @@
 FROM ubuntu:18.04
 
-RUN apt-get update -y && \
-    env DEBIAN_FRONTEND=noninteractive apt-get install -y \
-        cmake ninja-build ccache pkg-config gcc g++ \
-        liblld-6.0-dev libclang-6.0-dev \
-        libssl-dev libicu-dev libreadline-dev libmysqlclient-dev unixodbc-dev \
-        bash expect python python-lxml python-termcolor python-requests curl perl sudo tzdata
+RUN apt-get update -y \
+    && env DEBIAN_FRONTEND=noninteractive \
+        apt-get install --yes --no-install-recommends \
+            bash \
+            ccache \
+            cmake \
+            curl \
+            expect \
+            g++ \
+            gcc \
+            libclang-6.0-dev \
+            libicu-dev \
+            liblld-6.0-dev \
+            libmysqlclient-dev \
+            libreadline-dev \
+            libssl-dev \
+            ninja-build \
+            perl \
+            pkg-config \
+            python \
+            python-lxml \
+            python-requests \
+            python-termcolor \
+            sudo \
+            tzdata \
+            unixodbc-dev
 
-ADD build.sh /
-RUN chmod +x /build.sh
+COPY build.sh /
 
-CMD ["/build.sh"]
+CMD ["/bin/bash", "/build.sh"]

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
 ARG repository="deb http://repo.yandex.ru/clickhouse/deb/stable/ main/"
-ARG version=18.12.17
+ARG version=18.13.0
 
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -1,21 +1,29 @@
 FROM ubuntu:18.04
 
 ARG repository="deb http://repo.yandex.ru/clickhouse/deb/stable/ main/"
-ARG version=18.13.0
+ARG version=18.12.17
 
-RUN apt-get update && \
-    apt-get install -y apt-transport-https dirmngr && \
-    mkdir -p /etc/apt/sources.list.d && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv E0C56BD4 && \
-    echo $repository | tee /etc/apt/sources.list.d/clickhouse.list && \
-    apt-get update && \
-    env DEBIAN_FRONTEND=noninteractive apt-get install --allow-unauthenticated -y clickhouse-client=$version clickhouse-common-static=$version locales tzdata && \
-    rm -rf /var/lib/apt/lists/* /var/cache/debconf && \
-    apt-get clean
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        apt-transport-https \
+        dirmngr \
+        gnupg \
+    && mkdir -p /etc/apt/sources.list.d \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv E0C56BD4 \
+    && echo $repository > /etc/apt/sources.list.d/clickhouse.list \
+    && apt-get update \
+    && env DEBIAN_FRONTEND=noninteractive \
+        apt-get install --allow-unauthenticated --yes --no-install-recommends \
+            clickhouse-client=$version \
+            clickhouse-common-static=$version \
+            locales \
+            tzdata \
+    && rm -rf /var/lib/apt/lists/* /var/cache/debconf \
+    && apt-get clean
 
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
-ENTRYPOINT ["/usr/bin/clickhouse-client"]
+CMD ["/usr/bin/clickhouse-client"]

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,25 +1,42 @@
 FROM ubuntu:18.04
 
 ARG repository="deb http://repo.yandex.ru/clickhouse/deb/stable/ main/"
-ARG version=18.13.0
+ARG version=18.12.17
+ARG gosu_ver=1.10
 
-RUN apt-get update && \
-    apt-get install -y apt-transport-https dirmngr && \
-    mkdir -p /etc/apt/sources.list.d && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv E0C56BD4 && \
-    echo $repository | tee /etc/apt/sources.list.d/clickhouse.list && \
-    apt-get update && \
-    env DEBIAN_FRONTEND=noninteractive apt-get install --allow-unauthenticated -y clickhouse-server=$version clickhouse-common-static=$version libgcc-7-dev && \
-    rm -rf /var/lib/apt/lists/* /var/cache/debconf && \
-    apt-get clean
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        apt-transport-https \
+        dirmngr \
+        gnupg \
+    && mkdir -p /etc/apt/sources.list.d \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv E0C56BD4 \
+    && echo $repository > /etc/apt/sources.list.d/clickhouse.list \
+    && apt-get update \
+    && env DEBIAN_FRONTEND=noninteractive \
+        apt-get install --allow-unauthenticated --yes --no-install-recommends \
+            clickhouse-common-static=$version \
+            clickhouse-server=$version \
+            libgcc-7-dev \
+    && rm -rf \
+        /var/lib/apt/lists/* \
+        /var/cache/debconf \
+        /tmp/* \
+    && apt-get clean
 
 COPY docker_related_config.xml /etc/clickhouse-server/config.d/
-RUN chown -R clickhouse /etc/clickhouse-server/
+COPY entrypoint.sh /entrypoint.sh
+ADD https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64 /bin/gosu
 
-USER clickhouse
+RUN chmod +x \
+    /entrypoint.sh \
+    /bin/gosu
+
 EXPOSE 9000 8123 9009
 VOLUME /var/lib/clickhouse
 
 ENV CLICKHOUSE_CONFIG /etc/clickhouse-server/config.xml
 
-ENTRYPOINT exec /usr/bin/clickhouse-server --config=${CLICKHOUSE_CONFIG}
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["/usr/bin/clickhouse-server", "--config=${CLICKHOUSE_CONFIG}"]

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
 ARG repository="deb http://repo.yandex.ru/clickhouse/deb/stable/ main/"
-ARG version=18.12.17
+ARG version=18.13.0
 ARG gosu_ver=1.10
 
 RUN apt-get update \

--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# set some vars
+CLICKHOUSE_CONFIG="${CLICKHOUSE_CONFIG:-/etc/clickhouse-server/config.xml}"
+USER="$(id -u clickhouse)"
+GROUP="$(id -g clickhouse)"
+
+# get CH directories locations
+DATA_DIR="$(grep -oP '<path>\K(.*)(?=[/?]</path>)' $CLICKHOUSE_CONFIG || true)"
+TMP_DIR="$(grep -oP '<tmp_path>\K(.*)(?=[/?]</tmp_path>)' $CLICKHOUSE_CONFIG || true)"
+USER_PATH="$(grep -oP '<user_files_path>\K(.*)(?=</user_files_path>)' $CLICKHOUSE_CONFIG || true)"
+LOG_PATH="$(grep -oP '<log>\K(.*)(?=</log>)' $CLICKHOUSE_CONFIG || true)"
+LOG_DIR="$(dirname $LOG_PATH || true)"
+ERROR_LOG_PATH="$(grep -oP '<errorlog>\K(.*)(?=</errorlog>)' $CLICKHOUSE_CONFIG || true)"
+ERROR_LOG_DIR="$(dirname $ERROR_LOG_PATH || true)"
+
+# ensure directories exist
+mkdir -p \
+    "$DATA_DIR" \
+    "$ERROR_LOG_DIR" \
+    "$LOG_DIR" \
+    "$TMP_DIR" \
+    "$USER_PATH"
+
+# ensure proper directories permissions
+chown -R $USER:$GROUP \
+    "$DATA_DIR" \
+    "$ERROR_LOG_DIR" \
+    "$LOG_DIR" \
+    "$TMP_DIR" \
+    "$USER_PATH"
+
+# execute CMD
+exec gosu clickhouse "$@"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

* Adjust syntax to follow best practices (mainly line breaks & indents)
* Use COPY for local files (not archives)
* Switch to CMD, use ENTRYPOINT as preparation step
* Use `gosu` to drop privileges, ensure proper folder permissions on startup
* Avoid additional packages by specifying --no-install-recommends