### PR TITLE
Fixed bad code for printing query_id in text logs

### DIFF
--- a/dbms/src/Common/CurrentThread.h
+++ b/dbms/src/Common/CurrentThread.h
@@ -69,7 +69,7 @@ public:
     static void finalizePerformanceCounters();
 
     /// Returns a non-empty string if the thread is attached to a query
-    static std::string getCurrentQueryID();
+    static const std::string & getQueryId();
 
     /// Non-master threads call this method in destructor automatically
     static void detachQuery();

--- a/dbms/src/Common/ThreadStatus.h
+++ b/dbms/src/Common/ThreadStatus.h
@@ -116,7 +116,7 @@ public:
         return thread_state.load(std::memory_order_relaxed);
     }
 
-    String getQueryID();
+    const std::string & getQueryId() const;
 
     /// Starts new query and create new thread group for it, current thread becomes master thread of the query
     void initializeQuery();
@@ -159,6 +159,8 @@ protected:
     Context * global_context = nullptr;
     /// Use it only from current thread
     Context * query_context = nullptr;
+
+    String query_id;
 
     /// A logs queue used by TCPHandler to pass logs to a client
     InternalTextLogsQueueWeakPtr logs_queue_ptr;

--- a/libs/libdaemon/src/ExtendedLogChannel.cpp
+++ b/libs/libdaemon/src/ExtendedLogChannel.cpp
@@ -23,7 +23,10 @@ ExtendedLogMessage ExtendedLogMessage::getFrom(const Poco::Message & base)
 
     msg_ext.time_seconds = static_cast<UInt32>(tv.tv_sec);
     msg_ext.time_microseconds = static_cast<UInt32>(tv.tv_usec);
-    msg_ext.query_id = CurrentThread::getCurrentQueryID();
+
+    if (current_thread)
+        msg_ext.query_id = CurrentThread::getQueryId();
+
     msg_ext.thread_number = Poco::ThreadNumber::get();
 
     return msg_ext;


### PR DESCRIPTION
No changes comparing to the previons stable.