### PR TITLE
Build fix

### DIFF
--- a/dbms/src/Common/MemorySanitizer.h
+++ b/dbms/src/Common/MemorySanitizer.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-id-macro"
+#endif
+
 #define __msan_unpoison(X, Y)
 #define __msan_test_shadow(X, Y) (false)
 #define __msan_print_shadow(X, Y)
@@ -10,4 +15,8 @@
 #       undef __msan_print_shadow
 #       include <sanitizer/msan_interface.h>
 #   endif
+#endif
+
+#ifdef __clang__
+#pragma clang diagnostic pop
 #endif


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

@akuzm 

```

PATH=/home/amos/gentoo/usr/lib/llvm/7/bin/:$PATH

cmake ../src -DENABLE_CAPNP=0 -DENABLE_ICU=0 -DUSE_LIBCXX=0 -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=None -DCMAKE_INSTALL_SYSCONFDIR=/etc -DCMAKE_INSTALL_LOCALSTATEDIR=/var -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY=ON -DENABLE_EMBEDDED_COMPILER=1 -DADD_GDB_INDEX_FOR_GOLD=1 -DENABLE_TESTS=0 -DENABLE_UTILS=0

...


/home/amos/gentoo/usr/lib/llvm/7/bin/clang++  -DBOOST_SYSTEM_NO_DEPRECATED -DPOCO_STATIC -DPOCO_UNBUNDLED_ZLIB -DUNALIGNED_OK -DWITH_GZFILEOP -DX86_64 -DZLIB_COMPAT -I/data/ClickHouse/src/libs/libcommon/include -Ilibs/libcommon/include -isystem /data/ClickHouse/src/contrib/double-conversion -isystem /data/ClickHouse/src/contrib/brotli/c/include -isystem /data/ClickHouse/src/contrib/libhdfs3/include -isystem /data/ClickHouse/src/contrib/re2 -Idbms/src/Core/include -isystem /data/ClickHouse/src/contrib/libpcg-random/include -isystem /data/ClickHouse/src/contrib/poco/Data/include -I/data/ClickHouse/src/dbms/src -Idbms/src -isystem /data/ClickHouse/src/contrib/libunwind/include -isystem /data/ClickHouse/src/contrib/poco/Util/include -isystem /data/ClickHouse/src/contrib/poco/Foundation/include -I/data/ClickHouse/src/contrib/zlib-ng -Icontrib/zlib-ng -isystem /data/ClickHouse/src/contrib/poco/XML/include -isystem /data/ClickHouse/src/contrib/poco/JSON/include -I/data/ClickHouse/src/contrib/cityhash102/include -isystem /data/ClickHouse/src/contrib/boost -I/data/ClickHouse/src/libs/libwidechar_width -isystem /data/ClickHouse/src/contrib/poco/Net/include -isystem contrib/re2_st -I/data/ClickHouse/src/contrib/croaring -isystem /data/ClickHouse/src/contrib/libcpuid/include -isystem /data/ClickHouse/src/contrib/poco/NetSSL_OpenSSL/include -isystem /data/ClickHouse/src/contrib/poco/Crypto/include -isystem /data/ClickHouse/src/contrib/ssl/include -fdiagnostics-color=always -fsized-deallocation  -gdwarf-aranges -pipe -msse4.1 -msse4.2 -mpopcnt  -fno-omit-frame-pointer  -Wall -Wno-unused-command-line-argument  -Wnon-virtual-dtor -Wextra -Werror -Wpedantic -Wno-vla-extension -Wno-zero-length-array -Wno-gnu-anonymous-struct -Wno-nested-anon-types -Wshadow -Wshadow-uncaptured-local -Wextra-semi -Wcomma -Winconsistent-missing-destructor-override -Wunused-exception-parameter -Wcovered-switch-default -Wold-style-cast -Wrange-loop-analysis -Wunused-member-function -Wunreachable-code -Wunreachable-code-return -Wnewline-eof -Wembedded-directive -Wgnu-case-range -Wunused-macros -Wconditional-uninitialized -Wdeprecated -Wundef -Wreserved-id-macro -Wredundant-parens -Wzero-as-null-pointer-constant -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-padded -Wno-switch-enum -Wno-deprecated-dynamic-exception-spec -Wno-float-equal -Wno-weak-vtables -Wno-shift-sign-overflow -Wno-sign-conversion -Wno-conversion -Wno-exit-time-destructors -Wno-undefined-func-template -Wno-documentation-unknown-command -Wno-missing-variable-declarations -Wno-unused-template -Wno-global-constructors -Wno-c99-extensions -Wno-missing-prototypes -Wno-weak-template-vtables -Wno-zero-length-array -Wno-gnu-anonymous-struct -Wno-nested-anon-types -Wno-double-promotion -Wno-disabled-macro-expansion -Wno-vla-extension -Wno-vla -Wno-packed -Wno-return-std-move-in-c++11 -O2 -g -DNDEBUG -O3    -D OS_LINUX -std=c++1z -MD -MT dbms/CMakeFiles/clickhouse_common_io.dir/src/IO/ZlibDeflatingWriteBuffer.cpp.o -MF dbms/CMakeFiles/clickhouse_common_io.dir/src/IO/ZlibDeflatingWriteBuffer.cpp.o.d -o dbms/CMakeFiles/clickhouse_common_io.dir/src/IO/ZlibDeflatingWriteBuffer.cpp.o -c /data/ClickHouse/src/dbms/src/IO/ZlibDeflatingWriteBuffer.cpp
In file included from /data/ClickHouse/src/dbms/src/IO/ZlibDeflatingWriteBuffer.cpp:2:
/data/ClickHouse/src/dbms/src/Common/MemorySanitizer.h:3:9: error: macro name is a reserved identifier [-Werror,-Wreserved-id-macro]
#define __msan_unpoison(X, Y)
        ^
/data/ClickHouse/src/dbms/src/Common/MemorySanitizer.h:4:9: error: macro name is a reserved identifier [-Werror,-Wreserved-id-macro]
#define __msan_test_shadow(X, Y) (false)
        ^
/data/ClickHouse/src/dbms/src/Common/MemorySanitizer.h:5:9: error: macro name is a reserved identifier [-Werror,-Wreserved-id-macro]
#define __msan_print_shadow(X, Y)
        ^
3 errors generated.
Category (leave one):
- Build/Testing/Packaging Improvement
```
