### PR TITLE
Remove context from formats

### DIFF
--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -186,8 +186,8 @@ endif()
 list (APPEND clickhouse_common_io_sources ${CONFIG_BUILD})
 list (APPEND clickhouse_common_io_headers ${CONFIG_VERSION} ${CONFIG_COMMON})
 
-list (APPEND dbms_sources src/Functions/IFunction.cpp src/Functions/FunctionFactory.cpp src/Functions/FunctionHelpers.cpp)
-list (APPEND dbms_headers src/Functions/IFunctionImpl.h src/Functions/FunctionFactory.h src/Functions/FunctionHelpers.h)
+list (APPEND dbms_sources src/Functions/IFunction.cpp src/Functions/FunctionFactory.cpp src/Functions/FunctionHelpers.cpp src/Functions/extractTimeZoneFromFunctionArguments.cpp)
+list (APPEND dbms_headers src/Functions/IFunctionImpl.h src/Functions/FunctionFactory.h src/Functions/FunctionHelpers.h src/Functions/extractTimeZoneFromFunctionArguments.h)
 
 list (APPEND dbms_sources
     src/AggregateFunctions/AggregateFunctionFactory.cpp

--- a/dbms/src/DataStreams/ParallelParsingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/ParallelParsingBlockInputStream.cpp
@@ -65,7 +65,7 @@ void ParallelParsingBlockInputStream::parserThreadFunction(size_t current_unit_n
          */
         ReadBuffer read_buffer(unit.segment.data(), unit.segment.size(), 0);
         auto parser = std::make_unique<InputStreamFromInputFormat>(
-            input_processor_creator(read_buffer, header, context,
+                input_processor_creator(read_buffer, header,
                 row_input_format_params, format_settings));
 
         unit.block_ext.block.clear();

--- a/dbms/src/DataStreams/ParallelParsingBlockInputStream.h
+++ b/dbms/src/DataStreams/ParallelParsingBlockInputStream.h
@@ -55,23 +55,21 @@ private:
     using InputProcessorCreator = std::function<InputFormatPtr(
             ReadBuffer & buf,
             const Block & header,
-            const Context & context,
             const RowInputFormatParams & params,
             const FormatSettings & settings)>;
 public:
     struct InputCreatorParams
     {
-        const Block &sample;
-        const Context &context;
-        const RowInputFormatParams& row_input_format_params;
+        const Block & sample;
+        const RowInputFormatParams & row_input_format_params;
         const FormatSettings &settings;
     };
 
     struct Params
     {
         ReadBuffer & read_buffer;
-        const InputProcessorCreator &input_processor_creator;
-        const InputCreatorParams &input_creator_params;
+        const InputProcessorCreator & input_processor_creator;
+        const InputCreatorParams & input_creator_params;
         FormatFactory::FileSegmentationEngine file_segmentation_engine;
         int max_threads;
         size_t min_chunk_bytes;
@@ -79,7 +77,6 @@ public:
 
     explicit ParallelParsingBlockInputStream(const Params & params)
             : header(params.input_creator_params.sample),
-              context(params.input_creator_params.context),
               row_input_format_params(params.input_creator_params.row_input_format_params),
               format_settings(params.input_creator_params.settings),
               input_processor_creator(params.input_processor_creator),
@@ -149,7 +146,6 @@ protected:
 
 private:
     const Block header;
-    const Context context;
     const RowInputFormatParams row_input_format_params;
     const FormatSettings format_settings;
     const InputProcessorCreator input_processor_creator;

--- a/dbms/src/Formats/FormatFactory.cpp
+++ b/dbms/src/Formats/FormatFactory.cpp
@@ -67,7 +67,6 @@ static FormatSettings getInputFormatSetting(const Settings & settings, const Con
     format_settings.custom.field_delimiter = settings.format_custom_field_delimiter;
     format_settings.custom.row_before_delimiter = settings.format_custom_row_before_delimiter;
     format_settings.custom.row_after_delimiter = settings.format_custom_row_after_delimiter;
-    format_settings.template_settings.row_between_delimiter = settings.format_custom_row_between_delimiter;
 
     return format_settings;
 }
@@ -98,7 +97,6 @@ static FormatSettings getOutputFormatSetting(const Settings & settings, const Co
     format_settings.custom.field_delimiter = settings.format_custom_field_delimiter;
     format_settings.custom.row_before_delimiter = settings.format_custom_row_before_delimiter;
     format_settings.custom.row_after_delimiter = settings.format_custom_row_after_delimiter;
-    format_settings.template_settings.row_between_delimiter = settings.format_custom_row_between_delimiter;
 
     return format_settings;
 }

--- a/dbms/src/Formats/FormatFactory.cpp
+++ b/dbms/src/Formats/FormatFactory.cpp
@@ -67,6 +67,7 @@ static FormatSettings getInputFormatSetting(const Settings & settings, const Con
     format_settings.custom.field_delimiter = settings.format_custom_field_delimiter;
     format_settings.custom.row_before_delimiter = settings.format_custom_row_before_delimiter;
     format_settings.custom.row_after_delimiter = settings.format_custom_row_after_delimiter;
+    format_settings.custom.row_between_delimiter = settings.format_custom_row_between_delimiter;
 
     return format_settings;
 }
@@ -97,6 +98,7 @@ static FormatSettings getOutputFormatSetting(const Settings & settings, const Co
     format_settings.custom.field_delimiter = settings.format_custom_field_delimiter;
     format_settings.custom.row_before_delimiter = settings.format_custom_row_before_delimiter;
     format_settings.custom.row_after_delimiter = settings.format_custom_row_after_delimiter;
+    format_settings.custom.row_between_delimiter = settings.format_custom_row_between_delimiter;
 
     return format_settings;
 }

--- a/dbms/src/Formats/FormatFactory.cpp
+++ b/dbms/src/Formats/FormatFactory.cpp
@@ -12,6 +12,8 @@
 #include <Processors/Formats/OutputStreamToOutputFormat.h>
 #include <DataStreams/SquashingBlockOutputStream.h>
 #include <DataStreams/NativeBlockInputStream.h>
+#include <Processors/Formats/Impl/ValuesBlockInputFormat.h>
+#include <Processors/Formats/Impl/MySQLOutputFormat.h>
 
 
 namespace DB
@@ -34,7 +36,7 @@ const FormatFactory::Creators & FormatFactory::getCreators(const String & name) 
 }
 
 
-static FormatSettings getInputFormatSetting(const Settings & settings)
+static FormatSettings getInputFormatSetting(const Settings & settings, const Context & context)
 {
     FormatSettings format_settings;
     format_settings.csv.delimiter = settings.format_csv_delimiter;
@@ -56,11 +58,21 @@ static FormatSettings getInputFormatSetting(const Settings & settings)
     format_settings.template_settings.row_format = settings.format_template_row;
     format_settings.template_settings.row_between_delimiter = settings.format_template_rows_between_delimiter;
     format_settings.tsv.empty_as_default = settings.input_format_tsv_empty_as_default;
+    format_settings.schema.format_schema = settings.format_schema;
+    format_settings.schema.format_schema_path = context.getFormatSchemaPath();
+    format_settings.schema.is_server = context.hasGlobalContext() && (context.getGlobalContext().getApplicationType() == Context::ApplicationType::SERVER);
+    format_settings.custom.result_before_delimiter = settings.format_custom_result_before_delimiter;
+    format_settings.custom.result_after_delimiter = settings.format_custom_result_after_delimiter;
+    format_settings.custom.escaping_rule = settings.format_custom_escaping_rule;
+    format_settings.custom.field_delimiter = settings.format_custom_field_delimiter;
+    format_settings.custom.row_before_delimiter = settings.format_custom_row_before_delimiter;
+    format_settings.custom.row_after_delimiter = settings.format_custom_row_after_delimiter;
+    format_settings.template_settings.row_between_delimiter = settings.format_custom_row_between_delimiter;
 
     return format_settings;
 }
 
-static FormatSettings getOutputFormatSetting(const Settings & settings)
+static FormatSettings getOutputFormatSetting(const Settings & settings, const Context & context)
 {
     FormatSettings format_settings;
     format_settings.json.quote_64bit_integers = settings.output_format_json_quote_64bit_integers;
@@ -77,6 +89,16 @@ static FormatSettings getOutputFormatSetting(const Settings & settings)
     format_settings.template_settings.row_between_delimiter = settings.format_template_rows_between_delimiter;
     format_settings.write_statistics = settings.output_format_write_statistics;
     format_settings.parquet.row_group_size = settings.output_format_parquet_row_group_size;
+    format_settings.schema.format_schema = settings.format_schema;
+    format_settings.schema.format_schema_path = context.getFormatSchemaPath();
+    format_settings.schema.is_server = context.hasGlobalContext() && (context.getGlobalContext().getApplicationType() == Context::ApplicationType::SERVER);
+    format_settings.custom.result_before_delimiter = settings.format_custom_result_before_delimiter;
+    format_settings.custom.result_after_delimiter = settings.format_custom_result_after_delimiter;
+    format_settings.custom.escaping_rule = settings.format_custom_escaping_rule;
+    format_settings.custom.field_delimiter = settings.format_custom_field_delimiter;
+    format_settings.custom.row_before_delimiter = settings.format_custom_row_before_delimiter;
+    format_settings.custom.row_after_delimiter = settings.format_custom_row_after_delimiter;
+    format_settings.template_settings.row_between_delimiter = settings.format_custom_row_between_delimiter;
 
     return format_settings;
 }
@@ -100,9 +122,9 @@ BlockInputStreamPtr FormatFactory::getInput(
             throw Exception("Format " + name + " is not suitable for input", ErrorCodes::FORMAT_IS_NOT_SUITABLE_FOR_INPUT);
 
         const Settings & settings = context.getSettingsRef();
-        FormatSettings format_settings = getInputFormatSetting(settings);
+        FormatSettings format_settings = getInputFormatSetting(settings, context);
 
-        return input_getter(buf, sample, context, max_block_size, callback ? callback : ReadCallback(), format_settings);
+        return input_getter(buf, sample, max_block_size, callback ? callback : ReadCallback(), format_settings);
     }
 
     const Settings & settings = context.getSettingsRef();
@@ -118,7 +140,7 @@ BlockInputStreamPtr FormatFactory::getInput(
         if (!input_getter)
             throw Exception("Format " + name + " is not suitable for input", ErrorCodes::FORMAT_IS_NOT_SUITABLE_FOR_INPUT);
 
-        FormatSettings format_settings = getInputFormatSetting(settings);
+        FormatSettings format_settings = getInputFormatSetting(settings, context);
 
         RowInputFormatParams row_input_format_params;
         row_input_format_params.max_block_size = max_block_size;
@@ -128,7 +150,7 @@ BlockInputStreamPtr FormatFactory::getInput(
         row_input_format_params.max_execution_time = settings.max_execution_time;
         row_input_format_params.timeout_overflow_mode = settings.timeout_overflow_mode;
 
-        auto input_creator_params = ParallelParsingBlockInputStream::InputCreatorParams{sample, context, row_input_format_params, format_settings};
+        auto input_creator_params = ParallelParsingBlockInputStream::InputCreatorParams{sample, row_input_format_params, format_settings};
         ParallelParsingBlockInputStream::Params params{buf, input_getter,
             input_creator_params, file_segmentation_engine,
             static_cast<int>(settings.max_threads),
@@ -164,16 +186,16 @@ BlockOutputStreamPtr FormatFactory::getOutput(
             throw Exception("Format " + name + " is not suitable for output", ErrorCodes::FORMAT_IS_NOT_SUITABLE_FOR_OUTPUT);
 
         const Settings & settings = context.getSettingsRef();
-        FormatSettings format_settings = getOutputFormatSetting(settings);
+        FormatSettings format_settings = getOutputFormatSetting(settings, context);
 
         /**  Materialization is needed, because formats can use the functions `IDataType`,
           *  which only work with full columns.
           */
         return std::make_shared<MaterializingBlockOutputStream>(
-                output_getter(buf, sample, context, callback, format_settings), sample);
+                output_getter(buf, sample, std::move(callback), format_settings), sample);
     }
 
-    auto format = getOutputFormat(name, buf, sample, context, callback);
+    auto format = getOutputFormat(name, buf, sample, context, std::move(callback));
     return std::make_shared<MaterializingBlockOutputStream>(std::make_shared<OutputStreamToOutputFormat>(format), sample);
 }
 
@@ -191,7 +213,7 @@ InputFormatPtr FormatFactory::getInputFormat(
         throw Exception("Format " + name + " is not suitable for input", ErrorCodes::FORMAT_IS_NOT_SUITABLE_FOR_INPUT);
 
     const Settings & settings = context.getSettingsRef();
-    FormatSettings format_settings = getInputFormatSetting(settings);
+    FormatSettings format_settings = getInputFormatSetting(settings, context);
 
     RowInputFormatParams params;
     params.max_block_size = max_block_size;
@@ -201,7 +223,13 @@ InputFormatPtr FormatFactory::getInputFormat(
     params.max_execution_time = settings.max_execution_time;
     params.timeout_overflow_mode = settings.timeout_overflow_mode;
 
-    return input_getter(buf, sample, context, params, format_settings);
+    auto format = input_getter(buf, sample, params, format_settings);
+
+    /// It's a kludge. Because I cannot remove context from values format.
+    if (auto * values = typeid_cast<ValuesBlockInputFormat *>(format.get()))
+        values->setContext(context);
+
+    return format;
 }
 
 
@@ -213,12 +241,18 @@ OutputFormatPtr FormatFactory::getOutputFormat(
         throw Exception("Format " + name + " is not suitable for output", ErrorCodes::FORMAT_IS_NOT_SUITABLE_FOR_OUTPUT);
 
     const Settings & settings = context.getSettingsRef();
-    FormatSettings format_settings = getOutputFormatSetting(settings);
+    FormatSettings format_settings = getOutputFormatSetting(settings, context);
 
     /** TODO: Materialization is needed, because formats can use the functions `IDataType`,
       *  which only work with full columns.
       */
-    return output_getter(buf, sample, context, callback, format_settings);
+    auto format = output_getter(buf, sample, std::move(callback), format_settings);
+
+    /// It's a kludge. Because I cannot remove context from MySQL format.
+    if (auto * mysql = typeid_cast<MySQLOutputFormat *>(format.get()))
+        mysql->setContext(context);
+
+    return format;
 }
 
 
@@ -259,7 +293,7 @@ void FormatFactory::registerFileSegmentationEngine(const String & name, FileSegm
     auto & target = dict[name].file_segmentation_engine;
     if (target)
         throw Exception("FormatFactory: File segmentation engine " + name + " is already registered", ErrorCodes::LOGICAL_ERROR);
-    target = file_segmentation_engine;
+    target = std::move(file_segmentation_engine);
 }
 
 FormatFactory::FormatFactory()

--- a/dbms/src/Formats/FormatFactory.h
+++ b/dbms/src/Formats/FormatFactory.h
@@ -59,7 +59,6 @@ private:
     using InputCreator = std::function<BlockInputStreamPtr(
         ReadBuffer & buf,
         const Block & sample,
-        const Context & context,
         UInt64 max_block_size,
         ReadCallback callback,
         const FormatSettings & settings)>;
@@ -67,21 +66,18 @@ private:
     using OutputCreator = std::function<BlockOutputStreamPtr(
         WriteBuffer & buf,
         const Block & sample,
-        const Context & context,
         WriteCallback callback,
         const FormatSettings & settings)>;
 
     using InputProcessorCreator = std::function<InputFormatPtr(
             ReadBuffer & buf,
             const Block & header,
-            const Context & context,
             const RowInputFormatParams & params,
             const FormatSettings & settings)>;
 
     using OutputProcessorCreator = std::function<OutputFormatPtr(
             WriteBuffer & buf,
             const Block & sample,
-            const Context & context,
             WriteCallback callback,
             const FormatSettings & settings)>;
 

--- a/dbms/src/Formats/FormatSchemaInfo.cpp
+++ b/dbms/src/Formats/FormatSchemaInfo.cpp
@@ -59,10 +59,6 @@ FormatSchemaInfo::FormatSchemaInfo(const String & format_schema, const String & 
         static const String str = Poco::Path(format_schema_path).makeAbsolute().makeDirectory().toString();
         return str;
     };
-//    auto is_server = [&context]()
-//    {
-//        return context.hasGlobalContext() && (context.getGlobalContext().getApplicationType() == Context::ApplicationType::SERVER);
-//    };
 
     if (path.getExtension().empty() && !default_file_extension.empty())
         path.setExtension(default_file_extension);

--- a/dbms/src/Formats/FormatSchemaInfo.cpp
+++ b/dbms/src/Formats/FormatSchemaInfo.cpp
@@ -26,7 +26,7 @@ namespace
 }
 
 
-FormatSchemaInfo::FormatSchemaInfo(const Context & context, const String & format_schema, const String & format, bool require_message)
+FormatSchemaInfo::FormatSchemaInfo(const String & format_schema, const String & format, bool require_message, bool is_server, const std::string & format_schema_path)
 {
     if (format_schema.empty())
         throw Exception(
@@ -54,29 +54,29 @@ FormatSchemaInfo::FormatSchemaInfo(const Context & context, const String & forma
     else
         path.assign(format_schema).makeFile().getFileName();
 
-    auto default_schema_directory = [&context]()
+    auto default_schema_directory = [&format_schema_path]()
     {
-        static const String str = Poco::Path(context.getFormatSchemaPath()).makeAbsolute().makeDirectory().toString();
+        static const String str = Poco::Path(format_schema_path).makeAbsolute().makeDirectory().toString();
         return str;
     };
-    auto is_server = [&context]()
-    {
-        return context.hasGlobalContext() && (context.getGlobalContext().getApplicationType() == Context::ApplicationType::SERVER);
-    };
+//    auto is_server = [&context]()
+//    {
+//        return context.hasGlobalContext() && (context.getGlobalContext().getApplicationType() == Context::ApplicationType::SERVER);
+//    };
 
     if (path.getExtension().empty() && !default_file_extension.empty())
         path.setExtension(default_file_extension);
 
     if (path.isAbsolute())
     {
-        if (is_server())
+        if (is_server)
             throw Exception("Absolute path in the 'format_schema' setting is prohibited: " + path.toString(), ErrorCodes::BAD_ARGUMENTS);
         schema_path = path.getFileName();
         schema_directory = path.makeParent().toString();
     }
     else if (path.depth() >= 1 && path.directory(0) == "..")
     {
-        if (is_server())
+        if (is_server)
             throw Exception(
                 "Path in the 'format_schema' setting shouldn't go outside the 'format_schema_path' directory: " + path.toString(),
                 ErrorCodes::BAD_ARGUMENTS);

--- a/dbms/src/Formats/FormatSchemaInfo.h
+++ b/dbms/src/Formats/FormatSchemaInfo.h
@@ -10,7 +10,7 @@ class Context;
 class FormatSchemaInfo
 {
 public:
-    FormatSchemaInfo(const Context & context, const String & format_schema, const String & format, bool require_message);
+    FormatSchemaInfo(const String & format_schema, const String & format, bool require_message, bool is_server, const std::string & format_schema_path);
 
     /// Returns path to the schema file.
     const String & schemaPath() const { return schema_path; }

--- a/dbms/src/Formats/FormatSettings.h
+++ b/dbms/src/Formats/FormatSettings.h
@@ -104,6 +104,7 @@ struct FormatSettings
         std::string result_after_delimiter;
         std::string row_before_delimiter;
         std::string row_after_delimiter;
+        std::string row_between_delimiter;
         std::string field_delimiter;
         std::string escaping_rule;
     };

--- a/dbms/src/Formats/FormatSettings.h
+++ b/dbms/src/Formats/FormatSettings.h
@@ -89,6 +89,26 @@ struct FormatSettings
         UInt64 row_group_size = 1000000;
     } parquet;
 
+    struct Schema
+    {
+        std::string format_schema;
+        std::string format_schema_path;
+        bool is_server = false;
+    };
+
+    Schema schema;
+
+    struct Custom
+    {
+        std::string result_before_delimiter;
+        std::string result_after_delimiter;
+        std::string row_before_delimiter;
+        std::string row_after_delimiter;
+        std::string field_delimiter;
+        std::string escaping_rule;
+    };
+
+    Custom custom;
 };
 
 }

--- a/dbms/src/Formats/NativeFormat.cpp
+++ b/dbms/src/Formats/NativeFormat.cpp
@@ -11,7 +11,6 @@ void registerInputFormatNative(FormatFactory & factory)
     factory.registerInputFormat("Native", [](
         ReadBuffer & buf,
         const Block & sample,
-        const Context &,
         UInt64 /* max_block_size */,
         FormatFactory::ReadCallback /* callback */,
         const FormatSettings &)
@@ -25,7 +24,6 @@ void registerOutputFormatNative(FormatFactory & factory)
     factory.registerOutputFormat("Native", [](
         WriteBuffer & buf,
         const Block & sample,
-        const Context &,
         FormatFactory::WriteCallback,
         const FormatSettings &)
     {

--- a/dbms/src/Formats/NullFormat.cpp
+++ b/dbms/src/Formats/NullFormat.cpp
@@ -10,7 +10,6 @@ void registerOutputFormatNull(FormatFactory & factory)
     factory.registerOutputFormat("Null", [](
         WriteBuffer &,
         const Block & sample,
-        const Context &,
         FormatFactory::WriteCallback,
         const FormatSettings &)
     {

--- a/dbms/src/Formats/ParsedTemplateFormatString.cpp
+++ b/dbms/src/Formats/ParsedTemplateFormatString.cpp
@@ -234,36 +234,32 @@ void ParsedTemplateFormatString::throwInvalidFormat(const String & message, size
                     ErrorCodes::INVALID_TEMPLATE_FORMAT);
 }
 
-ParsedTemplateFormatString ParsedTemplateFormatString::setupCustomSeparatedResultsetFormat(const Context & context)
+ParsedTemplateFormatString ParsedTemplateFormatString::setupCustomSeparatedResultsetFormat(const FormatSettings::Custom & settings)
 {
-    const Settings & settings = context.getSettingsRef();
-
     /// Set resultset format to "result_before_delimiter ${data} result_after_delimiter"
     ParsedTemplateFormatString resultset_format;
-    resultset_format.delimiters.emplace_back(settings.format_custom_result_before_delimiter);
-    resultset_format.delimiters.emplace_back(settings.format_custom_result_after_delimiter);
+    resultset_format.delimiters.emplace_back(settings.result_before_delimiter);
+    resultset_format.delimiters.emplace_back(settings.result_after_delimiter);
     resultset_format.formats.emplace_back(ParsedTemplateFormatString::ColumnFormat::None);
     resultset_format.format_idx_to_column_idx.emplace_back(0);
     resultset_format.column_names.emplace_back("data");
     return resultset_format;
 }
 
-ParsedTemplateFormatString ParsedTemplateFormatString::setupCustomSeparatedRowFormat(const Context & context, const Block & sample)
+ParsedTemplateFormatString ParsedTemplateFormatString::setupCustomSeparatedRowFormat(const FormatSettings::Custom & settings, const Block & sample)
 {
-    const Settings & settings = context.getSettingsRef();
-
     /// Set row format to
     /// "row_before_delimiter ${Col0:escaping} field_delimiter ${Col1:escaping} field_delimiter ... ${ColN:escaping} row_after_delimiter"
-    ParsedTemplateFormatString::ColumnFormat escaping = ParsedTemplateFormatString::stringToFormat(settings.format_custom_escaping_rule);
+    ParsedTemplateFormatString::ColumnFormat escaping = ParsedTemplateFormatString::stringToFormat(settings.escaping_rule);
     ParsedTemplateFormatString row_format;
-    row_format.delimiters.emplace_back(settings.format_custom_row_before_delimiter);
+    row_format.delimiters.emplace_back(settings.row_before_delimiter);
     for (size_t i = 0; i < sample.columns(); ++i)
     {
         row_format.formats.emplace_back(escaping);
         row_format.format_idx_to_column_idx.emplace_back(i);
         row_format.column_names.emplace_back(sample.getByPosition(i).name);
         bool last_column = i == sample.columns() - 1;
-        row_format.delimiters.emplace_back(last_column ? settings.format_custom_row_after_delimiter : settings.format_custom_field_delimiter);
+        row_format.delimiters.emplace_back(last_column ? settings.row_after_delimiter : settings.field_delimiter);
     }
     return row_format;
 }

--- a/dbms/src/Formats/ParsedTemplateFormatString.h
+++ b/dbms/src/Formats/ParsedTemplateFormatString.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include <optional>
 #include <Formats/FormatSchemaInfo.h>
+#include <Formats/FormatSettings.h>
 
 namespace DB
 {
@@ -49,8 +50,8 @@ struct ParsedTemplateFormatString
     String dump() const;
     [[noreturn]] void throwInvalidFormat(const String & message, size_t column) const;
 
-    static ParsedTemplateFormatString setupCustomSeparatedResultsetFormat(const Context & context);
-    static ParsedTemplateFormatString setupCustomSeparatedRowFormat(const Context & context, const Block & sample);
+    static ParsedTemplateFormatString setupCustomSeparatedResultsetFormat(const FormatSettings::Custom & settings);
+    static ParsedTemplateFormatString setupCustomSeparatedRowFormat(const FormatSettings::Custom & settings, const Block & sample);
 };
 
 }

--- a/dbms/src/Functions/FunctionsConversion.cpp
+++ b/dbms/src/Functions/FunctionsConversion.cpp
@@ -5,29 +5,6 @@
 namespace DB
 {
 
-void throwExceptionForIncompletelyParsedValue(
-    ReadBuffer & read_buffer, Block & block, size_t result)
-{
-    const IDataType & to_type = *block.getByPosition(result).type;
-
-    WriteBufferFromOwnString message_buf;
-    message_buf << "Cannot parse string " << quote << String(read_buffer.buffer().begin(), read_buffer.buffer().size())
-        << " as " << to_type.getName()
-        << ": syntax error";
-
-    if (read_buffer.offset())
-        message_buf << " at position " << read_buffer.offset()
-            << " (parsed just " << quote << String(read_buffer.buffer().begin(), read_buffer.offset()) << ")";
-    else
-        message_buf << " at begin of string";
-
-    if (isNativeNumber(to_type))
-        message_buf << ". Note: there are to" << to_type.getName() << "OrZero and to" << to_type.getName() << "OrNull functions, which returns zero/NULL instead of throwing exception.";
-
-    throw Exception(message_buf.str(), ErrorCodes::CANNOT_PARSE_TEXT);
-}
-
-
 void registerFunctionsConversion(FunctionFactory & factory)
 {
     factory.registerFunction<FunctionToUInt8>();

--- a/dbms/src/Functions/FunctionsConversion.h
+++ b/dbms/src/Functions/FunctionsConversion.h
@@ -2339,8 +2339,8 @@ public:
     using MonotonicityForRange = FunctionCast::MonotonicityForRange;
 
     static constexpr auto name = "CAST";
-    static FunctionOverloadResolverImplPtr create(const Context &) { return std::make_unique<CastOverloadResolver>(); }
-    static FunctionOverloadResolverImplPtr create() { return std::make_unique<CastOverloadResolver>(); }
+    static FunctionOverloadResolverImplPtr create(const Context &) { return createImpl(); }
+    static FunctionOverloadResolverImplPtr createImpl() { return std::make_unique<CastOverloadResolver>(); }
 
     CastOverloadResolver() {}
 

--- a/dbms/src/Interpreters/castColumn.cpp
+++ b/dbms/src/Interpreters/castColumn.cpp
@@ -2,13 +2,14 @@
 #include <Interpreters/castColumn.h>
 #include <Interpreters/ExpressionActions.h>
 #include <DataTypes/DataTypeString.h>
-#include <Functions/FunctionFactory.h>
+#include <Functions/IFunctionAdaptors.h>
+#include <Functions/FunctionsConversion.h>
 
 
 namespace DB
 {
 
-ColumnPtr castColumn(const ColumnWithTypeAndName & arg, const DataTypePtr & type, const Context & context)
+ColumnPtr castColumn(const ColumnWithTypeAndName & arg, const DataTypePtr & type)
 {
     if (arg.type->equals(*type))
         return arg.column;
@@ -28,13 +29,18 @@ ColumnPtr castColumn(const ColumnWithTypeAndName & arg, const DataTypePtr & type
         }
     };
 
-    FunctionOverloadResolverPtr func_builder_cast = FunctionFactory::instance().get("CAST", context);
+    FunctionOverloadResolverPtr func_builder_cast = std::make_shared<FunctionOverloadResolverAdaptor>(CastOverloadResolver::create());
 
     ColumnsWithTypeAndName arguments{ temporary_block.getByPosition(0), temporary_block.getByPosition(1) };
     auto func_cast = func_builder_cast->build(arguments);
 
     func_cast->execute(temporary_block, {0, 1}, 2, arg.column->size());
     return temporary_block.getByPosition(2).column;
+}
+
+ColumnPtr castColumn(const ColumnWithTypeAndName & arg, const DataTypePtr & type, const Context &)
+{
+    return castColumn(arg, type);
 }
 
 }

--- a/dbms/src/Interpreters/castColumn.cpp
+++ b/dbms/src/Interpreters/castColumn.cpp
@@ -29,7 +29,7 @@ ColumnPtr castColumn(const ColumnWithTypeAndName & arg, const DataTypePtr & type
         }
     };
 
-    FunctionOverloadResolverPtr func_builder_cast = std::make_shared<FunctionOverloadResolverAdaptor>(CastOverloadResolver::create());
+    FunctionOverloadResolverPtr func_builder_cast = std::make_shared<FunctionOverloadResolverAdaptor>(CastOverloadResolver::createImpl());
 
     ColumnsWithTypeAndName arguments{ temporary_block.getByPosition(0), temporary_block.getByPosition(1) };
     auto func_cast = func_builder_cast->build(arguments);

--- a/dbms/src/Interpreters/castColumn.h
+++ b/dbms/src/Interpreters/castColumn.h
@@ -6,7 +6,7 @@
 
 namespace DB
 {
-
+ColumnPtr castColumn(const ColumnWithTypeAndName & arg, const DataTypePtr & type);
 ColumnPtr castColumn(const ColumnWithTypeAndName & arg, const DataTypePtr & type, const Context & context);
 
 }

--- a/dbms/src/Processors/Formats/Impl/ArrowColumnToCHColumn.cpp
+++ b/dbms/src/Processors/Formats/Impl/ArrowColumnToCHColumn.cpp
@@ -248,7 +248,7 @@ namespace DB
 
     void ArrowColumnToCHColumn::arrowTableToCHChunk(Chunk &res, std::shared_ptr<arrow::Table> &table,
                                                     arrow::Status &read_status, const Block &header,
-                                                    int &row_group_current, const Context &context, std::string format_name)
+                                                    int &row_group_current, std::string format_name)
     {
         Columns columns_list;
         UInt64 num_rows = 0;
@@ -389,7 +389,7 @@ namespace DB
             else
                 column.column = std::move(read_column);
 
-            column.column = castColumn(column, column_type, context);
+            column.column = castColumn(column, column_type);
             column.type = column_type;
             num_rows = column.column->size();
             columns_list.push_back(std::move(column.column));

--- a/dbms/src/Processors/Formats/Impl/ArrowColumnToCHColumn.h
+++ b/dbms/src/Processors/Formats/Impl/ArrowColumnToCHColumn.h
@@ -39,7 +39,7 @@ namespace DB
 
         static void arrowTableToCHChunk(Chunk &res, std::shared_ptr<arrow::Table> &table,
                                         arrow::Status &read_status, const Block &header,
-                                        int &row_group_current, const Context &context, std::string format_name);
+                                        int &row_group_current, std::string format_name);
     };
 }
 #endif

--- a/dbms/src/Processors/Formats/Impl/BinaryRowInputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/BinaryRowInputFormat.cpp
@@ -61,7 +61,6 @@ void registerInputFormatProcessorRowBinary(FormatFactory & factory)
     factory.registerInputFormatProcessor("RowBinary", [](
         ReadBuffer & buf,
         const Block & sample,
-        const Context &,
         const IRowInputFormat::Params & params,
         const FormatSettings &)
     {
@@ -71,7 +70,6 @@ void registerInputFormatProcessorRowBinary(FormatFactory & factory)
     factory.registerInputFormatProcessor("RowBinaryWithNamesAndTypes", [](
         ReadBuffer & buf,
         const Block & sample,
-        const Context &,
         const IRowInputFormat::Params & params,
         const FormatSettings &)
     {

--- a/dbms/src/Processors/Formats/Impl/BinaryRowOutputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/BinaryRowOutputFormat.cpp
@@ -52,7 +52,6 @@ void registerOutputFormatProcessorRowBinary(FormatFactory & factory)
     factory.registerOutputFormatProcessor("RowBinary", [](
         WriteBuffer & buf,
         const Block & sample,
-        const Context &,
         FormatFactory::WriteCallback callback,
         const FormatSettings &)
     {
@@ -62,7 +61,6 @@ void registerOutputFormatProcessorRowBinary(FormatFactory & factory)
     factory.registerOutputFormatProcessor("RowBinaryWithNamesAndTypes", [](
         WriteBuffer & buf,
         const Block & sample,
-        const Context &,
         FormatFactory::WriteCallback callback,
         const FormatSettings &)
     {

--- a/dbms/src/Processors/Formats/Impl/CSVRowInputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/CSVRowInputFormat.cpp
@@ -421,7 +421,6 @@ void registerInputFormatProcessorCSV(FormatFactory & factory)
         factory.registerInputFormatProcessor(with_names ? "CSVWithNames" : "CSV", [=](
             ReadBuffer & buf,
             const Block & sample,
-            const Context &,
             IRowInputFormat::Params params,
             const FormatSettings & settings)
         {

--- a/dbms/src/Processors/Formats/Impl/CSVRowOutputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/CSVRowOutputFormat.cpp
@@ -76,7 +76,6 @@ void registerOutputFormatProcessorCSV(FormatFactory & factory)
         factory.registerOutputFormatProcessor(with_names ? "CSVWithNames" : "CSV", [=](
             WriteBuffer & buf,
             const Block & sample,
-            const Context &,
             FormatFactory::WriteCallback callback,
             const FormatSettings & format_settings)
         {

--- a/dbms/src/Processors/Formats/Impl/CapnProtoRowInputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/CapnProtoRowInputFormat.cpp
@@ -301,10 +301,11 @@ void registerInputFormatProcessorCapnProto(FormatFactory & factory)
 {
     factory.registerInputFormatProcessor(
         "CapnProto",
-        [](ReadBuffer & buf, const Block & sample, const Context & context, IRowInputFormat::Params params, const FormatSettings &)
+        [](ReadBuffer & buf, const Block & sample, IRowInputFormat::Params params, const FormatSettings & settings)
         {
             return std::make_shared<CapnProtoRowInputFormat>(buf, sample, std::move(params),
-                                                             FormatSchemaInfo(context, context.getSettingsRef().format_schema, "CapnProto", true));
+                       FormatSchemaInfo(settings.schema.format_schema, "CapnProto", true,
+                                        settings.schema.is_server, settings.schema.format_schema_path));
         });
 }
 

--- a/dbms/src/Processors/Formats/Impl/JSONCompactEachRowRowInputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/JSONCompactEachRowRowInputFormat.cpp
@@ -217,7 +217,6 @@ void registerInputFormatProcessorJSONCompactEachRow(FormatFactory & factory)
     factory.registerInputFormatProcessor("JSONCompactEachRow", [](
             ReadBuffer & buf,
             const Block & sample,
-            const Context &,
             IRowInputFormat::Params params,
             const FormatSettings & settings)
     {
@@ -227,7 +226,6 @@ void registerInputFormatProcessorJSONCompactEachRow(FormatFactory & factory)
     factory.registerInputFormatProcessor("JSONCompactEachRowWithNamesAndTypes", [](
             ReadBuffer & buf,
             const Block & sample,
-            const Context &,
             IRowInputFormat::Params params,
             const FormatSettings & settings)
     {

--- a/dbms/src/Processors/Formats/Impl/JSONCompactEachRowRowOutputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/JSONCompactEachRowRowOutputFormat.cpp
@@ -94,7 +94,6 @@ void registerOutputFormatProcessorJSONCompactEachRow(FormatFactory & factory)
     factory.registerOutputFormatProcessor("JSONCompactEachRow", [](
             WriteBuffer & buf,
             const Block & sample,
-            const Context &,
             FormatFactory::WriteCallback callback,
             const FormatSettings & format_settings)
     {
@@ -104,7 +103,6 @@ void registerOutputFormatProcessorJSONCompactEachRow(FormatFactory & factory)
     factory.registerOutputFormatProcessor("JSONCompactEachRowWithNamesAndTypes", [](
             WriteBuffer &buf,
             const Block &sample,
-            const Context &,
             FormatFactory::WriteCallback callback,
             const FormatSettings &format_settings)
     {

--- a/dbms/src/Processors/Formats/Impl/JSONCompactRowOutputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/JSONCompactRowOutputFormat.cpp
@@ -80,7 +80,6 @@ void registerOutputFormatProcessorJSONCompact(FormatFactory & factory)
     factory.registerOutputFormatProcessor("JSONCompact", [](
         WriteBuffer & buf,
         const Block & sample,
-        const Context &,
         FormatFactory::WriteCallback callback,
         const FormatSettings & format_settings)
     {

--- a/dbms/src/Processors/Formats/Impl/JSONEachRowRowInputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/JSONEachRowRowInputFormat.cpp
@@ -271,7 +271,6 @@ void registerInputFormatProcessorJSONEachRow(FormatFactory & factory)
     factory.registerInputFormatProcessor("JSONEachRow", [](
         ReadBuffer & buf,
         const Block & sample,
-        const Context &,
         IRowInputFormat::Params params,
         const FormatSettings & settings)
     {

--- a/dbms/src/Processors/Formats/Impl/JSONEachRowRowOutputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/JSONEachRowRowOutputFormat.cpp
@@ -56,7 +56,6 @@ void registerOutputFormatProcessorJSONEachRow(FormatFactory & factory)
     factory.registerOutputFormatProcessor("JSONEachRow", [](
         WriteBuffer & buf,
         const Block & sample,
-        const Context &,
         FormatFactory::WriteCallback callback,
         const FormatSettings & format_settings)
     {

--- a/dbms/src/Processors/Formats/Impl/JSONEachRowWithProgressRowOutputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/JSONEachRowWithProgressRowOutputFormat.cpp
@@ -33,7 +33,6 @@ void registerOutputFormatProcessorJSONEachRowWithProgress(FormatFactory & factor
     factory.registerOutputFormatProcessor("JSONEachRowWithProgress", [](
             WriteBuffer & buf,
             const Block & sample,
-            const Context &,
             FormatFactory::WriteCallback callback,
             const FormatSettings & format_settings)
     {

--- a/dbms/src/Processors/Formats/Impl/JSONRowOutputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/JSONRowOutputFormat.cpp
@@ -246,7 +246,6 @@ void registerOutputFormatProcessorJSON(FormatFactory & factory)
     factory.registerOutputFormatProcessor("JSON", [](
         WriteBuffer & buf,
         const Block & sample,
-        const Context &,
         FormatFactory::WriteCallback callback,
         const FormatSettings & format_settings)
     {

--- a/dbms/src/Processors/Formats/Impl/MySQLOutputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/MySQLOutputFormat.cpp
@@ -12,13 +12,10 @@ namespace DB
 using namespace MySQLProtocol;
 
 
-MySQLOutputFormat::MySQLOutputFormat(WriteBuffer & out_, const Block & header_, const Context & context_, const FormatSettings & settings_)
+MySQLOutputFormat::MySQLOutputFormat(WriteBuffer & out_, const Block & header_, const FormatSettings & settings_)
     : IOutputFormat(header_, out_)
-    , context(context_)
-    , packet_sender(out, const_cast<uint8_t &>(context_.mysql.sequence_id)) /// TODO: fix it
     , format_settings(settings_)
 {
-    packet_sender.max_packet_size = context_.mysql.max_packet_size;
 }
 
 void MySQLOutputFormat::initialize()
@@ -32,17 +29,17 @@ void MySQLOutputFormat::initialize()
 
     if (header.columns())
     {
-        packet_sender.sendPacket(LengthEncodedNumber(header.columns()));
+        packet_sender->sendPacket(LengthEncodedNumber(header.columns()));
 
         for (size_t i = 0; i < header.columns(); i++)
         {
             const auto & column_name = header.getColumnsWithTypeAndName()[i].name;
-            packet_sender.sendPacket(getColumnDefinition(column_name, data_types[i]->getTypeId()));
+            packet_sender->sendPacket(getColumnDefinition(column_name, data_types[i]->getTypeId()));
         }
 
-        if (!(context.mysql.client_capabilities & Capability::CLIENT_DEPRECATE_EOF))
+        if (!(context->mysql.client_capabilities & Capability::CLIENT_DEPRECATE_EOF))
         {
-            packet_sender.sendPacket(EOF_Packet(0, 0));
+            packet_sender->sendPacket(EOF_Packet(0, 0));
         }
     }
 }
@@ -53,7 +50,7 @@ void MySQLOutputFormat::consume(Chunk chunk)
     for (size_t i = 0; i < chunk.getNumRows(); i++)
     {
         ProtocolText::ResultsetRow row_packet(data_types, chunk.getColumns(), i);
-        packet_sender.sendPacket(row_packet);
+        packet_sender->sendPacket(row_packet);
     }
 }
 
@@ -61,7 +58,7 @@ void MySQLOutputFormat::finalize()
 {
     size_t affected_rows = 0;
     std::stringstream human_readable_info;
-    if (QueryStatus * process_list_elem = context.getProcessListElement())
+    if (QueryStatus * process_list_elem = context->getProcessListElement())
     {
         CurrentThread::finalizePerformanceCounters();
         QueryStatusInfo info = process_list_elem->getInfo();
@@ -74,17 +71,17 @@ void MySQLOutputFormat::finalize()
 
     const auto & header = getPort(PortKind::Main).getHeader();
     if (header.columns() == 0)
-        packet_sender.sendPacket(OK_Packet(0x0, context.mysql.client_capabilities, affected_rows, 0, 0, "", human_readable_info.str()), true);
+        packet_sender->sendPacket(OK_Packet(0x0, context->mysql.client_capabilities, affected_rows, 0, 0, "", human_readable_info.str()), true);
     else
-    if (context.mysql.client_capabilities & CLIENT_DEPRECATE_EOF)
-        packet_sender.sendPacket(OK_Packet(0xfe, context.mysql.client_capabilities, affected_rows, 0, 0, "", human_readable_info.str()), true);
+    if (context->mysql.client_capabilities & CLIENT_DEPRECATE_EOF)
+        packet_sender->sendPacket(OK_Packet(0xfe, context->mysql.client_capabilities, affected_rows, 0, 0, "", human_readable_info.str()), true);
     else
-        packet_sender.sendPacket(EOF_Packet(0, 0), true);
+        packet_sender->sendPacket(EOF_Packet(0, 0), true);
 }
 
 void MySQLOutputFormat::flush()
 {
-    packet_sender.out->next();
+    packet_sender->out->next();
 }
 
 void registerOutputFormatProcessorMySQLWrite(FormatFactory & factory)
@@ -93,9 +90,8 @@ void registerOutputFormatProcessorMySQLWrite(FormatFactory & factory)
         "MySQLWire",
         [](WriteBuffer & buf,
            const Block & sample,
-           const Context & context,
            FormatFactory::WriteCallback,
-           const FormatSettings & settings) { return std::make_shared<MySQLOutputFormat>(buf, sample, context, settings); });
+           const FormatSettings & settings) { return std::make_shared<MySQLOutputFormat>(buf, sample, settings); });
 }
 
 }

--- a/dbms/src/Processors/Formats/Impl/MySQLOutputFormat.h
+++ b/dbms/src/Processors/Formats/Impl/MySQLOutputFormat.h
@@ -16,12 +16,19 @@ class Context;
 
 /** A stream for outputting data in a binary line-by-line format.
   */
-class MySQLOutputFormat: public IOutputFormat
+class MySQLOutputFormat final : public IOutputFormat
 {
 public:
-    MySQLOutputFormat(WriteBuffer & out_, const Block & header_, const Context & context_, const FormatSettings & settings_);
+    MySQLOutputFormat(WriteBuffer & out_, const Block & header_, const FormatSettings & settings_);
 
     String getName() const override { return "MySQLOutputFormat"; }
+
+    void setContext(const Context & context_)
+    {
+        context = &context_;
+        packet_sender = std::make_unique<MySQLProtocol::PacketSender>(out, const_cast<uint8_t &>(context_.mysql.sequence_id)); /// TODO: fix it
+        packet_sender->max_packet_size = context_.mysql.max_packet_size;
+    }
 
     void consume(Chunk) override;
     void finalize() override;
@@ -34,8 +41,8 @@ private:
 
     bool initialized = false;
 
-    const Context & context;
-    MySQLProtocol::PacketSender packet_sender;
+    const Context * context = nullptr;
+    std::unique_ptr<MySQLProtocol::PacketSender> packet_sender;
     FormatSettings format_settings;
     DataTypes data_types;
 };

--- a/dbms/src/Processors/Formats/Impl/NativeFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/NativeFormat.cpp
@@ -156,7 +156,6 @@ void registerInputFormatProcessorNative(FormatFactory & factory)
     factory.registerInputFormatProcessor("Native", [](
         ReadBuffer & buf,
         const Block & sample,
-        const Context &,
         const RowInputFormatParams &,
         const FormatSettings &)
     {
@@ -169,7 +168,6 @@ void registerOutputFormatProcessorNative(FormatFactory & factory)
     factory.registerOutputFormatProcessor("Native", [](
         WriteBuffer & buf,
         const Block & sample,
-        const Context &,
         FormatFactory::WriteCallback,
         const FormatSettings &)
     {

--- a/dbms/src/Processors/Formats/Impl/NullFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/NullFormat.cpp
@@ -21,7 +21,6 @@ void registerOutputFormatProcessorNull(FormatFactory & factory)
     factory.registerOutputFormatProcessor("Null", [](
         WriteBuffer & buf,
         const Block & sample,
-        const Context &,
         FormatFactory::WriteCallback,
         const FormatSettings &)
     {

--- a/dbms/src/Processors/Formats/Impl/ODBCDriver2BlockOutputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/ODBCDriver2BlockOutputFormat.cpp
@@ -107,7 +107,7 @@ void ODBCDriver2BlockOutputFormat::writePrefix()
 void registerOutputFormatProcessorODBCDriver2(FormatFactory & factory)
 {
     factory.registerOutputFormatProcessor(
-        "ODBCDriver2", [](WriteBuffer & buf, const Block & sample, const Context &, FormatFactory::WriteCallback, const FormatSettings & format_settings)
+        "ODBCDriver2", [](WriteBuffer & buf, const Block & sample, FormatFactory::WriteCallback, const FormatSettings & format_settings)
         {
             return std::make_shared<ODBCDriver2BlockOutputFormat>(buf, sample, format_settings);
         });

--- a/dbms/src/Processors/Formats/Impl/ODBCDriverBlockOutputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/ODBCDriverBlockOutputFormat.cpp
@@ -69,7 +69,6 @@ void registerOutputFormatProcessorODBCDriver(FormatFactory & factory)
     factory.registerOutputFormatProcessor("ODBCDriver", [](
         WriteBuffer & buf,
         const Block & sample,
-        const Context &,
         FormatFactory::WriteCallback,
         const FormatSettings & format_settings)
     {

--- a/dbms/src/Processors/Formats/Impl/ORCBlockInputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/ORCBlockInputFormat.cpp
@@ -12,8 +12,8 @@
 
 namespace DB
 {
-    ORCBlockInputFormat::ORCBlockInputFormat(ReadBuffer &in_, Block header_)
-            : IInputFormat(std::move(header_), in_) {
+    ORCBlockInputFormat::ORCBlockInputFormat(ReadBuffer &in_, Block header_) : IInputFormat(std::move(header_), in_)
+    {
     }
 
     Chunk ORCBlockInputFormat::generate()

--- a/dbms/src/Processors/Formats/Impl/ORCBlockInputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/ORCBlockInputFormat.cpp
@@ -12,8 +12,8 @@
 
 namespace DB
 {
-    ORCBlockInputFormat::ORCBlockInputFormat(ReadBuffer &in_, Block header_, const Context &context_)
-            : IInputFormat(std::move(header_), in_), context{context_} {
+    ORCBlockInputFormat::ORCBlockInputFormat(ReadBuffer &in_, Block header_)
+            : IInputFormat(std::move(header_), in_) {
     }
 
     Chunk ORCBlockInputFormat::generate()
@@ -57,7 +57,7 @@ namespace DB
 
         arrow::Status read_status = file_reader->Read(&table);
 
-        ArrowColumnToCHColumn::arrowTableToCHChunk(res, table, read_status, header, row_group_current, context, "ORC");
+        ArrowColumnToCHColumn::arrowTableToCHChunk(res, table, read_status, header, row_group_current, "ORC");
 
         return res;
     }
@@ -78,11 +78,10 @@ namespace DB
                 "ORC",
                 [](ReadBuffer &buf,
                    const Block &sample,
-                   const Context &context,
                    const RowInputFormatParams &,
                    const FormatSettings & /* settings */)
                    {
-                    return std::make_shared<ORCBlockInputFormat>(buf, sample, context);
+                    return std::make_shared<ORCBlockInputFormat>(buf, sample);
                 });
     }
 

--- a/dbms/src/Processors/Formats/Impl/ORCBlockInputFormat.h
+++ b/dbms/src/Processors/Formats/Impl/ORCBlockInputFormat.h
@@ -17,7 +17,7 @@ class Context;
 class ORCBlockInputFormat: public IInputFormat
 {
 public:
-    ORCBlockInputFormat(ReadBuffer & in_, Block header_, const Context & context_);
+    ORCBlockInputFormat(ReadBuffer & in_, Block header_);
 
     String getName() const override { return "ORCBlockInputFormat"; }
 
@@ -29,8 +29,6 @@ protected:
 private:
 
     // TODO: check that this class implements every part of its parent
-
-    const Context & context;
 
     std::unique_ptr<arrow::adapters::orc::ORCFileReader> file_reader;
     std::string file_data;

--- a/dbms/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
@@ -15,8 +15,9 @@
 namespace DB
 {
 
-    ParquetBlockInputFormat::ParquetBlockInputFormat(ReadBuffer &in_, Block header_, const Context &context_)
-            : IInputFormat(std::move(header_), in_), context{context_} {
+    ParquetBlockInputFormat::ParquetBlockInputFormat(ReadBuffer & in_, Block header_)
+            : IInputFormat(std::move(header_), in_)
+    {
     }
 
     Chunk ParquetBlockInputFormat::generate()
@@ -59,7 +60,7 @@ namespace DB
         std::shared_ptr<arrow::Table> table;
         arrow::Status read_status = file_reader->ReadRowGroup(row_group_current, &table);
 
-        ArrowColumnToCHColumn::arrowTableToCHChunk(res, table, read_status, header, row_group_current, context, "Parquet");
+        ArrowColumnToCHColumn::arrowTableToCHChunk(res, table, read_status, header, row_group_current, "Parquet");
         return res;
     }
 
@@ -80,11 +81,10 @@ namespace DB
                 "Parquet",
                 [](ReadBuffer &buf,
                    const Block &sample,
-                   const Context &context,
                    const RowInputFormatParams &,
                    const FormatSettings & /* settings */)
                 {
-                    return std::make_shared<ParquetBlockInputFormat>(buf, sample, context);
+                    return std::make_shared<ParquetBlockInputFormat>(buf, sample);
                 });
     }
 

--- a/dbms/src/Processors/Formats/Impl/ParquetBlockInputFormat.h
+++ b/dbms/src/Processors/Formats/Impl/ParquetBlockInputFormat.h
@@ -16,7 +16,7 @@ class Context;
 class ParquetBlockInputFormat: public IInputFormat
 {
 public:
-    ParquetBlockInputFormat(ReadBuffer & in_, Block header_, const Context & context_);
+    ParquetBlockInputFormat(ReadBuffer & in_, Block header_);
 
     void resetParser() override;
 
@@ -29,8 +29,6 @@ protected:
 private:
 
     // TODO: check that this class implements every part of its parent
-
-    const Context & context;
 
     std::unique_ptr<parquet::arrow::FileReader> file_reader;
     std::string file_data;

--- a/dbms/src/Processors/Formats/Impl/ParquetBlockOutputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/ParquetBlockOutputFormat.cpp
@@ -426,7 +426,6 @@ void registerOutputFormatProcessorParquet(FormatFactory & factory)
         "Parquet",
         [](WriteBuffer & buf,
            const Block & sample,
-           const Context & /*context*/,
            FormatFactory::WriteCallback,
            const FormatSettings & format_settings)
         {

--- a/dbms/src/Processors/Formats/Impl/PrettyBlockOutputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/PrettyBlockOutputFormat.cpp
@@ -260,7 +260,6 @@ void registerOutputFormatProcessorPretty(FormatFactory & factory)
     factory.registerOutputFormatProcessor("Pretty", [](
         WriteBuffer & buf,
         const Block & sample,
-        const Context &,
         FormatFactory::WriteCallback,
         const FormatSettings & format_settings)
     {
@@ -270,7 +269,6 @@ void registerOutputFormatProcessorPretty(FormatFactory & factory)
     factory.registerOutputFormatProcessor("PrettyNoEscapes", [](
         WriteBuffer & buf,
         const Block & sample,
-        const Context &,
         FormatFactory::WriteCallback,
         const FormatSettings & format_settings)
     {

--- a/dbms/src/Processors/Formats/Impl/PrettyCompactBlockOutputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/PrettyCompactBlockOutputFormat.cpp
@@ -134,7 +134,6 @@ void registerOutputFormatProcessorPrettyCompact(FormatFactory & factory)
     factory.registerOutputFormatProcessor("PrettyCompact", [](
         WriteBuffer & buf,
         const Block & sample,
-        const Context &,
         FormatFactory::WriteCallback,
         const FormatSettings & format_settings)
     {
@@ -144,7 +143,6 @@ void registerOutputFormatProcessorPrettyCompact(FormatFactory & factory)
     factory.registerOutputFormatProcessor("PrettyCompactNoEscapes", [](
         WriteBuffer & buf,
         const Block & sample,
-        const Context &,
         FormatFactory::WriteCallback,
         const FormatSettings & format_settings)
     {
@@ -157,7 +155,6 @@ void registerOutputFormatProcessorPrettyCompact(FormatFactory & factory)
 //    factory.registerOutputFormat("PrettyCompactMonoBlock", [](
 //        WriteBuffer & buf,
 //        const Block & sample,
-//        const Context &,
 //        const FormatSettings & format_settings)
 //    {
 //        BlockOutputStreamPtr impl = std::make_shared<PrettyCompactBlockOutputFormat>(buf, sample, format_settings);

--- a/dbms/src/Processors/Formats/Impl/PrettySpaceBlockOutputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/PrettySpaceBlockOutputFormat.cpp
@@ -97,7 +97,6 @@ void registerOutputFormatProcessorPrettySpace(FormatFactory & factory)
     factory.registerOutputFormatProcessor("PrettySpace", [](
         WriteBuffer & buf,
         const Block & sample,
-        const Context &,
         FormatFactory::WriteCallback,
         const FormatSettings & format_settings)
     {
@@ -107,7 +106,6 @@ void registerOutputFormatProcessorPrettySpace(FormatFactory & factory)
     factory.registerOutputFormatProcessor("PrettySpaceNoEscapes", [](
         WriteBuffer & buf,
         const Block & sample,
-        const Context &,
         FormatFactory::WriteCallback,
         const FormatSettings & format_settings)
     {

--- a/dbms/src/Processors/Formats/Impl/ProtobufRowInputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/ProtobufRowInputFormat.cpp
@@ -70,12 +70,12 @@ void registerInputFormatProcessorProtobuf(FormatFactory & factory)
     factory.registerInputFormatProcessor("Protobuf", [](
         ReadBuffer & buf,
         const Block & sample,
-        const Context & context,
         IRowInputFormat::Params params,
-        const FormatSettings &)
+        const FormatSettings & settings)
     {
         return std::make_shared<ProtobufRowInputFormat>(buf, sample, std::move(params),
-                                                        FormatSchemaInfo(context, context.getSettingsRef().format_schema, "Protobuf", true));
+            FormatSchemaInfo(settings.schema.format_schema, "Protobuf", true,
+                             settings.schema.is_server, settings.schema.format_schema_path));
     });
 }
 

--- a/dbms/src/Processors/Formats/Impl/ProtobufRowOutputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/ProtobufRowOutputFormat.cpp
@@ -50,12 +50,12 @@ void registerOutputFormatProcessorProtobuf(FormatFactory & factory)
         "Protobuf",
         [](WriteBuffer & buf,
            const Block & header,
-           const Context & context,
            FormatFactory::WriteCallback callback,
-           const FormatSettings &)
+           const FormatSettings & settings)
         {
-            return std::make_shared<ProtobufRowOutputFormat>(buf, header, callback,
-                                                             FormatSchemaInfo(context, context.getSettingsRef().format_schema, "Protobuf", true));
+            return std::make_shared<ProtobufRowOutputFormat>(buf, header, std::move(callback),
+                FormatSchemaInfo(settings.schema.format_schema, "Protobuf", true,
+                                 settings.schema.is_server, settings.schema.format_schema_path));
         });
 }
 

--- a/dbms/src/Processors/Formats/Impl/TSKVRowInputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/TSKVRowInputFormat.cpp
@@ -210,7 +210,6 @@ void registerInputFormatProcessorTSKV(FormatFactory & factory)
     factory.registerInputFormatProcessor("TSKV", [](
         ReadBuffer & buf,
         const Block & sample,
-        const Context &,
         IRowInputFormat::Params params,
         const FormatSettings & settings)
     {

--- a/dbms/src/Processors/Formats/Impl/TSKVRowOutputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/TSKVRowOutputFormat.cpp
@@ -45,7 +45,6 @@ void registerOutputFormatProcessorTSKV(FormatFactory & factory)
     factory.registerOutputFormatProcessor("TSKV", [](
         WriteBuffer & buf,
         const Block & sample,
-        const Context &,
         FormatFactory::WriteCallback callback,
         const FormatSettings & settings)
     {

--- a/dbms/src/Processors/Formats/Impl/TabSeparatedRowInputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/TabSeparatedRowInputFormat.cpp
@@ -356,7 +356,6 @@ void registerInputFormatProcessorTabSeparated(FormatFactory & factory)
         factory.registerInputFormatProcessor(name, [](
             ReadBuffer & buf,
             const Block & sample,
-            const Context &,
             IRowInputFormat::Params params,
             const FormatSettings & settings)
         {
@@ -369,7 +368,6 @@ void registerInputFormatProcessorTabSeparated(FormatFactory & factory)
         factory.registerInputFormatProcessor(name, [](
             ReadBuffer & buf,
             const Block & sample,
-            const Context &,
             IRowInputFormat::Params params,
             const FormatSettings & settings)
         {
@@ -382,7 +380,6 @@ void registerInputFormatProcessorTabSeparated(FormatFactory & factory)
         factory.registerInputFormatProcessor(name, [](
             ReadBuffer & buf,
             const Block & sample,
-            const Context &,
             IRowInputFormat::Params params,
             const FormatSettings & settings)
         {

--- a/dbms/src/Processors/Formats/Impl/TabSeparatedRowOutputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/TabSeparatedRowOutputFormat.cpp
@@ -78,7 +78,6 @@ void registerOutputFormatProcessorTabSeparated(FormatFactory & factory)
         factory.registerOutputFormatProcessor(name, [](
             WriteBuffer & buf,
             const Block & sample,
-            const Context &,
             FormatFactory::WriteCallback callback,
             const FormatSettings & settings)
         {
@@ -91,7 +90,6 @@ void registerOutputFormatProcessorTabSeparated(FormatFactory & factory)
         factory.registerOutputFormatProcessor(name, [](
             WriteBuffer & buf,
             const Block & sample,
-            const Context &,
             FormatFactory::WriteCallback callback,
             const FormatSettings & settings)
         {
@@ -104,7 +102,6 @@ void registerOutputFormatProcessorTabSeparated(FormatFactory & factory)
         factory.registerOutputFormatProcessor(name, [](
             WriteBuffer & buf,
             const Block & sample,
-            const Context &,
             FormatFactory::WriteCallback callback,
             const FormatSettings & settings)
         {
@@ -117,7 +114,6 @@ void registerOutputFormatProcessorTabSeparated(FormatFactory & factory)
         factory.registerOutputFormatProcessor(name, [](
             WriteBuffer & buf,
             const Block & sample,
-            const Context &,
             FormatFactory::WriteCallback callback,
             const FormatSettings & settings)
         {

--- a/dbms/src/Processors/Formats/Impl/TemplateBlockOutputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/TemplateBlockOutputFormat.cpp
@@ -246,7 +246,7 @@ void registerOutputFormatProcessorTemplate(FormatFactory & factory)
         {
             /// Read format string from file
             resultset_format = ParsedTemplateFormatString(
-                    FormatSchemaInfo(settings.template_settings.row_format, "Template", false,
+                    FormatSchemaInfo(settings.template_settings.resultset_format, "Template", false,
                             settings.schema.is_server, settings.schema.format_schema_path),
                     [&](const String & partName)
                     {

--- a/dbms/src/Processors/Formats/Impl/TemplateBlockOutputFormat.h
+++ b/dbms/src/Processors/Formats/Impl/TemplateBlockOutputFormat.h
@@ -15,7 +15,8 @@ class TemplateBlockOutputFormat : public IOutputFormat
     using ColumnFormat = ParsedTemplateFormatString::ColumnFormat;
 public:
     TemplateBlockOutputFormat(const Block & header_, WriteBuffer & out_, const FormatSettings & settings_,
-                              ParsedTemplateFormatString format_, ParsedTemplateFormatString row_format_);
+                              ParsedTemplateFormatString format_, ParsedTemplateFormatString row_format_,
+                              std::string row_between_delimiter_);
 
     String getName() const override { return "TemplateBlockOutputFormat"; }
 
@@ -65,6 +66,8 @@ protected:
 
     size_t row_count = 0;
     bool need_write_prefix = true;
+
+    std::string row_between_delimiter;
 };
 
 }

--- a/dbms/src/Processors/Formats/Impl/TemplateRowInputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/TemplateRowInputFormat.cpp
@@ -525,7 +525,7 @@ void registerInputFormatProcessorTemplate(FormatFactory & factory)
             {
                 /// Read format string from file
                 resultset_format = ParsedTemplateFormatString(
-                        FormatSchemaInfo(settings.template_settings.row_format, "Template", false,
+                        FormatSchemaInfo(settings.template_settings.resultset_format, "Template", false,
                                          settings.schema.is_server, settings.schema.format_schema_path),
                         [&](const String & partName) -> std::optional<size_t>
                         {

--- a/dbms/src/Processors/Formats/Impl/TemplateRowInputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/TemplateRowInputFormat.cpp
@@ -21,11 +21,12 @@ extern const int SYNTAX_ERROR;
 
 TemplateRowInputFormat::TemplateRowInputFormat(const Block & header_, ReadBuffer & in_, const Params & params_,
                                                FormatSettings settings_, bool ignore_spaces_,
-                                               ParsedTemplateFormatString format_, ParsedTemplateFormatString row_format_)
+                                               ParsedTemplateFormatString format_, ParsedTemplateFormatString row_format_,
+                                               std::string row_between_delimiter_)
     : RowInputFormatWithDiagnosticInfo(header_, buf, params_), buf(in_), data_types(header_.getDataTypes()),
       settings(std::move(settings_)), ignore_spaces(ignore_spaces_),
       format(std::move(format_)), row_format(std::move(row_format_)),
-      default_csv_delimiter(settings.csv.delimiter)
+      default_csv_delimiter(settings.csv.delimiter), row_between_delimiter(std::move(row_between_delimiter_))
 {
     /// Validate format string for result set
     bool has_data = false;
@@ -160,7 +161,7 @@ bool TemplateRowInputFormat::readRow(MutableColumns & columns, RowReadExtension 
     updateDiagnosticInfo();
 
     if (likely(row_num != 1))
-        assertString(settings.template_settings.row_between_delimiter, buf);
+        assertString(row_between_delimiter, buf);
 
     extra.read_columns.assign(columns.size(), false);
 
@@ -339,11 +340,11 @@ bool TemplateRowInputFormat::parseRowAndPrintDiagnosticInfo(MutableColumns & col
     try
     {
         if (likely(row_num != 1))
-            assertString(settings.template_settings.row_between_delimiter, buf);
+            assertString(row_between_delimiter, buf);
     }
     catch (const DB::Exception &)
     {
-        writeErrorStringForWrongDelimiter(out, "delimiter between rows", settings.template_settings.row_between_delimiter);
+        writeErrorStringForWrongDelimiter(out, "delimiter between rows", row_between_delimiter);
 
         return false;
     }
@@ -428,7 +429,7 @@ bool TemplateRowInputFormat::isGarbageAfterField(size_t, ReadBuffer::Position)
 
 bool TemplateRowInputFormat::allowSyncAfterError() const
 {
-    return !row_format.delimiters.back().empty() || !settings.template_settings.row_between_delimiter.empty();
+    return !row_format.delimiters.back().empty() || !row_between_delimiter.empty();
 }
 
 void TemplateRowInputFormat::syncAfterError()
@@ -450,10 +451,10 @@ void TemplateRowInputFormat::syncAfterError()
 
         bool last_delimiter_in_row_found = !row_format.delimiters.back().empty();
 
-        if (last_delimiter_in_row_found && checkString(settings.template_settings.row_between_delimiter, buf))
+        if (last_delimiter_in_row_found && checkString(row_between_delimiter, buf))
             at_beginning_of_row_or_eof = true;
         else
-            skipToNextDelimiterOrEof(settings.template_settings.row_between_delimiter);
+            skipToNextDelimiterOrEof(row_between_delimiter);
 
         if (buf.eof())
             at_beginning_of_row_or_eof = end_of_stream = true;
@@ -544,7 +545,7 @@ void registerInputFormatProcessorTemplate(FormatFactory & factory)
                         return sample.getPositionByName(colName);
                     });
 
-            return std::make_shared<TemplateRowInputFormat>(sample, buf, params, settings, ignore_spaces, resultset_format, row_format);
+            return std::make_shared<TemplateRowInputFormat>(sample, buf, params, settings, ignore_spaces, resultset_format, row_format, settings.template_settings.row_between_delimiter);
         });
     }
 
@@ -559,7 +560,7 @@ void registerInputFormatProcessorTemplate(FormatFactory & factory)
             ParsedTemplateFormatString resultset_format = ParsedTemplateFormatString::setupCustomSeparatedResultsetFormat(settings.custom);
             ParsedTemplateFormatString row_format = ParsedTemplateFormatString::setupCustomSeparatedRowFormat(settings.custom, sample);
 
-            return std::make_shared<TemplateRowInputFormat>(sample, buf, params, settings, ignore_spaces, resultset_format, row_format);
+            return std::make_shared<TemplateRowInputFormat>(sample, buf, params, settings, ignore_spaces, resultset_format, row_format, settings.custom.row_between_delimiter);
         });
     }
 }

--- a/dbms/src/Processors/Formats/Impl/TemplateRowInputFormat.h
+++ b/dbms/src/Processors/Formats/Impl/TemplateRowInputFormat.h
@@ -17,7 +17,8 @@ class TemplateRowInputFormat : public RowInputFormatWithDiagnosticInfo
 public:
     TemplateRowInputFormat(const Block & header_, ReadBuffer & in_, const Params & params_,
                            FormatSettings settings_, bool ignore_spaces_,
-                           ParsedTemplateFormatString format_, ParsedTemplateFormatString row_format_);
+                           ParsedTemplateFormatString format_, ParsedTemplateFormatString row_format_,
+                           std::string row_between_delimiter);
 
     String getName() const override { return "TemplateRowInputFormat"; }
 
@@ -61,6 +62,8 @@ private:
     bool end_of_stream = false;
     std::vector<size_t> always_default_columns;
     char default_csv_delimiter;
+
+    std::string row_between_delimiter;
 };
 
 }

--- a/dbms/src/Processors/Formats/Impl/TemplateRowInputFormat.h
+++ b/dbms/src/Processors/Formats/Impl/TemplateRowInputFormat.h
@@ -16,7 +16,7 @@ class TemplateRowInputFormat : public RowInputFormatWithDiagnosticInfo
     using ColumnFormat = ParsedTemplateFormatString::ColumnFormat;
 public:
     TemplateRowInputFormat(const Block & header_, ReadBuffer & in_, const Params & params_,
-                           const FormatSettings & settings_, bool ignore_spaces_,
+                           FormatSettings settings_, bool ignore_spaces_,
                            ParsedTemplateFormatString format_, ParsedTemplateFormatString row_format_);
 
     String getName() const override { return "TemplateRowInputFormat"; }

--- a/dbms/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
@@ -33,8 +33,8 @@ namespace ErrorCodes
 
 
 ValuesBlockInputFormat::ValuesBlockInputFormat(ReadBuffer & in_, const Block & header_, const RowInputFormatParams & params_,
-                                               const Context & context_, const FormatSettings & format_settings_)
-        : IInputFormat(header_, buf), buf(in_), params(params_), context(std::make_unique<Context>(context_)),
+                                               const FormatSettings & format_settings_)
+        : IInputFormat(header_, buf), buf(in_), params(params_),
           format_settings(format_settings_), num_columns(header_.columns()),
           parser_type_for_column(num_columns, ParserType::Streaming),
           attempts_to_deduce_template(num_columns), attempts_to_deduce_template_cached(num_columns),
@@ -424,11 +424,10 @@ void registerInputFormatProcessorValues(FormatFactory & factory)
     factory.registerInputFormatProcessor("Values", [](
         ReadBuffer & buf,
         const Block & header,
-        const Context & context,
         const RowInputFormatParams & params,
         const FormatSettings & settings)
     {
-        return std::make_shared<ValuesBlockInputFormat>(buf, header, params, context, settings);
+        return std::make_shared<ValuesBlockInputFormat>(buf, header, params, settings);
     });
 }
 

--- a/dbms/src/Processors/Formats/Impl/ValuesBlockInputFormat.h
+++ b/dbms/src/Processors/Formats/Impl/ValuesBlockInputFormat.h
@@ -18,7 +18,7 @@ class ReadBuffer;
 
 /** Stream to read data in VALUES format (as in INSERT query).
   */
-class ValuesBlockInputFormat : public IInputFormat
+class ValuesBlockInputFormat final : public IInputFormat
 {
 public:
     /** Data is parsed using fast, streaming parser.
@@ -29,11 +29,14 @@ public:
       * than interpreting expressions in each row separately, but it's still slower than streaming parsing)
       */
     ValuesBlockInputFormat(ReadBuffer & in_, const Block & header_, const RowInputFormatParams & params_,
-                           const Context & context_, const FormatSettings & format_settings_);
+                           const FormatSettings & format_settings_);
 
     String getName() const override { return "ValuesBlockInputFormat"; }
 
     void resetParser() override;
+
+    /// TODO: remove context somehow.
+    void setContext(const Context & context_) { context = std::make_unique<Context>(context_); }
 
     const BlockMissingValues & getMissingValues() const override { return block_missing_values; }
 

--- a/dbms/src/Processors/Formats/Impl/ValuesRowOutputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/ValuesRowOutputFormat.cpp
@@ -46,7 +46,6 @@ void registerOutputFormatProcessorValues(FormatFactory & factory)
     factory.registerOutputFormatProcessor("Values", [](
         WriteBuffer & buf,
         const Block & sample,
-        const Context &,
         FormatFactory::WriteCallback callback,
         const FormatSettings & settings)
     {

--- a/dbms/src/Processors/Formats/Impl/VerticalRowOutputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/VerticalRowOutputFormat.cpp
@@ -168,7 +168,6 @@ void registerOutputFormatProcessorVertical(FormatFactory & factory)
     factory.registerOutputFormatProcessor("Vertical", [](
         WriteBuffer & buf,
         const Block & sample,
-        const Context &,
         FormatFactory::WriteCallback callback,
         const FormatSettings & settings)
     {

--- a/dbms/src/Processors/Formats/Impl/XMLRowOutputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/XMLRowOutputFormat.cpp
@@ -245,7 +245,6 @@ void registerOutputFormatProcessorXML(FormatFactory & factory)
     factory.registerOutputFormatProcessor("XML", [](
         WriteBuffer & buf,
         const Block & sample,
-        const Context &,
         FormatFactory::WriteCallback callback,
         const FormatSettings & settings)
     {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Remove `Context` from formats.