### PR TITLE
Disable colored output in non tty environment

### DIFF
--- a/dbms/tests/clickhouse-test
+++ b/dbms/tests/clickhouse-test
@@ -17,10 +17,15 @@ from subprocess import CalledProcessError
 from datetime import datetime
 from time import sleep
 from errno import ESRCH
-from termcolor import colored
+import termcolor
 from random import random
 import commands
 
+def colored(text, color=None, on_color=None, attrs=None):
+    if sys.stdout.isatty():
+        return termcolor.colored(text, color, on_color, attrs)
+    else:
+        return text
 
 OP_SQUARE_BRACKET = colored("[", attrs=['bold'])
 CL_SQUARE_BRACKET = colored("]", attrs=['bold'])


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement

Disable color control sequences in non tty environment.