### PR TITLE
replication: reset stale http pooled connections

### DIFF
--- a/dbms/src/IO/ReadWriteBufferFromHTTP.h
+++ b/dbms/src/IO/ReadWriteBufferFromHTTP.h
@@ -10,6 +10,7 @@
 #include <Poco/Net/HTTPClientSession.h>
 #include <Poco/Net/HTTPRequest.h>
 #include <Poco/Net/HTTPResponse.h>
+#include <Poco/Net/NetException.h>
 #include <Poco/URI.h>
 #include <Poco/Version.h>
 #include <Common/DNSResolver.h>
@@ -69,10 +70,23 @@ namespace detail
 
             LOG_TRACE((&Logger::get("ReadWriteBufferFromHTTP")), "Sending request to " << uri.toString());
 
-            auto & stream_out = session->sendRequest(request);
+            try
+            {
+                auto & stream_out = session->sendRequest(request);
+                if (out_stream_callback)
+                    out_stream_callback(stream_out);
+            }
+            catch (const Poco::Net::NetException & e)
+            {
+                auto log = &Logger::get("IOHTTP");
+                LOG_DEBUG(log, "reason: " << e.displayText());
+                session->reset();
+                // Retry once
+                auto & stream_out = session->sendRequest(request);
+                if (out_stream_callback)
+                    out_stream_callback(stream_out);
+            }
 
-            if (out_stream_callback)
-                out_stream_callback(stream_out);
 
             istr = receiveResponse(*session, request, response);
 


### PR DESCRIPTION
I don't have experience writing C++, but this is generally what I think needs to be happening.  I'd love some assistance to get this to build and eventually merged mainline.  Or if one of the contributors wants to just take it, that would be much appreciated as well!

Related to:
https://github.com/yandex/ClickHouse/issues/5287

According to the Poco docs, we should be resetting the connection when
sendRequest or readResponse throws.

https://pocoproject.org/docs/Poco.Net.HTTPClientSession.html#21613

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category:
- Bug Fix