### PR TITLE
Removed "pie" code generation that gcc occasionally brings by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,8 +248,16 @@ endif ()
 string (TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_UC)
 set (CMAKE_POSTFIX_VARIABLE "CMAKE_${CMAKE_BUILD_TYPE_UC}_POSTFIX")
 
-if (NOT MAKE_STATIC_LIBRARIES)
-    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+if (MAKE_STATIC_LIBRARIES)
+    set (CMAKE_POSITION_INDEPENDENT_CODE OFF)
+    if (OS_LINUX)
+        # Slightly more efficient code may be generated
+        set (CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -no-pie")
+        set (CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -no-pie")
+        set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-no-pie")
+    endif ()
+else ()
+    set (CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif ()
 
 # Using "include-what-you-use" tool.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,9 +251,9 @@ set (CMAKE_POSTFIX_VARIABLE "CMAKE_${CMAKE_BUILD_TYPE_UC}_POSTFIX")
 if (MAKE_STATIC_LIBRARIES)
     set (CMAKE_POSITION_INDEPENDENT_CODE OFF)
     if (OS_LINUX)
-        # Slightly more efficient code may be generated
-        set (CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -no-pie")
-        set (CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -no-pie")
+        # Slightly more efficient code can be generated
+        set (CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -fno-pie")
+        set (CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -fno-pie")
         set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-no-pie")
     endif ()
 else ()


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Removed "pie" code generation that gcc from Debian packages occasionally brings by default.

Detailed description (optional):
After upgrading from gcc-8 to gcc-9 in our CI about half a year ago, occasionally our code starts to be generated with "position independent executable" option. This leads to less efficient addressing of global const tables. We saw slight performance degradation in our CI but decided to not pay attention.