### PR TITLE
clickhouse-test improvements

### DIFF
--- a/dbms/tests/clickhouse-test
+++ b/dbms/tests/clickhouse-test
@@ -100,7 +100,7 @@ def print_err(*args):
 def report_failure(name, msg):
     print(msg)
     # If stderr is not the same as stdout, duplicate the test name there.
-    if os.fstat(0) != os.fstat(1):
+    if os.fstat(2) != os.fstat(1):
         print_err(name, ":", msg)
 
 SERVER_DIED = False

--- a/dbms/tests/clickhouse-test
+++ b/dbms/tests/clickhouse-test
@@ -94,6 +94,14 @@ def colored(text, args, color=None, on_color=None, attrs=None):
        else:
            return text
 
+def print_err(*args):
+    sys.stderr.write(' '.join(map(str,args)) + '\n')
+
+def report_failure(name, msg):
+    print(msg)
+    # If stderr is not the same as stdout, duplicate the test name there.
+    if os.fstat(0) != os.fstat(1):
+        print_err(name, ":", msg)
 
 SERVER_DIED = False
 exit_code = 0
@@ -171,7 +179,7 @@ def run_tests_array(all_tests_with_params):
                                 raise
 
                         failures += 1
-                        print("{0} - Timeout!".format(MSG_FAIL))
+                        report_failure(name, "{0} - Timeout!".format(MSG_FAIL))
                     else:
                         counter = 1
                         while proc.returncode != 0 and need_retry(stderr):
@@ -184,10 +192,10 @@ def run_tests_array(all_tests_with_params):
                         if proc.returncode != 0:
                             failures += 1
                             failures_chain += 1
-                            print("{0} - return code {1}".format(MSG_FAIL, proc.returncode))
+                            report_failure(name, "{0} - return code {1}".format(MSG_FAIL, proc.returncode))
 
                             if stderr:
-                                print(stderr.encode('utf-8'))
+                                print_err(stderr.encode('utf-8'))
 
                             if args.stop and ('Connection refused' in stderr or 'Attempt to read after eof' in stderr) and not 'Received exception from server' in stderr:
                                 SERVER_DIED = True
@@ -195,20 +203,20 @@ def run_tests_array(all_tests_with_params):
                         elif stderr:
                             failures += 1
                             failures_chain += 1
-                            print("{0} - having stderror:\n{1}".format(MSG_FAIL, stderr.encode('utf-8')))
+                            report_failure(name, "{0} - having stderror:\n{1}".format(MSG_FAIL, stderr.encode('utf-8')))
                         elif 'Exception' in stdout:
                             failures += 1
                             failures_chain += 1
-                            print("{0} - having exception:\n{1}".format(MSG_FAIL, stdout.encode('utf-8')))
+                            report_failure(name, "{0} - having exception:\n{1}".format(MSG_FAIL, stdout.encode('utf-8')))
                         elif not os.path.isfile(reference_file):
-                            print("{0} - no reference file".format(MSG_UNKNOWN))
+                            report_failure(name, "{0} - no reference file".format(MSG_UNKNOWN))
                         else:
                             result_is_different = subprocess.call(['diff', '-q', reference_file, stdout_file], stdout = PIPE)
 
                             if result_is_different:
                                 diff = Popen(['diff', '--unified', reference_file, stdout_file], stdout = PIPE).communicate()[0]
                                 failures += 1
-                                print("{0} - result differs with reference:\n{1}".format(MSG_FAIL, diff))
+                                report_failure(name, "{0} - result differs with reference:\n{1}".format(MSG_FAIL, diff))
                             else:
                                 passed_total += 1
                                 failures_chain = 0
@@ -224,7 +232,7 @@ def run_tests_array(all_tests_with_params):
             import traceback
             exc_type, exc_value, tb = sys.exc_info()
             failures += 1
-            print("{0} - Test internal error: {1}\n{2}\n{3}".format(MSG_FAIL, exc_type.__name__, exc_value, "\n".join(traceback.format_tb(tb, 10))))
+            print_err("{0} - Test internal error: {1}\n{2}\n{3}".format(MSG_FAIL, exc_type.__name__, exc_value, "\n".join(traceback.format_tb(tb, 10))))
 
         if failures_chain >= 20:
             break
@@ -232,7 +240,7 @@ def run_tests_array(all_tests_with_params):
     failures_total = failures_total + failures
 
     if failures_total > 0:
-        print(colored("\nHaving {failures_total} errors! {passed_total} tests passed. {skipped_total} tests skipped.".format(passed_total = passed_total, skipped_total = skipped_total, failures_total = failures_total), args, "red", attrs=["bold"]))
+        print_err(colored("\nHaving {failures_total} errors! {passed_total} tests passed. {skipped_total} tests skipped.".format(passed_total = passed_total, skipped_total = skipped_total, failures_total = failures_total), args, "red", attrs=["bold"]))
         exit_code = 1
     else:
         print(colored("\n{passed_total} tests passed. {skipped_total} tests skipped.".format(passed_total = passed_total, skipped_total = skipped_total), args, "green", attrs=["bold"]))
@@ -388,11 +396,11 @@ def main(args):
         processlist = get_processlist(args.client_with_database)
         if processlist:
             server_pid = get_server_pid(os.getenv("CLICKHOUSE_PORT_TCP", '9000'))
-            print(colored("\nFound hung queries in processlist:", args, "red", attrs=["bold"]))
-            print(processlist)
+            print_err(colored("\nFound hung queries in processlist:", args, "red", attrs=["bold"]))
+            print_err(processlist)
             if server_pid:
-                print("\nStacktraces of all threads:")
-                print(get_stacktraces(server_pid))
+                print_err("\nStacktraces of all threads:")
+                print_err(get_stacktraces(server_pid))
             exit_code = 1
         else:
             print(colored("\nNo queries hung.", args, "green", attrs=["bold"]))

--- a/dbms/tests/clickhouse-test
+++ b/dbms/tests/clickhouse-test
@@ -148,7 +148,9 @@ def run_tests_array(all_tests_with_params):
             elif not args.zookeeper and 'zookeeper' in name:
                 print(MSG_SKIPPED + " - no zookeeper")
                 skipped_total += 1
-            elif not args.shard and 'shard' in name:
+            elif not args.shard and ('shard' in name
+                    or 'distributed' in name
+                    or 'global' in name):
                 print(MSG_SKIPPED + " - no shard")
                 skipped_total += 1
             elif not args.no_long and 'long' in name:

--- a/dbms/tests/clickhouse-test
+++ b/dbms/tests/clickhouse-test
@@ -463,6 +463,9 @@ if __name__ == '__main__':
             args.queries = '/usr/share/clickhouse-test/queries'
         if args.tmp is None:
             args.tmp = '/tmp/clickhouse-test'
+    if args.queries is None:
+        print_err("Failed to detect path to the queries directory. Please specify it with '--queries' option.")
+        exit(1)
     if args.tmp is None:
         args.tmp = args.queries
     if args.client is None:

--- a/docs/en/development/tests.md
+++ b/docs/en/development/tests.md
@@ -21,7 +21,12 @@ Tests should use (create, drop, etc) only tables in `test` database that is assu
 
 If you want to use distributed queries in functional tests, you can leverage `remote` table function with `127.0.0.{1..2}` addresses for the server to query itself; or you can use predefined test clusters in server configuration file like `test_shard_localhost`.
 
-Some tests are marked with `zookeeper`, `shard` or `long` in their names. `zookeeper` is for tests that are using ZooKeeper; `shard` is for tests that requires server to listen `127.0.0.*`; `long` is for tests that run slightly longer that one second.
+Some tests are marked with `zookeeper`, `shard` or `long` in their names.
+`zookeeper` is for tests that are using ZooKeeper. `shard` is for tests that
+requires server to listen `127.0.0.*`; `distributed` or `global` have the same
+meaning. `long` is for tests that run slightly longer that one second. You can
+disable these groups of tests using `--no-zookeeper`, `--no-shard` and
+`--no-long` options, respectively.
 
 
 ## Known bugs


### PR DESCRIPTION
- Build/Testing/Packaging Improvement

* Print error messages to stderr.
* Show an error message if we failed to find the queries dir.
* Treat 'distributed' and 'global' in test names as a synonym of 'shard', i.e. disable with --no-shard.