### PR TITLE
Fix build under gcc-8.2

### DIFF
--- a/dbms/src/Interpreters/Aggregator.h
+++ b/dbms/src/Interpreters/Aggregator.h
@@ -120,8 +120,9 @@ private:
 template <typename Base>
 struct AggregationDataWithNullKeyTwoLevel : public Base
 {
-    using Base::Base;
     using Base::impls;
+    
+    AggregationDataWithNullKeyTwoLevel() {}
 
     template <typename Other>
     explicit AggregationDataWithNullKeyTwoLevel(const Other & other) : Base(other)

--- a/dbms/src/Interpreters/Aggregator.h
+++ b/dbms/src/Interpreters/Aggregator.h
@@ -121,7 +121,7 @@ template <typename Base>
 struct AggregationDataWithNullKeyTwoLevel : public Base
 {
     using Base::impls;
-    
+
     AggregationDataWithNullKeyTwoLevel() {}
 
     template <typename Other>


### PR DESCRIPTION
Disclaimer: I am not completely sure, why the original version is not compilable under gcc-8.2. Nevertheless, the proposed patch fixes build.

For Yandex employees: you can easily reproduce build failure by running dist-build with target-platform=gcc8-linux-x86_64.

Compilation error log: https://pastebin.com/2Zh0WJW4