### PR TITLE
Fix aio seek after eof

### DIFF
--- a/dbms/src/IO/ReadBufferAIO.cpp
+++ b/dbms/src/IO/ReadBufferAIO.cpp
@@ -187,6 +187,9 @@ off_t ReadBufferAIO::doSeek(off_t off, int whence)
             pos = working_buffer.end();
             first_unread_pos_in_file = new_pos_in_file;
 
+            /// If we goes back, than it's not eof
+            is_eof = false;
+
             /// We can not use the result of the current asynchronous request.
             skip();
         }

--- a/dbms/src/IO/ReadBufferAIO.cpp
+++ b/dbms/src/IO/ReadBufferAIO.cpp
@@ -187,7 +187,7 @@ off_t ReadBufferAIO::doSeek(off_t off, int whence)
             pos = working_buffer.end();
             first_unread_pos_in_file = new_pos_in_file;
 
-            /// If we goes back, than it's not eof
+            /// If we go back, than it's not eof
             is_eof = false;
 
             /// We can not use the result of the current asynchronous request.

--- a/dbms/src/IO/ReadBufferFromFileBase.h
+++ b/dbms/src/IO/ReadBufferFromFileBase.h
@@ -43,6 +43,7 @@ protected:
     ProfileCallback profile_callback;
     clockid_t clock_type;
 
+    /// Children implementation should be able to seek backwards
     virtual off_t doSeek(off_t off, int whence) = 0;
 };
 

--- a/dbms/src/IO/tests/gtest_aio_seek_back_after_eof.cpp
+++ b/dbms/src/IO/tests/gtest_aio_seek_back_after_eof.cpp
@@ -1,0 +1,71 @@
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+#pragma clang diagnostic ignored "-Wundef"
+#endif
+#include <gtest/gtest.h>
+
+#include <Core/Defines.h>
+#include <port/unistd.h>
+#include <IO/ReadBufferAIO.h>
+#include <fstream>
+
+namespace
+{
+std::string createTmpFileForEOFtest()
+{
+    char pattern[] = "/tmp/fileXXXXXX";
+    char * dir = ::mkdtemp(pattern);
+    return std::string(dir) + "/foo";
+}
+
+void prepare_for_eof(std::string & filename, std::string & buf)
+{
+    static const std::string symbols = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+    filename = createTmpFileForEOFtest();
+
+    size_t n = 10 * DEFAULT_AIO_FILE_BLOCK_SIZE;
+    buf.reserve(n);
+
+    for (size_t i = 0; i < n; ++i)
+        buf += symbols[i % symbols.length()];
+
+    std::ofstream out(filename.c_str());
+    out << buf;
+}
+
+
+}
+TEST(ReadBufferAIOTest, TestReadAfterAIO)
+{
+    using namespace DB;
+    std::string data;
+    std::string file_path;
+    prepare_for_eof(file_path, data);
+    ReadBufferAIO testbuf(file_path);
+
+    std::string newdata;
+    newdata.resize(data.length());
+
+    size_t total_read = testbuf.read(newdata.data(), newdata.length());
+    EXPECT_EQ(total_read, data.length());
+    EXPECT_TRUE(testbuf.eof());
+
+
+    testbuf.seek(data.length() - 100);
+
+    std::string smalldata;
+    smalldata.resize(100);
+    size_t read_after_eof = testbuf.read(smalldata.data(), smalldata.size());
+    EXPECT_EQ(read_after_eof, 100);
+    EXPECT_TRUE(testbuf.eof());
+
+
+    testbuf.seek(0);
+    std::string repeatdata;
+    repeatdata.resize(data.length());
+    size_t read_after_eof_big = testbuf.read(repeatdata.data(), repeatdata.size());
+    EXPECT_EQ(read_after_eof_big, data.length());
+    EXPECT_TRUE(testbuf.eof());
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fix bug in `ReadBufferAIO` which was not able to seek backwards after EOF (now it can). In case of concurrent `SELECT` query some threads may "steal" portions of read-data from other threads and seek backwards in buffers. It leads to `Can't adjust last granule` error in rare cases if setting `min_bytes_to_use_direct_io` was set to positive number.
