### PR TITLE
Fix make_changelog.py

### DIFF
--- a/utils/make_changelog.py
+++ b/utils/make_changelog.py
@@ -110,9 +110,29 @@ def get_commits_from_branch(repo, branch, base_sha, commits_info, max_pages, tok
     return commits
 
 
+# Get list of commits a specified commit is cherry-picked from. Can return an empty list.
+def parse_original_commits_from_cherry_pick_message(commit_message):
+    prefix = '(cherry picked from commits'
+    pos = commit_message.find(prefix)
+    if pos == -1:
+        prefix = '(cherry picked from commit'
+        pos = commit_message.find(prefix)
+        if pos == -1:
+            return []
+    pos += len(prefix)
+    endpos = commit_message.find(')', pos)
+    if endpos == -1:
+        return []
+    lst = [x.strip() for x in commit_message[pos:endpos].split(',')]
+    lst = [x for x in lst if x]
+    return lst
+
+
 # Use GitHub search api to check if commit from any pull request. Update pull_requests info.
-def find_pull_request_for_commit(commit_sha, pull_requests, token, max_retries, retry_timeout):
-    resp = github_api_get_json('search/issues?q={}+type:pr+repo:{}&sort=created&order=asc'.format(commit_sha, repo), token, max_retries, retry_timeout)
+def find_pull_request_for_commit(commit_info, pull_requests, token, max_retries, retry_timeout):
+    commits = [commit_info['sha']] + parse_original_commits_from_cherry_pick_message(commit_info['commit']['message'])
+    query = 'search/issues?q={}+type:pr+repo:{}&sort=created&order=asc'.format(' '.join(commits), repo)
+    resp = github_api_get_json(query, token, max_retries, retry_timeout)
 
     found = False
     for item in resp['items']:
@@ -130,14 +150,14 @@ def find_pull_request_for_commit(commit_sha, pull_requests, token, max_retries, 
 
 
 # Find pull requests from list of commits. If no pull request found, add commit to not_found_commits list.
-def find_pull_requests(commits, token, max_retries, retry_timeout):
+def find_pull_requests(commits, commits_info, token, max_retries, retry_timeout):
     not_found_commits = []
     pull_requests = {}
 
     for i, commit in enumerate(commits):
         if (i + 1) % 10 == 0:
             logging.info('Processed %d commits', i + 1)
-        if not find_pull_request_for_commit(commit, pull_requests, token, max_retries, retry_timeout):
+        if not find_pull_request_for_commit(commits_info[commit], pull_requests, token, max_retries, retry_timeout):
             not_found_commits.append(commit)
 
     return not_found_commits, pull_requests
@@ -410,7 +430,7 @@ def make_changelog(new_tag, prev_tag, pull_requests_nums, repo, repo_folder, sta
 
         if not is_pull_requests_loaded:
             logging.info('Searching for pull requests using github api.')
-            unknown_commits, pull_requests = find_pull_requests(commits, token, max_retries, retry_timeout)
+            unknown_commits, pull_requests = find_pull_requests(commits, commits_info, token, max_retries, retry_timeout)
             state['unknown_commits'] = unknown_commits
             state['pull_requests'] = pull_requests
     else:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Non-significant (changelog entry is not needed)

`make_changelog.py` now considers not only release PR but also PRs which were cherry-picked to the release branch.