### PR TITLE
Fix exception 'No message received'

### DIFF
--- a/dbms/src/Dictionaries/HTTPDictionarySource.cpp
+++ b/dbms/src/Dictionaries/HTTPDictionarySource.cpp
@@ -32,7 +32,7 @@ HTTPDictionarySource::HTTPDictionarySource(
     , format{config.getString(config_prefix + ".format")}
     , sample_block{sample_block}
     , context(context)
-    , timeouts(ConnectionTimeouts::getHTTPTimeouts(context.getSettingsRef()))
+    , timeouts(ConnectionTimeouts::getHTTPTimeouts(context))
 {
 }
 
@@ -45,7 +45,7 @@ HTTPDictionarySource::HTTPDictionarySource(const HTTPDictionarySource & other)
     , format{other.format}
     , sample_block{other.sample_block}
     , context(other.context)
-    , timeouts(ConnectionTimeouts::getHTTPTimeouts(context.getSettingsRef()))
+    , timeouts(ConnectionTimeouts::getHTTPTimeouts(context))
 {
 }
 

--- a/dbms/src/Dictionaries/XDBCDictionarySource.cpp
+++ b/dbms/src/Dictionaries/XDBCDictionarySource.cpp
@@ -84,7 +84,7 @@ XDBCDictionarySource::XDBCDictionarySource(
     , load_all_query{query_builder.composeLoadAllQuery()}
     , invalidate_query{config_.getString(config_prefix_ + ".invalidate_query", "")}
     , bridge_helper{bridge_}
-    , timeouts{ConnectionTimeouts::getHTTPTimeouts(context_.getSettingsRef())}
+    , timeouts{ConnectionTimeouts::getHTTPTimeouts(context_)}
     , global_context(context_)
 {
     bridge_url = bridge_helper->getMainURI();

--- a/dbms/src/IO/ConnectionTimeouts.h
+++ b/dbms/src/IO/ConnectionTimeouts.h
@@ -3,6 +3,9 @@
 #include <Poco/Timespan.h>
 #include <Core/Settings.h>
 
+#include <Interpreters/Context.h>
+#include <Poco/Util/AbstractConfiguration.h>
+
 namespace DB
 {
 
@@ -12,6 +15,7 @@ struct ConnectionTimeouts
     Poco::Timespan send_timeout;
     Poco::Timespan receive_timeout;
     Poco::Timespan tcp_keep_alive_timeout;
+    Poco::Timespan http_keep_alive_timeout;
 
     ConnectionTimeouts() = default;
 
@@ -21,7 +25,8 @@ struct ConnectionTimeouts
     : connection_timeout(connection_timeout_),
       send_timeout(send_timeout_),
       receive_timeout(receive_timeout_),
-      tcp_keep_alive_timeout(0)
+      tcp_keep_alive_timeout(0),
+      http_keep_alive_timeout(0)
     {
     }
 
@@ -32,9 +37,23 @@ struct ConnectionTimeouts
     : connection_timeout(connection_timeout_),
       send_timeout(send_timeout_),
       receive_timeout(receive_timeout_),
-      tcp_keep_alive_timeout(tcp_keep_alive_timeout_)
+      tcp_keep_alive_timeout(tcp_keep_alive_timeout_),
+      http_keep_alive_timeout(0)
     {
     }
+    ConnectionTimeouts(const Poco::Timespan & connection_timeout_,
+                       const Poco::Timespan & send_timeout_,
+                       const Poco::Timespan & receive_timeout_,
+                       const Poco::Timespan & tcp_keep_alive_timeout_,
+                       const Poco::Timespan & http_keep_alive_timeout_)
+        : connection_timeout(connection_timeout_),
+          send_timeout(send_timeout_),
+          receive_timeout(receive_timeout_),
+          tcp_keep_alive_timeout(tcp_keep_alive_timeout_),
+          http_keep_alive_timeout(http_keep_alive_timeout_)
+    {
+    }
+
 
     static Poco::Timespan saturate(const Poco::Timespan & timespan, const Poco::Timespan & limit)
     {
@@ -49,7 +68,8 @@ struct ConnectionTimeouts
         return ConnectionTimeouts(saturate(connection_timeout, limit),
                                   saturate(send_timeout, limit),
                                   saturate(receive_timeout, limit),
-                                  saturate(tcp_keep_alive_timeout, limit));
+                                  saturate(tcp_keep_alive_timeout, limit),
+                                  saturate(http_keep_alive_timeout, limit));
     }
 
     /// Timeouts for the case when we have just single attempt to connect.
@@ -64,9 +84,12 @@ struct ConnectionTimeouts
         return ConnectionTimeouts(settings.connect_timeout_with_failover_ms, settings.send_timeout, settings.receive_timeout, settings.tcp_keep_alive_timeout);
     }
 
-    static ConnectionTimeouts getHTTPTimeouts(const Settings & settings)
+    static ConnectionTimeouts getHTTPTimeouts(const Context & context)
     {
-        return ConnectionTimeouts(settings.http_connection_timeout, settings.http_send_timeout, settings.http_receive_timeout);
+        const auto & settings = context.getSettingsRef();
+        const auto & config = context.getConfigRef();
+        Poco::Timespan http_keep_alive_timeout{config.getUInt("keep_alive_timeout", 10), 0};
+        return ConnectionTimeouts(settings.http_connection_timeout, settings.http_send_timeout, settings.http_receive_timeout, http_keep_alive_timeout);
     }
 };
 

--- a/dbms/src/IO/HTTPCommon.cpp
+++ b/dbms/src/IO/HTTPCommon.cpp
@@ -45,13 +45,14 @@ namespace ErrorCodes
 
 namespace
 {
-    void setTimeouts(Poco::Net::HTTPClientSession & session, const ConnectionTimeouts & timeouts)
+void setTimeouts(Poco::Net::HTTPClientSession & session, const ConnectionTimeouts & timeouts)
     {
 #if defined(POCO_CLICKHOUSE_PATCH) || POCO_VERSION >= 0x02000000
         session.setTimeout(timeouts.connection_timeout, timeouts.send_timeout, timeouts.receive_timeout);
 #else
         session.setTimeout(std::max({timeouts.connection_timeout, timeouts.send_timeout, timeouts.receive_timeout}));
 #endif
+        session.setKeepAliveTimeout(timeouts.http_keep_alive_timeout);
     }
 
     bool isHTTPS(const Poco::URI & uri)
@@ -99,7 +100,6 @@ namespace
         const UInt16 port;
         bool https;
         using Base = PoolBase<Poco::Net::HTTPClientSession>;
-
         ObjectPtr allocObject() override
         {
             return makeHTTPSessionImpl(host, port, https, true);
@@ -140,7 +140,10 @@ namespace
         HTTPSessionPool() = default;
 
     public:
-        Entry getSession(const Poco::URI & uri, const ConnectionTimeouts & timeouts, size_t max_connections_per_endpoint)
+        Entry getSession(
+            const Poco::URI & uri,
+            const ConnectionTimeouts & timeouts,
+            size_t max_connections_per_endpoint)
         {
             std::unique_lock lock(mutex);
             const std::string & host = uri.getHost();
@@ -156,6 +159,7 @@ namespace
             auto session = pool_ptr->second->get(retry_timeout);
 
             setTimeouts(*session, timeouts);
+
             return session;
         }
     };

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1786,7 +1786,7 @@ bool StorageReplicatedMergeTree::executeReplaceRange(const LogEntry & entry)
         {
             String source_replica_path = zookeeper_path + "/replicas/" + part_desc->replica;
             ReplicatedMergeTreeAddress address(getZooKeeper()->get(source_replica_path + "/host"));
-            auto timeouts = ConnectionTimeouts::getHTTPTimeouts(global_context.getSettingsRef());
+            auto timeouts = ConnectionTimeouts::getHTTPTimeouts(global_context);
             auto [user, password] = global_context.getInterserverCredentials();
             String interserver_scheme = global_context.getInterserverScheme();
 
@@ -2741,7 +2741,7 @@ bool StorageReplicatedMergeTree::fetchPart(const String & part_name, const Strin
     else
     {
         ReplicatedMergeTreeAddress address(getZooKeeper()->get(source_replica_path + "/host"));
-        auto timeouts = ConnectionTimeouts::getHTTPTimeouts(global_context.getSettingsRef());
+        auto timeouts = ConnectionTimeouts::getHTTPTimeouts(global_context);
         auto user_password = global_context.getInterserverCredentials();
         String interserver_scheme = global_context.getInterserverScheme();
 

--- a/dbms/src/Storages/StorageURL.cpp
+++ b/dbms/src/Storages/StorageURL.cpp
@@ -173,7 +173,7 @@ BlockInputStreams IStorageURLBase::read(const Names & column_names,
         getHeaderBlock(column_names),
         context,
         max_block_size,
-        ConnectionTimeouts::getHTTPTimeouts(context.getSettingsRef()));
+        ConnectionTimeouts::getHTTPTimeouts(context));
 
 
     auto column_defaults = getColumns().getDefaults();
@@ -187,7 +187,7 @@ void IStorageURLBase::rename(const String & /*new_path_to_db*/, const String & /
 BlockOutputStreamPtr IStorageURLBase::write(const ASTPtr & /*query*/, const Context & /*context*/)
 {
     return std::make_shared<StorageURLBlockOutputStream>(
-        uri, format_name, getSampleBlock(), context_global, ConnectionTimeouts::getHTTPTimeouts(context_global.getSettingsRef()));
+        uri, format_name, getSampleBlock(), context_global, ConnectionTimeouts::getHTTPTimeouts(context_global));
 }
 
 void registerStorageURL(StorageFactory & factory)

--- a/dbms/tests/integration/helpers/cluster.py
+++ b/dbms/tests/integration/helpers/cluster.py
@@ -501,6 +501,10 @@ class ClickHouseInstance:
             raise Exception('Cmd "{}" failed! Return code {}. Output: {}'.format(' '.join(cmd), exit_code, output))
         return output
 
+    def contains_in_log(self, substring):
+        result = self.exec_in_container(["bash", "-c", "grep '{}' /var/log/clickhouse-server/clickhouse-server.log || true".format(substring)])
+        return len(result) > 0
+
     def copy_file_to_container(self, local_path, dest_path):
         with open(local_path, 'r') as fdata:
             data = fdata.read()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fix `No message received` exception in replication.

Detailed description:
Default server `keep_alive_timeout` is 3 seconds https://github.com/yandex/ClickHouse/blob/master/dbms/programs/server/config.xml#L88. But default Poco HTTPClientSession timeout is 8 seconds https://github.com/ClickHouse-Extras/poco/blob/d0271f990869b7f23dac4bb2ee0c127cf815f077/Net/include/Poco/Net/HTTPClientSession.h#L269. Server closes connection in three seconds, but client session tries to reconnect  after 8 seconds https://github.com/ClickHouse-Extras/poco/blob/d0271f990869b7f23dac4bb2ee0c127cf815f077/Net/src/HTTPClientSession.cpp#L403. If we make request in interval between (3, 8] seconds after previous we will try to write in `CLOSE_WAIT` socket and exception `No message received` will be thrown.

Closes: https://github.com/yandex/ClickHouse/issues/4047