### PR TITLE
AsynchronousMetrics: add a metric for number of databases and total number of tables.

### DIFF
--- a/dbms/src/Interpreters/AsynchronousMetrics.cpp
+++ b/dbms/src/Interpreters/AsynchronousMetrics.cpp
@@ -159,10 +159,14 @@ void AsynchronousMetrics::update()
 
         size_t max_part_count_for_partition = 0;
 
+        size_t number_of_databases = databases.size();
+        size_t total_number_of_tables = 0;
+
         for (const auto & db : databases)
         {
             for (auto iterator = db.second->getIterator(context); iterator->isValid(); iterator->next())
             {
+                ++total_number_of_tables;
                 auto & table = iterator->table();
                 StorageMergeTree * table_merge_tree = dynamic_cast<StorageMergeTree *>(table.get());
                 StorageReplicatedMergeTree * table_replicated_merge_tree = dynamic_cast<StorageReplicatedMergeTree *>(table.get());
@@ -213,6 +217,9 @@ void AsynchronousMetrics::update()
         set("ReplicasMaxRelativeDelay", max_relative_delay);
 
         set("MaxPartCountForPartition", max_part_count_for_partition);
+
+        set("NumberOfDatabases", number_of_databases);
+        set("TotalNumberOfTables", total_number_of_tables);
     }
 
 #if USE_TCMALLOC

--- a/dbms/src/Interpreters/AsynchronousMetrics.cpp
+++ b/dbms/src/Interpreters/AsynchronousMetrics.cpp
@@ -219,7 +219,7 @@ void AsynchronousMetrics::update()
         set("MaxPartCountForPartition", max_part_count_for_partition);
 
         set("NumberOfDatabases", number_of_databases);
-        set("TotalNumberOfTables", total_number_of_tables);
+        set("NumberOfTables", total_number_of_tables);
     }
 
 #if USE_TCMALLOC


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- New Feature

Short description (up to few sentences):
Two metrics added to the system.asynchronous table.

Use case.
DBA will look at these metrics for servers with a huge number of tables.

#4290