### PR TITLE
Fix build with Poco Redis

### DIFF
--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -376,7 +376,7 @@ if (USE_POCO_MONGODB)
     dbms_target_link_libraries (PRIVATE ${Poco_MongoDB_LIBRARY})
 endif()
 
-if(USE_POCO_REDIS)
+if (USE_POCO_REDIS)
     dbms_target_link_libraries (PRIVATE ${Poco_Redis_LIBRARY})
 endif()
 

--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -376,6 +376,10 @@ if (USE_POCO_MONGODB)
     dbms_target_link_libraries (PRIVATE ${Poco_MongoDB_LIBRARY})
 endif()
 
+if(USE_POCO_REDIS)
+    dbms_target_link_libraries (PRIVATE ${Poco_Redis_LIBRARY})
+endif()
+
 if (USE_POCO_NETSSL)
     target_link_libraries (clickhouse_common_io PRIVATE ${Poco_NetSSL_LIBRARY} ${Poco_Crypto_LIBRARY})
     dbms_target_link_libraries (PRIVATE ${Poco_NetSSL_LIBRARY} ${Poco_Crypto_LIBRARY})


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Non-significant (changelog entry is not needed)

Was getting that (Debug build, clang-8) 
```
[build] FAILED: dbms/src/Dictionaries/CMakeFiles/clickhouse_dictionaries.dir/RedisDictionarySource.cpp.o 
...
[build] ../../dbms/src/Dictionaries/RedisDictionarySource.cpp:38:14: fatal error: 'Poco/Redis/Array.h' file not found
[build] #    include <Poco/Redis/Array.h>
[build]              ^~~~~~~~~~~~~~~~~~~~
[build] 1 error generated.
```