### PR TITLE
Add aggregate function combinators: -OrNull & -OrDefault

### DIFF
--- a/dbms/src/AggregateFunctions/AggregateFunctionOrFill.cpp
+++ b/dbms/src/AggregateFunctions/AggregateFunctionOrFill.cpp
@@ -1,0 +1,39 @@
+#include <AggregateFunctions/AggregateFunctionOrFill.h>
+
+#include <AggregateFunctions/AggregateFunctionCombinatorFactory.h>
+
+
+namespace DB
+{
+
+template <bool UseNull>
+class AggregateFunctionCombinatorOrFill final : public IAggregateFunctionCombinator
+{
+public:
+    String getName() const override
+    {
+        if constexpr (UseNull)
+            return "OrNull";
+        else
+            return "OrDefault";
+    }
+
+    AggregateFunctionPtr transformAggregateFunction(
+        const AggregateFunctionPtr & nested_function,
+        const DataTypes & arguments,
+        const Array & params) const override
+    {
+        return std::make_shared<AggregateFunctionOrFill<UseNull>>(
+            nested_function,
+            arguments,
+            params);
+    }
+};
+
+void registerAggregateFunctionCombinatorOrFill(AggregateFunctionCombinatorFactory & factory)
+{
+    factory.registerCombinator(std::make_shared<AggregateFunctionCombinatorOrFill<false>>());
+    factory.registerCombinator(std::make_shared<AggregateFunctionCombinatorOrFill<true>>());
+}
+
+}

--- a/dbms/src/AggregateFunctions/AggregateFunctionOrFill.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionOrFill.h
@@ -1,0 +1,172 @@
+#pragma once
+
+#include <AggregateFunctions/IAggregateFunction.h>
+#include <Columns/ColumnNullable.h>
+#include <DataTypes/DataTypeNullable.h>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int ARGUMENT_OUT_OF_BOUND;
+}
+
+template <bool UseNull>
+class AggregateFunctionOrFill final : public IAggregateFunctionHelper<AggregateFunctionOrFill<UseNull>>
+{
+private:
+    AggregateFunctionPtr nested_function;
+
+    size_t sod;
+    DataTypePtr inner_type;
+    bool inner_nullable;
+
+public:
+    AggregateFunctionOrFill(AggregateFunctionPtr nested_function_, const DataTypes & arguments, const Array & params)
+        : IAggregateFunctionHelper<AggregateFunctionOrFill>{arguments, params}
+        , nested_function{nested_function_}
+        , sod {nested_function->sizeOfData()}
+        , inner_type {nested_function->getReturnType()}
+        , inner_nullable {inner_type->isNullable()}
+    {
+        // nothing
+    }
+
+    String getName() const override
+    {
+        if constexpr (UseNull)
+            return nested_function->getName() + "OrNull";
+        else
+            return nested_function->getName() + "OrDefault";
+    }
+
+    const char * getHeaderFilePath() const override
+    {
+        return __FILE__;
+    }
+
+    bool isState() const override
+    {
+        return nested_function->isState();
+    }
+
+    bool allocatesMemoryInArena() const override
+    {
+        return nested_function->allocatesMemoryInArena();
+    }
+
+    bool hasTrivialDestructor() const override
+    {
+        return nested_function->hasTrivialDestructor();
+    }
+
+    size_t sizeOfData() const override
+    {
+        return sod + sizeof(bool);
+    }
+
+    size_t alignOfData() const override
+    {
+        return nested_function->alignOfData();
+    }
+
+    void create(AggregateDataPtr place) const override
+    {
+        nested_function->create(place);
+
+        place[sod] = 0;
+    }
+
+    void destroy(AggregateDataPtr place) const noexcept override
+    {
+        nested_function->destroy(place);
+    }
+
+    void add(
+        AggregateDataPtr place,
+        const IColumn ** columns,
+        size_t row_num,
+        Arena * arena) const override
+    {
+        nested_function->add(place, columns, row_num, arena);
+
+        place[sod] = 1;
+    }
+
+    void merge(
+        AggregateDataPtr place,
+        ConstAggregateDataPtr rhs,
+        Arena * arena) const override
+    {
+        nested_function->merge(place, rhs, arena);
+    }
+
+    void serialize(
+        ConstAggregateDataPtr place,
+        WriteBuffer & buf) const override
+    {
+        nested_function->serialize(place, buf);
+    }
+
+    void deserialize(
+        AggregateDataPtr place,
+        ReadBuffer & buf,
+        Arena * arena) const override
+    {
+        nested_function->deserialize(place, buf, arena);
+    }
+
+    DataTypePtr getReturnType() const override
+    {
+        if constexpr (UseNull)
+        {
+            // -OrNull
+
+            if (inner_nullable)
+                return inner_type;
+
+            return std::make_shared<DataTypeNullable>(inner_type);
+        }
+        else
+        {
+            // -OrDefault
+
+            return inner_type;
+        }
+    }
+
+    void insertResultInto(
+        ConstAggregateDataPtr place,
+        IColumn & to) const override
+    {
+        if constexpr (UseNull)
+        {
+            // -OrNull
+
+            ColumnNullable & col = static_cast<ColumnNullable &>(to);
+
+            if (place[sod])
+            {
+                if (inner_nullable)
+                    nested_function->insertResultInto(place, col);
+                else
+                    nested_function->insertResultInto(place, col.getNestedColumn());
+            }
+            else
+                col.insertDefault();
+        }
+        else
+        {
+            // -OrDefault
+
+            if (place[sod])
+                nested_function->insertResultInto(place, to);
+            else
+                to.insertDefault();
+        }
+    }
+};
+
+}

--- a/dbms/src/AggregateFunctions/AggregateFunctionOrFill.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionOrFill.h
@@ -14,6 +14,12 @@ namespace ErrorCodes
     extern const int ARGUMENT_OUT_OF_BOUND;
 }
 
+/**
+  * -OrDefault and -OrNull combinators for aggregate functions.
+  * If there are no input values, return NULL or a default value, accordingly.
+  * Use a single additional byte of data after the nested function data:
+  * 0 means there was no input, 1 means there was some.
+  */
 template <bool UseNull>
 class AggregateFunctionOrFill final : public IAggregateFunctionHelper<AggregateFunctionOrFill<UseNull>>
 {

--- a/dbms/src/AggregateFunctions/AggregateFunctionOrFill.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionOrFill.h
@@ -26,7 +26,7 @@ class AggregateFunctionOrFill final : public IAggregateFunctionHelper<AggregateF
 private:
     AggregateFunctionPtr nested_function;
 
-    size_t sod;
+    size_t size_of_data;
     DataTypePtr inner_type;
     bool inner_nullable;
 
@@ -34,7 +34,7 @@ public:
     AggregateFunctionOrFill(AggregateFunctionPtr nested_function_, const DataTypes & arguments, const Array & params)
         : IAggregateFunctionHelper<AggregateFunctionOrFill>{arguments, params}
         , nested_function{nested_function_}
-        , sod {nested_function->sizeOfData()}
+        , size_of_data {nested_function->sizeOfData()}
         , inner_type {nested_function->getReturnType()}
         , inner_nullable {inner_type->isNullable()}
     {
@@ -71,7 +71,7 @@ public:
 
     size_t sizeOfData() const override
     {
-        return sod + sizeof(bool);
+        return size_of_data + sizeof(char);
     }
 
     size_t alignOfData() const override
@@ -83,7 +83,7 @@ public:
     {
         nested_function->create(place);
 
-        place[sod] = 0;
+        place[size_of_data] = 0;
     }
 
     void destroy(AggregateDataPtr place) const noexcept override
@@ -99,7 +99,7 @@ public:
     {
         nested_function->add(place, columns, row_num, arena);
 
-        place[sod] = 1;
+        place[size_of_data] = 1;
     }
 
     void merge(
@@ -148,7 +148,7 @@ public:
         ConstAggregateDataPtr place,
         IColumn & to) const override
     {
-        if (place[sod])
+        if (place[size_of_data])
         {
             if constexpr (UseNull)
             {

--- a/dbms/src/AggregateFunctions/registerAggregateFunctions.cpp
+++ b/dbms/src/AggregateFunctions/registerAggregateFunctions.cpp
@@ -42,6 +42,7 @@ void registerAggregateFunctionCombinatorForEach(AggregateFunctionCombinatorFacto
 void registerAggregateFunctionCombinatorState(AggregateFunctionCombinatorFactory &);
 void registerAggregateFunctionCombinatorMerge(AggregateFunctionCombinatorFactory &);
 void registerAggregateFunctionCombinatorNull(AggregateFunctionCombinatorFactory &);
+void registerAggregateFunctionCombinatorOrFill(AggregateFunctionCombinatorFactory &);
 void registerAggregateFunctionCombinatorResample(AggregateFunctionCombinatorFactory &);
 
 void registerAggregateFunctions()
@@ -88,6 +89,7 @@ void registerAggregateFunctions()
         registerAggregateFunctionCombinatorState(factory);
         registerAggregateFunctionCombinatorMerge(factory);
         registerAggregateFunctionCombinatorNull(factory);
+        registerAggregateFunctionCombinatorOrFill(factory);
         registerAggregateFunctionCombinatorResample(factory);
     }
 }

--- a/dbms/tests/queries/0_stateless/01018_empty_aggregation_filling.reference
+++ b/dbms/tests/queries/0_stateless/01018_empty_aggregation_filling.reference
@@ -1,0 +1,48 @@
+--- Int Empty ---
+0
+\N
+0
+\N
+0
+\N
+0
+\N
+0
+\N
+0
+\N
+--- Int Non-empty ---
+1
+1
+nan
+nan
+1
+1
+1
+1
+nan
+nan
+1
+1
+--- Other Types Empty ---
+
+\N
+\N
+\N
+0.00
+\N
+0
+\N
+0.00
+\N
+--- Other Types Non-empty ---
+hello
+hello
+2011-04-05 14:19:19
+2011-04-05 14:19:19
+-123.45
+-123.45
+inf
+inf
+-123.45
+-123.45

--- a/dbms/tests/queries/0_stateless/01018_empty_aggregation_filling.sql
+++ b/dbms/tests/queries/0_stateless/01018_empty_aggregation_filling.sql
@@ -1,0 +1,61 @@
+SELECT '--- Int Empty ---';
+
+SELECT arrayReduce('avgOrDefault', arrayPopBack([1]));
+SELECT arrayReduce('avgOrNull', arrayPopBack([1]));
+SELECT arrayReduce('stddevSampOrDefault', arrayPopBack([1]));
+SELECT arrayReduce('stddevSampOrNull', arrayPopBack([1]));
+SELECT arrayReduce('maxOrDefault', arrayPopBack([1]));
+SELECT arrayReduce('maxOrNull', arrayPopBack([1]));
+
+SELECT avgOrDefaultIf(x, x > 1) FROM (SELECT 1 AS x);
+SELECT avgOrNullIf(x, x > 1) FROM (SELECT 1 AS x);
+SELECT stddevSampOrDefaultIf(x, x > 1) FROM (SELECT 1 AS x);
+SELECT stddevSampOrNullIf(x, x > 1) FROM (SELECT 1 AS x);
+SELECT maxOrDefaultIf(x, x > 1) FROM (SELECT 1 AS x);
+SELECT maxOrNullIf(x, x > 1) FROM (SELECT 1 AS x);
+
+SELECT '--- Int Non-empty ---';
+
+SELECT arrayReduce('avgOrDefault', [1]);
+SELECT arrayReduce('avgOrNull', [1]);
+SELECT arrayReduce('stddevSampOrDefault', [1]);
+SELECT arrayReduce('stddevSampOrNull', [1]);
+SELECT arrayReduce('maxOrDefault', [1]);
+SELECT arrayReduce('maxOrNull', [1]);
+
+SELECT avgOrDefaultIf(x, x > 0) FROM (SELECT 1 AS x);
+SELECT avgOrNullIf(x, x > 0) FROM (SELECT 1 AS x);
+SELECT stddevSampOrDefaultIf(x, x > 0) FROM (SELECT 1 AS x);
+SELECT stddevSampOrNullIf(x, x > 0) FROM (SELECT 1 AS x);
+SELECT maxOrDefaultIf(x, x > 0) FROM (SELECT 1 AS x);
+SELECT maxOrNullIf(x, x > 0) FROM (SELECT 1 AS x);
+
+SELECT '--- Other Types Empty ---';
+
+SELECT arrayReduce('maxOrDefault', arrayPopBack(['hello']));
+SELECT arrayReduce('maxOrNull', arrayPopBack(['hello']));
+
+SELECT arrayReduce('maxOrDefault', arrayPopBack(arrayPopBack([toDateTime('2011-04-05 14:19:19'), null])));
+SELECT arrayReduce('maxOrNull', arrayPopBack(arrayPopBack([toDateTime('2011-04-05 14:19:19'), null])));
+
+SELECT arrayReduce('avgOrDefault', arrayPopBack([toDecimal128(-123.45, 2)]));
+SELECT arrayReduce('avgOrNull', arrayPopBack([toDecimal128(-123.45, 2)]));
+SELECT arrayReduce('stddevSampOrDefault', arrayPopBack([toDecimal128(-123.45, 2)]));
+SELECT arrayReduce('stddevSampOrNull', arrayPopBack([toDecimal128(-123.45, 2)]));
+SELECT arrayReduce('maxOrDefault', arrayPopBack([toDecimal128(-123.45, 2)]));
+SELECT arrayReduce('maxOrNull', arrayPopBack([toDecimal128(-123.45, 2)]));
+
+SELECT '--- Other Types Non-empty ---';
+
+SELECT arrayReduce('maxOrDefault', ['hello']);
+SELECT arrayReduce('maxOrNull', ['hello']);
+
+SELECT arrayReduce('maxOrDefault', [toDateTime('2011-04-05 14:19:19'), null]);
+SELECT arrayReduce('maxOrNull', [toDateTime('2011-04-05 14:19:19'), null]);
+
+SELECT arrayReduce('avgOrDefault', [toDecimal128(-123.45, 2)]);
+SELECT arrayReduce('avgOrNull', [toDecimal128(-123.45, 2)]);
+SELECT arrayReduce('stddevSampOrDefault', [toDecimal128(-123.45, 2)]);
+SELECT arrayReduce('stddevSampOrNull', [toDecimal128(-123.45, 2)]);
+SELECT arrayReduce('maxOrDefault', [toDecimal128(-123.45, 2)]);
+SELECT arrayReduce('maxOrNull', [toDecimal128(-123.45, 2)]);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- New Feature

Short description (up to few sentences):

Add aggregate function combinators which fill null or default value when there is nothing to aggregate.
