### PR TITLE
Fix memory tracking under sanitizers

### DIFF
--- a/dbms/src/Common/new_delete.cpp
+++ b/dbms/src/Common/new_delete.cpp
@@ -1,3 +1,4 @@
+#include <malloc.h>
 #include <new>
 
 #include <common/config_common.h>
@@ -49,6 +50,11 @@ ALWAYS_INLINE void untrackMemory(void * ptr [[maybe_unused]], std::size_t size [
 #else
         if (size)
             CurrentMemoryTracker::free(size);
+#ifdef _GNU_SOURCE
+        /// It's innaccurate resource free for sanitizers. malloc_usable_size() result is greater or equal to allocated size.
+        else
+            CurrentMemoryTracker::free(malloc_usable_size(ptr));
+#endif
 #endif
     }
     catch (...)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Fix new/delete memory tracking then build with sanitizers. Tracking is not clear. It only prevents memory limit exceptions in tests.
