### PR TITLE
Backport to 19.11: Fix msan for LowCardinality

### DIFF
--- a/dbms/src/Core/Block.cpp
+++ b/dbms/src/Core/Block.cpp
@@ -217,11 +217,14 @@ size_t Block::getPositionByName(const std::string & name) const
 }
 
 
-void Block::checkNumberOfRows() const
+void Block::checkNumberOfRows(bool allow_null_columns) const
 {
     ssize_t rows = -1;
     for (const auto & elem : data)
     {
+        if (!elem.column && allow_null_columns)
+            continue;
+
         if (!elem.column)
             throw Exception("Column " + elem.name + " in block is nullptr, in method checkNumberOfRows."
                 , ErrorCodes::SIZES_OF_COLUMNS_DOESNT_MATCH);

--- a/dbms/src/Core/Block.h
+++ b/dbms/src/Core/Block.h
@@ -90,7 +90,7 @@ public:
     size_t columns() const { return data.size(); }
 
     /// Checks that every column in block is not nullptr and has same number of elements.
-    void checkNumberOfRows() const;
+    void checkNumberOfRows(bool allow_null_columns = false) const;
 
     /// Approximate number of bytes in memory - for profiling and limits.
     size_t bytes() const;

--- a/dbms/src/Functions/IFunction.cpp
+++ b/dbms/src/Functions/IFunction.cpp
@@ -336,19 +336,43 @@ static ColumnPtr replaceLowCardinalityColumnsByNestedAndGetDictionaryIndexes(
     size_t num_rows = input_rows_count;
     ColumnPtr indexes;
 
+    /// Find first LowCardinality column and replace it to nested dictionary.
     for (auto arg : args)
     {
         ColumnWithTypeAndName & column = block.getByPosition(arg);
         if (auto * low_cardinality_column = checkAndGetColumn<ColumnLowCardinality>(column.column.get()))
         {
+            /// Single LowCardinality column is supported now.
             if (indexes)
                 throw Exception("Expected single dictionary argument for function.", ErrorCodes::LOGICAL_ERROR);
 
-            indexes = low_cardinality_column->getIndexesPtr();
-            num_rows = low_cardinality_column->getDictionary().size();
+            auto * low_cardinality_type = checkAndGetDataType<DataTypeLowCardinality>(column.type.get());
+
+            if (!low_cardinality_type)
+                throw Exception("Incompatible type for low cardinality column: " + column.type->getName(),
+                                ErrorCodes::LOGICAL_ERROR);
+
+            if (can_be_executed_on_default_arguments)
+            {
+                /// Normal case, when function can be executed on values's default.
+                column.column = low_cardinality_column->getDictionary().getNestedColumn();
+                indexes = low_cardinality_column->getIndexesPtr();
+            }
+            else
+            {
+                /// Special case when default value can't be used. Example: 1 % LowCardinality(Int).
+                /// LowCardinality always contains default, so 1 % 0 will throw exception in normal case.
+                auto dict_encoded = low_cardinality_column->getMinimalDictionaryEncodedColumn(0, low_cardinality_column->size());
+                column.column = dict_encoded.dictionary;
+                indexes = dict_encoded.indexes;
+            }
+
+            num_rows = column.column->size();
+            column.type = low_cardinality_type->getDictionaryType();
         }
     }
 
+    /// Change size of constants.
     for (auto arg : args)
     {
         ColumnWithTypeAndName & column = block.getByPosition(arg);
@@ -357,25 +381,11 @@ static ColumnPtr replaceLowCardinalityColumnsByNestedAndGetDictionaryIndexes(
             column.column = column_const->removeLowCardinality()->cloneResized(num_rows);
             column.type = removeLowCardinality(column.type);
         }
-        else if (auto * low_cardinality_column = checkAndGetColumn<ColumnLowCardinality>(column.column.get()))
-        {
-            auto * low_cardinality_type = checkAndGetDataType<DataTypeLowCardinality>(column.type.get());
-
-            if (!low_cardinality_type)
-                throw Exception("Incompatible type for low cardinality column: " + column.type->getName(),
-                                ErrorCodes::LOGICAL_ERROR);
-
-            if (can_be_executed_on_default_arguments)
-                column.column = low_cardinality_column->getDictionary().getNestedColumn();
-            else
-            {
-                auto dict_encoded = low_cardinality_column->getMinimalDictionaryEncodedColumn(0, low_cardinality_column->size());
-                column.column = dict_encoded.dictionary;
-                indexes = dict_encoded.indexes;
-            }
-            column.type = low_cardinality_type->getDictionaryType();
-        }
     }
+
+#ifndef NDEBUG
+    block.checkNumberOfRows(true);
+#endif
 
     return indexes;
 }


### PR DESCRIPTION
Backport to 19.11: Fix msan for LowCardinality
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Other

Short description (up to few sentences):
backport #7062 to 19.11
