### PR TITLE
Unify hash table interface

### DIFF
--- a/dbms/programs/obfuscator/Obfuscator.cpp
+++ b/dbms/programs/obfuscator/Obfuscator.cpp
@@ -579,7 +579,7 @@ public:
         {
             for (auto & elem : table)
             {
-                Histogram & histogram = elem.getSecond();
+                Histogram & histogram = elem.getMapped();
 
                 if (histogram.buckets.size() < params.num_buckets_cutoff)
                 {
@@ -593,7 +593,7 @@ public:
         {
             for (auto & elem : table)
             {
-                Histogram & histogram = elem.getSecond();
+                Histogram & histogram = elem.getMapped();
                 if (!histogram.total)
                     continue;
 
@@ -625,7 +625,7 @@ public:
         {
             for (auto & elem : table)
             {
-                Histogram & histogram = elem.getSecond();
+                Histogram & histogram = elem.getMapped();
                 if (!histogram.total)
                     continue;
 
@@ -641,7 +641,7 @@ public:
         {
             for (auto & elem : table)
             {
-                Histogram & histogram = elem.getSecond();
+                Histogram & histogram = elem.getMapped();
                 if (!histogram.total)
                     continue;
 
@@ -676,7 +676,7 @@ public:
             while (true)
             {
                 it = table.find(hashContext(code_points.data() + code_points.size() - context_size, code_points.data() + code_points.size()));
-                if (it && lookupResultGetMapped(it)->total + lookupResultGetMapped(it)->count_end != 0)
+                if (it && it->getMapped().total + it->getMapped().count_end != 0)
                     break;
 
                 if (context_size == 0)
@@ -710,7 +710,7 @@ public:
             if (num_bytes_after_desired_size > 0)
                 end_probability_multiplier = std::pow(1.25, num_bytes_after_desired_size);
 
-            CodePoint code = lookupResultGetMapped(it)->sample(determinator, end_probability_multiplier);
+            CodePoint code = it->getMapped().sample(determinator, end_probability_multiplier);
 
             if (code == END)
                 break;

--- a/dbms/src/AggregateFunctions/AggregateFunctionEntropy.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionEntropy.h
@@ -55,7 +55,7 @@ struct EntropyData
     void merge(const EntropyData & rhs)
     {
         for (const auto & pair : rhs.map)
-            map[pair.getFirst()] += pair.getSecond();
+            map[pair.getKey()] += pair.getMapped();
     }
 
     void serialize(WriteBuffer & buf) const
@@ -77,12 +77,12 @@ struct EntropyData
     {
         UInt64 total_value = 0;
         for (const auto & pair : map)
-            total_value += pair.getSecond();
+            total_value += pair.getMapped();
 
         Float64 shannon_entropy = 0;
         for (const auto & pair : map)
         {
-            Float64 frequency = Float64(pair.getSecond()) / total_value;
+            Float64 frequency = Float64(pair.getMapped()) / total_value;
             shannon_entropy -= frequency * log2(frequency);
         }
 

--- a/dbms/src/AggregateFunctions/QuantileExactWeighted.h
+++ b/dbms/src/AggregateFunctions/QuantileExactWeighted.h
@@ -58,7 +58,7 @@ struct QuantileExactWeighted
     void merge(const QuantileExactWeighted & rhs)
     {
         for (const auto & pair : rhs.map)
-            map[pair.getFirst()] += pair.getSecond();
+            map[pair.getKey()] += pair.getMapped();
     }
 
     void serialize(WriteBuffer & buf) const
@@ -93,7 +93,7 @@ struct QuantileExactWeighted
         UInt64 sum_weight = 0;
         for (const auto & pair : map)
         {
-            sum_weight += pair.getSecond();
+            sum_weight += pair.getMapped();
             array[i] = pair.getValue();
             ++i;
         }
@@ -143,7 +143,7 @@ struct QuantileExactWeighted
         UInt64 sum_weight = 0;
         for (const auto & pair : map)
         {
-            sum_weight += pair.getSecond();
+            sum_weight += pair.getMapped();
             array[i] = pair.getValue();
             ++i;
         }

--- a/dbms/src/Columns/ColumnLowCardinality.cpp
+++ b/dbms/src/Columns/ColumnLowCardinality.cpp
@@ -35,7 +35,7 @@ namespace
 
         data.resize(hash_map.size());
         for (const auto & val : hash_map)
-            data[val.getSecond()] = val.getFirst();
+            data[val.getMapped()] = val.getKey();
 
         for (auto & ind : index)
             ind = hash_map[ind];

--- a/dbms/src/Common/ColumnsHashing.h
+++ b/dbms/src/Common/ColumnsHashing.h
@@ -359,7 +359,7 @@ struct HashMethodSingleLowCardinalityColumn : public SingleColumnMethod
 
         if constexpr (has_mapped)
         {
-            auto & mapped = *lookupResultGetMapped(it);
+            auto & mapped = it->getMapped();
             if (inserted)
             {
                 new (&mapped) Mapped();

--- a/dbms/src/Common/ColumnsHashingImpl.h
+++ b/dbms/src/Common/ColumnsHashingImpl.h
@@ -174,13 +174,13 @@ protected:
 
         [[maybe_unused]] Mapped * cached = nullptr;
         if constexpr (has_mapped)
-            cached = lookupResultGetMapped(it);
+            cached = &it->getMapped();
 
         if (inserted)
         {
             if constexpr (has_mapped)
             {
-                new(lookupResultGetMapped(it)) Mapped();
+                new (&it->getMapped()) Mapped();
             }
         }
 
@@ -191,18 +191,18 @@ protected:
 
             if constexpr (has_mapped)
             {
-                cache.value.first = *lookupResultGetKey(it);
-                cache.value.second = *lookupResultGetMapped(it);
+                cache.value.first = it->getKey();
+                cache.value.second = it->getMapped();
                 cached = &cache.value.second;
             }
             else
             {
-                cache.value = *lookupResultGetKey(it);
+                cache.value = it->getKey();
             }
         }
 
         if constexpr (has_mapped)
-            return EmplaceResult(*lookupResultGetMapped(it), *cached, inserted);
+            return EmplaceResult(it->getMapped(), *cached, inserted);
         else
             return EmplaceResult(inserted);
     }
@@ -233,7 +233,7 @@ protected:
                 cache.value.first = key;
                 if (it)
                 {
-                    cache.value.second = *lookupResultGetMapped(it);
+                    cache.value.second = it->getMapped();
                 }
             }
             else
@@ -243,7 +243,7 @@ protected:
         }
 
         if constexpr (has_mapped)
-            return FindResult(it ? lookupResultGetMapped(it) : nullptr, it != nullptr);
+            return FindResult(it ? &it->getMapped() : nullptr, it != nullptr);
         else
             return FindResult(it != nullptr);
     }

--- a/dbms/src/Common/HashTable/ClearableHashMap.h
+++ b/dbms/src/Common/HashTable/ClearableHashMap.h
@@ -14,12 +14,6 @@ struct ClearableHashMapCell : public ClearableHashTableCell<Key, HashMapCell<Key
         : Base::BaseCell(value_, state), Base::version(state.version) {}
 };
 
-template<typename Key, typename Mapped, typename Hash>
-ALWAYS_INLINE inline auto lookupResultGetKey(ClearableHashMapCell<Key, Mapped, Hash> * cell) { return &cell->getFirst(); }
-
-template<typename Key, typename Mapped, typename Hash>
-ALWAYS_INLINE inline auto lookupResultGetMapped(ClearableHashMapCell<Key, Mapped, Hash> * cell) { return &cell->getSecond(); }
-
 template
 <
     typename Key,
@@ -42,9 +36,9 @@ public:
         this->emplace(x, it, inserted);
 
         if (inserted)
-            new(lookupResultGetMapped(it)) mapped_type();
+            new (&it->getMapped()) mapped_type();
 
-        return *lookupResultGetMapped(it);
+        return it->getMapped();
     }
 
     void clear()

--- a/dbms/src/Common/HashTable/ClearableHashSet.h
+++ b/dbms/src/Common/HashTable/ClearableHashSet.h
@@ -48,12 +48,6 @@ struct ClearableHashTableCell : public BaseCell
     ClearableHashTableCell(const Key & key_, const State & state) : BaseCell(key_, state), version(state.version) {}
 };
 
-template<typename Key, typename BaseCell>
-ALWAYS_INLINE inline auto lookupResultGetKey(ClearableHashTableCell<Key, BaseCell> * cell) { return &cell->key; }
-
-template<typename Key, typename BaseCell>
-ALWAYS_INLINE inline void * lookupResultGetMapped(ClearableHashTableCell<Key, BaseCell> *) { return nullptr; }
-
 template
 <
     typename Key,

--- a/dbms/src/Common/HashTable/FixedClearableHashMap.h
+++ b/dbms/src/Common/HashTable/FixedClearableHashMap.h
@@ -18,28 +18,12 @@ struct FixedClearableHashMapCell
     FixedClearableHashMapCell(const Key &, const State & state) : version(state.version) {}
     FixedClearableHashMapCell(const value_type & value_, const State & state) : version(state.version), mapped(value_.second) {}
 
-    Mapped & getSecond() { return mapped; }
-    const Mapped & getSecond() const { return mapped; }
+    const VoidKey getKey() const { return VoidKey{}; }
+    Mapped & getMapped() { return mapped; }
+    const Mapped & getMapped() const { return mapped; }
+
     bool isZero(const State & state) const { return version != state.version; }
     void setZero() { version = 0; }
-    static constexpr bool need_zero_value_storage = false;
-
-    struct CellExt
-    {
-        CellExt() {}
-        CellExt(Key && key_, FixedClearableHashMapCell * ptr_) : key(key_), ptr(ptr_) {}
-        void update(Key && key_, FixedClearableHashMapCell * ptr_)
-        {
-            key = key_;
-            ptr = ptr_;
-        }
-        Key key;
-        FixedClearableHashMapCell * ptr;
-        const Key & getFirst() const { return key; }
-        Mapped & getSecond() { return ptr->mapped; }
-        const Mapped & getSecond() const { return *ptr->mapped; }
-        const value_type getValue() const { return {key, *ptr->mapped}; }
-    };
 };
 
 
@@ -53,14 +37,14 @@ public:
 
     mapped_type & operator[](Key x)
     {
-        typename FixedClearableHashMap::iterator it;
+        typename FixedClearableHashMap::LookupResult it;
         bool inserted;
         this->emplace(x, it, inserted);
 
         if (inserted)
-            new (&it->second) mapped_type();
+            new (&it->getMapped()) mapped_type();
 
-        return it->second;
+        return it->getMapped();
     }
 
     void clear()

--- a/dbms/src/Common/HashTable/FixedClearableHashSet.h
+++ b/dbms/src/Common/HashTable/FixedClearableHashSet.h
@@ -3,29 +3,23 @@
 #include <Common/HashTable/ClearableHashSet.h>
 #include <Common/HashTable/FixedHashTable.h>
 
-
 template <typename Key>
 struct FixedClearableHashTableCell
 {
     using State = ClearableHashSetState;
 
     using value_type = Key;
-    using mapped_type = void;
+    using mapped_type = VoidMapped;
     UInt32 version;
 
     FixedClearableHashTableCell() {}
     FixedClearableHashTableCell(const Key &, const State & state) : version(state.version) {}
 
+    const VoidKey getKey() const { return VoidKey{}; }
+    VoidMapped & getMapped() const { return voidMapped; }
+
     bool isZero(const State & state) const { return version != state.version; }
     void setZero() { version = 0; }
-    static constexpr bool need_zero_value_storage = false;
-
-    struct CellExt
-    {
-        Key key;
-        const value_type & getValue() const { return key; }
-        void update(Key && key_, FixedClearableHashTableCell *) { key = key_; }
-    };
 };
 
 

--- a/dbms/src/Common/HashTable/FixedHashMap.h
+++ b/dbms/src/Common/HashTable/FixedHashMap.h
@@ -3,7 +3,6 @@
 #include <Common/HashTable/FixedHashTable.h>
 #include <Common/HashTable/HashMap.h>
 
-
 template <typename Key, typename TMapped, typename TState = HashTableNoState>
 struct FixedHashMapCell
 {
@@ -13,47 +12,20 @@ struct FixedHashMapCell
     using value_type = PairNoInit<Key, Mapped>;
     using mapped_type = TMapped;
 
-    Mapped mapped;
     bool full;
+    Mapped mapped;
 
     FixedHashMapCell() {}
     FixedHashMapCell(const Key &, const State &) : full(true) {}
     FixedHashMapCell(const value_type & value_, const State &) : full(true), mapped(value_.second) {}
 
-    Mapped & getSecond() { return mapped; }
-    const Mapped & getSecond() const { return mapped; }
+    const VoidKey getKey() const { return VoidKey{}; }
+    Mapped & getMapped() { return mapped; }
+    const Mapped & getMapped() const { return mapped; }
+
     bool isZero(const State &) const { return !full; }
     void setZero() { full = false; }
-    static constexpr bool need_zero_value_storage = false;
-
-    /// Similar to FixedHashSetCell except that we need to contain a pointer to the Mapped field.
-    ///  Note that we have to assemble a continuous layout for the value_type on each call of getValue().
-    struct CellExt
-    {
-        CellExt() {}
-        CellExt(Key && key_, const FixedHashMapCell * ptr_) : key(key_), ptr(const_cast<FixedHashMapCell *>(ptr_)) {}
-        void update(Key && key_, const FixedHashMapCell * ptr_)
-        {
-            key = key_;
-            ptr = const_cast<FixedHashMapCell *>(ptr_);
-        }
-        Key key;
-        FixedHashMapCell * ptr;
-
-        const Key & getFirst() const { return key; }
-        Mapped & getSecond() { return ptr->mapped; }
-        const Mapped & getSecond() const { return ptr->mapped; }
-        const value_type getValue() const { return {key, ptr->mapped}; }
-    };
 };
-
-template<typename Key, typename Mapped, typename State>
-ALWAYS_INLINE inline void * lookupResultGetKey(FixedHashMapCell<Key, Mapped, State> *)
-{ return nullptr; }
-
-template<typename Key, typename Mapped, typename State>
-ALWAYS_INLINE inline auto lookupResultGetMapped(FixedHashMapCell<Key, Mapped, State> * cell)
-{ return &cell->getSecond(); }
 
 template <typename Key, typename Mapped, typename Allocator = HashTableAllocator>
 class FixedHashMap : public FixedHashTable<Key, FixedHashMapCell<Key, Mapped>, Allocator>
@@ -70,43 +42,55 @@ public:
 
     using LookupResult = typename Base::LookupResult;
 
-    template <typename Func>
-    void ALWAYS_INLINE mergeToViaEmplace(Self & that, Func && func)
+    template <typename TSelf, typename Func>
+    static void ALWAYS_INLINE mergeToViaEmplace(TSelf & self, Self & that, Func && func)
     {
-        for (auto it = this->begin(), end = this->end(); it != end; ++it)
+        using UCell = std::conditional_t<std::is_const_v<TSelf>, std::add_const_t<Cell>, Cell>;
+        self.forEachCell([&](Key i, UCell & cell)
         {
             typename Self::LookupResult res_it;
             bool inserted;
-            that.emplace(it->getFirst(), res_it, inserted, it.getHash());
-            func(*lookupResultGetMapped(res_it), it->getSecond(), inserted);
-        }
+            that.emplace(i, res_it, inserted);
+            func(res_it->getMapped(), cell.getMapped(), inserted);
+        });
+    }
+
+    template <typename Func>
+    void ALWAYS_INLINE mergeToViaEmplace(Self & that, Func && func) const
+    {
+        mergeToViaEmplace(*this, that, std::forward<Func>(func));
+    }
+
+    template <typename Func>
+    void ALWAYS_INLINE mergeToViaEmplace(Self & that, Func && func)
+    {
+        mergeToViaEmplace(*this, that, std::forward<Func>(func));
+    }
+
+    template <typename TSelf, typename Func>
+    static void ALWAYS_INLINE mergeToViaFind(TSelf & self, Self & that, Func && func)
+    {
+        using UCell = std::conditional_t<std::is_const_v<TSelf>, std::add_const_t<Cell>, Cell>;
+        self.forEachCell([&](Key i, UCell & cell)
+        {
+            auto & that_cell = that.buf[i];
+            if (that_cell.isZero(that))
+                func(cell.getMapped(), cell.getMapped(), false);
+            else
+                func(that_cell.getMapped(), cell.getMapped(), true);
+        });
+    }
+
+    template <typename Func>
+    void ALWAYS_INLINE mergeToViaFind(Self & that, Func && func) const
+    {
+        mergeToViaFind(*this, that, std::forward<Func>(func));
     }
 
     template <typename Func>
     void ALWAYS_INLINE mergeToViaFind(Self & that, Func && func)
     {
-        for (auto it = this->begin(), end = this->end(); it != end; ++it)
-        {
-            auto res_it = that.find(it->getFirst(), it.getHash());
-            if (!res_it)
-                func(it->getSecond(), it->getSecond(), false);
-            else
-                func(*lookupResultGetMapped(res_it), it->getSecond(), true);
-        }
-    }
-
-    template <typename Func>
-    void forEachValue(Func && func)
-    {
-        for (auto & v : *this)
-            func(v.getFirst(), v.getSecond());
-    }
-
-    template <typename Func>
-    void forEachMapped(Func && func)
-    {
-        for (auto & v : *this)
-            func(v.getSecond());
+        mergeToViaFind(*this, that, std::forward<Func>(func));
     }
 
     mapped_type & ALWAYS_INLINE operator[](Key x)

--- a/dbms/src/Common/HashTable/FixedHashSet.h
+++ b/dbms/src/Common/HashTable/FixedHashSet.h
@@ -6,14 +6,17 @@ template <typename Key, typename Allocator = HashTableAllocator>
 class FixedHashSet : public FixedHashTable<Key, FixedHashTableCell<Key>, Allocator>
 {
 public:
-    using Base = FixedHashTable<Key, FixedHashTableCell<Key>, Allocator>;
+    using Cell = FixedHashTableCell<Key>;
+    using Base = FixedHashTable<Key, Cell, Allocator>;
     using Self = FixedHashSet;
 
     void merge(const Self & rhs)
     {
-        for (size_t i = 0; i < Base::BUFFER_SIZE; ++i)
-            if (Base::buf[i].isZero(*this) && !rhs.buf[i].isZero(*this))
-                Base::buf[i] = rhs.buf[i];
+        rhs.forEachCell([&](Key i, const Cell & cell)
+        {
+            if (Base::buf[i].isZero(*this))
+                new (&Base::buf[i]) Cell(cell);
+        });
     }
 
     /// NOTE: Currently this method isn't used. When it does, the ReadBuffer should

--- a/dbms/src/Common/HashTable/FixedHashTable.h
+++ b/dbms/src/Common/HashTable/FixedHashTable.h
@@ -8,29 +8,17 @@ struct FixedHashTableCell
     using State = TState;
 
     using value_type = Key;
-    using mapped_type = void;
+    using mapped_type = VoidMapped;
     bool full;
 
     FixedHashTableCell() {}
     FixedHashTableCell(const Key &, const State &) : full(true) {}
 
+    const VoidKey getKey() const { return VoidKey{}; }
+    VoidMapped & getMapped() const { return voidMapped; }
+
     bool isZero(const State &) const { return !full; }
     void setZero() { full = false; }
-    static constexpr bool need_zero_value_storage = false;
-
-    /// This Cell is only stored inside an iterator. It's used to accomodate the fact
-    ///  that the iterator based API always provide a reference to a continuous memory
-    ///  containing the Key. As a result, we have to instantiate a real Key field.
-    /// All methods that return a mutable reference to the Key field are named with
-    ///  -Mutable suffix, indicating this is uncommon usage. As this is only for lookup
-    ///  tables, it's totally fine to discard the Key mutations.
-    struct CellExt
-    {
-        Key key;
-
-        const value_type & getValue() const { return key; }
-        void update(Key && key_, FixedHashTableCell *) { key = key_; }
-    };
 };
 
 
@@ -44,29 +32,21 @@ struct FixedHashTableCell
   * NOTE: For Set variants this should always be better. For Map variants
   *  however, as we need to assemble the real cell inside each iterator, there
   *  might be some cases we fall short.
-  *
-  * TODO: Deprecate the cell API so that end users don't rely on the structure
-  *  of cell. Instead iterator should be used for operations such as cell
-  *  transfer, key updates (f.g. StringRef) and serde. This will allow
-  *  TwoLevelHashSet(Map) to contain different type of sets(maps).
   */
 template <typename Key, typename Cell, typename Allocator>
 class FixedHashTable : private boost::noncopyable, protected Allocator, protected Cell::State
 {
-    static constexpr size_t BUFFER_SIZE = 1ULL << (sizeof(Key) * 8);
+    static constexpr size_t CELL_NUM = 1ULL << (sizeof(Key) * 8);
 
 protected:
-    friend class const_iterator;
-    friend class iterator;
     friend class Reader;
 
     using Self = FixedHashTable;
-    using cell_type = Cell;
 
     size_t m_size = 0; /// Amount of elements
-    Cell * buf; /// A piece of memory for all elements except the element with zero key.
+    Cell * buf; /// A piece of memory for all elements.
 
-    void alloc() { buf = reinterpret_cast<Cell *>(Allocator::alloc(BUFFER_SIZE * sizeof(Cell))); }
+    void alloc() { buf = reinterpret_cast<Cell *>(Allocator::alloc(CELL_NUM * sizeof(Cell))); }
 
     void free()
     {
@@ -80,68 +60,14 @@ protected:
     void destroyElements()
     {
         if (!std::is_trivially_destructible_v<Cell>)
-            for (iterator it = begin(), it_end = end(); it != it_end; ++it)
-                it.ptr->~Cell();
+            forEachCell([&](Key, Cell & cell) { cell.~Cell(); });
     }
-
-
-    template <typename Derived, bool is_const>
-    class iterator_base
-    {
-        using Container = std::conditional_t<is_const, const Self, Self>;
-        using cell_type = std::conditional_t<is_const, const Cell, Cell>;
-
-        Container * container;
-        cell_type * ptr;
-
-        friend class FixedHashTable;
-
-    public:
-        iterator_base() {}
-        iterator_base(Container * container_, cell_type * ptr_) : container(container_), ptr(ptr_)
-        {
-            cell.update(ptr - container->buf, ptr);
-        }
-
-        bool operator==(const iterator_base & rhs) const { return ptr == rhs.ptr; }
-        bool operator!=(const iterator_base & rhs) const { return ptr != rhs.ptr; }
-
-        Derived & operator++()
-        {
-            ++ptr;
-
-            /// Skip empty cells in the main buffer.
-            auto buf_end = container->buf + container->BUFFER_SIZE;
-            while (ptr < buf_end && ptr->isZero(*container))
-                ++ptr;
-
-            return static_cast<Derived &>(*this);
-        }
-
-        auto & operator*()
-        {
-            if (cell.key != ptr - container->buf)
-                cell.update(ptr - container->buf, ptr);
-            return cell;
-        }
-        auto * operator-> ()
-        {
-            if (cell.key != ptr - container->buf)
-                cell.update(ptr - container->buf, ptr);
-            return &cell;
-        }
-
-        auto getPtr() const { return ptr; }
-        size_t getHash() const { return ptr - container->buf; }
-        size_t getCollisionChainLength() const { return 0; }
-        typename cell_type::CellExt cell;
-    };
-
 
 public:
     using key_type = Key;
     using value_type = typename Cell::value_type;
     using mapped_type = typename Cell::mapped_type;
+    using cell_type = Cell;
 
     using LookupResult = Cell *;
     using ConstLookupResult = const Cell *;
@@ -219,56 +145,68 @@ public:
         bool is_initialized = false;
     };
 
-
-    class iterator : public iterator_base<iterator, false>
-    {
-    public:
-        using iterator_base<iterator, false>::iterator_base;
-    };
-
-    class const_iterator : public iterator_base<const_iterator, true>
-    {
-    public:
-        using iterator_base<const_iterator, true>::iterator_base;
-    };
-
-
-    const_iterator begin() const
-    {
-        if (!buf)
-            return end();
-
-        const Cell * ptr = buf;
-        auto buf_end = buf + BUFFER_SIZE;
-        while (ptr < buf_end && ptr->isZero(*this))
-            ++ptr;
-
-        return const_iterator(this, ptr);
-    }
-
-    const_iterator cbegin() const { return begin(); }
-
-    iterator begin()
-    {
-        if (!buf)
-            return end();
-
-        Cell * ptr = buf;
-        auto buf_end = buf + BUFFER_SIZE;
-        while (ptr < buf_end && ptr->isZero(*this))
-            ++ptr;
-
-        return iterator(this, ptr);
-    }
-
-    const_iterator end() const { return const_iterator(this, buf + BUFFER_SIZE); }
-    const_iterator cend() const { return end(); }
-    iterator end() { return iterator(this, buf + BUFFER_SIZE); }
-
-
 public:
+    using Position = Cell *;
+    using ConstPosition = const Cell *;
+
+    Position startPos() { return buf; }
+    ConstPosition startPos() const { return buf; }
+
+    template <typename TSelf, typename Func, typename TPosition>
+    static bool forEachCell(TSelf & self, Func && func, TPosition & pos)
+    {
+        using TCell = decltype(*std::declval<TSelf>().buf);
+        static constexpr bool with_key = std::is_invocable_v<Func, const Key &, TCell>;
+        auto loopee = loopeeGenerator<with_key>(std::forward<Func>(func));
+
+        size_t i = pos - self.buf;
+        for (; i < CELL_NUM; ++i)
+        {
+            if (!self.buf[i].isZero(self) && loopee(i, self.buf[i]))
+            {
+                pos = &self.buf[i + 1];
+                return true;
+            }
+        }
+        pos = &self.buf[i];
+
+        return false;
+    }
+
+    /// Iterate over every cell and pass non-zero cells to func.
+    ///  Func should have signature (1) void(const Key &, const Cell &); or (2)  void(const Cell &).
+    template <typename Func>
+    auto forEachCell(Func && func) const
+    {
+        ConstPosition pos = startPos();
+        return forEachCell(*this, std::forward<Func>(func), pos);
+    }
+
+    /// Iterate over every cell and pass non-zero cells to func.
+    ///  Func should have signature (1) void(const Key &, Cell &); or (2)  void(const Cell &).
+    template <typename Func>
+    auto forEachCell(Func && func)
+    {
+        Position pos = startPos();
+        return forEachCell(*this, std::forward<Func>(func), pos);
+    }
+
+    /// Same as the above functions but with additional position variable to resume last iteration.
+    template <typename Func>
+    auto forEachCell(Func && func, ConstPosition & pos) const
+    {
+        return forEachCell(*this, std::forward<Func>(func), pos);
+    }
+
+    /// Same as the above functions but with additional position variable to resume last iteration.
+    template <typename Func>
+    auto forEachCell(Func && func, Position & pos)
+    {
+        return forEachCell(*this, std::forward<Func>(func), pos);
+    }
+
     /// The last parameter is unused but exists for compatibility with HashTable interface.
-    void ALWAYS_INLINE emplace(Key x, LookupResult & it, bool & inserted, size_t /* hash */ = 0)
+    void ALWAYS_INLINE emplace(const Key & x, LookupResult & it, bool & inserted, size_t /* hash */ = 0)
     {
         it = &buf[x];
 
@@ -288,40 +226,31 @@ public:
         std::pair<LookupResult, bool> res;
         emplace(Cell::getKey(x), res.first, res.second);
         if (res.second)
-            insertSetMapped(lookupResultGetMapped(res.first), x);
+            insertSetMapped(res.first->getMapped(), x);
 
         return res;
     }
 
-    LookupResult ALWAYS_INLINE find(Key x)
-    {
-        return !buf[x].isZero(*this) ? &buf[x] : nullptr;
-    }
+    LookupResult ALWAYS_INLINE find(const Key & x) { return !buf[x].isZero(*this) ? &buf[x] : nullptr; }
 
-    ConstLookupResult ALWAYS_INLINE find(Key x) const
-    {
-        return const_cast<std::decay_t<decltype(*this)> *>(this)->find(x);
-    }
+    ConstLookupResult ALWAYS_INLINE find(const Key & x) const { return const_cast<std::decay_t<decltype(*this)> *>(this)->find(x); }
 
-    LookupResult ALWAYS_INLINE find(Key, size_t hash_value)
-    {
-        return !buf[hash_value].isZero(*this) ? &buf[hash_value] : nullptr;
-    }
+    LookupResult ALWAYS_INLINE find(const Key &, size_t hash_value) { return !buf[hash_value].isZero(*this) ? &buf[hash_value] : nullptr; }
 
-    ConstLookupResult ALWAYS_INLINE find(Key key, size_t hash_value) const
+    ConstLookupResult ALWAYS_INLINE find(const Key & key, size_t hash_value) const
     {
         return const_cast<std::decay_t<decltype(*this)> *>(this)->find(key, hash_value);
     }
 
-    bool ALWAYS_INLINE has(Key x) const { return !buf[x].isZero(*this); }
-    bool ALWAYS_INLINE has(Key, size_t hash_value) const { return !buf[hash_value].isZero(*this); }
+    bool ALWAYS_INLINE has(const Key & x) const { return !buf[x].isZero(*this); }
+    bool ALWAYS_INLINE has(const Key &, size_t hash_value) const { return !buf[hash_value].isZero(*this); }
 
     void write(DB::WriteBuffer & wb) const
     {
         Cell::State::write(wb);
         DB::writeVarUInt(m_size, wb);
 
-        for (auto ptr = buf, buf_end = buf + BUFFER_SIZE; ptr < buf_end; ++ptr)
+        for (auto ptr = buf, buf_end = buf + CELL_NUM; ptr < buf_end; ++ptr)
             if (!ptr->isZero(*this))
             {
                 DB::writeVarUInt(ptr - buf);
@@ -334,7 +263,7 @@ public:
         Cell::State::writeText(wb);
         DB::writeText(m_size, wb);
 
-        for (auto ptr = buf, buf_end = buf + BUFFER_SIZE; ptr < buf_end; ++ptr)
+        for (auto ptr = buf, buf_end = buf + CELL_NUM; ptr < buf_end; ++ptr)
         {
             if (!ptr->isZero(*this))
             {
@@ -393,7 +322,7 @@ public:
         destroyElements();
         m_size = 0;
 
-        memset(static_cast<void *>(buf), 0, BUFFER_SIZE * sizeof(*buf));
+        memset(static_cast<void *>(buf), 0, CELL_NUM * sizeof(*buf));
     }
 
     /// After executing this function, the table can only be destroyed,
@@ -405,9 +334,9 @@ public:
         free();
     }
 
-    size_t getBufferSizeInBytes() const { return BUFFER_SIZE * sizeof(Cell); }
+    size_t getBufferSizeInBytes() const { return CELL_NUM * sizeof(Cell); }
 
-    size_t getBufferSizeInCells() const { return BUFFER_SIZE; }
+    size_t getBufferSizeInCells() const { return CELL_NUM; }
 
 #ifdef DBMS_HASH_MAP_COUNT_COLLISIONS
     size_t getCollisions() const { return 0; }

--- a/dbms/src/Common/HashTable/HashSet.h
+++ b/dbms/src/Common/HashTable/HashSet.h
@@ -84,14 +84,6 @@ struct HashSetCellWithSavedHash : public HashTableCell<Key, Hash, TState>
     size_t getHash(const Hash & /*hash_function*/) const { return saved_hash; }
 };
 
-template<typename Key, typename Hash, typename State>
-ALWAYS_INLINE inline auto lookupResultGetKey(HashSetCellWithSavedHash<Key, Hash, State> * cell)
-{ return &cell->key; }
-
-template<typename Key, typename Hash, typename State>
-ALWAYS_INLINE inline void * lookupResultGetMapped(HashSetCellWithSavedHash<Key, Hash, State> *)
-{ return nullptr; }
-
 template
 <
     typename Key,

--- a/dbms/src/Common/HashTable/HashTable.cpp
+++ b/dbms/src/Common/HashTable/HashTable.cpp
@@ -1,0 +1,3 @@
+#include <Common/HashTable/HashTable.h>
+
+VoidMapped voidMapped;

--- a/dbms/src/Common/HashTable/HashTable.h
+++ b/dbms/src/Common/HashTable/HashTable.h
@@ -45,6 +45,37 @@ namespace ErrorCodes
 }
 
 
+namespace
+{
+template <bool with_key, typename Func>
+auto loopeeGenerator(Func && f)
+{
+    return [func = std::forward<Func>(f)](auto && first, auto &&... args)
+    {
+        if constexpr (with_key)
+        {
+            if constexpr (std::is_same_v<std::invoke_result_t<decltype(func), decltype(first), decltype(args)...>, bool>)
+                return func(std::forward<decltype(first)>(first), std::forward<decltype(args)>(args)...);
+            else
+            {
+                func(std::forward<decltype(first)>(first), std::forward<decltype(args)>(args)...);
+                return false;
+            }
+        }
+        else
+        {
+            if constexpr (std::is_same_v<std::invoke_result_t<decltype(func), decltype(args)...>, bool>)
+                return func(std::forward<decltype(args)>(args)...);
+            else
+            {
+                func(std::forward<decltype(args)>(args)...);
+                return false;
+            }
+        }
+    };
+}
+}
+
 /** The state of the hash table that affects the properties of its cells.
   * Used as a template parameter.
   * For example, there is an implementation of an instantly clearable hash table - ClearableHashMap.
@@ -78,66 +109,50 @@ void set(T & x) { x = 0; }
 }
 
 /**
-  * lookupResultGetKey/Mapped -- functions to get key/"mapped" values from the
-  * LookupResult returned by find() and emplace() methods of HashTable.
-  * Must not be called for a null LookupResult.
+  * getKey/Mapped -- methods to get key/"mapped" values from the LookupResult returned by find() and
+  * emplace() methods of HashTable. Must not be called for a null LookupResult.
   *
-  * We don't use iterators for lookup result to avoid creating temporary
-  * objects. Instead, LookupResult is a pointer of some kind. There are global
-  * functions lookupResultGetKey/Mapped, overloaded for this pointer type, that
-  * return pointers to key/"mapped" values. They are implemented as global
-  * functions and not as methods, because they have to be overloaded for POD
-  * types, e.g. in StringHashTable where different components have different
-  * Cell format.
+  * We don't use iterators for lookup result to avoid creating temporary objects. Instead,
+  * LookupResult is a pointer of some kind. There are methods getKey/Mapped, that return pointers to
+  * key/"mapped" values.
   *
-  * Different hash table implementations support this interface to a varying
-  * degree:
+  * Different hash table implementations support this interface to a varying degree:
   *
-  * 1) Hash tables that store neither the key in its original form, nor a
-  *    "mapped" value: FixedHashTable or StringHashTable.
-  *    Neither GetKey nor GetMapped are supported, the only valid operation is
-  *    checking LookupResult for null.
+  * 1) Hash tables that store neither the key in its original form, nor a "mapped" value:
+  *    FixedHashTable or StringHashTable. Neither GetKey nor GetMapped are supported, the only valid
+  *    operation is checking LookupResult for null.
   *
-  * 2) Hash maps that do not store the key, e.g. FixedHashMap or StringHashMap.
-  *    Only GetMapped is supported.
+  * 2) Hash maps that do not store the key, e.g. FixedHashMap or StringHashMap. Only GetMapped is
+  *    supported.
   *
-  * 3) Hash tables that store the key and do not have a "mapped" value, e.g. the
-  *    normal HashTable.
-  *    GetKey returns the key, and GetMapped returns a zero void pointer. This
-  *    simplifies generic code that works with mapped values: it can overload
-  *    on the return type of GetMapped(), and doesn't need other parameters. One
-  *    example is insertSetMapped() function.
+  * 3) Hash tables that store the key and do not have a "mapped" value, e.g. the normal HashTable.
+  *    GetKey returns the key, and GetMapped returns a zero void pointer. This simplifies generic
+  *    code that works with mapped values: it can overload on the return type of GetMapped(), and
+  *    doesn't need other parameters. One example is insertSetMapped() function.
   *
-  * 4) Hash tables that store both the key and the "mapped" value, e.g. HashMap.
-  *    Both GetKey and GetMapped are supported.
+  * 4) Hash tables that store both the key and the "mapped" value, e.g. HashMap. Both GetKey and
+  *    GetMapped are supported.
   *
   * The implementation side goes as follows:
-  * for (1), LookupResult = void *, no getters;
-  * for (2), LookupResult = Mapped *, GetMapped is a default implementation that
-  * takes any pointer-like object;
-  * for (3) and (4), LookupResult = Cell *, and both getters are implemented.
-  * They have to be specialized for each particular Cell class to supersede the
-  * default verision that takes a generic pointer-like object.
+  *
+  * for (1), LookupResult->getKey = VoidKey, LookupResult->getMapped = VoidMapped;
+  *
+  * for (2), LookupResult->getKey = VoidKey, LookupResult->getMapped = Mapped &;
+  *
+  * for (3) and (4), LookupResult->getKey = const Key &, LookupResult->getMapped = Mapped &; VoidKey
+  * and VoidMapped may have specialized function overloads for generic code.
   */
 
-/**
-  * The default implementation of GetMapped that is used for the above case (2).
-  */
-template<typename PointerLike>
-ALWAYS_INLINE inline auto lookupResultGetMapped(PointerLike && ptr) { return &*ptr; }
-
-/**
-  * Generic const wrapper for lookupResultGetMapped, that calls a non-const
-  * version. Should be safe, given that these functions only do pointer
-  * arithmetics.
-  */
-template<typename T>
-ALWAYS_INLINE inline auto lookupResultGetMapped(const T * obj)
+struct VoidKey {};
+struct VoidMapped
 {
-    auto mapped_ptr = lookupResultGetMapped(const_cast<T *>(obj));
-    const auto const_mapped_ptr = mapped_ptr;
-    return const_mapped_ptr;
-}
+    template <typename T>
+    auto & operator=(const T &)
+    {
+        return *this;
+    }
+};
+extern VoidMapped voidMapped;
 
 /** Compile-time interface for cell of the hash table.
   * Different cell types are used to implement different hash tables.
@@ -152,7 +167,7 @@ struct HashTableCell
 
     using key_type = Key;
     using value_type = Key;
-    using mapped_type = void;
+    using mapped_type = VoidMapped;
 
     Key key;
 
@@ -161,10 +176,12 @@ struct HashTableCell
     /// Create a cell with the given key / key and value.
     HashTableCell(const Key & key_, const State &) : key(key_) {}
 
-    /// Get what the value_type of the container will be.
+    /// Get the key (externally).
+    const Key & getKey() const { return key; }
+    VoidMapped & getMapped() const { return voidMapped; }
     const value_type & getValue() const { return key; }
 
-    /// Get the key.
+    /// Get the key (internally).
     static const Key & getKey(const value_type & value) { return value; }
 
     /// Are the keys at the cells equal?
@@ -199,31 +216,23 @@ struct HashTableCell
     void setMapped(const value_type & /*value*/) {}
 
     /// Serialization, in binary and text form.
-    void write(DB::WriteBuffer & wb) const         { DB::writeBinary(key, wb); }
-    void writeText(DB::WriteBuffer & wb) const     { DB::writeDoubleQuoted(key, wb); }
+    void write(DB::WriteBuffer & wb) const { DB::writeBinary(key, wb); }
+    void writeText(DB::WriteBuffer & wb) const { DB::writeDoubleQuoted(key, wb); }
 
     /// Deserialization, in binary and text form.
-    void read(DB::ReadBuffer & rb)        { DB::readBinary(key, rb); }
-    void readText(DB::ReadBuffer & rb)    { DB::readDoubleQuoted(key, rb); }
+    void read(DB::ReadBuffer & rb) { DB::readBinary(key, rb); }
+    void readText(DB::ReadBuffer & rb) { DB::readDoubleQuoted(key, rb); }
 };
-
-template<typename Key, typename Hash, typename State>
-ALWAYS_INLINE inline auto lookupResultGetKey(HashTableCell<Key, Hash, State> * cell)
-{ return &cell->key; }
-
-template<typename Key, typename Hash, typename State>
-ALWAYS_INLINE inline void * lookupResultGetMapped(HashTableCell<Key, Hash, State> *)
-{ return nullptr; }
 
 /**
   * A helper function for HashTable::insert() to set the "mapped" value.
-  * Overloaded on the mapped type, does nothing if it's void.
+  * Overloaded on the mapped type, does nothing if it's VoidMapped.
   */
 template <typename ValueType>
-void insertSetMapped(void * /* dest */, const ValueType & /* src */) {}
+void insertSetMapped(VoidMapped & /* dest */, const ValueType & /* src */) {}
 
 template <typename MappedType, typename ValueType>
-void insertSetMapped(MappedType * dest, const ValueType & src) { *dest = src.second; }
+void insertSetMapped(MappedType & dest, const ValueType & src) { dest = src.second; }
 
 
 /** Determines the size of the hash table, and when and how much it should be resized.
@@ -276,7 +285,7 @@ struct HashTableGrower
 /** When used as a Grower, it turns a hash table into something like a lookup table.
   * It remains non-optimal - the cells store the keys.
   * Also, the compiler can not completely remove the code of passing through the collision resolution chain, although it is not needed.
-  * TODO Make a proper lookup table.
+  * NOTE: Better to use FixedHashTable instead.
   */
 template <size_t key_bits>
 struct HashTableFixedGrower
@@ -366,7 +375,6 @@ protected:
 
     using HashValue = size_t;
     using Self = HashTable;
-    using cell_type = Cell;
 
     size_t m_size = 0;        /// Amount of elements
     Cell * buf;               /// A piece of memory for all elements except the element with zero key.
@@ -519,7 +527,7 @@ protected:
                 it.ptr->~Cell();
     }
 
-
+    /// NOTE: Iterators are not universally available. Better to use forEachCell and Position instead.
     template <typename Derived, bool is_const>
     class iterator_base
     {
@@ -587,8 +595,9 @@ protected:
 public:
     using key_type = Key;
     using value_type = typename Cell::value_type;
+    using mapped_type = typename Cell::mapped_type;
+    using cell_type = Cell;
 
-    // Use lookupResultGetMapped/Key to work with these values.
     using LookupResult = Cell *;
     using ConstLookupResult = const Cell *;
 
@@ -740,6 +749,76 @@ public:
     const_iterator cend() const        { return end(); }
     iterator end()                     { return iterator(this, buf + grower.bufSize()); }
 
+    using Position = Cell *;
+    using ConstPosition = const Cell *;
+
+    Position startPos() { return nullptr; }
+    ConstPosition startPos() const { return nullptr; }
+
+    template <typename TSelf, typename Func, typename TPosition>
+    static bool forEachCell(TSelf & self, Func && func, TPosition & pos)
+    {
+        using TCell = decltype(*std::declval<TSelf>().buf);
+        using TKey = decltype(std::declval<Cell>().getKey());
+        static constexpr bool with_key = std::is_invocable_v<Func, const TKey &, TCell &>;
+        auto loopee = loopeeGenerator<with_key>(std::forward<Func>(func));
+
+        if (!self.buf || self.empty())
+            return false;
+
+        if (pos == self.startPos())
+        {
+            pos = self.buf;
+            if (self.hasZero() && loopee(self.zeroValue()->getKey(), *self.zeroValue()))
+                return true;
+        }
+
+        auto ptr = pos;
+        auto ptr_end = self.buf + self.grower.bufSize();
+        for (; ptr < ptr_end; ++ptr)
+        {
+            if (!ptr->isZero(self) && loopee(ptr->getKey(), *ptr))
+            {
+                pos = ptr + 1;
+                return true;
+            }
+        }
+        pos = ptr_end;
+
+        return false;
+    }
+
+    /// Iterate over every cell and pass non-zero cells to func.
+    ///  Func should have signature (1) void(const Key &, const Cell &); or (2)  void(const Cell &).
+    template <typename Func>
+    auto forEachCell(Func && func) const
+    {
+        ConstPosition pos = startPos();
+        return forEachCell(*this, std::forward<Func>(func), pos);
+    }
+
+    /// Iterate over every cell and pass non-zero cells to func.
+    ///  Func should have signature (1) void(const Key &, Cell &); or (2)  void(Cell &).
+    template <typename Func>
+    auto forEachCell(Func && func)
+    {
+        Position pos = nullptr;
+        return forEachCell(*this, std::forward<Func>(func), pos);
+    }
+
+    /// Same as the above functions but with additional position variable to resume last iteration.
+    template <typename Func>
+    auto forEachCell(Func && func, ConstPosition & pos) const
+    {
+        return forEachCell(*this, std::forward<Func>(func), pos);
+    }
+
+    /// Same as the above functions but with additional position variable to resume last iteration.
+    template <typename Func>
+    auto forEachCell(Func && func, Position & pos)
+    {
+        return forEachCell(*this, std::forward<Func>(func), pos);
+    }
 
 protected:
     const_iterator iteratorTo(const Cell * ptr) const { return const_iterator(this, ptr); }
@@ -751,7 +830,7 @@ protected:
     /// If the key is zero, insert it into a special place and return true.
     /// We don't have to persist a zero key, because it's not actually inserted.
     /// That's why we just take a Key by value, an not a key holder.
-    bool ALWAYS_INLINE emplaceIfZero(Key x, LookupResult & it, bool & inserted, size_t hash_value)
+    bool ALWAYS_INLINE emplaceIfZero(const Key & x, LookupResult & it, bool & inserted, size_t hash_value)
     {
         /// If it is claimed that the zero key can not be inserted into the table.
         if (!Cell::need_zero_value_storage)
@@ -793,7 +872,7 @@ protected:
         keyHolderPersistKey(key_holder);
         const auto & key = keyHolderGetKey(key_holder);
 
-        new(&buf[place_value]) Cell(key, *this);
+        new (&buf[place_value]) Cell(key, *this);
         buf[place_value].setHash(hash_value);
         inserted = true;
         ++m_size;
@@ -846,7 +925,7 @@ public:
         }
 
         if (res.second)
-            insertSetMapped(lookupResultGetMapped(res.first), x);
+            insertSetMapped(res.first->getMapped(), x);
 
         return res;
     }
@@ -869,11 +948,11 @@ public:
       *
       * Example usage:
       *
-      * Map::iterator it;
+      * Map::LookupResult it;
       * bool inserted;
       * map.emplace(key, it, inserted);
       * if (inserted)
-      *     new(&it->second) Mapped(value);
+      *     new (&it->getMapped()) Mapped(value);
       */
     template <typename KeyHolder>
     void ALWAYS_INLINE emplace(KeyHolder && key_holder, LookupResult & it, bool & inserted)
@@ -903,7 +982,7 @@ public:
             resize();
     }
 
-    LookupResult ALWAYS_INLINE find(Key x)
+    LookupResult ALWAYS_INLINE find(const Key & x)
     {
         if (Cell::isZero(x, *this))
             return this->hasZero() ? this->zeroValue() : nullptr;
@@ -913,12 +992,12 @@ public:
         return !buf[place_value].isZero(*this) ? &buf[place_value] : nullptr;
     }
 
-    ConstLookupResult ALWAYS_INLINE find(Key x) const
+    ConstLookupResult ALWAYS_INLINE find(const Key & x) const
     {
         return const_cast<std::decay_t<decltype(*this)> *>(this)->find(x);
     }
 
-    LookupResult ALWAYS_INLINE find(Key x, size_t hash_value)
+    LookupResult ALWAYS_INLINE find(const Key & x, size_t hash_value)
     {
         if (Cell::isZero(x, *this))
             return this->hasZero() ? this->zeroValue() : nullptr;
@@ -927,7 +1006,7 @@ public:
         return !buf[place_value].isZero(*this) ? &buf[place_value] : nullptr;
     }
 
-    bool ALWAYS_INLINE has(Key x) const
+    bool ALWAYS_INLINE has(const Key & x) const
     {
         if (Cell::isZero(x, *this))
             return this->hasZero();
@@ -938,7 +1017,7 @@ public:
     }
 
 
-    bool ALWAYS_INLINE has(Key x, size_t hash_value) const
+    bool ALWAYS_INLINE has(const Key & x, size_t hash_value) const
     {
         if (Cell::isZero(x, *this))
             return this->hasZero();

--- a/dbms/src/Common/HashTable/SmallTable.h
+++ b/dbms/src/Common/HashTable/SmallTable.h
@@ -399,8 +399,8 @@ public:
         typename SmallMapTable::iterator it;
         bool inserted;
         this->emplace(x, it, inserted);
-        new(&it->getSecond()) mapped_type();
-        return it->getSecond();
+        new (&it->getMapped()) mapped_type();
+        return it->getMapped();
     }
 };
 

--- a/dbms/src/Common/HashTable/StringHashMap.h
+++ b/dbms/src/Common/HashTable/StringHashMap.h
@@ -8,44 +8,62 @@ template <typename Key, typename TMapped>
 struct StringHashMapCell : public HashMapCell<Key, TMapped, StringHashTableHash, HashTableNoState>
 {
     using Base = HashMapCell<Key, TMapped, StringHashTableHash, HashTableNoState>;
+    using value_type = typename Base::value_type;
     using Base::Base;
     static constexpr bool need_zero_value_storage = false;
+    // external
+    const StringRef getKey() const { return toStringRef(this->value.first); }
+    // internal
+    static const Key & getKey(const value_type & value_) { return value_.first; }
 };
-
-template<typename Key, typename Mapped>
-auto lookupResultGetMapped(StringHashMapCell<Key, Mapped> * cell) { return &cell->getSecond(); }
 
 template <typename TMapped>
 struct StringHashMapCell<StringKey16, TMapped> : public HashMapCell<StringKey16, TMapped, StringHashTableHash, HashTableNoState>
 {
     using Base = HashMapCell<StringKey16, TMapped, StringHashTableHash, HashTableNoState>;
+    using value_type = typename Base::value_type;
     using Base::Base;
     static constexpr bool need_zero_value_storage = false;
     bool isZero(const HashTableNoState & state) const { return isZero(this->value.first, state); }
     // Assuming String does not contain zero bytes. NOTE: Cannot be used in serialized method
     static bool isZero(const StringKey16 & key, const HashTableNoState & /*state*/) { return key.low == 0; }
     void setZero() { this->value.first.low = 0; }
+    // external
+    const StringRef getKey() const { return toStringRef(this->value.first); }
+    // internal
+    static const StringKey16 & getKey(const value_type & value_) { return value_.first; }
 };
 
 template <typename TMapped>
 struct StringHashMapCell<StringKey24, TMapped> : public HashMapCell<StringKey24, TMapped, StringHashTableHash, HashTableNoState>
 {
     using Base = HashMapCell<StringKey24, TMapped, StringHashTableHash, HashTableNoState>;
+    using value_type = typename Base::value_type;
     using Base::Base;
     static constexpr bool need_zero_value_storage = false;
     bool isZero(const HashTableNoState & state) const { return isZero(this->value.first, state); }
     // Assuming String does not contain zero bytes. NOTE: Cannot be used in serialized method
     static bool isZero(const StringKey24 & key, const HashTableNoState & /*state*/) { return key.a == 0; }
     void setZero() { this->value.first.a = 0; }
+    // external
+    const StringRef getKey() const { return toStringRef(this->value.first); }
+    // internal
+    static const StringKey24 & getKey(const value_type & value_) { return value_.first; }
 };
 
 template <typename TMapped>
 struct StringHashMapCell<StringRef, TMapped> : public HashMapCellWithSavedHash<StringRef, TMapped, StringHashTableHash, HashTableNoState>
 {
     using Base = HashMapCellWithSavedHash<StringRef, TMapped, StringHashTableHash, HashTableNoState>;
+    using value_type = typename Base::value_type;
     using Base::Base;
     static constexpr bool need_zero_value_storage = false;
+    // external
+    using Base::getKey;
+    // internal
+    static const StringRef & getKey(const value_type & value_) { return value_.first; }
 };
+
 
 template <typename TMapped, typename Allocator>
 struct StringHashMapSubMaps
@@ -67,7 +85,6 @@ public:
     using key_type = StringRef;
     using mapped_type = TMapped;
     using value_type = typename Base::Ts::value_type;
-    using LookupResult = mapped_type *;
 
     using Base::Base;
 
@@ -80,18 +97,10 @@ public:
     template <typename Func>
     void ALWAYS_INLINE mergeToViaEmplace(Self & that, Func && func)
     {
-        if (this->m0.hasZero())
-        {
-            const bool emplace_new_zero = !that.m0.hasZero();
-            if (emplace_new_zero)
-            {
-                that.m0.setHasZero();
-            }
-
-            func(that.m0.zeroValue()->getSecond(), this->m0.zeroValue()->getSecond(),
-                 emplace_new_zero);
-        }
-
+        if (this->m0.hasZero() && that.m0.hasZero())
+            func(that.m0.zeroValue()->getMapped(), this->m0.zeroValue()->getMapped(), false);
+        else if (this->m0.hasZero())
+            func(that.m0.zeroValue()->getMapped(), this->m0.zeroValue()->getMapped(), true);
         this->m1.mergeToViaEmplace(that.m1, func);
         this->m2.mergeToViaEmplace(that.m2, func);
         this->m3.mergeToViaEmplace(that.m3, func);
@@ -106,18 +115,10 @@ public:
     template <typename Func>
     void ALWAYS_INLINE mergeToViaFind(Self & that, Func && func)
     {
-        if (this->m0.hasZero())
-        {
-            if (that.m0.hasZero())
-            {
-                func(that.m0.zeroValue()->getSecond(), this->m0.zeroValue()->getSecond(), true);
-            }
-            else
-            {
-                func(this->m0.zeroValue()->getSecond(), this->m0.zeroValue()->getSecond(), false);
-            }
-        }
-
+        if (this->m0.size() && that.m0.size())
+            func(that.m0.zeroValue()->getMapped(), this->m0.zeroValue()->getMapped(), true);
+        else if (this->m0.size())
+            func(this->m0.zeroValue()->getMapped(), this->m0.zeroValue()->getMapped(), false);
         this->m1.mergeToViaFind(that.m1, func);
         this->m2.mergeToViaFind(that.m2, func);
         this->m3.mergeToViaFind(that.m3, func);
@@ -126,55 +127,13 @@ public:
 
     mapped_type & ALWAYS_INLINE operator[](Key x)
     {
+        typename Base::LookupResult it;
         bool inserted;
-        LookupResult it = nullptr;
-        emplace(x, it, inserted);
+        this->emplace(x, it, inserted);
+
         if (inserted)
-            new (it) mapped_type();
-        return *it;
-    }
+            new (it->getMapped()) mapped_type();
 
-    template <typename Func>
-    void ALWAYS_INLINE forEachValue(Func && func)
-    {
-        if (this->m0.size())
-        {
-            func(StringRef{}, this->m0.zeroValue()->getSecond());
-        }
-
-        for (auto & v : this->m1)
-        {
-            func(toStringRef(v.getFirst()), v.getSecond());
-        }
-
-        for (auto & v : this->m2)
-        {
-            func(toStringRef(v.getFirst()), v.getSecond());
-        }
-
-        for (auto & v : this->m3)
-        {
-            func(toStringRef(v.getFirst()), v.getSecond());
-        }
-
-        for (auto & v : this->ms)
-        {
-            func(v.getFirst(), v.getSecond());
-        }
-    }
-
-    template <typename Func>
-    void ALWAYS_INLINE forEachMapped(Func && func)
-    {
-        if (this->m0.size())
-            func(this->m0.zeroValue()->getSecond());
-        for (auto & v : this->m1)
-            func(v.getSecond());
-        for (auto & v : this->m2)
-            func(v.getSecond());
-        for (auto & v : this->m3)
-            func(v.getSecond());
-        for (auto & v : this->ms)
-            func(v.getSecond());
+        return *it->getMapped();
     }
 };

--- a/dbms/src/Common/HashTable/TwoLevelHashMap.h
+++ b/dbms/src/Common/HashTable/TwoLevelHashMap.h
@@ -39,9 +39,9 @@ public:
         this->emplace(x, it, inserted);
 
         if (inserted)
-            new(lookupResultGetMapped(it)) mapped_type();
+            new (&it->getMapped()) mapped_type();
 
-        return *lookupResultGetMapped(it);
+        return it->getMapped();
     }
 };
 

--- a/dbms/src/Common/HashTable/TwoLevelStringHashMap.h
+++ b/dbms/src/Common/HashTable/TwoLevelStringHashMap.h
@@ -31,7 +31,7 @@ public:
         LookupResult it;
         emplace(x, it, inserted);
         if (inserted)
-            new (lookupResultGetMapped(it)) mapped_type();
-        return *lookupResultGetMapped(it);
+            new (&it->getMapped()) mapped_type();
+        return it->getMapped();
     }
 };

--- a/dbms/src/Common/HashTable/TwoLevelStringHashTable.h
+++ b/dbms/src/Common/HashTable/TwoLevelStringHashTable.h
@@ -69,6 +69,26 @@ public:
         }
     }
 
+    /// No positional variants for TwoLevelHashTable as it's only used for aggregations.
+
+    /// Iterate over every cell and pass non-zero cells to func.
+    ///  Func should have signature void(const Cell &).
+    template <typename Func>
+    void forEachCell(Func && func) const
+    {
+        for (size_t i = 0; i < NUM_BUCKETS; ++i)
+            impls[i].forEachCell(func);
+    }
+
+    /// Iterate over every cell and pass non-zero cells to func.
+    ///  Func should have signature void(Cell &).
+    template <typename Func>
+    void forEachCell(Func && func)
+    {
+        for (size_t i = 0; i < NUM_BUCKETS; ++i)
+            impls[i].forEachCell(func);
+    }
+
     // This function is mostly the same as StringHashTable::dispatch, but with
     // added bucket computation. See the comments there.
     template <typename Func, typename KeyHolder>
@@ -78,9 +98,8 @@ public:
         const size_t sz = x.size;
         if (sz == 0)
         {
-            static constexpr StringKey0 key0{};
             keyHolderDiscardKey(key_holder);
-            return func(impls[0].m0, key0, 0);
+            return func(impls[0].m0, VoidKey{}, 0);
         }
 
         const char * p = x.data;

--- a/dbms/src/Common/SpaceSaving.h
+++ b/dbms/src/Common/SpaceSaving.h
@@ -369,7 +369,7 @@ private:
         if (!it)
             return nullptr;
 
-        return *lookupResultGetMapped(it);
+        return it->getMapped();
     }
 
     void rebuildCounterMap()

--- a/dbms/src/Common/tests/auto_array.cpp
+++ b/dbms/src/Common/tests/auto_array.cpp
@@ -155,10 +155,10 @@ int main(int argc, char ** argv)
             map.emplace(rand(), it, inserted);
             if (inserted)
             {
-                new(lookupResultGetMapped(it)) Arr(n);
+                new (&it->getMapped()) Arr(n);
 
                 for (size_t j = 0; j < n; ++j)
-                    (*lookupResultGetMapped(it))[j] = field;
+                    (it->getMapped())[j] = field;
             }
         }
 

--- a/dbms/src/Common/tests/parallel_aggregation.cpp
+++ b/dbms/src/Common/tests/parallel_aggregation.cpp
@@ -82,14 +82,14 @@ void aggregate12(Map & map, Source::const_iterator begin, Source::const_iterator
     {
         if (prev_it != end && *it == *prev_it)
         {
-            ++*lookupResultGetMapped(found);
+            ++found->getMapped();
             continue;
         }
         prev_it = it;
 
         bool inserted;
         map.emplace(*it, found, inserted);
-        ++*lookupResultGetMapped(found);
+        ++found->getMapped();
     }
 }
 
@@ -107,14 +107,14 @@ void aggregate22(MapTwoLevel & map, Source::const_iterator begin, Source::const_
     {
         if (*it == *prev_it)
         {
-            ++*lookupResultGetMapped(found);
+            ++found->getMapped();
             continue;
         }
         prev_it = it;
 
         bool inserted;
         map.emplace(*it, found, inserted);
-        ++*lookupResultGetMapped(found);
+        ++found->getMapped();
     }
 }
 
@@ -126,7 +126,7 @@ void merge2(MapTwoLevel * maps, size_t num_threads, size_t bucket)
 {
     for (size_t i = 1; i < num_threads; ++i)
         for (auto it = maps[i].impls[bucket].begin(); it != maps[i].impls[bucket].end(); ++it)
-            maps[0].impls[bucket][it->getFirst()] += it->getSecond();
+            maps[0].impls[bucket][it->getKey()] += it->getMapped();
 }
 
 void aggregate3(Map & local_map, Map & global_map, Mutex & mutex, Source::const_iterator begin, Source::const_iterator end)
@@ -138,7 +138,7 @@ void aggregate3(Map & local_map, Map & global_map, Mutex & mutex, Source::const_
         auto found = local_map.find(*it);
 
         if (found)
-            ++*lookupResultGetMapped(found);
+            ++found->getMapped();
         else if (local_map.size() < threshold)
             ++local_map[*it];    /// TODO You could do one lookup, not two.
         else
@@ -163,13 +163,13 @@ void aggregate33(Map & local_map, Map & global_map, Mutex & mutex, Source::const
         Map::LookupResult found;
         bool inserted;
         local_map.emplace(*it, found, inserted);
-        ++*lookupResultGetMapped(found);
+        ++found->getMapped();
 
         if (inserted && local_map.size() == threshold)
         {
             std::lock_guard<Mutex> lock(mutex);
             for (auto & value_type : local_map)
-                global_map[value_type.getFirst()] += value_type.getSecond();
+                global_map[value_type.getKey()] += value_type.getMapped();
 
             local_map.clear();
         }
@@ -198,7 +198,7 @@ void aggregate4(Map & local_map, MapTwoLevel & global_map, Mutex * mutexes, Sour
                 auto found = local_map.find(*it);
 
                 if (found)
-                    ++*lookupResultGetMapped(found);
+                    ++found->getMapped();
                 else
                 {
                     size_t hash_value = global_map.hash(*it);
@@ -311,7 +311,7 @@ int main(int argc, char ** argv)
 
         for (size_t i = 1; i < num_threads; ++i)
             for (auto it = maps[i].begin(); it != maps[i].end(); ++it)
-                maps[0][it->getFirst()] += it->getSecond();
+                maps[0][it->getKey()] += it->getMapped();
 
         watch.stop();
         double time_merged = watch.elapsedSeconds();
@@ -365,7 +365,7 @@ int main(int argc, char ** argv)
 
         for (size_t i = 1; i < num_threads; ++i)
             for (auto it = maps[i].begin(); it != maps[i].end(); ++it)
-                maps[0][it->getFirst()] += it->getSecond();
+                maps[0][it->getKey()] += it->getMapped();
 
         watch.stop();
 
@@ -435,7 +435,7 @@ int main(int argc, char ** argv)
                     continue;
 
                 finish = false;
-                maps[0][iterators[i]->getFirst()] += iterators[i]->getSecond();
+                maps[0][iterators[i]->getKey()] += iterators[i]->getMapped();
                 ++iterators[i];
             }
 
@@ -623,7 +623,7 @@ int main(int argc, char ** argv)
 
         for (size_t i = 0; i < num_threads; ++i)
             for (auto it = local_maps[i].begin(); it != local_maps[i].end(); ++it)
-                global_map[it->getFirst()] += it->getSecond();
+                global_map[it->getKey()] += it->getMapped();
 
         pool.wait();
 
@@ -689,7 +689,7 @@ int main(int argc, char ** argv)
 
         for (size_t i = 0; i < num_threads; ++i)
             for (auto it = local_maps[i].begin(); it != local_maps[i].end(); ++it)
-                global_map[it->getFirst()] += it->getSecond();
+                global_map[it->getKey()] += it->getMapped();
 
         pool.wait();
 
@@ -760,7 +760,7 @@ int main(int argc, char ** argv)
 
         for (size_t i = 0; i < num_threads; ++i)
             for (auto it = local_maps[i].begin(); it != local_maps[i].end(); ++it)
-                global_map[it->getFirst()] += it->getSecond();
+                global_map[it->getKey()] += it->getMapped();
 
         pool.wait();
 

--- a/dbms/src/Common/tests/parallel_aggregation2.cpp
+++ b/dbms/src/Common/tests/parallel_aggregation2.cpp
@@ -51,9 +51,9 @@ struct AggregateIndependent
                     map.emplace(*it, place, inserted);
 
                     if (inserted)
-                        creator(*lookupResultGetMapped(place));
+                        creator(place->getMapped());
                     else
-                        updater(*lookupResultGetMapped(place));
+                        updater(place->getMapped());
                 }
             });
         }
@@ -93,7 +93,7 @@ struct AggregateIndependentWithSequentialKeysOptimization
                 {
                     if (it != begin && *it == prev_key)
                     {
-                        updater(*lookupResultGetMapped(place));
+                        updater(place->getMapped());
                         continue;
                     }
                     prev_key = *it;
@@ -102,9 +102,9 @@ struct AggregateIndependentWithSequentialKeysOptimization
                     map.emplace(*it, place, inserted);
 
                     if (inserted)
-                        creator(*lookupResultGetMapped(place));
+                        creator(place->getMapped());
                     else
-                        updater(*lookupResultGetMapped(place));
+                        updater(place->getMapped());
                 }
             });
         }
@@ -131,7 +131,7 @@ struct MergeSequential
             auto begin = source_maps[i]->begin();
             auto end = source_maps[i]->end();
             for (auto it = begin; it != end; ++it)
-                merger((*source_maps[0])[it->getFirst()], it->getSecond());
+                merger((*source_maps[0])[it->getKey()], it->getMapped());
         }
 
         result_map = source_maps[0];
@@ -161,7 +161,7 @@ struct MergeSequentialTransposed    /// In practice not better than usual.
                     continue;
 
                 finish = false;
-                merger((*result_map)[iterators[i]->getFirst()], iterators[i]->getSecond());
+                merger((*result_map)[iterators[i]->getKey()], iterators[i]->getMapped());
                 ++iterators[i];
             }
 

--- a/dbms/src/Common/tests/small_table.cpp
+++ b/dbms/src/Common/tests/small_table.cpp
@@ -42,7 +42,7 @@ int main(int, char **)
         cont[1] = "Goodbye.";
 
         for (auto x : cont)
-            std::cerr << x.getFirst() << " -> " << x.getSecond() << std::endl;
+            std::cerr << x.getKey() << " -> " << x.getMapped() << std::endl;
 
         DB::WriteBufferFromOwnString wb;
         cont.writeText(wb);

--- a/dbms/src/Core/tests/string_pool.cpp
+++ b/dbms/src/Core/tests/string_pool.cpp
@@ -211,7 +211,7 @@ int main(int argc, char ** argv)
         {
             RefsHashMap::LookupResult inserted_it;
             bool inserted;
-            set.emplace(StringRef(*lookupResultGetMapped(it)), inserted_it, inserted);
+            set.emplace(StringRef(*it), inserted_it, inserted);
         }
 
         std::cerr << "Inserted refs into HashMap in " << watch.elapsedSeconds() << " sec, "
@@ -222,7 +222,7 @@ int main(int argc, char ** argv)
         size_t i = 0;
         for (auto it = set.begin(); i < elems_show && it != set.end(); ++it, ++i)
         {
-            devnull.write(it->getFirst().data, it->getFirst().size);
+            devnull.write(it->getKey().data, it->getKey().size);
             devnull << std::endl;
         }
 
@@ -249,7 +249,7 @@ int main(int argc, char ** argv)
         size_t i = 0;
         for (auto it = set.begin(); i < elems_show && it != set.end(); ++it, ++i)
         {
-            devnull.write(it->getFirst().data, it->getFirst().size);
+            devnull.write(it->getKey().data, it->getKey().size);
             devnull << std::endl;
         }
     }

--- a/dbms/src/DataTypes/DataTypeEnum.cpp
+++ b/dbms/src/DataTypes/DataTypeEnum.cpp
@@ -75,7 +75,7 @@ void DataTypeEnum<Type>::fillMaps()
 
         if (!inserted_value.second)
             throw Exception{"Duplicate names in enum: '" + name_and_value.first + "' = " + toString(name_and_value.second)
-                    + " and " + toString(*lookupResultGetMapped(inserted_value.first)),
+                    + " and " + toString(inserted_value.first->getMapped()),
                 ErrorCodes::SYNTAX_ERROR};
 
         const auto inserted_name = value_to_name_map.insert(

--- a/dbms/src/DataTypes/DataTypeEnum.h
+++ b/dbms/src/DataTypes/DataTypeEnum.h
@@ -81,7 +81,7 @@ public:
         if (!it)
             throw Exception{"Unknown element '" + field_name.toString() + "' for type " + getName(), ErrorCodes::LOGICAL_ERROR};
 
-        return *lookupResultGetMapped(it);
+        return it->getMapped();
     }
 
     Field castToName(const Field & value_or_name) const override;

--- a/dbms/src/Dictionaries/ComplexKeyCacheDictionary.cpp
+++ b/dbms/src/Dictionaries/ComplexKeyCacheDictionary.cpp
@@ -216,7 +216,7 @@ void ComplexKeyCacheDictionary::has(const Columns & key_columns, const DataTypes
 
     std::vector<size_t> required_rows(outdated_keys.size());
     std::transform(
-        std::begin(outdated_keys), std::end(outdated_keys), std::begin(required_rows), [](auto & pair) { return pair.getSecond().front(); });
+        std::begin(outdated_keys), std::end(outdated_keys), std::begin(required_rows), [](auto & pair) { return pair.getMapped().front(); });
 
     /// request new values
     update(

--- a/dbms/src/Dictionaries/ComplexKeyCacheDictionary.h
+++ b/dbms/src/Dictionaries/ComplexKeyCacheDictionary.h
@@ -311,7 +311,7 @@ private:
 
         std::vector<size_t> required_rows(outdated_keys.size());
         std::transform(
-            std::begin(outdated_keys), std::end(outdated_keys), std::begin(required_rows), [](auto & pair) { return pair.getSecond().front(); });
+            std::begin(outdated_keys), std::end(outdated_keys), std::begin(required_rows), [](auto & pair) { return pair.getMapped().front(); });
 
         /// request new values
         update(
@@ -437,7 +437,7 @@ private:
             std::vector<size_t> required_rows(outdated_keys.size());
             std::transform(std::begin(outdated_keys), std::end(outdated_keys), std::begin(required_rows), [](auto & pair)
             {
-                return pair.getSecond().front();
+                return pair.getMapped().front();
             });
 
             update(
@@ -469,7 +469,7 @@ private:
         {
             const StringRef key = keys_array[row];
             const auto it = map.find(key);
-            const auto string_ref = it ? *lookupResultGetMapped(it) : get_default(row);
+            const auto string_ref = it ? it->getMapped() : get_default(row);
             out->insertData(string_ref.data, string_ref.size);
         }
     }
@@ -576,7 +576,7 @@ private:
         /// Check which ids have not been found and require setting null_value
         for (const auto & key_found_pair : remaining_keys)
         {
-            if (key_found_pair.getSecond())
+            if (key_found_pair.getMapped())
             {
                 ++found_num;
                 continue;
@@ -584,7 +584,7 @@ private:
 
             ++not_found_num;
 
-            auto key = key_found_pair.getFirst();
+            auto key = key_found_pair.getKey();
             const auto hash = StringRefHash{}(key);
             const auto find_result = findCellIdx(key, now, hash);
             const auto & cell_idx = find_result.cell_idx;

--- a/dbms/src/Dictionaries/ComplexKeyHashedDictionary.cpp
+++ b/dbms/src/Dictionaries/ComplexKeyHashedDictionary.cpp
@@ -561,7 +561,7 @@ void ComplexKeyHashedDictionary::getItemsImpl(
         const auto key = placeKeysInPool(i, key_columns, keys, temporary_keys_pool);
 
         const auto it = attr.find(key);
-        set_value(i, it ? static_cast<OutputType>(*lookupResultGetMapped(it)) : get_default(i));
+        set_value(i, it ? static_cast<OutputType>(it->getMapped()) : get_default(i));
 
         /// free memory allocated for the key
         temporary_keys_pool.rollback(key.size);
@@ -729,7 +729,7 @@ std::vector<StringRef> ComplexKeyHashedDictionary::getKeys(const Attribute & att
     std::vector<StringRef> keys;
     keys.reserve(attr.size());
     for (const auto & key : attr)
-        keys.push_back(key.getFirst());
+        keys.push_back(key.getKey());
 
     return keys;
 }

--- a/dbms/src/Dictionaries/HashedDictionary.cpp
+++ b/dbms/src/Dictionaries/HashedDictionary.cpp
@@ -13,8 +13,8 @@ template <typename T> auto first(const T & value) -> decltype(value.first) { ret
 template <typename T> auto second(const T & value) -> decltype(value.second) { return value.second; }
 
 /// HashMap
-template <typename T> auto first(const T & value) -> decltype(value.getFirst()) { return value.getFirst(); }
-template <typename T> auto second(const T & value) -> decltype(value.getSecond()) { return value.getSecond(); }
+template <typename T> auto first(const T & value) -> decltype(value.getKey()) { return value.getKey(); }
+template <typename T> auto second(const T & value) -> decltype(value.getMapped()) { return value.getMapped(); }
 
 }
 

--- a/dbms/src/Dictionaries/RangeHashedDictionary.cpp
+++ b/dbms/src/Dictionaries/RangeHashedDictionary.cpp
@@ -127,7 +127,7 @@ void RangeHashedDictionary::getString(
         if (it)
         {
             const auto date = dates[i];
-            const auto & ranges_and_values = *lookupResultGetMapped(it);
+            const auto & ranges_and_values = it->getMapped();
             const auto val_it
                 = std::find_if(std::begin(ranges_and_values), std::end(ranges_and_values), [date](const Value<StringRef> & v)
                   {
@@ -398,7 +398,7 @@ void RangeHashedDictionary::getItemsImpl(
         if (it)
         {
             const auto date = dates[i];
-            const auto & ranges_and_values = *lookupResultGetMapped(it);
+            const auto & ranges_and_values = it->getMapped();
             const auto val_it
                 = std::find_if(std::begin(ranges_and_values), std::end(ranges_and_values), [date](const Value<AttributeType> & v)
                   {
@@ -425,7 +425,7 @@ void RangeHashedDictionary::setAttributeValueImpl(Attribute & attribute, const K
 
     if (it)
     {
-        auto & values = *lookupResultGetMapped(it);
+        auto & values = it->getMapped();
 
         const auto insert_it
             = std::lower_bound(std::begin(values), std::end(values), range, [](const Value<T> & lhs, const Range & rhs_range)
@@ -498,7 +498,7 @@ void RangeHashedDictionary::setAttributeValue(Attribute & attribute, const Key i
 
             if (it)
             {
-                auto & values = *lookupResultGetMapped(it);
+                auto & values = it->getMapped();
 
                 const auto insert_it = std::lower_bound(
                     std::begin(values), std::end(values), range, [](const Value<StringRef> & lhs, const Range & rhs_range)
@@ -610,9 +610,9 @@ void RangeHashedDictionary::getIdsAndDates(
 
     for (const auto & key : attr)
     {
-        for (const auto & value : key.getSecond())
+        for (const auto & value : key.getMapped())
         {
-            ids.push_back(key.getFirst());
+            ids.push_back(key.getKey());
             start_dates.push_back(value.range.left);
             end_dates.push_back(value.range.right);
 

--- a/dbms/src/Functions/addressToLine.cpp
+++ b/dbms/src/Functions/addressToLine.cpp
@@ -140,8 +140,8 @@ private:
         std::lock_guard lock(mutex);
         map.emplace(addr, it, inserted);
         if (inserted)
-            *lookupResultGetMapped(it) = impl(addr);
-        return *lookupResultGetMapped(it);
+            it->getMapped() = impl(addr);
+        return it->getMapped();
     }
 };
 

--- a/dbms/src/Functions/array/arrayIntersect.cpp
+++ b/dbms/src/Functions/array/arrayIntersect.cpp
@@ -467,15 +467,15 @@ ColumnPtr FunctionArrayIntersect::execute(const UnpackedArrays & arrays, Mutable
 
         for (const auto & pair : map)
         {
-            if (pair.getSecond() == args)
+            if (pair.getMapped() == args)
             {
                 ++result_offset;
                 if constexpr (is_numeric_column)
-                    result_data.insertValue(pair.getFirst());
+                    result_data.insertValue(pair.getKey());
                 else if constexpr (std::is_same<ColumnType, ColumnString>::value || std::is_same<ColumnType, ColumnFixedString>::value)
-                    result_data.insertData(pair.getFirst().data, pair.getFirst().size);
+                    result_data.insertData(pair.getKey().data, pair.getKey().size);
                 else
-                    result_data.deserializeAndInsertFromArena(pair.getFirst().data);
+                    result_data.deserializeAndInsertFromArena(pair.getKey().data);
 
                 if (all_nullable)
                     null_map.push_back(0);

--- a/dbms/src/Functions/transform.cpp
+++ b/dbms/src/Functions/transform.cpp
@@ -508,7 +508,7 @@ private:
         {
             auto it = table.find(src[i]);
             if (it)
-                memcpy(&dst[i], lookupResultGetMapped(it), sizeof(dst[i]));    /// little endian.
+                memcpy(&dst[i], &it->getMapped(), sizeof(dst[i]));    /// little endian.
             else
                 dst[i] = dst_default;
         }
@@ -524,7 +524,7 @@ private:
         {
             auto it = table.find(src[i]);
             if (it)
-                memcpy(&dst[i], lookupResultGetMapped(it), sizeof(dst[i]));    /// little endian.
+                memcpy(&dst[i], &it->getMapped(), sizeof(dst[i]));    /// little endian.
             else
                 dst[i] = dst_default[i];
         }
@@ -540,7 +540,7 @@ private:
         {
             auto it = table.find(src[i]);
             if (it)
-                memcpy(&dst[i], lookupResultGetMapped(it), sizeof(dst[i]));
+                memcpy(&dst[i], &it->getMapped(), sizeof(dst[i]));
             else
                 dst[i] = src[i];
         }
@@ -557,7 +557,7 @@ private:
         for (size_t i = 0; i < size; ++i)
         {
             auto it = table.find(src[i]);
-            StringRef ref = it ? *lookupResultGetMapped(it) : dst_default;
+            StringRef ref = it ? it->getMapped() : dst_default;
             dst_data.resize(current_dst_offset + ref.size);
             memcpy(&dst_data[current_dst_offset], ref.data, ref.size);
             current_dst_offset += ref.size;
@@ -581,7 +581,7 @@ private:
             StringRef ref;
 
             if (it)
-                ref = *lookupResultGetMapped(it);
+                ref = it->getMapped();
             else
             {
                 ref.data = reinterpret_cast<const char *>(&dst_default_data[current_dst_default_offset]);
@@ -611,7 +611,7 @@ private:
             current_src_offset = src_offsets[i];
             auto it = table.find(ref);
             if (it)
-                memcpy(&dst[i], lookupResultGetMapped(it), sizeof(dst[i]));
+                memcpy(&dst[i], &it->getMapped(), sizeof(dst[i]));
             else
                 dst[i] = dst_default;
         }
@@ -632,7 +632,7 @@ private:
             current_src_offset = src_offsets[i];
             auto it = table.find(ref);
             if (it)
-                memcpy(&dst[i], lookupResultGetMapped(it), sizeof(dst[i]));
+                memcpy(&dst[i], &it->getMapped(), sizeof(dst[i]));
             else
                 dst[i] = dst_default[i];
         }
@@ -655,7 +655,7 @@ private:
 
             auto it = table.find(src_ref);
 
-            StringRef dst_ref = it ? *lookupResultGetMapped(it) : (with_default ? dst_default : src_ref);
+            StringRef dst_ref = it ? it->getMapped() : (with_default ? dst_default : src_ref);
             dst_data.resize(current_dst_offset + dst_ref.size);
             memcpy(&dst_data[current_dst_offset], dst_ref.data, dst_ref.size);
             current_dst_offset += dst_ref.size;
@@ -697,7 +697,7 @@ private:
             StringRef dst_ref;
 
             if (it)
-                dst_ref = *lookupResultGetMapped(it);
+                dst_ref = it->getMapped();
             else
             {
                 dst_ref.data = reinterpret_cast<const char *>(&dst_default_data[current_dst_default_offset]);

--- a/dbms/src/Interpreters/Aggregator.h
+++ b/dbms/src/Interpreters/Aggregator.h
@@ -180,8 +180,6 @@ struct AggregationMethodOneNumber
     using Data = TData;
     using Key = typename Data::key_type;
     using Mapped = typename Data::mapped_type;
-    using iterator = typename Data::iterator;
-    using const_iterator = typename Data::const_iterator;
 
     Data data;
 
@@ -356,8 +354,6 @@ struct AggregationMethodKeysFixed
     using Data = TData;
     using Key = typename Data::key_type;
     using Mapped = typename Data::mapped_type;
-    using iterator = typename Data::iterator;
-    using const_iterator = typename Data::const_iterator;
     static constexpr bool has_nullable_keys = has_nullable_keys_;
     static constexpr bool has_low_cardinality = has_low_cardinality_;
 

--- a/dbms/src/Interpreters/tests/hash_map.cpp
+++ b/dbms/src/Interpreters/tests/hash_map.cpp
@@ -162,8 +162,8 @@ int main(int argc, char ** argv)
             map.emplace(data[i], it, inserted);
             if (inserted)
             {
-                new(lookupResultGetMapped(it)) Value;
-                std::swap(*lookupResultGetMapped(it), value);
+                new (&it->getMapped()) Value;
+                std::swap(it->getMapped(), value);
                 INIT
             }
         }
@@ -193,8 +193,8 @@ int main(int argc, char ** argv)
             map.emplace(data[i], it, inserted);
             if (inserted)
             {
-                new(lookupResultGetMapped(it)) Value;
-                std::swap(*lookupResultGetMapped(it), value);
+                new (&it->getMapped()) Value;
+                std::swap(it->getMapped(), value);
                 INIT
             }
         }
@@ -225,8 +225,8 @@ int main(int argc, char ** argv)
             map.emplace(data[i], it, inserted);
             if (inserted)
             {
-                new(lookupResultGetMapped(it)) Value;
-                std::swap(*lookupResultGetMapped(it), value);
+                new (&it->getMapped()) Value;
+                std::swap(it->getMapped(), value);
                 INIT
             }
         }

--- a/dbms/src/Interpreters/tests/hash_map3.cpp
+++ b/dbms/src/Interpreters/tests/hash_map3.cpp
@@ -85,7 +85,7 @@ int main(int, char **)
     std::cerr << "Collisions: " << map.getCollisions() << std::endl;
 
     for (auto x : map)
-        std::cerr << x.getFirst().toString() << " -> " << x.getSecond() << std::endl;
+        std::cerr << x.getKey().toString() << " -> " << x.getMapped() << std::endl;
 
     return 0;
 }

--- a/dbms/src/Interpreters/tests/hash_map_lookup.cpp
+++ b/dbms/src/Interpreters/tests/hash_map_lookup.cpp
@@ -55,15 +55,15 @@ void NO_INLINE bench(const std::vector<UInt16> & data, const char * name)
 
         map.emplace(data[i], it, inserted);
         if (inserted)
-            *lookupResultGetMapped(it) = 1;
+            it->getMapped() = 1;
         else
-            ++*lookupResultGetMapped(it);
+            ++it->getMapped();
     }
 
     for (size_t i = 0, size = data.size(); i < size; ++i)
     {
         auto it = map.find(data[i]);
-        ++*lookupResultGetMapped(it);
+        ++it->getMapped();
     }
     watch.stop();
     std::cerr << std::fixed << std::setprecision(2) << "HashMap (" << name << "). Size: " << map.size()
@@ -81,10 +81,10 @@ void insert(Map & map, StringRef & k)
     typename Map::LookupResult it;
     map.emplace(k, it, inserted, nullptr);
     if (inserted)
-        *lookupResultGetMapped(it) = 1;
+        it->getMapped() = 1;
     else
-        ++*lookupResultGetMapped(it);
-    std::cout << *lookupResultGetMapped(map.find(k))<< std::endl;
+        ++it->getMapped();
+    std::cout << map.find(k)->getMapped() << std::endl;
 }
 
 int main(int argc, char ** argv)

--- a/dbms/src/Interpreters/tests/hash_map_string.cpp
+++ b/dbms/src/Interpreters/tests/hash_map_string.cpp
@@ -337,8 +337,8 @@ int main(int argc, char ** argv)
         {
             map.emplace(data[i], it, inserted);
             if (inserted)
-                *lookupResultGetMapped(it) = 0;
-            ++*lookupResultGetMapped(it);
+                it->getMapped() = 0;
+            ++it->getMapped();
         }
 
         watch.stop();
@@ -366,8 +366,8 @@ int main(int argc, char ** argv)
         {
             map.emplace(data[i], it, inserted);
             if (inserted)
-                *lookupResultGetMapped(it) = 0;
-            ++*lookupResultGetMapped(it);
+                it->getMapped() = 0;
+            ++it->getMapped();
         }
 
         watch.stop();
@@ -396,8 +396,8 @@ int main(int argc, char ** argv)
         {
             map.emplace(data[i], it, inserted);
             if (inserted)
-                *lookupResultGetMapped(it) = 0;
-            ++*lookupResultGetMapped(it);
+                it->getMapped() = 0;
+            ++it->getMapped();
         }
 
         watch.stop();
@@ -426,8 +426,8 @@ int main(int argc, char ** argv)
         {
             map.emplace(data[i], it, inserted);
             if (inserted)
-                *lookupResultGetMapped(it) = 0;
-            ++*lookupResultGetMapped(it);
+                it->getMapped() = 0;
+            ++it->getMapped();
         }
 
         watch.stop();

--- a/dbms/src/Interpreters/tests/hash_map_string_2.cpp
+++ b/dbms/src/Interpreters/tests/hash_map_string_2.cpp
@@ -595,8 +595,8 @@ void NO_INLINE bench(const std::vector<StringRef> & data, const char * name)
     {
         map.emplace(static_cast<const Key &>(data[i]), it, inserted);
         if (inserted)
-            *lookupResultGetMapped(it) = 0;
-        ++*lookupResultGetMapped(it);
+            it->getMapped() = 0;
+        ++it->getMapped();
     }
 
     watch.stop();

--- a/dbms/src/Interpreters/tests/hash_map_string_3.cpp
+++ b/dbms/src/Interpreters/tests/hash_map_string_3.cpp
@@ -442,8 +442,8 @@ void NO_INLINE bench(const std::vector<StringRef> & data, const char * name)
     {
         map.emplace(static_cast<const Key &>(data[i]), it, inserted);
         if (inserted)
-            *lookupResultGetMapped(it) = 0;
-        ++*lookupResultGetMapped(it);
+            it->getMapped() = 0;
+        ++it->getMapped();
     }
 
     watch.stop();

--- a/dbms/src/Interpreters/tests/hash_map_string_small.cpp
+++ b/dbms/src/Interpreters/tests/hash_map_string_small.cpp
@@ -144,8 +144,8 @@ int main(int argc, char ** argv)
         {
             map.emplace(data[i], it, inserted);
             if (inserted)
-                *lookupResultGetMapped(it) = 0;
-            ++*lookupResultGetMapped(it);
+                it->getMapped() = 0;
+            ++it->getMapped();
         }
 
         watch.stop();
@@ -173,8 +173,8 @@ int main(int argc, char ** argv)
         {
             map.emplace(SmallStringRef(data[i].data, data[i].size), it, inserted);
             if (inserted)
-                *lookupResultGetMapped(it) = 0;
-            ++*lookupResultGetMapped(it);
+                it->getMapped() = 0;
+            ++it->getMapped();
         }
 
         watch.stop();

--- a/dbms/src/Interpreters/tests/string_hash_map.cpp
+++ b/dbms/src/Interpreters/tests/string_hash_map.cpp
@@ -151,8 +151,8 @@ void NO_INLINE bench(const std::vector<StringRef> & data, DB::Arena &, const cha
         {
             map.emplace(DB::ArenaKeyHolder{data[i], pool}, it, inserted);
             if (inserted)
-                *lookupResultGetMapped(it) = 0;
-            ++*lookupResultGetMapped(it);
+                it->getMapped() = 0;
+            ++it->getMapped();
         }
         watch.stop();
 

--- a/dbms/src/Interpreters/tests/two_level_hash_map.cpp
+++ b/dbms/src/Interpreters/tests/two_level_hash_map.cpp
@@ -67,8 +67,8 @@ int main(int argc, char ** argv)
         {
             map.emplace(data[i], it, inserted);
             if (inserted)
-                *lookupResultGetMapped(it) = 0;
-            ++*lookupResultGetMapped(it);
+                it->getMapped() = 0;
+            ++it->getMapped();
         }
 
         watch.stop();
@@ -82,7 +82,7 @@ int main(int argc, char ** argv)
         size_t elems = 0;
         for (const auto & kv : map)
         {
-            sum_counts += kv.getSecond();
+            sum_counts += kv.getMapped();
             ++elems;
         }
 
@@ -103,8 +103,8 @@ int main(int argc, char ** argv)
         {
             map.emplace(i, it, inserted);
             if (inserted)
-                *lookupResultGetMapped(it) = 0;
-            ++*lookupResultGetMapped(it);
+                it->getMapped() = 0;
+            ++it->getMapped();
         }
 
         watch.stop();
@@ -118,11 +118,11 @@ int main(int argc, char ** argv)
         size_t elems = 0;
         for (const auto & kv : map)
         {
-            sum_counts += kv.getSecond();
+            sum_counts += kv.getMapped();
             ++elems;
 
-            if (kv.getFirst() > n)
-                std::cerr << kv.getFirst() << std::endl;
+            if (kv.getKey() > n)
+                std::cerr << kv.getKey() << std::endl;
         }
 
         std::cerr << "sum_counts: " << sum_counts << ", elems: " << elems << std::endl;

--- a/dbms/src/Processors/Formats/Impl/JSONEachRowRowInputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/JSONEachRowRowInputFormat.cpp
@@ -65,9 +65,9 @@ inline size_t JSONEachRowRowInputFormat::columnIndex(const StringRef & name, siz
 
     if (prev_positions.size() > key_index
         && prev_positions[key_index]
-        && name == *lookupResultGetKey(prev_positions[key_index]))
+        && name == prev_positions[key_index]->getKey())
     {
-        return *lookupResultGetMapped(prev_positions[key_index]);
+        return prev_positions[key_index]->getMapped();
     }
     else
     {
@@ -78,7 +78,7 @@ inline size_t JSONEachRowRowInputFormat::columnIndex(const StringRef & name, siz
             if (key_index < prev_positions.size())
                 prev_positions[key_index] = it;
 
-            return *lookupResultGetMapped(it);
+            return it->getMapped();
         }
         else
             return UNKNOWN_FIELD;

--- a/dbms/src/Processors/Formats/Impl/TSKVRowInputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/TSKVRowInputFormat.cpp
@@ -131,7 +131,7 @@ bool TSKVRowInputFormat::readRow(MutableColumns & columns, RowReadExtension & ex
                 }
                 else
                 {
-                    index = *lookupResultGetMapped(it);
+                    index = it->getMapped();
 
                     if (seen_columns[index])
                         throw Exception("Duplicate field found while parsing TSKV format: " + name_ref.toString(), ErrorCodes::INCORRECT_DATA);

--- a/dbms/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -57,7 +57,7 @@ void buildScatterSelector(
                 throw Exception("Too many partitions for single INSERT block (more than " + toString(max_parts) + "). The limit is controlled by 'max_partitions_per_insert_block' setting. Large number of partitions is a common misconception. It will lead to severe negative performance impact, including slow server startup, slow INSERT queries and slow SELECT queries. Recommended total number of partitions for a table is under 1000..10000. Please note, that partitioning is not intended to speed up SELECT queries (ORDER BY key is sufficient to make range queries fast). Partitions are intended for data manipulation (DROP PARTITION, etc).", ErrorCodes::TOO_MANY_PARTS);
 
             partition_num_to_first_row.push_back(i);
-            *lookupResultGetMapped(it) = partitions_count;
+            it->getMapped() = partitions_count;
 
             ++partitions_count;
 
@@ -70,7 +70,7 @@ void buildScatterSelector(
         }
 
         if (partitions_count > 1)
-            selector[i] = *lookupResultGetMapped(it);
+            selector[i] = it->getMapped();
     }
 }
 

--- a/dbms/src/Storages/StorageJoin.cpp
+++ b/dbms/src/Storages/StorageJoin.cpp
@@ -14,6 +14,7 @@
 #include <Poco/String.h>    /// toLower
 #include <Poco/File.h>
 
+#include <any>
 
 namespace DB
 {
@@ -252,7 +253,7 @@ private:
     std::optional<size_t> key_pos;
     MutableColumns columns;
 
-    std::unique_ptr<void, std::function<void(void *)>> position; /// type erasure
+    std::any position;
 
 
     template <ASTTableJoin::Strictness STRICTNESS, typename Maps>
@@ -319,23 +320,22 @@ private:
     {
         size_t rows_added = 0;
 
-        if (!position)
-            position = decltype(position)(
-                static_cast<void *>(new typename Map::const_iterator(map.begin())),
-                [](void * ptr) { delete reinterpret_cast<typename Map::const_iterator *>(ptr); });
+        using Pos = typename Map::ConstPosition;
+        if (!position.has_value())
+            position = std::make_any<Pos>(map.startPos());
 
-        auto & it = *reinterpret_cast<typename Map::const_iterator *>(position.get());
-        auto end = map.end();
+        Pos & pos = std::any_cast<Pos &>(position);
 
-        for (; it != end; ++it)
+        map.forEachCell([&](const auto & key, const auto & cell)
         {
             if constexpr (STRICTNESS == ASTTableJoin::Strictness::Any)
             {
                 for (size_t j = 0; j < columns.size(); ++j)
                     if (j == key_pos)
-                        columns[j]->insertData(rawData(it->getFirst()), rawSize(it->getFirst()));
+                        columns[j]->insertData(rawData(key), rawSize(key));
                     else
-                        columns[j]->insertFrom(*it->getSecond().block->getByPosition(column_indices[j]).column.get(), it->getSecond().row_num);
+                        columns[j]->insertFrom(
+                            *cell.getMapped().block->getByPosition(column_indices[j]).column.get(), cell.getMapped().row_num);
                 ++rows_added;
             }
             else if constexpr (STRICTNESS == ASTTableJoin::Strictness::Asof)
@@ -343,22 +343,21 @@ private:
                 throw Exception("ASOF join storage is not implemented yet", ErrorCodes::NOT_IMPLEMENTED);
             }
             else
-                for (auto ref_it = it->getSecond().begin(); ref_it.ok(); ++ref_it)
+                for (auto ref_it = cell.getMapped().begin(); ref_it.ok(); ++ref_it)
                 {
                     for (size_t j = 0; j < columns.size(); ++j)
                         if (j == key_pos)
-                            columns[j]->insertData(rawData(it->getFirst()), rawSize(it->getFirst()));
+                            columns[j]->insertData(rawData(key), rawSize(key));
                         else
                             columns[j]->insertFrom(*ref_it->block->getByPosition(column_indices[j]).column.get(), ref_it->row_num);
                     ++rows_added;
                 }
 
             if (rows_added >= max_block_size)
-            {
-                ++it;
-                break;
-            }
-        }
+                return true;
+
+            return false;
+        }, pos);
 
         return rows_added;
     }

--- a/utils/test-data-generator/MarkovModel.h
+++ b/utils/test-data-generator/MarkovModel.h
@@ -105,7 +105,7 @@ public:
             if (table.end() == it)
                 return pos - data;
 
-            *pos = it->getSecond().sample(random());
+            *pos = it->getMapped().sample(random());
 
             /// Zero byte marks end of string.
             if (0 == *pos)
@@ -125,12 +125,12 @@ public:
         for (auto & elem : table)
         {
             UInt32 new_total = 0;
-            for (auto & frequency : elem.getSecond().data)
+            for (auto & frequency : elem.getMapped().data)
             {
                 frequency.count = transform(frequency.count);
                 new_total += frequency.count;
             }
-            elem.getSecond().total = new_total;
+            elem.getMapped().total = new_total;
         }
     }
 
@@ -142,10 +142,10 @@ public:
 
         for (const auto & elem : table)
         {
-            writeBinary(elem.getFirst(), out);
-            writeBinary(UInt8(elem.getSecond().data.size()), out);
+            writeBinary(elem.getKey(), out);
+            writeBinary(UInt8(elem.getMapped().data.size()), out);
 
-            for (const auto & frequency : elem.getSecond().data)
+            for (const auto & frequency : elem.getMapped().data)
             {
                 writeBinary(frequency.byte, out);
                 writeVarUInt(frequency.count, out);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Performance Improvement

Short description (up to few sentences):
Unifying hash table interface so that we have a consistent usage of lookup, emplace and iteration.

Detailed description (optional):
This pr supercedes https://github.com/ClickHouse/ClickHouse/pull/7292 and https://github.com/ClickHouse/ClickHouse/pull/7267 . The main improvements are:

1. find & emplace results of hash tables now all support `getKey()/getMapped()` methods (code simplification) 
2. internal iteration of hash table supports additional variants that avoid cell assembling and support break/resume. (performance improvement for FixedHashTable and StringHashTable)

