### PR TITLE
Make Field::get type-safe in debug builds

### DIFF
--- a/dbms/src/Core/Field.h
+++ b/dbms/src/Core/Field.h
@@ -694,11 +694,25 @@ template <> struct Field::EnumToType<Field::Types::Decimal64> { using Type = Dec
 template <> struct Field::EnumToType<Field::Types::Decimal128> { using Type = DecimalField<Decimal128>; };
 template <> struct Field::EnumToType<Field::Types::AggregateFunctionState> { using Type = DecimalField<AggregateFunctionStateData>; };
 
+inline constexpr bool isInt64FieldType(Field::Types::Which t)
+{
+    return t == Field::Types::Int64
+        || t == Field::Types::UInt64;
+}
+
+// Field value getter with type checking in debug builds.
 template <typename T>
 T & Field::get()
 {
     using ValueType = std::decay_t<T>;
-    //assert(TypeToEnum<NearestFieldType<ValueType>>::value == which);
+
+#ifndef NDEBUG
+    // Disregard signedness when converting between int64 types.
+    constexpr Field::Types::Which target = TypeToEnum<NearestFieldType<ValueType>>::value;
+    assert(target == which
+           || (isInt64FieldType(target) && isInt64FieldType(which)));
+#endif
+
     ValueType * MAY_ALIAS ptr = reinterpret_cast<ValueType *>(&storage);
     return *ptr;
 }


### PR DESCRIPTION
Category (leave one):
- Build/Testing/Packaging Improvement

Short description (up to few sentences):
Make Field methods more type-safe to find more errors.