### PR TITLE
make isSupportedAlterType better

### DIFF
--- a/dbms/src/Interpreters/DDLWorker.cpp
+++ b/dbms/src/Interpreters/DDLWorker.cpp
@@ -200,21 +200,16 @@ static std::unique_ptr<zkutil::Lock> createSimpleZooKeeperLock(
 
 static bool isSupportedAlterType(int type)
 {
-    static const std::unordered_set<int> supported_alter_types{
-        ASTAlterCommand::ADD_COLUMN,
-        ASTAlterCommand::DROP_COLUMN,
-        ASTAlterCommand::MODIFY_COLUMN,
-        ASTAlterCommand::DROP_PARTITION,
-        ASTAlterCommand::DELETE,
-        ASTAlterCommand::UPDATE,
-        ASTAlterCommand::COMMENT_COLUMN,
-        ASTAlterCommand::MODIFY_ORDER_BY,
-        ASTAlterCommand::MODIFY_TTL,
-        ASTAlterCommand::ADD_INDEX,
-        ASTAlterCommand::DROP_INDEX,
+    static const std::unordered_set<int> unsupported_alter_types{
+        ASTAlterCommand::ATTACH_PARTITION,
+        ASTAlterCommand::REPLACE_PARTITION,
+        ASTAlterCommand::FETCH_PARTITION,
+        ASTAlterCommand::FREEZE_PARTITION,
+        ASTAlterCommand::FREEZE_ALL,
+        ASTAlterCommand::NO_TYPE,
     };
 
-    return supported_alter_types.count(type) != 0;
+    return unsupported_alter_types.count(type) == 0;
 }
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

#5593 

> It's better to change the list to "unsupported_alter_types",
> because unsupported commands are specific and supported are common.
