### PR TITLE
macOS Clang builds

### DIFF
--- a/contrib/libcxx-cmake/CMakeLists.txt
+++ b/contrib/libcxx-cmake/CMakeLists.txt
@@ -44,7 +44,7 @@ target_include_directories(cxx SYSTEM BEFORE PUBLIC $<BUILD_INTERFACE:${LIBCXX_S
 target_compile_definitions(cxx PRIVATE -D_LIBCPP_BUILDING_LIBRARY -DLIBCXX_BUILDING_LIBCXXABI)
 
 target_compile_options(cxx PUBLIC -nostdinc++ -Wno-reserved-id-macro)
-if (OS_DARWIN AND (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9) AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11))
+if ((NOT OS_DARWIN) AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11))
     target_compile_options(cxx PUBLIC -Wno-ctad-maybe-unsupported)
 endif ()
 

--- a/docs/en/development/build_osx.md
+++ b/docs/en/development/build_osx.md
@@ -33,10 +33,22 @@ For the latest stable version, switch to the `stable` branch.
 ```bash
 $ mkdir build
 $ cd build
-$ cmake .. -DCMAKE_CXX_COMPILER=`which g++-8` -DCMAKE_C_COMPILER=`which gcc-8`
+$ cmake .. -DCMAKE_CXX_COMPILER=`which g++` -DCMAKE_C_COMPILER=`which gcc`
 $ ninja
 $ cd ..
 ```
+
+## Build ClickHouse client only
+
+```bash
+$ mkdir build
+$ cd build
+$ cmake .. -DENABLE_CLICKHOUSE_ALL=0 -DENABLE_CLICKHOUSE_CLIENT=1 -DENABLE_MYSQL=0 -DCMAKE_CXX_COMPILER=`which g++` -DCMAKE_C_COMPILER=`which gcc`
+$ ninja
+$ cd ..
+```
+
+
 
 ## Caveats
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Bug Fix
- Documentation

Changelog entry:

- Remove unsupported compiler flag on Clang / macOS (-Wno-ctad-maybe-unsupported)
- Update build docs for Clang / macOS

Addresses:

- #7995
- #7546
- #5765