### PR TITLE
Add env variable if user don't want to chown directories in docker image

### DIFF
--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -27,14 +27,16 @@ mkdir -p \
     "$USER_PATH" \
     "$FORMAT_SCHEMA_PATH"
 
-# ensure proper directories permissions
-chown -R $USER:$GROUP \
-    "$DATA_DIR" \
-    "$ERROR_LOG_DIR" \
-    "$LOG_DIR" \
-    "$TMP_DIR" \
-    "$USER_PATH" \
-    "$FORMAT_SCHEMA_PATH"
+if [ "$CLICKHOUSE_DO_NOT_CHOWN" != "1" ]; then
+    # ensure proper directories permissions
+    chown -R $USER:$GROUP \
+        "$DATA_DIR" \
+        "$ERROR_LOG_DIR" \
+        "$LOG_DIR" \
+        "$TMP_DIR" \
+        "$USER_PATH" \
+        "$FORMAT_SCHEMA_PATH"
+fi
 
 if [ -n "$(ls /docker-entrypoint-initdb.d/)" ]; then
     gosu clickhouse /usr/bin/clickhouse-server --config-file=$CLICKHOUSE_CONFIG &


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en


Category (leave one):

- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Add env variable if user don't want to chown directories in server docker image

