### PR TITLE
Fix nullIf function.

### DIFF
--- a/dbms/src/Functions/nullIf.cpp
+++ b/dbms/src/Functions/nullIf.cpp
@@ -50,10 +50,10 @@ public:
         auto equals_func = FunctionFactory::instance().get("equals", context)->build(
             {temp_block.getByPosition(arguments[0]), temp_block.getByPosition(arguments[1])});
 
-        size_t not_equals_res_pos = temp_block.columns();
+        size_t equals_res_pos = temp_block.columns();
         temp_block.insert({nullptr, equals_func->getReturnType(), ""});
 
-        equals_func->execute(temp_block, {arguments[0], arguments[1]}, not_equals_res_pos, input_rows_count);
+        equals_func->execute(temp_block, {arguments[0], arguments[1]}, equals_res_pos, input_rows_count);
 
         /// Argument corresponding to the NULL value.
         size_t null_pos = temp_block.columns();
@@ -67,8 +67,8 @@ public:
         temp_block.insert(null_elem);
 
         auto func_if = FunctionFactory::instance().get("if", context)->build(
-            {temp_block.getByPosition(not_equals_res_pos), temp_block.getByPosition(null_pos), temp_block.getByPosition(arguments[0])});
-        func_if->execute(temp_block, {not_equals_res_pos, null_pos, arguments[0]}, result, input_rows_count);
+            {temp_block.getByPosition(equals_res_pos), temp_block.getByPosition(null_pos), temp_block.getByPosition(arguments[0])});
+        func_if->execute(temp_block, {equals_res_pos, null_pos, arguments[0]}, result, input_rows_count);
 
         block.getByPosition(result).column = std::move(temp_block.getByPosition(result).column);
     }

--- a/dbms/src/Functions/nullIf.cpp
+++ b/dbms/src/Functions/nullIf.cpp
@@ -70,7 +70,7 @@ public:
             {temp_block.getByPosition(equals_res_pos), temp_block.getByPosition(null_pos), temp_block.getByPosition(arguments[0])});
         func_if->execute(temp_block, {equals_res_pos, null_pos, arguments[0]}, result, input_rows_count);
 
-        block.getByPosition(result).column = std::move(temp_block.getByPosition(result).column);
+        block.getByPosition(result).column = makeNullable(std::move(temp_block.getByPosition(result).column));
     }
 };
 


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fixed wrong behaviour of `nullIf` function for constant arguments.

Detailed description (optional):
For backports: just copy `nullIf.cpp` file as a whole.