### PR TITLE
Attempt to fix MSan failure in IFunction::wrapInNullable.

### DIFF
--- a/dbms/src/Functions/IFunction.cpp
+++ b/dbms/src/Functions/IFunction.cpp
@@ -126,7 +126,7 @@ ColumnPtr wrapInNullable(const ColumnPtr & src, const Block & block, const Colum
 
         /// Const Nullable that are NULL.
         if (elem.column->onlyNull())
-            return block.getByPosition(result).type->createColumnConst(input_rows_count, Null());
+            return elem.type->createColumnConst(input_rows_count, Null());
 
         if (isColumnConst(*elem.column))
             continue;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Fixed potential bug in functions that can take NULL as one of the arguments and return non-NULL.

Detailed description (optional):
`SELECT randConstant(CAST(NULL, 'Nullable(Int8)'))`:
`./dbms/tests/queries/0_stateless/00534_filimonov.sh`

https://clickhouse-test-reports.s3.yandex.net/8182/f0ed2bd2331a59f0771f2a7e6969928c3aa04e31/functional_stateless_tests_(memory)/stderr.log
