### PR TITLE
Add PARTITION ID to OPTIMIZE documentation

### DIFF
--- a/docs/en/query_language/misc.md
+++ b/docs/en/query_language/misc.md
@@ -174,7 +174,7 @@ Changes already made by the mutation are not rolled back.
 ## OPTIMIZE {#misc_operations-optimize}
 
 ```sql
-OPTIMIZE TABLE [db.]name [ON CLUSTER cluster] [PARTITION partition] [FINAL]
+OPTIMIZE TABLE [db.]name [ON CLUSTER cluster] [PARTITION partition | PARTITION ID 'partition_id'] [FINAL]
 ```
 
 This query tries to initialize an unscheduled merge of data parts for tables with a table engine from the [MergeTree](../operations/table_engines/mergetree.md) family. Other kinds of table engines aren't supported.
@@ -182,7 +182,7 @@ This query tries to initialize an unscheduled merge of data parts for tables wit
 When `OPTIMIZE` is used with the [ReplicatedMergeTree](../operations/table_engines/replication.md) family of table engines, ClickHouse creates a task for merging and waits for execution on all nodes (if the `replication_alter_partitions_sync` setting is enabled).
 
 - If `OPTIMIZE` doesn't perform a merge for any reason, it doesn't notify the client. To enable notifications, use the [optimize_throw_if_noop](../operations/settings/settings.md#setting-optimize_throw_if_noop) setting.
-- If you specify a `PARTITION`, only the specified partition is optimized.
+- If you specify a `PARTITION`, only the specified partition is optimized. [How to set partition expression](alter.md#alter-how-to-specify-part-expr).
 - If you specify `FINAL`, optimization is performed even when all the data is already in one part.
 
 !!! warning "Warning"

--- a/docs/ru/query_language/misc.md
+++ b/docs/ru/query_language/misc.md
@@ -173,7 +173,7 @@ KILL MUTATION WHERE database = 'default' AND table = 'table' AND mutation_id = '
 ## OPTIMIZE {#misc_operations-optimize}
 
 ```sql
-OPTIMIZE TABLE [db.]name [ON CLUSTER cluster] [PARTITION partition] [FINAL]
+OPTIMIZE TABLE [db.]name [ON CLUSTER cluster] [PARTITION partition | PARTITION ID 'partition_id'] [FINAL]
 ```
 
 Запрос пытается запустить внеплановый мёрж кусков данных для таблиц семейства [MergeTree](../operations/table_engines/mergetree.md). Другие движки таблиц не поддерживаются.
@@ -181,7 +181,7 @@ OPTIMIZE TABLE [db.]name [ON CLUSTER cluster] [PARTITION partition] [FINAL]
 Если `OPTIMIZE` применяется к таблицам семейства [ReplicatedMergeTree](../operations/table_engines/replication.md), ClickHouse создаёт задачу на мёрж и ожидает её исполнения на всех узлах (если активирована настройка `replication_alter_partitions_sync`).
 
 - Если `OPTIMIZE` не выполняет мёрж по любой причине, ClickHouse не оповещает об этом клиента. Чтобы включить оповещения, используйте настройку [optimize_throw_if_noop](../operations/settings/settings.md#setting-optimize_throw_if_noop).
-- Если указать `PARTITION`, то оптимизация выполняется только для указанной партиции.
+- Если указать `PARTITION`, то оптимизация выполняется только для указанной партиции. [Как задавать имя партиции в запросах](alter.md#alter-how-to-specify-part-expr).
 - Если указать `FINAL`, то оптимизация выполняется даже в том случае, если все данные уже лежат в одном куске.
 
 !!! warning "Внимание"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Documentation

Short description (up to few sentences):

Add `PARTITION ID` variant to OPTIMIZE description and link to `How To Set Partition Expression`