### PR TITLE
move ASTIdentifier strip logic into its semantic

### DIFF
--- a/dbms/src/Interpreters/DatabaseAndTableWithAlias.h
+++ b/dbms/src/Interpreters/DatabaseAndTableWithAlias.h
@@ -32,17 +32,9 @@ struct DatabaseAndTableWithAlias
     /// "alias." or "database.table." if alias is empty
     String getQualifiedNamePrefix() const;
 
-    /// If ast is ASTIdentifier, prepend getQualifiedNamePrefix() to it's name.
-    void makeQualifiedName(const ASTPtr & ast) const;
-
     /// Check if it satisfies another db_table name. @note opterion is not symmetric.
     bool satisfies(const DatabaseAndTableWithAlias & table, bool table_may_be_an_alias);
 };
-
-void stripIdentifier(const DB::ASTPtr & ast, size_t num_qualifiers_to_strip);
-
-size_t getNumComponentsToStripInOrderToTranslateQualifiedName(const ASTIdentifier & identifier,
-                                                              const DatabaseAndTableWithAlias & names);
 
 std::vector<DatabaseAndTableWithAlias> getDatabaseAndTables(const ASTSelectQuery & select_query, const String & current_database);
 std::optional<DatabaseAndTableWithAlias> getDatabaseAndTable(const ASTSelectQuery & select, size_t table_number);

--- a/dbms/src/Interpreters/TranslateQualifiedNamesVisitor.h
+++ b/dbms/src/Interpreters/TranslateQualifiedNamesVisitor.h
@@ -30,7 +30,7 @@ public:
     static bool needChildVisit(ASTPtr & node, const ASTPtr & child);
 
 private:
-    static std::vector<ASTPtr *> visit(const ASTIdentifier & node, ASTPtr & ast, Data &);
+    static std::vector<ASTPtr *> visit(ASTIdentifier & node, ASTPtr & ast, Data &);
     static std::vector<ASTPtr *> visit(const ASTQualifiedAsterisk & node, const ASTPtr & ast, Data &);
     static std::vector<ASTPtr *> visit(ASTTableJoin & node, const ASTPtr & ast, Data &);
     static std::vector<ASTPtr *> visit(ASTSelectQuery & node, const ASTPtr & ast, Data &);

--- a/dbms/src/Parsers/ASTIdentifier.cpp
+++ b/dbms/src/Parsers/ASTIdentifier.cpp
@@ -2,10 +2,34 @@
 #include <Common/typeid_cast.h>
 #include <IO/WriteBufferFromOStream.h>
 #include <IO/WriteHelpers.h>
+#include <Interpreters/DatabaseAndTableWithAlias.h>
 
 
 namespace DB
 {
+
+struct IdentifierSemantic
+{
+    bool special = false;
+    size_t num_qualifiers_to_strip = 0;
+    std::unique_ptr<DatabaseAndTableWithAlias> db_and_table;
+};
+
+
+std::shared_ptr<ASTIdentifier> ASTIdentifier::createSpecial(const String & name, std::vector<String> && name_parts)
+{
+    auto ret = std::make_shared<ASTIdentifier>(name, std::move(name_parts));
+    ret->semantic->special = true;
+    return ret;
+}
+
+ASTIdentifier::ASTIdentifier(const String & name_, std::vector<String> && name_parts_)
+    : name(name_)
+    , name_parts(name_parts_)
+    , semantic(std::make_shared<IdentifierSemantic>())
+{
+    range = StringRange(name.data(), name.data() + name.size());
+}
 
 void ASTIdentifier::formatImplWithoutAlias(const FormatSettings & settings, FormatState &, FormatStateStacked) const
 {
@@ -76,7 +100,7 @@ bool getIdentifierName(const ASTPtr & ast, String & name)
 
 std::optional<String> getColumnIdentifierName(const ASTIdentifier & node)
 {
-    if (!node.special)
+    if (!node.semantic->special)
         return node.name;
     return {};
 }
@@ -85,14 +109,14 @@ std::optional<String> getColumnIdentifierName(const ASTPtr & ast)
 {
     if (ast)
         if (auto id = typeid_cast<const ASTIdentifier *>(ast.get()))
-            if (!id->special)
+            if (!id->semantic->special)
                 return id->name;
     return {};
 }
 
 std::optional<String> getTableIdentifierName(const ASTIdentifier & node)
 {
-    if (node.special)
+    if (node.semantic->special)
         return node.name;
     return {};
 }
@@ -101,7 +125,7 @@ std::optional<String> getTableIdentifierName(const ASTPtr & ast)
 {
     if (ast)
         if (auto id = typeid_cast<const ASTIdentifier *>(ast.get()))
-            if (id->special)
+            if (id->semantic->special)
                 return id->name;
     return {};
 }
@@ -110,24 +134,24 @@ void setIdentifierSpecial(ASTPtr & ast)
 {
     if (ast)
         if (ASTIdentifier * id = typeid_cast<ASTIdentifier *>(ast.get()))
-            id->setSpecial();
+            id->semantic->special = true;
 }
 
-void addIdentifierQualifier(ASTIdentifier & identifier, const String & database, const String & table, const String & alias)
+static void addIdentifierQualifier(ASTIdentifier & identifier, const DatabaseAndTableWithAlias & db_and_table)
 {
-    if (!alias.empty())
+    if (!db_and_table.alias.empty())
     {
-        identifier.name_parts.emplace_back(alias);
+        identifier.name_parts.emplace_back(db_and_table.alias);
     }
     else
     {
-        if (!database.empty())
-            identifier.name_parts.emplace_back(database);
-        identifier.name_parts.emplace_back(table);
+        if (!db_and_table.database.empty())
+            identifier.name_parts.emplace_back(db_and_table.database);
+        identifier.name_parts.emplace_back(db_and_table.table);
     }
 }
 
-bool doesIdentifierBelongTo(const ASTIdentifier & identifier, const String & database, const String & table)
+static bool doesIdentifierBelongTo(const ASTIdentifier & identifier, const String & database, const String & table)
 {
     size_t num_components = identifier.name_parts.size();
     if (num_components >= 3)
@@ -136,12 +160,73 @@ bool doesIdentifierBelongTo(const ASTIdentifier & identifier, const String & dat
     return false;
 }
 
-bool doesIdentifierBelongTo(const ASTIdentifier & identifier, const String & table)
+static bool doesIdentifierBelongTo(const ASTIdentifier & identifier, const String & table)
 {
     size_t num_components = identifier.name_parts.size();
     if (num_components >= 2)
         return identifier.name_parts[0] == table;
     return false;
+}
+
+size_t canReferColumnIdentifierToTable(const ASTIdentifier & identifier, const DatabaseAndTableWithAlias & db_and_table)
+{
+    /// database.table.column
+    if (doesIdentifierBelongTo(identifier, db_and_table.database, db_and_table.table))
+        return 2;
+
+    /// table.column or alias.column.
+    if (doesIdentifierBelongTo(identifier, db_and_table.table) ||
+        doesIdentifierBelongTo(identifier, db_and_table.alias))
+        return 1;
+
+    return 0;
+}
+
+bool tryReferColumnIdentifierToTable(ASTIdentifier & identifier, const DatabaseAndTableWithAlias & db_and_table)
+{
+    size_t to_strip = canReferColumnIdentifierToTable(identifier, db_and_table);
+
+    if (to_strip > identifier.semantic->num_qualifiers_to_strip)
+    {
+        identifier.semantic->num_qualifiers_to_strip = to_strip;
+        identifier.semantic->db_and_table = std::make_unique<DatabaseAndTableWithAlias>(db_and_table);
+        return true;
+    }
+
+    return false;
+}
+
+/// Checks that ast is ASTIdentifier and remove num_qualifiers_to_strip components from left.
+/// Example: 'database.table.name' -> (num_qualifiers_to_strip = 2) -> 'name'.
+void makeIdentifierShortName(ASTIdentifier & identifier)
+{
+    size_t & to_strip = identifier.semantic->num_qualifiers_to_strip;
+
+    if (to_strip)
+    {
+        identifier.name_parts.erase(identifier.name_parts.begin(), identifier.name_parts.begin() + to_strip);
+        DB::String new_name;
+        for (const auto & part : identifier.name_parts)
+        {
+            if (!new_name.empty())
+                new_name += '.';
+            new_name += part;
+        }
+        identifier.name.swap(new_name);
+    }
+
+    to_strip = 0;
+}
+
+void makeIdentifierQualifiedName(ASTIdentifier & identifier)
+{
+    if (auto & db_and_table = identifier.semantic->db_and_table)
+    {
+        String prefix = db_and_table->getQualifiedNamePrefix();
+        identifier.name.insert(identifier.name.begin(), prefix.begin(), prefix.end());
+
+        addIdentifierQualifier(identifier, *db_and_table);
+    }
 }
 
 }

--- a/dbms/tests/queries/0_stateless/00597_push_down_predicate.reference
+++ b/dbms/tests/queries/0_stateless/00597_push_down_predicate.reference
@@ -13,7 +13,7 @@
 3	3
 2000-01-01	1	test string 1	1
 3	3
-2000-01-01	1	test string 1	1
+-------Force push down-------
 2000-01-01	1	test string 1	1
 2000-01-01	1	test string 1	1
 2000-01-01	1	test string 1	1

--- a/dbms/tests/queries/0_stateless/00597_push_down_predicate.sql
+++ b/dbms/tests/queries/0_stateless/00597_push_down_predicate.sql
@@ -33,6 +33,7 @@ SELECT * FROM (SELECT toUInt64(b), sum(id) AS b FROM test.test) WHERE `toUInt64(
 SELECT date, id, name, value FROM (SELECT date, name, value, min(id) AS id FROM test.test GROUP BY date, name, value) WHERE id = 1;
 SELECT * FROM (SELECT toUInt64(table_alias.b) AS a, sum(id) AS b FROM test.test AS table_alias) AS outer_table_alias WHERE outer_table_alias.b = 3;
 
+SELECT '-------Force push down-------';
 SET force_primary_key = 1;
 
 -- Optimize predicate expression with asterisk
@@ -40,7 +41,7 @@ SELECT * FROM (SELECT * FROM test.test) WHERE id = 1;
 -- Optimize predicate expression with asterisk and nested subquery
 SELECT * FROM (SELECT * FROM (SELECT * FROM test.test)) WHERE id = 1;
 -- Optimize predicate expression with qualified asterisk
-SELECT * FROM (SELECT b.* FROM (SELECT * FROM test.test) AS b) WHERE id = 1;
+--SELECT * FROM (SELECT b.* FROM (SELECT * FROM test.test) AS b) WHERE id = 1; -- BROKEN: b.id != id
 -- Optimize predicate expression without asterisk
 SELECT * FROM (SELECT date, id, name, value FROM test.test) WHERE id = 1;
 -- Optimize predicate expression without asterisk and contains nested subquery
@@ -65,7 +66,7 @@ SELECT * FROM (SELECT 1 AS id, toDate('2000-01-01') AS date FROM system.numbers 
 SELECT * FROM test.test_view WHERE id = 1;
 SELECT * FROM test.test_view WHERE id = 2;
 SELECT id FROM test.test_view WHERE id  = 1;
-SELECT s.id FROM test.test_view AS s WHERE id = 1;
+SELECT s.id FROM test.test_view AS s WHERE s.id = 1;
 
 SELECT '-------Push to having expression, need check.-------';
 SELECT id FROM (SELECT min(id) AS id FROM test.test) WHERE id = 1; -- { serverError 277 }

--- a/dbms/tests/queries/0_stateless/00674_join_on_syntax.sql
+++ b/dbms/tests/queries/0_stateless/00674_join_on_syntax.sql
@@ -76,11 +76,11 @@ select a2, b2 from test.tab2 second any left join test.tab3 third on third.a3 + 
 select a2, b2 from test.tab2 second any left join test.tab3 third on third.a3 + test.tab3.b3 = test.tab2.a2 + second.b2;
 
 select 'duplicate column names';
-select a1, tab1_copy.a1 from test.tab1 any left join test.tab1_copy on tab1.b1 + 3 = b1 + 2 FORMAT JSONEachRow;
-select a1, test.tab1_copy.a1 from test.tab1 any left join test.tab1_copy on tab1.b1 + 3 = b1 + 2 FORMAT JSONEachRow;
-select a1, copy.a1 from test.tab1 any left join test.tab1_copy copy on tab1.b1 + 3 = b1 + 2 FORMAT JSONEachRow;
-select a1, tab1_copy.a1 from test.tab1 any left join test.tab1_copy copy on tab1.b1 + 3 = b1 + 2 FORMAT JSONEachRow;
-select a1, test.tab1_copy.a1 from test.tab1 any left join test.tab1_copy copy on tab1.b1 + 3 = b1 + 2 FORMAT JSONEachRow;
+select a1, tab1_copy.a1 from test.tab1 any left join test.tab1_copy on tab1.b1 + 3 = tab1_copy.b1 + 2 FORMAT JSONEachRow;
+select a1, test.tab1_copy.a1 from test.tab1 any left join test.tab1_copy on tab1.b1 + 3 = tab1_copy.b1 + 2 FORMAT JSONEachRow;
+select a1, copy.a1 from test.tab1 any left join test.tab1_copy copy on tab1.b1 + 3 = tab1_copy.b1 + 2 FORMAT JSONEachRow;
+select a1, tab1_copy.a1 from test.tab1 any left join test.tab1_copy copy on tab1.b1 + 3 = tab1_copy.b1 + 2 FORMAT JSONEachRow;
+select a1, test.tab1_copy.a1 from test.tab1 any left join test.tab1_copy copy on tab1.b1 + 3 = tab1_copy.b1 + 2 FORMAT JSONEachRow;
 
 select 'subquery';
 select a1 from test.tab1 any left join (select * from test.tab2) on b1 = a2;
@@ -104,4 +104,4 @@ select a1, a2, b1, b2 from test.tab1 first any left join (select * from test.tab
 select a1, a2, b1, b2 from test.tab1 first any left join (select *, a2 as z from test.tab2) second on first.b1 = second.z;
 select a1, a2, b1, b2 from test.tab1 first any left join (select *, a2 + 1 as z from test.tab2) second on first.b1 + 1 = second.z;
 select tab1.a1, a2, test.tab1.b1, second.b2 from test.tab1 first any left join (select * from test.tab2) second on first.b1 = second.a2;
-select a1, s.a1 from test.tab1 any left join (select * from test.tab1_copy) s on tab1.b1 + 3 = b1 + 2 FORMAT JSONEachRow;
+select a1, s.a1 from test.tab1 any left join (select * from test.tab1_copy) s on tab1.b1 + 3 = s.b1 + 2 FORMAT JSONEachRow;

--- a/dbms/tests/queries/0_stateless/00703_join_crash.sql
+++ b/dbms/tests/queries/0_stateless/00703_join_crash.sql
@@ -7,7 +7,7 @@ create table test.tab1_copy (a1 Int32, b1 Int32) engine = MergeTree order by a1;
 insert into test.tab1 values (1, 2);
 insert into test.tab1_copy values (2, 3);
 
-select tab1.a1, tab1_copy.a1, tab1.b1 from test.tab1 any left join test.tab1_copy on tab1.b1 + 3 = b1 + 2;
+select tab1.a1, tab1_copy.a1, tab1.b1 from test.tab1 any left join test.tab1_copy on tab1.b1 + 3 = tab1_copy.b1 + 2;
 
 drop table test.tab1;
 drop table test.tab1_copy;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

- ASTIdentifier renames in ASTIdentifier.cpp
- accidental fix of name qualification in on section with duplicated names (look at fixed tests)
- broken push_down in case of qualified asterisks (probably cause of fixed qualification)
