### PR TITLE
Add dependency ninja-build and cmake

### DIFF
--- a/docs/en/development/build.md
+++ b/docs/en/development/build.md
@@ -67,7 +67,7 @@ export CXX=g++-9
 ## Install Required Libraries from Packages
 
 ```bash
-sudo apt-get install libicu-dev libreadline-dev gperf
+sudo apt-get install libicu-dev libreadline-dev gperf cmake ninja-build
 ```
 
 ## Checkout ClickHouse Sources


### PR DESCRIPTION
If user has no ninja installed and does cmake
he/she will not have a build.ninja file generated.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement


Short description (up to few sentences):
If user has no ninja installed and does cmake
he/she will not have a build.ninja file generated.
Installing ninja at this point is to late and requires to rerun cmake.
...

Detailed description (optional):

...
