### PR TITLE
Fix invalid documentation

### DIFF
--- a/docs/en/operations/server_settings/settings.md
+++ b/docs/en/operations/server_settings/settings.md
@@ -278,12 +278,12 @@ Useful for breaking away from a specific network interface.
 
 ## keep_alive_timeout
 
-The number of milliseconds that ClickHouse waits for incoming requests before closing the connection.
+The number of seconds that ClickHouse waits for incoming requests before closing the connection. Defaults to 10 seconds
 
 **Example**
 
 ```xml
-<keep_alive_timeout>3</keep_alive_timeout>
+<keep_alive_timeout>10</keep_alive_timeout>
 ```
 
 <a name="server_settings-listen_host"></a>

--- a/docs/ru/operations/server_settings/settings.md
+++ b/docs/ru/operations/server_settings/settings.md
@@ -279,12 +279,12 @@ ClickHouse проверит условия `min_part_size` и `min_part_size_rat
 
 ## keep_alive_timeout
 
-Время в миллисекундах, в течение которого ClickHouse ожидает входящих запросов прежде, чем закрыть соединение.
+Время в секундах, в течение которого ClickHouse ожидает входящих запросов прежде, чем закрыть соединение.
 
 **Пример**
 
 ```xml
-<keep_alive_timeout>3</keep_alive_timeout>
+<keep_alive_timeout>10</keep_alive_timeout>
 ```
 
 <a name="server_settings-listen_host"></a>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

The keep_alive_timeout is a value of seconds not milliseconds :)
