### PR TITLE
Remove a redundant condition (found by PVS Studio).

### DIFF
--- a/dbms/src/Functions/GeoUtils.cpp
+++ b/dbms/src/Functions/GeoUtils.cpp
@@ -332,7 +332,7 @@ UInt64 geohashesInBox(const GeohashesInBoxPreparedArgs & args, char * out)
         }
     }
 
-    if (items == 0 && args.items_count != 0)
+    if (items == 0)
     {
         size_t l = geohashEncodeImpl(args.longitude_min, args.latitude_min, args.precision, out);
         out += l;


### PR DESCRIPTION
Fixes a PVS Studio warning, non-significant change.