### PR TITLE
Interpose malloc symbols entirely.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,16 +382,12 @@ add_subdirectory (contrib EXCLUDE_FROM_ALL)
 
 macro (add_executable target)
     # invoke built-in add_executable
-    _add_executable (${ARGV})
+    # explicitly acquire and interpose malloc symbols by clickhouse_malloc
+    _add_executable (${ARGV} $<TARGET_OBJECTS:clickhouse_malloc>)
     get_target_property (type ${target} TYPE)
     if (${type} STREQUAL EXECUTABLE)
-        file (RELATIVE_PATH dir ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
-        if (${dir} MATCHES "^dbms")
-            # Only interpose operator::new/delete for dbms executables (MemoryTracker stuff)
-            target_link_libraries (${target} PRIVATE clickhouse_new_delete ${MALLOC_LIBRARIES})
-        else ()
-            target_link_libraries (${target} PRIVATE ${MALLOC_LIBRARIES})
-        endif ()
+        # operator::new/delete for executables (MemoryTracker stuff)
+        target_link_libraries (${target} PRIVATE clickhouse_new_delete ${MALLOC_LIBRARIES})
     endif()
 endmacro()
 

--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -100,7 +100,7 @@ set(dbms_sources)
 add_headers_and_sources(clickhouse_common_io src/Common)
 add_headers_and_sources(clickhouse_common_io src/Common/HashTable)
 add_headers_and_sources(clickhouse_common_io src/IO)
-list (REMOVE_ITEM clickhouse_common_io_sources src/Common/new_delete.cpp)
+list (REMOVE_ITEM clickhouse_common_io_sources src/Common/malloc.cpp src/Common/new_delete.cpp)
 
 if(USE_RDKAFKA)
     add_headers_and_sources(dbms src/Storages/Kafka)
@@ -139,6 +139,9 @@ if (NOT ENABLE_SSL)
 endif ()
 
 add_library(clickhouse_common_io ${clickhouse_common_io_headers} ${clickhouse_common_io_sources})
+
+add_library (clickhouse_malloc OBJECT src/Common/malloc.cpp)
+set_source_files_properties(src/Common/malloc.cpp PROPERTIES COMPILE_FLAGS "-fno-builtin")
 
 add_library (clickhouse_new_delete STATIC src/Common/new_delete.cpp)
 target_link_libraries (clickhouse_new_delete PRIVATE clickhouse_common_io)

--- a/dbms/programs/odbc-bridge/CMakeLists.txt
+++ b/dbms/programs/odbc-bridge/CMakeLists.txt
@@ -30,11 +30,6 @@ if (Poco_Data_FOUND)
     set(CLICKHOUSE_ODBC_BRIDGE_LINK ${CLICKHOUSE_ODBC_BRIDGE_LINK} PRIVATE ${Poco_Data_LIBRARY})
     set(CLICKHOUSE_ODBC_BRIDGE_INCLUDE ${CLICKHOUSE_ODBC_BRIDGE_INCLUDE} SYSTEM PRIVATE ${Poco_Data_INCLUDE_DIR})
 endif ()
-if (USE_JEMALLOC)
-    # We need to link jemalloc directly to odbc-bridge-library, because in other case
-    # we will build it with default malloc.
-    set(CLICKHOUSE_ODBC_BRIDGE_LINK ${CLICKHOUSE_ODBC_BRIDGE_LINK} PRIVATE ${JEMALLOC_LIBRARIES})
-endif()
 
 clickhouse_program_add_library(odbc-bridge)
 

--- a/dbms/src/Common/malloc.cpp
+++ b/dbms/src/Common/malloc.cpp
@@ -1,0 +1,40 @@
+#if defined(OS_LINUX)
+#include <stdlib.h>
+
+/// Interposing these symbols explicitly. The idea works like this: malloc.cpp compiles to a
+/// dedicated object (namely clickhouse_malloc.o), and it will show earlier in the link command
+/// than malloc libs like libjemalloc.a. As a result, these symbols get picked in time right after.
+extern "C"
+{
+    void *malloc(size_t size);
+    void free(void *ptr);
+    void *calloc(size_t nmemb, size_t size);
+    void *realloc(void *ptr, size_t size);
+    int posix_memalign(void **memptr, size_t alignment, size_t size);
+    void *aligned_alloc(size_t alignment, size_t size);
+    void *valloc(size_t size);
+    void *memalign(size_t alignment, size_t size);
+    void *pvalloc(size_t size);
+}
+
+template<typename T>
+inline void ignore(T x __attribute__((unused)))
+{
+}
+
+static void dummyFunctionForInterposing() __attribute__((used));
+static void dummyFunctionForInterposing()
+{
+    void* dummy;
+    /// Suppression for PVS-Studio.
+    free(nullptr); // -V575
+    ignore(malloc(0)); // -V575
+    ignore(calloc(0, 0)); // -V575
+    ignore(realloc(nullptr, 0)); // -V575
+    ignore(posix_memalign(&dummy, 0, 0)); // -V575
+    ignore(aligned_alloc(0, 0)); // -V575
+    ignore(valloc(0)); // -V575
+    ignore(memalign(0, 0)); // -V575
+    ignore(pvalloc(0)); // -V575
+}
+#endif


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):

This pr reverts https://github.com/ClickHouse/ClickHouse/pull/8028 and tries to interpose all malloc symbols correctly. 

@alesapin Could you help check if it's indeed working? I cannot reproduce the issue before even without your pr.