### PR TITLE
LfAlloc more reliable choice of hint

### DIFF
--- a/contrib/lfalloc/src/lf_allocX64.h
+++ b/contrib/lfalloc/src/lf_allocX64.h
@@ -358,7 +358,7 @@ static char* AllocWithMMap(uintptr_t sz, EMMapMode mode) {
     }
 #if defined(USE_LFALLOC_RANDOM_HINT)
     static thread_local std::mt19937_64 generator(std::random_device{}());
-    std::uniform_int_distribution<intptr_t> distr(areaStart, areaFinish - sz);
+    std::uniform_int_distribution<intptr_t> distr(areaStart, areaFinish - sz - 1);
     char* largeBlock;
     static constexpr size_t MaxAttempts = 100;
     size_t attempt = 0;

--- a/contrib/lfalloc/src/lf_allocX64.h
+++ b/contrib/lfalloc/src/lf_allocX64.h
@@ -360,13 +360,13 @@ static char* AllocWithMMap(uintptr_t sz, EMMapMode mode) {
     static thread_local std::mt19937_64 generator(std::random_device{}());
     std::uniform_int_distribution<intptr_t> distr(areaStart, areaFinish - sz);
     char* largeBlock;
-    static constexpr size_t maxAttempts = 10;
+    static constexpr size_t MaxAttempts = 100;
     size_t attempt = 0;
     do
     {
         largeBlock = (char*)mmap(reinterpret_cast<void*>(distr(generator)), sz, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
         ++attempt;
-    } while (uintptr_t(((char*)largeBlock - ALLOC_START) + sz) >= areaFinish && attempt < maxAttempts && munmap(largeBlock, sz) == 0);
+    } while (uintptr_t(((char*)largeBlock - ALLOC_START) + sz) >= areaFinish && attempt < MaxAttempts && munmap(largeBlock, sz) == 0);
 #else
     char* largeBlock = (char*)mmap(0, sz, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
 #endif

--- a/contrib/lfalloc/src/lf_allocX64.h
+++ b/contrib/lfalloc/src/lf_allocX64.h
@@ -358,8 +358,15 @@ static char* AllocWithMMap(uintptr_t sz, EMMapMode mode) {
     }
 #if defined(USE_LFALLOC_RANDOM_HINT)
     static thread_local std::mt19937_64 generator(std::random_device{}());
-    std::uniform_int_distribution<intptr_t> distr(areaStart, areaFinish / 2);
-    char* largeBlock = (char*)mmap(reinterpret_cast<void*>(distr(generator)), sz, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
+    std::uniform_int_distribution<intptr_t> distr(areaStart, areaFinish - sz);
+    char* largeBlock;
+    static constexpr size_t maxAttempts = 10;
+    size_t attempt = 0;
+    do
+    {
+        largeBlock = (char*)mmap(reinterpret_cast<void*>(distr(generator)), sz, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
+        ++attempt;
+    } while (uintptr_t(((char*)largeBlock - ALLOC_START) + sz) >= areaFinish && attempt < maxAttempts && munmap(largeBlock, sz) == 0);
 #else
     char* largeBlock = (char*)mmap(0, sz, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
 #endif


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Choose again the hint for lfalloc because sometimes when the hint points to the allocated memory, mmap can return the far away address, make the probability of it exponentially small
