### PR TITLE
Recheck parts in ReplicatedMergeTreeAlterThread in case of error

### DIFF
--- a/dbms/src/Storages/MergeTree/ReplicatedMergeTreeAlterThread.cpp
+++ b/dbms/src/Storages/MergeTree/ReplicatedMergeTreeAlterThread.cpp
@@ -33,8 +33,6 @@ ReplicatedMergeTreeAlterThread::ReplicatedMergeTreeAlterThread(StorageReplicated
 
 void ReplicatedMergeTreeAlterThread::run()
 {
-    bool force_recheck_parts = true;
-
     try
     {
         /** We have a description of columns in ZooKeeper, common for all replicas (Example: /clickhouse/tables/02-06/visits/columns),

--- a/dbms/src/Storages/MergeTree/ReplicatedMergeTreeAlterThread.h
+++ b/dbms/src/Storages/MergeTree/ReplicatedMergeTreeAlterThread.h
@@ -36,6 +36,7 @@ private:
     String log_name;
     Logger * log;
     BackgroundSchedulePool::TaskHolder task;
+    bool force_recheck_parts = true;
 };
 
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fix recheck parts in ReplicatedMergeTreeAlterThread in case of error.