### PR TITLE
Fixed erroneous warning `max_data_part_size is too low`

### DIFF
--- a/dbms/src/Common/DiskSpaceMonitor.cpp
+++ b/dbms/src/Common/DiskSpaceMonitor.cpp
@@ -292,7 +292,7 @@ Volume::Volume(
                                     formatReadableSizeWithBinarySuffix(max_data_part_size) << ")");
     }
     constexpr UInt64 MIN_PART_SIZE = 8u * 1024u * 1024u;
-    if (max_data_part_size < MIN_PART_SIZE)
+    if (max_data_part_size != 0 && max_data_part_size < MIN_PART_SIZE)
         LOG_WARNING(logger, "Volume " << backQuote(name) << " max_data_part_size is too low ("
             << formatReadableSizeWithBinarySuffix(max_data_part_size) << " < "
             << formatReadableSizeWithBinarySuffix(MIN_PART_SIZE) << ")");


### PR DESCRIPTION
Thanks to @filimonov

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):

Fixed erroneous warning `max_data_part_size is too low` #7414

Fixes #7414 