### PR TITLE
Fix DROP DICTIONARY IF EXISTS

### DIFF
--- a/dbms/src/Interpreters/InterpreterDropQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterDropQuery.cpp
@@ -164,7 +164,7 @@ BlockIO InterpreterDropQuery::executeToDictionary(
 
     auto ddl_guard = (!no_ddl_lock ? context.getDDLGuard(database_name, dictionary_name) : nullptr);
 
-    DatabasePtr database = tryGetDatabase(database_name, false);
+    DatabasePtr database = tryGetDatabase(database_name, if_exists);
 
     if (!database || !database->isDictionaryExist(context, dictionary_name))
     {

--- a/dbms/tests/queries/0_stateless/01041_create_dictionary_if_not_exists.sql
+++ b/dbms/tests/queries/0_stateless/01041_create_dictionary_if_not_exists.sql
@@ -1,3 +1,5 @@
+DROP TABLE IF EXISTS dictdb.table_for_dict;
+DROP DICTIONARY IF EXISTS dictdb.dict_exists;
 DROP DATABASE IF EXISTS dictdb;
 
 CREATE DATABASE dictdb ENGINE = Ordinary;
@@ -37,4 +39,6 @@ LAYOUT(FLAT());
 
 SELECT dictGetFloat64('dictdb.dict_exists', 'value', toUInt64(1));
 
-DROP DATABASE IF EXISTS dictdb;
+DROP TABLE dictdb.table_for_dict;
+DROP DICTIONARY dictdb.dict_exists;
+DROP DATABASE dictdb;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry:
Fix `DROP DICTIONARY IF EXISTS db.dict`, now it doesn't throw exception if `db` doesn't exist.
