### PR TITLE
Changed serialization of query parameters

### DIFF
--- a/dbms/tests/queries/0_stateless/01056_prepared_statements_null_and_escaping.reference
+++ b/dbms/tests/queries/0_stateless/01056_prepared_statements_null_and_escaping.reference
@@ -1,0 +1,8 @@
+Hello, World
+Hello,\tWorld
+Hello,\nWorld
+Hello,\tWorld
+Hello,\nWorld
+\N
+457
+457

--- a/dbms/tests/queries/0_stateless/01056_prepared_statements_null_and_escaping.sh
+++ b/dbms/tests/queries/0_stateless/01056_prepared_statements_null_and_escaping.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. $CURDIR/../shell_config.sh
+
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&param_x=Hello,%20World" \
+    -d "SELECT {x:Nullable(String)}";
+
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&param_x=Hello,%5CtWorld" \
+    -d "SELECT {x:Nullable(String)}";
+
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&param_x=Hello,%5CnWorld" \
+    -d "SELECT {x:Nullable(String)}";
+
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&param_x=Hello,%5C%09World" \
+    -d "SELECT {x:Nullable(String)}";
+
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&param_x=Hello,%5C%0AWorld" \
+    -d "SELECT {x:Nullable(String)}";
+
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&param_x=%5CN" \
+    -d "SELECT {x:Nullable(String)}";
+
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&param_x=Hello,%09World" \
+    -d "SELECT {x:Nullable(String)}" 2>&1 | grep -oF '457';
+
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&param_x=Hello,%0AWorld" \
+    -d "SELECT {x:Nullable(String)}" 2>&1 | grep -oF '457';


### PR DESCRIPTION
Changelog category (leave one):
- Backward Incompatible Change


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Now it's expected that query parameters are represented in "escaped" format. For example, to pass string `a<tab>b` you have to write `a\tb` or `a\<tab>b` and respectively, `a%5Ctb` or `a%5C%09b` in URL. This is needed to add the possibility to pass NULL as `\N`. This fixes #7488.