### PR TITLE
Build shared library for protobuf when MAKE_STATIC_LIBRARIES == OFF.

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -283,9 +283,13 @@ if (USE_INTERNAL_BROTLI_LIBRARY)
 endif ()
 
 if (USE_INTERNAL_PROTOBUF_LIBRARY)
-    set(protobuf_BUILD_TESTS OFF CACHE INTERNAL "" FORCE)
-    set(protobuf_BUILD_SHARED_LIBS OFF CACHE INTERNAL "" FORCE)
+    if (MAKE_STATIC_LIBRARIES)
+        set(protobuf_BUILD_SHARED_LIBS OFF CACHE INTERNAL "" FORCE)
+    else ()
+        set(protobuf_BUILD_SHARED_LIBS ON CACHE INTERNAL "" FORCE)
+    endif ()
     set(protobuf_WITH_ZLIB 0 CACHE INTERNAL "" FORCE) # actually will use zlib, but skip find
+    set(protobuf_BUILD_TESTS OFF CACHE INTERNAL "" FORCE)
     add_subdirectory(protobuf/cmake)
 endif ()
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

When running Clickhouse build with shared libraries and ubsan the following error occurred:

```
[libprotobuf ERROR ../../contrib/protobuf/src/google/protobuf/descriptor_database.cc:58] File already exists in database: google/protobuf/descriptor.proto
[libprotobuf FATAL ../../contrib/protobuf/src/google/protobuf/descriptor.cc:1358] CHECK failed: GeneratedDatabase()->Add(encoded_file_descriptor, size):
terminating with uncaught exception of type google::protobuf::FatalException: CHECK failed: GeneratedDatabase()->Add(encoded_file_descriptor, size):
./server.sh: line 9: 19045 Aborted                 (core dumped) $DIR/bin/clickhouse server --config-file=$DIR/config/config.xml "$@"
```

This PR fixes it.
