### PR TITLE
Prometheus endpoint fixes

### DIFF
--- a/dbms/programs/server/PrometheusMetricsWriter.h
+++ b/dbms/programs/server/PrometheusMetricsWriter.h
@@ -28,9 +28,9 @@ private:
     const bool send_metrics;
     const bool send_asynchronous_metrics;
 
-    static inline constexpr auto profile_events_prefix = "ClickHouseProfileEvents";
-    static inline constexpr auto current_metrics_prefix = "ClickHouseMetrics";
-    static inline constexpr auto asynchronous_metrics_prefix = "ClickHouseAsyncMetrics";
+    static inline constexpr auto profile_events_prefix = "ClickHouseProfileEvents_";
+    static inline constexpr auto current_metrics_prefix = "ClickHouseMetrics_";
+    static inline constexpr auto asynchronous_metrics_prefix = "ClickHouseAsyncMetrics_";
 };
 
 }

--- a/dbms/programs/server/config.xml
+++ b/dbms/programs/server/config.xml
@@ -318,7 +318,7 @@
     <!--
     <prometheus>
         <endpoint>/metrics</endpoint>
-        <port>8001</port>
+        <port>9363</port>
 
         <metrics>true</metrics>
         <events>true</events>

--- a/dbms/src/Interpreters/AsynchronousMetrics.cpp
+++ b/dbms/src/Interpreters/AsynchronousMetrics.cpp
@@ -72,9 +72,6 @@ void AsynchronousMetrics::run()
 
     while (true)
     {
-        if (wait_cond.wait_until(lock, get_next_minute(), [this] { return quit; }))
-            break;
-
         try
         {
             update();
@@ -83,6 +80,9 @@ void AsynchronousMetrics::run()
         {
             tryLogCurrentException(__PRETTY_FUNCTION__);
         }
+
+        if (wait_cond.wait_until(lock, get_next_minute(), [this] { return quit; }))
+            break;
     }
 }
 

--- a/dbms/tests/integration/test_prometheus_endpoint/test.py
+++ b/dbms/tests/integration/test_prometheus_endpoint/test.py
@@ -56,12 +56,12 @@ def get_and_check_metrics():
 def test_prometheus_endpoint(start_cluster):
 
     metrics_dict = get_and_check_metrics()
-    assert metrics_dict['ClickHouseProfileEventsQuery'] >= 0
-    prev_query_count = metrics_dict['ClickHouseProfileEventsQuery']
+    assert metrics_dict['ClickHouseProfileEvents_Query'] >= 0
+    prev_query_count = metrics_dict['ClickHouseProfileEvents_Query']
 
     resp = node.query("SELECT 1")
     resp = node.query("SELECT 2")
     resp = node.query("SELECT 3")
 
     metrics_dict = get_and_check_metrics()
-    assert metrics_dict['ClickHouseProfileEventsQuery'] >= prev_query_count + 3
+    assert metrics_dict['ClickHouseProfileEvents_Query'] >= prev_query_count + 3


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en


Changelog category (leave one):
- Non-significant (changelog entry is not needed)

Fixes for Prometheus endpoint:
- Replace dots with underscores in metric names.
- Async metrics updated at program startup. It is the reason why we  don't catch incorrect AsyncMetrics names with dots in test.
-  Change default port to `9363`. I have grab free port on Prometheus [wiki page](https://github.com/prometheus/prometheus/wiki/Default-port-allocations) as stated in [docs](https://prometheus.io/docs/instrumenting/writing_exporters/#port-numbers). (It don't require any approve from maintainers or additional permissions)

Also I have edit link on _Exporters and integrations_ a page (on [review](https://github.com/prometheus/docs/pull/1513))

Ref #7369

