### PR TITLE
Doc fix: edit info about escaping

### DIFF
--- a/docs/en/interfaces/formats.md
+++ b/docs/en/interfaces/formats.md
@@ -347,10 +347,10 @@ Each result block is output as a separate table. This is necessary so that block
 Example (shown for the [PrettyCompact](#prettycompact) format):
 
 ``` sql
-SELECT * FROM t_null FORMAT 
+SELECT * FROM t_null 
 ```
 
-``` text
+```
 ┌─x─┬─y────┐
 │ 1 │ ᴺᵁᴸᴸ │
 └───┴──────┘

--- a/docs/en/interfaces/formats.md
+++ b/docs/en/interfaces/formats.md
@@ -347,11 +347,11 @@ Each result block is output as a separate table. This is necessary so that block
 Example (shown for the [PrettyCompact](#prettycompact) format):
 
 ``` sql
-SELECT * FROM t_null 
+SELECT * FROM t_null
 ```
 
 ```
-┌─x─┬─y────┐
+┌─x─┬────y─┐
 │ 1 │ ᴺᵁᴸᴸ │
 └───┴──────┘
 ```
@@ -363,9 +363,9 @@ SELECT 'String with \'quotes\' and \t character' AS Escaping_test
 ```
 
 ``` 
-┌─Escaping_test────────────────────────────┐
-│ String with 'quotes' and 	 character     │
-└──────────────────────────────────────────┘
+┌─Escaping_test────────────────────────┐
+│ String with 'quotes' and 	 character │
+└──────────────────────────────────────┘
 ```
 
 To avoid dumping too much data to the terminal, only the first 10,000 rows are printed. If the number of rows is greater than or equal to 10,000, the message "Showed first 10 000" is printed.
@@ -402,7 +402,7 @@ Extremes:
 
 ## PrettyCompact {#prettycompact}
 
-Differs from `Pretty` in that the grid is drawn between rows and the result is more compact.
+Differs from [Pretty](#pretty) in that the grid is drawn between rows and the result is more compact.
 This format is used by default in the command-line client in interactive mode.
 
 ## PrettyCompactMonoBlock {#prettycompactmonoblock}
@@ -483,7 +483,7 @@ SELECT 'string with \'quotes\' and \t with some special \n characters' AS test F
 ```
 Row 1:
 ──────
-test: string with 'quotes' and 	 with some special 
+test: string with 'quotes' and 	 with some special
  characters
 ```
 

--- a/docs/en/interfaces/formats.md
+++ b/docs/en/interfaces/formats.md
@@ -356,7 +356,7 @@ SELECT * FROM t_null
 └───┴──────┘
 ```
 
-Rows are not escaped in Pretty* format. Example is shown for the [PrettyCompact](#prettycompact) format:
+Rows are not escaped in Pretty* formats. Example is shown for the [PrettyCompact](#prettycompact) format:
 
 ``` sql
 SELECT 'String with \'quotes\' and \t character' AS Escaping_test

--- a/docs/en/interfaces/formats.md
+++ b/docs/en/interfaces/formats.md
@@ -344,37 +344,34 @@ Each result block is output as a separate table. This is necessary so that block
 
 [NULL](../query_language/syntax.md) is output as `ᴺᵁᴸᴸ`.
 
+Example (shown for the [PrettyCompact](#prettycompact) format):
+
 ``` sql
-SELECT * FROM t_null FORMAT Pretty;
+SELECT * FROM t_null FORMAT 
 ```
 
-```
-┏━━━┳━━━━━━┓
-┃ x ┃ y    ┃
-┡━━━╇━━━━━━┩
+``` text
+┌─x─┬─y────┐
 │ 1 │ ᴺᵁᴸᴸ │
 └───┴──────┘
 ```
 
-Rows are not escaped in `Pretty` format:
+Rows are not escaped in Pretty* format. Example is shown for the [PrettyCompact](#prettycompact) format:
 
 ``` sql
-:) SELECT 'String with \'quotes\' and \t character' AS Escaping_test
-FORMAT Pretty;
+SELECT 'String with \'quotes\' and \t character' AS Escaping_test
 ```
 
-```
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Escaping_test                            ┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ String with 'quotes' and      character  │
+``` 
+┌─Escaping_test────────────────────────────┐
+│ String with 'quotes' and 	 character     │
 └──────────────────────────────────────────┘
 ```
 
 To avoid dumping too much data to the terminal, only the first 10,000 rows are printed. If the number of rows is greater than or equal to 10,000, the message "Showed first 10 000" is printed.
 This format is only appropriate for outputting a query result, but not for parsing (retrieving data to insert in a table).
 
-The Pretty format supports outputting total values (when using WITH TOTALS) and extremes (when 'extremes' is set to 1). In these cases, total values and extreme values are output after the main data, in separate tables. Example (shown for the PrettyCompact format):
+The Pretty format supports outputting total values (when using WITH TOTALS) and extremes (when 'extremes' is set to 1). In these cases, total values and extreme values are output after the main data, in separate tables. Example (shown for the [PrettyCompact](#prettycompact) format):
 
 ``` sql
 SELECT EventDate, count() AS c FROM test.hits GROUP BY EventDate WITH TOTALS ORDER BY EventDate FORMAT PrettyCompact
@@ -477,10 +474,13 @@ Row 1:
 x: 1
 y: ᴺᵁᴸᴸ
 ```
-Rows are not escaped in `Vertical` format: 
+Rows are not escaped in Vertical format: 
+
+``` sql
+SELECT 'string with \'quotes\' and \t with some special \n characters' AS test FORMAT Vertical
+```
 
 ```
-:) SELECT 'string with \'quotes\' and \t with some special \n characters' AS test FORMAT Vertical;
 Row 1:
 ──────
 test: string with 'quotes' and 	 with some special 

--- a/docs/en/interfaces/formats.md
+++ b/docs/en/interfaces/formats.md
@@ -357,11 +357,11 @@ SELECT * FROM t_null
 Rows are not escaped in `Pretty` format:
 
 ``` sql
-:) SELECT 'String with \'quotes\' and \t character' AS Test_escaping
-FORMAT Pretty
+:) SELECT 'String with \'quotes\' and \t character' AS Escaping_test
+FORMAT Pretty;
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Test_escaping                             ┃
+┃ Escaping_test                             ┃
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
 │ String with 'quotes' and 	 character      │
 └───────────────────────────────────────────┘

--- a/docs/en/interfaces/formats.md
+++ b/docs/en/interfaces/formats.md
@@ -14,7 +14,6 @@ The table below lists supported formats and how they can be used in `INSERT` and
 | [CSVWithNames](#csvwithnames) | ✔ | ✔ |
 | [Values](#values) | ✔ | ✔ |
 | [Vertical](#vertical) | ✗ | ✔ |
-| [VerticalRaw](#verticalraw) | ✗ | ✔ |
 | [JSON](#json) | ✗ | ✔ |
 | [JSONCompact](#jsoncompact) | ✗ | ✔ |
 | [JSONEachRow](#jsoneachrow) | ✔ | ✔ |
@@ -355,6 +354,19 @@ SELECT * FROM t_null
 └───┴──────┘
 ```
 
+Rows are not escaped in `Pretty` format:
+
+``` sql
+:) SELECT 'String with \'quotes\' and \t character' AS Test_escaping
+FORMAT Pretty
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Test_escaping                             ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ String with 'quotes' and 	 character      │
+└───────────────────────────────────────────┘
+```
+
 To avoid dumping too much data to the terminal, only the first 10,000 rows are printed. If the number of rows is greater than or equal to 10,000, the message "Showed first 10 000" is printed.
 This format is only appropriate for outputting a query result, but not for parsing (retrieving data to insert in a table).
 
@@ -461,37 +473,17 @@ Row 1:
 x: 1
 y: ᴺᵁᴸᴸ
 ```
-
-This format is only appropriate for outputting a query result, but not for parsing (retrieving data to insert in a table).
-
-## VerticalRaw {#verticalraw}
-
-Differs from `Vertical` format in that the rows are not escaped.
-This format is only appropriate for outputting a query result, but not for parsing (retrieving data to insert in a table).
-
-Examples:
-
-```
-:) SHOW CREATE TABLE geonames FORMAT VerticalRaw;
-Row 1:
-──────
-statement: CREATE TABLE default.geonames ( geonameid UInt32, date Date DEFAULT CAST('2017-12-08' AS Date)) ENGINE = MergeTree(date, geonameid, 8192)
-
-:) SELECT 'string with \'quotes\' and \t with some special \n characters' AS test FORMAT VerticalRaw;
-Row 1:
-──────
-test: string with 'quotes' and   with some special
- characters
-```
-
-Compare with the Vertical format:
+Rows are not escaped in `Vertical` format: 
 
 ```
 :) SELECT 'string with \'quotes\' and \t with some special \n characters' AS test FORMAT Vertical;
 Row 1:
 ──────
-test: string with \'quotes\' and \t with some special \n characters
+test: string with 'quotes' and 	 with some special 
+ characters
 ```
+
+This format is only appropriate for outputting a query result, but not for parsing (retrieving data to insert in a table).
 
 ## XML {#xml}
 

--- a/docs/en/interfaces/formats.md
+++ b/docs/en/interfaces/formats.md
@@ -345,11 +345,13 @@ Each result block is output as a separate table. This is necessary so that block
 [NULL](../query_language/syntax.md) is output as `ᴺᵁᴸᴸ`.
 
 ``` sql
-SELECT * FROM t_null
+SELECT * FROM t_null FORMAT Pretty;
 ```
 
 ```
-┌─x─┬────y─┐
+┏━━━┳━━━━━━┓
+┃ x ┃ y    ┃
+┡━━━╇━━━━━━┩
 │ 1 │ ᴺᵁᴸᴸ │
 └───┴──────┘
 ```
@@ -359,12 +361,14 @@ Rows are not escaped in `Pretty` format:
 ``` sql
 :) SELECT 'String with \'quotes\' and \t character' AS Escaping_test
 FORMAT Pretty;
+```
 
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Escaping_test                             ┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ String with 'quotes' and 	 character      │
-└───────────────────────────────────────────┘
+```
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Escaping_test                            ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ String with 'quotes' and      character  │
+└──────────────────────────────────────────┘
 ```
 
 To avoid dumping too much data to the terminal, only the first 10,000 rows are printed. If the number of rows is greater than or equal to 10,000, the message "Showed first 10 000" is printed.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Doc fixes.

Short description:
- https://st.yandex-team.ru/DOCAPI-4241

Fixes according to changelog made on 2018-06-28: 
"Removed escaping in `Vertical` and `Pretty*` formats and deleted the `VerticalRaw` format." 