### PR TITLE
Do not convert a NULL Field to a non-nullable data type.

### DIFF
--- a/dbms/src/Columns/ColumnTuple.cpp
+++ b/dbms/src/Columns/ColumnTuple.cpp
@@ -94,16 +94,17 @@ MutableColumnPtr ColumnTuple::cloneResized(size_t new_size) const
 
 Field ColumnTuple::operator[](size_t n) const
 {
-    return Tuple{ext::map<TupleBackend>(columns, [n] (const auto & column) { return (*column)[n]; })};
+    return ext::map<Tuple>(columns, [n] (const auto & column) { return (*column)[n]; });
 }
 
 void ColumnTuple::get(size_t n, Field & res) const
 {
     const size_t tuple_size = columns.size();
-    res = Tuple(TupleBackend(tuple_size));
-    TupleBackend & res_arr = DB::get<Tuple &>(res).toUnderType();
+    Tuple tuple(tuple_size);
     for (const auto i : ext::range(0, tuple_size))
-        columns[i]->get(n, res_arr[i]);
+        columns[i]->get(n, tuple[i]);
+
+    res = tuple;
 }
 
 StringRef ColumnTuple::getDataAt(size_t) const
@@ -118,7 +119,7 @@ void ColumnTuple::insertData(const char *, size_t)
 
 void ColumnTuple::insert(const Field & x)
 {
-    const TupleBackend & tuple = DB::get<const Tuple &>(x).toUnderType();
+    auto & tuple = DB::get<const Tuple &>(x);
 
     const size_t tuple_size = columns.size();
     if (tuple.size() != tuple_size)
@@ -352,14 +353,14 @@ void ColumnTuple::getExtremes(Field & min, Field & max) const
 {
     const size_t tuple_size = columns.size();
 
-    min = Tuple(TupleBackend(tuple_size));
-    max = Tuple(TupleBackend(tuple_size));
-
-    auto & min_backend = min.get<Tuple &>().toUnderType();
-    auto & max_backend = max.get<Tuple &>().toUnderType();
+    Tuple min_tuple(tuple_size);
+    Tuple max_tuple(tuple_size);
 
     for (const auto i : ext::range(0, tuple_size))
-        columns[i]->getExtremes(min_backend[i], max_backend[i]);
+        columns[i]->getExtremes(min_tuple[i], max_tuple[i]);
+
+    min = min_tuple;
+    max = max_tuple;
 }
 
 void ColumnTuple::forEachSubcolumn(ColumnCallback callback)

--- a/dbms/src/Common/FieldVisitors.cpp
+++ b/dbms/src/Common/FieldVisitors.cpp
@@ -72,9 +72,8 @@ String FieldVisitorDump::operator() (const Array & x) const
     return wb.str();
 }
 
-String FieldVisitorDump::operator() (const Tuple & x_def) const
+String FieldVisitorDump::operator() (const Tuple & x) const
 {
-    auto & x = x_def.toUnderType();
     WriteBufferFromOwnString wb;
 
     wb << "Tuple_(";
@@ -149,9 +148,8 @@ String FieldVisitorToString::operator() (const Array & x) const
     return wb.str();
 }
 
-String FieldVisitorToString::operator() (const Tuple & x_def) const
+String FieldVisitorToString::operator() (const Tuple & x) const
 {
-    auto & x = x_def.toUnderType();
     WriteBufferFromOwnString wb;
 
     wb << '(';
@@ -209,6 +207,16 @@ void FieldVisitorHash::operator() (const String & x) const
     hash.update(type);
     hash.update(x.size());
     hash.update(x.data(), x.size());
+}
+
+void FieldVisitorHash::operator() (const Tuple & x) const
+{
+    UInt8 type = Field::Types::Tuple;
+    hash.update(type);
+    hash.update(x.size());
+
+    for (const auto & elem : x)
+        applyVisitor(*this, elem);
 }
 
 void FieldVisitorHash::operator() (const Array & x) const

--- a/dbms/src/Common/FieldVisitors.h
+++ b/dbms/src/Common/FieldVisitors.h
@@ -231,6 +231,7 @@ public:
     void operator() (const Float64 & x) const;
     void operator() (const String & x) const;
     void operator() (const Array & x) const;
+    void operator() (const Tuple & x) const;
     void operator() (const DecimalField<Decimal32> & x) const;
     void operator() (const DecimalField<Decimal64> & x) const;
     void operator() (const DecimalField<Decimal128> & x) const;
@@ -479,6 +480,7 @@ public:
     bool operator() (Null &) const { throw Exception("Cannot sum Nulls", ErrorCodes::LOGICAL_ERROR); }
     bool operator() (String &) const { throw Exception("Cannot sum Strings", ErrorCodes::LOGICAL_ERROR); }
     bool operator() (Array &) const { throw Exception("Cannot sum Arrays", ErrorCodes::LOGICAL_ERROR); }
+    bool operator() (Tuple &) const { throw Exception("Cannot sum Tuples", ErrorCodes::LOGICAL_ERROR); }
     bool operator() (UInt128 &) const { throw Exception("Cannot sum UUIDs", ErrorCodes::LOGICAL_ERROR); }
     bool operator() (AggregateFunctionStateData &) const { throw Exception("Cannot sum AggregateFunctionStates", ErrorCodes::LOGICAL_ERROR); }
 

--- a/dbms/src/Core/Field.cpp
+++ b/dbms/src/Core/Field.cpp
@@ -152,9 +152,8 @@ namespace DB
         buf.write(res.data(), res.size());
     }
 
-    void readBinary(Tuple & x_def, ReadBuffer & buf)
+    void readBinary(Tuple & x, ReadBuffer & buf)
     {
-        auto & x = x_def.toUnderType();
         size_t size;
         DB::readBinary(size, buf);
 
@@ -231,9 +230,8 @@ namespace DB
         }
     }
 
-    void writeBinary(const Tuple & x_def, WriteBuffer & buf)
+    void writeBinary(const Tuple & x, WriteBuffer & buf)
     {
-        auto & x = x_def.toUnderType();
         const size_t size = x.size();
         DB::writeBinary(size, buf);
 
@@ -292,7 +290,12 @@ namespace DB
 
     void writeText(const Tuple & x, WriteBuffer & buf)
     {
-        DB::String res = applyVisitor(DB::FieldVisitorToString(), DB::Field(x));
+        writeFieldText(DB::Field(x), buf);
+    }
+
+    void writeFieldText(const Field & x, WriteBuffer & buf)
+    {
+        DB::String res = applyVisitor(DB::FieldVisitorToString(), x);
         buf.write(res.data(), res.size());
     }
 

--- a/dbms/src/Core/Field.h
+++ b/dbms/src/Core/Field.h
@@ -34,9 +34,23 @@ template <typename T>
 using NearestFieldType = typename NearestFieldTypeImpl<T>::Type;
 
 class Field;
-using Array = std::vector<Field>;
-using TupleBackend = std::vector<Field>;
-STRONG_TYPEDEF(TupleBackend, Tuple) /// Array and Tuple are different types with equal representation inside Field.
+using FieldVector = std::vector<Field>;
+
+/// Array and Tuple use the same storage type -- FieldVector, but we declare
+/// distinct types for them, so that the caller can choose whether it wants to
+/// construct a Field of Array or a Tuple type. An alternative approach would be
+/// to construct both of these types from FieldVector, and have the caller
+/// specify the desired Field type explicitly.
+#define DEFINE_FIELD_VECTOR(X) \
+struct X : public FieldVector \
+{ \
+    using FieldVector::FieldVector; \
+}
+
+DEFINE_FIELD_VECTOR(Array);
+DEFINE_FIELD_VECTOR(Tuple);
+
+#undef DEFINE_FIELD_VECTOR
 
 struct AggregateFunctionStateData
 {
@@ -747,6 +761,8 @@ void readBinary(Tuple & x, ReadBuffer & buf);
 void writeBinary(const Tuple & x, WriteBuffer & buf);
 
 void writeText(const Tuple & x, WriteBuffer & buf);
+
+void writeFieldText(const Field & x, WriteBuffer & buf);
 
 [[noreturn]] inline void writeQuoted(const Tuple &, WriteBuffer &) { throw Exception("Cannot write Tuple quoted.", ErrorCodes::NOT_IMPLEMENTED); }
 }

--- a/dbms/src/DataTypes/DataTypeTuple.cpp
+++ b/dbms/src/DataTypes/DataTypeTuple.cpp
@@ -101,7 +101,7 @@ static inline const IColumn & extractElementColumn(const IColumn & column, size_
 
 void DataTypeTuple::serializeBinary(const Field & field, WriteBuffer & ostr) const
 {
-    const auto & tuple = get<const Tuple &>(field).toUnderType();
+    const auto & tuple = get<const Tuple &>(field);
     for (const auto idx_elem : ext::enumerate(elems))
         idx_elem.second->serializeBinary(tuple[idx_elem.first], ostr);
 }
@@ -109,10 +109,12 @@ void DataTypeTuple::serializeBinary(const Field & field, WriteBuffer & ostr) con
 void DataTypeTuple::deserializeBinary(Field & field, ReadBuffer & istr) const
 {
     const size_t size = elems.size();
-    field = Tuple(TupleBackend(size));
-    TupleBackend & tuple = get<Tuple &>(field).toUnderType();
+
+    Tuple tuple(size);
     for (const auto i : ext::range(0, size))
         elems[i]->deserializeBinary(tuple[i], istr);
+
+    field = tuple;
 }
 
 void DataTypeTuple::serializeBinary(const IColumn & column, size_t row_num, WriteBuffer & ostr) const
@@ -447,7 +449,7 @@ MutableColumnPtr DataTypeTuple::createColumn() const
 
 Field DataTypeTuple::getDefault() const
 {
-    return Tuple(ext::map<TupleBackend>(elems, [] (const DataTypePtr & elem) { return elem->getDefault(); }));
+    return Tuple(ext::map<Tuple>(elems, [] (const DataTypePtr & elem) { return elem->getDefault(); }));
 }
 
 void DataTypeTuple::insertDefaultInto(IColumn & column) const

--- a/dbms/src/DataTypes/FieldToDataType.cpp
+++ b/dbms/src/DataTypes/FieldToDataType.cpp
@@ -90,9 +90,8 @@ DataTypePtr FieldToDataType::operator() (const Array & x) const
 }
 
 
-DataTypePtr FieldToDataType::operator() (const Tuple & x) const
+DataTypePtr FieldToDataType::operator() (const Tuple & tuple) const
 {
-    auto & tuple = static_cast<const TupleBackend &>(x);
     if (tuple.empty())
         throw Exception("Cannot infer type of an empty tuple", ErrorCodes::EMPTY_DATA_PASSED);
 

--- a/dbms/src/Interpreters/Set.cpp
+++ b/dbms/src/Interpreters/Set.cpp
@@ -246,7 +246,7 @@ void Set::createFromAST(const DataTypes & types, ASTPtr node, const Context & co
         else if (const auto * func = elem->as<ASTFunction>())
         {
             Field function_result;
-            const TupleBackend * tuple = nullptr;
+            const Tuple * tuple = nullptr;
             if (func->name != "tuple")
             {
                 if (!tuple_type)
@@ -257,7 +257,7 @@ void Set::createFromAST(const DataTypes & types, ASTPtr node, const Context & co
                     throw Exception("Invalid type of set. Expected tuple, got " + String(function_result.getTypeName()),
                                     ErrorCodes::INCORRECT_ELEMENT_OF_SET);
 
-                tuple = &function_result.get<Tuple>().toUnderType();
+                tuple = &function_result.get<Tuple>();
             }
 
             size_t tuple_size = tuple ? tuple->size() : func->arguments->children.size();

--- a/dbms/src/Interpreters/convertFieldToType.cpp
+++ b/dbms/src/Interpreters/convertFieldToType.cpp
@@ -246,7 +246,7 @@ Field convertFieldToTypeImpl(const Field & src, const IDataType & type, const ID
     {
         if (src.getType() == Field::Types::Tuple)
         {
-            const TupleBackend & src_tuple = src.get<Tuple>();
+            const auto & src_tuple = src.get<Tuple>();
             size_t src_tuple_size = src_tuple.size();
             size_t dst_tuple_size = type_tuple->getElements().size();
 
@@ -254,7 +254,7 @@ Field convertFieldToTypeImpl(const Field & src, const IDataType & type, const ID
                 throw Exception("Bad size of tuple in IN or VALUES section. Expected size: "
                     + toString(dst_tuple_size) + ", actual size: " + toString(src_tuple_size), ErrorCodes::TYPE_MISMATCH);
 
-            TupleBackend res(dst_tuple_size);
+            Tuple res(dst_tuple_size);
             for (size_t i = 0; i < dst_tuple_size; ++i)
                 res[i] = convertFieldToType(src_tuple[i], *type_tuple->getElements()[i]);
 

--- a/dbms/src/Interpreters/convertFieldToType.cpp
+++ b/dbms/src/Interpreters/convertFieldToType.cpp
@@ -294,7 +294,14 @@ Field convertFieldToTypeImpl(const Field & src, const IDataType & type, const ID
 Field convertFieldToType(const Field & from_value, const IDataType & to_type, const IDataType * from_type_hint)
 {
     if (from_value.isNull())
+    {
+        if (!to_type.isNullable() && to_type.getTypeId() != TypeIndex::Nothing)
+        {
+            throw Exception("Cannot convert a NULL value to a non-nullable type '" + to_type.getName() + "'.",
+                            ErrorCodes::TYPE_MISMATCH);
+        }
         return from_value;
+    }
 
     if (from_type_hint && from_type_hint->equals(to_type))
         return from_value;

--- a/dbms/src/Processors/Formats/Impl/CapnProtoRowInputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/CapnProtoRowInputFormat.cpp
@@ -81,12 +81,11 @@ static Field convertNodeToField(const capnp::DynamicValue::Reader & value)
             auto structValue = value.as<capnp::DynamicStruct>();
             const auto & fields = structValue.getSchema().getFields();
 
-            Field field = Tuple(TupleBackend(fields.size()));
-            TupleBackend & tuple = get<Tuple &>(field).toUnderType();
+            Tuple tuple(fields.size());
             for (auto i : kj::indices(fields))
                 tuple[i] = convertNodeToField(structValue.get(fields[i]));
 
-            return field;
+            return tuple;
         }
         case capnp::DynamicValue::CAPABILITY:
             throw Exception("CAPABILITY type not supported", ErrorCodes::BAD_TYPE_OF_FIELD);
@@ -271,7 +270,7 @@ bool CapnProtoRowInputFormat::readRow(MutableColumns & columns, RowReadExtension
                         // Populate array with a single tuple elements
                         for (size_t off = 0; off < size; ++off)
                         {
-                            const TupleBackend & tuple = DB::get<const Tuple &>(collected[off]).toUnderType();
+                            const auto & tuple = DB::get<const Tuple &>(collected[off]);
                             flattened[off] = tuple[column_index];
                         }
                         auto & col = columns[action.columns[column_index]];

--- a/dbms/src/Storages/MergeTree/MergeTreeIndexConditionBloomFilter.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeIndexConditionBloomFilter.cpp
@@ -331,7 +331,7 @@ bool MergeTreeIndexConditionBloomFilter::traverseASTEquals(
 
         if (which.isTuple() && function->name == "tuple")
         {
-            const TupleBackend & tuple = get<const Tuple &>(value_field).toUnderType();
+            const Tuple & tuple = get<const Tuple &>(value_field);
             const auto value_tuple_data_type = typeid_cast<const DataTypeTuple *>(value_type.get());
             const ASTs & arguments = typeid_cast<const ASTExpressionList &>(*function->arguments).children;
 

--- a/dbms/src/TableFunctions/TableFunctionValues.cpp
+++ b/dbms/src/TableFunctions/TableFunctionValues.cpp
@@ -44,7 +44,7 @@ static void parseAndInsertValues(MutableColumns & res_columns, const ASTs & args
         {
             const auto & [value_field, value_type_ptr] = evaluateConstantExpression(args[i], context);
             const DataTypes & value_types_tuple = typeid_cast<const DataTypeTuple *>(value_type_ptr.get())->getElements();
-            const TupleBackend & value_tuple = value_field.safeGet<Tuple>().toUnderType();
+            const Tuple & value_tuple = value_field.safeGet<Tuple>();
 
             if (value_tuple.size() != sample_block.columns())
                 throw Exception("Values size should match with number of columns", ErrorCodes::LOGICAL_ERROR);

--- a/dbms/tests/queries/0_stateless/01016_index_tuple_field_type.sql
+++ b/dbms/tests/queries/0_stateless/01016_index_tuple_field_type.sql
@@ -1,0 +1,12 @@
+CREATE TABLE tuple_01015(a Tuple(DateTime, Int32)) ENGINE = MergeTree() ORDER BY a;
+-- repeat a couple of times, because it doesn't always reproduce well
+INSERT INTO tuple_01015 VALUES (('2018-01-01 00:00:00', 1));
+SELECT * FROM tuple_01015 WHERE a < tuple(toDateTime('2019-01-01 00:00:00'), 0) format Null;
+INSERT INTO tuple_01015 VALUES (('2018-01-01 00:00:00', 1));
+SELECT * FROM tuple_01015 WHERE a < tuple(toDateTime('2019-01-01 00:00:00'), 0) format Null;
+INSERT INTO tuple_01015 VALUES (('2018-01-01 00:00:00', 1));
+SELECT * FROM tuple_01015 WHERE a < tuple(toDateTime('2019-01-01 00:00:00'), 0) format Null;
+INSERT INTO tuple_01015 VALUES (('2018-01-01 00:00:00', 1));
+SELECT * FROM tuple_01015 WHERE a < tuple(toDateTime('2019-01-01 00:00:00'), 0) format Null;
+INSERT INTO tuple_01015 VALUES (('2018-01-01 00:00:00', 1));
+SELECT * FROM tuple_01015 WHERE a < tuple(toDateTime('2019-01-01 00:00:00'), 0) format Null;


### PR DESCRIPTION
Category (leave one):
- Build/Testing/Packaging Improvement.

Short description:
Fix some type safety issue in Fields. Found with MemorySanitizer.

Requires  #7179