### PR TITLE
Add ability to build rpm and tgz packages via packager

### DIFF
--- a/debian/pbuilder-hooks/A00ccache
+++ b/debian/pbuilder-hooks/A00ccache
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+# set -x
+
 # CCACHEDIR - for pbuilder ; CCACHE_DIR - for ccache
 
 echo "CCACHEDIR=$CCACHEDIR CCACHE_DIR=$CCACHE_DIR SET_CCACHEDIR=$SET_CCACHEDIR"
@@ -12,9 +14,7 @@ if [ -n "$CCACHE_DIR" ]; then
     chmod -R a+rwx $CCACHE_DIR $DISTCC_DIR ||:
 fi
 
-[ $CCACHE_PREFIX = 'distcc' ] && mkdir -p ~/.distcc && echo "localhost/`nproc`" >> ~/.distcc/hosts
-# [ $CCACHE_PREFIX = 'distcc' ] && mkdir -p /etc/distcc/ && echo "localhost/`nproc`" >> /etc/distcc/hosts
-# distcc --show-hosts
+[ $CCACHE_PREFIX = 'distcc' ] && mkdir -p $DISTCC_DIR && echo "localhost/`nproc`" >> $DISTCC_DIR/hosts && distcc --show-hosts
 
 df -h
 ccache --show-stats

--- a/debian/rules
+++ b/debian/rules
@@ -130,5 +130,7 @@ override_dh_auto_install:
 override_dh_shlibdeps:
 	true # We depend only on libc and dh_shlibdeps gives us wrong (too strict) dependency.
 
+#TODO: faster packing of non-release builds: ifdef RELEASE_COMPATIBLE
 override_dh_builddeb:
 	dh_builddeb -- -Z gzip # Older systems don't have "xz", so use "gzip" instead.
+#TODO: endif

--- a/docker/packager/deb/Dockerfile
+++ b/docker/packager/deb/Dockerfile
@@ -67,7 +67,9 @@ RUN apt-get --allow-unauthenticated update -y \
             unixodbc-dev \
             odbcinst \
             tzdata \
-            gperf
+            gperf \
+            alien
+
 
 COPY build.sh /
 CMD ["/bin/bash", "/build.sh"]

--- a/docker/packager/deb/build.sh
+++ b/docker/packager/deb/build.sh
@@ -4,8 +4,10 @@ set -x -e
 
 ccache --show-stats ||:
 ccache --zero-stats ||:
-build/release --no-pbuilder
+build/release --no-pbuilder $ALIEN_PKGS
 mv /*.deb /output
 mv *.changes /output
 mv *.buildinfo /output
+mv /*.rpm /output ||: # if exists
+mv /*.tgz /output ||: # if exists
 ccache --show-stats ||:

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -103,7 +103,7 @@ def run_vagrant_box_with_env(image_path, output_dir, ch_root):
         logging.info("Copying binary back")
         vagrant.copy_from_image("~/ClickHouse/dbms/programs/clickhouse", output_dir)
 
-def parse_env_variables(build_type, compiler, sanitizer, package_type, cache, distcc_hosts, unbundled, split_binary, version, author, official):
+def parse_env_variables(build_type, compiler, sanitizer, package_type, cache, distcc_hosts, unbundled, split_binary, version, author, official, alien_pkgs):
     result = []
     cmake_flags = ['$CMAKE_FLAGS']
 
@@ -138,6 +138,9 @@ def parse_env_variables(build_type, compiler, sanitizer, package_type, cache, di
         result.append('DISTCC_HOSTS="{}"'.format(" ".join(hosts_with_params)))
     elif cache == "distcc":
         result.append('DISTCC_HOSTS="{}"'.format("localhost/`nproc`"))
+
+    if alien_pkgs:
+        result.append("ALIEN_PKGS='" + ' '.join(['--' + pkg for pkg in alien_pkgs]) + "'")
 
     if unbundled:
         cmake_flags.append('-DUNBUNDLED=1 -DENABLE_MYSQL=0 -DENABLE_POCO_ODBC=0 -DENABLE_ODBC=0')
@@ -176,6 +179,7 @@ if __name__ == "__main__":
     parser.add_argument("--version")
     parser.add_argument("--author", default="clickhouse")
     parser.add_argument("--official", action="store_true")
+    parser.add_argument("--alien-pkgs", nargs='+', default=[])
 
     args = parser.parse_args()
     if not os.path.isabs(args.output_dir):
@@ -188,6 +192,9 @@ if __name__ == "__main__":
     else:
         ch_root = args.clickhouse_repo_path
 
+    if args.alien_pkgs and not args.package_type == "deb":
+        raise Exception("Can add alien packages only in deb build")
+
     dockerfile = os.path.join(ch_root, "docker/packager", args.package_type, "Dockerfile")
     if args.package_type != "freebsd" and not check_image_exists_locally(image_name) or args.force_build_image:
         if not pull_image(image_name) or args.force_build_image:
@@ -195,7 +202,7 @@ if __name__ == "__main__":
     env_prepared = parse_env_variables(
         args.build_type, args.compiler, args.sanitizer, args.package_type,
         args.cache, args.distcc_hosts, args.unbundled, args.split_binary,
-        args.version, args.author, args.official)
+        args.version, args.author, args.official, args.alien_pkgs)
     if args.package_type != "freebsd":
         run_docker_image_with_env(image_name, args.output_dir, env_prepared, ch_root, args.ccache_dir)
     else:

--- a/release
+++ b/release
@@ -113,9 +113,8 @@ export EXTRAPACKAGES
 VERSION_STRING+=$VERSION_POSTFIX
 echo -e "\nCurrent version is $VERSION_STRING"
 
-gen_changelog "$VERSION_STRING" "" "$AUTHOR" ""
-
 if [ -z "$NO_BUILD" ] ; then
+    gen_changelog "$VERSION_STRING" "" "$AUTHOR" ""
     if [ -z "$USE_PBUILDER" ] ; then
         DEB_CC=${DEB_CC:=`which gcc-7 gcc-8 gcc | head -n1`}
         DEB_CXX=${DEB_CXX:=`which g++-7 g++-8 g++ | head -n1`}

--- a/utils/release/release_lib.sh
+++ b/utils/release/release_lib.sh
@@ -1,4 +1,5 @@
 set +e
+# set -x
 
 function gen_version_string {
     if [ -n "$TEST" ]; then
@@ -181,9 +182,8 @@ function gen_dockerfiles {
 }
 
 function make_rpm {
-    get_version
-    [ -z "$VERSION_STRING" ] && get_version
-    VERSION_FULL=${VERSION_STRING}${VERSION_POSTFIX}
+    [ -z "$VERSION_STRING" ] && get_version && VERSION_STRING+=${VERSION_POSTFIX}
+    VERSION_FULL="${VERSION_STRING}"
     PACKAGE_DIR=${PACKAGE_DIR=../}
 
     function deb_unpack {
@@ -257,8 +257,8 @@ function make_rpm {
 }
 
 function make_tgz {
-    [ -z "$VERSION_STRING" ] && get_version
-    VERSION_FULL="${VERSION_STRING}${VERSION_POSTFIX}"
+    [ -z "$VERSION_STRING" ] && get_version && VERSION_STRING+=${VERSION_POSTFIX}
+    VERSION_FULL="${VERSION_STRING}"
     PACKAGE_DIR=${PACKAGE_DIR=../}
 
     for PACKAGE in clickhouse-server clickhouse-client clickhouse-test clickhouse-common-static clickhouse-common-static-dbg; do

--- a/utils/release/release_lib.sh
+++ b/utils/release/release_lib.sh
@@ -182,16 +182,16 @@ function gen_dockerfiles {
 
 function make_rpm {
     get_version
-    VERSION_STRING+=$VERSION_POSTFIX
-    VERSION=$VERSION_STRING
-    PACKAGE_DIR=../
+    [ -z "$VERSION_STRING" ] && get_version
+    VERSION_FULL=${VERSION_STRING}${VERSION_POSTFIX}
+    PACKAGE_DIR=${PACKAGE_DIR=../}
 
     function deb_unpack {
-        rm -rf $PACKAGE-$VERSION
-        alien --verbose --generate --to-rpm --scripts ${PACKAGE_DIR}${PACKAGE}_${VERSION}_${ARCH}.deb
-        cd $PACKAGE-$VERSION
-        mv ${PACKAGE}-$VERSION-2.spec ${PACKAGE}-$VERSION-2.spec.tmp
-        cat ${PACKAGE}-$VERSION-2.spec.tmp \
+        rm -rf $PACKAGE-$VERSION_FULL
+        alien --verbose --generate --to-rpm --scripts ${PACKAGE_DIR}${PACKAGE}_${VERSION_FULL}_${ARCH}.deb
+        cd $PACKAGE-$VERSION_FULL
+        mv ${PACKAGE}-$VERSION_FULL-2.spec ${PACKAGE}-$VERSION_FULL-2.spec.tmp
+        cat ${PACKAGE}-$VERSION_FULL-2.spec.tmp \
             | grep -vF '%dir "/"' \
             | grep -vF '%dir "/usr/"' \
             | grep -vF '%dir "/usr/bin/"' \
@@ -210,11 +210,11 @@ function make_rpm {
             | grep -vF '%dir "/etc/cron.d/"' \
             | grep -vF '%dir "/etc/systemd/system/"' \
             | grep -vF '%dir "/etc/systemd/"' \
-            > ${PACKAGE}-$VERSION-2.spec
+            > ${PACKAGE}-$VERSION_FULL-2.spec
     }
 
     function rpm_pack {
-        rpmbuild --buildroot="$CUR_DIR/${PACKAGE}-$VERSION" -bb --target ${TARGET} "${PACKAGE}-$VERSION-2.spec"
+        rpmbuild --buildroot="$CUR_DIR/${PACKAGE}-$VERSION_FULL" -bb --target ${TARGET} "${PACKAGE}-$VERSION_FULL-2.spec"
         cd $CUR_DIR
     }
 
@@ -237,10 +237,10 @@ function make_rpm {
     ARCH=all
     TARGET=noarch
     deb_unpack
-    mv ${PACKAGE}-$VERSION-2.spec ${PACKAGE}-$VERSION-2.spec_tmp
-    echo "Requires: python2" >> ${PACKAGE}-$VERSION-2.spec
+    mv ${PACKAGE}-$VERSION_FULL-2.spec ${PACKAGE}-$VERSION_FULL-2.spec_tmp
+    echo "Requires: python2" >> ${PACKAGE}-$VERSION_FULL-2.spec
     #echo "Requires: python2-termcolor" >> ${PACKAGE}-$VERSION-2.spec
-    cat ${PACKAGE}-$VERSION-2.spec_tmp >> ${PACKAGE}-$VERSION-2.spec
+    cat ${PACKAGE}-$VERSION_FULL-2.spec_tmp >> ${PACKAGE}-$VERSION_FULL-2.spec
     rpm_pack
 
     PACKAGE=clickhouse-common-static
@@ -253,18 +253,17 @@ function make_rpm {
     TARGET=x86_64
     unpack_pack
 
-    mv clickhouse-*-${VERSION_STRING}-2.*.rpm ${PACKAGE_DIR}
+    mv clickhouse-*-${VERSION_FULL}-2.*.rpm ${PACKAGE_DIR}
 }
 
 function make_tgz {
-    get_version
-    VERSION_STRING+=$VERSION_POSTFIX
-    VERSION=$VERSION_STRING
-    PACKAGE_DIR=../
+    [ -z "$VERSION_STRING" ] && get_version
+    VERSION_FULL="${VERSION_STRING}${VERSION_POSTFIX}"
+    PACKAGE_DIR=${PACKAGE_DIR=../}
 
     for PACKAGE in clickhouse-server clickhouse-client clickhouse-test clickhouse-common-static clickhouse-common-static-dbg; do
-        alien --verbose --to-tgz ${PACKAGE_DIR}${PACKAGE}_${VERSION}_*.deb
+        alien --verbose --to-tgz ${PACKAGE_DIR}${PACKAGE}_${VERSION_FULL}_*.deb
     done
 
-    mv clickhouse-*-${VERSION_STRING}.tgz ${PACKAGE_DIR}
+    mv clickhouse-*-${VERSION_FULL}.tgz ${PACKAGE_DIR}
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Add an ability to build `.rpm` and `.tgz` packages with `packager` script.
