### PR TITLE
Fix perf regression: do not add right join key to result if possible

### DIFF
--- a/dbms/src/Interpreters/AnalyzedJoin.cpp
+++ b/dbms/src/Interpreters/AnalyzedJoin.cpp
@@ -25,11 +25,25 @@ void AnalyzedJoin::addUsingKey(const ASTPtr & ast)
 
 void AnalyzedJoin::addOnKeys(ASTPtr & left_table_ast, ASTPtr & right_table_ast)
 {
+    with_using = false;
     key_names_left.push_back(left_table_ast->getColumnName());
     key_names_right.push_back(right_table_ast->getAliasOrColumnName());
 
     key_asts_left.push_back(left_table_ast);
     key_asts_right.push_back(right_table_ast);
+}
+
+/// @return how many times right key appears in ON section.
+size_t AnalyzedJoin::rightKeyInclusion(const String & name) const
+{
+    if (with_using)
+        return 0;
+
+    size_t count = 0;
+    for (const auto & key_name : key_names_right)
+        if (name == key_name)
+            ++count;
+    return count;
 }
 
 ExpressionActionsPtr AnalyzedJoin::createJoinedBlockActions(

--- a/dbms/src/Interpreters/AnalyzedJoin.h
+++ b/dbms/src/Interpreters/AnalyzedJoin.h
@@ -55,6 +55,7 @@ struct AnalyzedJoin
     Names key_names_right; /// Duplicating names are qualified.
     ASTs key_asts_left;
     ASTs key_asts_right;
+    bool with_using = true;
 
     /// All columns which can be read from joined table. Duplicating names are qualified.
     JoinedColumnsList columns_from_joined_table;
@@ -74,6 +75,7 @@ struct AnalyzedJoin
 
     void calculateColumnsFromJoinedTable(const NamesAndTypesList & columns, const Names & original_names);
     void calculateAvailableJoinedColumns(bool make_nullable);
+    size_t rightKeyInclusion(const String & name) const;
 };
 
 struct ASTTableExpression;

--- a/dbms/src/Interpreters/ColumnNamesContext.h
+++ b/dbms/src/Interpreters/ColumnNamesContext.h
@@ -51,7 +51,20 @@ struct ColumnNamesContext
         }
     };
 
-    std::unordered_map<String, std::set<String>> required_names; /// names with aliases
+    struct NameInfo
+    {
+        std::set<String> aliases;
+        size_t appears = 0;
+
+        void addInclusion(const String & alias)
+        {
+            if (!alias.empty())
+                aliases.insert(alias);
+            ++appears;
+        }
+    };
+
+    std::unordered_map<String, NameInfo> required_names;
     NameSet table_aliases;
     NameSet private_aliases;
     NameSet complex_aliases;
@@ -68,6 +81,7 @@ struct ColumnNamesContext
     void addArrayJoinIdentifier(const ASTIdentifier & node);
 
     NameSet requiredColumns() const;
+    size_t nameInclusion(const String & name) const;
 };
 
 std::ostream & operator << (std::ostream & os, const ColumnNamesContext & cols);

--- a/dbms/tests/performance/joins_in_memory.xml
+++ b/dbms/tests/performance/joins_in_memory.xml
@@ -16,9 +16,9 @@
 
     <fill_query>INSERT INTO ints SELECT number AS i64, i64 AS i32, i64 AS i16, i64 AS i8 FROM numbers(10000)</fill_query>
     <fill_query>INSERT INTO ints SELECT 10000 + number % 1000 AS i64, i64 AS i32, i64 AS i16, i64 AS i8 FROM numbers(10000)</fill_query>
-    <fill_query>INSERT INTO ints SELECT 20000 + number % 100  AS i64, i64 AS i32, i64 AS i16, i64 AS i8 FROM numbers(10000)</fill_query>
-    <fill_query>INSERT INTO ints SELECT 30000 + number % 10   AS i64, i64 AS i32, i64 AS i16, i64 AS i8 FROM numbers(10000)</fill_query>
-    <fill_query>INSERT INTO ints SELECT 40000 + number % 1    AS i64, i64 AS i32, i64 AS i16, i64 AS i8 FROM numbers(10000)</fill_query>
+    <fill_query>INSERT INTO ints SELECT 20000 + number % 100 AS i64, i64 AS i32, i64 AS i16, i64 AS i8 FROM numbers(10000)</fill_query>
+    <fill_query>INSERT INTO ints SELECT 30000 + number % 10 AS i64, i64 AS i32, i64 AS i16, i64 AS i8 FROM numbers(10000)</fill_query>
+    <fill_query>INSERT INTO ints SELECT 40000 + number % 1 AS i64, i64 AS i32, i64 AS i16, i64 AS i8 FROM numbers(10000)</fill_query>
 
     <query tag='ANY LEFT'>SELECT COUNT() FROM ints l ANY LEFT JOIN ints r USING i64 WHERE i32 = 200042</query>
     <query tag='ANY LEFT KEY'>SELECT COUNT() FROM ints l ANY LEFT JOIN ints r USING i64,i32,i16,i8 WHERE i32 = 200042</query>
@@ -30,23 +30,23 @@
     <query tag='INNER ON'>SELECT COUNT() FROM ints l INNER JOIN ints r ON l.i64 = r.i64 WHERE i32 = 200042</query>
     <query tag='INNER IN'>SELECT COUNT() FROM ints l INNER JOIN ints r USING i64 WHERE i32 IN(42, 100042, 200042, 300042, 400042)</query>
 
-    <query tag='LEFT'> SELECT COUNT() FROM ints l LEFT  JOIN ints r USING i64 WHERE i32 = 200042</query>
-    <query tag='LEFT KEY'> SELECT COUNT() FROM ints l LEFT  JOIN ints r USING i64,i32,i16,i8 WHERE i32 = 200042</query>
-    <query tag='LEFT ON'> SELECT COUNT() FROM ints l LEFT  JOIN ints r ON l.i64 = r.i64 WHERE i32 = 200042</query>
-    <query tag='LEFT IN'> SELECT COUNT() FROM ints l LEFT  JOIN ints r USING i64 WHERE i32 IN(42, 100042, 200042, 300042, 400042)</query>
+    <query tag='LEFT'>SELECT COUNT() FROM ints l LEFT JOIN ints r USING i64 WHERE i32 = 200042</query>
+    <query tag='LEFT KEY'>SELECT COUNT() FROM ints l LEFT JOIN ints r USING i64,i32,i16,i8 WHERE i32 = 200042</query>
+    <query tag='LEFT ON'>SELECT COUNT() FROM ints l LEFT JOIN ints r ON l.i64 = r.i64 WHERE i32 = 200042</query>
+    <query tag='LEFT IN'>SELECT COUNT() FROM ints l LEFT JOIN ints r USING i64 WHERE i32 IN(42, 100042, 200042, 300042, 400042)</query>
 
     <query tag='RIGHT'>SELECT COUNT() FROM ints l RIGHT JOIN ints r USING i64 WHERE i32 = 200042</query>
     <query tag='RIGHT KEY'>SELECT COUNT() FROM ints l RIGHT JOIN ints r USING i64,i32,i16,i8 WHERE i32 = 200042</query>
     <query tag='RIGHT ON'>SELECT COUNT() FROM ints l RIGHT JOIN ints r ON l.i64 = r.i64 WHERE i32 = 200042</query>
     <query tag='RIGHT IN'>SELECT COUNT() FROM ints l RIGHT JOIN ints r USING i64 WHERE i32 IN(42, 100042, 200042, 300042, 400042)</query>
 
-    <query tag='FULL'> SELECT COUNT() FROM ints l FULL  JOIN ints r USING i64 WHERE i32 = 200042</query>
-    <query tag='FULL KEY'> SELECT COUNT() FROM ints l FULL  JOIN ints r USING i64,i32,i16,i8 WHERE i32 = 200042</query>
-    <query tag='FULL ON'> SELECT COUNT() FROM ints l FULL  JOIN ints r ON l.i64 = r.i64 WHERE i32 = 200042</query>
-    <query tag='FULL IN'> SELECT COUNT() FROM ints l FULL  JOIN ints r USING i64 WHERE i32 IN(42, 100042, 200042, 300042, 400042)</query>
+    <query tag='FULL'>SELECT COUNT() FROM ints l FULL JOIN ints r USING i64 WHERE i32 = 200042</query>
+    <query tag='FULL KEY'>SELECT COUNT() FROM ints l FULL JOIN ints r USING i64,i32,i16,i8 WHERE i32 = 200042</query>
+    <query tag='FULL ON'>SELECT COUNT() FROM ints l FULL JOIN ints r ON l.i64 = r.i64 WHERE i32 = 200042</query>
+    <query tag='FULL IN'>SELECT COUNT() FROM ints l FULL JOIN ints r USING i64 WHERE i32 IN(42, 100042, 200042, 300042, 400042)</query>
 
-    <query tag='CROSS'> SELECT COUNT() FROM ints l CROSS JOIN (SELECT number as i64 FROM numbers(4)) WHERE i32 = 42</query>
-    <query tag='CROSS KEY'> SELECT COUNT() FROM ints l CROSS JOIN (SELECT number as i64 FROM numbers(4)) WHERE i32 = 42</query>
+    <query tag='CROSS'>SELECT COUNT() FROM ints l CROSS JOIN (SELECT number as i64 FROM numbers(4)) WHERE i32 = 42</query>
+    <query tag='CROSS KEY'>SELECT COUNT() FROM ints l CROSS JOIN (SELECT number as i64 FROM numbers(4)) WHERE i32 = 42</query>
 
     <drop_query>DROP TABLE IF EXISTS ints</drop_query>
 </test>

--- a/dbms/tests/performance/joins_in_memory.xml
+++ b/dbms/tests/performance/joins_in_memory.xml
@@ -1,0 +1,52 @@
+<test>
+    <name>Joins In Memory</name>
+    <type>loop</type>
+
+    <stop_conditions>
+        <any_of>
+            <iterations>10</iterations>
+        </any_of>
+    </stop_conditions>
+
+    <main_metric>
+        <rows_per_second />
+    </main_metric>
+
+    <create_query>CREATE TABLE ints (i64 Int64, i32 Int32, i16 Int16, i8 Int8) ENGINE = Memory</create_query>
+
+    <fill_query>INSERT INTO ints SELECT number AS i64, i64 AS i32, i64 AS i16, i64 AS i8 FROM numbers(10000)</fill_query>
+    <fill_query>INSERT INTO ints SELECT 10000 + number % 1000 AS i64, i64 AS i32, i64 AS i16, i64 AS i8 FROM numbers(10000)</fill_query>
+    <fill_query>INSERT INTO ints SELECT 20000 + number % 100  AS i64, i64 AS i32, i64 AS i16, i64 AS i8 FROM numbers(10000)</fill_query>
+    <fill_query>INSERT INTO ints SELECT 30000 + number % 10   AS i64, i64 AS i32, i64 AS i16, i64 AS i8 FROM numbers(10000)</fill_query>
+    <fill_query>INSERT INTO ints SELECT 40000 + number % 1    AS i64, i64 AS i32, i64 AS i16, i64 AS i8 FROM numbers(10000)</fill_query>
+
+    <query tag='ANY LEFT'>SELECT COUNT() FROM ints l ANY LEFT JOIN ints r USING i64 WHERE i32 = 200042</query>
+    <query tag='ANY LEFT KEY'>SELECT COUNT() FROM ints l ANY LEFT JOIN ints r USING i64,i32,i16,i8 WHERE i32 = 200042</query>
+    <query tag='ANY LEFT ON'>SELECT COUNT() FROM ints l ANY LEFT JOIN ints r ON l.i64 = r.i64 WHERE i32 = 200042</query>
+    <query tag='ANY LEFT IN'>SELECT COUNT() FROM ints l ANY LEFT JOIN ints r USING i64 WHERE i32 IN(42, 100042, 200042, 300042, 400042)</query>
+
+    <query tag='INNER'>SELECT COUNT() FROM ints l INNER JOIN ints r USING i64 WHERE i32 = 200042</query>
+    <query tag='INNER KEY'>SELECT COUNT() FROM ints l INNER JOIN ints r USING i64,i32,i16,i8 WHERE i32 = 200042</query>
+    <query tag='INNER ON'>SELECT COUNT() FROM ints l INNER JOIN ints r ON l.i64 = r.i64 WHERE i32 = 200042</query>
+    <query tag='INNER IN'>SELECT COUNT() FROM ints l INNER JOIN ints r USING i64 WHERE i32 IN(42, 100042, 200042, 300042, 400042)</query>
+
+    <query tag='LEFT'> SELECT COUNT() FROM ints l LEFT  JOIN ints r USING i64 WHERE i32 = 200042</query>
+    <query tag='LEFT KEY'> SELECT COUNT() FROM ints l LEFT  JOIN ints r USING i64,i32,i16,i8 WHERE i32 = 200042</query>
+    <query tag='LEFT ON'> SELECT COUNT() FROM ints l LEFT  JOIN ints r ON l.i64 = r.i64 WHERE i32 = 200042</query>
+    <query tag='LEFT IN'> SELECT COUNT() FROM ints l LEFT  JOIN ints r USING i64 WHERE i32 IN(42, 100042, 200042, 300042, 400042)</query>
+
+    <query tag='RIGHT'>SELECT COUNT() FROM ints l RIGHT JOIN ints r USING i64 WHERE i32 = 200042</query>
+    <query tag='RIGHT KEY'>SELECT COUNT() FROM ints l RIGHT JOIN ints r USING i64,i32,i16,i8 WHERE i32 = 200042</query>
+    <query tag='RIGHT ON'>SELECT COUNT() FROM ints l RIGHT JOIN ints r ON l.i64 = r.i64 WHERE i32 = 200042</query>
+    <query tag='RIGHT IN'>SELECT COUNT() FROM ints l RIGHT JOIN ints r USING i64 WHERE i32 IN(42, 100042, 200042, 300042, 400042)</query>
+
+    <query tag='FULL'> SELECT COUNT() FROM ints l FULL  JOIN ints r USING i64 WHERE i32 = 200042</query>
+    <query tag='FULL KEY'> SELECT COUNT() FROM ints l FULL  JOIN ints r USING i64,i32,i16,i8 WHERE i32 = 200042</query>
+    <query tag='FULL ON'> SELECT COUNT() FROM ints l FULL  JOIN ints r ON l.i64 = r.i64 WHERE i32 = 200042</query>
+    <query tag='FULL IN'> SELECT COUNT() FROM ints l FULL  JOIN ints r USING i64 WHERE i32 IN(42, 100042, 200042, 300042, 400042)</query>
+
+    <query tag='CROSS'> SELECT COUNT() FROM ints l CROSS JOIN (SELECT number as i64 FROM numbers(4)) WHERE i32 = 42</query>
+    <query tag='CROSS KEY'> SELECT COUNT() FROM ints l CROSS JOIN (SELECT number as i64 FROM numbers(4)) WHERE i32 = 42</query>
+
+    <drop_query>DROP TABLE IF EXISTS ints</drop_query>
+</test>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Performance Improvement

Short description (up to few sentences):
Do not add right join key column to join result if it's used only in join on section.

Detailed description (optional):
Right and left join key could differ for LEFT/RIGHT/FULL JOINS. So if right key selected it needs to be generated in JOIN. We could avoid this phase if right key column is not used outside of JOIN. 18.6- returns wrong right key column (using left one) so it was faster.

```
    "query": "SELECT COUNT() FROM ints l INNER JOIN ints r ON l.i64 = r.i64 WHERE i32 = 200042",
    18.6 "rows_per_second": 122760.682719
    19.x "rows_per_second": 69802.994638
    fixed "rows_per_second": 117674.135628

    "query": " SELECT COUNT() FROM ints l LEFT  JOIN ints r ON l.i64 = r.i64 WHERE i32 = 200042",
    18.6 "rows_per_second": 122010.357709
    19.x "rows_per_second": 69745.632064,
    fixed "rows_per_second": 123532.142580,
```