### PR TITLE
Fixed compatibility for distributed queries between 19.14 and earlier versions

### DIFF
--- a/dbms/src/Interpreters/ClusterProxy/executeQuery.cpp
+++ b/dbms/src/Interpreters/ClusterProxy/executeQuery.cpp
@@ -18,8 +18,6 @@ Context removeUserRestrictionsFromSettings(const Context & context, const Settin
 {
     Settings new_settings = settings;
     new_settings.queue_max_wait_ms = Cluster::saturate(new_settings.queue_max_wait_ms, settings.max_execution_time);
-    new_settings.connection_pool_max_wait_ms = Cluster::saturate(new_settings.connection_pool_max_wait_ms, settings.max_execution_time);
-    new_settings.replace_running_query_max_wait_ms = Cluster::saturate(new_settings.replace_running_query_max_wait_ms, settings.max_execution_time);
 
     /// Does not matter on remote servers, because queries are sent under different user.
     new_settings.max_concurrent_queries_for_user = 0;
@@ -39,8 +37,8 @@ Context removeUserRestrictionsFromSettings(const Context & context, const Settin
 }
 
 BlockInputStreams executeQuery(
-        IStreamFactory & stream_factory, const ClusterPtr & cluster,
-        const ASTPtr & query_ast, const Context & context, const Settings & settings)
+    IStreamFactory & stream_factory, const ClusterPtr & cluster,
+    const ASTPtr & query_ast, const Context & context, const Settings & settings)
 {
     BlockInputStreams res;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fixed compatibility for distributed queries between 19.14 and earlier versions. This fixes #7068

Detailed description (optional):

There are no such kind of tests in our CI. We only test communication between different versions of clickhouse-client and clickhouse-server.

To fix the issue in fundamental way, we need to change Settings serialization (to write all settings in the same format e.g. strings). This will also require some efforts for compatibility.