### PR TITLE
Do not show virtual columns in DESCRIBE TABLE

### DIFF
--- a/dbms/src/Interpreters/InterpreterDescribeQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterDescribeQuery.cpp
@@ -101,6 +101,9 @@ BlockInputStreamPtr InterpreterDescribeQuery::executeImpl()
 
     for (const auto & column : columns)
     {
+        if (column.is_virtual)
+            continue;
+        
         res_columns[0]->insert(column.name);
         res_columns[1]->insert(column.type->getName());
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
After introduction of virtual columns in IStorage interface DESCRIBE TABLE started to show them too, it was unexpected and now is fixed.