### PR TITLE
Add missing linking with PocoXML for clickhouse_common_io

### DIFF
--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -256,6 +256,7 @@ target_link_libraries (clickhouse_common_io
     ${Poco_Net_LIBRARY}
     ${Poco_Util_LIBRARY}
     ${Poco_Foundation_LIBRARY}
+    ${Poco_XML_LIBRARY}
 )
 
 if(RE2_LIBRARY)


### PR DESCRIPTION
Otherwise unbundled build fail with:
```
  FAILED: dbms/libclickhouse_common_iod.so
  ...
  ../dbms/src/IO/WriteBufferFromS3.cpp:143: error: undefined reference to 'Poco::XML::InputSource::InputSource(std::istream&)'
  ../dbms/src/IO/WriteBufferFromS3.cpp:144: error: undefined reference to 'Poco::XML::DOMParser::DOMParser(Poco::XML::NamePool*)'
  ../dbms/src/IO/WriteBufferFromS3.cpp:145: error: undefined reference to 'Poco::XML::DOMParser::parse(Poco::XML::InputSource*)'
  ../dbms/src/IO/WriteBufferFromS3.cpp:146: error: undefined reference to 'Poco::XML::Document::getElementsByTagName(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const'
  ../dbms/src/IO/WriteBufferFromS3.cpp:144: error: undefined reference to 'Poco::XML::DOMParser::~DOMParser()'
  ../dbms/src/IO/WriteBufferFromS3.cpp:143: error: undefined reference to 'Poco::XML::InputSource::~InputSource()'
  ../dbms/src/IO/WriteBufferFromS3.cpp:144: error: undefined reference to 'Poco::XML::DOMParser::~DOMParser()'
  ../dbms/src/IO/WriteBufferFromS3.cpp:143: error: undefined reference to 'Poco::XML::InputSource::~InputSource()'
  collect2: error: ld returned 1 exit status
```
Category:
Non-significant change.

