### PR TITLE
Fix for initial load of external dictionaries via ODBC

### DIFF
--- a/dbms/src/Dictionaries/ClickHouseDictionarySource.cpp
+++ b/dbms/src/Dictionaries/ClickHouseDictionarySource.cpp
@@ -115,8 +115,7 @@ std::string ClickHouseDictionarySource::getUpdateFieldAndDate()
     else
     {
         update_time = std::chrono::system_clock::now();
-        std::string str_time("0000-00-00 00:00:00"); ///for initial load
-        return query_builder.composeUpdateQuery(update_field, str_time);
+        return query_builder.composeLoadAllQuery();
     }
 }
 

--- a/dbms/src/Dictionaries/ExternalQueryBuilder.cpp
+++ b/dbms/src/Dictionaries/ExternalQueryBuilder.cpp
@@ -167,7 +167,7 @@ std::string ExternalQueryBuilder::composeUpdateQuery(const std::string & update_
     else
         update_query = " WHERE " + update_field + " >= '" + time_point + "'";
 
-    return out.insert(out.size() - 1, update_query); ///This is done to insert "update_query" before "out"'s semicolon
+    return out.insert(out.size() - 1, update_query); /// This is done to insert "update_query" before "out"'s semicolon
 }
 
 

--- a/dbms/src/Dictionaries/ExternalQueryBuilder.h
+++ b/dbms/src/Dictionaries/ExternalQueryBuilder.h
@@ -35,7 +35,7 @@ struct ExternalQueryBuilder
     /** Generate a query to load all data. */
     std::string composeLoadAllQuery() const;
 
-    /** Generate a query to load data after certain time point*/
+    /** Generate a query to load data after certain time point */
     std::string composeUpdateQuery(const std::string & update_field, const std::string & time_point) const;
 
     /** Generate a query to load data by set of UInt64 keys. */

--- a/dbms/src/Dictionaries/HTTPDictionarySource.cpp
+++ b/dbms/src/Dictionaries/HTTPDictionarySource.cpp
@@ -66,7 +66,6 @@ void HTTPDictionarySource::getUpdateFieldAndDate(Poco::URI & uri)
     else
     {
         update_time = std::chrono::system_clock::now();
-        uri.addQueryParameter(update_field, "0000-00-00 00:00:00");
     }
 }
 

--- a/dbms/src/Dictionaries/MySQLDictionarySource.cpp
+++ b/dbms/src/Dictionaries/MySQLDictionarySource.cpp
@@ -109,8 +109,7 @@ std::string MySQLDictionarySource::getUpdateFieldAndDate()
     else
     {
         update_time = std::chrono::system_clock::now();
-        std::string str_time("0000-00-00 00:00:00"); ///for initial load
-        return query_builder.composeUpdateQuery(update_field, str_time);
+        return query_builder.composeLoadAllQuery();
     }
 }
 

--- a/dbms/src/Dictionaries/XDBCDictionarySource.cpp
+++ b/dbms/src/Dictionaries/XDBCDictionarySource.cpp
@@ -127,12 +127,7 @@ std::string XDBCDictionarySource::getUpdateFieldAndDate()
     else
     {
         update_time = std::chrono::system_clock::now();
-
-        /// For initial load. We use at least start of unix epoch for compatibility reasons.
-        /// We use 1970-01-02 instead 1970-01-01, because 1970-01-01 00:00:00 is before unix epoch in some time zones.
-        std::string str_time("1970-01-02 00:00:00");
-
-        return query_builder.composeUpdateQuery(update_field, str_time);
+        return query_builder.composeLoadAllQuery();
     }
 }
 

--- a/dbms/src/Dictionaries/XDBCDictionarySource.cpp
+++ b/dbms/src/Dictionaries/XDBCDictionarySource.cpp
@@ -127,7 +127,11 @@ std::string XDBCDictionarySource::getUpdateFieldAndDate()
     else
     {
         update_time = std::chrono::system_clock::now();
-        std::string str_time("0000-00-00 00:00:00"); ///for initial load
+
+        /// For initial load. We use at least start of unix epoch for compatibility reasons.
+        /// We use 1970-01-02 instead 1970-01-01, because 1970-01-01 00:00:00 is before unix epoch in some time zones.
+        std::string str_time("1970-01-02 00:00:00");
+
         return query_builder.composeUpdateQuery(update_field, str_time);
     }
 }


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fixed useless and incorrect condition on update field for initial loading of external dictionaries via ODBC, MySQL, ClickHouse and HTTP. This fixes #6069 