### PR TITLE
Fix PODArray.insert

### DIFF
--- a/dbms/src/Common/PODArray.h
+++ b/dbms/src/Common/PODArray.h
@@ -430,10 +430,10 @@ public:
     template <typename It1, typename It2>
     void insert(iterator it, It1 from_begin, It2 from_end)
     {
-        insertPrepare(from_begin, from_end);
-
         size_t bytes_to_copy = this->byte_size(from_end - from_begin);
         size_t bytes_to_move = (end() - it) * sizeof(T);
+
+        insertPrepare(from_begin, from_end);
 
         if (unlikely(bytes_to_move))
             memcpy(this->c_end + bytes_to_copy - bytes_to_move, this->c_end - bytes_to_move, bytes_to_move);

--- a/dbms/src/Common/tests/gtest_pod_array.cpp
+++ b/dbms/src/Common/tests/gtest_pod_array.cpp
@@ -1,0 +1,34 @@
+#include <gtest/gtest.h>
+
+#include <Common/PODArray.h>
+
+using namespace DB;
+
+TEST(Common, PODArray_Insert)
+{
+    std::string str = "test_string_abacaba";
+    PODArray<char> chars;
+    chars.insert(chars.end(), str.begin(), str.end());
+    EXPECT_EQ(str, std::string(chars.data(), chars.size()));
+
+    std::string insert_in_the_middle = "insert_in_the_middle";
+    auto pos = str.size() / 2;
+    str.insert(str.begin() + pos, insert_in_the_middle.begin(), insert_in_the_middle.end());
+    chars.insert(chars.begin() + pos, insert_in_the_middle.begin(), insert_in_the_middle.end());
+    EXPECT_EQ(str, std::string(chars.data(), chars.size()));
+
+    std::string insert_with_resize;
+    insert_with_resize.reserve(chars.capacity() * 2);
+    char curChar = 'a';
+    while (insert_with_resize.size() < insert_with_resize.capacity())
+    {
+        insert_with_resize += curChar;
+        if (curChar == 'z')
+            curChar = 'a';
+        else
+            ++curChar;
+    }
+    str.insert(str.begin(), insert_with_resize.begin(), insert_with_resize.end());
+    chars.insert(chars.begin(), insert_with_resize.begin(), insert_with_resize.end());
+    EXPECT_EQ(str, std::string(chars.data(), chars.size()));
+}

--- a/dbms/src/Common/tests/gtest_pod_array.cpp
+++ b/dbms/src/Common/tests/gtest_pod_array.cpp
@@ -19,14 +19,14 @@ TEST(Common, PODArray_Insert)
 
     std::string insert_with_resize;
     insert_with_resize.reserve(chars.capacity() * 2);
-    char curChar = 'a';
+    char cur_char = 'a';
     while (insert_with_resize.size() < insert_with_resize.capacity())
     {
-        insert_with_resize += curChar;
-        if (curChar == 'z')
-            curChar = 'a';
+        insert_with_resize += cur_char;
+        if (cur_char == 'z')
+            cur_char = 'a';
         else
-            ++curChar;
+            ++cur_char;
     }
     str.insert(str.begin(), insert_with_resize.begin(), insert_with_resize.end());
     chars.insert(chars.begin(), insert_with_resize.begin(), insert_with_resize.end());


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Fix the case where PODArray.insert works with iterator after invalidation.

