### PR TITLE
detach thread before erasing it from the FreeThreadPool

### DIFF
--- a/dbms/src/Common/ThreadPool.cpp
+++ b/dbms/src/Common/ThreadPool.cpp
@@ -66,6 +66,7 @@ ReturnType ThreadPoolImpl<Thread>::scheduleImpl(Job job, int priority, std::opti
             }
             catch (...)
             {
+                threads.front().detach();
                 threads.pop_front();
             }
         }
@@ -188,6 +189,7 @@ void ThreadPoolImpl<Thread>::worker(typename std::list<Thread>::iterator thread_
 
             if (threads.size() > scheduled_jobs + max_free_threads)
             {
+                thread_it->detach();
                 threads.erase(thread_it);
                 job_finished.notify_all();
                 return;

--- a/dbms/src/Common/ThreadPool.h
+++ b/dbms/src/Common/ThreadPool.h
@@ -168,10 +168,11 @@ public:
 
     void join()
     {
-        {
-            std::lock_guard lock(*mutex);
-        }
-        mutex.reset();
+        reset();
+    }
+    void detach()
+    {
+        reset();
     }
 
     bool joinable() const
@@ -181,6 +182,14 @@ public:
 
 private:
     std::unique_ptr<std::mutex> mutex;  /// Object must be moveable.
+
+    void reset()
+    {
+        {
+            std::lock_guard lock(*mutex);
+        }
+        mutex.reset();
+    }
 };
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Category (leave one):
- Bug Fix

Short description (up to few sentences):

Otherwise std::thread will call std::terminate() from the dtor:

Detailed description (optional):

```
  ...
  #4  0x000000000ac829c1 in std::terminate() ()
  #5  0x0000000006f1c87f in std::thread::~thread (this=<optimized out>, __in_chrg=<optimized out>) at /usr/include/c++/7/thread:135
  ...
  #10 ThreadPoolImpl<std::thread>::worker (this=0xf370680 <ext::singleton<GlobalThreadPool>::instance()::instance>, thread_it=...) at ../dbms/src/Common/ThreadPool.cpp:191
```

Refs: f6b9b063071662f1c391ee95ff16a30c89069010 ("Attempt to implemnt global thread pool #4018")