### PR TITLE
murmurhash32 ubsan fix.

### DIFF
--- a/contrib/murmurhash/src/murmurhash2.cpp
+++ b/contrib/murmurhash/src/murmurhash2.cpp
@@ -13,6 +13,7 @@
 //    machines.
 
 #include "murmurhash2.h"
+#include <cstring>
 
 // Platform-specific functions and macros
 // Microsoft Visual Studio
@@ -48,7 +49,8 @@ uint32_t MurmurHash2(const void * key, int len, uint32_t seed)
 
     while (len >= 4)
     {
-        uint32_t k = *reinterpret_cast<const uint32_t *>(data);
+        uint32_t k;
+        memcpy(&k, data, sizeof(k));
         k *= m;
         k ^= k >> r;
         k *= m;

--- a/contrib/murmurhash/src/murmurhash3.cpp
+++ b/contrib/murmurhash/src/murmurhash3.cpp
@@ -7,6 +7,7 @@
 // non-native version will be less than optimal.
 
 #include "murmurhash3.h"
+#include <cstring>
 
 //-----------------------------------------------------------------------------
 // Platform-specific functions and macros
@@ -53,7 +54,9 @@ inline uint64_t rotl64 ( uint64_t x, int8_t r )
 
 FORCE_INLINE uint32_t getblock32 ( const uint32_t * p, int i )
 {
-  return p[i];
+  uint32_t res;
+  memcpy(&res, p + i, sizeof(res));
+  return res;
 }
 
 FORCE_INLINE uint64_t getblock64 ( const uint64_t * p, int i )


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Can be reproduced with ubsan build and following queries.
```
SELECT * from numbers(1000, 2) where murmurHash2_32(toString(number)) = 1;
SELECT * from numbers(1000, 2) where murmurHash3_32(toString(number)) = 1;
```

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix
