### PR TITLE
Fix nullIf function compiled using Clang

### DIFF
--- a/dbms/src/Functions/nullIf.cpp
+++ b/dbms/src/Functions/nullIf.cpp
@@ -34,7 +34,6 @@ public:
 
     size_t getNumberOfArguments() const override { return 2; }
     bool useDefaultImplementationForNulls() const override { return false; }
-    bool useDefaultImplementationForConstants() const override { return true; }
 
     DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
     {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):

Followup PR concerning #6446

Using Clang  7.1.0, `SELECT nullIf(1, NULL)` returned `NULL` on every case. Now it return the correct value with setting the original value of `useDefaultImplementationForConstants` to true.