### PR TITLE
CHYT-67: introduce host context for using CH as a library.

### DIFF
--- a/dbms/programs/server/HTTPHandler.cpp
+++ b/dbms/programs/server/HTTPHandler.cpp
@@ -602,6 +602,8 @@ void HTTPHandler::processQuery(
         });
     }
 
+    customizeContext(context);
+
     executeQuery(*in, *used_output.out_maybe_delayed_and_compressed, /* allow_into_outfile = */ false, context,
         [&response] (const String & content_type) { response.setContentType(content_type); },
         [&response] (const String & current_query_id) { response.add("Query-Id", current_query_id); });

--- a/dbms/programs/server/HTTPHandler.h
+++ b/dbms/programs/server/HTTPHandler.h
@@ -28,6 +28,9 @@ public:
 
     void handleRequest(Poco::Net::HTTPServerRequest & request, Poco::Net::HTTPServerResponse & response) override;
 
+    /// This method is called right before the query execution.
+    virtual void customizeContext(DB::Context& /* context */) {}
+
 private:
     struct Output
     {

--- a/dbms/programs/server/TCPHandler.cpp
+++ b/dbms/programs/server/TCPHandler.cpp
@@ -120,11 +120,10 @@ void TCPHandler::runImpl()
 
     connection_context.setProgressCallback([this] (const Progress & value) { return this->updateProgress(value); });
 
-    /// Set context of request.
-    query_context = connection_context;
-
     while (1)
     {
+        /// Set context of request.
+        query_context = connection_context;
 
         /// We are waiting for a packet from the client. Thus, every `POLL_INTERVAL` seconds check whether we need to shut down.
         while (!static_cast<ReadBufferFromPocoSocket &>(*in).poll(global_settings.poll_interval * 1000000) && !server.isCancelled())
@@ -159,22 +158,22 @@ void TCPHandler::runImpl()
             if (!receivePacket())
                 continue;
 
-            query_scope.emplace(query_context);
+            query_scope.emplace(*query_context);
 
-            send_exception_with_stack_trace = query_context.getSettingsRef().calculate_text_stack_trace;
+            send_exception_with_stack_trace = query_context->getSettingsRef().calculate_text_stack_trace;
 
             /// Should we send internal logs to client?
             if (client_revision >= DBMS_MIN_REVISION_WITH_SERVER_LOGS
-                && query_context.getSettingsRef().send_logs_level.value != LogsLevel::none)
+                && query_context->getSettingsRef().send_logs_level.value != LogsLevel::none)
             {
                 state.logs_queue = std::make_shared<InternalTextLogsQueue>();
-                state.logs_queue->max_priority = Poco::Logger::parseLevel(query_context.getSettingsRef().send_logs_level.toString());
+                state.logs_queue->max_priority = Poco::Logger::parseLevel(query_context->getSettingsRef().send_logs_level.toString());
                 CurrentThread::attachInternalTextLogsQueue(state.logs_queue);
             }
 
-            query_context.setExternalTablesInitializer([&global_settings, this] (Context & context)
+            query_context->setExternalTablesInitializer([&global_settings, this] (Context & context)
             {
-                if (&context != &query_context)
+                if (&context != &*query_context)
                     throw Exception("Unexpected context in external tables initializer", ErrorCodes::LOGICAL_ERROR);
 
                 /// Get blocks of temporary tables
@@ -186,11 +185,11 @@ void TCPHandler::runImpl()
                 state.maybe_compressed_in.reset(); /// For more accurate accounting by MemoryTracker.
             });
 
-            customizeContext(query_context);
+            customizeContext(*query_context);
 
             bool may_have_embedded_data = client_revision >= DBMS_MIN_REVISION_WITH_CLIENT_SUPPORT_EMBEDDED_DATA;
             /// Processing Query
-            state.io = executeQuery(state.query, query_context, false, state.stage, may_have_embedded_data);
+            state.io = executeQuery(state.query, *query_context, false, state.stage, may_have_embedded_data);
 
             if (state.io.out)
                 state.need_receive_data_for_insert = true;
@@ -209,9 +208,6 @@ void TCPHandler::runImpl()
 
             sendLogs();
             sendEndOfStream();
-
-            /// Restore context of request.
-            query_context = connection_context;
 
             query_scope.reset();
             state.reset();
@@ -299,6 +295,9 @@ void TCPHandler::runImpl()
         LOG_INFO(log, std::fixed << std::setprecision(3)
             << "Processed in " << watch.elapsedSeconds() << " sec.");
 
+        /// It is important to destroy query context here. We do not want it to live arbitrarily longer than the query.
+        query_context.reset();
+
         if (network_error)
             break;
     }
@@ -307,7 +306,7 @@ void TCPHandler::runImpl()
 
 void TCPHandler::readData(const Settings & global_settings)
 {
-    const auto receive_timeout = query_context.getSettingsRef().receive_timeout.value;
+    const auto receive_timeout = query_context->getSettingsRef().receive_timeout.value;
 
     /// Poll interval should not be greater than receive_timeout
     const size_t default_poll_interval = global_settings.poll_interval.value * 1000000;
@@ -370,8 +369,8 @@ void TCPHandler::processInsertQuery(const Settings & global_settings)
     /// Send ColumnsDescription for insertion table
     if (client_revision >= DBMS_MIN_REVISION_WITH_COLUMN_DEFAULTS_METADATA)
     {
-        const auto & db_and_table = query_context.getInsertionTable();
-        if (auto * columns = ColumnsDescription::loadFromContext(query_context, db_and_table.first, db_and_table.second))
+        const auto & db_and_table = query_context->getInsertionTable();
+        if (auto * columns = ColumnsDescription::loadFromContext(*query_context, db_and_table.first, db_and_table.second))
             sendTableColumns(*columns);
     }
 
@@ -414,7 +413,7 @@ void TCPHandler::processOrdinaryQuery()
                 }
                 else
                 {
-                    if (after_send_progress.elapsed() / 1000 >= query_context.getSettingsRef().interactive_delay)
+                    if (after_send_progress.elapsed() / 1000 >= query_context->getSettingsRef().interactive_delay)
                     {
                         /// Some time passed and there is a progress.
                         after_send_progress.restart();
@@ -423,7 +422,7 @@ void TCPHandler::processOrdinaryQuery()
 
                     sendLogs();
 
-                    if (async_in.poll(query_context.getSettingsRef().interactive_delay / 1000))
+                    if (async_in.poll(query_context->getSettingsRef().interactive_delay / 1000))
                     {
                         /// There is the following result block.
                         block = async_in.read();
@@ -651,11 +650,11 @@ void TCPHandler::receiveQuery()
     state.is_empty = false;
     readStringBinary(state.query_id, *in);
 
-    query_context.setCurrentQueryId(state.query_id);
+    query_context->setCurrentQueryId(state.query_id);
 
     /// Client info
     {
-        ClientInfo & client_info = query_context.getClientInfo();
+        ClientInfo & client_info = query_context->getClientInfo();
         if (client_revision >= DBMS_MIN_REVISION_WITH_CLIENT_INFO)
             client_info.read(*in, client_revision);
 
@@ -683,7 +682,7 @@ void TCPHandler::receiveQuery()
     }
 
     /// Per query settings.
-    Settings & settings = query_context.getSettingsRef();
+    Settings & settings = query_context->getSettingsRef();
     settings.deserialize(*in);
 
     /// Sync timeouts on client and server during current query to avoid dangling queries on server
@@ -721,16 +720,16 @@ bool TCPHandler::receiveData()
         {
             StoragePtr storage;
             /// If such a table does not exist, create it.
-            if (!(storage = query_context.tryGetExternalTable(external_table_name)))
+            if (!(storage = query_context->tryGetExternalTable(external_table_name)))
             {
                 NamesAndTypesList columns = block.getNamesAndTypesList();
                 storage = StorageMemory::create(external_table_name,
                     ColumnsDescription{columns, NamesAndTypesList{}, NamesAndTypesList{}, ColumnDefaults{}, ColumnComments{}, ColumnCodecs{}});
                 storage->startup();
-                query_context.addExternalTable(external_table_name, storage);
+                query_context->addExternalTable(external_table_name, storage);
             }
             /// The data will be written directly to the table.
-            state.io.out = storage->write(ASTPtr(), query_context);
+            state.io.out = storage->write(ASTPtr(), *query_context);
         }
         if (block)
             state.io.out->write(block);
@@ -769,10 +768,10 @@ void TCPHandler::initBlockOutput(const Block & block)
     {
         if (!state.maybe_compressed_out)
         {
-            std::string method = query_context.getSettingsRef().network_compression_method;
+            std::string method = query_context->getSettingsRef().network_compression_method;
             std::optional<int> level;
             if (method == "ZSTD")
-                level = query_context.getSettingsRef().network_zstd_compression_level;
+                level = query_context->getSettingsRef().network_zstd_compression_level;
 
             if (state.compression == Protocol::Compression::Enable)
                 state.maybe_compressed_out = std::make_shared<CompressedWriteBuffer>(
@@ -808,7 +807,7 @@ bool TCPHandler::isQueryCancelled()
     if (state.is_cancelled || state.sent_all_data)
         return true;
 
-    if (after_check_cancelled.elapsed() / 1000 < query_context.getSettingsRef().interactive_delay)
+    if (after_check_cancelled.elapsed() / 1000 < query_context->getSettingsRef().interactive_delay)
         return false;
 
     after_check_cancelled.restart();

--- a/dbms/programs/server/TCPHandler.cpp
+++ b/dbms/programs/server/TCPHandler.cpp
@@ -120,7 +120,7 @@ void TCPHandler::runImpl()
 
     connection_context.setProgressCallback([this] (const Progress & value) { return this->updateProgress(value); });
 
-    /// Restore context of request.
+    /// Set context of request.
     query_context = connection_context;
 
     while (1)

--- a/dbms/programs/server/TCPHandler.h
+++ b/dbms/programs/server/TCPHandler.h
@@ -95,6 +95,9 @@ public:
 
     void run();
 
+    /// This method is called right before the query execution.
+    virtual void customizeContext(DB::Context & /*context*/) {}
+
 private:
     IServer & server;
     Poco::Logger * log;

--- a/dbms/programs/server/TCPHandler.h
+++ b/dbms/programs/server/TCPHandler.h
@@ -109,7 +109,7 @@ private:
     UInt64 client_revision = 0;
 
     Context connection_context;
-    Context query_context;
+    std::optional<Context> query_context;
 
     /// Streams for reading/writing from/to client connection socket.
     std::shared_ptr<ReadBuffer> in;

--- a/dbms/programs/server/config.xml
+++ b/dbms/programs/server/config.xml
@@ -318,10 +318,10 @@
     -->
 
     <!-- Path to file with region hierarchy. -->
-    <path_to_regions_hierarchy_file>../../../../geo/regions_hierarchy.txt</path_to_regions_hierarchy_file>
+    <!-- <path_to_regions_hierarchy_file>/opt/geo/regions_hierarchy.txt</path_to_regions_hierarchy_file> -->
 
     <!-- Path to directory with files containing names of regions -->
-    <path_to_regions_names_files>../../../../geo/</path_to_regions_names_files>
+    <!-- <path_to_regions_names_files>/opt/geo/</path_to_regions_names_files> -->
 
 
     <!-- Configuration of external dictionaries. See:

--- a/dbms/programs/server/config.xml
+++ b/dbms/programs/server/config.xml
@@ -318,10 +318,10 @@
     -->
 
     <!-- Path to file with region hierarchy. -->
-    <!-- <path_to_regions_hierarchy_file>/opt/geo/regions_hierarchy.txt</path_to_regions_hierarchy_file> -->
+    <path_to_regions_hierarchy_file>../../../../geo/regions_hierarchy.txt</path_to_regions_hierarchy_file>
 
     <!-- Path to directory with files containing names of regions -->
-    <!-- <path_to_regions_names_files>/opt/geo/</path_to_regions_names_files> -->
+    <path_to_regions_names_files>../../../../geo/</path_to_regions_names_files>
 
 
     <!-- Configuration of external dictionaries. See:

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -1818,6 +1818,19 @@ void Context::addXDBCBridgeCommand(std::unique_ptr<ShellCommand> cmd)
     shared->bridge_commands.emplace_back(std::move(cmd));
 }
 
+
+IHostContextPtr & Context::getHostContext()
+{
+    return host_context;
+}
+
+
+const IHostContextPtr & Context::getHostContext() const
+{
+    return host_context;
+}
+
+
 std::shared_ptr<ActionLocksManager> Context::getActionLocksManager()
 {
     auto lock = getLock();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

This PR introduces an option to save any kind of additional context information alongside context, which may be useful when using ClickHouse engine as a blackbox library inside any other project.

See internal resource st/CHYT-67 for further details.