### PR TITLE
Fix invalidate query for clickhouse dictionary source

### DIFF
--- a/dbms/src/Dictionaries/ClickHouseDictionarySource.cpp
+++ b/dbms/src/Dictionaries/ClickHouseDictionarySource.cpp
@@ -6,6 +6,7 @@
 #include <Interpreters/executeQuery.h>
 #include <Common/isLocalAddress.h>
 #include <ext/range.h>
+#include <common/logger_useful.h>
 #include "DictionarySourceFactory.h"
 #include "DictionaryStructure.h"
 #include "ExternalQueryBuilder.h"
@@ -155,6 +156,7 @@ bool ClickHouseDictionarySource::isModified() const
     if (!invalidate_query.empty())
     {
         auto response = doInvalidateQuery(invalidate_query);
+        LOG_TRACE(log, "Invalidate query has returned: '" << response << "', previous value: '" << invalidate_query_response << "'");
         if (invalidate_query_response == response)
             return false;
         invalidate_query_response = response;
@@ -182,6 +184,7 @@ BlockInputStreamPtr ClickHouseDictionarySource::createStreamForSelectiveLoad(con
 
 std::string ClickHouseDictionarySource::doInvalidateQuery(const std::string & request) const
 {
+    LOG_TRACE(log, "Performing invalidate query: " << request);
     if (is_local)
     {
         Context query_context = context;

--- a/dbms/src/Dictionaries/ClickHouseDictionarySource.cpp
+++ b/dbms/src/Dictionaries/ClickHouseDictionarySource.cpp
@@ -184,7 +184,7 @@ BlockInputStreamPtr ClickHouseDictionarySource::createStreamForSelectiveLoad(con
 
 std::string ClickHouseDictionarySource::doInvalidateQuery(const std::string & request) const
 {
-    LOG_TRACE(log, "Performing invalidate query: " << request);
+    LOG_TRACE(log, "Performing invalidate query");
     if (is_local)
     {
         Context query_context = context;

--- a/dbms/src/Dictionaries/ClickHouseDictionarySource.cpp
+++ b/dbms/src/Dictionaries/ClickHouseDictionarySource.cpp
@@ -156,7 +156,7 @@ bool ClickHouseDictionarySource::isModified() const
     if (!invalidate_query.empty())
     {
         auto response = doInvalidateQuery(invalidate_query);
-        LOG_TRACE(log, "Invalidate query has returned: '" << response << "', previous value: '" << invalidate_query_response << "'");
+        LOG_TRACE(log, "Invalidate query has returned: " << response << ", previous value: " << invalidate_query_response);
         if (invalidate_query_response == response)
             return false;
         invalidate_query_response = response;

--- a/dbms/src/Dictionaries/ClickHouseDictionarySource.h
+++ b/dbms/src/Dictionaries/ClickHouseDictionarySource.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <Poco/Logger.h>
 #include <Client/ConnectionPoolWithFailover.h>
 #include <Interpreters/Context.h>
 #include "DictionaryStructure.h"
@@ -70,6 +71,7 @@ private:
     const bool is_local;
     ConnectionPoolWithFailoverPtr pool;
     const std::string load_all_query;
+    Poco::Logger * log = &Poco::Logger::get("ClickHouseDictionarySource");
 };
 
 }

--- a/dbms/src/Dictionaries/readInvalidateQuery.cpp
+++ b/dbms/src/Dictionaries/readInvalidateQuery.cpp
@@ -2,6 +2,7 @@
 #include <DataStreams/IBlockInputStream.h>
 #include <IO/WriteBufferFromString.h>
 
+
 namespace DB
 {
 
@@ -32,16 +33,13 @@ std::string readInvalidateQuery(IBlockInputStream & block_input_stream)
 
     WriteBufferFromOwnString out;
     auto & column_type = block.getByPosition(0);
-    column_type.type->serializeAsText(*column_type.column, 0, out, FormatSettings());
+    column_type.type->serializeAsTextQuoted(*column_type.column->convertToFullColumnIfConst(), 0, out, FormatSettings());
 
     while ((block = block_input_stream.read()))
-    {
         if (block.rows() > 0)
             throw Exception("Expected single row in resultset, got at least " + std::to_string(rows + 1), ErrorCodes::TOO_MANY_ROWS);
-    }
 
     block_input_stream.readSuffix();
-
     return out.str();
 }
 

--- a/dbms/src/Dictionaries/readInvalidateQuery.h
+++ b/dbms/src/Dictionaries/readInvalidateQuery.h
@@ -5,8 +5,8 @@ class IBlockInputStream;
 
 namespace DB
 {
-// Using in MySQLDictionarySource and XDBCDictionarySource after processing invalidate_query
-std::string readInvalidateQuery(IBlockInputStream & block_input_stream);
 
+/// Using in MySQLDictionarySource and XDBCDictionarySource after processing invalidate_query.
+std::string readInvalidateQuery(IBlockInputStream & block_input_stream);
 
 }

--- a/dbms/src/Interpreters/ExternalLoader.cpp
+++ b/dbms/src/Interpreters/ExternalLoader.cpp
@@ -155,6 +155,14 @@ void ExternalLoader::reloadAndUpdate(bool throw_on_error)
     /// periodic update
     std::vector<std::pair<std::string, LoadablePtr>> objects_to_update;
 
+    auto getNextUpdateTime = [this](const LoadablePtr & current)
+    {
+        /// calculate next update time
+        const auto & lifetime = current->getLifetime();
+        std::uniform_int_distribution<UInt64> distribution{lifetime.min_sec, lifetime.max_sec};
+        return std::chrono::system_clock::now() + std::chrono::seconds{distribution(rnd_engine)};
+    };
+
     /// Collect objects that needs to be updated under lock. Then create new versions without lock, and assign under lock.
     {
         std::lock_guard lock{map_mutex};
@@ -177,14 +185,17 @@ void ExternalLoader::reloadAndUpdate(bool throw_on_error)
                 if (!current->supportUpdates())
                     continue;
 
-                auto update_time = update_times[current->getName()];
+                auto & update_time = update_times[current->getName()];
 
                 /// check that timeout has passed
                 if (std::chrono::system_clock::now() < update_time)
                     continue;
 
                 if (!current->isModified())
+                {
+                    update_time = getNextUpdateTime(current);
                     continue;
+                }
 
                 objects_to_update.emplace_back(loadable_object.first, current);
             }
@@ -219,10 +230,7 @@ void ExternalLoader::reloadAndUpdate(bool throw_on_error)
 
             if (auto it = loadable_objects.find(name); it != loadable_objects.end())
             {
-                /// calculate next update time
-                const auto & lifetime = current->getLifetime();
-                std::uniform_int_distribution<UInt64> distribution{lifetime.min_sec, lifetime.max_sec};
-                update_times[name] = std::chrono::system_clock::now() + std::chrono::seconds{distribution(rnd_engine)};
+                update_times[name] = getNextUpdateTime(current);
 
                 it->second.exception = exception;
                 if (!exception)

--- a/dbms/src/Interpreters/IExternalLoadable.h
+++ b/dbms/src/Interpreters/IExternalLoadable.h
@@ -37,7 +37,7 @@ public:
     virtual std::string getName() const = 0;
     /// True if object can be updated when lifetime exceeded.
     virtual bool supportUpdates() const = 0;
-    /// If lifetime exceeded and isModified() ExternalLoader replace current object with the result of clone().
+    /// If lifetime exceeded and isModified(), ExternalLoader replace current object with the result of clone().
     virtual bool isModified() const = 0;
     /// Returns new object with the same configuration. Is used to update modified object when lifetime exceeded.
     virtual std::unique_ptr<IExternalLoadable> clone() const = 0;

--- a/dbms/src/Interpreters/executeQuery.cpp
+++ b/dbms/src/Interpreters/executeQuery.cpp
@@ -63,18 +63,24 @@ static String joinLines(const String & query)
 
 
 /// Log query into text log (not into system table).
-static void logQuery(const String & query, const Context & context)
+static void logQuery(const String & query, const Context & context, bool internal)
 {
-    const auto & current_query_id = context.getClientInfo().current_query_id;
-    const auto & initial_query_id = context.getClientInfo().initial_query_id;
-    const auto & current_user = context.getClientInfo().current_user;
+    if (internal)
+    {
+        LOG_DEBUG(&Logger::get("executeQuery"), "(internal) " << joinLines(query));
+    }
+    else
+    {
+        const auto & current_query_id = context.getClientInfo().current_query_id;
+        const auto & initial_query_id = context.getClientInfo().initial_query_id;
+        const auto & current_user = context.getClientInfo().current_user;
 
-    LOG_DEBUG(&Logger::get("executeQuery"), "(from " << context.getClientInfo().current_address.toString()
-    << (current_user != "default" ? ", user: " + context.getClientInfo().current_user : "")
-    << (!initial_query_id.empty() && current_query_id != initial_query_id ? ", initial_query_id: " + initial_query_id : std::string())
-    << ") "
-    << joinLines(query)
-    );
+        LOG_DEBUG(&Logger::get("executeQuery"), "(from " << context.getClientInfo().current_address.toString()
+            << (current_user != "default" ? ", user: " + context.getClientInfo().current_user : "")
+            << (!initial_query_id.empty() && current_query_id != initial_query_id ? ", initial_query_id: " + initial_query_id : std::string())
+            << ") "
+            << joinLines(query));
+    }
 }
 
 
@@ -176,13 +182,12 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
     }
     catch (...)
     {
+        /// Anyway log the query.
+        String query = String(begin, begin + std::min(end - begin, static_cast<ptrdiff_t>(max_query_size)));
+        logQuery(query.substr(0, settings.log_queries_cut_to_length), context, internal);
+
         if (!internal)
-        {
-            /// Anyway log the query.
-            String query = String(begin, begin + std::min(end - begin, static_cast<ptrdiff_t>(max_query_size)));
-            logQuery(query.substr(0, settings.log_queries_cut_to_length), context);
             onExceptionBeforeStart(query, context, current_time);
-        }
 
         throw;
     }
@@ -193,15 +198,14 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
 
     try
     {
-        if (!internal)
-            logQuery(query.substr(0, settings.log_queries_cut_to_length), context);
+        logQuery(query.substr(0, settings.log_queries_cut_to_length), context, internal);
 
         if (!internal && settings.allow_experimental_multiple_joins_emulation)
         {
             JoinToSubqueryTransformVisitor::Data join_to_subs_data;
             JoinToSubqueryTransformVisitor(join_to_subs_data).visit(ast);
             if (join_to_subs_data.done)
-                logQuery(queryToString(*ast), context);
+                logQuery(queryToString(*ast), context, internal);
         }
 
         if (!internal && settings.allow_experimental_cross_to_join_conversion)
@@ -209,7 +213,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
             CrossToInnerJoinVisitor::Data cross_to_inner;
             CrossToInnerJoinVisitor(cross_to_inner).visit(ast);
             if (cross_to_inner.done)
-                logQuery(queryToString(*ast), context);
+                logQuery(queryToString(*ast), context, internal);
         }
 
         /// Check the limits.


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Prevent `std::terminate` when `invalidate_query` for `clickhouse` external dictionary source has returned wrong resultset (empty or more than one row or more than one column). Fixed issue when the `invalidate_query` was performed every five seconds regardless to the `lifetime`. This PR fixes #4580 and #4581.