### PR TITLE
[RFC] Do not account memory for Buffer engine in max_memory_usage limit

### DIFF
--- a/dbms/src/Storages/StorageBuffer.cpp
+++ b/dbms/src/Storages/StorageBuffer.cpp
@@ -265,6 +265,8 @@ static void appendBlock(const Block & from, Block & to)
 
     size_t old_rows = to.rows();
 
+    auto temporarily_disable_memory_tracker = getCurrentMemoryTrackerActionLock();
+
     try
     {
         for (size_t column_no = 0, columns = to.columns(); column_no < columns; ++column_no)
@@ -282,9 +284,6 @@ static void appendBlock(const Block & from, Block & to)
         /// Rollback changes.
         try
         {
-            /// Avoid "memory limit exceeded" exceptions during rollback.
-            auto temporarily_disable_memory_tracker = getCurrentMemoryTrackerActionLock();
-
             for (size_t column_no = 0, columns = to.columns(); column_no < columns; ++column_no)
             {
                 ColumnPtr & col_to = to.getByPosition(column_no).column;
@@ -339,7 +338,7 @@ public:
             {
                 LOG_TRACE(storage.log, "Writing block with " << rows << " rows, " << bytes << " bytes directly.");
                 storage.writeBlockToDestination(block, destination);
-             }
+            }
             return;
         }
 
@@ -621,6 +620,8 @@ void StorageBuffer::writeBlockToDestination(const Block & block, StoragePtr tabl
         LOG_ERROR(log, "Destination table " << backQuoteIfNeed(destination_database) << "." << backQuoteIfNeed(destination_table) << " doesn't exist. Block of data is discarded.");
         return;
     }
+
+    auto temporarily_disable_memory_tracker = getCurrentMemoryTrackerActionLock();
 
     auto insert = std::make_shared<ASTInsertQuery>();
 

--- a/dbms/tests/queries/0_stateless/01019_Buffer_and_max_memory_usage.sql
+++ b/dbms/tests/queries/0_stateless/01019_Buffer_and_max_memory_usage.sql
@@ -1,0 +1,24 @@
+DROP TABLE IF EXISTS null_;
+DROP TABLE IF EXISTS buffer_;
+
+CREATE TABLE null_ (key UInt64) Engine=Null();
+CREATE TABLE buffer_ (key UInt64) Engine=Buffer(currentDatabase(), null_,
+    1,    /* num_layers */
+    0,    /* min_time   */
+    86400,/* max_time   */
+    0,    /* min_rows   */
+    100e9,/* max_rows   */
+    0,    /* min_bytes  */
+    20e6  /* max_bytes  */
+);
+
+-- note that there is untracked_memory_limit (4MB) in MemoryTracker
+SET max_memory_usage=10e6;
+
+SET min_insert_block_size_bytes=9e6;
+INSERT INTO buffer_ SELECT toUInt64(number) FROM system.numbers LIMIT 10e6; -- { serverError 241 }
+
+OPTIMIZE TABLE buffer_; -- flush
+
+SET min_insert_block_size_bytes=1e6;
+INSERT INTO buffer_ SELECT toUInt64(number) FROM system.numbers LIMIT 10e6;


### PR DESCRIPTION
Thoughts?

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Do not account memory for Buffer engine in max_memory_usage limit

Detailed description (optional):

Since background flush will not be accounted there, and it can be too
tricky to calclulate this limit, in case you have multiple materialized
views with Buffer engine.