### PR TITLE
Do not send queries received from DDLWorker to leader replica

### DIFF
--- a/dbms/src/Interpreters/ClientInfo.h
+++ b/dbms/src/Interpreters/ClientInfo.h
@@ -37,7 +37,7 @@ public:
     {
         NO_QUERY = 0,            /// Uninitialized object.
         INITIAL_QUERY = 1,
-        SECONDARY_QUERY = 2,    /// Query that was initiated by another query for distributed query execution.
+        SECONDARY_QUERY = 2,    /// Query that was initiated by another query for distributed or ON CLUSTER query execution.
     };
 
 

--- a/dbms/src/Interpreters/DDLWorker.cpp
+++ b/dbms/src/Interpreters/DDLWorker.cpp
@@ -547,6 +547,7 @@ bool DDLWorker::tryExecuteQuery(const String & query, const DDLTask & task, Exec
     try
     {
         current_context = std::make_unique<Context>(context);
+        current_context->getClientInfo().query_kind = ClientInfo::QueryKind::SECONDARY_QUERY;
         current_context->setCurrentQueryId(""); // generate random query_id
         executeQuery(istr, ostr, false, *current_context, {}, {});
     }

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -3941,6 +3941,14 @@ void StorageReplicatedMergeTree::sendRequestToLeaderReplica(const ASTPtr & query
     if (leader == replica_name)
         throw Exception("Leader was suddenly changed or logical error.", ErrorCodes::LEADERSHIP_CHANGED);
 
+    /// SECONDARY_QUERY here means, that we received query from DDLWorker
+    /// there is no sense to send query to leader, because he will receive it from own DDLWorker
+    if (query_context.getClientInfo().query_kind == ClientInfo::QueryKind::SECONDARY_QUERY)
+    {
+        LOG_DEBUG(log, "Not leader replica received query from DDLWorker, skipping it.");
+        return;
+    }
+
     ReplicatedMergeTreeAddress leader_address(getZooKeeper()->get(zookeeper_path + "/replicas/" + leader + "/host"));
 
     /// TODO: add setters and getters interface for database and table fields of AST
@@ -3969,6 +3977,7 @@ void StorageReplicatedMergeTree::sendRequestToLeaderReplica(const ASTPtr & query
     const auto & query_client_info = query_context.getClientInfo();
     String user = query_client_info.current_user;
     String password = query_client_info.current_password;
+
     if (auto address = findClusterAddress(leader_address); address)
     {
         user = address->user;
@@ -3979,7 +3988,7 @@ void StorageReplicatedMergeTree::sendRequestToLeaderReplica(const ASTPtr & query
         leader_address.host,
         leader_address.queries_port,
         leader_address.database,
-        user, password, timeouts, "ClickHouse replica");
+        user, password, timeouts, "Follower replica");
 
     std::stringstream new_query_ss;
     formatAST(*new_query, new_query_ss, false, true);

--- a/dbms/tests/integration/test_distributed_ddl_password/configs/config.d/clusters.xml
+++ b/dbms/tests/integration/test_distributed_ddl_password/configs/config.d/clusters.xml
@@ -1,0 +1,28 @@
+<yandex>
+<remote_servers>
+    <awesome_cluster>
+        <shard>
+            <internal_replication>true</internal_replication>
+            <replica>
+                <host>node1</host>
+                <port>9000</port>
+            </replica>
+            <replica>
+                <host>node2</host>
+                <port>9000</port>
+            </replica>
+        </shard>
+        <shard>
+            <internal_replication>true</internal_replication>
+            <replica>
+                <host>node3</host>
+                <port>9000</port>
+            </replica>
+            <replica>
+                <host>node4</host>
+                <port>9000</port>
+            </replica>
+        </shard>
+    </awesome_cluster>
+</remote_servers>
+</yandex>

--- a/dbms/tests/integration/test_distributed_ddl_password/configs/users.d/default_with_password.xml
+++ b/dbms/tests/integration/test_distributed_ddl_password/configs/users.d/default_with_password.xml
@@ -1,0 +1,22 @@
+<yandex>
+    <profiles>
+        <default>
+        </default>
+    </profiles>
+
+    <users>
+        <default>
+            <password>clickhouse</password>
+            <networks incl="networks" replace="replace">
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </default>
+    </users>
+
+    <quotas>
+        <default>
+        </default>
+    </quotas>
+</yandex>

--- a/dbms/tests/integration/test_distributed_ddl_password/test.py
+++ b/dbms/tests/integration/test_distributed_ddl_password/test.py
@@ -1,0 +1,54 @@
+import time
+import pytest
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node1 = cluster.add_instance('node1', config_dir="configs", with_zookeeper=True)
+node2 = cluster.add_instance('node2', config_dir="configs", with_zookeeper=True)
+node3 = cluster.add_instance('node3', config_dir="configs", with_zookeeper=True)
+node4 = cluster.add_instance('node4', config_dir="configs", with_zookeeper=True)
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+
+        for node, shard in [(node1, 1), (node2, 1), (node3, 2), (node4, 2)]:
+            node.query(
+            '''
+                CREATE TABLE test_table(date Date, id UInt32, dummy UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test{shard}/replicated', '{replica}')
+                PARTITION BY date
+                ORDER BY id
+            '''.format(shard=shard, replica=node.name), settings={"password": "clickhouse"})
+
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+def test_truncate(start_cluster):
+    node1.query("insert into test_table values ('2019-02-15', 1, 2), ('2019-02-15', 2, 3), ('2019-02-15', 3, 4)", settings={"password": "clickhouse"})
+
+    assert node1.query("select count(*) from test_table", settings={"password": "clickhouse"}) == "3\n"
+    node2.query("system sync replica test_table", settings={"password": "clickhouse"})
+    assert node2.query("select count(*) from test_table", settings={"password": "clickhouse"}) == "3\n"
+
+
+    node3.query("insert into test_table values ('2019-02-16', 1, 2), ('2019-02-16', 2, 3), ('2019-02-16', 3, 4)", settings={"password": "clickhouse"})
+
+    assert node3.query("select count(*) from test_table", settings={"password": "clickhouse"}) == "3\n"
+    node4.query("system sync replica test_table", settings={"password": "clickhouse"})
+    assert node4.query("select count(*) from test_table", settings={"password": "clickhouse"}) == "3\n"
+
+    node3.query("truncate table test_table on cluster 'awesome_cluster'", settings={"password": "clickhouse"})
+    time.sleep(2)
+
+    for node in [node1, node2, node3, node4]:
+        assert node.query("select count(*) from test_table", settings={"password": "clickhouse"}) == "0\n"
+
+    node2.query("drop table test_table on cluster 'awesome_cluster'", settings={"password": "clickhouse"})
+    time.sleep(2)
+
+    for node in [node1, node2, node3, node4]:
+        assert node.query("select count(*) from system.tables where name='test_table'", settings={"password": "clickhouse"}) == "0\n"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Now follower replicas would not send queries to leader if they receive them from DDL.