### PR TITLE
Fix build error when cmake_minimum_required(3.12)

### DIFF
--- a/contrib/arrow-cmake/orc_check.cmake
+++ b/contrib/arrow-cmake/orc_check.cmake
@@ -124,3 +124,7 @@ CHECK_CXX_SOURCE_COMPILES("
     }"
   NEEDS_Z_PREFIX
 )
+
+# See https://cmake.org/cmake/help/v3.14/policy/CMP0075.html. Without unsetting it breaks thrift.
+set(CMAKE_REQUIRED_INCLUDES)
+set(CMAKE_REQUIRED_LIBRARIES)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

- Build/Testing/Packaging Improvement

