### PR TITLE
Fix wrong array_join_columns calculation

### DIFF
--- a/dbms/src/Interpreters/ExpressionAnalyzer.cpp
+++ b/dbms/src/Interpreters/ExpressionAnalyzer.cpp
@@ -144,7 +144,11 @@ void ExpressionAnalyzer::analyzeAggregation()
         {
             getRootActions(array_join_expression_list, true, temp_actions);
             addMultipleArrayJoinAction(temp_actions, is_array_join_left);
-            array_join_columns = temp_actions->getSampleBlock().getNamesAndTypesList();
+
+            array_join_columns.clear();
+            for (auto & column : temp_actions->getSampleBlock().getNamesAndTypesList())
+                if (syntax->array_join_result_to_source.count(column.name))
+                    array_join_columns.emplace_back(column);
         }
 
         const ASTTablesInSelectQueryElement * join = select_query->join();

--- a/dbms/tests/queries/0_stateless/00876_wrong_arraj_join_column.sql
+++ b/dbms/tests/queries/0_stateless/00876_wrong_arraj_join_column.sql
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS visits;
+CREATE TABLE visits (str String) ENGINE = MergeTree ORDER BY (str);
+
+SELECT 1
+FROM visits
+ARRAY JOIN arrayFilter(t -> 1, arrayMap(x -> tuple(x), [42])) AS i
+WHERE ((str, i.1) IN ('x', 0));
+
+DROP TABLE visits;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Prevent source and intermediate array join columns of masking same name columns.

