### PR TITLE
Fixed race condition in removal of data parts

### DIFF
--- a/dbms/src/Storages/MergeTree/MergeTreeDataPart.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataPart.cpp
@@ -334,8 +334,20 @@ void MergeTreeDataPart::remove() const
     if (relative_path.empty())
         throw Exception("Part relative_path cannot be empty. This is bug.", ErrorCodes::LOGICAL_ERROR);
 
+    /** Atomic directory removal:
+      * - rename directory to temporary name;
+      * - remove it recursive.
+      *
+      * For temporary name we use "delete_tmp_" prefix.
+      *
+      * NOTE: We cannot use "tmp_delete_" prefix, because there is a second thread,
+      *  that calls "clearOldTemporaryDirectories" and removes all directories, that begin with "tmp_" and are old enough.
+      * But when we removing data part, it can be old enough. And rename doesn't change mtime.
+      * And a race condition can happen that will lead to "File not found" error here.
+      */
+
     String from = storage.full_path + relative_path;
-    String to = storage.full_path + "tmp_delete_" + name;
+    String to = storage.full_path + "delete_tmp_" + name;
 
     Poco::File from_dir{from};
     Poco::File to_dir{to};


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fixed rare race condition when removing of old data parts can fail with `File not found` error.

Detailed description (optional):
This PR fixes #3531
