### PR TITLE
Do not access shared arenas in aggregate function columns.

### DIFF
--- a/dbms/src/Columns/ColumnAggregateFunction.h
+++ b/dbms/src/Columns/ColumnAggregateFunction.h
@@ -17,7 +17,8 @@ namespace DB
 
 class Arena;
 using ArenaPtr = std::shared_ptr<Arena>;
-using Arenas = std::vector<ArenaPtr>;
+using ConstArenaPtr = std::shared_ptr<const Arena>;
+using ConstArenas = std::vector<ConstArenaPtr>;
 
 
 /** Column of states of aggregate functions.
@@ -52,8 +53,15 @@ public:
 private:
     friend class COWHelper<IColumn, ColumnAggregateFunction>;
 
-    /// Memory pools. Aggregate states are allocated from them.
-    Arenas arenas;
+    /// Arenas used by function states that are created elsewhere. We own these
+    /// arenas in the sense of extending their lifetime, but do not modify them.
+    /// Even reading these arenas is unsafe, because they may be shared with
+    /// other data blocks and modified by other threads concurrently.
+    ConstArenas foreign_arenas;
+
+    /// Arena for allocating the internals of function states created by current
+    /// column (e.g., when inserting new states).
+    ArenaPtr my_arena;
 
     /// Used for destroying states and for finalization of values.
     AggregateFunctionPtr func;
@@ -68,12 +76,7 @@ private:
     ColumnAggregateFunction() {}
 
     /// Create a new column that has another column as a source.
-    MutablePtr createView() const
-    {
-        MutablePtr res = create(func, arenas);
-        res->src = getPtr();
-        return res;
-    }
+    MutablePtr createView() const;
 
     /// If we have another column as a source (owner of data), copy all data to ourself and reset source.
     /// This is needed before inserting new elements, because we must own these elements (to destroy them in destructor),
@@ -85,15 +88,14 @@ private:
     {
     }
 
-    ColumnAggregateFunction(const AggregateFunctionPtr & func_, const Arenas & arenas_)
-        : arenas(arenas_), func(func_)
+    ColumnAggregateFunction(const AggregateFunctionPtr & func_,
+                            const ConstArenas & arenas_)
+        : foreign_arenas(arenas_), func(func_)
     {
     }
 
-    ColumnAggregateFunction(const ColumnAggregateFunction & src_)
-        : arenas(src_.arenas), func(src_.func), src(src_.getPtr()), data(src_.data.begin(), src_.data.end())
-    {
-    }
+
+    ColumnAggregateFunction(const ColumnAggregateFunction & src_);
 
     String getTypeString() const;
 
@@ -109,7 +111,7 @@ public:
     AggregateFunctionPtr getAggregateFunction() const { return func; }
 
     /// Take shared ownership of Arena, that holds memory for states of aggregate functions.
-    void addArena(ArenaPtr arena_);
+    void addArena(ConstArenaPtr arena_);
 
     /** Transform column with states of aggregate functions to column with final result values.
       */

--- a/dbms/src/DataStreams/TotalsHavingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/TotalsHavingBlockInputStream.cpp
@@ -24,32 +24,15 @@ TotalsHavingBlockInputStream::TotalsHavingBlockInputStream(
 
     /// Initialize current totals with initial state.
 
-    arena = std::make_shared<Arena>();
     Block source_header = children.at(0)->getHeader();
 
     current_totals.reserve(source_header.columns());
     for (const auto & elem : source_header)
     {
-        if (const ColumnAggregateFunction * column = typeid_cast<const ColumnAggregateFunction *>(elem.column.get()))
-        {
-            /// Create ColumnAggregateFunction with initial aggregate function state.
-
-            IAggregateFunction * function = column->getAggregateFunction().get();
-            auto target = ColumnAggregateFunction::create(column->getAggregateFunction(), Arenas(1, arena));
-            AggregateDataPtr data = arena->alignedAlloc(function->sizeOfData(), function->alignOfData());
-            function->create(data);
-            target->getData().push_back(data);
-            current_totals.emplace_back(std::move(target));
-        }
-        else
-        {
-
-            /// Not an aggregate function state. Just create a column with default value.
-
-            MutableColumnPtr new_column = elem.type->createColumn();
-            elem.type->insertDefaultInto(*new_column);
-            current_totals.emplace_back(std::move(new_column));
-        }
+        // Create a column with default value
+        MutableColumnPtr new_column = elem.type->createColumn();
+        elem.type->insertDefaultInto(*new_column);
+        current_totals.emplace_back(std::move(new_column));
     }
 }
 
@@ -161,34 +144,35 @@ Block TotalsHavingBlockInputStream::readImpl()
 }
 
 
-void TotalsHavingBlockInputStream::addToTotals(const Block & block, const IColumn::Filter * filter)
+void TotalsHavingBlockInputStream::addToTotals(const Block & source_block, const IColumn::Filter * filter)
 {
-    for (size_t i = 0, num_columns = block.columns(); i < num_columns; ++i)
+    for (size_t i = 0, num_columns = source_block.columns(); i < num_columns; ++i)
     {
-        const ColumnWithTypeAndName & current = block.getByPosition(i);
-
-        if (const ColumnAggregateFunction * column = typeid_cast<const ColumnAggregateFunction *>(current.column.get()))
+        const auto * source_column = typeid_cast<const ColumnAggregateFunction *>(
+                    source_block.getByPosition(i).column.get());
+        if (!source_column)
         {
-            auto & target = typeid_cast<ColumnAggregateFunction &>(*current_totals[i]);
-            IAggregateFunction * function = target.getAggregateFunction().get();
-            AggregateDataPtr data = target.getData()[0];
+            continue;
+        }
 
-            /// Accumulate all aggregate states into that value.
+        auto & totals_column = static_cast<ColumnAggregateFunction &>(*current_totals[i]);
+        assert(totals_column.size() == 1);
 
-            const ColumnAggregateFunction::Container & vec = column->getData();
-            size_t size = vec.size();
+        /// Accumulate all aggregate states from a column of a source block into
+        /// the corresponding totals column.
+        const auto & vec = source_column->getData();
+        size_t size = vec.size();
 
-            if (filter)
-            {
-                for (size_t j = 0; j < size; ++j)
-                    if ((*filter)[j])
-                        function->merge(data, vec[j], arena.get());
-            }
-            else
-            {
-                for (size_t j = 0; j < size; ++j)
-                    function->merge(data, vec[j], arena.get());
-            }
+        if (filter)
+        {
+            for (size_t j = 0; j < size; ++j)
+                if ((*filter)[j])
+                    totals_column.insertMergeFrom(vec[j]);
+        }
+        else
+        {
+            for (size_t j = 0; j < size; ++j)
+                totals_column.insertMergeFrom(vec[j]);
         }
     }
 }

--- a/dbms/src/DataStreams/TotalsHavingBlockInputStream.h
+++ b/dbms/src/DataStreams/TotalsHavingBlockInputStream.h
@@ -54,8 +54,6 @@ private:
 
     /// Here, total values are accumulated. After the work is finished, they will be placed in IBlockInputStream::totals.
     MutableColumns current_totals;
-    /// Arena for aggregate function states in totals.
-    ArenaPtr arena;
 
     /// If filter == nullptr - add all rows. Otherwise, only the rows that pass the filter (HAVING).
     void addToTotals(const Block & block, const IColumn::Filter * filter);

--- a/dbms/src/Processors/Transforms/TotalsHavingTransform.cpp
+++ b/dbms/src/Processors/Transforms/TotalsHavingTransform.cpp
@@ -49,7 +49,6 @@ TotalsHavingTransform::TotalsHavingTransform(
     , totals_mode(totals_mode_)
     , auto_include_threshold(auto_include_threshold_)
     , final(final_)
-    , arena(std::make_shared<Arena>())
 {
     if (!filter_column_name.empty())
         filter_column_pos = outputs.front().getHeader().getPositionByName(filter_column_name);
@@ -71,25 +70,9 @@ TotalsHavingTransform::TotalsHavingTransform(
     current_totals.reserve(header.columns());
     for (const auto & elem : header)
     {
-        if (const auto * column = typeid_cast<const ColumnAggregateFunction *>(elem.column.get()))
-        {
-            /// Create ColumnAggregateFunction with initial aggregate function state.
-
-            IAggregateFunction * function = column->getAggregateFunction().get();
-            auto target = ColumnAggregateFunction::create(column->getAggregateFunction(), Arenas(1, arena));
-            AggregateDataPtr data = arena->alignedAlloc(function->sizeOfData(), function->alignOfData());
-            function->create(data);
-            target->getData().push_back(data);
-            current_totals.emplace_back(std::move(target));
-        }
-        else
-        {
-            /// Not an aggregate function state. Just create a column with default value.
-
-            MutableColumnPtr new_column = elem.type->createColumn();
-            elem.type->insertDefaultInto(*new_column);
-            current_totals.emplace_back(std::move(new_column));
-        }
+        MutableColumnPtr new_column = elem.type->createColumn();
+        elem.type->insertDefaultInto(*new_column);
+        current_totals.emplace_back(std::move(new_column));
     }
 }
 
@@ -225,12 +208,11 @@ void TotalsHavingTransform::addToTotals(const Chunk & chunk, const IColumn::Filt
 
         if (const auto * column = typeid_cast<const ColumnAggregateFunction *>(current.get()))
         {
-            auto & target = typeid_cast<ColumnAggregateFunction &>(*current_totals[col]);
-            IAggregateFunction * function = target.getAggregateFunction().get();
-            AggregateDataPtr data = target.getData()[0];
+            auto & totals_column = typeid_cast<ColumnAggregateFunction &>(*current_totals[col]);
+            assert(totals_column.size() == 1);
 
-            /// Accumulate all aggregate states into that value.
-
+            /// Accumulate all aggregate states from a column of a source chunk into
+            /// the corresponding totals column.
             const ColumnAggregateFunction::Container & vec = column->getData();
             size_t size = vec.size();
 
@@ -238,12 +220,12 @@ void TotalsHavingTransform::addToTotals(const Chunk & chunk, const IColumn::Filt
             {
                 for (size_t row = 0; row < size; ++row)
                     if ((*filter)[row])
-                        function->merge(data, vec[row], arena.get());
+                        totals_column.insertMergeFrom(vec[row]);
             }
             else
             {
                 for (size_t row = 0; row < size; ++row)
-                    function->merge(data, vec[row], arena.get());
+                    totals_column.insertMergeFrom(vec[row]);
             }
         }
     }

--- a/dbms/src/Processors/Transforms/TotalsHavingTransform.h
+++ b/dbms/src/Processors/Transforms/TotalsHavingTransform.h
@@ -66,8 +66,6 @@ private:
 
     /// Here, total values are accumulated. After the work is finished, they will be placed in IBlockInputStream::totals.
     MutableColumns current_totals;
-    /// Arena for aggregate function states in totals.
-    ArenaPtr arena;
 };
 
 void finalizeChunk(Chunk & chunk);


### PR DESCRIPTION
These arenas may be updated concurrently, so it is unsafe to
access them, as illustrated by issue #4402. Store them separately
and use a different arena for the updates. Change some callers
to accomodate for this.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Closes #4402 