### PR TITLE
Fix DUMP debug.

### DIFF
--- a/dbms/src/Core/iostream_debug_helpers.cpp
+++ b/dbms/src/Core/iostream_debug_helpers.cpp
@@ -18,15 +18,17 @@
 
 namespace DB
 {
-std::ostream & operator<<(std::ostream & stream, const IBlockInputStream & what)
+
+template <>
+std::ostream & operator<< <Field>(std::ostream & stream, const Field & what)
 {
-    stream << "IBlockInputStream(name = " << what.getName() << ")";
+    stream << applyVisitor(FieldVisitorDump(), what);
     return stream;
 }
 
-std::ostream & operator<<(std::ostream & stream, const Field & what)
+std::ostream & operator<<(std::ostream & stream, const IBlockInputStream & what)
 {
-    stream << applyVisitor(FieldVisitorDump(), what);
+    stream << "IBlockInputStream(name = " << what.getName() << ")";
     return stream;
 }
 
@@ -99,14 +101,6 @@ std::ostream & operator<<(std::ostream & stream, const Connection::Packet & what
         stream << "exception = " << what.exception.get();
     // TODO: profile_info
     stream << ") {" << what.block << "}";
-    return stream;
-}
-
-std::ostream & operator<<(std::ostream & stream, const IAST & what)
-{
-    stream << "IAST{";
-    what.dumpTree(stream);
-    stream << "}";
     return stream;
 }
 

--- a/dbms/src/Core/iostream_debug_helpers.h
+++ b/dbms/src/Core/iostream_debug_helpers.h
@@ -7,17 +7,14 @@
 namespace DB
 {
 
-// Used to disable implicit casting for certain overloaded types such as Field, which leads to
-// overload resolution ambiguity.
-template <typename T> struct Dumpable;
-template <typename T>
-std::ostream & operator<<(std::ostream & stream, const typename Dumpable<T>::Type & what);
+// Use template to disable implicit casting for certain overloaded types such as Field, which leads
+// to overload resolution ambiguity.
+class Field;
+template <typename T, typename U = std::enable_if_t<std::is_same_v<T, Field>>>
+std::ostream & operator<<(std::ostream & stream, const T & what);
 
 class IBlockInputStream;
 std::ostream & operator<<(std::ostream & stream, const IBlockInputStream & what);
-
-class Field;
-template <> struct Dumpable<Field> { using Type = Field; };
 
 struct NameAndTypePair;
 std::ostream & operator<<(std::ostream & stream, const NameAndTypePair & what);
@@ -42,9 +39,6 @@ std::ostream & operator<<(std::ostream & stream, const ColumnWithTypeAndName & w
 
 class IColumn;
 std::ostream & operator<<(std::ostream & stream, const IColumn & what);
-
-class IAST;
-std::ostream & operator<<(std::ostream & stream, const IAST & what);
 
 std::ostream & operator<<(std::ostream & stream, const Connection::Packet & what);
 

--- a/dbms/src/Parsers/iostream_debug_helpers.cpp
+++ b/dbms/src/Parsers/iostream_debug_helpers.cpp
@@ -1,4 +1,5 @@
 #include "iostream_debug_helpers.h"
+#include <Parsers/IAST.h>
 #include <Parsers/IParser.h>
 #include <Parsers/Lexer.h>
 #include <Parsers/TokenIterator.h>
@@ -17,6 +18,14 @@ std::ostream & operator<<(std::ostream & stream, const Expected & what)
     stream << "Expected {variants=";
     dumpValue(stream, what.variants)
        << "; max_parsed_pos=" << what.max_parsed_pos << "}";
+    return stream;
+}
+
+std::ostream & operator<<(std::ostream & stream, const IAST & what)
+{
+    stream << "IAST{";
+    what.dumpTree(stream);
+    stream << "}";
     return stream;
 }
 

--- a/dbms/src/Parsers/iostream_debug_helpers.h
+++ b/dbms/src/Parsers/iostream_debug_helpers.h
@@ -9,6 +9,9 @@ std::ostream & operator<<(std::ostream & stream, const Token & what);
 struct Expected;
 std::ostream & operator<<(std::ostream & stream, const Expected & what);
 
+class IAST;
+std::ostream & operator<<(std::ostream & stream, const IAST & what);
+
 }
 
 #include <Core/iostream_debug_helpers.h>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Build/Testing/Packaging Improvement


Short description (up to few sentences):

https://github.com/ClickHouse/ClickHouse/pull/7419 is wrong. Dependent type cannot be used for template deduction. Also move DUMP AST to parser DSO.