### PR TITLE
Fixing ThreadSanitizer data race error in the LIVE VIEW when accessing no_users_thread variable

### DIFF
--- a/dbms/src/Storages/LiveView/StorageLiveView.cpp
+++ b/dbms/src/Storages/LiveView/StorageLiveView.cpp
@@ -375,7 +375,7 @@ void StorageLiveView::noUsersThread(std::shared_ptr<StorageLiveView> storage, co
     {
         while (1)
         {
-            std::unique_lock lock(storage->no_users_thread_mutex);
+            std::unique_lock lock(storage->no_users_thread_wakeup_mutex);
             if (!storage->no_users_thread_condition.wait_for(lock, std::chrono::seconds(timeout), [&] { return storage->no_users_thread_wakeup; }))
             {
                 storage->no_users_thread_wakeup = false;
@@ -421,17 +421,22 @@ void StorageLiveView::startNoUsersThread(const UInt64 & timeout)
 
     if (is_temporary)
     {
+        std::lock_guard no_users_thread_lock(no_users_thread_mutex);
+
+        if (shutdown_called)
+            return;
+
         if (no_users_thread.joinable())
         {
             {
-                std::lock_guard lock(no_users_thread_mutex);
+                std::lock_guard lock(no_users_thread_wakeup_mutex);
                 no_users_thread_wakeup = true;
                 no_users_thread_condition.notify_one();
             }
             no_users_thread.join();
         }
         {
-            std::lock_guard lock(no_users_thread_mutex);
+            std::lock_guard lock(no_users_thread_wakeup_mutex);
             no_users_thread_wakeup = false;
         }
         if (!is_dropped)
@@ -453,12 +458,15 @@ void StorageLiveView::shutdown()
     if (!shutdown_called.compare_exchange_strong(expected, true))
         return;
 
-    if (no_users_thread.joinable())
     {
+        std::lock_guard no_users_thread_lock(no_users_thread_mutex);
+        if (no_users_thread.joinable())
         {
-            std::lock_guard lock(no_users_thread_mutex);
-            no_users_thread_wakeup = true;
-            no_users_thread_condition.notify_one();
+            {
+                std::lock_guard lock(no_users_thread_wakeup_mutex);
+                no_users_thread_wakeup = true;
+                no_users_thread_condition.notify_one();
+            }
         }
     }
 }
@@ -466,8 +474,12 @@ void StorageLiveView::shutdown()
 StorageLiveView::~StorageLiveView()
 {
     shutdown();
-    if (no_users_thread.joinable())
-        no_users_thread.detach();
+
+    {
+        std::lock_guard lock(no_users_thread_mutex);
+        if (no_users_thread.joinable())
+            no_users_thread.detach();
+    }
 }
 
 void StorageLiveView::drop(TableStructureWriteLockHolder &)
@@ -539,11 +551,14 @@ BlockInputStreams StorageLiveView::watch(
             context.getSettingsRef().live_view_heartbeat_interval.totalSeconds(),
             context.getSettingsRef().temporary_live_view_timeout.totalSeconds());
 
-        if (no_users_thread.joinable())
         {
-            std::lock_guard lock(no_users_thread_mutex);
-            no_users_thread_wakeup = true;
-            no_users_thread_condition.notify_one();
+            std::lock_guard no_users_thread_lock(no_users_thread_mutex);
+            if (no_users_thread.joinable())
+            {
+                std::lock_guard lock(no_users_thread_wakeup_mutex);
+                no_users_thread_wakeup = true;
+                no_users_thread_condition.notify_one();
+            }
         }
 
         {
@@ -567,11 +582,14 @@ BlockInputStreams StorageLiveView::watch(
             context.getSettingsRef().live_view_heartbeat_interval.totalSeconds(),
             context.getSettingsRef().temporary_live_view_timeout.totalSeconds());
 
-        if (no_users_thread.joinable())
         {
-            std::lock_guard lock(no_users_thread_mutex);
-            no_users_thread_wakeup = true;
-            no_users_thread_condition.notify_one();
+            std::lock_guard no_users_thread_lock(no_users_thread_mutex);
+            if (no_users_thread.joinable())
+            {
+                std::lock_guard lock(no_users_thread_wakeup_mutex);
+                no_users_thread_wakeup = true;
+                no_users_thread_condition.notify_one();
+            }
         }
 
         {

--- a/dbms/src/Storages/LiveView/StorageLiveView.h
+++ b/dbms/src/Storages/LiveView/StorageLiveView.h
@@ -73,7 +73,7 @@ public:
     }
     /// No users thread mutex, predicate and wake up condition
     void startNoUsersThread(const UInt64 & timeout);
-    std::mutex no_users_thread_mutex;
+    std::mutex no_users_thread_wakeup_mutex;
     bool no_users_thread_wakeup = false;
     std::condition_variable no_users_thread_condition;
     /// Get blocks hash
@@ -168,6 +168,7 @@ private:
     /// Background thread for temporary tables
     /// which drops this table if there are no users
     static void noUsersThread(std::shared_ptr<StorageLiveView> storage, const UInt64 & timeout);
+    std::mutex no_users_thread_mutex;
     std::thread no_users_thread;
     std::atomic<bool> shutdown_called = false;
     std::atomic<bool> start_no_users_thread_called = false;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Bug Fix

Fixing ThreadSanitizer data race error in the LIVE VIEW when accessing no_users_thread variable.

