### PR TITLE
Put delimiter only after consuming a message

### DIFF
--- a/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
+++ b/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
@@ -150,8 +150,6 @@ bool ReadBufferFromKafkaConsumer::nextImpl()
         return true;
     }
 
-    put_delimiter = (delimiter != 0);
-
     if (current == messages.end())
     {
         if (intermediate_commit)
@@ -183,6 +181,7 @@ bool ReadBufferFromKafkaConsumer::nextImpl()
     // XXX: very fishy place with const casting.
     auto new_position = reinterpret_cast<char *>(const_cast<unsigned char *>(current->get_payload().get_data()));
     BufferBase::set(new_position, current->get_payload().get_size(), 0);
+    put_delimiter = (delimiter != 0);
 
     /// Since we can poll more messages than we already processed - commit only processed messages.
     consumer->store_offset(*current);

--- a/dbms/tests/integration/test_storage_kafka/test.py
+++ b/dbms/tests/integration/test_storage_kafka/test.py
@@ -249,6 +249,21 @@ def test_kafka_tsv_with_delimiter(kafka_cluster):
 
 
 @pytest.mark.timeout(180)
+def test_kafka_select_empty(kafka_cluster):
+    instance.query('''
+        CREATE TABLE test.kafka (key UInt64)
+            ENGINE = Kafka
+            SETTINGS kafka_broker_list = 'kafka1:19092',
+                     kafka_topic_list = 'empty',
+                     kafka_group_name = 'empty',
+                     kafka_format = 'TSV',
+                     kafka_row_delimiter = '\\n';
+        ''')
+
+    assert int(instance.query('SELECT count() FROM test.kafka')) == 0
+
+
+@pytest.mark.timeout(180)
 def test_kafka_json_without_delimiter(kafka_cluster):
     instance.query('''
         CREATE TABLE test.kafka (key UInt64, value UInt64)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fix logical error causing segfaults when selecting from Kafka empty topic (#6902)