### PR TITLE
Disable query profiler with sanitizers

### DIFF
--- a/dbms/programs/server/Server.cpp
+++ b/dbms/programs/server/Server.cpp
@@ -520,7 +520,18 @@ int Server::main(const std::vector<std::string> & /*args*/)
 
     /// Init trace collector only after trace_log system table was created
     /// Disable it if we collect test coverage information, because it will work extremely slow.
-#if USE_UNWIND && !WITH_COVERAGE
+    ///
+    /// It also cannot work with sanitizers.
+    /// Sanitizers are using quick "frame walking" stack unwinding (this implies -fno-omit-frame-pointer)
+    /// And they do unwiding frequently (on every malloc/free, thread/mutex operations, etc).
+    /// They change %rbp during unwinding and it confuses libunwind if signal comes during sanitizer unwiding
+    ///  and query profiler decide to unwind stack with libunwind at this moment.
+    ///
+    /// Symptoms: you'll get silent Segmentation Fault - without sanitizer message and without usual ClickHouse diagnostics.
+    ///
+    /// Look at compiler-rt/lib/sanitizer_common/sanitizer_stacktrace.h
+    ///
+#if USE_UNWIND && !WITH_COVERAGE && !defined(SANITIZER)
     /// QueryProfiler cannot work reliably with any other libunwind or without PHDR cache.
     if (hasPHDRCache())
         global_context->initializeTraceCollector();

--- a/dbms/src/Core/Defines.h
+++ b/dbms/src/Core/Defines.h
@@ -124,6 +124,8 @@
 #endif
 #endif
 
+/// TODO Strange enough, there is no way to detect UB sanitizer.
+
 /// Explicitly allow undefined behaviour for certain functions. Use it as a function attribute.
 /// It is useful in case when compiler cannot see (and exploit) it, but UBSan can.
 /// Example: multiplication of signed integers with possibility of overflow when both sides are from user input.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Don't allow to use query profiler with sanitizers because it is not compatible.

Detailed description (optional):
Query profiler cannot work with sanitizers.
Sanitizers are using quick "frame walking" stack unwinding (this implies `-fno-omit-frame-pointer`)
And they do unwiding frequently (on every malloc/free, thread/mutex operations, etc).
They change %rbp during unwinding and it confuses libunwind if signal comes during sanitizer unwiding and query profiler decide to unwind stack with libunwind at this moment.

Symptoms: you'll get silent Segmentation Fault - without sanitizer message and without usual ClickHouse diagnostics. It triggers stress test to fail sporadically.

```
Thread 350 "AsyncBlockInput" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fdc1ccad700 (LWP 58420)]
libunwind::DwarfInstructions<libunwind::LocalAddressSpace, libunwind::Registers_x86_64>::getSavedRegister (addressSpace=..., registers=..., cfa=140583344201744, savedReg=...) at ../contrib/libunwind/src/DwarfInstructions.hpp:92
92          return (pint_t)addressSpace.getRegister(cfa + (pint_t)savedReg.value);
(gdb) bt
#0  libunwind::DwarfInstructions<libunwind::LocalAddressSpace, libunwind::Registers_x86_64>::getSavedRegister (addressSpace=..., registers=..., cfa=140583344201744, savedReg=...) at ../contrib/libunwind/src/DwarfInstructions.hpp:92
#1  0x000000001658f79b in libunwind::DwarfInstructions<libunwind::LocalAddressSpace, libunwind::Registers_x86_64>::stepWithDwarf (addressSpace=..., pc=<optimized out>, fdeStart=<optimized out>, registers=...) at ../contrib/libunwind/src/DwarfInstructions.hpp:207
#2  0x000000001658f12e in libunwind::UnwindCursor<libunwind::LocalAddressSpace, libunwind::Registers_x86_64>::stepWithDwarfFDE (this=0x7fdc1cca2540) at ../contrib/libunwind/src/UnwindCursor.hpp:929
#3  libunwind::UnwindCursor<libunwind::LocalAddressSpace, libunwind::Registers_x86_64>::step (this=0x7fdc1cca2540) at ../contrib/libunwind/src/UnwindCursor.hpp:1972
#4  0x000000001658db98 in unw_backtrace (buffer=0x7fdc1cca3200, size=<optimized out>) at ../contrib/libunwind/src/libunwind.cpp:291
#5  0x000000000765708d in StackTrace::tryCapture (this=0x7fdc1cca31f0) at ../dbms/src/Common/StackTrace.cpp:227
#6  StackTrace::StackTrace (this=0x7fdc1cca31f0, signal_context=...) at ../dbms/src/Common/StackTrace.cpp:195
#7  0x0000000007674593 in DB::(anonymous namespace)::writeTraceInfo (timer_type=<optimized out>, info=<optimized out>, context=<optimized out>) at ../dbms/src/Common/QueryProfiler.cpp:70
#8  <signal handler called>
#9  __sanitizer::BufferedStackTrace::UnwindFast (this=0x7fdc1cca3a60, pc=pc@entry=122986953, bp=bp@entry=140583352550064, stack_top=140583352573760, stack_bottom=stack_bottom@entry=140583344201728, max_depth=max_depth@entry=30)
    at /home/milovidov/ClickHouse/ci/workspace/llvm/llvm/projects/compiler-rt/lib/sanitizer_common/sanitizer_stacktrace.cc:72
#10 0x0000000007537439 in __sanitizer::BufferedStackTrace::Unwind (this=this@entry=0x7fdc1cca3a60, max_depth=max_depth@entry=30, pc=pc@entry=122986953, bp=bp@entry=140583352550064, context=context@entry=0x0, stack_top=<optimized out>, stack_bottom=140583344201728, 
    request_fast_unwind=true) at /home/milovidov/ClickHouse/ci/workspace/llvm/llvm/projects/compiler-rt/lib/sanitizer_common/sanitizer_stacktrace_libcdep.cc:83
#11 0x000000000751708f in __sanitizer::BufferedStackTrace::UnwindImpl (this=this@entry=0x7fdc1cca3a60, pc=122986953, bp=bp@entry=140583352550064, context=context@entry=0x0, request_fast=<optimized out>, request_fast@entry=true, max_depth=max_depth@entry=30)
    at /home/milovidov/ClickHouse/ci/workspace/llvm/llvm/projects/compiler-rt/lib/asan/asan_stack.cc:69
#12 0x000000000754a1ef in __sanitizer::BufferedStackTrace::Unwind (context=0x0, max_depth=30, request_fast=true, bp=140583352550064, pc=<optimized out>, this=0x7fdc1cca3a60)
    at /home/milovidov/ClickHouse/ci/workspace/llvm/llvm/projects/compiler-rt/lib/asan/../sanitizer_common/sanitizer_stacktrace.h:115
#13 operator delete (ptr=0x60f006cac450, size=168) at /home/milovidov/ClickHouse/ci/workspace/llvm/llvm/projects/compiler-rt/lib/asan/asan_new_delete.cc:178
```

Look at `compiler-rt/lib/sanitizer_common/sanitizer_stacktrace.h`