### PR TITLE
Run clickhouse-server in exec form inside Docker

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -39,4 +39,3 @@ ENV CLICKHOUSE_CONFIG /etc/clickhouse-server/config.xml
 
 ENTRYPOINT ["/entrypoint.sh"]
 
-CMD /usr/bin/clickhouse-server --config=${CLICKHOUSE_CONFIG}

--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -30,5 +30,11 @@ chown -R $USER:$GROUP \
     "$TMP_DIR" \
     "$USER_PATH"
 
-# execute CMD
-exec gosu clickhouse "$@"
+
+# if no args passed to `docker run` or first argument start with `--`, then the user is passing clickhouse-server arguments
+if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
+    exec gosu clickhouse /usr/bin/clickhouse-server --config-file=$CLICKHOUSE_CONFIG "$@"
+fi
+
+# Otherwise, we assume the user want to run his own process, for example a `bash` shell to explore this image
+exec "$@"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Currenly, clickhouse-server is run inside Docker in shell form and this prevents the server from handling SIGINT and SIGTERM signals sent, for example, by `docker stop`. Hence, Docker (or any other container orchestrator) is always forced to kill the container which may lead to data corruption.

In this pull request, I aim to run `clickhouse-server` in exec form. The server will be run as PID 1 and hence will be able to handle the signals.
