### PR TITLE
Settings constraints

### DIFF
--- a/dbms/programs/benchmark/Benchmark.cpp
+++ b/dbms/programs/benchmark/Benchmark.cpp
@@ -451,14 +451,14 @@ int mainEntryClickHouseBenchmark(int argc, char ** argv)
             ("password",      value<std::string>()->default_value(""),          "")
             ("database",      value<std::string>()->default_value("default"),   "")
             ("stacktrace",                                                      "print stack traces of exceptions")
-
-        #define DECLARE_SETTING(TYPE, NAME, DEFAULT, DESCRIPTION) (#NAME, boost::program_options::value<std::string> (), DESCRIPTION)
-            APPLY_FOR_SETTINGS(DECLARE_SETTING)
-        #undef DECLARE_SETTING
         ;
+
+        Settings settings;
+        settings.addProgramOptions(desc);
 
         boost::program_options::variables_map options;
         boost::program_options::store(boost::program_options::parse_command_line(argc, argv, desc), options);
+        boost::program_options::notify(options);
 
         if (options.count("help"))
         {
@@ -468,15 +468,6 @@ int mainEntryClickHouseBenchmark(int argc, char ** argv)
         }
 
         print_stacktrace = options.count("stacktrace");
-
-        /// Extract `settings` and `limits` from received `options`
-        Settings settings;
-
-        #define EXTRACT_SETTING(TYPE, NAME, DEFAULT, DESCRIPTION) \
-        if (options.count(#NAME)) \
-            settings.set(#NAME, options[#NAME].as<std::string>());
-        APPLY_FOR_SETTINGS(EXTRACT_SETTING)
-        #undef EXTRACT_SETTING
 
         UseSSL use_ssl;
 

--- a/dbms/programs/client/Client.cpp
+++ b/dbms/programs/client/Client.cpp
@@ -816,8 +816,7 @@ private:
             {
                 if (!old_settings)
                     old_settings.emplace(context.getSettingsRef());
-                for (const auto & change : settings_ast.as<ASTSetQuery>()->changes)
-                    context.setSetting(change.name, change.value);
+                context.applySettingsChanges(settings_ast.as<ASTSetQuery>()->changes);
             };
             const auto * insert = parsed_query->as<ASTInsertQuery>();
             if (insert && insert->settings_ast)
@@ -847,7 +846,7 @@ private:
                     if (change.name == "profile")
                         current_profile = change.value.safeGet<String>();
                     else
-                        context.setSetting(change.name, change.value);
+                        context.applySettingChange(change);
                 }
             }
 

--- a/dbms/programs/local/LocalServer.cpp
+++ b/dbms/programs/local/LocalServer.cpp
@@ -69,11 +69,7 @@ void LocalServer::initialize(Poco::Util::Application & self)
 
 void LocalServer::applyCmdSettings()
 {
-#define EXTRACT_SETTING(TYPE, NAME, DEFAULT, DESCRIPTION) \
-        if (cmd_settings.NAME.changed) \
-            context->getSettingsRef().NAME = cmd_settings.NAME;
-        APPLY_FOR_SETTINGS(EXTRACT_SETTING)
-#undef EXTRACT_SETTING
+    context->getSettingsRef().copyChangesFrom(cmd_settings);
 }
 
 /// If path is specified and not empty, will try to setup server environment and load existing metadata
@@ -414,7 +410,6 @@ void LocalServer::init(int argc, char ** argv)
         min_description_length = std::min(min_description_length, line_length - 2);
     }
 
-#define DECLARE_SETTING(TYPE, NAME, DEFAULT, DESCRIPTION) (#NAME, po::value<std::string> (), DESCRIPTION)
     po::options_description description("Main options", line_length, min_description_length);
     description.add_options()
         ("help", "produce help message")
@@ -435,13 +430,15 @@ void LocalServer::init(int argc, char ** argv)
         ("verbose", "print query and other debugging info")
         ("ignore-error", "do not stop processing if a query failed")
         ("version,V", "print version information and exit")
-        APPLY_FOR_SETTINGS(DECLARE_SETTING);
-#undef DECLARE_SETTING
+        ;
+
+    cmd_settings.addProgramOptions(description);
 
     /// Parse main commandline options.
     po::parsed_options parsed = po::command_line_parser(argc, argv).options(description).run();
     po::variables_map options;
     po::store(parsed, options);
+    po::notify(options);
 
     if (options.count("version") || options.count("V"))
     {
@@ -456,13 +453,6 @@ void LocalServer::init(int argc, char ** argv)
         std::cout << getHelpFooter() << "\n";
         exit(0);
     }
-
-    /// Extract settings and limits from the options.
-#define EXTRACT_SETTING(TYPE, NAME, DEFAULT, DESCRIPTION) \
-    if (options.count(#NAME)) \
-        cmd_settings.set(#NAME, options[#NAME].as<std::string>());
-    APPLY_FOR_SETTINGS(EXTRACT_SETTING)
-#undef EXTRACT_SETTING
 
     /// Save received data into the internal config.
     if (options.count("config-file"))

--- a/dbms/programs/performance-test/PerformanceTestSuite.cpp
+++ b/dbms/programs/performance-test/PerformanceTestSuite.cpp
@@ -61,6 +61,7 @@ public:
         const std::string & default_database_,
         const std::string & user_,
         const std::string & password_,
+        const Settings & cmd_settings,
         const bool lite_output_,
         const std::string & profiles_file_,
         Strings && input_files_,
@@ -87,6 +88,7 @@ public:
         , input_files(input_files_)
         , log(&Poco::Logger::get("PerformanceTestSuite"))
     {
+        global_context.getSettingsRef().copyChangesFrom(cmd_settings);
         if (input_files.size() < 1)
             throw Exception("No tests were specified", ErrorCodes::BAD_ARGUMENTS);
     }
@@ -109,10 +111,6 @@ public:
         processTestsConfigurations(input_files);
 
         return 0;
-    }
-    void setContextSetting(const String & name, const std::string & value)
-    {
-        global_context.setSetting(name, value);
     }
 
 private:
@@ -326,7 +324,6 @@ try
     using Strings = DB::Strings;
 
 
-#define DECLARE_SETTING(TYPE, NAME, DEFAULT, DESCRIPTION) (#NAME, po::value<std::string>(), DESCRIPTION)
     po::options_description desc("Allowed options");
     desc.add_options()
         ("help", "produce help message")
@@ -348,9 +345,10 @@ try
         ("input-files", value<Strings>()->multitoken(), "Input .xml files")
         ("query-indexes", value<std::vector<size_t>>()->multitoken(), "Input query indexes")
         ("recursive,r", "Recurse in directories to find all xml's")
-    APPLY_FOR_SETTINGS(DECLARE_SETTING);
-#undef DECLARE_SETTING
+    ;
 
+    DB::Settings cmd_settings;
+    cmd_settings.addProgramOptions(desc);
 
     po::options_description cmdline_options;
     cmdline_options.add(desc);
@@ -397,6 +395,7 @@ try
         options["database"].as<std::string>(),
         options["user"].as<std::string>(),
         options["password"].as<std::string>(),
+        cmd_settings,
         options.count("lite") > 0,
         options["profiles-file"].as<std::string>(),
         std::move(input_files),
@@ -408,15 +407,6 @@ try
         std::move(skip_names_regexp),
         queries_with_indexes,
         timeouts);
-    /// Extract settings from the options.
-#define EXTRACT_SETTING(TYPE, NAME, DEFAULT, DESCRIPTION) \
-    if (options.count(#NAME)) \
-    { \
-        performance_test_suite.setContextSetting(#NAME, options[#NAME].as<std::string>()); \
-    }
-    APPLY_FOR_SETTINGS(EXTRACT_SETTING)
-#undef EXTRACT_SETTING
-
     return performance_test_suite.run();
 }
 catch (...)

--- a/dbms/programs/server/HTTPHandler.cpp
+++ b/dbms/programs/server/HTTPHandler.cpp
@@ -497,8 +497,7 @@ void HTTPHandler::processQuery(
             settings.readonly = 2;
     }
 
-    auto readonly_before_query = settings.readonly;
-
+    SettingsChanges settings_changes;
     for (auto it = params.begin(); it != params.end(); ++it)
     {
         if (it->first == "database")
@@ -515,20 +514,12 @@ void HTTPHandler::processQuery(
         else
         {
             /// All other query parameters are treated as settings.
-            String value;
-            /// Setting is skipped if value wasn't changed.
-            if (!settings.tryGet(it->first, value) || it->second != value)
-            {
-                if (readonly_before_query == 1)
-                    throw Exception("Cannot override setting (" + it->first + ") in readonly mode", ErrorCodes::READONLY);
-
-                if (readonly_before_query && it->first == "readonly")
-                    throw Exception("Setting 'readonly' cannot be overrided in readonly mode", ErrorCodes::READONLY);
-
-                context.setSetting(it->first, it->second);
-            }
+            settings_changes.push_back({it->first, it->second});
         }
     }
+
+    context.checkSettingsConstraints(settings_changes);
+    context.applySettingsChanges(settings_changes);
 
     /// HTTP response compression is turned on only if the client signalled that they support it
     /// (using Accept-Encoding header) and 'enable_http_compression' setting is turned on.

--- a/dbms/src/Client/Connection.cpp
+++ b/dbms/src/Client/Connection.cpp
@@ -401,7 +401,7 @@ void Connection::sendQuery(
     if (settings)
         settings->serialize(*out);
     else
-        writeStringBinary("", *out);
+        writeStringBinary("" /* empty string is a marker of the end of settings */, *out);
 
     writeVarUInt(stage, *out);
     writeVarUInt(static_cast<bool>(compression), *out);

--- a/dbms/src/Common/ErrorCodes.cpp
+++ b/dbms/src/Common/ErrorCodes.cpp
@@ -426,6 +426,7 @@ namespace ErrorCodes
     extern const int BROTLI_WRITE_FAILED = 449;
     extern const int BAD_TTL_EXPRESSION = 450;
     extern const int BAD_TTL_FILE = 451;
+    extern const int SETTING_CONSTRAINT_VIOLATION = 452;
 
     extern const int KEEPER_EXCEPTION = 999;
     extern const int POCO_EXCEPTION = 1000;

--- a/dbms/src/Common/SettingsChanges.h
+++ b/dbms/src/Common/SettingsChanges.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <Core/Field.h>
+
+
+namespace DB
+{
+
+struct SettingChange
+{
+    String name;
+    Field value;
+};
+
+using SettingsChanges = std::vector<SettingChange>;
+
+}

--- a/dbms/src/Core/Settings.cpp
+++ b/dbms/src/Core/Settings.cpp
@@ -1,9 +1,6 @@
 #include "Settings.h"
 
 #include <Poco/Util/AbstractConfiguration.h>
-#include <Core/Field.h>
-#include <IO/ReadHelpers.h>
-#include <IO/WriteHelpers.h>
 #include <Columns/ColumnArray.h>
 #include <Common/typeid_cast.h>
 #include <string.h>
@@ -14,94 +11,13 @@ namespace DB
 
 namespace ErrorCodes
 {
-    extern const int UNKNOWN_SETTING;
     extern const int THERE_IS_NO_PROFILE;
     extern const int NO_ELEMENTS_IN_CONFIG;
 }
 
 
-/// Set the configuration by name.
-void Settings::set(const String & name, const Field & value)
-{
-#define TRY_SET(TYPE, NAME, DEFAULT, DESCRIPTION) \
-    else if (name == #NAME) NAME.set(value);
+IMPLEMENT_SETTINGS_COLLECTION(Settings, APPLY_FOR_SETTINGS)
 
-    if (false) {}
-    APPLY_FOR_SETTINGS(TRY_SET)
-    else
-        throw Exception("Unknown setting " + name, ErrorCodes::UNKNOWN_SETTING);
-
-#undef TRY_SET
-}
-
-/// Set the configuration by name. Read the binary serialized value from the buffer (for interserver interaction).
-void Settings::set(const String & name, ReadBuffer & buf)
-{
-#define TRY_SET(TYPE, NAME, DEFAULT, DESCRIPTION) \
-    else if (name == #NAME) NAME.set(buf);
-
-    if (false) {}
-    APPLY_FOR_SETTINGS(TRY_SET)
-    else
-        throw Exception("Unknown setting " + name, ErrorCodes::UNKNOWN_SETTING);
-
-#undef TRY_SET
-}
-
-/// Skip the binary-serialized value from the buffer.
-void Settings::ignore(const String & name, ReadBuffer & buf)
-{
-#define TRY_IGNORE(TYPE, NAME, DEFAULT, DESCRIPTION) \
-    else if (name == #NAME) decltype(NAME)(DEFAULT).set(buf);
-
-    if (false) {}
-    APPLY_FOR_SETTINGS(TRY_IGNORE)
-    else
-        throw Exception("Unknown setting " + name, ErrorCodes::UNKNOWN_SETTING);
-
-    #undef TRY_IGNORE
-}
-
-/** Set the setting by name. Read the value in text form from a string (for example, from a config, or from a URL parameter).
-    */
-void Settings::set(const String & name, const String & value)
-{
-#define TRY_SET(TYPE, NAME, DEFAULT, DESCRIPTION) \
-    else if (name == #NAME) NAME.set(value);
-
-    if (false) {}
-    APPLY_FOR_SETTINGS(TRY_SET)
-    else
-        throw Exception("Unknown setting " + name, ErrorCodes::UNKNOWN_SETTING);
-
-#undef TRY_SET
-}
-
-String Settings::get(const String & name) const
-{
-#define GET(TYPE, NAME, DEFAULT, DESCRIPTION) \
-    else if (name == #NAME) return NAME.toString();
-
-    if (false) {}
-    APPLY_FOR_SETTINGS(GET)
-    else
-        throw Exception("Unknown setting " + name, ErrorCodes::UNKNOWN_SETTING);
-
-#undef GET
-}
-
-bool Settings::tryGet(const String & name, String & value) const
-{
-#define TRY_GET(TYPE, NAME, DEFAULT, DESCRIPTION) \
-    else if (name == #NAME) { value = NAME.toString(); return true; }
-
-    if (false) {}
-    APPLY_FOR_SETTINGS(TRY_GET)
-    else
-        return false;
-
-#undef TRY_GET
-}
 
 /** Set the settings from the profile (in the server configuration, many settings can be listed in one profile).
     * The profile can also be set using the `set` functions, like the `profile` setting.
@@ -137,47 +53,6 @@ void Settings::loadSettingsFromConfig(const String & path, const Poco::Util::Abs
     {
         set(key, config.getString(path + "." + key));
     }
-}
-
-/// Read the settings from the buffer. They are written as a set of name-value pairs that go successively, ending with an empty `name`.
-/// If the `check_readonly` flag is set, `readonly` is set in the preferences, but some changes have occurred - throw an exception.
-void Settings::deserialize(ReadBuffer & buf)
-{
-    auto before_readonly = readonly;
-
-    while (true)
-    {
-        String name;
-        readBinary(name, buf);
-
-        /// An empty string is the marker for the end of the settings.
-        if (name.empty())
-            break;
-
-        /// If readonly = 2, then you can change the settings, except for the readonly setting.
-        if (before_readonly == 0 || (before_readonly == 2 && name != "readonly"))
-            set(name, buf);
-        else
-            ignore(name, buf);
-    }
-}
-
-/// Record the changed settings to the buffer. (For example, to send to a remote server.)
-void Settings::serialize(WriteBuffer & buf) const
-{
-#define WRITE(TYPE, NAME, DEFAULT, DESCRIPTION) \
-    if (NAME.changed) \
-    { \
-        writeStringBinary(#NAME, buf); \
-        NAME.write(buf); \
-    }
-
-    APPLY_FOR_SETTINGS(WRITE)
-
-    /// An empty string is a marker for the end of the settings.
-    writeStringBinary("", buf);
-
-#undef WRITE
 }
 
 void Settings::dumpToArrayColumns(IColumn * column_names_, IColumn * column_values_, bool changed_only)

--- a/dbms/src/Core/Settings.cpp
+++ b/dbms/src/Core/Settings.cpp
@@ -34,6 +34,8 @@ void Settings::setProfile(const String & profile_name, const Poco::Util::Abstrac
 
     for (const std::string & key : config_keys)
     {
+        if (key == "constraints")
+            continue;
         if (key == "profile")   /// Inheritance of one profile from another.
             setProfile(config.getString(elem + "." + key), config);
         else

--- a/dbms/src/Core/Settings.h
+++ b/dbms/src/Core/Settings.h
@@ -16,11 +16,11 @@ namespace DB
 {
 
 class IColumn;
-class Field;
+
 
 /** Settings of query execution.
   */
-struct Settings
+struct Settings : public SettingsCollection<Settings>
 {
     /// For initialization from empty initializer-list to be "value initialization", not "aggregate initialization" in C++14.
     /// http://en.cppreference.com/w/cpp/language/aggregate_initialization
@@ -315,48 +315,18 @@ struct Settings
     \
     M(SettingUInt64, max_partitions_per_insert_block, 100, "Limit maximum number of partitions in single INSERTed block. Zero means unlimited. Throw exception if the block contains too many partitions. This setting is a safety threshold, because using large number of partitions is a common misconception.") \
 
-#define DECLARE(TYPE, NAME, DEFAULT, DESCRIPTION) \
-    TYPE NAME {DEFAULT};
-
-    APPLY_FOR_SETTINGS(DECLARE)
-
-#undef DECLARE
-
-    /// Set setting by name.
-    void set(const String & name, const Field & value);
-
-    /// Set setting by name. Read value, serialized in binary form from buffer (for inter-server communication).
-    void set(const String & name, ReadBuffer & buf);
-
-    /// Skip value, serialized in binary form in buffer.
-    void ignore(const String & name, ReadBuffer & buf);
-
-    /// Set setting by name. Read value in text form from string (for example, from configuration file or from URL parameter).
-    void set(const String & name, const String & value);
-
-    /// Get setting by name. Converts value to String.
-    String get(const String & name) const;
-
-    bool tryGet(const String & name, String & value) const;
+    DECLARE_SETTINGS_COLLECTION(APPLY_FOR_SETTINGS)
 
     /** Set multiple settings from "profile" (in server configuration file (users.xml), profiles contain groups of multiple settings).
-      * The profile can also be set using the `set` functions, like the profile setting.
-      */
+     * The profile can also be set using the `set` functions, like the profile setting.
+     */
     void setProfile(const String & profile_name, const Poco::Util::AbstractConfiguration & config);
 
     /// Load settings from configuration file, at "path" prefix in configuration.
     void loadSettingsFromConfig(const String & path, const Poco::Util::AbstractConfiguration & config);
 
-    /// Read settings from buffer. They are serialized as list of contiguous name-value pairs, finished with empty name.
-    /// If readonly=1 is set, ignore read settings.
-    void deserialize(ReadBuffer & buf);
-
-    /// Write changed settings to buffer. (For example, to be sent to remote server.)
-    void serialize(WriteBuffer & buf) const;
-
     /// Dumps profile events to two columns of type Array(String)
     void dumpToArrayColumns(IColumn * column_names, IColumn * column_values, bool changed_only = true);
 };
-
 
 }

--- a/dbms/src/Core/Settings.h
+++ b/dbms/src/Core/Settings.h
@@ -12,6 +12,15 @@ namespace Poco
     }
 }
 
+namespace boost
+{
+    namespace program_options
+    {
+        class options_description;
+    }
+}
+
+
 namespace DB
 {
 
@@ -327,6 +336,10 @@ struct Settings : public SettingsCollection<Settings>
 
     /// Dumps profile events to two columns of type Array(String)
     void dumpToArrayColumns(IColumn * column_names, IColumn * column_values, bool changed_only = true);
+
+    /// Adds program options to set the settings from a command line.
+    /// (Don't forget to call notify() on the `variables_map` after parsing it!)
+    void addProgramOptions(boost::program_options::options_description & options);
 };
 
 }

--- a/dbms/src/Core/SettingsCommon.h
+++ b/dbms/src/Core/SettingsCommon.h
@@ -469,17 +469,19 @@ namespace details
   * mysettings.cpp:
   * IMPLEMENT_SETTINGS_COLLECTION(MySettings, APPLY_FOR_MYSETTINGS)
   */
-template <typename T>
+template <class Derived>
 class SettingsCollection
 {
 private:
-    using Type = T;
-    using GetStringFunction = String (*)(const Type &);
-    using GetFieldFunction = Field (*)(const Type &);
-    using SetStringFunction = void (*)(Type &, const String &);
-    using SetFieldFunction = void (*)(Type &, const Field &);
-    using SerializeFunction = void (*)(const Type &, WriteBuffer & buf);
-    using DeserializeFunction = void (*)(Type &, ReadBuffer & buf);
+    Derived & castToDerived() { return *static_cast<Derived *>(this); }
+    const Derived & castToDerived() const { return *static_cast<const Derived *>(this); }
+
+    using GetStringFunction = String (*)(const Derived &);
+    using GetFieldFunction = Field (*)(const Derived &);
+    using SetStringFunction = void (*)(Derived &, const String &);
+    using SetFieldFunction = void (*)(Derived &, const Field &);
+    using SerializeFunction = void (*)(const Derived &, WriteBuffer & buf);
+    using DeserializeFunction = void (*)(Derived &, ReadBuffer & buf);
 
     struct MemberInfo
     {
@@ -492,169 +494,219 @@ private:
         SetFieldFunction set_field;
         SerializeFunction serialize;
         DeserializeFunction deserialize;
-        bool isChanged(const Type & collection) const { return *reinterpret_cast<const bool*>(reinterpret_cast<const UInt8*>(&collection) + offset_of_changed); }
+        bool isChanged(const Derived & collection) const { return *reinterpret_cast<const bool*>(reinterpret_cast<const UInt8*>(&collection) + offset_of_changed); }
     };
 
-    using MemberInfos = std::vector<MemberInfo>;
-
-    class Layout
+    class MemberInfos
     {
     public:
+        static const MemberInfos & instance()
+        {
+            static const MemberInfos single_instance;
+            return single_instance;
+        }
+
         size_t size() const { return infos.size(); }
         const MemberInfo & operator[](size_t index) const { return infos[index]; }
+        const MemberInfo * begin() const { return infos.data(); }
+        const MemberInfo * end() const { return infos.data() + infos.size(); }
 
-        static constexpr size_t npos = static_cast<size_t>(-1);
-
-        size_t find(const StringRef & name) const
+        size_t findIndex(const StringRef & name) const
         {
-            auto map_it = by_name_map.find(name);
-            if (map_it == by_name_map.end())
-                return npos;
-            else
-                return map_it->second;
+            auto it = by_name_map.find(name);
+            if (it == by_name_map.end())
+                return static_cast<size_t>(-1);
+            return it->second;
         }
 
-        size_t findStrict(const StringRef & name) const
+        size_t findIndexStrict(const StringRef & name) const
         {
-            auto map_it = by_name_map.find(name);
-            if (map_it == by_name_map.end())
+            auto it = by_name_map.find(name);
+            if (it == by_name_map.end())
                 details::SettingsCollectionUtils::throwNameNotFound(name);
-            return map_it->second;
+            return it->second;
         }
 
-        void addMemberInfo(MemberInfo && info)
+        const MemberInfo * find(const StringRef & name) const
+        {
+            auto it = by_name_map.find(name);
+            if (it == by_name_map.end())
+                return end();
+            else
+                return &infos[it->second];
+        }
+
+        const MemberInfo * findStrict(const StringRef & name) const { return &infos[findIndexStrict(name)]; }
+
+    private:
+        MemberInfos();
+
+        void add(MemberInfo && member)
         {
             size_t index = infos.size();
-            infos.emplace_back(info);
+            infos.emplace_back(member);
             by_name_map.emplace(infos.back().name, index);
         }
 
-    private:
-        MemberInfos infos;
+        std::vector<MemberInfo> infos;
         std::unordered_map<StringRef, size_t> by_name_map;
     };
 
-    static const Layout & getLayout();
-    Type & castThis() { return static_cast<Type &>(*this); }
-    const Type & castThis() const { return static_cast<const Type &>(*this); }
+    static const MemberInfos & members() { return MemberInfos::instance(); }
 
 public:
-    /// Provides access to a setting.
-    class reference
-    {
-    public:
-        const StringRef & getName() const { return member.name; }
-        const StringRef & getDescription() const { return member.description; }
-        bool isChanged() const { return member.isChanged(collection); }
-        Field getValue() const { return member.get_field(collection); }
-        String getValueAsString() const { return member.get_string(collection); }
-        void setValue(const Field & value) { member.set_field(collection, value); }
-        void setValue(const String & value) { member.set_string(collection, value); }
-
-        reference(Type & collection_, const MemberInfo & member_) : collection(collection_), member(member_) {}
-    private:
-        Type & collection;
-        const MemberInfo & member;
-    };
+    class const_iterator;
 
     /// Provides read-only access to a setting.
     class const_reference
     {
     public:
-        const StringRef & getName() const { return member.name; }
-        const StringRef & getDescription() const { return member.description; }
-        bool isChanged() const { return member.isChanged(collection); }
-        Field getValue() const { return member.get_field(collection); }
-        String getValueAsString() const { return member.get_string(collection); }
-
-        const_reference(const Type & collection_, const MemberInfo & member_) : collection(collection_), member(member_) {}
-    private:
-        const Type & collection;
-        const MemberInfo & member;
+        const_reference(const Derived & collection_, const MemberInfo & member_) : collection(&collection_), member(&member_) {}
+        const_reference(const const_reference & src) = default;
+        const StringRef & getName() const { return member->name; }
+        const StringRef & getDescription() const { return member->description; }
+        bool isChanged() const { return member->isChanged(*collection); }
+        Field getValue() const { return member->get_field(*collection); }
+        String getValueAsString() const { return member->get_string(*collection); }
+    protected:
+        friend class SettingsCollection<Derived>::const_iterator;
+        const_reference() : collection(nullptr), member(nullptr) {}
+        const_reference & operator=(const const_reference &) = default;
+        const Derived * collection;
+        const MemberInfo * member;
     };
 
-    /// Returns number of settings.
-    size_t size() const { return getLayout().size(); }
-
-    /// Returns a setting by its zero-based index.
-    reference operator [](size_t index) { return reference(castThis(), getLayout()[index]); }
-    const_reference operator [](size_t index) const { return const_reference(castThis(), getLayout()[index]); }
-
-    /// Returns a setting by its name. Throws an exception if there is not setting with such name.
-    reference operator [](const String & name)
+    /// Provides access to a setting.
+    class reference : public const_reference
     {
-        const Layout & layout = getLayout();
-        return reference(castThis(), layout[layout.findStrict(name)]);
-    }
+    public:
+        reference(Derived & collection_, const MemberInfo & member_) : const_reference(collection_, member_) {}
+        reference(const const_reference & src) : const_reference(src) {}
+        void setValue(const Field & value) { this->member->set_field(*const_cast<Derived *>(this->collection), value); }
+        void setValue(const String & value) { this->member->set_string(*const_cast<Derived *>(this->collection), value); }
+    };
 
-    const_reference operator [](const String & name) const
+    /// Iterator to iterating through all the settings.
+    class const_iterator
     {
-        const Layout & layout = getLayout();
-        return const_reference(castThis(), layout[layout.findStrict(name)]);
-    }
+    public:
+        const_iterator(const Derived & collection_, const MemberInfo * member_) : ref(const_cast<Derived &>(collection_), *member_) {}
+        const_iterator() = default;
+        const_iterator(const const_iterator & src) = default;
+        const_iterator & operator =(const const_iterator & src) = default;
+        const const_reference & operator *() const { return ref; }
+        const const_reference * operator ->() const { return &ref; }
+        const_iterator & operator ++() { ++ref.member; return *this; }
+        const_iterator & operator ++(int) { const_iterator tmp = *this; ++*this; return tmp; }
+        bool operator ==(const const_iterator & rhs) const { return ref.member == rhs.ref.member && ref.collection == rhs.ref.collection; }
+        bool operator !=(const const_iterator & rhs) const { return !(*this == rhs); }
+    protected:
+        mutable reference ref;
+    };
 
-    /// Finds a setting by name and returns its index. Returns npos if not found.
-    size_t find(const String & name) const { return getLayout().find(name); }
+    class iterator : public const_iterator
+    {
+    public:
+        iterator(Derived & collection_, const MemberInfo * member_) : const_iterator(collection_, member_) {}
+        iterator() = default;
+        iterator(const const_iterator & src) : const_iterator(src) {}
+        iterator & operator =(const const_iterator & src) { const_iterator::operator =(src); return *this; }
+        reference & operator *() const { return this->ref; }
+        reference * operator ->() const { return &this->ref; }
+        iterator & operator ++() { const_iterator::operator ++(); return *this; }
+        iterator & operator ++(int) { iterator tmp = *this; ++*this; return tmp; }
+    };
+
+    /// Returns the number of settings.
+    static size_t size() { return members().size(); }
+
+    /// Returns name of a setting by its index (0..size()-1).
+    static StringRef getNameByIndex(size_t index) { return members()[index].name; }
+
+    /// Returns description of a setting by its index.
+    static StringRef getDescriptionByIndex(size_t index) { return members()[index].description; }
+
+    /// Searches a setting by its name; returns `npos` if not found.
+    static size_t findIndex(const String & name) { return members().findIndex(name); }
     static constexpr size_t npos = static_cast<size_t>(-1);
 
-    /// Finds a setting by name and returns its index. Throws an exception if not found.
-    size_t findStrict(const String & name) const { return getLayout().findStrict(name); }
+    /// Searches a setting by its name; throws an exception if not found.
+    static size_t findIndexStrict(const String & name) { return members().findIndexStrict(name); }
 
-    /// Sets setting by name.
+    iterator begin() { return iterator(castToDerived(), members().begin()); }
+    const_iterator begin() const { return const_iterator(castToDerived(), members().begin()); }
+    iterator end() { return iterator(castToDerived(), members().end()); }
+    const_iterator end() const { return const_iterator(castToDerived(), members().end()); }
+
+    /// Returns a proxy object for accessing to a setting. Throws an exception if there is not setting with such name.
+    reference operator[](size_t index) { return reference(castToDerived(), members()[index]); }
+    reference operator[](const String & name) { return reference(castToDerived(), *(members().findStrict(name))); }
+    const_reference operator[](size_t index) const { return const_reference(castToDerived(), members()[index]); }
+    const_reference operator[](const String & name) const { return const_reference(castToDerived(), *(members().findStrict(name))); }
+
+    /// Searches a setting by its name; returns end() if not found.
+    iterator find(const String & name) { return iterator(castToDerived(), members().find(name)); }
+    const_iterator find(const String & name) const { return const_iterator(castToDerived(), members().find(name)); }
+
+    /// Searches a setting by its name; throws an exception if not found.
+    iterator findStrict(const String & name) { return iterator(castToDerived(), members().findStrict(name)); }
+    const_iterator findStrict(const String & name) const { return const_iterator(castToDerived(), members().findStrict(name)); }
+
+    /// Sets setting's value.
+    void set(size_t index, const Field & value) { (*this)[index].setValue(value); }
     void set(const String & name, const Field & value) { (*this)[name].setValue(value); }
 
-    /// Sets setting by name. Read value in text form from string (for example, from configuration file or from URL parameter).
+    /// Sets setting's value. Read value in text form from string (for example, from configuration file or from URL parameter).
+    void set(size_t index, const String & value) { (*this)[index].setValue(value); }
     void set(const String & name, const String & value) { (*this)[name].setValue(value); }
 
-    /// Returns the value of a setting.
+    /// Returns value of a setting.
+    Field get(size_t index) const { return (*this)[index].getValue(); }
     Field get(const String & name) const { return (*this)[name].getValue(); }
 
-    /// Returns the value of a setting converted to string.
+    /// Returns value of a setting converted to string.
+    String getAsString(size_t index) const { return (*this)[index].getValueAsString(); }
     String getAsString(const String & name) const { return (*this)[name].getValueAsString(); }
 
-    /// Returns the value of a setting.
+    /// Returns value of a setting; returns false if there is no setting with the specified name.
     bool tryGet(const String & name, Field & value) const
     {
-        const Layout & layout = getLayout();
-        size_t index = layout.find(name);
-        if (index == npos)
+        auto it = find(name);
+        if (it == end())
             return false;
-        value = layout[index].get_field(castThis());
+        value = it->getValue();
         return true;
     }
 
-    /// Returns the value of a setting converted to string.
+    /// Returns value of a setting converted to string; returns false if there is no setting with the specified name.
     bool tryGet(const String & name, String & value) const
     {
-        const Layout & layout = getLayout();
-        size_t index = layout.find(name);
-        if (index == npos)
+        auto it = find(name);
+        if (it == end())
             return false;
-        value = layout[index].get_string(castThis());
+        value = it->getValueAsString();
         return true;
     }
 
     /// Compares two collections of settings.
-    bool operator ==(const Type & rhs) const
+    bool operator ==(const Derived & rhs) const
     {
-        const Layout & layout = getLayout();
-        for (size_t i = 0; i != layout.size(); ++i)
+        for (const auto & member : members())
         {
-            const auto & member = layout[i];
-            bool left_changed = member.isChanged(castThis());
+            bool left_changed = member.isChanged(castToDerived());
             bool right_changed = member.isChanged(rhs);
             if (left_changed || right_changed)
             {
                 if (left_changed != right_changed)
                     return false;
-                if (member.get_field(castThis()) != member.get_field(rhs))
+                if (member.get_field(castToDerived()) != member.get_field(rhs))
                     return false;
             }
         }
         return true;
     }
 
-    bool operator !=(const Type & rhs) const
+    bool operator !=(const Derived & rhs) const
     {
         return !(*this == rhs);
     }
@@ -663,12 +715,10 @@ public:
     SettingsChanges changes() const
     {
         SettingsChanges found_changes;
-        const Layout & layout = getLayout();
-        for (size_t i = 0; i != layout.size(); ++i)
+        for (const auto & member : members())
         {
-            const auto & member = layout[i];
-            if (member.isChanged(castThis()))
-                found_changes.emplace_back(member.name.toString(), member.get_field(castThis()));
+            if (member.isChanged(castToDerived()))
+                found_changes.emplace_back(member.name.toString(), member.get_field(castToDerived()));
         }
         return found_changes;
     }
@@ -685,20 +735,16 @@ public:
             applyChange(change);
     }
 
-    void copyChangesFrom(const Type & src)
+    void copyChangesFrom(const Derived & src)
     {
-        const Layout & layout = getLayout();
-        for (size_t i = 0; i != layout.size(); ++i)
-        {
-            const auto & member = layout[i];
+        for (const auto & member : members())
             if (member.isChanged(src))
-                member.set_field(castThis(), member.get_field(src));
-        }
+                member.set_field(castToDerived(), member.get_field(src));
     }
 
-    void copyChangesTo(Type & dest) const
+    void copyChangesTo(Derived & dest) const
     {
-        dest.copyChangesFrom(castThis());
+        dest.copyChangesFrom(castToDerived());
     }
 
     /// Writes the settings to buffer (e.g. to be sent to remote server).
@@ -706,14 +752,12 @@ public:
     /// finished with empty name.
     void serialize(WriteBuffer & buf) const
     {
-        const Layout & layout = getLayout();
-        for (size_t i = 0; i != layout.size(); ++i)
+        for (const auto & member : members())
         {
-            const auto & member = layout[i];
-            if (member.isChanged(castThis()))
+            if (member.isChanged(castToDerived()))
             {
                 details::SettingsCollectionUtils::serializeName(member.name, buf);
-                member.serialize(castThis(), buf);
+                member.serialize(castToDerived(), buf);
             }
         }
         details::SettingsCollectionUtils::serializeName(StringRef{} /* empty string is a marker of the end of settings */, buf);
@@ -722,14 +766,13 @@ public:
     /// Reads the settings from buffer.
     void deserialize(ReadBuffer & buf)
     {
-        const Layout & layout = getLayout();
+        const auto & the_members = members();
         while (true)
         {
             String name = details::SettingsCollectionUtils::deserializeName(buf);
             if (name.empty() /* empty string is a marker of the end of settings */)
-                break; \
-            const auto & member = layout[layout.findStrict(name)];
-            member.deserialize(castThis(), buf); \
+                break;
+            the_members.findStrict(name)->deserialize(castToDerived(), buf);
         }
     }
 };
@@ -738,21 +781,16 @@ public:
     APPLY_MACRO(DECLARE_SETTINGS_COLLECTION_DECLARE_VARIABLES_HELPER_)
 
 
-#define IMPLEMENT_SETTINGS_COLLECTION(CLASS_NAME, APPLY_MACRO) \
+#define IMPLEMENT_SETTINGS_COLLECTION(DERIVED_CLASS_NAME, APPLY_MACRO) \
     template<> \
-    const SettingsCollection<CLASS_NAME>::Layout & SettingsCollection<CLASS_NAME>::getLayout() \
+    SettingsCollection<DERIVED_CLASS_NAME>::MemberInfos::MemberInfos() \
     { \
+        using Derived = DERIVED_CLASS_NAME; \
         struct Functions \
         { \
             APPLY_MACRO(IMPLEMENT_SETTINGS_COLLECTION_DEFINE_FUNCTIONS_HELPER_) \
         }; \
-        static const SettingsCollection<Type>::Layout single_instance = [] \
-        { \
-            SettingsCollection<Type>::Layout layout; \
-            APPLY_MACRO(IMPLEMENT_SETTINGS_COLLECTION_ADD_MEMBER_INFO_HELPER_) \
-            return layout; \
-        }(); \
-        return single_instance; \
+        APPLY_MACRO(IMPLEMENT_SETTINGS_COLLECTION_ADD_MEMBER_INFO_HELPER_) \
     }
 
 
@@ -761,20 +799,20 @@ public:
 
 
 #define IMPLEMENT_SETTINGS_COLLECTION_DEFINE_FUNCTIONS_HELPER_(TYPE, NAME, DEFAULT, DESCRIPTION) \
-    static String NAME##_getString(const Type & collection) { return collection.NAME.toString(); } \
-    static Field NAME##_getField(const Type & collection) { return collection.NAME.toField(); } \
-    static void NAME##_setString(Type & collection, const String & value) { collection.NAME.set(value); } \
-    static void NAME##_setField(Type & collection, const Field & value) { collection.NAME.set(value); } \
-    static void NAME##_serialize(const Type & collection, WriteBuffer & buf) { collection.NAME.serialize(buf); } \
-    static void NAME##_deserialize(Type & collection, ReadBuffer & buf) { collection.NAME.deserialize(buf); }
+    static String NAME##_getString(const Derived & collection) { return collection.NAME.toString(); } \
+    static Field NAME##_getField(const Derived & collection) { return collection.NAME.toField(); } \
+    static void NAME##_setString(Derived & collection, const String & value) { collection.NAME.set(value); } \
+    static void NAME##_setField(Derived & collection, const Field & value) { collection.NAME.set(value); } \
+    static void NAME##_serialize(const Derived & collection, WriteBuffer & buf) { collection.NAME.serialize(buf); } \
+    static void NAME##_deserialize(Derived & collection, ReadBuffer & buf) { collection.NAME.deserialize(buf); }
 
 
 #define IMPLEMENT_SETTINGS_COLLECTION_ADD_MEMBER_INFO_HELPER_(TYPE, NAME, DEFAULT, DESCRIPTION) \
-    static_assert(std::is_same_v<decltype(std::declval<TYPE>().changed), bool>); \
-    layout.addMemberInfo({offsetof(Type, NAME.changed), \
-                          StringRef(#NAME, strlen(#NAME)), StringRef(#DESCRIPTION, strlen(#DESCRIPTION)), \
-                          &Functions::NAME##_getString, &Functions::NAME##_getField, \
-                          &Functions::NAME##_setString, &Functions::NAME##_setField, \
-                          &Functions::NAME##_serialize, &Functions::NAME##_deserialize });
+    static_assert(std::is_same_v<decltype(std::declval<Derived>().NAME.changed), bool>); \
+    add({offsetof(Derived, NAME.changed), \
+         StringRef(#NAME, strlen(#NAME)), StringRef(#DESCRIPTION, strlen(#DESCRIPTION)), \
+         &Functions::NAME##_getString, &Functions::NAME##_getField, \
+        &Functions::NAME##_setString, &Functions::NAME##_setField, \
+        &Functions::NAME##_serialize, &Functions::NAME##_deserialize });
 
 }

--- a/dbms/src/Core/SettingsCommon.h
+++ b/dbms/src/Core/SettingsCommon.h
@@ -515,7 +515,7 @@ private:
         {
             auto it = by_name_map.find(name);
             if (it == by_name_map.end())
-                return static_cast<size_t>(-1);
+                return static_cast<size_t>(-1); // npos
             return it->second;
         }
 

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -620,14 +620,22 @@ void Context::calculateUserSettings()
     /// NOTE: we ignore global_context settings (from which it is usually copied)
     /// NOTE: global_context settings are immutable and not auto updated
     settings = Settings();
+    settings_constraints = SettingsConstraints();
 
     /// 2) Apply settings from default profile
     auto default_profile_name = getDefaultProfileName();
     if (profile != default_profile_name)
-        settings.setProfile(default_profile_name, *shared->users_config);
+        setProfile(default_profile_name);
 
     /// 3) Apply settings from current user
+    setProfile(profile);
+}
+
+
+void Context::setProfile(const String & profile)
+{
     settings.setProfile(profile, *shared->users_config);
+    settings_constraints.setProfile(profile, *shared->users_config);
 }
 
 
@@ -1033,7 +1041,7 @@ void Context::setSetting(const String & name, const String & value)
     auto lock = getLock();
     if (name == "profile")
     {
-        settings.setProfile(value, *shared->users_config);
+        setProfile(value);
         return;
     }
     settings.set(name, value);
@@ -1045,7 +1053,7 @@ void Context::setSetting(const String & name, const Field & value)
     auto lock = getLock();
     if (name == "profile")
     {
-        settings.setProfile(value.safeGet<String>(), *shared->users_config);
+        setProfile(value.safeGet<String>());
         return;
     }
     settings.set(name, value);
@@ -1068,13 +1076,13 @@ void Context::applySettingsChanges(const SettingsChanges & changes)
 
 void Context::checkSettingsConstraints(const SettingChange & change)
 {
-    SettingsConstraints::check(settings, change);
+    settings_constraints.check(settings, change);
 }
 
 
 void Context::checkSettingsConstraints(const SettingsChanges & changes)
 {
-    SettingsConstraints::check(settings, changes);
+    settings_constraints.check(settings, changes);
 }
 
 

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -263,11 +263,15 @@ public:
     Settings getSettings() const;
     void setSettings(const Settings & settings_);
 
-    /// Set a setting by name.
+    /// Set settings by name.
+    void setSetting(const String & name, const String & value);
     void setSetting(const String & name, const Field & value);
+    void applySettingChange(const SettingChange & change);
+    void applySettingsChanges(const SettingsChanges & changes);
 
-    /// Set a setting by name. Read the value in text form from a string (for example, from a config, or from a URL parameter).
-    void setSetting(const String & name, const std::string & value);
+    /// Checks the constraints.
+    void checkSettingsConstraints(const SettingChange & change);
+    void checkSettingsConstraints(const SettingsChanges & changes);
 
     const EmbeddedDictionaries & getEmbeddedDictionaries() const;
     const ExternalDictionaries & getExternalDictionaries() const;

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -4,7 +4,6 @@
 #include <Core/NamesAndTypes.h>
 #include <Core/Types.h>
 #include <Interpreters/ClientInfo.h>
-#include <Interpreters/SettingsConstraints.h>
 #include <Core/Settings.h>
 #include <Parsers/IAST_fwd.h>
 #include <Common/LRUCache.h>
@@ -79,6 +78,8 @@ class ActionLocksManager;
 using ActionLocksManagerPtr = std::shared_ptr<ActionLocksManager>;
 class ShellCommand;
 class ICompressionCodec;
+class SettingsConstraints;
+
 
 #if USE_EMBEDDED_COMPILER
 
@@ -126,7 +127,7 @@ private:
     std::shared_ptr<QuotaForIntervals> quota;           /// Current quota. By default - empty quota, that have no limits.
     String current_database;
     Settings settings;                                  /// Setting for query execution.
-    SettingsConstraints settings_constraints;
+    std::shared_ptr<const SettingsConstraints> settings_constraints;
     using ProgressCallback = std::function<void(const Progress & progress)>;
     ProgressCallback progress_callback;                 /// Callback for tracking progress of query execution.
     QueryStatus * process_list_elem = nullptr;   /// For tracking total resource usage for query.
@@ -163,8 +164,8 @@ public:
     static Context createGlobal(std::unique_ptr<IRuntimeComponentsFactory> runtime_components_factory);
     static Context createGlobal();
 
-    Context(const Context &) = default;
-    Context & operator=(const Context &) = default;
+    Context(const Context &);
+    Context & operator=(const Context &);
     ~Context();
 
     String getPath() const;

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -4,6 +4,7 @@
 #include <Core/NamesAndTypes.h>
 #include <Core/Types.h>
 #include <Interpreters/ClientInfo.h>
+#include <Interpreters/SettingsConstraints.h>
 #include <Core/Settings.h>
 #include <Parsers/IAST_fwd.h>
 #include <Common/LRUCache.h>
@@ -125,6 +126,7 @@ private:
     std::shared_ptr<QuotaForIntervals> quota;           /// Current quota. By default - empty quota, that have no limits.
     String current_database;
     Settings settings;                                  /// Setting for query execution.
+    SettingsConstraints settings_constraints;
     using ProgressCallback = std::function<void(const Progress & progress)>;
     ProgressCallback progress_callback;                 /// Callback for tracking progress of query execution.
     QueryStatus * process_list_elem = nullptr;   /// For tracking total resource usage for query.
@@ -483,6 +485,8 @@ private:
       * NOTE: This method should always be called when the `shared->mutex` mutex is acquired.
       */
     void checkDatabaseAccessRightsImpl(const std::string & database_name) const;
+
+    void setProfile(const String & profile);
 
     EmbeddedDictionaries & getEmbeddedDictionariesImpl(bool throw_on_error) const;
     ExternalDictionaries & getExternalDictionariesImpl(bool throw_on_error) const;

--- a/dbms/src/Interpreters/InterpreterSetQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterSetQuery.cpp
@@ -1,73 +1,25 @@
 #include <Parsers/ASTSetQuery.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/InterpreterSetQuery.h>
-#include <Common/typeid_cast.h>
-#include <Common/FieldVisitors.h>
 
 namespace DB
 {
-
-namespace ErrorCodes
-{
-    extern const int READONLY;
-    extern const int QUERY_IS_PROHIBITED;
-}
 
 
 BlockIO InterpreterSetQuery::execute()
 {
     const auto & ast = query_ptr->as<ASTSetQuery &>();
-
-    checkAccess(ast);
-
-    Context & target = context.getSessionContext();
-    for (const auto & change : ast.changes)
-        target.setSetting(change.name, change.value);
-
+    context.checkSettingsConstraints(ast.changes);
+    context.getSessionContext().applySettingsChanges(ast.changes);
     return {};
-}
-
-void InterpreterSetQuery::checkAccess(const ASTSetQuery & ast)
-{
-    /** The `readonly` value is understood as follows:
-      * 0 - everything allowed.
-      * 1 - only read queries can be made; you can not change the settings.
-      * 2 - You can only do read queries and you can change the settings, except for the `readonly` setting.
-      */
-
-    const Settings & settings = context.getSettingsRef();
-    auto readonly = settings.readonly;
-    auto allow_ddl = settings.allow_ddl;
-
-    for (const auto & change : ast.changes)
-    {
-        String value;
-        /// Setting isn't checked if value wasn't changed.
-        if (!settings.tryGet(change.name, value) || applyVisitor(FieldVisitorToString(), change.value) != value)
-        {
-
-            if (!allow_ddl && change.name == "allow_ddl")
-                throw Exception("Cannot modify 'allow_ddl' setting when DDL queries are prohibited for the user", ErrorCodes::QUERY_IS_PROHIBITED);
-
-            if (readonly == 1)
-                throw Exception("Cannot execute SET query in readonly mode", ErrorCodes::READONLY);
-
-            if (readonly > 1 && change.name == "readonly")
-                throw Exception("Cannot modify 'readonly' setting in readonly mode", ErrorCodes::READONLY);
-        }
-    }
 }
 
 
 void InterpreterSetQuery::executeForCurrentContext()
 {
     const auto & ast = query_ptr->as<ASTSetQuery &>();
-
-    checkAccess(ast);
-
-    for (const auto & change : ast.changes)
-        context.setSetting(change.name, change.value);
+    context.checkSettingsConstraints(ast.changes);
+    context.applySettingsChanges(ast.changes);
 }
-
 
 }

--- a/dbms/src/Interpreters/InterpreterSetQuery.h
+++ b/dbms/src/Interpreters/InterpreterSetQuery.h
@@ -23,8 +23,6 @@ public:
       */
     BlockIO execute() override;
 
-    void checkAccess(const ASTSetQuery & ast);
-
     /** Set setting for current context (query context).
       * It is used for interpretation of SETTINGS clause in SELECT query.
       */

--- a/dbms/src/Interpreters/SettingsConstraints.cpp
+++ b/dbms/src/Interpreters/SettingsConstraints.cpp
@@ -1,0 +1,65 @@
+#include <Interpreters/SettingsConstraints.h>
+#include <Core/Settings.h>
+
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int READONLY;
+    extern const int QUERY_IS_PROHIBITED;
+    extern const int NO_ELEMENTS_IN_CONFIG;
+}
+
+namespace
+{
+    thread_local Settings temp_settings;
+
+    void checkImpl(const Settings & current_settings, size_t index)
+    {
+        const auto & new_setting = temp_settings[index];
+        Field new_value = new_setting.getValue();
+
+        const auto & current_setting = current_settings[index];
+        Field current_value = current_setting.getValue();
+
+        /// Setting isn't checked if value wasn't changed.
+        if (current_value == new_value)
+            return;
+
+        const StringRef & name = new_setting.getName();
+        if (!current_settings.allow_ddl && name == "allow_ddl")
+            throw Exception("Cannot modify 'allow_ddl' setting when DDL queries are prohibited for the user", ErrorCodes::QUERY_IS_PROHIBITED);
+
+        /** The `readonly` value is understood as follows:
+          * 0 - everything allowed.
+          * 1 - only read queries can be made; you can not change the settings.
+          * 2 - You can only do read queries and you can change the settings, except for the `readonly` setting.
+          */
+        if (current_settings.readonly == 1)
+            throw Exception("Cannot modify '" + name.toString() + "' setting in readonly mode", ErrorCodes::READONLY);
+
+        if (current_settings.readonly > 1 && name == "readonly")
+            throw Exception("Cannot modify 'readonly' setting in readonly mode", ErrorCodes::READONLY);
+    }
+}
+
+
+void SettingsConstraints::check(const Settings & current_settings, const SettingChange & change)
+{
+    size_t index = current_settings.find(change.name);
+    if (index == Settings::npos)
+        return;
+    // We store `change.value` to `temp_settings` to ensure it's converted to the correct type.
+    temp_settings[index].setValue(change.value);
+    checkImpl(current_settings, index);
+}
+
+
+void SettingsConstraints::check(const Settings & current_settings, const SettingsChanges & changes)
+{
+    for (const auto & change : changes)
+        check(current_settings, change);
+}
+
+}

--- a/dbms/src/Interpreters/SettingsConstraints.cpp
+++ b/dbms/src/Interpreters/SettingsConstraints.cpp
@@ -1,5 +1,8 @@
 #include <Interpreters/SettingsConstraints.h>
 #include <Core/Settings.h>
+#include <Common/FieldVisitors.h>
+#include <IO/WriteHelpers.h>
+#include <Poco/Util/AbstractConfiguration.h>
 
 
 namespace DB
@@ -9,43 +12,35 @@ namespace ErrorCodes
     extern const int READONLY;
     extern const int QUERY_IS_PROHIBITED;
     extern const int NO_ELEMENTS_IN_CONFIG;
+    extern const int SETTING_CONSTRAINT_VIOLATION;
 }
 
 namespace
 {
     thread_local Settings temp_settings;
-
-    void checkImpl(const Settings & current_settings, size_t index)
-    {
-        const auto & new_setting = temp_settings[index];
-        Field new_value = new_setting.getValue();
-
-        const auto & current_setting = current_settings[index];
-        Field current_value = current_setting.getValue();
-
-        /// Setting isn't checked if value wasn't changed.
-        if (current_value == new_value)
-            return;
-
-        const StringRef & name = new_setting.getName();
-        if (!current_settings.allow_ddl && name == "allow_ddl")
-            throw Exception("Cannot modify 'allow_ddl' setting when DDL queries are prohibited for the user", ErrorCodes::QUERY_IS_PROHIBITED);
-
-        /** The `readonly` value is understood as follows:
-          * 0 - everything allowed.
-          * 1 - only read queries can be made; you can not change the settings.
-          * 2 - You can only do read queries and you can change the settings, except for the `readonly` setting.
-          */
-        if (current_settings.readonly == 1)
-            throw Exception("Cannot modify '" + name.toString() + "' setting in readonly mode", ErrorCodes::READONLY);
-
-        if (current_settings.readonly > 1 && name == "readonly")
-            throw Exception("Cannot modify 'readonly' setting in readonly mode", ErrorCodes::READONLY);
-    }
 }
 
 
-void SettingsConstraints::check(const Settings & current_settings, const SettingChange & change)
+SettingsConstraints::SettingsConstraints() = default;
+SettingsConstraints::SettingsConstraints(const SettingsConstraints & src) = default;
+SettingsConstraints & SettingsConstraints::operator=(const SettingsConstraints & src) = default;
+SettingsConstraints::SettingsConstraints(SettingsConstraints && src) = default;
+SettingsConstraints & SettingsConstraints::operator=(SettingsConstraints && src) = default;
+SettingsConstraints::~SettingsConstraints() = default;
+
+
+void SettingsConstraints::setMaxValue(const String & name, const String & max_value)
+{
+    max_settings.set(name, max_value);
+}
+
+void SettingsConstraints::setMaxValue(const String & name, const Field & max_value)
+{
+    max_settings.set(name, max_value);
+}
+
+
+void SettingsConstraints::check(const Settings & current_settings, const SettingChange & change) const
 {
     size_t index = current_settings.find(change.name);
     if (index == Settings::npos)
@@ -56,10 +51,86 @@ void SettingsConstraints::check(const Settings & current_settings, const Setting
 }
 
 
-void SettingsConstraints::check(const Settings & current_settings, const SettingsChanges & changes)
+void SettingsConstraints::check(const Settings & current_settings, const SettingsChanges & changes) const
 {
     for (const auto & change : changes)
         check(current_settings, change);
+}
+
+
+void SettingsConstraints::checkImpl(const Settings & current_settings, size_t index) const
+{
+    const auto & new_setting = temp_settings[index];
+    Field new_value = new_setting.getValue();
+
+    const auto & current_setting = current_settings[index];
+    Field current_value = current_setting.getValue();
+
+    /// Setting isn't checked if value wasn't changed.
+    if (current_value == new_value)
+        return;
+
+    const StringRef & name = new_setting.getName();
+    if (!current_settings.allow_ddl && name == "allow_ddl")
+        throw Exception("Cannot modify 'allow_ddl' setting when DDL queries are prohibited for the user", ErrorCodes::QUERY_IS_PROHIBITED);
+
+    /** The `readonly` value is understood as follows:
+      * 0 - everything allowed.
+      * 1 - only read queries can be made; you can not change the settings.
+      * 2 - You can only do read queries and you can change the settings, except for the `readonly` setting.
+      */
+    if (current_settings.readonly == 1)
+        throw Exception("Cannot modify '" + name.toString() + "' setting in readonly mode", ErrorCodes::READONLY);
+
+    if (current_settings.readonly > 1 && name == "readonly")
+        throw Exception("Cannot modify 'readonly' setting in readonly mode", ErrorCodes::READONLY);
+
+    const auto & max_setting = max_settings[index];
+    if (max_setting.isChanged())
+    {
+        Field max_value = max_setting.getValue();
+        if (new_value > max_value)
+            throw Exception(
+                "Setting " + name.toString() + " shouldn't be greater than " + applyVisitor(FieldVisitorToString(), max_value),
+                ErrorCodes::SETTING_CONSTRAINT_VIOLATION);
+    }
+}
+
+
+void SettingsConstraints::setProfile(const String & profile_name, const Poco::Util::AbstractConfiguration & config)
+{
+    String parent_profile = "profiles." + profile_name + ".profile";
+    if (config.has(parent_profile))
+        setProfile(parent_profile, config); // Inheritance of one profile from another.
+
+    String path_to_constraints = "profiles." + profile_name + ".constraints";
+    if (config.has(path_to_constraints))
+        loadFromConfig(path_to_constraints, config);
+}
+
+
+void SettingsConstraints::loadFromConfig(const String & path_to_constraints, const Poco::Util::AbstractConfiguration & config)
+{
+    if (!config.has(path_to_constraints))
+        throw Exception("There is no path '" + path_to_constraints + "' in configuration file.", ErrorCodes::NO_ELEMENTS_IN_CONFIG);
+
+    Poco::Util::AbstractConfiguration::Keys names;
+    config.keys(path_to_constraints, names);
+
+    for (const String & name : names)
+    {
+        String path_to_name = path_to_constraints + "." + name;
+        Poco::Util::AbstractConfiguration::Keys constraint_types;
+        config.keys(path_to_name, constraint_types);
+        for (const String & constraint_type : constraint_types)
+        {
+            String path_to_type = path_to_name + "." + constraint_type;
+            if (constraint_type == "max")
+                setMaxValue(name, config.getString(path_to_type));
+            else
+                throw Exception("Setting " + constraint_type + " value for " + name + " isn't supported", ErrorCodes::NOT_IMPLEMENTED);
+        }
+    }
 }
 
 }

--- a/dbms/src/Interpreters/SettingsConstraints.cpp
+++ b/dbms/src/Interpreters/SettingsConstraints.cpp
@@ -42,7 +42,7 @@ void SettingsConstraints::setMaxValue(const String & name, const Field & max_val
 
 void SettingsConstraints::check(const Settings & current_settings, const SettingChange & change) const
 {
-    size_t index = current_settings.find(change.name);
+    size_t index = current_settings.findIndex(change.name);
     if (index == Settings::npos)
         return;
     // We store `change.value` to `temp_settings` to ensure it's converted to the correct type.

--- a/dbms/src/Interpreters/SettingsConstraints.h
+++ b/dbms/src/Interpreters/SettingsConstraints.h
@@ -19,18 +19,27 @@ struct Settings;
 /** Checks if specified changes of settings are allowed or not.
   * If the changes are not allowed (i.e. violates some constraints) this class throws an exception.
   * The constraints are set by editing the `users.xml` file.
-  * For examples, the following lines in `users.xml` will set that `max_memory_usage` cannot be greater than 20000000000:
+  *
+  * For examples, the following lines in `users.xml` will set that `max_memory_usage` cannot be greater than 20000000000,
+  * and `force_index_by_date` should be always equal to 0:
+  *
   * <profiles>
   *   <user_profile>
   *       <max_memory_usage>10000000000</max_memory_usage>
+  *       <force_index_by_date>0</force_index_by_date>
   *       ...
   *       <constraints>
   *           <max_memory_usage>
+  *               <min>200000</min>
   *               <max>20000000000</max>
   *           </max_memory_usage>
+  *           <force_index_by_date>
+  *               <readonly/>
+  *           </force_index_by_date>
   *       </constraints>
   *   </user_profile>
   * </profiles>
+  *
   * This class also checks that we are not in the read-only mode.
   * If a setting cannot be change due to the read-only mode this class throws an exception.
   * The value of `readonly` value is understood as follows:
@@ -48,8 +57,13 @@ public:
     SettingsConstraints & operator =(SettingsConstraints && src);
     ~SettingsConstraints();
 
+    void clear();
+
+    void setMinValue(const String & name, const String & min_value);
+    void setMinValue(const String & name, const Field & min_value);
     void setMaxValue(const String & name, const String & max_value);
     void setMaxValue(const String & name, const Field & max_value);
+    void setReadOnly(const String & name, bool read_only);
 
     void check(const Settings & current_settings, const SettingChange & change) const;
     void check(const Settings & current_settings, const SettingsChanges & changes) const;
@@ -63,9 +77,17 @@ public:
     void loadFromConfig(const String & path, const Poco::Util::AbstractConfiguration & config);
 
 private:
-    void checkImpl(const Settings & current_settings, size_t index) const;
+    struct Constraint
+    {
+        bool read_only = false;
+        Field min_value;
+        Field max_value;
+    };
 
-    Settings max_settings;
+    Constraint & getConstraintRef(size_t index);
+    const Constraint * tryGetConstraint(size_t) const;
+
+    std::unordered_map<size_t, Constraint> constraints_by_index;
 };
 
 }

--- a/dbms/src/Interpreters/SettingsConstraints.h
+++ b/dbms/src/Interpreters/SettingsConstraints.h
@@ -1,6 +1,16 @@
 #pragma once
 
 #include <Common/SettingsChanges.h>
+#include <Core/Settings.h>
+
+namespace Poco
+{
+namespace Util
+{
+    class AbstractConfiguration;
+}
+}
+
 
 namespace DB
 {
@@ -8,7 +18,20 @@ struct Settings;
 
 /** Checks if specified changes of settings are allowed or not.
   * If the changes are not allowed (i.e. violates some constraints) this class throws an exception.
-  * This class checks that we are not in the read-only mode.
+  * The constraints are set by editing the `users.xml` file.
+  * For examples, the following lines in `users.xml` will set that `max_memory_usage` cannot be greater than 20000000000:
+  * <profiles>
+  *   <user_profile>
+  *       <max_memory_usage>10000000000</max_memory_usage>
+  *       ...
+  *       <constraints>
+  *           <max_memory_usage>
+  *               <max>20000000000</max>
+  *           </max_memory_usage>
+  *       </constraints>
+  *   </user_profile>
+  * </profiles>
+  * This class also checks that we are not in the read-only mode.
   * If a setting cannot be change due to the read-only mode this class throws an exception.
   * The value of `readonly` value is understood as follows:
   * 0 - everything allowed.
@@ -18,8 +41,31 @@ struct Settings;
 class SettingsConstraints
 {
 public:
-    static void check(const Settings & current_settings, const SettingChange & change);
-    static void check(const Settings & current_settings, const SettingsChanges & changes);
+    SettingsConstraints();
+    SettingsConstraints(const SettingsConstraints & src);
+    SettingsConstraints & operator =(const SettingsConstraints & src);
+    SettingsConstraints(SettingsConstraints && src);
+    SettingsConstraints & operator =(SettingsConstraints && src);
+    ~SettingsConstraints();
+
+    void setMaxValue(const String & name, const String & max_value);
+    void setMaxValue(const String & name, const Field & max_value);
+
+    void check(const Settings & current_settings, const SettingChange & change) const;
+    void check(const Settings & current_settings, const SettingsChanges & changes) const;
+
+    /** Set multiple settings from "profile" (in server configuration file (users.xml), profiles contain groups of multiple settings).
+      * The profile can also be set using the `set` functions, like the profile setting.
+      */
+    void setProfile(const String & profile_name, const Poco::Util::AbstractConfiguration & config);
+
+    /// Loads the constraints from configuration file, at "path" prefix in configuration.
+    void loadFromConfig(const String & path, const Poco::Util::AbstractConfiguration & config);
+
+private:
+    void checkImpl(const Settings & current_settings, size_t index) const;
+
+    Settings max_settings;
 };
 
 }

--- a/dbms/src/Interpreters/SettingsConstraints.h
+++ b/dbms/src/Interpreters/SettingsConstraints.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <Common/SettingsChanges.h>
+
+namespace DB
+{
+struct Settings;
+
+/** Checks if specified changes of settings are allowed or not.
+  * If the changes are not allowed (i.e. violates some constraints) this class throws an exception.
+  * This class checks that we are not in the read-only mode.
+  * If a setting cannot be change due to the read-only mode this class throws an exception.
+  * The value of `readonly` value is understood as follows:
+  * 0 - everything allowed.
+  * 1 - only read queries can be made; you can not change the settings.
+  * 2 - you can only do read queries and you can change the settings, except for the `readonly` setting.
+  */
+class SettingsConstraints
+{
+public:
+    static void check(const Settings & current_settings, const SettingChange & change);
+    static void check(const Settings & current_settings, const SettingsChanges & changes);
+};
+
+}

--- a/dbms/src/Parsers/ASTSetQuery.h
+++ b/dbms/src/Parsers/ASTSetQuery.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <Core/Field.h>
 #include <Common/FieldVisitors.h>
+#include <Common/SettingsChanges.h>
 #include <Parsers/IAST.h>
 
 
@@ -16,14 +16,7 @@ class ASTSetQuery : public IAST
 public:
     bool is_standalone = true; /// If false, this AST is a part of another query, such as SELECT.
 
-    struct Change
-    {
-        String name;
-        Field value;
-    };
-
-    using Changes = std::vector<Change>;
-    Changes changes;
+    SettingsChanges changes;
 
     /** Get the text that identifies this element. */
     String getID(char) const override { return "Set"; }
@@ -35,7 +28,7 @@ public:
         if (is_standalone)
             settings.ostr << (settings.hilite ? hilite_keyword : "") << "SET " << (settings.hilite ? hilite_none : "");
 
-        for (ASTSetQuery::Changes::const_iterator it = changes.begin(); it != changes.end(); ++it)
+        for (auto it = changes.begin(); it != changes.end(); ++it)
         {
             if (it != changes.begin())
                 settings.ostr << ", ";

--- a/dbms/src/Parsers/ParserSetQuery.cpp
+++ b/dbms/src/Parsers/ParserSetQuery.cpp
@@ -31,7 +31,6 @@ static bool parseNameValuePair(SettingChange & change, IParser::Pos & pos, Expec
     if (!value_p.parse(pos, value, expected))
         return false;
 
-    String change_name;
     getIdentifierName(name, change.name);
     change.value = value->as<ASTLiteral &>().value;
 

--- a/dbms/src/Storages/Kafka/KafkaSettings.cpp
+++ b/dbms/src/Storages/Kafka/KafkaSettings.cpp
@@ -11,24 +11,25 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
+    extern const int UNKNOWN_SETTING;
 }
+
+IMPLEMENT_SETTINGS_COLLECTION(KafkaSettings, APPLY_FOR_KAFKA_SETTINGS)
 
 void KafkaSettings::loadFromQuery(ASTStorage & storage_def)
 {
     if (storage_def.settings)
     {
-        for (const ASTSetQuery::Change & setting : storage_def.settings->changes)
+        try
         {
-#define SET(TYPE, NAME, DEFAULT, DESCRIPTION) \
-            else if (setting.name == #NAME) NAME.set(setting.value);
-
-            if (false) {}
-            APPLY_FOR_KAFKA_SETTINGS(SET)
+            applyChanges(storage_def.settings->changes);
+        }
+        catch (Exception & e)
+        {
+            if (e.code() == ErrorCodes::UNKNOWN_SETTING)
+                throw Exception(e.message() + " for storage " + storage_def.engine->name, ErrorCodes::BAD_ARGUMENTS);
             else
-                throw Exception(
-                    "Unknown setting " + setting.name + " for storage " + storage_def.engine->name,
-                    ErrorCodes::BAD_ARGUMENTS);
-#undef SET
+                e.rethrow();
         }
     }
     else

--- a/dbms/src/Storages/Kafka/KafkaSettings.h
+++ b/dbms/src/Storages/Kafka/KafkaSettings.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <Poco/Util/AbstractConfiguration.h>
-#include <Core/Defines.h>
-#include <Core/Types.h>
 #include <Core/SettingsCommon.h>
 
 
@@ -14,7 +11,7 @@ class ASTStorage;
 /** Settings for the Kafka engine.
   * Could be loaded from a CREATE TABLE query (SETTINGS clause).
   */
-struct KafkaSettings
+struct KafkaSettings : public SettingsCollection<KafkaSettings>
 {
 
 #define APPLY_FOR_KAFKA_SETTINGS(M) \
@@ -28,14 +25,8 @@ struct KafkaSettings
     M(SettingUInt64, kafka_max_block_size, 0, "The maximum block size per table for Kafka engine.") \
     M(SettingUInt64, kafka_skip_broken_messages, 0, "Skip at least this number of broken messages from Kafka topic per block")
 
-#define DECLARE(TYPE, NAME, DEFAULT, DESCRIPTION) \
-    TYPE NAME {DEFAULT};
+    DECLARE_SETTINGS_COLLECTION(APPLY_FOR_KAFKA_SETTINGS)
 
-    APPLY_FOR_KAFKA_SETTINGS(DECLARE)
-
-#undef DECLARE
-
-public:
     void loadFromQuery(ASTStorage & storage_def);
 };
 

--- a/dbms/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -1,4 +1,5 @@
 #include <Storages/MergeTree/MergeTreeSettings.h>
+#include <Poco/Util/AbstractConfiguration.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Parsers/ASTFunction.h>
@@ -12,7 +13,10 @@ namespace ErrorCodes
 {
     extern const int INVALID_CONFIG_PARAMETER;
     extern const int BAD_ARGUMENTS;
+    extern const int UNKNOWN_SETTING;
 }
+
+IMPLEMENT_SETTINGS_COLLECTION(MergeTreeSettings, APPLY_FOR_MERGE_TREE_SETTINGS)
 
 void MergeTreeSettings::loadFromConfig(const String & config_elem, const Poco::Util::AbstractConfiguration & config)
 {
@@ -22,18 +26,17 @@ void MergeTreeSettings::loadFromConfig(const String & config_elem, const Poco::U
     Poco::Util::AbstractConfiguration::Keys config_keys;
     config.keys(config_elem, config_keys);
 
-    for (const String & key : config_keys)
+    try
     {
-        String value = config.getString(config_elem + "." + key);
-
-#define SET(TYPE, NAME, DEFAULT, DESCRIPTION) \
-        else if (key == #NAME) NAME.set(value);
-
-        if (false) {}
-        APPLY_FOR_MERGE_TREE_SETTINGS(SET)
+        for (const String & key : config_keys)
+            set(key, config.getString(config_elem + "." + key));
+    }
+    catch (Exception & e)
+    {
+        if (e.code() == ErrorCodes::UNKNOWN_SETTING)
+            throw Exception(e.message() + " in MergeTree config", ErrorCodes::INVALID_CONFIG_PARAMETER);
         else
-            throw Exception("Unknown MergeTree setting " + key + " in config", ErrorCodes::INVALID_CONFIG_PARAMETER);
-#undef SET
+            e.rethrow();
     }
 }
 
@@ -41,18 +44,16 @@ void MergeTreeSettings::loadFromQuery(ASTStorage & storage_def)
 {
     if (storage_def.settings)
     {
-        for (const ASTSetQuery::Change & setting : storage_def.settings->changes)
+        try
         {
-#define SET(TYPE, NAME, DEFAULT, DESCRIPTION) \
-            else if (setting.name == #NAME) NAME.set(setting.value);
-
-            if (false) {}
-            APPLY_FOR_MERGE_TREE_SETTINGS(SET)
+            applyChanges(storage_def.settings->changes);
+        }
+        catch (Exception & e)
+        {
+            if (e.code() == ErrorCodes::UNKNOWN_SETTING)
+                throw Exception(e.message() + " for storage " + storage_def.engine->name, ErrorCodes::BAD_ARGUMENTS);
             else
-                throw Exception(
-                    "Unknown setting " + setting.name + " for storage " + storage_def.engine->name,
-                    ErrorCodes::BAD_ARGUMENTS);
-#undef SET
+                e.rethrow();
         }
     }
     else
@@ -62,13 +63,13 @@ void MergeTreeSettings::loadFromQuery(ASTStorage & storage_def)
         storage_def.set(storage_def.settings, settings_ast);
     }
 
-    ASTSetQuery::Changes & changes = storage_def.settings->changes;
+    SettingsChanges & changes = storage_def.settings->changes;
 
 #define ADD_IF_ABSENT(NAME)                                                                                   \
     if (std::find_if(changes.begin(), changes.end(),                                                          \
-                  [](const ASTSetQuery::Change & c) { return c.name == #NAME; })                              \
+                  [](const SettingChange & c) { return c.name == #NAME; })                              \
             == changes.end())                                                                                 \
-        changes.push_back(ASTSetQuery::Change{#NAME, NAME.value});
+        changes.push_back(SettingChange{#NAME, NAME.value});
 
     APPLY_FOR_IMMUTABLE_MERGE_TREE_SETTINGS(ADD_IF_ABSENT)
 #undef ADD_IF_ABSENT

--- a/dbms/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -26,7 +26,7 @@ void MergeTreeSettings::loadFromConfig(const String & config_elem, const Poco::U
     {
         String value = config.getString(config_elem + "." + key);
 
-#define SET(TYPE, NAME, DEFAULT) \
+#define SET(TYPE, NAME, DEFAULT, DESCRIPTION) \
         else if (key == #NAME) NAME.set(value);
 
         if (false) {}
@@ -43,7 +43,7 @@ void MergeTreeSettings::loadFromQuery(ASTStorage & storage_def)
     {
         for (const ASTSetQuery::Change & setting : storage_def.settings->changes)
         {
-#define SET(TYPE, NAME, DEFAULT) \
+#define SET(TYPE, NAME, DEFAULT, DESCRIPTION) \
             else if (setting.name == #NAME) NAME.set(setting.value);
 
             if (false) {}

--- a/dbms/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeSettings.h
@@ -18,161 +18,161 @@ struct MergeTreeSettings
 {
 
 #define APPLY_FOR_MERGE_TREE_SETTINGS(M) \
-    /** How many rows correspond to one primary key value. */                                                 \
-    M(SettingUInt64, index_granularity, 8192)                                                                 \
-                                                                                                              \
-    /** Merge settings. */                                                                                    \
-                                                                                                              \
-    /** Maximum in total size of parts to merge, when there are maximum (minimum) free threads                \
-     * in background pool (or entries in replication queue). */                                               \
-    M(SettingUInt64, max_bytes_to_merge_at_max_space_in_pool, 150ULL * 1024 * 1024 * 1024)                    \
-    M(SettingUInt64, max_bytes_to_merge_at_min_space_in_pool, 1024 * 1024)                                    \
-                                                                                                              \
-    /** How many tasks of merging parts are allowed simultaneously in ReplicatedMergeTree queue. */           \
-    M(SettingUInt64, max_replicated_merges_in_queue, 16)                                                      \
-                                                                                                              \
-    /** When there is less than specified number of free entries in pool (or replicated queue),               \
-     *  start to lower maximum size of merge to process (or to put in queue).                                 \
-     *  This is to allow small merges to process - not filling the pool with long running merges. */          \
-    M(SettingUInt64, number_of_free_entries_in_pool_to_lower_max_size_of_merge, 8)                            \
-                                                                                                              \
-    /** How many seconds to keep obsolete parts. */                                                           \
-    M(SettingSeconds, old_parts_lifetime, 8 * 60)                                                             \
-                                                                                                              \
-    /** How many seconds to keep tmp_-directories. */                                                         \
-    M(SettingSeconds, temporary_directories_lifetime, 86400)                                                  \
-                                                                                                              \
-    /** Inserts settings. */                                                                                  \
-                                                                                                              \
-    /** If table contains at least that many active parts, artificially slow down insert into table. */       \
-    M(SettingUInt64, parts_to_delay_insert, 150)                                                              \
-                                                                                                              \
-    /** If more than this number active parts, throw 'Too many parts ...' exception */                        \
-    M(SettingUInt64, parts_to_throw_insert, 300)                                                              \
-                                                                                                              \
-    /** Max delay of inserting data into MergeTree table in seconds, if there are a lot of unmerged parts. */ \
-    M(SettingUInt64, max_delay_to_insert, 1)                                                                  \
-                                                                                                              \
-    /** Replication settings. */                                                                              \
-                                                                                                              \
-    /** How many last blocks of hashes should be kept in ZooKeeper (old blocks will be deleted). */           \
-    M(SettingUInt64, replicated_deduplication_window, 100)                                                    \
-    /** Similar to previous, but determines old blocks by their lifetime.                                     \
-     *  Hash of an inserted block will be deleted (and the block will not be deduplicated after)              \
-     *  if it outside of one "window". You can set very big replicated_deduplication_window to avoid          \
-     *  duplicating INSERTs during that period of time. */                                                    \
-    M(SettingUInt64, replicated_deduplication_window_seconds, 7 * 24 * 60 * 60) /** one week */               \
-                                                                                                              \
-    /** How many records may be in log, if there is inactive replica  */                                      \
-    M(SettingUInt64, max_replicated_logs_to_keep, 10000)                                                      \
-                                                                                                              \
-    /** Keep about this number of last records in ZooKeeper log, even if they are obsolete.                   \
-     *  It doesn't affect work of tables: used only to diagnose ZooKeeper log before cleaning. */             \
-    M(SettingUInt64, min_replicated_logs_to_keep, 100)                                                        \
-                                                                                                              \
-    /** After specified amount of time passed after replication log entry creation                            \
-     *  and sum size of parts is greater than threshold,                                                      \
-     *  prefer fetching merged part from replica instead of doing merge locally.                              \
-     *  To speed up very long merges. */                                                                      \
-    M(SettingSeconds, prefer_fetch_merged_part_time_threshold, 3600)                                          \
-    M(SettingUInt64, prefer_fetch_merged_part_size_threshold, 10ULL * 1024 * 1024 * 1024)                     \
-                                                                                                              \
-    /** Max broken parts, if more - deny automatic deletion. */                                               \
-    M(SettingUInt64, max_suspicious_broken_parts, 10)                                                         \
-                                                                                                              \
-    /** Not apply ALTER if number of files for modification(deletion, addition) more than this. */            \
-    M(SettingUInt64, max_files_to_modify_in_alter_columns, 75)                                                \
-    /** Not apply ALTER, if number of files for deletion more than this. */                                   \
-    M(SettingUInt64, max_files_to_remove_in_alter_columns, 50)                                                \
-                                                                                                              \
-    /** If ratio of wrong parts to total number of parts is less than this - allow to start. */               \
-    M(SettingFloat, replicated_max_ratio_of_wrong_parts, 0.5)                                                 \
-                                                                                                              \
-    /** Limit parallel fetches */                                                                             \
-    M(SettingUInt64, replicated_max_parallel_fetches, 0)                                                      \
-    M(SettingUInt64, replicated_max_parallel_fetches_for_table, 0)                                            \
-                                                                                                              \
-    /** Limit parallel fetches from endpoint (actually pool size) */                                          \
-    M(SettingUInt64, replicated_max_parallel_fetches_for_host, DEFAULT_COUNT_OF_HTTP_CONNECTIONS_PER_ENDPOINT)\
-                                                                                                              \
-    /** Limit parallel sends */                                                                               \
-    M(SettingUInt64, replicated_max_parallel_sends, 0)                                                        \
-    M(SettingUInt64, replicated_max_parallel_sends_for_table, 0)                                              \
-                                                                                                              \
-    /** If true, Replicated tables replicas on this node will try to acquire leadership. */                   \
-    M(SettingBool, replicated_can_become_leader, true)                                                        \
-                                                                                                              \
-    M(SettingSeconds, zookeeper_session_expiration_check_period, 60)                                          \
-                                                                                                              \
-    /** Check delay of replicas settings. */                                                                  \
-                                                                                                              \
-    /** Period to check replication delay and compare with other replicas. */                                 \
-    M(SettingUInt64, check_delay_period, 60)                                                                  \
-                                                                                                              \
-    /** Period to clean old queue logs, blocks hashes and parts */                                            \
-    M(SettingUInt64, cleanup_delay_period, 30)                                                                \
-    /** Add uniformly distributed value from 0 to x seconds to cleanup_delay_period                           \
+    /** How many rows correspond to one primary key value. */                                                     \
+    M(SettingUInt64, index_granularity, 8192, "")                                                                 \
+                                                                                                                  \
+    /** Merge settings. */                                                                                        \
+                                                                                                                  \
+    /** Maximum in total size of parts to merge, when there are maximum (minimum) free threads                    \
+     * in background pool (or entries in replication queue). */                                                   \
+    M(SettingUInt64, max_bytes_to_merge_at_max_space_in_pool, 150ULL * 1024 * 1024 * 1024, "")                    \
+    M(SettingUInt64, max_bytes_to_merge_at_min_space_in_pool, 1024 * 1024, "")                                    \
+                                                                                                                  \
+    /** How many tasks of merging parts are allowed simultaneously in ReplicatedMergeTree queue. */               \
+    M(SettingUInt64, max_replicated_merges_in_queue, 16, "")                                                      \
+                                                                                                                  \
+    /** When there is less than specified number of free entries in pool (or replicated queue),                   \
+     *  start to lower maximum size of merge to process (or to put in queue).                                     \
+     *  This is to allow small merges to process - not filling the pool with long running merges. */              \
+    M(SettingUInt64, number_of_free_entries_in_pool_to_lower_max_size_of_merge, 8, "")                            \
+                                                                                                                  \
+    /** How many seconds to keep obsolete parts. */                                                               \
+    M(SettingSeconds, old_parts_lifetime, 8 * 60, "")                                                             \
+                                                                                                                  \
+    /** How many seconds to keep tmp_-directories. */                                                             \
+    M(SettingSeconds, temporary_directories_lifetime, 86400, "")                                                  \
+                                                                                                                  \
+    /** Inserts settings. */                                                                                      \
+                                                                                                                  \
+    /** If table contains at least that many active parts, artificially slow down insert into table. */           \
+    M(SettingUInt64, parts_to_delay_insert, 150, "")                                                              \
+                                                                                                                  \
+    /** If more than this number active parts, throw 'Too many parts ...' exception */                            \
+    M(SettingUInt64, parts_to_throw_insert, 300, "")                                                              \
+                                                                                                                  \
+    /** Max delay of inserting data into MergeTree table in seconds, if there are a lot of unmerged parts. */     \
+    M(SettingUInt64, max_delay_to_insert, 1, "")                                                                  \
+                                                                                                                  \
+    /** Replication settings. */                                                                                  \
+                                                                                                                  \
+    /** How many last blocks of hashes should be kept in ZooKeeper (old blocks will be deleted). */               \
+    M(SettingUInt64, replicated_deduplication_window, 100, "")                                                    \
+    /** Similar to previous, but determines old blocks by their lifetime.                                         \
+     *  Hash of an inserted block will be deleted (and the block will not be deduplicated after)                  \
+     *  if it outside of one "window". You can set very big replicated_deduplication_window to avoid              \
+     *  duplicating INSERTs during that period of time. */                                                        \
+    M(SettingUInt64, replicated_deduplication_window_seconds, 7 * 24 * 60 * 60, "") /** one week */               \
+                                                                                                                  \
+    /** How many records may be in log, if there is inactive replica  */                                          \
+    M(SettingUInt64, max_replicated_logs_to_keep, 10000, "")                                                      \
+                                                                                                                  \
+    /** Keep about this number of last records in ZooKeeper log, even if they are obsolete.                       \
+     *  It doesn't affect work of tables: used only to diagnose ZooKeeper log before cleaning. */                 \
+    M(SettingUInt64, min_replicated_logs_to_keep, 100, "")                                                        \
+                                                                                                                  \
+    /** After specified amount of time passed after replication log entry creation                                \
+     *  and sum size of parts is greater than threshold,                                                          \
+     *  prefer fetching merged part from replica instead of doing merge locally.                                  \
+     *  To speed up very long merges. */                                                                          \
+    M(SettingSeconds, prefer_fetch_merged_part_time_threshold, 3600, "")                                          \
+    M(SettingUInt64, prefer_fetch_merged_part_size_threshold, 10ULL * 1024 * 1024 * 1024, "")                     \
+                                                                                                                  \
+    /** Max broken parts, if more - deny automatic deletion. */                                                   \
+    M(SettingUInt64, max_suspicious_broken_parts, 10, "")                                                         \
+                                                                                                                  \
+    /** Not apply ALTER if number of files for modification(deletion, addition) more than this. */                \
+    M(SettingUInt64, max_files_to_modify_in_alter_columns, 75, "")                                                \
+    /** Not apply ALTER, if number of files for deletion more than this. */                                       \
+    M(SettingUInt64, max_files_to_remove_in_alter_columns, 50, "")                                                \
+                                                                                                                  \
+    /** If ratio of wrong parts to total number of parts is less than this - allow to start. */                   \
+    M(SettingFloat, replicated_max_ratio_of_wrong_parts, 0.5, "")                                                 \
+                                                                                                                  \
+    /** Limit parallel fetches */                                                                                 \
+    M(SettingUInt64, replicated_max_parallel_fetches, 0, "")                                                      \
+    M(SettingUInt64, replicated_max_parallel_fetches_for_table, 0, "")                                            \
+                                                                                                                  \
+    /** Limit parallel fetches from endpoint (actually pool size) */                                              \
+    M(SettingUInt64, replicated_max_parallel_fetches_for_host, DEFAULT_COUNT_OF_HTTP_CONNECTIONS_PER_ENDPOINT, "")\
+                                                                                                                  \
+    /** Limit parallel sends */                                                                                   \
+    M(SettingUInt64, replicated_max_parallel_sends, 0, "")                                                        \
+    M(SettingUInt64, replicated_max_parallel_sends_for_table, 0, "")                                              \
+                                                                                                                  \
+    /** If true, Replicated tables replicas on this node will try to acquire leadership. */                       \
+    M(SettingBool, replicated_can_become_leader, true, "")                                                        \
+                                                                                                                  \
+    M(SettingSeconds, zookeeper_session_expiration_check_period, 60, "")                                          \
+                                                                                                                  \
+    /** Check delay of replicas settings. */                                                                      \
+                                                                                                                  \
+    /** Period to check replication delay and compare with other replicas. */                                     \
+    M(SettingUInt64, check_delay_period, 60, "")                                                                  \
+                                                                                                                  \
+    /** Period to clean old queue logs, blocks hashes and parts */                                                \
+    M(SettingUInt64, cleanup_delay_period, 30, "")                                                                \
+    /** Add uniformly distributed value from 0 to x seconds to cleanup_delay_period                               \
         to avoid thundering herd effect and subsequent DoS of ZooKeeper in case of very large number of tables */ \
-    M(SettingUInt64, cleanup_delay_period_random_add, 10)                                                     \
-                                                                                                              \
-    /** Minimal delay from other replicas to yield leadership. Here and further 0 means unlimited. */         \
-    M(SettingUInt64, min_relative_delay_to_yield_leadership, 120)                                             \
-                                                                                                              \
-    /** Minimal delay from other replicas to close, stop serving requests and not return Ok                   \
-     *  during status check. */                                                                               \
-    M(SettingUInt64, min_relative_delay_to_close, 300)                                                        \
-                                                                                                              \
-    /** Minimal absolute delay to close, stop serving requests and not return Ok during status check. */      \
-    M(SettingUInt64, min_absolute_delay_to_close, 0)                                                          \
-                                                                                                              \
-    /** Enable usage of Vertical merge algorithm. */                                                          \
-    M(SettingUInt64, enable_vertical_merge_algorithm, 1)                                                      \
-                                                                                                              \
-    /** Minimal (approximate) sum of rows in merging parts to activate Vertical merge algorithm */            \
-    M(SettingUInt64, vertical_merge_algorithm_min_rows_to_activate, 16 * DEFAULT_MERGE_BLOCK_SIZE)            \
-                                                                                                              \
-    /** Minimal amount of non-PK columns to activate Vertical merge algorithm */                              \
-    M(SettingUInt64, vertical_merge_algorithm_min_columns_to_activate, 11)                                    \
-                                                                                                              \
-    /** Compatibility settings */                                                                             \
-                                                                                                              \
-    /** Allow to create a table with sampling expression not in primary key.                                  \
-      * This is needed only to temporarily allow to run the server with wrong tables                          \
-      *  for backward compatibility.                                                                          \
-      */                                                                                                      \
-    M(SettingBool, compatibility_allow_sampling_expression_not_in_primary_key, false)                         \
-                                                                                                              \
-    /** Use small format (dozens bytes) for part checksums in ZooKeeper                                       \
-      *  instead of ordinary ones (dozens KB).                                                                \
-      * Before enabling check that all replicas support new format.                                           \
-      */                                                                                                      \
-    M(SettingBool, use_minimalistic_checksums_in_zookeeper, true)                                             \
-                                                                                                              \
-    /** Store part header (checksums and columns) in a compact format and a single part znode                 \
-      *  instead of separate znodes (<part>/columns and <part>/checksums).                                    \
-      * This can dramatically reduce snapshot size in ZooKeeper.                                              \
-      * Before enabling check that all replicas support new format.                                           \
-      */                                                                                                      \
-    M(SettingBool, use_minimalistic_part_header_in_zookeeper, false)                                          \
-                                                                                                              \
-    /** How many records about mutations that are done to keep.                                               \
-     *  If zero, then keep all of them */                                                                     \
-    M(SettingUInt64, finished_mutations_to_keep, 100)                                                         \
-                                                                                                              \
-    /** Minimal amount of bytes to enable O_DIRECT in merge (0 - disabled) */                                 \
-    M(SettingUInt64, min_merge_bytes_to_use_direct_io, 10ULL * 1024 * 1024 * 1024)                            \
-                                                                                                              \
-    /** Approximate amount of bytes in single granule (0 - disabled) */                                       \
-    M(SettingUInt64, index_granularity_bytes, 0)                                                              \
-                                                                                                              \
-    /** Minimal time in seconds, when merge with TTL can be repeated */                                       \
-    M(SettingInt64, merge_with_ttl_timeout, 3600 * 24)
+    M(SettingUInt64, cleanup_delay_period_random_add, 10, "")                                                     \
+                                                                                                                  \
+    /** Minimal delay from other replicas to yield leadership. Here and further 0 means unlimited. */             \
+    M(SettingUInt64, min_relative_delay_to_yield_leadership, 120, "")                                             \
+                                                                                                                  \
+    /** Minimal delay from other replicas to close, stop serving requests and not return Ok                       \
+     *  during status check. */                                                                                   \
+    M(SettingUInt64, min_relative_delay_to_close, 300, "")                                                        \
+                                                                                                                  \
+    /** Minimal absolute delay to close, stop serving requests and not return Ok during status check. */          \
+    M(SettingUInt64, min_absolute_delay_to_close, 0, "")                                                          \
+                                                                                                                  \
+    /** Enable usage of Vertical merge algorithm. */                                                              \
+    M(SettingUInt64, enable_vertical_merge_algorithm, 1, "")                                                      \
+                                                                                                                  \
+    /** Minimal (approximate) sum of rows in merging parts to activate Vertical merge algorithm */                \
+    M(SettingUInt64, vertical_merge_algorithm_min_rows_to_activate, 16 * DEFAULT_MERGE_BLOCK_SIZE, "")            \
+                                                                                                                  \
+    /** Minimal amount of non-PK columns to activate Vertical merge algorithm */                                  \
+    M(SettingUInt64, vertical_merge_algorithm_min_columns_to_activate, 11, "")                                    \
+                                                                                                                  \
+    /** Compatibility settings */                                                                                 \
+                                                                                                                  \
+    /** Allow to create a table with sampling expression not in primary key.                                      \
+      * This is needed only to temporarily allow to run the server with wrong tables                              \
+      *  for backward compatibility.                                                                              \
+      */                                                                                                          \
+    M(SettingBool, compatibility_allow_sampling_expression_not_in_primary_key, false, "")                         \
+                                                                                                                  \
+    /** Use small format (dozens bytes) for part checksums in ZooKeeper                                           \
+      *  instead of ordinary ones (dozens KB).                                                                    \
+      * Before enabling check that all replicas support new format.                                               \
+      */                                                                                                          \
+    M(SettingBool, use_minimalistic_checksums_in_zookeeper, true, "")                                             \
+                                                                                                                  \
+    /** Store part header (checksums and columns) in a compact format and a single part znode                     \
+      *  instead of separate znodes (<part>/columns and <part>/checksums).                                        \
+      * This can dramatically reduce snapshot size in ZooKeeper.                                                  \
+      * Before enabling check that all replicas support new format.                                               \
+      */                                                                                                          \
+    M(SettingBool, use_minimalistic_part_header_in_zookeeper, false, "")                                          \
+                                                                                                                  \
+    /** How many records about mutations that are done to keep.                                                   \
+     *  If zero, then keep all of them */                                                                         \
+    M(SettingUInt64, finished_mutations_to_keep, 100, "")                                                         \
+                                                                                                                  \
+    /** Minimal amount of bytes to enable O_DIRECT in merge (0 - disabled) */                                     \
+    M(SettingUInt64, min_merge_bytes_to_use_direct_io, 10ULL * 1024 * 1024 * 1024, "")                            \
+                                                                                                                  \
+    /** Approximate amount of bytes in single granule (0 - disabled) */                                           \
+    M(SettingUInt64, index_granularity_bytes, 0, "")                                                              \
+                                                                                                                  \
+    /** Minimal time in seconds, when merge with TTL can be repeated */                                           \
+    M(SettingInt64, merge_with_ttl_timeout, 3600 * 24, "")
 
     /// Settings that should not change after the creation of a table.
 #define APPLY_FOR_IMMUTABLE_MERGE_TREE_SETTINGS(M) \
     M(index_granularity)
 
-#define DECLARE(TYPE, NAME, DEFAULT) \
+#define DECLARE(TYPE, NAME, DEFAULT, DESCRIPTION) \
     TYPE NAME {DEFAULT};
 
     APPLY_FOR_MERGE_TREE_SETTINGS(DECLARE)

--- a/dbms/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeSettings.h
@@ -1,9 +1,16 @@
 #pragma once
 
-#include <Poco/Util/AbstractConfiguration.h>
 #include <Core/Defines.h>
-#include <Core/Types.h>
 #include <Core/SettingsCommon.h>
+
+
+namespace Poco
+{
+    namespace Util
+    {
+        class AbstractConfiguration;
+    }
+}
 
 
 namespace DB
@@ -14,7 +21,7 @@ class ASTStorage;
 /** Settings for the MergeTree family of engines.
   * Could be loaded from config or from a CREATE TABLE query (SETTINGS clause).
   */
-struct MergeTreeSettings
+struct MergeTreeSettings : public SettingsCollection<MergeTreeSettings>
 {
 
 #define APPLY_FOR_MERGE_TREE_SETTINGS(M) \
@@ -168,18 +175,12 @@ struct MergeTreeSettings
     /** Minimal time in seconds, when merge with TTL can be repeated */                                           \
     M(SettingInt64, merge_with_ttl_timeout, 3600 * 24, "")
 
+    DECLARE_SETTINGS_COLLECTION(APPLY_FOR_MERGE_TREE_SETTINGS)
+
     /// Settings that should not change after the creation of a table.
 #define APPLY_FOR_IMMUTABLE_MERGE_TREE_SETTINGS(M) \
     M(index_granularity)
 
-#define DECLARE(TYPE, NAME, DEFAULT, DESCRIPTION) \
-    TYPE NAME {DEFAULT};
-
-    APPLY_FOR_MERGE_TREE_SETTINGS(DECLARE)
-
-#undef DECLARE
-
-public:
     void loadFromConfig(const String & config_elem, const Poco::Util::AbstractConfiguration & config);
 
     /// NOTE: will rewrite the AST to add immutable settings.

--- a/dbms/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeSettings.h
@@ -25,155 +25,59 @@ struct MergeTreeSettings : public SettingsCollection<MergeTreeSettings>
 {
 
 #define APPLY_FOR_MERGE_TREE_SETTINGS(M) \
-    /** How many rows correspond to one primary key value. */                                                     \
-    M(SettingUInt64, index_granularity, 8192, "")                                                                 \
-                                                                                                                  \
-    /** Merge settings. */                                                                                        \
-                                                                                                                  \
-    /** Maximum in total size of parts to merge, when there are maximum (minimum) free threads                    \
-     * in background pool (or entries in replication queue). */                                                   \
-    M(SettingUInt64, max_bytes_to_merge_at_max_space_in_pool, 150ULL * 1024 * 1024 * 1024, "")                    \
-    M(SettingUInt64, max_bytes_to_merge_at_min_space_in_pool, 1024 * 1024, "")                                    \
-                                                                                                                  \
-    /** How many tasks of merging parts are allowed simultaneously in ReplicatedMergeTree queue. */               \
-    M(SettingUInt64, max_replicated_merges_in_queue, 16, "")                                                      \
-                                                                                                                  \
-    /** When there is less than specified number of free entries in pool (or replicated queue),                   \
-     *  start to lower maximum size of merge to process (or to put in queue).                                     \
-     *  This is to allow small merges to process - not filling the pool with long running merges. */              \
-    M(SettingUInt64, number_of_free_entries_in_pool_to_lower_max_size_of_merge, 8, "")                            \
-                                                                                                                  \
-    /** How many seconds to keep obsolete parts. */                                                               \
-    M(SettingSeconds, old_parts_lifetime, 8 * 60, "")                                                             \
-                                                                                                                  \
-    /** How many seconds to keep tmp_-directories. */                                                             \
-    M(SettingSeconds, temporary_directories_lifetime, 86400, "")                                                  \
-                                                                                                                  \
-    /** Inserts settings. */                                                                                      \
-                                                                                                                  \
-    /** If table contains at least that many active parts, artificially slow down insert into table. */           \
-    M(SettingUInt64, parts_to_delay_insert, 150, "")                                                              \
-                                                                                                                  \
-    /** If more than this number active parts, throw 'Too many parts ...' exception */                            \
-    M(SettingUInt64, parts_to_throw_insert, 300, "")                                                              \
-                                                                                                                  \
-    /** Max delay of inserting data into MergeTree table in seconds, if there are a lot of unmerged parts. */     \
-    M(SettingUInt64, max_delay_to_insert, 1, "")                                                                  \
-                                                                                                                  \
-    /** Replication settings. */                                                                                  \
-                                                                                                                  \
-    /** How many last blocks of hashes should be kept in ZooKeeper (old blocks will be deleted). */               \
-    M(SettingUInt64, replicated_deduplication_window, 100, "")                                                    \
-    /** Similar to previous, but determines old blocks by their lifetime.                                         \
-     *  Hash of an inserted block will be deleted (and the block will not be deduplicated after)                  \
-     *  if it outside of one "window". You can set very big replicated_deduplication_window to avoid              \
-     *  duplicating INSERTs during that period of time. */                                                        \
-    M(SettingUInt64, replicated_deduplication_window_seconds, 7 * 24 * 60 * 60, "") /** one week */               \
-                                                                                                                  \
-    /** How many records may be in log, if there is inactive replica  */                                          \
-    M(SettingUInt64, max_replicated_logs_to_keep, 10000, "")                                                      \
-                                                                                                                  \
-    /** Keep about this number of last records in ZooKeeper log, even if they are obsolete.                       \
-     *  It doesn't affect work of tables: used only to diagnose ZooKeeper log before cleaning. */                 \
-    M(SettingUInt64, min_replicated_logs_to_keep, 100, "")                                                        \
-                                                                                                                  \
-    /** After specified amount of time passed after replication log entry creation                                \
-     *  and sum size of parts is greater than threshold,                                                          \
-     *  prefer fetching merged part from replica instead of doing merge locally.                                  \
-     *  To speed up very long merges. */                                                                          \
-    M(SettingSeconds, prefer_fetch_merged_part_time_threshold, 3600, "")                                          \
-    M(SettingUInt64, prefer_fetch_merged_part_size_threshold, 10ULL * 1024 * 1024 * 1024, "")                     \
-                                                                                                                  \
-    /** Max broken parts, if more - deny automatic deletion. */                                                   \
-    M(SettingUInt64, max_suspicious_broken_parts, 10, "")                                                         \
-                                                                                                                  \
-    /** Not apply ALTER if number of files for modification(deletion, addition) more than this. */                \
-    M(SettingUInt64, max_files_to_modify_in_alter_columns, 75, "")                                                \
-    /** Not apply ALTER, if number of files for deletion more than this. */                                       \
-    M(SettingUInt64, max_files_to_remove_in_alter_columns, 50, "")                                                \
-                                                                                                                  \
-    /** If ratio of wrong parts to total number of parts is less than this - allow to start. */                   \
-    M(SettingFloat, replicated_max_ratio_of_wrong_parts, 0.5, "")                                                 \
-                                                                                                                  \
-    /** Limit parallel fetches */                                                                                 \
-    M(SettingUInt64, replicated_max_parallel_fetches, 0, "")                                                      \
-    M(SettingUInt64, replicated_max_parallel_fetches_for_table, 0, "")                                            \
-                                                                                                                  \
-    /** Limit parallel fetches from endpoint (actually pool size) */                                              \
-    M(SettingUInt64, replicated_max_parallel_fetches_for_host, DEFAULT_COUNT_OF_HTTP_CONNECTIONS_PER_ENDPOINT, "")\
-                                                                                                                  \
-    /** Limit parallel sends */                                                                                   \
-    M(SettingUInt64, replicated_max_parallel_sends, 0, "")                                                        \
-    M(SettingUInt64, replicated_max_parallel_sends_for_table, 0, "")                                              \
-                                                                                                                  \
-    /** If true, Replicated tables replicas on this node will try to acquire leadership. */                       \
-    M(SettingBool, replicated_can_become_leader, true, "")                                                        \
-                                                                                                                  \
-    M(SettingSeconds, zookeeper_session_expiration_check_period, 60, "")                                          \
-                                                                                                                  \
-    /** Check delay of replicas settings. */                                                                      \
-                                                                                                                  \
-    /** Period to check replication delay and compare with other replicas. */                                     \
-    M(SettingUInt64, check_delay_period, 60, "")                                                                  \
-                                                                                                                  \
-    /** Period to clean old queue logs, blocks hashes and parts */                                                \
-    M(SettingUInt64, cleanup_delay_period, 30, "")                                                                \
-    /** Add uniformly distributed value from 0 to x seconds to cleanup_delay_period                               \
-        to avoid thundering herd effect and subsequent DoS of ZooKeeper in case of very large number of tables */ \
-    M(SettingUInt64, cleanup_delay_period_random_add, 10, "")                                                     \
-                                                                                                                  \
-    /** Minimal delay from other replicas to yield leadership. Here and further 0 means unlimited. */             \
-    M(SettingUInt64, min_relative_delay_to_yield_leadership, 120, "")                                             \
-                                                                                                                  \
-    /** Minimal delay from other replicas to close, stop serving requests and not return Ok                       \
-     *  during status check. */                                                                                   \
-    M(SettingUInt64, min_relative_delay_to_close, 300, "")                                                        \
-                                                                                                                  \
-    /** Minimal absolute delay to close, stop serving requests and not return Ok during status check. */          \
-    M(SettingUInt64, min_absolute_delay_to_close, 0, "")                                                          \
-                                                                                                                  \
-    /** Enable usage of Vertical merge algorithm. */                                                              \
-    M(SettingUInt64, enable_vertical_merge_algorithm, 1, "")                                                      \
-                                                                                                                  \
-    /** Minimal (approximate) sum of rows in merging parts to activate Vertical merge algorithm */                \
-    M(SettingUInt64, vertical_merge_algorithm_min_rows_to_activate, 16 * DEFAULT_MERGE_BLOCK_SIZE, "")            \
-                                                                                                                  \
-    /** Minimal amount of non-PK columns to activate Vertical merge algorithm */                                  \
-    M(SettingUInt64, vertical_merge_algorithm_min_columns_to_activate, 11, "")                                    \
-                                                                                                                  \
-    /** Compatibility settings */                                                                                 \
-                                                                                                                  \
-    /** Allow to create a table with sampling expression not in primary key.                                      \
-      * This is needed only to temporarily allow to run the server with wrong tables                              \
-      *  for backward compatibility.                                                                              \
-      */                                                                                                          \
-    M(SettingBool, compatibility_allow_sampling_expression_not_in_primary_key, false, "")                         \
-                                                                                                                  \
-    /** Use small format (dozens bytes) for part checksums in ZooKeeper                                           \
-      *  instead of ordinary ones (dozens KB).                                                                    \
-      * Before enabling check that all replicas support new format.                                               \
-      */                                                                                                          \
-    M(SettingBool, use_minimalistic_checksums_in_zookeeper, true, "")                                             \
-                                                                                                                  \
-    /** Store part header (checksums and columns) in a compact format and a single part znode                     \
-      *  instead of separate znodes (<part>/columns and <part>/checksums).                                        \
-      * This can dramatically reduce snapshot size in ZooKeeper.                                                  \
-      * Before enabling check that all replicas support new format.                                               \
-      */                                                                                                          \
-    M(SettingBool, use_minimalistic_part_header_in_zookeeper, false, "")                                          \
-                                                                                                                  \
-    /** How many records about mutations that are done to keep.                                                   \
-     *  If zero, then keep all of them */                                                                         \
-    M(SettingUInt64, finished_mutations_to_keep, 100, "")                                                         \
-                                                                                                                  \
-    /** Minimal amount of bytes to enable O_DIRECT in merge (0 - disabled) */                                     \
-    M(SettingUInt64, min_merge_bytes_to_use_direct_io, 10ULL * 1024 * 1024 * 1024, "")                            \
-                                                                                                                  \
-    /** Approximate amount of bytes in single granule (0 - disabled) */                                           \
-    M(SettingUInt64, index_granularity_bytes, 0, "")                                                              \
-                                                                                                                  \
-    /** Minimal time in seconds, when merge with TTL can be repeated */                                           \
-    M(SettingInt64, merge_with_ttl_timeout, 3600 * 24, "")
+    M(SettingUInt64, index_granularity, 8192, "How many rows correspond to one primary key value.") \
+    \
+    /** Merge settings. */ \
+    M(SettingUInt64, max_bytes_to_merge_at_max_space_in_pool, 150ULL * 1024 * 1024 * 1024, "Maximum in total size of parts to merge, when there are maximum free threads in background pool (or entries in replication queue).") \
+    M(SettingUInt64, max_bytes_to_merge_at_min_space_in_pool, 1024 * 1024, "Maximum in total size of parts to merge, when there are minimum free threads in background pool (or entries in replication queue).") \
+    M(SettingUInt64, max_replicated_merges_in_queue, 16, "How many tasks of merging parts are allowed simultaneously in ReplicatedMergeTree queue.") \
+    M(SettingUInt64, number_of_free_entries_in_pool_to_lower_max_size_of_merge, 8, "When there is less than specified number of free entries in pool (or replicated queue), start to lower maximum size of merge to process (or to put in queue). This is to allow small merges to process - not filling the pool with long running merges.") \
+    M(SettingSeconds, old_parts_lifetime, 8 * 60, "How many seconds to keep obsolete parts.") \
+    M(SettingSeconds, temporary_directories_lifetime, 86400, "How many seconds to keep tmp_-directories.") \
+    \
+    /** Inserts settings. */ \
+    M(SettingUInt64, parts_to_delay_insert, 150, "If table contains at least that many active parts, artificially slow down insert into table.") \
+    M(SettingUInt64, parts_to_throw_insert, 300, "If more than this number active parts, throw 'Too many parts ...' exception.") \
+    M(SettingUInt64, max_delay_to_insert, 1, "Max delay of inserting data into MergeTree table in seconds, if there are a lot of unmerged parts.") \
+    \
+    /** Replication settings. */ \
+    M(SettingUInt64, replicated_deduplication_window, 100, "How many last blocks of hashes should be kept in ZooKeeper (old blocks will be deleted).") \
+    M(SettingUInt64, replicated_deduplication_window_seconds, 7 * 24 * 60 * 60 /* one week */, "Similar to \"replicated_deduplication_window\", but determines old blocks by their lifetime. Hash of an inserted block will be deleted (and the block will not be deduplicated after) if it outside of one \"window\". You can set very big replicated_deduplication_window to avoid duplicating INSERTs during that period of time.") \
+    M(SettingUInt64, max_replicated_logs_to_keep, 10000, "How many records may be in log, if there is inactive replica.") \
+    M(SettingUInt64, min_replicated_logs_to_keep, 100, "Keep about this number of last records in ZooKeeper log, even if they are obsolete. It doesn't affect work of tables: used only to diagnose ZooKeeper log before cleaning.") \
+    M(SettingSeconds, prefer_fetch_merged_part_time_threshold, 3600, "If time passed after replication log entry creation exceeds this threshold and sum size of parts is greater than \"prefer_fetch_merged_part_size_threshold\", prefer fetching merged part from replica instead of doing merge locally. To speed up very long merges.") \
+    M(SettingUInt64, prefer_fetch_merged_part_size_threshold, 10ULL * 1024 * 1024 * 1024, "If sum size of parts exceeds this threshold and time passed after replication log entry creation is greater than \"prefer_fetch_merged_part_time_threshold\", prefer fetching merged part from replica instead of doing merge locally. To speed up very long merges.") \
+    M(SettingUInt64, max_suspicious_broken_parts, 10, "Max broken parts, if more - deny automatic deletion.") \
+    M(SettingUInt64, max_files_to_modify_in_alter_columns, 75, "Not apply ALTER if number of files for modification(deletion, addition) more than this.") \
+    M(SettingUInt64, max_files_to_remove_in_alter_columns, 50, "Not apply ALTER, if number of files for deletion more than this.") \
+    M(SettingFloat, replicated_max_ratio_of_wrong_parts, 0.5, "If ratio of wrong parts to total number of parts is less than this - allow to start.") \
+    M(SettingUInt64, replicated_max_parallel_fetches, 0, "Limit parallel fetches.") \
+    M(SettingUInt64, replicated_max_parallel_fetches_for_table, 0, "Limit parallel fetches for one table.") \
+    M(SettingUInt64, replicated_max_parallel_fetches_for_host, DEFAULT_COUNT_OF_HTTP_CONNECTIONS_PER_ENDPOINT, "Limit parallel fetches from endpoint (actually pool size).") \
+    M(SettingUInt64, replicated_max_parallel_sends, 0, "Limit parallel sends.") \
+    M(SettingUInt64, replicated_max_parallel_sends_for_table, 0, "Limit parallel sends for one table.") \
+    M(SettingBool, replicated_can_become_leader, true, "If true, Replicated tables replicas on this node will try to acquire leadership.") \
+    M(SettingSeconds, zookeeper_session_expiration_check_period, 60, "ZooKeeper session expiration check period, in seconds.") \
+    \
+    /** Check delay of replicas settings. */ \
+    M(SettingUInt64, check_delay_period, 60, "Period to check replication delay and compare with other replicas.") \
+    M(SettingUInt64, cleanup_delay_period, 30, "Period to clean old queue logs, blocks hashes and parts.") \
+    M(SettingUInt64, cleanup_delay_period_random_add, 10, "Add uniformly distributed value from 0 to x seconds to cleanup_delay_period to avoid thundering herd effect and subsequent DoS of ZooKeeper in case of very large number of tables.") \
+    M(SettingUInt64, min_relative_delay_to_yield_leadership, 120, "Minimal delay from other replicas to yield leadership. Here and further 0 means unlimited.") \
+    M(SettingUInt64, min_relative_delay_to_close, 300, "Minimal delay from other replicas to close, stop serving requests and not return Ok during status check.") \
+    M(SettingUInt64, min_absolute_delay_to_close, 0, "Minimal absolute delay to close, stop serving requests and not return Ok during status check.") \
+    M(SettingUInt64, enable_vertical_merge_algorithm, 1, "Enable usage of Vertical merge algorithm.") \
+    M(SettingUInt64, vertical_merge_algorithm_min_rows_to_activate, 16 * DEFAULT_MERGE_BLOCK_SIZE, "Minimal (approximate) sum of rows in merging parts to activate Vertical merge algorithm.") \
+    M(SettingUInt64, vertical_merge_algorithm_min_columns_to_activate, 11, "Minimal amount of non-PK columns to activate Vertical merge algorithm.") \
+    \
+    /** Compatibility settings */ \
+    M(SettingBool, compatibility_allow_sampling_expression_not_in_primary_key, false, "Allow to create a table with sampling expression not in primary key. This is needed only to temporarily allow to run the server with wrong tables for backward compatibility.") \
+    M(SettingBool, use_minimalistic_checksums_in_zookeeper, true, "Use small format (dozens bytes) for part checksums in ZooKeeper instead of ordinary ones (dozens KB). Before enabling check that all replicas support new format.") \
+    M(SettingBool, use_minimalistic_part_header_in_zookeeper, false, "Store part header (checksums and columns) in a compact format and a single part znode instead of separate znodes (<part>/columns and <part>/checksums). This can dramatically reduce snapshot size in ZooKeeper. Before enabling check that all replicas support new format.") \
+    M(SettingUInt64, finished_mutations_to_keep, 100, "How many records about mutations that are done to keep. If zero, then keep all of them.") \
+    M(SettingUInt64, min_merge_bytes_to_use_direct_io, 10ULL * 1024 * 1024 * 1024, "Minimal amount of bytes to enable O_DIRECT in merge (0 - disabled).") \
+    M(SettingUInt64, index_granularity_bytes, 0, "Approximate amount of bytes in single granule (0 - disabled).") \
+    M(SettingInt64, merge_with_ttl_timeout, 3600 * 24, "Minimal time in seconds, when merge with TTL can be repeated.")
 
     DECLARE_SETTINGS_COLLECTION(APPLY_FOR_MERGE_TREE_SETTINGS)
 

--- a/dbms/src/Storages/StorageJoin.cpp
+++ b/dbms/src/Storages/StorageJoin.cpp
@@ -139,7 +139,7 @@ void registerStorageJoin(StorageFactory & factory)
 
         if (args.storage_def && args.storage_def->settings)
         {
-            for (const ASTSetQuery::Change & setting : args.storage_def->settings->changes)
+            for (const auto & setting : args.storage_def->settings->changes)
             {
                 if (setting.name == "join_use_nulls")
                     join_use_nulls.set(setting.value);

--- a/dbms/src/Storages/System/StorageSystemMergeTreeSettings.cpp
+++ b/dbms/src/Storages/System/StorageSystemMergeTreeSettings.cpp
@@ -20,7 +20,7 @@ void SystemMergeTreeSettings::fillData(MutableColumns & res_columns, const Conte
 {
     const MergeTreeSettings & settings = context.getMergeTreeSettings();
 
-#define ADD_SETTING(TYPE, NAME, DEFAULT)              \
+#define ADD_SETTING(TYPE, NAME, DEFAULT, DESCRIPTION)              \
     res_columns[0]->insert(#NAME);            \
     res_columns[1]->insert(settings.NAME.toString()); \
     res_columns[2]->insert(settings.NAME.changed);

--- a/dbms/src/Storages/System/StorageSystemMergeTreeSettings.cpp
+++ b/dbms/src/Storages/System/StorageSystemMergeTreeSettings.cpp
@@ -10,9 +10,10 @@ namespace DB
 NamesAndTypesList SystemMergeTreeSettings::getNamesAndTypes()
 {
     return {
-        {"name",    std::make_shared<DataTypeString>()},
-        {"value",   std::make_shared<DataTypeString>()},
-        {"changed", std::make_shared<DataTypeUInt8>()},
+        {"name",        std::make_shared<DataTypeString>()},
+        {"value",       std::make_shared<DataTypeString>()},
+        {"changed",     std::make_shared<DataTypeUInt8>()},
+        {"description", std::make_shared<DataTypeString>()},
     };
 }
 
@@ -23,6 +24,7 @@ void SystemMergeTreeSettings::fillData(MutableColumns & res_columns, const Conte
         res_columns[0]->insert(setting.getName().toString());
         res_columns[1]->insert(setting.getValueAsString());
         res_columns[2]->insert(setting.isChanged());
+        res_columns[3]->insert(setting.getDescription().toString());
     }
 }
 

--- a/dbms/src/Storages/System/StorageSystemMergeTreeSettings.cpp
+++ b/dbms/src/Storages/System/StorageSystemMergeTreeSettings.cpp
@@ -18,14 +18,12 @@ NamesAndTypesList SystemMergeTreeSettings::getNamesAndTypes()
 
 void SystemMergeTreeSettings::fillData(MutableColumns & res_columns, const Context & context, const SelectQueryInfo &) const
 {
-    const MergeTreeSettings & settings = context.getMergeTreeSettings();
-
-#define ADD_SETTING(TYPE, NAME, DEFAULT, DESCRIPTION)              \
-    res_columns[0]->insert(#NAME);            \
-    res_columns[1]->insert(settings.NAME.toString()); \
-    res_columns[2]->insert(settings.NAME.changed);
-    APPLY_FOR_MERGE_TREE_SETTINGS(ADD_SETTING)
-#undef ADD_SETTING
+    for (const auto & setting : context.getMergeTreeSettings())
+    {
+        res_columns[0]->insert(setting.getName().toString());
+        res_columns[1]->insert(setting.getValueAsString());
+        res_columns[2]->insert(setting.isChanged());
+    }
 }
 
 }

--- a/dbms/src/Storages/System/StorageSystemSettings.cpp
+++ b/dbms/src/Storages/System/StorageSystemSettings.cpp
@@ -23,15 +23,13 @@ NamesAndTypesList StorageSystemSettings::getNamesAndTypes()
 
 void StorageSystemSettings::fillData(MutableColumns & res_columns, const Context & context, const SelectQueryInfo &) const
 {
-    const Settings & settings = context.getSettingsRef();
-
-#define ADD_SETTING(TYPE, NAME, DEFAULT, DESCRIPTION)      \
-    res_columns[0]->insert(#NAME);                 \
-    res_columns[1]->insert(settings.NAME.toString());      \
-    res_columns[2]->insert(settings.NAME.changed); \
-    res_columns[3]->insert(DESCRIPTION);
-    APPLY_FOR_SETTINGS(ADD_SETTING)
-#undef ADD_SETTING
+    for (const auto & setting : context.getSettingsRef())
+    {
+        res_columns[0]->insert(setting.getName().toString());
+        res_columns[1]->insert(setting.getValueAsString());
+        res_columns[2]->insert(setting.isChanged());
+        res_columns[3]->insert(setting.getDescription().toString());
+    }
 }
 
 }

--- a/dbms/tests/integration/helpers/cluster.py
+++ b/dbms/tests/integration/helpers/cluster.py
@@ -483,6 +483,10 @@ class ClickHouseInstance:
     def get_query_request(self, *args, **kwargs):
         return self.client.get_query_request(*args, **kwargs)
 
+    # Connects to the instance via clickhouse-client, sends a query (1st argument), expects an error and return its code
+    def query_and_get_error(self, sql, stdin=None, timeout=None, settings=None, user=None):
+        return self.client.query_and_get_error(sql, stdin, timeout, settings, user)
+
     # Connects to the instance via HTTP interface, sends a query and returns the answer
     def http_query(self, sql, data=None):
         return urllib.urlopen("http://"+self.ip_address+":8123/?query="+urllib.quote(sql,safe=''), data).read()

--- a/dbms/tests/integration/test_settings_constraints/configs/users.xml
+++ b/dbms/tests/integration/test_settings_constraints/configs/users.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<yandex>
+    <profiles>
+        <default>
+            <max_memory_usage>10000000000</max_memory_usage>
+            <constraints>
+                <max_memory_usage>
+                    <max>20000000000</max>
+                </max_memory_usage>
+            </constraints>
+        </default>
+    </profiles>
+
+    <users>
+        <default>
+            <password></password>
+            <networks incl="networks" replace="replace">
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </default>
+    </users>
+
+    <quotas>
+        <default>
+        </default>
+    </quotas>
+</yandex>

--- a/dbms/tests/integration/test_settings_constraints/configs/users.xml
+++ b/dbms/tests/integration/test_settings_constraints/configs/users.xml
@@ -3,10 +3,15 @@
     <profiles>
         <default>
             <max_memory_usage>10000000000</max_memory_usage>
+            <force_index_by_date>0</force_index_by_date>
             <constraints>
                 <max_memory_usage>
+                    <min>5000000000</min>
                     <max>20000000000</max>
                 </max_memory_usage>
+               <force_index_by_date>
+                   <readonly/>
+               </force_index_by_date>
             </constraints>
         </default>
     </profiles>

--- a/dbms/tests/integration/test_settings_constraints/test.py
+++ b/dbms/tests/integration/test_settings_constraints/test.py
@@ -18,6 +18,48 @@ def started_cluster():
         cluster.shutdown()
 
 
+def test_read_only_constraint(started_cluster):
+    # Change a setting for session with SET.
+    assert instance.query("SELECT value FROM system.settings WHERE name='force_index_by_date'") ==\
+           "0\n"
+
+    expected_error = "Setting force_index_by_date should not be changed"
+    assert expected_error in instance.query_and_get_error("SET force_index_by_date=1")
+
+    # Change a setting for query with SETTINGS.
+    assert instance.query("SELECT value FROM system.settings WHERE name='force_index_by_date'") ==\
+           "0\n"
+
+    assert expected_error in instance.query_and_get_error(
+           "SELECT value FROM system.settings WHERE name='force_index_by_date' "
+           "SETTINGS force_index_by_date=1")
+
+
+def test_min_constraint(started_cluster):
+    # Change a setting for session with SET.
+    assert instance.query("SELECT value FROM system.settings WHERE name='max_memory_usage'") ==\
+           "10000000000\n"
+
+    assert instance.query("SET max_memory_usage=5000000000;\n"
+                          "SELECT value FROM system.settings WHERE name='max_memory_usage'") ==\
+           "5000000000\n"
+
+    expected_error = "Setting max_memory_usage shouldn't be less than 5000000000"
+    assert expected_error in instance.query_and_get_error("SET max_memory_usage=4999999999")
+
+    # Change a setting for query with SETTINGS.
+    assert instance.query("SELECT value FROM system.settings WHERE name='max_memory_usage'") ==\
+           "10000000000\n"
+
+    assert instance.query("SET max_memory_usage=5000000001;\n"
+                          "SELECT value FROM system.settings WHERE name='max_memory_usage'") ==\
+           "5000000001\n"
+
+    assert expected_error in instance.query_and_get_error(
+           "SELECT value FROM system.settings WHERE name='max_memory_usage' "
+           "SETTINGS max_memory_usage=4999999999")
+
+
 def test_max_constraint(started_cluster):
     # Change a setting for session with SET.
     assert instance.query("SELECT value FROM system.settings WHERE name='max_memory_usage'") ==\
@@ -30,20 +72,14 @@ def test_max_constraint(started_cluster):
     expected_error = "Setting max_memory_usage shouldn't be greater than 20000000000"
     assert expected_error in instance.query_and_get_error("SET max_memory_usage=20000000001")
 
-    assert instance.query("SET max_memory_usage=11000000000;\n"
-                          "SELECT value FROM system.settings WHERE name='max_memory_usage'") ==\
-           "11000000000\n"
-
-    # Change a setting for query with SETTINGS.
+     # Change a setting for query with SETTINGS.
     assert instance.query("SELECT value FROM system.settings WHERE name='max_memory_usage'") ==\
            "10000000000\n"
 
     assert instance.query("SELECT value FROM system.settings WHERE name='max_memory_usage' "
-                          "SETTINGS max_memory_usage=20000000000") == "20000000000\n"
+                          "SETTINGS max_memory_usage=19999999999") == "19999999999\n"
 
     assert expected_error in instance.query_and_get_error(
            "SELECT value FROM system.settings WHERE name='max_memory_usage' "
            "SETTINGS max_memory_usage=20000000001")
-
-    assert instance.query("SELECT value FROM system.settings WHERE name='max_memory_usage' "
-                          "SETTINGS max_memory_usage=12000000000") == "12000000000\n"
+ 

--- a/dbms/tests/integration/test_settings_constraints/test.py
+++ b/dbms/tests/integration/test_settings_constraints/test.py
@@ -1,0 +1,49 @@
+import pytest
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+instance = cluster.add_instance('instance',
+                                config_dir="configs")
+
+
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def test_max_constraint(started_cluster):
+    # Change a setting for session with SET.
+    assert instance.query("SELECT value FROM system.settings WHERE name='max_memory_usage'") ==\
+           "10000000000\n"
+
+    assert instance.query("SET max_memory_usage=20000000000;\n"
+                          "SELECT value FROM system.settings WHERE name='max_memory_usage'") ==\
+           "20000000000\n"
+
+    expected_error = "Setting max_memory_usage shouldn't be greater than 20000000000"
+    assert expected_error in instance.query_and_get_error("SET max_memory_usage=20000000001")
+
+    assert instance.query("SET max_memory_usage=11000000000;\n"
+                          "SELECT value FROM system.settings WHERE name='max_memory_usage'") ==\
+           "11000000000\n"
+
+    # Change a setting for query with SETTINGS.
+    assert instance.query("SELECT value FROM system.settings WHERE name='max_memory_usage'") ==\
+           "10000000000\n"
+
+    assert instance.query("SELECT value FROM system.settings WHERE name='max_memory_usage' "
+                          "SETTINGS max_memory_usage=20000000000") == "20000000000\n"
+
+    assert expected_error in instance.query_and_get_error(
+           "SELECT value FROM system.settings WHERE name='max_memory_usage' "
+           "SETTINGS max_memory_usage=20000000001")
+
+    assert instance.query("SELECT value FROM system.settings WHERE name='max_memory_usage' "
+                          "SETTINGS max_memory_usage=12000000000") == "12000000000\n"

--- a/dbms/tests/queries/0_stateless/00474_readonly_settings.reference
+++ b/dbms/tests/queries/0_stateless/00474_readonly_settings.reference
@@ -4,11 +4,11 @@
 			"value": "4611686018427387904"
 value
 value
-Cannot execute SET query in readonly mode.
+Cannot modify 'output_format_json_quote_64bit_integers' setting in readonly mode
 			"name": "value",
 			"value": "9223372036854775808"
 			"name": "value",
 			"value": 9223372036854775808
 value
 value
-Cannot override setting
+Cannot modify 'output_format_json_quote_64bit_integers' setting in readonly mode

--- a/dbms/tests/queries/0_stateless/00474_readonly_settings.sh
+++ b/dbms/tests/queries/0_stateless/00474_readonly_settings.sh
@@ -6,13 +6,13 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 $CLICKHOUSE_CLIENT --query="select toUInt64(pow(2, 62)) as value format JSON" --output_format_json_quote_64bit_integers=0 | grep value
 $CLICKHOUSE_CLIENT --query="select toUInt64(pow(2, 62)) as value format JSON" --output_format_json_quote_64bit_integers=1 | grep value
 
-$CLICKHOUSE_CLIENT --readonly=1 --multiquery --query="set output_format_json_quote_64bit_integers=1 ; select toUInt64(pow(2, 63)) as value format JSON" --server_logs_file=/dev/null 2>&1 | grep -o 'value\|Cannot execute SET query in readonly mode.'
-$CLICKHOUSE_CLIENT --readonly=1 --multiquery --query="set output_format_json_quote_64bit_integers=0 ; select toUInt64(pow(2, 63)) as value format JSON" --server_logs_file=/dev/null 2>&1 | grep -o 'value\|Cannot execute SET query in readonly mode.'
+$CLICKHOUSE_CLIENT --readonly=1 --multiquery --query="set output_format_json_quote_64bit_integers=1 ; select toUInt64(pow(2, 63)) as value format JSON" --server_logs_file=/dev/null 2>&1 | grep -o 'value\|Cannot modify .* setting in readonly mode'
+$CLICKHOUSE_CLIENT --readonly=1 --multiquery --query="set output_format_json_quote_64bit_integers=0 ; select toUInt64(pow(2, 63)) as value format JSON" --server_logs_file=/dev/null 2>&1 | grep -o 'value\|Cannot modify .* setting in readonly mode'
 
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?query=SELECT+toUInt64(pow(2,+63))+as+value+format+JSON&output_format_json_quote_64bit_integers=1" | grep value
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?query=SELECT+toUInt64(pow(2,+63))+as+value+format+JSON&output_format_json_quote_64bit_integers=0" | grep value
 
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?session_id=readonly&session_timeout=3600" -d 'SET readonly = 1'
 
-${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?session_id=readonly&query=SELECT+toUInt64(pow(2,+63))+as+value+format+JSON&output_format_json_quote_64bit_integers=1" 2>&1 | grep -o 'value\|Cannot override setting'
-${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?session_id=readonly&query=SELECT+toUInt64(pow(2,+63))+as+value+format+JSON&output_format_json_quote_64bit_integers=0" 2>&1 | grep -o 'value\|Cannot override setting'
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?session_id=readonly&query=SELECT+toUInt64(pow(2,+63))+as+value+format+JSON&output_format_json_quote_64bit_integers=1" 2>&1 | grep -o 'value\|Cannot modify .* setting in readonly mode.'
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?session_id=readonly&query=SELECT+toUInt64(pow(2,+63))+as+value+format+JSON&output_format_json_quote_64bit_integers=0" 2>&1 | grep -o 'value\|Cannot modify .* setting in readonly mode'


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category:
- New Feature
- Improvement

This PR makes possible to set constraints in `users.xml`, for example

```
<profiles>
  <user_profile>
    <max_memory_usage>10000000000</max_memory_usage>
    <force_index_by_date>0</force_index_by_date>
    ...
    <constraints>
      <max_memory_usage>
        <min>5000000000</min>
        <max>20000000000</max>
      </max_memory_usage>
      <force_index_by_date>
        <readonly/>
      </force_index_by_date>
    </constraints>
  </user_profile>
</profiles>
```

It means that `max_memory_usage` should be between `5000000000` and `20000000000`.
The following query will raise an exception:
```
SET max_memory_usage=20000000001
```