### PR TITLE
Docs: arrayDistinct function had (wrong) copy/paste example from arrayDifference

### DIFF
--- a/docs/en/query_language/functions/array_functions.md
+++ b/docs/en/query_language/functions/array_functions.md
@@ -488,13 +488,13 @@ SELECT arrayDifference([1, 2, 3, 4])
 Takes an array, returns an array containing the different elements in all the arrays. For example:
 
 ```sql
-SELECT arrayDifference([1, 2, 3, 4])
+SELECT arrayDistinct([1, 2, 2, 3, 1])
 ```
 
 ```
-┌─arrayDifference([1, 2, 3, 4])─┐
-│ [0,1,1,1]                     │
-└───────────────────────────────┘
+┌─arrayDistinct([1, 2, 2, 3, 1])─┐
+│ [1,2,3]                        │
+└────────────────────────────────┘
 ```
 
 ## arrayEnumerateDense(arr)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Minor fix in the documentation of "Working with Arrays".
