### PR TITLE
Backport to 19.5: Fix BlockIO::operator=

### DIFF
--- a/dbms/src/DataStreams/BlockIO.h
+++ b/dbms/src/DataStreams/BlockIO.h
@@ -43,6 +43,9 @@ struct BlockIO
 
     BlockIO & operator= (const BlockIO & rhs)
     {
+        if (this == &rhs)
+            return *this;
+
         out.reset();
         in.reset();
         process_list_entry.reset();


### PR DESCRIPTION
Original pull-request #4920 

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en