### PR TITLE
Fix osx build

### DIFF
--- a/dbms/src/Common/PoolWithFailoverBase.h
+++ b/dbms/src/Common/PoolWithFailoverBase.h
@@ -199,7 +199,7 @@ PoolWithFailoverBase<TNestedPool>::getMany(
         for (const ShuffledPool & pool: shuffled_pools)
         {
             auto & pool_state = shared_pool_states[pool.index];
-            pool_state.error_count = std::min(max_error_cap, pool_state.error_count + pool.error_count);
+            pool_state.error_count = std::min(max_error_cap, static_cast<size_t>(pool_state.error_count + pool.error_count));
         }
     });
 

--- a/dbms/src/Common/QueryProfiler.cpp
+++ b/dbms/src/Common/QueryProfiler.cpp
@@ -30,10 +30,13 @@ namespace
     /// Thus upper bound on query_id length should be introduced to avoid buffer overflow in signal handler.
     constexpr size_t QUERY_ID_MAX_LEN = 1024;
 
+# if !defined(__APPLE__)
     thread_local size_t write_trace_iteration = 0;
+#endif
 
     void writeTraceInfo(TimerType timer_type, int /* sig */, siginfo_t * info, void * context)
     {
+# if !defined(__APPLE__)
         /// Quickly drop if signal handler is called too frequently.
         /// Otherwise we may end up infinitelly processing signals instead of doing any useful work.
         ++write_trace_iteration;
@@ -50,6 +53,9 @@ namespace
                 return;
             }
         }
+#else
+	UNUSED(info);
+#endif
 
         constexpr size_t buf_size = sizeof(char) + // TraceCollector stop flag
                                     8 * sizeof(char) + // maximum VarUInt length for string size

--- a/dbms/src/Common/QueryProfiler.cpp
+++ b/dbms/src/Common/QueryProfiler.cpp
@@ -54,7 +54,7 @@ namespace
             }
         }
 #else
-	UNUSED(info);
+        UNUSED(info);
 #endif
 
         constexpr size_t buf_size = sizeof(char) + // TraceCollector stop flag

--- a/dbms/src/Common/StackTrace.cpp
+++ b/dbms/src/Common/StackTrace.cpp
@@ -6,6 +6,7 @@
 #include <Common/config.h>
 #include <common/SimpleCache.h>
 #include <common/demangle.h>
+#include <Core/Defines.h>
 
 #include <cstring>
 #include <filesystem>

--- a/dbms/src/Common/TraceCollector.cpp
+++ b/dbms/src/Common/TraceCollector.cpp
@@ -46,7 +46,7 @@ TraceCollector::TraceCollector(std::shared_ptr<TraceLog> & trace_log_)
     if (-1 == fcntl(trace_pipe.fds_rw[1], F_SETFL, flags | O_NONBLOCK))
         throwFromErrno("Cannot set non-blocking mode of pipe", ErrorCodes::CANNOT_FCNTL);
 
-#if !defined(__FreeBSD__)
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
     /** Increase pipe size to avoid slowdown during fine-grained trace collection.
       */
     int pipe_size = fcntl(trace_pipe.fds_rw[1], F_GETPIPE_SZ);

--- a/dbms/src/Common/checkStackSize.cpp
+++ b/dbms/src/Common/checkStackSize.cpp
@@ -27,14 +27,32 @@ void checkStackSize()
 
     if (!stack_address)
     {
+#if defined(__APPLE__)
+        // pthread_get_stacksize_np() returns a value too low for the main thread on
+        // OSX 10.9, http://mail.openjdk.java.net/pipermail/hotspot-dev/2013-October/011369.html
+        //
+        // Multiple workarounds possible, adopt the one made by https://github.com/robovm/robovm/issues/274
+        // https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/Multithreading/CreatingThreads/CreatingThreads.html
+        // Stack size for the main thread is 8MB on OSX excluding the guard page size.
+        pthread_t thread = pthread_self();
+        max_stack_size = pthread_main_np() ? (8 * 1024 * 1024) : pthread_get_stacksize_np(thread);
+        stack_address = pthread_get_stackaddr_np(thread);
+#else
         pthread_attr_t attr;
+#if defined(__FreeBSD__)
+        pthread_attr_init(&attr);
+        if (0 != pthread_attr_get_np(pthread_self(), &attr))
+            throwFromErrno("Cannot pthread_attr_get_np", ErrorCodes::CANNOT_PTHREAD_ATTR);
+#else
         if (0 != pthread_getattr_np(pthread_self(), &attr))
             throwFromErrno("Cannot pthread_getattr_np", ErrorCodes::CANNOT_PTHREAD_ATTR);
+#endif
 
         SCOPE_EXIT({ pthread_attr_destroy(&attr); });
 
         if (0 != pthread_attr_getstack(&attr, &stack_address, &max_stack_size))
             throwFromErrno("Cannot pthread_getattr_np", ErrorCodes::CANNOT_PTHREAD_ATTR);
+#endif
     }
 
     const void * frame_address = __builtin_frame_address(0);

--- a/dbms/src/Common/new_delete.cpp
+++ b/dbms/src/Common/new_delete.cpp
@@ -1,4 +1,8 @@
+#if defined(__MACH__)
+#include <stdlib.h>
+#else
 #include <malloc.h>
+#endif
 #include <new>
 
 #include <common/config_common.h>

--- a/dbms/src/Functions/registerFunctionsIntrospection.cpp
+++ b/dbms/src/Functions/registerFunctionsIntrospection.cpp
@@ -3,16 +3,20 @@ namespace DB
 
 class FunctionFactory;
 
+#ifdef __ELF__
 void registerFunctionAddressToSymbol(FunctionFactory & factory);
-void registerFunctionDemangle(FunctionFactory & factory);
 void registerFunctionAddressToLine(FunctionFactory & factory);
+#endif
+void registerFunctionDemangle(FunctionFactory & factory);
 void registerFunctionTrap(FunctionFactory & factory);
 
 void registerFunctionsIntrospection(FunctionFactory & factory)
 {
+#ifdef __ELF__
     registerFunctionAddressToSymbol(factory);
-    registerFunctionDemangle(factory);
     registerFunctionAddressToLine(factory);
+#endif
+    registerFunctionDemangle(factory);
     registerFunctionTrap(factory);
 }
 

--- a/dbms/src/Interpreters/MetricLog.cpp
+++ b/dbms/src/Interpreters/MetricLog.cpp
@@ -103,7 +103,7 @@ void MetricLog::metricThreadFunction()
             for (size_t i = 0, end = ProfileEvents::end(); i < end; ++i)
             {
                 const ProfileEvents::Count new_value = ProfileEvents::global_counters[i].load(std::memory_order_relaxed);
-                UInt64 & old_value = prev_profile_events[i];
+                auto & old_value = prev_profile_events[i];
                 elem.profile_events[i] = new_value - old_value;
                 old_value = new_value;
             }

--- a/libs/libcommon/src/sleep.cpp
+++ b/libs/libcommon/src/sleep.cpp
@@ -3,6 +3,11 @@
 #include <time.h>
 #include <errno.h>
 
+#if defined(__APPLE__)
+#include <mach/mach.h>
+#include <mach/mach_time.h>
+#endif
+
 /**
   * Sleep with nanoseconds precision. Tolerant to signal interruptions
   *
@@ -14,6 +19,18 @@
   */
 void sleepForNanoseconds(uint64_t nanoseconds)
 {
+# if defined(__APPLE__)
+    //https://developer.apple.com/library/archive/technotes/tn2169/_index.html
+    //https://dshil.github.io/blog/missed-os-x-clock-guide/
+    static mach_timebase_info_data_t timebase_info = {0};
+    if(timebase_info.denom == 0)
+        mach_timebase_info(&timebase_info);
+
+    uint64_t time_to_wait = nanoseconds * timebase_info.denom / timebase_info.numer;
+    uint64_t now = mach_absolute_time();
+
+    while(mach_wait_until(now + time_to_wait) != KERN_SUCCESS);
+#else
     constexpr auto clock_type = CLOCK_MONOTONIC;
 
     struct timespec current_time;
@@ -29,6 +46,7 @@ void sleepForNanoseconds(uint64_t nanoseconds)
     finish_time.tv_sec += (nanoseconds / resolution) + extra_second;
 
     while (clock_nanosleep(clock_type, TIMER_ABSTIME, &finish_time, nullptr) == EINTR);
+#endif
 }
 
 void sleepForMicroseconds(uint64_t microseconds)

--- a/libs/libcommon/src/sleep.cpp
+++ b/libs/libcommon/src/sleep.cpp
@@ -23,13 +23,13 @@ void sleepForNanoseconds(uint64_t nanoseconds)
     //https://developer.apple.com/library/archive/technotes/tn2169/_index.html
     //https://dshil.github.io/blog/missed-os-x-clock-guide/
     static mach_timebase_info_data_t timebase_info = {0};
-    if(timebase_info.denom == 0)
+    if (timebase_info.denom == 0)
         mach_timebase_info(&timebase_info);
 
     uint64_t time_to_wait = nanoseconds * timebase_info.denom / timebase_info.numer;
     uint64_t now = mach_absolute_time();
 
-    while(mach_wait_until(now + time_to_wait) != KERN_SUCCESS);
+    while (mach_wait_until(now + time_to_wait) != KERN_SUCCESS);
 #else
     constexpr auto clock_type = CLOCK_MONOTONIC;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):

This PR it's fixing the compiling on OSX. It's work in progress as time the linking part is broken.

Using this PR the build on osx is fixed :

```
cmake .. -DCMAKE_CXX_COMPILER=`which g++-9` -DCMAKE_C_COMPILER=`which gcc-9` -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DCMAKE_BUILD_TYPE=Debug
```

Problem is that linking is broken because:

- `ld: unknown option: --no-undefined` generated because of:

```
# Make this extra-checks for correct library dependencies.
if (NOT SANITIZE)
    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-undefined")
    set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-undefined")
endif ()
```

-  `--start-group` and `--end-group` aare not available on OSX. Those are used here:

```
add_library(global-group INTERFACE)
target_link_libraries(global-group INTERFACE
    -Wl,--start-group
    $<TARGET_PROPERTY:global-libs,INTERFACE_LINK_LIBRARIES>
    -Wl,--end-group
)
```

- syntax like: `-l:libstdc++.a -l:libstdc++fs.a` seems not working on OSX

```
target_link_libraries(global-libs INTERFACE -l:libstdc++.a -l:libstdc++fs.a) # Always link these libraries as static
```

Maybe somebody more familiar with ClickHouse cmake files can fix those easly than me.