### PR TITLE
Issue 3269 Fix incorrect OR evaluation when multiples ORs are optimized to IN

### DIFF
--- a/dbms/src/Interpreters/LogicalExpressionsOptimizer.cpp
+++ b/dbms/src/Interpreters/LogicalExpressionsOptimizer.cpp
@@ -237,7 +237,7 @@ void LogicalExpressionsOptimizer::addInExpression(const DisjunctiveEqualityChain
         /// Get range min/max from all literals x1...xN, which will be used as tuple_functions' range
         if (min_range_first == nullptr || min_range_first > operands[1]->range.first)
             min_range_first = operands[1]->range.first;
-        if (max_range_second < operands[1]->range.second)
+        if (max_range_second == nullptr || max_range_second < operands[1]->range.second)
             max_range_second = operands[1]->range.second;
     }
 


### PR DESCRIPTION
https://github.com/yandex/ClickHouse/issues/3269 In this case when multiple equality evaluation are bundled into one IN set evaluation, since tuple_function is generated from optimizer, it doesn't have a proper range which is later used as indexation key for prepared set.
Add fake range for tuple ASTFunction generated by Optimizer so that prepared set indexation works correctly.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
