### PR TITLE
Added gcc-9 to docker/builder container

### DIFF
--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:18.04
 
 RUN apt-get update -y \
+    && apt-get install -y software-properties-common \
+    && add-apt-repository ppa:ubuntu-toolchain-r/test \
     && env DEBIAN_FRONTEND=noninteractive \
         apt-get install --yes --no-install-recommends \
             bash \
@@ -8,8 +10,8 @@ RUN apt-get update -y \
             cmake \
             curl \
             expect \
-            g++ \
-            gcc \
+            g++-9 \
+            gcc-9 \
             libclang-6.0-dev \
             libicu-dev \
             liblld-6.0-dev \

--- a/docker/builder/build.sh
+++ b/docker/builder/build.sh
@@ -3,7 +3,7 @@
 #ccache -s
 mkdir -p /server/build_docker
 cd /server/build_docker
-cmake -G Ninja /server -DENABLE_TESTS=1
+cmake -G Ninja /server -DENABLE_TESTS=1 -DCMAKE_C_COMPILER=`which gcc-9` -DCMAKE_CXX_COMPILER=`which g++-9`
 
 # Set the number of build jobs to the half of number of virtual CPU cores (rounded up).
 # By default, ninja use all virtual CPU cores, that leads to very high memory consumption without much improvement in build time.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):

Added gcc-9 support to `docker/builder` container that builds image locally.
