### PR TITLE
typechecks for set index functions

### DIFF
--- a/dbms/src/Functions/bitBoolMaskAnd.cpp
+++ b/dbms/src/Functions/bitBoolMaskAnd.cpp
@@ -4,6 +4,10 @@
 
 namespace DB
 {
+    namespace ErrorCodes
+    {
+        extern const int BAD_CAST;
+    }
 
     /// Working with UInt8: last bit = can be true, previous = can be false (Like dbms/src/Storages/MergeTree/BoolMask.h).
     /// This function provides "AND" operation for BoolMasks.
@@ -17,6 +21,8 @@ namespace DB
         template <typename Result = ResultType>
         static inline Result apply(A left, B right)
         {
+            if constexpr (!std::is_same_v<A, ResultType> || !std::is_same_v<B, ResultType>)
+                throw DB::Exception("Only UInt8 type is supported by __bitBoolMaskAnd.", ErrorCodes::BAD_CAST);
             return static_cast<ResultType>(
                     ((static_cast<ResultType>(left) & static_cast<ResultType>(right)) & 1)
                     | ((((static_cast<ResultType>(left) >> 1) | (static_cast<ResultType>(right) >> 1)) & 1) << 1));

--- a/dbms/src/Functions/bitBoolMaskAnd.cpp
+++ b/dbms/src/Functions/bitBoolMaskAnd.cpp
@@ -22,7 +22,7 @@ namespace DB
         static inline Result apply(A left, B right)
         {
             if constexpr (!std::is_same_v<A, ResultType> || !std::is_same_v<B, ResultType>)
-                throw DB::Exception("Only UInt8 type is supported by __bitBoolMaskAnd.", ErrorCodes::BAD_CAST);
+                throw DB::Exception("It's a bug! Only UInt8 type is supported by __bitBoolMaskAnd.", ErrorCodes::BAD_CAST);
             return static_cast<ResultType>(
                     ((static_cast<ResultType>(left) & static_cast<ResultType>(right)) & 1)
                     | ((((static_cast<ResultType>(left) >> 1) | (static_cast<ResultType>(right) >> 1)) & 1) << 1));

--- a/dbms/src/Functions/bitBoolMaskOr.cpp
+++ b/dbms/src/Functions/bitBoolMaskOr.cpp
@@ -4,6 +4,10 @@
 
 namespace DB
 {
+    namespace ErrorCodes
+    {
+        extern const int BAD_CAST;
+    }
 
     /// Working with UInt8: last bit = can be true, previous = can be false (Like dbms/src/Storages/MergeTree/BoolMask.h).
     /// This function provides "OR" operation for BoolMasks.
@@ -17,6 +21,8 @@ namespace DB
         template <typename Result = ResultType>
         static inline Result apply(A left, B right)
         {
+            if constexpr (!std::is_same_v<A, ResultType> || !std::is_same_v<B, ResultType>)
+                throw DB::Exception("Only UInt8 type is supported by __bitBoolMaskOr.", ErrorCodes::BAD_CAST);
             return static_cast<ResultType>(
                     ((static_cast<ResultType>(left) | static_cast<ResultType>(right)) & 1)
                     | ((((static_cast<ResultType>(left) >> 1) & (static_cast<ResultType>(right) >> 1)) & 1) << 1));

--- a/dbms/src/Functions/bitBoolMaskOr.cpp
+++ b/dbms/src/Functions/bitBoolMaskOr.cpp
@@ -22,7 +22,7 @@ namespace DB
         static inline Result apply(A left, B right)
         {
             if constexpr (!std::is_same_v<A, ResultType> || !std::is_same_v<B, ResultType>)
-                throw DB::Exception("Only UInt8 type is supported by __bitBoolMaskOr.", ErrorCodes::BAD_CAST);
+                throw DB::Exception("It's a bug! Only UInt8 type is supported by __bitBoolMaskOr.", ErrorCodes::BAD_CAST);
             return static_cast<ResultType>(
                     ((static_cast<ResultType>(left) | static_cast<ResultType>(right)) & 1)
                     | ((((static_cast<ResultType>(left) >> 1) & (static_cast<ResultType>(right) >> 1)) & 1) << 1));

--- a/dbms/src/Functions/bitSwapLastTwo.cpp
+++ b/dbms/src/Functions/bitSwapLastTwo.cpp
@@ -4,6 +4,10 @@
 
 namespace DB
 {
+    namespace ErrorCodes
+    {
+        extern const int BAD_CAST;
+    }
 
     /// Working with UInt8: last bit = can be true, previous = can be false (Like dbms/src/Storages/MergeTree/BoolMask.h).
     /// This function provides "NOT" operation for BoolMasks by swapping last two bits ("can be true" <-> "can be false").
@@ -14,6 +18,8 @@ namespace DB
 
         static inline ResultType NO_SANITIZE_UNDEFINED apply(A a)
         {
+            if constexpr (!std::is_same_v<A, ResultType>)
+                throw DB::Exception("Only UInt8 type is supported by __bitSwapLastTwo.", ErrorCodes::BAD_CAST);
             return static_cast<ResultType>(
                     ((static_cast<ResultType>(a) & 1) << 1) | ((static_cast<ResultType>(a) >> 1) & 1));
         }

--- a/dbms/src/Functions/bitSwapLastTwo.cpp
+++ b/dbms/src/Functions/bitSwapLastTwo.cpp
@@ -19,7 +19,7 @@ namespace DB
         static inline ResultType NO_SANITIZE_UNDEFINED apply(A a)
         {
             if constexpr (!std::is_same_v<A, ResultType>)
-                throw DB::Exception("Only UInt8 type is supported by __bitSwapLastTwo.", ErrorCodes::BAD_CAST);
+                throw DB::Exception("It's a bug! Only UInt8 type is supported by __bitSwapLastTwo.", ErrorCodes::BAD_CAST);
             return static_cast<ResultType>(
                     ((static_cast<ResultType>(a) & 1) << 1) | ((static_cast<ResultType>(a) >> 1) & 1));
         }

--- a/dbms/src/Functions/bitWrapperFunc.cpp
+++ b/dbms/src/Functions/bitWrapperFunc.cpp
@@ -4,6 +4,10 @@
 
 namespace DB
 {
+    namespace ErrorCodes
+    {
+        extern const int BAD_CAST;
+    }
 
     /// Working with UInt8: last bit = can be true, previous = can be false (Like dbms/src/Storages/MergeTree/BoolMask.h).
     /// This function wraps bool atomic functions
@@ -15,7 +19,9 @@ namespace DB
 
         static inline ResultType NO_SANITIZE_UNDEFINED apply(A a)
         {
-            return a == static_cast<UInt8>(0) ? static_cast<ResultType>(0b10) : static_cast<ResultType >(0b1);
+            if constexpr (!std::is_integral_v<A>)
+                throw DB::Exception("It's a bug! Only integer types are supported by __bitWrapperFunc.", ErrorCodes::BAD_CAST);
+            return a == 0 ? static_cast<ResultType>(0b10) : static_cast<ResultType >(0b1);
         }
 
 #if USE_EMBEDDED_COMPILER


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Throw exception if function got a wrong type. This fixes fuzz test with UBSan.