### PR TITLE
CLICKHOUSE-4284 debian init: wait for server startup on 'clickhouse-server start'

### DIFF
--- a/debian/clickhouse-server.init
+++ b/debian/clickhouse-server.init
@@ -174,7 +174,16 @@ start()
     fi
 
     if [ $EXIT_STATUS -eq 0 ]; then
-        echo "DONE"
+        attempts=0
+        while ! is_running && [ $attempts -le 10 ]; do
+            attempts=$(($attempts + 1))
+            sleep 1
+        done
+        if is_running; then
+            echo "DONE"
+        else
+            echo "UNKNOWN"
+        fi
     else
         echo "FAILED"
     fi


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement
