### PR TITLE
Parallel INSERT in INSERT SELECT query

### DIFF
--- a/dbms/src/Core/Settings.h
+++ b/dbms/src/Core/Settings.h
@@ -52,6 +52,7 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingUInt64, max_insert_block_size, DEFAULT_INSERT_BLOCK_SIZE, "The maximum block size for insertion, if we control the creation of blocks for insertion.", 0) \
     M(SettingUInt64, min_insert_block_size_rows, DEFAULT_INSERT_BLOCK_SIZE, "Squash blocks passed to INSERT query to specified size in rows, if blocks are not big enough.", 0) \
     M(SettingUInt64, min_insert_block_size_bytes, (DEFAULT_INSERT_BLOCK_SIZE * 256), "Squash blocks passed to INSERT query to specified size in bytes, if blocks are not big enough.", 0) \
+    M(SettingMaxThreads, max_insert_threads, 0, "The maximum number of threads to execute the INSERT SELECT query. By default, it is determined automatically.", 0) \
     M(SettingMaxThreads, max_threads, 0, "The maximum number of threads to execute the request. By default, it is determined automatically.", 0) \
     M(SettingMaxThreads, max_alter_threads, 0, "The maximum number of threads to execute the ALTER requests. By default, it is determined automatically.", 0) \
     M(SettingUInt64, max_read_buffer_size, DBMS_DEFAULT_BUFFER_SIZE, "The maximum size of the buffer to read from the filesystem.", 0) \

--- a/dbms/src/DataStreams/IBlockStream_fwd.h
+++ b/dbms/src/DataStreams/IBlockStream_fwd.h
@@ -12,5 +12,6 @@ class IBlockOutputStream;
 using BlockInputStreamPtr = std::shared_ptr<IBlockInputStream>;
 using BlockInputStreams = std::vector<BlockInputStreamPtr>;
 using BlockOutputStreamPtr = std::shared_ptr<IBlockOutputStream>;
+using BlockOutputStreams = std::vector<BlockOutputStreamPtr>;
 
 }

--- a/dbms/src/DataStreams/copyData.cpp
+++ b/dbms/src/DataStreams/copyData.cpp
@@ -1,6 +1,8 @@
+#include <thread>
 #include <DataStreams/IBlockInputStream.h>
 #include <DataStreams/IBlockOutputStream.h>
 #include <DataStreams/copyData.h>
+#include <Common/ConcurrentBoundedQueue.h>
 
 
 namespace DB
@@ -51,6 +53,73 @@ void copyDataImpl(IBlockInputStream & from, IBlockOutputStream & to, TCancelCall
 
 inline void doNothing(const Block &) {}
 
+
+void copyDataImpl(BlockInputStreams & froms, BlockOutputStreams & tos)
+{
+    if (froms.size() == tos.size())
+    {
+        std::vector<std::thread> threads(froms.size());
+        for (size_t i = 0; i < froms.size(); i++)
+        {
+            threads[i] = std::thread(
+                [&](BlockInputStreamPtr from, BlockOutputStreamPtr to) {
+                    from->readPrefix();
+                    to->writePrefix();
+                    while (Block block = from->read())
+                    {
+                        to->write(block);
+                    }
+                    from->readSuffix();
+                    to->writeSuffix();
+                }, froms.at(i), tos.at(i));
+        }
+        for (auto & thread : threads)
+            thread.join();
+    }
+    else
+    {
+        ConcurrentBoundedQueue<Block> queue(froms.size());
+        std::thread from_threads([&]() {
+            std::vector<std::thread> _from_threads;
+            for (auto & _from : froms)
+            {
+                _from_threads.emplace_back([&](BlockInputStreamPtr from) {
+                    from->readPrefix();
+                    while (Block block = from->read())
+                    {
+                        queue.push(block);
+                    }
+                    from->readSuffix();
+                }, _from);
+            }
+            for (auto & thread : _from_threads)
+                thread.join();
+            for (size_t i = 0; i < tos.size(); i++)
+                queue.push({});
+        });
+        std::vector<std::thread> _to_threads;
+        for (auto & _to : tos)
+        {
+            _to_threads.emplace_back([&](BlockOutputStreamPtr to) {
+                to->writePrefix();
+                Block block;
+                while (true)
+                {
+                    queue.pop(block);
+                    if (!block)
+                        break;
+                    to->write(block);
+                }
+                to->writeSuffix();
+            }, _to);
+        }
+
+        from_threads.join();
+        for (auto & thread : _to_threads)
+            thread.join();
+    }
+}
+
 void copyData(IBlockInputStream & from, IBlockOutputStream & to, std::atomic<bool> * is_cancelled)
 {
     auto is_cancelled_pred = [is_cancelled] ()
@@ -61,6 +130,10 @@ void copyData(IBlockInputStream & from, IBlockOutputStream & to, std::atomic<boo
     copyDataImpl(from, to, is_cancelled_pred, doNothing);
 }
 
+void copyData(BlockInputStreams & froms, BlockOutputStreams & tos)
+{
+    copyDataImpl(froms, tos);
+}
 
 void copyData(IBlockInputStream & from, IBlockOutputStream & to, const std::function<bool()> & is_cancelled)
 {

--- a/dbms/src/DataStreams/copyData.cpp
+++ b/dbms/src/DataStreams/copyData.cpp
@@ -63,7 +63,7 @@ void copyDataImpl(BlockInputStreams & froms, BlockOutputStreams & tos)
         threads.reserve(froms.size());
         for (size_t i = 0; i < froms.size(); i++)
         {
-            threads.emplace_back([from = froms.at(i), to = tos.at(i)]() 
+            threads.emplace_back([from = froms.at(i), to = tos.at(i)]()
             {
                 from->readPrefix();
                 to->writePrefix();
@@ -79,13 +79,13 @@ void copyDataImpl(BlockInputStreams & froms, BlockOutputStreams & tos)
     else
     {
         ConcurrentBoundedQueue<Block> queue(froms.size());
-        ThreadFromGlobalPool from_threads([&]() 
+        ThreadFromGlobalPool from_threads([&]()
         {
             std::vector<ThreadFromGlobalPool> from_threads_;
             from_threads_.reserve(froms.size());
             for (auto & from : froms)
             {
-                from_threads_.emplace_back([&queue, from]() 
+                from_threads_.emplace_back([&queue, from]()
                 {
                     from->readPrefix();
                     while (Block block = from->read())
@@ -101,7 +101,7 @@ void copyDataImpl(BlockInputStreams & froms, BlockOutputStreams & tos)
         std::vector<ThreadFromGlobalPool> to_threads;
         for (auto & to : tos)
         {
-            to_threads.emplace_back([&queue, to]() 
+            to_threads.emplace_back([&queue, to]()
             {
                 to->writePrefix();
                 Block block;

--- a/dbms/src/DataStreams/copyData.h
+++ b/dbms/src/DataStreams/copyData.h
@@ -16,6 +16,8 @@ class Block;
   */
 void copyData(IBlockInputStream & from, IBlockOutputStream & to, std::atomic<bool> * is_cancelled = nullptr);
 
+void copyData(BlockInputStreams & froms, BlockOutputStreams & tos);
+
 void copyData(IBlockInputStream & from, IBlockOutputStream & to, const std::function<bool()> & is_cancelled);
 
 void copyData(IBlockInputStream & from, IBlockOutputStream & to, const std::function<bool()> & is_cancelled,

--- a/dbms/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterInsertQuery.cpp
@@ -103,56 +103,84 @@ BlockIO InterpreterInsertQuery::execute()
 
     auto table_lock = table->lockStructureForShare(true, context.getInitialQueryId());
 
-    /// We create a pipeline of several streams, into which we will write data.
-    BlockOutputStreamPtr out;
-
-    /// NOTE: we explicitly ignore bound materialized views when inserting into Kafka Storage.
-    ///       Otherwise we'll get duplicates when MV reads same rows again from Kafka.
-    if (table->noPushingToViews() && !no_destination)
-        out = table->write(query_ptr, context);
-    else
-        out = std::make_shared<PushingToViewsBlockOutputStream>(query.database, query.table, table, context, query_ptr, no_destination);
-
-    /// Do not squash blocks if it is a sync INSERT into Distributed, since it lead to double bufferization on client and server side.
-    /// Client-side bufferization might cause excessive timeouts (especially in case of big blocks).
-    if (!(context.getSettingsRef().insert_distributed_sync && table->isRemote()) && !no_squash)
-    {
-        out = std::make_shared<SquashingBlockOutputStream>(
-            out, out->getHeader(), context.getSettingsRef().min_insert_block_size_rows, context.getSettingsRef().min_insert_block_size_bytes);
-    }
-    auto query_sample_block = getSampleBlock(query, table);
-
-    /// Actually we don't know structure of input blocks from query/table,
-    /// because some clients break insertion protocol (columns != header)
-    out = std::make_shared<AddingDefaultBlockOutputStream>(
-        out, query_sample_block, out->getHeader(), table->getColumns().getDefaults(), context);
-
-    if (const auto & constraints = table->getConstraints(); !constraints.empty())
-        out = std::make_shared<CheckConstraintsBlockOutputStream>(query.table,
-            out, query_sample_block, table->getConstraints(), context);
-
-    auto out_wrapper = std::make_shared<CountingBlockOutputStream>(out);
-    out_wrapper->setProcessListElement(context.getProcessListElement());
-    out = std::move(out_wrapper);
-
-    BlockIO res;
-
-    /// What type of query: INSERT or INSERT SELECT?
+    BlockInputStreams in_streams;
+    size_t out_streams_size = 1;
     if (query.select)
     {
         /// Passing 1 as subquery_depth will disable limiting size of intermediate result.
         InterpreterSelectWithUnionQuery interpreter_select{query.select, context, SelectQueryOptions(QueryProcessingStage::Complete, 1)};
 
-        /// BlockIO may hold StoragePtrs to temporary tables
-        res = interpreter_select.execute();
-        res.out = nullptr;
+        if (table->supportsParallelInsert())
+        {
+            in_streams = interpreter_select.executeWithMultipleStreams(res.pipeline);
+            const Settings & settings = context.getSettingsRef();
+            out_streams_size = std::min(size_t(settings.max_insert_threads), in_streams.size());
+        }
+        else
+            in_streams.emplace_back(interpreter_select.execute().in);
+    }
+
+    BlockOutputStreams out_streams;
+    auto query_sample_block = getSampleBlock(query, table);
+
+    while (out_streams_size-- > 0)
+    {
+        /// We create a pipeline of several streams, into which we will write data.
+        BlockOutputStreamPtr out;
+
+        /// NOTE: we explicitly ignore bound materialized views when inserting into Kafka Storage.
+        ///       Otherwise we'll get duplicates when MV reads same rows again from Kafka.
+        if (table->noPushingToViews() && !no_destination)
+            out = table->write(query_ptr, context);
+        else
+            out = std::make_shared<PushingToViewsBlockOutputStream>(query.database, query.table, table, context, query_ptr, no_destination);
+
+        /// Do not squash blocks if it is a sync INSERT into Distributed, since it lead to double bufferization on client and server side.
+        /// Client-side bufferization might cause excessive timeouts (especially in case of big blocks).
+        if (!(context.getSettingsRef().insert_distributed_sync && table->isRemote()) && !no_squash)
+        {
+            out = std::make_shared<SquashingBlockOutputStream>(
+                out, out->getHeader(), context.getSettingsRef().min_insert_block_size_rows, context.getSettingsRef().min_insert_block_size_bytes);
+        }
+
+        /// Actually we don't know structure of input blocks from query/table,
+        /// because some clients break insertion protocol (columns != header)
+        out = std::make_shared<AddingDefaultBlockOutputStream>(
+            out, query_sample_block, out->getHeader(), table->getColumns().getDefaults(), context);
+
+        if (const auto & constraints = table->getConstraints(); !constraints.empty())
+            out = std::make_shared<CheckConstraintsBlockOutputStream>(query.table,
+             out, query_sample_block, table->getConstraints(), context);
+
+        auto out_wrapper = std::make_shared<CountingBlockOutputStream>(out);
+        out_wrapper->setProcessListElement(context.getProcessListElement());
+        out = std::move(out_wrapper);
+        out_streams.emplace_back(std::move(out));
+    }
+
+    /// What type of query: INSERT or INSERT SELECT?
+    if (query.select)
+    {
+        for (auto & in_stream : in_streams)
+        {
+            in_stream = std::make_shared<ConvertingBlockInputStream>(
+                context, in_stream, out_streams.at(0)->getHeader(), ConvertingBlockInputStream::MatchColumnsMode::Position);
+        }
+
+        Block in_header = in_streams.at(0)->getHeader();
+        if(in_streams.size() > 1)
+        {
+            for (size_t i = 1; i < in_streams.size(); ++i)
+                assertBlocksHaveEqualStructure(in_streams[i]->getHeader(), in_header, "INSERT SELECT");
+        }
+
+        res.in = std::make_shared<NullAndDoCopyBlockInputStream>(in_streams, out_streams);
 
         res.in = std::make_shared<ConvertingBlockInputStream>(context, res.in, out->getHeader(), ConvertingBlockInputStream::MatchColumnsMode::Position);
         res.in = std::make_shared<NullAndDoCopyBlockInputStream>(res.in, out);
 
         if (!allow_materialized)
         {
-            Block in_header = res.in->getHeader();
             for (const auto & column : table->getColumns())
                 if (column.default_desc.kind == ColumnDefaultKind::Materialized && in_header.has(column.name))
                     throw Exception("Cannot insert column " + column.name + ", because it is MATERIALIZED column.", ErrorCodes::ILLEGAL_COLUMN);
@@ -160,12 +188,12 @@ BlockIO InterpreterInsertQuery::execute()
     }
     else if (query.data && !query.has_tail) /// can execute without additional data
     {
+        res.out = std::move(out_streams.at(0));
         res.in = std::make_shared<InputStreamFromASTInsertQuery>(query_ptr, nullptr, query_sample_block, context, nullptr);
         res.in = std::make_shared<NullAndDoCopyBlockInputStream>(res.in, out);
     }
     else
-        res.out = std::move(out);
-
+        res.out = std::move(out_streams.at(0));
     res.pipeline.addStorageHolder(table);
 
     return res;

--- a/dbms/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterInsertQuery.cpp
@@ -116,6 +116,8 @@ BlockIO InterpreterInsertQuery::execute()
             in_streams = interpreter_select.executeWithMultipleStreams(res.pipeline);
             const Settings & settings = context.getSettingsRef();
             out_streams_size = std::min(size_t(settings.max_insert_threads), in_streams.size());
+            if (out_streams_size == 0)
+                out_streams_size = 1;
         }
         else
             in_streams.emplace_back(interpreter_select.execute().in);

--- a/dbms/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterInsertQuery.cpp
@@ -123,7 +123,7 @@ BlockIO InterpreterInsertQuery::execute()
     BlockOutputStreams out_streams;
     auto query_sample_block = getSampleBlock(query, table);
 
-    while (out_streams_size-- > 0)
+    for (size_t i = 0; i < out_streams_size; i++)
     {
         /// We create a pipeline of several streams, into which we will write data.
         BlockOutputStreamPtr out;
@@ -168,7 +168,7 @@ BlockIO InterpreterInsertQuery::execute()
         }
 
         Block in_header = in_streams.at(0)->getHeader();
-        if(in_streams.size() > 1)
+        if (in_streams.size() > 1)
         {
             for (size_t i = 1; i < in_streams.size(); ++i)
                 assertBlocksHaveEqualStructure(in_streams[i]->getHeader(), in_header, "INSERT SELECT");

--- a/dbms/src/Storages/IStorage.h
+++ b/dbms/src/Storages/IStorage.h
@@ -104,6 +104,9 @@ public:
     /// Returns true if the storage replicates SELECT, INSERT and ALTER commands among replicas.
     virtual bool supportsReplication() const { return false; }
 
+    /// Returns true if the storage supports parallel insert.
+    virtual bool supportsParallelInsert() const { return false; }
+
     /// Returns true if the storage supports deduplication of inserted data blocks.
     virtual bool supportsDeduplication() const { return false; }
 

--- a/dbms/src/Storages/StorageMergeTree.h
+++ b/dbms/src/Storages/StorageMergeTree.h
@@ -35,6 +35,8 @@ public:
     std::string getTableName() const override { return table_name; }
     std::string getDatabaseName() const override { return database_name; }
 
+    bool supportsParallelInsert() const override { return true; }
+
     bool supportsIndexForIn() const override { return true; }
 
     Pipes readWithProcessors(

--- a/dbms/src/Storages/StorageReplicatedMergeTree.h
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.h
@@ -86,6 +86,7 @@ public:
     std::string getTableName() const override { return table_name; }
     std::string getDatabaseName() const override { return database_name; }
 
+    bool supportsParallelInsert() const override { return true; }
     bool supportsReplication() const override { return true; }
     bool supportsDeduplication() const override { return true; }
 

--- a/dbms/tests/performance/parallel_insert.xml
+++ b/dbms/tests/performance/parallel_insert.xml
@@ -1,0 +1,23 @@
+<test>
+    <type>loop</type>
+
+    <stop_conditions>
+        <any_of>
+            <iterations>2</iterations>
+        </any_of>
+    </stop_conditions>
+
+    <main_metric>
+        <rows_per_second />
+    </main_metric>
+
+    <preconditions>
+        <table_exists>default.hits_10m_single</table_exists>
+    </preconditions>
+
+    <create_query>CREATE TABLE hits2 AS hits_10m_single</create_query>
+
+    <query>INSERT INTO hits2 SELECT * FROM hits_10m_single</query>
+
+    <drop_query>DROP TABLE IF EXISTS hits2</drop_query>
+</test>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Added setting `max_insert_threads`. This setting is used for `INSERT SELECT` queries if the destination table supports parallel insertion (this is true for tables from MergeTree family) and it has effect if the `SELECT` part of the query returns data in several threads. The setting is set to 1 by default (do not do parallel INSERT) to avoid excessive memory usage (otherwise it can compromise backward compatibility).

# Description

This pull request enables parallel insert in INSERT SELECT query, this PR will address [#8038 ](https://github.com/ClickHouse/ClickHouse/issues/8038)

When doing INSERT SELECT query, if we INSERT into a table that supports parallel insertion (e.g. `StorageMergeTree` and `ReplicatedMergeTree `), we can create multiple insertion streams (as many as SELECT streams) and do a parallel insertion.

This behavior is controlled by a separate setting `max_insert_threads`. The number of insert threads also capped by the number of streams that SELECT query returned.

Generally, the number of insertion streams will be equal with SELECT streams, we create multiple threads to pipeline process the insertion streams and SELECT streams. But, if the insertion streams less than SELECT streams(in case `executeWithMultipleStreams` returns more streams than insertion streams), we use a concurrent queue to decouple the read and write thread to alleviate the skew problem caused by the partial merge of SELECT streams.

# Benchmark

We have a simple benchmark on a 20 core machine (2× Intel E5-2640 v4), the results are as follows:

```
dell127 :) CREATE TABLE test (number UInt64) engine=MergeTree() order by tuple()

CREATE TABLE test
(
    `number` UInt64
)
ENGINE = MergeTree()
ORDER BY tuple()

Ok.

0 rows in set. Elapsed: 0.174 sec.
```

Case without parallel insert:

```
dell127 :) insert into test select number from numbers_mt(1000000000)

INSERT INTO test SELECT number
FROM numbers_mt(1000000000)

Ok.

0 rows in set. Elapsed: 35.054 sec. Processed 1.00 billion rows, 8.00 GB (28.53 million rows/s., 228.22 MB/s.)
```

Case with parallel insert:

```
dell127 :) insert into test select number from numbers_mt(1000000000)

INSERT INTO test SELECT number
FROM numbers_mt(1000000000)

Ok.

0 rows in set. Elapsed: 3.890 sec. Processed 1.00 billion rows, 8.00 GB (257.04 million rows/s., 2.06 GB/s.)
```

We have another benchmark using  `hits` [dataset](https://clickhouse.yandex/docs/en/getting_started/example_datasets/metrica/), parallel insert improves performance by about 3-4 times compared with the single thread version, the results are as follows:

Query SQL: `insert into hits_to select * from hits`

Case without parallel insert:

```
Queries executed: 4.

localhost:9000, queries 4, QPS: 0.043, RPS: 378441.218, MiB/s: 344.095, result RPS: 0.000, result MiB/s: 0.000.

0.000%          22.497 sec.
10.000%         22.651 sec.
20.000%         22.804 sec.
30.000%         22.958 sec.
40.000%         23.197 sec.
50.000%         23.478 sec.
60.000%         23.760 sec.
70.000%         23.987 sec.
80.000%         24.105 sec.
90.000%         24.222 sec.
95.000%         24.281 sec.
99.000%         24.328 sec.
99.900%         24.339 sec.
99.990%         24.340 sec.
```

Case with parallel insert:

```
Queries executed: 6.

localhost:9000, queries 6, QPS: 0.184, RPS: 1636661.264, MiB/s: 1488.124, result RPS: 0.000, result MiB/s: 0.000.

0.000%          4.463 sec.
10.000%         4.578 sec.
20.000%         4.692 sec.
30.000%         4.737 sec.
40.000%         4.782 sec.
50.000%         4.912 sec.
60.000%         5.042 sec.
70.000%         5.329 sec.
80.000%         5.617 sec.
90.000%         6.776 sec.
95.000%         7.356 sec.
99.000%         7.820 sec.
99.900%         7.925 sec.
99.990%         7.935 sec.
```