### PR TITLE
Reduce mark cache size and uncompressed cache size accordingly to available memory amount

### DIFF
--- a/dbms/programs/server/Server.cpp
+++ b/dbms/programs/server/Server.cpp
@@ -398,10 +398,20 @@ int Server::main(const std::vector<std::string> & /*args*/)
     if (config().has("max_partition_size_to_drop"))
         global_context->setMaxPartitionSizeToDrop(config().getUInt64("max_partition_size_to_drop"));
 
+    const auto cache_reduce_coef = 0.5;
     /// Size of cache for uncompressed blocks. Zero means disabled.
     size_t uncompressed_cache_size = config().getUInt64("uncompressed_cache_size", 0);
-    if (uncompressed_cache_size)
+    size_t recommended_uncompressed_cache_size = cache_reduce_coef * memory_amount;
+    if (recommended_uncompressed_cache_size < uncompressed_cache_size)
+    {
+        LOG_WARNING(log, "Uncompressed cache size is set automatically: ");
+        LOG_WARNING(log, recommended_uncompressed_cache_size);
+        global_context->setUncompressedCache(recommended_uncompressed_cache_size);
+    }
+    else
+    {
         global_context->setUncompressedCache(uncompressed_cache_size);
+    }
 
     /// Load global settings from default_profile and system_profile.
     global_context->setDefaultProfiles(config());
@@ -409,8 +419,18 @@ int Server::main(const std::vector<std::string> & /*args*/)
 
     /// Size of cache for marks (index of MergeTree family of tables). It is necessary.
     size_t mark_cache_size = config().getUInt64("mark_cache_size");
-    if (mark_cache_size)
+    size_t recommended_mark_cache_size = cache_reduce_coef * memory_amount;
+    if (recommended_mark_cache_size < mark_cache_size
+        || mark_cache_size == 0)
+    {
+        LOG_WARNING(log, "Mark cache size is set automatically: ");
+        LOG_WARNING(log, recommended_mark_cache_size);
+        global_context->setMarkCache(recommended_mark_cache_size);
+    }
+    else
+    {
         global_context->setMarkCache(mark_cache_size);
+    }
 
 #if USE_EMBEDDED_COMPILER
     size_t compiled_expression_cache_size = config().getUInt64("compiled_expression_cache_size", 500);


### PR DESCRIPTION
Category (leave one):
- Performance Improvement

Short description (up to few sentences):
Sets mark cahce size and uncompressed cache size accordingly to available memory amount (with coefficient = 0.5). 
