### PR TITLE
rand and nullable argument

### DIFF
--- a/dbms/src/Functions/FunctionsRandom.h
+++ b/dbms/src/Functions/FunctionsRandom.h
@@ -55,6 +55,7 @@ public:
 
     bool isDeterministic() const override { return false; }
     bool isDeterministicInScopeOfQuery() const override { return false; }
+    bool useDefaultImplementationForNulls() const override { return false; }
 
     bool isVariadic() const override { return true; }
     size_t getNumberOfArguments() const override { return 0; }

--- a/dbms/src/Functions/randConstant.cpp
+++ b/dbms/src/Functions/randConstant.cpp
@@ -13,6 +13,8 @@ public:
 
     String getName() const override { return Name::name; }
 
+bool useDefaultImplementationForNulls() const override { return false; }
+
     void execute(Block & block, const ColumnNumbers &, size_t result, size_t input_rows_count) override
     {
         block.getByPosition(result).column = DataTypeNumber<ToType>().createColumnConst(input_rows_count, value);

--- a/dbms/src/Functions/randConstant.cpp
+++ b/dbms/src/Functions/randConstant.cpp
@@ -26,10 +26,10 @@ template <typename ToType, typename Name>
 class FunctionBaseRandomConstant : public IFunctionBaseImpl
 {
 public:
-    explicit FunctionBaseRandomConstant(ToType value_, DataTypes argument_types_)
+    explicit FunctionBaseRandomConstant(ToType value_, DataTypes argument_types_, DataTypePtr return_type_)
         : value(value_)
         , argument_types(std::move(argument_types_))
-        , return_type(std::make_shared<DataTypeNumber<ToType>>()) {}
+        , return_type(std::move(return_type_)) {}
 
     String getName() const override { return Name::name; }
 
@@ -65,6 +65,7 @@ public:
     String getName() const override { return name; }
 
     bool isDeterministic() const override { return false; }
+    bool useDefaultImplementationForNulls() const override { return false; }
 
     bool isVariadic() const override { return true; }
     size_t getNumberOfArguments() const override { return 0; }
@@ -84,7 +85,7 @@ public:
 
     DataTypePtr getReturnType(const DataTypes &) const override { return std::make_shared<DataTypeNumber<ToType>>(); }
 
-    FunctionBaseImplPtr build(const ColumnsWithTypeAndName & arguments, const DataTypePtr &) const override
+    FunctionBaseImplPtr build(const ColumnsWithTypeAndName & arguments, const DataTypePtr & return_type) const override
     {
         DataTypes argument_types;
 
@@ -95,7 +96,7 @@ public:
         RandImpl::execute(reinterpret_cast<char *>(vec_to.data()), sizeof(ToType));
         ToType value = vec_to[0];
 
-        return std::make_unique<FunctionBaseRandomConstant<ToType, Name>>(value, argument_types);
+        return std::make_unique<FunctionBaseRandomConstant<ToType, Name>>(value, argument_types, return_type);
     }
 };
 

--- a/dbms/tests/queries/0_stateless/01047_nullable_rand.reference
+++ b/dbms/tests/queries/0_stateless/01047_nullable_rand.reference
@@ -1,0 +1,8 @@
+UInt32
+UInt32
+UInt32
+UInt32
+0
+0
+0
+0

--- a/dbms/tests/queries/0_stateless/01047_nullable_rand.sql
+++ b/dbms/tests/queries/0_stateless/01047_nullable_rand.sql
@@ -1,0 +1,9 @@
+select toTypeName(rand(cast(4 as Nullable(UInt8))));
+select toTypeName(randConstant(CAST(4 as Nullable(UInt8))));
+select toTypeName(rand(Null));
+select toTypeName(randConstant(Null));
+
+select rand(cast(4 as Nullable(UInt8))) * 0;
+select randConstant(CAST(4 as Nullable(UInt8))) * 0;
+select rand(Null) * 0;
+select randConstant(Null) * 0;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Fixed return type for functions `rand` and `randConstant` in case of nullable argument. Now functions always return `UInt32` and never `Nullable(UInt32)`.
