### PR TITLE
Fix deserializeAndInsertFromArena.

### DIFF
--- a/dbms/src/Columns/ColumnArray.cpp
+++ b/dbms/src/Columns/ColumnArray.cpp
@@ -184,7 +184,7 @@ StringRef ColumnArray::serializeValueIntoArena(size_t n, Arena & arena, char con
     {
         auto value_ref = getData().serializeValueIntoArena(offset + i, arena, begin);
         res.data = value_ref.data - res.size;
-        res.data += value_ref.size;
+        res.size += value_ref.size;
     }
 
     return res;

--- a/dbms/src/Columns/ColumnArray.cpp
+++ b/dbms/src/Columns/ColumnArray.cpp
@@ -178,11 +178,16 @@ StringRef ColumnArray::serializeValueIntoArena(size_t n, Arena & arena, char con
     char * pos = arena.allocContinue(sizeof(array_size), begin);
     memcpy(pos, &array_size, sizeof(array_size));
 
-    size_t values_size = 0;
-    for (size_t i = 0; i < array_size; ++i)
-        values_size += getData().serializeValueIntoArena(offset + i, arena, begin).size;
+    StringRef res(pos, sizeof(array_size);
 
-    return StringRef(begin, sizeof(array_size) + values_size);
+    for (size_t i = 0; i < array_size; ++i)
+    {
+        auto value_ref = getData().serializeValueIntoArena(offset + i, arena, begin);
+        res.data = value_ref.data - res.size;
+        res.data += value_ref.size;
+    }
+
+    return res;
 }
 
 

--- a/dbms/src/Columns/ColumnArray.cpp
+++ b/dbms/src/Columns/ColumnArray.cpp
@@ -178,7 +178,7 @@ StringRef ColumnArray::serializeValueIntoArena(size_t n, Arena & arena, char con
     char * pos = arena.allocContinue(sizeof(array_size), begin);
     memcpy(pos, &array_size, sizeof(array_size));
 
-    StringRef res(pos, sizeof(array_size);
+    StringRef res(pos, sizeof(array_size));
 
     for (size_t i = 0; i < array_size; ++i)
     {

--- a/dbms/src/Columns/ColumnTuple.cpp
+++ b/dbms/src/Columns/ColumnTuple.cpp
@@ -142,11 +142,15 @@ void ColumnTuple::popBack(size_t n)
 
 StringRef ColumnTuple::serializeValueIntoArena(size_t n, Arena & arena, char const *& begin) const
 {
-    size_t values_size = 0;
+    StringRef res(begin, 0);
     for (auto & column : columns)
-        values_size += column->serializeValueIntoArena(n, arena, begin).size;
+    {
+        auto value_ref = column->serializeValueIntoArena(n, arena, begin);
+        res.data = value_ref.data - res.size;
+        res.size += value_ref.size;
+    }
 
-    return StringRef(begin, values_size);
+    return res;
 }
 
 const char * ColumnTuple::deserializeAndInsertFromArena(const char * pos)

--- a/dbms/src/Columns/ColumnUnique.h
+++ b/dbms/src/Columns/ColumnUnique.h
@@ -300,12 +300,10 @@ StringRef ColumnUnique<ColumnType>::serializeValueIntoArena(size_t n, Arena & ar
 {
     if (is_nullable)
     {
-        static constexpr UInt8 null_flag = 1;
-        static constexpr UInt8 not_null_flag = 0;
-        static constexpr auto s = sizeof(null_flag);
+        static constexpr auto s = sizeof(UInt8);
 
-        auto pos = arena.allocContinue(sizeof(null_flag), begin);
-        auto flag = (n == getNullValueIndex() ? null_flag : not_null_flag);
+        auto pos = arena.allocContinue(s, begin);
+        auto flag = (n == getNullValueIndex() ? 1 : 0);
         memcpy(pos, &flag, s);
 
         if (n == getNullValueIndex())

--- a/dbms/src/Columns/ColumnUnique.h
+++ b/dbms/src/Columns/ColumnUnique.h
@@ -304,7 +304,7 @@ StringRef ColumnUnique<ColumnType>::serializeValueIntoArena(size_t n, Arena & ar
 
         auto pos = arena.allocContinue(s, begin);
         UInt8 flag = (n == getNullValueIndex() ? 1 : 0);
-        memcpy(pos, &flag, s);
+        unalignedStore<UInt8>(pos, flag);
 
         if (n == getNullValueIndex())
             return StringRef(pos, s);

--- a/dbms/src/Columns/ColumnUnique.h
+++ b/dbms/src/Columns/ColumnUnique.h
@@ -300,19 +300,21 @@ StringRef ColumnUnique<ColumnType>::serializeValueIntoArena(size_t n, Arena & ar
 {
     if (is_nullable)
     {
-        const UInt8 null_flag = 1;
-        const UInt8 not_null_flag = 0;
+        static constexpr UInt8 null_flag = 1;
+        static constexpr UInt8 not_null_flag = 0;
+        static constexpr auto s = sizeof(null_flag);
 
         auto pos = arena.allocContinue(sizeof(null_flag), begin);
-        auto & flag = (n == getNullValueIndex() ? null_flag : not_null_flag);
-        memcpy(pos, &flag, sizeof(flag));
+        auto flag = (n == getNullValueIndex() ? null_flag : not_null_flag);
+        memcpy(pos, &flag, s);
 
-        size_t nested_size = 0;
+        if (n == getNullValueIndex())
+            return StringRef(pos, s);
 
-        if (n != getNullValueIndex())
-            nested_size = column_holder->serializeValueIntoArena(n, arena, begin).size;
+        auto nested_ref = column_holder->serializeValueIntoArena(n, arena, begin);
 
-        return StringRef(pos, sizeof(null_flag) + nested_size);
+        /// serializeValueIntoArena may reallocate memory. Have to use ptr from nested_ref.data and move it back.
+        return StringRef(nested_ref.data - s, nested_ref.size + s);
     }
 
     return column_holder->serializeValueIntoArena(n, arena, begin);

--- a/dbms/src/Columns/ColumnUnique.h
+++ b/dbms/src/Columns/ColumnUnique.h
@@ -303,7 +303,7 @@ StringRef ColumnUnique<ColumnType>::serializeValueIntoArena(size_t n, Arena & ar
         static constexpr auto s = sizeof(UInt8);
 
         auto pos = arena.allocContinue(s, begin);
-        auto flag = (n == getNullValueIndex() ? 1 : 0);
+        UInt8 flag = (n == getNullValueIndex() ? 1 : 0);
         memcpy(pos, &flag, s);
 
         if (n == getNullValueIndex())


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix


Short description (up to few sentences):
Fixed wrong `StringRef` pointer returned by some implementations of `IColumn::deserializeAndInsertFromArena`. This bug affected only unit-tests.