### PR TITLE
Don't crash the server when Kafka consumers have failed to start

### DIFF
--- a/dbms/src/Storages/Kafka/StorageKafka.cpp
+++ b/dbms/src/Storages/Kafka/StorageKafka.cpp
@@ -125,8 +125,15 @@ void StorageKafka::startup()
     for (size_t i = 0; i < num_consumers; ++i)
     {
         // Make buffer available
-        pushBuffer(createBuffer());
-        ++num_created_consumers;
+        try
+        {
+            pushBuffer(createBuffer());
+            ++num_created_consumers;
+        }
+        catch (cppkafka::Exception &)
+        {
+            tryLogCurrentException(log);
+        }
     }
 
     // Start the reader thread

--- a/dbms/src/Storages/Kafka/StorageKafka.cpp
+++ b/dbms/src/Storages/Kafka/StorageKafka.cpp
@@ -130,7 +130,7 @@ void StorageKafka::startup()
             pushBuffer(createBuffer());
             ++num_created_consumers;
         }
-        catch (cppkafka::Exception &)
+        catch (const cppkafka::Exception &)
         {
             tryLogCurrentException(log);
         }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix