### PR TITLE
Fix multithreaded ASOF JOIN + some refactoring

### DIFF
--- a/dbms/src/Common/SortedLookupPODArray.h
+++ b/dbms/src/Common/SortedLookupPODArray.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <Common/PODArray.h>
+#include <vector>
+//#include <Common/PODArray.h>
 
 namespace DB
 {
@@ -17,7 +18,8 @@ template <typename T>
 class SortedLookupPODArray
 {
 public:
-    using Base = PaddedPODArray<T>;
+    using Base = std::vector<T>;
+    //using Base = PaddedPODArray<T>;
 
     template <typename U, typename ... TAllocatorParams>
     void insert(U && x, TAllocatorParams &&... allocator_params)

--- a/dbms/src/Common/SortedLookupPODArray.h
+++ b/dbms/src/Common/SortedLookupPODArray.h
@@ -13,36 +13,38 @@ namespace DB
  * This way the data only gets sorted once.
  */
 
-template <typename T, size_t INITIAL_SIZE = 4096, typename TAllocator = Allocator<false>>
-class SortedLookupPODArray : private PaddedPODArray<T, INITIAL_SIZE, TAllocator>
+template <typename T>
+class SortedLookupPODArray
 {
 public:
-    using Base = PaddedPODArray<T, INITIAL_SIZE, TAllocator>;
-    using typename Base::PODArray;
-    using Base::cbegin;
-    using Base::cend;
+    using Base = PaddedPODArray<T>;
 
     template <typename U, typename ... TAllocatorParams>
     void insert(U && x, TAllocatorParams &&... allocator_params)
     {
-        Base::push_back(std::forward<U>(x), std::forward<TAllocatorParams>(allocator_params)...);
+        array.push_back(std::forward<U>(x), std::forward<TAllocatorParams>(allocator_params)...);
         sorted = false;
     }
 
-    typename Base::const_iterator upper_bound (const T& k)
+    typename Base::const_iterator upper_bound(const T & k)
     {
         if (!sorted)
-            this->sort();
-        return std::upper_bound(this->cbegin(), this->cend(), k);
-    }
-private:
-    void sort()
-    {
-        std::sort(this->begin(), this->end());
-        sorted = true;
+            sort();
+        return std::upper_bound(array.cbegin(), array.cend(), k);
     }
 
+    typename Base::const_iterator cbegin() const { return array.cbegin(); }
+    typename Base::const_iterator cend() const { return array.cend(); }
+
+private:
+    Base array;
     bool sorted = false;
+
+    void sort()
+    {
+        std::sort(array.begin(), array.end());
+        sorted = true;
+    }
 };
 
 }

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -415,21 +415,22 @@ namespace
     template <typename Map, typename KeyGetter>
     struct Inserter<ASTTableJoin::Strictness::Asof, Map, KeyGetter>
     {
-        static ALWAYS_INLINE void insert(const Join & join, Map & map, KeyGetter & key_getter, Block * stored_block, size_t i, Arena & pool, const IColumn * asof_column)
+        static ALWAYS_INLINE void insert(Join & join, Map & map, KeyGetter & key_getter, Block * stored_block, size_t i, Arena & pool,
+                                         const IColumn * asof_column)
         {
             auto emplace_result = key_getter.emplaceKey(map, i, pool);
             typename Map::mapped_type * time_series_map = &emplace_result.getMapped();
 
             if (emplace_result.isInserted())
-                time_series_map = new (time_series_map) typename Map::mapped_type(join.getAsofType());
-            time_series_map->insert(asof_column, stored_block, i);
+                time_series_map = new (time_series_map) typename Map::mapped_type();
+            time_series_map->insert(join.getAsofType(), join.getAsofData(), asof_column, stored_block, i);
         }
     };
 
 
     template <ASTTableJoin::Strictness STRICTNESS, typename KeyGetter, typename Map, bool has_null_map>
     void NO_INLINE insertFromBlockImplTypeCase(
-        const Join & join, Map & map, size_t rows, const ColumnRawPtrs & key_columns,
+        Join & join, Map & map, size_t rows, const ColumnRawPtrs & key_columns,
         const Sizes & key_sizes, Block * stored_block, ConstNullMapPtr null_map, Arena & pool)
     {
         const IColumn * asof_column [[maybe_unused]] = nullptr;
@@ -453,7 +454,7 @@ namespace
 
     template <ASTTableJoin::Strictness STRICTNESS, typename KeyGetter, typename Map>
     void insertFromBlockImplType(
-        const Join & join, Map & map, size_t rows, const ColumnRawPtrs & key_columns,
+        Join & join, Map & map, size_t rows, const ColumnRawPtrs & key_columns,
         const Sizes & key_sizes, Block * stored_block, ConstNullMapPtr null_map, Arena & pool)
     {
         if (null_map)
@@ -465,7 +466,7 @@ namespace
 
     template <ASTTableJoin::Strictness STRICTNESS, typename Maps>
     void insertFromBlockImpl(
-        const Join & join, Join::Type type, Maps & maps, size_t rows, const ColumnRawPtrs & key_columns,
+        Join & join, Join::Type type, Maps & maps, size_t rows, const ColumnRawPtrs & key_columns,
         const Sizes & key_sizes, Block * stored_block, ConstNullMapPtr null_map, Arena & pool)
     {
         switch (type)
@@ -686,7 +687,7 @@ void addNotFoundRow(AddedColumns & added [[maybe_unused]], IColumn::Offset & cur
 /// Makes filter (1 if row presented in right table) and returns offsets to replicate (for ALL JOINS).
 template <bool _add_missing, ASTTableJoin::Strictness STRICTNESS, typename KeyGetter, typename Map, bool _has_null_map>
 std::unique_ptr<IColumn::Offsets> NO_INLINE joinRightIndexedColumns(
-    const Map & map, size_t rows, const ColumnRawPtrs & key_columns, const Sizes & key_sizes,
+    const Join & join, const Map & map, size_t rows, const ColumnRawPtrs & key_columns, const Sizes & key_sizes,
     AddedColumns & added_columns, ConstNullMapPtr null_map, IColumn::Filter & filter)
 {
     std::unique_ptr<IColumn::Offsets> offsets_to_replicate;
@@ -719,7 +720,7 @@ std::unique_ptr<IColumn::Offsets> NO_INLINE joinRightIndexedColumns(
 
                 if constexpr (STRICTNESS == ASTTableJoin::Strictness::Asof)
                 {
-                    if (const RowRef * found = mapped.findAsof(asof_column, i))
+                    if (const RowRef * found = mapped.findAsof(join.getAsofType(), join.getAsofData(), asof_column, i))
                     {
                         filter[i] = 1;
                         mapped.setUsed();
@@ -748,7 +749,7 @@ std::unique_ptr<IColumn::Offsets> NO_INLINE joinRightIndexedColumns(
 
 template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename KeyGetter, typename Map>
 IColumn::Filter joinRightColumns(
-    const Map & map, size_t rows, const ColumnRawPtrs & key_columns, const Sizes & key_sizes,
+    const Join & join, const Map & map, size_t rows, const ColumnRawPtrs & key_columns, const Sizes & key_sizes,
     AddedColumns & added_columns, ConstNullMapPtr null_map, std::unique_ptr<IColumn::Offsets> & offsets_to_replicate)
 {
     constexpr bool left_or_full = static_in_v<KIND, ASTTableJoin::Kind::Left, ASTTableJoin::Kind::Full>;
@@ -757,17 +758,17 @@ IColumn::Filter joinRightColumns(
 
     if (null_map)
         offsets_to_replicate = joinRightIndexedColumns<left_or_full, STRICTNESS, KeyGetter, Map, true>(
-            map, rows, key_columns, key_sizes, added_columns, null_map, filter);
+            join, map, rows, key_columns, key_sizes, added_columns, null_map, filter);
     else
         offsets_to_replicate = joinRightIndexedColumns<left_or_full, STRICTNESS, KeyGetter, Map, false>(
-            map, rows, key_columns, key_sizes, added_columns, null_map, filter);
+            join, map, rows, key_columns, key_sizes, added_columns, null_map, filter);
 
     return filter;
 }
 
 template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS, typename Maps>
 IColumn::Filter switchJoinRightColumns(
-    Join::Type type,
+    Join::Type type, const Join & join,
     const Maps & maps_, size_t rows, const ColumnRawPtrs & key_columns, const Sizes & key_sizes,
     AddedColumns & added_columns, ConstNullMapPtr null_map,
     std::unique_ptr<IColumn::Offsets> & offsets_to_replicate)
@@ -777,7 +778,7 @@ IColumn::Filter switchJoinRightColumns(
     #define M(TYPE) \
         case Join::Type::TYPE: \
             return joinRightColumns<KIND, STRICTNESS, typename KeyGetterForType<Join::Type::TYPE, const std::remove_reference_t<decltype(*maps_.TYPE)>>::Type>(\
-                *maps_.TYPE, rows, key_columns, key_sizes, added_columns, null_map, offsets_to_replicate);
+                join, *maps_.TYPE, rows, key_columns, key_sizes, added_columns, null_map, offsets_to_replicate);
         APPLY_FOR_JOIN_VARIANTS(M)
     #undef M
 
@@ -851,7 +852,7 @@ void Join::joinBlockImpl(
     std::unique_ptr<IColumn::Offsets> offsets_to_replicate;
 
     IColumn::Filter row_filter = switchJoinRightColumns<KIND, STRICTNESS>(
-        type, maps_, block.rows(), key_columns, key_sizes, added, null_map, offsets_to_replicate);
+        type, *this, maps_, block.rows(), key_columns, key_sizes, added, null_map, offsets_to_replicate);
 
     for (size_t i = 0; i < added.size(); ++i)
         block.insert(added.moveColumn(i));

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -301,9 +301,8 @@ void Join::setSampleBlock(const Block & block)
         const IColumn * asof_column = key_columns.back();
         size_t asof_size;
 
-        if (auto t = AsofRowRefs::getTypeSize(asof_column))
-            std::tie(asof_type, asof_size) = *t;
-        else
+        asof_type = AsofRowRefs::getTypeSize(asof_column, asof_size);
+        if (!asof_type)
         {
             std::string msg = "ASOF join not supported for type";
             msg += asof_column->getFamilyName();

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -422,7 +422,7 @@ namespace
 
             if (emplace_result.isInserted())
                 time_series_map = new (time_series_map) typename Map::mapped_type(join.getAsofType());
-            time_series_map->insert(asof_column, stored_block, i, pool);
+            time_series_map->insert(asof_column, stored_block, i);
         }
     };
 
@@ -719,7 +719,7 @@ std::unique_ptr<IColumn::Offsets> NO_INLINE joinRightIndexedColumns(
 
                 if constexpr (STRICTNESS == ASTTableJoin::Strictness::Asof)
                 {
-                    if (const RowRef * found = mapped.findAsof(asof_column, i, pool))
+                    if (const RowRef * found = mapped.findAsof(asof_column, i))
                     {
                         filter[i] = 1;
                         mapped.setUsed();

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -131,7 +131,7 @@ public:
     size_t getTotalByteCount() const;
 
     ASTTableJoin::Kind getKind() const { return kind; }
-    AsofRowRefs::Type getAsofType() const { return asof_type; }
+    AsofRowRefs::Type getAsofType() const { return *asof_type; }
 
     /** Depending on template parameter, adds or doesn't add a flag, that element was used (row was joined).
       * Depending on template parameter, decide whether to overwrite existing values when encountering the same key again
@@ -366,7 +366,7 @@ private:
 
 private:
     Type type = Type::EMPTY;
-    AsofRowRefs::Type asof_type = AsofRowRefs::Type::EMPTY;
+    std::optional<AsofRowRefs::Type> asof_type;
 
     static Type chooseMethod(const ColumnRawPtrs & key_columns, Sizes & key_sizes);
 

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -132,6 +132,8 @@ public:
 
     ASTTableJoin::Kind getKind() const { return kind; }
     AsofRowRefs::Type getAsofType() const { return *asof_type; }
+    AsofRowRefs::LookupLists & getAsofData() { return asof_lookup_lists; }
+    const AsofRowRefs::LookupLists & getAsofData() const { return asof_lookup_lists; }
 
     /** Depending on template parameter, adds or doesn't add a flag, that element was used (row was joined).
       * Depending on template parameter, decide whether to overwrite existing values when encountering the same key again
@@ -367,6 +369,7 @@ private:
 private:
     Type type = Type::EMPTY;
     std::optional<AsofRowRefs::Type> asof_type;
+    AsofRowRefs::LookupLists asof_lookup_lists;
 
     static Type chooseMethod(const ColumnRawPtrs & key_columns, Sizes & key_sizes);
 

--- a/dbms/src/Interpreters/RowRefs.cpp
+++ b/dbms/src/Interpreters/RowRefs.cpp
@@ -30,56 +30,55 @@ void callWithType(AsofRowRefs::Type which, F && f)
 } // namespace
 
 
-void AsofRowRefs::createLookup(AsofRowRefs::Type which)
+void AsofRowRefs::insert(Type type, LookupLists & lookup_data, const IColumn * asof_column, const Block * block, size_t row_num)
 {
     auto call = [&](const auto & t)
     {
         using T = std::decay_t<decltype(t)>;
         using LookupType = typename Entry<T>::LookupType;
 
-        lookups = std::make_unique<LookupType>();
-    };
-
-    callWithType(which, call);
-}
-
-
-void AsofRowRefs::insert(const IColumn * asof_column, const Block * block, size_t row_num)
-{
-    auto call = [&](const auto & t)
-    {
-        using T = std::decay_t<decltype(t)>;
-        using LookupPtr = typename Entry<T>::LookupPtr;
-
         auto * column = typeid_cast<const ColumnVector<T> *>(asof_column);
         T key = column->getElement(row_num);
         auto entry = Entry<T>(key, RowRef(block, row_num));
 
-        std::get<LookupPtr>(lookups)->insert(entry);
+        std::lock_guard<std::mutex> lock(lookup_data.mutex);
+
+        if (!lookups)
+        {
+            lookup_data.lookups.push_back(Lookups());
+            lookup_data.lookups.back() = LookupType();
+            lookups = &lookup_data.lookups.back();
+        }
+        std::get<LookupType>(*lookups).insert(entry);
     };
 
-    callWithType(*type, call);
+    callWithType(type, call);
 }
 
-const RowRef * AsofRowRefs::findAsof(const IColumn * asof_column, size_t row_num) const
+const RowRef * AsofRowRefs::findAsof(Type type, const LookupLists & lookup_data, const IColumn * asof_column, size_t row_num) const
 {
     const RowRef * out = nullptr;
 
     auto call = [&](const auto & t)
     {
         using T = std::decay_t<decltype(t)>;
-        using LookupPtr = typename Entry<T>::LookupPtr;
+        using LookupType = typename Entry<T>::LookupType;
 
         auto * column = typeid_cast<const ColumnVector<T> *>(asof_column);
         T key = column->getElement(row_num);
 
-        auto & typed_lookup = std::get<LookupPtr>(lookups);
-        auto it = typed_lookup->upper_bound(Entry<T>(key));
-        if (it != typed_lookup->cbegin())
+        std::lock_guard<std::mutex> lock(lookup_data.mutex);
+
+        if (!lookups)
+            return;
+
+        auto & typed_lookup = std::get<LookupType>(*lookups);
+        auto it = typed_lookup.upper_bound(Entry<T>(key));
+        if (it != typed_lookup.cbegin())
             out = &((--it)->row_ref);
     };
 
-    callWithType(*type, call);
+    callWithType(type, call);
     return out;
 }
 

--- a/dbms/src/Interpreters/RowRefs.h
+++ b/dbms/src/Interpreters/RowRefs.h
@@ -83,7 +83,7 @@ public:
     const RowRef * findAsof(const IColumn * asof_column, size_t row_num, Arena & pool) const;
 
 private:
-    const std::optional<Type> type;
+    const std::optional<Type> type = {};
     mutable Lookups lookups;
 
     void createLookup(Type which);

--- a/dbms/src/Interpreters/RowRefs.h
+++ b/dbms/src/Interpreters/RowRefs.h
@@ -33,34 +33,29 @@ struct RowRefList : RowRef
 class AsofRowRefs
 {
 public:
-    template<typename T>
+    template <typename T>
     struct Entry
     {
+        using LookupType = SortedLookupPODArray<Entry<T>>;
+        using LookupPtr = std::unique_ptr<LookupType>;
+
         T asof_value;
         RowRef row_ref;
 
         Entry(T v) : asof_value(v) {}
         Entry(T v, RowRef rr) : asof_value(v), row_ref(rr) {}
 
-        bool operator< (const Entry& o) const
+        bool operator < (const Entry & o) const
         {
             return asof_value < o.asof_value;
         }
     };
 
-    template <typename T>
-    struct LookupTypes
-    {
-        using ElementType = T;
-        using SearcherType = SortedLookupPODArray<Entry<T>>;
-        using Ptr = std::unique_ptr<SearcherType>;
-    };
-
     using Lookups = std::variant<
-        LookupTypes<UInt32>::Ptr,
-        LookupTypes<UInt64>::Ptr,
-        LookupTypes<Float32>::Ptr,
-        LookupTypes<Float64>::Ptr>;
+        Entry<UInt32>::LookupPtr,
+        Entry<UInt64>::LookupPtr,
+        Entry<Float32>::LookupPtr,
+        Entry<Float64>::LookupPtr>;
 
     enum class Type
     {
@@ -79,8 +74,8 @@ public:
         createLookup(t);
     }
 
-    void insert(const IColumn * asof_column, const Block * block, size_t row_num, Arena & pool);
-    const RowRef * findAsof(const IColumn * asof_column, size_t row_num, Arena & pool) const;
+    void insert(const IColumn * asof_column, const Block * block, size_t row_num);
+    const RowRef * findAsof(const IColumn * asof_column, size_t row_num) const;
 
 private:
     const std::optional<Type> type = {};


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bugfix

Short description (up to few sentences):
Add locks for ASOF lookup data cause it has multithreaded access. Replace some macro code with templates.