### PR TITLE
Fix bug client version which is able to read additional progress fiel…

### DIFF
--- a/dbms/src/Core/Defines.h
+++ b/dbms/src/Core/Defines.h
@@ -56,7 +56,7 @@
 
 #define DBMS_MIN_REVISION_WITH_LOW_CARDINALITY_TYPE 54405
 
-#define DBMS_MIN_REVISION_WITH_CLIENT_WRITE_INFO 54421
+#define DBMS_MIN_REVISION_WITH_CLIENT_WRITE_INFO 54420
 
 /// Version of ClickHouse TCP protocol. Set to git tag with latest protocol change.
 #define DBMS_TCP_PROTOCOL_VERSION 54226

--- a/dbms/tests/integration/test_old_versions_client/test.py
+++ b/dbms/tests/integration/test_old_versions_client/test.py
@@ -11,13 +11,14 @@ node18_14 = cluster.add_instance('node18_14', image='yandex/clickhouse-server:18
 node19_1 = cluster.add_instance('node19_1', image='yandex/clickhouse-server:19.1.16', with_installed_binary=True)
 node19_4 = cluster.add_instance('node19_4', image='yandex/clickhouse-server:19.4.5.35', with_installed_binary=True)
 node19_6 = cluster.add_instance('node19_6', image='yandex/clickhouse-server:19.6.3.18', with_installed_binary=True)
+node19_8 = cluster.add_instance('node19_8', image='yandex/clickhouse-server:19.8.3.8', with_installed_binary=True)
 node_new = cluster.add_instance('node_new')
 
 @pytest.fixture(scope="module")
 def setup_nodes():
     try:
         cluster.start()
-        for n in (node18_14, node19_1, node19_4, node19_6, node_new):
+        for n in (node18_14, node19_1, node19_4, node19_6, node19_8, node_new):
             n.query('''CREATE TABLE test_table (id UInt32, value UInt64) ENGINE = MergeTree() ORDER BY tuple()''')
 
         yield cluster
@@ -29,7 +30,7 @@ def query_from_one_node_to_another(client_node, server_node, query):
     client_node.exec_in_container(["bash", "-c", "/usr/bin/clickhouse client --host {} --query '{}'".format(server_node.name, query)])
 
 def test_client_from_different_versions(setup_nodes):
-    old_nodes = (node18_14, node19_1, node19_4, node19_6,)
+    old_nodes = (node18_14, node19_1, node19_4, node19_6, node19_8)
     # from new to old
     for n in old_nodes:
         query_from_one_node_to_another(node_new, n, "INSERT INTO test_table VALUES (1, 1)")


### PR DESCRIPTION
…ds from server

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):

- Bug Fix

Short description (up to few sentences):
Fix client version number which is able to read additional progress data from the server. Greater version leads to incompatibility between 19.8 and 19.9+ versions.