### PR TITLE
Usability: highlight metacharacters in LIKE expressions and regexps

### DIFF
--- a/dbms/src/Parsers/ASTFunction.cpp
+++ b/dbms/src/Parsers/ASTFunction.cpp
@@ -55,7 +55,7 @@ ASTPtr ASTFunction::clone() const
 
 /** A special hack. If it's LIKE or NOT LIKE expression and the right hand side is a string literal,
   *  we will highlight unescaped metacharacters % and _ in string literal for convenience.
-  * Motivation: most people don't aware that _ is a metacharacter and forgot to properly escape it with two backslashes.
+  * Motivation: most people are unaware that _ is a metacharacter and forgot to properly escape it with two backslashes.
   * With highlighting we make it clearly obvious.
   *
   * Another case is regexp match. Suppose the user types match(URL, 'www.yandex.ru'). It often means that the user is unaware that . is a metacharacter.

--- a/dbms/src/Parsers/ASTFunction.cpp
+++ b/dbms/src/Parsers/ASTFunction.cpp
@@ -52,6 +52,55 @@ ASTPtr ASTFunction::clone() const
     return res;
 }
 
+
+/** A special hack. If it's LIKE or NOT LIKE expression and the right hand side is a string literal,
+  *  we will highlight unescaped metacharacters % and _ in string literal for convenience.
+  * Motivation: most people don't aware that _ is a metacharacter and forgot to properly escape it with two backslashes.
+  * With highlighting we make it clearly obvious.
+  *
+  * Another case is regexp match. Suppose the user types match(URL, 'www.yandex.ru'). It often means that the user is unaware that . is a metacharacter.
+  */
+static bool highlightStringLiteralWithMetacharacters(const ASTPtr & node, const IAST::FormatSettings & settings, const char * metacharacters)
+{
+    if (auto literal = dynamic_cast<const ASTLiteral *>(node.get()))
+    {
+        if (literal->value.getType() == Field::Types::String)
+        {
+            auto string = applyVisitor(FieldVisitorToString(), literal->value);
+
+            unsigned escaping = 0;
+            for (auto c : string)
+            {
+                if (c == '\\')
+                {
+                    settings.ostr << c;
+                    if (escaping == 2)
+                        escaping = 0;
+                    ++escaping;
+                }
+                else if (nullptr != strchr(metacharacters, c))
+                {
+                    if (escaping == 2)      /// Properly escaped metacharacter
+                        settings.ostr << c;
+                    else                    /// Unescaped metacharacter
+                        settings.ostr << "\033[1;35m" << c << "\033[0m";
+                    escaping = 0;
+                }
+                else
+                {
+                    settings.ostr << c;
+                    escaping = 0;
+                }
+            }
+
+            return true;
+        }
+    }
+
+    return false;
+}
+
+
 void ASTFunction::formatImplWithoutAlias(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     FormatStateStacked nested_need_parens = frame;
@@ -128,7 +177,14 @@ void ASTFunction::formatImplWithoutAlias(const FormatSettings & settings, Format
                         settings.ostr << '(';
                     arguments->children[0]->formatImpl(settings, state, nested_need_parens);
                     settings.ostr << (settings.hilite ? hilite_operator : "") << func[1] << (settings.hilite ? hilite_none : "");
-                    arguments->children[1]->formatImpl(settings, state, nested_need_parens);
+
+                    bool special_hilite = settings.hilite
+                        && (name == "like" || name == "notLike")
+                        && highlightStringLiteralWithMetacharacters(arguments->children[1], settings, "%_");
+
+                    if (!special_hilite)
+                        arguments->children[1]->formatImpl(settings, state, nested_need_parens);
+
                     if (frame.need_parens)
                         settings.ostr << ')';
                     written = true;
@@ -254,7 +310,23 @@ void ASTFunction::formatImplWithoutAlias(const FormatSettings & settings, Format
         if (arguments)
         {
             settings.ostr << '(' << (settings.hilite ? hilite_none : "");
-            arguments->formatImpl(settings, state, nested_dont_need_parens);
+
+            bool special_hilite_regexp = settings.hilite
+                && (name == "match" || name == "extract" || name == "extractAll" || name == "replaceRegexpOne" || name == "replaceRegexpAll");
+
+            for (size_t i = 0, size = arguments->children.size(); i < size; ++i)
+            {
+                if (i != 0)
+                    settings.ostr << ", ";
+
+                bool special_hilite = false;
+                if (i == 1 && special_hilite_regexp)
+                    special_hilite = highlightStringLiteralWithMetacharacters(arguments->children[i], settings, "|()^$.[]?*+{:-");
+
+                if (!special_hilite)
+                    arguments->children[i]->formatImpl(settings, state, nested_dont_need_parens);
+            }
+
             settings.ostr << (settings.hilite ? hilite_function : "") << ')';
         }
 


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

Short description (up to few sentences):
Highlight unescaped metacharacters in string literals that contain `LIKE` expressions or regexps.