### PR TITLE
Use SIGRTMIN instead of SIGPROF for user debugging purposes

### DIFF
--- a/dbms/programs/client/readpassphrase/readpassphrase.c
+++ b/dbms/programs/client/readpassphrase/readpassphrase.c
@@ -121,7 +121,6 @@ restart:
 	(void)sigaction(SIGPIPE, &sa, &savepipe);
 	(void)sigaction(SIGQUIT, &sa, &savequit);
 	(void)sigaction(SIGTERM, &sa, &saveterm);
-	(void)sigaction(SIGTSTP, &sa, &savetstp);
 	(void)sigaction(SIGTTIN, &sa, &savettin);
 	(void)sigaction(SIGTTOU, &sa, &savettou);
 
@@ -163,7 +162,6 @@ restart:
 	(void)sigaction(SIGQUIT, &savequit, NULL);
 	(void)sigaction(SIGPIPE, &savepipe, NULL);
 	(void)sigaction(SIGTERM, &saveterm, NULL);
-	(void)sigaction(SIGTSTP, &savetstp, NULL);
 	(void)sigaction(SIGTTIN, &savettin, NULL);
 	(void)sigaction(SIGTTOU, &savettou, NULL);
 	if (input != STDIN_FILENO)
@@ -177,7 +175,6 @@ restart:
 		if (signo[i]) {
 			kill(getpid(), i);
 			switch (i) {
-			case SIGTSTP:
 			case SIGTTIN:
 			case SIGTTOU:
 				need_restart = 1;

--- a/dbms/src/Common/StackTrace.cpp
+++ b/dbms/src/Common/StackTrace.cpp
@@ -157,10 +157,13 @@ std::string signalToErrorMessage(int sig, const siginfo_t & info, const ucontext
             }
             break;
         }
-    }
 
-    if (sig == SIGRTMIN)
-        error << "This is a signal used for debugging purposes by the user.";
+        case SIGTSTP:
+        {
+            error << "This is a signal used for debugging purposes by the user.";
+            break;
+        }
+    }
 
     return error.str();
 }

--- a/dbms/src/Common/StackTrace.cpp
+++ b/dbms/src/Common/StackTrace.cpp
@@ -157,13 +157,10 @@ std::string signalToErrorMessage(int sig, const siginfo_t & info, const ucontext
             }
             break;
         }
-
-        case SIGRTMIN:
-        {
-            error << "This is a signal used for debugging purposes by the user.";
-            break;
-        }
     }
+
+    if (sig == SIGRTMIN)
+        error << "This is a signal used for debugging purposes by the user.";
 
     return error.str();
 }

--- a/dbms/src/Common/StackTrace.cpp
+++ b/dbms/src/Common/StackTrace.cpp
@@ -158,7 +158,7 @@ std::string signalToErrorMessage(int sig, const siginfo_t & info, const ucontext
             break;
         }
 
-        case SIGPROF:
+        case SIGRTMIN:
         {
             error << "This is a signal used for debugging purposes by the user.";
             break;

--- a/libs/libdaemon/src/BaseDaemon.cpp
+++ b/libs/libdaemon/src/BaseDaemon.cpp
@@ -732,6 +732,7 @@ void BaseDaemon::initializeTerminationAndSignalProcessing()
     signal_listener.reset(new SignalListener(*this));
     signal_listener_thread.start(*signal_listener);
 
+    Logger::root().information("Hint: use signal number " + std::to_string(SIGRTMIN) + " (SIGRTMIN) for user debugging purposes");
 }
 
 void BaseDaemon::logRevision() const

--- a/libs/libdaemon/src/BaseDaemon.cpp
+++ b/libs/libdaemon/src/BaseDaemon.cpp
@@ -110,7 +110,7 @@ static void faultSignalHandler(int sig, siginfo_t * info, void * context)
 
     out.next();
 
-    if (sig != SIGRTMIN) /// This signal is used for debugging.
+    if (sig != SIGTSTP) /// This signal is used for debugging.
     {
         /// The time that is usually enough for separate thread to print info into log.
         ::sleep(10);
@@ -719,9 +719,9 @@ void BaseDaemon::initializeTerminationAndSignalProcessing()
             }
         };
 
-    /// SIGRTMIN is added for debugging purposes. To output a stack trace of any running thread at anytime.
+    /// SIGTSTP is added for debugging purposes. To output a stack trace of any running thread at anytime.
 
-    add_signal_handler({SIGABRT, SIGSEGV, SIGILL, SIGBUS, SIGSYS, SIGFPE, SIGPIPE, SIGRTMIN}, faultSignalHandler);
+    add_signal_handler({SIGABRT, SIGSEGV, SIGILL, SIGBUS, SIGSYS, SIGFPE, SIGPIPE, SIGTSTP}, faultSignalHandler);
     add_signal_handler({SIGHUP, SIGUSR1}, closeLogsSignalHandler);
     add_signal_handler({SIGINT, SIGQUIT, SIGTERM}, terminateRequestedSignalHandler);
 
@@ -731,8 +731,6 @@ void BaseDaemon::initializeTerminationAndSignalProcessing()
 
     signal_listener.reset(new SignalListener(*this));
     signal_listener_thread.start(*signal_listener);
-
-    Logger::root().information("Hint: use signal number " + std::to_string(SIGRTMIN) + " (SIGRTMIN) for user debugging purposes");
 }
 
 void BaseDaemon::logRevision() const

--- a/libs/libdaemon/src/BaseDaemon.cpp
+++ b/libs/libdaemon/src/BaseDaemon.cpp
@@ -110,7 +110,7 @@ static void faultSignalHandler(int sig, siginfo_t * info, void * context)
 
     out.next();
 
-    if (sig != SIGPROF) /// This signal is used for debugging.
+    if (sig != SIGRTMIN) /// This signal is used for debugging.
     {
         /// The time that is usually enough for separate thread to print info into log.
         ::sleep(10);
@@ -719,9 +719,9 @@ void BaseDaemon::initializeTerminationAndSignalProcessing()
             }
         };
 
-    /// SIGPROF is added for debugging purposes. To output a stack trace of any running thread at anytime.
+    /// SIGRTMIN is added for debugging purposes. To output a stack trace of any running thread at anytime.
 
-    add_signal_handler({SIGABRT, SIGSEGV, SIGILL, SIGBUS, SIGSYS, SIGFPE, SIGPIPE, SIGPROF}, faultSignalHandler);
+    add_signal_handler({SIGABRT, SIGSEGV, SIGILL, SIGBUS, SIGSYS, SIGFPE, SIGPIPE, SIGRTMIN}, faultSignalHandler);
     add_signal_handler({SIGHUP, SIGUSR1}, closeLogsSignalHandler);
     add_signal_handler({SIGINT, SIGQUIT, SIGTERM}, terminateRequestedSignalHandler);
 
@@ -891,4 +891,3 @@ void BaseDaemon::waitForTerminationRequest()
     std::unique_lock<std::mutex> lock(signal_handler_mutex);
     signal_event.wait(lock, [this](){ return terminate_signals_counter > 0; });
 }
-


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Use SIGRTMIN instead of SIGPROF for user debugging purposes