### PR TITLE
Fixed use after free in clickhouse-client (suggestion thread)

### DIFF
--- a/dbms/programs/client/Client.cpp
+++ b/dbms/programs/client/Client.cpp
@@ -12,6 +12,7 @@
 #include <unordered_set>
 #include <algorithm>
 #include <optional>
+#include <ext/scope_guard.h>
 #include <boost/program_options.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <Poco/String.h>
@@ -400,6 +401,7 @@ private:
                 throw Exception("time option could be specified only in non-interactive mode", ErrorCodes::BAD_ARGUMENTS);
 
 #if USE_READLINE
+            SCOPE_EXIT({ Suggest::instance().finalize(); });
             if (server_revision >= Suggest::MIN_SERVER_REVISION
                 && !config().getBool("disable_suggestion", false))
             {

--- a/dbms/programs/client/Suggest.h
+++ b/dbms/programs/client/Suggest.h
@@ -194,6 +194,12 @@ public:
         });
     }
 
+    void finalize()
+    {
+        if (loading_thread.joinable())
+            loading_thread.join();
+    }
+
     /// A function for readline.
     static char * generator(const char * text, int state)
     {
@@ -211,8 +217,7 @@ public:
 
     ~Suggest()
     {
-        if (loading_thread.joinable())
-            loading_thread.join();
+        finalize();
     }
 };
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
clickhouse-client can segfault on exit while loading data for command line suggestions if it was run in interactive mode.