### PR TITLE
update macOS build docs (gcc -> gcc@8)

### DIFF
--- a/docs/en/development/build_osx.md
+++ b/docs/en/development/build_osx.md
@@ -11,7 +11,7 @@ Build should work on Mac OS X 10.12.
 ## Install Required Compilers, Tools, and Libraries
 
 ```bash
-brew install cmake ninja gcc icu4c openssl libtool gettext readline gperf
+brew install cmake ninja gcc@8 icu4c openssl libtool gettext readline gperf
 ```
 
 ## Checkout ClickHouse Sources


### PR DESCRIPTION
homebrew gcc is now @9, but ClickHouse build requires gcc-8 and g++-8