### PR TITLE
Add coverage image for CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,7 @@ if(WITH_COVERAGE AND COMPILER_CLANG)
 endif()
 if(WITH_COVERAGE AND COMPILER_GCC)
    set(COMPILER_FLAGS "${COMPILER_FLAGS} -fprofile-arcs -ftest-coverage")
+   set(COVERAGE_OPTION "-lgcov")
 endif()
 
 set (CMAKE_BUILD_COLOR_MAKEFILE          ON)
@@ -252,7 +253,7 @@ if (OS_LINUX AND NOT UNBUNDLED AND (GLIBC_COMPATIBILITY OR USE_INTERNAL_UNWIND_L
     if (USE_LIBCXX)
         set (DEFAULT_LIBS "${DEFAULT_LIBS} -Wl,-Bstatic -lc++ -lc++abi ${EXCEPTION_HANDLING_LIBRARY} ${BUILTINS_LIB_PATH} -Wl,-Bdynamic")
     else ()
-        set (DEFAULT_LIBS "${DEFAULT_LIBS} -Wl,-Bstatic -lstdc++ ${EXCEPTION_HANDLING_LIBRARY} -lgcc ${BUILTINS_LIB_PATH} -Wl,-Bdynamic")
+        set (DEFAULT_LIBS "${DEFAULT_LIBS} -Wl,-Bstatic -lstdc++ ${EXCEPTION_HANDLING_LIBRARY} ${COVERAGE_OPTION} -lgcc ${BUILTINS_LIB_PATH} -Wl,-Bdynamic")
     endif ()
 
     # Linking with GLIBC prevents portability of binaries to older systems.

--- a/docker/images.json
+++ b/docker/images.json
@@ -7,7 +7,9 @@
     "docker/test/performance": "yandex/clickhouse-performance-test",
     "docker/test/pvs": "yandex/clickhouse-pvs-test",
     "docker/test/stateful": "yandex/clickhouse-stateful-test",
+    "docker/test/stateful_with_coverage": "yandex/clickhouse-stateful-with-coverage-test",
     "docker/test/stateless": "yandex/clickhouse-stateless-test",
+    "docker/test/stateless_with_coverage": "yandex/clickhouse-stateless-with-coverage-test",
     "docker/test/unit": "yandex/clickhouse-unit-test",
     "docker/test/stress": "yandex/clickhouse-stress-test",
     "dbms/tests/integration/image": "yandex/clickhouse-integration-tests-runner"

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -103,7 +103,7 @@ def run_vagrant_box_with_env(image_path, output_dir, ch_root):
         logging.info("Copying binary back")
         vagrant.copy_from_image("~/ClickHouse/dbms/programs/clickhouse", output_dir)
 
-def parse_env_variables(build_type, compiler, sanitizer, package_type, cache, distcc_hosts, unbundled, split_binary, version, author, official, alien_pkgs):
+def parse_env_variables(build_type, compiler, sanitizer, package_type, cache, distcc_hosts, unbundled, split_binary, version, author, official, alien_pkgs, with_coverage):
     result = []
     cmake_flags = ['$CMAKE_FLAGS']
 
@@ -148,6 +148,9 @@ def parse_env_variables(build_type, compiler, sanitizer, package_type, cache, di
     if split_binary:
         cmake_flags.append('-DUSE_STATIC_LIBRARIES=0 -DSPLIT_SHARED_LIBRARIES=1 -DCLICKHOUSE_SPLIT_BINARY=1')
 
+    if with_coverage:
+        cmake_flags.append('-DWITH_COVERAGE=1')
+
     if version:
         result.append("VERSION_STRING='{}'".format(version))
 
@@ -180,6 +183,7 @@ if __name__ == "__main__":
     parser.add_argument("--author", default="clickhouse")
     parser.add_argument("--official", action="store_true")
     parser.add_argument("--alien-pkgs", nargs='+', default=[])
+    parser.add_argument("--with-coverage", action="store_true")
 
     args = parser.parse_args()
     if not os.path.isabs(args.output_dir):
@@ -202,7 +206,7 @@ if __name__ == "__main__":
     env_prepared = parse_env_variables(
         args.build_type, args.compiler, args.sanitizer, args.package_type,
         args.cache, args.distcc_hosts, args.unbundled, args.split_binary,
-        args.version, args.author, args.official, args.alien_pkgs)
+        args.version, args.author, args.official, args.alien_pkgs, args.with_coverage)
     if args.package_type != "freebsd":
         run_docker_image_with_env(image_name, args.output_dir, env_prepared, ch_root, args.ccache_dir)
     else:

--- a/docker/test/coverage/Dockerfile
+++ b/docker/test/coverage/Dockerfile
@@ -1,5 +1,5 @@
 # docker build -t yandex/clickhouse-coverage .
-FROM ubuntu:18.04
+FROM yandex/clickhouse-deb-builder
 
 RUN apt-get --allow-unauthenticated update -y \
     && env DEBIAN_FRONTEND=noninteractive \
@@ -29,7 +29,8 @@ ENV OUTPUT_DIR=/output
 ENV IGNORE='.*contrib.*'
 
 
-CMD dpkg -i /package_folder/clickhouse-common-static_*.deb; \
+CMD mkdir -p /build/obj-x86_64-linux-gnu && cd /build/obj-x86_64-linux-gnu && CC=clang-7 CXX=clang++-7 cmake .. && cd /; \
+    dpkg -i /package_folder/clickhouse-common-static_*.deb; \
     llvm-profdata-9 merge -sparse ${COVERAGE_DIR}/* -o clickhouse.profdata && \
     llvm-cov-9 export /usr/bin/clickhouse -instr-profile=clickhouse.profdata -j=16 -format=lcov -skip-functions -ignore-filename-regex $IGNORE > output.lcov && \
     genhtml output.lcov --ignore-errors source --output-directory ${OUTPUT_DIR}

--- a/docker/test/coverage/Dockerfile
+++ b/docker/test/coverage/Dockerfile
@@ -1,0 +1,33 @@
+# docker build -t yandex/clickhouse-coverage .
+FROM ubuntu:18.04
+
+RUN apt-get --allow-unauthenticated update -y \
+    && env DEBIAN_FRONTEND=noninteractive \
+    apt-get --allow-unauthenticated install --yes --no-install-recommends \
+    bash \
+    fakeroot \
+    cmake \
+    ccache \
+    curl \
+    software-properties-common
+
+
+RUN echo "deb [trusted=yes] http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" >> /etc/apt/sources.list
+
+RUN apt-get --allow-unauthenticated update -y \
+    && env DEBIAN_FRONTEND=noninteractive \
+        apt-get --allow-unauthenticated install --yes --no-install-recommends \
+            perl \
+            lcov \
+            llvm-9 \
+            tzdata
+
+
+ENV COVERAGE_DIR=/coverage_reports
+ENV SOURCE_DIR=/build
+ENV OUTPUT_DIR=/output
+
+CMD dpkg -i /package_folder/clickhouse-common-static_*.deb; \
+    llvm-profdata-9 merge -sparse ${COVERAGE_DIR}/* -o clickhouse.profdata && \
+    llvm-cov-9 export /usr/bin/clickhouse -instr-profile=clickhouse.profdata -arch=x86_64 -j=16 -format=lcov -skip-functions -ignore-filename-regex '.*contrib.*' > output.lcov && \
+    genhtml output.lcov  --ignore-errors source --output-directory ${OUTPUT_DIR}

--- a/docker/test/coverage/Dockerfile
+++ b/docker/test/coverage/Dockerfile
@@ -26,8 +26,10 @@ RUN apt-get --allow-unauthenticated update -y \
 ENV COVERAGE_DIR=/coverage_reports
 ENV SOURCE_DIR=/build
 ENV OUTPUT_DIR=/output
+ENV IGNORE='.*contrib.*'
+
 
 CMD dpkg -i /package_folder/clickhouse-common-static_*.deb; \
     llvm-profdata-9 merge -sparse ${COVERAGE_DIR}/* -o clickhouse.profdata && \
-    llvm-cov-9 export /usr/bin/clickhouse -instr-profile=clickhouse.profdata -arch=x86_64 -j=16 -format=lcov -skip-functions -ignore-filename-regex '.*contrib.*' > output.lcov && \
+    llvm-cov-9 export /usr/bin/clickhouse -instr-profile=clickhouse.profdata -arch=x86_64 -j=16 -format=lcov -skip-functions -ignore-filename-regex $IGNORE > output.lcov && \
     genhtml output.lcov  --ignore-errors source --output-directory ${OUTPUT_DIR}

--- a/docker/test/coverage/Dockerfile
+++ b/docker/test/coverage/Dockerfile
@@ -31,5 +31,5 @@ ENV IGNORE='.*contrib.*'
 
 CMD dpkg -i /package_folder/clickhouse-common-static_*.deb; \
     llvm-profdata-9 merge -sparse ${COVERAGE_DIR}/* -o clickhouse.profdata && \
-    llvm-cov-9 export /usr/bin/clickhouse -instr-profile=clickhouse.profdata -arch=x86_64 -j=16 -format=lcov -skip-functions -ignore-filename-regex $IGNORE > output.lcov && \
-    genhtml output.lcov  --ignore-errors source --output-directory ${OUTPUT_DIR}
+    llvm-cov-9 export /usr/bin/clickhouse -instr-profile=clickhouse.profdata -j=16 -format=lcov -skip-functions -ignore-filename-regex $IGNORE > output.lcov && \
+    genhtml output.lcov --ignore-errors source --output-directory ${OUTPUT_DIR}

--- a/docker/test/stateful/Dockerfile
+++ b/docker/test/stateful/Dockerfile
@@ -10,10 +10,8 @@ RUN apt-get update -y \
 COPY s3downloader /s3downloader
 
 ENV DATASETS="hits visits"
-ENV WITH_COVERAGE=0
 
-CMD chmod 777 /; \
-    dpkg -i package_folder/clickhouse-common-static_*.deb; \
+CMD dpkg -i package_folder/clickhouse-common-static_*.deb; \
     dpkg -i package_folder/clickhouse-common-static-dbg_*.deb; \
     dpkg -i package_folder/clickhouse-server_*.deb;  \
     dpkg -i package_folder/clickhouse-client_*.deb; \
@@ -46,5 +44,4 @@ CMD chmod 777 /; \
     && clickhouse-client --query "RENAME TABLE datasets.hits_v1 TO test.hits" \
     && clickhouse-client --query "RENAME TABLE datasets.visits_v1 TO test.visits" \
     && clickhouse-client --query "SHOW TABLES FROM test" \
-    && clickhouse-test --shard --zookeeper --no-stateless $SKIP_TESTS_OPTION 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee test_output/test_result.txt; \
-    if [ $WITH_COVERAGE -eq 1 ]; then cp /*.profraw /profraw ||:; fi
+    && clickhouse-test --shard --zookeeper --no-stateless $SKIP_TESTS_OPTION 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee test_output/test_result.txt;

--- a/docker/test/stateful/Dockerfile
+++ b/docker/test/stateful/Dockerfile
@@ -38,4 +38,4 @@ CMD chmod 777 /; \
     && clickhouse-client --query "RENAME TABLE datasets.visits_v1 TO test.visits" \
     && clickhouse-client --query "SHOW TABLES FROM test" \
     && clickhouse-test --shard --zookeeper --no-stateless $SKIP_TESTS_OPTION 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee test_output/test_result.txt; \
-    if [ $WITH_COVERAGE -eq 1 ]; then cp /*.profraw /profraw; fi
+    if [ $WITH_COVERAGE -eq 1 ]; then cp /*.profraw /profraw ||:; fi

--- a/docker/test/stateful/Dockerfile
+++ b/docker/test/stateful/Dockerfile
@@ -11,7 +11,8 @@ COPY s3downloader /s3downloader
 
 ENV DATASETS="hits visits"
 
-CMD dpkg -i package_folder/clickhouse-common-static_*.deb; \
+CMD chmod 777 /; \
+    dpkg -i package_folder/clickhouse-common-static_*.deb; \
     dpkg -i package_folder/clickhouse-common-static-dbg_*.deb; \
     dpkg -i package_folder/clickhouse-server_*.deb;  \
     dpkg -i package_folder/clickhouse-client_*.deb; \
@@ -36,4 +37,5 @@ CMD dpkg -i package_folder/clickhouse-common-static_*.deb; \
     && clickhouse-client --query "RENAME TABLE datasets.hits_v1 TO test.hits" \
     && clickhouse-client --query "RENAME TABLE datasets.visits_v1 TO test.visits" \
     && clickhouse-client --query "SHOW TABLES FROM test" \
-    && clickhouse-test --shard --zookeeper --no-stateless $SKIP_TESTS_OPTION 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee test_output/test_result.txt
+    && clickhouse-test --shard --zookeeper --no-stateless $SKIP_TESTS_OPTION 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee test_output/test_result.txt; \
+    if [ $WITH_COVERAGE -eq 1 ]; then cp /*.profraw /profraw; fi

--- a/docker/test/stateful/Dockerfile
+++ b/docker/test/stateful/Dockerfile
@@ -44,4 +44,4 @@ CMD dpkg -i package_folder/clickhouse-common-static_*.deb; \
     && clickhouse-client --query "RENAME TABLE datasets.hits_v1 TO test.hits" \
     && clickhouse-client --query "RENAME TABLE datasets.visits_v1 TO test.visits" \
     && clickhouse-client --query "SHOW TABLES FROM test" \
-    && clickhouse-test --shard --zookeeper --no-stateless $SKIP_TESTS_OPTION 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee test_output/test_result.txt;
+    && clickhouse-test --shard --zookeeper --no-stateless $SKIP_TESTS_OPTION 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee test_output/test_result.txt

--- a/docker/test/stateful/Dockerfile
+++ b/docker/test/stateful/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update -y \
 COPY s3downloader /s3downloader
 
 ENV DATASETS="hits visits"
+ENV WITH_COVERAGE=0
 
 CMD chmod 777 /; \
     dpkg -i package_folder/clickhouse-common-static_*.deb; \
@@ -17,6 +18,14 @@ CMD chmod 777 /; \
     dpkg -i package_folder/clickhouse-server_*.deb;  \
     dpkg -i package_folder/clickhouse-client_*.deb; \
     dpkg -i package_folder/clickhouse-test_*.deb; \
+    ln -s /usr/share/clickhouse-test/config/zookeeper.xml /etc/clickhouse-server/config.d/; \
+    ln -s /usr/share/clickhouse-test/config/listen.xml /etc/clickhouse-server/config.d/; \
+    ln -s /usr/share/clickhouse-test/config/part_log.xml /etc/clickhouse-server/config.d/; \
+    ln -s /usr/share/clickhouse-test/config/log_queries.xml /etc/clickhouse-server/users.d/; \
+    ln -s /usr/share/clickhouse-test/config/readonly.xml /etc/clickhouse-server/users.d/; \
+    ln -s /usr/share/clickhouse-test/config/ints_dictionary.xml /etc/clickhouse-server/; \
+    ln -s /usr/share/clickhouse-test/config/strings_dictionary.xml /etc/clickhouse-server/; \
+    ln -s /usr/share/clickhouse-test/config/decimals_dictionary.xml /etc/clickhouse-server/; \
     ln -s /usr/lib/llvm-8/bin/llvm-symbolizer /usr/bin/llvm-symbolizer; \
     echo "TSAN_OPTIONS='halt_on_error=1 history_size=7'" >> /etc/environment; \
     echo "TSAN_SYMBOLIZER_PATH=/usr/lib/llvm-8/bin/llvm-symbolizer" >> /etc/environment; \

--- a/docker/test/stateful_with_coverage/Dockerfile
+++ b/docker/test/stateful_with_coverage/Dockerfile
@@ -1,11 +1,14 @@
 # docker build -t yandex/clickhouse-stateful-test .
 FROM yandex/clickhouse-stateless-test
 
+RUN echo "deb [trusted=yes] http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" >> /etc/apt/sources.list
+
 RUN apt-get update -y \
     && env DEBIAN_FRONTEND=noninteractive \
         apt-get install --yes --no-install-recommends \
         python-requests \
-        llvm-8
+        llvm-8 \
+        llvm-9
 
 COPY s3downloader /s3downloader
 COPY run.sh /run.sh

--- a/docker/test/stateful_with_coverage/Dockerfile
+++ b/docker/test/stateful_with_coverage/Dockerfile
@@ -1,0 +1,16 @@
+# docker build -t yandex/clickhouse-stateful-test .
+FROM yandex/clickhouse-stateless-test
+
+RUN apt-get update -y \
+    && env DEBIAN_FRONTEND=noninteractive \
+        apt-get install --yes --no-install-recommends \
+        python-requests \
+        llvm-8
+
+COPY s3downloader /s3downloader
+COPY run.sh /run.sh
+
+ENV DATASETS="hits visits"
+
+CMD ["/bin/bash", "/run.sh"]
+

--- a/docker/test/stateful_with_coverage/run.sh
+++ b/docker/test/stateful_with_coverage/run.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -x
-
 kill_clickhouse () {
     while kill -0 `pgrep -u clickhouse`;
     do
@@ -13,6 +11,23 @@ kill_clickhouse () {
 
 start_clickhouse () {
     LLVM_PROFILE_FILE='server_%h_%p_%m.profraw' sudo -Eu clickhouse /usr/bin/clickhouse-server --config /etc/clickhouse-server/config.xml &
+}
+
+wait_llvm_profdata () {
+    while kill -0 `pgrep llvm-profdata-9`;
+    do
+        echo "Waiting for profdata " `pgrep llvm-profdata-9` "still alive"
+        sleep 3
+    done
+}
+
+merge_client_files_in_background () {
+    client_files=`ls /client_*profraw 2>/dev/null`
+    if [ ! -z "$client_files" ]
+    then
+        llvm-profdata-9 merge -sparse $client_files -o merged_client_`date +%s`.profraw
+        rm $client_files
+    fi
 }
 
 chmod 777 /
@@ -37,6 +52,7 @@ ln -s /usr/share/clickhouse-test/config/zookeeper.xml /etc/clickhouse-server/con
     ln -s /usr/share/clickhouse-test/config/decimals_dictionary.xml /etc/clickhouse-server/; \
     ln -s /usr/lib/llvm-8/bin/llvm-symbolizer /usr/bin/llvm-symbolizer
 
+
 service zookeeper start
 
 sleep 5
@@ -49,22 +65,34 @@ sleep 5
 
 chmod 777 -R /var/lib/clickhouse
 
-LLVM_PROFILE_FILE='client.profraw' clickhouse-client --query "SHOW DATABASES"
-LLVM_PROFILE_FILE='client.profraw' clickhouse-client --query "CREATE DATABASE datasets"
-LLVM_PROFILE_FILE='client.profraw' clickhouse-client --query "CREATE DATABASE test"
+while /bin/true; do
+    merge_client_files_in_background
+    sleep 2
+done &
+
+LLVM_PROFILE_FILE='client_%h_%p_%m.profraw' clickhouse-client --query "SHOW DATABASES"
+LLVM_PROFILE_FILE='client_%h_%p_%m.profraw' clickhouse-client --query "CREATE DATABASE datasets"
+LLVM_PROFILE_FILE='client_%h_%p_%m.profraw' clickhouse-client --query "CREATE DATABASE test"
 
 kill_clickhouse
 start_clickhouse
 
 sleep 10
 
-LLVM_PROFILE_FILE='client.profraw' clickhouse-client --query "SHOW TABLES FROM datasets"
-LLVM_PROFILE_FILE='client.profraw' clickhouse-client --query "SHOW TABLES FROM test"
-LLVM_PROFILE_FILE='client.profraw' clickhouse-client --query "RENAME TABLE datasets.hits_v1 TO test.hits"
-LLVM_PROFILE_FILE='client.profraw' clickhouse-client --query "RENAME TABLE datasets.visits_v1 TO test.visits"
-LLVM_PROFILE_FILE='client.profraw' clickhouse-client --query "SHOW TABLES FROM test"
-LLVM_PROFILE_FILE='client.profraw' clickhouse-test --shard --zookeeper --no-stateless $SKIP_TESTS_OPTION 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee test_output/test_result.txt
+LLVM_PROFILE_FILE='client_%h_%p_%m.profraw' clickhouse-client --query "SHOW TABLES FROM datasets"
+LLVM_PROFILE_FILE='client_%h_%p_%m.profraw' clickhouse-client --query "SHOW TABLES FROM test"
+LLVM_PROFILE_FILE='client_%h_%p_%m.profraw' clickhouse-client --query "RENAME TABLE datasets.hits_v1 TO test.hits"
+LLVM_PROFILE_FILE='client_%h_%p_%m.profraw' clickhouse-client --query "RENAME TABLE datasets.visits_v1 TO test.visits"
+LLVM_PROFILE_FILE='client_%h_%p_%m.profraw' clickhouse-client --query "SHOW TABLES FROM test"
+LLVM_PROFILE_FILE='client_%h_%p_%m.profraw' clickhouse-test --shard --zookeeper --no-stateless $SKIP_TESTS_OPTION 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee test_output/test_result.txt
 
 kill_clickhouse
+
+wait_llvm_profdata
+
+sleep 3
+
+wait_llvm_profdata # 100% merged all parts
+
 
 cp /*.profraw /profraw ||:

--- a/docker/test/stateful_with_coverage/run.sh
+++ b/docker/test/stateful_with_coverage/run.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -x
+
+kill_clickhouse () {
+    while kill -0 `pgrep -u clickhouse`;
+    do
+        kill `pgrep -u clickhouse` 2>/dev/null
+        echo "Process" `pgrep -u clickhouse` "still alive"
+        sleep 10
+    done
+}
+
+start_clickhouse () {
+    LLVM_PROFILE_FILE='server_%h_%p_%m.profraw' sudo -Eu clickhouse /usr/bin/clickhouse-server --config /etc/clickhouse-server/config.xml &
+}
+
+chmod 777 /
+
+dpkg -i package_folder/clickhouse-common-static_*.deb; \
+    dpkg -i package_folder/clickhouse-common-static-dbg_*.deb; \
+    dpkg -i package_folder/clickhouse-server_*.deb;  \
+    dpkg -i package_folder/clickhouse-client_*.deb; \
+    dpkg -i package_folder/clickhouse-test_*.deb
+
+ln -s /usr/share/clickhouse-test/config/zookeeper.xml /etc/clickhouse-server/config.d/; \
+    ln -s /usr/share/clickhouse-test/config/listen.xml /etc/clickhouse-server/config.d/; \
+    ln -s /usr/share/clickhouse-test/config/part_log.xml /etc/clickhouse-server/config.d/; \
+    ln -s /usr/share/clickhouse-test/config/log_queries.xml /etc/clickhouse-server/users.d/; \
+    ln -s /usr/share/clickhouse-test/config/readonly.xml /etc/clickhouse-server/users.d/; \
+    ln -s /usr/share/clickhouse-test/config/ints_dictionary.xml /etc/clickhouse-server/; \
+    ln -s /usr/share/clickhouse-test/config/strings_dictionary.xml /etc/clickhouse-server/; \
+    ln -s /usr/share/clickhouse-test/config/decimals_dictionary.xml /etc/clickhouse-server/; \
+    ln -s /usr/lib/llvm-8/bin/llvm-symbolizer /usr/bin/llvm-symbolizer
+
+service zookeeper start
+
+sleep 5
+
+start_clickhouse
+
+sleep 5
+
+/s3downloader --dataset-names $DATASETS
+chmod 777 -R /var/lib/clickhouse
+
+LLVM_PROFILE_FILE='client.profraw' clickhouse-client --query "SHOW DATABASES"
+LLVM_PROFILE_FILE='client.profraw' clickhouse-client --query "CREATE DATABASE datasets"
+LLVM_PROFILE_FILE='client.profraw' clickhouse-client --query "CREATE DATABASE test"
+
+kill_clickhouse
+start_clickhouse
+
+sleep 10
+
+LLVM_PROFILE_FILE='client.profraw' clickhouse-client --query "SHOW TABLES FROM datasets"
+LLVM_PROFILE_FILE='client.profraw' clickhouse-client --query "SHOW TABLES FROM test"
+LLVM_PROFILE_FILE='client.profraw' clickhouse-client --query "RENAME TABLE datasets.hits_v1 TO test.hits"
+LLVM_PROFILE_FILE='client.profraw' clickhouse-client --query "RENAME TABLE datasets.visits_v1 TO test.visits"
+LLVM_PROFILE_FILE='client.profraw' clickhouse-client --query "SHOW TABLES FROM test"
+LLVM_PROFILE_FILE='client.profraw' clickhouse-test --shard --zookeeper --no-stateless 00146 $SKIP_TESTS_OPTION 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee test_output/test_result.txt
+
+kill_clickhouse
+
+cp /*.profraw /profraw ||:

--- a/docker/test/stateful_with_coverage/run.sh
+++ b/docker/test/stateful_with_coverage/run.sh
@@ -58,7 +58,7 @@ LLVM_PROFILE_FILE='client.profraw' clickhouse-client --query "SHOW TABLES FROM t
 LLVM_PROFILE_FILE='client.profraw' clickhouse-client --query "RENAME TABLE datasets.hits_v1 TO test.hits"
 LLVM_PROFILE_FILE='client.profraw' clickhouse-client --query "RENAME TABLE datasets.visits_v1 TO test.visits"
 LLVM_PROFILE_FILE='client.profraw' clickhouse-client --query "SHOW TABLES FROM test"
-LLVM_PROFILE_FILE='client.profraw' clickhouse-test --shard --zookeeper --no-stateless 00146 $SKIP_TESTS_OPTION 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee test_output/test_result.txt
+LLVM_PROFILE_FILE='client.profraw' clickhouse-test --shard --zookeeper --no-stateless $SKIP_TESTS_OPTION 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee test_output/test_result.txt
 
 kill_clickhouse
 

--- a/docker/test/stateful_with_coverage/run.sh
+++ b/docker/test/stateful_with_coverage/run.sh
@@ -23,6 +23,10 @@ dpkg -i package_folder/clickhouse-common-static_*.deb; \
     dpkg -i package_folder/clickhouse-client_*.deb; \
     dpkg -i package_folder/clickhouse-test_*.deb
 
+mkdir -p /var/lib/clickhouse
+mkdir -p /var/log/clickhouse-server
+chmod 777 -R /var/log/clickhouse-server/
+
 ln -s /usr/share/clickhouse-test/config/zookeeper.xml /etc/clickhouse-server/config.d/; \
     ln -s /usr/share/clickhouse-test/config/listen.xml /etc/clickhouse-server/config.d/; \
     ln -s /usr/share/clickhouse-test/config/part_log.xml /etc/clickhouse-server/config.d/; \
@@ -42,6 +46,7 @@ start_clickhouse
 sleep 5
 
 /s3downloader --dataset-names $DATASETS
+
 chmod 777 -R /var/lib/clickhouse
 
 LLVM_PROFILE_FILE='client.profraw' clickhouse-client --query "SHOW DATABASES"

--- a/docker/test/stateful_with_coverage/s3downloader
+++ b/docker/test/stateful_with_coverage/s3downloader
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+import sys
+import tarfile
+import logging
+import argparse
+import requests
+import tempfile
+
+
+DEFAULT_URL = 'https://clickhouse-datasets.s3.yandex.net'
+
+AVAILABLE_DATASETS = {
+    'hits': 'hits_v1.tar',
+    'visits': 'visits_v1.tar',
+}
+
+def _get_temp_file_name():
+    return os.path.join(tempfile._get_default_tempdir(), next(tempfile._get_candidate_names()))
+
+def build_url(base_url, dataset):
+    return os.path.join(base_url, dataset, 'partitions', AVAILABLE_DATASETS[dataset])
+
+def dowload_with_progress(url, path):
+    logging.info("Downloading from %s to temp path %s", url, path)
+    with open(path, 'w') as f:
+        response = requests.get(url, stream=True)
+        response.raise_for_status()
+        total_length = response.headers.get('content-length')
+        if total_length is None or int(total_length) == 0:
+            logging.info("No content-length, will download file without progress")
+            f.write(response.content)
+        else:
+            dl = 0
+            total_length = int(total_length)
+            logging.info("Content length is %ld bytes", total_length)
+            for data in response.iter_content(chunk_size=4096):
+                dl += len(data)
+                f.write(data)
+                if sys.stdout.isatty():
+                    done = int(50 * dl / total_length)
+                    percent = int(100 * float(dl) / total_length)
+                    sys.stdout.write("\r[{}{}] {}%".format('=' * done, ' ' * (50-done), percent))
+                    sys.stdout.flush()
+    sys.stdout.write("\n")
+    logging.info("Downloading finished")
+
+def unpack_to_clickhouse_directory(tar_path, clickhouse_path):
+    logging.info("Will unpack data from temp path %s to clickhouse db %s", tar_path, clickhouse_path)
+    with tarfile.open(tar_path, 'r') as comp_file:
+        comp_file.extractall(path=clickhouse_path)
+    logging.info("Unpack finished")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+
+    parser = argparse.ArgumentParser(
+        description="Simple tool for dowloading datasets for clickhouse from S3")
+
+    parser.add_argument('--dataset-names', required=True, nargs='+', choices=AVAILABLE_DATASETS.keys())
+    parser.add_argument('--url-prefix', default=DEFAULT_URL)
+    parser.add_argument('--clickhouse-data-path', default='/var/lib/clickhouse/')
+
+    args = parser.parse_args()
+    datasets = args.dataset_names
+    logging.info("Will fetch following datasets: %s", ', '.join(datasets))
+    for dataset in datasets:
+        logging.info("Processing %s", dataset)
+        temp_archive_path = _get_temp_file_name()
+        try:
+            download_url_for_dataset = build_url(args.url_prefix, dataset)
+            dowload_with_progress(download_url_for_dataset, temp_archive_path)
+            unpack_to_clickhouse_directory(temp_archive_path, args.clickhouse_data_path)
+        except Exception as ex:
+            logging.info("Some exception occured %s", str(ex))
+            raise
+        finally:
+            logging.info("Will remove dowloaded file %s from filesystem if it exists", temp_archive_path)
+            if os.path.exists(temp_archive_path):
+                os.remove(temp_archive_path)
+        logging.info("Processing of %s finished", dataset)
+    logging.info("Fetch finished, enjoy your tables!")
+
+

--- a/docker/test/stateless/Dockerfile
+++ b/docker/test/stateless/Dockerfile
@@ -31,7 +31,8 @@ ENV TZ=Europe/Moscow
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 
-CMD dpkg -i package_folder/clickhouse-common-static_*.deb; \
+CMD chmod 777 /; \
+    dpkg -i package_folder/clickhouse-common-static_*.deb; \
     dpkg -i package_folder/clickhouse-common-static-dbg_*.deb; \
     dpkg -i package_folder/clickhouse-server_*.deb;  \
     dpkg -i package_folder/clickhouse-client_*.deb; \
@@ -52,4 +53,6 @@ CMD dpkg -i package_folder/clickhouse-common-static_*.deb; \
     echo "TSAN_SYMBOLIZER_PATH=/usr/lib/llvm-8/bin/llvm-symbolizer" >> /etc/environment; \
     echo "LLVM_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer" >> /etc/environment; \
     service zookeeper start; sleep 5; \
-    service clickhouse-server start && sleep 5 && clickhouse-test --shard --zookeeper $ADDITIONAL_OPTIONS $SKIP_TESTS_OPTION 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee test_output/test_result.txt
+    service clickhouse-server start && sleep 5 && \
+    clickhouse-test --shard --zookeeper $ADDITIONAL_OPTIONS $SKIP_TESTS_OPTION 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee test_output/test_result.txt; \
+    if [ $WITH_COVERAGE -eq 1 ]; then cp /*.profraw /profraw; fi

--- a/docker/test/stateless/Dockerfile
+++ b/docker/test/stateless/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update -y \
 
 ENV TZ=Europe/Moscow
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+ENV WITH_COVERAGE=0
 
 
 CMD chmod 777 /; \

--- a/docker/test/stateless/Dockerfile
+++ b/docker/test/stateless/Dockerfile
@@ -55,4 +55,4 @@ CMD chmod 777 /; \
     service zookeeper start; sleep 5; \
     service clickhouse-server start && sleep 5 && \
     clickhouse-test --shard --zookeeper $ADDITIONAL_OPTIONS $SKIP_TESTS_OPTION 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee test_output/test_result.txt; \
-    if [ $WITH_COVERAGE -eq 1 ]; then cp /*.profraw /profraw; fi
+    if [ $WITH_COVERAGE -eq 1 ]; then cp /*.profraw /profraw ||:; fi

--- a/docker/test/stateless_with_coverage/Dockerfile
+++ b/docker/test/stateless_with_coverage/Dockerfile
@@ -28,28 +28,6 @@ RUN apt-get update -y \
 
 ENV TZ=Europe/Moscow
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-ENV LLVM_PROFILE_FILE='code_%h_%p_%m.profraw'
+COPY run.sh /run.sh
 
-
-CMD chmod 777 /; \
-    echo "LLVM_PROFILE_FILE='code_%h_%p_%m.profraw'" >> /etc/environment; \
-    dpkg -i package_folder/clickhouse-common-static_*.deb; \
-    dpkg -i package_folder/clickhouse-common-static-dbg_*.deb; \
-    dpkg -i package_folder/clickhouse-server_*.deb;  \
-    dpkg -i package_folder/clickhouse-client_*.deb; \
-    dpkg -i package_folder/clickhouse-test_*.deb; \
-    ln -s /usr/share/clickhouse-test/config/zookeeper.xml /etc/clickhouse-server/config.d/; \
-    ln -s /usr/share/clickhouse-test/config/listen.xml /etc/clickhouse-server/config.d/; \
-    ln -s /usr/share/clickhouse-test/config/part_log.xml /etc/clickhouse-server/config.d/; \
-    ln -s /usr/share/clickhouse-test/config/log_queries.xml /etc/clickhouse-server/users.d/; \
-    ln -s /usr/share/clickhouse-test/config/readonly.xml /etc/clickhouse-server/users.d/; \
-    ln -s /usr/share/clickhouse-test/config/ints_dictionary.xml /etc/clickhouse-server/; \
-    ln -s /usr/share/clickhouse-test/config/strings_dictionary.xml /etc/clickhouse-server/; \
-    ln -s /usr/share/clickhouse-test/config/decimals_dictionary.xml /etc/clickhouse-server/; \
-    ln -s /usr/lib/llvm-8/bin/llvm-symbolizer /usr/bin/llvm-symbolizer; \
-    service zookeeper start; sleep 5; \
-    LLVM_PROFILE_FILE='code_%h_%p_%m.profraw' sudo -Eu clickhouse /usr/bin/clickhouse-server --config /etc/clickhouse-server/config.xml 1>/dev/null 2>/dev/null & \
-    sleep 10; \
-    LLVM_PROFILE_FILE='client.profraw' clickhouse-test --shard --zookeeper $ADDITIONAL_OPTIONS $SKIP_TESTS_OPTION 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee test_output/test_result.txt; \
-    while kill -0 `pgrep -u clickhouse`; do kill `pgrep -u clickhouse` 2>/dev/null; echo "Process" `pgrep -u clickhouse` "still alive"; sleep 10; done; \
-    cp /*.profraw /profraw ||:
+CMD ["/bin/bash", "/run.sh"]

--- a/docker/test/stateless_with_coverage/Dockerfile
+++ b/docker/test/stateless_with_coverage/Dockerfile
@@ -1,4 +1,4 @@
-# docker build -t yandex/clickhouse-stateless-test .
+# docker build -t yandex/clickhouse-stateless-with-coverage-test .
 FROM yandex/clickhouse-deb-builder
 
 RUN apt-get update -y \
@@ -23,15 +23,17 @@ RUN apt-get update -y \
             moreutils \
             brotli \
             gdb \
-            lsof \
-            llvm-8
+            lsof
 
 
 ENV TZ=Europe/Moscow
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+ENV LLVM_PROFILE_FILE='code_%h_%p_%m.profraw'
 
 
-CMD dpkg -i package_folder/clickhouse-common-static_*.deb; \
+CMD chmod 777 /; \
+    echo "LLVM_PROFILE_FILE='code_%h_%p_%m.profraw'" >> /etc/environment; \
+    dpkg -i package_folder/clickhouse-common-static_*.deb; \
     dpkg -i package_folder/clickhouse-common-static-dbg_*.deb; \
     dpkg -i package_folder/clickhouse-server_*.deb;  \
     dpkg -i package_folder/clickhouse-client_*.deb; \
@@ -45,11 +47,9 @@ CMD dpkg -i package_folder/clickhouse-common-static_*.deb; \
     ln -s /usr/share/clickhouse-test/config/strings_dictionary.xml /etc/clickhouse-server/; \
     ln -s /usr/share/clickhouse-test/config/decimals_dictionary.xml /etc/clickhouse-server/; \
     ln -s /usr/lib/llvm-8/bin/llvm-symbolizer /usr/bin/llvm-symbolizer; \
-    echo "TSAN_OPTIONS='halt_on_error=1 history_size=7'" >> /etc/environment; \
-    echo "UBSAN_OPTIONS='print_stacktrace=1'" >> /etc/environment; \
-    echo "ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer" >> /etc/environment; \
-    echo "UBSAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer" >> /etc/environment; \
-    echo "TSAN_SYMBOLIZER_PATH=/usr/lib/llvm-8/bin/llvm-symbolizer" >> /etc/environment; \
-    echo "LLVM_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer" >> /etc/environment; \
     service zookeeper start; sleep 5; \
-    service clickhouse-server start && sleep 5 && clickhouse-test --shard --zookeeper $ADDITIONAL_OPTIONS $SKIP_TESTS_OPTION 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee test_output/test_result.txt
+    LLVM_PROFILE_FILE='code_%h_%p_%m.profraw' sudo -Eu clickhouse /usr/bin/clickhouse-server --config /etc/clickhouse-server/config.xml 1>/dev/null 2>/dev/null & \
+    sleep 10; \
+    LLVM_PROFILE_FILE='client.profraw' clickhouse-test --shard --zookeeper $ADDITIONAL_OPTIONS $SKIP_TESTS_OPTION 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee test_output/test_result.txt; \
+    while kill -0 `pgrep -u clickhouse`; do kill `pgrep -u clickhouse` 2>/dev/null; echo "Process" `pgrep -u clickhouse` "still alive"; sleep 10; done; \
+    cp /*.profraw /profraw ||:

--- a/docker/test/stateless_with_coverage/Dockerfile
+++ b/docker/test/stateless_with_coverage/Dockerfile
@@ -1,6 +1,8 @@
 # docker build -t yandex/clickhouse-stateless-with-coverage-test .
 FROM yandex/clickhouse-deb-builder
 
+RUN echo "deb [trusted=yes] http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" >> /etc/apt/sources.list
+
 RUN apt-get update -y \
     && env DEBIAN_FRONTEND=noninteractive \
         apt-get install --yes --no-install-recommends \
@@ -23,7 +25,8 @@ RUN apt-get update -y \
             moreutils \
             brotli \
             gdb \
-            lsof
+            lsof \
+            llvm-9
 
 
 ENV TZ=Europe/Moscow

--- a/docker/test/stateless_with_coverage/run.sh
+++ b/docker/test/stateless_with_coverage/run.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -x
+
+kill_clickhouse () {
+    while kill -0 `pgrep -u clickhouse`;
+    do
+        kill `pgrep -u clickhouse` 2>/dev/null
+        echo "Process" `pgrep -u clickhouse` "still alive"
+        sleep 10
+    done
+}
+
+start_clickhouse () {
+    LLVM_PROFILE_FILE='server_%h_%p_%m.profraw' sudo -Eu clickhouse /usr/bin/clickhouse-server --config /etc/clickhouse-server/config.xml &
+}
+
+chmod 777 /
+dpkg -i package_folder/clickhouse-common-static_*.deb; \
+    dpkg -i package_folder/clickhouse-common-static-dbg_*.deb; \
+    dpkg -i package_folder/clickhouse-server_*.deb;  \
+    dpkg -i package_folder/clickhouse-client_*.deb; \
+    dpkg -i package_folder/clickhouse-test_*.deb
+
+ln -s /usr/share/clickhouse-test/config/zookeeper.xml /etc/clickhouse-server/config.d/; \
+    ln -s /usr/share/clickhouse-test/config/listen.xml /etc/clickhouse-server/config.d/; \
+    ln -s /usr/share/clickhouse-test/config/part_log.xml /etc/clickhouse-server/config.d/; \
+    ln -s /usr/share/clickhouse-test/config/log_queries.xml /etc/clickhouse-server/users.d/; \
+    ln -s /usr/share/clickhouse-test/config/readonly.xml /etc/clickhouse-server/users.d/; \
+    ln -s /usr/share/clickhouse-test/config/ints_dictionary.xml /etc/clickhouse-server/; \
+    ln -s /usr/share/clickhouse-test/config/strings_dictionary.xml /etc/clickhouse-server/; \
+    ln -s /usr/share/clickhouse-test/config/decimals_dictionary.xml /etc/clickhouse-server/; \
+    ln -s /usr/lib/llvm-8/bin/llvm-symbolizer /usr/bin/llvm-symbolizer
+
+service zookeeper start
+sleep 5
+
+start_clickhouse
+
+sleep 10
+
+LLVM_PROFILE_FILE='client.profraw' clickhouse-test --shard --zookeeper $ADDITIONAL_OPTIONS $SKIP_TESTS_OPTION 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee test_output/test_result.txt
+
+kill_clickhouse
+
+cp /*.profraw /profraw ||:

--- a/docker/test/stateless_with_coverage/run.sh
+++ b/docker/test/stateless_with_coverage/run.sh
@@ -16,11 +16,18 @@ start_clickhouse () {
 }
 
 chmod 777 /
+
 dpkg -i package_folder/clickhouse-common-static_*.deb; \
     dpkg -i package_folder/clickhouse-common-static-dbg_*.deb; \
     dpkg -i package_folder/clickhouse-server_*.deb;  \
     dpkg -i package_folder/clickhouse-client_*.deb; \
     dpkg -i package_folder/clickhouse-test_*.deb
+
+
+mkdir -p /var/lib/clickhouse
+mkdir -p /var/log/clickhouse-server
+chmod 777 -R /var/lib/clickhouse
+chmod 777 -R /var/log/clickhouse-server/
 
 ln -s /usr/share/clickhouse-test/config/zookeeper.xml /etc/clickhouse-server/config.d/; \
     ln -s /usr/share/clickhouse-test/config/listen.xml /etc/clickhouse-server/config.d/; \

--- a/docker/test/stateless_with_coverage/run.sh
+++ b/docker/test/stateless_with_coverage/run.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -x
-
 kill_clickhouse () {
     while kill -0 `pgrep -u clickhouse`;
     do
@@ -11,8 +9,25 @@ kill_clickhouse () {
     done
 }
 
+wait_llvm_profdata () {
+    while kill -0 `pgrep llvm-profdata-9`;
+    do
+        echo "Waiting for profdata " `pgrep llvm-profdata-9` "still alive"
+        sleep 3
+    done
+}
+
 start_clickhouse () {
     LLVM_PROFILE_FILE='server_%h_%p_%m.profraw' sudo -Eu clickhouse /usr/bin/clickhouse-server --config /etc/clickhouse-server/config.xml &
+}
+
+merge_client_files_in_background () {
+    client_files=`ls /client_*profraw 2>/dev/null`
+    if [ ! -z "$client_files" ]
+    then
+        llvm-profdata-9 merge -sparse $client_files -o merged_client_`date +%s`.profraw
+        rm $client_files
+    fi
 }
 
 chmod 777 /
@@ -46,8 +61,19 @@ start_clickhouse
 
 sleep 10
 
-LLVM_PROFILE_FILE='client.profraw' clickhouse-test --shard --zookeeper $ADDITIONAL_OPTIONS $SKIP_TESTS_OPTION 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee test_output/test_result.txt
+while /bin/true; do
+    merge_client_files_in_background
+    sleep 2
+done &
+
+LLVM_PROFILE_FILE='client_%h_%p_%m.profraw' clickhouse-test --shard --zookeeper $ADDITIONAL_OPTIONS $SKIP_TESTS_OPTION 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee test_output/test_result.txt
 
 kill_clickhouse
+
+wait_llvm_profdata
+
+sleep 3
+
+wait_llvm_profdata # 100% merged all parts
 
 cp /*.profraw /profraw ||:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement


Short description (up to few sentences):
Add the ability to build ClickHouse with coverage via packager script. Also add image for coverage info. Mostly for usage in CI.
