### PR TITLE
Move packager docker images to 18.10 and add compatibility file for glibc >= 2.28

### DIFF
--- a/docker/packager/binary/Dockerfile
+++ b/docker/packager/binary/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:18.10
 
 RUN apt-get update -y \
     && env DEBIAN_FRONTEND=noninteractive \
@@ -11,11 +11,20 @@ RUN apt-get update -y \
             gcc-8 \
             g++-8 \
             clang-6.0 \
-            clang++-6.0 \
             lld-6.0 \
             libclang-6.0-dev \
-            libicu-dev \
             liblld-6.0-dev \
+            llvm-6.0 \
+            libllvm6.0 \
+            llvm-6.0-dev \
+            clang-7 \
+            lld-7 \
+            libclang-7-dev \
+            liblld-7-dev \
+            llvm-7 \
+            libllvm7 \
+            llvm-7-dev \
+            libicu-dev \
             libreadline-dev \
             ninja-build \
             git

--- a/docker/packager/deb/Dockerfile
+++ b/docker/packager/deb/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:18.10
 
 RUN apt-get update -y \
     && env DEBIAN_FRONTEND=noninteractive \
@@ -18,6 +18,13 @@ RUN apt-get update -y \
             llvm-6.0 \
             libllvm6.0 \
             llvm-6.0-dev \
+            clang-7 \
+            lld-7 \
+            libclang-7-dev \
+            liblld-7-dev \
+            llvm-7 \
+            libllvm7 \
+            llvm-7-dev \
             libicu-dev \
             libreadline-dev \
             ninja-build \

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -86,7 +86,7 @@ if __name__ == "__main__":
     parser.add_argument("--clickhouse-repo-path", default="../../")
     parser.add_argument("--output-dir", required=True)
     parser.add_argument("--build-type", choices=("debug", ""), default="")
-    parser.add_argument("--compiler", choices=("clang-6.0", "gcc-7", "gcc-8"), default="gcc-7")
+    parser.add_argument("--compiler", choices=("clang-6.0", "clang-7", "gcc-7", "gcc-8"), default="gcc-7")
     parser.add_argument("--sanitizer", choices=("address", "thread", "memory", "undefined", ""), default="")
     parser.add_argument("--unbundled", action="store_true")
     parser.add_argument("--cache", choices=("", "ccache", "distcc"), default="")

--- a/libs/libglibc-compatibility/CMakeLists.txt
+++ b/libs/libglibc-compatibility/CMakeLists.txt
@@ -19,7 +19,8 @@ musl/sched_cpucount.c
 musl/glob.c
 musl/exp2f.c
 musl/pwritev.c
-musl/getrandom.c)
+musl/getrandom.c
+musl/fcntl.c)
 
 if (MAKE_STATIC_LIBRARIES)
     set (GLIBC_COMPATIBILITY_SOURCES ${GLIBC_COMPATIBILITY_SOURCES}

--- a/libs/libglibc-compatibility/musl/fcntl.c
+++ b/libs/libglibc-compatibility/musl/fcntl.c
@@ -1,0 +1,61 @@
+#define _GNU_SOURCE
+#include <fcntl.h>
+#include <stdarg.h>
+#include <errno.h>
+#include <unistd.h>
+#include <syscall.h>
+#include "syscall.h"
+
+#include <features.h>
+#if defined(__GLIBC__) && __GLIBC__ >= 2
+#   define GLIBC_MINOR __GLIBC_MINOR__
+#elif defined (__GNU_LIBRARY__) && __GNU_LIBRARY__ >= 2
+#   define GLIBC_MINOR __GNU_LIBRARY_MINOR__
+#endif
+
+#if defined(GLIBC_MINOR) && GLIBC_MINOR >= 28
+
+int fcntl64(int fd, int cmd, ...)
+{
+    unsigned long arg;
+    va_list ap;
+    va_start(ap, cmd);
+    arg = va_arg(ap, unsigned long);
+    va_end(ap);
+    if (cmd == F_SETFL) arg |= O_LARGEFILE;
+    if (cmd == F_SETLKW) return syscall(SYS_fcntl, fd, cmd, (void *)arg);
+    if (cmd == F_GETOWN) {
+        struct f_owner_ex ex;
+        int ret = __syscall(SYS_fcntl, fd, F_GETOWN_EX, &ex);
+        if (ret == -EINVAL) return __syscall(SYS_fcntl, fd, cmd, (void *)arg);
+        if (ret) return __syscall_ret(ret);
+        return ex.type == F_OWNER_PGRP ? -ex.pid : ex.pid;
+    }
+    if (cmd == F_DUPFD_CLOEXEC) {
+        int ret = __syscall(SYS_fcntl, fd, F_DUPFD_CLOEXEC, arg);
+        if (ret != -EINVAL) {
+            if (ret >= 0)
+                __syscall(SYS_fcntl, ret, F_SETFD, FD_CLOEXEC);
+            return __syscall_ret(ret);
+        }
+        ret = __syscall(SYS_fcntl, fd, F_DUPFD_CLOEXEC, 0);
+        if (ret != -EINVAL) {
+            if (ret >= 0) __syscall(SYS_close, ret);
+            return __syscall_ret(-EINVAL);
+        }
+        ret = __syscall(SYS_fcntl, fd, F_DUPFD, arg);
+        if (ret >= 0) __syscall(SYS_fcntl, ret, F_SETFD, FD_CLOEXEC);
+        return __syscall_ret(ret);
+    }
+    switch (cmd) {
+    case F_SETLK:
+    case F_GETLK:
+    case F_GETOWN_EX:
+    case F_SETOWN_EX:
+        return syscall(SYS_fcntl, fd, cmd, (void *)arg);
+    default:
+        return syscall(SYS_fcntl, fd, cmd, arg);
+    }
+}
+
+#endif


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Move docker images to 18.10 and add compatibility file for glibc >= 2.28

