### PR TITLE
Improved getting ClickHouse server pid in clickhouse-test

### DIFF
--- a/dbms/tests/clickhouse-test
+++ b/dbms/tests/clickhouse-test
@@ -104,7 +104,7 @@ def get_stacktraces(server_pid):
 
 
 def get_server_pid(server_tcp_port):
-    cmd = "lsof -i tcp:{port} | grep '*:{port}'".format(port=server_tcp_port)
+    cmd = "lsof -i tcp:{port} | fgrep 'TCP *:{port} (LISTEN)'".format(port=server_tcp_port)
     try:
         output = subprocess.check_output(cmd, shell=True)
         if output:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Improved expression for getting clickhouse-server pid in clickhouse-test

Detailed description (optional):
Current implementation of `get_server_pid()` in clickhouse-test occasionally does not return correct pid of clickhouse-server process, which makes it difficult to investigate hung queries