### PR TITLE
Fixed time calculation in `MergeTreeData`.

### DIFF
--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3357,7 +3357,7 @@ try
 
     part_log_elem.event_time = time(nullptr);
     /// TODO: Stop stopwatch in outer code to exclude ZK timings and so on
-    part_log_elem.duration_ms = elapsed_ns / 10000000;
+    part_log_elem.duration_ms = elapsed_ns / 1000000;
 
     part_log_elem.database_name = database_name;
     part_log_elem.table_name = table_name;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

The bug was introduced at 
https://github.com/ClickHouse/ClickHouse/commit/59fe12ed15e03c602f472e14e6b3dc9062cc589e#diff-df22870de8c9f30baaf8be33ab11c18eL1192

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fixed wrong `duration_ms` value in `system.part_log` table. It was ten times off.

Detailed description (optional):

...
