### PR TITLE
Formats/CapnProtoRowInputStream: fix column mismatch in list of structs

### DIFF
--- a/dbms/src/Formats/CapnProtoRowInputStream.cpp
+++ b/dbms/src/Formats/CapnProtoRowInputStream.cpp
@@ -144,7 +144,12 @@ void CapnProtoRowInputStream::createActions(const NestedFieldList & sortedFields
         {
             // The field list here flattens Nested elements into multiple arrays
             // In order to map Nested types in Cap'nProto back, they need to be collected
-            actions.back().columns.push_back(field.pos);
+            // Since the field names are sorted, the order of field positions must be preserved
+            // For example, if the fields are { b @0 :Text, a @1 :Text }, the `a` would come first
+            // even though it's position is second.
+            auto & columns = actions.back().columns;
+            auto it = std::upper_bound(columns.cbegin(), columns.cend(), field.pos);
+            columns.insert(it, field.pos);
         }
         else
         {


### PR DESCRIPTION
The fields are lexicographically sorted to make traversal easier,
but their order must be preserved when collecting fields from structures.

For example, a list with a structure like `{b @0 :Text, a @1 :Text}` would
read `a` first despite being second, which would cause a mismatch.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
