### PR TITLE
Better hints provider

### DIFF
--- a/dbms/src/Common/IFactoryWithAliases.h
+++ b/dbms/src/Common/IFactoryWithAliases.h
@@ -131,7 +131,7 @@ private:
     /**
       * prompter for names, if a person makes a typo for some function or type, it
       * helps to find best possible match (in particular, edit distance is done like in clang
-      * (max edit distance is (typo.size() + 2) / 3 and not bigger than)
+      * (max edit distance is (typo.size() + 2) / 3)
       */
     NamePrompter</*MaxNumHints=*/2> prompter;
 };

--- a/dbms/src/Common/IFactoryWithAliases.h
+++ b/dbms/src/Common/IFactoryWithAliases.h
@@ -130,9 +130,10 @@ private:
 
     /**
       * prompter for names, if a person makes a typo for some function or type, it
-      * helps to find best possible match (in particular, edit distance is one or two symbols)
+      * helps to find best possible match (in particular, edit distance is done like in clang
+      * (max edit distance is (typo.size() + 2) / 3 and not bigger than)
       */
-    NamePrompter</*MistakeFactor=*/2, /*MaxNumHints=*/2> prompter;
+    NamePrompter</*MaxNumHints=*/2> prompter;
 };
 
 }

--- a/dbms/tests/queries/0_stateless/00834_hints_for_type_function_typos.sh
+++ b/dbms/tests/queries/0_stateless/00834_hints_for_type_function_typos.sh
@@ -11,4 +11,12 @@ $CLICKHOUSE_CLIENT -q "select positin(*) from system.functions;" 2>&1 | grep "Ma
 $CLICKHOUSE_CLIENT -q "select POSITIO(*) from system.functions;" 2>&1 | grep "Maybe you meant: \['position'" &>/dev/null;
 $CLICKHOUSE_CLIENT -q "select fount(*) from system.functions;" 2>&1 | grep "Maybe you meant: \['count'" | grep "Maybe you meant: \['round'" | grep "Or unknown aggregate function" &>/dev/null;
 $CLICKHOUSE_CLIENT -q "select positin(*) from system.functions;" 2>&1 | grep -v "Or unknown aggregate function" &>/dev/null;
-$CLICKHOUSE_CLIENT -q "select pov(*) from system.functions;" 2>&1 | grep "Maybe you meant: \['pow','cos'\]" &>/dev/null;
+$CLICKHOUSE_CLIENT -q "select pov(*) from system.functions;" 2>&1 | grep "Maybe you meant: \['pow'\]" &>/dev/null;
+$CLICKHOUSE_CLIENT -q "select getColumnStructure('abc');" 2>&1 | grep "Maybe you meant: \['dumpColumnStructure'\]" &>/dev/null;
+$CLICKHOUSE_CLIENT -q "select gutColumnStructure('abc');" 2>&1 | grep "Maybe you meant: \['dumpColumnStructure'\]" &>/dev/null;
+$CLICKHOUSE_CLIENT -q "select gupColumnStructure('abc');" 2>&1 | grep "Maybe you meant: \['dumpColumnStructure'\]" &>/dev/null;
+$CLICKHOUSE_CLIENT -q "select provideColumnStructure('abc');" 2>&1 | grep "Maybe you meant: \['dumpColumnStructure'\]" &>/dev/null;
+$CLICKHOUSE_CLIENT -q "select multiposicionutf7('abc');" 2>&1 | grep "Maybe you meant: \['multiPositionUTF8','multiPosition'\]" &>/dev/null;
+$CLICKHOUSE_CLIENT -q "select multiposicionutf7casesensitive('abc');" 2>&1 | grep "Maybe you meant: \['multiPositionCaseInsensitive'\]" &>/dev/null;
+$CLICKHOUSE_CLIENT -q "select multiposicionutf7sensitive('abc');" 2>&1 | grep "Maybe you meant: \['multiPositionCaseInsensitive'\]" &>/dev/null;
+$CLICKHOUSE_CLIENT -q "select multiPosicionSensitiveUTF8('abc');" 2>&1 | grep "Maybe you meant: \['multiPositionCaseInsensitiveUTF8'\]" &>/dev/null;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

Short description (up to few sentences):

Improved hints selector -- now it is similar to clang SimpleTypoCorrector