### PR TITLE
Fix build without jemalloc

### DIFF
--- a/libs/libglibc-compatibility/glibc-compatibility.c
+++ b/libs/libglibc-compatibility/glibc-compatibility.c
@@ -147,7 +147,7 @@ const char * __shm_directory(size_t * len)
  * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
-void explicit_bzero(void * buf, size_t len)
+void __attribute__((__weak__)) explicit_bzero(void * buf, size_t len)
 {
     memset(buf, 0, len);
     __asm__ __volatile__("" :: "r"(buf) : "memory");


### PR DESCRIPTION
```
libs/libglibc-compatibility/libglibc-compatibility.a(glibc-compatibility.c.o): In function `explicit_bzero':
/home/amos/git/chorigin/build-dev/../libs/libglibc-compatibility/glibc-compatibility.c:151: multiple definition of `explicit_bzero'
contrib/ssl/crypto/libcrypto.a(explicit_bzero.c.o):/home/amos/git/chorigin/build-dev/../contrib/ssl/crypto/compat/explicit_bzero.c:16: first defined here
collect2: error: ld returned 1 exit status
```

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
