### PR TITLE
Better error message on checksum mismatch #5347

### DIFF
--- a/dbms/src/Compression/CompressedReadBufferBase.cpp
+++ b/dbms/src/Compression/CompressedReadBufferBase.cpp
@@ -37,7 +37,62 @@ namespace ErrorCodes
     extern const int CANNOT_DECOMPRESS;
 }
 
-static constexpr auto CHECKSUM_SIZE{sizeof(CityHash_v1_0_2::uint128)};
+using Checksum = CityHash_v1_0_2::uint128;
+static constexpr auto CHECKSUM_SIZE{sizeof(Checksum)};
+
+
+/// Validate checksum of data, and if it mismatches, find out possible reason and throw exception.
+static void validateChecksum(char * data, size_t size, const Checksum expected_checksum)
+{
+    auto calculated_checksum = CityHash_v1_0_2::CityHash128(data, size);
+    if (expected_checksum == calculated_checksum)
+        return;
+
+    std::stringstream message;
+
+    /// TODO mess up of endianess in error message.
+    message << "Checksum doesn't match: corrupted data."
+        " Reference: " + getHexUIntLowercase(expected_checksum.first) + getHexUIntLowercase(expected_checksum.second)
+        + ". Actual: " + getHexUIntLowercase(calculated_checksum.first) + getHexUIntLowercase(calculated_checksum.second)
+        + ". Size of compressed block: " + toString(size);
+
+    auto message_hardware_failure = "This is most likely due to hardware failure. If you receive broken data over network and the error does not repeat every time, this can be caused by bad RAM on network interface controller or bad controller itself or bad RAM on network switches or bad CPU on network switches (look at the logs on related network switches; note that TCP checksums don't help) or bad RAM on host (look at dmesg or kern.log for enormous amount of EDAC errors, ECC-related reports, Machine Check Exceptions, mcelog; note that ECC memory can fail if the number of errors is huge) or bad CPU on host. If you read data from disk, this can be caused by disk bit rott. This exception protects ClickHouse from data corruption due to hardware failures.";
+
+    auto flip_bit = [](char * buf, size_t pos)
+    {
+        buf[pos / 8] ^= 1 << pos % 8;
+    };
+
+    /// Check if the difference caused by single bit flip in data.
+    for (size_t bit_pos = 0; bit_pos < size * 8; ++bit_pos)
+    {
+        flip_bit(data, bit_pos);
+
+        auto checksum_of_data_with_flipped_bit = CityHash_v1_0_2::CityHash128(data, size);
+        if (expected_checksum == checksum_of_data_with_flipped_bit)
+        {
+            message << ". The mismatch is caused by single bit flip in data block at byte " << (bit_pos / 8) << ", bit " << (bit_pos % 8) << ". "
+                << message_hardware_failure;
+            throw Exception(message.str(), ErrorCodes::CHECKSUM_DOESNT_MATCH);
+        }
+
+        flip_bit(data, bit_pos);    /// Restore
+    }
+
+    /// Check if the difference caused by single bit flip in stored checksum.
+    size_t difference = __builtin_popcountll(expected_checksum.first ^ calculated_checksum.first)
+        + __builtin_popcountll(expected_checksum.second ^ calculated_checksum.second);
+
+    if (difference == 1)
+    {
+        message << ". The mismatch is caused by single bit flip in checksum. "
+            << message_hardware_failure;
+        throw Exception(message.str(), ErrorCodes::CHECKSUM_DOESNT_MATCH);
+    }
+
+    throw Exception(message.str(), ErrorCodes::CHECKSUM_DOESNT_MATCH);
+}
+
 
 /// Read compressed data into compressed_buffer. Get size of decompressed data from block header. Checksum if need.
 /// Returns number of compressed bytes read.
@@ -46,7 +101,7 @@ size_t CompressedReadBufferBase::readCompressedData(size_t & size_decompressed, 
     if (compressed_in->eof())
         return 0;
 
-    CityHash_v1_0_2::uint128 checksum;
+    Checksum checksum;
     compressed_in->readStrict(reinterpret_cast<char *>(&checksum), CHECKSUM_SIZE);
 
     UInt8 header_size = ICompressionCodec::getHeaderSize();
@@ -91,16 +146,7 @@ size_t CompressedReadBufferBase::readCompressedData(size_t & size_decompressed, 
     }
 
     if (!disable_checksum)
-    {
-        auto checksum_calculated = CityHash_v1_0_2::CityHash128(compressed_buffer, size_compressed_without_checksum);
-        if (checksum != checksum_calculated)
-            throw Exception("Checksum doesn't match: corrupted data."
-                            " Reference: " + getHexUIntLowercase(checksum.first) + getHexUIntLowercase(checksum.second)
-                            + ". Actual: " + getHexUIntLowercase(checksum_calculated.first) + getHexUIntLowercase(checksum_calculated.second)
-                            + ". Size of compressed block: " + toString(size_compressed_without_checksum),
-                            ErrorCodes::CHECKSUM_DOESNT_MATCH);
-    }
-
+        validateChecksum(compressed_buffer, size_compressed_without_checksum, checksum);
 
     return size_compressed_without_checksum + CHECKSUM_SIZE;
 }

--- a/dbms/src/Compression/CompressedReadBufferBase.cpp
+++ b/dbms/src/Compression/CompressedReadBufferBase.cpp
@@ -38,7 +38,6 @@ namespace ErrorCodes
 }
 
 using Checksum = CityHash_v1_0_2::uint128;
-static constexpr auto CHECKSUM_SIZE{sizeof(Checksum)};
 
 
 /// Validate checksum of data, and if it mismatches, find out possible reason and throw exception.
@@ -102,7 +101,7 @@ size_t CompressedReadBufferBase::readCompressedData(size_t & size_decompressed, 
         return 0;
 
     Checksum checksum;
-    compressed_in->readStrict(reinterpret_cast<char *>(&checksum), CHECKSUM_SIZE);
+    compressed_in->readStrict(reinterpret_cast<char *>(&checksum), sizeof(Checksum));
 
     UInt8 header_size = ICompressionCodec::getHeaderSize();
     own_compressed_buffer.resize(header_size);
@@ -128,7 +127,7 @@ size_t CompressedReadBufferBase::readCompressedData(size_t & size_decompressed, 
                         + ". Most likely corrupted data.",
                         ErrorCodes::TOO_LARGE_SIZE_COMPRESSED);
 
-    ProfileEvents::increment(ProfileEvents::ReadCompressedBytes, size_compressed_without_checksum + CHECKSUM_SIZE);
+    ProfileEvents::increment(ProfileEvents::ReadCompressedBytes, size_compressed_without_checksum + sizeof(Checksum));
 
     /// Is whole compressed block located in 'compressed_in->' buffer?
     if (compressed_in->offset() >= header_size &&
@@ -148,7 +147,7 @@ size_t CompressedReadBufferBase::readCompressedData(size_t & size_decompressed, 
     if (!disable_checksum)
         validateChecksum(compressed_buffer, size_compressed_without_checksum, checksum);
 
-    return size_compressed_without_checksum + CHECKSUM_SIZE;
+    return size_compressed_without_checksum + sizeof(Checksum);
 }
 
 


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

Short description (up to few sentences):
Better error messages if checksum mismatch is most likely caused by hardware failures.

A test:
```
echo "Hello, world" | clickhouse-compressor | tr e d | clickhouse-compressor -d
```