### PR TITLE
Simplify format of the header of data sent to a shard in a distributed query.

### DIFF
--- a/dbms/src/Core/Defines.h
+++ b/dbms/src/Core/Defines.h
@@ -151,8 +151,8 @@
 #endif
 
 /// Marks that extra information is sent to a shard. It could be any magic numbers.
-#define DBMS_DISTRIBUTED_SIGNATURE_EXTRA_INFO 0xCAFEDACEull
-#define DBMS_DISTRIBUTED_SIGNATURE_SETTINGS_OLD_FORMAT 0xCAFECABEull
+#define DBMS_DISTRIBUTED_SIGNATURE_HEADER 0xCAFEDACEull
+#define DBMS_DISTRIBUTED_SIGNATURE_HEADER_OLD_FORMAT 0xCAFECABEull
 
 #if !__has_include(<sanitizer/asan_interface.h>)
 #   define ASAN_UNPOISON_MEMORY_REGION(a, b)

--- a/dbms/src/Storages/Distributed/DirectoryMonitor.h
+++ b/dbms/src/Storages/Distributed/DirectoryMonitor.h
@@ -66,7 +66,7 @@ private:
     ThreadFromGlobalPool thread{&StorageDistributedDirectoryMonitor::run, this};
 
     /// Read insert query and insert settings for backward compatible.
-    void readQueryAndSettings(ReadBuffer & in, Settings & insert_settings, std::string & insert_query) const;
+    void readHeader(ReadBuffer & in, Settings & insert_settings, std::string & insert_query) const;
 };
 
 }

--- a/dbms/src/Storages/Distributed/DistributedBlockOutputStream.cpp
+++ b/dbms/src/Storages/Distributed/DistributedBlockOutputStream.cpp
@@ -588,25 +588,22 @@ void DistributedBlockOutputStream::writeToShard(const Block & block, const std::
             CompressedWriteBuffer compress{out};
             NativeBlockOutputStream stream{compress, ClickHouseRevision::get(), block.cloneEmpty()};
 
-            /// We wrap the extra information into a string for compatibility with older versions:
-            /// a shard will able to read this information partly and ignore other parts
-            /// based on its version.
-            WriteBufferFromOwnString extra_info;
-            writeVarUInt(ClickHouseRevision::get(), extra_info);
-            context.getSettingsRef().serialize(extra_info);
-
-            writePODBinary(CityHash_v1_0_2::CityHash128(query_string.data(), query_string.size()), extra_info);
+            /// Prepare the header.
+            /// We wrap the header into a string for compatibility with older versions:
+            /// a shard will able to read the header partly and ignore other parts based on its version.
+            WriteBufferFromOwnString header_buf;
+            writeVarUInt(ClickHouseRevision::get(), header_buf);
+            writeStringBinary(query_string, header_buf);
+            context.getSettingsRef().serialize(header_buf);
 
             /// Add new fields here, for example:
-            /// writeVarUInt(my_new_data, extra_info);
+            /// writeVarUInt(my_new_data, header_buf);
 
-            const auto &extra_info_ref = extra_info.stringRef();
-            writePODBinary(CityHash_v1_0_2::CityHash128(extra_info_ref.data, extra_info_ref.size), extra_info);
-
-            writeVarUInt(DBMS_DISTRIBUTED_SIGNATURE_EXTRA_INFO, out);
-            writeStringBinary(extra_info.str(), out);
-
-            writeStringBinary(query_string, out);
+            /// Write the header.
+            const StringRef header = header_buf.stringRef();
+            writeVarUInt(DBMS_DISTRIBUTED_SIGNATURE_HEADER, out);
+            writeStringBinary(header, out);
+            writePODBinary(CityHash_v1_0_2::CityHash128(header.data, header.size), out);
 
             stream.writePrefix();
             stream.write(block);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry:
Simplify format of the header of data sending to a shard in a distributed query.

Detailed description:
Due to https://github.com/ClickHouse/ClickHouse/pull/7653 and https://github.com/ClickHouse/ClickHouse/pull/7914 changed the binary format of the data sending from a distributed query's initiator to a shard, we can change the binary format in the current revision [54429](https://github.com/ClickHouse/ClickHouse/blob/master/dbms/cmake/version.cmake#L2) one more time to make the things easier.