### PR TITLE
Fix non initialized codec and wrong size in CacheCompressedReadBuffer

### DIFF
--- a/dbms/src/Compression/CompressedReadBufferFromFile.cpp
+++ b/dbms/src/Compression/CompressedReadBufferFromFile.cpp
@@ -23,7 +23,7 @@ bool CompressedReadBufferFromFile::nextImpl()
     if (!size_compressed)
         return false;
 
-    memory.resize(size_decompressed + LZ4::ADDITIONAL_BYTES_AT_END_OF_BUFFER);
+    memory.resize(size_decompressed + codec->getAdditionalSizeAtTheEndOfBuffer());
     working_buffer = Buffer(memory.data(), &memory[size_decompressed]);
 
     decompress(working_buffer.begin(), size_decompressed, size_compressed_without_checksum);
@@ -91,7 +91,7 @@ size_t CompressedReadBufferFromFile::readBig(char * to, size_t n)
             return bytes_read;
 
         /// If the decompressed block fits entirely where it needs to be copied.
-        if (size_decompressed + LZ4::ADDITIONAL_BYTES_AT_END_OF_BUFFER <= n - bytes_read)
+        if (size_decompressed + codec->getAdditionalSizeAtTheEndOfBuffer() <= n - bytes_read)
         {
             decompress(to + bytes_read, size_decompressed, size_compressed_without_checksum);
             bytes_read += size_decompressed;
@@ -101,7 +101,7 @@ size_t CompressedReadBufferFromFile::readBig(char * to, size_t n)
         {
             size_compressed = new_size_compressed;
             bytes += offset();
-            memory.resize(size_decompressed + LZ4::ADDITIONAL_BYTES_AT_END_OF_BUFFER);
+            memory.resize(size_decompressed + codec->getAdditionalSizeAtTheEndOfBuffer());
             working_buffer = Buffer(memory.data(), &memory[size_decompressed]);
             pos = working_buffer.begin();
 

--- a/dbms/tests/integration/test_non_default_compression/configs/enable_uncompressed_cache.xml
+++ b/dbms/tests/integration/test_non_default_compression/configs/enable_uncompressed_cache.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<yandex>
+    <profiles>
+        <default>
+            <use_uncompressed_cache>1</use_uncompressed_cache>
+        </default>
+    </profiles>
+    <users>
+        <default>
+            <password></password>
+            <networks incl="networks" replace="replace">
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </default>
+    </users>
+
+    <quotas>
+        <default>
+        </default>
+    </quotas>
+
+</yandex>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fix segfault with uncompressed_cache=1 and exception with wrong uncompressed size.