### PR TITLE
Update clickhouse documentation. Add puppet module for Clickhouse

### DIFF
--- a/docs/en/interfaces/third-party/integrations.md
+++ b/docs/en/interfaces/third-party/integrations.md
@@ -22,6 +22,7 @@
 - Configuration management
     - [puppet](https://puppet.com)
         - [innogames/clickhouse](https://forge.puppet.com/innogames/clickhouse)
+        - [mfedotov/clickhouse] (https://forge.puppet.com/mfedotov/clickhouse)
 - Monitoring
     - [Graphite](https://graphiteapp.org)
         - [graphouse](https://github.com/yandex/graphouse)

--- a/docs/en/interfaces/third-party/integrations.md
+++ b/docs/en/interfaces/third-party/integrations.md
@@ -22,7 +22,7 @@
 - Configuration management
     - [puppet](https://puppet.com)
         - [innogames/clickhouse](https://forge.puppet.com/innogames/clickhouse)
-        - [mfedotov/clickhouse] (https://forge.puppet.com/mfedotov/clickhouse)
+        - [mfedotov/clickhouse](https://forge.puppet.com/mfedotov/clickhouse)
 - Monitoring
     - [Graphite](https://graphiteapp.org)
         - [graphouse](https://github.com/yandex/graphouse)

--- a/docs/fa/interfaces/third-party/integrations.md
+++ b/docs/fa/interfaces/third-party/integrations.md
@@ -24,6 +24,7 @@
 - مدیریت تنظیمات
     - [puppet](https://puppet.com)
         - [innogames/clickhouse](https://forge.puppet.com/innogames/clickhouse)
+        - [mfedotov/clickhouse] (https://forge.puppet.com/mfedotov/clickhouse)
 - نظارت بر
     - [Graphite](https://graphiteapp.org)
         - [graphouse](https://github.com/yandex/graphouse)

--- a/docs/fa/interfaces/third-party/integrations.md
+++ b/docs/fa/interfaces/third-party/integrations.md
@@ -24,7 +24,7 @@
 - مدیریت تنظیمات
     - [puppet](https://puppet.com)
         - [innogames/clickhouse](https://forge.puppet.com/innogames/clickhouse)
-        - [mfedotov/clickhouse] (https://forge.puppet.com/mfedotov/clickhouse)
+        - [mfedotov/clickhouse](https://forge.puppet.com/mfedotov/clickhouse)
 - نظارت بر
     - [Graphite](https://graphiteapp.org)
         - [graphouse](https://github.com/yandex/graphouse)

--- a/docs/ru/interfaces/third-party/integrations.md
+++ b/docs/ru/interfaces/third-party/integrations.md
@@ -21,7 +21,7 @@
 - Системы управления конфигурацией
     - [puppet](https://puppet.com)
         - [innogames/clickhouse](https://forge.puppet.com/innogames/clickhouse)
-        - [mfedotov/clickhouse] (https://forge.puppet.com/mfedotov/clickhouse)
+        - [mfedotov/clickhouse](https://forge.puppet.com/mfedotov/clickhouse)
 - Мониторинг
     - [Graphite](https://graphiteapp.org)
         - [graphouse](https://github.com/yandex/graphouse)

--- a/docs/ru/interfaces/third-party/integrations.md
+++ b/docs/ru/interfaces/third-party/integrations.md
@@ -21,6 +21,7 @@
 - Системы управления конфигурацией
     - [puppet](https://puppet.com)
         - [innogames/clickhouse](https://forge.puppet.com/innogames/clickhouse)
+        - [mfedotov/clickhouse] (https://forge.puppet.com/mfedotov/clickhouse)
 - Мониторинг
     - [Graphite](https://graphiteapp.org)
         - [graphouse](https://github.com/yandex/graphouse)

--- a/docs/zh/interfaces/third-party/integrations.md
+++ b/docs/zh/interfaces/third-party/integrations.md
@@ -21,7 +21,7 @@
 - 配置管理
     - [puppet](https://puppet.com)
         - [innogames/clickhouse](https://forge.puppet.com/innogames/clickhouse)
-        - [mfedotov/clickhouse] (https://forge.puppet.com/mfedotov/clickhouse)
+        - [mfedotov/clickhouse](https://forge.puppet.com/mfedotov/clickhouse)
 - 监控
     - [Graphite](https://graphiteapp.org)
         - [graphouse](https://github.com/yandex/graphouse)

--- a/docs/zh/interfaces/third-party/integrations.md
+++ b/docs/zh/interfaces/third-party/integrations.md
@@ -21,6 +21,7 @@
 - 配置管理
     - [puppet](https://puppet.com)
         - [innogames/clickhouse](https://forge.puppet.com/innogames/clickhouse)
+        - [mfedotov/clickhouse] (https://forge.puppet.com/mfedotov/clickhouse)
 - 监控
     - [Graphite](https://graphiteapp.org)
         - [graphouse](https://github.com/yandex/graphouse)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Other

Short description (up to few sentences):
Add puppet module for Clickhouse

Detailed description (optional):
The Clickhouse module installs, configures and manages the Clickhouse Server service. It also allows to create and manage users, quotas, profiles, dictionaries, databases as well as configure replication and sharding.
