### PR TITLE
Fixed quotes in exceptions and log messages.

### DIFF
--- a/dbms/programs/server/Server.cpp
+++ b/dbms/programs/server/Server.cpp
@@ -310,7 +310,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
     /// Initialize DateLUT early, to not interfere with running time of first query.
     LOG_DEBUG(log, "Initializing DateLUT.");
     DateLUT::instance();
-    LOG_TRACE(log, "Initialized DateLUT with time zone `" << DateLUT::instance().getTimeZone() << "'.");
+    LOG_TRACE(log, "Initialized DateLUT with time zone '" << DateLUT::instance().getTimeZone() << "'.");
 
     /// Directory with temporary data for processing of heavy queries.
     {

--- a/dbms/src/Common/Config/ConfigProcessor.cpp
+++ b/dbms/src/Common/Config/ConfigProcessor.cpp
@@ -527,7 +527,7 @@ ConfigProcessor::LoadedConfig ConfigProcessor::loadConfig(bool allow_zk_includes
     XMLDocumentPtr config_xml = processConfig(&has_zk_includes);
 
     if (has_zk_includes && !allow_zk_includes)
-        throw Poco::Exception("Error while loading config `" + path + "': from_zk includes are not allowed!");
+        throw Poco::Exception("Error while loading config '" + path + "': from_zk includes are not allowed!");
 
     ConfigurationPtr configuration(new Poco::Util::XMLConfiguration(config_xml));
 

--- a/dbms/src/Common/Config/ConfigReloader.cpp
+++ b/dbms/src/Common/Config/ConfigReloader.cpp
@@ -87,7 +87,7 @@ void ConfigReloader::reloadIfNewer(bool force, bool throw_on_error, bool fallbac
         ConfigProcessor::LoadedConfig loaded_config;
         try
         {
-            LOG_DEBUG(log, "Loading config `" << path << "'");
+            LOG_DEBUG(log, "Loading config '" << path << "'");
 
             loaded_config = config_processor.loadConfig(/* allow_zk_includes = */ true);
             if (loaded_config.has_zk_includes)
@@ -102,7 +102,7 @@ void ConfigReloader::reloadIfNewer(bool force, bool throw_on_error, bool fallbac
             if (throw_on_error)
                 throw;
 
-            tryLogCurrentException(log, "ZooKeeper error when loading config from `" + path + "'");
+            tryLogCurrentException(log, "ZooKeeper error when loading config from '" + path + "'");
             return;
         }
         catch (...)
@@ -110,7 +110,7 @@ void ConfigReloader::reloadIfNewer(bool force, bool throw_on_error, bool fallbac
             if (throw_on_error)
                 throw;
 
-            tryLogCurrentException(log, "Error loading config from `" + path + "'");
+            tryLogCurrentException(log, "Error loading config from '" + path + "'");
             return;
         }
         config_processor.savePreprocessedConfig(loaded_config, preprocessed_dir);
@@ -134,7 +134,7 @@ void ConfigReloader::reloadIfNewer(bool force, bool throw_on_error, bool fallbac
         {
             if (throw_on_error)
                 throw;
-            tryLogCurrentException(log, "Error updating configuration from `" + path + "' config.");
+            tryLogCurrentException(log, "Error updating configuration from '" + path + "' config.");
         }
     }
 }

--- a/dbms/src/Common/ZooKeeper/ZooKeeperNodeCache.cpp
+++ b/dbms/src/Common/ZooKeeper/ZooKeeperNodeCache.cpp
@@ -36,7 +36,7 @@ ZooKeeperNodeCache::ZNode ZooKeeperNodeCache::get(const std::string & path, Coor
 
     zkutil::ZooKeeperPtr zookeeper = get_zookeeper();
     if (!zookeeper)
-        throw DB::Exception("Could not get znode: `" + path + "'. ZooKeeper not configured.", DB::ErrorCodes::NO_ZOOKEEPER);
+        throw DB::Exception("Could not get znode: '" + path + "'. ZooKeeper not configured.", DB::ErrorCodes::NO_ZOOKEEPER);
 
     for (const auto & invalidated_path : invalidated_paths)
         path_to_cached_znode.erase(invalidated_path);

--- a/dbms/src/Dictionaries/Embedded/GeodataProviders/HierarchiesProvider.cpp
+++ b/dbms/src/Dictionaries/Embedded/GeodataProviders/HierarchiesProvider.cpp
@@ -69,5 +69,5 @@ IRegionsHierarchyDataSourcePtr RegionsHierarchiesDataProvider::getHierarchySourc
         return std::make_shared<RegionsHierarchyDataSource>(hierarchy_file_path);
     }
 
-    throw Poco::Exception("Regions hierarchy `" + name + "` not found");
+    throw Poco::Exception("Regions hierarchy '" + name + "' not found");
 }

--- a/dbms/src/Interpreters/Cluster.cpp
+++ b/dbms/src/Interpreters/Cluster.cpp
@@ -197,7 +197,7 @@ void Clusters::updateClusters(const Poco::Util::AbstractConfiguration & config, 
     for (const auto & key : config_keys)
     {
         if (key.find('.') != String::npos)
-            throw Exception("Cluster names with dots are not supported: `" + key + "`", ErrorCodes::SYNTAX_ERROR);
+            throw Exception("Cluster names with dots are not supported: '" + key + "'", ErrorCodes::SYNTAX_ERROR);
 
         impl.emplace(key, std::make_shared<Cluster>(config, settings, config_name + "." + key));
     }

--- a/dbms/src/Interpreters/MutationsInterpreter.cpp
+++ b/dbms/src/Interpreters/MutationsInterpreter.cpp
@@ -133,14 +133,14 @@ static void validateUpdateColumns(
             for (const auto & col : storage->getColumns().getMaterialized())
             {
                 if (col.name == column_name)
-                    throw Exception("Cannot UPDATE materialized column `" + column_name + "`", ErrorCodes::CANNOT_UPDATE_COLUMN);
+                    throw Exception("Cannot UPDATE materialized column " + backQuote(column_name), ErrorCodes::CANNOT_UPDATE_COLUMN);
             }
 
-            throw Exception("There is no column `" + column_name + "` in table", ErrorCodes::NO_SUCH_COLUMN_IN_TABLE);
+            throw Exception("There is no column " + backQuote(column_name) + " in table", ErrorCodes::NO_SUCH_COLUMN_IN_TABLE);
         }
 
         if (key_columns.count(column_name))
-            throw Exception("Cannot UPDATE key column `" + column_name + "`", ErrorCodes::CANNOT_UPDATE_COLUMN);
+            throw Exception("Cannot UPDATE key column " + backQuote(column_name), ErrorCodes::CANNOT_UPDATE_COLUMN);
 
         auto materialized_it = column_to_affected_materialized.find(column_name);
         if (materialized_it != column_to_affected_materialized.end())
@@ -148,8 +148,8 @@ static void validateUpdateColumns(
             for (const String & materialized : materialized_it->second)
             {
                 if (key_columns.count(materialized))
-                    throw Exception("Updated column `" + column_name + "` affects MATERIALIZED column `"
-                        + materialized + "`, which is a key column. Cannot UPDATE it.",
+                    throw Exception("Updated column " + backQuote(column_name) + " affects MATERIALIZED column "
+                        + backQuote(materialized) + ", which is a key column. Cannot UPDATE it.",
                         ErrorCodes::CANNOT_UPDATE_COLUMN);
             }
         }

--- a/dbms/src/Storages/AlterCommands.cpp
+++ b/dbms/src/Storages/AlterCommands.cpp
@@ -274,7 +274,7 @@ void AlterCommand::apply(ColumnsDescription & columns_description, IndicesDescri
                     });
 
             if (insert_it == indices_description.indices.end())
-                throw Exception("Wrong index name. Cannot find index `" + after_index_name + "` to insert after.",
+                throw Exception("Wrong index name. Cannot find index " + backQuote(after_index_name) + " to insert after.",
                         ErrorCodes::LOGICAL_ERROR);
 
             ++insert_it;
@@ -296,7 +296,7 @@ void AlterCommand::apply(ColumnsDescription & columns_description, IndicesDescri
         {
             if (if_exists)
                 return;
-            throw Exception("Wrong index name. Cannot find index `" + index_name + "` to drop.",
+            throw Exception("Wrong index name. Cannot find index " + backQuote(index_name) + " to drop.",
                             ErrorCodes::LOGICAL_ERROR);
         }
 

--- a/dbms/src/Storages/MergeTree/MergeTreeBloomFilterIndex.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeBloomFilterIndex.cpp
@@ -62,7 +62,7 @@ void MergeTreeBloomFilterIndexGranule::serializeBinary(WriteBuffer & ostr) const
 {
     if (empty())
         throw Exception(
-                "Attempt to write empty minmax index `" + index.name + "`", ErrorCodes::LOGICAL_ERROR);
+                "Attempt to write empty minmax index " + backQuote(index.name), ErrorCodes::LOGICAL_ERROR);
 
     for (const auto & bloom_filter : bloom_filters)
         ostr.write(reinterpret_cast<const char *>(bloom_filter.getFilter().data()), index.bloom_filter_size);
@@ -703,7 +703,7 @@ std::unique_ptr<IMergeTreeIndex> bloomFilterIndexCreator(
     }
     else
     {
-        throw Exception("Unknown index type: `" + node->name + "`.", ErrorCodes::LOGICAL_ERROR);
+        throw Exception("Unknown index type: " + backQuote(node->name), ErrorCodes::LOGICAL_ERROR);
     }
 }
 

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -151,7 +151,7 @@ MergeTreeData::MergeTreeData(
         catch (Exception & e)
         {
             /// Better error message.
-            e.addMessage("(while initializing MergeTree partition key from date column `" + date_column_name + "`)");
+            e.addMessage("(while initializing MergeTree partition key from date column " + backQuote(date_column_name) + ")");
             throw;
         }
     }
@@ -381,7 +381,7 @@ void MergeTreeData::setPrimaryKeyIndicesAndColumns(
 
             if (indices_names.find(new_indices.back()->name) != indices_names.end())
                 throw Exception(
-                        "Index with name `" + new_indices.back()->name + "` already exsists",
+                        "Index with name " + backQuote(new_indices.back()->name) + " already exsists",
                         ErrorCodes::LOGICAL_ERROR);
 
             ASTPtr expr_list = MergeTreeData::extractKeyExpressionList(index_decl->expr->clone());
@@ -1476,12 +1476,12 @@ void MergeTreeData::alterDataPart(
                 exception_message << ", ";
             if (forbidden_because_of_modify)
             {
-                exception_message << "from `" << from_to.first << "' to `" << from_to.second << "'";
+                exception_message << "from " << backQuote(from_to.first) << " to " << backQuote(from_to.second);
                 first = false;
             }
             else if (from_to.second.empty())
             {
-                exception_message << "`" << from_to.first << "'";
+                exception_message << backQuote(from_to.first);
                 first = false;
             }
         }

--- a/dbms/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -999,7 +999,7 @@ MarkRanges MergeTreeDataSelectExecutor::filterMarksUsingIndex(
 {
     if (!Poco::File(part->getFullPath() + index->getFileName() + ".idx").exists())
     {
-        LOG_DEBUG(log, "File for index `" << index->name << "` does not exist. Skipping it.");
+        LOG_DEBUG(log, "File for index " << backQuote(index->name) << " does not exist. Skipping it.");
         return ranges;
     }
 
@@ -1054,7 +1054,7 @@ MarkRanges MergeTreeDataSelectExecutor::filterMarksUsingIndex(
         last_index_mark = index_range.end - 1;
     }
 
-    LOG_DEBUG(log, "Index `" << index->name << "` has dropped " << granules_dropped << " granules.");
+    LOG_DEBUG(log, "Index " << backQuote(index->name) << " has dropped " << granules_dropped << " granules.");
 
     return res;
 }

--- a/dbms/src/Storages/MergeTree/MergeTreeMinMaxIndex.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeMinMaxIndex.cpp
@@ -27,7 +27,7 @@ void MergeTreeMinMaxGranule::serializeBinary(WriteBuffer & ostr) const
 {
     if (empty())
         throw Exception(
-                "Attempt to write empty minmax index `" + index.name + "`", ErrorCodes::LOGICAL_ERROR);
+            "Attempt to write empty minmax index " + backQuote(index.name), ErrorCodes::LOGICAL_ERROR);
 
     for (size_t i = 0; i < index.columns.size(); ++i)
     {

--- a/dbms/src/Storages/MergeTree/MergeTreeSetSkippingIndex.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeSetSkippingIndex.cpp
@@ -36,7 +36,7 @@ void MergeTreeSetIndexGranule::serializeBinary(WriteBuffer & ostr) const
 {
     if (empty())
         throw Exception(
-                "Attempt to write empty set index `" + index.name + "`", ErrorCodes::LOGICAL_ERROR);
+            "Attempt to write empty set index " + backQuote(index.name), ErrorCodes::LOGICAL_ERROR);
 
     const auto & size_type = DataTypePtr(std::make_shared<DataTypeUInt64>());
 

--- a/dbms/src/Storages/MutationCommands.cpp
+++ b/dbms/src/Storages/MutationCommands.cpp
@@ -38,7 +38,7 @@ std::optional<MutationCommand> MutationCommand::parse(ASTAlterCommand * command)
             const auto & assignment = assignment_ast->as<ASTAssignment &>();
             auto insertion = res.column_to_update_expression.emplace(assignment.column_name, assignment.expression);
             if (!insertion.second)
-                throw Exception("Multiple assignments in the single statement to column `" + assignment.column_name + "`",
+                throw Exception("Multiple assignments in the single statement to column " + backQuote(assignment.column_name),
                     ErrorCodes::MULTIPLE_ASSIGNMENTS_TO_COLUMN);
         }
         return res;

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1061,8 +1061,8 @@ bool StorageReplicatedMergeTree::tryExecuteMerge(const LogEntry & entry)
     FutureMergedMutatedPart future_merged_part(parts);
     if (future_merged_part.name != entry.new_part_name)
     {
-        throw Exception("Future merged part name `" + future_merged_part.name + "` differs from part name in log entry: `"
-                        + entry.new_part_name + "`", ErrorCodes::BAD_DATA_PART_NAME);
+        throw Exception("Future merged part name " + backQuote(future_merged_part.name) + " differs from part name in log entry: "
+            + backQuote(entry.new_part_name), ErrorCodes::BAD_DATA_PART_NAME);
     }
 
     MergeList::EntryPtr merge_entry = global_context.getMergeList().insert(database_name, table_name, future_merged_part);

--- a/dbms/src/TableFunctions/TableFunctionMySQL.cpp
+++ b/dbms/src/TableFunctions/TableFunctionMySQL.cpp
@@ -116,7 +116,7 @@ StoragePtr TableFunctionMySQL::executeImpl(const ASTPtr & ast_function, const Co
     }
 
     if (columns.empty())
-        throw Exception("MySQL table `" + database_name + "`.`" + table_name + "` doesn't exist.", ErrorCodes::UNKNOWN_TABLE);
+        throw Exception("MySQL table " + backQuoteIfNeed(database_name) + "." + backQuoteIfNeed(table_name) + " doesn't exist.", ErrorCodes::UNKNOWN_TABLE);
 
     auto res = StorageMySQL::create(
         table_name,


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Other

Short description (up to few sentences):
Removed strange quoting style like `this'. See https://english.stackexchange.com/questions/17695/any-reference-on-the-usage-of-a-backtick-and-single-quotation-mark-like-this

Added `backQuote` and `backQuoteIfNeed` when required to correctly quote identifiers with proper escaping.

Addition to #5599 