### PR TITLE
Common/MemoryTracker: fix metrics not being updated after MemoryTracker reset

### DIFF
--- a/dbms/src/Common/MemoryTracker.cpp
+++ b/dbms/src/Common/MemoryTracker.cpp
@@ -43,7 +43,8 @@ MemoryTracker::~MemoryTracker()
       *  then memory usage of 'next' memory trackers will be underestimated,
       *  because amount will be decreased twice (first - here, second - when real 'free' happens).
       */
-    reset();
+    if (auto value = amount.load(std::memory_order_relaxed))
+        free(value);
 }
 
 
@@ -169,9 +170,8 @@ void MemoryTracker::resetCounters()
 
 void MemoryTracker::reset()
 {
-    if (!parent.load(std::memory_order_relaxed))
-        if (auto value = amount.load(std::memory_order_relaxed))
-            free(value);
+    if (metric != CurrentMetrics::end())
+        CurrentMetrics::sub(metric, amount.load(std::memory_order_relaxed));
 
     resetCounters();
 }


### PR DESCRIPTION
The #3230 fixed a problem with memory accounting, but it introduces a regression
in which the memory tracker isn't reset until there are zero queries in process list.
This makes it difficult to see in tests as there's always just one query in-flight,
but in production it produces a sawtooth memory usage pattern that resets when
the allocated memory exceeds set memory limits and all queries are terminated.

cc @dqminh @bocharov 

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
