### PR TITLE
Silent warnings in CapNProto

### DIFF
--- a/contrib/capnproto-cmake/CMakeLists.txt
+++ b/contrib/capnproto-cmake/CMakeLists.txt
@@ -28,8 +28,8 @@ set (KJ_SRCS
 )
 
 add_library(kj ${KJ_SRCS})
-target_include_directories(kj PUBLIC ${CAPNPROTO_SOURCE_DIR})
-target_compile_options(kj PUBLIC -Wno-non-virtual-dtor)
+target_include_directories(kj SYSTEM PUBLIC ${CAPNPROTO_SOURCE_DIR})
+target_compile_options(kj PRIVATE -Wno-non-virtual-dtor)
 
 set (CAPNP_SRCS
     ${CAPNPROTO_SOURCE_DIR}/capnp/c++.capnp.c++
@@ -51,6 +51,7 @@ set (CAPNP_SRCS
 
 add_library(capnp ${CAPNP_SRCS})
 target_link_libraries(capnp PUBLIC kj)
+target_compile_options(capnp PRIVATE -Wno-non-virtual-dtor)
 
 set (CAPNPC_SRCS
     ${CAPNPROTO_SOURCE_DIR}/capnp/compiler/type-id.c++


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Silent warnings in CapNProto library.