### PR TITLE
Avoid data race on Settings in KILL QUERY.

### DIFF
--- a/dbms/src/Interpreters/InterpreterKillQueryQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterKillQueryQuery.cpp
@@ -265,11 +265,6 @@ Block InterpreterKillQueryQuery::getSelectResult(const String & columns, const S
     if (where_expression)
         select_query += " WHERE " + queryToString(where_expression);
 
-    auto use_processors = context.getSettingsRef().experimental_use_processors;
-    context.getSettingsRef().experimental_use_processors = false;
-
-    SCOPE_EXIT(context.getSettingsRef().experimental_use_processors = use_processors);
-
     BlockIO block_io = executeQuery(select_query, context, true);
     Block res = block_io.in->read();
 

--- a/dbms/tests/queries/0_stateless/01003_kill_query_race_condition.sh
+++ b/dbms/tests/queries/0_stateless/01003_kill_query_race_condition.sh
@@ -8,7 +8,7 @@ set -e
 function thread1()
 {
     while true; do 
-        $CLICKHOUSE_CLIENT --query_id=hello --query "SELECT count() FROM system.numbers";
+        $CLICKHOUSE_CLIENT --query_id=hello --query "SELECT count() FROM numbers(1000000000)" --format Null;
     done
 }
 

--- a/dbms/tests/queries/0_stateless/01003_kill_query_race_condition.sh
+++ b/dbms/tests/queries/0_stateless/01003_kill_query_race_condition.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. $CURDIR/../shell_config.sh
+
+set -e
+
+function thread1()
+{
+    while true; do 
+        $CLICKHOUSE_CLIENT --query_id=hello --query "SELECT count() FROM system.numbers";
+    done
+}
+
+function thread2()
+{
+    while true; do
+        $CLICKHOUSE_CLIENT --query "KILL QUERY WHERE query_id = 'hello'" --format Null;
+        sleep 0.$RANDOM
+    done
+}
+
+function thread3()
+{
+    while true; do
+        $CLICKHOUSE_CLIENT --query "SHOW PROCESSLIST" --format Null;
+        $CLICKHOUSE_CLIENT --query "SELECT * FROM system.processes" --format Null;
+    done
+}
+
+# https://stackoverflow.com/questions/9954794/execute-a-shell-function-with-timeout
+export -f thread1;
+export -f thread2;
+export -f thread3;
+
+TIMEOUT=10
+
+timeout $TIMEOUT bash -c thread1 2> /dev/null &
+timeout $TIMEOUT bash -c thread1 2> /dev/null &
+timeout $TIMEOUT bash -c thread1 2> /dev/null &
+timeout $TIMEOUT bash -c thread1 2> /dev/null &
+
+timeout $TIMEOUT bash -c thread2 2> /dev/null &
+
+timeout $TIMEOUT bash -c thread3 2> /dev/null &
+timeout $TIMEOUT bash -c thread3 2> /dev/null &
+timeout $TIMEOUT bash -c thread3 2> /dev/null &
+timeout $TIMEOUT bash -c thread3 2> /dev/null &
+
+wait


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement

Detailed description (optional):
```
WARNING: ThreadSanitizer: data race (pid=257179)
  Read of size 8 at 0x7b9000861940 by thread T176 (mutexes: write M921):
    #0 memcpy <null> (clickhouse+0x6a5d2cd)
    #1 DB::Settings::Settings(DB::Settings const&) /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/src/Core/Settings.h:32:8 (clickhouse+0x6c2ba15)
    #2 std::__1::__compressed_pair_elem<DB::Settings, 1, false>::__compressed_pair_elem<DB::Settings&, 0ul>(std::__1::piecewise_construct_t, std::__1::tuple<DB::Settings&>, std::__1::__tuple_indices<0ul>) /home/milovidov/ClickHouse/contrib/libcxx/include/memory:2155:9 (clickhouse+0xc4874f9)
    #3 std::__1::__compressed_pair<std::__1::allocator<DB::Settings>, DB::Settings>::__compressed_pair<std::__1::allocator<DB::Settings>&, DB::Settings&>(std::__1::piecewise_construct_t, std::__1::tuple<std::__1::allocator<DB::Settings>&>, std::__1::tuple<DB::Settings&>) /home/milovidov/ClickHouse/contrib/libcxx/include/memory:2258 (clickhouse+0xc4874f9)
    #4 std::__1::__shared_ptr_emplace<DB::Settings, std::__1::allocator<DB::Settings> >::__shared_ptr_emplace<DB::Settings&>(std::__1::allocator<DB::Settings>, DB::Settings&) /home/milovidov/ClickHouse/contrib/libcxx/include/memory:3671 (clickhouse+0xc4874f9)
    #5 std::__1::shared_ptr<DB::Settings> std::__1::shared_ptr<DB::Settings>::make_shared<DB::Settings&>(DB::Settings&) /home/milovidov/ClickHouse/contrib/libcxx/include/memory:4330 (clickhouse+0xc4874f9)
    #6 std::__1::enable_if<!(is_array<DB::Settings>::value), std::__1::shared_ptr<DB::Settings> >::type std::__1::make_shared<DB::Settings, DB::Settings&>(DB::Settings&) /home/milovidov/ClickHouse/contrib/libcxx/include/memory:4709 (clickhouse+0xc4874f9)
    #7 DB::QueryStatus::getInfo(bool, bool, bool) const /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/src/Interpreters/ProcessList.cpp:450 (clickhouse+0xc4874f9)
    #8 DB::ProcessList::getInfo(bool, bool, bool) const /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/src/Interpreters/ProcessList.cpp:464:46 (clickhouse+0xc487815)
    #9 DB::StorageSystemProcesses::fillData(std::__1::vector<COW<DB::IColumn>::mutable_ptr<DB::IColumn>, std::__1::allocator<COW<DB::IColumn>::mutable_ptr<DB::IColumn> > >&, DB::Context const&, DB::SelectQueryInfo const&) const /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/src/Storages/System/StorageSystemProcesses.cpp:71:55 (clickhouse+0xbdca79a)
    #10 DB::IStorageSystemOneBlock<DB::StorageSystemProcesses>::read(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, DB::SelectQueryInfo const&, DB::Context const&, DB::QueryProcessingStage::Enum, unsigned long, unsigned int) /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/src/Storages/System/IStorageSystemOneBlock.h:42:9 (clickhouse+0xbd74f95)
    #11 void DB::InterpreterSelectQuery::executeFetchColumns<DB::InterpreterSelectQuery::Pipeline>(DB::QueryProcessingStage::Enum, DB::InterpreterSelectQuery::Pipeline&, std::__1::shared_ptr<DB::SortingInfo> const&, std::__1::shared_ptr<DB::PrewhereInfo> const&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/src/Interpreters/InterpreterSelectQuery.cpp:1397:33 (clickhouse+0xc1b63e2)
    #12 void DB::InterpreterSelectQuery::executeImpl<DB::InterpreterSelectQuery::Pipeline>(DB::InterpreterSelectQuery::Pipeline&, std::__1::shared_ptr<DB::IBlockInputStream> const&, bool) /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/src/Interpreters/InterpreterSelectQuery.cpp:863:9 (clickhouse+0xc1a85a5)
    #13 DB::InterpreterSelectQuery::executeWithMultipleStreams() /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/src/Interpreters/InterpreterSelectQuery.cpp:395:5 (clickhouse+0xc18f56f)
    #14 DB::InterpreterSelectWithUnionQuery::executeWithMultipleStreams() /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/src/Interpreters/InterpreterSelectWithUnionQuery.cpp:173:50 (clickhouse+0xc384573)
    #15 DB::InterpreterSelectWithUnionQuery::execute() /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/src/Interpreters/InterpreterSelectWithUnionQuery.cpp:190:40 (clickhouse+0xc384941)
    #16 DB::executeQueryImpl(char const*, char const*, DB::Context&, bool, DB::QueryProcessingStage::Enum, bool) /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/src/Interpreters/executeQuery.cpp:247:32 (clickhouse+0xc54080e)
    #17 DB::executeQuery(DB::ReadBuffer&, DB::WriteBuffer&, bool, DB::Context&, std::__1::function<void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)>, std::__1::function<void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)>) /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/src/Interpreters/executeQuery.cpp:538:30 (clickhouse+0xc543106)
    #18 DB::HTTPHandler::processQuery(Poco::Net::HTTPServerRequest&, HTMLForm&, Poco::Net::HTTPServerResponse&, DB::HTTPHandler::Output&) /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/programs/server/HTTPHandler.cpp:625:5 (clickhouse+0x6ba867f)
    #19 DB::HTTPHandler::handleRequest(Poco::Net::HTTPServerRequest&, Poco::Net::HTTPServerResponse&) /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/programs/server/HTTPHandler.cpp:736:9 (clickhouse+0x6bac315)
    #20 Poco::Net::HTTPServerConnection::run() /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Net/src/HTTPServerConnection.cpp:85:17 (clickhouse+0xd00e7e5)
    #21 Poco::Net::TCPServerConnection::start() /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Net/src/TCPServerConnection.cpp:43:3 (clickhouse+0xd0492a2)
    #22 Poco::Net::TCPServerDispatcher::run() /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Net/src/TCPServerDispatcher.cpp:114:20 (clickhouse+0xd049b3a)
    #23 Poco::PooledThread::run() /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Foundation/src/ThreadPool.cpp:214:14 (clickhouse+0xd9e4161)
    #24 Poco::(anonymous namespace)::RunnableHolder::run() /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Foundation/src/Thread.cpp:43:11 (clickhouse+0xd9e260f)
    #25 Poco::ThreadImpl::runnableEntry(void*) /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Foundation/src/Thread_STD.cpp:139:27 (clickhouse+0xd9e0d7a)
    #26 decltype(std::__1::forward<void* (*)(void*)>(fp)(std::__1::forward<Poco::ThreadImpl*>(fp0))) std::__1::__invoke<void* (*)(void*), Poco::ThreadImpl*>(void* (*&&)(void*), Poco::ThreadImpl*&&) /home/milovidov/ClickHouse/contrib/libcxx/include/type_traits:4410:1 (clickhouse+0xd9e303a)
    #27 void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*, 2ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*>&, std::__1::__tuple_indices<2ul>) /home/milovidov/ClickHouse/contrib/libcxx/include/thread:341 (clickhouse+0xd9e303a)
    #28 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*> >(void*) /home/milovidov/ClickHouse/contrib/libcxx/include/thread:351 (clickhouse+0xd9e303a)

  Previous write of size 2 at 0x7b9000861940 by thread T179:
    #0 DB::InterpreterKillQueryQuery::getSelectResult(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)::$_0::operator()() const /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/src/Interpreters/InterpreterKillQueryQuery.cpp:271:5 (clickhouse+0xc1838d0)
    #1 ext::scope_guard<DB::InterpreterKillQueryQuery::getSelectResult(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)::$_0>::~scope_guard() /home/milovidov/ClickHouse/build_clang8_tsan/../libs/libcommon/include/ext/scope_guard.h:14 (clickhouse+0xc1838d0)
    #2 DB::InterpreterKillQueryQuery::getSelectResult(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/src/Interpreters/InterpreterKillQueryQuery.cpp:280 (clickhouse+0xc1838d0)
    #3 DB::InterpreterKillQueryQuery::execute() /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/src/Interpreters/InterpreterKillQueryQuery.cpp:220:33 (clickhouse+0xc180c53)
    #4 DB::executeQueryImpl(char const*, char const*, DB::Context&, bool, DB::QueryProcessingStage::Enum, bool) /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/src/Interpreters/executeQuery.cpp:247:32 (clickhouse+0xc54080e)
    #5 DB::executeQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::Context&, bool, DB::QueryProcessingStage::Enum, bool) /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/src/Interpreters/executeQuery.cpp:487:38 (clickhouse+0xc53fdca)
    #6 DB::TCPHandler::runImpl() /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/programs/server/TCPHandler.cpp:210:24 (clickhouse+0x6bd0c16)
    #7 DB::TCPHandler::run() /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/programs/server/TCPHandler.cpp:1083:9 (clickhouse+0x6bde387)
    #8 Poco::Net::TCPServerConnection::start() /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Net/src/TCPServerConnection.cpp:43:3 (clickhouse+0xd0492a2)
    #9 Poco::Net::TCPServerDispatcher::run() /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Net/src/TCPServerDispatcher.cpp:114:20 (clickhouse+0xd049b3a)
    #10 Poco::PooledThread::run() /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Foundation/src/ThreadPool.cpp:214:14 (clickhouse+0xd9e4161)
    #11 Poco::(anonymous namespace)::RunnableHolder::run() /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Foundation/src/Thread.cpp:43:11 (clickhouse+0xd9e260f)
    #12 Poco::ThreadImpl::runnableEntry(void*) /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Foundation/src/Thread_STD.cpp:139:27 (clickhouse+0xd9e0d7a)
    #13 decltype(std::__1::forward<void* (*)(void*)>(fp)(std::__1::forward<Poco::ThreadImpl*>(fp0))) std::__1::__invoke<void* (*)(void*), Poco::ThreadImpl*>(void* (*&&)(void*), Poco::ThreadImpl*&&) /home/milovidov/ClickHouse/contrib/libcxx/include/type_traits:4410:1 (clickhouse+0xd9e303a)
    #14 void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*, 2ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*>&, std::__1::__tuple_indices<2ul>) /home/milovidov/ClickHouse/contrib/libcxx/include/thread:341 (clickhouse+0xd9e303a)
    #15 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*> >(void*) /home/milovidov/ClickHouse/contrib/libcxx/include/thread:351 (clickhouse+0xd9e303a)

  Location is heap block of size 7664 at 0x7b9000860000 allocated by thread T179:
    #0 operator new(unsigned long) <null> (clickhouse+0x6adcb1d)
    #1 DB::TCPHandlerFactory::createConnection(Poco::Net::StreamSocket const&) /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/programs/server/TCPHandlerFactory.h:33:16 (clickhouse+0x6b053cf)
    #2 Poco::Net::TCPServerDispatcher::run() /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Net/src/TCPServerDispatcher.cpp:111:77 (clickhouse+0xd049a87)
    #3 Poco::PooledThread::run() /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Foundation/src/ThreadPool.cpp:214:14 (clickhouse+0xd9e4161)
    #4 Poco::(anonymous namespace)::RunnableHolder::run() /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Foundation/src/Thread.cpp:43:11 (clickhouse+0xd9e260f)
    #5 Poco::ThreadImpl::runnableEntry(void*) /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Foundation/src/Thread_STD.cpp:139:27 (clickhouse+0xd9e0d7a)
    #6 decltype(std::__1::forward<void* (*)(void*)>(fp)(std::__1::forward<Poco::ThreadImpl*>(fp0))) std::__1::__invoke<void* (*)(void*), Poco::ThreadImpl*>(void* (*&&)(void*), Poco::ThreadImpl*&&) /home/milovidov/ClickHouse/contrib/libcxx/include/type_traits:4410:1 (clickhouse+0xd9e303a)
    #7 void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*, 2ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*>&, std::__1::__tuple_indices<2ul>) /home/milovidov/ClickHouse/contrib/libcxx/include/thread:341 (clickhouse+0xd9e303a)
    #8 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*> >(void*) /home/milovidov/ClickHouse/contrib/libcxx/include/thread:351 (clickhouse+0xd9e303a)

  Mutex M921 (0x7b8000017438) created at:
    #0 pthread_mutex_lock <null> (clickhouse+0x6a6f66e)
    #1 std::__1::__libcpp_mutex_lock(pthread_mutex_t*) /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/libcxx/include/__threading_support:255:10 (clickhouse+0xe21d869)
    #2 std::__1::mutex::lock() /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/libcxx/src/mutex.cpp:30 (clickhouse+0xe21d869)
    #3 std::__1::lock_guard<std::__1::mutex>::lock_guard(std::__1::mutex&) /home/milovidov/ClickHouse/contrib/libcxx/include/__mutex_base:103:27 (clickhouse+0x6ae87c6)
    #4 DB::ProcessList::setMaxSize(unsigned long) /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/src/Interpreters/ProcessList.h:312 (clickhouse+0x6ae87c6)
    #5 DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/programs/server/Server.cpp:450 (clickhouse+0x6ae87c6)
    #6 Poco::Util::Application::run() /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Util/src/Application.cpp:335:8 (clickhouse+0xd15d38d)
    #7 DB::Server::run() /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/programs/server/Server.cpp:146:25 (clickhouse+0x6ae235a)
    #8 Poco::Util::ServerApplication::run(int, char**) /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Util/src/ServerApplication.cpp:618:9 (clickhouse+0xd17b3b8)
    #9 mainEntryClickHouseServer(int, char**) /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/programs/server/Server.cpp:925:20 (clickhouse+0x6afbe73)
    #10 main /home/milovidov/ClickHouse/build_clang8_tsan/../dbms/programs/main.cpp:182:12 (clickhouse+0x6adee92)

  Thread T176 'HTTPHandler' (tid=259808, running) created by thread T172 at:
    #0 pthread_create <null> (clickhouse+0x6a534a5)
    #1 std::__1::__libcpp_thread_create(unsigned long*, void* (*)(void*), void*) /home/milovidov/ClickHouse/contrib/libcxx/include/__threading_support:327:10 (clickhouse+0xd9e29e7)
    #2 std::__1::thread::thread<void* (&)(void*), Poco::ThreadImpl*, void>(void* (&)(void*), Poco::ThreadImpl*&&) /home/milovidov/ClickHouse/contrib/libcxx/include/thread:367 (clickhouse+0xd9e29e7)
    #3 Poco::ThreadImpl::startImpl(Poco::SharedPtr<Poco::Runnable, Poco::ReferenceCounter, Poco::ReleasePolicy<Poco::Runnable> >) /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Foundation/src/Thread_STD.cpp:58:53 (clickhouse+0xd9e0817)
    #4 Poco::Thread::start(Poco::Runnable&) /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Foundation/src/Thread.cpp:116:2 (clickhouse+0xd9e1fbc)
    #5 Poco::PooledThread::start(int) /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Foundation/src/ThreadPool.cpp:88:10 (clickhouse+0xd9e5b09)
    #6 Poco::ThreadPool::getThread() /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Foundation/src/ThreadPool.cpp:525 (clickhouse+0xd9e5b09)
    #7 Poco::ThreadPool::startWithPriority(Poco::Thread::Priority, Poco::Runnable&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Foundation/src/ThreadPool.cpp:429:2 (clickhouse+0xd9e5dce)
    #8 Poco::Net::TCPServerDispatcher::enqueue(Poco::Net::StreamSocket const&) /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Net/src/TCPServerDispatcher.cpp:144:17 (clickhouse+0xd04a0a0)
    #9 Poco::Net::TCPServer::run() /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Net/src/TCPServer.cpp:148:21 (clickhouse+0xd048c95)
    #10 Poco::(anonymous namespace)::RunnableHolder::run() /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Foundation/src/Thread.cpp:43:11 (clickhouse+0xd9e260f)
    #11 Poco::ThreadImpl::runnableEntry(void*) /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Foundation/src/Thread_STD.cpp:139:27 (clickhouse+0xd9e0d7a)
    #12 decltype(std::__1::forward<void* (*)(void*)>(fp)(std::__1::forward<Poco::ThreadImpl*>(fp0))) std::__1::__invoke<void* (*)(void*), Poco::ThreadImpl*>(void* (*&&)(void*), Poco::ThreadImpl*&&) /home/milovidov/ClickHouse/contrib/libcxx/include/type_traits:4410:1 (clickhouse+0xd9e303a)
    #13 void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*, 2ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*>&, std::__1::__tuple_indices<2ul>) /home/milovidov/ClickHouse/contrib/libcxx/include/thread:341 (clickhouse+0xd9e303a)
    #14 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*> >(void*) /home/milovidov/ClickHouse/contrib/libcxx/include/thread:351 (clickhouse+0xd9e303a)

  Thread T179 'TCPHandler' (tid=259811, running) created by thread T172 at:
    #0 pthread_create <null> (clickhouse+0x6a534a5)
    #1 std::__1::__libcpp_thread_create(unsigned long*, void* (*)(void*), void*) /home/milovidov/ClickHouse/contrib/libcxx/include/__threading_support:327:10 (clickhouse+0xd9e29e7)
    #2 std::__1::thread::thread<void* (&)(void*), Poco::ThreadImpl*, void>(void* (&)(void*), Poco::ThreadImpl*&&) /home/milovidov/ClickHouse/contrib/libcxx/include/thread:367 (clickhouse+0xd9e29e7)
    #3 Poco::ThreadImpl::startImpl(Poco::SharedPtr<Poco::Runnable, Poco::ReferenceCounter, Poco::ReleasePolicy<Poco::Runnable> >) /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Foundation/src/Thread_STD.cpp:58:53 (clickhouse+0xd9e0817)
    #4 Poco::Thread::start(Poco::Runnable&) /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Foundation/src/Thread.cpp:116:2 (clickhouse+0xd9e1fbc)
    #5 Poco::PooledThread::start(int) /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Foundation/src/ThreadPool.cpp:88:10 (clickhouse+0xd9e5b09)
    #6 Poco::ThreadPool::getThread() /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Foundation/src/ThreadPool.cpp:525 (clickhouse+0xd9e5b09)
    #7 Poco::ThreadPool::startWithPriority(Poco::Thread::Priority, Poco::Runnable&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Foundation/src/ThreadPool.cpp:429:2 (clickhouse+0xd9e5dce)
    #8 Poco::Net::TCPServerDispatcher::enqueue(Poco::Net::StreamSocket const&) /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Net/src/TCPServerDispatcher.cpp:144:17 (clickhouse+0xd04a0a0)
    #9 Poco::Net::TCPServer::run() /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Net/src/TCPServer.cpp:148:21 (clickhouse+0xd048c95)
    #10 Poco::(anonymous namespace)::RunnableHolder::run() /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Foundation/src/Thread.cpp:43:11 (clickhouse+0xd9e260f)
    #11 Poco::ThreadImpl::runnableEntry(void*) /home/milovidov/ClickHouse/build_clang8_tsan/../contrib/poco/Foundation/src/Thread_STD.cpp:139:27 (clickhouse+0xd9e0d7a)
    #12 decltype(std::__1::forward<void* (*)(void*)>(fp)(std::__1::forward<Poco::ThreadImpl*>(fp0))) std::__1::__invoke<void* (*)(void*), Poco::ThreadImpl*>(void* (*&&)(void*), Poco::ThreadImpl*&&) /home/milovidov/ClickHouse/contrib/libcxx/include/type_traits:4410:1 (clickhouse+0xd9e303a)
    #13 void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*, 2ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*>&, std::__1::__tuple_indices<2ul>) /home/milovidov/ClickHouse/contrib/libcxx/include/thread:341 (clickhouse+0xd9e303a)
    #14 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void* (*)(void*), Poco::ThreadImpl*> >(void*) /home/milovidov/ClickHouse/contrib/libcxx/include/thread:351 (clickhouse+0xd9e303a)
```