### PR TITLE
Add clickhouse puppet module to third party libraries

### DIFF
--- a/docs/en/interfaces/third-party/integrations.md
+++ b/docs/en/interfaces/third-party/integrations.md
@@ -31,6 +31,9 @@
 - Logging
     - [fluentd](https://www.fluentd.org)
         - [loghouse](https://github.com/flant/loghouse) (for [Kubernetes](https://kubernetes.io))
+- Configuration management
+    - [puppet](https://puppet.com)
+        - [innogames/clickhouse](https://forge.puppet.com/innogames/clickhouse)
 
 ## Programming Language Ecosystems
 

--- a/docs/fa/interfaces/third-party/integrations.md
+++ b/docs/fa/interfaces/third-party/integrations.md
@@ -33,6 +33,9 @@
 - ثبت نام
     - [fluentd](https://www.fluentd.org)
         - [loghouse](https://github.com/flant/loghouse) (برای [Kubernetes](https://kubernetes.io))
+- مدیریت تنظیمات
+    - [puppet](https://puppet.com)
+        - [innogames/clickhouse](https://forge.puppet.com/innogames/clickhouse)
 
 ## اکوسیستم زبان برنامه نویسی
 

--- a/docs/ru/interfaces/third-party/integrations.md
+++ b/docs/ru/interfaces/third-party/integrations.md
@@ -30,6 +30,9 @@
 - Логирование
     - [fluentd](https://www.fluentd.org)
         - [loghouse](https://github.com/flant/loghouse) (для [Kubernetes](https://kubernetes.io))
+- Системы управления конфигурацией
+    - [puppet](https://puppet.com)
+        - [innogames/clickhouse](https://forge.puppet.com/innogames/clickhouse)
 
 ## Экосистемы вокруг языков программирования
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Other

Short description:

Add puppet module to the list of the third party libraries