### PR TITLE
Test runner script and corresponding Dockerfile and docker-compose.

### DIFF
--- a/docker/server/local.Dockerfile
+++ b/docker/server/local.Dockerfile
@@ -1,0 +1,38 @@
+FROM ubuntu:18.04
+
+ARG gosu_ver=1.10
+ARG CLICKHOUSE_PACKAGES_DIR
+
+COPY ${CLICKHOUSE_PACKAGES_DIR}/clickhouse-*.deb /packages/
+
+# installing via apt to simulate real-world scenario, where user installs deb package and all it's dependecies automatically.
+RUN apt update; \
+    DEBIAN_FRONTEND=noninteractive \
+    apt install -y \
+        /packages/clickhouse-common-static_*.deb \
+        /packages/clickhouse-server_*.deb \
+        locales ;\
+    rm -rf /packages
+
+ADD https://github.com/tianon/gosu/releases/download/${gosu_ver}/gosu-amd64 /bin/gosu
+
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+RUN mkdir /docker-entrypoint-initdb.d
+
+COPY server/docker_related_config.xml /etc/clickhouse-server/config.d/
+COPY server/entrypoint.sh /entrypoint.sh
+
+RUN chmod +x \
+    /entrypoint.sh \
+    /bin/gosu
+
+EXPOSE 9000 8123 9009
+VOLUME /var/lib/clickhouse
+
+ENV CLICKHOUSE_CONFIG /etc/clickhouse-server/config.xml
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/test/stateless/clickhouse-statelest-test-runner.Dockerfile
+++ b/docker/test/stateless/clickhouse-statelest-test-runner.Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:18.10
+
+ARG CLICKHOUSE_PACKAGES_DIR
+COPY ${CLICKHOUSE_PACKAGES_DIR}/clickhouse-*.deb /packages/
+
+RUN apt-get update ;\
+	DEBIAN_FRONTEND=noninteractive \
+	apt install -y /packages/clickhouse-common-static_*.deb \
+		/packages/clickhouse-client_*.deb \
+		/packages/clickhouse-test_*.deb \
+		wait-for-it; \
+	rm -rf /packages

--- a/docker/test/test_runner.sh
+++ b/docker/test/test_runner.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -e
+
+# Run tests in docker
+# OR
+# Build containers from deb packages, copying the tests from the source directory 
+
+readonly CLICKHOUSE_DOCKER_DIR="$(realpath ${1})"
+readonly CLICKHOUSE_PACKAGES_DIR="${2}"
+CLICKHOUSE_SERVER_IMAGE="${3}"
+
+# Build test runner image
+docker build \
+	-f "${CLICKHOUSE_DOCKER_DIR}/test/stateless/clickhouse-statelest-test-runner.Dockerfile" \
+	-t clickhouse-statelest-test-runner:local \
+	--build-arg CLICKHOUSE_PACKAGES_DIR="${CLICKHOUSE_PACKAGES_DIR}" \
+	"${CLICKHOUSE_DOCKER_DIR}"
+
+# Build server image (optional) from local packages
+if [ -z "${CLICKHOUSE_SERVER_IMAGE}" ]; then
+	CLICKHOUSE_SERVER_IMAGE="yandex/clickhouse_server:local"
+
+	docker build \
+		-f "${CLICKHOUSE_DOCKER_DIR}/server/local.Dockerfile" \
+		-t "${CLICKHOUSE_SERVER_IMAGE}" \
+		--build-arg CLICKHOUSE_PACKAGES_DIR=${CLICKHOUSE_PACKAGES_DIR} \
+		"${CLICKHOUSE_DOCKER_DIR}"
+fi
+
+CLICKHOUSE_SERVER_IMAGE="${CLICKHOUSE_SERVER_IMAGE}" docker-compose -f "${CLICKHOUSE_DOCKER_DIR}/test/test_runner_docker_compose.yaml" run test-runner

--- a/docker/test/test_runner_docker_compose.yaml
+++ b/docker/test/test_runner_docker_compose.yaml
@@ -1,0 +1,30 @@
+version: "2"
+
+services:
+  clickhouse-server:
+    image: ${CLICKHOUSE_SERVER_IMAGE}
+    expose:
+      - "8123"
+      - "9000"
+      - "9009"
+    restart: "no"
+
+  test-runner:
+    image: yandex/clickhouse-statelest-test-runner:local
+
+    restart: "no"
+    depends_on:
+      - clickhouse-server
+    environment:
+      # these are used by clickhouse-test to point clickhouse-client to the right server
+      - CLICKHOUSE_HOST=clickhouse-server
+      - CLICKHOUSE_PORT=8123
+
+    entrypoint:
+      - wait-for-it
+      - clickhouse-server:8123
+      - -- 
+      - clickhouse-test
+      # - -c
+      # - `which clickhouse-client`
+      - ${CLICKHOUSE_TEST_ARGS}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

- Build/Testing/Packaging Improvement

Test harness and helper script to allow testing of clickhouse-server docker image against stateless tests.

...

There are two containers instantiated from two separate images started from single docker-compose:
* clickhouse-server
* tests

One might specify an clickhouse-server image to run the tests against or build a new image from set of existing deb packages.
Image with tests is built from existing deb packages: clickhouse-client and clickhouse-test with all dependencies (should we allow building test image with local binaries/test cases?).

The benefits of having tests and server in separate containers/images:
* No modifications to the server image is required - you test what you intend to ship to customers.
* Testing against realistic scenarios - DB is often run in isolated container, with minimum extra stuff.
* Tests setup does not depends on server setup - server may run on whatever OS.

### Examples
```bash
# Build clickhouse-server and test runner images from deb packages
ClickHouse/docker$ sudo ./test/test_runner.sh . packager/OUT/packages/current
```

```bash
# Use existing clickhouse-server image and build test runner image from deb packages
ClickHouse/docker$ sudo ./test/test_runner.sh . packager/OUT/packages/current yandex/clickhouse-server:latest
```
### Notes
`sudo` is optional if current user can invoke docker directly.
Some tests fail due to compatibility reasons and are to be fixed later.

...
