### PR TITLE
Relax ambiguous column check for multiple JOIN ON section

### DIFF
--- a/dbms/src/Interpreters/AnalyzedJoin.cpp
+++ b/dbms/src/Interpreters/AnalyzedJoin.cpp
@@ -98,14 +98,6 @@ NameSet AnalyzedJoin::getQualifiedColumnsSet() const
     return out;
 }
 
-NameSet AnalyzedJoin::getOriginalColumnsSet() const
-{
-    NameSet out;
-    for (const auto & names : original_names)
-        out.insert(names.second);
-    return out;
-}
-
 NamesWithAliases AnalyzedJoin::getNamesWithAliases(const NameSet & required_columns) const
 {
     NamesWithAliases out;

--- a/dbms/src/Interpreters/AnalyzedJoin.h
+++ b/dbms/src/Interpreters/AnalyzedJoin.h
@@ -96,7 +96,6 @@ public:
     bool hasOn() const { return table_join.on_expression != nullptr; }
 
     NameSet getQualifiedColumnsSet() const;
-    NameSet getOriginalColumnsSet() const;
     NamesWithAliases getNamesWithAliases(const NameSet & required_columns) const;
     NamesWithAliases getRequiredColumns(const Block & sample, const Names & action_columns) const;
 

--- a/dbms/src/Interpreters/CollectJoinOnKeysVisitor.h
+++ b/dbms/src/Interpreters/CollectJoinOnKeysVisitor.h
@@ -3,6 +3,7 @@
 #include <Core/Names.h>
 #include <Parsers/ASTFunction.h>
 #include <Interpreters/InDepthNodeVisitor.h>
+#include <Interpreters/DatabaseAndTableWithAlias.h>
 #include <Interpreters/Aliases.h>
 
 
@@ -25,8 +26,8 @@ public:
     struct Data
     {
         AnalyzedJoin & analyzed_join;
-        const NameSet & source_columns;
-        const NameSet & joined_columns;
+        const TableWithColumnNames & left_table;
+        const TableWithColumnNames & right_table;
         const Aliases & aliases;
         const bool is_asof{false};
         ASTPtr asof_left_key{};

--- a/dbms/src/Interpreters/DatabaseAndTableWithAlias.h
+++ b/dbms/src/Interpreters/DatabaseAndTableWithAlias.h
@@ -53,6 +53,20 @@ struct TableWithColumnNames
         for (auto & column : addition)
             hidden_columns.push_back(column.name);
     }
+
+    bool hasColumn(const String & name) const
+    {
+        if (columns_set.empty())
+        {
+            columns_set.insert(columns.begin(), columns.end());
+            columns_set.insert(hidden_columns.begin(), hidden_columns.end());
+        }
+
+        return columns_set.count(name);
+    }
+
+private:
+    mutable NameSet columns_set;
 };
 
 std::vector<DatabaseAndTableWithAlias> getDatabaseAndTables(const ASTSelectQuery & select_query, const String & current_database);

--- a/dbms/src/Interpreters/IdentifierSemantic.cpp
+++ b/dbms/src/Interpreters/IdentifierSemantic.cpp
@@ -92,6 +92,22 @@ std::optional<String> IdentifierSemantic::getTableName(const ASTPtr & ast)
     return {};
 }
 
+std::optional<ASTIdentifier> IdentifierSemantic::uncover(const ASTIdentifier & identifier)
+{
+    if (identifier.semantic->covered)
+    {
+        std::vector<String> name_parts = identifier.name_parts;
+        return ASTIdentifier(std::move(name_parts));
+    }
+    return {};
+}
+
+void IdentifierSemantic::coverName(ASTIdentifier & identifier, const String & alias)
+{
+    identifier.setShortName(alias);
+    identifier.semantic->covered = true;
+}
+
 bool IdentifierSemantic::canBeAlias(const ASTIdentifier & identifier)
 {
     return identifier.semantic->can_be_alias;

--- a/dbms/src/Interpreters/IdentifierSemantic.h
+++ b/dbms/src/Interpreters/IdentifierSemantic.h
@@ -12,6 +12,7 @@ struct IdentifierSemanticImpl
 {
     bool special = false;       /// for now it's 'not a column': tables, subselects and some special stuff like FORMAT
     bool can_be_alias = true;   /// if it's a cropped name it could not be an alias
+    bool covered = false;       /// real (compound) name is hidden by an alias (short name)
     std::optional<size_t> membership; /// table position in join
 };
 
@@ -43,6 +44,8 @@ struct IdentifierSemantic
     static void setColumnLongName(ASTIdentifier & identifier, const DatabaseAndTableWithAlias & db_and_table);
     static bool canBeAlias(const ASTIdentifier & identifier);
     static void setMembership(ASTIdentifier &, size_t table_no);
+    static void coverName(ASTIdentifier &, const String & alias);
+    static std::optional<ASTIdentifier> uncover(const ASTIdentifier & identifier);
     static std::optional<size_t> getMembership(const ASTIdentifier & identifier);
     static bool chooseTable(const ASTIdentifier &, const std::vector<DatabaseAndTableWithAlias> & tables, size_t & best_table_pos,
                             bool ambiguous = false);

--- a/dbms/src/Interpreters/JoinToSubqueryTransformVisitor.cpp
+++ b/dbms/src/Interpreters/JoinToSubqueryTransformVisitor.cpp
@@ -159,7 +159,7 @@ struct ColumnAliasesMatcher
                         aliases[alias] = long_name;
                         rev_aliases[long_name].push_back(alias);
 
-                        identifier->setShortName(alias);
+                        IdentifierSemantic::coverName(*identifier, alias);
                         if (is_public)
                         {
                             identifier->setAlias(long_name);
@@ -177,7 +177,7 @@ struct ColumnAliasesMatcher
                     if (is_public && allowed_long_names.count(long_name))
                         ; /// leave original name unchanged for correct output
                     else
-                        identifier->setShortName(it->second[0]);
+                        IdentifierSemantic::coverName(*identifier, it->second[0]);
                 }
             }
         }
@@ -229,7 +229,7 @@ struct ColumnAliasesMatcher
 
             if (!last_table)
             {
-                node.setShortName(alias);
+                IdentifierSemantic::coverName(node, alias);
                 node.setAlias("");
             }
         }

--- a/dbms/tests/queries/0_stateless/01051_same_name_alias_with_joins.sql
+++ b/dbms/tests/queries/0_stateless/01051_same_name_alias_with_joins.sql
@@ -1,0 +1,29 @@
+DROP TABLE IF EXISTS a;
+DROP TABLE IF EXISTS b;
+DROP TABLE IF EXISTS c;
+
+CREATE TABLE a (x UInt64) ENGINE = Memory;
+CREATE TABLE b (x UInt64) ENGINE = Memory;
+CREATE TABLE c (x UInt64) ENGINE = Memory;
+
+SET enable_optimize_predicate_expression = 0;
+
+SELECT a.x AS x FROM a
+LEFT JOIN b ON a.x = b.x
+LEFT JOIN c ON a.x = c.x;
+
+SELECT a.x AS x FROM a
+LEFT JOIN b ON a.x = b.x
+LEFT JOIN c ON b.x = c.x;
+
+SELECT b.x AS x FROM a
+LEFT JOIN b ON a.x = b.x
+LEFT JOIN c ON b.x = c.x;
+
+SELECT c.x AS x FROM a
+LEFT JOIN b ON a.x = b.x
+LEFT JOIN c ON b.x = c.x;
+
+DROP TABLE a;
+DROP TABLE b;
+DROP TABLE c;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Relax ambiguous column check that leads to false positives in multiple JOIN ON section.

