### PR TITLE
Add handling of SQL_TINYINT and SQL_BIGINT, fix SQL_FLOAT in ODBC Bridge

### DIFF
--- a/dbms/programs/odbc-bridge/ColumnInfoHandler.cpp
+++ b/dbms/programs/odbc-bridge/ColumnInfoHandler.cpp
@@ -38,12 +38,16 @@ namespace
 
         switch (type)
         {
+            case SQL_TINYINT:
+                return factory.get("Int8");
             case SQL_INTEGER:
                 return factory.get("Int32");
             case SQL_SMALLINT:
                 return factory.get("Int16");
+            case SQL_BIGINT:
+                return factory.get("Int64");
             case SQL_FLOAT:
-                return factory.get("Float32");
+                return factory.get("Float64");
             case SQL_REAL:
                 return factory.get("Float32");
             case SQL_DOUBLE:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):

Add handling of SQL_TINYINT and SQL_BIGINT, and fix handling of SQL_FLOAT data source types in ODBC Bridge.
