### PR TITLE
Add custom dpkg to deb build image

### DIFF
--- a/docker/packager/deb/Dockerfile
+++ b/docker/packager/deb/Dockerfile
@@ -83,7 +83,7 @@ RUN apt-get --allow-unauthenticated update -y \
             pigz
 
 
-# Special dpkg-deb (https://github.com/alesapin/dpkg) version which is able
+# Special dpkg-deb (https://github.com/ClickHouse-Extras/dpkg) version which is able
 # to compress files using pigz (https://zlib.net/pigz/) instead of gzip.
 # Significantly increase deb packaging speed and compatible with old systems
 RUN curl -O https://clickhouse-builds.s3.yandex.net/utils/dpkg-deb

--- a/docker/packager/deb/Dockerfile
+++ b/docker/packager/deb/Dockerfile
@@ -79,8 +79,16 @@ RUN apt-get --allow-unauthenticated update -y \
             alien \
             libcapnp-dev \
             cmake \
-            gdb
+            gdb  \
+            pigz
 
+
+# Special dpkg-deb (https://github.com/alesapin/dpkg) version which is able
+# to compress files using pigz (https://zlib.net/pigz/) instead of gzip.
+# Significantly increase deb packaging speed and compatible with old systems
+RUN curl -O https://clickhouse-builds.s3.yandex.net/utils/dpkg-deb
+RUN chmod +x dpkg-deb
+RUN cp dpkg-deb /usr/bin
 
 COPY build.sh /
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Speed up deb packaging with patched dpkg-deb which uses `pigz`.
