### PR TITLE
Add groupBit* aggregation function to the type SimpleAggregationFunction

### DIFF
--- a/dbms/src/DataTypes/DataTypeCustomSimpleAggregateFunction.cpp
+++ b/dbms/src/DataTypes/DataTypeCustomSimpleAggregateFunction.cpp
@@ -30,7 +30,7 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-static const std::vector<String> supported_functions{"any", "anyLast", "min", "max", "sum"};
+static const std::vector<String> supported_functions{"any", "anyLast", "min", "max", "sum", "groupBitAnd", "groupBitOr", "groupBitXor"};
 
 
 String DataTypeCustomSimpleAggregateFunction::getName() const

--- a/dbms/tests/queries/0_stateless/00915_simple_aggregate_function.reference
+++ b/dbms/tests/queries/0_stateless/00915_simple_aggregate_function.reference
@@ -39,6 +39,6 @@ SimpleAggregateFunction(sum, Double)
 7	14
 8	16
 9	18
-1	1	2	2.2.2.2
-10	2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222	20	20.20.20.20
-SimpleAggregateFunction(anyLast, Nullable(String))	SimpleAggregateFunction(anyLast, LowCardinality(Nullable(String)))	SimpleAggregateFunction(anyLast, IPv4)
+1	1	2	2.2.2.2	3
+10	2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222	20	20.20.20.20	5
+SimpleAggregateFunction(anyLast, Nullable(String))	SimpleAggregateFunction(anyLast, LowCardinality(Nullable(String)))	SimpleAggregateFunction(anyLast, IPv4)	SimpleAggregateFunction(groupBitOr, UInt32)

--- a/dbms/tests/queries/0_stateless/00915_simple_aggregate_function.sql
+++ b/dbms/tests/queries/0_stateless/00915_simple_aggregate_function.sql
@@ -19,14 +19,20 @@ select * from simple;
 -- complex types
 drop table if exists simple;
 
-create table simple (id UInt64,nullable_str SimpleAggregateFunction(anyLast,Nullable(String)),low_str SimpleAggregateFunction(anyLast,LowCardinality(Nullable(String))),ip SimpleAggregateFunction(anyLast,IPv4)) engine=AggregatingMergeTree order by id;
-insert into simple values(1,'1','1','1.1.1.1');
-insert into simple values(1,null,'2','2.2.2.2');
+create table simple (
+    id UInt64,
+    nullable_str SimpleAggregateFunction(anyLast,Nullable(String)),
+    low_str SimpleAggregateFunction(anyLast,LowCardinality(Nullable(String))),
+    ip SimpleAggregateFunction(anyLast,IPv4),
+    status SimpleAggregateFunction(groupBitOr, UInt32)
+) engine=AggregatingMergeTree order by id;
+insert into simple values(1,'1','1','1.1.1.1', 1);
+insert into simple values(1,null,'2','2.2.2.2', 2);
 -- String longer then MAX_SMALL_STRING_SIZE (actual string length is 100)
-insert into simple values(10,'10','10','10.10.10.10');
-insert into simple values(10,'2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222','20','20.20.20.20');
+insert into simple values(10,'10','10','10.10.10.10', 4);
+insert into simple values(10,'2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222','20','20.20.20.20', 1);
 
 select * from simple final;
-select toTypeName(nullable_str),toTypeName(low_str),toTypeName(ip) from simple limit 1;
+select toTypeName(nullable_str),toTypeName(low_str),toTypeName(ip),toTypeName(status) from simple limit 1;
 
 drop table simple;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):

Add `groupBit*` functions for the `SimpleAggregationFunction` type