### PR TITLE
Fix wrong name qualification in GLOBAL JOIN

### DIFF
--- a/dbms/tests/queries/0_stateless/00857_global_joinsavel_table_alias.reference
+++ b/dbms/tests/queries/0_stateless/00857_global_joinsavel_table_alias.reference
@@ -1,0 +1,12 @@
+One Hundred
+Two Hundred
+One Hundred
+Two Hundred
+One Hundred
+Two Hundred
+One Hundred
+Two Hundred
+One Hundred
+Two Hundred
+One Hundred
+Two Hundred

--- a/dbms/tests/queries/0_stateless/00857_global_joinsavel_table_alias.sql
+++ b/dbms/tests/queries/0_stateless/00857_global_joinsavel_table_alias.sql
@@ -1,0 +1,59 @@
+USE test;
+
+DROP TABLE IF EXISTS local_table;
+DROP TABLE IF EXISTS other_table;
+
+CREATE TABLE local_table
+(
+    id Int32,
+    name String,
+    ts DateTime,
+    oth_id Int32
+) ENGINE = MergeTree() PARTITION BY toMonday(ts) ORDER BY (ts, id);
+
+CREATE TABLE other_table
+(
+    id Int32,
+    name String,
+    ts DateTime,
+    trd_id Int32
+) ENGINE = MergeTree() PARTITION BY toMonday(ts) ORDER BY (ts, id);
+
+INSERT INTO local_table VALUES(1, 'One', now(), 100);
+INSERT INTO local_table VALUES(2, 'Two', now(), 200);
+INSERT INTO other_table VALUES(100, 'One Hundred', now(), 1000);
+INSERT INTO other_table VALUES(200, 'Two Hundred', now(), 2000);
+
+-- FIXME: test.other_table -> other_table in first query breaks test (external tables cache error)
+select t2.name from remote('127.0.0.2', 'test.local_table') as t1
+left join test.other_table as t2
+on t1.oth_id = t2.id
+order by t2.name;
+
+select t2.name from test.other_table as t2
+global right join remote('127.0.0.2', 'test.local_table') as t1
+on t1.oth_id = t2.id
+order by t2.name;
+
+select t2.name from remote('127.0.0.2', 'test.local_table') as t1
+global left join other_table as t2
+on t1.oth_id = t2.id
+order by t2.name;
+
+select t2.name from remote('127.0.0.2', 'test.local_table') as t1
+global left join other_table as t2
+on t1.oth_id = t2.id
+order by t2.name;
+
+select other_table.name from remote('127.0.0.2', 'test.local_table') as t1
+global left join other_table
+on t1.oth_id = other_table.id
+order by other_table.name;
+
+select other_table.name from remote('127.0.0.2', 'test.local_table') as t1
+global left join other_table as t2
+on t1.oth_id = other_table.id
+order by other_table.name;
+
+DROP TABLE local_table;
+DROP TABLE other_table;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Set alias for external table (right part of GLOBAL JOIN) to be able to resolve its columns.