### PR TITLE
CurrentThread initialization bug

### DIFF
--- a/dbms/src/Common/CurrentThread.cpp
+++ b/dbms/src/Common/CurrentThread.cpp
@@ -26,6 +26,11 @@ void CurrentThread::updatePerformanceCounters()
     current_thread->updatePerformanceCounters();
 }
 
+bool CurrentThread::isInitialized()
+{
+    return unlikely(current_thread);
+}
+
 ThreadStatus & CurrentThread::get()
 {
     if (unlikely(!current_thread))

--- a/dbms/src/Common/CurrentThread.cpp
+++ b/dbms/src/Common/CurrentThread.cpp
@@ -28,7 +28,7 @@ void CurrentThread::updatePerformanceCounters()
 
 bool CurrentThread::isInitialized()
 {
-    return likely(current_thread);
+    return current_thread;
 }
 
 ThreadStatus & CurrentThread::get()

--- a/dbms/src/Common/CurrentThread.cpp
+++ b/dbms/src/Common/CurrentThread.cpp
@@ -28,7 +28,7 @@ void CurrentThread::updatePerformanceCounters()
 
 bool CurrentThread::isInitialized()
 {
-    return unlikely(current_thread);
+    return likely(current_thread);
 }
 
 ThreadStatus & CurrentThread::get()

--- a/dbms/src/Common/CurrentThread.h
+++ b/dbms/src/Common/CurrentThread.h
@@ -33,6 +33,9 @@ class InternalTextLogsQueue;
 class CurrentThread
 {
 public:
+    //Return true in case of successful initializaiton
+    static bool isInitialized();
+
     /// Handler to current thread
     static ThreadStatus & get();
 

--- a/dbms/src/Common/CurrentThread.h
+++ b/dbms/src/Common/CurrentThread.h
@@ -33,7 +33,7 @@ class InternalTextLogsQueue;
 class CurrentThread
 {
 public:
-    //Return true in case of successful initializaiton
+    /// Return true in case of successful initializaiton
     static bool isInitialized();
 
     /// Handler to current thread

--- a/libs/libloggers/loggers/OwnSplitChannel.cpp
+++ b/libs/libloggers/loggers/OwnSplitChannel.cpp
@@ -58,14 +58,11 @@ void OwnSplitChannel::log(const Poco::Message & msg)
 
     elem.thread_name = getThreadName();
     elem.thread_number = msg_ext.thread_number;
-    try
-    {
-        if (CurrentThread::isInitialized())
-            elem.os_thread_id = CurrentThread::get().os_thread_id;
-    } catch (...)
-    {
+
+    if (CurrentThread::isInitialized())
+        elem.os_thread_id = CurrentThread::get().os_thread_id;
+    else
         elem.os_thread_id = 0;
-    }
 
     elem.query_id = msg_ext.query_id;
 

--- a/libs/libloggers/loggers/OwnSplitChannel.cpp
+++ b/libs/libloggers/loggers/OwnSplitChannel.cpp
@@ -60,7 +60,8 @@ void OwnSplitChannel::log(const Poco::Message & msg)
     elem.thread_number = msg_ext.thread_number;
     try
     {
-        elem.os_thread_id = CurrentThread::get().os_thread_id;
+        if (CurrentThread::isInitialized())
+            elem.os_thread_id = CurrentThread::get().os_thread_id;
     } catch (...)
     {
         elem.os_thread_id = 0;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fixed possible crash during server startup in case of exception happened in `libunwind` during exception at access to uninitialised `ThreadStatus` structure.