### PR TITLE
Fix alter modify of codec when column type is not specified

### DIFF
--- a/dbms/src/Compression/CompressionCodecDelta.h
+++ b/dbms/src/Compression/CompressionCodecDelta.h
@@ -14,15 +14,18 @@ public:
 
     String getCodecDesc() const override;
 
+    void useInfoAboutType(DataTypePtr data_type) override;
+
 protected:
     UInt32 doCompressData(const char * source, UInt32 source_size, char * dest) const override;
 
     void doDecompressData(const char * source, UInt32 source_size, char * dest, UInt32 uncompressed_size) const override;
 
     UInt32 getMaxCompressedDataSize(UInt32 uncompressed_size) const override { return uncompressed_size + 2; }
+
+
 private:
-    const UInt8 delta_bytes_size;
+    UInt8 delta_bytes_size;
 };
 
 }
-

--- a/dbms/src/Compression/CompressionCodecMultiple.cpp
+++ b/dbms/src/Compression/CompressionCodecMultiple.cpp
@@ -21,16 +21,6 @@ extern const int CORRUPTED_DATA;
 CompressionCodecMultiple::CompressionCodecMultiple(Codecs codecs)
     : codecs(codecs)
 {
-    std::ostringstream ss;
-    for (size_t idx = 0; idx < codecs.size(); idx++)
-    {
-        if (idx != 0)
-            ss << ',' << ' ';
-
-        const auto codec = codecs[idx];
-        ss << codec->getCodecDesc();
-    }
-    codec_desc = ss.str();
 }
 
 UInt8 CompressionCodecMultiple::getMethodByte() const
@@ -40,7 +30,16 @@ UInt8 CompressionCodecMultiple::getMethodByte() const
 
 String CompressionCodecMultiple::getCodecDesc() const
 {
-    return codec_desc;
+    std::ostringstream ss;
+    for (size_t idx = 0; idx < codecs.size(); idx++)
+    {
+        if (idx != 0)
+            ss << ',' << ' ';
+
+        const auto codec = codecs[idx];
+        ss << codec->getCodecDesc();
+    }
+    return ss.str();
 }
 
 UInt32 CompressionCodecMultiple::getMaxCompressedDataSize(UInt32 uncompressed_size) const
@@ -77,6 +76,14 @@ UInt32 CompressionCodecMultiple::doCompressData(const char * source, UInt32 sour
     memcpy(&dest[1 + codecs.size()], uncompressed_buf.data(), source_size);
 
     return 1 + codecs.size() + source_size;
+}
+
+void CompressionCodecMultiple::useInfoAboutType(DataTypePtr data_type)
+{
+    for (auto & codec : codecs)
+    {
+        codec->useInfoAboutType(data_type);
+    }
 }
 
 void CompressionCodecMultiple::doDecompressData(const char * source, UInt32 source_size, char * dest, UInt32 decompressed_size) const

--- a/dbms/src/Compression/CompressionCodecMultiple.h
+++ b/dbms/src/Compression/CompressionCodecMultiple.h
@@ -17,6 +17,8 @@ public:
 
     UInt32 getMaxCompressedDataSize(UInt32 uncompressed_size) const override;
 
+    void useInfoAboutType(DataTypePtr data_type) override;
+
 protected:
     UInt32 doCompressData(const char * source, UInt32 source_size, char * dest) const override;
 
@@ -24,7 +26,6 @@ protected:
 
 private:
     Codecs codecs;
-    String codec_desc;
 
 };
 

--- a/dbms/src/Compression/ICompressionCodec.h
+++ b/dbms/src/Compression/ICompressionCodec.h
@@ -58,6 +58,9 @@ public:
     /// Read method byte from compressed source
     static UInt8 readMethod(const char * source);
 
+    /// Some codecs may use information about column type which appears after codec creation
+    virtual void useInfoAboutType(DataTypePtr /* data_type */) { }
+
 protected:
 
     /// Return size of compressed data without header

--- a/dbms/src/Storages/AlterCommands.cpp
+++ b/dbms/src/Storages/AlterCommands.cpp
@@ -59,7 +59,7 @@ std::optional<AlterCommand> AlterCommand::parse(const ASTAlterCommand * command_
         }
 
         if (ast_col_decl.codec)
-            command.codec = compression_codec_factory.get(ast_col_decl.codec);
+            command.codec = compression_codec_factory.get(ast_col_decl.codec, command.data_type);
 
         if (command_ast->column)
             command.after_column = *getIdentifierName(command_ast->column);
@@ -105,7 +105,7 @@ std::optional<AlterCommand> AlterCommand::parse(const ASTAlterCommand * command_
         }
 
         if (ast_col_decl.codec)
-            command.codec = compression_codec_factory.get(ast_col_decl.codec);
+            command.codec = compression_codec_factory.get(ast_col_decl.codec, command.data_type);
 
         command.if_exists = command_ast->if_exists;
 
@@ -190,7 +190,13 @@ void AlterCommand::apply(ColumnsDescription & columns_description, IndicesDescri
         ColumnDescription & column = columns_description.get(column_name);
 
         if (codec)
+        {
+            /// User doesn't specify data type, it means that datatype doesn't change
+            /// let's use info about old type
+            if (data_type == nullptr)
+                codec->useInfoAboutType(column.type);
             column.codec = codec;
+        }
 
         if (!is_mutable())
         {

--- a/dbms/tests/queries/0_stateless/00804_test_delta_codec_no_type_alter.reference
+++ b/dbms/tests/queries/0_stateless/00804_test_delta_codec_no_type_alter.reference
@@ -1,0 +1,3 @@
+CODEC(Delta(4))
+CODEC(Delta(4), LZ4)
+CODEC(Delta(8), LZ4)

--- a/dbms/tests/queries/0_stateless/00804_test_delta_codec_no_type_alter.sql
+++ b/dbms/tests/queries/0_stateless/00804_test_delta_codec_no_type_alter.sql
@@ -1,0 +1,10 @@
+SET send_logs_level = 'none';
+
+DROP TABLE IF EXISTS test.delta_codec_for_alter;
+CREATE TABLE test.delta_codec_for_alter (date Date, x UInt32 Codec(Delta), s FixedString(128)) ENGINE = MergeTree ORDER BY tuple();
+SELECT compression_codec FROM system.columns WHERE database = 'test' AND table = 'delta_codec_for_alter' AND name = 'x';
+ALTER TABLE test.delta_codec_for_alter MODIFY COLUMN x Codec(Delta, LZ4);
+SELECT compression_codec FROM system.columns WHERE database = 'test' AND table = 'delta_codec_for_alter' AND name = 'x';
+ALTER TABLE test.delta_codec_for_alter MODIFY COLUMN x UInt64 Codec(Delta, LZ4);
+SELECT compression_codec FROM system.columns WHERE database = 'test' AND table = 'delta_codec_for_alter' AND name = 'x';
+DROP TABLE IF EXISTS test.delta_codec_for_alter;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fix bug in codecs parameters detection in `ALTER MODIFY` of codec without type of column.
