### PR TITLE
Fix typo in Memory: reuse buffer if capacity allows.

### DIFF
--- a/dbms/src/IO/BufferWithOwnMemory.h
+++ b/dbms/src/IO/BufferWithOwnMemory.h
@@ -77,7 +77,7 @@ struct Memory : boost::noncopyable, Allocator
             m_capacity = new_size;
             alloc();
         }
-        else if (new_size <= m_size)
+        else if (new_size <= m_capacity - pad_right)
         {
             m_size = new_size;
             return;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Fix a typo that might have caused excessive memory copying.