### PR TITLE
Add Sematext clickhouse integrations to 3rd party docs

### DIFF
--- a/docs/en/interfaces/third-party/integrations.md
+++ b/docs/en/interfaces/third-party/integrations.md
@@ -35,11 +35,16 @@
         - [clickhouse_exporter](https://github.com/hot-wifi/clickhouse_exporter) (uses [Go client](https://github.com/kshvakov/clickhouse/))
     - [Nagios](https://www.nagios.org/)
         - [check_clickhouse](https://github.com/exogroup/check_clickhouse/)
+    - [Sematext](https://sematext.com/)
+        -  [Monitoring ClickHouse with Sematext](https://sematext.com/blog/clickhouse-monitoring-sematext/)
+        -  [clickhouse integration](https://github.com/sematext/sematext-agent-integrations/tree/master/clickhouse)
 - Logging
     - [rsyslog](https://www.rsyslog.com/)
         - [omclickhouse](https://www.rsyslog.com/doc/master/configuration/modules/omclickhouse.html)
     - [fluentd](https://www.fluentd.org)
         - [loghouse](https://github.com/flant/loghouse) (for [Kubernetes](https://kubernetes.io))
+    - [logagent](https://www.sematext.com/logagent)
+        - [logagent output-plugin-clickhouse](https://sematext.com/docs/logagent/output-plugin-clickhouse/)
 
 ## Programming Language Ecosystems
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Other 

Short description (up to few sentences):

Add Sematext clickhouse integrations to 3rd party docs

...

Detailed description (optional):

...
