### PR TITLE
Added EN translation of developer instructions

### DIFF
--- a/dbms/tests/instructions/developer_instruction_en.md
+++ b/dbms/tests/instructions/developer_instruction_en.md
@@ -1,0 +1,268 @@
+Building of ClickHouse is supported on Linux, FreeBSD and Mac OS X.
+
+# If you use Windows
+
+If you use Windows, you need to create a virtual machine with Ubuntu. To start working with a virtual machine please install VirtualBox. You can download Ubuntu from the website: https://www.ubuntu.com/#download Please create a virtual machine from the downloaded image (you should reserve at least 4GB of RAM for it). To run a command line terminal in Ubuntu, please locate a program containing the word "terminal" in its name (gnome-terminal, konsole etc.) or just press Ctrl+Alt+T.
+
+
+# Creating a repository on GitHub
+
+To start working with ClickHouse repository you will need a GitHub account.
+
+Probably, you already have one. If you don't, please register at https://github.com In case you do not have ssh keys, you should generate them and then upload them on GitHub. It is required for sending over your patches. It is also possible to use the same ssh keys that you use with any other ssh servers - probably you already have those.
+
+Create a fork of ClickHouse repository. To do that please click on the "fork" button in the upper right corner at https://github.com/ClickHouse/ClickHouse  It will fork your own copy of ClickHouse/ClickHouse to your account.
+
+Development process consists of first committing the intended changes into your fork of ClickHouse and then creating a "pull request" for these changes to be accepted into the main repository (ClickHouse/ClickHouse).
+
+To work with git repositories, please install `git`.
+
+To do that in Ubuntu you would run in the command line terminal:
+```
+sudo apt update
+sudo apt install git
+```
+
+A brief manual on using Git can be found here: https://services.github.com/on-demand/downloads/github-git-cheat-sheet.pdf
+For a detailed manual on Git see: https://git-scm.com/book/ru/v2
+
+
+# Cloning a repository on your development machine
+
+Next you need to download the source files onto your working machine. This is called "to clone a repository" because it creates a local copy of the repository on your working machine. //TODO:?? (You are going to work with this local copy.)
+
+In the command line terminal run:
+```
+git clone --recursive git@guthub.com:your_github_username/ClickHouse.git
+cd ClickHouse
+```
+Note: please, substitute *your_github_username* with what is appropriate
+
+This command will create a directory `ClickHouse` containing the working copy of the project.
+
+It is important that the path to the working directory contain no whitespaces as it may lead to problems with running the build system.
+
+Please note that ClickHouse repository uses `submodules`. That is what the references to additional repositories are called (i.e. external libraries on which the project depends). It means that when cloning the repository you need to specify the `--recursive` flag as in the example above. If the repository has been cloned without submodules, to download them you need to run the following:
+```
+git submodule init
+git submodule update
+```
+You can check status with command: `git submodule status`.
+
+If you get the following error message:
+```
+Permission denied (publickey).
+fatal: Could not read from remote repository.
+
+Please make sure you have the correct access rights
+and the repository exists.
+```
+It generally means that the ssh keys for connecting to GitHub are missing. These keys are normally located in `~/.ssh`. For ssh keys to be accepted you need to upload them in the settings section of GitHub UI.
+
+You can also clone the repository via https protocol:
+```
+git clone https://github.com/ClickHouse/ClickHouse.git
+```
+This however will not let you send your changes to the server. You can still use it temporarily and add the ssh keys later replacing the remote address of the repository with `git remote` command.
+
+You can also add original ClickHouse repo's address to your local repository to pull updates from there:
+```
+git remote add upstream git@github.com:ClickHouse/ClickHouse.git
+```
+After successfully running this command you will be able to pull updates from the main ClickHouse repo by running `git pull upstream master`.
+
+
+# Build System
+
+ClickHouse uses CMake and Ninja for building.
+
+CMake - a meta-build system that can generate Ninja files (build tasks).
+Ninja - a smaller build system with focus on speed used to execute those cmake generated tasks.
+
+To install on Ubuntu, Debian or Mint run `sudo apt install cmake ninja-build`.
+
+On CentOS, RedHat run `sudo yum install cmake ninja-build`.
+
+If you use Arch or Gentoo, you probably know it yourself how to install CMake.
+
+For installing CMake and Ninja on Mac OS X first install Homebrew and then install everything else via brew:
+```
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+brew install cmake ninja
+```
+
+Next, check the version of CMake: `cmake --version`. If it is below 3.3, you should install a newer version from the website: https://cmake.org/download/
+
+
+#Optional External Libraries
+
+ClickHouse uses several external libraries for building. Most of them do not need to be installed separately as they are built together with ClickHouse from the sources located in the submodules. You can check the list in `contrib`.
+
+There is a couple of libraries that are not built from sources but are supplied by the system: ICU and Readline, and thus are recommended to be installed.
+
+Ubuntu: `sudo apt install libicu-dev libreadline-dev`
+
+Mac OS X: `brew install icu4c readline`
+
+However, these libraries are optional and ClickHouse can well be built without them. ICU is used for support of `COLLATE` in `ORDER BY` (i.e. for sorting in turkish alphabet). Readline is used for more convenient command input in clickhouse-client.
+
+
+# C++ Compiler
+
+Compilers GCC starting from version 7 and Clang version 7 or above are supported for building ClickHouse.
+
+Official Yandex builds currently use GCC because it generates machine code of slightly better performance (yielding a difference of up to several percent according to our benchmarks). And Clang is more convenient for development usually. Though, our continuous integration (CI) platform runs checks for about a dozen of build combinations.
+
+To install GCC on Ubuntu run: `sudo apt install gcc g++`
+
+Check the version of gcc: `gcc --version`. If it is below 7, then follow the instruction here: https://clickhouse.yandex/docs/en/development/build/#install-gcc-7
+
+To install GCC on Mac OS X run: `brew install gcc`.
+
+If you decide to use Clang, you can also install `libc++` and `lld`, if you know what it is. Using `ccache` is also recommended.
+
+
+# The Building process
+
+Now that you are ready to build ClickHouse we recommend you to create a separate directory `build` inside `ClickHouse` that will contain all of the build artefacts:
+```
+mkdir build
+cd build
+```
+You can have several different directories (build_release, build_debug, etc.) for different types of build.
+
+While inside the `build` directory, configure your build by running CMake. Before the first run you need to define environment variables that specify compiler (version 7 gcc compiler in this example).
+```
+export CC=gcc-7 CXX=g++-7
+cmake ..
+```
+The `CC` variable specifies the compiler for C (short for C Compiler), and `CXX` variable instructs which C++ compiler is to be used for building.
+
+For a faster build you can resort to the `debug` build type - a build with no optimizations. For that supply the following parameter `-D CMAKE_BUILD_TYPE=Debug`:
+```
+cmake -D CMAKE_BUILD_TYPE=Debug ..
+```
+You can change the type of build by running this command in the `build` directory.
+
+Run ninja to build:
+```
+ninja clickhouse-server clickhouse-client
+```
+Only the required binaries are going to be built in this example.
+
+If you require to build all the binaries (utilities and tests), you should run ninja with no parameters:
+```
+ninja
+```
+
+Full build requires about 30GB of free disk space or 15GB to build the main binaries.
+
+When large amount of RAM is available on build machine you should limit the number of build tasks run in parallel with `-j` param:
+```
+ninja -j 1 clickhouse-server clickhouse-client
+```
+On machines with 4GB of RAM it is recommended to specify 1, for 8GB of RAM `-j 2` is recommended.
+
+If you get the message: `ninja: error: loading 'build.ninja': No such file or directory`, it means that generating a build configuration has failed and you need to inspect the message above.
+
+Upon successful start of the building process you'll see the build progress - the number of processed tasks and the total number of tasks.
+
+While building messages about protobuf files in libhdfs2 library like `libprotobuf WARNING` may show up. They affect nothing and are safe to be ignored.
+
+Upon successful build you get an executable file `ClickHouse/<build_dir>/dbms/programs/clickhouse`:
+```
+ls -l dbms/programs/clickhouse
+```
+
+
+# Running the built executable of ClickHouse
+
+To run the server under the current user you need to navigate to `ClickHouse/dbms/programs/server/` (located outside of `build`) and run:
+
+```
+../../../build/dbms/programs/clickhouse server
+```
+
+In this case ClickHouse will use config files located in the current directory. You can run `clickhouse server` from any directory specifying the path to a config file as a command line parameter `--config-file`.
+
+To connect to ClickHouse with clickhouse-client in another terminal navigate to `ClickHouse/build/dbms/programs/` and run `clickhouse client`.
+
+If you get `Connection refused` message on Mac OS X or FreeBSD, try specifying host address 127.0.0.1:
+```
+clickhouse client --host 127.0.0.1
+```
+
+You can replace production version of ClickHouse binary installed in your system with your custom built ClickHouse binary. To do that install ClickHouse on your machine following the instructions from the official website. Next, run the following:
+```
+sudo service clickhouse-server stop
+sudo cp ClickHouse/build/dbms/programs/clickhouse /usr/bin/
+sudo service clickhouse-server start
+```
+
+Note that `clickhouse-client`, `clickhouse-server` and others are symlinks to the commonly shared `clickhouse` binary.
+
+You can also run your custom built ClickHouse binary with the config file from the ClickHouse package installed on your system:
+```
+sudo service clickhouse-server stop
+sudo -u clickhouse ClickHouse/build/dbms/programs/clickhouse server --config-file /etc/clickhouse-server/config.xml
+```
+
+
+# IDE (Integrated Development Environment)
+
+If you do not know which IDE to use, we recommend that you use CLion. CLion is a commercial software, but it offers 30 day free trial period. It is also free of charge for students. CLion can be used both on Linux and on Mac OS X.
+
+KDevelop and QTCreator are another great alternatives of an IDE for developing ClickHouse. KDevelop comes in as a very handy IDE although unstable. If KDevelop crashes after a while upon opening project, you should click "Stop All" button as soon as it has opened the list of project's files. After doing so KDevelop should be fine to work with.
+
+As simple code editors you can use Sublime Text or Visual Studio Code, or Kate (all of which are available on Linux).
+
+Just in case it is worth mentioning that CLion creates by itself its own `build` path, it also selects by itself the type of build `debug` as default, for configuration it uses a version of CMake that is built into CLion and not the one installed by you, and finally CLion will use make to run build tasks instead of ninja. This is a normal behaviour, just keep that in mind to avoid confusion.
+
+
+# Writing Code
+
+The description of ClickHouse architecture can be found here: https://clickhouse.yandex/docs/en/development/architecture/
+
+The Code Style Guide: https://clickhouse.yandex/docs/en/development/style/
+
+Writing tests: https://clickhouse.yandex/docs/en/development/tests/
+
+List of tasks: https://github.com/yandex/ClickHouse/blob/master/dbms/tests/instructions/easy_tasks_sorted_en.md
+
+
+# Test Data
+
+Developing ClickHouse often requires loading realistic datasets. It is particularly important for performance testing. Especially for you we have prepared a set of anonymized data from Yandex.Metrica. It requires additionally some 3GB of free disk space. Note that this data is not required to accomplish most of development tasks.
+
+```
+sudo apt install wget xz-utils
+
+wget https://clickhouse-datasets.s3.yandex.net/hits/tsv/hits_v1.tsv.xz
+wget https://clickhouse-datasets.s3.yandex.net/visits/tsv/visits_v1.tsv.xz
+
+xz -v -d hits_v1.tsv.xz
+xz -v -d visits_v1.tsv.xz
+
+clickhouse-client
+
+CREATE TABLE test.hits ( WatchID UInt64,  JavaEnable UInt8,  Title String,  GoodEvent Int16,  EventTime DateTime,  EventDate Date,  CounterID UInt32,  ClientIP UInt32,  ClientIP6 FixedString(16),  RegionID UInt32,  UserID UInt64,  CounterClass Int8,  OS UInt8,  UserAgent UInt8,  URL String,  Referer String,  URLDomain String,  RefererDomain String,  Refresh UInt8,  IsRobot UInt8,  RefererCategories Array(UInt16),  URLCategories Array(UInt16),  URLRegions Array(UInt32),  RefererRegions Array(UInt32),  ResolutionWidth UInt16,  ResolutionHeight UInt16,  ResolutionDepth UInt8,  FlashMajor UInt8,  FlashMinor UInt8,  FlashMinor2 String,  NetMajor UInt8,  NetMinor UInt8,  UserAgentMajor UInt16,  UserAgentMinor FixedString(2),  CookieEnable UInt8,  JavascriptEnable UInt8,  IsMobile UInt8,  MobilePhone UInt8,  MobilePhoneModel String,  Params String,  IPNetworkID UInt32,  TraficSourceID Int8,  SearchEngineID UInt16,  SearchPhrase String,  AdvEngineID UInt8,  IsArtifical UInt8,  WindowClientWidth UInt16,  WindowClientHeight UInt16,  ClientTimeZone Int16,  ClientEventTime DateTime,  SilverlightVersion1 UInt8,  SilverlightVersion2 UInt8,  SilverlightVersion3 UInt32,  SilverlightVersion4 UInt16,  PageCharset String,  CodeVersion UInt32,  IsLink UInt8,  IsDownload UInt8,  IsNotBounce UInt8,  FUniqID UInt64,  HID UInt32,  IsOldCounter UInt8,  IsEvent UInt8,  IsParameter UInt8,  DontCountHits UInt8,  WithHash UInt8,  HitColor FixedString(1),  UTCEventTime DateTime,  Age UInt8,  Sex UInt8,  Income UInt8,  Interests UInt16,  Robotness UInt8,  GeneralInterests Array(UInt16),  RemoteIP UInt32,  RemoteIP6 FixedString(16),  WindowName Int32,  OpenerName Int32,  HistoryLength Int16,  BrowserLanguage FixedString(2),  BrowserCountry FixedString(2),  SocialNetwork String,  SocialAction String,  HTTPError UInt16,  SendTiming Int32,  DNSTiming Int32,  ConnectTiming Int32,  ResponseStartTiming Int32,  ResponseEndTiming Int32,  FetchTiming Int32,  RedirectTiming Int32,  DOMInteractiveTiming Int32,  DOMContentLoadedTiming Int32,  DOMCompleteTiming Int32,  LoadEventStartTiming Int32,  LoadEventEndTiming Int32,  NSToDOMContentLoadedTiming Int32,  FirstPaintTiming Int32,  RedirectCount Int8,  SocialSourceNetworkID UInt8,  SocialSourcePage String,  ParamPrice Int64,  ParamOrderID String,  ParamCurrency FixedString(3),  ParamCurrencyID UInt16,  GoalsReached Array(UInt32),  OpenstatServiceName String,  OpenstatCampaignID String,  OpenstatAdID String,  OpenstatSourceID String,  UTMSource String,  UTMMedium String,  UTMCampaign String,  UTMContent String,  UTMTerm String,  FromTag String,  HasGCLID UInt8,  RefererHash UInt64,  URLHash UInt64,  CLID UInt32,  YCLID UInt64,  ShareService String,  ShareURL String,  ShareTitle String,  `ParsedParams.Key1` Array(String),  `ParsedParams.Key2` Array(String),  `ParsedParams.Key3` Array(String),  `ParsedParams.Key4` Array(String),  `ParsedParams.Key5` Array(String),  `ParsedParams.ValueDouble` Array(Float64),  IslandID FixedString(16),  RequestNum UInt32,  RequestTry UInt8) ENGINE = MergeTree PARTITION BY toYYYYMM(EventDate) SAMPLE BY intHash32(UserID) ORDER BY (CounterID, EventDate, intHash32(UserID), EventTime);
+
+CREATE TABLE test.visits ( CounterID UInt32,  StartDate Date,  Sign Int8,  IsNew UInt8,  VisitID UInt64,  UserID UInt64,  StartTime DateTime,  Duration UInt32,  UTCStartTime DateTime,  PageViews Int32,  Hits Int32,  IsBounce UInt8,  Referer String,  StartURL String,  RefererDomain String,  StartURLDomain String,  EndURL String,  LinkURL String,  IsDownload UInt8,  TraficSourceID Int8,  SearchEngineID UInt16,  SearchPhrase String,  AdvEngineID UInt8,  PlaceID Int32,  RefererCategories Array(UInt16),  URLCategories Array(UInt16),  URLRegions Array(UInt32),  RefererRegions Array(UInt32),  IsYandex UInt8,  GoalReachesDepth Int32,  GoalReachesURL Int32,  GoalReachesAny Int32,  SocialSourceNetworkID UInt8,  SocialSourcePage String,  MobilePhoneModel String,  ClientEventTime DateTime,  RegionID UInt32,  ClientIP UInt32,  ClientIP6 FixedString(16),  RemoteIP UInt32,  RemoteIP6 FixedString(16),  IPNetworkID UInt32,  SilverlightVersion3 UInt32,  CodeVersion UInt32,  ResolutionWidth UInt16,  ResolutionHeight UInt16,  UserAgentMajor UInt16,  UserAgentMinor UInt16,  WindowClientWidth UInt16,  WindowClientHeight UInt16,  SilverlightVersion2 UInt8,  SilverlightVersion4 UInt16,  FlashVersion3 UInt16,  FlashVersion4 UInt16,  ClientTimeZone Int16,  OS UInt8,  UserAgent UInt8,  ResolutionDepth UInt8,  FlashMajor UInt8,  FlashMinor UInt8,  NetMajor UInt8,  NetMinor UInt8,  MobilePhone UInt8,  SilverlightVersion1 UInt8,  Age UInt8,  Sex UInt8,  Income UInt8,  JavaEnable UInt8,  CookieEnable UInt8,  JavascriptEnable UInt8,  IsMobile UInt8,  BrowserLanguage UInt16,  BrowserCountry UInt16,  Interests UInt16,  Robotness UInt8,  GeneralInterests Array(UInt16),  Params Array(String),  `Goals.ID` Array(UInt32),  `Goals.Serial` Array(UInt32),  `Goals.EventTime` Array(DateTime),  `Goals.Price` Array(Int64),  `Goals.OrderID` Array(String),  `Goals.CurrencyID` Array(UInt32),  WatchIDs Array(UInt64),  ParamSumPrice Int64,  ParamCurrency FixedString(3),  ParamCurrencyID UInt16,  ClickLogID UInt64,  ClickEventID Int32,  ClickGoodEvent Int32,  ClickEventTime DateTime,  ClickPriorityID Int32,  ClickPhraseID Int32,  ClickPageID Int32,  ClickPlaceID Int32,  ClickTypeID Int32,  ClickResourceID Int32,  ClickCost UInt32,  ClickClientIP UInt32,  ClickDomainID UInt32,  ClickURL String,  ClickAttempt UInt8,  ClickOrderID UInt32,  ClickBannerID UInt32,  ClickMarketCategoryID UInt32,  ClickMarketPP UInt32,  ClickMarketCategoryName String,  ClickMarketPPName String,  ClickAWAPSCampaignName String,  ClickPageName String,  ClickTargetType UInt16,  ClickTargetPhraseID UInt64,  ClickContextType UInt8,  ClickSelectType Int8,  ClickOptions String,  ClickGroupBannerID Int32,  OpenstatServiceName String,  OpenstatCampaignID String,  OpenstatAdID String,  OpenstatSourceID String,  UTMSource String,  UTMMedium String,  UTMCampaign String,  UTMContent String,  UTMTerm String,  FromTag String,  HasGCLID UInt8,  FirstVisit DateTime,  PredLastVisit Date,  LastVisit Date,  TotalVisits UInt32,  `TraficSource.ID` Array(Int8),  `TraficSource.SearchEngineID` Array(UInt16),  `TraficSource.AdvEngineID` Array(UInt8),  `TraficSource.PlaceID` Array(UInt16),  `TraficSource.SocialSourceNetworkID` Array(UInt8),  `TraficSource.Domain` Array(String),  `TraficSource.SearchPhrase` Array(String),  `TraficSource.SocialSourcePage` Array(String),  Attendance FixedString(16),  CLID UInt32,  YCLID UInt64,  NormalizedRefererHash UInt64,  SearchPhraseHash UInt64,  RefererDomainHash UInt64,  NormalizedStartURLHash UInt64,  StartURLDomainHash UInt64,  NormalizedEndURLHash UInt64,  TopLevelDomain UInt64,  URLScheme UInt64,  OpenstatServiceNameHash UInt64,  OpenstatCampaignIDHash UInt64,  OpenstatAdIDHash UInt64,  OpenstatSourceIDHash UInt64,  UTMSourceHash UInt64,  UTMMediumHash UInt64,  UTMCampaignHash UInt64,  UTMContentHash UInt64,  UTMTermHash UInt64,  FromHash UInt64,  WebVisorEnabled UInt8,  WebVisorActivity UInt32,  `ParsedParams.Key1` Array(String),  `ParsedParams.Key2` Array(String),  `ParsedParams.Key3` Array(String),  `ParsedParams.Key4` Array(String),  `ParsedParams.Key5` Array(String),  `ParsedParams.ValueDouble` Array(Float64),  `Market.Type` Array(UInt8),  `Market.GoalID` Array(UInt32),  `Market.OrderID` Array(String),  `Market.OrderPrice` Array(Int64),  `Market.PP` Array(UInt32),  `Market.DirectPlaceID` Array(UInt32),  `Market.DirectOrderID` Array(UInt32),  `Market.DirectBannerID` Array(UInt32),  `Market.GoodID` Array(String),  `Market.GoodName` Array(String),  `Market.GoodQuantity` Array(Int32),  `Market.GoodPrice` Array(Int64),  IslandID FixedString(16)) ENGINE = CollapsingMergeTree(Sign) PARTITION BY toYYYYMM(StartDate) SAMPLE BY intHash32(UserID) ORDER BY (CounterID, StartDate, intHash32(UserID), VisitID);
+
+clickhouse-client --max_insert_block_size 100000 --query "INSERT INTO test.hits FORMAT TSV" < hits_v1.tsv
+clickhouse-client --max_insert_block_size 100000 --query "INSERT INTO test.visits FORMAT TSV" < visits_v1.tsv
+```
+
+
+
+# Creating Pull Request
+
+Navigate to your fork repository in GitHub's UI. If you have been developing in a branch, you need to select that branch. There will be a "Pull request" button located on the screen. In essence this means "create a request for accepting my changes into the main repository".
+
+A pull request can be created even if the work is not completed yet. In this case please put the word "WIP" (work in progress) at the beginning of the title, it can be changed later. This is useful for cooperative reviewing and discussion of changes as well as for running all of the available tests. It is important that you provide a brief description of your changes, it will later be used for generating realease changelogs.
+
+Testing will commence as soon as Yandex employees label your PR with a tag "can be tested". The results of some first checks (e.g. code style) will come in within several minutes. Build check results will arrive within a half an hour. And the main set of tests will report itself within an hour.
+
+The system will prepare ClickHouse binary builds for your pull request individually. To retrieve these builds click the "Details" link next to "ClickHouse build check" entry in the list of checks. There you will find direct links to the built .deb packages of ClickHouse, which you can deploy even on your production servers (if you have no fear).
+
+Most probably some of the builds will fail at first times. This is due to the fact that we check build both with gcc as well as with clang, enabling almost all of existing warnings (always with the `-Werror` flag) for clang. On that same page you can find all of the build logs - you do not have to build ClickHouse in all possible ways.

--- a/dbms/tests/instructions/developer_instruction_en.md
+++ b/dbms/tests/instructions/developer_instruction_en.md
@@ -2,16 +2,16 @@ Building of ClickHouse is supported on Linux, FreeBSD and Mac OS X.
 
 # If you use Windows
 
-If you use Windows, you need to create a virtual machine with Ubuntu. To start working with a virtual machine please install VirtualBox. You can download Ubuntu from the website: https://www.ubuntu.com/#download Please create a virtual machine from the downloaded image (you should reserve at least 4GB of RAM for it). To run a command line terminal in Ubuntu, please locate a program containing the word "terminal" in its name (gnome-terminal, konsole etc.) or just press Ctrl+Alt+T.
+If you use Windows, you need to create a virtual machine with Ubuntu. To start working with a virtual machine please install VirtualBox. You can download Ubuntu from the website: https://www.ubuntu.com/#download. Please create a virtual machine from the downloaded image (you should reserve at least 4GB of RAM for it). To run a command line terminal in Ubuntu, please locate a program containing the word "terminal" in its name (gnome-terminal, konsole etc.) or just press Ctrl+Alt+T.
 
 
 # Creating a repository on GitHub
 
 To start working with ClickHouse repository you will need a GitHub account.
 
-Probably, you already have one. If you don't, please register at https://github.com In case you do not have ssh keys, you should generate them and then upload them on GitHub. It is required for sending over your patches. It is also possible to use the same ssh keys that you use with any other ssh servers - probably you already have those.
+Probably, you already have one. If you don't, please register at https://github.com. In case you do not have ssh keys, you should generate them and then upload them on GitHub. It is required for sending over your patches. It is also possible to use the same ssh keys that you use with any other ssh servers - probably you already have those.
 
-Create a fork of ClickHouse repository. To do that please click on the "fork" button in the upper right corner at https://github.com/ClickHouse/ClickHouse  It will fork your own copy of ClickHouse/ClickHouse to your account.
+Create a fork of ClickHouse repository. To do that please click on the "fork" button in the upper right corner at https://github.com/ClickHouse/ClickHouse.  It will fork your own copy of ClickHouse/ClickHouse to your account.
 
 Development process consists of first committing the intended changes into your fork of ClickHouse and then creating a "pull request" for these changes to be accepted into the main repository (ClickHouse/ClickHouse).
 
@@ -23,13 +23,13 @@ sudo apt update
 sudo apt install git
 ```
 
-A brief manual on using Git can be found here: https://services.github.com/on-demand/downloads/github-git-cheat-sheet.pdf
-For a detailed manual on Git see: https://git-scm.com/book/ru/v2
+A brief manual on using Git can be found here: https://services.github.com/on-demand/downloads/github-git-cheat-sheet.pdf.
+For a detailed manual on Git see: https://git-scm.com/book/ru/v2.
 
 
 # Cloning a repository on your development machine
 
-Next you need to download the source files onto your working machine. This is called "to clone a repository" because it creates a local copy of the repository on your working machine. //TODO:?? (You are going to work with this local copy.)
+Next you need to download the source files onto your working machine. This is called "to clone a repository" because it creates a local copy of the repository on your working machine.
 
 In the command line terminal run:
 ```
@@ -91,10 +91,10 @@ For installing CMake and Ninja on Mac OS X first install Homebrew and then insta
 brew install cmake ninja
 ```
 
-Next, check the version of CMake: `cmake --version`. If it is below 3.3, you should install a newer version from the website: https://cmake.org/download/
+Next, check the version of CMake: `cmake --version`. If it is below 3.3, you should install a newer version from the website: https://cmake.org/download/.
 
 
-#Optional External Libraries
+# Optional External Libraries
 
 ClickHouse uses several external libraries for building. Most of them do not need to be installed separately as they are built together with ClickHouse from the sources located in the submodules. You can check the list in `contrib`.
 
@@ -115,7 +115,7 @@ Official Yandex builds currently use GCC because it generates machine code of sl
 
 To install GCC on Ubuntu run: `sudo apt install gcc g++`
 
-Check the version of gcc: `gcc --version`. If it is below 7, then follow the instruction here: https://clickhouse.yandex/docs/en/development/build/#install-gcc-7
+Check the version of gcc: `gcc --version`. If it is below 7, then follow the instruction here: https://clickhouse.yandex/docs/en/development/build/#install-gcc-7.
 
 To install GCC on Mac OS X run: `brew install gcc`.
 
@@ -232,7 +232,7 @@ List of tasks: https://github.com/yandex/ClickHouse/blob/master/dbms/tests/instr
 
 # Test Data
 
-Developing ClickHouse often requires loading realistic datasets. It is particularly important for performance testing. Especially for you we have prepared a set of anonymized data from Yandex.Metrica. It requires additionally some 3GB of free disk space. Note that this data is not required to accomplish most of development tasks.
+Developing ClickHouse often requires loading realistic datasets. It is particularly important for performance testing. We have a specially prepared set of anonymized data from Yandex.Metrica. It requires additionally some 3GB of free disk space. Note that this data is not required to accomplish most of development tasks.
 
 ```
 sudo apt install wget xz-utils
@@ -263,6 +263,6 @@ A pull request can be created even if the work is not completed yet. In this cas
 
 Testing will commence as soon as Yandex employees label your PR with a tag "can be tested". The results of some first checks (e.g. code style) will come in within several minutes. Build check results will arrive within a half an hour. And the main set of tests will report itself within an hour.
 
-The system will prepare ClickHouse binary builds for your pull request individually. To retrieve these builds click the "Details" link next to "ClickHouse build check" entry in the list of checks. There you will find direct links to the built .deb packages of ClickHouse, which you can deploy even on your production servers (if you have no fear).
+The system will prepare ClickHouse binary builds for your pull request individually. To retrieve these builds click the "Details" link next to "ClickHouse build check" entry in the list of checks. There you will find direct links to the built .deb packages of ClickHouse which you can deploy even on your production servers (if you have no fear).
 
-Most probably some of the builds will fail at first times. This is due to the fact that we check build both with gcc as well as with clang, enabling almost all of existing warnings (always with the `-Werror` flag) for clang. On that same page you can find all of the build logs - you do not have to build ClickHouse in all possible ways.
+Most probably some of the builds will fail at first times. This is due to the fact that we check builds both with gcc as well as with clang, with almost all of existing warnings (always with the `-Werror` flag) enabled for clang. On that same page you can find all of the build logs so that you do not have to build ClickHouse in all of the possible ways.

--- a/dbms/tests/instructions/developer_instruction_en.md
+++ b/dbms/tests/instructions/developer_instruction_en.md
@@ -9,7 +9,7 @@ If you use Windows, you need to create a virtual machine with Ubuntu. To start w
 
 To start working with ClickHouse repository you will need a GitHub account.
 
-Probably, you already have one. If you don't, please register at https://github.com. In case you do not have ssh keys, you should generate them and then upload them on GitHub. It is required for sending over your patches. It is also possible to use the same ssh keys that you use with any other ssh servers - probably you already have those.
+You probably already have one, but if you don't, please register at https://github.com. In case you do not have SSH keys, you should generate them and then upload them on GitHub. It is required for sending over your patches. It is also possible to use the same SSH keys that you use with any other SSH servers - probably you already have those.
 
 Create a fork of ClickHouse repository. To do that please click on the "fork" button in the upper right corner at https://github.com/ClickHouse/ClickHouse.  It will fork your own copy of ClickHouse/ClickHouse to your account.
 
@@ -27,20 +27,20 @@ A brief manual on using Git can be found here: https://services.github.com/on-de
 For a detailed manual on Git see: https://git-scm.com/book/ru/v2.
 
 
-# Cloning a repository on your development machine
+# Cloning a repository to your development machine
 
-Next you need to download the source files onto your working machine. This is called "to clone a repository" because it creates a local copy of the repository on your working machine.
+Next, you need to download the source files onto your working machine. This is called "to clone a repository" because it creates a local copy of the repository on your working machine.
 
 In the command line terminal run:
 ```
 git clone --recursive git@guthub.com:your_github_username/ClickHouse.git
 cd ClickHouse
 ```
-Note: please, substitute *your_github_username* with what is appropriate
+Note: please, substitute *your_github_username* with what is appropriate!
 
 This command will create a directory `ClickHouse` containing the working copy of the project.
 
-It is important that the path to the working directory contain no whitespaces as it may lead to problems with running the build system.
+It is important that the path to the working directory contains no whitespaces as it may lead to problems with running the build system.
 
 Please note that ClickHouse repository uses `submodules`. That is what the references to additional repositories are called (i.e. external libraries on which the project depends). It means that when cloning the repository you need to specify the `--recursive` flag as in the example above. If the repository has been cloned without submodules, to download them you need to run the following:
 ```
@@ -57,13 +57,13 @@ fatal: Could not read from remote repository.
 Please make sure you have the correct access rights
 and the repository exists.
 ```
-It generally means that the ssh keys for connecting to GitHub are missing. These keys are normally located in `~/.ssh`. For ssh keys to be accepted you need to upload them in the settings section of GitHub UI.
+It generally means that the SSH keys for connecting to GitHub are missing. These keys are normally located in `~/.ssh`. For SSH keys to be accepted you need to upload them in the settings section of GitHub UI.
 
 You can also clone the repository via https protocol:
 ```
 git clone https://github.com/ClickHouse/ClickHouse.git
 ```
-This however will not let you send your changes to the server. You can still use it temporarily and add the ssh keys later replacing the remote address of the repository with `git remote` command.
+This however will not let you send your changes to the server. You can still use it temporarily and add the SSH keys later replacing the remote address of the repository with `git remote` command.
 
 You can also add original ClickHouse repo's address to your local repository to pull updates from there:
 ```

--- a/dbms/tests/instructions/developer_instruction_en.md
+++ b/dbms/tests/instructions/developer_instruction_en.md
@@ -216,7 +216,7 @@ KDevelop and QTCreator are another great alternatives of an IDE for developing C
 
 As simple code editors you can use Sublime Text or Visual Studio Code, or Kate (all of which are available on Linux).
 
-Just in case it is worth mentioning that CLion creates by itself its own `build` path, it also selects by itself the type of build `debug` as default, for configuration it uses a version of CMake that is built into CLion and not the one installed by you, and finally CLion will use make to run build tasks instead of ninja. This is a normal behaviour, just keep that in mind to avoid confusion.
+Just in case, it is worth mentioning that CLion creates by itself its own `build` path, it also selects by itself `debug` for build type, for configuration it uses a version of CMake that is defined in CLion and not the one installed by you, and finally CLion will use `make` to run build tasks instead of `ninja`. This is a normal behaviour, just keep that in mind to avoid confusion.
 
 
 # Writing Code


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Added EN translation of developer instructions in the `dbms/tests/instructions` section.

Closes #7569