### PR TITLE
Deprecate tcmalloc

### DIFF
--- a/dbms/programs/main.cpp
+++ b/dbms/programs/main.cpp
@@ -14,10 +14,6 @@
 #include "config_core.h"
 #endif
 
-#if USE_TCMALLOC
-#include <gperftools/malloc_extension.h>
-#endif
-
 #include <Common/StringUtils/StringUtils.h>
 
 #include <common/phdr_cache.h>
@@ -152,14 +148,6 @@ int main(int argc_, char ** argv_)
     /// It also speed up exception handling, but exceptions from dynamically loaded libraries (dlopen)
     ///  will work only after additional call of this function.
     updatePHDRCache();
-
-#if USE_TCMALLOC
-    /** Without this option, tcmalloc returns memory to OS too frequently for medium-sized memory allocations
-      *  (like IO buffers, column vectors, hash tables, etc.),
-      *  that lead to page faults and significantly hurts performance.
-      */
-    MallocExtension::instance()->SetNumericProperty("tcmalloc.aggressive_memory_decommit", false);
-#endif
 
     std::vector<char *> argv(argv_, argv_ + argc_);
 

--- a/dbms/src/Interpreters/AsynchronousMetrics.cpp
+++ b/dbms/src/Interpreters/AsynchronousMetrics.cpp
@@ -16,19 +16,6 @@
 #include <common/config_common.h>
 #endif
 
-#if USE_TCMALLOC
-    #include <gperftools/malloc_extension.h>
-
-    /// Initializing malloc extension in global constructor as required.
-    struct MallocExtensionInitializer
-    {
-        MallocExtensionInitializer()
-        {
-            MallocExtension::Initialize();
-        }
-    } malloc_extension_initializer;
-#endif
-
 #if USE_JEMALLOC
     #include <jemalloc/jemalloc.h>
 #endif
@@ -227,33 +214,6 @@ void AsynchronousMetrics::update()
         set("NumberOfDatabases", number_of_databases);
         set("NumberOfTables", total_number_of_tables);
     }
-
-#if USE_TCMALLOC
-    {
-        /// tcmalloc related metrics. Remove if you switch to different allocator.
-
-        MallocExtension & malloc_extension = *MallocExtension::instance();
-
-        auto malloc_metrics =
-        {
-            "generic.current_allocated_bytes",
-            "generic.heap_size",
-            "tcmalloc.current_total_thread_cache_bytes",
-            "tcmalloc.central_cache_free_bytes",
-            "tcmalloc.transfer_cache_free_bytes",
-            "tcmalloc.thread_cache_free_bytes",
-            "tcmalloc.pageheap_free_bytes",
-            "tcmalloc.pageheap_unmapped_bytes",
-        };
-
-        for (auto malloc_metric : malloc_metrics)
-        {
-            size_t value = 0;
-            if (malloc_extension.GetNumericProperty(malloc_metric, &value))
-                set(malloc_metric, value);
-        }
-    }
-#endif
 
 #if USE_JEMALLOC
     {


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Removed special cases of code for tcmalloc, because it's no longer supported.