### PR TITLE
Simplify shared_ptr_helper

### DIFF
--- a/dbms/src/Interpreters/tests/in_join_subqueries_preprocessor.cpp
+++ b/dbms/src/Interpreters/tests/in_join_subqueries_preprocessor.cpp
@@ -30,6 +30,7 @@ namespace DB
 /// Simplified version of the StorageDistributed class.
 class StorageDistributedFake : public ext::shared_ptr_helper<StorageDistributedFake>, public DB::IStorage
 {
+    friend struct ext::shared_ptr_helper<StorageDistributedFake>;
 public:
     std::string getName() const override { return "DistributedFake"; }
     bool isRemote() const override { return true; }

--- a/dbms/src/Storages/Kafka/StorageKafka.h
+++ b/dbms/src/Storages/Kafka/StorageKafka.h
@@ -20,6 +20,7 @@ namespace DB
   */
 class StorageKafka : public ext::shared_ptr_helper<StorageKafka>, public IStorage
 {
+    friend struct ext::shared_ptr_helper<StorageKafka>;
 public:
     std::string getName() const override { return "Kafka"; }
     std::string getTableName() const override { return table_name; }

--- a/dbms/src/Storages/MergeTree/StorageFromMergeTreeDataPart.h
+++ b/dbms/src/Storages/MergeTree/StorageFromMergeTreeDataPart.h
@@ -14,6 +14,7 @@ namespace DB
 /// A Storage that allows reading from a single MergeTree data part.
 class StorageFromMergeTreeDataPart : public ext::shared_ptr_helper<StorageFromMergeTreeDataPart>, public IStorage
 {
+    friend struct ext::shared_ptr_helper<StorageFromMergeTreeDataPart>;
 public:
     String getName() const override { return "FromMergeTreeDataPart"; }
     String getTableName() const override { return part->storage.getTableName() + " (part " + part->name + ")"; }

--- a/dbms/src/Storages/StorageBuffer.h
+++ b/dbms/src/Storages/StorageBuffer.h
@@ -39,6 +39,7 @@ class Context;
   */
 class StorageBuffer : public ext::shared_ptr_helper<StorageBuffer>, public IStorage
 {
+friend struct ext::shared_ptr_helper<StorageBuffer>;
 friend class BufferBlockInputStream;
 friend class BufferBlockOutputStream;
 
@@ -94,6 +95,8 @@ public:
         const AlterCommands & params, const String & database_name, const String & table_name,
         const Context & context, TableStructureWriteLockHolder & table_lock_holder) override;
 
+    ~StorageBuffer() override;
+
 private:
     String table_name;
     String database_name;
@@ -145,8 +148,6 @@ protected:
         Context & context_,
         size_t num_shards_, const Thresholds & min_thresholds_, const Thresholds & max_thresholds_,
         const String & destination_database_, const String & destination_table_, bool allow_materialized_);
-
-    ~StorageBuffer() override;
 };
 
 }

--- a/dbms/src/Storages/StorageDictionary.h
+++ b/dbms/src/Storages/StorageDictionary.h
@@ -21,6 +21,7 @@ class ExternalDictionaries;
 
 class StorageDictionary : public ext::shared_ptr_helper<StorageDictionary>, public IStorage
 {
+    friend struct ext::shared_ptr_helper<StorageDictionary>;
 public:
     std::string getName() const override { return "Dictionary"; }
     std::string getTableName() const override { return table_name; }

--- a/dbms/src/Storages/StorageDistributed.cpp
+++ b/dbms/src/Storages/StorageDistributed.cpp
@@ -266,11 +266,8 @@ StoragePtr StorageDistributed::createWithOwnCluster(
     ClusterPtr owned_cluster_,
     const Context & context_)
 {
-    auto res = ext::shared_ptr_helper<StorageDistributed>::create(
-        String{}, table_name_, columns_, ConstraintsDescription{}, remote_database_, remote_table_, String{}, context_, ASTPtr(), String(), false);
-
+    auto res = create(String{}, table_name_, columns_, ConstraintsDescription{}, remote_database_, remote_table_, String{}, context_, ASTPtr(), String(), false);
     res->owned_cluster = owned_cluster_;
-
     return res;
 }
 
@@ -282,11 +279,8 @@ StoragePtr StorageDistributed::createWithOwnCluster(
     ClusterPtr & owned_cluster_,
     const Context & context_)
 {
-    auto res = ext::shared_ptr_helper<StorageDistributed>::create(
-        String{}, table_name_, columns_, ConstraintsDescription{}, remote_table_function_ptr_, String{}, context_, ASTPtr(), String(), false);
-
+    auto res = create(String{}, table_name_, columns_, ConstraintsDescription{}, remote_table_function_ptr_, String{}, context_, ASTPtr(), String(), false);
     res->owned_cluster = owned_cluster_;
-
     return res;
 }
 

--- a/dbms/src/Storages/StorageDistributed.h
+++ b/dbms/src/Storages/StorageDistributed.h
@@ -29,6 +29,7 @@ class StorageDistributedDirectoryMonitor;
   */
 class StorageDistributed : public ext::shared_ptr_helper<StorageDistributed>, public IStorage
 {
+    friend struct ext::shared_ptr_helper<StorageDistributed>;
     friend class DistributedBlockOutputStream;
     friend class StorageDistributedDirectoryMonitor;
 

--- a/dbms/src/Storages/StorageFile.h
+++ b/dbms/src/Storages/StorageFile.h
@@ -20,6 +20,7 @@ class StorageFileBlockOutputStream;
 
 class StorageFile : public ext::shared_ptr_helper<StorageFile>, public IStorage
 {
+    friend struct ext::shared_ptr_helper<StorageFile>;
 public:
     std::string getName() const override { return "File"; }
     std::string getTableName() const override { return table_name; }

--- a/dbms/src/Storages/StorageHDFS.h
+++ b/dbms/src/Storages/StorageHDFS.h
@@ -15,6 +15,7 @@ namespace DB
  */
 class StorageHDFS : public ext::shared_ptr_helper<StorageHDFS>, public IStorage
 {
+    friend struct ext::shared_ptr_helper<StorageHDFS>;
 public:
     String getName() const override { return "HDFS"; }
     String getTableName() const override { return table_name; }

--- a/dbms/src/Storages/StorageJoin.h
+++ b/dbms/src/Storages/StorageJoin.h
@@ -22,6 +22,7 @@ using JoinPtr = std::shared_ptr<Join>;
   */
 class StorageJoin : public ext::shared_ptr_helper<StorageJoin>, public StorageSetOrJoinBase
 {
+    friend struct ext::shared_ptr_helper<StorageJoin>;
 public:
     String getName() const override { return "Join"; }
 

--- a/dbms/src/Storages/StorageLog.h
+++ b/dbms/src/Storages/StorageLog.h
@@ -21,6 +21,7 @@ class StorageLog : public ext::shared_ptr_helper<StorageLog>, public IStorage
 {
 friend class LogBlockInputStream;
 friend class LogBlockOutputStream;
+friend struct ext::shared_ptr_helper<StorageLog>;
 
 public:
     std::string getName() const override { return "Log"; }

--- a/dbms/src/Storages/StorageMaterializedView.h
+++ b/dbms/src/Storages/StorageMaterializedView.h
@@ -11,6 +11,7 @@ namespace DB
 
 class StorageMaterializedView : public ext::shared_ptr_helper<StorageMaterializedView>, public IStorage
 {
+    friend struct ext::shared_ptr_helper<StorageMaterializedView>;
 public:
     std::string getName() const override { return "MaterializedView"; }
     std::string getTableName() const override { return table_name; }

--- a/dbms/src/Storages/StorageMemory.h
+++ b/dbms/src/Storages/StorageMemory.h
@@ -21,6 +21,7 @@ class StorageMemory : public ext::shared_ptr_helper<StorageMemory>, public IStor
 {
 friend class MemoryBlockInputStream;
 friend class MemoryBlockOutputStream;
+friend struct ext::shared_ptr_helper<StorageMemory>;
 
 public:
     String getName() const override { return "Memory"; }

--- a/dbms/src/Storages/StorageMerge.h
+++ b/dbms/src/Storages/StorageMerge.h
@@ -14,6 +14,7 @@ namespace DB
   */
 class StorageMerge : public ext::shared_ptr_helper<StorageMerge>, public IStorage
 {
+    friend struct ext::shared_ptr_helper<StorageMerge>;
 public:
     std::string getName() const override { return "Merge"; }
     std::string getTableName() const override { return table_name; }

--- a/dbms/src/Storages/StorageMergeTree.h
+++ b/dbms/src/Storages/StorageMergeTree.h
@@ -23,6 +23,7 @@ namespace DB
   */
 class StorageMergeTree : public ext::shared_ptr_helper<StorageMergeTree>, public MergeTreeData
 {
+    friend struct ext::shared_ptr_helper<StorageMergeTree>;
 public:
     void startup() override;
     void shutdown() override;

--- a/dbms/src/Storages/StorageMySQL.h
+++ b/dbms/src/Storages/StorageMySQL.h
@@ -18,6 +18,7 @@ namespace DB
   */
 class StorageMySQL : public ext::shared_ptr_helper<StorageMySQL>, public IStorage
 {
+    friend struct ext::shared_ptr_helper<StorageMySQL>;
 public:
     StorageMySQL(
         const std::string & database_name_,

--- a/dbms/src/Storages/StorageNull.h
+++ b/dbms/src/Storages/StorageNull.h
@@ -16,6 +16,7 @@ namespace DB
   */
 class StorageNull : public ext::shared_ptr_helper<StorageNull>, public IStorage
 {
+    friend struct ext::shared_ptr_helper<StorageNull>;
 public:
     std::string getName() const override { return "Null"; }
     std::string getTableName() const override { return table_name; }

--- a/dbms/src/Storages/StorageReplicatedMergeTree.h
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.h
@@ -74,6 +74,7 @@ namespace DB
 
 class StorageReplicatedMergeTree : public ext::shared_ptr_helper<StorageReplicatedMergeTree>, public MergeTreeData
 {
+    friend struct ext::shared_ptr_helper<StorageReplicatedMergeTree>;
 public:
     void startup() override;
     void shutdown() override;

--- a/dbms/src/Storages/StorageStripeLog.h
+++ b/dbms/src/Storages/StorageStripeLog.h
@@ -23,6 +23,7 @@ class StorageStripeLog : public ext::shared_ptr_helper<StorageStripeLog>, public
 {
 friend class StripeLogBlockInputStream;
 friend class StripeLogBlockOutputStream;
+friend struct ext::shared_ptr_helper<StorageStripeLog>;
 
 public:
     std::string getName() const override { return "StripeLog"; }

--- a/dbms/src/Storages/StorageTinyLog.h
+++ b/dbms/src/Storages/StorageTinyLog.h
@@ -22,6 +22,7 @@ class StorageTinyLog : public ext::shared_ptr_helper<StorageTinyLog>, public ISt
 {
 friend class TinyLogBlockInputStream;
 friend class TinyLogBlockOutputStream;
+friend struct ext::shared_ptr_helper<StorageTinyLog>;
 
 public:
     std::string getName() const override { return "TinyLog"; }

--- a/dbms/src/Storages/StorageURL.h
+++ b/dbms/src/Storages/StorageURL.h
@@ -71,6 +71,7 @@ private:
 
 class StorageURL : public ext::shared_ptr_helper<StorageURL>, public IStorageURLBase
 {
+    friend struct ext::shared_ptr_helper<StorageURL>;
 public:
     StorageURL(
         const Poco::URI & uri_,

--- a/dbms/src/Storages/StorageValues.h
+++ b/dbms/src/Storages/StorageValues.h
@@ -11,6 +11,7 @@ namespace DB
  */
 class StorageValues : public ext::shared_ptr_helper<StorageValues>, public IStorage
 {
+    friend struct ext::shared_ptr_helper<StorageValues>;
 public:
     std::string getName() const override { return "Values"; }
     std::string getTableName() const override { return table_name; }

--- a/dbms/src/Storages/StorageView.h
+++ b/dbms/src/Storages/StorageView.h
@@ -12,6 +12,7 @@ namespace DB
 
 class StorageView : public ext::shared_ptr_helper<StorageView>, public IStorage
 {
+    friend struct ext::shared_ptr_helper<StorageView>;
 public:
     std::string getName() const override { return "View"; }
     std::string getTableName() const override { return table_name; }

--- a/dbms/src/Storages/System/StorageSystemAggregateFunctionCombinators.h
+++ b/dbms/src/Storages/System/StorageSystemAggregateFunctionCombinators.h
@@ -4,11 +4,13 @@
 #include <DataTypes/DataTypesNumber.h>
 #include <Storages/System/IStorageSystemOneBlock.h>
 #include <ext/shared_ptr_helper.h>
+
 namespace DB
 {
 class StorageSystemAggregateFunctionCombinators : public ext::shared_ptr_helper<StorageSystemAggregateFunctionCombinators>,
                                                   public IStorageSystemOneBlock<StorageSystemAggregateFunctionCombinators>
 {
+    friend struct ext::shared_ptr_helper<StorageSystemAggregateFunctionCombinators>;
 protected:
     void fillData(MutableColumns & res_columns, const Context & context, const SelectQueryInfo & query_info) const override;
 

--- a/dbms/src/Storages/System/StorageSystemAsynchronousMetrics.h
+++ b/dbms/src/Storages/System/StorageSystemAsynchronousMetrics.h
@@ -12,8 +12,10 @@ class Context;
 
 /** Implements system table asynchronous_metrics, which allows to get values of periodically (asynchronously) updated metrics.
   */
-class StorageSystemAsynchronousMetrics : public ext::shared_ptr_helper<StorageSystemAsynchronousMetrics>, public IStorageSystemOneBlock<StorageSystemAsynchronousMetrics>
+class StorageSystemAsynchronousMetrics : public ext::shared_ptr_helper<StorageSystemAsynchronousMetrics>,
+    public IStorageSystemOneBlock<StorageSystemAsynchronousMetrics>
 {
+    friend struct ext::shared_ptr_helper<StorageSystemAsynchronousMetrics>;
 public:
     std::string getName() const override { return "SystemAsynchronousMetrics"; }
 

--- a/dbms/src/Storages/System/StorageSystemBuildOptions.h
+++ b/dbms/src/Storages/System/StorageSystemBuildOptions.h
@@ -14,6 +14,7 @@ class Context;
   */
 class StorageSystemBuildOptions : public ext::shared_ptr_helper<StorageSystemBuildOptions>, public IStorageSystemOneBlock<StorageSystemBuildOptions>
 {
+    friend struct ext::shared_ptr_helper<StorageSystemBuildOptions>;
 protected:
     void fillData(MutableColumns & res_columns, const Context & context, const SelectQueryInfo & query_info) const override;
 

--- a/dbms/src/Storages/System/StorageSystemClusters.h
+++ b/dbms/src/Storages/System/StorageSystemClusters.h
@@ -17,6 +17,7 @@ class Context;
   */
 class StorageSystemClusters : public ext::shared_ptr_helper<StorageSystemClusters>, public IStorageSystemOneBlock<StorageSystemClusters>
 {
+    friend struct ext::shared_ptr_helper<StorageSystemClusters>;
 public:
     std::string getName() const override { return "SystemClusters"; }
 

--- a/dbms/src/Storages/System/StorageSystemCollations.h
+++ b/dbms/src/Storages/System/StorageSystemCollations.h
@@ -8,6 +8,7 @@ namespace DB
 class StorageSystemCollations : public ext::shared_ptr_helper<StorageSystemCollations>,
                                 public IStorageSystemOneBlock<StorageSystemCollations>
 {
+    friend struct ext::shared_ptr_helper<StorageSystemCollations>;
 protected:
     void fillData(MutableColumns & res_columns, const Context & context, const SelectQueryInfo & query_info) const override;
 

--- a/dbms/src/Storages/System/StorageSystemColumns.h
+++ b/dbms/src/Storages/System/StorageSystemColumns.h
@@ -13,6 +13,7 @@ class Context;
   */
 class StorageSystemColumns : public ext::shared_ptr_helper<StorageSystemColumns>, public IStorage
 {
+    friend struct ext::shared_ptr_helper<StorageSystemColumns>;
 public:
     std::string getName() const override { return "SystemColumns"; }
     std::string getTableName() const override { return name; }

--- a/dbms/src/Storages/System/StorageSystemContributors.h
+++ b/dbms/src/Storages/System/StorageSystemContributors.h
@@ -14,6 +14,7 @@ class Context;
 class StorageSystemContributors : public ext::shared_ptr_helper<StorageSystemContributors>,
                                   public IStorageSystemOneBlock<StorageSystemContributors>
 {
+    friend struct ext::shared_ptr_helper<StorageSystemContributors>;
 protected:
     void fillData(MutableColumns & res_columns, const Context & context, const SelectQueryInfo & query_info) const override;
 

--- a/dbms/src/Storages/System/StorageSystemDataTypeFamilies.h
+++ b/dbms/src/Storages/System/StorageSystemDataTypeFamilies.h
@@ -9,6 +9,7 @@ namespace DB
 class StorageSystemDataTypeFamilies : public ext::shared_ptr_helper<StorageSystemDataTypeFamilies>,
                                       public IStorageSystemOneBlock<StorageSystemDataTypeFamilies>
 {
+    friend struct ext::shared_ptr_helper<StorageSystemDataTypeFamilies>;
 protected:
     void fillData(MutableColumns & res_columns, const Context & context, const SelectQueryInfo & query_info) const override;
 

--- a/dbms/src/Storages/System/StorageSystemDatabases.h
+++ b/dbms/src/Storages/System/StorageSystemDatabases.h
@@ -14,6 +14,7 @@ class Context;
   */
 class StorageSystemDatabases : public ext::shared_ptr_helper<StorageSystemDatabases>, public IStorageSystemOneBlock<StorageSystemDatabases>
 {
+    friend struct ext::shared_ptr_helper<StorageSystemDatabases>;
 public:
     std::string getName() const override
     {

--- a/dbms/src/Storages/System/StorageSystemDetachedParts.cpp
+++ b/dbms/src/Storages/System/StorageSystemDetachedParts.cpp
@@ -21,6 +21,7 @@ class StorageSystemDetachedParts :
     public ext::shared_ptr_helper<StorageSystemDetachedParts>,
     public IStorage
 {
+    friend struct ext::shared_ptr_helper<StorageSystemDetachedParts>;
 public:
     std::string getName() const override { return "SystemDetachedParts"; }
     std::string getTableName() const override { return "detached_parts"; }

--- a/dbms/src/Storages/System/StorageSystemDictionaries.h
+++ b/dbms/src/Storages/System/StorageSystemDictionaries.h
@@ -12,6 +12,7 @@ class Context;
 
 class StorageSystemDictionaries : public ext::shared_ptr_helper<StorageSystemDictionaries>, public IStorageSystemOneBlock<StorageSystemDictionaries>
 {
+    friend struct ext::shared_ptr_helper<StorageSystemDictionaries>;
 public:
     std::string getName() const override { return "SystemDictionaries"; }
 

--- a/dbms/src/Storages/System/StorageSystemEvents.h
+++ b/dbms/src/Storages/System/StorageSystemEvents.h
@@ -13,6 +13,7 @@ class Context;
   */
 class StorageSystemEvents : public ext::shared_ptr_helper<StorageSystemEvents>, public IStorageSystemOneBlock<StorageSystemEvents>
 {
+    friend struct ext::shared_ptr_helper<StorageSystemEvents>;
 public:
     std::string getName() const override { return "SystemEvents"; }
 

--- a/dbms/src/Storages/System/StorageSystemFormats.h
+++ b/dbms/src/Storages/System/StorageSystemFormats.h
@@ -7,6 +7,7 @@ namespace DB
 {
 class StorageSystemFormats : public ext::shared_ptr_helper<StorageSystemFormats>, public IStorageSystemOneBlock<StorageSystemFormats>
 {
+    friend struct ext::shared_ptr_helper<StorageSystemFormats>;
 protected:
     void fillData(MutableColumns & res_columns, const Context & context, const SelectQueryInfo & query_info) const override;
 

--- a/dbms/src/Storages/System/StorageSystemFunctions.h
+++ b/dbms/src/Storages/System/StorageSystemFunctions.h
@@ -15,6 +15,7 @@ class Context;
   */
 class StorageSystemFunctions : public ext::shared_ptr_helper<StorageSystemFunctions>, public IStorageSystemOneBlock<StorageSystemFunctions>
 {
+    friend struct ext::shared_ptr_helper<StorageSystemFunctions>;
 public:
     std::string getName() const override { return "SystemFunctions"; }
 

--- a/dbms/src/Storages/System/StorageSystemGraphite.h
+++ b/dbms/src/Storages/System/StorageSystemGraphite.h
@@ -13,6 +13,7 @@ namespace DB
 /// Provides information about Graphite configuration.
 class StorageSystemGraphite : public ext::shared_ptr_helper<StorageSystemGraphite>, public IStorageSystemOneBlock<StorageSystemGraphite>
 {
+    friend struct ext::shared_ptr_helper<StorageSystemGraphite>;
 public:
     std::string getName() const override { return "SystemGraphite"; }
 

--- a/dbms/src/Storages/System/StorageSystemMacros.h
+++ b/dbms/src/Storages/System/StorageSystemMacros.h
@@ -15,6 +15,7 @@ class Context;
   */
 class StorageSystemMacros : public ext::shared_ptr_helper<StorageSystemMacros>, public IStorageSystemOneBlock<StorageSystemMacros>
 {
+    friend struct ext::shared_ptr_helper<StorageSystemMacros>;
 public:
     std::string getName() const override { return "SystemMacros"; }
 

--- a/dbms/src/Storages/System/StorageSystemMergeTreeSettings.h
+++ b/dbms/src/Storages/System/StorageSystemMergeTreeSettings.h
@@ -15,6 +15,7 @@ class Context;
   */
 class SystemMergeTreeSettings : public ext::shared_ptr_helper<SystemMergeTreeSettings>, public IStorageSystemOneBlock<SystemMergeTreeSettings>
 {
+    friend struct ext::shared_ptr_helper<SystemMergeTreeSettings>;
 public:
     std::string getName() const override { return "SystemMergeTreeSettings"; }
 

--- a/dbms/src/Storages/System/StorageSystemMerges.h
+++ b/dbms/src/Storages/System/StorageSystemMerges.h
@@ -15,6 +15,7 @@ class Context;
 
 class StorageSystemMerges : public ext::shared_ptr_helper<StorageSystemMerges>, public IStorageSystemOneBlock<StorageSystemMerges>
 {
+    friend struct ext::shared_ptr_helper<StorageSystemMerges>;
 public:
     std::string getName() const override { return "SystemMerges"; }
 

--- a/dbms/src/Storages/System/StorageSystemMetrics.h
+++ b/dbms/src/Storages/System/StorageSystemMetrics.h
@@ -14,6 +14,7 @@ class Context;
   */
 class StorageSystemMetrics : public ext::shared_ptr_helper<StorageSystemMetrics>, public IStorageSystemOneBlock<StorageSystemMetrics>
 {
+    friend struct ext::shared_ptr_helper<StorageSystemMetrics>;
 public:
     std::string getName() const override { return "SystemMetrics"; }
 

--- a/dbms/src/Storages/System/StorageSystemModels.h
+++ b/dbms/src/Storages/System/StorageSystemModels.h
@@ -12,6 +12,7 @@ class Context;
 
 class StorageSystemModels : public ext::shared_ptr_helper<StorageSystemModels>, public IStorageSystemOneBlock<StorageSystemModels>
 {
+    friend struct ext::shared_ptr_helper<StorageSystemModels>;
 public:
     std::string getName() const override { return "SystemModels"; }
 

--- a/dbms/src/Storages/System/StorageSystemMutations.h
+++ b/dbms/src/Storages/System/StorageSystemMutations.h
@@ -14,6 +14,7 @@ class Context;
 /// in the MergeTree tables.
 class StorageSystemMutations : public ext::shared_ptr_helper<StorageSystemMutations>, public IStorageSystemOneBlock<StorageSystemMutations>
 {
+    friend struct ext::shared_ptr_helper<StorageSystemMutations>;
 public:
     String getName() const override { return "SystemMutations"; }
 

--- a/dbms/src/Storages/System/StorageSystemNumbers.h
+++ b/dbms/src/Storages/System/StorageSystemNumbers.h
@@ -25,6 +25,7 @@ class Context;
   */
 class StorageSystemNumbers : public ext::shared_ptr_helper<StorageSystemNumbers>, public IStorage
 {
+    friend struct ext::shared_ptr_helper<StorageSystemNumbers>;
 public:
     std::string getName() const override { return "SystemNumbers"; }
     std::string getTableName() const override { return name; }

--- a/dbms/src/Storages/System/StorageSystemOne.h
+++ b/dbms/src/Storages/System/StorageSystemOne.h
@@ -17,6 +17,7 @@ class Context;
   */
 class StorageSystemOne : public ext::shared_ptr_helper<StorageSystemOne>, public IStorage
 {
+    friend struct ext::shared_ptr_helper<StorageSystemOne>;
 public:
     std::string getName() const override { return "SystemOne"; }
     std::string getTableName() const override { return name; }

--- a/dbms/src/Storages/System/StorageSystemParts.h
+++ b/dbms/src/Storages/System/StorageSystemParts.h
@@ -14,6 +14,7 @@ class Context;
   */
 class StorageSystemParts : public ext::shared_ptr_helper<StorageSystemParts>, public StorageSystemPartsBase
 {
+    friend struct ext::shared_ptr_helper<StorageSystemParts>;
 public:
     std::string getName() const override { return "SystemParts"; }
 

--- a/dbms/src/Storages/System/StorageSystemPartsColumns.h
+++ b/dbms/src/Storages/System/StorageSystemPartsColumns.h
@@ -16,6 +16,7 @@ class Context;
 class StorageSystemPartsColumns
         : public ext::shared_ptr_helper<StorageSystemPartsColumns>, public StorageSystemPartsBase
 {
+    friend struct ext::shared_ptr_helper<StorageSystemPartsColumns>;
 public:
     std::string getName() const override { return "SystemPartsColumns"; }
 

--- a/dbms/src/Storages/System/StorageSystemProcesses.h
+++ b/dbms/src/Storages/System/StorageSystemProcesses.h
@@ -14,6 +14,7 @@ class Context;
   */
 class StorageSystemProcesses : public ext::shared_ptr_helper<StorageSystemProcesses>, public IStorageSystemOneBlock<StorageSystemProcesses>
 {
+    friend struct ext::shared_ptr_helper<StorageSystemProcesses>;
 public:
     std::string getName() const override { return "SystemProcesses"; }
 

--- a/dbms/src/Storages/System/StorageSystemReplicas.h
+++ b/dbms/src/Storages/System/StorageSystemReplicas.h
@@ -14,6 +14,7 @@ class Context;
   */
 class StorageSystemReplicas : public ext::shared_ptr_helper<StorageSystemReplicas>, public IStorage
 {
+    friend struct ext::shared_ptr_helper<StorageSystemReplicas>;
 public:
     std::string getName() const override { return "SystemReplicas"; }
     std::string getTableName() const override { return name; }

--- a/dbms/src/Storages/System/StorageSystemReplicationQueue.h
+++ b/dbms/src/Storages/System/StorageSystemReplicationQueue.h
@@ -14,6 +14,7 @@ class Context;
   */
 class StorageSystemReplicationQueue : public ext::shared_ptr_helper<StorageSystemReplicationQueue>, public IStorageSystemOneBlock<StorageSystemReplicationQueue>
 {
+    friend struct ext::shared_ptr_helper<StorageSystemReplicationQueue>;
 public:
     std::string getName() const override { return "SystemReplicationQueue"; }
 

--- a/dbms/src/Storages/System/StorageSystemSettings.h
+++ b/dbms/src/Storages/System/StorageSystemSettings.h
@@ -14,6 +14,7 @@ class Context;
   */
 class StorageSystemSettings : public ext::shared_ptr_helper<StorageSystemSettings>, public IStorageSystemOneBlock<StorageSystemSettings>
 {
+    friend struct ext::shared_ptr_helper<StorageSystemSettings>;
 public:
     std::string getName() const override { return "SystemSettings"; }
 

--- a/dbms/src/Storages/System/StorageSystemTableEngines.h
+++ b/dbms/src/Storages/System/StorageSystemTableEngines.h
@@ -10,6 +10,7 @@ namespace DB
 class StorageSystemTableEngines : public ext::shared_ptr_helper<StorageSystemTableEngines>,
                                   public IStorageSystemOneBlock<StorageSystemTableEngines>
 {
+    friend struct ext::shared_ptr_helper<StorageSystemTableEngines>;
 protected:
     void fillData(MutableColumns & res_columns, const Context & context, const SelectQueryInfo & query_info) const override;
 

--- a/dbms/src/Storages/System/StorageSystemTableFunctions.h
+++ b/dbms/src/Storages/System/StorageSystemTableFunctions.h
@@ -9,6 +9,7 @@ namespace DB
 class StorageSystemTableFunctions : public ext::shared_ptr_helper<StorageSystemTableFunctions>,
                                     public IStorageSystemOneBlock<StorageSystemTableFunctions>
 {
+    friend struct ext::shared_ptr_helper<StorageSystemTableFunctions>;
 protected:
 
     using IStorageSystemOneBlock::IStorageSystemOneBlock;

--- a/dbms/src/Storages/System/StorageSystemTables.h
+++ b/dbms/src/Storages/System/StorageSystemTables.h
@@ -14,6 +14,7 @@ class Context;
   */
 class StorageSystemTables : public ext::shared_ptr_helper<StorageSystemTables>, public IStorage
 {
+    friend struct ext::shared_ptr_helper<StorageSystemTables>;
 public:
     std::string getName() const override { return "SystemTables"; }
     std::string getTableName() const override { return name; }

--- a/dbms/src/Storages/System/StorageSystemZooKeeper.h
+++ b/dbms/src/Storages/System/StorageSystemZooKeeper.h
@@ -14,6 +14,7 @@ class Context;
   */
 class StorageSystemZooKeeper : public ext::shared_ptr_helper<StorageSystemZooKeeper>, public IStorageSystemOneBlock<StorageSystemZooKeeper>
 {
+    friend struct ext::shared_ptr_helper<StorageSystemZooKeeper>;
 public:
     std::string getName() const override { return "SystemZooKeeper"; }
 

--- a/libs/libcommon/include/ext/shared_ptr_helper.h
+++ b/libs/libcommon/include/ext/shared_ptr_helper.h
@@ -7,32 +7,16 @@ namespace ext
 
 /** Allows to make std::shared_ptr from T with protected constructor.
   *
-  * Derive your T class from shared_ptr_helper<T>
+  * Derive your T class from shared_ptr_helper<T> and add shared_ptr_helper<T> as a friend
   *  and you will have static 'create' method in your class.
-  *
-  * Downsides:
-  * - your class cannot be final;
-  * - awful compilation error messages;
-  * - bad code navigation.
-  * - different dynamic type of created object, you cannot use typeid.
   */
 template <typename T>
 struct shared_ptr_helper
 {
     template <typename... TArgs>
-    static auto create(TArgs &&... args)
+    static std::shared_ptr<T> create(TArgs &&... args)
     {
-        /** Local struct makes protected constructor to be accessible by std::make_shared function.
-          * This trick is suggested by Yurii Diachenko,
-          *  inspired by https://habrahabr.ru/company/mailru/blog/341584/
-          *  that is translation of http://videocortex.io/2017/Bestiary/#-voldemort-types
-          */
-        struct Local : T
-        {
-            Local(TArgs &&... args) : T(std::forward<TArgs>(args)...) {}
-        };
-
-        return std::make_shared<Local>(std::forward<TArgs>(args)...);
+        return std::shared_ptr<T>(new T(std::forward<TArgs>(args)...));
     }
 };
 


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Simplify `shared_ptr_helper` because people facing difficulties understanding it.