### PR TITLE
Fix infinite loop when reading Kafka messages

### DIFF
--- a/dbms/src/Storages/IStorage.cpp
+++ b/dbms/src/Storages/IStorage.cpp
@@ -145,9 +145,12 @@ namespace
     }
 }
 
-void IStorage::check(const Names & column_names) const
+void IStorage::check(const Names & column_names, bool include_virtuals) const
 {
-    const NamesAndTypesList & available_columns = getColumns().getAllPhysical();
+    NamesAndTypesList available_columns = getColumns().getAllPhysical();
+    if (include_virtuals)
+        available_columns.splice(available_columns.end(), getColumns().getVirtuals());
+
     const String list_of_columns = listOfColumns(available_columns);
 
     if (column_names.empty())

--- a/dbms/src/Storages/IStorage.h
+++ b/dbms/src/Storages/IStorage.h
@@ -116,7 +116,7 @@ public: /// thread-unsafe part. lockStructure must be acquired
 
     /// Verify that all the requested names are in the table and are set correctly:
     /// list of names is not empty and the names do not repeat.
-    void check(const Names & column_names) const;
+    void check(const Names & column_names, bool include_virtuals = false) const;
 
     /// Check that all the requested names are in the table and have the correct types.
     void check(const NamesAndTypesList & columns) const;

--- a/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
+++ b/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
@@ -56,29 +56,26 @@ void ReadBufferFromKafkaConsumer::commit()
 void ReadBufferFromKafkaConsumer::subscribe(const Names & topics)
 {
     {
-        String message = "Subscribed to topics:";
+        String message = "Already subscribed to topics:";
         for (const auto & topic : consumer->get_subscription())
             message += " " + topic;
         LOG_TRACE(log, message);
     }
 
     {
-        String message = "Assigned to topics:";
+        String message = "Already assigned to topics:";
         for (const auto & toppar : consumer->get_assignment())
             message += " " + toppar.get_topic();
         LOG_TRACE(log, message);
     }
 
-    consumer->resume();
-
     // While we wait for an assignment after subscribtion, we'll poll zero messages anyway.
     // If we're doing a manual select then it's better to get something after a wait, then immediate nothing.
+    // But due to the nature of async pause/resume/subscribe we can't guarantee any persistent state:
+    // see https://github.com/edenhill/librdkafka/issues/2455
     if (consumer->get_subscription().empty())
     {
-        consumer->pause(); // don't accidentally read any messages
         consumer->subscribe(topics);
-        consumer->poll(5s);
-        consumer->resume();
 
         // FIXME: if we failed to receive "subscribe" response while polling and destroy consumer now, then we may hang up.
         //        see https://github.com/edenhill/librdkafka/issues/2077

--- a/dbms/src/Storages/StorageValues.cpp
+++ b/dbms/src/Storages/StorageValues.cpp
@@ -21,7 +21,7 @@ BlockInputStreams StorageValues::read(
     size_t /*max_block_size*/,
     unsigned /*num_streams*/)
 {
-    check(column_names);
+    check(column_names, true);
 
     return BlockInputStreams(1, std::make_shared<OneBlockInputStream>(res_block));
 }

--- a/dbms/tests/integration/helpers/cluster.py
+++ b/dbms/tests/integration/helpers/cluster.py
@@ -367,7 +367,7 @@ class ClickHouseCluster:
             subprocess_check_call(self.base_mongo_cmd + common_opts)
             self.wait_mongo_to_start(30)
 
-        subprocess_check_call(self.base_cmd + common_opts + ['--renew-anon-volumes'])
+        subprocess_check_call(self.base_cmd + ['up', '-d', '--no-recreate'])
 
         start_deadline = time.time() + 20.0 # seconds
         for instance in self.instances.itervalues():

--- a/dbms/tests/integration/helpers/cluster.py
+++ b/dbms/tests/integration/helpers/cluster.py
@@ -367,7 +367,7 @@ class ClickHouseCluster:
             subprocess_check_call(self.base_mongo_cmd + common_opts)
             self.wait_mongo_to_start(30)
 
-        subprocess_check_call(self.base_cmd + ['up', '-d', '--no-recreate'])
+        subprocess_check_call(self.base_cmd + common_opts + ['--renew-anon-volumes'])
 
         start_deadline = time.time() + 20.0 # seconds
         for instance in self.instances.itervalues():

--- a/dbms/tests/integration/test_storage_kafka/test.py
+++ b/dbms/tests/integration/test_storage_kafka/test.py
@@ -138,7 +138,7 @@ def test_kafka_settings_old_syntax(kafka_cluster):
 
     result = ''
     while True:
-        result += instance.query('SELECT * FROM test.kafka')
+        result += instance.query('SELECT * FROM test.kafka', ignore_error=True)
         if kafka_check_result(result):
             break
 
@@ -174,7 +174,7 @@ def test_kafka_settings_new_syntax(kafka_cluster):
 
     result = ''
     while True:
-        result += instance.query('SELECT * FROM test.kafka')
+        result += instance.query('SELECT * FROM test.kafka', ignore_error=True)
         if kafka_check_result(result):
             break
 
@@ -200,7 +200,7 @@ def test_kafka_csv_with_delimiter(kafka_cluster):
 
     result = ''
     while True:
-        result += instance.query('SELECT * FROM test.kafka')
+        result += instance.query('SELECT * FROM test.kafka', ignore_error=True)
         if kafka_check_result(result):
             break
 
@@ -226,7 +226,7 @@ def test_kafka_tsv_with_delimiter(kafka_cluster):
 
     result = ''
     while True:
-        result += instance.query('SELECT * FROM test.kafka')
+        result += instance.query('SELECT * FROM test.kafka', ignore_error=True)
         if kafka_check_result(result):
             break
 
@@ -256,7 +256,7 @@ def test_kafka_json_without_delimiter(kafka_cluster):
 
     result = ''
     while True:
-        result += instance.query('SELECT * FROM test.kafka')
+        result += instance.query('SELECT * FROM test.kafka', ignore_error=True)
         if kafka_check_result(result):
             break
 
@@ -281,7 +281,7 @@ def test_kafka_protobuf(kafka_cluster):
 
     result = ''
     while True:
-        result += instance.query('SELECT * FROM test.kafka')
+        result += instance.query('SELECT * FROM test.kafka', ignore_error=True)
         if kafka_check_result(result):
             break
 
@@ -325,7 +325,7 @@ def test_kafka_materialized_view(kafka_cluster):
     kafka_check_result(result, True)
 
 
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(300)
 def test_kafka_flush_on_big_message(kafka_cluster):
     # Create batchs of messages of size ~100Kb
     kafka_messages = 1000
@@ -398,7 +398,7 @@ def test_kafka_virtual_columns(kafka_cluster):
 
     result = ''
     while True:
-        result += instance.query('SELECT _key, key, _topic, value, _offset FROM test.kafka')
+        result += instance.query('SELECT _key, key, _topic, value, _offset FROM test.kafka', ignore_error=True)
         if kafka_check_result(result, False, 'test_kafka_virtual1.reference'):
             break
 

--- a/dbms/tests/integration/test_storage_kafka/test.py
+++ b/dbms/tests/integration/test_storage_kafka/test.py
@@ -143,7 +143,6 @@ def test_kafka_settings_old_syntax(kafka_cluster):
         time.sleep(0.5)
     kafka_check_result(result, True)
 
-@pytest.mark.skip(reason="fails for some reason")
 def test_kafka_settings_new_syntax(kafka_cluster):
     instance.query('''
         CREATE TABLE test.kafka (key UInt64, value UInt64)
@@ -317,7 +316,6 @@ def test_kafka_materialized_view(kafka_cluster):
         DROP TABLE test.view;
     ''')
 
-@pytest.mark.skip(reason="Hungs")
 def test_kafka_flush_on_big_message(kafka_cluster):
     # Create batchs of messages of size ~100Kb
     kafka_messages = 1000

--- a/dbms/tests/integration/test_storage_kafka/test.py
+++ b/dbms/tests/integration/test_storage_kafka/test.py
@@ -122,6 +122,7 @@ def kafka_setup_teardown():
 
 # Tests
 
+@pytest.mark.timeout(60)
 def test_kafka_settings_old_syntax(kafka_cluster):
     instance.query('''
         CREATE TABLE test.kafka (key UInt64, value UInt64)
@@ -136,13 +137,15 @@ def test_kafka_settings_old_syntax(kafka_cluster):
     kafka_produce('old', messages)
 
     result = ''
-    for i in range(50):
+    while True:
         result += instance.query('SELECT * FROM test.kafka')
         if kafka_check_result(result):
             break
-        time.sleep(0.5)
+
     kafka_check_result(result, True)
 
+
+@pytest.mark.timeout(60)
 def test_kafka_settings_new_syntax(kafka_cluster):
     instance.query('''
         CREATE TABLE test.kafka (key UInt64, value UInt64)
@@ -170,14 +173,15 @@ def test_kafka_settings_new_syntax(kafka_cluster):
     kafka_produce('new', messages)
 
     result = ''
-    for i in range(50):
+    while True:
         result += instance.query('SELECT * FROM test.kafka')
         if kafka_check_result(result):
             break
-        time.sleep(0.5)
+
     kafka_check_result(result, True)
 
 
+@pytest.mark.timeout(60)
 def test_kafka_csv_with_delimiter(kafka_cluster):
     instance.query('''
         CREATE TABLE test.kafka (key UInt64, value UInt64)
@@ -195,14 +199,15 @@ def test_kafka_csv_with_delimiter(kafka_cluster):
     kafka_produce('csv', messages)
 
     result = ''
-    for i in range(50):
+    while True:
         result += instance.query('SELECT * FROM test.kafka')
         if kafka_check_result(result):
             break
-        time.sleep(0.5)
+
     kafka_check_result(result, True)
 
 
+@pytest.mark.timeout(60)
 def test_kafka_tsv_with_delimiter(kafka_cluster):
     instance.query('''
         CREATE TABLE test.kafka (key UInt64, value UInt64)
@@ -220,14 +225,15 @@ def test_kafka_tsv_with_delimiter(kafka_cluster):
     kafka_produce('tsv', messages)
 
     result = ''
-    for i in range(50):
+    while True:
         result += instance.query('SELECT * FROM test.kafka')
         if kafka_check_result(result):
             break
-        time.sleep(0.5)
+
     kafka_check_result(result, True)
 
 
+@pytest.mark.timeout(60)
 def test_kafka_json_without_delimiter(kafka_cluster):
     instance.query('''
         CREATE TABLE test.kafka (key UInt64, value UInt64)
@@ -249,14 +255,15 @@ def test_kafka_json_without_delimiter(kafka_cluster):
     kafka_produce('json', [messages])
 
     result = ''
-    for i in range(50):
+    while True:
         result += instance.query('SELECT * FROM test.kafka')
         if kafka_check_result(result):
             break
-        time.sleep(0.5)
+
     kafka_check_result(result, True)
 
 
+@pytest.mark.timeout(60)
 def test_kafka_protobuf(kafka_cluster):
     instance.query('''
         CREATE TABLE test.kafka (key UInt64, value String)
@@ -273,14 +280,15 @@ def test_kafka_protobuf(kafka_cluster):
     kafka_produce_protobuf_messages('pb', 21, 29)
 
     result = ''
-    for i in range(50):
+    while True:
         result += instance.query('SELECT * FROM test.kafka')
         if kafka_check_result(result):
             break
-        time.sleep(0.5)
+
     kafka_check_result(result, True)
 
 
+@pytest.mark.timeout(60)
 def test_kafka_materialized_view(kafka_cluster):
     instance.query('''
         DROP TABLE IF EXISTS test.view;
@@ -304,18 +312,20 @@ def test_kafka_materialized_view(kafka_cluster):
         messages.append(json.dumps({'key': i, 'value': i}))
     kafka_produce('mv', messages)
 
-    for i in range(50):
+    while True:
         result = instance.query('SELECT * FROM test.view')
         if kafka_check_result(result):
             break
-        time.sleep(0.5)
-    kafka_check_result(result, True)
 
     instance.query('''
         DROP TABLE test.consumer;
         DROP TABLE test.view;
     ''')
 
+    kafka_check_result(result, True)
+
+
+@pytest.mark.timeout(60)
 def test_kafka_flush_on_big_message(kafka_cluster):
     # Create batchs of messages of size ~100Kb
     kafka_messages = 1000
@@ -352,15 +362,20 @@ def test_kafka_flush_on_big_message(kafka_cluster):
         except kafka.errors.GroupCoordinatorNotAvailableError:
             continue
 
-    for i in range(50):
+    while True:
         result = instance.query('SELECT count() FROM test.view')
         if int(result) == kafka_messages*batch_messages:
             break
-        time.sleep(0.5)
+
+    instance.query('''
+        DROP TABLE test.consumer;
+        DROP TABLE test.view;
+    ''')
 
     assert int(result) == kafka_messages*batch_messages, 'ClickHouse lost some messages: {}'.format(result)
 
 
+@pytest.mark.timeout(60)
 def test_kafka_virtual_columns(kafka_cluster):
     instance.query('''
         CREATE TABLE test.kafka (key UInt64, value UInt64)
@@ -382,14 +397,15 @@ def test_kafka_virtual_columns(kafka_cluster):
     kafka_produce('virt1', [messages])
 
     result = ''
-    for i in range(50):
+    while True:
         result += instance.query('SELECT _key, key, _topic, value, _offset FROM test.kafka')
         if kafka_check_result(result, False, 'test_kafka_virtual1.reference'):
             break
-        time.sleep(0.5)
+
     kafka_check_result(result, True, 'test_kafka_virtual1.reference')
 
 
+@pytest.mark.timeout(60)
 def test_kafka_virtual_columns_with_materialized_view(kafka_cluster):
     instance.query('''
         DROP TABLE IF EXISTS test.view;
@@ -413,17 +429,17 @@ def test_kafka_virtual_columns_with_materialized_view(kafka_cluster):
         messages.append(json.dumps({'key': i, 'value': i}))
     kafka_produce('virt2', messages)
 
-    for i in range(50):
+    while True:
         result = instance.query('SELECT kafka_key, key, topic, value, offset FROM test.view')
         if kafka_check_result(result, False, 'test_kafka_virtual2.reference'):
             break
-        time.sleep(0.5)
-    kafka_check_result(result, True, 'test_kafka_virtual2.reference')
 
     instance.query('''
         DROP TABLE test.consumer;
         DROP TABLE test.view;
     ''')
+
+    kafka_check_result(result, True, 'test_kafka_virtual2.reference')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Do not pause/resume consumer on subscription at all - otherwise it may get paused indefinitely in some scenarios.

Detailed description:
Try to wait until the consumer gets subscription in an infinite loop - assume that it won't get hung.