### PR TITLE
Update max_table_size_to_drop and max_partition_size_to_drop with config reload

### DIFF
--- a/dbms/programs/server/Server.cpp
+++ b/dbms/programs/server/Server.cpp
@@ -438,6 +438,13 @@ int Server::main(const std::vector<std::string> & /*args*/)
             buildLoggers(*config, logger());
             global_context->setClustersConfig(config);
             global_context->setMacros(std::make_unique<Macros>(*config, "macros"));
+
+            /// Setup protection to avoid accidental DROP for big tables (that are greater than 50 GB by default)
+            if (config->has("max_table_size_to_drop"))
+                global_context->setMaxTableSizeToDrop(config->getUInt64("max_table_size_to_drop"));
+
+            if (config->has("max_partition_size_to_drop"))
+                global_context->setMaxPartitionSizeToDrop(config->getUInt64("max_partition_size_to_drop"));
         },
         /* already_loaded = */ true);
 
@@ -468,13 +475,6 @@ int Server::main(const std::vector<std::string> & /*args*/)
 
     /// Limit on total number of concurrently executed queries.
     global_context->getProcessList().setMaxSize(config().getInt("max_concurrent_queries", 0));
-
-    /// Setup protection to avoid accidental DROP for big tables (that are greater than 50 GB by default)
-    if (config().has("max_table_size_to_drop"))
-        global_context->setMaxTableSizeToDrop(config().getUInt64("max_table_size_to_drop"));
-
-    if (config().has("max_partition_size_to_drop"))
-        global_context->setMaxPartitionSizeToDrop(config().getUInt64("max_partition_size_to_drop"));
 
     /// Set up caches.
 

--- a/dbms/programs/server/config.xml
+++ b/dbms/programs/server/config.xml
@@ -411,7 +411,7 @@
 
     <!-- Protection from accidental DROP.
          If size of a MergeTree table is greater than max_table_size_to_drop (in bytes) than table could not be dropped with any DROP query.
-         If you want do delete one table and don't want to restart clickhouse-server, you could create special file <clickhouse-path>/flags/force_drop_table and make DROP once.
+         If you want do delete one table and don't want to change clickhouse-server config, you could create special file <clickhouse-path>/flags/force_drop_table and make DROP once.
          By default max_table_size_to_drop is 50GB; max_table_size_to_drop=0 allows to DROP any tables.
          The same for max_partition_size_to_drop.
          Uncomment to disable protection.

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -1891,7 +1891,7 @@ void Context::checkCanBeDropped(const String & database, const String & table, c
 
 void Context::setMaxTableSizeToDrop(size_t max_size)
 {
-    // Is initialized at server startup
+    // Is initialized at server startup and updated at config reload
     shared->max_table_size_to_drop.store(max_size, std::memory_order_relaxed);
 }
 
@@ -1906,7 +1906,7 @@ void Context::checkTableCanBeDropped(const String & database, const String & tab
 
 void Context::setMaxPartitionSizeToDrop(size_t max_size)
 {
-    // Is initialized at server startup
+    // Is initialized at server startup and updated at config reload
     shared->max_partition_size_to_drop.store(max_size, std::memory_order_relaxed);
 }
 

--- a/dbms/tests/integration/test_reload_max_table_size_to_drop/configs/config.xml
+++ b/dbms/tests/integration/test_reload_max_table_size_to_drop/configs/config.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<yandex>
+    <logger>
+        <level>trace</level>
+        <log>/var/log/clickhouse-server/clickhouse-server.log</log>
+        <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
+        <size>1000M</size>
+        <count>10</count>
+    </logger>
+
+    <tcp_port>9000</tcp_port>
+    <listen_host>127.0.0.1</listen_host>
+
+    <openSSL>
+        <client>
+            <cacheSessions>true</cacheSessions>
+            <verificationMode>none</verificationMode>
+            <invalidCertificateHandler>
+                <name>AcceptCertificateHandler</name>
+            </invalidCertificateHandler>
+        </client>
+    </openSSL>
+
+    <max_concurrent_queries>500</max_concurrent_queries>
+    <mark_cache_size>5368709120</mark_cache_size>
+    <path>./clickhouse/</path>
+    <users_config>users.xml</users_config>
+
+    <max_table_size_to_drop>1</max_table_size_to_drop>
+    <max_partition_size_to_drop>1</max_partition_size_to_drop>
+</yandex>

--- a/dbms/tests/integration/test_reload_max_table_size_to_drop/configs/users.xml
+++ b/dbms/tests/integration/test_reload_max_table_size_to_drop/configs/users.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<yandex>
+    <profiles>
+        <default>
+        </default>
+    </profiles>
+
+    <users>
+        <default>
+            <password></password>
+            <networks incl="networks" replace="replace">
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </default>
+    </users>
+
+    <quotas>
+        <default>
+        </default>
+    </quotas>
+</yandex>

--- a/dbms/tests/integration/test_reload_max_table_size_to_drop/test.py
+++ b/dbms/tests/integration/test_reload_max_table_size_to_drop/test.py
@@ -41,7 +41,7 @@ def test_reload_max_table_size_to_drop(start_cluster):
     config.writelines(config_lines)
     config.close()
 
-    time.sleep(5)  # wait for config reload
+    node.query("SYSTEM RELOAD CONFIG")
 
     drop = node.get_query_request("DROP TABLE test")
     out, err = drop.get_answer_and_error()

--- a/dbms/tests/integration/test_reload_max_table_size_to_drop/test.py
+++ b/dbms/tests/integration/test_reload_max_table_size_to_drop/test.py
@@ -1,0 +1,55 @@
+import time
+import pytest
+import sys
+import os
+
+from helpers.cluster import ClickHouseCluster
+
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance('node', config_dir="configs")
+
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+config_dir = os.path.join(SCRIPT_DIR, './_instances/node/configs')
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        node.query("CREATE DATABASE chtest;")
+        node.query(
+            '''
+            CREATE TABLE chtest.reload_max_table_size (date Date, id UInt32) 
+            ENGINE = MergeTree(date, id, 8192)
+            '''
+        )
+        node.query("INSERT INTO chtest.reload_max_table_size VALUES (now(), 0)")
+        yield cluster
+    finally:
+        #cluster.shutdown()
+        pass
+
+
+def test_reload_max_table_size_to_drop(start_cluster):
+    config = open(config_dir + '/config.xml', 'r')
+    config_lines = config.readlines()
+    config.close()
+
+    error = node.get_query_request("DROP TABLE chtest.reload_max_table_size") # change to query_and_get_error after fix
+    print >> sys.stderr, 'error: ' + error.get_answer()
+    print >> sys.stderr, 'path: ' + config_dir
+    print >> sys.stderr, 'config: '
+    for line in config_lines:
+        print >> sys.stderr, line
+
+    assert error != "" # Crashes due to illigal config
+
+    config_lines = map(lambda line: line.replace("<max_table_size_to_drop>1", "<max_table_size_to_drop>1000000"),
+                       config_lines)
+    config = open(config_dir + '/config.xml', 'w')
+    config.writelines(config_lines)
+
+    time.sleep(50000)
+    error = node.query_and_get_error("DROP TABLE chtest.reload_max_table_size")
+    assert error == ""

--- a/dbms/tests/integration/test_reload_max_table_size_to_drop/test.py
+++ b/dbms/tests/integration/test_reload_max_table_size_to_drop/test.py
@@ -16,7 +16,7 @@ CONFIG_PATH = os.path.join(SCRIPT_DIR, './_instances/node/configs/config.xml')
 def start_cluster():
     try:
         cluster.start()
-        node.query("CREATE TABLE test(date Date, id UInt32) ENGINE = MergeTree(date, id, 8192)")
+        node.query("CREATE TABLE test(date Date, id UInt32) ENGINE = MergeTree() PARTITION BY date ORDER BY id")
         yield cluster
     finally:
         cluster.shutdown()

--- a/dbms/tests/integration/test_reload_max_table_size_to_drop/test.py
+++ b/dbms/tests/integration/test_reload_max_table_size_to_drop/test.py
@@ -1,6 +1,5 @@
 import time
 import pytest
-import sys
 import os
 
 from helpers.cluster import ClickHouseCluster
@@ -10,46 +9,41 @@ cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance('node', config_dir="configs")
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
-config_dir = os.path.join(SCRIPT_DIR, './_instances/node/configs')
+CONFIG_PATH = os.path.join(SCRIPT_DIR, './_instances/node/configs/config.xml')
 
 
 @pytest.fixture(scope="module")
 def start_cluster():
     try:
         cluster.start()
-        node.query("CREATE DATABASE chtest;")
-        node.query(
-            '''
-            CREATE TABLE chtest.reload_max_table_size (date Date, id UInt32) 
-            ENGINE = MergeTree(date, id, 8192)
-            '''
-        )
-        node.query("INSERT INTO chtest.reload_max_table_size VALUES (now(), 0)")
+        node.query("CREATE TABLE test(date Date, id UInt32) ENGINE = MergeTree(date, id, 8192)")
         yield cluster
     finally:
-        #cluster.shutdown()
-        pass
+        cluster.shutdown()
 
 
 def test_reload_max_table_size_to_drop(start_cluster):
-    config = open(config_dir + '/config.xml', 'r')
+    node.query("INSERT INTO test VALUES (now(), 0)")
+
+    time.sleep(5)  # wait for data part commit
+
+    drop = node.get_query_request("DROP TABLE test")
+    out, err = drop.get_answer_and_error()
+    assert out == ""
+    assert err != ""
+
+    config = open(CONFIG_PATH, 'r')
     config_lines = config.readlines()
     config.close()
-
-    error = node.get_query_request("DROP TABLE chtest.reload_max_table_size") # change to query_and_get_error after fix
-    print >> sys.stderr, 'error: ' + error.get_answer()
-    print >> sys.stderr, 'path: ' + config_dir
-    print >> sys.stderr, 'config: '
-    for line in config_lines:
-        print >> sys.stderr, line
-
-    assert error != "" # Crashes due to illigal config
-
     config_lines = map(lambda line: line.replace("<max_table_size_to_drop>1", "<max_table_size_to_drop>1000000"),
                        config_lines)
-    config = open(config_dir + '/config.xml', 'w')
+    config = open(CONFIG_PATH, 'w')
     config.writelines(config_lines)
+    config.close()
 
-    time.sleep(50000)
-    error = node.query_and_get_error("DROP TABLE chtest.reload_max_table_size")
-    assert error == ""
+    time.sleep(5)  # wait for config reload
+
+    drop = node.get_query_request("DROP TABLE test")
+    out, err = drop.get_answer_and_error()
+    assert out == ""
+    assert err == ""


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):

Move setMax(Table|Partition)SizeToDrop call into config updater to change these settings without a restart.