### PR TITLE
Support more AlterType in distribute DDL

### DIFF
--- a/dbms/src/Interpreters/DDLWorker.cpp
+++ b/dbms/src/Interpreters/DDLWorker.cpp
@@ -207,7 +207,6 @@ static bool isSupportedAlterType(int type)
         ASTAlterCommand::DROP_PARTITION,
         ASTAlterCommand::DELETE,
         ASTAlterCommand::UPDATE,
-
         ASTAlterCommand::COMMENT_COLUMN,
         ASTAlterCommand::MODIFY_ORDER_BY,
         ASTAlterCommand::MODIFY_TTL,

--- a/dbms/src/Interpreters/DDLWorker.cpp
+++ b/dbms/src/Interpreters/DDLWorker.cpp
@@ -207,6 +207,12 @@ static bool isSupportedAlterType(int type)
         ASTAlterCommand::DROP_PARTITION,
         ASTAlterCommand::DELETE,
         ASTAlterCommand::UPDATE,
+
+        ASTAlterCommand::COMMENT_COLUMN,
+        ASTAlterCommand::MODIFY_ORDER_BY,
+        ASTAlterCommand::MODIFY_TTL,
+        ASTAlterCommand::ADD_INDEX,
+        ASTAlterCommand::DROP_INDEX,
     };
 
     return supported_alter_types.count(type) != 0;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

Short description (up to few sentences):

It's possible to support more AlterType  in distribute DDLWorker .

Detailed description (optional):


Added AlterTypes
```
        ASTAlterCommand::COMMENT_COLUMN,
        ASTAlterCommand::MODIFY_ORDER_BY,
        ASTAlterCommand::MODIFY_TTL,
        ASTAlterCommand::ADD_INDEX,
        ASTAlterCommand::DROP_INDEX
```


