### PR TITLE
clickhouse-test "no binary found"

### DIFF
--- a/dbms/tests/clickhouse-test
+++ b/dbms/tests/clickhouse-test
@@ -369,12 +369,15 @@ if __name__ == '__main__':
             args.tmp = '/tmp/clickhouse-test'
     if args.tmp is None:
         args.tmp = args.queries
-
     if args.client is None:
         if os.access(args.binary + '-client', os.X_OK):
             args.client = args.binary + '-client'
-        else:
+        elif os.access(args.binary,os.X_OK):
             args.client = args.binary + ' client'
+        else:
+            print("No clickhouse binary found")
+            parser.print_help();
+            exit(0);
         if args.configclient:
             args.client += ' --config-file=' + args.configclient
         if os.getenv("CLICKHOUSE_HOST"):


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

**Category:**
- Bug Fix

**Short description:**
clickhouse-test now outputs helpful infromation when no clickhouse binart is found.

**Detailed description:**
When no binary was found clickhouse-test would output:
>   Traceback (most recent call last):
>   File "clickhouse-test", line 394, in <module>
>     main(args)
>   File "clickhouse-test", line 110, in main
>     clickhouse_proc_create = Popen(shlex.split(args.client), stdin=PIPE, stdout=PIPE, stderr=PIPE)
>   File "/usr/lib/python2.7/subprocess.py", line 394, in __init__
>     errread, errwrite)
>   File "/usr/lib/python2.7/subprocess.py", line 1047, in _execute_child
>     raise child_exception
> OSError: [Errno 2] No such file or directory

Fixed it so it now outputs:
> No clickhouse binary found

followed by the help message.