### PR TITLE
MergeTree part-level insertion deduplication

### DIFF
--- a/docs/en/engines/table_engines/mergetree_family/mergetree.md
+++ b/docs/en/engines/table_engines/mergetree_family/mergetree.md
@@ -95,6 +95,8 @@ For a description of parameters, see the [CREATE query description](../../../sql
     -   `write_final_mark` — Enables or disables writing the final index mark at the end of data part (after the last byte). Default value: 1. Don’t turn it off.
     -   `merge_max_block_size` — Maximum number of rows in block for merge operations. Default value: 8192.
     -   `storage_policy` — Storage policy. See [Using Multiple Block Devices for Data Storage](#table_engine-mergetree-multiple-volumes).
+    - `enable_insertion_deduplication` - Enable block insertion deduplication. Default value: 0.
+    - `insertion_deduplication_window` - How many last blocks of hashes should be kept (older blocks will be deleted). Default value: 100.
 
 **Example of Sections Setting**
 

--- a/src/Storages/MergeTree/MergeTreeBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/MergeTreeBlockOutputStream.cpp
@@ -22,7 +22,9 @@ void MergeTreeBlockOutputStream::write(const Block & block)
         Stopwatch watch;
 
         MergeTreeData::MutableDataPartPtr part = storage.writer.writeTempPart(current_block);
-        storage.renameTempPartAndAdd(part, &storage.increment);
+        bool added = storage.renameTempPartAndAdd(part, &storage.increment);
+        if (!added)
+            continue;
 
         PartLog::addNewPart(storage.global_context, part, watch.elapsed());
 

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -446,7 +446,8 @@ public:
     /// If out_transaction != nullptr, adds the part in the PreCommitted state (the part will be added to the
     /// active set later with out_transaction->commit()).
     /// Else, commits the part immediately.
-    void renameTempPartAndAdd(MutableDataPartPtr & part, SimpleIncrement * increment = nullptr, Transaction * out_transaction = nullptr);
+    /// Returns false if part was deduplicated (not inserted because it's a duplicate of previously inserted part).
+    bool renameTempPartAndAdd(MutableDataPartPtr & part, SimpleIncrement * increment = nullptr, Transaction * out_transaction = nullptr);
 
     /// The same as renameTempPartAndAdd but the block range of the part can contain existing parts.
     /// Returns all parts covered by the added part (in ascending order).
@@ -916,6 +917,16 @@ protected:
 
     bool areBackgroundMovesNeeded() const;
 
+    /// Load insertion history
+    void histLoad();
+
+    /// Find and set in history
+    /// Return true if block_id in history
+    bool histFindAndAdd(const String & block_id);
+
+    /// Drop a partition related records in history
+    void histDropPartition(const String & partition_id);
+
 private:
     /// RAII Wrapper for atomic work with currently moving parts
     /// Acuire them in constructor and remove them in destructor
@@ -940,6 +951,16 @@ private:
     CurrentlyMovingPartsTagger checkPartsForMove(const DataPartsVector & parts, SpacePtr space);
 
     bool canUsePolymorphicParts(const MergeTreeSettings & settings, String * out_reason);
+
+    /// Insertion history
+    mutable std::mutex hist_mutex;
+    std::list<String> hist_id_list;
+    std::unordered_set<String> hist_id_set;
+    std::unique_ptr<WriteBufferFromFile> hist_writer;
+    UInt64 hist_cnt;
+
+    /// dump history to file
+    void histDump();
 };
 
 }

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -48,6 +48,8 @@ struct MergeTreeSettings : public SettingsCollection<MergeTreeSettings>
     M(SettingUInt64, parts_to_throw_insert, 300, "If more than this number active parts in single partition, throw 'Too many parts ...' exception.", 0) \
     M(SettingUInt64, max_delay_to_insert, 1, "Max delay of inserting data into MergeTree table in seconds, if there are a lot of unmerged parts in single partition.", 0) \
     M(SettingUInt64, max_parts_in_total, 100000, "If more than this number active parts in all partitions in total, throw 'Too many parts ...' exception.", 0) \
+    M(SettingBool, enable_insertion_deduplication, 0, "Enable block insertion deduplication.", 0) \
+    M(SettingUInt64, insertion_deduplication_window, 100, "How many last blocks of hashes should be kept (old blocks will be deleted).", 0) \
     \
     /** Replication settings. */ \
     M(SettingUInt64, replicated_deduplication_window, 100, "How many last blocks of hashes should be kept in ZooKeeper (old blocks will be deleted).", 0) \

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -1001,6 +1001,7 @@ void StorageMergeTree::dropPartition(const ASTPtr & partition, bool detach, cons
         auto lock = lockExclusively(context.getCurrentQueryId());
 
         String partition_id = getPartitionIDFromQuery(partition, context);
+        histDropPartition(partition_id);
 
         /// TODO: should we include PreComitted parts like in Replicated case?
         auto parts_to_remove = getDataPartsVectorInPartition(MergeTreeDataPartState::Committed, partition_id);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Added part-level insertion deduplication for MergeTree just like ReplicatedMergeTree.
