### PR TITLE
Add ability to send events with absolute values to graphite

### DIFF
--- a/dbms/programs/server/MetricsTransmitter.cpp
+++ b/dbms/programs/server/MetricsTransmitter.cpp
@@ -21,6 +21,7 @@ MetricsTransmitter::MetricsTransmitter(
 {
     interval_seconds = config.getInt(config_name + ".interval", 60);
     send_events = config.getBool(config_name + ".events", true);
+    send_events_absolute = config.getBool(config_name + ".events_absolute", false);
     send_metrics = config.getBool(config_name + ".metrics", true);
     send_asynchronous_metrics = config.getBool(config_name + ".asynchronous_metrics", true);
 }
@@ -92,6 +93,16 @@ void MetricsTransmitter::transmit(std::vector<ProfileEvents::Count> & prev_count
 
             std::string key{ProfileEvents::getName(static_cast<ProfileEvents::Event>(i))};
             key_vals.emplace_back(profile_events_path_prefix + key, counter_increment);
+        }
+    }
+
+    if (send_events_absolute)
+    {
+        for (size_t i = 0, end = ProfileEvents::end(); i < end; ++i)
+        {
+            const auto counter = ProfileEvents::global_counters[i].load(std::memory_order_relaxed);
+            std::string key{ProfileEvents::getName(static_cast<ProfileEvents::Event>(i))};
+            key_vals.emplace_back(profile_events_absolute_path_prefix + key, counter);
         }
     }
 

--- a/dbms/programs/server/MetricsTransmitter.h
+++ b/dbms/programs/server/MetricsTransmitter.h
@@ -24,7 +24,8 @@ class AsynchronousMetrics;
 
 
 /** Automatically sends
-  * - difference of ProfileEvents;
+  * - values deltas of ProfileEvents;
+  * - absolute values of ProfileEvents;
   * - values of CurrentMetrics;
   * - values of AsynchronousMetrics;
   *  to Graphite at beginning of every minute.
@@ -44,6 +45,7 @@ private:
     std::string config_name;
     UInt32 interval_seconds;
     bool send_events;
+    bool send_events_absolute;
     bool send_metrics;
     bool send_asynchronous_metrics;
 
@@ -53,6 +55,7 @@ private:
     ThreadFromGlobalPool thread{&MetricsTransmitter::run, this};
 
     static inline constexpr auto profile_events_path_prefix = "ClickHouse.ProfileEvents.";
+    static inline constexpr auto profile_events_absolute_path_prefix = "ClickHouse.ProfileEventsAbsolute.";
     static inline constexpr auto current_metrics_path_prefix = "ClickHouse.Metrics.";
     static inline constexpr auto asynchronous_metrics_path_prefix = "ClickHouse.AsynchronousMetrics.";
 };

--- a/dbms/programs/server/config.xml
+++ b/dbms/programs/server/config.xml
@@ -258,6 +258,7 @@
 
         <metrics>true</metrics>
         <events>true</events>
+        <events_absolute>false</events_absolute>
         <asynchronous_metrics>true</asynchronous_metrics>
     </graphite>
     <graphite>
@@ -269,6 +270,7 @@
 
         <metrics>true</metrics>
         <events>true</events>
+        <events_absolute>false</events_absolute>
         <asynchronous_metrics>false</asynchronous_metrics>
     </graphite>
     -->

--- a/docs/en/operations/server_settings/settings.md
+++ b/docs/en/operations/server_settings/settings.md
@@ -141,7 +141,8 @@ Settings:
 - timeout – The timeout for sending data, in seconds.
 - root_path – Prefix for keys.
 - metrics – Sending data from a :ref:`system_tables-system.metrics` table.
-- events – Sending data from a :ref:`system_tables-system.events` table.
+- events – Sending deltas data from a :ref:`system_tables-system.events` table
+- events_absolute – Sending absolute data from a :ref:`system_tables-system.events` table
 - asynchronous_metrics – Sending data from a :ref:`system_tables-system.asynchronous_metrics` table.
 
 You can configure multiple `<graphite>` clauses. For instance, you can use this for sending different data at different intervals.
@@ -157,6 +158,7 @@ You can configure multiple `<graphite>` clauses. For instance, you can use this 
     <root_path>one_min</root_path>
     <metrics>true</metrics>
     <events>true</events>
+    <events_absolute>false</events_absolute>
     <asynchronous_metrics>true</asynchronous_metrics>
 </graphite>
 ```

--- a/docs/ru/operations/server_settings/settings.md
+++ b/docs/ru/operations/server_settings/settings.md
@@ -140,7 +140,8 @@ ClickHouse проверит условия `min_part_size` и `min_part_size_rat
 - timeout - Таймаут отправки данных в секундах.
 - root_path - Префикс для ключей.
 - metrics - Отправка данных из таблицы :ref:`system_tables-system.metrics`.
-- events - Отправка данных из таблицы :ref:`system_tables-system.events`.
+- events - Отправка дельты данных из таблицы :ref:`system_tables-system.events`
+- events_absolute - Отправка абсолютных данных из таблицы :ref:`system_tables-system.events`
 - asynchronous_metrics - Отправка данных из таблицы :ref:`system_tables-system.asynchronous_metrics`.
 
 Можно определить несколько секций `<graphite>`, например, для передачи различных данных с различной частотой.
@@ -156,6 +157,7 @@ ClickHouse проверит условия `min_part_size` и `min_part_size_rat
     <root_path>one_min</root_path>
     <metrics>true</metrics>
     <events>true</events>
+    <events_absolute>false</events_absolute>
     <asynchronous_metrics>true</asynchronous_metrics>
 </graphite>
 ```


### PR DESCRIPTION
Category (leave one):
- Improvement

Short description (up to few sentences):

Add ability to send profile events (counters) with cumulative values to graphite. It can be enabled under `<events_cumulative>` in server `config.xml`.

Detailed description (optional):

Before this patch only delta values for events was sent, while this is not convenient for calculating rates. So after this patch <events_cumulative> is introduced.