### PR TITLE
Clear Kafka's buffer if an invalid message is found.

### DIFF
--- a/dbms/src/IO/DelimitedReadBuffer.h
+++ b/dbms/src/IO/DelimitedReadBuffer.h
@@ -21,6 +21,10 @@ public:
         return typeid_cast<BufferType *>(buffer.get());
     }
 
+    void reset(){
+        BufferBase::set(nullptr, 0, 0);
+    }
+
 protected:
     // XXX: don't know how to guarantee that the next call to this method is done after we read all previous data.
     bool nextImpl() override

--- a/dbms/src/IO/DelimitedReadBuffer.h
+++ b/dbms/src/IO/DelimitedReadBuffer.h
@@ -21,7 +21,8 @@ public:
         return typeid_cast<BufferType *>(buffer.get());
     }
 
-    void reset(){
+    void reset()
+    {
         BufferBase::set(nullptr, 0, 0);
     }
 

--- a/dbms/src/Storages/Kafka/KafkaBlockInputStream.cpp
+++ b/dbms/src/Storages/Kafka/KafkaBlockInputStream.cpp
@@ -27,8 +27,10 @@ KafkaBlockInputStream::~KafkaBlockInputStream()
     if (!claimed)
         return;
 
-    if (broken)
+    if (broken){
         buffer->subBufferAs<ReadBufferFromKafkaConsumer>()->unsubscribe();
+        buffer->reset();
+    }
 
     storage.pushBuffer(buffer);
 }

--- a/dbms/src/Storages/Kafka/KafkaBlockInputStream.cpp
+++ b/dbms/src/Storages/Kafka/KafkaBlockInputStream.cpp
@@ -27,7 +27,8 @@ KafkaBlockInputStream::~KafkaBlockInputStream()
     if (!claimed)
         return;
 
-    if (broken){
+    if (broken)
+    {
         buffer->subBufferAs<ReadBufferFromKafkaConsumer>()->unsubscribe();
         buffer->reset();
     }

--- a/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
+++ b/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
@@ -74,6 +74,11 @@ void ReadBufferFromKafkaConsumer::subscribe(const Names & topics)
 void ReadBufferFromKafkaConsumer::unsubscribe()
 {
     LOG_TRACE(log, "Re-joining claimed consumer after failure");
+
+    messages.clear();
+    current = messages.begin();
+    BufferBase::set(nullptr, 0, 0);
+
     consumer->unsubscribe();
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category:
- Bug Fix

Short description:

Clearing the data buffer from the previous read operation that was completed with an error

Detailed description:

Problems may be due to incorrectly formed messages in the Kafka stream or due to inconsistency of the message scheme with the table schema in the database (such as inconsistency between the types of UInt and Int)
