### PR TITLE
[PATCH] Fixup for "AIOcontextPool: Found io_event with unknown id 0'' error #4434 from urgordeadbeef

### DIFF
--- a/dbms/src/IO/AIOContextPool.cpp
+++ b/dbms/src/IO/AIOContextPool.cpp
@@ -84,7 +84,11 @@ void AIOContextPool::fulfillPromises(const io_event events[], const int num_even
     for (const auto & event : boost::make_iterator_range(events, events + num_events))
     {
         /// get id from event
+#if defined(__FreeBSD__)
+        const auto completed_id = (reinterpret_cast<struct iocb *>(event.udata))->aio_data;
+#else
         const auto completed_id = event.data;
+#endif
 
         /// set value via promise and release it
         const auto it = promises.find(completed_id);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Freebsd: Fixup for "AIOcontextPool: Found io_event with unknown id 0'' error (patch by urgordeadbeef)
