### PR TITLE
Add CLI settings for clickhouse-performance-test.

### DIFF
--- a/dbms/programs/performance-test/PerformanceTestInfo.cpp
+++ b/dbms/programs/performance-test/PerformanceTestInfo.cpp
@@ -43,8 +43,10 @@ namespace fs = boost::filesystem;
 
 PerformanceTestInfo::PerformanceTestInfo(
     XMLConfigurationPtr config,
-    const std::string & profiles_file_)
+    const std::string & profiles_file_,
+    const Settings & global_settings_)
     : profiles_file(profiles_file_)
+    , settings(global_settings_)
 {
     test_name = config->getString("name");
     path = config->getString("path");

--- a/dbms/programs/performance-test/PerformanceTestInfo.h
+++ b/dbms/programs/performance-test/PerformanceTestInfo.h
@@ -26,7 +26,7 @@ using StringToVector = std::map<std::string, Strings>;
 class PerformanceTestInfo
 {
 public:
-    PerformanceTestInfo(XMLConfigurationPtr config, const std::string & profiles_file_);
+    PerformanceTestInfo(XMLConfigurationPtr config, const std::string & profiles_file_, const Settings & global_settings_);
 
     std::string test_name;
     std::string path;
@@ -34,12 +34,12 @@ public:
 
     Strings queries;
 
+    std::string profiles_file;
     Settings settings;
     ExecutionType exec_type;
     StringToVector substitutions;
     size_t times_to_run;
 
-    std::string profiles_file;
     std::vector<TestStopConditions> stop_conditions_by_run;
 
     Strings create_queries;

--- a/dbms/programs/performance-test/PerformanceTestSuite.cpp
+++ b/dbms/programs/performance-test/PerformanceTestSuite.cpp
@@ -91,16 +91,6 @@ public:
             throw Exception("No tests were specified", ErrorCodes::BAD_ARGUMENTS);
     }
 
-    /// This functionality seems strange.
-    //void initialize(Poco::Util::Application & self [[maybe_unused]])
-    //{
-    //    std::string home_path;
-    //    const char * home_path_cstr = getenv("HOME");
-    //    if (home_path_cstr)
-    //        home_path = home_path_cstr;
-    //    configReadClient(Poco::Util::Application::instance().config(), home_path);
-    //}
-
     int run()
     {
         std::string name;
@@ -119,6 +109,10 @@ public:
         processTestsConfigurations(input_files);
 
         return 0;
+    }
+    void setContextSetting(const String & name, const std::string & value)
+    {
+        global_context.setSetting(name, value);
     }
 
 private:
@@ -201,7 +195,7 @@ private:
 
     std::pair<std::string, bool> runTest(XMLConfigurationPtr & test_config)
     {
-        PerformanceTestInfo info(test_config, profiles_file);
+        PerformanceTestInfo info(test_config, profiles_file, global_context.getSettingsRef());
         LOG_INFO(log, "Config for test '" << info.test_name << "' parsed");
         PerformanceTest current(test_config, connection, interrupt_listener, info, global_context, query_indexes[info.path]);
 
@@ -330,6 +324,7 @@ try
     using Strings = DB::Strings;
 
 
+#define DECLARE_SETTING(TYPE, NAME, DEFAULT, DESCRIPTION) (#NAME, po::value<std::string>(), DESCRIPTION)
     po::options_description desc("Allowed options");
     desc.add_options()
         ("help", "produce help message")
@@ -350,7 +345,10 @@ try
         ("skip-names-regexp", value<Strings>()->multitoken(), "Do not run tests with names matching regexp")
         ("input-files", value<Strings>()->multitoken(), "Input .xml files")
         ("query-indexes", value<std::vector<size_t>>()->multitoken(), "Input query indexes")
-        ("recursive,r", "Recurse in directories to find all xml's");
+        ("recursive,r", "Recurse in directories to find all xml's")
+    APPLY_FOR_SETTINGS(DECLARE_SETTING);
+#undef DECLARE_SETTING
+
 
     po::options_description cmdline_options;
     cmdline_options.add(desc);
@@ -408,6 +406,15 @@ try
         std::move(skip_names_regexp),
         queries_with_indexes,
         timeouts);
+    /// Extract settings from the options.
+#define EXTRACT_SETTING(TYPE, NAME, DEFAULT, DESCRIPTION) \
+    if (options.count(#NAME)) \
+    { \
+        performance_test_suite.setContextSetting(#NAME, options[#NAME].as<std::string>()); \
+    }
+    APPLY_FOR_SETTINGS(EXTRACT_SETTING)
+#undef EXTRACT_SETTING
+
     return performance_test_suite.run();
 }
 catch (...)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement
Short description (up to few sentences):
Add ability to specify settings for `clickhouse-performance-test` from CLI.
