### PR TITLE
Check background_task_handle before use

### DIFF
--- a/dbms/src/Storages/MergeTree/MergeTreeBlockOutputStream.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeBlockOutputStream.cpp
@@ -27,7 +27,8 @@ void MergeTreeBlockOutputStream::write(const Block & block)
         PartLog::addNewPart(storage.global_context, part, watch.elapsed());
 
         /// Initiate async merge - it will be done if it's good time for merge and if there are space in 'background_pool'.
-        storage.background_task_handle->wake();
+        if (storage.background_task_handle)
+            storage.background_task_handle->wake();
     }
 }
 

--- a/dbms/tests/integration/test_storage_kafka/test.py
+++ b/dbms/tests/integration/test_storage_kafka/test.py
@@ -174,6 +174,7 @@ def test_kafka_settings_new_syntax(kafka_cluster):
         result += instance.query('SELECT * FROM test.kafka')
         if kafka_check_result(result):
             break
+        print result
     kafka_check_result(result, True)
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Since `StorageMergeTree::background_task_handle` is initialized in `startup()` the `MergeTreeBlockOutputStream::write()` may try to use it before initialization. Just check if it is initialized.

Detailed description:
First idea was to start schedule pool only after all storages get initialized - or we can get segfault. But it doesn't work because `StorageReplicatedMergeTree::startup()` waits for some internal task event.