### PR TITLE
Add way to launch container as custom user

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update \
         /tmp/* \
     && apt-get clean
 
-ADD https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64 /bin/gosu
+ADD https://github.com/tianon/gosu/releases/download/$gosu_ver/gosu-amd64 /bin/gosu
 
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8

--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -33,6 +33,13 @@ ClickHouse configuration represented with a file "config.xml" ([documentation](h
 $ docker run -d --name some-clickhouse-server --ulimit nofile=262144:262144 -v /path/to/your/config.xml:/etc/clickhouse-server/config.xml yandex/clickhouse-server
 ```
 
+### Start server as custom user
+```
+# $(pwd)/data/clickhouse should exist and be owned by current user
+$ docker run --rm --user ${UID}:${GID} --name some-clickhouse-server --ulimit nofile=262144:262144 -v "$(pwd)/data/clickhouse:/var/log/clickhouse-server" -v "$(pwd)/data/clickhouse:/var/lib/clickhouse" yandex/clickhouse-server
+```
+When you use the image with mounting local directories inside you probably would like to not mess your directory tree with files owner and permissions. Then you could use `--user` argument. In this case, you should mount every necessary directory (`/var/lib/clickhouse` and `/var/log/clickhouse-server`) inside the container. Otherwise, image will complain and not start.
+
 ## How to extend this image
 
 If you would like to do additional initialization in an image derived from this one, add one or more `*.sql`, `*.sql.gz`, or `*.sh` scripts under `/docker-entrypoint-initdb.d`. After the entrypoint calls `initdb` it will run any `*.sql` files, run any executable `*.sh` scripts, and source any non-executable `*.sh` scripts found in that directory to do further initialization before starting the service.

--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -2,8 +2,15 @@
 
 # set some vars
 CLICKHOUSE_CONFIG="${CLICKHOUSE_CONFIG:-/etc/clickhouse-server/config.xml}"
-USER="$(id -u clickhouse)"
-GROUP="$(id -g clickhouse)"
+if [ x"$UID" == x0 ]; then
+    USER="$(id -u clickhouse)"
+    GROUP="$(id -g clickhouse)"
+    gosu="gosu $USER:$GROUP"
+else
+    USER="$(id -u)"
+    GROUP="$(id -g)"
+    gosu=""
+fi
 
 # port is needed to check if clickhouse-server is ready for connections
 HTTP_PORT="$(clickhouse extract-from-config --config-file $CLICKHOUSE_CONFIG --key=http_port)"
@@ -18,28 +25,32 @@ ERROR_LOG_PATH="$(clickhouse extract-from-config --config-file $CLICKHOUSE_CONFI
 ERROR_LOG_DIR="$(dirname $ERROR_LOG_PATH || true)"
 FORMAT_SCHEMA_PATH="$(clickhouse extract-from-config --config-file $CLICKHOUSE_CONFIG --key=format_schema_path || true)"
 
-# ensure directories exist
-mkdir -p \
-    "$DATA_DIR" \
-    "$ERROR_LOG_DIR" \
-    "$LOG_DIR" \
-    "$TMP_DIR" \
-    "$USER_PATH" \
-    "$FORMAT_SCHEMA_PATH"
+for dir in "$DATA_DIR" \
+  "$ERROR_LOG_DIR" \
+  "$LOG_DIR" \
+  "$TMP_DIR" \
+  "$USER_PATH" \
+  "$FORMAT_SCHEMA_PATH"
+do
+    # ensure directories exist
+    if ! mkdir -p "$dir"; then
+        echo "Couldn't create necessary directory: $dir"
+        exit 1
+    fi
 
-if [ "$CLICKHOUSE_DO_NOT_CHOWN" != "1" ]; then
-    # ensure proper directories permissions
-    chown -R $USER:$GROUP \
-        "$DATA_DIR" \
-        "$ERROR_LOG_DIR" \
-        "$LOG_DIR" \
-        "$TMP_DIR" \
-        "$USER_PATH" \
-        "$FORMAT_SCHEMA_PATH"
-fi
+    if [ x"$UID" == x0 ] && [ "$CLICKHOUSE_DO_NOT_CHOWN" != "1" ]; then
+        # ensure proper directories permissions
+        chown -R "$USER:$GROUP" "$dir"
+    elif [ "$(stat -c %u "$dir")" != "$USER" ]; then
+        echo "Necessary directory '$dir' isn't owned by user with id '$USER'"
+        exit 1
+    fi
+done
+
+
 
 if [ -n "$(ls /docker-entrypoint-initdb.d/)" ]; then
-    gosu clickhouse /usr/bin/clickhouse-server --config-file=$CLICKHOUSE_CONFIG &
+    $gosu /usr/bin/clickhouse-server --config-file=$CLICKHOUSE_CONFIG &
     pid="$!"
 
     # check if clickhouse is ready to accept connections
@@ -77,7 +88,7 @@ fi
 
 # if no args passed to `docker run` or first argument start with `--`, then the user is passing clickhouse-server arguments
 if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
-    exec gosu clickhouse /usr/bin/clickhouse-server --config-file=$CLICKHOUSE_CONFIG "$@"
+    exec $gosu /usr/bin/clickhouse-server --config-file=$CLICKHOUSE_CONFIG "$@"
 fi
 
 # Otherwise, we assume the user want to run his own process, for example a `bash` shell to explore this image


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Add a way to launch clickhouse-server image from a custom user

Detailed description (optional):
Currently, clickhouse-server inside a docker container is launched as `clickhouse` user and in case of using a persistent directory, you always have a mess, especially in the home directory. This PR implements a way to have persistent clickhouse data on disk with proper ownership and permissions.