### PR TITLE
Fixed DoubleDelta codec edge case

### DIFF
--- a/dbms/tests/queries/0_stateless/00950_test_double_delta_codec.reference
+++ b/dbms/tests/queries/0_stateless/00950_test_double_delta_codec.reference
@@ -8,3 +8,4 @@ I16
 I8
 DT
 D
+Compression:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fixed DoubleDelta codec encoding bug that killed compression ratio.
...

Detailed description (optional):
Caused by mistreating negative double delta value as HUGE unsigned value, crippling compression ratio.
Added test case to verify the fix.
...
