### PR TITLE
Check column for __getScalar() (avoids assertion)

### DIFF
--- a/dbms/src/Functions/getScalar.cpp
+++ b/dbms/src/Functions/getScalar.cpp
@@ -42,7 +42,7 @@ public:
 
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
     {
-        if (arguments.size() != 1 || !isString(arguments[0].type) || !isColumnConst(*arguments[0].column))
+        if (arguments.size() != 1 || !isString(arguments[0].type) || !arguments[0].column || !isColumnConst(*arguments[0].column))
             throw Exception("Function " + getName() + " accepts one const string argument", ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
         auto scalar_name = assert_cast<const ColumnConst &>(*arguments[0].column).getField().get<String>();
         scalar = context.getScalar(scalar_name).getByPosition(0);

--- a/dbms/tests/queries/0_stateless/01024__getScalar.sql
+++ b/dbms/tests/queries/0_stateless/01024__getScalar.sql
@@ -1,0 +1,1 @@
+CREATE TABLE foo (key String, macro String MATERIALIZED __getScalar(key)) Engine=Null(); -- { serverError 43 }


### PR DESCRIPTION
Category (leave one):
-non-significant

Can be triggered using the following query:

      CREATE TABLE foo (key String, macro String MATERIALIZED __getScalar(key)) Engine=Null();

Trace:
```
    3. 0x00007ffff6d5d526 __assert_fail (libc.so.6)
    4. 0x00007ffff41fd931 boost::intrusive_ptr<DB::IColumn const>::operator*() const (libclickhouse_functionsd.so)
    5. 0x00007ffff41fcd64 COW<DB::IColumn>::IntrusivePtr<DB::IColumn const>::operator*() const & (libclickhouse_functionsd.so)
    6. 0x00007ffff4dc5944 DB::FunctionGetScalar::getReturnTypeImpl() const (libclickhouse_functionsd.so)
```

*(Even though it is internal I guess it is better to fix it)*

Refs: #7392
Cc: @amosbird
