### PR TITLE
Fix UB in IsIn function of cache dictionary and typo in integration test

### DIFF
--- a/dbms/src/Dictionaries/CacheDictionary.cpp
+++ b/dbms/src/Dictionaries/CacheDictionary.cpp
@@ -111,7 +111,7 @@ void CacheDictionary::isInImpl(const PaddedPODArray<Key> & child_ids, const Ance
 
     const auto null_value = std::get<UInt64>(hierarchical_attribute->null_values);
 
-    PaddedPODArray<Key> children(out_size);
+    PaddedPODArray<Key> children(out_size, 0);
     PaddedPODArray<Key> parents(child_ids.begin(), child_ids.end());
 
     while (true)

--- a/dbms/tests/integration/test_external_dictionaries/test.py
+++ b/dbms/tests/integration/test_external_dictionaries/test.py
@@ -79,7 +79,6 @@ LAYOUTS = [
 ]
 
 SOURCES = [
-    # some troubles with that dictionary
     SourceMongo("MongoDB", "localhost", "27018", "mongo1", "27017", "root", "clickhouse"),
     SourceMySQL("MySQL", "localhost", "3308", "mysql1", "3306", "root", "clickhouse"),
     SourceClickHouse("RemoteClickHouse", "localhost", "9000", "clickhouse1", "9000", "default", ""),
@@ -238,7 +237,7 @@ def test_ranged_dictionaries(started_cluster):
             '1973-06-28', '1985-02-28 23:43:25', 'hello',
             22.543, 3332154213.4]),
         Row(fields,
-            [1, '2019-04-10', '2019-04-01', '2019-04-28',
+            [2, '2019-04-10', '2019-04-01', '2019-04-28',
             11, 3223, 41444, 52515, -65, -747, -8388, -9099,
             '550e8400-e29b-41d4-a716-446655440004',
             '1973-06-29', '2002-02-28 23:23:25', '!!!!',


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fix undefined behaviour in `dictIsIn` function for cache dictionaries.
