### PR TITLE
Fix crash when distributed modify order by

### DIFF
--- a/dbms/src/Storages/AlterCommands.cpp
+++ b/dbms/src/Storages/AlterCommands.cpp
@@ -315,7 +315,7 @@ void AlterCommand::apply(ColumnsDescription & columns_description, IndicesDescri
     }
     else if (type == MODIFY_ORDER_BY)
     {
-        if (!primary_key_ast)
+        if (!primary_key_ast && order_by_ast)
         {
             /// Primary and sorting key become independent after this ALTER so we have to
             /// save the old ORDER BY expression as the new primary key.

--- a/dbms/tests/queries/0_stateless/00910_crash_when_distributed_modify_order_by.sql
+++ b/dbms/tests/queries/0_stateless/00910_crash_when_distributed_modify_order_by.sql
@@ -3,3 +3,5 @@ DROP TABLE IF EXISTS test.union2;
 CREATE TABLE test.union1 ( date Date, a Int32, b Int32, c Int32, d Int32) ENGINE = MergeTree(date, (a, date), 8192);
 CREATE TABLE test.union2 ( date Date, a Int32, b Int32, c Int32, d Int32) ENGINE = Distributed(test_shard_localhost, 'test', 'union1');
 ALTER TABLE test.union2 MODIFY ORDER BY a; -- { serverError 48 }
+DROP TABLE test.union1;
+DROP TABLE test.union2;

--- a/dbms/tests/queries/0_stateless/00910_crash_when_distributed_modify_order_by.sql
+++ b/dbms/tests/queries/0_stateless/00910_crash_when_distributed_modify_order_by.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS test.union1;
+DROP TABLE IF EXISTS test.union2;
+CREATE TABLE test.union1 ( date Date, a Int32, b Int32, c Int32, d Int32) ENGINE = MergeTree(date, (a, date), 8192);
+CREATE TABLE test.union2 ( date Date, a Int32, b Int32, c Int32, d Int32) ENGINE = Distributed(test_shard_localhost, 'test', 'union1');
+ALTER TABLE test.union2 MODIFY ORDER BY a; -- { serverError 48 }


### PR DESCRIPTION
Did not determine if order_by_ast is empty.
If it is null, it will clone a null pointer and cause server crash.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fix crash in `ALTER ... MODIFY ORDER BY` on Distributed table.
