### PR TITLE
add user parsing in HDFS URI

### DIFF
--- a/dbms/src/IO/HDFSCommon.cpp
+++ b/dbms/src/IO/HDFSCommon.cpp
@@ -2,6 +2,7 @@
 
 #if USE_HDFS
 #include <Common/Exception.h>
+#include <string.h>
 namespace DB
 {
 namespace ErrorCodes
@@ -25,6 +26,13 @@ HDFSBuilderPtr createHDFSBuilder(const Poco::URI & uri)
     hdfsBuilderConfSetStr(builder.get(), "input.write.timeout", "60000"); // 1 min
     hdfsBuilderConfSetStr(builder.get(), "input.connect.timeout", "60000"); // 1 min
 
+    std::string userInfo = uri.getUserInfo();
+    if (!userInfo.empty() && userInfo.front() != ':') {
+        char *user = strtok(const_cast<char *> (userInfo.c_str()), ":");
+        if (user != NULL) {
+            hdfsBuilderSetUserName(builder.get(), user);
+        }
+    }
     hdfsBuilderSetNameNode(builder.get(), host.c_str());
     hdfsBuilderSetNameNodePort(builder.get(), port);
     return builder;

--- a/dbms/src/IO/HDFSCommon.cpp
+++ b/dbms/src/IO/HDFSCommon.cpp
@@ -10,6 +10,7 @@ namespace ErrorCodes
 extern const int BAD_ARGUMENTS;
 extern const int NETWORK_ERROR;
 }
+
 HDFSBuilderPtr createHDFSBuilder(const Poco::URI & uri)
 {
     auto & host = uri.getHost();
@@ -26,19 +27,16 @@ HDFSBuilderPtr createHDFSBuilder(const Poco::URI & uri)
     hdfsBuilderConfSetStr(builder.get(), "input.write.timeout", "60000"); // 1 min
     hdfsBuilderConfSetStr(builder.get(), "input.connect.timeout", "60000"); // 1 min
 
-    std::string userInfo = uri.getUserInfo();
-    if (!userInfo.empty() && userInfo.front() != ':')
+    std::string user_info = uri.getUserInfo();
+    if (!user_info.empty() && user_info.front() != ':')
     {
         std::string user;
-        size_t delimPos = userInfo.find(":");
-        if (delimPos != std::string::npos)
-        {
-            user = userInfo.substr(0, delimPos);
-        }
+        size_t delim_pos = user_info.find(":");
+        if (delim_pos != std::string::npos)
+            user = user_info.substr(0, delim_pos);
         else
-        {
-            user = userInfo;
-        }
+            user = user_info;
+
         hdfsBuilderSetUserName(builder.get(), user.c_str());
     }
     hdfsBuilderSetNameNode(builder.get(), host.c_str());

--- a/dbms/src/IO/HDFSCommon.cpp
+++ b/dbms/src/IO/HDFSCommon.cpp
@@ -2,8 +2,6 @@
 
 #if USE_HDFS
 #include <Common/Exception.h>
-#include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/classification.hpp>
 
 namespace DB
 {
@@ -31,13 +29,17 @@ HDFSBuilderPtr createHDFSBuilder(const Poco::URI & uri)
     std::string userInfo = uri.getUserInfo();
     if (!userInfo.empty() && userInfo.front() != ':')
     {
-        std::vector<std::string> splitRes;
-        boost::split(splitRes, userInfo, boost::algorithm::is_any_of(":"), boost::algorithm::token_compress_on);
-        const char *user = splitRes.front().c_str();
-        if (user)
+        std::string user;
+        size_t delimPos = userInfo.find(":");
+        if (delimPos != std::string::npos)
         {
-            hdfsBuilderSetUserName(builder.get(), user);
+            user = userInfo.substr(0, delimPos);
         }
+        else
+        {
+            user = userInfo;
+        }
+        hdfsBuilderSetUserName(builder.get(), user.c_str());
     }
     hdfsBuilderSetNameNode(builder.get(), host.c_str());
     hdfsBuilderSetNameNodePort(builder.get(), port);

--- a/dbms/src/IO/HDFSCommon.cpp
+++ b/dbms/src/IO/HDFSCommon.cpp
@@ -2,7 +2,9 @@
 
 #if USE_HDFS
 #include <Common/Exception.h>
-#include <string.h>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/classification.hpp>
+
 namespace DB
 {
 namespace ErrorCodes
@@ -27,9 +29,13 @@ HDFSBuilderPtr createHDFSBuilder(const Poco::URI & uri)
     hdfsBuilderConfSetStr(builder.get(), "input.connect.timeout", "60000"); // 1 min
 
     std::string userInfo = uri.getUserInfo();
-    if (!userInfo.empty() && userInfo.front() != ':') {
-        char *user = strtok(const_cast<char *> (userInfo.c_str()), ":");
-        if (user != NULL) {
+    if (!userInfo.empty() && userInfo.front() != ':')
+    {
+        std::vector<std::string> splitRes;
+        boost::split(splitRes, userInfo, boost::algorithm::is_any_of(":"), boost::algorithm::token_compress_on);
+        const char *user = splitRes.front().c_str();
+        if (user)
+        {
             hdfsBuilderSetUserName(builder.get(), user);
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

- Improvement
Short description :
add user parsing in HDFS engine builder

Detailed description :
when we using HDFS with hadoop.security.authentication=simple, we can't set username for hdfs-table in ClickHouse.
hdfsLib use user from under which clickhouse is running
User in URI is ignored
I think this must be fixed