### PR TITLE
[ISSUE-8157] incorrect parsing of file extension in URL

### DIFF
--- a/dbms/src/Storages/StorageURL.cpp
+++ b/dbms/src/Storages/StorageURL.cpp
@@ -196,7 +196,7 @@ BlockInputStreams IStorageURLBase::read(const Names & column_names,
         context,
         max_block_size,
         ConnectionTimeouts::getHTTPTimeouts(context),
-        IStorage::chooseCompressionMethod(request_uri.toString(), compression_method));
+        IStorage::chooseCompressionMethod(request_uri.getPath(), compression_method));
 
     auto column_defaults = getColumns().getDefaults();
     if (column_defaults.empty())


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories): 
Fix incorrect parsing of file extension in URL. This fixes #8157