### PR TITLE
Fix strange behavior of send_logs_level setting.

### DIFF
--- a/dbms/src/Common/ErrorCodes.cpp
+++ b/dbms/src/Common/ErrorCodes.cpp
@@ -402,6 +402,7 @@ namespace ErrorCodes
     extern const int SYSTEM_ERROR = 425;
     extern const int NULL_POINTER_DEREFERENCE = 426;
     extern const int CANNOT_COMPILE_REGEXP = 427;
+    extern const int UNKNOWN_LOG_LEVEL = 428;
 
     extern const int KEEPER_EXCEPTION = 999;
     extern const int POCO_EXCEPTION = 1000;

--- a/dbms/src/Interpreters/Settings.h
+++ b/dbms/src/Interpreters/Settings.h
@@ -277,7 +277,7 @@ struct Settings
     M(SettingBool, log_profile_events, true, "Log query performance statistics into the query_log and query_thread_log.") \
     M(SettingBool, log_query_settings, true, "Log query settings into the query_log.") \
     M(SettingBool, log_query_threads, true, "Log query threads into system.query_thread_log table. This setting have effect only when 'log_queries' is true.") \
-    M(SettingString, send_logs_level, "none", "Send server text logs with specified minumum level to client. Valid values: 'trace', 'debug', 'information', 'warning', 'error', 'none'") \
+    M(SettingLogsLevel, send_logs_level, "none", "Send server text logs with specified minumum level to client. Valid values: 'trace', 'debug', 'information', 'warning', 'error', 'none'") \
     M(SettingBool, enable_optimize_predicate_expression, 0, "If it is set to true, optimize predicates to subqueries.") \
     \
     M(SettingUInt64, low_cardinality_max_dictionary_size, 8192, "Maximum size (in rows) of shared global dictionary for LowCardinality type.") \

--- a/dbms/src/Interpreters/SettingsCommon.cpp
+++ b/dbms/src/Interpreters/SettingsCommon.cpp
@@ -23,6 +23,7 @@ namespace ErrorCodes
     extern const int UNKNOWN_DISTRIBUTED_PRODUCT_MODE;
     extern const int UNKNOWN_GLOBAL_SUBQUERIES_METHOD;
     extern const int UNKNOWN_JOIN_STRICTNESS;
+    extern const int UNKNOWN_LOG_LEVEL;
     extern const int SIZE_OF_FIXED_STRING_DOESNT_MATCH;
     extern const int BAD_ARGUMENTS;
 }
@@ -670,6 +671,60 @@ void SettingDateTimeInputFormat::set(ReadBuffer & buf)
 }
 
 void SettingDateTimeInputFormat::write(WriteBuffer & buf) const
+{
+    writeBinary(toString(), buf);
+}
+
+
+const std::vector<String> SettingLogsLevel::log_levels =
+{
+        "none",
+        "trace",
+        "debug",
+        "information",
+        "warning",
+        "error"
+};
+
+
+SettingLogsLevel::SettingLogsLevel(const String & level)
+{
+    set(level);
+}
+
+
+void SettingLogsLevel::set(const String & level)
+{
+    auto it = std::find(log_levels.begin(), log_levels.end(), level);
+    if (it == log_levels.end())
+        throw Exception("Log level '" + level + "' not allowed.", ErrorCodes::UNKNOWN_LOG_LEVEL);
+
+    value = *it;
+    changed = true;
+}
+
+
+void SettingLogsLevel::set(const Field & level)
+{
+    set(safeGet<String>(level));
+}
+
+
+void SettingLogsLevel::set(ReadBuffer & buf)
+{
+    String x;
+    readBinary(x, buf);
+    set(x);
+}
+
+
+String SettingLogsLevel::toString() const
+{
+    return value;
+}
+
+
+void SettingLogsLevel::write(WriteBuffer & buf) const
 {
     writeBinary(toString(), buf);
 }

--- a/dbms/src/Interpreters/SettingsCommon.h
+++ b/dbms/src/Interpreters/SettingsCommon.h
@@ -404,4 +404,25 @@ struct SettingDateTimeInputFormat
     void write(WriteBuffer & buf) const;
 };
 
+
+class SettingLogsLevel
+{
+public:
+
+    String value;
+    bool changed = false;
+    static const std::vector<String> log_levels;
+
+    SettingLogsLevel(const String & level);
+    operator String() const { return value; }
+    void set(const String & level);
+    void set(const Field & level);
+    void set(ReadBuffer & buf);
+
+    String toString() const;
+    void write(WriteBuffer & buf) const;
+};
+
+
+
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category:

Bug Fix
Short description (up to few sentences):
Add checking that 'SET send_logs_level = value' query accept appropriate value.