### PR TITLE
[RFC] Introduce create_as_skip_indices

### DIFF
--- a/dbms/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterCreateQuery.cpp
@@ -2,6 +2,7 @@
 
 #include <Poco/File.h>
 
+#include <Common/StringUtils/StringUtils.h>
 #include <Common/escapeForFileName.h>
 #include <Common/typeid_cast.h>
 
@@ -416,7 +417,8 @@ ColumnsDescription InterpreterCreateQuery::setProperties(
     else if (!create.as_table.empty())
     {
         columns = as_storage->getColumns();
-        indices = as_storage->getIndices();
+        if (create.storage && endsWith(create.storage->engine->name, "MergeTree"))
+            indices = as_storage->getIndices();
         constraints = as_storage->getConstraints();
     }
     else if (create.select)

--- a/dbms/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterCreateQuery.cpp
@@ -417,8 +417,12 @@ ColumnsDescription InterpreterCreateQuery::setProperties(
     else if (!create.as_table.empty())
     {
         columns = as_storage->getColumns();
+
+        /// Secondary indices make sense only for MergeTree family of storage engines.
+        /// We should not copy them for other storages.
         if (create.storage && endsWith(create.storage->engine->name, "MergeTree"))
             indices = as_storage->getIndices();
+
         constraints = as_storage->getConstraints();
     }
     else if (create.select)

--- a/dbms/tests/queries/0_stateless/01011_test_create_as_skip_indices.sql
+++ b/dbms/tests/queries/0_stateless/01011_test_create_as_skip_indices.sql
@@ -1,0 +1,5 @@
+SET allow_experimental_data_skipping_indices=1;
+CREATE TABLE foo (key int, INDEX i1 key TYPE minmax GRANULARITY 1) Engine=MergeTree() ORDER BY key;
+CREATE TABLE as_foo AS foo;
+CREATE TABLE dist (key int, INDEX i1 key TYPE minmax GRANULARITY 1) Engine=Distributed(test_shard_localhost, currentDatabase(), 'foo'); -- { serverError 36 }
+CREATE TABLE dist_as_foo Engine=Distributed(test_shard_localhost, currentDatabase(), 'foo') AS foo;


### PR DESCRIPTION
Category (leave one):
- New Feature

Short description (up to few sentences):

Useful to create Distributed/Buffer table using CREATE TABLE ... AS ...
for MergeTree family tables.