### PR TITLE
 Do not use iterators in find() and emplace() methods of hash tables.

### DIFF
--- a/dbms/programs/obfuscator/Obfuscator.cpp
+++ b/dbms/programs/obfuscator/Obfuscator.cpp
@@ -670,13 +670,13 @@ public:
 
         while (pos < end)
         {
-            Table::iterator it = table.end();
+            Table::LookupResult it;
 
             size_t context_size = params.order;
             while (true)
             {
                 it = table.find(hashContext(code_points.data() + code_points.size() - context_size, code_points.data() + code_points.size()));
-                if (table.end() != it && it->getSecond().total + it->getSecond().count_end != 0)
+                if (it && lookupResultGetMapped(it)->total + lookupResultGetMapped(it)->count_end != 0)
                     break;
 
                 if (context_size == 0)
@@ -684,7 +684,7 @@ public:
                 --context_size;
             }
 
-            if (table.end() == it)
+            if (!it)
                 throw Exception("Logical error in markov model", ErrorCodes::LOGICAL_ERROR);
 
             size_t offset_from_begin_of_string = pos - data;
@@ -710,7 +710,7 @@ public:
             if (num_bytes_after_desired_size > 0)
                 end_probability_multiplier = std::pow(1.25, num_bytes_after_desired_size);
 
-            CodePoint code = it->getSecond().sample(determinator, end_probability_multiplier);
+            CodePoint code = lookupResultGetMapped(it)->sample(determinator, end_probability_multiplier);
 
             if (code == END)
                 break;

--- a/dbms/src/AggregateFunctions/AggregateFunctionGroupUniqArray.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionGroupUniqArray.h
@@ -218,7 +218,7 @@ public:
             return;
 
         bool inserted;
-        State::Set::iterator it;
+        State::Set::LookupResult it;
         auto key_holder = getKeyHolder(*columns[0], row_num, *arena);
         set.emplace(key_holder, it, inserted);
     }
@@ -229,7 +229,7 @@ public:
         auto & rhs_set = this->data(rhs).value;
 
         bool inserted;
-        State::Set::iterator it;
+        State::Set::LookupResult it;
         for (auto & rhs_elem : rhs_set)
         {
             if (limit_num_elems && cur_set.size() >= max_elems)

--- a/dbms/src/Columns/ReverseIndex.h
+++ b/dbms/src/Columns/ReverseIndex.h
@@ -151,6 +151,7 @@ namespace
     public:
         using Base::Base;
         using iterator = typename Base::iterator;
+        using LookupResult = typename Base::LookupResult;
         State & getState() { return *this; }
 
 
@@ -168,7 +169,7 @@ namespace
         }
 
         template <typename ObjectToCompareWith>
-        void ALWAYS_INLINE reverseIndexEmplaceNonZero(const Key & key, iterator & it,
+        void ALWAYS_INLINE reverseIndexEmplaceNonZero(const Key & key, LookupResult & it,
             bool & inserted, size_t hash_value, const ObjectToCompareWith & object)
         {
             size_t place_value = reverseIndexFindCell(object, hash_value,
@@ -184,10 +185,14 @@ namespace
         void ALWAYS_INLINE reverseIndexEmplace(Key key, iterator & it, bool & inserted,
             size_t hash_value, const ObjectToCompareWith& object)
         {
-            if (!this->emplaceIfZero(key, it, inserted, hash_value))
+            LookupResult impl_it = nullptr;
+
+            if (!this->emplaceIfZero(key, impl_it, inserted, hash_value))
             {
-                reverseIndexEmplaceNonZero(key, it, inserted, hash_value, object);
+                reverseIndexEmplaceNonZero(key, impl_it, inserted, hash_value, object);
             }
+            assert(impl_it != nullptr);
+            it = iterator(this, impl_it);
         }
 
         template <typename ObjectToCompareWith>

--- a/dbms/src/Common/ColumnsHashing.h
+++ b/dbms/src/Common/ColumnsHashing.h
@@ -349,7 +349,7 @@ struct HashMethodSingleLowCardinalityColumn : public SingleColumnMethod
         auto key_holder = getKeyHolder(row_, pool);
 
         bool inserted = false;
-        typename Data::iterator it;
+        typename Data::LookupResult it;
         if (saved_hash)
             data.emplace(key_holder, it, inserted, saved_hash[row]);
         else
@@ -359,12 +359,13 @@ struct HashMethodSingleLowCardinalityColumn : public SingleColumnMethod
 
         if constexpr (has_mapped)
         {
+            auto & mapped = *lookupResultGetMapped(it);
             if (inserted)
             {
-                new (&it->getSecond()) Mapped();
+                new (&mapped) Mapped();
             }
-            mapped_cache[row] = it->getSecond();
-            return EmplaceResult(it->getSecond(), mapped_cache[row], inserted);
+            mapped_cache[row] = mapped;
+            return EmplaceResult(mapped, mapped_cache[row], inserted);
         }
         else
             return EmplaceResult(inserted);

--- a/dbms/src/Common/ColumnsHashingImpl.h
+++ b/dbms/src/Common/ColumnsHashingImpl.h
@@ -168,34 +168,41 @@ protected:
             }
         }
 
-        typename Data::iterator it;
+        typename Data::LookupResult it;
         bool inserted = false;
         data.emplace(key_holder, it, inserted);
 
         [[maybe_unused]] Mapped * cached = nullptr;
         if constexpr (has_mapped)
-            cached = &it->getSecond();
+            cached = lookupResultGetMapped(it);
 
         if (inserted)
         {
             if constexpr (has_mapped)
             {
-                new(&it->getSecond()) Mapped();
+                new(lookupResultGetMapped(it)) Mapped();
             }
         }
 
         if constexpr (consecutive_keys_optimization)
         {
-            cache.value = it->getValue();
             cache.found = true;
             cache.empty = false;
 
             if constexpr (has_mapped)
+            {
+                cache.value.first = *lookupResultGetKey(it);
+                cache.value.second = *lookupResultGetMapped(it);
                 cached = &cache.value.second;
+            }
+            else
+            {
+                cache.value = *lookupResultGetKey(it);
+            }
         }
 
         if constexpr (has_mapped)
-            return EmplaceResult(it->getSecond(), *cached, inserted);
+            return EmplaceResult(*lookupResultGetMapped(it), *cached, inserted);
         else
             return EmplaceResult(inserted);
     }
@@ -215,28 +222,30 @@ protected:
         }
 
         auto it = data.find(key);
-        bool found = it != data.end();
 
         if constexpr (consecutive_keys_optimization)
         {
-            cache.found = found;
+            cache.found = it != nullptr;
             cache.empty = false;
 
-            if (found)
-                cache.value = it->getValue();
+            if constexpr (has_mapped)
+            {
+                cache.value.first = key;
+                if (it)
+                {
+                    cache.value.second = *lookupResultGetMapped(it);
+                }
+            }
             else
             {
-                if constexpr (has_mapped)
-                    cache.value.first = key;
-                else
-                    cache.value = key;
+                cache.value = key;
             }
         }
 
         if constexpr (has_mapped)
-            return FindResult(found ? &it->getSecond() : nullptr, found);
+            return FindResult(it ? lookupResultGetMapped(it) : nullptr, it != nullptr);
         else
-            return FindResult(found);
+            return FindResult(it != nullptr);
     }
 };
 

--- a/dbms/src/Common/HashTable/ClearableHashMap.h
+++ b/dbms/src/Common/HashTable/ClearableHashMap.h
@@ -14,6 +14,11 @@ struct ClearableHashMapCell : public ClearableHashTableCell<Key, HashMapCell<Key
         : Base::BaseCell(value_, state), Base::version(state.version) {}
 };
 
+template<typename Key, typename Mapped, typename Hash>
+auto lookupResultGetKey(ClearableHashMapCell<Key, Mapped, Hash> * cell) { return &cell->getFirst(); }
+
+template<typename Key, typename Mapped, typename Hash>
+auto lookupResultGetMapped(ClearableHashMapCell<Key, Mapped, Hash> * cell) { return &cell->getSecond(); }
 
 template
 <
@@ -32,14 +37,14 @@ public:
 
     mapped_type & operator[](Key x)
     {
-        typename ClearableHashMap::iterator it;
+        typename ClearableHashMap::LookupResult it;
         bool inserted;
         this->emplace(x, it, inserted);
 
         if (inserted)
-            new(&it->getSecond()) mapped_type();
+            new(lookupResultGetMapped(it)) mapped_type();
 
-        return it->getSecond();
+        return *lookupResultGetMapped(it);
     }
 
     void clear()

--- a/dbms/src/Common/HashTable/ClearableHashMap.h
+++ b/dbms/src/Common/HashTable/ClearableHashMap.h
@@ -15,10 +15,10 @@ struct ClearableHashMapCell : public ClearableHashTableCell<Key, HashMapCell<Key
 };
 
 template<typename Key, typename Mapped, typename Hash>
-auto lookupResultGetKey(ClearableHashMapCell<Key, Mapped, Hash> * cell) { return &cell->getFirst(); }
+ALWAYS_INLINE inline auto lookupResultGetKey(ClearableHashMapCell<Key, Mapped, Hash> * cell) { return &cell->getFirst(); }
 
 template<typename Key, typename Mapped, typename Hash>
-auto lookupResultGetMapped(ClearableHashMapCell<Key, Mapped, Hash> * cell) { return &cell->getSecond(); }
+ALWAYS_INLINE inline auto lookupResultGetMapped(ClearableHashMapCell<Key, Mapped, Hash> * cell) { return &cell->getSecond(); }
 
 template
 <

--- a/dbms/src/Common/HashTable/ClearableHashSet.h
+++ b/dbms/src/Common/HashTable/ClearableHashSet.h
@@ -49,10 +49,10 @@ struct ClearableHashTableCell : public BaseCell
 };
 
 template<typename Key, typename BaseCell>
-auto lookupResultGetKey(ClearableHashTableCell<Key, BaseCell> * cell) { return &cell->key; }
+ALWAYS_INLINE inline auto lookupResultGetKey(ClearableHashTableCell<Key, BaseCell> * cell) { return &cell->key; }
 
 template<typename Key, typename BaseCell>
-void * lookupResultGetMapped(ClearableHashTableCell<Key, BaseCell> *) { return nullptr; }
+ALWAYS_INLINE inline void * lookupResultGetMapped(ClearableHashTableCell<Key, BaseCell> *) { return nullptr; }
 
 template
 <

--- a/dbms/src/Common/HashTable/ClearableHashSet.h
+++ b/dbms/src/Common/HashTable/ClearableHashSet.h
@@ -48,6 +48,11 @@ struct ClearableHashTableCell : public BaseCell
     ClearableHashTableCell(const Key & key_, const State & state) : BaseCell(key_, state), version(state.version) {}
 };
 
+template<typename Key, typename BaseCell>
+auto lookupResultGetKey(ClearableHashTableCell<Key, BaseCell> * cell) { return &cell->key; }
+
+template<typename Key, typename BaseCell>
+void * lookupResultGetMapped(ClearableHashTableCell<Key, BaseCell> *) { return nullptr; }
 
 template
 <
@@ -61,6 +66,9 @@ class ClearableHashSet : public HashTable<Key, ClearableHashTableCell<Key, HashT
 public:
     using key_type = Key;
     using value_type = typename ClearableHashSet::cell_type::value_type;
+
+    using Base = HashTable<Key, ClearableHashTableCell<Key, HashTableCell<Key, Hash, ClearableHashSetState>>, Hash, Grower, Allocator>;
+    using typename Base::LookupResult;
 
     void clear()
     {

--- a/dbms/src/Common/HashTable/FixedClearableHashMap.h
+++ b/dbms/src/Common/HashTable/FixedClearableHashMap.h
@@ -23,7 +23,6 @@ struct FixedClearableHashMapCell
     bool isZero(const State & state) const { return version != state.version; }
     void setZero() { version = 0; }
     static constexpr bool need_zero_value_storage = false;
-    void setMapped(const value_type & value) { mapped = value.getSecond(); }
 
     struct CellExt
     {

--- a/dbms/src/Common/HashTable/FixedClearableHashSet.h
+++ b/dbms/src/Common/HashTable/FixedClearableHashSet.h
@@ -10,6 +10,7 @@ struct FixedClearableHashTableCell
     using State = ClearableHashSetState;
 
     using value_type = Key;
+    using mapped_type = void;
     UInt32 version;
 
     FixedClearableHashTableCell() {}
@@ -18,7 +19,6 @@ struct FixedClearableHashTableCell
     bool isZero(const State & state) const { return version != state.version; }
     void setZero() { version = 0; }
     static constexpr bool need_zero_value_storage = false;
-    void setMapped(const value_type & /*value*/) {}
 
     struct CellExt
     {
@@ -33,8 +33,10 @@ template <typename Key, typename Allocator = HashTableAllocator>
 class FixedClearableHashSet : public FixedHashTable<Key, FixedClearableHashTableCell<Key>, Allocator>
 {
 public:
+    using Base = FixedHashTable<Key, FixedClearableHashTableCell<Key>, Allocator>;
     using key_type = Key;
     using value_type = typename FixedClearableHashSet::cell_type::value_type;
+    using LookupResult = typename Base::LookupResult;
 
     void clear()
     {

--- a/dbms/src/Common/HashTable/FixedHashMap.h
+++ b/dbms/src/Common/HashTable/FixedHashMap.h
@@ -48,10 +48,12 @@ struct FixedHashMapCell
 };
 
 template<typename Key, typename Mapped, typename State>
-void * lookupResultGetKey(FixedHashMapCell<Key, Mapped, State> *) { return nullptr; }
+ALWAYS_INLINE inline void * lookupResultGetKey(FixedHashMapCell<Key, Mapped, State> *)
+{ return nullptr; }
 
 template<typename Key, typename Mapped, typename State>
-auto lookupResultGetMapped(FixedHashMapCell<Key, Mapped, State> * cell) { return &cell->getSecond(); }
+ALWAYS_INLINE inline auto lookupResultGetMapped(FixedHashMapCell<Key, Mapped, State> * cell)
+{ return &cell->getSecond(); }
 
 template <typename Key, typename Mapped, typename Allocator = HashTableAllocator>
 class FixedHashMap : public FixedHashTable<Key, FixedHashMapCell<Key, Mapped>, Allocator>

--- a/dbms/src/Common/HashTable/HashMap.h
+++ b/dbms/src/Common/HashTable/HashMap.h
@@ -111,10 +111,12 @@ struct HashMapCell
 };
 
 template<typename Key, typename Mapped, typename Hash, typename State>
-auto lookupResultGetKey(HashMapCell<Key, Mapped, Hash, State> * cell) { return &cell->getFirst(); }
+ALWAYS_INLINE inline auto lookupResultGetKey(HashMapCell<Key, Mapped, Hash, State> * cell)
+{ return &cell->getFirst(); }
 
 template<typename Key, typename Mapped, typename Hash, typename State>
-auto lookupResultGetMapped(HashMapCell<Key, Mapped, Hash, State> * cell) { return &cell->getSecond(); }
+ALWAYS_INLINE inline auto lookupResultGetMapped(HashMapCell<Key, Mapped, Hash, State> * cell)
+{ return &cell->getSecond(); }
 
 
 template <typename Key, typename TMapped, typename Hash, typename TState = HashTableNoState>
@@ -135,10 +137,12 @@ struct HashMapCellWithSavedHash : public HashMapCell<Key, TMapped, Hash, TState>
 };
 
 template<typename Key, typename Mapped, typename Hash, typename State>
-auto lookupResultGetKey(HashMapCellWithSavedHash<Key, Mapped, Hash, State> * cell) { return &cell->getFirst(); }
+ALWAYS_INLINE inline auto lookupResultGetKey(HashMapCellWithSavedHash<Key, Mapped, Hash, State> * cell)
+{ return &cell->getFirst(); }
 
 template<typename Key, typename Mapped, typename Hash, typename State>
-auto lookupResultGetMapped(HashMapCellWithSavedHash<Key, Mapped, Hash, State> * cell) { return &cell->getSecond(); }
+ALWAYS_INLINE inline auto lookupResultGetMapped(HashMapCellWithSavedHash<Key, Mapped, Hash, State> * cell)
+{ return &cell->getSecond(); }
 
 
 template <

--- a/dbms/src/Common/HashTable/HashMap.h
+++ b/dbms/src/Common/HashTable/HashMap.h
@@ -43,6 +43,9 @@ struct HashMapCell
     using State = TState;
 
     using value_type = PairNoInit<Key, Mapped>;
+    using mapped_type = Mapped;
+    using key_type = Key;
+
     value_type value;
 
     HashMapCell() {}
@@ -107,6 +110,12 @@ struct HashMapCell
     }
 };
 
+template<typename Key, typename Mapped, typename Hash, typename State>
+auto lookupResultGetKey(HashMapCell<Key, Mapped, Hash, State> * cell) { return &cell->getFirst(); }
+
+template<typename Key, typename Mapped, typename Hash, typename State>
+auto lookupResultGetMapped(HashMapCell<Key, Mapped, Hash, State> * cell) { return &cell->getSecond(); }
+
 
 template <typename Key, typename TMapped, typename Hash, typename TState = HashTableNoState>
 struct HashMapCellWithSavedHash : public HashMapCell<Key, TMapped, Hash, TState>
@@ -125,6 +134,12 @@ struct HashMapCellWithSavedHash : public HashMapCell<Key, TMapped, Hash, TState>
     size_t getHash(const Hash & /*hash_function*/) const { return saved_hash; }
 };
 
+template<typename Key, typename Mapped, typename Hash, typename State>
+auto lookupResultGetKey(HashMapCellWithSavedHash<Key, Mapped, Hash, State> * cell) { return &cell->getFirst(); }
+
+template<typename Key, typename Mapped, typename Hash, typename State>
+auto lookupResultGetMapped(HashMapCellWithSavedHash<Key, Mapped, Hash, State> * cell) { return &cell->getSecond(); }
+
 
 template <
     typename Key,
@@ -136,9 +151,13 @@ class HashMapTable : public HashTable<Key, Cell, Hash, Grower, Allocator>
 {
 public:
     using Self = HashMapTable;
+    using Base = HashTable<Key, Cell, Hash, Grower, Allocator>;
+
     using key_type = Key;
-    using mapped_type = typename Cell::Mapped;
     using value_type = typename Cell::value_type;
+    using mapped_type = typename Cell::Mapped;
+
+    using LookupResult = typename Base::LookupResult;
 
     using HashTable<Key, Cell, Hash, Grower, Allocator>::HashTable;
 
@@ -153,10 +172,10 @@ public:
     {
         for (auto it = this->begin(), end = this->end(); it != end; ++it)
         {
-            decltype(it) res_it;
+            typename Self::LookupResult res_it;
             bool inserted;
             that.emplace(it->getFirst(), res_it, inserted, it.getHash());
-            func(res_it->getSecond(), it->getSecond(), inserted);
+            func(*lookupResultGetMapped(res_it), it->getSecond(), inserted);
         }
     }
 
@@ -170,11 +189,11 @@ public:
     {
         for (auto it = this->begin(), end = this->end(); it != end; ++it)
         {
-            decltype(it) res_it = that.find(it->getFirst(), it.getHash());
-            if (res_it == that.end())
+            auto res_it = that.find(it->getFirst(), it.getHash());
+            if (!res_it)
                 func(it->getSecond(), it->getSecond(), false);
             else
-                func(res_it->getSecond(), it->getSecond(), true);
+                func(*lookupResultGetMapped(res_it), it->getSecond(), true);
         }
     }
 
@@ -196,7 +215,7 @@ public:
 
     mapped_type & ALWAYS_INLINE operator[](Key x)
     {
-        typename HashMapTable::iterator it;
+        typename HashMapTable::LookupResult it;
         bool inserted;
         this->emplace(x, it, inserted);
 
@@ -215,9 +234,9 @@ public:
           *  the compiler can not guess about this, and generates the `load`, `increment`, `store` code.
           */
         if (inserted)
-            new(&it->getSecond()) mapped_type();
+            new(lookupResultGetMapped(it)) mapped_type();
 
-        return it->getSecond();
+        return *lookupResultGetMapped(it);
     }
 };
 

--- a/dbms/src/Common/HashTable/HashSet.h
+++ b/dbms/src/Common/HashTable/HashSet.h
@@ -30,6 +30,9 @@ public:
     using Self = HashSetTable;
     using Cell = TCell;
 
+    using Base = HashTable<Key, TCell, Hash, Grower, Allocator>;
+    using typename Base::LookupResult;
+
     void merge(const Self & rhs)
     {
         if (!this->hasZero() && rhs.hasZero())
@@ -81,6 +84,11 @@ struct HashSetCellWithSavedHash : public HashTableCell<Key, Hash, TState>
     size_t getHash(const Hash & /*hash_function*/) const { return saved_hash; }
 };
 
+template<typename Key, typename Hash, typename State>
+auto lookupResultGetKey(HashSetCellWithSavedHash<Key, Hash, State> * cell) { return &cell->key; }
+
+template<typename Key, typename Hash, typename State>
+void * lookupResultGetMapped(HashSetCellWithSavedHash<Key, Hash, State> *) { return nullptr; }
 
 template
 <

--- a/dbms/src/Common/HashTable/HashSet.h
+++ b/dbms/src/Common/HashTable/HashSet.h
@@ -85,10 +85,12 @@ struct HashSetCellWithSavedHash : public HashTableCell<Key, Hash, TState>
 };
 
 template<typename Key, typename Hash, typename State>
-auto lookupResultGetKey(HashSetCellWithSavedHash<Key, Hash, State> * cell) { return &cell->key; }
+ALWAYS_INLINE inline auto lookupResultGetKey(HashSetCellWithSavedHash<Key, Hash, State> * cell)
+{ return &cell->key; }
 
 template<typename Key, typename Hash, typename State>
-void * lookupResultGetMapped(HashSetCellWithSavedHash<Key, Hash, State> *) { return nullptr; }
+ALWAYS_INLINE inline void * lookupResultGetMapped(HashSetCellWithSavedHash<Key, Hash, State> *)
+{ return nullptr; }
 
 template
 <

--- a/dbms/src/Common/HashTable/HashTable.h
+++ b/dbms/src/Common/HashTable/HashTable.h
@@ -124,7 +124,7 @@ void set(T & x) { x = 0; }
   * The default implementation of GetMapped that is used for the above case (2).
   */
 template<typename PointerLike>
-inline auto lookupResultGetMapped(PointerLike && ptr) { return &*ptr; }
+ALWAYS_INLINE inline auto lookupResultGetMapped(PointerLike && ptr) { return &*ptr; }
 
 /**
   * Generic const wrapper for lookupResultGetMapped, that calls a non-const
@@ -132,7 +132,7 @@ inline auto lookupResultGetMapped(PointerLike && ptr) { return &*ptr; }
   * arithmetics.
   */
 template<typename T>
-auto lookupResultGetMapped(const T * obj)
+ALWAYS_INLINE inline auto lookupResultGetMapped(const T * obj)
 {
     auto mapped_ptr = lookupResultGetMapped(const_cast<T *>(obj));
     const auto const_mapped_ptr = mapped_ptr;
@@ -208,10 +208,12 @@ struct HashTableCell
 };
 
 template<typename Key, typename Hash, typename State>
-auto lookupResultGetKey(HashTableCell<Key, Hash, State> * cell) { return &cell->key; }
+ALWAYS_INLINE inline auto lookupResultGetKey(HashTableCell<Key, Hash, State> * cell)
+{ return &cell->key; }
 
 template<typename Key, typename Hash, typename State>
-void * lookupResultGetMapped(HashTableCell<Key, Hash, State> *) { return nullptr; }
+ALWAYS_INLINE inline void * lookupResultGetMapped(HashTableCell<Key, Hash, State> *)
+{ return nullptr; }
 
 /**
   * A helper function for HashTable::insert() to set the "mapped" value.

--- a/dbms/src/Common/HashTable/HashTable.h
+++ b/dbms/src/Common/HashTable/HashTable.h
@@ -77,6 +77,67 @@ void set(T & x) { x = 0; }
 
 }
 
+/**
+  * lookupResultGetKey/Mapped -- functions to get key/"mapped" values from the
+  * LookupResult returned by find() and emplace() methods of HashTable.
+  * Must not be called for a null LookupResult.
+  *
+  * We don't use iterators for lookup result to avoid creating temporary
+  * objects. Instead, LookupResult is a pointer of some kind. There are global
+  * functions lookupResultGetKey/Mapped, overloaded for this pointer type, that
+  * return pointers to key/"mapped" values. They are implemented as global
+  * functions and not as methods, because they have to be overloaded for POD
+  * types, e.g. in StringHashTable where different components have different
+  * Cell format.
+  *
+  * Different hash table implementations support this interface to a varying
+  * degree:
+  *
+  * 1) Hash tables that store neither the key in its original form, nor a
+  *    "mapped" value: FixedHashTable or StringHashTable.
+  *    Neither GetKey nor GetMapped are supported, the only valid operation is
+  *    checking LookupResult for null.
+  *
+  * 2) Hash maps that do not store the key, e.g. FixedHashMap or StringHashMap.
+  *    Only GetMapped is supported.
+  *
+  * 3) Hash tables that store the key and do not have a "mapped" value, e.g. the
+  *    normal HashTable.
+  *    GetKey returns the key, and GetMapped returns a zero void pointer. This
+  *    simplifies generic code that works with mapped values: it can overload
+  *    on the return type of GetMapped(), and doesn't need other parameters. One
+  *    example is insertSetMapped() function.
+  *
+  * 4) Hash tables that store both the key and the "mapped" value, e.g. HashMap.
+  *    Both GetKey and GetMapped are supported.
+  *
+  * The implementation side goes as follows:
+  * for (1), LookupResult = void *, no getters;
+  * for (2), LookupResult = Mapped *, GetMapped is a default implementation that
+  * takes any pointer-like object;
+  * for (3) and (4), LookupResult = Cell *, and both getters are implemented.
+  * They have to be specialized for each particular Cell class to supersede the
+  * default verision that takes a generic pointer-like object.
+  */
+
+/**
+  * The default implementation of GetMapped that is used for the above case (2).
+  */
+template<typename PointerLike>
+inline auto lookupResultGetMapped(PointerLike && ptr) { return &*ptr; }
+
+/**
+  * Generic const wrapper for lookupResultGetMapped, that calls a non-const
+  * version. Should be safe, given that these functions only do pointer
+  * arithmetics.
+  */
+template<typename T>
+auto lookupResultGetMapped(const T * obj)
+{
+    auto mapped_ptr = lookupResultGetMapped(const_cast<T *>(obj));
+    const auto const_mapped_ptr = mapped_ptr;
+    return const_mapped_ptr;
+}
 
 /** Compile-time interface for cell of the hash table.
   * Different cell types are used to implement different hash tables.
@@ -89,7 +150,10 @@ struct HashTableCell
 {
     using State = TState;
 
+    using key_type = Key;
     using value_type = Key;
+    using mapped_type = void;
+
     Key key;
 
     HashTableCell() {}
@@ -142,6 +206,22 @@ struct HashTableCell
     void read(DB::ReadBuffer & rb)        { DB::readBinary(key, rb); }
     void readText(DB::ReadBuffer & rb)    { DB::readDoubleQuoted(key, rb); }
 };
+
+template<typename Key, typename Hash, typename State>
+auto lookupResultGetKey(HashTableCell<Key, Hash, State> * cell) { return &cell->key; }
+
+template<typename Key, typename Hash, typename State>
+void * lookupResultGetMapped(HashTableCell<Key, Hash, State> *) { return nullptr; }
+
+/**
+  * A helper function for HashTable::insert() to set the "mapped" value.
+  * Overloaded on the mapped type, does nothing if it's void.
+  */
+template <typename ValueType>
+void insertSetMapped(void * /* dest */, const ValueType & /* src */) {}
+
+template <typename MappedType, typename ValueType>
+void insertSetMapped(MappedType * dest, const ValueType & src) { *dest = src.second; }
 
 
 /** Determines the size of the hash table, and when and how much it should be resized.
@@ -476,12 +556,33 @@ protected:
         {
             return container->grower.place((ptr - container->buf) - container->grower.place(getHash()));
         }
+
+        /**
+          * A hack for HashedDictionary.
+          *
+          * The problem: std-like find() returns an iterator, which has to be
+          * compared to end(). On the other hand, HashMap::find() returns
+          * LookupResult, which is compared to nullptr. HashedDictionary has to
+          * support both hash maps with the same code, hence the need for this
+          * hack.
+          *
+          * The proper way would be to remove iterator interface from our
+          * HashMap completely, change all its users to the existing internal
+          * iteration interface, and redefine end() to return LookupResult for
+          * compatibility with std find(). Unfortunately, now is not the time to
+          * do this.
+          */
+        operator Cell * () const { return nullptr; }
     };
 
 
 public:
     using key_type = Key;
     using value_type = typename Cell::value_type;
+
+    // Use lookupResultGetMapped/Key to work with these values.
+    using LookupResult = Cell *;
+    using ConstLookupResult = const Cell *;
 
     size_t hash(const Key & x) const { return Hash::operator()(x); }
 
@@ -642,7 +743,7 @@ protected:
     /// If the key is zero, insert it into a special place and return true.
     /// We don't have to persist a zero key, because it's not actually inserted.
     /// That's why we just take a Key by value, an not a key holder.
-    bool ALWAYS_INLINE emplaceIfZero(Key x, iterator & it, bool & inserted, size_t hash_value)
+    bool ALWAYS_INLINE emplaceIfZero(Key x, LookupResult & it, bool & inserted, size_t hash_value)
     {
         /// If it is claimed that the zero key can not be inserted into the table.
         if (!Cell::need_zero_value_storage)
@@ -650,12 +751,13 @@ protected:
 
         if (Cell::isZero(x, *this))
         {
-            it = iteratorToZero();
+            it = this->zeroValue();
+
             if (!this->hasZero())
             {
                 ++m_size;
                 this->setHasZero();
-                it.ptr->setHash(hash_value);
+                this->zeroValue()->setHash(hash_value);
                 inserted = true;
             }
             else
@@ -669,9 +771,9 @@ protected:
 
     template <typename KeyHolder>
     void ALWAYS_INLINE emplaceNonZeroImpl(size_t place_value, KeyHolder && key_holder,
-                                          iterator & it, bool & inserted, size_t hash_value)
+                                          LookupResult & it, bool & inserted, size_t hash_value)
     {
-        it = iterator(this, &buf[place_value]);
+        it = &buf[place_value];
 
         if (!buf[place_value].isZero(*this))
         {
@@ -705,13 +807,16 @@ protected:
                 throw;
             }
 
-            it = find(keyHolderGetKey(key_holder), hash_value);
+            // The hash table was rehashed, so we have to re-find the key.
+            size_t new_place = findCell(key, hash_value, grower.place(hash_value));
+            assert(!buf[new_place].isZero(*this));
+            it = &buf[new_place];
         }
     }
 
     /// Only for non-zero keys. Find the right place, insert the key there, if it does not already exist. Set iterator to the cell in output parameter.
     template <typename KeyHolder>
-    void ALWAYS_INLINE emplaceNonZero(KeyHolder && key_holder, iterator & it,
+    void ALWAYS_INLINE emplaceNonZero(KeyHolder && key_holder, LookupResult & it,
                                       bool & inserted, size_t hash_value)
     {
         const auto & key = keyHolderGetKey(key_holder);
@@ -722,9 +827,9 @@ protected:
 
 public:
     /// Insert a value. In the case of any more complex values, it is better to use the `emplace` function.
-    std::pair<iterator, bool> ALWAYS_INLINE insert(const value_type & x)
+    std::pair<LookupResult, bool> ALWAYS_INLINE insert(const value_type & x)
     {
-        std::pair<iterator, bool> res;
+        std::pair<LookupResult, bool> res;
 
         size_t hash_value = hash(Cell::getKey(x));
         if (!emplaceIfZero(Cell::getKey(x), res.first, res.second, hash_value))
@@ -733,7 +838,7 @@ public:
         }
 
         if (res.second)
-            res.first.ptr->setMapped(x);
+            insertSetMapped(lookupResultGetMapped(res.first), x);
 
         return res;
     }
@@ -746,9 +851,10 @@ public:
     }
 
 
-    /** Insert the key,
-      * return an iterator to a position that can be used for `placement new` of value,
-      * as well as the flag - whether a new key was inserted.
+    /** Insert the key.
+      * Return values:
+      * 'it' -- a LookupResult pointing to the corresponding key/mapped pair.
+      * 'inserted' -- whether a new key was inserted.
       *
       * You have to make `placement new` of value if you inserted a new key,
       * since when destroying a hash table, it will call the destructor!
@@ -762,14 +868,14 @@ public:
       *     new(&it->second) Mapped(value);
       */
     template <typename KeyHolder>
-    void ALWAYS_INLINE emplace(KeyHolder && key_holder, iterator & it, bool & inserted)
+    void ALWAYS_INLINE emplace(KeyHolder && key_holder, LookupResult & it, bool & inserted)
     {
         const auto & key = keyHolderGetKey(key_holder);
         emplace(key_holder, it, inserted, hash(key));
     }
 
     template <typename KeyHolder>
-    void ALWAYS_INLINE emplace(KeyHolder && key_holder, iterator & it,
+    void ALWAYS_INLINE emplace(KeyHolder && key_holder, LookupResult & it,
                                   bool & inserted, size_t hash_value)
     {
         const auto & key = keyHolderGetKey(key_holder);
@@ -789,47 +895,29 @@ public:
             resize();
     }
 
-    iterator ALWAYS_INLINE find(Key x)
+    LookupResult ALWAYS_INLINE find(Key x)
     {
         if (Cell::isZero(x, *this))
-            return this->hasZero() ? iteratorToZero() : end();
+            return this->hasZero() ? this->zeroValue() : nullptr;
 
         size_t hash_value = hash(x);
         size_t place_value = findCell(x, hash_value, grower.place(hash_value));
-        return !buf[place_value].isZero(*this) ? iterator(this, &buf[place_value]) : end();
+        return !buf[place_value].isZero(*this) ? &buf[place_value] : nullptr;
     }
 
+    ConstLookupResult ALWAYS_INLINE find(Key x) const
+    {
+        return const_cast<std::decay_t<decltype(*this)> *>(this)->find(x);
+    }
 
-    const_iterator ALWAYS_INLINE find(Key x) const
+    LookupResult ALWAYS_INLINE find(Key x, size_t hash_value)
     {
         if (Cell::isZero(x, *this))
-            return this->hasZero() ? iteratorToZero() : end();
-
-        size_t hash_value = hash(x);
-        size_t place_value = findCell(x, hash_value, grower.place(hash_value));
-        return !buf[place_value].isZero(*this) ? const_iterator(this, &buf[place_value]) : end();
-    }
-
-
-    iterator ALWAYS_INLINE find(Key x, size_t hash_value)
-    {
-        if (Cell::isZero(x, *this))
-            return this->hasZero() ? iteratorToZero() : end();
+            return this->hasZero() ? this->zeroValue() : nullptr;
 
         size_t place_value = findCell(x, hash_value, grower.place(hash_value));
-        return !buf[place_value].isZero(*this) ? iterator(this, &buf[place_value]) : end();
+        return !buf[place_value].isZero(*this) ? &buf[place_value] : nullptr;
     }
-
-
-    const_iterator ALWAYS_INLINE find(Key x, size_t hash_value) const
-    {
-        if (Cell::isZero(x, *this))
-            return this->hasZero() ? iteratorToZero() : end();
-
-        size_t place_value = findCell(x, hash_value, grower.place(hash_value));
-        return !buf[place_value].isZero(*this) ? const_iterator(this, &buf[place_value]) : end();
-    }
-
 
     bool ALWAYS_INLINE has(Key x) const
     {

--- a/dbms/src/Common/HashTable/TwoLevelHashMap.h
+++ b/dbms/src/Common/HashTable/TwoLevelHashMap.h
@@ -20,6 +20,9 @@ public:
     using mapped_type = typename Cell::Mapped;
     using value_type = typename Cell::value_type;
 
+    using Impl = ImplTable<Key, Cell, Hash, Grower, Allocator>;
+    using LookupResult = typename Impl::LookupResult;
+
     using TwoLevelHashTable<Key, Cell, Hash, Grower, Allocator, ImplTable<Key, Cell, Hash, Grower, Allocator>>::TwoLevelHashTable;
 
     template <typename Func>
@@ -31,14 +34,14 @@ public:
 
     mapped_type & ALWAYS_INLINE operator[](Key x)
     {
-        typename TwoLevelHashMapTable::iterator it;
+        typename TwoLevelHashMapTable::LookupResult it;
         bool inserted;
         this->emplace(x, it, inserted);
 
         if (inserted)
-            new(&it->getSecond()) mapped_type();
+            new(lookupResultGetMapped(it)) mapped_type();
 
-        return it->getSecond();
+        return *lookupResultGetMapped(it);
     }
 };
 

--- a/dbms/src/Common/HashTable/TwoLevelHashTable.h
+++ b/dbms/src/Common/HashTable/TwoLevelHashTable.h
@@ -84,6 +84,9 @@ public:
     using key_type = typename Impl::key_type;
     using value_type = typename Impl::value_type;
 
+    using LookupResult = typename Impl::LookupResult;
+    using ConstLookupResult = typename Impl::ConstLookupResult;
+
     Impl impls[NUM_BUCKETS];
 
 
@@ -206,15 +209,15 @@ public:
 
 
     /// Insert a value. In the case of any more complex values, it is better to use the `emplace` function.
-    std::pair<iterator, bool> ALWAYS_INLINE insert(const value_type & x)
+    std::pair<LookupResult, bool> ALWAYS_INLINE insert(const value_type & x)
     {
         size_t hash_value = hash(Cell::getKey(x));
 
-        std::pair<iterator, bool> res;
+        std::pair<LookupResult, bool> res;
         emplace(Cell::getKey(x), res.first, res.second, hash_value);
 
         if (res.second)
-            res.first.getPtr()->setMapped(x);
+            insertSetMapped(lookupResultGetMapped(res.first), x);
 
         return res;
     }
@@ -236,7 +239,7 @@ public:
       *     new(&it->second) Mapped(value);
       */
     template <typename KeyHolder>
-    void ALWAYS_INLINE emplace(KeyHolder && key_holder, iterator & it, bool & inserted)
+    void ALWAYS_INLINE emplace(KeyHolder && key_holder, LookupResult & it, bool & inserted)
     {
         size_t hash_value = hash(keyHolderGetKey(key_holder));
         emplace(key_holder, it, inserted, hash_value);
@@ -245,40 +248,27 @@ public:
 
     /// Same, but with a precalculated values of hash function.
     template <typename KeyHolder>
-    void ALWAYS_INLINE emplace(KeyHolder && key_holder, iterator & it,
+    void ALWAYS_INLINE emplace(KeyHolder && key_holder, LookupResult & it,
                                   bool & inserted, size_t hash_value)
     {
         size_t buck = getBucketFromHash(hash_value);
-        typename Impl::iterator impl_it;
-        impls[buck].emplace(key_holder, impl_it, inserted, hash_value);
-        it = iterator(this, buck, impl_it);
+        impls[buck].emplace(key_holder, it, inserted, hash_value);
     }
 
-
-    iterator ALWAYS_INLINE find(Key x, size_t hash_value)
+    LookupResult ALWAYS_INLINE find(Key x, size_t hash_value)
     {
         size_t buck = getBucketFromHash(hash_value);
-
-        typename Impl::iterator found = impls[buck].find(x, hash_value);
-        return found != impls[buck].end()
-            ? iterator(this, buck, found)
-            : end();
+        return impls[buck].find(x, hash_value);
     }
 
-
-    const_iterator ALWAYS_INLINE find(Key x, size_t hash_value) const
+    ConstLookupResult ALWAYS_INLINE find(Key x, size_t hash_value) const
     {
-        size_t buck = getBucketFromHash(hash_value);
-
-        typename Impl::const_iterator found = impls[buck].find(x, hash_value);
-        return found != impls[buck].end()
-            ? const_iterator(this, buck, found)
-            : end();
+        return const_cast<std::decay_t<decltype(*this)> *>(this)->find(x, hash_value);
     }
 
+    LookupResult ALWAYS_INLINE find(Key x) { return find(x, hash(x)); }
 
-    iterator ALWAYS_INLINE find(Key x) { return find(x, hash(x)); }
-    const_iterator ALWAYS_INLINE find(Key x) const { return find(x, hash(x)); }
+    ConstLookupResult ALWAYS_INLINE find(Key x) const { return find(x, hash(x)); }
 
 
     void write(DB::WriteBuffer & wb) const

--- a/dbms/src/Common/SpaceSaving.h
+++ b/dbms/src/Common/SpaceSaving.h
@@ -366,10 +366,10 @@ private:
     Counter * findCounter(const TKey & key, size_t hash)
     {
         auto it = counter_map.find(key, hash);
-        if (it == counter_map.end())
+        if (!it)
             return nullptr;
 
-        return it->getSecond();
+        return *lookupResultGetMapped(it);
     }
 
     void rebuildCounterMap()

--- a/dbms/src/Common/tests/auto_array.cpp
+++ b/dbms/src/Common/tests/auto_array.cpp
@@ -149,16 +149,16 @@ int main(int argc, char ** argv)
         Map map;
         for (size_t i = 0; i < map_size; ++i)
         {
-            Map::iterator it;
+            Map::LookupResult it;
             bool inserted;
 
             map.emplace(rand(), it, inserted);
             if (inserted)
             {
-                new(&it->getSecond()) Arr(n);
+                new(lookupResultGetMapped(it)) Arr(n);
 
                 for (size_t j = 0; j < n; ++j)
-                    it->getSecond()[j] = field;
+                    (*lookupResultGetMapped(it))[j] = field;
             }
         }
 

--- a/dbms/src/Common/tests/hash_table.cpp
+++ b/dbms/src/Common/tests/hash_table.cpp
@@ -17,14 +17,14 @@ int main(int, char **)
         cont.insert(1);
         cont.insert(2);
 
-        Cont::iterator it;
+        Cont::LookupResult it;
         bool inserted;
+        int key = 3;
+        cont.emplace(key, it, inserted);
+        std::cerr << inserted << ", " << key << std::endl;
 
-        cont.emplace(3, it, inserted);
-        std::cerr << inserted << ", " << it->getValue() << std::endl;
-
-        cont.emplace(3, it, inserted);
-        std::cerr << inserted << ", " << it->getValue() << std::endl;
+        cont.emplace(key, it, inserted);
+        std::cerr << inserted << ", " << key << std::endl;
 
         for (auto x : cont)
             std::cerr << x.getValue() << std::endl;

--- a/dbms/src/Common/tests/parallel_aggregation.cpp
+++ b/dbms/src/Common/tests/parallel_aggregation.cpp
@@ -76,20 +76,20 @@ void aggregate1(Map & map, Source::const_iterator begin, Source::const_iterator 
 
 void aggregate12(Map & map, Source::const_iterator begin, Source::const_iterator end)
 {
-    Map::iterator found;
+    Map::LookupResult found = nullptr;
     auto prev_it = end;
     for (auto it = begin; it != end; ++it)
     {
-        if (*it == *prev_it)
+        if (prev_it != end && *it == *prev_it)
         {
-            ++found->getSecond();
+            ++*lookupResultGetMapped(found);
             continue;
         }
         prev_it = it;
 
         bool inserted;
         map.emplace(*it, found, inserted);
-        ++found->getSecond();
+        ++*lookupResultGetMapped(found);
     }
 }
 
@@ -101,20 +101,20 @@ void aggregate2(MapTwoLevel & map, Source::const_iterator begin, Source::const_i
 
 void aggregate22(MapTwoLevel & map, Source::const_iterator begin, Source::const_iterator end)
 {
-    MapTwoLevel::iterator found;
+    MapTwoLevel::LookupResult found = nullptr;
     auto prev_it = end;
     for (auto it = begin; it != end; ++it)
     {
         if (*it == *prev_it)
         {
-            ++found->getSecond();
+            ++*lookupResultGetMapped(found);
             continue;
         }
         prev_it = it;
 
         bool inserted;
         map.emplace(*it, found, inserted);
-        ++found->getSecond();
+        ++*lookupResultGetMapped(found);
     }
 }
 
@@ -135,10 +135,10 @@ void aggregate3(Map & local_map, Map & global_map, Mutex & mutex, Source::const_
 
     for (auto it = begin; it != end; ++it)
     {
-        Map::iterator found = local_map.find(*it);
+        auto found = local_map.find(*it);
 
-        if (found != local_map.end())
-            ++found->getSecond();
+        if (found)
+            ++*lookupResultGetMapped(found);
         else if (local_map.size() < threshold)
             ++local_map[*it];    /// TODO You could do one lookup, not two.
         else
@@ -160,10 +160,10 @@ void aggregate33(Map & local_map, Map & global_map, Mutex & mutex, Source::const
 
     for (auto it = begin; it != end; ++it)
     {
-        Map::iterator found;
+        Map::LookupResult found;
         bool inserted;
         local_map.emplace(*it, found, inserted);
-        ++found->getSecond();
+        ++*lookupResultGetMapped(found);
 
         if (inserted && local_map.size() == threshold)
         {
@@ -195,10 +195,10 @@ void aggregate4(Map & local_map, MapTwoLevel & global_map, Mutex * mutexes, Sour
         {
             for (; it != block_end; ++it)
             {
-                Map::iterator found = local_map.find(*it);
+                auto found = local_map.find(*it);
 
-                if (found != local_map.end())
-                    ++found->getSecond();
+                if (found)
+                    ++*lookupResultGetMapped(found);
                 else
                 {
                     size_t hash_value = global_map.hash(*it);

--- a/dbms/src/Common/tests/parallel_aggregation2.cpp
+++ b/dbms/src/Common/tests/parallel_aggregation2.cpp
@@ -46,14 +46,14 @@ struct AggregateIndependent
             {
                 for (auto it = begin; it != end; ++it)
                 {
-                    typename Map::iterator place;
+                    typename Map::LookupResult place;
                     bool inserted;
                     map.emplace(*it, place, inserted);
 
                     if (inserted)
-                        creator(place->getSecond());
+                        creator(*lookupResultGetMapped(place));
                     else
-                        updater(place->getSecond());
+                        updater(*lookupResultGetMapped(place));
                 }
             });
         }
@@ -87,13 +87,13 @@ struct AggregateIndependentWithSequentialKeysOptimization
 
             pool.schedule([&, begin, end]()
             {
-                typename Map::iterator place;
+                typename Map::LookupResult place = nullptr;
                 Key prev_key {};
                 for (auto it = begin; it != end; ++it)
                 {
                     if (it != begin && *it == prev_key)
                     {
-                        updater(place->getSecond());
+                        updater(*lookupResultGetMapped(place));
                         continue;
                     }
                     prev_key = *it;
@@ -102,9 +102,9 @@ struct AggregateIndependentWithSequentialKeysOptimization
                     map.emplace(*it, place, inserted);
 
                     if (inserted)
-                        creator(place->getSecond());
+                        creator(*lookupResultGetMapped(place));
                     else
-                        updater(place->getSecond());
+                        updater(*lookupResultGetMapped(place));
                 }
             });
         }

--- a/dbms/src/Core/tests/string_pool.cpp
+++ b/dbms/src/Core/tests/string_pool.cpp
@@ -209,9 +209,9 @@ int main(int argc, char ** argv)
 
         for (Vec::iterator it = vec.begin(); it != vec.end(); ++it)
         {
-            RefsHashMap::iterator inserted_it;
+            RefsHashMap::LookupResult inserted_it;
             bool inserted;
-            set.emplace(StringRef(*it), inserted_it, inserted);
+            set.emplace(StringRef(*lookupResultGetMapped(it)), inserted_it, inserted);
         }
 
         std::cerr << "Inserted refs into HashMap in " << watch.elapsedSeconds() << " sec, "
@@ -236,7 +236,7 @@ int main(int argc, char ** argv)
 
         for (Vec::iterator it = vec.begin(); it != vec.end(); ++it)
         {
-            RefsHashMap::iterator inserted_it;
+            RefsHashMap::LookupResult inserted_it;
             bool inserted;
             set.emplace(StringRef(pool.insert(it->data(), it->size()), it->size()), inserted_it, inserted);
         }

--- a/dbms/src/DataTypes/DataTypeEnum.cpp
+++ b/dbms/src/DataTypes/DataTypeEnum.cpp
@@ -70,20 +70,20 @@ void DataTypeEnum<Type>::fillMaps()
 {
     for (const auto & name_and_value : values)
     {
-        const auto name_to_value_pair = name_to_value_map.insert(
+        const auto inserted_value = name_to_value_map.insert(
             { StringRef{name_and_value.first}, name_and_value.second });
 
-        if (!name_to_value_pair.second)
+        if (!inserted_value.second)
             throw Exception{"Duplicate names in enum: '" + name_and_value.first + "' = " + toString(name_and_value.second)
-                    + " and '" + name_to_value_pair.first->getFirst().toString() + "' = " + toString(name_to_value_pair.first->getSecond()),
+                    + " and " + toString(*lookupResultGetMapped(inserted_value.first)),
                 ErrorCodes::SYNTAX_ERROR};
 
-        const auto value_to_name_pair = value_to_name_map.insert(
+        const auto inserted_name = value_to_name_map.insert(
             { name_and_value.second, StringRef{name_and_value.first} });
 
-        if (!value_to_name_pair.second)
+        if (!inserted_name.second)
             throw Exception{"Duplicate values in enum: '" + name_and_value.first + "' = " + toString(name_and_value.second)
-                    + " and '" + value_to_name_pair.first->second.toString() + "' = " + toString(value_to_name_pair.first->first),
+                    + " and '" + toString((*inserted_name.first).first) + "'",
                 ErrorCodes::SYNTAX_ERROR};
     }
 }

--- a/dbms/src/DataTypes/DataTypeEnum.h
+++ b/dbms/src/DataTypes/DataTypeEnum.h
@@ -78,10 +78,10 @@ public:
     FieldType getValue(StringRef field_name) const
     {
         const auto it = name_to_value_map.find(field_name);
-        if (it == std::end(name_to_value_map))
+        if (!it)
             throw Exception{"Unknown element '" + field_name.toString() + "' for type " + getName(), ErrorCodes::LOGICAL_ERROR};
 
-        return it->getSecond();
+        return *lookupResultGetMapped(it);
     }
 
     Field castToName(const Field & value_or_name) const override;

--- a/dbms/src/Dictionaries/ComplexKeyCacheDictionary.h
+++ b/dbms/src/Dictionaries/ComplexKeyCacheDictionary.h
@@ -469,7 +469,7 @@ private:
         {
             const StringRef key = keys_array[row];
             const auto it = map.find(key);
-            const auto string_ref = it != std::end(map) ? it->getSecond() : get_default(row);
+            const auto string_ref = it ? *lookupResultGetMapped(it) : get_default(row);
             out->insertData(string_ref.data, string_ref.size);
         }
     }

--- a/dbms/src/Dictionaries/ComplexKeyHashedDictionary.cpp
+++ b/dbms/src/Dictionaries/ComplexKeyHashedDictionary.cpp
@@ -357,7 +357,7 @@ void ComplexKeyHashedDictionary::updateData()
             {
                 const auto s_key = placeKeysInPool(i, saved_key_column_ptrs, keys, temp_key_pool);
                 auto it = update_key_hash.find(s_key);
-                if (it != std::end(update_key_hash))
+                if (it)
                     filter[i] = 0;
                 else
                     filter[i] = 1;
@@ -561,7 +561,7 @@ void ComplexKeyHashedDictionary::getItemsImpl(
         const auto key = placeKeysInPool(i, key_columns, keys, temporary_keys_pool);
 
         const auto it = attr.find(key);
-        set_value(i, it != attr.end() ? static_cast<OutputType>(it->getSecond()) : get_default(i));
+        set_value(i, it ? static_cast<OutputType>(*lookupResultGetMapped(it)) : get_default(i));
 
         /// free memory allocated for the key
         temporary_keys_pool.rollback(key.size);
@@ -672,7 +672,7 @@ void ComplexKeyHashedDictionary::has(const Attribute & attribute, const Columns 
         const auto key = placeKeysInPool(i, key_columns, keys, temporary_keys_pool);
 
         const auto it = attr.find(key);
-        out[i] = it != attr.end();
+        out[i] = static_cast<bool>(it);
 
         /// free memory allocated for the key
         temporary_keys_pool.rollback(key.size);

--- a/dbms/src/Dictionaries/HashedDictionary.cpp
+++ b/dbms/src/Dictionaries/HashedDictionary.cpp
@@ -696,7 +696,7 @@ void HashedDictionary::has(const Attribute & attribute, const PaddedPODArray<Key
     const auto rows = ext::size(ids);
 
     for (const auto i : ext::range(0, rows))
-        out[i] = attr.find(ids[i]) != std::end(attr);
+        out[i] = attr.find(ids[i]) != nullptr;
 
     query_count.fetch_add(rows, std::memory_order_relaxed);
 }

--- a/dbms/src/Dictionaries/RangeHashedDictionary.cpp
+++ b/dbms/src/Dictionaries/RangeHashedDictionary.cpp
@@ -124,10 +124,10 @@ void RangeHashedDictionary::getString(
     for (const auto i : ext::range(0, ids.size()))
     {
         const auto it = attr.find(ids[i]);
-        if (it != std::end(attr))
+        if (it)
         {
             const auto date = dates[i];
-            const auto & ranges_and_values = it->getSecond();
+            const auto & ranges_and_values = *lookupResultGetMapped(it);
             const auto val_it
                 = std::find_if(std::begin(ranges_and_values), std::end(ranges_and_values), [date](const Value<StringRef> & v)
                   {
@@ -395,10 +395,10 @@ void RangeHashedDictionary::getItemsImpl(
     for (const auto i : ext::range(0, ids.size()))
     {
         const auto it = attr.find(ids[i]);
-        if (it != std::end(attr))
+        if (it)
         {
             const auto date = dates[i];
-            const auto & ranges_and_values = it->getSecond();
+            const auto & ranges_and_values = *lookupResultGetMapped(it);
             const auto val_it
                 = std::find_if(std::begin(ranges_and_values), std::end(ranges_and_values), [date](const Value<AttributeType> & v)
                   {
@@ -423,9 +423,9 @@ void RangeHashedDictionary::setAttributeValueImpl(Attribute & attribute, const K
     auto & map = *std::get<Ptr<T>>(attribute.maps);
     const auto it = map.find(id);
 
-    if (it != map.end())
+    if (it)
     {
-        auto & values = it->getSecond();
+        auto & values = *lookupResultGetMapped(it);
 
         const auto insert_it
             = std::lower_bound(std::begin(values), std::end(values), range, [](const Value<T> & lhs, const Range & rhs_range)
@@ -496,9 +496,9 @@ void RangeHashedDictionary::setAttributeValue(Attribute & attribute, const Key i
 
             const auto it = map.find(id);
 
-            if (it != map.end())
+            if (it)
             {
-                auto & values = it->getSecond();
+                auto & values = *lookupResultGetMapped(it);
 
                 const auto insert_it = std::lower_bound(
                     std::begin(values), std::end(values), range, [](const Value<StringRef> & lhs, const Range & rhs_range)

--- a/dbms/src/Functions/addressToLine.cpp
+++ b/dbms/src/Functions/addressToLine.cpp
@@ -135,13 +135,13 @@ private:
 
     StringRef implCached(uintptr_t addr)
     {
-        Map::iterator it;
+        Map::LookupResult it;
         bool inserted;
         std::lock_guard lock(mutex);
         map.emplace(addr, it, inserted);
         if (inserted)
-            it->getSecond() = impl(addr);
-        return it->getSecond();
+            *lookupResultGetMapped(it) = impl(addr);
+        return *lookupResultGetMapped(it);
     }
 };
 

--- a/dbms/src/Functions/array/arrayDistinct.cpp
+++ b/dbms/src/Functions/array/arrayDistinct.cpp
@@ -173,7 +173,7 @@ bool FunctionArrayDistinct::executeNumber(
             if (nullable_col && (*src_null_map)[j])
                 continue;
 
-            if (set.find(values[j]) == set.end())
+            if (!set.find(values[j]))
             {
                 res_data.emplace_back(values[j]);
                 set.insert(values[j]);
@@ -229,7 +229,7 @@ bool FunctionArrayDistinct::executeString(
 
             StringRef str_ref = src_data_concrete->getDataAt(j);
 
-            if (set.find(str_ref) == set.end())
+            if (!set.find(str_ref))
             {
                 set.insert(str_ref);
                 res_data_column_string.insertData(str_ref.data, str_ref.size);
@@ -279,7 +279,7 @@ void FunctionArrayDistinct::executeHashed(
             src_data.updateHashWithValue(j, hash_function);
             hash_function.get128(reinterpret_cast<char *>(&hash));
 
-            if (set.find(hash) == set.end())
+            if (!set.find(hash))
             {
                 set.insert(hash);
                 res_data_col.insertFrom(src_data, j);

--- a/dbms/src/Functions/transform.cpp
+++ b/dbms/src/Functions/transform.cpp
@@ -507,8 +507,8 @@ private:
         for (size_t i = 0; i < size; ++i)
         {
             auto it = table.find(src[i]);
-            if (it != table.end())
-                memcpy(&dst[i], &it->getSecond(), sizeof(dst[i]));    /// little endian.
+            if (it)
+                memcpy(&dst[i], lookupResultGetMapped(it), sizeof(dst[i]));    /// little endian.
             else
                 dst[i] = dst_default;
         }
@@ -523,8 +523,8 @@ private:
         for (size_t i = 0; i < size; ++i)
         {
             auto it = table.find(src[i]);
-            if (it != table.end())
-                memcpy(&dst[i], &it->getSecond(), sizeof(dst[i]));    /// little endian.
+            if (it)
+                memcpy(&dst[i], lookupResultGetMapped(it), sizeof(dst[i]));    /// little endian.
             else
                 dst[i] = dst_default[i];
         }
@@ -539,8 +539,8 @@ private:
         for (size_t i = 0; i < size; ++i)
         {
             auto it = table.find(src[i]);
-            if (it != table.end())
-                memcpy(&dst[i], &it->getSecond(), sizeof(dst[i]));
+            if (it)
+                memcpy(&dst[i], lookupResultGetMapped(it), sizeof(dst[i]));
             else
                 dst[i] = src[i];
         }
@@ -557,7 +557,7 @@ private:
         for (size_t i = 0; i < size; ++i)
         {
             auto it = table.find(src[i]);
-            StringRef ref = it != table.end() ? it->getSecond() : dst_default;
+            StringRef ref = it ? *lookupResultGetMapped(it) : dst_default;
             dst_data.resize(current_dst_offset + ref.size);
             memcpy(&dst_data[current_dst_offset], ref.data, ref.size);
             current_dst_offset += ref.size;
@@ -580,8 +580,8 @@ private:
             auto it = table.find(src[i]);
             StringRef ref;
 
-            if (it != table.end())
-                ref = it->getSecond();
+            if (it)
+                ref = *lookupResultGetMapped(it);
             else
             {
                 ref.data = reinterpret_cast<const char *>(&dst_default_data[current_dst_default_offset]);
@@ -610,8 +610,8 @@ private:
             StringRef ref{&src_data[current_src_offset], src_offsets[i] - current_src_offset};
             current_src_offset = src_offsets[i];
             auto it = table.find(ref);
-            if (it != table.end())
-                memcpy(&dst[i], &it->getSecond(), sizeof(dst[i]));
+            if (it)
+                memcpy(&dst[i], lookupResultGetMapped(it), sizeof(dst[i]));
             else
                 dst[i] = dst_default;
         }
@@ -631,8 +631,8 @@ private:
             StringRef ref{&src_data[current_src_offset], src_offsets[i] - current_src_offset};
             current_src_offset = src_offsets[i];
             auto it = table.find(ref);
-            if (it != table.end())
-                memcpy(&dst[i], &it->getSecond(), sizeof(dst[i]));
+            if (it)
+                memcpy(&dst[i], lookupResultGetMapped(it), sizeof(dst[i]));
             else
                 dst[i] = dst_default[i];
         }
@@ -655,7 +655,7 @@ private:
 
             auto it = table.find(src_ref);
 
-            StringRef dst_ref = it != table.end() ? it->getSecond() : (with_default ? dst_default : src_ref);
+            StringRef dst_ref = it ? *lookupResultGetMapped(it) : (with_default ? dst_default : src_ref);
             dst_data.resize(current_dst_offset + dst_ref.size);
             memcpy(&dst_data[current_dst_offset], dst_ref.data, dst_ref.size);
             current_dst_offset += dst_ref.size;
@@ -696,8 +696,8 @@ private:
             auto it = table.find(src_ref);
             StringRef dst_ref;
 
-            if (it != table.end())
-                dst_ref = it->getSecond();
+            if (it)
+                dst_ref = *lookupResultGetMapped(it);
             else
             {
                 dst_ref.data = reinterpret_cast<const char *>(&dst_default_data[current_dst_default_offset]);

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -486,6 +486,7 @@ void NO_INLINE Aggregator::executeImplBatch(
             aggregate_data = emplace_result.getMapped();
 
         places[i] = aggregate_data;
+        assert(places[i] != nullptr);
     }
 
     /// Add values to the aggregate functions.

--- a/dbms/src/Interpreters/SetVariants.h
+++ b/dbms/src/Interpreters/SetVariants.h
@@ -22,7 +22,7 @@ namespace DB
 
 
 /// For the case where there is one numeric key.
-template <typename FieldType, typename TData>    /// UInt8/16/32/64 for any types with corresponding bit width.
+template <typename FieldType, typename TData, bool use_cache = true>    /// UInt8/16/32/64 for any types with corresponding bit width.
 struct SetMethodOneNumber
 {
     using Data = TData;
@@ -30,7 +30,8 @@ struct SetMethodOneNumber
 
     Data data;
 
-    using State = ColumnsHashing::HashMethodOneNumber<typename Data::value_type, void, FieldType>;
+    using State = ColumnsHashing::HashMethodOneNumber<typename Data::value_type,
+        void, FieldType, use_cache>;
 };
 
 /// For the case where there is one string key.
@@ -183,8 +184,12 @@ struct SetMethodHashed
   */
 struct NonClearableSet
 {
-    std::unique_ptr<SetMethodOneNumber<UInt8, FixedHashSet<UInt8>>>                                             key8;
-    std::unique_ptr<SetMethodOneNumber<UInt16, FixedHashSet<UInt16>>>                                           key16;
+    /*
+     * As in Aggregator, using consecutive keys cache doesn't improve performance
+     * for FixedHashTables.
+     */
+    std::unique_ptr<SetMethodOneNumber<UInt8, FixedHashSet<UInt8>, false /* use_cache */>>                                             key8;
+    std::unique_ptr<SetMethodOneNumber<UInt16, FixedHashSet<UInt16>, false /* use_cache */>>                                           key16;
 
     /** Also for the experiment was tested the ability to use SmallSet,
       *  as long as the number of elements in the set is small (and, if necessary, converted to a full-fledged HashSet).
@@ -209,8 +214,8 @@ struct NonClearableSet
 
 struct ClearableSet
 {
-    std::unique_ptr<SetMethodOneNumber<UInt8, FixedClearableHashSet<UInt8>>>                                        key8;
-    std::unique_ptr<SetMethodOneNumber<UInt16, FixedClearableHashSet<UInt16>>>                                      key16;
+    std::unique_ptr<SetMethodOneNumber<UInt8, FixedClearableHashSet<UInt8>, false /* use_cache */>>                                        key8;
+    std::unique_ptr<SetMethodOneNumber<UInt16, FixedClearableHashSet<UInt16>, false /*use_cache */>>                                      key16;
 
     std::unique_ptr<SetMethodOneNumber<UInt32, ClearableHashSet<UInt32, HashCRC32<UInt32>>>>                        key32;
     std::unique_ptr<SetMethodOneNumber<UInt64, ClearableHashSet<UInt64, HashCRC32<UInt64>>>>                        key64;

--- a/dbms/src/Interpreters/tests/hash_map.cpp
+++ b/dbms/src/Interpreters/tests/hash_map.cpp
@@ -154,7 +154,7 @@ int main(int argc, char ** argv)
         Stopwatch watch;
 
         HashMap<Key, Value> map;
-        HashMap<Key, Value>::iterator it;
+        HashMap<Key, Value>::LookupResult it;
         bool inserted;
 
         for (size_t i = 0; i < n; ++i)
@@ -162,8 +162,8 @@ int main(int argc, char ** argv)
             map.emplace(data[i], it, inserted);
             if (inserted)
             {
-                new(&it->getSecond()) Value;
-                std::swap(it->getSecond(), value);
+                new(lookupResultGetMapped(it)) Value;
+                std::swap(*lookupResultGetMapped(it), value);
                 INIT
             }
         }
@@ -185,7 +185,7 @@ int main(int argc, char ** argv)
 
         using Map = HashMap<Key, Value, AlternativeHash>;
         Map map;
-        Map::iterator it;
+        Map::LookupResult it;
         bool inserted;
 
         for (size_t i = 0; i < n; ++i)
@@ -193,8 +193,8 @@ int main(int argc, char ** argv)
             map.emplace(data[i], it, inserted);
             if (inserted)
             {
-                new(&it->getSecond()) Value;
-                std::swap(it->getSecond(), value);
+                new(lookupResultGetMapped(it)) Value;
+                std::swap(*lookupResultGetMapped(it), value);
                 INIT
             }
         }
@@ -217,7 +217,7 @@ int main(int argc, char ** argv)
 
         using Map = HashMap<Key, Value, CRC32Hash_>;
         Map map;
-        Map::iterator it;
+        Map::LookupResult it;
         bool inserted;
 
         for (size_t i = 0; i < n; ++i)
@@ -225,8 +225,8 @@ int main(int argc, char ** argv)
             map.emplace(data[i], it, inserted);
             if (inserted)
             {
-                new(&it->getSecond()) Value;
-                std::swap(it->getSecond(), value);
+                new(lookupResultGetMapped(it)) Value;
+                std::swap(*lookupResultGetMapped(it), value);
                 INIT
             }
         }

--- a/dbms/src/Interpreters/tests/hash_map_lookup.cpp
+++ b/dbms/src/Interpreters/tests/hash_map_lookup.cpp
@@ -46,23 +46,24 @@ template <typename Map>
 void NO_INLINE bench(const std::vector<UInt16> & data, const char * name)
 {
     Map map;
-    typename Map::iterator it;
-    bool inserted;
 
     Stopwatch watch;
     for (size_t i = 0, size = data.size(); i < size; ++i)
     {
+        typename Map::LookupResult it;
+        bool inserted;
+
         map.emplace(data[i], it, inserted);
         if (inserted)
-            it->getSecond() = 1;
+            *lookupResultGetMapped(it) = 1;
         else
-            ++it->getSecond();
+            ++*lookupResultGetMapped(it);
     }
 
     for (size_t i = 0, size = data.size(); i < size; ++i)
     {
-        it = map.find(data[i]);
-        ++it->getSecond();
+        auto it = map.find(data[i]);
+        ++*lookupResultGetMapped(it);
     }
     watch.stop();
     std::cerr << std::fixed << std::setprecision(2) << "HashMap (" << name << "). Size: " << map.size()
@@ -77,13 +78,13 @@ template <typename Map>
 void insert(Map & map, StringRef & k)
 {
     bool inserted;
-    typename Map::iterator it;
+    typename Map::LookupResult it;
     map.emplace(k, it, inserted, nullptr);
     if (inserted)
-        *it = 1;
+        *lookupResultGetMapped(it) = 1;
     else
-        ++*it;
-    std::cout << *map.find(k) << std::endl;
+        ++*lookupResultGetMapped(it);
+    std::cout << *lookupResultGetMapped(map.find(k))<< std::endl;
 }
 
 int main(int argc, char ** argv)

--- a/dbms/src/Interpreters/tests/hash_map_string.cpp
+++ b/dbms/src/Interpreters/tests/hash_map_string.cpp
@@ -330,15 +330,15 @@ int main(int argc, char ** argv)
         using Map = HashMapWithSavedHash<Key, Value, DefaultHash<Key>, Grower>;
 
         Map map;
-        Map::iterator it;
+        Map::LookupResult it;
         bool inserted;
 
         for (size_t i = 0; i < n; ++i)
         {
             map.emplace(data[i], it, inserted);
             if (inserted)
-                it->getSecond() = 0;
-            ++it->getSecond();
+                *lookupResultGetMapped(it) = 0;
+            ++*lookupResultGetMapped(it);
         }
 
         watch.stop();
@@ -359,15 +359,15 @@ int main(int argc, char ** argv)
         using Map = HashMapWithSavedHash<Key, Value, FastHash64, Grower>;
 
         Map map;
-        Map::iterator it;
+        Map::LookupResult it;
         bool inserted;
 
         for (size_t i = 0; i < n; ++i)
         {
             map.emplace(data[i], it, inserted);
             if (inserted)
-                it->getSecond() = 0;
-            ++it->getSecond();
+                *lookupResultGetMapped(it) = 0;
+            ++*lookupResultGetMapped(it);
         }
 
         watch.stop();
@@ -389,15 +389,15 @@ int main(int argc, char ** argv)
         using Map = HashMapWithSavedHash<Key, Value, CrapWow, Grower>;
 
         Map map;
-        Map::iterator it;
+        Map::LookupResult it;
         bool inserted;
 
         for (size_t i = 0; i < n; ++i)
         {
             map.emplace(data[i], it, inserted);
             if (inserted)
-                it->getSecond() = 0;
-            ++it->getSecond();
+                *lookupResultGetMapped(it) = 0;
+            ++*lookupResultGetMapped(it);
         }
 
         watch.stop();
@@ -419,15 +419,15 @@ int main(int argc, char ** argv)
         using Map = HashMapWithSavedHash<Key, Value, SimpleHash, Grower>;
 
         Map map;
-        Map::iterator it;
+        Map::LookupResult it;
         bool inserted;
 
         for (size_t i = 0; i < n; ++i)
         {
             map.emplace(data[i], it, inserted);
             if (inserted)
-                it->getSecond() = 0;
-            ++it->getSecond();
+                *lookupResultGetMapped(it) = 0;
+            ++*lookupResultGetMapped(it);
         }
 
         watch.stop();

--- a/dbms/src/Interpreters/tests/hash_map_string_2.cpp
+++ b/dbms/src/Interpreters/tests/hash_map_string_2.cpp
@@ -588,15 +588,15 @@ void NO_INLINE bench(const std::vector<StringRef> & data, const char * name)
     using Map = HashMapWithSavedHash<Key, Value, DefaultHash<Key>>;
 
     Map map;
-    typename Map::iterator it;
+    typename Map::LookupResult it;
     bool inserted;
 
     for (size_t i = 0, size = data.size(); i < size; ++i)
     {
         map.emplace(static_cast<const Key &>(data[i]), it, inserted);
         if (inserted)
-            it->getSecond() = 0;
-        ++it->getSecond();
+            *lookupResultGetMapped(it) = 0;
+        ++*lookupResultGetMapped(it);
     }
 
     watch.stop();

--- a/dbms/src/Interpreters/tests/hash_map_string_3.cpp
+++ b/dbms/src/Interpreters/tests/hash_map_string_3.cpp
@@ -435,15 +435,15 @@ void NO_INLINE bench(const std::vector<StringRef> & data, const char * name)
     using Map = HashMapWithSavedHash<Key, Value, Hash>;
 
     Map map;
-    typename Map::iterator it;
+    typename Map::LookupResult it;
     bool inserted;
 
     for (size_t i = 0, size = data.size(); i < size; ++i)
     {
         map.emplace(static_cast<const Key &>(data[i]), it, inserted);
         if (inserted)
-            it->getSecond() = 0;
-        ++it->getSecond();
+            *lookupResultGetMapped(it) = 0;
+        ++*lookupResultGetMapped(it);
     }
 
     watch.stop();

--- a/dbms/src/Interpreters/tests/hash_map_string_small.cpp
+++ b/dbms/src/Interpreters/tests/hash_map_string_small.cpp
@@ -137,15 +137,15 @@ int main(int argc, char ** argv)
         using Map = HashMapWithSavedHash<StringRef, Value>;
 
         Map map;
-        Map::iterator it;
+        Map::LookupResult it;
         bool inserted;
 
         for (size_t i = 0; i < n; ++i)
         {
             map.emplace(data[i], it, inserted);
             if (inserted)
-                it->getSecond() = 0;
-            ++it->getSecond();
+                *lookupResultGetMapped(it) = 0;
+            ++*lookupResultGetMapped(it);
         }
 
         watch.stop();
@@ -166,15 +166,15 @@ int main(int argc, char ** argv)
         using Map = HashMapWithSavedHash<SmallStringRef, Value>;
 
         Map map;
-        Map::iterator it;
+        Map::LookupResult it;
         bool inserted;
 
         for (size_t i = 0; i < n; ++i)
         {
             map.emplace(SmallStringRef(data[i].data, data[i].size), it, inserted);
             if (inserted)
-                it->getSecond() = 0;
-            ++it->getSecond();
+                *lookupResultGetMapped(it) = 0;
+            ++*lookupResultGetMapped(it);
         }
 
         watch.stop();

--- a/dbms/src/Interpreters/tests/two_level_hash_map.cpp
+++ b/dbms/src/Interpreters/tests/two_level_hash_map.cpp
@@ -60,15 +60,15 @@ int main(int argc, char ** argv)
         using Map = TwoLevelHashTable<Key, HashMapCell<Key, Value, DefaultHash<Key>>, DefaultHash<Key>, HashTableGrower<8>, HashTableAllocator>;
 
         Map map;
-        Map::iterator it;
+        Map::LookupResult it;
         bool inserted;
 
         for (size_t i = 0; i < n; ++i)
         {
             map.emplace(data[i], it, inserted);
             if (inserted)
-                it->getSecond() = 0;
-            ++it->getSecond();
+                *lookupResultGetMapped(it) = 0;
+            ++*lookupResultGetMapped(it);
         }
 
         watch.stop();
@@ -96,15 +96,15 @@ int main(int argc, char ** argv)
         //using Map = HashMap<Key, Value, UniquesHashSetDefaultHash>;
 
         Map map;
-        Map::iterator it;
+        Map::LookupResult it;
         bool inserted;
 
         for (size_t i = 0; i < n; ++i)
         {
             map.emplace(i, it, inserted);
             if (inserted)
-                it->getSecond() = 0;
-            ++it->getSecond();
+                *lookupResultGetMapped(it) = 0;
+            ++*lookupResultGetMapped(it);
         }
 
         watch.stop();

--- a/dbms/src/Processors/Formats/Impl/JSONEachRowRowInputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/JSONEachRowRowInputFormat.cpp
@@ -49,7 +49,7 @@ JSONEachRowRowInputFormat::JSONEachRowRowInputFormat(
         }
     }
 
-    prev_positions.assign(num_columns, name_map.end());
+    prev_positions.resize(num_columns);
 }
 
 const String & JSONEachRowRowInputFormat::columnName(size_t i) const
@@ -63,21 +63,21 @@ inline size_t JSONEachRowRowInputFormat::columnIndex(const StringRef & name, siz
     /// and a quick check to match the next expected field, instead of searching the hash table.
 
     if (prev_positions.size() > key_index
-        && prev_positions[key_index] != name_map.end()
-        && name == prev_positions[key_index]->getFirst())
+        && prev_positions[key_index]
+        && name == *lookupResultGetKey(prev_positions[key_index]))
     {
-        return prev_positions[key_index]->getSecond();
+        return *lookupResultGetMapped(prev_positions[key_index]);
     }
     else
     {
         const auto it = name_map.find(name);
 
-        if (name_map.end() != it)
+        if (it)
         {
             if (key_index < prev_positions.size())
                 prev_positions[key_index] = it;
 
-            return it->getSecond();
+            return *lookupResultGetMapped(it);
         }
         else
             return UNKNOWN_FIELD;

--- a/dbms/src/Processors/Formats/Impl/JSONEachRowRowInputFormat.h
+++ b/dbms/src/Processors/Formats/Impl/JSONEachRowRowInputFormat.h
@@ -62,7 +62,7 @@ private:
     NameMap name_map;
 
     /// Cached search results for previous row (keyed as index in JSON object) - used as a hint.
-    std::vector<NameMap::iterator> prev_positions;
+    std::vector<NameMap::LookupResult> prev_positions;
 };
 
 }

--- a/dbms/src/Processors/Formats/Impl/TSKVRowInputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/TSKVRowInputFormat.cpp
@@ -118,7 +118,7 @@ bool TSKVRowInputFormat::readRow(MutableColumns & columns, RowReadExtension & ex
                 /// and quickly checking for the next expected field, instead of searching the hash table.
 
                 auto it = name_map.find(name_ref);
-                if (name_map.end() == it)
+                if (!it)
                 {
                     if (!format_settings.skip_unknown_fields)
                         throw Exception("Unknown field found while parsing TSKV format: " + name_ref.toString(), ErrorCodes::INCORRECT_DATA);
@@ -129,7 +129,7 @@ bool TSKVRowInputFormat::readRow(MutableColumns & columns, RowReadExtension & ex
                 }
                 else
                 {
-                    index = it->getSecond();
+                    index = *lookupResultGetMapped(it);
 
                     if (read_columns[index])
                         throw Exception("Duplicate field found while parsing TSKV format: " + name_ref.toString(), ErrorCodes::INCORRECT_DATA);

--- a/dbms/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -47,7 +47,7 @@ void buildScatterSelector(
     for (size_t i = 0; i < num_rows; ++i)
     {
         Data::key_type key = hash128(i, columns.size(), columns);
-        typename Data::iterator it;
+        typename Data::LookupResult it;
         bool inserted;
         partitions_map.emplace(key, it, inserted);
 
@@ -57,7 +57,7 @@ void buildScatterSelector(
                 throw Exception("Too many partitions for single INSERT block (more than " + toString(max_parts) + "). The limit is controlled by 'max_partitions_per_insert_block' setting. Large number of partitions is a common misconception. It will lead to severe negative performance impact, including slow server startup, slow INSERT queries and slow SELECT queries. Recommended total number of partitions for a table is under 1000..10000. Please note, that partitioning is not intended to speed up SELECT queries (ORDER BY key is sufficient to make range queries fast). Partitions are intended for data manipulation (DROP PARTITION, etc).", ErrorCodes::TOO_MANY_PARTS);
 
             partition_num_to_first_row.push_back(i);
-            it->getSecond() = partitions_count;
+            *lookupResultGetMapped(it) = partitions_count;
 
             ++partitions_count;
 
@@ -70,7 +70,7 @@ void buildScatterSelector(
         }
 
         if (partitions_count > 1)
-            selector[i] = it->getSecond();
+            selector[i] = *lookupResultGetMapped(it);
     }
 }
 


### PR DESCRIPTION
Instead, these methods return a pointer to the required data as they are
stored inside the hash table. The caller uses overloaded functions to
get the key and "mapped" values from this pointer. Such an interface
avoids the need for constructing iterator-like wrapper objects, which is
especially important for compound hash tables such as the future
StringHashMap.

This is a preparation for #5417.

Category:
- Code cleanup

Todo:
- rebase to master after sparse dictionary changes
- test the performance -- I've seen an improvement on string_hash_map test, probably because we don't need temporary iterator objects with this patch.