### PR TITLE
Fixed TSan report in fetchPart

### DIFF
--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -611,7 +611,7 @@ String MergeTreeData::MergingParams::getModeName() const
 
 Int64 MergeTreeData::getMaxBlockNumber()
 {
-    std::lock_guard lock_all(data_parts_mutex);
+    auto lock = lockParts();
 
     Int64 max_block_num = 0;
     for (const DataPartPtr & part : data_parts_by_info)
@@ -640,7 +640,7 @@ void MergeTreeData::loadDataParts(bool skip_sanity_checks)
     DataPartsVector broken_parts_to_detach;
     size_t suspicious_broken_parts = 0;
 
-    std::lock_guard lock(data_parts_mutex);
+    auto lock = lockParts();
     data_parts_indexes.clear();
 
     for (const String & file_name : part_file_names)
@@ -866,7 +866,7 @@ MergeTreeData::DataPartsVector MergeTreeData::grabOldParts()
     std::vector<DataPartIteratorByStateAndInfo> parts_to_delete;
 
     {
-        std::lock_guard lock_parts(data_parts_mutex);
+        auto parts_lock = lockParts();
 
         auto outdated_parts_range = getDataPartsStateRange(DataPartState::Outdated);
         for (auto it = outdated_parts_range.begin(); it != outdated_parts_range.end(); ++it)
@@ -900,7 +900,7 @@ MergeTreeData::DataPartsVector MergeTreeData::grabOldParts()
 
 void MergeTreeData::rollbackDeletingParts(const MergeTreeData::DataPartsVector & parts)
 {
-    std::lock_guard lock(data_parts_mutex);
+    auto lock = lockParts();
     for (auto & part : parts)
     {
         /// We should modify it under data_parts_mutex
@@ -912,7 +912,7 @@ void MergeTreeData::rollbackDeletingParts(const MergeTreeData::DataPartsVector &
 void MergeTreeData::removePartsFinally(const MergeTreeData::DataPartsVector & parts)
 {
     {
-        std::lock_guard lock(data_parts_mutex);
+        auto lock = lockParts();
 
         /// TODO: use data_parts iterators instead of pointers
         for (auto & part : parts)
@@ -980,7 +980,7 @@ void MergeTreeData::dropAllData()
 {
     LOG_TRACE(log, "dropAllData: waiting for locks.");
 
-    std::lock_guard lock(data_parts_mutex);
+    auto lock = lockParts();
 
     LOG_TRACE(log, "dropAllData: removing data from memory.");
 
@@ -1717,7 +1717,7 @@ MergeTreeData::DataPartsVector MergeTreeData::renameTempPartAndReplace(
 
     DataPartsVector covered_parts;
     {
-        std::unique_lock lock(data_parts_mutex);
+        auto lock = lockParts();
         renameTempPartAndReplace(part, increment, out_transaction, lock, &covered_parts);
     }
     return covered_parts;
@@ -1814,7 +1814,7 @@ restore_covered)
 {
     LOG_INFO(log, "Renaming " << part_to_detach->relative_path << " to " << prefix << part_to_detach->name << " and forgiving it.");
 
-    auto data_parts_lock = lockParts();
+    auto lock = lockParts();
 
     auto it_part = data_parts_by_info.find(part_to_detach->info);
     if (it_part == data_parts_by_info.end())
@@ -1931,7 +1931,7 @@ void MergeTreeData::tryRemovePartImmediately(DataPartPtr && part)
 {
     DataPartPtr part_to_delete;
     {
-        std::lock_guard lock_parts(data_parts_mutex);
+        auto lock = lockParts();
 
         LOG_TRACE(log, "Trying to immediately remove part " << part->getNameWithState());
 
@@ -1967,7 +1967,7 @@ size_t MergeTreeData::getTotalActiveSizeInBytes() const
 {
     size_t res = 0;
     {
-        std::lock_guard lock(data_parts_mutex);
+        auto lock = lockParts();
 
         for (auto & part : getDataPartsStateRange(DataPartState::Committed))
             res += part->bytes_on_disk;
@@ -1979,7 +1979,7 @@ size_t MergeTreeData::getTotalActiveSizeInBytes() const
 
 size_t MergeTreeData::getMaxPartsCountForPartition() const
 {
-    std::lock_guard lock(data_parts_mutex);
+    auto lock = lockParts();
 
     size_t res = 0;
     size_t cur_count = 0;
@@ -2006,7 +2006,7 @@ size_t MergeTreeData::getMaxPartsCountForPartition() const
 
 std::optional<Int64> MergeTreeData::getMinPartDataVersion() const
 {
-    std::lock_guard lock(data_parts_mutex);
+    auto lock = lockParts();
 
     std::optional<Int64> result;
     for (const DataPartPtr & part : getDataPartsStateRange(DataPartState::Committed))
@@ -2088,8 +2088,8 @@ MergeTreeData::DataPartPtr MergeTreeData::getActiveContainingPart(
 
 MergeTreeData::DataPartPtr MergeTreeData::getActiveContainingPart(const MergeTreePartInfo & part_info)
 {
-    DataPartsLock data_parts_lock(data_parts_mutex);
-    return getActiveContainingPart(part_info, DataPartState::Committed, data_parts_lock);
+    auto lock = lockParts();
+    return getActiveContainingPart(part_info, DataPartState::Committed, lock);
 }
 
 MergeTreeData::DataPartPtr MergeTreeData::getActiveContainingPart(const String & part_name)
@@ -2103,7 +2103,7 @@ MergeTreeData::DataPartsVector MergeTreeData::getDataPartsVectorInPartition(Merg
 {
     DataPartStateAndPartitionID state_with_partition{state, partition_id};
 
-    std::lock_guard lock(data_parts_mutex);
+    auto lock = lockParts();
     return DataPartsVector(
         data_parts_by_state_and_info.lower_bound(state_with_partition),
         data_parts_by_state_and_info.upper_bound(state_with_partition));
@@ -2112,7 +2112,7 @@ MergeTreeData::DataPartsVector MergeTreeData::getDataPartsVectorInPartition(Merg
 
 MergeTreeData::DataPartPtr MergeTreeData::getPartIfExists(const MergeTreePartInfo & part_info, const MergeTreeData::DataPartStates & valid_states)
 {
-    std::lock_guard lock(data_parts_mutex);
+    auto lock = lockParts();
 
     auto it = data_parts_by_info.find(part_info);
     if (it == data_parts_by_info.end())
@@ -2331,7 +2331,7 @@ String MergeTreeData::getPartitionIDFromQuery(const ASTPtr & ast, const Context 
     String partition_id = partition.getID(*this);
 
     {
-        DataPartsLock data_parts_lock(data_parts_mutex);
+        auto data_parts_lock = lockParts();
         DataPartPtr existing_part_in_partition = getAnyPartInPartition(partition_id, data_parts_lock);
         if (existing_part_in_partition && existing_part_in_partition->partition.value != partition.value)
         {
@@ -2352,7 +2352,7 @@ MergeTreeData::DataPartsVector MergeTreeData::getDataPartsVector(const DataPartS
     DataPartsVector res;
     DataPartsVector buf;
     {
-        std::lock_guard lock(data_parts_mutex);
+        auto lock = lockParts();
 
         for (auto state : affordable_states)
         {
@@ -2378,7 +2378,7 @@ MergeTreeData::DataPartsVector MergeTreeData::getAllDataPartsVector(MergeTreeDat
 {
     DataPartsVector res;
     {
-        std::lock_guard lock(data_parts_mutex);
+        auto lock = lockParts();
         res.assign(data_parts_by_info.begin(), data_parts_by_info.end());
 
         if (out_states != nullptr)
@@ -2396,7 +2396,7 @@ MergeTreeData::DataParts MergeTreeData::getDataParts(const DataPartStates & affo
 {
     DataParts res;
     {
-        std::lock_guard lock(data_parts_mutex);
+        auto lock = lockParts();
         for (auto state : affordable_states)
         {
             auto range = getDataPartsStateRange(state);

--- a/dbms/src/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.h
@@ -538,8 +538,7 @@ public:
 
     size_t getColumnCompressedSize(const std::string & name) const
     {
-        std::lock_guard lock{data_parts_mutex};
-
+        auto lock = lockParts();
         const auto it = column_sizes.find(name);
         return it == std::end(column_sizes) ? 0 : it->second.data_compressed;
     }
@@ -547,14 +546,14 @@ public:
     using ColumnSizeByName = std::unordered_map<std::string, DataPart::ColumnSize>;
     ColumnSizeByName getColumnSizes() const
     {
-        std::lock_guard lock{data_parts_mutex};
+        auto lock = lockParts();
         return column_sizes;
     }
 
     /// Calculates column sizes in compressed form for the current state of data_parts.
     void recalculateColumnSizes()
     {
-        std::lock_guard lock{data_parts_mutex};
+        auto lock = lockParts();
         calculateColumnSizesImpl();
     }
 

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -2655,7 +2655,7 @@ bool StorageReplicatedMergeTree::fetchPart(const String & part_name, const Strin
 
     if (auto part = data.getPartIfExists(part_info, {MergeTreeDataPart::State::Outdated, MergeTreeDataPart::State::Deleting}))
     {
-        LOG_DEBUG(log, "Part " << part->getNameWithState() << " should be deleted after previous attempt before fetch");
+        LOG_DEBUG(log, "Part " << part->name << " should be deleted after previous attempt before fetch");
         /// Force immediate parts cleanup to delete the part that was left from the previous fetch attempt.
         cleanup_thread.wakeup();
         return false;


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fixed data race when fetching data part that is already obsolete.

Details:
```
==================
WARNING: ThreadSanitizer: data race (pid=242)
  Write of size 4 at 0x7b500004c8b4 by thread T44 (mutexes: write M888189031972340064, write M891004194055218936, write M722682157982246560):
    #0 DB::MergeTreeData::getStateModifier(DB::MergeTreeDataPart::State)::'lambda'(std::__1::shared_ptr<DB::MergeTreeDataPart const> const&)::operator()(std::__1::shared_ptr<DB::MergeTreeDataPart const> const&) const /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/MergeTreeData.h:704:65 (clickhouse+0xcb37e0e)
    #1 bool boost::multi_index::multi_index_container<std::__1::shared_ptr<DB::MergeTreeDataPart const>, boost::multi_index::indexed_by<boost::multi_index::ordered_unique<boost::multi_index::tag<DB::MergeTreeData::TagByInfo, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, boost::multi_index::global_fun<std::__1::shared_ptr<DB::MergeTreeDataPart const> const&, DB::MergeTreePartInfo const&, &(DB::MergeTreeData::dataPartPtrToInfo(std::__1::shared_ptr<DB::MergeTreeDataPart const> const&))>, mpl_::na>, boost::multi_index::ordered_unique<boost::multi_index::tag<DB::MergeTreeData::TagByStateAndInfo, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, boost::multi_index::global_fun<std::__1::shared_ptr<DB::MergeTreeDataPart const> const&, DB::MergeTreeData::DataPartStateAndInfo, &(DB::MergeTreeData::dataPartPtrToStateAndInfo(std::__1::shared_ptr<DB::MergeTreeDataPart const> const&))>, DB::MergeTreeData::LessStateDataPart>, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, std::__1::allocator<std::__1::shared_ptr<DB::MergeTreeDataPart const> > >::modify_<DB::MergeTreeData::getStateModifier(DB::MergeTreeDataPart::State)::'lambda'(std::__1::shared_ptr<DB::MergeTreeDataPart const> const&)>(DB::MergeTreeData::getStateModifier(DB::MergeTreeDataPart::State)::'lambda'(std::__1::shared_ptr<DB::MergeTreeDataPart const> const&)&, boost::multi_index::detail::ordered_index_node<boost::multi_index::detail::null_augment_policy, boost::multi_index::detail::ordered_index_node<boost::multi_index::detail::null_augment_policy, boost::multi_index::detail::index_node_base<std::__1::shared_ptr<DB::MergeTreeDataPart const>, std::__1::allocator<std::__1::shared_ptr<DB::MergeTreeDataPart const> > > > >*) /build/obj-x86_64-linux-gnu/../contrib/boost/boost/multi_index_container.hpp:841 (clickhouse+0xcb37e0e)
    #2 bool boost::multi_index::detail::index_base<std::__1::shared_ptr<DB::MergeTreeDataPart const>, boost::multi_index::indexed_by<boost::multi_index::ordered_unique<boost::multi_index::tag<DB::MergeTreeData::TagByInfo, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, boost::multi_index::global_fun<std::__1::shared_ptr<DB::MergeTreeDataPart const> const&, DB::MergeTreePartInfo const&, &(DB::MergeTreeData::dataPartPtrToInfo(std::__1::shared_ptr<DB::MergeTreeDataPart const> const&))>, mpl_::na>, boost::multi_index::ordered_unique<boost::multi_index::tag<DB::MergeTreeData::TagByStateAndInfo, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, boost::multi_index::global_fun<std::__1::shared_ptr<DB::MergeTreeDataPart const> const&, DB::MergeTreeData::DataPartStateAndInfo, &(DB::MergeTreeData::dataPartPtrToStateAndInfo(std::__1::shared_ptr<DB::MergeTreeDataPart const> const&))>, DB::MergeTreeData::LessStateDataPart>, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, std::__1::allocator<std::__1::shared_ptr<DB::MergeTreeDataPart const> > >::final_modify_<DB::MergeTreeData::getStateModifier(DB::MergeTreeDataPart::State)::'lambda'(std::__1::shared_ptr<DB::MergeTreeDataPart const> const&)>(DB::MergeTreeData::getStateModifier(DB::MergeTreeDataPart::State)::'lambda'(std::__1::shared_ptr<DB::MergeTreeDataPart const> const&)&, boost::multi_index::detail::ordered_index_node<boost::multi_index::detail::null_augment_policy, boost::multi_index::detail::ordered_index_node<boost::multi_index::detail::null_augment_policy, boost::multi_index::detail::index_node_base<std::__1::shared_ptr<DB::MergeTreeDataPart const>, std::__1::allocator<std::__1::shared_ptr<DB::MergeTreeDataPart const> > > > >*) /build/obj-x86_64-linux-gnu/../contrib/boost/boost/multi_index/detail/index_base.hpp:280:21 (clickhouse+0xcb346d7)
    #3 bool boost::multi_index::detail::ordered_index_impl<boost::multi_index::global_fun<std::__1::shared_ptr<DB::MergeTreeDataPart const> const&, DB::MergeTreeData::DataPartStateAndInfo, &(DB::MergeTreeData::dataPartPtrToStateAndInfo(std::__1::shared_ptr<DB::MergeTreeDataPart const> const&))>, DB::MergeTreeData::LessStateDataPart, boost::multi_index::detail::nth_layer<2, std::__1::shared_ptr<DB::MergeTreeDataPart const>, boost::multi_index::indexed_by<boost::multi_index::ordered_unique<boost::multi_index::tag<DB::MergeTreeData::TagByInfo, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, boost::multi_index::global_fun<std::__1::shared_ptr<DB::MergeTreeDataPart const> const&, DB::MergeTreePartInfo const&, &(DB::MergeTreeData::dataPartPtrToInfo(std::__1::shared_ptr<DB::MergeTreeDataPart const> const&))>, mpl_::na>, boost::multi_index::ordered_unique<boost::multi_index::tag<DB::MergeTreeData::TagByStateAndInfo, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, boost::multi_index::global_fun<std::__1::shared_ptr<DB::MergeTreeDataPart const> const&, DB::MergeTreeData::DataPartStateAndInfo, &(DB::MergeTreeData::dataPartPtrToStateAndInfo(std::__1::shared_ptr<DB::MergeTreeDataPart const> const&))>, DB::MergeTreeData::LessStateDataPart>, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, std::__1::allocator<std::__1::shared_ptr<DB::MergeTreeDataPart const> > >, boost::mpl::v_item<DB::MergeTreeData::TagByStateAndInfo, boost::mpl::vector0<mpl_::na>, 0>, boost::multi_index::detail::ordered_unique_tag, boost::multi_index::detail::null_augment_policy>::modify<DB::MergeTreeData::getStateModifier(DB::MergeTreeDataPart::State)::'lambda'(std::__1::shared_ptr<DB::MergeTreeDataPart const> const&)>(boost::multi_index::detail::bidir_node_iterator<boost::multi_index::detail::ordered_index_node<boost::multi_index::detail::null_augment_policy, boost::multi_index::detail::index_node_base<std::__1::shared_ptr<DB::MergeTreeDataPart const>, std::__1::allocator<std::__1::shared_ptr<DB::MergeTreeDataPart const> > > > >, DB::MergeTreeData::getStateModifier(DB::MergeTreeDataPart::State)::'lambda'(std::__1::shared_ptr<DB::MergeTreeDataPart const> const&)) /build/obj-x86_64-linux-gnu/../contrib/boost/boost/multi_index/detail/ord_index_impl.hpp:431 (clickhouse+0xcb346d7)
    #4 DB::MergeTreeData::modifyPartState(boost::multi_index::detail::bidir_node_iterator<boost::multi_index::detail::ordered_index_node<boost::multi_index::detail::null_augment_policy, boost::multi_index::detail::index_node_base<std::__1::shared_ptr<DB::MergeTreeDataPart const>, std::__1::allocator<std::__1::shared_ptr<DB::MergeTreeDataPart const> > > > >, DB::MergeTreeDataPart::State) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/MergeTreeData.h:709 (clickhouse+0xcb346d7)
    #5 DB::MergeTreeData::grabOldParts() /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/MergeTreeData.cpp:890:13 (clickhouse+0xcb132fb)
    #6 DB::StorageReplicatedMergeTree::clearOldPartsAndRemoveFromZK() /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageReplicatedMergeTree.cpp:4425:49 (clickhouse+0xca52505)
    #7 DB::ReplicatedMergeTreeCleanupThread::iterate() /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/ReplicatedMergeTreeCleanupThread.cpp:55:13 (clickhouse+0xcc2ba5f)
    #8 DB::ReplicatedMergeTreeCleanupThread::run() /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/ReplicatedMergeTreeCleanupThread.cpp:35 (clickhouse+0xcc2ba5f)
    #9 DB::ReplicatedMergeTreeCleanupThread::ReplicatedMergeTreeCleanupThread(DB::StorageReplicatedMergeTree&)::$_0::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/ReplicatedMergeTreeCleanupThread.cpp:25:82 (clickhouse+0xcc33b53)
    #10 decltype(std::__1::forward<DB::ReplicatedMergeTreeCleanupThread::ReplicatedMergeTreeCleanupThread(DB::StorageReplicatedMergeTree&)::$_0&>(fp)()) std::__1::__invoke<DB::ReplicatedMergeTreeCleanupThread::ReplicatedMergeTreeCleanupThread(DB::StorageReplicatedMergeTree&)::$_0&>(DB::ReplicatedMergeTreeCleanupThread::ReplicatedMergeTreeCleanupThread(DB::StorageReplicatedMergeTree&)::$_0&) /usr/include/c++/v1/type_traits:4482 (clickhouse+0xcc33b53)
    #11 void std::__1::__invoke_void_return_wrapper<void>::__call<DB::ReplicatedMergeTreeCleanupThread::ReplicatedMergeTreeCleanupThread(DB::StorageReplicatedMergeTree&)::$_0&>(DB::ReplicatedMergeTreeCleanupThread::ReplicatedMergeTreeCleanupThread(DB::StorageReplicatedMergeTree&)::$_0&) /usr/include/c++/v1/__functional_base:349 (clickhouse+0xcc33b53)
    #12 std::__1::__function::__func<DB::ReplicatedMergeTreeCleanupThread::ReplicatedMergeTreeCleanupThread(DB::StorageReplicatedMergeTree&)::$_0, std::__1::allocator<DB::ReplicatedMergeTreeCleanupThread::ReplicatedMergeTreeCleanupThread(DB::StorageReplicatedMergeTree&)::$_0>, void ()>::operator()() /usr/include/c++/v1/functional:1562 (clickhouse+0xcc33b53)
    #13 std::__1::function<void ()>::operator()() const /usr/include/c++/v1/functional:1916:12 (clickhouse+0xc387250)
    #14 DB::BackgroundSchedulePool::TaskInfo::execute() /build/obj-x86_64-linux-gnu/../dbms/src/Core/BackgroundSchedulePool.cpp:111 (clickhouse+0xc387250)
    #15 DB::TaskNotification::execute() /build/obj-x86_64-linux-gnu/../dbms/src/Core/BackgroundSchedulePool.cpp:27:28 (clickhouse+0xc389131)
    #16 DB::BackgroundSchedulePool::threadFunction() /build/obj-x86_64-linux-gnu/../dbms/src/Core/BackgroundSchedulePool.cpp:261 (clickhouse+0xc389131)
    #17 DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long)::$_1::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Core/BackgroundSchedulePool.cpp:164:48 (clickhouse+0xc389e05)
    #18 decltype(std::__1::forward<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long)::$_1 const&>(fp)()) std::__1::__invoke_constexpr<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long)::$_1 const&>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long)::$_1 const&) /usr/include/c++/v1/type_traits:4488 (clickhouse+0xc389e05)
    #19 decltype(auto) std::__1::__apply_tuple_impl<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long)::$_1 const&, std::__1::tuple<> const&>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long)::$_1 const&, std::__1::tuple<> const&, std::__1::__tuple_indices<>) /usr/include/c++/v1/tuple:1379 (clickhouse+0xc389e05)
    #20 decltype(auto) std::__1::apply<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long)::$_1 const&, std::__1::tuple<> const&>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long)::$_1 const&, std::__1::tuple<> const&) /usr/include/c++/v1/tuple:1388 (clickhouse+0xc389e05)
    #21 ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long)::$_1>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long)::$_1&&)::'lambda'()::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.h:147 (clickhouse+0xc389e05)
    #22 decltype(std::__1::forward<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long)::$_1>(fp)()) std::__1::__invoke<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long)::$_1>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long)::$_1&&)::'lambda'()&>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long)::$_1&&) /usr/include/c++/v1/type_traits:4482 (clickhouse+0xc389e05)
    #23 void std::__1::__invoke_void_return_wrapper<void>::__call<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long)::$_1>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long)::$_1&&)::'lambda'()&>(ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long)::$_1>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long)::$_1&&)::'lambda'()&) /usr/include/c++/v1/__functional_base:349 (clickhouse+0xc389e05)
    #24 std::__1::__function::__func<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long)::$_1>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long)::$_1&&)::'lambda'(), std::__1::allocator<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long)::$_1>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long)::$_1&&)::'lambda'()>, void ()>::operator()() /usr/include/c++/v1/functional:1562 (clickhouse+0xc389e05)
    #25 std::__1::function<void ()>::operator()() const /usr/include/c++/v1/functional:1916:12 (clickhouse+0x64eb176)
    #26 ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:169 (clickhouse+0x64eb176)
    #27 void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:65:73 (clickhouse+0x64eeaec)
    #28 decltype(std::__1::forward<void>(fp)()) std::__1::__invoke<void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(void&&) /usr/include/c++/v1/type_traits:4482 (clickhouse+0x64eeaec)
    #29 void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(std::__1::tuple<void, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>&, std::__1::__tuple_indices<>) /usr/include/c++/v1/thread:342 (clickhouse+0x64eeaec)
    #30 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()> >(void*) /usr/include/c++/v1/thread:352 (clickhouse+0x64eeaec)
    #31 <null> <null> (clickhouse+0x6435422)

  Previous read of size 4 at 0x7b500004c8b4 by thread T21:
    #0 DB::MergeTreeDataPart::stateString() const /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/MergeTreeDataPart.cpp:838:26 (clickhouse+0xcb81f41)
    #1 DB::MergeTreeDataPart::getNameWithState() const /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/MergeTreeDataPart.h:141:36 (clickhouse+0xca61e29)
    #2 DB::StorageReplicatedMergeTree::fetchPart(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, unsigned long) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageReplicatedMergeTree.cpp:2658:9 (clickhouse+0xca1f5da)
    #3 DB::StorageReplicatedMergeTree::executeFetch(DB::ReplicatedMergeTreeLogEntry&) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageReplicatedMergeTree.cpp:1392:18 (clickhouse+0xca1bbf5)
    #4 DB::StorageReplicatedMergeTree::executeLogEntry(DB::ReplicatedMergeTreeLogEntry&) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageReplicatedMergeTree.cpp:922:16 (clickhouse+0xca08d8f)
    #5 DB::StorageReplicatedMergeTree::queueTask()::$_16::operator()(std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&) const /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageReplicatedMergeTree.cpp:2098:20 (clickhouse+0xca5be82)
    #6 decltype(std::__1::forward<DB::StorageReplicatedMergeTree::queueTask()::$_16&>(fp)(std::__1::forward<std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&>(fp0))) std::__1::__invoke<DB::StorageReplicatedMergeTree::queueTask()::$_16&, std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&>(DB::StorageReplicatedMergeTree::queueTask()::$_16&, std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&) /usr/include/c++/v1/type_traits:4482 (clickhouse+0xca5be82)
    #7 bool std::__1::__invoke_void_return_wrapper<bool>::__call<DB::StorageReplicatedMergeTree::queueTask()::$_16&, std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&>(DB::StorageReplicatedMergeTree::queueTask()::$_16&, std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&) /usr/include/c++/v1/__functional_base:318 (clickhouse+0xca5be82)
    #8 std::__1::__function::__func<DB::StorageReplicatedMergeTree::queueTask()::$_16, std::__1::allocator<DB::StorageReplicatedMergeTree::queueTask()::$_16>, bool (std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&)>::operator()(std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&) /usr/include/c++/v1/functional:1562 (clickhouse+0xca5be82)
    #9 std::__1::function<bool (std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&)>::operator()(std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&) const /usr/include/c++/v1/functional:1916:12 (clickhouse+0xcc57a0e)
    #10 DB::ReplicatedMergeTreeQueue::processEntry(std::__1::function<std::__1::shared_ptr<zkutil::ZooKeeper> ()>, std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&, std::__1::function<bool (std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&)>) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp:1112 (clickhouse+0xcc57a0e)
    #11 DB::StorageReplicatedMergeTree::queueTask() /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageReplicatedMergeTree.cpp:2094:22 (clickhouse+0xca2ab9d)
    #12 DB::StorageReplicatedMergeTree::startup()::$_22::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageReplicatedMergeTree.cpp:2836:84 (clickhouse+0xca5e2a3)
    #13 decltype(std::__1::forward<DB::StorageReplicatedMergeTree::startup()::$_22&>(fp)()) std::__1::__invoke<DB::StorageReplicatedMergeTree::startup()::$_22&>(DB::StorageReplicatedMergeTree::startup()::$_22&) /usr/include/c++/v1/type_traits:4482 (clickhouse+0xca5e2a3)
    #14 DB::BackgroundProcessingPoolTaskResult std::__1::__invoke_void_return_wrapper<DB::BackgroundProcessingPoolTaskResult>::__call<DB::StorageReplicatedMergeTree::startup()::$_22&>(DB::StorageReplicatedMergeTree::startup()::$_22&) /usr/include/c++/v1/__functional_base:318 (clickhouse+0xca5e2a3)
    #15 std::__1::__function::__func<DB::StorageReplicatedMergeTree::startup()::$_22, std::__1::allocator<DB::StorageReplicatedMergeTree::startup()::$_22>, DB::BackgroundProcessingPoolTaskResult ()>::operator()() /usr/include/c++/v1/functional:1562 (clickhouse+0xca5e2a3)
    #16 std::__1::function<DB::BackgroundProcessingPoolTaskResult ()>::operator()() const /usr/include/c++/v1/functional:1916:12 (clickhouse+0xcad4a3b)
    #17 DB::BackgroundProcessingPool::threadFunction() /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/BackgroundProcessingPool.cpp:203 (clickhouse+0xcad4a3b)
    #18 DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/BackgroundProcessingPool.cpp:70:48 (clickhouse+0xcad5305)
    #19 decltype(std::__1::forward<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0 const&>(fp)()) std::__1::__invoke_constexpr<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0 const&>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0 const&) /usr/include/c++/v1/type_traits:4488 (clickhouse+0xcad5305)
    #20 decltype(auto) std::__1::__apply_tuple_impl<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0 const&, std::__1::tuple<> const&>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0 const&, std::__1::tuple<> const&, std::__1::__tuple_indices<>) /usr/include/c++/v1/tuple:1379 (clickhouse+0xcad5305)
    #21 decltype(auto) std::__1::apply<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0 const&, std::__1::tuple<> const&>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0 const&, std::__1::tuple<> const&) /usr/include/c++/v1/tuple:1388 (clickhouse+0xcad5305)
    #22 ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0&&)::'lambda'()::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.h:147 (clickhouse+0xcad5305)
    #23 decltype(std::__1::forward<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0>(fp)()) std::__1::__invoke<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0&&)::'lambda'()&>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0&&) /usr/include/c++/v1/type_traits:4482 (clickhouse+0xcad5305)
    #24 void std::__1::__invoke_void_return_wrapper<void>::__call<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0&&)::'lambda'()&>(ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0&&)::'lambda'()&) /usr/include/c++/v1/__functional_base:349 (clickhouse+0xcad5305)
    #25 std::__1::__function::__func<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0&&)::'lambda'(), std::__1::allocator<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0&&)::'lambda'()>, void ()>::operator()() /usr/include/c++/v1/functional:1562 (clickhouse+0xcad5305)
    #26 std::__1::function<void ()>::operator()() const /usr/include/c++/v1/functional:1916:12 (clickhouse+0x64eb176)
    #27 ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:169 (clickhouse+0x64eb176)
    #28 void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:65:73 (clickhouse+0x64eeaec)
    #29 decltype(std::__1::forward<void>(fp)()) std::__1::__invoke<void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(void&&) /usr/include/c++/v1/type_traits:4482 (clickhouse+0x64eeaec)
    #30 void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(std::__1::tuple<void, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>&, std::__1::__tuple_indices<>) /usr/include/c++/v1/thread:342 (clickhouse+0x64eeaec)
    #31 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()> >(void*) /usr/include/c++/v1/thread:352 (clickhouse+0x64eeaec)
    #32 <null> <null> (clickhouse+0x6435422)

  Location is heap block of size 480 at 0x7b500004c800 allocated by thread T15:
    #0 operator new(unsigned long) <null> (clickhouse+0x64beb1d)
    #1 std::__1::__allocate(unsigned long) /usr/include/c++/v1/new:228:10 (clickhouse+0xcad80fd)
    #2 std::__1::allocator<std::__1::__shared_ptr_emplace<DB::MergeTreeDataPart, std::__1::allocator<DB::MergeTreeDataPart> > >::allocate(unsigned long, void const*) /usr/include/c++/v1/memory:1793 (clickhouse+0xcad80fd)
    #3 std::__1::shared_ptr<DB::MergeTreeDataPart> std::__1::shared_ptr<DB::MergeTreeDataPart>::make_shared<DB::MergeTreeData&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>(DB::MergeTreeData&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /usr/include/c++/v1/memory:4276 (clickhouse+0xcad80fd)
    #4 std::__1::enable_if<!(is_array<DB::MergeTreeDataPart>::value), std::__1::shared_ptr<DB::MergeTreeDataPart> >::type std::__1::make_shared<DB::MergeTreeDataPart, DB::MergeTreeData&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>(DB::MergeTreeData&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /usr/include/c++/v1/memory:4656 (clickhouse+0xcad80fd)
    #5 DB::DataPartsExchange::Fetcher::fetchPart(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, DB::ConnectionTimeouts const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/DataPartsExchange.cpp:213 (clickhouse+0xcad80fd)
    #6 DB::StorageReplicatedMergeTree::fetchPart(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, unsigned long)::$_21::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageReplicatedMergeTree.cpp:2755:28 (clickhouse+0xca5dbe7)
    #7 decltype(std::__1::forward<DB::StorageReplicatedMergeTree::fetchPart(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, unsigned long)::$_21&>(fp)()) std::__1::__invoke<DB::StorageReplicatedMergeTree::fetchPart(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, unsigned long)::$_21&>(DB::StorageReplicatedMergeTree::fetchPart(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, unsigned long)::$_21&) /usr/include/c++/v1/type_traits:4482 (clickhouse+0xca5dbe7)
    #8 std::__1::shared_ptr<DB::MergeTreeDataPart> std::__1::__invoke_void_return_wrapper<std::__1::shared_ptr<DB::MergeTreeDataPart> >::__call<DB::StorageReplicatedMergeTree::fetchPart(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, unsigned long)::$_21&>(DB::StorageReplicatedMergeTree::fetchPart(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, unsigned long)::$_21&) /usr/include/c++/v1/__functional_base:318 (clickhouse+0xca5dbe7)
    #9 std::__1::__function::__func<DB::StorageReplicatedMergeTree::fetchPart(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, unsigned long)::$_21, std::__1::allocator<DB::StorageReplicatedMergeTree::fetchPart(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, unsigned long)::$_21>, std::__1::shared_ptr<DB::MergeTreeDataPart> ()>::operator()() /usr/include/c++/v1/functional:1562 (clickhouse+0xca5dbe7)
    #10 std::__1::function<std::__1::shared_ptr<DB::MergeTreeDataPart> ()>::operator()() const /usr/include/c++/v1/functional:1916:12 (clickhouse+0xca216b4)
    #11 DB::StorageReplicatedMergeTree::fetchPart(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, unsigned long) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageReplicatedMergeTree.cpp:2764 (clickhouse+0xca216b4)
    #12 DB::StorageReplicatedMergeTree::executeFetch(DB::ReplicatedMergeTreeLogEntry&) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageReplicatedMergeTree.cpp:1392:18 (clickhouse+0xca1bbf5)
    #13 DB::StorageReplicatedMergeTree::executeLogEntry(DB::ReplicatedMergeTreeLogEntry&) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageReplicatedMergeTree.cpp:922:16 (clickhouse+0xca08d8f)
    #14 DB::StorageReplicatedMergeTree::queueTask()::$_16::operator()(std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&) const /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageReplicatedMergeTree.cpp:2098:20 (clickhouse+0xca5be82)
    #15 decltype(std::__1::forward<DB::StorageReplicatedMergeTree::queueTask()::$_16&>(fp)(std::__1::forward<std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&>(fp0))) std::__1::__invoke<DB::StorageReplicatedMergeTree::queueTask()::$_16&, std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&>(DB::StorageReplicatedMergeTree::queueTask()::$_16&, std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&) /usr/include/c++/v1/type_traits:4482 (clickhouse+0xca5be82)
    #16 bool std::__1::__invoke_void_return_wrapper<bool>::__call<DB::StorageReplicatedMergeTree::queueTask()::$_16&, std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&>(DB::StorageReplicatedMergeTree::queueTask()::$_16&, std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&) /usr/include/c++/v1/__functional_base:318 (clickhouse+0xca5be82)
    #17 std::__1::__function::__func<DB::StorageReplicatedMergeTree::queueTask()::$_16, std::__1::allocator<DB::StorageReplicatedMergeTree::queueTask()::$_16>, bool (std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&)>::operator()(std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&) /usr/include/c++/v1/functional:1562 (clickhouse+0xca5be82)
    #18 std::__1::function<bool (std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&)>::operator()(std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&) const /usr/include/c++/v1/functional:1916:12 (clickhouse+0xcc57a0e)
    #19 DB::ReplicatedMergeTreeQueue::processEntry(std::__1::function<std::__1::shared_ptr<zkutil::ZooKeeper> ()>, std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&, std::__1::function<bool (std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>&)>) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp:1112 (clickhouse+0xcc57a0e)
    #20 DB::StorageReplicatedMergeTree::queueTask() /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageReplicatedMergeTree.cpp:2094:22 (clickhouse+0xca2ab9d)
    #21 DB::StorageReplicatedMergeTree::startup()::$_22::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageReplicatedMergeTree.cpp:2836:84 (clickhouse+0xca5e2a3)
    #22 decltype(std::__1::forward<DB::StorageReplicatedMergeTree::startup()::$_22&>(fp)()) std::__1::__invoke<DB::StorageReplicatedMergeTree::startup()::$_22&>(DB::StorageReplicatedMergeTree::startup()::$_22&) /usr/include/c++/v1/type_traits:4482 (clickhouse+0xca5e2a3)
    #23 DB::BackgroundProcessingPoolTaskResult std::__1::__invoke_void_return_wrapper<DB::BackgroundProcessingPoolTaskResult>::__call<DB::StorageReplicatedMergeTree::startup()::$_22&>(DB::StorageReplicatedMergeTree::startup()::$_22&) /usr/include/c++/v1/__functional_base:318 (clickhouse+0xca5e2a3)
    #24 std::__1::__function::__func<DB::StorageReplicatedMergeTree::startup()::$_22, std::__1::allocator<DB::StorageReplicatedMergeTree::startup()::$_22>, DB::BackgroundProcessingPoolTaskResult ()>::operator()() /usr/include/c++/v1/functional:1562 (clickhouse+0xca5e2a3)
    #25 std::__1::function<DB::BackgroundProcessingPoolTaskResult ()>::operator()() const /usr/include/c++/v1/functional:1916:12 (clickhouse+0xcad4a3b)
    #26 DB::BackgroundProcessingPool::threadFunction() /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/BackgroundProcessingPool.cpp:203 (clickhouse+0xcad4a3b)
    #27 DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/BackgroundProcessingPool.cpp:70:48 (clickhouse+0xcad5305)
    #28 decltype(std::__1::forward<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0 const&>(fp)()) std::__1::__invoke_constexpr<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0 const&>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0 const&) /usr/include/c++/v1/type_traits:4488 (clickhouse+0xcad5305)
    #29 decltype(auto) std::__1::__apply_tuple_impl<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0 const&, std::__1::tuple<> const&>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0 const&, std::__1::tuple<> const&, std::__1::__tuple_indices<>) /usr/include/c++/v1/tuple:1379 (clickhouse+0xcad5305)
    #30 decltype(auto) std::__1::apply<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0 const&, std::__1::tuple<> const&>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0 const&, std::__1::tuple<> const&) /usr/include/c++/v1/tuple:1388 (clickhouse+0xcad5305)
    #31 ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0&&)::'lambda'()::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.h:147 (clickhouse+0xcad5305)
    #32 decltype(std::__1::forward<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0>(fp)()) std::__1::__invoke<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0&&)::'lambda'()&>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0&&) /usr/include/c++/v1/type_traits:4482 (clickhouse+0xcad5305)
    #33 void std::__1::__invoke_void_return_wrapper<void>::__call<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0&&)::'lambda'()&>(ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0&&)::'lambda'()&) /usr/include/c++/v1/__functional_base:349 (clickhouse+0xcad5305)
    #34 std::__1::__function::__func<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0&&)::'lambda'(), std::__1::allocator<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0&&)::'lambda'()>, void ()>::operator()() /usr/include/c++/v1/functional:1562 (clickhouse+0xcad5305)
    #35 std::__1::function<void ()>::operator()() const /usr/include/c++/v1/functional:1916:12 (clickhouse+0x64eb176)
    #36 ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:169 (clickhouse+0x64eb176)
    #37 void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:65:73 (clickhouse+0x64eeaec)
    #38 decltype(std::__1::forward<void>(fp)()) std::__1::__invoke<void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(void&&) /usr/include/c++/v1/type_traits:4482 (clickhouse+0x64eeaec)
    #39 void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(std::__1::tuple<void, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>&, std::__1::__tuple_indices<>) /usr/include/c++/v1/thread:342 (clickhouse+0x64eeaec)
    #40 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()> >(void*) /usr/include/c++/v1/thread:352 (clickhouse+0x64eeaec)
    #41 <null> <null> (clickhouse+0x6435422)

  Mutex M888189031972340064 is already destroyed.

  Mutex M891004194055218936 is already destroyed.

  Mutex M722682157982246560 is already destroyed.

  Thread T44 'BackgrSchedPool' (tid=304, running) created by thread T26 at:
    #0 pthread_create <null> (clickhouse+0x64354a5)
    #1 std::__1::__libcpp_thread_create(unsigned long*, void* (*)(void*), void*) /usr/include/c++/v1/__threading_support:327:10 (clickhouse+0x64ee051)
    #2 std::__1::thread::thread<void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'(), void>(void&&) /usr/include/c++/v1/thread:368 (clickhouse+0x64ee051)
    #3 ThreadPoolImpl<std::__1::thread>::scheduleOrThrow(std::__1::function<void ()>, int, unsigned long) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:92:5 (clickhouse+0x64e9a0f)
    #4 ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long)::$_1>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long)::$_1&&) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.h:140:38 (clickhouse+0x64ea568)
    #5 DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long) /build/obj-x86_64-linux-gnu/../dbms/src/Core/BackgroundSchedulePool.cpp:164 (clickhouse+0x64ea568)
    #6 void std::__1::__optional_storage_base<DB::BackgroundSchedulePool, false>::__construct<DB::SettingInt<unsigned long>&>(DB::SettingInt<unsigned long>&) /usr/include/c++/v1/optional:318:54 (clickhouse+0xc387ee3)
    #7 DB::BackgroundSchedulePool& std::__1::optional<DB::BackgroundSchedulePool>::emplace<DB::SettingInt<unsigned long>&, void>(DB::SettingInt<unsigned long>&) /usr/include/c++/v1/optional:817 (clickhouse+0xc387ee3)
    #8 DB::Context::getSchedulePool() /build/obj-x86_64-linux-gnu/../dbms/src/Interpreters/Context.cpp:1373 (clickhouse+0xc387ee3)
    #9 DB::ReplicatedMergeTreeCleanupThread::ReplicatedMergeTreeCleanupThread(DB::StorageReplicatedMergeTree&) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/ReplicatedMergeTreeCleanupThread.cpp:25:35 (clickhouse+0xc36f7f7)
    #10 DB::StorageReplicatedMergeTree::StorageReplicatedMergeTree(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::shared_ptr<DB::IAST> const&, std::__1::shared_ptr<DB::IAST> const&, std::__1::shared_ptr<DB::IAST> const&, std::__1::shared_ptr<DB::IAST> const&, DB::MergeTreeData::MergingParams const&, DB::MergeTreeSettings const&, bool) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageReplicatedMergeTree.cpp:224:5 (clickhouse+0xcc2b631)
    #11  >&, bool const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, bool const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&)::Local> >::__shared_ptr_emplace<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, bool const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::allocator<auto ext::shared_ptr_helper<DB::StorageReplicatedMergeTree>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, bool const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, bool const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&)::Local>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, bool const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&) /usr/include/c++/v1/memory:3618 (clickhouse+0xc9f710c)
    #12 std::__1::shared_ptr<auto ext::shared_ptr_helper<DB::StorageReplicatedMergeTree>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, bool const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, bool const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&)::Local> std::__1::shared_ptr<auto ext::shared_ptr_helper<DB::StorageReplicatedMergeTree>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, bool const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, bool const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&)::Local>::make_shared<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, bool const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, bool const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&) /usr/include/c++/v1/memory:4277 (clickhouse+0xc9f710c)
    #13 <null> <null> (clickhouse+0xcc88d90)
    #14 std::__1::enable_if<!(is_array<auto ext::shared_ptr_helper<DB::StorageReplicatedMergeTree>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, bool const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, bool const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&)::Local>::value), std::__1::shared_ptr<auto ext::shared_ptr_helper<DB::StorageReplicatedMergeTree>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, bool const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, bool const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&)::Local> >::type std::__1::make_shared<auto ext::shared_ptr_helper<DB::StorageReplicatedMergeTree>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, bool const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, bool const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&)::Local, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, bool const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, bool const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&) /usr/include/c++/v1/memory:4656:12 (clickhouse+0xcc821f6)
    #15 auto ext::shared_ptr_helper<DB::StorageReplicatedMergeTree>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, bool const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, bool const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&) /build/obj-x86_64-linux-gnu/../libs/libcommon/include/ext/shared_ptr_helper.h:35 (clickhouse+0xcc821f6)
    #16 DB::create(DB::StorageFactory::Arguments const&) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/registerStorageMergeTree.cpp:635 (clickhouse+0xcc821f6)
    #17 decltype(std::__1::forward<std::__1::shared_ptr<DB::IStorage> (*&)(DB::StorageFactory::Arguments const&)>(fp)(std::__1::forward<DB::StorageFactory::Arguments const&>(fp0))) std::__1::__invoke<std::__1::shared_ptr<DB::IStorage> (*&)(DB::StorageFactory::Arguments const&), DB::StorageFactory::Arguments const&>(std::__1::shared_ptr<DB::IStorage> (*&)(DB::StorageFactory::Arguments const&), DB::StorageFactory::Arguments const&) /usr/include/c++/v1/type_traits:4482:1 (clickhouse+0xcc894ed)
    #18 std::__1::shared_ptr<DB::IStorage> std::__1::__invoke_void_return_wrapper<std::__1::shared_ptr<DB::IStorage> >::__call<std::__1::shared_ptr<DB::IStorage> (*&)(DB::StorageFactory::Arguments const&), DB::StorageFactory::Arguments const&>(std::__1::shared_ptr<DB::IStorage> (*&)(DB::StorageFactory::Arguments const&), DB::StorageFactory::Arguments const&) /usr/include/c++/v1/__functional_base:318 (clickhouse+0xcc894ed)
    #19 std::__1::__function::__func<std::__1::shared_ptr<DB::IStorage> (*)(DB::StorageFactory::Arguments const&), std::__1::allocator<std::__1::shared_ptr<DB::IStorage> (*)(DB::StorageFactory::Arguments const&)>, std::__1::shared_ptr<DB::IStorage> (DB::StorageFactory::Arguments const&)>::operator()(DB::StorageFactory::Arguments const&) /usr/include/c++/v1/functional:1562 (clickhouse+0xcc894ed)
    #20 std::__1::function<std::__1::shared_ptr<DB::IStorage> (DB::StorageFactory::Arguments const&)>::operator()(DB::StorageFactory::Arguments const&) const /usr/include/c++/v1/functional:1916:12 (clickhouse+0xc996422)
    #21 DB::StorageFactory::get(DB::ASTCreateQuery&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::Context&, DB::Context&, DB::ColumnsDescription const&, bool, bool) const /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageFactory.cpp:141 (clickhouse+0xc996422)
    #22 DB::InterpreterCreateQuery::createTable(DB::ASTCreateQuery&) /build/obj-x86_64-linux-gnu/../dbms/src/Interpreters/InterpreterCreateQuery.cpp:564:42 (clickhouse+0xc3d0b22)
    #23 DB::InterpreterCreateQuery::execute() /build/obj-x86_64-linux-gnu/../dbms/src/Interpreters/InterpreterCreateQuery.cpp:627:16 (clickhouse+0xc3d22b4)
    #24 DB::executeQueryImpl(char const*, char const*, DB::Context&, bool, DB::QueryProcessingStage::Enum, bool) /build/obj-x86_64-linux-gnu/../dbms/src/Interpreters/executeQuery.cpp:221:28 (clickhouse+0xc81196f)
    #25 DB::executeQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::Context&, bool, DB::QueryProcessingStage::Enum, bool) /build/obj-x86_64-linux-gnu/../dbms/src/Interpreters/executeQuery.cpp:428:38 (clickhouse+0xc8111ae)
    #26 DB::TCPHandler::runImpl() /build/obj-x86_64-linux-gnu/../dbms/programs/server/TCPHandler.cpp:192:24 (clickhouse+0x654d508)
    #27 DB::TCPHandler::run() /build/obj-x86_64-linux-gnu/../dbms/programs/server/TCPHandler.cpp:941:9 (clickhouse+0x6558fb7)
    #28 Poco::Net::TCPServerConnection::start() /build/obj-x86_64-linux-gnu/../contrib/poco/Net/src/TCPServerConnection.cpp:43:3 (clickhouse+0xd45d002)
    #29 Poco::Net::TCPServerDispatcher::run() /build/obj-x86_64-linux-gnu/../contrib/poco/Net/src/TCPServerDispatcher.cpp:114:20 (clickhouse+0xd45d87a)
    #30 Poco::PooledThread::run() /build/obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/ThreadPool.cpp:214:14 (clickhouse+0xd5520b1)
    #31 Poco::(anonymous namespace)::RunnableHolder::run() /build/obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Thread.cpp:43:11 (clickhouse+0xd5505df)
    #32 Poco::ThreadImpl::runnableEntry(void*) /build/obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Thread_STD.cpp:139:27 (clickhouse+0xd54ee4a)
    #33 decltype(std::__1::forward<void* (*)(void*)>(fp)(std::__1::forward<Poco::ThreadImpl*>(fp0))) std::__1::__invoke<void* (*)(void*), Poco::ThreadImpl*>(void* (*&&)(void*), Poco::ThreadImpl*&&) /usr/include/c++/v1/type_traits:4482:1 (clickhouse+0xd550f8a)
    #34 void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*, 2ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*>&, std::__1::__tuple_indices<2ul>) /usr/include/c++/v1/thread:342 (clickhouse+0xd550f8a)
    #35 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*> >(void*) /usr/include/c++/v1/thread:352 (clickhouse+0xd550f8a)
    #36 <null> <null> (clickhouse+0x6435422)

  Thread T21 'BackgrProcPool' (tid=266, running) created by main thread at:
    #0 pthread_create <null> (clickhouse+0x64354a5)
    #1 std::__1::__libcpp_thread_create(unsigned long*, void* (*)(void*), void*) /usr/include/c++/v1/__threading_support:327:10 (clickhouse+0x64ee051)
    #2 std::__1::thread::thread<void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'(), void>(void&&) /usr/include/c++/v1/thread:368 (clickhouse+0x64ee051)
    #3 void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:65:35 (clickhouse+0x64e9a0f)
    #4 ThreadPoolImpl<std::__1::thread>::scheduleOrThrow(std::__1::function<void ()>, int, unsigned long) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:92:5 (clickhouse+0x64ea568)
    #5 ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0&&) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.h:140:38 (clickhouse+0xcad3931)
    #6 DB::BackgroundProcessingPool::BackgroundProcessingPool(int) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/BackgroundProcessingPool.cpp:70 (clickhouse+0xcad3931)
    #7 void std::__1::__optional_storage_base<DB::BackgroundProcessingPool, false>::__construct<DB::SettingInt<unsigned long>&>(DB::SettingInt<unsigned long>&) /usr/include/c++/v1/optional:318:54 (clickhouse+0xc36f6b7)
    #8 DB::BackgroundProcessingPool& std::__1::optional<DB::BackgroundProcessingPool>::emplace<DB::SettingInt<unsigned long>&, void>(DB::SettingInt<unsigned long>&) /usr/include/c++/v1/optional:817 (clickhouse+0xc36f6b7)
    #9 DB::Context::getBackgroundPool() /build/obj-x86_64-linux-gnu/../dbms/src/Interpreters/Context.cpp:1365 (clickhouse+0xc36f6b7)
    #10 DB::DNSCacheUpdater::DNSCacheUpdater(DB::Context&) /build/obj-x86_64-linux-gnu/../dbms/src/Interpreters/DNSCacheUpdater.cpp:59:40 (clickhouse+0xc3af913)
    #11 std::__1::__unique_if<DB::DNSCacheUpdater>::__unique_single std::__1::make_unique<DB::DNSCacheUpdater, DB::Context&>(DB::Context&) /usr/include/c++/v1/memory:3078:32 (clickhouse+0x64c7f33)
    #12 DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) /build/obj-x86_64-linux-gnu/../dbms/programs/server/Server.cpp:526 (clickhouse+0x64c7f33)
    #13 Poco::Util::Application::run() /build/obj-x86_64-linux-gnu/../contrib/poco/Util/src/Application.cpp:335:8 (clickhouse+0xd46ee4d)
    #14 DB::Server::run() /build/obj-x86_64-linux-gnu/../dbms/programs/server/Server.cpp:138:25 (clickhouse+0x64c1ad7)
    #15 Poco::Util::ServerApplication::run(int, char**) /build/obj-x86_64-linux-gnu/../contrib/poco/Util/src/ServerApplication.cpp:618:9 (clickhouse+0xd48c0d8)
    #16 mainEntryClickHouseServer(int, char**) /build/obj-x86_64-linux-gnu/../dbms/programs/server/Server.cpp:844:20 (clickhouse+0x64d2263)
    #17 main /build/obj-x86_64-linux-gnu/../dbms/programs/main.cpp:174:12 (clickhouse+0x64c0e32)

  Thread T15 'BackgrProcPool' (tid=260, running) created by main thread at:
    #0 pthread_create <null> (clickhouse+0x64354a5)
    #1 std::__1::__libcpp_thread_create(unsigned long*, void* (*)(void*), void*) /usr/include/c++/v1/__threading_support:327:10 (clickhouse+0x64ee051)
    #2 std::__1::thread::thread<void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'(), void>(void&&) /usr/include/c++/v1/thread:368 (clickhouse+0x64ee051)
    #3 void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:65:35 (clickhouse+0x64e9a0f)
    #4 ThreadPoolImpl<std::__1::thread>::scheduleOrThrow(std::__1::function<void ()>, int, unsigned long) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:92:5 (clickhouse+0x64ea568)
    #5 ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0&&) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.h:140:38 (clickhouse+0xcad3931)
    #6 DB::BackgroundProcessingPool::BackgroundProcessingPool(int) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/BackgroundProcessingPool.cpp:70 (clickhouse+0xcad3931)
    #7 void std::__1::__optional_storage_base<DB::BackgroundProcessingPool, false>::__construct<DB::SettingInt<unsigned long>&>(DB::SettingInt<unsigned long>&) /usr/include/c++/v1/optional:318:54 (clickhouse+0xc36f6b7)
    #8 DB::BackgroundProcessingPool& std::__1::optional<DB::BackgroundProcessingPool>::emplace<DB::SettingInt<unsigned long>&, void>(DB::SettingInt<unsigned long>&) /usr/include/c++/v1/optional:817 (clickhouse+0xc36f6b7)
    #9 DB::Context::getBackgroundPool() /build/obj-x86_64-linux-gnu/../dbms/src/Interpreters/Context.cpp:1365 (clickhouse+0xc36f6b7)
    #10 DB::DNSCacheUpdater::DNSCacheUpdater(DB::Context&) /build/obj-x86_64-linux-gnu/../dbms/src/Interpreters/DNSCacheUpdater.cpp:59:40 (clickhouse+0xc3af913)
    #11 std::__1::__unique_if<DB::DNSCacheUpdater>::__unique_single std::__1::make_unique<DB::DNSCacheUpdater, DB::Context&>(DB::Context&) /usr/include/c++/v1/memory:3078:32 (clickhouse+0x64c7f33)
    #12 DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) /build/obj-x86_64-linux-gnu/../dbms/programs/server/Server.cpp:526 (clickhouse+0x64c7f33)
    #13 Poco::Util::Application::run() /build/obj-x86_64-linux-gnu/../contrib/poco/Util/src/Application.cpp:335:8 (clickhouse+0xd46ee4d)
    #14 DB::Server::run() /build/obj-x86_64-linux-gnu/../dbms/programs/server/Server.cpp:138:25 (clickhouse+0x64c1ad7)
    #15 Poco::Util::ServerApplication::run(int, char**) /build/obj-x86_64-linux-gnu/../contrib/poco/Util/src/ServerApplication.cpp:618:9 (clickhouse+0xd48c0d8)
    #16 mainEntryClickHouseServer(int, char**) /build/obj-x86_64-linux-gnu/../dbms/programs/server/Server.cpp:844:20 (clickhouse+0x64d2263)
    #17 main /build/obj-x86_64-linux-gnu/../dbms/programs/main.cpp:174:12 (clickhouse+0x64c0e32)

SUMMARY: ThreadSanitizer: data race /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/MergeTreeData.h:704:65 in DB::MergeTreeData::getStateModifier(DB::MergeTreeDataPart::State)::'lambda'(std::__1::shared_ptr<DB::MergeTreeDataPart const> const&)::operator()(std::__1::shared_ptr<DB::MergeTreeDataPart const> const&) const
==================
```