### PR TITLE
Fixed #5335. clickhouse-local. Print help if no arguments are passed

### DIFF
--- a/dbms/programs/local/LocalServer.cpp
+++ b/dbms/programs/local/LocalServer.cpp
@@ -443,7 +443,7 @@ void LocalServer::init(int argc, char ** argv)
         exit(0);
     }
 
-    if (options.count("help"))
+    if (options.empty() || options.count("help"))
     {
         std::cout << getHelpHeader() << "\n";
         std::cout << description << "\n";


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Printed help message when no arguments are passed when calling `clickhouse-local`. This fixes #5335.