### PR TITLE
Fixed DoubleDelta encoding cases for random Int32 and Int64.

### DIFF
--- a/dbms/src/Compression/CompressionCodecDoubleDelta.cpp
+++ b/dbms/src/Compression/CompressionCodecDoubleDelta.cpp
@@ -38,11 +38,10 @@ Int64 getMaxValueForByteSize(UInt8 byte_size)
             return std::numeric_limits<Int32>::max();
         case sizeof(UInt64):
             return std::numeric_limits<Int64>::max();
-    default:
-        assert(false && "only 1,2,4 and 8 data sizes are supported");
+        default:
+            assert(false && "only 1, 2, 4 and 8 data sizes are supported");
     }
-
-    return std::numeric_limits<Int64>::max();
+    __builtin_unreachable();
 }
 
 struct WriteSpec

--- a/dbms/src/Compression/CompressionCodecDoubleDelta.cpp
+++ b/dbms/src/Compression/CompressionCodecDoubleDelta.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <type_traits>
+#include <limits>
 
 namespace DB
 {
@@ -24,28 +25,24 @@ extern const int CANNOT_DECOMPRESS;
 
 namespace
 {
-UInt32 getDeltaTypeByteSize(UInt8 data_bytes_size)
+
+Int64 getMaxValueForByteSize(UInt8 byte_size)
 {
-    // both delta and double delta can be twice the size of data item, but not less than 32 bits and not more that 64.
-    return std::min(64/8, std::max(32/8, data_bytes_size * 2));
-}
+    switch (byte_size)
+    {
+        case sizeof(UInt8):
+            return std::numeric_limits<Int8>::max();
+        case sizeof(UInt16):
+            return std::numeric_limits<Int16>::max();
+        case sizeof(UInt32):
+            return std::numeric_limits<Int32>::max();
+        case sizeof(UInt64):
+            return std::numeric_limits<Int64>::max();
+    default:
+        assert(false && "only 1,2,4 and 8 data sizes are supported");
+    }
 
-UInt32 getCompressedHeaderSize(UInt8 data_bytes_size)
-{
-    const UInt8 items_count_size = 4;
-
-    return items_count_size + data_bytes_size + getDeltaTypeByteSize(data_bytes_size);
-}
-
-UInt32 getCompressedDataSize(UInt8 data_bytes_size, UInt32 uncompressed_size)
-{
-    const UInt32 items_count = uncompressed_size / data_bytes_size;
-
-    // 11111 + max 64 bits of double delta.
-    const UInt32 max_item_size_bits = 5 + getDeltaTypeByteSize(data_bytes_size) * 8;
-
-    // + 8 is to round up to next byte.
-    return (items_count * max_item_size_bits + 8) / 8;
+    return std::numeric_limits<Int64>::max();
 }
 
 struct WriteSpec
@@ -55,8 +52,10 @@ struct WriteSpec
     const UInt8 data_bits;
 };
 
+const std::array<UInt8, 5> DELTA_SIZES{7, 9, 12, 32, 64};
+
 template <typename T>
-WriteSpec getWriteSpec(const T & value)
+WriteSpec getDeltaWriteSpec(const T & value)
 {
     if (value > -63 && value < 64)
     {
@@ -80,27 +79,60 @@ WriteSpec getWriteSpec(const T & value)
     }
 }
 
-template <typename T, typename DeltaType>
+WriteSpec getDeltaMaxWriteSpecByteSize(UInt8 data_bytes_size)
+{
+    return getDeltaWriteSpec(getMaxValueForByteSize(data_bytes_size));
+}
+
+UInt32 getCompressedHeaderSize(UInt8 data_bytes_size)
+{
+    const UInt8 items_count_size = 4;
+    const UInt8 first_delta_bytes_size = data_bytes_size;
+
+    return items_count_size + data_bytes_size + first_delta_bytes_size;
+}
+
+UInt32 getCompressedDataSize(UInt8 data_bytes_size, UInt32 uncompressed_size)
+{
+    const UInt32 items_count = uncompressed_size / data_bytes_size;
+    const auto double_delta_write_spec = getDeltaMaxWriteSpecByteSize(data_bytes_size);
+
+    const UInt32 max_item_size_bits = double_delta_write_spec.prefix_bits + double_delta_write_spec.data_bits;
+
+    // + 8 is to round up to next byte.
+    auto result = (items_count * max_item_size_bits + 7) / 8;
+
+    return result;
+}
+
+template <typename ValueType>
 UInt32 compressDataForType(const char * source, UInt32 source_size, char * dest)
 {
-    static_assert(std::is_unsigned_v<T> && std::is_signed_v<DeltaType>, "T must be unsigned, while DeltaType must be signed integer type.");
-    using UnsignedDeltaType = typename std::make_unsigned<DeltaType>::type;
+    // Since only unsinged int has granted 2-compliment overflow handling, we are doing math here on unsigned types.
+    // To simplify and booletproof code, we operate enforce ValueType to be unsigned too.
+    static_assert(std::is_unsigned_v<ValueType>, "ValueType must be unsigned.");
+    using UnsignedDeltaType = ValueType;
 
-    if (source_size % sizeof(T) != 0)
-        throw Exception("Cannot compress, data size " + toString(source_size) + " is not aligned to " + toString(sizeof(T)), ErrorCodes::CANNOT_COMPRESS);
+    // We use signed delta type to turn huge unsigned values into smaller signed:
+    // ffffffff => -1
+    using SignedDeltaType = typename std::make_signed<UnsignedDeltaType>::type;
+
+    if (source_size % sizeof(ValueType) != 0)
+        throw Exception("Cannot compress, data size " + toString(source_size)
+                        + " is not aligned to " + toString(sizeof(ValueType)), ErrorCodes::CANNOT_COMPRESS);
     const char * source_end = source + source_size;
 
-    const UInt32 items_count = source_size / sizeof(T);
+    const UInt32 items_count = source_size / sizeof(ValueType);
     unalignedStore<UInt32>(dest, items_count);
     dest += sizeof(items_count);
 
-    T prev_value{};
-    DeltaType prev_delta{};
+    ValueType prev_value{};
+    UnsignedDeltaType prev_delta{};
 
     if (source < source_end)
     {
-        prev_value = unalignedLoad<T>(source);
-        unalignedStore<T>(dest, prev_value);
+        prev_value = unalignedLoad<ValueType>(source);
+        unalignedStore<ValueType>(dest, prev_value);
 
         source += sizeof(prev_value);
         dest += sizeof(prev_value);
@@ -108,24 +140,26 @@ UInt32 compressDataForType(const char * source, UInt32 source_size, char * dest)
 
     if (source < source_end)
     {
-        const T curr_value = unalignedLoad<T>(source);
-        prev_delta = static_cast<DeltaType>(curr_value - prev_value);
-        unalignedStore<DeltaType>(dest, prev_delta);
+        const ValueType curr_value = unalignedLoad<ValueType>(source);
+
+        prev_delta = curr_value - prev_value;
+        unalignedStore<UnsignedDeltaType>(dest, prev_delta);
 
         source += sizeof(curr_value);
         dest += sizeof(prev_delta);
         prev_value = curr_value;
     }
 
-    WriteBuffer buffer(dest, getCompressedDataSize(sizeof(T), source_size - sizeof(T)*2));
+    WriteBuffer buffer(dest, getCompressedDataSize(sizeof(ValueType), source_size - sizeof(ValueType)*2));
     BitWriter writer(buffer);
 
-    for (; source < source_end; source += sizeof(T))
+    int item = 2;
+    for (; source < source_end; source += sizeof(ValueType), ++item)
     {
-        const T curr_value = unalignedLoad<T>(source);
+        const ValueType curr_value = unalignedLoad<ValueType>(source);
 
-        const DeltaType delta = static_cast<DeltaType>(curr_value - prev_value);
-        const DeltaType double_delta = delta - prev_delta;
+        const UnsignedDeltaType delta = curr_value - prev_value;
+        const UnsignedDeltaType double_delta = delta - prev_delta;
 
         prev_delta = delta;
         prev_value = curr_value;
@@ -136,9 +170,11 @@ UInt32 compressDataForType(const char * source, UInt32 source_size, char * dest)
         }
         else
         {
-            const auto sign = std::signbit(double_delta);
-            const auto abs_value = static_cast<UnsignedDeltaType>(std::abs(double_delta));
-            const auto write_spec = getWriteSpec(double_delta);
+            const SignedDeltaType signed_dd = static_cast<SignedDeltaType>(double_delta);
+            const auto sign = std::signbit(signed_dd);
+            // -1 shirnks dd down to fit into number of bits, and there can't be 0, so it is OK.
+            const auto abs_value = static_cast<UnsignedDeltaType>(std::abs(signed_dd) - 1);
+            const auto write_spec = getDeltaWriteSpec(signed_dd);
 
             writer.writeBits(write_spec.prefix_bits, write_spec.prefix);
             writer.writeBits(1, sign);
@@ -151,22 +187,25 @@ UInt32 compressDataForType(const char * source, UInt32 source_size, char * dest)
     return sizeof(items_count) + sizeof(prev_value) + sizeof(prev_delta) + buffer.count();
 }
 
-template <typename T, typename DeltaType>
+template <typename ValueType>
 void decompressDataForType(const char * source, UInt32 source_size, char * dest)
 {
-    static_assert(std::is_unsigned_v<T> && std::is_signed_v<DeltaType>, "T must be unsigned, while DeltaType must be signed integer type.");
+    static_assert(std::is_unsigned_v<ValueType>, "ValueType must be unsigned.");
+    using UnsignedDeltaType = ValueType;
+    using SignedDeltaType = typename std::make_signed<UnsignedDeltaType>::type;
+
     const char * source_end = source + source_size;
 
     const UInt32 items_count = unalignedLoad<UInt32>(source);
     source += sizeof(items_count);
 
-    T prev_value{};
-    DeltaType prev_delta{};
+    ValueType prev_value{};
+    UnsignedDeltaType prev_delta{};
 
     if (source < source_end)
     {
-        prev_value = unalignedLoad<T>(source);
-        unalignedStore<T>(dest, prev_value);
+        prev_value = unalignedLoad<ValueType>(source);
+        unalignedStore<ValueType>(dest, prev_value);
 
         source += sizeof(prev_value);
         dest += sizeof(prev_value);
@@ -174,9 +213,9 @@ void decompressDataForType(const char * source, UInt32 source_size, char * dest)
 
     if (source < source_end)
     {
-        prev_delta = unalignedLoad<DeltaType>(source);
-        prev_value = prev_value + static_cast<T>(prev_delta);
-        unalignedStore<T>(dest, prev_value);
+        prev_delta = unalignedLoad<UnsignedDeltaType>(source);
+        prev_value = prev_value + static_cast<ValueType>(prev_delta);
+        unalignedStore<ValueType>(dest, prev_value);
 
         source += sizeof(prev_delta);
         dest += sizeof(prev_value);
@@ -189,32 +228,35 @@ void decompressDataForType(const char * source, UInt32 source_size, char * dest)
     // we have to keep track of items to avoid reading more that there is.
     for (UInt32 items_read = 2; items_read < items_count && !reader.eof(); ++items_read)
     {
-        DeltaType double_delta = 0;
+        UnsignedDeltaType double_delta = 0;
         if (reader.readBit() == 1)
         {
-            const UInt8 data_sizes[] = {6, 8, 11, 31, 63};
             UInt8 i = 0;
-            for (; i < sizeof(data_sizes) - 1; ++i)
+            for (; i < sizeof(DELTA_SIZES) - 1; ++i)
             {
                 const auto next_bit = reader.readBit();
                 if (next_bit == 0)
+                {
                     break;
+                }
             }
 
             const UInt8 sign = reader.readBit();
-            double_delta = static_cast<DeltaType>(reader.readBits(data_sizes[i]));
+            SignedDeltaType signed_dd = static_cast<SignedDeltaType>(reader.readBits(DELTA_SIZES[i] - 1) + 1);
             if (sign)
             {
-                double_delta *= -1;
+                signed_dd *= -1;
             }
+            double_delta = static_cast<UnsignedDeltaType>(signed_dd);
         }
         // else if first bit is zero, no need to read more data.
 
-        const T curr_value = prev_value + static_cast<T>(prev_delta + double_delta);
-        unalignedStore<T>(dest, curr_value);
+        const UnsignedDeltaType delta = double_delta + prev_delta;
+        const ValueType curr_value = prev_value + delta;
+        unalignedStore<ValueType>(dest, curr_value);
         dest += sizeof(curr_value);
 
-        prev_delta = static_cast<DeltaType>(curr_value - prev_value);
+        prev_delta = curr_value - prev_value;
         prev_value = curr_value;
     }
 }
@@ -267,19 +309,20 @@ UInt32 CompressionCodecDoubleDelta::doCompressData(const char * source, UInt32 s
     memcpy(&dest[2], source, bytes_to_skip);
     size_t start_pos = 2 + bytes_to_skip;
     UInt32 compressed_size = 0;
+
     switch (data_bytes_size)
     {
     case 1:
-        compressed_size = compressDataForType<UInt8, Int16>(&source[bytes_to_skip], source_size - bytes_to_skip, &dest[start_pos]);
+        compressed_size = compressDataForType<UInt8>(&source[bytes_to_skip], source_size - bytes_to_skip, &dest[start_pos]);
         break;
     case 2:
-        compressed_size = compressDataForType<UInt16, Int32>(&source[bytes_to_skip], source_size - bytes_to_skip, &dest[start_pos]);
+        compressed_size = compressDataForType<UInt16>(&source[bytes_to_skip], source_size - bytes_to_skip, &dest[start_pos]);
         break;
     case 4:
-        compressed_size = compressDataForType<UInt32, Int64>(&source[bytes_to_skip], source_size - bytes_to_skip, &dest[start_pos]);
+        compressed_size = compressDataForType<UInt32>(&source[bytes_to_skip], source_size - bytes_to_skip, &dest[start_pos]);
         break;
     case 8:
-        compressed_size = compressDataForType<UInt64, Int64>(&source[bytes_to_skip], source_size - bytes_to_skip, &dest[start_pos]);
+        compressed_size = compressDataForType<UInt64>(&source[bytes_to_skip], source_size - bytes_to_skip, &dest[start_pos]);
         break;
     }
 
@@ -296,16 +339,16 @@ void CompressionCodecDoubleDelta::doDecompressData(const char * source, UInt32 s
     switch (bytes_size)
     {
     case 1:
-        decompressDataForType<UInt8, Int16>(&source[2 + bytes_to_skip], source_size_no_header, &dest[bytes_to_skip]);
+        decompressDataForType<UInt8>(&source[2 + bytes_to_skip], source_size_no_header, &dest[bytes_to_skip]);
         break;
     case 2:
-        decompressDataForType<UInt16, Int32>(&source[2 + bytes_to_skip], source_size_no_header, &dest[bytes_to_skip]);
+        decompressDataForType<UInt16>(&source[2 + bytes_to_skip], source_size_no_header, &dest[bytes_to_skip]);
         break;
     case 4:
-        decompressDataForType<UInt32, Int64>(&source[2 + bytes_to_skip], source_size_no_header, &dest[bytes_to_skip]);
+        decompressDataForType<UInt32>(&source[2 + bytes_to_skip], source_size_no_header, &dest[bytes_to_skip]);
         break;
     case 8:
-        decompressDataForType<UInt64, Int64>(&source[2 + bytes_to_skip], source_size_no_header, &dest[bytes_to_skip]);
+        decompressDataForType<UInt64>(&source[2 + bytes_to_skip], source_size_no_header, &dest[bytes_to_skip]);
         break;
     }
 }

--- a/dbms/src/Compression/tests/gtest_compressionCodec.cpp
+++ b/dbms/src/Compression/tests/gtest_compressionCodec.cpp
@@ -8,16 +8,16 @@
 
 #include <boost/format.hpp>
 
+#include <bitset>
 #include <cmath>
 #include <initializer_list>
 #include <iomanip>
-#include <memory>
-#include <vector>
-#include <typeinfo>
-#include <iterator>
-#include <optional>
 #include <iostream>
-#include <bitset>
+#include <iterator>
+#include <memory>
+#include <typeinfo>
+#include <vector>
+
 #include <string.h>
 
 #pragma GCC diagnostic ignored "-Wsign-compare"
@@ -119,17 +119,22 @@ template <typename T, typename ContainerLeft, typename ContainerRight>
                 result = ::testing::AssertionFailure();
             }
 
-            result << "mismatching " << sizeof(T) << "-byte item #" << i
-                   << "\nexpected: " << bin(left_value)
-                   << "\ngot     : " << bin(right_value)
-                   << std::endl;
-
-            if (++mismatching_items >= MAX_MISMATCHING_ITEMS)
+            if (++mismatching_items <= MAX_MISMATCHING_ITEMS)
             {
-                result << "..." << std::endl;
-                break;
+                result << "mismatching " << sizeof(T) << "-byte item #" << i
+                   << "\nexpected: " << bin(left_value) << " (0x" << std::hex << left_value << ")"
+                   << "\ngot     : " << bin(right_value) << " (0x" << std::hex << right_value << ")"
+                   << std::endl;
+                if (mismatching_items == MAX_MISMATCHING_ITEMS)
+                {
+                    result << "..." << std::endl;
+                }
             }
         }
+    }
+    if (mismatching_items > 0)
+    {
+        result << "\ntotal mismatching items:" << mismatching_items << " of " << size;
     }
 
     return result;
@@ -137,17 +142,47 @@ template <typename T, typename ContainerLeft, typename ContainerRight>
 
 struct CodecTestParam
 {
+    std::string type_name;
     std::vector<char> source_data;
     UInt8 data_byte_size;
+    double min_compression_ratio;
     std::string case_name;
+
+    // to allow setting ratio after building with complex builder functions.
+    CodecTestParam && setRatio(const double & ratio) &&
+    {
+        this->min_compression_ratio = ratio;
+        return std::move(*this);
+    }
 };
+
+CodecTestParam operator+(CodecTestParam && left, CodecTestParam && right)
+{
+    assert(left.type_name == right.type_name);
+    assert(left.data_byte_size == right.data_byte_size);
+
+    std::vector data(std::move(left.source_data));
+    data.insert(data.end(), right.source_data.begin(), right.source_data.end());
+
+    return CodecTestParam{
+                        left.type_name,
+                        std::move(data),
+                        left.data_byte_size,
+                        std::min(left.min_compression_ratio, right.min_compression_ratio),
+                        left.case_name + " + " + right.case_name
+    };
+}
 
 std::ostream & operator<<(std::ostream & ostr, const CodecTestParam & param)
 {
     return ostr << "name: " << param.case_name
+                << "\ntype name:" << param.type_name
                 << "\nbyte size: " << static_cast<UInt32>(param.data_byte_size)
                 << "\ndata size: " << param.source_data.size();
 }
+
+// compression ratio < 1.0 means that codec output is smaller than input.
+const double DEFAULT_MIN_COMPRESSION_RATIO = 1.0;
 
 template <typename T, typename... Args>
 CodecTestParam makeParam(Args && ... args)
@@ -162,11 +197,11 @@ CodecTestParam makeParam(Args && ... args)
         write_pos += sizeof(v);
     }
 
-    return CodecTestParam{std::move(data), sizeof(T),
-                (boost::format("%1% %2%") % (sizeof(T) * std::size(vals)) % " predefined values").str()};
+    return CodecTestParam{type_name<T>(), std::move(data), sizeof(T), DEFAULT_MIN_COMPRESSION_RATIO,
+                (boost::format("%1% values of %2%") % std::size(vals) % type_name<T>()).str()};
 }
 
-template <typename T, size_t Begin = 1, size_t End = 10000, typename Generator>
+template <typename T, size_t Begin = 1, size_t End = 10001, typename Generator>
 CodecTestParam generateParam(Generator gen, const char* gen_name)
 {
     static_assert (End >= Begin, "End must be not less than Begin");
@@ -181,8 +216,8 @@ CodecTestParam generateParam(Generator gen, const char* gen_name)
         write_pos += sizeof(v);
     }
 
-    return CodecTestParam{std::move(data), sizeof(T),
-                (boost::format("%1% from %2% (%3% => %4%)") % type_name<T>() % gen_name % Begin % End).str()};
+    return CodecTestParam{type_name<T>(), std::move(data), sizeof(T), DEFAULT_MIN_COMPRESSION_RATIO,
+                (boost::format("%1% values of %2% from %3%") % (End - Begin) % type_name<T>() % gen_name).str()};
 }
 
 void TestTranscoding(ICompressionCodec * codec, const CodecTestParam & param)
@@ -216,6 +251,13 @@ void TestTranscoding(ICompressionCodec * codec, const CodecTestParam & param)
         default:
             FAIL() << "Invalid data_byte_size: " << param.data_byte_size;
     }
+    const auto header_size = codec->getHeaderSize();
+    const auto compression_ratio = (encoded_size - header_size) / (source_data.size() * 1.0);
+
+    ASSERT_LE(compression_ratio, param.min_compression_ratio)
+            << "\n\tdecoded size: " << source_data.size()
+            << "\n\tencoded size: " << encoded_size
+            << "(no header: " << encoded_size - header_size << ")";
 }
 
 class CodecTest : public ::testing::TestWithParam<CodecTestParam>
@@ -230,19 +272,33 @@ public:
 
 TEST_P(CodecTest, DoubleDelta)
 {
-    const auto & param = GetParam();
+    auto param = GetParam();
     auto codec = std::make_unique<CompressionCodecDoubleDelta>(param.data_byte_size);
+    if (param.type_name == type_name<Float32>() || param.type_name == type_name<Float64>())
+    {
+        // dd doesn't work great with many cases of integers and may result in very poor compression rate.
+        param.min_compression_ratio *= 1.5;
+    }
 
     TestTranscoding(codec.get(), param);
 }
 
 TEST_P(CodecTest, Gorilla)
 {
-    const auto & param = GetParam();
+    auto param = GetParam();
     auto codec = std::make_unique<CompressionCodecGorilla>(param.data_byte_size);
+    if (param.type_name == type_name<UInt32>() || param.type_name == type_name<Int32>()
+            || param.type_name == type_name<UInt64>() || param.type_name == type_name<Int64>())
+    {
+        // gorilla doesn't work great with many cases of integers and may result in very poor compression rate.
+        param.min_compression_ratio *= 1.5;
+    }
 
     TestTranscoding(codec.get(), param);
 }
+
+// Here we use generators to produce test payload for codecs.
+// Generator is a callable that should produce output value of the same type as input value.
 
 auto SameValueGenerator = [](auto value)
 {
@@ -261,30 +317,44 @@ auto SequentialGenerator = [](auto stride = 1)
     };
 };
 
+// Generator that helps debugging output of other generators
+// by logging every output value alongside iteration index and input.
+//auto LoggingProxyGenerator = [](auto other_generator, const char * name, std::ostream & ostr, const int limit = std::numeric_limits<int>::max())
+//{
+//    ostr << "\n\nValues from " << name << ":\n";
+//    auto count = std::make_shared<int>(0);
+//    return [&, count](auto i)
+//    {
+//        using ValueType = decltype(i);
+//        const auto ret = static_cast<ValueType>(other_generator(i));
+//        if (++(*count) < limit)
+//        {
+//            ostr << "\t" << *count << " : " << i << " => " << ret << "\n";
+//        }
+
+//        return ret;
+//    };
+//};
+
 template <typename T>
 struct MonotonicGenerator
 {
     MonotonicGenerator(T stride = 1, size_t max_step = 10)
-        : prev_value{},
+        : prev_value(0),
           stride(stride),
           max_step(max_step)
     {}
 
     template <typename U>
-    U operator()(U i)
+    U operator()(U)
     {
-        if (!prev_value.has_value())
-        {
-            prev_value = i * stride;
-        }
-
-        const U result = *prev_value + static_cast<T>(stride * (rand() % max_step));
+        const U result = prev_value + static_cast<T>(stride * (rand() % max_step));
 
         prev_value = result;
         return result;
     }
 
-    std::optional<T> prev_value;
+    T prev_value;
     const T stride;
     const size_t max_step;
 };
@@ -301,24 +371,44 @@ auto MinMaxGenerator = [](auto i)
     }
 };
 
-auto RandomGenerator = [](auto i) {return static_cast<decltype(i)>(rand());};
+template <typename T>
+struct RandomGenerator
+{
+    RandomGenerator(T seed = 0, T value_cap = std::numeric_limits<T>::max())
+        : e(seed),
+          value_cap(value_cap)
+    {
+    }
+
+    template <typename U>
+    U operator()(U i)
+    {
+        return static_cast<decltype(i)>(distribution(e) % value_cap);
+    }
+
+private:
+    std::default_random_engine e;
+    std::uniform_int_distribution<T> distribution;
+    const T value_cap;
+};
 
 auto RandomishGenerator = [](auto i)
 {
     return static_cast<decltype(i)>(sin(static_cast<double>(i) * i) * i);
 };
 
-INSTANTIATE_TEST_CASE_P(Basic,
+// helper macro to produce human-friendly test case name
+#define G(generator) generator, #generator
+
+INSTANTIATE_TEST_CASE_P(Mixed,
     CodecTest,
     ::testing::Values(
-        makeParam<UInt32>(1, 2, 3, 4),
-        makeParam<UInt64>(1, 2, 3, 4),
-        makeParam<Float32>(1.1, 2.2, 3.3, 4.4),
-        makeParam<Float64>(1.1, 2.2, 3.3, 4.4)
+        generateParam<Int32,  1, 3>(G(MinMaxGenerator)) + generateParam<Int32,  1, 11>(G(SequentialGenerator(1))).setRatio(1),
+        generateParam<UInt32, 1, 3>(G(MinMaxGenerator)) + generateParam<UInt32, 1, 11>(G(SequentialGenerator(1))).setRatio(1),
+        generateParam<Int64,  1, 3>(G(MinMaxGenerator)) + generateParam<Int64,  1, 11>(G(SequentialGenerator(1))).setRatio(1),
+        generateParam<UInt64, 1, 3>(G(MinMaxGenerator)) + generateParam<UInt64, 1, 11>(G(SequentialGenerator(1))).setRatio(1)
     ),
 );
-
-#define G(generator) generator, #generator
 
 INSTANTIATE_TEST_CASE_P(Same,
     CodecTest,
@@ -359,18 +449,20 @@ INSTANTIATE_TEST_CASE_P(Monotonic,
 INSTANTIATE_TEST_CASE_P(Random,
     CodecTest,
     ::testing::Values(
-        generateParam<UInt32>(G(RandomGenerator)),
-        generateParam<UInt64>(G(RandomGenerator))
+        generateParam<UInt32>(G(RandomGenerator<UInt32>(0, 1000'000'000))).setRatio(1.2),
+        generateParam<UInt64>(G(RandomGenerator<UInt64>(0, 1000'000'000))).setRatio(1.1)
     ),
 );
 
-INSTANTIATE_TEST_CASE_P(RandomLike,
+INSTANTIATE_TEST_CASE_P(Randomish,
     CodecTest,
     ::testing::Values(
-        generateParam<Int32>(G(RandomishGenerator)),
-        generateParam<Int64>(G(RandomishGenerator)),
-        generateParam<Float32>(G(RandomishGenerator)),
-        generateParam<Float64>(G(RandomishGenerator))
+        generateParam<Int32>(G(RandomishGenerator)).setRatio(1.1),
+        generateParam<Int64>(G(RandomishGenerator)).setRatio(1.1),
+        generateParam<UInt32>(G(RandomishGenerator)).setRatio(1.1),
+        generateParam<UInt64>(G(RandomishGenerator)).setRatio(1.1),
+        generateParam<Float32>(G(RandomishGenerator)).setRatio(1.1),
+        generateParam<Float64>(G(RandomishGenerator)).setRatio(1.1)
     ),
 );
 

--- a/dbms/src/IO/BitHelpers.h
+++ b/dbms/src/IO/BitHelpers.h
@@ -150,7 +150,6 @@ public:
 
             const UInt64 mask = maskLowBits<UInt64>(to_write);
             v &= mask;
-//            assert(v <= 255);
 
             bits_buffer <<= to_write;
             bits_buffer |= v;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
 * Fixed DoubleDelta encoding of Int64 for large DD values.
 * Improved DoubleDelta encoding for random data for Int32.
 * Improved test coverage for codecs.
...

Detailed description (optional):
...
