### PR TITLE
Fix command line prefix from % to $

### DIFF
--- a/docs/ru/getting_started/index.md
+++ b/docs/ru/getting_started/index.md
@@ -73,7 +73,7 @@ Server: dbms/programs/clickhouse-server
 Для запуска сервера в качестве демона, выполните:
 
 ``` bash
-% sudo service clickhouse-server start
+$ sudo service clickhouse-server start
 ```
 
 Смотрите логи в директории `/var/log/clickhouse-server/`.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Short description (up to few sentences):
Fix command line prefix from % to $
...

Detailed description (optional):

...
