### PR TITLE
Removed WTF code

### DIFF
--- a/dbms/src/Common/RWLock.cpp
+++ b/dbms/src/Common/RWLock.cpp
@@ -169,8 +169,6 @@ RWLockImpl::LockHolderImpl::~LockHolderImpl()
         if (!parent_queue.empty())
             parent_queue.front().cv.notify_all();
     }
-
-    parent.reset();
 }
 
 


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fixed tsan report `destroy of a locked mutex`.

Detailed description (optional):
Removed useless code. No idea what it was trying to do.

```
2019.03.20 21:39:56.259994 [ 55 ] {5913c77b-7f92-4b7e-a499-5e18f8994094} <Debug> executeQuery: (from [::1]:46340) SELECT sum(dummy) FROM remote('localhost', system, one) WHERE 1 GLOBAL IN (SELECT 1)
2019.03.20 21:39:56.262901 [ 55 ] {5913c77b-7f92-4b7e-a499-5e18f8994094} <Trace> InterpreterSelectQuery: FetchColumns -> Complete
2019.03.20 21:39:56.268865 [ 55 ] {5913c77b-7f92-4b7e-a499-5e18f8994094} <Trace> InterpreterSelectQuery: FetchColumns -> Complete
2019.03.20 21:39:56.269374 [ 55 ] {5913c77b-7f92-4b7e-a499-5e18f8994094} <Trace> InterpreterSelectQuery: Complete -> Complete
2019.03.20 21:39:56.270384 [ 55 ] {5913c77b-7f92-4b7e-a499-5e18f8994094} <Debug> executeQuery: Query pipeline:
CreatingSets
 Expression
  Expression
   One
 Materializing
  CreatingSets
   Lazy
   Expression
    Expression
     Aggregating
      Concat
       Expression
        Filter
         One

2019.03.20 21:39:56.271117 [ 69 ] {} <Trace> CreatingSetsBlockInputStream: Filling temporary table. 
2019.03.20 21:39:56.271479 [ 69 ] {} <Debug> CreatingSetsBlockInputStream: Created. Table with 1 rows. In 0.000 sec.
2019.03.20 21:39:56.271567 [ 69 ] {} <Trace> CreatingSetsBlockInputStream: Creating set. 
2019.03.20 21:39:56.271964 [ 69 ] {} <Trace> InterpreterSelectQuery: FetchColumns -> Complete
2019.03.20 21:39:56.272212 [ 69 ] {} <Debug> CreatingSetsBlockInputStream: Created. Set with 1 entries from 1 rows. In 0.001 sec.
2019.03.20 21:39:56.272352 [ 69 ] {} <Trace> Aggregator: Aggregating
2019.03.20 21:39:56.272623 [ 69 ] {} <Trace> Aggregator: Aggregation method: without_key
2019.03.20 21:39:56.272799 [ 69 ] {} <Trace> Aggregator: Aggregated. 1 to 1 rows (from 0.000 MiB) in 0.000 sec. (2791.783 rows/sec., 0.003 MiB/sec.)
2019.03.20 21:39:56.272902 [ 69 ] {} <Trace> Aggregator: Merging aggregated data
2019.03.20 21:39:56.273770 [ 55 ] {5913c77b-7f92-4b7e-a499-5e18f8994094} <Information> executeQuery: Read 3 rows, 3.00 B in 0.014 sec., 221 rows/sec., 221.28 B/sec.
2019.03.20 21:39:56.273930 [ 55 ] {5913c77b-7f92-4b7e-a499-5e18f8994094} <Debug> MemoryTracker: Peak memory usage (for query): 1.02 MiB.
2019.03.20 21:39:56.274330 [ 55 ] {5913c77b-7f92-4b7e-a499-5e18f8994094} <Trace> virtual DB::MergingAndConvertingBlockInputStream::~MergingAndConvertingBlockInputStream(): Waiting for threads to finish
2019.03.20 21:39:56.425917 [ 58 ] {} <Trace> TCPHandlerFactory: TCP Request. Address: [::1]:46342
==================
WARNING: ThreadSanitizer: destroy of a locked mutex (pid=264002)
    #0 pthread_mutex_destroy /home/milovidov/ClickHouse/ci/workspace/llvm/llvm/projects/compiler-rt/lib/tsan/rtl/tsan_interceptors.cc:1251 (clickhouse+0x637646b)
    #1 DB::RWLockImpl::~RWLockImpl() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Common/RWLock.h:28:7 (clickhouse+0xb9eda5b)
    #2 std::__1::default_delete<DB::RWLockImpl>::operator()(DB::RWLockImpl*) const /usr/local/bin/../include/c++/v1/memory:2338:5 (clickhouse+0xb9ed7cb)
    #3 std::__1::__shared_ptr_pointer<DB::RWLockImpl*, std::__1::default_delete<DB::RWLockImpl>, std::__1::allocator<DB::RWLockImpl> >::__on_zero_shared() /usr/local/bin/../include/c++/v1/memory:3639 (clickhouse+0xb9ed7cb)
    #4 std::__1::__shared_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3543:9 (clickhouse+0x9e88d7f)
    #5 std::__1::__shared_weak_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3585 (clickhouse+0x9e88d7f)
    #6 std::__1::shared_ptr<DB::RWLockImpl>::~shared_ptr() /usr/local/bin/../include/c++/v1/memory:4521 (clickhouse+0x9e88d7f)
    #7 std::__1::shared_ptr<DB::RWLockImpl>::reset() /usr/local/bin/../include/c++/v1/memory:4656 (clickhouse+0x9e88d7f)
    #8 DB::RWLockImpl::LockHolderImpl::~LockHolderImpl() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Common/RWLock.cpp:173 (clickhouse+0x9e88d7f)
    #9 std::__1::default_delete<DB::RWLockImpl::LockHolderImpl>::operator()(DB::RWLockImpl::LockHolderImpl*) const /usr/local/bin/../include/c++/v1/memory:2338:5 (clickhouse+0x9e8925b)
    #10 std::__1::__shared_ptr_pointer<DB::RWLockImpl::LockHolderImpl*, std::__1::default_delete<DB::RWLockImpl::LockHolderImpl>, std::__1::allocator<DB::RWLockImpl::LockHolderImpl> >::__on_zero_shared() /usr/local/bin/../include/c++/v1/memory:3639 (clickhouse+0x9e8925b)
    #11 std::__1::__shared_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3543:9 (clickhouse+0x64b508e)
    #12 std::__1::__shared_weak_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3585 (clickhouse+0x64b508e)
    #13 std::__1::shared_ptr<DB::RWLockImpl::LockHolderImpl>::~shared_ptr() /usr/local/bin/../include/c++/v1/memory:4521 (clickhouse+0x64b508e)
    #14 DB::TableStructureReadLockHolder::~TableStructureReadLockHolder() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Storages/TableStructureLockHolder.h:27 (clickhouse+0x64b508e)
    #15 std::__1::allocator<DB::TableStructureReadLockHolder>::destroy(DB::TableStructureReadLockHolder*) /usr/local/bin/../include/c++/v1/memory:1880 (clickhouse+0x64b508e)
    #16 void std::__1::allocator_traits<std::__1::allocator<DB::TableStructureReadLockHolder> >::__destroy<DB::TableStructureReadLockHolder>(std::__1::integral_constant<bool, true>, std::__1::allocator<DB::TableStructureReadLockHolder>&, DB::TableStructureReadLockHolder*) /usr/local/bin/../include/c++/v1/memory:1742 (clickhouse+0x64b508e)
    #17 void std::__1::allocator_traits<std::__1::allocator<DB::TableStructureReadLockHolder> >::destroy<DB::TableStructureReadLockHolder>(std::__1::allocator<DB::TableStructureReadLockHolder>&, DB::TableStructureReadLockHolder*) /usr/local/bin/../include/c++/v1/memory:1595 (clickhouse+0x64b508e)
    #18 std::__1::__vector_base<DB::TableStructureReadLockHolder, std::__1::allocator<DB::TableStructureReadLockHolder> >::__destruct_at_end(DB::TableStructureReadLockHolder*) /usr/local/bin/../include/c++/v1/vector:426 (clickhouse+0x64b508e)
    #19 std::__1::__vector_base<DB::TableStructureReadLockHolder, std::__1::allocator<DB::TableStructureReadLockHolder> >::clear() /usr/local/bin/../include/c++/v1/vector:369 (clickhouse+0x64b508e)
    #20 std::__1::__vector_base<DB::TableStructureReadLockHolder, std::__1::allocator<DB::TableStructureReadLockHolder> >::~__vector_base() /usr/local/bin/../include/c++/v1/vector:463 (clickhouse+0x64b508e)
    #21 std::__1::vector<DB::TableStructureReadLockHolder, std::__1::allocator<DB::TableStructureReadLockHolder> >::~vector() /usr/local/bin/../include/c++/v1/vector:555 (clickhouse+0x64b508e)
    #22 DB::IBlockInputStream::~IBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/IBlockInputStream.h:52 (clickhouse+0x64b508e)
    #23 DB::MemoryBlockInputStream::~MemoryBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Storages/StorageMemory.cpp:20:7 (clickhouse+0xc286dfa)
    #24 std::__1::__shared_ptr_emplace<DB::MemoryBlockInputStream, std::__1::allocator<DB::MemoryBlockInputStream> >::__on_zero_shared() /usr/local/bin/../include/c++/v1/memory:3709:23 (clickhouse+0xc286ce7)
    #25 std::__1::__shared_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3543:9 (clickhouse+0x64b4fe0)
    #26 std::__1::__shared_weak_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3585 (clickhouse+0x64b4fe0)
    #27 std::__1::shared_ptr<DB::IBlockInputStream>::~shared_ptr() /usr/local/bin/../include/c++/v1/memory:4521 (clickhouse+0x64b4fe0)
    #28 std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >::destroy(std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1880 (clickhouse+0x64b4fe0)
    #29 void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::__destroy<std::__1::shared_ptr<DB::IBlockInputStream> >(std::__1::integral_constant<bool, true>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >&, std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1742 (clickhouse+0x64b4fe0)
    #30 void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::destroy<std::__1::shared_ptr<DB::IBlockInputStream> >(std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >&, std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1595 (clickhouse+0x64b4fe0)
    #31 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::__destruct_at_end(std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/vector:426 (clickhouse+0x64b4fe0)
    #32 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::clear() /usr/local/bin/../include/c++/v1/vector:369 (clickhouse+0x64b4fe0)
    #33 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::~__vector_base() /usr/local/bin/../include/c++/v1/vector:463 (clickhouse+0x64b4fe0)
    #34 std::__1::vector<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::~vector() /usr/local/bin/../include/c++/v1/vector:555 (clickhouse+0x64b4fe0)
    #35 DB::IBlockInputStream::~IBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/IBlockInputStream.h:52 (clickhouse+0x64b4fe0)
    #36 DB::ExpressionBlockInputStream::~ExpressionBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/ExpressionBlockInputStream.h:16:7 (clickhouse+0xbeaa3a9)
    #37 std::__1::__shared_ptr_emplace<DB::ExpressionBlockInputStream, std::__1::allocator<DB::ExpressionBlockInputStream> >::__on_zero_shared() /usr/local/bin/../include/c++/v1/memory:3709:23 (clickhouse+0xbd1ade7)
    #38 std::__1::__shared_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3543:9 (clickhouse+0x64b4fe0)
    #39 std::__1::__shared_weak_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3585 (clickhouse+0x64b4fe0)
    #40 std::__1::shared_ptr<DB::IBlockInputStream>::~shared_ptr() /usr/local/bin/../include/c++/v1/memory:4521 (clickhouse+0x64b4fe0)
    #41 std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >::destroy(std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1880 (clickhouse+0x64b4fe0)
    #42 void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::__destroy<std::__1::shared_ptr<DB::IBlockInputStream> >(std::__1::integral_constant<bool, true>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >&, std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1742 (clickhouse+0x64b4fe0)
    #43 void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::destroy<std::__1::shared_ptr<DB::IBlockInputStream> >(std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >&, std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1595 (clickhouse+0x64b4fe0)
    #44 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::__destruct_at_end(std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/vector:426 (clickhouse+0x64b4fe0)
    #45 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::clear() /usr/local/bin/../include/c++/v1/vector:369 (clickhouse+0x64b4fe0)
    #46 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::~__vector_base() /usr/local/bin/../include/c++/v1/vector:463 (clickhouse+0x64b4fe0)
    #47 std::__1::vector<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::~vector() /usr/local/bin/../include/c++/v1/vector:555 (clickhouse+0x64b4fe0)
    #48 DB::IBlockInputStream::~IBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/IBlockInputStream.h:52 (clickhouse+0x64b4fe0)
    #49 DB::ExpressionBlockInputStream::~ExpressionBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/ExpressionBlockInputStream.h:16:7 (clickhouse+0xbeaa3a9)
    #50 std::__1::__shared_ptr_emplace<DB::ExpressionBlockInputStream, std::__1::allocator<DB::ExpressionBlockInputStream> >::__on_zero_shared() /usr/local/bin/../include/c++/v1/memory:3709:23 (clickhouse+0xbd1ade7)
    #51 std::__1::__shared_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3543:9 (clickhouse+0x64b4fe0)
    #52 std::__1::__shared_weak_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3585 (clickhouse+0x64b4fe0)
    #53 std::__1::shared_ptr<DB::IBlockInputStream>::~shared_ptr() /usr/local/bin/../include/c++/v1/memory:4521 (clickhouse+0x64b4fe0)
    #54 std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >::destroy(std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1880 (clickhouse+0x64b4fe0)
    #55 void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::__destroy<std::__1::shared_ptr<DB::IBlockInputStream> >(std::__1::integral_constant<bool, true>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >&, std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1742 (clickhouse+0x64b4fe0)
    #56 void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::destroy<std::__1::shared_ptr<DB::IBlockInputStream> >(std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >&, std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1595 (clickhouse+0x64b4fe0)
    #57 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::__destruct_at_end(std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/vector:426 (clickhouse+0x64b4fe0)
    #58 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::clear() /usr/local/bin/../include/c++/v1/vector:369 (clickhouse+0x64b4fe0)
    #59 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::~__vector_base() /usr/local/bin/../include/c++/v1/vector:463 (clickhouse+0x64b4fe0)
    #60 std::__1::vector<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::~vector() /usr/local/bin/../include/c++/v1/vector:555 (clickhouse+0x64b4fe0)
    #61 DB::IBlockInputStream::~IBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/IBlockInputStream.h:52 (clickhouse+0x64b4fe0)
    #62 DB::LazyBlockInputStream::~LazyBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/LazyBlockInputStream.h:13:7 (clickhouse+0xbcad42c)
    #63 std::__1::__shared_ptr_emplace<DB::LazyBlockInputStream, std::__1::allocator<DB::LazyBlockInputStream> >::__on_zero_shared() /usr/local/bin/../include/c++/v1/memory:3709:23 (clickhouse+0xbcad1b7)
    #64 std::__1::__shared_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3543:9 (clickhouse+0x64b4fe0)
    #65 std::__1::__shared_weak_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3585 (clickhouse+0x64b4fe0)
    #66 std::__1::shared_ptr<DB::IBlockInputStream>::~shared_ptr() /usr/local/bin/../include/c++/v1/memory:4521 (clickhouse+0x64b4fe0)
    #67 std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >::destroy(std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1880 (clickhouse+0x64b4fe0)
    #68 void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::__destroy<std::__1::shared_ptr<DB::IBlockInputStream> >(std::__1::integral_constant<bool, true>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >&, std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1742 (clickhouse+0x64b4fe0)
    #69 void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::destroy<std::__1::shared_ptr<DB::IBlockInputStream> >(std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >&, std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1595 (clickhouse+0x64b4fe0)
    #70 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::__destruct_at_end(std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/vector:426 (clickhouse+0x64b4fe0)
    #71 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::clear() /usr/local/bin/../include/c++/v1/vector:369 (clickhouse+0x64b4fe0)
    #72 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::~__vector_base() /usr/local/bin/../include/c++/v1/vector:463 (clickhouse+0x64b4fe0)
    #73 std::__1::vector<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::~vector() /usr/local/bin/../include/c++/v1/vector:555 (clickhouse+0x64b4fe0)
    #74 DB::IBlockInputStream::~IBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/IBlockInputStream.h:52 (clickhouse+0x64b4fe0)
    #75 DB::CreatingSetsBlockInputStream::~CreatingSetsBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/CreatingSetsBlockInputStream.h:17:7 (clickhouse+0xbeacf35)
    #76 std::__1::__shared_ptr_emplace<DB::CreatingSetsBlockInputStream, std::__1::allocator<DB::CreatingSetsBlockInputStream> >::__on_zero_shared() /usr/local/bin/../include/c++/v1/memory:3709:23 (clickhouse+0xbd2d9e7)
    #77 std::__1::__shared_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3543:9 (clickhouse+0x64b4fe0)
    #78 std::__1::__shared_weak_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3585 (clickhouse+0x64b4fe0)
    #79 std::__1::shared_ptr<DB::IBlockInputStream>::~shared_ptr() /usr/local/bin/../include/c++/v1/memory:4521 (clickhouse+0x64b4fe0)
    #80 std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >::destroy(std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1880 (clickhouse+0x64b4fe0)
    #81 void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::__destroy<std::__1::shared_ptr<DB::IBlockInputStream> >(std::__1::integral_constant<bool, true>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >&, std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1742 (clickhouse+0x64b4fe0)
    #82 void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::destroy<std::__1::shared_ptr<DB::IBlockInputStream> >(std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >&, std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1595 (clickhouse+0x64b4fe0)
    #83 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::__destruct_at_end(std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/vector:426 (clickhouse+0x64b4fe0)
    #84 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::clear() /usr/local/bin/../include/c++/v1/vector:369 (clickhouse+0x64b4fe0)
    #85 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::~__vector_base() /usr/local/bin/../include/c++/v1/vector:463 (clickhouse+0x64b4fe0)
    #86 std::__1::vector<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::~vector() /usr/local/bin/../include/c++/v1/vector:555 (clickhouse+0x64b4fe0)
    #87 DB::IBlockInputStream::~IBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/IBlockInputStream.h:52 (clickhouse+0x64b4fe0)
    #88 std::__1::__shared_ptr_emplace<DB::MaterializingBlockInputStream, std::__1::allocator<DB::MaterializingBlockInputStream> >::__on_zero_shared() /usr/local/bin/../include/c++/v1/memory:3709:23 (clickhouse+0xbcf3ec7)
    #89 std::__1::__shared_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3543:9 (clickhouse+0x64b4fe0)
    #90 std::__1::__shared_weak_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3585 (clickhouse+0x64b4fe0)
    #91 std::__1::shared_ptr<DB::IBlockInputStream>::~shared_ptr() /usr/local/bin/../include/c++/v1/memory:4521 (clickhouse+0x64b4fe0)
    #92 std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >::destroy(std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1880 (clickhouse+0x64b4fe0)
    #93 void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::__destroy<std::__1::shared_ptr<DB::IBlockInputStream> >(std::__1::integral_constant<bool, true>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >&, std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1742 (clickhouse+0x64b4fe0)
    #94 void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::destroy<std::__1::shared_ptr<DB::IBlockInputStream> >(std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >&, std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1595 (clickhouse+0x64b4fe0)
    #95 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::__destruct_at_end(std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/vector:426 (clickhouse+0x64b4fe0)
    #96 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::clear() /usr/local/bin/../include/c++/v1/vector:369 (clickhouse+0x64b4fe0)
    #97 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::~__vector_base() /usr/local/bin/../include/c++/v1/vector:463 (clickhouse+0x64b4fe0)
    #98 std::__1::vector<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::~vector() /usr/local/bin/../include/c++/v1/vector:555 (clickhouse+0x64b4fe0)
    #99 DB::IBlockInputStream::~IBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/IBlockInputStream.h:52 (clickhouse+0x64b4fe0)
    #100 DB::CreatingSetsBlockInputStream::~CreatingSetsBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/CreatingSetsBlockInputStream.h:17:7 (clickhouse+0xbeacf35)
    #101 std::__1::__shared_ptr_emplace<DB::CreatingSetsBlockInputStream, std::__1::allocator<DB::CreatingSetsBlockInputStream> >::__on_zero_shared() /usr/local/bin/../include/c++/v1/memory:3709:23 (clickhouse+0xbd2d9e7)
    #102 std::__1::__shared_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3543:9 (clickhouse+0xbffbf3c)
    #103 std::__1::__shared_weak_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3585 (clickhouse+0xbffbf3c)
    #104 std::__1::shared_ptr<DB::IBlockInputStream>::~shared_ptr() /usr/local/bin/../include/c++/v1/memory:4521 (clickhouse+0xbffbf3c)
    #105 DB::QueryStatus::releaseQueryStreams() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Interpreters/ProcessList.cpp:307 (clickhouse+0xbffbf3c)
    #106 DB::ProcessListEntry::~ProcessListEntry() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Interpreters/ProcessList.cpp:206 (clickhouse+0xbffbf3c)
    #107 std::__1::__shared_ptr_emplace<DB::ProcessListEntry, std::__1::allocator<DB::ProcessListEntry> >::__on_zero_shared() /usr/local/bin/../include/c++/v1/memory:3709:23 (clickhouse+0xbfffb8d)
    #108 std::__1::__shared_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3543:9 (clickhouse+0x64b41c0)
    #109 std::__1::__shared_weak_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3585 (clickhouse+0x64b41c0)
    #110 std::__1::shared_ptr<DB::ProcessListEntry>::~shared_ptr() /usr/local/bin/../include/c++/v1/memory:4521 (clickhouse+0x64b41c0)
    #111 std::__1::shared_ptr<DB::ProcessListEntry>::reset() /usr/local/bin/../include/c++/v1/memory:4656 (clickhouse+0x64b41c0)
    #112 DB::BlockIO::reset() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/BlockIO.h:45 (clickhouse+0x64b41c0)
    #113 DB::BlockIO::operator=(DB::BlockIO const&) /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/BlockIO.h:50:9 (clickhouse+0x64b2367)
    #114 DB::QueryState::operator=(DB::QueryState&&) /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/programs/server/TCPHandler.h:31:8 (clickhouse+0x64b3e53)
    #115 DB::QueryState::reset() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/programs/server/TCPHandler.h:73:15 (clickhouse+0x64a60b9)
    #116 DB::TCPHandler::runImpl() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/programs/server/TCPHandler.cpp:213 (clickhouse+0x64a60b9)
    #117 DB::TCPHandler::run() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/programs/server/TCPHandler.cpp:941:9 (clickhouse+0x64b1357)
    #118 Poco::Net::TCPServerConnection::start() /home/milovidov/ClickHouse/build_clang9_tsan/../contrib/poco/Net/src/TCPServerConnection.cpp:43:3 (clickhouse+0xccfe092)
    #119 Poco::Net::TCPServerDispatcher::run() /home/milovidov/ClickHouse/build_clang9_tsan/../contrib/poco/Net/src/TCPServerDispatcher.cpp:114:20 (clickhouse+0xccfe90a)
    #120 Poco::PooledThread::run() /home/milovidov/ClickHouse/build_clang9_tsan/../contrib/poco/Foundation/src/ThreadPool.cpp:214:14 (clickhouse+0xcdf0191)
    #121 Poco::(anonymous namespace)::RunnableHolder::run() /home/milovidov/ClickHouse/build_clang9_tsan/../contrib/poco/Foundation/src/Thread.cpp:43:11 (clickhouse+0xcdee6bf)
    #122 Poco::ThreadImpl::runnableEntry(void*) /home/milovidov/ClickHouse/build_clang9_tsan/../contrib/poco/Foundation/src/Thread_STD.cpp:139:27 (clickhouse+0xcdecf2a)
    #123 decltype(std::__1::forward<void* (*)(void*)>(fp)(std::__1::forward<Poco::ThreadImpl*>(fp0))) std::__1::__invoke<void* (*)(void*), Poco::ThreadImpl*>(void* (*&&)(void*), Poco::ThreadImpl*&&) /usr/local/bin/../include/c++/v1/type_traits:4410:1 (clickhouse+0xcdef06a)
    #124 void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*, 2ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*>&, std::__1::__tuple_indices<2ul>) /usr/local/bin/../include/c++/v1/thread:341 (clickhouse+0xcdef06a)
    #125 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*> >(void*) /usr/local/bin/../include/c++/v1/thread:351 (clickhouse+0xcdef06a)

  and:
    #0 pthread_mutex_lock /home/milovidov/ClickHouse/ci/workspace/llvm/llvm/projects/compiler-rt/lib/tsan/../sanitizer_common/sanitizer_common_interceptors.inc:4112 (clickhouse+0x638eb8b)
    #1 std::__1::mutex::lock() <null> (clickhouse+0xdb7a3a5)
    #2 std::__1::default_delete<DB::RWLockImpl::LockHolderImpl>::operator()(DB::RWLockImpl::LockHolderImpl*) const /usr/local/bin/../include/c++/v1/memory:2338:5 (clickhouse+0x9e8925b)
    #3 std::__1::__shared_ptr_pointer<DB::RWLockImpl::LockHolderImpl*, std::__1::default_delete<DB::RWLockImpl::LockHolderImpl>, std::__1::allocator<DB::RWLockImpl::LockHolderImpl> >::__on_zero_shared() /usr/local/bin/../include/c++/v1/memory:3639 (clickhouse+0x9e8925b)
    #4 std::__1::__shared_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3543:9 (clickhouse+0x64b508e)
    #5 std::__1::__shared_weak_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3585 (clickhouse+0x64b508e)
    #6 std::__1::shared_ptr<DB::RWLockImpl::LockHolderImpl>::~shared_ptr() /usr/local/bin/../include/c++/v1/memory:4521 (clickhouse+0x64b508e)
    #7 DB::TableStructureReadLockHolder::~TableStructureReadLockHolder() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Storages/TableStructureLockHolder.h:27 (clickhouse+0x64b508e)
    #8 std::__1::allocator<DB::TableStructureReadLockHolder>::destroy(DB::TableStructureReadLockHolder*) /usr/local/bin/../include/c++/v1/memory:1880 (clickhouse+0x64b508e)
    #9 void std::__1::allocator_traits<std::__1::allocator<DB::TableStructureReadLockHolder> >::__destroy<DB::TableStructureReadLockHolder>(std::__1::integral_constant<bool, true>, std::__1::allocator<DB::TableStructureReadLockHolder>&, DB::TableStructureReadLockHolder*) /usr/local/bin/../include/c++/v1/memory:1742 (clickhouse+0x64b508e)
    #10 void std::__1::allocator_traits<std::__1::allocator<DB::TableStructureReadLockHolder> >::destroy<DB::TableStructureReadLockHolder>(std::__1::allocator<DB::TableStructureReadLockHolder>&, DB::TableStructureReadLockHolder*) /usr/local/bin/../include/c++/v1/memory:1595 (clickhouse+0x64b508e)
    #11 std::__1::__vector_base<DB::TableStructureReadLockHolder, std::__1::allocator<DB::TableStructureReadLockHolder> >::__destruct_at_end(DB::TableStructureReadLockHolder*) /usr/local/bin/../include/c++/v1/vector:426 (clickhouse+0x64b508e)
    #12 std::__1::__vector_base<DB::TableStructureReadLockHolder, std::__1::allocator<DB::TableStructureReadLockHolder> >::clear() /usr/local/bin/../include/c++/v1/vector:369 (clickhouse+0x64b508e)
    #13 std::__1::__vector_base<DB::TableStructureReadLockHolder, std::__1::allocator<DB::TableStructureReadLockHolder> >::~__vector_base() /usr/local/bin/../include/c++/v1/vector:463 (clickhouse+0x64b508e)
    #14 std::__1::vector<DB::TableStructureReadLockHolder, std::__1::allocator<DB::TableStructureReadLockHolder> >::~vector() /usr/local/bin/../include/c++/v1/vector:555 (clickhouse+0x64b508e)
    #15 DB::IBlockInputStream::~IBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/IBlockInputStream.h:52 (clickhouse+0x64b508e)
    #16 DB::MemoryBlockInputStream::~MemoryBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Storages/StorageMemory.cpp:20:7 (clickhouse+0xc286dfa)
    #17 std::__1::__shared_ptr_emplace<DB::MemoryBlockInputStream, std::__1::allocator<DB::MemoryBlockInputStream> >::__on_zero_shared() /usr/local/bin/../include/c++/v1/memory:3709:23 (clickhouse+0xc286ce7)
    #18 std::__1::__shared_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3543:9 (clickhouse+0x64b4fe0)
    #19 std::__1::__shared_weak_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3585 (clickhouse+0x64b4fe0)
    #20 std::__1::shared_ptr<DB::IBlockInputStream>::~shared_ptr() /usr/local/bin/../include/c++/v1/memory:4521 (clickhouse+0x64b4fe0)
    #21 std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >::destroy(std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1880 (clickhouse+0x64b4fe0)
    #22 void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::__destroy<std::__1::shared_ptr<DB::IBlockInputStream> >(std::__1::integral_constant<bool, true>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >&, std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1742 (clickhouse+0x64b4fe0)
    #23 void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::destroy<std::__1::shared_ptr<DB::IBlockInputStream> >(std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >&, std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1595 (clickhouse+0x64b4fe0)
    #24 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::__destruct_at_end(std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/vector:426 (clickhouse+0x64b4fe0)
    #25 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::clear() /usr/local/bin/../include/c++/v1/vector:369 (clickhouse+0x64b4fe0)
    #26 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::~__vector_base() /usr/local/bin/../include/c++/v1/vector:463 (clickhouse+0x64b4fe0)
    #27 std::__1::vector<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::~vector() /usr/local/bin/../include/c++/v1/vector:555 (clickhouse+0x64b4fe0)
    #28 DB::IBlockInputStream::~IBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/IBlockInputStream.h:52 (clickhouse+0x64b4fe0)
    #29 DB::ExpressionBlockInputStream::~ExpressionBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/ExpressionBlockInputStream.h:16:7 (clickhouse+0xbeaa3a9)
    #30 std::__1::__shared_ptr_emplace<DB::ExpressionBlockInputStream, std::__1::allocator<DB::ExpressionBlockInputStream> >::__on_zero_shared() /usr/local/bin/../include/c++/v1/memory:3709:23 (clickhouse+0xbd1ade7)
    #31 std::__1::__shared_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3543:9 (clickhouse+0x64b4fe0)
    #32 std::__1::__shared_weak_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3585 (clickhouse+0x64b4fe0)
    #33 std::__1::shared_ptr<DB::IBlockInputStream>::~shared_ptr() /usr/local/bin/../include/c++/v1/memory:4521 (clickhouse+0x64b4fe0)
    #34 std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >::destroy(std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1880 (clickhouse+0x64b4fe0)
    #35 void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::__destroy<std::__1::shared_ptr<DB::IBlockInputStream> >(std::__1::integral_constant<bool, true>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >&, std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1742 (clickhouse+0x64b4fe0)
    #36 void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::destroy<std::__1::shared_ptr<DB::IBlockInputStream> >(std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >&, std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1595 (clickhouse+0x64b4fe0)
    #37 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::__destruct_at_end(std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/vector:426 (clickhouse+0x64b4fe0)
    #38 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::clear() /usr/local/bin/../include/c++/v1/vector:369 (clickhouse+0x64b4fe0)
    #39 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::~__vector_base() /usr/local/bin/../include/c++/v1/vector:463 (clickhouse+0x64b4fe0)
    #40 std::__1::vector<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::~vector() /usr/local/bin/../include/c++/v1/vector:555 (clickhouse+0x64b4fe0)
    #41 DB::IBlockInputStream::~IBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/IBlockInputStream.h:52 (clickhouse+0x64b4fe0)
    #42 DB::ExpressionBlockInputStream::~ExpressionBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/ExpressionBlockInputStream.h:16:7 (clickhouse+0xbeaa3a9)
    #43 std::__1::__shared_ptr_emplace<DB::ExpressionBlockInputStream, std::__1::allocator<DB::ExpressionBlockInputStream> >::__on_zero_shared() /usr/local/bin/../include/c++/v1/memory:3709:23 (clickhouse+0xbd1ade7)
    #44 std::__1::__shared_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3543:9 (clickhouse+0x64b4fe0)
    #45 std::__1::__shared_weak_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3585 (clickhouse+0x64b4fe0)
    #46 std::__1::shared_ptr<DB::IBlockInputStream>::~shared_ptr() /usr/local/bin/../include/c++/v1/memory:4521 (clickhouse+0x64b4fe0)
    #47 std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >::destroy(std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1880 (clickhouse+0x64b4fe0)
    #48 void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::__destroy<std::__1::shared_ptr<DB::IBlockInputStream> >(std::__1::integral_constant<bool, true>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >&, std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1742 (clickhouse+0x64b4fe0)
    #49 void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::destroy<std::__1::shared_ptr<DB::IBlockInputStream> >(std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >&, std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1595 (clickhouse+0x64b4fe0)
    #50 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::__destruct_at_end(std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/vector:426 (clickhouse+0x64b4fe0)
    #51 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::clear() /usr/local/bin/../include/c++/v1/vector:369 (clickhouse+0x64b4fe0)
    #52 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::~__vector_base() /usr/local/bin/../include/c++/v1/vector:463 (clickhouse+0x64b4fe0)
    #53 std::__1::vector<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::~vector() /usr/local/bin/../include/c++/v1/vector:555 (clickhouse+0x64b4fe0)
    #54 DB::IBlockInputStream::~IBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/IBlockInputStream.h:52 (clickhouse+0x64b4fe0)
    #55 DB::LazyBlockInputStream::~LazyBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/LazyBlockInputStream.h:13:7 (clickhouse+0xbcad42c)
    #56 std::__1::__shared_ptr_emplace<DB::LazyBlockInputStream, std::__1::allocator<DB::LazyBlockInputStream> >::__on_zero_shared() /usr/local/bin/../include/c++/v1/memory:3709:23 (clickhouse+0xbcad1b7)
    #57 std::__1::__shared_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3543:9 (clickhouse+0x64b4fe0)
    #58 std::__1::__shared_weak_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3585 (clickhouse+0x64b4fe0)
    #59 std::__1::shared_ptr<DB::IBlockInputStream>::~shared_ptr() /usr/local/bin/../include/c++/v1/memory:4521 (clickhouse+0x64b4fe0)
    #60 std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >::destroy(std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1880 (clickhouse+0x64b4fe0)
    #61 void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::__destroy<std::__1::shared_ptr<DB::IBlockInputStream> >(std::__1::integral_constant<bool, true>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >&, std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1742 (clickhouse+0x64b4fe0)
    #62 void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::destroy<std::__1::shared_ptr<DB::IBlockInputStream> >(std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >&, std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1595 (clickhouse+0x64b4fe0)
    #63 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::__destruct_at_end(std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/vector:426 (clickhouse+0x64b4fe0)
    #64 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::clear() /usr/local/bin/../include/c++/v1/vector:369 (clickhouse+0x64b4fe0)
    #65 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::~__vector_base() /usr/local/bin/../include/c++/v1/vector:463 (clickhouse+0x64b4fe0)
    #66 std::__1::vector<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::~vector() /usr/local/bin/../include/c++/v1/vector:555 (clickhouse+0x64b4fe0)
    #67 DB::IBlockInputStream::~IBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/IBlockInputStream.h:52 (clickhouse+0x64b4fe0)
    #68 DB::CreatingSetsBlockInputStream::~CreatingSetsBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/CreatingSetsBlockInputStream.h:17:7 (clickhouse+0xbeacf35)
    #69 std::__1::__shared_ptr_emplace<DB::CreatingSetsBlockInputStream, std::__1::allocator<DB::CreatingSetsBlockInputStream> >::__on_zero_shared() /usr/local/bin/../include/c++/v1/memory:3709:23 (clickhouse+0xbd2d9e7)
    #70 std::__1::__shared_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3543:9 (clickhouse+0x64b4fe0)
    #71 std::__1::__shared_weak_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3585 (clickhouse+0x64b4fe0)
    #72 std::__1::shared_ptr<DB::IBlockInputStream>::~shared_ptr() /usr/local/bin/../include/c++/v1/memory:4521 (clickhouse+0x64b4fe0)
    #73 std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >::destroy(std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1880 (clickhouse+0x64b4fe0)
    #74 void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::__destroy<std::__1::shared_ptr<DB::IBlockInputStream> >(std::__1::integral_constant<bool, true>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >&, std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1742 (clickhouse+0x64b4fe0)
    #75 void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::destroy<std::__1::shared_ptr<DB::IBlockInputStream> >(std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >&, std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1595 (clickhouse+0x64b4fe0)
    #76 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::__destruct_at_end(std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/vector:426 (clickhouse+0x64b4fe0)
    #77 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::clear() /usr/local/bin/../include/c++/v1/vector:369 (clickhouse+0x64b4fe0)
    #78 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::~__vector_base() /usr/local/bin/../include/c++/v1/vector:463 (clickhouse+0x64b4fe0)
    #79 std::__1::vector<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::~vector() /usr/local/bin/../include/c++/v1/vector:555 (clickhouse+0x64b4fe0)
    #80 DB::IBlockInputStream::~IBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/IBlockInputStream.h:52 (clickhouse+0x64b4fe0)
    #81 std::__1::__shared_ptr_emplace<DB::MaterializingBlockInputStream, std::__1::allocator<DB::MaterializingBlockInputStream> >::__on_zero_shared() /usr/local/bin/../include/c++/v1/memory:3709:23 (clickhouse+0xbcf3ec7)
    #82 std::__1::__shared_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3543:9 (clickhouse+0x64b4fe0)
    #83 std::__1::__shared_weak_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3585 (clickhouse+0x64b4fe0)
    #84 std::__1::shared_ptr<DB::IBlockInputStream>::~shared_ptr() /usr/local/bin/../include/c++/v1/memory:4521 (clickhouse+0x64b4fe0)
    #85 std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >::destroy(std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1880 (clickhouse+0x64b4fe0)
    #86 void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::__destroy<std::__1::shared_ptr<DB::IBlockInputStream> >(std::__1::integral_constant<bool, true>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >&, std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1742 (clickhouse+0x64b4fe0)
    #87 void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::destroy<std::__1::shared_ptr<DB::IBlockInputStream> >(std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> >&, std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/memory:1595 (clickhouse+0x64b4fe0)
    #88 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::__destruct_at_end(std::__1::shared_ptr<DB::IBlockInputStream>*) /usr/local/bin/../include/c++/v1/vector:426 (clickhouse+0x64b4fe0)
    #89 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::clear() /usr/local/bin/../include/c++/v1/vector:369 (clickhouse+0x64b4fe0)
    #90 std::__1::__vector_base<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::~__vector_base() /usr/local/bin/../include/c++/v1/vector:463 (clickhouse+0x64b4fe0)
    #91 std::__1::vector<std::__1::shared_ptr<DB::IBlockInputStream>, std::__1::allocator<std::__1::shared_ptr<DB::IBlockInputStream> > >::~vector() /usr/local/bin/../include/c++/v1/vector:555 (clickhouse+0x64b4fe0)
    #92 DB::IBlockInputStream::~IBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/IBlockInputStream.h:52 (clickhouse+0x64b4fe0)
    #93 DB::CreatingSetsBlockInputStream::~CreatingSetsBlockInputStream() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/CreatingSetsBlockInputStream.h:17:7 (clickhouse+0xbeacf35)
    #94 std::__1::__shared_ptr_emplace<DB::CreatingSetsBlockInputStream, std::__1::allocator<DB::CreatingSetsBlockInputStream> >::__on_zero_shared() /usr/local/bin/../include/c++/v1/memory:3709:23 (clickhouse+0xbd2d9e7)
    #95 std::__1::__shared_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3543:9 (clickhouse+0xbffbf3c)
    #96 std::__1::__shared_weak_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3585 (clickhouse+0xbffbf3c)
    #97 std::__1::shared_ptr<DB::IBlockInputStream>::~shared_ptr() /usr/local/bin/../include/c++/v1/memory:4521 (clickhouse+0xbffbf3c)
    #98 DB::QueryStatus::releaseQueryStreams() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Interpreters/ProcessList.cpp:307 (clickhouse+0xbffbf3c)
    #99 DB::ProcessListEntry::~ProcessListEntry() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Interpreters/ProcessList.cpp:206 (clickhouse+0xbffbf3c)
    #100 std::__1::__shared_ptr_emplace<DB::ProcessListEntry, std::__1::allocator<DB::ProcessListEntry> >::__on_zero_shared() /usr/local/bin/../include/c++/v1/memory:3709:23 (clickhouse+0xbfffb8d)
    #101 std::__1::__shared_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3543:9 (clickhouse+0x64b41c0)
    #102 std::__1::__shared_weak_count::__release_shared() /usr/local/bin/../include/c++/v1/memory:3585 (clickhouse+0x64b41c0)
    #103 std::__1::shared_ptr<DB::ProcessListEntry>::~shared_ptr() /usr/local/bin/../include/c++/v1/memory:4521 (clickhouse+0x64b41c0)
    #104 std::__1::shared_ptr<DB::ProcessListEntry>::reset() /usr/local/bin/../include/c++/v1/memory:4656 (clickhouse+0x64b41c0)
    #105 DB::BlockIO::reset() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/BlockIO.h:45 (clickhouse+0x64b41c0)
    #106 DB::BlockIO::operator=(DB::BlockIO const&) /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/DataStreams/BlockIO.h:50:9 (clickhouse+0x64b2367)
    #107 DB::QueryState::operator=(DB::QueryState&&) /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/programs/server/TCPHandler.h:31:8 (clickhouse+0x64b3e53)
    #108 DB::QueryState::reset() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/programs/server/TCPHandler.h:73:15 (clickhouse+0x64a60b9)
    #109 DB::TCPHandler::runImpl() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/programs/server/TCPHandler.cpp:213 (clickhouse+0x64a60b9)
    #110 DB::TCPHandler::run() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/programs/server/TCPHandler.cpp:941:9 (clickhouse+0x64b1357)
    #111 Poco::Net::TCPServerConnection::start() /home/milovidov/ClickHouse/build_clang9_tsan/../contrib/poco/Net/src/TCPServerConnection.cpp:43:3 (clickhouse+0xccfe092)
    #112 Poco::Net::TCPServerDispatcher::run() /home/milovidov/ClickHouse/build_clang9_tsan/../contrib/poco/Net/src/TCPServerDispatcher.cpp:114:20 (clickhouse+0xccfe90a)
    #113 Poco::PooledThread::run() /home/milovidov/ClickHouse/build_clang9_tsan/../contrib/poco/Foundation/src/ThreadPool.cpp:214:14 (clickhouse+0xcdf0191)
    #114 Poco::(anonymous namespace)::RunnableHolder::run() /home/milovidov/ClickHouse/build_clang9_tsan/../contrib/poco/Foundation/src/Thread.cpp:43:11 (clickhouse+0xcdee6bf)
    #115 Poco::ThreadImpl::runnableEntry(void*) /home/milovidov/ClickHouse/build_clang9_tsan/../contrib/poco/Foundation/src/Thread_STD.cpp:139:27 (clickhouse+0xcdecf2a)
    #116 decltype(std::__1::forward<void* (*)(void*)>(fp)(std::__1::forward<Poco::ThreadImpl*>(fp0))) std::__1::__invoke<void* (*)(void*), Poco::ThreadImpl*>(void* (*&&)(void*), Poco::ThreadImpl*&&) /usr/local/bin/../include/c++/v1/type_traits:4410:1 (clickhouse+0xcdef06a)
    #117 void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*, 2ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*>&, std::__1::__tuple_indices<2ul>) /usr/local/bin/../include/c++/v1/thread:341 (clickhouse+0xcdef06a)
    #118 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*> >(void*) /usr/local/bin/../include/c++/v1/thread:351 (clickhouse+0xcdef06a)

  Location is heap block of size 128 at 0x7b2000079780 allocated by thread T57:
    #0 operator new(unsigned long) /home/milovidov/ClickHouse/ci/workspace/llvm/llvm/projects/compiler-rt/lib/tsan/rtl/tsan_new_delete.cc:64 (clickhouse+0x6418c77)
    #1 DB::RWLockImpl::create() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Common/RWLock.h:37:44 (clickhouse+0xc240a5e)
    #2 DB::IStorage::IStorage(DB::ColumnsDescription) /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Storages/IStorage.h:357 (clickhouse+0xc240a5e)
    #3 DB::StorageMemory::StorageMemory(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, DB::ColumnsDescription) /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Storages/StorageMemory.cpp:78:7 (clickhouse+0xc285606)
    #4 auto ext::shared_ptr_helper<DB::StorageMemory>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription&&)::Local::Local(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription&&) /home/milovidov/ClickHouse/build_clang9_tsan/../libs/libcommon/include/ext/shared_ptr_helper.h:32:39 (clickhouse+0x64b5fa6)
    #5 std::__1::__compressed_pair_elem<auto ext::shared_ptr_helper<DB::StorageMemory>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription&&)::Local, 1, false>::__compressed_pair_elem<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription&&, 0ul, 1ul>(std::__1::piecewise_construct_t, std::__1::tuple<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription>, std::__1::__tuple_indices<0ul, 1ul>) /usr/local/bin/../include/c++/v1/memory:2155:9 (clickhouse+0x64b58d9)
    #6 std::__1::__compressed_pair<std::__1::allocator<auto ext::shared_ptr_helper<DB::StorageMemory>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription&&)::Local>, auto ext::shared_ptr_helper<DB::StorageMemory>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription&&)::Local>::__compressed_pair<std::__1::allocator<auto ext::shared_ptr_helper<DB::StorageMemory>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription&&)::Local>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription&&>(std::__1::piecewise_construct_t, std::__1::tuple<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription>, std::__1::tuple<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription&&>) /usr/local/bin/../include/c++/v1/memory:2258 (clickhouse+0x64b58d9)
    #7 std::__1::__shared_ptr_emplace<auto ext::shared_ptr_helper<DB::StorageMemory>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription&&)::Local, std::__1::allocator<auto ext::shared_ptr_helper<DB::StorageMemory>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription&&)::Local> >::__shared_ptr_emplace<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription>(std::__1::allocator<auto ext::shared_ptr_helper<DB::StorageMemory>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription&&)::Local>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription&&) /usr/local/bin/../include/c++/v1/memory:3671 (clickhouse+0x64b58d9)
    #8 std::__1::shared_ptr<auto ext::shared_ptr_helper<DB::StorageMemory>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription&&)::Local> std::__1::shared_ptr<auto ext::shared_ptr_helper<DB::StorageMemory>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription&&)::Local>::make_shared<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription&&) /usr/local/bin/../include/c++/v1/memory:4330 (clickhouse+0x64b58d9)
    #9 std::__1::enable_if<!(is_array<auto ext::shared_ptr_helper<DB::StorageMemory>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription&&)::Local>::value), std::__1::shared_ptr<auto ext::shared_ptr_helper<DB::StorageMemory>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription&&)::Local> >::type std::__1::make_shared<auto ext::shared_ptr_helper<DB::StorageMemory>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription&&)::Local, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription&&) /usr/local/bin/../include/c++/v1/memory:4709:12 (clickhouse+0xbc8f919)
    #10 auto ext::shared_ptr_helper<DB::StorageMemory>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::ColumnsDescription&&) /home/milovidov/ClickHouse/build_clang9_tsan/../libs/libcommon/include/ext/shared_ptr_helper.h:35 (clickhouse+0xbc8f919)
    #11 DB::GlobalSubqueriesMatcher::Data::addExternalStorage(std::__1::shared_ptr<DB::IAST>&) /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Interpreters/GlobalSubqueriesVisitor.h:107 (clickhouse+0xbc8f919)
    #12 DB::GlobalSubqueriesMatcher::visit(DB::ASTFunction&, std::__1::shared_ptr<DB::IAST>&, DB::GlobalSubqueriesMatcher::Data&) /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Interpreters/GlobalSubqueriesVisitor.h:163:18 (clickhouse+0xbc8f293)
    #13 DB::GlobalSubqueriesMatcher::visit(std::__1::shared_ptr<DB::IAST>&, DB::GlobalSubqueriesMatcher::Data&) /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Interpreters/GlobalSubqueriesVisitor.h:144:13 (clickhouse+0xbc8b9b9)
    #14 DB::InDepthNodeVisitor<DB::GlobalSubqueriesMatcher, false>::visit(std::__1::shared_ptr<DB::IAST>&) /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Interpreters/InDepthNodeVisitor.h:32 (clickhouse+0xbc8b9b9)
    #15 DB::InDepthNodeVisitor<DB::GlobalSubqueriesMatcher, false>::visitChildren(std::__1::shared_ptr<DB::IAST>&) /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Interpreters/InDepthNodeVisitor.h:47:17 (clickhouse+0xbc8b97f)
    #16 DB::InDepthNodeVisitor<DB::GlobalSubqueriesMatcher, false>::visit(std::__1::shared_ptr<DB::IAST>&) /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Interpreters/InDepthNodeVisitor.h:30 (clickhouse+0xbc8b97f)
    #17 DB::ExpressionAnalyzer::initGlobalSubqueriesAndExternalTables() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Interpreters/ExpressionAnalyzer.cpp:246:50 (clickhouse+0xbc7ebbf)
    #18 DB::ExpressionAnalyzer::ExpressionAnalyzer(std::__1::shared_ptr<DB::IAST> const&, std::__1::shared_ptr<DB::SyntaxAnalyzerResult const> const&, DB::Context const&, DB::NamesAndTypesList const&, std::__1::unordered_set<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, unsigned long, bool, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, DB::SubqueryForSet, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, DB::SubqueryForSet> > > const&) /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Interpreters/ExpressionAnalyzer.cpp:104 (clickhouse+0xbc7ebbf)
    #19 std::__1::__unique_if<DB::ExpressionAnalyzer>::__unique_single std::__1::make_unique<DB::ExpressionAnalyzer, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::SyntaxAnalyzerResult const>&, DB::Context&, DB::NamesAndTypesList, std::__1::unordered_set<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >, unsigned long&, bool>(std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::SyntaxAnalyzerResult const>&, DB::Context&, DB::NamesAndTypesList&&, std::__1::unordered_set<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >&&, unsigned long&, bool&&) /usr/local/bin/../include/c++/v1/memory:3131:32 (clickhouse+0xbd14d5c)
    #20 DB::InterpreterSelectQuery::InterpreterSelectQuery(std::__1::shared_ptr<DB::IAST> const&, DB::Context const&, std::__1::shared_ptr<DB::IBlockInputStream> const&, std::__1::shared_ptr<DB::IStorage> const&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, DB::QueryProcessingStage::Enum, unsigned long, bool, bool) /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Interpreters/InterpreterSelectQuery.cpp:220:22 (clickhouse+0xbd004e9)
    #21 DB::InterpreterSelectQuery::InterpreterSelectQuery(std::__1::shared_ptr<DB::IAST> const&, DB::Context const&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, DB::QueryProcessingStage::Enum, unsigned long, bool, bool) /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Interpreters/InterpreterSelectQuery.cpp:86:7 (clickhouse+0xbcff2dc)
    #22 std::__1::__unique_if<DB::InterpreterSelectQuery>::__unique_single std::__1::make_unique<DB::InterpreterSelectQuery, std::__1::shared_ptr<DB::IAST>&, DB::Context&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, DB::QueryProcessingStage::Enum&, unsigned long&, bool&, bool&>(std::__1::shared_ptr<DB::IAST>&, DB::Context&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, DB::QueryProcessingStage::Enum&, unsigned long&, bool&, bool&) /usr/local/bin/../include/c++/v1/memory:3131:32 (clickhouse+0xbed7a16)
    #23 DB::InterpreterSelectWithUnionQuery::InterpreterSelectWithUnionQuery(std::__1::shared_ptr<DB::IAST> const&, DB::Context const&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, DB::QueryProcessingStage::Enum, unsigned long, bool, bool) /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Interpreters/InterpreterSelectWithUnionQuery.cpp:89 (clickhouse+0xbed7a16)
    #24 std::__1::__unique_if<DB::InterpreterSelectWithUnionQuery>::__unique_single std::__1::make_unique<DB::InterpreterSelectWithUnionQuery, std::__1::shared_ptr<DB::IAST>&, DB::Context&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >, DB::QueryProcessingStage::Enum&>(std::__1::shared_ptr<DB::IAST>&, DB::Context&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >&&, DB::QueryProcessingStage::Enum&) /usr/local/bin/../include/c++/v1/memory:3131:32 (clickhouse+0xbcd8d54)
    #25 DB::InterpreterFactory::get(std::__1::shared_ptr<DB::IAST>&, DB::Context&, DB::QueryProcessingStage::Enum) /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Interpreters/InterpreterFactory.cpp:92 (clickhouse+0xbcd8d54)
    #26 DB::executeQueryImpl(char const*, char const*, DB::Context&, bool, DB::QueryProcessingStage::Enum, bool) /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Interpreters/executeQuery.cpp:220:28 (clickhouse+0xc0d7efb)
    #27 DB::executeQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::Context&, bool, DB::QueryProcessingStage::Enum, bool) /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Interpreters/executeQuery.cpp:428:38 (clickhouse+0xc0d774e)
    #28 DB::TCPHandler::runImpl() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/programs/server/TCPHandler.cpp:192:24 (clickhouse+0x64a5f41)
    #29 DB::TCPHandler::run() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/programs/server/TCPHandler.cpp:941:9 (clickhouse+0x64b1357)
    #30 Poco::Net::TCPServerConnection::start() /home/milovidov/ClickHouse/build_clang9_tsan/../contrib/poco/Net/src/TCPServerConnection.cpp:43:3 (clickhouse+0xccfe092)
    #31 Poco::Net::TCPServerDispatcher::run() /home/milovidov/ClickHouse/build_clang9_tsan/../contrib/poco/Net/src/TCPServerDispatcher.cpp:114:20 (clickhouse+0xccfe90a)
    #32 Poco::PooledThread::run() /home/milovidov/ClickHouse/build_clang9_tsan/../contrib/poco/Foundation/src/ThreadPool.cpp:214:14 (clickhouse+0xcdf0191)
    #33 Poco::(anonymous namespace)::RunnableHolder::run() /home/milovidov/ClickHouse/build_clang9_tsan/../contrib/poco/Foundation/src/Thread.cpp:43:11 (clickhouse+0xcdee6bf)
    #34 Poco::ThreadImpl::runnableEntry(void*) /home/milovidov/ClickHouse/build_clang9_tsan/../contrib/poco/Foundation/src/Thread_STD.cpp:139:27 (clickhouse+0xcdecf2a)
    #35 decltype(std::__1::forward<void* (*)(void*)>(fp)(std::__1::forward<Poco::ThreadImpl*>(fp0))) std::__1::__invoke<void* (*)(void*), Poco::ThreadImpl*>(void* (*&&)(void*), Poco::ThreadImpl*&&) /usr/local/bin/../include/c++/v1/type_traits:4410:1 (clickhouse+0xcdef06a)
    #36 void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*, 2ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*>&, std::__1::__tuple_indices<2ul>) /usr/local/bin/../include/c++/v1/thread:341 (clickhouse+0xcdef06a)
    #37 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*> >(void*) /usr/local/bin/../include/c++/v1/thread:351 (clickhouse+0xcdef06a)

  Mutex M440925190898554768 is already destroyed.

  Thread T57 'TCPHandler' (tid=264472, running) created by main thread at:
    #0 pthread_create /home/milovidov/ClickHouse/ci/workspace/llvm/llvm/projects/compiler-rt/lib/tsan/rtl/tsan_interceptors.cc:976 (clickhouse+0x6375d95)
    #1 std::__1::__libcpp_thread_create(unsigned long*, void* (*)(void*), void*) /usr/local/bin/../include/c++/v1/__threading_support:327:10 (clickhouse+0xcdeea67)
    #2 std::__1::thread::thread<void* (&)(void*), Poco::ThreadImpl*, void>(void* (&)(void*), Poco::ThreadImpl*&&) /usr/local/bin/../include/c++/v1/thread:367 (clickhouse+0xcdeea67)
    #3 Poco::ThreadImpl::startImpl(Poco::SharedPtr<Poco::Runnable, Poco::ReferenceCounter, Poco::ReleasePolicy<Poco::Runnable> >) /home/milovidov/ClickHouse/build_clang9_tsan/../contrib/poco/Foundation/src/Thread_STD.cpp:58:53 (clickhouse+0xcdec9f2)
    #4 Poco::Thread::start(Poco::Runnable&) /home/milovidov/ClickHouse/build_clang9_tsan/../contrib/poco/Foundation/src/Thread.cpp:116:2 (clickhouse+0xcdee0ac)
    #5 Poco::PooledThread::start(int) /home/milovidov/ClickHouse/build_clang9_tsan/../contrib/poco/Foundation/src/ThreadPool.cpp:88:10 (clickhouse+0xcdf0618)
    #6 Poco::ThreadPool::ThreadPool(int, int, int, int, Poco::ThreadPool::ThreadAffinityPolicy) /home/milovidov/ClickHouse/build_clang9_tsan/../contrib/poco/Foundation/src/ThreadPool.cpp:278 (clickhouse+0xcdf0618)
    #7 DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/programs/server/Server.cpp:545:26 (clickhouse+0x6423a60)
    #8 Poco::Util::Application::run() /home/milovidov/ClickHouse/build_clang9_tsan/../contrib/poco/Util/src/Application.cpp:335:8 (clickhouse+0xcd0fabd)
    #9 DB::Server::run() /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/programs/server/Server.cpp:138:25 (clickhouse+0x641d397)
    #10 Poco::Util::ServerApplication::run(int, char**) /home/milovidov/ClickHouse/build_clang9_tsan/../contrib/poco/Util/src/ServerApplication.cpp:618:9 (clickhouse+0xcd2cda8)
    #11 mainEntryClickHouseServer(int, char**) /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/programs/server/Server.cpp:844:20 (clickhouse+0x642d2f3)
    #12 main /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/programs/main.cpp:174:12 (clickhouse+0x641c6f2)

SUMMARY: ThreadSanitizer: destroy of a locked mutex /home/milovidov/ClickHouse/build_clang9_tsan/../dbms/src/Common/RWLock.h:28:7 in DB::RWLockImpl::~RWLockImpl()
```