### PR TITLE
[RFC] Ignore memory limit from the StackTrace module

### DIFF
--- a/dbms/src/Common/MemoryTracker.h
+++ b/dbms/src/Common/MemoryTracker.h
@@ -70,6 +70,10 @@ public:
     {
         limit.store(limit_, std::memory_order_relaxed);
     }
+    Int64 getLimit()
+    {
+        return limit.load(std::memory_order_relaxed);
+    }
 
     /** Set limit if it was not set.
       * Otherwise, set limit to new value, if new value is greater than previous limit.
@@ -126,5 +130,16 @@ namespace CurrentMemoryTracker
     void free(Int64 size);
 }
 
+/// Use by the StackTrace
+class IgnoreMemoryLimit
+{
+public:
+    IgnoreMemoryLimit();
+    ~IgnoreMemoryLimit();
+
+private:
+    MemoryTracker * memory_tracker;
+    Int64 limit = 0;
+};
 
 DB::SimpleActionLock getCurrentMemoryTrackerActionLock();

--- a/dbms/src/Common/StackTrace.cpp
+++ b/dbms/src/Common/StackTrace.cpp
@@ -4,6 +4,7 @@
 #include <Common/Elf.h>
 #include <Common/SymbolIndex.h>
 #include <Common/config.h>
+#include <Common/MemoryTracker.h>
 #include <common/SimpleCache.h>
 #include <common/demangle.h>
 #include <Core/Defines.h>
@@ -251,6 +252,8 @@ static void toStringEveryLineImpl(const StackTrace::Frames & frames, size_t offs
         return callback("<Empty trace>");
 
 #if defined(__ELF__) && !defined(__FreeBSD__)
+    auto ignoreMemoryLimit = std::make_unique<IgnoreMemoryLimit>();
+
     const DB::SymbolIndex & symbol_index = DB::SymbolIndex::instance();
     std::unordered_map<std::string, DB::Dwarf> dwarfs;
 


### PR DESCRIPTION
Category (leave one):
- Bug Fix

Short description (up to few sentences):
Ignore memory limit from the StackTrace module to avoid unexpected exception, that will lead to closing the client socket and read after eof on the client eventually.

Detailed description (optional):

Otherwise once `max_memory_usage` reached, StackTrace can fail to resolve
the addresses and the client will got EOF:

```
  # restart the server
  $ clickhouse-client --max_memory_usage=4000000 -q 'select foo'
  Code: 32. DB::Exception: Attempt to read after eof: while receiving packet from localhost:9000
```

```
  $ clickhouse-client -q 'select foo'
  Received exception from server (version 19.16.1):
  Code: 47. DB::Exception: Received from localhost:9000. DB::Exception: Missing columns: 'foo' while processing query: 'SELECT foo', required columns: 'foo', source columns: 'dummy'.
```
And the server should got this:
```
  2019.10.10 15:17:23.712268 [ 27 ] {} <Error> ServerErrorHandler: Code: 241, e.displayText() = DB::Exception: Memory limit (for query) exceeded: would use 4.16 MiB (attempt to allocate chunk of 4367069 bytes), maximum: 3.81 MiB, Stack trace:

  0. 0x55c55645e300 StackTrace::StackTrace() /build/obj-x86_64-linux-gnu/../dbms/src/Common/StackTrace.cpp:228
  1. 0x55c55645e0d5 DB::Exception::Exception(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int) /build/obj-x86_64-linux-gnu/../dbms/src/Common/Exception.h:27
  2. 0x55c555facf43 MemoryTracker::alloc(long) [clone .cold] /usr/include/c++/9/bits/basic_string.h:222
  3. 0x55c55645cf5c MemoryTracker::alloc(long) /build/obj-x86_64-linux-gnu/../dbms/src/Common/MemoryTracker.cpp:134
  4. 0x55c556404111 operator new(unsigned long) /build/obj-x86_64-linux-gnu/../libs/libcommon/include/common/memory.h:44
  5. 0x55c5564647b6 void std::vector<DB::SymbolIndex::Symbol, std::allocator<DB::SymbolIndex::Symbol> >::_M_realloc_insert<DB::SymbolIndex::Symbol>(__gnu_cxx::__normal_iterator<DB::SymbolIndex::Symbol*, std::vector<DB::SymbolIndex::Symbol, std::allocator<DB::SymbolIndex::Symb
  6. 0x55c5564630cd DB::(anonymous namespace)::collectSymbols(dl_phdr_info*, unsigned long, void*) /usr/include/c++/9/bits/vector.tcc:121
  7. 0x55c55b98da47 dl_iterate_phdr /build/obj-x86_64-linux-gnu/../libs/libcommon/src/phdr_cache.cpp:84
  8. 0x55c5564643cd DB::SymbolIndex::update() /usr/include/c++/9/bits/stl_iterator.h:807
  9. 0x55c5564646ad DB::SymbolIndex::instance() /build/obj-x86_64-linux-gnu/../dbms/src/Common/SymbolIndex.cpp:366
  10. 0x55c55645ed8d toStringEveryLineImpl(std::array<void*, 32ul> const&, unsigned long, unsigned long, std::function<void (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>) /usr/include/c++/9/bits/basic_ios.h:462
  11. 0x55c55645fccc std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > SimpleCache<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > (std::array<void*, 32ul> const&, unsigned long, unsigned long), &(toStringImpl(std:
  12. 0x55c556460191 StackTrace::toString[abi:cxx11]() const /build/obj-x86_64-linux-gnu/../dbms/src/Common/StackTrace.cpp:327
  13. 0x55c5561b4b43 DB::setExceptionStackTrace(DB::QueryLogElement&) /build/obj-x86_64-linux-gnu/../dbms/src/Interpreters/executeQuery.cpp:129
  14. 0x55c5561b504e DB::executeQueryImpl(char const*, char const*, DB::Context&, bool, DB::QueryProcessingStage::Enum, bool, DB::ReadBuffer*, bool)::{lambda()#3}::operator()() [clone .cold] /build/obj-x86_64-linux-gnu/../dbms/src/Interpreters/executeQuery.cpp:508
  15. 0x55c555fc0e96 DB::TCPHandler::runImpl() [clone .cold] /usr/include/c++/9/bits/std_function.h:690
  16. 0x55c5564e4b7b DB::TCPHandler::run() /build/obj-x86_64-linux-gnu/../dbms/programs/server/TCPHandler.cpp:1225
  17. 0x55c55a350ac0 Poco::Net::TCPServerConnection::start() /build/obj-x86_64-linux-gnu/../contrib/poco/Net/src/TCPServerConnection.cpp:57
  18. 0x55c55a3511dd Poco::Net::TCPServerDispatcher::run() /usr/include/c++/9/bits/atomic_base.h:327
  19. 0x55c55ba273b1 Poco::PooledThread::run() /usr/include/x86_64-linux-gnu/c++/9/bits/gthr-default.h:748
  20. 0x55c55ba2515c Poco::ThreadImpl::runnableEntry(void*) /build/obj-x86_64-linux-gnu/../contrib/poco/Foundation/include/Poco/AutoPtr.h:205
  21. 0x55c55c196ce0 execute_native_thread_routine /usr/lib/debug/usr/bin/clickhouse
  22. 0x7f0c3877f6db start_thread /lib/x86_64-linux-gnu/libpthread-2.27.so
  23. 0x7f0c3809c88f clone /lib/x86_64-linux-gnu/libc-2.27.so
```

But it wont because the catch handler from `TCPHandler::runImpl()`, and
silently discarded.

P.S. this patch should fix failure of the `01017_uniqCombined_memory_usage` test