### PR TITLE
Fixed type check in toDateTime64

### DIFF
--- a/dbms/src/DataTypes/IDataType.h
+++ b/dbms/src/DataTypes/IDataType.h
@@ -534,6 +534,7 @@ struct WhichDataType
 
 inline bool isDate(const DataTypePtr & data_type) { return WhichDataType(data_type).isDate(); }
 inline bool isDateOrDateTime(const DataTypePtr & data_type) { return WhichDataType(data_type).isDateOrDateTime(); }
+inline bool isDateTime(const DataTypePtr & data_type) { return WhichDataType(data_type).isDateTime(); }
 inline bool isDateTime64(const DataTypePtr & data_type) { return WhichDataType(data_type).isDateTime64(); }
 inline bool isEnum(const DataTypePtr & data_type) { return WhichDataType(data_type).isEnum(); }
 inline bool isDecimal(const DataTypePtr & data_type) { return WhichDataType(data_type).isDecimal(); }

--- a/dbms/src/Functions/FunctionHelpers.cpp
+++ b/dbms/src/Functions/FunctionHelpers.cpp
@@ -177,7 +177,8 @@ void validateFunctionArgumentTypes(const IFunction & func,
                 {
                     if (a.argument_name)
                         result += "'" + std::string(a.argument_name) + "' : ";
-                    result += a.expected_type_description;
+                    if (a.expected_type_description)
+                        result += a.expected_type_description;
                 }
                 else if constexpr (std::is_same_v<A, ColumnWithTypeAndName>)
                     result += a.type->getName();

--- a/dbms/src/Functions/FunctionHelpers.cpp
+++ b/dbms/src/Functions/FunctionHelpers.cpp
@@ -194,7 +194,7 @@ void validateFunctionArgumentTypes(const IFunction & func,
 
         throw Exception("Incorrect number of arguments for function " + func.getName()
                         + " provided " + std::to_string(arguments.size())
-                        + (arguments.size() ? " (" + joinArgumentTypes(arguments) + ")" : String{} )
+                        + (arguments.size() ? " (" + joinArgumentTypes(arguments) + ")" : String{})
                         + ", expected " + std::to_string(mandatory_args.size())
                         + (optional_args.size() ? " to " + std::to_string(mandatory_args.size() + optional_args.size()) : "")
                         + " (" + joinArgumentTypes(mandatory_args)

--- a/dbms/src/Functions/FunctionHelpers.cpp
+++ b/dbms/src/Functions/FunctionHelpers.cpp
@@ -139,7 +139,7 @@ void validateArgumentsImpl(const IFunction & func,
         const auto validator = decriptors[i];
         if (!validator.isValid(arg.type, arg.column))
             throw Exception("Illegal type of argument #" + std::to_string(i)
-                            + (validator.argument_name ? " '" + std::string(validator.argument_name) + "'": std::string{})
+                            + (validator.argument_name ? " '" + std::string(validator.argument_name) + "'" : std::string{})
                             + " of function " + func.getName()
                             + ", expected " + validator.expected_type_description
                             + (arg.type ? ", got " + arg.type->getName() : std::string{}),

--- a/dbms/src/Functions/FunctionHelpers.h
+++ b/dbms/src/Functions/FunctionHelpers.h
@@ -91,13 +91,19 @@ void validateArgumentType(const IFunction & func, const DataTypes & arguments,
         const char * expected_type_description);
 
 // Simple validator that is used in conjunction with validateFunctionArgumentTypes() to check if function arguments are as expected.
-struct FunctionArgumentTypeValidator
+struct FunctionArgumentDescriptor
 {
-    bool (* validator_func)(const IDataType &);
+    const char * argument_name;
+
+    bool (* type_validator_func)(const IDataType &);
+    bool (* column_validator_func)(const IColumn &);
+
     const char * expected_type_description;
+
+    bool isValid(const DataTypePtr & data_type, const ColumnPtr & column) const;
 };
 
-using FunctionArgumentTypeValidators = std::vector<FunctionArgumentTypeValidator>;
+using FunctionArgumentDescriptors = std::vector<FunctionArgumentDescriptor>;
 
 /** Validate that function arguments match specification.
  *
@@ -117,7 +123,9 @@ using FunctionArgumentTypeValidators = std::vector<FunctionArgumentTypeValidator
  *
  * If any mandatory arg is missing, throw an exception, with explicit description of expected arguments.
  */
-void validateFunctionArgumentTypes(const IFunction & func, const ColumnsWithTypeAndName & arguments, const FunctionArgumentTypeValidators & mandatory_args, const FunctionArgumentTypeValidators & optional_args = {});
+void validateFunctionArgumentTypes(const IFunction & func, const ColumnsWithTypeAndName & arguments,
+                                   const FunctionArgumentDescriptors & mandatory_args,
+                                   const FunctionArgumentDescriptors & optional_args = {});
 
 /// Checks if a list of array columns have equal offsets. Return a pair of nested columns and offsets if true, otherwise throw.
 std::pair<std::vector<const IColumn *>, const ColumnArray::Offset *>

--- a/dbms/src/Functions/FunctionsConversion.h
+++ b/dbms/src/Functions/FunctionsConversion.h
@@ -898,7 +898,7 @@ public:
 
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
     {
-        FunctionArgumentDescriptors mandatory_args = {{"Value", nullptr, nullptr, "ANY TYPE"}};
+        FunctionArgumentDescriptors mandatory_args = {{"Value", nullptr, nullptr, nullptr}};
         FunctionArgumentDescriptors optional_args;
 
         if constexpr (to_decimal || to_datetime64)
@@ -907,8 +907,14 @@ public:
         }
         // toString(DateTime or DateTime64, [timezone: String])
         if ((std::is_same_v<Name, NameToString> && arguments.size() > 0 && (isDateTime64(arguments[0].type) || isDateTime(arguments[0].type)))
-            // toDateTime(value, [timezone: String]) or toDateTime64(value, scale : Integer, [timezone: string])
-            || std::is_same_v<ToDataType, DataTypeDateTime> || std::is_same_v<ToDataType, DataTypeDateTime64>)
+            // toUnixTimestamp(value[, timezone : String])
+            || std::is_same_v<Name, NameToUnixTimestamp>
+            // toDate(value[, timezone : String])
+            || std::is_same_v<ToDataType, DataTypeDate> // TODO: shall we allow timestamp argument for toDate? DateTime knows nothing about timezones and this arument is ignored below.
+            // toDateTime(value[, timezone: String])
+            || std::is_same_v<ToDataType, DataTypeDateTime>
+            // toDateTime64(value, scale : Integer[, timezone: String])
+            || std::is_same_v<ToDataType, DataTypeDateTime64>)
         {
             optional_args.push_back({"timezone", &isString, &isColumnConst, "const String"});
         }

--- a/dbms/tests/queries/0_stateless/00921_datetime64_basic.sql
+++ b/dbms/tests/queries/0_stateless/00921_datetime64_basic.sql
@@ -9,7 +9,7 @@ SELECT CAST(1 as DateTime64(3, 'qqq')); -- { serverError 1000 } # invalid timezo
 
 SELECT toDateTime64('2019-09-16 19:20:11.234', 'abc'); -- { serverError 43 } # invalid scale
 SELECT toDateTime64('2019-09-16 19:20:11.234', 100); -- { serverError 69 } # too big scale
-SELECT toDateTime64(CAST([['CLb5Ph ']], 'String'), uniqHLL12('2Gs1V', 752)); -- { serverError 43 } # non-const string and non-const scale
+SELECT toDateTime64(CAST([['CLb5Ph ']], 'String'), uniqHLL12('2Gs1V', 752)); -- { serverError 44 } # non-const string and non-const scale
 SELECT toDateTime64('2019-09-16 19:20:11.234', 3, 'qqq'); -- { serverError 1000 } # invalid timezone
 
 SELECT ignore(now64(gccMurmurHash())); -- { serverError 43 } # Illegal argument type

--- a/dbms/tests/queries/0_stateless/00921_datetime64_basic.sql
+++ b/dbms/tests/queries/0_stateless/00921_datetime64_basic.sql
@@ -9,6 +9,7 @@ SELECT CAST(1 as DateTime64(3, 'qqq')); -- { serverError 1000 } # invalid timezo
 
 SELECT toDateTime64('2019-09-16 19:20:11.234', 'abc'); -- { serverError 43 } # invalid scale
 SELECT toDateTime64('2019-09-16 19:20:11.234', 100); -- { serverError 69 } # too big scale
+SELECT toDateTime64(CAST([['CLb5Ph ']], 'String'), uniqHLL12('2Gs1V', 752)); -- { serverError 43 } # non-const string and non-const scale
 SELECT toDateTime64('2019-09-16 19:20:11.234', 3, 'qqq'); -- { serverError 1000 } # invalid timezone
 
 SELECT ignore(now64(gccMurmurHash())); -- { serverError 43 } # Illegal argument type


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
- Better type check for `toDateTime64`
...
