### PR TITLE
porting clock_gettime and clock_nanosleep

### DIFF
--- a/libs/libglibc-compatibility/CMakeLists.txt
+++ b/libs/libglibc-compatibility/CMakeLists.txt
@@ -31,6 +31,9 @@ if (GLIBC_COMPATIBILITY)
         list(APPEND glibc_compatibility_sources libcxxabi/cxa_thread_atexit.cpp)
     endif()
 
+    # Need to omit frame pointers to match the performance of glibc
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fomit-frame-pointer")
+
     add_library(glibc-compatibility STATIC ${glibc_compatibility_sources})
 
     target_include_directories(glibc-compatibility PRIVATE libcxxabi ${musl_arch_include_dir})

--- a/libs/libglibc-compatibility/musl/aarch64/syscall_arch.h
+++ b/libs/libglibc-compatibility/musl/aarch64/syscall_arch.h
@@ -1,0 +1,3 @@
+#define VDSO_USEFUL
+#define VDSO_CGT_SYM "__kernel_clock_gettime"
+#define VDSO_CGT_VER "LINUX_2.6.39"

--- a/libs/libglibc-compatibility/musl/clock_gettime.c
+++ b/libs/libglibc-compatibility/musl/clock_gettime.c
@@ -5,21 +5,104 @@
 #include "musl_features.h"
 #include "syscall.h"
 
-int __clock_gettime(clockid_t clk, struct timespec * ts)
+#ifdef VDSO_CGT_SYM
+
+static void *volatile vdso_func;
+
+#ifdef VDSO_CGT32_SYM
+static void *volatile vdso_func_32;
+static int cgt_time32_wrap(clockid_t clk, struct timespec *ts)
 {
-    int r;
-    r = __syscall(SYS_clock_gettime, clk, ts);
-    if (r == -ENOSYS)
-    {
-        if (clk == CLOCK_REALTIME)
-        {
-            __syscall(SYS_gettimeofday, ts, 0);
-            ts->tv_nsec = (int)ts->tv_nsec * 1000;
-            return 0;
-        }
-        r = -EINVAL;
-    }
-    return __syscall_ret(r);
+	long ts32[2];
+	int (*f)(clockid_t, long[2]) =
+		(int (*)(clockid_t, long[2]))vdso_func_32;
+	int r = f(clk, ts32);
+	if (!r) {
+		/* Fallback to syscalls if time32 overflowed. Maybe
+		 * we lucked out and somehow migrated to a kernel with
+		 * time64 syscalls available. */
+		if (ts32[0] < 0) {
+			a_cas_p(&vdso_func, (void *)cgt_time32_wrap, 0);
+			return -ENOSYS;
+		}
+		ts->tv_sec = ts32[0];
+		ts->tv_nsec = ts32[1];
+	}
+	return r;
+}
+#endif
+
+static int cgt_init(clockid_t clk, struct timespec *ts)
+{
+	void *p = __vdsosym(VDSO_CGT_VER, VDSO_CGT_SYM);
+#ifdef VDSO_CGT32_SYM
+	if (!p) {
+		void *q = __vdsosym(VDSO_CGT32_VER, VDSO_CGT32_SYM);
+		if (q) {
+			a_cas_p(&vdso_func_32, 0, q);
+			p = cgt_time32_wrap;
+		}
+	}
+#endif
+	int (*f)(clockid_t, struct timespec *) =
+		(int (*)(clockid_t, struct timespec *))p;
+	a_cas_p(&vdso_func, (void *)cgt_init, p);
+	return f ? f(clk, ts) : -ENOSYS;
+}
+
+static void *volatile vdso_func = (void *)cgt_init;
+
+#endif
+
+int __clock_gettime(clockid_t clk, struct timespec *ts)
+{
+	int r;
+
+#ifdef VDSO_CGT_SYM
+	int (*f)(clockid_t, struct timespec *) =
+		(int (*)(clockid_t, struct timespec *))vdso_func;
+	if (f) {
+		r = f(clk, ts);
+		if (!r) return r;
+		if (r == -EINVAL) return __syscall_ret(r);
+		/* Fall through on errors other than EINVAL. Some buggy
+		 * vdso implementations return ENOSYS for clocks they
+		 * can't handle, rather than making the syscall. This
+		 * also handles the case where cgt_init fails to find
+		 * a vdso function to use. */
+	}
+#endif
+
+#ifdef SYS_clock_gettime64
+	r = -ENOSYS;
+	if (sizeof(time_t) > 4)
+		r = __syscall(SYS_clock_gettime64, clk, ts);
+	if (SYS_clock_gettime == SYS_clock_gettime64 || r!=-ENOSYS)
+		return __syscall_ret(r);
+	long ts32[2];
+	r = __syscall(SYS_clock_gettime, clk, ts32);
+	if (r==-ENOSYS && clk==CLOCK_REALTIME) {
+		r = __syscall(SYS_gettimeofday, ts32, 0);
+		ts32[1] *= 1000;
+	}
+	if (!r) {
+		ts->tv_sec = ts32[0];
+		ts->tv_nsec = ts32[1];
+		return r;
+	}
+	return __syscall_ret(r);
+#else
+	r = __syscall(SYS_clock_gettime, clk, ts);
+	if (r == -ENOSYS) {
+		if (clk == CLOCK_REALTIME) {
+			__syscall(SYS_gettimeofday, ts, 0);
+			ts->tv_nsec = (int)ts->tv_nsec * 1000;
+			return 0;
+		}
+		r = -EINVAL;
+	}
+	return __syscall_ret(r);
+#endif
 }
 
 weak_alias(__clock_gettime, clock_gettime);

--- a/libs/libglibc-compatibility/musl/clock_gettime.c
+++ b/libs/libglibc-compatibility/musl/clock_gettime.c
@@ -1,0 +1,25 @@
+#include <errno.h>
+#include <stdint.h>
+#include <time.h>
+#include "atomic.h"
+#include "musl_features.h"
+#include "syscall.h"
+
+int __clock_gettime(clockid_t clk, struct timespec * ts)
+{
+    int r;
+    r = __syscall(SYS_clock_gettime, clk, ts);
+    if (r == -ENOSYS)
+    {
+        if (clk == CLOCK_REALTIME)
+        {
+            __syscall(SYS_gettimeofday, ts, 0);
+            ts->tv_nsec = (int)ts->tv_nsec * 1000;
+            return 0;
+        }
+        r = -EINVAL;
+    }
+    return __syscall_ret(r);
+}
+
+weak_alias(__clock_gettime, clock_gettime);

--- a/libs/libglibc-compatibility/musl/clock_nanosleep.c
+++ b/libs/libglibc-compatibility/musl/clock_nanosleep.c
@@ -1,0 +1,27 @@
+#include <errno.h>
+#include <pthread.h>
+#include <time.h>
+#include "musl_features.h"
+#include "syscall.h"
+
+int __clock_nanosleep(clockid_t clk, int flags, const struct timespec * req, struct timespec * rem)
+{
+    if (clk == CLOCK_THREAD_CPUTIME_ID)
+        return EINVAL;
+    int old_cancel_type;
+    int status;
+    /// We cannot port __syscall_cp because musl has very limited cancellation point implementation.
+    /// For example, c++ destructors won't get called and exception unwinding isn't implemented.
+    /// Instead, we use normal __syscall here and turn on the asynchrous cancel mode to allow
+    /// cancel. This works because nanosleep doesn't contain any resource allocations or
+    /// deallocations.
+    pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, &old_cancel_type);
+    if (clk == CLOCK_REALTIME && !flags)
+        status = -__syscall(SYS_nanosleep, req, rem);
+    else
+        status = -__syscall(SYS_clock_nanosleep, clk, flags, req, rem);
+    pthread_setcanceltype(old_cancel_type, NULL);
+    return status;
+}
+
+weak_alias(__clock_nanosleep, clock_nanosleep);

--- a/libs/libglibc-compatibility/musl/sched_getcpu.c
+++ b/libs/libglibc-compatibility/musl/sched_getcpu.c
@@ -1,13 +1,10 @@
 #define _GNU_SOURCE
 #include <errno.h>
 #include <sched.h>
-#include <syscall.h>
 #include "syscall.h"
 #include "atomic.h"
 
 #ifdef VDSO_GETCPU_SYM
-
-void *__vdsosym(const char *, const char *);
 
 static void *volatile vdso_func;
 

--- a/libs/libglibc-compatibility/musl/syscall.h
+++ b/libs/libglibc-compatibility/musl/syscall.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <sys/syscall.h>
+
 typedef long syscall_arg_t;
 
 __attribute__((visibility("hidden")))

--- a/libs/libglibc-compatibility/musl/syscall.h
+++ b/libs/libglibc-compatibility/musl/syscall.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <sys/syscall.h>
+#include <syscall_arch.h>
 
 typedef long syscall_arg_t;
 
@@ -9,3 +10,6 @@ long __syscall_ret(unsigned long);
 
 __attribute__((visibility("hidden")))
 long __syscall(syscall_arg_t, ...);
+
+__attribute__((visibility("hidden")))
+void *__vdsosym(const char *, const char *);

--- a/libs/libglibc-compatibility/musl/vdso.c
+++ b/libs/libglibc-compatibility/musl/vdso.c
@@ -1,0 +1,92 @@
+#include <elf.h>
+#include <link.h>
+#include <limits.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/auxv.h>
+#include "syscall.h"
+
+#ifdef VDSO_USEFUL
+
+#if ULONG_MAX == 0xffffffff
+typedef Elf32_Ehdr Ehdr;
+typedef Elf32_Phdr Phdr;
+typedef Elf32_Sym Sym;
+typedef Elf32_Verdef Verdef;
+typedef Elf32_Verdaux Verdaux;
+#else
+typedef Elf64_Ehdr Ehdr;
+typedef Elf64_Phdr Phdr;
+typedef Elf64_Sym Sym;
+typedef Elf64_Verdef Verdef;
+typedef Elf64_Verdaux Verdaux;
+#endif
+
+static int checkver(Verdef *def, int vsym, const char *vername, char *strings)
+{
+	vsym &= 0x7fff;
+	for (;;) {
+		if (!(def->vd_flags & VER_FLG_BASE)
+		  && (def->vd_ndx & 0x7fff) == vsym)
+			break;
+		if (def->vd_next == 0)
+			return 0;
+		def = (Verdef *)((char *)def + def->vd_next);
+	}
+	Verdaux *aux = (Verdaux *)((char *)def + def->vd_aux);
+	return !strcmp(vername, strings + aux->vda_name);
+}
+
+#define OK_TYPES (1<<STT_NOTYPE | 1<<STT_OBJECT | 1<<STT_FUNC | 1<<STT_COMMON)
+#define OK_BINDS (1<<STB_GLOBAL | 1<<STB_WEAK | 1<<STB_GNU_UNIQUE)
+
+void *__vdsosym(const char *vername, const char *name)
+{
+	size_t i;
+
+	// We don't have libc struct available here. Use getauxval instead.
+	Ehdr *eh = (void *)getauxval(AT_SYSINFO_EHDR);
+	Phdr *ph = (void *)((char *)eh + eh->e_phoff);
+	size_t *dynv=0, base=-1;
+	for (i=0; i<eh->e_phnum; i++, ph=(void *)((char *)ph+eh->e_phentsize)) {
+		if (ph->p_type == PT_LOAD)
+			base = (size_t)eh + ph->p_offset - ph->p_vaddr;
+		else if (ph->p_type == PT_DYNAMIC)
+			dynv = (void *)((char *)eh + ph->p_offset);
+	}
+	if (!dynv || base==(size_t)-1) return 0;
+
+	char *strings = 0;
+	Sym *syms = 0;
+	Elf_Symndx *hashtab = 0;
+	uint16_t *versym = 0;
+	Verdef *verdef = 0;
+
+	for (i=0; dynv[i]; i+=2) {
+		void *p = (void *)(base + dynv[i+1]);
+		switch(dynv[i]) {
+		case DT_STRTAB: strings = p; break;
+		case DT_SYMTAB: syms = p; break;
+		case DT_HASH: hashtab = p; break;
+		case DT_VERSYM: versym = p; break;
+		case DT_VERDEF: verdef = p; break;
+		}
+	}
+
+	if (!strings || !syms || !hashtab) return 0;
+	if (!verdef) versym = 0;
+
+	for (i=0; i<hashtab[1]; i++) {
+		if (!(1<<(syms[i].st_info&0xf) & OK_TYPES)) continue;
+		if (!(1<<(syms[i].st_info>>4) & OK_BINDS)) continue;
+		if (!syms[i].st_shndx) continue;
+		if (strcmp(name, strings+syms[i].st_name)) continue;
+		if (versym && !checkver(verdef, versym[i], vername, strings))
+			continue;
+		return (void *)(base + syms[i].st_value);
+	}
+
+	return 0;
+}
+
+#endif

--- a/libs/libglibc-compatibility/musl/vdso.c
+++ b/libs/libglibc-compatibility/musl/vdso.c
@@ -40,12 +40,25 @@ static int checkver(Verdef *def, int vsym, const char *vername, char *strings)
 #define OK_TYPES (1<<STT_NOTYPE | 1<<STT_OBJECT | 1<<STT_FUNC | 1<<STT_COMMON)
 #define OK_BINDS (1<<STB_GLOBAL | 1<<STB_WEAK | 1<<STB_GNU_UNIQUE)
 
+extern char** environ;
+static Ehdr *eh = NULL;
+void *__vdsosym(const char *vername, const char *name);
+// We don't have libc struct available here. Compute aux vector manually.
+__attribute__((constructor)) static void auxv_init()
+{
+	size_t i, *auxv;
+	for (i=0; environ[i]; i++);
+	auxv = (void *)(environ+i+1);
+	for (i=0; auxv[i] != AT_SYSINFO_EHDR; i+=2)
+		if (!auxv[i]) return;
+	if (!auxv[i+1]) return;
+	eh = (void *)auxv[i+1];
+}
+
 void *__vdsosym(const char *vername, const char *name)
 {
 	size_t i;
 
-	// We don't have libc struct available here. Use getauxval instead.
-	Ehdr *eh = (void *)getauxval(AT_SYSINFO_EHDR);
 	Phdr *ph = (void *)((char *)eh + eh->e_phoff);
 	size_t *dynv=0, base=-1;
 	for (i=0; i<eh->e_phnum; i++, ph=(void *)((char *)ph+eh->e_phentsize)) {

--- a/libs/libglibc-compatibility/musl/vdso.c
+++ b/libs/libglibc-compatibility/musl/vdso.c
@@ -58,7 +58,7 @@ __attribute__((constructor)) static void auxv_init()
 void *__vdsosym(const char *vername, const char *name)
 {
 	size_t i;
-
+	if (!eh) return 0;
 	Phdr *ph = (void *)((char *)eh + eh->e_phoff);
 	size_t *dynv=0, base=-1;
 	for (i=0; i<eh->e_phnum; i++, ph=(void *)((char *)ph+eh->e_phentsize)) {

--- a/libs/libglibc-compatibility/musl/x86_64/syscall_arch.h
+++ b/libs/libglibc-compatibility/musl/x86_64/syscall_arch.h
@@ -1,0 +1,5 @@
+#define VDSO_USEFUL
+#define VDSO_CGT_SYM "__vdso_clock_gettime"
+#define VDSO_CGT_VER "LINUX_2.6"
+#define VDSO_GETCPU_SYM "__vdso_getcpu"
+#define VDSO_GETCPU_VER "LINUX_2.6"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):

glibc2.30 removes the faulty ifunc compat redirects of clock_gettime and clock_nanosleep. Linking to librt won't help anymore. 