### PR TITLE
Show physical addresses in stack traces

### DIFF
--- a/dbms/src/Common/Dwarf.h
+++ b/dbms/src/Common/Dwarf.h
@@ -127,8 +127,8 @@ public:
         uint64_t line = 0;
     };
 
-    /**
-      * Find the file and line number information corresponding to address.
+    /** Find the file and line number information corresponding to address.
+      * The address must be physical - offset in object file without offset in virtual memory where the object is loaded.
       */
     bool findAddress(uintptr_t address, LocationInfo & info, LocationInfoMode mode) const;
 

--- a/dbms/src/Common/StackTrace.cpp
+++ b/dbms/src/Common/StackTrace.cpp
@@ -258,10 +258,14 @@ static void toStringEveryLineImpl(const StackTrace::Frames & frames, size_t offs
 
     for (size_t i = offset; i < size; ++i)
     {
-        const void * addr = frames[i];
+        const void * virtual_addr = frames[i];
+        auto object = symbol_index.findObject(virtual_addr);
+        uintptr_t virtual_offset = object ? uintptr_t(object->address_begin) : 0;
+        const void * physical_addr = reinterpret_cast<const void *>(uintptr_t(virtual_addr) - virtual_offset);
 
-        out << i << ". " << addr << " ";
-        auto symbol = symbol_index.findSymbol(addr);
+        out << i << ". " << physical_addr << " ";
+
+        auto symbol = symbol_index.findSymbol(virtual_addr);
         if (symbol)
         {
             int status = 0;
@@ -272,18 +276,17 @@ static void toStringEveryLineImpl(const StackTrace::Frames & frames, size_t offs
 
         out << " ";
 
-        if (auto object = symbol_index.findObject(addr))
+        if (object)
         {
             if (std::filesystem::exists(object->name))
             {
                 auto dwarf_it = dwarfs.try_emplace(object->name, *object->elf).first;
 
                 DB::Dwarf::LocationInfo location;
-                if (dwarf_it->second.findAddress(uintptr_t(addr) - uintptr_t(object->address_begin), location, DB::Dwarf::LocationInfoMode::FAST))
+                if (dwarf_it->second.findAddress(uintptr_t(physical_addr), location, DB::Dwarf::LocationInfoMode::FAST))
                     out << location.file.toString() << ":" << location.line;
-                else
-                    out << object->name;
             }
+            out << " in " << object->name;
         }
         else
             out << "?";

--- a/dbms/src/Common/SymbolIndex.h
+++ b/dbms/src/Common/SymbolIndex.h
@@ -38,6 +38,7 @@ public:
         std::unique_ptr<Elf> elf;
     };
 
+    /// Address in virtual memory should be passed. These addresses include offset where the object is loaded in memory.
     const Symbol * findSymbol(const void * address) const;
     const Object * findObject(const void * address) const;
 

--- a/dbms/src/Common/tests/symbol_index.cpp
+++ b/dbms/src/Common/tests/symbol_index.cpp
@@ -49,7 +49,7 @@ int main(int argc, char ** argv)
     Dwarf dwarf(*object->elf);
 
     Dwarf::LocationInfo location;
-    if (dwarf.findAddress(uintptr_t(address), location, Dwarf::LocationInfoMode::FAST))
+    if (dwarf.findAddress(uintptr_t(address) - uintptr_t(info.dli_fbase), location, Dwarf::LocationInfoMode::FAST))
         std::cerr << location.file.toString() << ":" << location.line << "\n";
     else
         std::cerr << "Dwarf: Not found\n";


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Stack traces now display physical addresses (offsets in object file) instead of virtual memory addresses (where the object file was loaded). That allows the use of `addr2line` when binary is position independent and ASLR is active. This fixes #8360


Detailed description (optional):
As a next step we can save physical addresses and object file paths in `system.trace_log`.