### PR TITLE
fix data race in rename query

### DIFF
--- a/dbms/src/Storages/StorageMergeTree.cpp
+++ b/dbms/src/Storages/StorageMergeTree.cpp
@@ -698,10 +698,10 @@ BackgroundProcessingPoolTaskResult StorageMergeTree::backgroundTask()
         /// Clear old parts. It is unnecessary to do it more than once a second.
         if (auto lock = time_after_previous_cleanup.compareAndRestartDeferred(1))
         {
-            clearOldPartsFromFilesystem();
             {
                 /// TODO: Implement tryLockStructureForShare.
                 auto lock_structure = lockStructureForShare(false, "");
+                clearOldPartsFromFilesystem();
                 clearOldTemporaryDirectories();
             }
             clearOldMutations();


### PR DESCRIPTION
#4935 #5179
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category:
- Bug Fix

Detailed description:

Rename query and background merges can cause data race problems.

I tried to use the following test case but could not reproduce it:
``` shell
#!/usr/bin/env bash

CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
. $CURDIR/../shell_config.sh

set -e

$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS rename_table"
$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS already_rename_table"
$CLICKHOUSE_CLIENT -q "CREATE TABLE rename_table (a UInt8, b Int16, c Float32, d String) ENGINE = MergeTree ORDER BY a"

function insert_function()
{
    while true; do $CLICKHOUSE_CLIENT --query "INSERT INTO rename_table SELECT toUInt8(number), toInt16(number), toFloat32(number), toString(number) FROM numbers(1000)"; done
}

function rename_function()
{
    while true; do $CLICKHOUSE_CLIENT --query "RENAME TABLE rename_table TO already_rename_table, already_rename_table TO rename_table"; done
}

# https://stackoverflow.com/questions/9954794/execute-a-shell-function-with-timeout
export -f insert_function;
export -f rename_function;

timeout 15 bash -c insert_function 2> /dev/null &
timeout 15 bash -c insert_function 2> /dev/null &
timeout 15 bash -c insert_function 2> /dev/null &
timeout 15 bash -c rename_function 2> /dev/null &

wait

$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS rename_table"
$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS already_rename_table"
```
