### PR TITLE
DEVTOOLS-5170 Delete Y_IGNORE markers

### DIFF
--- a/contrib/libpcg-random/include/pcg_extras.hpp
+++ b/contrib/libpcg-random/include/pcg_extras.hpp
@@ -81,7 +81,7 @@
     #define PCG_128BIT_CONSTANT(high,low) \
             ((pcg128_t(high) << 64) + low)
 #else
-    #include "pcg_uint128.hpp" // Y_IGNORE
+    #include "pcg_uint128.hpp"
     namespace pcg_extras {
         typedef pcg_extras::uint_x4<uint32_t,uint64_t> pcg128_t;
     }

--- a/contrib/librdkafka-cmake/include/librdkafka/rdkafka.h
+++ b/contrib/librdkafka-cmake/include/librdkafka/rdkafka.h
@@ -1,5 +1,5 @@
 #if __has_include(<rdkafka.h>) // maybe bundled
-#    include_next <rdkafka.h> // Y_IGNORE
+#    include_next <rdkafka.h>
 #else // system
 #    include_next <librdkafka/rdkafka.h>
 #endif

--- a/dbms/programs/client/Client.cpp
+++ b/dbms/programs/client/Client.cpp
@@ -67,7 +67,7 @@
 #include <Storages/ColumnsDescription.h>
 
 #if USE_READLINE
-#include "Suggest.h" // Y_IGNORE
+#include "Suggest.h"
 #endif
 
 #ifndef __clang__

--- a/dbms/programs/main.cpp
+++ b/dbms/programs/main.cpp
@@ -15,7 +15,7 @@
 #endif
 
 #if USE_TCMALLOC
-#include <gperftools/malloc_extension.h> // Y_IGNORE
+#include <gperftools/malloc_extension.h>
 #endif
 
 #include <Common/StringUtils/StringUtils.h>

--- a/dbms/programs/odbc-bridge/ColumnInfoHandler.cpp
+++ b/dbms/programs/odbc-bridge/ColumnInfoHandler.cpp
@@ -3,9 +3,9 @@
 #if USE_POCO_SQLODBC || USE_POCO_DATAODBC
 
 #if USE_POCO_SQLODBC
-#include <Poco/SQL/ODBC/ODBCException.h> // Y_IGNORE
-#include <Poco/SQL/ODBC/SessionImpl.h> // Y_IGNORE
-#include <Poco/SQL/ODBC/Utility.h> // Y_IGNORE
+#include <Poco/SQL/ODBC/ODBCException.h>
+#include <Poco/SQL/ODBC/SessionImpl.h>
+#include <Poco/SQL/ODBC/Utility.h>
 #define POCO_SQL_ODBC_CLASS Poco::SQL::ODBC
 #endif
 #if USE_POCO_DATAODBC

--- a/dbms/programs/odbc-bridge/IdentifierQuoteHandler.cpp
+++ b/dbms/programs/odbc-bridge/IdentifierQuoteHandler.cpp
@@ -2,9 +2,9 @@
 #if USE_POCO_SQLODBC || USE_POCO_DATAODBC
 
 #if USE_POCO_SQLODBC
-#include <Poco/SQL/ODBC/ODBCException.h> // Y_IGNORE
-#include <Poco/SQL/ODBC/SessionImpl.h> // Y_IGNORE
-#include <Poco/SQL/ODBC/Utility.h> // Y_IGNORE
+#include <Poco/SQL/ODBC/ODBCException.h>
+#include <Poco/SQL/ODBC/SessionImpl.h>
+#include <Poco/SQL/ODBC/Utility.h>
 #define POCO_SQL_ODBC_CLASS Poco::SQL::ODBC
 #endif
 #if USE_POCO_DATAODBC

--- a/dbms/programs/odbc-bridge/getIdentifierQuote.cpp
+++ b/dbms/programs/odbc-bridge/getIdentifierQuote.cpp
@@ -2,9 +2,9 @@
 #if USE_POCO_SQLODBC || USE_POCO_DATAODBC
 
 #if USE_POCO_SQLODBC
-#include <Poco/SQL/ODBC/ODBCException.h> // Y_IGNORE
-#include <Poco/SQL/ODBC/SessionImpl.h> // Y_IGNORE
-#include <Poco/SQL/ODBC/Utility.h> // Y_IGNORE
+#include <Poco/SQL/ODBC/ODBCException.h>
+#include <Poco/SQL/ODBC/SessionImpl.h>
+#include <Poco/SQL/ODBC/Utility.h>
 #define POCO_SQL_ODBC_CLASS Poco::SQL::ODBC
 #endif
 #if USE_POCO_DATAODBC

--- a/dbms/programs/odbc-bridge/getIdentifierQuote.h
+++ b/dbms/programs/odbc-bridge/getIdentifierQuote.h
@@ -8,7 +8,7 @@
 #if USE_POCO_SQLODBC || USE_POCO_DATAODBC
 
 #if USE_POCO_SQLODBC
-#include <Poco/SQL/ODBC/Utility.h> // Y_IGNORE
+#include <Poco/SQL/ODBC/Utility.h>
 #endif
 #if USE_POCO_DATAODBC
 #include <Poco/Data/ODBC/Utility.h>

--- a/dbms/src/Common/OptimizedRegularExpression.h
+++ b/dbms/src/Common/OptimizedRegularExpression.h
@@ -6,7 +6,7 @@
 #include <Common/config.h>
 #include <re2/re2.h>
 #if USE_RE2_ST
-    #include <re2_st/re2.h> // Y_IGNORE
+    #include <re2_st/re2.h>
 #else
     #define re2_st re2
 #endif

--- a/dbms/src/Common/getNumberOfPhysicalCPUCores.cpp
+++ b/dbms/src/Common/getNumberOfPhysicalCPUCores.cpp
@@ -7,7 +7,7 @@
 #   include <Common/Exception.h>
     namespace DB { namespace ErrorCodes { extern const int CPUID_ERROR; }}
 #elif USE_CPUINFO
-#   include <cpuinfo.h> // Y_IGNORE
+#   include <cpuinfo.h>
 #endif
 
 

--- a/dbms/src/DataTypes/Native.h
+++ b/dbms/src/DataTypes/Native.h
@@ -16,7 +16,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
-#include <llvm/IR/IRBuilder.h> // Y_IGNORE
+#include <llvm/IR/IRBuilder.h>
 
 #pragma GCC diagnostic pop
 

--- a/dbms/src/Formats/CapnProtoRowInputStream.cpp
+++ b/dbms/src/Formats/CapnProtoRowInputStream.cpp
@@ -3,13 +3,13 @@
 
 #include <IO/ReadBuffer.h>
 #include <Interpreters/Context.h>
-#include <Formats/CapnProtoRowInputStream.h> // Y_IGNORE
+#include <Formats/CapnProtoRowInputStream.h>
 #include <Formats/FormatFactory.h>
 #include <Formats/BlockInputStreamFromRowInputStream.h>
 #include <Formats/FormatSchemaInfo.h>
-#include <capnp/serialize.h> // Y_IGNORE
-#include <capnp/dynamic.h> // Y_IGNORE
-#include <capnp/common.h> // Y_IGNORE
+#include <capnp/serialize.h>
+#include <capnp/dynamic.h>
+#include <capnp/common.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/range/join.hpp>
 #include <common/logger_useful.h>

--- a/dbms/src/Formats/ProtobufSchemas.cpp
+++ b/dbms/src/Formats/ProtobufSchemas.cpp
@@ -2,8 +2,8 @@
 #if USE_PROTOBUF
 
 #include <Formats/FormatSchemaInfo.h>
-#include <Formats/ProtobufSchemas.h> // Y_IGNORE
-#include <google/protobuf/compiler/importer.h> // Y_IGNORE
+#include <Formats/ProtobufSchemas.h>
+#include <google/protobuf/compiler/importer.h>
 #include <Common/Exception.h>
 
 

--- a/dbms/src/Formats/ProtobufWriter.cpp
+++ b/dbms/src/Formats/ProtobufWriter.cpp
@@ -7,8 +7,8 @@
 #include <AggregateFunctions/IAggregateFunction.h>
 #include <DataTypes/DataTypesDecimal.h>
 #include <boost/numeric/conversion/cast.hpp>
-#include <google/protobuf/descriptor.h> // Y_IGNORE
-#include <google/protobuf/descriptor.pb.h> // Y_IGNORE
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/descriptor.pb.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
 #include "ProtobufWriter.h"

--- a/dbms/src/Functions/FunctionBase64Conversion.h
+++ b/dbms/src/Functions/FunctionBase64Conversion.h
@@ -7,7 +7,7 @@
 #include <Functions/FunctionHelpers.h>
 #include <Functions/GatherUtils/Algorithms.h>
 #include <IO/WriteHelpers.h>
-#include <libbase64.h> // Y_IGNORE
+#include <libbase64.h>
 
 
 namespace DB

--- a/dbms/src/Functions/FunctionBinaryArithmetic.h
+++ b/dbms/src/Functions/FunctionBinaryArithmetic.h
@@ -24,7 +24,7 @@
 #if USE_EMBEDDED_COMPILER
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-#include <llvm/IR/IRBuilder.h> // Y_IGNORE
+#include <llvm/IR/IRBuilder.h>
 #pragma GCC diagnostic pop
 #endif
 

--- a/dbms/src/Functions/FunctionMathBinaryFloat64.h
+++ b/dbms/src/Functions/FunctionMathBinaryFloat64.h
@@ -22,8 +22,8 @@
         #pragma clang diagnostic ignored "-Wshift-negative-value"
     #endif
 
-    #include <vectorf128.h> // Y_IGNORE
-    #include <vectormath_exp.h> // Y_IGNORE
+    #include <vectorf128.h>
+    #include <vectormath_exp.h>
 
     #ifdef __clang__
         #pragma clang diagnostic pop

--- a/dbms/src/Functions/FunctionMathUnaryFloat64.h
+++ b/dbms/src/Functions/FunctionMathUnaryFloat64.h
@@ -21,9 +21,9 @@
         #pragma clang diagnostic ignored "-Wshift-negative-value"
     #endif
 
-    #include <vectorf128.h> // Y_IGNORE
-    #include <vectormath_exp.h> // Y_IGNORE
-    #include <vectormath_trig.h> // Y_IGNORE
+    #include <vectorf128.h>
+    #include <vectormath_exp.h>
+    #include <vectormath_trig.h>
 
     #ifdef __clang__
         #pragma clang diagnostic pop

--- a/dbms/src/Functions/FunctionUnaryArithmetic.h
+++ b/dbms/src/Functions/FunctionUnaryArithmetic.h
@@ -13,7 +13,7 @@
 #if USE_EMBEDDED_COMPILER
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-#include <llvm/IR/IRBuilder.h> // Y_IGNORE
+#include <llvm/IR/IRBuilder.h>
 #pragma GCC diagnostic pop
 #endif
 

--- a/dbms/src/Functions/FunctionsHashing.h
+++ b/dbms/src/Functions/FunctionsHashing.h
@@ -12,7 +12,7 @@
 
 #include <Common/config.h>
 #if USE_XXHASH
-#   include <xxhash.h> // Y_IGNORE
+#   include <xxhash.h>
 #endif
 
 #if USE_SSL

--- a/dbms/src/Functions/FunctionsLogical.h
+++ b/dbms/src/Functions/FunctionsLogical.h
@@ -18,7 +18,7 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-#include <llvm/IR/IRBuilder.h> // Y_IGNORE
+#include <llvm/IR/IRBuilder.h>
 #pragma GCC diagnostic pop
 #endif
 

--- a/dbms/src/Functions/FunctionsStringRegex.cpp
+++ b/dbms/src/Functions/FunctionsStringRegex.cpp
@@ -27,7 +27,7 @@
 #endif
 
 #if USE_RE2_ST
-#    include <re2_st/re2.h> // Y_IGNORE
+#    include <re2_st/re2.h>
 #else
 #    define re2_st re2
 #endif

--- a/dbms/src/Functions/IFunction.cpp
+++ b/dbms/src/Functions/IFunction.cpp
@@ -25,7 +25,7 @@
 #if USE_EMBEDDED_COMPILER
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-#include <llvm/IR/IRBuilder.h> // Y_IGNORE
+#include <llvm/IR/IRBuilder.h>
 #pragma GCC diagnostic pop
 #endif
 

--- a/dbms/src/IO/BrotliReadBuffer.cpp
+++ b/dbms/src/IO/BrotliReadBuffer.cpp
@@ -2,7 +2,7 @@
 #if USE_BROTLI
 
 #include "BrotliReadBuffer.h"
-#include <brotli/decode.h> // Y_IGNORE
+#include <brotli/decode.h>
 
 namespace DB
 {

--- a/dbms/src/IO/HDFSCommon.h
+++ b/dbms/src/IO/HDFSCommon.h
@@ -4,7 +4,7 @@
 #include <Poco/URI.h>
 
 #if USE_HDFS
-#include <hdfs/hdfs.h> // Y_IGNORE
+#include <hdfs/hdfs.h>
 
 namespace DB
 {

--- a/dbms/src/IO/ReadBufferFromHDFS.cpp
+++ b/dbms/src/IO/ReadBufferFromHDFS.cpp
@@ -2,10 +2,10 @@
 
 #if USE_HDFS
 
-#include <IO/ReadBufferFromHDFS.h> // Y_IGNORE
+#include <IO/ReadBufferFromHDFS.h>
 #include <IO/HDFSCommon.h>
 #include <Poco/URI.h>
-#include <hdfs/hdfs.h> // Y_IGNORE
+#include <hdfs/hdfs.h>
 
 
 namespace DB

--- a/dbms/src/IO/WriteBufferFromHDFS.cpp
+++ b/dbms/src/IO/WriteBufferFromHDFS.cpp
@@ -3,9 +3,9 @@
 #if USE_HDFS
 
 #include <Poco/URI.h>
-#include <IO/WriteBufferFromHDFS.h> // Y_IGNORE
+#include <IO/WriteBufferFromHDFS.h>
 #include <IO/HDFSCommon.h>
-#include <hdfs/hdfs.h> // Y_IGNORE
+#include <hdfs/hdfs.h>
 
 
 namespace DB

--- a/dbms/src/Interpreters/AsynchronousMetrics.cpp
+++ b/dbms/src/Interpreters/AsynchronousMetrics.cpp
@@ -17,7 +17,7 @@
 #endif
 
 #if USE_TCMALLOC
-    #include <gperftools/malloc_extension.h> // Y_IGNORE
+    #include <gperftools/malloc_extension.h>
 
     /// Initializing malloc extension in global constructor as required.
     struct MallocExtensionInitializer

--- a/dbms/src/Interpreters/ExpressionJIT.cpp
+++ b/dbms/src/Interpreters/ExpressionJIT.cpp
@@ -19,38 +19,30 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
 
-/** Y_IGNORE marker means that this header is not analyzed by Arcadia build system.
-  * "Arcadia" is the name of internal Yandex source code repository.
-  * ClickHouse have limited support for build in Arcadia
-  * (ClickHouse source code is used in another Yandex products as a library).
-  * Some libraries are not enabled when build inside Arcadia is used,
-  *  that what does Y_IGNORE indicate.
-  */
-
-#include <llvm/Analysis/TargetTransformInfo.h> // Y_IGNORE
-#include <llvm/Config/llvm-config.h> // Y_IGNORE
-#include <llvm/IR/BasicBlock.h> // Y_IGNORE
-#include <llvm/IR/DataLayout.h> // Y_IGNORE
-#include <llvm/IR/DerivedTypes.h> // Y_IGNORE
-#include <llvm/IR/Function.h> // Y_IGNORE
-#include <llvm/IR/IRBuilder.h> // Y_IGNORE
-#include <llvm/IR/LLVMContext.h> // Y_IGNORE
-#include <llvm/IR/Mangler.h> // Y_IGNORE
-#include <llvm/IR/Module.h> // Y_IGNORE
-#include <llvm/IR/Type.h> // Y_IGNORE
-#include <llvm/ExecutionEngine/ExecutionEngine.h> // Y_IGNORE
-#include <llvm/ExecutionEngine/JITSymbol.h> // Y_IGNORE
-#include <llvm/ExecutionEngine/SectionMemoryManager.h> // Y_IGNORE
-#include <llvm/ExecutionEngine/Orc/CompileUtils.h> // Y_IGNORE
-#include <llvm/ExecutionEngine/Orc/IRCompileLayer.h> // Y_IGNORE
-#include <llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h> // Y_IGNORE
-#include <llvm/Target/TargetMachine.h> // Y_IGNORE
-#include <llvm/MC/SubtargetFeature.h> // Y_IGNORE
-#include <llvm/Support/DynamicLibrary.h> // Y_IGNORE
-#include <llvm/Support/Host.h> // Y_IGNORE
-#include <llvm/Support/TargetRegistry.h> // Y_IGNORE
-#include <llvm/Support/TargetSelect.h> // Y_IGNORE
-#include <llvm/Transforms/IPO/PassManagerBuilder.h> // Y_IGNORE
+#include <llvm/Analysis/TargetTransformInfo.h>
+#include <llvm/Config/llvm-config.h>
+#include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/DataLayout.h>
+#include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Mangler.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Type.h>
+#include <llvm/ExecutionEngine/ExecutionEngine.h>
+#include <llvm/ExecutionEngine/JITSymbol.h>
+#include <llvm/ExecutionEngine/SectionMemoryManager.h>
+#include <llvm/ExecutionEngine/Orc/CompileUtils.h>
+#include <llvm/ExecutionEngine/Orc/IRCompileLayer.h>
+#include <llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h>
+#include <llvm/Target/TargetMachine.h>
+#include <llvm/MC/SubtargetFeature.h>
+#include <llvm/Support/DynamicLibrary.h>
+#include <llvm/Support/Host.h>
+#include <llvm/Support/TargetRegistry.h>
+#include <llvm/Support/TargetSelect.h>
+#include <llvm/Transforms/IPO/PassManagerBuilder.h>
 
 #pragma GCC diagnostic pop
 

--- a/dbms/src/Storages/StorageHDFS.cpp
+++ b/dbms/src/Storages/StorageHDFS.cpp
@@ -3,12 +3,12 @@
 #if USE_HDFS
 
 #include <Storages/StorageFactory.h>
-#include <Storages/StorageHDFS.h> // Y_IGNORE
+#include <Storages/StorageHDFS.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/evaluateConstantExpression.h>
 #include <Parsers/ASTLiteral.h>
-#include <IO/ReadBufferFromHDFS.h> // Y_IGNORE
-#include <IO/WriteBufferFromHDFS.h> // Y_IGNORE
+#include <IO/ReadBufferFromHDFS.h>
+#include <IO/WriteBufferFromHDFS.h>
 #include <Formats/FormatFactory.h>
 #include <DataStreams/IBlockOutputStream.h>
 #include <DataStreams/UnionBlockInputStream.h>

--- a/dbms/src/TableFunctions/TableFunctionHDFS.cpp
+++ b/dbms/src/TableFunctions/TableFunctionHDFS.cpp
@@ -1,9 +1,9 @@
 #include <Common/config.h>
 
 #if USE_HDFS
-#include <Storages/StorageHDFS.h> // Y_IGNORE
+#include <Storages/StorageHDFS.h>
 #include <TableFunctions/TableFunctionFactory.h>
-#include <TableFunctions/TableFunctionHDFS.h> // Y_IGNORE
+#include <TableFunctions/TableFunctionHDFS.h>
 
 namespace DB
 {

--- a/libs/libcommon/src/DateLUTImpl.cpp
+++ b/libs/libcommon/src/DateLUTImpl.cpp
@@ -1,13 +1,13 @@
 #if __has_include(<cctz/civil_time.h>)
 #include <cctz/civil_time.h> // bundled, debian
 #else
-#include <civil_time.h> // Y_IGNORE // freebsd
+#include <civil_time.h> // freebsd
 #endif
 
 #if __has_include(<cctz/time_zone.h>)
 #include <cctz/time_zone.h>
 #else
-#include <time_zone.h> // Y_IGNORE
+#include <time_zone.h>
 #endif
 
 #include <common/DateLUTImpl.h>

--- a/libs/libmysqlxx/src/Connection.cpp
+++ b/libs/libmysqlxx/src/Connection.cpp
@@ -1,5 +1,5 @@
 #if __has_include(<mariadb/mysql.h>)
-#include <mariadb/mysql.h> // Y_IGNORE
+#include <mariadb/mysql.h>
 #else
 #include <mysql/mysql.h>
 #endif

--- a/libs/libmysqlxx/src/Exception.cpp
+++ b/libs/libmysqlxx/src/Exception.cpp
@@ -1,5 +1,5 @@
 #if __has_include(<mariadb/mysql.h>)
-#include <mariadb/mysql.h> // Y_IGNORE
+#include <mariadb/mysql.h>
 #else
 #include <mysql/mysql.h>
 #endif

--- a/libs/libmysqlxx/src/Pool.cpp
+++ b/libs/libmysqlxx/src/Pool.cpp
@@ -1,6 +1,6 @@
 #if __has_include(<mariadb/mysql.h>)
-#include <mariadb/mysql.h> // Y_IGNORE
-#include <mariadb/mysqld_error.h> // Y_IGNORE
+#include <mariadb/mysql.h>
+#include <mariadb/mysqld_error.h>
 #else
 #include <mysql/mysql.h>
 #include <mysql/mysqld_error.h>

--- a/libs/libmysqlxx/src/Query.cpp
+++ b/libs/libmysqlxx/src/Query.cpp
@@ -1,5 +1,5 @@
 #if __has_include(<mariadb/mysql.h>)
-#include <mariadb/mysql.h> // Y_IGNORE
+#include <mariadb/mysql.h>
 #else
 #include <mysql/mysql.h>
 #endif

--- a/libs/libmysqlxx/src/ResultBase.cpp
+++ b/libs/libmysqlxx/src/ResultBase.cpp
@@ -1,5 +1,5 @@
 #if __has_include(<mariadb/mysql.h>)
-#include <mariadb/mysql.h> // Y_IGNORE
+#include <mariadb/mysql.h>
 #else
 #include <mysql/mysql.h>
 #endif

--- a/libs/libmysqlxx/src/Row.cpp
+++ b/libs/libmysqlxx/src/Row.cpp
@@ -1,5 +1,5 @@
 #if __has_include(<mariadb/mysql.h>)
-#include <mariadb/mysql.h> // Y_IGNORE
+#include <mariadb/mysql.h>
 #else
 #include <mysql/mysql.h>
 #endif

--- a/libs/libmysqlxx/src/StoreQueryResult.cpp
+++ b/libs/libmysqlxx/src/StoreQueryResult.cpp
@@ -1,5 +1,5 @@
 #if __has_include(<mariadb/mysql.h>)
-#include <mariadb/mysql.h> // Y_IGNORE
+#include <mariadb/mysql.h>
 #else
 #include <mysql/mysql.h>
 #endif

--- a/libs/libmysqlxx/src/UseQueryResult.cpp
+++ b/libs/libmysqlxx/src/UseQueryResult.cpp
@@ -1,5 +1,5 @@
 #if __has_include(<mariadb/mysql.h>)
-#include <mariadb/mysql.h> // Y_IGNORE
+#include <mariadb/mysql.h>
 #else
 #include <mysql/mysql.h>
 #endif


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Improvement

Short description (up to few sentences):

Delete Y_IGNORE markers. They have been superseded by a new include resolution configuration that lives outside clickhouse source tree.