### PR TITLE
Add info about replicated_can_become_leader to logs and system.replicas

### DIFF
--- a/dbms/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/dbms/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -183,6 +183,8 @@ bool ReplicatedMergeTreeRestartingThread::tryStartup()
 
         if (storage.data.settings.replicated_can_become_leader)
             storage.enterLeaderElection();
+        else
+            LOG_INFO(log, "Will not enter leader election because replicated_can_become_leader=0");
 
         /// Anything above can throw a KeeperException if something is wrong with ZK.
         /// Anything below should not throw exceptions.

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -3904,6 +3904,7 @@ void StorageReplicatedMergeTree::getStatus(Status & res, bool with_zk_fields)
     auto zookeeper = tryGetZooKeeper();
 
     res.is_leader = is_leader;
+    res.can_become_leader = data.settings.replicated_can_become_leader;
     res.is_readonly = is_readonly;
     res.is_session_expired = !zookeeper || zookeeper->expired();
 

--- a/dbms/src/Storages/StorageReplicatedMergeTree.h
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.h
@@ -153,6 +153,7 @@ public:
     struct Status
     {
         bool is_leader;
+        bool can_become_leader;
         bool is_readonly;
         bool is_session_expired;
         ReplicatedMergeTreeQueue::Status queue;

--- a/dbms/src/Storages/System/StorageSystemReplicas.cpp
+++ b/dbms/src/Storages/System/StorageSystemReplicas.cpp
@@ -22,6 +22,7 @@ StorageSystemReplicas::StorageSystemReplicas(const std::string & name_)
         { "table",                                std::make_shared<DataTypeString>()   },
         { "engine",                               std::make_shared<DataTypeString>()   },
         { "is_leader",                            std::make_shared<DataTypeUInt8>()    },
+        { "can_become_leader",                    std::make_shared<DataTypeUInt8>()    },
         { "is_readonly",                          std::make_shared<DataTypeUInt8>()    },
         { "is_session_expired",                   std::make_shared<DataTypeUInt8>()    },
         { "future_parts",                         std::make_shared<DataTypeUInt32>()   },
@@ -137,6 +138,7 @@ BlockInputStreams StorageSystemReplicas::read(
 
         size_t col_num = 3;
         res_columns[col_num++]->insert(status.is_leader);
+        res_columns[col_num++]->insert(status.can_become_leader);
         res_columns[col_num++]->insert(status.is_readonly);
         res_columns[col_num++]->insert(status.is_session_expired);
         res_columns[col_num++]->insert(status.queue.future_parts);


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement


Short description (up to few sentences):

Add info about the replicated_can_become_leader setting to system.replicas and add logging if the replica won't try to become leader.
