### PR TITLE
CLICKHOUSE-4229: Fix user forwarding for replicated queries

### DIFF
--- a/dbms/src/Interpreters/InterpreterDropQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterDropQuery.cpp
@@ -80,7 +80,7 @@ BlockIO InterpreterDropQuery::executeToTable(String & database_name_, String & t
             /// If table was already dropped by anyone, an exception will be thrown
             auto table_lock = database_and_table.second->lockForAlter();
             /// Drop table data, don't touch metadata
-            database_and_table.second->truncate(query_ptr);
+            database_and_table.second->truncate(query_ptr, context);
         }
         else if (kind == ASTDropQuery::Kind::Drop)
         {
@@ -128,7 +128,7 @@ BlockIO InterpreterDropQuery::executeToTemporaryTable(String & table_name, ASTDr
                 /// If table was already dropped by anyone, an exception will be thrown
                 auto table_lock = table->lockForAlter();
                 /// Drop table data, don't touch metadata
-                table->truncate(query_ptr);
+                table->truncate(query_ptr, context);
             }
             else if (kind == ASTDropQuery::Kind::Drop)
             {

--- a/dbms/src/Storages/IStorage.h
+++ b/dbms/src/Storages/IStorage.h
@@ -214,7 +214,7 @@ public:
     /** Clear the table data and leave it empty.
       * Must be called under lockForAlter.
       */
-    virtual void truncate(const ASTPtr & /*query*/)
+    virtual void truncate(const ASTPtr & /*query*/, const Context & /* context */)
     {
         throw Exception("Truncate is not supported by storage " + getName(), ErrorCodes::NOT_IMPLEMENTED);
     }

--- a/dbms/src/Storages/StorageDistributed.cpp
+++ b/dbms/src/Storages/StorageDistributed.cpp
@@ -360,7 +360,7 @@ void StorageDistributed::shutdown()
 }
 
 
-void StorageDistributed::truncate(const ASTPtr &)
+void StorageDistributed::truncate(const ASTPtr &, const Context &)
 {
     std::lock_guard lock(cluster_nodes_mutex);
 

--- a/dbms/src/Storages/StorageDistributed.h
+++ b/dbms/src/Storages/StorageDistributed.h
@@ -76,7 +76,7 @@ public:
     void drop() override {}
 
     /// Removes temporary data in local filesystem.
-    void truncate(const ASTPtr &) override;
+    void truncate(const ASTPtr &, const Context &) override;
 
     void rename(const String & /*new_path_to_db*/, const String & /*new_database_name*/, const String & new_table_name) override { table_name = new_table_name; }
     /// in the sub-tables, you need to manually add and delete columns

--- a/dbms/src/Storages/StorageJoin.cpp
+++ b/dbms/src/Storages/StorageJoin.cpp
@@ -51,7 +51,7 @@ StorageJoin::StorageJoin(
 }
 
 
-void StorageJoin::truncate(const ASTPtr &)
+void StorageJoin::truncate(const ASTPtr &, const Context &)
 {
     Poco::File(path).remove(true);
     Poco::File(path).createDirectories();

--- a/dbms/src/Storages/StorageJoin.h
+++ b/dbms/src/Storages/StorageJoin.h
@@ -25,7 +25,7 @@ class StorageJoin : public ext::shared_ptr_helper<StorageJoin>, public StorageSe
 public:
     String getName() const override { return "Join"; }
 
-    void truncate(const ASTPtr &) override;
+    void truncate(const ASTPtr &, const Context &) override;
 
     /// Access the innards.
     JoinPtr & getJoin() { return join; }

--- a/dbms/src/Storages/StorageLog.cpp
+++ b/dbms/src/Storages/StorageLog.cpp
@@ -520,7 +520,7 @@ void StorageLog::rename(const String & new_path_to_db, const String & /*new_data
     marks_file = Poco::File(path + escapeForFileName(name) + '/' + DBMS_STORAGE_LOG_MARKS_FILE_NAME);
 }
 
-void StorageLog::truncate(const ASTPtr &)
+void StorageLog::truncate(const ASTPtr &, const Context &)
 {
     std::shared_lock<std::shared_mutex> lock(rwlock);
 

--- a/dbms/src/Storages/StorageLog.h
+++ b/dbms/src/Storages/StorageLog.h
@@ -40,7 +40,7 @@ public:
 
     bool checkData() const override;
 
-    void truncate(const ASTPtr &) override;
+    void truncate(const ASTPtr &, const Context &) override;
 
     std::string full_path() const { return path + escapeForFileName(name) + '/';}
 

--- a/dbms/src/Storages/StorageMaterializedView.cpp
+++ b/dbms/src/Storages/StorageMaterializedView.cpp
@@ -229,7 +229,7 @@ void StorageMaterializedView::drop()
         executeDropQuery(ASTDropQuery::Kind::Drop, global_context, target_database_name, target_table_name);
 }
 
-void StorageMaterializedView::truncate(const ASTPtr &)
+void StorageMaterializedView::truncate(const ASTPtr &, const Context &)
 {
     if (has_inner_table)
         executeDropQuery(ASTDropQuery::Kind::Truncate, global_context, target_database_name, target_table_name);

--- a/dbms/src/Storages/StorageMaterializedView.h
+++ b/dbms/src/Storages/StorageMaterializedView.h
@@ -31,7 +31,7 @@ public:
     BlockOutputStreamPtr write(const ASTPtr & query, const Settings & settings) override;
     void drop() override;
 
-    void truncate(const ASTPtr &) override;
+    void truncate(const ASTPtr &, const Context &) override;
 
     bool optimize(const ASTPtr & query, const ASTPtr & partition, bool final, bool deduplicate, const Context & context) override;
 

--- a/dbms/src/Storages/StorageMemory.cpp
+++ b/dbms/src/Storages/StorageMemory.cpp
@@ -127,7 +127,7 @@ void StorageMemory::drop()
     data.clear();
 }
 
-void StorageMemory::truncate(const ASTPtr &)
+void StorageMemory::truncate(const ASTPtr &, const Context &)
 {
     std::lock_guard<std::mutex> lock(mutex);
     data.clear();

--- a/dbms/src/Storages/StorageMemory.h
+++ b/dbms/src/Storages/StorageMemory.h
@@ -40,7 +40,7 @@ public:
 
     void drop() override;
 
-    void truncate(const ASTPtr &) override;
+    void truncate(const ASTPtr &, const Context &) override;
 
     void rename(const String & /*new_path_to_db*/, const String & /*new_database_name*/, const String & new_table_name) override { table_name = new_table_name; }
 

--- a/dbms/src/Storages/StorageMergeTree.cpp
+++ b/dbms/src/Storages/StorageMergeTree.cpp
@@ -157,7 +157,7 @@ void StorageMergeTree::drop()
     data.dropAllData();
 }
 
-void StorageMergeTree::truncate(const ASTPtr &)
+void StorageMergeTree::truncate(const ASTPtr &, const Context &)
 {
     {
         /// Asks to complete merges and does not allow them to start.

--- a/dbms/src/Storages/StorageMergeTree.h
+++ b/dbms/src/Storages/StorageMergeTree.h
@@ -67,7 +67,7 @@ public:
     std::vector<MergeTreeMutationStatus> getMutationsStatus() const;
 
     void drop() override;
-    void truncate(const ASTPtr &) override;
+    void truncate(const ASTPtr &, const Context &) override;
 
     void rename(const String & new_path_to_db, const String & new_database_name, const String & new_table_name) override;
 

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -2934,13 +2934,13 @@ BlockOutputStreamPtr StorageReplicatedMergeTree::write(const ASTPtr & /*query*/,
 }
 
 
-bool StorageReplicatedMergeTree::optimize(const ASTPtr & query, const ASTPtr & partition, bool final, bool deduplicate, const Context & context)
+bool StorageReplicatedMergeTree::optimize(const ASTPtr & query, const ASTPtr & partition, bool final, bool deduplicate, const Context & query_context)
 {
     assertNotReadonly();
 
     if (!is_leader)
     {
-        sendRequestToLeaderReplica(query, context.getSettingsRef());
+        sendRequestToLeaderReplica(query, query_context);
         return true;
     }
 
@@ -2955,7 +2955,7 @@ bool StorageReplicatedMergeTree::optimize(const ASTPtr & query, const ASTPtr & p
 
         auto handle_noop = [&] (const String & message)
         {
-            if (context.getSettingsRef().optimize_throw_if_noop)
+            if (query_context.getSettingsRef().optimize_throw_if_noop)
                 throw Exception(message, ErrorCodes::CANNOT_ASSIGN_OPTIMIZE);
             return false;
         };
@@ -2993,7 +2993,7 @@ bool StorageReplicatedMergeTree::optimize(const ASTPtr & query, const ASTPtr & p
             else
             {
                 UInt64 disk_space = DiskSpaceMonitor::getUnreservedFreeSpace(full_path);
-                String partition_id = data.getPartitionIDFromQuery(partition, context);
+                String partition_id = data.getPartitionIDFromQuery(partition, query_context);
                 selected = merger_mutator.selectAllPartsToMergeWithinPartition(
                     future_merged_part, disk_space, can_merge, partition_id, final, &disable_reason);
             }
@@ -3010,7 +3010,7 @@ bool StorageReplicatedMergeTree::optimize(const ASTPtr & query, const ASTPtr & p
     }
 
     /// TODO: Bad setting name for such purpose
-    if (context.getSettingsRef().replication_alter_partitions_sync != 0)
+    if (query_context.getSettingsRef().replication_alter_partitions_sync != 0)
         waitForAllReplicasToProcessLogEntry(merge_entry);
 
     return true;
@@ -3018,7 +3018,7 @@ bool StorageReplicatedMergeTree::optimize(const ASTPtr & query, const ASTPtr & p
 
 
 void StorageReplicatedMergeTree::alter(const AlterCommands & params,
-    const String & /*database_name*/, const String & /*table_name*/, const Context & context)
+    const String & /*database_name*/, const String & /*table_name*/, const Context & query_context)
 {
     assertNotReadonly();
 
@@ -3113,7 +3113,7 @@ void StorageReplicatedMergeTree::alter(const AlterCommands & params,
     std::set<String> inactive_replicas;
     std::set<String> timed_out_replicas;
 
-    time_t replication_alter_columns_timeout = context.getSettingsRef().replication_alter_columns_timeout;
+    time_t replication_alter_columns_timeout = query_context.getSettingsRef().replication_alter_columns_timeout;
 
     for (const String & replica : replicas)
     {
@@ -3277,7 +3277,7 @@ void StorageReplicatedMergeTree::alter(const AlterCommands & params,
     LOG_DEBUG(log, "ALTER finished");
 }
 
-void StorageReplicatedMergeTree::alterPartition(const ASTPtr & query, const PartitionCommands & commands, const Context & context)
+void StorageReplicatedMergeTree::alterPartition(const ASTPtr & query, const PartitionCommands & commands, const Context & query_context)
 {
     for (const PartitionCommand & command : commands)
     {
@@ -3285,46 +3285,46 @@ void StorageReplicatedMergeTree::alterPartition(const ASTPtr & query, const Part
         {
             case PartitionCommand::DROP_PARTITION:
                 checkPartitionCanBeDropped(command.partition);
-                dropPartition(query, command.partition, command.detach, context);
+                dropPartition(query, command.partition, command.detach, query_context);
                 break;
 
             case PartitionCommand::ATTACH_PARTITION:
-                attachPartition(command.partition, command.part, context);
+                attachPartition(command.partition, command.part, query_context);
                 break;
 
             case PartitionCommand::REPLACE_PARTITION:
             {
                 checkPartitionCanBeDropped(command.partition);
-                String from_database = command.from_database.empty() ? context.getCurrentDatabase() : command.from_database;
-                auto from_storage = context.getTable(from_database, command.from_table);
-                replacePartitionFrom(from_storage, command.partition, command.replace, context);
+                String from_database = command.from_database.empty() ? query_context.getCurrentDatabase() : command.from_database;
+                auto from_storage = query_context.getTable(from_database, command.from_table);
+                replacePartitionFrom(from_storage, command.partition, command.replace, query_context);
             }
             break;
 
             case PartitionCommand::FETCH_PARTITION:
-                fetchPartition(command.partition, command.from_zookeeper_path, context);
+                fetchPartition(command.partition, command.from_zookeeper_path, query_context);
                 break;
 
             case PartitionCommand::FREEZE_PARTITION:
             {
                 auto lock = lockStructure(false);
-                data.freezePartition(command.partition, command.with_name, context);
+                data.freezePartition(command.partition, command.with_name, query_context);
             }
             break;
 
             case PartitionCommand::CLEAR_COLUMN:
-                clearColumnInPartition(command.partition, command.column_name, context);
+                clearColumnInPartition(command.partition, command.column_name, query_context);
                 break;
 
             case PartitionCommand::FREEZE_ALL_PARTITIONS:
             {
                 auto lock = lockStructure(false);
-                data.freezeAll(command.with_name, context);
+                data.freezeAll(command.with_name, query_context);
             }
             break;
 
             default:
-                IStorage::alterPartition(query, commands, context); // should throw an exception.
+                IStorage::alterPartition(query, commands, query_context); // should throw an exception.
         }
     }
 }
@@ -3382,13 +3382,13 @@ bool StorageReplicatedMergeTree::getFakePartCoveringAllPartsInPartition(const St
 
 
 void StorageReplicatedMergeTree::clearColumnInPartition(
-    const ASTPtr & partition, const Field & column_name, const Context & context)
+    const ASTPtr & partition, const Field & column_name, const Context & query_context)
 {
     assertNotReadonly();
 
     /// We don't block merges, so anyone can manage this task (not only leader)
 
-    String partition_id = data.getPartitionIDFromQuery(partition, context);
+    String partition_id = data.getPartitionIDFromQuery(partition, query_context);
     MergeTreePartInfo drop_range_info;
 
     if (!getFakePartCoveringAllPartsInPartition(partition_id, drop_range_info))
@@ -3409,9 +3409,9 @@ void StorageReplicatedMergeTree::clearColumnInPartition(
     entry.znode_name = log_znode_path.substr(log_znode_path.find_last_of('/') + 1);
 
     /// If necessary, wait until the operation is performed on itself or on all replicas.
-    if (context.getSettingsRef().replication_alter_partitions_sync != 0)
+    if (query_context.getSettingsRef().replication_alter_partitions_sync != 0)
     {
-        if (context.getSettingsRef().replication_alter_partitions_sync == 1)
+        if (query_context.getSettingsRef().replication_alter_partitions_sync == 1)
             waitForReplicaToProcessLogEntry(replica_name, entry);
         else
             waitForAllReplicasToProcessLogEntry(entry);
@@ -3419,7 +3419,7 @@ void StorageReplicatedMergeTree::clearColumnInPartition(
 }
 
 
-void StorageReplicatedMergeTree::dropPartition(const ASTPtr & query, const ASTPtr & partition, bool detach, const Context & context)
+void StorageReplicatedMergeTree::dropPartition(const ASTPtr & query, const ASTPtr & partition, bool detach, const Context & query_context)
 {
     assertNotReadonly();
 
@@ -3429,19 +3429,19 @@ void StorageReplicatedMergeTree::dropPartition(const ASTPtr & query, const ASTPt
     {
         // TODO: we can manually reconstruct the query from outside the |dropPartition()| and remove the |query| argument from interface.
         //       It's the only place where we need this argument.
-        sendRequestToLeaderReplica(query, context.getSettingsRef());
+        sendRequestToLeaderReplica(query, query_context);
         return;
     }
 
-    String partition_id = data.getPartitionIDFromQuery(partition, context);
+    String partition_id = data.getPartitionIDFromQuery(partition, query_context);
 
     LogEntry entry;
     if (dropPartsInPartition(*zookeeper, partition_id, entry, detach))
     {
         /// If necessary, wait until the operation is performed on itself or on all replicas.
-        if (context.getSettingsRef().replication_alter_partitions_sync != 0)
+        if (query_context.getSettingsRef().replication_alter_partitions_sync != 0)
         {
-            if (context.getSettingsRef().replication_alter_partitions_sync == 1)
+            if (query_context.getSettingsRef().replication_alter_partitions_sync == 1)
                 waitForReplicaToProcessLogEntry(replica_name, entry);
             else
                 waitForAllReplicasToProcessLogEntry(entry);
@@ -3450,7 +3450,7 @@ void StorageReplicatedMergeTree::dropPartition(const ASTPtr & query, const ASTPt
 }
 
 
-void StorageReplicatedMergeTree::truncate(const ASTPtr & query)
+void StorageReplicatedMergeTree::truncate(const ASTPtr & query, const Context & query_context)
 {
     assertNotReadonly();
 
@@ -3458,7 +3458,7 @@ void StorageReplicatedMergeTree::truncate(const ASTPtr & query)
 
     if (!is_leader)
     {
-        sendRequestToLeaderReplica(query, context.getSettingsRef());
+        sendRequestToLeaderReplica(query, query_context);
         return;
     }
 
@@ -3474,7 +3474,7 @@ void StorageReplicatedMergeTree::truncate(const ASTPtr & query)
 }
 
 
-void StorageReplicatedMergeTree::attachPartition(const ASTPtr & partition, bool attach_part, const Context & context)
+void StorageReplicatedMergeTree::attachPartition(const ASTPtr & partition, bool attach_part, const Context & query_context)
 {
     // TODO: should get some locks to prevent race with 'alter … modify column'
 
@@ -3485,7 +3485,7 @@ void StorageReplicatedMergeTree::attachPartition(const ASTPtr & partition, bool 
     if (attach_part)
         partition_id = typeid_cast<const ASTLiteral &>(*partition).value.safeGet<String>();
     else
-        partition_id = data.getPartitionIDFromQuery(partition, context);
+        partition_id = data.getPartitionIDFromQuery(partition, query_context);
 
     String source_dir = "detached/";
 
@@ -3886,7 +3886,7 @@ void StorageReplicatedMergeTree::getStatus(Status & res, bool with_zk_fields)
 
 
 /// TODO: Probably it is better to have queue in ZK with tasks for leader (like DDL)
-void StorageReplicatedMergeTree::sendRequestToLeaderReplica(const ASTPtr & query, const Settings & settings)
+void StorageReplicatedMergeTree::sendRequestToLeaderReplica(const ASTPtr & query, const Context & query_context)
 {
     auto live_replicas = getZooKeeper()->getChildren(zookeeper_path + "/leader_election");
     if (live_replicas.empty())
@@ -3923,15 +3923,19 @@ void StorageReplicatedMergeTree::sendRequestToLeaderReplica(const ASTPtr & query
     /// Query send with current user credentials
 
     auto timeouts = ConnectionTimeouts::getTCPTimeoutsWithoutFailover(context.getSettingsRef());
+
+    const auto & query_settings = query_context.getSettingsRef();
+    const auto & query_client_info = query_context.getClientInfo();
+
     Connection connection(
         leader_address.host,
         leader_address.queries_port,
         leader_address.database,
-        context.getClientInfo().current_user, context.getClientInfo().current_password, timeouts, "ClickHouse replica");
+        query_client_info.current_user, query_client_info.current_password, timeouts, "ClickHouse replica");
 
     std::stringstream new_query_ss;
     formatAST(*new_query, new_query_ss, false, true);
-    RemoteBlockInputStream stream(connection, new_query_ss.str(), {}, context, &settings);
+    RemoteBlockInputStream stream(connection, new_query_ss.str(), {}, context, &query_settings);
     NullBlockOutputStream output({});
 
     copyData(stream, output);
@@ -4052,9 +4056,9 @@ void StorageReplicatedMergeTree::getReplicaDelays(time_t & out_absolute_delay, t
 }
 
 
-void StorageReplicatedMergeTree::fetchPartition(const ASTPtr & partition, const String & from_, const Context & context)
+void StorageReplicatedMergeTree::fetchPartition(const ASTPtr & partition, const String & from_, const Context & query_context)
 {
-    String partition_id = data.getPartitionIDFromQuery(partition, context);
+    String partition_id = data.getPartitionIDFromQuery(partition, query_context);
 
     String from = from_;
     if (from.back() == '/')
@@ -4146,7 +4150,7 @@ void StorageReplicatedMergeTree::fetchPartition(const ASTPtr & partition, const 
         if (try_no)
             LOG_INFO(log, "Some of parts (" << missing_parts.size() << ") are missing. Will try to fetch covering parts.");
 
-        if (try_no >= context.getSettings().max_fetch_partition_retries_count)
+        if (try_no >= query_context.getSettings().max_fetch_partition_retries_count)
             throw Exception("Too many retries to fetch parts from " + best_replica_path, ErrorCodes::TOO_MANY_RETRIES_TO_FETCH_PARTS);
 
         Strings parts = getZooKeeper()->getChildren(best_replica_path + "/parts");

--- a/dbms/src/Storages/StorageReplicatedMergeTree.h
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.h
@@ -113,11 +113,11 @@ public:
 
     BlockOutputStreamPtr write(const ASTPtr & query, const Settings & settings) override;
 
-    bool optimize(const ASTPtr & query, const ASTPtr & partition, bool final, bool deduplicate, const Context & context) override;
+    bool optimize(const ASTPtr & query, const ASTPtr & partition, bool final, bool deduplicate, const Context & query_context) override;
 
-    void alter(const AlterCommands & params, const String & database_name, const String & table_name, const Context & context) override;
+    void alter(const AlterCommands & params, const String & database_name, const String & table_name, const Context & query_context) override;
 
-    void alterPartition(const ASTPtr & query, const PartitionCommands & commands, const Context & context) override;
+    void alterPartition(const ASTPtr & query, const PartitionCommands & commands, const Context & query_context) override;
 
     void mutate(const MutationCommands & commands, const Context & context) override;
 
@@ -127,7 +127,7 @@ public:
       */
     void drop() override;
 
-    void truncate(const ASTPtr &) override;
+    void truncate(const ASTPtr &, const Context &) override;
 
     void rename(const String & new_path_to_db, const String & new_database_name, const String & new_table_name) override;
 
@@ -502,7 +502,7 @@ private:
     void waitForReplicaToProcessLogEntry(const String & replica_name, const ReplicatedMergeTreeLogEntryData & entry);
 
     /// Choose leader replica, send requst to it and wait.
-    void sendRequestToLeaderReplica(const ASTPtr & query, const Settings & settings);
+    void sendRequestToLeaderReplica(const ASTPtr & query, const Context & query_context);
 
     /// Throw an exception if the table is readonly.
     void assertNotReadonly() const;
@@ -527,11 +527,11 @@ private:
         StorageReplicatedMergeTree::LogEntry & entry, bool detach);
 
     // Partition helpers
-    void clearColumnInPartition(const ASTPtr & partition, const Field & column_name, const Context & context);
-    void dropPartition(const ASTPtr & query, const ASTPtr & partition, bool detach, const Context & context);
-    void attachPartition(const ASTPtr & partition, bool part, const Context & context);
-    void replacePartitionFrom(const StoragePtr & source_table, const ASTPtr & partition, bool replace, const Context & context);
-    void fetchPartition(const ASTPtr & partition, const String & from, const Context & context);
+    void clearColumnInPartition(const ASTPtr & partition, const Field & column_name, const Context & query_context);
+    void dropPartition(const ASTPtr & query, const ASTPtr & partition, bool detach, const Context & query_context);
+    void attachPartition(const ASTPtr & partition, bool part, const Context & query_context);
+    void replacePartitionFrom(const StoragePtr & source_table, const ASTPtr & partition, bool replace, const Context & query_context);
+    void fetchPartition(const ASTPtr & partition, const String & from, const Context & query_context);
 
 protected:
     /** If not 'attach', either creates a new table in ZK, or adds a replica to an existing table.

--- a/dbms/src/Storages/StorageSet.cpp
+++ b/dbms/src/Storages/StorageSet.cpp
@@ -119,7 +119,7 @@ void StorageSet::insertBlock(const Block & block) { set->insertFromBlock(block);
 size_t StorageSet::getSize() const { return set->getTotalRowCount(); }
 
 
-void StorageSet::truncate(const ASTPtr &)
+void StorageSet::truncate(const ASTPtr &, const Context &)
 {
     Poco::File(path).remove(true);
     Poco::File(path).createDirectories();

--- a/dbms/src/Storages/StorageSet.h
+++ b/dbms/src/Storages/StorageSet.h
@@ -65,7 +65,7 @@ public:
     /// Access the insides.
     SetPtr & getSet() { return set; }
 
-    void truncate(const ASTPtr &) override;
+    void truncate(const ASTPtr &, const Context &) override;
 
 private:
     SetPtr set;

--- a/dbms/src/Storages/StorageStripeLog.cpp
+++ b/dbms/src/Storages/StorageStripeLog.cpp
@@ -288,7 +288,7 @@ bool StorageStripeLog::checkData() const
     return file_checker.check();
 }
 
-void StorageStripeLog::truncate(const ASTPtr &)
+void StorageStripeLog::truncate(const ASTPtr &, const Context &)
 {
     if (name.empty())
         throw Exception("Logical error: table name is empty", ErrorCodes::LOGICAL_ERROR);

--- a/dbms/src/Storages/StorageStripeLog.h
+++ b/dbms/src/Storages/StorageStripeLog.h
@@ -53,7 +53,7 @@ public:
 
     String getDataPath() const override { return full_path(); }
 
-    void truncate(const ASTPtr &) override;
+    void truncate(const ASTPtr &, const Context &) override;
 
 private:
     String path;

--- a/dbms/src/Storages/StorageTinyLog.cpp
+++ b/dbms/src/Storages/StorageTinyLog.cpp
@@ -407,7 +407,7 @@ bool StorageTinyLog::checkData() const
     return file_checker.check();
 }
 
-void StorageTinyLog::truncate(const ASTPtr &)
+void StorageTinyLog::truncate(const ASTPtr &, const Context &)
 {
     if (name.empty())
         throw Exception("Logical error: table name is empty", ErrorCodes::LOGICAL_ERROR);

--- a/dbms/src/Storages/StorageTinyLog.h
+++ b/dbms/src/Storages/StorageTinyLog.h
@@ -52,7 +52,7 @@ public:
 
     String getDataPath() const override { return full_path(); }
 
-    void truncate(const ASTPtr &) override;
+    void truncate(const ASTPtr &, const Context &) override;
 
 private:
     String path;

--- a/dbms/tests/integration/helpers/test_tools.py
+++ b/dbms/tests/integration/helpers/test_tools.py
@@ -28,13 +28,13 @@ def assert_eq_with_retry(instance, query, expectation, retry_count=20, sleep_tim
     expectation_tsv = TSV(expectation)
     for i in xrange(retry_count):
         try:
-            if TSV(instance.query(query)) == expectation_tsv:
+            if TSV(instance.query(query, user=user, stdin=stdin, timeout=timeout, settings=settings, ignore_error=ignore_error)) == expectation_tsv:
                 break
             time.sleep(sleep_time)
         except Exception as ex:
             print "assert_eq_with_retry retry {} exception {}".format(i + 1, ex)
             time.sleep(sleep_time)
     else:
-        val = TSV(instance.query(query))
+        val = TSV(instance.query(query, user=user, stdin=stdin, timeout=timeout, settings=settings, ignore_error=ignore_error))
         if expectation_tsv != val:
             raise AssertionError("'{}' != '{}'\n{}".format(expectation_tsv, val, '\n'.join(expectation_tsv.diff(val, n1="expectation", n2="query"))))

--- a/dbms/tests/integration/test_send_request_to_leader_replica/configs/remote_servers.xml
+++ b/dbms/tests/integration/test_send_request_to_leader_replica/configs/remote_servers.xml
@@ -1,0 +1,19 @@
+<yandex>
+    <remote_servers>
+        <test_cluster>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                    <user>awesome</user>
+                </replica>
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                    <user>awesome</user>
+                </replica>
+            </shard>
+        </test_cluster>
+    </remote_servers>
+</yandex>

--- a/dbms/tests/integration/test_send_request_to_leader_replica/configs/users_local_default.xml
+++ b/dbms/tests/integration/test_send_request_to_leader_replica/configs/users_local_default.xml
@@ -1,0 +1,39 @@
+<yandex>
+    <profiles>
+        <default>
+            <max_memory_usage>10000000000</max_memory_usage>
+            <use_uncompressed_cache>0</use_uncompressed_cache>
+            <load_balancing>random</load_balancing>
+        </default>
+        <awesome>
+            <max_memory_usage>10000000000</max_memory_usage>
+            <use_uncompressed_cache>0</use_uncompressed_cache>
+            <load_balancing>random</load_balancing>
+        </awesome>
+    </profiles>
+
+    <users>
+        <default>
+            <password></password>
+            <networks incl="networks" replace="replace">
+                <ip>127.0.0.1</ip>
+                <ip>::1</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </default>
+        <awesome>
+            <password></password>
+            <networks incl="networks" replace="replace">
+                <ip>::/0</ip>
+            </networks>
+            <profile>awesome</profile>
+            <quota>default</quota>
+        </awesome>
+    </users>
+
+    <quotas>
+        <default>
+        </default>
+    </quotas>
+</yandex>

--- a/dbms/tests/integration/test_send_request_to_leader_replica/test.py
+++ b/dbms/tests/integration/test_send_request_to_leader_replica/test.py
@@ -1,0 +1,63 @@
+import time
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml'], user_configs=['configs/users_local_default.xml'], with_zookeeper=True)
+node2 = cluster.add_instance('node2', main_configs=['configs/remote_servers.xml'], user_configs=['configs/users_local_default.xml'], with_zookeeper=True)
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+
+
+        for node in [node1, node2]:
+            node.query('''
+            CREATE TABLE sometable(date Date, id UInt32, value Int32)
+    ENGINE = ReplicatedMergeTree('/clickhouse/tables/0/sometable', '{replica}', date, id, 8192);
+                '''.format(replica=node.name), user='awesome')
+
+
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+@pytest.mark.parametrize("query,expected", [
+    ("ALTER TABLE sometable DROP PARTITION 201706", '1'),
+    ("TRUNCATE TABLE sometable", '0'),
+    ("OPTIMIZE TABLE sometable", '4'),
+])
+def test_alter_table_drop_partition(started_cluster, query, expected):
+    to_insert = '''\
+2017-06-16	111	0
+2017-06-16	222	1
+2017-06-16	333	2
+2017-07-16	444	3
+'''
+    node1.query("INSERT INTO sometable FORMAT TSV", stdin=to_insert, user='awesome')
+
+    assert_eq_with_retry(node1, "SELECT COUNT(*) from sometable", '4', user='awesome')
+    assert_eq_with_retry(node2, "SELECT COUNT(*) from sometable", '4', user='awesome')
+
+    ### It maybe leader and everything will be ok
+    node1.query(query, user='awesome')
+
+    assert_eq_with_retry(node1, "SELECT COUNT(*) from sometable", expected, user='awesome')
+    assert_eq_with_retry(node2, "SELECT COUNT(*) from sometable", expected, user='awesome')
+
+    node1.query("INSERT INTO sometable FORMAT TSV", stdin=to_insert, user='awesome')
+
+    assert_eq_with_retry(node1, "SELECT COUNT(*) from sometable", '4', user='awesome')
+    assert_eq_with_retry(node2, "SELECT COUNT(*) from sometable", '4', user='awesome')
+
+    ### If node1 is leader than node2 will be slave
+    node2.query(query, user='awesome')
+
+    assert_eq_with_retry(node1, "SELECT COUNT(*) from sometable", expected, user='awesome')
+    assert_eq_with_retry(node2, "SELECT COUNT(*) from sometable", expected, user='awesome')


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Bug Fix

Short description (up to few sentences):
 Fix user and password forwarding for replicated tables queries which actually send queries to master node