### PR TITLE
Update tutorial.html

### DIFF
--- a/website/tutorial.html
+++ b/website/tutorial.html
@@ -542,7 +542,7 @@ LIMIT 20
     <div class="spoiler"><a class="spoiler_title">Set ZooKeeper locations in configuration file</a>
         <div class="spoiler_body">
 <pre>
-&lt;zookeeper-servers&gt;
+&lt;zookeeper&gt;
     &lt;node&gt;
         &lt;host&gt;zoo01.yandex.ru&lt;/host&gt;
         &lt;port&gt;2181&lt;/port&gt;
@@ -555,7 +555,7 @@ LIMIT 20
         &lt;host&gt;zoo03.yandex.ru&lt;/host&gt;
         &lt;port&gt;2181&lt;/port&gt;
     &lt;/node&gt;
-&lt;/zookeeper-servers&gt;
+&lt;/zookeeper&gt;
 </pre>
         </div>
     </div>


### PR DESCRIPTION
wrong tag zookeeper-servers instead of zookeeper

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation
- Non-significant (changelog entry is not needed)
