### PR TITLE
fixed group by int16 and Date types on AMD EPYC 7401P machine

### DIFF
--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -1475,9 +1475,8 @@ void NO_INLINE Aggregator::mergeDataImpl(
     Table & table_src,
     Arena * arena) const
 {
-    decltype(table_src.end()) end = table_src.end();
 
-    for (auto it = table_src.begin(); it != end; ++it)
+    for (auto it = table_src.begin(), end = table_src.end(); it != end; ++it)
     {
         decltype(it) res_it;
         bool inserted;

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -1475,7 +1475,9 @@ void NO_INLINE Aggregator::mergeDataImpl(
     Table & table_src,
     Arena * arena) const
 {
-    for (auto it = table_src.begin(); it != table_src.end(); ++it)
+    decltype(table_src.end()) end = table_src.end();
+
+    for (auto it = table_src.begin(); it != end; ++it)
     {
         decltype(it) res_it;
         bool inserted;

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -1475,7 +1475,6 @@ void NO_INLINE Aggregator::mergeDataImpl(
     Table & table_src,
     Arena * arena) const
 {
-
     for (auto it = table_src.begin(), end = table_src.end(); it != end; ++it)
     {
         decltype(it) res_it;


### PR DESCRIPTION
There is sever performance degradation on AMD EPYC 7401P  based systems. Every query with grouping by int16 or Date type becomes very slow (see: https://github.com/yandex/ClickHouse/issues/3490).

