### PR TITLE
Fix behavior low cardinality setting in creating materialized view (Fix #6293) 

### DIFF
--- a/dbms/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterCreateQuery.cpp
@@ -542,7 +542,7 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
         columns = setColumns(create, as_select_sample, as_storage);
 
         /// Check low cardinality types in creating table if it was not allowed in setting
-        if (!create.attach && !context.getSettingsRef().allow_suspicious_low_cardinality_types)
+        if (!create.attach && !context.getSettingsRef().allow_suspicious_low_cardinality_types && !create.is_materialized_view)
         {
             for (const auto & name_and_type_pair : columns.getAllPhysical())
             {

--- a/dbms/tests/queries/0_stateless/00982_low_cardinality_setting_in_mv.sql
+++ b/dbms/tests/queries/0_stateless/00982_low_cardinality_setting_in_mv.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS test1;
+DROP TABLE IF EXISTS test2;
+DROP TABLE IF EXISTS mat_view;
+
+CREATE TABLE test1 (a LowCardinality(String)) ENGINE=MergeTree() ORDER BY a;
+CREATE TABLE test2 (a UInt64) engine=MergeTree() ORDER BY a;
+CREATE MATERIALIZED VIEW test_mv TO test2 AS SELECT toUInt64(a = 'test') FROM test1;
+
+DROP TABLE test_mv;
+DROP TABLE test1;
+DROP TABLE test2;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.
Fix #6293
Category (leave one):
- Bug Fix. Small one.

Short description (up to few sentences):
Materialized view now could be created with any low cardinality types regardless to the setting about suspicious low cardinality types.