### PR TITLE
Fixed error in system.tables

### DIFF
--- a/dbms/src/Storages/System/StorageSystemTables.cpp
+++ b/dbms/src/Storages/System/StorageSystemTables.cpp
@@ -173,8 +173,12 @@ protected:
 
             for (; rows_count < max_block_size && tables_it->isValid(); tables_it->next())
             {
-                ++rows_count;
                 auto table_name = tables_it->name();
+                const auto table = context.tryGetTable(database_name, table_name);
+                if (!table)
+                    continue;
+
+                ++rows_count;
 
                 size_t src_index = 0;
                 size_t res_index = 0;
@@ -253,11 +257,10 @@ protected:
                 else
                     src_index += 2;
 
-                const auto table_it = context.getTable(database_name, table_name);
                 ASTPtr expression_ptr;
                 if (columns_mask[src_index++])
                 {
-                    if ((expression_ptr = table_it->getPartitionKeyAST()))
+                    if ((expression_ptr = table->getPartitionKeyAST()))
                         res_columns[res_index++]->insert(queryToString(expression_ptr));
                     else
                         res_columns[res_index++]->insertDefault();
@@ -265,7 +268,7 @@ protected:
 
                 if (columns_mask[src_index++])
                 {
-                    if ((expression_ptr = table_it->getSortingKeyAST()))
+                    if ((expression_ptr = table->getSortingKeyAST()))
                         res_columns[res_index++]->insert(queryToString(expression_ptr));
                     else
                         res_columns[res_index++]->insertDefault();
@@ -273,7 +276,7 @@ protected:
 
                 if (columns_mask[src_index++])
                 {
-                    if ((expression_ptr = table_it->getPrimaryKeyAST()))
+                    if ((expression_ptr = table->getPrimaryKeyAST()))
                         res_columns[res_index++]->insert(queryToString(expression_ptr));
                     else
                         res_columns[res_index++]->insertDefault();
@@ -281,7 +284,7 @@ protected:
 
                 if (columns_mask[src_index++])
                 {
-                    if ((expression_ptr = table_it->getSamplingKeyAST()))
+                    if ((expression_ptr = table->getSamplingKeyAST()))
                         res_columns[res_index++]->insert(queryToString(expression_ptr));
                     else
                         res_columns[res_index++]->insertDefault();

--- a/dbms/tests/queries/0_stateless/00838_system_tables_drop_table_race.sh
+++ b/dbms/tests/queries/0_stateless/00838_system_tables_drop_table_race.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. $CURDIR/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS test.table"
+
+seq 1 100 | sed -r -e "s/.+/CREATE TABLE test.table (x UInt8) ENGINE = MergeTree ORDER BY x; DROP TABLE test.table;/" | $CLICKHOUSE_CLIENT -n &
+seq 1 1000 | sed -r -e "s/.+/SELECT * FROM system.tables WHERE database = 'test' LIMIT 1000000, 1;/" | $CLICKHOUSE_CLIENT -n &
+
+wait

--- a/dbms/tests/queries/0_stateless/00838_system_tables_drop_table_race.sh
+++ b/dbms/tests/queries/0_stateless/00838_system_tables_drop_table_race.sh
@@ -8,6 +8,6 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS test.table"
 
 seq 1 100 | sed -r -e "s/.+/CREATE TABLE test.table (x UInt8) ENGINE = MergeTree ORDER BY x; DROP TABLE test.table;/" | $CLICKHOUSE_CLIENT -n &
-seq 1 1000 | sed -r -e "s/.+/SELECT * FROM system.tables WHERE database = 'test' LIMIT 1000000, 1;/" | $CLICKHOUSE_CLIENT -n &
+seq 1 100 | sed -r -e "s/.+/SELECT * FROM system.tables WHERE database = 'test' LIMIT 1000000, 1;/" | $CLICKHOUSE_CLIENT -n &
 
 wait


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fixed race condition when selecting from `system.tables` may give `table doesn't exist` error. The bug appeared in version 18.16.0.

Detailed description (optional):
This PR fixes #3982.