### PR TITLE
SQL uniqState memory leak test

### DIFF
--- a/dbms/tests/queries/bugs/leak_when_memory_limit_exceeded.sql
+++ b/dbms/tests/queries/bugs/leak_when_memory_limit_exceeded.sql
@@ -1,0 +1,22 @@
+--  max_memory_usage = 10000000000 (10 GB default)
+--  Intel® Xeon® E5-1650 v3 Hexadcore 128 GB DDR4 ECC
+--  Estimated time: ~ 250 seconds
+--  Read rows:      ~ 272 000 000
+SELECT
+  key,
+  uniqState(uuid_1) uuid_1_st,
+  uniqState(uuid_2) uuid_2_st,
+  uniqState(uuid_3) uuid_3_st
+FROM (
+  SELECT
+    rand64() value,
+    toString(value) value_str,
+    UUIDNumToString(toFixedString(substring(value_str, 1, 16), 16)) uuid_1, -- Any UUID
+    UUIDNumToString(toFixedString(substring(value_str, 2, 16), 16)) uuid_2, -- More memory
+    UUIDNumToString(toFixedString(substring(value_str, 3, 16), 16)) uuid_3, -- And more memory
+    modulo(value, 5000000) key -- Cardinality in my case
+  FROM numbers(550000000)
+)
+GROUP BY
+  key
+LIMIT 100;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Category (leave one):

- Build/Testing/Packaging Improvement

Short description (up to few sentences):

Memory leak when memory limit (for query) exceeded

Detailed description (optional):

ClickHouse: v19.1.6
How to reproduce: run query with low memory limit to invoke exception, then a memory leak occurs.
Query: 
- uniq() function
- -State combinators 
- GROUP BY high cardinality key

Example:
- create aggregation table (engine: SummingMergeTree) from main table with UniqUsers column

![2](https://user-images.githubusercontent.com/17858233/52285101-cdf86a80-2976-11e9-96cc-c1aa2bb3a747.png)

- run 4 times query with low memory
- run 1 more time with enough memory

| query_start_time    | query_duration | memory_usage | exception                                                                                                                                                                                   |
|---------------------|------------------|--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| 2019-02-05 16:19:24 | 242676          | 9.31 GiB     | Code: 241, e.displayText() = DB::Exception: Memory limit (for query) exceeded: would use 9.31 GiB |
| 2019-02-05 16:53:57 | 254514          | 9.31 GiB     | Code: 241, e.displayText() = DB::Exception: Memory limit (for query) exceeded: would use 9.31 GiB |
| 2019-02-05 17:19:10 | 233147          | 9.31 GiB     | Code: 241, e.displayText() = DB::Exception: Memory limit (for query) exceeded: would use 9.31 GiB |
| 2019-02-05 17:42:44 | 237689          | 9.31 GiB     | Code: 241, e.displayText() = DB::Exception: Memory limit (for query) exceeded: would use 9.31 GiB |
| 2019-02-05 18:30:09 | 518513          | 16.53 GiB     | Successful |
