### PR TITLE
Remove old packages from control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -63,19 +63,3 @@ Priority: optional
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, clickhouse-client, bash, expect, python, python-lxml, python-termcolor, python-requests, curl, perl, sudo, openssl, netcat-openbsd, telnet, brotli
 Description: ClickHouse tests
-
-
-
-# TODO: Remove:
-
-Package: clickhouse-server-base
-Architecture: any
-Priority: optional
-Depends: ${shlibs:Depends}, ${misc:Depends}, adduser, tzdata
-Description: DEPRECATED PACKAGE (use clickhouse-common-static): Server binary for clickhouse
-
-Package: clickhouse-server-common
-Architecture: all
-Priority: optional
-Depends: ${shlibs:Depends}, ${misc:Depends}, clickhouse-server-base (= ${binary:Version})
-Description: DEPRECATED PACKAGE (use clickhouse-server): Common configuration files for clickhouse-server-base package


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Remove old packages `clickhouse-server-base` and `clickhouse-server-common` from clickhouse.
