### PR TITLE
Some clarifications to File engine docs.

### DIFF
--- a/docs/en/interfaces/formats.md
+++ b/docs/en/interfaces/formats.md
@@ -1,10 +1,14 @@
 # Formats for input and output data {#formats}
 
-ClickHouse can accept (`INSERT`) and return (`SELECT`) data in various formats.
+ClickHouse can accept and return data in various formats. A format that is
+supported for output can be used to arrange the results of a `SELECT` query,
+and the data for an `INSERT` query can be accepted in a format that is
+supported for input. Conversely, when working with a data file using the
+[File](../operations/table_engines/file.md) table engine, to enable `SELECT`s
+from the file, its format must be supported for input, and to enable `INSERT`s
+-- for output. The table below lists the supported formats.
 
-The table below lists supported formats and how they can be used in `INSERT` and `SELECT` queries.
-
-| Format | INSERT | SELECT |
+| Format | input | output |
 | ------- | -------- | -------- |
 | [TabSeparated](#tabseparated) | ✔ | ✔ |
 | [TabSeparatedRaw](#tabseparatedraw) | ✗ | ✔ |

--- a/docs/en/interfaces/formats.md
+++ b/docs/en/interfaces/formats.md
@@ -1,12 +1,12 @@
 # Formats for input and output data {#formats}
 
-ClickHouse can accept and return data in various formats. A format that is
-supported for output can be used to arrange the results of a `SELECT` query,
-and the data for an `INSERT` query can be accepted in a format that is
-supported for input. Conversely, when working with a data file using the
-[File](../operations/table_engines/file.md) table engine, to enable `SELECT`s
-from the file, its format must be supported for input, and to enable `INSERT`s
--- for output. The table below lists the supported formats.
+ClickHouse can accept and return data in various formats. A format supported
+for input can be used to parse the data provided to `INSERT`s, to perform
+`SELECT`s from a file-backed table such as File, URL or HDFS, or to read an
+external dictionary. A format supported for output can be used to arrange the
+results of a `SELECT`, and to perform `INSERT`s into a file-backed table.
+
+The supported formats are:
 
 | Format | input | output |
 | ------- | -------- | -------- |

--- a/docs/en/interfaces/formats.md
+++ b/docs/en/interfaces/formats.md
@@ -8,7 +8,7 @@ results of a `SELECT`, and to perform `INSERT`s into a file-backed table.
 
 The supported formats are:
 
-| Format | input | output |
+| Format | Input | Output |
 | ------- | -------- | -------- |
 | [TabSeparated](#tabseparated) | ✔ | ✔ |
 | [TabSeparatedRaw](#tabseparatedraw) | ✗ | ✔ |

--- a/docs/en/operations/table_engines/file.md
+++ b/docs/en/operations/table_engines/file.md
@@ -1,6 +1,7 @@
-# File(InputFormat) {#table_engines-file}
+# File {#table_engines-file}
 
-The data source is a file that stores data in one of the supported input formats (TabSeparated, Native, etc.).
+The File table engine keeps the data in a file in one of the supported [file
+formats](../../interfaces/formats.md#formats) (TabSeparated, Native, etc.).
 
 Usage examples:
 
@@ -14,7 +15,10 @@ Usage examples:
 File(Format)
 ```
 
-`Format` should be supported for either `INSERT` and `SELECT`. For the full list of supported formats see [Formats](../../interfaces/formats.md#formats).
+The `Format` parameter specifies one of the available file formats. To perform
+`SELECT` queries, the format must be supported for input, and to perform
+`INSERT` queries -- for output. The available formats are listed in the
+[Formats](../../interfaces/formats.md#formats) section.
 
 ClickHouse does not allow to specify filesystem path for`File`. It will use folder defined by [path](../server_settings/settings.md) setting in server configuration.
 


### PR DESCRIPTION
The input/output capability of file formats was explained in terms of `SELECT`/`INSERT` queries, but for File engine, this relation is reversed. I reworded the description of formats to better reflect this, and also made some tweaks to the File engine section.