### PR TITLE
CLICKHOUSE-4519 Support dictionaries in clickhouse-copier

### DIFF
--- a/dbms/programs/copier/CMakeLists.txt
+++ b/dbms/programs/copier/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(CLICKHOUSE_COPIER_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/ClusterCopier.cpp)
-set(CLICKHOUSE_COPIER_LINK PRIVATE clickhouse_functions clickhouse_table_functions clickhouse_aggregate_functions PUBLIC daemon)
+set(CLICKHOUSE_COPIER_LINK PRIVATE clickhouse_functions clickhouse_table_functions clickhouse_aggregate_functions clickhouse_dictionaries PUBLIC daemon)
 set(CLICKHOUSE_COPIER_INCLUDE SYSTEM PRIVATE ${PCG_RANDOM_INCLUDE_DIR})
 
 clickhouse_program_add(copier)

--- a/dbms/programs/copier/ClusterCopier.cpp
+++ b/dbms/programs/copier/ClusterCopier.cpp
@@ -63,6 +63,7 @@
 #include <AggregateFunctions/registerAggregateFunctions.h>
 #include <Storages/registerStorages.h>
 #include <Storages/StorageDistributed.h>
+#include <Dictionaries/registerDictionaries.h>
 #include <Databases/DatabaseMemory.h>
 #include <Common/StatusFile.h>
 
@@ -2169,6 +2170,7 @@ void ClusterCopierApp::mainImpl()
     registerAggregateFunctions();
     registerTableFunctions();
     registerStorages();
+    registerDictionaries();
 
     static const std::string default_database = "_local";
     context->addDatabase(default_database, std::make_shared<DatabaseMemory>(default_database));

--- a/dbms/src/Common/Config/ConfigProcessor.cpp
+++ b/dbms/src/Common/Config/ConfigProcessor.cpp
@@ -571,41 +571,41 @@ ConfigProcessor::LoadedConfig ConfigProcessor::loadConfigWithZooKeeperIncludes(
 
 void ConfigProcessor::savePreprocessedConfig(const LoadedConfig & loaded_config, std::string preprocessed_dir)
 {
-    if (preprocessed_path.empty())
+    try
     {
-        auto new_path = loaded_config.config_path;
-        if (new_path.substr(0, main_config_path.size()) == main_config_path)
-            new_path.replace(0, main_config_path.size(), "");
-        std::replace(new_path.begin(), new_path.end(), '/', '_');
-
-        if (preprocessed_dir.empty())
+        if (preprocessed_path.empty())
         {
-            if (!loaded_config.configuration->has("path"))
+            auto new_path = loaded_config.config_path;
+            if (new_path.substr(0, main_config_path.size()) == main_config_path)
+                new_path.replace(0, main_config_path.size(), "");
+            std::replace(new_path.begin(), new_path.end(), '/', '_');
+
+            if (preprocessed_dir.empty())
             {
-                // Will use current directory
-                auto parent_path = Poco::Path(loaded_config.config_path).makeParent();
-                preprocessed_dir = parent_path.toString();
-                Poco::Path poco_new_path(new_path);
-                poco_new_path.setBaseName(poco_new_path.getBaseName() + PREPROCESSED_SUFFIX);
-                new_path = poco_new_path.toString();
+                if (!loaded_config.configuration->has("path"))
+                {
+                    // Will use current directory
+                    auto parent_path = Poco::Path(loaded_config.config_path).makeParent();
+                    preprocessed_dir = parent_path.toString();
+                    Poco::Path poco_new_path(new_path);
+                    poco_new_path.setBaseName(poco_new_path.getBaseName() + PREPROCESSED_SUFFIX);
+                    new_path = poco_new_path.toString();
+                }
+                else
+                {
+                    preprocessed_dir = loaded_config.configuration->getString("path") + "/preprocessed_configs/";
+                }
             }
             else
             {
-                preprocessed_dir = loaded_config.configuration->getString("path") + "/preprocessed_configs/";
+                preprocessed_dir += "/preprocessed_configs/";
             }
-        }
-        else
-        {
-            preprocessed_dir += "/preprocessed_configs/";
-        }
 
-        preprocessed_path = preprocessed_dir + new_path;
-        auto preprocessed_path_parent = Poco::Path(preprocessed_path).makeParent();
-        if (!preprocessed_path_parent.toString().empty())
-            Poco::File(preprocessed_path_parent).createDirectories();
-    }
-    try
-    {
+            preprocessed_path = preprocessed_dir + new_path;
+            auto preprocessed_path_parent = Poco::Path(preprocessed_path).makeParent();
+            if (!preprocessed_path_parent.toString().empty())
+                Poco::File(preprocessed_path_parent).createDirectories();
+        }
         DOMWriter().writeNode(preprocessed_path, loaded_config.preprocessed_xml);
     }
     catch (Poco::Exception & e)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

Short description (up to few sentences):
Support dictionaries in clickhouse-copier for functions in <sharding_key>
