### PR TITLE
Rename insert_sample_with_metadata setting

### DIFF
--- a/dbms/src/Core/Settings.h
+++ b/dbms/src/Core/Settings.h
@@ -127,7 +127,6 @@ struct Settings
     M(SettingUInt64, max_concurrent_queries_for_user, 0, "The maximum number of concurrent requests per user.") \
     \
     M(SettingBool, insert_deduplicate, true, "For INSERT queries in the replicated table, specifies that deduplication of insertings blocks should be preformed") \
-    M(SettingBool, insert_sample_with_metadata, false, "For INSERT queries, specifies that the server need to send metadata about column defaults to the client. This will be used to calculate default expressions.") \
     \
     M(SettingUInt64, insert_quorum, 0, "For INSERT queries in the replicated table, wait writing for the specified number of replicas and linearize the addition of the data. 0 - disabled.") \
     M(SettingMilliseconds, insert_quorum_timeout, 600000, "") \
@@ -153,6 +152,7 @@ struct Settings
     \
     M(SettingBool, input_format_skip_unknown_fields, false, "Skip columns with unknown names from input data (it works for JSONEachRow and TSKV formats).") \
     M(SettingBool, input_format_import_nested_json, false, "Map nested JSON data to nested tables (it works for JSONEachRow format).") \
+    M(SettingBool, input_format_defaults_for_omitted_fields, false, "For input data calculate default expressions for omitted fields (it works for JSONEachRow format).") \
     \
     M(SettingBool, input_format_values_interpret_expressions, true, "For Values format: if field could not be parsed by streaming parser, run SQL parser and try to interpret it as SQL expression.") \
     \

--- a/dbms/src/Storages/ColumnsDescription.cpp
+++ b/dbms/src/Storages/ColumnsDescription.cpp
@@ -427,7 +427,7 @@ ColumnsDescription ColumnsDescription::parse(const String & str)
 
 const ColumnsDescription * ColumnsDescription::loadFromContext(const Context & context, const String & db, const String & table)
 {
-    if (context.getSettingsRef().insert_sample_with_metadata)
+    if (context.getSettingsRef().input_format_defaults_for_omitted_fields)
     {
         if (context.isTableExist(db, table))
         {

--- a/dbms/tests/queries/0_stateless/00760_insert_json_with_defaults.sql
+++ b/dbms/tests/queries/0_stateless/00760_insert_json_with_defaults.sql
@@ -1,4 +1,4 @@
-SET insert_sample_with_metadata=1;
+SET input_format_defaults_for_omitted_fields=1;
 
 CREATE DATABASE IF NOT EXISTS test;
 DROP TABLE IF EXISTS test.defaults;

--- a/dbms/tests/queries/0_stateless/00851_http_insert_json_defaults.sh
+++ b/dbms/tests/queries/0_stateless/00851_http_insert_json_defaults.sh
@@ -6,10 +6,10 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 $CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS test.defaults"
 $CLICKHOUSE_CLIENT --query="CREATE TABLE test.defaults (x UInt32, y UInt32, a DEFAULT x + y, b Float32 DEFAULT log(1 + x + y), c UInt32 DEFAULT 42, e MATERIALIZED x + y, f ALIAS x + y) ENGINE = Memory"
 
-echo -ne '{"x":1, "y":1}\n' | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?query=INSERT%20INTO%20test.defaults%20FORMAT%20JSONEachRow%20SETTINGS%20insert_sample_with_metadata=1" --data-binary @-
-echo -ne '{"x":2, "y":2, "c":2}\n' | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?query=INSERT+INTO+test.defaults+FORMAT+JSONEachRow+SETTINGS+insert_sample_with_metadata=1" --data-binary @-
-echo -ne '{"x":3, "y":3, "a":3, "b":3, "c":3}\n' | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?query=INSERT+INTO+test.defaults+FORMAT+JSONEachRow+SETTINGS+insert_sample_with_metadata=1" --data-binary @-
-echo -ne '{"x":4} {"y":5, "c":5} {"a":6, "b":6, "c":6}\n' | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?query=INSERT+INTO+test.defaults+FORMAT+JSONEachRow+SETTINGS+insert_sample_with_metadata=1" --data-binary @-
+echo -ne '{"x":1, "y":1}\n' | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?query=INSERT%20INTO%20test.defaults%20FORMAT%20JSONEachRow%20SETTINGS%20input_format_defaults_for_omitted_fields=1" --data-binary @-
+echo -ne '{"x":2, "y":2, "c":2}\n' | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?query=INSERT+INTO+test.defaults+FORMAT+JSONEachRow+SETTINGS+input_format_defaults_for_omitted_fields=1" --data-binary @-
+echo -ne '{"x":3, "y":3, "a":3, "b":3, "c":3}\n' | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?query=INSERT+INTO+test.defaults+FORMAT+JSONEachRow+SETTINGS+input_format_defaults_for_omitted_fields=1" --data-binary @-
+echo -ne '{"x":4} {"y":5, "c":5} {"a":6, "b":6, "c":6}\n' | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?query=INSERT+INTO+test.defaults+FORMAT+JSONEachRow+SETTINGS+input_format_defaults_for_omitted_fields=1" --data-binary @-
 
 $CLICKHOUSE_CLIENT --query="SELECT * FROM test.defaults ORDER BY x, y FORMAT JSONEachRow"
 $CLICKHOUSE_CLIENT --query="DROP TABLE test.defaults"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Backward Incompatible Change

Short description (up to few sentences):
Rename setting 'insert_sample_with_metadata' to 'setting input_format_defaults_for_omitted_fields'.

Detailed description (optional):
New setting name describes usage scenario, not implementation details as old one does. User should set it for formats that allow omitted fields to set DEFAULT value for these fields from table schema.