### PR TITLE
Fixed build of "widechar_width" library on ARM [#CLICKHOUSE-2]

### DIFF
--- a/libs/libwidechar_width/widechar_width.h
+++ b/libs/libwidechar_width/widechar_width.h
@@ -495,7 +495,7 @@ static const struct widechar_range widechar_widened_table[] = {
 template<typename Collection>
 bool widechar_in_table(const Collection &arr, int32_t c) {
     auto where = std::lower_bound(std::begin(arr), std::end(arr), c,
-        [](widechar_range p, wchar_t c) { return p.hi < c; });
+        [](widechar_range p, int32_t c) { return p.hi < c; });
     return where != std::end(arr) && where->lo <= c;
 }
 


### PR DESCRIPTION
Because `wchar_t` is unsigned on ARM. The same as `char`.
http://blog.cdleary.com/2012/11/arm-chars-are-unsigned-by-default/
