### PR TITLE
Ability to change history path by changing env

### DIFF
--- a/dbms/programs/client/Client.cpp
+++ b/dbms/programs/client/Client.cpp
@@ -431,8 +431,14 @@ private:
             /// Load command history if present.
             if (config().has("history_file"))
                 history_file = config().getString("history_file");
-            else if (!home_path.empty())
-                history_file = home_path + "/.clickhouse-client-history";
+            else
+            {
+                auto history_file_from_env = getenv("CLICKHOUSE_HISTORY_FILE");
+                if (history_file_from_env)
+                    history_file = history_file_from_env;
+                else if (!home_path.empty())
+                    history_file = home_path + "/.clickhouse-client-history";
+            }
 
             if (!history_file.empty())
             {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- New Feature

Short description (up to few sentences):
Possibility to change the location of clickhouse history file using `CLICKHOUSE_HISTORY_FILE` env.

Detailed description (optional):
Sometimes you may need to use several history files (for different clusters),
Or use history file stored in some network location.
Or just disable writing history by using /dev/null instead of history file. 

Now it's possible using CLICKHOUSE_HISTORY_FILE env variable (you can put it to your `~/.bashrc` or set for particular run).

Before that the only possibility to change that was editing /etc/clickhouse-client/config.xml
implements #6622