### PR TITLE
Add setting to Kafka Engine to control number of parsing errors

### DIFF
--- a/dbms/src/Storages/Kafka/KafkaSettings.h
+++ b/dbms/src/Storages/Kafka/KafkaSettings.h
@@ -23,11 +23,12 @@ struct KafkaSettings
     M(SettingString, kafka_broker_list, "", "A comma-separated list of brokers for Kafka engine.") \
     M(SettingString, kafka_topic_list, "", "A list of Kafka topics.") \
     M(SettingString, kafka_group_name, "", "A group of Kafka consumers.") \
-    M(SettingString, kafka_format, "", "Message format for Kafka engine.") \
+    M(SettingString, kafka_format, "", "The message format for Kafka engine.") \
     M(SettingChar, kafka_row_delimiter, '\0', "The character to be considered as a delimiter in Kafka message.") \
     M(SettingString, kafka_schema, "", "Schema identifier (used by schema-based formats) for Kafka engine") \
     M(SettingUInt64, kafka_num_consumers, 1, "The number of consumers per table for Kafka engine.") \
-    M(SettingUInt64, kafka_max_block_size, 0, "The maximum block size per table for Kafka engine.")
+    M(SettingUInt64, kafka_max_block_size, 0, "The maximum block size per table for Kafka engine.") \
+    M(SettingUInt64, kafka_skip_broken_messages, 0, "Skip at least this number of consecutive broken messages from Kafka topic")
 
 #define DECLARE(TYPE, NAME, DEFAULT, DESCRIPTION) \
     TYPE NAME {DEFAULT};

--- a/dbms/src/Storages/Kafka/KafkaSettings.h
+++ b/dbms/src/Storages/Kafka/KafkaSettings.h
@@ -28,7 +28,7 @@ struct KafkaSettings
     M(SettingString, kafka_schema, "", "Schema identifier (used by schema-based formats) for Kafka engine") \
     M(SettingUInt64, kafka_num_consumers, 1, "The number of consumers per table for Kafka engine.") \
     M(SettingUInt64, kafka_max_block_size, 0, "The maximum block size per table for Kafka engine.") \
-    M(SettingUInt64, kafka_skip_broken_messages, 0, "Skip at least this number of consecutive broken messages from Kafka topic")
+    M(SettingUInt64, kafka_skip_broken_messages, 0, "Skip at least this number of broken messages from Kafka topic per block")
 
 #define DECLARE(TYPE, NAME, DEFAULT, DESCRIPTION) \
     TYPE NAME {DEFAULT};

--- a/dbms/src/Storages/Kafka/StorageKafka.h
+++ b/dbms/src/Storages/Kafka/StorageKafka.h
@@ -80,6 +80,8 @@ private:
     std::mutex mutex;
     std::vector<ConsumerPtr> consumers; /// Available consumers
 
+    size_t skip_broken;
+
     // Stream thread
     BackgroundSchedulePool::TaskHolder task;
     std::atomic<bool> stream_cancelled{false};
@@ -101,7 +103,7 @@ protected:
         const ColumnsDescription & columns_,
         const String & brokers_, const String & group_, const Names & topics_,
         const String & format_name_, char row_delimiter_, const String & schema_name_,
-        size_t num_consumers_, size_t max_block_size_);
+        size_t num_consumers_, size_t max_block_size_, size_t skip_broken);
 };
 
 }

--- a/dbms/tests/instructions/kafka.txt
+++ b/dbms/tests/instructions/kafka.txt
@@ -1,0 +1,45 @@
+Use this config for docker-compose:
+
+    version: '3'
+
+    services:
+
+    kafka:
+        depends_on:
+        - zookeeper
+        hostname: kafka
+        image: wurstmeister/kafka
+        environment:
+        KAFKA_LISTENERS: INSIDE://:9092,OUTSIDE://:9094
+        KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+        KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
+        KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+        ports:
+        - "9092:9092"
+        - "9094:9094"
+
+        security_opt:
+        - label:disable
+
+    zookeeper:
+        hostname: zookeeper
+        image: zookeeper
+
+        security_opt:
+        - label:disable
+
+Start containers with `docker-compose up`.
+
+In clickhouse-client create table like:
+
+    CREATE TABLE kafka ( a UInt8,  b String) ENGINE = Kafka('localhost:9092', 'topic', 'group1', 'CSV') SETTINGS kafka_row_delimiter = '\n';
+
+Login inside Kafka container and stream some data:
+
+    docker exec -it <kafka_container_id> bash --login
+    vi data.csv
+    cat data.csv | /opt/kafka/bin/kafka-console-producer.sh --topic topic --broker-list localhost:9092
+    
+Read data in clickhouse:
+
+    SELECT * FROM kafka;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Allow Kafka Engine to ignore some number of parsing errors per block.

Detailed description (optional):
By default this settings is 0, so engine will fail to read anything beyond broken message.
This new settings 'kafka_skip_broken_messages` applies to the background mode (with materialized views). Also if this setting is not 0, then it also applies to manual selects but allows to skip any number of broken messages.