### PR TITLE
Rwlock sanitary update 1: removed weak_ptrs from implementation + added strong exception safety guarantee

### DIFF
--- a/dbms/src/Common/RWLock.cpp
+++ b/dbms/src/Common/RWLock.cpp
@@ -179,7 +179,7 @@ RWLockImpl::LockHolder RWLockImpl::getLock(RWLockImpl::Type type, const String &
     }
 
     /// LockHolder needs to be created before waiting to guarantee
-    /// that this group does not get deleted (group's referers is incremented)
+    /// that this group does not get deleted prematurely (group's referers is incremented)
     res.reset(new LockHolderImpl(shared_from_this(), it_group));
 
     /// Wait a notification until we will be the only in the group.
@@ -212,14 +212,14 @@ RWLockImpl::LockHolderImpl::~LockHolderImpl()
             all_read_locks.remove(query_id);
     }
 
-    /// Remove the group if we were the last referer and notify the next group
+    /// Remove the group if we are the last referer and notify the next group
     if (--it_group->referers == 0)
     {
         auto & parent_queue = parent->queue;
         parent_queue.erase(it_group);
 
         if (!parent_queue.empty())
-            parent_queue.front().cv.notify_all();
+            parent_queue.begin()->cv.notify_all();
     }
 }
 

--- a/dbms/src/Common/RWLock.cpp
+++ b/dbms/src/Common/RWLock.cpp
@@ -39,11 +39,10 @@ class RWLockImpl::LockHolderImpl
 {
     RWLock parent;
     GroupsContainer::iterator it_group;
-    ClientsContainer::iterator it_client;
     QueryIdToHolder::key_type query_id;
     CurrentMetrics::Increment active_client_increment;
 
-    LockHolderImpl(RWLock && parent, GroupsContainer::iterator it_group, ClientsContainer::iterator it_client);
+    LockHolderImpl(RWLock && parent, GroupsContainer::iterator it_group);
 
 public:
 
@@ -114,6 +113,7 @@ RWLockImpl::LockHolder RWLockImpl::getLock(RWLockImpl::Type type, const String &
     std::unique_lock<std::mutex> lock(mutex);
 
     /// Check if the same query is acquiring previously acquired lock
+    /// This FastPath tries to create a "light copy" of a lock without creating a separate LockHolderImpl
     if (request_has_query_id)
     {
         const auto it_query = query_id_to_holder.find(query_id);
@@ -163,7 +163,7 @@ RWLockImpl::LockHolder RWLockImpl::getLock(RWLockImpl::Type type, const String &
         if (type == Type::Read && request_has_query_id && !queue.empty())
             all_read_locks.check(query_id);
 
-        /// Create new group of clients
+        /// Create a new group of locking requests
         it_group = queue.emplace(queue.end(), type);
     }
     else
@@ -174,23 +174,8 @@ RWLockImpl::LockHolder RWLockImpl::getLock(RWLockImpl::Type type, const String &
         /// Will append myself to last group
         it_group = std::prev(queue.end());
     }
-
-    ClientsContainer::iterator it_client;
-    /// Append myself to the end of chosen group
-    auto & clients = it_group->clients;
-    try
-    {
-        it_client = clients.emplace(clients.end(), type);
-    }
-    catch (...)
-    {
-        /// Remove group if it was the first client in the group and an error occurred
-        if (clients.empty())
-            queue.erase(it_group);
-        throw;
-    }
-
-    res.reset(new LockHolderImpl(shared_from_this(), it_group, it_client));
+    ++it_group->referers;
+    res.reset(new LockHolderImpl(shared_from_this(), it_group));
 
     /// Wait a notification until we will be the only in the group.
     it_group->cv.wait(lock, [&] () { return it_group == queue.begin(); });
@@ -202,8 +187,8 @@ RWLockImpl::LockHolder RWLockImpl::getLock(RWLockImpl::Type type, const String &
 
         if (type == Type::Read)
             all_read_locks.add(query_id);
+        res->query_id = query_id;
     }
-    res->query_id = query_id;
 
     finalize_metrics();
     return res;
@@ -217,14 +202,11 @@ RWLockImpl::LockHolderImpl::~LockHolderImpl()
     /// Remove weak_ptrs to the holder, since there are no owners of the current lock
     parent->query_id_to_holder.erase(query_id);
 
-    if (*it_client == RWLockImpl::Read && query_id != RWLockImpl::NO_QUERY)
+    if (it_group->type == RWLockImpl::Read && query_id != RWLockImpl::NO_QUERY)
         all_read_locks.remove(query_id);
 
-    /// Removes myself from client list of our group
-    it_group->clients.erase(it_client);
-
-    /// Remove the group if we were the last client and notify the next group
-    if (it_group->clients.empty())
+    /// Remove the group if we were the last referer and notify the next group
+    if (--it_group->referers == 0)
     {
         auto & parent_queue = parent->queue;
         parent_queue.erase(it_group);
@@ -235,10 +217,9 @@ RWLockImpl::LockHolderImpl::~LockHolderImpl()
 }
 
 
-RWLockImpl::LockHolderImpl::LockHolderImpl(RWLock && parent_, RWLockImpl::GroupsContainer::iterator it_group_,
-                                             RWLockImpl::ClientsContainer::iterator it_client_)
-    : parent{std::move(parent_)}, it_group{it_group_}, it_client{it_client_},
-      active_client_increment{(*it_client == RWLockImpl::Read) ? CurrentMetrics::RWLockActiveReaders
+RWLockImpl::LockHolderImpl::LockHolderImpl(RWLock && parent_, RWLockImpl::GroupsContainer::iterator it_group_)
+    : parent{std::move(parent_)}, it_group{it_group_},
+      active_client_increment{(it_group_->type == RWLockImpl::Read) ? CurrentMetrics::RWLockActiveReaders
                                                                : CurrentMetrics::RWLockActiveWriters}
 {
 }

--- a/dbms/src/Common/RWLock.cpp
+++ b/dbms/src/Common/RWLock.cpp
@@ -143,7 +143,7 @@ RWLockImpl::LockHolder RWLockImpl::getLock(RWLockImpl::Type type, const String &
     };
 
     /// This object is placed above unique_lock, because it may lock in destructor.
-    std::shared_ptr lock_holder(new LockHolderImpl(query_id, type));
+    auto lock_holder = std::make_shared<LockHolderImpl>(query_id, type);
 
     std::unique_lock lock(mutex);
 

--- a/dbms/src/Common/RWLock.cpp
+++ b/dbms/src/Common/RWLock.cpp
@@ -4,10 +4,6 @@
 #include <Common/CurrentMetrics.h>
 #include <Common/ProfileEvents.h>
 
-#include <cassert>
-#include <random>
-#include <pcg_random.hpp>
-
 
 namespace ProfileEvents
 {

--- a/dbms/src/Common/RWLock.cpp
+++ b/dbms/src/Common/RWLock.cpp
@@ -133,7 +133,6 @@ RWLockImpl::LockHolder RWLockImpl::getLock(RWLockImpl::Type type, const String &
                         ErrorCodes::LOGICAL_ERROR);
 
             res.reset(new LockHolderImpl(shared_from_this(), current_owner_group));
-            res.make_shared(shared_from_this(), current_owner_group);
             ++current_owner_group->referers;
 
             ++owner_queries[query_id];

--- a/dbms/src/Common/RWLock.h
+++ b/dbms/src/Common/RWLock.h
@@ -61,11 +61,11 @@ private:
     struct Group
     {
         const Type type;
-        size_t referers;
+        size_t refererrs;
 
         std::condition_variable cv; /// all locking requests of the group wait on this condvar
 
-        explicit Group(Type type_) : type{type_}, referers{0} {}
+        explicit Group(Type type_) : type{type_}, refererrs{0} {}
     };
 
     GroupsContainer queue;

--- a/dbms/src/Common/RWLock.h
+++ b/dbms/src/Common/RWLock.h
@@ -8,6 +8,7 @@
 #include <condition_variable>
 #include <map>
 #include <string>
+#include <unordered_map>
 
 
 namespace DB
@@ -53,7 +54,7 @@ private:
 
     struct Group;
     using GroupsContainer = std::list<Group>;
-    using QueryIdToHolder = std::map<String, std::weak_ptr<LockHolderImpl>>;
+    using OwnerQueryIds = std::unordered_map<String, size_t>;
 
     /// Group of locking requests that should be granted concurrently
     /// i.e. a group can contain several readers, but only one writer
@@ -67,9 +68,10 @@ private:
         explicit Group(Type type_) : type{type_}, referers{0} {}
     };
 
-    mutable std::mutex mutex;
     GroupsContainer queue;
-    QueryIdToHolder query_id_to_holder;
+    OwnerQueryIds owner_queries;
+
+    mutable std::mutex mutex;
 };
 
 

--- a/dbms/src/Common/RWLock.h
+++ b/dbms/src/Common/RWLock.h
@@ -53,20 +53,18 @@ private:
 
     struct Group;
     using GroupsContainer = std::list<Group>;
-    using ClientsContainer = std::list<Type>;
     using QueryIdToHolder = std::map<String, std::weak_ptr<LockHolderImpl>>;
 
-    /// Group of clients that should be executed concurrently
-    /// i.e. a group could contain several readers, but only one writer
+    /// Group of locking requests that should be granted concurrently
+    /// i.e. a group can contain several readers, but only one writer
     struct Group
     {
-        // FIXME: there is only redundant |type| information inside |clients|.
         const Type type;
-        ClientsContainer clients;
+        size_t referers;
 
-        std::condition_variable cv; /// all clients of the group wait group condvar
+        std::condition_variable cv; /// all locking requests of the group wait on this condvar
 
-        explicit Group(Type type_) : type{type_} {}
+        explicit Group(Type type_) : type{type_}, referers{0} {}
     };
 
     mutable std::mutex mutex;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

Short description (up to few sentences):
 - The most important change is removing weak_ptrs from implementation. As it is the primary source of glitches during destruction of `RWLockImpl::LockHolderImpl` objects.
 - Strong exception safety is a very important property for this key primitive: for our data to be safe RWLock's state must be preserved consistent at all times, especially during high memory pressure when `std::bad_alloc` is a common system's response