### PR TITLE
Use DFA algorithm for sequenceMatch without `(?t)`.

### DIFF
--- a/dbms/src/AggregateFunctions/AggregateFunctionSequenceMatch.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionSequenceMatch.h
@@ -314,11 +314,13 @@ private:
                     throw_exception("Expected closing parenthesis, found");
 
             }
-            else if (match(".*")) {
+            else if (match(".*"))
+            {
                 actions.emplace_back(PatternActionType::KleeneStar);
                 dfa_states.back().has_kleene = true;
             }
-            else if (match(".")) {
+            else if (match("."))
+            {
                 actions.emplace_back(PatternActionType::AnyEvent);
                 dfa_states.back().transition = DFATransition::AnyEvent;
                 dfa_states.emplace_back();
@@ -352,16 +354,20 @@ protected:
         /// the match failed.
         size_t n_active = 1;
 
-        for (/* empty */; events_it != events_end && n_active > 0 && !active_states.back(); ++events_it) {
+        for (/* empty */; events_it != events_end && n_active > 0 && !active_states.back(); ++events_it)
+        {
             n_active = 0;
             next_active_states.assign(dfa_states.size(), false);
 
-            for (size_t state = 0; state < dfa_states.size(); ++state) {
-                if (!active_states[state]) {
+            for (size_t state = 0; state < dfa_states.size(); ++state)
+            {
+                if (!active_states[state])
+                {
                     continue;
                 }
 
-                switch (dfa_states[state].transition) {
+                switch (dfa_states[state].transition)
+                {
                 case DFATransition::None:
                     break;
                 case DFATransition::AnyEvent:
@@ -369,14 +375,16 @@ protected:
                     ++n_active;
                     break;
                 case DFATransition::SpecificEvent:
-                    if (events_it->second.test(dfa_states[state].event)) {
+                    if (events_it->second.test(dfa_states[state].event))
+                    {
                         next_active_states[state + 1] = true;
                         ++n_active;
                     }
                     break;
                 }
 
-                if (dfa_states[state].has_kleene) {
+                if (dfa_states[state].has_kleene)
+                {
                     next_active_states[state] = true;
                     ++n_active;
                 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

## Short description (up to few sentences):
Add an optional parameter to `sequenceMatch` and `sequenceCount` in order to temporary lift the hard-coded limit on the number of iterations.

## Detailed description (optional):
As of today the constant [sequence_match_max_iterations](https://github.com/yandex/ClickHouse/blob/master/dbms/src/AggregateFunctions/AggregateFunctionSequenceMatch.h#L135) sets an arbitrary limit on the number of iterations supported by `sequenceMatch` and `sequenceCount`. In certain cases, making this limit configurable may be desirable ([current opened issue](https://github.com/yandex/ClickHouse/issues/2399)).

In order to do so, a new parameter has been added to those two functions. The fact that the parameter is optional and default to the previous hard-coded value makes this change backward compatible.

I think going for a query setting would have been cleaner but I've found no way to access the query settings from within the implementation of function. If such a way exists, I'll gladly modify the PR in order to interact with the settings rather than an optional parameter.

Let me know if anything is to be changed !
