### PR TITLE
Fix build without Brotli (#5513)

### DIFF
--- a/dbms/programs/server/HTTPHandler.cpp
+++ b/dbms/programs/server/HTTPHandler.cpp
@@ -312,11 +312,13 @@ void HTTPHandler::processQuery(
             client_supports_http_compression = true;
             http_response_compression_method = CompressionMethod::Zlib;
         }
+#if USE_BROTLI
         else if (http_response_compression_methods == "br")
         {
             client_supports_http_compression = true;
             http_response_compression_method = CompressionMethod::Brotli;
         }
+#endif
     }
 
     /// Client can pass a 'compress' flag in the query string. In this case the query result is

--- a/dbms/src/IO/WriteBufferFromHTTPServerResponse.cpp
+++ b/dbms/src/IO/WriteBufferFromHTTPServerResponse.cpp
@@ -128,6 +128,7 @@ void WriteBufferFromHTTPServerResponse::nextImpl()
                     deflating_buf.emplace(*out_raw, compression_method, compression_level, working_buffer.size(), working_buffer.begin());
                     out = &*deflating_buf;
                 }
+#if USE_BROTLI
                 else if (compression_method == CompressionMethod::Brotli)
                 {
 #if defined(POCO_CLICKHOUSE_PATCH)
@@ -140,6 +141,7 @@ void WriteBufferFromHTTPServerResponse::nextImpl()
                     brotli_buf.emplace(*out_raw, compression_level, working_buffer.size(), working_buffer.begin());
                     out = &*brotli_buf;
                 }
+#endif
 
                 else
                     throw Exception("Logical error: unknown compression method passed to WriteBufferFromHTTPServerResponse",

--- a/dbms/src/IO/WriteBufferFromHTTPServerResponse.h
+++ b/dbms/src/IO/WriteBufferFromHTTPServerResponse.h
@@ -61,7 +61,9 @@ private:
 
     std::optional<WriteBufferFromOStream> out_raw;
     std::optional<ZlibDeflatingWriteBuffer> deflating_buf;
+#if USE_BROTLI
     std::optional<BrotliWriteBuffer> brotli_buf;
+#endif
 
     WriteBuffer * out = nullptr;     /// Uncompressed HTTP body is written to this buffer. Points to out_raw or possibly to deflating_buf.
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

This patch should fix build without Brotli (https://github.com/yandex/ClickHouse/issues/5513)

For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Fixed build without `Brotli` HTTP compression support (`ENABLE_BROTLI=OFF` cmake variable).