### PR TITLE
DEVTOOLS-5755 Remove odbc-bridge.cpp from clickhouse-lib

### DIFF
--- a/dbms/programs/odbc-bridge/CMakeLists.txt
+++ b/dbms/programs/odbc-bridge/CMakeLists.txt
@@ -5,7 +5,6 @@ set(CLICKHOUSE_ODBC_BRIDGE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/IdentifierQuoteHandler.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/MainHandler.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ODBCBlockInputStream.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/odbc-bridge.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ODBCBridge.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/PingHandler.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/validateODBCConnectionString.cpp


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):

odbc-bridge.cpp defines main() so it should not be included in clickhouse-lib.