### PR TITLE
Fixed ThreadPool when there are too many inactive threads #4485

### DIFF
--- a/dbms/src/Common/ThreadPool.cpp
+++ b/dbms/src/Common/ThreadPool.cpp
@@ -188,6 +188,7 @@ void ThreadPoolImpl<Thread>::worker(typename std::list<Thread>::iterator thread_
 
             if (threads.size() > scheduled_jobs + max_free_threads)
             {
+                thread_it->detach();
                 threads.erase(thread_it);
                 job_finished.notify_all();
                 return;

--- a/dbms/src/Common/tests/CMakeLists.txt
+++ b/dbms/src/Common/tests/CMakeLists.txt
@@ -56,6 +56,9 @@ target_link_libraries (thread_pool PRIVATE clickhouse_common_io)
 add_executable (thread_pool_2 thread_pool_2.cpp)
 target_link_libraries (thread_pool_2 PRIVATE clickhouse_common_io)
 
+add_executable (thread_pool_3 thread_pool_3.cpp)
+target_link_libraries (thread_pool_3 PRIVATE clickhouse_common_io)
+
 add_executable (multi_version multi_version.cpp)
 target_link_libraries (multi_version PRIVATE clickhouse_common_io)
 add_check(multi_version)

--- a/dbms/src/Common/tests/thread_pool_3.cpp
+++ b/dbms/src/Common/tests/thread_pool_3.cpp
@@ -1,0 +1,26 @@
+#include <atomic>
+#include <iostream>
+#include <Common/ThreadPool.h>
+
+/// Test for thread self-removal when number of free threads in pool is too large.
+/// Just checks that nothing weird happens.
+
+template <typename Pool>
+void test()
+{
+    Pool pool(10, 2, 10);
+
+    for (size_t i = 0; i < 10; ++i)
+        pool.schedule([]{ std::cerr << '.'; });
+    pool.wait();
+}
+
+int main(int, char **)
+{
+    test<FreeThreadPool>();
+    std::cerr << '\n';
+    test<ThreadPool>();
+    std::cerr << '\n';
+
+    return 0;
+}


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
When there are more than 1000 threads in a thread pool, `std::terminate` may happen on thread exit. The bug and the fix is described by [Azat Khuzhin](https://github.com/azat) in PR #4485.