### PR TITLE
Display warning if clickhouse-client version is older than clickhouse-server.

### DIFF
--- a/dbms/programs/client/Client.cpp
+++ b/dbms/programs/client/Client.cpp
@@ -563,9 +563,15 @@ private:
         if (is_interactive)
         {
             std::cout << "Connected to " << server_name
-                      << " server version " << server_version
-                      << " revision " << server_revision
-                      << "." << std::endl << std::endl;
+                << " server version " << server_version
+                << " revision " << server_revision
+                << "." << std::endl << std::endl;
+
+            if (VERSION_STRING < server_version) {
+                std::cout << "ClickHouse client version is older than ClickHouse server. "
+                    << "It may lack support for new features."
+                    << std::endl << std::endl;
+            }
         }
     }
 

--- a/dbms/programs/client/Client.cpp
+++ b/dbms/programs/client/Client.cpp
@@ -567,7 +567,8 @@ private:
                 << " revision " << server_revision
                 << "." << std::endl << std::endl;
 
-            if (VERSION_STRING < server_version) {
+            if (VERSION_STRING < server_version)
+            {
                 std::cout << "ClickHouse client version is older than ClickHouse server. "
                     << "It may lack support for new features."
                     << std::endl << std::endl;

--- a/dbms/programs/client/Client.cpp
+++ b/dbms/programs/client/Client.cpp
@@ -567,9 +567,8 @@ private:
                 << " revision " << server_revision
                 << "." << std::endl << std::endl;
 
-            if (VERSION_MAJOR < server_version_major
-                || VERSION_MINOR < server_version_minor
-                || VERSION_PATCH < server_version_patch)
+            if (std::make_tuple(VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
+                < std::make_tuple(server_version_major, server_version_minor, server_version_patch))
             {
                 std::cout << "ClickHouse client version is older than ClickHouse server. "
                     << "It may lack support for new features."

--- a/dbms/programs/client/Client.cpp
+++ b/dbms/programs/client/Client.cpp
@@ -567,7 +567,9 @@ private:
                 << " revision " << server_revision
                 << "." << std::endl << std::endl;
 
-            if (VERSION_STRING < server_version)
+            if (VERSION_MAJOR < server_version_major
+                || VERSION_MINOR < server_version_minor
+                || VERSION_PATCH < server_version_patch)
             {
                 std::cout << "ClickHouse client version is older than ClickHouse server. "
                     << "It may lack support for new features."


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

Short description (up to few sentences):
Added a warning message when a client with an older version connects to a server.

Detailed description (optional):
Here is the examples when a client is behind the new version:
![Screenshot from 2019-09-10 21-48-49](https://user-images.githubusercontent.com/37879664/64644925-6c244580-d41c-11e9-8b7c-bf35b673e64c.png)

![Screenshot from 2019-09-11 01-15-17](https://user-images.githubusercontent.com/37879664/64655058-c2e94980-d433-11e9-9a16-42de58130c85.png)

Client and server are up-to-date (prints as before):
![Screenshot from 2019-09-10 22-52-45](https://user-images.githubusercontent.com/37879664/64645543-cb368a00-d41d-11e9-80fa-0efc5c4e3987.png)

#6665 