### PR TITLE
Add StringHashMap to optimize string aggregation

### DIFF
--- a/dbms/src/Columns/ColumnArray.cpp
+++ b/dbms/src/Columns/ColumnArray.cpp
@@ -136,6 +136,8 @@ StringRef ColumnArray::getDataAt(size_t n) const
 
     size_t offset_of_first_elem = offsetAt(n);
     StringRef first = getData().getDataAtWithTerminatingZero(offset_of_first_elem);
+    if (reinterpret_cast<uintptr_t>(first.data) == 0xffffffffffffffff)
+        throw Exception("getDataAt returns a StringRef with -1 pointer", ErrorCodes::BAD_GET);
 
     size_t array_size = sizeAt(n);
     if (array_size == 0)

--- a/dbms/src/Columns/ColumnLowCardinality.cpp
+++ b/dbms/src/Columns/ColumnLowCardinality.cpp
@@ -32,7 +32,7 @@ namespace
         auto & data = res_col->getData();
 
         data.resize(hash_map.size());
-        for (auto val : hash_map)
+        for (const auto & val : hash_map)
             data[val.getSecond()] = val.getFirst();
 
         for (auto & ind : index)

--- a/dbms/src/Common/ColumnsHashing.h
+++ b/dbms/src/Common/ColumnsHashing.h
@@ -76,6 +76,7 @@ struct HashMethodString
 
     const IColumn::Offset * offsets;
     const UInt8 * chars;
+    static constexpr bool key_to_arena = place_string_to_arena;
 
     HashMethodString(const ColumnRawPtrs & key_columns, const Sizes & /*key_sizes*/, const HashMethodContextPtr &)
     {
@@ -94,15 +95,6 @@ struct HashMethodString
 
 protected:
     friend class columns_hashing_impl::HashMethodBase<Self, Value, Mapped, use_cache>;
-
-    static ALWAYS_INLINE void onNewKey([[maybe_unused]] StringRef & key, [[maybe_unused]] Arena & pool)
-    {
-        if constexpr (place_string_to_arena)
-        {
-            if (key.size)
-                key.data = pool.insert(key.data, key.size);
-        }
-    }
 };
 
 
@@ -116,6 +108,7 @@ struct HashMethodFixedString
 
     size_t n;
     const ColumnFixedString::Chars * chars;
+    static constexpr bool key_to_arena = place_string_to_arena;
 
     HashMethodFixedString(const ColumnRawPtrs & key_columns, const Sizes & /*key_sizes*/, const HashMethodContextPtr &)
     {
@@ -131,11 +124,6 @@ struct HashMethodFixedString
 
 protected:
     friend class columns_hashing_impl::HashMethodBase<Self, Value, Mapped, use_cache>;
-    static ALWAYS_INLINE void onNewKey([[maybe_unused]] StringRef & key, [[maybe_unused]] Arena & pool)
-    {
-        if constexpr (place_string_to_arena)
-            key.data = pool.insert(key.data, key.size);
-    }
 };
 
 
@@ -350,22 +338,27 @@ struct HashMethodSingleLowCardinalityColumn : public SingleColumnMethod
 
         bool inserted = false;
         typename Data::iterator it;
-        if (saved_hash)
-            data.emplace(key, it, inserted, saved_hash[row]);
+        if constexpr (SingleColumnMethod::key_to_arena)
+        {
+            if (saved_hash)
+                data.emplace(key, it, inserted, saved_hash[row], pool);
+            else
+                data.emplace(key, it, inserted, pool);
+        }
         else
-            data.emplace(key, it, inserted);
+        {
+            if (saved_hash)
+                data.emplace(key, it, inserted, saved_hash[row]);
+            else
+                data.emplace(key, it, inserted);
+        }
 
         visit_cache[row] = VisitValue::Found;
 
         if (inserted)
         {
             if constexpr (has_mapped)
-            {
                 new(&it->getSecond()) Mapped();
-                Base::onNewKey(it->getFirstMutable(), pool);
-            }
-            else
-                Base::onNewKey(*it, pool);
         }
 
         if constexpr (has_mapped)

--- a/dbms/src/Common/HashTable/FixedClearableHashSet.h
+++ b/dbms/src/Common/HashTable/FixedClearableHashSet.h
@@ -23,7 +23,6 @@ struct FixedClearableHashTableCell
     struct CellExt
     {
         Key key;
-        value_type & getValueMutable() { return key; }
         const value_type & getValue() const { return key; }
         void update(Key && key_, FixedClearableHashTableCell *) { key = key_; }
     };

--- a/dbms/src/Common/HashTable/HashTable.h
+++ b/dbms/src/Common/HashTable/HashTable.h
@@ -95,13 +95,12 @@ struct HashTableCell
 
     /// Create a cell with the given key / key and value.
     HashTableCell(const Key & key_, const State &) : key(key_) {}
-/// HashTableCell(const value_type & value_, const State & state) : key(value_) {}
 
     /// Get what the value_type of the container will be.
-    value_type & getValueMutable() { return key; }
     const value_type & getValue() const { return key; }
 
     /// Get the key.
+    Key & getKey() { return key; }
     static const Key & getKey(const value_type & value) { return value; }
 
     /// Are the keys at the cells equal?
@@ -266,6 +265,12 @@ protected:
 
     template <typename, typename, typename, typename, typename, typename, size_t>
     friend class TwoLevelHashTable;
+
+    template <typename>
+    friend class StringHashTable;
+
+    template <typename, typename, size_t>
+    friend class TwoLevelStringHashTable;
 
     using HashValue = size_t;
     using Self = HashTable;
@@ -751,16 +756,36 @@ public:
     void ALWAYS_INLINE emplace(Key x, iterator & it, bool & inserted)
     {
         size_t hash_value = hash(x);
-        if (!emplaceIfZero(x, it, inserted, hash_value))
-            emplaceNonZero(x, it, inserted, hash_value);
+        emplace(x, it, inserted, hash_value);
     }
 
+    void ALWAYS_INLINE emplace(Key x, iterator & it, bool & inserted, DB::Arena & pool)
+    {
+        size_t hash_value = hash(x);
+        emplace(x, it, inserted, hash_value, pool);
+    }
 
     /// Same, but with a precalculated value of hash function.
     void ALWAYS_INLINE emplace(Key x, iterator & it, bool & inserted, size_t hash_value)
     {
         if (!emplaceIfZero(x, it, inserted, hash_value))
             emplaceNonZero(x, it, inserted, hash_value);
+    }
+
+    void ALWAYS_INLINE emplace(Key x, iterator & it, bool & inserted, size_t hash_value, DB::Arena & pool)
+    {
+        if (!emplaceIfZero(x, it, inserted, hash_value))
+        {
+            emplaceNonZero(x, it, inserted, hash_value);
+            if constexpr (std::is_same_v<Key, StringRef>)
+            {
+                if (inserted)
+                {
+                    auto & key = it->getKey();
+                    key.data = pool.insert(key.data, key.size);
+                }
+            }
+        }
     }
 
     /// Same, but search position by object. Hack for ReverseIndex.

--- a/dbms/src/Common/HashTable/StringHashMap.h
+++ b/dbms/src/Common/HashTable/StringHashMap.h
@@ -1,0 +1,263 @@
+#pragma once
+
+#include <Common/HashTable/HashMap.h>
+#include <Common/HashTable/HashTableAllocator.h>
+#include <Common/HashTable/StringHashTable.h>
+
+template <typename Key, typename TMapped>
+struct StringHashMapCell : public HashMapCell<Key, TMapped, StringHashTableHash, HashTableNoState>
+{
+    using Base = HashMapCell<Key, TMapped, StringHashTableHash, HashTableNoState>;
+    using Base::Base;
+    static constexpr bool need_zero_value_storage = false;
+};
+
+template <typename TMapped>
+struct StringHashMapCell<StringKey16, TMapped> : public HashMapCell<StringKey16, TMapped, StringHashTableHash, HashTableNoState>
+{
+    using Base = HashMapCell<StringKey16, TMapped, StringHashTableHash, HashTableNoState>;
+    using Base::Base;
+    static constexpr bool need_zero_value_storage = false;
+    bool isZero(const HashTableNoState & state) const { return isZero(this->value.first, state); }
+    // Assuming String does not contain zero bytes. NOTE: Cannot be used in serialized method
+    static bool isZero(const StringKey16 & key, const HashTableNoState & /*state*/) { return key.low == 0; }
+    void setZero() { this->value.first.low = 0; }
+};
+
+template <typename TMapped>
+struct StringHashMapCell<StringKey24, TMapped> : public HashMapCell<StringKey24, TMapped, StringHashTableHash, HashTableNoState>
+{
+    using Base = HashMapCell<StringKey24, TMapped, StringHashTableHash, HashTableNoState>;
+    using Base::Base;
+    static constexpr bool need_zero_value_storage = false;
+    bool isZero(const HashTableNoState & state) const { return isZero(this->value.first, state); }
+    // Assuming String does not contain zero bytes. NOTE: Cannot be used in serialized method
+    static bool isZero(const StringKey24 & key, const HashTableNoState & /*state*/) { return key.a == 0; }
+    void setZero() { this->value.first.a = 0; }
+};
+
+template <typename TMapped>
+struct StringHashMapCell<StringRef, TMapped> : public HashMapCellWithSavedHash<StringRef, TMapped, StringHashTableHash, HashTableNoState>
+{
+    using Base = HashMapCellWithSavedHash<StringRef, TMapped, StringHashTableHash, HashTableNoState>;
+    using Base::Base;
+    static constexpr bool need_zero_value_storage = false;
+};
+
+template <typename TMapped, typename Allocator>
+struct StringHashMapSubMaps
+{
+    using T0 = StringHashTableEmpty<StringHashMapCell<StringRef, TMapped>>;
+    using T1 = HashMapTable<StringKey8, StringHashMapCell<StringKey8, TMapped>, StringHashTableHash, StringHashTableGrower<>, Allocator>;
+    using T2 = HashMapTable<StringKey16, StringHashMapCell<StringKey16, TMapped>, StringHashTableHash, StringHashTableGrower<>, Allocator>;
+    using T3 = HashMapTable<StringKey24, StringHashMapCell<StringKey24, TMapped>, StringHashTableHash, StringHashTableGrower<>, Allocator>;
+    using Ts = HashMapTable<StringRef, StringHashMapCell<StringRef, TMapped>, StringHashTableHash, StringHashTableGrower<>, Allocator>;
+};
+
+template <typename TMapped, typename Allocator = HashTableAllocator>
+class StringHashMap : public StringHashTable<StringHashMapSubMaps<TMapped, Allocator>>
+{
+public:
+    using Base = StringHashTable<StringHashMapSubMaps<TMapped, Allocator>>;
+    using Self = StringHashMap;
+    using Key = StringRef;
+    using key_type = StringRef;
+    using mapped_type = TMapped;
+    using value_type = typename Base::Ts::value_type;
+
+    using Base::Base;
+
+    /// Merge every cell's value of current map into the destination map.
+    ///  Func should have signature void(Mapped & dst, Mapped & src, bool emplaced).
+    ///  Each filled cell in current map will invoke func once. If that map doesn't
+    ///  have a key equals to the given cell, a new cell gets emplaced into that map,
+    ///  and func is invoked with the third argument emplaced set to true. Otherwise
+    ///  emplaced is set to false.
+    template <typename Func>
+    void ALWAYS_INLINE mergeToViaEmplace(Self & that, Func && func)
+    {
+        if (this->m0.size() && that.m0.size())
+            func(that.m0.value.getSecond(), this->m0.value.getSecond(), false);
+        else if (this->m0.size())
+            func(that.m0.value.getSecond(), this->m0.value.getSecond(), true);
+        this->m1.mergeToViaEmplace(that.m1, func);
+        this->m2.mergeToViaEmplace(that.m2, func);
+        this->m3.mergeToViaEmplace(that.m3, func);
+        this->ms.mergeToViaEmplace(that.ms, func);
+    }
+
+    /// Merge every cell's value of current map into the destination map via find.
+    ///  Func should have signature void(Mapped & dst, Mapped & src, bool exist).
+    ///  Each filled cell in current map will invoke func once. If that map doesn't
+    ///  have a key equals to the given cell, func is invoked with the third argument
+    ///  exist set to false. Otherwise exist is set to true.
+    template <typename Func>
+    void ALWAYS_INLINE mergeToViaFind(Self & that, Func && func)
+    {
+        if (this->m0.size() && that.m0.size())
+            func(that.m0.value.getSecond(), this->m0.value.getSecond(), true);
+        else if (this->m0.size())
+            func(this->m0.value.getSecond(), this->m0.value.getSecond(), false);
+        this->m1.mergeToViaFind(that.m1, func);
+        this->m2.mergeToViaFind(that.m2, func);
+        this->m3.mergeToViaFind(that.m3, func);
+        this->ms.mergeToViaFind(that.ms, func);
+    }
+
+    struct ValueHolder
+    {
+        StringRef key;
+        mapped_type * mapped;
+        auto * operator-> () { return this; }
+        mapped_type & getSecond() { return *mapped; }
+        const mapped_type & getSecond() const { return *mapped; }
+        value_type getValue() const { return {key, *mapped}; }
+        ValueHolder() : key{}, mapped{} {}
+        template <typename Value>
+        ValueHolder(Value & value) : key(toStringRef(value.getFirst())), mapped(&value.getSecond())
+        {
+        }
+        template <typename Value>
+        void operator=(Value & value)
+        {
+            key = toStringRef(value.getFirst());
+            mapped = &value.getSecond();
+        }
+        // Only used to check if it's end() in find
+        bool operator==(const ValueHolder & that) const { return key.size == 0 && that.key.size == 0; }
+        bool operator!=(const ValueHolder & that) const { return !(*this == that); }
+    };
+
+    struct MappedHolder
+    {
+        mapped_type * mapped;
+        auto * operator-> () { return this; }
+        mapped_type & getSecond() { return *mapped; }
+        const mapped_type & getSecond() const { return *mapped; }
+        MappedHolder() : mapped{} {}
+        template <typename Value>
+        MappedHolder(Value & value) : mapped(&value.getSecond())
+        {
+        }
+        template <typename Value>
+        void operator=(Value & value)
+        {
+            mapped = &value.getSecond();
+        }
+        // Only used to check if it's end() in find
+        bool operator==(const MappedHolder & that) const { return mapped == that.mapped; }
+        bool operator!=(const MappedHolder & that) const { return !(*this == that); }
+    };
+
+    template <typename Holder>
+    struct EmplaceCallable
+    {
+        Holder & it;
+        bool & inserted;
+        EmplaceCallable(Holder & it_, bool & inserted_) : it(it_), inserted(inserted_) {}
+        template <typename Map, typename Key>
+        void ALWAYS_INLINE operator()(Map & map, const Key & x, size_t hash)
+        {
+            typename Map::iterator impl_it;
+            map.emplace(x, impl_it, inserted, hash);
+            it = *impl_it;
+        }
+    };
+
+    template <typename Holder>
+    struct EmplaceCallableWithPool
+    {
+        Holder & it;
+        bool & inserted;
+        DB::Arena & pool;
+        EmplaceCallableWithPool(Holder & it_, bool & inserted_, DB::Arena & pool_) : it(it_), inserted(inserted_), pool(pool_) {}
+        template <typename Map, typename Key>
+        void ALWAYS_INLINE operator()(Map & map, const Key & x, size_t hash)
+        {
+            typename Map::iterator impl_it;
+            map.emplace(x, impl_it, inserted, hash, pool);
+            it = *impl_it;
+        }
+    };
+
+    using EmplaceValueCallable = EmplaceCallable<ValueHolder>;
+    using EmplaceMappedCallable = EmplaceCallable<MappedHolder>;
+    using EmplaceValueCallableWithPool = EmplaceCallableWithPool<ValueHolder>;
+    using EmplaceMappedCallableWithPool = EmplaceCallableWithPool<MappedHolder>;
+
+    void ALWAYS_INLINE emplace(Key x, ValueHolder & it, bool & inserted) { this->dispatch(x, EmplaceValueCallable{it, inserted}); }
+    void ALWAYS_INLINE emplace(Key x, ValueHolder & it, bool & inserted, DB::Arena & pool)
+    {
+        this->dispatch(x, EmplaceValueCallableWithPool{it, inserted, pool});
+    }
+    void ALWAYS_INLINE emplace(Key x, MappedHolder & it, bool & inserted) { this->dispatch(x, EmplaceMappedCallable{it, inserted}); }
+    void ALWAYS_INLINE emplace(Key x, MappedHolder & it, bool & inserted, DB::Arena & pool)
+    {
+        this->dispatch(x, EmplaceMappedCallableWithPool{it, inserted, pool});
+    }
+
+    struct FindValueCallable
+    {
+        template <typename Map, typename Key>
+        ValueHolder ALWAYS_INLINE operator()(Map & map, const Key & x, size_t hash)
+        {
+            typename Map::iterator it = map.find(x, hash);
+            return it != map.end() ? ValueHolder(*it) : ValueHolder();
+        }
+    };
+
+    ValueHolder ALWAYS_INLINE find(Key x) { return this->dispatch(x, FindValueCallable{}); }
+    ValueHolder ALWAYS_INLINE end() { return ValueHolder{}; }
+
+    using iterator = MappedHolder;
+
+    mapped_type & ALWAYS_INLINE operator[](Key x)
+    {
+        bool inserted;
+        MappedHolder it;
+        emplace(x, it, inserted);
+        if (inserted)
+            new (&it->getSecond()) mapped_type();
+        return it->getSecond();
+    }
+
+    template <typename Func>
+    void ALWAYS_INLINE forEachValue(Func && func)
+    {
+        ValueHolder value;
+        if (this->m0.size())
+            func(this->m0.value);
+        for (auto & v : this->m1)
+        {
+            value = v;
+            func(value);
+        }
+        for (auto & v : this->m2)
+        {
+            value = v;
+            func(value);
+        }
+        for (auto & v : this->m3)
+        {
+            value = v;
+            func(value);
+        }
+        for (auto & v : this->ms)
+            func(v);
+    }
+
+    template <typename Func>
+    void ALWAYS_INLINE forEachMapped(Func && func)
+    {
+        if (this->m0.size())
+            func(this->m0.value.getSecond());
+        for (auto & v : this->m1)
+            func(v.getSecond());
+        for (auto & v : this->m2)
+            func(v.getSecond());
+        for (auto & v : this->m3)
+            func(v.getSecond());
+        for (auto & v : this->ms)
+            func(v.getSecond());
+    }
+};

--- a/dbms/src/Common/HashTable/StringHashSet.h
+++ b/dbms/src/Common/HashTable/StringHashSet.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <Common/HashTable/HashSet.h>
+#include <Common/HashTable/StringHashTable.h>
+
+template <typename Key>
+struct StringHashSetCell : public HashTableCell<Key, StringHashTableHash, HashTableNoState>
+{
+    using Base = HashTableCell<Key, StringHashTableHash, HashTableNoState>;
+    using Base::Base;
+    static constexpr bool need_zero_value_storage = false;
+};
+
+template <>
+struct StringHashSetCell<StringKey16> : public HashTableCell<StringKey16, StringHashTableHash, HashTableNoState>
+{
+    using Base = HashTableCell<StringKey16, StringHashTableHash, HashTableNoState>;
+    using Base::Base;
+    static constexpr bool need_zero_value_storage = false;
+    bool isZero(const HashTableNoState & state) const { return isZero(this->key, state); }
+    // Assuming String does not contain zero bytes. NOTE: Cannot be used in serialized method
+    static bool isZero(const StringKey16 & key, const HashTableNoState & /*state*/) { return key.low == 0; }
+    void setZero() { this->key.low = 0; }
+};
+
+template <>
+struct StringHashSetCell<StringKey24> : public HashTableCell<StringKey24, StringHashTableHash, HashTableNoState>
+{
+    using Base = HashTableCell<StringKey24, StringHashTableHash, HashTableNoState>;
+    using Base::Base;
+    static constexpr bool need_zero_value_storage = false;
+    bool isZero(const HashTableNoState & state) const { return isZero(this->key, state); }
+    // Assuming String does not contain zero bytes. NOTE: Cannot be used in serialized method
+    static bool isZero(const StringKey24 & key, const HashTableNoState & /*state*/) { return key.a == 0; }
+    void setZero() { this->key.a = 0; }
+};
+
+template <>
+struct StringHashSetCell<StringRef> : public HashSetCellWithSavedHash<StringRef, StringHashTableHash, HashTableNoState>
+{
+    using Base = HashSetCellWithSavedHash<StringRef, StringHashTableHash, HashTableNoState>;
+    using Base::Base;
+    static constexpr bool need_zero_value_storage = false;
+};
+
+template <typename Allocator>
+struct StringHashSetSubMaps
+{
+    using T0 = StringHashTableEmpty<StringHashSetCell<StringRef>>;
+    using T1 = HashTable<StringKey8, StringHashSetCell<StringKey8>, StringHashTableHash, StringHashTableGrower<>, Allocator>;
+    using T2 = HashTable<StringKey16, StringHashSetCell<StringKey16>, StringHashTableHash, StringHashTableGrower<>, Allocator>;
+    using T3 = HashTable<StringKey24, StringHashSetCell<StringKey24>, StringHashTableHash, StringHashTableGrower<>, Allocator>;
+    using Ts = HashTable<StringRef, StringHashSetCell<StringRef>, StringHashTableHash, StringHashTableGrower<>, Allocator>;
+};
+
+template <typename Allocator = HashTableAllocator>
+class StringHashSet : public StringHashTable<StringHashSetSubMaps<Allocator>>
+{
+public:
+    using Self = StringHashSet;
+    using Base = StringHashTable<StringHashSetSubMaps<Allocator>>;
+
+    void merge(const Self & rhs)
+    {
+        if (rhs.m0.size())
+            this->m0.insert(rhs.m0.value);
+        this->m1.merge(rhs.m1);
+        this->m2.merge(rhs.m2);
+        this->m3.merge(rhs.m3);
+        this->ms.merge(rhs.ms);
+    }
+};

--- a/dbms/src/Common/HashTable/StringHashTable.h
+++ b/dbms/src/Common/HashTable/StringHashTable.h
@@ -1,0 +1,511 @@
+#pragma once
+
+#include <Common/HashTable/HashMap.h>
+#include <Common/HashTable/HashTable.h>
+
+/// TODO feature macros
+
+#define CASE_1_8 \
+    case 1: \
+    case 2: \
+    case 3: \
+    case 4: \
+    case 5: \
+    case 6: \
+    case 7: \
+    case 8
+
+#define CASE_9_16 \
+    case 9: \
+    case 10: \
+    case 11: \
+    case 12: \
+    case 13: \
+    case 14: \
+    case 15: \
+    case 16
+
+#define CASE_17_24 \
+    case 17: \
+    case 18: \
+    case 19: \
+    case 20: \
+    case 21: \
+    case 22: \
+    case 23: \
+    case 24
+
+struct StringKey0
+{
+};
+
+using StringKey8 = UInt64;
+using StringKey16 = DB::UInt128;
+struct StringKey24
+{
+    UInt64 a;
+    UInt64 b;
+    UInt64 c;
+
+    bool operator==(const StringKey24 rhs) const { return a == rhs.a && b == rhs.b && c == rhs.c; }
+    bool operator!=(const StringKey24 rhs) const { return !operator==(rhs); }
+    bool operator==(const UInt64 rhs) const { return a == rhs && b == 0 && c == 0; }
+    bool operator!=(const UInt64 rhs) const { return !operator==(rhs); }
+
+    StringKey24 & operator=(const UInt64 rhs)
+    {
+        a = rhs;
+        b = 0;
+        c = 0;
+        return *this;
+    }
+};
+
+inline StringRef ALWAYS_INLINE toStringRef(const StringKey8 & n)
+{
+    return {reinterpret_cast<const char *>(&n), 8ul - (__builtin_clzll(n) >> 3)};
+}
+inline StringRef ALWAYS_INLINE toStringRef(const StringKey16 & n)
+{
+    return {reinterpret_cast<const char *>(&n), 16ul - (__builtin_clzll(n.high) >> 3)};
+}
+inline StringRef ALWAYS_INLINE toStringRef(const StringKey24 & n)
+{
+    return {reinterpret_cast<const char *>(&n), 24ul - (__builtin_clzll(n.c) >> 3)};
+}
+inline const StringRef & ALWAYS_INLINE toStringRef(const StringRef & s)
+{
+    return s;
+}
+
+struct StringHashTableHash
+{
+    size_t ALWAYS_INLINE operator()(StringKey8 key) const
+    {
+        size_t res = -1ULL;
+        res = _mm_crc32_u64(res, key);
+        return res;
+    }
+    size_t ALWAYS_INLINE operator()(StringKey16 key) const
+    {
+        size_t res = -1ULL;
+        res = _mm_crc32_u64(res, key.low);
+        res = _mm_crc32_u64(res, key.high);
+        return res;
+    }
+    size_t ALWAYS_INLINE operator()(StringKey24 key) const
+    {
+        size_t res = -1ULL;
+        res = _mm_crc32_u64(res, key.a);
+        res = _mm_crc32_u64(res, key.b);
+        res = _mm_crc32_u64(res, key.c);
+        return res;
+    }
+    size_t ALWAYS_INLINE operator()(StringRef key) const
+    {
+        size_t res = -1ULL;
+        size_t sz = key.size;
+        const char * p = key.data;
+        const char * lp = p + sz - 8; // starting pointer of the last 8 bytes segment
+        char s = (-sz & 7) * 8; // pending bits that needs to be shifted out
+        UInt64 n[3]; // StringRef in SSO map will have length > 24
+        memcpy(&n, p, 24);
+        res = _mm_crc32_u64(res, n[0]);
+        res = _mm_crc32_u64(res, n[1]);
+        res = _mm_crc32_u64(res, n[2]);
+        p += 24;
+        while (p + 8 < lp)
+        {
+            memcpy(&n[0], p, 8);
+            res = _mm_crc32_u64(res, n[0]);
+            p += 8;
+        }
+        memcpy(&n[0], lp, 8);
+        n[0] >>= s;
+        res = _mm_crc32_u64(res, n[0]);
+        return res;
+    }
+};
+
+template <typename Cell>
+struct StringHashTableEmpty
+{
+    using Self = StringHashTableEmpty;
+
+    Cell value;
+    bool is_empty{true};
+
+    StringHashTableEmpty() { memset(reinterpret_cast<char *>(&value), 0, sizeof(value)); }
+
+    template <bool is_const>
+    struct iterator_base
+    {
+        using Parent = std::conditional_t<is_const, const Self *, Self *>;
+        Cell * ptr;
+
+        friend struct iterator_base<!is_const>; // bidirectional friendliness
+
+        iterator_base(Cell * ptr_ = nullptr) : ptr(ptr_) {}
+
+        iterator_base & operator++()
+        {
+            ptr = nullptr;
+            return *this;
+        }
+
+        auto & operator*() const { return *ptr; }
+        auto * operator-> () const { return ptr; }
+
+        auto getPtr() const { return ptr; }
+        size_t getHash() const { return 0; }
+    };
+    using iterator = iterator_base<false>;
+    using const_iterator = iterator_base<true>;
+
+    friend bool operator==(const iterator & lhs, const iterator & rhs)
+    {
+        return (lhs.ptr == nullptr && rhs.ptr == nullptr) || (lhs.ptr != nullptr && rhs.ptr != nullptr);
+    }
+    friend bool operator!=(const iterator & lhs, const iterator & rhs) { return !(lhs == rhs); }
+    friend bool operator==(const const_iterator & lhs, const const_iterator & rhs)
+    {
+        return (lhs.ptr == nullptr && rhs.ptr == nullptr) || (lhs.ptr != nullptr && rhs.ptr != nullptr);
+    }
+    friend bool operator!=(const const_iterator & lhs, const const_iterator & rhs) { return !(lhs == rhs); }
+
+    std::pair<iterator, bool> ALWAYS_INLINE insert(const Cell & x)
+    {
+        if (is_empty)
+        {
+            is_empty = false;
+            value->setMapped(x);
+            return {begin(), true};
+        }
+        return {begin(), false};
+    }
+
+    template <typename Key>
+    void ALWAYS_INLINE emplace(Key, iterator & it, bool & inserted, size_t)
+    {
+        if (is_empty)
+        {
+            inserted = true;
+            is_empty = false;
+        }
+        else
+            inserted = false;
+        it = begin();
+    }
+
+    template <typename Key>
+    void ALWAYS_INLINE emplace(Key, iterator & it, bool & inserted, size_t, DB::Arena &)
+    {
+        if (is_empty)
+        {
+            inserted = true;
+            is_empty = false;
+        }
+        else
+            inserted = false;
+        it = begin();
+    }
+
+    template <typename Key>
+    iterator ALWAYS_INLINE find(Key, size_t)
+    {
+        return begin();
+    }
+
+    const_iterator begin() const
+    {
+        if (is_empty)
+            return end();
+        return {&value};
+    }
+    iterator begin()
+    {
+        if (is_empty)
+            return end();
+        return {&value};
+    }
+    const_iterator end() const { return {}; }
+    iterator end() { return {}; }
+    void write(DB::WriteBuffer & wb) const { value.write(wb); }
+    void writeText(DB::WriteBuffer & wb) const { value.writeText(wb); }
+    void read(DB::ReadBuffer & rb) { value.read(rb); }
+    void readText(DB::ReadBuffer & rb) { value.readText(rb); }
+    size_t size() const { return is_empty ? 0 : 1; }
+    bool empty() const { return is_empty; }
+    size_t getBufferSizeInBytes() const { return sizeof(Cell); }
+    size_t getCollisions() const { return 0; }
+};
+
+template <size_t initial_size_degree = 8>
+struct StringHashTableGrower : public HashTableGrower<initial_size_degree>
+{
+    // Smooth growing for string maps
+    void increaseSize() { this->size_degree += 1; }
+};
+
+template <typename SubMaps>
+class StringHashTable : private boost::noncopyable
+{
+protected:
+    static constexpr size_t NUM_MAPS = 5;
+    // Map for storing empty string
+    using T0 = typename SubMaps::T0;
+
+    // Short strings are stored as numbers
+    using T1 = typename SubMaps::T1;
+    using T2 = typename SubMaps::T2;
+    using T3 = typename SubMaps::T3;
+
+    // Long strings are stored as StringRef along with saved hash
+    using Ts = typename SubMaps::Ts;
+    using Self = StringHashTable;
+
+    template <typename, typename, size_t>
+    friend class TwoLevelStringHashTable;
+
+    T0 m0;
+    T1 m1;
+    T2 m2;
+    T3 m3;
+    Ts ms;
+
+public:
+    using Key = StringRef;
+    using key_type = Key;
+    using value_type = typename Ts::value_type;
+
+    StringHashTable() {}
+
+    StringHashTable(size_t reserve_for_num_elements)
+        : m1{reserve_for_num_elements / 4}
+        , m2{reserve_for_num_elements / 4}
+        , m3{reserve_for_num_elements / 4}
+        , ms{reserve_for_num_elements / 4}
+    {
+    }
+
+    StringHashTable(StringHashTable && rhs) { *this = std::move(rhs); }
+    ~StringHashTable() {}
+
+public:
+    // Dispatch is written in a way that maximizes the performance:
+    // 1. Always memcpy 8 times bytes
+    // 2. Use switch case extension to generate fast dispatching table
+    // 3. Combine hash computation along with key loading
+    // 4. Funcs are named callables that can be force_inlined
+    // NOTE: It relies on Little Endianness and SSE4.2
+    template <typename Func>
+    decltype(auto) ALWAYS_INLINE dispatch(Key & x, Func && func)
+    {
+        static constexpr StringKey0 key0{};
+        size_t sz = x.size;
+        const char * p = x.data;
+        // pending bits that needs to be shifted out
+        char s = (-sz & 7) * 8;
+        size_t res = -1ULL;
+        union
+        {
+            StringKey8 k8;
+            StringKey16 k16;
+            StringKey24 k24;
+            UInt64 n[3];
+        };
+        switch (sz)
+        {
+            case 0:
+                return func(m0, key0, 0);
+            CASE_1_8 : {
+                // first half page
+                if ((reinterpret_cast<uintptr_t>(p) & 2048) == 0)
+                {
+                    memcpy(&n[0], p, 8);
+                    n[0] &= -1ul >> s;
+                }
+                else
+                {
+                    const char * lp = x.data + x.size - 8;
+                    memcpy(&n[0], lp, 8);
+                    n[0] >>= s;
+                }
+                res = _mm_crc32_u64(res, n[0]);
+                return func(m1, k8, res);
+            }
+            CASE_9_16 : {
+                memcpy(&n[0], p, 8);
+                res = _mm_crc32_u64(res, n[0]);
+                const char * lp = x.data + x.size - 8;
+                memcpy(&n[1], lp, 8);
+                n[1] >>= s;
+                res = _mm_crc32_u64(res, n[1]);
+                return func(m2, k16, res);
+            }
+            CASE_17_24 : {
+                memcpy(&n[0], p, 16);
+                res = _mm_crc32_u64(res, n[0]);
+                res = _mm_crc32_u64(res, n[1]);
+                const char * lp = x.data + x.size - 8;
+                memcpy(&n[2], lp, 8);
+                n[2] >>= s;
+                res = _mm_crc32_u64(res, n[2]);
+                return func(m3, k24, res);
+            }
+            default: {
+                memcpy(&n, x.data, 24);
+                res = _mm_crc32_u64(res, n[0]);
+                res = _mm_crc32_u64(res, n[1]);
+                res = _mm_crc32_u64(res, n[2]);
+                p += 24;
+                const char * lp = x.data + x.size - 8;
+                while (p + 8 < lp)
+                {
+                    memcpy(&n[0], p, 8);
+                    res = _mm_crc32_u64(res, n[0]);
+                    p += 8;
+                }
+                memcpy(&n[0], lp, 8);
+                n[0] >>= s;
+                res = _mm_crc32_u64(res, n[0]);
+                return func(ms, x, res);
+            }
+        }
+    }
+
+    struct ValueHolder
+    {
+        StringRef value;
+        auto * operator-> () { return this; }
+        value_type getValue() const { return value; }
+        ValueHolder() : value{} {}
+        template <typename Iterator>
+        ValueHolder(const Iterator & iter) : value(toStringRef(iter->getValue()))
+        {
+        }
+        template <typename Iterator>
+        void operator=(const Iterator & iter)
+        {
+            value = toStringRef(iter->getValue());
+        }
+        // Only used to check if it's end() in find
+        bool operator==(const ValueHolder & that) const { return value.size == 0 && that.value.size == 0; }
+        bool operator!=(const ValueHolder & that) const { return !(*this == that); }
+    };
+
+    struct EmplaceCallable
+    {
+        ValueHolder & it;
+        bool & inserted;
+        EmplaceCallable(ValueHolder & it_, bool & inserted_) : it(it_), inserted(inserted_) {}
+        template <typename Map, typename Key>
+        void ALWAYS_INLINE operator()(Map & map, const Key & x, size_t hash)
+        {
+            typename Map::iterator impl_it;
+            map.emplace(x, impl_it, inserted, hash);
+            it = impl_it;
+        }
+    };
+
+    struct EmplaceCallableWithPool
+    {
+        ValueHolder & it;
+        bool & inserted;
+        DB::Arena & pool;
+        EmplaceCallableWithPool(ValueHolder & it_, bool & inserted_, DB::Arena & pool_) : it(it_), inserted(inserted_), pool(pool_) {}
+        template <typename Map, typename Key>
+        void ALWAYS_INLINE operator()(Map & map, const Key & x, size_t hash)
+        {
+            typename Map::iterator impl_it;
+            map.emplace(x, impl_it, inserted, hash, pool);
+            it = impl_it;
+        }
+    };
+
+    void ALWAYS_INLINE emplace(Key x, ValueHolder & it, bool & inserted) { dispatch(x, EmplaceCallable{it, inserted}); }
+    void ALWAYS_INLINE emplace(Key x, ValueHolder & it, bool & inserted, DB::Arena & pool)
+    {
+        dispatch(x, EmplaceCallableWithPool{it, inserted, pool});
+    }
+
+    struct FindCallable
+    {
+        template <typename Map, typename Key>
+        ValueHolder ALWAYS_INLINE operator()(Map & map, const Key & x, size_t hash)
+        {
+            typename Map::iterator it = map.find(x, hash);
+            return it != map.end() ? ValueHolder(it) : ValueHolder();
+        }
+    };
+
+    ValueHolder ALWAYS_INLINE find(Key x) { return dispatch(x, FindCallable{}); }
+    ValueHolder ALWAYS_INLINE end() { return ValueHolder{}; }
+
+    using iterator = ValueHolder;
+
+    void write(DB::WriteBuffer & wb) const
+    {
+        m0.write(wb);
+        m1.write(wb);
+        m2.write(wb);
+        m3.write(wb);
+        ms.write(wb);
+    }
+
+    void writeText(DB::WriteBuffer & wb) const
+    {
+        m0.writeText(wb);
+        DB::writeChar(',', wb);
+        m1.writeText(wb);
+        DB::writeChar(',', wb);
+        m2.writeText(wb);
+        DB::writeChar(',', wb);
+        m3.writeText(wb);
+        DB::writeChar(',', wb);
+        ms.writeText(wb);
+    }
+
+    void read(DB::ReadBuffer & rb)
+    {
+        m0.read(rb);
+        m1.read(rb);
+        m2.read(rb);
+        m3.read(rb);
+        ms.read(rb);
+    }
+
+    void readText(DB::ReadBuffer & rb)
+    {
+        m0.readText(rb);
+        DB::assertChar(',', rb);
+        m1.readText(rb);
+        DB::assertChar(',', rb);
+        m2.readText(rb);
+        DB::assertChar(',', rb);
+        m3.readText(rb);
+        DB::assertChar(',', rb);
+        ms.readText(rb);
+    }
+
+    size_t size() const { return m0.size() + m1.size() + m2.size() + m3.size() + ms.size(); }
+
+    bool empty() const { return m0.empty() && m1.empty() && m2.empty() && m3.empty() && ms.empty(); }
+
+    size_t getBufferSizeInBytes() const
+    {
+        return m0.getBufferSizeInBytes() + m1.getBufferSizeInBytes() + m2.getBufferSizeInBytes() + m3.getBufferSizeInBytes()
+            + ms.getBufferSizeInBytes();
+    }
+
+    void clearAndShrink()
+    {
+        using Cell = decltype(m0.value);
+        if (!std::is_trivially_destructible_v<Cell>)
+            m0.value.~Cell();
+        m1.clearAndShrink();
+        m2.clearAndShrink();
+        m3.clearAndShrink();
+        ms.clearAndShrink();
+    }
+};

--- a/dbms/src/Common/HashTable/TwoLevelHashMap.h
+++ b/dbms/src/Common/HashTable/TwoLevelHashMap.h
@@ -22,6 +22,13 @@ public:
 
     using TwoLevelHashTable<Key, Cell, Hash, Grower, Allocator, ImplTable<Key, Cell, Hash, Grower, Allocator>>::TwoLevelHashTable;
 
+    template <typename Func>
+    void ALWAYS_INLINE forEachMapped(Func && func)
+    {
+        for (auto i = 0u; i < this->NUM_BUCKETS; ++i)
+            this->impls[i].forEachMapped(func);
+    }
+
     mapped_type & ALWAYS_INLINE operator[](Key x)
     {
         typename TwoLevelHashMapTable::iterator it;

--- a/dbms/src/Common/HashTable/TwoLevelHashTable.h
+++ b/dbms/src/Common/HashTable/TwoLevelHashTable.h
@@ -242,6 +242,12 @@ public:
     }
 
 
+    void ALWAYS_INLINE emplace(Key x, iterator & it, bool & inserted, DB::Arena & pool)
+    {
+        size_t hash_value = hash(x);
+        emplace(x, it, inserted, hash_value, pool);
+    }
+
     /// Same, but with a precalculated values of hash function.
     void ALWAYS_INLINE emplace(Key x, iterator & it, bool & inserted, size_t hash_value)
     {
@@ -251,6 +257,13 @@ public:
         it = iterator(this, buck, impl_it);
     }
 
+    void ALWAYS_INLINE emplace(Key x, iterator & it, bool & inserted, size_t hash_value, DB::Arena & pool)
+    {
+        size_t buck = getBucketFromHash(hash_value);
+        typename Impl::iterator impl_it;
+        impls[buck].emplace(x, impl_it, inserted, hash_value, pool);
+        it = iterator(this, buck, impl_it);
+    }
 
     iterator ALWAYS_INLINE find(Key x, size_t hash_value)
     {

--- a/dbms/src/Common/HashTable/TwoLevelStringHashMap.h
+++ b/dbms/src/Common/HashTable/TwoLevelStringHashMap.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <Common/HashTable/StringHashMap.h>
+#include <Common/HashTable/TwoLevelStringHashTable.h>
+
+template <typename TMapped, typename Allocator = HashTableAllocator, template <typename...> typename ImplTable = StringHashMap>
+class TwoLevelStringHashMap : public TwoLevelStringHashTable<StringHashMapSubMaps<TMapped, Allocator>, ImplTable<TMapped, Allocator>>
+{
+public:
+    using Key = StringRef;
+    using key_type = Key;
+    using Self = TwoLevelStringHashMap;
+    using Base = TwoLevelStringHashTable<StringHashMapSubMaps<TMapped, Allocator>, StringHashMap<TMapped, Allocator>>;
+    using Base::Base;
+    using mapped_type = TMapped;
+    using value_type = typename Base::value_type;
+
+    template <typename Func>
+    void ALWAYS_INLINE forEachMapped(Func && func)
+    {
+        for (auto i = 0u; i < this->NUM_BUCKETS; ++i)
+            return this->impls[i].forEachMapped(func);
+    }
+
+    using RawImpl = StringHashMap<TMapped, Allocator>;
+    using MappedHolder = typename RawImpl::MappedHolder;
+    using ValueHolder = typename RawImpl::ValueHolder;
+    using FindValueCallable = typename RawImpl::FindValueCallable;
+    using EmplaceValueCallable = typename RawImpl::template EmplaceCallable<ValueHolder>;
+    using EmplaceValueCallableWithPool = typename RawImpl::template EmplaceCallableWithPool<ValueHolder>;
+    using EmplaceMappedCallable = typename RawImpl::template EmplaceCallable<MappedHolder>;
+    using EmplaceMappedCallableWithPool = typename RawImpl::template EmplaceCallableWithPool<MappedHolder>;
+
+    void ALWAYS_INLINE emplace(Key x, ValueHolder & it, bool & inserted) { this->dispatch(x, EmplaceValueCallable{it, inserted}); }
+    void ALWAYS_INLINE emplace(Key x, ValueHolder & it, bool & inserted, DB::Arena & pool)
+    {
+        this->dispatch(x, EmplaceValueCallableWithPool{it, inserted, pool});
+    }
+    void ALWAYS_INLINE emplace(Key x, MappedHolder & it, bool & inserted) { this->dispatch(x, EmplaceMappedCallable{it, inserted}); }
+    void ALWAYS_INLINE emplace(Key x, MappedHolder & it, bool & inserted, DB::Arena & pool)
+    {
+        this->dispatch(x, EmplaceMappedCallableWithPool{it, inserted, pool});
+    }
+    ValueHolder ALWAYS_INLINE find(Key x) { return this->dispatch(x, FindValueCallable{}); }
+    ValueHolder ALWAYS_INLINE end() { return ValueHolder{}; }
+
+    using iterator = MappedHolder;
+
+    mapped_type & ALWAYS_INLINE operator[](Key x)
+    {
+        bool inserted;
+        MappedHolder it;
+        emplace(x, it, inserted);
+        if (inserted)
+            new (&it->getSecond()) mapped_type();
+        return it->getSecond();
+    }
+};

--- a/dbms/src/Common/HashTable/TwoLevelStringHashTable.h
+++ b/dbms/src/Common/HashTable/TwoLevelStringHashTable.h
@@ -1,0 +1,233 @@
+#pragma once
+
+#include <Common/HashTable/StringHashTable.h>
+
+template <typename SubMaps, typename ImplTable = StringHashTable<SubMaps>, size_t BITS_FOR_BUCKET = 8>
+class TwoLevelStringHashTable : private boost::noncopyable
+{
+protected:
+    using HashValue = size_t;
+    using Self = TwoLevelStringHashTable;
+
+public:
+    using Key = StringRef;
+    using Impl = ImplTable;
+
+    static constexpr size_t NUM_BUCKETS = 1ULL << BITS_FOR_BUCKET;
+    static constexpr size_t MAX_BUCKET = NUM_BUCKETS - 1;
+
+    // TODO: currently hashing contains redundant computations when doing distributed or external aggregations
+    size_t hash(const Key & x) const
+    {
+        return const_cast<Self &>(*this).dispatch(x, [&](const auto &, const auto &, size_t hash) { return hash; });
+    }
+
+    size_t operator()(const Key & x) const { return hash(x); }
+
+    /// NOTE Bad for hash tables with more than 2^32 cells.
+    static size_t getBucketFromHash(size_t hash_value) { return (hash_value >> (32 - BITS_FOR_BUCKET)) & MAX_BUCKET; }
+
+public:
+    using key_type = typename Impl::key_type;
+    using value_type = typename Impl::value_type;
+
+    Impl impls[NUM_BUCKETS];
+
+    TwoLevelStringHashTable() {}
+
+    template <typename Source>
+    TwoLevelStringHashTable(const Source & src)
+    {
+        if (src.m0.size())
+        {
+            impls[0].m0.value = src.m0.value;
+            impls[0].m0.is_empty = false;
+        }
+        for (auto & v : src.m1)
+        {
+            size_t hash_value = v.getHash(src.m1);
+            size_t buck = getBucketFromHash(hash_value);
+            impls[buck].m1.insertUniqueNonZero(&v, hash_value);
+        }
+        for (auto & v : src.m2)
+        {
+            size_t hash_value = v.getHash(src.m2);
+            size_t buck = getBucketFromHash(hash_value);
+            impls[buck].m2.insertUniqueNonZero(&v, hash_value);
+        }
+        for (auto & v : src.m3)
+        {
+            size_t hash_value = v.getHash(src.m3);
+            size_t buck = getBucketFromHash(hash_value);
+            impls[buck].m3.insertUniqueNonZero(&v, hash_value);
+        }
+        for (auto & v : src.ms)
+        {
+            size_t hash_value = v.getHash(src.ms);
+            size_t buck = getBucketFromHash(hash_value);
+            impls[buck].ms.insertUniqueNonZero(&v, hash_value);
+        }
+    }
+
+    // Dispatch is written in a way that maximizes the performance:
+    // 1. Always memcpy 8 times bytes
+    // 2. Use switch case extension to generate fast dispatching table
+    // 3. Combine hash computation along with bucket computation and key loading
+    // 4. Funcs are named callables that can be force_inlined
+    // NOTE: It relies on Little Endianness and SSE4.2
+    template <typename Func>
+    decltype(auto) ALWAYS_INLINE dispatch(Key x, Func && func)
+    {
+        static constexpr StringKey0 key0{};
+        size_t sz = x.size;
+        const char * p = x.data;
+        // pending bits that needs to be shifted out
+        char s = (-sz & 7) * 8;
+        size_t res = -1ULL;
+        size_t buck;
+        union
+        {
+            StringKey8 k8;
+            StringKey16 k16;
+            StringKey24 k24;
+            UInt64 n[3];
+        };
+        switch (sz)
+        {
+            case 0:
+                return func(impls[0].m0, key0, 0);
+            CASE_1_8 : {
+                // first half page
+                if ((reinterpret_cast<uintptr_t>(p) & 2048) == 0)
+                {
+                    memcpy(&n[0], p, 8);
+                    n[0] &= -1ul >> s;
+                }
+                else
+                {
+                    const char * lp = x.data + x.size - 8;
+                    memcpy(&n[0], lp, 8);
+                    n[0] >>= s;
+                }
+                res = _mm_crc32_u64(res, n[0]);
+                buck = getBucketFromHash(res);
+                return func(impls[buck].m1, k8, res);
+            }
+            CASE_9_16 : {
+                memcpy(&n[0], p, 8);
+                res = _mm_crc32_u64(res, n[0]);
+                const char * lp = x.data + x.size - 8;
+                memcpy(&n[1], lp, 8);
+                n[1] >>= s;
+                res = _mm_crc32_u64(res, n[1]);
+                buck = getBucketFromHash(res);
+                return func(impls[buck].m2, k16, res);
+            }
+            CASE_17_24 : {
+                memcpy(&n[0], p, 16);
+                res = _mm_crc32_u64(res, n[0]);
+                res = _mm_crc32_u64(res, n[1]);
+                const char * lp = x.data + x.size - 8;
+                memcpy(&n[2], lp, 8);
+                n[2] >>= s;
+                res = _mm_crc32_u64(res, n[2]);
+                buck = getBucketFromHash(res);
+                return func(impls[buck].m3, k24, res);
+            }
+            default: {
+                memcpy(&n, x.data, 24);
+                res = _mm_crc32_u64(res, n[0]);
+                res = _mm_crc32_u64(res, n[1]);
+                res = _mm_crc32_u64(res, n[2]);
+                p += 24;
+                const char * lp = x.data + x.size - 8;
+                while (p + 8 < lp)
+                {
+                    memcpy(&n[0], p, 8);
+                    res = _mm_crc32_u64(res, n[0]);
+                    p += 8;
+                }
+                memcpy(&n[0], lp, 8);
+                n[0] >>= s;
+                res = _mm_crc32_u64(res, n[0]);
+                buck = getBucketFromHash(res);
+                return func(impls[buck].ms, x, res);
+            }
+        }
+    }
+
+    using RawImpl = StringHashTable<SubMaps>;
+    using EmplaceCallable = typename RawImpl::EmplaceCallable;
+    using EmplaceCallableWithPool = typename RawImpl::EmplaceCallableWithPool;
+    using FindCallable = typename RawImpl::FindCallable;
+    using ValueHolder = typename RawImpl::ValueHolder;
+
+    void ALWAYS_INLINE emplace(Key x, ValueHolder & it, bool & inserted) { dispatch(x, EmplaceCallable{it, inserted}); }
+    void ALWAYS_INLINE emplace(Key x, ValueHolder & it, bool & inserted, DB::Arena & pool)
+    {
+        dispatch(x, EmplaceCallableWithPool{it, inserted, pool});
+    }
+    ValueHolder ALWAYS_INLINE find(Key x) { return dispatch(x, FindCallable{}); }
+    ValueHolder ALWAYS_INLINE end() { return ValueHolder{}; }
+
+    using iterator = ValueHolder;
+
+    void write(DB::WriteBuffer & wb) const
+    {
+        for (size_t i = 0; i < NUM_BUCKETS; ++i)
+            impls[i].write(wb);
+    }
+
+    void writeText(DB::WriteBuffer & wb) const
+    {
+        for (size_t i = 0; i < NUM_BUCKETS; ++i)
+        {
+            if (i != 0)
+                DB::writeChar(',', wb);
+            impls[i].writeText(wb);
+        }
+    }
+
+    void read(DB::ReadBuffer & rb)
+    {
+        for (size_t i = 0; i < NUM_BUCKETS; ++i)
+            impls[i].read(rb);
+    }
+
+    void readText(DB::ReadBuffer & rb)
+    {
+        for (size_t i = 0; i < NUM_BUCKETS; ++i)
+        {
+            if (i != 0)
+                DB::assertChar(',', rb);
+            impls[i].readText(rb);
+        }
+    }
+
+    size_t size() const
+    {
+        size_t res = 0;
+        for (size_t i = 0; i < NUM_BUCKETS; ++i)
+            res += impls[i].size();
+
+        return res;
+    }
+
+    bool empty() const
+    {
+        for (size_t i = 0; i < NUM_BUCKETS; ++i)
+            if (!impls[i].empty())
+                return false;
+
+        return true;
+    }
+
+    size_t getBufferSizeInBytes() const
+    {
+        size_t res = 0;
+        for (size_t i = 0; i < NUM_BUCKETS; ++i)
+            res += impls[i].getBufferSizeInBytes();
+
+        return res;
+    }
+};

--- a/dbms/src/Common/SpaceSaving.h
+++ b/dbms/src/Common/SpaceSaving.h
@@ -198,10 +198,7 @@ public:
             min->count = alpha + increment;
             min->error = alpha + error;
             percolate(min);
-
-            it->getSecond() = min;
-            it->getFirstMutable() = min->key;
-            counter_map.reinsert(it, hash);
+            counter_map[min->key] = min;
         }
     }
 

--- a/dbms/src/Core/Defines.h
+++ b/dbms/src/Core/Defines.h
@@ -136,6 +136,17 @@
     #define OPTIMIZE(x)
 #endif
 
+#if defined __GNUC__ && !defined __clang__
+    #define IGNORE_MAYBE_UNINITIALIZED_PUSH \
+        _Pragma("GCC diagnostic push")\
+        _Pragma("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+    #define IGNORE_MAYBE_UNINITIALIZED_POP \
+        _Pragma("GCC diagnostic pop")
+#else
+    #define IGNORE_MAYBE_UNINITIALIZED_PUSH
+    #define IGNORE_MAYBE_UNINITIALIZED_POP
+#endif
+
 /// This number is only used for distributed version compatible.
 /// It could be any magic number.
 #define DBMS_DISTRIBUTED_SENDS_MAGIC_NUMBER 0xCAFECABE

--- a/dbms/src/Core/Settings.h
+++ b/dbms/src/Core/Settings.h
@@ -342,6 +342,8 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingUInt64, max_partitions_per_insert_block, 100, "Limit maximum number of partitions in single INSERTed block. Zero means unlimited. Throw exception if the block contains too many partitions. This setting is a safety threshold, because using large number of partitions is a common misconception.") \
     M(SettingBool, check_query_single_value_result, true, "Return check query result as single 1/0 value") \
     \
+    M(SettingBool, short_string_optimization, true, "If it is set to true, string aggregation will favor short string keys.") \
+    \
     /** Obsolete settings that do nothing but left for compatibility reasons. Remove each one after half a year of obsolescence. */ \
     \
     M(SettingBool, allow_experimental_low_cardinality_type, true, "Obsolete setting, does nothing. Will be removed after 2019-08-13") \

--- a/dbms/src/Functions/array/arrayUniq.cpp
+++ b/dbms/src/Functions/array/arrayUniq.cpp
@@ -222,7 +222,7 @@ void FunctionArrayUniq::executeMethodImpl(
                 }
             }
 
-            method.emplaceKey(set, j, pool);
+            method.template emplaceKey(set, j, pool);
         }
 
         res_values[i] = set.size() + found_null;

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -533,6 +533,8 @@ AggregatedDataVariants::Type Aggregator::chooseAggregationMethod()
     {
         if (has_low_cardinality)
             return AggregatedDataVariants::Type::low_cardinality_key_string;
+        else if (params.short_string_optimization)
+            return AggregatedDataVariants::Type::key_short_string;
         else
             return AggregatedDataVariants::Type::key_string;
     }
@@ -541,6 +543,8 @@ AggregatedDataVariants::Type Aggregator::chooseAggregationMethod()
     {
         if (has_low_cardinality)
             return AggregatedDataVariants::Type::low_cardinality_key_fixed_string;
+        else if (params.short_string_optimization)
+            return AggregatedDataVariants::Type::key_short_fixed_string;
         else
             return AggregatedDataVariants::Type::key_fixed_string;
     }
@@ -1120,15 +1124,12 @@ void NO_INLINE Aggregator::convertToBlockImplFinal(
         }
     }
 
-    for (const auto & value : data)
+    data.forEachValue([&](const auto & value)
     {
         method.insertKeyIntoColumns(value.getValue(), key_columns, key_sizes);
-
         for (size_t i = 0; i < params.aggregates_size; ++i)
-            aggregate_functions[i]->insertResultInto(
-                value.getSecond() + offsets_of_aggregate_states[i],
-                *final_aggregate_columns[i]);
-    }
+            aggregate_functions[i]->insertResultInto(value.getSecond() + offsets_of_aggregate_states[i], *final_aggregate_columns[i]);
+    });
 
     destroyImpl<Method>(data);
 }
@@ -1151,7 +1152,7 @@ void NO_INLINE Aggregator::convertToBlockImplNotFinal(
         }
     }
 
-    for (auto & value : data)
+    data.forEachValue([&](auto & value)
     {
         method.insertKeyIntoColumns(value.getValue(), key_columns, key_sizes);
 
@@ -1160,7 +1161,7 @@ void NO_INLINE Aggregator::convertToBlockImplNotFinal(
             aggregate_columns[i]->push_back(value.getSecond() + offsets_of_aggregate_states[i]);
 
         value.getSecond() = nullptr;
-    }
+    });
 }
 
 
@@ -1493,32 +1494,19 @@ void NO_INLINE Aggregator::mergeDataImpl(
     if constexpr (Method::low_cardinality_optimization)
         mergeDataNullKey<Method, Table>(table_dst, table_src, arena);
 
-    for (auto it = table_src.begin(), end = table_src.end(); it != end; ++it)
+    table_src.mergeToViaEmplace(table_dst, [&](auto & dst, auto & src, bool inserted)
     {
-        typename Table::iterator res_it;
-        bool inserted;
-        table_dst.emplace(it->getFirst(), res_it, inserted, it.getHash());
-
         if (!inserted)
         {
             for (size_t i = 0; i < params.aggregates_size; ++i)
-                aggregate_functions[i]->merge(
-                    res_it->getSecond() + offsets_of_aggregate_states[i],
-                    it->getSecond() + offsets_of_aggregate_states[i],
-                    arena);
-
+                aggregate_functions[i]->merge(dst + offsets_of_aggregate_states[i], src + offsets_of_aggregate_states[i], arena);
             for (size_t i = 0; i < params.aggregates_size; ++i)
-                aggregate_functions[i]->destroy(
-                    it->getSecond() + offsets_of_aggregate_states[i]);
+                aggregate_functions[i]->destroy(src + offsets_of_aggregate_states[i]);
         }
         else
-        {
-            res_it->getSecond() = it->getSecond();
-        }
-
-        it->getSecond() = nullptr;
-    }
-
+            dst = src;
+        src = nullptr;
+    });
     table_src.clearAndShrink();
 }
 
@@ -1534,26 +1522,15 @@ void NO_INLINE Aggregator::mergeDataNoMoreKeysImpl(
     if constexpr (Method::low_cardinality_optimization)
         mergeDataNullKey<Method, Table>(table_dst, table_src, arena);
 
-    for (auto it = table_src.begin(), end = table_src.end(); it != end; ++it)
+    table_src.mergeToViaFind(table_dst, [&](auto & dst, auto & src, bool found)
     {
-        typename Table::iterator res_it = table_dst.find(it->getFirst(), it.getHash());
-
-        AggregateDataPtr res_data = table_dst.end() == res_it
-            ? overflows
-            : res_it->getSecond();
-
+        AggregateDataPtr res_data = found ? dst : overflows;
         for (size_t i = 0; i < params.aggregates_size; ++i)
-            aggregate_functions[i]->merge(
-                res_data + offsets_of_aggregate_states[i],
-                it->getSecond() + offsets_of_aggregate_states[i],
-                arena);
-
+            aggregate_functions[i]->merge(res_data + offsets_of_aggregate_states[i], src + offsets_of_aggregate_states[i], arena);
         for (size_t i = 0; i < params.aggregates_size; ++i)
-            aggregate_functions[i]->destroy(it->getSecond() + offsets_of_aggregate_states[i]);
-
-        it->getSecond() = nullptr;
-    }
-
+            aggregate_functions[i]->destroy(src + offsets_of_aggregate_states[i]);
+        src = nullptr;
+    });
     table_src.clearAndShrink();
 }
 
@@ -1567,27 +1544,17 @@ void NO_INLINE Aggregator::mergeDataOnlyExistingKeysImpl(
     if constexpr (Method::low_cardinality_optimization)
         mergeDataNullKey<Method, Table>(table_dst, table_src, arena);
 
-    for (auto it = table_src.begin(); it != table_src.end(); ++it)
+    table_src.mergeToViaFind(table_dst, [&](auto & dst, auto & src, bool found)
     {
-        decltype(it) res_it = table_dst.find(it->getFirst(), it.getHash());
-
-        if (table_dst.end() == res_it)
-            continue;
-
-        AggregateDataPtr res_data = res_it->getSecond();
-
+        if (!found)
+            return;
+        AggregateDataPtr res_data = dst;
         for (size_t i = 0; i < params.aggregates_size; ++i)
-            aggregate_functions[i]->merge(
-                res_data + offsets_of_aggregate_states[i],
-                it->getSecond() + offsets_of_aggregate_states[i],
-                arena);
-
+            aggregate_functions[i]->merge(res_data + offsets_of_aggregate_states[i], src + offsets_of_aggregate_states[i], arena);
         for (size_t i = 0; i < params.aggregates_size; ++i)
-            aggregate_functions[i]->destroy(it->getSecond() + offsets_of_aggregate_states[i]);
-
-        it->getSecond() = nullptr;
-    }
-
+            aggregate_functions[i]->destroy(src + offsets_of_aggregate_states[i]);
+        src = nullptr;
+    });
     table_src.clearAndShrink();
 }
 
@@ -2438,23 +2405,21 @@ std::vector<Block> Aggregator::convertBlockToTwoLevel(const Block & block)
 template <typename Method, typename Table>
 void NO_INLINE Aggregator::destroyImpl(Table & table) const
 {
-    for (auto elem : table)
+    table.forEachMapped([&](auto & data)
     {
-        AggregateDataPtr & data = elem.getSecond();
-
         /** If an exception (usually a lack of memory, the MemoryTracker throws) arose
           *  after inserting the key into a hash table, but before creating all states of aggregate functions,
           *  then data will be equal nullptr.
           */
         if (nullptr == data)
-            continue;
+            return;
 
         for (size_t i = 0; i < params.aggregates_size; ++i)
             if (!aggregate_functions[i]->isState())
                 aggregate_functions[i]->destroy(data + offsets_of_aggregate_states[i]);
 
         data = nullptr;
-    }
+    });
 }
 
 

--- a/dbms/src/Interpreters/Aggregator.h
+++ b/dbms/src/Interpreters/Aggregator.h
@@ -13,6 +13,9 @@
 #include <Common/HashTable/FixedHashMap.h>
 #include <Common/HashTable/HashMap.h>
 #include <Common/HashTable/TwoLevelHashMap.h>
+#include <Common/HashTable/StringHashMap.h>
+#include <Common/HashTable/TwoLevelStringHashMap.h>
+
 #include <Common/ThreadPool.h>
 #include <Common/UInt128.h>
 #include <Common/LRUCache.h>
@@ -69,12 +72,20 @@ using AggregatedDataWithUInt8Key = FixedHashMap<UInt8, AggregateDataPtr>;
 using AggregatedDataWithUInt16Key = FixedHashMap<UInt16, AggregateDataPtr>;
 
 using AggregatedDataWithUInt64Key = HashMap<UInt64, AggregateDataPtr, HashCRC32<UInt64>>;
+
+using AggregatedDataWithShortStringKey = StringHashMap<AggregateDataPtr>;
+
 using AggregatedDataWithStringKey = HashMapWithSavedHash<StringRef, AggregateDataPtr>;
+
 using AggregatedDataWithKeys128 = HashMap<UInt128, AggregateDataPtr, UInt128HashCRC32>;
 using AggregatedDataWithKeys256 = HashMap<UInt256, AggregateDataPtr, UInt256HashCRC32>;
 
 using AggregatedDataWithUInt64KeyTwoLevel = TwoLevelHashMap<UInt64, AggregateDataPtr, HashCRC32<UInt64>>;
+
+using AggregatedDataWithShortStringKeyTwoLevel = TwoLevelStringHashMap<AggregateDataPtr>;
+
 using AggregatedDataWithStringKeyTwoLevel = TwoLevelHashMapWithSavedHash<StringRef, AggregateDataPtr>;
+
 using AggregatedDataWithKeys128TwoLevel = TwoLevelHashMap<UInt128, AggregateDataPtr, UInt128HashCRC32>;
 using AggregatedDataWithKeys256TwoLevel = TwoLevelHashMap<UInt256, AggregateDataPtr, UInt256HashCRC32>;
 
@@ -139,6 +150,8 @@ struct AggregationDataWithNullKeyTwoLevel : public Base
 
 template <typename ... Types>
 using HashTableWithNullKey = AggregationDataWithNullKey<HashMapTable<Types ...>>;
+template <typename ... Types>
+using StringHashTableWithNullKey = AggregationDataWithNullKey<StringHashMap<Types ...>>;
 
 using AggregatedDataWithNullableUInt8Key = AggregationDataWithNullKey<AggregatedDataWithUInt8Key>;
 using AggregatedDataWithNullableUInt16Key = AggregationDataWithNullKey<AggregatedDataWithUInt16Key>;
@@ -149,6 +162,10 @@ using AggregatedDataWithNullableStringKey = AggregationDataWithNullKey<Aggregate
 using AggregatedDataWithNullableUInt64KeyTwoLevel = AggregationDataWithNullKeyTwoLevel<
         TwoLevelHashMap<UInt64, AggregateDataPtr, HashCRC32<UInt64>,
         TwoLevelHashTableGrower<>, HashTableAllocator, HashTableWithNullKey>>;
+
+using AggregatedDataWithNullableShortStringKeyTwoLevel = AggregationDataWithNullKeyTwoLevel<
+        TwoLevelStringHashMap<AggregateDataPtr, HashTableAllocator, StringHashTableWithNullKey>>;
+
 using AggregatedDataWithNullableStringKeyTwoLevel = AggregationDataWithNullKeyTwoLevel<
         TwoLevelHashMapWithSavedHash<StringRef, AggregateDataPtr, DefaultHash<StringRef>,
         TwoLevelHashTableGrower<>, HashTableAllocator, HashTableWithNullKey>>;
@@ -189,14 +206,12 @@ struct AggregationMethodOneNumber
 
 
 /// For the case where there is one string key.
-template <typename TData>
+template <typename TData, bool consecutive_keys_optimization = true>
 struct AggregationMethodString
 {
     using Data = TData;
     using Key = typename Data::key_type;
     using Mapped = typename Data::mapped_type;
-    using iterator = typename Data::iterator;
-    using const_iterator = typename Data::const_iterator;
 
     Data data;
 
@@ -205,7 +220,7 @@ struct AggregationMethodString
     template <typename Other>
     AggregationMethodString(const Other & other) : data(other.data) {}
 
-    using State = ColumnsHashing::HashMethodString<typename Data::value_type, Mapped>;
+    using State = ColumnsHashing::HashMethodString<typename Data::value_type, Mapped, true, consecutive_keys_optimization>;
 
     static const bool low_cardinality_optimization = false;
 
@@ -217,14 +232,12 @@ struct AggregationMethodString
 
 
 /// For the case where there is one fixed-length string key.
-template <typename TData>
+template <typename TData, bool consecutive_keys_optimization = true>
 struct AggregationMethodFixedString
 {
     using Data = TData;
     using Key = typename Data::key_type;
     using Mapped = typename Data::mapped_type;
-    using iterator = typename Data::iterator;
-    using const_iterator = typename Data::const_iterator;
 
     Data data;
 
@@ -233,7 +246,7 @@ struct AggregationMethodFixedString
     template <typename Other>
     AggregationMethodFixedString(const Other & other) : data(other.data) {}
 
-    using State = ColumnsHashing::HashMethodFixedString<typename Data::value_type, Mapped>;
+    using State = ColumnsHashing::HashMethodFixedString<typename Data::value_type, Mapped, true, consecutive_keys_optimization>;
 
     static const bool low_cardinality_optimization = false;
 
@@ -242,6 +255,7 @@ struct AggregationMethodFixedString
         key_columns[0]->insertData(value.first.data, value.first.size);
     }
 };
+
 
 /// Single low cardinality column.
 template <typename SingleColumnMethod>
@@ -253,8 +267,6 @@ struct AggregationMethodSingleLowCardinalityColumn : public SingleColumnMethod
     using Data = typename Base::Data;
     using Key = typename Base::Key;
     using Mapped = typename Base::Mapped;
-    using iterator = typename Base::iterator;
-    using const_iterator = typename Base::const_iterator;
 
     using Base::data;
 
@@ -364,8 +376,6 @@ struct AggregationMethodSerialized
     using Data = TData;
     using Key = typename Data::key_type;
     using Mapped = typename Data::mapped_type;
-    using iterator = typename Data::iterator;
-    using const_iterator = typename Data::const_iterator;
 
     Data data;
 
@@ -433,6 +443,8 @@ struct AggregatedDataVariants : private boost::noncopyable
     std::unique_ptr<AggregationMethodOneNumber<UInt64, AggregatedDataWithUInt64Key>>         key64;
     std::unique_ptr<AggregationMethodString<AggregatedDataWithStringKey>>                    key_string;
     std::unique_ptr<AggregationMethodFixedString<AggregatedDataWithStringKey>>               key_fixed_string;
+    std::unique_ptr<AggregationMethodString<AggregatedDataWithShortStringKey, false>>        key_short_string;
+    std::unique_ptr<AggregationMethodFixedString<AggregatedDataWithShortStringKey, false>>   key_short_fixed_string;
     std::unique_ptr<AggregationMethodKeysFixed<AggregatedDataWithKeys128>>                   keys128;
     std::unique_ptr<AggregationMethodKeysFixed<AggregatedDataWithKeys256>>                   keys256;
     std::unique_ptr<AggregationMethodSerialized<AggregatedDataWithStringKey>>                serialized;
@@ -441,6 +453,8 @@ struct AggregatedDataVariants : private boost::noncopyable
     std::unique_ptr<AggregationMethodOneNumber<UInt64, AggregatedDataWithUInt64KeyTwoLevel>> key64_two_level;
     std::unique_ptr<AggregationMethodString<AggregatedDataWithStringKeyTwoLevel>>            key_string_two_level;
     std::unique_ptr<AggregationMethodFixedString<AggregatedDataWithStringKeyTwoLevel>>       key_fixed_string_two_level;
+    std::unique_ptr<AggregationMethodString<AggregatedDataWithShortStringKeyTwoLevel, false>>       key_short_string_two_level;
+    std::unique_ptr<AggregationMethodFixedString<AggregatedDataWithShortStringKeyTwoLevel, false>>  key_short_fixed_string_two_level;
     std::unique_ptr<AggregationMethodKeysFixed<AggregatedDataWithKeys128TwoLevel>>           keys128_two_level;
     std::unique_ptr<AggregationMethodKeysFixed<AggregatedDataWithKeys256TwoLevel>>           keys256_two_level;
     std::unique_ptr<AggregationMethodSerialized<AggregatedDataWithStringKeyTwoLevel>>        serialized_two_level;
@@ -453,14 +467,14 @@ struct AggregatedDataVariants : private boost::noncopyable
     std::unique_ptr<AggregationMethodSerialized<AggregatedDataWithStringKeyHash64>>          serialized_hash64;
 
     /// Support for nullable keys.
-    std::unique_ptr<AggregationMethodKeysFixed<AggregatedDataWithKeys128, true>>             nullable_keys128;
-    std::unique_ptr<AggregationMethodKeysFixed<AggregatedDataWithKeys256, true>>             nullable_keys256;
-    std::unique_ptr<AggregationMethodKeysFixed<AggregatedDataWithKeys128TwoLevel, true>>     nullable_keys128_two_level;
-    std::unique_ptr<AggregationMethodKeysFixed<AggregatedDataWithKeys256TwoLevel, true>>     nullable_keys256_two_level;
+    std::unique_ptr<AggregationMethodKeysFixed<AggregatedDataWithKeys128, true>>                    nullable_keys128;
+    std::unique_ptr<AggregationMethodKeysFixed<AggregatedDataWithKeys256, true>>                    nullable_keys256;
+    std::unique_ptr<AggregationMethodKeysFixed<AggregatedDataWithKeys128TwoLevel, true>>            nullable_keys128_two_level;
+    std::unique_ptr<AggregationMethodKeysFixed<AggregatedDataWithKeys256TwoLevel, true>>            nullable_keys256_two_level;
 
     /// Support for low cardinality.
-    std::unique_ptr<AggregationMethodSingleLowCardinalityColumn<AggregationMethodOneNumber<UInt8, AggregatedDataWithNullableUInt8Key>>> low_cardinality_key8;
-    std::unique_ptr<AggregationMethodSingleLowCardinalityColumn<AggregationMethodOneNumber<UInt16, AggregatedDataWithNullableUInt16Key>>> low_cardinality_key16;
+    std::unique_ptr<AggregationMethodSingleLowCardinalityColumn<AggregationMethodOneNumber<UInt8, AggregatedDataWithNullableUInt8Key, false>>> low_cardinality_key8;
+    std::unique_ptr<AggregationMethodSingleLowCardinalityColumn<AggregationMethodOneNumber<UInt16, AggregatedDataWithNullableUInt16Key, false>>> low_cardinality_key16;
     std::unique_ptr<AggregationMethodSingleLowCardinalityColumn<AggregationMethodOneNumber<UInt32, AggregatedDataWithNullableUInt64Key>>> low_cardinality_key32;
     std::unique_ptr<AggregationMethodSingleLowCardinalityColumn<AggregationMethodOneNumber<UInt64, AggregatedDataWithNullableUInt64Key>>> low_cardinality_key64;
     std::unique_ptr<AggregationMethodSingleLowCardinalityColumn<AggregationMethodString<AggregatedDataWithNullableStringKey>>> low_cardinality_key_string;
@@ -477,20 +491,24 @@ struct AggregatedDataVariants : private boost::noncopyable
     std::unique_ptr<AggregationMethodKeysFixed<AggregatedDataWithKeys256TwoLevel, false, true>> low_cardinality_keys256_two_level;
 
     /// In this and similar macros, the option without_key is not considered.
-    #define APPLY_FOR_AGGREGATED_VARIANTS(M) \
-        M(key8,                       false) \
-        M(key16,                      false) \
-        M(key32,                      false) \
-        M(key64,                      false) \
-        M(key_string,                 false) \
-        M(key_fixed_string,           false) \
-        M(keys128,                    false) \
-        M(keys256,                    false) \
-        M(serialized,                 false) \
-        M(key32_two_level,            true) \
-        M(key64_two_level,            true) \
-        M(key_string_two_level,       true) \
-        M(key_fixed_string_two_level, true) \
+    #define APPLY_FOR_AGGREGATED_VARIANTS(M)       \
+        M(key8,                             false) \
+        M(key16,                            false) \
+        M(key32,                            false) \
+        M(key64,                            false) \
+        M(key_string,                       false) \
+        M(key_fixed_string,                 false) \
+        M(key_short_string,                 false) \
+        M(key_short_fixed_string,           false) \
+        M(keys128,                          false) \
+        M(keys256,                          false) \
+        M(serialized,                       false) \
+        M(key32_two_level,                  true) \
+        M(key64_two_level,                  true) \
+        M(key_string_two_level,             true) \
+        M(key_fixed_string_two_level,       true) \
+        M(key_short_string_two_level,       true) \
+        M(key_short_fixed_string_two_level, true) \
         M(keys128_two_level,          true) \
         M(keys256_two_level,          true) \
         M(serialized_two_level,       true) \
@@ -623,6 +641,8 @@ struct AggregatedDataVariants : private boost::noncopyable
         M(key64)            \
         M(key_string)       \
         M(key_fixed_string) \
+        M(key_short_string)       \
+        M(key_short_fixed_string) \
         M(keys128)          \
         M(keys256)          \
         M(serialized)       \
@@ -673,6 +693,8 @@ struct AggregatedDataVariants : private boost::noncopyable
         M(key64_two_level)            \
         M(key_string_two_level)       \
         M(key_fixed_string_two_level) \
+        M(key_short_string_two_level)       \
+        M(key_short_fixed_string_two_level) \
         M(keys128_two_level)          \
         M(keys256_two_level)          \
         M(serialized_two_level)       \
@@ -800,6 +822,9 @@ public:
         /// Settings is used to determine cache size. No threads are created.
         size_t max_threads;
 
+        /// Whether to enable short string optimizations
+        bool short_string_optimization;
+
         Params(
             const Block & src_header_,
             const ColumnNumbers & keys_, const AggregateDescriptions & aggregates_,
@@ -808,7 +833,7 @@ public:
             size_t group_by_two_level_threshold_, size_t group_by_two_level_threshold_bytes_,
             size_t max_bytes_before_external_group_by_,
             bool empty_result_for_aggregation_by_empty_set_,
-            const std::string & tmp_path_, size_t max_threads_)
+            const std::string & tmp_path_, size_t max_threads_, bool short_string_optimization_)
             : src_header(src_header_),
             keys(keys_), aggregates(aggregates_), keys_size(keys.size()), aggregates_size(aggregates.size()),
             overflow_row(overflow_row_), max_rows_to_group_by(max_rows_to_group_by_), group_by_overflow_mode(group_by_overflow_mode_),
@@ -816,14 +841,16 @@ public:
             group_by_two_level_threshold(group_by_two_level_threshold_), group_by_two_level_threshold_bytes(group_by_two_level_threshold_bytes_),
             max_bytes_before_external_group_by(max_bytes_before_external_group_by_),
             empty_result_for_aggregation_by_empty_set(empty_result_for_aggregation_by_empty_set_),
-            tmp_path(tmp_path_), max_threads(max_threads_)
+            tmp_path(tmp_path_), max_threads(max_threads_), short_string_optimization(short_string_optimization_)
         {
         }
 
         /// Only parameters that matter during merge.
-        Params(const Block & intermediate_header_,
-            const ColumnNumbers & keys_, const AggregateDescriptions & aggregates_, bool overflow_row_, size_t max_threads_)
-            : Params(Block(), keys_, aggregates_, overflow_row_, 0, OverflowMode::THROW, nullptr, 0, 0, 0, 0, false, "", max_threads_)
+        Params(
+            const Block & intermediate_header_, const ColumnNumbers & keys_, const AggregateDescriptions & aggregates_,
+            bool overflow_row_, size_t max_threads_, bool short_string_optimization_)
+            : Params(Block(), keys_, aggregates_, overflow_row_, 0, OverflowMode::THROW,
+                nullptr, 0, 0, 0, 0, false, "", max_threads_, short_string_optimization_)
         {
             intermediate_header = intermediate_header_;
         }

--- a/dbms/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1562,7 +1562,7 @@ void InterpreterSelectQuery::executeAggregation(Pipeline & pipeline, const Expre
         allow_to_use_two_level_group_by ? settings.group_by_two_level_threshold : SettingUInt64(0),
         allow_to_use_two_level_group_by ? settings.group_by_two_level_threshold_bytes : SettingUInt64(0),
         settings.max_bytes_before_external_group_by, settings.empty_result_for_aggregation_by_empty_set,
-        context.getTemporaryPath(), settings.max_threads);
+        context.getTemporaryPath(), settings.max_threads, settings.short_string_optimization);
 
     /// If there are several sources, then we perform parallel aggregation
     if (pipeline.streams.size() > 1)
@@ -1629,7 +1629,7 @@ void InterpreterSelectQuery::executeAggregation(QueryPipeline & pipeline, const 
                               allow_to_use_two_level_group_by ? settings.group_by_two_level_threshold : SettingUInt64(0),
                               allow_to_use_two_level_group_by ? settings.group_by_two_level_threshold_bytes : SettingUInt64(0),
                               settings.max_bytes_before_external_group_by, settings.empty_result_for_aggregation_by_empty_set,
-                              context.getTemporaryPath(), settings.max_threads);
+                              context.getTemporaryPath(), settings.max_threads, settings.short_string_optimization);
 
     auto transform_params = std::make_shared<AggregatingTransformParams>(params, final);
 
@@ -1694,7 +1694,7 @@ void InterpreterSelectQuery::executeMergeAggregated(Pipeline & pipeline, bool ov
 
     const Settings & settings = context.getSettingsRef();
 
-    Aggregator::Params params(header, keys, aggregates, overflow_row, settings.max_threads);
+    Aggregator::Params params(header, keys, aggregates, overflow_row, settings.max_threads, settings.short_string_optimization);
 
     if (!settings.distributed_aggregation_memory_efficient)
     {
@@ -1745,7 +1745,8 @@ void InterpreterSelectQuery::executeMergeAggregated(QueryPipeline & pipeline, bo
 
     const Settings & settings = context.getSettingsRef();
 
-    Aggregator::Params params(header_before_merge, keys, aggregates, overflow_row, settings.max_threads);
+    Aggregator::Params params(header_before_merge, keys, aggregates, overflow_row,
+                              settings.max_threads, settings.short_string_optimization);
 
     auto transform_params = std::make_shared<AggregatingTransformParams>(params, final);
 
@@ -1850,7 +1851,7 @@ void InterpreterSelectQuery::executeRollupOrCube(Pipeline & pipeline, Modificato
         settings.compile ? &context.getCompiler() : nullptr, settings.min_count_to_compile,
         SettingUInt64(0), SettingUInt64(0),
         settings.max_bytes_before_external_group_by, settings.empty_result_for_aggregation_by_empty_set,
-        context.getTemporaryPath(), settings.max_threads);
+        context.getTemporaryPath(), settings.max_threads, settings.short_string_optimization);
 
     if (modificator == Modificator::ROLLUP)
         pipeline.firstStream() = std::make_shared<RollupBlockInputStream>(pipeline.firstStream(), params);
@@ -1880,7 +1881,7 @@ void InterpreterSelectQuery::executeRollupOrCube(QueryPipeline & pipeline, Modif
                               settings.compile ? &context.getCompiler() : nullptr, settings.min_count_to_compile,
                               SettingUInt64(0), SettingUInt64(0),
                               settings.max_bytes_before_external_group_by, settings.empty_result_for_aggregation_by_empty_set,
-                              context.getTemporaryPath(), settings.max_threads);
+                              context.getTemporaryPath(), settings.max_threads, settings.short_string_optimization);
 
     auto transform_params = std::make_shared<AggregatingTransformParams>(params, true);
 

--- a/dbms/src/Interpreters/tests/CMakeLists.txt
+++ b/dbms/src/Interpreters/tests/CMakeLists.txt
@@ -37,6 +37,12 @@ add_executable (hash_map_string_small hash_map_string_small.cpp)
 target_include_directories (hash_map_string_small SYSTEM BEFORE PRIVATE ${SPARCEHASH_INCLUDE_DIR})
 target_link_libraries (hash_map_string_small PRIVATE dbms)
 
+add_executable (string_hash_map string_hash_map.cpp)
+target_link_libraries (string_hash_map PRIVATE dbms)
+
+add_executable (string_hash_map_aggregation string_hash_map.cpp)
+target_link_libraries (string_hash_map_aggregation PRIVATE dbms)
+
 add_executable (two_level_hash_map two_level_hash_map.cpp)
 target_include_directories (two_level_hash_map SYSTEM BEFORE PRIVATE ${SPARCEHASH_INCLUDE_DIR})
 target_link_libraries (two_level_hash_map PRIVATE dbms)

--- a/dbms/src/Interpreters/tests/aggregate.cpp
+++ b/dbms/src/Interpreters/tests/aggregate.cpp
@@ -79,7 +79,7 @@ int main(int argc, char ** argv)
 
         Aggregator::Params params(
             stream->getHeader(), {0, 1}, aggregate_descriptions,
-            false, 0, OverflowMode::THROW, nullptr, 0, 0, 0, 0, false, "", 1);
+            false, 0, OverflowMode::THROW, nullptr, 0, 0, 0, 0, false, "", 1, 0);
 
         Aggregator aggregator(params);
 

--- a/dbms/src/Interpreters/tests/string_hash_map.cpp
+++ b/dbms/src/Interpreters/tests/string_hash_map.cpp
@@ -1,0 +1,200 @@
+#include <iomanip>
+#include <iostream>
+#include <vector>
+#include <Compression/CompressedReadBuffer.h>
+#include <Core/Types.h>
+#include <IO/ReadBufferFromFile.h>
+#include <IO/ReadHelpers.h>
+#include <Interpreters/AggregationCommon.h>
+#include <Common/HashTable/HashMap.h>
+#include <Common/HashTable/StringHashMap.h>
+#include <Common/Stopwatch.h>
+#include <common/StringRef.h>
+
+/**
+
+#include <fstream>
+#include <random>
+
+using namespace std;
+
+int main()
+{
+    std::string s;
+    std::random_device dev;
+    std::mt19937 rng(dev());
+    std::uniform_int_distribution<std::mt19937::result_type> dist(0, 25);
+    std::binomial_distribution<std::mt19937::result_type> binomial1(100, 0.01);
+    std::binomial_distribution<std::mt19937::result_type> binomial2(100, 0.02);
+    std::binomial_distribution<std::mt19937::result_type> binomial4(100, 0.04);
+    std::binomial_distribution<std::mt19937::result_type> binomial8(100, 0.08);
+    std::binomial_distribution<std::mt19937::result_type> binomial16(100, 0.16);
+    std::binomial_distribution<std::mt19937::result_type> binomial24(100, 0.24);
+    std::binomial_distribution<std::mt19937::result_type> binomial48(100, 0.48);
+    // 11GB
+    std::ofstream f("/tmp/terms.csv");
+    size_t l1, l2, l4, l8, l16, l24, l48;
+    for (auto n = 0ul; n < 1e8; ++n)
+    {
+        l1 = binomial1(rng) + 1;
+        l2 = binomial2(rng) + l1 + 1;
+        l4 = binomial4(rng) + l2 + 1;
+        l8 = binomial8(rng) + l4 + 1;
+        l16 = binomial16(rng) + l8 + 1;
+        l24 = binomial24(rng) + l16 + 1;
+        l48 = binomial48(rng) + l24 + 1;
+        s.resize(l48);
+        for (auto i = 0ul; i < l48 - 1; ++i)
+            s[i] = 'a' + dist(rng);
+        s[l1 - 1] = ',';
+        s[l2 - 1] = ',';
+        s[l4 - 1] = ',';
+        s[l8 - 1] = ',';
+        s[l16 - 1] = ',';
+        s[l24 - 1] = ',';
+        s[l48 - 1] = '\n';
+        f << s;
+    }
+    f.close();
+    return 0;
+}
+
+create table terms (term1 String, term2 String, term4 String, term8 String, term16 String, term24 String, term48 String) engine TinyLog;
+insert into terms select * from file('/tmp/terms.csv', CSV, 'a String, b String, c String, d String, e String, f String, g String');
+
+NOTE: for reliable test results, try isolating cpu cores and do python -m perf tune. Also bind numa nodes if any.
+# isolate cpu 18
+dir=/home/amos/git/chorigin/data/data/default/terms
+for file in term1 term2 term4 term8 term16 term24 term48; do
+    for size in 30000000 50000000 80000000 100000000; do
+        BEST_METHOD=0
+        BEST_RESULT=0
+        for method in {1..2}; do
+            echo -ne $file $size $method ''
+            numactl --membind=0 taskset -c 18 ./string_hash_map $size $method <"$dir"/"$file".bin 2>&1 | perl -nE 'say /([0-9\.]+) elem/g if /HashMap/' | tee /tmp/string_hash_map_res
+            CUR_RESULT=$(cat /tmp/string_hash_map_res | tr -d '.')
+            if [[ $CUR_RESULT -gt $BEST_RESULT ]]; then
+                BEST_METHOD=$method
+                BEST_RESULT=$CUR_RESULT
+            fi
+        done
+        echo Best: $BEST_METHOD - $BEST_RESULT
+    done
+done
+
+---------------------------
+
+term1 30000000 1 68785770.85   term2 30000000 1 42531788.83   term4 30000000 1 14759901.41   term8 30000000 1 8072903.47
+term1 30000000 2 40812128.16   term2 30000000 2 21352402.10   term4 30000000 2 9008907.80    term8 30000000 2 5822641.82
+Best: 1 - 6878577085           Best: 1 - 4253178883           Best: 1 - 1475990141           Best: 1 - 807290347
+term1 50000000 1 68027542.41   term2 50000000 1 40493742.80   term4 50000000 1 16827650.85   term8 50000000 1 7405230.14
+term1 50000000 2 37589806.02   term2 50000000 2 19362975.09   term4 50000000 2 8278094.11    term8 50000000 2 5106810.80
+Best: 1 - 6802754241           Best: 1 - 4049374280           Best: 1 - 1682765085           Best: 1 - 740523014
+term1 80000000 1 68651875.88   term2 80000000 1 38253695.50   term4 80000000 1 15847177.93   term8 80000000 1 7536319.25
+term1 80000000 2 38092189.20   term2 80000000 2 20287003.01   term4 80000000 2 9322770.34    term8 80000000 2 4355572.15
+Best: 1 - 6865187588           Best: 1 - 3825369550           Best: 1 - 1584717793           Best: 1 - 753631925
+term1 100000000 1 68641941.59  term2 100000000 1 39120834.79  term4 100000000 1 16773904.90  term8 100000000 1 7147146.55
+term1 100000000 2 38358006.72  term2 100000000 2 20629363.17  term4 100000000 2 9665201.92   term8 100000000 2 4728255.07
+Best: 1 - 6864194159           Best: 1 - 3912083479           Best: 1 - 1677390490           Best: 1 - 714714655
+
+
+term16 30000000 1 6823029.35        term24 30000000 1 5706271.14        term48 30000000 1 4695716.47
+term16 30000000 2 5672283.33        term24 30000000 2 5498855.56        term48 30000000 2 4860537.26
+Best: 1 - 682302935                 Best: 1 - 570627114                 Best: 2 - 486053726
+term16 50000000 1 6214581.25        term24 50000000 1 5249785.66        term48 50000000 1 4282606.12
+term16 50000000 2 4990361.44        term24 50000000 2 4855552.24        term48 50000000 2 4348923.29
+Best: 1 - 621458125                 Best: 1 - 524978566                 Best: 2 - 434892329
+term16 80000000 1 5382855.70        term24 80000000 1 4580133.04        term48 80000000 1 3779436.15
+term16 80000000 2 4282192.79        term24 80000000 2 4178791.09        term48 80000000 2 3788409.72
+Best: 1 - 538285570                 Best: 1 - 458013304                 Best: 2 - 378840972
+term16 100000000 1 5930103.42       term24 100000000 1 5030621.52       term48 100000000 1 4084666.73
+term16 100000000 2 4621719.60       term24 100000000 2 4499866.83       term48 100000000 2 4067029.31
+Best: 1 - 593010342                 Best: 1 - 503062152                 Best: 1 - 408466673
+
+*/
+
+
+using Value = uint64_t;
+
+template <typename Map>
+void NO_INLINE bench(const std::vector<StringRef> & data, DB::Arena & pool, const char * name)
+{
+    // warm up
+    {
+        Map map;
+        typename Map::iterator it;
+        bool inserted;
+
+        for (size_t i = 0, size = data.size(); i < size; ++i)
+        {
+            map.emplace(data[i], it, inserted, pool);
+            if (inserted)
+                it->getSecond() = 0;
+            ++it->getSecond();
+        }
+    }
+    double best_time = 10000;
+    for (auto t = 0ul; t < 5; ++t)
+    {
+        Stopwatch watch;
+        Map map;
+        typename Map::iterator it;
+        bool inserted;
+
+        for (size_t i = 0, size = data.size(); i < size; ++i)
+        {
+            map.emplace(data[i], it, inserted, pool);
+            if (inserted)
+                it->getSecond() = 0;
+            ++it->getSecond();
+        }
+        watch.stop();
+        best_time = std::min(watch.elapsedSeconds(), best_time);
+    }
+
+    std::cerr << std::fixed << std::setprecision(2) << "HashMap (" << name << "). Elapsed: " << best_time << " (" << data.size() / best_time
+              << " elem/sec.)" << std::endl;
+}
+
+
+int main(int argc, char ** argv)
+{
+    if (argc < 3)
+    {
+        std::cerr << "Usage: program n m\n";
+        return 1;
+    }
+
+    size_t n = atoi(argv[1]);
+    size_t m = atoi(argv[2]);
+
+    DB::Arena pool;
+    std::vector<StringRef> data(n);
+
+    std::cerr << "sizeof(Key) = " << sizeof(StringRef) << ", sizeof(Value) = " << sizeof(Value) << std::endl;
+
+    {
+        Stopwatch watch;
+        DB::ReadBufferFromFileDescriptor in1(STDIN_FILENO);
+        DB::CompressedReadBuffer in2(in1);
+
+        std::string tmp;
+        for (size_t i = 0; i < n && !in2.eof(); ++i)
+        {
+            DB::readStringBinary(tmp, in2);
+            data[i] = StringRef(pool.insert(tmp.data(), tmp.size()), tmp.size());
+        }
+
+        watch.stop();
+        std::cerr << std::fixed << std::setprecision(2) << "Vector. Size: " << n << ", elapsed: " << watch.elapsedSeconds() << " ("
+                  << n / watch.elapsedSeconds() << " elem/sec.)" << std::endl;
+    }
+
+    if (!m || m == 1)
+        bench<StringHashMap<Value>>(data, pool, "StringHashMap");
+    if (!m || m == 2)
+        bench<HashMapWithSavedHash<StringRef, Value>>(data, pool, "HashMapWithSavedHash");
+    if (!m || m == 3)
+        bench<HashMap<StringRef, Value>>(data, pool, "HashMap");
+    return 0;
+}

--- a/dbms/src/Interpreters/tests/string_hash_map_aggregation.cpp
+++ b/dbms/src/Interpreters/tests/string_hash_map_aggregation.cpp
@@ -1,0 +1,218 @@
+#include <iomanip>
+#include <iostream>
+#include <vector>
+#include <Columns/ColumnString.h>
+#include <Compression/CompressedReadBuffer.h>
+#include <Core/Block.h>
+#include <Core/ColumnWithTypeAndName.h>
+#include <Core/Types.h>
+#include <DataStreams/ConcatBlockInputStream.h>
+#include <DataStreams/OneBlockInputStream.h>
+#include <DataTypes/DataTypeFactory.h>
+#include <DataTypes/DataTypeString.h>
+#include <IO/ReadBufferFromFile.h>
+#include <IO/ReadHelpers.h>
+#include <Interpreters/AggregationCommon.h>
+#include <Interpreters/Aggregator.h>
+#include <Common/HashTable/HashMap.h>
+#include <Common/HashTable/StringHashMap.h>
+#include <Common/Stopwatch.h>
+
+
+/*
+
+#include <fstream>
+#include <random>
+
+using namespace std;
+
+int main()
+{
+    std::string s;
+    std::random_device dev;
+    std::mt19937 rng(dev());
+    std::uniform_int_distribution<std::mt19937::result_type> dist(0, 25);
+    std::binomial_distribution<std::mt19937::result_type> binomial1(100, 0.01);
+    std::binomial_distribution<std::mt19937::result_type> binomial2(100, 0.02);
+    std::binomial_distribution<std::mt19937::result_type> binomial4(100, 0.04);
+    std::binomial_distribution<std::mt19937::result_type> binomial8(100, 0.08);
+    std::binomial_distribution<std::mt19937::result_type> binomial16(100, 0.16);
+    std::binomial_distribution<std::mt19937::result_type> binomial24(100, 0.24);
+    std::binomial_distribution<std::mt19937::result_type> binomial48(100, 0.48);
+    // 11GB
+    std::ofstream f("/tmp/terms.csv");
+    size_t l1, l2, l4, l8, l16, l24, l48;
+    for (auto n = 0ul; n < 1e8; ++n)
+    {
+        l1 = binomial1(rng) + 1;
+        l2 = binomial2(rng) + l1 + 1;
+        l4 = binomial4(rng) + l2 + 1;
+        l8 = binomial8(rng) + l4 + 1;
+        l16 = binomial16(rng) + l8 + 1;
+        l24 = binomial24(rng) + l16 + 1;
+        l48 = binomial48(rng) + l24 + 1;
+        s.resize(l48);
+        for (auto i = 0ul; i < l48 - 1; ++i)
+            s[i] = 'a' + dist(rng);
+        s[l1 - 1] = ',';
+        s[l2 - 1] = ',';
+        s[l4 - 1] = ',';
+        s[l8 - 1] = ',';
+        s[l16 - 1] = ',';
+        s[l24 - 1] = ',';
+        s[l48 - 1] = '\n';
+        f << s;
+    }
+    f.close();
+    return 0;
+}
+
+create table terms (term1 String, term2 String, term4 String, term8 String, term16 String, term24 String, term48 String) engine TinyLog;
+insert into terms select * from file('/tmp/terms.csv', CSV, 'a String, b String, c String, d String, e String, f String, g String');
+
+NOTE: for reliable test results, try isolating cpu cores and do python -m perf tune. Also bind numa nodes if any.
+# isolate cpu 18
+dir=/home/amos/git/chorigin/data/data/default/terms
+export BEST
+for file in term1 term2 term4 term8 term16 term24 term48; do
+    for size in 30000000 50000000 80000000 100000000; do
+        echo $file $size" rows"
+        for method in {0..1}; do
+            echo
+            BEST=0
+            for two_level in {0..1}; do
+                for sso in {0..1}; do
+                    printf $two_level$sso"  :  "
+                    numactl --membind=0 taskset -c 18 ./string_hash_map_aggregation $size $method $two_level $sso <"$dir"/"$file".bin 2>&1 | tee /tmp/string_hash_map_res
+                    BEST2=$(perl -nE '/,([0-9\.]+)/; print $1 > $ENV{"BEST"} ? $1 : $ENV{"BEST"};' < /tmp/string_hash_map_res)
+                    if [ ! $BEST2 = $BEST ]; then
+                        BEST=$BEST2
+                        CUR=$two_level$sso
+                    fi
+                done
+            done
+            echo BEST IS $CUR : $BEST
+        done
+        echo
+    done
+done
+
+*/
+
+using namespace DB;
+
+void bench_agg(Block & block, Block & firstblock, int two_level, int sso)
+{
+    size_t n = block.rows();
+    AggregateDescriptions aggregate_descriptions(1);
+    aggregate_descriptions[0].function = std::make_shared<AggregateFunctionCount>(DataTypes{});
+
+    Aggregator::Params params(
+        block.cloneEmpty(), {0}, aggregate_descriptions, false, 0, OverflowMode::THROW, nullptr, 0, two_level, 0, 0, false, "", 1, sso);
+
+    // warm up
+    {
+        AggregatedDataVariants aggregated_data_variants;
+        BlockInputStreamPtr stream = std::make_shared<ConcatBlockInputStream>(std::vector<BlockInputStreamPtr>{
+            std::make_shared<OneBlockInputStream>(firstblock), std::make_shared<OneBlockInputStream>(block)});
+        Aggregator aggregator(params);
+        aggregator.execute(stream, aggregated_data_variants);
+    }
+
+    double best_time = 10000;
+    for (auto i = 0ul; i < 5; ++i)
+    {
+        AggregatedDataVariants aggregated_data_variants;
+        BlockInputStreamPtr stream = std::make_shared<ConcatBlockInputStream>(std::vector<BlockInputStreamPtr>{
+            std::make_shared<OneBlockInputStream>(firstblock), std::make_shared<OneBlockInputStream>(block)});
+        Stopwatch stopwatch;
+        Aggregator aggregator(params);
+        aggregator.execute(stream, aggregated_data_variants);
+        best_time = std::min(best_time, stopwatch.elapsedSeconds());
+    }
+    const char * p[] = {"", "(two_level)", "(sso)", "(two_level, sso)"};
+    std::cout << std::fixed << std::setprecision(2) << "Aggregation" << p[two_level + sso * 2] << " elapsed " << best_time << " sec.,"
+              << n / best_time << " rows/sec. (best in 5)" << std::endl;
+}
+
+void bench_merge(Block & block, Block & firstblock, int two_level, int sso)
+{
+    size_t n = block.rows();
+    AggregateDescriptions aggregate_descriptions(1);
+    aggregate_descriptions[0].function = std::make_shared<AggregateFunctionCount>(DataTypes{});
+
+    Aggregator::Params params(
+        block.cloneEmpty(), {0}, aggregate_descriptions, false, 0, OverflowMode::THROW, nullptr, 0, two_level, 0, 0, false, "", 1, sso);
+    // warm up
+    {
+        AggregatedDataVariantsPtr aggregated_data_variants_ptr = std::make_shared<AggregatedDataVariants>();
+        AggregatedDataVariants & aggregated_data_variants = *aggregated_data_variants_ptr;
+        BlockInputStreamPtr stream = std::make_shared<ConcatBlockInputStream>(std::vector<BlockInputStreamPtr>{
+            std::make_shared<OneBlockInputStream>(firstblock), std::make_shared<OneBlockInputStream>(block)});
+        Aggregator aggregator(params);
+        aggregator.execute(stream, aggregated_data_variants);
+        ManyAggregatedDataVariants many_data{aggregated_data_variants_ptr};
+        auto impl = aggregator.mergeAndConvertToBlocks(many_data, true, 1);
+        while (impl->read())
+            ;
+    }
+
+    double best_time = 10000;
+    for (auto i = 0ul; i < 5; ++i)
+    {
+        AggregatedDataVariantsPtr aggregated_data_variants_ptr = std::make_shared<AggregatedDataVariants>();
+        AggregatedDataVariants & aggregated_data_variants = *aggregated_data_variants_ptr;
+        BlockInputStreamPtr stream = std::make_shared<ConcatBlockInputStream>(std::vector<BlockInputStreamPtr>{
+            std::make_shared<OneBlockInputStream>(firstblock), std::make_shared<OneBlockInputStream>(block)});
+        Aggregator aggregator(params);
+        aggregator.execute(stream, aggregated_data_variants);
+        Stopwatch stopwatch;
+        ManyAggregatedDataVariants many_data{aggregated_data_variants_ptr};
+        auto impl = aggregator.mergeAndConvertToBlocks(many_data, true, 1);
+        while (impl->read())
+            ;
+        best_time = std::min(best_time, stopwatch.elapsedSeconds());
+    }
+    const char * p[] = {"", "(two_level)", "(sso)", "(two_level, sso)"};
+    std::cout << std::fixed << std::setprecision(2) << "Merge" << p[two_level + sso * 2] << " elapsed " << best_time << " sec.,"
+              << n / best_time << " rows/sec. (best in 5)" << std::endl;
+}
+
+int main(int argc, char ** argv)
+{
+    if (argc < 5)
+    {
+        std::cerr << "Usage: program n kind two_level sso\n";
+        return 1;
+    }
+
+    size_t n = atoi(argv[1]);
+    int k = atoi(argv[2]);
+    int t = atoi(argv[3]);
+    int s = atoi(argv[4]);
+    ReadBufferFromFileDescriptor in1(STDIN_FILENO);
+    CompressedReadBuffer in2(in1);
+
+    Block block;
+
+    {
+        ColumnWithTypeAndName column;
+        column.name = "s";
+        column.type = std::make_shared<DataTypeString>();
+        auto col = ColumnString::create();
+        column.type->deserializeBinaryBulk(*col, in2, n, 0);
+        column.column = std::move(col);
+        block.insert(column);
+    }
+
+    // a chance to convert to two level
+    Block firstblock = block.cloneWithoutColumns();
+    size_t columns = block.columns();
+    for (size_t i = 0; i < columns; ++i)
+        firstblock.getByPosition(i).column = block.getByPosition(i).column->cut(0, 1);
+
+    if (k)
+        bench_merge(block, firstblock, t, s);
+    else
+        bench_agg(block, firstblock, t, s);
+}

--- a/dbms/src/Processors/tests/processors_test_aggregation.cpp
+++ b/dbms/src/Processors/tests/processors_test_aggregation.cpp
@@ -231,7 +231,8 @@ try
                 max_bytes_before_external_group_by,
                 false, /// empty_result_for_aggregation_by_empty_set
                 cur_path, /// tmp_path
-                1 /// max_threads
+                1, /// max_threads
+                0
             );
 
         auto agg_params = std::make_shared<AggregatingTransformParams>(params, /* final =*/ false);
@@ -305,7 +306,8 @@ try
                 max_bytes_before_external_group_by,
                 false, /// empty_result_for_aggregation_by_empty_set
                 cur_path, /// tmp_path
-                1 /// max_threads
+                1, /// max_threads
+                0
         );
 
         auto agg_params = std::make_shared<AggregatingTransformParams>(params, /* final =*/ false);

--- a/dbms/tests/queries/0_stateless/00960_string_hash_map.reference
+++ b/dbms/tests/queries/0_stateless/00960_string_hash_map.reference
@@ -1,0 +1,2 @@
+amos	2
+alexey	1

--- a/dbms/tests/queries/0_stateless/00960_string_hash_map.sql
+++ b/dbms/tests/queries/0_stateless/00960_string_hash_map.sql
@@ -1,0 +1,1 @@
+select name, count() from (select arrayJoin(['alexey', 'amos', 'amos']) name) group by name settings short_string_optimization = 1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. 

Add short_string_optimization settings to optimize short string aggregations.

Category (leave one):
- Performance Improvement

## Motivations

There are a lot of string data that acts as an aggregation key all over the place, such as url domains, nick names, key words, rdf attributes, IDs, to name a few. Most of them share a common property: the length is small. A few of them have low cardinalities and are well handled by ClickHouse now, while others generally don't. Since a major portion of time consuming operations related to short strings are based on hash tables, a better hash table is needed for speeding them up for short string keys. No only will it give better aggregation performance, but also help improve Join, Dict and other analytical functions.

## Observations and Current Limitations

Currently strings are represented as StringRefs and a linear probing hash table with saved hash values is used to support all string key related operations. The obvious drawback of this approach is its huge memory overhead. Each short string might results in a StringRef structure that is larger than itself. An naive appproach would be adopting the SSO techniques in major standard libraries that encodes short strings in place of their StringRef structures. However it might lead to even worse memory overhead, and suffer from tons of branch misses due to several branch conditions it introduces.

There are other aspects that can be optimized:

1. It doesn't make sense to save short keys' hash values

2. The loaded piece of memory in the hash computation process can be reused.

3. CRC32 hash works well for both numeric and string values.

4. We can assume strings don't contain zero bytes in middle. (this might not be true, but can be served as an optimization hint)

Side node: ClickHouse's HashMapWithSavedHash is already very efficient in aggregation workloads. I've tested 10+ hashmaps that are all self-claimed to be the fastest one, none of them runs even closed to HashMapWithSavedHash (+20% - 100%). Oh, there are also maps built via Trie, which are generally slower than hashmaps in aggregation workloads.

## Main Ideas and Promising Results

The main idea of this patch is to use string length dispatching so that small string keys will end up in hash tables that are built for integers. It's both CPU and memory efficient than using StringRef for short keys. The outcome is a hashtable that is up to **100% faster** than the original one.

## Unit Testing

In order to get reliable test results, I did the following steps as a prelude:

1. add "isolcpus=5,11 rcu_nocbs=5,11" to boot cmdline to isolate a real cpu (hyperthreaded) for testing

2. `sudo python3 -m perf system tune` to set stable cpu frequency

3. numactl and taskset to make sure local memory access and using the isolated cores

The following tests are all single-threaded.

### Map

StringHashMap is up to 100% faster than both HashMap<StringRef> and HashMapWithSavedHash<StringRef> in small string workloads when tested directly (See string_hash_map.cpp). Here are some results: (termN means the key length is subject to binomial distribution with expectation N)

![image](https://user-images.githubusercontent.com/5085485/58373321-ea88d480-7f5e-11e9-8982-ce7ea953e020.png)

I've also tested StringHashMap with long string dataset (expectation = 48 bytes). It's about 1% slower. I decided to use up to 24 bytes for small strings, same as gcc and clang for their SSO strings. It makes code smaller and properly does faster dispatching.

### Aggregation

StringHashMap is consistently more effcient in the aggregation tests (See string_hash_map_aggregation.cpp bench_agg). The improvement is a bit lower (up to 70%) since the actual time spending on hashmap operations are around 70%. (perf shows the two other major operations are: 1. getKey; and 2. agg function). To complete the comparision, I've also tested the merging process (See string_hash_map_aggregation.cpp bench_merge). As we now have more sequencial memory access during map iterations, the merge process runs faster too. Here are some results:

![image](https://user-images.githubusercontent.com/5085485/58373316-d9d85e80-7f5e-11e9-8a09-82015cdddb68.png)


## End to End Testing (Parallel 40 Threads)

To validate the efficiency of StringHashMap, I've carried on some e2e tests via the SQL interface. The query I used looks like this: `insert into blackhole select term8, count() from terms group by term8`. Here are some results:

![image](https://user-images.githubusercontent.com/5085485/58373313-caf1ac00-7f5e-11e9-99f0-0a7c0d8b8c0a.png)

## Memory Consumption Testing

StringHashMap is very memory efficient compared to HashMap<StringRef>. It doesn't use Arena when keys are shorter than 24 bytes. To achieve this, I changed the emplace API to accept an additional Arena argument that is only used when Key is of type StringRef, wihch replaces the onNewKey method. Here are some results:

![image](https://user-images.githubusercontent.com/5085485/58373309-b6151880-7f5e-11e9-9f9a-67fe9925a21a.png)

To further validate the efficiency, I tried grouping 1 billion small string records with high cardinality. StringHashMap consumes 60GB memory while HashMap<StringRef> 100GB. In addition, https://greg7mdp.github.io/parallel-hashmap/ suggests that two level hash tables use memory in a smooth manner. As we already adopted TwoLevelHashMap, StringHashMap makes it even smoother. Note: the table grower used in StringHashMap (or its two level variant) has its glowing rate set to 1, or else we could end up having too many submaps with a very low fill factor. It also helps make testing stable to different dataset, since some dataset might trigger the grow too early, resulting in unfair comparisions.

## Additional Testing

I've also tested with some real dataset (100M weibo posting dataset with nickname and number of comments). The name cardinality is around 20M and the length distribution is

```
SELECT quantilesExact(0.2, 0.4, 0.6, 0.9, 1)(length(name)) FROM weibo

┌─quantilesExact(0.2, 0.4, 0.6, 0.9, 1)(length(name))─┐
│ [10,12,16,24,45]                                    │
└─────────────────────────────────────────────────────┘
```

Testing SQL: `insert into blackhole select name, count(comments_num) from weibo group by name;`. StringHashMap is 25% faster.

In addition to the StringHashMap work, I've also built a RobinHoodMap because of its recent fame (https://news.ycombinator.com/item?id=12399989 and rust's default hashmap). It turns out that the performance of a hashmap is heavily related to the workloads it's dealing with. For aggregations, ClickHouse's linear probing hashmap outperforms robinhood map by 20%. In fact, it outperforms all hashmaps I could find, which gives me a really hard time when building the map, since there is really nothing to optimize: the code is dead simple. However, there is indeed an opportunity for string keys to use RobinHoodMap due to its variant length property. This might make StringHashMap more efficient. I'll try to enhance it in near future. Also, for long string keys, there are some chances we can do better too.

## Some Implementation Details

### Key Dispatching

The key dispatching process is critical for efficiency. It has to do proper inlining, fast memcpying and hash computation, etc. (See comments in StringHashMap.h for detail)

### Serialization and Merge

After aggregation, there is a workload for extracting key-values from hashmap into actual blocks. This might be a heavy workload when the grouping key has a high cardinality. Since StringHashMap requires converting different cells into a StringRef representation, it consumes addtional cpu resources. In order to avoid unnecessary data conversion, I've turned the iterator inside out (http://journal.stuffwithstuff.com/2013/01/13/iteration-inside-and-out/), and make key disassembling as late as possible, hoping compilers eliminate additional data movements for me. This works well and is even faster due to that strings are stored continuously in the cells, compared to a bunch of randomly allocated StringRef pointers.

### LastElemCache

Building the LastElemCache requires the original StringRef key stored, which drags StringHashMap down as we have to convert the numeric representation to a StringRef. To tackle this, I tried reusing the input key and making sure that onExistingKey wouldn't rollback the cache. (There is also a bug discovered in the Serialized method https://github.com/yandex/ClickHouse/blob/master/dbms/src/Common/ColumnsHashingImpl.h#L243) However, enabling LastElemCache still slows down the aggregation by 20% due to code bloating. Luckily, emplacing keys in the numeric hash table has comparable performance to StringRef comparisons, so we can disable the use_cache without possibly introducing regression. To validate this observation, I've generated three datasets, each of them has 100 million same strings with length <= 8, <= 16, and <=24. Hence, all except one operation will end up hitting the LastElemCache if it's enabled. The test result shows that using StringHashMap without cache is as efficient as using HashMap<StringRef> with cache. That's why I have cached disabled for StringHashMap.

## TODO

1. StringHashMap in Join, Dict and others

2. Apply to serialized method. Need to resolve zeroes in middle

3. In distributed env the two level hash computation is redundant

4. Make compatible to non SSE4.2 build and Big Endianness?

5. Better hash maps for short keys and long keys
