### PR TITLE
fix page.title on 'hidden' pages

### DIFF
--- a/docs/tools/mkdocs-material-theme/base.html
+++ b/docs/tools/mkdocs-material-theme/base.html
@@ -42,7 +42,7 @@
         <title>{{ page.meta.title }}</title>
       {% elif page and page.title and not page.is_homepage and page.title != 'hidden' %}
         <title>{{ page.title }} - {{ config.site_name }}</title>
-      {% elif page and not page.is_homepage and page.title == 'hidden' and page.ancestors  %}
+      {% elif page and page.title and not page.is_homepage and page.title == 'hidden' and page.ancestors  %}
         <title>{{ (page.ancestors | first).title }} - {{ config.site_name }}</title>
       {% else %}
         <title>{{ config.site_name }}</title>

--- a/docs/tools/mkdocs-material-theme/base.html
+++ b/docs/tools/mkdocs-material-theme/base.html
@@ -42,7 +42,7 @@
         <title>{{ page.meta.title }}</title>
       {% elif page and page.title and not page.is_homepage and page.title != 'hidden' %}
         <title>{{ page.title }} - {{ config.site_name }}</title>
-      {% elif page and not page.is_homepage and page.ancestors  %}
+      {% elif page and not page.is_homepage and page.title == 'hidden' and page.ancestors  %}
         <title>{{ (page.ancestors | first).title }} - {{ config.site_name }}</title>
       {% else %}
         <title>{{ config.site_name }}</title>

--- a/docs/tools/mkdocs-material-theme/base.html
+++ b/docs/tools/mkdocs-material-theme/base.html
@@ -42,7 +42,7 @@
         <title>{{ page.meta.title }}</title>
       {% elif page and page.title and not page.is_homepage and page.title != 'hidden' %}
         <title>{{ page.title }} - {{ config.site_name }}</title>
-      {% elif page and page.title and not page.is_homepage and page.title == 'hidden' and page.ancestors  %}
+      {% elif page and page.title and not page.is_homepage and page.title == 'hidden' and page.ancestors %}
         <title>{{ (page.ancestors | first).title }} - {{ config.site_name }}</title>
       {% else %}
         <title>{{ config.site_name }}</title>

--- a/docs/tools/mkdocs-material-theme/base.html
+++ b/docs/tools/mkdocs-material-theme/base.html
@@ -40,8 +40,10 @@
     {% block htmltitle %}
       {% if page and page.meta and page.meta.title %}
         <title>{{ page.meta.title }}</title>
-      {% elif page and page.title and not page.is_homepage %}
+      {% elif page and page.title and not page.is_homepage and page.title != 'hidden' %}
         <title>{{ page.title }} - {{ config.site_name }}</title>
+      {% elif page and not page.is_homepage and page.ancestors  %}
+        <title>{{ (page.ancestors | first).title }} - {{ config.site_name }}</title>
       {% else %}
         <title>{{ config.site_name }}</title>
       {% endif %}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category:
- Other

Short description:
- fixed `hidden` on page title

Example: 
- page: https://clickhouse.yandex/docs/ru/development/
- old title: `hidden - ClickHouse Documentation`
- new title: `Разработка - Документация ClickHouse` 

Исправляет вот такое недоразумение:
<img width="651" alt="2019-01-11 3 00 59" src="https://user-images.githubusercontent.com/201306/51004765-2b062980-154d-11e9-9023-30526d61c7fd.png">
