### PR TITLE
Do not create part_log if it is not defined in configuration file

### DIFF
--- a/dbms/programs/server/config.xml
+++ b/dbms/programs/server/config.xml
@@ -294,12 +294,20 @@
         <flush_interval_milliseconds>7500</flush_interval_milliseconds>
     </query_log>
 
+    <!-- Query thread log. Has information about all threads participated in query execution.
+         Used only for queries with setting log_query_threads = 1. -->
+    <query_thread_log>
+        <database>system</database>
+        <table>query_thread_log</table>
+        <partition_by>toYYYYMM(event_date)</partition_by>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    </query_thread_log>
 
-    <!-- Uncomment if use part_log
+    <!-- Uncomment if use part log.
+         Part log contains information about all actions with parts in MergeTree tables (creation, deletion, merges, downloads).
     <part_log>
         <database>system</database>
         <table>part_log</table>
-
         <flush_interval_milliseconds>7500</flush_interval_milliseconds>
     </part_log>
     -->

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -1578,7 +1578,7 @@ PartLog * Context::getPartLog(const String & part_database)
 {
     auto lock = getLock();
 
-    /// System logs are shutting down.
+    /// No part log or system logs are shutting down.
     if (!shared->system_logs || !shared->system_logs->part_log)
         return nullptr;
 

--- a/dbms/src/Interpreters/SystemLog.cpp
+++ b/dbms/src/Interpreters/SystemLog.cpp
@@ -9,11 +9,41 @@
 namespace DB
 {
 
+namespace
+{
+
+constexpr size_t DEFAULT_SYSTEM_LOG_FLUSH_INTERVAL_MILLISECONDS = 7500;
+
+/// Creates a system log with MergeTree engine using parameters from config
+template <typename TSystemLog>
+std::unique_ptr<TSystemLog> createSystemLog(
+    Context & context,
+    const String & default_database_name,
+    const String & default_table_name,
+    const Poco::Util::AbstractConfiguration & config,
+    const String & config_prefix)
+{
+    if (!config.has(config_prefix))
+        return {};
+
+    String database = config.getString(config_prefix + ".database", default_database_name);
+    String table = config.getString(config_prefix + ".table", default_table_name);
+    String partition_by = config.getString(config_prefix + ".partition_by", "toYYYYMM(event_date)");
+    String engine = "ENGINE = MergeTree PARTITION BY (" + partition_by + ") ORDER BY (event_date, event_time) SETTINGS index_granularity = 1024";
+
+    size_t flush_interval_milliseconds = config.getUInt64(config_prefix + ".flush_interval_milliseconds", DEFAULT_SYSTEM_LOG_FLUSH_INTERVAL_MILLISECONDS);
+
+    return std::make_unique<TSystemLog>(context, database, table, engine, flush_interval_milliseconds);
+}
+
+}
+
+
 SystemLogs::SystemLogs(Context & global_context, const Poco::Util::AbstractConfiguration & config)
 {
-    query_log = createDefaultSystemLog<QueryLog>(global_context, "system", "query_log", config, "query_log");
-    query_thread_log = createDefaultSystemLog<QueryThreadLog>(global_context, "system", "query_thread_log", config, "query_thread_log");
-    part_log = createDefaultSystemLog<PartLog>(global_context, "system", "part_log", config, "part_log");
+    query_log = createSystemLog<QueryLog>(global_context, "system", "query_log", config, "query_log");
+    query_thread_log = createSystemLog<QueryThreadLog>(global_context, "system", "query_thread_log", config, "query_thread_log");
+    part_log = createSystemLog<PartLog>(global_context, "system", "part_log", config, "part_log");
 
     part_log_database = config.getString("part_log.database", "system");
 }

--- a/dbms/src/Interpreters/SystemLog.h
+++ b/dbms/src/Interpreters/SystemLog.h
@@ -378,26 +378,4 @@ void SystemLog<LogElement>::prepareTable()
     is_prepared = true;
 }
 
-/// Creates a system log with MergeTree engine using parameters from config
-template<typename TSystemLog>
-std::unique_ptr<TSystemLog> createDefaultSystemLog(
-    Context & context,
-    const String & default_database_name,
-    const String & default_table_name,
-    const Poco::Util::AbstractConfiguration & config,
-    const String & config_prefix)
-{
-    static constexpr size_t DEFAULT_SYSTEM_LOG_FLUSH_INTERVAL_MILLISECONDS = 7500;
-
-    String database = config.getString(config_prefix + ".database", default_database_name);
-    String table = config.getString(config_prefix + ".table", default_table_name);
-    String partition_by = config.getString(config_prefix + ".partition_by", "toYYYYMM(event_date)");
-    String engine = "ENGINE = MergeTree PARTITION BY (" + partition_by + ") ORDER BY (event_date, event_time) SETTINGS index_granularity = 1024";
-
-    size_t flush_interval_milliseconds = config.getUInt64(config_prefix + ".flush_interval_milliseconds", DEFAULT_SYSTEM_LOG_FLUSH_INTERVAL_MILLISECONDS);
-
-    return std::make_unique<TSystemLog>(context, database, table, engine, flush_interval_milliseconds);
-}
-
-
 }


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
`system.part_log` was used unconditionally.