### PR TITLE
Fix SimpleAggregateFunction for String longer MAX_SMALL_STRING_SIZE

### DIFF
--- a/dbms/src/AggregateFunctions/AggregateFunctionArgMinMax.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionArgMinMax.h
@@ -27,8 +27,8 @@ struct AggregateFunctionArgMinMaxData
 };
 
 /// Returns the first arg value found for the minimum/maximum value. Example: argMax(arg, value).
-template <typename Data>
-class AggregateFunctionArgMinMax final : public IAggregateFunctionDataHelper<Data, AggregateFunctionArgMinMax<Data>>
+template <typename Data, bool AllocatesMemoryInArena>
+class AggregateFunctionArgMinMax final : public IAggregateFunctionDataHelper<Data, AggregateFunctionArgMinMax<Data, AllocatesMemoryInArena>>
 {
 private:
     const DataTypePtr & type_res;
@@ -36,7 +36,7 @@ private:
 
 public:
     AggregateFunctionArgMinMax(const DataTypePtr & type_res, const DataTypePtr & type_val)
-        : IAggregateFunctionDataHelper<Data, AggregateFunctionArgMinMax<Data>>({type_res, type_val}, {}),
+        : IAggregateFunctionDataHelper<Data, AggregateFunctionArgMinMax<Data, AllocatesMemoryInArena>>({type_res, type_val}, {}),
         type_res(this->argument_types[0]), type_val(this->argument_types[1])
     {
         if (!type_val->isComparable())
@@ -73,6 +73,11 @@ public:
     {
         this->data(place).result.read(buf, *type_res, arena);
         this->data(place).value.read(buf, *type_val, arena);
+    }
+
+    bool allocatesMemoryInArena() const override
+    {
+        return AllocatesMemoryInArena;
     }
 
     void insertResultInto(ConstAggregateDataPtr place, IColumn & to) const override

--- a/dbms/src/AggregateFunctions/AggregateFunctionMinMaxAny.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionMinMaxAny.h
@@ -672,15 +672,15 @@ struct AggregateFunctionAnyHeavyData : Data
 };
 
 
-template <typename Data>
-class AggregateFunctionsSingleValue final : public IAggregateFunctionDataHelper<Data, AggregateFunctionsSingleValue<Data>>
+template <typename Data, bool AllocatesMemoryInArena>
+class AggregateFunctionsSingleValue final : public IAggregateFunctionDataHelper<Data, AggregateFunctionsSingleValue<Data, AllocatesMemoryInArena>>
 {
 private:
     DataTypePtr & type;
 
 public:
     AggregateFunctionsSingleValue(const DataTypePtr & type)
-        : IAggregateFunctionDataHelper<Data, AggregateFunctionsSingleValue<Data>>({type}, {})
+        : IAggregateFunctionDataHelper<Data, AggregateFunctionsSingleValue<Data, AllocatesMemoryInArena>>({type}, {})
         , type(this->argument_types[0])
     {
         if (StringRef(Data::name()) == StringRef("min")
@@ -717,6 +717,11 @@ public:
     void deserialize(AggregateDataPtr place, ReadBuffer & buf, Arena * arena) const override
     {
         this->data(place).read(buf, *type.get(), arena);
+    }
+
+    bool allocatesMemoryInArena() const override
+    {
+        return AllocatesMemoryInArena;
     }
 
     void insertResultInto(ConstAggregateDataPtr place, IColumn & to) const override

--- a/dbms/src/AggregateFunctions/HelpersMinMaxAny.h
+++ b/dbms/src/AggregateFunctions/HelpersMinMaxAny.h
@@ -14,7 +14,7 @@ namespace DB
 {
 
 /// min, max, any, anyLast
-template <template <typename> class AggregateFunctionTemplate, template <typename> class Data>
+template <template <typename, bool> class AggregateFunctionTemplate, template <typename> class Data>
 static IAggregateFunction * createAggregateFunctionSingleValue(const String & name, const DataTypes & argument_types, const Array & parameters)
 {
     assertNoParameters(name, parameters);
@@ -24,18 +24,18 @@ static IAggregateFunction * createAggregateFunctionSingleValue(const String & na
 
     WhichDataType which(argument_type);
 #define DISPATCH(TYPE) \
-    if (which.idx == TypeIndex::TYPE) return new AggregateFunctionTemplate<Data<SingleValueDataFixed<TYPE>>>(argument_type);
+    if (which.idx == TypeIndex::TYPE) return new AggregateFunctionTemplate<Data<SingleValueDataFixed<TYPE>>, false>(argument_type);
     FOR_NUMERIC_TYPES(DISPATCH)
 #undef DISPATCH
 
     if (which.idx == TypeIndex::Date)
-        return new AggregateFunctionTemplate<Data<SingleValueDataFixed<DataTypeDate::FieldType>>>(argument_type);
+        return new AggregateFunctionTemplate<Data<SingleValueDataFixed<DataTypeDate::FieldType>>, false>(argument_type);
     if (which.idx == TypeIndex::DateTime)
-        return new AggregateFunctionTemplate<Data<SingleValueDataFixed<DataTypeDateTime::FieldType>>>(argument_type);
+        return new AggregateFunctionTemplate<Data<SingleValueDataFixed<DataTypeDateTime::FieldType>>, false>(argument_type);
     if (which.idx == TypeIndex::String)
-        return new AggregateFunctionTemplate<Data<SingleValueDataString>>(argument_type);
+        return new AggregateFunctionTemplate<Data<SingleValueDataString>, true>(argument_type);
 
-    return new AggregateFunctionTemplate<Data<SingleValueDataGeneric>>(argument_type);
+    return new AggregateFunctionTemplate<Data<SingleValueDataGeneric>, false>(argument_type);
 }
 
 
@@ -46,18 +46,18 @@ static IAggregateFunction * createAggregateFunctionArgMinMaxSecond(const DataTyp
     WhichDataType which(val_type);
 #define DISPATCH(TYPE) \
     if (which.idx == TypeIndex::TYPE) \
-        return new AggregateFunctionArgMinMax<AggregateFunctionArgMinMaxData<ResData, MinMaxData<SingleValueDataFixed<TYPE>>>>(res_type, val_type);
+        return new AggregateFunctionArgMinMax<AggregateFunctionArgMinMaxData<ResData, MinMaxData<SingleValueDataFixed<TYPE>>>, false>(res_type, val_type);
     FOR_NUMERIC_TYPES(DISPATCH)
 #undef DISPATCH
 
     if (which.idx == TypeIndex::Date)
-        return new AggregateFunctionArgMinMax<AggregateFunctionArgMinMaxData<ResData, MinMaxData<SingleValueDataFixed<DataTypeDate::FieldType>>>>(res_type, val_type);
+        return new AggregateFunctionArgMinMax<AggregateFunctionArgMinMaxData<ResData, MinMaxData<SingleValueDataFixed<DataTypeDate::FieldType>>>, false>(res_type, val_type);
     if (which.idx == TypeIndex::DateTime)
-        return new AggregateFunctionArgMinMax<AggregateFunctionArgMinMaxData<ResData, MinMaxData<SingleValueDataFixed<DataTypeDateTime::FieldType>>>>(res_type, val_type);
+        return new AggregateFunctionArgMinMax<AggregateFunctionArgMinMaxData<ResData, MinMaxData<SingleValueDataFixed<DataTypeDateTime::FieldType>>>, false>(res_type, val_type);
     if (which.idx == TypeIndex::String)
-        return new AggregateFunctionArgMinMax<AggregateFunctionArgMinMaxData<ResData, MinMaxData<SingleValueDataString>>>(res_type, val_type);
+        return new AggregateFunctionArgMinMax<AggregateFunctionArgMinMaxData<ResData, MinMaxData<SingleValueDataString>>, true>(res_type, val_type);
 
-    return new AggregateFunctionArgMinMax<AggregateFunctionArgMinMaxData<ResData, MinMaxData<SingleValueDataGeneric>>>(res_type, val_type);
+    return new AggregateFunctionArgMinMax<AggregateFunctionArgMinMaxData<ResData, MinMaxData<SingleValueDataGeneric>>, false>(res_type, val_type);
 }
 
 template <template <typename> class MinMaxData>

--- a/dbms/src/DataStreams/AggregatingSortedBlockInputStream.cpp
+++ b/dbms/src/DataStreams/AggregatingSortedBlockInputStream.cpp
@@ -47,6 +47,9 @@ AggregatingSortedBlockInputStream::AggregatingSortedBlockInputStream(
         {
             // simple aggregate function
             SimpleAggregateDescription desc{simple_aggr->getFunction(), i};
+            if (desc.function->allocatesMemoryInArena())
+                allocatesMemoryInArena = true;
+
             columns_to_simple_aggregate.emplace_back(std::move(desc));
         }
         else
@@ -135,7 +138,8 @@ void AggregatingSortedBlockInputStream::merge(MutableColumns & merged_columns, s
             for (auto & desc : columns_to_simple_aggregate)
                 desc.createState();
 
-            arena = std::make_unique<Arena>();
+            if (allocatesMemoryInArena)
+                arena = std::make_unique<Arena>();
 
             ++merged_rows;
         }

--- a/dbms/src/DataStreams/AggregatingSortedBlockInputStream.cpp
+++ b/dbms/src/DataStreams/AggregatingSortedBlockInputStream.cpp
@@ -1,6 +1,7 @@
 #include <DataStreams/AggregatingSortedBlockInputStream.h>
 #include <Common/typeid_cast.h>
 #include <Common/StringUtils/StringUtils.h>
+#include <Common/Arena.h>
 #include <DataTypes/DataTypeAggregateFunction.h>
 #include <DataTypes/DataTypeCustomSimpleAggregateFunction.h>
 
@@ -134,6 +135,8 @@ void AggregatingSortedBlockInputStream::merge(MutableColumns & merged_columns, s
             for (auto & desc : columns_to_simple_aggregate)
                 desc.createState();
 
+            arena = std::make_unique<Arena>();
+
             ++merged_rows;
         }
 
@@ -169,7 +172,7 @@ void AggregatingSortedBlockInputStream::addRow(SortCursor & cursor)
     for (auto & desc : columns_to_simple_aggregate)
     {
         auto & col = cursor->all_columns[desc.column_number];
-        desc.add_function(desc.function.get(), desc.state.data(), &col, cursor->pos, nullptr);
+        desc.add_function(desc.function.get(), desc.state.data(), &col, cursor->pos, arena.get());
     }
 }
 

--- a/dbms/src/DataStreams/AggregatingSortedBlockInputStream.h
+++ b/dbms/src/DataStreams/AggregatingSortedBlockInputStream.h
@@ -66,7 +66,10 @@ private:
      */
     void insertSimpleAggregationResult(MutableColumns & merged_columns);
 
-    /// Memory pool for SimpleAggregateFunction.
+    /// Does SimpleAggregateFunction allocates memory in arena?
+    bool allocatesMemoryInArena = false;
+    /// Memory pool for SimpleAggregateFunction
+    /// (only when allocatesMemoryInArena == true).
     std::unique_ptr<Arena> arena;
 
     /// Stores information for aggregation of SimpleAggregateFunction columns

--- a/dbms/src/DataStreams/AggregatingSortedBlockInputStream.h
+++ b/dbms/src/DataStreams/AggregatingSortedBlockInputStream.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <common/logger_useful.h>
+#include <memory>
 
 #include <Core/Row.h>
 #include <Core/ColumnNumbers.h>
@@ -12,6 +13,8 @@
 
 namespace DB
 {
+
+class Arena;
 
 /** Merges several sorted streams to one.
   * During this for each group of consecutive identical values of the primary key (the columns by which the data is sorted),
@@ -62,6 +65,9 @@ private:
     /** Insert all values of current row for simple aggregate functions
      */
     void insertSimpleAggregationResult(MutableColumns & merged_columns);
+
+    /// Memory pool for SimpleAggregateFunction.
+    std::unique_ptr<Arena> arena;
 
     /// Stores information for aggregation of SimpleAggregateFunction columns
     struct SimpleAggregateDescription

--- a/dbms/tests/queries/0_stateless/00915_simple_aggregate_function.reference
+++ b/dbms/tests/queries/0_stateless/00915_simple_aggregate_function.reference
@@ -40,4 +40,5 @@ SimpleAggregateFunction(sum, Float64)
 8	16
 9	18
 1	1	2	2.2.2.2
+10	2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222	20	20.20.20.20
 SimpleAggregateFunction(anyLast, Nullable(String))	SimpleAggregateFunction(anyLast, LowCardinality(Nullable(String)))	SimpleAggregateFunction(anyLast, IPv4)

--- a/dbms/tests/queries/0_stateless/00915_simple_aggregate_function.sql
+++ b/dbms/tests/queries/0_stateless/00915_simple_aggregate_function.sql
@@ -22,6 +22,9 @@ drop table if exists test.simple;
 create table test.simple (id UInt64,nullable_str SimpleAggregateFunction(anyLast,Nullable(String)),low_str SimpleAggregateFunction(anyLast,LowCardinality(Nullable(String))),ip SimpleAggregateFunction(anyLast,IPv4)) engine=AggregatingMergeTree order by id;
 insert into test.simple values(1,'1','1','1.1.1.1');
 insert into test.simple values(1,null,'2','2.2.2.2');
+-- String longer then MAX_SMALL_STRING_SIZE (actual string length is 100)
+insert into test.simple values(10,'10','10','10.10.10.10');
+insert into test.simple values(10,'2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222','20','20.20.20.20');
 
 select * from test.simple final;
 select toTypeName(nullable_str),toTypeName(low_str),toTypeName(ip) from test.simple limit 1;


### PR DESCRIPTION
SimpleAggregateFunction do not pass arena to the
add_function -> getAddressOfAddFunction(), hence next crash happens:
```
  (gdb) bt
  #0  DB::Arena::alloc (size=64, this=0x0) at ../dbms/src/Common/Arena.h:124
  #1  DB::SingleValueDataString::changeImpl (this=0x7f97424a27d8, value=..., arena=0x0) at ../dbms/src/AggregateFunctions/AggregateFunctionMinMaxAny.h:274
  #2  0x0000000005ea5319 in DB::AggregateFunctionNullUnary<true>::add (arena=<optimized out>, row_num=<optimized out>, columns=<optimized out>, place=<optimized out>, this=<optimized out>) at ../dbms/src/AggregateFunctions/AggregateFunctionNull.h:43
  #3  DB::IAggregateFunctionHelper<DB::AggregateFunctionNullUnary<true> >::addFree (that=<optimized out>, place=<optimized out>, columns=<optimized out>, row_num=<optimized out>, arena=<optimized out>) at ../dbms/src/AggregateFunctions/IAggregateFunction.h:131
  #4  0x000000000679772f in DB::AggregatingSortedBlockInputStream::addRow (this=this@entry=0x7f982de19c00, cursor=...) at ../dbms/src/Common/AlignedBuffer.h:31
  #5  0x0000000006797faa in DB::AggregatingSortedBlockInputStream::merge (this=this@entry=0x7f982de19c00, merged_columns=..., queue=...) at ../dbms/src/DataStreams/AggregatingSortedBlockInputStream.cpp:140
  #6  0x0000000006798979 in DB::AggregatingSortedBlockInputStream::readImpl (this=0x7f982de19c00) at ../dbms/src/DataStreams/AggregatingSortedBlockInputStream.cpp:78
  #7  0x000000000622db55 in DB::IBlockInputStream::read (this=0x7f982de19c00) at ../dbms/src/DataStreams/IBlockInputStream.cpp:56
  #8  0x0000000006613bee in DB::MergeTreeDataMergerMutator::mergePartsToTemporaryPart (this=this@entry=0x7f97ec65e1a0, future_part=..., merge_entry=..., time_of_merge=<optimized out>, disk_reservation=<optimized out>, deduplicate=<optimized out>) at /usr/include/c++/8/bits/shared_ptr_base.h:1018
  #9  0x000000000658f7a4 in DB::StorageReplicatedMergeTree::tryExecuteMerge (this=0x7f97ec65b810, entry=...) at /usr/include/c++/8/bits/unique_ptr.h:342
  #10 0x00000000065940ab in DB::StorageReplicatedMergeTree::executeLogEntry (this=0x7f97ec65b810, entry=...) at ../dbms/src/Storages/StorageReplicatedMergeTree.cpp:910
  <snip>

  (gdb) f 1
  (gdb) p MAX_SMALL_STRING_SIZE
  $1 = 48
  (gdb) p capacity
  $2 = 64
  (gdb) p value
  $3 = {data = 0x7f97242fcbd0 "HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH", size = 61}
```

Fixes: 8f8d2c048e ("Merge pull request #4629 from bgranvea/simple_aggregate_function")

Category (leave one):
- Bug Fix