### PR TITLE
Fix crash when joining nulluble vs not nullable

### DIFF
--- a/dbms/tests/queries/0_stateless/00853_join_with_nulls_crash.reference
+++ b/dbms/tests/queries/0_stateless/00853_join_with_nulls_crash.reference
@@ -1,0 +1,16 @@
+foo	\N	2	0	Nullable(String)	Nullable(String)
+bar	bar	1	2	Nullable(String)	Nullable(String)
+\N		0	1	Nullable(String)	Nullable(String)
+\N	test	0	1	Nullable(String)	Nullable(String)
+foo	\N	2	0	Nullable(String)	Nullable(String)
+bar	bar	1	2	Nullable(String)	Nullable(String)
+\N		0	1	Nullable(String)	Nullable(String)
+\N	test	0	1	Nullable(String)	Nullable(String)
+foo		2	0	String	Nullable(String)
+bar	bar	1	2	String	Nullable(String)
+	test	0	1	String	Nullable(String)
+bar	bar	1	2	String	Nullable(String)
+	test	0	1	String	Nullable(String)
+foo	2	0	String
+bar	1	2	String
+test	0	1	String

--- a/dbms/tests/queries/0_stateless/00853_join_with_nulls_crash.sql
+++ b/dbms/tests/queries/0_stateless/00853_join_with_nulls_crash.sql
@@ -1,0 +1,57 @@
+USE test;
+
+DROP TABLE IF EXISTS table_a;
+DROP TABLE IF EXISTS table_b;
+
+CREATE TABLE table_a (
+    event_id UInt64,
+    something String,
+    other Nullable(String)
+) ENGINE = MergeTree ORDER BY (event_id);
+
+CREATE TABLE table_b (
+    event_id UInt64,
+    something Nullable(String),
+    other String
+) ENGINE = MergeTree ORDER BY (event_id);
+
+INSERT INTO table_a VALUES (1, 'foo', 'foo'), (2, 'foo', 'foo'), (3, 'bar', 'bar');
+INSERT INTO table_b VALUES (1, 'bar', 'bar'), (2, 'bar', 'bar'), (3, 'test', 'test'), (4, NULL, '');
+
+SELECT s1.other, s2.other, count_a, count_b, toTypeName(s1.other), toTypeName(s2.other) FROM
+    ( SELECT other, count() AS count_a FROM table_a GROUP BY other ) s1
+ALL FULL JOIN
+    ( SELECT other, count() AS count_b FROM table_b GROUP BY other ) s2
+ON s1.other = s2.other
+ORDER BY count_a DESC;
+
+SELECT s1.other, s2.other, count_a, count_b, toTypeName(s1.other), toTypeName(s2.other) FROM
+    ( SELECT other, count() AS count_a FROM table_a GROUP BY other ) s1
+ALL FULL JOIN
+    ( SELECT other, count() AS count_b FROM table_b GROUP BY other ) s2
+USING other
+ORDER BY count_a DESC;
+
+SELECT s1.something, s2.something, count_a, count_b, toTypeName(s1.something), toTypeName(s2.something) FROM
+    ( SELECT something, count() AS count_a FROM table_a GROUP BY something ) s1
+ALL FULL JOIN
+    ( SELECT something, count() AS count_b FROM table_b GROUP BY something ) s2
+ON s1.something = s2.something
+ORDER BY count_a DESC;
+
+SELECT s1.something, s2.something, count_a, count_b, toTypeName(s1.something), toTypeName(s2.something) FROM
+    ( SELECT something, count() AS count_a FROM table_a GROUP BY something ) s1
+ALL RIGHT JOIN
+    ( SELECT something, count() AS count_b FROM table_b GROUP BY something ) s2
+USING (something)
+ORDER BY count_a DESC;
+
+SELECT something, count_a, count_b, toTypeName(something) FROM
+    ( SELECT something, count() AS count_a FROM table_a GROUP BY something )
+ALL FULL JOIN
+    ( SELECT something, count() AS count_b FROM table_b GROUP BY something )
+USING (something)
+ORDER BY count_a DESC;
+
+DROP TABLE table_a;
+DROP TABLE table_b;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fix crash in FULL/RIGHT JOIN when we joining on nullable vs not nullable

Detailed description (optional):
Convert destination column from/to nullable according to source one, set data then convert it back.