### PR TITLE
Fixed Segment Fault Caused by 'KILL QUERY SYNC'

### DIFF
--- a/dbms/src/Interpreters/InterpreterKillQueryQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterKillQueryQuery.cpp
@@ -221,8 +221,11 @@ BlockIO InterpreterKillQueryQuery::execute()
 
 Block InterpreterKillQueryQuery::getSelectFromSystemProcessesResult()
 {
-    String system_processes_query = "SELECT query_id, user, query FROM system.processes WHERE "
-        + queryToString(static_cast<ASTKillQueryQuery &>(*query_ptr).where_expression);
+    String system_processes_query = "SELECT query_id, user, query FROM system.processes";
+    auto & where_expression = static_cast<ASTKillQueryQuery &>(*query_ptr).where_expression;
+    if (where_expression)
+        system_processes_query += " WHERE " + queryToString(where_expression);
+
 
     BlockIO system_processes_io = executeQuery(system_processes_query, context, true);
     Block res = system_processes_io.in->read();

--- a/dbms/src/Parsers/ASTKillQueryQuery.h
+++ b/dbms/src/Parsers/ASTKillQueryQuery.h
@@ -15,8 +15,12 @@ public:
     ASTPtr clone() const override
     {
         auto clone = std::make_shared<ASTKillQueryQuery>(*this);
-        clone->where_expression = where_expression->clone();
-        clone->children = {clone->where_expression};
+        if (where_expression)
+        {
+            clone->where_expression = where_expression->clone();
+            clone->children = {clone->where_expression};
+        }
+
         return clone;
     }
 

--- a/dbms/src/Parsers/ParserKillQueryQuery.cpp
+++ b/dbms/src/Parsers/ParserKillQueryQuery.cpp
@@ -39,7 +39,8 @@ bool ParserKillQueryQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expect
         query->test = true;
 
     query->cluster = cluster_str;
-    query->children.emplace_back(query->where_expression);
+    if (query->where_expression)
+        query->children.emplace_back(query->where_expression);
     node = std::move(query);
     return true;
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fixed a bug introduced by 'kill query sync' which leads to a core dump.

This bug can be reproduced by run 'kill query sync'. It appears in 18.14.+ and I think it may exist in all versions.
![image](https://user-images.githubusercontent.com/6196299/50395040-8f2e9c80-079c-11e9-8d5c-8ab0cf437e5c.png)

