### PR TITLE
Fix documentation concerning IPv4/IPv6 CIDR function

### DIFF
--- a/docs/en/query_language/functions/ip_address_functions.md
+++ b/docs/en/query_language/functions/ip_address_functions.md
@@ -147,35 +147,35 @@ SELECT
 └─────────────────────────────────────┴─────────────────────┘
 ```
 
-## IPv4CIDRtoIPv4Range(ipv4, cidr),
+## IPv4CIDRToRange(ipv4, cidr),
 
 Accepts an IPv4 and an UInt8 value containing the CIDR. Return a tuple with two IPv4 containing the lower range and the higher range of the subnet.
 
 
 ```sql
-SELECT IPv4CIDRtoIPv4Range(toIPv4('192.168.5.2'), 16)
+SELECT IPv4CIDRToRange(toIPv4('192.168.5.2'), 16)
 ```
 
 ```
-┌─IPv4CIDRtoIPv4Range(toIPv4('192.168.5.2'), 16)─┐
-│ ('192.168.0.0','192.168.255.255')              │
-└────────────────────────────────────────────────┘
+┌─IPv4CIDRToRange(toIPv4('192.168.5.2'), 16)─┐
+│ ('192.168.0.0','192.168.255.255')          │
+└────────────────────────────────────────────┘
 ```
 
 
-## IPv6CIDRtoIPv6Range(ipv6, cidr),
+## IPv6CIDRToRange(ipv6, cidr),
 
 Accepts an IPv6 and an UInt8 value containing the CIDR. Return a tuple with two IPv6 containing the lower range and the higher range of the subnet.
 
 
 ```sql
-SELECT IPv6CIDRtoIPv6Range(toIPv6('2001:0db8:0000:85a3:0000:0000:ac1f:8001'), 32);
+SELECT IPv6CIDRToRange(toIPv6('2001:0db8:0000:85a3:0000:0000:ac1f:8001'), 32);
 ```
 
 ```
-┌─IPv6CIDRtoIPv6Range(toIPv6('2001:0db8:0000:85a3:0000:0000:ac1f:8001'), 32)─┐
-│ ('2001:db8::','2001:db8:ffff:ffff:ffff:ffff:ffff:ffff')                    │
-└────────────────────────────────────────────────────────────────────────────┘
+┌─IPv6CIDRToRange(toIPv6('2001:0db8:0000:85a3:0000:0000:ac1f:8001'), 32)─┐
+│ ('2001:db8::','2001:db8:ffff:ffff:ffff:ffff:ffff:ffff')                │
+└────────────────────────────────────────────────────────────────────────┘
 ```
 
 ## toIPv4(string)

--- a/docs/zh/query_language/functions/ip_address_functions.md
+++ b/docs/zh/query_language/functions/ip_address_functions.md
@@ -147,35 +147,35 @@ SELECT
 └─────────────────────────────────────┴─────────────────────┘
 ```
 
-## IPv4CIDRtoIPv4Range(ipv4, cidr),
+## IPv4CIDRToRange(ipv4, cidr),
 
 接受一个IPv4地址以及一个UInt8类型的CIDR。返回包含子网最低范围以及最高范围的元组。
 
 
 ```sql
-SELECT IPv4CIDRtoIPv4Range(toIPv4('192.168.5.2'), 16)
+SELECT IPv4CIDRToRange(toIPv4('192.168.5.2'), 16)
 ```
 
 ```
-┌─IPv4CIDRtoIPv4Range(toIPv4('192.168.5.2'), 16)─┐
-│ ('192.168.0.0','192.168.255.255')              │
-└────────────────────────────────────────────────┘
+┌─IPv4CIDRToRange(toIPv4('192.168.5.2'), 16)─┐
+│ ('192.168.0.0','192.168.255.255')          │
+└────────────────────────────────────────────┘
 ```
 
 
-## IPv6CIDRtoIPv6Range(ipv6, cidr),
+## IPv6CIDRToRange(ipv6, cidr),
 
 接受一个IPv6地址以及一个UInt8类型的CIDR。返回包含子网最低范围以及最高范围的元组。
 
 
 ```sql
-SELECT IPv6CIDRtoIPv6Range(toIPv6('2001:0db8:0000:85a3:0000:0000:ac1f:8001'), 32);
+SELECT IPv6CIDRToRange(toIPv6('2001:0db8:0000:85a3:0000:0000:ac1f:8001'), 32);
 ```
 
 ```
-┌─IPv6CIDRtoIPv6Range(toIPv6('2001:0db8:0000:85a3:0000:0000:ac1f:8001'), 32)─┐
-│ ('2001:db8::','2001:db8:ffff:ffff:ffff:ffff:ffff:ffff')                    │
-└────────────────────────────────────────────────────────────────────────────┘
+┌─IPv6CIDRToRange(toIPv6('2001:0db8:0000:85a3:0000:0000:ac1f:8001'), 32)─┐
+│ ('2001:db8::','2001:db8:ffff:ffff:ffff:ffff:ffff:ffff')                │
+└────────────────────────────────────────────────────────────────────────┘
 ```
 
 ## toIPv4(string)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Short description:
Just a documentation modfication as the function concerning the IPv4 function using a CIDR range got renamed.