### PR TITLE
odbc table function now respects external_table_functions_use_nulls

### DIFF
--- a/dbms/programs/odbc-bridge/ColumnInfoHandler.cpp
+++ b/dbms/programs/odbc-bridge/ColumnInfoHandler.cpp
@@ -63,15 +63,6 @@ namespace
                 return factory.get("String");
         }
     }
-
-    bool parseBool(const std::string & s, bool default_value = false)
-    {
-        bool result;
-        if (Poco::NumberParser::tryParseBool(s, result))
-            return result;
-
-        return default_value;
-    }
 }
 
 namespace ErrorCodes
@@ -105,7 +96,6 @@ void ODBCColumnsInfoHandler::handleRequest(Poco::Net::HTTPServerRequest & reques
     std::string schema_name = "";
     std::string table_name = params.get("table");
     std::string connection_string = params.get("connection_string");
-    const bool external_table_functions_use_nulls = parseBool(params.get("external_table_functions_use_nulls", "false"));
 
     if (params.has("schema"))
     {
@@ -118,6 +108,8 @@ void ODBCColumnsInfoHandler::handleRequest(Poco::Net::HTTPServerRequest & reques
 
     try
     {
+        const bool external_table_functions_use_nulls = Poco::NumberParser::parseBool(params.get("external_table_functions_use_nulls", "false"));
+
         POCO_SQL_ODBC_CLASS::SessionImpl session(validateODBCConnectionString(connection_string), DBMS_DEFAULT_CONNECT_TIMEOUT_SEC);
         SQLHDBC hdbc = session.dbc().handle();
 

--- a/dbms/src/Core/Settings.h
+++ b/dbms/src/Core/Settings.h
@@ -357,7 +357,7 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingBool, allow_experimental_multiple_joins_emulation, true, "Emulate multiple joins using subselects") \
     M(SettingBool, allow_experimental_cross_to_join_conversion, true, "Convert CROSS JOIN to INNER JOIN if possible") \
     M(SettingBool, cancel_http_readonly_queries_on_client_close, false, "Cancel HTTP readonly queries when a client closes the connection without waiting for response.") \
-    M(SettingBool, external_table_functions_use_nulls, true, "If it is set to true, external table functions will implicitly use Nullable type if needed. Otherwise NULLs will be substituted with default values. Currently supported only for 'mysql' table function.") \
+    M(SettingBool, external_table_functions_use_nulls, true, "If it is set to true, external table functions will implicitly use Nullable type if needed. Otherwise NULLs will be substituted with default values. Currently supported only by 'mysql' and 'odbc' table functions.") \
     M(SettingBool, allow_experimental_data_skipping_indices, false, "If it is set to true, data skipping indices can be used in CREATE TABLE/ALTER TABLE queries.") \
     \
     M(SettingBool, experimental_use_processors, false, "Use processors pipeline.") \

--- a/dbms/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterSelectQuery.cpp
@@ -286,8 +286,9 @@ InterpreterSelectQuery::InterpreterSelectQuery(
     {
         if (is_table_func)
         {
-            /// Read from table function.
-            storage = context.getQueryContext().executeTableFunction(table_expression);
+            /// Read from table function. propagate all settings from initSettings(),
+            /// alternative is to call on current `context`, but that can potentially pollute it.
+            storage = getSubqueryContext(context).executeTableFunction(table_expression);
         }
         else
         {

--- a/dbms/src/TableFunctions/ITableFunctionXDBC.cpp
+++ b/dbms/src/TableFunctions/ITableFunctionXDBC.cpp
@@ -71,9 +71,9 @@ StoragePtr ITableFunctionXDBC::executeImpl(const ASTPtr & ast_function, const Co
         columns_info_uri.addQueryParameter("schema", schema_name);
     columns_info_uri.addQueryParameter("table", remote_table_name);
 
-    const auto use_nuls = context.getSettingsRef().external_table_functions_use_nulls;
+    const auto use_nulls = context.getSettingsRef().external_table_functions_use_nulls;
     columns_info_uri.addQueryParameter("external_table_functions_use_nulls",
-        Poco::NumberFormatter::format(use_nuls));
+        Poco::NumberFormatter::format(use_nulls));
 
     ReadWriteBufferFromHTTP buf(columns_info_uri, Poco::Net::HTTPRequest::HTTP_POST, nullptr);
 

--- a/dbms/src/TableFunctions/ITableFunctionXDBC.cpp
+++ b/dbms/src/TableFunctions/ITableFunctionXDBC.cpp
@@ -16,6 +16,7 @@
 #include <Poco/Net/HTTPRequest.h>
 #include <Common/Exception.h>
 #include <Common/typeid_cast.h>
+#include <Poco/NumberFormatter.h>
 
 
 namespace DB
@@ -69,6 +70,10 @@ StoragePtr ITableFunctionXDBC::executeImpl(const ASTPtr & ast_function, const Co
     if (!schema_name.empty())
         columns_info_uri.addQueryParameter("schema", schema_name);
     columns_info_uri.addQueryParameter("table", remote_table_name);
+
+    const auto use_nuls = context.getSettingsRef().external_table_functions_use_nulls;
+    columns_info_uri.addQueryParameter("external_table_functions_use_nulls",
+        Poco::NumberFormatter::format(use_nuls));
 
     ReadWriteBufferFromHTTP buf(columns_info_uri, Poco::Net::HTTPRequest::HTTP_POST, nullptr);
 

--- a/dbms/tests/integration/test_odbc_interaction/test.py
+++ b/dbms/tests/integration/test_odbc_interaction/test.py
@@ -91,7 +91,8 @@ def test_mysql_simple_select_works(started_cluster):
     with conn.cursor() as cursor:
         cursor.execute("INSERT INTO clickhouse.{} VALUES(50, 'null-guy', 127, 255, NULL), (100, 'non-null-guy', 127, 255, 511);".format(table_name))
         conn.commit()
-    assert node1.query("SELECT column_x FROM odbc('DSN={}', '{}')".format(mysql_setup["DSN"], table_name)) == '\\N\n511\n'
+    assert node1.query("SELECT column_x FROM odbc('DSN={}', '{}') SETTINGS external_table_functions_use_nulls=1".format(mysql_setup["DSN"], table_name)) == '\\N\n511\n'
+    assert node1.query("SELECT column_x FROM odbc('DSN={}', '{}') SETTINGS external_table_functions_use_nulls=0".format(mysql_setup["DSN"], table_name)) == '0\n511\n'
 
     node1.query('''
 CREATE TABLE {}(id UInt32, name String, age UInt32, money UInt32, column_x Nullable(UInt32)) ENGINE = MySQL('mysql1:3306', 'clickhouse', '{}', 'root', 'clickhouse');


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
 * Passing setting value to ODBC-bridge on each request
 * Handling that setting value correctly in ODBC-bridge
 * Fixed issue with executing table-functions on context with no settings
   applied in `SELECT ... SETTINGS x=foo` query.
 * Tests to verify fix.

...