### PR TITLE
Less locking in MetricsTransmitter

### DIFF
--- a/dbms/programs/server/MetricsTransmitter.cpp
+++ b/dbms/programs/server/MetricsTransmitter.cpp
@@ -1,7 +1,6 @@
 #include "MetricsTransmitter.h"
 
 #include <Interpreters/AsynchronousMetrics.h>
-#include <Interpreters/Context.h>
 
 #include <Common/CurrentMetrics.h>
 #include <Common/Exception.h>
@@ -15,6 +14,17 @@
 
 namespace DB
 {
+
+MetricsTransmitter::MetricsTransmitter(
+    const Poco::Util::AbstractConfiguration & config, const std::string & config_name, const AsynchronousMetrics & async_metrics)
+    : async_metrics(async_metrics), config_name(config_name)
+{
+    interval_seconds = config.getInt(config_name + ".interval", 60);
+    send_events = config.getBool(config_name + ".events", true);
+    send_metrics = config.getBool(config_name + ".metrics", true);
+    send_asynchronous_metrics = config.getBool(config_name + ".asynchronous_metrics", true);
+}
+
 
 MetricsTransmitter::~MetricsTransmitter()
 {
@@ -38,10 +48,7 @@ MetricsTransmitter::~MetricsTransmitter()
 
 void MetricsTransmitter::run()
 {
-    const auto & config = context.getConfigRef();
-    auto interval = config.getInt(config_name + ".interval", 60);
-
-    const std::string thread_name = "MetrTx" + std::to_string(interval);
+    const std::string thread_name = "MetrTx" + std::to_string(interval_seconds);
     setThreadName(thread_name.c_str());
 
     const auto get_next_time = [](size_t seconds)
@@ -60,7 +67,7 @@ void MetricsTransmitter::run()
 
     while (true)
     {
-        if (cond.wait_until(lock, get_next_time(interval), [this] { return quit; }))
+        if (cond.wait_until(lock, get_next_time(interval_seconds), [this] { return quit; }))
             break;
 
         transmit(prev_counters);
@@ -70,14 +77,12 @@ void MetricsTransmitter::run()
 
 void MetricsTransmitter::transmit(std::vector<ProfileEvents::Count> & prev_counters)
 {
-    const auto & config = context.getConfigRef();
     auto async_metrics_values = async_metrics.getValues();
 
     GraphiteWriter::KeyValueVector<ssize_t> key_vals{};
     key_vals.reserve(ProfileEvents::end() + CurrentMetrics::end() + async_metrics_values.size());
 
-
-    if (config.getBool(config_name + ".events", true))
+    if (send_events)
     {
         for (size_t i = 0, end = ProfileEvents::end(); i < end; ++i)
         {
@@ -90,7 +95,7 @@ void MetricsTransmitter::transmit(std::vector<ProfileEvents::Count> & prev_count
         }
     }
 
-    if (config.getBool(config_name + ".metrics", true))
+    if (send_metrics)
     {
         for (size_t i = 0, end = CurrentMetrics::end(); i < end; ++i)
         {
@@ -101,7 +106,7 @@ void MetricsTransmitter::transmit(std::vector<ProfileEvents::Count> & prev_count
         }
     }
 
-    if (config.getBool(config_name + ".asynchronous_metrics", true))
+    if (send_asynchronous_metrics)
     {
         for (const auto & name_value : async_metrics_values)
         {
@@ -112,4 +117,5 @@ void MetricsTransmitter::transmit(std::vector<ProfileEvents::Count> & prev_count
     if (key_vals.size())
         BaseDaemon::instance().writeToGraphite(key_vals, config_name);
 }
+
 }

--- a/dbms/programs/server/MetricsTransmitter.h
+++ b/dbms/programs/server/MetricsTransmitter.h
@@ -9,14 +9,21 @@
 #include <Common/ThreadPool.h>
 
 
+namespace Poco
+{
+    namespace Util
+    {
+        class AbstractConfiguration;
+    }
+}
+
 namespace DB
 {
 
 class AsynchronousMetrics;
-class Context;
 
 
-/**    Automatically sends
+/** Automatically sends
   * - difference of ProfileEvents;
   * - values of CurrentMetrics;
   * - values of AsynchronousMetrics;
@@ -25,33 +32,29 @@ class Context;
 class MetricsTransmitter
 {
 public:
-    MetricsTransmitter(Context & context_,
-                       const AsynchronousMetrics & async_metrics_,
-                       const std::string & config_name_)
-        : context(context_)
-        , async_metrics(async_metrics_)
-        , config_name(config_name_)
-    {
-    }
+    MetricsTransmitter(const Poco::Util::AbstractConfiguration & config, const std::string & config_name, const AsynchronousMetrics & async_metrics);
     ~MetricsTransmitter();
 
 private:
     void run();
     void transmit(std::vector<ProfileEvents::Count> & prev_counters);
 
-    Context & context;
-
     const AsynchronousMetrics & async_metrics;
-    const std::string config_name;
+
+    std::string config_name;
+    UInt32 interval_seconds;
+    bool send_events;
+    bool send_metrics;
+    bool send_asynchronous_metrics;
 
     bool quit = false;
     std::mutex mutex;
     std::condition_variable cond;
     ThreadFromGlobalPool thread{&MetricsTransmitter::run, this};
 
-    static constexpr auto profile_events_path_prefix = "ClickHouse.ProfileEvents.";
-    static constexpr auto current_metrics_path_prefix = "ClickHouse.Metrics.";
-    static constexpr auto asynchronous_metrics_path_prefix = "ClickHouse.AsynchronousMetrics.";
+    static inline constexpr auto profile_events_path_prefix = "ClickHouse.ProfileEvents.";
+    static inline constexpr auto current_metrics_path_prefix = "ClickHouse.Metrics.";
+    static inline constexpr auto asynchronous_metrics_path_prefix = "ClickHouse.AsynchronousMetrics.";
 };
 
 }

--- a/dbms/programs/server/Server.cpp
+++ b/dbms/programs/server/Server.cpp
@@ -850,7 +850,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
         for (const auto & graphite_key : DB::getMultipleKeysFromConfig(config(), "", "graphite"))
         {
             metrics_transmitters.emplace_back(std::make_unique<MetricsTransmitter>(
-                *global_context, async_metrics, graphite_key));
+                global_context->getConfigRef(), graphite_key, async_metrics));
         }
 
         SessionCleaner session_cleaner(*global_context);


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

Short description (up to few sentences):
More robust code for sending metrics to Graphite. It will work even during long multiple `RENAME TABLE` operation.