### PR TITLE
Remove deprecated PermissionsStartOnly

### DIFF
--- a/debian/clickhouse-server.service
+++ b/debian/clickhouse-server.service
@@ -5,7 +5,6 @@ Description=ClickHouse Server (analytic DBMS for big data)
 Type=simple
 User=clickhouse
 Group=clickhouse
-PermissionsStartOnly=true
 Restart=always
 RestartSec=30
 ExecStart=/usr/bin/clickhouse-server --config=/etc/clickhouse-server/config.xml


### PR DESCRIPTION
PermissionsStartOnly has been deprecated, see 
https://github.com/systemd/systemd/pull/10802 
and 
https://github.com/NixOS/nixpkgs/issues/53852

A previous change removed the use of ExecStartPre so it is no longer needed.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en