### PR TITLE
dictGet with table name

### DIFF
--- a/dbms/src/Interpreters/ActionsVisitor.cpp
+++ b/dbms/src/Interpreters/ActionsVisitor.cpp
@@ -438,7 +438,7 @@ void ActionsMatcher::visit(const ASTFunction & node, const ASTPtr & ast, Data & 
             argument_types.push_back(column.type);
             argument_names.push_back(column.name);
         }
-        else if (identifier && node.name == "joinGet" && arg == 0)
+        else if (identifier && functionIsJoinGetOrDictGet(node.name) && arg == 0)
         {
             String database_name;
             String table_name;
@@ -450,7 +450,7 @@ void ActionsMatcher::visit(const ASTFunction & node, const ASTPtr & ast, Data & 
             ColumnWithTypeAndName column(
                 ColumnConst::create(std::move(column_string), 1),
                 std::make_shared<DataTypeString>(),
-                getUniqueName(data.getSampleBlock(), "__joinGet"));
+                getUniqueName(data.getSampleBlock(), "__joinGetOrDictGet"));
             data.addAction(ExpressionAction::addColumn(column));
             argument_types.push_back(column.type);
             argument_names.push_back(column.name);

--- a/dbms/src/Interpreters/MarkTableIdentifiersVisitor.cpp
+++ b/dbms/src/Interpreters/MarkTableIdentifiersVisitor.cpp
@@ -44,7 +44,7 @@ void MarkTableIdentifiersMatcher::visit(const ASTFunction & func, ASTPtr &, Data
     }
 
     // first argument of joinGet can be a table identifier
-    if (func.name == "joinGet")
+    if (functionIsJoinGetOrDictGet(func.name))
     {
         auto & ast = func.arguments->children.at(0);
         if (auto opt_name = tryGetIdentifierName(ast))

--- a/dbms/src/Interpreters/misc.h
+++ b/dbms/src/Interpreters/misc.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <Common/StringUtils/StringUtils.h>
+
 namespace DB
 {
 
@@ -11,6 +13,11 @@ inline bool functionIsInOperator(const std::string & name)
 inline bool functionIsInOrGlobalInOperator(const std::string & name)
 {
     return functionIsInOperator(name) || name == "globalIn" || name == "globalNotIn";
+}
+
+inline bool functionIsJoinGetOrDictGet(const std::string & name)
+{
+    return name == "joinGet" || startsWith(name, "dictGet");
 }
 
 }

--- a/dbms/tests/queries/0_stateless/01018_ddl_dictionaries_select.reference
+++ b/dbms/tests/queries/0_stateless/01018_ddl_dictionaries_select.reference
@@ -17,3 +17,7 @@ database_for_dict	dict1	ComplexKeyCache
 database_for_dict	dict2	Hashed
 6
 6
+6
+6
+6
+6

--- a/dbms/tests/queries/0_stateless/01018_ddl_dictionaries_select.sql
+++ b/dbms/tests/queries/0_stateless/01018_ddl_dictionaries_select.sql
@@ -105,6 +105,16 @@ LAYOUT(HASHED());
 
 SELECT dictGetString('database_for_dict.dict3', 'some_column', toUInt64(12));
 
+-- dictGet with table name
+USE database_for_dict;
+SELECT dictGetString(dict3, 'some_column', toUInt64(12));
+SELECT dictGetString(database_for_dict.dict3, 'some_column', toUInt64(12));
+SELECT dictGetString(default.dict3, 'some_column', toUInt64(12)); -- {serverError 36}
+SELECT dictGet(dict3, 'some_column', toUInt64(12));
+SELECT dictGet(database_for_dict.dict3, 'some_column', toUInt64(12));
+SELECT dictGet(default.dict3, 'some_column', toUInt64(12)); -- {serverError 36}
+USE default;
+
 DROP TABLE database_for_dict.table_for_dict;
 
 SYSTEM RELOAD DICTIONARIES; -- {serverError 60}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):

continuation of https://github.com/ClickHouse/ClickHouse/pull/7707

Now `dictGet*` functions accept table names.

