### PR TITLE
No virtual columns in system.columns

### DIFF
--- a/dbms/src/Storages/System/StorageSystemColumns.cpp
+++ b/dbms/src/Storages/System/StorageSystemColumns.cpp
@@ -126,6 +126,9 @@ protected:
 
             for (const auto & column : columns)
             {
+                if (column.is_virtual)
+                    continue;
+
                 size_t src_index = 0;
                 size_t res_index = 0;
 

--- a/dbms/tests/queries/0_stateless/00981_no_virtual_columns_in_system_columns.reference
+++ b/dbms/tests/queries/0_stateless/00981_no_virtual_columns_in_system_columns.reference
@@ -1,0 +1,1 @@
+default	merge_ab	x	UInt8			0	0	0		0	0	0	0	

--- a/dbms/tests/queries/0_stateless/00981_no_virtual_columns_in_system_columns.sql
+++ b/dbms/tests/queries/0_stateless/00981_no_virtual_columns_in_system_columns.sql
@@ -1,0 +1,13 @@
+DROP TABLE IF EXISTS merge_a;
+DROP TABLE IF EXISTS merge_b;
+DROP TABLE IF EXISTS merge_ab;
+
+CREATE TABLE merge_a (x UInt8) ENGINE = StripeLog;
+CREATE TABLE merge_b (x UInt8) ENGINE = StripeLog;
+CREATE TABLE merge_ab AS merge(currentDatabase(), '^merge_[ab]$');
+
+SELECT * FROM system.columns WHERE database = currentDatabase() AND table = 'merge_ab';
+
+DROP TABLE merge_a;
+DROP TABLE merge_b;
+DROP TABLE merge_ab;


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Do not expose virtual columns in `system.columns` table. This is required for backward compatibility.