### PR TITLE
X-ClickHouse header with query dependent tables

### DIFF
--- a/dbms/programs/local/LocalServer.cpp
+++ b/dbms/programs/local/LocalServer.cpp
@@ -302,7 +302,7 @@ void LocalServer::processQueries()
 
         try
         {
-            executeQuery(read_buf, write_buf, /* allow_into_outfile = */ true, *context, {}, {});
+            executeQuery(read_buf, write_buf, /* allow_into_outfile = */ true, *context, {}, {}, {});
         }
         catch (...)
         {

--- a/dbms/programs/server/HTTPHandler.cpp
+++ b/dbms/programs/server/HTTPHandler.cpp
@@ -623,8 +623,17 @@ void HTTPHandler::processQuery(
     customizeContext(context);
 
     executeQuery(*in, *used_output.out_maybe_delayed_and_compressed, /* allow_into_outfile = */ false, context,
-        [&response] (const String & content_type) { response.setContentType(content_type); },
-        [&response] (const String & current_query_id) { response.add("X-ClickHouse-Query-Id", current_query_id); });
+        [&response] (const String & content_type) {
+            response.setContentType(content_type);
+        },
+        [&response] (const String & current_query_id) {
+            response.add("X-ClickHouse-Query-Id", current_query_id);
+        },
+        [&response] (const String & dependent_tables) {
+            if (!dependent_tables.empty())
+                response.add("X-ClickHouse-Query-Dependent-Tables", dependent_tables);
+        }
+    );
 
     if (used_output.hasDelayed())
     {

--- a/dbms/programs/server/MySQLHandler.cpp
+++ b/dbms/programs/server/MySQLHandler.cpp
@@ -381,7 +381,7 @@ void MySQLHandler::comQuery(ReadBuffer & payload)
         should_replace = true;
     }
 
-    executeQuery(should_replace ? empty_select : payload, *out, true, connection_context, set_content_type, nullptr);
+    executeQuery(should_replace ? empty_select : payload, *out, true, connection_context, set_content_type, nullptr, nullptr);
 
     if (!with_output)
         packet_sender->sendPacket(OK_Packet(0x00, client_capability_flags, 0, 0, 0), true);

--- a/dbms/src/Interpreters/DDLWorker.cpp
+++ b/dbms/src/Interpreters/DDLWorker.cpp
@@ -555,7 +555,7 @@ bool DDLWorker::tryExecuteQuery(const String & query, const DDLTask & task, Exec
         current_context = std::make_unique<Context>(context);
         current_context->getClientInfo().query_kind = ClientInfo::QueryKind::SECONDARY_QUERY;
         current_context->setCurrentQueryId(""); // generate random query_id
-        executeQuery(istr, ostr, false, *current_context, {}, {});
+        executeQuery(istr, ostr, false, *current_context, {}, {}, {});
     }
     catch (...)
     {

--- a/dbms/src/Interpreters/executeQuery.h
+++ b/dbms/src/Interpreters/executeQuery.h
@@ -20,7 +20,8 @@ void executeQuery(
     bool allow_into_outfile,            /// If true and the query contains INTO OUTFILE section, redirect output to that file.
     Context & context,                  /// DB, tables, data types, storage engines, functions, aggregate functions...
     std::function<void(const String &)> set_content_type, /// If non-empty callback is passed, it will be called with the Content-Type of the result.
-    std::function<void(const String &)> set_query_id /// If non-empty callback is passed, it will be called with the query id.
+    std::function<void(const String &)> set_query_id, /// If non-empty callback is passed, it will be called with the query id.
+    std::function<void(const String &)> set_dependent_tables /// If non-empty callback is passed, it will be called with the dependent tables.
     );
 
 

--- a/dbms/src/Interpreters/tests/select_query.cpp
+++ b/dbms/src/Interpreters/tests/select_query.cpp
@@ -46,7 +46,7 @@ try
     ReadBufferFromFileDescriptor in(STDIN_FILENO);
     WriteBufferFromFileDescriptor out(STDOUT_FILENO);
 
-    executeQuery(in, out, /* allow_into_outfile = */ false, context, {}, {});
+    executeQuery(in, out, /* allow_into_outfile = */ false, context, {}, {}, {});
 
     return 0;
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- New Feature

Short description (up to few sentences):

Add a new `X-ClickHouse-Query-Dependent-Tables` header with the query's involved tables. For insert queries, it also returns dependent views. This helps with invalidations when running the ClickHouse HTTP server behind a caching layer like Varnish.

Detailed description (optional):

```sh
clickhouse-client --query 'CREATE TABLE test (a UInt64) ENGINE=Memory()'
clickhouse-client --query 'CREATE MATERIALIZED VIEW vtest ENGINE=Memory() AS SELECT a * 10 as a FROM test'

curl -v "http://localhost:8123/?query=SELECT+count()+FROM+test" 2>&1 >/dev/null | grep X-ClickHouse-Query-Dependent-Tables
< X-ClickHouse-Query-Dependent-Tables: default.test
curl -v "http://localhost:8123/?query=SELECT+count()+FROM+vtest" 2>&1 >/dev/null | grep X-ClickHouse-Query-Dependent-Tables
< X-ClickHouse-Query-Dependent-Tables: default.vtest

curl -X POST -v "http://localhost:8123/" -d "INSERT INTO test VALUES(1)" 2>&1 >/dev/null | grep X-ClickHouse-Query-Dependent-Tables
< X-ClickHouse-Query-Dependent-Tables: default.test default.vtest
```

