### PR TITLE
Prepare MergeTreeSettings for two immutable settings.

### DIFF
--- a/dbms/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeSettings.h
@@ -168,9 +168,11 @@ struct MergeTreeSettings
     /** Minimal time in seconds, when merge with TTL can be repeated */                                       \
     M(SettingInt64, merge_with_ttl_timeout, 3600 * 24)
 
-    /// Settings that should not change after the creation of a table.
+/// Settings that should not change after the creation of a table.
+/// They are also mutually exclusive.
 #define APPLY_FOR_IMMUTABLE_MERGE_TREE_SETTINGS(M) \
-    M(index_granularity)
+    M(index_granularity)                           \
+    M(index_granularity_bytes)
 
 #define DECLARE(TYPE, NAME, DEFAULT) \
     TYPE NAME {DEFAULT};

--- a/dbms/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/dbms/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -625,7 +625,10 @@ static StoragePtr create(const StorageFactory::Arguments & args)
 
         const auto * ast = engine_args.back()->as<ASTLiteral>();
         if (ast && ast->value.getType() == Field::Types::UInt64)
+        {
             storage_settings.index_granularity = safeGet<UInt64>(ast->value);
+            storage_settings.index_granularity_bytes = 0;
+        }
         else
             throw Exception(
                 "Index granularity must be a positive integer" + getMergeTreeVerboseHelp(is_extended_storage_def),

--- a/dbms/tests/queries/0_stateless/00634_performance_introspection_and_logging.sh
+++ b/dbms/tests/queries/0_stateless/00634_performance_introspection_and_logging.sh
@@ -20,7 +20,7 @@ settings="$server_logs --log_queries=1 --log_query_threads=1 --log_profile_event
 
 $CLICKHOUSE_CLIENT $settings -n -q "
 DROP TABLE IF EXISTS null;
-CREATE TABLE null (i UInt8) ENGINE = MergeTree PARTITION BY tuple() ORDER BY tuple();"
+CREATE TABLE null (i UInt8) ENGINE = MergeTree PARTITION BY tuple() ORDER BY tuple() SETTINGS index_granularity = 8192;"
 
 head -c 1000 /dev/zero | $CLICKHOUSE_CLIENT $settings --max_insert_block_size=10 --min_insert_block_size_rows=1 --min_insert_block_size_bytes=1 -q "INSERT INTO null FORMAT RowBinary"
 

--- a/dbms/tests/queries/0_stateless/00642_cast.sql
+++ b/dbms/tests/queries/0_stateless/00642_cast.sql
@@ -37,7 +37,7 @@ CREATE TABLE cast
             'world' = 2
         )
     )
-) ENGINE = MergeTree ORDER BY e;
+) ENGINE = MergeTree ORDER BY e SETTINGS index_granularity = 8192;
 
 SHOW CREATE TABLE cast FORMAT TSVRaw;
 DESC TABLE cast;

--- a/dbms/tests/queries/0_stateless/00643_cast_zookeeper.sql
+++ b/dbms/tests/queries/0_stateless/00643_cast_zookeeper.sql
@@ -20,7 +20,7 @@ CREATE TABLE cast1
             'world' = 2
         )
     )
-) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test_cast', 'r1') ORDER BY e;
+) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test_cast', 'r1') ORDER BY e SETTINGS index_granularity = 8192;
 
 SHOW CREATE TABLE cast1 FORMAT TSVRaw;
 DESC TABLE cast1;

--- a/dbms/tests/queries/0_stateless/00725_comment_columns.sql
+++ b/dbms/tests/queries/0_stateless/00725_comment_columns.sql
@@ -52,7 +52,8 @@ CREATE TABLE test.check_query_comment_column
   ) ENGINE = MergeTree()
         ORDER BY first_column
         PARTITION BY second_column
-        SAMPLE BY first_column;
+        SAMPLE BY first_column
+        SETTINGS index_granularity = 8192;
 
 SHOW CREATE TABLE test.check_query_comment_column;
 DESCRIBE TABLE test.check_query_comment_column;

--- a/dbms/tests/queries/0_stateless/00751_default_databasename_for_view.sql
+++ b/dbms/tests/queries/0_stateless/00751_default_databasename_for_view.sql
@@ -18,7 +18,7 @@ CREATE TABLE v (platform Enum8('a' = 0, 'b' = 1)) ENGINE = Memory;
 INSERT INTO u VALUES ('b');
 INSERT INTO v VALUES ('b');
 
-CREATE MATERIALIZED VIEW t_mv ENGINE = MergeTree ORDER BY date
+CREATE MATERIALIZED VIEW t_mv ENGINE = MergeTree ORDER BY date SETTINGS index_granularity = 8192
     AS SELECT date, platform, app FROM t
     WHERE app = (SELECT min(app) from u) AND platform = (SELECT (SELECT min(platform) from v));
 

--- a/dbms/tests/queries/0_stateless/00753_comment_columns_zookeeper.sql
+++ b/dbms/tests/queries/0_stateless/00753_comment_columns_zookeeper.sql
@@ -1,11 +1,11 @@
 DROP TABLE IF EXISTS test.check_comments;
 
 CREATE TABLE test.check_comments
-  (
-    column_name1 UInt8 DEFAULT 1 COMMENT 'comment',
-    column_name2 UInt8 COMMENT 'non default comment'
-  ) ENGINE = ReplicatedMergeTree('clickhouse/tables/test_comments', 'r1')
-    ORDER BY column_name1;
+(
+  column_name1 UInt8 DEFAULT 1 COMMENT 'comment',
+  column_name2 UInt8 COMMENT 'non default comment'
+) ENGINE = ReplicatedMergeTree('clickhouse/tables/test_comments', 'r1')
+ORDER BY column_name1 SETTINGS index_granularity = 8192;
 
 SHOW CREATE test.check_comments;
 DESC test.check_comments;

--- a/dbms/tests/queries/0_stateless/00754_alter_modify_order_by.sql
+++ b/dbms/tests/queries/0_stateless/00754_alter_modify_order_by.sql
@@ -6,7 +6,7 @@ ALTER TABLE test.old_style ADD COLUMN y UInt32, MODIFY ORDER BY (x, y); -- { ser
 DROP TABLE test.old_style;
 
 DROP TABLE IF EXISTS test.summing;
-CREATE TABLE test.summing(x UInt32, y UInt32, val UInt32) ENGINE SummingMergeTree ORDER BY (x, y);
+CREATE TABLE test.summing(x UInt32, y UInt32, val UInt32) ENGINE SummingMergeTree ORDER BY (x, y) SETTINGS index_granularity = 8192;
 
 /* Can't add an expression with existing column to ORDER BY. */
 ALTER TABLE test.summing MODIFY ORDER BY (x, y, -val); -- { serverError 36}

--- a/dbms/tests/queries/0_stateless/00754_alter_modify_order_by_replicated_zookeeper.sql
+++ b/dbms/tests/queries/0_stateless/00754_alter_modify_order_by_replicated_zookeeper.sql
@@ -7,8 +7,8 @@ DROP TABLE test.old_style;
 
 DROP TABLE IF EXISTS test.summing_r1;
 DROP TABLE IF EXISTS test.summing_r2;
-CREATE TABLE test.summing_r1(x UInt32, y UInt32, val UInt32) ENGINE ReplicatedSummingMergeTree('/clickhouse/tables/test/summing', 'r1') ORDER BY (x, y);
-CREATE TABLE test.summing_r2(x UInt32, y UInt32, val UInt32) ENGINE ReplicatedSummingMergeTree('/clickhouse/tables/test/summing', 'r2') ORDER BY (x, y);
+CREATE TABLE test.summing_r1(x UInt32, y UInt32, val UInt32) ENGINE ReplicatedSummingMergeTree('/clickhouse/tables/test/summing', 'r1') ORDER BY (x, y) SETTINGS index_granularity = 8192;
+CREATE TABLE test.summing_r2(x UInt32, y UInt32, val UInt32) ENGINE ReplicatedSummingMergeTree('/clickhouse/tables/test/summing', 'r2') ORDER BY (x, y) SETTINGS index_granularity = 8192;
 
 /* Can't add an expression with existing column to ORDER BY. */
 ALTER TABLE test.summing_r1 MODIFY ORDER BY (x, y, -val); -- { serverError 36 }

--- a/dbms/tests/queries/0_stateless/00804_test_custom_compression_codecs.sql
+++ b/dbms/tests/queries/0_stateless/00804_test_custom_compression_codecs.sql
@@ -9,7 +9,7 @@ CREATE TABLE test.compression_codec(
     somenum Float64 CODEC(ZSTD(2)),
     somestr FixedString(3) CODEC(LZ4HC(7)),
     othernum Int64 CODEC(Delta)
-) ENGINE = MergeTree() ORDER BY tuple();
+) ENGINE = MergeTree() ORDER BY tuple() SETTINGS index_granularity = 8192;
 
 INSERT INTO test.compression_codec VALUES(1, 'hello', toDate('2018-12-14'), 1.1, 'aaa', 5);
 INSERT INTO test.compression_codec VALUES(2, 'world', toDate('2018-12-15'), 2.2, 'bbb', 6);
@@ -61,7 +61,7 @@ CREATE TABLE test.compression_codec_multiple (
     data String CODEC(ZSTD(2), NONE, Delta(2), LZ4HC, LZ4, LZ4, Delta(8)),
     ddd Date CODEC(NONE, NONE, NONE, Delta(1), LZ4, ZSTD, LZ4HC, LZ4HC),
     somenum Float64 CODEC(Delta(4), LZ4, LZ4, ZSTD(2), LZ4HC(5), ZSTD(3), ZSTD)
-) ENGINE = MergeTree() ORDER BY tuple();
+) ENGINE = MergeTree() ORDER BY tuple() SETTINGS index_granularity = 8192;
 
 INSERT INTO test.compression_codec_multiple VALUES (1, 'world', toDate('2018-10-05'), 1.1), (2, 'hello', toDate('2018-10-01'), 2.2), (3, 'buy', toDate('2018-10-11'), 3.3);
 
@@ -87,7 +87,7 @@ CREATE TABLE test.compression_codec_multiple_more_types (
     id Decimal128(13) CODEC(ZSTD, LZ4, ZSTD, ZSTD, Delta(2), Delta(4), Delta(1), LZ4HC),
     data FixedString(12) CODEC(ZSTD, ZSTD, Delta, Delta, Delta, NONE, NONE, NONE, LZ4HC),
     ddd Nested (age UInt8, Name String) CODEC(LZ4, LZ4HC, NONE, NONE, NONE, ZSTD, Delta(8))
-) ENGINE = MergeTree() ORDER BY tuple();
+) ENGINE = MergeTree() ORDER BY tuple() SETTINGS index_granularity = 8192;
 
 SHOW CREATE TABLE test.compression_codec_multiple_more_types;
 
@@ -137,7 +137,7 @@ CREATE TABLE test.test_default_delta(
     othernum Int64 CODEC(Delta),
     yetothernum Float32 CODEC(Delta),
     ddd Nested (age UInt8, Name String, OName String, BName String) CODEC(Delta)
-) ENGINE = MergeTree() ORDER BY tuple();
+) ENGINE = MergeTree() ORDER BY tuple() SETTINGS index_granularity = 8192;
 
 SHOW CREATE TABLE test.test_default_delta;
 

--- a/dbms/tests/queries/0_stateless/00804_test_delta_codec_compression.sql
+++ b/dbms/tests/queries/0_stateless/00804_test_delta_codec_compression.sql
@@ -6,12 +6,12 @@ DROP TABLE IF EXISTS test.default_codec_synthetic;
 CREATE TABLE test.delta_codec_synthetic
 (
     id UInt64 Codec(Delta, ZSTD)
-) ENGINE MergeTree() ORDER BY tuple();
+) ENGINE MergeTree() ORDER BY tuple() SETTINGS index_granularity = 8192;
 
 CREATE TABLE test.default_codec_synthetic
 (
     id UInt64 Codec(ZSTD)
-) ENGINE MergeTree() ORDER BY tuple();
+) ENGINE MergeTree() ORDER BY tuple() SETTINGS index_granularity = 8192;
 
 INSERT INTO test.delta_codec_synthetic SELECT number FROM system.numbers LIMIT 5000000;
 INSERT INTO test.default_codec_synthetic SELECT number FROM system.numbers LIMIT 5000000;
@@ -44,12 +44,12 @@ DROP TABLE IF EXISTS test.default_codec_float;
 CREATE TABLE test.delta_codec_float
 (
     id Float64 Codec(Delta, LZ4HC)
-) ENGINE MergeTree() ORDER BY tuple();
+) ENGINE MergeTree() ORDER BY tuple() SETTINGS index_granularity = 8192;
 
 CREATE TABLE test.default_codec_float
 (
     id Float64 Codec(LZ4HC)
-) ENGINE MergeTree() ORDER BY tuple();
+) ENGINE MergeTree() ORDER BY tuple() SETTINGS index_granularity = 8192;
 
 INSERT INTO test.delta_codec_float SELECT number FROM numbers(1547510400, 500000) WHERE number % 3 == 0 OR number % 5 == 0 OR number % 7 == 0 OR number % 11 == 0;
 INSERT INTO test.default_codec_float SELECT * from test.delta_codec_float;
@@ -82,12 +82,12 @@ DROP TABLE IF EXISTS test.default_codec_string;
 CREATE TABLE test.delta_codec_string
 (
     id Float64 Codec(Delta, LZ4)
-) ENGINE MergeTree() ORDER BY tuple();
+) ENGINE MergeTree() ORDER BY tuple() SETTINGS index_granularity = 8192;
 
 CREATE TABLE test.default_codec_string
 (
     id Float64 Codec(LZ4)
-) ENGINE MergeTree() ORDER BY tuple();
+) ENGINE MergeTree() ORDER BY tuple() SETTINGS index_granularity = 8192;
 
 INSERT INTO test.delta_codec_string SELECT concat(toString(number), toString(number % 100)) FROM numbers(1547510400, 500000);
 INSERT INTO test.default_codec_string SELECT * from test.delta_codec_string;

--- a/dbms/tests/queries/0_stateless/00836_indices_alter.sql
+++ b/dbms/tests/queries/0_stateless/00836_indices_alter.sql
@@ -8,7 +8,7 @@ CREATE TABLE test.minmax_idx
     u64 UInt64,
     i32 Int32
 ) ENGINE = MergeTree()
-ORDER BY u64;
+ORDER BY u64 SETTINGS index_granularity = 8192;
 
 INSERT INTO test.minmax_idx VALUES (1, 2);
 
@@ -53,7 +53,7 @@ CREATE TABLE test.minmax_idx2
     INDEX idx1 (u64 + i32) TYPE minmax GRANULARITY 10,
     INDEX idx2 u64 * i32 TYPE minmax GRANULARITY 10
 ) ENGINE = MergeTree()
-ORDER BY u64;
+ORDER BY u64 SETTINGS index_granularity = 8192;
 
 INSERT INTO test.minmax_idx2 VALUES (1, 2);
 INSERT INTO test.minmax_idx2 VALUES (1, 2);

--- a/dbms/tests/queries/0_stateless/00836_indices_alter_replicated_zookeeper.sql
+++ b/dbms/tests/queries/0_stateless/00836_indices_alter_replicated_zookeeper.sql
@@ -10,14 +10,14 @@ CREATE TABLE test.minmax_idx
     u64 UInt64,
     i32 Int32
 ) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/indices_alter1', 'r1')
-ORDER BY u64;
+ORDER BY u64 SETTINGS index_granularity = 8192;
 
 CREATE TABLE test.minmax_idx_r
 (
     u64 UInt64,
     i32 Int32
 ) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/indices_alter1', 'r2')
-ORDER BY u64;
+ORDER BY u64 SETTINGS index_granularity = 8192;
 
 INSERT INTO test.minmax_idx VALUES (1, 2);
 
@@ -75,7 +75,7 @@ CREATE TABLE test.minmax_idx2
     INDEX idx1 u64 + i32 TYPE minmax GRANULARITY 10,
     INDEX idx2 u64 * i32 TYPE minmax GRANULARITY 10
 ) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/indices_alter2', 'r1')
-ORDER BY u64;
+ORDER BY u64 SETTINGS index_granularity = 8192;
 
 CREATE TABLE test.minmax_idx2_r
 (
@@ -84,7 +84,7 @@ CREATE TABLE test.minmax_idx2_r
     INDEX idx1 u64 + i32 TYPE minmax GRANULARITY 10,
     INDEX idx2 u64 * i32 TYPE minmax GRANULARITY 10
 ) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/indices_alter2', 'r2')
-ORDER BY u64;
+ORDER BY u64 SETTINGS index_granularity = 8192;
 
 
 SHOW CREATE TABLE test.minmax_idx2;

--- a/dbms/tests/queries/0_stateless/00910_zookeeper_custom_compression_codecs_replicated.sql
+++ b/dbms/tests/queries/0_stateless/00910_zookeeper_custom_compression_codecs_replicated.sql
@@ -10,7 +10,7 @@ CREATE TABLE test.compression_codec_replicated1(
     somenum Float64 CODEC(ZSTD(2)),
     somestr FixedString(3) CODEC(LZ4HC(7)),
     othernum Int64 CODEC(Delta)
-) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/compression_codec_replicated', '1') ORDER BY tuple();
+) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/compression_codec_replicated', '1') ORDER BY tuple() SETTINGS index_granularity = 8192;
 
 CREATE TABLE test.compression_codec_replicated2(
   id UInt64 CODEC(LZ4),
@@ -19,7 +19,7 @@ CREATE TABLE test.compression_codec_replicated2(
   somenum Float64 CODEC(ZSTD(2)),
   somestr FixedString(3) CODEC(LZ4HC(7)),
   othernum Int64 CODEC(Delta)
-) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/compression_codec_replicated', '2') ORDER BY tuple();
+) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/compression_codec_replicated', '2') ORDER BY tuple() SETTINGS index_granularity = 8192;
 
 
 INSERT INTO test.compression_codec_replicated1 VALUES(1, 'hello', toDate('2018-12-14'), 1.1, 'aaa', 5);
@@ -56,14 +56,14 @@ CREATE TABLE test.compression_codec_multiple_replicated1 (
     data String CODEC(ZSTD(2), NONE, Delta(2), LZ4HC, LZ4, LZ4, Delta(8)),
     ddd Date CODEC(NONE, NONE, NONE, Delta(1), LZ4, ZSTD, LZ4HC, LZ4HC),
     somenum Float64 CODEC(Delta(4), LZ4, LZ4, ZSTD(2), LZ4HC(5), ZSTD(3), ZSTD)
-) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/compression_codec_multiple', '1') ORDER BY tuple();
+) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/compression_codec_multiple', '1') ORDER BY tuple() SETTINGS index_granularity = 8192;
 
 CREATE TABLE test.compression_codec_multiple_replicated2 (
     id UInt64 CODEC(LZ4, ZSTD, NONE, LZ4HC, Delta(4)),
     data String CODEC(ZSTD(2), NONE, Delta(2), LZ4HC, LZ4, LZ4, Delta(8)),
     ddd Date CODEC(NONE, NONE, NONE, Delta(1), LZ4, ZSTD, LZ4HC, LZ4HC),
     somenum Float64 CODEC(Delta(4), LZ4, LZ4, ZSTD(2), LZ4HC(5), ZSTD(3), ZSTD)
-) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/compression_codec_multiple', '2') ORDER BY tuple();
+) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/compression_codec_multiple', '2') ORDER BY tuple() SETTINGS index_granularity = 8192;
 
 
 INSERT INTO test.compression_codec_multiple_replicated2 VALUES (1, 'world', toDate('2018-10-05'), 1.1), (2, 'hello', toDate('2018-10-01'), 2.2), (3, 'buy', toDate('2018-10-11'), 3.3);
@@ -105,7 +105,7 @@ CREATE TABLE test.compression_codec_multiple_more_types_replicated (
     id Decimal128(13) CODEC(ZSTD, LZ4, ZSTD, ZSTD, Delta(2), Delta(4), Delta(1), LZ4HC),
     data FixedString(12) CODEC(ZSTD, ZSTD, Delta, Delta, Delta, NONE, NONE, NONE, LZ4HC),
     ddd Nested (age UInt8, Name String) CODEC(LZ4, LZ4HC, NONE, NONE, NONE, ZSTD, Delta(8))
-) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/compression_codec_multiple_more_types_replicated', '1') ORDER BY tuple();
+) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/compression_codec_multiple_more_types_replicated', '1') ORDER BY tuple() SETTINGS index_granularity = 8192;
 
 SHOW CREATE TABLE test.compression_codec_multiple_more_types_replicated;
 

--- a/dbms/tests/queries/0_stateless/00910_zookeeper_test_alter_compression_codecs.sql
+++ b/dbms/tests/queries/0_stateless/00910_zookeeper_test_alter_compression_codecs.sql
@@ -6,12 +6,12 @@ DROP TABLE IF EXISTS test.alter_compression_codec2;
 CREATE TABLE test.alter_compression_codec1 (
     somedate Date CODEC(LZ4),
     id UInt64 CODEC(NONE)
-) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/alter_compression_codecs', '1') PARTITION BY somedate ORDER BY id;
+) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/alter_compression_codecs', '1') PARTITION BY somedate ORDER BY id SETTINGS index_granularity = 8192;
 
 CREATE TABLE test.alter_compression_codec2 (
   somedate Date CODEC(LZ4),
   id UInt64 CODEC(NONE)
-) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/alter_compression_codecs', '2') PARTITION BY somedate ORDER BY id;
+) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/alter_compression_codecs', '2') PARTITION BY somedate ORDER BY id SETTINGS index_granularity = 8192;
 
 INSERT INTO test.alter_compression_codec1 VALUES('2018-01-01', 1);
 INSERT INTO test.alter_compression_codec1 VALUES('2018-01-01', 2);

--- a/dbms/tests/queries/0_stateless/00927_table_filter.sql
+++ b/dbms/tests/queries/0_stateless/00927_table_filter.sql
@@ -3,15 +3,15 @@ DROP TABLE IF EXISTS filtered_table2;
 DROP TABLE IF EXISTS filtered_table3;
 
 -- Filter: a = 1, values: (1, 0), (1, 1)
-CREATE TABLE filtered_table1 (a UInt8, b UInt8) ENGINE MergeTree ORDER BY a;
+CREATE TABLE filtered_table1 (a UInt8, b UInt8) ENGINE MergeTree ORDER BY a SETTINGS index_granularity = 8192;
 INSERT INTO filtered_table1 values (0, 0), (0, 1), (1, 0), (1, 1);
 
 -- Filter: a + b < 1 or c - d > 5, values: (0, 0, 0, 0), (0, 0, 6, 0)
-CREATE TABLE filtered_table2 (a UInt8, b UInt8, c UInt8, d UInt8) ENGINE MergeTree ORDER BY a;
+CREATE TABLE filtered_table2 (a UInt8, b UInt8, c UInt8, d UInt8) ENGINE MergeTree ORDER BY a SETTINGS index_granularity = 8192;
 INSERT INTO filtered_table2 values (0, 0, 0, 0), (1, 2, 3, 4), (4, 3, 2, 1), (0, 0, 6, 0);
 
 -- Filter: c = 1, values: (0, 1), (1, 0)
-CREATE TABLE filtered_table3 (a UInt8, b UInt8, c UInt16 ALIAS a + b) ENGINE MergeTree ORDER BY a;
+CREATE TABLE filtered_table3 (a UInt8, b UInt8, c UInt16 ALIAS a + b) ENGINE MergeTree ORDER BY a SETTINGS index_granularity = 8192;
 INSERT INTO filtered_table3 values (0, 0), (0, 1), (1, 0), (1, 1);
 
 SELECT '-- PREWHERE should fail';

--- a/dbms/tests/queries/0_stateless/00933_alter_ttl.sql
+++ b/dbms/tests/queries/0_stateless/00933_alter_ttl.sql
@@ -2,7 +2,7 @@ set send_logs_level = 'none';
 
 drop table if exists test.ttl;
 
-create table test.ttl (d Date, a Int) engine = MergeTree order by a partition by toDayOfMonth(d);
+create table test.ttl (d Date, a Int) engine = MergeTree order by a partition by toDayOfMonth(d) SETTINGS index_granularity = 8192;
 alter table test.ttl modify ttl d + interval 1 day;
 show create table test.ttl;
 insert into test.ttl values (toDateTime('2000-10-10 00:00:00'), 1);
@@ -18,7 +18,7 @@ alter table test.ttl modify ttl a; -- { serverError 450 }
 
 drop table if exists test.ttl;
 
-create table test.ttl (d Date, a Int) engine = MergeTree order by tuple() partition by toDayOfMonth(d);
+create table test.ttl (d Date, a Int) engine = MergeTree order by tuple() partition by toDayOfMonth(d) SETTINGS index_granularity = 8192;
 alter table test.ttl modify column a Int ttl d + interval 1 day;
 desc table test.ttl;
 alter table test.ttl modify column d Int ttl d + interval 1 day; -- { serverError 44}

--- a/dbms/tests/queries/0_stateless/00933_test_fix_extra_seek_on_compressed_cache.sh
+++ b/dbms/tests/queries/0_stateless/00933_test_fix_extra_seek_on_compressed_cache.sh
@@ -6,7 +6,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 $CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS small_table"
 
-$CLICKHOUSE_CLIENT --query="CREATE TABLE small_table (a UInt64 default 0, n UInt64) ENGINE = MergeTree() PARTITION BY tuple() ORDER BY (a);"
+$CLICKHOUSE_CLIENT --query="CREATE TABLE small_table (a UInt64 default 0, n UInt64) ENGINE = MergeTree() PARTITION BY tuple() ORDER BY (a) SETTINGS index_granularity = 8192;"
 
 $CLICKHOUSE_CLIENT --query="INSERT INTO small_table(n) SELECT * from system.numbers limit 100000;"
 


### PR DESCRIPTION
… them can be specified. Also fix tests for future index_granularity_bytes by default

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

Short description (up to few sentences):
[This shouldn't be listed in changelog] Now only one setting `index_granularity` or `index_granularity_bytes` can be specified for MergeTree engines family. Also fix tests for future replacement `index_granularity != 0` to `index_granularity_bytes != 0`.
