### PR TITLE
ClusterCopier: refine zxid definition

### DIFF
--- a/dbms/programs/copier/ClusterCopier.cpp
+++ b/dbms/programs/copier/ClusterCopier.cpp
@@ -1285,28 +1285,28 @@ protected:
       * We assume that we compare values that are not too far away.
       * For example, when we increment 0xFFFFFFFF, we get 0. So, 0xFFFFFFFF is less than 0.
       */
-    class WarpingUInt32
+    class WrappingUInt32
     {
     public:
         UInt32 value;
 
-        WarpingUInt32(UInt32 _value)
+        WrappingUInt32(UInt32 _value)
             : value(_value)
         {}
 
-        bool operator<(const WarpingUInt32 & other) const
+        bool operator<(const WrappingUInt32 & other) const
         {
             return value != other.value && *this <= other;
         }
 
-        bool operator<=(const WarpingUInt32 & other) const
+        bool operator<=(const WrappingUInt32 & other) const
         {
             const UInt32 HALF = 1 << 31;
             return (value <= other.value && other.value - value < HALF)
                 || (value > other.value && value - other.value > HALF);
         }
 
-        bool operator==(const WarpingUInt32 & other) const
+        bool operator==(const WrappingUInt32 & other) const
         {
             return value == other.value;
         }
@@ -1318,8 +1318,8 @@ protected:
     class Zxid
     {
     public:
-        WarpingUInt32 epoch;
-        WarpingUInt32 counter;
+        WrappingUInt32 epoch;
+        WrappingUInt32 counter;
         Zxid(UInt64 _zxid)
             : epoch(_zxid >> 32)
             , counter(_zxid)

--- a/dbms/programs/copier/ClusterCopier.cpp
+++ b/dbms/programs/copier/ClusterCopier.cpp
@@ -1312,6 +1312,9 @@ protected:
         }
     };
 
+    /** Conforming Zxid definition.
+      * cf. https://github.com/apache/zookeeper/blob/631d1b284f0edb1c4f6b0fb221bf2428aec71aaa/zookeeper-docs/src/main/resources/markdown/zookeeperInternals.md#guarantees-properties-and-definitions
+      */
     class Zxid
     {
     public:

--- a/dbms/programs/copier/ClusterCopier.cpp
+++ b/dbms/programs/copier/ClusterCopier.cpp
@@ -1281,6 +1281,10 @@ protected:
         return res;
     }
 
+    /** Allows to compare two incremental counters of type UInt32 in presence of possible overflow.
+      * We assume that we compare values that are not too far away.
+      * For example, when we increment 0xFFFFFFFF, we get 0. So, 0xFFFFFFFF is less than 0.
+      */
     class WarpingUInt32
     {
     public:
@@ -1299,7 +1303,7 @@ protected:
         {
             const UInt32 HALF = 1 << 31;
             return (value <= other.value && other.value - value < HALF)
-                || (value >= other.value && value - other.value > HALF);
+                || (value > other.value && value - other.value > HALF);
         }
 
         bool operator==(const WarpingUInt32 & other) const


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Refine the definition of ZXid according to the ZooKeeper Programmer's Guide.

...


Detailed description (optional):
Sorry for making this pull request so late. As explained in an earlier session, the 64-bit Zxids should be interpreted as [two wrapping 32-bit unsigned integers](https://github.com/apache/zookeeper/blob/631d1b284f0edb1c4f6b0fb221bf2428aec71aaa/zookeeper-docs/src/main/resources/markdown/zookeeperInternals.md#guarantees-properties-and-definitions). A simple numerical comparison between two Zxids cannot establish a "causal" relation correctly, which currently the `ClusterCopier` depends on. Therefore, this request is to rectify the related constructions to reflect this fact.
...
