### PR TITLE
Do not log from odbc-bridge when there is no console

### DIFF
--- a/dbms/programs/odbc-bridge/ODBCBridge.cpp
+++ b/dbms/programs/odbc-bridge/ODBCBridge.cpp
@@ -121,9 +121,6 @@ void ODBCBridge::initialize(Application & self)
     if (is_help)
         return;
 
-    if (!config().has("logger.log"))
-        config().setBool("logger.console", true);
-
     config().setString("logger", "ODBCBridge");
 
     buildLoggers(config());


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

This stupid `if` forces BaseDaemon `buildLoggers()` to create logger to nonexistent console. Actually it creates pipe, which nobody reads from. Logging messages were written to this pipe util it reaches 64K size. After that odbc-bridge hangs on `write` syscall. 