### PR TITLE
Limit sleep time in max_execution_speed; fixed Estimated query execution time (inf seconds) is too long

### DIFF
--- a/dbms/src/DataStreams/IBlockInputStream.cpp
+++ b/dbms/src/DataStreams/IBlockInputStream.cpp
@@ -255,6 +255,10 @@ static void limitProgressingSpeed(size_t total_progress_size, size_t max_speed_i
     if (desired_microseconds > total_elapsed_microseconds)
     {
         UInt64 sleep_microseconds = desired_microseconds - total_elapsed_microseconds;
+
+        /// Never sleep more than one second (it should be enough to limit speed for a reasonable amount, and otherwise it's too easy to make query hang).
+        sleep_microseconds = std::min(UInt64(1000000), sleep_microseconds);
+
         sleepForMicroseconds(sleep_microseconds);
 
         ProfileEvents::increment(ProfileEvents::ThrottlerSleepMicroseconds, sleep_microseconds);

--- a/dbms/src/DataStreams/IBlockInputStream.cpp
+++ b/dbms/src/DataStreams/IBlockInputStream.cpp
@@ -353,7 +353,7 @@ void IBlockInputStream::progressImpl(const Progress & value)
                         ErrorCodes::TOO_SLOW);
 
                 /// If the predicted execution time is longer than `max_execution_time`.
-                if (limits.max_execution_time != 0 && total_rows)
+                if (limits.max_execution_time != 0 && total_rows && progress.read_rows)
                 {
                     double estimated_execution_time_seconds = elapsed_seconds * (static_cast<double>(total_rows) / progress.read_rows);
 

--- a/dbms/tests/queries/0_stateless/00976_max_execution_speed.sql
+++ b/dbms/tests/queries/0_stateless/00976_max_execution_speed.sql
@@ -1,0 +1,2 @@
+SET max_execution_speed = 1, max_execution_time = 3;
+SELECT count() FROM system.numbers; -- { serverError 159 }


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Limit maximum sleep time for throttling when `max_execution_speed` or `max_execution_speed_bytes` is set. Fixed false errors like `Estimated query execution time (inf seconds) is too long`. This fixes  #5547