### PR TITLE
PushingToViewsBlockOutputStream: process blocks concurrently

### DIFF
--- a/dbms/src/DataStreams/PushingToViewsBlockOutputStream.cpp
+++ b/dbms/src/DataStreams/PushingToViewsBlockOutputStream.cpp
@@ -78,13 +78,15 @@ void PushingToViewsBlockOutputStream::write(const Block & block)
 
     // Insert data into materialized views only after successful insert into main table
     bool allow_concurrent_view_processing = context.getSettingsRef().allow_concurrent_view_processing;
-    if (allow_concurrent_view_processing && views.size() > 1) {
+    if (allow_concurrent_view_processing && views.size() > 1)
+    {
         // Push to views concurrently if enabled, and more than one view is attached
         ThreadPool pool(std::min(getNumberOfPhysicalCPUCores(), views.size()));
         for (size_t view_num = 0; view_num < views.size(); ++view_num)
         {
             auto thread_group = CurrentThread::getGroup();
-            pool.schedule([=] () {
+            pool.schedule([=] ()
+            {
                 setThreadName("PushingToViewsBlockOutputStream");
                 CurrentThread::attachToIfDetached(thread_group);
                 process(block, view_num);
@@ -92,7 +94,9 @@ void PushingToViewsBlockOutputStream::write(const Block & block)
         }
         // Wait for concurrent view processing
         pool.wait();
-    } else {
+    }
+    else
+    {
         // Process sequentially
         for (size_t view_num = 0; view_num < views.size(); ++view_num)
             process(block, view_num);

--- a/dbms/src/DataStreams/PushingToViewsBlockOutputStream.h
+++ b/dbms/src/DataStreams/PushingToViewsBlockOutputStream.h
@@ -47,6 +47,8 @@ private:
 
     std::vector<ViewInfo> views;
     std::unique_ptr<Context> views_context;
+
+    void process(const Block & block, size_t view_num);
 };
 
 

--- a/dbms/src/Interpreters/Settings.h
+++ b/dbms/src/Interpreters/Settings.h
@@ -291,6 +291,7 @@ struct Settings
     M(SettingUInt64, http_max_multipart_form_data_size, 1024 * 1024 * 1024, "Limit on size of multipart/form-data content. This setting cannot be parsed from URL parameters and should be set in user profile. Note that content is parsed and external tables are created in memory before start of query execution. And this is the only limit that has effect on that stage (limits on max memory usage and max execution time have no effect while reading HTTP form data).") \
     M(SettingBool, calculate_text_stack_trace, 1, "Calculate text stack trace in case of exceptions during query execution. This is the default. It requires symbol lookups that may slow down fuzzing tests when huge amount of wrong queries are executed. In normal cases you should not disable this option.") \
     M(SettingBool, allow_ddl, true, "If it is set to true, then a user is allowed to executed DDL queries.") \
+    M(SettingBool, allow_concurrent_view_processing, false, "Enables pushing to attached views concurrently instead of sequentially.") \
 
 
 #define DECLARE(TYPE, NAME, DEFAULT, DESCRIPTION) \


### PR DESCRIPTION
The current model is to process blocks for attached views in sequence.
This is not ideal when the processing time for each view varies, or is blocking (for example with replicated tables), as processing of next-in-line view is blocked by wait in it's predecessor.

This commit changes the behavior to process 2 or more attached views concurrently.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

cc @bocharov @dqminh
