### PR TITLE
Added asserts to KeyCondition while evaluating RPN

### DIFF
--- a/dbms/src/Storages/MergeTree/KeyCondition.cpp
+++ b/dbms/src/Storages/MergeTree/KeyCondition.cpp
@@ -16,6 +16,8 @@
 #include <Parsers/ASTSubquery.h>
 #include <Parsers/ASTIdentifier.h>
 
+#include <cassert>
+
 
 namespace DB
 {
@@ -1095,10 +1097,14 @@ bool KeyCondition::mayBeTrueInParallelogram(const std::vector<Range> & parallelo
         }
         else if (element.function == RPNElement::FUNCTION_NOT)
         {
+            assert(!rpn_stack.empty());
+
             rpn_stack.back() = !rpn_stack.back();
         }
         else if (element.function == RPNElement::FUNCTION_AND)
         {
+            assert(!rpn_stack.empty());
+
             auto arg1 = rpn_stack.back();
             rpn_stack.pop_back();
             auto arg2 = rpn_stack.back();
@@ -1106,6 +1112,8 @@ bool KeyCondition::mayBeTrueInParallelogram(const std::vector<Range> & parallelo
         }
         else if (element.function == RPNElement::FUNCTION_OR)
         {
+            assert(!rpn_stack.empty());
+
             auto arg1 = rpn_stack.back();
             rpn_stack.pop_back();
             auto arg2 = rpn_stack.back();
@@ -1223,6 +1231,8 @@ bool KeyCondition::alwaysUnknownOrTrue() const
         }
         else if (element.function == RPNElement::FUNCTION_AND)
         {
+            assert(!rpn_stack.empty());
+
             auto arg1 = rpn_stack.back();
             rpn_stack.pop_back();
             auto arg2 = rpn_stack.back();
@@ -1230,6 +1240,8 @@ bool KeyCondition::alwaysUnknownOrTrue() const
         }
         else if (element.function == RPNElement::FUNCTION_OR)
         {
+            assert(!rpn_stack.empty());
+
             auto arg1 = rpn_stack.back();
             rpn_stack.pop_back();
             auto arg2 = rpn_stack.back();
@@ -1238,6 +1250,9 @@ bool KeyCondition::alwaysUnknownOrTrue() const
         else
             throw Exception("Unexpected function type in KeyCondition::RPNElement", ErrorCodes::LOGICAL_ERROR);
     }
+
+    if (rpn_stack.size() != 1)
+        throw Exception("Unexpected stack size in KeyCondition::mayBeTrueInRange", ErrorCodes::LOGICAL_ERROR);
 
     return rpn_stack[0];
 }

--- a/dbms/src/Storages/MergeTree/KeyCondition.cpp
+++ b/dbms/src/Storages/MergeTree/KeyCondition.cpp
@@ -1252,7 +1252,7 @@ bool KeyCondition::alwaysUnknownOrTrue() const
     }
 
     if (rpn_stack.size() != 1)
-        throw Exception("Unexpected stack size in KeyCondition::mayBeTrueInRange", ErrorCodes::LOGICAL_ERROR);
+        throw Exception("Unexpected stack size in KeyCondition::alwaysUnknownOrTrue", ErrorCodes::LOGICAL_ERROR);
 
     return rpn_stack[0];
 }

--- a/dbms/src/Storages/MergeTree/KeyCondition.cpp
+++ b/dbms/src/Storages/MergeTree/KeyCondition.cpp
@@ -1132,7 +1132,7 @@ bool KeyCondition::mayBeTrueInParallelogram(const std::vector<Range> & parallelo
     }
 
     if (rpn_stack.size() != 1)
-        throw Exception("Unexpected stack size in KeyCondition::mayBeTrueInRange", ErrorCodes::LOGICAL_ERROR);
+        throw Exception("Unexpected stack size in KeyCondition::mayBeTrueInParallelogram", ErrorCodes::LOGICAL_ERROR);
 
     return rpn_stack[0].can_be_true;
 }


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Added asserts to KeyCondition while evaluating RPN. This will fix warning from gcc-9.