### PR TITLE
session->setHost: Let the host resolve the address

### DIFF
--- a/dbms/src/IO/HTTPCommon.cpp
+++ b/dbms/src/IO/HTTPCommon.cpp
@@ -80,7 +80,7 @@ void setTimeouts(Poco::Net::HTTPClientSession & session, const ConnectionTimeout
 
         ProfileEvents::increment(ProfileEvents::CreatedHTTPConnections);
 
-        session->setHost(DNSResolver::instance().resolveHost(host).toString());
+        session->setHost(host);
         session->setPort(port);
 
         /// doesn't work properly without patch


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Fixes #5287 

Bug described here:
https://github.com/yandex/ClickHouse/issues/5287#issuecomment-495071521

Summarized here:
At startup, when we first connect to a hostname in the cluster, we allocate a pool for it.  That pool is keyed by the hostname in `HTTPSessionPool` but the pool itself is instantiated pointing to the IP address resolved by DNSResolver.  Since these never get recycled, when the DNS changes we still try to connect to the old IP address.  This fixes that issue.