### PR TITLE
Better Null format for tcp handler.

### DIFF
--- a/dbms/programs/server/TCPHandler.cpp
+++ b/dbms/programs/server/TCPHandler.cpp
@@ -530,7 +530,8 @@ void TCPHandler::processOrdinaryQuery()
                 sendLogs();
             }
 
-            sendData(block);
+            if (!block || !state.io.null_format)
+                sendData(block);
             if (!block)
                 break;
         }

--- a/dbms/src/DataStreams/BlockIO.h
+++ b/dbms/src/DataStreams/BlockIO.h
@@ -33,6 +33,9 @@ struct BlockIO
     std::function<void(IBlockInputStream *, IBlockOutputStream *)>    finish_callback;
     std::function<void()>                                             exception_callback;
 
+    /// When it is true, don't bother sending any non-empty blocks to the out stream
+    bool null_format = false;
+
     /// Call these functions if you want to log the request.
     void onFinish()
     {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement


Short description (up to few sentences):

so that we can use `select ignore(<expression>) from table format Null` for perf measure via clickhouse-client