### PR TITLE
Fix some MemorySanitizer warnings for Fields.

### DIFF
--- a/dbms/src/AggregateFunctions/FactoryHelpers.h
+++ b/dbms/src/AggregateFunctions/FactoryHelpers.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Core/Field.h>
 #include <DataTypes/IDataType.h>
 
 

--- a/dbms/src/AggregateFunctions/IAggregateFunction.h
+++ b/dbms/src/AggregateFunctions/IAggregateFunction.h
@@ -6,7 +6,6 @@
 #include <type_traits>
 
 #include <Core/Types.h>
-#include <Core/Field.h>
 #include <Core/ColumnNumbers.h>
 #include <Core/Block.h>
 #include <Common/Exception.h>

--- a/dbms/src/AggregateFunctions/QuantilesCommon.h
+++ b/dbms/src/AggregateFunctions/QuantilesCommon.h
@@ -2,7 +2,6 @@
 
 #include <vector>
 
-#include <Core/Field.h>
 #include <Common/FieldVisitors.h>
 #include <Common/NaNUtils.h>
 

--- a/dbms/src/Columns/ColumnDecimal.h
+++ b/dbms/src/Columns/ColumnDecimal.h
@@ -5,6 +5,7 @@
 #include <Common/typeid_cast.h>
 #include <Columns/IColumn.h>
 #include <Columns/ColumnVectorHelper.h>
+#include <Core/Field.h>
 
 
 namespace DB

--- a/dbms/src/Columns/ColumnFixedString.h
+++ b/dbms/src/Columns/ColumnFixedString.h
@@ -6,6 +6,7 @@
 #include <Common/assert_cast.h>
 #include <Columns/IColumn.h>
 #include <Columns/ColumnVectorHelper.h>
+#include <Core/Field.h>
 
 
 namespace DB

--- a/dbms/src/Columns/ColumnString.h
+++ b/dbms/src/Columns/ColumnString.h
@@ -9,6 +9,7 @@
 #include <Common/memcpySmall.h>
 #include <Common/memcmpSmall.h>
 #include <Common/assert_cast.h>
+#include <Core/Field.h>
 
 
 class Collator;

--- a/dbms/src/Columns/ColumnVector.h
+++ b/dbms/src/Columns/ColumnVector.h
@@ -4,6 +4,7 @@
 #include <Columns/IColumn.h>
 #include <Columns/ColumnVectorHelper.h>
 #include <common/unaligned.h>
+#include <Core/Field.h>
 
 
 namespace DB

--- a/dbms/src/Columns/IColumn.cpp
+++ b/dbms/src/Columns/IColumn.cpp
@@ -3,6 +3,7 @@
 #include <Columns/IColumn.h>
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnConst.h>
+#include <Core/Field.h>
 
 
 namespace DB
@@ -22,6 +23,11 @@ String IColumn::dumpStructure() const
 
     res << ")";
     return res.str();
+}
+
+void IColumn::insertFrom(const IColumn & src, size_t n)
+{
+    insert(src[n]);
 }
 
 bool isColumnNullable(const IColumn & column)

--- a/dbms/src/Columns/IColumn.h
+++ b/dbms/src/Columns/IColumn.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Core/Field.h>
 #include <Common/COW.h>
 #include <Common/PODArray.h>
 #include <Common/Exception.h>
@@ -23,6 +22,7 @@ namespace ErrorCodes
 
 class Arena;
 class ColumnGathererStream;
+class Field;
 
 /// Declares interface to store columns in memory.
 class IColumn : public COW<IColumn>
@@ -140,7 +140,7 @@ public:
 
     /// Appends n-th element from other column with the same type.
     /// Is used in merge-sort and merges. It could be implemented in inherited classes more optimally than default implementation.
-    virtual void insertFrom(const IColumn & src, size_t n) { insert(src[n]); }
+    virtual void insertFrom(const IColumn & src, size_t n);
 
     /// Appends range of elements from other column with the same type.
     /// Could be used to concatenate columns.

--- a/dbms/src/Common/MemorySanitizer.h
+++ b/dbms/src/Common/MemorySanitizer.h
@@ -1,9 +1,13 @@
 #pragma once
 
 #define __msan_unpoison(X, Y)
+#define __msan_test_shadow(X, Y) (false)
+#define __msan_print_shadow(X, Y)
 #if defined(__has_feature)
 #   if __has_feature(memory_sanitizer)
 #       undef __msan_unpoison
+#       undef __msan_test_shadow
+#       undef __msan_print_shadow
 #       include <sanitizer/msan_interface.h>
 #   endif
 #endif

--- a/dbms/src/Compression/ICompressionCodec.h
+++ b/dbms/src/Compression/ICompressionCodec.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <memory>
-#include <Core/Field.h>
 #include <IO/ReadBuffer.h>
 #include <IO/WriteBuffer.h>
 #include <IO/BufferWithOwnMemory.h>

--- a/dbms/src/DataTypes/DataTypeEnum.cpp
+++ b/dbms/src/DataTypes/DataTypeEnum.cpp
@@ -115,7 +115,7 @@ void DataTypeEnum<Type>::deserializeBinary(Field & field, ReadBuffer & istr) con
 {
     FieldType x;
     readBinary(x, istr);
-    field = nearestFieldType(x);
+    field = castToNearestFieldType(x);
 }
 
 template <typename Type>

--- a/dbms/src/Dictionaries/IDictionary.h
+++ b/dbms/src/Dictionaries/IDictionary.h
@@ -1,7 +1,6 @@
 #pragma once
 
 
-#include <Core/Field.h>
 #include <Core/Names.h>
 #include <DataStreams/IBlockStream_fwd.h>
 #include <Interpreters/IExternalLoadable.h>

--- a/dbms/src/Functions/FunctionsComparison.h
+++ b/dbms/src/Functions/FunctionsComparison.h
@@ -891,7 +891,7 @@ private:
     {
         const auto type = static_cast<const EnumType *>(type_untyped);
 
-        const Field x = nearestFieldType(type->getValue(column_string->getValue<String>()));
+        const Field x = castToNearestFieldType(type->getValue(column_string->getValue<String>()));
         const auto enum_col = type->createColumnConst(input_rows_count, x);
 
         executeNumLeftType<typename EnumType::FieldType>(block, result,

--- a/dbms/src/Functions/FunctionsStringRegex.h
+++ b/dbms/src/Functions/FunctionsStringRegex.h
@@ -5,7 +5,6 @@
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnVector.h>
 #include <Columns/ColumnsNumber.h>
-#include <Core/Field.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>

--- a/dbms/src/Functions/FunctionsStringSearch.h
+++ b/dbms/src/Functions/FunctionsStringSearch.h
@@ -4,7 +4,6 @@
 #include <Columns/ColumnConst.h>
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnVector.h>
-#include <Core/Field.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>

--- a/dbms/src/Functions/IFunction.h
+++ b/dbms/src/Functions/IFunction.h
@@ -4,7 +4,6 @@
 
 #include "config_core.h"
 #include <Core/Names.h>
-#include <Core/Field.h>
 #include <Core/Block.h>
 #include <Core/ColumnNumbers.h>
 #include <DataTypes/IDataType.h>
@@ -27,6 +26,8 @@ namespace ErrorCodes
     extern const int NOT_IMPLEMENTED;
     extern const int LOGICAL_ERROR;
 }
+
+class Field;
 
 /// The simplest executable object.
 /// Motivation:

--- a/dbms/src/Interpreters/QueryLog.h
+++ b/dbms/src/Interpreters/QueryLog.h
@@ -22,7 +22,7 @@ namespace DB
 /// A struct which will be inserted as row into query_log table
 struct QueryLogElement
 {
-    enum Type
+    enum Type : UInt8 // Make it signed for compatibility with DataTypeEnum8
     {
         QUERY_START = 1,
         QUERY_FINISH = 2,

--- a/dbms/src/Interpreters/TraceLog.h
+++ b/dbms/src/Interpreters/TraceLog.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Core/Field.h>
 #include <Common/QueryProfiler.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeEnum.h>

--- a/dbms/src/Processors/Chunk.cpp
+++ b/dbms/src/Processors/Chunk.cpp
@@ -7,6 +7,7 @@ namespace DB
 
 namespace ErrorCodes
 {
+    extern const int LOGICAL_ERROR;
     extern const int POSITION_OUT_OF_BOUND;
 }
 

--- a/dbms/src/Storages/System/StorageSystemParts.cpp
+++ b/dbms/src/Storages/System/StorageSystemParts.cpp
@@ -95,8 +95,8 @@ void StorageSystemParts::processNextStorage(MutableColumns & columns_, const Sto
 
         columns_[i++]->insert(part->getMinDate());
         columns_[i++]->insert(part->getMaxDate());
-        columns_[i++]->insert(part->getMinTime());
-        columns_[i++]->insert(part->getMaxTime());
+        columns_[i++]->insert(static_cast<UInt32>(part->getMinTime()));
+        columns_[i++]->insert(static_cast<UInt32>(part->getMaxTime()));
         columns_[i++]->insert(part->info.partition_id);
         columns_[i++]->insert(part->info.min_block);
         columns_[i++]->insert(part->info.max_block);


### PR DESCRIPTION
Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Fix some problems when working with variant values. Found with MemorySanitizer.