### PR TITLE
Allow table identifier as the first arg to joinGet

### DIFF
--- a/dbms/src/Interpreters/ActionsVisitor.cpp
+++ b/dbms/src/Interpreters/ActionsVisitor.cpp
@@ -9,6 +9,7 @@
 #include <DataTypes/DataTypeSet.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeFunction.h>
+#include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/FieldToDataType.h>
@@ -37,6 +38,7 @@
 #include <Interpreters/convertFieldToType.h>
 #include <Interpreters/interpretSubquery.h>
 #include <Interpreters/DatabaseAndTableWithAlias.h>
+#include <Interpreters/IdentifierSemantic.h>
 
 namespace DB
 {
@@ -392,6 +394,7 @@ void ActionsMatcher::visit(const ASTFunction & node, const ASTPtr & ast, Data & 
         auto child_column_name = child->getColumnName();
 
         const auto * lambda = child->as<ASTFunction>();
+        const auto * identifier = child->as<ASTIdentifier>();
         if (lambda && lambda->name == "lambda")
         {
             /// If the argument is a lambda expression, just remember its approximate type.
@@ -432,6 +435,23 @@ void ActionsMatcher::visit(const ASTFunction & node, const ASTPtr & ast, Data & 
                 data.addAction(ExpressionAction::addColumn(column));
             }
 
+            argument_types.push_back(column.type);
+            argument_names.push_back(column.name);
+        }
+        else if (identifier && node.name == "joinGet" && arg == 0)
+        {
+            String database_name;
+            String table_name;
+            std::tie(database_name, table_name) = IdentifierSemantic::extractDatabaseAndTable(*identifier);
+            if (database_name.empty())
+                database_name = data.context.getCurrentDatabase();
+            auto column_string = ColumnString::create();
+            column_string->insert(database_name + "." + table_name);
+            ColumnWithTypeAndName column(
+                ColumnConst::create(std::move(column_string), 1),
+                std::make_shared<DataTypeString>(),
+                getUniqueName(data.getSampleBlock(), "__joinGet"));
+            data.addAction(ExpressionAction::addColumn(column));
             argument_types.push_back(column.type);
             argument_names.push_back(column.name);
         }

--- a/dbms/src/Interpreters/MarkTableIdentifiersVisitor.cpp
+++ b/dbms/src/Interpreters/MarkTableIdentifiersVisitor.cpp
@@ -42,6 +42,14 @@ void MarkTableIdentifiersMatcher::visit(const ASTFunction & func, ASTPtr &, Data
             if (!data.aliases.count(*opt_name))
                 setIdentifierSpecial(ast);
     }
+
+    // first argument of joinGet can be a table identifier
+    if (func.name == "joinGet")
+    {
+        auto & ast = func.arguments->children.at(0);
+        if (auto opt_name = tryGetIdentifierName(ast))
+            setIdentifierSpecial(ast);
+    }
 }
 
 }

--- a/dbms/tests/queries/0_stateless/00800_versatile_storage_join.reference
+++ b/dbms/tests/queries/0_stateless/00800_versatile_storage_join.reference
@@ -16,6 +16,14 @@ def
 abc
 def
 
+
+abc
+def
+
+\N
+abc
+def
+
 [0]	1
 0
 0

--- a/dbms/tests/queries/0_stateless/00800_versatile_storage_join.sql
+++ b/dbms/tests/queries/0_stateless/00800_versatile_storage_join.sql
@@ -37,6 +37,13 @@ SELECT '';
 SELECT joinGet('join_any_left_null', 's', number) FROM numbers(3);
 SELECT '';
 
+-- Using identifier as the first argument
+
+SELECT joinGet(join_any_left, 's', number) FROM numbers(3);
+SELECT '';
+SELECT joinGet(test.join_any_left_null, 's', number) FROM numbers(3);
+SELECT '';
+
 CREATE TABLE test.join_string_key (s String, x Array(UInt8), k UInt64) ENGINE = Join(ANY, LEFT, s);
 INSERT INTO test.join_string_key VALUES ('abc', [0], 1), ('def', [1, 2], 2);
 SELECT joinGet('join_string_key', 'x', 'abc'), joinGet('join_string_key', 'k', 'abc');


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (up to few sentences, not needed for non-significant PRs):

mutations might use joinGet without specifying default db. However if the argument isn't treated as special, it won't get currentdb appended thus breaks the background mutation job. Before this pr, we have to specify the database name explicitly, now we can use table identifier, https://github.com/ClickHouse/ClickHouse/issues/7699  

Note: doc might needs update
