### PR TITLE
Storage hdfs write and refactoring

### DIFF
--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -299,8 +299,8 @@ target_include_directories (dbms SYSTEM BEFORE PRIVATE ${DIVIDE_INCLUDE_DIR})
 target_include_directories (dbms SYSTEM BEFORE PRIVATE ${SPARCEHASH_INCLUDE_DIR})
 
 if (USE_HDFS)
-    target_link_libraries (dbms PRIVATE ${HDFS3_LIBRARY})
-    target_include_directories (dbms SYSTEM BEFORE PRIVATE ${HDFS3_INCLUDE_DIR})
+    target_link_libraries (clickhouse_common_io PRIVATE ${HDFS3_LIBRARY})
+    target_include_directories (clickhouse_common_io SYSTEM BEFORE PRIVATE ${HDFS3_INCLUDE_DIR})
 endif()
 
 if (USE_JEMALLOC)

--- a/dbms/src/IO/HDFSCommon.cpp
+++ b/dbms/src/IO/HDFSCommon.cpp
@@ -1,0 +1,43 @@
+#include <IO/HDFSCommon.h>
+
+#if USE_HDFS
+#include <Common/Exception.h>
+namespace DB
+{
+namespace ErrorCodes
+{
+extern const int BAD_ARGUMENTS;
+extern const int NETWORK_ERROR;
+}
+HDFSBuilderPtr createHDFSBuilder(const Poco::URI & uri)
+{
+    auto & host = uri.getHost();
+    auto port = uri.getPort();
+    auto & path = uri.getPath();
+    if (host.empty() || port == 0 || path.empty())
+        throw Exception("Illegal HDFS URI: " + uri.toString(), ErrorCodes::BAD_ARGUMENTS);
+
+    HDFSBuilderPtr builder(hdfsNewBuilder());
+    if (builder == nullptr)
+        throw Exception("Unable to create builder to connect to HDFS: " + uri.toString() + " " + std::string(hdfsGetLastError()),
+            ErrorCodes::NETWORK_ERROR);
+    hdfsBuilderConfSetStr(builder.get(), "input.read.timeout", "60000"); // 1 min
+    hdfsBuilderConfSetStr(builder.get(), "input.write.timeout", "60000"); // 1 min
+    hdfsBuilderConfSetStr(builder.get(), "input.connect.timeout", "60000"); // 1 min
+
+    hdfsBuilderSetNameNode(builder.get(), host.c_str());
+    hdfsBuilderSetNameNodePort(builder.get(), port);
+    return builder;
+}
+
+HDFSFSPtr createHDFSFS(hdfsBuilder * builder)
+{
+    HDFSFSPtr fs(hdfsBuilderConnect(builder));
+    if (fs == nullptr)
+        throw Exception("Unable to connect to HDFS: " + std::string(hdfsGetLastError()),
+            ErrorCodes::NETWORK_ERROR);
+
+    return fs;
+}
+}
+#endif

--- a/dbms/src/IO/HDFSCommon.h
+++ b/dbms/src/IO/HDFSCommon.h
@@ -1,0 +1,38 @@
+#include <Common/config.h>
+#include <memory>
+#include <type_traits>
+#include <Poco/URI.h>
+
+#if USE_HDFS
+#include <hdfs/hdfs.h>
+
+namespace DB
+{
+namespace detail
+{
+struct HDFSBuilderDeleter
+{
+    void operator()(hdfsBuilder * builder_ptr)
+    {
+        hdfsFreeBuilder(builder_ptr);
+    }
+};
+struct HDFSFsDeleter
+{
+    void operator()(hdfsFS fs_ptr)
+    {
+        hdfsDisconnect(fs_ptr);
+    }
+};
+
+}
+
+using HDFSBuilderPtr = std::unique_ptr<hdfsBuilder, detail::HDFSBuilderDeleter>;
+using HDFSFSPtr = std::unique_ptr<std::remove_pointer_t<hdfsFS>, detail::HDFSFsDeleter>;
+
+// set read/connect timeout, default value in libhdfs3 is about 1 hour, and too large
+/// TODO Allow to tune from query Settings.
+HDFSBuilderPtr createHDFSBuilder(const Poco::URI & hdfs_uri);
+HDFSFSPtr createHDFSFS(hdfsBuilder * builder);
+}
+#endif

--- a/dbms/src/IO/ReadBufferFromHDFS.cpp
+++ b/dbms/src/IO/ReadBufferFromHDFS.cpp
@@ -56,6 +56,12 @@ struct ReadBufferFromHDFS::ReadBufferFromHDFSImpl
         }
 
         fin = hdfsOpenFile(fs, path.c_str(), O_RDONLY, 0, 0, 0);
+
+        if (fin == nullptr)
+        {
+            throw Exception("Unable to open HDFS file: " + path + " error: " + std::string(hdfsGetLastError()),
+                ErrorCodes::NETWORK_ERROR);
+        }
     }
 
     ~ReadBufferFromHDFSImpl()

--- a/dbms/src/IO/ReadBufferFromHDFS.cpp
+++ b/dbms/src/IO/ReadBufferFromHDFS.cpp
@@ -1,0 +1,104 @@
+#include <IO/ReadBufferFromHDFS.h>
+
+#if USE_HDFS
+#include <Poco/URI.h>
+#include <hdfs/hdfs.h>
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+    extern const int NETWORK_ERROR;
+}
+
+struct ReadBufferFromHDFS::ReadBufferFromHDFSImpl
+{
+    std::string hdfs_uri;
+    struct hdfsBuilder * builder;
+    hdfsFS fs;
+    hdfsFile fin;
+
+    ReadBufferFromHDFSImpl(const std::string & hdfs_name_)
+        : hdfs_uri(hdfs_name_)
+        , builder(hdfsNewBuilder())
+    {
+        builder = hdfsNewBuilder();
+        hdfs_uri = hdfs_name_;
+        Poco::URI uri(hdfs_name_);
+        auto & host = uri.getHost();
+        auto port = uri.getPort();
+        auto & path = uri.getPath();
+        if (host.empty() || port == 0 || path.empty())
+        {
+            throw Exception("Illegal HDFS URI: " + hdfs_uri, ErrorCodes::BAD_ARGUMENTS);
+        }
+        // set read/connect timeout, default value in libhdfs3 is about 1 hour, and too large
+        /// TODO Allow to tune from query Settings.
+        hdfsBuilderConfSetStr(builder, "input.read.timeout", "60000"); // 1 min
+        hdfsBuilderConfSetStr(builder, "input.connect.timeout", "60000"); // 1 min
+
+        hdfsBuilderSetNameNode(builder, host.c_str());
+        hdfsBuilderSetNameNodePort(builder, port);
+        fs = hdfsBuilderConnect(builder);
+
+        if (fs == nullptr)
+        {
+            throw Exception("Unable to connect to HDFS: " + std::string(hdfsGetLastError()), ErrorCodes::NETWORK_ERROR);
+        }
+
+        fin = hdfsOpenFile(fs, path.c_str(), O_RDONLY, 0, 0, 0);
+    }
+
+    ~ReadBufferFromHDFSImpl()
+    {
+        close();
+        hdfsFreeBuilder(builder);
+    }
+
+    void close()
+    {
+        hdfsCloseFile(fs, fin);
+    }
+
+    int read(char * start, size_t size)
+    {
+        int bytes_read = hdfsRead(fs, fin, start, size);
+        if (bytes_read < 0)
+        {
+            throw Exception("Fail to read HDFS file: " + hdfs_uri + " " + std::string(hdfsGetLastError()), ErrorCodes::NETWORK_ERROR);
+        }
+        return bytes_read;
+    }
+};
+
+ReadBufferFromHDFS::ReadBufferFromHDFS(const std::string & hdfs_name_, size_t buf_size)
+    : BufferWithOwnMemory<ReadBuffer>(buf_size)
+    , impl(std::make_unique<ReadBufferFromHDFSImpl>(hdfs_name_))
+{
+}
+
+
+bool ReadBufferFromHDFS::nextImpl()
+{
+    int bytes_read = impl->read(internal_buffer.begin(), internal_buffer.size());
+
+    if (bytes_read)
+        working_buffer.resize(bytes_read);
+    else
+        return false;
+    return true;
+}
+
+const std::string & ReadBufferFromHDFS::getHDFSUri() const
+{
+    return impl->hdfs_uri;
+}
+
+ReadBufferFromHDFS::~ReadBufferFromHDFS()
+{
+}
+
+}
+
+#endif

--- a/dbms/src/IO/ReadBufferFromHDFS.cpp
+++ b/dbms/src/IO/ReadBufferFromHDFS.cpp
@@ -23,7 +23,6 @@ struct ReadBufferFromHDFS::ReadBufferFromHDFSImpl
         : hdfs_uri(hdfs_name_)
         , builder(hdfsNewBuilder())
     {
-        hdfs_uri = hdfs_name_;
         Poco::URI uri(hdfs_name_);
         auto & host = uri.getHost();
         auto port = uri.getPort();

--- a/dbms/src/IO/ReadBufferFromHDFS.cpp
+++ b/dbms/src/IO/ReadBufferFromHDFS.cpp
@@ -90,11 +90,6 @@ bool ReadBufferFromHDFS::nextImpl()
     return true;
 }
 
-const std::string & ReadBufferFromHDFS::getHDFSUri() const
-{
-    return impl->hdfs_uri;
-}
-
 ReadBufferFromHDFS::~ReadBufferFromHDFS()
 {
 }

--- a/dbms/src/IO/ReadBufferFromHDFS.cpp
+++ b/dbms/src/IO/ReadBufferFromHDFS.cpp
@@ -16,9 +16,9 @@ struct ReadBufferFromHDFS::ReadBufferFromHDFSImpl
 {
     struct HDFSBuilderDeleter
     {
-        void operator()(hdfsBuilder * builder)
+        void operator()(hdfsBuilder * builder_ptr)
         {
-            hdfsFreeBuilder(builder);
+            hdfsFreeBuilder(builder_ptr);
         }
     };
 

--- a/dbms/src/IO/ReadBufferFromHDFS.cpp
+++ b/dbms/src/IO/ReadBufferFromHDFS.cpp
@@ -19,7 +19,7 @@ struct ReadBufferFromHDFS::ReadBufferFromHDFSImpl
     hdfsFile fin;
     HDFSBuilderPtr builder;
     HDFSFSPtr fs;
- 
+
     ReadBufferFromHDFSImpl(const std::string & hdfs_name_)
         : hdfs_uri(hdfs_name_)
         , builder(createHDFSBuilder(hdfs_uri))

--- a/dbms/src/IO/ReadBufferFromHDFS.cpp
+++ b/dbms/src/IO/ReadBufferFromHDFS.cpp
@@ -15,7 +15,7 @@ namespace ErrorCodes
 struct ReadBufferFromHDFS::ReadBufferFromHDFSImpl
 {
     std::string hdfs_uri;
-    struct hdfsBuilder * builder;
+    hdfsBuilder * builder;
     hdfsFS fs;
     hdfsFile fin;
 
@@ -36,6 +36,7 @@ struct ReadBufferFromHDFS::ReadBufferFromHDFSImpl
         // set read/connect timeout, default value in libhdfs3 is about 1 hour, and too large
         /// TODO Allow to tune from query Settings.
         hdfsBuilderConfSetStr(builder, "input.read.timeout", "60000"); // 1 min
+        hdfsBuilderConfSetStr(builder, "input.write.timeout", "60000"); // 1 min
         hdfsBuilderConfSetStr(builder, "input.connect.timeout", "60000"); // 1 min
 
         hdfsBuilderSetNameNode(builder, host.c_str());
@@ -65,9 +66,8 @@ struct ReadBufferFromHDFS::ReadBufferFromHDFSImpl
     {
         int bytes_read = hdfsRead(fs, fin, start, size);
         if (bytes_read < 0)
-        {
-            throw Exception("Fail to read HDFS file: " + hdfs_uri + " " + std::string(hdfsGetLastError()), ErrorCodes::NETWORK_ERROR);
-        }
+            throw Exception("Fail to read HDFS file: " + hdfs_uri + " " + std::string(hdfsGetLastError()),
+                ErrorCodes::NETWORK_ERROR);
         return bytes_read;
     }
 };

--- a/dbms/src/IO/ReadBufferFromHDFS.h
+++ b/dbms/src/IO/ReadBufferFromHDFS.h
@@ -24,8 +24,6 @@ public:
     bool nextImpl() override;
 
     ~ReadBufferFromHDFS() override;
-
-    const std::string & getHDFSUri() const;
 };
 }
 #endif

--- a/dbms/src/IO/ReadBufferFromHDFS.h
+++ b/dbms/src/IO/ReadBufferFromHDFS.h
@@ -4,94 +4,28 @@
 
 #if USE_HDFS
 #include <IO/ReadBuffer.h>
-#include <Poco/URI.h>
-#include <hdfs/hdfs.h>
 #include <IO/BufferWithOwnMemory.h>
 #include <string>
-
-#ifndef O_DIRECT
-#define O_DIRECT 00040000
-#endif
+#include <memory>
 
 namespace DB
 {
-    namespace ErrorCodes
-    {
-        extern const int BAD_ARGUMENTS;
-        extern const int NETWORK_ERROR;
-    }
-    /** Accepts path to file and opens it, or pre-opened file descriptor.
-     * Closes file by himself (thus "owns" a file descriptor).
-     */
-    class ReadBufferFromHDFS : public BufferWithOwnMemory<ReadBuffer>
-    {
-        protected:
-            std::string hdfs_uri;
-            struct hdfsBuilder *builder;
-            hdfsFS fs;
-            hdfsFile fin;
-        public:
-            ReadBufferFromHDFS(const std::string & hdfs_name_, size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE)
-                : BufferWithOwnMemory<ReadBuffer>(buf_size), hdfs_uri(hdfs_name_) , builder(hdfsNewBuilder())
-            {
-                Poco::URI uri(hdfs_name_);
-                auto & host = uri.getHost();
-                auto port = uri.getPort();
-                auto & path = uri.getPath();
-                if (host.empty() || port == 0 || path.empty())
-                {
-                    throw Exception("Illegal HDFS URI: " + hdfs_uri, ErrorCodes::BAD_ARGUMENTS);
-                }
-                // set read/connect timeout, default value in libhdfs3 is about 1 hour, and too large
-                /// TODO Allow to tune from query Settings.
-                hdfsBuilderConfSetStr(builder, "input.read.timeout", "60000"); // 1 min
-                hdfsBuilderConfSetStr(builder, "input.connect.timeout", "60000"); // 1 min
+/** Accepts path to file and opens it, or pre-opened file descriptor.
+ * Closes file by himself (thus "owns" a file descriptor).
+ */
+class ReadBufferFromHDFS : public BufferWithOwnMemory<ReadBuffer>
+{
+    struct ReadBufferFromHDFSImpl;
+    std::unique_ptr<ReadBufferFromHDFSImpl> impl;
+public:
+    ReadBufferFromHDFS(const std::string & hdfs_name_, size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE);
+    ReadBufferFromHDFS(ReadBufferFromHDFS &&) = default;
 
-                hdfsBuilderSetNameNode(builder, host.c_str());
-                hdfsBuilderSetNameNodePort(builder, port);
-                fs = hdfsBuilderConnect(builder);
+    bool nextImpl() override;
 
-                if (fs == nullptr)
-                {
-                    throw Exception("Unable to connect to HDFS: " + std::string(hdfsGetLastError()), ErrorCodes::NETWORK_ERROR);
-                }
+    ~ReadBufferFromHDFS() override;
 
-                fin = hdfsOpenFile(fs, path.c_str(), O_RDONLY, 0, 0, 0);
-            }
-
-            ReadBufferFromHDFS(ReadBufferFromHDFS &&) = default;
-
-            ~ReadBufferFromHDFS() override
-            {
-                close();
-                hdfsFreeBuilder(builder);
-            }
-
-            /// Close HDFS connection before destruction of object.
-            void close()
-            {
-                hdfsCloseFile(fs, fin);
-            }
-
-            bool nextImpl() override
-            {
-                int bytes_read = hdfsRead(fs, fin, internal_buffer.begin(), internal_buffer.size());
-                if (bytes_read < 0)
-                {
-                    throw Exception("Fail to read HDFS file: " + hdfs_uri + " " + std::string(hdfsGetLastError()), ErrorCodes::NETWORK_ERROR);
-                }
-
-                if (bytes_read)
-                    working_buffer.resize(bytes_read);
-                else
-                    return false;
-                return true;
-            }
-
-            const std::string & getHDFSUri() const
-            {
-                return hdfs_uri;
-            }
-    };
+    const std::string & getHDFSUri() const;
+};
 }
 #endif

--- a/dbms/src/IO/ReadBufferFromHDFS.h
+++ b/dbms/src/IO/ReadBufferFromHDFS.h
@@ -10,7 +10,7 @@
 
 namespace DB
 {
-/** Accepts path to file and opens it, or pre-opened file descriptor.
+/** Accepts HDFS path to file and opens it.
  * Closes file by himself (thus "owns" a file descriptor).
  */
 class ReadBufferFromHDFS : public BufferWithOwnMemory<ReadBuffer>

--- a/dbms/src/IO/WriteBufferFromHDFS.cpp
+++ b/dbms/src/IO/WriteBufferFromHDFS.cpp
@@ -23,8 +23,8 @@ struct WriteBufferFromHDFS::WriteBufferFromHDFSImpl
     hdfsFile fout;
 
     WriteBufferFromHDFSImpl(const std::string & hdfs_name_)
+        : hdfs_uri(hdfs_name_)
     {
-        hdfs_uri = hdfs_name_;
         Poco::URI uri(hdfs_name_);
         auto & host = uri.getHost();
         auto port = uri.getPort();

--- a/dbms/src/IO/WriteBufferFromHDFS.cpp
+++ b/dbms/src/IO/WriteBufferFromHDFS.cpp
@@ -19,9 +19,9 @@ struct WriteBufferFromHDFS::WriteBufferFromHDFSImpl
 {
     struct HDFSBuilderDeleter
     {
-        void operator()(hdfsBuilder * builder)
+        void operator()(hdfsBuilder * builder_ptr)
         {
-            hdfsFreeBuilder(builder);
+            hdfsFreeBuilder(builder_ptr);
         }
     };
 

--- a/dbms/src/IO/WriteBufferFromHDFS.cpp
+++ b/dbms/src/IO/WriteBufferFromHDFS.cpp
@@ -60,6 +60,12 @@ struct WriteBufferFromHDFS::WriteBufferFromHDFSImpl
         }
 
         fout = hdfsOpenFile(fs, path.c_str(), O_WRONLY, 0, 0, 0);
+        if (fout == nullptr)
+        {
+            throw Exception("Unable to open HDFS file: " + path + " error: " + std::string(hdfsGetLastError()),
+                ErrorCodes::NETWORK_ERROR);
+        }
+
     }
 
     ~WriteBufferFromHDFSImpl()

--- a/dbms/src/IO/WriteBufferFromHDFS.cpp
+++ b/dbms/src/IO/WriteBufferFromHDFS.cpp
@@ -17,13 +17,22 @@ extern const int CANNOT_FSYNC;
 
 struct WriteBufferFromHDFS::WriteBufferFromHDFSImpl
 {
+    struct HDFSBuilderDeleter
+    {
+        void operator()(hdfsBuilder * builder)
+        {
+            hdfsFreeBuilder(builder);
+        }
+    };
+
     std::string hdfs_uri;
-    hdfsBuilder * builder;
+    std::unique_ptr<hdfsBuilder, HDFSBuilderDeleter> builder;
     hdfsFS fs;
     hdfsFile fout;
 
     WriteBufferFromHDFSImpl(const std::string & hdfs_name_)
         : hdfs_uri(hdfs_name_)
+        , builder(hdfsNewBuilder())
     {
         Poco::URI uri(hdfs_name_);
         auto & host = uri.getHost();
@@ -34,21 +43,20 @@ struct WriteBufferFromHDFS::WriteBufferFromHDFSImpl
             throw Exception("Illegal HDFS URI: " + hdfs_uri, ErrorCodes::BAD_ARGUMENTS);
         }
 
-        builder = hdfsNewBuilder();
         // set read/connect timeout, default value in libhdfs3 is about 1 hour, and too large
         /// TODO Allow to tune from query Settings.
-        hdfsBuilderConfSetStr(builder, "input.read.timeout", "60000"); // 1 min
-        hdfsBuilderConfSetStr(builder, "input.write.timeout", "60000"); // 1 min
-        hdfsBuilderConfSetStr(builder, "input.connect.timeout", "60000"); // 1 min
+        hdfsBuilderConfSetStr(builder.get(), "input.read.timeout", "60000"); // 1 min
+        hdfsBuilderConfSetStr(builder.get(), "input.write.timeout", "60000"); // 1 min
+        hdfsBuilderConfSetStr(builder.get(), "input.connect.timeout", "60000"); // 1 min
 
-        hdfsBuilderSetNameNode(builder, host.c_str());
-        hdfsBuilderSetNameNodePort(builder, port);
-        fs = hdfsBuilderConnect(builder);
+        hdfsBuilderSetNameNode(builder.get(), host.c_str());
+        hdfsBuilderSetNameNodePort(builder.get(), port);
+        fs = hdfsBuilderConnect(builder.get());
 
         if (fs == nullptr)
         {
-            hdfsFreeBuilder(builder);
-            throw Exception("Unable to connect to HDFS: " + std::string(hdfsGetLastError()), ErrorCodes::NETWORK_ERROR);
+            throw Exception("Unable to connect to HDFS: " + std::string(hdfsGetLastError()),
+                ErrorCodes::NETWORK_ERROR);
         }
 
         fout = hdfsOpenFile(fs, path.c_str(), O_WRONLY, 0, 0, 0);

--- a/dbms/src/IO/WriteBufferFromHDFS.cpp
+++ b/dbms/src/IO/WriteBufferFromHDFS.cpp
@@ -1,0 +1,119 @@
+#include <IO/WriteBufferFromHDFS.h>
+
+#if USE_HDFS
+#include <Poco/URI.h>
+#include <hdfs/hdfs.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+extern const int BAD_ARGUMENTS;
+extern const int NETWORK_ERROR;
+extern const int CANNOT_FSYNC;
+}
+
+
+struct WriteBufferFromHDFS::WriteBufferFromHDFSImpl
+{
+    std::string hdfs_uri;
+    hdfsBuilder * builder;
+    hdfsFS fs;
+    hdfsFile fout;
+
+    WriteBufferFromHDFSImpl(const std::string & hdfs_name_)
+    {
+        builder = hdfsNewBuilder();
+        hdfs_uri = hdfs_name_;
+        Poco::URI uri(hdfs_name_);
+        auto & host = uri.getHost();
+        auto port = uri.getPort();
+        auto & path = uri.getPath();
+        if (host.empty() || port == 0 || path.empty())
+        {
+            throw Exception("Illegal HDFS URI: " + hdfs_uri, ErrorCodes::BAD_ARGUMENTS);
+        }
+        // set read/connect timeout, default value in libhdfs3 is about 1 hour, and too large
+        /// TODO Allow to tune from query Settings.
+        hdfsBuilderConfSetStr(builder, "input.read.timeout", "60000"); // 1 min
+        hdfsBuilderConfSetStr(builder, "input.write.timeout", "60000"); // 1 min
+        hdfsBuilderConfSetStr(builder, "input.connect.timeout", "60000"); // 1 min
+
+        hdfsBuilderSetNameNode(builder, host.c_str());
+        hdfsBuilderSetNameNodePort(builder, port);
+        fs = hdfsBuilderConnect(builder);
+
+        if (fs == nullptr)
+        {
+            throw Exception("Unable to connect to HDFS: " + std::string(hdfsGetLastError()), ErrorCodes::NETWORK_ERROR);
+        }
+
+        fout = hdfsOpenFile(fs, path.c_str(), O_WRONLY, 0, 0, 0);
+    }
+
+    ~WriteBufferFromHDFSImpl()
+    {
+        close();
+        hdfsFreeBuilder(builder);
+    }
+
+    void close()
+    {
+        hdfsCloseFile(fs, fout);
+    }
+
+
+    int write(const char * start, size_t size)
+    {
+        int bytes_written = hdfsWrite(fs, fout, start, size);
+        if (bytes_written < 0)
+            throw Exception("Fail to write HDFS file: " + hdfs_uri + " " + std::string(hdfsGetLastError()),
+                ErrorCodes::NETWORK_ERROR);
+        return bytes_written;
+    }
+
+    void sync()
+    {
+        int result = hdfsSync(fs, fout);
+        if (result < 0)
+            throwFromErrno("Cannot HDFS sync" + hdfs_uri + " " + std::string(hdfsGetLastError()),
+                ErrorCodes::CANNOT_FSYNC);
+    }
+};
+
+WriteBufferFromHDFS::WriteBufferFromHDFS(const std::string & hdfs_name_, size_t buf_size)
+    : BufferWithOwnMemory<WriteBuffer>(buf_size)
+    , impl(std::make_unique<WriteBufferFromHDFSImpl>(hdfs_name_))
+{
+}
+
+
+void WriteBufferFromHDFS::nextImpl()
+{
+    if (!offset())
+        return;
+
+    size_t bytes_written = 0;
+
+    while (bytes_written != offset())
+        bytes_written += impl->write(working_buffer.begin() + bytes_written, offset() - bytes_written);
+}
+
+
+void WriteBufferFromHDFS::sync()
+{
+    impl->sync();
+}
+
+const std::string & WriteBufferFromHDFS::getHDFSUri() const
+{
+    return impl->hdfs_uri;
+}
+
+WriteBufferFromHDFS::~WriteBufferFromHDFS()
+{
+}
+
+}
+#endif

--- a/dbms/src/IO/WriteBufferFromHDFS.h
+++ b/dbms/src/IO/WriteBufferFromHDFS.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <Common/config.h>
+
+#if USE_HDFS
+#include <IO/WriteBuffer.h>
+#include <IO/BufferWithOwnMemory.h>
+#include <string>
+#include <memory>
+
+namespace DB
+{
+/** Accepts path to file and opens it, or pre-opened file descriptor.
+ * Closes file by himself (thus "owns" a file descriptor).
+ */
+class WriteBufferFromHDFS : public BufferWithOwnMemory<WriteBuffer>
+{
+    struct WriteBufferFromHDFSImpl;
+    std::unique_ptr<WriteBufferFromHDFSImpl> impl;
+public:
+    WriteBufferFromHDFS(const std::string & hdfs_name_, size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE);
+    WriteBufferFromHDFS(WriteBufferFromHDFS &&) = default;
+
+    void nextImpl() override;
+
+    ~WriteBufferFromHDFS() override;
+
+    const std::string & getHDFSUri() const;
+
+    void sync();
+};
+}
+#endif

--- a/dbms/src/IO/WriteBufferFromHDFS.h
+++ b/dbms/src/IO/WriteBufferFromHDFS.h
@@ -25,8 +25,6 @@ public:
 
     ~WriteBufferFromHDFS() override;
 
-    const std::string & getHDFSUri() const;
-
     void sync();
 };
 }

--- a/dbms/src/IO/WriteBufferFromHDFS.h
+++ b/dbms/src/IO/WriteBufferFromHDFS.h
@@ -10,7 +10,7 @@
 
 namespace DB
 {
-/** Accepts path to file and opens it, or pre-opened file descriptor.
+/** Accepts HDFS path to file and opens it.
  * Closes file by himself (thus "owns" a file descriptor).
  */
 class WriteBufferFromHDFS : public BufferWithOwnMemory<WriteBuffer>

--- a/dbms/src/Storages/StorageHDFS.cpp
+++ b/dbms/src/Storages/StorageHDFS.cpp
@@ -131,7 +131,7 @@ private:
 BlockInputStreams StorageHDFS::read(
     const Names & /*column_names*/,
     const SelectQueryInfo & /*query_info*/,
-    const Context & context,
+    const Context & context_,
     QueryProcessingStage::Enum  /*processed_stage*/,
     size_t max_block_size,
     unsigned /*num_streams*/)
@@ -140,7 +140,7 @@ BlockInputStreams StorageHDFS::read(
         uri,
         format_name,
         getSampleBlock(),
-        context,
+        context_,
         max_block_size)};
 }
 

--- a/dbms/src/Storages/StorageHDFS.cpp
+++ b/dbms/src/Storages/StorageHDFS.cpp
@@ -8,13 +8,12 @@
 #include <Interpreters/evaluateConstantExpression.h>
 #include <Parsers/ASTLiteral.h>
 #include <IO/ReadBufferFromHDFS.h>
+#include <IO/WriteBufferFromHDFS.h>
 #include <Formats/FormatFactory.h>
 #include <DataStreams/IBlockOutputStream.h>
 #include <DataStreams/UnionBlockInputStream.h>
 #include <DataStreams/IProfilingBlockInputStream.h>
 #include <DataStreams/OwningBlockInputStream.h>
-#include <Poco/Path.h>
-#include <Common/parseRemoteDescription.h>
 
 
 namespace DB
@@ -30,94 +29,101 @@ StorageHDFS::StorageHDFS(const String & uri_,
     const std::string & table_name_,
     const String & format_name_,
     const ColumnsDescription & columns_,
-    Context &)
-    : IStorage(columns_), uri(uri_), format_name(format_name_), table_name(table_name_)
+    Context & context_)
+    : IStorage(columns_)
+    , uri(uri_)
+    , format_name(format_name_)
+    , table_name(table_name_)
+    , context(context_)
 {
 }
 
 namespace
 {
-    class HDFSBlockInputStream : public IProfilingBlockInputStream
+
+class HDFSBlockInputStream : public IProfilingBlockInputStream
+{
+public:
+    HDFSBlockInputStream(const String & uri,
+        const String & format,
+        const Block & sample_block,
+        const Context & context,
+        size_t max_block_size)
     {
-    public:
-        HDFSBlockInputStream(const String & uri,
-            const String & format,
-            const Block & sample_block,
-            const Context & context,
-            size_t max_block_size)
-        {
-            // Assume no query and fragment in uri, todo, add sanity check
-            String glob_file_names;
-            String url_prefix = uri.substr(0, uri.find_last_of('/'));
-            if (url_prefix.length() == uri.length())
-            {
-                glob_file_names = uri;
-                url_prefix.clear();
-            }
-            else
-            {
-                url_prefix += "/";
-                glob_file_names = uri.substr(url_prefix.length());
-            }
+        std::unique_ptr<ReadBuffer> read_buf = std::make_unique<ReadBufferFromHDFS>(uri);
+        auto input_stream = FormatFactory::instance().getInput(format, *read_buf, sample_block, context, max_block_size);
+        reader = std::make_shared<OwningBlockInputStream<ReadBuffer>>(input_stream, std::move(read_buf));
+    }
 
-            std::vector<String> glob_names_list = parseRemoteDescription(glob_file_names, 0, glob_file_names.length(), ',' , 100/* hard coded max files */);
+    String getName() const override
+    {
+        return "HDFS";
+    }
 
-            BlockInputStreams inputs;
+    Block readImpl() override
+    {
+        return reader->read();
+    }
 
-            for (const auto & name : glob_names_list)
-            {
-                std::unique_ptr<ReadBuffer> read_buf = std::make_unique<ReadBufferFromHDFS>(url_prefix + name);
+    Block getHeader() const override
+    {
+        return reader->getHeader();
+    }
 
-                inputs.emplace_back(
-                    std::make_shared<OwningBlockInputStream<ReadBuffer>>(
-                        FormatFactory::instance().getInput(format, *read_buf, sample_block, context, max_block_size),
-                        std::move(read_buf)));
-            }
+    void readPrefixImpl() override
+    {
+        reader->readPrefix();
+    }
 
-            if (inputs.size() == 0)
-                throw Exception("StorageHDFS inputs interpreter error", ErrorCodes::BAD_ARGUMENTS);
+    void readSuffixImpl() override
+    {
+        reader->readSuffix();
+    }
 
-            if (inputs.size() == 1)
-            {
-                reader = inputs[0];
-            }
-            else
-            {
-                reader = std::make_shared<UnionBlockInputStream>(inputs, nullptr, context.getSettingsRef().max_distributed_connections);
-            }
-        }
+private:
+    BlockInputStreamPtr reader;
+};
 
-        String getName() const override
-        {
-            return "HDFS";
-        }
+class HDFSBlockOutputStream : public IBlockOutputStream
+{
+public:
+    HDFSBlockOutputStream(const String & uri,
+        const String & format,
+        const Block & sample_block_,
+        const Context & context)
+        : sample_block(sample_block_)
+    {
+        write_buf = std::make_unique<WriteBufferFromHDFS>(uri);
+        writer = FormatFactory::instance().getOutput(format, *write_buf, sample_block, context);
+    }
 
-        Block readImpl() override
-        {
-            return reader->read();
-        }
+    Block getHeader() const override
+    {
+        return sample_block;
+    }
 
-        Block getHeader() const override
-        {
-            return reader->getHeader();
-        }
+    void write(const Block & block) override
+    {
+        writer->write(block);
+    }
 
-        void readPrefixImpl() override
-        {
-            reader->readPrefix();
-        }
+    void writePrefix() override
+    {
+        writer->writePrefix();
+    }
 
-        void readSuffixImpl() override
-        {
-            if (auto concrete_reader = dynamic_cast<UnionBlockInputStream *>(reader.get()))
-                concrete_reader->cancel(false); // skip Union read suffix assertion
+    void writeSuffix() override
+    {
+        writer->writeSuffix();
+        writer->flush();
+        write_buf->sync();
+    }
 
-            reader->readSuffix();
-        }
-
-    private:
-        BlockInputStreamPtr reader;
-    };
+private:
+    Block sample_block;
+    std::unique_ptr<WriteBufferFromHDFS> write_buf;
+    BlockOutputStreamPtr writer;
+};
 
 }
 
@@ -142,7 +148,7 @@ void StorageHDFS::rename(const String & /*new_path_to_db*/, const String & /*new
 
 BlockOutputStreamPtr StorageHDFS::write(const ASTPtr & /*query*/, const Settings & /*settings*/)
 {
-    throw Exception("StorageHDFS write is not supported yet", ErrorCodes::NOT_IMPLEMENTED);
+    return std::make_shared<HDFSBlockOutputStream>(uri, format_name, getSampleBlock(), context);
 }
 
 void registerStorageHDFS(StorageFactory & factory)

--- a/dbms/src/Storages/StorageHDFS.h
+++ b/dbms/src/Storages/StorageHDFS.h
@@ -48,6 +48,7 @@ private:
     String uri;
     String format_name;
     String table_name;
+    Context & context;
 
     Logger * log = &Logger::get("StorageHDFS");
 };

--- a/dbms/tests/integration/test_storage_hdfs/test.py
+++ b/dbms/tests/integration/test_storage_hdfs/test.py
@@ -56,3 +56,21 @@ def test_write_table(started_cluster):
     result = "10\ttomas\t55.55\n11\tjack\t32.54\n"
     assert hdfs_api.read_data("/other_storage") == result
     assert node1.query("select * from OtherHDFSStorage order by id") == result
+
+def test_bad_hdfs_uri(started_cluster):
+    try:
+        node1.query("create table BadStorage1 (id UInt32, name String, weight Float64) ENGINE = HDFS('hads:hgsdfs100500:9000/other_storage', 'TSV')")
+    except Exception as ex:
+        print ex
+        assert 'Illegal HDFS URI' in str(ex)
+    try:
+        node1.query("create table BadStorage2 (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs100500:9000/other_storage', 'TSV')")
+    except Exception as ex:
+        print ex
+        assert 'Unable to create builder to connect to HDFS' in str(ex)
+
+    try:
+        node1.query("create table BadStorage3 (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs1:9000/<>', 'TSV')")
+    except Exception as ex:
+        print ex
+        assert 'Unable to open HDFS file' in str(ex)

--- a/dbms/tests/integration/test_storage_hdfs/test.py
+++ b/dbms/tests/integration/test_storage_hdfs/test.py
@@ -45,3 +45,14 @@ def test_read_write_table(started_cluster):
     assert hdfs_api.read_data("/simple_table_function") == data
 
     assert node1.query("select * from hdfs('hdfs://hdfs1:9000/simple_table_function', 'TSV', 'id UInt64, text String, number Float64')") == data
+
+
+def test_write_table(started_cluster):
+    hdfs_api = HDFSApi("root")
+
+    node1.query("create table OtherHDFSStorage (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs1:9000/other_storage', 'TSV')")
+    node1.query("insert into OtherHDFSStorage values (10, 'tomas', 55.55), (11, 'jack', 32.54)")
+
+    result = "10\ttomas\t55.55\n11\tjack\t32.54\n"
+    assert hdfs_api.read_data("/other_storage") == result
+    assert node1.query("select * from OtherHDFSStorage order by id") == result


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- New Feature

Short description (up to few sentences):
Add ability to write data into HDFS and small refactoring.

**NOTE:** Previously there was strange possibility to specify HDFS URL in the following form:
```
create table SimpleHDFSStorage ...
ENGINE = HDFS('hdfs://hdfs1:9000/file1,file2,file3', 'TSV')
```
This format is not consistent with official https://hadoop.apache.org/docs/r2.4.1/hadoop-project-dist/hadoop-common/FileSystemShell.html:
```
The URI format is scheme://authority/path. For HDFS the scheme is hdfs, and for the Local FS the scheme is file. The scheme and authority are optional. If not specified, the default scheme specified in the configuration is used. An HDFS file or directory such as /parent/child can be specified as hdfs://namenodehost/parent/child or simply as /parent/child (given that your configuration is set to point to hdfs://namenodehost).
```
So I have removed this ability -- now only one file is allowed.