### PR TITLE
FREEZE TABLE

### DIFF
--- a/dbms/src/Interpreters/InterpreterFactory.cpp
+++ b/dbms/src/Interpreters/InterpreterFactory.cpp
@@ -7,6 +7,7 @@
 #include <Parsers/ASTInsertQuery.h>
 #include <Parsers/ASTKillQueryQuery.h>
 #include <Parsers/ASTOptimizeQuery.h>
+#include <Parsers/ASTFreezeQuery.h>
 #include <Parsers/ASTRenameQuery.h>
 #include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
@@ -30,6 +31,7 @@
 #include <Interpreters/InterpreterDropQuery.h>
 #include <Interpreters/InterpreterExistsQuery.h>
 #include <Interpreters/InterpreterFactory.h>
+#include <Interpreters/InterpreterFreezeQuery.h>
 #include <Interpreters/InterpreterInsertQuery.h>
 #include <Interpreters/InterpreterKillQueryQuery.h>
 #include <Interpreters/InterpreterOptimizeQuery.h>
@@ -177,6 +179,11 @@ std::unique_ptr<IInterpreter> InterpreterFactory::get(ASTPtr & query, Context & 
     {
         throwIfNoAccess(context);
         return std::make_unique<InterpreterAlterQuery>(query, context);
+    }
+    else if (query->as<ASTFreezeQuery>())
+    {
+        throwIfNoAccess(context);
+        return std::make_unique<InterpreterFreezeQuery>(query, context);
     }
     else if (query->as<ASTCheckQuery>())
     {

--- a/dbms/src/Interpreters/InterpreterFreezeQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterFreezeQuery.cpp
@@ -1,0 +1,51 @@
+#include <Interpreters/InterpreterFreezeQuery.h>
+
+#include <DataStreams/OneBlockInputStream.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/DDLWorker.h>
+#include <Parsers/ASTFreezeQuery.h>
+#include <Storages/IStorage.h>
+#include <Common/typeid_cast.h>
+
+
+namespace DB
+{
+
+BlockIO InterpreterFreezeQuery::execute()
+{
+    BlockIO res;
+    res.in = executeImpl();
+    return res;
+}
+
+
+Block InterpreterFreezeQuery::getSampleBlock()
+{
+    Block block;
+
+    ColumnWithTypeAndName col;
+    col.name = "increment";
+    col.type = std::make_shared<DataTypeUInt64>();
+    col.column = col.type->createColumn();
+    block.insert(col);
+
+    return block;
+}
+
+
+BlockInputStreamPtr InterpreterFreezeQuery::executeImpl()
+{
+    const auto & ast = query_ptr->as<ASTFreezeQuery &>();
+
+    StoragePtr table = context.getTable(ast.database, ast.table);
+    UInt64 increment = table->freeze(ast.partition, ast.with_name, context);
+
+    Block sample_block = getSampleBlock();
+    MutableColumns res_columns = sample_block.cloneEmptyColumns();
+    res_columns[0]->insert(increment);
+
+    return std::make_shared<OneBlockInputStream>(sample_block.cloneWithColumns(std::move(res_columns)));
+}
+
+}

--- a/dbms/src/Interpreters/InterpreterFreezeQuery.h
+++ b/dbms/src/Interpreters/InterpreterFreezeQuery.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <Interpreters/IInterpreter.h>
+#include <Parsers/IAST_fwd.h>
+
+
+namespace DB
+{
+class Context;
+
+class InterpreterFreezeQuery : public IInterpreter
+{
+public:
+    InterpreterFreezeQuery(const ASTPtr & query_ptr_, Context & context_) : query_ptr(query_ptr_), context(context_) {}
+
+    BlockIO execute() override;
+
+    static Block getSampleBlock();
+
+private:
+    ASTPtr query_ptr;
+    Context & context;
+
+    BlockInputStreamPtr executeImpl();
+};
+
+}

--- a/dbms/src/Parsers/ASTFreezeQuery.cpp
+++ b/dbms/src/Parsers/ASTFreezeQuery.cpp
@@ -1,0 +1,27 @@
+#include <Parsers/ASTFreezeQuery.h>
+#include <Common/quoteString.h>
+
+#include <iomanip>
+
+
+namespace DB
+{
+void ASTFreezeQuery::formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+{
+    settings.ostr << (settings.hilite ? hilite_keyword : "") << "FREEZE TABLE " << (settings.hilite ? hilite_none : "")
+                  << (!database.empty() ? backQuoteIfNeed(database) + "." : "") << backQuoteIfNeed(table);
+
+    if (partition)
+    {
+        settings.ostr << (settings.hilite ? hilite_keyword : "") << " PARTITION " << (settings.hilite ? hilite_none : "");
+        partition->formatImpl(settings, state, frame);
+    }
+
+    if (!with_name.empty())
+    {
+        settings.ostr << " " << (settings.hilite ? hilite_keyword : "") << "WITH NAME" << (settings.hilite ? hilite_none : "")
+                      << " " << std::quoted(with_name, '\'');
+    }
+}
+
+}

--- a/dbms/src/Parsers/ASTFreezeQuery.h
+++ b/dbms/src/Parsers/ASTFreezeQuery.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <Parsers/ASTQueryWithTableAndOutput.h>
+#include <Parsers/IAST.h>
+
+namespace DB
+{
+/** FREEZE query
+  */
+class ASTFreezeQuery : public ASTQueryWithTableAndOutput
+{
+public:
+    /// The partition to be frozen can be specified.
+    ASTPtr partition;
+
+    String with_name;
+
+    /** Get the text that identifies this element. */
+    String getID(char delim) const override { return "FreezeQuery" + (delim + database) + delim + table; }
+
+    ASTPtr clone() const override
+    {
+        auto res = std::make_shared<ASTFreezeQuery>(*this);
+        res->children.clear();
+
+        if (partition)
+        {
+            res->partition = partition->clone();
+            res->children.push_back(res->partition);
+        }
+
+        return res;
+    }
+
+    void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+};
+
+}

--- a/dbms/src/Parsers/ParserFreezeQuery.cpp
+++ b/dbms/src/Parsers/ParserFreezeQuery.cpp
@@ -1,0 +1,54 @@
+#include <Parsers/ASTFreezeQuery.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTLiteral.h>
+#include <Parsers/CommonParsers.h>
+#include <Parsers/ParserFreezeQuery.h>
+#include <Parsers/ParserPartition.h>
+#include <Parsers/parseDatabaseAndTableName.h>
+
+
+namespace DB
+{
+bool ParserFreezeQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+{
+    ParserKeyword s_freeze_table("FREEZE TABLE");
+    ParserKeyword s_partition("PARTITION");
+
+    ParserKeyword s_with("WITH");
+    ParserKeyword s_name("NAME");
+
+    ParserStringLiteral string_literal_p;
+    ParserPartition partition_p;
+
+    auto query = std::make_shared<ASTFreezeQuery>();
+    node = query;
+
+    if (!s_freeze_table.ignore(pos, expected))
+        return false;
+
+    if (!parseDatabaseAndTableName(pos, expected, query->database, query->table))
+        return false;
+
+    if (s_partition.ignore(pos, expected))
+    {
+        if (!partition_p.parse(pos, query->partition, expected))
+            return false;
+    }
+
+    /// WITH NAME 'name' - place local backup to directory with specified name
+    if (s_with.ignore(pos, expected))
+    {
+        if (!s_name.ignore(pos, expected))
+            return false;
+
+        ASTPtr ast_with_name;
+        if (!string_literal_p.parse(pos, ast_with_name, expected))
+            return false;
+
+        query->with_name = ast_with_name->as<ASTLiteral &>().value.get<const String &>();
+    }
+
+    return true;
+}
+
+}

--- a/dbms/src/Parsers/ParserFreezeQuery.h
+++ b/dbms/src/Parsers/ParserFreezeQuery.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <Parsers/IParserBase.h>
+#include <Parsers/ExpressionElementParsers.h>
+
+
+namespace DB
+{
+
+/** Query FREEZE TABLE [db.]name [PARTITION partition]
+  */
+class ParserFreezeQuery : public IParserBase
+{
+protected:
+    const char * getName() const { return "FREEZE query"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+};
+
+}

--- a/dbms/src/Parsers/ParserQueryWithOutput.cpp
+++ b/dbms/src/Parsers/ParserQueryWithOutput.cpp
@@ -11,6 +11,7 @@
 #include <Parsers/ParserDropQuery.h>
 #include <Parsers/ParserKillQueryQuery.h>
 #include <Parsers/ParserOptimizeQuery.h>
+#include <Parsers/ParserFreezeQuery.h>
 #include <Parsers/ParserWatchQuery.h>
 #include <Parsers/ParserSetQuery.h>
 #include <Parsers/ASTExplainQuery.h>
@@ -34,6 +35,7 @@ bool ParserQueryWithOutput::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     ParserDropQuery drop_p;
     ParserCheckQuery check_p;
     ParserOptimizeQuery optimize_p;
+    ParserFreezeQuery freeze_p;
     ParserKillQueryQuery kill_query_p;
     ParserWatchQuery watch_p;
     ParserShowCreateAccessEntityQuery show_create_access_entity_p;
@@ -65,6 +67,7 @@ bool ParserQueryWithOutput::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
         || check_p.parse(pos, query, expected)
         || kill_query_p.parse(pos, query, expected)
         || optimize_p.parse(pos, query, expected)
+        || freeze_p.parse(pos, query, expected)
         || watch_p.parse(pos, query, expected)
         || show_quotas_p.parse(pos, query, expected);
 

--- a/dbms/src/Storages/IStorage.h
+++ b/dbms/src/Storages/IStorage.h
@@ -332,6 +332,11 @@ public:
         throw Exception("Method optimize is not supported by storage " + getName(), ErrorCodes::NOT_IMPLEMENTED);
     }
 
+    virtual UInt64 freeze(const ASTPtr & /*partition*/, const String & /* with_name */, const Context & /*context*/)
+    {
+        throw Exception("Method freeze is not supported by storage " + getName(), ErrorCodes::NOT_IMPLEMENTED);
+    }
+
     /// Mutate the table contents
     virtual void mutate(const MutationCommands &, const Context &)
     {

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3317,12 +3317,12 @@ MergeTreeData::MatcherFn MergeTreeData::freezePartitionMatcher(const ASTPtr & pa
         partition_id = getPartitionIDFromQuery(partition_ast, context);
 
     if (prefix)
-        return [&prefix](const DataPartPtr & part)
+        return [prefix](const DataPartPtr & part)
         {
             return startsWith(part->info.partition_id, *prefix);
         };
     else
-        return [&partition_id](const DataPartPtr & part)
+        return [partition_id](const DataPartPtr & part)
         {
             return part->info.partition_id == partition_id;
         };

--- a/dbms/src/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.h
@@ -568,9 +568,6 @@ public:
     /// Remove columns, that have been markedd as empty after zeroing values with expired ttl
     void removeEmptyColumnsFromPart(MergeTreeData::MutableDataPartPtr & data_part);
 
-    /// Freezes all parts.
-    UInt64 freezeAll(const String & with_name, const Context & context, TableStructureReadLockHolder & table_lock_holder);
-
     /// Should be called if part data is suspected to be corrupted.
     void reportBrokenPart(const String & name) const
     {
@@ -597,8 +594,7 @@ public:
       * Backup is created in directory clickhouse_dir/shadow/i/, where i - incremental number,
       *  or if 'with_name' is specified - backup is created in directory with specified name.
       */
-    UInt64 freezePartition(const ASTPtr & partition, const String & with_name, const Context & context, TableStructureReadLockHolder & table_lock_holder);
-
+    UInt64 freeze(const ASTPtr & partition_ast, const String & with_name, const Context & context) override;
 
 public:
     /// Moves partition to specified Disk
@@ -913,9 +909,10 @@ protected:
     /// Checks whether the column is in the primary key, possibly wrapped in a chain of functions with single argument.
     bool isPrimaryOrMinMaxKeyColumnPossiblyWrappedInFunctions(const ASTPtr & node) const;
 
-    /// Common part for |freezePartition()| and |freezeAll()|.
+    /// Common part for |freeze()|.
     using MatcherFn = std::function<bool(const DataPartPtr &)>;
-    UInt64 freezePartitionsByMatcher(MatcherFn matcher, const String & with_name, const Context & context);
+    MatcherFn freezePartitionMatcher(const ASTPtr & partition_ast, const Context & context);
+    UInt64 freezePartitionsByMatcher(const MatcherFn& matcher, const String & with_name, const Context & context);
 
     bool canReplacePartition(const DataPartPtr & data_part) const;
 

--- a/dbms/src/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.h
@@ -569,7 +569,7 @@ public:
     void removeEmptyColumnsFromPart(MergeTreeData::MutableDataPartPtr & data_part);
 
     /// Freezes all parts.
-    void freezeAll(const String & with_name, const Context & context, TableStructureReadLockHolder & table_lock_holder);
+    UInt64 freezeAll(const String & with_name, const Context & context, TableStructureReadLockHolder & table_lock_holder);
 
     /// Should be called if part data is suspected to be corrupted.
     void reportBrokenPart(const String & name) const
@@ -597,7 +597,7 @@ public:
       * Backup is created in directory clickhouse_dir/shadow/i/, where i - incremental number,
       *  or if 'with_name' is specified - backup is created in directory with specified name.
       */
-    void freezePartition(const ASTPtr & partition, const String & with_name, const Context & context, TableStructureReadLockHolder & table_lock_holder);
+    UInt64 freezePartition(const ASTPtr & partition, const String & with_name, const Context & context, TableStructureReadLockHolder & table_lock_holder);
 
 
 public:
@@ -915,7 +915,7 @@ protected:
 
     /// Common part for |freezePartition()| and |freezeAll()|.
     using MatcherFn = std::function<bool(const DataPartPtr &)>;
-    void freezePartitionsByMatcher(MatcherFn matcher, const String & with_name, const Context & context);
+    UInt64 freezePartitionsByMatcher(MatcherFn matcher, const String & with_name, const Context & context);
 
     bool canReplacePartition(const DataPartPtr & data_part) const;
 

--- a/dbms/src/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.h
@@ -912,7 +912,7 @@ protected:
     /// Common part for |freeze()|.
     using MatcherFn = std::function<bool(const DataPartPtr &)>;
     MatcherFn freezePartitionMatcher(const ASTPtr & partition_ast, const Context & context);
-    UInt64 freezePartitionsByMatcher(const MatcherFn& matcher, const String & with_name, const Context & context);
+    UInt64 freezePartitionsByMatcher(const MatcherFn & matcher, const String & with_name, const Context & context);
 
     bool canReplacePartition(const DataPartPtr & data_part) const;
 

--- a/dbms/src/Storages/StorageMergeTree.cpp
+++ b/dbms/src/Storages/StorageMergeTree.cpp
@@ -966,21 +966,6 @@ bool StorageMergeTree::optimize(
 }
 
 
-UInt64 StorageMergeTree::freeze(const ASTPtr & partition, const String & with_name, const Context & query_context)
-{
-    auto lock = lockStructureForShare(false, query_context.getCurrentQueryId());
-
-    if (partition)
-    {
-        return freezePartition(partition, with_name, query_context, lock);
-    }
-    else
-    {
-        return freezeAll(with_name, query_context, lock);
-    }
-}
-
-
 void StorageMergeTree::alterPartition(const ASTPtr & query, const PartitionCommands & commands, const Context & context)
 {
     for (const PartitionCommand & command : commands)

--- a/dbms/src/Storages/StorageMergeTree.h
+++ b/dbms/src/Storages/StorageMergeTree.h
@@ -55,8 +55,6 @@ public:
       */
     bool optimize(const ASTPtr & query, const ASTPtr & partition, bool final, bool deduplicate, const Context & context) override;
 
-    UInt64 freeze(const ASTPtr & partition, const String & with_name, const Context & query_context) override;
-
     void alterPartition(const ASTPtr & query, const PartitionCommands & commands, const Context & context) override;
 
     void mutate(const MutationCommands & commands, const Context & context) override;

--- a/dbms/src/Storages/StorageMergeTree.h
+++ b/dbms/src/Storages/StorageMergeTree.h
@@ -55,6 +55,8 @@ public:
       */
     bool optimize(const ASTPtr & query, const ASTPtr & partition, bool final, bool deduplicate, const Context & context) override;
 
+    UInt64 freeze(const ASTPtr & partition, const String & with_name, const Context & query_context) override;
+
     void alterPartition(const ASTPtr & query, const PartitionCommands & commands, const Context & context) override;
 
     void mutate(const MutationCommands & commands, const Context & context) override;

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -3145,21 +3145,6 @@ bool StorageReplicatedMergeTree::optimize(const ASTPtr & query, const ASTPtr & p
 }
 
 
-UInt64 StorageReplicatedMergeTree::freeze(const ASTPtr & partition, const String & with_name, const Context & query_context)
-{
-    auto lock = lockStructureForShare(false, query_context.getCurrentQueryId());
-
-    if (partition)
-    {
-        return freezePartition(partition, with_name, query_context, lock);
-    }
-    else
-    {
-        return freezeAll(with_name, query_context, lock);
-    }
-}
-
-
 void StorageReplicatedMergeTree::alter(
     const AlterCommands & params, const Context & query_context, TableStructureWriteLockHolder & table_lock_holder)
 {

--- a/dbms/src/Storages/StorageReplicatedMergeTree.h
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.h
@@ -105,6 +105,8 @@ public:
 
     bool optimize(const ASTPtr & query, const ASTPtr & partition, bool final, bool deduplicate, const Context & query_context) override;
 
+    UInt64 freeze(const ASTPtr & partition, const String & with_name, const Context & query_context) override;
+
     void alter(const AlterCommands & params, const Context & query_context, TableStructureWriteLockHolder & table_lock_holder) override;
 
     void alterPartition(const ASTPtr & query, const PartitionCommands & commands, const Context & query_context) override;

--- a/dbms/src/Storages/StorageReplicatedMergeTree.h
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.h
@@ -105,8 +105,6 @@ public:
 
     bool optimize(const ASTPtr & query, const ASTPtr & partition, bool final, bool deduplicate, const Context & query_context) override;
 
-    UInt64 freeze(const ASTPtr & partition, const String & with_name, const Context & query_context) override;
-
     void alter(const AlterCommands & params, const Context & query_context, TableStructureWriteLockHolder & table_lock_holder) override;
 
     void alterPartition(const ASTPtr & query, const PartitionCommands & commands, const Context & query_context) override;

--- a/dbms/tests/integration/test_freeze_table/test.py
+++ b/dbms/tests/integration/test_freeze_table/test.py
@@ -1,0 +1,56 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node")
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_freeze_table(started_cluster):
+    node.query('CREATE DATABASE IF NOT EXISTS test')
+    node.query('''
+        CREATE TABLE test.table
+        (
+          d Date
+        ) ENGINE = MergeTree(d, d, 8192);
+        ''')
+    node.query('''
+        INSERT INTO
+          test.table
+        VALUES
+          (toDate('2019-01-01')), (toDate('2019-02-01')), (toDate('2020-01-01'));
+        ''')
+
+    increment = int(node.query('''FREEZE TABLE test.table;'''))
+    assert 3 == int(node.exec_in_container(
+        ["bash", "-c", "ls -1 /var/lib/clickhouse/shadow/{}/data/test/table/ | wc -l".format(increment)]
+    )), "expected 3 parts in backup"
+
+    node.query('''FREEZE TABLE test.table WITH NAME 'custom-shadow-path';''')
+    assert 3 == int(node.exec_in_container(
+        ["bash", "-c", "ls -1 /var/lib/clickhouse/shadow/custom%2Dshadow%2Dpath/data/test/table/ | wc -l"]
+    )), "expected 3 parts in backup"
+
+    increment = int(node.query('''FREEZE TABLE test.table PARTITION 2019;'''))
+    assert 2 == int(node.exec_in_container(
+        ["bash", "-c", "ls -1 /var/lib/clickhouse/shadow/{}/data/test/table/ | wc -l".format(increment)]
+    )), "expected 3 parts in backup"
+
+    increment = int(node.query('''FREEZE TABLE test.table PARTITION 202001;'''))
+    assert 1 == int(node.exec_in_container(
+        ["bash", "-c", "ls -1 /var/lib/clickhouse/shadow/{}/data/test/table/ | wc -l".format(increment)]
+    )), "expected 3 parts in backup"
+
+    increment = int(node.query('''FREEZE TABLE test.table PARTITION 999;'''))
+    node.exec_in_container(
+        ["bash", "-c", "test ! -d /var/lib/clickhouse/shadow/{}/data/test/table/".format(increment)]
+    )

--- a/dbms/tests/queries/0_stateless/01043_mergetree_freezing.reference
+++ b/dbms/tests/queries/0_stateless/01043_mergetree_freezing.reference
@@ -1,0 +1,9 @@
+3
+1
+2
+---custom_partition---
+3
+0
+OK
+1
+1

--- a/dbms/tests/queries/0_stateless/01043_mergetree_freezing.sh
+++ b/dbms/tests/queries/0_stateless/01043_mergetree_freezing.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. $CURDIR/../shell_config.sh
+
+# Smoke tests for freeze partition.
+
+function test_freeze_date_partition() {
+  local suffix=$1
+
+  $CLICKHOUSE_CLIENT --multiquery <<EOF
+DROP TABLE IF EXISTS t_01043_freeze;
+CREATE TABLE t_01043_freeze
+(
+  d Date
+) ENGINE = MergeTree(d, d, 8192);
+
+INSERT INTO
+  t_01043_freeze
+VALUES
+  (toDate('2019-01-01')), (toDate('2019-02-01')), (toDate('2020-01-01'));
+EOF
+
+  $CLICKHOUSE_CLIENT --query "FREEZE TABLE t_01043_freeze $suffix" | grep -qP "\d+"
+  $CLICKHOUSE_CLIENT --query "SELECT count() FROM system.parts WHERE table = 't_01043_freeze' and is_frozen"
+}
+
+function test_freeze_custom_partition() {
+  local suffix=$1
+  local exception=$2
+
+  $CLICKHOUSE_CLIENT --multiquery <<EOF
+DROP TABLE IF EXISTS t_01043_freeze;
+CREATE TABLE t_01043_freeze
+(
+  d Date
+) ENGINE = MergeTree()
+  ORDER BY d
+  PARTITION BY d;
+
+INSERT INTO
+  t_01043_freeze
+VALUES
+  (toDate('2019-01-01')), (toDate('2019-02-01')), (toDate('2020-01-01'));
+EOF
+
+  if [[ ! -z $exception ]]; then
+    $CLICKHOUSE_CLIENT --query "FREEZE TABLE t_01043_freeze $suffix" --format Null 2>&1 |
+      grep -q "Cannot parse date" && echo "OK" || echo "FAIL"
+
+    return
+  fi
+
+  $CLICKHOUSE_CLIENT --query "FREEZE TABLE t_01043_freeze $suffix" | grep -qP "\d+"
+  $CLICKHOUSE_CLIENT --query "SELECT count() FROM system.parts WHERE table = 't_01043_freeze' and is_frozen"
+}
+
+test_freeze_date_partition ""
+test_freeze_date_partition "PARTITION 201901"
+test_freeze_date_partition "PARTITION '2019'"
+# test_freeze_date_partition "PARTITION ID '201901'" doesn't work in master either
+
+echo "---custom_partition---"
+
+test_freeze_custom_partition ""
+test_freeze_custom_partition "PARTITION 201901"
+test_freeze_custom_partition "PARTITION '2019'" "Cannot parse date"
+test_freeze_custom_partition "PARTITION '2020-01-01'"
+test_freeze_custom_partition "PARTITION ID '20190101'"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):

`FREEZE TABLE [db.]name [PARTITION partition_expr] [WITH NAME custom_dir]` returning snapshot id.


Detailed description (optional):

Possible solution to #7785. While implementing this discovered `ALTER TABLE ... FREEZE ... WITH NAME` syntax which with a random unique string can be used as a workaround.

Closes #7785.