### PR TITLE
Fix ubsan introduced by Field refactoring.

### DIFF
--- a/dbms/src/Core/Field.h
+++ b/dbms/src/Core/Field.h
@@ -457,7 +457,6 @@ private:
     void createConcrete(T && x)
     {
         using UnqualifiedType = std::decay_t<T>;
-        which = TypeToEnum<UnqualifiedType>::value;
 
         // In both Field and PODArray, small types may be stored as wider types,
         // e.g. char is stored as UInt64. Field can return this extended value
@@ -466,6 +465,7 @@ private:
         // nominal type.
         using StorageType = NearestFieldType<UnqualifiedType>;
         new (&storage) StorageType(std::forward<T>(x));
+        which = TypeToEnum<UnqualifiedType>::value;
     }
 
     /// Assuming same types.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

`which` is also acted as an empty guard for `destroy` and should be set after `new`.

This ubsan can be reproduced using the following SQL along with this pr https://github.com/ClickHouse/ClickHouse/pull/7179  

```
SET max_memory_usage = 1000000000;
SELECT
    number,
    argMax(number, tuple(toFixedString('1234567890123456789012', 25)))
FROM numbers(100000000);
```

Why did CI not catch this? Because it only happens when the memory exception is thrown right after a field is created (note the string size, <=22 is fine), which is very unlikely. 

Category (leave one):
- Bug Fix

