### PR TITLE
doc: fixup replicas monitor url path

### DIFF
--- a/docs/en/operations/monitoring.md
+++ b/docs/en/operations/monitoring.md
@@ -34,4 +34,4 @@ You can configure ClickHouse to export metrics to [Graphite](https://github.com/
 
 Additionally, you can monitor server availability through the HTTP API. Send the `HTTP GET` request to `/`. If the server is available, it responds with `200 OK`.
 
-To monitor servers in a cluster configuration, you should set the [max_replica_delay_for_distributed_queries](settings/settings.md#settings-max_replica_delay_for_distributed_queries) parameter and use the HTTP resource `/replicas-delay`. A request to `/replicas-delay` returns `200 OK` if the replica is available and is not delayed behind the other replicas. If a replica is delayed, it returns information about the gap.
+To monitor servers in a cluster configuration, you should set the [max_replica_delay_for_distributed_queries](settings/settings.md#settings-max_replica_delay_for_distributed_queries) parameter and use the HTTP resource `/replicas_status`. A request to `/replicas_status` returns `200 OK` if the replica is available and is not delayed behind the other replicas. If a replica is delayed, it returns information about the gap.

--- a/docs/ru/operations/monitoring.md
+++ b/docs/ru/operations/monitoring.md
@@ -34,4 +34,4 @@ ClickHouse собирает:
 
 Также, можно отслеживать доступность сервера через HTTP API. Отправьте `HTTP GET` к ресурсу `/`. Если сервер доступен, он отвечает `200 OK`.
 
-Для мониторинга серверов в кластерной конфигурации необходимо установить параметр [max_replica_delay_for_distributed_queries](settings/settings.md#settings-max_replica_delay_for_distributed_queries) и использовать HTTP ресурс `/replicas-delay`. Если реплика доступна и не отстаёт от других реплик, то запрос к `/replicas-delay` возвращает `200 OK`. Если реплика отстаёт, то она возвращает информацию о размере отставания.
+Для мониторинга серверов в кластерной конфигурации необходимо установить параметр [max_replica_delay_for_distributed_queries](settings/settings.md#settings-max_replica_delay_for_distributed_queries) и использовать HTTP ресурс `/replicas_status`. Если реплика доступна и не отстаёт от других реплик, то запрос к `/replicas_status` возвращает `200 OK`. Если реплика отстаёт, то она возвращает информацию о размере отставания.

--- a/docs/zh/development/build_cross.md
+++ b/docs/zh/development/build_cross.md
@@ -1,13 +1,13 @@
 # 如何在Linux中编译Mac OS X ClickHouse
 
-Linux机器也可以编译运行在OS X系统的`clickhouse`二进制包，这可以用于在Linux上跑持续集成测试。如果要直接在Mac OS X上构建ClickHouse，请参考另外一篇指南： https://clickhouse.yandex/docs/zh/development/build_osx/
+Linux机器也可以编译运行在OS X系统的`clickhouse`二进制包，这可以用于在Linux上跑持续集成测试。如果要在Mac OS X上直接构建ClickHouse，请参考另外一篇指南： https://clickhouse.yandex/docs/zh/development/build_osx/
 
 Mac OS X的交叉编译基于以下构建说明，请首先遵循它们。
 
 # Install Clang-8
 
 按照https://apt.llvm.org/中的说明进行Ubuntu或Debian安装。
-例如，按照Bionic的命令如下：
+例如，安装Bionic的命令如下：
 
 ```bash
 sudo echo "deb [trusted=yes] http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main" >> /etc/apt/sources.list

--- a/docs/zh/operations/monitoring.md
+++ b/docs/zh/operations/monitoring.md
@@ -34,4 +34,4 @@ ClickHouse 收集的指标项：
 
 此外，您可以通过HTTP API监视服务器可用性。 将HTTP GET请求发送到 `/`。 如果服务器可用，它将以 `200 OK` 响应。
 
-要监视服务器集群的配置中，应设置[max_replica_delay_for_distributed_queries](settings/settings.md#settings-max_replica_delay_for_distributed_queries)参数并使用HTTP资源`/replicas-delay`。 如果副本可用，并且不延迟在其他副本之后，则对`/replicas-delay`的请求将返回200 OK。 如果副本被延迟，它将返回有关延迟信息。
+要监视服务器集群的配置中，应设置[max_replica_delay_for_distributed_queries](settings/settings.md#settings-max_replica_delay_for_distributed_queries)参数并使用HTTP资源`/replicas_status`。 如果副本可用，并且不延迟在其他副本之后，则对`/replicas_status`的请求将返回200 OK。 如果副本被延迟，它将返回有关延迟信息。


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation

- Detailed description (optional):
 
In the docs,  `/replicas-delay` should be `/replicas_status`.

