### PR TITLE
Fix crash in StorageJoin (add restriction)

### DIFF
--- a/dbms/src/Storages/StorageJoin.cpp
+++ b/dbms/src/Storages/StorageJoin.cpp
@@ -10,6 +10,7 @@
 #include <Interpreters/joinDispatch.h>
 #include <Interpreters/AnalyzedJoin.h>
 #include <Common/assert_cast.h>
+#include <Common/quoteString.h>
 
 #include <Poco/String.h>    /// toLower
 #include <Poco/File.h>

--- a/dbms/src/Storages/StorageJoin.cpp
+++ b/dbms/src/Storages/StorageJoin.cpp
@@ -73,8 +73,9 @@ HashJoinPtr StorageJoin::getJoin(std::shared_ptr<AnalyzedJoin> analyzed_join) co
     if (kind != analyzed_join->kind() || strictness != analyzed_join->strictness())
         throw Exception("Table " + table_name + " has incompatible type of JOIN.", ErrorCodes::INCOMPATIBLE_TYPE_OF_JOIN);
 
-    if (analyzed_join->forceNullableRight() && !use_nulls)
-        throw Exception("Table " + table_name + " need join_use_nulls settings to support LEFT or FULL JOIN with join_use_nulls.",
+    if ((analyzed_join->forceNullableRight() && !use_nulls) ||
+        (!analyzed_join->forceNullableRight() && isLeftOrFull(analyzed_join->kind()) && use_nulls))
+        throw Exception("Table " + table_name + " needs the same join_use_nulls setting as present in LEFT or FULL JOIN.",
                         ErrorCodes::INCOMPATIBLE_TYPE_OF_JOIN);
 
     /// TODO: check key columns

--- a/dbms/src/Storages/StorageJoin.cpp
+++ b/dbms/src/Storages/StorageJoin.cpp
@@ -71,11 +71,11 @@ void StorageJoin::truncate(const ASTPtr &, const Context &, TableStructureWriteL
 HashJoinPtr StorageJoin::getJoin(std::shared_ptr<AnalyzedJoin> analyzed_join) const
 {
     if (kind != analyzed_join->kind() || strictness != analyzed_join->strictness())
-        throw Exception("Table " + table_name + " has incompatible type of JOIN.", ErrorCodes::INCOMPATIBLE_TYPE_OF_JOIN);
+        throw Exception("Table " + backQuote(table_name) + " has incompatible type of JOIN.", ErrorCodes::INCOMPATIBLE_TYPE_OF_JOIN);
 
     if ((analyzed_join->forceNullableRight() && !use_nulls) ||
         (!analyzed_join->forceNullableRight() && isLeftOrFull(analyzed_join->kind()) && use_nulls))
-        throw Exception("Table " + table_name + " needs the same join_use_nulls setting as present in LEFT or FULL JOIN.",
+        throw Exception("Table " + backQuote(table_name) + " needs the same join_use_nulls setting as present in LEFT or FULL JOIN.",
                         ErrorCodes::INCOMPATIBLE_TYPE_OF_JOIN);
 
     /// TODO: check key columns

--- a/dbms/src/Storages/StorageJoin.cpp
+++ b/dbms/src/Storages/StorageJoin.cpp
@@ -73,6 +73,10 @@ HashJoinPtr StorageJoin::getJoin(std::shared_ptr<AnalyzedJoin> analyzed_join) co
     if (kind != analyzed_join->kind() || strictness != analyzed_join->strictness())
         throw Exception("Table " + table_name + " has incompatible type of JOIN.", ErrorCodes::INCOMPATIBLE_TYPE_OF_JOIN);
 
+    if (analyzed_join->forceNullableRight() && !use_nulls)
+        throw Exception("Table " + table_name + " need join_use_nulls settings to support LEFT or FULL JOIN with join_use_nulls.",
+                        ErrorCodes::INCOMPATIBLE_TYPE_OF_JOIN);
+
     /// TODO: check key columns
 
     /// Some HACK to remove wrong names qualifiers: table.column -> column.

--- a/dbms/tests/queries/0_stateless/01051_all_join_engine.reference
+++ b/dbms/tests/queries/0_stateless/01051_all_join_engine.reference
@@ -30,3 +30,48 @@ full
 4	a5	b4
 4	a5	b5
 5		b6
+inner (join_use_nulls mix)
+2	a3	b1
+2	a3	b2
+4	a5	b3
+4	a5	b4
+4	a5	b5
+right (join_use_nulls mix)
+2	a3	b1
+2	a3	b2
+4	a5	b3
+4	a5	b4
+4	a5	b5
+5	\N	b6
+left (join_use_nulls)
+0	a1	\N
+1	a2	\N
+2	a3	b1
+2	a3	b2
+3	a4	\N
+4	a5	b3
+4	a5	b4
+4	a5	b5
+inner (join_use_nulls)
+2	a3	b1
+2	a3	b2
+4	a5	b3
+4	a5	b4
+4	a5	b5
+right (join_use_nulls)
+2	a3	b1
+2	a3	b2
+4	a5	b3
+4	a5	b4
+4	a5	b5
+5	\N	b6
+full (join_use_nulls)
+0	a1	\N
+1	a2	\N
+2	a3	b1
+2	a3	b2
+3	a4	\N
+4	a5	b3
+4	a5	b4
+4	a5	b5
+5	\N	b6

--- a/dbms/tests/queries/0_stateless/01051_all_join_engine.reference
+++ b/dbms/tests/queries/0_stateless/01051_all_join_engine.reference
@@ -75,3 +75,16 @@ full (join_use_nulls)
 4	a5	b4
 4	a5	b5
 5	\N	b6
+inner (join_use_nulls mix2)
+2	a3	b1
+2	a3	b2
+4	a5	b3
+4	a5	b4
+4	a5	b5
+right (join_use_nulls mix2)
+2	a3	b1
+2	a3	b2
+4	a5	b3
+4	a5	b4
+4	a5	b5
+5		b6

--- a/dbms/tests/queries/0_stateless/01051_all_join_engine.sql
+++ b/dbms/tests/queries/0_stateless/01051_all_join_engine.sql
@@ -33,20 +33,43 @@ SELECT * FROM t1 RIGHT JOIN right_join j USING(x) ORDER BY x, str, s;
 SELECT 'full';
 SELECT * FROM t1 FULL JOIN full_join j USING(x) ORDER BY x, str, s;
 
--- TODO
--- SET join_use_nulls = 1;
--- 
--- SELECT 'left (join_use_nulls)';
--- SELECT * FROM t1 LEFT JOIN left_join j USING(x) ORDER BY x, str, s;
--- 
--- SELECT 'inner (join_use_nulls)';
--- SELECT * FROM t1 INNER JOIN inner_join j USING(x) ORDER BY x, str, s;
--- 
--- SELECT 'right (join_use_nulls)';
--- SELECT * FROM t1 RIGHT JOIN right_join j USING(x) ORDER BY x, str, s;
--- 
--- SELECT 'full (join_use_nulls)';
--- SELECT * FROM t1 FULL JOIN full_join j USING(x) ORDER BY x, str, s;
+SET join_use_nulls = 1;
+
+SELECT * FROM t1 LEFT JOIN left_join j USING(x) ORDER BY x, str, s; -- { serverError 264 }
+SELECT * FROM t1 FULL JOIN full_join j USING(x) ORDER BY x, str, s; -- { serverError 264 }
+
+SELECT 'inner (join_use_nulls mix)';
+SELECT * FROM t1 INNER JOIN inner_join j USING(x) ORDER BY x, str, s;
+
+SELECT 'right (join_use_nulls mix)';
+SELECT * FROM t1 RIGHT JOIN right_join j USING(x) ORDER BY x, str, s;
+
+DROP TABLE left_join;
+DROP TABLE inner_join;
+DROP TABLE right_join;
+DROP TABLE full_join;
+
+CREATE TABLE left_join (x UInt32, s String) engine = Join(ALL, LEFT, x) SETTINGS join_use_nulls = 1;
+CREATE TABLE inner_join (x UInt32, s String) engine = Join(ALL, INNER, x) SETTINGS join_use_nulls = 1;
+CREATE TABLE right_join (x UInt32, s String) engine = Join(ALL, RIGHT, x) SETTINGS join_use_nulls = 1;
+CREATE TABLE full_join (x UInt32, s String) engine = Join(ALL, FULL, x) SETTINGS join_use_nulls = 1;
+
+INSERT INTO left_join (x, s) VALUES (2, 'b1'), (2, 'b2'), (4, 'b3'), (4, 'b4'), (4, 'b5'), (5, 'b6');
+INSERT INTO inner_join (x, s) VALUES (2, 'b1'), (2, 'b2'), (4, 'b3'), (4, 'b4'), (4, 'b5'), (5, 'b6');
+INSERT INTO right_join (x, s) VALUES (2, 'b1'), (2, 'b2'), (4, 'b3'), (4, 'b4'), (4, 'b5'), (5, 'b6');
+INSERT INTO full_join (x, s) VALUES (2, 'b1'), (2, 'b2'), (4, 'b3'), (4, 'b4'), (4, 'b5'), (5, 'b6');
+
+SELECT 'left (join_use_nulls)';
+SELECT * FROM t1 LEFT JOIN left_join j USING(x) ORDER BY x, str, s;
+
+SELECT 'inner (join_use_nulls)';
+SELECT * FROM t1 INNER JOIN inner_join j USING(x) ORDER BY x, str, s;
+
+SELECT 'right (join_use_nulls)';
+SELECT * FROM t1 RIGHT JOIN right_join j USING(x) ORDER BY x, str, s;
+
+SELECT 'full (join_use_nulls)';
+SELECT * FROM t1 FULL JOIN full_join j USING(x) ORDER BY x, str, s;
 
 DROP TABLE t1;
 

--- a/dbms/tests/queries/0_stateless/01051_all_join_engine.sql
+++ b/dbms/tests/queries/0_stateless/01051_all_join_engine.sql
@@ -71,6 +71,17 @@ SELECT * FROM t1 RIGHT JOIN right_join j USING(x) ORDER BY x, str, s;
 SELECT 'full (join_use_nulls)';
 SELECT * FROM t1 FULL JOIN full_join j USING(x) ORDER BY x, str, s;
 
+SET join_use_nulls = 0;
+
+SELECT * FROM t1 LEFT JOIN left_join j USING(x) ORDER BY x, str, s; -- { serverError 264 }
+SELECT * FROM t1 FULL JOIN full_join j USING(x) ORDER BY x, str, s; -- { serverError 264 }
+
+SELECT 'inner (join_use_nulls mix2)';
+SELECT * FROM t1 INNER JOIN inner_join j USING(x) ORDER BY x, str, s;
+
+SELECT 'right (join_use_nulls mix2)';
+SELECT * FROM t1 RIGHT JOIN right_join j USING(x) ORDER BY x, str, s;
+
 DROP TABLE t1;
 
 DROP TABLE left_join;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Do not crash on LEFT or FULL JOIN with Join engine and unsupported join_use_nulls settings.

Detailed description (optional):
You have to create engine Join with correct join_use_nulls for LEFT and FULL JOINs.