### PR TITLE
Primary key, MergeTreeIndexFullText and MergeTreeIndexSet support for string functions

### DIFF
--- a/dbms/src/Storages/MergeTree/MergeTreeIndexFullText.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeIndexFullText.cpp
@@ -142,7 +142,6 @@ const MergeTreeConditionFullText::AtomMap MergeTreeConditionFullText::atom_map
                 "like",
                 [] (RPNElement & out, const Field & value, const MergeTreeIndexFullText & idx)
                 {
-                    std::cerr << "FULLTEXT INDEX IS USED FOR LIKE FUNCTION" << '\n';
                     out.function = RPNElement::FUNCTION_EQUALS;
                     out.bloom_filter = std::make_unique<BloomFilter>(
                             idx.bloom_filter_size, idx.bloom_filter_hashes, idx.seed);
@@ -156,7 +155,6 @@ const MergeTreeConditionFullText::AtomMap MergeTreeConditionFullText::atom_map
                 "notLike",
                 [] (RPNElement & out, const Field & value, const MergeTreeIndexFullText & idx)
                 {
-                    std::cerr << "FULLTEXT INDEX IS USED FOR NOT_LIKE FUNCTION" << '\n';
                     out.function = RPNElement::FUNCTION_NOT_EQUALS;
                     out.bloom_filter = std::make_unique<BloomFilter>(
                             idx.bloom_filter_size, idx.bloom_filter_hashes, idx.seed);

--- a/dbms/src/Storages/MergeTree/MergeTreeIndexFullText.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeIndexFullText.h
@@ -78,8 +78,6 @@ private:
             /// Atoms of a Boolean expression.
             FUNCTION_EQUALS,
             FUNCTION_NOT_EQUALS,
-            FUNCTION_LIKE,
-            FUNCTION_NOT_LIKE,
             FUNCTION_IN,
             FUNCTION_NOT_IN,
             FUNCTION_UNKNOWN, /// Can take any value.
@@ -97,7 +95,7 @@ private:
             : function(function_), key_column(key_column_), bloom_filter(std::move(const_bloom_filter_)) {}
 
         Function function = FUNCTION_UNKNOWN;
-        /// For FUNCTION_EQUALS, FUNCTION_NOT_EQUALS, FUNCTION_LIKE, FUNCTION_NOT_LIKE.
+        /// For FUNCTION_EQUALS, FUNCTION_NOT_EQUALS
         size_t key_column;
         std::unique_ptr<BloomFilter> bloom_filter;
         /// For FUNCTION_IN and FUNCTION_NOT_IN

--- a/dbms/src/Storages/MergeTree/MergeTreeIndexFullText.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeIndexFullText.h
@@ -80,6 +80,7 @@ private:
             FUNCTION_NOT_EQUALS,
             FUNCTION_IN,
             FUNCTION_NOT_IN,
+            FUNCTION_MULTI_SEARCH,
             FUNCTION_UNKNOWN, /// Can take any value.
             /// Operators of the logical expression.
             FUNCTION_NOT,
@@ -91,15 +92,20 @@ private:
         };
 
         RPNElement(
-            Function function_ = FUNCTION_UNKNOWN, size_t key_column_ = 0, std::unique_ptr<BloomFilter> && const_bloom_filter_ = nullptr)
-            : function(function_), key_column(key_column_), bloom_filter(std::move(const_bloom_filter_)) {}
+                Function function_ = FUNCTION_UNKNOWN, size_t key_column_ = 0, std::unique_ptr<BloomFilter> && const_bloom_filter_ = nullptr)
+                : function(function_), key_column(key_column_), bloom_filter(std::move(const_bloom_filter_)) {}
 
         Function function = FUNCTION_UNKNOWN;
-        /// For FUNCTION_EQUALS, FUNCTION_NOT_EQUALS
+        /// For FUNCTION_EQUALS, FUNCTION_NOT_EQUALS and FUNCTION_MULTI_SEARCH
         size_t key_column;
+
+        /// For FUNCTION_EQUALS, FUNCTION_NOT_EQUALS
         std::unique_ptr<BloomFilter> bloom_filter;
-        /// For FUNCTION_IN and FUNCTION_NOT_IN
+
+        /// For FUNCTION_IN, FUNCTION_NOT_IN and FUNCTION_MULTI_SEARCH
         std::vector<std::vector<BloomFilter>> set_bloom_filters;
+
+        /// For FUNCTION_IN and FUNCTION_NOT_IN
         std::vector<size_t> set_key_position;
     };
 

--- a/dbms/src/Storages/MergeTree/MergeTreeIndexSet.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeIndexSet.cpp
@@ -411,7 +411,10 @@ static bool checkAtomName(const String & name)
             "greaterOrEquals",
             "in",
             "notIn",
-            "like"
+            "like",
+            "startsWith",
+            "endsWith",
+            "multiSearchAny"
             };
     return atoms.find(name) != atoms.end();
 }

--- a/dbms/tests/queries/0_stateless/00964_bloom_index_string_functions.reference
+++ b/dbms/tests/queries/0_stateless/00964_bloom_index_string_functions.reference
@@ -1,0 +1,53 @@
+9	abra
+14	abracadabra
+		"rows_read": 6,
+8	computer science
+		"rows_read": 2,
+9	abra
+10	cadabra
+11	crabacadabra
+14	abracadabra
+15	cadabraabra
+		"rows_read": 6,
+6	some string
+7	another string
+		"rows_read": 2,
+9	abra
+14	abracadabra
+		"rows_read": 6,
+8	computer science
+		"rows_read": 2,
+1	ClickHouse is a column-oriented database management system (DBMS)
+2	column-oriented database management system
+13	basement
+		"rows_read": 6,
+6	some string
+7	another string
+		"rows_read": 2,
+6	some string
+7	another string
+8	computer science
+		"rows_read": 4,
+1	ClickHouse is a column-oriented database management system (DBMS)
+2	column-oriented database management system
+13	basement
+		"rows_read": 6,
+9	abra
+10	cadabra
+11	crabacadabra
+14	abracadabra
+15	cadabraabra
+		"rows_read": 6,
+4	какая-то строка
+5	еще строка
+6	some string
+7	another string
+		"rows_read": 4,
+14	abracadabra
+		"rows_read": 4,
+1	ClickHouse is a column-oriented database management system (DBMS)
+2	column-oriented database management system
+10	cadabra
+11	crabacadabra
+15	cadabraabra
+		"rows_read": 8,

--- a/dbms/tests/queries/0_stateless/00964_bloom_index_string_functions.sh
+++ b/dbms/tests/queries/0_stateless/00964_bloom_index_string_functions.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. $CURDIR/../shell_config.sh
+
+$CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS bloom_filter_idx;"
+
+# NGRAM BF
+$CLICKHOUSE_CLIENT -n --query="
+SET allow_experimental_data_skipping_indices = 1;
+CREATE TABLE bloom_filter_idx
+(
+    k UInt64,
+    s String,
+    INDEX bf (s, lower(s)) TYPE ngrambf_v1(3, 512, 2, 0) GRANULARITY 1
+) ENGINE = MergeTree()
+ORDER BY k
+SETTINGS index_granularity = 2;"
+
+$CLICKHOUSE_CLIENT --query="INSERT INTO bloom_filter_idx VALUES
+(0, 'ClickHouse - столбцовая система управления базами данных (СУБД)'),
+(1, 'ClickHouse is a column-oriented database management system (DBMS)'),
+(2, 'column-oriented database management system'),
+(3, 'columns'),
+(4, 'какая-то строка'),
+(5, 'еще строка'),
+(6, 'some string'),
+(7, 'another string'),
+(8, 'computer science'),
+(9, 'abra'),
+(10, 'cadabra'),
+(11, 'crabacadabra'),
+(12, 'crab'),
+(13, 'basement'),
+(14, 'abracadabra'),
+(15, 'cadabraabra')"
+
+# STARTS_WITH
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE startsWith(s, 'abra') ORDER BY k"
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE startsWith(s, 'abra') ORDER BY k FORMAT JSON" | grep "rows_read"
+
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE startsWith(s, 'computer') ORDER BY k"
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE startsWith(s, 'computer') ORDER BY k FORMAT JSON" | grep "rows_read"
+
+# ENDS_WITH
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE endsWith(s, 'abra') ORDER BY k"
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE endsWith(s, 'abra') ORDER BY k FORMAT JSON" | grep "rows_read"
+
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE endsWith(s, 'ring') ORDER BY k"
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE endsWith(s, 'ring') ORDER BY k FORMAT JSON" | grep "rows_read"
+
+# COMBINED
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE startsWith(s, 'abra') AND endsWith(s, 'abra')"
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE startsWith(s, 'abra') AND endsWith(s, 'abra') FORMAT JSON" | grep "rows_read"
+
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE startsWith(s, 'c') AND endsWith(s, 'science')"
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE startsWith(s, 'c') AND endsWith(s, 'science') FORMAT JSON" | grep "rows_read"
+
+# MULTY_SEARCH_ANY
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE multiSearchAny(s, ['data', 'base'])"
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE multiSearchAny(s, ['data', 'base']) FORMAT JSON" | grep "rows_read"
+
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE multiSearchAny(s, ['string'])"
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE multiSearchAny(s, ['string']) FORMAT JSON" | grep "rows_read"
+
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE multiSearchAny(s, ['string', 'computer'])"
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE multiSearchAny(s, ['string', 'computer']) FORMAT JSON" | grep "rows_read"
+
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE multiSearchAny(s, ['base', 'seme', 'gement'])"
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE multiSearchAny(s, ['base', 'seme', 'gement']) FORMAT JSON" | grep "rows_read"
+
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE multiSearchAny(s, ['abra', 'cadabra', 'cab', 'extra'])"
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE multiSearchAny(s, ['abra', 'cadabra', 'cab', 'extra']) FORMAT JSON" | grep "rows_read"
+
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE multiSearchAny(s, ['строка', 'string'])"
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE multiSearchAny(s, ['строка', 'string']) FORMAT JSON" | grep "rows_read"
+
+# MULTY_SEARCH_ANY + OTHER
+
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE multiSearchAny(s, ['adab', 'cad', 'aba']) AND startsWith(s, 'abra')"
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE multiSearchAny(s, ['adab', 'cad', 'aba']) AND startsWith(s, 'abra') FORMAT JSON" | grep "rows_read"
+
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE multiSearchAny(s, ['adab', 'cad', 'aba']) AND (startsWith(s, 'c') OR startsWith(s, 'C'))"
+$CLICKHOUSE_CLIENT --query="SELECT * FROM bloom_filter_idx WHERE multiSearchAny(s, ['adab', 'cad', 'aba']) AND (startsWith(s, 'c') OR startsWith(s, 'C')) FORMAT JSON" | grep "rows_read"
+
+$CLICKHOUSE_CLIENT --query="DROP TABLE bloom_filter_idx;"

--- a/dbms/tests/queries/0_stateless/00965_set_index_string_functions.reference
+++ b/dbms/tests/queries/0_stateless/00965_set_index_string_functions.reference
@@ -1,0 +1,16 @@
+9	abra
+14	abracadabra
+		"rows_read": 4,
+9	abra
+10	cadabra
+11	crabacadabra
+14	abracadabra
+15	cadabraabra
+		"rows_read": 6,
+9	abra
+14	abracadabra
+		"rows_read": 4,
+1	ClickHouse is a column-oriented database management system (DBMS)
+2	column-oriented database management system
+13	basement
+		"rows_read": 6,

--- a/dbms/tests/queries/0_stateless/00965_set_index_string_functions.sh
+++ b/dbms/tests/queries/0_stateless/00965_set_index_string_functions.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. $CURDIR/../shell_config.sh
+
+$CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS set_idx;"
+
+$CLICKHOUSE_CLIENT -n --query="
+SET allow_experimental_data_skipping_indices = 1;
+CREATE TABLE set_idx
+(
+    k UInt64,
+    s String,
+    INDEX idx (s) TYPE set(2) GRANULARITY 1
+) ENGINE = MergeTree()
+ORDER BY k
+SETTINGS index_granularity = 2;"
+
+$CLICKHOUSE_CLIENT --query="INSERT INTO set_idx VALUES
+(0, 'ClickHouse - столбцовая система управления базами данных (СУБД)'),
+(1, 'ClickHouse is a column-oriented database management system (DBMS)'),
+(2, 'column-oriented database management system'),
+(3, 'columns'),
+(4, 'какая-то строка'),
+(5, 'еще строка'),
+(6, 'some string'),
+(7, 'another string'),
+(8, 'computer science'),
+(9, 'abra'),
+(10, 'cadabra'),
+(11, 'crabacadabra'),
+(12, 'crab'),
+(13, 'basement'),
+(14, 'abracadabra'),
+(15, 'cadabraabra')"
+
+# STARTS_WITH
+$CLICKHOUSE_CLIENT --query="SELECT * FROM set_idx WHERE startsWith(s, 'abra')"
+$CLICKHOUSE_CLIENT --query="SELECT * FROM set_idx WHERE startsWith(s, 'abra') FORMAT JSON" | grep "rows_read"
+
+# ENDS_WITH
+$CLICKHOUSE_CLIENT --query="SELECT * FROM set_idx WHERE endsWith(s, 'abra')"
+$CLICKHOUSE_CLIENT --query="SELECT * FROM set_idx WHERE endsWith(s, 'abra') FORMAT JSON" | grep "rows_read"
+
+# COMBINED
+$CLICKHOUSE_CLIENT --query="SELECT * FROM set_idx WHERE startsWith(s, 'abra') AND endsWith(s, 'abra')"
+$CLICKHOUSE_CLIENT --query="SELECT * FROM set_idx WHERE startsWith(s, 'abra') AND endsWith(s, 'abra') FORMAT JSON" | grep "rows_read"
+
+# MULTY_SEARCH_ANY
+$CLICKHOUSE_CLIENT --query="SELECT * FROM set_idx WHERE multiSearchAny(s, ['data', 'base'])"
+$CLICKHOUSE_CLIENT --query="SELECT * FROM set_idx WHERE multiSearchAny(s, ['data', 'base']) FORMAT JSON" | grep "rows_read"
+
+$CLICKHOUSE_CLIENT --query="DROP TABLE set_idx;"
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/dbms/tests/queries/0_stateless/00965_set_index_string_functions.sh
+++ b/dbms/tests/queries/0_stateless/00965_set_index_string_functions.sh
@@ -51,16 +51,3 @@ $CLICKHOUSE_CLIENT --query="SELECT * FROM set_idx WHERE multiSearchAny(s, ['data
 $CLICKHOUSE_CLIENT --query="SELECT * FROM set_idx WHERE multiSearchAny(s, ['data', 'base']) FORMAT JSON" | grep "rows_read"
 
 $CLICKHOUSE_CLIENT --query="DROP TABLE set_idx;"
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- New Feature


Short description (up to few sentences):
Added support startsWith, endsWith, multiSearchAny, notLike for MergeTreeIndexFullText.
Added support startsWith, endsWith, multiSearchAny for MergeTreeIndexSet.
Added support empty, notEmpty, notLike for Primary key.