### PR TITLE
Clickhouse obfuscator symlink

### DIFF
--- a/dbms/programs/CMakeLists.txt
+++ b/dbms/programs/CMakeLists.txt
@@ -98,7 +98,7 @@ endif()
 
 if (CLICKHOUSE_SPLIT_BINARY)
     set (CLICKHOUSE_ALL_TARGETS clickhouse-server clickhouse-client clickhouse-local clickhouse-benchmark clickhouse-performance-test
-            clickhouse-extract-from-config clickhouse-compressor clickhouse-format clickhouse-copier)
+            clickhouse-extract-from-config clickhouse-compressor clickhouse-format clickhouse-obfuscator clickhouse-copier)
 
     if (ENABLE_CLICKHOUSE_ODBC_BRIDGE)
         list (APPEND CLICKHOUSE_ALL_TARGETS clickhouse-odbc-bridge)

--- a/debian/clickhouse-client.install
+++ b/debian/clickhouse-client.install
@@ -3,5 +3,6 @@ usr/bin/clickhouse-local
 usr/bin/clickhouse-compressor
 usr/bin/clickhouse-benchmark
 usr/bin/clickhouse-format
+usr/bin/clickhouse-obfuscator
 etc/clickhouse-client/config.xml
 usr/bin/clickhouse-extract-from-config


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

Short description (up to few sentences):
Now `clickhouse-obfuscator` file is available in clickhouse-client package. In previous versions it was available as `clickhouse obfuscator` (with whitespace). Fixes #5816