### PR TITLE
Separate the hash table interface for ReverseIndex.

### DIFF
--- a/dbms/src/Columns/ReverseIndex.h
+++ b/dbms/src/Columns/ReverseIndex.h
@@ -81,6 +81,8 @@ namespace
         template <typename T>
         static bool isZero(const T &, const State & /*state*/)
         {
+            /// Careful: apparently this uses SFINAE to redefine isZero for all types
+            /// except the IndexType, for which the default ZeroTraits::isZero is used.
             static_assert(!std::is_same_v<typename std::decay<T>::type, typename std::decay<IndexType>::type>);
             return false;
         }
@@ -121,19 +123,88 @@ namespace
     };
 
 
+    /**
+      * ReverseIndexHashTableBase implements a special hash table interface for
+      * reverse index.
+      *
+      * The following requirements are different compared to a plain hash table:
+      *
+      * 1) Provide public access to 'hash table state' that contains
+      * additional data needed to calculate cell hashes.
+      *
+      * 2) Support emplace() and find() with a Key different from the resulting
+      * hash table key. This means emplace() accepts a different kind of object
+      * as a key, and then the real key can be read from the returned cell iterator.
+      *
+      * These requirements are unique to ReverseIndex and are in conflict with
+      * supporting hash tables that use alternative key storage, such as FixedHashMap
+      * or StringHashMap. Therefore, we implement an interface for ReverseIndex
+      * separately.
+      */
     template <typename Key, typename Cell, typename Hash>
-    class HashTableWithPublicState : public HashTable<Key, Cell, Hash, HashTableGrower<>, HashTableAllocator>
+    class ReverseIndexHashTableBase : public HashTable<Key, Cell, Hash, HashTableGrower<>, HashTableAllocator>
     {
         using State = typename Cell::State;
         using Base = HashTable<Key, Cell, Hash, HashTableGrower<>, HashTableAllocator>;
 
     public:
         using Base::Base;
+        using iterator = typename Base::iterator;
         State & getState() { return *this; }
+
+
+        template <typename ObjectToCompareWith>
+        size_t ALWAYS_INLINE reverseIndexFindCell(const ObjectToCompareWith & x,
+            size_t hash_value, size_t place_value) const
+        {
+            while (!this->buf[place_value].isZero(*this)
+                   && !this->buf[place_value].keyEquals(x, hash_value, *this))
+            {
+                place_value = this->grower.next(place_value);
+            }
+
+            return place_value;
+        }
+
+        template <typename ObjectToCompareWith>
+        void ALWAYS_INLINE reverseIndexEmplaceNonZero(const Key & key, iterator & it,
+            bool & inserted, size_t hash_value, const ObjectToCompareWith & object)
+        {
+            size_t place_value = reverseIndexFindCell(object, hash_value,
+                  this->grower.place(hash_value));
+            // emplaceNonZeroImpl() might need to re-find the cell if the table grows,
+            // but it will find it correctly by the key alone, so we don't have to
+            // pass it the 'object'.
+            this->emplaceNonZeroImpl(place_value, key, it, inserted, hash_value);
+        }
+
+        /// Searches position by object.
+        template <typename ObjectToCompareWith>
+        void ALWAYS_INLINE reverseIndexEmplace(Key key, iterator & it, bool & inserted,
+            size_t hash_value, const ObjectToCompareWith& object)
+        {
+            if (!this->emplaceIfZero(key, it, inserted, hash_value))
+            {
+                reverseIndexEmplaceNonZero(key, it, inserted, hash_value, object);
+            }
+        }
+
+        template <typename ObjectToCompareWith>
+        iterator ALWAYS_INLINE reverseIndexFind(ObjectToCompareWith x, size_t hash_value)
+        {
+            if (Cell::isZero(x, *this))
+                return this->hasZero() ? this->iteratorToZero() : this->end();
+
+            size_t place_value = reverseIndexFindCell(x, hash_value,
+                                    this->grower.place(hash_value));
+            return !this->buf[place_value].isZero(*this)
+                    ? iterator(this, &this->buf[place_value])
+                    : this->end();
+        }
     };
 
     template <typename IndexType, typename ColumnType, bool has_base_index>
-    class ReverseIndexStringHashTable : public HashTableWithPublicState<
+    class ReverseIndexStringHashTable : public ReverseIndexHashTableBase<
             IndexType,
             ReverseIndexHashTableCell<
                     IndexType,
@@ -144,7 +215,7 @@ namespace
                     has_base_index>,
             ReverseIndexHash>
     {
-        using Base = HashTableWithPublicState<
+        using Base = ReverseIndexHashTableBase<
                 IndexType,
                 ReverseIndexHashTableCell<
                         IndexType,
@@ -166,7 +237,7 @@ namespace
     };
 
     template <typename IndexType, typename ColumnType, bool has_base_index>
-    class ReverseIndexNumberHashTable : public HashTableWithPublicState<
+    class ReverseIndexNumberHashTable : public ReverseIndexHashTableBase<
             IndexType,
             ReverseIndexHashTableCell<
                     IndexType,
@@ -177,7 +248,7 @@ namespace
                     has_base_index>,
             ReverseIndexHash>
     {
-        using Base = HashTableWithPublicState<
+        using Base = ReverseIndexHashTableBase<
                 IndexType,
                 ReverseIndexHashTableCell<
                         IndexType,
@@ -356,7 +427,7 @@ void ReverseIndex<IndexType, ColumnType>::buildIndex()
         else
             hash = getHash(column->getDataAt(row));
 
-        index->emplace(row + base_index, iterator, inserted, hash, column->getDataAt(row));
+        index->reverseIndexEmplace(row + base_index, iterator, inserted, hash, column->getDataAt(row));
 
         if (!inserted)
             throw Exception("Duplicating keys found in ReverseIndex.", ErrorCodes::LOGICAL_ERROR);
@@ -401,7 +472,7 @@ UInt64 ReverseIndex<IndexType, ColumnType>::insert(const StringRef & data)
     else
         column->insertData(data.data, data.size);
 
-    index->emplace(num_rows + base_index, iterator, inserted, hash, data);
+    index->reverseIndexEmplace(num_rows + base_index, iterator, inserted, hash, data);
 
     if constexpr (use_saved_hash)
     {
@@ -427,7 +498,7 @@ UInt64 ReverseIndex<IndexType, ColumnType>::getInsertionPoint(const StringRef & 
     IteratorType iterator;
 
     auto hash = getHash(data);
-    iterator = index->find(data, hash);
+    iterator = index->reverseIndexFind(data, hash);
 
     return iterator == index->end() ? size() + base_index : iterator->getValue();
 }

--- a/dbms/src/Common/HashTable/FixedHashTable.h
+++ b/dbms/src/Common/HashTable/FixedHashTable.h
@@ -294,26 +294,22 @@ public:
     void ALWAYS_INLINE emplace(Key x, iterator & it, bool & inserted) { emplaceImpl(x, it, inserted); }
     void ALWAYS_INLINE emplace(Key x, iterator & it, bool & inserted, size_t) { emplaceImpl(x, it, inserted); }
 
-    template <typename ObjectToCompareWith>
-    iterator ALWAYS_INLINE find(ObjectToCompareWith x)
+    iterator ALWAYS_INLINE find(Key x)
     {
         return !buf[x].isZero(*this) ? iterator(this, &buf[x]) : end();
     }
 
-    template <typename ObjectToCompareWith>
-    const_iterator ALWAYS_INLINE find(ObjectToCompareWith x) const
+    const_iterator ALWAYS_INLINE find(Key x) const
     {
         return !buf[x].isZero(*this) ? const_iterator(this, &buf[x]) : end();
     }
 
-    template <typename ObjectToCompareWith>
-    iterator ALWAYS_INLINE find(ObjectToCompareWith, size_t hash_value)
+    iterator ALWAYS_INLINE find(Key, size_t hash_value)
     {
         return !buf[hash_value].isZero(*this) ? iterator(this, &buf[hash_value]) : end();
     }
 
-    template <typename ObjectToCompareWith>
-    const_iterator ALWAYS_INLINE find(ObjectToCompareWith, size_t hash_value) const
+    const_iterator ALWAYS_INLINE find(Key, size_t hash_value) const
     {
         return !buf[hash_value].isZero(*this) ? const_iterator(this, &buf[hash_value]) : end();
     }

--- a/dbms/src/Common/HashTable/HashTable.h
+++ b/dbms/src/Common/HashTable/HashTable.h
@@ -280,8 +280,7 @@ protected:
 #endif
 
     /// Find a cell with the same key or an empty cell, starting from the specified position and further along the collision resolution chain.
-    template <typename ObjectToCompareWith>
-    size_t ALWAYS_INLINE findCell(const ObjectToCompareWith & x, size_t hash_value, size_t place_value) const
+    size_t ALWAYS_INLINE findCell(const Key & x, size_t hash_value, size_t place_value) const
     {
         while (!buf[place_value].isZero(*this) && !buf[place_value].keyEquals(x, hash_value, *this))
         {
@@ -700,13 +699,6 @@ protected:
         emplaceNonZeroImpl(place_value, x, it, inserted, hash_value);
     }
 
-    /// Same but find place using object. Hack for ReverseIndex.
-    template <typename ObjectToCompareWith>
-    void ALWAYS_INLINE emplaceNonZero(Key x, iterator & it, bool & inserted, size_t hash_value, const ObjectToCompareWith & object)
-    {
-        size_t place_value = findCell(object, hash_value, grower.place(hash_value));
-        emplaceNonZeroImpl(place_value, x, it, inserted, hash_value);
-    }
 
 
 public:
@@ -763,14 +755,6 @@ public:
             emplaceNonZero(x, it, inserted, hash_value);
     }
 
-    /// Same, but search position by object. Hack for ReverseIndex.
-    template <typename ObjectToCompareWith>
-    void ALWAYS_INLINE emplace(Key x, iterator & it, bool & inserted, size_t hash_value, const ObjectToCompareWith & object)
-    {
-        if (!emplaceIfZero(x, it, inserted, hash_value))
-            emplaceNonZero(x, it, inserted, hash_value, object);
-    }
-
     /// Copy the cell from another hash table. It is assumed that the cell is not zero, and also that there was no such key in the table yet.
     void ALWAYS_INLINE insertUniqueNonZero(const Cell * cell, size_t hash_value)
     {
@@ -783,9 +767,7 @@ public:
             resize();
     }
 
-
-    template <typename ObjectToCompareWith>
-    iterator ALWAYS_INLINE find(ObjectToCompareWith x)
+    iterator ALWAYS_INLINE find(Key x)
     {
         if (Cell::isZero(x, *this))
             return this->hasZero() ? iteratorToZero() : end();
@@ -796,8 +778,7 @@ public:
     }
 
 
-    template <typename ObjectToCompareWith>
-    const_iterator ALWAYS_INLINE find(ObjectToCompareWith x) const
+    const_iterator ALWAYS_INLINE find(Key x) const
     {
         if (Cell::isZero(x, *this))
             return this->hasZero() ? iteratorToZero() : end();
@@ -808,8 +789,7 @@ public:
     }
 
 
-    template <typename ObjectToCompareWith>
-    iterator ALWAYS_INLINE find(ObjectToCompareWith x, size_t hash_value)
+    iterator ALWAYS_INLINE find(Key x, size_t hash_value)
     {
         if (Cell::isZero(x, *this))
             return this->hasZero() ? iteratorToZero() : end();
@@ -819,8 +799,7 @@ public:
     }
 
 
-    template <typename ObjectToCompareWith>
-    const_iterator ALWAYS_INLINE find(ObjectToCompareWith x, size_t hash_value) const
+    const_iterator ALWAYS_INLINE find(Key x, size_t hash_value) const
     {
         if (Cell::isZero(x, *this))
             return this->hasZero() ? iteratorToZero() : end();


### PR DESCRIPTION
It is significantly different from other uses of hash tables, and poses
the main obstacle to changing the hash table interface to the one that
can be easily supported by compound hash tables.

Make it explicitly separate, implement it only for a particular kind of
HashTable, and move this implementation to the ReverseIndex module.

This prepares for the PR #5417.