### PR TITLE
ISSUES-5432 fix bad alloc when truncate join storage

### DIFF
--- a/dbms/src/Storages/StorageJoin.h
+++ b/dbms/src/Storages/StorageJoin.h
@@ -43,7 +43,7 @@ public:
 
 private:
     Block sample_block;
-    const Names & key_names;
+    const Names key_names;
     bool use_nulls;
     SizeLimits limits;
     ASTTableJoin::Kind kind;                    /// LEFT | INNER ...

--- a/dbms/tests/queries/0_stateless/00950_bad_alloc_when_truncate_join_storage.sql
+++ b/dbms/tests/queries/0_stateless/00950_bad_alloc_when_truncate_join_storage.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS test.join_test;
+CREATE TABLE test.join_test (number UInt8, value Float32) Engine = Join(ANY, LEFT, number);
+TRUNCATE TABLE test.join_test;
+DROP TABLE IF EXISTS test.join_test;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Fixes #5432

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):

 fix bad alloc when truncate join storage

