### PR TITLE
Destroy the text log queue after the I/O blocks.

### DIFF
--- a/dbms/programs/server/TCPHandler.h
+++ b/dbms/programs/server/TCPHandler.h
@@ -36,6 +36,12 @@ struct QueryState
     QueryProcessingStage::Enum stage = QueryProcessingStage::Complete;
     Protocol::Compression compression = Protocol::Compression::Disable;
 
+    /// A queue with internal logs that will be passed to client. It must be
+    /// destroyed after input/output blocks, because they may contain other
+    /// threads that use this queue.
+    InternalTextLogsQueuePtr logs_queue;
+    BlockOutputStreamPtr logs_block_out;
+
     /// From where to read data for INSERT.
     std::shared_ptr<ReadBuffer> maybe_compressed_in;
     BlockInputStreamPtr block_in;
@@ -63,10 +69,6 @@ struct QueryState
 
     /// Timeouts setter for current query
     std::unique_ptr<TimeoutSetter> timeout_setter;
-
-    /// A queue with internal logs that will be passed to client
-    InternalTextLogsQueuePtr logs_queue;
-    BlockOutputStreamPtr logs_block_out;
 
     void reset()
     {


### PR DESCRIPTION
These blocks contain threads that use the queue, so they must be
destroyed first. This was reported by ThreadSanitizer.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Fix some ThreadSanitizer failures.
