### PR TITLE
"-C" option for client and show problematic file path

### DIFF
--- a/dbms/programs/client/Client.cpp
+++ b/dbms/programs/client/Client.cpp
@@ -1542,8 +1542,8 @@ public:
         po::options_description main_description("Main options", line_length, min_description_length);
         main_description.add_options()
             ("help", "produce help message")
-            ("config-file,c", po::value<std::string>(), "config-file path")
-            ("Config-file,C", po::value<std::string>(), "config-file path (another shorthand)")
+            ("config-file,C", po::value<std::string>(), "config-file path")
+            ("config,c", po::value<std::string>(), "config-file path (another shorthand)")
             ("host,h", po::value<std::string>()->default_value("localhost"), "server host")
             ("port", po::value<int>()->default_value(9000), "server port")
             ("secure,s", "Use TLS connection")
@@ -1650,11 +1650,14 @@ public:
         APPLY_FOR_SETTINGS(EXTRACT_SETTING)
 #undef EXTRACT_SETTING
 
+        if (options.count("config-file") && options.count("config"))
+            throw Exception("Two o more configuration files referenced in arguments", ErrorCodes::BAD_ARGUMENTS);
+
         /// Save received data into the internal config.
         if (options.count("config-file"))
             config().setString("config-file", options["config-file"].as<std::string>());
-        if (options.count("Config-file"))
-            config().setString("config-file", options["Config-file"].as<std::string>());
+        if (options.count("config"))
+            config().setString("config-file", options["config"].as<std::string>());
         if (options.count("host") && !options["host"].defaulted())
             config().setString("host", options["host"].as<std::string>());
         if (options.count("query_id"))

--- a/dbms/programs/client/Client.cpp
+++ b/dbms/programs/client/Client.cpp
@@ -1651,12 +1651,10 @@ public:
 #undef EXTRACT_SETTING
 
         /// Save received data into the internal config.
-        if (options.count("config-file")) {
+        if (options.count("config-file"))
             config().setString("config-file", options["config-file"].as<std::string>());
-        }
-        if (options.count("Config-file")) {
+        if (options.count("Config-file"))
             config().setString("config-file", options["Config-file"].as<std::string>());
-        }
         if (options.count("host") && !options["host"].defaulted())
             config().setString("host", options["host"].as<std::string>());
         if (options.count("query_id"))

--- a/dbms/programs/client/Client.cpp
+++ b/dbms/programs/client/Client.cpp
@@ -1651,7 +1651,7 @@ public:
 #undef EXTRACT_SETTING
 
         if (options.count("config-file") && options.count("config"))
-            throw Exception("Two o more configuration files referenced in arguments", ErrorCodes::BAD_ARGUMENTS);
+            throw Exception("Two or more configuration files referenced in arguments", ErrorCodes::BAD_ARGUMENTS);
 
         /// Save received data into the internal config.
         if (options.count("config-file"))

--- a/dbms/programs/client/Client.cpp
+++ b/dbms/programs/client/Client.cpp
@@ -1520,14 +1520,7 @@ public:
             else
             {
                 in_external_group = false;
-                if (0 != strcmp(arg, "-C"))
-                {
-                    common_arguments.emplace_back(arg);
-                }
-                else
-                {
-                    common_arguments.emplace_back("-c");
-                }
+                common_arguments.emplace_back(arg);
             }
         }
 

--- a/dbms/programs/client/Client.cpp
+++ b/dbms/programs/client/Client.cpp
@@ -1717,11 +1717,11 @@ public:
 
 int mainEntryClickHouseClient(int argc, char ** argv)
 {
-    DB::Client client;
-
     try
     {
+        DB::Client client;
         client.init(argc, argv);
+        return client.run();
     }
     catch (const boost::program_options::error & e)
     {
@@ -1733,6 +1733,4 @@ int mainEntryClickHouseClient(int argc, char ** argv)
         std::cerr << DB::getCurrentExceptionMessage(true) << std::endl;
         return 1;
     }
-
-    return client.run();
 }

--- a/dbms/programs/client/Client.cpp
+++ b/dbms/programs/client/Client.cpp
@@ -1520,7 +1520,14 @@ public:
             else
             {
                 in_external_group = false;
-                common_arguments.emplace_back(arg);
+                if (0 != strcmp(arg, "-C"))
+                {
+                    common_arguments.emplace_back(arg);
+                }
+                else
+                {
+                    common_arguments.emplace_back("-c");
+                }
             }
         }
 

--- a/dbms/programs/client/Client.cpp
+++ b/dbms/programs/client/Client.cpp
@@ -1543,6 +1543,7 @@ public:
         main_description.add_options()
             ("help", "produce help message")
             ("config-file,c", po::value<std::string>(), "config-file path")
+            ("Config-file,C", po::value<std::string>(), "config-file path (another shorthand)")
             ("host,h", po::value<std::string>()->default_value("localhost"), "server host")
             ("port", po::value<int>()->default_value(9000), "server port")
             ("secure,s", "Use TLS connection")
@@ -1650,8 +1651,12 @@ public:
 #undef EXTRACT_SETTING
 
         /// Save received data into the internal config.
-        if (options.count("config-file"))
+        if (options.count("config-file")) {
             config().setString("config-file", options["config-file"].as<std::string>());
+        }
+        if (options.count("Config-file")) {
+            config().setString("config-file", options["Config-file"].as<std::string>());
+        }
         if (options.count("host") && !options["host"].defaulted())
             config().setString("host", options["host"].as<std::string>());
         if (options.count("query_id"))

--- a/dbms/src/Common/Config/configReadClient.cpp
+++ b/dbms/src/Common/Config/configReadClient.cpp
@@ -3,7 +3,6 @@
 #include <Poco/Util/Application.h>
 #include <Poco/Util/LayeredConfiguration.h>
 #include <Poco/File.h>
-#include <iostream>
 #include "ConfigProcessor.h"
 
 namespace DB
@@ -23,13 +22,7 @@ bool configReadClient(Poco::Util::LayeredConfiguration & config, const std::stri
     if (!config_path.empty())
     {
         ConfigProcessor config_processor(config_path);
-        ConfigProcessor::LoadedConfig loaded_config;
-        try {
-            loaded_config = config_processor.loadConfig();
-        } catch (const Poco::Exception& ex) {
-            std::cerr << "problem with file: " << config_path << std::endl;
-            ex.rethrow();
-        }
+        auto loaded_config = config_processor.loadConfig();
         config.add(loaded_config.configuration);
         return true;
     }

--- a/dbms/src/Common/Config/configReadClient.cpp
+++ b/dbms/src/Common/Config/configReadClient.cpp
@@ -3,6 +3,7 @@
 #include <Poco/Util/Application.h>
 #include <Poco/Util/LayeredConfiguration.h>
 #include <Poco/File.h>
+#include <iostream>
 #include "ConfigProcessor.h"
 
 namespace DB
@@ -22,7 +23,13 @@ bool configReadClient(Poco::Util::LayeredConfiguration & config, const std::stri
     if (!config_path.empty())
     {
         ConfigProcessor config_processor(config_path);
-        auto loaded_config = config_processor.loadConfig();
+        ConfigProcessor::LoadedConfig loaded_config;
+        try {
+            loaded_config = config_processor.loadConfig();
+        } catch (const Poco::Exception& ex) {
+            std::cerr << "problem with file: " << config_path << std::endl;
+            ex.rethrow();
+        }
         config.add(loaded_config.configuration);
         return true;
     }

--- a/dbms/tests/queries/0_stateless/00834_dont_allow_to_set_two_configuration_files_in_client.sh
+++ b/dbms/tests/queries/0_stateless/00834_dont_allow_to_set_two_configuration_files_in_client.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+OUTPUT=`$CLICKHOUSE_CLIENT -c 1 -C 2 2>&1`
+
+#test will fail if clickouse-client exit code is 0
+if [ $? -eq 0 ]; then
+    exit 1
+fi
+
+#test will fail if no special error message was printed
+grep "Two or more configuration files referenced in arguments" > /dev/null <<< "$OUTPUT"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

Short description (up to few sentences):
Alow "-C" option of client to work as "-c" option.
Show name of problematic file when exception occurs on client config loading.
...

Detailed description (optional):

...
