### PR TITLE
Kafka fixes

### DIFF
--- a/dbms/src/DataStreams/IBlockInputStream.h
+++ b/dbms/src/DataStreams/IBlockInputStream.h
@@ -263,6 +263,11 @@ protected:
       */
     bool checkTimeLimit();
 
+#ifndef NDEBUG
+    bool read_prefix_is_called = false;
+    bool read_suffix_is_called = false;
+#endif
+
 private:
     bool enabled_extremes = false;
 
@@ -315,10 +320,6 @@ private:
                 return;
     }
 
-#ifndef NDEBUG
-    bool read_prefix_is_called = false;
-    bool read_suffix_is_called = false;
-#endif
 };
 
 }

--- a/dbms/src/DataStreams/NativeBlockInputStream.cpp
+++ b/dbms/src/DataStreams/NativeBlockInputStream.cpp
@@ -57,12 +57,19 @@ NativeBlockInputStream::NativeBlockInputStream(ReadBuffer & istr_, UInt64 server
     }
 }
 
+// also resets few vars from IBlockInputStream (I didn't want to propagate resetParser upthere)
 void NativeBlockInputStream::resetParser()
 {
     istr_concrete = nullptr;
     use_index = false;
-    header.clear();
-    avg_value_size_hints.clear();
+
+#ifndef NDEBUG
+    read_prefix_is_called = false;
+    read_suffix_is_called = false;
+#endif
+
+    is_cancelled.store(false);
+    is_killed.store(false);
 }
 
 void NativeBlockInputStream::readData(const IDataType & type, IColumn & column, ReadBuffer & istr, size_t rows, double avg_value_size_hint)

--- a/dbms/src/Storages/Kafka/KafkaBlockInputStream.cpp
+++ b/dbms/src/Storages/Kafka/KafkaBlockInputStream.cpp
@@ -119,8 +119,6 @@ Block KafkaBlockInputStream::readImpl()
 
     while (true)
     {
-        buffer->allowNext();
-
         // some formats (like RowBinaryWithNamesAndTypes / CSVWithNames)
         // throw an exception from readPrefix when buffer in empty
         if (buffer->eof())
@@ -135,7 +133,6 @@ Block KafkaBlockInputStream::readImpl()
         auto _timestamp_raw = buffer->currentTimestamp();
         auto _timestamp     = _timestamp_raw ? std::chrono::duration_cast<std::chrono::seconds>(_timestamp_raw->get_timestamp()).count()
                                                 : 0;
-
         for (size_t i = 0; i < new_rows; ++i)
         {
             virtual_columns[0]->insert(_topic);
@@ -153,6 +150,7 @@ Block KafkaBlockInputStream::readImpl()
         }
 
         total_rows = total_rows + new_rows;
+        buffer->allowNext();
         if (!new_rows || total_rows >= max_block_size || !checkTimeLimit())
             break;
     }

--- a/dbms/src/Storages/Kafka/KafkaBlockInputStream.cpp
+++ b/dbms/src/Storages/Kafka/KafkaBlockInputStream.cpp
@@ -136,12 +136,20 @@ Block KafkaBlockInputStream::readImpl()
         auto _timestamp     = _timestamp_raw ? std::chrono::duration_cast<std::chrono::seconds>(_timestamp_raw->get_timestamp()).count()
                                                 : 0;
 
-        for (size_t i = 0; i < new_rows; ++i) {
+        for (size_t i = 0; i < new_rows; ++i)
+        {
             virtual_columns[0]->insert(_topic);
             virtual_columns[1]->insert(_key);
             virtual_columns[2]->insert(_offset);
             virtual_columns[3]->insert(_partition);
-            virtual_columns[4]->insert(_timestamp);
+            if (_timestamp_raw)
+            {
+                virtual_columns[4]->insert(_timestamp);
+            }
+            else
+            {
+                virtual_columns[4]->insertDefault();
+            }
         }
 
         total_rows = total_rows + new_rows;

--- a/dbms/src/Storages/Kafka/KafkaBlockInputStream.cpp
+++ b/dbms/src/Storages/Kafka/KafkaBlockInputStream.cpp
@@ -125,12 +125,16 @@ Block KafkaBlockInputStream::readImpl()
     };
 
     size_t total_rows = 0;
-    while (total_rows < max_block_size)
+
+    buffer->allowNext();
+    // some formats (like RowBinaryWithNamesAndTypes / CSVWithNames)
+    // throw an exception when buffer in empty, so just
+    while (!buffer->eof())
     {
         auto new_rows = read_kafka_message();
         total_rows = total_rows + new_rows;
         buffer->allowNext();
-        if (!new_rows || !checkTimeLimit())
+        if (!new_rows || total_rows >= max_block_size || !checkTimeLimit())
             break;
     }
 

--- a/dbms/src/Storages/Kafka/KafkaBlockInputStream.cpp
+++ b/dbms/src/Storages/Kafka/KafkaBlockInputStream.cpp
@@ -141,8 +141,7 @@ Block KafkaBlockInputStream::readImpl()
             virtual_columns[1]->insert(_key);
             virtual_columns[2]->insert(_offset);
             virtual_columns[3]->insert(_partition);
-            if (_timestamp)
-                virtual_columns[4]->insert(_timestamp);
+            virtual_columns[4]->insert(_timestamp);
         }
 
         total_rows = total_rows + new_rows;

--- a/dbms/src/Storages/Kafka/KafkaBlockInputStream.cpp
+++ b/dbms/src/Storages/Kafka/KafkaBlockInputStream.cpp
@@ -163,7 +163,7 @@ Block KafkaBlockInputStream::readImpl()
     // and it's misleading to use them here,
     // as columns 'materialized' that way stays 'ephemeral'
     // i.e. will not be stored anythere
-    // IF needed any extra columns can be added using DEFAULT  they can be added at MV level if needed,
+    // If needed any extra columns can be added using DEFAULT they can be added at MV level if needed.
 
     auto result_block  = non_virtual_header.cloneWithColumns(std::move(result_columns));
     auto virtual_block = virtual_header.cloneWithColumns(std::move(virtual_columns));


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Fixed Native format for Kafka,  resolves #6731 #7337 #8003  
Fixed formats with headers (like CSVWithNames) which were throwing exception about eof.

Detailed description (optional):
Continuation of #7935

Those formats was tested with Kafka, and after that changes pass very basic tests: CSV CSVWithNames JSONEachRow Native RowBinary RowBinaryWithNamesAndTypes TSKV TSV TSVWithNames TSVWithNamesAndTypes

Values - is currently broken for Kafka (seems like some magic with peekable buffer), fails the test 10 msgs x 8K rows each (stops consuming after 16K rows).

~~Schema-based format was not tested yet (still TODO)~~. Tested & works (see below)

Note for backporters: **THAT PR DEPENDS ON https://github.com/ClickHouse/ClickHouse/pull/8005 !!**

