### PR TITLE
Added creation of user and working directory to Arch Linux install script

### DIFF
--- a/utils/package/arch/PKGBUILD.in
+++ b/utils/package/arch/PKGBUILD.in
@@ -7,6 +7,12 @@ url='https://clickhouse.yandex/'
 license=('Apache')
 
 package() {
+    install -dm 755 $pkgdir/usr/lib/tmpfiles.d
+    install -dm 755 $pkgdir/usr/lib/sysusers.d
+    install -Dm 644 ${CMAKE_CURRENT_SOURCE_DIR}/clickhouse.tmpfiles $pkgdir/usr/lib/tmpfiles.d/clickhouse.conf
+    install -Dm 644 ${CMAKE_CURRENT_SOURCE_DIR}/clickhouse.sysusers $pkgdir/usr/lib/sysusers.d/clickhouse.conf
+    install -dm 755 $pkgdir/etc/clickhouse-server/config.d
+    install -Dm 644 ${CMAKE_CURRENT_SOURCE_DIR}/logging.xml $pkgdir/etc/clickhouse-server/config.d/logging.xml
     # This code was requisited from kmeaw@ https://aur.archlinux.org/packages/clickhouse/ .
     SRC=${ClickHouse_SOURCE_DIR}
     BIN=${ClickHouse_BINARY_DIR}

--- a/utils/package/arch/README.md
+++ b/utils/package/arch/README.md
@@ -1,9 +1,17 @@
-### Build Arch linux package
+### Build Arch Linux package
 
 From binary directory:
 
 ```
 make
-cd arch
+cd utils/package/arch
 makepkg
+```
+
+### Install and start ClickHouse server
+
+```
+pacman -U clickhouse-*.pkg.tar.xz
+systemctl enable clickhouse-server
+systemctl start clickhouse-server
 ```

--- a/utils/package/arch/clickhouse.sysusers
+++ b/utils/package/arch/clickhouse.sysusers
@@ -1,0 +1,3 @@
+u clickhouse - "ClickHouse user" /nonexistent /bin/false
+g clickhouse - "ClickHouse group"
+m clickhouse clickhouse

--- a/utils/package/arch/clickhouse.tmpfiles
+++ b/utils/package/arch/clickhouse.tmpfiles
@@ -1,0 +1,1 @@
+d /var/lib/clickhouse 0700 clickhouse clickhouse

--- a/utils/package/arch/logging.xml
+++ b/utils/package/arch/logging.xml
@@ -1,0 +1,6 @@
+<yandex>
+    <logger>
+        <log></log>
+        <errorlog></errorlog>
+    </logger>
+</yandex>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement;

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):

Package for Arch Linux now allows to run ClickHouse server, and not only client.
