### PR TITLE
Fix race for totals.

### DIFF
--- a/dbms/programs/server/TCPHandler.cpp
+++ b/dbms/programs/server/TCPHandler.cpp
@@ -523,6 +523,9 @@ void TCPHandler::processOrdinaryQuery()
               */
             if (!block && !isQueryCancelled())
             {
+                /// Wait till inner thread finish to avoid possible race with getTotals.
+                async_in.waitInnerThread();
+
                 sendTotals(state.io.in->getTotals());
                 sendExtremes(state.io.in->getExtremes());
                 sendProfileInfo(state.io.in->getProfileInfo());

--- a/dbms/src/DataStreams/AsynchronousBlockInputStream.h
+++ b/dbms/src/DataStreams/AsynchronousBlockInputStream.h
@@ -33,6 +33,12 @@ public:
 
     String getName() const override { return "Asynchronous"; }
 
+    void waitInnerThread()
+    {
+        if (started)
+            pool.wait();
+    }
+
     void readPrefix() override
     {
         /// Do not call `readPrefix` on the child, so that the corresponding actions are performed in a separate thread.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (up to few sentences, not needed for non-significant PRs):
Fix possible race while calculating totals.

Detailed description (optional):
Wait for `AsynchronousBlockInputStream` inner thread before getting totals to avoid possible race.