### PR TITLE
build fix

### DIFF
--- a/dbms/src/Interpreters/Join.cpp
+++ b/dbms/src/Interpreters/Join.cpp
@@ -403,7 +403,7 @@ namespace
         Join & join, Map & map, size_t rows, const ColumnRawPtrs & key_columns,
         const Sizes & key_sizes, Block * stored_block, ConstNullMapPtr null_map, Arena & pool)
     {
-        constexpr bool mapped_one = std::is_same_v<typename Map::mapped_type, JoinStuff::MappedOne> ||
+        [[maybe_unused]] constexpr bool mapped_one = std::is_same_v<typename Map::mapped_type, JoinStuff::MappedOne> ||
                                     std::is_same_v<typename Map::mapped_type, JoinStuff::MappedOneFlagged>;
         constexpr bool is_asof_join = STRICTNESS == ASTTableJoin::Strictness::Asof;
 
@@ -1123,7 +1123,7 @@ struct AdderNonJoined
     static void add(const Mapped & mapped, size_t & rows_added, MutableColumns & columns_right)
     {
         constexpr bool mapped_asof = std::is_same_v<Mapped, JoinStuff::MappedAsof>;
-        constexpr bool mapped_one = std::is_same_v<Mapped, JoinStuff::MappedOne> || std::is_same_v<Mapped, JoinStuff::MappedOneFlagged>;
+        [[maybe_unused]] constexpr bool mapped_one = std::is_same_v<Mapped, JoinStuff::MappedOne> || std::is_same_v<Mapped, JoinStuff::MappedOneFlagged>;
 
         if constexpr (mapped_asof)
         {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Fix build error in `Join.cpp`:

```
../dbms/src/Interpreters/Join.cpp:406:24: error: variable ‘mapped_one’ set but not used [-Werror=unused-but-set-variable]
```
```
../dbms/src/Interpreters/Join.cpp:1126:40: error: variable ‘mapped_one’ set but not used [-Werror=unused-but-set-variable]
```