### PR TITLE
Catboost multiclass models

### DIFF
--- a/dbms/src/Functions/FunctionsExternalModels.cpp
+++ b/dbms/src/Functions/FunctionsExternalModels.cpp
@@ -10,6 +10,10 @@
 #include <ext/range.h>
 #include <string>
 #include <memory>
+#include <DataTypes/DataTypeNullable.h>
+#include <Columns/ColumnNullable.h>
+#include <Columns/ColumnTuple.h>
+#include <DataTypes/DataTypeTuple.h>
 
 namespace DB
 {
@@ -26,17 +30,43 @@ namespace ErrorCodes
     extern const int ILLEGAL_COLUMN;
 }
 
-DataTypePtr FunctionModelEvaluate::getReturnTypeImpl(const DataTypes & arguments) const
+DataTypePtr FunctionModelEvaluate::getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const
 {
     if (arguments.size() < 2)
         throw Exception("Function " + getName() + " expects at least 2 arguments",
                         ErrorCodes::TOO_FEW_ARGUMENTS_FOR_FUNCTION);
 
-    if (!isString(arguments[0]))
-        throw Exception("Illegal type " + arguments[0]->getName() + " of first argument of function " + getName()
+    if (!isString(arguments[0].type))
+        throw Exception("Illegal type " + arguments[0].type->getName() + " of first argument of function " + getName()
                         + ", expected a string.", ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
 
-    return std::make_shared<DataTypeFloat64>();
+    const auto name_col = checkAndGetColumnConst<ColumnString>(arguments[0].column.get());
+    if (!name_col)
+        throw Exception("First argument of function " + getName() + " must be a constant string",
+                        ErrorCodes::ILLEGAL_COLUMN);
+
+    bool has_nullable = false;
+    for (size_t i = 1; i < arguments.size(); ++i)
+        has_nullable = has_nullable || arguments[i].type->isNullable();
+
+    auto model = models.getModel(name_col->getValue<String>());
+    auto type = model->getReturnType();
+
+    if (has_nullable)
+    {
+        if (auto * tuple = typeid_cast<const DataTypeTuple *>(type.get()))
+        {
+            auto elements = tuple->getElements();
+            for (auto & element : elements)
+                element = makeNullable(element);
+
+            type = std::make_shared<DataTypeTuple>(elements);
+        }
+        else
+            type = makeNullable(type);
+    }
+
+    return type;
 }
 
 void FunctionModelEvaluate::executeImpl(Block & block, const ColumnNumbers & arguments, size_t result, size_t /*input_rows_count*/)
@@ -49,11 +79,58 @@ void FunctionModelEvaluate::executeImpl(Block & block, const ColumnNumbers & arg
     auto model = models.getModel(name_col->getValue<String>());
 
     ColumnRawPtrs columns;
-    columns.reserve(arguments.size());
-    for (auto i : ext::range(1, arguments.size()))
-        columns.push_back(block.getByPosition(arguments[i]).column.get());
+    Columns materialized_columns;
+    ColumnPtr null_map;
 
-    block.getByPosition(result).column = model->evaluate(columns);
+    columns.reserve(arguments.size());
+    for (auto arg : ext::range(1, arguments.size()))
+    {
+        auto & column = block.getByPosition(arguments[arg]).column;
+        columns.push_back(column.get());
+        if (auto full_column = column->convertToFullColumnIfConst())
+        {
+            materialized_columns.push_back(full_column);
+            columns.back() = full_column.get();
+        }
+        if (auto * col_nullable = typeid_cast<const ColumnNullable *>(columns.back()))
+        {
+            if (!null_map)
+                null_map = col_nullable->getNullMapColumnPtr();
+            else
+            {
+                auto mut_null_map = (*std::move(null_map)).mutate();
+
+                NullMap & result_null_map = static_cast<ColumnUInt8 &>(*mut_null_map).getData();
+                const NullMap & src_null_map = col_nullable->getNullMapColumn().getData();
+
+                for (size_t i = 0, size = result_null_map.size(); i < size; ++i)
+                    if (src_null_map[i])
+                        result_null_map[i] = 1;
+
+                null_map = std::move(mut_null_map);
+            }
+
+            columns.back() = &col_nullable->getNestedColumn();
+        }
+    }
+
+    auto res = model->evaluate(columns);
+
+    if (null_map)
+    {
+        if (auto * tuple = typeid_cast<const ColumnTuple *>(res.get()))
+        {
+            auto nested = tuple->getColumns();
+            for (auto & col : nested)
+                col = ColumnNullable::create(col, null_map);
+
+            res = ColumnTuple::create(nested);
+        }
+        else
+            res = ColumnNullable::create(res, null_map);
+    }
+
+    block.getByPosition(result).column = res;
 }
 
 void registerFunctionsExternalModels(FunctionFactory & factory)

--- a/dbms/src/Functions/FunctionsExternalModels.h
+++ b/dbms/src/Functions/FunctionsExternalModels.h
@@ -25,9 +25,11 @@ public:
 
     bool isDeterministic() const override { return false; }
 
+    bool useDefaultImplementationForNulls() const override { return false; }
+
     size_t getNumberOfArguments() const override { return 0; }
 
-    DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override;
+    DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override;
 
     void executeImpl(Block & block, const ColumnNumbers & arguments, size_t result, size_t input_rows_count) override;
 

--- a/dbms/src/Interpreters/CatBoostModel.h
+++ b/dbms/src/Interpreters/CatBoostModel.h
@@ -27,7 +27,11 @@ public:
 
     virtual size_t getFloatFeaturesCount() const = 0;
     virtual size_t getCatFeaturesCount() const = 0;
+    virtual size_t getTreeCount() const = 0;
 };
+
+class IDataType;
+using DataTypePtr = std::shared_ptr<const IDataType>;
 
 /// General ML model evaluator interface.
 class IModel : public IExternalLoadable
@@ -35,6 +39,7 @@ class IModel : public IExternalLoadable
 public:
     virtual ColumnPtr evaluate(const ColumnRawPtrs & columns) const = 0;
     virtual std::string getTypeName() const = 0;
+    virtual DataTypePtr getReturnType() const = 0;
 };
 
 class CatBoostModel : public IModel
@@ -48,6 +53,8 @@ public:
 
     size_t getFloatFeaturesCount() const;
     size_t getCatFeaturesCount() const;
+    size_t getTreeCount() const;
+    DataTypePtr getReturnType() const override;
 
     /// IExternalLoadable interface.
 
@@ -76,6 +83,7 @@ private:
 
     size_t float_features_count;
     size_t cat_features_count;
+    size_t tree_count;
 
     std::chrono::time_point<std::chrono::system_clock> creation_time;
     std::exception_ptr creation_exception;

--- a/dbms/tests/external_models/catboost/helpers/server_with_models.py
+++ b/dbms/tests/external_models/catboost/helpers/server_with_models.py
@@ -20,6 +20,13 @@ CLICKHOUSE_CONFIG = \
     <users_config>users.xml</users_config>
     <tcp_port>{tcp_port}</tcp_port>
     <catboost_dynamic_library_path>{catboost_dynamic_library_path}</catboost_dynamic_library_path>
+    <logger>
+        <level>trace</level>
+        <log>{path}/clickhouse-server.log</log>
+        <errorlog>{path}/clickhouse-server.err.log</errorlog>
+        <size>never</size>
+        <count>50</count>
+    </logger>
 </yandex>
 '''
 

--- a/dbms/tests/external_models/catboost/helpers/table.py
+++ b/dbms/tests/external_models/catboost/helpers/table.py
@@ -56,7 +56,12 @@ class ClickHouseTable:
         columns = ', '.join(list(float_columns) + list(cat_columns))
         query = "select modelEvaluate('{}', {}) from test.{} format TSV"
         result = self.client.query(query.format(model_name, columns, self.table_name))
-        return tuple(map(float, filter(len, map(str.strip, result.split()))))
+
+        def parse_row(row):
+            values = tuple(map(float, filter(len, map(str.strip, row.replace('(', '').replace(')', '').split(',')))))
+            return values if len(values) != 1 else values[0]
+
+        return tuple(map(parse_row, filter(len, map(str.strip, result.split('\n')))))
 
     def _drop_table(self):
         self.client.query('drop table test.{}'.format(self.table_name))


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- New Feature

Short description (up to few sentences):
Added support for CatBoost multiclass models evaluation. Function `modelEvaluate` returns tuple with per-class raw predictions for multiclass models. `llibcatboostmodel.so` should be built with [#607](https://github.com/catboost/catboost/pull/607).