### PR TITLE
clickhouse-odbc#125 : Make TIMESTAMP alias for DateTime type for allowing CAST(x AS TIMESTAMP)

### DIFF
--- a/dbms/src/DataTypes/DataTypeDateTime.cpp
+++ b/dbms/src/DataTypes/DataTypeDateTime.cpp
@@ -172,6 +172,7 @@ static DataTypePtr create(const ASTPtr & arguments)
 void registerDataTypeDateTime(DataTypeFactory & factory)
 {
     factory.registerDataType("DateTime", create, DataTypeFactory::CaseInsensitive);
+    factory.registerAlias("TIMESTAMP", "DateTime", DataTypeFactory::CaseInsensitive);
 }
 
 

--- a/dbms/tests/queries/0_stateless/00642_cast.reference
+++ b/dbms/tests/queries/0_stateless/00642_cast.reference
@@ -6,6 +6,7 @@ hello
 hello
 hello
 hello
+1970-01-01 00:00:01
 CREATE TABLE test.cast ( x UInt8,  e Enum8('hello' = 1, 'world' = 2) DEFAULT CAST(x, 'Enum8(\'hello\' = 1, \'world\' = 2)')) ENGINE = MergeTree ORDER BY e SETTINGS index_granularity = 8192
 x	UInt8		
 e	Enum8(\'hello\' = 1, \'world\' = 2)	DEFAULT	CAST(x, \'Enum8(\\\'hello\\\' = 1, \\\'world\\\' = 2)\')

--- a/dbms/tests/queries/0_stateless/00642_cast.sql
+++ b/dbms/tests/queries/0_stateless/00642_cast.sql
@@ -15,6 +15,8 @@ SELECT cast(1 AS Enum8(
 SELECT CAST(1, 'Enum8(\'hello\' = 1,\n\t\'world\' = 2)');
 SELECT cast(1, 'Enum8(\'hello\' = 1,\n\t\'world\' = 2)');
 
+SELECT toTimeZone(CAST(1 AS TIMESTAMP), 'UTC');
+
 DROP TABLE IF EXISTS test.cast;
 CREATE TABLE test.cast
 (


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
