### PR TITLE
Don't push to MVs when inserting into Kafka table

### DIFF
--- a/dbms/src/Interpreters/InterpreterInsertQuery.h
+++ b/dbms/src/Interpreters/InterpreterInsertQuery.h
@@ -15,7 +15,12 @@ namespace DB
 class InterpreterInsertQuery : public IInterpreter
 {
 public:
-    InterpreterInsertQuery(const ASTPtr & query_ptr_, const Context & context_, bool allow_materialized_ = false, bool no_squash_ = false);
+    InterpreterInsertQuery(
+        const ASTPtr & query_ptr_,
+        const Context & context_,
+        bool allow_materialized_ = false,
+        bool no_squash_ = false,
+        bool no_destination_ = false);
 
     /** Prepare a request for execution. Return block streams
       * - the stream into which you can write data to execute the query, if INSERT;
@@ -35,6 +40,7 @@ private:
     const Context & context;
     const bool allow_materialized;
     const bool no_squash;
+    const bool no_destination;
 };
 
 

--- a/dbms/src/Parsers/ASTInsertQuery.h
+++ b/dbms/src/Parsers/ASTInsertQuery.h
@@ -20,9 +20,6 @@ public:
     ASTPtr table_function;
     ASTPtr settings_ast;
 
-    // Set to true if the data should only be inserted into attached views
-    bool no_destination = false;
-
     /// Data to insert
     const char * data = nullptr;
     const char * end = nullptr;

--- a/dbms/src/Storages/IStorage.h
+++ b/dbms/src/Storages/IStorage.h
@@ -101,6 +101,9 @@ public:
     /// Returns true if the storage supports settings.
     virtual bool supportsSettings() const { return false; }
 
+    /// Returns true if the blocks shouldn't be pushed to associated views on insert.
+    virtual bool noPushingToViews() const { return false; }
+
     /// Optional size information of each physical column.
     /// Currently it's only used by the MergeTree family for query optimizations.
     using ColumnSizeByName = std::unordered_map<std::string, ColumnSize>;

--- a/dbms/src/Storages/IStorage.h
+++ b/dbms/src/Storages/IStorage.h
@@ -63,7 +63,7 @@ struct ColumnSize
   * - data storage structure (compression, etc.)
   * - concurrent access to data (locks, etc.)
   */
-class IStorage : public std::enable_shared_from_this<IStorage>
+class IStorage : public std::enable_shared_from_this<IStorage>, public TypePromotion<IStorage>
 {
 public:
     IStorage() = default;

--- a/dbms/src/Storages/Kafka/Buffer_fwd.h
+++ b/dbms/src/Storages/Kafka/Buffer_fwd.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <memory>
+
+namespace DB
+{
+
+class ReadBufferFromKafkaConsumer;
+class WriteBufferToKafkaProducer;
+
+using ConsumerBufferPtr = std::shared_ptr<ReadBufferFromKafkaConsumer>;
+using ProducerBufferPtr = std::shared_ptr<WriteBufferToKafkaProducer>;
+
+}

--- a/dbms/src/Storages/Kafka/KafkaBlockOutputStream.cpp
+++ b/dbms/src/Storages/Kafka/KafkaBlockOutputStream.cpp
@@ -1,6 +1,7 @@
 #include "KafkaBlockOutputStream.h"
 
 #include <Formats/FormatFactory.h>
+#include <Storages/Kafka/WriteBufferToKafkaProducer.h>
 
 namespace DB
 {

--- a/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
+++ b/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
@@ -2,6 +2,8 @@
 
 #include <common/logger_useful.h>
 
+#include <cppkafka/cppkafka.h>
+
 namespace DB
 {
 

--- a/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.h
+++ b/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.h
@@ -4,7 +4,10 @@
 #include <Core/Types.h>
 #include <IO/ReadBuffer.h>
 
-#include <cppkafka/cppkafka.h>
+namespace cppkafka
+{
+    class Consumer;
+}
 
 namespace Poco
 {

--- a/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.h
+++ b/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.h
@@ -4,10 +4,7 @@
 #include <Core/Types.h>
 #include <IO/ReadBuffer.h>
 
-namespace cppkafka
-{
-    class Consumer;
-}
+#include <cppkafka/cppkafka.h>
 
 namespace Poco
 {
@@ -63,7 +60,5 @@ private:
 
     bool nextImpl() override;
 };
-
-using ConsumerBufferPtr = std::shared_ptr<ReadBufferFromKafkaConsumer>;
 
 }

--- a/dbms/src/Storages/Kafka/StorageKafka.cpp
+++ b/dbms/src/Storages/Kafka/StorageKafka.cpp
@@ -17,6 +17,7 @@
 #include <Storages/Kafka/KafkaSettings.h>
 #include <Storages/Kafka/KafkaBlockInputStream.h>
 #include <Storages/Kafka/KafkaBlockOutputStream.h>
+#include <Storages/Kafka/WriteBufferToKafkaProducer.h>
 #include <Storages/StorageFactory.h>
 #include <Storages/StorageMaterializedView.h>
 #include <boost/algorithm/string/replace.hpp>

--- a/dbms/src/Storages/Kafka/StorageKafka.cpp
+++ b/dbms/src/Storages/Kafka/StorageKafka.cpp
@@ -367,7 +367,6 @@ bool StorageKafka::streamToViews()
     auto insert = std::make_shared<ASTInsertQuery>();
     insert->database = database_name;
     insert->table = table_name;
-    insert->no_destination = true; // Only insert into dependent views and expect that input blocks contain virtual columns
 
     const Settings & settings = global_context.getSettingsRef();
     size_t block_size = max_block_size;
@@ -375,7 +374,8 @@ bool StorageKafka::streamToViews()
         block_size = settings.max_block_size;
 
     // Create a stream for each consumer and join them in a union stream
-    InterpreterInsertQuery interpreter(insert, global_context, false, true);
+    // Only insert into dependent views and expect that input blocks contain virtual columns
+    InterpreterInsertQuery interpreter(insert, global_context, false, true, true);
     auto block_io = interpreter.execute();
 
     // Create a stream for each consumer and join them in a union stream

--- a/dbms/src/Storages/Kafka/StorageKafka.h
+++ b/dbms/src/Storages/Kafka/StorageKafka.h
@@ -2,8 +2,7 @@
 
 #include <Core/BackgroundSchedulePool.h>
 #include <Storages/IStorage.h>
-#include <Storages/Kafka/ReadBufferFromKafkaConsumer.h>
-#include <Storages/Kafka/WriteBufferToKafkaProducer.h>
+#include <Storages/Kafka/Buffer_fwd.h>
 
 #include <Poco/Semaphore.h>
 #include <ext/shared_ptr_helper.h>
@@ -11,6 +10,12 @@
 #include <mutex>
 #include <atomic>
 
+namespace cppkafka
+{
+
+class Configuration;
+
+}
 
 namespace DB
 {

--- a/dbms/src/Storages/Kafka/StorageKafka.h
+++ b/dbms/src/Storages/Kafka/StorageKafka.h
@@ -30,7 +30,9 @@ public:
     std::string getName() const override { return "Kafka"; }
     std::string getTableName() const override { return table_name; }
     std::string getDatabaseName() const override { return database_name; }
+
     bool supportsSettings() const override { return true; }
+    bool noPushingToViews() const override { return true; }
 
     void startup() override;
     void shutdown() override;

--- a/dbms/src/Storages/Kafka/WriteBufferToKafkaProducer.h
+++ b/dbms/src/Storages/Kafka/WriteBufferToKafkaProducer.h
@@ -9,9 +9,6 @@
 namespace DB
 {
 
-class WriteBufferToKafkaProducer;
-
-using ProducerBufferPtr = std::shared_ptr<WriteBufferToKafkaProducer>;
 using ProducerPtr = std::shared_ptr<cppkafka::Producer>;
 
 class WriteBufferToKafkaProducer : public WriteBuffer

--- a/dbms/tests/integration/test_storage_kafka/test.py
+++ b/dbms/tests/integration/test_storage_kafka/test.py
@@ -560,6 +560,8 @@ def test_kafka_insert(kafka_cluster):
 @pytest.mark.timeout(180)
 def test_kafka_produce_consume(kafka_cluster):
     instance.query('''
+        DROP TABLE IF EXISTS test.view;
+        DROP TABLE IF EXISTS test.consumer;
         CREATE TABLE test.kafka (key UInt64, value UInt64)
             ENGINE = Kafka
             SETTINGS kafka_broker_list = 'kafka1:19092',
@@ -567,6 +569,11 @@ def test_kafka_produce_consume(kafka_cluster):
                      kafka_group_name = 'insert2',
                      kafka_format = 'TSV',
                      kafka_row_delimiter = '\\n';
+        CREATE TABLE test.view (key UInt64, value UInt64)
+            ENGINE = MergeTree
+            ORDER BY key;
+        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
+            SELECT * FROM test.kafka;
     ''')
 
     messages_num = 10000
@@ -593,16 +600,6 @@ def test_kafka_produce_consume(kafka_cluster):
     for thread in threads:
         time.sleep(random.uniform(0, 1))
         thread.start()
-
-    instance.query('''
-        DROP TABLE IF EXISTS test.view;
-        DROP TABLE IF EXISTS test.consumer;
-        CREATE TABLE test.view (key UInt64, value UInt64)
-            ENGINE = MergeTree
-            ORDER BY key;
-        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
-            SELECT * FROM test.kafka;
-    ''')
 
     while True:
         result = instance.query('SELECT count() FROM test.view')


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Prevent message duplication when producing Kafka table has any MVs selecting from it