### PR TITLE
fix HDFS HA can't work on DEBUG mode

### DIFF
--- a/dbms/src/IO/HDFSCommon.cpp
+++ b/dbms/src/IO/HDFSCommon.cpp
@@ -40,7 +40,10 @@ HDFSBuilderPtr createHDFSBuilder(const Poco::URI & uri)
         hdfsBuilderSetUserName(builder.get(), user.c_str());
     }
     hdfsBuilderSetNameNode(builder.get(), host.c_str());
-    hdfsBuilderSetNameNodePort(builder.get(), port);
+    if (port != 0)
+    {
+        hdfsBuilderSetNameNodePort(builder.get(), port);
+    }
     return builder;
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

The Describe the bug
when the using HDFS HA nameserivce as the uri, the port will be 0.
hdfsBuilderSetNameNodePort will be called to set the port.
hdfsBuilderSetNameNodePort call asset to check if the port is greater
than 0.
So in Release mode, it works OK. In the Debug mode, the asset will fail.

How to reproduce
when compiler the Clickhouse, use DEBUG mode, it will throw error when
using HDFS HA nameservice url

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
HDFS HA now work in debug build.
