### PR TITLE
Perf test format io without disk

### DIFF
--- a/dbms/src/Storages/StorageFile.cpp
+++ b/dbms/src/Storages/StorageFile.cpp
@@ -108,7 +108,8 @@ static void checkCreationIsAllowed(const Context & context_global, const std::st
     if (context_global.getApplicationType() != Context::ApplicationType::SERVER)
         return;
 
-    if (!startsWith(table_path, db_dir_path))
+    /// "/dev/null" is allowed for perf testing
+    if (!startsWith(table_path, db_dir_path) && table_path != "/dev/null")
         throw Exception("Part path " + table_path + " is not inside " + db_dir_path, ErrorCodes::DATABASE_ACCESS_DENIED);
 
     Poco::File table_path_poco_file = Poco::File(table_path);

--- a/dbms/tests/performance/select_format.xml
+++ b/dbms/tests/performance/select_format.xml
@@ -1,7 +1,7 @@
 <test>
     <type>loop</type>
 
-    <create_query>CREATE TABLE IF NOT EXISTS table_{format} ENGINE = File({format}) AS test.hits</create_query>
+    <create_query>CREATE TABLE IF NOT EXISTS table_{format} ENGINE = File({format}, '/dev/null') AS test.hits</create_query>
 
     <stop_conditions>
         <all_of>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):

support `StorageFile(<format>, null) ` to deser block into given format file without actually write to disk. It's used to perf test format parsers.

# update

It doesn't have noticeable improvement compared to using `/dev/null` as backend file. Revert and whitelist `/dev/null` instead.