### PR TITLE
Corrections to tests 00992/00993: changed "ALTER DELETE ..." mutations to be deterministic

### DIFF
--- a/dbms/tests/queries/0_stateless/00993_system_parts_race_condition_drop_zookeeper.sh
+++ b/dbms/tests/queries/0_stateless/00993_system_parts_race_condition_drop_zookeeper.sh
@@ -41,7 +41,7 @@ function thread5()
 {
     while true; do
         REPLICA=$(($RANDOM % 10))
-        $CLICKHOUSE_CLIENT -q "ALTER TABLE alter_table_$REPLICA DELETE WHERE rand() % 2 = 1";
+        $CLICKHOUSE_CLIENT -q "ALTER TABLE alter_table_$REPLICA DELETE WHERE cityHash64(a,b,c,d,e,g) % 1048576 < 524288";
         sleep 0.$RANDOM;
     done
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Some of our tests (00992_system_parts_race_condition + 00993_system_parts_race_condition_drop) contained incorrect `ALTER DELETE` queries that produced different results for different replicas ("non-deterministic" mutations). This made no sense. There are a few additional minor adjustments as well