### PR TITLE
Fix "Unknown identifier" in lambda

### DIFF
--- a/dbms/src/Interpreters/RequiredSourceColumnsVisitor.cpp
+++ b/dbms/src/Interpreters/RequiredSourceColumnsVisitor.cpp
@@ -157,7 +157,7 @@ void RequiredSourceColumnsMatcher::visit(const ASTFunction & node, const ASTPtr 
                 local_aliases.push_back(name);
 
         /// visit child with masked local aliases
-        visit(node.arguments->children[1], data);
+        RequiredSourceColumnsVisitor(data).visit(node.arguments->children[1]);
 
         for (const auto & name : local_aliases)
             data.private_aliases.erase(name);

--- a/dbms/tests/queries/0_stateless/00819_ast_refactoring_bugs.sql
+++ b/dbms/tests/queries/0_stateless/00819_ast_refactoring_bugs.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS test.sign (Sign Int8, Arr Array(Int8)) ENGINE = Memory;
+
+SELECT arrayMap(x -> x * Sign, Arr) FROM test.sign;
+
+DROP TABLE test.sign;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Regression in master. Fix "Unknown identifier" error in case column names appear in lambdas.
