### PR TITLE
Fix AIO unknown compression method when merge tree has mark to the last byte of file

### DIFF
--- a/dbms/src/IO/ReadBufferAIO.cpp
+++ b/dbms/src/IO/ReadBufferAIO.cpp
@@ -115,7 +115,7 @@ bool ReadBufferAIO::nextImpl()
 
     /// If the end of the file is just reached, do nothing else.
     if (is_eof)
-        return true;
+        return bytes_read != 0;
 
     /// Create an asynchronous request.
     prepare();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
