### PR TITLE
Distributed and remote timeouts

### DIFF
--- a/dbms/programs/benchmark/Benchmark.cpp
+++ b/dbms/programs/benchmark/Benchmark.cpp
@@ -54,10 +54,10 @@ public:
             const String & host_, UInt16 port_, bool secure_, const String & default_database_,
             const String & user_, const String & password_, const String & stage,
             bool randomize_, size_t max_iterations_, double max_time_,
-            const String & json_path_, const ConnectionTimeouts & timeouts, const Settings & settings_)
+            const String & json_path_, const Settings & settings_)
         :
         concurrency(concurrency_), delay(delay_), queue(concurrency),
-        connections(concurrency, host_, port_, default_database_, user_, password_, timeouts, "benchmark", Protocol::Compression::Enable, secure_ ? Protocol::Secure::Enable : Protocol::Secure::Disable),
+        connections(concurrency, host_, port_, default_database_, user_, password_, "benchmark", Protocol::Compression::Enable, secure_ ? Protocol::Secure::Enable : Protocol::Secure::Disable),
         randomize(randomize_), max_iterations(max_iterations_), max_time(max_time_),
         json_path(json_path_), settings(settings_), global_context(Context::createGlobal()), pool(concurrency)
     {
@@ -240,7 +240,8 @@ private:
         std::uniform_int_distribution<size_t> distribution(0, queries.size() - 1);
 
         for (size_t i = 0; i < concurrency; ++i)
-            pool.schedule(std::bind(&Benchmark::thread, this, connections.get()));
+            pool.schedule(std::bind(&Benchmark::thread, this,
+                                    connections.get(ConnectionTimeouts::getTCPTimeoutsWithoutFailover(settings))));
 
         InterruptListener interrupt_listener;
         info_per_interval.watch.restart();
@@ -310,7 +311,9 @@ private:
     void execute(ConnectionPool::Entry & connection, Query & query)
     {
         Stopwatch watch;
-        RemoteBlockInputStream stream(*connection, query, {}, global_context, &settings, nullptr, Tables(), query_processing_stage);
+        RemoteBlockInputStream stream(
+            *connection,
+            query, {}, global_context, &settings, nullptr, Tables(), query_processing_stage);
 
         Progress progress;
         stream.setProgressCallback([&progress](const Progress & value) { progress.incrementPiecewiseAtomically(value); });
@@ -485,7 +488,6 @@ int mainEntryClickHouseBenchmark(int argc, char ** argv)
             options["iterations"].as<size_t>(),
             options["timelimit"].as<double>(),
             options["json"].as<std::string>(),
-            ConnectionTimeouts::getTCPTimeoutsWithoutFailover(settings),
             settings);
         return benchmark.run();
     }

--- a/dbms/programs/client/Client.cpp
+++ b/dbms/programs/client/Client.cpp
@@ -203,7 +203,6 @@ private:
 
     ConnectionParameters connection_parameters;
 
-
     void initialize(Poco::Util::Application & self)
     {
         Poco::Util::Application::initialize(self);
@@ -336,7 +335,7 @@ private:
         DateLUT::instance();
         if (!context.getSettingsRef().use_client_time_zone)
         {
-            const auto & time_zone = connection->getServerTimezone();
+            const auto & time_zone = connection->getServerTimezone(connection_parameters.timeouts);
             if (!time_zone.empty())
             {
                 try
@@ -520,7 +519,6 @@ private:
             connection_parameters.default_database,
             connection_parameters.user,
             connection_parameters.password,
-            connection_parameters.timeouts,
             "client",
             connection_parameters.compression,
             connection_parameters.security);
@@ -536,11 +534,14 @@ private:
             connection->setThrottler(throttler);
         }
 
-        connection->getServerVersion(server_name, server_version_major, server_version_minor, server_version_patch, server_revision);
+        connection->getServerVersion(connection_parameters.timeouts,
+                                     server_name, server_version_major, server_version_minor, server_version_patch, server_revision);
 
         server_version = toString(server_version_major) + "." + toString(server_version_minor) + "." + toString(server_version_patch);
 
-        if (server_display_name = connection->getServerDisplayName(); server_display_name.length() == 0)
+        if (
+            server_display_name = connection->getServerDisplayName(connection_parameters.timeouts);
+            server_display_name.length() == 0)
         {
             server_display_name = config().getString("host", "localhost");
         }
@@ -751,7 +752,7 @@ private:
                 }
 
                 if (!test_hint.checkActual(actual_server_error, actual_client_error, got_exception, last_exception))
-                    connection->forceConnected();
+                    connection->forceConnected(connection_parameters.timeouts);
 
                 if (got_exception && !ignore_error)
                 {
@@ -827,7 +828,7 @@ private:
             if (with_output && with_output->settings_ast)
                 apply_query_settings(*with_output->settings_ast);
 
-            connection->forceConnected();
+            connection->forceConnected(connection_parameters.timeouts);
 
             /// INSERT query for which data transfer is needed (not an INSERT SELECT) is processed separately.
             if (insert && !insert->select)
@@ -898,7 +899,7 @@ private:
     /// Process the query that doesn't require transferring data blocks to the server.
     void processOrdinaryQuery()
     {
-        connection->sendQuery(query, query_id, QueryProcessingStage::Complete, &context.getSettingsRef(), nullptr, true);
+        connection->sendQuery(connection_parameters.timeouts, query, query_id, QueryProcessingStage::Complete, &context.getSettingsRef(), nullptr, true);
         sendExternalTables();
         receiveResult();
     }
@@ -916,7 +917,7 @@ private:
         if (!parsed_insert_query.data && (is_interactive || (stdin_is_not_tty && std_in.eof())))
             throw Exception("No data to insert", ErrorCodes::NO_DATA_TO_INSERT);
 
-        connection->sendQuery(query_without_data, query_id, QueryProcessingStage::Complete, &context.getSettingsRef(), nullptr, true);
+        connection->sendQuery(connection_parameters.timeouts, query_without_data, query_id, QueryProcessingStage::Complete, &context.getSettingsRef(), nullptr, true);
         sendExternalTables();
 
         /// Receive description of table structure.
@@ -1063,7 +1064,7 @@ private:
         bool cancelled = false;
 
         // TODO: get the poll_interval from commandline.
-        const auto receive_timeout = connection->getTimeouts().receive_timeout;
+        const auto receive_timeout = connection_parameters.timeouts.receive_timeout;
         constexpr size_t default_poll_interval = 1000000; /// in microseconds
         constexpr size_t min_poll_interval = 5000; /// in microseconds
         const size_t poll_interval

--- a/dbms/programs/copier/ClusterCopier.cpp
+++ b/dbms/programs/copier/ClusterCopier.cpp
@@ -55,6 +55,7 @@
 #include <DataStreams/AsynchronousBlockInputStream.h>
 #include <DataStreams/copyData.h>
 #include <DataStreams/NullBlockOutputStream.h>
+#include <IO/ConnectionTimeouts.h>
 #include <IO/Operators.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/ReadBufferFromFile.h>
@@ -799,13 +800,13 @@ public:
     }
 
 
-    void discoverShardPartitions(const TaskShardPtr & task_shard)
+    void discoverShardPartitions(const ConnectionTimeouts & timeouts, const TaskShardPtr & task_shard)
     {
         TaskTable & task_table = task_shard->task_table;
 
         LOG_INFO(log, "Discover partitions of shard " << task_shard->getDescription());
 
-        auto get_partitions = [&] () { return getShardPartitions(*task_shard); };
+        auto get_partitions = [&] () { return getShardPartitions(timeouts, *task_shard); };
         auto existing_partitions_names = retry(get_partitions, 60);
         Strings filtered_partitions_names;
         Strings missing_partitions;
@@ -881,14 +882,14 @@ public:
     }
 
     /// Compute set of partitions, assume set of partitions aren't changed during the processing
-    void discoverTablePartitions(TaskTable & task_table, UInt64 num_threads = 0)
+    void discoverTablePartitions(const ConnectionTimeouts & timeouts, TaskTable & task_table, UInt64 num_threads = 0)
     {
         /// Fetch partitions list from a shard
         {
             ThreadPool thread_pool(num_threads ? num_threads : 2 * getNumberOfPhysicalCPUCores());
 
             for (const TaskShardPtr & task_shard : task_table.all_shards)
-                thread_pool.schedule([this, task_shard]() { discoverShardPartitions(task_shard); });
+                thread_pool.schedule([this, timeouts, task_shard]() { discoverShardPartitions(timeouts, task_shard); });
 
             LOG_DEBUG(log, "Waiting for " << thread_pool.active() << " setup jobs");
             thread_pool.wait();
@@ -956,7 +957,7 @@ public:
         task_descprtion_current_version = version_to_update;
     }
 
-    void process()
+    void process(const ConnectionTimeouts & timeouts)
     {
         for (TaskTable & task_table : task_cluster->table_tasks)
         {
@@ -970,7 +971,7 @@ public:
             if (!task_table.has_enabled_partitions)
             {
                 /// If there are no specified enabled_partitions, we must discover them manually
-                discoverTablePartitions(task_table);
+                discoverTablePartitions(timeouts, task_table);
 
                 /// After partitions of each shard are initialized, initialize cluster partitions
                 for (const TaskShardPtr & task_shard : task_table.all_shards)
@@ -1010,7 +1011,7 @@ public:
             bool table_is_done = false;
             for (UInt64 num_table_tries = 0; num_table_tries < max_table_tries; ++num_table_tries)
             {
-                if (tryProcessTable(task_table))
+                if (tryProcessTable(timeouts, task_table))
                 {
                     table_is_done = true;
                     break;
@@ -1054,8 +1055,10 @@ protected:
         return getWorkersPath() + "/" + host_id;
     }
 
-    zkutil::EphemeralNodeHolder::Ptr createTaskWorkerNodeAndWaitIfNeed(const zkutil::ZooKeeperPtr & zookeeper,
-                                                                       const String & description, bool unprioritized)
+    zkutil::EphemeralNodeHolder::Ptr createTaskWorkerNodeAndWaitIfNeed(
+        const zkutil::ZooKeeperPtr & zookeeper,
+        const String & description,
+        bool unprioritized)
     {
         std::chrono::milliseconds current_sleep_time = default_sleep_time;
         static constexpr std::chrono::milliseconds max_sleep_time(30000); // 30 sec
@@ -1330,7 +1333,7 @@ protected:
     static constexpr UInt64 max_table_tries = 1000;
     static constexpr UInt64 max_shard_partition_tries = 600;
 
-    bool tryProcessTable(TaskTable & task_table)
+    bool tryProcessTable(const ConnectionTimeouts & timeouts, TaskTable & task_table)
     {
         /// An heuristic: if previous shard is already done, then check next one without sleeps due to max_workers constraint
         bool previous_shard_is_instantly_finished = false;
@@ -1361,7 +1364,7 @@ protected:
                     /// If not, did we check existence of that partition previously?
                     if (shard->checked_partitions.count(partition_name) == 0)
                     {
-                        auto check_shard_has_partition = [&] () { return checkShardHasPartition(*shard, partition_name); };
+                        auto check_shard_has_partition = [&] () { return checkShardHasPartition(timeouts, *shard, partition_name); };
                         bool has_partition = retry(check_shard_has_partition);
 
                         shard->checked_partitions.emplace(partition_name);
@@ -1398,7 +1401,7 @@ protected:
                 bool was_error = false;
                 for (UInt64 try_num = 0; try_num < max_shard_partition_tries; ++try_num)
                 {
-                    task_status = tryProcessPartitionTask(partition, is_unprioritized_task);
+                    task_status = tryProcessPartitionTask(timeouts, partition, is_unprioritized_task);
 
                     /// Exit if success
                     if (task_status == PartitionTaskStatus::Finished)
@@ -1484,13 +1487,13 @@ protected:
         Error,
     };
 
-    PartitionTaskStatus tryProcessPartitionTask(ShardPartition & task_partition, bool is_unprioritized_task)
+    PartitionTaskStatus tryProcessPartitionTask(const ConnectionTimeouts & timeouts, ShardPartition & task_partition, bool is_unprioritized_task)
     {
         PartitionTaskStatus res;
 
         try
         {
-            res = processPartitionTaskImpl(task_partition, is_unprioritized_task);
+            res = processPartitionTaskImpl(timeouts, task_partition, is_unprioritized_task);
         }
         catch (...)
         {
@@ -1511,7 +1514,7 @@ protected:
         return res;
     }
 
-    PartitionTaskStatus processPartitionTaskImpl(ShardPartition & task_partition, bool is_unprioritized_task)
+    PartitionTaskStatus processPartitionTaskImpl(const ConnectionTimeouts & timeouts, ShardPartition & task_partition, bool is_unprioritized_task)
     {
         TaskShard & task_shard = task_partition.task_shard;
         TaskTable & task_table = task_shard.task_table;
@@ -1612,7 +1615,7 @@ protected:
         zookeeper->createAncestors(current_task_status_path);
 
         /// We need to update table definitions for each partition, it could be changed after ALTER
-        createShardInternalTables(task_shard);
+        createShardInternalTables(timeouts, task_shard);
 
         /// Check that destination partition is empty if we are first worker
         /// NOTE: this check is incorrect if pull and push tables have different partition key!
@@ -1829,23 +1832,25 @@ protected:
         return typeid_cast<const ColumnString &>(*block.safeGetByPosition(0).column).getDataAt(0).toString();
     }
 
-    ASTPtr getCreateTableForPullShard(TaskShard & task_shard)
+    ASTPtr getCreateTableForPullShard(const ConnectionTimeouts & timeouts, TaskShard & task_shard)
     {
         /// Fetch and parse (possibly) new definition
-        auto connection_entry = task_shard.info.pool->get(&task_cluster->settings_pull);
-        String create_query_pull_str = getRemoteCreateTable(task_shard.task_table.table_pull, *connection_entry,
-                                                            &task_cluster->settings_pull);
+        auto connection_entry = task_shard.info.pool->get(timeouts, &task_cluster->settings_pull);
+        String create_query_pull_str = getRemoteCreateTable(
+            task_shard.task_table.table_pull,
+            *connection_entry,
+            &task_cluster->settings_pull);
 
         ParserCreateQuery parser_create_query;
         return parseQuery(parser_create_query, create_query_pull_str, 0);
     }
 
-    void createShardInternalTables(TaskShard & task_shard, bool create_split = true)
+    void createShardInternalTables(const ConnectionTimeouts & timeouts, TaskShard & task_shard, bool create_split = true)
     {
         TaskTable & task_table = task_shard.task_table;
 
         /// We need to update table definitions for each part, it could be changed after ALTER
-        task_shard.current_pull_table_create_query = getCreateTableForPullShard(task_shard);
+        task_shard.current_pull_table_create_query = getCreateTableForPullShard(timeouts, task_shard);
 
         /// Create local Distributed tables:
         ///  a table fetching data from current shard and a table inserting data to the whole destination cluster
@@ -1873,9 +1878,9 @@ protected:
     }
 
 
-    std::set<String> getShardPartitions(TaskShard & task_shard)
+    std::set<String> getShardPartitions(const ConnectionTimeouts & timeouts, TaskShard & task_shard)
     {
-        createShardInternalTables(task_shard, false);
+        createShardInternalTables(timeouts, task_shard, false);
 
         TaskTable & task_table = task_shard.task_table;
 
@@ -1915,9 +1920,9 @@ protected:
         return res;
     }
 
-    bool checkShardHasPartition(TaskShard & task_shard, const String & partition_quoted_name)
+    bool checkShardHasPartition(const ConnectionTimeouts & timeouts, TaskShard & task_shard, const String & partition_quoted_name)
     {
-        createShardInternalTables(task_shard, false);
+        createShardInternalTables(timeouts, task_shard, false);
 
         TaskTable & task_table = task_shard.task_table;
 
@@ -1999,7 +2004,8 @@ protected:
                 Settings current_settings = settings ? *settings : task_cluster->settings_common;
                 current_settings.max_parallel_replicas = num_remote_replicas ? num_remote_replicas : 1;
 
-                auto connections = shard.pool->getMany(&current_settings, pool_mode);
+                auto timeouts = ConnectionTimeouts::getTCPTimeoutsWithFailover(current_settings).getSaturated(current_settings.max_execution_time);
+                auto connections = shard.pool->getMany(timeouts, &current_settings, pool_mode);
 
                 for (auto & connection : connections)
                 {
@@ -2188,7 +2194,7 @@ void ClusterCopierApp::mainImpl()
         copier->uploadTaskDescription(task_path, task_file, config().getBool("task-upload-force", false));
 
     copier->init();
-    copier->process();
+    copier->process(ConnectionTimeouts::getTCPTimeoutsWithoutFailover(context->getSettingsRef()));
 }
 
 

--- a/dbms/programs/performance-test/PerformanceTest.h
+++ b/dbms/programs/performance-test/PerformanceTest.h
@@ -5,6 +5,7 @@
 #include <common/logger_useful.h>
 #include <Poco/Util/XMLConfiguration.h>
 
+#include <IO/ConnectionTimeouts.h>
 #include "PerformanceTestInfo.h"
 
 namespace DB
@@ -20,6 +21,7 @@ public:
     PerformanceTest(
         const XMLConfigurationPtr & config_,
         Connection & connection_,
+        const ConnectionTimeouts & timeouts_,
         InterruptListener & interrupt_listener_,
         const PerformanceTestInfo & test_info_,
         Context & context_,
@@ -45,6 +47,7 @@ private:
 private:
     XMLConfigurationPtr config;
     Connection & connection;
+    const ConnectionTimeouts & timeouts;
     InterruptListener & interrupt_listener;
 
     PerformanceTestInfo test_info;

--- a/dbms/programs/performance-test/PerformanceTestSuite.cpp
+++ b/dbms/programs/performance-test/PerformanceTestSuite.cpp
@@ -72,10 +72,11 @@ public:
         Strings && tests_names_regexp_,
         Strings && skip_names_regexp_,
         const std::unordered_map<std::string, std::vector<size_t>> query_indexes_,
-        const ConnectionTimeouts & timeouts)
+        const ConnectionTimeouts & timeouts_)
         : connection(host_, port_, default_database_, user_,
-            password_, timeouts, "performance-test", Protocol::Compression::Enable,
+            password_, "performance-test", Protocol::Compression::Enable,
             secure_ ? Protocol::Secure::Enable : Protocol::Secure::Disable)
+        , timeouts(timeouts_)
         , tests_tags(std::move(tests_tags_))
         , tests_names(std::move(tests_names_))
         , tests_names_regexp(std::move(tests_names_regexp_))
@@ -100,7 +101,7 @@ public:
         UInt64 version_minor;
         UInt64 version_patch;
         UInt64 version_revision;
-        connection.getServerVersion(name, version_major, version_minor, version_patch, version_revision);
+        connection.getServerVersion(timeouts, name, version_major, version_minor, version_patch, version_revision);
 
         std::stringstream ss;
         ss << version_major << "." << version_minor << "." << version_patch;
@@ -115,6 +116,7 @@ public:
 
 private:
     Connection connection;
+    const ConnectionTimeouts & timeouts;
 
     const Strings & tests_tags;
     const Strings & tests_names;
@@ -195,7 +197,7 @@ private:
     {
         PerformanceTestInfo info(test_config, profiles_file, global_context.getSettingsRef());
         LOG_INFO(log, "Config for test '" << info.test_name << "' parsed");
-        PerformanceTest current(test_config, connection, interrupt_listener, info, global_context, query_indexes[info.path]);
+        PerformanceTest current(test_config, connection, timeouts, interrupt_listener, info, global_context, query_indexes[info.path]);
 
         if (current.checkPreconditions())
         {

--- a/dbms/src/Client/Connection.cpp
+++ b/dbms/src/Client/Connection.cpp
@@ -48,7 +48,7 @@ namespace ErrorCodes
 }
 
 
-void Connection::connect()
+void Connection::connect(const ConnectionTimeouts & timeouts)
 {
     try
     {
@@ -230,10 +230,15 @@ UInt16 Connection::getPort() const
     return port;
 }
 
-void Connection::getServerVersion(String & name, UInt64 & version_major, UInt64 & version_minor, UInt64 & version_patch, UInt64 & revision)
+void Connection::getServerVersion(const ConnectionTimeouts & timeouts,
+                                  String & name,
+                                  UInt64 & version_major,
+                                  UInt64 & version_minor,
+                                  UInt64 & version_patch,
+                                  UInt64 & revision)
 {
     if (!connected)
-        connect();
+        connect(timeouts);
 
     name = server_name;
     version_major = server_version_major;
@@ -242,40 +247,40 @@ void Connection::getServerVersion(String & name, UInt64 & version_major, UInt64 
     revision = server_revision;
 }
 
-UInt64 Connection::getServerRevision()
+UInt64 Connection::getServerRevision(const ConnectionTimeouts & timeouts)
 {
     if (!connected)
-        connect();
+        connect(timeouts);
 
     return server_revision;
 }
 
-const String & Connection::getServerTimezone()
+const String & Connection::getServerTimezone(const ConnectionTimeouts & timeouts)
 {
     if (!connected)
-        connect();
+        connect(timeouts);
 
     return server_timezone;
 }
 
-const String & Connection::getServerDisplayName()
+const String & Connection::getServerDisplayName(const ConnectionTimeouts & timeouts)
 {
     if (!connected)
-        connect();
+        connect(timeouts);
 
     return server_display_name;
 }
 
-void Connection::forceConnected()
+void Connection::forceConnected(const ConnectionTimeouts & timeouts)
 {
     if (!connected)
     {
-        connect();
+        connect(timeouts);
     }
     else if (!ping())
     {
         LOG_TRACE(log_wrapper.get(), "Connection was closed, will reconnect.");
-        connect();
+        connect(timeouts);
     }
 }
 
@@ -318,10 +323,11 @@ bool Connection::ping()
     return true;
 }
 
-TablesStatusResponse Connection::getTablesStatus(const TablesStatusRequest & request)
+TablesStatusResponse Connection::getTablesStatus(const ConnectionTimeouts & timeouts,
+                                                 const TablesStatusRequest & request)
 {
     if (!connected)
-        connect();
+        connect(timeouts);
 
     TimeoutSetter timeout_setter(*socket, sync_request_timeout, true);
 
@@ -344,6 +350,7 @@ TablesStatusResponse Connection::getTablesStatus(const TablesStatusRequest & req
 
 
 void Connection::sendQuery(
+    const ConnectionTimeouts & timeouts,
     const String & query,
     const String & query_id_,
     UInt64 stage,
@@ -352,7 +359,7 @@ void Connection::sendQuery(
     bool with_pending_data)
 {
     if (!connected)
-        connect();
+        connect(timeouts);
 
     if (settings)
     {

--- a/dbms/src/Client/Connection.cpp
+++ b/dbms/src/Client/Connection.cpp
@@ -361,6 +361,8 @@ void Connection::sendQuery(
     if (!connected)
         connect(timeouts);
 
+    TimeoutSetter timeout_setter(*socket, timeouts.send_timeout, timeouts.receive_timeout, true);
+
     if (settings)
     {
         std::optional<int> level;

--- a/dbms/src/Client/Connection.h
+++ b/dbms/src/Client/Connection.h
@@ -57,7 +57,6 @@ public:
     Connection(const String & host_, UInt16 port_,
         const String & default_database_,
         const String & user_, const String & password_,
-        const ConnectionTimeouts & timeouts_,
         const String & client_name_ = "client",
         Protocol::Compression compression_ = Protocol::Compression::Enable,
         Protocol::Secure secure_ = Protocol::Secure::Disable,
@@ -68,7 +67,6 @@ public:
         client_name(client_name_),
         compression(compression_),
         secure(secure_),
-        timeouts(timeouts_),
         sync_request_timeout(sync_request_timeout_),
         log_wrapper(*this)
     {
@@ -106,11 +104,16 @@ public:
     /// Change default database. Changes will take effect on next reconnect.
     void setDefaultDatabase(const String & database);
 
-    void getServerVersion(String & name, UInt64 & version_major, UInt64 & version_minor, UInt64 & version_patch, UInt64 & revision);
-    UInt64 getServerRevision();
+    void getServerVersion(const ConnectionTimeouts & timeouts,
+                          String & name,
+                          UInt64 & version_major,
+                          UInt64 & version_minor,
+                          UInt64 & version_patch,
+                          UInt64 & revision);
+    UInt64 getServerRevision(const ConnectionTimeouts & timeouts);
 
-    const String & getServerTimezone();
-    const String & getServerDisplayName();
+    const String & getServerTimezone(const ConnectionTimeouts & timeouts);
+    const String & getServerDisplayName(const ConnectionTimeouts & timeouts);
 
     /// For log and exception messages.
     const String & getDescription() const;
@@ -119,13 +122,14 @@ public:
     const String & getDefaultDatabase() const;
 
     /// For proper polling.
-    inline const auto & getTimeouts() const
-    {
-        return timeouts;
-    }
+    //inline const auto & getTimeouts() const
+    //{
+    //    return timeouts;
+    //}
 
     /// If last flag is true, you need to call sendExternalTablesData after.
     void sendQuery(
+        const ConnectionTimeouts & timeouts,
         const String & query,
         const String & query_id_ = "",
         UInt64 stage = QueryProcessingStage::Complete,
@@ -156,9 +160,10 @@ public:
     Packet receivePacket();
 
     /// If not connected yet, or if connection is broken - then connect. If cannot connect - throw an exception.
-    void forceConnected();
+    void forceConnected(const ConnectionTimeouts & timeouts);
 
-    TablesStatusResponse getTablesStatus(const TablesStatusRequest & request);
+    TablesStatusResponse getTablesStatus(const ConnectionTimeouts & timeouts,
+                                         const TablesStatusRequest & request);
 
     /** Disconnect.
       * This may be used, if connection is left in unsynchronised state
@@ -216,7 +221,7 @@ private:
       */
     ThrottlerPtr throttler;
 
-    ConnectionTimeouts timeouts;
+    //ConnectionTimeouts timeouts;
     Poco::Timespan sync_request_timeout;
 
     /// From where to read query execution result.
@@ -252,7 +257,7 @@ private:
 
     LoggerWrapper log_wrapper;
 
-    void connect();
+    void connect(const ConnectionTimeouts & timeouts);
     void sendHello();
     void receiveHello();
     bool ping();

--- a/dbms/src/Client/Connection.h
+++ b/dbms/src/Client/Connection.h
@@ -121,12 +121,6 @@ public:
     UInt16 getPort() const;
     const String & getDefaultDatabase() const;
 
-    /// For proper polling.
-    //inline const auto & getTimeouts() const
-    //{
-    //    return timeouts;
-    //}
-
     /// If last flag is true, you need to call sendExternalTablesData after.
     void sendQuery(
         const ConnectionTimeouts & timeouts,
@@ -221,7 +215,6 @@ private:
       */
     ThrottlerPtr throttler;
 
-    //ConnectionTimeouts timeouts;
     Poco::Timespan sync_request_timeout;
 
     /// From where to read query execution result.

--- a/dbms/src/Client/ConnectionPool.h
+++ b/dbms/src/Client/ConnectionPool.h
@@ -30,7 +30,9 @@ public:
 
     /// Selects the connection to work.
     /// If force_connected is false, the client must manually ensure that returned connection is good.
-    virtual Entry get(const Settings * settings = nullptr, bool force_connected = true) = 0;
+    virtual Entry get(const ConnectionTimeouts & timeouts,
+                      const Settings * settings = nullptr,
+                      bool force_connected = true) = 0;
 };
 
 using ConnectionPoolPtr = std::shared_ptr<IConnectionPool>;
@@ -50,7 +52,6 @@ public:
             const String & default_database_,
             const String & user_,
             const String & password_,
-            const ConnectionTimeouts & timeouts,
             const String & client_name_ = "client",
             Protocol::Compression compression_ = Protocol::Compression::Enable,
             Protocol::Secure secure_ = Protocol::Secure::Disable)
@@ -63,12 +64,13 @@ public:
         password(password_),
         client_name(client_name_),
         compression(compression_),
-        secure{secure_},
-        timeouts(timeouts)
+        secure{secure_}
     {
     }
 
-    Entry get(const Settings * settings = nullptr, bool force_connected = true) override
+    Entry get(const ConnectionTimeouts & timeouts,
+              const Settings * settings = nullptr,
+              bool force_connected = true) override
     {
         Entry entry;
         if (settings)
@@ -77,7 +79,7 @@ public:
             entry = Base::get(-1);
 
         if (force_connected)
-            entry->forceConnected();
+            entry->forceConnected(timeouts);
 
         return entry;
     }
@@ -93,7 +95,7 @@ protected:
     {
         return std::make_shared<Connection>(
             host, port,
-            default_database, user, password, timeouts,
+            default_database, user, password,
             client_name, compression, secure);
     }
 
@@ -108,7 +110,6 @@ private:
     Protocol::Compression compression;        /// Whether to compress data when interacting with the server.
     Protocol::Secure secure;          /// Whether to encrypt data when interacting with the server.
 
-    ConnectionTimeouts timeouts;
 };
 
 }

--- a/dbms/src/Client/ConnectionPoolWithFailover.cpp
+++ b/dbms/src/Client/ConnectionPoolWithFailover.cpp
@@ -8,6 +8,8 @@
 #include <Common/ProfileEvents.h>
 #include <Core/Settings.h>
 
+#include <IO/ConnectionTimeouts.h>
+
 
 namespace ProfileEvents
 {
@@ -29,9 +31,8 @@ namespace ErrorCodes
 ConnectionPoolWithFailover::ConnectionPoolWithFailover(
         ConnectionPoolPtrs nested_pools_,
         LoadBalancing load_balancing,
-        size_t max_tries_,
         time_t decrease_error_period_)
-    : Base(std::move(nested_pools_), max_tries_, decrease_error_period_, &Logger::get("ConnectionPoolWithFailover"))
+    : Base(std::move(nested_pools_), decrease_error_period_, &Logger::get("ConnectionPoolWithFailover"))
     , default_load_balancing(load_balancing)
 {
     const std::string & local_hostname = getFQDNOrHostName();
@@ -44,11 +45,13 @@ ConnectionPoolWithFailover::ConnectionPoolWithFailover(
     }
 }
 
-IConnectionPool::Entry ConnectionPoolWithFailover::get(const Settings * settings, bool /*force_connected*/)
+IConnectionPool::Entry ConnectionPoolWithFailover::get(const ConnectionTimeouts & timeouts,
+                                                       const Settings * settings,
+                                                       bool /*force_connected*/)
 {
     TryGetEntryFunc try_get_entry = [&](NestedPool & pool, std::string & fail_message)
     {
-        return tryGetEntry(pool, fail_message, settings);
+        return tryGetEntry(pool, timeouts, fail_message, settings);
     };
 
     GetPriorityFunc get_priority;
@@ -70,11 +73,13 @@ IConnectionPool::Entry ConnectionPoolWithFailover::get(const Settings * settings
     return Base::get(try_get_entry, get_priority);
 }
 
-std::vector<IConnectionPool::Entry> ConnectionPoolWithFailover::getMany(const Settings * settings, PoolMode pool_mode)
+std::vector<IConnectionPool::Entry> ConnectionPoolWithFailover::getMany(const ConnectionTimeouts & timeouts,
+                                                                        const Settings * settings,
+                                                                        PoolMode pool_mode)
 {
     TryGetEntryFunc try_get_entry = [&](NestedPool & pool, std::string & fail_message)
     {
-        return tryGetEntry(pool, fail_message, settings);
+        return tryGetEntry(pool, timeouts, fail_message, settings);
     };
 
     std::vector<TryResult> results = getManyImpl(settings, pool_mode, try_get_entry);
@@ -86,22 +91,27 @@ std::vector<IConnectionPool::Entry> ConnectionPoolWithFailover::getMany(const Se
     return entries;
 }
 
-std::vector<ConnectionPoolWithFailover::TryResult> ConnectionPoolWithFailover::getManyForTableFunction(const Settings * settings, PoolMode pool_mode)
+std::vector<ConnectionPoolWithFailover::TryResult> ConnectionPoolWithFailover::getManyForTableFunction(
+    const ConnectionTimeouts & timeouts,
+    const Settings * settings,
+    PoolMode pool_mode)
 {
     TryGetEntryFunc try_get_entry = [&](NestedPool & pool, std::string & fail_message)
     {
-        return tryGetEntry(pool, fail_message, settings);
+        return tryGetEntry(pool, timeouts, fail_message, settings);
     };
 
     return getManyImpl(settings, pool_mode, try_get_entry);
 }
 
 std::vector<ConnectionPoolWithFailover::TryResult> ConnectionPoolWithFailover::getManyChecked(
-        const Settings * settings, PoolMode pool_mode, const QualifiedTableName & table_to_check)
+    const ConnectionTimeouts & timeouts,
+    const Settings * settings, PoolMode pool_mode,
+    const QualifiedTableName & table_to_check)
 {
     TryGetEntryFunc try_get_entry = [&](NestedPool & pool, std::string & fail_message)
     {
-        return tryGetEntry(pool, fail_message, settings, &table_to_check);
+        return tryGetEntry(pool, timeouts, fail_message, settings, &table_to_check);
     };
 
     return getManyImpl(settings, pool_mode, try_get_entry);
@@ -113,6 +123,9 @@ std::vector<ConnectionPoolWithFailover::TryResult> ConnectionPoolWithFailover::g
         const TryGetEntryFunc & try_get_entry)
 {
     size_t min_entries = (settings && settings->skip_unavailable_shards) ? 0 : 1;
+    size_t max_tries = (settings ?
+        size_t{settings->connections_with_failover_max_tries} :
+        size_t{DBMS_CONNECTION_POOL_WITH_FAILOVER_DEFAULT_MAX_TRIES});
     size_t max_entries;
     if (pool_mode == PoolMode::GET_ALL)
     {
@@ -144,12 +157,13 @@ std::vector<ConnectionPoolWithFailover::TryResult> ConnectionPoolWithFailover::g
 
     bool fallback_to_stale_replicas = settings ? bool(settings->fallback_to_stale_replicas_for_distributed_queries) : true;
 
-    return Base::getMany(min_entries, max_entries, try_get_entry, get_priority, fallback_to_stale_replicas);
+    return Base::getMany(min_entries, max_entries, max_tries, try_get_entry, get_priority, fallback_to_stale_replicas);
 }
 
 ConnectionPoolWithFailover::TryResult
 ConnectionPoolWithFailover::tryGetEntry(
         IConnectionPool & pool,
+        const ConnectionTimeouts & timeouts,
         std::string & fail_message,
         const Settings * settings,
         const QualifiedTableName * table_to_check)
@@ -157,15 +171,15 @@ ConnectionPoolWithFailover::tryGetEntry(
     TryResult result;
     try
     {
-        result.entry = pool.get(settings, /* force_connected = */ false);
+        result.entry = pool.get(timeouts, settings, /* force_connected = */ false);
 
         UInt64 server_revision = 0;
         if (table_to_check)
-            server_revision = result.entry->getServerRevision();
+            server_revision = result.entry->getServerRevision(timeouts);
 
         if (!table_to_check || server_revision < DBMS_MIN_REVISION_WITH_TABLES_STATUS)
         {
-            result.entry->forceConnected();
+            result.entry->forceConnected(timeouts);
             result.is_usable = true;
             result.is_up_to_date = true;
             return result;
@@ -176,7 +190,7 @@ ConnectionPoolWithFailover::tryGetEntry(
         TablesStatusRequest status_request;
         status_request.tables.emplace(*table_to_check);
 
-        TablesStatusResponse status_response = result.entry->getTablesStatus(status_request);
+        TablesStatusResponse status_response = result.entry->getTablesStatus(timeouts, status_request);
         auto table_status_it = status_response.table_states_by_id.find(*table_to_check);
         if (table_status_it == status_response.table_states_by_id.end())
         {

--- a/dbms/src/Client/MultiplexedConnections.h
+++ b/dbms/src/Client/MultiplexedConnections.h
@@ -1,9 +1,10 @@
 #pragma once
 
+#include <mutex>
 #include <Common/Throttler.h>
 #include <Client/Connection.h>
 #include <Client/ConnectionPoolWithFailover.h>
-#include <mutex>
+#include <IO/ConnectionTimeouts.h>
 
 namespace DB
 {
@@ -31,6 +32,7 @@ public:
 
     /// Send request to replicas.
     void sendQuery(
+        const ConnectionTimeouts & timeouts,
         const String & query,
         const String & query_id = "",
         UInt64 stage = QueryProcessingStage::Complete,

--- a/dbms/src/DataStreams/RemoteBlockInputStream.h
+++ b/dbms/src/DataStreams/RemoteBlockInputStream.h
@@ -96,6 +96,7 @@ private:
 
     const String query;
     Context context;
+
     /// Temporary tables needed to be sent to remote servers
     Tables external_tables;
     QueryProcessingStage::Enum stage;
@@ -118,7 +119,7 @@ private:
       */
     std::atomic<bool> finished { false };
 
-    /** Cancel query request was sent to all replicas beacuse data is not needed anymore
+    /** Cancel query request was sent to all replicas because data is not needed anymore
       * This behaviour may occur when:
       * - data size is already satisfactory (when using LIMIT, for example)
       * - an exception was thrown from client side

--- a/dbms/src/DataStreams/RemoteBlockOutputStream.cpp
+++ b/dbms/src/DataStreams/RemoteBlockOutputStream.cpp
@@ -6,6 +6,7 @@
 #include <Common/NetException.h>
 #include <Common/CurrentThread.h>
 #include <Interpreters/InternalTextLogsQueue.h>
+#include <IO/ConnectionTimeouts.h>
 
 
 namespace DB
@@ -18,13 +19,16 @@ namespace ErrorCodes
 }
 
 
-RemoteBlockOutputStream::RemoteBlockOutputStream(Connection & connection_, const String & query_, const Settings * settings_)
+RemoteBlockOutputStream::RemoteBlockOutputStream(Connection & connection_,
+                                                 const ConnectionTimeouts & timeouts,
+                                                 const String & query_,
+                                                 const Settings * settings_)
     : connection(connection_), query(query_), settings(settings_)
 {
     /** Send query and receive "header", that describe table structure.
       * Header is needed to know, what structure is required for blocks to be passed to 'write' method.
       */
-    connection.sendQuery(query, "", QueryProcessingStage::Complete, settings, nullptr);
+    connection.sendQuery(timeouts, query, "", QueryProcessingStage::Complete, settings, nullptr);
 
     while (true)
     {

--- a/dbms/src/DataStreams/RemoteBlockOutputStream.h
+++ b/dbms/src/DataStreams/RemoteBlockOutputStream.h
@@ -3,6 +3,7 @@
 #include <Core/Block.h>
 #include <DataStreams/IBlockOutputStream.h>
 #include <Common/Throttler.h>
+#include <IO/ConnectionTimeouts.h>
 
 
 namespace DB
@@ -18,7 +19,10 @@ struct Settings;
 class RemoteBlockOutputStream : public IBlockOutputStream
 {
 public:
-    RemoteBlockOutputStream(Connection & connection_, const String & query_, const Settings * settings_ = nullptr);
+    RemoteBlockOutputStream(Connection & connection_,
+                            const ConnectionTimeouts & timeouts,
+                            const String & query_,
+                            const Settings * settings_ = nullptr);
 
     Block getHeader() const override { return header; }
 

--- a/dbms/src/DataStreams/UnionBlockInputStream.h
+++ b/dbms/src/DataStreams/UnionBlockInputStream.h
@@ -43,10 +43,13 @@ private:
 public:
     using ExceptionCallback = std::function<void()>;
 
-    UnionBlockInputStream(BlockInputStreams inputs, BlockInputStreamPtr additional_input_at_end, size_t max_threads,
-        ExceptionCallback exception_callback_ = ExceptionCallback()) :
-        output_queue(std::min(inputs.size(), max_threads)),
-        handler(*this),
+    UnionBlockInputStream(
+        BlockInputStreams inputs,
+        BlockInputStreamPtr additional_input_at_end,
+        size_t max_threads,
+        ExceptionCallback exception_callback_ = ExceptionCallback()
+    ) :
+        output_queue(std::min(inputs.size(), max_threads)), handler(*this),
         processor(inputs, additional_input_at_end, max_threads, handler),
         exception_callback(exception_callback_)
     {

--- a/dbms/src/Interpreters/ClusterProxy/SelectStreamFactory.cpp
+++ b/dbms/src/Interpreters/ClusterProxy/SelectStreamFactory.cpp
@@ -185,7 +185,9 @@ void SelectStreamFactory::createForShard(
             -> BlockInputStreamPtr
         {
             auto current_settings = context.getSettingsRef();
-            auto timeouts = ConnectionTimeouts::getTCPTimeoutsWithFailover(current_settings);
+            auto timeouts = ConnectionTimeouts::getTCPTimeoutsWithFailover(
+                current_settings).getSaturated(
+                    current_settings.max_execution_time);
             std::vector<ConnectionPoolWithFailover::TryResult> try_results;
             try
             {

--- a/dbms/src/Interpreters/ClusterProxy/SelectStreamFactory.cpp
+++ b/dbms/src/Interpreters/ClusterProxy/SelectStreamFactory.cpp
@@ -184,13 +184,15 @@ void SelectStreamFactory::createForShard(
                 local_delay]()
             -> BlockInputStreamPtr
         {
+            auto current_settings = context.getSettingsRef();
+            auto timeouts = ConnectionTimeouts::getTCPTimeoutsWithFailover(current_settings);
             std::vector<ConnectionPoolWithFailover::TryResult> try_results;
             try
             {
                 if (table_func_ptr)
-                    try_results = pool->getManyForTableFunction(&context.getSettingsRef(), PoolMode::GET_MANY);
+                    try_results = pool->getManyForTableFunction(timeouts, &current_settings, PoolMode::GET_MANY);
                 else
-                    try_results = pool->getManyChecked(&context.getSettingsRef(), PoolMode::GET_MANY, main_table);
+                    try_results = pool->getManyChecked(timeouts, &current_settings, PoolMode::GET_MANY, main_table);
             }
             catch (const Exception & ex)
             {

--- a/dbms/src/Storages/Distributed/DistributedBlockOutputStream.cpp
+++ b/dbms/src/Storages/Distributed/DistributedBlockOutputStream.cpp
@@ -242,6 +242,8 @@ ThreadPool::Job DistributedBlockOutputStream::runWritingJob(DistributedBlockOutp
         {
             if (!job.stream)
             {
+                const Settings & settings = context.getSettingsRef();
+                auto timeouts = ConnectionTimeouts::getTCPTimeoutsWithFailover(settings);
                 if (shard_info.hasInternalReplication())
                 {
                     /// Skip replica_index in case of internal replication
@@ -249,7 +251,7 @@ ThreadPool::Job DistributedBlockOutputStream::runWritingJob(DistributedBlockOutp
                         throw Exception("There are several writing job for an automatically replicated shard", ErrorCodes::LOGICAL_ERROR);
 
                     /// TODO: it make sense to rewrite skip_unavailable_shards and max_parallel_replicas here
-                    auto connections = shard_info.pool->getMany(&context.getSettingsRef(), PoolMode::GET_ONE);
+                    auto connections = shard_info.pool->getMany(timeouts, &settings, PoolMode::GET_ONE);
                     if (connections.empty() || connections.front().isNull())
                         throw Exception("Expected exactly one connection for shard " + toString(job.shard_index), ErrorCodes::LOGICAL_ERROR);
 
@@ -263,7 +265,7 @@ ThreadPool::Job DistributedBlockOutputStream::runWritingJob(DistributedBlockOutp
                     if (!connection_pool)
                         throw Exception("Connection pool for replica " + replica.readableString() + " does not exist", ErrorCodes::LOGICAL_ERROR);
 
-                    job.connection_entry = connection_pool->get(&context.getSettingsRef());
+                    job.connection_entry = connection_pool->get(timeouts, &settings);
                     if (job.connection_entry.isNull())
                         throw Exception("Got empty connection for replica" + replica.readableString(), ErrorCodes::LOGICAL_ERROR);
                 }
@@ -271,7 +273,7 @@ ThreadPool::Job DistributedBlockOutputStream::runWritingJob(DistributedBlockOutp
                 if (throttler)
                     job.connection_entry->setThrottler(throttler);
 
-                job.stream = std::make_shared<RemoteBlockOutputStream>(*job.connection_entry, query_string, &context.getSettingsRef());
+                job.stream = std::make_shared<RemoteBlockOutputStream>(*job.connection_entry, timeouts, query_string, &settings);
                 job.stream->writePrefix();
             }
 

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -3986,8 +3986,6 @@ void StorageReplicatedMergeTree::sendRequestToLeaderReplica(const ASTPtr & query
     else
         throw Exception("Can't proxy this query. Unsupported query type", ErrorCodes::NOT_IMPLEMENTED);
 
-    auto timeouts = ConnectionTimeouts::getTCPTimeoutsWithoutFailover(global_context.getSettingsRef());
-
     const auto & query_settings = query_context.getSettingsRef();
     const auto & query_client_info = query_context.getClientInfo();
     String user = query_client_info.current_user;
@@ -4003,7 +4001,7 @@ void StorageReplicatedMergeTree::sendRequestToLeaderReplica(const ASTPtr & query
         leader_address.host,
         leader_address.queries_port,
         leader_address.database,
-        user, password, timeouts, "Follower replica");
+        user, password, "Follower replica");
 
     std::stringstream new_query_ss;
     formatAST(*new_query, new_query_ss, false, true);

--- a/dbms/tests/integration/test_distributed_respect_user_timeouts/configs/remote_servers.xml
+++ b/dbms/tests/integration/test_distributed_respect_user_timeouts/configs/remote_servers.xml
@@ -1,0 +1,18 @@
+<yandex>
+    <remote_servers>
+        <test_cluster>
+            <shard>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+            <shard>
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster>
+    </remote_servers>
+</yandex>

--- a/dbms/tests/integration/test_distributed_respect_user_timeouts/configs/set_distributed_defaults.xml
+++ b/dbms/tests/integration/test_distributed_respect_user_timeouts/configs/set_distributed_defaults.xml
@@ -1,0 +1,35 @@
+<yandex>
+    <profiles>
+        <default>
+            <connections_with_failover_max_tries>3</connections_with_failover_max_tries>
+            <connect_timeout_with_failover_ms>1000</connect_timeout_with_failover_ms>
+            <min_insert_block_size_rows>1</min_insert_block_size_rows>
+        </default>
+        <delays>
+            <connections_with_failover_max_tries>5</connections_with_failover_max_tries>
+            <connect_timeout_with_failover_ms>3000</connect_timeout_with_failover_ms>
+            <min_insert_block_size_rows>1</min_insert_block_size_rows>
+        </delays>
+    </profiles>
+
+    <users>
+        <default>
+            <password></password>
+            <networks incl="networks" replace="replace">
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </default>
+        <ready_to_wait>
+            <password></password>
+            <networks incl="networks" replace="replace">
+                <ip>::/0</ip>
+            </networks>
+            <profile>delays</profile>
+            <quota>default</quota>
+        </ready_to_wait>
+    </users>
+
+    <quotas><default></default></quotas>
+</yandex>

--- a/dbms/tests/integration/test_distributed_respect_user_timeouts/test.py
+++ b/dbms/tests/integration/test_distributed_respect_user_timeouts/test.py
@@ -1,0 +1,141 @@
+import itertools
+import timeit
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.network import PartitionManager
+from helpers.test_tools import TSV
+
+
+cluster = ClickHouseCluster(__file__)
+
+NODES = {'node' + str(i): cluster.add_instance(
+    'node' + str(i),
+    main_configs=['configs/remote_servers.xml'],
+    user_configs=['configs/set_distributed_defaults.xml'],
+) for i in (1, 2)}
+
+CREATE_TABLES_SQL = '''
+CREATE DATABASE test;
+
+CREATE TABLE base_table(
+    node String
+)
+ENGINE = MergeTree
+PARTITION BY node
+ORDER BY node;
+
+CREATE TABLE distributed_table
+ENGINE = Distributed(test_cluster, default, base_table) AS base_table;
+'''
+
+INSERT_SQL_TEMPLATE = "INSERT INTO base_table VALUES ('{node_id}')"
+
+SELECTS_SQL = {
+    'distributed': 'SELECT node FROM distributed_table ORDER BY node',
+    'remote': ("SELECT node FROM remote('node1,node2', default.base_table) "
+               "ORDER BY node"),
+}
+
+EXCEPTION_NETWORK = 'e.displayText() = DB::NetException: '
+EXCEPTION_TIMEOUT = 'Timeout exceeded while reading from socket ('
+EXCEPTION_CONNECT = 'Timeout: connect timed out: '
+
+TIMEOUT_MEASUREMENT_EPS = 0.01
+
+EXPECTED_BEHAVIOR = {
+    'default': {
+        'times': 3,
+        'timeout': 1,
+    },
+    'ready_to_wait': {
+        'times': 5,
+        'timeout': 3,
+    },
+}
+
+
+def _check_exception(exception, expected_tries=3):
+    lines = exception.split('\n')
+
+    assert len(lines) > 4, "Unexpected exception (expected: timeout info)"
+
+    assert lines[0].startswith('Received exception from server (version')
+
+    assert lines[1].startswith('Code: 279')
+    assert lines[1].endswith('All connection tries failed. Log: ')
+
+    assert lines[2] == '', "Unexpected exception text (expected: empty line)"
+
+    for i, line in enumerate(lines[3:3 + expected_tries]):
+        expected_lines = (
+            'Code: 209, ' + EXCEPTION_NETWORK + EXCEPTION_TIMEOUT,
+            'Code: 209, ' + EXCEPTION_NETWORK + EXCEPTION_CONNECT,
+        )
+
+        assert any(line.startswith(expected) for expected in expected_lines), \
+            'Unexpected exception at one of the connection attempts'
+
+    assert lines[3 + expected_tries] == '', 'Wrong number of connect attempts'
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+
+        for node_id, node in NODES.items():
+            node.query(CREATE_TABLES_SQL)
+            node.query(INSERT_SQL_TEMPLATE.format(node_id=node_id))
+
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def _check_timeout_and_exception(node, user, query_base):
+    repeats = EXPECTED_BEHAVIOR[user]['times']
+    expected_timeout = EXPECTED_BEHAVIOR[user]['timeout'] * repeats
+
+    start = timeit.default_timer()
+    exception = node.query_and_get_error(SELECTS_SQL[query_base], user=user)
+
+    # And it should timeout no faster than:
+    measured_timeout = timeit.default_timer() - start
+
+    assert measured_timeout >= expected_timeout - TIMEOUT_MEASUREMENT_EPS
+
+    # And exception should reflect connection attempts:
+    _check_exception(exception, repeats)
+
+
+@pytest.mark.parametrize(
+    ('first_user', 'node_name', 'query_base'),
+    tuple(itertools.product(EXPECTED_BEHAVIOR, NODES, SELECTS_SQL)),
+)
+def test_reconnect(started_cluster, node_name, first_user, query_base):
+    node = NODES[node_name]
+
+    # Everything is up, select should work:
+    assert TSV(node.query(SELECTS_SQL[query_base],
+                          user=first_user)) == TSV('node1\nnode2')
+
+    with PartitionManager() as pm:
+        # Break the connection.
+        pm.partition_instances(*NODES.values())
+
+        # Now it shouldn't:
+        _check_timeout_and_exception(node, first_user, query_base)
+
+        # Other user should have different timeout and exception
+        _check_timeout_and_exception(
+            node,
+            'default' if first_user != 'default' else 'ready_to_wait',
+            query_base,
+        )
+
+    # select should work again:
+    assert TSV(node.query(SELECTS_SQL[query_base],
+                          user=first_user)) == TSV('node1\nnode2')


### PR DESCRIPTION
Qrator Labs s.r.o. contributes this under the terms of the Apache-2.0 license

related to issue #4211 
 
Category (leave one):
- Improvement

Previously timeouts for clusters and clickhouse-dictionaries were basically immutable after corresponding object creation. This PR tackles this.