### PR TITLE
Flush buffer when WriteBufferFromHDFS's destructor is called

### DIFF
--- a/dbms/src/IO/WriteBufferFromHDFS.cpp
+++ b/dbms/src/IO/WriteBufferFromHDFS.cpp
@@ -92,6 +92,14 @@ void WriteBufferFromHDFS::sync()
 
 WriteBufferFromHDFS::~WriteBufferFromHDFS()
 {
+    try
+    {
+        next();
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+    }
 }
 
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- New Feature
- Bug Fix
- Improvement
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Other

Short description (up to few sentences):

...

Detailed description (optional):

...
