### PR TITLE
Fixed potential deadlock in ExternalDictionaries

### DIFF
--- a/dbms/src/Dictionaries/DictionaryFactory.h
+++ b/dbms/src/Dictionaries/DictionaryFactory.h
@@ -3,26 +3,29 @@
 #include <ext/singleton.h>
 #include "IDictionary.h"
 
+
 namespace Poco
 {
+
 namespace Util
 {
     class AbstractConfiguration;
 }
 
 class Logger;
+
 }
+
 
 namespace DB
 {
+
 class Context;
 
 class DictionaryFactory : public ext::singleton<DictionaryFactory>
 {
 public:
-    DictionaryPtr
-    create(const std::string & name, const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix, Context & context)
-        const;
+    DictionaryPtr create(const std::string & name, const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix, Context & context) const;
 
     using Creator = std::function<DictionaryPtr(
         const std::string & name,

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -1203,6 +1203,8 @@ EmbeddedDictionaries & Context::getEmbeddedDictionariesImpl(const bool throw_on_
 
 ExternalDictionaries & Context::getExternalDictionariesImpl(const bool throw_on_error) const
 {
+    const auto & config = getConfigRef();
+
     std::lock_guard lock(shared->external_dictionaries_mutex);
 
     if (!shared->external_dictionaries)
@@ -1214,6 +1216,7 @@ ExternalDictionaries & Context::getExternalDictionariesImpl(const bool throw_on_
 
         shared->external_dictionaries.emplace(
             std::move(config_repository),
+            config,
             *this->global_context,
             throw_on_error);
     }

--- a/dbms/src/Interpreters/ExternalDictionaries.cpp
+++ b/dbms/src/Interpreters/ExternalDictionaries.cpp
@@ -26,11 +26,13 @@ namespace
 }
 
 
+/// Must not acquire Context lock in constructor to avoid possibility of deadlocks.
 ExternalDictionaries::ExternalDictionaries(
     std::unique_ptr<IExternalLoaderConfigRepository> config_repository,
+    const Poco::Util::AbstractConfiguration & config,
     Context & context,
     bool throw_on_error)
-        : ExternalLoader(context.getConfigRef(),
+        : ExternalLoader(config,
                          externalDictionariesUpdateSettings,
                          getExternalDictionariesConfigSettings(),
                          std::move(config_repository),

--- a/dbms/src/Interpreters/ExternalDictionaries.h
+++ b/dbms/src/Interpreters/ExternalDictionaries.h
@@ -20,6 +20,7 @@ public:
     /// Dictionaries will be loaded immediately and then will be updated in separate thread, each 'reload_period' seconds.
     ExternalDictionaries(
         std::unique_ptr<IExternalLoaderConfigRepository> config_repository,
+        const Poco::Util::AbstractConfiguration & config,
         Context & context,
         bool throw_on_error);
 

--- a/dbms/src/Interpreters/ExternalLoader.h
+++ b/dbms/src/Interpreters/ExternalLoader.h
@@ -19,8 +19,6 @@
 namespace DB
 {
 
-class Context;
-
 struct ExternalLoaderUpdateSettings
 {
     UInt64 check_period_sec = 5;


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Deadlock may happen while executing `DROP DATABASE dictionary` query.