### PR TITLE
early constant folding improvement

### DIFF
--- a/dbms/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterSelectQuery.cpp
@@ -384,6 +384,9 @@ InterpreterSelectQuery::InterpreterSelectQuery(
             }
         }
 
+        if (!options.only_analyze && storage && filter_info && query.prewhere())
+            throw Exception("PREWHERE is not supported if the table is filtered by row-level security expression", ErrorCodes::ILLEGAL_PREWHERE);
+
         /// Calculate structure of the result.
         result_header = getSampleBlockImpl();
     };
@@ -393,18 +396,18 @@ InterpreterSelectQuery::InterpreterSelectQuery(
     bool need_analyze_again = false;
     if (analysis_result.prewhere_constant_filter_description.always_false || analysis_result.prewhere_constant_filter_description.always_true)
     {
-        auto constant = std::make_shared<ASTLiteral>(0u);
         if (analysis_result.prewhere_constant_filter_description.always_true)
-            constant->value = 1u;
-        query.setExpression(ASTSelectQuery::Expression::PREWHERE, constant);
+            query.setExpression(ASTSelectQuery::Expression::PREWHERE, {});
+        else
+            query.setExpression(ASTSelectQuery::Expression::PREWHERE, std::make_shared<ASTLiteral>(0u));
         need_analyze_again = true;
     }
     if (analysis_result.where_constant_filter_description.always_false || analysis_result.where_constant_filter_description.always_true)
     {
-        auto constant = std::make_shared<ASTLiteral>(0u);
         if (analysis_result.where_constant_filter_description.always_true)
-            constant->value = 1u;
-        query.setExpression(ASTSelectQuery::Expression::WHERE, constant);
+            query.setExpression(ASTSelectQuery::Expression::WHERE, {});
+        else
+            query.setExpression(ASTSelectQuery::Expression::WHERE, std::make_shared<ASTLiteral>(0u));
         need_analyze_again = true;
     }
     if (need_analyze_again)
@@ -1034,9 +1037,6 @@ void InterpreterSelectQuery::executeImpl(TPipeline & pipeline, const BlockInputS
             pipeline.init({std::make_shared<NullSource>(source_header)});
         else
             pipeline.streams.emplace_back(std::make_shared<NullBlockInputStream>(source_header));
-
-        if (storage && expressions.filter_info && expressions.prewhere_info)
-            throw Exception("PREWHERE is not supported if the table is filtered by row-level security expression", ErrorCodes::ILLEGAL_PREWHERE);
 
         if (expressions.prewhere_info)
         {

--- a/dbms/tests/queries/0_stateless/00597_push_down_predicate.reference
+++ b/dbms/tests/queries/0_stateless/00597_push_down_predicate.reference
@@ -11,15 +11,15 @@ SELECT \n    a, \n    b\nFROM \n(\n    SELECT \n        1 AS a, \n        1 AS b
 SELECT \n    a, \n    b\nFROM \n(\n    SELECT 1 AS a\n)\nANY FULL OUTER JOIN \n(\n    SELECT \n        1 AS a, \n        1 AS b\n) USING (a)\nWHERE b = 0
 SELECT \n    a, \n    b\nFROM \n(\n    SELECT \n        1 AS a, \n        1 AS b\n)\nANY FULL OUTER JOIN \n(\n    SELECT 1 AS a\n) USING (a)\nWHERE b = 0
 -------Need push down-------
-SELECT toString(value) AS value\nFROM \n(\n    SELECT 1 AS value\n    WHERE 1\n)\nWHERE 1
+SELECT toString(value) AS value\nFROM \n(\n    SELECT 1 AS value\n)
 1
-SELECT id\nFROM \n(\n    SELECT 1 AS id\n    WHERE 1\n    UNION ALL\n    SELECT 2 AS `2`\n    WHERE 0\n)\nWHERE id = 1
-1
-SELECT id\nFROM \n(\n    SELECT arrayJoin([1, 2, 3]) AS id\n    WHERE id = 1\n)\nWHERE id = 1
+SELECT id\nFROM \n(\n    SELECT 1 AS id\n    UNION ALL\n    SELECT 2 AS `2`\n    WHERE 0\n)\nWHERE id = 1
 1
 SELECT id\nFROM \n(\n    SELECT arrayJoin([1, 2, 3]) AS id\n    WHERE id = 1\n)\nWHERE id = 1
 1
-SELECT \n    id, \n    subquery\nFROM \n(\n    SELECT \n        1 AS id, \n        CAST(1, \'UInt8\') AS subquery\n    WHERE 1\n)\nWHERE 1
+SELECT id\nFROM \n(\n    SELECT arrayJoin([1, 2, 3]) AS id\n    WHERE id = 1\n)\nWHERE id = 1
+1
+SELECT \n    id, \n    subquery\nFROM \n(\n    SELECT \n        1 AS id, \n        CAST(1, \'UInt8\') AS subquery\n)
 1	1
 SELECT \n    a, \n    b\nFROM \n(\n    SELECT \n        toUInt64(sum(id) AS b) AS a, \n        b\n    FROM test_00597\n    HAVING a = 3\n)\nWHERE a = 3
 3	3

--- a/dbms/tests/queries/0_stateless/01029_early_constant_folding.reference
+++ b/dbms/tests/queries/0_stateless/01029_early_constant_folding.reference
@@ -1,5 +1,5 @@
 SELECT 1\nWHERE 0
-SELECT 1\nWHERE 1
+SELECT 1
 SELECT 1\nWHERE 0
 SELECT 1\nWHERE 1 IN (\n(\n    SELECT arrayJoin([1, 2, 3])\n) AS subquery)
 SELECT 1\nWHERE NOT ignore()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

Short description (up to few sentences):
Get rid of (pre)where statement when always true instead of using ASTLiteral(1). This help remove useless steps in the query pipelines. e.g  select count() from large_merge_tree_table where 1;
