### PR TITLE
Fallback to UTC if tzdata is missing

### DIFF
--- a/libs/libcommon/src/DateLUT.cpp
+++ b/libs/libcommon/src/DateLUT.cpp
@@ -22,6 +22,7 @@ Poco::DigestEngine::Digest calcSHA1(const std::string & path)
     return digest_engine.digest();
 }
 
+
 std::string determineDefaultTimeZone()
 {
     namespace fs = boost::filesystem;
@@ -51,6 +52,10 @@ std::string determineDefaultTimeZone()
     {
         error_prefix = "Could not determine local time zone: ";
         tz_file_path = "/etc/localtime"; /// FIXME: in case of no TZ use the immediate linked file as tz name.
+
+        /// No TZ variable and no tzdata installed (e.g. Docker)
+        if (!fs::exists(tz_file_path))
+            return "UTC";
     }
 
     try


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

Short description (up to few sentences):
Use `UTC` as default timezone on a system without `tzdata` (e.g. bare Docker container). Before this patch, error message `Could not determine local time zone` was printed and server or client refused to start.

Detailed description:

A test:
```
docker run -it --rm --volume=/home/milovidov/work/ClickHouse/build:/build ubuntu:bionic /bin/bash
root@337bc9a91b76:/# /build/dbms/programs/clickhouse local --query "SELECT 1"
1
root@337bc9a91b76:/# /build/dbms/programs/clickhouse local --query "SELECT now()"
2019-07-01 23:25:24
```