### PR TITLE
Add FIRST_OR_RANDOM Load Balancing policy

### DIFF
--- a/dbms/programs/server/users.xml
+++ b/dbms/programs/server/users.xml
@@ -16,6 +16,7 @@
                   with minimum number of different symbols between replica's hostname and local hostname
                   (Hamming distance).
                  in_order - first live replica is chosen in specified order.
+                 first_or_random - if first replica one has higher number of errors, pick a random one from replicas with minimum number of errors.
             -->
             <load_balancing>random</load_balancing>
         </default>

--- a/dbms/src/Client/ConnectionPoolWithFailover.cpp
+++ b/dbms/src/Client/ConnectionPoolWithFailover.cpp
@@ -62,6 +62,9 @@ IConnectionPool::Entry ConnectionPoolWithFailover::get(const Settings * settings
         break;
     case LoadBalancing::RANDOM:
         break;
+    case LoadBalancing::FIRST_OR_RANDOM:
+        get_priority = [](size_t i) { return i >= 1; };
+        break;
     }
 
     return Base::get(try_get_entry, get_priority);
@@ -133,6 +136,9 @@ std::vector<ConnectionPoolWithFailover::TryResult> ConnectionPoolWithFailover::g
         get_priority = [](size_t i) { return i; };
         break;
     case LoadBalancing::RANDOM:
+        break;
+    case LoadBalancing::FIRST_OR_RANDOM:
+        get_priority = [](size_t i) { return i >= 1; };
         break;
     }
 

--- a/dbms/src/Client/ConnectionPoolWithFailover.cpp
+++ b/dbms/src/Client/ConnectionPoolWithFailover.cpp
@@ -63,7 +63,7 @@ IConnectionPool::Entry ConnectionPoolWithFailover::get(const Settings * settings
     case LoadBalancing::RANDOM:
         break;
     case LoadBalancing::FIRST_OR_RANDOM:
-        get_priority = [](size_t i) { return i >= 1; };
+        get_priority = [](size_t i) -> size_t { return i >= 1; };
         break;
     }
 
@@ -138,7 +138,7 @@ std::vector<ConnectionPoolWithFailover::TryResult> ConnectionPoolWithFailover::g
     case LoadBalancing::RANDOM:
         break;
     case LoadBalancing::FIRST_OR_RANDOM:
-        get_priority = [](size_t i) { return i >= 1; };
+        get_priority = [](size_t i) -> size_t { return i >= 1; };
         break;
     }
 

--- a/dbms/src/Core/SettingsCommon.cpp
+++ b/dbms/src/Core/SettingsCommon.cpp
@@ -247,15 +247,16 @@ LoadBalancing SettingLoadBalancing::getLoadBalancing(const String & s)
     if (s == "random")           return LoadBalancing::RANDOM;
     if (s == "nearest_hostname") return LoadBalancing::NEAREST_HOSTNAME;
     if (s == "in_order")         return LoadBalancing::IN_ORDER;
+    if (s == "first_or_random")  return LoadBalancing::FIRST_OR_RANDOM;
 
-    throw Exception("Unknown load balancing mode: '" + s + "', must be one of 'random', 'nearest_hostname', 'in_order'",
+    throw Exception("Unknown load balancing mode: '" + s + "', must be one of 'random', 'nearest_hostname', 'in_order', 'first_or_random'",
         ErrorCodes::UNKNOWN_LOAD_BALANCING);
 }
 
 String SettingLoadBalancing::toString() const
 {
-    const char * strings[] = {"random", "nearest_hostname", "in_order"};
-    if (value < LoadBalancing::RANDOM || value > LoadBalancing::IN_ORDER)
+    const char * strings[] = {"random", "nearest_hostname", "in_order", "first_or_random"};
+    if (value < LoadBalancing::RANDOM || value > LoadBalancing::FIRST_OR_RANDOM)
         throw Exception("Unknown load balancing mode", ErrorCodes::UNKNOWN_LOAD_BALANCING);
     return strings[static_cast<size_t>(value)];
 }

--- a/dbms/src/Core/SettingsCommon.h
+++ b/dbms/src/Core/SettingsCommon.h
@@ -167,6 +167,9 @@ enum class LoadBalancing
     NEAREST_HOSTNAME,
     /// replicas are walked through strictly in order; the number of errors does not matter
     IN_ORDER,
+    /// if first replica one has higher number of errors,
+    ///   pick a random one from replicas with minimum number of errors
+    FIRST_OR_RANDOM,
 };
 
 struct SettingLoadBalancing


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- New Feature

Short description (up to few sentences):

Add new load balancing policy for picking replicas (first_or_random). Useful for cross-replication topology setups.

Detailed description (optional):

For cross-replication topology setups load_balancing=in_order works best
as nodes handle equal amount of load and usually they hit only 1/n of
data (n = number of replicas), which makes page cache usage more
efficient.

The problem is when one node of the shard goes down. If one replica goes
down, the next one in config will handle twice the usual load while
remaining ones will handle usual traffic.

Closes #4820.