### PR TITLE
Ignore query execution limits and limits for max parts size for merge while executing mutations.

### DIFF
--- a/dbms/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1196,7 +1196,8 @@ void InterpreterSelectQuery::executeFetchColumns(
 
             pipeline.transform([&](auto & stream)
             {
-                stream->setLimits(limits);
+                if (!options.ignore_limits)
+                    stream->setLimits(limits);
 
                 if (options.to_stage == QueryProcessingStage::Complete)
                     stream->setQuota(quota);

--- a/dbms/src/Interpreters/MutationsInterpreter.cpp
+++ b/dbms/src/Interpreters/MutationsInterpreter.cpp
@@ -69,7 +69,7 @@ bool MutationsInterpreter::isStorageTouchedByMutations() const
     context_copy.getSettingsRef().merge_tree_uniform_read_distribution = 0;
     context_copy.getSettingsRef().max_threads = 1;
 
-    BlockInputStreamPtr in = InterpreterSelectQuery(select, context_copy, storage).execute().in;
+    BlockInputStreamPtr in = InterpreterSelectQuery(select, context_copy, storage, SelectQueryOptions().ignoreLimits()).execute().in;
 
     Block block = in->read();
     if (!block.rows())
@@ -358,7 +358,7 @@ void MutationsInterpreter::prepare(bool dry_run)
         select->setExpression(ASTSelectQuery::Expression::WHERE, std::move(where_expression));
     }
 
-    interpreter_select = std::make_unique<InterpreterSelectQuery>(select, context, storage, SelectQueryOptions().analyze(dry_run));
+    interpreter_select = std::make_unique<InterpreterSelectQuery>(select, context, storage, SelectQueryOptions().analyze(dry_run).ignoreLimits());
 
     is_prepared = true;
 }

--- a/dbms/src/Interpreters/SelectQueryOptions.h
+++ b/dbms/src/Interpreters/SelectQueryOptions.h
@@ -27,6 +27,7 @@ struct SelectQueryOptions
     bool only_analyze;
     bool modify_inplace;
     bool remove_duplicates;
+    bool ignore_limits;
 
     SelectQueryOptions(QueryProcessingStage::Enum stage = QueryProcessingStage::Complete, size_t depth = 0)
         : to_stage(stage)
@@ -69,6 +70,12 @@ struct SelectQueryOptions
     SelectQueryOptions & noSubquery()
     {
         subquery_depth = 0;
+        return *this;
+    }
+
+    SelectQueryOptions & ignoreLimits(bool value = true)
+    {
+        ignore_limits = value;
         return *this;
     }
 };

--- a/dbms/src/Interpreters/SelectQueryOptions.h
+++ b/dbms/src/Interpreters/SelectQueryOptions.h
@@ -35,6 +35,7 @@ struct SelectQueryOptions
         , only_analyze(false)
         , modify_inplace(false)
         , remove_duplicates(false)
+        , ignore_limits(false)
     {}
 
     SelectQueryOptions copy() const { return *this; }

--- a/dbms/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
@@ -45,12 +45,17 @@ public:
     /** Get maximum total size of parts to do merge, at current moment of time.
       * It depends on number of free threads in background_pool and amount of free space in disk.
       */
-    UInt64 getMaxSourcePartsSize();
+    UInt64 getMaxSourcePartsSizeForMerge();
 
     /** For explicitly passed size of pool and number of used tasks.
       * This method could be used to calculate threshold depending on number of tasks in replication queue.
       */
-    UInt64 getMaxSourcePartsSize(size_t pool_size, size_t pool_used);
+    UInt64 getMaxSourcePartsSizeForMerge(size_t pool_size, size_t pool_used);
+
+    /** Get maximum total size of parts to do mutation, at current moment of time.
+      * It depends only on amount of free space in disk.
+      */
+    UInt64 getMaxSourcePartSizeForMutation();
 
     /** Selects which parts to merge. Uses a lot of heuristics.
       *

--- a/dbms/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/dbms/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -960,7 +960,7 @@ bool ReplicatedMergeTreeQueue::shouldExecuteLogEntry(
           * But if all threads are free (maximal size of merge is allowed) then execute any merge,
           *  (because it may be ordered by OPTIMIZE or early with differrent settings).
           */
-        UInt64 max_source_parts_size = merger_mutator.getMaxSourcePartsSize();
+        UInt64 max_source_parts_size = merger_mutator.getMaxSourcePartsSizeForMerge();
         if (max_source_parts_size != data.settings.max_bytes_to_merge_at_max_space_in_pool
             && sum_parts_size_in_bytes > max_source_parts_size)
         {

--- a/dbms/src/Storages/StorageMergeTree.cpp
+++ b/dbms/src/Storages/StorageMergeTree.cpp
@@ -513,7 +513,7 @@ bool StorageMergeTree::merge(
 
         if (partition_id.empty())
         {
-            UInt64 max_source_parts_size = merger_mutator.getMaxSourcePartsSize();
+            UInt64 max_source_parts_size = merger_mutator.getMaxSourcePartsSizeForMerge();
             if (max_source_parts_size > 0)
                 selected = merger_mutator.selectPartsToMerge(future_part, aggressive, max_source_parts_size, can_merge, out_disable_reason);
             else if (out_disable_reason)

--- a/dbms/tests/integration/test_replicated_mutations/configs/merge_tree.xml
+++ b/dbms/tests/integration/test_replicated_mutations/configs/merge_tree.xml
@@ -1,0 +1,6 @@
+<yandex>
+    <merge_tree>
+        <max_bytes_to_merge_at_min_space_in_pool>1</max_bytes_to_merge_at_min_space_in_pool>
+        <max_bytes_to_merge_at_max_space_in_pool>2</max_bytes_to_merge_at_max_space_in_pool>
+    </merge_tree>
+</yandex>

--- a/dbms/tests/integration/test_replicated_mutations/test.py
+++ b/dbms/tests/integration/test_replicated_mutations/test.py
@@ -11,7 +11,8 @@ from helpers.cluster import ClickHouseCluster
 cluster = ClickHouseCluster(__file__)
 
 node1 = cluster.add_instance('node1', with_zookeeper=True)
-node2 = cluster.add_instance('node2', with_zookeeper=True)
+# Check, that limits on max part size for merges doesn`t affect mutations
+node2 = cluster.add_instance('node2', main_configs=["configs/merge_tree.xml"], with_zookeeper=True)
 nodes = [node1, node2]
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Ignore query execution limits and max parts size for merge limits while executing mutations.

Detailed description (optional):
These limits could fail mutation and it will never be executed or will be infinitely retried.
#5571  #5240 