### PR TITLE
Improved performance of max(), min(), argMin(), argMax() for DateTime64

### DIFF
--- a/dbms/src/AggregateFunctions/HelpersMinMaxAny.h
+++ b/dbms/src/AggregateFunctions/HelpersMinMaxAny.h
@@ -32,6 +32,8 @@ static IAggregateFunction * createAggregateFunctionSingleValue(const String & na
         return new AggregateFunctionTemplate<Data<SingleValueDataFixed<DataTypeDate::FieldType>>, false>(argument_type);
     if (which.idx == TypeIndex::DateTime)
         return new AggregateFunctionTemplate<Data<SingleValueDataFixed<DataTypeDateTime::FieldType>>, false>(argument_type);
+    if (which.idx == TypeIndex::DateTime64)
+        return new AggregateFunctionTemplate<Data<SingleValueDataFixed<DateTime64>>, false>(argument_type);
     if (which.idx == TypeIndex::Decimal32)
         return new AggregateFunctionTemplate<Data<SingleValueDataFixed<Decimal32>>, false>(argument_type);
     if (which.idx == TypeIndex::Decimal64)
@@ -60,6 +62,8 @@ static IAggregateFunction * createAggregateFunctionArgMinMaxSecond(const DataTyp
         return new AggregateFunctionArgMinMax<AggregateFunctionArgMinMaxData<ResData, MinMaxData<SingleValueDataFixed<DataTypeDate::FieldType>>>, false>(res_type, val_type);
     if (which.idx == TypeIndex::DateTime)
         return new AggregateFunctionArgMinMax<AggregateFunctionArgMinMaxData<ResData, MinMaxData<SingleValueDataFixed<DataTypeDateTime::FieldType>>>, false>(res_type, val_type);
+    if (which.idx == TypeIndex::DateTime64)
+        return new AggregateFunctionArgMinMax<AggregateFunctionArgMinMaxData<ResData, MinMaxData<SingleValueDataFixed<DateTime64>>>, false>(res_type, val_type);
     if (which.idx == TypeIndex::Decimal32)
         return new AggregateFunctionArgMinMax<AggregateFunctionArgMinMaxData<ResData, MinMaxData<SingleValueDataFixed<Decimal32>>>, false>(res_type, val_type);
     if (which.idx == TypeIndex::Decimal64)
@@ -92,6 +96,8 @@ static IAggregateFunction * createAggregateFunctionArgMinMax(const String & name
         return createAggregateFunctionArgMinMaxSecond<MinMaxData, SingleValueDataFixed<DataTypeDate::FieldType>>(res_type, val_type);
     if (which.idx == TypeIndex::DateTime)
         return createAggregateFunctionArgMinMaxSecond<MinMaxData, SingleValueDataFixed<DataTypeDateTime::FieldType>>(res_type, val_type);
+    if (which.idx == TypeIndex::DateTime64)
+        return createAggregateFunctionArgMinMaxSecond<MinMaxData, SingleValueDataFixed<DateTime64>>(res_type, val_type);
     if (which.idx == TypeIndex::Decimal32)
         return createAggregateFunctionArgMinMaxSecond<MinMaxData, SingleValueDataFixed<Decimal32>>(res_type, val_type);
     if (which.idx == TypeIndex::Decimal64)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Performance Improvement

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Improved performance of max(), min(), argMin(), argMax() for DateTime64
...


Detailed description (optional):
This boost performance of min/max on my machine by factor of 2:
pre-fix query performance on hits_v1 dataset with [perftest](https://github.com/ClickHouse/ClickHouse/blob/master/dbms/tests/performance/date_time_64.xml):

| Query | Execution time (seconds) |
|----------|-----------------------------------|
| SELECT max(x) FROM dt  | [0.006] |
| SELECT max(x) FROM dt64 | [0.046] |

max on DateTime64 is 0.046 / 0.006 = **7.666666666666666** slower (A)

post-fix performance:

| Query | Execution time (seconds) |
|----------|-----------------------------------|
| SELECT max(x) FROM dt  |  [0.005] |
| SELECT max(x) FROM dt64 | [0.018] |

max on DateTime64 is 0.018 / 0.005 = **3.5999999999999996** slower (B)

Gain is:
(A - B) / A * 100 % = 53%