### PR TITLE
Try to reduce CompiledExpressionsCache size

### DIFF
--- a/dbms/src/Interpreters/AsynchronousMetrics.cpp
+++ b/dbms/src/Interpreters/AsynchronousMetrics.cpp
@@ -137,10 +137,7 @@ void AsynchronousMetrics::update()
 #if USE_EMBEDDED_COMPILER
     {
         if (auto compiled_expression_cache = context.getCompiledExpressionCache())
-        {
-            set("CompiledExpressionCacheBytes", compiled_expression_cache->weight());
             set("CompiledExpressionCacheCount", compiled_expression_cache->count());
-        }
     }
 #endif
 

--- a/dbms/src/Interpreters/ExpressionJIT.cpp
+++ b/dbms/src/Interpreters/ExpressionJIT.cpp
@@ -190,7 +190,7 @@ auto wrapJITSymbolResolver(llvm::JITSymbolResolver & jsr)
 #endif
 
 #if LLVM_VERSION_MAJOR >= 7
-using ModulePtr = std::shared_ptr<llvm::Module>;
+using ModulePtr = std::unique_ptr<llvm::Module>;
 #else
 using ModulePtr = std::shared_ptr<llvm::Module>;
 #endif

--- a/dbms/src/Interpreters/ExpressionJIT.cpp
+++ b/dbms/src/Interpreters/ExpressionJIT.cpp
@@ -189,70 +189,36 @@ auto wrapJITSymbolResolver(llvm::JITSymbolResolver & jsr)
 }
 #endif
 
-#if LLVM_VERSION_MAJOR >= 6
-struct CountingMMapper final : public llvm::SectionMemoryManager::MemoryMapper
-{
-    MemoryTracker memory_tracker{VariableContext::Global};
-
-    llvm::sys::MemoryBlock allocateMappedMemory(llvm::SectionMemoryManager::AllocationPurpose /*purpose*/,
-        size_t num_bytes,
-        const llvm::sys::MemoryBlock * const near_block,
-        unsigned flags,
-        std::error_code & error_code) override
-    {
-        memory_tracker.alloc(num_bytes);
-        return llvm::sys::Memory::allocateMappedMemory(num_bytes, near_block, flags, error_code);
-    }
-
-    std::error_code protectMappedMemory(const llvm::sys::MemoryBlock & block, unsigned flags) override
-    {
-        return llvm::sys::Memory::protectMappedMemory(block, flags);
-    }
-
-    std::error_code releaseMappedMemory(llvm::sys::MemoryBlock & block) override
-    {
-        memory_tracker.free(block.size());
-        return llvm::sys::Memory::releaseMappedMemory(block);
-    }
-};
+#if LLVM_VERSION_MAJOR >= 7
+using ModulePtr = std::shared_ptr<llvm::Module>;
+#else
+using ModulePtr = std::shared_ptr<llvm::Module>;
 #endif
 
 struct LLVMContext
 {
-    static inline std::atomic<size_t> id_counter{0};
-    llvm::LLVMContext context;
+    std::shared_ptr<llvm::LLVMContext> context;
 #if LLVM_VERSION_MAJOR >= 7
     llvm::orc::ExecutionSession execution_session;
-    std::unique_ptr<llvm::Module> module;
-#else
-    std::shared_ptr<llvm::Module> module;
 #endif
+    ModulePtr module;
     std::unique_ptr<llvm::TargetMachine> machine;
-#if LLVM_VERSION_MAJOR >= 6
-    std::unique_ptr<CountingMMapper> memory_mapper;
-#endif
     std::shared_ptr<llvm::SectionMemoryManager> memory_manager;
     llvm::orc::RTDyldObjectLinkingLayer object_layer;
     llvm::orc::IRCompileLayer<decltype(object_layer), llvm::orc::SimpleCompiler> compile_layer;
     llvm::DataLayout layout;
     llvm::IRBuilder<> builder;
     std::unordered_map<std::string, void *> symbols;
-    size_t id;
 
     LLVMContext()
+        : context(std::make_shared<llvm::LLVMContext>())
 #if LLVM_VERSION_MAJOR >= 7
-        : module(std::make_unique<llvm::Module>("jit", context))
+        , module(std::make_unique<llvm::Module>("jit", *context))
 #else
-        : module(std::make_shared<llvm::Module>("jit", context))
+        , module(std::make_shared<llvm::Module>("jit", *context))
 #endif
         , machine(getNativeMachine())
-
-#if LLVM_VERSION_MAJOR >= 6
-        , memory_mapper(std::make_unique<CountingMMapper>())
-        , memory_manager(std::make_shared<llvm::SectionMemoryManager>(memory_mapper.get()))
-#else
         , memory_manager(std::make_shared<llvm::SectionMemoryManager>())
-#endif
 #if LLVM_VERSION_MAJOR >= 7
         , object_layer(execution_session, [this](llvm::orc::VModuleKey)
         {
@@ -263,18 +229,17 @@ struct LLVMContext
 #endif
         , compile_layer(object_layer, llvm::orc::SimpleCompiler(*machine))
         , layout(machine->createDataLayout())
-        , builder(context)
-        , id(id_counter++)
+        , builder(*context)
     {
         module->setDataLayout(layout);
         module->setTargetTriple(machine->getTargetTriple().getTriple());
     }
 
     /// returns used memory
-    size_t compileAllFunctionsToNativeCode()
+    void compileAllFunctionsToNativeCode()
     {
         if (!module->size())
-            return 0;
+            return;
         llvm::PassManagerBuilder pass_manager_builder;
         llvm::legacy::PassManager mpm;
         llvm::legacy::FunctionPassManager fpm(module.get());
@@ -323,26 +288,20 @@ struct LLVMContext
                 throw Exception("Function " + name + " failed to link", ErrorCodes::CANNOT_COMPILE_CODE);
             symbols[name] = reinterpret_cast<void *>(*address);
         }
-#if LLVM_VERSION_MAJOR >= 6
-        return memory_mapper->memory_tracker.get();
-#else
-        return 0;
-#endif
     }
 };
 
 class LLVMPreparedFunction : public PreparedFunctionImpl
 {
     std::string name;
-    std::shared_ptr<LLVMContext> context;
     void * function;
 
 public:
-    LLVMPreparedFunction(std::string name_, std::shared_ptr<LLVMContext> context)
-        : name(std::move(name_)), context(context)
+    LLVMPreparedFunction(const std::string & name_, const std::unordered_map<std::string, void *> & symbols)
+        : name(name_)
     {
-        auto it = context->symbols.find(name);
-        if (context->symbols.end() == it)
+        auto it = symbols.find(name);
+        if (symbols.end() == it)
             throw Exception("Cannot find symbol " + name + " in LLVMContext", ErrorCodes::LOGICAL_ERROR);
         function = it->second;
     }
@@ -373,16 +332,16 @@ public:
     }
 };
 
-static void compileFunctionToLLVMByteCode(std::shared_ptr<LLVMContext> & context, const IFunctionBase & f)
+static void compileFunctionToLLVMByteCode(LLVMContext & context, const IFunctionBase & f)
 {
     ProfileEvents::increment(ProfileEvents::CompileFunction);
 
     auto & arg_types = f.getArgumentTypes();
-    auto & b = context->builder;
+    auto & b = context.builder;
     auto * size_type = b.getIntNTy(sizeof(size_t) * 8);
     auto * data_type = llvm::StructType::get(b.getInt8PtrTy(), b.getInt8PtrTy(), size_type);
     auto * func_type = llvm::FunctionType::get(b.getVoidTy(), { size_type, data_type->getPointerTo() }, /*isVarArg=*/false);
-    auto * func = llvm::Function::Create(func_type, llvm::Function::ExternalLinkage, f.getName(), context->module.get());
+    auto * func = llvm::Function::Create(func_type, llvm::Function::ExternalLinkage, f.getName(), context.module.get());
     auto args = func->args().begin();
     llvm::Value * counter_arg = &*args++;
     llvm::Value * columns_arg = &*args++;
@@ -490,6 +449,8 @@ static CompilableExpression subexpression(size_t i)
     return [=](llvm::IRBuilderBase &, const ValuePlaceholders & inputs) { return inputs[i](); };
 }
 
+
+
 static CompilableExpression subexpression(const IFunctionBase & f, std::vector<CompilableExpression> args)
 {
     return [&, args = std::move(args)](llvm::IRBuilderBase & builder, const ValuePlaceholders & inputs)
@@ -504,12 +465,21 @@ static CompilableExpression subexpression(const IFunctionBase & f, std::vector<C
     };
 }
 
-LLVMFunction::LLVMFunction(const ExpressionActions::Actions & actions, std::shared_ptr<LLVMContext> context, const Block & sample_block)
-        : name(actions.back().result_name), context(context)
+struct LLVMModuleState
 {
+    std::unordered_map<std::string, void *> symbols;
+    std::shared_ptr<llvm::LLVMContext> major_context;
+    std::shared_ptr<llvm::SectionMemoryManager> memory_manager;
+};
+
+LLVMFunction::LLVMFunction(const ExpressionActions::Actions & actions, const Block & sample_block)
+    : name(actions.back().result_name)
+    , module_state(std::make_unique<LLVMModuleState>())
+{
+    LLVMContext context;
     for (const auto & c : sample_block)
         /// TODO: implement `getNativeValue` for all types & replace the check with `c.column && toNativeType(...)`
-        if (c.column && getNativeValue(toNativeType(context->builder, c.type), *c.column, 0))
+        if (c.column && getNativeValue(toNativeType(context.builder, c.type), *c.column, 0))
             subexpressions[c.name] = subexpression(c.column, c.type);
     for (const auto & action : actions)
     {
@@ -530,6 +500,11 @@ LLVMFunction::LLVMFunction(const ExpressionActions::Actions & actions, std::shar
         originals.push_back(action.function_base);
     }
     compileFunctionToLLVMByteCode(context, *this);
+    context.compileAllFunctionsToNativeCode();
+
+    module_state->symbols = context.symbols;
+    module_state->major_context = context.context;
+    module_state->memory_manager = context.memory_manager;
 }
 
 llvm::Value * LLVMFunction::compile(llvm::IRBuilderBase & builder, ValuePlaceholders values) const
@@ -540,8 +515,7 @@ llvm::Value * LLVMFunction::compile(llvm::IRBuilderBase & builder, ValuePlacehol
     return it->second(builder, values);
 }
 
-
-PreparedFunctionPtr LLVMFunction::prepare(const Block &, const ColumnNumbers &, size_t) const { return std::make_shared<LLVMPreparedFunction>(name, context); }
+PreparedFunctionPtr LLVMFunction::prepare(const Block &, const ColumnNumbers &, size_t) const { return std::make_shared<LLVMPreparedFunction>(name, module_state->symbols); }
 
 bool LLVMFunction::isDeterministic() const
 {
@@ -620,28 +594,6 @@ static bool isCompilable(const IFunctionBase & function)
         if (!canBeNativeType(*type))
             return false;
     return function.isCompilable();
-}
-
-size_t CompiledExpressionCache::weight() const
-{
-
-#if LLVM_VERSION_MAJOR >= 6
-    std::lock_guard lock(mutex);
-    size_t result{0};
-    std::unordered_set<size_t> seen;
-    for (const auto & cell : cells)
-    {
-        auto function_context = cell.second.value->getContext();
-        if (!seen.count(function_context->id))
-        {
-            result += function_context->memory_mapper->memory_tracker.get();
-            seen.insert(function_context->id);
-        }
-    }
-    return result;
-#else
-    return Base::weight();
-#endif
 }
 
 std::vector<std::unordered_set<std::optional<size_t>>> getActionsDependents(const ExpressionActions::Actions & actions, const Names & output_columns)
@@ -748,21 +700,16 @@ void compileFunctions(ExpressionActions::Actions & actions, const Names & output
                 std::tie(fn, std::ignore) = compilation_cache->getOrSet(hash_key, [&inlined_func=std::as_const(fused[i]), &sample_block] ()
                 {
                     Stopwatch watch;
-                    std::shared_ptr<LLVMContext> context = std::make_shared<LLVMContext>();
-                    auto result_fn = std::make_shared<LLVMFunction>(inlined_func, context, sample_block);
-                    size_t used_memory = context->compileAllFunctionsToNativeCode();
-                    ProfileEvents::increment(ProfileEvents::CompileExpressionsBytes, used_memory);
+                    std::shared_ptr<LLVMFunction> result_fn;
+                    result_fn = std::make_shared<LLVMFunction>(inlined_func, sample_block);
                     ProfileEvents::increment(ProfileEvents::CompileExpressionsMicroseconds, watch.elapsedMicroseconds());
                     return result_fn;
                 });
             }
             else
             {
-                std::shared_ptr<LLVMContext> context = std::make_shared<LLVMContext>();
                 Stopwatch watch;
-                fn = std::make_shared<LLVMFunction>(fused[i], context, sample_block);
-                size_t used_memory = context->compileAllFunctionsToNativeCode();
-                ProfileEvents::increment(ProfileEvents::CompileExpressionsBytes, used_memory);
+                fn = std::make_shared<LLVMFunction>(fused[i], sample_block);
                 ProfileEvents::increment(ProfileEvents::CompileExpressionsMicroseconds, watch.elapsedMicroseconds());
             }
 

--- a/dbms/src/Interpreters/ExpressionJIT.cpp
+++ b/dbms/src/Interpreters/ExpressionJIT.cpp
@@ -449,8 +449,6 @@ static CompilableExpression subexpression(size_t i)
     return [=](llvm::IRBuilderBase &, const ValuePlaceholders & inputs) { return inputs[i](); };
 }
 
-
-
 static CompilableExpression subexpression(const IFunctionBase & f, std::vector<CompilableExpression> args)
 {
     return [&, args = std::move(args)](llvm::IRBuilderBase & builder, const ValuePlaceholders & inputs)

--- a/dbms/src/Interpreters/ExpressionJIT.h
+++ b/dbms/src/Interpreters/ExpressionJIT.h
@@ -25,7 +25,7 @@ class LLVMFunction : public IFunctionBase
     DataTypes arg_types;
 
     std::vector<FunctionBasePtr> originals;
-    std::unordered_map<std::string, CompilableExpression> subexpressions;
+    std::unordered_map<StringRef, CompilableExpression> subexpressions;
 
     std::unique_ptr<LLVMModuleState> module_state;
 

--- a/dbms/src/Interpreters/ExpressionJIT.h
+++ b/dbms/src/Interpreters/ExpressionJIT.h
@@ -14,19 +14,23 @@
 namespace DB
 {
 
-struct LLVMContext;
 using CompilableExpression = std::function<llvm::Value * (llvm::IRBuilderBase &, const ValuePlaceholders &)>;
+
+struct LLVMModuleState;
 
 class LLVMFunction : public IFunctionBase
 {
     std::string name;
     Names arg_names;
     DataTypes arg_types;
-    std::shared_ptr<LLVMContext> context;
+
     std::vector<FunctionBasePtr> originals;
-    std::unordered_map<StringRef, CompilableExpression> subexpressions;
+    std::unordered_map<std::string, CompilableExpression> subexpressions;
+
+    std::unique_ptr<LLVMModuleState> module_state;
+
 public:
-    LLVMFunction(const ExpressionActions::Actions & actions, std::shared_ptr<LLVMContext> context, const Block & sample_block);
+    LLVMFunction(const ExpressionActions::Actions & actions, const Block & sample_block);
 
     bool isCompilable() const override { return true; }
 
@@ -54,8 +58,7 @@ public:
 
     Monotonicity getMonotonicityForRange(const IDataType & type, const Field & left, const Field & right) const override;
 
-    std::shared_ptr<LLVMContext> getContext() const { return context; }
-
+    const LLVMModuleState * getLLVMModuleState() const { return module_state.get(); }
 };
 
 /** This child of LRUCache breaks one of it's invariants: total weight may be changed after insertion.
@@ -63,13 +66,9 @@ public:
  */
 class CompiledExpressionCache : public LRUCache<UInt128, LLVMFunction, UInt128Hash>
 {
-private:
-    using Base = LRUCache<UInt128, LLVMFunction, UInt128Hash>;
-
 public:
+    using Base = LRUCache<UInt128, LLVMFunction, UInt128Hash>;
     using Base::Base;
-
-    size_t weight() const;
 };
 
 /// For each APPLY_FUNCTION action, try to compile the function to native code; if the only uses of a compilable


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en


Category (leave one):
- New Feature (Remove feature)
- Performance Improvement

Short description (up to few sentences):
Remove some redundant objects from compiled expressions cache (optimization)
Remove CompiledExpressionsCacheBytes metric, because it's lying
