### PR TITLE
Make log_to_console.xml log to stderr always.

### DIFF
--- a/dbms/programs/server/config.d/log_to_console.xml
+++ b/dbms/programs/server/config.d/log_to_console.xml
@@ -1,5 +1,6 @@
 <yandex>
     <logger>
+        <console>true</console>
         <log remove="remove"/>
         <errorlog remove="remove"/>
     </logger>


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Make log_to_console.xml always log to stderr, regardless of is it interactive or not.
