### PR TITLE
A workaround for PHP mysqlnd extension bugs

### DIFF
--- a/dbms/src/Core/MySQLProtocol.h
+++ b/dbms/src/Core/MySQLProtocol.h
@@ -34,6 +34,7 @@ const size_t SSL_REQUEST_PAYLOAD_SIZE = 32;
 
 namespace Authentication
 {
+    const String Native = "mysql_native_password";
     const String SHA256 = "sha256_password"; /// Caching SHA2 plugin is not used because it would be possible to authenticate knowing hash from users.xml.
 }
 
@@ -285,7 +286,12 @@ public:
         result.append(1, auth_plugin_data.size());
         result.append(10, 0x0);
         result.append(auth_plugin_data.substr(AUTH_PLUGIN_DATA_PART_1_LENGTH, auth_plugin_data.size() - AUTH_PLUGIN_DATA_PART_1_LENGTH));
-        result.append(Authentication::SHA256);
+
+        // A workaround for PHP mysqlnd extension bug which occurs when sha256_password is used as a default authentication plugin.
+        // Instead of using client response for mysql_native_password plugin, the server will always generate authentication method mismatch
+        // and switch to sha256_password to simulate that mysql_native_password is used as a default plugin.
+        result.append(Authentication::Native);
+
         result.append(1, 0x0);
         return result;
     }

--- a/dbms/tests/integration/test_mysql_protocol/clients/php-mysqlnd/Dockerfile
+++ b/dbms/tests/integration/test_mysql_protocol/clients/php-mysqlnd/Dockerfile
@@ -3,5 +3,6 @@ FROM php:7.3-cli
 COPY ./client.crt client.crt
 COPY ./client.key client.key
 COPY ./test.php test.php
+COPY ./test_ssl.php test_ssl.php
 
 RUN docker-php-ext-install pdo pdo_mysql

--- a/dbms/tests/integration/test_mysql_protocol/clients/php-mysqlnd/test_ssl.php
+++ b/dbms/tests/integration/test_mysql_protocol/clients/php-mysqlnd/test_ssl.php
@@ -12,6 +12,9 @@ $options = [
     PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
     PDO::ATTR_EMULATE_PREPARES   => false,
     PDO::MYSQL_ATTR_DIRECT_QUERY => true,
+    PDO::MYSQL_ATTR_SSL_CERT     => "client.crt",
+    PDO::MYSQL_ATTR_SSL_KEY      => "client.key",
+    PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => 0,
 ];
 $pdo = new PDO($dsn, $user, $pass, $options);
 

--- a/dbms/tests/integration/test_mysql_protocol/test.py
+++ b/dbms/tests/integration/test_mysql_protocol/test.py
@@ -152,3 +152,7 @@ def test_php_client(server_address, php_container):
     code, (stdout, stderr) = php_container.exec_run('php -f test.php {host} {port} default 123 '.format(host=server_address, port=server_port), demux=True)
     assert code == 0
     assert stdout == 'tables\n'
+
+    code, (stdout, stderr) = php_container.exec_run('php -f test_ssl.php {host} {port} default 123 '.format(host=server_address, port=server_port), demux=True)
+    assert code == 0
+    assert stdout == 'tables\n'


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Improvement

Short description (up to few sentences):
A workaround for PHP mysqlnd extension bugs which occur when sha256_password is used as a default authentication plugin (described in #6031).