### PR TITLE
fix clang build with certain toolchain

### DIFF
--- a/dbms/src/Common/TaskStatsInfoGetter.cpp
+++ b/dbms/src/Common/TaskStatsInfoGetter.cpp
@@ -133,7 +133,7 @@ struct NetlinkMessage
         if (header.nlmsg_type == NLMSG_ERROR)
             throw Exception("Can't receive Netlink response: error " + std::to_string(error.error), ErrorCodes::NETLINK_ERROR);
 
-        if (!is_nlmsg_ok((&header), bytes_received))
+        if (!is_nlmsg_ok(&header, bytes_received))
             throw Exception("Can't receive Netlink response: wrong number of bytes received", ErrorCodes::NETLINK_ERROR);
     }
 };

--- a/dbms/src/Common/TaskStatsInfoGetter.cpp
+++ b/dbms/src/Common/TaskStatsInfoGetter.cpp
@@ -34,6 +34,11 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
+// Replace NLMSG_OK with explicit casts since that system macro contains signedness bugs which are not going to be fixed.
+static inline bool is_nlmsg_ok(const struct nlmsghdr * const nlh, const ssize_t len)
+{
+    return len >= static_cast<ssize_t>(sizeof(*nlh)) && nlh->nlmsg_len >= sizeof(*nlh) && static_cast<size_t>(len) >= nlh->nlmsg_len;
+}
 
 namespace
 {
@@ -128,7 +133,7 @@ struct NetlinkMessage
         if (header.nlmsg_type == NLMSG_ERROR)
             throw Exception("Can't receive Netlink response: error " + std::to_string(error.error), ErrorCodes::NETLINK_ERROR);
 
-        if (!NLMSG_OK((&header), bytes_received))
+        if (!is_nlmsg_ok((&header), bytes_received))
             throw Exception("Can't receive Netlink response: wrong number of bytes received", ErrorCodes::NETLINK_ERROR);
     }
 };


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

work around an old kernel header bug. Or else
```
/home/amos/git/chorigin/dbms/src/Common/TaskStatsInfoGetter.cpp:131:14: error: comparison of integers of different signs: 'ssize_t' (aka 'long') and 'unsigned long' [-Werror,-Wsign-compare]
        if (!NLMSG_OK((&header), bytes_received))
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/amos/gentoo/usr/include/linux/netlink.h:97:34: note: expanded from macro 'NLMSG_OK'
#define NLMSG_OK(nlh,len) ((len) >= sizeof(struct nlmsghdr) && \
                            ~~~  ^  ~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```