### PR TITLE
Enabled SIMDJSON for SSE 4.2 with PCLMUL instruction set

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -93,7 +93,7 @@
 	url = https://github.com/ClickHouse-Extras/libunwind.git
 [submodule "contrib/simdjson"]
 	path = contrib/simdjson
-	url = https://github.com/ClickHouse-Extras/simdjson.git
+	url = https://github.com/lemire/simdjson.git
 [submodule "contrib/rapidjson"]
 	path = contrib/rapidjson
 	url = https://github.com/Tencent/rapidjson

--- a/cmake/find_simdjson.cmake
+++ b/cmake/find_simdjson.cmake
@@ -3,8 +3,11 @@ if (NOT EXISTS "${ClickHouse_SOURCE_DIR}/contrib/simdjson/include/simdjson/jsonp
     return()
 endif ()
 
-if (NOT HAVE_AVX2)
-    message (WARNING "submodule contrib/simdjson requires AVX2 support")
+if (NOT HAVE_SSE42)
+    message (WARNING "submodule contrib/simdjson requires support of SSE4.2 instructions")
+    return()
+elseif (NOT HAVE_PCLMULQDQ)
+    message (WARNING "submodule contrib/simdjson requires support of PCLMULQDQ instructions")
     return()
 endif ()
 

--- a/cmake/test_cpu.cmake
+++ b/cmake/test_cpu.cmake
@@ -81,6 +81,17 @@ check_cxx_source_compiles("
     }
 " HAVE_AVX2)
 
+set (TEST_FLAG "-mpclmul")
+set (CMAKE_REQUIRED_FLAGS "${TEST_FLAG} -O0")
+check_cxx_source_compiles("
+    #include <wmmintrin.h>
+    int main() {
+        auto a = _mm_clmulepi64_si128(__m128i(), __m128i(), 0);
+        (void)a;
+        return 0;
+    }
+" HAVE_PCLMULQDQ)
+
 # gcc -dM -E -mpopcnt - < /dev/null | sort > gcc-dump-popcnt
 #define __POPCNT__ 1
 

--- a/contrib/simdjson-cmake/CMakeLists.txt
+++ b/contrib/simdjson-cmake/CMakeLists.txt
@@ -1,6 +1,3 @@
-if (NOT HAVE_AVX2)
-    message (FATAL_ERROR "No AVX2 support")
-endif ()
 set(SIMDJSON_INCLUDE_DIR "${ClickHouse_SOURCE_DIR}/contrib/simdjson/include")
 set(SIMDJSON_SRC_DIR "${SIMDJSON_INCLUDE_DIR}/../src")
 set(SIMDJSON_SRC
@@ -16,4 +13,3 @@ set(SIMDJSON_SRC
 
 add_library(${SIMDJSON_LIBRARY} ${SIMDJSON_SRC})
 target_include_directories(${SIMDJSON_LIBRARY} SYSTEM PUBLIC "${SIMDJSON_INCLUDE_DIR}")
-target_compile_options(${SIMDJSON_LIBRARY} PRIVATE -mavx2 -mbmi -mbmi2 -mpclmul)

--- a/dbms/src/Functions/FunctionsJSON.h
+++ b/dbms/src/Functions/FunctionsJSON.h
@@ -64,7 +64,7 @@ public:
     {
         /// Choose JSONParser.
 #if USE_SIMDJSON
-        if (context.getSettings().allow_simdjson && Cpu::CpuFlagsCache::have_AVX2)
+        if (context.getSettings().allow_simdjson && Cpu::CpuFlagsCache::have_SSE42 && Cpu::CpuFlagsCache::have_PCLMUL)
         {
             Executor<SimdJSONParser>::run(block, arguments, result_pos, input_rows_count);
             return;

--- a/dbms/src/Functions/FunctionsJSON.h
+++ b/dbms/src/Functions/FunctionsJSON.h
@@ -7,6 +7,7 @@
 #include "config_functions.h"
 #include <Common/CpuId.h>
 #include <Common/typeid_cast.h>
+#include <Core/AccurateComparison.h>
 #include <Core/Settings.h>
 #include <Columns/ColumnConst.h>
 #include <Columns/ColumnString.h>
@@ -15,7 +16,6 @@
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnTuple.h>
-#include <Core/AccurateComparison.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeEnum.h>

--- a/dbms/tests/queries/0_stateless/00975_json_hang.sql
+++ b/dbms/tests/queries/0_stateless/00975_json_hang.sql
@@ -1,1 +1,1 @@
-SELECT DISTINCT JSONExtractRaw(concat('{"x":', rand() % 2 ? 'true' : 'false', '}'), 'x') AS res FROM numbers(1000000) ORDER BY res;
+SELECT DISTINCT JSONExtractRaw(concat('{"x":', rand() % 2 ? 'true' : 'false', '}'), 'x') AS res FROM numbers(100000) ORDER BY res;


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

Short description (up to few sentences):
Enabled SIMDJSON for machines without AVX2 but with SSE 4.2 and PCLMUL instruction set.

https://github.com/yandex/ClickHouse/issues/6285