### PR TITLE
Now concat always return string column

### DIFF
--- a/dbms/src/Functions/concat.cpp
+++ b/dbms/src/Functions/concat.cpp
@@ -214,7 +214,8 @@ protected:
                     + ", should be at least 2.",
                 ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
 
-        return getLeastSupertype(arguments);
+        /// We always return Strings from concat, even if arguments were fixed strings.
+        return std::make_shared<DataTypeString>();
     }
 
 private:

--- a/dbms/tests/queries/0_stateless/01030_concatenate_equal_fixed_strings.reference
+++ b/dbms/tests/queries/0_stateless/01030_concatenate_equal_fixed_strings.reference
@@ -1,0 +1,3 @@
+aa	aaaa
+aa	4
+aa	String

--- a/dbms/tests/queries/0_stateless/01030_concatenate_equal_fixed_strings.sql
+++ b/dbms/tests/queries/0_stateless/01030_concatenate_equal_fixed_strings.sql
@@ -1,0 +1,3 @@
+SELECT toFixedString('aa' , 2 ) as a, concat(a, a);
+SELECT toFixedString('aa' , 2 ) as a, length(concat(a, a));
+SELECT toFixedString('aa' , 2 ) as a, toTypeName(concat(a, a));


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Fix bug in `concat` function when all arguments were `FixedString` of the same size.
