### PR TITLE
Fix a typo in a Decimal exception

### DIFF
--- a/dbms/src/DataTypes/DataTypesDecimal.cpp
+++ b/dbms/src/DataTypes/DataTypesDecimal.cpp
@@ -212,7 +212,7 @@ DataTypePtr createDecimal(UInt64 precision_value, UInt64 scale_value)
         throw Exception("Wrong precision", ErrorCodes::ARGUMENT_OUT_OF_BOUND);
 
     if (static_cast<UInt64>(scale_value) > precision_value)
-        throw Exception("Negative scales and scales larger than presicion are not supported", ErrorCodes::ARGUMENT_OUT_OF_BOUND);
+        throw Exception("Negative scales and scales larger than precision are not supported", ErrorCodes::ARGUMENT_OUT_OF_BOUND);
 
     if (precision_value <= maxDecimalPrecision<Decimal32>())
         return std::make_shared<DataTypeDecimal<Decimal32>>(precision_value, scale_value);


### PR DESCRIPTION
(presicion -> precision)

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en