### PR TITLE
Fix float to decimal convert overflow, extreme values

### DIFF
--- a/dbms/src/DataTypes/DataTypesDecimal.h
+++ b/dbms/src/DataTypes/DataTypesDecimal.h
@@ -327,22 +327,20 @@ convertToDecimal(const typename FromDataType::FieldType & value, UInt32 scale)
         if (!std::isfinite(value))
             throw Exception("Decimal convert overflow. Cannot convert infinity or NaN to decimal", ErrorCodes::DECIMAL_OVERFLOW);
 
-        ToNativeType min_value;
-        ToNativeType max_value;
+        auto out = value * ToDataType::getScaleMultiplier(scale);
         if constexpr (std::is_same_v<ToNativeType, Int128>)
         {
-            min_value = __int128(0x8000000000000000ll) << 64; // min __int128
-            max_value = (__int128(0x7fffffffffffffffll) << 64) + 0xffffffffffffffffll; // max __int128
+            static constexpr __int128 min_int128 = __int128(0x8000000000000000ll) << 64;
+            static constexpr __int128 max_int128 = (__int128(0x7fffffffffffffffll) << 64) + 0xffffffffffffffffll;
+            if (! (out > min_int128 && out < max_int128))
+                throw Exception("Decimal convert overflow. Float is out of Decimal range", ErrorCodes::DECIMAL_OVERFLOW);
         }
         else
         {
-            min_value = std::numeric_limits<ToNativeType>::min();
-            max_value = std::numeric_limits<ToNativeType>::max();
+            if (! (out > std::numeric_limits<ToNativeType>::min() && out < std::numeric_limits<ToNativeType>::max()))
+                throw Exception("Decimal convert overflow. Float is out of Decimal range", ErrorCodes::DECIMAL_OVERFLOW);
         }
-        ToNativeType converted_value = static_cast<ToNativeType>(value * ToDataType::getScaleMultiplier(scale));
-        if (converted_value == min_value || converted_value == max_value)
-            throw Exception("Decimal convert overflow. Float is out of Decimal range", ErrorCodes::DECIMAL_OVERFLOW);
-        return converted_value;
+        return out;
     }
     else
     {

--- a/dbms/src/DataTypes/DataTypesDecimal.h
+++ b/dbms/src/DataTypes/DataTypesDecimal.h
@@ -332,12 +332,12 @@ convertToDecimal(const typename FromDataType::FieldType & value, UInt32 scale)
         {
             static constexpr __int128 min_int128 = __int128(0x8000000000000000ll) << 64;
             static constexpr __int128 max_int128 = (__int128(0x7fffffffffffffffll) << 64) + 0xffffffffffffffffll;
-            if (! (out > min_int128 && out < max_int128))
+            if (out <= static_cast<ToNativeType>(min_int128) || out >= static_cast<ToNativeType>(max_int128))
                 throw Exception("Decimal convert overflow. Float is out of Decimal range", ErrorCodes::DECIMAL_OVERFLOW);
         }
         else
         {
-            if (! (out > std::numeric_limits<ToNativeType>::min() && out < std::numeric_limits<ToNativeType>::max()))
+            if (out <= std::numeric_limits<ToNativeType>::min() || out >= std::numeric_limits<ToNativeType>::max())
                 throw Exception("Decimal convert overflow. Float is out of Decimal range", ErrorCodes::DECIMAL_OVERFLOW);
         }
         return out;

--- a/dbms/tests/queries/0_stateless/00700_decimal_casts.sql
+++ b/dbms/tests/queries/0_stateless/00700_decimal_casts.sql
@@ -258,3 +258,11 @@ select toDecimal128(1000000000000000000000.1, 18); -- { serverError 407 }
 select toDecimal32(-10000.1, 6); -- { serverError 407 }
 select toDecimal64(-10000.1, 18); -- { serverError 407 }
 select toDecimal128(-1000000000000000000000.1, 18); -- { serverError 407 }
+
+select toDecimal32(2147483647.0 + 1.0, 0); -- { serverError 407 }
+select toDecimal64(9223372036854775807.0, 0); -- { serverError 407 }
+select toDecimal128(170141183460469231731687303715884105729.0, 0); -- { serverError 407 }
+
+select toDecimal32(-2147483647.0 - 1.0, 0); -- { serverError 407 }
+select toDecimal64(-9223372036854775807.0, 0); -- { serverError 407 }
+select toDecimal128(-170141183460469231731687303715884105729.0, 0); -- { serverError 407 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
PR is continue of https://github.com/yandex/ClickHouse/pull/5607  
Actual PR handles also border values.

```sql
select toDecimal32(2147483647.0 + 1.0, 0); -- { should be serverError 407 as {maxInt32} +1 }
select toDecimal64(9223372036854775807.0, 0); -- { should be serverError 407 as {maxInt64} }
select toDecimal128(170141183460469231731687303715884105729.0, 0); -- { should be serverError 407 as as ~{maxInt128}}
```


Detailed description (optional):
double precision typed values comparison leads to incorrect results in boundaries. So we need to `static_cast ` to a `<ToNativeType>` and then make a comparison. 
