### PR TITLE
Fix too early MySQL connection closure in MySQLBlockInputStreamream.cpp

### DIFF
--- a/dbms/src/Formats/MySQLBlockInputStream.cpp
+++ b/dbms/src/Formats/MySQLBlockInputStream.cpp
@@ -131,8 +131,6 @@ Block MySQLBlockInputStream::readImpl()
 
         row = result.fetch();
     }
-    if (auto_close)
-        entry.disconnect();
     return description.sample_block.cloneWithColumns(std::move(columns));
 }
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix: #6825  

Short description: 
Issue coming with #5395
MySQL connection is closed too early it induces a partial load of MySQL dictionaries.


Detailed description:
MySQL connection is closed at end of readImpl method even if there are still Block to come after the current one is full.
Removing connection closure at lines 133 & 134, fix the issue (locally reproduced and fixed).
Proposed fix still permits to have MySQL connection closed but only when the last row of remote table is read.
