### PR TITLE
New ANY JOIN + SEMI, ANTI JOIN for StorageJoin

### DIFF
--- a/dbms/tests/queries/0_stateless/01050_engine_join_crash.sql
+++ b/dbms/tests/queries/0_stateless/01050_engine_join_crash.sql
@@ -1,24 +1,26 @@
 DROP TABLE IF EXISTS testJoinTable;
 
-CREATE TABLE testJoinTable (number UInt64, data String) ENGINE = Join(ANY, INNER, number);
+SET any_join_distinct_right_table_keys = 1;
+SET enable_optimize_predicate_expression = 0;
+
+CREATE TABLE testJoinTable (number UInt64, data String) ENGINE = Join(ANY, INNER, number) SETTINGS any_join_distinct_right_table_keys = 1;
 
 INSERT INTO testJoinTable VALUES (1, '1'), (2, '2'), (3, '3');
 
-SELECT * FROM (SELECT * FROM numbers(10)) INNER JOIN testJoinTable USING number;
+SELECT * FROM (SELECT * FROM numbers(10)) INNER JOIN testJoinTable USING number; -- { serverError 264 }
 SELECT * FROM (SELECT * FROM numbers(10)) INNER JOIN (SELECT * FROM testJoinTable) USING number;
+SELECT * FROM (SELECT * FROM numbers(10)) ANY INNER JOIN testJoinTable USING number;
 SELECT * FROM testJoinTable;
 
 DROP TABLE testJoinTable;
 
 SELECT '-';
-
-SET any_join_distinct_right_table_keys = 1;
  
 DROP TABLE IF EXISTS master;
 DROP TABLE IF EXISTS transaction;
 
 CREATE TABLE transaction (id Int32, value Float64, master_id Int32) ENGINE = MergeTree() ORDER BY id;
-CREATE TABLE master (id Int32, name String) ENGINE = Join (ANY, LEFT, id);
+CREATE TABLE master (id Int32, name String) ENGINE = Join (ANY, LEFT, id) SETTINGS any_join_distinct_right_table_keys = 1;
 
 INSERT INTO master VALUES (1, 'ONE');
 INSERT INTO transaction VALUES (1, 52.5, 1);
@@ -34,7 +36,7 @@ DROP TABLE IF EXISTS some_join;
 DROP TABLE IF EXISTS tbl;
 
 CREATE TABLE tbl (eventDate Date, id String) ENGINE = MergeTree() PARTITION BY tuple() ORDER BY eventDate;
-CREATE TABLE some_join (id String, value String) ENGINE = Join(ANY, LEFT, id);
+CREATE TABLE some_join (id String, value String) ENGINE = Join(ANY, LEFT, id) SETTINGS any_join_distinct_right_table_keys = 1;
 
 SELECT * FROM tbl AS t ANY LEFT JOIN some_join USING (id);
 SELECT * FROM tbl AS t ANY LEFT JOIN some_join AS d USING (id);

--- a/dbms/tests/queries/0_stateless/01051_new_any_join_engine.reference
+++ b/dbms/tests/queries/0_stateless/01051_new_any_join_engine.reference
@@ -1,0 +1,32 @@
+any left
+0	a1	
+1	a2	
+2	a3	b1
+3	a4	
+4	a5	b3
+any inner
+2	a3	b1
+4	a5	b3
+any right
+2	a3	b1
+2	a3	b2
+4	a5	b3
+4	a5	b4
+4	a5	b5
+5		b6
+semi left
+2	a3	b1
+2	a6	b1
+4	a5	b3
+semi right
+2	a3	b1
+2	a3	b2
+4	a5	b3
+4	a5	b4
+4	a5	b5
+anti left
+0	a1	
+1	a2	
+3	a4	
+anti right
+5		b6

--- a/dbms/tests/queries/0_stateless/01051_new_any_join_engine.sql
+++ b/dbms/tests/queries/0_stateless/01051_new_any_join_engine.sql
@@ -1,0 +1,72 @@
+DROP TABLE IF EXISTS t1;
+
+DROP TABLE IF EXISTS any_left_join;
+DROP TABLE IF EXISTS any_inner_join;
+DROP TABLE IF EXISTS any_right_join;
+DROP TABLE IF EXISTS any_full_join;
+
+DROP TABLE IF EXISTS semi_left_join;
+DROP TABLE IF EXISTS semi_right_join;
+DROP TABLE IF EXISTS anti_left_join;
+DROP TABLE IF EXISTS anti_right_join;
+
+CREATE TABLE t1 (x UInt32, str String) engine = Memory;
+
+CREATE TABLE any_left_join (x UInt32, s String) engine = Join(ANY, LEFT, x);
+CREATE TABLE any_inner_join (x UInt32, s String) engine = Join(ANY, INNER, x);
+CREATE TABLE any_right_join (x UInt32, s String) engine = Join(ANY, RIGHT, x);
+
+CREATE TABLE semi_left_join (x UInt32, s String) engine = Join(SEMI, LEFT, x);
+CREATE TABLE semi_right_join (x UInt32, s String) engine = Join(SEMI, RIGHT, x);
+
+CREATE TABLE anti_left_join (x UInt32, s String) engine = Join(ANTI, LEFT, x);
+CREATE TABLE anti_right_join (x UInt32, s String) engine = Join(ANTI, RIGHT, x);
+
+INSERT INTO t1 (x, str) VALUES (0, 'a1'), (1, 'a2'), (2, 'a3'), (3, 'a4'), (4, 'a5');
+
+INSERT INTO any_left_join (x, s) VALUES (2, 'b1'), (2, 'b2'), (4, 'b3'), (4, 'b4'), (4, 'b5'), (5, 'b6');
+INSERT INTO any_inner_join (x, s) VALUES (2, 'b1'), (2, 'b2'), (4, 'b3'), (4, 'b4'), (4, 'b5'), (5, 'b6');
+INSERT INTO any_right_join (x, s) VALUES (2, 'b1'), (2, 'b2'), (4, 'b3'), (4, 'b4'), (4, 'b5'), (5, 'b6');
+
+INSERT INTO semi_left_join (x, s) VALUES (2, 'b1'), (2, 'b2'), (4, 'b3'), (4, 'b4'), (4, 'b5'), (5, 'b6');
+INSERT INTO semi_right_join (x, s) VALUES (2, 'b1'), (2, 'b2'), (4, 'b3'), (4, 'b4'), (4, 'b5'), (5, 'b6');
+INSERT INTO anti_left_join (x, s) VALUES (2, 'b1'), (2, 'b2'), (4, 'b3'), (4, 'b4'), (4, 'b5'), (5, 'b6');
+INSERT INTO anti_right_join (x, s) VALUES (2, 'b1'), (2, 'b2'), (4, 'b3'), (4, 'b4'), (4, 'b5'), (5, 'b6');
+
+SET join_use_nulls = 0;
+SET any_join_distinct_right_table_keys = 0;
+
+SELECT 'any left';
+SELECT * FROM t1 ANY LEFT JOIN any_left_join j USING(x) ORDER BY x, str, s;
+
+SELECT 'any inner';
+SELECT * FROM t1 ANY INNER JOIN any_inner_join j USING(x) ORDER BY x, str, s;
+
+SELECT 'any right';
+SELECT * FROM t1 ANY RIGHT JOIN any_right_join j USING(x) ORDER BY x, str, s;
+
+
+INSERT INTO t1 (x, str) VALUES (2, 'a6');
+
+SELECT 'semi left';
+SELECT * FROM t1 SEMI LEFT JOIN semi_left_join j USING(x) ORDER BY x, str, s;
+
+SELECT 'semi right';
+SELECT * FROM t1 SEMI RIGHT JOIN semi_right_join j USING(x) ORDER BY x, str, s;
+
+SELECT 'anti left';
+SELECT * FROM t1 ANTI LEFT JOIN anti_left_join j USING(x) ORDER BY x, str, s;
+
+SELECT 'anti right';
+SELECT * FROM t1 ANTI RIGHT JOIN anti_right_join j USING(x) ORDER BY x, str, s;
+
+DROP TABLE t1;
+
+DROP TABLE any_left_join;
+DROP TABLE any_inner_join;
+DROP TABLE any_right_join;
+
+DROP TABLE semi_left_join;
+DROP TABLE semi_right_join;
+DROP TABLE anti_left_join;
+DROP TABLE anti_right_join;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Backward Incompatible Change

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Add new ANY JOIN logic for StorageJoin consistent with JOIN operation. Backward incompatible change: to upgrade you need add `SETTINGS any_join_distinct_right_table_keys = 1` to Engine Join tables metadata or remake these tables after upgrade.