### PR TITLE
Add a message in case of queue_wait_max_ms wait takes place

### DIFF
--- a/dbms/src/Interpreters/ProcessList.cpp
+++ b/dbms/src/Interpreters/ProcessList.cpp
@@ -90,6 +90,8 @@ ProcessList::EntryPtr ProcessList::insert(const String & query_, const IAST * as
         const auto queue_max_wait_ms = settings.queue_max_wait_ms.totalMilliseconds();
         if (!is_unlimited_query && max_size && processes.size() >= max_size)
         {
+            if (queue_max_wait_ms)
+                LOG_WARNING(&Logger::get("ProcessList"), "Too many simultaneous queries, will wait " << queue_max_wait_ms << " ms.");
             if (!queue_max_wait_ms || !have_space.wait_for(lock, std::chrono::milliseconds(queue_max_wait_ms), [&]{ return processes.size() < max_size; }))
                 throw Exception("Too many simultaneous queries. Maximum: " + toString(max_size), ErrorCodes::TOO_MANY_SIMULTANEOUS_QUERIES);
         }


### PR DESCRIPTION
Category (leave one):
- Improvement

Short description (up to few sentences):
Add a message in case of queue_wait_max_ms wait takes place

Detailed description (optional):
Since there no information about this, while this can be interesting,
for example to tune max_concurrent_queries in some cases.