### PR TITLE
Hyperscan better usage of scratch space and error handling

### DIFF
--- a/dbms/src/Common/ErrorCodes.cpp
+++ b/dbms/src/Common/ErrorCodes.cpp
@@ -421,6 +421,7 @@ namespace ErrorCodes
     extern const int UNKNOWN_PROTOBUF_FORMAT = 444;
     extern const int CANNOT_MPROTECT = 445;
     extern const int FUNCTION_NOT_ALLOWED = 446;
+    extern const int HYPERSCAN_CANNOT_SCAN_TEXT = 447;
 
     extern const int KEEPER_EXCEPTION = 999;
     extern const int POCO_EXCEPTION = 1000;

--- a/dbms/src/Functions/Regexps.h
+++ b/dbms/src/Functions/Regexps.h
@@ -104,7 +104,9 @@ namespace MultiRegexps
 
     struct Pool
     {
+        /// Mutex for finding in map
         std::mutex mutex;
+        /// Patterns + possible edit_distance to database and scratch
         std::map<std::pair<std::vector<String>, std::optional<UInt32>>, Regexps> storage;
     };
 
@@ -219,7 +221,7 @@ namespace MultiRegexps
             it = known_regexps.storage.emplace(
                 std::pair{str_patterns, edit_distance},
                 constructRegexps<FindAnyIndex, CompileForEditDistance>(str_patterns, edit_distance)).first;
-
+        lock.unlock();
         return &it->second;
     }
 }

--- a/dbms/src/Functions/Regexps.h
+++ b/dbms/src/Functions/Regexps.h
@@ -96,8 +96,8 @@ namespace MultiRegexps
     public:
         Regexps(hs_database_t * db_, hs_scratch_t * scratch_) : db{db_}, scratch{scratch_} {}
 
-        hs_database_t * getDB() const { return db.get(); };
-        hs_scratch_t * getScratch() const { return scratch.get(); };
+        hs_database_t * getDB() const { return db.get(); }
+        hs_scratch_t * getScratch() const { return scratch.get(); }
     private:
         DataBasePtr db;
         ScratchPtr scratch;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

Short description (up to few sentences):
We use hs_clone_scratch instead of hs_alloc_scratch because it is faster and recommended by the hyperscan API. Also, I add error handling for hs_scan (everything can happen, we should know about this).

`Database` is thread-safe, `Scratch` can be allocated once and copied many times. So no need to use the old pool, it is better to once safely add Regexps and use it over times.
