### PR TITLE
Fixed performance degradation of "boundingRatio" aggregate function

### DIFF
--- a/dbms/src/AggregateFunctions/AggregateFunctionBoundingRatio.h
+++ b/dbms/src/AggregateFunctions/AggregateFunctionBoundingRatio.h
@@ -129,9 +129,9 @@ public:
 
     void add(AggregateDataPtr place, const IColumn ** columns, const size_t row_num, Arena *) const override
     {
-        /// TODO Inefficient.
-        const auto x = applyVisitor(FieldVisitorConvertToNumber<Float64>(), (*columns[0])[row_num]);
-        const auto y = applyVisitor(FieldVisitorConvertToNumber<Float64>(), (*columns[1])[row_num]);
+        /// NOTE Slightly inefficient.
+        const auto x = columns[0]->getFloat64(row_num);
+        const auto y = columns[1]->getFloat64(row_num);
         data(place).add(x, y);
     }
 

--- a/dbms/src/AggregateFunctions/IAggregateFunction.h
+++ b/dbms/src/AggregateFunctions/IAggregateFunction.h
@@ -131,9 +131,7 @@ public:
     /** Contains a loop with calls to "add" function. You can collect arguments into array "places"
       *  and do a single call to "addBatch" for devirtualization and inlining.
       */
-    virtual void
-    addBatch(size_t batch_size, AggregateDataPtr * places, size_t place_offset, const IColumn ** columns, Arena * arena)
-        const = 0;
+    virtual void addBatch(size_t batch_size, AggregateDataPtr * places, size_t place_offset, const IColumn ** columns, Arena * arena) const = 0;
 
     /** The same for single place.
       */
@@ -144,9 +142,8 @@ public:
       *  -Array combinator. It might also be used generally to break data dependency when array
       *  "places" contains a large number of same values consecutively.
       */
-    virtual void
-    addBatchArray(size_t batch_size, AggregateDataPtr * places, size_t place_offset, const IColumn ** columns, const UInt64 * offsets, Arena * arena)
-        const = 0;
+    virtual void addBatchArray(
+        size_t batch_size, AggregateDataPtr * places, size_t place_offset, const IColumn ** columns, const UInt64 * offsets, Arena * arena) const = 0;
 
     const DataTypes & getArgumentTypes() const { return argument_types; }
     const Array & getParameters() const { return parameters; }

--- a/dbms/src/Dictionaries/MongoDBDictionarySource.cpp
+++ b/dbms/src/Dictionaries/MongoDBDictionarySource.cpp
@@ -316,7 +316,7 @@ BlockInputStreamPtr MongoDBDictionarySource::loadKeys(const Columns & key_column
 
                 case AttributeUnderlyingType::utFloat32:
                 case AttributeUnderlyingType::utFloat64:
-                    key.add(attr.second.name, applyVisitor(FieldVisitorConvertToNumber<Float64>(), (*key_columns[attr.first])[row_idx]));
+                    key.add(attr.second.name, key_columns[attr.first]->getFloat64(row_idx));
                     break;
 
                 case AttributeUnderlyingType::utString:


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Performance degradation is not yet in release. Do not include in changelog.

Detailed description (optional):
It was caused by changes in function inlining that depend on compiler version and the inlining of other functions in the covering scope.