### PR TITLE
POC zero left padding for PODArray

### DIFF
--- a/dbms/src/AggregateFunctions/AggregateFunctionArray.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionArray.h
@@ -85,7 +85,7 @@ public:
         const ColumnArray & first_array_column = static_cast<const ColumnArray &>(*columns[0]);
         const IColumn::Offsets & offsets = first_array_column.getOffsets();
 
-        size_t begin = row_num == 0 ? 0 : offsets[row_num - 1];
+        size_t begin = offsets[row_num - 1];
         size_t end = offsets[row_num];
 
         /// Sanity check. NOTE We can implement specialization for a case with single argument, if the check will hurt performance.

--- a/dbms/src/AggregateFunctions/AggregateFunctionForEach.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionForEach.h
@@ -146,7 +146,7 @@ public:
         const ColumnArray & first_array_column = static_cast<const ColumnArray &>(*columns[0]);
         const IColumn::Offsets & offsets = first_array_column.getOffsets();
 
-        size_t begin = row_num == 0 ? 0 : offsets[row_num - 1];
+        size_t begin = offsets[row_num - 1];
         size_t end = offsets[row_num];
 
         /// Sanity check. NOTE We can implement specialization for a case with single argument, if the check will hurt performance.

--- a/dbms/src/AggregateFunctions/AggregateFunctionGroupArray.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionGroupArray.h
@@ -119,7 +119,7 @@ public:
         ColumnArray & arr_to = static_cast<ColumnArray &>(to);
         ColumnArray::Offsets & offsets_to = arr_to.getOffsets();
 
-        offsets_to.push_back((offsets_to.size() == 0 ? 0 : offsets_to.back()) + size);
+        offsets_to.push_back(offsets_to.back() + size);
 
         typename ColumnVector<T>::Container & data_to = static_cast<ColumnVector<T> &>(arr_to.getData()).getData();
         data_to.insert(this->data(place).value.begin(), this->data(place).value.end());
@@ -370,7 +370,7 @@ public:
         auto & column_array = static_cast<ColumnArray &>(to);
 
         auto & offsets = column_array.getOffsets();
-        offsets.push_back((offsets.size() == 0 ? 0 : offsets.back()) + data(place).elems);
+        offsets.push_back(offsets.back() + data(place).elems);
 
         auto & column_data = column_array.getData();
 

--- a/dbms/src/AggregateFunctions/AggregateFunctionGroupUniqArray.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionGroupUniqArray.h
@@ -83,7 +83,7 @@ public:
         const typename State::Set & set = this->data(place).value;
         size_t size = set.size();
 
-        offsets_to.push_back((offsets_to.size() == 0 ? 0 : offsets_to.back()) + size);
+        offsets_to.push_back(offsets_to.back() + size);
 
         typename ColumnVector<T>::Container & data_to = static_cast<ColumnVector<T> &>(arr_to.getData()).getData();
         size_t old_size = data_to.size();
@@ -207,7 +207,7 @@ public:
         IColumn & data_to = arr_to.getData();
 
         auto & set = this->data(place).value;
-        offsets_to.push_back((offsets_to.size() == 0 ? 0 : offsets_to.back()) + set.size());
+        offsets_to.push_back(offsets_to.back() + set.size());
 
         for (auto & elem : set)
         {

--- a/dbms/src/AggregateFunctions/AggregateFunctionQuantile.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionQuantile.h
@@ -138,7 +138,7 @@ public:
             ColumnArray::Offsets & offsets_to = arr_to.getOffsets();
 
             size_t size = levels.size();
-            offsets_to.push_back((offsets_to.size() == 0 ? 0 : offsets_to.back()) + size);
+            offsets_to.push_back(offsets_to.back() + size);
 
             if (!size)
                 return;

--- a/dbms/src/AggregateFunctions/AggregateFunctionSumMap.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionSumMap.h
@@ -83,7 +83,7 @@ public:
         const ColumnArray & array_column = static_cast<const ColumnArray &>(*columns[0]);
         const IColumn::Offsets & offsets = array_column.getOffsets();
         const auto & keys_vec = static_cast<const ColVecType &>(array_column.getData());
-        const size_t keys_vec_offset = row_num == 0 ? 0 : offsets[row_num - 1];
+        const size_t keys_vec_offset = offsets[row_num - 1];
         const size_t keys_vec_size = (offsets[row_num] - keys_vec_offset);
 
         // Columns 1..n contain arrays of numeric values to sum
@@ -93,7 +93,7 @@ public:
             Field value;
             const ColumnArray & array_column = static_cast<const ColumnArray &>(*columns[col + 1]);
             const IColumn::Offsets & offsets = array_column.getOffsets();
-            const size_t values_vec_offset = row_num == 0 ? 0 : offsets[row_num - 1];
+            const size_t values_vec_offset = offsets[row_num - 1];
             const size_t values_vec_size = (offsets[row_num] - values_vec_offset);
 
             // Expect key and value arrays to be of same length

--- a/dbms/src/AggregateFunctions/AggregateFunctionTopK.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionTopK.h
@@ -93,7 +93,7 @@ public:
         auto result_vec = set.topK(threshold);
         size_t size = result_vec.size();
 
-        offsets_to.push_back((offsets_to.size() == 0 ? 0 : offsets_to.back()) + size);
+        offsets_to.push_back(offsets_to.back() + size);
 
         typename ColumnVector<T>::Container & data_to = static_cast<ColumnVector<T> &>(arr_to.getData()).getData();
         size_t old_size = data_to.size();
@@ -212,7 +212,7 @@ public:
         IColumn & data_to = arr_to.getData();
 
         auto result_vec = this->data(place).value.topK(threshold);
-        offsets_to.push_back((offsets_to.size() == 0 ? 0 : offsets_to.back()) + result_vec.size());
+        offsets_to.push_back(offsets_to.back() + result_vec.size());
 
         for (auto & elem : result_vec)
         {

--- a/dbms/src/Columns/ColumnArray.cpp
+++ b/dbms/src/Columns/ColumnArray.cpp
@@ -166,7 +166,7 @@ void ColumnArray::insertData(const char * pos, size_t length)
     if (pos != end)
         throw Exception("Incorrect length argument for method ColumnArray::insertData", ErrorCodes::BAD_ARGUMENTS);
 
-    getOffsets().push_back((getOffsets().size() == 0 ? 0 : getOffsets().back()) + elems);
+    getOffsets().push_back(getOffsets().back() + elems);
 }
 
 
@@ -194,7 +194,7 @@ const char * ColumnArray::deserializeAndInsertFromArena(const char * pos)
     for (size_t i = 0; i < array_size; ++i)
         pos = getData().deserializeAndInsertFromArena(pos);
 
-    getOffsets().push_back((getOffsets().size() == 0 ? 0 : getOffsets().back()) + array_size);
+    getOffsets().push_back(getOffsets().back() + array_size);
     return pos;
 }
 
@@ -216,7 +216,7 @@ void ColumnArray::insert(const Field & x)
     size_t size = array.size();
     for (size_t i = 0; i < size; ++i)
         getData().insert(array[i]);
-    getOffsets().push_back((getOffsets().size() == 0 ? 0 : getOffsets().back()) + size);
+    getOffsets().push_back(getOffsets().back() + size);
 }
 
 
@@ -227,13 +227,13 @@ void ColumnArray::insertFrom(const IColumn & src_, size_t n)
     size_t offset = src.offsetAt(n);
 
     getData().insertRangeFrom(src.getData(), offset, size);
-    getOffsets().push_back((getOffsets().size() == 0 ? 0 : getOffsets().back()) + size);
+    getOffsets().push_back(getOffsets().back() + size);
 }
 
 
 void ColumnArray::insertDefault()
 {
-    getOffsets().push_back(getOffsets().size() == 0 ? 0 : getOffsets().back());
+    getOffsets().push_back(getOffsets().back());
 }
 
 

--- a/dbms/src/Columns/ColumnArray.h
+++ b/dbms/src/Columns/ColumnArray.h
@@ -124,8 +124,8 @@ private:
     ColumnPtr data;
     ColumnPtr offsets;
 
-    size_t ALWAYS_INLINE offsetAt(size_t i) const { return i == 0 ? 0 : getOffsets()[i - 1]; }
-    size_t ALWAYS_INLINE sizeAt(size_t i) const { return i == 0 ? getOffsets()[0] : (getOffsets()[i] - getOffsets()[i - 1]); }
+    size_t ALWAYS_INLINE offsetAt(size_t i) const { return getOffsets()[i - 1]; }
+    size_t ALWAYS_INLINE sizeAt(size_t i) const { return getOffsets()[i] - getOffsets()[i - 1]; }
 
 
     /// Multiply values if the nested column is ColumnVector<T>.

--- a/dbms/src/Columns/ColumnString.cpp
+++ b/dbms/src/Columns/ColumnString.cpp
@@ -148,7 +148,7 @@ ColumnPtr ColumnString::permute(const Permutation & perm, size_t limit) const
     for (size_t i = 0; i < limit; ++i)
     {
         size_t j = perm[i];
-        size_t string_offset = j == 0 ? 0 : offsets[j - 1];
+        size_t string_offset = offsets[j - 1];
         size_t string_size = offsets[j] - string_offset;
 
         memcpySmallAllowReadWriteOverflow15(&res_chars[current_new_offset], &chars[string_offset], string_size);
@@ -219,7 +219,7 @@ ColumnPtr ColumnString::indexImpl(const PaddedPODArray<Type> & indexes, size_t l
     for (size_t i = 0; i < limit; ++i)
     {
         size_t j = indexes[i];
-        size_t string_offset = j == 0 ? 0 : offsets[j - 1];
+        size_t string_offset = offsets[j - 1];
         size_t string_size = offsets[j] - string_offset;
 
         memcpySmallAllowReadWriteOverflow15(&res_chars[current_new_offset], &chars[string_offset], string_size);

--- a/dbms/src/Columns/ColumnString.h
+++ b/dbms/src/Columns/ColumnString.h
@@ -31,10 +31,10 @@ private:
     /// For convenience, every string ends with terminating zero byte. Note that strings could contain zero bytes in the middle.
     Chars chars;
 
-    size_t ALWAYS_INLINE offsetAt(size_t i) const { return i == 0 ? 0 : offsets[i - 1]; }
+    size_t ALWAYS_INLINE offsetAt(size_t i) const { return offsets[i - 1]; }
 
     /// Size of i-th element, including terminating zero.
-    size_t ALWAYS_INLINE sizeAt(size_t i) const { return i == 0 ? offsets[0] : (offsets[i] - offsets[i - 1]); }
+    size_t ALWAYS_INLINE sizeAt(size_t i) const { return offsets[i] - offsets[i - 1]; }
 
     template <bool positive>
     struct less;
@@ -203,7 +203,7 @@ public:
     void insertDefault() override
     {
         chars.push_back(0);
-        offsets.push_back(offsets.size() == 0 ? 1 : (offsets.back() + 1));
+        offsets.push_back(offsets.back() + 1);
     }
 
     int compareAt(size_t n, size_t m, const IColumn & rhs_, int /*nan_direction_hint*/) const override

--- a/dbms/src/Columns/IColumnDummy.h
+++ b/dbms/src/Columns/IColumnDummy.h
@@ -107,7 +107,7 @@ public:
         if (s != offsets.size())
             throw Exception("Size of offsets doesn't match size of column.", ErrorCodes::SIZES_OF_COLUMNS_DOESNT_MATCH);
 
-        return cloneDummy(s == 0 ? 0 : offsets.back());
+        return cloneDummy(offsets.back());
     }
 
     MutableColumns scatter(ColumnIndex num_columns, const Selector & selector) const override

--- a/dbms/src/Common/PODArray.cpp
+++ b/dbms/src/Common/PODArray.cpp
@@ -1,0 +1,8 @@
+#include <Common/PODArray.h>
+
+namespace DB
+{
+/// Used for left padding of PODArray when empty
+const char EmptyPODArray[EmptyPODArraySize]{};
+
+}

--- a/dbms/src/Common/PODArray.h
+++ b/dbms/src/Common/PODArray.h
@@ -95,7 +95,7 @@ protected:
         c_start = c_end = reinterpret_cast<char *>(TAllocator::alloc(bytes, std::forward<TAllocatorParams>(allocator_params)...)) + pad_left;
         c_end_of_storage = c_start + bytes - pad_right - pad_left;
         if (pad_left)
-            *(t_start() - 1) = {};
+            t_start()[-1] = {};
     }
 
     void dealloc()

--- a/dbms/src/Common/PODArray.h
+++ b/dbms/src/Common/PODArray.h
@@ -51,15 +51,19 @@ namespace DB
   */
 static constexpr size_t EmptyPODArraySize = 1024;
 extern const char EmptyPODArray[EmptyPODArraySize];
+
 template <typename T, size_t INITIAL_SIZE = 4096, typename TAllocator = Allocator<false>, size_t pad_right_ = 0, size_t pad_left_ = 0>
 class PODArray : private boost::noncopyable, private TAllocator    /// empty base optimization
 {
 protected:
     /// Round padding up to an whole number of elements to simplify arithmetic.
     static constexpr size_t pad_right = (pad_right_ + sizeof(T) - 1) / sizeof(T) * sizeof(T);
+    
     static constexpr size_t pad_left_unaligned = (pad_left_ + sizeof(T) - 1) / sizeof(T) * sizeof(T);
-    static constexpr size_t pad_left = pad_left_unaligned ? pad_left_unaligned + 15 - (pad_left_unaligned - 1) % 16 : 0;
+    static constexpr size_t pad_left = pad_left_unaligned ? (pad_left_unaligned + 15) / 16 * 16 : 0;
+
     static constexpr char * null = pad_left ? const_cast<char *>(EmptyPODArray) + EmptyPODArraySize : nullptr;
+
     static_assert(pad_left <= EmptyPODArraySize && "Left Padding exceeds EmptyPODArraySize. Element size too large?");
 
     char * c_start          = null;    /// Does not include pad_left.

--- a/dbms/src/Common/PODArray.h
+++ b/dbms/src/Common/PODArray.h
@@ -123,7 +123,7 @@ protected:
         c_end = c_start + end_diff;
         c_end_of_storage = c_start + bytes - pad_right - pad_left;
         if (pad_left)
-            *(t_start() - 1) = {};
+            t_start()[-1] = {};
     }
 
     bool isInitialized() const

--- a/dbms/src/DataTypes/DataTypeArray.cpp
+++ b/dbms/src/DataTypes/DataTypeArray.cpp
@@ -59,7 +59,7 @@ void DataTypeArray::serializeBinary(const IColumn & column, size_t row_num, Writ
     const ColumnArray & column_array = static_cast<const ColumnArray &>(column);
     const ColumnArray::Offsets & offsets = column_array.getOffsets();
 
-    size_t offset = row_num == 0 ? 0 : offsets[row_num - 1];
+    size_t offset = offsets[row_num - 1];
     size_t next_offset = offsets[row_num];
     size_t size = next_offset - offset;
 
@@ -113,7 +113,7 @@ namespace
             ? offset + limit
             : size;
 
-        ColumnArray::Offset prev_offset = offset == 0 ? 0 : offset_values[offset - 1];
+        ColumnArray::Offset prev_offset = offset_values[offset - 1];
         for (size_t i = offset; i < end; ++i)
         {
             ColumnArray::Offset current_offset = offset_values[i];
@@ -280,7 +280,7 @@ static void serializeTextImpl(const IColumn & column, size_t row_num, WriteBuffe
     const ColumnArray & column_array = static_cast<const ColumnArray &>(column);
     const ColumnArray::Offsets & offsets = column_array.getOffsets();
 
-    size_t offset = row_num == 0 ? 0 : offsets[row_num - 1];
+    size_t offset = offsets[row_num - 1];
     size_t next_offset = offsets[row_num];
 
     const IColumn & nested_column = column_array.getData();
@@ -369,7 +369,7 @@ void DataTypeArray::serializeTextJSON(const IColumn & column, size_t row_num, Wr
     const ColumnArray & column_array = static_cast<const ColumnArray &>(column);
     const ColumnArray::Offsets & offsets = column_array.getOffsets();
 
-    size_t offset = row_num == 0 ? 0 : offsets[row_num - 1];
+    size_t offset = offsets[row_num - 1];
     size_t next_offset = offsets[row_num];
 
     const IColumn & nested_column = column_array.getData();
@@ -396,7 +396,7 @@ void DataTypeArray::serializeTextXML(const IColumn & column, size_t row_num, Wri
     const ColumnArray & column_array = static_cast<const ColumnArray &>(column);
     const ColumnArray::Offsets & offsets = column_array.getOffsets();
 
-    size_t offset = row_num == 0 ? 0 : offsets[row_num - 1];
+    size_t offset = offsets[row_num - 1];
     size_t next_offset = offsets[row_num];
 
     const IColumn & nested_column = column_array.getData();

--- a/dbms/src/Functions/arrayReverse.cpp
+++ b/dbms/src/Functions/arrayReverse.cpp
@@ -225,7 +225,7 @@ bool FunctionArrayReverse::executeString(const IColumn & src_data, const ColumnA
                 {
                     size_t j_reversed = array_size - j - 1;
 
-                    auto src_pos = src_array_prev_offset + j_reversed == 0 ? 0 : src_string_offsets[src_array_prev_offset + j_reversed - 1];
+                    auto src_pos = src_string_offsets[src_array_prev_offset + j_reversed - 1];
                     size_t string_size = src_string_offsets[src_array_prev_offset + j_reversed] - src_pos;
 
                     memcpySmallAllowReadWriteOverflow15(&res_chars[res_string_prev_offset], &src_data[src_pos], string_size);

--- a/dbms/src/Interpreters/Aggregator.h
+++ b/dbms/src/Interpreters/Aggregator.h
@@ -271,7 +271,7 @@ struct AggregationMethodString
             Arena & /*pool*/) const
         {
             return StringRef(
-                &(*chars)[i == 0 ? 0 : (*offsets)[i - 1]],
+                &(*chars)[(*offsets)[i - 1]],
                 (i == 0 ? (*offsets)[i] : ((*offsets)[i] - (*offsets)[i - 1])) - 1);
         }
     };

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -75,7 +75,7 @@ struct JoinKeyGetterString
         const Sizes &) const
     {
         return StringRef(
-            &(*chars)[i == 0 ? 0 : (*offsets)[i - 1]],
+            &(*chars)[(*offsets)[i - 1]],
             (i == 0 ? (*offsets)[i] : ((*offsets)[i] - (*offsets)[i - 1])) - 1);
     }
 

--- a/dbms/src/Interpreters/SetVariants.h
+++ b/dbms/src/Interpreters/SetVariants.h
@@ -86,7 +86,7 @@ struct SetMethodString
             const Sizes &) const
         {
             return StringRef(
-                &(*chars)[i == 0 ? 0 : (*offsets)[i - 1]],
+                &(*chars)[(*offsets)[i - 1]],
                 (i == 0 ? (*offsets)[i] : ((*offsets)[i] - (*offsets)[i - 1])) - 1);
         }
     };

--- a/dbms/tests/performance/leftpad/leftpad.xml
+++ b/dbms/tests/performance/leftpad/leftpad.xml
@@ -1,0 +1,37 @@
+<test>
+    <name>left pad test</name>
+
+    <tags>
+        <tag>string</tag>
+    </tags>
+
+    <preconditions>
+        <table_exists>hashfile</table_exists>
+    </preconditions>
+
+    <type>loop</type>
+
+    <stop_conditions>
+        <all_of>
+            <iterations>5</iterations>
+            <min_time_not_changing_for_ms>10000</min_time_not_changing_for_ms>
+        </all_of>
+        <any_of>
+            <iterations>50</iterations>
+            <total_time_ms>60000</total_time_ms>
+        </any_of>
+    </stop_conditions>
+
+    <main_metric>
+        <min_time/>
+    </main_metric>
+
+    <query><![CDATA[SELECT max(length(MobilePhoneModel)) FROM hashfile]]></query>
+    <query><![CDATA[SELECT max(length(Params)) FROM hashfile]]></query>
+    <query><![CDATA[SELECT max(length(Title)) FROM hashfile]]></query>
+    <query><![CDATA[SELECT max(length(URLDomain)) FROM hashfile]]></query>
+    <query><![CDATA[SELECT max(length(PageCharset)) FROM hashfile]]></query>
+    <query><![CDATA[SELECT max(length(Referer)) FROM hashfile]]></query>
+    <query><![CDATA[SELECT max(length(URL)) FROM hashfile]]></query>
+    <query><![CDATA[SELECT max(length(UTMSource)) FROM hashfile]]></query>
+</test>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Performance Improvement

Short description (up to few sentences):

Zero left padding PODArray so that -1 element is always valid and zeroed. It's used for branchless Offset access.


simple tests show 1%-5% improvements

Before padding
```
Running: left pad test
[
{
    "hostname": "201.nobida.cn",
    "main_metric": "min_time",
    "num_cores": 20,
    "num_threads": 40,
    "ram": 134768111616,
    "runs": [
        {
            "min_time": 0.086000,
            "query": "SELECT max(length(MobilePhoneModel)) FROM hashfile"
        },
        {
            "min_time": 0.102000,
            "query": "SELECT max(length(Params)) FROM hashfile"
        },
        {
            "min_time": 0.441000,
            "query": "SELECT max(length(Title)) FROM hashfile"
        },
        {
            "min_time": 0.143000,
            "query": "SELECT max(length(URLDomain)) FROM hashfile"
        },
        {
            "min_time": 0.120000,
            "query": "SELECT max(length(PageCharset)) FROM hashfile"
        },
        {
            "min_time": 0.429000,
            "query": "SELECT max(length(Referer)) FROM hashfile"
        },
        {
            "min_time": 0.504000,
            "query": "SELECT max(length(URL)) FROM hashfile"
        },
        {
            "min_time": 0.075000,
            "query": "SELECT max(length(UTMSource)) FROM hashfile"
        }
    ],
    "server_version": "18.16.0",
    "test_name": "left pad test",
    "time": "2018-12-24 22:45:10"
}
]
```

After padding

```
Running: left pad test
[
{
    "hostname": "201.nobida.cn",
    "main_metric": "min_time",
    "num_cores": 20,
    "num_threads": 40,
    "ram": 134768111616,
    "runs": [
        {
            "min_time": 0.083000,
            "query": "SELECT max(length(MobilePhoneModel)) FROM hashfile"
        },
        {
            "min_time": 0.098000,
            "query": "SELECT max(length(Params)) FROM hashfile"
        },
        {
            "min_time": 0.399000,
            "query": "SELECT max(length(Title)) FROM hashfile"
        },
        {
            "min_time": 0.139000,
            "query": "SELECT max(length(URLDomain)) FROM hashfile"
        },
        {
            "min_time": 0.116000,
            "query": "SELECT max(length(PageCharset)) FROM hashfile"
        },
        {
            "min_time": 0.424000,
            "query": "SELECT max(length(Referer)) FROM hashfile"
        },
        {
            "min_time": 0.492000,
            "query": "SELECT max(length(URL)) FROM hashfile"
        },
        {
            "min_time": 0.072000,
            "query": "SELECT max(length(UTMSource)) FROM hashfile"
        }
    ],
    "server_version": "18.16.0",
    "test_name": "left pad test",
    "time": "2018-12-24 22:47:23"
}
]
```