### PR TITLE
Update firstSignificantSubdomain function

### DIFF
--- a/dbms/src/Functions/FunctionsURL.h
+++ b/dbms/src/Functions/FunctionsURL.h
@@ -206,7 +206,10 @@ struct ExtractFirstSignificantSubdomain
             || !strncmp(last_3_periods[1] + 1, "net.", 4)
             || !strncmp(last_3_periods[1] + 1, "org.", 4)
             || !strncmp(last_3_periods[1] + 1, "co.", 3)
-            || !strncmp(last_3_periods[1] + 1, "biz.", 4))
+            || !strncmp(last_3_periods[1] + 1, "biz.", 4)
+            || !strncmp(last_3_periods[1] + 1, "gov.", 4)
+            || !strncmp(last_3_periods[1] + 1, "mil.", 4)
+            || !strncmp(last_3_periods[1] + 1, "edu.", 4))
         {
             res_data += last_3_periods[2] + 1 - begin;
             res_size = last_3_periods[1] - last_3_periods[2] - 1;


### PR DESCRIPTION
Added `gov`, `mil` and `edu` 2nd level domains.

I also parsed the public suffix list (https://publicsuffix.org/list/public_suffix_list.dat) to get the most popular 2nd level domains, and here's the top ones:
(on the left - amount of TLDs that have such 2nd level domain)
```
    145 org
    134 com
    128 net
    122 gov
    121 edu
     66 co
     58 mil
     54 blogspot
     42 nom
     40 ac
     32 info
     22 nym
     21 biz
     19 barsy
     18 int
     17 name
     16 or
     15 gob
     13 web
     12 go
     11 tm
     11 sch
     11 pro
     11 med
     11 cloudns
     10 asso
      9 tv
```

I guess it'd be a performance issue to use the whole public suffix list?

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
