### PR TITLE
Fix data type (enum) table name error in docs

### DIFF
--- a/docs/en/data_types/enum.md
+++ b/docs/en/data_types/enum.md
@@ -94,7 +94,7 @@ ENGINE = TinyLog
 it can store not only `'hello'` and `'world'`, but `NULL`, as well.
 
 ```
-INSERT INTO t_enum_null Values('hello'),('world'),(NULL)
+INSERT INTO t_enum_nullable Values('hello'),('world'),(NULL)
 ```
 
 In RAM, an `Enum` column is stored in the same way as `Int8` or `Int16` of the corresponding numerical values.

--- a/docs/ru/data_types/enum.md
+++ b/docs/ru/data_types/enum.md
@@ -90,7 +90,7 @@ ENGINE = TinyLog
 , то в ней можно будет хранить не только `'hello'` и `'world'`, но и `NULL`.
 
 ```
-INSERT INTO t_enum_null Values('hello'),('world'),(NULL)
+INSERT INTO t_enum_nullable Values('hello'),('world'),(NULL)
 ```
 
 В оперативке столбец типа `Enum` представлен так же, как `Int8` или `Int16` соответствующими числовыми значениями.

--- a/docs/zh/data_types/enum.md
+++ b/docs/zh/data_types/enum.md
@@ -91,7 +91,7 @@ ENGINE = TinyLog
 不仅可以存储 `'hello'` 和 `'world'` ，还可以存储 `NULL`。
 
 ```
-INSERT INTO t_enum_null Values('hello'),('world'),(NULL)
+INSERT INTO t_enum_nullable Values('hello'),('world'),(NULL)
 ```
 
 在内存中，`Enum` 列的存储方式与相应数值的 `Int8` 或 `Int16` 相同。


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en


Category (leave one):

- Documentation Fix

In the example, the table names are different


```sql
CREATE TABLE t_enum_nullable
(
    x Nullable( Enum8('hello' = 1, 'world' = 2) )
)
ENGINE = TinyLog
```

```sql
INSERT INTO t_enum_null Values('hello'),('world'),(NULL)
```

