### PR TITLE
Fix functions cutQueryStringAndFragment() and queryStringAndFragment().

### DIFF
--- a/dbms/src/Functions/queryStringAndFragment.h
+++ b/dbms/src/Functions/queryStringAndFragment.h
@@ -17,15 +17,15 @@ struct ExtractQueryStringAndFragment
         res_data = data;
         res_size = 0;
 
-        Pos pos = data;
-        Pos end = pos + size;
+        Pos end = data + size;
+        Pos pos;
 
-        if (end != (pos = find_first_symbols<'?'>(pos, end)))
+        if (end != (pos = find_first_symbols<'?'>(data, end)))
         {
             res_data = pos + (without_leading_char ? 1 : 0);
             res_size = end - res_data;
         }
-        else if (end != (pos = find_first_symbols<'#'>(pos, end)))
+        else if (end != (pos = find_first_symbols<'#'>(data, end)))
         {
             res_data = pos;
             res_size = end - res_data;

--- a/dbms/tests/queries/0_stateless/00398_url_functions.reference
+++ b/dbms/tests/queries/0_stateless/00398_url_functions.reference
@@ -52,6 +52,7 @@ query=hello world+foo+bar
 query=hello world+foo+bar#a=b
 query=hello world+foo+bar#a=b
 query=hello world+foo+bar#a=b
+#a=b
 ====CUT TO FIRST SIGNIFICANT SUBDOMAIN====
 example.com
 example.com
@@ -91,4 +92,5 @@ http://www.example.com/a/b/c
 http://www.example.com/a/b/c
 http://www.example.com/a/b/c
 http://paul@www.example.com/a/b/c
+//paul@www.example.com/a/b/c
 //paul@www.example.com/a/b/c

--- a/dbms/tests/queries/0_stateless/00398_url_functions.sql
+++ b/dbms/tests/queries/0_stateless/00398_url_functions.sql
@@ -59,6 +59,7 @@ SELECT decodeURLComponent(queryStringAndFragment('http://127.0.0.1/?query=hello%
 SELECT decodeURLComponent(queryStringAndFragment('http://127.0.0.1/?query=hello%20world+foo%2Bbar#a=b'));
 SELECT decodeURLComponent(queryStringAndFragment('http://paul@127.0.0.1/?query=hello%20world+foo%2Bbar#a=b'));
 SELECT decodeURLComponent(queryStringAndFragment('//paul@127.0.0.1/?query=hello%20world+foo%2Bbar#a=b'));
+SELECT decodeURLComponent(queryStringAndFragment('//paul@127.0.0.1/#a=b'));
 
 SELECT '====CUT TO FIRST SIGNIFICANT SUBDOMAIN====';
 SELECT cutToFirstSignificantSubdomain('http://www.example.com');
@@ -104,4 +105,5 @@ SELECT cutQueryStringAndFragment('http://www.example.com/a/b/c?a=b');
 SELECT cutQueryStringAndFragment('http://www.example.com/a/b/c?a=b#d=f');
 SELECT cutQueryStringAndFragment('http://paul@www.example.com/a/b/c?a=b#d=f');
 SELECT cutQueryStringAndFragment('//paul@www.example.com/a/b/c?a=b#d=f');
+SELECT cutQueryStringAndFragment('//paul@www.example.com/a/b/c#d=f');
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Functions cutQueryStringAndFragment() and queryStringAndFragment() now works correctly when url contains a fragment and no query. 