### PR TITLE
Fix json functions constness

### DIFF
--- a/dbms/src/Functions/FunctionsJSON.h
+++ b/dbms/src/Functions/FunctionsJSON.h
@@ -120,11 +120,22 @@ private:
             /// prepare() does Impl-specific preparation before handling each row.
             impl.prepare(Name::name, block, arguments, result_pos);
 
+            bool json_parsed_ok = false;
+            if (col_json_const)
+            {
+                StringRef json{reinterpret_cast<const char *>(&chars[0]), offsets[0] - 1};
+                json_parsed_ok = parser.parse(json);
+            }
+
             for (const auto i : ext::range(0, input_rows_count))
             {
-                StringRef json{reinterpret_cast<const char *>(&chars[offsets[i - 1]]), offsets[i] - offsets[i - 1] - 1};
-                bool ok = parser.parse(json);
+                if (!col_json_const)
+                {
+                    StringRef json{reinterpret_cast<const char *>(&chars[offsets[i - 1]]), offsets[i] - offsets[i - 1] - 1};
+                    json_parsed_ok = parser.parse(json);
+                }
 
+                bool ok = json_parsed_ok;
                 if (ok)
                 {
                     auto it = parser.getRoot();

--- a/dbms/tests/performance/json_extract_without_simdjson.xml
+++ b/dbms/tests/performance/json_extract_without_simdjson.xml
@@ -1,5 +1,5 @@
 <test>
-    <name>json_extract</name>
+    <name>json_extract_without_simdjson</name>
     <type>once</type>
 
     <stop_conditions>
@@ -27,7 +27,7 @@
     </substitutions>
 
     <settings>
-        <allow_simdjson>1</allow_simdjson>
+        <allow_simdjson>0</allow_simdjson>
     </settings>
 
     <query>SELECT count() FROM system.numbers WHERE NOT ignore(JSONExtractString(materialize({json}), 'sparam'))</query>

--- a/dbms/tests/queries/0_stateless/00918_json_functions.reference
+++ b/dbms/tests/queries/0_stateless/00918_json_functions.reference
@@ -64,3 +64,11 @@ Friday
 {}
 "\\n\\u0000"
 "☺"
+--const/non-const mixed--
+a
+b
+c
+d
+e
+u
+v

--- a/dbms/tests/queries/0_stateless/00918_json_functions.sql
+++ b/dbms/tests/queries/0_stateless/00918_json_functions.sql
@@ -72,5 +72,9 @@ SELECT JSONExtractRaw('{"a": "hello", "b": [-100, 200.0, 300], "c":{"d":[121,144
 SELECT JSONExtractRaw('{"a": "hello", "b": [-100, 200.0, 300], "c":{"d":[121,144]}}', 'c', 'd', 3);
 SELECT JSONExtractRaw('{"passed": true}');
 SELECT JSONExtractRaw('{}');
-select JSONExtractRaw('{"abc":"\\n\\u0000"}', 'abc');
-select JSONExtractRaw('{"abc":"\\u263a"}', 'abc');
+SELECT JSONExtractRaw('{"abc":"\\n\\u0000"}', 'abc');
+SELECT JSONExtractRaw('{"abc":"\\u263a"}', 'abc');
+
+SELECT '--const/non-const mixed--';
+SELECT JSONExtractString('["a", "b", "c", "d", "e"]', idx) FROM (SELECT arrayJoin([1,2,3,4,5]) AS idx);
+SELECT JSONExtractString(json, 's') FROM (SELECT arrayJoin(['{"s":"u"}', '{"s":"v"}']) AS json);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Fixed handling mixed const/nonconst cases in JSON functions.

Category (leave one):
- Bug Fix

Changes:
- Fix handling mixed const/non-const cases like `SELECT JSONExtractString('["a", "b", "c", "d", "e"]', idx) FROM (SELECT arrayJoin([1,2,3,4,5]) AS idx)`
- Fix assigning `allow_simdjson` setting for the performance tests