### PR TITLE
add obsoletes section to clickhouse-server spec

### DIFF
--- a/utils/release/release_lib.sh
+++ b/utils/release/release_lib.sh
@@ -231,6 +231,8 @@ function make_rpm {
     echo "Requires: clickhouse-common-static = $VERSION_FULL-2" >> ${PACKAGE}-$VERSION_FULL-2.spec
     echo "Requires: tzdata" >> ${PACKAGE}-$VERSION_FULL-2.spec
     echo "Requires: initscripts" >> ${PACKAGE}-$VERSION_FULL-2.spec
+    echo "Obsoletes: clickhouse-server-common < $VERSION_FULL" >> ${PACKAGE}-$VERSION_FULL-2.spec
+
     cat ${PACKAGE}-$VERSION_FULL-2.spec_tmp >> ${PACKAGE}-$VERSION_FULL-2.spec
     rpm_pack
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Attempt to avoid conflict when updating from altinity rpm - it has config file packaged separately in clickhouse-server-common. 

Detailed description (optional):

When updating from altinity rpm currently you get that message:
```
Transaction check error:
  file /etc/clickhouse-server/config.xml from install of clickhouse-server-19.14.3.3-2.noarch conflicts with file from package clickhouse-server-common-19.11.8.46-1.el7.x86_64
  file /etc/clickhouse-server/users.xml from install of clickhouse-server-19.14.3.3-2.noarch conflicts with file from package clickhouse-server-common-19.11.8.46-1.el7.x86_64
```

P.S. don't merge for now, I'll test how it works 