### PR TITLE
Outline methods to get needed instantiations.

### DIFF
--- a/dbms/src/DataTypes/DataTypeLowCardinality.cpp
+++ b/dbms/src/DataTypes/DataTypeLowCardinality.cpp
@@ -742,6 +742,74 @@ void DataTypeLowCardinality::deserializeBinary(Field & field, ReadBuffer & istr)
     dictionary_type->deserializeBinary(field, istr);
 }
 
+void DataTypeLowCardinality::serializeBinary(const IColumn & column, size_t row_num, WriteBuffer & ostr) const
+{
+    serializeImpl(column, row_num, &IDataType::serializeBinary, ostr);
+}
+void DataTypeLowCardinality::deserializeBinary(IColumn & column, ReadBuffer & istr) const
+{
+    deserializeImpl(column, &IDataType::deserializeBinary, istr);
+}
+
+void DataTypeLowCardinality::serializeTextEscaped(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
+{
+    serializeImpl(column, row_num, &IDataType::serializeAsTextEscaped, ostr, settings);
+}
+
+void DataTypeLowCardinality::deserializeTextEscaped(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const
+{
+    deserializeImpl(column, &IDataType::deserializeAsTextEscaped, istr, settings);
+}
+
+void DataTypeLowCardinality::serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
+{
+    serializeImpl(column, row_num, &IDataType::serializeAsTextQuoted, ostr, settings);
+}
+
+void DataTypeLowCardinality::deserializeTextQuoted(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const
+{
+    deserializeImpl(column, &IDataType::deserializeAsTextQuoted, istr, settings);
+}
+
+void DataTypeLowCardinality::deserializeWholeText(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const
+{
+    deserializeImpl(column, &IDataType::deserializeAsTextEscaped, istr, settings);
+}
+
+void DataTypeLowCardinality::serializeTextCSV(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
+{
+    serializeImpl(column, row_num, &IDataType::serializeAsTextCSV, ostr, settings);
+}
+
+void DataTypeLowCardinality::deserializeTextCSV(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const
+{
+    deserializeImpl(column, &IDataType::deserializeAsTextCSV, istr, settings);
+}
+
+void DataTypeLowCardinality::serializeText(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
+{
+    serializeImpl(column, row_num, &IDataType::serializeAsText, ostr, settings);
+}
+
+void DataTypeLowCardinality::serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
+{
+    serializeImpl(column, row_num, &IDataType::serializeAsTextJSON, ostr, settings);
+}
+void DataTypeLowCardinality::deserializeTextJSON(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const
+{
+    deserializeImpl(column, &IDataType::deserializeAsTextJSON, istr, settings);
+}
+
+void DataTypeLowCardinality::serializeTextXML(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
+{
+    serializeImpl(column, row_num, &IDataType::serializeAsTextXML, ostr, settings);
+}
+
+void DataTypeLowCardinality::serializeProtobuf(const IColumn & column, size_t row_num, ProtobufWriter & protobuf, size_t & value_index) const
+{
+    serializeImpl(column, row_num, &IDataType::serializeProtobuf, protobuf, value_index);
+}
+
 void DataTypeLowCardinality::deserializeProtobuf(IColumn & column, ProtobufReader & protobuf, bool allow_add_row, bool & row_added) const
 {
     if (allow_add_row)

--- a/dbms/src/DataTypes/DataTypeLowCardinality.h
+++ b/dbms/src/DataTypes/DataTypeLowCardinality.h
@@ -51,75 +51,20 @@ public:
 
     void serializeBinary(const Field & field, WriteBuffer & ostr) const override;
     void deserializeBinary(Field & field, ReadBuffer & istr) const override;
-
-    void serializeBinary(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override
-    {
-        serializeImpl(column, row_num, &IDataType::serializeBinary, ostr);
-    }
-    void deserializeBinary(IColumn & column, ReadBuffer & istr) const override
-    {
-        deserializeImpl(column, &IDataType::deserializeBinary, istr);
-    }
-
-    void serializeTextEscaped(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const override
-    {
-        serializeImpl(column, row_num, &IDataType::serializeAsTextEscaped, ostr, settings);
-    }
-
-    void deserializeTextEscaped(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const override
-    {
-        deserializeImpl(column, &IDataType::deserializeAsTextEscaped, istr, settings);
-    }
-
-    void serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const override
-    {
-        serializeImpl(column, row_num, &IDataType::serializeAsTextQuoted, ostr, settings);
-    }
-
-    void deserializeTextQuoted(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const override
-    {
-        deserializeImpl(column, &IDataType::deserializeAsTextQuoted, istr, settings);
-    }
-
-    void deserializeWholeText(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const override
-    {
-        deserializeImpl(column, &IDataType::deserializeAsTextEscaped, istr, settings);
-    }
-
-    void serializeTextCSV(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const override
-    {
-        serializeImpl(column, row_num, &IDataType::serializeAsTextCSV, ostr, settings);
-    }
-
-    void deserializeTextCSV(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const override
-    {
-        deserializeImpl(column, &IDataType::deserializeAsTextCSV, istr, settings);
-    }
-
-    void serializeText(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const override
-    {
-        serializeImpl(column, row_num, &IDataType::serializeAsText, ostr, settings);
-    }
-
-    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const override
-    {
-        serializeImpl(column, row_num, &IDataType::serializeAsTextJSON, ostr, settings);
-    }
-    void deserializeTextJSON(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const override
-    {
-        deserializeImpl(column, &IDataType::deserializeAsTextJSON, istr, settings);
-    }
-
-    void serializeTextXML(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const override
-    {
-        serializeImpl(column, row_num, &IDataType::serializeAsTextXML, ostr, settings);
-    }
-
-    void serializeProtobuf(const IColumn & column, size_t row_num, ProtobufWriter & protobuf, size_t & value_index) const override
-    {
-        serializeImpl(column, row_num, &IDataType::serializeProtobuf, protobuf, value_index);
-    }
-
+    void serializeBinary(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;
+    void deserializeBinary(IColumn & column, ReadBuffer & istr) const override;
+    void serializeTextEscaped(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const override;
+    void deserializeTextEscaped(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const override;
+    void serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const override;
+    void deserializeTextQuoted(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const override;
+    void deserializeWholeText(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const override;
+    void serializeTextCSV(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const override;
+    void deserializeTextCSV(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const override;
+    void serializeText(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const override;
+    void serializeTextJSON(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const override;
+    void deserializeTextJSON(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const override;
+    void serializeTextXML(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const override;
+    void serializeProtobuf(const IColumn & column, size_t row_num, ProtobufWriter & protobuf, size_t & value_index) const override;
     void deserializeProtobuf(IColumn & column, ProtobufReader & protobuf, bool allow_add_row, bool & row_added) const override;
 
     MutableColumnPtr createColumn() const override;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):

- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Move some `IDataType` serialization methods for `LowCardinality` to `.cpp` file. Those methods had undefined symbols. It worked because there is no call site to those methods yet.
