### PR TITLE
IO: fix endian portable on macos x

### DIFF
--- a/dbms/src/IO/BitHelpers.h
+++ b/dbms/src/IO/BitHelpers.h
@@ -7,6 +7,11 @@
 
 #if defined(__OpenBSD__) || defined(__FreeBSD__)
 #   include <sys/endian.h>
+#elif defined(__APPLE__)
+#   include <libkern/OSByteOrder.h>
+
+#   define htobe64(x) OSSwapHostToBigInt64(x)
+#   define be64toh(x) OSSwapBigToHostInt64(x)
 #endif
 
 namespace DB


### PR DESCRIPTION
Signed-off-by: fredchenbj <cfworking@163.com>

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en


Category (leave one):
- Bug Fix


Short description (up to few sentences):
convert BSD/Linux endian macros( 'be64toh' and 'htobe64') to the Mac OS X equivalents


Detailed description (optional):
when compile on macos, the following error occurs:
```
../dbms/src/IO/BitHelpers.h:102:23: error: use of undeclared identifier 'be64toh'
        bits_buffer = be64toh(bits_buffer);
                      ^
../dbms/src/IO/BitHelpers.h:174:23: error: use of undeclared identifier 'htobe64'
        bits_buffer = htobe64(bits_buffer);
                      ^
2 errors generated.
```
