### PR TITLE
Read temporary tables on failure to avoid interpreting that bits as query

### DIFF
--- a/dbms/programs/server/TCPHandler.h
+++ b/dbms/programs/server/TCPHandler.h
@@ -63,6 +63,8 @@ struct QueryState
     bool sent_all_data = false;
     /// Request requires data from the client (INSERT, but not INSERT SELECT).
     bool need_receive_data_for_insert = false;
+    /// Temporary tables read
+    bool temporary_tables_read = false;
 
     /// Request requires data from client for function input()
     bool need_receive_data_for_input = false;

--- a/dbms/tests/integration/test_read_temporary_tables_on_failure/test.py
+++ b/dbms/tests/integration/test_read_temporary_tables_on_failure/test.py
@@ -1,0 +1,26 @@
+import pytest
+import time
+
+from helpers.cluster import ClickHouseCluster
+from helpers.client import QueryTimeoutExceedException, QueryRuntimeException
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance('node')
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+def test_different_versions(start_cluster):
+    with pytest.raises(QueryTimeoutExceedException):
+        node.query("SELECT sleep(3)", timeout=1)
+    with pytest.raises(QueryRuntimeException):
+        node.query("SELECT 1", settings={'max_concurrent_queries_for_user': 1})
+    assert node.contains_in_log('Too many simultaneous queries for user')
+    assert not node.contains_in_log('Unknown packet')


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Read temporary tables on failure to avoid interpreting that bits as query

Detailed description (optional):
Before this patch if the query failes (due to "Too many simultaneous
queries" for example) it will not read external tables info, and the
next request will interpret them as the query beginning at got:

> DB::Exception: Unknown packet 11861 from client
