### PR TITLE
Add "os_thread_ids" column to system tables

### DIFF
--- a/dbms/src/Common/ThreadStatus.h
+++ b/dbms/src/Common/ThreadStatus.h
@@ -61,6 +61,7 @@ public:
     InternalTextLogsQueueWeakPtr logs_queue_ptr;
 
     std::vector<UInt32> thread_numbers;
+    std::vector<UInt32> os_thread_ids;
 
     /// The first thread created this thread group
     UInt32 master_thread_number = 0;

--- a/dbms/src/Interpreters/ProcessList.cpp
+++ b/dbms/src/Interpreters/ProcessList.cpp
@@ -444,6 +444,7 @@ QueryStatusInfo QueryStatus::getInfo(bool get_thread_list, bool get_profile_even
         {
             std::lock_guard lock(thread_group->mutex);
             res.thread_numbers = thread_group->thread_numbers;
+            res.os_thread_ids = thread_group->os_thread_ids;
         }
 
         if (get_profile_events)

--- a/dbms/src/Interpreters/ProcessList.h
+++ b/dbms/src/Interpreters/ProcessList.h
@@ -66,6 +66,7 @@ struct QueryStatusInfo
 
     /// Optional fields, filled by request
     std::vector<UInt32> thread_numbers;
+    std::vector<UInt32> os_thread_ids;
     std::shared_ptr<ProfileEvents::Counters> profile_counters;
     std::shared_ptr<Settings> query_settings;
 };

--- a/dbms/src/Interpreters/QueryLog.cpp
+++ b/dbms/src/Interpreters/QueryLog.cpp
@@ -78,6 +78,7 @@ Block QueryLogElement::createBlock()
         {std::make_shared<DataTypeUInt32>(),                                  "revision"},
 
         {std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt32>()), "thread_numbers"},
+        {std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt32>()), "os_thread_ids"},
         {std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>()), "ProfileEvents.Names"},
         {std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt64>()), "ProfileEvents.Values"},
         {std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>()), "Settings.Names"},
@@ -119,6 +120,14 @@ void QueryLogElement::appendToBlock(Block & block) const
         Array threads_array;
         threads_array.reserve(thread_numbers.size());
         for (const UInt32 thread_number : thread_numbers)
+            threads_array.emplace_back(UInt64(thread_number));
+        columns[i++]->insert(threads_array);
+    }
+
+    {
+        Array threads_array;
+        threads_array.reserve(os_thread_ids.size());
+        for (const UInt32 thread_number : os_thread_ids)
             threads_array.emplace_back(UInt64(thread_number));
         columns[i++]->insert(threads_array);
     }

--- a/dbms/src/Interpreters/QueryLog.h
+++ b/dbms/src/Interpreters/QueryLog.h
@@ -60,6 +60,7 @@ struct QueryLogElement
     ClientInfo client_info;
 
     std::vector<UInt32> thread_numbers;
+    std::vector<UInt32> os_thread_ids;
     std::shared_ptr<ProfileEvents::Counters> profile_counters;
     std::shared_ptr<Settings> query_settings;
 

--- a/dbms/src/Interpreters/ThreadStatusExt.cpp
+++ b/dbms/src/Interpreters/ThreadStatusExt.cpp
@@ -61,6 +61,7 @@ void ThreadStatus::initializeQuery()
     thread_group->memory_tracker.setDescription("(for query)");
 
     thread_group->thread_numbers.emplace_back(thread_number);
+    thread_group->os_thread_ids.emplace_back(os_thread_id);
     thread_group->master_thread_number = thread_number;
     thread_group->master_thread_os_id = os_thread_id;
 
@@ -99,6 +100,7 @@ void ThreadStatus::attachQuery(const ThreadGroupStatusPtr & thread_group_, bool 
 
         /// NOTE: A thread may be attached multiple times if it is reused from a thread pool.
         thread_group->thread_numbers.emplace_back(thread_number);
+        thread_group->os_thread_ids.emplace_back(os_thread_id);
     }
 
     if (query_context)

--- a/dbms/src/Interpreters/executeQuery.cpp
+++ b/dbms/src/Interpreters/executeQuery.cpp
@@ -400,6 +400,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
                 }
 
                 elem.thread_numbers = std::move(info.thread_numbers);
+                elem.os_thread_ids = std::move(info.os_thread_ids);
                 elem.profile_counters = std::move(info.profile_counters);
 
                 if (log_queries)
@@ -437,6 +438,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
                     elem.memory_usage = info.peak_memory_usage > 0 ? info.peak_memory_usage : 0;
 
                     elem.thread_numbers = std::move(info.thread_numbers);
+                    elem.os_thread_ids = std::move(info.os_thread_ids);
                     elem.profile_counters = std::move(info.profile_counters);
                 }
 

--- a/dbms/src/Storages/System/StorageSystemProcesses.cpp
+++ b/dbms/src/Storages/System/StorageSystemProcesses.cpp
@@ -58,6 +58,7 @@ NamesAndTypesList StorageSystemProcesses::getNamesAndTypes()
         {"query", std::make_shared<DataTypeString>()},
 
         {"thread_numbers", std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt32>())},
+        {"os_thread_ids", std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt32>())},
         {"ProfileEvents.Names", std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>())},
         {"ProfileEvents.Values", std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt64>())},
         {"Settings.Names", std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>())},
@@ -116,6 +117,14 @@ void StorageSystemProcesses::fillData(MutableColumns & res_columns, const Contex
             Array threads_array;
             threads_array.reserve(process.thread_numbers.size());
             for (const UInt32 thread_number : process.thread_numbers)
+                threads_array.emplace_back(thread_number);
+            res_columns[i++]->insert(threads_array);
+        }
+
+        {
+            Array threads_array;
+            threads_array.reserve(process.os_thread_ids.size());
+            for (const UInt32 thread_number : process.os_thread_ids)
                 threads_array.emplace_back(thread_number);
             res_columns[i++]->insert(threads_array);
         }


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

Short description (up to few sentences):
Added `os_thread_ids` column to `system.processes` and `system.query_log` for better debugging possibilities.