### PR TITLE
Fix reading empty set with prewhere dependent on alias column.

### DIFF
--- a/dbms/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1694,6 +1694,13 @@ void InterpreterSelectQuery::executeFetchColumns(
 
             if (query_info.prewhere_info)
             {
+                if (query_info.prewhere_info->alias_actions)
+                {
+                    streams.back() = std::make_shared<ExpressionBlockInputStream>(
+                        streams.back(),
+                        query_info.prewhere_info->alias_actions);
+                }
+
                 streams.back() = std::make_shared<FilterBlockInputStream>(
                     streams.back(),
                     prewhere_info->prewhere_actions,
@@ -1718,6 +1725,10 @@ void InterpreterSelectQuery::executeFetchColumns(
 
             if (query_info.prewhere_info)
             {
+                if (query_info.prewhere_info->alias_actions)
+                    pipe.addSimpleTransform(std::make_shared<ExpressionTransform>(
+                        pipe.getHeader(), query_info.prewhere_info->alias_actions));
+
                 pipe.addSimpleTransform(std::make_shared<FilterTransform>(
                         pipe.getHeader(),
                         prewhere_info->prewhere_actions,

--- a/dbms/tests/queries/0_stateless/01035_prewhere_with_alias.sql
+++ b/dbms/tests/queries/0_stateless/01035_prewhere_with_alias.sql
@@ -1,0 +1,36 @@
+DROP TABLE IF EXISTS test;
+CREATE TABLE test (a UInt8, b UInt8, c UInt16 ALIAS a + b) ENGINE = MergeTree ORDER BY a;
+
+SELECT b FROM test PREWHERE c = 1;
+
+DROP TABLE test;
+
+drop table if exists audience_local;
+create table audience_local
+(
+ Date Date,
+ AudienceType Enum8('other' = 0, 'client' = 1, 'group' = 2),
+ UMA UInt64,
+ APIKey String,
+ TrialNameID UInt32,
+ TrialGroupID UInt32,
+ AppVersion String,
+ Arch Enum8('other' = 0, 'x32' = 1, 'x64' = 2),
+ UserID UInt32,
+ GroupID UInt8,
+ OSName Enum8('other' = 0, 'Android' = 1, 'iOS' = 2, 'macOS' = 3, 'Windows' = 4, 'Linux' = 5),
+ Channel Enum8('other' = 0, 'Canary' = 1, 'Dev' = 2, 'Beta' = 3, 'Stable' = 4),
+ Hits UInt64,
+ Sum Int64,
+ Release String alias splitByChar('-', AppVersion)[1]
+)
+engine = SummingMergeTree
+PARTITION BY (toISOYear(Date), toISOWeek(Date))
+ORDER BY (AudienceType, UMA, APIKey, Date, TrialNameID, TrialGroupID, AppVersion, Arch, UserID, GroupID, OSName, Channel)
+SETTINGS index_granularity = 8192;
+
+SELECT DISTINCT UserID
+FROM audience_local
+PREWHERE Date = toDate('2019-07-25') AND Release = '17.11.0.542';
+
+drop table if exists audience_local;

--- a/dbms/tests/queries/bugs/prewhere_with_alias.sql
+++ b/dbms/tests/queries/bugs/prewhere_with_alias.sql
@@ -1,6 +1,0 @@
-DROP TABLE IF EXISTS test.test;
-CREATE TABLE test.test (a UInt8, b UInt8, c UInt16 ALIAS a + b) ENGINE = MergeTree ORDER BY a;
-
-SELECT b FROM test.test PREWHERE c = 1;
-
-DROP TABLE test;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Fix error `Not found column` if query used `prewhere` dependent on table's alias and the result set was empty because of PK condition.

Detailed description (optional):
It was forgotten to execute `sample_expression` after reading from `NullSource`.