### PR TITLE
docs: Fix `sudo` position in CPU scaling governor command

### DIFF
--- a/docs/en/operations/tips.md
+++ b/docs/en/operations/tips.md
@@ -21,7 +21,7 @@ You can use `turbostat` to view the CPU's actual clock rate under a load.
 Always use the `performance` scaling governor. The `on-demand` scaling governor works much worse with constantly high demand.
 
 ```bash
-sudo echo 'performance' | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+echo 'performance' | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 ```
 
 ## CPU Limitations

--- a/docs/ru/operations/tips.md
+++ b/docs/ru/operations/tips.md
@@ -21,7 +21,7 @@ Turbo-Boost крайне не рекомендуется отключать. П�
 Нужно всегда использовать `performance` scaling governor. `ondemand` scaling governor работает намного хуже при постоянно высоком спросе.
 
 ```bash
-sudo echo 'performance' | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+echo 'performance' | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 ```
 
 ## Ограничение CPU

--- a/docs/zh/operations/tips.md
+++ b/docs/zh/operations/tips.md
@@ -21,7 +21,7 @@ You can use `turbostat` to view the CPU's actual clock rate under a load.
 Always use the `performance` scaling governor. The `on-demand` scaling governor works much worse with constantly high demand.
 
 ```bash
-sudo echo 'performance' | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+echo 'performance' | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 ```
 
 ## CPU Limitations


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Short description (up to few sentences):

`tee` needs `sudo` in order to write to `/sys`.