### PR TITLE
Fix 00600_replace_running_query.

### DIFF
--- a/dbms/tests/queries/0_stateless/00600_replace_running_query.sh
+++ b/dbms/tests/queries/0_stateless/00600_replace_running_query.sh
@@ -21,7 +21,7 @@ $CLICKHOUSE_CURL -sS "$CLICKHOUSE_URL&query_id=hello&replace_running_query=1" -d
 # Wait for it to be replaced
 wait
 
-${CLICKHOUSE_CLIENT} --user=readonly --query_id=42 --query='SELECT 2, count() FROM system.numbers' 2>&1 | grep -cF 'was cancelled' &
+${CLICKHOUSE_CLIENT_BINARY} --user=readonly --query_id=42 --query='SELECT 2, count() FROM system.numbers' 2>&1 | grep -cF 'was cancelled' &
 wait_for_query_to_start '42'
 
 # Trying to run another query with the same query_id


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Fix 00600_replace_running_query for processors.

Test was failed because of exception `Cannot modify 'experimental_use_processors' setting in readonly mode.` if query was executed in readonly mode and changes `experimental_use_processors` settings: `clickhouse client --send_logs_level=none --database=test_72bxfl --experimental_use_processors=1 --user=readonly --query_id=42 --query='SELECT 2, count() FROM system.numbers'`.
Used `CLICKHOUSE_CLIENT_BINARY` env variable instead of `CLICKHOUSE_CLIENT`, which ignores additional client options from test config.