### PR TITLE
fix deadlock when xid equal to close_xid

### DIFF
--- a/dbms/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/dbms/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -1430,6 +1430,8 @@ void ZooKeeper::pushRequest(RequestInfo && info)
         if (!info.request->xid)
         {
             info.request->xid = next_xid.fetch_add(1);
+            if (info.request->xid == close_xid)
+                throw Exception("xid equal to close_xid", ZSESSIONEXPIRED);
             if (info.request->xid < 0)
                 throw Exception("XID overflow", ZSESSIONEXPIRED);
         }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix


Short description (up to few sentences):

Zookeeper operation will blocked in deadlock state when xid == close_xid.


Detailed description (optional):

- Reason

In **ZooKeeper::sendThread()**，request info with xid equal to close_xid  is not stored in operations, then the callback in the request is lost. The thread waiting for the callback done will wait forever.
```
if (info.request->xid != close_xid)
{
    CurrentMetrics::add(CurrentMetrics::ZooKeeperRequest);
    std::lock_guard lock(operations_mutex);
    operations[info.request->xid] = info;
}
```

So we should protect the xid of normal request must not equal to close_xid. So I add a guarantee in the **ZooKeeper::pushRequest()**

```
if (info.request->xid == close_xid)
     throw Exception("xid equal to close_xid", ZSESSIONEXPIRED);
```

 
- My Test

My test version is **Stable 19.1.14**

After modify the code, the case described above occurred. The log is as follows 
```
<Error> adshonor.unlocked_201905311300 (StorageReplicatedMergeTree): void DB::StorageReplicatedMergeTree::mergeSelectingTask(): Code: 999, e.displayText() = Coordination::Exception: xid equal to close_xid (Session expired), e.what() = Coordination::Exception, Stack trace:
```


- How I found it

This problem may cause other serious problem such as readonly-state table.
I my case, I found some table  occasionally in readonly state and they can not recover automatically.
The issue is [5014](https://github.com/yandex/ClickHouse/issues/5014)

 After I analysis the stack of background schedule thread, I found two thread are blocked all the time and can not continue.

```
#1  0x000000000677856c in __gthread_cond_wait (__mutex=<optimized out>, __cond=__cond@entry=0x7f4e901ed1e0) at /data/home/linceyou/code/ClickHouse/ci/workspace/gcc/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/include/x86_64-pc-linux-gnu/bits/gthr-default.h:864
#2  std::condition_variable::wait (this=this@entry=0x7f4e901ed1e0, __lock=...) at ../../../../../gcc-8.3.0/libstdc++-v3/src/c++11/condition_variable.cc:53
#3  0x00000000060db72c in wait<Poco::Event::wait()::<lambda()> > (__p=..., __lock=..., this=0x7f4e901ed1e0) at /data/home/linceyou/code/ClickHouse/contrib/poco/Foundation/src/Event.cpp:79
#4  Poco::Event::wait() () at /data/home/linceyou/code/ClickHouse/contrib/poco/Foundation/src/Event.cpp:79
#5  0x00000000053c73d3 in zkutil::ZooKeeper::existsImpl(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Coordination::Stat*, std::function<void (Coordination::WatchResponse const&)>) () at /data/home/linceyou/code/ClickHouse/dbms/src/Common/ZooKeeper/ZooKeeper.cpp:360
#6  0x00000000053c7444 in zkutil::ZooKeeper::existsWatch(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Coordination::Stat*, std::function<void (Coordination::WatchResponse const&)>) () at /data/home/linceyou/code/ClickHouse/dbms/src/Common/ZooKeeper/ZooKeeper.cpp:371
#7  0x00000000053c92c4 in zkutil::ZooKeeper::exists(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Coordination::Stat*, std::shared_ptr<Poco::Event> const&) () at /data/home/linceyou/code/ClickHouse/dbms/src/Common/ZooKeeper/ZooKeeper.cpp:366
#8  0x00000000050eb01b in DB::ReplicatedMergeTreeCleanupThread::clearOldLogs() () at /data/home/linceyou/code/ClickHouse/dbms/src/Storages/MergeTree/ReplicatedMergeTreeCleanupThread.cpp:75
#9  0x00000000050ec8d8 in iterate (this=0x7f4e704d5d50) at /data/home/linceyou/code/ClickHouse/dbms/src/Storages/MergeTree/ReplicatedMergeTreeCleanupThread.cpp:63
#10 iterate (this=0x7f4e704d5d50) at /data/home/linceyou/code/ClickHouse/dbms/src/Storages/MergeTree/ReplicatedMergeTreeCleanupThread.cpp:54
```   

```
#0  0x00007f4f79e7542d in __lll_lock_wait () from /lib64/libpthread.so.0
#1  0x00007f4f79e70dcb in _L_lock_812 () from /lib64/libpthread.so.0
#2  0x00007f4f79e70c98 in pthread_mutex_lock () from /lib64/libpthread.so.0
#3  0x000000000519ec1a in __gthread_mutex_lock (__mutex=0x7f4e7038da68) at /usr/local/include/c++/8.3.0/x86_64-pc-linux-gnu/bits/gthr-default.h:748
#4  lock (this=0x7f4e7038da68) at /usr/local/include/c++/8.3.0/bits/std_mutex.h:103
#5  lock_guard (__m=..., this=<synthetic pointer>) at /usr/local/include/c++/8.3.0/bits/std_mutex.h:162
#6  DB::BackgroundSchedulePool::TaskInfo::deactivate() () at /data/home/linceyou/code/ClickHouse/dbms/src/Core/BackgroundSchedulePool.cpp:63
#7  0x0000000005114796 in stop (this=<optimized out>) at /data/home/linceyou/code/ClickHouse/dbms/src/Core/BackgroundSchedulePool.h:107
#8  DB::ReplicatedMergeTreeRestartingThread::partialShutdown() () at /data/home/linceyou/code/ClickHouse/dbms/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp:365
#9  0x0000000005115de0 in DB::ReplicatedMergeTreeRestartingThread::run() () at /data/home/linceyou/code/ClickHouse/dbms/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp:80
#10 0x00000000051a0b2d in operator() (this=0x7f4e7038dce8) at /usr/local/include/c++/8.3.0/bits/std_function.h:260
#11 DB::BackgroundSchedulePool::TaskInfo::execute() () at /data/home/linceyou/code/ClickHouse/dbms/src/Core/BackgroundSchedulePool.cpp:111
```

In this case,  **deactivate()** can not acquire the lock because another thread having the lock is waiting for zookeeper callback all the time.


