### PR TITLE
Regexp extraction fix for small prefixes

### DIFF
--- a/dbms/src/Common/OptimizedRegularExpression.cpp
+++ b/dbms/src/Common/OptimizedRegularExpression.cpp
@@ -1,7 +1,6 @@
 #include <Common/Exception.h>
 #include <Common/OptimizedRegularExpression.h>
 
-
 #define MIN_LENGTH_FOR_STRSTR 3
 #define MAX_SUBPATTERNS 5
 
@@ -214,20 +213,35 @@ void OptimizedRegularExpressionImpl<thread_safe>::analyze(
             /** We choose the non-alternative substring of the maximum length, among the prefixes,
               *  or a non-alternative substring of maximum length.
               */
+
+            /// Tuning for typical usage domain
+            auto tuning_strings_condition = [](const std::string & str)
+            {
+                return str != "://" && str != "http://" && str != "www" && str != "Windows ";
+            };
             size_t max_length = 0;
             Substrings::const_iterator candidate_it = trivial_substrings.begin();
             for (Substrings::const_iterator it = trivial_substrings.begin(); it != trivial_substrings.end(); ++it)
             {
                 if (((it->second == 0 && candidate_it->second != 0)
                         || ((it->second == 0) == (candidate_it->second == 0) && it->first.size() > max_length))
-                    /// Tuning for typical usage domain
-                    && (it->first.size() > strlen("://") || strncmp(it->first.data(), "://", strlen("://")))
-                    && (it->first.size() > strlen("http://") || strncmp(it->first.data(), "http", strlen("http")))
-                    && (it->first.size() > strlen("www.") || strncmp(it->first.data(), "www", strlen("www")))
-                    && (it->first.size() > strlen("Windows ") || strncmp(it->first.data(), "Windows ", strlen("Windows "))))
+                    && tuning_strings_condition(it->first))
                 {
                     max_length = it->first.size();
                     candidate_it = it;
+                }
+            }
+
+            /// If prefix is small, it won't be chosen
+            if (max_length == 0)
+            {
+                for (Substrings::const_iterator it = trivial_substrings.begin(); it != trivial_substrings.end(); ++it)
+                {
+                    if (it->first.size() > max_length && tuning_strings_condition(it->first))
+                    {
+                        max_length = it->first.size();
+                        candidate_it = it;
+                    }
                 }
             }
 

--- a/dbms/src/Common/OptimizedRegularExpression.cpp
+++ b/dbms/src/Common/OptimizedRegularExpression.cpp
@@ -233,7 +233,7 @@ void OptimizedRegularExpressionImpl<thread_safe>::analyze(
             }
 
             /// If prefix is small, it won't be chosen
-            if (max_length == 0)
+            if (max_length < MIN_LENGTH_FOR_STRSTR)
             {
                 for (Substrings::const_iterator it = trivial_substrings.begin(); it != trivial_substrings.end(); ++it)
                 {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Performance Improvement

Short description (up to few sentences):
For regular expressions that have a small prefix, we won't extract any word and will be using matching all the time, let's use optimization instead if it exists.


Maybe we should just use maximum length candidate? Or add some weight to prefix and choose according to the weight? 