### PR TITLE
 CLICKHOUSE-4098 Correct /etc/init.d/clickhouse-server status exit code

### DIFF
--- a/debian/clickhouse-server.init
+++ b/debian/clickhouse-server.init
@@ -328,12 +328,14 @@ status()
 {
     if is_running; then
         echo "$PROGRAM service is running"
+        exit 0
     else
         if is_cron_disabled; then
             echo "$PROGRAM service is stopped";
         else
             echo "$PROGRAM: process unexpectedly terminated"
         fi
+        exit 3
     fi
 }
 
@@ -342,7 +344,6 @@ status()
 case "$1" in
 status)
     status
-    exit 0
     ;;
 esac
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
