### PR TITLE
Support xxHash with external lz4

### DIFF
--- a/cmake/find_xxhash.cmake
+++ b/cmake/find_xxhash.cmake
@@ -1,15 +1,22 @@
-# Freebsd: TODO: use system devel/xxhash. now error: undefined reference to `XXH32'
-if (LZ4_INCLUDE_DIR)
-    if (NOT EXISTS "${LZ4_INCLUDE_DIR}/xxhash.h")
-        message (WARNING "LZ4 library does not have XXHash. Support for XXHash will be disabled.")
-        set (USE_XXHASH 0)
-    else ()
-        set (USE_XXHASH 1)
-    endif ()
+option (USE_INTERNAL_XXHASH_LIBRARY "Set to FALSE to use system xxHash library instead of bundled" ${NOT_UNBUNDLED})
+
+if (USE_INTERNAL_XXHASH_LIBRARY AND NOT USE_INTERNAL_LZ4_LIBRARY)
+    message (WARNING "can not use internal xxhash without internal lz4")
+    set (USE_INTERNAL_XXHASH_LIBRARY 0)
 endif ()
 
-if (OS_FREEBSD AND NOT USE_INTERNAL_LZ4_LIBRARY)
+if (USE_INTERNAL_XXHASH_LIBRARY)
+    set (XXHASH_LIBRARY lz4)
+    set (XXHASH_INCLUDE_DIR ${ClickHouse_SOURCE_DIR}/contrib/lz4/lib)
+else ()
+    find_library (XXHASH_LIBRARY xxhash)
+    find_path (XXHASH_INCLUDE_DIR NAMES xxhash.h PATHS ${XXHASH_INCLUDE_PATHS})
+endif ()
+
+if (XXHASH_LIBRARY AND XXHASH_INCLUDE_DIR)
+    set (USE_XXHASH 1)
+else ()
     set (USE_XXHASH 0)
 endif ()
 
-message (STATUS "Using xxhash=${USE_XXHASH}")
+message (STATUS "Using xxhash=${USE_XXHASH}: ${XXHASH_INCLUDE_DIR} : ${XXHASH_LIBRARY}")

--- a/dbms/src/Functions/CMakeLists.txt
+++ b/dbms/src/Functions/CMakeLists.txt
@@ -20,8 +20,7 @@ target_link_libraries(clickhouse_functions
         ${METROHASH_LIBRARIES}
         murmurhash
         ${BASE64_LIBRARY}
-        ${OPENSSL_CRYPTO_LIBRARY}
-        ${LZ4_LIBRARY})
+        ${OPENSSL_CRYPTO_LIBRARY})
 
 target_include_directories (clickhouse_functions SYSTEM BEFORE PUBLIC ${DIVIDE_INCLUDE_DIR} ${METROHASH_INCLUDE_DIR})
 
@@ -55,4 +54,9 @@ endif ()
 
 if(USE_BASE64)
     target_include_directories(clickhouse_functions SYSTEM PRIVATE ${BASE64_INCLUDE_DIR})
+endif()
+
+if (USE_XXHASH)
+    target_link_libraries(clickhouse_functions PRIVATE ${XXHASH_LIBRARY})
+    target_include_directories(clickhouse_functions SYSTEM PRIVATE ${XXHASH_INCLUDE_DIR})
 endif()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):

`xxhash.h` does not exist in external lz4 because it is an implementation detail and its symbols are namespaced with `XXH_NAMESPACE` macro.  When lz4 is external, xxHash has to be external too, and the dependents have to link to it.

The old `find_xxhash.cmake` was added in 7b420297edb100a945a84a1e574ae47e804a9e0c.
The new `find_xxhash.cmake` is based on `find_lz4.cmake`.

---

I have tested that ClickHouse builds without `contrib/lz4` both with and without system xxhash, and uses system xxhash if available.