### PR TITLE
fix crash when predicate optimzer & join on

### DIFF
--- a/dbms/src/Interpreters/PredicateExpressionsOptimizer.cpp
+++ b/dbms/src/Interpreters/PredicateExpressionsOptimizer.cpp
@@ -340,8 +340,9 @@ ASTs PredicateExpressionsOptimizer::getSelectQueryProjectionColumns(ASTPtr & ast
     std::vector<DatabaseAndTableWithAlias> tables = getDatabaseAndTables(*select_query, context.getCurrentDatabase());
 
     /// TODO: get tables from evaluateAsterisk instead of tablesOnly() to extract asterisks in general way
+    NameSet source_columns;
     std::vector<TableWithColumnNames> tables_with_columns = TranslateQualifiedNamesVisitor::Data::tablesOnly(tables);
-    TranslateQualifiedNamesVisitor::Data qn_visitor_data({}, tables_with_columns, false);
+    TranslateQualifiedNamesVisitor::Data qn_visitor_data(source_columns, tables_with_columns, false);
     TranslateQualifiedNamesVisitor(qn_visitor_data).visit(ast);
 
     QueryAliasesVisitor::Data query_aliases_data{aliases};

--- a/dbms/src/Interpreters/TranslateQualifiedNamesVisitor.cpp
+++ b/dbms/src/Interpreters/TranslateQualifiedNamesVisitor.cpp
@@ -16,6 +16,7 @@
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTFunction.h>
+#include <iostream>
 
 
 namespace DB
@@ -74,7 +75,7 @@ void TranslateQualifiedNamesMatcher::visit(ASTIdentifier & identifier, ASTPtr &,
             IdentifierSemantic::setMembership(identifier, best_table_pos + 1);
 
         /// In case if column from the joined table are in source columns, change it's name to qualified.
-        if (best_table_pos && !data.source_columns.empty() && data.source_columns.count(identifier.shortName()))
+        if (best_table_pos && data.source_columns.count(identifier.shortName()))
             IdentifierSemantic::setNeedLongName(identifier, true);
         if (!data.tables.empty())
             IdentifierSemantic::setColumnNormalName(identifier, data.tables[best_table_pos].first);

--- a/dbms/src/Interpreters/TranslateQualifiedNamesVisitor.cpp
+++ b/dbms/src/Interpreters/TranslateQualifiedNamesVisitor.cpp
@@ -74,7 +74,7 @@ void TranslateQualifiedNamesMatcher::visit(ASTIdentifier & identifier, ASTPtr &,
             IdentifierSemantic::setMembership(identifier, best_table_pos + 1);
 
         /// In case if column from the joined table are in source columns, change it's name to qualified.
-        if (best_table_pos && data.source_columns.count(identifier.shortName()))
+        if (best_table_pos && !data.source_columns.empty() && data.source_columns.count(identifier.shortName()))
             IdentifierSemantic::setNeedLongName(identifier, true);
         if (!data.tables.empty())
             IdentifierSemantic::setColumnNormalName(identifier, data.tables[best_table_pos].first);

--- a/dbms/tests/queries/0_stateless/00597_push_down_predicate.reference
+++ b/dbms/tests/queries/0_stateless/00597_push_down_predicate.reference
@@ -53,3 +53,5 @@ SELECT \n    date, \n    id, \n    name, \n    value, \n    b.date, \n    b.name
 2000-01-01	1	test string 1	1	2000-01-01	test string 1	1
 SELECT \n    id, \n    date, \n    name, \n    value\nFROM \n(\n    SELECT \n        toInt8(1) AS id, \n        toDate(\'2000-01-01\') AS date\n    FROM system.numbers \n    LIMIT 1\n) \nANY LEFT JOIN \n(\n    SELECT *\n    FROM test.test \n    WHERE date = toDate(\'2000-01-01\')\n) AS b USING (date, id)\nWHERE b.date = toDate(\'2000-01-01\')
 1	2000-01-01	test string 1	1
+SELECT \n    date, \n    id, \n    name, \n    value, \n    `b.date`, \n    `b.id`, \n    `b.name`, \n    `b.value`\nFROM \n(\n    SELECT \n        date, \n        id, \n        name, \n        value, \n        b.date, \n        b.id, \n        b.name, \n        b.value\n    FROM \n    (\n        SELECT \n            date, \n            id, \n            name, \n            value\n        FROM test.test \n        WHERE id = 1\n    ) AS a \n    ANY LEFT JOIN \n    (\n        SELECT *\n        FROM test.test \n    ) AS b ON id = b.id\n    WHERE id = 1\n) \nWHERE id = 1
+2000-01-01	1	test string 1	1	2000-01-01	1	test string 1	1

--- a/dbms/tests/queries/0_stateless/00597_push_down_predicate.sql
+++ b/dbms/tests/queries/0_stateless/00597_push_down_predicate.sql
@@ -108,5 +108,8 @@ SELECT * FROM (SELECT * FROM test.test) ANY LEFT JOIN (SELECT * FROM test.test) 
 ANALYZE SELECT * FROM (SELECT toInt8(1) AS id, toDate('2000-01-01') AS date FROM system.numbers LIMIT 1) ANY LEFT JOIN (SELECT * FROM test.test) AS b USING date, id WHERE b.date = toDate('2000-01-01');
 SELECT * FROM (SELECT toInt8(1) AS id, toDate('2000-01-01') AS date FROM system.numbers LIMIT 1) ANY LEFT JOIN (SELECT * FROM test.test) AS b USING date, id WHERE b.date = toDate('2000-01-01');
 
+ANALYZE SELECT * FROM (SELECT * FROM (SELECT * FROM test.test) AS a ANY LEFT JOIN (SELECT * FROM test.test) AS b  ON  a.id = b.id) WHERE id = 1;
+SELECT * FROM (SELECT * FROM (SELECT * FROM test.test) AS a ANY LEFT JOIN (SELECT * FROM test.test) AS b  ON  a.id = b.id) WHERE id = 1;
+
 DROP TABLE IF EXISTS test.test;
 DROP TABLE IF EXISTS test.test_view;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
https://github.com/yandex/ClickHouse/pull/3588#issuecomment-476110720