### PR TITLE
More languages for regions

### DIFF
--- a/dbms/src/Dictionaries/Embedded/GeodataProviders/INamesProvider.h
+++ b/dbms/src/Dictionaries/Embedded/GeodataProviders/INamesProvider.h
@@ -42,6 +42,7 @@ using ILanguageRegionsNamesDataSourcePtr = std::unique_ptr<ILanguageRegionsNames
 class IRegionsNamesDataProvider
 {
 public:
+    /// Returns nullptr if the language data does not exist.
     virtual ILanguageRegionsNamesDataSourcePtr getLanguageRegionsNamesSource(const std::string & language) const = 0;
 
     virtual ~IRegionsNamesDataProvider() {}

--- a/dbms/src/Dictionaries/Embedded/GeodataProviders/NamesProvider.cpp
+++ b/dbms/src/Dictionaries/Embedded/GeodataProviders/NamesProvider.cpp
@@ -39,7 +39,10 @@ RegionsNamesDataProvider::RegionsNamesDataProvider(const std::string & directory
 ILanguageRegionsNamesDataSourcePtr RegionsNamesDataProvider::getLanguageRegionsNamesSource(const std::string & language) const
 {
     const auto data_file = getDataFilePath(language);
-    return std::make_unique<LanguageRegionsNamesDataSource>(data_file, language);
+    if (Poco::File(data_file).exists())
+        return std::make_unique<LanguageRegionsNamesDataSource>(data_file, language);
+    else
+        return {};
 }
 
 std::string RegionsNamesDataProvider::getDataFilePath(const std::string & language) const

--- a/dbms/src/Dictionaries/Embedded/RegionsNames.cpp
+++ b/dbms/src/Dictionaries/Embedded/RegionsNames.cpp
@@ -1,10 +1,12 @@
 #include "RegionsNames.h"
 
 #include <IO/WriteHelpers.h>
+#include <IO/WriteBufferFromString.h>
+#include <IO/Operators.h>
 #include <Poco/Exception.h>
-#include <Poco/Util/Application.h>
 #include <common/logger_useful.h>
 #include "GeodataProviders/INamesProvider.h"
+
 
 namespace DB
 {
@@ -17,9 +19,9 @@ namespace ErrorCodes
 
 RegionsNames::RegionsNames(IRegionsNamesDataProviderPtr data_provider)
 {
-    for (size_t language_id = 0; language_id < SUPPORTED_LANGUAGES_COUNT; ++language_id)
+    for (size_t language_id = 0; language_id < total_languages; ++language_id)
     {
-        const std::string & language = supported_languages[language_id];
+        const std::string & language = languages[language_id];
         names_sources[language_id] = data_provider->getLanguageRegionsNamesSource(language);
     }
 
@@ -28,16 +30,14 @@ RegionsNames::RegionsNames(IRegionsNamesDataProviderPtr data_provider)
 
 std::string RegionsNames::dumpSupportedLanguagesNames()
 {
-    std::string res = "";
-    for (size_t i = 0; i < LANGUAGE_ALIASES_COUNT; ++i)
+    DB::WriteBufferFromOwnString out;
+    for (size_t i = 0; i < total_languages; ++i)
     {
         if (i > 0)
-            res += ", ";
-        res += '\'';
-        res += language_aliases[i].first;
-        res += '\'';
+            out << ", ";
+        out << '\'' << languages[i] << '\'';
     }
-    return res;
+    return out.str();
 }
 
 void RegionsNames::reload()
@@ -46,13 +46,13 @@ void RegionsNames::reload()
     LOG_DEBUG(log, "Reloading regions names");
 
     RegionID max_region_id = 0;
-    for (size_t language_id = 0; language_id < SUPPORTED_LANGUAGES_COUNT; ++language_id)
+    for (size_t language_id = 0; language_id < total_languages; ++language_id)
     {
-        const std::string & language = supported_languages[language_id];
+        const std::string & language = languages[language_id];
 
         auto names_source = names_sources[language_id];
 
-        if (!names_source->isModified())
+        if (!names_source || !names_source->isModified())
             continue;
 
         LOG_DEBUG(log, "Reloading regions names for language: " << language);
@@ -99,6 +99,6 @@ void RegionsNames::reload()
         names_refs[language_id].swap(new_names_refs);
     }
 
-    for (size_t language_id = 0; language_id < SUPPORTED_LANGUAGES_COUNT; ++language_id)
+    for (size_t language_id = 0; language_id < total_languages; ++language_id)
         names_refs[language_id].resize(max_region_id + 1, StringRef("", 0));
 }

--- a/dbms/src/Dictionaries/Embedded/RegionsNames.h
+++ b/dbms/src/Dictionaries/Embedded/RegionsNames.h
@@ -8,55 +8,57 @@
 #include "GeodataProviders/INamesProvider.h"
 
 
-/** A class that allows you to recognize by region id its text name in one of the supported languages: ru, en, ua, by, kz, tr.
+/** A class that allows you to recognize by region id its text name in one of the supported languages.
   *
-  * Information about region names loads from text files with the following format names:
-  *     regions_names_xx.txt,
-  * where xx is one of the two letters of the following supported languages:
-  *     ru, en, ua, by, kz, tr.
+  * Information about region names loads from text files with the following format names: regions_names_xx.txt,
+  * where xx is one of the two letters of the following supported languages.
   *
   * Can on request update the data.
   */
 class RegionsNames
 {
+/// Language name and fallback language name.
+#define FOR_EACH_LANGUAGE(M) \
+    M(ru, ru, 0) \
+    M(en, ru, 1) \
+    M(ua, ru, 2) \
+    M(uk, ua, 3) \
+    M(by, ru, 4) \
+    M(kz, ru, 5) \
+    M(tr, en, 6) \
+    M(de, en, 7) \
+    M(uz, ru, 8) \
+    M(lv, ru, 9) \
+    M(lt, ru, 10) \
+    M(et, ru, 11) \
+    M(pt, en, 12) \
+    M(he, en, 13) \
+    M(vi, en, 14)
+
+    static constexpr size_t total_languages = 15;
+
 public:
     enum class Language : size_t
     {
-        RU = 0,
-        EN,
-        UA,
-        BY,
-        KZ,
-        TR,
-
-        END
+        #define M(NAME, FALLBACK, NUM) NAME = NUM,
+        FOR_EACH_LANGUAGE(M)
+    #undef M
     };
 
 private:
-    static inline constexpr const char * supported_languages[] =
+    static inline constexpr const char * languages[] =
     {
-        "ru",
-        "en",
-        "ua",
-        "by",
-        "kz",
-        "tr"
+        #define M(NAME, FALLBACK, NUM) #NAME,
+        FOR_EACH_LANGUAGE(M)
+        #undef M
     };
 
-    static inline constexpr std::pair<const char *, Language> language_aliases[] =
+    static inline constexpr Language fallbacks[] =
     {
-        {"ru", Language::RU},
-        {"en", Language::EN},
-        {"ua", Language::UA},
-        {"uk", Language::UA},
-        {"by", Language::BY},
-        {"kz", Language::KZ},
-        {"tr", Language::TR}
+        #define M(NAME, FALLBACK, NUM) Language::FALLBACK,
+        FOR_EACH_LANGUAGE(M)
+        #undef M
     };
-
-    static constexpr size_t ROOT_LANGUAGE = 0;
-    static constexpr size_t SUPPORTED_LANGUAGES_COUNT = size_t(Language::END);
-    static constexpr size_t LANGUAGE_ALIASES_COUNT = sizeof(language_aliases);
 
     using NamesSources = std::vector<std::shared_ptr<ILanguageRegionsNamesDataSource>>;
 
@@ -65,10 +67,20 @@ private:
     using StringRefs = std::vector<StringRef>; /// Lookup table RegionID -> StringRef
     using StringRefsForLanguageID = std::vector<StringRefs>;
 
+
+    NamesSources names_sources = NamesSources(total_languages);
+
+    /// Bytes of names for each language, laid out in a row, separated by zeros
+    CharsForLanguageID chars = CharsForLanguageID(total_languages);
+
+    /// Mapping for each language from the region id into a pointer to the byte range of the name
+    StringRefsForLanguageID names_refs = StringRefsForLanguageID(total_languages);
+
+    static std::string dumpSupportedLanguagesNames();
 public:
     RegionsNames(IRegionsNamesDataProviderPtr data_provider);
 
-    StringRef getRegionName(RegionID region_id, Language language = Language::RU) const
+    StringRef getRegionName(RegionID region_id, Language language) const
     {
         size_t language_id = static_cast<size_t>(language);
 
@@ -77,10 +89,10 @@ public:
 
         StringRef ref = names_refs[language_id][region_id];
 
-        while (ref.size == 0 && language_id != ROOT_LANGUAGE)
+        static constexpr size_t root_language = static_cast<size_t>(Language::ru);
+        while (ref.size == 0 && language_id != root_language)
         {
-            static const size_t FALLBACK[] = {0, 0, 0, 0, 0, 1};
-            language_id = FALLBACK[language_id];
+            language_id = static_cast<size_t>(fallbacks[language_id]);
             ref = names_refs[language_id][region_id];
         }
 
@@ -89,28 +101,13 @@ public:
 
     static Language getLanguageEnum(const std::string & language)
     {
-        if (language.size() == 2)
-        {
-            for (size_t i = 0; i < LANGUAGE_ALIASES_COUNT; ++i)
-            {
-                const auto & alias = language_aliases[i];
-                if (language[0] == alias.first[0] && language[1] == alias.first[1])
-                    return alias.second;
-            }
-        }
+        #define M(NAME, FALLBACK, NUM) \
+            if (0 == language.compare(#NAME)) \
+                return Language::NAME;
+        FOR_EACH_LANGUAGE(M)
+        #undef M
         throw Poco::Exception("Unsupported language for region name. Supported languages are: " + dumpSupportedLanguagesNames() + ".");
     }
 
     void reload();
-
-private:
-    static std::string dumpSupportedLanguagesNames();
-
-    NamesSources names_sources = NamesSources(SUPPORTED_LANGUAGES_COUNT);
-
-    /// Bytes of names for each language, laid out in a row, separated by zeros
-    CharsForLanguageID chars = CharsForLanguageID(SUPPORTED_LANGUAGES_COUNT);
-
-    /// Mapping for each language from the region id into a pointer to the byte range of the name
-    StringRefsForLanguageID names_refs = StringRefsForLanguageID(SUPPORTED_LANGUAGES_COUNT);
 };

--- a/dbms/src/Functions/FunctionsEmbeddedDictionaries.h
+++ b/dbms/src/Functions/FunctionsEmbeddedDictionaries.h
@@ -617,7 +617,7 @@ public:
 
     void executeImpl(Block & block, const ColumnNumbers & arguments, size_t result, size_t /*input_rows_count*/) override
     {
-        RegionsNames::Language language = RegionsNames::Language::RU;
+        RegionsNames::Language language = RegionsNames::Language::ru;
 
         /// If the result language is specified
         if (arguments.size() == 2)


### PR DESCRIPTION
Changelog category (leave one):
- New Feature


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Support more languages in embedded dictionary for region names: 'ru', 'en', 'ua', 'uk', 'by', 'kz', 'tr', 'de', 'uz', 'lv', 'lt', 'et', 'pt', 'he', 'vi'.

Detailed description:
TODO: Add integration test. Support all languages.