### PR TITLE
remove meaningless check of libunwind stack size

### DIFF
--- a/libs/libcommon/src/StackTrace.cpp
+++ b/libs/libcommon/src/StackTrace.cpp
@@ -10,8 +10,6 @@
 #if USE_UNWIND
 #define UNW_LOCAL_ONLY
 #include <libunwind.h>
-
-static_assert(StackTrace::capacity < LIBUNWIND_MAX_STACK_SIZE, "StackTrace cannot be larger than libunwind upper bound on stack size");
 #endif
 
 std::string signalToErrorMessage(int sig, const siginfo_t & info, const ucontext_t & context)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

**Category:** Bug Fix

**Short description:** `LIBUNWIND_MAX_STACK_SIZE` shows maximum stack size for DWARF instructions `DW_CFA_remember_state` and `DW_CFA_restore_state`. Nothing to do with actual stack trace size