### PR TITLE
Fix ZooKeeperNodeCache becoming unusable after SessionExpired event

### DIFF
--- a/dbms/src/Common/ZooKeeper/ZooKeeperNodeCache.h
+++ b/dbms/src/Common/ZooKeeper/ZooKeeperNodeCache.h
@@ -53,8 +53,8 @@ private:
     struct Context
     {
         std::mutex mutex;
-        zkutil::ZooKeeperPtr zookeeper;
         std::unordered_set<std::string> invalidated_paths;
+        bool all_paths_invalidated = false;
     };
 
     std::shared_ptr<Context> context;


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):

Fix a bug that led to hangups in threads that perform ALTERs of Replicated tables and in the thread that updates configuration from ZooKeeper. #2947 #3891 

Detailed description (optional):

Previously after a SessionExpired event the context->zookeeper field in the ZooKeeperNodeCache 
class was reinitialized with the old expired ZooKeeper instance. This led to inability
to get new paths. Better not cache the ZooKeeper instance and get it at the
start of each request.
