### PR TITLE
Fixed hang in JSONExtractRaw function

### DIFF
--- a/dbms/src/IO/WriteBufferFromVector.h
+++ b/dbms/src/IO/WriteBufferFromVector.h
@@ -57,7 +57,7 @@ public:
         : WriteBuffer(nullptr, 0), vector(vector_)
     {
         size_t old_size = vector.size();
-        vector.resize(vector.capacity() < initial_size ? initial_size : vector.capacity());
+        vector.resize(std::max(vector.size() + initial_size, vector.capacity()));
         set(reinterpret_cast<Position>(vector.data() + old_size), (vector.size() - old_size) * sizeof(typename VectorType::value_type));
     }
 

--- a/dbms/tests/queries/0_stateless/00975_json_hang.reference
+++ b/dbms/tests/queries/0_stateless/00975_json_hang.reference
@@ -1,0 +1,2 @@
+false
+true

--- a/dbms/tests/queries/0_stateless/00975_json_hang.sql
+++ b/dbms/tests/queries/0_stateless/00975_json_hang.sql
@@ -1,0 +1,1 @@
+SELECT DISTINCT JSONExtractRaw(concat('{"x":', rand() % 2 ? 'true' : 'false', '}'), 'x') AS res FROM numbers(1000000) ORDER BY res;


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fixed hang in JSONExtractRaw function. This PR fixes #6195