### PR TITLE
Calculate stack trace for std::exception (experimental)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,7 +210,7 @@ set (CMAKE_C_FLAGS_DEBUG                 "${CMAKE_C_FLAGS_DEBUG} -O0 -g3 -ggdb3 
 
 if (COMPILER_CLANG)
     # Exception unwinding doesn't work in clang release build without this option
-    # TODO investigate if contrib/libcxxabi is out of date
+    # TODO investigate that
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-omit-frame-pointer")
 endif ()

--- a/contrib/libcxx-cmake/CMakeLists.txt
+++ b/contrib/libcxx-cmake/CMakeLists.txt
@@ -48,7 +48,9 @@ target_include_directories(cxx SYSTEM BEFORE PUBLIC $<BUILD_INTERFACE:${LIBCXX_S
 target_compile_definitions(cxx PRIVATE -D_LIBCPP_BUILDING_LIBRARY -DLIBCXX_BUILDING_LIBCXXABI)
 
 # Enable capturing stack traces for all exceptions.
-target_compile_definitions(cxx PUBLIC -DSTD_EXCEPTION_HAS_STACK_TRACE=1)
+if (USE_UNWIND)
+    target_compile_definitions(cxx PUBLIC -DSTD_EXCEPTION_HAS_STACK_TRACE=1)
+endif ()
 
 target_compile_options(cxx PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>)
 

--- a/contrib/libcxx-cmake/CMakeLists.txt
+++ b/contrib/libcxx-cmake/CMakeLists.txt
@@ -47,6 +47,9 @@ add_library(cxx ${SRCS})
 target_include_directories(cxx SYSTEM BEFORE PUBLIC $<BUILD_INTERFACE:${LIBCXX_SOURCE_DIR}/include>)
 target_compile_definitions(cxx PRIVATE -D_LIBCPP_BUILDING_LIBRARY -DLIBCXX_BUILDING_LIBCXXABI)
 
+# Enable capturing stack traces for all exceptions.
+target_compile_definitions(cxx PUBLIC -DSTD_EXCEPTION_HAS_STACK_TRACE=1)
+
 target_compile_options(cxx PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>)
 
 check_cxx_compiler_flag(-Wreserved-id-macro HAVE_WARNING_RESERVED_ID_MACRO)

--- a/contrib/libcxxabi-cmake/CMakeLists.txt
+++ b/contrib/libcxxabi-cmake/CMakeLists.txt
@@ -32,6 +32,9 @@ target_compile_definitions(cxxabi PRIVATE -D_LIBCPP_BUILDING_LIBRARY)
 target_compile_options(cxxabi PRIVATE -nostdinc++ -fno-sanitize=undefined -Wno-macro-redefined) # If we don't disable UBSan, infinite recursion happens in dynamic_cast.
 target_link_libraries(cxxabi PUBLIC ${EXCEPTION_HANDLING_LIBRARY})
 
+# Enable capturing stack traces for all exceptions.
+target_compile_definitions(cxxabi PUBLIC -DSTD_EXCEPTION_HAS_STACK_TRACE=1)
+
 install(
     TARGETS cxxabi
     EXPORT global

--- a/contrib/libcxxabi-cmake/CMakeLists.txt
+++ b/contrib/libcxxabi-cmake/CMakeLists.txt
@@ -33,7 +33,9 @@ target_compile_options(cxxabi PRIVATE -nostdinc++ -fno-sanitize=undefined -Wno-m
 target_link_libraries(cxxabi PUBLIC ${EXCEPTION_HANDLING_LIBRARY})
 
 # Enable capturing stack traces for all exceptions.
-target_compile_definitions(cxxabi PUBLIC -DSTD_EXCEPTION_HAS_STACK_TRACE=1)
+if (USE_UNWIND)
+    target_compile_definitions(cxxabi PUBLIC -DSTD_EXCEPTION_HAS_STACK_TRACE=1)
+endif ()
 
 install(
     TARGETS cxxabi

--- a/dbms/programs/client/Client.cpp
+++ b/dbms/programs/client/Client.cpp
@@ -300,7 +300,7 @@ private:
                 && std::string::npos == embedded_stack_trace_pos)
             {
                 std::cerr << "Stack trace:" << std::endl
-                    << e.getStackTrace().toString();
+                    << e.getStackTraceString();
             }
 
             /// If exception code isn't zero, we should return non-zero return code anyway.
@@ -714,7 +714,7 @@ private:
 
                         if (config().getBool("stacktrace", false))
                             std::cerr << "Stack trace:" << std::endl
-                                      << e.getStackTrace().toString() << std::endl;
+                                      << e.getStackTraceString() << std::endl;
 
                         std::cerr << std::endl;
 

--- a/dbms/programs/odbc-bridge/MainHandler.cpp
+++ b/dbms/programs/odbc-bridge/MainHandler.cpp
@@ -115,7 +115,7 @@ void ODBCHandler::handleRequest(Poco::Net::HTTPServerRequest & request, Poco::Ne
     catch (const Exception & ex)
     {
         process_error("Invalid 'columns' parameter in request body '" + ex.message() + "'");
-        LOG_WARNING(log, ex.getStackTrace().toString());
+        LOG_WARNING(log, ex.getStackTraceString());
         return;
     }
 

--- a/dbms/programs/performance-test/PerformanceTest.cpp
+++ b/dbms/programs/performance-test/PerformanceTest.cpp
@@ -337,7 +337,7 @@ void PerformanceTest::runQueries(
         {
             statistics.exception = "Code: " + std::to_string(e.code()) + ", e.displayText() = " + e.displayText();
             LOG_WARNING(log, "Code: " << e.code() << ", e.displayText() = " << e.displayText()
-                << ", Stack trace:\n\n" << e.getStackTrace().toString());
+                << ", Stack trace:\n\n" << e.getStackTraceString());
         }
 
         if (!statistics.got_SIGINT)

--- a/dbms/src/Common/ErrorCodes.cpp
+++ b/dbms/src/Common/ErrorCodes.cpp
@@ -138,7 +138,6 @@ namespace ErrorCodes
     extern const int FUNCTION_IS_SPECIAL = 129;
     extern const int CANNOT_READ_ARRAY_FROM_TEXT = 130;
     extern const int TOO_LARGE_STRING_SIZE = 131;
-    extern const int CANNOT_CREATE_TABLE_FROM_METADATA = 132;
     extern const int AGGREGATE_FUNCTION_DOESNT_ALLOW_PARAMETERS = 133;
     extern const int PARAMETERS_TO_AGGREGATE_FUNCTIONS_MUST_BE_LITERALS = 134;
     extern const int ZERO_ARRAY_OR_TUPLE_INDEX = 135;
@@ -474,7 +473,6 @@ namespace ErrorCodes
     extern const int NOT_ENOUGH_PRIVILEGES = 497;
     extern const int LIMIT_BY_WITH_TIES_IS_NOT_SUPPORTED = 498;
     extern const int S3_ERROR = 499;
-    extern const int CANNOT_CREATE_DICTIONARY_FROM_METADATA = 500;
     extern const int CANNOT_CREATE_DATABASE = 501;
     extern const int CANNOT_SIGQUEUE = 502;
     extern const int AGGREGATE_FUNCTION_THROW = 503;

--- a/dbms/src/Common/Exception.cpp
+++ b/dbms/src/Common/Exception.cpp
@@ -42,7 +42,7 @@ Exception::Exception(CreateFromPocoTag, const Poco::Exception & exc)
 }
 
 Exception::Exception(CreateFromSTDTag, const std::exception & exc)
-    : Poco::Exception(String(exc.what()), ErrorCodes::STD_EXCEPTION)
+    : Poco::Exception(String(typeid(exc).name()) + ": " + String(exc.what()), ErrorCodes::STD_EXCEPTION)
 {
     set_stack_trace(exc.get_stack_trace_frames(), exc.get_stack_trace_size());
 }

--- a/dbms/src/Common/Exception.cpp
+++ b/dbms/src/Common/Exception.cpp
@@ -57,8 +57,8 @@ std::string getExceptionStackTraceString(const std::exception & e)
 #ifdef STD_EXCEPTION_HAS_STACK_TRACE
     return StackTrace::toString(e.get_stack_trace_frames(), 0, e.get_stack_trace_size());
 #else
-    if (const auto & db_exception = dynamic_cast<const Exception &>(e))
-        return db_exception.getStackTraceString();
+    if (const auto * db_exception = dynamic_cast<const Exception *>(e))
+        return db_exception->getStackTraceString();
     return {};
 #endif
 }

--- a/dbms/src/Common/Exception.cpp
+++ b/dbms/src/Common/Exception.cpp
@@ -57,7 +57,7 @@ std::string getExceptionStackTraceString(const std::exception & e)
 #ifdef STD_EXCEPTION_HAS_STACK_TRACE
     return StackTrace::toString(e.get_stack_trace_frames(), 0, e.get_stack_trace_size());
 #else
-    if (const auto * db_exception = dynamic_cast<const Exception *>(e))
+    if (const auto * db_exception = dynamic_cast<const Exception *>(&e))
         return db_exception->getStackTraceString();
     return {};
 #endif

--- a/dbms/src/Common/Exception.cpp
+++ b/dbms/src/Common/Exception.cpp
@@ -38,13 +38,17 @@ Exception::Exception(const std::string & msg, int code)
 Exception::Exception(CreateFromPocoTag, const Poco::Exception & exc)
     : Poco::Exception(exc.displayText(), ErrorCodes::POCO_EXCEPTION)
 {
+#ifdef STD_EXCEPTION_HAS_STACK_TRACE
     set_stack_trace(exc.get_stack_trace_frames(), exc.get_stack_trace_size());
+#endif
 }
 
 Exception::Exception(CreateFromSTDTag, const std::exception & exc)
     : Poco::Exception(String(typeid(exc).name()) + ": " + String(exc.what()), ErrorCodes::STD_EXCEPTION)
 {
+#ifdef STD_EXCEPTION_HAS_STACK_TRACE
     set_stack_trace(exc.get_stack_trace_frames(), exc.get_stack_trace_size());
+#endif
 }
 
 

--- a/dbms/src/Common/Exception.cpp
+++ b/dbms/src/Common/Exception.cpp
@@ -42,7 +42,7 @@ Exception::Exception(CreateFromPocoTag, const Poco::Exception & exc)
 }
 
 Exception::Exception(CreateFromSTDTag, const std::exception & exc)
-    : Poco::Exception(String(e.what()), ErrorCodes::STD_EXCEPTION)
+    : Poco::Exception(String(exc.what()), ErrorCodes::STD_EXCEPTION)
 {
     set_stack_trace(exc.get_stack_trace_frames(), exc.get_stack_trace_size());
 }

--- a/dbms/src/Common/StackTrace.cpp
+++ b/dbms/src/Common/StackTrace.cpp
@@ -328,3 +328,13 @@ std::string StackTrace::toString() const
     static SimpleCache<decltype(toStringImpl), &toStringImpl> func_cached;
     return func_cached(frames, offset, size);
 }
+
+std::string StackTrace::toString(void ** frames_, size_t offset, size_t size)
+{
+    StackTrace::Frames frames_copy{};
+    for (size_t i = 0; i < size; ++i)
+        frames_copy[i] = frames_[i];
+
+    static SimpleCache<decltype(toStringImpl), &toStringImpl> func_cached;
+    return func_cached(frames_copy, offset, size);
+}

--- a/dbms/src/Common/StackTrace.h
+++ b/dbms/src/Common/StackTrace.h
@@ -36,13 +36,6 @@ public:
     /// Creates empty object for deferred initialization
     StackTrace(NoCapture);
 
-    void assign(void ** frames_, size_t size_)
-    {
-        size = size_;
-        for (size_t i = 0; i < size; ++i)
-            frames[i] = frames_[i];
-    }
-
     size_t getSize() const;
     size_t getOffset() const;
     const Frames & getFrames() const;

--- a/dbms/src/Common/StackTrace.h
+++ b/dbms/src/Common/StackTrace.h
@@ -36,10 +36,19 @@ public:
     /// Creates empty object for deferred initialization
     StackTrace(NoCapture);
 
+    void assign(void ** frames_, size_t size_)
+    {
+        size = size_;
+        for (size_t i = 0; i < size; ++i)
+            frames[i] = frames_[i];
+    }
+
     size_t getSize() const;
     size_t getOffset() const;
     const Frames & getFrames() const;
     std::string toString() const;
+
+    static std::string toString(void ** frames, size_t offset, size_t size);
 
     void toStringEveryLine(std::function<void(const std::string &)> callback) const;
 

--- a/dbms/src/DataStreams/tests/union_stream2.cpp
+++ b/dbms/src/DataStreams/tests/union_stream2.cpp
@@ -57,6 +57,6 @@ catch (const Exception & e)
     std::cerr << e.what() << ", " << e.displayText() << std::endl
         << std::endl
         << "Stack trace:" << std::endl
-        << e.getStackTrace().toString();
+        << e.getStackTraceString();
     return 1;
 }

--- a/dbms/src/Databases/DatabaseLazy.cpp
+++ b/dbms/src/Databases/DatabaseLazy.cpp
@@ -23,7 +23,6 @@ namespace ErrorCodes
     extern const int TABLE_ALREADY_EXISTS;
     extern const int UNKNOWN_TABLE;
     extern const int UNSUPPORTED_METHOD;
-    extern const int CANNOT_CREATE_TABLE_FROM_METADATA;
     extern const int LOGICAL_ERROR;
 }
 
@@ -255,10 +254,10 @@ StoragePtr DatabaseLazy::loadTable(const Context & context, const String & table
             return it->second.table = table;
         }
     }
-    catch (const Exception & e)
+    catch (Exception & e)
     {
-        throw Exception("Cannot create table from metadata file " + table_metadata_path + ". Error: " + DB::getCurrentExceptionMessage(true),
-                e, DB::ErrorCodes::CANNOT_CREATE_TABLE_FROM_METADATA);
+        e.addMessage("Cannot create table from metadata file " + table_metadata_path);
+        throw;
     }
 }
 

--- a/dbms/src/Databases/DatabaseOrdinary.cpp
+++ b/dbms/src/Databases/DatabaseOrdinary.cpp
@@ -36,7 +36,6 @@ namespace DB
 
 namespace ErrorCodes
 {
-    extern const int CANNOT_CREATE_TABLE_FROM_METADATA;
     extern const int CANNOT_CREATE_DICTIONARY_FROM_METADATA;
     extern const int EMPTY_LIST_OF_COLUMNS_PASSED;
     extern const int CANNOT_PARSE_TEXT;
@@ -66,13 +65,10 @@ namespace
                 = createTableFromAST(query, database_name, database.getTableDataPath(query), context, has_force_restore_data_flag);
             database.attachTable(table_name, table);
         }
-        catch (const Exception & e)
+        catch (Exception & e)
         {
-            throw Exception(
-                "Cannot attach table '" + query.table + "' from query " + serializeAST(query)
-                    + ". Error: " + DB::getCurrentExceptionMessage(true),
-                e,
-                DB::ErrorCodes::CANNOT_CREATE_TABLE_FROM_METADATA);
+            e.addMessage("Cannot attach table '" + backQuote(query.table) + "' from query " + serializeAST(query));
+            throw;
         }
     }
 
@@ -87,13 +83,10 @@ namespace
         {
             database.attachDictionary(query.table, context);
         }
-        catch (const Exception & e)
+        catch (Exception & e)
         {
-            throw Exception(
-                "Cannot create dictionary '" + query.table + "' from query " + serializeAST(query)
-                    + ". Error: " + DB::getCurrentExceptionMessage(true),
-                e,
-                DB::ErrorCodes::CANNOT_CREATE_DICTIONARY_FROM_METADATA);
+            e.addMessage("Cannot attach table '" + backQuote(query.table) + "' from query " + serializeAST(query));
+            throw;
         }
     }
 
@@ -142,10 +135,10 @@ void DatabaseOrdinary::loadStoredObjects(
                 total_dictionaries += create_query->is_dictionary;
             }
         }
-        catch (const Exception & e)
+        catch (Exception & e)
         {
-            throw Exception(
-                "Cannot parse definition from metadata file " + full_path + ". Error: " + DB::getCurrentExceptionMessage(true), e, ErrorCodes::CANNOT_PARSE_TEXT);
+            e.addMessage("Cannot parse definition from metadata file " + full_path);
+            throw;
         }
 
     });

--- a/dbms/src/Functions/trap.cpp
+++ b/dbms/src/Functions/trap.cpp
@@ -124,6 +124,10 @@ public:
                 t1.join();
                 t2.join();
             }
+            else if (mode == "throw exception")
+            {
+                std::vector<int>().at(0);
+            }
             else if (mode == "access context")
             {
                 (void)context.getCurrentQueryId();

--- a/dbms/src/IO/ReadHelpers.cpp
+++ b/dbms/src/IO/ReadHelpers.cpp
@@ -965,7 +965,7 @@ void readException(Exception & e, ReadBuffer & buf, const String & additional_me
     String name;
     String message;
     String stack_trace;
-    bool has_nested = false;
+    bool has_nested = false;    /// Obsolete
 
     readBinary(code, buf);
     readBinary(name, buf);
@@ -986,14 +986,7 @@ void readException(Exception & e, ReadBuffer & buf, const String & additional_me
     if (!stack_trace.empty())
         out << " Stack trace:\n\n" << stack_trace;
 
-    if (has_nested)
-    {
-        Exception nested;
-        readException(nested, buf);
-        e = Exception(out.str(), nested, code);
-    }
-    else
-        e = Exception(out.str(), code);
+    e = Exception(out.str(), code);
 }
 
 void readAndThrowException(ReadBuffer & buf, const String & additional_message)

--- a/dbms/src/IO/WriteHelpers.cpp
+++ b/dbms/src/IO/WriteHelpers.cpp
@@ -48,7 +48,6 @@ void formatUUID(std::reverse_iterator<const UInt8 *> src16, UInt8 * dst36)
 }
 
 
-
 void writeException(const Exception & e, WriteBuffer & buf, bool with_stack_trace)
 {
     writeBinary(e.code(), buf);
@@ -56,14 +55,11 @@ void writeException(const Exception & e, WriteBuffer & buf, bool with_stack_trac
     writeBinary(e.displayText(), buf);
 
     if (with_stack_trace)
-        writeBinary(e.getStackTrace().toString(), buf);
+        writeBinary(e.getStackTraceString(), buf);
     else
         writeBinary(String(), buf);
 
-    bool has_nested = e.nested() != nullptr;
+    bool has_nested = false;
     writeBinary(has_nested, buf);
-
-    if (has_nested)
-        writeException(Exception(Exception::CreateFromPoco, *e.nested()), buf, with_stack_trace);
 }
 }

--- a/dbms/src/Interpreters/executeQuery.cpp
+++ b/dbms/src/Interpreters/executeQuery.cpp
@@ -129,9 +129,9 @@ static void setExceptionStackTrace(QueryLogElement & elem)
     {
         throw;
     }
-    catch (const Exception & e)
+    catch (const std::exception & e)
     {
-        elem.stack_trace = e.getStackTraceString();
+        elem.stack_trace = getExceptionStackTraceString(e);
     }
     catch (...) {}
 }

--- a/dbms/src/Interpreters/executeQuery.cpp
+++ b/dbms/src/Interpreters/executeQuery.cpp
@@ -131,7 +131,7 @@ static void setExceptionStackTrace(QueryLogElement & elem)
     }
     catch (const Exception & e)
     {
-        elem.stack_trace = e.getStackTrace().toString();
+        elem.stack_trace = e.getStackTraceString();
     }
     catch (...) {}
 }

--- a/dbms/src/Interpreters/tests/create_query.cpp
+++ b/dbms/src/Interpreters/tests/create_query.cpp
@@ -97,6 +97,6 @@ catch (const Exception & e)
     std::cerr << e.what() << ", " << e.displayText() << std::endl
         << std::endl
         << "Stack trace:" << std::endl
-        << e.getStackTrace().toString();
+        << e.getStackTraceString();
     return 1;
 }

--- a/dbms/src/Interpreters/tests/select_query.cpp
+++ b/dbms/src/Interpreters/tests/select_query.cpp
@@ -55,6 +55,6 @@ catch (const Exception & e)
     std::cerr << e.what() << ", " << e.displayText() << std::endl
         << std::endl
         << "Stack trace:" << std::endl
-        << e.getStackTrace().toString();
+        << e.getStackTraceString();
     return 1;
 }

--- a/dbms/src/Storages/tests/get_abandonable_lock_in_all_partitions.cpp
+++ b/dbms/src/Storages/tests/get_abandonable_lock_in_all_partitions.cpp
@@ -54,7 +54,7 @@ try
 catch (const Exception & e)
 {
     std::cerr << e.what() << ", " << e.displayText() << ": " << std::endl
-              << e.getStackTrace().toString() << std::endl;
+              << e.getStackTraceString() << std::endl;
     throw;
 }
 catch (Poco::Exception & e)

--- a/dbms/src/Storages/tests/get_current_inserts_in_replicated.cpp
+++ b/dbms/src/Storages/tests/get_current_inserts_in_replicated.cpp
@@ -112,7 +112,7 @@ try
 catch (const Exception & e)
 {
     std::cerr << e.what() << ", " << e.displayText() << ": " << std::endl
-              << e.getStackTrace().toString() << std::endl;
+              << e.getStackTraceString() << std::endl;
     throw;
 }
 catch (Poco::Exception & e)

--- a/utils/check-marks/main.cpp
+++ b/utils/check-marks/main.cpp
@@ -133,7 +133,7 @@ int main(int argc, char ** argv)
         std::cerr << e.what() << ", " << e.message() << std::endl
             << std::endl
             << "Stack trace:" << std::endl
-            << e.getStackTrace().toString()
+            << e.getStackTraceString()
             << std::endl;
         throw;
     }

--- a/utils/fill-factor/main.cpp
+++ b/utils/fill-factor/main.cpp
@@ -53,7 +53,7 @@ int main(int argc, char ** argv)
         std::cerr << e.what() << ", " << e.message() << std::endl
             << std::endl
             << "Stack trace:" << std::endl
-            << e.getStackTrace().toString()
+            << e.getStackTraceString()
             << std::endl;
         throw;
     }


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Now stack trace is displayed for `std::exception` and `Poco::Exception`. In previous versions it was available only for `DB::Exception`. This improves diagnostics.

Detailed description (optional):
Notes and caveats:
1. This is implemented with a small patch to libc++;
2. This patch breaks C++ ABI. To work successfully it's required that all linked C++ libraries are build with the same libc++. This is ok, because we build all libraries (including libc++ and libc++abi) from sources. There is alternative "unbundled" build (for enthusiastic developers, not for production) that uses system libraries - it will continue to work because it doesn't use bundled libc++.
3. Also you may afraid that sometimes we `dlopen` libraries. Actually dynamic libraries with C++ interface is a bad practice and they already don't work at all.
4. Stack trace is captured in constructor of `std::exception` object. Actually it is duplicate work, because the stack is unwound when we capture stack trace and then the stack will be unwinded again while exception is thrown. It's not an issue, because exceptions are thrown rarely.