### PR TITLE
Added function `getMacro`

### DIFF
--- a/dbms/programs/server/config.d/macros.xml
+++ b/dbms/programs/server/config.d/macros.xml
@@ -1,0 +1,5 @@
+<yandex>
+    <macros>
+        <test>Hello, world!</test>
+    </macros>
+</yandex>

--- a/dbms/src/Common/Macros.cpp
+++ b/dbms/src/Common/Macros.cpp
@@ -74,6 +74,13 @@ String Macros::expand(const String & s, size_t level, const String & database_na
     return expand(res, level + 1, database_name, table_name);
 }
 
+String Macros::getValue(const String & key) const
+{
+    if (auto it = macros.find(key); it != macros.end())
+        return it->second;
+    throw Exception("No macro " + key + " in config", ErrorCodes::SYNTAX_ERROR);
+}
+
 String Macros::expand(const String & s, const String & database_name, const String & table_name) const
 {
     return expand(s, 0, database_name, table_name);

--- a/dbms/src/Common/Macros.h
+++ b/dbms/src/Common/Macros.h
@@ -43,6 +43,8 @@ public:
     using MacroMap = std::map<String, String>;
     const MacroMap getMacroMap() const { return macros; }
 
+    String getValue(const String & key) const;
+
 private:
     MacroMap macros;
 };

--- a/dbms/src/Functions/getMacro.cpp
+++ b/dbms/src/Functions/getMacro.cpp
@@ -1,0 +1,84 @@
+#include <Functions/IFunction.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/FunctionHelpers.h>
+#include <DataTypes/DataTypeString.h>
+#include <Columns/ColumnString.h>
+#include <Interpreters/Context.h>
+#include <Common/Macros.h>
+#include <Core/Field.h>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+    extern const int ILLEGAL_COLUMN;
+}
+
+/** Get the value of macro from configuration file.
+  * For example, it may be used as a sophisticated replacement for the function 'hostName' if servers have complicated hostnames
+  *  but you still need to distinguish them by some convenient names.
+  */
+class FunctionGetMacro : public IFunction
+{
+private:
+    MultiVersion<Macros>::Version macros;
+
+public:
+    static constexpr auto name = "getMacro";
+    static FunctionPtr create(const Context & context)
+    {
+        return std::make_shared<FunctionGetMacro>(context.getMacros());
+    }
+
+    FunctionGetMacro(MultiVersion<Macros>::Version macros_) : macros(std::move(macros_)) {}
+
+    String getName() const override
+    {
+        return name;
+    }
+
+    bool isDeterministic() const override { return false; }
+
+    bool isDeterministicInScopeOfQuery() const override
+    {
+        return false;
+    }
+
+    size_t getNumberOfArguments() const override
+    {
+        return 1;
+    }
+
+    DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
+    {
+        if (!isString(arguments[0]))
+            throw Exception("The argument of function " + getName() + " must have String type", ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+        return std::make_shared<DataTypeString>();
+    }
+
+    /** convertToFullColumn needed because in distributed query processing,
+      *    each server returns its own value.
+      */
+    void executeImpl(Block & block, const ColumnNumbers & arguments, size_t result, size_t input_rows_count) override
+    {
+        const IColumn * arg_column = block.getByPosition(arguments[0]).column.get();
+        const ColumnString * arg_string = checkAndGetColumnConstData<ColumnString>(arg_column);
+
+        if (!arg_string)
+            throw Exception("The argument of function " + getName() + " must be constant String", ErrorCodes::ILLEGAL_COLUMN);
+
+        block.getByPosition(result).column = block.getByPosition(result).type->createColumnConst(
+            input_rows_count, macros->getValue(arg_string->getDataAt(0).toString()))->convertToFullColumnIfConst();
+    }
+};
+
+
+void registerFunctionGetMacro(FunctionFactory & factory)
+{
+    factory.registerFunction<FunctionGetMacro>();
+}
+
+}

--- a/dbms/src/Functions/registerFunctionsMiscellaneous.cpp
+++ b/dbms/src/Functions/registerFunctionsMiscellaneous.cpp
@@ -50,6 +50,7 @@ void registerFunctionFilesystem(FunctionFactory &);
 void registerFunctionEvalMLMethod(FunctionFactory &);
 void registerFunctionBasename(FunctionFactory &);
 void registerFunctionTransform(FunctionFactory &);
+void registerFunctionGetMacro(FunctionFactory &);
 
 #if USE_ICU
 void registerFunctionConvertCharset(FunctionFactory &);
@@ -102,6 +103,7 @@ void registerFunctionsMiscellaneous(FunctionFactory & factory)
     registerFunctionEvalMLMethod(factory);
     registerFunctionBasename(factory);
     registerFunctionTransform(factory);
+    registerFunctionGetMacro(factory);
 
 #if USE_ICU
     registerFunctionConvertCharset(factory);

--- a/dbms/tests/config/macros.xml
+++ b/dbms/tests/config/macros.xml
@@ -1,0 +1,5 @@
+<yandex>
+    <macros>
+        <test>Hello, world!</test>
+    </macros>
+</yandex>

--- a/dbms/tests/queries/0_stateless/01016_macros.reference
+++ b/dbms/tests/queries/0_stateless/01016_macros.reference
@@ -1,0 +1,2 @@
+test	Hello, world!
+Hello, world!

--- a/dbms/tests/queries/0_stateless/01016_macros.sql
+++ b/dbms/tests/queries/0_stateless/01016_macros.sql
@@ -1,0 +1,2 @@
+SELECT * FROM system.macros WHERE macro = 'test';
+SELECT getMacro('test');


### PR DESCRIPTION
For changelog. Remove if this is non-significant change.

Category (leave one):
- New Feature

Short description (up to few sentences):
Added miscellaneous function `getMacro(name)` that returns String with the value of corresponding `<macros>` from configuration file on current server where the function is executed. This function is ordered by Yandex Banner System for filtering duplicate data on distributed queries during cluster resharding. For example, it may be used as a sophisticated replacement for the function 'hostName' if servers have complicated hostnames but you still need to distinguish them by some convenient names. This fixes #7239.