### PR TITLE
Close idle TCP connections

### DIFF
--- a/dbms/programs/server/TCPHandler.cpp
+++ b/dbms/programs/server/TCPHandler.cpp
@@ -120,7 +120,10 @@ void TCPHandler::runImpl()
 
     while (1)
     {
-        /// We are waiting for a packet from the client. Thus, every `POLL_INTERVAL` seconds check whether we need to shut down.
+        /// Set context of request.
+        query_context = connection_context;
+
+        /// We are waiting for a packet from the client. Thus, every `poll_interval` seconds check whether we need to shut down.
         {
             Stopwatch idle_time;
             while (!static_cast<ReadBufferFromPocoSocket &>(*in).poll(global_settings.poll_interval * 1000000) && !server.isCancelled())
@@ -133,9 +136,6 @@ void TCPHandler::runImpl()
         /// If we need to shut down, or client disconnects.
         if (server.isCancelled() || in->eof())
             break;
-
-        /// Set context of request.
-        query_context = connection_context;
 
         Stopwatch watch;
         state.reset();

--- a/dbms/programs/server/TCPHandler.cpp
+++ b/dbms/programs/server/TCPHandler.cpp
@@ -120,16 +120,22 @@ void TCPHandler::runImpl()
 
     while (1)
     {
-        /// Set context of request.
-        query_context = connection_context;
-
         /// We are waiting for a packet from the client. Thus, every `POLL_INTERVAL` seconds check whether we need to shut down.
-        while (!static_cast<ReadBufferFromPocoSocket &>(*in).poll(global_settings.poll_interval * 1000000) && !server.isCancelled())
-            ;
+        {
+            Stopwatch idle_time;
+            while (!static_cast<ReadBufferFromPocoSocket &>(*in).poll(global_settings.poll_interval * 1000000) && !server.isCancelled())
+            {
+                if (idle_time.elapsedSeconds() > global_settings.idle_connection_timeout)
+                    return;
+            }
+        }
 
         /// If we need to shut down, or client disconnects.
         if (server.isCancelled() || in->eof())
             break;
+
+        /// Set context of request.
+        query_context = connection_context;
 
         Stopwatch watch;
         state.reset();

--- a/dbms/programs/server/TCPHandler.cpp
+++ b/dbms/programs/server/TCPHandler.cpp
@@ -120,22 +120,25 @@ void TCPHandler::runImpl()
 
     while (1)
     {
-        /// Set context of request.
-        query_context = connection_context;
-
         /// We are waiting for a packet from the client. Thus, every `poll_interval` seconds check whether we need to shut down.
         {
             Stopwatch idle_time;
             while (!static_cast<ReadBufferFromPocoSocket &>(*in).poll(global_settings.poll_interval * 1000000) && !server.isCancelled())
             {
                 if (idle_time.elapsedSeconds() > global_settings.idle_connection_timeout)
+                {
+                    LOG_TRACE(log, "Closing idle connection");
                     return;
+                }
             }
         }
 
         /// If we need to shut down, or client disconnects.
         if (server.isCancelled() || in->eof())
             break;
+
+        /// Set context of request.
+        query_context = connection_context;
 
         Stopwatch watch;
         state.reset();

--- a/dbms/src/Core/Settings.h
+++ b/dbms/src/Core/Settings.h
@@ -62,6 +62,7 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingSeconds, tcp_keep_alive_timeout, 0, "") \
     M(SettingMilliseconds, queue_max_wait_ms, 5000, "The wait time in the request queue, if the number of concurrent requests exceeds the maximum.") \
     M(SettingUInt64, poll_interval, DBMS_DEFAULT_POLL_INTERVAL, "Block at the query wait loop on the server for the specified number of seconds.") \
+    M(SettingUInt64, idle_connection_timeout, 3600, "Close idle TCP connections after specified number of seconds.") \
     M(SettingUInt64, distributed_connections_pool_size, DBMS_DEFAULT_DISTRIBUTED_CONNECTIONS_POOL_SIZE, "Maximum number of connections with one remote server in the pool.") \
     M(SettingUInt64, connections_with_failover_max_tries, DBMS_CONNECTION_POOL_WITH_FAILOVER_DEFAULT_MAX_TRIES, "The maximum number of attempts to connect to replicas.") \
     M(SettingBool, extremes, false, "Calculate minimums and maximums of the result columns. They can be output in JSON-formats.") \


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

Short description (up to few sentences):
Close idle TCP connections (with one hour timeout by default). This is especially important for large clusters with multiple distributed tables on every server, because every server can possibly keep a connection pool to every other server, and after peak query concurrency, connections will stall. This fixes #5879