### PR TITLE
Fixed false data race in "MergeTreeDataPart::is_frozen" field

### DIFF
--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -2876,7 +2876,7 @@ void MergeTreeData::freezePartitionsByMatcher(MatcherFn matcher, const String & 
         String backup_part_absolute_path = part_absolute_path;
         backup_part_absolute_path.replace(0, clickhouse_path.size(), backup_path);
         localBackup(part_absolute_path, backup_part_absolute_path);
-        part->is_frozen = true;
+        part->is_frozen.store(true, std::memory_order_relaxed);
         ++parts_processed;
     }
 

--- a/dbms/src/Storages/MergeTree/MergeTreeDataPart.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataPart.h
@@ -94,8 +94,8 @@ struct MergeTreeDataPart
     /// If true it means that there are no ZooKeeper node for this part, so it should be deleted only from filesystem
     bool is_duplicate = false;
 
-    /// Frozen by ALTER TABLE ... FREEZE ...
-    mutable bool is_frozen = false;
+    /// Frozen by ALTER TABLE ... FREEZE ... It is used for information purposes in system.parts table.
+    mutable std::atomic<bool> is_frozen {false};
 
     /**
      * Part state is a stage of its lifetime. States are ordered and state of a part could be increased only.

--- a/dbms/src/Storages/System/StorageSystemParts.cpp
+++ b/dbms/src/Storages/System/StorageSystemParts.cpp
@@ -103,7 +103,7 @@ void StorageSystemParts::processNextStorage(MutableColumns & columns_, const Sto
         columns_[i++]->insert(static_cast<UInt64>(part->info.getDataVersion()));
         columns_[i++]->insert(part->getIndexSizeInBytes());
         columns_[i++]->insert(part->getIndexSizeInAllocatedBytes());
-        columns_[i++]->insert(part->is_frozen);
+        columns_[i++]->insert(part->is_frozen.load(std::memory_order_relaxed));
 
         columns_[i++]->insert(info.database);
         columns_[i++]->insert(info.table);


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement

Detailed description (optional):
https://clickhouse-test-reports.s3.yandex.net/6578/17e93b8f2d9672616a2e5b15148258467886a423/stress_test_(thread)/stderr.txt