### PR TITLE
arrayWithConstant function implementation;

### DIFF
--- a/dbms/src/Functions/arrayWithConstant.cpp
+++ b/dbms/src/Functions/arrayWithConstant.cpp
@@ -1,0 +1,72 @@
+#include <Functions/IFunction.h>
+#include <Functions/FunctionHelpers.h>
+#include <Functions/FunctionFactory.h>
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <DataTypes/getLeastSupertype.h>
+#include <Columns/ColumnArray.h>
+
+#include <iostream>
+
+namespace DB {
+namespace ErrorCodes {
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+}
+
+/*
+* arrayWithConstant(num, const) - make array of constants with length num.
+* arrayWithConstant(3, 'hello') = ['hello', 'hello', 'hello']
+* arrayWithConstant(1, 'hello') = ['hello']
+* arrayWithConstant(0, 'hello') = []
+*/
+
+class FunctionArrayWithConstant : public IFunction
+{
+public:
+    static constexpr auto name = "arrayWithConstant";
+
+    static FunctionPtr create(const Context &) { return std::make_shared<FunctionArrayWithConstant>(); }
+
+    String getName() const override { return name; }
+
+    size_t getNumberOfArguments() const override { return 2; }
+
+    DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
+    {
+        if (!isUnsignedInteger(arguments[0])) {
+            throw Exception("Illegal type " + arguments[0]->getName() +
+                            " of argument of function " + getName() +
+                            ", expected Integer", ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+        }
+        return std::make_shared<DataTypeArray>(arguments[1]);
+    }
+
+
+    bool useDefaultImplementationForConstants() const override { return true; }
+
+    bool useDefaultImplementationForNulls() const override { return false; }
+    void executeImpl(Block & block, const ColumnNumbers & arguments, size_t result, size_t) override
+    {
+        const auto * num = block.getByPosition(arguments[0]).column.get();
+        const auto * constant = block.getByPosition(arguments[1]).column.get();
+        uint64_t a = num->getUInt(0);
+
+        auto offsets_col = ColumnArray::ColumnOffsets::create();
+        ColumnArray::Offsets & offsets = offsets_col->getData();
+
+        offsets.push_back(a);
+        auto data_col = constant->replicate(offsets);
+        block.getByPosition(result).column = ColumnArray::create(std::move(data_col), std::move(offsets_col));
+    }
+};
+
+void registerFunctionArrayWithConstant(FunctionFactory & factory)
+{
+    factory.registerFunction<FunctionArrayWithConstant>();
+}
+
+} // namespace DB
+
+
+
+

--- a/dbms/src/Functions/registerFunctionsArray.cpp
+++ b/dbms/src/Functions/registerFunctionsArray.cpp
@@ -28,6 +28,7 @@ void registerFunctionArrayEnumerateUniq(FunctionFactory &);
 void registerFunctionArrayEnumerateDense(FunctionFactory &);
 void registerFunctionArrayUniq(FunctionFactory &);
 void registerFunctionArrayDistinct(FunctionFactory &);
+void registerFunctionArrayWithConstant(FunctionFactory &);
 
 void registerFunctionsArray(FunctionFactory & factory)
 {
@@ -56,6 +57,7 @@ void registerFunctionsArray(FunctionFactory & factory)
     registerFunctionArrayEnumerateDense(factory);
     registerFunctionArrayUniq(factory);
     registerFunctionArrayDistinct(factory);
+    registerFunctionArrayWithConstant(factory);
 }
 
 }

--- a/dbms/tests/queries/0_stateless/00903_array_with_constant_function.reference
+++ b/dbms/tests/queries/0_stateless/00903_array_with_constant_function.reference
@@ -1,0 +1,1 @@
+['qwerty','qwerty']     []      [1]

--- a/dbms/tests/queries/0_stateless/00903_array_with_constant_function.sql
+++ b/dbms/tests/queries/0_stateless/00903_array_with_constant_function.sql
@@ -1,0 +1,1 @@
+select arrayWithConstant(2, 'qwerty'), arrayWithConstant(0, -1), arrayWithConstant(1, 1)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog.

Category :
- New Feature

Short description (up to few sentences):
generic implementation of arrayWithConstant function ;

Detailed description (optional):
arrayWithConstant(num, const) - make array of constants with length num.
arrayWithConstant(3, 'hello') = ['hello', 'hello', 'hello']
arrayWithConstant(1, 'hello') = ['hello']
arrayWithConstant(0, 'hello') = []
