### PR TITLE
Remove condition of prefixes first in OptimizedRegularExpression

### DIFF
--- a/dbms/src/Common/OptimizedRegularExpression.cpp
+++ b/dbms/src/Common/OptimizedRegularExpression.cpp
@@ -210,9 +210,7 @@ void OptimizedRegularExpressionImpl<thread_safe>::analyze(
     {
         if (!has_alternative_on_depth_0)
         {
-            /** We choose the non-alternative substring of the maximum length, among the prefixes,
-              *  or a non-alternative substring of maximum length.
-              */
+            /// We choose the non-alternative substring of the maximum length for first search.
 
             /// Tuning for typical usage domain
             auto tuning_strings_condition = [](const std::string & str)
@@ -223,25 +221,10 @@ void OptimizedRegularExpressionImpl<thread_safe>::analyze(
             Substrings::const_iterator candidate_it = trivial_substrings.begin();
             for (Substrings::const_iterator it = trivial_substrings.begin(); it != trivial_substrings.end(); ++it)
             {
-                if (((it->second == 0 && candidate_it->second != 0)
-                        || ((it->second == 0) == (candidate_it->second == 0) && it->first.size() > max_length))
-                    && tuning_strings_condition(it->first))
+                if (it->first.size() > max_length && tuning_strings_condition(it->first))
                 {
                     max_length = it->first.size();
                     candidate_it = it;
-                }
-            }
-
-            /// If prefix is small, it won't be chosen
-            if (max_length < MIN_LENGTH_FOR_STRSTR)
-            {
-                for (Substrings::const_iterator it = trivial_substrings.begin(); it != trivial_substrings.end(); ++it)
-                {
-                    if (it->first.size() > max_length && tuning_strings_condition(it->first))
-                    {
-                        max_length = it->first.size();
-                        candidate_it = it;
-                    }
                 }
             }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Performance Improvement

Short description (up to few sentences):
Remove prefix condition in OptimizedRegularExpression and remain only maximum substring one.