### PR TITLE
Complement to #7501

### DIFF
--- a/dbms/src/DataTypes/DataTypeTuple.cpp
+++ b/dbms/src/DataTypes/DataTypeTuple.cpp
@@ -188,6 +188,13 @@ void DataTypeTuple::deserializeText(IColumn & column, ReadBuffer & istr, const F
         }
     });
 
+    // Special format for one element tuple (1,)
+    if (1 == elems.size())
+    {
+        skipWhitespaceIfAny(istr);
+        // Allow both (1) and (1,)
+        checkChar(',', istr);
+    }
     skipWhitespaceIfAny(istr);
     assertChar(')', istr);
 }

--- a/dbms/tests/queries/0_stateless/01021_tuple_parser.sql
+++ b/dbms/tests/queries/0_stateless/01021_tuple_parser.sql
@@ -2,4 +2,12 @@ SELECT toTypeName((1,)), (1,);
 
 SET enable_debug_queries = 1;
 
-ANALYZE SELECT (1,)
+ANALYZE SELECT (1,);
+
+DROP TABLE IF EXISTS tuple_values;
+
+CREATE TABLE tuple_values (t Tuple(int)) ENGINE = Memory;
+
+INSERT INTO tuple_values VALUES ((1)), ((2,));
+
+DROP TABLE tuple_values;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en


For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

Short description (up to few sentences):
Have format Value accept single element tuple as  `(1,)`. https://github.com/ClickHouse/ClickHouse/pull/7501