### PR TITLE
added description for secure argument to cli docs

### DIFF
--- a/docs/en/interfaces/cli.md
+++ b/docs/en/interfaces/cli.md
@@ -92,7 +92,7 @@ You can pass parameters to `clickhouse-client` (all parameters have a default va
 - `--time, -t` – If specified, print the query execution time to 'stderr' in non-interactive mode.
 - `--stacktrace` – If specified, also print the stack trace if an exception occurs.
 - `--config-file` – The name of the configuration file.
-- `--secure` – If specified, will connect to server over secure connection
+- `--secure` – If specified, will connect to server over secure connection.
 
 ### Configuration Files
 

--- a/docs/en/interfaces/cli.md
+++ b/docs/en/interfaces/cli.md
@@ -92,6 +92,7 @@ You can pass parameters to `clickhouse-client` (all parameters have a default va
 - `--time, -t` – If specified, print the query execution time to 'stderr' in non-interactive mode.
 - `--stacktrace` – If specified, also print the stack trace if an exception occurs.
 - `--config-file` – The name of the configuration file.
+- `--secure` – If specified, will connect to server over secure connection
 
 ### Configuration Files
 
@@ -108,6 +109,7 @@ Example of a config file:
 <config>
     <user>username</user>
     <password>password</password>
+    <secure>False</secure>
 </config>
 ```
 

--- a/docs/ru/interfaces/cli.md
+++ b/docs/ru/interfaces/cli.md
@@ -95,6 +95,7 @@ cat file.csv | clickhouse-client --database=test --query="INSERT INTO test FORMA
 - `--time, -t` - если указано, в неинтерактивном режиме вывести время выполнения запроса в stderr.
 - `--stacktrace` - если указано, в случае исключения, выводить также его стек трейс.
 - `--config-file` - имя конфигурационного файла.
+- `--secure` - если указано, будет использован безопасный канал.
 
 ### Конфигурационные файлы
 
@@ -111,6 +112,7 @@ cat file.csv | clickhouse-client --database=test --query="INSERT INTO test FORMA
 <config>
     <user>username</user>
     <password>password</password>
+    <secure>False</secure>
 </config>
 ```
 [Оригинальная статья](https://clickhouse.yandex/docs/ru/interfaces/cli/) <!--hide-->


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

- Docs improvement

Added description for `--secure` argument to cli docs
