### PR TITLE
Support Oracle Linux

### DIFF
--- a/debian/clickhouse-server.postinst
+++ b/debian/clickhouse-server.postinst
@@ -20,7 +20,7 @@ OS=${OS=`lsb_release -is 2>/dev/null ||:`}
 [ -f /usr/share/debconf/confmodule ] && . /usr/share/debconf/confmodule
 [ -f /etc/default/clickhouse ] && . /etc/default/clickhouse
 
-if [ "$OS" = "rhel" ] || [ "$OS" = "centos" ] || [ "$OS" = "fedora" ] || [ "$OS" = "CentOS" ] || [ "$OS" = "Fedora" ]; then
+if [ "$OS" = "rhel" ] || [ "$OS" = "centos" ] || [ "$OS" = "fedora" ] || [ "$OS" = "CentOS" ] || [ "$OS" = "Fedora" ] || [ "$OS" = "ol" ]; then
     is_rh=1
 fi
 


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Support for Oracle Linux in official RPM packages. This fixes #6356
