### PR TITLE
Enable taskstat accounting for versions >= 3

### DIFF
--- a/dbms/src/Common/ThreadProfileEvents.h
+++ b/dbms/src/Common/ThreadProfileEvents.h
@@ -137,8 +137,8 @@ struct TasksStatsCounters
         profile_events.increment(ProfileEvents::OSCPUVirtualTimeMicroseconds,
                                  safeDiff(prev.stat.cpu_run_virtual_total, curr.stat.cpu_run_virtual_total) / 1000U);
 
-        /// Too old struct version, do not read new fields
-        if (curr.stat.version < TASKSTATS_VERSION)
+        /// Since TASKSTATS_VERSION = 3 extended accounting and IO accounting is available.
+        if (curr.stat.version < 3)
             return;
 
         profile_events.increment(ProfileEvents::OSReadChars, safeDiff(prev.stat.read_char, curr.stat.read_char));


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Other

Short description (up to few sentences):
Enable extended accounting and io accounting based on good known version instead of kernel under which it is compiled.

Detailed description (optional):

Previously if clickhouse was compiled under a kernel with higher
TASKSTATS_VERSION, but run under a kernel with older TASKSTAT_VERSION
extended and io accounting would be disabled.