### PR TITLE
Remove move-assignment to prevent possible self-move

### DIFF
--- a/dbms/src/Storages/ColumnsDescription.h
+++ b/dbms/src/Storages/ColumnsDescription.h
@@ -38,7 +38,6 @@ public:
     ColumnsDescription(const ColumnsDescription & other);
     ColumnsDescription & operator=(const ColumnsDescription & other);
     ColumnsDescription(ColumnsDescription &&) noexcept = default;
-    ColumnsDescription & operator=(ColumnsDescription &&) noexcept = default;
 
     /// `after_column` can be a Nested column name;
     void add(ColumnDescription column, const String & after_column = String());

--- a/dbms/src/Storages/ITableDeclaration.cpp
+++ b/dbms/src/Storages/ITableDeclaration.cpp
@@ -28,7 +28,7 @@ void ITableDeclaration::setColumns(ColumnsDescription columns_)
 {
     if (columns_.getOrdinary().empty())
         throw Exception("Empty list of columns passed", ErrorCodes::EMPTY_LIST_OF_COLUMNS_PASSED);
-    columns = std::move(columns_);
+    columns = columns_;
 }
 
 void ITableDeclaration::setIndicesDescription(IndicesDescription indices_)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
There are some sanitizer reports that show a self-move leading to use-after-free. To prevent it - remove the move-assignment operator.