### PR TITLE
Check extra parts of `MergeTree` at different disks, in order to not allow to miss data parts at undefined disks

### DIFF
--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -803,11 +803,9 @@ void MergeTreeData::loadDataParts(bool skip_sanity_checks)
             {
                 for (Poco::DirectoryIterator it(getFullPathOnDisk(disk_ptr)); it != end; ++it)
                 {
-                    /// Skip temporary directories.
-                    if (startsWith(it.name(), "tmp"))
-                        continue;
-
-                    throw Exception("Part " + backQuote(it.name()) + " was found on a disk " + backQuote(disk_name) + " which is not defined in the storage policy", ErrorCodes::UNKNOWN_DISK);
+                    MergeTreePartInfo part_info;
+                    if (MergeTreePartInfo::tryParsePartName(it.name(), &part_info, format_version))
+                        throw Exception("Part " + backQuote(it.name()) + " was found on a disk " + backQuote(disk_name) + " which is not defined in the storage policy", ErrorCodes::UNKNOWN_DISK);
                 }
             }
         }

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -793,10 +793,13 @@ void MergeTreeData::loadDataParts(bool skip_sanity_checks)
     if (getStoragePolicy()->getName() != "default")
     {
         /// Check extra parts at different disks, in order to not allow to miss data parts at undefined disks.
-        std::unordered_set<String> disks_set(disks.begin(), disks.end());
+        std::unordered_set<String> defined_disk_names;
+        for (const auto & disk_ptr : disks)
+            defined_disk_names.insert(disk_ptr->getName());
+
         for (auto & [disk_name, disk_ptr] : global_context.getDiskSelector().getDisksMap())
         {
-            if (disks_set.count(disk_name) == 0)
+            if (defined_disk_names.count(disk_name) == 0)
             {
                 for (Poco::DirectoryIterator it(getFullPathOnDisk(disk_ptr)); it != end; ++it)
                 {

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -799,7 +799,7 @@ void MergeTreeData::loadDataParts(bool skip_sanity_checks)
 
         for (auto & [disk_name, disk_ptr] : global_context.getDiskSelector().getDisksMap())
         {
-            if (defined_disk_names.count(disk_name) == 0)
+            if (defined_disk_names.count(disk_name) == 0 && Poco::File(getFullPathOnDisk(disk_ptr)).exists())
             {
                 for (Poco::DirectoryIterator it(getFullPathOnDisk(disk_ptr)); it != end; ++it)
                 {

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -805,7 +805,7 @@ void MergeTreeData::loadDataParts(bool skip_sanity_checks)
                 {
                     MergeTreePartInfo part_info;
                     if (MergeTreePartInfo::tryParsePartName(it.name(), &part_info, format_version))
-                        throw Exception("Part " + backQuote(it.name()) + " was found on a disk " + backQuote(disk_name) + " which is not defined in the storage policy", ErrorCodes::UNKNOWN_DISK);
+                        throw Exception("Part " + backQuote(it.name()) + " was found on disk " + backQuote(disk_name) + " which is not defined in the storage policy", ErrorCodes::UNKNOWN_DISK);
                 }
             }
         }

--- a/dbms/tests/integration/test_multiple_disks/test.py
+++ b/dbms/tests/integration/test_multiple_disks/test.py
@@ -1063,6 +1063,7 @@ def test_freeze(start_cluster):
 
     finally:
         node1.query("DROP TABLE IF EXISTS default.freezing_table")
+        node1.exec_in_container(["rm", "-rf", "/jbod1/shadow", "/external/shadow"])
 
 
 def test_kill_while_insert(start_cluster):


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):

Added check for extra parts of `MergeTree` at different disks, in order to not allow to miss data parts at undefined disks.
