### PR TITLE
[docs] Replace unmaintainable Ruby client by a newer one

### DIFF
--- a/docs/en/interfaces/third-party/client_libraries.md
+++ b/docs/en/interfaces/third-party/client_libraries.md
@@ -27,7 +27,7 @@
     - [HTTP-ClickHouse](https://metacpan.org/release/HTTP-ClickHouse)
     - [AnyEvent-ClickHouse](https://metacpan.org/release/AnyEvent-ClickHouse)
 - Ruby
-    - [clickhouse (Ruby)](https://github.com/archan937/clickhouse)
+    - [ClickHouse (Ruby)](https://github.com/shlima/click_house)
 - R
     - [clickhouse-r](https://github.com/hannesmuehleisen/clickhouse-r)
     - [RClickhouse](https://github.com/IMSMWU/RClickhouse)

--- a/docs/fa/interfaces/third-party/client_libraries.md
+++ b/docs/fa/interfaces/third-party/client_libraries.md
@@ -27,7 +27,7 @@
     - [HTTP-ClickHouse](https://metacpan.org/release/HTTP-ClickHouse)
     - [AnyEvent-ClickHouse](https://metacpan.org/release/AnyEvent-ClickHouse)
 - Ruby
-    - [clickhouse (Ruby)](https://github.com/archan937/clickhouse)
+    - [ClickHouse (Ruby)](https://github.com/shlima/click_house)
 - R
     - [clickhouse-r](https://github.com/hannesmuehleisen/clickhouse-r)
     - [RClickhouse](https://github.com/IMSMWU/RClickhouse)

--- a/docs/ru/interfaces/third-party/client_libraries.md
+++ b/docs/ru/interfaces/third-party/client_libraries.md
@@ -26,7 +26,7 @@
     - [HTTP-ClickHouse](https://metacpan.org/release/HTTP-ClickHouse)
     - [AnyEvent-ClickHouse](https://metacpan.org/release/AnyEvent-ClickHouse)
 - Ruby
-    - [clickhouse (Ruby)](https://github.com/archan937/clickhouse)
+    - [ClickHouse (Ruby)](https://github.com/shlima/click_house)
 - R
     - [clickhouse-r](https://github.com/hannesmuehleisen/clickhouse-r)
     - [RClickhouse](https://github.com/IMSMWU/RClickhouse)

--- a/docs/zh/interfaces/third-party/client_libraries.md
+++ b/docs/zh/interfaces/third-party/client_libraries.md
@@ -26,7 +26,7 @@
     - [HTTP-ClickHouse](https://metacpan.org/release/HTTP-ClickHouse)
     - [AnyEvent-ClickHouse](https://metacpan.org/release/AnyEvent-ClickHouse)
 - Ruby
-    - [clickhouse (Ruby)](https://github.com/archan937/clickhouse)
+    - [ClickHouse (Ruby)](https://github.com/shlima/click_house)
 - R
     - [clickhouse-r](https://github.com/hannesmuehleisen/clickhouse-r)
     - [RClickhouse](https://github.com/IMSMWU/RClickhouse)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation

Original Ruby client was not maintained for more than 3 years and not working with up to date ClickHouse server version.

Brand [new client](https://github.com/shlima/click_house) was inspired by an [older one](https://github.com/archan937/clickhouse), has compatible interface and works with modern ClickHouse server.

This will make it easier to get started with ClickHouse for Ruby developers.