### PR TITLE
Fix wrong __asm__ instructions (again)

### DIFF
--- a/libs/libdaemon/src/BaseDaemon.cpp
+++ b/libs/libdaemon/src/BaseDaemon.cpp
@@ -700,12 +700,12 @@ static void checkRequiredInstructions(volatile InstructionFail & fail)
 
 #if __AVX2__
     fail = InstructionFail::AVX2;
-    __asm__ volatile ("vpabsw %%ymm0, %%ymm0, %%ymm0" : : : "ymm0");
+    __asm__ volatile ("vpabsw %%ymm0, %%ymm0" : : : "ymm0");
 #endif
 
 #if __AVX512__
     fail = InstructionFail::AVX512;
-    __asm__ volatile ("vpabsw %%zmm0, %%zmm0, %%zmm0" : : : "zmm0");
+    __asm__ volatile ("vpabsw %%zmm0, %%zmm0" : : : "zmm0");
 #endif
 
     fail = InstructionFail::NONE;


### PR DESCRIPTION
Qrator Labs s.r.o. contributes this under the terms of the Apache-2.0 license

Category (leave one):
- Build/Testing/Packaging Improvement