### PR TITLE
Avoid use of uninitialized values in MetricsTransmitter

### DIFF
--- a/dbms/programs/server/MetricsTransmitter.cpp
+++ b/dbms/programs/server/MetricsTransmitter.cpp
@@ -24,6 +24,8 @@ MetricsTransmitter::MetricsTransmitter(
     send_events_cumulative = config.getBool(config_name + ".events_cumulative", false);
     send_metrics = config.getBool(config_name + ".metrics", true);
     send_asynchronous_metrics = config.getBool(config_name + ".asynchronous_metrics", true);
+
+    thread = ThreadFromGlobalPool{&MetricsTransmitter::run, this};
 }
 
 
@@ -38,7 +40,7 @@ MetricsTransmitter::~MetricsTransmitter()
 
         cond.notify_one();
 
-        thread.join();
+        thread->join();
     }
     catch (...)
     {

--- a/dbms/programs/server/MetricsTransmitter.h
+++ b/dbms/programs/server/MetricsTransmitter.h
@@ -5,8 +5,10 @@
 #include <string>
 #include <thread>
 #include <vector>
-#include <Common/ProfileEvents.h>
+#include <optional>
+#include <Core/Types.h>
 #include <Common/ThreadPool.h>
+#include <Common/ProfileEvents.h>
 
 
 namespace Poco
@@ -52,7 +54,7 @@ private:
     bool quit = false;
     std::mutex mutex;
     std::condition_variable cond;
-    ThreadFromGlobalPool thread{&MetricsTransmitter::run, this};
+    std::optional<ThreadFromGlobalPool> thread;
 
     static inline constexpr auto profile_events_path_prefix = "ClickHouse.ProfileEvents.";
     static inline constexpr auto profile_events_cumulative_path_prefix = "ClickHouse.ProfileEventsCumulative.";


### PR DESCRIPTION
Category (leave one):
- Bug Fix

Short description (up to few sentences):

Avoid use of uninitialized values in MetricsTransmitter

Detailed description (optional):

Defer thread creation after values had been initialized correctly.