### PR TITLE
Return SparseHashed name (system.dictionaries:type) for the sparse_hashed layout

### DIFF
--- a/dbms/src/Dictionaries/HashedDictionary.h
+++ b/dbms/src/Dictionaries/HashedDictionary.h
@@ -36,7 +36,7 @@ public:
 
     std::string getName() const override { return name; }
 
-    std::string getTypeName() const override { return "Hashed"; }
+    std::string getTypeName() const override { return sparse ? "SparseHashed" : "Hashed"; }
 
     size_t getBytesAllocated() const override { return bytes_allocated; }
 


### PR DESCRIPTION
Category (leave one):
- Bug Fix

Short description (up to few sentences):
Return SparseHashed name (system.dictionaries:type) for the sparse_hashed layout