### PR TITLE
Docs(hash_functions): fix `xxHash32`, `xxHash64`

### DIFF
--- a/docs/en/query_language/functions/hash_functions.md
+++ b/docs/en/query_language/functions/hash_functions.md
@@ -307,14 +307,14 @@ SELECT murmurHash3_128('example_string') AS MurmurHash3, toTypeName(MurmurHash3)
 
 ## xxHash32, xxHash64 {#hash_functions-xxhash32}
 
-Calculates `xxHash` from a string. It is proposed in two flavors, 32 and 64 bits.
+Calculates `xxHash` from a string. It is proposed in two flavors, 32 and 64 bits. The current version of ClickHouse uses `xxHash` version 0.6.5.
 
 ```sql
-SELECT xxHash32();
+SELECT xxHash32('');
 
 OR
 
-SELECT xxHash64();
+SELECT xxHash64('');
 ```
 
 **Returned value**

--- a/docs/en/query_language/functions/hash_functions.md
+++ b/docs/en/query_language/functions/hash_functions.md
@@ -310,11 +310,11 @@ SELECT murmurHash3_128('example_string') AS MurmurHash3, toTypeName(MurmurHash3)
 Calculates `xxHash` from a string. It is proposed in two flavors, 32 and 64 bits.
 
 ```sql
-SELECT xxHash32('srting');
+SELECT xxHash32();
 
 OR
 
-SELECT  xxHash64('srting');
+SELECT xxHash64();
 ```
 
 **Returned value**

--- a/docs/en/query_language/functions/hash_functions.md
+++ b/docs/en/query_language/functions/hash_functions.md
@@ -307,7 +307,7 @@ SELECT murmurHash3_128('example_string') AS MurmurHash3, toTypeName(MurmurHash3)
 
 ## xxHash32, xxHash64 {#hash_functions-xxhash32}
 
-Calculates `xxHash` from a string. It is proposed in two flavors, 32 and 64 bits. The current version of ClickHouse uses `xxHash` version 0.6.5.
+Calculates `xxHash` from a string. It is proposed in two flavors, 32 and 64 bits.
 
 ```sql
 SELECT xxHash32('');

--- a/docs/en/query_language/functions/hash_functions.md
+++ b/docs/en/query_language/functions/hash_functions.md
@@ -305,10 +305,42 @@ SELECT murmurHash3_128('example_string') AS MurmurHash3, toTypeName(MurmurHash3)
 └──────────────────┴─────────────────┘
 ```
 
-## xxHash32, xxHash64
+## xxHash32, xxHash64 {#hash_functions-xxhash32}
 
-Calculates xxHash from a string.
-Accepts a String-type argument. Returns UInt64 Or UInt32.
-For more information, see the link: [xxHash](http://cyan4973.github.io/xxHash/)
+Calculates `xxHash` from a string. It is proposed in two flavors, 32 and 64 bits.
+
+```sql
+SELECT xxHash32('srting');
+
+OR
+
+SELECT  xxHash64('srting');
+```
+
+**Returned value**
+
+A `Uint32` or `Uint64` data type hash value.
+
+Type: `xxHash`.
+
+**Example**
+
+Query:
+
+```sql
+SELECT xxHash32('Hello, world!');
+```
+
+Result:
+
+```text
+┌─xxHash32('Hello, world!')─┐
+│                 834093149 │
+└───────────────────────────┘
+```
+
+**See Also**
+
+- [xxHash](http://cyan4973.github.io/xxHash/).
 
 [Original article](https://clickhouse.yandex/docs/en/query_language/functions/hash_functions/) <!--hide-->

--- a/docs/ru/query_language/functions/hash_functions.md
+++ b/docs/ru/query_language/functions/hash_functions.md
@@ -310,10 +310,42 @@ SELECT murmurHash3_128('example_string') AS MurmurHash3, toTypeName(MurmurHash3)
 └──────────────────┴─────────────────┘
 ```
 
-## xxHash32, xxHash64
+## xxHash32, xxHash64 {#hash_functions-xxhash32-xxhash64}
 
-Вычисляет xxHash от строки.
-Принимает аргумент типа String. Возвращает значение типа Uint64 или Uint32.
-Дополнительные сведения см. по ссылке: [xxHash](http://cyan4973.github.io/xxHash/)
+Вычисляет `xxHash` от строки. Предлагается в двух вариантах: 32 и 64 бита.
+
+```sql
+SELECT xxHash32('srting');
+
+OR
+
+SELECT  xxHash64('srting');
+```
+
+**Возвращаемое значение**
+
+Хэш-значение типа `Uint32` или `Uint64`.
+
+Тип: `xxHash`.
+
+**Пример**
+
+Запрос:
+
+```sql
+SELECT xxHash32('Hello, world!');
+```
+
+Ответ:
+
+```text
+┌─xxHash32('Hello, world!')─┐
+│                 834093149 │
+└───────────────────────────┘
+```
+
+**Смотрите также**
+
+- [xxHash](http://cyan4973.github.io/xxHash/).
 
 [Оригинальная статья](https://clickhouse.yandex/docs/ru/query_language/functions/hash_functions/) <!--hide-->

--- a/docs/ru/query_language/functions/hash_functions.md
+++ b/docs/ru/query_language/functions/hash_functions.md
@@ -312,7 +312,7 @@ SELECT murmurHash3_128('example_string') AS MurmurHash3, toTypeName(MurmurHash3)
 
 ## xxHash32, xxHash64 {#hash_functions-xxhash32-xxhash64}
 
-Вычисляет `xxHash` от строки. Предлагается в двух вариантах: 32 и 64 бита. Текущая версия ClicHouse использует `xxHash` версии 0.6.5.
+Вычисляет `xxHash` от строки. Предлагается в двух вариантах: 32 и 64 бита.
 
 ```sql
 SELECT xxHash32('');

--- a/docs/ru/query_language/functions/hash_functions.md
+++ b/docs/ru/query_language/functions/hash_functions.md
@@ -315,11 +315,11 @@ SELECT murmurHash3_128('example_string') AS MurmurHash3, toTypeName(MurmurHash3)
 Вычисляет `xxHash` от строки. Предлагается в двух вариантах: 32 и 64 бита.
 
 ```sql
-SELECT xxHash32('srting');
+SELECT xxHash32();
 
 OR
 
-SELECT  xxHash64('srting');
+SELECT xxHash64();
 ```
 
 **Возвращаемое значение**

--- a/docs/ru/query_language/functions/hash_functions.md
+++ b/docs/ru/query_language/functions/hash_functions.md
@@ -312,14 +312,14 @@ SELECT murmurHash3_128('example_string') AS MurmurHash3, toTypeName(MurmurHash3)
 
 ## xxHash32, xxHash64 {#hash_functions-xxhash32-xxhash64}
 
-Вычисляет `xxHash` от строки. Предлагается в двух вариантах: 32 и 64 бита.
+Вычисляет `xxHash` от строки. Предлагается в двух вариантах: 32 и 64 бита. Текущая версия ClicHouse использует `xxHash` версии 0.6.5.
 
 ```sql
-SELECT xxHash32();
+SELECT xxHash32('');
 
 OR
 
-SELECT xxHash64();
+SELECT xxHash64('');
 ```
 
 **Возвращаемое значение**


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):

- Documentation

Fix `xxHash32`, `xxHash64` functions descriptions.
