### PR TITLE
Returned support for very old Linux kernels (that lack of F_GETPIPE_SZ fcntl)

### DIFF
--- a/dbms/src/Common/TraceCollector.cpp
+++ b/dbms/src/Common/TraceCollector.cpp
@@ -49,15 +49,26 @@ TraceCollector::TraceCollector(std::shared_ptr<TraceLog> & trace_log_)
 #if !defined(__FreeBSD__)
     /** Increase pipe size to avoid slowdown during fine-grained trace collection.
       */
-    constexpr int max_pipe_capacity_to_set = 1048576;
     int pipe_size = fcntl(trace_pipe.fds_rw[1], F_GETPIPE_SZ);
     if (-1 == pipe_size)
-        throwFromErrno("Cannot get pipe capacity", ErrorCodes::CANNOT_FCNTL);
-    for (errno = 0; errno != EPERM && pipe_size < max_pipe_capacity_to_set; pipe_size *= 2)
-        if (-1 == fcntl(trace_pipe.fds_rw[1], F_SETPIPE_SZ, pipe_size * 2) && errno != EPERM)
-            throwFromErrno("Cannot increase pipe capacity to " + toString(pipe_size * 2), ErrorCodes::CANNOT_FCNTL);
+    {
+        if (errno == EINVAL)
+        {
+            LOG_INFO(log, "Cannot get pipe capacity, " << errnoToString(ErrorCodes::CANNOT_FCNTL) << ". Very old Linux kernels have no support for this fcntl.");
+            /// It will work nevertheless.
+        }
+        else
+            throwFromErrno("Cannot get pipe capacity", ErrorCodes::CANNOT_FCNTL);
+    }
+    else
+    {
+        constexpr int max_pipe_capacity_to_set = 1048576;
+        for (errno = 0; errno != EPERM && pipe_size < max_pipe_capacity_to_set; pipe_size *= 2)
+            if (-1 == fcntl(trace_pipe.fds_rw[1], F_SETPIPE_SZ, pipe_size * 2) && errno != EPERM)
+                throwFromErrno("Cannot increase pipe capacity to " + toString(pipe_size * 2), ErrorCodes::CANNOT_FCNTL);
 
-    LOG_TRACE(log, "Pipe capacity is " << formatReadableSizeWithBinarySuffix(std::min(pipe_size, max_pipe_capacity_to_set)));
+        LOG_TRACE(log, "Pipe capacity is " << formatReadableSizeWithBinarySuffix(std::min(pipe_size, max_pipe_capacity_to_set)));
+    }
 #endif
 
     thread = ThreadFromGlobalPool(&TraceCollector::run, this);


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Detailed description (optional):
This often happens on RHEL based systems. This PR fixes  #6841. No tests required (please test manually).