### PR TITLE
Fix max_http_get_redirects documentation. 

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -137,7 +137,7 @@ Limits the maximum number of HTTP GET redirect hops for [URL](../table_engines/u
 Possible values:
 
 - Positive integer number of hops.
-- 0 — Unlimited number of hops.
+- 0 — No hops allowed.
 
 Default value: 0.
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Non-significant (changelog entry is not needed)


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):

0 means "no redirects allowed" instead of "unlimited number of hops".