### PR TITLE
Trivial build fixes (mostly for -DSPLIT_SHARED_LIBRARIES=ON)

### DIFF
--- a/dbms/programs/copier/CMakeLists.txt
+++ b/dbms/programs/copier/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(CLICKHOUSE_COPIER_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/ClusterCopier.cpp)
-set(CLICKHOUSE_COPIER_LINK PRIVATE clickhouse_common_zookeeper clickhouse_parsers clickhouse_functions clickhouse_table_functions clickhouse_aggregate_functions clickhouse_dictionaries string_utils PUBLIC daemon)
+set(CLICKHOUSE_COPIER_LINK PRIVATE clickhouse_common_zookeeper clickhouse_parsers clickhouse_functions clickhouse_table_functions clickhouse_aggregate_functions clickhouse_dictionaries string_utils ${Poco_XML_LIBRARY} PUBLIC daemon)
 set(CLICKHOUSE_COPIER_INCLUDE SYSTEM PRIVATE ${PCG_RANDOM_INCLUDE_DIR})
 
 clickhouse_program_add(copier)

--- a/dbms/src/Common/tests/gtest_sensitive_data_masker.cpp
+++ b/dbms/src/Common/tests/gtest_sensitive_data_masker.cpp
@@ -11,6 +11,7 @@
 #endif
 
 #include <gtest/gtest.h>
+#include <chrono>
 
 
 namespace DB


### PR DESCRIPTION
(this is non-significant change, so description is empty)