### PR TITLE
Use MAP_POPULATE only on Linux.

### DIFF
--- a/dbms/src/Common/Allocator.h
+++ b/dbms/src/Common/Allocator.h
@@ -178,8 +178,13 @@ protected:
     // hash tables, it makes sense to pre-fault the pages by passing
     // MAP_POPULATE to mmap(). This takes some time, but should be faster
     // overall than having a hot loop interrupted by page faults.
+    // It is only supported on Linux.
+#if defined(__linux__)
     static constexpr int mmap_flags = MAP_PRIVATE | MAP_ANONYMOUS
             | (mmap_populate ? MAP_POPULATE : 0);
+#else
+    static constexpr int mmap_flags = MAP_PRIVATE | MAP_ANONYMOUS;
+#endif
 
 private:
     void * allocNoTrack(size_t size, size_t alignment)


### PR DESCRIPTION
Fixes #6959

Category (leave one):
- Build/Testing/Packaging Improvement