### PR TITLE
Reduced children_mutex lock scope in IBlockInputStream

### DIFF
--- a/dbms/src/DataStreams/IBlockInputStream.h
+++ b/dbms/src/DataStreams/IBlockInputStream.h
@@ -314,7 +314,11 @@ private:
         /// NOTE: Acquire a read lock, therefore f() should be thread safe
         std::shared_lock lock(children_mutex);
 
-        for (auto & child : children)
+        // Reduce lock scope and avoid recursive locking since that is undefined for shared_mutex.
+        const auto children_copy = children;
+        lock.unlock();
+
+        for (auto & child : children_copy)
             if (f(*child))
                 return;
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement
Short description (up to few sentences):
This is to fix TSan warning 'lock-order-inversion': https://clickhouse-test-reports.s3.yandex.net/6399/c1c1d1daa98e199e620766f1bd06a5921050a00d/functional_stateful_tests_(thread).html
...

Detailed description (optional):
Issue analysis: Thread locks IBlockInputStream::children_mutex (A) and then subsequently locks
MergeTreeDataPart::columns_lock mutex (B), holding it for extended period of
time, surviving the unlock of the A. Then, while B is still locked, A
is locked again, causing a TSan warning.
...
