### PR TITLE
ISSUE-6136: Fix DB::Exception throwed by bitmapContains

### DIFF
--- a/dbms/src/Storages/MergeTree/KeyCondition.cpp
+++ b/dbms/src/Storages/MergeTree/KeyCondition.cpp
@@ -688,6 +688,9 @@ bool KeyCondition::atomFromAST(const ASTPtr & node, const Context & context, Blo
         size_t key_column_num = -1;   /// Number of a key column (inside key_column_names array)
         MonotonicFunctionsChain chain;
         std::string func_name = func->name;
+        const auto atom_it = atom_map.find(func_name);
+        if (atom_it == std::end(atom_map))
+            return false;
 
         if (args.size() == 1)
         {
@@ -772,10 +775,6 @@ bool KeyCondition::atomFromAST(const ASTPtr & node, const Context & context, Blo
                 castValueToType(key_expr_type, const_value, const_type, node);
         }
         else
-            return false;
-
-        const auto atom_it = atom_map.find(func_name);
-        if (atom_it == std::end(atom_map))
             return false;
 
         out.key_column = key_column_num;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fix issue [6136](https://github.com/yandex/ClickHouse/issues/6136)
...

Detailed description (optional):
Issue [6136](https://github.com/yandex/ClickHouse/issues/6136) is caused by previous commit of 
```
commit c9a5b3c9ab5f1617bf3913ffc0378d73c405b1b6
Author: dimarub2000 <dimarub2000@gmail.com>
Date:   Wed Jul 10 17:53:57 2019 +0300

    primary key and MergeTreeIndexFullText support for string functions
```
In function of 
```
bool KeyCondition::atomFromAST(const ASTPtr & node, const Context & context, Block & block_with_constants, RPNElement & out)
```
from `KeyCondition.cpp`

...
