### PR TITLE
Fixed data race in clearOldTemporaryDirectories

### DIFF
--- a/dbms/src/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.h
@@ -465,6 +465,7 @@ public:
 
     /// Delete all directories which names begin with "tmp"
     /// Set non-negative parameter value to override MergeTreeSettings temporary_directories_lifetime
+    /// Must be called with locked lockStructureForShare().
     void clearOldTemporaryDirectories(ssize_t custom_directories_lifetime_seconds = -1);
 
     /// After the call to dropAllData() no method can be called.

--- a/dbms/src/Storages/MergeTree/ReplicatedMergeTreeCleanupThread.cpp
+++ b/dbms/src/Storages/MergeTree/ReplicatedMergeTreeCleanupThread.cpp
@@ -53,7 +53,12 @@ void ReplicatedMergeTreeCleanupThread::run()
 void ReplicatedMergeTreeCleanupThread::iterate()
 {
     storage.clearOldPartsAndRemoveFromZK();
-    storage.data.clearOldTemporaryDirectories();
+
+    {
+        /// TODO: Implement tryLockStructureForShare.
+        auto lock = storage.lockStructureForShare(false, "");
+        storage.data.clearOldTemporaryDirectories();
+    }
 
     /// This is loose condition: no problem if we actually had lost leadership at this moment
     ///  and two replicas will try to do cleanup simultaneously.

--- a/dbms/src/Storages/StorageMergeTree.cpp
+++ b/dbms/src/Storages/StorageMergeTree.cpp
@@ -690,7 +690,11 @@ BackgroundProcessingPoolTaskResult StorageMergeTree::backgroundTask()
         if (auto lock = time_after_previous_cleanup.compareAndRestartDeferred(1))
         {
             data.clearOldPartsFromFilesystem();
-            data.clearOldTemporaryDirectories();
+            {
+                /// TODO: Implement tryLockStructureForShare.
+                auto lock_structure = lockStructureForShare(false, "");
+                data.clearOldTemporaryDirectories();
+            }
             clearOldMutations();
         }
 


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fixed rare data race that can happen during `RENAME` table of MergeTree family.

Details:
```
WARNING: ThreadSanitizer: data race (pid=326)
  Read of size 8 at 0x7b0c000335d0 by thread T4 (mutexes: write M720148866011305568):
    #0 strlen <null> (clickhouse+0x6443cd4)
    #1 std::__1::char_traits<char>::length(char const*) /usr/include/c++/v1/__string:217:53 (clickhouse+0xd535663)
    #2 Poco::Path::Path(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /build/obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Path.cpp:52 (clickhouse+0xd535663)
    #3 Poco::DirectoryIterator::DirectoryIterator(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /build/obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/DirectoryIterator.cpp:35:70 (clickhouse+0xd4bedff)
    #4 DB::MergeTreeData::clearOldTemporaryDirectories(long) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/MergeTreeData.cpp:833:34 (clickhouse+0xcb22e4e)
    #5 DB::StorageMergeTree::backgroundTask() /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageMergeTree.cpp:693:18 (clickhouse+0xc9ef1a6)
    #6 DB::StorageMergeTree::startup()::$_0::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageMergeTree.cpp:98:70 (clickhouse+0xc9f6143)
    #7 decltype(std::__1::forward<DB::StorageMergeTree::startup()::$_0&>(fp)()) std::__1::__invoke<DB::StorageMergeTree::startup()::$_0&>(DB::StorageMergeTree::startup()::$_0&) /usr/include/c++/v1/type_traits:4482 (clickhouse+0xc9f6143)
    #8 DB::BackgroundProcessingPoolTaskResult std::__1::__invoke_void_return_wrapper<DB::BackgroundProcessingPoolTaskResult>::__call<DB::StorageMergeTree::startup()::$_0&>(DB::StorageMergeTree::startup()::$_0&) /usr/include/c++/v1/__functional_base:318 (clickhouse+0xc9f6143)
    #9 std::__1::__function::__func<DB::StorageMergeTree::startup()::$_0, std::__1::allocator<DB::StorageMergeTree::startup()::$_0>, DB::BackgroundProcessingPoolTaskResult ()>::operator()() /usr/include/c++/v1/functional:1562 (clickhouse+0xc9f6143)
    #10 std::__1::function<DB::BackgroundProcessingPoolTaskResult ()>::operator()() const /usr/include/c++/v1/functional:1916:12 (clickhouse+0xcae526b)
    #11 DB::BackgroundProcessingPool::threadFunction() /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/BackgroundProcessingPool.cpp:203 (clickhouse+0xcae526b)
    #12 DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/BackgroundProcessingPool.cpp:70:48 (clickhouse+0xcae5b35)
    #13 decltype(std::__1::forward<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0 const&>(fp)()) std::__1::__invoke_constexpr<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0 const&>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0 const&) /usr/include/c++/v1/type_traits:4488 (clickhouse+0xcae5b35)
    #14 decltype(auto) std::__1::__apply_tuple_impl<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0 const&, std::__1::tuple<> const&>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0 const&, std::__1::tuple<> const&, std::__1::__tuple_indices<>) /usr/include/c++/v1/tuple:1379 (clickhouse+0xcae5b35)
    #15 decltype(auto) std::__1::apply<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0 const&, std::__1::tuple<> const&>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0 const&, std::__1::tuple<> const&) /usr/include/c++/v1/tuple:1388 (clickhouse+0xcae5b35)
    #16 ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0&&)::'lambda'()::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.h:147 (clickhouse+0xcae5b35)
    #17 decltype(std::__1::forward<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0>(fp)()) std::__1::__invoke<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0&&)::'lambda'()&>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0&&) /usr/include/c++/v1/type_traits:4482 (clickhouse+0xcae5b35)
    #18 void std::__1::__invoke_void_return_wrapper<void>::__call<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0&&)::'lambda'()&>(ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0&&)::'lambda'()&) /usr/include/c++/v1/__functional_base:349 (clickhouse+0xcae5b35)
    #19 std::__1::__function::__func<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0&&)::'lambda'(), std::__1::allocator<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0&&)::'lambda'()>, void ()>::operator()() /usr/include/c++/v1/functional:1562 (clickhouse+0xcae5b35)
    #20 std::__1::function<void ()>::operator()() const /usr/include/c++/v1/functional:1916:12 (clickhouse+0x64f2176)
    #21 ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:169 (clickhouse+0x64f2176)
    #22 void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:65:73 (clickhouse+0x64f5aec)
    #23 decltype(std::__1::forward<void>(fp)()) std::__1::__invoke<void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(void&&) /usr/include/c++/v1/type_traits:4482 (clickhouse+0x64f5aec)
    #24 void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(std::__1::tuple<void, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>&, std::__1::__tuple_indices<>) /usr/include/c++/v1/thread:342 (clickhouse+0x64f5aec)
    #25 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()> >(void*) /usr/include/c++/v1/thread:352 (clickhouse+0x64f5aec)
    #26 <null> <null> (clickhouse+0x643c422)

  Previous write of size 8 at 0x7b0c000335d0 by thread T69:
    [failed to restore the stack]

  Location is heap block of size 48 at 0x7b0c000335d0 allocated by thread T23:
    #0 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::basic_string(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) <null> (clickhouse+0x64c5b1d)
    #1 DB::StorageMergeTree::StorageMergeTree(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription const&, bool, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::shared_ptr<DB::IAST> const&, std::__1::shared_ptr<DB::IAST> const&, std::__1::shared_ptr<DB::IAST> const&, std::__1::shared_ptr<DB::IAST> const&, DB::MergeTreeData::MergingParams const&, DB::MergeTreeSettings const&, bool) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageMergeTree.cpp:67:5 (clickhouse+0xe2fb003)
    #2 std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&) /usr/include/c++/v1/memory:3618 (clickhouse+0xc9e6a28)
    #3 std::__1::shared_ptr<auto ext::shared_ptr_helper<DB::StorageMergeTree>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&)::Local> std::__1::shared_ptr<auto ext::shared_ptr_helper<DB::StorageMergeTree>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&)::Local>::make_shared<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::
MergingParams&, DB::MergeTreeSettings&, bool const&) /usr/include/c++/v1/memory:4277 (clickhouse+0xc9e6a28)
    #4 <null> <null> (clickhouse+0xcc99904)
    #5 std::__1::enable_if<!(is_array<auto ext::shared_ptr_helper<DB::StorageMergeTree>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&)::Local>::value), std::__1::shared_ptr<auto ext::shared_ptr_helper<DB::StorageMergeTree>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&)::Local> >::type std::__1::make_shared<auto ext::shared_ptr_helper<DB::StorageMergeTree>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std:
:__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&)::Local, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&) /usr/include/c++/v1/memory:4656:12 (clickhouse+0xcc92ade)
    #6 auto ext::shared_ptr_helper<DB::StorageMergeTree>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&) /build/obj-x86_64-linux-gnu/../libs/libcommon/include/ext/shared_ptr_helper.h:35 (clickhouse+0xcc92ade)
    #7 DB::create(DB::StorageFactory::Arguments const&) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/registerStorageMergeTree.cpp:641 (clickhouse+0xcc92ade)
    #8 decltype(std::__1::forward<std::__1::shared_ptr<DB::IStorage> (*&)(DB::StorageFactory::Arguments const&)>(fp)(std::__1::forward<DB::StorageFactory::Arguments const&>(fp0))) std::__1::__invoke<std::__1::shared_ptr<DB::IStorage> (*&)(DB::StorageFactory::Arguments const&), DB::StorageFactory::Arguments const&>(std::__1::shared_ptr<DB::IStorage> (*&)(DB::StorageFactory::Arguments const&), DB::StorageFactory::Arguments const&) /usr/include/c++/v1/type_traits:4482:1 (clickhouse+0xcc99d1d)
    #9 std::__1::shared_ptr<DB::IStorage> std::__1::__invoke_void_return_wrapper<std::__1::shared_ptr<DB::IStorage> >::__call<std::__1::shared_ptr<DB::IStorage> (*&)(DB::StorageFactory::Arguments const&), DB::StorageFactory::Arguments const&>(std::__1::shared_ptr<DB::IStorage> (*&)(DB::StorageFactory::Arguments const&), DB::StorageFactory::Arguments const&) /usr/include/c++/v1/__functional_base:318 (clickhouse+0xcc99d1d)
    #10 std::__1::__function::__func<std::__1::shared_ptr<DB::IStorage> (*)(DB::StorageFactory::Arguments const&), std::__1::allocator<std::__1::shared_ptr<DB::IStorage> (*)(DB::StorageFactory::Arguments const&)>, std::__1::shared_ptr<DB::IStorage> (DB::StorageFactory::Arguments const&)>::operator()(DB::StorageFactory::Arguments const&) /usr/include/c++/v1/functional:1562 (clickhouse+0xcc99d1d)
    #11 std::__1::function<std::__1::shared_ptr<DB::IStorage> (DB::StorageFactory::Arguments const&)>::operator()(DB::StorageFactory::Arguments const&) const /usr/include/c++/v1/functional:1916:12 (clickhouse+0xc9a6bc2)
    #12 DB::StorageFactory::get(DB::ASTCreateQuery&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::Context&, DB::Context&, DB::ColumnsDescription const&, bool, bool) const /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageFactory.cpp:141 (clickhouse+0xc9a6bc2)
    #13 DB::createTableFromDefinition(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::Context&, bool, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /build/obj-x86_64-linux-gnu/../dbms/src/Databases/DatabasesCommon.cpp:80:36 (clickhouse+0xc351114)
    #14 DB::loadTable(DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::DatabaseOrdinary&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool) /build/obj-x86_64-linux-gnu/../dbms/src/Databases/DatabaseOrdinary.cpp:96:39 (clickhouse+0xc3eb8dd)
    #15 DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0::operator()(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) const /build/obj-x86_64-linux-gnu/../dbms/src/Databases/DatabaseOrdinary.cpp:186 (clickhouse+0xc3eb8dd)
    #16 decltype(std::__1::forward<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0&>(fp)(std::__1::forward<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&>(fp0))) std::__1::__invoke<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&>(DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) /usr/include/c++/v1/type_traits:4482 (clickhouse+0xc3eb8dd)
    #17 std::__1::__bind_return<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0, std::__1::tuple<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::tuple<>, __is_valid_bind_return<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0, std::__1::tuple<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::tuple<> >::value>::type std::__1::__apply_functor<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0, std::__1::tuple<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, 0ul, std::__1::tuple<> >(DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0&, std::__1::tuple<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >&, std::__1::__tuple_indices<0ul>, std::__1::tuple<>&&) /usr/include/c++/v1/functional:2219 (clickhouse+0xc3eb8dd)
    #18 std::__1::__bind_return<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0, std::__1::tuple<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::tuple<>, __is_valid_bind_return<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0, std::__1::tuple<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::tuple<> >::value>::type std::__1::__bind<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>::operator()<>() /usr/include/c++/v1/functional:2252 (clickhouse+0xc3eb8dd)
    #19 decltype(std::__1::forward<std::__1::__bind<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>&>(fp)()) std::__1::__invoke<std::__1::__bind<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>&>(std::__1::__bind<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>&) /usr/include/c++/v1/type_traits:4482 (clickhouse+0xc3eb8dd)
    #20 void std::__1::__invoke_void_return_wrapper<void>::__call<std::__1::__bind<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>&>(std::__1::__bind<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>&) /usr/include/c++/v1/__functional_base:349 (clickhouse+0xc3eb8dd)
    #21 std::__1::__function::__func<std::__1::__bind<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>, std::__1::allocator<std::__1::__bind<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&> >, void ()>::operator()() /usr/include/c++/v1/functional:1562 (clickhouse+0xc3eb8dd)
    #22 std::__1::function<void ()>::operator()() const /usr/include/c++/v1/functional:1916:12 (clickhouse+0x64effe9)
    #23 createExceptionHandledJob(std::__1::function<void ()>, ExceptionHandler&)::$_0::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:229 (clickhouse+0x64effe9)
    #24 decltype(std::__1::forward<createExceptionHandledJob(std::__1::function<void ()>, ExceptionHandler&)::$_0&>(fp)()) std::__1::__invoke<createExceptionHandledJob(std::__1::function<void ()>, ExceptionHandler&)::$_0&>(createExceptionHandledJob(std::__1::function<void ()>, ExceptionHandler&)::$_0&) /usr/include/c++/v1/type_traits:4482 (clickhouse+0x64effe9)
    #25 void std::__1::__invoke_void_return_wrapper<void>::__call<createExceptionHandledJob(std::__1::function<void ()>, ExceptionHandler&)::$_0&>(createExceptionHandledJob(std::__1::function<void ()>, ExceptionHandler&)::$_0&) /usr/include/c++/v1/__functional_base:349 (clickhouse+0x64effe9)
    #26 std::__1::__function::__func<createExceptionHandledJob(std::__1::function<void ()>, ExceptionHandler&)::$_0, std::__1::allocator<createExceptionHandledJob(std::__1::function<void ()>, ExceptionHandler&)::$_0>, void ()>::operator()() /usr/include/c++/v1/functional:1562 (clickhouse+0x64effe9)
    #27 std::__1::function<void ()>::operator()() const /usr/include/c++/v1/functional:1916:12 (clickhouse+0x64f4b46)
    #28 ThreadPoolImpl<ThreadFromGlobalPool>::worker(std::__1::__list_iterator<ThreadFromGlobalPool, void*>) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:169 (clickhouse+0x64f4b46)
    #29 void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:65:73 (clickhouse+0x64f7777)
    #30 decltype(std::__1::forward<void>(fp)()) std::__1::__invoke_constexpr<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'() const&>(void&&) /usr/include/c++/v1/type_traits:4488 (clickhouse+0x64f7777)
    #31 decltype(auto) std::__1::__apply_tuple_impl<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'() const&, std::__1::tuple<> const&>(void&&, std::__1::tuple<> const&, std::__1::__tuple_indices<>) /usr/include/c++/v1/tuple:1379 (clickhouse+0x64f7777)
    #32 decltype(auto) std::__1::apply<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'() const&, std::__1::tuple<> const&>(void&&, std::__1::tuple<> const&) /usr/include/c++/v1/tuple:1388 (clickhouse+0x64f7777)
    #33 ThreadFromGlobalPool::ThreadFromGlobalPool<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(void&&)::'lambda'()::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.h:147 (clickhouse+0x64f7777)
    #34 decltype(std::__1::forward<void>(fp)()) std::__1::__invoke<ThreadFromGlobalPool::ThreadFromGlobalPool<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(void&&)::'lambda'()&>(void&&) /usr/include/c++/v1/type_traits:4482 (clickhouse+0x64f7777)
    #35 void std::__1::__invoke_void_return_wrapper<void>::__call<ThreadFromGlobalPool::ThreadFromGlobalPool<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(void&&)::'lambda'()&>(ThreadFromGlobalPool::ThreadFromGlobalPool<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(void&&)::'lambda'()&) /usr/include/c++/v1/__functional_base:349 (clickhouse+0x64f7777)
    #36 std::__1::__function::__func<ThreadFromGlobalPool::ThreadFromGlobalPool<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(void&&)::'lambda'(), std::__1::allocator<ThreadFromGlobalPool::ThreadFromGlobalPool<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(void&&)::'lambda'()>, void ()>::operator()() /usr/include/c++/v1/functional:1562 (clickhouse+0x64f7777)
    #37 std::__1::function<void ()>::operator()() const /usr/include/c++/v1/functional:1916:12 (clickhouse+0x64f2176)
    #38 ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:169 (clickhouse+0x64f2176)
    #39 void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:65:73 (clickhouse+0x64f5aec)
    #40 decltype(std::__1::forward<void>(fp)()) std::__1::__invoke<void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(void&&) /usr/include/c++/v1/type_traits:4482 (clickhouse+0x64f5aec)
    #41 void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(std::__1::tuple<void, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>&, std::__1::__tuple_indices<>) /usr/include/c++/v1/thread:342 (clickhouse+0x64f5aec)
    #42 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()> >(void*) /usr/include/c++/v1/thread:352 (clickhouse+0x64f5aec)
    #43 <null> <null> (clickhouse+0x643c422)

  Mutex M720148866011305568 is already destroyed.

  Thread T4 'BackgrProcPool' (tid=333, running) created by main thread at:
    #0 pthread_create <null> (clickhouse+0x643c4a5)
    #1 std::__1::__libcpp_thread_create(unsigned long*, void* (*)(void*), void*) /usr/include/c++/v1/__threading_support:327:10 (clickhouse+0x64f5051)
    #2 std::__1::thread::thread<void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'(), void>(void&&) /usr/include/c++/v1/thread:368 (clickhouse+0x64f5051)
    #3 ThreadPoolImpl<std::__1::thread>::scheduleOrThrow(std::__1::function<void ()>, int, unsigned long) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:92:5 (clickhouse+0x64f0a0f)
    #4 ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int)::$_0&&) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.h:140:38 (clickhouse+0x64f1568)
    #5 DB::BackgroundProcessingPool::BackgroundProcessingPool(int) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/BackgroundProcessingPool.cpp:70 (clickhouse+0x64f1568)
    #6 void std::__1::__optional_storage_base<DB::BackgroundProcessingPool, false>::__construct<DB::SettingInt<unsigned long>&>(DB::SettingInt<unsigned long>&) /usr/include/c++/v1/optional:318:54 (clickhouse+0xcae4161)
    #7 DB::BackgroundProcessingPool& std::__1::optional<DB::BackgroundProcessingPool>::emplace<DB::SettingInt<unsigned long>&, void>(DB::SettingInt<unsigned long>&) /usr/include/c++/v1/optional:817 (clickhouse+0xcae4161)
    #8 DB::Context::getBackgroundPool() /build/obj-x86_64-linux-gnu/../dbms/src/Interpreters/Context.cpp:1390 (clickhouse+0xcae4161)
    #9 DB::StorageMergeTree::StorageMergeTree(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription const&, bool, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::shared_ptr<DB::IAST> const&, std::__1::shared_ptr<DB::IAST> const&, std::__1::shared_ptr<DB::IAST> const&, std::__1::shared_ptr<DB::IAST> const&, DB::MergeTreeData::MergingParams const&, DB::MergeTreeSettings const&, bool) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageMergeTree.cpp:66:56 (clickhouse+0xc3799b7)
    #10 std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&) /usr/include/c++/v1/memory:3618 (clickhouse+0xc9e69a8)
    #11 std::__1::shared_ptr<auto ext::shared_ptr_helper<DB::StorageMergeTree>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&)::Local> std::__1::shared_ptr<auto ext::shared_ptr_helper<DB::StorageMergeTree>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&)::Local>::make_shared<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::
MergingParams&, DB::MergeTreeSettings&, bool const&) /usr/include/c++/v1/memory:4277 (clickhouse+0xc9e69a8)
    #12 <null> <null> (clickhouse+0xcc99904)
    #13 std::__1::enable_if<!(is_array<auto ext::shared_ptr_helper<DB::StorageMergeTree>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&)::Local>::value), std::__1::shared_ptr<auto ext::shared_ptr_helper<DB::StorageMergeTree>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&)::Local> >::type std::__1::make_shared<auto ext::shared_ptr_helper<DB::StorageMergeTree>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, 
std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&)::Local, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&) /usr/include/c++/v1/memory:4656:12 (clickhouse+0xcc92ade)
    #14 auto ext::shared_ptr_helper<DB::StorageMergeTree>::create<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::ColumnsDescription const&, DB::IndicesDescription&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::IAST>&, DB::MergeTreeData::MergingParams&, DB::MergeTreeSettings&, bool const&) /build/obj-x86_64-linux-gnu/../libs/libcommon/include/ext/shared_ptr_helper.h:35 (clickhouse+0xcc92ade)
    #15 DB::create(DB::StorageFactory::Arguments const&) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/registerStorageMergeTree.cpp:641 (clickhouse+0xcc92ade)
    #16 decltype(std::__1::forward<std::__1::shared_ptr<DB::IStorage> (*&)(DB::StorageFactory::Arguments const&)>(fp)(std::__1::forward<DB::StorageFactory::Arguments const&>(fp0))) std::__1::__invoke<std::__1::shared_ptr<DB::IStorage> (*&)(DB::StorageFactory::Arguments const&), DB::StorageFactory::Arguments const&>(std::__1::shared_ptr<DB::IStorage> (*&)(DB::StorageFactory::Arguments const&), DB::StorageFactory::Arguments const&) /usr/include/c++/v1/type_traits:4482:1 (clickhouse+0xcc99d1d)
    #17 std::__1::shared_ptr<DB::IStorage> std::__1::__invoke_void_return_wrapper<std::__1::shared_ptr<DB::IStorage> >::__call<std::__1::shared_ptr<DB::IStorage> (*&)(DB::StorageFactory::Arguments const&), DB::StorageFactory::Arguments const&>(std::__1::shared_ptr<DB::IStorage> (*&)(DB::StorageFactory::Arguments const&), DB::StorageFactory::Arguments const&) /usr/include/c++/v1/__functional_base:318 (clickhouse+0xcc99d1d)
    #18 std::__1::__function::__func<std::__1::shared_ptr<DB::IStorage> (*)(DB::StorageFactory::Arguments const&), std::__1::allocator<std::__1::shared_ptr<DB::IStorage> (*)(DB::StorageFactory::Arguments const&)>, std::__1::shared_ptr<DB::IStorage> (DB::StorageFactory::Arguments const&)>::operator()(DB::StorageFactory::Arguments const&) /usr/include/c++/v1/functional:1562 (clickhouse+0xcc99d1d)
    #19 std::__1::function<std::__1::shared_ptr<DB::IStorage> (DB::StorageFactory::Arguments const&)>::operator()(DB::StorageFactory::Arguments const&) const /usr/include/c++/v1/functional:1916:12 (clickhouse+0xc9a6bc2)
    #20 DB::StorageFactory::get(DB::ASTCreateQuery&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::Context&, DB::Context&, DB::ColumnsDescription const&, bool, bool) const /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageFactory.cpp:141 (clickhouse+0xc9a6bc2)
    #21 DB::createTableFromDefinition(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::Context&, bool, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /build/obj-x86_64-linux-gnu/../dbms/src/Databases/DatabasesCommon.cpp:80:36 (clickhouse+0xc351114)
    #22 DB::loadTable(DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::DatabaseOrdinary&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool) /build/obj-x86_64-linux-gnu/../dbms/src/Databases/DatabaseOrdinary.cpp:96:39 (clickhouse+0xc3eb8dd)
    #23 DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0::operator()(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) const /build/obj-x86_64-linux-gnu/../dbms/src/Databases/DatabaseOrdinary.cpp:186 (clickhouse+0xc3eb8dd)
    #24 decltype(std::__1::forward<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0&>(fp)(std::__1::forward<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&>(fp0))) std::__1::__invoke<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&>(DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) /usr/include/c++/v1/type_traits:4482 (clickhouse+0xc3eb8dd)
    #25 std::__1::__bind_return<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0, std::__1::tuple<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::tuple<>, __is_valid_bind_return<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0, std::__1::tuple<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::tuple<> >::value>::type std::__1::__apply_functor<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0, std::__1::tuple<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, 0ul, std::__1::tuple<> >(DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0&, std::__1::tuple<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >&, std::__1::__tuple_indices<0ul>, std::__1::tuple<>&&) /usr/include/c++/v1/functional:2219 (clickhouse+0xc3eb8dd)
    #26 std::__1::__bind_return<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0, std::__1::tuple<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::tuple<>, __is_valid_bind_return<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0, std::__1::tuple<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::tuple<> >::value>::type std::__1::__bind<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>::operator()<>() /usr/include/c++/v1/functional:2252 (clickhouse+0xc3eb8dd)
    #27 decltype(std::__1::forward<std::__1::__bind<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>&>(fp)()) std::__1::__invoke<std::__1::__bind<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>&>(std::__1::__bind<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>&) /usr/include/c++/v1/type_traits:4482 (clickhouse+0xc3eb8dd)
    #28 void std::__1::__invoke_void_return_wrapper<void>::__call<std::__1::__bind<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>&>(std::__1::__bind<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>&) /usr/include/c++/v1/__functional_base:349 (clickhouse+0xc3eb8dd)
    #29 std::__1::__function::__func<std::__1::__bind<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>, std::__1::allocator<std::__1::__bind<DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool)::$_0&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&> >, void ()>::operator()() /usr/include/c++/v1/functional:1562 (clickhouse+0xc3eb8dd)
    #30 std::__1::function<void ()>::operator()() const /usr/include/c++/v1/functional:1916:12 (clickhouse+0x64effe9)
    #31 createExceptionHandledJob(std::__1::function<void ()>, ExceptionHandler&)::$_0::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:229 (clickhouse+0x64effe9)
    #32 decltype(std::__1::forward<createExceptionHandledJob(std::__1::function<void ()>, ExceptionHandler&)::$_0&>(fp)()) std::__1::__invoke<createExceptionHandledJob(std::__1::function<void ()>, ExceptionHandler&)::$_0&>(createExceptionHandledJob(std::__1::function<void ()>, ExceptionHandler&)::$_0&) /usr/include/c++/v1/type_traits:4482 (clickhouse+0x64effe9)
    #33 void std::__1::__invoke_void_return_wrapper<void>::__call<createExceptionHandledJob(std::__1::function<void ()>, ExceptionHandler&)::$_0&>(createExceptionHandledJob(std::__1::function<void ()>, ExceptionHandler&)::$_0&) /usr/include/c++/v1/__functional_base:349 (clickhouse+0x64effe9)
    #34 std::__1::__function::__func<createExceptionHandledJob(std::__1::function<void ()>, ExceptionHandler&)::$_0, std::__1::allocator<createExceptionHandledJob(std::__1::function<void ()>, ExceptionHandler&)::$_0>, void ()>::operator()() /usr/include/c++/v1/functional:1562 (clickhouse+0x64effe9)
    #35 std::__1::function<void ()>::operator()() const /usr/include/c++/v1/functional:1916:12 (clickhouse+0xc3e710a)
    #36 DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool) /build/obj-x86_64-linux-gnu/../dbms/src/Databases/DatabaseOrdinary.cpp:196 (clickhouse+0xc3e710a)
    #37 DB::InterpreterCreateQuery::createDatabase(DB::ASTCreateQuery&) /build/obj-x86_64-linux-gnu/../dbms/src/Interpreters/InterpreterCreateQuery.cpp:164:19 (clickhouse+0xc3d23e6)
    #38 DB::InterpreterCreateQuery::execute() /build/obj-x86_64-linux-gnu/../dbms/src/Interpreters/InterpreterCreateQuery.cpp:624:16 (clickhouse+0xc3dcb6c)
    #39 DB::executeCreateQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool) /build/obj-x86_64-linux-gnu/../dbms/src/Interpreters/loadMetadata.cpp:51:17 (clickhouse+0xc82cf39)
    #40 DB::loadDatabase(DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool) /build/obj-x86_64-linux-gnu/../dbms/src/Interpreters/loadMetadata.cpp:76 (clickhouse+0xc82cf39)
    #41 DB::loadMetadataSystem(DB::Context&) /build/obj-x86_64-linux-gnu/../dbms/src/Interpreters/loadMetadata.cpp:141:9 (clickhouse+0xc82d266)
    #42 DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) /build/obj-x86_64-linux-gnu/../dbms/programs/server/Server.cpp:493:9 (clickhouse+0x64ce842)
    #43 Poco::Util::Application::run() /build/obj-x86_64-linux-gnu/../contrib/poco/Util/src/Application.cpp:335:8 (clickhouse+0xd47fa3d)
    #44 DB::Server::run() /build/obj-x86_64-linux-gnu/../dbms/programs/server/Server.cpp:138:25 (clickhouse+0x64c8ad7)
    #45 Poco::Util::ServerApplication::run(int, char**) /build/obj-x86_64-linux-gnu/../contrib/poco/Util/src/ServerApplication.cpp:618:9 (clickhouse+0xd49ccc8)
    #46 mainEntryClickHouseServer(int, char**) /build/obj-x86_64-linux-gnu/../dbms/programs/server/Server.cpp:844:20 (clickhouse+0x64d9263)
    #47 main /build/obj-x86_64-linux-gnu/../dbms/programs/main.cpp:174:12 (clickhouse+0x64c7e32)

  Thread T69 'TCPHandler' (tid=419, running) created by thread T29 at:
    #0 pthread_create <null> (clickhouse+0x643c4a5)
    #1 std::__1::__libcpp_thread_create(unsigned long*, void* (*)(void*), void*) /usr/include/c++/v1/__threading_support:327:10 (clickhouse+0xd561577)
    #2 std::__1::thread::thread<void* (&)(void*), Poco::ThreadImpl*, void>(void* (&)(void*), Poco::ThreadImpl*&&) /usr/include/c++/v1/thread:368 (clickhouse+0xd561577)
    #3 Poco::ThreadImpl::startImpl(Poco::SharedPtr<Poco::Runnable, Poco::ReferenceCounter, Poco::ReleasePolicy<Poco::Runnable> >) /build/obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Thread_STD.cpp:58:53 (clickhouse+0xd55f502)
    #4 Poco::Thread::start(Poco::Runnable&) /build/obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Thread.cpp:116:2 (clickhouse+0xd560bbc)
    #5 Poco::PooledThread::start(int) /build/obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/ThreadPool.cpp:88:10 (clickhouse+0xd564509)
    #6 Poco::ThreadPool::getThread() /build/obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/ThreadPool.cpp:525 (clickhouse+0xd564509)
    #7 Poco::ThreadPool::startWithPriority(Poco::Thread::Priority, Poco::Runnable&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) /build/obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/ThreadPool.cpp:429:2 (clickhouse+0xd5647ce)
    #8 Poco::Net::TCPServerDispatcher::enqueue(Poco::Net::StreamSocket const&) /build/obj-x86_64-linux-gnu/../contrib/poco/Net/src/TCPServerDispatcher.cpp:145:17 (clickhouse+0xd46ea5f)
    #9 Poco::Net::TCPServer::run() /build/obj-x86_64-linux-gnu/../contrib/poco/Net/src/TCPServer.cpp:148:21 (clickhouse+0xd46d5e5)
    #10 Poco::(anonymous namespace)::RunnableHolder::run() /build/obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Thread.cpp:43:11 (clickhouse+0xd5611cf)
    #11 Poco::ThreadImpl::runnableEntry(void*) /build/obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Thread_STD.cpp:139:27 (clickhouse+0xd55fa3a)
    #12 decltype(std::__1::forward<void* (*)(void*)>(fp)(std::__1::forward<Poco::ThreadImpl*>(fp0))) std::__1::__invoke<void* (*)(void*), Poco::ThreadImpl*>(void* (*&&)(void*), Poco::ThreadImpl*&&) /usr/include/c++/v1/type_traits:4482:1 (clickhouse+0xd561b7a)
    #13 void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*, 2ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*>&, std::__1::__tuple_indices<2ul>) /usr/include/c++/v1/thread:342 (clickhouse+0xd561b7a)
    #14 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*> >(void*) /usr/include/c++/v1/thread:352 (clickhouse+0xd561b7a)
    #15 <null> <null> (clickhouse+0x643c422)

  Thread T23 'DDLWorker' (tid=352, running) created by main thread at:
    #0 std::__1::__libcpp_thread_create(unsigned long*, void* (*)(void*), void*) /usr/include/c++/v1/__threading_support:327:10 (clickhouse+0x643c4a5)
    #1 std::__1::thread::thread<void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'(), void>(void&&) /usr/include/c++/v1/thread:368 (clickhouse+0x643c4a5)
    #2 void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:65:35 (clickhouse+0x64f5051)
    #3 ThreadPoolImpl<std::__1::thread>::scheduleOrThrow(std::__1::function<void ()>, int, unsigned long) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:92:5 (clickhouse+0x64f0a0f)
    #4 ThreadFromGlobalPool::ThreadFromGlobalPool<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(void&&) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.h:140:38 (clickhouse+0x64f1568)
    #5 void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:65:35 (clickhouse+0x64f6591)
    #6 ThreadPoolImpl<ThreadFromGlobalPool>::schedule(std::__1::function<void ()>, int) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:80:5 (clickhouse+0x64f2dfc)
    #7 DB::DatabaseOrdinary::loadTables(DB::Context&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool) /build/obj-x86_64-linux-gnu/../dbms/src/Databases/DatabaseOrdinary.cpp:194:26 (clickhouse+0x64f27a0)
    #8 DB::InterpreterCreateQuery::createDatabase(DB::ASTCreateQuery&) /build/obj-x86_64-linux-gnu/../dbms/src/Interpreters/InterpreterCreateQuery.cpp:164:19 (clickhouse+0xc3e7174)
    #9 DB::InterpreterCreateQuery::execute() /build/obj-x86_64-linux-gnu/../dbms/src/Interpreters/InterpreterCreateQuery.cpp:624:16 (clickhouse+0xc3d23e6)
    #10 DB::executeCreateQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool) /build/obj-x86_64-linux-gnu/../dbms/src/Interpreters/loadMetadata.cpp:51:17 (clickhouse+0xc3dcb6c)
    #11 DB::loadDatabase(DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, ThreadPoolImpl<ThreadFromGlobalPool>*, bool) /build/obj-x86_64-linux-gnu/../dbms/src/Interpreters/loadMetadata.cpp:76 (clickhouse+0xc3dcb6c)
    #12 DB::loadMetadata(DB::Context&) /build/obj-x86_64-linux-gnu/../dbms/src/Interpreters/loadMetadata.cpp:117:9 (clickhouse+0xc82cf39)
    #13 DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) /build/obj-x86_64-linux-gnu/../dbms/programs/server/Server.cpp:499:9 (clickhouse+0xc82c946)
    #14 Poco::Util::Application::run() /build/obj-x86_64-linux-gnu/../contrib/poco/Util/src/Application.cpp:335:8 (clickhouse+0x64ce910)
    #15 DB::Server::run() /build/obj-x86_64-linux-gnu/../dbms/programs/server/Server.cpp:138:25 (clickhouse+0xd47fa3d)
    #16 Poco::Util::ServerApplication::run(int, char**) /build/obj-x86_64-linux-gnu/../contrib/poco/Util/src/ServerApplication.cpp:618:9 (clickhouse+0x64c8ad7)
    #17 mainEntryClickHouseServer(int, char**) /build/obj-x86_64-linux-gnu/../dbms/programs/server/Server.cpp:844:20 (clickhouse+0xd49ccc8)
    #18 main /build/obj-x86_64-linux-gnu/../dbms/programs/main.cpp:174:12 (clickhouse+0x64d9263)
    #19 __libc_start_main <null> (clickhouse+0x64c7e32)
    #20 operator new(unsigned long) <null> (libc.so.6+0x21b96)

SUMMARY: ThreadSanitizer: data race (/usr/bin/clickhouse+0x6443cd4) in strlen
==================
```

The fix is non perfect. `cleanupThread` will temporarily block during some phase of ALTER.