### PR TITLE
Fixed missing file name escaping in FREEZE command

### DIFF
--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3355,7 +3355,11 @@ void MergeTreeData::freezePartitionsByMatcher(MatcherFn matcher, const String & 
         LOG_DEBUG(log, "Freezing part " << part->name << " snapshot will be placed at " + backup_path);
 
         String part_absolute_path = Poco::Path(part->getFullPath()).absolute().toString();
-        String backup_part_absolute_path = backup_path + "data/" + getDatabaseName() + "/" + getTableName() + "/" + part->relative_path;
+        String backup_part_absolute_path = backup_path
+            + "data/"
+            + escapeForFileName(getDatabaseName()) + "/"
+            + escapeForFileName(getTableName()) + "/"
+            + part->relative_path;
         localBackup(part_absolute_path, backup_part_absolute_path);
         part->is_frozen.store(true, std::memory_order_relaxed);
         ++parts_processed;

--- a/dbms/tests/integration/test_filesystem_layout/test.py
+++ b/dbms/tests/integration/test_filesystem_layout/test.py
@@ -1,0 +1,28 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node")
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_file_path_escaping(started_cluster):
+    node.query('''
+        CREATE TABLE test.`T.a_b,l-e!` (`~Id` UInt32)
+        ENGINE = MergeTree() PARTITION BY `~Id` ORDER BY `~Id`;
+        ''')
+    node.query('''INSERT INTO test.`T.a_b,l-e!` VALUES (1);''')
+    node.query('''ALTER TABLE test.`T.a_b,l-e!` FREEZE;''')
+
+    node.exec_in_container(["bash", "-c", "test -f /var/lib/clickhouse/data/test/T%2Ea_b%2Cl%2De%21/1_1_1_0/%7EId.bin"])
+    node.exec_in_container(["bash", "-c", "test -f /var/lib/clickhouse/shadow/1/data/test/T%2Ea_b%2Cl%2De%21/1_1_1_0/%7EId.bin"])
+

--- a/dbms/tests/integration/test_filesystem_layout/test.py
+++ b/dbms/tests/integration/test_filesystem_layout/test.py
@@ -16,6 +16,7 @@ def started_cluster():
 
 
 def test_file_path_escaping(started_cluster):
+    node.query('CREATE DATABASE IF NOT EXISTS test')
     node.query('''
         CREATE TABLE test.`T.a_b,l-e!` (`~Id` UInt32)
         ENGINE = MergeTree() PARTITION BY `~Id` ORDER BY `~Id`;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Database and table name escaping in data dir and shadow dir mismatches:  
```
root@sas-5a7hf5ht2zpr3wr7 ~ # ls -a /var/lib/clickhouse/data/test_db/
.  ..  %2Einner%2Emview_01  table_01
root@sas-5a7hf5ht2zpr3wr7 ~ # ls -a /var/lib/clickhouse/shadow/1/data/test_db/
.  ..  .inner.mview_01
```
