### PR TITLE
Add element on SpaceSaving set if the last element has a lower value compared to the last one

### DIFF
--- a/dbms/src/Common/SpaceSaving.h
+++ b/dbms/src/Common/SpaceSaving.h
@@ -304,7 +304,6 @@ public:
     }
 
 protected:
-
     void push(Counter * counter)
     {
         counter->slot = counter_list.size();

--- a/dbms/src/Common/SpaceSaving.h
+++ b/dbms/src/Common/SpaceSaving.h
@@ -167,6 +167,12 @@ public:
         }
 
         auto min = counter_list.back();
+        if (increment > min->count)
+        {
+            destroyLastElement();
+            push(new Counter(arena.emplace(key), increment, error, hash));
+            return;
+        }
         const size_t alpha_mask = alpha_map.size() - 1;
         auto & alpha = alpha_map[hash & alpha_mask];
         if (alpha + increment < min->count)
@@ -298,6 +304,7 @@ public:
     }
 
 protected:
+
     void push(Counter * counter)
     {
         counter->slot = counter_list.size();
@@ -331,6 +338,17 @@ private:
         counter_map.clear();
         counter_list.clear();
         alpha_map.clear();
+    }
+
+    void destroyLastElement()
+    {
+        auto last_element = counter_list.back();
+        auto cell = counter_map.find(last_element->key, last_element->hash);
+        cell->setZero();
+        counter_map.reinsert(cell, last_element->hash);
+        counter_list.pop_back();
+        arena.free(last_element->key);
+        delete last_element;
     }
 
     HashMap<TKey, Counter *, Hash, Grower, Allocator> counter_map;

--- a/dbms/src/Common/SpaceSaving.h
+++ b/dbms/src/Common/SpaceSaving.h
@@ -167,6 +167,10 @@ public:
         }
 
         auto min = counter_list.back();
+        // The key doesn't exist and cannot fit in the current top K, but
+        // the new key has a bigger weight and is virtually more present
+        // compared to the element who is less present on the set. This part
+        // of the code is useful for the function topKWeighted
         if (increment > min->count)
         {
             destroyLastElement();

--- a/dbms/tests/queries/0_stateless/00840_top_k_weighted.reference
+++ b/dbms/tests/queries/0_stateless/00840_top_k_weighted.reference
@@ -1,2 +1,3 @@
 ['hello','world']	['hello','world']
 ['goodbye','hello']	['hello','world']
+[99,98,97,96,95]

--- a/dbms/tests/queries/0_stateless/00840_top_k_weighted.sql
+++ b/dbms/tests/queries/0_stateless/00840_top_k_weighted.sql
@@ -1,2 +1,3 @@
 SELECT topKWeighted(2)(x, weight), topK(2)(x) FROM (SELECT t.1 AS x, t.2 AS weight FROM (SELECT arrayJoin([('hello', 1), ('world', 1), ('goodbye', 1), ('abc', 1)]) AS t));
 SELECT topKWeighted(2)(x, weight), topK(2)(x) FROM (SELECT t.1 AS x, t.2 AS weight FROM (SELECT arrayJoin([('hello', 1), ('world', 1), ('goodbye', 2), ('abc', 1)]) AS t));
+SELECT topKWeighted(5)(n, weight) FROM (SELECT number as n, number as weight from system.numbers LIMIT 100);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

**Category (leave one):**
- Bug Fix

**Short description (up to few sentences):**

Proposal for change the SavingSpace set behavior to remove the last element if the new element have a bigger weight. #5833

**Detailed description (optional):**

The undocumented function `topKWeighted` had a problem when we weren't able to fit all keys to memory, who give quite bad approximation, for example

```
DROP TABLE IF EXISTS test.insert_number_query;

CREATE TABLE test.insert_number_query (
    record UInt32
) Engine = Log;

INSERT INTO test.insert_number_query SELECT * from system.numbers LIMIT 100000;
```

```
SELECT topKWeighted(5)(record, record)
FROM test.insert_number_query 

┌─topKWeighted(5)(record, record)─┐
│ [46,45,44,43,42]                │
└─────────────────────────────────┘
```

Instead of

```
SELECT topKWeighted(5)(record, record)
FROM test.insert_number_query 

┌─topKWeighted(5)(record, record)─┐
│ [99999,99998,99997,99996,99995] │
└─────────────────────────────────┘
```

It was due than the Set was originally created in mind to count the maximum number of occurrence for the function `topK`. Who need to treat one element, with one element, and with increment the internal count one by one.

However as the topKWeighted "emulate" with the weight that the element was already present N times, it doesn't make sense to keep last element if the new element is virtually more present.

expected result now
```
SELECT topKWeighted(5)(record, record)
FROM test.insert_number_query 

┌─topKWeighted(5)(record, record)─┐
│ [99999,99998,99997,99996,99995] │
└─────────────────────────────────┘
```

However, this PR still give an approximation, the result can be different, however it give a better approximation.