### PR TITLE
Backport to 19.6: fix data race in rename query

### DIFF
--- a/dbms/src/Storages/StorageMergeTree.cpp
+++ b/dbms/src/Storages/StorageMergeTree.cpp
@@ -698,10 +698,10 @@ BackgroundProcessingPoolTaskResult StorageMergeTree::backgroundTask()
         /// Clear old parts. It is unnecessary to do it more than once a second.
         if (auto lock = time_after_previous_cleanup.compareAndRestartDeferred(1))
         {
-            data.clearOldPartsFromFilesystem();
             {
                 /// TODO: Implement tryLockStructureForShare.
                 auto lock_structure = lockStructureForShare(false, "");
+                data.clearOldPartsFromFilesystem();
                 data.clearOldTemporaryDirectories();
             }
             clearOldMutations();


### PR DESCRIPTION
Original pull-request #5247 

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en