### PR TITLE
Constness-aware JoinGet.

### DIFF
--- a/dbms/src/Functions/FunctionJoinGet.cpp
+++ b/dbms/src/Functions/FunctionJoinGet.cpp
@@ -82,13 +82,18 @@ DataTypePtr FunctionBuilderJoinGet::getReturnTypeImpl(const ColumnsWithTypeAndNa
 }
 
 
-void FunctionJoinGet::executeImpl(Block & block, const ColumnNumbers & arguments, size_t result, size_t /*input_rows_count*/)
+void FunctionJoinGet::executeImpl(Block & block, const ColumnNumbers & arguments, size_t result, size_t input_rows_count)
 {
-    auto & ctn = block.getByPosition(arguments[2]);
+    auto ctn = block.getByPosition(arguments[2]);
+    if (isColumnConst(*ctn.column))
+        ctn.column = ctn.column->cloneResized(1);
     ctn.name = ""; // make sure the key name never collide with the join columns
     Block key_block = {ctn};
     join->joinGet(key_block, attr_name);
-    block.getByPosition(result) = key_block.getByPosition(1);
+    auto & result_ctn = key_block.getByPosition(1);
+    if (isColumnConst(*ctn.column))
+        result_ctn.column = ColumnConst::create(result_ctn.column, input_rows_count);
+    block.getByPosition(result) = result_ctn;
 }
 
 void registerFunctionJoinGet(FunctionFactory & factory)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

The problem is discovered by @yingfeng and his collegue when testing joinGet with bitmaps.

Consider the following query,
```
WITH joinGet('cdp_tags_kv', 'mid_seqs', 'tag1') AS bm1,
     joinGet('cdp_tags_kv', 'mid_seqs', 'tag2') AS bm2,
SELECT multiIf(bitmapContains(bm1, mid_seq), 1, bitmapContains(bm2, mid_seq), 2, 0) AS tag, count() AS gc
FROM cdp_orders
PREWHERE order_complete_time >= '2019-01-01 00:00:00' AND order_complete_time <= '2019-01-01 01:00:00'
GROUP BY tag;
```

without constness-aware, joinGet will duplicate bitmaps.


Category (leave one):
- Performance Improvement


