### PR TITLE
Fixed error when program cannot start within container due to capabilities.

### DIFF
--- a/debian/clickhouse-server.postinst
+++ b/debian/clickhouse-server.postinst
@@ -100,8 +100,10 @@ Please fix this and reinstall this package." >&2
     #  but the executable file inside the container has capabilities,
     #  then attempt to run this file will end up with a cryptic "Operation not permitted" message.
 
+    TMPFILE=/tmp/test_setcap.sh
+
     command -v setcap >/dev/null \
-        && touch /tmp/test.sh && chmod a+x /tmp/test.sh && /tmp/test.sh && setcap "cap_net_admin,cap_ipc_lock+ep" /tmp/test.sh && /tmp/test.sh && rm /tmp/test.sh \
+        && echo > $TMPFILE && chmod a+x $TMPFILE && $TMPFILE && setcap "cap_net_admin,cap_ipc_lock+ep" $TMPFILE && $TMPFILE && rm $TMPFILE \
         && setcap "cap_net_admin,cap_ipc_lock+ep" "${CLICKHOUSE_BINDIR}/${CLICKHOUSE_GENERIC_PROGRAM}" \
         || echo "Cannot set 'net_admin' or 'ipc_lock' capability for clickhouse binary. This is optional. Taskstats accounting will be disabled. To enable taskstats accounting you may add the required capability later manually."
 

--- a/debian/clickhouse-server.postinst
+++ b/debian/clickhouse-server.postinst
@@ -88,9 +88,20 @@ Please fix this and reinstall this package." >&2
         chmod 775 ${CLICKHOUSE_LOGDIR}
     fi
 
-    # Set net_admin capabilities to support introspection of "taskstats" performance metrics from the kernel.
+    # Set net_admin capabilities to support introspection of "taskstats" performance metrics from the kernel
+    #  and ipc_lock capabilities to allow mlock of clickhouse binary.
+
+    # 1. Check that "setcap" tool exists.
+    # 2. Check that an arbitrary program with installed capabilities can run.
+    # 3. Set the capabilities.
+
+    # The second is important for Docker and systemd-nspawn.
+    # When the container has no capabilities,
+    #  but the executable file inside the container has capabilities,
+    #  then attempt to run this file will end up with a cryptic "Operation not permitted" message.
 
     command -v setcap >/dev/null \
+        && echo > /tmp/test.sh && chmod a+x /tmp/test.sh && /tmp/test.sh && setcap "cap_net_admin,cap_ipc_lock+ep" /tmp/test.sh && /tmp/test.sh && rm /tmp/test.sh
         && setcap "cap_net_admin=+ep cap_ipc_lock=+ep" "${CLICKHOUSE_BINDIR}/${CLICKHOUSE_GENERIC_PROGRAM}" \
         || echo "Cannot set 'net_admin' or 'ipc_lock' capability for clickhouse binary. This is optional. Taskstats accounting will be disabled. To enable taskstats accounting you may add the required capability later manually."
 

--- a/debian/clickhouse-server.postinst
+++ b/debian/clickhouse-server.postinst
@@ -101,8 +101,8 @@ Please fix this and reinstall this package." >&2
     #  then attempt to run this file will end up with a cryptic "Operation not permitted" message.
 
     command -v setcap >/dev/null \
-        && echo > /tmp/test.sh && chmod a+x /tmp/test.sh && /tmp/test.sh && setcap "cap_net_admin,cap_ipc_lock+ep" /tmp/test.sh && /tmp/test.sh && rm /tmp/test.sh
-        && setcap "cap_net_admin=+ep cap_ipc_lock=+ep" "${CLICKHOUSE_BINDIR}/${CLICKHOUSE_GENERIC_PROGRAM}" \
+        && touch /tmp/test.sh && chmod a+x /tmp/test.sh && /tmp/test.sh && setcap "cap_net_admin,cap_ipc_lock+ep" /tmp/test.sh && /tmp/test.sh && rm /tmp/test.sh \
+        && setcap "cap_net_admin,cap_ipc_lock+ep" "${CLICKHOUSE_BINDIR}/${CLICKHOUSE_GENERIC_PROGRAM}" \
         || echo "Cannot set 'net_admin' or 'ipc_lock' capability for clickhouse binary. This is optional. Taskstats accounting will be disabled. To enable taskstats accounting you may add the required capability later manually."
 
     # Clean old dynamic compilation results


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Fixed error when the server cannot start with the `bash: /usr/bin/clickhouse-extract-from-config: Operation not permitted` message within Docker or systemd-nspawn.