### PR TITLE
Ensure ROLLUP and CUBE respect HAVING (no change to TOTALS)

### DIFF
--- a/dbms/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterSelectQuery.cpp
@@ -606,6 +606,8 @@ void InterpreterSelectQuery::executeImpl(Pipeline & pipeline, const BlockInputSt
                         executeRollupOrCube(pipeline, Modificator::ROLLUP);
                     else if (query.group_by_with_cube)
                         executeRollupOrCube(pipeline, Modificator::CUBE);
+                    if ((query.group_by_with_rollup || query.group_by_with_cube) && expressions.has_having)
+                        executeHaving(pipeline, expressions.before_having);
                 }
                 else if (expressions.has_having)
                     executeHaving(pipeline, expressions.before_having);
@@ -625,10 +627,15 @@ void InterpreterSelectQuery::executeImpl(Pipeline & pipeline, const BlockInputSt
                     executeTotalsAndHaving(pipeline, expressions.has_having, expressions.before_having, aggregate_overflow_row, final);
                 }
 
-                if (query.group_by_with_rollup && !aggregate_final)
-                    executeRollupOrCube(pipeline, Modificator::ROLLUP);
-                else if (query.group_by_with_cube && !aggregate_final)
-                    executeRollupOrCube(pipeline, Modificator::CUBE);
+                if ((query.group_by_with_rollup || query.group_by_with_cube) && !aggregate_final)
+                {
+                    if (query.group_by_with_rollup)
+                        executeRollupOrCube(pipeline, Modificator::ROLLUP);
+                    else if (query.group_by_with_cube)
+                        executeRollupOrCube(pipeline, Modificator::CUBE);
+                    if (expressions.has_having)
+                        executeHaving(pipeline, expressions.before_having);
+                }
             }
 
             if (expressions.has_order_by)
@@ -1483,3 +1490,4 @@ void InterpreterSelectQuery::initSettings()
 }
 
 }
+

--- a/dbms/tests/queries/0_stateless/00804_rollup_with_having.reference
+++ b/dbms/tests/queries/0_stateless/00804_rollup_with_having.reference
@@ -5,11 +5,8 @@ a	b	1
 a	\N	1
 a	b	1
 a	\N	2
-\N	\N	2
 
 \N	\N	2
 a	b	1
-a	\N	1
-\N	\N	1
 
 \N	\N	1

--- a/dbms/tests/queries/0_stateless/00804_rollup_with_having.reference
+++ b/dbms/tests/queries/0_stateless/00804_rollup_with_having.reference
@@ -1,0 +1,15 @@
+a	\N	1
+a	b	1
+a	\N	2
+a	b	1
+a	\N	1
+a	b	1
+a	\N	2
+\N	\N	2
+
+\N	\N	2
+a	b	1
+a	\N	1
+\N	\N	1
+
+\N	\N	1

--- a/dbms/tests/queries/0_stateless/00804_rollup_with_having.sql
+++ b/dbms/tests/queries/0_stateless/00804_rollup_with_having.sql
@@ -1,0 +1,15 @@
+DROP TABLE IF EXISTS test.rollup_having;
+CREATE TABLE test.rollup_having (
+  a Nullable(String),
+  b Nullable(String)
+) ENGINE = Memory;
+
+INSERT INTO test.rollup_having VALUES (NULL, NULL);
+INSERT INTO test.rollup_having VALUES ('a', NULL);
+INSERT INTO test.rollup_having VALUES ('a', 'b');
+
+SELECT a, b, count(*) FROM test.rollup_having GROUP BY a, b WITH ROLLUP HAVING a IS NOT NULL;
+SELECT a, b, count(*) FROM test.rollup_having GROUP BY a, b WITH ROLLUP HAVING a IS NOT NULL and b IS NOT NULL;
+
+SELECT a, b, count(*) FROM test.rollup_having GROUP BY a, b WITH ROLLUP WITH TOTALS HAVING a IS NOT NULL;
+SELECT a, b, count(*) FROM test.rollup_having GROUP BY a, b WITH ROLLUP WITH TOTALS HAVING a IS NOT NULL and b IS NOT NULL;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Fixes #3756 .  Tests match postgres output now.

```
ubuntu :) select * from test.rollup_having;

SELECT *
FROM test.rollup_having

┌─a────┬─b────┐
│ ᴺᵁᴸᴸ │ ᴺᵁᴸᴸ │
└──────┴──────┘
┌─a─┬─b────┐
│ a │ ᴺᵁᴸᴸ │
└───┴──────┘
┌─a─┬─b─┐
│ a │ b │
└───┴───┘

3 rows in set. Elapsed: 0.006 sec.

ubuntu :) SELECT a, b, count(*) FROM test.rollup_having GROUP BY a, b WITH ROLLUP HAVING a IS NOT NULL;

SELECT
    a,
    b,
    count(*)
FROM test.rollup_having
GROUP BY
    a,
    b
    WITH ROLLUP
HAVING isNotNull(a)

┌─a─┬─b────┬─count()─┐
│ a │ ᴺᵁᴸᴸ │       1 │
│ a │ b    │       1 │
└───┴──────┴─────────┘
┌─a─┬─b────┬─count()─┐
│ a │ ᴺᵁᴸᴸ │       2 │
└───┴──────┴─────────┘

3 rows in set. Elapsed: 0.007 sec.

ubuntu :) SELECT a, b, count(*) FROM test.rollup_having GROUP BY a, b WITH ROLLUP HAVING a IS NOT NULL and b IS NOT NULL;

SELECT
    a,
    b,
    count(*)
FROM test.rollup_having
GROUP BY
    a,
    b
    WITH ROLLUP
HAVING isNotNull(a) AND isNotNull(b)

┌─a─┬─b─┬─count()─┐
│ a │ b │       1 │
└───┴───┴─────────┘

1 rows in set. Elapsed: 0.005 sec.

ubuntu :) SELECT a, b, count(*) FROM test.rollup_having GROUP BY a, b WITH ROLLUP WITH TOTALS HAVING a IS NOT NULL;

SELECT
    a,
    b,
    count(*)
FROM test.rollup_having
GROUP BY
    a,
    b
    WITH ROLLUP
    WITH TOTALS
HAVING isNotNull(a)

┌─a─┬─b────┬─count()─┐
│ a │ ᴺᵁᴸᴸ │       1 │
│ a │ b    │       1 │
└───┴──────┴─────────┘
┌─a─┬─b────┬─count()─┐
│ a │ ᴺᵁᴸᴸ │       2 │
└───┴──────┴─────────┘

Totals:
┌─a────┬─b────┬─count()─┐
│ ᴺᵁᴸᴸ │ ᴺᵁᴸᴸ │       2 │
└──────┴──────┴─────────┘

3 rows in set. Elapsed: 0.009 sec.

ubuntu :) SELECT a, b, count(*) FROM test.rollup_having GROUP BY a, b WITH ROLLUP WITH TOTALS HAVING a IS NOT NULL and b IS NOT NULL;

SELECT
    a,
    b,
    count(*)
FROM test.rollup_having
GROUP BY
    a,
    b
    WITH ROLLUP
    WITH TOTALS
HAVING isNotNull(a) AND isNotNull(b)

┌─a─┬─b─┬─count()─┐
│ a │ b │       1 │
└───┴───┴─────────┘

Totals:
┌─a────┬─b────┬─count()─┐
│ ᴺᵁᴸᴸ │ ᴺᵁᴸᴸ │       1 │
└──────┴──────┴─────────┘
```