### PR TITLE
Backport to 19.11: Avoid SIGSEGV on batch send failure (file with index XX is absent)

### DIFF
--- a/dbms/src/Storages/Distributed/DirectoryMonitor.cpp
+++ b/dbms/src/Storages/Distributed/DirectoryMonitor.cpp
@@ -387,7 +387,8 @@ struct StorageDistributedDirectoryMonitor::Batch
                 remote->writePrepared(in);
             }
 
-            remote->writeSuffix();
+            if (remote)
+                remote->writeSuffix();
         }
         catch (const Exception & e)
         {


### PR DESCRIPTION
Avoid SIGSEGV on batch send failure (file with index XX is absent)

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Other

Short description (up to few sentences):
Backport from #7032