### PR TITLE
all_of setting in performance-test now works properly

### DIFF
--- a/dbms/programs/performance-test/StopConditionsSet.cpp
+++ b/dbms/programs/performance-test/StopConditionsSet.cpp
@@ -31,7 +31,7 @@ void StopConditionsSet::loadFromConfig(const ConfigurationPtr & stop_conditions_
         else if (key == "average_speed_not_changing_for_ms")
             average_speed_not_changing_for_ms.value = stop_conditions_view->getUInt64(key);
         else
-            throw Exception("Met unkown stop condition: " + key, ErrorCodes::LOGICAL_ERROR);
+            throw Exception("Met unknown stop condition: " + key, ErrorCodes::LOGICAL_ERROR);
 
         ++initialized_count;
     }

--- a/dbms/programs/performance-test/StopConditionsSet.cpp
+++ b/dbms/programs/performance-test/StopConditionsSet.cpp
@@ -32,8 +32,9 @@ void StopConditionsSet::loadFromConfig(const ConfigurationPtr & stop_conditions_
             average_speed_not_changing_for_ms.value = stop_conditions_view->getUInt64(key);
         else
             throw Exception("Met unkown stop condition: " + key, ErrorCodes::LOGICAL_ERROR);
+
+        ++initialized_count;
     }
-    ++initialized_count;
 }
 
 void StopConditionsSet::reset()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Other

Short description (up to few sentences):
Performance test bug fix.
all_of setting used to work as any_of.
