### PR TITLE
Some parser improvements.

### DIFF
--- a/dbms/src/Parsers/ExpressionElementParsers.cpp
+++ b/dbms/src/Parsers/ExpressionElementParsers.cpp
@@ -81,6 +81,13 @@ bool ParserParenthesisExpression::parseImpl(Pos & pos, ASTPtr & node, Expected &
     if (!contents.parse(pos, contents_node, expected))
         return false;
 
+    bool is_elem = true;
+    if (pos->type == TokenType::Comma)
+    {
+        is_elem = false;
+        ++pos;
+    }
+
     if (pos->type != TokenType::ClosingRoundBracket)
         return false;
     ++pos;
@@ -94,7 +101,7 @@ bool ParserParenthesisExpression::parseImpl(Pos & pos, ASTPtr & node, Expected &
         return false;
     }
 
-    if (expr_list.children.size() == 1)
+    if (expr_list.children.size() == 1 && is_elem)
     {
         node = expr_list.children.front();
     }

--- a/dbms/src/Parsers/ExpressionElementParsers.h
+++ b/dbms/src/Parsers/ExpressionElementParsers.h
@@ -275,8 +275,7 @@ class ParserWithOptionalAlias : public IParserBase
 {
 public:
     ParserWithOptionalAlias(ParserPtr && elem_parser_, bool allow_alias_without_as_keyword_)
-    : elem_parser(std::move(elem_parser_)), allow_alias_without_as_keyword(allow_alias_without_as_keyword_)
-    {}
+    : elem_parser(std::move(elem_parser_)), allow_alias_without_as_keyword(allow_alias_without_as_keyword_) {}
 protected:
     ParserPtr elem_parser;
     bool allow_alias_without_as_keyword;

--- a/dbms/src/Parsers/ExpressionListParsers.cpp
+++ b/dbms/src/Parsers/ExpressionListParsers.cpp
@@ -560,7 +560,7 @@ bool ParserOrderByExpressionList::parseImpl(Pos & pos, ASTPtr & node, Expected &
 bool ParserNullityChecking::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
     ASTPtr node_comp;
-    if (!ParserComparisonExpression{}.parse(pos, node_comp, expected))
+    if (!elem_parser.parse(pos, node_comp, expected))
         return false;
 
     ParserKeyword s_is{"IS"};

--- a/dbms/src/Parsers/ExpressionListParsers.h
+++ b/dbms/src/Parsers/ExpressionListParsers.h
@@ -115,18 +115,6 @@ protected:
 };
 
 
-class ParserTupleElementExpression : public IParserBase
-{
-private:
-    static const char * operators[];
-
-protected:
-    const char * getName() const { return "tuple element expression"; }
-
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
-};
-
-
 class ParserArrayElementExpression : public IParserBase
 {
 private:
@@ -134,6 +122,18 @@ private:
 
 protected:
     const char * getName() const { return "array element expression"; }
+
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+};
+
+
+class ParserTupleElementExpression : public IParserBase
+{
+private:
+    static const char * operators[];
+
+protected:
+    const char * getName() const { return "tuple element expression"; }
 
     bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
 };
@@ -241,6 +241,9 @@ protected:
   */
 class ParserNullityChecking : public IParserBase
 {
+private:
+    ParserComparisonExpression elem_parser;
+
 protected:
     const char * getName() const override { return "nullity checking"; }
     bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;

--- a/dbms/tests/queries/0_stateless/01021_tuple_parser.reference
+++ b/dbms/tests/queries/0_stateless/01021_tuple_parser.reference
@@ -1,0 +1,2 @@
+Tuple(UInt8)	(1)
+SELECT tuple(1)

--- a/dbms/tests/queries/0_stateless/01021_tuple_parser.sql
+++ b/dbms/tests/queries/0_stateless/01021_tuple_parser.sql
@@ -1,0 +1,5 @@
+SELECT toTypeName((1,)), (1,);
+
+SET enable_debug_queries = 1;
+
+ANALYZE SELECT (1,)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement


Short description (up to few sentences):
Support parsing `(X,)` as tuple similar to python. More consistent code.
