### PR TITLE
Replace fcntl64 with fcntl syscall

### DIFF
--- a/libs/libglibc-compatibility/musl/fcntl.c
+++ b/libs/libglibc-compatibility/musl/fcntl.c
@@ -17,45 +17,14 @@
 
 int fcntl64(int fd, int cmd, ...)
 {
-    unsigned long arg;
     va_list ap;
-    va_start(ap, cmd);
-    arg = va_arg(ap, unsigned long);
-    va_end(ap);
-    if (cmd == F_SETFL) arg |= O_LARGEFILE;
-    if (cmd == F_SETLKW) return syscall(SYS_fcntl, fd, cmd, (void *)arg);
-    if (cmd == F_GETOWN) {
-        struct f_owner_ex ex;
-        int ret = __syscall(SYS_fcntl, fd, F_GETOWN_EX, &ex);
-        if (ret == -EINVAL) return __syscall(SYS_fcntl, fd, cmd, (void *)arg);
-        if (ret) return __syscall_ret(ret);
-        return ex.type == F_OWNER_PGRP ? -ex.pid : ex.pid;
-    }
-    if (cmd == F_DUPFD_CLOEXEC) {
-        int ret = __syscall(SYS_fcntl, fd, F_DUPFD_CLOEXEC, arg);
-        if (ret != -EINVAL) {
-            if (ret >= 0)
-                __syscall(SYS_fcntl, ret, F_SETFD, FD_CLOEXEC);
-            return __syscall_ret(ret);
-        }
-        ret = __syscall(SYS_fcntl, fd, F_DUPFD_CLOEXEC, 0);
-        if (ret != -EINVAL) {
-            if (ret >= 0) __syscall(SYS_close, ret);
-            return __syscall_ret(-EINVAL);
-        }
-        ret = __syscall(SYS_fcntl, fd, F_DUPFD, arg);
-        if (ret >= 0) __syscall(SYS_fcntl, ret, F_SETFD, FD_CLOEXEC);
-        return __syscall_ret(ret);
-    }
-    switch (cmd) {
-    case F_SETLK:
-    case F_GETLK:
-    case F_GETOWN_EX:
-    case F_SETOWN_EX:
-        return syscall(SYS_fcntl, fd, cmd, (void *)arg);
-    default:
-        return syscall(SYS_fcntl, fd, cmd, arg);
-    }
+    void * arg;
+
+    va_start (ap, cmd);
+    arg = va_arg (ap, void *);
+    va_end (ap);
+
+    return __syscall(SYS_fcntl, fd, cmd, arg);
 }
 
 #endif


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Change fcntl64 replacement
