### PR TITLE
Add ability to run queries by indexes

### DIFF
--- a/dbms/programs/performance-test/PerformanceTest.cpp
+++ b/dbms/programs/performance-test/PerformanceTest.cpp
@@ -25,12 +25,14 @@ PerformanceTest::PerformanceTest(
     Connection & connection_,
     InterruptListener & interrupt_listener_,
     const PerformanceTestInfo & test_info_,
-    Context & context_)
+    Context & context_,
+    const std::vector<size_t> & queries_to_run_)
     : config(config_)
     , connection(connection_)
     , interrupt_listener(interrupt_listener_)
     , test_info(test_info_)
     , context(context_)
+    , queries_to_run(queries_to_run_)
     , log(&Poco::Logger::get("PerformanceTest"))
 {
 }
@@ -157,9 +159,14 @@ void PerformanceTest::finish() const
 std::vector<TestStats> PerformanceTest::execute()
 {
     std::vector<TestStats> statistics_by_run;
+    size_t query_count;
+    if (queries_to_run.empty())
+        query_count = test_info.queries.size();
+    else
+        query_count = queries_to_run.size();
     size_t total_runs = test_info.times_to_run * test_info.queries.size();
     statistics_by_run.resize(total_runs);
-    LOG_INFO(log, "Totally will run cases " << total_runs << " times");
+    LOG_INFO(log, "Totally will run cases " << test_info.times_to_run * query_count << " times");
     UInt64 max_exec_time = calculateMaxExecTime();
     if (max_exec_time != 0)
         LOG_INFO(log, "Test will be executed for a maximum of " << max_exec_time / 1000. << " seconds");
@@ -172,9 +179,13 @@ std::vector<TestStats> PerformanceTest::execute()
 
         for (size_t query_index = 0; query_index < test_info.queries.size(); ++query_index)
         {
-            size_t statistic_index = number_of_launch * test_info.queries.size() + query_index;
-
-            queries_with_indexes.push_back({test_info.queries[query_index], statistic_index});
+            if (queries_to_run.empty() || std::find(queries_to_run.begin(), queries_to_run.end(), query_index) != queries_to_run.end())
+            {
+                size_t statistic_index = number_of_launch * test_info.queries.size() + query_index;
+                queries_with_indexes.push_back({test_info.queries[query_index], statistic_index});
+            }
+            else
+                LOG_INFO(log, "Will skip query " << test_info.queries[query_index] << " by index");
         }
 
         if (got_SIGINT)

--- a/dbms/programs/performance-test/PerformanceTest.h
+++ b/dbms/programs/performance-test/PerformanceTest.h
@@ -22,7 +22,8 @@ public:
         Connection & connection_,
         InterruptListener & interrupt_listener_,
         const PerformanceTestInfo & test_info_,
-        Context & context_);
+        Context & context_,
+        const std::vector<size_t> & queries_to_run_);
 
     bool checkPreconditions() const;
     void prepare() const;
@@ -54,6 +55,7 @@ private:
     PerformanceTestInfo test_info;
     Context & context;
 
+    std::vector<size_t> queries_to_run;
     Poco::Logger * log;
 
     bool got_SIGINT = false;

--- a/dbms/programs/performance-test/PerformanceTestSuite.cpp
+++ b/dbms/programs/performance-test/PerformanceTestSuite.cpp
@@ -11,12 +11,13 @@
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 
-#include <Poco/Util/XMLConfiguration.h>
-#include <Poco/Logger.h>
+#include <Poco/AutoPtr.h>
 #include <Poco/ConsoleChannel.h>
 #include <Poco/FormattingChannel.h>
+#include <Poco/Logger.h>
+#include <Poco/Path.h>
 #include <Poco/PatternFormatter.h>
-
+#include <Poco/Util/XMLConfiguration.h>
 
 #include <common/logger_useful.h>
 #include <Client/Connection.h>
@@ -25,7 +26,6 @@
 #include <IO/ConnectionTimeouts.h>
 #include <IO/UseSSL.h>
 #include <Interpreters/Settings.h>
-#include <Poco/AutoPtr.h>
 #include <Common/Exception.h>
 #include <Common/InterruptListener.h>
 
@@ -70,6 +70,7 @@ public:
         Strings && skip_names_,
         Strings && tests_names_regexp_,
         Strings && skip_names_regexp_,
+        const std::unordered_map<std::string, std::vector<size_t>> query_indexes_,
         const ConnectionTimeouts & timeouts)
         : connection(host_, port_, default_database_, user_,
             password_, timeouts, "performance-test", Protocol::Compression::Enable,
@@ -80,6 +81,7 @@ public:
         , skip_tags(std::move(skip_tags_))
         , skip_names(std::move(skip_names_))
         , skip_names_regexp(std::move(skip_names_regexp_))
+        , query_indexes(query_indexes_)
         , lite_output(lite_output_)
         , profiles_file(profiles_file_)
         , input_files(input_files_)
@@ -128,6 +130,7 @@ private:
     const Strings & skip_tags;
     const Strings & skip_names;
     const Strings & skip_names_regexp;
+    std::unordered_map<std::string, std::vector<size_t>> query_indexes;
 
     Context global_context = Context::createGlobal();
     std::shared_ptr<ReportBuilder> report_builder;
@@ -198,7 +201,7 @@ private:
     {
         PerformanceTestInfo info(test_config, profiles_file);
         LOG_INFO(log, "Config for test '" << info.test_name << "' parsed");
-        PerformanceTest current(test_config, connection, interrupt_listener, info, global_context);
+        PerformanceTest current(test_config, connection, interrupt_listener, info, global_context, query_indexes[info.path]);
 
         current.checkPreconditions();
         LOG_INFO(log, "Preconditions for test '" << info.test_name << "' are fullfilled");
@@ -215,9 +218,9 @@ private:
         LOG_INFO(log, "Postqueries finished");
 
         if (lite_output)
-            return {report_builder->buildCompactReport(info, result), current.checkSIGINT()};
+            return {report_builder->buildCompactReport(info, result, query_indexes[info.path]), current.checkSIGINT()};
         else
-            return {report_builder->buildFullReport(info, result), current.checkSIGINT()};
+            return {report_builder->buildFullReport(info, result, query_indexes[info.path]), current.checkSIGINT()};
     }
 
 };
@@ -289,6 +292,29 @@ static std::vector<std::string> getInputFiles(const po::variables_map & options,
     return input_files;
 }
 
+std::unordered_map<std::string, std::vector<std::size_t>> getTestQueryIndexes(const po::basic_parsed_options<char> & parsed_opts)
+{
+    std::unordered_map<std::string, std::vector<std::size_t>> result;
+    const auto & options = parsed_opts.options;
+    for (size_t i = 0; i < options.size() - 1; ++i)
+    {
+        const auto & opt = options[i];
+        if (opt.string_key == "input-files")
+        {
+            if (options[i + 1].string_key == "query-indexes")
+            {
+                const std::string & test_path = Poco::Path(opt.value[0]).absolute().toString();
+                for (const auto & query_num_str : options[i + 1].value)
+                {
+                    size_t query_num = std::stoul(query_num_str);
+                    result[test_path].push_back(query_num);
+                }
+            }
+        }
+    }
+    return result;
+}
+
 int mainEntryClickHousePerformanceTest(int argc, char ** argv)
 try
 {
@@ -314,24 +340,18 @@ try
         ("skip-names", value<Strings>()->multitoken(), "Do not run tests with name")
         ("names-regexp", value<Strings>()->multitoken(), "Run tests with names matching regexp")
         ("skip-names-regexp", value<Strings>()->multitoken(), "Do not run tests with names matching regexp")
+        ("input-files", value<Strings>()->multitoken(), "Input .xml files")
+        ("query-indexes", value<std::vector<size_t>>()->multitoken(), "Input query indexes")
         ("recursive,r", "Recurse in directories to find all xml's");
 
-    /// These options will not be displayed in --help
-    po::options_description hidden("Hidden options");
-    hidden.add_options()
-        ("input-files", value<std::vector<std::string>>(), "");
-
-    /// But they will be legit, though. And they must be given without name
-    po::positional_options_description positional;
-    positional.add("input-files", -1);
-
     po::options_description cmdline_options;
-    cmdline_options.add(desc).add(hidden);
+    cmdline_options.add(desc);
 
     po::variables_map options;
-    po::store(
-        po::command_line_parser(argc, argv).
-        options(cmdline_options).positional(positional).run(), options);
+    po::basic_parsed_options<char> parsed = po::command_line_parser(argc, argv).options(cmdline_options).run();
+    auto queries_with_indexes = getTestQueryIndexes(parsed);
+    po::store(parsed, options);
+
     po::notify(options);
 
     Poco::AutoPtr<Poco::PatternFormatter> formatter(new Poco::PatternFormatter("%Y.%m.%d %H:%M:%S.%F <%p> %s: %t"));
@@ -378,6 +398,7 @@ try
         std::move(skip_names),
         std::move(tests_names_regexp),
         std::move(skip_names_regexp),
+        queries_with_indexes,
         timeouts);
     return performance_test_suite.run();
 }

--- a/dbms/programs/performance-test/ReportBuilder.cpp
+++ b/dbms/programs/performance-test/ReportBuilder.cpp
@@ -35,7 +35,8 @@ std::string ReportBuilder::getCurrentTime() const
 
 std::string ReportBuilder::buildFullReport(
     const PerformanceTestInfo & test_info,
-    std::vector<TestStats> & stats) const
+    std::vector<TestStats> & stats,
+    const std::vector<std::size_t> & queries_to_run) const
 {
     JSONString json_output;
 
@@ -85,6 +86,9 @@ std::string ReportBuilder::buildFullReport(
     std::vector<JSONString> run_infos;
     for (size_t query_index = 0; query_index < test_info.queries.size(); ++query_index)
     {
+        if (!queries_to_run.empty() && std::find(queries_to_run.begin(), queries_to_run.end(), query_index) == queries_to_run.end())
+            continue;
+
         for (size_t number_of_launch = 0; number_of_launch < test_info.times_to_run; ++number_of_launch)
         {
             size_t stat_index = number_of_launch * test_info.queries.size() + query_index;
@@ -97,6 +101,7 @@ std::string ReportBuilder::buildFullReport(
 
             auto query = std::regex_replace(test_info.queries[query_index], QUOTE_REGEX, "\\\"");
             runJSON.set("query", query);
+            runJSON.set("query_index", query_index);
             if (!statistics.exception.empty())
                 runJSON.set("exception", statistics.exception);
 
@@ -171,13 +176,17 @@ std::string ReportBuilder::buildFullReport(
 
 std::string ReportBuilder::buildCompactReport(
     const PerformanceTestInfo & test_info,
-    std::vector<TestStats> & stats) const
+    std::vector<TestStats> & stats,
+    const std::vector<std::size_t> & queries_to_run) const
 {
 
     std::ostringstream output;
 
     for (size_t query_index = 0; query_index < test_info.queries.size(); ++query_index)
     {
+        if (!queries_to_run.empty() && std::find(queries_to_run.begin(), queries_to_run.end(), query_index) == queries_to_run.end())
+            continue;
+
         for (size_t number_of_launch = 0; number_of_launch < test_info.times_to_run; ++number_of_launch)
         {
             if (test_info.queries.size() > 1)
@@ -192,5 +201,4 @@ std::string ReportBuilder::buildCompactReport(
     }
     return output.str();
 }
-
 }

--- a/dbms/programs/performance-test/ReportBuilder.h
+++ b/dbms/programs/performance-test/ReportBuilder.h
@@ -9,14 +9,18 @@ namespace DB
 class ReportBuilder
 {
 public:
-    explicit ReportBuilder(const std::string & server_version_);
+    ReportBuilder(const std::string & server_version_);
     std::string buildFullReport(
         const PerformanceTestInfo & test_info,
-        std::vector<TestStats> & stats) const;
+        std::vector<TestStats> & stats,
+        const std::vector<std::size_t> & queries_to_run) const;
+
 
     std::string buildCompactReport(
         const PerformanceTestInfo & test_info,
-        std::vector<TestStats> & stats) const;
+        std::vector<TestStats> & stats,
+        const std::vector<std::size_t> & queries_to_run) const;
+
 private:
     std::string server_version;
     std::string hostname;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):

- Build/Testing/Packaging Improvement

Short description (up to few sentences):

Add ability to run queries by index in performance test

