### PR TITLE
Disable usage of "mremap" when compiled with Thread Sanitizer.

### DIFF
--- a/dbms/src/Common/Allocator.cpp
+++ b/dbms/src/Common/Allocator.cpp
@@ -10,6 +10,7 @@
 
 #include <Core/Defines.h>
 #ifdef THREAD_SANITIZER
+    /// Thread sanitizer does not intercept mremap. The usage of mremap will lead to false positives.
     #define DISABLE_MREMAP 1
 #endif
 #include <common/mremap.h>

--- a/dbms/src/Common/Allocator.cpp
+++ b/dbms/src/Common/Allocator.cpp
@@ -8,7 +8,12 @@
 #include <algorithm>
 #include <sys/mman.h>
 
+#include <Core/Defines.h>
+#ifdef THREAD_SANITIZER
+    #define DISABLE_MREMAP 1
+#endif
 #include <common/mremap.h>
+
 #include <Common/MemoryTracker.h>
 #include <Common/Exception.h>
 #include <Common/formatReadable.h>

--- a/libs/libcommon/include/common/mremap.h
+++ b/libs/libcommon/include/common/mremap.h
@@ -64,6 +64,10 @@ inline void * clickhouse_mremap(
     [[maybe_unused]] int mmap_fd = -1,
     [[maybe_unused]] off_t mmap_offset = 0)
 {
+#if DISABLE_MREMAP
+    return mremap_fallback(old_address, old_size, new_size, flags, mmap_prot, mmap_flags, mmap_fd, mmap_offset);
+#else
+
     return mremap(
         old_address,
         old_size,
@@ -77,4 +81,5 @@ inline void * clickhouse_mremap(
         mmap_offset
 #endif
         );
+#endif
 }

--- a/libs/libcommon/include/common/mremap.h
+++ b/libs/libcommon/include/common/mremap.h
@@ -6,23 +6,31 @@
 #include <sys/mman.h>
 #endif
 
-#if defined(MREMAP_MAYMOVE)
-// we already have implementation (linux)
-#else
-
-#define MREMAP_MAYMOVE 1
-
-void * mremap(
-    void * old_address,
-    size_t old_size,
-    size_t new_size,
-    int flags = 0,
-    int mmap_prot = 0,
-    int mmap_flags = 0,
-    int mmap_fd = -1,
-    off_t mmap_offset = 0);
-
+/// You can forcely disable mremap by defining DISABLE_MREMAP to 1 before including this file.
+#if !defined(DISABLE_MREMAP)
+    #if defined(MREMAP_MAYMOVE) && defined(MREMAP_MAYMOVE)
+        #define DISABLE_MREMAP 0
+    #else
+        #define DISABLE_MREMAP 1
+    #endif
 #endif
+
+
+#if DISABLE_MREMAP
+    #define MREMAP_MAYMOVE 1
+
+    /// Implement mremap with mmap/memcpy/munmap.
+    void * mremap(
+        void * old_address,
+        size_t old_size,
+        size_t new_size,
+        int flags = 0,
+        int mmap_prot = 0,
+        int mmap_flags = 0,
+        int mmap_fd = -1,
+        off_t mmap_offset = 0);
+#endif
+
 
 inline void * clickhouse_mremap(
     void * old_address,

--- a/libs/libcommon/src/mremap.cpp
+++ b/libs/libcommon/src/mremap.cpp
@@ -1,12 +1,12 @@
 #include <common/mremap.h>
+
+#if DISABLE_MREMAP
+
 #include <cstddef>
 #include <cstdlib>
 #include <cstring>
 #include <errno.h>
 
-#if defined(MREMAP_FIXED)
-// we already have implementation (linux)
-#else
 
 void * mremap(
     void * old_address, size_t old_size, size_t new_size, int flags, int mmap_prot, int mmap_flags, int mmap_fd, off_t mmap_offset)
@@ -18,7 +18,7 @@ void * mremap(
     if (!(flags & MREMAP_MAYMOVE))
     {
         errno = ENOMEM;
-        return nullptr;
+        return MAP_FAILED;
     }
 
 #if _MSC_VER
@@ -26,9 +26,7 @@ void * mremap(
 #else
     void * new_address = mmap(nullptr, new_size, mmap_prot, mmap_flags, mmap_fd, mmap_offset);
     if (MAP_FAILED == new_address)
-    {
         return MAP_FAILED;
-    }
 #endif
 
     memcpy(new_address, old_address, old_size);
@@ -37,9 +35,7 @@ void * mremap(
     delete old_address;
 #else
     if (munmap(old_address, old_size))
-    {
         abort();
-    }
 #endif
 
     return new_address;

--- a/libs/libcommon/src/mremap.cpp
+++ b/libs/libcommon/src/mremap.cpp
@@ -1,14 +1,12 @@
 #include <common/mremap.h>
 
-#if DISABLE_MREMAP
-
 #include <cstddef>
 #include <cstdlib>
 #include <cstring>
 #include <errno.h>
 
 
-void * mremap(
+void * mremap_fallback(
     void * old_address, size_t old_size, size_t new_size, int flags, int mmap_prot, int mmap_flags, int mmap_fd, off_t mmap_offset)
 {
     /// No actual shrink
@@ -40,5 +38,3 @@ void * mremap(
 
     return new_address;
 }
-
-#endif


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Disable usage of `mremap` when compiled with Thread Sanitizer. Surprisingly enough, TSan does not intercept `mremap` (though it does intercept `mmap`, `munmap`) that leads to false positives. Fixed TSan report in stateful tests.