### PR TITLE
Serialize Null Fields correctly in DataTypeNullable.

### DIFF
--- a/dbms/src/DataTypes/DataTypeNullable.cpp
+++ b/dbms/src/DataTypes/DataTypeNullable.cpp
@@ -118,6 +118,33 @@ void DataTypeNullable::deserializeBinaryBulkWithMultipleStreams(
 }
 
 
+void DataTypeNullable::serializeBinary(const Field & field, WriteBuffer & ostr) const
+{
+    if (field.isNull())
+    {
+        writeBinary(true, ostr);
+    }
+    else
+    {
+        writeBinary(false, ostr);
+        nested_data_type->serializeBinary(field, ostr);
+    }
+}
+
+void DataTypeNullable::deserializeBinary(Field & field, ReadBuffer & istr) const
+{
+    bool is_null = false;
+    readBinary(is_null, istr);
+    if (!is_null)
+    {
+        nested_data_type->deserializeBinary(field, istr);
+    }
+    else
+    {
+        field = Null();
+    }
+}
+
 void DataTypeNullable::serializeBinary(const IColumn & column, size_t row_num, WriteBuffer & ostr) const
 {
     const ColumnNullable & col = assert_cast<const ColumnNullable &>(column);
@@ -416,6 +443,10 @@ MutableColumnPtr DataTypeNullable::createColumn() const
     return ColumnNullable::create(nested_data_type->createColumn(), ColumnUInt8::create());
 }
 
+Field DataTypeNullable::getDefault() const
+{
+    return Null();
+}
 
 size_t DataTypeNullable::getSizeOfValueInMemory() const
 {

--- a/dbms/src/DataTypes/DataTypeNullable.h
+++ b/dbms/src/DataTypes/DataTypeNullable.h
@@ -45,8 +45,8 @@ public:
             DeserializeBinaryBulkSettings & settings,
             DeserializeBinaryBulkStatePtr & state) const override;
 
-    void serializeBinary(const Field & field, WriteBuffer & ostr) const override { nested_data_type->serializeBinary(field, ostr); }
-    void deserializeBinary(Field & field, ReadBuffer & istr) const override { nested_data_type->deserializeBinary(field, istr); }
+    void serializeBinary(const Field & field, WriteBuffer & ostr) const override;
+    void deserializeBinary(Field & field, ReadBuffer & istr) const override;
     void serializeBinary(const IColumn & column, size_t row_num, WriteBuffer & ostr) const override;
     void deserializeBinary(IColumn & column, ReadBuffer & istr) const override;
     void serializeTextEscaped(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings &) const override;
@@ -77,7 +77,7 @@ public:
 
     MutableColumnPtr createColumn() const override;
 
-    Field getDefault() const override { return Null(); }
+    Field getDefault() const override;
 
     bool equals(const IDataType & rhs) const override;
 

--- a/dbms/tests/queries/0_stateless/01016_null_part_minmax.sql
+++ b/dbms/tests/queries/0_stateless/01016_null_part_minmax.sql
@@ -1,0 +1,3 @@
+-- this test checks that null values are correctly serialized inside minmax index (issue #7113)
+create table null_01016 (x Nullable(String)) engine MergeTree order by ifNull(x, 'order-null') partition by ifNull(x, 'partition-null');
+insert into null_01016 values (null);

--- a/dbms/tests/queries/0_stateless/01016_null_part_minmax.sql
+++ b/dbms/tests/queries/0_stateless/01016_null_part_minmax.sql
@@ -1,3 +1,5 @@
 -- this test checks that null values are correctly serialized inside minmax index (issue #7113)
-create table null_01016 (x Nullable(String)) engine MergeTree order by ifNull(x, 'order-null') partition by ifNull(x, 'partition-null');
+drop table if exists null_01016;
+create table if not exists null_01016 (x Nullable(String)) engine MergeTree order by ifNull(x, 'order-null') partition by ifNull(x, 'partition-null');
 insert into null_01016 values (null);
+drop table null_01016;


### PR DESCRIPTION
Fixes #7113.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Serialize NULL values correctly in min/max indexes of MergeTree parts.