### PR TITLE
Add missing verb in readme

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -2,4 +2,4 @@
 
 This directory contain Dockerfiles for `clickhouse-client` and `clickhouse-server`. They updated each release.
 
-Also there is bunch of images for testing and CI. They listed in `images.json` file and updated on each commit to master. If you need to add another image, place information about it into `images.json`.
+Also there is bunch of images for testing and CI. They are listed in `images.json` file and updated on each commit to master. If you need to add another image, place information about it into `images.json`.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Other

Short description (up to few sentences):
Add missing verb in documentation

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>