### PR TITLE
Don't use a pool for TaskStatsInfoGetters

### DIFF
--- a/dbms/src/Common/CurrentThread.cpp
+++ b/dbms/src/Common/CurrentThread.cpp
@@ -3,7 +3,6 @@
 #include "CurrentThread.h"
 #include <common/logger_useful.h>
 #include <Common/ThreadStatus.h>
-#include <Common/ObjectPool.h>
 #include <Common/TaskStatsInfoGetter.h>
 #include <Interpreters/ProcessList.h>
 #include <Interpreters/Context.h>
@@ -23,8 +22,6 @@ namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
 }
-
-SimpleObjectPool<TaskStatsInfoGetter> task_stats_info_getter_pool;
 
 // Smoker's implementation to avoid thread_local usage: error: undefined symbol: __cxa_thread_atexit
 #if defined(ARCADIA_ROOT)

--- a/dbms/src/Common/ThreadStatus.cpp
+++ b/dbms/src/Common/ThreadStatus.cpp
@@ -21,9 +21,6 @@ namespace ErrorCodes
 }
 
 
-extern SimpleObjectPool<TaskStatsInfoGetter> task_stats_info_getter_pool;
-
-
 TasksStatsCounters TasksStatsCounters::current()
 {
     TasksStatsCounters res;
@@ -74,7 +71,7 @@ void ThreadStatus::initPerformanceCounters()
         if (TaskStatsInfoGetter::checkPermissions())
         {
             if (!taskstats_getter)
-                taskstats_getter = task_stats_info_getter_pool.getDefault();
+                taskstats_getter = std::make_unique<TaskStatsInfoGetter>();
 
             *last_taskstats = TasksStatsCounters::current();
         }

--- a/dbms/src/Common/ThreadStatus.h
+++ b/dbms/src/Common/ThreadStatus.h
@@ -2,7 +2,6 @@
 
 #include <Common/ProfileEvents.h>
 #include <Common/MemoryTracker.h>
-#include <Common/ObjectPool.h>
 
 #include <IO/Progress.h>
 
@@ -175,8 +174,7 @@ protected:
     std::unique_ptr<TasksStatsCounters> last_taskstats;
 
     /// Set to non-nullptr only if we have enough capabilities.
-    /// We use pool because creation and destruction of TaskStatsInfoGetter objects are expensive.
-    SimpleObjectPool<TaskStatsInfoGetter>::Pointer taskstats_getter;
+    std::unique_ptr<TaskStatsInfoGetter> taskstats_getter;
 };
 
 }


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug fix

Short description (up to few sentences):

Fix a leak of netlink sockets. They were placed in a pool where they were never deleted and new sockets were created at the start of a new thread when all current sockets were in use.