### PR TITLE
Get proper stack address on osx

### DIFF
--- a/dbms/src/Common/checkStackSize.cpp
+++ b/dbms/src/Common/checkStackSize.cpp
@@ -36,7 +36,9 @@ void checkStackSize()
         // Stack size for the main thread is 8MB on OSX excluding the guard page size.
         pthread_t thread = pthread_self();
         max_stack_size = pthread_main_np() ? (8 * 1024 * 1024) : pthread_get_stacksize_np(thread);
-        stack_address = pthread_get_stackaddr_np(thread);
+
+        // stack_address points to the start of the stack, not the end how it's returned by pthread_get_stackaddr_np
+        stack_address = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(pthread_get_stackaddr_np(thread)) - max_stack_size);
 #else
         pthread_attr_t attr;
 #if defined(__FreeBSD__)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Bug Fix

Short description (up to few sentences):

After I successful compiled and linked as well the osx (not proud about my cmake changes to publish them) I could saw that the way stack address it's wrong. the `pthread_get_stackaddr_np` seems returning the end of the stack and every single query is triggering an exception.

Also after more research I found out that on OSX. The main thread is the only one that has a 8MB stack. all other threads has around 512 KB.

An interesting workaround here: https://github.com/chromium/chromium/blob/master/base/threading/platform_thread_mac.mm

Not sure if we should stick with current one or use the above. 512 KB seems very low..
