### PR TITLE
Fixed error with query_id printing

### DIFF
--- a/dbms/src/Interpreters/ThreadStatusExt.cpp
+++ b/dbms/src/Interpreters/ThreadStatusExt.cpp
@@ -29,6 +29,7 @@ namespace ErrorCodes
 void ThreadStatus::attachQueryContext(Context & query_context_)
 {
     query_context = &query_context_;
+    query_id = query_context->getCurrentQueryId();
     if (!global_context)
         global_context = &query_context->getGlobalContext();
 
@@ -270,7 +271,7 @@ void CurrentThread::attachQueryContext(Context & query_context)
 {
     if (unlikely(!current_thread))
         return;
-    return current_thread->attachQueryContext(query_context);
+    current_thread->attachQueryContext(query_context);
 }
 
 void CurrentThread::finalizePerformanceCounters()

--- a/dbms/src/Interpreters/ThreadStatusExt.cpp
+++ b/dbms/src/Interpreters/ThreadStatusExt.cpp
@@ -32,8 +32,6 @@ void ThreadStatus::attachQueryContext(Context & query_context_)
     if (!global_context)
         global_context = &query_context->getGlobalContext();
 
-    query_id = query_context->getCurrentQueryId();
-
     if (thread_group)
     {
         std::lock_guard lock(thread_group->mutex);
@@ -105,6 +103,9 @@ void ThreadStatus::attachQuery(const ThreadGroupStatusPtr & thread_group_, bool 
         /// NOTE: A thread may be attached multiple times if it is reused from a thread pool.
         thread_group->thread_numbers.emplace_back(thread_number);
     }
+
+    if (query_context)
+        query_id = query_context->getCurrentQueryId();
 
 #if defined(__linux__)
     /// Set "nice" value if required.

--- a/dbms/tests/queries/0_stateless/00971_query_id_in_logs.sh
+++ b/dbms/tests/queries/0_stateless/00971_query_id_in_logs.sh
@@ -6,4 +6,4 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 set -e
 
 # No log lines without query id
-$CLICKHOUSE_CLIENT --send_logs_level=trace --query_id=hello --query="SELECT count() FROM numbers(10)" 2>&1 | grep -vF ' {hello} ' | grep -P '<\w+>'
+$CLICKHOUSE_CLIENT --send_logs_level=trace --query_id=hello --query="SELECT count() FROM numbers(10)" 2>&1 | grep -vF ' {hello} ' | grep -P '<\w+>' ||:

--- a/dbms/tests/queries/0_stateless/00971_query_id_in_logs.sh
+++ b/dbms/tests/queries/0_stateless/00971_query_id_in_logs.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. $CURDIR/../shell_config.sh
+
+set -e
+
+# No log lines without query id
+$CLICKHOUSE_CLIENT --send_logs_level=trace --query_id=hello --query="SELECT count() FROM numbers(10)" 2>&1 | grep -vF ' {hello} ' | grep -P '<\w+>'


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Query id was not printed in logs for some threads.