### PR TITLE
Fix uniqCombined() result for >UINT_MAX values (return UInt64 to avoid overflow)

### DIFF
--- a/dbms/src/Common/CombinedCardinalityEstimator.h
+++ b/dbms/src/Common/CombinedCardinalityEstimator.h
@@ -106,7 +106,7 @@ public:
             getContainer<Large>().insert(value);
     }
 
-    UInt32 size() const
+    UInt64 size() const
     {
         auto container_type = getContainerType();
 


### PR DESCRIPTION
Category:
- Bug Fix

Short description (up to few sentences):

Fix uniqCombined() result for >UINT_MAX values (return UInt64 to avoid overflow)

Detailed description (optional):

uniqCombined() return type is UInt64, but uniqCombined() uses
CombinedCardinalityEstimator, and CombinedCardinalityEstimator::size()
return type is UInt32, while the underlying HyperLogLog::size() is
UInt64.

So after this patch uniqCombined() can be used for >UINT_MAX values, the
outcome is not ideal (#2073) but at least sane.