### PR TITLE
String optimized IN operator

### DIFF
--- a/dbms/src/Common/HashTable/ClearableFixedHashMap.h
+++ b/dbms/src/Common/HashTable/ClearableFixedHashMap.h
@@ -5,7 +5,7 @@
 
 
 template <typename Key, typename TMapped>
-struct FixedClearableHashMapCell
+struct ClearableFixedHashMapCell
 {
     using Mapped = TMapped;
     using State = ClearableHashSetState;
@@ -16,9 +16,9 @@ struct FixedClearableHashMapCell
     UInt32 version;
     Mapped mapped;
 
-    FixedClearableHashMapCell() {}
-    FixedClearableHashMapCell(const Key &, const State & state) : version(state.version) {}
-    FixedClearableHashMapCell(const value_type & value_, const State & state) : version(state.version), mapped(value_.second) {}
+    ClearableFixedHashMapCell() {}
+    ClearableFixedHashMapCell(const Key &, const State & state) : version(state.version) {}
+    ClearableFixedHashMapCell(const value_type & value_, const State & state) : version(state.version), mapped(value_.second) {}
 
     const VoidKey getKey() const { return {}; }
     Mapped & getMapped() { return mapped; }
@@ -30,14 +30,14 @@ struct FixedClearableHashMapCell
     struct CellExt
     {
         CellExt() {}
-        CellExt(Key && key_, FixedClearableHashMapCell * ptr_) : key(key_), ptr(ptr_) {}
-        void update(Key && key_, FixedClearableHashMapCell * ptr_)
+        CellExt(Key && key_, ClearableFixedHashMapCell * ptr_) : key(key_), ptr(ptr_) {}
+        void update(Key && key_, ClearableFixedHashMapCell * ptr_)
         {
             key = key_;
             ptr = ptr_;
         }
         Key key;
-        FixedClearableHashMapCell * ptr;
+        ClearableFixedHashMapCell * ptr;
         const Key & getKey() const { return key; }
         Mapped & getMapped() { return ptr->mapped; }
         const Mapped & getMapped() const { return *ptr->mapped; }
@@ -47,11 +47,11 @@ struct FixedClearableHashMapCell
 
 
 template <typename Key, typename Mapped, typename Allocator = HashTableAllocator>
-class FixedClearableHashMap : public FixedHashMap<Key, Mapped, FixedClearableHashMapCell<Key, Mapped>, Allocator>
+class ClearableFixedHashMap : public FixedHashMap<Key, Mapped, ClearableFixedHashMapCell<Key, Mapped>, Allocator>
 {
 public:
-    using Base = FixedHashMap<Key, Mapped, FixedClearableHashMapCell<Key, Mapped>, Allocator>;
-    using Self = FixedClearableHashMap;
+    using Base = FixedHashMap<Key, Mapped, ClearableFixedHashMapCell<Key, Mapped>, Allocator>;
+    using Self = ClearableFixedHashMap;
     using LookupResult = typename Base::LookupResult;
 
     using Base::Base;

--- a/dbms/src/Common/HashTable/ClearableFixedHashSet.h
+++ b/dbms/src/Common/HashTable/ClearableFixedHashSet.h
@@ -5,7 +5,7 @@
 
 
 template <typename Key>
-struct FixedClearableHashTableCell
+struct ClearableFixedHashTableCell
 {
     using State = ClearableHashSetState;
 
@@ -13,11 +13,11 @@ struct FixedClearableHashTableCell
     using mapped_type = VoidMapped;
     UInt32 version;
 
-    FixedClearableHashTableCell() {}
-    FixedClearableHashTableCell(const Key &, const State & state) : version(state.version) {}
+    ClearableFixedHashTableCell() {}
+    ClearableFixedHashTableCell(const Key &, const State & state) : version(state.version) {}
 
     const VoidKey getKey() const { return {}; }
-    VoidMapped getMapped() const { return {}; }
+    VoidMapped & getMapped() const { return voidMapped; }
 
     bool isZero(const State & state) const { return version != state.version; }
     void setZero() { version = 0; }
@@ -26,18 +26,18 @@ struct FixedClearableHashTableCell
     {
         Key key;
         const VoidKey getKey() const { return {}; }
-        VoidMapped getMapped() const { return {}; }
+        VoidMapped & getMapped() const { return voidMapped; }
         const value_type & getValue() const { return key; }
-        void update(Key && key_, FixedClearableHashTableCell *) { key = key_; }
+        void update(Key && key_, ClearableFixedHashTableCell *) { key = key_; }
     };
 };
 
 
 template <typename Key, typename Allocator = HashTableAllocator>
-class FixedClearableHashSet : public FixedHashTable<Key, FixedClearableHashTableCell<Key>, Allocator>
+class ClearableFixedHashSet : public FixedHashTable<Key, ClearableFixedHashTableCell<Key>, Allocator>
 {
 public:
-    using Base = FixedHashTable<Key, FixedClearableHashTableCell<Key>, Allocator>;
+    using Base = FixedHashTable<Key, ClearableFixedHashTableCell<Key>, Allocator>;
     using LookupResult = typename Base::LookupResult;
 
     void clear()

--- a/dbms/src/Common/HashTable/ClearableStringHashSet.h
+++ b/dbms/src/Common/HashTable/ClearableStringHashSet.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <Common/HashTable/ClearableHashSet.h>
+#include <Common/HashTable/HashTableAllocator.h>
+#include <Common/HashTable/StringHashTable.h>
+
+template <typename Key>
+struct ClearableStringHashSetCell : public ClearableHashTableCell<Key, HashTableCell<Key, StringHashTableHash, ClearableHashSetState>>
+{
+    using Base = ClearableHashTableCell<Key, HashTableCell<Key, StringHashTableHash, ClearableHashSetState>>;
+    using value_type = typename Base::value_type;
+    using Base::Base;
+    // external
+    const StringRef getKey() const { return toStringRef(this->key); }
+    // internal
+    static const Key & getKey(const value_type & value_) { return value_; }
+};
+
+template <>
+struct ClearableStringHashSetCell<StringRef>
+    : public ClearableHashTableCell<StringRef, HashSetCellWithSavedHash<StringRef, StringHashTableHash, ClearableHashSetState>>
+{
+    using Base = ClearableHashTableCell<StringRef, HashSetCellWithSavedHash<StringRef, StringHashTableHash, ClearableHashSetState>>;
+    using value_type = typename Base::value_type;
+    using Base::Base;
+    // external
+    using Base::getKey;
+    // internal
+    static const StringRef & getKey(const value_type & value_) { return value_; }
+};
+
+template <typename Allocator>
+struct ClearableStringHashSetSubSets
+{
+    template <typename Key>
+    class ClearableHashSet
+        : public HashTable<Key, ClearableStringHashSetCell<Key>, StringHashTableHash, StringHashTableGrower<>, Allocator>
+    {
+    public:
+        using Base = HashTable<Key, ClearableStringHashSetCell<Key>, StringHashTableHash, StringHashTableGrower<>, Allocator>;
+        using typename Base::LookupResult;
+        void clear()
+        {
+            ++this->version;
+            this->m_size = 0;
+        }
+    };
+    using T0 = StringHashTableEmpty<ClearableStringHashSetCell<StringRef>>;
+    using T1 = ClearableHashSet<StringKey8>;
+    using T2 = ClearableHashSet<StringKey16>;
+    using T3 = ClearableHashSet<StringKey24>;
+    using Ts = ClearableHashSet<StringRef>;
+};
+
+template <typename Allocator = HashTableAllocator>
+class ClearableStringHashSet : public StringHashTable<ClearableStringHashSetSubSets<Allocator>>
+{
+public:
+    using Key = StringRef;
+    using Base = StringHashTable<ClearableStringHashSetSubSets<Allocator>>;
+    using Self = ClearableStringHashSet;
+    using LookupResult = typename Base::LookupResult;
+
+    using Base::Base;
+
+    void clear()
+    {
+        this->m0.clearHasZero();
+        this->m1.clear();
+        this->m2.clear();
+        this->m3.clear();
+        this->ms.clear();
+    }
+};

--- a/dbms/src/Common/HashTable/FixedHashMap.h
+++ b/dbms/src/Common/HashTable/FixedHashMap.h
@@ -83,20 +83,6 @@ public:
         }
     }
 
-    template <typename Func>
-    void forEachValue(Func && func)
-    {
-        for (auto & v : *this)
-            func(v.getKey(), v.getMapped());
-    }
-
-    template <typename Func>
-    void forEachMapped(Func && func)
-    {
-        for (auto & v : *this)
-            func(v.getMapped());
-    }
-
     Mapped & ALWAYS_INLINE operator[](const Key & x)
     {
         LookupResult it;

--- a/dbms/src/Common/HashTable/FixedHashTable.h
+++ b/dbms/src/Common/HashTable/FixedHashTable.h
@@ -15,7 +15,7 @@ struct FixedHashTableCell
     FixedHashTableCell(const Key &, const State &) : full(true) {}
 
     const VoidKey getKey() const { return {}; }
-    VoidMapped getMapped() const { return {}; }
+    VoidMapped & getMapped() const { return voidMapped; }
 
     bool isZero(const State &) const { return !full; }
     void setZero() { full = false; }
@@ -32,7 +32,7 @@ struct FixedHashTableCell
         Key key;
 
         const VoidKey getKey() const { return {}; }
-        VoidMapped getMapped() const { return {}; }
+        VoidMapped & getMapped() const { return voidMapped; }
         const value_type & getValue() const { return key; }
         void update(Key && key_, FixedHashTableCell *) { key = key_; }
     };

--- a/dbms/src/Common/HashTable/HashMap.h
+++ b/dbms/src/Common/HashTable/HashMap.h
@@ -179,22 +179,6 @@ public:
         }
     }
 
-    /// Call func(const Key &, Mapped &) for each hash map element.
-    template <typename Func>
-    void forEachValue(Func && func)
-    {
-        for (auto & v : *this)
-            func(v.getKey(), v.getMapped());
-    }
-
-    /// Call func(Mapped &) for each hash map element.
-    template <typename Func>
-    void forEachMapped(Func && func)
-    {
-        for (auto & v : *this)
-            func(v.getMapped());
-    }
-
     typename Cell::Mapped & ALWAYS_INLINE operator[](const Key & x)
     {
         LookupResult it;

--- a/dbms/src/Common/HashTable/HashTable.cpp
+++ b/dbms/src/Common/HashTable/HashTable.cpp
@@ -1,0 +1,3 @@
+#include <Common/HashTable/HashTable.h>
+
+VoidMapped voidMapped;

--- a/dbms/src/Common/HashTable/HashTable.h
+++ b/dbms/src/Common/HashTable/HashTable.h
@@ -136,7 +136,7 @@ void set(T & x) { x = 0; }
   *
   * The implementation side goes as follows:
   *
-  * for (1), LookupResult->getKey = const VoidKey, LookupResult->getMapped = VoidMapped;
+  * for (1), LookupResult->getKey = const VoidKey, LookupResult->getMapped = VoidMapped &;
   *
   * for (2), LookupResult->getKey = const VoidKey, LookupResult->getMapped = Mapped &;
   *
@@ -153,6 +153,10 @@ struct VoidMapped
         return *this;
     }
 };
+
+/// We use a global VoidMapped value so that &LookupResult->getMapped() always works and returns
+///  either a nullptr or a defined memory address.
+extern VoidMapped voidMapped;
 
 /** Compile-time interface for cell of the hash table.
   * Different cell types are used to implement different hash tables.
@@ -178,7 +182,7 @@ struct HashTableCell
 
     /// Get the key (externally).
     const Key & getKey() const { return key; }
-    VoidMapped getMapped() const { return {}; }
+    VoidMapped & getMapped() const { return voidMapped; }
     const value_type & getValue() const { return key; }
 
     /// Get the key (internally).
@@ -229,7 +233,7 @@ struct HashTableCell
   * Overloaded on the mapped type, does nothing if it's VoidMapped.
   */
 template <typename ValueType>
-void insertSetMapped(VoidMapped /* dest */, const ValueType & /* src */) {}
+void insertSetMapped(VoidMapped & /* dest */, const ValueType & /* src */) {}
 
 template <typename MappedType, typename ValueType>
 void insertSetMapped(MappedType & dest, const ValueType & src) { dest = src.second; }

--- a/dbms/src/Common/HashTable/HashTable.h
+++ b/dbms/src/Common/HashTable/HashTable.h
@@ -945,6 +945,17 @@ public:
         return const_cast<std::decay_t<decltype(*this)> *>(this)->find(x, hash_value);
     }
 
+    LookupResult ALWAYS_INLINE findNonZero(const Key & x, size_t hash_value)
+    {
+        size_t place_value = findCell(x, hash_value, grower.place(hash_value));
+        return !buf[place_value].isZero(*this) ? &buf[place_value] : nullptr;
+    }
+
+    ConstLookupResult ALWAYS_INLINE findNonZero(const Key & x, size_t hash_value) const
+    {
+        return const_cast<std::decay_t<decltype(*this)> *>(this)->findNonZero(x, hash_value);
+    }
+
     bool ALWAYS_INLINE has(const Key & x) const
     {
         if (Cell::isZero(x, *this))

--- a/dbms/src/Common/HashTable/StringHashMap.h
+++ b/dbms/src/Common/HashTable/StringHashMap.h
@@ -135,48 +135,4 @@ public:
 
         return it->getMapped();
     }
-
-    template <typename Func>
-    void ALWAYS_INLINE forEachValue(Func && func)
-    {
-        if (this->m0.size())
-        {
-            func(StringRef{}, this->m0.zeroValue()->getMapped());
-        }
-
-        for (auto & v : this->m1)
-        {
-            func(v.getKey(), v.getMapped());
-        }
-
-        for (auto & v : this->m2)
-        {
-            func(v.getKey(), v.getMapped());
-        }
-
-        for (auto & v : this->m3)
-        {
-            func(v.getKey(), v.getMapped());
-        }
-
-        for (auto & v : this->ms)
-        {
-            func(v.getKey(), v.getMapped());
-        }
-    }
-
-    template <typename Func>
-    void ALWAYS_INLINE forEachMapped(Func && func)
-    {
-        if (this->m0.size())
-            func(this->m0.zeroValue()->getMapped());
-        for (auto & v : this->m1)
-            func(v.getMapped());
-        for (auto & v : this->m2)
-            func(v.getMapped());
-        for (auto & v : this->m3)
-            func(v.getMapped());
-        for (auto & v : this->ms)
-            func(v.getMapped());
-    }
 };

--- a/dbms/src/Common/HashTable/StringHashSet.h
+++ b/dbms/src/Common/HashTable/StringHashSet.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <Common/HashTable/HashSet.h>
+#include <Common/HashTable/HashTableAllocator.h>
+#include <Common/HashTable/StringHashTable.h>
+
+template <typename Key>
+struct StringHashSetCell : public HashTableCell<Key, StringHashTableHash, HashTableNoState>
+{
+    using Base = HashTableCell<Key, StringHashTableHash, HashTableNoState>;
+    using value_type = typename Base::value_type;
+    using Base::Base;
+    static constexpr bool need_zero_value_storage = false;
+    // external
+    const StringRef getKey() const { return toStringRef(this->key); }
+    // internal
+    static const Key & getKey(const value_type & value_) { return value_; }
+};
+
+template <>
+struct StringHashSetCell<StringKey16> : public HashTableCell<StringKey16, StringHashTableHash, HashTableNoState>
+{
+    using Base = HashTableCell<StringKey16, StringHashTableHash, HashTableNoState>;
+    using value_type = typename Base::value_type;
+    using Base::Base;
+    static constexpr bool need_zero_value_storage = false;
+    bool isZero(const HashTableNoState & state) const { return isZero(this->key, state); }
+    // Assuming String does not contain zero bytes. NOTE: Cannot be used in serialized method
+    static bool isZero(const StringKey16 & key_, const HashTableNoState & /*state*/) { return key_.low == 0; }
+    void setZero() { this->key.low = 0; }
+    // external
+    const StringRef getKey() const { return toStringRef(this->key); }
+    // internal
+    static const StringKey16 & getKey(const value_type & value_) { return value_; }
+};
+
+template <>
+struct StringHashSetCell<StringKey24> : public HashTableCell<StringKey24, StringHashTableHash, HashTableNoState>
+{
+    using Base = HashTableCell<StringKey24, StringHashTableHash, HashTableNoState>;
+    using value_type = typename Base::value_type;
+    using Base::Base;
+    static constexpr bool need_zero_value_storage = false;
+    bool isZero(const HashTableNoState & state) const { return isZero(this->key, state); }
+    // Assuming String does not contain zero bytes. NOTE: Cannot be used in serialized method
+    static bool isZero(const StringKey24 & key_, const HashTableNoState & /*state*/) { return key_.a == 0; }
+    void setZero() { this->key.a = 0; }
+    // external
+    const StringRef getKey() const { return toStringRef(this->key); }
+    // internal
+    static const StringKey24 & getKey(const value_type & value_) { return value_; }
+};
+
+template <>
+struct StringHashSetCell<StringRef> : public HashSetCellWithSavedHash<StringRef, StringHashTableHash, HashTableNoState>
+{
+    using Base = HashSetCellWithSavedHash<StringRef, StringHashTableHash, HashTableNoState>;
+    using value_type = typename Base::value_type;
+    using Base::Base;
+    static constexpr bool need_zero_value_storage = false;
+    // external
+    using Base::getKey;
+    // internal
+    static const StringRef & getKey(const value_type & value_) { return value_; }
+};
+
+template <typename Allocator>
+struct StringHashSetSubSets
+{
+    using T0 = StringHashTableEmpty<StringHashSetCell<StringRef>>;
+    using T1 = HashTable<StringKey8, StringHashSetCell<StringKey8>, StringHashTableHash, StringHashTableGrower<>, Allocator>;
+    using T2 = HashTable<StringKey16, StringHashSetCell<StringKey16>, StringHashTableHash, StringHashTableGrower<>, Allocator>;
+    using T3 = HashTable<StringKey24, StringHashSetCell<StringKey24>, StringHashTableHash, StringHashTableGrower<>, Allocator>;
+    using Ts = HashTable<StringRef, StringHashSetCell<StringRef>, StringHashTableHash, StringHashTableGrower<>, Allocator>;
+};
+
+template <typename Allocator = HashTableAllocator>
+class StringHashSet : public StringHashTable<StringHashSetSubSets<Allocator>>
+{
+public:
+    using Key = StringRef;
+    using Base = StringHashTable<StringHashSetSubSets<Allocator>>;
+    using Self = StringHashSet;
+    using LookupResult = typename Base::LookupResult;
+
+    using Base::Base;
+};

--- a/dbms/src/Common/HashTable/StringHashTable.h
+++ b/dbms/src/Common/HashTable/StringHashTable.h
@@ -229,21 +229,20 @@ struct StringHashTableLookupResult
     friend bool operator!=(const std::nullptr_t &, const StringHashTableLookupResult & b) { return b.mapped_ptr; }
 };
 
-template <typename SubMaps>
-class StringHashTable : private boost::noncopyable
+template <typename SubTable>
+class StringHashTable : private boost::noncopyable, protected SubTable::Ts::cell_type::State
 {
 protected:
-    static constexpr size_t NUM_MAPS = 5;
-    // Map for storing empty string
-    using T0 = typename SubMaps::T0;
+    // Table for storing empty string
+    using T0 = typename SubTable::T0;
 
     // Short strings are stored as numbers
-    using T1 = typename SubMaps::T1;
-    using T2 = typename SubMaps::T2;
-    using T3 = typename SubMaps::T3;
+    using T1 = typename SubTable::T1;
+    using T2 = typename SubTable::T2;
+    using T3 = typename SubTable::T3;
 
     // Long strings are stored as StringRef along with saved hash
-    using Ts = typename SubMaps::Ts;
+    using Ts = typename SubTable::Ts;
     using Self = StringHashTable;
 
     template <typename, typename, size_t>

--- a/dbms/src/Common/HashTable/TwoLevelHashMap.h
+++ b/dbms/src/Common/HashTable/TwoLevelHashMap.h
@@ -21,13 +21,6 @@ public:
 
     using TwoLevelHashTable<Key, Cell, Hash, Grower, Allocator, ImplTable<Key, Cell, Hash, Grower, Allocator>>::TwoLevelHashTable;
 
-    template <typename Func>
-    void ALWAYS_INLINE forEachMapped(Func && func)
-    {
-        for (auto i = 0u; i < this->NUM_BUCKETS; ++i)
-            this->impls[i].forEachMapped(func);
-    }
-
     typename Cell::Mapped & ALWAYS_INLINE operator[](const Key & x)
     {
         LookupResult it;

--- a/dbms/src/Common/HashTable/TwoLevelHashTable.h
+++ b/dbms/src/Common/HashTable/TwoLevelHashTable.h
@@ -272,6 +272,25 @@ public:
 
     ConstLookupResult ALWAYS_INLINE find(Key x) const { return find(x, hash(x)); }
 
+    /// No positional variants for TwoLevelHashTable as it's only used for aggregations.
+
+    /// Iterate over every cell and pass non-zero cells to func.
+    ///  Func should have signature (1) void(const Key &, const Mapped &); or (2)  void(const Mapped &).
+    template <typename Func>
+    void forEachCell(Func && func) const
+    {
+        for (size_t i = 0; i < NUM_BUCKETS; ++i)
+            impls[i].forEachCell(func);
+    }
+
+    /// Iterate over every cell and pass non-zero cells to func.
+    ///  Func should have signature (1) void(const Key &, Mapped &); or (2)  void(Mapped &).
+    template <typename Func>
+    void forEachCell(Func && func)
+    {
+        for (size_t i = 0; i < NUM_BUCKETS; ++i)
+            impls[i].forEachCell(func);
+    }
 
     void write(DB::WriteBuffer & wb) const
     {

--- a/dbms/src/Common/HashTable/TwoLevelStringHashMap.h
+++ b/dbms/src/Common/HashTable/TwoLevelStringHashMap.h
@@ -14,13 +14,6 @@ public:
 
     using Base::Base;
 
-    template <typename Func>
-    void ALWAYS_INLINE forEachMapped(Func && func)
-    {
-        for (auto i = 0u; i < this->NUM_BUCKETS; ++i)
-            return this->impls[i].forEachMapped(func);
-    }
-
     TMapped & ALWAYS_INLINE operator[](const Key & x)
     {
         bool inserted;

--- a/dbms/src/Common/HashTable/TwoLevelStringHashTable.h
+++ b/dbms/src/Common/HashTable/TwoLevelStringHashTable.h
@@ -164,6 +164,27 @@ public:
         return dispatch(*this, x, typename Impl::FindCallable{});
     }
 
+
+    /// No positional variants for TwoLevelHashTable as it's only used for aggregations.
+
+    /// Iterate over every cell and pass non-zero cells to func.
+    ///  Func should have signature (1) void(const Key &, const Mapped &); or (2)  void(const Mapped &).
+    template <typename Func>
+    void forEachCell(Func && func) const
+    {
+        for (size_t i = 0; i < NUM_BUCKETS; ++i)
+            impls[i].forEachCell(func);
+    }
+
+    /// Iterate over every cell and pass non-zero cells to func.
+    ///  Func should have signature (1) void(const Key &, Mapped &); or (2)  void(Mapped &).
+    template <typename Func>
+    void forEachCell(Func && func)
+    {
+        for (size_t i = 0; i < NUM_BUCKETS; ++i)
+            impls[i].forEachCell(func);
+    }
+
     void write(DB::WriteBuffer & wb) const
     {
         for (size_t i = 0; i < NUM_BUCKETS; ++i)

--- a/dbms/src/Interpreters/Aggregator.cpp
+++ b/dbms/src/Interpreters/Aggregator.cpp
@@ -962,7 +962,7 @@ void NO_INLINE Aggregator::convertToBlockImplFinal(
         }
     }
 
-    data.forEachValue([&](const auto & key, auto & mapped)
+    data.forEachCell([&](const auto & key, auto & mapped)
     {
         method.insertKeyIntoColumns(key, key_columns, key_sizes);
 
@@ -993,7 +993,7 @@ void NO_INLINE Aggregator::convertToBlockImplNotFinal(
         }
     }
 
-    data.forEachValue([&](const auto & key, auto & mapped)
+    data.forEachCell([&](const auto & key, auto & mapped)
     {
         method.insertKeyIntoColumns(key, key_columns, key_sizes);
 
@@ -2273,7 +2273,7 @@ std::vector<Block> Aggregator::convertBlockToTwoLevel(const Block & block)
 template <typename Method, typename Table>
 void NO_INLINE Aggregator::destroyImpl(Table & table) const
 {
-    table.forEachMapped([&](AggregateDataPtr & data)
+    table.forEachCell([&](AggregateDataPtr & data)
     {
         /** If an exception (usually a lack of memory, the MemoryTracker throws) arose
           *  after inserting the key into a hash table, but before creating all states of aggregate functions,

--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -1256,30 +1256,27 @@ private:
     size_t fillColumns(const Map & map, MutableColumns & columns_keys_and_right)
     {
         using Mapped = typename Map::mapped_type;
-        using Iterator = typename Map::const_iterator;
 
         size_t rows_added = 0;
 
+        using Pos = typename Map::ConstPosition;
         if (!position.has_value())
-            position = std::make_any<Iterator>(map.begin());
+            position = std::make_any<Pos>(map.startPos());
 
-        Iterator & it = std::any_cast<Iterator &>(position);
-        auto end = map.end();
+        Pos & pos = std::any_cast<Pos &>(position);
 
-        for (; it != end; ++it)
+        map.forEachCell([&](const auto & mapped)
         {
-            const Mapped & mapped = it->getMapped();
             if (mapped.getUsed())
-                continue;
+                return false;
 
             AdderNonJoined<STRICTNESS, Mapped>::add(mapped, rows_added, columns_keys_and_right);
 
             if (rows_added >= max_block_size)
-            {
-                ++it;
-                break;
-            }
-        }
+                return true;
+
+            return false;
+        }, pos);
 
         return rows_added;
     }

--- a/dbms/src/Interpreters/Join.h
+++ b/dbms/src/Interpreters/Join.h
@@ -15,6 +15,7 @@
 #include <Common/ColumnsHashing.h>
 #include <Common/HashTable/HashMap.h>
 #include <Common/HashTable/FixedHashMap.h>
+#include <Common/HashTable/StringHashMap.h>
 
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnFixedString.h>
@@ -211,8 +212,8 @@ public:
         std::unique_ptr<FixedHashMap<UInt16, Mapped>> key16;
         std::unique_ptr<HashMap<UInt32, Mapped, HashCRC32<UInt32>>>                     key32;
         std::unique_ptr<HashMap<UInt64, Mapped, HashCRC32<UInt64>>>                     key64;
-        std::unique_ptr<HashMapWithSavedHash<StringRef, Mapped>>                        key_string;
-        std::unique_ptr<HashMapWithSavedHash<StringRef, Mapped>>                        key_fixed_string;
+        std::unique_ptr<StringHashMap<Mapped>>                                          key_string;
+        std::unique_ptr<StringHashMap<Mapped>>                                          key_fixed_string;
         std::unique_ptr<HashMap<UInt128, Mapped, UInt128HashCRC32>>                     keys128;
         std::unique_ptr<HashMap<UInt256, Mapped, UInt256HashCRC32>>                     keys256;
         std::unique_ptr<HashMap<UInt128, Mapped, UInt128TrivialHash>>                   hashed;

--- a/dbms/src/Interpreters/SetVariants.h
+++ b/dbms/src/Interpreters/SetVariants.h
@@ -6,8 +6,10 @@
 #include <Common/Arena.h>
 #include <Common/HashTable/HashSet.h>
 #include <Common/HashTable/ClearableHashSet.h>
-#include <Common/HashTable/FixedClearableHashSet.h>
+#include <Common/HashTable/ClearableFixedHashSet.h>
+#include <Common/HashTable/ClearableStringHashSet.h>
 #include <Common/HashTable/FixedHashSet.h>
+#include <Common/HashTable/StringHashSet.h>
 #include <Common/UInt128.h>
 
 
@@ -186,8 +188,8 @@ struct NonClearableSet
      * As in Aggregator, using consecutive keys cache doesn't improve performance
      * for FixedHashTables.
      */
-    std::unique_ptr<SetMethodOneNumber<UInt8, FixedHashSet<UInt8>, false /* use_cache */>>                                             key8;
-    std::unique_ptr<SetMethodOneNumber<UInt16, FixedHashSet<UInt16>, false /* use_cache */>>                                           key16;
+    std::unique_ptr<SetMethodOneNumber<UInt8, FixedHashSet<UInt8>, false /* use_cache */>>                      key8;
+    std::unique_ptr<SetMethodOneNumber<UInt16, FixedHashSet<UInt16>, false /* use_cache */>>                    key16;
 
     /** Also for the experiment was tested the ability to use SmallSet,
       *  as long as the number of elements in the set is small (and, if necessary, converted to a full-fledged HashSet).
@@ -195,8 +197,8 @@ struct NonClearableSet
       */
     std::unique_ptr<SetMethodOneNumber<UInt32, HashSet<UInt32, HashCRC32<UInt32>>>>                             key32;
     std::unique_ptr<SetMethodOneNumber<UInt64, HashSet<UInt64, HashCRC32<UInt64>>>>                             key64;
-    std::unique_ptr<SetMethodString<HashSetWithSavedHash<StringRef>>>                                           key_string;
-    std::unique_ptr<SetMethodFixedString<HashSetWithSavedHash<StringRef>>>                                      key_fixed_string;
+    std::unique_ptr<SetMethodString<StringHashSet<>>>                                                           key_string;
+    std::unique_ptr<SetMethodFixedString<StringHashSet<>>>                                                      key_fixed_string;
     std::unique_ptr<SetMethodKeysFixed<HashSet<UInt128, UInt128HashCRC32>>>                                     keys128;
     std::unique_ptr<SetMethodKeysFixed<HashSet<UInt256, UInt256HashCRC32>>>                                     keys256;
     std::unique_ptr<SetMethodHashed<HashSet<UInt128, UInt128TrivialHash>>>                                      hashed;
@@ -212,13 +214,13 @@ struct NonClearableSet
 
 struct ClearableSet
 {
-    std::unique_ptr<SetMethodOneNumber<UInt8, FixedClearableHashSet<UInt8>, false /* use_cache */>>                                        key8;
-    std::unique_ptr<SetMethodOneNumber<UInt16, FixedClearableHashSet<UInt16>, false /*use_cache */>>                                      key16;
+    std::unique_ptr<SetMethodOneNumber<UInt8, ClearableFixedHashSet<UInt8>, false /* use_cache */>>                 key8;
+    std::unique_ptr<SetMethodOneNumber<UInt16, ClearableFixedHashSet<UInt16>, false /*use_cache */>>                key16;
 
     std::unique_ptr<SetMethodOneNumber<UInt32, ClearableHashSet<UInt32, HashCRC32<UInt32>>>>                        key32;
     std::unique_ptr<SetMethodOneNumber<UInt64, ClearableHashSet<UInt64, HashCRC32<UInt64>>>>                        key64;
-    std::unique_ptr<SetMethodString<ClearableHashSetWithSavedHash<StringRef>>>                                      key_string;
-    std::unique_ptr<SetMethodFixedString<ClearableHashSetWithSavedHash<StringRef>>>                                 key_fixed_string;
+    std::unique_ptr<SetMethodString<ClearableStringHashSet<>>>                                                      key_string;
+    std::unique_ptr<SetMethodFixedString<ClearableStringHashSet<>>>                                                 key_fixed_string;
     std::unique_ptr<SetMethodKeysFixed<ClearableHashSet<UInt128, UInt128HashCRC32>>>                                keys128;
     std::unique_ptr<SetMethodKeysFixed<ClearableHashSet<UInt256, UInt256HashCRC32>>>                                keys256;
     std::unique_ptr<SetMethodHashed<ClearableHashSet<UInt128, UInt128TrivialHash>>>                                 hashed;

--- a/dbms/src/Storages/StorageJoin.cpp
+++ b/dbms/src/Storages/StorageJoin.cpp
@@ -14,6 +14,7 @@
 #include <Poco/String.h>    /// toLower
 #include <Poco/File.h>
 
+#include <any>
 
 namespace DB
 {
@@ -252,7 +253,7 @@ private:
     std::optional<size_t> key_pos;
     MutableColumns columns;
 
-    std::unique_ptr<void, std::function<void(void *)>> position; /// type erasure
+    std::any position;
 
 
     template <ASTTableJoin::Strictness STRICTNESS, typename Maps>
@@ -319,23 +320,22 @@ private:
     {
         size_t rows_added = 0;
 
-        if (!position)
-            position = decltype(position)(
-                static_cast<void *>(new typename Map::const_iterator(map.begin())),
-                [](void * ptr) { delete reinterpret_cast<typename Map::const_iterator *>(ptr); });
+        using Pos = typename Map::ConstPosition;
+        if (!position.has_value())
+            position = std::make_any<Pos>(map.startPos());
 
-        auto & it = *reinterpret_cast<typename Map::const_iterator *>(position.get());
-        auto end = map.end();
+        Pos & pos = std::any_cast<Pos &>(position);
 
-        for (; it != end; ++it)
+        map.forEachCell([&](const auto & key, const auto & mapped)
         {
             if constexpr (STRICTNESS == ASTTableJoin::Strictness::Any)
             {
                 for (size_t j = 0; j < columns.size(); ++j)
                     if (j == key_pos)
-                        columns[j]->insertData(rawData(it->getKey()), rawSize(it->getKey()));
+                        columns[j]->insertData(rawData(key), rawSize(key));
                     else
-                        columns[j]->insertFrom(*it->getMapped().block->getByPosition(column_indices[j]).column.get(), it->getMapped().row_num);
+                        columns[j]->insertFrom(
+                            *mapped.block->getByPosition(column_indices[j]).column.get(), mapped.row_num);
                 ++rows_added;
             }
             else if constexpr (STRICTNESS == ASTTableJoin::Strictness::Asof)
@@ -343,22 +343,21 @@ private:
                 throw Exception("ASOF join storage is not implemented yet", ErrorCodes::NOT_IMPLEMENTED);
             }
             else
-                for (auto ref_it = it->getMapped().begin(); ref_it.ok(); ++ref_it)
+                for (auto ref_it = mapped.begin(); ref_it.ok(); ++ref_it)
                 {
                     for (size_t j = 0; j < columns.size(); ++j)
                         if (j == key_pos)
-                            columns[j]->insertData(rawData(it->getKey()), rawSize(it->getKey()));
+                            columns[j]->insertData(rawData(key), rawSize(key));
                         else
                             columns[j]->insertFrom(*ref_it->block->getByPosition(column_indices[j]).column.get(), ref_it->row_num);
                     ++rows_added;
                 }
 
             if (rows_added >= max_block_size)
-            {
-                ++it;
-                break;
-            }
-        }
+                return true;
+
+            return false;
+        }, pos);
 
         return rows_added;
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Performance Improvement

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):

Enable SSO for IN operator. Improvements varies from 4% -  **257%** . Should be merged after https://github.com/ClickHouse/ClickHouse/pull/7662

<details>

```
before:

[
{
    "hostname": "201.nobida.cn",
    "main_metric": "rows_per_second",
    "num_cores": 20,
    "num_threads": 40,
    "path": "/data/ClickHouse/src/dbms/tests/performance/string_set.xml",
    "ram": 134765342720,
    "runs": [
        {
            "bytes_per_second": 368044422.809631,
            "memory_usage": 0,
            "min_time": 0.504000,
            "quantiles": {
                "0.1": 0.528337,
                "0.2": 0.531904,
                "0.3": 0.532189,
                "0.4": 0.532633,
                "0.5": 0.533234,
                "0.6": 0.533937,
                "0.7": 0.535373,
                "0.8": 0.537885,
                "0.9": 0.543382,
                "0.95": 0.559287,
                "0.99": 0.572012,
                "0.999": 0.574875,
                "0.9999": 0.575161
            },
            "queries_per_second": 1.868023,
            "query": "SELECT 1 FROM hits_10m_words WHERE word IN (SELECT word FROM hits_10m_words) FORMAT Null",
            "query_index": 0,
            "rows_per_second": 17866550.375103,
            "total_time": 5.353253
        },
        {
            "bytes_per_second": 213019833.991382,
            "memory_usage": 0,
            "min_time": 0.168000,
            "quantiles": {
                "0.1": 0.174986,
                "0.2": 0.175882,
                "0.3": 0.176110,
                "0.4": 0.176196,
                "0.5": 0.176206,
                "0.6": 0.176356,
                "0.7": 0.176592,
                "0.8": 0.177023,
                "0.9": 0.178620,
                "0.95": 0.179009,
                "0.99": 0.179320,
                "0.999": 0.179391,
                "0.9999": 0.179398
            },
            "queries_per_second": 5.683125,
            "query": "SELECT 1 FROM strings WHERE short IN (SELECT short FROM strings) FORMAT Null",
            "query_index": 1,
            "rows_per_second": 11366249.309358,
            "total_time": 1.759595
        },
        {
            "bytes_per_second": 820697966.529802,
            "memory_usage": 0,
            "min_time": 0.296000,
            "quantiles": {
                "0.1": 0.296521,
                "0.2": 0.297664,
                "0.3": 0.298108,
                "0.4": 0.299864,
                "0.5": 0.301401,
                "0.6": 0.302371,
                "0.7": 0.308462,
                "0.8": 0.321663,
                "0.9": 0.325565,
                "0.95": 0.326139,
                "0.99": 0.326597,
                "0.999": 0.326701,
                "0.9999": 0.326711
            },
            "queries_per_second": 3.259396,
            "query": "SELECT 1 FROM strings WHERE long IN (SELECT long FROM strings) FORMAT Null",
            "query_index": 2,
            "rows_per_second": 6518792.776396,
            "total_time": 3.068053
        },
        {
            "bytes_per_second": 659477358.614271,
            "memory_usage": 0,
            "min_time": 0.211000,
            "quantiles": {
                "0.1": 0.217720,
                "0.2": 0.218711,
                "0.3": 0.219188,
                "0.4": 0.219451,
                "0.5": 0.219546,
                "0.6": 0.219585,
                "0.7": 0.219762,
                "0.8": 0.220638,
                "0.9": 0.222671,
                "0.95": 0.223015,
                "0.99": 0.223290,
                "0.999": 0.223352,
                "0.9999": 0.223358
            },
            "queries_per_second": 4.559482,
            "query": "SELECT 1 FROM strings WHERE short IN (SELECT long FROM strings) FORMAT Null",
            "query_index": 3,
            "rows_per_second": 9118963.382797,
            "total_time": 2.193232
        },
        {
            "bytes_per_second": 795195777.826913,
            "memory_usage": 0,
            "min_time": 0.180000,
            "quantiles": {
                "0.1": 0.180861,
                "0.2": 0.180992,
                "0.3": 0.181240,
                "0.4": 0.181383,
                "0.5": 0.181457,
                "0.6": 0.181559,
                "0.7": 0.181659,
                "0.8": 0.182019,
                "0.9": 0.183562,
                "0.95": 0.184427,
                "0.99": 0.185119,
                "0.999": 0.185275,
                "0.9999": 0.185290
            },
            "queries_per_second": 5.497809,
            "query": "SELECT 1 FROM strings WHERE long IN (SELECT short FROM strings) FORMAT Null",
            "query_index": 4,
            "rows_per_second": 10995618.098846,
            "total_time": 1.818906
        },
        {
            "bytes_per_second": 490171004.709044,
            "memory_usage": 0,
            "min_time": 0.227000,
            "quantiles": {
                "0.1": 0.227895,
                "0.2": 0.228227,
                "0.3": 0.228404,
                "0.4": 0.228643,
                "0.5": 0.229939,
                "0.6": 0.232367,
                "0.7": 0.236146,
                "0.8": 0.244028,
                "0.9": 0.260872,
                "0.95": 0.274031,
                "0.99": 0.284559,
                "0.999": 0.286927,
                "0.9999": 0.287164
            },
            "queries_per_second": 4.180450,
            "query": "SELECT 1 FROM hits_10m_words WHERE word IN (SELECT short FROM strings) FORMAT Null",
            "query_index": 5,
            "rows_per_second": 24172229.506384,
            "total_time": 2.392087
        },
        {
            "bytes_per_second": 704963554.841534,
            "memory_usage": 0,
            "min_time": 0.296000,
            "quantiles": {
                "0.1": 0.298237,
                "0.2": 0.302659,
                "0.3": 0.305543,
                "0.4": 0.313259,
                "0.5": 0.320942,
                "0.6": 0.326171,
                "0.7": 0.331032,
                "0.8": 0.334841,
                "0.9": 0.335255,
                "0.95": 0.335929,
                "0.99": 0.336468,
                "0.999": 0.336589,
                "0.9999": 0.336601
            },
            "queries_per_second": 3.141423,
            "query": "SELECT 1 FROM hits_10m_words WHERE word IN (SELECT long FROM strings) FORMAT Null",
            "query_index": 6,
            "rows_per_second": 18164362.378296,
            "total_time": 3.183271
        }
    ],
    "server_version": "19.17.1",
    "test_name": "string_set",
    "time": "2019-11-15 13:44:31"
}
]

after:

[
{
    "hostname": "201.nobida.cn",
    "main_metric": "rows_per_second",
    "num_cores": 20,
    "num_threads": 40,
    "path": "/data/ClickHouse/src/dbms/tests/performance/string_set.xml",
    "ram": 134765342720,
    "runs": [
        {
            "bytes_per_second": 750032587.982162,
            "memory_usage": 0,
            "min_time": 0.234000,
            "quantiles": {
                "0.1": 0.235263,
                "0.2": 0.236501,
                "0.3": 0.260768,
                "0.4": 0.272356,
                "0.5": 0.273470,
                "0.6": 0.273806,
                "0.7": 0.274289,
                "0.8": 0.275151,
                "0.9": 0.275650,
                "0.95": 0.276382,
                "0.99": 0.276968,
                "0.999": 0.277100,
                "0.9999": 0.277114
            },
            "queries_per_second": 3.806818,
            "query": "SELECT 1 FROM hits_10m_words WHERE word IN (SELECT word FROM hits_10m_words) FORMAT Null",
            "query_index": 0,
            "rows_per_second": 36409993.429199,
            "total_time": 2.626866
        },
        {
            "bytes_per_second": 421376603.673944,
            "memory_usage": 0,
            "min_time": 0.086000,
            "quantiles": {
                "0.1": 0.087440,
                "0.2": 0.087720,
                "0.3": 0.087931,
                "0.4": 0.088338,
                "0.5": 0.088798,
                "0.6": 0.089121,
                "0.7": 0.089310,
                "0.8": 0.089853,
                "0.9": 0.091500,
                "0.95": 0.091639,
                "0.99": 0.091751,
                "0.999": 0.091776,
                "0.9999": 0.091778
            },
            "queries_per_second": 11.242588,
            "query": "SELECT 1 FROM strings WHERE short IN (SELECT short FROM strings) FORMAT Null",
            "query_index": 1,
            "rows_per_second": 22485175.911391,
            "total_time": 0.889475
        },
        {
            "bytes_per_second": 856529664.863820,
            "memory_usage": 0,
            "min_time": 0.285000,
            "quantiles": {
                "0.1": 0.286660,
                "0.2": 0.287500,
                "0.3": 0.289618,
                "0.4": 0.290466,
                "0.5": 0.290766,
                "0.6": 0.293492,
                "0.7": 0.298719,
                "0.8": 0.302457,
                "0.9": 0.302960,
                "0.95": 0.303917,
                "0.99": 0.304682,
                "0.999": 0.304854,
                "0.9999": 0.304871
            },
            "queries_per_second": 3.402104,
            "query": "SELECT 1 FROM strings WHERE long IN (SELECT long FROM strings) FORMAT Null",
            "query_index": 2,
            "rows_per_second": 6804207.668950,
            "total_time": 2.939358
        },
        {
            "bytes_per_second": 746751865.914899,
            "memory_usage": 0,
            "min_time": 0.161000,
            "quantiles": {
                "0.1": 0.176888,
                "0.2": 0.180039,
                "0.3": 0.185353,
                "0.4": 0.188428,
                "0.5": 0.197290,
                "0.6": 0.206214,
                "0.7": 0.207605,
                "0.8": 0.208463,
                "0.9": 0.208792,
                "0.95": 0.209183,
                "0.99": 0.209496,
                "0.999": 0.209566,
                "0.9999": 0.209573
            },
            "queries_per_second": 5.163454,
            "query": "SELECT 1 FROM strings WHERE short IN (SELECT long FROM strings) FORMAT Null",
            "query_index": 3,
            "rows_per_second": 10326907.888733,
            "total_time": 1.936688
        },
        {
            "bytes_per_second": 1742085478.735176,
            "memory_usage": 0,
            "min_time": 0.071000,
            "quantiles": {
                "0.1": 0.071377,
                "0.2": 0.075928,
                "0.3": 0.077123,
                "0.4": 0.080181,
                "0.5": 0.084667,
                "0.6": 0.087885,
                "0.7": 0.089688,
                "0.8": 0.091361,
                "0.9": 0.091777,
                "0.95": 0.091907,
                "0.99": 0.092010,
                "0.999": 0.092034,
                "0.9999": 0.092036
            },
            "queries_per_second": 12.045739,
            "query": "SELECT 1 FROM strings WHERE long IN (SELECT short FROM strings) FORMAT Null",
            "query_index": 4,
            "rows_per_second": 24091478.166118,
            "total_time": 0.830169
        },
        {
            "bytes_per_second": 615174037.596330,
            "memory_usage": 0,
            "min_time": 0.173000,
            "quantiles": {
                "0.1": 0.176009,
                "0.2": 0.177864,
                "0.3": 0.178359,
                "0.4": 0.184781,
                "0.5": 0.191961,
                "0.6": 0.195286,
                "0.7": 0.196534,
                "0.8": 0.200416,
                "0.9": 0.210032,
                "0.95": 0.210666,
                "0.99": 0.211174,
                "0.999": 0.211288,
                "0.9999": 0.211300
            },
            "queries_per_second": 5.246600,
            "query": "SELECT 1 FROM hits_10m_words WHERE word IN (SELECT short FROM strings) FORMAT Null",
            "query_index": 5,
            "rows_per_second": 30336933.722313,
            "total_time": 1.905996
        },
        {
            "bytes_per_second": 890828866.077839,
            "memory_usage": 0,
            "min_time": 0.221000,
            "quantiles": {
                "0.1": 0.233963,
                "0.2": 0.237790,
                "0.3": 0.239276,
                "0.4": 0.243009,
                "0.5": 0.252586,
                "0.6": 0.262455,
                "0.7": 0.266897,
                "0.8": 0.269071,
                "0.9": 0.271810,
                "0.95": 0.271943,
                "0.99": 0.272049,
                "0.999": 0.272073,
                "0.9999": 0.272075
            },
            "queries_per_second": 3.969930,
            "query": "SELECT 1 FROM hits_10m_words WHERE word IN (SELECT long FROM strings) FORMAT Null",
            "query_index": 6,
            "rows_per_second": 22954961.635582,
            "total_time": 2.518936
        }
    ],
    "server_version": "19.18.1",
    "test_name": "string_set",
    "time": "2019-11-15 13:45:11"
}
]

```
</details>
