### PR TITLE
Accept multiple test filter arguments in clickhouse-test.

### DIFF
--- a/dbms/tests/clickhouse-test
+++ b/dbms/tests/clickhouse-test
@@ -364,7 +364,7 @@ def main(args):
 
             all_tests = os.listdir(suite_dir)
             all_tests = filter(lambda case: is_test_from_dir(suite_dir, case), all_tests)
-            all_tests = sorted(filter(lambda case: re.search(args.test, case) if args.test else True, all_tests), key=key_func)
+            all_tests = [t for t in all_tests if any([re.search(r, t) for r in args.test])]
 
             run_n, run_total = args.parallel.split('/')
             run_n = float(run_n)
@@ -437,7 +437,7 @@ if __name__ == '__main__':
     parser.add_argument('--configserver', default= '/etc/clickhouse-server/config.xml', help='Preprocessed server config')
     parser.add_argument('-o', '--output', help='Output xUnit compliant test report directory')
     parser.add_argument('-t', '--timeout', type=int, default=600, help='Timeout for each test case in seconds')
-    parser.add_argument('test', nargs='?', help='Optional test case name regex')
+    parser.add_argument('test', nargs='*', help='Optional test case name regex')
     parser.add_argument('-d', '--disabled', action='store_true', default=False, help='Also run disabled tests')
     parser.add_argument('--stop', action='store_true', default=None, dest='stop', help='Stop on network errors')
     parser.add_argument('--order', default='desc', help='Run order (asc, desc, random)')


### PR DESCRIPTION
Sometimes it is more convenient to supply space-separated test names
without having to concatenate them into one regex with pipes.

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Accept multiple test filter arguments in clickhouse-test.
