### PR TITLE
fix utils/grammar problem

### DIFF
--- a/utils/grammar/ClickHouseParser.g4
+++ b/utils/grammar/ClickHouseParser.g4
@@ -41,7 +41,7 @@ select_query
  ;
 
 select_query_main
- :  select_with_step
+ :  select_with_step?
     select_select_step select_from_step?
     K_FINAL? select_sample_step?
     select_array_join_step? select_join_step?

--- a/utils/grammar/ClickHouseParser.g4
+++ b/utils/grammar/ClickHouseParser.g4
@@ -12,7 +12,7 @@ options {
 // 4. правило для expr переписано чтобы понизить глубину AST и сразу выходить на уровень expr - al
 
 parse
- : ( query | error ) EOF
+ : ( query | err ) EOF
  ;
 
 query
@@ -575,7 +575,7 @@ literal
  |    STRING_LITERAL
  ;
 
-error
+err
  : UNEXPECTED_CHAR
    {
      throw new RuntimeException("UNEXPECTED_CHAR=" + $UNEXPECTED_CHAR.text);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
1. rename "error" to "err" in .g4 file to avoid symbol conflict
2. make with clause optional in select query parse

