### PR TITLE
Compatibility with old compiler (gcc-7)

### DIFF
--- a/dbms/src/Interpreters/ExternalLoader.cpp
+++ b/dbms/src/Interpreters/ExternalLoader.cpp
@@ -403,8 +403,8 @@ public:
     bool hasCurrentlyLoadedObjects() const
     {
         std::lock_guard lock{mutex};
-        for (auto & [name, info] : infos)
-            if (info.loaded())
+        for (auto & name_info : infos)
+            if (name_info.second.loaded())
                 return true;
         return false;
     }


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Fixed compatibility with gcc-7.