### PR TITLE
Remove asterisk_left_columns_only setting

### DIFF
--- a/dbms/src/Core/Settings.h
+++ b/dbms/src/Core/Settings.h
@@ -344,7 +344,6 @@ struct Settings : public SettingsCollection<Settings>
     \
     M(SettingBool, prefer_localhost_replica, 1, "1 - always send query to local replica, if it exists. 0 - choose replica to send query between local and remote ones according to load_balancing") \
     M(SettingUInt64, max_fetch_partition_retries_count, 5, "Amount of retries while fetching partition from another host.") \
-    M(SettingBool, asterisk_left_columns_only, 0, "If it is set to true, the asterisk only return left of join query.") \
     M(SettingUInt64, http_max_multipart_form_data_size, 1024 * 1024 * 1024, "Limit on size of multipart/form-data content. This setting cannot be parsed from URL parameters and should be set in user profile. Note that content is parsed and external tables are created in memory before start of query execution. And this is the only limit that has effect on that stage (limits on max memory usage and max execution time have no effect while reading HTTP form data).") \
     M(SettingBool, calculate_text_stack_trace, 1, "Calculate text stack trace in case of exceptions during query execution. This is the default. It requires symbol lookups that may slow down fuzzing tests when huge amount of wrong queries are executed. In normal cases you should not disable this option.") \
     M(SettingBool, allow_ddl, true, "If it is set to true, then a user is allowed to executed DDL queries.") \

--- a/dbms/src/Interpreters/PredicateExpressionsOptimizer.cpp
+++ b/dbms/src/Interpreters/PredicateExpressionsOptimizer.cpp
@@ -406,7 +406,7 @@ ASTs PredicateExpressionsOptimizer::getSelectQueryProjectionColumns(ASTPtr & ast
 
     /// TODO: get tables from evaluateAsterisk instead of tablesOnly() to extract asterisks in general way
     std::vector<TableWithColumnNames> tables_with_columns = TranslateQualifiedNamesVisitor::Data::tablesOnly(tables);
-    TranslateQualifiedNamesVisitor::Data qn_visitor_data({}, tables_with_columns, false);
+    TranslateQualifiedNamesVisitor::Data qn_visitor_data({}, std::move(tables_with_columns), false);
     TranslateQualifiedNamesVisitor(qn_visitor_data).visit(ast);
 
     QueryAliasesVisitor::Data query_aliases_data{aliases};

--- a/dbms/src/Interpreters/SyntaxAnalyzer.cpp
+++ b/dbms/src/Interpreters/SyntaxAnalyzer.cpp
@@ -74,36 +74,28 @@ using LogAST = DebugASTLog<false>; /// set to true to enable logs
 
 
 /// Add columns from storage to source_columns list.
-void collectSourceColumns(const ASTSelectQuery * select_query, StoragePtr storage, NamesAndTypesList & source_columns)
+void collectSourceColumns(const ColumnsDescription & columns, NamesAndTypesList & source_columns, bool add_virtuals)
 {
-    if (storage)
-    {
-        auto physical_columns = storage->getColumns().getAllPhysical();
-        if (source_columns.empty())
-            source_columns.swap(physical_columns);
-        else
-            source_columns.insert(source_columns.end(), physical_columns.begin(), physical_columns.end());
+    auto physical_columns = columns.getAllPhysical();
+    if (source_columns.empty())
+        source_columns.swap(physical_columns);
+    else
+        source_columns.insert(source_columns.end(), physical_columns.begin(), physical_columns.end());
 
-        if (select_query)
-        {
-            const auto & storage_aliases = storage->getColumns().getAliases();
-            const auto & storage_virtuals = storage->getColumns().getVirtuals();
-            source_columns.insert(source_columns.end(), storage_aliases.begin(), storage_aliases.end());
-            source_columns.insert(source_columns.end(), storage_virtuals.begin(), storage_virtuals.end());
-        }
+    if (add_virtuals)
+    {
+        const auto & storage_aliases = columns.getAliases();
+        const auto & storage_virtuals = columns.getVirtuals();
+        source_columns.insert(source_columns.end(), storage_aliases.begin(), storage_aliases.end());
+        source_columns.insert(source_columns.end(), storage_virtuals.begin(), storage_virtuals.end());
     }
 }
 
-/// Translate qualified names such as db.table.column, table.column, table_alias.column to names' normal form.
-/// Expand asterisks and qualified asterisks with column names.
-/// There would be columns in normal form & column aliases after translation. Column & column alias would be normalized in QueryNormalizer.
-void translateQualifiedNames(ASTPtr & query, const ASTSelectQuery & select_query, const Context & context,
-                             const Names & source_columns_list, const NameSet & source_columns_set,
-                             const NameSet & columns_from_joined_table)
+std::vector<TableWithColumnNames> getTablesWithColumns(const ASTSelectQuery & select_query, const Context & context)
 {
-    auto & settings = context.getSettingsRef();
-
     std::vector<TableWithColumnNames> tables_with_columns = getDatabaseAndTablesWithColumnNames(select_query, context);
+
+    auto & settings = context.getSettingsRef();
     if (settings.joined_subquery_requires_alias && tables_with_columns.size() > 1)
     {
         for (auto & pr : tables_with_columns)
@@ -112,21 +104,18 @@ void translateQualifiedNames(ASTPtr & query, const ASTSelectQuery & select_query
                                 ErrorCodes::ALIAS_REQUIRED);
     }
 
-    if (tables_with_columns.empty())
-    {
-        Names all_columns_name = source_columns_list;
+    return tables_with_columns;
+}
 
-        if (!settings.asterisk_left_columns_only)
-        {
-            for (auto & column : columns_from_joined_table)
-                all_columns_name.emplace_back(column);
-        }
 
-        tables_with_columns.emplace_back(DatabaseAndTableWithAlias{}, std::move(all_columns_name));
-    }
-
+/// Translate qualified names such as db.table.column, table.column, table_alias.column to names' normal form.
+/// Expand asterisks and qualified asterisks with column names.
+/// There would be columns in normal form & column aliases after translation. Column & column alias would be normalized in QueryNormalizer.
+void translateQualifiedNames(ASTPtr & query, const ASTSelectQuery & select_query, const NameSet & source_columns_set,
+                             std::vector<TableWithColumnNames> && tables_with_columns)
+{
     LogAST log;
-    TranslateQualifiedNamesVisitor::Data visitor_data(source_columns_set, tables_with_columns);
+    TranslateQualifiedNamesVisitor::Data visitor_data(source_columns_set, std::move(tables_with_columns));
     TranslateQualifiedNamesVisitor visitor(visitor_data, log.stream());
     visitor.visit(query);
 
@@ -456,7 +445,7 @@ void optimizeUsing(const ASTSelectQuery * select_query)
 }
 
 void getArrayJoinedColumns(ASTPtr & query, SyntaxAnalyzerResult & result, const ASTSelectQuery * select_query,
-                           const Names & source_columns, const NameSet & source_columns_set)
+                           const NameSet & source_columns_set)
 {
     if (ASTPtr array_join_expression_list = select_query->array_join_expression_list())
     {
@@ -482,7 +471,7 @@ void getArrayJoinedColumns(ASTPtr & query, SyntaxAnalyzerResult & result, const 
             else /// This is a nested table.
             {
                 bool found = false;
-                for (const auto & column_name : source_columns)
+                for (const auto & column_name : source_columns_set)
                 {
                     auto splitted = Nested::splitName(column_name);
                     if (splitted.first == source_name && !splitted.second.empty())
@@ -807,16 +796,9 @@ SyntaxAnalyzerResultPtr SyntaxAnalyzer::analyze(
     result.source_columns = source_columns_;
     result.analyzed_join = std::make_shared<AnalyzedJoin>(settings); /// TODO: move to select_query logic
 
-    collectSourceColumns(select_query, result.storage, result.source_columns);
+    if (storage)
+        collectSourceColumns(storage->getColumns(), result.source_columns, (select_query != nullptr));
     NameSet source_columns_set = removeDuplicateColumns(result.source_columns);
-
-    Names source_columns_list;
-    source_columns_list.reserve(result.source_columns.size());
-    for (const auto & type_name : result.source_columns)
-        source_columns_list.emplace_back(type_name.name);
-
-    if (source_columns_set.size() != source_columns_list.size())
-        throw Exception("Unexpected duplicates in source columns list.", ErrorCodes::LOGICAL_ERROR);
 
     if (select_query)
     {
@@ -838,9 +820,28 @@ SyntaxAnalyzerResultPtr SyntaxAnalyzer::analyze(
             result.analyzed_join->deduplicateAndQualifyColumnNames(source_columns_set, table.getQualifiedNamePrefix());
         }
 
-        translateQualifiedNames(query, *select_query, context,
-                                (storage ? storage->getColumns().getOrdinary().getNames() : source_columns_list), source_columns_set,
-                                result.analyzed_join->getQualifiedColumnsSet());
+        auto tables_with_columns = getTablesWithColumns(*select_query, context);
+
+        /// If empty make fake table with list of source and joined columns
+        if (tables_with_columns.empty())
+        {
+            Names columns_list;
+            if (storage)
+                columns_list = storage->getColumns().getOrdinary().getNames();
+            else
+            {
+                columns_list.reserve(result.source_columns.size());
+                for (const auto & type_name : result.source_columns)
+                    columns_list.emplace_back(type_name.name);
+            }
+
+            for (auto & column : result.analyzed_join->getQualifiedColumnsSet())
+                columns_list.emplace_back(column);
+
+            tables_with_columns.emplace_back(DatabaseAndTableWithAlias{}, std::move(columns_list));
+        }
+
+        translateQualifiedNames(query, *select_query, source_columns_set, std::move(tables_with_columns));
 
         /// Rewrite IN and/or JOIN for distributed tables according to distributed_product_mode setting.
         InJoinSubqueriesPreprocessor(context).visit(query);
@@ -890,7 +891,7 @@ SyntaxAnalyzerResultPtr SyntaxAnalyzer::analyze(
         optimizeUsing(select_query);
 
         /// array_join_alias_to_name, array_join_result_to_source.
-        getArrayJoinedColumns(query, result, select_query, source_columns_list, source_columns_set);
+        getArrayJoinedColumns(query, result, select_query, source_columns_set);
 
         /// Push the predicate expression down to the subqueries.
         result.rewrite_subqueries = PredicateExpressionsOptimizer(select_query, settings, context).optimize();

--- a/dbms/src/Interpreters/TranslateQualifiedNamesVisitor.h
+++ b/dbms/src/Interpreters/TranslateQualifiedNamesVisitor.h
@@ -25,11 +25,11 @@ public:
     struct Data
     {
         const NameSet source_columns;
-        const std::vector<TableWithColumnNames> & tables;
+        const std::vector<TableWithColumnNames> tables;
         std::unordered_set<String> join_using_columns;
         bool has_columns;
 
-        Data(const NameSet & source_columns_, const std::vector<TableWithColumnNames> & tables_, bool has_columns_ = true)
+        Data(const NameSet & source_columns_, std::vector<TableWithColumnNames> && tables_, bool has_columns_ = true)
             : source_columns(source_columns_)
             , tables(tables_)
             , has_columns(has_columns_)

--- a/dbms/tests/queries/0_stateless/00850_global_join_dups.sql
+++ b/dbms/tests/queries/0_stateless/00850_global_join_dups.sql
@@ -8,7 +8,6 @@ CREATE TABLE t2_00850 (dummy UInt8) ENGINE = Distributed(test_shard_localhost, c
 
 INSERT INTO t_local VALUES (1);
 
-SET asterisk_left_columns_only = 1;
 SET joined_subquery_requires_alias = 0;
 
 SELECT * FROM t1_00850
@@ -33,9 +32,6 @@ GLOBAL INNER JOIN
     GLOBAL INNER JOIN ( SELECT dummy FROM remote('127.0.0.3', system.one) ) t2_00850
     USING dummy
 ) USING dummy;
-
-
-SET asterisk_left_columns_only = 0;
 
 SELECT * FROM remote('127.0.0.2', system.one)
 GLOBAL INNER JOIN


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Backward Incompatible Change

Short description (up to few sentences):
Remove legacy ```asterisk_left_columns_only``` setting (it was disabled by default).

Detailed description (optional):
You can use qualified asterisks instead: ```select t.* from t join u```.