### PR TITLE
check for active replicas when waiting for commands

### DIFF
--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -3844,9 +3844,15 @@ void StorageReplicatedMergeTree::waitForAllReplicasToProcessLogEntry(const Repli
 {
     LOG_DEBUG(log, "Waiting for all replicas to process " << entry.znode_name);
 
-    Strings replicas = getZooKeeper()->getChildren(zookeeper_path + "/replicas");
+    auto zookeeper = getZooKeeper()
+    Strings replicas = zookeeper->getChildren(zookeeper_path + "/replicas");
     for (const String & replica : replicas)
-        waitForReplicaToProcessLogEntry(replica, entry);
+    {
+        if (zookeeper->exists(zookeeper_path + "/replicas/" + replica + "/is_active"))
+        {
+            waitForReplicaToProcessLogEntry(replica, entry);
+        }
+    }
 
     LOG_DEBUG(log, "Finished waiting for all replicas to process " << entry.znode_name);
 }

--- a/dbms/src/Storages/StorageReplicatedMergeTree.h
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.h
@@ -486,7 +486,7 @@ private:
       * Because it effectively waits for other thread that usually has to also acquire a lock to proceed and this yields deadlock.
       * TODO: There are wrong usages of this method that are not fixed yet.
       */
-    void waitForAllReplicasToProcessLogEntry(const ReplicatedMergeTreeLogEntryData & entry);
+    void waitForAllReplicasToProcessLogEntry(const ReplicatedMergeTreeLogEntryData & entry, bool wait_for_non_active = true);
 
     /** Wait until the specified replica executes the specified action from the log.
       * NOTE: See comment about locks above.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
`OPTIMIZE TABLE` query will not wait for offline replicas to perform the operation.

Detailed description:

This is more a question than a bugfix. Having a `Replicated*` table, when a "optimize" query is executed, the optimize commands are sent to the replicas and after that, leader waits for other replicas to finish the command.

The problem is when a replica is down for any reason, the command is still sent to the replica (which probably make sense) but after that the leader waits forever for the answer.

This patch (not tested, it's just to explain the issue) checks wether a replica is active or not and do not wait for the command to finish.

Does it makes sense?