### PR TITLE
more fixes for integration tests dockerfiles 

### DIFF
--- a/dbms/tests/integration/image/Dockerfile
+++ b/dbms/tests/integration/image/Dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:18.04
+# yandex/clickhouse-integration-tests-runner
 
-
-RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install --yes --force-yes \
+RUN apt-get update \
+    && env DEBIAN_FRONTEND=noninteractive apt-get install --yes \
     ca-certificates \
     bash \
     btrfs-progs \
@@ -21,8 +22,11 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install --yes -
     libicu-dev \
     bsdutils \
     curl \
-    llvm-6.0 \
-    llvm-6.0-dev
+    && rm -rf \
+        /var/lib/apt/lists/* \
+        /var/cache/debconf \
+        /tmp/* \
+    && apt-get clean
 
 ENV TZ=Europe/Moscow
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
@@ -31,12 +35,6 @@ RUN pip install pytest docker-compose==1.22.0 docker dicttoxml kazoo PyMySQL psy
 
 ENV DOCKER_CHANNEL stable
 ENV DOCKER_VERSION 17.09.1-ce
-
-ENV TSAN_OPTIONS 'halt_on_error=1 history_size=7'
-ENV UBSAN_OPTIONS 'print_stacktrace=1'
-ENV ASAN_SYMBOLIZER_PATH /usr/lib/llvm-6.0/bin/llvm-symbolizer
-ENV UBSAN_SYMBOLIZER_PATH /usr/lib/llvm-6.0/bin/llvm-symbolizer
-ENV LLVM_SYMBOLIZER_PATH /usr/lib/llvm-6.0/bin/llvm-symbolizer
 
 RUN set -eux; \
 	\

--- a/docker/test/integration/Dockerfile
+++ b/docker/test/integration/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update \
 ENV TZ=Europe/Moscow
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-ENV TSAN_OPTIONS 'halt_on_error=1 history_size=7'
-ENV UBSAN_OPTIONS 'print_stacktrace=1'
-ENV ASAN_SYMBOLIZER_PATH /usr/lib/llvm-6.0/bin/llvm-symbolizer
-ENV UBSAN_SYMBOLIZER_PATH /usr/lib/llvm-6.0/bin/llvm-symbolizer
-ENV LLVM_SYMBOLIZER_PATH /usr/lib/llvm-6.0/bin/llvm-symbolizer
+RUN echo "TSAN_OPTIONS='halt_on_error=1 history_size=7'" >> /etc/environment; \
+    echo "UBSAN_OPTIONS='print_stacktrace=1'" >> /etc/environment; \
+    echo "ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer" >> /etc/environment; \
+    echo "UBSAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer" >> /etc/environment; \
+    echo "LLVM_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer" >> /etc/environment;

--- a/docker/test/integration/Dockerfile
+++ b/docker/test/integration/Dockerfile
@@ -1,12 +1,19 @@
 FROM ubuntu:18.04
+# yandex/clickhouse-integration-test
 
-RUN apt-get update && apt-get -y install tzdata python llvm-6.0 llvm-6.0-dev
+RUN apt-get update \
+    && env DEBIAN_FRONTEND=noninteractive apt-get -y install tzdata python llvm-6.0 llvm-6.0-dev libreadline-dev libicu-dev bsdutils \
+    && rm -rf \
+        /var/lib/apt/lists/* \
+        /var/cache/debconf \
+        /tmp/* \
+    && apt-get clean
 
 ENV TZ=Europe/Moscow
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-CMD echo "TSAN_OPTIONS='halt_on_error=1 history_size=7'" >> /etc/environment;
-CMD echo "UBSAN_OPTIONS='print_stacktrace=1'" >> /etc/environment;
-CMD echo "ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer" >> /etc/environment;
-CMD echo "UBSAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer" >> /etc/environment;
-CMD echo "LLVM_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer" >> /etc/environment;
+ENV TSAN_OPTIONS 'halt_on_error=1 history_size=7'
+ENV UBSAN_OPTIONS 'print_stacktrace=1'
+ENV ASAN_SYMBOLIZER_PATH /usr/lib/llvm-6.0/bin/llvm-symbolizer
+ENV UBSAN_SYMBOLIZER_PATH /usr/lib/llvm-6.0/bin/llvm-symbolizer
+ENV LLVM_SYMBOLIZER_PATH /usr/lib/llvm-6.0/bin/llvm-symbolizer


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Some more test improvements after #5340

Detailed description (optional):

Dockerfile yandex/clickhouse-integration-test:
1) Properly set symbolizer env for docker image  
2) noninteractive mode (avoid questions about timezone)
3) add clickhouse deps 

Dockerfile yandex/clickhouse-integration-tests-runner:
1) Remove llvm & symbolizer (not needed here, clickhouse is executed in other container)
2) fix force-yes warning

Both: add cleanup after apt-get to reduce image size