### PR TITLE
CMake curl build quiet mode

### DIFF
--- a/contrib/curl-cmake/CMake/Macros.cmake
+++ b/contrib/curl-cmake/CMake/Macros.cmake
@@ -35,7 +35,6 @@ macro(curl_internal_test CURL_TEST)
         "-DLINK_LIBRARIES:STRING=${CMAKE_REQUIRED_LIBRARIES}")
     endif()
 
-    message(STATUS "Performing Curl Test ${CURL_TEST}")
     try_compile(${CURL_TEST}
       ${CMAKE_BINARY_DIR}
       ${CMAKE_CURRENT_SOURCE_DIR}/CMake/CurlTests.c
@@ -44,12 +43,10 @@ macro(curl_internal_test CURL_TEST)
       OUTPUT_VARIABLE OUTPUT)
     if(${CURL_TEST})
       set(${CURL_TEST} 1 CACHE INTERNAL "Curl test ${FUNCTION}")
-      message(STATUS "Performing Curl Test ${CURL_TEST} - Success")
       file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeOutput.log
         "Performing Curl Test ${CURL_TEST} passed with the following output:\n"
         "${OUTPUT}\n")
     else()
-      message(STATUS "Performing Curl Test ${CURL_TEST} - Failed")
       set(${CURL_TEST} "" CACHE INTERNAL "Curl test ${FUNCTION}")
       file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
         "Performing Curl Test ${CURL_TEST} failed with the following output:\n"
@@ -71,7 +68,6 @@ macro(curl_nroff_check)
         ERROR_QUIET)
       # Save the option if it was valid
       if(NROFF_MANOPT_OUTPUT)
-        message("Found *nroff option: -- ${_MANOPT}")
         set(NROFF_MANOPT ${_MANOPT})
         set(NROFF_USEFUL ON)
         break()

--- a/contrib/curl-cmake/CMake/OtherTests.cmake
+++ b/contrib/curl-cmake/CMake/OtherTests.cmake
@@ -54,8 +54,6 @@ if(curl_cv_recv)
                     return 0;
                   }"
                   curl_cv_func_recv_test)
-                message(STATUS
-                  "Tested: ${recv_retv} recv(${recv_arg1}, ${recv_arg2}, ${recv_arg3}, ${recv_arg4})")
                 if(curl_cv_func_recv_test)
                   set(curl_cv_func_recv_args
                     "${recv_arg1},${recv_arg2},${recv_arg3},${recv_arg4},${recv_retv}")
@@ -118,8 +116,6 @@ if(curl_cv_send)
                     return 0;
                   }"
                   curl_cv_func_send_test)
-                message(STATUS
-                  "Tested: ${send_retv} send(${send_arg1}, ${send_arg2}, ${send_arg3}, ${send_arg4})")
                 if(curl_cv_func_send_test)
                   string(REGEX REPLACE "(const) .*" "\\1" send_qual_arg2 "${send_arg2}")
                   string(REGEX REPLACE "const (.*)" "\\1" send_arg2 "${send_arg2}")

--- a/contrib/curl-cmake/CMakeLists.txt
+++ b/contrib/curl-cmake/CMakeLists.txt
@@ -30,6 +30,9 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 SET(CURL_SOURCE_DIR ${ClickHouse_SOURCE_DIR}/contrib/curl)
 SET(CURL_LIBRARY_DIR ${CURL_SOURCE_DIR}/lib)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake;${CMAKE_MODULE_PATH}")
+# Disable status messages when perform checks
+set(CMAKE_REQUIRED_QUIET)
+
 include(Macros)
 include(CMakeDependentOption)
 include(CheckCCompilerFlag)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Disable "Performing test" messages during curl build process.

Detailed description (optional):