### PR TITLE
Init query context for Kafka to make subqueries work

### DIFF
--- a/dbms/src/Storages/Kafka/StorageKafka.cpp
+++ b/dbms/src/Storages/Kafka/StorageKafka.cpp
@@ -96,7 +96,8 @@ StorageKafka::StorageKafka(
                             {"_timestamp", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeDateTime>())}}, true))
     , table_name(table_name_)
     , database_name(database_name_)
-    , global_context(context_)
+    , global_context(context_.getGlobalContext())
+    , kafka_context(Context(global_context))
     , topics(global_context.getMacros()->expand(topics_))
     , brokers(global_context.getMacros()->expand(brokers_))
     , group(global_context.getMacros()->expand(group_))
@@ -110,6 +111,8 @@ StorageKafka::StorageKafka(
     , skip_broken(skip_broken_)
     , intermediate_commit(intermediate_commit_)
 {
+    kafka_context.makeQueryContext();
+
     setColumns(columns_);
     task = global_context.getSchedulePool().createTask(log->name(), [this]{ threadFunc(); });
     task->deactivate();
@@ -375,7 +378,7 @@ bool StorageKafka::streamToViews()
 
     // Create a stream for each consumer and join them in a union stream
     // Only insert into dependent views and expect that input blocks contain virtual columns
-    InterpreterInsertQuery interpreter(insert, global_context, false, true, true);
+    InterpreterInsertQuery interpreter(insert, kafka_context, false, true, true);
     auto block_io = interpreter.execute();
 
     // Create a stream for each consumer and join them in a union stream
@@ -384,7 +387,7 @@ bool StorageKafka::streamToViews()
     for (size_t i = 0; i < num_created_consumers; ++i)
     {
         auto stream
-            = std::make_shared<KafkaBlockInputStream>(*this, global_context, block_io.out->getHeader().getNames(), block_size, false);
+            = std::make_shared<KafkaBlockInputStream>(*this, kafka_context, block_io.out->getHeader().getNames(), block_size, false);
         streams.emplace_back(stream);
 
         // Limit read batch to maximum block size to allow DDL

--- a/dbms/src/Storages/Kafka/StorageKafka.h
+++ b/dbms/src/Storages/Kafka/StorageKafka.h
@@ -82,6 +82,7 @@ private:
     String table_name;
     String database_name;
     Context global_context;
+    Context kafka_context;
     Names topics;
     const String brokers;
     const String group;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Allow using MV with subqueries above Kafka tables.  

Detailed description (optional):
As here #7792- the original reason is lack of query context.
Fixes #8180

Kudos to @vzakaznikov 

P.S. It looks like there is one more place: #7039