### PR TITLE
Optimize Volnitsky by inlining compare function

### DIFF
--- a/dbms/src/Common/StringSearcher.h
+++ b/dbms/src/Common/StringSearcher.h
@@ -156,7 +156,7 @@ public:
 #endif
     }
 
-    bool compare(const UInt8 * pos) const
+    ALWAYS_INLINE bool compare(const UInt8 * pos) const
     {
         static const Poco::UTF8Encoding utf8;
 
@@ -374,7 +374,7 @@ public:
 #endif
     }
 
-    bool compare(const UInt8 * pos) const
+    ALWAYS_INLINE bool compare(const UInt8 * pos) const
     {
 #ifdef __SSE4_1__
         if (pageSafe(pos))
@@ -568,7 +568,7 @@ public:
 #endif
     }
 
-    bool compare(const UInt8 * pos) const
+    ALWAYS_INLINE bool compare(const UInt8 * pos) const
     {
 #ifdef __SSE4_1__
         if (pageSafe(pos))

--- a/dbms/src/Functions/FunctionsStringSearch.cpp
+++ b/dbms/src/Functions/FunctionsStringSearch.cpp
@@ -173,10 +173,7 @@ struct PositionImpl
 
             /// We check that the entry does not pass through the boundaries of strings.
             if (pos + needle.size() < begin + offsets[i])
-            {
-                size_t prev_offset = i != 0 ? offsets[i - 1] : 0;
-                res[i] = 1 + Impl::countChars(reinterpret_cast<const char *>(begin + prev_offset), reinterpret_cast<const char *>(pos));
-            }
+                res[i] = 1 + Impl::countChars(reinterpret_cast<const char *>(begin + offsets[i - 1]), reinterpret_cast<const char *>(pos));
             else
                 res[i] = 0;
 
@@ -306,7 +303,8 @@ struct MultiSearchAllPositionsImpl
         const std::vector<StringRef> & needles,
         PaddedPODArray<UInt64> & res)
     {
-        auto res_callback = [](const UInt8 * start, const UInt8 * end) -> UInt64 {
+        auto res_callback = [](const UInt8 * start, const UInt8 * end) -> UInt64
+        {
             return 1 + Impl::countChars(reinterpret_cast<const char *>(start), reinterpret_cast<const char *>(end));
         };
         Impl::createMultiSearcherInBigHaystack(needles).searchAllPositions(haystack_data, haystack_offsets, res_callback, res);
@@ -341,7 +339,8 @@ struct MultiSearchFirstPositionImpl
         const std::vector<StringRef> & needles,
         PaddedPODArray<UInt64> & res)
     {
-        auto res_callback = [](const UInt8 * start, const UInt8 * end) -> UInt64 {
+        auto res_callback = [](const UInt8 * start, const UInt8 * end) -> UInt64
+        {
             return 1 + Impl::countChars(reinterpret_cast<const char *>(start), reinterpret_cast<const char *>(end));
         };
         Impl::createMultiSearcherInBigHaystack(needles).searchFirstPosition(haystack_data, haystack_offsets, res_callback, res);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Performance Improvement

Short description (up to few sentences):
Optimize Volnitsky searcher by inlining, should be about 5-10% search improvement for queries with many needles or many similar bigrams

```
New:
{
    "bytes_per_second": 8399491347.017362,
    "min_time": 1.102000,
    "quantiles": {
        "0.1": 1.103980,
        "0.2": 1.105114,
        "0.3": 1.107664,
        "0.4": 1.111630,
        "0.5": 1.115596,
        "0.6": 1.116642,
        "0.7": 1.117689,
        "0.8": 1.122416,
        "0.9": 1.130826,
        "0.95": 1.135031,
        "0.99": 1.138395,
        "0.999": 1.139151,
        "0.9999": 1.139227
    },
    "queries_per_second": 0.895798,
    "query": "SELECT count() FROM hits_100m_single WHERE multiSearchAny(URL, ['chelyabinsk.74.ru', 'doctor.74.ru', 'transport.74.ru', 'm.74.ru', '//74.ru/', 'chel.74.ru', 'afisha.74.ru', 'diplom.74.ru', 'chelfin.ru', '//chel.ru', 'chelyabinsk.ru', 'cheldoctor.ru', '//mychel.ru', 'cheldiplom.ru', '74.ru/video', 'market', 'poll', 'mail', 'conference', 'consult', 'contest', 'tags', 'feedback', 'pages', 'text'])",
    "query_index": 22,
    "rows_per_second": 89579767.534917,
    "total_time": 5.581618
}
Old:
{
    "bytes_per_second": 7375106469.066102,
    "min_time": 1.252000,
    "quantiles": {
        "0.1": 1.252928,
        "0.2": 1.253537,
        "0.3": 1.257292,
        "0.4": 1.264194,
        "0.5": 1.271096,
        "0.6": 1.271365,
        "0.7": 1.271634,
        "0.8": 1.278974,
        "0.9": 1.293385,
        "0.95": 1.300590,
        "0.99": 1.306354,
        "0.999": 1.307651,
        "0.9999": 1.307781
    },
    "queries_per_second": 0.786548,
    "query": "SELECT count() FROM hits_100m_single WHERE multiSearchAny(URL, ['chelyabinsk.74.ru', 'doctor.74.ru', 'transport.74.ru', 'm.74.ru', '//74.ru/', 'chel.74.ru', 'afisha.74.ru', 'diplom.74.ru', 'chelfin.ru', '//chel.ru', 'chelyabinsk.ru', 'cheldoctor.ru', '//mychel.ru', 'cheldiplom.ru', '74.ru/video', 'market', 'poll', 'mail', 'conference', 'consult', 'contest', 'tags', 'feedback', 'pages', 'text'])",
    "query_index": 22,
    "rows_per_second": 78654801.314701,
    "total_time": 6.356891
}
```