### PR TITLE
Safer interface of mysqlxx::Pool

### DIFF
--- a/libs/libmysqlxx/include/mysqlxx/Pool.h
+++ b/libs/libmysqlxx/include/mysqlxx/Pool.h
@@ -72,25 +72,25 @@ public:
             return data == nullptr;
         }
 
-        operator mysqlxx::Connection & ()
+        operator mysqlxx::Connection & () &
         {
             forceConnected();
             return data->conn;
         }
 
-        operator const mysqlxx::Connection & () const
+        operator const mysqlxx::Connection & () const &
         {
             forceConnected();
             return data->conn;
         }
 
-        const mysqlxx::Connection * operator->() const
+        const mysqlxx::Connection * operator->() const &
         {
             forceConnected();
             return &data->conn;
         }
 
-        mysqlxx::Connection * operator->()
+        mysqlxx::Connection * operator->() &
         {
             forceConnected();
             return &data->conn;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Improvement

Short description (up to few sentences):
- mysqlxx::Pool::Entry should not be used as a temporary object, because it leads to UB.

Linked PR: https://nda.ya.ru/3VmRLL