### PR TITLE
Temporary disabled tests of MySQLWire format until it is fixed

### DIFF
--- a/dbms/tests/performance/number_formatting_formats.xml
+++ b/dbms/tests/performance/number_formatting_formats.xml
@@ -35,7 +35,6 @@
                 <value>Parquet</value>
                 <value>ODBCDriver2</value>
                 <value>Null</value>
-                <value>MySQLWire</value>
             </values>
         </substitution>
     </substitutions>

--- a/dbms/tests/performance/select_format.xml
+++ b/dbms/tests/performance/select_format.xml
@@ -44,7 +44,6 @@
                 <value>Native</value>
                 <value>XML</value>
                 <value>ODBCDriver2</value>
-                <value>MySQLWire</value>
             </values>
         </substitution>
     </substitutions>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
The bug reproduces when total size of written packets exceeds DBMS_DEFAULT_BUFFER_SIZE.