### PR TITLE
Include PODArray.h into fewer files.

### DIFF
--- a/dbms/src/AggregateFunctions/AggregateFunctionGroupBitmap.cpp
+++ b/dbms/src/AggregateFunctions/AggregateFunctionGroupBitmap.cpp
@@ -1,8 +1,11 @@
 #include <AggregateFunctions/AggregateFunctionFactory.h>
-#include <AggregateFunctions/AggregateFunctionGroupBitmap.h>
 #include <AggregateFunctions/Helpers.h>
 #include <AggregateFunctions/FactoryHelpers.h>
 #include <DataTypes/DataTypeAggregateFunction.h>
+
+// TODO include this last because of a broken roaring header. See the comment
+// inside.
+#include <AggregateFunctions/AggregateFunctionGroupBitmap.h>
 
 namespace DB
 {

--- a/dbms/src/AggregateFunctions/AggregateFunctionGroupBitmap.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionGroupBitmap.h
@@ -3,9 +3,12 @@
 #include <Columns/ColumnVector.h>
 #include <Common/assert_cast.h>
 #include <AggregateFunctions/IAggregateFunction.h>
-#include <AggregateFunctions/AggregateFunctionGroupBitmapData.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <Columns/ColumnAggregateFunction.h>
+
+// TODO include this last because of a broken roaring header. See the comment
+// inside.
+#include <AggregateFunctions/AggregateFunctionGroupBitmapData.h>
 
 namespace DB
 {

--- a/dbms/src/AggregateFunctions/AggregateFunctionGroupBitmapData.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionGroupBitmapData.h
@@ -1,13 +1,17 @@
 #pragma once
 
 #include <algorithm>
-#include <roaring/roaring.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
 #include <boost/noncopyable.hpp>
-#include <roaring/roaring.hh>
 #include <Common/HashTable/SmallTable.h>
 #include <Common/PODArray.h>
+
+// Include this header last, because it is an auto-generated dump of questionable
+// garbage that breaks the build (e.g. it changes _POSIX_C_SOURCE).
+// TODO: find out what it is. On github, they have proper inteface headers like
+// this one: https://github.com/RoaringBitmap/CRoaring/blob/master/include/roaring/roaring.h
+#include <roaring/roaring.h>
 
 namespace DB
 {

--- a/dbms/src/Client/ConnectionPoolWithFailover.cpp
+++ b/dbms/src/Client/ConnectionPoolWithFailover.cpp
@@ -3,6 +3,7 @@
 #include <Poco/Net/NetException.h>
 #include <Poco/Net/DNS.h>
 
+#include <Common/BitHelpers.h>
 #include <Common/getFQDNOrHostName.h>
 #include <Common/isLocalAddress.h>
 #include <Common/ProfileEvents.h>

--- a/dbms/src/Columns/ColumnAggregateFunction.h
+++ b/dbms/src/Columns/ColumnAggregateFunction.h
@@ -3,6 +3,7 @@
 #include <AggregateFunctions/IAggregateFunction.h>
 
 #include <Columns/IColumn.h>
+#include <Common/PODArray.h>
 
 #include <Core/Field.h>
 

--- a/dbms/src/Columns/ColumnArray.h
+++ b/dbms/src/Columns/ColumnArray.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Columns/IColumn.h>
+#include <Columns/IColumnImpl.h>
 #include <Columns/ColumnVector.h>
 #include <Core/Defines.h>
 #include <Common/typeid_cast.h>

--- a/dbms/src/Columns/ColumnConst.cpp
+++ b/dbms/src/Columns/ColumnConst.cpp
@@ -2,6 +2,7 @@
 
 #include <Columns/ColumnConst.h>
 #include <Columns/ColumnsCommon.h>
+#include <Common/PODArray.h>
 #include <Common/typeid_cast.h>
 
 

--- a/dbms/src/Columns/ColumnDecimal.h
+++ b/dbms/src/Columns/ColumnDecimal.h
@@ -4,6 +4,7 @@
 
 #include <Common/typeid_cast.h>
 #include <Columns/IColumn.h>
+#include <Columns/IColumnImpl.h>
 #include <Columns/ColumnVectorHelper.h>
 #include <Core/Field.h>
 

--- a/dbms/src/Columns/ColumnFixedString.h
+++ b/dbms/src/Columns/ColumnFixedString.h
@@ -5,6 +5,7 @@
 #include <Common/typeid_cast.h>
 #include <Common/assert_cast.h>
 #include <Columns/IColumn.h>
+#include <Columns/IColumnImpl.h>
 #include <Columns/ColumnVectorHelper.h>
 #include <Core/Field.h>
 

--- a/dbms/src/Columns/ColumnFunction.cpp
+++ b/dbms/src/Columns/ColumnFunction.cpp
@@ -1,6 +1,7 @@
 #include <Interpreters/ExpressionActions.h>
 #include <Columns/ColumnFunction.h>
 #include <Columns/ColumnsCommon.h>
+#include <Common/PODArray.h>
 #include <IO/WriteHelpers.h>
 #include <Functions/IFunction.h>
 

--- a/dbms/src/Columns/ColumnNullable.h
+++ b/dbms/src/Columns/ColumnNullable.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Columns/IColumn.h>
+#include <Columns/IColumnImpl.h>
 #include <Columns/ColumnsNumber.h>
 #include <Common/typeid_cast.h>
 #include <Common/assert_cast.h>

--- a/dbms/src/Columns/ColumnString.h
+++ b/dbms/src/Columns/ColumnString.h
@@ -4,6 +4,7 @@
 #include <cassert>
 
 #include <Columns/IColumn.h>
+#include <Columns/IColumnImpl.h>
 #include <Common/PODArray.h>
 #include <Common/SipHash.h>
 #include <Common/memcpySmall.h>

--- a/dbms/src/Columns/ColumnVector.h
+++ b/dbms/src/Columns/ColumnVector.h
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <Columns/IColumn.h>
+#include <Columns/IColumnImpl.h>
 #include <Columns/ColumnVectorHelper.h>
 #include <common/unaligned.h>
 #include <Core/Field.h>

--- a/dbms/src/Columns/IColumn.h
+++ b/dbms/src/Columns/IColumn.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include <Common/COW.h>
-#include <Common/PODArray.h>
+#include <Common/PODArray_fwd.h>
 #include <Common/Exception.h>
 #include <Common/typeid_cast.h>
 #include <common/StringRef.h>
+#include <Core/Types.h>
 
 
 class SipHash;
@@ -373,32 +374,7 @@ protected:
     /// Template is to devirtualize calls to insertFrom method.
     /// In derived classes (that use final keyword), implement scatter method as call to scatterImpl.
     template <typename Derived>
-    std::vector<MutablePtr> scatterImpl(ColumnIndex num_columns, const Selector & selector) const
-    {
-        size_t num_rows = size();
-
-        if (num_rows != selector.size())
-            throw Exception(
-                    "Size of selector: " + std::to_string(selector.size()) + " doesn't match size of column: " + std::to_string(num_rows),
-                    ErrorCodes::SIZES_OF_COLUMNS_DOESNT_MATCH);
-
-        std::vector<MutablePtr> columns(num_columns);
-        for (auto & column : columns)
-            column = cloneEmpty();
-
-        {
-            size_t reserve_size = num_rows * 1.1 / num_columns;    /// 1.1 is just a guess. Better to use n-sigma rule.
-
-            if (reserve_size > 1)
-                for (auto & column : columns)
-                    column->reserve(reserve_size);
-        }
-
-        for (size_t i = 0; i < num_rows; ++i)
-            static_cast<Derived &>(*columns[selector[i]]).insertFrom(*this, i);
-
-        return columns;
-    }
+    std::vector<MutablePtr> scatterImpl(ColumnIndex num_columns, const Selector & selector) const;
 };
 
 using ColumnPtr = IColumn::Ptr;

--- a/dbms/src/Columns/IColumnDummy.h
+++ b/dbms/src/Columns/IColumnDummy.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Common/Arena.h>
+#include <Common/PODArray.h>
 #include <Columns/IColumn.h>
 #include <Columns/ColumnsCommon.h>
 

--- a/dbms/src/Columns/IColumnImpl.h
+++ b/dbms/src/Columns/IColumnImpl.h
@@ -1,0 +1,45 @@
+/**
+  * This file implements template methods of IColumn that depend on other types
+  * we don't want to include.
+  * Currently, this is only the scatterImpl method that depends on PODArray
+  * implementation.
+  */
+
+#pragma once
+
+#include <Columns/IColumn.h>
+#include <Common/PODArray.h>
+
+namespace DB
+{
+
+template <typename Derived>
+std::vector<IColumn::MutablePtr> IColumn::scatterImpl(ColumnIndex num_columns,
+                                             const Selector & selector) const
+{
+    size_t num_rows = size();
+
+    if (num_rows != selector.size())
+        throw Exception(
+                "Size of selector: " + std::to_string(selector.size()) + " doesn't match size of column: " + std::to_string(num_rows),
+                ErrorCodes::SIZES_OF_COLUMNS_DOESNT_MATCH);
+
+    std::vector<MutablePtr> columns(num_columns);
+    for (auto & column : columns)
+        column = cloneEmpty();
+
+    {
+        size_t reserve_size = num_rows * 1.1 / num_columns;    /// 1.1 is just a guess. Better to use n-sigma rule.
+
+        if (reserve_size > 1)
+            for (auto & column : columns)
+                column->reserve(reserve_size);
+    }
+
+    for (size_t i = 0; i < num_rows; ++i)
+        static_cast<Derived &>(*columns[selector[i]]).insertFrom(*this, i);
+
+    return columns;
+}
+
+}

--- a/dbms/src/Common/Allocator.h
+++ b/dbms/src/Common/Allocator.h
@@ -30,6 +30,8 @@
 #include <Common/Exception.h>
 #include <Common/formatReadable.h>
 
+#include <Common/Allocator_fwd.h>
+
 
 /// Required for older Darwin builds, that lack definition of MAP_ANONYMOUS
 #ifndef MAP_ANONYMOUS
@@ -84,7 +86,7 @@ namespace ErrorCodes
   * - random hint address for mmap
   * - mmap_threshold for using mmap less or more
   */
-template <bool clear_memory_, bool mmap_populate = false>
+template <bool clear_memory_, bool mmap_populate>
 class Allocator
 {
 public:
@@ -270,7 +272,7 @@ private:
 
 /** Allocator with optimization to place small memory ranges in automatic memory.
   */
-template <typename Base, size_t N = 64, size_t Alignment = 1>
+template <typename Base, size_t N, size_t Alignment>
 class AllocatorWithStackMemory : private Base
 {
 private:

--- a/dbms/src/Common/Allocator_fwd.h
+++ b/dbms/src/Common/Allocator_fwd.h
@@ -1,0 +1,10 @@
+/**
+  * This file provides forward declarations for Allocator.
+  */
+#pragma once
+
+template <bool clear_memory_, bool mmap_populate = false>
+class Allocator;
+
+template <typename Base, size_t N = 64, size_t Alignment = 1>
+class AllocatorWithStackMemory;

--- a/dbms/src/Common/PODArray_fwd.h
+++ b/dbms/src/Common/PODArray_fwd.h
@@ -1,0 +1,35 @@
+/**
+  * This file contains some using-declarations that define various kinds of
+  * PODArray.
+  */
+#pragma once
+
+#include <Common/Allocator_fwd.h>
+
+namespace DB
+{
+
+inline constexpr size_t integerRoundUp(size_t value, size_t dividend)
+{
+    return ((value + dividend - 1) / dividend) * dividend;
+}
+
+template <typename T, size_t initial_bytes = 4096,
+          typename TAllocator = Allocator<false>, size_t pad_right_ = 0,
+          size_t pad_left_ = 0>
+class PODArray;
+
+/** For columns. Padding is enough to read and write xmm-register at the address of the last element. */
+template <typename T, size_t initial_bytes = 4096, typename TAllocator = Allocator<false>>
+using PaddedPODArray = PODArray<T, initial_bytes, TAllocator, 15, 16>;
+
+/** A helper for declaring PODArray that uses inline memory.
+  * The initial size is set to use all the inline bytes, since using less would
+  * only add some extra allocation calls.
+  */
+template <typename T, size_t inline_bytes,
+          size_t rounded_bytes = integerRoundUp(inline_bytes, sizeof(T))>
+using PODArrayWithStackMemory = PODArray<T, rounded_bytes,
+    AllocatorWithStackMemory<Allocator<false>, rounded_bytes, alignof(T)>>;
+
+}

--- a/dbms/src/Common/formatReadable.h
+++ b/dbms/src/Common/formatReadable.h
@@ -1,8 +1,13 @@
 #pragma once
 
 #include <string>
-#include <IO/WriteBuffer.h>
 
+namespace DB
+{
+
+class WriteBuffer;
+
+}
 
 /// Displays the passed size in bytes as 123.45 GiB.
 void formatReadableSizeWithBinarySuffix(double value, DB::WriteBuffer & out, int precision = 2);

--- a/dbms/src/Compression/CompressionCodecMultiple.cpp
+++ b/dbms/src/Compression/CompressionCodecMultiple.cpp
@@ -1,5 +1,6 @@
 #include <Compression/CompressionCodecMultiple.h>
 #include <Compression/CompressionInfo.h>
+#include <Common/PODArray.h>
 #include <common/unaligned.h>
 #include <Compression/CompressionFactory.h>
 #include <IO/ReadHelpers.h>

--- a/dbms/src/Compression/ICompressionCodec.h
+++ b/dbms/src/Compression/ICompressionCodec.h
@@ -4,7 +4,6 @@
 #include <IO/ReadBuffer.h>
 #include <IO/WriteBuffer.h>
 #include <IO/BufferWithOwnMemory.h>
-#include <Common/PODArray.h>
 #include <DataTypes/IDataType.h>
 #include <boost/noncopyable.hpp>
 #include <IO/UncompressedCache.h>

--- a/dbms/src/DataStreams/LimitByBlockInputStream.cpp
+++ b/dbms/src/DataStreams/LimitByBlockInputStream.cpp
@@ -1,4 +1,5 @@
 #include <DataStreams/LimitByBlockInputStream.h>
+#include <Common/PODArray.h>
 #include <Common/SipHash.h>
 
 

--- a/dbms/src/DataStreams/ReverseBlockInputStream.cpp
+++ b/dbms/src/DataStreams/ReverseBlockInputStream.cpp
@@ -1,5 +1,7 @@
 #include "ReverseBlockInputStream.h"
 
+#include <Common/PODArray.h>
+
 namespace DB
 {
     ReverseBlockInputStream::ReverseBlockInputStream(const BlockInputStreamPtr & input)

--- a/dbms/src/Functions/FunctionsBitmap.cpp
+++ b/dbms/src/Functions/FunctionsBitmap.cpp
@@ -1,4 +1,7 @@
 #include <Functions/FunctionFactory.h>
+
+// TODO include this last because of a broken roaring header. See the comment
+// inside.
 #include <Functions/FunctionsBitmap.h>
 
 

--- a/dbms/src/Functions/FunctionsBitmap.h
+++ b/dbms/src/Functions/FunctionsBitmap.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <AggregateFunctions/AggregateFunctionFactory.h>
-#include <AggregateFunctions/AggregateFunctionGroupBitmapData.h>
 #include <Columns/ColumnAggregateFunction.h>
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnConst.h>
@@ -15,6 +14,9 @@
 #include <Common/typeid_cast.h>
 #include <Common/assert_cast.h>
 
+// TODO include this last because of a broken roaring header. See the comment
+// inside.
+#include <AggregateFunctions/AggregateFunctionGroupBitmapData.h>
 
 namespace DB
 {

--- a/dbms/src/Functions/FunctionsJSON.h
+++ b/dbms/src/Functions/FunctionsJSON.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Functions/IFunction.h>
+#include <Core/AccurateComparison.h>
 #include <Functions/DummyJSONParser.h>
 #include <Functions/SimdJSONParser.h>
 #include <Functions/RapidJSONParser.h>
@@ -8,7 +9,6 @@
 #include <Common/CpuId.h>
 #include <Common/typeid_cast.h>
 #include <Common/assert_cast.h>
-#include <Core/AccurateComparison.h>
 #include <Core/Settings.h>
 #include <Columns/ColumnConst.h>
 #include <Columns/ColumnString.h>

--- a/dbms/src/Interpreters/ActionsVisitor.cpp
+++ b/dbms/src/Interpreters/ActionsVisitor.cpp
@@ -1,4 +1,5 @@
 #include <Common/typeid_cast.h>
+#include <Common/PODArray.h>
 
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionsMiscellaneous.h>

--- a/dbms/src/Interpreters/executeQuery.cpp
+++ b/dbms/src/Interpreters/executeQuery.cpp
@@ -1,4 +1,5 @@
 #include <Common/formatReadable.h>
+#include <Common/PODArray.h>
 #include <Common/typeid_cast.h>
 
 #include <IO/ConcatReadBuffer.h>

--- a/dbms/src/Processors/Formats/Impl/PrettyBlockOutputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/PrettyBlockOutputFormat.cpp
@@ -5,6 +5,7 @@
 #include <IO/WriteBuffer.h>
 #include <IO/WriteHelpers.h>
 #include <IO/WriteBufferFromString.h>
+#include <Common/PODArray.h>
 #include <Common/UTF8Helpers.h>
 
 

--- a/dbms/src/Processors/Formats/Impl/PrettyCompactBlockOutputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/PrettyCompactBlockOutputFormat.cpp
@@ -1,3 +1,4 @@
+#include <Common/PODArray.h>
 #include <IO/WriteBuffer.h>
 #include <IO/WriteHelpers.h>
 ///#include <DataStreams/SquashingBlockOutputStream.h>

--- a/dbms/src/Processors/Formats/Impl/PrettySpaceBlockOutputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/PrettySpaceBlockOutputFormat.cpp
@@ -1,3 +1,4 @@
+#include <Common/PODArray.h>
 #include <IO/WriteBuffer.h>
 #include <IO/WriteHelpers.h>
 #include <Formats/FormatFactory.h>

--- a/dbms/src/Processors/Port.h
+++ b/dbms/src/Processors/Port.h
@@ -6,8 +6,10 @@
 #include <cstdint>
 
 #include <Core/Block.h>
+#include <Core/Defines.h>
 #include <Processors/Chunk.h>
 #include <Common/Exception.h>
+#include <common/likely.h>
 
 namespace DB
 {

--- a/dbms/src/Processors/Transforms/LimitByTransform.cpp
+++ b/dbms/src/Processors/Transforms/LimitByTransform.cpp
@@ -1,4 +1,5 @@
 #include <Processors/Transforms/LimitByTransform.h>
+#include <Common/PODArray.h>
 #include <Common/SipHash.h>
 
 namespace DB

--- a/dbms/src/Storages/Distributed/DistributedBlockOutputStream.h
+++ b/dbms/src/Storages/Distributed/DistributedBlockOutputStream.h
@@ -3,6 +3,7 @@
 #include <Parsers/formatAST.h>
 #include <DataStreams/IBlockOutputStream.h>
 #include <Core/Block.h>
+#include <Common/PODArray.h>
 #include <Common/Throttler.h>
 #include <Common/ThreadPool.h>
 #include <atomic>


### PR DESCRIPTION
The number of files including PODArray.h is reduced by 200, from 970 to 770. The total preprocessed source size is reduced by 120 MB, from 5.24 GB to 5.12 GB.

Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Optimize some header files for faster rebuilds.
