### PR TITLE
Add a basename function

### DIFF
--- a/dbms/src/Functions/basename.cpp
+++ b/dbms/src/Functions/basename.cpp
@@ -8,7 +8,7 @@ namespace DB
 
 struct ExtractBasename
 {
-    static size_t getReserveLengthForElement() { return 25; }
+    static size_t getReserveLengthForElement() { return 16; } /// Just a guess.
 
     static void execute(Pos data, size_t size, Pos & res_data, size_t & res_size)
     {

--- a/dbms/src/Functions/basename.cpp
+++ b/dbms/src/Functions/basename.cpp
@@ -7,7 +7,7 @@ namespace DB
 {
 
 /** Extract substring after the last slash or backslash.
-  * If there is no slashes, return the string unchanged.
+  * If there are no slashes, return the string unchanged.
   * It is used to extract filename from path.
   */
 struct ExtractBasename

--- a/dbms/src/Functions/basename.cpp
+++ b/dbms/src/Functions/basename.cpp
@@ -6,6 +6,10 @@
 namespace DB
 {
 
+/** Extract substring after the last slash or backslash.
+  * If there is no slashes, return the string unchanged.
+  * It is used to extract filename from path.
+  */
 struct ExtractBasename
 {
     static size_t getReserveLengthForElement() { return 16; } /// Just a guess.

--- a/dbms/src/Functions/basename.cpp
+++ b/dbms/src/Functions/basename.cpp
@@ -1,0 +1,38 @@
+#include <Functions/FunctionFactory.h>
+#include <Functions/FunctionStringToString.h>
+#include <Functions/FunctionsURL.h>
+#include <common/find_symbols.h>
+
+namespace DB
+{
+
+struct ExtractBasename
+{
+    static size_t getReserveLengthForElement() { return 25; }
+
+    static void execute(Pos data, size_t size, Pos & res_data, size_t & res_size)
+    {
+        res_data = data;
+        res_size = size;
+
+        Pos pos = data;
+        Pos end = pos + size;
+
+        if ((pos = find_last_symbols_or_null<'/', '\\'>(pos, end)))
+        {
+            ++pos;
+            res_data = pos;
+            res_size = end - pos;
+        }
+    }
+};
+
+struct NameBasename { static constexpr auto name = "basename"; };
+using FunctionBasename = FunctionStringToString<ExtractSubstringImpl<ExtractBasename>, NameBasename>;
+
+void registerFunctionBasename(FunctionFactory & factory)
+{
+    factory.registerFunction<FunctionBasename>();
+}
+
+}

--- a/dbms/src/Functions/registerFunctionsMiscellaneous.cpp
+++ b/dbms/src/Functions/registerFunctionsMiscellaneous.cpp
@@ -42,6 +42,7 @@ void registerFunctionLowCardinalityKeys(FunctionFactory &);
 void registerFunctionsIn(FunctionFactory &);
 void registerFunctionJoinGet(FunctionFactory &);
 void registerFunctionFilesystem(FunctionFactory &);
+void registerFunctionBasename(FunctionFactory &);
 
 void registerFunctionsMiscellaneous(FunctionFactory & factory)
 {
@@ -84,6 +85,7 @@ void registerFunctionsMiscellaneous(FunctionFactory & factory)
     registerFunctionsIn(factory);
     registerFunctionJoinGet(factory);
     registerFunctionFilesystem(factory);
+    registerFunctionBasename(factory);
 }
 
 }

--- a/dbms/tests/queries/0_stateless/00938_basename.reference
+++ b/dbms/tests/queries/0_stateless/00938_basename.reference
@@ -1,0 +1,5 @@
+bash
+
+bash
+test_file
+script.php

--- a/dbms/tests/queries/0_stateless/00938_basename.sql
+++ b/dbms/tests/queries/0_stateless/00938_basename.sql
@@ -1,0 +1,5 @@
+SELECT basename('/usr/bin/bash');
+SELECT basename('/usr/bin/bash/');
+SELECT basename('bash');
+SELECT basename('C:\\\\Users\\Documents\\test_file');
+SELECT basename(path('http://example.com/folder_1/folder_2/script.php'))


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- New Feature

Short description (up to few sentences):

Add a function basename, with a similar behaviour compared compared to a basename function who exist in lot of language (`os.path.basename` in python, `basename` in PHP, etc...). Work with both an UNIX-like path or a Windows path.