### PR TITLE
Fix perf-test input data and refactor two tests

### DIFF
--- a/dbms/programs/client/Client.cpp
+++ b/dbms/programs/client/Client.cpp
@@ -722,7 +722,11 @@ private:
 
                 try
                 {
-                    if (!processSingleQuery(str) && !ignore_error)
+                    auto ast_to_process = ast;
+                    if (insert && insert->data)
+                        ast_to_process = nullptr;
+
+                    if (!processSingleQuery(str, ast_to_process) && !ignore_error)
                         return false;
                 }
                 catch (...)

--- a/dbms/programs/client/Client.cpp
+++ b/dbms/programs/client/Client.cpp
@@ -722,7 +722,7 @@ private:
 
                 try
                 {
-                    if (!processSingleQuery(str, ast) && !ignore_error)
+                    if (!processSingleQuery(str) && !ignore_error)
                         return false;
                 }
                 catch (...)

--- a/dbms/programs/performance-test/PerformanceTest.cpp
+++ b/dbms/programs/performance-test/PerformanceTest.cpp
@@ -18,6 +18,32 @@ namespace ErrorCodes
 extern const int NOT_IMPLEMENTED;
 }
 
+namespace
+{
+void waitQuery(Connection & connection)
+{
+    bool finished = false;
+    while (true)
+    {
+        if (!connection.poll(1000000))
+            continue;
+
+        Connection::Packet packet = connection.receivePacket();
+        switch (packet.type)
+        {
+            case Protocol::Server::EndOfStream:
+                finished = true;
+                break;
+            case Protocol::Server::Exception:
+                throw *packet.exception;
+        }
+
+        if (finished)
+            break;
+    }
+}
+}
+
 namespace fs = boost::filesystem;
 
 PerformanceTest::PerformanceTest(
@@ -135,14 +161,18 @@ void PerformanceTest::prepare() const
 {
     for (const auto & query : test_info.create_queries)
     {
-        LOG_INFO(log, "Executing create query '" << query << "'");
-        connection.sendQuery(query);
+        LOG_INFO(log, "Executing create query \"" << query << '\"');
+        connection.sendQuery(query, "", QueryProcessingStage::Complete, &test_info.settings, nullptr, false);
+        waitQuery(connection);
+        LOG_INFO(log, "Query finished");
     }
 
     for (const auto & query : test_info.fill_queries)
     {
-        LOG_INFO(log, "Executing fill query '" << query << "'");
-        connection.sendQuery(query);
+        LOG_INFO(log, "Executing fill query \"" << query << '\"');
+        connection.sendQuery(query, "", QueryProcessingStage::Complete, &test_info.settings, nullptr, false);
+        waitQuery(connection);
+        LOG_INFO(log, "Query finished");
     }
 
 }
@@ -151,8 +181,10 @@ void PerformanceTest::finish() const
 {
     for (const auto & query : test_info.drop_queries)
     {
-        LOG_INFO(log, "Executing drop query '" << query << "'");
-        connection.sendQuery(query);
+        LOG_INFO(log, "Executing drop query \"" << query << '\"');
+        connection.sendQuery(query, "", QueryProcessingStage::Complete, &test_info.settings, nullptr, false);
+        waitQuery(connection);
+        LOG_INFO(log, "Query finished");
     }
 }
 

--- a/dbms/src/DataStreams/InputStreamFromASTInsertQuery.cpp
+++ b/dbms/src/DataStreams/InputStreamFromASTInsertQuery.cpp
@@ -17,7 +17,7 @@ namespace ErrorCodes
 
 
 InputStreamFromASTInsertQuery::InputStreamFromASTInsertQuery(
-    const ASTPtr & ast, ReadBuffer & input_buffer_tail_part, const BlockIO & streams, Context & context)
+    const ASTPtr & ast, ReadBuffer * input_buffer_tail_part, const Block & header, const Context & context)
 {
     const ASTInsertQuery * ast_insert_query = dynamic_cast<const ASTInsertQuery *>(ast.get());
 
@@ -36,7 +36,9 @@ InputStreamFromASTInsertQuery::InputStreamFromASTInsertQuery(
     ConcatReadBuffer::ReadBuffers buffers;
     if (ast_insert_query->data)
         buffers.push_back(input_buffer_ast_part.get());
-    buffers.push_back(&input_buffer_tail_part);
+
+    if (input_buffer_tail_part)
+        buffers.push_back(input_buffer_tail_part);
 
     /** NOTE Must not read from 'input_buffer_tail_part' before read all between 'ast_insert_query.data' and 'ast_insert_query.end'.
         * - because 'query.data' could refer to memory piece, used as buffer for 'input_buffer_tail_part'.
@@ -44,7 +46,7 @@ InputStreamFromASTInsertQuery::InputStreamFromASTInsertQuery(
 
     input_buffer_contacenated = std::make_unique<ConcatReadBuffer>(buffers);
 
-    res_stream = context.getInputFormat(format, *input_buffer_contacenated, streams.out->getHeader(), context.getSettings().max_insert_block_size);
+    res_stream = context.getInputFormat(format, *input_buffer_contacenated, header, context.getSettings().max_insert_block_size);
 
     auto columns_description = ColumnsDescription::loadFromContext(context, ast_insert_query->database, ast_insert_query->table);
     if (columns_description && !columns_description->defaults.empty())

--- a/dbms/src/DataStreams/InputStreamFromASTInsertQuery.h
+++ b/dbms/src/DataStreams/InputStreamFromASTInsertQuery.h
@@ -19,7 +19,7 @@ class Context;
 class InputStreamFromASTInsertQuery : public IBlockInputStream
 {
 public:
-    InputStreamFromASTInsertQuery(const ASTPtr & ast, ReadBuffer & input_buffer_tail_part, const BlockIO & streams, Context & context);
+    InputStreamFromASTInsertQuery(const ASTPtr & ast, ReadBuffer * input_buffer_tail_part, const Block & header, const Context & context);
 
     Block readImpl() override { return res_stream->read(); }
     void readPrefixImpl() override { return res_stream->readPrefix(); }

--- a/dbms/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterInsertQuery.cpp
@@ -146,7 +146,11 @@ BlockIO InterpreterInsertQuery::execute()
     else if (query.data)
     {
         auto data_in = std::make_unique<ReadBufferFromMemory>(query.data, query.end - query.data);
-        res.in = context.getInputFormat("Values", *data_in, table->getSampleBlock(), context.getSettingsRef().max_insert_block_size);
+        std::string format = "Values";
+        if (!query.format.empty())
+            format = query.format;
+
+        res.in = context.getInputFormat(format, *data_in, table->getSampleBlock(), context.getSettingsRef().max_insert_block_size);
         res.in = std::make_shared<OwningBlockInputStream<ReadBufferFromMemory>>(res.in, std::move(data_in));
         res.in = std::make_shared<NullAndDoCopyBlockInputStream>(res.in, res.out);
 

--- a/dbms/src/Parsers/ASTInsertQuery.h
+++ b/dbms/src/Parsers/ASTInsertQuery.h
@@ -26,6 +26,9 @@ public:
     const char * data = nullptr;
     const char * end = nullptr;
 
+    /// Query has additional data, which will be sent later
+    bool has_tail = false;
+
     /** Get the text that identifies this element. */
     String getID(char delim) const override { return "InsertQuery" + (delim + database) + delim + table; }
 

--- a/dbms/tests/performance/ipv4_ipv6/IPv4.xml
+++ b/dbms/tests/performance/ipv4_ipv6/IPv4.xml
@@ -1,152 +1,47 @@
 <test>
     <name>IPv4 Functions</name>
 
-    <type>once</type>
+    <type>loop</type>
 
     <tags>
     </tags>
 
     <stop_conditions>
+        <all_of>
+            <total_time_ms>30000</total_time_ms>
+        </all_of>
         <any_of>
-            <average_speed_not_changing_for_ms>2000</average_speed_not_changing_for_ms>
-            <total_time_ms>10000</total_time_ms>
+            <min_time_not_changing_for_ms>5000</min_time_not_changing_for_ms>
+            <total_time_ms>60000</total_time_ms>
         </any_of>
     </stop_conditions>
 
-    <metrics>
-        <max_rows_per_second />
-        <max_bytes_per_second />
-        <avg_rows_per_second />
-        <avg_bytes_per_second />
-    </metrics>
+    <create_query>CREATE TABLE IF NOT EXISTS ips_v4(ip String) ENGINE = MergeTree() PARTITION BY tuple() ORDER BY tuple()</create_query>
+    <!-- The CAIDA UCSD IPv4 Routed /24 DNS Names Dataset – 20171130,
+    http://www.caida.org/data/active/ipv4_dnsnames_dataset.xml.
+    Randomly selected entries from first 50000 rows of dataset. -->
 
-    <substitutions>
-       <substitution>
-           <name>ipv4_string</name>
-           <values>
-              <!-- The CAIDA UCSD IPv4 Routed /24 DNS Names Dataset – 20171130,
-                   http://www.caida.org/data/active/ipv4_dnsnames_dataset.xml.
-                   Randomly selected entries from first 50000 rows of dataset. -->
-              <value>116.253.40.133</value>
-              <value>183.247.232.58</value>
-              <value>116.106.34.242</value>
-              <value>111.56.27.171</value>
-              <value>183.245.137.140</value>
-              <value>183.212.25.70</value>
-              <value>162.144.2.57</value>
-              <value>111.4.229.190</value>
-              <value>59.52.3.168</value>
-              <value>115.11.21.200</value>
-              <value>121.28.97.113</value>
-              <value>111.46.39.248</value>
-              <value>120.192.122.34</value>
-              <value>113.56.44.105</value>
-              <value>116.66.238.92</value>
-              <value>67.22.254.206</value>
-              <value>115.0.24.191</value>
-              <value>182.30.107.86</value>
-              <value>223.73.153.243</value>
-              <value>115.159.103.38</value>
-              <value>36.186.75.121</value>
-              <value>111.56.188.125</value>
-              <value>115.14.93.25</value>
-              <value>211.97.110.141</value>
-              <value>61.58.96.173</value>
-              <value>203.126.212.37</value>
-              <value>192.220.125.142</value>
-              <value>115.22.20.223</value>
-              <value>121.25.160.80</value>
-              <value>117.150.98.199</value>
-              <value>183.211.172.143</value>
-              <value>180.244.18.143</value>
-              <value>209.131.3.252</value>
-              <value>220.200.1.22</value>
-              <value>171.225.130.45</value>
-              <value>115.4.78.200</value>
-              <value>36.183.59.29</value>
-              <value>218.42.159.17</value>
-              <value>115.13.39.164</value>
-              <value>142.254.161.133</value>
-              <value>116.2.211.43</value>
-              <value>36.183.126.25</value>
-              <value>66.150.171.196</value>
-              <value>104.149.148.137</value>
-              <value>120.239.82.212</value>
-              <value>111.14.182.156</value>
-              <value>115.6.63.224</value>
-              <value>153.35.83.233</value>
-              <value>113.142.1.1</value>
-              <value>121.25.82.29</value>
-              <value>62.151.203.189</value>
-              <value>104.27.46.146</value>
-              <value>36.189.46.88</value>
-              <value>116.252.54.207</value>
-              <value>64.77.240.1</value>
-              <value>142.252.102.78</value>
-              <value>36.82.224.170</value>
-              <value>117.33.191.217</value>
-              <value>144.12.164.251</value>
-              <value>122.10.93.66</value>
-              <value>104.25.84.59</value>
-              <value>111.4.242.106</value>
-              <value>222.216.51.186</value>
-              <value>112.33.13.212</value>
-              <value>115.9.240.116</value>
-              <value>171.228.0.153</value>
-              <value>45.3.47.158</value>
-              <value>69.57.193.230</value>
-              <value>115.6.104.199</value>
-              <value>104.24.237.140</value>
-              <value>199.17.84.108</value>
-              <value>120.193.17.57</value>
-              <value>112.40.38.145</value>
-              <value>67.55.90.43</value>
-              <value>180.253.57.249</value>
-              <value>14.204.253.158</value>
-              <value>1.83.241.116</value>
-              <value>202.198.37.147</value>
-              <value>115.6.31.95</value>
-              <value>117.32.14.179</value>
-              <value>23.238.237.26</value>
-              <value>116.97.76.104</value>
-              <value>1.80.2.248</value>
-              <value>59.50.185.152</value>
-              <value>42.117.228.166</value>
-              <value>119.36.22.147</value>
-              <value>210.66.18.184</value>
-              <value>115.19.192.159</value>
-              <value>112.15.128.113</value>
-              <value>1.55.138.211</value>
-              <value>210.183.19.113</value>
-              <value>42.115.43.114</value>
-              <value>58.16.171.31</value>
-              <value>171.234.78.185</value>
-              <value>113.56.43.134</value>
-              <value>111.53.182.225</value>
-              <value>107.160.215.141</value>
-              <value>171.229.231.90</value>
-              <value>58.19.84.138</value>
-              <value>36.79.88.107</value>
+    <fill_query> INSERT INTO ips_v4 VALUES ('116.253.40.133')('183.247.232.58')('116.106.34.242')('111.56.27.171')('183.245.137.140')('183.212.25.70')('162.144.2.57')('111.4.229.190')('59.52.3.168')('115.11.21.200')('121.28.97.113')('111.46.39.248')('120.192.122.34')('113.56.44.105')('116.66.238.92')('67.22.254.206')('115.0.24.191')('182.30.107.86')('223.73.153.243')('115.159.103.38')('36.186.75.121')('111.56.188.125')('115.14.93.25')('211.97.110.141')('61.58.96.173')('203.126.212.37')('192.220.125.142')('115.22.20.223')('121.25.160.80')('117.150.98.199')('183.211.172.143')('180.244.18.143')('209.131.3.252')('220.200.1.22')('171.225.130.45')('115.4.78.200')('36.183.59.29')('218.42.159.17')('115.13.39.164')('142.254.161.133')('116.2.211.43')('36.183.126.25')('66.150.171.196')('104.149.148.137')('120.239.82.212')('111.14.182.156')('115.6.63.224')('153.35.83.233')('113.142.1.1')('121.25.82.29')('62.151.203.189')('104.27.46.146')('36.189.46.88')('116.252.54.207')('64.77.240.1')('142.252.102.78')('36.82.224.170')('117.33.191.217')('144.12.164.251')('122.10.93.66')('104.25.84.59')('111.4.242.106')('222.216.51.186')('112.33.13.212')('115.9.240.116')('171.228.0.153')('45.3.47.158')('69.57.193.230')('115.6.104.199')('104.24.237.140')('199.17.84.108')('120.193.17.57')('112.40.38.145')('67.55.90.43')('180.253.57.249')('14.204.253.158')('1.83.241.116')('202.198.37.147')('115.6.31.95')('117.32.14.179')('23.238.237.26')('116.97.76.104')('1.80.2.248')('59.50.185.152')('42.117.228.166')('119.36.22.147')('210.66.18.184')('115.19.192.159')('112.15.128.113')('1.55.138.211')('210.183.19.113')('42.115.43.114')('58.16.171.31')('171.234.78.185')('113.56.43.134')('111.53.182.225')('107.160.215.141')('171.229.231.90')('58.19.84.138')('36.79.88.107')</fill_query>
 
-              <!-- invalid values -->
-              <value tag="error"></value>
-              <value tag="error"> </value>
-              <value tag="error">1</value>
-              <value tag="error">1.</value>
-              <value tag="error">1.2.</value>
-              <value tag="error">.2.</value>
-              <value tag="error">abc</value>
-              <value tag="error">127.0.0.1/24</value>
-              <value tag="error"> 127.0.0.1</value>
-              <value tag="error">127.0.0.1 </value>
-              <value tag="error">127.0.0.1?</value>
-              <value tag="error">999.999.999.999</value>
-           </values>
-       </substitution>
-    </substitutions>
+    <fill_query>insert into ips_v4 select * from ips_v4</fill_query>
+    <fill_query>insert into ips_v4 select * from ips_v4</fill_query>
+    <fill_query>insert into ips_v4 select * from ips_v4</fill_query>
+    <fill_query>insert into ips_v4 select * from ips_v4</fill_query>
+    <fill_query>insert into ips_v4 select * from ips_v4</fill_query>
+    <fill_query>insert into ips_v4 select * from ips_v4</fill_query>
+    <fill_query>insert into ips_v4 select * from ips_v4</fill_query>
+    <fill_query>insert into ips_v4 select * from ips_v4</fill_query>
+    <fill_query>insert into ips_v4 select * from ips_v4</fill_query>
+    <fill_query>insert into ips_v4 select * from ips_v4</fill_query>
+    <fill_query>insert into ips_v4 select * from ips_v4</fill_query>
+    <fill_query>insert into ips_v4 select * from ips_v4</fill_query>
+    <fill_query>insert into ips_v4 select * from ips_v4</fill_query>
 
-    <query tag='IPv4StringToNum'>SELECT count() FROM system.numbers WHERE NOT ignore(IPv4StringToNum(materialize('{ipv4_string}')))</query>
-    <query tag='IPv4NumToString+IPv4StringToNum'>SELECT count() FROM system.numbers WHERE NOT ignore(IPv4NumToString(IPv4StringToNum(materialize('{ipv4_string}'))))</query>
-    <query tag='IPv4NumToStringClassC+IPv4StringToNum'>SELECT count() FROM system.numbers WHERE NOT ignore(IPv4NumToStringClassC(IPv4StringToNum(materialize('{ipv4_string}'))))</query>
-    <query tag='IPv4ToIPv6+IPv4StringToNum'>SELECT count() FROM system.numbers WHERE NOT ignore(IPv4ToIPv6(IPv4StringToNum(materialize('{ipv4_string}'))))</query>
+
+    <query tag='IPv4StringToNum'>SELECT count() FROM ips_v4 WHERE NOT ignore(IPv4StringToNum(materialize(ip))) SETTINGS max_threads=1</query>
+    <query tag='IPv4NumToString+IPv4StringToNum'>SELECT count() FROM ips_v4 WHERE NOT ignore(IPv4NumToString(IPv4StringToNum(materialize(ip)))) SETTINGS max_threads=1</query>
+    <query tag='IPv4NumToStringClassC+IPv4StringToNum'>SELECT count() FROM ips_v4 WHERE NOT ignore(IPv4NumToStringClassC(IPv4StringToNum(materialize(ip)))) SETTINGS max_threads=1</query>
+    <query tag='IPv4ToIPv6+IPv4StringToNum'>SELECT count() FROM ips_v4 WHERE NOT ignore(IPv4ToIPv6(IPv4StringToNum(materialize(ip)))) SETTINGS max_threads=1</query>
+
+    <drop_query>DROP TABLE IF EXISTS ips_v4</drop_query>
 </test>

--- a/dbms/tests/performance/ipv4_ipv6/IPv4.xml
+++ b/dbms/tests/performance/ipv4_ipv6/IPv4.xml
@@ -3,9 +3,6 @@
 
     <type>loop</type>
 
-    <tags>
-    </tags>
-
     <stop_conditions>
         <all_of>
             <total_time_ms>30000</total_time_ms>

--- a/dbms/tests/performance/ipv4_ipv6/IPv6.xml
+++ b/dbms/tests/performance/ipv4_ipv6/IPv6.xml
@@ -3,9 +3,6 @@
 
     <type>loop</type>
 
-    <tags>
-    </tags>
-
     <stop_conditions>
         <all_of>
             <total_time_ms>30000</total_time_ms>
@@ -40,4 +37,6 @@
 
     <query tag="IPv6StringToNum">SELECT count() FROM ips_v6 WHERE NOT ignore(IPv6StringToNum(materialize(ip)))</query>
     <query tag="IPv6NumToString+IPv6StringToNum">SELECT count() FROM ips_v6 WHERE NOT ignore(IPv6NumToString(IPv6StringToNum(materialize(ip))))</query>
+
+    <drop_query>DROP TABLE IF EXISTS ips_v6</drop_query>
 </test>

--- a/dbms/tests/performance/ipv4_ipv6/IPv6.xml
+++ b/dbms/tests/performance/ipv4_ipv6/IPv6.xml
@@ -1,257 +1,43 @@
 <test>
     <name>IPv6 Functions</name>
 
-    <type>once</type>
+    <type>loop</type>
 
     <tags>
     </tags>
 
     <stop_conditions>
+        <all_of>
+            <total_time_ms>30000</total_time_ms>
+        </all_of>
         <any_of>
-            <average_speed_not_changing_for_ms>2000</average_speed_not_changing_for_ms>
-            <total_time_ms>10000</total_time_ms>
+            <min_time_not_changing_for_ms>5000</min_time_not_changing_for_ms>
+            <total_time_ms>60000</total_time_ms>
         </any_of>
     </stop_conditions>
 
-    <metrics>
-        <max_rows_per_second />
-        <max_bytes_per_second />
-        <avg_rows_per_second />
-        <avg_bytes_per_second />
-    </metrics>
+    <!-- The CAIDA UCSD IPv4 Routed /24 DNS Names Dataset - 20181130,
+         http://www.caida.org/data/active/ipv4_dnsnames_dataset.xml.
+         Randomly selected entries from first 50000 rows of dataset. -->
 
-    <substitutions>
-       <substitution>
-           <name>ipv6_string</name>
-           <values>
-              <!-- The CAIDA UCSD IPv4 Routed /24 DNS Names Dataset - 20181130,
-                   http://www.caida.org/data/active/ipv4_dnsnames_dataset.xml.
-                   Randomly selected entries from first 50000 rows of dataset. -->
-              <value>2606:2b00::1</value>
-              <value>2001:2000:3080:1351::2</value>
-              <value>2a01:8840:16::1</value>
-              <value>2001:550:0:1000::9a36:2a61</value>
-              <value>2001:578:400:4:2000::19</value>
-              <value>2607:f290::1</value>
-              <value>2a02:23f0:ffff:8::5</value>
-              <value>2400:c700:0:158::</value>
-              <value>2001:67c:24e4:4::250</value>
-              <value>2a02:2a38:37:5::2</value>
-              <value>2001:41a8:400:2::13a</value>
-              <value>2405:9800:9800:66::2</value>
-              <value>2a07:a343:f210::1</value>
-              <value>2403:5000:171:46::2</value>
-              <value>2800:c20:1141::8</value>
-              <value>2402:7800:40:2::62</value>
-              <value>2a00:de00::1</value>
-              <value>2001:688:0:2:1::9e</value>
-              <value>2001:2000:3080:80::2</value>
-              <value>2001:428::205:171:200:230</value>
-              <value>2001:fb1:fe0:9::8</value>
-              <value>2001:2000:3080:10ca::2</value>
-              <value>2400:dd0b:1003::2</value>
-              <value>2001:1a98:6677::9d9d:140a</value>
-              <value>2001:2000:3018:3b::1</value>
-              <value>2607:fa70:3:33::2</value>
-              <value>2001:5b0:23ff:fffa::113</value>
-              <value>2001:450:2001:1000:0:40:6924:23</value>
-              <value>2001:418:0:5000::c2d</value>
-              <value>2a01:b740:a09::1</value>
-              <value>2607:f0d0:2:2::243</value>
-              <value>2a01:348::e:1:1</value>
-              <value>2405:4800::3221:3621:2</value>
-              <value>2a02:aa08:e000:3100::2</value>
-              <value>2001:44c8:129:2632:33:0:252:2</value>
-              <value>2a02:e980:1e::1</value>
-              <value>2a0a:6f40:2::1</value>
-              <value>2001:550:2:29::2c9:1</value>
-              <value>2001:c20:4800::175</value>
-              <value>2c0f:feb0:1:2::d1</value>
-              <value>2a0b:7086:fff0::1</value>
-              <value>2a04:2dc0::16d</value>
-              <value>2604:7e00::105d</value>
-              <value>2001:470:1:946::2</value>
-              <value>2a0c:3240::1</value>
-              <value>2800:630:4010:8::2</value>
-              <value>2001:1af8:4040::12</value>
-              <value>2c0f:fc98:1200::2</value>
-              <value>2001:470:1:248::2</value>
-              <value>2620:44:a000::1</value>
-              <value>2402:800:63ff:40::1</value>
-              <value>2a02:b000:fff::524</value>
-              <value>2001:470:0:327::1</value>
-              <value>2401:7400:8888:2::8</value>
-              <value>2001:500:55::1</value>
-              <value>2001:668:0:3::f000:c2</value>
-              <value>2400:bf40::1</value>
-              <value>2001:67c:754::1</value>
-              <value>2402:28c0:100:ffff:ffff:ffff:ffff:ffff</value>
-              <value>2001:470:0:1fa::2</value>
-              <value>2001:550:0:1000::9a18:292a</value>
-              <value>2001:470:1:89e::2</value>
-              <value>2001:579:6f05:500:9934:5b3e:b7fe:1447</value>
-              <value>2804:158c::1</value>
-              <value>2600:140e:6::1</value>
-              <value>2a00:18e0:0:bb04::82</value>
-              <value>2a02:2698:5000::1e06</value>
-              <value>2402:800:63ff:10::7:2</value>
-              <value>2a02:e980:19::1</value>
-              <value>2001:4888::342:1:0:0</value>
-              <value>2607:fc68:0:4:0:2:2711:21</value>
-              <value>2606:2800:602a::1</value>
-              <value>2404:c600:1000:2::1d1</value>
-              <value>2001:578:1400:4::9d</value>
-              <value>2804:64:0:25::1</value>
-              <value>2605:3e00::1:2:2</value>
-              <value>2c0f:fa18:0:4::b</value>
-              <value>2606:2800:602c:b::d004</value>
-              <value>2610:18:181:4000::66</value>
-              <value>2001:48f8:1000:1::16</value>
-              <value>2408:8000:c000::1</value>
-              <value>2a03:4200:441:2::4e</value>
-              <value>2400:dd00:1:200a::2</value>
-              <value>2a02:e980:83:5b09:ecb8:c669:b336:650e</value>
-              <value>2001:16a0:2:200a::2</value>
-              <value>2001:4888:1f:e891:161:26::</value>
-              <value>2a0c:f743::1</value>
-              <value>2a02:e980:b::1</value>
-              <value>2001:578:201:1::601:9</value>
-              <value>2001:438:ffff::407d:1bc1</value>
-              <value>2001:920:1833::1</value>
-              <value>2001:1b70:a1:610::b102:2</value>
-              <value>2001:13c7:6014::1</value>
-              <value>2003:0:1203:4001::1</value>
-              <value>2804:a8:2:c8::d6</value>
-              <value>2a02:2e00:2080:f000:0:261:1:11</value>
-              <value>2001:578:20::d</value>
-              <value>2001:550:2:48::34:1</value>
-              <value>2a03:9d40:fe00:5::</value>
-              <value>2403:e800:200:102::2</value>
+    <create_query>CREATE TABLE IF NOT EXISTS ips_v6(ip String) ENGINE = MergeTree() PARTITION BY tuple() ORDER BY tuple()</create_query>
 
-              <!-- The CAIDA UCSD IPv4 Routed /24 DNS Names Dataset – 20171130,
-                   http://www.caida.org/data/active/ipv4_dnsnames_dataset.xml.
-                   Randomly selected entries from first 50000 rows of dataset.
-                   IPv4 addresses from dataset are represented in IPv6 form. -->
-              <value tag="mapped">::ffff:116.253.40.133</value>
-              <value tag="mapped">::ffff:183.247.232.58</value>
-              <value tag="mapped">::ffff:116.106.34.242</value>
-              <value tag="mapped">::ffff:111.56.27.171</value>
-              <value tag="mapped">::ffff:183.245.137.140</value>
-              <value tag="mapped">::ffff:183.212.25.70</value>
-              <value tag="mapped">::ffff:162.144.2.57</value>
-              <value tag="mapped">::ffff:111.4.229.190</value>
-              <value tag="mapped">::ffff:59.52.3.168</value>
-              <value tag="mapped">::ffff:115.11.21.200</value>
-              <value tag="mapped">::ffff:121.28.97.113</value>
-              <value tag="mapped">::ffff:111.46.39.248</value>
-              <value tag="mapped">::ffff:120.192.122.34</value>
-              <value tag="mapped">::ffff:113.56.44.105</value>
-              <value tag="mapped">::ffff:116.66.238.92</value>
-              <value tag="mapped">::ffff:67.22.254.206</value>
-              <value tag="mapped">::ffff:115.0.24.191</value>
-              <value tag="mapped">::ffff:182.30.107.86</value>
-              <value tag="mapped">::ffff:223.73.153.243</value>
-              <value tag="mapped">::ffff:115.159.103.38</value>
-              <value tag="mapped">::ffff:36.186.75.121</value>
-              <value tag="mapped">::ffff:111.56.188.125</value>
-              <value tag="mapped">::ffff:115.14.93.25</value>
-              <value tag="mapped">::ffff:211.97.110.141</value>
-              <value tag="mapped">::ffff:61.58.96.173</value>
-              <value tag="mapped">::ffff:203.126.212.37</value>
-              <value tag="mapped">::ffff:192.220.125.142</value>
-              <value tag="mapped">::ffff:115.22.20.223</value>
-              <value tag="mapped">::ffff:121.25.160.80</value>
-              <value tag="mapped">::ffff:117.150.98.199</value>
-              <value tag="mapped">::ffff:183.211.172.143</value>
-              <value tag="mapped">::ffff:180.244.18.143</value>
-              <value tag="mapped">::ffff:209.131.3.252</value>
-              <value tag="mapped">::ffff:220.200.1.22</value>
-              <value tag="mapped">::ffff:171.225.130.45</value>
-              <value tag="mapped">::ffff:115.4.78.200</value>
-              <value tag="mapped">::ffff:36.183.59.29</value>
-              <value tag="mapped">::ffff:218.42.159.17</value>
-              <value tag="mapped">::ffff:115.13.39.164</value>
-              <value tag="mapped">::ffff:142.254.161.133</value>
-              <value tag="mapped">::ffff:116.2.211.43</value>
-              <value tag="mapped">::ffff:36.183.126.25</value>
-              <value tag="mapped">::ffff:66.150.171.196</value>
-              <value tag="mapped">::ffff:104.149.148.137</value>
-              <value tag="mapped">::ffff:120.239.82.212</value>
-              <value tag="mapped">::ffff:111.14.182.156</value>
-              <value tag="mapped">::ffff:115.6.63.224</value>
-              <value tag="mapped">::ffff:153.35.83.233</value>
-              <value tag="mapped">::ffff:113.142.1.1</value>
-              <value tag="mapped">::ffff:121.25.82.29</value>
-              <value tag="mapped">::ffff:62.151.203.189</value>
-              <value tag="mapped">::ffff:104.27.46.146</value>
-              <value tag="mapped">::ffff:36.189.46.88</value>
-              <value tag="mapped">::ffff:116.252.54.207</value>
-              <value tag="mapped">::ffff:64.77.240.1</value>
-              <value tag="mapped">::ffff:142.252.102.78</value>
-              <value tag="mapped">::ffff:36.82.224.170</value>
-              <value tag="mapped">::ffff:117.33.191.217</value>
-              <value tag="mapped">::ffff:144.12.164.251</value>
-              <value tag="mapped">::ffff:122.10.93.66</value>
-              <value tag="mapped">::ffff:104.25.84.59</value>
-              <value tag="mapped">::ffff:111.4.242.106</value>
-              <value tag="mapped">::ffff:222.216.51.186</value>
-              <value tag="mapped">::ffff:112.33.13.212</value>
-              <value tag="mapped">::ffff:115.9.240.116</value>
-              <value tag="mapped">::ffff:171.228.0.153</value>
-              <value tag="mapped">::ffff:45.3.47.158</value>
-              <value tag="mapped">::ffff:69.57.193.230</value>
-              <value tag="mapped">::ffff:115.6.104.199</value>
-              <value tag="mapped">::ffff:104.24.237.140</value>
-              <value tag="mapped">::ffff:199.17.84.108</value>
-              <value tag="mapped">::ffff:120.193.17.57</value>
-              <value tag="mapped">::ffff:112.40.38.145</value>
-              <value tag="mapped">::ffff:67.55.90.43</value>
-              <value tag="mapped">::ffff:180.253.57.249</value>
-              <value tag="mapped">::ffff:14.204.253.158</value>
-              <value tag="mapped">::ffff:1.83.241.116</value>
-              <value tag="mapped">::ffff:202.198.37.147</value>
-              <value tag="mapped">::ffff:115.6.31.95</value>
-              <value tag="mapped">::ffff:117.32.14.179</value>
-              <value tag="mapped">::ffff:23.238.237.26</value>
-              <value tag="mapped">::ffff:116.97.76.104</value>
-              <value tag="mapped">::ffff:1.80.2.248</value>
-              <value tag="mapped">::ffff:59.50.185.152</value>
-              <value tag="mapped">::ffff:42.117.228.166</value>
-              <value tag="mapped">::ffff:119.36.22.147</value>
-              <value tag="mapped">::ffff:210.66.18.184</value>
-              <value tag="mapped">::ffff:115.19.192.159</value>
-              <value tag="mapped">::ffff:112.15.128.113</value>
-              <value tag="mapped">::ffff:1.55.138.211</value>
-              <value tag="mapped">::ffff:210.183.19.113</value>
-              <value tag="mapped">::ffff:42.115.43.114</value>
-              <value tag="mapped">::ffff:58.16.171.31</value>
-              <value tag="mapped">::ffff:171.234.78.185</value>
-              <value tag="mapped">::ffff:113.56.43.134</value>
-              <value tag="mapped">::ffff:111.53.182.225</value>
-              <value tag="mapped">::ffff:107.160.215.141</value>
-              <value tag="mapped">::ffff:171.229.231.90</value>
-              <value tag="mapped">::ffff:58.19.84.138</value>
-              <value tag="mapped">::ffff:36.79.88.107</value>
+    <fill_query> INSERT INTO ips_v6 VALUES ('2606:2b00::1')('2001:2000:3080:1351::2')('2a01:8840:16::1')('2001:550:0:1000::9a36:2a61')('2001:578:400:4:2000::19')('2607:f290::1')('2a02:23f0:ffff:8::5')('2400:c700:0:158::')('2001:67c:24e4:4::250')('2a02:2a38:37:5::2')('2001:41a8:400:2::13a')('2405:9800:9800:66::2')('2a07:a343:f210::1')('2403:5000:171:46::2')('2800:c20:1141::8')('2402:7800:40:2::62')('2a00:de00::1')('2001:688:0:2:1::9e')('2001:2000:3080:80::2')('2001:428::205:171:200:230')('2001:fb1:fe0:9::8')('2001:2000:3080:10ca::2')('2400:dd0b:1003::2')('2001:1a98:6677::9d9d:140a')('2001:2000:3018:3b::1')('2607:fa70:3:33::2')('2001:5b0:23ff:fffa::113')('2001:450:2001:1000:0:40:6924:23')('2001:418:0:5000::c2d')('2a01:b740:a09::1')('2607:f0d0:2:2::243')('2a01:348::e:1:1')('2405:4800::3221:3621:2')('2a02:aa08:e000:3100::2')('2001:44c8:129:2632:33:0:252:2')('2a02:e980:1e::1')('2a0a:6f40:2::1')('2001:550:2:29::2c9:1')('2001:c20:4800::175')('2c0f:feb0:1:2::d1')('2a0b:7086:fff0::1')('2a04:2dc0::16d')('2604:7e00::105d')('2001:470:1:946::2')('2a0c:3240::1')('2800:630:4010:8::2')('2001:1af8:4040::12')('2c0f:fc98:1200::2')('2001:470:1:248::2')('2620:44:a000::1')('2402:800:63ff:40::1')('2a02:b000:fff::524')('2001:470:0:327::1')('2401:7400:8888:2::8')('2001:500:55::1')('2001:668:0:3::f000:c2')('2400:bf40::1')('2001:67c:754::1')('2402:28c0:100:ffff:ffff:ffff:ffff:ffff')('2001:470:0:1fa::2')('2001:550:0:1000::9a18:292a')('2001:470:1:89e::2')('2001:579:6f05:500:9934:5b3e:b7fe:1447')('2804:158c::1')('2600:140e:6::1')('2a00:18e0:0:bb04::82')('2a02:2698:5000::1e06')('2402:800:63ff:10::7:2')('2a02:e980:19::1')('2001:4888::342:1:0:0')('2607:fc68:0:4:0:2:2711:21')('2606:2800:602a::1')('2404:c600:1000:2::1d1')('2001:578:1400:4::9d')('2804:64:0:25::1')('2605:3e00::1:2:2')('2c0f:fa18:0:4::b')('2606:2800:602c:b::d004')('2610:18:181:4000::66')('2001:48f8:1000:1::16')('2408:8000:c000::1')('2a03:4200:441:2::4e')('2400:dd00:1:200a::2')('2a02:e980:83:5b09:ecb8:c669:b336:650e')('2001:16a0:2:200a::2')('2001:4888:1f:e891:161:26::')('2a0c:f743::1')('2a02:e980:b::1')('2001:578:201:1::601:9')('2001:438:ffff::407d:1bc1')('2001:920:1833::1')('2001:1b70:a1:610::b102:2')('2001:13c7:6014::1')('2003:0:1203:4001::1')('2804:a8:2:c8::d6')('2a02:2e00:2080:f000:0:261:1:11')('2001:578:20::d')('2001:550:2:48::34:1')('2a03:9d40:fe00:5::')('2403:e800:200:102::2')('::ffff:113.56.44.105')('::ffff:116.66.238.92')('::ffff:67.22.254.206')('::ffff:115.0.24.191')('::ffff:182.30.107.86')('::ffff:223.73.153.243')('::ffff:115.159.103.38')('::ffff:36.186.75.121')('::ffff:111.56.188.125')('::ffff:115.14.93.25')('::ffff:211.97.110.141')('::ffff:61.58.96.173')('::ffff:203.126.212.37')('::ffff:192.220.125.142')('::ffff:115.22.20.223')('::ffff:121.25.160.80')('::ffff:117.150.98.199')('::ffff:183.211.172.143')('::ffff:180.244.18.143')('::ffff:209.131.3.252')('::ffff:220.200.1.22')('::ffff:171.225.130.45')('::ffff:115.4.78.200')('::ffff:36.183.59.29')('::ffff:218.42.159.17')('::ffff:115.13.39.164')('::ffff:142.254.161.133')('::ffff:116.2.211.43')('::ffff:36.183.126.25')('::ffff:66.150.171.196')('::ffff:104.149.148.137')('::ffff:120.239.82.212')('::ffff:111.14.182.156')('::ffff:115.6.63.224')('::ffff:153.35.83.233')('::ffff:113.142.1.1')('::ffff:121.25.82.29')('::ffff:62.151.203.189')('::ffff:104.27.46.146')('::ffff:36.189.46.88')('::ffff:116.252.54.207')('::ffff:64.77.240.1')('::ffff:142.252.102.78')('::ffff:36.82.224.170')('::ffff:117.33.191.217')('::ffff:144.12.164.251')('::ffff:122.10.93.66')('::ffff:104.25.84.59')('::ffff:111.4.242.106')('::ffff:222.216.51.186')('::ffff:112.33.13.212')('::ffff:115.9.240.116')('::ffff:171.228.0.153')('::ffff:45.3.47.158')('::ffff:69.57.193.230')('::ffff:115.6.104.199')('::ffff:104.24.237.140')('::ffff:199.17.84.108')('::ffff:120.193.17.57')('::ffff:112.40.38.145')('::ffff:67.55.90.43')('::ffff:180.253.57.249')('::ffff:14.204.253.158')('::ffff:1.83.241.116')('::ffff:202.198.37.147')('::ffff:115.6.31.95')('::ffff:117.32.14.179')('::ffff:23.238.237.26')('::ffff:116.97.76.104')('::ffff:1.80.2.248')('::ffff:59.50.185.152')('::ffff:42.117.228.166')('::ffff:119.36.22.147')('::ffff:210.66.18.184')('::ffff:115.19.192.159')('::ffff:112.15.128.113')('::ffff:1.55.138.211')('::ffff:210.183.19.113')('::ffff:42.115.43.114')('::ffff:58.16.171.31')('::ffff:171.234.78.185')('::ffff:113.56.43.134')('::ffff:111.53.182.225')('::ffff:107.160.215.141')('::ffff:171.229.231.90')('::ffff:58.19.84.138')('::ffff:36.79.88.107')</fill_query>
 
-              <!-- invalid values -->
-              <value tag="error"></value>
-              <value tag="error"> </value>
-              <value tag="error">1</value>
-              <value tag="error">1.</value>
-              <value tag="error">1.2.</value>
-              <value tag="error">.2.</value>
-              <value tag="error">abc</value>
-              <value tag="error">ab:cd:ef:gh:ij:kl:mn</value>
-              <value tag="error">ffffffffffffff</value>
-              <value tag="error">abcdefghijklmn</value>
-              <value tag="error">::::::::::::::</value>
-              <value tag="error">::ffff:127.0.0.1 </value>
-              <value tag="error"> ::ffff:127.0.0.1</value>
-              <value tag="error">::ffff:999.999.999.999</value>
-           </values>
-       </substitution>
-    </substitutions>
+    <fill_query>insert into ips_v6 select * from ips_v6</fill_query>
+    <fill_query>insert into ips_v6 select * from ips_v6</fill_query>
+    <fill_query>insert into ips_v6 select * from ips_v6</fill_query>
+    <fill_query>insert into ips_v6 select * from ips_v6</fill_query>
+    <fill_query>insert into ips_v6 select * from ips_v6</fill_query>
+    <fill_query>insert into ips_v6 select * from ips_v6</fill_query>
+    <fill_query>insert into ips_v6 select * from ips_v6</fill_query>
+    <fill_query>insert into ips_v6 select * from ips_v6</fill_query>
+    <fill_query>insert into ips_v6 select * from ips_v6</fill_query>
+    <fill_query>insert into ips_v6 select * from ips_v6</fill_query>
+    <fill_query>insert into ips_v6 select * from ips_v6</fill_query>
+    <fill_query>insert into ips_v6 select * from ips_v6</fill_query>
+    <fill_query>insert into ips_v6 select * from ips_v6</fill_query>
 
-    <query tag="IPv6StringToNum">SELECT count() FROM system.numbers WHERE NOT ignore(IPv6StringToNum(materialize('{ipv6_string}')))</query>
-    <query tag="IPv6NumToString+IPv6StringToNum">SELECT count() FROM system.numbers WHERE NOT ignore(IPv6NumToString(IPv6StringToNum(materialize('{ipv6_string}'))))</query>
+    <query tag="IPv6StringToNum">SELECT count() FROM ips_v6 WHERE NOT ignore(IPv6StringToNum(materialize(ip)))</query>
+    <query tag="IPv6NumToString+IPv6StringToNum">SELECT count() FROM ips_v6 WHERE NOT ignore(IPv6NumToString(IPv6StringToNum(materialize(ip))))</query>
 </test>

--- a/dbms/tests/performance/trim/trim_whitespace.xml
+++ b/dbms/tests/performance/trim/trim_whitespace.xml
@@ -4,8 +4,6 @@
 
     <create_query>CREATE TABLE IF NOT EXISTS whitespaces(value String) ENGINE = MergeTree() PARTITION BY tuple() ORDER BY tuple()</create_query>
     <fill_query> INSERT INTO whitespaces SELECT value FROM (SELECT arrayStringConcat(groupArray(' ')) AS spaces, concat(spaces, toString(any(number)), spaces) AS value FROM numbers(100000000) GROUP BY pow(number, intHash32(number) % 4) % 12345678)</fill_query>
-    <fill_query> INSERT INTO whitespaces SELECT value FROM (SELECT arrayStringConcat(groupArray(' ')) AS spaces, concat(spaces, toString(any(number)), spaces) AS value FROM numbers(100000000) GROUP BY pow(number, intHash32(number) % 4) % 12345678)</fill_query>
-    <fill_query> INSERT INTO whitespaces SELECT value FROM (SELECT arrayStringConcat(groupArray(' ')) AS spaces, concat(spaces, toString(any(number)), spaces) AS value FROM numbers(100000000) GROUP BY pow(number, intHash32(number) % 4) % 12345678)</fill_query>
 
     <stop_conditions>
         <all_of>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
1. Add ability to send queries `INSERT INTO tbl VALUES (....` to server without splitting on 'query' and 'data' parts.
2. Fix ipv4 and ipv6 performance tests.
