### PR TITLE
old kernel hdfs support

### DIFF
--- a/contrib/libhdfs3-cmake/CMakeLists.txt
+++ b/contrib/libhdfs3-cmake/CMakeLists.txt
@@ -182,6 +182,9 @@ set(SRCS
     ${HDFS3_SOURCE_DIR}/common/FileWrapper.h
     )
 
+# old kernels (< 3.17) doens't have SYS_getrandom. Always use POSIX implementation to have better compatibility
+set_source_files_properties(${HDFS3_SOURCE_DIR}/rpc/RpcClient.cpp PROPERTIES COMPILE_FLAGS "-DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX=1")
+
 # target
 add_library(hdfs3 ${SRCS} ${PROTO_SOURCES} ${PROTO_HEADERS})
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement



Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):

old kernels (< 3.17) don't have SYS_getrandom. Always use POSIX implementation to have better compatibility

Just got bitten by this https://github.com/ClickHouse/ClickHouse/issues/4197

