### PR TITLE
MergedColumnOnlyOutputStream. Skip empty blocks. Fix 5377

### DIFF
--- a/dbms/src/Common/IPv6ToBinary.cpp
+++ b/dbms/src/Common/IPv6ToBinary.cpp
@@ -1,5 +1,6 @@
 #include "IPv6ToBinary.h"
 #include <Poco/Net/IPAddress.h>
+#include <cstring>
 
 
 namespace DB

--- a/dbms/src/Storages/MergeTree/IMergedBlockOutputStream.cpp
+++ b/dbms/src/Storages/MergeTree/IMergedBlockOutputStream.cpp
@@ -211,6 +211,8 @@ size_t IMergedBlockOutputStream::writeSingleGranule(
     return from_row + number_of_rows;
 }
 
+/// column must not be empty. (column.size() !== 0)
+
 std::pair<size_t, size_t> IMergedBlockOutputStream::writeColumn(
     const String & name,
     const IDataType & type,

--- a/dbms/src/Storages/MergeTree/MergedColumnOnlyOutputStream.cpp
+++ b/dbms/src/Storages/MergeTree/MergedColumnOnlyOutputStream.cpp
@@ -21,10 +21,6 @@ MergedColumnOnlyOutputStream::MergedColumnOnlyOutputStream(
 
 void MergedColumnOnlyOutputStream::write(const Block & block)
 {
-    size_t rows = block.rows();
-    if (!rows)
-        return;
-
     if (!initialized)
     {
         column_streams.clear();
@@ -46,6 +42,10 @@ void MergedColumnOnlyOutputStream::write(const Block & block)
 
         initialized = true;
     }
+
+    size_t rows = block.rows();
+    if (!rows)
+        return;
 
     size_t new_index_offset = 0;
     size_t new_current_mark = 0;

--- a/dbms/src/Storages/MergeTree/MergedColumnOnlyOutputStream.cpp
+++ b/dbms/src/Storages/MergeTree/MergedColumnOnlyOutputStream.cpp
@@ -21,6 +21,10 @@ MergedColumnOnlyOutputStream::MergedColumnOnlyOutputStream(
 
 void MergedColumnOnlyOutputStream::write(const Block & block)
 {
+    size_t rows = block.rows();
+    if (!rows)
+        return;
+
     if (!initialized)
     {
         column_streams.clear();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
This is fix for 
https://github.com/yandex/ClickHouse/issues/5377


Detailed description (optional):
when https://github.com/yandex/ClickHouse/blob/4f98f875c338370aee7f7ef45ba38b3fb862d084/dbms/src/Storages/MergeTree/IMergedBlockOutputStream.cpp#L214 receives empty column it returns 0 in second value. That leads resetting a `index_offset`.
looks like we need to skip empty blocks like there
https://github.com/yandex/ClickHouse/blob/4f98f875c338370aee7f7ef45ba38b3fb862d084/dbms/src/Storages/MergeTree/MergedBlockOutputStream.cpp#L267