### PR TITLE
Let the choice to write credential for HTTP source on external dictionaries

### DIFF
--- a/dbms/src/Dictionaries/HTTPDictionarySource.cpp
+++ b/dbms/src/Dictionaries/HTTPDictionarySource.cpp
@@ -52,7 +52,7 @@ HTTPDictionarySource::HTTPDictionarySource(
         this->header_entries.reserve(config_keys.size());
         for (const auto & key : config_keys)
         {
-            const auto header_key = config.getString(http_headers_prefix + "." + key + ".key", "");
+            const auto header_key = config.getString(http_headers_prefix + "." + key + ".name", "");
             const auto header_value = config.getString(http_headers_prefix + "." + key + ".value", "");
             this->header_entries.emplace_back(std::make_tuple(header_key, header_value));
         }

--- a/dbms/src/Dictionaries/HTTPDictionarySource.cpp
+++ b/dbms/src/Dictionaries/HTTPDictionarySource.cpp
@@ -57,7 +57,6 @@ HTTPDictionarySource::HTTPDictionarySource(
             this->header_entries.emplace_back(std::make_tuple(header_key, header_value));
         }
     }
-
 }
 
 HTTPDictionarySource::HTTPDictionarySource(const HTTPDictionarySource & other)

--- a/dbms/src/Dictionaries/HTTPDictionarySource.cpp
+++ b/dbms/src/Dictionaries/HTTPDictionarySource.cpp
@@ -38,23 +38,23 @@ HTTPDictionarySource::HTTPDictionarySource(
 
     if (config.has(credentials_prefix))
     {
-        this->credentials.setUsername(config.getString(credentials_prefix + ".user", ""));
-        this->credentials.setPassword(config.getString(credentials_prefix + ".password", ""));
+        credentials.setUsername(config.getString(credentials_prefix + ".user", ""));
+        credentials.setPassword(config.getString(credentials_prefix + ".password", ""));
     }
 
-    const auto & http_headers_prefix = config_prefix + ".http-headers";
+    const auto & headers_prefix = config_prefix + ".headers";
 
-    if (config.has(http_headers_prefix))
+    if (config.has(headers_prefix))
     {
         Poco::Util::AbstractConfiguration::Keys config_keys;
-        config.keys(http_headers_prefix, config_keys);
+        config.keys(headers_prefix, config_keys);
 
-        this->header_entries.reserve(config_keys.size());
+        header_entries.reserve(config_keys.size());
         for (const auto & key : config_keys)
         {
-            const auto header_key = config.getString(http_headers_prefix + "." + key + ".name", "");
-            const auto header_value = config.getString(http_headers_prefix + "." + key + ".value", "");
-            this->header_entries.emplace_back(std::make_tuple(header_key, header_value));
+            const auto header_key = config.getString(headers_prefix + "." + key + ".name", "");
+            const auto header_value = config.getString(headers_prefix + "." + key + ".value", "");
+            header_entries.emplace_back(std::make_tuple(header_key, header_value));
         }
     }
 }
@@ -71,8 +71,8 @@ HTTPDictionarySource::HTTPDictionarySource(const HTTPDictionarySource & other)
     , context(other.context)
     , timeouts(ConnectionTimeouts::getHTTPTimeouts(context))
 {
-    this->credentials.setUsername(other.credentials.getUsername());
-    this->credentials.setPassword(other.credentials.getPassword());
+    credentials.setUsername(other.credentials.getUsername());
+    credentials.setPassword(other.credentials.getPassword());
 }
 
 void HTTPDictionarySource::getUpdateFieldAndDate(Poco::URI & uri)
@@ -101,7 +101,7 @@ BlockInputStreamPtr HTTPDictionarySource::loadAll()
     Poco::URI uri(url);
     auto in_ptr = std::make_unique<ReadWriteBufferFromHTTP>(
         uri, Poco::Net::HTTPRequest::HTTP_GET, ReadWriteBufferFromHTTP::OutStreamCallback(), timeouts,
-        0, this->credentials, DBMS_DEFAULT_BUFFER_SIZE, this->header_entries);
+        0, credentials, DBMS_DEFAULT_BUFFER_SIZE, header_entries);
     auto input_stream = context.getInputFormat(format, *in_ptr, sample_block, max_block_size);
     return std::make_shared<OwningBlockInputStream<ReadWriteBufferFromHTTP>>(input_stream, std::move(in_ptr));
 }
@@ -113,7 +113,7 @@ BlockInputStreamPtr HTTPDictionarySource::loadUpdatedAll()
     LOG_TRACE(log, "loadUpdatedAll " + uri.toString());
     auto in_ptr = std::make_unique<ReadWriteBufferFromHTTP>(
         uri, Poco::Net::HTTPRequest::HTTP_GET, ReadWriteBufferFromHTTP::OutStreamCallback(), timeouts,
-        0, this->credentials, DBMS_DEFAULT_BUFFER_SIZE, this->header_entries);
+        0, credentials, DBMS_DEFAULT_BUFFER_SIZE, header_entries);
     auto input_stream = context.getInputFormat(format, *in_ptr, sample_block, max_block_size);
     return std::make_shared<OwningBlockInputStream<ReadWriteBufferFromHTTP>>(input_stream, std::move(in_ptr));
 }
@@ -132,7 +132,7 @@ BlockInputStreamPtr HTTPDictionarySource::loadIds(const std::vector<UInt64> & id
     Poco::URI uri(url);
     auto in_ptr = std::make_unique<ReadWriteBufferFromHTTP>(
         uri, Poco::Net::HTTPRequest::HTTP_POST, out_stream_callback, timeouts,
-        0, this->credentials, DBMS_DEFAULT_BUFFER_SIZE, this->header_entries);
+        0, credentials, DBMS_DEFAULT_BUFFER_SIZE, header_entries);
     auto input_stream = context.getInputFormat(format, *in_ptr, sample_block, max_block_size);
     return std::make_shared<OwningBlockInputStream<ReadWriteBufferFromHTTP>>(input_stream, std::move(in_ptr));
 }
@@ -151,7 +151,7 @@ BlockInputStreamPtr HTTPDictionarySource::loadKeys(const Columns & key_columns, 
     Poco::URI uri(url);
     auto in_ptr = std::make_unique<ReadWriteBufferFromHTTP>(
         uri, Poco::Net::HTTPRequest::HTTP_POST, out_stream_callback, timeouts,
-        0, this->credentials, DBMS_DEFAULT_BUFFER_SIZE, this->header_entries);
+        0, credentials, DBMS_DEFAULT_BUFFER_SIZE, header_entries);
     auto input_stream = context.getInputFormat(format, *in_ptr, sample_block, max_block_size);
     return std::make_shared<OwningBlockInputStream<ReadWriteBufferFromHTTP>>(input_stream, std::move(in_ptr));
 }

--- a/dbms/src/Dictionaries/HTTPDictionarySource.h
+++ b/dbms/src/Dictionaries/HTTPDictionarySource.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <IO/ConnectionTimeouts.h>
+#include <IO/ReadWriteBufferFromHTTP.h>
 #include <Poco/Net/HTTPBasicCredentials.h>
 #include <Poco/URI.h>
 #include <common/LocalDateTime.h>
@@ -58,6 +59,7 @@ private:
     const DictionaryStructure dict_struct;
     const std::string url;
     Poco::Net::HTTPBasicCredentials credentials;
+    ReadWriteBufferFromHTTP::HttpHeaderEntries header_entries;
     std::string update_field;
     const std::string format;
     Block sample_block;

--- a/dbms/src/Dictionaries/HTTPDictionarySource.h
+++ b/dbms/src/Dictionaries/HTTPDictionarySource.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <IO/ConnectionTimeouts.h>
+#include <Poco/Net/HTTPBasicCredentials.h>
 #include <Poco/URI.h>
 #include <common/LocalDateTime.h>
 #include "DictionaryStructure.h"
@@ -56,6 +57,7 @@ private:
     std::chrono::time_point<std::chrono::system_clock> update_time;
     const DictionaryStructure dict_struct;
     const std::string url;
+    Poco::Net::HTTPBasicCredentials credentials;
     std::string update_field;
     const std::string format;
     Block sample_block;

--- a/dbms/src/Dictionaries/HTTPDictionarySource.h
+++ b/dbms/src/Dictionaries/HTTPDictionarySource.h
@@ -59,7 +59,7 @@ private:
     const DictionaryStructure dict_struct;
     const std::string url;
     Poco::Net::HTTPBasicCredentials credentials;
-    ReadWriteBufferFromHTTP::HttpHeaderEntries header_entries;
+    ReadWriteBufferFromHTTP::HTTPHeaderEntries header_entries;
     std::string update_field;
     const std::string format;
     Block sample_block;

--- a/dbms/src/IO/ReadWriteBufferFromHTTP.h
+++ b/dbms/src/IO/ReadWriteBufferFromHTTP.h
@@ -87,8 +87,8 @@ namespace detail
     class ReadWriteBufferFromHTTPBase : public ReadBuffer
     {
     public:
-        using HttpHeaderEntry = std::tuple<std::string, std::string>;
-        using HttpHeaderEntries = std::vector<HttpHeaderEntry>;
+        using HTTPHeaderEntry = std::tuple<std::string, std::string>;
+        using HTTPHeaderEntries = std::vector<HTTPHeaderEntry>;
 
     protected:
         Poco::URI uri;
@@ -100,7 +100,7 @@ namespace detail
         std::function<void(std::ostream &)> out_stream_callback;
         const Poco::Net::HTTPBasicCredentials & credentials;
         std::vector<Poco::Net::HTTPCookie> cookies;
-        HttpHeaderEntries http_header_entries;
+        HTTPHeaderEntries http_header_entries;
 
         std::istream * call(const Poco::URI uri_, Poco::Net::HTTPResponse & response)
         {
@@ -157,7 +157,7 @@ namespace detail
             OutStreamCallback out_stream_callback_ = {},
             const Poco::Net::HTTPBasicCredentials & credentials_ = {},
             size_t buffer_size_ = DBMS_DEFAULT_BUFFER_SIZE,
-            HttpHeaderEntries http_header_entries_ = {})
+            HTTPHeaderEntries http_header_entries_ = {})
             : ReadBuffer(nullptr, 0)
             , uri {uri_}
             , method {!method_.empty() ? method_ : out_stream_callback_ ? Poco::Net::HTTPRequest::HTTP_POST : Poco::Net::HTTPRequest::HTTP_GET}
@@ -243,7 +243,7 @@ public:
         const DB::SettingUInt64 max_redirects = 0,
         const Poco::Net::HTTPBasicCredentials & credentials_ = {},
         size_t buffer_size_ = DBMS_DEFAULT_BUFFER_SIZE,
-        const HttpHeaderEntries & http_header_entries_ = {})
+        const HTTPHeaderEntries & http_header_entries_ = {})
         : Parent(std::make_shared<UpdatableSession>(uri_, timeouts, max_redirects), uri_, method_, out_stream_callback_, credentials_, buffer_size_, http_header_entries_)
     {
     }

--- a/dbms/src/IO/ReadWriteBufferFromHTTP.h
+++ b/dbms/src/IO/ReadWriteBufferFromHTTP.h
@@ -122,7 +122,7 @@ namespace detail
             if (!credentials.getUsername().empty())
                 credentials.authenticate(request);
 
-           LOG_TRACE((&Logger::get("ReadWriteBufferFromHTTP")), "Sending request to " << uri.toString());
+            LOG_TRACE((&Logger::get("ReadWriteBufferFromHTTP")), "Sending request to " << uri.toString());
 
             auto sess = session->getSession();
 

--- a/dbms/tests/integration/test_dictionaries_all_layouts_and_sources/external_sources.py
+++ b/dbms/tests/integration/test_dictionaries_all_layouts_and_sources/external_sources.py
@@ -331,6 +331,16 @@ class SourceHTTPBase(ExternalSource):
             <http>
                 <url>{url}</url>
                 <format>TabSeparated</format>
+                <credentials>
+                    <user>foo</user>
+                    <password>bar</password>
+                </credentials>
+                <headers>
+                    <header>
+                        <name>api-key</name>
+                        <value>secret</value>
+                    </header>
+                </headers>
             </http>
         '''.format(url=url)
 

--- a/dbms/tests/integration/test_dictionaries_all_layouts_and_sources/http_server.py
+++ b/dbms/tests/integration/test_dictionaries_all_layouts_and_sources/http_server.py
@@ -9,9 +9,9 @@ import csv
 # Decorator used to see if authentification works for external dictionary who use a HTTP source.
 def check_auth(fn):
     def wrapper(req):
-        auth_header = self.headers.get('Authorization', None)
-        api_key = self.headers.get('api-key', None)
-        if not auth_header or auth_header != 'Zm9vOmJhcg==' or not api_key or api_key != 'secret':
+        auth_header = req.headers.get('authorization', None)
+        api_key = req.headers.get('api-key', None)
+        if not auth_header or auth_header != 'Basic Zm9vOmJhcg==' or not api_key or api_key != 'secret':
             req.send_response(401)
         else:
             fn(req)

--- a/dbms/tests/integration/test_dictionaries_all_layouts_and_sources/http_server.py
+++ b/dbms/tests/integration/test_dictionaries_all_layouts_and_sources/http_server.py
@@ -6,12 +6,26 @@ import ssl
 import csv
 
 
+# Decorator used to see if authentification works for external dictionary who use a HTTP source.
+def check_auth(fn):
+    def wrapper(req):
+        auth_header = self.headers.get('Authorization', None)
+        api_key = self.headers.get('api-key', None)
+        if not auth_header or auth_header != 'Zm9vOmJhcg==' or not api_key or api_key != 'secret':
+            req.send_response(401)
+        else:
+            fn(req)
+    return wrapper
+
+
 def start_server(server_address, data_path, schema, cert_path, address_family):
     class TSVHTTPHandler(BaseHTTPRequestHandler):
+        @check_auth
         def do_GET(self):
             self.__send_headers()
             self.__send_data()
 
+        @check_auth
         def do_POST(self):
             ids = self.__read_and_decode_post_ids()
             print "ids=", ids

--- a/docs/en/query_language/dicts/external_dicts_dict_sources.md
+++ b/docs/en/query_language/dicts/external_dicts_dict_sources.md
@@ -109,7 +109,7 @@ Setting fields:
     - `password` – Password required for the authentification.
 - `http-headers` – All custom HTTP headers entries used for the HTTP request.
     - `http-header` – Single HTTP header entry.
-        - `key` – Identifiant name used for the header send on the request.
+        - `name` – Identifiant name used for the header send on the request.
         - `value` – Value set for a specific identifiant name.
 
 

--- a/docs/en/query_language/dicts/external_dicts_dict_sources.md
+++ b/docs/en/query_language/dicts/external_dicts_dict_sources.md
@@ -112,6 +112,7 @@ Setting fields:
         - `key` – Identifiant name used for the header send on the request.
         - `value` – Value set for a specific identifiant name.
 
+
 ## ODBC {#dicts-external_dicts_dict_sources-odbc}
 
 You can use this method to connect any database that has an ODBC driver.

--- a/docs/en/query_language/dicts/external_dicts_dict_sources.md
+++ b/docs/en/query_language/dicts/external_dicts_dict_sources.md
@@ -84,6 +84,16 @@ Example of settings:
     <http>
         <url>http://[::1]/os.tsv</url>
         <format>TabSeparated</format>
+        <credentials>
+            <user>user</user>
+            <password>password</password>
+        </credentials>
+        <http-headers>
+            <http-header>
+                <name>API-KEY</name>
+                <value>key</value>
+            </http-header>
+        </http-headers>
     </http>
 </source>
 ```
@@ -94,7 +104,13 @@ Setting fields:
 
 - `url` – The source URL.
 - `format` – The file format. All the formats described in "[Formats](../../interfaces/formats.md#formats)" are supported.
-
+- `credentials` – Basic HTTP authentification.
+    - `user` – Username required for the authentification.
+    - `password` – Password required for the authentification.
+- `http-headers` – All custom HTTP headers entries used for the HTTP request.
+    - `http-header` – Single HTTP header entry.
+        - `key` – Identifiant name used for the header send on the request.
+        - `value` – Value set for a specific identifiant name.
 
 ## ODBC {#dicts-external_dicts_dict_sources-odbc}
 

--- a/docs/en/query_language/dicts/external_dicts_dict_sources.md
+++ b/docs/en/query_language/dicts/external_dicts_dict_sources.md
@@ -88,12 +88,12 @@ Example of settings:
             <user>user</user>
             <password>password</password>
         </credentials>
-        <http-headers>
-            <http-header>
+        <headers>
+            <header>
                 <name>API-KEY</name>
                 <value>key</value>
-            </http-header>
-        </http-headers>
+            </header>
+        </headers>
     </http>
 </source>
 ```
@@ -108,7 +108,7 @@ Setting fields:
     - `user` – Username required for the authentification.
     - `password` – Password required for the authentification.
 - `headers` – All custom HTTP headers entries used for the HTTP request. Optional parameter.
-    - `http-header` – Single HTTP header entry.
+    - `header` – Single HTTP header entry.
         - `name` – Identifiant name used for the header send on the request.
         - `value` – Value set for a specific identifiant name.
 

--- a/docs/en/query_language/dicts/external_dicts_dict_sources.md
+++ b/docs/en/query_language/dicts/external_dicts_dict_sources.md
@@ -104,10 +104,10 @@ Setting fields:
 
 - `url` – The source URL.
 - `format` – The file format. All the formats described in "[Formats](../../interfaces/formats.md#formats)" are supported.
-- `credentials` – Basic HTTP authentification.
+- `credentials` – Basic HTTP authentification. Optional parameter.
     - `user` – Username required for the authentification.
     - `password` – Password required for the authentification.
-- `http-headers` – All custom HTTP headers entries used for the HTTP request.
+- `headers` – All custom HTTP headers entries used for the HTTP request. Optional parameter.
     - `http-header` – Single HTTP header entry.
         - `key` – Identifiant name used for the header send on the request.
         - `value` – Value set for a specific identifiant name.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- New Feature

Short description (up to few sentences):

Set two configuration options for a dictionary based on an HTTP source. `credentials` and `http-headers`.

Detailed description (optional):

Two options has been made, mostly for improve security when we use a private dataset using an HTTP dictionary.

The first one is `credentials`, used when a server use a basic http auth. With an user and a password.

The second is `http-headers` for set some datas on the HTTP request header. The motivation of it is for service who can possibly get an API key from an header, to be able let ClickHouse get the datas.