### PR TITLE
Added missing [Primary Key expr] to syntax

### DIFF
--- a/docs/en/operations/table_engines/replacingmergetree.md
+++ b/docs/en/operations/table_engines/replacingmergetree.md
@@ -17,6 +17,7 @@ CREATE TABLE [IF NOT EXISTS] [db.]table_name [ON CLUSTER cluster]
 ) ENGINE = ReplacingMergeTree([ver])
 [PARTITION BY expr]
 [ORDER BY expr]
+[PRIMARY KEY expr]
 [SAMPLE BY expr]
 [SETTINGS name=value, ...]
 ```


### PR DESCRIPTION
[Primary Key] was missing in creating `ReplacingMergeTree` syntax.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en