### PR TITLE
Miscellaneous changes

### DIFF
--- a/dbms/src/Core/Defines.h
+++ b/dbms/src/Core/Defines.h
@@ -86,7 +86,7 @@
 #define PLATFORM_NOT_SUPPORTED "The only supported platforms are x86_64 and AArch64, PowerPC (work in progress)"
 
 #if !defined(__x86_64__) && !defined(__aarch64__) && !defined(__PPC__)
-//    #error PLATFORM_NOT_SUPPORTED
+    #error PLATFORM_NOT_SUPPORTED
 #endif
 
 /// Check for presence of address sanitizer
@@ -112,10 +112,12 @@
 #if defined(__clang__)
     #define NO_SANITIZE_UNDEFINED __attribute__((__no_sanitize__("undefined")))
     #define NO_SANITIZE_ADDRESS __attribute__((__no_sanitize__("address")))
+    #define NO_SANITIZE_THREAD __attribute__((__no_sanitize__("thread")))
 #else
     /// It does not work in GCC. GCC 7 cannot recognize this attribute and GCC 8 simply ignores it.
     #define NO_SANITIZE_UNDEFINED
     #define NO_SANITIZE_ADDRESS
+    #define NO_SANITIZE_THREAD
 #endif
 
 #if defined __GNUC__ && !defined __clang__

--- a/dbms/src/DataStreams/ParallelInputsProcessor.h
+++ b/dbms/src/DataStreams/ParallelInputsProcessor.h
@@ -95,12 +95,11 @@ public:
     {
         active_threads = max_threads;
         threads.reserve(max_threads);
-        auto thread_group = CurrentThread::getGroup();
 
         try
         {
             for (size_t i = 0; i < max_threads; ++i)
-                threads.emplace_back(&ParallelInputsProcessor::thread, this, std::move(thread_group), i);
+                threads.emplace_back(&ParallelInputsProcessor::thread, this, CurrentThread::getGroup(), i);
         }
         catch (...)
         {

--- a/dbms/src/DataStreams/ParallelInputsProcessor.h
+++ b/dbms/src/DataStreams/ParallelInputsProcessor.h
@@ -100,7 +100,7 @@ public:
         try
         {
             for (size_t i = 0; i < max_threads; ++i)
-                threads.emplace_back([=] () { thread(thread_group, i); });
+                threads.emplace_back(&ParallelInputsProcessor::thread, this, std::move(thread_group), i);
         }
         catch (...)
         {


### PR DESCRIPTION
Avoid one or two copies of std::shared_ptr.
More clean stack trace in TSan about false positive report inside libc++ related to std::shared_ptr/std::weak_ptr.