### PR TITLE
Fix recreation of replicated table with fixed granularity

### DIFF
--- a/dbms/src/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.h
@@ -576,7 +576,9 @@ public:
 
     virtual std::vector<MergeTreeMutationStatus> getMutationsStatus() const = 0;
 
-    bool canUseAdaptiveGranularity() const
+    /// Returns true if table can create new parts with adaptive granularity
+    /// Has additional constraint in replicated version
+    virtual bool canUseAdaptiveGranularity() const
     {
         return settings.index_granularity_bytes != 0 &&
             (settings.enable_mixed_granularity_parts || !has_non_adaptive_index_granularity_parts);
@@ -632,7 +634,7 @@ public:
     String sampling_expr_column_name;
     Names columns_required_for_sampling;
 
-    const MergeTreeSettings settings;
+    MergeTreeSettings settings;
 
     /// Limiting parallel sends per one table, used in DataPartsExchange
     std::atomic_uint current_table_sends {0};

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -297,6 +297,17 @@ StorageReplicatedMergeTree::StorageReplicatedMergeTree(
     }
 
     createNewZooKeeperNodes();
+
+    other_replicas_fixed_granularity = checkFixedGranualrityInZookeeper();
+}
+
+
+bool StorageReplicatedMergeTree::checkFixedGranualrityInZookeeper()
+{
+    auto zookeeper = getZooKeeper();
+    String metadata_str = zookeeper->get(zookeeper_path + "/metadata");
+    auto metadata_from_zk = ReplicatedMergeTreeTableMetadata::parse(metadata_str);
+    return metadata_from_zk.index_granularity_bytes == 0;
 }
 
 
@@ -5142,5 +5153,13 @@ CheckResults StorageReplicatedMergeTree::checkData(const ASTPtr & query, const C
     }
     return results;
 }
+
+bool StorageReplicatedMergeTree::canUseAdaptiveGranularity() const
+{
+    return settings.index_granularity_bytes != 0 &&
+        (settings.enable_mixed_granularity_parts ||
+            (!has_non_adaptive_index_granularity_parts && !other_replicas_fixed_granularity));
+}
+
 
 }

--- a/dbms/src/Storages/StorageReplicatedMergeTree.h
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.h
@@ -172,6 +172,9 @@ public:
 
     CheckResults checkData(const ASTPtr & query, const Context & context) override;
 
+    /// Checks ability to use granularity
+    bool canUseAdaptiveGranularity() const override;
+
 private:
     /// Delete old parts from disk and from ZooKeeper.
     void clearOldPartsAndRemoveFromZK();
@@ -284,6 +287,9 @@ private:
 
     /// An event that awakens `alter` method from waiting for the completion of the ALTER query.
     zkutil::EventPtr alter_query_event = std::make_shared<Poco::Event>();
+
+    /// True if replica was created for existing table with fixed granularity
+    bool other_replicas_fixed_granularity = false;
 
     /** Creates the minimum set of nodes in ZooKeeper.
       */
@@ -505,6 +511,10 @@ private:
     void attachPartition(const ASTPtr & partition, bool part, const Context & query_context);
     void replacePartitionFrom(const StoragePtr & source_table, const ASTPtr & partition, bool replace, const Context & query_context);
     void fetchPartition(const ASTPtr & partition, const String & from, const Context & query_context);
+
+    /// Check granularity of already existing replicated table in zookeeper if it exists
+    /// return true if it's fixed
+    bool checkFixedGranualrityInZookeeper();
 
 protected:
     /** If not 'attach', either creates a new table in ZK, or adds a replica to an existing table.

--- a/dbms/tests/integration/test_adaptive_granularity_replicated/test.py
+++ b/dbms/tests/integration/test_adaptive_granularity_replicated/test.py
@@ -1,0 +1,97 @@
+import time
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from multiprocessing.dummy import Pool
+from helpers.client import QueryRuntimeException, QueryTimeoutExceedException
+
+from helpers.test_tools import assert_eq_with_retry
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance('node1', with_zookeeper=True)
+node2 = cluster.add_instance('node2', with_zookeeper=True)
+node3 = cluster.add_instance('node3', with_zookeeper=True, image='yandex/clickhouse-server:19.1.14', with_installed_binary=True)
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        time.sleep(1)
+
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+def test_creating_table_different_setting(start_cluster):
+    node1.query("CREATE TABLE t1 (c1 String, c2 String) ENGINE=ReplicatedMergeTree('/clickhouse/t1', '1') ORDER BY tuple(c1) SETTINGS index_granularity_bytes = 0")
+    node1.query("INSERT INTO t1 VALUES('x', 'y')")
+
+    node2.query("CREATE TABLE t1 (c1 String, c2 String) ENGINE=ReplicatedMergeTree('/clickhouse/t1', '2') ORDER BY tuple(c1)")
+
+    node1.query("INSERT INTO t1 VALUES('a', 'b')")
+    node2.query("SYSTEM SYNC REPLICA t1", timeout=5)
+
+    node1.query("SELECT count() FROM t1") == "2\n"
+    node2.query("SELECT count() FROM t1") == "1\n"
+
+    node2.query("INSERT INTO t1 VALUES('c', 'd')")
+    node1.query("SYSTEM SYNC REPLICA t1", timeout=5)
+
+    # replication works
+    node1.query("SELECT count() FROM t1") == "3\n"
+    node2.query("SELECT count() FROM t1") == "2\n"
+
+    # OPTIMIZE also works correctly
+    node2.query("OPTIMIZE TABLE t1 FINAL") == "3\n"
+    node1.query("SYSTEM SYNC REPLICA t1", timeout=5)
+
+    node1.query("SELECT count() FROM t1") == "3\n"
+    node2.query("SELECT count() FROM t1") == "2\n"
+
+    path_part = node1.query("SELECT path FROM system.parts WHERE table = 't1' AND active=1 ORDER BY partition DESC LIMIT 1").strip()
+
+    with pytest.raises(Exception): # check that we have no adaptive files
+        node1.exec_in_container(["bash", "-c", "find {p} -name '*.mrk2' | grep '.*'".format(p=path_part)])
+
+    path_part = node2.query("SELECT path FROM system.parts WHERE table = 't1' AND active=1 ORDER BY partition DESC LIMIT 1").strip()
+
+    with pytest.raises(Exception): # check that we have no adaptive files
+        node2.exec_in_container(["bash", "-c", "find {p} -name '*.mrk2' | grep '.*'".format(p=path_part)])
+
+
+def test_old_node_with_new_node(start_cluster):
+    node3.query("CREATE TABLE t2 (c1 String, c2 String) ENGINE=ReplicatedMergeTree('/clickhouse/t2', '3') ORDER BY tuple(c1)")
+    node3.query("INSERT INTO t2 VALUES('x', 'y')")
+
+    node2.query("CREATE TABLE t2 (c1 String, c2 String) ENGINE=ReplicatedMergeTree('/clickhouse/t2', '2') ORDER BY tuple(c1)")
+
+    node3.query("INSERT INTO t2 VALUES('a', 'b')")
+    node2.query("SYSTEM SYNC REPLICA t2", timeout=5)
+
+    node3.query("SELECT count() FROM t2") == "2\n"
+    node2.query("SELECT count() FROM t2") == "1\n"
+
+    node2.query("INSERT INTO t2 VALUES('c', 'd')")
+    node3.query("SYSTEM SYNC REPLICA t2", timeout=5)
+
+    # replication works
+    node3.query("SELECT count() FROM t2") == "3\n"
+    node2.query("SELECT count() FROM t2") == "2\n"
+
+    # OPTIMIZE also works correctly
+    node3.query("OPTIMIZE table t2 FINAL")
+    node2.query("SYSTEM SYNC REPLICA t2", timeout=5)
+
+    node3.query("SELECT count() FROM t2") == "3\n"
+    node2.query("SELECT count() FROM t2") == "2\n"
+
+    path_part = node3.query("SELECT path FROM system.parts WHERE table = 't2' AND active=1 ORDER BY partition DESC LIMIT 1").strip()
+
+    with pytest.raises(Exception): # check that we have no adaptive files
+        node3.exec_in_container(["bash", "-c", "find {p} -name '*.mrk2' | grep '.*'".format(p=path_part)])
+
+    path_part = node2.query("SELECT path FROM system.parts WHERE table = 't2' AND active=1 ORDER BY partition DESC LIMIT 1").strip()
+
+    with pytest.raises(Exception): # check that we have no adaptive files
+        node2.exec_in_container(["bash", "-c", "find {p} -name '*.mrk2' | grep '.*'".format(p=path_part)])


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fix bug with enabling adaptive granularity when creating new replica for Replicated*MergeTree table. Fixes https://github.com/yandex/ClickHouse/issues/6394.