### PR TITLE
Avoid extra dependency in Compiler (used with compile = 1 setting)

### DIFF
--- a/dbms/src/Interpreters/Compiler.cpp
+++ b/dbms/src/Interpreters/Compiler.cpp
@@ -236,6 +236,9 @@ void Compiler::compile(
             " -fuse-ld=" << compiler_executable_root << INTERNAL_LINKER_EXECUTABLE
             " -fdiagnostics-color=never"
 
+            /// Do not use libgcc and startup files. The library will work nevertheless and we avoid extra dependency.
+            " -nodefaultlibs -nostartfiles"
+
     #if INTERNAL_COMPILER_CUSTOM_ROOT
             /// To get correct order merge this results carefully:
             /// echo | clang -x c++ -E -Wp,-v -


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

Short description (up to few sentences):
Avoid extra dependency for the setting `compile` to work. In previous versions, the user may get error like `cannot open crti.o`, `unable to find library -lc` etc.