### PR TITLE
Fixed backward incompatibility of table function "remote" introduced with column comments

### DIFF
--- a/dbms/src/Interpreters/InterpreterDescribeQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterDescribeQuery.cpp
@@ -46,7 +46,7 @@ Block InterpreterDescribeQuery::getSampleBlock()
     col.name = "default_expression";
     block.insert(col);
 
-    col.name = "comment_expression";
+    col.name = "comment";
     block.insert(col);
 
     col.name = "codec_expression";


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

Short description (up to few sentences):
Fixed backward incompatibility of table function "remote" introduced with column comments. If the function "remote" or "cluster" is querying old ClickHouse server, it was failing with `Not found column comment_expression in block` error message. Renamed `comment_expression` to `comment` in the result of `DESC TABLE` query.

Detailed description (optional):
This PR fixes #4040
Not covered by tests.