### PR TITLE
Avoid SIGSEGV on batch send failure (file with index XX is absent)

### DIFF
--- a/dbms/src/Storages/Distributed/DirectoryMonitor.cpp
+++ b/dbms/src/Storages/Distributed/DirectoryMonitor.cpp
@@ -392,7 +392,8 @@ struct StorageDistributedDirectoryMonitor::Batch
                 remote->writePrepared(in);
             }
 
-            remote->writeSuffix();
+            if (remote)
+                remote->writeSuffix();
         }
         catch (const Exception & e)
         {


### PR DESCRIPTION
Category (leave one):
- Bug Fix

Short description (up to few sentences):

Avoid SIGSEGV on batch send failure (file with index XX is absent)

Detailed description (optional):

In case of the following error:
  Failed to send batch: file with index 23742 is absent

NULL dereference will occur for the "remote".