### PR TITLE
Disable tests and add global timeout

### DIFF
--- a/dbms/tests/integration/README.md
+++ b/dbms/tests/integration/README.md
@@ -14,9 +14,9 @@ Don't use Docker from your system repository.
 
 * [pip](https://pypi.python.org/pypi/pip). To install: `sudo apt-get install python-pip`
 * [py.test](https://docs.pytest.org/) testing framework. To install: `sudo -H pip install pytest`
-* [docker-compose](https://docs.docker.com/compose/) and additional python libraries. To install: `sudo -H pip install docker-compose docker dicttoxml kazoo PyMySQL psycopg2 pymongo tzlocal kafka-python protobuf`
+* [docker-compose](https://docs.docker.com/compose/) and additional python libraries. To install: `sudo -H pip install docker-compose docker dicttoxml kazoo PyMySQL psycopg2 pymongo tzlocal kafka-python protobuf pytest-timeout`
 
-(highly not recommended) If you really want to use OS packages on modern debian/ubuntu instead of "pip": `sudo apt install -y docker docker-compose python-pytest python-dicttoxml python-docker python-pymysql python-pymongo python-tzlocal python-kazoo python-psycopg2 python-kafka`
+(highly not recommended) If you really want to use OS packages on modern debian/ubuntu instead of "pip": `sudo apt install -y docker docker-compose python-pytest python-dicttoxml python-docker python-pymysql python-pymongo python-tzlocal python-kazoo python-psycopg2 python-kafka python-pytest-timeout`
 
 If you want to run the tests under a non-privileged user, you must add this user to `docker` group: `sudo usermod -aG docker $USER` and re-login.
 (You must close all your sessions (for example, restart your computer))

--- a/dbms/tests/integration/image/Dockerfile
+++ b/dbms/tests/integration/image/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update \
 ENV TZ=Europe/Moscow
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN pip install pytest docker-compose==1.22.0 docker dicttoxml kazoo PyMySQL psycopg2==2.7.5 pymongo tzlocal kafka-python protobuf redis aerospike
+RUN pip install pytest docker-compose==1.22.0 docker dicttoxml kazoo PyMySQL psycopg2==2.7.5 pymongo tzlocal kafka-python protobuf redis aerospike pytest-timeout
 
 ENV DOCKER_CHANNEL stable
 ENV DOCKER_VERSION 17.09.1-ce

--- a/dbms/tests/integration/pytest.ini
+++ b/dbms/tests/integration/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 python_files = test.py
 norecursedirs = _instances
+timeout = 600

--- a/dbms/tests/integration/test_extreme_deduplication/test.py
+++ b/dbms/tests/integration/test_extreme_deduplication/test.py
@@ -51,6 +51,7 @@ def test_deduplication_window_in_seconds(started_cluster):
 
 
 # Currently this test just reproduce incorrect behavior that sould be fixed
+@pytest.mark.skip(reason="Flapping test")
 def test_deduplication_works_in_case_of_intensive_inserts(started_cluster):
     inserters = []
     fetchers = []

--- a/dbms/tests/integration/test_insert_into_distributed_through_materialized_view/test.py
+++ b/dbms/tests/integration/test_insert_into_distributed_through_materialized_view/test.py
@@ -78,7 +78,7 @@ def test_reconnect(started_cluster):
 
         assert remote.query("SELECT count(*) FROM local1").strip() == '3'
 
-
+@pytest.mark.skip(reason="Flapping test")
 def test_inserts_batching(started_cluster):
     instance = instance_test_inserts_batching
 

--- a/dbms/tests/integration/test_storage_kafka/test.py
+++ b/dbms/tests/integration/test_storage_kafka/test.py
@@ -318,7 +318,7 @@ def test_kafka_materialized_view(kafka_cluster):
         DROP TABLE test.view;
     ''')
 
-
+@pytest.mark.skip(reason="Hungs")
 def test_kafka_flush_on_big_message(kafka_cluster):
     # Create batchs of messages of size ~100Kb
     kafka_messages = 10000


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement


Short description (up to few sentences):
Add global timeout for integration tests and disable some of them in tests code.
