### PR TITLE
FREEZE TABLE syntax returning snapshot details

### DIFF
--- a/dbms/Interpreters/InterpreterFactory.cpp
+++ b/dbms/Interpreters/InterpreterFactory.cpp
@@ -11,6 +11,7 @@
 #include <Parsers/ASTInsertQuery.h>
 #include <Parsers/ASTKillQueryQuery.h>
 #include <Parsers/ASTOptimizeQuery.h>
+#include <Parsers/ASTFreezeQuery.h>
 #include <Parsers/ASTRenameQuery.h>
 #include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
@@ -42,6 +43,7 @@
 #include <Interpreters/InterpreterDropQuery.h>
 #include <Interpreters/InterpreterExistsQuery.h>
 #include <Interpreters/InterpreterFactory.h>
+#include <Interpreters/InterpreterFreezeQuery.h>
 #include <Interpreters/InterpreterInsertQuery.h>
 #include <Interpreters/InterpreterKillQueryQuery.h>
 #include <Interpreters/InterpreterOptimizeQuery.h>
@@ -173,6 +175,10 @@ std::unique_ptr<IInterpreter> InterpreterFactory::get(ASTPtr & query, Context & 
     else if (query->as<ASTAlterQuery>())
     {
         return std::make_unique<InterpreterAlterQuery>(query, context);
+    }
+    else if (query->as<ASTFreezeQuery>())
+    {
+        return std::make_unique<InterpreterFreezeQuery>(query, context);
     }
     else if (query->as<ASTCheckQuery>())
     {

--- a/dbms/Interpreters/InterpreterFreezeQuery.cpp
+++ b/dbms/Interpreters/InterpreterFreezeQuery.cpp
@@ -1,0 +1,63 @@
+#include <Access/AccessRightsElement.h>
+#include <Common/typeid_cast.h>
+#include <DataStreams/OneBlockInputStream.h>
+#include <DataTypes/DataTypeString.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/DDLWorker.h>
+#include <Interpreters/InterpreterFreezeQuery.h>
+#include <Parsers/ASTFreezeQuery.h>
+#include <Storages/IStorage.h>
+
+
+namespace DB
+{
+
+BlockIO InterpreterFreezeQuery::execute()
+{
+    BlockIO res;
+    res.in = executeImpl();
+    return res;
+}
+
+
+Block InterpreterFreezeQuery::getSampleBlock()
+{
+    Block block{
+        ColumnWithTypeAndName(std::make_shared<DataTypeString>(), "backup_name"),
+        ColumnWithTypeAndName(std::make_shared<DataTypeString>(), "partition"),
+        ColumnWithTypeAndName(std::make_shared<DataTypeString>(), "partition_id"),
+        ColumnWithTypeAndName(std::make_shared<DataTypeString>(), "part_name"),
+        ColumnWithTypeAndName(std::make_shared<DataTypeString>(), "backup_path"),
+    };
+
+    return block;
+}
+
+
+BlockInputStreamPtr InterpreterFreezeQuery::executeImpl()
+{
+    const auto & ast = query_ptr->as<ASTFreezeQuery &>();
+
+    context.checkAccess(AccessType::FREEZE_PARTITION, ast.database, ast.table);
+
+    auto table_id = context.resolveStorageID(ast, Context::ResolveOrdinary);
+    StoragePtr table = DatabaseCatalog::instance().getTable(table_id);
+
+    FreezeResult freeze_result = table->freeze(ast.partition, ast.with_name, context);
+
+    Block sample_block = getSampleBlock();
+    MutableColumns res_columns = sample_block.cloneEmptyColumns();
+
+    for (const FreezeResult::PartInfo & frozen_part : freeze_result.frozen_parts)
+    {
+        res_columns[0]->insert(freeze_result.backup_name);
+        res_columns[1]->insert(frozen_part.partition);
+        res_columns[2]->insert(frozen_part.partition_id);
+        res_columns[3]->insert(frozen_part.part_name);
+        res_columns[4]->insert(frozen_part.backup_path);
+    }
+
+    return std::make_shared<OneBlockInputStream>(sample_block.cloneWithColumns(std::move(res_columns)));
+}
+
+}

--- a/dbms/Interpreters/InterpreterFreezeQuery.h
+++ b/dbms/Interpreters/InterpreterFreezeQuery.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <Interpreters/IInterpreter.h>
+#include <Parsers/IAST_fwd.h>
+
+
+namespace DB
+{
+class Context;
+
+class InterpreterFreezeQuery : public IInterpreter
+{
+public:
+    InterpreterFreezeQuery(const ASTPtr & query_ptr_, Context & context_) : query_ptr(query_ptr_), context(context_) {}
+
+    BlockIO execute() override;
+
+    static Block getSampleBlock();
+
+private:
+    ASTPtr query_ptr;
+    Context & context;
+
+    BlockInputStreamPtr executeImpl();
+};
+
+}

--- a/dbms/Parsers/ASTFreezeQuery.cpp
+++ b/dbms/Parsers/ASTFreezeQuery.cpp
@@ -1,0 +1,27 @@
+#include <Parsers/ASTFreezeQuery.h>
+#include <Common/quoteString.h>
+
+#include <iomanip>
+
+
+namespace DB
+{
+void ASTFreezeQuery::formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+{
+    settings.ostr << (settings.hilite ? hilite_keyword : "") << "FREEZE TABLE " << (settings.hilite ? hilite_none : "")
+                  << (!database.empty() ? backQuoteIfNeed(database) + "." : "") << backQuoteIfNeed(table);
+
+    if (partition)
+    {
+        settings.ostr << (settings.hilite ? hilite_keyword : "") << " PARTITION " << (settings.hilite ? hilite_none : "");
+        partition->formatImpl(settings, state, frame);
+    }
+
+    if (!with_name.empty())
+    {
+        settings.ostr << " " << (settings.hilite ? hilite_keyword : "") << "WITH NAME" << (settings.hilite ? hilite_none : "")
+                      << " " << std::quoted(with_name, '\'');
+    }
+}
+
+}

--- a/dbms/Parsers/ASTFreezeQuery.h
+++ b/dbms/Parsers/ASTFreezeQuery.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <Parsers/ASTQueryWithTableAndOutput.h>
+#include <Parsers/IAST.h>
+
+namespace DB
+{
+/** FREEZE query
+  */
+class ASTFreezeQuery : public ASTQueryWithTableAndOutput
+{
+public:
+    /// The partition to be frozen can be specified.
+    ASTPtr partition;
+
+    String with_name;
+
+    /** Get the text that identifies this element. */
+    String getID(char delim) const override { return "FreezeQuery" + (delim + database) + delim + table; }
+
+    ASTPtr clone() const override
+    {
+        auto res = std::make_shared<ASTFreezeQuery>(*this);
+        res->children.clear();
+
+        if (partition)
+        {
+            res->partition = partition->clone();
+            res->children.push_back(res->partition);
+        }
+
+        return res;
+    }
+
+    void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+};
+
+}

--- a/dbms/Parsers/ParserFreezeQuery.cpp
+++ b/dbms/Parsers/ParserFreezeQuery.cpp
@@ -1,0 +1,54 @@
+#include <Parsers/ASTFreezeQuery.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTLiteral.h>
+#include <Parsers/CommonParsers.h>
+#include <Parsers/ParserFreezeQuery.h>
+#include <Parsers/ParserPartition.h>
+#include <Parsers/parseDatabaseAndTableName.h>
+
+
+namespace DB
+{
+bool ParserFreezeQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+{
+    ParserKeyword s_freeze_table("FREEZE TABLE");
+    ParserKeyword s_partition("PARTITION");
+
+    ParserKeyword s_with("WITH");
+    ParserKeyword s_name("NAME");
+
+    ParserStringLiteral string_literal_p;
+    ParserPartition partition_p;
+
+    auto query = std::make_shared<ASTFreezeQuery>();
+    node = query;
+
+    if (!s_freeze_table.ignore(pos, expected))
+        return false;
+
+    if (!parseDatabaseAndTableName(pos, expected, query->database, query->table))
+        return false;
+
+    if (s_partition.ignore(pos, expected))
+    {
+        if (!partition_p.parse(pos, query->partition, expected))
+            return false;
+    }
+
+    /// WITH NAME 'name' - place local backup to directory with specified name
+    if (s_with.ignore(pos, expected))
+    {
+        if (!s_name.ignore(pos, expected))
+            return false;
+
+        ASTPtr ast_with_name;
+        if (!string_literal_p.parse(pos, ast_with_name, expected))
+            return false;
+
+        query->with_name = ast_with_name->as<ASTLiteral &>().value.get<const String &>();
+    }
+
+    return true;
+}
+
+}

--- a/dbms/Parsers/ParserFreezeQuery.h
+++ b/dbms/Parsers/ParserFreezeQuery.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <Parsers/IParserBase.h>
+#include <Parsers/ExpressionElementParsers.h>
+
+
+namespace DB
+{
+
+/** Query FREEZE TABLE [db.]name [PARTITION partition]
+  */
+class ParserFreezeQuery : public IParserBase
+{
+protected:
+    const char * getName() const override { return "FREEZE query"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+};
+
+}

--- a/dbms/Parsers/ParserQueryWithOutput.cpp
+++ b/dbms/Parsers/ParserQueryWithOutput.cpp
@@ -11,6 +11,7 @@
 #include <Parsers/ParserDropQuery.h>
 #include <Parsers/ParserKillQueryQuery.h>
 #include <Parsers/ParserOptimizeQuery.h>
+#include <Parsers/ParserFreezeQuery.h>
 #include <Parsers/ParserWatchQuery.h>
 #include <Parsers/ParserSetQuery.h>
 #include <Parsers/ASTExplainQuery.h>
@@ -36,6 +37,7 @@ bool ParserQueryWithOutput::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     ParserDropQuery drop_p;
     ParserCheckQuery check_p;
     ParserOptimizeQuery optimize_p;
+    ParserFreezeQuery freeze_p;
     ParserKillQueryQuery kill_query_p;
     ParserWatchQuery watch_p;
     ParserShowCreateAccessEntityQuery show_create_access_entity_p;
@@ -69,6 +71,7 @@ bool ParserQueryWithOutput::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
         || check_p.parse(pos, query, expected)
         || kill_query_p.parse(pos, query, expected)
         || optimize_p.parse(pos, query, expected)
+        || freeze_p.parse(pos, query, expected)
         || watch_p.parse(pos, query, expected)
         || show_grants_p.parse(pos, query, expected)
         || show_quotas_p.parse(pos, query, expected)

--- a/dbms/Storages/FreezeResult.h
+++ b/dbms/Storages/FreezeResult.h
@@ -1,0 +1,30 @@
+#include <utility>
+
+#pragma once
+
+namespace DB
+{
+/// Result of FREEZE TABLE ... query.
+struct FreezeResult
+{
+    struct PartInfo
+    {
+        PartInfo(String partition_, String partition_id_, String part_name_, String backup_path_)
+            : partition(std::move(partition_))
+            , partition_id(std::move(partition_id_))
+            , part_name(std::move(part_name_))
+            , backup_path(std::move(backup_path_))
+        {
+        }
+
+        String partition;
+        String partition_id;
+        String part_name;
+        String backup_path;
+    };
+
+    String backup_name;
+    std::vector<PartInfo> frozen_parts;
+};
+
+}

--- a/dbms/Storages/IStorage.h
+++ b/dbms/Storages/IStorage.h
@@ -15,6 +15,7 @@
 #include <Storages/ConstraintsDescription.h>
 #include <Storages/StorageInMemoryMetadata.h>
 #include <Storages/ColumnDependency.h>
+#include <Storages/FreezeResult.h>
 #include <Common/ActionLock.h>
 #include <Common/Exception.h>
 #include <Common/RWLock.h>
@@ -360,6 +361,11 @@ public:
     virtual bool optimize(const ASTPtr & /*query*/, const ASTPtr & /*partition*/, bool /*final*/, bool /*deduplicate*/, const Context & /*context*/)
     {
         throw Exception("Method optimize is not supported by storage " + getName(), ErrorCodes::NOT_IMPLEMENTED);
+    }
+
+    virtual FreezeResult freeze(const ASTPtr & /*partition*/, const String & /* with_name */, const Context & /*context*/)
+    {
+        throw Exception("Method freeze is not supported by storage " + getName(), ErrorCodes::NOT_IMPLEMENTED);
     }
 
     /// Mutate the table contents

--- a/dbms/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/Storages/MergeTree/MergeTreeData.h
@@ -526,9 +526,6 @@ public:
            const ASTPtr & new_settings,
            TableStructureWriteLockHolder & table_lock_holder);
 
-    /// Freezes all parts.
-    void freezeAll(const String & with_name, const Context & context, TableStructureReadLockHolder & table_lock_holder);
-
     /// Should be called if part data is suspected to be corrupted.
     void reportBrokenPart(const String & name) const
     {
@@ -557,8 +554,7 @@ public:
       * Backup is created in directory clickhouse_dir/shadow/i/, where i - incremental number,
       *  or if 'with_name' is specified - backup is created in directory with specified name.
       */
-    void freezePartition(const ASTPtr & partition, const String & with_name, const Context & context, TableStructureReadLockHolder & table_lock_holder);
-
+    FreezeResult freeze(const ASTPtr & partition_ast, const String & with_name, const Context & context) override;
 
 public:
     /// Moves partition to specified Disk
@@ -888,9 +884,10 @@ protected:
     /// Checks whether the column is in the primary key, possibly wrapped in a chain of functions with single argument.
     bool isPrimaryOrMinMaxKeyColumnPossiblyWrappedInFunctions(const ASTPtr & node) const;
 
-    /// Common part for |freezePartition()| and |freezeAll()|.
+    /// Common part for |freeze()|.
     using MatcherFn = std::function<bool(const DataPartPtr &)>;
-    void freezePartitionsByMatcher(MatcherFn matcher, const String & with_name, const Context & context);
+    MatcherFn freezePartitionMatcher(const ASTPtr & partition_ast, const Context & context);
+    FreezeResult freezePartitionsByMatcher(const MatcherFn & matcher, const String & with_name, const Context & context);
 
     bool canReplacePartition(const DataPartPtr & src_part) const;
 

--- a/dbms/Storages/StorageMergeTree.cpp
+++ b/dbms/Storages/StorageMergeTree.cpp
@@ -920,6 +920,7 @@ bool StorageMergeTree::optimize(
     return true;
 }
 
+
 void StorageMergeTree::alterPartition(const ASTPtr & query, const PartitionCommands & commands, const Context & context)
 {
     for (const PartitionCommand & command : commands)
@@ -971,17 +972,10 @@ void StorageMergeTree::alterPartition(const ASTPtr & query, const PartitionComma
             }
             break;
 
-            case PartitionCommand::FREEZE_PARTITION:
-            {
-                auto lock = lockStructureForShare(false, context.getCurrentQueryId());
-                freezePartition(command.partition, command.with_name, context, lock);
-            }
-            break;
-
+            case PartitionCommand::FREEZE_PARTITION: [[fallthrough]];
             case PartitionCommand::FREEZE_ALL_PARTITIONS:
             {
-                auto lock = lockStructureForShare(false, context.getCurrentQueryId());
-                freezeAll(command.with_name, context, lock);
+                freeze(command.partition, command.with_name, context);
             }
             break;
 

--- a/dbms/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/Storages/StorageReplicatedMergeTree.cpp
@@ -3426,17 +3426,10 @@ void StorageReplicatedMergeTree::alterPartition(const ASTPtr & query, const Part
                 fetchPartition(command.partition, command.from_zookeeper_path, query_context);
                 break;
 
-            case PartitionCommand::FREEZE_PARTITION:
-            {
-                auto lock = lockStructureForShare(false, query_context.getCurrentQueryId());
-                freezePartition(command.partition, command.with_name, query_context, lock);
-            }
-            break;
-
+            case PartitionCommand::FREEZE_PARTITION: [[fallthrough]];
             case PartitionCommand::FREEZE_ALL_PARTITIONS:
             {
-                auto lock = lockStructureForShare(false, query_context.getCurrentQueryId());
-                freezeAll(command.with_name, query_context, lock);
+                freeze(command.partition, command.with_name, query_context);
             }
             break;
         }

--- a/dbms/tests/integration/test_freeze_table/test.py
+++ b/dbms/tests/integration/test_freeze_table/test.py
@@ -1,0 +1,58 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import TSV
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node")
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_freeze_table(started_cluster):
+    node.query('CREATE DATABASE IF NOT EXISTS test')
+    node.query('''
+        CREATE TABLE test.table
+        (
+          d Date
+        ) ENGINE = MergeTree(d, d, 8192);
+        ''')
+    node.query('''
+        INSERT INTO
+          test.table
+        VALUES
+          (toDate('2019-01-01')), (toDate('2019-02-01')), (toDate('2020-01-01'));
+        ''')
+
+    freeze_result = TSV.toMat(node.query('''FREEZE TABLE test.table;'''))
+    assert 3 == len(freeze_result)
+    for row in freeze_result:
+        backup_path = row[4]
+        node.exec_in_container(
+            ["bash", "-c", "test -d {}".format(backup_path)]
+        )
+
+    freeze_result = TSV.toMat(node.query('''FREEZE TABLE test.table WITH NAME 'custom-shadow-path';'''))
+    assert 3 == len(freeze_result)
+    for row in freeze_result:
+        backup_path = row[4]
+        assert 'custom%2Dshadow%2Dpath' in backup_path
+        node.exec_in_container(
+            ["bash", "-c", "test -d {}".format(backup_path)]
+        )
+
+    freeze_result = TSV.toMat(node.query('''FREEZE TABLE test.table PARTITION 2019;'''))
+    assert 2 == len(freeze_result)
+
+    freeze_result = TSV.toMat(node.query('''FREEZE TABLE test.table PARTITION 202001;'''))
+    assert 1 == len(freeze_result)
+
+    freeze_result = TSV.toMat(node.query('''FREEZE TABLE test.table PARTITION 999;'''))
+    assert 0 == len(freeze_result)

--- a/dbms/tests/queries/0_stateless/01043_mergetree_freezing.reference
+++ b/dbms/tests/queries/0_stateless/01043_mergetree_freezing.reference
@@ -1,0 +1,9 @@
+3
+1
+2
+---custom_partition---
+3
+0
+OK
+1
+1

--- a/dbms/tests/queries/0_stateless/01043_mergetree_freezing.sh
+++ b/dbms/tests/queries/0_stateless/01043_mergetree_freezing.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. $CURDIR/../shell_config.sh
+
+# Smoke tests for freeze partition.
+
+function test_freeze_date_partition() {
+  local suffix=$1
+
+  $CLICKHOUSE_CLIENT --multiquery <<EOF
+DROP TABLE IF EXISTS t_01043_freeze;
+CREATE TABLE t_01043_freeze
+(
+  d Date
+) ENGINE = MergeTree(d, d, 8192);
+
+INSERT INTO
+  t_01043_freeze
+VALUES
+  (toDate('2019-01-01')), (toDate('2019-02-01')), (toDate('2020-01-01'));
+EOF
+
+  $CLICKHOUSE_CLIENT --query "FREEZE TABLE t_01043_freeze $suffix" | grep -qP "\d+"
+  $CLICKHOUSE_CLIENT --query "SELECT count() FROM system.parts WHERE table = 't_01043_freeze' and is_frozen"
+}
+
+function test_freeze_custom_partition() {
+  local suffix=$1
+  local exception=$2
+
+  $CLICKHOUSE_CLIENT --multiquery <<EOF
+DROP TABLE IF EXISTS t_01043_freeze;
+CREATE TABLE t_01043_freeze
+(
+  d Date
+) ENGINE = MergeTree()
+  ORDER BY d
+  PARTITION BY d;
+
+INSERT INTO
+  t_01043_freeze
+VALUES
+  (toDate('2019-01-01')), (toDate('2019-02-01')), (toDate('2020-01-01'));
+EOF
+
+  if [[ ! -z $exception ]]; then
+    $CLICKHOUSE_CLIENT --query "FREEZE TABLE t_01043_freeze $suffix" --format Null 2>&1 |
+      grep -q "Cannot parse date" && echo "OK" || echo "FAIL"
+
+    return
+  fi
+
+  $CLICKHOUSE_CLIENT --query "FREEZE TABLE t_01043_freeze $suffix" | grep -qP "\d+"
+  $CLICKHOUSE_CLIENT --query "SELECT count() FROM system.parts WHERE table = 't_01043_freeze' and is_frozen"
+}
+
+test_freeze_date_partition ""
+test_freeze_date_partition "PARTITION 201901"
+test_freeze_date_partition "PARTITION '2019'"
+# test_freeze_date_partition "PARTITION ID '201901'" doesn't work in master either
+
+echo "---custom_partition---"
+
+test_freeze_custom_partition ""
+test_freeze_custom_partition "PARTITION 201901"
+test_freeze_custom_partition "PARTITION '2019'" "Cannot parse date"
+test_freeze_custom_partition "PARTITION '2020-01-01'"
+test_freeze_custom_partition "PARTITION ID '20190101'"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):

`FREEZE TABLE [db.]name [PARTITION partition_expr] [WITH NAME custom_dir]`


Detailed description (optional):

```sql
FREEZE TABLE system.query_log

┌─backup_name─┬─partition─┬─partition_id─┬─part_name──────┬─backup_path─────────────────────────────────────────────────────────────────────────┐
│ 5           │ 201912    │ 201912       │ 201912_1_10_2  │ /home/nv/clickhouse-testbed/srv2/data/shadow/5/data/system/query_log/201912_1_10_2  │
│ 5           │ 201912    │ 201912       │ 201912_11_11_0 │ /home/nv/clickhouse-testbed/srv2/data/shadow/5/data/system/query_log/201912_11_11_0 │
└─────────────┴───────────┴──────────────┴────────────────┴─────────────────────────────────────────────────────────────────────────────────────┘

2 rows in set. Elapsed: 0.007 sec.
```

Closes #7785.
