### PR TITLE
Fix docs for Lazy database

### DIFF
--- a/docs/en/database_engines/lazy.md
+++ b/docs/en/database_engines/lazy.md
@@ -9,3 +9,5 @@ It's optimized for storing many small \*Log tables, for which there is a long ti
 ```
 CREATE DATABASE testlazy ENGINE = Lazy(expiration_time_in_seconds);
 ```
+
+[Original article](https://clickhouse.yandex/docs/en/database_engines/lazy/) <!--hide-->

--- a/docs/toc_en.yml
+++ b/docs/toc_en.yml
@@ -35,6 +35,7 @@ nav:
 - 'Database Engines':
     - 'Introduction': 'database_engines/index.md'
     - 'MySQL': 'database_engines/mysql.md'
+    - 'Lazy': 'database_engines/lazy.md'
 
 - 'Table Engines':
   - 'Introduction': 'operations/table_engines/index.md'


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Documentation

Short description (up to few sentences):
fix ```INFO:root:Link to nowhere: #lazy/```
