### PR TITLE
Fixed race condition with recursive usage of RWLock

### DIFF
--- a/dbms/src/Common/RWLock.h
+++ b/dbms/src/Common/RWLock.h
@@ -1,6 +1,7 @@
 #pragma once
+
 #include <Core/Types.h>
-#include <boost/core/noncopyable.hpp>
+
 #include <list>
 #include <vector>
 #include <mutex>


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fixed very rare data race condition that could happen when executing a query with `UNION ALL` involving at least two SELECTs from `system.columns`, `system.tables`, `system.parts`, `system.parts_tables` or tables of `Merge` family and performing `ALTER` of columns of the related tables concurrently.

Detailed description:
The bug was introduced in #4535 in line https://github.com/yandex/ClickHouse/pull/4535/files#diff-3e4a7657eee1bdf8c216f277458cf455R130. Lock is registered in dictionary of queries before it is acquired. While waiting for lock on condvar, another thread of the same query may get this lock before it is acquired. The code was already bad in #1192, because there was the same ordering of statements for registering locks in threads dictionary, but the bug didn't exist because no another threads with the same thread_id possible. The bug was not reproduced by any tests due to unusual case, but in #5127 another test was added and the bug started to reproduce in about 90% probability in stress test (parallel run of all available tests without checking the result) under address sanitizer. Then I have added isolated test case to reproduce the specific issue in https://github.com/yandex/ClickHouse/commit/0a072ccc571bbb48146119f826963bd428b3897d and https://github.com/yandex/ClickHouse/commit/a924e1c5fbee7a9e6306e8fdf30090650d3f6a7f - it reproduced the bug in ASan and TSan test runs.