### PR TITLE
Freeze the Kafka buffer after first empty response

### DIFF
--- a/dbms/src/Formats/BlockInputStreamFromRowInputStream.cpp
+++ b/dbms/src/Formats/BlockInputStreamFromRowInputStream.cpp
@@ -63,7 +63,7 @@ Block BlockInputStreamFromRowInputStream::readImpl()
             if (rows_portion_size && batch == rows_portion_size)
             {
                 batch = 0;
-                if (!checkTimeLimit())
+                if (!checkTimeLimit() || isCancelled())
                     break;
             }
 

--- a/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.h
+++ b/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.h
@@ -38,6 +38,7 @@ private:
     Poco::Logger * log;
     const size_t batch_size = 1;
     const size_t poll_timeout = 0;
+    bool stalled = false;
 
     Messages messages;
     Messages::const_iterator current;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Performance Improvement

Short description (up to few sentences):
Some row-parsing streams invokes `ReadBuffer::next()` multiple times even for empty result, expecting that the result stays unchanged. We guarantee the stable result for `ReadBufferFromKafkaConsumer::nextImpl()` too.