### PR TITLE
Merge pull request #6026 from bopohaa/fix-kafka-unclean-stream

### DIFF
--- a/dbms/src/IO/DelimitedReadBuffer.h
+++ b/dbms/src/IO/DelimitedReadBuffer.h
@@ -21,6 +21,11 @@ public:
         return typeid_cast<BufferType *>(buffer.get());
     }
 
+    void reset()
+    {
+        BufferBase::set(nullptr, 0, 0);
+    }
+
 protected:
     // XXX: don't know how to guarantee that the next call to this method is done after we read all previous data.
     bool nextImpl() override

--- a/dbms/src/Storages/Kafka/KafkaBlockInputStream.cpp
+++ b/dbms/src/Storages/Kafka/KafkaBlockInputStream.cpp
@@ -28,7 +28,10 @@ KafkaBlockInputStream::~KafkaBlockInputStream()
         return;
 
     if (broken)
+    {
         buffer->subBufferAs<ReadBufferFromKafkaConsumer>()->unsubscribe();
+        buffer->reset();
+    }
 
     storage.pushBuffer(buffer);
 }

--- a/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
+++ b/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
@@ -74,6 +74,11 @@ void ReadBufferFromKafkaConsumer::subscribe(const Names & topics)
 void ReadBufferFromKafkaConsumer::unsubscribe()
 {
     LOG_TRACE(log, "Re-joining claimed consumer after failure");
+
+    messages.clear();
+    current = messages.begin();
+    BufferBase::set(nullptr, 0, 0);
+
     consumer->unsubscribe();
 }
 


### PR DESCRIPTION
Clear Kafka's buffer if an invalid message is found.

(cherry picked from commit 7219e167d2b4a8fb91bc576dc3551b461183054f)

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- New Feature
- Bug Fix
- Improvement
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Other

Short description (up to few sentences):

...

Detailed description (optional):

...
