### PR TITLE
Fix dmesg error netlink: '...': attribute type 1 has an invalid length.

### DIFF
--- a/dbms/src/Common/TaskStatsInfoGetter.cpp
+++ b/dbms/src/Common/TaskStatsInfoGetter.cpp
@@ -155,7 +155,7 @@ NetlinkMessage query(
     request.generic_header.version = 1;
 
     request.payload.attribute.header.nla_type = attribute_type;
-    request.payload.attribute.header.nla_len = attribute_size + 1 + NLA_HDRLEN;
+    request.payload.attribute.header.nla_len = attribute_size + NLA_HDRLEN;
 
     memcpy(&request.payload.attribute.payload, attribute_data, attribute_size);
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
