### PR TITLE
Fix bug in prewhere + distributed

### DIFF
--- a/dbms/src/Interpreters/ExpressionActions.cpp
+++ b/dbms/src/Interpreters/ExpressionActions.cpp
@@ -510,6 +510,7 @@ void ExpressionAction::execute(Block & block, bool dry_run) const
             if (can_replace && block.has(result_name))
             {
                 auto & result = block.getByName(result_name);
+                result.type = block.getByName(source_name).type;
                 result.column = block.getByName(source_name).column;
             }
             else

--- a/dbms/src/Interpreters/ExpressionActions.cpp
+++ b/dbms/src/Interpreters/ExpressionActions.cpp
@@ -950,7 +950,7 @@ void ExpressionActions::finalize(const Names & output_columns)
 
     /// Also, it seems like we will always have same type (UInt8) of "redundant" column, but it's not obvious.
 
-    bool dummy_projection_added = false;
+    bool dummy_column_copied = false;
 
 
     /// We will not throw out all the input columns, so as not to lose the number of rows in the block.
@@ -959,7 +959,7 @@ void ExpressionActions::finalize(const Names & output_columns)
         auto colname = getSmallestColumn(input_columns);
         needed_columns.insert(colname);
         actions.insert(actions.begin(), ExpressionAction::copyColumn(colname, DUMMY_COLUMN_NAME, true));
-        dummy_projection_added = true;
+        dummy_column_copied = true;
     }
 
     /// We will not leave the block empty so as not to lose the number of rows in it.
@@ -967,7 +967,7 @@ void ExpressionActions::finalize(const Names & output_columns)
     {
         auto colname = getSmallestColumn(input_columns);
         final_columns.insert(DUMMY_COLUMN_NAME);
-        if (!dummy_projection_added) /// otherwise we already have this projection
+        if (!dummy_column_copied) /// otherwise we already have this column
             actions.insert(actions.begin(), ExpressionAction::copyColumn(colname, DUMMY_COLUMN_NAME, true));
     }
 

--- a/dbms/src/Interpreters/ExpressionActions.cpp
+++ b/dbms/src/Interpreters/ExpressionActions.cpp
@@ -510,8 +510,9 @@ void ExpressionAction::execute(Block & block, bool dry_run) const
             if (can_replace && block.has(result_name))
             {
                 auto & result = block.getByName(result_name);
-                result.type = block.getByName(source_name).type;
-                result.column = block.getByName(source_name).column;
+                const auto & source = block.getByName(source_name);
+                result.type = source.type;
+                result.column = source.column;
             }
             else
             {

--- a/dbms/src/Interpreters/ExpressionActions.cpp
+++ b/dbms/src/Interpreters/ExpressionActions.cpp
@@ -510,7 +510,6 @@ void ExpressionAction::execute(Block & block, bool dry_run) const
             if (can_replace && block.has(result_name))
             {
                 auto & result = block.getByName(result_name);
-                result.type = result_type;
                 result.column = block.getByName(source_name).column;
             }
             else

--- a/dbms/src/Interpreters/ExpressionActions.h
+++ b/dbms/src/Interpreters/ExpressionActions.h
@@ -257,9 +257,13 @@ public:
     };
 
 private:
+    /// These columns have to be in input blocks (arguments of execute* methods)
     NamesAndTypesList input_columns;
+    /// These actions will be executed on input blocks
     Actions actions;
+    /// The example of result (output) block.
     Block sample_block;
+
     Settings settings;
 #if USE_EMBEDDED_COMPILER
     std::shared_ptr<CompiledExpressionCache> compilation_cache;

--- a/dbms/tests/integration/test_remote_prewhere/configs/log_conf.xml
+++ b/dbms/tests/integration/test_remote_prewhere/configs/log_conf.xml
@@ -1,0 +1,12 @@
+<yandex>
+<shutdown_wait_unfinished>3</shutdown_wait_unfinished>
+<logger>
+    <level>trace</level>
+    <log>/var/log/clickhouse-server/log.log</log>
+    <errorlog>/var/log/clickhouse-server/log.err.log</errorlog>
+    <size>1000M</size>
+    <count>10</count>
+    <stderr>/var/log/clickhouse-server/stderr.log</stderr>
+    <stdout>/var/log/clickhouse-server/stdout.log</stdout>
+    </logger>
+    </yandex>

--- a/dbms/tests/integration/test_remote_prewhere/test.py
+++ b/dbms/tests/integration/test_remote_prewhere/test.py
@@ -1,0 +1,35 @@
+import time
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.client import QueryRuntimeException, QueryTimeoutExceedException
+
+
+cluster = ClickHouseCluster(__file__)
+node1 = cluster.add_instance('node1', main_configs=['configs/log_conf.xml'])
+node2 = cluster.add_instance('node2', main_configs=['configs/log_conf.xml'])
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+
+        for node in [node1, node2]:
+            node.query("""
+                CREATE TABLE test_table(
+                    APIKey UInt32,
+                    CustomAttributeId UInt64,
+                    ProfileIDHash UInt64,
+                    DeviceIDHash UInt64,
+                    Data String)
+                ENGINE = SummingMergeTree()
+                ORDER BY (APIKey, CustomAttributeId, ProfileIDHash, DeviceIDHash, intHash32(DeviceIDHash))
+            """)
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def test_remote(start_cluster):
+    assert node1.query("SELECT 1 FROM remote('node{1,2}', default.test_table) WHERE (APIKey = 137715) AND (CustomAttributeId IN (45, 66)) AND (ProfileIDHash != 0) LIMIT 1") == ""


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fix bug opened by https://github.com/yandex/ClickHouse/pull/4405 (since 19.4.0). Reproduces in queries to Distributed tables over MergeTree tables when we doesn't query any columns (`SELECT 1`). 
