### PR TITLE
Move parts between storage volumes according to configured TTL expressions

### DIFF
--- a/dbms/src/Common/quoteString.cpp
+++ b/dbms/src/Common/quoteString.cpp
@@ -14,6 +14,15 @@ String quoteString(const StringRef & x)
 }
 
 
+String doubleQuoteString(const StringRef & x)
+{
+    String res(x.size, '\0');
+    WriteBufferFromString wb(res);
+    writeDoubleQuotedString(x, wb);
+    return res;
+}
+
+
 String backQuote(const StringRef & x)
 {
     String res(x.size, '\0');

--- a/dbms/src/Common/quoteString.h
+++ b/dbms/src/Common/quoteString.h
@@ -9,6 +9,9 @@ namespace DB
 /// Quote the string.
 String quoteString(const StringRef & x);
 
+/// Double quote the string.
+String doubleQuoteString(const StringRef & x);
+
 /// Quote the identifier with backquotes.
 String backQuote(const StringRef & x);
 

--- a/dbms/src/DataStreams/TTLBlockInputStream.cpp
+++ b/dbms/src/DataStreams/TTLBlockInputStream.cpp
@@ -205,9 +205,9 @@ void TTLBlockInputStream::removeValuesWithExpiredColumnTTL(Block & block)
 void TTLBlockInputStream::updateMovesTTL(Block & block)
 {
     std::vector<String> columns_to_remove;
-    for (const auto & [name, ttl_entry] : storage.move_ttl_entries_by_name)
+    for (const auto & ttl_entry : storage.move_ttl_entries)
     {
-        auto & new_ttl_info = new_ttl_infos.moves_ttl[name];
+        auto & new_ttl_info = new_ttl_infos.moves_ttl[ttl_entry.result_column];
 
         if (!block.has(ttl_entry.result_column))
         {

--- a/dbms/src/DataStreams/TTLBlockInputStream.cpp
+++ b/dbms/src/DataStreams/TTLBlockInputStream.cpp
@@ -194,9 +194,10 @@ void TTLBlockInputStream::removeValuesWithExpiredColumnTTL(Block & block)
         column_with_type.column = std::move(result_column);
     }
 
-    for (const auto & elem : storage.column_ttl_entries_by_name)
-        if (block.has(elem.second.result_column))
-            block.erase(elem.second.result_column);
+    for (const auto & [_, ttl_entry] : storage.column_ttl_entries_by_name)
+        if (block.has(ttl_entry.result_column))
+            block.erase(ttl_entry.result_column);
+    /// FIXME: what if table had legitimate column with this name?
 }
 
 void TTLBlockInputStream::updateMovesTTL(Block & block)
@@ -217,9 +218,10 @@ void TTLBlockInputStream::updateMovesTTL(Block & block)
         }
     }
 
-    for (const auto & elem : storage.move_ttl_entries_by_name)
-        if (block.has(elem.second.result_column))
-            block.erase(elem.second.result_column);
+    for (const auto & [_, ttl_entry] : storage.move_ttl_entries_by_name)
+        if (block.has(ttl_entry.result_column))
+            block.erase(ttl_entry.result_column);
+    /// FIXME: what if table had legitimate column with this name?
 }
 
 UInt32 TTLBlockInputStream::getTimestampByIndex(const IColumn * column, size_t ind)

--- a/dbms/src/DataStreams/TTLBlockInputStream.cpp
+++ b/dbms/src/DataStreams/TTLBlockInputStream.cpp
@@ -147,7 +147,7 @@ void TTLBlockInputStream::removeValuesWithExpiredColumnTTL(Block & block)
         defaults_expression->execute(block_with_defaults);
     }
 
-    for (const auto & [name, ttl_entry] : storage.ttl_entries_by_name)
+    for (const auto & [name, ttl_entry] : storage.column_ttl_entries_by_name)
     {
         const auto & old_ttl_info = old_ttl_infos.columns_ttl[name];
         auto & new_ttl_info = new_ttl_infos.columns_ttl[name];
@@ -194,7 +194,7 @@ void TTLBlockInputStream::removeValuesWithExpiredColumnTTL(Block & block)
         column_with_type.column = std::move(result_column);
     }
 
-    for (const auto & elem : storage.ttl_entries_by_name)
+    for (const auto & elem : storage.column_ttl_entries_by_name)
         if (block.has(elem.second.result_column))
             block.erase(elem.second.result_column);
 }

--- a/dbms/src/DataStreams/TTLBlockInputStream.h
+++ b/dbms/src/DataStreams/TTLBlockInputStream.h
@@ -58,6 +58,9 @@ private:
     /// Removes rows with expired table ttl and computes new ttl_infos for part
     void removeRowsWithExpiredTableTTL(Block & block);
 
+    /// Updates TTL for moves
+    void updateMovesTTL(Block & block);
+
     UInt32 getTimestampByIndex(const IColumn * column, size_t ind);
     bool isTTLExpired(time_t ttl);
 };

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -1508,7 +1508,7 @@ BackgroundProcessingPool & Context::getBackgroundMovePool()
 {
     auto lock = getLock();
     if (!shared->background_move_pool)
-        shared->background_move_pool.emplace(settings.background_move_pool_size, "BackgroundMovePool", "BgMoveProcPool");
+        shared->background_move_pool.emplace(settings.background_move_pool_size, getConfigRef(), "BackgroundMovePool", "BgMoveProcPool");
     return *shared->background_move_pool;
 }
 

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -1500,7 +1500,7 @@ BackgroundProcessingPool & Context::getBackgroundPool()
 {
     auto lock = getLock();
     if (!shared->background_pool)
-        shared->background_pool.emplace(settings.background_pool_size);
+        shared->background_pool.emplace(settings.background_pool_size, getConfigRef());
     return *shared->background_pool;
 }
 

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -1500,7 +1500,7 @@ BackgroundProcessingPool & Context::getBackgroundPool()
 {
     auto lock = getLock();
     if (!shared->background_pool)
-        shared->background_pool.emplace(settings.background_pool_size, getConfigRef());
+        shared->background_pool.emplace(settings.background_pool_size);
     return *shared->background_pool;
 }
 
@@ -1508,7 +1508,18 @@ BackgroundProcessingPool & Context::getBackgroundMovePool()
 {
     auto lock = getLock();
     if (!shared->background_move_pool)
-        shared->background_move_pool.emplace(settings.background_move_pool_size, getConfigRef(), "BackgroundMovePool", "BgMoveProcPool");
+    {
+        BackgroundProcessingPool::PoolSettings pool_settings;
+        auto & config = getConfigRef();
+        pool_settings.thread_sleep_seconds = config.getDouble("background_move_processing_pool_thread_sleep_seconds", 10);
+        pool_settings.thread_sleep_seconds_random_part = config.getDouble("background_move_processing_pool_thread_sleep_seconds_random_part", 1.0);
+        pool_settings.thread_sleep_seconds_if_nothing_to_do = config.getDouble("background_move_processing_pool_thread_sleep_seconds_if_nothing_to_do", 0.1);
+        pool_settings.task_sleep_seconds_when_no_work_min = config.getDouble("background_move_processing_pool_task_sleep_seconds_when_no_work_min", 10);
+        pool_settings.task_sleep_seconds_when_no_work_max = config.getDouble("background_move_processing_pool_task_sleep_seconds_when_no_work_max", 600);
+        pool_settings.task_sleep_seconds_when_no_work_multiplier = config.getDouble("background_move_processing_pool_task_sleep_seconds_when_no_work_multiplier", 1.1);
+        pool_settings.task_sleep_seconds_when_no_work_random_part = config.getDouble("background_move_processing_pool_task_sleep_seconds_when_no_work_random_part", 1.0);
+        shared->background_move_pool.emplace(settings.background_move_pool_size, pool_settings, "BackgroundMovePool", "BgMoveProcPool");
+    }
     return *shared->background_move_pool;
 }
 

--- a/dbms/src/Parsers/ASTAlterQuery.cpp
+++ b/dbms/src/Parsers/ASTAlterQuery.cpp
@@ -176,10 +176,10 @@ void ASTAlterCommand::formatImpl(
         settings.ostr << " TO ";
         switch (move_destination_type)
         {
-            case ASTTTLElement::DestinationType::DISK:
+            case TTLDestinationType::DISK:
                 settings.ostr << "DISK ";
                 break;
-            case ASTTTLElement::DestinationType::VOLUME:
+            case TTLDestinationType::VOLUME:
                 settings.ostr << "VOLUME ";
                 break;
             default:

--- a/dbms/src/Parsers/ASTAlterQuery.cpp
+++ b/dbms/src/Parsers/ASTAlterQuery.cpp
@@ -176,11 +176,13 @@ void ASTAlterCommand::formatImpl(
         settings.ostr << " TO ";
         switch (move_destination_type)
         {
-            case MoveDestinationType::DISK:
+            case ASTTTLElement::DestinationType::DISK:
                 settings.ostr << "DISK ";
                 break;
-            case MoveDestinationType::VOLUME:
+            case ASTTTLElement::DestinationType::VOLUME:
                 settings.ostr << "VOLUME ";
+                break;
+            default:
                 break;
         }
         settings.ostr << quoteString(move_destination_name);

--- a/dbms/src/Parsers/ASTAlterQuery.cpp
+++ b/dbms/src/Parsers/ASTAlterQuery.cpp
@@ -176,10 +176,10 @@ void ASTAlterCommand::formatImpl(
         settings.ostr << " TO ";
         switch (move_destination_type)
         {
-            case TTLDestinationType::DISK:
+            case PartDestinationType::DISK:
                 settings.ostr << "DISK ";
                 break;
-            case TTLDestinationType::VOLUME:
+            case PartDestinationType::VOLUME:
                 settings.ostr << "VOLUME ";
                 break;
             default:

--- a/dbms/src/Parsers/ASTAlterQuery.h
+++ b/dbms/src/Parsers/ASTAlterQuery.h
@@ -3,6 +3,7 @@
 #include <Parsers/IAST.h>
 #include <Parsers/ASTQueryWithTableAndOutput.h>
 #include <Parsers/ASTQueryWithOnCluster.h>
+#include <Parsers/ASTTTLElement.h>
 
 
 namespace DB
@@ -128,13 +129,7 @@ public:
 
     bool if_exists = false;     /// option for DROP_COLUMN, MODIFY_COLUMN, COMMENT_COLUMN
 
-    enum MoveDestinationType
-    {
-        DISK,
-        VOLUME,
-    };
-
-    MoveDestinationType move_destination_type;
+    ASTTTLElement::DestinationType move_destination_type;
 
     String move_destination_name;
 

--- a/dbms/src/Parsers/ASTAlterQuery.h
+++ b/dbms/src/Parsers/ASTAlterQuery.h
@@ -129,7 +129,7 @@ public:
 
     bool if_exists = false;     /// option for DROP_COLUMN, MODIFY_COLUMN, COMMENT_COLUMN
 
-    TTLDestinationType move_destination_type; /// option for MOVE PART/PARTITION
+    PartDestinationType move_destination_type; /// option for MOVE PART/PARTITION
 
     String move_destination_name;             /// option for MOVE PART/PARTITION
 

--- a/dbms/src/Parsers/ASTAlterQuery.h
+++ b/dbms/src/Parsers/ASTAlterQuery.h
@@ -129,9 +129,9 @@ public:
 
     bool if_exists = false;     /// option for DROP_COLUMN, MODIFY_COLUMN, COMMENT_COLUMN
 
-    ASTTTLElement::DestinationType move_destination_type;
+    TTLDestinationType move_destination_type; /// option for MOVE PART/PARTITION
 
-    String move_destination_name;
+    String move_destination_name;             /// option for MOVE PART/PARTITION
 
     /** For FETCH PARTITION - the path in ZK to the shard, from which to download the partition.
      */

--- a/dbms/src/Parsers/ASTTTLElement.cpp
+++ b/dbms/src/Parsers/ASTTTLElement.cpp
@@ -1,0 +1,26 @@
+#include <Columns/Collator.h>
+#include <Parsers/ASTTTLElement.h>
+
+
+namespace DB
+{
+
+void ASTTTLElement::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+{
+    children.front()->formatImpl(settings, state, frame);
+    if (destination_type == DestinationType::DISK) {
+        settings.ostr << " TO DISK ";
+    } else if (destination_type == DestinationType::VOLUME) {
+        settings.ostr << " TO VOLUME ";
+    } else if (destination_type == DestinationType::DELETE) {
+        settings.ostr << " DELETE";
+    }
+
+    if (destination_type == DestinationType::DISK || destination_type == DestinationType::VOLUME) {
+        WriteBufferFromOwnString destination_name_buf;
+        writeQuoted(destination_name, destination_name_buf);
+        settings.ostr << destination_name_buf.str();
+    }
+}
+
+}

--- a/dbms/src/Parsers/ASTTTLElement.cpp
+++ b/dbms/src/Parsers/ASTTTLElement.cpp
@@ -1,3 +1,4 @@
+
 #include <Columns/Collator.h>
 #include <Common/quoteString.h>
 #include <Parsers/ASTTTLElement.h>
@@ -9,15 +10,15 @@ namespace DB
 void ASTTTLElement::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     children.front()->formatImpl(settings, state, frame);
-    if (destination_type == DestinationType::DISK)
+    if (destination_type == TTLDestinationType::DISK)
     {
         settings.ostr << " TO DISK " << quoteString(destination_name);
     }
-    else if (destination_type == DestinationType::VOLUME)
+    else if (destination_type == TTLDestinationType::VOLUME)
     {
         settings.ostr << " TO VOLUME " << quoteString(destination_name);
     }
-    else if (destination_type == DestinationType::DELETE)
+    else if (destination_type == TTLDestinationType::DELETE)
     {
         settings.ostr << " DELETE";
     }

--- a/dbms/src/Parsers/ASTTTLElement.cpp
+++ b/dbms/src/Parsers/ASTTTLElement.cpp
@@ -20,7 +20,7 @@ void ASTTTLElement::formatImpl(const FormatSettings & settings, FormatState & st
     }
     else if (destination_type == TTLDestinationType::DELETE)
     {
-        settings.ostr << " DELETE";
+	/// It would be better to output "DELETE" here but that will break compatibility with earlier versions.
     }
 }
 

--- a/dbms/src/Parsers/ASTTTLElement.cpp
+++ b/dbms/src/Parsers/ASTTTLElement.cpp
@@ -1,4 +1,5 @@
 #include <Columns/Collator.h>
+#include <Common/quoteString.h>
 #include <Parsers/ASTTTLElement.h>
 
 
@@ -8,18 +9,17 @@ namespace DB
 void ASTTTLElement::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     children.front()->formatImpl(settings, state, frame);
-    if (destination_type == DestinationType::DISK) {
-        settings.ostr << " TO DISK ";
-    } else if (destination_type == DestinationType::VOLUME) {
-        settings.ostr << " TO VOLUME ";
-    } else if (destination_type == DestinationType::DELETE) {
-        settings.ostr << " DELETE";
+    if (destination_type == DestinationType::DISK)
+    {
+        settings.ostr << " TO DISK " << quoteString(destination_name);
     }
-
-    if (destination_type == DestinationType::DISK || destination_type == DestinationType::VOLUME) {
-        WriteBufferFromOwnString destination_name_buf;
-        writeQuoted(destination_name, destination_name_buf);
-        settings.ostr << destination_name_buf.str();
+    else if (destination_type == DestinationType::VOLUME)
+    {
+        settings.ostr << " TO VOLUME " << quoteString(destination_name);
+    }
+    else if (destination_type == DestinationType::DELETE)
+    {
+        settings.ostr << " DELETE";
     }
 }
 

--- a/dbms/src/Parsers/ASTTTLElement.cpp
+++ b/dbms/src/Parsers/ASTTTLElement.cpp
@@ -10,15 +10,15 @@ namespace DB
 void ASTTTLElement::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     children.front()->formatImpl(settings, state, frame);
-    if (destination_type == TTLDestinationType::DISK)
+    if (destination_type == PartDestinationType::DISK)
     {
         settings.ostr << " TO DISK " << quoteString(destination_name);
     }
-    else if (destination_type == TTLDestinationType::VOLUME)
+    else if (destination_type == PartDestinationType::VOLUME)
     {
         settings.ostr << " TO VOLUME " << quoteString(destination_name);
     }
-    else if (destination_type == TTLDestinationType::DELETE)
+    else if (destination_type == PartDestinationType::DELETE)
     {
 	/// It would be better to output "DELETE" here but that will break compatibility with earlier versions.
     }

--- a/dbms/src/Parsers/ASTTTLElement.cpp
+++ b/dbms/src/Parsers/ASTTTLElement.cpp
@@ -20,7 +20,7 @@ void ASTTTLElement::formatImpl(const FormatSettings & settings, FormatState & st
     }
     else if (destination_type == PartDestinationType::DELETE)
     {
-	/// It would be better to output "DELETE" here but that will break compatibility with earlier versions.
+        /// It would be better to output "DELETE" here but that will break compatibility with earlier versions.
     }
 }
 

--- a/dbms/src/Parsers/ASTTTLElement.h
+++ b/dbms/src/Parsers/ASTTTLElement.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <Parsers/IAST.h>
+
+
+namespace DB
+{
+/** Element of TTL expression.
+  */
+class ASTTTLElement : public IAST
+{
+public:
+    enum DestinationType
+    {
+        DISK,
+        VOLUME,
+        DELETE,
+    };
+
+    DestinationType destination_type;
+    String destination_name;
+
+    ASTTTLElement(DestinationType destination_type_, const String & destination_name_)
+        : destination_type(destination_type_)
+        , destination_name(destination_name_)
+    {
+    }
+
+    String getID(char) const override { return "TTLElement"; }
+
+    ASTPtr clone() const override
+    {
+        auto clone = std::make_shared<ASTTTLElement>(*this);
+        clone->cloneChildren();
+        return clone;
+    }
+
+protected:
+    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+};
+
+}

--- a/dbms/src/Parsers/ASTTTLElement.h
+++ b/dbms/src/Parsers/ASTTTLElement.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <Parsers/IAST.h>
-#include <Storages/MergeTree/TTLDestinationType.h>
+#include <Storages/MergeTree/PartDestinationType.h>
 
 
 namespace DB
@@ -11,10 +11,10 @@ namespace DB
 class ASTTTLElement : public IAST
 {
 public:
-    TTLDestinationType destination_type;
+    PartDestinationType destination_type;
     String destination_name;
 
-    ASTTTLElement(TTLDestinationType destination_type_, const String & destination_name_)
+    ASTTTLElement(PartDestinationType destination_type_, const String & destination_name_)
         : destination_type(destination_type_)
         , destination_name(destination_name_)
     {

--- a/dbms/src/Parsers/ASTTTLElement.h
+++ b/dbms/src/Parsers/ASTTTLElement.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Parsers/IAST.h>
+#include <Storages/MergeTree/TTLDestinationType.h>
 
 
 namespace DB
@@ -10,17 +11,10 @@ namespace DB
 class ASTTTLElement : public IAST
 {
 public:
-    enum DestinationType
-    {
-        DISK,
-        VOLUME,
-        DELETE,
-    };
-
-    DestinationType destination_type;
+    TTLDestinationType destination_type;
     String destination_name;
 
-    ASTTTLElement(DestinationType destination_type_, const String & destination_name_)
+    ASTTTLElement(TTLDestinationType destination_type_, const String & destination_name_)
         : destination_type(destination_type_)
         , destination_name(destination_name_)
     {

--- a/dbms/src/Parsers/ExpressionElementParsers.cpp
+++ b/dbms/src/Parsers/ExpressionElementParsers.cpp
@@ -16,6 +16,7 @@
 #include <Parsers/ASTAsterisk.h>
 #include <Parsers/ASTQualifiedAsterisk.h>
 #include <Parsers/ASTQueryParameter.h>
+#include <Parsers/ASTTTLElement.h>
 #include <Parsers/ASTOrderByElement.h>
 #include <Parsers/ASTSubquery.h>
 #include <Parsers/ASTFunctionWithKeyValueArguments.h>
@@ -1410,6 +1411,42 @@ bool ParserFunctionWithKeyValueArguments::parseImpl(Pos & pos, ASTPtr & node, Ex
     function->elements = expr_list_args;
     function->children.push_back(function->elements);
     node = function;
+
+    return true;
+}
+
+bool ParserTTLElement::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+{
+    ParserKeyword s_to_disk("TO DISK");
+    ParserKeyword s_to_volume("TO VOLUME");
+    ParserKeyword s_delete("DELETE");
+    ParserStringLiteral parser_string_literal;
+    ParserExpression parser_exp;
+
+    ASTPtr expr_elem;
+    if (!parser_exp.parse(pos, expr_elem, expected))
+        return false;
+
+    ASTTTLElement::DestinationType destination_type = ASTTTLElement::DestinationType::DELETE;
+    String destination_name;
+    if (s_to_disk.ignore(pos)) {
+        destination_type = ASTTTLElement::DestinationType::DISK;
+    } else if (s_to_volume.ignore(pos)) {
+        destination_type = ASTTTLElement::DestinationType::VOLUME;
+    } else {
+        s_delete.ignore(pos);
+    }
+
+    if (destination_type == ASTTTLElement::DestinationType::DISK || destination_type == ASTTTLElement::DestinationType::VOLUME) {
+        ASTPtr ast_space_name;
+        if (!parser_string_literal.parse(pos, ast_space_name, expected))
+            return false;
+
+        destination_name = ast_space_name->as<ASTLiteral &>().value.get<const String &>();
+    }
+
+    node = std::make_shared<ASTTTLElement>(destination_type, destination_name);
+    node->children.push_back(expr_elem);
 
     return true;
 }

--- a/dbms/src/Parsers/ExpressionElementParsers.cpp
+++ b/dbms/src/Parsers/ExpressionElementParsers.cpp
@@ -1429,15 +1429,15 @@ bool ParserTTLElement::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 
     ASTTTLElement::DestinationType destination_type = ASTTTLElement::DestinationType::DELETE;
     String destination_name;
-    if (s_to_disk.ignore(pos)) {
+    if (s_to_disk.ignore(pos))
         destination_type = ASTTTLElement::DestinationType::DISK;
-    } else if (s_to_volume.ignore(pos)) {
+    else if (s_to_volume.ignore(pos))
         destination_type = ASTTTLElement::DestinationType::VOLUME;
-    } else {
+    else
         s_delete.ignore(pos);
-    }
 
-    if (destination_type == ASTTTLElement::DestinationType::DISK || destination_type == ASTTTLElement::DestinationType::VOLUME) {
+    if (destination_type == ASTTTLElement::DestinationType::DISK || destination_type == ASTTTLElement::DestinationType::VOLUME)
+    {
         ASTPtr ast_space_name;
         if (!parser_string_literal.parse(pos, ast_space_name, expected))
             return false;

--- a/dbms/src/Parsers/ExpressionElementParsers.cpp
+++ b/dbms/src/Parsers/ExpressionElementParsers.cpp
@@ -1427,16 +1427,16 @@ bool ParserTTLElement::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     if (!parser_exp.parse(pos, expr_elem, expected))
         return false;
 
-    ASTTTLElement::DestinationType destination_type = ASTTTLElement::DestinationType::DELETE;
+    TTLDestinationType destination_type = TTLDestinationType::DELETE;
     String destination_name;
     if (s_to_disk.ignore(pos))
-        destination_type = ASTTTLElement::DestinationType::DISK;
+        destination_type = TTLDestinationType::DISK;
     else if (s_to_volume.ignore(pos))
-        destination_type = ASTTTLElement::DestinationType::VOLUME;
+        destination_type = TTLDestinationType::VOLUME;
     else
         s_delete.ignore(pos);
 
-    if (destination_type == ASTTTLElement::DestinationType::DISK || destination_type == ASTTTLElement::DestinationType::VOLUME)
+    if (destination_type == TTLDestinationType::DISK || destination_type == TTLDestinationType::VOLUME)
     {
         ASTPtr ast_space_name;
         if (!parser_string_literal.parse(pos, ast_space_name, expected))

--- a/dbms/src/Parsers/ExpressionElementParsers.cpp
+++ b/dbms/src/Parsers/ExpressionElementParsers.cpp
@@ -1427,16 +1427,16 @@ bool ParserTTLElement::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     if (!parser_exp.parse(pos, expr_elem, expected))
         return false;
 
-    TTLDestinationType destination_type = TTLDestinationType::DELETE;
+    PartDestinationType destination_type = PartDestinationType::DELETE;
     String destination_name;
     if (s_to_disk.ignore(pos))
-        destination_type = TTLDestinationType::DISK;
+        destination_type = PartDestinationType::DISK;
     else if (s_to_volume.ignore(pos))
-        destination_type = TTLDestinationType::VOLUME;
+        destination_type = PartDestinationType::VOLUME;
     else
         s_delete.ignore(pos);
 
-    if (destination_type == TTLDestinationType::DISK || destination_type == TTLDestinationType::VOLUME)
+    if (destination_type == PartDestinationType::DISK || destination_type == PartDestinationType::VOLUME)
     {
         ASTPtr ast_space_name;
         if (!parser_string_literal.parse(pos, ast_space_name, expected))

--- a/dbms/src/Parsers/ExpressionElementParsers.h
+++ b/dbms/src/Parsers/ExpressionElementParsers.h
@@ -320,4 +320,14 @@ protected:
     bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
 };
 
+/** Element of TTL expression - same as expression element, but in addition,
+ *   TO DISK 'xxx' | TO VOLUME 'xxx' | DELETE could be specified
+  */
+class ParserTTLElement : public IParserBase
+{
+protected:
+    const char * getName() const { return "element of TTL expression"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+};
+
 }

--- a/dbms/src/Parsers/ExpressionListParsers.cpp
+++ b/dbms/src/Parsers/ExpressionListParsers.cpp
@@ -557,6 +557,13 @@ bool ParserOrderByExpressionList::parseImpl(Pos & pos, ASTPtr & node, Expected &
 }
 
 
+bool ParserTTLExpressionList::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+{
+    return ParserList(std::make_unique<ParserTTLElement>(), std::make_unique<ParserToken>(TokenType::Comma), false)
+        .parse(pos, node, expected);
+}
+
+
 bool ParserNullityChecking::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
     ASTPtr node_comp;

--- a/dbms/src/Parsers/ExpressionListParsers.h
+++ b/dbms/src/Parsers/ExpressionListParsers.h
@@ -386,12 +386,21 @@ protected:
     bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
+
 /// Parser for list of key-value pairs.
 class ParserKeyValuePairsList : public IParserBase
 {
 protected:
     const char * getName() const override { return "list of pairs"; }
     bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+};
+
+
+class ParserTTLExpressionList : public IParserBase
+{
+protected:
+    const char * getName() const { return "ttl expression"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
 };
 
 }

--- a/dbms/src/Parsers/ParserAlterQuery.cpp
+++ b/dbms/src/Parsers/ParserAlterQuery.cpp
@@ -243,8 +243,6 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
             else
                 return false;
 
-            // FIXME See ParserTTLElement
-
             ASTPtr ast_space_name;
             if (!parser_string_literal.parse(pos, ast_space_name, expected))
                 return false;
@@ -264,8 +262,6 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
                 command->move_destination_type = TTLDestinationType::VOLUME;
             else
                 return false;
-
-            // FIXME See ParserTTLElement
 
             ASTPtr ast_space_name;
             if (!parser_string_literal.parse(pos, ast_space_name, expected))
@@ -437,7 +433,6 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
         else if (s_modify_ttl.ignore(pos, expected))
         {
             if (!parser_ttl_list.parse(pos, command->ttl, expected))
-// FIXME check if that is fine, can be `toDate(), toDate() TO DISK 'abc'` and that is not tuple TO DISK 'abc'
                 return false;
             command->type = ASTAlterCommand::MODIFY_TTL;
         }

--- a/dbms/src/Parsers/ParserAlterQuery.cpp
+++ b/dbms/src/Parsers/ParserAlterQuery.cpp
@@ -237,9 +237,9 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
             command->part = true;
 
             if (s_to_disk.ignore(pos))
-                command->move_destination_type = ASTTTLElement::DestinationType::DISK;
+                command->move_destination_type = TTLDestinationType::DISK;
             else if (s_to_volume.ignore(pos))
-                command->move_destination_type = ASTTTLElement::DestinationType::VOLUME;
+                command->move_destination_type = TTLDestinationType::VOLUME;
             else
                 return false;
 
@@ -259,9 +259,9 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
             command->type = ASTAlterCommand::MOVE_PARTITION;
 
             if (s_to_disk.ignore(pos))
-                command->move_destination_type = ASTTTLElement::DestinationType::DISK;
+                command->move_destination_type = TTLDestinationType::DISK;
             else if (s_to_volume.ignore(pos))
-                command->move_destination_type = ASTTTLElement::DestinationType::VOLUME;
+                command->move_destination_type = TTLDestinationType::VOLUME;
             else
                 return false;
 

--- a/dbms/src/Parsers/ParserAlterQuery.cpp
+++ b/dbms/src/Parsers/ParserAlterQuery.cpp
@@ -237,9 +237,9 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
             command->part = true;
 
             if (s_to_disk.ignore(pos))
-                command->move_destination_type = TTLDestinationType::DISK;
+                command->move_destination_type = PartDestinationType::DISK;
             else if (s_to_volume.ignore(pos))
-                command->move_destination_type = TTLDestinationType::VOLUME;
+                command->move_destination_type = PartDestinationType::VOLUME;
             else
                 return false;
 
@@ -257,9 +257,9 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
             command->type = ASTAlterCommand::MOVE_PARTITION;
 
             if (s_to_disk.ignore(pos))
-                command->move_destination_type = TTLDestinationType::DISK;
+                command->move_destination_type = PartDestinationType::DISK;
             else if (s_to_volume.ignore(pos))
-                command->move_destination_type = TTLDestinationType::VOLUME;
+                command->move_destination_type = PartDestinationType::VOLUME;
             else
                 return false;
 

--- a/dbms/src/Parsers/ParserCreateQuery.cpp
+++ b/dbms/src/Parsers/ParserCreateQuery.cpp
@@ -250,6 +250,7 @@ bool ParserStorage::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     ParserIdentifierWithOptionalParameters ident_with_optional_params_p;
     ParserExpression expression_p;
     ParserSetQuery settings_p(/* parse_only_internals_ = */ true);
+    ParserTTLExpressionList parser_ttl_list;
 
     ASTPtr engine;
     ASTPtr partition_by;
@@ -303,7 +304,7 @@ bool ParserStorage::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 
         if (!ttl_table && s_ttl.ignore(pos, expected))
         {
-            if (expression_p.parse(pos, ttl_table, expected))
+            if (parser_ttl_list.parse(pos, ttl_table, expected))
                 continue;
             else
                 return false;

--- a/dbms/src/Storages/MergeTree/BackgroundProcessingPool.cpp
+++ b/dbms/src/Storages/MergeTree/BackgroundProcessingPool.cpp
@@ -51,22 +51,15 @@ void BackgroundProcessingPoolTaskInfo::wake()
 
 
 BackgroundProcessingPool::BackgroundProcessingPool(int size_,
-        const Poco::Util::AbstractConfiguration & config,
+        const PoolSettings & pool_settings,
         const char * log_name,
         const char * thread_name_)
     : size(size_)
     , thread_name(thread_name_)
+    , settings(pool_settings)
 {
     logger = &Logger::get(log_name);
     LOG_INFO(logger, "Create " << log_name << " with " << size << " threads");
-
-    thread_sleep_seconds = config.getDouble("background_processing_pool_thread_sleep_seconds", 10);
-    thread_sleep_seconds_random_part = config.getDouble("background_processing_pool_thread_sleep_seconds_random_part", 1.0);
-    thread_sleep_seconds_if_nothing_to_do = config.getDouble("background_processing_pool_thread_sleep_seconds_if_nothing_to_do", 0.1);
-    task_sleep_seconds_when_no_work_min = config.getDouble("background_processing_pool_task_sleep_seconds_when_no_work_min", 10);
-    task_sleep_seconds_when_no_work_max = config.getDouble("background_processing_pool_task_sleep_seconds_when_no_work_max", 600);
-    task_sleep_seconds_when_no_work_multiplier = config.getDouble("background_processing_pool_task_sleep_seconds_when_no_work_multiplier", 1.1);
-    task_sleep_seconds_when_no_work_random_part = config.getDouble("background_processing_pool_task_sleep_seconds_when_no_work_random_part", 1.0);
 
     threads.resize(size);
     for (auto & thread : threads)
@@ -147,7 +140,7 @@ void BackgroundProcessingPool::threadFunction()
         memory_tracker->setMetric(CurrentMetrics::MemoryTrackingInBackgroundProcessingPool);
 
     pcg64 rng(randomSeed());
-    std::this_thread::sleep_for(std::chrono::duration<double>(std::uniform_real_distribution<double>(0, thread_sleep_seconds_random_part)(rng)));
+    std::this_thread::sleep_for(std::chrono::duration<double>(std::uniform_real_distribution<double>(0, settings.thread_sleep_seconds_random_part)(rng)));
 
     while (!shutdown)
     {
@@ -182,8 +175,8 @@ void BackgroundProcessingPool::threadFunction()
             {
                 std::unique_lock lock(tasks_mutex);
                 wake_event.wait_for(lock,
-                    std::chrono::duration<double>(thread_sleep_seconds
-                        + std::uniform_real_distribution<double>(0, thread_sleep_seconds_random_part)(rng)));
+                    std::chrono::duration<double>(settings.thread_sleep_seconds
+                        + std::uniform_real_distribution<double>(0, settings.thread_sleep_seconds_random_part)(rng)));
                 continue;
             }
 
@@ -193,7 +186,7 @@ void BackgroundProcessingPool::threadFunction()
             {
                 std::unique_lock lock(tasks_mutex);
                 wake_event.wait_for(lock, std::chrono::microseconds(
-                    min_time - current_time + std::uniform_int_distribution<uint64_t>(0, thread_sleep_seconds_random_part * 1000000)(rng)));
+                    min_time - current_time + std::uniform_int_distribution<uint64_t>(0, settings.thread_sleep_seconds_random_part * 1000000)(rng)));
             }
 
             std::shared_lock rlock(task->rwlock);
@@ -231,11 +224,11 @@ void BackgroundProcessingPool::threadFunction()
             Poco::Timestamp next_time_to_execute;   /// current time
             if (task_result == TaskResult::ERROR)
                 next_time_to_execute += 1000000 * (std::min(
-                        task_sleep_seconds_when_no_work_max,
-                        task_sleep_seconds_when_no_work_min * std::pow(task_sleep_seconds_when_no_work_multiplier, task->count_no_work_done))
-                    + std::uniform_real_distribution<double>(0, task_sleep_seconds_when_no_work_random_part)(rng));
+                        settings.task_sleep_seconds_when_no_work_max,
+                        settings.task_sleep_seconds_when_no_work_min * std::pow(settings.task_sleep_seconds_when_no_work_multiplier, task->count_no_work_done))
+                    + std::uniform_real_distribution<double>(0, settings.task_sleep_seconds_when_no_work_random_part)(rng));
             else if (task_result == TaskResult::NOTHING_TO_DO)
-                next_time_to_execute += 1000000 * thread_sleep_seconds_if_nothing_to_do;
+                next_time_to_execute += 1000000 * settings.thread_sleep_seconds_if_nothing_to_do;
 
             tasks.erase(task->iterator);
             task->iterator = tasks.emplace(next_time_to_execute, task);

--- a/dbms/src/Storages/MergeTree/BackgroundProcessingPool.h
+++ b/dbms/src/Storages/MergeTree/BackgroundProcessingPool.h
@@ -47,8 +47,23 @@ public:
     using TaskHandle = std::shared_ptr<TaskInfo>;
 
 
+    struct PoolSettings
+    {
+        double thread_sleep_seconds = 10;
+        double thread_sleep_seconds_random_part = 1.0;
+        double thread_sleep_seconds_if_nothing_to_do = 0.1;
+
+        /// For exponential backoff.
+        double task_sleep_seconds_when_no_work_min = 10;
+        double task_sleep_seconds_when_no_work_max = 600;
+        double task_sleep_seconds_when_no_work_multiplier = 1.1;
+        double task_sleep_seconds_when_no_work_random_part = 1.0;
+
+        PoolSettings() noexcept {}
+    };
+
     BackgroundProcessingPool(int size_,
-        const Poco::Util::AbstractConfiguration & config,
+        const PoolSettings & pool_settings = {},
         const char * log_name = "BackgroundProcessingPool",
         const char * thread_name_ = "BackgrProcPool");
 
@@ -88,15 +103,7 @@ protected:
     void threadFunction();
 
 private:
-    double thread_sleep_seconds;
-    double thread_sleep_seconds_random_part;
-    double thread_sleep_seconds_if_nothing_to_do;
-
-    /// For exponential backoff.
-    double task_sleep_seconds_when_no_work_min;
-    double task_sleep_seconds_when_no_work_max;
-    double task_sleep_seconds_when_no_work_multiplier;
-    double task_sleep_seconds_when_no_work_random_part;
+    PoolSettings settings;
 };
 
 

--- a/dbms/src/Storages/MergeTree/BackgroundProcessingPool.h
+++ b/dbms/src/Storages/MergeTree/BackgroundProcessingPool.h
@@ -14,6 +14,7 @@
 #include <Core/Types.h>
 #include <Common/CurrentThread.h>
 #include <Common/ThreadPool.h>
+#include <Poco/Util/AbstractConfiguration.h>
 
 
 namespace DB
@@ -47,6 +48,7 @@ public:
 
 
     BackgroundProcessingPool(int size_,
+        const Poco::Util::AbstractConfiguration & config,
         const char * log_name = "BackgroundProcessingPool",
         const char * thread_name_ = "BackgrProcPool");
 
@@ -84,6 +86,17 @@ protected:
     ThreadGroupStatusPtr thread_group;
 
     void threadFunction();
+
+private:
+    double thread_sleep_seconds;
+    double thread_sleep_seconds_random_part;
+    double thread_sleep_seconds_if_nothing_to_do;
+
+    /// For exponential backoff.
+    double task_sleep_seconds_when_no_work_min;
+    double task_sleep_seconds_when_no_work_max;
+    double task_sleep_seconds_when_no_work_multiplier;
+    double task_sleep_seconds_when_no_work_random_part;
 };
 
 

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -612,13 +612,21 @@ void MergeTreeData::setTTLExpressions(const ColumnsDescription::ColumnTTLs & new
             {
                 if (new_delete_ttl_table_ast)
                 {
-                    throw Exception("Too many DELETE ttls.", ErrorCodes::BAD_TTL_EXPRESSION);
+                    throw Exception("Too many DELETE ttls", ErrorCodes::BAD_TTL_EXPRESSION);
                 }
                 new_delete_ttl_table_ast = ttl_element.children[0];
             }
             else
             {
-                // FIXME: Read MOVE ttls.
+                auto new_ttl_entry = create_ttl_entry(ttl_element.children[0]);
+                if (!only_check)
+                {
+                    std::ostringstream expression_text_stream;
+                    IAST::FormatSettings settings(expression_text_stream, true);
+                    ttl_element.children[0]->format(settings);
+                    move_ttl_entries_by_name.emplace(expression_text_stream.str(), new_ttl_entry);
+                    /// FIXME: Save TTLElement type and destination somehow.
+                }
             }
         }
 
@@ -628,9 +636,9 @@ void MergeTreeData::setTTLExpressions(const ColumnsDescription::ColumnTTLs & new
             ttl_table_ast = new_delete_ttl_table_ast;
             ttl_table_entry = new_ttl_table_entry;
         }
-
-        // FIXME: Apply MOVE ttls.
     }
+
+    // FIXME: In case of ALTER one need to clean up previous values to actually set expression but not merge them.
 }
 
 

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -38,6 +38,7 @@
 #include <Common/Increment.h>
 #include <Common/SimpleIncrement.h>
 #include <Common/escapeForFileName.h>
+#include <Common/quoteString.h>
 #include <Common/StringUtils/StringUtils.h>
 #include <Common/Stopwatch.h>
 #include <Common/typeid_cast.h>
@@ -130,7 +131,6 @@ MergeTreeData::MergeTreeData(
     , merging_params(merging_params_)
     , partition_by_ast(partition_by_ast_)
     , sample_by_ast(sample_by_ast_)
-    , ttl_table_ast(ttl_table_ast_)
     , require_part_metadata(require_part_metadata_)
     , database_name(database_)
     , table_name(table_)
@@ -580,7 +580,7 @@ void MergeTreeData::setTTLExpressions(const ColumnsDescription::ColumnTTLs & new
         String result_column = ttl_ast->getColumnName();
         checkTTLExpression(expr, result_column);
 
-        return {expr, result_column, PartDestinationType::DELETE, {}};
+        return {expr, result_column, PartDestinationType::DELETE, {}, ttl_ast};
     };
 
     if (!new_column_ttls.empty())

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3214,26 +3214,26 @@ DiskSpace::ReservationPtr MergeTreeData::tryReserveSpaceInSpecificSpace(UInt64 e
     return space->reserve(expected_size);
 }
 
-DiskSpace::SpacePtr MergeTreeData::TTLEntry::getDestination(const DiskSpace::StoragePolicyPtr & storage_policy) const
+DiskSpace::SpacePtr MergeTreeData::TTLEntry::getDestination(const DiskSpace::StoragePolicyPtr & policy) const
 {
     if (destination_type == PartDestinationType::VOLUME)
-        return storage_policy->getVolumeByName(destination_name);
+        return policy->getVolumeByName(destination_name);
     else if (destination_type == PartDestinationType::DISK)
-        return storage_policy->getDiskByName(destination_name);
+        return policy->getDiskByName(destination_name);
     else
         return {};
 }
 
-bool MergeTreeData::TTLEntry::isPartInDestination(const DiskSpace::StoragePolicyPtr & storage_policy, const MergeTreeDataPart & part) const
+bool MergeTreeData::TTLEntry::isPartInDestination(const DiskSpace::StoragePolicyPtr & policy, const MergeTreeDataPart & part) const
 {
     if (destination_type == PartDestinationType::VOLUME)
     {
-        for (const auto & disk : storage_policy->getVolumeByName(destination_name)->disks)
+        for (const auto & disk : policy->getVolumeByName(destination_name)->disks)
             if (disk->getName() == part.disk->getName())
                 return true;
     }
     else if (destination_type == PartDestinationType::DISK)
-        return storage_policy->getDiskByName(destination_name)->getName() == part.disk->getName();
+        return policy->getDiskByName(destination_name)->getName() == part.disk->getName();
     return false;
 }
 

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3734,7 +3734,7 @@ const MergeTreeData::TTLEntry * MergeTreeData::selectMoveDestination(
     {
         auto ttl_info_it = ttl_infos.moves_ttl.find(ttl_entry.result_column);
         if (ttl_info_it != ttl_infos.moves_ttl.end()
-                && ttl_info_it->second.min >= minimum_time
+                && ttl_info_it->second.min <= minimum_time
                 && max_min_ttl <= ttl_info_it->second.min)
         {
             result = &ttl_entry;

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -572,15 +572,17 @@ void checkTTLExpression(const ExpressionActionsPtr & ttl_expression, const Strin
 void MergeTreeData::setTTLExpressions(const ColumnsDescription::ColumnTTLs & new_column_ttls,
         const ASTPtr & new_ttl_table_ast, bool only_check)
 {
-    auto create_ttl_entry = [this](ASTPtr ttl_ast) -> TTLEntry
+    auto create_ttl_entry = [this](ASTPtr ttl_ast)
     {
+        TTLEntry result;
+
         auto syntax_result = SyntaxAnalyzer(global_context).analyze(ttl_ast, getColumns().getAllPhysical());
-        auto expr = ExpressionAnalyzer(ttl_ast, syntax_result, global_context).getActions(false);
+        result.expression = ExpressionAnalyzer(ttl_ast, syntax_result, global_context).getActions(false);
+        result.destination_type = PartDestinationType::DELETE;
+        result.result_column = ttl_ast->getColumnName();
 
-        String result_column = ttl_ast->getColumnName();
-        checkTTLExpression(expr, result_column);
-
-        return {expr, result_column, PartDestinationType::DELETE, {}, {}};
+        checkTTLExpression(result.expression, result.result_column);
+        return result;
     };
 
     if (!new_column_ttls.empty())
@@ -3131,7 +3133,7 @@ MergeTreeData::MutableDataPartsVector MergeTreeData::tryLoadPartsToAttach(const 
 namespace
 {
 
-inline DiskSpace::ReservationPtr returnReservationOrThrowError(UInt64 expected_size, DiskSpace::ReservationPtr reservation)
+inline DiskSpace::ReservationPtr checkAndReturnReservation(UInt64 expected_size, DiskSpace::ReservationPtr reservation)
 {
     if (reservation)
         return reservation;
@@ -3148,7 +3150,23 @@ DiskSpace::ReservationPtr MergeTreeData::reserveSpace(UInt64 expected_size) cons
 
     auto reservation = storage_policy->reserve(expected_size);
 
-    return returnReservationOrThrowError(expected_size, std::move(reservation));
+    return checkAndReturnReservation(expected_size, std::move(reservation));
+}
+
+DiskSpace::ReservationPtr MergeTreeData::reserveSpace(UInt64 expected_size, DiskSpace::SpacePtr space) const
+{
+    expected_size = std::max(RESERVATION_MIN_ESTIMATION_SIZE, expected_size);
+
+    auto reservation = tryReserveSpace(expected_size, space);
+
+    return checkAndReturnReservation(expected_size, std::move(reservation));
+}
+
+DiskSpace::ReservationPtr MergeTreeData::tryReserveSpace(UInt64 expected_size, DiskSpace::SpacePtr space) const
+{
+    expected_size = std::max(RESERVATION_MIN_ESTIMATION_SIZE, expected_size);
+
+    return space->reserve(expected_size);
 }
 
 DiskSpace::ReservationPtr MergeTreeData::reserveSpacePreferringMoveDestination(UInt64 expected_size,
@@ -3159,7 +3177,7 @@ DiskSpace::ReservationPtr MergeTreeData::reserveSpacePreferringMoveDestination(U
 
     DiskSpace::ReservationPtr reservation = tryReserveSpacePreferringMoveDestination(expected_size, ttl_infos, time_of_move);
 
-    return returnReservationOrThrowError(expected_size, std::move(reservation));
+    return checkAndReturnReservation(expected_size, std::move(reservation));
 }
 
 DiskSpace::ReservationPtr MergeTreeData::tryReserveSpacePreferringMoveDestination(UInt64 expected_size,
@@ -3196,22 +3214,6 @@ DiskSpace::ReservationPtr MergeTreeData::tryReserveSpacePreferringMoveDestinatio
     reservation = storage_policy->reserve(expected_size);
 
     return reservation;
-}
-
-DiskSpace::ReservationPtr MergeTreeData::reserveSpaceInSpecificSpace(UInt64 expected_size, DiskSpace::SpacePtr space) const
-{
-    expected_size = std::max(RESERVATION_MIN_ESTIMATION_SIZE, expected_size);
-
-    auto reservation = tryReserveSpaceInSpecificSpace(expected_size, space);
-
-    return returnReservationOrThrowError(expected_size, std::move(reservation));
-}
-
-DiskSpace::ReservationPtr MergeTreeData::tryReserveSpaceInSpecificSpace(UInt64 expected_size, DiskSpace::SpacePtr space) const
-{
-    expected_size = std::max(RESERVATION_MIN_ESTIMATION_SIZE, expected_size);
-
-    return space->reserve(expected_size);
 }
 
 DiskSpace::SpacePtr MergeTreeData::TTLEntry::getDestination(const DiskSpace::StoragePolicyPtr & policy) const
@@ -3439,7 +3441,7 @@ MergeTreeData::MutableDataPartPtr MergeTreeData::cloneAndLoadDataPartOnSameDisk(
     String dst_part_name = src_part->getNewName(dst_part_info);
     String tmp_dst_part_name = tmp_part_prefix + dst_part_name;
 
-    auto reservation = reserveSpaceInSpecificSpace(src_part->bytes_on_disk, src_part->disk);
+    auto reservation = reserveSpace(src_part->bytes_on_disk, src_part->disk);
     String dst_part_path = getFullPathOnDisk(reservation->getDisk());
     Poco::Path dst_part_absolute_path = Poco::Path(dst_part_path + tmp_dst_part_name).absolute();
     Poco::Path src_part_absolute_path = Poco::Path(src_part->getFullPath()).absolute();

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -580,7 +580,7 @@ void MergeTreeData::setTTLExpressions(const ColumnsDescription::ColumnTTLs & new
         String result_column = ttl_ast->getColumnName();
         checkTTLExpression(expr, result_column);
 
-        return {expr, result_column, PartDestinationType::DELETE, {}, ttl_ast};
+        return {expr, result_column, PartDestinationType::DELETE, {}, {}};
     };
 
     if (!new_column_ttls.empty())
@@ -635,6 +635,7 @@ void MergeTreeData::setTTLExpressions(const ColumnsDescription::ColumnTTLs & new
                 auto new_ttl_entry = create_ttl_entry(ttl_element.children[0]);
                 if (!only_check)
                 {
+                    new_ttl_entry.entry_ast = ttl_element_ptr;
                     new_ttl_entry.destination_type = ttl_element.destination_type;
                     new_ttl_entry.destination_name = ttl_element.destination_name;
                     move_ttl_entries.emplace_back(std::move(new_ttl_entry));

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -598,12 +598,12 @@ void MergeTreeData::setTTLExpressions(const ColumnsDescription::ColumnTTLs & new
         for (const auto & [name, ast] : new_column_ttls)
         {
             if (columns_ttl_forbidden.count(name))
-                throw Exception("Trying to set ttl for key column " + name, ErrorCodes::ILLEGAL_COLUMN);
+                throw Exception("Trying to set TTL for key column " + name, ErrorCodes::ILLEGAL_COLUMN);
             else
             {
                 auto new_ttl_entry = create_ttl_entry(ast);
                 if (!only_check)
-                    ttl_entries_by_name.emplace(name, new_ttl_entry);
+                    column_ttl_entries_by_name.emplace(name, new_ttl_entry);
             }
         }
     }
@@ -3729,9 +3729,9 @@ const MergeTreeData::TTLEntry * MergeTreeData::selectMoveDestination(
     /// Prefer TTL rule which went into action last.
     time_t max_min_ttl = 0;
 
-    for (const auto & [expression, ttl_entry] : move_ttl_entries_by_name)
+    for (const auto & [name, ttl_entry] : move_ttl_entries_by_name)
     {
-        auto ttl_info_it = ttl_infos.moves_ttl.find(expression);
+        auto ttl_info_it = ttl_infos.moves_ttl.find(name);
         if (ttl_info_it != ttl_infos.moves_ttl.end()
                 && ttl_info_it->second.min >= minimum_time
                 && max_min_ttl <= ttl_info_it->second.min)

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -641,10 +641,6 @@ void MergeTreeData::setTTLExpressions(const ColumnsDescription::ColumnTTLs & new
             }
         }
     }
-
-    // FIXME: In case of ALTER one need to clean up previous values to actually set expression but not merge them.
-    // TODO: Check if ALTER MODIFY replaces TTL
-    // TODO: Check if ALTER MODIFY COLUMN + TTL works well (changing of name works with ttl)
 }
 
 

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3728,17 +3728,17 @@ const MergeTreeData::TTLEntry * MergeTreeData::selectMoveDestination(
 {
     const MergeTreeData::TTLEntry * result = nullptr;
     /// Prefer TTL rule which went into action last.
-    time_t max_min_ttl = 0;
+    time_t max_max_ttl = 0;
 
     for (const auto & ttl_entry : move_ttl_entries)
     {
         auto ttl_info_it = ttl_infos.moves_ttl.find(ttl_entry.result_column);
         if (ttl_info_it != ttl_infos.moves_ttl.end()
-                && ttl_info_it->second.min <= minimum_time
-                && max_min_ttl <= ttl_info_it->second.min)
+                && ttl_info_it->second.max <= minimum_time
+                && max_max_ttl >= ttl_info_it->second.max)
         {
             result = &ttl_entry;
-            max_min_ttl = ttl_info_it->second.min;
+            max_max_ttl = ttl_info_it->second.max;
         }
     }
 

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3153,71 +3153,93 @@ DiskSpace::ReservationPtr MergeTreeData::reserveSpace(UInt64 expected_size) cons
 
 DiskSpace::ReservationPtr MergeTreeData::reserveSpacePreferringMoveDestination(UInt64 expected_size,
         const MergeTreeDataPart::TTLInfos & ttl_infos,
-        time_t minimum_time) const
+        time_t time_of_move) const
 {
     expected_size = std::max(RESERVATION_MIN_ESTIMATION_SIZE, expected_size);
 
-    auto reservation = tryReserveSpaceOnMoveDestination(expected_size, ttl_infos, minimum_time);
-    if (reservation)
-        return reservation;
+    DiskSpace::ReservationPtr reservation;
+
+    auto ttl_entry = selectMoveDestination(ttl_infos, time_of_move);
+    if (ttl_entry != nullptr)
+    {
+        DiskSpace::SpacePtr destination_ptr = ttl_entry->getDestination(storage_policy);
+        if (!destination_ptr)
+        {
+            if (ttl_entry->destination_type == PartDestinationType::VOLUME)
+                LOG_WARNING(log, "Would like to reserve space on volume '"
+                        << ttl_entry->destination_name << "' by TTL rule of table '"
+                        << log_name << "' but volume was not found");
+            else if (ttl_entry->destination_type == PartDestinationType::DISK)
+                LOG_WARNING(log, "Would like to reserve space on disk '"
+                        << ttl_entry->destination_name << "' by TTL rule of table '"
+                        << log_name << "' but disk was not found");
+        }
+        else
+        {
+            reservation = destination_ptr->reserve(expected_size);
+            if (reservation)
+                return reservation;
+        }
+    }
 
     reservation = storage_policy->reserve(expected_size);
 
     return returnReservationOrThrowError(expected_size, std::move(reservation));
 }
 
-DiskSpace::ReservationPtr MergeTreeData::tryReserveSpaceOnMoveDestination(UInt64 expected_size,
-        const MergeTreeDataPart::TTLInfos & ttl_infos,
-        time_t minimum_time) const
+DiskSpace::ReservationPtr MergeTreeData::reserveSpaceInSpecificSpace(UInt64 expected_size, DiskSpace::SpacePtr space) const
 {
     expected_size = std::max(RESERVATION_MIN_ESTIMATION_SIZE, expected_size);
 
-    auto ttl_entry = selectMoveDestination(ttl_infos, minimum_time);
-    if (ttl_entry != nullptr)
-    {
-        DiskSpace::ReservationPtr reservation;
-        if (ttl_entry->destination_type == PartDestinationType::VOLUME)
-        {
-            auto volume_ptr = storage_policy->getVolumeByName(ttl_entry->destination_name);
-            if (volume_ptr)
-            {
-                reservation = volume_ptr->reserve(expected_size);
-            }
-            else
-            {
-                LOG_WARNING(log, "Would like to reserve space on volume '"
-                        << ttl_entry->destination_name << "' by TTL rule of table '"
-                        << log_name << "' but volume was not found");
-            }
-        }
-        else if (ttl_entry->destination_type == PartDestinationType::DISK)
-        {
-            auto disk_ptr = storage_policy->getDiskByName(ttl_entry->destination_name);
-            if (disk_ptr)
-            {
-                reservation = disk_ptr->reserve(expected_size);
-            }
-            else
-            {
-                LOG_WARNING(log, "Would like to reserve space on disk '"
-                        << ttl_entry->destination_name << "' by TTL rule of table '"
-                        << log_name << "' but disk was not found");
-            }
-        }
-        if (reservation)
-            return reservation;
-    }
-
-    return {};
-}
-
-DiskSpace::ReservationPtr MergeTreeData::reserveSpaceOnSpecificDisk(UInt64 expected_size, DiskSpace::DiskPtr disk) const
-{
-    expected_size = std::max(RESERVATION_MIN_ESTIMATION_SIZE, expected_size);
-
-    auto reservation = disk->reserve(expected_size);
+    auto reservation = space->reserve(expected_size);
 
     return returnReservationOrThrowError(expected_size, std::move(reservation));
+}
+
+DiskSpace::SpacePtr MergeTreeData::TTLEntry::getDestination(const DiskSpace::StoragePolicyPtr & storage_policy) const
+{
+    if (destination_type == PartDestinationType::VOLUME)
+        return storage_policy->getVolumeByName(destination_name);
+    else if (destination_type == PartDestinationType::DISK)
+        return storage_policy->getDiskByName(destination_name);
+    else
+        return {};
+}
+
+bool MergeTreeData::TTLEntry::isPartInDestination(const DiskSpace::StoragePolicyPtr & storage_policy, const MergeTreeDataPart & part) const
+{
+    if (destination_type == PartDestinationType::VOLUME)
+    {
+        for (const auto & disk : storage_policy->getVolumeByName(destination_name)->disks)
+            if (disk->getName() == part.disk->getName())
+                return true;
+    }
+    else if (destination_type == PartDestinationType::DISK)
+        return storage_policy->getDiskByName(destination_name)->getName() == part.disk->getName();
+    return false;
+}
+
+const MergeTreeData::TTLEntry * MergeTreeData::selectMoveDestination(
+        const MergeTreeDataPart::TTLInfos & ttl_infos,
+        time_t time_of_move) const
+{
+    const MergeTreeData::TTLEntry * result = nullptr;
+    /// Prefer TTL rule which went into action last.
+    time_t max_max_ttl = 0;
+
+    for (const auto & ttl_entry : move_ttl_entries)
+    {
+        auto ttl_info_it = ttl_infos.moves_ttl.find(ttl_entry.result_column);
+        if (ttl_info_it != ttl_infos.moves_ttl.end()
+                && ttl_info_it->second.max <= time_of_move
+                && max_max_ttl >= ttl_info_it->second.max)
+        {
+            result = &ttl_entry;
+            max_max_ttl = ttl_info_it->second.max;
+        }
+    }
+
+    return result;
 }
 
 MergeTreeData::DataParts MergeTreeData::getDataParts(const DataPartStates & affordable_states) const
@@ -3399,7 +3421,7 @@ MergeTreeData::MutableDataPartPtr MergeTreeData::cloneAndLoadDataPartOnSameDisk(
     String dst_part_name = src_part->getNewName(dst_part_info);
     String tmp_dst_part_name = tmp_part_prefix + dst_part_name;
 
-    auto reservation = reserveSpaceOnSpecificDisk(src_part->bytes_on_disk, src_part->disk);
+    auto reservation = reserveSpaceInSpecificSpace(src_part->bytes_on_disk, src_part->disk);
     String dst_part_path = getFullPathOnDisk(reservation->getDisk());
     Poco::Path dst_part_absolute_path = Poco::Path(dst_part_path + tmp_dst_part_name).absolute();
     Poco::Path src_part_absolute_path = Poco::Path(src_part->getFullPath()).absolute();
@@ -3720,29 +3742,6 @@ bool MergeTreeData::moveParts(CurrentlyMovingPartsTagger && moving_tagger)
         }
     }
     return true;
-}
-
-const MergeTreeData::TTLEntry * MergeTreeData::selectMoveDestination(
-        const MergeTreeDataPart::TTLInfos & ttl_infos,
-        time_t minimum_time) const
-{
-    const MergeTreeData::TTLEntry * result = nullptr;
-    /// Prefer TTL rule which went into action last.
-    time_t max_max_ttl = 0;
-
-    for (const auto & ttl_entry : move_ttl_entries)
-    {
-        auto ttl_info_it = ttl_infos.moves_ttl.find(ttl_entry.result_column);
-        if (ttl_info_it != ttl_infos.moves_ttl.end()
-                && ttl_info_it->second.max <= minimum_time
-                && max_max_ttl >= ttl_info_it->second.max)
-        {
-            result = &ttl_entry;
-            max_max_ttl = ttl_info_it->second.max;
-        }
-    }
-
-    return result;
 }
 
 }

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3159,7 +3159,7 @@ DiskSpace::ReservationPtr MergeTreeData::reserveSpacePreferringMoveDestination(U
     auto reservation = tryReserveSpaceOnMoveDestination(expected_size, ttl_infos, minimum_time);
     if (reservation)
         return reservation;
-    
+
     reservation = storage_policy->reserve(expected_size);
 
     return returnReservationOrThrowError(expected_size, std::move(reservation));

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -580,7 +580,7 @@ void MergeTreeData::setTTLExpressions(const ColumnsDescription::ColumnTTLs & new
         String result_column = ttl_ast->getColumnName();
         checkTTLExpression(expr, result_column);
 
-        return {expr, result_column};
+        return {expr, result_column, TTLDestinationType::DELETE, {}};
     };
 
     if (!new_column_ttls.empty())
@@ -635,8 +635,9 @@ void MergeTreeData::setTTLExpressions(const ColumnsDescription::ColumnTTLs & new
                 auto new_ttl_entry = create_ttl_entry(ttl_element.children[0]);
                 if (!only_check)
                 {
-                    TTLEntry entry{new_ttl_entry.expression, new_ttl_entry.result_column, ttl_element.destination_type, ttl_element.destination_name};
-                    move_ttl_entries_by_name.emplace(new_ttl_entry.result_column, entry);
+                    new_ttl_entry.destination_type = ttl_element.destination_type;
+                    new_ttl_entry.destination_name = ttl_element.destination_name;
+                    move_ttl_entries_by_name.emplace(new_ttl_entry.result_column, new_ttl_entry);
                 }
             }
         }
@@ -3129,11 +3130,13 @@ MergeTreeData::MutableDataPartsVector MergeTreeData::tryLoadPartsToAttach(const 
 namespace
 {
 
-inline DiskSpace::ReservationPtr throwNotEnoughSpace(UInt64 expected_size)
+inline DiskSpace::ReservationPtr returnReservationOrThrowError(UInt64 expected_size, DiskSpace::ReservationPtr reservation)
 {
+    if (reservation)
+        return reservation;
+
     throw Exception("Cannot reserve " + formatReadableSizeWithBinarySuffix(expected_size) + ", not enough space",
                     ErrorCodes::NOT_ENOUGH_SPACE);
-    return {};
 }
 
 }
@@ -3143,10 +3146,8 @@ DiskSpace::ReservationPtr MergeTreeData::reserveSpace(UInt64 expected_size) cons
     expected_size = std::max(RESERVATION_MIN_ESTIMATION_SIZE, expected_size);
 
     auto reservation = storage_policy->reserve(expected_size);
-    if (reservation)
-        return reservation;
 
-    return throwNotEnoughSpace(expected_size);
+    return returnReservationOrThrowError(expected_size, std::move(reservation));
 }
 
 DiskSpace::ReservationPtr MergeTreeData::reserveSpacePreferringMoveDestination(UInt64 expected_size,
@@ -3160,10 +3161,8 @@ DiskSpace::ReservationPtr MergeTreeData::reserveSpacePreferringMoveDestination(U
         return reservation;
     
     reservation = storage_policy->reserve(expected_size);
-    if (reservation)
-        return reservation;
 
-    return throwNotEnoughSpace(expected_size);
+    return returnReservationOrThrowError(expected_size, std::move(reservation));
 }
 
 DiskSpace::ReservationPtr MergeTreeData::tryReserveSpaceOnMoveDestination(UInt64 expected_size,
@@ -3216,10 +3215,8 @@ DiskSpace::ReservationPtr MergeTreeData::reserveSpaceOnSpecificDisk(UInt64 expec
     expected_size = std::max(RESERVATION_MIN_ESTIMATION_SIZE, expected_size);
 
     auto reservation = disk->reserve(expected_size);
-    if (reservation)
-        return reservation;
 
-    return throwNotEnoughSpace(expected_size);
+    return returnReservationOrThrowError(expected_size, std::move(reservation));
 }
 
 MergeTreeData::DataParts MergeTreeData::getDataParts(const DataPartStates & affordable_states) const

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3169,18 +3169,18 @@ DiskSpace::ReservationPtr MergeTreeData::tryReserveSpace(UInt64 expected_size, D
     return space->reserve(expected_size);
 }
 
-DiskSpace::ReservationPtr MergeTreeData::reserveSpacePreferringMoveDestination(UInt64 expected_size,
+DiskSpace::ReservationPtr MergeTreeData::reserveSpacePreferringTTLRules(UInt64 expected_size,
         const MergeTreeDataPart::TTLInfos & ttl_infos,
         time_t time_of_move) const
 {
     expected_size = std::max(RESERVATION_MIN_ESTIMATION_SIZE, expected_size);
 
-    DiskSpace::ReservationPtr reservation = tryReserveSpacePreferringMoveDestination(expected_size, ttl_infos, time_of_move);
+    DiskSpace::ReservationPtr reservation = tryReserveSpacePreferringTTLRules(expected_size, ttl_infos, time_of_move);
 
     return checkAndReturnReservation(expected_size, std::move(reservation));
 }
 
-DiskSpace::ReservationPtr MergeTreeData::tryReserveSpacePreferringMoveDestination(UInt64 expected_size,
+DiskSpace::ReservationPtr MergeTreeData::tryReserveSpacePreferringTTLRules(UInt64 expected_size,
         const MergeTreeDataPart::TTLInfos & ttl_infos,
         time_t time_of_move) const
 {
@@ -3188,7 +3188,7 @@ DiskSpace::ReservationPtr MergeTreeData::tryReserveSpacePreferringMoveDestinatio
 
     DiskSpace::ReservationPtr reservation;
 
-    auto ttl_entry = selectMoveDestination(ttl_infos, time_of_move);
+    auto ttl_entry = selectTTLEntryForTTLInfos(ttl_infos, time_of_move);
     if (ttl_entry != nullptr)
     {
         DiskSpace::SpacePtr destination_ptr = ttl_entry->getDestination(storage_policy);
@@ -3239,7 +3239,7 @@ bool MergeTreeData::TTLEntry::isPartInDestination(const DiskSpace::StoragePolicy
     return false;
 }
 
-const MergeTreeData::TTLEntry * MergeTreeData::selectMoveDestination(
+const MergeTreeData::TTLEntry * MergeTreeData::selectTTLEntryForTTLInfos(
         const MergeTreeDataPart::TTLInfos & ttl_infos,
         time_t time_of_move) const
 {

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -70,6 +70,12 @@ namespace CurrentMetrics
 }
 
 
+namespace
+{
+    constexpr UInt64 RESERVATION_MIN_ESTIMATION_SIZE = 1u * 1024u * 1024u; /// 1MB
+}
+
+
 namespace DB
 {
 
@@ -608,11 +614,11 @@ void MergeTreeData::setTTLExpressions(const ColumnsDescription::ColumnTTLs & new
         for (auto ttl_element_ptr : new_ttl_table_ast->children)
         {
             ASTTTLElement & ttl_element = static_cast<ASTTTLElement &>(*ttl_element_ptr);
-            if (ttl_element.destination_type == ASTTTLElement::DELETE)
+            if (ttl_element.destination_type == TTLDestinationType::DELETE)
             {
                 if (seen_delete_ttl)
                 {
-                    throw Exception("Too many DELETE ttls", ErrorCodes::BAD_TTL_EXPRESSION);
+                    throw Exception("More than one DELETE TTL expression is not allowed", ErrorCodes::BAD_TTL_EXPRESSION);
                 }
 
                 auto new_ttl_table_entry = create_ttl_entry(ttl_element.children[0]);
@@ -629,7 +635,7 @@ void MergeTreeData::setTTLExpressions(const ColumnsDescription::ColumnTTLs & new
                 auto new_ttl_entry = create_ttl_entry(ttl_element.children[0]);
                 if (!only_check)
                 {
-                    MoveTTLEntry entry = { new_ttl_entry.expression, new_ttl_entry.result_column, ttl_element.destination_type, ttl_element.destination_name };
+                    TTLEntry entry{new_ttl_entry.expression, new_ttl_entry.result_column, ttl_element.destination_type, ttl_element.destination_name};
                     move_ttl_entries_by_name.emplace(new_ttl_entry.result_column, entry);
                 }
             }
@@ -3124,18 +3130,100 @@ MergeTreeData::MutableDataPartsVector MergeTreeData::tryLoadPartsToAttach(const 
     return loaded_parts;
 }
 
-DiskSpace::ReservationPtr MergeTreeData::reserveSpace(UInt64 expected_size)
+namespace
 {
-    constexpr UInt64 RESERVATION_MIN_ESTIMATION_SIZE = 1u * 1024u * 1024u; /// 1MB
 
+inline DiskSpace::ReservationPtr throwNotEnoughSpace(UInt64 expected_size)
+{
+    throw Exception("Cannot reserve " + formatReadableSizeWithBinarySuffix(expected_size) + ", not enough space",
+                    ErrorCodes::NOT_ENOUGH_SPACE);
+    return {};
+}
+
+}
+
+DiskSpace::ReservationPtr MergeTreeData::reserveSpace(UInt64 expected_size) const
+{
     expected_size = std::max(RESERVATION_MIN_ESTIMATION_SIZE, expected_size);
 
     auto reservation = storage_policy->reserve(expected_size);
     if (reservation)
         return reservation;
 
-    throw Exception("Cannot reserve " + formatReadableSizeWithBinarySuffix(expected_size) + ", not enough space.",
-                    ErrorCodes::NOT_ENOUGH_SPACE);
+    return throwNotEnoughSpace(expected_size);
+}
+
+DiskSpace::ReservationPtr MergeTreeData::reserveSpacePreferringMoveDestination(UInt64 expected_size,
+        const MergeTreeDataPart::TTLInfos & ttl_infos,
+        time_t minimum_time) const
+{
+    expected_size = std::max(RESERVATION_MIN_ESTIMATION_SIZE, expected_size);
+
+    auto reservation = tryReserveSpaceOnMoveDestination(expected_size, ttl_infos, minimum_time);
+    if (reservation)
+        return reservation;
+    
+    reservation = storage_policy->reserve(expected_size);
+    if (reservation)
+        return reservation;
+
+    return throwNotEnoughSpace(expected_size);
+}
+
+DiskSpace::ReservationPtr MergeTreeData::tryReserveSpaceOnMoveDestination(UInt64 expected_size,
+        const MergeTreeDataPart::TTLInfos & ttl_infos,
+        time_t minimum_time) const
+{
+    expected_size = std::max(RESERVATION_MIN_ESTIMATION_SIZE, expected_size);
+
+    auto ttl_entry = selectMoveDestination(ttl_infos, minimum_time);
+    if (ttl_entry != nullptr)
+    {
+        DiskSpace::ReservationPtr reservation;
+        if (ttl_entry->destination_type == TTLDestinationType::VOLUME)
+        {
+            auto volume_ptr = storage_policy->getVolumeByName(ttl_entry->destination_name);
+            if (volume_ptr)
+            {
+                reservation = volume_ptr->reserve(expected_size);
+            }
+            else
+            {
+                LOG_WARNING(log, "Would like to reserve space on volume '"
+                        << ttl_entry->destination_name << "' by TTL rule of table '"
+                        << log_name << "' but volume was not found");
+            }
+        }
+        else if (ttl_entry->destination_type == TTLDestinationType::DISK)
+        {
+            auto disk_ptr = storage_policy->getDiskByName(ttl_entry->destination_name);
+            if (disk_ptr)
+            {
+                reservation = disk_ptr->reserve(expected_size);
+            }
+            else
+            {
+                LOG_WARNING(log, "Would like to reserve space on disk '"
+                        << ttl_entry->destination_name << "' by TTL rule of table '"
+                        << log_name << "' but disk was not found");
+            }
+        }
+        if (reservation)
+            return reservation;
+    }
+
+    return {};
+}
+
+DiskSpace::ReservationPtr MergeTreeData::reserveSpaceOnSpecificDisk(UInt64 expected_size, DiskSpace::DiskPtr disk) const
+{
+    expected_size = std::max(RESERVATION_MIN_ESTIMATION_SIZE, expected_size);
+
+    auto reservation = disk->reserve(expected_size);
+    if (reservation)
+        return reservation;
+
+    return throwNotEnoughSpace(expected_size);
 }
 
 MergeTreeData::DataParts MergeTreeData::getDataParts(const DataPartStates & affordable_states) const
@@ -3317,12 +3405,7 @@ MergeTreeData::MutableDataPartPtr MergeTreeData::cloneAndLoadDataPartOnSameDisk(
     String dst_part_name = src_part->getNewName(dst_part_info);
     String tmp_dst_part_name = tmp_part_prefix + dst_part_name;
 
-    auto reservation = src_part->disk->reserve(src_part->bytes_on_disk);
-    if (!reservation)
-    {
-        throw Exception("Cannot reserve " + formatReadableSizeWithBinarySuffix(src_part->bytes_on_disk) + ", not enough space",
-                    ErrorCodes::NOT_ENOUGH_SPACE);
-    }
+    auto reservation = reserveSpaceOnSpecificDisk(src_part->bytes_on_disk, src_part->disk);
     String dst_part_path = getFullPathOnDisk(reservation->getDisk());
     Poco::Path dst_part_absolute_path = Poco::Path(dst_part_path + tmp_dst_part_name).absolute();
     Poco::Path src_part_absolute_path = Poco::Path(src_part->getFullPath()).absolute();
@@ -3643,6 +3726,29 @@ bool MergeTreeData::moveParts(CurrentlyMovingPartsTagger && moving_tagger)
         }
     }
     return true;
+}
+
+const MergeTreeData::TTLEntry * MergeTreeData::selectMoveDestination(
+        const MergeTreeDataPart::TTLInfos & ttl_infos,
+        time_t minimum_time) const
+{
+    const MergeTreeData::TTLEntry * result = nullptr;
+    /// Prefer TTL rule which went into action last.
+    time_t max_min_ttl = 0;
+
+    for (const auto & [expression, ttl_entry] : move_ttl_entries_by_name)
+    {
+        auto ttl_info_it = ttl_infos.moves_ttl.find(expression);
+        if (ttl_info_it != ttl_infos.moves_ttl.end()
+                && ttl_info_it->second.min >= minimum_time
+                && max_min_ttl <= ttl_info_it->second.min)
+        {
+            result = &ttl_entry;
+            max_min_ttl = ttl_info_it->second.min;
+        }
+    }
+
+    return result;
 }
 
 }

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -637,7 +637,7 @@ void MergeTreeData::setTTLExpressions(const ColumnsDescription::ColumnTTLs & new
                 {
                     new_ttl_entry.destination_type = ttl_element.destination_type;
                     new_ttl_entry.destination_name = ttl_element.destination_name;
-                    move_ttl_entries_by_name.emplace(new_ttl_entry.result_column, new_ttl_entry);
+                    move_ttl_entries.emplace_back(std::move(new_ttl_entry));
                 }
             }
         }
@@ -3729,9 +3729,9 @@ const MergeTreeData::TTLEntry * MergeTreeData::selectMoveDestination(
     /// Prefer TTL rule which went into action last.
     time_t max_min_ttl = 0;
 
-    for (const auto & [name, ttl_entry] : move_ttl_entries_by_name)
+    for (const auto & ttl_entry : move_ttl_entries)
     {
-        auto ttl_info_it = ttl_infos.moves_ttl.find(name);
+        auto ttl_info_it = ttl_infos.moves_ttl.find(ttl_entry.result_column);
         if (ttl_info_it != ttl_infos.moves_ttl.end()
                 && ttl_info_it->second.min >= minimum_time
                 && max_min_ttl <= ttl_info_it->second.min)

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -580,7 +580,7 @@ void MergeTreeData::setTTLExpressions(const ColumnsDescription::ColumnTTLs & new
         String result_column = ttl_ast->getColumnName();
         checkTTLExpression(expr, result_column);
 
-        return {expr, result_column, TTLDestinationType::DELETE, {}};
+        return {expr, result_column, PartDestinationType::DELETE, {}};
     };
 
     if (!new_column_ttls.empty())
@@ -614,7 +614,7 @@ void MergeTreeData::setTTLExpressions(const ColumnsDescription::ColumnTTLs & new
         for (auto ttl_element_ptr : new_ttl_table_ast->children)
         {
             ASTTTLElement & ttl_element = static_cast<ASTTTLElement &>(*ttl_element_ptr);
-            if (ttl_element.destination_type == TTLDestinationType::DELETE)
+            if (ttl_element.destination_type == PartDestinationType::DELETE)
             {
                 if (seen_delete_ttl)
                 {
@@ -3175,7 +3175,7 @@ DiskSpace::ReservationPtr MergeTreeData::tryReserveSpaceOnMoveDestination(UInt64
     if (ttl_entry != nullptr)
     {
         DiskSpace::ReservationPtr reservation;
-        if (ttl_entry->destination_type == TTLDestinationType::VOLUME)
+        if (ttl_entry->destination_type == PartDestinationType::VOLUME)
         {
             auto volume_ptr = storage_policy->getVolumeByName(ttl_entry->destination_name);
             if (volume_ptr)
@@ -3189,7 +3189,7 @@ DiskSpace::ReservationPtr MergeTreeData::tryReserveSpaceOnMoveDestination(UInt64
                         << log_name << "' but volume was not found");
             }
         }
-        else if (ttl_entry->destination_type == TTLDestinationType::DISK)
+        else if (ttl_entry->destination_type == PartDestinationType::DISK)
         {
             auto disk_ptr = storage_policy->getDiskByName(ttl_entry->destination_name);
             if (disk_ptr)

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3232,7 +3232,7 @@ const MergeTreeData::TTLEntry * MergeTreeData::selectMoveDestination(
         auto ttl_info_it = ttl_infos.moves_ttl.find(ttl_entry.result_column);
         if (ttl_info_it != ttl_infos.moves_ttl.end()
                 && ttl_info_it->second.max <= time_of_move
-                && max_max_ttl >= ttl_info_it->second.max)
+                && max_max_ttl <= ttl_info_it->second.max)
         {
             result = &ttl_entry;
             max_max_ttl = ttl_info_it->second.max;

--- a/dbms/src/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.h
@@ -565,7 +565,7 @@ public:
     /// All MergeTreeData children have settings.
     void checkSettingCanBeChanged(const String & setting_name) const override;
 
-    /// Remove columns, that have been markedd as empty after zeroing values with expired ttl
+    /// Remove columns, that have been marked as empty after zeroing values with expired ttl
     void removeEmptyColumnsFromPart(MergeTreeData::MutableDataPartPtr & data_part);
 
     /// Freezes all parts.

--- a/dbms/src/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.h
@@ -737,7 +737,7 @@ public:
     TTLEntriesByName column_ttl_entries_by_name;
 
     TTLEntry ttl_table_entry;
-    TTLEntriesByName move_ttl_entries_by_name;
+    std::vector<TTLEntry> move_ttl_entries;
 
     String sampling_expr_column_name;
     Names columns_required_for_sampling;

--- a/dbms/src/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.h
@@ -732,7 +732,7 @@ public:
         ExpressionActionsPtr expression;
         String result_column;
         ASTTTLElement::DestinationType destination_type;
-        String destination_name; 
+        String destination_name;
     };
 
     using MoveTTLEntriesByName = std::unordered_map<String, MoveTTLEntry>;

--- a/dbms/src/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.h
@@ -726,6 +726,8 @@ public:
 
     TTLEntry ttl_table_entry;
 
+    TTLEntriesByName move_ttl_entries_by_name;
+
     String sampling_expr_column_name;
     Names columns_required_for_sampling;
 

--- a/dbms/src/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.h
@@ -21,7 +21,6 @@
 #include <Storages/IndicesDescription.h>
 #include <Storages/MergeTree/MergeTreePartsMover.h>
 #include <Interpreters/PartLog.h>
-#include <Common/DiskSpaceMonitor.h>
 
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/ordered_index.hpp>

--- a/dbms/src/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.h
@@ -587,8 +587,8 @@ public:
     bool hasSortingKey() const { return !sorting_key_columns.empty(); }
     bool hasPrimaryKey() const { return !primary_key_columns.empty(); }
     bool hasSkipIndices() const { return !skip_indices.empty(); }
-    bool hasTableTTL() const { return ttl_table_ast != nullptr; }
-    bool hasAnyColumnTTL() const { return !ttl_entries_by_name.empty(); }
+    bool hasTableTTL() const { return ttl_table_entry.expression != nullptr; }
+    bool hasAnyColumnTTL() const { return !column_ttl_entries_by_name.empty(); }
 
     /// Check that the part is not broken and calculate the checksums for it if they are not present.
     MutableDataPartPtr loadPartAndFixMetadata(const DiskSpace::DiskPtr & disk, const String & relative_path);
@@ -734,7 +734,7 @@ public:
     };
 
     using TTLEntriesByName = std::unordered_map<String, TTLEntry>;
-    TTLEntriesByName ttl_entries_by_name;
+    TTLEntriesByName column_ttl_entries_by_name;
 
     TTLEntry ttl_table_entry;
     TTLEntriesByName move_ttl_entries_by_name;

--- a/dbms/src/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.h
@@ -674,17 +674,21 @@ public:
     using PathsWithDisks = std::vector<PathWithDisk>;
     PathsWithDisks getDataPathsWithDisks() const;
 
-    /// Reserves space at least 1MB
+    /// Reserves space at least 1MB.
     DiskSpace::ReservationPtr reserveSpace(UInt64 expected_size) const;
+
+    /// Reserves space at least 1MB on specific disk or volume.
+    DiskSpace::ReservationPtr reserveSpace(UInt64 expected_size, DiskSpace::SpacePtr space) const;
+    DiskSpace::ReservationPtr tryReserveSpace(UInt64 expected_size, DiskSpace::SpacePtr space) const;
+
+ 
+    /// Reserves space at least 1MB preferring best destination according to `ttl_infos`.
     DiskSpace::ReservationPtr reserveSpacePreferringMoveDestination(UInt64 expected_size,
                                                                     const MergeTreeDataPart::TTLInfos & ttl_infos,
                                                                     time_t time_of_move) const;
     DiskSpace::ReservationPtr tryReserveSpacePreferringMoveDestination(UInt64 expected_size,
                                                                     const MergeTreeDataPart::TTLInfos & ttl_infos,
                                                                     time_t time_of_move) const;
-    DiskSpace::ReservationPtr reserveSpaceInSpecificSpace(UInt64 expected_size, DiskSpace::SpacePtr space) const;
-    DiskSpace::ReservationPtr tryReserveSpaceInSpecificSpace(UInt64 expected_size, DiskSpace::SpacePtr space) const;
-
     /// Choose disk with max available free space
     /// Reserves 0 bytes
     DiskSpace::ReservationPtr makeEmptyReservationOnLargestDisk() { return storage_policy->makeEmptyReservationOnLargestDisk(); }
@@ -735,7 +739,10 @@ public:
 
         ASTPtr entry_ast;
 
+        /// Returns destination disk or volume for this rule.
         DiskSpace::SpacePtr getDestination(const DiskSpace::StoragePolicyPtr & policy) const;
+
+        /// Checks if given part already belongs destination disk or volume for this rule.
         bool isPartInDestination(const DiskSpace::StoragePolicyPtr & policy, const MergeTreeDataPart & part) const;
     };
 

--- a/dbms/src/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.h
@@ -681,7 +681,6 @@ public:
     DiskSpace::ReservationPtr reserveSpace(UInt64 expected_size, DiskSpace::SpacePtr space) const;
     DiskSpace::ReservationPtr tryReserveSpace(UInt64 expected_size, DiskSpace::SpacePtr space) const;
 
- 
     /// Reserves space at least 1MB preferring best destination according to `ttl_infos`.
     DiskSpace::ReservationPtr reserveSpacePreferringMoveDestination(UInt64 expected_size,
                                                                     const MergeTreeDataPart::TTLInfos & ttl_infos,

--- a/dbms/src/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.h
@@ -10,7 +10,7 @@
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/MergeTree/MergeTreeMutationStatus.h>
 #include <Storages/MergeTree/MergeList.h>
-#include <Storages/MergeTree/TTLDestinationType.h>
+#include <Storages/MergeTree/PartDestinationType.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/WriteBufferFromFile.h>
 #include <IO/ReadBufferFromFile.h>
@@ -729,7 +729,7 @@ public:
         String result_column;
 
         /// Name and type of a destination are only valid in table-level context.
-        TTLDestinationType destination_type;
+        PartDestinationType destination_type;
         String destination_name;
     };
 

--- a/dbms/src/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.h
@@ -678,11 +678,8 @@ public:
     DiskSpace::ReservationPtr reserveSpace(UInt64 expected_size) const;
     DiskSpace::ReservationPtr reserveSpacePreferringMoveDestination(UInt64 expected_size,
                                                                     const MergeTreeDataPart::TTLInfos & ttl_infos,
-                                                                    time_t minimum_time) const;
-    DiskSpace::ReservationPtr tryReserveSpaceOnMoveDestination(UInt64 expected_size,
-                                                               const MergeTreeDataPart::TTLInfos & ttl_infos,
-                                                               time_t minimum_time) const;
-    DiskSpace::ReservationPtr reserveSpaceOnSpecificDisk(UInt64 expected_size, DiskSpace::DiskPtr disk) const;
+                                                                    time_t time_of_move) const;
+    DiskSpace::ReservationPtr reserveSpaceInSpecificSpace(UInt64 expected_size, DiskSpace::SpacePtr space) const;
 
     /// Choose disk with max available free space
     /// Reserves 0 bytes
@@ -733,7 +730,12 @@ public:
         String destination_name;
 
         ASTPtr entry_ast;
+
+        DiskSpace::SpacePtr getDestination(const DiskSpace::StoragePolicyPtr & storage_policy) const;
+        bool isPartInDestination(const DiskSpace::StoragePolicyPtr & storage_policy, const MergeTreeDataPart & part) const;
     };
+
+    const TTLEntry * selectMoveDestination(const MergeTreeDataPart::TTLInfos & ttl_infos, time_t time_of_move) const;
 
     using TTLEntriesByName = std::unordered_map<String, TTLEntry>;
     TTLEntriesByName column_ttl_entries_by_name;
@@ -978,9 +980,6 @@ private:
 
     /// Check selected parts for movements. Used by ALTER ... MOVE queries.
     CurrentlyMovingPartsTagger checkPartsForMove(const DataPartsVector & parts, DiskSpace::SpacePtr space);
-
-    const MergeTreeData::TTLEntry * selectMoveDestination(const MergeTreeDataPart::TTLInfos & ttl_infos,
-                                                          time_t minimum_time) const;
 };
 
 }

--- a/dbms/src/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.h
@@ -682,12 +682,12 @@ public:
     DiskSpace::ReservationPtr tryReserveSpace(UInt64 expected_size, DiskSpace::SpacePtr space) const;
 
     /// Reserves space at least 1MB preferring best destination according to `ttl_infos`.
-    DiskSpace::ReservationPtr reserveSpacePreferringMoveDestination(UInt64 expected_size,
-                                                                    const MergeTreeDataPart::TTLInfos & ttl_infos,
-                                                                    time_t time_of_move) const;
-    DiskSpace::ReservationPtr tryReserveSpacePreferringMoveDestination(UInt64 expected_size,
-                                                                    const MergeTreeDataPart::TTLInfos & ttl_infos,
-                                                                    time_t time_of_move) const;
+    DiskSpace::ReservationPtr reserveSpacePreferringTTLRules(UInt64 expected_size,
+                                                                const MergeTreeDataPart::TTLInfos & ttl_infos,
+                                                                time_t time_of_move) const;
+    DiskSpace::ReservationPtr tryReserveSpacePreferringTTLRules(UInt64 expected_size,
+                                                                const MergeTreeDataPart::TTLInfos & ttl_infos,
+                                                                time_t time_of_move) const;
     /// Choose disk with max available free space
     /// Reserves 0 bytes
     DiskSpace::ReservationPtr makeEmptyReservationOnLargestDisk() { return storage_policy->makeEmptyReservationOnLargestDisk(); }
@@ -745,7 +745,7 @@ public:
         bool isPartInDestination(const DiskSpace::StoragePolicyPtr & policy, const MergeTreeDataPart & part) const;
     };
 
-    const TTLEntry * selectMoveDestination(const MergeTreeDataPart::TTLInfos & ttl_infos, time_t time_of_move) const;
+    const TTLEntry * selectTTLEntryForTTLInfos(const MergeTreeDataPart::TTLInfos & ttl_infos, time_t time_of_move) const;
 
     using TTLEntriesByName = std::unordered_map<String, TTLEntry>;
     TTLEntriesByName column_ttl_entries_by_name;

--- a/dbms/src/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.h
@@ -679,7 +679,11 @@ public:
     DiskSpace::ReservationPtr reserveSpacePreferringMoveDestination(UInt64 expected_size,
                                                                     const MergeTreeDataPart::TTLInfos & ttl_infos,
                                                                     time_t time_of_move) const;
+    DiskSpace::ReservationPtr tryReserveSpacePreferringMoveDestination(UInt64 expected_size,
+                                                                    const MergeTreeDataPart::TTLInfos & ttl_infos,
+                                                                    time_t time_of_move) const;
     DiskSpace::ReservationPtr reserveSpaceInSpecificSpace(UInt64 expected_size, DiskSpace::SpacePtr space) const;
+    DiskSpace::ReservationPtr tryReserveSpaceInSpecificSpace(UInt64 expected_size, DiskSpace::SpacePtr space) const;
 
     /// Choose disk with max available free space
     /// Reserves 0 bytes

--- a/dbms/src/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.h
@@ -587,7 +587,7 @@ public:
     bool hasSortingKey() const { return !sorting_key_columns.empty(); }
     bool hasPrimaryKey() const { return !primary_key_columns.empty(); }
     bool hasSkipIndices() const { return !skip_indices.empty(); }
-    bool hasTableTTL() const { return ttl_table_entry.expression != nullptr; }
+    bool hasTableTTL() const { return ttl_table_ast != nullptr; }
     bool hasAnyColumnTTL() const { return !column_ttl_entries_by_name.empty(); }
 
     /// Check that the part is not broken and calculate the checksums for it if they are not present.
@@ -731,6 +731,8 @@ public:
         /// Name and type of a destination are only valid in table-level context.
         PartDestinationType destination_type;
         String destination_name;
+
+        ASTPtr entry_ast;
     };
 
     using TTLEntriesByName = std::unordered_map<String, TTLEntry>;

--- a/dbms/src/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.h
@@ -735,8 +735,8 @@ public:
 
         ASTPtr entry_ast;
 
-        DiskSpace::SpacePtr getDestination(const DiskSpace::StoragePolicyPtr & storage_policy) const;
-        bool isPartInDestination(const DiskSpace::StoragePolicyPtr & storage_policy, const MergeTreeDataPart & part) const;
+        DiskSpace::SpacePtr getDestination(const DiskSpace::StoragePolicyPtr & policy) const;
+        bool isPartInDestination(const DiskSpace::StoragePolicyPtr & policy, const MergeTreeDataPart & part) const;
     };
 
     const TTLEntry * selectMoveDestination(const MergeTreeDataPart::TTLInfos & ttl_infos, time_t time_of_move) const;

--- a/dbms/src/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.h
@@ -3,6 +3,7 @@
 #include <Common/SimpleIncrement.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/ExpressionActions.h>
+#include <Parsers/ASTTTLElement.h>
 #include <Storages/IStorage.h>
 #include <Storages/MergeTree/MergeTreeIndices.h>
 #include <Storages/MergeTree/MergeTreePartInfo.h>
@@ -726,7 +727,16 @@ public:
 
     TTLEntry ttl_table_entry;
 
-    TTLEntriesByName move_ttl_entries_by_name;
+    struct MoveTTLEntry
+    {
+        ExpressionActionsPtr expression;
+        String result_column;
+        ASTTTLElement::DestinationType destination_type;
+        String destination_name; 
+    };
+
+    using MoveTTLEntriesByName = std::unordered_map<String, MoveTTLEntry>;
+    MoveTTLEntriesByName move_ttl_entries_by_name;
 
     String sampling_expr_column_name;
     Names columns_required_for_sampling;

--- a/dbms/src/Storages/MergeTree/MergeTreeDataPartTTLInfo.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataPartTTLInfo.cpp
@@ -35,8 +35,8 @@ void MergeTreeDataPartTTLInfos::read(ReadBuffer & in)
     JSON json(json_str);
     if (json.has("columns"))
     {
-        JSON columns = json["columns"];
-        for (auto col : columns)
+        const JSON & columns = json["columns"];
+        for (const auto & col : columns)
         {
             MergeTreeDataPartTTLInfo ttl_info;
             ttl_info.min = col["min"].getUInt();
@@ -49,7 +49,7 @@ void MergeTreeDataPartTTLInfos::read(ReadBuffer & in)
     }
     if (json.has("table"))
     {
-        JSON table = json["table"];
+        const JSON & table = json["table"];
         table_ttl.min = table["min"].getUInt();
         table_ttl.max = table["max"].getUInt();
 
@@ -57,8 +57,8 @@ void MergeTreeDataPartTTLInfos::read(ReadBuffer & in)
     }
     if (json.has("moves"))
     {
-        JSON moves = json["moves"];
-        for (const auto move : moves)
+        const JSON & moves = json["moves"];
+        for (const auto & move : moves)
         {
             MergeTreeDataPartTTLInfo ttl_info;
             ttl_info.min = move["min"].getUInt();

--- a/dbms/src/Storages/MergeTree/MergeTreeDataPartTTLInfo.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataPartTTLInfo.cpp
@@ -16,13 +16,16 @@ void MergeTreeDataPartTTLInfos::update(const MergeTreeDataPartTTLInfos & other_i
         updatePartMinMaxTTL(ttl_info.min, ttl_info.max);
     }
 
-    table_ttl.update(other_infos.table_ttl);
-    updatePartMinMaxTTL(table_ttl.min, table_ttl.max);
-
     for (const auto & [expression, ttl_info] : other_infos.moves_ttl)
     {
         moves_ttl[expression].update(ttl_info);
+        updatePartMinMaxTTL(ttl_info.min, ttl_info.max);
+        /// FIXME: Possibly one need another logic here, because move TTL may spoil part min/max TTL
+        /// in this case we also need to skip updating part min/max in `updateTTL` method
     }
+
+    table_ttl.update(other_infos.table_ttl);
+    updatePartMinMaxTTL(table_ttl.min, table_ttl.max);
 }
 
 

--- a/dbms/src/Storages/MergeTree/MergeTreeDataPartTTLInfo.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataPartTTLInfo.cpp
@@ -19,9 +19,6 @@ void MergeTreeDataPartTTLInfos::update(const MergeTreeDataPartTTLInfos & other_i
     for (const auto & [expression, ttl_info] : other_infos.moves_ttl)
     {
         moves_ttl[expression].update(ttl_info);
-        updatePartMinMaxTTL(ttl_info.min, ttl_info.max);
-        /// FIXME: Possibly one need another logic here, because move TTL may spoil part min/max TTL
-        /// in this case we also need to skip updating part min/max in `updateTTL` method
     }
 
     table_ttl.update(other_infos.table_ttl);

--- a/dbms/src/Storages/MergeTree/MergeTreeDataPartTTLInfo.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataPartTTLInfo.cpp
@@ -58,7 +58,7 @@ void MergeTreeDataPartTTLInfos::read(ReadBuffer & in)
     if (json.has("moves"))
     {
         JSON moves = json["moves"];
-        for (auto move : moves)
+        for (const auto move : moves)
         {
             MergeTreeDataPartTTLInfo ttl_info;
             ttl_info.min = move["min"].getUInt();

--- a/dbms/src/Storages/MergeTree/MergeTreeDataPartTTLInfo.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataPartTTLInfo.cpp
@@ -1,6 +1,7 @@
 #include <Storages/MergeTree/MergeTreeDataPartTTLInfo.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
+#include <Common/quoteString.h>
 
 #include <common/JSON.h>
 
@@ -17,7 +18,13 @@ void MergeTreeDataPartTTLInfos::update(const MergeTreeDataPartTTLInfos & other_i
 
     table_ttl.update(other_infos.table_ttl);
     updatePartMinMaxTTL(table_ttl.min, table_ttl.max);
+
+    for (const auto & [expression, ttl_info] : other_infos.moves_ttl)
+    {
+        moves_ttl[expression].update(ttl_info);
+    }
 }
+
 
 void MergeTreeDataPartTTLInfos::read(ReadBuffer & in)
 {
@@ -48,7 +55,20 @@ void MergeTreeDataPartTTLInfos::read(ReadBuffer & in)
 
         updatePartMinMaxTTL(table_ttl.min, table_ttl.max);
     }
+    if (json.has("moves"))
+    {
+        JSON moves = json["moves"];
+        for (auto move : moves)
+        {
+            MergeTreeDataPartTTLInfo ttl_info;
+            ttl_info.min = move["min"].getUInt();
+            ttl_info.max = move["max"].getUInt();
+            String expression = move["expression"].getString();
+            moves_ttl.emplace(expression, ttl_info);
+        }
+    }
 }
+
 
 void MergeTreeDataPartTTLInfos::write(WriteBuffer & out) const
 {
@@ -62,9 +82,9 @@ void MergeTreeDataPartTTLInfos::write(WriteBuffer & out) const
             if (it != columns_ttl.begin())
                 writeString(",", out);
 
-            writeString("{\"name\":\"", out);
-            writeString(it->first, out);
-            writeString("\",\"min\":", out);
+            writeString("{\"name\":", out);
+            writeString(doubleQuoteString(it->first), out);
+            writeString(",\"min\":", out);
             writeIntText(it->second.min, out);
             writeString(",\"max\":", out);
             writeIntText(it->second.max, out);
@@ -81,6 +101,26 @@ void MergeTreeDataPartTTLInfos::write(WriteBuffer & out) const
         writeString(",\"max\":", out);
         writeIntText(table_ttl.max, out);
         writeString("}", out);
+    }
+    if (!moves_ttl.empty())
+    {
+        if (!columns_ttl.empty() || table_ttl.min)
+            writeString(",", out);
+        writeString("\"moves\":[", out);
+        for (auto it = moves_ttl.begin(); it != moves_ttl.end(); ++it)
+        {
+            if (it != moves_ttl.begin())
+                writeString(",", out);
+
+            writeString("{\"expression\":", out);
+            writeString(doubleQuoteString(it->first), out);
+            writeString(",\"min\":", out);
+            writeIntText(it->second.min, out);
+            writeString(",\"max\":", out);
+            writeIntText(it->second.max, out);
+            writeString("}", out);
+        }
+        writeString("]", out);
     }
     writeString("}", out);
 }

--- a/dbms/src/Storages/MergeTree/MergeTreeDataPartTTLInfo.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataPartTTLInfo.cpp
@@ -36,7 +36,7 @@ void MergeTreeDataPartTTLInfos::read(ReadBuffer & in)
     if (json.has("columns"))
     {
         const JSON & columns = json["columns"];
-        for (const auto & col : columns)
+        for (auto col : columns)
         {
             MergeTreeDataPartTTLInfo ttl_info;
             ttl_info.min = col["min"].getUInt();
@@ -58,7 +58,7 @@ void MergeTreeDataPartTTLInfos::read(ReadBuffer & in)
     if (json.has("moves"))
     {
         const JSON & moves = json["moves"];
-        for (const auto & move : moves)
+        for (auto move : moves)
         {
             MergeTreeDataPartTTLInfo ttl_info;
             ttl_info.min = move["min"].getUInt();

--- a/dbms/src/Storages/MergeTree/MergeTreeDataPartTTLInfo.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataPartTTLInfo.h
@@ -38,6 +38,8 @@ struct MergeTreeDataPartTTLInfos
     time_t part_min_ttl = 0;
     time_t part_max_ttl = 0;
 
+    std::unordered_map<String, MergeTreeDataPartTTLInfo> moves_ttl;
+
     void read(ReadBuffer & in);
     void write(WriteBuffer & out) const;
     void update(const MergeTreeDataPartTTLInfos & other_infos);

--- a/dbms/src/Storages/MergeTree/MergeTreeDataPartTTLInfo.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataPartTTLInfo.h
@@ -35,6 +35,9 @@ struct MergeTreeDataPartTTLInfos
 {
     std::unordered_map<String, MergeTreeDataPartTTLInfo> columns_ttl;
     MergeTreeDataPartTTLInfo table_ttl;
+
+    /// `part_min_ttl` and `part_max_ttl` are TTLs which are used for selecting parts
+    /// to merge in order to remove expired rows.    
     time_t part_min_ttl = 0;
     time_t part_max_ttl = 0;
 

--- a/dbms/src/Storages/MergeTree/MergeTreeDataPartTTLInfo.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataPartTTLInfo.h
@@ -52,6 +52,11 @@ struct MergeTreeDataPartTTLInfos
         if (time_max && (!part_max_ttl || time_max > part_max_ttl))
             part_max_ttl = time_max;
     }
+
+    bool empty()
+    {
+        return !part_min_ttl && moves_ttl.empty();
+    }
 };
 
 }

--- a/dbms/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -75,8 +75,10 @@ void buildScatterSelector(
 }
 
 /// Computes ttls and updates ttl infos
-template <typename TTLEntry>
-void updateTTL(const TTLEntry & ttl_entry, MergeTreeDataPart::TTLInfos & ttl_infos, DB::MergeTreeDataPartTTLInfo & ttl_info, Block & block)
+void updateTTL(const MergeTreeData::TTLEntry & ttl_entry,
+    MergeTreeDataPart::TTLInfos & ttl_infos,
+    DB::MergeTreeDataPartTTLInfo & ttl_info,
+    Block & block)
 {
     if (!block.has(ttl_entry.result_column))
         ttl_entry.expression->execute(block);

--- a/dbms/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -122,9 +122,7 @@ void updateTTL(const MergeTreeData::TTLEntry & ttl_entry,
         ttl_infos.updatePartMinMaxTTL(ttl_info.min, ttl_info.max);
 
     if (remove_column)
-    {
         block.erase(ttl_entry.result_column);
-    }
 }
 
 }
@@ -230,7 +228,7 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataWriter::writeTempPart(BlockWithPa
     for (const auto & ttl_entry : data.move_ttl_entries)
         updateTTL(ttl_entry, move_ttl_infos, move_ttl_infos.moves_ttl[ttl_entry.result_column], block, false);
 
-    DiskSpace::ReservationPtr reservation = data.reserveSpacePreferringMoveDestination(expected_size, move_ttl_infos, time(nullptr));
+    DiskSpace::ReservationPtr reservation = data.reserveSpacePreferringTTLRules(expected_size, move_ttl_infos, time(nullptr));
 
     MergeTreeData::MutableDataPartPtr new_data_part =
         std::make_shared<MergeTreeData::DataPart>(data, reservation->getDisk(), part_name, new_part_info);

--- a/dbms/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -226,8 +226,8 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataWriter::writeTempPart(BlockWithPa
     size_t expected_size = block.bytes();
 
     DB::MergeTreeDataPart::TTLInfos move_ttl_infos;
-    for (const auto & [name, ttl_entry] : data.move_ttl_entries_by_name)
-        updateTTL(ttl_entry, move_ttl_infos, move_ttl_infos.moves_ttl[name], block);
+    for (const auto & ttl_entry : data.move_ttl_entries)
+        updateTTL(ttl_entry, move_ttl_infos, move_ttl_infos.moves_ttl[ttl_entry.result_column], block);
 
     DiskSpace::ReservationPtr reservation = data.reserveSpacePreferringMoveDestination(expected_size, move_ttl_infos, time(nullptr));
 

--- a/dbms/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -116,7 +116,7 @@ void updateTTL(const MergeTreeData::TTLEntry & ttl_entry,
 
     ttl_infos.updatePartMinMaxTTL(ttl_info.min, ttl_info.max);
 
-    /// FIXME why we don't erase new column from block?
+    /// FIXME: why we don't erase new column from block?
 }
 
 }

--- a/dbms/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -75,12 +75,10 @@ void buildScatterSelector(
 }
 
 /// Computes ttls and updates ttl infos
-void updateTTL(const MergeTreeData::TTLEntry & ttl_entry, MergeTreeDataPart::TTLInfos & ttl_infos, Block & block, const String & column_name)
+void updateTTL(const MergeTreeData::TTLEntry & ttl_entry, MergeTreeDataPart::TTLInfos & ttl_infos, DB::MergeTreeDataPartTTLInfo & ttl_info, Block & block)
 {
     if (!block.has(ttl_entry.result_column))
         ttl_entry.expression->execute(block);
-
-    auto & ttl_info = (column_name.empty() ? ttl_infos.table_ttl : ttl_infos.columns_ttl[column_name]);
 
     const auto & current = block.getByName(ttl_entry.result_column);
 
@@ -251,7 +249,7 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataWriter::writeTempPart(BlockWithPa
 
     ProfileEvents::increment(ProfileEvents::MergeTreeDataWriterBlocks);
 
-    /// Sort.
+    /// Sort
     IColumn::Permutation * perm_ptr = nullptr;
     IColumn::Permutation perm;
     if (!sort_description.empty())
@@ -266,10 +264,13 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataWriter::writeTempPart(BlockWithPa
     }
 
     if (data.hasTableTTL())
-        updateTTL(data.ttl_table_entry, new_data_part->ttl_infos, block, "");
+        updateTTL(data.ttl_table_entry, new_data_part->ttl_infos, new_data_part->ttl_infos.table_ttl, block);
 
     for (const auto & [name, ttl_entry] : data.ttl_entries_by_name)
-        updateTTL(ttl_entry, new_data_part->ttl_infos, block, name);
+        updateTTL(ttl_entry, new_data_part->ttl_infos, new_data_part->ttl_infos.columns_ttl[name], block);
+
+    for (const auto & [expression, ttl_entry] : data.move_ttl_entries_by_name)
+        updateTTL(ttl_entry, new_data_part->ttl_infos, new_data_part->ttl_infos.moves_ttl[expression], block);
 
     /// This effectively chooses minimal compression method:
     ///  either default lz4 or compression method with zero thresholds on absolute and relative part size.

--- a/dbms/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -75,7 +75,8 @@ void buildScatterSelector(
 }
 
 /// Computes ttls and updates ttl infos
-void updateTTL(const MergeTreeData::TTLEntry & ttl_entry, MergeTreeDataPart::TTLInfos & ttl_infos, DB::MergeTreeDataPartTTLInfo & ttl_info, Block & block)
+template <typename TTLEntry>
+void updateTTL(const TTLEntry & ttl_entry, MergeTreeDataPart::TTLInfos & ttl_infos, DB::MergeTreeDataPartTTLInfo & ttl_info, Block & block)
 {
     if (!block.has(ttl_entry.result_column))
         ttl_entry.expression->execute(block);

--- a/dbms/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -80,8 +80,12 @@ void updateTTL(const MergeTreeData::TTLEntry & ttl_entry,
     DB::MergeTreeDataPartTTLInfo & ttl_info,
     Block & block)
 {
+    bool remove_column = false;
     if (!block.has(ttl_entry.result_column))
+    {
         ttl_entry.expression->execute(block);
+        remove_column = true;
+    }
 
     const auto & current = block.getByName(ttl_entry.result_column);
 
@@ -116,7 +120,10 @@ void updateTTL(const MergeTreeData::TTLEntry & ttl_entry,
 
     ttl_infos.updatePartMinMaxTTL(ttl_info.min, ttl_info.max);
 
-    /// FIXME: why we don't erase new column from block?
+    if (remove_column)
+    {
+        block.erase(ttl_entry.result_column);
+    }
 }
 
 }

--- a/dbms/src/Storages/MergeTree/MergeTreePartsMover.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreePartsMover.cpp
@@ -130,7 +130,7 @@ bool MergeTreePartsMover::selectPartsForMove(
         {
             auto destination = ttl_entry_ptr->getDestination(policy);
             if (destination && !ttl_entry_ptr->isPartInDestination(policy, *part))
-                reservation = part->storage.reserveSpaceInSpecificSpace(part->bytes_on_disk, ttl_entry_ptr->getDestination(policy));
+                reservation = part->storage.tryReserveSpaceInSpecificSpace(part->bytes_on_disk, ttl_entry_ptr->getDestination(policy));
         }
 
         if (reservation)

--- a/dbms/src/Storages/MergeTree/MergeTreePartsMover.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreePartsMover.cpp
@@ -113,16 +113,16 @@ bool MergeTreePartsMover::selectPartsForMove(
 
         const auto ttl_entries_end = part->storage.move_ttl_entries_by_name.end();
         auto best_ttl_entry_it = ttl_entries_end;
-        time_t max_max_ttl = 0;
+        time_t max_min_ttl = 0;
         for (auto & [name, ttl_info] : part->ttl_infos.moves_ttl)
         {
             auto move_ttl_entry_it = part->storage.move_ttl_entries_by_name.find(name);
             if (move_ttl_entry_it != part->storage.move_ttl_entries_by_name.end())
             {
-                if (ttl_info.max < current_time && max_max_ttl < ttl_info.max)
+                if (ttl_info.min > current_time && max_min_ttl < ttl_info.min)
                 {
                     best_ttl_entry_it = move_ttl_entry_it;
-                    max_max_ttl = ttl_info.max;
+                    max_min_ttl = ttl_info.min;
                 }
             }
         }
@@ -143,7 +143,7 @@ bool MergeTreePartsMover::selectPartsForMove(
                 }
                 else
                 {
-                    /// FIXME: log error
+                    /// FIXME: log warning?
                 }
             }
             else if (move_ttl_entry.destination_type == ASTTTLElement::DestinationType::DISK)
@@ -160,7 +160,7 @@ bool MergeTreePartsMover::selectPartsForMove(
                 }
                 else
                 {
-                    /// FIXME: log error
+                    /// FIXME: log warning?
                 }
             }
         }

--- a/dbms/src/Storages/MergeTree/MergeTreePartsMover.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreePartsMover.cpp
@@ -130,7 +130,7 @@ bool MergeTreePartsMover::selectPartsForMove(
         {
             auto destination = ttl_entry_ptr->getDestination(policy);
             if (destination && !ttl_entry_ptr->isPartInDestination(policy, *part))
-                reservation = part->storage.tryReserveSpaceInSpecificSpace(part->bytes_on_disk, ttl_entry_ptr->getDestination(policy));
+                reservation = part->storage.tryReserveSpace(part->bytes_on_disk, ttl_entry_ptr->getDestination(policy));
         }
 
         if (reservation)

--- a/dbms/src/Storages/MergeTree/MergeTreePartsMover.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreePartsMover.cpp
@@ -56,7 +56,7 @@ public:
     }
 
     /// Weaken requirements on size
-    void decreaseRequiredSize(UInt64 size_decrease)
+    void decreaseRequiredSizeAndRemoveRedundantParts(UInt64 size_decrease)
     {
         required_size_sum -= std::min(size_decrease, required_size_sum);
         removeRedundantElements();
@@ -123,7 +123,7 @@ bool MergeTreePartsMover::selectPartsForMove(
         if (!can_move(part, &reason))
             continue;
 
-        const MergeTreeData::TTLEntry * ttl_entry_ptr = part->storage.selectMoveDestination(part->ttl_infos, time_of_move);
+        const MergeTreeData::TTLEntry * ttl_entry_ptr = part->storage.selectTTLEntryForTTLInfos(part->ttl_infos, time_of_move);
         auto to_insert = need_to_move.find(part->disk);
         DiskSpace::ReservationPtr reservation;
         if (ttl_entry_ptr)
@@ -141,7 +141,7 @@ bool MergeTreePartsMover::selectPartsForMove(
             /// possibly to zero.
             if (to_insert != need_to_move.end())
             {
-                to_insert->second.decreaseRequiredSize(part->bytes_on_disk);
+                to_insert->second.decreaseRequiredSizeAndRemoveRedundantParts(part->bytes_on_disk);
             }
         }
         else

--- a/dbms/src/Storages/MergeTree/MergeTreePartsMover.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreePartsMover.cpp
@@ -133,7 +133,7 @@ bool MergeTreePartsMover::selectPartsForMove(
                 reservation = part->storage.tryReserveSpace(part->bytes_on_disk, ttl_entry_ptr->getDestination(policy));
         }
 
-        if (reservation)
+        if (reservation) /// Found reservation by TTL rule.
         {
             parts_to_move.emplace_back(part, std::move(reservation));
             /// If table TTL rule satisfies on this part, won't apply policy rules on it.

--- a/dbms/src/Storages/MergeTree/MergedBlockOutputStream.cpp
+++ b/dbms/src/Storages/MergeTree/MergedBlockOutputStream.cpp
@@ -186,7 +186,7 @@ void MergedBlockOutputStream::writeSuffixAndFinalizePart(
         checksums.files["count.txt"].file_hash = count_out_hashing.getHash();
     }
 
-    if (new_part->ttl_infos.part_min_ttl)
+    if (!new_part->ttl_infos.empty())
     {
         /// Write a file with ttl infos in json format.
         WriteBufferFromFile out(part_path + "ttl.txt", 4096);

--- a/dbms/src/Storages/MergeTree/PartDestinationType.h
+++ b/dbms/src/Storages/MergeTree/PartDestinationType.h
@@ -4,7 +4,7 @@
 namespace DB
 {
 
-enum class TTLDestinationType
+enum class PartDestinationType
 {
     DISK,
     VOLUME,

--- a/dbms/src/Storages/MergeTree/ReplicatedMergeTreeTableMetadata.cpp
+++ b/dbms/src/Storages/MergeTree/ReplicatedMergeTreeTableMetadata.cpp
@@ -5,6 +5,7 @@
 #include <Parsers/ExpressionListParsers.h>
 #include <IO/Operators.h>
 
+
 namespace DB
 {
 
@@ -47,6 +48,16 @@ ReplicatedMergeTreeTableMetadata::ReplicatedMergeTreeTableMetadata(const MergeTr
         partition_key = formattedAST(MergeTreeData::extractKeyExpressionList(data.partition_by_ast));
 
     ttl_table = formattedAST(data.ttl_table_ast);
+
+    std::ostringstream ttl_move_stream;
+    for (const auto & ttl_entry : data.move_ttl_entries)
+    {
+        if (ttl_move_stream.tellp() > 0)
+            ttl_move_stream << ", ";
+        ttl_move_stream << formattedAST(ttl_entry.entry_ast);
+    }
+    ttl_move = ttl_move_stream.str();
+
     skip_indices = data.getIndices().toString();
     if (data.canUseAdaptiveGranularity())
         index_granularity_bytes = data_settings->index_granularity_bytes;
@@ -77,6 +88,9 @@ void ReplicatedMergeTreeTableMetadata::write(WriteBuffer & out) const
 
     if (!ttl_table.empty())
         out << "ttl: " << ttl_table << "\n";
+
+    if (!ttl_move.empty())
+        out << "move ttl: " << ttl_move << "\n";
 
     if (!skip_indices.empty())
         out << "indices: " << skip_indices << "\n";
@@ -118,6 +132,9 @@ void ReplicatedMergeTreeTableMetadata::read(ReadBuffer & in)
 
     if (checkString("ttl: ", in))
         in >> ttl_table >> "\n";
+
+    if (checkString("move ttl: ", in))
+        in >> ttl_move >> "\n";
 
     if (checkString("indices: ", in))
         in >> skip_indices >> "\n";
@@ -223,9 +240,24 @@ ReplicatedMergeTreeTableMetadata::checkAndFindDiff(const ReplicatedMergeTreeTabl
         }
         else
             throw Exception(
-                    "Existing table metadata in ZooKeeper differs in ttl."
+                    "Existing table metadata in ZooKeeper differs in TTL."
                     " Stored in ZooKeeper: " + from_zk.ttl_table +
                     ", local: " + ttl_table,
+                    ErrorCodes::METADATA_MISMATCH);
+    }
+
+    if (ttl_move != from_zk.ttl_move)
+    {
+        if (allow_alter)
+        {
+            diff.ttl_move_changed = true;
+            diff.new_ttl_move = from_zk.ttl_move;
+        }
+        else
+            throw Exception(
+                    "Existing table metadata in ZooKeeper differs in move TTL."
+                    " Stored in ZooKeeper: " + from_zk.ttl_move +
+                    ", local: " + ttl_move,
                     ErrorCodes::METADATA_MISMATCH);
     }
 

--- a/dbms/src/Storages/MergeTree/ReplicatedMergeTreeTableMetadata.h
+++ b/dbms/src/Storages/MergeTree/ReplicatedMergeTreeTableMetadata.h
@@ -28,6 +28,7 @@ struct ReplicatedMergeTreeTableMetadata
     String skip_indices;
     String constraints;
     String ttl_table;
+    String ttl_move;
     UInt64 index_granularity_bytes;
 
     ReplicatedMergeTreeTableMetadata() = default;
@@ -53,9 +54,12 @@ struct ReplicatedMergeTreeTableMetadata
         bool ttl_table_changed = false;
         String new_ttl_table;
 
+        bool ttl_move_changed = false;
+        String new_ttl_move;
+
         bool empty() const
         {
-            return !sorting_key_changed && !skip_indices_changed && !ttl_table_changed && !constraints_changed;
+            return !sorting_key_changed && !skip_indices_changed && !ttl_table_changed && !constraints_changed && !ttl_move_changed;
         }
     };
 

--- a/dbms/src/Storages/MergeTree/TTLDestinationType.h
+++ b/dbms/src/Storages/MergeTree/TTLDestinationType.h
@@ -1,0 +1,14 @@
+#pragma once
+
+
+namespace DB
+{
+
+enum class TTLDestinationType
+{
+    DISK,
+    VOLUME,
+    DELETE,
+};
+
+}

--- a/dbms/src/Storages/PartitionCommands.cpp
+++ b/dbms/src/Storages/PartitionCommands.cpp
@@ -1,5 +1,6 @@
 #include <Storages/PartitionCommands.h>
 #include <Storages/IStorage.h>
+#include <Storages/MergeTree/TTLDestinationType.h>
 #include <Parsers/ASTAlterQuery.h>
 #include <Parsers/ASTIdentifier.h>
 
@@ -47,10 +48,10 @@ std::optional<PartitionCommand> PartitionCommand::parse(const ASTAlterCommand * 
         res.part = command_ast->part;
         switch (command_ast->move_destination_type)
         {
-            case ASTTTLElement::DestinationType::DISK:
+            case TTLDestinationType::DISK:
                 res.move_destination_type = PartitionCommand::MoveDestinationType::DISK;
                 break;
-            case ASTTTLElement::DestinationType::VOLUME:
+            case TTLDestinationType::VOLUME:
                 res.move_destination_type = PartitionCommand::MoveDestinationType::VOLUME;
                 break;
             default:

--- a/dbms/src/Storages/PartitionCommands.cpp
+++ b/dbms/src/Storages/PartitionCommands.cpp
@@ -47,11 +47,13 @@ std::optional<PartitionCommand> PartitionCommand::parse(const ASTAlterCommand * 
         res.part = command_ast->part;
         switch (command_ast->move_destination_type)
         {
-            case ASTAlterCommand::MoveDestinationType::DISK:
+            case ASTTTLElement::DestinationType::DISK:
                 res.move_destination_type = PartitionCommand::MoveDestinationType::DISK;
                 break;
-            case ASTAlterCommand::MoveDestinationType::VOLUME:
+            case ASTTTLElement::DestinationType::VOLUME:
                 res.move_destination_type = PartitionCommand::MoveDestinationType::VOLUME;
+                break;
+            default:
                 break;
         }
         res.move_destination_name = command_ast->move_destination_name;

--- a/dbms/src/Storages/PartitionCommands.cpp
+++ b/dbms/src/Storages/PartitionCommands.cpp
@@ -1,6 +1,6 @@
 #include <Storages/PartitionCommands.h>
 #include <Storages/IStorage.h>
-#include <Storages/MergeTree/TTLDestinationType.h>
+#include <Storages/MergeTree/PartDestinationType.h>
 #include <Parsers/ASTAlterQuery.h>
 #include <Parsers/ASTIdentifier.h>
 
@@ -48,10 +48,10 @@ std::optional<PartitionCommand> PartitionCommand::parse(const ASTAlterCommand * 
         res.part = command_ast->part;
         switch (command_ast->move_destination_type)
         {
-            case TTLDestinationType::DISK:
+            case PartDestinationType::DISK:
                 res.move_destination_type = PartitionCommand::MoveDestinationType::DISK;
                 break;
-            case TTLDestinationType::VOLUME:
+            case PartDestinationType::VOLUME:
                 res.move_destination_type = PartitionCommand::MoveDestinationType::VOLUME;
                 break;
             default:

--- a/dbms/src/Storages/StorageMergeTree.cpp
+++ b/dbms/src/Storages/StorageMergeTree.cpp
@@ -355,9 +355,8 @@ public:
         {
             MergeTreeDataPart::TTLInfos ttl_infos;
             for (auto & part_ptr : future_part_.parts)
-            {
                 ttl_infos.update(part_ptr->ttl_infos);
-            }
+            
             reserved_space = storage.tryReserveSpacePreferringTTLRules(total_size, ttl_infos, time(nullptr));
         }
         if (!reserved_space)

--- a/dbms/src/Storages/StorageMergeTree.cpp
+++ b/dbms/src/Storages/StorageMergeTree.cpp
@@ -350,9 +350,16 @@ public:
 
         /// if we mutate part, than we should reserve space on the same disk, because mutations possible can create hardlinks
         if (is_mutation)
-            reserved_space = future_part_.parts[0]->disk->reserve(total_size);
+            reserved_space = storage.reserveSpaceOnSpecificDisk(total_size, future_part_.parts[0]->disk);
         else
-            reserved_space = storage.reserveSpace(total_size);
+        {
+            MergeTreeDataPart::TTLInfos ttl_infos;
+            for (auto & part_ptr : future_part_.parts)
+            {
+                ttl_infos.update(part_ptr->ttl_infos);
+            }
+            reserved_space = storage.reserveSpacePreferringMoveDestination(total_size, ttl_infos, time(nullptr));
+        }
         if (!reserved_space)
         {
             if (is_mutation)

--- a/dbms/src/Storages/StorageMergeTree.cpp
+++ b/dbms/src/Storages/StorageMergeTree.cpp
@@ -350,7 +350,7 @@ public:
 
         /// if we mutate part, than we should reserve space on the same disk, because mutations possible can create hardlinks
         if (is_mutation)
-            reserved_space = storage.reserveSpaceOnSpecificDisk(total_size, future_part_.parts[0]->disk);
+            reserved_space = storage.reserveSpaceInSpecificSpace(total_size, future_part_.parts[0]->disk);
         else
         {
             MergeTreeDataPart::TTLInfos ttl_infos;

--- a/dbms/src/Storages/StorageMergeTree.cpp
+++ b/dbms/src/Storages/StorageMergeTree.cpp
@@ -350,7 +350,7 @@ public:
 
         /// if we mutate part, than we should reserve space on the same disk, because mutations possible can create hardlinks
         if (is_mutation)
-            reserved_space = storage.reserveSpaceInSpecificSpace(total_size, future_part_.parts[0]->disk);
+            reserved_space = storage.tryReserveSpaceInSpecificSpace(total_size, future_part_.parts[0]->disk);
         else
         {
             MergeTreeDataPart::TTLInfos ttl_infos;
@@ -358,7 +358,7 @@ public:
             {
                 ttl_infos.update(part_ptr->ttl_infos);
             }
-            reserved_space = storage.reserveSpacePreferringMoveDestination(total_size, ttl_infos, time(nullptr));
+            reserved_space = storage.tryReserveSpacePreferringMoveDestination(total_size, ttl_infos, time(nullptr));
         }
         if (!reserved_space)
         {

--- a/dbms/src/Storages/StorageMergeTree.cpp
+++ b/dbms/src/Storages/StorageMergeTree.cpp
@@ -358,7 +358,7 @@ public:
             {
                 ttl_infos.update(part_ptr->ttl_infos);
             }
-            reserved_space = storage.tryReserveSpacePreferringMoveDestination(total_size, ttl_infos, time(nullptr));
+            reserved_space = storage.tryReserveSpacePreferringTTLRules(total_size, ttl_infos, time(nullptr));
         }
         if (!reserved_space)
         {

--- a/dbms/src/Storages/StorageMergeTree.cpp
+++ b/dbms/src/Storages/StorageMergeTree.cpp
@@ -350,7 +350,7 @@ public:
 
         /// if we mutate part, than we should reserve space on the same disk, because mutations possible can create hardlinks
         if (is_mutation)
-            reserved_space = storage.tryReserveSpaceInSpecificSpace(total_size, future_part_.parts[0]->disk);
+            reserved_space = storage.tryReserveSpace(total_size, future_part_.parts[0]->disk);
         else
         {
             MergeTreeDataPart::TTLInfos ttl_infos;

--- a/dbms/src/Storages/StorageMergeTree.cpp
+++ b/dbms/src/Storages/StorageMergeTree.cpp
@@ -356,7 +356,7 @@ public:
             MergeTreeDataPart::TTLInfos ttl_infos;
             for (auto & part_ptr : future_part_.parts)
                 ttl_infos.update(part_ptr->ttl_infos);
-            
+
             reserved_space = storage.tryReserveSpacePreferringTTLRules(total_size, ttl_infos, time(nullptr));
         }
         if (!reserved_space)

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1147,7 +1147,7 @@ bool StorageReplicatedMergeTree::tryExecutePartMutation(const StorageReplicatedM
 
     /// Once we mutate part, we must reserve space on the same disk, because mutations can possibly create hardlinks.
     /// Can throw an exception.
-    DiskSpace::ReservationPtr reserved_space = reserveSpaceInSpecificSpace(estimated_space_for_result, source_part->disk);
+    DiskSpace::ReservationPtr reserved_space = reserveSpace(estimated_space_for_result, source_part->disk);
 
     auto table_lock = lockStructureForShare(false, RWLockImpl::NO_QUERY);
 

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1005,8 +1005,14 @@ bool StorageReplicatedMergeTree::tryExecuteMerge(const LogEntry & entry)
     /// Start to make the main work
     size_t estimated_space_for_merge = MergeTreeDataMergerMutator::estimateNeededDiskSpace(parts);
 
-    /// Can throw an exception.
-    DiskSpace::ReservationPtr reserved_space = reserveSpace(estimated_space_for_merge);
+    /// Can throw an exception while reserving space.
+    MergeTreeDataPart::TTLInfos ttl_infos;
+    for (auto & part_ptr : parts)
+    {
+        ttl_infos.update(part_ptr->ttl_infos);
+    }
+    DiskSpace::ReservationPtr reserved_space = reserveSpacePreferringMoveDestination(estimated_space_for_merge,
+            ttl_infos, time(nullptr));
 
     auto table_lock = lockStructureForShare(false, RWLockImpl::NO_QUERY);
 
@@ -1139,14 +1145,9 @@ bool StorageReplicatedMergeTree::tryExecutePartMutation(const StorageReplicatedM
         entry.new_part_name, format_version);
     MutationCommands commands = queue.getMutationCommands(source_part, new_part_info.mutation);
 
-    /// Can throw an exception.
     /// Once we mutate part, we must reserve space on the same disk, because mutations can possibly create hardlinks.
-    DiskSpace::ReservationPtr reserved_space = source_part->disk->reserve(estimated_space_for_result);
-    if (!reserved_space)
-    {
-        throw Exception("Cannot reserve " + formatReadableSizeWithBinarySuffix(estimated_space_for_result) + ", not enough space",
-                    ErrorCodes::NOT_ENOUGH_SPACE);
-    }
+    /// Can throw an exception.
+    DiskSpace::ReservationPtr reserved_space = reserveSpaceOnSpecificDisk(estimated_space_for_result, source_part->disk);
 
     auto table_lock = lockStructureForShare(false, RWLockImpl::NO_QUERY);
 

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1011,7 +1011,7 @@ bool StorageReplicatedMergeTree::tryExecuteMerge(const LogEntry & entry)
     {
         ttl_infos.update(part_ptr->ttl_infos);
     }
-    DiskSpace::ReservationPtr reserved_space = reserveSpacePreferringMoveDestination(estimated_space_for_merge,
+    DiskSpace::ReservationPtr reserved_space = reserveSpacePreferringTTLRules(estimated_space_for_merge,
             ttl_infos, time(nullptr));
 
     auto table_lock = lockStructureForShare(false, RWLockImpl::NO_QUERY);

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1147,7 +1147,7 @@ bool StorageReplicatedMergeTree::tryExecutePartMutation(const StorageReplicatedM
 
     /// Once we mutate part, we must reserve space on the same disk, because mutations can possibly create hardlinks.
     /// Can throw an exception.
-    DiskSpace::ReservationPtr reserved_space = reserveSpaceOnSpecificDisk(estimated_space_for_result, source_part->disk);
+    DiskSpace::ReservationPtr reserved_space = reserveSpaceInSpecificSpace(estimated_space_for_result, source_part->disk);
 
     auto table_lock = lockStructureForShare(false, RWLockImpl::NO_QUERY);
 

--- a/dbms/tests/integration/test_ttl_move/configs/config.d/cluster.xml
+++ b/dbms/tests/integration/test_ttl_move/configs/config.d/cluster.xml
@@ -1,0 +1,16 @@
+<yandex>
+    <remote_servers>
+        <test_cluster>
+            <shard>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster>
+    </remote_servers>
+</yandex>

--- a/dbms/tests/integration/test_ttl_move/configs/config.d/instant_moves.xml
+++ b/dbms/tests/integration/test_ttl_move/configs/config.d/instant_moves.xml
@@ -1,4 +1,4 @@
 <yandex>
-    <background_processing_pool_thread_sleep_seconds>0.5</background_processing_pool_thread_sleep_seconds>
-    <background_processing_pool_task_sleep_seconds_when_no_work_max>0.5</background_processing_pool_task_sleep_seconds_when_no_work_max>
+    <background_move_processing_pool_thread_sleep_seconds>0.5</background_move_processing_pool_thread_sleep_seconds>
+    <background_move_processing_pool_task_sleep_seconds_when_no_work_max>0.5</background_move_processing_pool_task_sleep_seconds_when_no_work_max>
 </yandex>

--- a/dbms/tests/integration/test_ttl_move/configs/config.d/instant_moves.xml
+++ b/dbms/tests/integration/test_ttl_move/configs/config.d/instant_moves.xml
@@ -1,0 +1,4 @@
+<yandex>
+    <background_processing_pool_thread_sleep_seconds>0.5</background_processing_pool_thread_sleep_seconds>
+    <background_processing_pool_task_sleep_seconds_when_no_work_max>0.5</background_processing_pool_task_sleep_seconds_when_no_work_max>
+</yandex>

--- a/dbms/tests/integration/test_ttl_move/configs/config.d/storage_configuration.xml
+++ b/dbms/tests/integration/test_ttl_move/configs/config.d/storage_configuration.xml
@@ -1,0 +1,64 @@
+<yandex>
+
+<storage_configuration>
+    <disks>
+        <default>
+        </default>
+        <jbod1>
+            <path>/jbod1/</path>
+        </jbod1>
+        <jbod2>
+            <path>/jbod2/</path>
+        </jbod2>
+        <external>
+            <path>/external/</path>
+        </external>
+    </disks>
+
+    <policies>
+        <external_with_jbods>
+            <volumes>
+                <external>
+                    <disk>external</disk>
+                </external>
+                <main>
+                    <disk>jbod1</disk>
+                    <disk>jbod2</disk>
+                </main>
+            </volumes>
+        </external_with_jbods>
+
+        <small_jbod_with_external>
+            <volumes>
+                <main>
+                    <disk>jbod1</disk>
+                </main>
+                <external>
+                    <disk>external</disk>
+                </external>
+            </volumes>
+        </small_jbod_with_external>
+
+        <jbod1_with_jbod2>
+            <volumes>
+                <main>
+                    <disk>jbod1</disk>
+                </main>
+                <external>
+                    <disk>jbod2</disk>
+                </external>
+            </volumes>
+        </jbod1_with_jbod2>
+
+        <only_jbod2>
+            <volumes>
+                <main>
+                    <disk>jbod2</disk>
+                </main>
+            </volumes>
+        </only_jbod2>
+    </policies>
+
+</storage_configuration>
+
+</yandex>

--- a/dbms/tests/integration/test_ttl_move/configs/config.d/storage_configuration.xml
+++ b/dbms/tests/integration/test_ttl_move/configs/config.d/storage_configuration.xml
@@ -28,6 +28,18 @@
             </volumes>
         </external_with_jbods>
 
+        <jbods_with_external>
+            <volumes>
+                <main>
+                    <disk>jbod1</disk>
+                    <disk>jbod2</disk>
+                </main>
+                <external>
+                    <disk>external</disk>
+                </external>
+            </volumes>
+        </jbods_with_external>
+
         <small_jbod_with_external>
             <volumes>
                 <main>

--- a/dbms/tests/integration/test_ttl_move/configs/logs_config.xml
+++ b/dbms/tests/integration/test_ttl_move/configs/logs_config.xml
@@ -1,0 +1,17 @@
+<yandex>
+    <shutdown_wait_unfinished>3</shutdown_wait_unfinished>
+    <logger>
+        <level>trace</level>
+        <log>/var/log/clickhouse-server/log.log</log>
+        <errorlog>/var/log/clickhouse-server/log.err.log</errorlog>
+        <size>1000M</size>
+        <count>10</count>
+        <stderr>/var/log/clickhouse-server/stderr.log</stderr>
+        <stdout>/var/log/clickhouse-server/stdout.log</stdout>
+    </logger>
+    <part_log>
+        <database>system</database>
+        <table>part_log</table>
+        <flush_interval_milliseconds>500</flush_interval_milliseconds>
+    </part_log>
+</yandex>

--- a/dbms/tests/integration/test_ttl_move/test.py
+++ b/dbms/tests/integration/test_ttl_move/test.py
@@ -196,10 +196,10 @@ def test_moves_to_disk_eventually_work(started_cluster, name, engine):
         node1.query("""
             CREATE TABLE {name} (
                 s1 String
-            ) ENGINE = {engine}
+            ) ENGINE = MergeTree()
             ORDER BY tuple()
             SETTINGS storage_policy='only_jbod2'
-        """.format(name=name_temp, engine=engine))
+        """.format(name=name_temp))
 
         data = [] # 35MB in total
         for i in range(35):
@@ -298,10 +298,10 @@ def test_merges_to_full_disk_work(started_cluster, name, engine):
         node1.query("""
             CREATE TABLE {name} (
                 s1 String
-            ) ENGINE = {engine}
+            ) ENGINE = MergeTree()
             ORDER BY tuple()
             SETTINGS storage_policy='only_jbod2'
-        """.format(name=name_temp, engine=engine))
+        """.format(name=name_temp))
 
         data = [] # 35MB in total
         for i in range(35):

--- a/dbms/tests/integration/test_ttl_move/test.py
+++ b/dbms/tests/integration/test_ttl_move/test.py
@@ -3,6 +3,7 @@ import pytest
 import random
 import re
 import string
+import threading
 import time
 from multiprocessing.dummy import Pool
 from helpers.client import QueryRuntimeException
@@ -38,7 +39,11 @@ def started_cluster():
 
 
 def get_random_string(length):
-    return ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(length))
+    symbols = bytes(string.ascii_uppercase + string.digits)
+    result_list = bytearray([0])*length
+    for i in range(length):
+        result_list[i] = random.choice(symbols)
+    return str(result_list)
 
 
 def get_used_disks_for_table(node, table_name):
@@ -65,7 +70,7 @@ def test_inserts_to_disk_work(started_cluster, name, engine, positive):
 
         data = [] # 10MB in total
         for i in range(10):
-            data.append(("'{}'".format(get_random_string(1024 * 1024)), "toDateTime({})".format(time.time()-2 if i > 0 or positive else time.time()+2))) # 1MB row
+            data.append(("'{}'".format(get_random_string(1024 * 1024)), "toDateTime({})".format(time.time()-1 if i > 0 or positive else time.time()+300))) # 1MB row
 
         node1.query("INSERT INTO {} (s1, d1) VALUES {}".format(name, ",".join(["(" + ",".join(x) + ")" for x in data])))
         used_disks = get_used_disks_for_table(node1, name)
@@ -95,15 +100,25 @@ def test_moves_to_disk_work(started_cluster, name, engine, positive):
             SETTINGS storage_policy='small_jbod_with_external'
         """.format(name=name, engine=engine))
 
+        wait_expire_1 = 6
+        wait_expire_2 = 4
+        time_1 = time.time() + wait_expire_1
+        time_2 = time.time() + wait_expire_1 + wait_expire_2
+
+        wait_expire_1_thread = threading.Thread(target=time.sleep, args=(wait_expire_1,))
+        wait_expire_1_thread.start()
+
         data = [] # 10MB in total
         for i in range(10):
-            data.append(("'{}'".format(get_random_string(1024 * 1024)), "toDateTime({})".format(time.time()+2 if i > 0 or positive else time.time()+6))) # 1MB row
+            data.append(("'{}'".format(get_random_string(1024 * 1024)), "toDateTime({})".format(time_1 if i > 0 or positive else time_2))) # 1MB row
 
         node1.query("INSERT INTO {} (s1, d1) VALUES {}".format(name, ",".join(["(" + ",".join(x) + ")" for x in data])))
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {"jbod1"}
 
-        time.sleep(4)
+        wait_expire_1_thread.join()
+        time.sleep(wait_expire_2/2)
+
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {"external" if positive else "jbod1"}
 
@@ -115,7 +130,7 @@ def test_moves_to_disk_work(started_cluster, name, engine, positive):
 
 @pytest.mark.parametrize("name,engine", [
     ("mt_test_moves_to_volume_work","MergeTree()"),
-    ("replicated_mt_test_moves_to_volume_work","ReplicatedMergeTree('/clickhouse/replicated_test_moves_to_volume_work', '1')",),
+    ("replicated_mt_test_moves_to_volume_work","ReplicatedMergeTree('/clickhouse/replicated_test_moves_to_volume_work', '1')"),
 ])
 def test_moves_to_volume_work(started_cluster, name, engine):
     try:
@@ -127,21 +142,29 @@ def test_moves_to_volume_work(started_cluster, name, engine):
             ) ENGINE = {engine}
             ORDER BY tuple()
             PARTITION BY p1
-            TTL d1 TO VOLUME 'main'
-            SETTINGS storage_policy='external_with_jbods'
+            TTL d1 TO VOLUME 'external'
+            SETTINGS storage_policy='jbods_with_external'
         """.format(name=name, engine=engine))
+
+        wait_expire_1 = 10
+        time_1 = time.time() + wait_expire_1
+
+        wait_expire_1_thread = threading.Thread(target=time.sleep, args=(wait_expire_1,))
+        wait_expire_1_thread.start()
 
         for p in range(2):
             data = [] # 20MB in total
             for i in range(10):
-                data.append((str(p), "'{}'".format(get_random_string(1024 * 1024)), "toDateTime({})".format(time.time()+2))) # 1MB row
+                data.append((str(p), "'{}'".format(get_random_string(1024 * 1024)), "toDateTime({})".format(time_1))) # 1MB row
 
             node1.query("INSERT INTO {} (p1, s1, d1) VALUES {}".format(name, ",".join(["(" + ",".join(x) + ")" for x in data])))
 
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {'jbod1', 'jbod2'}
 
-        time.sleep(4)
+        wait_expire_1_thread.join()
+        time.sleep(1)
+
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {"external"}
 
@@ -151,11 +174,13 @@ def test_moves_to_volume_work(started_cluster, name, engine):
         node1.query("DROP TABLE IF EXISTS {}".format(name))
 
 
-@pytest.mark.parametrize("name,engine", [
-    ("mt_test_inserts_to_volume_work","MergeTree()"),
-    ("replicated_mt_test_inserts_to_volume_work","ReplicatedMergeTree('/clickhouse/replicated_test_inserts_to_volume_work', '1')",),
+@pytest.mark.parametrize("name,engine,positive", [
+    ("mt_test_inserts_to_volume_do_not_work","MergeTree()",0),
+    ("replicated_mt_test_inserts_to_volume_do_not_work","ReplicatedMergeTree('/clickhouse/replicated_test_inserts_to_volume_do_not_work', '1')",0),
+    ("mt_test_inserts_to_volume_work","MergeTree()",1),
+    ("replicated_mt_test_inserts_to_volume_work","ReplicatedMergeTree('/clickhouse/replicated_test_inserts_to_volume_work', '1')",1),
 ])
-def test_inserts_to_volume_work(started_cluster, name, engine):
+def test_inserts_to_volume_work(started_cluster, name, engine, positive):
     try:
         node1.query("""
             CREATE TABLE {name} (
@@ -165,19 +190,21 @@ def test_inserts_to_volume_work(started_cluster, name, engine):
             ) ENGINE = {engine}
             ORDER BY tuple()
             PARTITION BY p1
-            TTL d1 TO VOLUME 'main'
-            SETTINGS storage_policy='external_with_jbods'
+            TTL d1 TO VOLUME 'external'
+            SETTINGS storage_policy='small_jbod_with_external'
         """.format(name=name, engine=engine))
+
+        node1.query("SYSTEM STOP MOVES {name}".format(name=name))
 
         for p in range(2):
             data = [] # 20MB in total
             for i in range(10):
-                data.append((str(p), "'{}'".format(get_random_string(1024 * 1024)), "toDateTime({})".format(time.time()-2))) # 1MB row
+                data.append((str(p), "'{}'".format(get_random_string(1024 * 1024)), "toDateTime({})".format(time.time()-1 if i > 0 or positive else time.time()+300))) # 1MB row
 
             node1.query("INSERT INTO {} (p1, s1, d1) VALUES {}".format(name, ",".join(["(" + ",".join(x) + ")" for x in data])))
 
         used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == {"external"}
+        assert set(used_disks) == {"external" if positive else "jbod1"}
 
         assert node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "20"
 
@@ -187,7 +214,7 @@ def test_inserts_to_volume_work(started_cluster, name, engine):
 
 @pytest.mark.parametrize("name,engine", [
     ("mt_test_moves_to_disk_eventually_work","MergeTree()"),
-    ("replicated_mt_test_moves_to_disk_eventually_work","ReplicatedMergeTree('/clickhouse/replicated_test_moves_to_disk_eventually_work', '1')",),
+    ("replicated_mt_test_moves_to_disk_eventually_work","ReplicatedMergeTree('/clickhouse/replicated_test_moves_to_disk_eventually_work', '1')"),
 ])
 def test_moves_to_disk_eventually_work(started_cluster, name, engine):
     try:
@@ -221,7 +248,7 @@ def test_moves_to_disk_eventually_work(started_cluster, name, engine):
 
         data = [] # 10MB in total
         for i in range(10):
-            data.append(("'{}'".format(get_random_string(1024 * 1024)), "toDateTime({})".format(time.time()-2))) # 1MB row
+            data.append(("'{}'".format(get_random_string(1024 * 1024)), "toDateTime({})".format(time.time()-1))) # 1MB row
 
         node1.query("INSERT INTO {} (s1, d1) VALUES {}".format(name, ",".join(["(" + ",".join(x) + ")" for x in data])))
         used_disks = get_used_disks_for_table(node1, name)
@@ -261,17 +288,27 @@ def test_merges_to_disk_work(started_cluster, name, engine, positive):
         node1.query("SYSTEM STOP MERGES {}".format(name))
         node1.query("SYSTEM STOP MOVES {}".format(name))
 
+        wait_expire_1 = 10
+        wait_expire_2 = 4
+        time_1 = time.time() + wait_expire_1
+        time_2 = time.time() + wait_expire_1 + wait_expire_2
+
+        wait_expire_1_thread = threading.Thread(target=time.sleep, args=(wait_expire_1,))
+        wait_expire_1_thread.start()
+
         for _ in range(2):
             data = [] # 16MB in total
             for i in range(8):
-                data.append(("'{}'".format(get_random_string(1024 * 1024)), "toDateTime({})".format(time.time()+2 if i > 0 or positive else time.time()+7))) # 1MB row
+                data.append(("'{}'".format(get_random_string(1024 * 1024)), "toDateTime({})".format(time_1 if i > 0 or positive else time_2))) # 1MB row
 
             node1.query("INSERT INTO {} (s1, d1) VALUES {}".format(name, ",".join(["(" + ",".join(x) + ")" for x in data])))
 
-        time.sleep(4)
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {"jbod1"}
         assert "2" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).strip()
+
+        wait_expire_1_thread.join()
+        time.sleep(wait_expire_2/2)
 
         node1.query("SYSTEM START MERGES {}".format(name))
         node1.query("OPTIMIZE TABLE {}".format(name))
@@ -288,10 +325,10 @@ def test_merges_to_disk_work(started_cluster, name, engine, positive):
 
 
 @pytest.mark.parametrize("name,engine", [
-    ("mt_test_merges_to_full_disk_work","MergeTree()"),
-    ("replicated_mt_test_merges_to_full_disk_work","ReplicatedMergeTree('/clickhouse/replicated_test_merges_to_full_disk_work', '1')",),
+    ("mt_test_merges_with_full_disk_work","MergeTree()"),
+    ("replicated_mt_test_merges_with_full_disk_work","ReplicatedMergeTree('/clickhouse/replicated_test_merges_with_full_disk_work', '1')"),
 ])
-def test_merges_to_full_disk_work(started_cluster, name, engine):
+def test_merges_with_full_disk_work(started_cluster, name, engine):
     try:
         name_temp = name + "_temp"
 
@@ -317,35 +354,41 @@ def test_merges_to_full_disk_work(started_cluster, name, engine):
                 d1 DateTime
             ) ENGINE = {engine}
             ORDER BY tuple()
-            TTL d1 TO DISK 'external'
-            SETTINGS storage_policy='small_jbod_with_external'
+            TTL d1 TO DISK 'jbod2'
+            SETTINGS storage_policy='jbod1_with_jbod2'
         """.format(name=name, engine=engine))
 
-        node1.query("SYSTEM STOP MOVES {}".format(name))
+        wait_expire_1 = 10
+        time_1 = time.time() + wait_expire_1
+
+        wait_expire_1_thread = threading.Thread(target=time.sleep, args=(wait_expire_1,))
+        wait_expire_1_thread.start()
 
         for _ in range(2):
-            data = [] # 16MB in total
-            for i in range(8):
-                data.append(("'{}'".format(get_random_string(1024 * 1024)), "toDateTime({})".format(time.time()+2))) # 1MB row
-
+            data = [] # 12MB in total
+            for i in range(6):
+                data.append(("'{}'".format(get_random_string(1024 * 1024)), "toDateTime({})".format(time_1))) # 1MB row
             node1.query("INSERT INTO {} (s1, d1) VALUES {}".format(name, ",".join(["(" + ",".join(x) + ")" for x in data])))
 
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {"jbod1"}
         assert "2" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).strip()
 
-        time.sleep(4)
+        wait_expire_1_thread.join()
+
         node1.query("OPTIMIZE TABLE {}".format(name))
+        time.sleep(1)
 
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {"jbod1"} # Merged to the same disk against the rule.
         assert "1" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).strip()
 
-        assert node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "16"
+        assert node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "12"
 
     finally:
         node1.query("DROP TABLE IF EXISTS {}".format(name_temp))
         node1.query("DROP TABLE IF EXISTS {}".format(name))
+
 
 @pytest.mark.parametrize("name,engine,positive", [
     ("mt_test_moves_after_merges_do_not_work","MergeTree()",0),
@@ -365,19 +408,30 @@ def test_moves_after_merges_work(started_cluster, name, engine, positive):
             SETTINGS storage_policy='small_jbod_with_external'
         """.format(name=name, engine=engine))
 
+        wait_expire_1 = 10
+        wait_expire_2 = 4
+        time_1 = time.time() + wait_expire_1
+        time_2 = time.time() + wait_expire_1 + wait_expire_2
+
+        wait_expire_1_thread = threading.Thread(target=time.sleep, args=(wait_expire_1,))
+        wait_expire_1_thread.start()
+
         for _ in range(2):
             data = [] # 16MB in total
             for i in range(8):
-                data.append(("'{}'".format(get_random_string(1024 * 1024)), "toDateTime({})".format(time.time()+2 if i > 0 or positive else time.time()+6))) # 1MB row
+                data.append(("'{}'".format(get_random_string(1024 * 1024)), "toDateTime({})".format(time_1 if i > 0 or positive else time_2))) # 1MB row
 
             node1.query("INSERT INTO {} (s1, d1) VALUES {}".format(name, ",".join(["(" + ",".join(x) + ")" for x in data])))
 
         node1.query("OPTIMIZE TABLE {}".format(name))
+        time.sleep(1)
+
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {"jbod1"}
         assert "1" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).strip()
 
-        time.sleep(4)
+        wait_expire_1_thread.join()
+        time.sleep(wait_expire_2/2)
 
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {"external" if positive else "jbod1"}

--- a/dbms/tests/integration/test_ttl_move/test.py
+++ b/dbms/tests/integration/test_ttl_move/test.py
@@ -134,7 +134,7 @@ def test_moves_to_volume_work(started_cluster, name, engine):
         for p in range(2):
             data = [] # 20MB in total
             for i in range(10):
-                data.append((p, "'{}'".format(get_random_string(1024 * 1024)), "toDateTime({})".format(time.time()+2))) # 1MB row
+                data.append((str(p), "'{}'".format(get_random_string(1024 * 1024)), "toDateTime({})".format(time.time()+2))) # 1MB row
 
             node1.query("INSERT INTO {} (p1, s1, d1) VALUES {}".format(name, ",".join(["(" + ",".join(x) + ")" for x in data])))
 
@@ -172,7 +172,7 @@ def test_inserts_to_volume_work(started_cluster, name, engine):
         for p in range(2):
             data = [] # 20MB in total
             for i in range(10):
-                data.append((p, "'{}'".format(get_random_string(1024 * 1024)), "toDateTime({})".format(time.time()-2))) # 1MB row
+                data.append((str(p), "'{}'".format(get_random_string(1024 * 1024)), "toDateTime({})".format(time.time()-2))) # 1MB row
 
             node1.query("INSERT INTO {} (p1, s1, d1) VALUES {}".format(name, ",".join(["(" + ",".join(x) + ")" for x in data])))
 

--- a/dbms/tests/integration/test_ttl_move/test.py
+++ b/dbms/tests/integration/test_ttl_move/test.py
@@ -71,7 +71,7 @@ def test_inserts_to_disk_work(started_cluster, name, engine, positive):
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {"external" if positive else "jbod1"}
 
-        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == "10"
+        assert node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "10"
 
     finally:
         node1.query("DROP TABLE IF EXISTS {}".format(name))
@@ -107,7 +107,7 @@ def test_moves_to_disk_work(started_cluster, name, engine, positive):
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {"external" if positive else "jbod1"}
 
-        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == "10"
+        assert node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "10"
 
     finally:
         node1.query("DROP TABLE IF EXISTS {}".format(name))
@@ -145,7 +145,7 @@ def test_moves_to_volume_work(started_cluster, name, engine):
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {"external"}
 
-        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == "20"
+        assert node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "20"
 
     finally:
         node1.query("DROP TABLE IF EXISTS {}".format(name))
@@ -179,7 +179,7 @@ def test_inserts_to_volume_work(started_cluster, name, engine):
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {"external"}
 
-        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == "20"
+        assert node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "20"
 
     finally:
         node1.query("DROP TABLE IF EXISTS {}".format(name))
@@ -233,7 +233,7 @@ def test_moves_to_disk_eventually_work(started_cluster, name, engine):
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {"jbod2"}
 
-        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == "10"
+        assert node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "10"
 
     finally:
         node1.query("DROP TABLE IF EXISTS {}".format(name_temp))
@@ -281,7 +281,7 @@ def test_merges_to_disk_work(started_cluster, name, engine, positive):
         assert set(used_disks) == {"external" if positive else "jbod1"}
         assert "1" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).strip()
 
-        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == "16"
+        assert node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "16"
 
     finally:
         node1.query("DROP TABLE IF EXISTS {}".format(name))
@@ -341,7 +341,7 @@ def test_merges_to_full_disk_work(started_cluster, name, engine):
         assert set(used_disks) == {"jbod1"} # Merged to the same disk against the rule.
         assert "1" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).strip()
 
-        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == "16"
+        assert node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "16"
 
     finally:
         node1.query("DROP TABLE IF EXISTS {}".format(name_temp))
@@ -382,7 +382,7 @@ def test_moves_after_merges_work(started_cluster, name, engine, positive):
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {"external" if positive else "jbod1"}
 
-        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == "16"
+        assert node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "16"
 
     finally:
         node1.query("DROP TABLE IF EXISTS {}".format(name))

--- a/dbms/tests/integration/test_ttl_move/test.py
+++ b/dbms/tests/integration/test_ttl_move/test.py
@@ -329,7 +329,7 @@ def test_merges_to_disk_work(started_cluster, name, engine):
         time.sleep(4)
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {'jbod1'}
-        assert "2" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).count()
+        assert "2" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).strip()
 
         node1.query("SYSTEM START MERGES {}".format(name))
         node1.query("OPTIMIZE TABLE {}".format(name))
@@ -337,7 +337,7 @@ def test_merges_to_disk_work(started_cluster, name, engine):
         time.sleep(1)
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {'external'}
-        assert "1" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).count()
+        assert "1" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).strip()
 
         assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 16
 
@@ -390,14 +390,14 @@ def test_merges_to_full_disk_work(started_cluster, name, engine):
 
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {'jbod1'}
-        assert "2" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).count()
+        assert "2" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).strip()
 
         time.sleep(4)
         node1.query("OPTIMIZE TABLE {}".format(name))
 
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {'jbod1'} # Merged to the same disk against the rule.
-        assert "1" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).count()
+        assert "1" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).strip()
 
         assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 16
 
@@ -431,7 +431,7 @@ def test_moves_after_merges_work(started_cluster, name, engine):
         node1.query("OPTIMIZE TABLE {}".format(name))
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {'jbod1'}
-        assert "1" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).count()
+        assert "1" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).strip()
 
         time.sleep(4)
 
@@ -473,7 +473,7 @@ def test_merges_to_disk_do_not_work(started_cluster, name, engine):
         time.sleep(4)
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {'jbod1'}
-        assert "2" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).count()
+        assert "2" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).strip()
 
         node1.query("SYSTEM START MERGES {}".format(name))
         node1.query("OPTIMIZE TABLE {}".format(name))
@@ -481,7 +481,7 @@ def test_merges_to_disk_do_not_work(started_cluster, name, engine):
         time.sleep(1)
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {'jbod1'}
-        assert "1" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).count()
+        assert "1" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).strip()
 
         assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 16
 
@@ -515,7 +515,7 @@ def test_moves_after_merges_do_not_work(started_cluster, name, engine):
         node1.query("OPTIMIZE TABLE {}".format(name))
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {'jbod1'}
-        assert "1" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).count()
+        assert "1" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).strip()
 
         time.sleep(4)
 

--- a/dbms/tests/integration/test_ttl_move/test.py
+++ b/dbms/tests/integration/test_ttl_move/test.py
@@ -192,7 +192,7 @@ def test_moves_to_volume_work(started_cluster, name, engine):
         """.format(name=name, engine=engine, time=time.time()+2))
 
         for _ in range(2):
-            data = [] # 10MB in total
+            data = [] # 20MB in total
             for i in range(10):
                 data.append((p, "'{}'".format(get_random_string(1024 * 1024)))) # 1MB row
 
@@ -230,7 +230,7 @@ def test_inserts_to_volume_work(started_cluster, name, engine):
         """.format(name=name, engine=engine, time=time.time()-2))
 
         for _ in range(2):
-            data = [] # 10MB in total
+            data = [] # 20MB in total
             for i in range(10):
                 data.append((p, "'{}'".format(get_random_string(1024 * 1024)))) # 1MB row
 
@@ -382,7 +382,7 @@ def test_merges_to_full_disk_work(started_cluster, name, engine):
         node1.query("SYSTEM STOP MOVES {}".format(name))
 
         for _ in range(2):
-            data = [] # 10MB in total
+            data = [] # 16MB in total
             for i in range(8):
                 data.append(get_random_string(1024 * 1024)) # 1MB row
 

--- a/dbms/tests/integration/test_ttl_move/test.py
+++ b/dbms/tests/integration/test_ttl_move/test.py
@@ -69,7 +69,7 @@ def test_inserts_to_disk_work(started_cluster, name, engine):
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {"external"}
 
-        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 10
+        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == "10"
 
     finally:
         node1.query("DROP TABLE IF EXISTS {}".format(name))
@@ -99,7 +99,7 @@ def test_inserts_to_disk_do_not_work(started_cluster, name, engine):
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {"jbod1"}
 
-        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 10
+        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == "10"
 
     finally:
         node1.query("DROP TABLE IF EXISTS {}".format(name))
@@ -133,7 +133,7 @@ def test_moves_to_disk_work(started_cluster, name, engine):
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {"external"}
 
-        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 10
+        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == "10"
 
     finally:
         node1.query("DROP TABLE IF EXISTS {}".format(name))
@@ -167,7 +167,7 @@ def test_moves_to_disk_do_not_work(started_cluster, name, engine):
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {"jbod1"}
 
-        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 10
+        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == "10"
 
     finally:
         node1.query("DROP TABLE IF EXISTS {}".format(name))
@@ -205,7 +205,7 @@ def test_moves_to_volume_work(started_cluster, name, engine):
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {"external"}
 
-        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 20
+        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == "20"
 
     finally:
         node1.query("DROP TABLE IF EXISTS {}".format(name))
@@ -239,7 +239,7 @@ def test_inserts_to_volume_work(started_cluster, name, engine):
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {"external"}
 
-        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 20
+        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == "20"
 
     finally:
         node1.query("DROP TABLE IF EXISTS {}".format(name))
@@ -293,7 +293,7 @@ def test_moves_to_disk_eventually_work(started_cluster, name, engine):
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {"jbod2"}
 
-        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 10
+        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == "10"
 
     finally:
         node1.query("DROP TABLE IF EXISTS {}".format(name_temp))
@@ -339,7 +339,7 @@ def test_merges_to_disk_work(started_cluster, name, engine):
         assert set(used_disks) == {"external"}
         assert "1" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).strip()
 
-        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 16
+        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == "16"
 
     finally:
         node1.query("DROP TABLE IF EXISTS {}".format(name))
@@ -399,7 +399,7 @@ def test_merges_to_full_disk_work(started_cluster, name, engine):
         assert set(used_disks) == {"jbod1"} # Merged to the same disk against the rule.
         assert "1" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).strip()
 
-        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 16
+        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == "16"
 
     finally:
         node1.query("DROP TABLE IF EXISTS {}".format(name_temp))
@@ -438,7 +438,7 @@ def test_moves_after_merges_work(started_cluster, name, engine):
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {"external"}
 
-        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 16
+        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == "16"
 
     finally:
         node1.query("DROP TABLE IF EXISTS {}".format(name))
@@ -483,7 +483,7 @@ def test_merges_to_disk_do_not_work(started_cluster, name, engine):
         assert set(used_disks) == {"jbod1"}
         assert "1" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).strip()
 
-        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 16
+        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == "16"
 
     finally:
         node1.query("DROP TABLE IF EXISTS {}".format(name))
@@ -522,7 +522,7 @@ def test_moves_after_merges_do_not_work(started_cluster, name, engine):
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {"jbod1"}
 
-        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 16
+        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == "16"
 
     finally:
         node1.query("DROP TABLE IF EXISTS {}".format(name))

--- a/dbms/tests/integration/test_ttl_move/test.py
+++ b/dbms/tests/integration/test_ttl_move/test.py
@@ -1,0 +1,530 @@
+import json
+import pytest
+import random
+import re
+import string
+import time
+from multiprocessing.dummy import Pool
+from helpers.client import QueryRuntimeException
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import TSV
+
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance('node1',
+            config_dir='configs',
+            main_configs=['configs/logs_config.xml'],
+            with_zookeeper=True,
+            tmpfs=['/jbod1:size=40M', '/jbod2:size=40M', '/external:size=200M'],
+            macros={"shard": 0, "replica": 1} )
+
+node2 = cluster.add_instance('node2',
+            config_dir='configs',
+            main_configs=['configs/logs_config.xml'],
+            with_zookeeper=True,
+            tmpfs=['/jbod1:size=40M', '/jbod2:size=40M', '/external:size=200M'],
+            macros={"shard": 0, "replica": 2} )
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def get_random_string(length):
+    return ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(length))
+
+
+def get_used_disks_for_table(node, table_name):
+    return node.query("select disk_name from system.parts where table == '{}' and active=1 order by modification_time".format(table_name)).strip().split('\n')
+
+
+@pytest.mark.parametrize("name,engine", [
+    ("mt_test_inserts_to_disk_work","MergeTree()"),
+    ("replicated_mt_test_inserts_to_disk_work","ReplicatedMergeTree('/clickhouse/replicated_test_inserts_to_disk_work', '1')",),
+])
+def test_inserts_to_disk_work(started_cluster, name, engine):
+    try:
+        node1.query("""
+            CREATE TABLE {name} (
+                s1 String,
+                d1 DateTime DEFAULT now()
+            ) ENGINE = {engine}
+            ORDER BY tuple()
+            TTL toDateTime({time}) + toInt64(d1)*0 TO DISK 'external'
+            SETTINGS storage_policy='small_jbod_with_external'
+        """.format(name=name, engine=engine, time=time.time()-2))
+
+        data = [] # 10MB in total
+        for i in range(10):
+            data.append(get_random_string(1024 * 1024)) # 1MB row
+
+        node1.query("INSERT INTO {} (s1) VALUES {}".format(name, ','.join(["('" + x + "')" for x in data])))
+        used_disks = get_used_disks_for_table(node1, name)
+        assert set(used_disks) == {'external'}
+
+        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 10
+
+    finally:
+        node1.query("DROP TABLE IF EXISTS {}".format(name))
+
+
+@pytest.mark.parametrize("name,engine", [
+    ("mt_test_inserts_to_disk_do_not_work","MergeTree()"),
+    ("replicated_mt_test_inserts_to_disk_do_not_work","ReplicatedMergeTree('/clickhouse/replicated_test_inserts_to_disk_do_not_work', '1')",),
+])
+def test_inserts_to_disk_do_not_work(started_cluster, name, engine):
+    try:
+        node1.query("""
+            CREATE TABLE {name} (
+                s1 String,
+                d1 DateTime
+            ) ENGINE = {engine}
+            ORDER BY tuple()
+            TTL d1 TO DISK 'external'
+            SETTINGS storage_policy='small_jbod_with_external'
+        """.format(name=name, engine=engine))
+
+        data = [] # 10MB in total
+        for i in range(10):
+            data.append(("'{}'".format(get_random_string(1024 * 1024)), "toDateTime({})".format(time.time()-2 if i > 0 else time.time()+2))) # 1MB row
+
+        node1.query("INSERT INTO {} VALUES {}".format(name, ','.join(["(" + ",".join(x) + ")" for x in data])))
+        used_disks = get_used_disks_for_table(node1, name)
+        assert set(used_disks) == {'jbod1'}
+
+        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 10
+
+    finally:
+        node1.query("DROP TABLE IF EXISTS {}".format(name))
+
+
+@pytest.mark.parametrize("name,engine", [
+    ("mt_test_moves_to_disk_work","MergeTree()"),
+    ("replicated_mt_test_moves_to_disk_work","ReplicatedMergeTree('/clickhouse/replicated_test_moves_to_disk_work', '1')",),
+])
+def test_moves_to_disk_work(started_cluster, name, engine):
+    try:
+        node1.query("""
+            CREATE TABLE {name} (
+                s1 String,
+                d1 DateTime DEFAULT now()
+            ) ENGINE = {engine}
+            ORDER BY tuple()
+            TTL toDateTime({time}) + toInt64(d1)*0 TO DISK 'external'
+            SETTINGS storage_policy='small_jbod_with_external'
+        """.format(name=name, engine=engine, time=time.time()+2))
+
+        data = [] # 10MB in total
+        for i in range(10):
+            data.append(get_random_string(1024 * 1024)) # 1MB row
+
+        node1.query("INSERT INTO {} (s1) VALUES {}".format(name, ','.join(["('" + x + "')" for x in data])))
+        used_disks = get_used_disks_for_table(node1, name)
+        assert set(used_disks) == {'jbod1'}
+
+        time.sleep(4)
+        used_disks = get_used_disks_for_table(node1, name)
+        assert set(used_disks) == {'external'}
+
+        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 10
+
+    finally:
+        node1.query("DROP TABLE IF EXISTS {}".format(name))
+
+
+@pytest.mark.parametrize("name,engine", [
+    ("mt_test_moves_to_disk_do_not_work","MergeTree()"),
+    ("replicated_mt_test_moves_to_disk_do_not_work","ReplicatedMergeTree('/clickhouse/replicated_test_moves_to_disk_do_not_work', '1')",),
+])
+def test_moves_to_disk_do_not_work(started_cluster, name, engine):
+    try:
+        node1.query("""
+            CREATE TABLE {name} (
+                s1 String,
+                d1 DateTime
+            ) ENGINE = {engine}
+            ORDER BY tuple()
+            TTL d1 TO DISK 'external'
+            SETTINGS storage_policy='small_jbod_with_external'
+        """.format(name=name, engine=engine, time=time.time()+2))
+
+        data = [] # 10MB in total
+        for i in range(10):
+            data.append(("'{}'".format(get_random_string(1024 * 1024)), "toDateTime({})".format(time.time()+2 if i > 0 else time.time()+6))) # 1MB row
+
+        node1.query("INSERT INTO {} (s1) VALUES {}".format(name, ','.join(["('" + x + "')" for x in data])))
+        used_disks = get_used_disks_for_table(node1, name)
+        assert set(used_disks) == {'jbod1'}
+
+        time.sleep(4)
+        used_disks = get_used_disks_for_table(node1, name)
+        assert set(used_disks) == {'jbod1'}
+
+        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 10
+
+    finally:
+        node1.query("DROP TABLE IF EXISTS {}".format(name))
+
+
+@pytest.mark.parametrize("name,engine", [
+    ("mt_test_moves_to_volume_work","MergeTree()"),
+    ("replicated_mt_test_moves_to_volume_work","ReplicatedMergeTree('/clickhouse/replicated_test_moves_to_volume_work', '1')",),
+])
+def test_moves_to_volume_work(started_cluster, name, engine):
+    try:
+        node1.query("""
+            CREATE TABLE {name} (
+                p1 Int64,
+                s1 String,
+                d1 DateTime DEFAULT now()
+            ) ENGINE = {engine}
+            ORDER BY tuple()
+            PARTITION BY p1
+            TTL toDateTime({time}) + toInt64(d1)*0 TO VOLUME 'main'
+            SETTINGS storage_policy='external_with_jbods'
+        """.format(name=name, engine=engine, time=time.time()+2))
+
+        for _ in range(2):
+            data = [] # 10MB in total
+            for i in range(10):
+                data.append((p, "'{}'".format(get_random_string(1024 * 1024)))) # 1MB row
+
+            node1.query("INSERT INTO {} (p1, s1) VALUES {}".format(name, ','.join(["(" + ",".join(x) + ")" for x in data])))
+
+        used_disks = get_used_disks_for_table(node1, name)
+        assert set(used_disks) == {'jbod1', 'jbod2'}
+
+        time.sleep(4)
+        used_disks = get_used_disks_for_table(node1, name)
+        assert set(used_disks) == {'external'}
+
+        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 20
+
+    finally:
+        node1.query("DROP TABLE IF EXISTS {}".format(name))
+
+
+@pytest.mark.parametrize("name,engine", [
+    ("mt_test_inserts_to_volume_work","MergeTree()"),
+    ("replicated_mt_test_inserts_to_volume_work","ReplicatedMergeTree('/clickhouse/replicated_test_inserts_to_volume_work', '1')",),
+])
+def test_inserts_to_volume_work(started_cluster, name, engine):
+    try:
+        node1.query("""
+            CREATE TABLE {name} (
+                p1 Int64,
+                s1 String,
+                d1 DateTime DEFAULT now()
+            ) ENGINE = {engine}
+            ORDER BY tuple()
+            PARTITION BY p1
+            TTL toDateTime({time}) + toInt64(d1)*0 TO VOLUME 'main'
+            SETTINGS storage_policy='external_with_jbods'
+        """.format(name=name, engine=engine, time=time.time()-2))
+
+        for _ in range(2):
+            data = [] # 10MB in total
+            for i in range(10):
+                data.append((p, "'{}'".format(get_random_string(1024 * 1024)))) # 1MB row
+
+            node1.query("INSERT INTO {} (p1, s1) VALUES {}".format(name, ','.join(["(" + ",".join(x) + ")" for x in data])))
+
+        used_disks = get_used_disks_for_table(node1, name)
+        assert set(used_disks) == {'external'}
+
+        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 20
+
+    finally:
+        node1.query("DROP TABLE IF EXISTS {}".format(name))
+
+
+@pytest.mark.parametrize("name,engine", [
+    ("mt_test_moves_to_disk_eventually_work","MergeTree()"),
+    ("replicated_mt_test_moves_to_disk_eventually_work","ReplicatedMergeTree('/clickhouse/replicated_test_moves_to_disk_eventually_work', '1')",),
+])
+def test_moves_to_disk_eventually_work(started_cluster, name, engine):
+    try:
+        name_temp = name + "_temp"
+
+        node1.query("""
+            CREATE TABLE {name} (
+                s1 String
+            ) ENGINE = {engine}
+            ORDER BY tuple()
+            SETTINGS storage_policy='only_jbod2'
+        """.format(name=name_temp, engine=engine))
+
+        data = [] # 35MB in total
+        for i in range(35):
+            data.append(get_random_string(1024 * 1024)) # 1MB row
+
+        node1.query("INSERT INTO {} VALUES {}".format(name_temp, ','.join(["('" + x + "')" for x in data])))
+        used_disks = get_used_disks_for_table(node1, name_temp)
+        assert set(used_disks) == {'jbod2'}
+
+        node1.query("""
+            CREATE TABLE {name} (
+                s1 String,
+                d1 DateTime DEFAULT now()
+            ) ENGINE = {engine}
+            ORDER BY tuple()
+            TTL toDateTime({time}) + toInt64(d1)*0 TO DISK 'jbod2'
+            SETTINGS storage_policy='jbod1_with_jbod2'
+        """.format(name=name, engine=engine, time=time.time()-2))
+
+        data = [] # 10MB in total
+        for i in range(10):
+            data.append(get_random_string(1024 * 1024)) # 1MB row
+
+        node1.query("INSERT INTO {} (s1) VALUES {}".format(name, ','.join(["('" + x + "')" for x in data])))
+        used_disks = get_used_disks_for_table(node1, name)
+        assert set(used_disks) == {'jbod1'}
+
+        node1.query("DROP TABLE {}".format(name_temp))
+
+        time.sleep(2)
+        used_disks = get_used_disks_for_table(node1, name)
+        assert set(used_disks) == {'jbod2'}
+
+        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 10
+
+    finally:
+        node1.query("DROP TABLE IF EXISTS {}".format(name_temp))
+        node1.query("DROP TABLE IF EXISTS {}".format(name))
+
+
+@pytest.mark.parametrize("name,engine", [
+    ("mt_test_merges_to_disk_work","MergeTree()"),
+    ("replicated_mt_test_merges_to_disk_work","ReplicatedMergeTree('/clickhouse/replicated_test_merges_to_disk_work', '1')",),
+])
+def test_merges_to_disk_work(started_cluster, name, engine):
+    try:
+        node1.query("""
+            CREATE TABLE {name} (
+                s1 String,
+                d1 DateTime DEFAULT now()
+            ) ENGINE = {engine}
+            ORDER BY tuple()
+            TTL toDateTime({time}) + toInt64(d1)*0 TO DISK 'external'
+            SETTINGS storage_policy='small_jbod_with_external'
+        """.format(name=name, engine=engine, time=time.time()+2))
+
+        node1.query("SYSTEM STOP MERGES {}".format(name))
+        node1.query("SYSTEM STOP MOVES {}".format(name))
+
+        for _ in range(2):
+            data = [] # 16MB in total
+            for i in range(8):
+                data.append(get_random_string(1024 * 1024)) # 1MB row
+
+            node1.query("INSERT INTO {} (s1) VALUES {}".format(name, ','.join(["('" + x + "')" for x in data])))
+
+        time.sleep(4)
+        used_disks = get_used_disks_for_table(node1, name)
+        assert set(used_disks) == {'jbod1'}
+        assert "2" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).count()
+
+        node1.query("SYSTEM START MERGES {}".format(name))
+        node1.query("OPTIMIZE TABLE {}".format(name))
+
+        time.sleep(1)
+        used_disks = get_used_disks_for_table(node1, name)
+        assert set(used_disks) == {'external'}
+        assert "1" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).count()
+
+        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 16
+
+    finally:
+        node1.query("DROP TABLE IF EXISTS {}".format(name))
+
+
+@pytest.mark.parametrize("name,engine", [
+    ("mt_test_merges_to_full_disk_work","MergeTree()"),
+    ("replicated_mt_test_merges_to_full_disk_work","ReplicatedMergeTree('/clickhouse/replicated_test_merges_to_full_disk_work', '1')",),
+])
+def test_merges_to_full_disk_work(started_cluster, name, engine):
+    try:
+        name_temp = name + "_temp"
+
+        node1.query("""
+            CREATE TABLE {name} (
+                s1 String
+            ) ENGINE = {engine}
+            ORDER BY tuple()
+            SETTINGS storage_policy='only_jbod2'
+        """.format(name=name_temp, engine=engine))
+
+        data = [] # 35MB in total
+        for i in range(35):
+            data.append(get_random_string(1024 * 1024)) # 1MB row
+
+        node1.query("INSERT INTO {} VALUES {}".format(name_temp, ','.join(["('" + x + "')" for x in data])))
+        used_disks = get_used_disks_for_table(node1, name_temp)
+        assert set(used_disks) == {'jbod2'}
+
+        node1.query("""
+            CREATE TABLE {name} (
+                s1 String,
+                d1 DateTime DEFAULT now()
+            ) ENGINE = {engine}
+            ORDER BY tuple()
+            TTL toDateTime({time}) + toInt64(d1)*0 TO DISK 'external'
+            SETTINGS storage_policy='small_jbod_with_external'
+        """.format(name=name, engine=engine, time=time.time()+2))
+
+        node1.query("SYSTEM STOP MOVES {}".format(name))
+
+        for _ in range(2):
+            data = [] # 10MB in total
+            for i in range(8):
+                data.append(get_random_string(1024 * 1024)) # 1MB row
+
+            node1.query("INSERT INTO {} (s1) VALUES {}".format(name, ','.join(["('" + x + "')" for x in data])))
+
+        used_disks = get_used_disks_for_table(node1, name)
+        assert set(used_disks) == {'jbod1'}
+        assert "2" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).count()
+
+        time.sleep(4)
+        node1.query("OPTIMIZE TABLE {}".format(name))
+
+        used_disks = get_used_disks_for_table(node1, name)
+        assert set(used_disks) == {'jbod1'} # Merged to the same disk against the rule.
+        assert "1" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).count()
+
+        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 16
+
+    finally:
+        node1.query("DROP TABLE IF EXISTS {}".format(name_temp))
+        node1.query("DROP TABLE IF EXISTS {}".format(name))
+
+@pytest.mark.parametrize("name,engine", [
+    ("mt_test_moves_after_merges_work","MergeTree()"),
+    ("replicated_mt_test_moves_after_merges_work","ReplicatedMergeTree('/clickhouse/replicated_test_moves_after_merges_work', '1')",),
+])
+def test_moves_after_merges_work(started_cluster, name, engine):
+    try:
+        node1.query("""
+            CREATE TABLE {name} (
+                s1 String,
+                d1 DateTime DEFAULT now()
+            ) ENGINE = {engine}
+            ORDER BY tuple()
+            TTL toDateTime({time}) + toInt64(d1)*0 TO DISK 'external'
+            SETTINGS storage_policy='small_jbod_with_external'
+        """.format(name=name, engine=engine, time=time.time()+2))
+
+        for _ in range(2):
+            data = [] # 16MB in total
+            for i in range(8):
+                data.append(get_random_string(1024 * 1024)) # 1MB row
+
+            node1.query("INSERT INTO {} (s1) VALUES {}".format(name, ','.join(["('" + x + "')" for x in data])))
+
+        node1.query("OPTIMIZE TABLE {}".format(name))
+        used_disks = get_used_disks_for_table(node1, name)
+        assert set(used_disks) == {'jbod1'}
+        assert "1" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).count()
+
+        time.sleep(4)
+
+        used_disks = get_used_disks_for_table(node1, name)
+        assert set(used_disks) == {'external'}
+
+        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 16
+
+    finally:
+        node1.query("DROP TABLE IF EXISTS {}".format(name))
+
+
+@pytest.mark.parametrize("name,engine", [
+    ("mt_test_merges_to_disk_do_not_work","MergeTree()"),
+    ("replicated_mt_test_merges_to_disk_do_not_work","ReplicatedMergeTree('/clickhouse/replicated_test_merges_to_disk_do_not_work', '1')",),
+])
+def test_merges_to_disk_do_not_work(started_cluster, name, engine):
+    try:
+        node1.query("""
+            CREATE TABLE {name} (
+                s1 String,
+                d1 DateTime
+            ) ENGINE = {engine}
+            ORDER BY tuple()
+            TTL d1 TO DISK 'external'
+            SETTINGS storage_policy='small_jbod_with_external'
+        """.format(name=name, engine=engine))
+
+        node1.query("SYSTEM STOP MERGES {}".format(name))
+        node1.query("SYSTEM STOP MOVES {}".format(name))
+
+        for _ in range(2):
+            data = [] # 16MB in total
+            for i in range(8):
+                data.append(("'{}'".format(get_random_string(1024 * 1024)), 'toDateTime({})'.format(time.time()+2 if i > 0 else time.time()+7))) # 1MB row
+
+            node1.query("INSERT INTO {} (s1, d1) VALUES {}".format(name, ','.join(["(" + ",".join(x) + ")" for x in data])))
+
+        time.sleep(4)
+        used_disks = get_used_disks_for_table(node1, name)
+        assert set(used_disks) == {'jbod1'}
+        assert "2" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).count()
+
+        node1.query("SYSTEM START MERGES {}".format(name))
+        node1.query("OPTIMIZE TABLE {}".format(name))
+
+        time.sleep(1)
+        used_disks = get_used_disks_for_table(node1, name)
+        assert set(used_disks) == {'jbod1'}
+        assert "1" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).count()
+
+        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 16
+
+    finally:
+        node1.query("DROP TABLE IF EXISTS {}".format(name))
+
+
+@pytest.mark.parametrize("name,engine", [
+    ("mt_test_moves_after_merges_do_not_work","MergeTree()"),
+    ("replicated_mt_test_moves_after_merges_do_not_work","ReplicatedMergeTree('/clickhouse/replicated_test_moves_after_merges_do_not_work', '1')",),
+])
+def test_moves_after_merges_do_not_work(started_cluster, name, engine):
+    try:
+        node1.query("""
+            CREATE TABLE {name} (
+                s1 String,
+                d1 DateTime
+            ) ENGINE = {engine}
+            ORDER BY tuple()
+            TTL d1 TO DISK 'external'
+            SETTINGS storage_policy='small_jbod_with_external'
+        """.format(name=name, engine=engine, time=time.time()+2))
+
+        for _ in range(2):
+            data = [] # 16MB in total
+            for i in range(8):
+                data.append(("'{}'".format(get_random_string(1024 * 1024)), "toDateTime({})".format(time.time()+2 if i > 0 else time.time()+6))) # 1MB row
+
+            node1.query("INSERT INTO {} (s1, d1) VALUES {}".format(name, ','.join(["(" + ",".join(x) + ")" for x in data])))
+
+        node1.query("OPTIMIZE TABLE {}".format(name))
+        used_disks = get_used_disks_for_table(node1, name)
+        assert set(used_disks) == {'jbod1'}
+        assert "1" == node1.query("SELECT count() FROM system.parts WHERE table = '{}' AND active = 1".format(name)).count()
+
+        time.sleep(4)
+
+        used_disks = get_used_disks_for_table(node1, name)
+        assert set(used_disks) == {'jbod1'}
+
+        assert node1.query("SELECT count() FROM {}".format(name=name)).strip() == 16
+
+    finally:
+        node1.query("DROP TABLE IF EXISTS {}".format(name))
+
+# FIXME refactor _do_not tests into main ones

--- a/dbms/tests/integration/test_ttl_move/test.py
+++ b/dbms/tests/integration/test_ttl_move/test.py
@@ -153,8 +153,8 @@ def test_moves_to_volume_work(started_cluster, name, engine):
         wait_expire_1_thread.start()
 
         for p in range(2):
-            data = [] # 20MB in total
-            for i in range(10):
+            data = [] # 10MB in total
+            for i in range(5):
                 data.append((str(p), "'{}'".format(get_random_string(1024 * 1024)), "toDateTime({})".format(time_1))) # 1MB row
 
             node1.query("INSERT INTO {} (p1, s1, d1) VALUES {}".format(name, ",".join(["(" + ",".join(x) + ")" for x in data])))
@@ -168,7 +168,7 @@ def test_moves_to_volume_work(started_cluster, name, engine):
         used_disks = get_used_disks_for_table(node1, name)
         assert set(used_disks) == {"external"}
 
-        assert node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "20"
+        assert node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "10"
 
     finally:
         node1.query("DROP TABLE IF EXISTS {}".format(name))

--- a/dbms/tests/integration/test_ttl_replicated/test.py
+++ b/dbms/tests/integration/test_ttl_replicated/test.py
@@ -1,6 +1,7 @@
 import time
 import pytest
 
+import helpers.client as client
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
@@ -9,7 +10,7 @@ node1 = cluster.add_instance('node1', with_zookeeper=True)
 node2 = cluster.add_instance('node2', with_zookeeper=True)
 
 @pytest.fixture(scope="module")
-def start_cluster():
+def started_cluster():
     try:
         cluster.start()
 
@@ -25,7 +26,7 @@ def drop_table(nodes, table_name):
     for node in nodes:
         node.query("DROP TABLE IF EXISTS {}".format(table_name))
 
-def test_ttl_columns(start_cluster):
+def test_ttl_columns(started_cluster):
     drop_table([node1, node2], "test_ttl")
     for node in [node1, node2]:
         node.query(
@@ -43,8 +44,12 @@ def test_ttl_columns(start_cluster):
     expected = "1\t0\t0\n2\t0\t0\n"
     assert TSV(node1.query("SELECT id, a, b FROM test_ttl ORDER BY id")) == TSV(expected)
     assert TSV(node2.query("SELECT id, a, b FROM test_ttl ORDER BY id")) == TSV(expected)
-    
-def test_ttl_table(start_cluster):
+ 
+@pytest.mark.parametrize("delete_suffix", [
+    "",
+    "DELETE",
+])
+def test_ttl_table(started_cluster, delete_suffix):
     drop_table([node1, node2], "test_ttl")
     for node in [node1, node2]:
         node.query(
@@ -52,8 +57,8 @@ def test_ttl_table(start_cluster):
             CREATE TABLE test_ttl(date DateTime, id UInt32)
             ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/test_ttl', '{replica}')
             ORDER BY id PARTITION BY toDayOfMonth(date)
-            TTL date + INTERVAL 1 DAY SETTINGS merge_with_ttl_timeout=0;
-        '''.format(replica=node.name))
+            TTL date + INTERVAL 1 DAY {delete_suffix} SETTINGS merge_with_ttl_timeout=0;
+        '''.format(replica=node.name, delete_suffix=delete_suffix))
 
     node1.query("INSERT INTO test_ttl VALUES (toDateTime('2000-10-10 00:00:00'), 1)")
     node1.query("INSERT INTO test_ttl VALUES (toDateTime('2000-10-11 10:00:00'), 2)")
@@ -62,4 +67,18 @@ def test_ttl_table(start_cluster):
 
     assert TSV(node1.query("SELECT * FROM test_ttl")) == TSV("")
     assert TSV(node2.query("SELECT * FROM test_ttl")) == TSV("")
-    
+
+def test_ttl_double_delete_rule_returns_error(started_cluster):
+    drop_table([node1, node2], "test_ttl")
+    try:
+        node1.query('''
+            CREATE TABLE test_ttl(date DateTime, id UInt32)
+            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/test_ttl', '{replica}')
+            ORDER BY id PARTITION BY toDayOfMonth(date)
+            TTL date + INTERVAL 1 DAY, date + INTERVAL 2 DAY SETTINGS merge_with_ttl_timeout=0;
+        '''.format(replica=node1.name))
+        assert False
+    except client.QueryRuntimeException:
+        pass
+    except:
+        assert False

--- a/dbms/tests/queries/0_stateless/00933_alter_ttl.reference
+++ b/dbms/tests/queries/0_stateless/00933_alter_ttl.reference
@@ -1,4 +1,4 @@
-CREATE TABLE default.ttl (`d` Date, `a` Int32) ENGINE = MergeTree PARTITION BY toDayOfMonth(d) ORDER BY a TTL d + toIntervalDay(1) DELETE SETTINGS index_granularity = 8192
+CREATE TABLE default.ttl (`d` Date, `a` Int32) ENGINE = MergeTree PARTITION BY toDayOfMonth(d) ORDER BY a TTL d + toIntervalDay(1) SETTINGS index_granularity = 8192
 2100-10-10	3
 2100-10-10	4
 d	Date					

--- a/dbms/tests/queries/0_stateless/00933_alter_ttl.reference
+++ b/dbms/tests/queries/0_stateless/00933_alter_ttl.reference
@@ -1,4 +1,4 @@
-CREATE TABLE default.ttl (`d` Date, `a` Int32) ENGINE = MergeTree PARTITION BY toDayOfMonth(d) ORDER BY a TTL d + toIntervalDay(1) SETTINGS index_granularity = 8192
+CREATE TABLE default.ttl (`d` Date, `a` Int32) ENGINE = MergeTree PARTITION BY toDayOfMonth(d) ORDER BY a TTL d + toIntervalDay(1) DELETE SETTINGS index_granularity = 8192
 2100-10-10	3
 2100-10-10	4
 d	Date					

--- a/dbms/tests/queries/0_stateless/00933_ttl_replicated_zookeeper.reference
+++ b/dbms/tests/queries/0_stateless/00933_ttl_replicated_zookeeper.reference
@@ -1,3 +1,3 @@
 200
 400
-CREATE TABLE test.ttl_repl2 (`d` Date, `x` UInt32) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/ttl_repl\', \'2\') PARTITION BY toDayOfMonth(d) ORDER BY x TTL d + toIntervalDay(1) SETTINGS index_granularity = 8192
+CREATE TABLE test.ttl_repl2 (`d` Date, `x` UInt32) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/ttl_repl\', \'2\') PARTITION BY toDayOfMonth(d) ORDER BY x TTL d + toIntervalDay(1) DELETE SETTINGS index_granularity = 8192

--- a/dbms/tests/queries/0_stateless/00933_ttl_replicated_zookeeper.reference
+++ b/dbms/tests/queries/0_stateless/00933_ttl_replicated_zookeeper.reference
@@ -1,3 +1,3 @@
 200
 400
-CREATE TABLE test.ttl_repl2 (`d` Date, `x` UInt32) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/ttl_repl\', \'2\') PARTITION BY toDayOfMonth(d) ORDER BY x TTL d + toIntervalDay(1) DELETE SETTINGS index_granularity = 8192
+CREATE TABLE test.ttl_repl2 (`d` Date, `x` UInt32) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/ttl_repl\', \'2\') PARTITION BY toDayOfMonth(d) ORDER BY x TTL d + toIntervalDay(1) SETTINGS index_granularity = 8192


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):

Move parts between storage volumes according to configured TTL expressions.