### PR TITLE
Better replica repair

### DIFF
--- a/dbms/src/Common/ZooKeeper/ZooKeeper.cpp
+++ b/dbms/src/Common/ZooKeeper/ZooKeeper.cpp
@@ -523,6 +523,22 @@ int32_t ZooKeeper::tryMulti(const Coordination::Requests & requests, Coordinatio
 }
 
 
+void ZooKeeper::removeChildren(const std::string & path)
+{
+    Strings children = getChildren(path);
+    while (!children.empty())
+    {
+        Coordination::Requests ops;
+        for (size_t i = 0; i < MULTI_BATCH_SIZE && !children.empty(); ++i)
+        {
+            ops.emplace_back(makeRemoveRequest(path + "/" + children.back(), -1));
+            children.pop_back();
+        }
+        multi(ops);
+    }
+}
+
+
 void ZooKeeper::removeChildrenRecursive(const std::string & path)
 {
     Strings children = getChildren(path);

--- a/dbms/src/Common/ZooKeeper/ZooKeeper.h
+++ b/dbms/src/Common/ZooKeeper/ZooKeeper.h
@@ -177,6 +177,9 @@ public:
     /// result would be the same as for the single call.
     void tryRemoveRecursive(const std::string & path);
 
+    /// Remove all children nodes (non recursive).
+    void removeChildren(const std::string & path);
+
     /// Wait for the node to disappear or return immediately if it doesn't exist.
     void waitForDisappear(const std::string & path);
 

--- a/dbms/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/dbms/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -14,6 +14,11 @@
 #include <array>
 
 
+/// ZooKeeper has 1 MB node size and serialization limit by default,
+/// but it can be raised up, so we have a slightly larger limit on our side.
+#define MAX_STRING_OR_ARRAY_SIZE (1 << 28)  /// 256 MiB
+
+
 namespace ProfileEvents
 {
     extern const Event ZooKeeperInit;
@@ -322,7 +327,6 @@ void read(bool & x, ReadBuffer & in)
 
 void read(String & s, ReadBuffer & in)
 {
-    static constexpr int32_t max_string_size = 1 << 20;
     int32_t size = 0;
     read(size, in);
 
@@ -336,7 +340,7 @@ void read(String & s, ReadBuffer & in)
     if (size < 0)
         throw Exception("Negative size while reading string from ZooKeeper", ZMARSHALLINGERROR);
 
-    if (size > max_string_size)
+    if (size > MAX_STRING_OR_ARRAY_SIZE)
         throw Exception("Too large string size while reading from ZooKeeper", ZMARSHALLINGERROR);
 
     s.resize(size);
@@ -369,12 +373,11 @@ void read(Stat & stat, ReadBuffer & in)
 
 template <typename T> void read(std::vector<T> & arr, ReadBuffer & in)
 {
-    static constexpr int32_t max_array_size = 1 << 20;
     int32_t size = 0;
     read(size, in);
     if (size < 0)
         throw Exception("Negative size while reading array from ZooKeeper", ZMARSHALLINGERROR);
-    if (size > max_array_size)
+    if (size > MAX_STRING_OR_ARRAY_SIZE)
         throw Exception("Too large array size while reading from ZooKeeper", ZMARSHALLINGERROR);
     arr.resize(size);
     for (auto & elem : arr)

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -2036,6 +2036,9 @@ void StorageReplicatedMergeTree::cloneReplicaIfNeeded(zkutil::ZooKeeperPtr zooke
     if (source_replica.empty())
         throw Exception("All replicas are lost", ErrorCodes::ALL_REPLICAS_LOST);
 
+    /// Clear obsolete queue that we no longer need.
+    zookeeper->removeChildren(replica_path + "/queue");
+
     /// Will do repair from the selected replica.
     cloneReplica(source_replica, source_is_lost_stat, zookeeper);
     /// If repair fails to whatever reason, the exception is thrown, is_lost will remain "1" and the replica will be repaired later.


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

Short description (up to few sentences):
Allow to repair abandoned replica even if it already has huge number of nodes in its queue.