### PR TITLE
Add ability to sign rpm packages

### DIFF
--- a/utils/release/push_packages
+++ b/utils/release/push_packages
@@ -6,6 +6,7 @@ import os
 import logging
 import shutil
 import base64
+import pexpect
 
 
 # Do nothing if keys are not provided
@@ -116,6 +117,20 @@ def debsign(path, gpg_passphrase, gpg_sec_key_path, gpg_pub_key_path, gpg_user):
         logging.error("Cannot debsign packages on path %s, with user key", path)
         raise ex
 
+def rpmsign(path, gpg_passphrase, gpg_sec_key_path, gpg_pub_key_path, gpg_user):
+    try:
+        with GpgKey(gpg_sec_key_path, gpg_pub_key_path):
+            for package in os.listdir(path):
+                package_path = os.path.join(path, package)
+                logging.info("Signing %s", package_path)
+                proc = pexpect.spawn('rpm --resign -D "_signature gpg" -D "_gpg_name {username}" {package}'.format(username=gpg_user, package=package_path))
+                proc.expect_exact("Enter pass phrase: ")
+                proc.sendline(gpg_passphrase)
+                proc.expect(pexpect.EOF)
+                logging.info("Signed successfully")
+    except Exception as ex:
+        logging.error("Cannot rpmsign packages on path %s, with user key", path)
+        raise ex
 
 def transfer_packages_scp(ssh_key, path, repo_user, repo_url, incoming_directory):
     logging.info("Transferring packages via scp to %s", repo_url)
@@ -212,6 +227,7 @@ if __name__ == "__main__":
     if args.rpm_directory:
         if not is_open_source:
             raise Exception("Cannot upload .rpm package to {}".format(args.repo_url))
+        rpmsign(args.rpm_directory, args.gpg_passphrase, args.gpg_sec_key_path, args.gpg_pub_key_path, args.gpg_key_user)
         packages.append((args.rpm_directory, 'rpm'))
 
     if args.tgz_directory:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):

Add ability to sign .rpm clickhouse packages.
