### PR TITLE
Skip ZNONODE during DDL query processing

### DIFF
--- a/dbms/src/Interpreters/DDLWorker.cpp
+++ b/dbms/src/Interpreters/DDLWorker.cpp
@@ -971,6 +971,10 @@ void DDLWorker::runMainThread()
                     }
                 }
             }
+            else if (e.code == Coordination::ZNONODE)
+            {
+                LOG_ERROR(log, "ZooKeeper error: " << getCurrentExceptionMessage(true));
+            }
             else
             {
                 LOG_ERROR(log, "Unexpected ZooKeeper error: " << getCurrentExceptionMessage(true) << ". Terminating.");


### PR DESCRIPTION
Right now if another node removes the znode in task_queue, the one that
did not process it, but already get list of children, will terminated
the DDLWorker thread, and this is very unconvinient because you do not
have any sane way to know is DDLWorker still running or not (except for
timed out DDL queries or via debugger), and the clickhouse-server it
self do not fail either.

This is kind of an RFC, since I'm not sure what is the best way to do this, but I suppose that this will be better then the behavior what clickhouse has now (since simply stopping DDLWorker is not an option). And AFAIU to implement this correctly cleanup should clean tasks that did not processed by all shards, but there is no enough info for this in zookeeper, and if you take dynamic config reloading into account this will require some careness (correct me if I'm wrong)

Fixes: #5064

Category (leave one):
- Bug Fix
