### PR TITLE
Fix search for lld

### DIFF
--- a/cmake/tools.cmake
+++ b/cmake/tools.cmake
@@ -20,9 +20,11 @@ else ()
     message (WARNING "You are using an unsupported compiler. Compilation has only been tested with Clang 6+ and GCC 7+.")
 endif ()
 
-option (LINKER_NAME "Linker name or full path")
+STRING(REGEX MATCHALL "[0-9]+" COMPILER_VERSION_LIST ${CMAKE_CXX_COMPILER_VERSION})
+LIST(GET COMPILER_VERSION_LIST 0 COMPILER_VERSION_MAJOR)
 
-find_program (LLD_PATH NAMES "ld.lld" "lld")
+option (LINKER_NAME "Linker name or full path")
+find_program (LLD_PATH NAMES "ld.lld" "lld" "lld-${COMPILER_VERSION_MAJOR}")
 find_program (GOLD_PATH NAMES "ld.gold" "gold")
 
 if (NOT LINKER_NAME)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Now we will also search for `lld-X` with corresponding `clang-X` version.
