### PR TITLE
Fix FPE in yandexConsistentHash function

### DIFF
--- a/dbms/src/Functions/FunctionsConsistentHashing.h
+++ b/dbms/src/Functions/FunctionsConsistentHashing.h
@@ -156,9 +156,8 @@ private:
                 "The second argument of function " + getName() + " (number of buckets) must be positive number", ErrorCodes::BAD_ARGUMENTS);
 
         if (unlikely(static_cast<UInt64>(buckets) > Impl::max_buckets))
-            throw Exception("The value of the second argument of function " + getName() + " (number of buckets) is not fit to "
-                    + DataTypeNumber<BucketsType>().getName(),
-                ErrorCodes::BAD_ARGUMENTS);
+            throw Exception("The value of the second argument of function " + getName() + " (number of buckets) must not be greater than "
+                    + std::to_string(Impl::max_buckets), ErrorCodes::BAD_ARGUMENTS);
 
         return static_cast<BucketsType>(buckets);
     }

--- a/dbms/src/Functions/FunctionsConsistentHashing.h
+++ b/dbms/src/Functions/FunctionsConsistentHashing.h
@@ -29,11 +29,12 @@ struct YandexConsistentHashImpl
     static constexpr auto name = "yandexConsistentHash";
 
     using HashType = UInt64;
-    /// Actually it supports UInt64, but it is effective only if n < 65536
-    using ResultType = UInt32;
-    using BucketsCountType = ResultType;
+    /// Actually it supports UInt64, but it is efficient only if n <= 32768
+    using ResultType = UInt16;
+    using BucketsType = ResultType;
+    static constexpr auto max_buckets = 32768;
 
-    static inline ResultType apply(UInt64 hash, BucketsCountType n)
+    static inline ResultType apply(UInt64 hash, BucketsType n)
     {
         return ConsistentHashing(hash, n);
     }
@@ -59,9 +60,10 @@ struct JumpConsistentHashImpl
 
     using HashType = UInt64;
     using ResultType = Int32;
-    using BucketsCountType = ResultType;
+    using BucketsType = ResultType;
+    static constexpr auto max_buckets = static_cast<UInt64>(std::numeric_limits<BucketsType>::max());
 
-    static inline ResultType apply(UInt64 hash, BucketsCountType n)
+    static inline ResultType apply(UInt64 hash, BucketsType n)
     {
         return JumpConsistentHash(hash, n);
     }
@@ -74,9 +76,10 @@ struct SumburConsistentHashImpl
 
     using HashType = UInt32;
     using ResultType = UInt16;
-    using BucketsCountType = ResultType;
+    using BucketsType = ResultType;
+    static constexpr auto max_buckets = static_cast<UInt64>(std::numeric_limits<BucketsType>::max());
 
-    static inline ResultType apply(HashType hash, BucketsCountType n)
+    static inline ResultType apply(HashType hash, BucketsType n)
     {
         return static_cast<ResultType>(sumburConsistentHash(hash, n));
     }
@@ -143,8 +146,7 @@ public:
 private:
     using HashType = typename Impl::HashType;
     using ResultType = typename Impl::ResultType;
-    using BucketsType = typename Impl::BucketsCountType;
-    static constexpr auto max_buckets = static_cast<UInt64>(std::numeric_limits<BucketsType>::max());
+    using BucketsType = typename Impl::BucketsType;
 
     template <typename T>
     inline BucketsType checkBucketsRange(T buckets)
@@ -153,7 +155,7 @@ private:
             throw Exception(
                 "The second argument of function " + getName() + " (number of buckets) must be positive number", ErrorCodes::BAD_ARGUMENTS);
 
-        if (unlikely(static_cast<UInt64>(buckets) > max_buckets))
+        if (unlikely(static_cast<UInt64>(buckets) > Impl::max_buckets))
             throw Exception("The value of the second argument of function " + getName() + " (number of buckets) is not fit to "
                     + DataTypeNumber<BucketsType>().getName(),
                 ErrorCodes::BAD_ARGUMENTS);

--- a/dbms/tests/queries/0_stateless/00979_yandex_consistent_hash_fpe.sql
+++ b/dbms/tests/queries/0_stateless/00979_yandex_consistent_hash_fpe.sql
@@ -1,0 +1,1 @@
+SELECT yandexConsistentHash(-1, 40000); -- { serverError 36 }

--- a/libs/consistent-hashing/consistent_hashing.h
+++ b/libs/consistent-hashing/consistent_hashing.h
@@ -15,5 +15,5 @@
  * It requires O(1) memory and cpu to calculate. So, it is faster than classic
  * consistent hashing algos with points on circle.
  */
-std::size_t ConsistentHashing(std::uint64_t x, std::size_t n); // Works good for n < 65536
-std::size_t ConsistentHashing(std::uint64_t lo, std::uint64_t hi, std::size_t n); // Works good for n < 4294967296
+std::size_t ConsistentHashing(std::uint64_t x, std::size_t n); // Works for n <= 32768
+std::size_t ConsistentHashing(std::uint64_t lo, std::uint64_t hi, std::size_t n); // Works for n <= 2^31


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fix FPE in yandexConsistentHash function. Found by fuzz test. This fixes #6304