### PR TITLE
Enabled sha256_password plugin in MariaDB Connector/C

### DIFF
--- a/contrib/mariadb-connector-c-cmake/CMakeLists.txt
+++ b/contrib/mariadb-connector-c-cmake/CMakeLists.txt
@@ -42,6 +42,7 @@ ${MARIADB_CLIENT_SOURCE_DIR}/plugins/auth/mariadb_cleartext.c
 ${MARIADB_CLIENT_SOURCE_DIR}/plugins/auth/my_auth.c
 ${MARIADB_CLIENT_SOURCE_DIR}/plugins/auth/old_password.c
 ${MARIADB_CLIENT_SOURCE_DIR}/plugins/auth/sha256_pw.c
+${MARIADB_CLIENT_SOURCE_DIR}/plugins/auth/caching_sha2_pw.c
 #${MARIADB_CLIENT_SOURCE_DIR}/plugins/auth/sspi_client.c
 #${MARIADB_CLIENT_SOURCE_DIR}/plugins/auth/sspi_errmsg.c
 ${MARIADB_CLIENT_SOURCE_DIR}/plugins/connection/aurora.c

--- a/contrib/mariadb-connector-c-cmake/CMakeLists.txt
+++ b/contrib/mariadb-connector-c-cmake/CMakeLists.txt
@@ -31,6 +31,7 @@ ${MARIADB_CLIENT_SOURCE_DIR}/libmariadb/ma_stmt_codec.c
 ${MARIADB_CLIENT_SOURCE_DIR}/libmariadb/ma_string.c
 ${MARIADB_CLIENT_SOURCE_DIR}/libmariadb/ma_time.c
 ${MARIADB_CLIENT_SOURCE_DIR}/libmariadb/ma_tls.c
+${MARIADB_CLIENT_SOURCE_DIR}/libmariadb/secure/openssl_crypt.c
 #${MARIADB_CLIENT_SOURCE_DIR}/libmariadb/secure/gnutls.c
 #${MARIADB_CLIENT_SOURCE_DIR}/libmariadb/secure/ma_schannel.c
 #${MARIADB_CLIENT_SOURCE_DIR}/libmariadb/secure/schannel.c

--- a/contrib/mariadb-connector-c-cmake/linux_x86_64/libmariadb/ma_client_plugin.c
+++ b/contrib/mariadb-connector-c-cmake/linux_x86_64/libmariadb/ma_client_plugin.c
@@ -80,6 +80,7 @@ extern struct st_mysql_client_plugin mysql_native_password_client_plugin;
 extern struct st_mysql_client_plugin mysql_old_password_client_plugin;
 extern struct st_mysql_client_plugin pvio_socket_client_plugin;
 extern struct st_mysql_client_plugin sha256_password_client_plugin;
+extern struct st_mysql_client_plugin caching_sha2_password_client_plugin;
 
 
 struct st_mysql_client_plugin *mysql_client_builtins[]=
@@ -88,6 +89,7 @@ struct st_mysql_client_plugin *mysql_client_builtins[]=
   (struct st_mysql_client_plugin *)&mysql_old_password_client_plugin,
   (struct st_mysql_client_plugin *)&pvio_socket_client_plugin,
   (struct st_mysql_client_plugin *)&sha256_password_client_plugin,
+  (struct st_mysql_client_plugin *)&caching_sha2_password_client_plugin,
   0
 };
 

--- a/contrib/mariadb-connector-c-cmake/linux_x86_64/libmariadb/ma_client_plugin.c
+++ b/contrib/mariadb-connector-c-cmake/linux_x86_64/libmariadb/ma_client_plugin.c
@@ -76,17 +76,18 @@ struct st_client_plugin_int *plugin_list[MYSQL_CLIENT_MAX_PLUGINS + MARIADB_CLIE
 static pthread_mutex_t LOCK_load_client_plugin;
 #endif
 
- extern struct st_mysql_client_plugin mysql_native_password_client_plugin;
- extern struct st_mysql_client_plugin mysql_old_password_client_plugin;
- extern struct st_mysql_client_plugin pvio_socket_client_plugin;
+extern struct st_mysql_client_plugin mysql_native_password_client_plugin;
+extern struct st_mysql_client_plugin mysql_old_password_client_plugin;
+extern struct st_mysql_client_plugin pvio_socket_client_plugin;
+extern struct st_mysql_client_plugin sha256_password_client_plugin;
 
 
 struct st_mysql_client_plugin *mysql_client_builtins[]=
 {
-     (struct st_mysql_client_plugin *)&mysql_native_password_client_plugin,
-   (struct st_mysql_client_plugin *)&mysql_old_password_client_plugin,
-   (struct st_mysql_client_plugin *)&pvio_socket_client_plugin,
-
+  (struct st_mysql_client_plugin *)&mysql_native_password_client_plugin,
+  (struct st_mysql_client_plugin *)&mysql_old_password_client_plugin,
+  (struct st_mysql_client_plugin *)&pvio_socket_client_plugin,
+  (struct st_mysql_client_plugin *)&sha256_password_client_plugin,
   0
 };
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

Short description (up to few sentences):
Static linking of sha256_password authentication plugin.