### PR TITLE
Removed `localtime` from `HTTPDictionarySource::getUpdateFieldAndDate…

### DIFF
--- a/dbms/src/Dictionaries/HTTPDictionarySource.cpp
+++ b/dbms/src/Dictionaries/HTTPDictionarySource.cpp
@@ -5,6 +5,8 @@
 #include <IO/ConnectionTimeouts.h>
 #include <IO/ReadWriteBufferFromHTTP.h>
 #include <IO/WriteBufferFromOStream.h>
+#include <IO/WriteBufferFromString.h>
+#include <IO/WriteHelpers.h>
 #include <Interpreters/Context.h>
 #include <Poco/Net/HTTPRequest.h>
 #include <common/logger_useful.h>
@@ -82,12 +84,9 @@ void HTTPDictionarySource::getUpdateFieldAndDate(Poco::URI & uri)
         auto tmp_time = update_time;
         update_time = std::chrono::system_clock::now();
         time_t hr_time = std::chrono::system_clock::to_time_t(tmp_time) - 1;
-        char buffer[80];
-        struct tm * timeinfo;
-        timeinfo = localtime(&hr_time);
-        strftime(buffer, 80, "%Y-%m-%d %H:%M:%S", timeinfo);
-        std::string str_time(buffer);
-        uri.addQueryParameter(update_field, str_time);
+        WriteBufferFromOwnString out;
+        writeDateTimeText(hr_time, out);
+        uri.addQueryParameter(update_field, out.str());
     }
     else
     {


### PR DESCRIPTION
…()`.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Non-significant (changelog entry is not needed)

