### PR TITLE
In this pull request I would like to check that tests fail when functionality of parsing ALTER MODIFY TTL in replicated tables is rolled back

### DIFF
--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -524,7 +524,7 @@ void StorageReplicatedMergeTree::setTableStructure(ColumnsDescription new_column
 
         if (metadata_diff.ttl_table_changed)
         {
-            ParserTTLExpressionList parser;
+            ParserExpression parser;
             metadata.ttl_for_table_ast = parseQuery(parser, metadata_diff.new_ttl_table, 0);
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Non-significant (changelog entry is not needed)

`test_ttl_move/test.py::test_alter_multiple_ttls` shall fail.