### PR TITLE
Fixed rare race condition on startup of non-replicated MergeTree tables: concurrent attempt to remove a temporary directory [#CLICKHOUSE-4296]

### DIFF
--- a/dbms/src/Storages/MergeTree/BackgroundProcessingPool.h
+++ b/dbms/src/Storages/MergeTree/BackgroundProcessingPool.h
@@ -53,7 +53,9 @@ public:
         return size;
     }
 
+    /// The task is started immediately.
     TaskHandle addTask(const Task & task);
+
     void removeTask(const TaskHandle & task);
 
     ~BackgroundProcessingPool();

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -831,7 +831,7 @@ void MergeTreeData::clearOldTemporaryDirectories(ssize_t custom_directories_life
     Poco::DirectoryIterator end;
     for (Poco::DirectoryIterator it{full_path}; it != end; ++it)
     {
-        if (startsWith(it.name(), "tmp"))
+        if (startsWith(it.name(), "tmp_"))
         {
             Poco::File tmp_dir(full_path + it.name());
 

--- a/dbms/src/Storages/StorageMergeTree.cpp
+++ b/dbms/src/Storages/StorageMergeTree.cpp
@@ -87,13 +87,15 @@ StorageMergeTree::StorageMergeTree(
 
 void StorageMergeTree::startup()
 {
-    background_task_handle = background_pool.addTask([this] { return backgroundTask(); });
-
     data.clearOldPartsFromFilesystem();
 
     /// Temporary directories contain incomplete results of merges (after forced restart)
     ///  and don't allow to reinitialize them, so delete each of them immediately
     data.clearOldTemporaryDirectories(0);
+
+    /// NOTE background task will also do the above cleanups periodically.
+    time_after_previous_cleanup.restart();
+    background_task_handle = background_pool.addTask([this] { return backgroundTask(); });
 }
 
 


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
There was a race condition at the server startup: when initializing a non-Replicated MergeTree table, there is a chance that an attempt of concurrent removal of a temporary directory will happen and the server will not startup with an error message `File not found` just after `Removing temporary directory` message.

Detailed description (optional):
This is minor issue.