### PR TITLE
utilize libunwind to achieve better abi-compat

### DIFF
--- a/contrib/libunwind-cmake/CMakeLists.txt
+++ b/contrib/libunwind-cmake/CMakeLists.txt
@@ -11,7 +11,9 @@ endif ()
 set(LIBUNWIND_C_SOURCES
     ${LIBUNWIND_SOURCE_DIR}/src/UnwindLevel1.c
     ${LIBUNWIND_SOURCE_DIR}/src/UnwindLevel1-gcc-ext.c
-    ${LIBUNWIND_SOURCE_DIR}/src/Unwind-sjlj.c)
+    ${LIBUNWIND_SOURCE_DIR}/src/Unwind-sjlj.c
+    # Use unw_backtrace to override libgcc's backtrace symbol for better ABI compatibility
+    unwind-override.c)
 set_source_files_properties(${LIBUNWIND_C_SOURCES} PROPERTIES COMPILE_FLAGS "-std=c99")
 
 set(LIBUNWIND_ASM_SOURCES

--- a/contrib/libunwind-cmake/unwind-override.c
+++ b/contrib/libunwind-cmake/unwind-override.c
@@ -1,0 +1,6 @@
+#include <libunwind.h>
+
+int backtrace(void ** buffer, int size)
+{
+    return unw_backtrace(buffer, size);
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):

thirdparty libraries such as libhdfs calls libgcc `backtrace` directly, which might lead to ABI mismatch issue when libunwind is enabled and running on old systems