### PR TITLE
MySQL 8 integration requires previous declaration checks

### DIFF
--- a/libs/libmysqlxx/include/mysqlxx/Types.h
+++ b/libs/libmysqlxx/include/mysqlxx/Types.h
@@ -3,6 +3,8 @@
 #include <cstdint>
 #include <string>
 
+#ifndef _mysql_h
+
 struct st_mysql;
 using MYSQL = st_mysql;
 
@@ -14,7 +16,7 @@ using MYSQL_ROW = char**;
 struct st_mysql_field;
 using MYSQL_FIELD = st_mysql_field;
 
-
+#endif
 
 namespace mysqlxx
 {


### PR DESCRIPTION
C and C++ differ in the form of types being defined. While C++ structs
are defined also as new types, in C you have to explicitly typedef the
struct to have a new type.

Fir this case, it was enough to check if MySQL header was already
defined in order not to re-declare MYSQL, MYSQL_RES, MYSQL_ROW and
MYSQL_FIELD.

Signed-off-by: Rafael David Tinoco <rafaeldtinoco@ubuntu.com>

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement
