### PR TITLE
Slightly better usability of exception messages

### DIFF
--- a/dbms/src/Common/Exception.cpp
+++ b/dbms/src/Common/Exception.cpp
@@ -261,7 +261,7 @@ std::string getExceptionMessage(const Exception & e, bool with_stacktrace, bool 
         stream << "Code: " << e.code() << ", e.displayText() = " << text;
 
         if (with_stacktrace && !has_embedded_stack_trace)
-            stream << ", Stack trace:\n\n" << e.getStackTrace().toString();
+            stream << ", Stack trace (when copying this message, always include the lines below):\n\n" << e.getStackTrace().toString();
     }
     catch (...) {}
 

--- a/dbms/src/Interpreters/executeQuery.cpp
+++ b/dbms/src/Interpreters/executeQuery.cpp
@@ -143,7 +143,7 @@ static void logException(Context & context, QueryLogElement & elem)
     LOG_ERROR(&Logger::get("executeQuery"), elem.exception
         << " (from " << context.getClientInfo().current_address.toString() << ")"
         << " (in query: " << joinLines(elem.query) << ")"
-        << (!elem.stack_trace.empty() ? ", Stack trace:\n\n" + elem.stack_trace : ""));
+        << (!elem.stack_trace.empty() ? ", Stack trace (when copying this message, always include the lines below):\n\n" + elem.stack_trace : ""));
 }
 
 


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Slightly better usability of error messages. Ask user not to remove the lines below `Stack trace:`.