### PR TITLE
refs #8443 fix logging

### DIFF
--- a/dbms/programs/local/LocalServer.cpp
+++ b/dbms/programs/local/LocalServer.cpp
@@ -76,7 +76,7 @@ void LocalServer::initialize(Poco::Util::Application & self)
     if (config().has("logger") || config().has("logger.level") || config().has("logger.log"))
     {
         // sensitive data rules are not used here
-        buildLoggers(config(), logger());
+        buildLoggers(config(), logger(), self.commandName());
     }
     else
     {

--- a/dbms/programs/odbc-bridge/ODBCBridge.cpp
+++ b/dbms/programs/odbc-bridge/ODBCBridge.cpp
@@ -124,7 +124,7 @@ void ODBCBridge::initialize(Application & self)
 
     config().setString("logger", "ODBCBridge");
 
-    buildLoggers(config(), logger());
+    buildLoggers(config(), logger(), self.commandName());
 
     log = &logger();
     hostname = config().getString("listen-host", "localhost");

--- a/libs/libdaemon/src/BaseDaemon.cpp
+++ b/libs/libdaemon/src/BaseDaemon.cpp
@@ -686,7 +686,7 @@ void BaseDaemon::initialize(Application & self)
     }
 
     // sensitive data masking rules are not used here
-    buildLoggers(config(), logger());
+    buildLoggers(config(), logger(), self.commandName());
 
     if (is_daemon)
     {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Using command name of the running clickhouse process when sending logs to syslog. In previous versions, empty string was used instead of command name.