### PR TITLE
Add docker-entrypoint-initdb.d support

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -24,6 +24,8 @@ RUN apt-get update \
         /tmp/* \
     && apt-get clean
 
+RUN mkdir /docker-entrypoint-initdb.d
+
 COPY docker_related_config.xml /etc/clickhouse-server/config.d/
 COPY entrypoint.sh /entrypoint.sh
 ADD https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64 /bin/gosu

--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -33,6 +33,22 @@ ClickHouse configuration represented with a file "config.xml" ([documentation](h
 $ docker run -d --name some-clickhouse-server --ulimit nofile=262144:262144 -v /path/to/your/config.xml:/etc/clickhouse-server/config.xml yandex/clickhouse-server
 ```
 
+## How to extend this image
+
+If you would like to do additional initialization in an image derived from this one, add one or more `*.sql`, `*.sql.gz`, or `*.sh` scripts under `/docker-entrypoint-initdb.d`. After the entrypoint calls `initdb` it will run any `*.sql` files, run any executable `*.sh` scripts, and source any non-executable `*.sh` scripts found in that directory to do further initialization before starting the service.
+
+For example, to add an additional user and database, add the following to `/docker-entrypoint-initdb.d/init-db.sh`:
+
+```bash
+#!/bin/bash
+set -e
+
+clickhouse client -n <<-EOSQL
+	CREATE DATABASE docker;
+	CREATE TABLE docker.docker (x Int32) ENGINE = Log;
+EOSQL
+```
+
 ## License
 
 View [license information](https://github.com/yandex/ClickHouse/blob/master/LICENSE) for the software contained in this image.

--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -35,7 +35,7 @@ if [ -n "$(ls /docker-entrypoint-initdb.d/)" ]; then
     pid="$!"
     sleep 1
 
-    clickhouseclient=( clickhouse client )
+    clickhouseclient=( clickhouse client --multiquery )
     echo
     for f in /docker-entrypoint-initdb.d/*; do
         case "$f" in


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

This done in postgres entrypoint in the same way: https://github.com/docker-library/postgres/tree/master/11.

The most tricky part is starting clickhouse-server in detached mode and sleeping 1 second after it