### PR TITLE
Execute some distributed DDL queries on leader

### DIFF
--- a/dbms/src/Interpreters/DDLWorker.cpp
+++ b/dbms/src/Interpreters/DDLWorker.cpp
@@ -1,6 +1,9 @@
 #include <Interpreters/DDLWorker.h>
 #include <Parsers/ASTAlterQuery.h>
+#include <Parsers/ASTDropQuery.h>
+#include <Parsers/ASTOptimizeQuery.h>
 #include <Parsers/ASTQueryWithOnCluster.h>
+#include <Parsers/ASTQueryWithTableAndOutput.h>
 #include <Parsers/ParserQuery.h>
 #include <Parsers/parseQuery.h>
 #include <Parsers/queryToString.h>
@@ -29,6 +32,7 @@
 #include <Common/ZooKeeper/KeeperException.h>
 #include <Common/ZooKeeper/Lock.h>
 #include <Common/isLocalAddress.h>
+#include <Storages/StorageReplicatedMergeTree.h>
 #include <Poco/Timestamp.h>
 #include <random>
 #include <pcg_random.hpp>
@@ -614,14 +618,24 @@ void DDLWorker::processTask(DDLTask & task, const ZooKeeperPtr & zookeeper)
             String rewritten_query = queryToString(rewritten_ast);
             LOG_DEBUG(log, "Executing query: " << rewritten_query);
 
-            if (const auto * ast_alter = rewritten_ast->as<ASTAlterQuery>())
+            if (auto query_with_table = dynamic_cast<ASTQueryWithTableAndOutput *>(rewritten_ast.get()); query_with_table)
             {
-                processTaskAlter(task, ast_alter, rewritten_query, task.entry_path, zookeeper);
+                String database = query_with_table->database.empty() ? context.getCurrentDatabase() : query_with_table->database;
+                StoragePtr storage = context.tryGetTable(database, query_with_table->table);
+
+                /// For some reason we check consistency of cluster definition only
+                /// in case of ALTER query, but not in case of CREATE/DROP etc.
+                /// It's strange, but this behaviour exits for a long and we cannot change it.
+                if (storage && query_with_table->as<ASTAlterQuery>())
+                    checkShardConfig(query_with_table->table, task, storage);
+
+                if (storage && taskShouldBeExecutedOnLeader(rewritten_ast, storage))
+                    tryExecuteQueryOnLeaderReplica(task, storage, rewritten_query, task.entry_path, zookeeper);
+                else
+                    tryExecuteQuery(rewritten_query, task, task.execution_status);
             }
             else
-            {
                 tryExecuteQuery(rewritten_query, task, task.execution_status);
-            }
         }
         catch (const Coordination::Exception &)
         {
@@ -646,43 +660,52 @@ void DDLWorker::processTask(DDLTask & task, const ZooKeeperPtr & zookeeper)
 }
 
 
-void DDLWorker::processTaskAlter(
-    DDLTask & task,
-    const ASTAlterQuery * ast_alter,
-    const String & rewritten_query,
-    const String & node_path,
-    const ZooKeeperPtr & zookeeper)
+bool DDLWorker::taskShouldBeExecutedOnLeader(const ASTPtr ast_ddl, const StoragePtr storage) const
 {
-    String database = ast_alter->database.empty() ? context.getCurrentDatabase() : ast_alter->database;
-    StoragePtr storage = context.getTable(database, ast_alter->table);
+    /// Pure DROP queries have to be executed on each node separately
+    if (auto query = ast_ddl->as<ASTDropQuery>(); query && query->kind != ASTDropQuery::Kind::Truncate)
+        return false;
 
-    bool execute_once_on_replica = storage->supportsReplication();
-    bool execute_on_leader_replica = false;
+    if (!ast_ddl->as<ASTAlterQuery>() && !ast_ddl->as<ASTOptimizeQuery>() && !ast_ddl->as<ASTDropQuery>())
+        return false;
 
-    for (const auto & command : ast_alter->command_list->commands)
-    {
-        if (!isSupportedAlterType(command->type))
-            throw Exception("Unsupported type of ALTER query", ErrorCodes::NOT_IMPLEMENTED);
+    return storage->supportsReplication();
+}
 
-        if (execute_once_on_replica)
-            execute_on_leader_replica |= command->type == ASTAlterCommand::DROP_PARTITION;
-    }
 
+void DDLWorker::checkShardConfig(const String & table, const DDLTask & task, StoragePtr storage) const
+{
     const auto & shard_info = task.cluster->getShardsInfo().at(task.host_shard_num);
     bool config_is_replicated_shard = shard_info.hasInternalReplication();
 
-    if (execute_once_on_replica && !config_is_replicated_shard)
+    if (storage->supportsReplication() && !config_is_replicated_shard)
     {
-        throw Exception("Table " + ast_alter->table + " is replicated, but shard #" + toString(task.host_shard_num + 1) +
+        throw Exception("Table '" + table + "' is replicated, but shard #" + toString(task.host_shard_num + 1) +
             " isn't replicated according to its cluster definition."
             " Possibly <internal_replication>true</internal_replication> is forgotten in the cluster config.",
             ErrorCodes::INCONSISTENT_CLUSTER_DEFINITION);
     }
-    if (!execute_once_on_replica && config_is_replicated_shard)
+
+    if (!storage->supportsReplication() && config_is_replicated_shard)
     {
-        throw Exception("Table " + ast_alter->table + " isn't replicated, but shard #" + toString(task.host_shard_num + 1) +
+        throw Exception("Table '" + table + "' isn't replicated, but shard #" + toString(task.host_shard_num + 1) +
             " is replicated according to its cluster definition", ErrorCodes::INCONSISTENT_CLUSTER_DEFINITION);
     }
+}
+
+
+bool DDLWorker::tryExecuteQueryOnLeaderReplica(
+    DDLTask & task,
+    StoragePtr storage,
+    const String & rewritten_query,
+    const String & node_path,
+    const ZooKeeperPtr & zookeeper)
+{
+    StorageReplicatedMergeTree * replicated_storage = dynamic_cast<StorageReplicatedMergeTree *>(storage.get());
+
+    /// If we will develop new replicated storage
+    if (!replicated_storage)
+        throw Exception("Storage type '" + storage->getName() + "' is not supported by distributed DDL", ErrorCodes::NOT_IMPLEMENTED);
 
     /// Generate unique name for shard node, it will be used to execute the query by only single host
     /// Shard node name has format 'replica_name1,replica_name2,...,replica_nameN'
@@ -701,70 +724,73 @@ void DDLWorker::processTaskAlter(
         return res;
     };
 
-    if (execute_once_on_replica)
+    String shard_node_name = get_shard_name(task.cluster->getShardsAddresses().at(task.host_shard_num));
+    String shard_path = node_path + "/shards/" + shard_node_name;
+    String is_executed_path = shard_path + "/executed";
+    zookeeper->createAncestors(shard_path + "/");
+
+    auto is_already_executed = [&]() -> bool
     {
-        String shard_node_name = get_shard_name(task.cluster->getShardsAddresses().at(task.host_shard_num));
-        String shard_path = node_path + "/shards/" + shard_node_name;
-        String is_executed_path = shard_path + "/executed";
-        zookeeper->createAncestors(shard_path + "/");
-
-        bool is_executed_by_any_replica = false;
+        String executed_by;
+        if (zookeeper->tryGet(is_executed_path, executed_by))
         {
-            auto lock = createSimpleZooKeeperLock(zookeeper, shard_path, "lock", task.host_id_str);
-            pcg64 rng(randomSeed());
+            LOG_DEBUG(log, "Task " << task.entry_name << " has already been executed by leader replica ("
+                << executed_by << ") of the same shard.");
+            return true;
+        }
 
-            auto is_already_executed = [&]() -> bool
+        return false;
+    };
+
+    pcg64 rng(randomSeed());
+
+    auto lock = createSimpleZooKeeperLock(zookeeper, shard_path, "lock", task.host_id_str);
+    static const size_t max_tries = 20;
+    bool executed_by_leader = false;
+    for (size_t num_tries = 0; num_tries < max_tries; ++num_tries)
+    {
+        if (is_already_executed())
+        {
+            executed_by_leader = true;
+            break;
+        }
+
+        StorageReplicatedMergeTree::Status status;
+        replicated_storage->getStatus(status);
+
+        /// Leader replica take lock
+        if (status.is_leader && lock->tryLock())
+        {
+            if (is_already_executed())
             {
-                String executed_by;
-                if (zookeeper->tryGet(is_executed_path, executed_by))
-                {
-                    is_executed_by_any_replica = true;
-                    LOG_DEBUG(log, "Task " << task.entry_name << " has already been executed by another replica ("
-                        << executed_by << ") of the same shard.");
-                    return true;
-                }
-
-                return false;
-            };
-
-            static const size_t max_tries = 20;
-            for (size_t num_tries = 0; num_tries < max_tries; ++num_tries)
-            {
-                if (is_already_executed())
-                    break;
-
-                if (lock->tryLock())
-                {
-                    if (is_already_executed())
-                        break;
-
-                    tryExecuteQuery(rewritten_query, task, task.execution_status);
-
-                    if (execute_on_leader_replica && task.execution_status.code == ErrorCodes::NOT_IMPLEMENTED)
-                    {
-                        /// TODO: it is ok to receive exception "host is not leader"
-                    }
-
-                    zookeeper->create(is_executed_path, task.host_id_str, zkutil::CreateMode::Persistent);
-                    lock->unlock();
-                    is_executed_by_any_replica = true;
-                    break;
-                }
-
-                std::this_thread::sleep_for(std::chrono::milliseconds(std::uniform_int_distribution<long>(0, 1000)(rng)));
+                executed_by_leader = true;
+                break;
             }
+
+            /// If the leader will unexpectedly changed this method will return false
+            /// and on the next iteration new leader will take lock
+            if (tryExecuteQuery(rewritten_query, task, task.execution_status))
+            {
+                zookeeper->create(is_executed_path, task.host_id_str, zkutil::CreateMode::Persistent);
+                executed_by_leader = true;
+                break;
+            }
+
         }
 
-        if (!is_executed_by_any_replica)
-        {
-            task.execution_status = ExecutionStatus(ErrorCodes::NOT_IMPLEMENTED,
-                                                    "Cannot enqueue replicated DDL query for a replicated shard");
-        }
+        /// Does nothing if wasn't previously locked
+        lock->unlock();
+        std::this_thread::sleep_for(std::chrono::milliseconds(std::uniform_int_distribution<long>(0, 1000)(rng)));
     }
-    else
+
+    /// Not executed by leader so was not executed at all
+    if (!executed_by_leader)
     {
-        tryExecuteQuery(rewritten_query, task, task.execution_status);
+        task.execution_status = ExecutionStatus(ErrorCodes::NOT_IMPLEMENTED,
+                                                "Cannot execute replicated DDL query on leader");
+        return false;
     }
+    return true;
 }
 
 

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -3958,8 +3958,7 @@ void StorageReplicatedMergeTree::sendRequestToLeaderReplica(const ASTPtr & query
     /// there is no sense to send query to leader, because he will receive it from own DDLWorker
     if (query_context.getClientInfo().query_kind == ClientInfo::QueryKind::SECONDARY_QUERY)
     {
-        LOG_DEBUG(log, "Not leader replica received query from DDLWorker, skipping it.");
-        return;
+        throw Exception("Cannot execute DDL query, because leader was suddenly changed or logical error.", ErrorCodes::LEADERSHIP_CHANGED);
     }
 
     ReplicatedMergeTreeAddress leader_address(getZooKeeper()->get(zookeeper_path + "/replicas/" + leader + "/host"));

--- a/dbms/tests/integration/test_distributed_ddl_password/configs/config.d/clusters.xml
+++ b/dbms/tests/integration/test_distributed_ddl_password/configs/config.d/clusters.xml
@@ -24,5 +24,18 @@
             </replica>
         </shard>
     </awesome_cluster>
+    <simple_cluster>
+        <shard>
+            <internal_replication>true</internal_replication>
+            <replica>
+                <host>node5</host>
+                <port>9000</port>
+            </replica>
+            <replica>
+                <host>node6</host>
+                <port>9000</port>
+            </replica>
+        </shard>
+    </simple_cluster>
 </remote_servers>
 </yandex>

--- a/dbms/tests/integration/test_distributed_ddl_password/test.py
+++ b/dbms/tests/integration/test_distributed_ddl_password/test.py
@@ -1,19 +1,25 @@
 import time
 import pytest
 from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
+
+from helpers.client import QueryRuntimeException
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', config_dir="configs", with_zookeeper=True)
 node2 = cluster.add_instance('node2', config_dir="configs", with_zookeeper=True)
 node3 = cluster.add_instance('node3', config_dir="configs", with_zookeeper=True)
 node4 = cluster.add_instance('node4', config_dir="configs", with_zookeeper=True)
+node5 = cluster.add_instance('node5', config_dir="configs", with_zookeeper=True)
+node6 = cluster.add_instance('node6', config_dir="configs", with_zookeeper=True)
+
 
 @pytest.fixture(scope="module")
 def start_cluster():
     try:
         cluster.start()
 
-        for node, shard in [(node1, 1), (node2, 1), (node3, 2), (node4, 2)]:
+        for node, shard in [(node1, 1), (node2, 1), (node3, 2), (node4, 2), (node5, 3), (node6, 3)]:
             node.query(
             '''
                 CREATE TABLE test_table(date Date, id UInt32, dummy UInt32)
@@ -42,13 +48,51 @@ def test_truncate(start_cluster):
     assert node4.query("select count(*) from test_table", settings={"password": "clickhouse"}) == "3\n"
 
     node3.query("truncate table test_table on cluster 'awesome_cluster'", settings={"password": "clickhouse"})
-    time.sleep(2)
 
     for node in [node1, node2, node3, node4]:
-        assert node.query("select count(*) from test_table", settings={"password": "clickhouse"}) == "0\n"
+        assert_eq_with_retry(node, "select count(*) from test_table", "0", settings={"password": "clickhouse"})
 
     node2.query("drop table test_table on cluster 'awesome_cluster'", settings={"password": "clickhouse"})
-    time.sleep(2)
 
     for node in [node1, node2, node3, node4]:
-        assert node.query("select count(*) from system.tables where name='test_table'", settings={"password": "clickhouse"}) == "0\n"
+        assert_eq_with_retry(node, "select count(*) from system.tables where name='test_table'", "0", settings={"password": "clickhouse"})
+
+def test_alter(start_cluster):
+    node5.query("insert into test_table values ('2019-02-15', 1, 2), ('2019-02-15', 2, 3), ('2019-02-15', 3, 4)", settings={"password": "clickhouse"})
+    node6.query("insert into test_table values ('2019-02-15', 4, 2), ('2019-02-15', 5, 3), ('2019-02-15', 6, 4)", settings={"password": "clickhouse"})
+
+    node5.query("SYSTEM SYNC REPLICA test_table", settings={"password": "clickhouse"})
+    node6.query("SYSTEM SYNC REPLICA test_table", settings={"password": "clickhouse"})
+
+    assert_eq_with_retry(node5, "select count(*) from test_table", "6", settings={"password": "clickhouse"})
+    assert_eq_with_retry(node6, "select count(*) from test_table", "6", settings={"password": "clickhouse"})
+
+    node6.query("OPTIMIZE TABLE test_table ON CLUSTER 'simple_cluster' FINAL", settings={"password": "clickhouse"})
+
+    node5.query("SYSTEM SYNC REPLICA test_table", settings={"password": "clickhouse"})
+    node6.query("SYSTEM SYNC REPLICA test_table", settings={"password": "clickhouse"})
+
+    assert_eq_with_retry(node5, "select count(*) from test_table", "6", settings={"password": "clickhouse"})
+    assert_eq_with_retry(node6, "select count(*) from test_table", "6", settings={"password": "clickhouse"})
+
+    node6.query("ALTER TABLE test_table ON CLUSTER 'simple_cluster' DETACH PARTITION '2019-02-15'", settings={"password": "clickhouse"})
+    assert_eq_with_retry(node5, "select count(*) from test_table", "0", settings={"password": "clickhouse"})
+    assert_eq_with_retry(node6, "select count(*) from test_table", "0", settings={"password": "clickhouse"})
+
+    with pytest.raises(QueryRuntimeException):
+        node6.query("ALTER TABLE test_table ON CLUSTER 'simple_cluster' ATTACH PARTITION '2019-02-15'", settings={"password": "clickhouse"})
+
+    node5.query("ALTER TABLE test_table ATTACH PARTITION '2019-02-15'", settings={"password": "clickhouse"})
+
+    assert_eq_with_retry(node5, "select count(*) from test_table", "6", settings={"password": "clickhouse"})
+    assert_eq_with_retry(node6, "select count(*) from test_table", "6", settings={"password": "clickhouse"})
+
+    node5.query("ALTER TABLE test_table ON CLUSTER 'simple_cluster' MODIFY COLUMN dummy String", settings={"password": "clickhouse"})
+
+    assert_eq_with_retry(node5, "select length(dummy) from test_table ORDER BY dummy LIMIT 1", "1", settings={"password": "clickhouse"})
+    assert_eq_with_retry(node6, "select length(dummy) from test_table ORDER BY dummy LIMIT 1", "1", settings={"password": "clickhouse"})
+
+    node6.query("ALTER TABLE test_table ON CLUSTER 'simple_cluster' DROP PARTITION '2019-02-15'", settings={"password": "clickhouse"})
+
+    assert_eq_with_retry(node5, "select count(*) from test_table", "0", settings={"password": "clickhouse"})
+    assert_eq_with_retry(node6, "select count(*) from test_table", "0", settings={"password": "clickhouse"})


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Now distributed `DROP/ALTER/TRUNCATE/OPTIMIZE ON CLUSTER` queries will be executed directly on leader replica. 