### PR TITLE
Disabling segmentation engine for TSV, CSV and JSONEachRow

### DIFF
--- a/dbms/src/Core/Settings.h
+++ b/dbms/src/Core/Settings.h
@@ -111,7 +111,7 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingBool, distributed_group_by_no_merge, false, "Do not merge aggregation states from different servers for distributed query processing - in case it is for certain that there are different keys on different shards.", 0) \
     M(SettingBool, optimize_skip_unused_shards, false, "Assumes that data is distributed by sharding_key. Optimization to skip unused shards if SELECT query filters by sharding_key.", 0) \
     \
-    M(SettingBool, input_format_parallel_parsing, true, "Enable parallel parsing for some data formats.", 0) \
+    M(SettingBool, input_format_parallel_parsing, false, "Enable parallel parsing for some data formats.", 0) \
     M(SettingUInt64, min_chunk_bytes_for_parallel_parsing, (1024 * 1024), "The minimum chunk size in bytes, which each thread will parse in parallel.", 0) \
     \
     M(SettingUInt64, merge_tree_min_rows_for_concurrent_read, (20 * 8192), "If at least as many lines are read from one file, the reading can be parallelized.", 0) \

--- a/dbms/src/Formats/FormatFactory.cpp
+++ b/dbms/src/Formats/FormatFactory.cpp
@@ -295,10 +295,8 @@ FormatFactory::FormatFactory()
     registerOutputFormatProcessorTemplate(*this);
 
     registerFileSegmentationEngineTabSeparated(*this);
-    /**  FIXME (akazz) - To provide a workaround for #8233 these are temporarily disabled
-      *  registerFileSegmentationEngineCSV(*this);
-      *  registerFileSegmentationEngineJSONEachRow(*this);
-      */
+    registerFileSegmentationEngineCSV(*this);
+    registerFileSegmentationEngineJSONEachRow(*this);
 
     registerOutputFormatNull(*this);
 

--- a/dbms/src/Formats/FormatFactory.cpp
+++ b/dbms/src/Formats/FormatFactory.cpp
@@ -295,8 +295,10 @@ FormatFactory::FormatFactory()
     registerOutputFormatProcessorTemplate(*this);
 
     registerFileSegmentationEngineTabSeparated(*this);
-    registerFileSegmentationEngineCSV(*this);
-    registerFileSegmentationEngineJSONEachRow(*this);
+    /**  FIXME (akazz) - To provide a workaround these are temporarily disabled
+      *  registerFileSegmentationEngineCSV(*this);
+      *  registerFileSegmentationEngineJSONEachRow(*this);
+      */
 
     registerOutputFormatNull(*this);
 

--- a/dbms/src/Formats/FormatFactory.cpp
+++ b/dbms/src/Formats/FormatFactory.cpp
@@ -295,7 +295,7 @@ FormatFactory::FormatFactory()
     registerOutputFormatProcessorTemplate(*this);
 
     registerFileSegmentationEngineTabSeparated(*this);
-    /**  FIXME (akazz) - To provide a workaround these are temporarily disabled
+    /**  FIXME (akazz) - To provide a workaround for #8233 these are temporarily disabled
       *  registerFileSegmentationEngineCSV(*this);
       *  registerFileSegmentationEngineJSONEachRow(*this);
       */


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
To overcome problems with clickhouse-server process terminating upon recieving `SIGTERM` (#8233) temporarily disable segmentation engine for TSV family, CSV and JSONEachRow.