### PR TITLE
Add verification of the length of the protobuf message

### DIFF
--- a/dbms/src/Formats/ProtobufReader.cpp
+++ b/dbms/src/Formats/ProtobufReader.cpp
@@ -67,7 +67,9 @@ bool ProtobufReader::SimpleReader::startMessage()
         if (unlikely(in.eof()))
             return false;
         size_t size_of_message = readVarint();
-        current_message_end = cursor + size_of_message;
+        if(size_of_message == 0)
+            unknownFormat();
+        current_message_end = root_message_end = cursor + size_of_message;
     }
     else
     {
@@ -375,6 +377,10 @@ void ProtobufReader::SimpleReader::ignoreGroup()
     }
 }
 
+[[noreturn]] void ProtobufReader::SimpleReader::throwUnknownFormat() const
+{
+    unknownFormat();
+}
 
 // Implementation for a converter from any protobuf field type to any DB data type.
 class ProtobufReader::ConverterBaseImpl : public ProtobufReader::IConverter

--- a/dbms/src/Formats/ProtobufReader.cpp
+++ b/dbms/src/Formats/ProtobufReader.cpp
@@ -67,7 +67,7 @@ bool ProtobufReader::SimpleReader::startMessage()
         if (unlikely(in.eof()))
             return false;
         size_t size_of_message = readVarint();
-        if(size_of_message == 0)
+        if (size_of_message == 0)
             unknownFormat();
         current_message_end = root_message_end = cursor + size_of_message;
     }

--- a/dbms/src/Formats/ProtobufReader.cpp
+++ b/dbms/src/Formats/ProtobufReader.cpp
@@ -69,7 +69,8 @@ bool ProtobufReader::SimpleReader::startMessage()
         size_t size_of_message = readVarint();
         if (size_of_message == 0)
             unknownFormat();
-        current_message_end = root_message_end = cursor + size_of_message;
+        current_message_end = cursor + size_of_message;
+        root_message_end = current_message_end;
     }
     else
     {

--- a/dbms/src/Formats/ProtobufReader.h
+++ b/dbms/src/Formats/ProtobufReader.h
@@ -109,7 +109,7 @@ private:
         }
 
     private:
-        void readBinary(void* data, size_t size);
+        void readBinary(void * data, size_t size);
         void ignore(UInt64 num_bytes);
         void moveCursorBackward(UInt64 num_bytes);
 

--- a/dbms/src/Formats/ProtobufReader.h
+++ b/dbms/src/Formats/ProtobufReader.h
@@ -97,6 +97,7 @@ private:
         bool readUInt(UInt64 & value);
         template<typename T> bool readFixed(T & value);
         bool readStringInto(PaddedPODArray<UInt8> & str);
+
         bool ALWAYS_INLINE maybeCanReadValue() const
         {
             if (field_end == REACHED_END)

--- a/dbms/src/Formats/ProtobufReader.h
+++ b/dbms/src/Formats/ProtobufReader.h
@@ -97,7 +97,15 @@ private:
         bool readUInt(UInt64 & value);
         template<typename T> bool readFixed(T & value);
         bool readStringInto(PaddedPODArray<UInt8> & str);
-        bool ALWAYS_INLINE maybeCanReadValue() const { return field_end != REACHED_END; }
+        bool ALWAYS_INLINE maybeCanReadValue() const
+        {
+            if (field_end == REACHED_END)
+                return false;
+            if (cursor < root_message_end)
+                return true;
+
+            throwUnknownFormat();
+        }
 
     private:
         void readBinary(void* data, size_t size);
@@ -119,6 +127,8 @@ private:
         void ignoreVarint();
         void ignoreGroup();
 
+        [[noreturn]] void throwUnknownFormat() const;
+
         static constexpr UInt64 REACHED_END = 0;
 
         ReadBuffer & in;
@@ -126,6 +136,8 @@ private:
         std::vector<UInt64> parent_message_ends;
         UInt64 current_message_end;
         UInt64 field_end;
+
+        UInt64 root_message_end;
     };
 
     class IConverter


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category:
- Improvement

Short description:

Additional verification of the message length while reading data columns

Detailed description:

If the data format is broken (for example, serialization problems), then we should throw an exception if we read more bytes than specified in the message header.