### PR TITLE
add auth support for init script: fix pr #5321

### DIFF
--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -43,7 +43,7 @@ When you use the image with mounting local directories inside you probably would
 ## How to extend this image
 
 If you would like to do additional initialization in an image derived from this one, add one or more `*.sql`, `*.sql.gz`, or `*.sh` scripts under `/docker-entrypoint-initdb.d`. After the entrypoint calls `initdb` it will run any `*.sql` files, run any executable `*.sh` scripts, and source any non-executable `*.sh` scripts found in that directory to do further initialization before starting the service.
-Also you can provide environment variablies `CLICKHOUSE_USER` & `CLICKHOUSE_PASSWORD` that will be used for clickhouse-client during initialization.
+Also you can provide environment variables `CLICKHOUSE_USER` & `CLICKHOUSE_PASSWORD` that will be used for clickhouse-client during initialization.
 
 For example, to add an additional user and database, add the following to `/docker-entrypoint-initdb.d/init-db.sh`:
 

--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -43,6 +43,7 @@ When you use the image with mounting local directories inside you probably would
 ## How to extend this image
 
 If you would like to do additional initialization in an image derived from this one, add one or more `*.sql`, `*.sql.gz`, or `*.sh` scripts under `/docker-entrypoint-initdb.d`. After the entrypoint calls `initdb` it will run any `*.sql` files, run any executable `*.sh` scripts, and source any non-executable `*.sh` scripts found in that directory to do further initialization before starting the service.
+Also you can provide environment variablies `CLICKHOUSE_USER` & `CLICKHOUSE_PASSWORD` that will be used for clickhouse-client during initialization.
 
 For example, to add an additional user and database, add the following to `/docker-entrypoint-initdb.d/init-db.sh`:
 

--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -24,6 +24,7 @@ LOG_DIR="$(dirname $LOG_PATH || true)"
 ERROR_LOG_PATH="$(clickhouse extract-from-config --config-file $CLICKHOUSE_CONFIG --key=logger.errorlog || true)"
 ERROR_LOG_DIR="$(dirname $ERROR_LOG_PATH || true)"
 FORMAT_SCHEMA_PATH="$(clickhouse extract-from-config --config-file $CLICKHOUSE_CONFIG --key=format_schema_path || true)"
+CLICKHOUSE_USER="${CLICKHOUSE_USER:-default}"
 
 for dir in "$DATA_DIR" \
   "$ERROR_LOG_DIR" \
@@ -62,7 +63,12 @@ if [ -n "$(ls /docker-entrypoint-initdb.d/)" ]; then
         exit 1
     fi
 
-    clickhouseclient=( clickhouse-client --multiquery )
+    if [ ! -z "$CLICKHOUSE_PASSWORD" ]; then
+        printf -v WITH_PASSWORD '%s %q' "--password" "$CLICKHOUSE_PASSWORD"
+    fi
+
+    clickhouseclient=( clickhouse-client --multiquery -u $CLICKHOUSE_USER $WITH_PASSWORD )
+
     echo
     for f in /docker-entrypoint-initdb.d/*; do
         case "$f" in


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category:
- Improvement

Short description:

Added possibility to init a ClickHouse instance which requires authentication.
Duplicated: [#5321](https://github.com/yandex/ClickHouse/pull/5321)
...

Detailed description:

Changes make it possible to provide environment variables `CLICKHOUSE_USER` & `CLICKHOUSE_PASSWORD` that will be used for clickhouse-client during initialization.
