### PR TITLE
Several improvements in integration tests runner

### DIFF
--- a/dbms/tests/integration/README.md
+++ b/dbms/tests/integration/README.md
@@ -43,7 +43,7 @@ Notes:
 
 You can run tests via `./runner` script and pass pytest arguments as last arg:
 ```
-$ ./runner --binary $HOME/ClickHouse/dbms/programs/clickhouse --configs-dir $HOME/ClickHouse/dbms/programs/server/ 'test_odbc_interaction -ss'
+$ ./runner --binary $HOME/ClickHouse/dbms/programs/clickhouse  --bridge-binary $HOME/ClickHouse/dbms/programs/clickhouse-odbc-bridge --configs-dir $HOME/ClickHouse/dbms/programs/server/ 'test_odbc_interaction -ss'
 Start tests
 ============================= test session starts ==============================
 platform linux2 -- Python 2.7.15rc1, pytest-4.0.0, py-1.7.0, pluggy-0.8.0
@@ -69,7 +69,9 @@ Path to binary and configs maybe specified via env variables:
 ```
 $ export CLICKHOUSE_TESTS_BASE_CONFIG_DIR=$HOME/ClickHouse/dbms/programs/server/
 $ export CLICKHOUSE_TESTS_SERVER_BIN_PATH=$HOME/ClickHouse/dbms/programs/clickhouse
+$ export CLICKHOUSE_TESTS_ODBC_BRIDGE_BIN_PATH=$HOME/ClickHouse/dbms/programs/clickhouse-odbc-bridge
 $ ./runner 'test_odbc_interaction'
+$ # or ./runner '-v -ss'
 Start tests
 ============================= test session starts ==============================
 platform linux2 -- Python 2.7.15rc1, pytest-4.0.0, py-1.7.0, pluggy-0.8.0
@@ -79,6 +81,9 @@ collected 6 items
 test_odbc_interaction/test.py ......                                     [100%]
 ==================== 6 passed, 1 warnings in 96.33 seconds =====================
 ```
+
+You can just open shell inside a container by overwritting the command:
+./runner --command=bash
 
 ### Adding new tests
 

--- a/dbms/tests/integration/image/Dockerfile
+++ b/dbms/tests/integration/image/Dockerfile
@@ -20,7 +20,9 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install --yes -
     libreadline-dev \
     libicu-dev \
     bsdutils \
-    curl
+    curl \
+    llvm-6.0 \
+    llvm-6.0-dev
 
 ENV TZ=Europe/Moscow
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
@@ -29,6 +31,12 @@ RUN pip install pytest docker-compose==1.22.0 docker dicttoxml kazoo PyMySQL psy
 
 ENV DOCKER_CHANNEL stable
 ENV DOCKER_VERSION 17.09.1-ce
+
+ENV TSAN_OPTIONS 'halt_on_error=1 history_size=7'
+ENV UBSAN_OPTIONS 'print_stacktrace=1'
+ENV ASAN_SYMBOLIZER_PATH /usr/lib/llvm-6.0/bin/llvm-symbolizer
+ENV UBSAN_SYMBOLIZER_PATH /usr/lib/llvm-6.0/bin/llvm-symbolizer
+ENV LLVM_SYMBOLIZER_PATH /usr/lib/llvm-6.0/bin/llvm-symbolizer
 
 RUN set -eux; \
 	\
@@ -62,4 +70,5 @@ RUN set -x \
 VOLUME /var/lib/docker
 EXPOSE 2375
 ENTRYPOINT ["dockerd-entrypoint.sh"]
-CMD []
+CMD ["sh", "-c", "pytest $PYTEST_OPTS"]
+

--- a/dbms/tests/integration/image/dockerd-entrypoint.sh
+++ b/dbms/tests/integration/image/dockerd-entrypoint.sh
@@ -3,7 +3,18 @@ set -e
 
 dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2375 &>/var/log/somefile &
 
-sleep 3 # to actual start
+set +e
+reties=0
+while true; do
+    docker info &>/dev/null && break
+    reties=$[$reties+1]
+    if [[ $reties -ge 100 ]]; then # 10 sec max
+        echo "Can't start docker daemon, timeout exceeded." >&2
+        exit 1;
+    fi
+    sleep 0.1
+done
+set -e
 
 echo "Start tests"
 export CLICKHOUSE_TESTS_SERVER_BIN_PATH=/clickhouse
@@ -11,4 +22,5 @@ export CLICKHOUSE_TESTS_CLIENT_BIN_PATH=/clickhouse
 export CLICKHOUSE_TESTS_BASE_CONFIG_DIR=/clickhouse-config
 export CLICKHOUSE_ODBC_BRIDGE_BINARY_PATH=/clickhouse-odbc-bridge
 
-cd /ClickHouse/dbms/tests/integration && pytest $PYTEST_OPTS
+cd /ClickHouse/dbms/tests/integration
+exec "$@"

--- a/dbms/tests/integration/runner
+++ b/dbms/tests/integration/runner
@@ -7,6 +7,7 @@ import argparse
 import logging
 import signal
 import subprocess
+import sys
 
 CUR_FILE_DIR = os.path.dirname(os.path.realpath(__file__))
 DEFAULT_CLICKHOUSE_ROOT = os.path.abspath(os.path.join(CUR_FILE_DIR, "../../../"))
@@ -86,9 +87,15 @@ if __name__ == "__main__":
     # should be removed manually when not needed
     subprocess.check_call('docker volume create {name}_volume'.format(name=CONTAINER_NAME), shell=True)
 
-    cmd = "docker run {net} -it --rm --name {name} --privileged --volume={bridge_bin}:/clickhouse-odbc-bridge --volume={bin}:/clickhouse \
+    # enable tty mode & interactive for docker if we have real tty
+    tty = ""
+    if sys.stdout.isatty() and sys.stdin.isatty():
+        tty = "-it"
+
+    cmd = "docker run {net} {tty} --rm --name {name} --privileged --volume={bridge_bin}:/clickhouse-odbc-bridge --volume={bin}:/clickhouse \
         --volume={cfg}:/clickhouse-config --volume={pth}:/ClickHouse --volume={name}_volume:/var/lib/docker -e PYTEST_OPTS='{opts}' {img} {command}".format(
         net=net,
+        tty=tty,
         bin=args.binary,
         bridge_bin=args.bridge_binary,
         cfg=args.configs_dir,

--- a/dbms/tests/integration/runner
+++ b/dbms/tests/integration/runner
@@ -29,15 +29,8 @@ def check_args_and_update_paths(args):
         if not os.path.exists(path):
             raise Exception("Path {} doesn't exists".format(path))
 
-def try_rm_image():
-    try:
-        subprocess.check_call('docker rm {name}'.format(name=CONTAINER_NAME), shell=True)
-    except:
-        pass
-
 def docker_kill_handler_handler(signum, frame):
     subprocess.check_call('docker kill $(docker ps -a -q --filter name={name} --format="{{{{.ID}}}}")'.format(name=CONTAINER_NAME), shell=True)
-    try_rm_image()
     raise KeyboardInterrupt("Killed by Ctrl+C")
 
 signal.signal(signal.SIGINT, docker_kill_handler_handler)
@@ -67,6 +60,11 @@ if __name__ == "__main__":
         help="Path to repository root folder")
 
     parser.add_argument(
+        "--command",
+        default='',
+        help="Set it to run some other command in container (for example bash)")
+
+    parser.add_argument(
         "--disable-net-host",
         action='store_true',
         default=False,
@@ -82,8 +80,14 @@ if __name__ == "__main__":
     if not args.disable_net_host:
         net = "--net=host"
 
-    cmd = "docker run {net} --name {name} --user={user} --privileged --volume={bridge_bin}:/clickhouse-odbc-bridge --volume={bin}:/clickhouse \
-        --volume={cfg}:/clickhouse-config --volume={pth}:/ClickHouse -e PYTEST_OPTS='{opts}' {img} ".format(
+    # create named volume which will be used inside to store images and other docker related files,
+    # to avoid redownloading it every time
+    #
+    # should be removed manually when not needed
+    subprocess.check_call('docker volume create {name}_volume'.format(name=CONTAINER_NAME), shell=True)
+
+    cmd = "docker run {net} -it --rm --name {name} --privileged --volume={bridge_bin}:/clickhouse-odbc-bridge --volume={bin}:/clickhouse \
+        --volume={cfg}:/clickhouse-config --volume={pth}:/ClickHouse --volume={name}_volume:/var/lib/docker -e PYTEST_OPTS='{opts}' {img} {command}".format(
         net=net,
         bin=args.binary,
         bridge_bin=args.bridge_binary,
@@ -91,11 +95,9 @@ if __name__ == "__main__":
         pth=args.clickhouse_root,
         opts=' '.join(args.pytest_args),
         img=DIND_INTEGRATION_TESTS_IMAGE_NAME,
-        user=getpass.getuser(),
         name=CONTAINER_NAME,
+        command=args.command
     )
 
-    try:
-        subprocess.check_call(cmd, shell=True)
-    finally:
-        try_rm_image()
+    #print(cmd)
+    subprocess.check_call(cmd, shell=True)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Make runner script more usable.

Detailed description (optional):
1) automatic container removal with --rm flag
2) named persistent volume for internal docker (to avoid redownloading images on each run)
3) in the container root user is used (can't make it work otherwise)
4) allow to run other command in test container (bash for example)
5) --bridge-binary added to README
6) added llvm & symbolizer path 
7) run docker as interactive & tty 
8) more intelligent waiting for docker daemon
