### PR TITLE
const modulo optimization

### DIFF
--- a/dbms/src/Functions/modulo.cpp
+++ b/dbms/src/Functions/modulo.cpp
@@ -61,8 +61,20 @@ struct ModuloByConstantImpl
 
         /// Here we failed to make the SSE variant from libdivide give an advantage.
         size_t size = a.size();
-        for (size_t i = 0; i < size; ++i)
-            c[i] = a[i] - (a[i] / divider) * b; /// NOTE: perhaps, the division semantics with the remainder of negative numbers is not preserved.
+
+        /// strict aliasing optimization for char like arrays
+        auto * __restrict src = a.data();
+        auto * __restrict dst = c.data();
+        if (b & (b - 1))
+            for (size_t i = 0; i < size; ++i)
+                dst[i] = src[i] - (src[i] / divider) * b; /// NOTE: perhaps, the division semantics with the remainder of negative numbers is not preserved.
+        else
+        {
+            // gcc libdivide doesn't work well for pow2 division
+            auto mask = b - 1;
+            for (size_t i = 0; i < size; ++i)
+                dst[i] = src[i] & mask;
+        }
     }
 };
 

--- a/dbms/src/Functions/modulo.cpp
+++ b/dbms/src/Functions/modulo.cpp
@@ -65,9 +65,12 @@ struct ModuloByConstantImpl
         /// strict aliasing optimization for char like arrays
         auto * __restrict src = a.data();
         auto * __restrict dst = c.data();
+        
         if (b & (b - 1))
+        {
             for (size_t i = 0; i < size; ++i)
                 dst[i] = src[i] - (src[i] / divider) * b; /// NOTE: perhaps, the division semantics with the remainder of negative numbers is not preserved.
+        }
         else
         {
             // gcc libdivide doesn't work well for pow2 division

--- a/dbms/tests/performance/modulo.xml
+++ b/dbms/tests/performance/modulo.xml
@@ -1,0 +1,17 @@
+<test>
+    <type>loop</type>
+
+    <stop_conditions>
+        <any_of>
+            <iterations>10</iterations>
+        </any_of>
+    </stop_conditions>
+
+    <main_metric>
+        <min_time />
+    </main_metric>
+
+    <query>SELECT number % 128 FROM numbers(300000000) FORMAT Null</query>
+    <query>SELECT number % 255 FROM numbers(300000000) FORMAT Null</query>
+    <query>SELECT number % 256 FROM numbers(300000000) FORMAT Null</query>
+</test>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Performance Improvement

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):

gcc generates suboptimal instructions when dealing with `select ... group by  column % 128`

This pr optimizes such case with **60%** improvement

```
query:  select number % 128 from numbers(900000000) format Null

Queries executed: 46.

localhost:9000, queries 26, QPS: 1.126, RPS: 1013319832.170, MiB/s: 7731.017, result RPS: 1013313202.850, result MiB/s: 966.371.
localhost:9001, queries 20, QPS: 0.715, RPS: 643897829.228, MiB/s: 4912.551, result RPS: 643893616.733, result MiB/s: 614.065.

0.000%          0.813 sec.      1.329 sec.
10.000%         0.826 sec.      1.345 sec.
20.000%         0.833 sec.      1.358 sec.
30.000%         0.843 sec.      1.374 sec.
40.000%         0.846 sec.      1.385 sec.
50.000%         0.875 sec.      1.399 sec.
60.000%         0.888 sec.      1.413 sec.
70.000%         0.939 sec.      1.423 sec.
80.000%         0.943 sec.      1.430 sec.
90.000%         0.965 sec.      1.446 sec.
95.000%         0.969 sec.      1.469 sec.
99.000%         1.004 sec.      1.471 sec.
99.900%         1.015 sec.      1.471 sec.
99.990%         1.016 sec.      1.471 sec.

Difference at 99.5% confidence : mean difference is 0.50957088, but confidence interval is 0.05163741
```
