### PR TITLE
Fix race condition in flushing system log in another way.

### DIFF
--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -249,7 +249,8 @@ struct ContextShared
           *  Note that part changes at shutdown won't be logged to part log.
           */
 
-        system_logs->shutdown();
+        if (system_logs)
+            system_logs->shutdown();
 
         /** At this point, some tables may have threads that block our mutex.
           * To shutdown them correctly, we will copy the current list of tables,

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -245,15 +245,12 @@ struct ContextShared
             return;
         shutdown_called = true;
 
-        {
-            std::lock_guard lock(mutex);
 
-            /** After this point, system logs will shutdown their threads and no longer write any data.
-            * It will prevent recreation of system tables at shutdown.
-            * Note that part changes at shutdown won't be logged to part log.
-            */
-            system_logs.reset();
-        }
+        /** At this point, system logs will flush accumulated data, then shutdown their threads and no longer write any data.
+        * It will prevent recreation of system tables at shutdown.
+        * Note that part changes at shutdown won't be logged to part log.
+        */
+        system_logs.reset();
 
         /** At this point, some tables may have threads that block our mutex.
           * To shutdown them correctly, we will copy the current list of tables,

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -245,12 +245,11 @@ struct ContextShared
             return;
         shutdown_called = true;
 
+        /**  After system_logs have been shut down it is guaranteed that no system table gets created or written to.
+          *  Note that part changes at shutdown won't be logged to part log.
+          */
 
-        /** At this point, system logs will flush accumulated data, then shutdown their threads and no longer write any data.
-        * It will prevent recreation of system tables at shutdown.
-        * Note that part changes at shutdown won't be logged to part log.
-        */
-        system_logs.reset();
+        system_logs->shutdown();
 
         /** At this point, some tables may have threads that block our mutex.
           * To shutdown them correctly, we will copy the current list of tables,

--- a/dbms/src/Interpreters/SystemLog.cpp
+++ b/dbms/src/Interpreters/SystemLog.cpp
@@ -51,6 +51,12 @@ SystemLogs::SystemLogs(Context & global_context, const Poco::Util::AbstractConfi
 
 SystemLogs::~SystemLogs()
 {
+    shutdown();
+}
+
+
+void SystemLogs::shutdown()
+{
     if (query_log)
         query_log->shutdown();
     if (query_thread_log)

--- a/dbms/src/Interpreters/SystemLog.h
+++ b/dbms/src/Interpreters/SystemLog.h
@@ -68,6 +68,8 @@ struct SystemLogs
     SystemLogs(Context & global_context, const Poco::Util::AbstractConfiguration & config);
     ~SystemLogs();
 
+    void shutdown();
+
     std::shared_ptr<QueryLog> query_log;                /// Used to log queries.
     std::shared_ptr<QueryThreadLog> query_thread_log;   /// Used to log query threads.
     std::shared_ptr<PartLog> part_log;                  /// Used to log operations with parts

--- a/dbms/src/Interpreters/SystemLog.h
+++ b/dbms/src/Interpreters/SystemLog.h
@@ -198,12 +198,13 @@ void SystemLog<LogElement>::flush()
         return;
 
     std::lock_guard flush_lock(flush_mutex);
+    force_flushing = true;
+
     /// Tell thread to execute extra flush.
     queue.push({ElementType::FORCE_FLUSH, {}});
 
     /// Wait for flush being finished.
     std::unique_lock lock(condvar_mutex);
-    force_flushing = true;
     while (force_flushing)
         flush_condvar.wait(lock);
 }

--- a/dbms/tests/integration/test_system_queries/configs/config.d/query_log.xml
+++ b/dbms/tests/integration/test_system_queries/configs/config.d/query_log.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<yandex>
+    <query_log>
+        <database>system</database>
+        <table>query_log</table>
+        <partition_by>toYYYYMM(event_date)</partition_by>
+        <flush_interval_milliseconds>300</flush_interval_milliseconds>
+    </query_log>
+</yandex>

--- a/dbms/tests/integration/test_system_queries/test.py
+++ b/dbms/tests/integration/test_system_queries/test.py
@@ -92,6 +92,23 @@ def test_RELOAD_CONFIG_AND_MACROS(started_cluster):
     instance.query("SYSTEM RELOAD CONFIG")
     assert TSV(instance.query("select * from system.macros")) == TSV("mac\tro\n")
 
+
+def test_SYSTEM_FLUSH_LOGS(started_cluster):
+    instance = cluster.instances['ch1']
+    for i in range(4):
+        # Sleep to execute flushing from background thread at first query
+        # by expiration of flush_interval_millisecond and test probable race condition.
+        time.sleep(0.5)
+        result = instance.query('''
+            SET log_queries = 1;
+            SELECT 1 FORMAT Null;
+            SET log_queries = 0;
+            SYSTEM FLUSH LOGS;
+            SELECT count() FROM system.query_log;''')
+        instance.query('TRUNCATE TABLE system.query_log')
+        assert TSV(result) == TSV('4')
+
+
 if __name__ == '__main__':
     with contextmanager(started_cluster)() as cluster:
        for name, instance in cluster.instances.items():


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):

Fix race condition, which cause that some queries may not appear in query_log after  `SYSTEM FLUSH LOGS` query. #5456