### PR TITLE
Changed boost::filesystem to std::filesystem

### DIFF
--- a/dbms/programs/performance-test/PerformanceTest.cpp
+++ b/dbms/programs/performance-test/PerformanceTest.cpp
@@ -9,9 +9,10 @@
 #include <IO/ReadHelpers.h>
 #include <IO/WriteBufferFromFile.h>
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include "executeQuery.h"
+
 
 namespace DB
 {
@@ -48,7 +49,7 @@ void waitQuery(Connection & connection)
 }
 }
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 PerformanceTest::PerformanceTest(
     const XMLConfigurationPtr & config_,

--- a/dbms/programs/performance-test/PerformanceTestInfo.cpp
+++ b/dbms/programs/performance-test/PerformanceTestInfo.cpp
@@ -3,9 +3,10 @@
 #include <IO/ReadBufferFromFile.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteBufferFromFile.h>
-#include <boost/filesystem.hpp>
 #include "applySubstitutions.h"
+#include <filesystem>
 #include <iostream>
+
 
 namespace DB
 {
@@ -39,7 +40,7 @@ void extractSettings(
 }
 
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 PerformanceTestInfo::PerformanceTestInfo(
     XMLConfigurationPtr config,

--- a/dbms/programs/performance-test/PerformanceTestSuite.cpp
+++ b/dbms/programs/performance-test/PerformanceTestSuite.cpp
@@ -4,11 +4,11 @@
 #include <regex>
 #include <thread>
 #include <memory>
+#include <filesystem>
 
 #include <port/unistd.h>
 #include <sys/stat.h>
 
-#include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 
 #include <Poco/AutoPtr.h>
@@ -36,7 +36,7 @@
 #include "ReportBuilder.h"
 
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 namespace po = boost::program_options;
 
 namespace DB

--- a/dbms/src/Common/tests/compact_array.cpp
+++ b/dbms/src/Common/tests/compact_array.cpp
@@ -7,7 +7,7 @@
 #include <Common/CompactArray.h>
 #include <IO/WriteBufferFromFile.h>
 #include <IO/ReadBufferFromFile.h>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <string>
 #include <iostream>
 #include <fstream>
@@ -15,7 +15,7 @@
 #include <cstdlib>
 #include <port/unistd.h>
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 std::string createTmpPath(const std::string & filename)
 {

--- a/dbms/src/Functions/filesystem.cpp
+++ b/dbms/src/Functions/filesystem.cpp
@@ -2,7 +2,7 @@
 #include <Functions/FunctionFactory.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <Interpreters/Context.h>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <Poco/Util/AbstractConfiguration.h>
 
 namespace DB
@@ -11,19 +11,19 @@ namespace DB
 struct FilesystemAvailable
 {
     static constexpr auto name = "filesystemAvailable";
-    static boost::uintmax_t get(boost::filesystem::space_info & spaceinfo) { return spaceinfo.available; }
+    static std::uintmax_t get(std::filesystem::space_info & spaceinfo) { return spaceinfo.available; }
 };
 
 struct FilesystemFree
 {
     static constexpr auto name = "filesystemFree";
-    static boost::uintmax_t get(boost::filesystem::space_info & spaceinfo) { return spaceinfo.free; }
+    static std::uintmax_t get(std::filesystem::space_info & spaceinfo) { return spaceinfo.free; }
 };
 
 struct FilesystemCapacity
 {
     static constexpr auto name = "filesystemCapacity";
-    static boost::uintmax_t get(boost::filesystem::space_info & spaceinfo) { return spaceinfo.capacity; }
+    static std::uintmax_t get(std::filesystem::space_info & spaceinfo) { return spaceinfo.capacity; }
 };
 
 template <typename Impl>
@@ -34,10 +34,10 @@ public:
 
     static FunctionPtr create(const Context & context)
     {
-        return std::make_shared<FilesystemImpl<Impl>>(boost::filesystem::space(context.getConfigRef().getString("path")));
+        return std::make_shared<FilesystemImpl<Impl>>(std::filesystem::space(context.getConfigRef().getString("path")));
     }
 
-    explicit FilesystemImpl(boost::filesystem::space_info spaceinfo_) : spaceinfo(spaceinfo_) { }
+    explicit FilesystemImpl(std::filesystem::space_info spaceinfo_) : spaceinfo(spaceinfo_) { }
 
     String getName() const override { return name; }
     size_t getNumberOfArguments() const override { return 0; }
@@ -54,7 +54,7 @@ public:
     }
 
 private:
-    boost::filesystem::space_info spaceinfo;
+    std::filesystem::space_info spaceinfo;
 };
 
 

--- a/dbms/src/IO/tests/read_buffer_aio.cpp
+++ b/dbms/src/IO/tests/read_buffer_aio.cpp
@@ -1,6 +1,6 @@
 #include <IO/ReadBufferAIO.h>
 #include <Core/Defines.h>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <vector>
 #include <iostream>
 #include <fstream>
@@ -44,7 +44,7 @@ bool test20(const std::string & filename, const std::string & buf);
 
 void run()
 {
-    namespace fs = boost::filesystem;
+    namespace fs = std::filesystem;
 
     std::string filename;
     std::string buf;

--- a/dbms/src/IO/tests/write_buffer_aio.cpp
+++ b/dbms/src/IO/tests/write_buffer_aio.cpp
@@ -1,8 +1,7 @@
 #include <IO/WriteBufferAIO.h>
 #include <Core/Defines.h>
 
-#include <boost/filesystem.hpp>
-
+#include <filesystem>
 #include <iostream>
 #include <fstream>
 #include <streambuf>
@@ -11,7 +10,7 @@
 namespace
 {
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 void run();
 [[noreturn]] void die(const std::string & msg);

--- a/dbms/src/Interpreters/tests/users.cpp
+++ b/dbms/src/Interpreters/tests/users.cpp
@@ -1,6 +1,6 @@
 #include <Common/Config/ConfigProcessor.h>
 #include <Interpreters/UsersManager.h>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <vector>
 #include <string>
 #include <tuple>
@@ -14,7 +14,7 @@
 namespace
 {
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 struct TestEntry
 {

--- a/dbms/src/Storages/StorageDistributed.cpp
+++ b/dbms/src/Storages/StorageDistributed.cpp
@@ -47,7 +47,7 @@
 #include <Poco/DirectoryIterator.h>
 
 #include <memory>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 
 namespace DB
@@ -120,13 +120,13 @@ UInt64 getMaximumFileNumber(const std::string & dir_path)
 {
     UInt64 res = 0;
 
-    boost::filesystem::recursive_directory_iterator begin(dir_path);
-    boost::filesystem::recursive_directory_iterator end;
+    std::filesystem::recursive_directory_iterator begin(dir_path);
+    std::filesystem::recursive_directory_iterator end;
     for (auto it = begin; it != end; ++it)
     {
         const auto & file_path = it->path();
 
-        if (it->status().type() != boost::filesystem::regular_file || !endsWith(file_path.filename().string(), ".bin"))
+        if (!std::filesystem::is_regular_file(*it) || !endsWith(file_path.filename().string(), ".bin"))
             continue;
 
         UInt64 num = 0;
@@ -431,10 +431,10 @@ void StorageDistributed::createDirectoryMonitors()
 
     Poco::File{path}.createDirectory();
 
-    boost::filesystem::directory_iterator begin(path);
-    boost::filesystem::directory_iterator end;
+    std::filesystem::directory_iterator begin(path);
+    std::filesystem::directory_iterator end;
     for (auto it = begin; it != end; ++it)
-        if (it->status().type() == boost::filesystem::directory_file)
+        if (std::filesystem::is_directory(*it))
             requireDirectoryMonitor(it->path().filename().string());
 }
 


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Switched from `boost::filesystem` to `std::filesystem` where appropriate.