### PR TITLE
Clickhouse server version option support

### DIFF
--- a/dbms/programs/server/Server.cpp
+++ b/dbms/programs/server/Server.cpp
@@ -157,11 +157,10 @@ void Server::defineOptions(Poco::Util::OptionSet & _options)
             .repeatable(false)
             .binding("help"));
     _options.addOption(
-            Poco::Util::Option("version", "V", "show version and exit")
-                    .required(false)
-                    .repeatable(false)
-                    .binding("version")
-    );
+        Poco::Util::Option("version", "V", "show version and exit")
+            .required(false)
+            .repeatable(false)
+            .binding("version"));
     BaseDaemon::defineOptions(_options);
 }
 

--- a/dbms/programs/server/Server.cpp
+++ b/dbms/programs/server/Server.cpp
@@ -48,6 +48,7 @@
 #include "MetricsTransmitter.h"
 #include <Common/StatusFile.h>
 #include "TCPHandlerFactory.h"
+#include "Common/config_version.h"
 
 #if defined(__linux__)
 #include <Common/hasLinuxCapability.h>
@@ -129,6 +130,11 @@ int Server::run()
         helpFormatter.format(std::cout);
         return 0;
     }
+    if (config().hasOption("version"))
+    {
+        std::cout << DBMS_NAME << " server version " << VERSION_STRING << "." << std::endl;
+        return 0;
+    }
     return Application::run();
 }
 
@@ -150,6 +156,12 @@ void Server::defineOptions(Poco::Util::OptionSet & _options)
             .required(false)
             .repeatable(false)
             .binding("help"));
+    _options.addOption(
+            Poco::Util::Option("version", "V", "show version and exit")
+                    .required(false)
+                    .repeatable(false)
+                    .binding("version")
+    );
     BaseDaemon::defineOptions(_options);
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

Short description (up to few sentences):
Support of version option for clickhouse server.
Example:
./clickhouse-server --version
ClickHouse server version 19.1.6.

./clickhouse-server -V       
ClickHouse server version 19.1.6.
