### PR TITLE
Slightly better message with reason for OPTIMIZE query with "optimize_throw_if_noop"

### DIFF
--- a/dbms/src/Storages/StorageMergeTree.cpp
+++ b/dbms/src/Storages/StorageMergeTree.cpp
@@ -403,6 +403,8 @@ bool StorageMergeTree::merge(
             UInt64 max_source_parts_size = merger_mutator.getMaxSourcePartsSize();
             if (max_source_parts_size > 0)
                 selected = merger_mutator.selectPartsToMerge(future_part, aggressive, max_source_parts_size, can_merge, out_disable_reason);
+            else if (out_disable_reason)
+                *out_disable_reason = "Current value of max_source_parts_size is zero";
         }
         else
         {


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

Short description (up to few sentences):
Slightly better message with reason for OPTIMIZE query with `optimize_throw_if_noop` setting enabled.