### PR TITLE
fix macos build after #4828

### DIFF
--- a/libs/libcommon/include/common/StackTrace.h
+++ b/libs/libcommon/include/common/StackTrace.h
@@ -8,7 +8,7 @@
 
 #ifdef __APPLE__
 // ucontext is not available without _XOPEN_SOURCE
-#define _XOPEN_SOURCE
+#define _XOPEN_SOURCE 700
 #endif
 #include <ucontext.h>
 

--- a/libs/libdaemon/src/BaseDaemon.cpp
+++ b/libs/libdaemon/src/BaseDaemon.cpp
@@ -48,7 +48,7 @@
 
 #ifdef __APPLE__
 // ucontext is not available without _XOPEN_SOURCE
-#define _XOPEN_SOURCE
+#define _XOPEN_SOURCE 700
 #endif
 #include <ucontext.h>
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Short description (up to few sentences):

Fixes that error: 
```
[2808/3382] Building CXX object dbms/src/Functions/CMakeFiles/clickhouse_functions.dir/FunctionsBitmap.cpp.o
FAILED: dbms/src/Functions/CMakeFiles/clickhouse_functions.dir/FunctionsBitmap.cpp.o 
/usr/local/bin/ccache /usr/local/bin/g++-9  -DBOOST_SYSTEM_NO_DEPRECATED -DLZ4_DISABLE_DEPRECATE_WARNINGS=1 -DPOCO_STATIC -DPOCO_UNBUNDLED_ZLIB -DUNALIGNED_OK -DWITH_GZFILEOP -DX86_64 -DZLIB_COMPAT -Idbms/src/Functions/include -Idbms/src/Core/include -I../dbms/src -Idbms/src -I../libs/libcommon/include -Ilibs/libcommon/include -I../contrib/zlib-ng -Icontrib/zlib-ng -I../contrib/cityhash102/include -I../contrib/croaring -I../libs/consistent-hashing -I../libs/consistent-hashing-sumbur -I../contrib/libfarmhash -I../contrib/murmurhash/include -I../contrib/simdjson/include -isystem ../contrib/libdivide -isystem ../contrib/libmetrohash/src -isystem ../contrib/base64/include -isystem ../contrib/lz4/lib -isystem ../contrib/h3/src/h3lib/include -isystem ../contrib/hyperscan/src -isystem ../contrib/rapidjson/include -isystem ../contrib/pdqsort -isystem ../contrib/libpcg-random/include -isystem ../contrib/double-conversion -isystem ../contrib/re2 -isystem ../contrib/poco/Util/include -isystem ../contrib/poco/Foundation/include -isystem ../contrib/poco/XML/include -isystem ../contrib/poco/JSON/include -isystem ../contrib/boost -isystem ../contrib/poco/Net/include -isystem contrib/re2_st -isystem ../contrib/ssl/include -isystem contrib/h3/src/h3lib/include -fdiagnostics-color=always  -pipe -msse4.1 -msse4.2 -mpopcnt  -fno-omit-frame-pointer  -Wall  -Wnon-virtual-dtor -Wno-array-bounds -Wextra -Werror -O2 -g -DNDEBUG -O3    -fno-tree-loop-distribute-patterns -g0 -std=c++17 -MD -MT dbms/src/Functions/CMakeFiles/clickhouse_functions.dir/FunctionsBitmap.cpp.o -MF dbms/src/Functions/CMakeFiles/clickhouse_functions.dir/FunctionsBitmap.cpp.o.d -o dbms/src/Functions/CMakeFiles/clickhouse_functions.dir/FunctionsBitmap.cpp.o -c ../dbms/src/Functions/FunctionsBitmap.cpp
In file included from ../dbms/src/AggregateFunctions/AggregateFunctionGroupBitmapData.h:3,
                 from ../dbms/src/Functions/FunctionsBitmap.h:4,
                 from ../dbms/src/Functions/FunctionsBitmap.cpp:2:
../contrib/croaring/roaring/roaring.h:48:49: error: operator '<' has no left operand
   48 | #if !(defined(_XOPEN_SOURCE)) || (_XOPEN_SOURCE < 700)
      |                                                 ^
[2812/3382] Building CXX object dbms/src/Functions/CMakeFiles/clickhouse_functions.dir/FunctionsConversion.cpp.o
ninja: build stopped: subcommand failed.
```
/cc @laplab @proller 