### PR TITLE
Fix union all supertype column

### DIFF
--- a/dbms/src/Columns/getLeastSuperColumn.cpp
+++ b/dbms/src/Columns/getLeastSuperColumn.cpp
@@ -1,0 +1,67 @@
+#include <Columns/getLeastSuperColumn.h>
+#include <Columns/IColumn.h>
+#include <Columns/ColumnConst.h>
+#include <DataTypes/getLeastSupertype.h>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
+static bool sameConstants(const IColumn & a, const IColumn & b)
+{
+    return static_cast<const ColumnConst &>(a).getField() == static_cast<const ColumnConst &>(b).getField();
+}
+
+ColumnWithTypeAndName getLeastSuperColumn(std::vector<const ColumnWithTypeAndName *> columns)
+{
+    if (columns.empty())
+        throw Exception("Logical error: no src columns for supercolumn", ErrorCodes::LOGICAL_ERROR);
+
+    ColumnWithTypeAndName result = *columns[0];
+
+    /// Determine common type.
+
+    size_t num_const = 0;
+    DataTypes types(columns.size());
+    for (size_t i = 0; i < columns.size(); ++i)
+    {
+        types[i] = columns[i]->type;
+        if (columns[i]->column->isColumnConst())
+            ++num_const;
+    }
+
+    result.type = getLeastSupertype(types);
+
+    /// Create supertype column saving constness if possible.
+
+    bool save_constness = false;
+    if (columns.size() == num_const)
+    {
+        save_constness = true;
+        for (size_t i = 1; i < columns.size(); ++i)
+        {
+            const ColumnWithTypeAndName & first = *columns[0];
+            const ColumnWithTypeAndName & other = *columns[i];
+
+            if (!sameConstants(*first.column, *other.column))
+            {
+                save_constness = false;
+                break;
+            }
+        }
+    }
+
+    if (save_constness)
+        result.column = result.type->createColumnConst(1, static_cast<const ColumnConst &>(*columns[0]->column).getField());
+    else
+        result.column = result.type->createColumn();
+
+    return result;
+}
+
+}

--- a/dbms/src/Columns/getLeastSuperColumn.cpp
+++ b/dbms/src/Columns/getLeastSuperColumn.cpp
@@ -57,7 +57,7 @@ ColumnWithTypeAndName getLeastSuperColumn(std::vector<const ColumnWithTypeAndNam
     }
 
     if (save_constness)
-        result.column = result.type->createColumnConst(1, static_cast<const ColumnConst &>(*columns[0]->column).getField());
+        result.column = result.type->createColumnConst(0, static_cast<const ColumnConst &>(*columns[0]->column).getField());
     else
         result.column = result.type->createColumn();
 

--- a/dbms/src/Columns/getLeastSuperColumn.h
+++ b/dbms/src/Columns/getLeastSuperColumn.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <Core/ColumnWithTypeAndName.h>
+
+
+namespace DB
+{
+
+/// getLeastSupertype + related column changes
+ColumnWithTypeAndName getLeastSuperColumn(std::vector<const ColumnWithTypeAndName *> columns);
+
+}

--- a/dbms/tests/queries/0_stateless/00864_union_all_supertype.reference
+++ b/dbms/tests/queries/0_stateless/00864_union_all_supertype.reference
@@ -2,7 +2,7 @@ UInt64	Nullable(String)
 UInt64	Nullable(String)
 Decimal(18, 8)	Nullable(String)
 Decimal(18, 8)	Nullable(String)
-v2	
-v1	\N
 v1	w1
+v1	\N
+v2	
 key1	value1	

--- a/dbms/tests/queries/0_stateless/00864_union_all_supertype.reference
+++ b/dbms/tests/queries/0_stateless/00864_union_all_supertype.reference
@@ -1,0 +1,8 @@
+UInt64	Nullable(String)
+UInt64	Nullable(String)
+Decimal(18, 8)	Nullable(String)
+Decimal(18, 8)	Nullable(String)
+v2	
+v1	\N
+v1	w1
+key1	value1	

--- a/dbms/tests/queries/0_stateless/00864_union_all_supertype.sql
+++ b/dbms/tests/queries/0_stateless/00864_union_all_supertype.sql
@@ -1,0 +1,30 @@
+select toTypeName(key), toTypeName(value) from (
+    select 1 as key, '' as value
+    union all
+    select toUInt64(2) as key, toNullable('') as value
+);
+
+select toTypeName(key), toTypeName(value) from (
+    select toDecimal64(2, 8) as key, toNullable('') as value
+    union all
+    select toDecimal32(2, 4) as key, toFixedString('', 1) as value
+);
+
+select * from (
+    select 'v1' as c1, null as c2
+    union all
+    select 'v2' as c1, '' as c2
+) ALL FULL JOIN (
+    select 'v1' as c1, 'w1' as c2
+) using c1,c2;
+
+select key, s1.value, s2.value
+from (
+    select 'key1' as key, 'value1' as value
+) s1
+all left join (
+    select 'key1' as key, '' as value
+    union all
+    select 'key2' as key, toNullable('') as value
+) s2
+using key;

--- a/dbms/tests/queries/0_stateless/00864_union_all_supertype.sql
+++ b/dbms/tests/queries/0_stateless/00864_union_all_supertype.sql
@@ -16,7 +16,8 @@ select * from (
     select 'v2' as c1, '' as c2
 ) ALL FULL JOIN (
     select 'v1' as c1, 'w1' as c2
-) using c1,c2;
+) using c1,c2
+order by c1, c2;
 
 select key, s1.value, s2.value
 from (


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fix mix UNION ALL result column type. There were cases with inconsistent data and column types of resulting columns.

Detailed description (optional):
UNION ALL calculates resulting column's type as supertype of unioned columns. There was an error that we do not make correct supertyped column for result in some cases. It leads to crashes in later operations on such the mixed columns, ex. in JOINS.