### PR TITLE
Disable implicit type conversions in dictGet functions (it's not working)

### DIFF
--- a/dbms/src/Dictionaries/CacheDictionary.cpp
+++ b/dbms/src/Dictionaries/CacheDictionary.cpp
@@ -207,9 +207,7 @@ void CacheDictionary::isInConstantVector(const Key child_id, const PaddedPODArra
 void CacheDictionary::getString(const std::string & attribute_name, const PaddedPODArray<Key> & ids, ColumnString * out) const
 {
     auto & attribute = getAttribute(attribute_name);
-    if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::String))
-        throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type),
-                        ErrorCodes::TYPE_MISMATCH};
+    checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::String);
 
     const auto null_value = StringRef{std::get<String>(attribute.null_values)};
 
@@ -220,9 +218,7 @@ void CacheDictionary::getString(
     const std::string & attribute_name, const PaddedPODArray<Key> & ids, const ColumnString * const def, ColumnString * const out) const
 {
     auto & attribute = getAttribute(attribute_name);
-    if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::String))
-        throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type),
-                        ErrorCodes::TYPE_MISMATCH};
+    checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::String);
 
     getItemsString(attribute, ids, out, [&](const size_t row) { return def->getDataAt(row); });
 }
@@ -231,9 +227,7 @@ void CacheDictionary::getString(
     const std::string & attribute_name, const PaddedPODArray<Key> & ids, const String & def, ColumnString * const out) const
 {
     auto & attribute = getAttribute(attribute_name);
-    if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::String))
-        throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type),
-                        ErrorCodes::TYPE_MISMATCH};
+    checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::String);
 
     getItemsString(attribute, ids, out, [&](const size_t) { return StringRef{def}; });
 }

--- a/dbms/src/Dictionaries/CacheDictionary_generate1.cpp.in
+++ b/dbms/src/Dictionaries/CacheDictionary_generate1.cpp.in
@@ -12,9 +12,7 @@ using TYPE = @NAME@;
 void CacheDictionary::get@NAME@(const std::string & attribute_name, const PaddedPODArray<Key> & ids, ResultArrayType<TYPE> & out) const
 {
     auto & attribute = getAttribute(attribute_name);
-    if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::@NAME@))
-        throw Exception {name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type),
-                         ErrorCodes::TYPE_MISMATCH};
+    checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::@NAME@);
 
     const auto null_value = std::get<TYPE>(attribute.null_values);
 

--- a/dbms/src/Dictionaries/CacheDictionary_generate2.cpp.in
+++ b/dbms/src/Dictionaries/CacheDictionary_generate2.cpp.in
@@ -15,9 +15,7 @@ void CacheDictionary::get@NAME@(const std::string & attribute_name,
       ResultArrayType<TYPE> & out) const
 {
     auto & attribute = getAttribute(attribute_name);
-    if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::@NAME@))
-        throw Exception {name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type),
-                         ErrorCodes::TYPE_MISMATCH};
+    checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::@NAME@);
 
     getItemsNumber<TYPE>(attribute, ids, out, [&](const size_t row) { return def[row]; });
 }

--- a/dbms/src/Dictionaries/CacheDictionary_generate3.cpp.in
+++ b/dbms/src/Dictionaries/CacheDictionary_generate3.cpp.in
@@ -12,9 +12,7 @@ using TYPE = @NAME@;
 void CacheDictionary::get@NAME@(const std::string & attribute_name, const PaddedPODArray<Key> & ids, const TYPE def, ResultArrayType<TYPE> & out) const
 {
     auto & attribute = getAttribute(attribute_name);
-    if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::@NAME@))
-        throw Exception {name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type),
-                         ErrorCodes::TYPE_MISMATCH};
+    checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::@NAME@);
 
     getItemsNumber<TYPE>(attribute, ids, out, [&](const size_t) { return def; });
 }

--- a/dbms/src/Dictionaries/ComplexKeyCacheDictionary.cpp
+++ b/dbms/src/Dictionaries/ComplexKeyCacheDictionary.cpp
@@ -77,9 +77,7 @@ void ComplexKeyCacheDictionary::getString(
     dict_struct.validateKeyTypes(key_types);
 
     auto & attribute = getAttribute(attribute_name);
-    if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::String))
-        throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type),
-                        ErrorCodes::TYPE_MISMATCH};
+    checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::String);
 
     const auto null_value = StringRef{std::get<String>(attribute.null_values)};
 
@@ -96,9 +94,7 @@ void ComplexKeyCacheDictionary::getString(
     dict_struct.validateKeyTypes(key_types);
 
     auto & attribute = getAttribute(attribute_name);
-    if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::String))
-        throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type),
-                        ErrorCodes::TYPE_MISMATCH};
+    checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::String);
 
     getItemsString(attribute, key_columns, out, [&](const size_t row) { return def->getDataAt(row); });
 }
@@ -113,9 +109,7 @@ void ComplexKeyCacheDictionary::getString(
     dict_struct.validateKeyTypes(key_types);
 
     auto & attribute = getAttribute(attribute_name);
-    if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::String))
-        throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type),
-                        ErrorCodes::TYPE_MISMATCH};
+    checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::String);
 
     getItemsString(attribute, key_columns, out, [&](const size_t) { return StringRef{def}; });
 }

--- a/dbms/src/Dictionaries/ComplexKeyCacheDictionary_generate1.cpp.in
+++ b/dbms/src/Dictionaries/ComplexKeyCacheDictionary_generate1.cpp.in
@@ -13,9 +13,7 @@ void ComplexKeyCacheDictionary::get@NAME@(const std::string & attribute_name, co
     dict_struct.validateKeyTypes(key_types);
 
     auto & attribute = getAttribute(attribute_name);
-    if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::@NAME@))
-        throw Exception {name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type),
-                         ErrorCodes::TYPE_MISMATCH};
+    checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::@NAME@);
 
     const auto null_value = std::get<TYPE>(attribute.null_values);
 

--- a/dbms/src/Dictionaries/ComplexKeyCacheDictionary_generate2.cpp.in
+++ b/dbms/src/Dictionaries/ComplexKeyCacheDictionary_generate2.cpp.in
@@ -18,9 +18,7 @@ void ComplexKeyCacheDictionary::get@NAME@(const std::string & attribute_name,
     dict_struct.validateKeyTypes(key_types);
 
     auto & attribute = getAttribute(attribute_name);
-    if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::@NAME@))
-        throw Exception {name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type),
-                         ErrorCodes::TYPE_MISMATCH};
+    checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::@NAME@);
 
     getItemsNumber<TYPE>(attribute, key_columns, out, [&](const size_t row) { return def[row]; });
 }

--- a/dbms/src/Dictionaries/ComplexKeyCacheDictionary_generate3.cpp.in
+++ b/dbms/src/Dictionaries/ComplexKeyCacheDictionary_generate3.cpp.in
@@ -18,9 +18,7 @@ void ComplexKeyCacheDictionary::get@NAME@(const std::string & attribute_name,
     dict_struct.validateKeyTypes(key_types);
 
     auto & attribute = getAttribute(attribute_name);
-    if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::@NAME@))
-        throw Exception {name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type),
-                         ErrorCodes::TYPE_MISMATCH};
+    checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::@NAME@);
 
     getItemsNumber<TYPE>(attribute, key_columns, out, [&](const size_t) { return def; });
 }

--- a/dbms/src/Dictionaries/ComplexKeyHashedDictionary.cpp
+++ b/dbms/src/Dictionaries/ComplexKeyHashedDictionary.cpp
@@ -50,9 +50,7 @@ ComplexKeyHashedDictionary::ComplexKeyHashedDictionary(
         dict_struct.validateKeyTypes(key_types); \
 \
         const auto & attribute = getAttribute(attribute_name); \
-        if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::TYPE)) \
-            throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type), \
-                            ErrorCodes::TYPE_MISMATCH}; \
+        checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::TYPE); \
 \
         const auto null_value = std::get<TYPE>(attribute.null_values); \
 \
@@ -84,9 +82,7 @@ void ComplexKeyHashedDictionary::getString(
     dict_struct.validateKeyTypes(key_types);
 
     const auto & attribute = getAttribute(attribute_name);
-    if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::String))
-        throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type),
-                        ErrorCodes::TYPE_MISMATCH};
+    checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::String);
 
     const auto & null_value = StringRef{std::get<String>(attribute.null_values)};
 
@@ -108,9 +104,7 @@ void ComplexKeyHashedDictionary::getString(
         dict_struct.validateKeyTypes(key_types); \
 \
         const auto & attribute = getAttribute(attribute_name); \
-        if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::TYPE)) \
-            throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type), \
-                            ErrorCodes::TYPE_MISMATCH}; \
+        checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::TYPE); \
 \
         getItemsNumber<TYPE>( \
             attribute, \
@@ -144,9 +138,7 @@ void ComplexKeyHashedDictionary::getString(
     dict_struct.validateKeyTypes(key_types);
 
     const auto & attribute = getAttribute(attribute_name);
-    if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::String))
-        throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type),
-                        ErrorCodes::TYPE_MISMATCH};
+    checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::String);
 
     getItemsImpl<StringRef, StringRef>(
         attribute,
@@ -166,9 +158,7 @@ void ComplexKeyHashedDictionary::getString(
         dict_struct.validateKeyTypes(key_types); \
 \
         const auto & attribute = getAttribute(attribute_name); \
-        if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::TYPE)) \
-            throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type), \
-                            ErrorCodes::TYPE_MISMATCH}; \
+        checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::TYPE); \
 \
         getItemsNumber<TYPE>( \
             attribute, key_columns, [&](const size_t row, const auto value) { out[row] = value; }, [&](const size_t) { return def; }); \
@@ -199,9 +189,7 @@ void ComplexKeyHashedDictionary::getString(
     dict_struct.validateKeyTypes(key_types);
 
     const auto & attribute = getAttribute(attribute_name);
-    if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::String))
-        throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type),
-                        ErrorCodes::TYPE_MISMATCH};
+    checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::String);
 
     getItemsImpl<StringRef, StringRef>(
         attribute,

--- a/dbms/src/Dictionaries/DictionaryStructure.cpp
+++ b/dbms/src/Dictionaries/DictionaryStructure.cpp
@@ -40,44 +40,6 @@ namespace
 } // namespace
 
 
-bool isAttributeTypeConvertibleTo(AttributeUnderlyingType from, AttributeUnderlyingType to)
-{
-    if (from == to)
-        return true;
-
-    /** This enum can be somewhat incomplete and the meaning may not coincide with NumberTraits.h.
-      * (for example, because integers can not be converted to floats)
-      * This is normal for a limited usage scope.
-      */
-    if ((from == AttributeUnderlyingType::UInt8 && to == AttributeUnderlyingType::UInt16)
-        || (from == AttributeUnderlyingType::UInt8 && to == AttributeUnderlyingType::UInt32)
-        || (from == AttributeUnderlyingType::UInt8 && to == AttributeUnderlyingType::UInt64)
-        || (from == AttributeUnderlyingType::UInt16 && to == AttributeUnderlyingType::UInt32)
-        || (from == AttributeUnderlyingType::UInt16 && to == AttributeUnderlyingType::UInt64)
-        || (from == AttributeUnderlyingType::UInt32 && to == AttributeUnderlyingType::UInt64)
-        || (from == AttributeUnderlyingType::UInt8 && to == AttributeUnderlyingType::Int16)
-        || (from == AttributeUnderlyingType::UInt8 && to == AttributeUnderlyingType::Int32)
-        || (from == AttributeUnderlyingType::UInt8 && to == AttributeUnderlyingType::Int64)
-        || (from == AttributeUnderlyingType::UInt16 && to == AttributeUnderlyingType::Int32)
-        || (from == AttributeUnderlyingType::UInt16 && to == AttributeUnderlyingType::Int64)
-        || (from == AttributeUnderlyingType::UInt32 && to == AttributeUnderlyingType::Int64)
-
-        || (from == AttributeUnderlyingType::Int8 && to == AttributeUnderlyingType::Int16)
-        || (from == AttributeUnderlyingType::Int8 && to == AttributeUnderlyingType::Int32)
-        || (from == AttributeUnderlyingType::Int8 && to == AttributeUnderlyingType::Int64)
-        || (from == AttributeUnderlyingType::Int16 && to == AttributeUnderlyingType::Int32)
-        || (from == AttributeUnderlyingType::Int16 && to == AttributeUnderlyingType::Int64)
-        || (from == AttributeUnderlyingType::Int32 && to == AttributeUnderlyingType::Int64)
-
-        || (from == AttributeUnderlyingType::Float32 && to == AttributeUnderlyingType::Float64))
-    {
-        return true;
-    }
-
-    return false;
-}
-
-
 AttributeUnderlyingType getAttributeUnderlyingType(const std::string & type)
 {
     static const std::unordered_map<std::string, AttributeUnderlyingType> dictionary{

--- a/dbms/src/Dictionaries/DictionaryStructure.h
+++ b/dbms/src/Dictionaries/DictionaryStructure.h
@@ -13,6 +13,12 @@
 
 namespace DB
 {
+
+namespace ErrorCodes
+{
+    extern const int TYPE_MISMATCH;
+}
+
 enum class AttributeUnderlyingType
 {
     UInt8,
@@ -33,14 +39,18 @@ enum class AttributeUnderlyingType
 };
 
 
-/** For implicit conversions in dictGet functions.
-  */
-bool isAttributeTypeConvertibleTo(AttributeUnderlyingType from, AttributeUnderlyingType to);
-
 AttributeUnderlyingType getAttributeUnderlyingType(const std::string & type);
 
 std::string toString(const AttributeUnderlyingType type);
 
+/// Implicit conversions in dictGet functions is disabled.
+inline void checkAttributeType(const std::string & dict_name, const std::string & attribute_name,
+                               AttributeUnderlyingType attribute_type, AttributeUnderlyingType to)
+{
+    if (attribute_type != to)
+        throw Exception{dict_name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute_type)
+            + ", expected " + toString(to), ErrorCodes::TYPE_MISMATCH};
+}
 
 /// Min and max lifetimes for a dictionary or it's entry
 using DictionaryLifetime = ExternalLoadableLifetime;

--- a/dbms/src/Dictionaries/FlatDictionary.cpp
+++ b/dbms/src/Dictionaries/FlatDictionary.cpp
@@ -117,9 +117,7 @@ void FlatDictionary::isInConstantVector(const Key child_id, const PaddedPODArray
     void FlatDictionary::get##TYPE(const std::string & attribute_name, const PaddedPODArray<Key> & ids, ResultArrayType<TYPE> & out) const \
     { \
         const auto & attribute = getAttribute(attribute_name); \
-        if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::TYPE)) \
-            throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type), \
-                            ErrorCodes::TYPE_MISMATCH}; \
+        checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::TYPE); \
 \
         const auto null_value = std::get<TYPE>(attribute.null_values); \
 \
@@ -145,9 +143,7 @@ DECLARE(Decimal128)
 void FlatDictionary::getString(const std::string & attribute_name, const PaddedPODArray<Key> & ids, ColumnString * out) const
 {
     const auto & attribute = getAttribute(attribute_name);
-    if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::String))
-        throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type),
-                        ErrorCodes::TYPE_MISMATCH};
+    checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::String);
 
     const auto & null_value = std::get<StringRef>(attribute.null_values);
 
@@ -166,9 +162,7 @@ void FlatDictionary::getString(const std::string & attribute_name, const PaddedP
         ResultArrayType<TYPE> & out) const \
     { \
         const auto & attribute = getAttribute(attribute_name); \
-        if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::TYPE)) \
-            throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type), \
-                            ErrorCodes::TYPE_MISMATCH}; \
+        checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::TYPE); \
 \
         getItemsNumber<TYPE>( \
             attribute, ids, [&](const size_t row, const auto value) { out[row] = value; }, [&](const size_t row) { return def[row]; }); \
@@ -193,9 +187,7 @@ void FlatDictionary::getString(
     const std::string & attribute_name, const PaddedPODArray<Key> & ids, const ColumnString * const def, ColumnString * const out) const
 {
     const auto & attribute = getAttribute(attribute_name);
-    if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::String))
-        throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type),
-                        ErrorCodes::TYPE_MISMATCH};
+    checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::String);
 
     getItemsImpl<StringRef, StringRef>(
         attribute,
@@ -209,9 +201,7 @@ void FlatDictionary::getString(
         const std::string & attribute_name, const PaddedPODArray<Key> & ids, const TYPE def, ResultArrayType<TYPE> & out) const \
     { \
         const auto & attribute = getAttribute(attribute_name); \
-        if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::TYPE)) \
-            throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type), \
-                            ErrorCodes::TYPE_MISMATCH}; \
+        checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::TYPE); \
 \
         getItemsNumber<TYPE>( \
             attribute, ids, [&](const size_t row, const auto value) { out[row] = value; }, [&](const size_t) { return def; }); \
@@ -236,9 +226,7 @@ void FlatDictionary::getString(
     const std::string & attribute_name, const PaddedPODArray<Key> & ids, const String & def, ColumnString * const out) const
 {
     const auto & attribute = getAttribute(attribute_name);
-    if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::String))
-        throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type),
-                        ErrorCodes::TYPE_MISMATCH};
+    checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::String);
 
     FlatDictionary::getItemsImpl<StringRef, StringRef>(
         attribute,

--- a/dbms/src/Dictionaries/HashedDictionary.cpp
+++ b/dbms/src/Dictionaries/HashedDictionary.cpp
@@ -116,9 +116,7 @@ void HashedDictionary::isInConstantVector(const Key child_id, const PaddedPODArr
         const \
     { \
         const auto & attribute = getAttribute(attribute_name); \
-        if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::TYPE)) \
-            throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type), \
-                            ErrorCodes::TYPE_MISMATCH}; \
+        checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::TYPE); \
 \
         const auto null_value = std::get<TYPE>(attribute.null_values); \
 \
@@ -144,9 +142,7 @@ DECLARE(Decimal128)
 void HashedDictionary::getString(const std::string & attribute_name, const PaddedPODArray<Key> & ids, ColumnString * out) const
 {
     const auto & attribute = getAttribute(attribute_name);
-    if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::String))
-        throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type),
-                        ErrorCodes::TYPE_MISMATCH};
+    checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::String);
 
     const auto & null_value = StringRef{std::get<String>(attribute.null_values)};
 
@@ -165,9 +161,7 @@ void HashedDictionary::getString(const std::string & attribute_name, const Padde
         ResultArrayType<TYPE> & out) const \
     { \
         const auto & attribute = getAttribute(attribute_name); \
-        if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::TYPE)) \
-            throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type), \
-                            ErrorCodes::TYPE_MISMATCH}; \
+        checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::TYPE); \
 \
         getItemsNumber<TYPE>( \
             attribute, ids, [&](const size_t row, const auto value) { out[row] = value; }, [&](const size_t row) { return def[row]; }); \
@@ -192,9 +186,7 @@ void HashedDictionary::getString(
     const std::string & attribute_name, const PaddedPODArray<Key> & ids, const ColumnString * const def, ColumnString * const out) const
 {
     const auto & attribute = getAttribute(attribute_name);
-    if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::String))
-        throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type),
-                        ErrorCodes::TYPE_MISMATCH};
+    checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::String);
 
     getItemsImpl<StringRef, StringRef>(
         attribute,
@@ -208,9 +200,7 @@ void HashedDictionary::getString(
         const std::string & attribute_name, const PaddedPODArray<Key> & ids, const TYPE & def, ResultArrayType<TYPE> & out) const \
     { \
         const auto & attribute = getAttribute(attribute_name); \
-        if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::TYPE)) \
-            throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type), \
-                            ErrorCodes::TYPE_MISMATCH}; \
+        checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::TYPE); \
 \
         getItemsNumber<TYPE>( \
             attribute, ids, [&](const size_t row, const auto value) { out[row] = value; }, [&](const size_t) { return def; }); \
@@ -235,9 +225,7 @@ void HashedDictionary::getString(
     const std::string & attribute_name, const PaddedPODArray<Key> & ids, const String & def, ColumnString * const out) const
 {
     const auto & attribute = getAttribute(attribute_name);
-    if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::String))
-        throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type),
-                        ErrorCodes::TYPE_MISMATCH};
+    checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::String);
 
     getItemsImpl<StringRef, StringRef>(
         attribute,

--- a/dbms/src/Dictionaries/TrieDictionary.cpp
+++ b/dbms/src/Dictionaries/TrieDictionary.cpp
@@ -75,9 +75,7 @@ TrieDictionary::~TrieDictionary()
         validateKeyTypes(key_types); \
 \
         const auto & attribute = getAttribute(attribute_name); \
-        if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::TYPE)) \
-            throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type), \
-                            ErrorCodes::TYPE_MISMATCH}; \
+        checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::TYPE); \
 \
         const auto null_value = std::get<TYPE>(attribute.null_values); \
 \
@@ -109,9 +107,7 @@ void TrieDictionary::getString(
     validateKeyTypes(key_types);
 
     const auto & attribute = getAttribute(attribute_name);
-    if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::String))
-        throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type),
-                        ErrorCodes::TYPE_MISMATCH};
+    checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::String);
 
     const auto & null_value = StringRef{std::get<String>(attribute.null_values)};
 
@@ -133,9 +129,7 @@ void TrieDictionary::getString(
         validateKeyTypes(key_types); \
 \
         const auto & attribute = getAttribute(attribute_name); \
-        if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::TYPE)) \
-            throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type), \
-                            ErrorCodes::TYPE_MISMATCH}; \
+        checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::TYPE); \
 \
         getItemsNumber<TYPE>( \
             attribute, \
@@ -169,9 +163,7 @@ void TrieDictionary::getString(
     validateKeyTypes(key_types);
 
     const auto & attribute = getAttribute(attribute_name);
-    if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::String))
-        throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type),
-                        ErrorCodes::TYPE_MISMATCH};
+    checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::String);
 
     getItemsImpl<StringRef, StringRef>(
         attribute,
@@ -191,9 +183,7 @@ void TrieDictionary::getString(
         validateKeyTypes(key_types); \
 \
         const auto & attribute = getAttribute(attribute_name); \
-        if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::TYPE)) \
-            throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type), \
-                            ErrorCodes::TYPE_MISMATCH}; \
+        checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::TYPE); \
 \
         getItemsNumber<TYPE>( \
             attribute, key_columns, [&](const size_t row, const auto value) { out[row] = value; }, [&](const size_t) { return def; }); \
@@ -224,9 +214,7 @@ void TrieDictionary::getString(
     validateKeyTypes(key_types);
 
     const auto & attribute = getAttribute(attribute_name);
-    if (!isAttributeTypeConvertibleTo(attribute.type, AttributeUnderlyingType::String))
-        throw Exception{name + ": type mismatch: attribute " + attribute_name + " has type " + toString(attribute.type),
-                        ErrorCodes::TYPE_MISMATCH};
+    checkAttributeType(name, attribute_name, attribute.type, AttributeUnderlyingType::String);
 
     getItemsImpl<StringRef, StringRef>(
         attribute,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Backward Incompatible Change

Short description (up to few sentences):
Do not try to convert integers in dictGetT functions. Throw an exception instead.

Detailed description (optional):
This functionality has been broken some time ago. You can use dictGet() without type to get correct underlying type or use correct dictGetT() function.