### PR TITLE
Hotfix for race in JOIN has/setTotals()

### DIFF
--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -1013,6 +1013,7 @@ void Join::joinBlock(Block & block)
 
 void Join::joinTotals(Block & block) const
 {
+    std::shared_lock lock(rwlock);
     JoinCommon::joinTotals(totals, sample_block_with_columns_to_add, key_names_right, block);
 }
 

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -144,10 +144,18 @@ public:
     /// Used by joinGet function that turns StorageJoin into a dictionary
     void joinGet(Block & block, const String & column_name) const;
 
-    /** Keep "totals" (separate part of dataset, see WITH TOTALS) to use later.
-      */
-    void setTotals(const Block & block) override { totals = block; }
-    bool hasTotals() const override { return totals; }
+    /// Keep "totals" (separate part of dataset, see WITH TOTALS) to use later.
+    void setTotals(const Block & block) override
+    {
+        std::unique_lock lock(rwlock);
+        totals = block;
+    }
+
+    bool hasTotals() const override
+    {
+        std::shared_lock lock(rwlock);
+        return totals;
+    }
 
     void joinTotals(Block & block) const override;
 

--- a/dbms/src/Interpreters/MergeJoin.cpp
+++ b/dbms/src/Interpreters/MergeJoin.cpp
@@ -468,12 +468,20 @@ MergeJoin::MergeJoin(std::shared_ptr<AnalyzedJoin> table_join_, const Block & ri
 
 void MergeJoin::setTotals(const Block & totals_block)
 {
+    std::unique_lock lock(rwlock);
     totals = totals_block;
     mergeRightBlocks();
 }
 
+bool MergeJoin::hasTotals() const
+{
+    std::shared_lock lock(rwlock);
+    return totals;
+}
+
 void MergeJoin::joinTotals(Block & block) const
 {
+    std::shared_lock lock(rwlock);
     JoinCommon::joinTotals(totals, right_columns_to_add, table_join->keyNamesRight(), block);
 }
 

--- a/dbms/src/Interpreters/MergeJoin.h
+++ b/dbms/src/Interpreters/MergeJoin.h
@@ -51,7 +51,7 @@ public:
     void joinBlock(Block &) override;
     void joinTotals(Block &) const override;
     void setTotals(const Block &) override;
-    bool hasTotals() const override { return totals; }
+    bool hasTotals() const override;
     size_t getTotalRowCount() const override { return right_blocks_row_count; }
 
 private:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (up to few sentences, not needed for non-significant PRs):
Fix race in queries WITH TOTALS
