### PR TITLE
Fix it removes PID file by mistake In Daemon

### DIFF
--- a/libs/libdaemon/include/daemon/BaseDaemon.h
+++ b/libs/libdaemon/include/daemon/BaseDaemon.h
@@ -166,6 +166,15 @@ protected:
     {
         std::string file;
 
+        /// track weather the process really write a PID file
+        /// If the process write a PID file, it's value will be set to true.
+        /// If there is a old running process, the daemon will not start,
+        /// and the process will not write a PID file. In this case it's
+        /// value will be false.
+        /// clear() will check the value, and it will only remove the file
+        /// when it's valeu is true.
+        bool pid_created = false;
+
         /// Создать объект, не создавая PID файл
         PID() {}
 

--- a/libs/libdaemon/src/BaseDaemon.cpp
+++ b/libs/libdaemon/src/BaseDaemon.cpp
@@ -835,6 +835,7 @@ void BaseDaemon::PID::seed(const std::string & file_)
         s << getpid();
         if (static_cast<ssize_t>(s.str().size()) != write(fd, s.str().c_str(), s.str().size()))
             throw Poco::Exception("Cannot write to pid file.");
+        pid_created = true;
     }
     catch (...)
     {
@@ -847,7 +848,7 @@ void BaseDaemon::PID::seed(const std::string & file_)
 
 void BaseDaemon::PID::clear()
 {
-    if (!file.empty())
+    if (!file.empty() && pid_created)
     {
         Poco::File(file).remove();
         file.clear();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

In Daemon mode, when the user start a new clickhouse, if there is old
runing process and the pid is same with the value in PID file, it will
not start. However it also remove the PID file of the old runing process by
mistake.

In this fix, it will not remove the pid file of old runing process when
it start failed.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Fixed the issue when pid file of another running clickhouse-server may be deleted.