### PR TITLE
Fix dictionary properties

### DIFF
--- a/dbms/src/Dictionaries/getDictionaryConfigurationFromAST.cpp
+++ b/dbms/src/Dictionaries/getDictionaryConfigurationFromAST.cpp
@@ -176,7 +176,7 @@ void buildSingleAttribute(
      AutoPtr<Element> null_value_element(doc->createElement("null_value"));
      String null_value_str;
      if (dict_attr->default_value)
-         null_value_str = queryToString(dict_attr->default_value);
+         null_value_str = getUnescapedFieldString(dict_attr->default_value->as<ASTLiteral>()->value);
      AutoPtr<Text> null_value(doc->createTextNode(null_value_str));
      null_value_element->appendChild(null_value);
      attribute_element->appendChild(null_value_element);
@@ -184,7 +184,19 @@ void buildSingleAttribute(
     if (dict_attr->expression != nullptr)
     {
         AutoPtr<Element> expression_element(doc->createElement("expression"));
-        AutoPtr<Text> expression(doc->createTextNode(queryToString(dict_attr->expression)));
+
+        /// Expression should be function or string
+        String expression_str;
+        if (const auto * literal = dict_attr->expression->as<ASTLiteral>();
+                literal && literal->value.getType() == Field::Types::String)
+        {
+            expression_str = getUnescapedFieldString(literal->value);
+        }
+        else
+            expression_str = queryToString(dict_attr->expression);
+
+
+        AutoPtr<Text> expression(doc->createTextNode(expression_str));
         expression_element->appendChild(expression);
         attribute_element->appendChild(expression_element);
     }

--- a/dbms/src/Dictionaries/getDictionaryConfigurationFromAST.cpp
+++ b/dbms/src/Dictionaries/getDictionaryConfigurationFromAST.cpp
@@ -185,7 +185,7 @@ void buildSingleAttribute(
     {
         AutoPtr<Element> expression_element(doc->createElement("expression"));
 
-        /// Expression should be function or string
+        /// EXPRESSION PROPERTY should be expression or string
         String expression_str;
         if (const auto * literal = dict_attr->expression->as<ASTLiteral>();
                 literal && literal->value.getType() == Field::Types::String)

--- a/dbms/tests/queries/0_stateless/01043_dictionary_attribute_properties_values.reference
+++ b/dbms/tests/queries/0_stateless/01043_dictionary_attribute_properties_values.reference
@@ -1,0 +1,4 @@
+hello
+world
+21844
+xxx

--- a/dbms/tests/queries/0_stateless/01043_dictionary_attribute_properties_values.sql
+++ b/dbms/tests/queries/0_stateless/01043_dictionary_attribute_properties_values.sql
@@ -1,0 +1,27 @@
+DROP DATABASE IF EXISTS dictdb;
+CREATE DATABASE dictdb Engine = Ordinary;
+
+CREATE TABLE dictdb.dicttbl(key Int64, value_default String, value_expression String) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO dictdb.dicttbl VALUES (12, 'hello', '55:66:77');
+
+
+CREATE DICTIONARY dictdb.dict
+(
+  key Int64 DEFAULT -1,
+  value_default String DEFAULT 'world',
+  value_expression String DEFAULT 'xxx' EXPRESSION 'toString(127 * 172)'
+
+)
+PRIMARY KEY key
+SOURCE(CLICKHOUSE(HOST 'localhost' PORT 9000 USER 'default' TABLE 'dicttbl' DB 'dictdb'))
+LAYOUT(FLAT())
+LIFETIME(1);
+
+
+SELECT dictGetString('dictdb.dict', 'value_default', toUInt64(12));
+SELECT dictGetString('dictdb.dict', 'value_default', toUInt64(14));
+
+SELECT dictGetString('dictdb.dict', 'value_expression', toUInt64(12));
+SELECT dictGetString('dictdb.dict', 'value_expression', toUInt64(14));
+
+DROP DATABASE IF EXISTS dictdb;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Now dictionaries support string as expression and fix for default string values.