### PR TITLE
Keep on reading of new Kafka message after stalling

### DIFF
--- a/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
+++ b/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
@@ -49,6 +49,8 @@ void ReadBufferFromKafkaConsumer::commit()
             "Committed offset " << topic_part.get_offset() << " (topic: " << topic_part.get_topic()
                                 << ", partition: " << topic_part.get_partition() << ")");
     }
+
+    stalled = false;
 }
 
 void ReadBufferFromKafkaConsumer::subscribe(const Names & topics)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fix the `ReadBufferFromKafkaConsumer` so that it keeps reading new messages after `commit()` even if it was stalled before