### PR TITLE
Fix broken progress in 19.3. Introduce total_rows for table function numbers().

### DIFF
--- a/dbms/src/DataStreams/LimitBlockInputStream.cpp
+++ b/dbms/src/DataStreams/LimitBlockInputStream.cpp
@@ -9,7 +9,8 @@ namespace DB
 LimitBlockInputStream::LimitBlockInputStream(const BlockInputStreamPtr & input, UInt64 limit_, UInt64 offset_, bool always_read_till_end_, bool use_limit_as_total_rows_approx )
     : limit(limit_), offset(offset_), always_read_till_end(always_read_till_end_)
 {
-    if (use_limit_as_total_rows_approx) {
+    if (use_limit_as_total_rows_approx)
+    {
         addTotalRowsApprox(static_cast<size_t>(limit));
     }
 

--- a/dbms/src/DataStreams/LimitBlockInputStream.cpp
+++ b/dbms/src/DataStreams/LimitBlockInputStream.cpp
@@ -6,7 +6,7 @@
 namespace DB
 {
 
-LimitBlockInputStream::LimitBlockInputStream(const BlockInputStreamPtr & input, UInt64 limit_, UInt64 offset_, bool always_read_till_end_, bool use_limit_as_total_rows_approx )
+LimitBlockInputStream::LimitBlockInputStream(const BlockInputStreamPtr & input, UInt64 limit_, UInt64 offset_, bool always_read_till_end_, bool use_limit_as_total_rows_approx)
     : limit(limit_), offset(offset_), always_read_till_end(always_read_till_end_)
 {
     if (use_limit_as_total_rows_approx)

--- a/dbms/src/DataStreams/LimitBlockInputStream.cpp
+++ b/dbms/src/DataStreams/LimitBlockInputStream.cpp
@@ -6,9 +6,13 @@
 namespace DB
 {
 
-LimitBlockInputStream::LimitBlockInputStream(const BlockInputStreamPtr & input, UInt64 limit_, UInt64 offset_, bool always_read_till_end_)
+LimitBlockInputStream::LimitBlockInputStream(const BlockInputStreamPtr & input, UInt64 limit_, UInt64 offset_, bool always_read_till_end_, bool use_limit_as_total_rows_approx )
     : limit(limit_), offset(offset_), always_read_till_end(always_read_till_end_)
 {
+    if (use_limit_as_total_rows_approx) {
+        addTotalRowsApprox(static_cast<size_t>(limit));
+    }
+
     children.push_back(input);
 }
 

--- a/dbms/src/DataStreams/LimitBlockInputStream.h
+++ b/dbms/src/DataStreams/LimitBlockInputStream.h
@@ -16,8 +16,9 @@ public:
       *  returns an empty block, and this causes the query to be canceled.
       * If always_read_till_end = true - reads all the data to the end, but ignores them. This is necessary in rare cases:
       *  when otherwise, due to the cancellation of the request, we would not have received the data for GROUP BY WITH TOTALS from the remote server.
+      * If use_limit_as_total_rows_approx = true, then addTotalRowsApprox is called to use the limit in progress & stats
       */
-    LimitBlockInputStream(const BlockInputStreamPtr & input, UInt64 limit_, UInt64 offset_, bool always_read_till_end_ = false);
+    LimitBlockInputStream(const BlockInputStreamPtr & input, UInt64 limit_, UInt64 offset_, bool always_read_till_end_ = false, bool use_limit_as_total_rows_approx = false);
 
     String getName() const override { return "Limit"; }
 

--- a/dbms/src/IO/Progress.h
+++ b/dbms/src/IO/Progress.h
@@ -55,14 +55,11 @@ struct Progress
     /// Each value separately is changed atomically (but not whole object).
     bool incrementPiecewiseAtomically(const Progress & rhs)
     {
-        if (!rhs.rows)
-            return false;
-
         rows += rhs.rows;
         bytes += rhs.bytes;
         total_rows += rhs.total_rows;
 
-        return true;
+        return rhs.rows ? true : false;
     }
 
     void reset()

--- a/dbms/src/Storages/System/StorageSystemNumbers.cpp
+++ b/dbms/src/Storages/System/StorageSystemNumbers.cpp
@@ -49,7 +49,6 @@ StorageSystemNumbers::StorageSystemNumbers(const std::string & name_, bool multi
     setColumns(ColumnsDescription({{"number", std::make_shared<DataTypeUInt64>()}}));
 }
 
-
 BlockInputStreams StorageSystemNumbers::read(
     const Names & column_names,
     const SelectQueryInfo &,
@@ -75,7 +74,7 @@ BlockInputStreams StorageSystemNumbers::read(
         res[i] = std::make_shared<NumbersBlockInputStream>(max_block_size, offset + i * max_block_size, num_streams * max_block_size);
 
         if (limit)  /// This formula is how to split 'limit' elements to 'num_streams' chunks almost uniformly.
-            res[i] = std::make_shared<LimitBlockInputStream>(res[i], *limit * (i + 1) / num_streams - *limit * i / num_streams, 0);
+            res[i] = std::make_shared<LimitBlockInputStream>(res[i], *limit * (i + 1) / num_streams - *limit * i / num_streams, 0,  false, true);
     }
 
     return res;

--- a/dbms/tests/queries/0_stateless/00416_pocopatch_progress_in_http_headers.reference
+++ b/dbms/tests/queries/0_stateless/00416_pocopatch_progress_in_http_headers.reference
@@ -1,3 +1,7 @@
+< X-ClickHouse-Progress: {"read_rows":"0","read_bytes":"0","total_rows":"10"}
+< X-ClickHouse-Progress: {"read_rows":"5","read_bytes":"40","total_rows":"10"}
+< X-ClickHouse-Progress: {"read_rows":"10","read_bytes":"80","total_rows":"10"}
+9
 < X-ClickHouse-Progress: {"read_rows":"1","read_bytes":"8","total_rows":"0"}
 < X-ClickHouse-Progress: {"read_rows":"2","read_bytes":"16","total_rows":"0"}
 < X-ClickHouse-Progress: {"read_rows":"3","read_bytes":"24","total_rows":"0"}

--- a/dbms/tests/queries/0_stateless/00416_pocopatch_progress_in_http_headers.sh
+++ b/dbms/tests/queries/0_stateless/00416_pocopatch_progress_in_http_headers.sh
@@ -3,6 +3,7 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . $CURDIR/../shell_config.sh
 
+${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}?max_block_size=5&send_progress_in_http_headers=1&http_headers_progress_interval_ms=0" -d 'SELECT max(number) FROM numbers(10)' 2>&1 | grep -E 'Content-Encoding|X-ClickHouse-Progress|^[0-9]'
 # This test will fail with external poco (progress not supported)
 
 ${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}?max_block_size=1&send_progress_in_http_headers=1&http_headers_progress_interval_ms=0" -d 'SELECT number FROM system.numbers LIMIT 10' 2>&1 | grep -E 'Content-Encoding|X-ClickHouse-Progress|^[0-9]'


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- New Feature
- Bug Fix

Short description (up to few sentences):
Fix broken progress in 19.3 (regression in 92769a24607ec5f78f605b2746699ffb2adba633)

Introduce total_rows for table function `numbers()`.

fixes https://github.com/yandex/ClickHouse/issues/4429
resolves https://github.com/yandex/ClickHouse/issues/4284