### PR TITLE
Disable ELF on Mac OS

### DIFF
--- a/dbms/src/Common/Dwarf.cpp
+++ b/dbms/src/Common/Dwarf.cpp
@@ -1,3 +1,5 @@
+#ifdef __ELF__
+
 /*
  * Copyright 2012-present Facebook, Inc.
  *
@@ -1031,3 +1033,5 @@ bool Dwarf::LineNumberVM::findAddress(uintptr_t target, Path & file, uint64_t & 
 }
 
 }
+
+#endif

--- a/dbms/src/Common/Dwarf.h
+++ b/dbms/src/Common/Dwarf.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#ifdef __ELF__
+
 /*
  * Copyright 2012-present Facebook, Inc.
  *
@@ -285,3 +287,5 @@ private:
 };
 
 }
+
+#endif

--- a/dbms/src/Common/Elf.cpp
+++ b/dbms/src/Common/Elf.cpp
@@ -1,3 +1,5 @@
+#ifdef __ELF__
+
 #include <Common/Elf.h>
 #include <Common/Exception.h>
 
@@ -128,3 +130,5 @@ size_t Elf::Section::size() const
 }
 
 }
+
+#endif

--- a/dbms/src/Common/Elf.h
+++ b/dbms/src/Common/Elf.h
@@ -1,44 +1,15 @@
 #pragma once
 
+#ifdef __ELF__
+
 #include <IO/MMapReadBufferFromFile.h>
 
 #include <string>
 #include <optional>
 #include <functional>
 
-#ifdef __APPLE__
-
-#include <libelf/gelf.h>
-
-typedef Elf64_Addr GElf_Addr;
-typedef Elf64_Half GElf_Half;
-typedef Elf64_Off GElf_Off;
-typedef Elf64_Sword GElf_Sword;
-typedef Elf64_Word GElf_Word;
-typedef Elf64_Sxword GElf_Sxword;
-typedef Elf64_Xword GElf_Xword;
-
-typedef Elf64_Ehdr GElf_Ehdr;
-typedef Elf64_Phdr GElf_Phdr;
-typedef Elf64_Shdr GElf_Shdr;
-typedef Elf64_Dyn GElf_Dyn;
-typedef Elf64_Rel GElf_Rel;
-typedef Elf64_Rela GElf_Rela;
-typedef Elf64_Sym GElf_Sym;
-
-#define DT_GNU_HASH	0x6ffffef5 /* GNU-style hash table. */
-
-#define __ELF_NATIVE_CLASS __WORDSIZE
-#define ElfW(type)         _ElfW(Elf, __ELF_NATIVE_CLASS, type)
-#define _ElfW(e, w, t)     _ElfW_1(e, w, _##t)
-#define _ElfW_1(e, w, t)   e##w##t
-
-#else
-
 #include <elf.h>
 #include <link.h>
-
-#endif
 
 
 using ElfAddr = ElfW(Addr);
@@ -92,3 +63,5 @@ private:
 };
 
 }
+
+#endif

--- a/dbms/src/Common/StackTrace.cpp
+++ b/dbms/src/Common/StackTrace.cpp
@@ -250,6 +250,7 @@ static void toStringEveryLineImpl(const StackTrace::Frames & frames, size_t offs
     if (size == 0)
         return callback("<Empty trace>");
 
+#ifdef __ELF__
     const DB::SymbolIndex & symbol_index = DB::SymbolIndex::instance();
     std::unordered_map<std::string, DB::Dwarf> dwarfs;
 
@@ -290,6 +291,18 @@ static void toStringEveryLineImpl(const StackTrace::Frames & frames, size_t offs
         callback(out.str());
         out.str({});
     }
+#else
+    std::stringstream out;
+
+    for (size_t i = offset; i < size; ++i)
+    {
+        const void * addr = frames[i];
+        out << i << ". " << addr;
+
+        callback(out.str());
+        out.str({});
+    }
+#endif
 }
 
 static std::string toStringImpl(const StackTrace::Frames & frames, size_t offset, size_t size)

--- a/dbms/src/Common/SymbolIndex.cpp
+++ b/dbms/src/Common/SymbolIndex.cpp
@@ -1,3 +1,5 @@
+#ifdef __ELF__
+
 #include <Common/SymbolIndex.h>
 
 #include <algorithm>
@@ -316,3 +318,5 @@ const SymbolIndex::Object * SymbolIndex::findObject(const void * address) const
 }
 
 }
+
+#endif

--- a/dbms/src/Common/SymbolIndex.h
+++ b/dbms/src/Common/SymbolIndex.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#ifdef __ELF__
+
 #include <vector>
 #include <string>
 #include <ext/singleton.h>
@@ -53,3 +55,5 @@ private:
 };
 
 }
+
+#endif

--- a/dbms/src/Common/tests/symbol_index.cpp
+++ b/dbms/src/Common/tests/symbol_index.cpp
@@ -16,6 +16,7 @@ using namespace DB;
 
 int main(int argc, char ** argv)
 {
+#ifdef __ELF__
     if (argc < 2)
     {
         std::cerr << "Usage: ./symbol_index address\n";
@@ -53,6 +54,12 @@ int main(int argc, char ** argv)
 
     std::cerr << "\n";
     std::cerr << StackTrace().toString() << "\n";
+#else
+    (void)argc;
+    (void)argv;
+
+    std::cerr << "This test does not make sense for non-ELF objects.\n";
+#endif
 
     return 0;
 }

--- a/dbms/src/Functions/addressToLine.cpp
+++ b/dbms/src/Functions/addressToLine.cpp
@@ -1,3 +1,5 @@
+#ifdef __ELF__
+
 #include <Common/Elf.h>
 #include <Common/Dwarf.h>
 #include <Common/SymbolIndex.h>
@@ -149,3 +151,5 @@ void registerFunctionAddressToLine(FunctionFactory & factory)
 }
 
 }
+
+#endif

--- a/dbms/src/Functions/addressToSymbol.cpp
+++ b/dbms/src/Functions/addressToSymbol.cpp
@@ -1,3 +1,5 @@
+#ifdef __ELF__
+
 #include <Common/SymbolIndex.h>
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnsNumber.h>
@@ -92,3 +94,5 @@ void registerFunctionAddressToSymbol(FunctionFactory & factory)
 }
 
 }
+
+#endif


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Disable parsing of ELF object files on Mac OS, because it makes no sense.