### PR TITLE
Fix crash on CAST exotic types to Decimal

### DIFF
--- a/dbms/src/DataTypes/IDataType.h
+++ b/dbms/src/DataTypes/IDataType.h
@@ -463,9 +463,8 @@ struct WhichDataType
 {
     TypeIndex idx;
 
-    /// For late initialization.
-    WhichDataType()
-        : idx(TypeIndex::Nothing)
+    WhichDataType(TypeIndex idx_ = TypeIndex::Nothing)
+        : idx(idx_)
     {}
 
     WhichDataType(const IDataType & data_type)

--- a/dbms/src/Functions/FunctionsConversion.h
+++ b/dbms/src/Functions/FunctionsConversion.h
@@ -1634,6 +1634,17 @@ private:
         TypeIndex type_index = from_type->getTypeId();
         UInt32 scale = to_type->getScale();
 
+        WhichDataType which(type_index);
+        bool ok = which.isNativeInt() ||
+            which.isNativeUInt() ||
+            which.isDecimal() ||
+            which.isFloat() ||
+            which.isDateOrDateTime() ||
+            which.isStringOrFixedString();
+        if (!ok)
+            throw Exception{"Conversion from " + from_type->getName() + " to " + to_type->getName() + " is not supported",
+                ErrorCodes::CANNOT_CONVERT_TYPE};
+
         return [type_index, scale] (Block & block, const ColumnNumbers & arguments, const size_t result, size_t input_rows_count)
         {
             callOnIndexAndDataType<ToDataType>(type_index, [&](const auto & types) -> bool

--- a/dbms/tests/queries/0_stateless/00879_cast_to_decimal_crash.sql
+++ b/dbms/tests/queries/0_stateless/00879_cast_to_decimal_crash.sql
@@ -1,0 +1,1 @@
+select cast(toIntervalDay(1) as Nullable(Decimal(10, 10))); -- { serverError 70 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fix crash when casting types to Decimal that do not support it. Throw exception instead.
