### PR TITLE
Get rid of thread_local in SettingsConstraints.cpp

### DIFF
--- a/dbms/src/Core/Settings.cpp
+++ b/dbms/src/Core/Settings.cpp
@@ -104,9 +104,9 @@ void Settings::addProgramOptions(boost::program_options::options_description & o
         auto on_program_option
             = boost::function1<void, const std::string &>([this, index](const std::string & value) { set(index, value); });
         options.add(boost::shared_ptr<boost::program_options::option_description>(new boost::program_options::option_description(
-            Settings::getNameByIndex(index).data,
+            Settings::getName(index).data,
             boost::program_options::value<std::string>()->composing()->notifier(on_program_option),
-            Settings::getDescriptionByIndex(index).data)));
+            Settings::getDescription(index).data)));
     }
 }
 

--- a/dbms/src/Interpreters/SettingsConstraints.h
+++ b/dbms/src/Interpreters/SettingsConstraints.h
@@ -59,9 +59,7 @@ public:
 
     void clear();
 
-    void setMinValue(const String & name, const String & min_value);
     void setMinValue(const String & name, const Field & min_value);
-    void setMaxValue(const String & name, const String & max_value);
     void setMaxValue(const String & name, const Field & max_value);
     void setReadOnly(const String & name, bool read_only);
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Build/Testing/Packaging Improvement

Old OSX versions don't have support for C++11 thread_local variables so it's better not to use them.