### PR TITLE
Add logger config for clickhouse-copier doc.

### DIFF
--- a/docs/en/operations/utils/clickhouse-copier.md
+++ b/docs/en/operations/utils/clickhouse-copier.md
@@ -38,6 +38,12 @@ Parameters:
 
 ```xml
 <yandex>
+    <logger>
+        <level>trace</level>
+        <size>100M</size>
+        <count>3</count>
+    </logger>
+
     <zookeeper>
         <node index="1">
             <host>127.0.0.1</host>

--- a/docs/ru/operations/utils/clickhouse-copier.md
+++ b/docs/ru/operations/utils/clickhouse-copier.md
@@ -37,6 +37,12 @@ clickhouse-copier copier --daemon --config zookeeper.xml --task-path /task/path 
 
 ```xml
 <yandex>
+    <logger>
+        <level>trace</level>
+        <size>100M</size>
+        <count>3</count>
+    </logger>
+
     <zookeeper>
         <node index="1">
             <host>127.0.0.1</host>

--- a/docs/zh/operations/utils/clickhouse-copier.md
+++ b/docs/zh/operations/utils/clickhouse-copier.md
@@ -38,6 +38,12 @@ Parameters:
 
 ```xml
 <yandex>
+    <logger>
+        <level>trace</level>
+        <size>100M</size>
+        <count>3</count>
+    </logger>
+
     <zookeeper>
         <node index="1">
             <host>127.0.0.1</host>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category:
- Other

Short description:

`clickhouse-copier` will fail without logger config. The error message is not very helpful for identifying the problem, so it's better to include logger config in document.