### PR TITLE
Fix wrong resolution of time zone name.

### DIFF
--- a/dbms/tests/queries/0_stateless/00336_shard_stack_trace.sh
+++ b/dbms/tests/queries/0_stateless/00336_shard_stack_trace.sh
@@ -5,9 +5,9 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d 'SELECT a' | wc -l
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?stacktrace=0" -d 'SELECT a' | wc -l
-[[ $(${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?stacktrace=1" -d 'SELECT a' | wc -l) -gt 3 ]] && echo 'Ok' || echo 'Fail'
+[[ $(${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}?stacktrace=1" -d 'SELECT a' | wc -l) -ge 3 ]] && echo 'Ok' || echo 'Fail'
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "SELECT intDiv(number, 0) FROM remote('127.0.0.{2,3}', system.numbers)" | wc -l
 
 $CLICKHOUSE_CLIENT --query="SELECT a" --server_logs_file=/dev/null 2>&1 | wc -l
-[[ $($CLICKHOUSE_CLIENT --query="SELECT a" --server_logs_file=/dev/null --stacktrace 2>&1 | wc -l) -gt 3 ]] && echo 'Ok' || echo 'Fail'
+[[ $($CLICKHOUSE_CLIENT --query="SELECT a" --server_logs_file=/dev/null --stacktrace 2>&1 | wc -l) -ge 3 ]] && echo 'Ok' || echo 'Fail'
 $CLICKHOUSE_CLIENT --query="SELECT intDiv(number, 0) FROM remote('127.0.0.{2,3}', system.numbers)" --server_logs_file=/dev/null 2>&1 | wc -l

--- a/libs/libcommon/src/DateLUT.cpp
+++ b/libs/libcommon/src/DateLUT.cpp
@@ -6,6 +6,7 @@
 #include <Poco/DigestStream.h>
 #include <fstream>
 
+
 namespace
 {
 
@@ -50,22 +51,41 @@ std::string determineDefaultTimeZone()
     else
     {
         error_prefix = "Could not determine local time zone: ";
-        tz_file_path = "/etc/localtime"; /// FIXME: in case of no TZ use the immediate linked file as tz name.
+        tz_file_path = "/etc/localtime";
+
+        /// Read symlink but not transitive.
+        /// Example:
+        ///  /etc/localtime -> /usr/share/zoneinfo//UTC
+        ///  /usr/share/zoneinfo//UTC -> UCT
+        /// But the preferred time zone name is pointed by the first link (UTC), and the second link is just an internal detail.
+        if (fs::is_symlink(tz_file_path))
+            tz_file_path = fs::read_symlink(tz_file_path);
     }
 
     try
     {
         tz_database_path = fs::canonical(tz_database_path);
-        tz_file_path = fs::canonical(tz_file_path, tz_database_path);
 
         /// The tzdata file exists. If it is inside the tz_database_dir,
         /// then the relative path is the time zone id.
-        fs::path relative_path = tz_file_path.lexically_relative(tz_database_path);
-        if (!relative_path.empty() && *relative_path.begin() != ".." && *relative_path.begin() != ".")
-            return tz_name.empty() ? relative_path.string() : tz_name;
+        {
+            fs::path relative_path = tz_file_path.lexically_relative(tz_database_path);
 
-        /// The file is not inside the tz_database_dir, so we hope that it was copied and
-        /// try to find the file with exact same contents in the database.
+            if (!relative_path.empty() && *relative_path.begin() != ".." && *relative_path.begin() != ".")
+                return tz_name.empty() ? relative_path.string() : tz_name;
+        }
+
+        /// Try the same with full symlinks resolution
+        {
+            tz_file_path = fs::canonical(tz_file_path, tz_database_path);
+
+            fs::path relative_path = tz_file_path.lexically_relative(tz_database_path);
+            if (!relative_path.empty() && *relative_path.begin() != ".." && *relative_path.begin() != ".")
+                return tz_name.empty() ? relative_path.string() : tz_name;
+        }
+
+        /// The file is not inside the tz_database_dir, so we hope that it was copied (not symlinked)
+        /// and try to find the file with exact same contents in the database.
 
         size_t tzfile_size = fs::file_size(tz_file_path);
         Poco::SHA1Engine::Digest tzfile_sha1 = calcSHA1(tz_file_path.string());

--- a/libs/libcommon/src/DateLUT.cpp
+++ b/libs/libcommon/src/DateLUT.cpp
@@ -22,6 +22,7 @@ Poco::DigestEngine::Digest calcSHA1(const std::string & path)
     return digest_engine.digest();
 }
 
+
 std::string determineDefaultTimeZone()
 {
     namespace fs = boost::filesystem;
@@ -51,6 +52,10 @@ std::string determineDefaultTimeZone()
     {
         error_prefix = "Could not determine local time zone: ";
         tz_file_path = "/etc/localtime"; /// FIXME: in case of no TZ use the immediate linked file as tz name.
+
+        /// No TZ variable and no tzdata installed (e.g. Docker)
+        if (!fs::exists(tz_file_path))
+            return "UTC";
     }
 
     try


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fixed the issue when ClickHouse determines default time zone as `UCT` instead of `UTC`. This fixes #5804.