### PR TITLE
support reading from HA mode HDFS

### DIFF
--- a/dbms/src/IO/HDFSCommon.cpp
+++ b/dbms/src/IO/HDFSCommon.cpp
@@ -16,7 +16,7 @@ HDFSBuilderPtr createHDFSBuilder(const Poco::URI & uri)
     auto & host = uri.getHost();
     auto port = uri.getPort();
     auto & path = uri.getPath();
-    if (host.empty() || port == 0 || path.empty())
+    if (host.empty() || path.empty())
         throw Exception("Illegal HDFS URI: " + uri.toString(), ErrorCodes::BAD_ARGUMENTS);
 
     HDFSBuilderPtr builder(hdfsNewBuilder());


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):

- Bug Fix

Short description (up to few sentences):
the driver libhdfs3 can support HA mode. When the uri doesn't contain
port num, the libhdfs3 will handle it in HA mode, treat the uri as
nameservice name and read the real host and port from configuration file
as the origin Java client.
the default configuration file is hdfs-client.xml in the working
directory, it also can be set in env variable "LIBHDFS3_CONF".
the format of the configuration file is same with hdfs-site.xml.

...

Detailed description (optional):

Fixes #6061