### PR TITLE
Added quick instruction on how to test a server with ClickHouse

### DIFF
--- a/docs/en/operations/index.md
+++ b/docs/en/operations/index.md
@@ -13,6 +13,7 @@ ClickHouse operations manual consists of the following major sections:
   - [Quotas](quotas.md)
   - [System Tables](system_tables.md)
   - [Server Configuration Parameters](server_settings/index.md)
+  - [How To Test Your Hardware With ClickHouse](performance_test.md)
   - [Settings](settings/index.md)
   - [Utilities](utils/index.md)
 

--- a/docs/en/operations/performance_test.md
+++ b/docs/en/operations/performance_test.md
@@ -1,0 +1,72 @@
+# How To Test Your Hardware With ClickHouse
+
+Draft.
+
+With this instruction you can run basic ClickHouse performance test on any server without installation of ClickHouse packages.
+
+1. Go to "commits" page: https://github.com/ClickHouse/ClickHouse/commits/master
+
+2. Click on the first green check mark or red cross with green "ClickHouse Build Check" and click on the "Details" link near "ClickHouse Build Check".
+
+3. Copy the link to "clickhouse" binary for amd64 or aarch64.
+
+4. ssh to the server and download it with wget:
+```
+# For amd64:
+wget https://clickhouse-builds.s3.yandex.net/0/00ba767f5d2a929394ea3be193b1f79074a1c4bc/1578163263_binary/clickhouse
+# For aarch64:
+wget https://clickhouse-builds.s3.yandex.net/0/00ba767f5d2a929394ea3be193b1f79074a1c4bc/1578161264_binary/clickhouse
+# Then do:
+chmod a+x clickhouse
+```
+
+5. Download configs:
+```
+wget https://raw.githubusercontent.com/ClickHouse/ClickHouse/master/dbms/programs/server/config.xml
+wget https://raw.githubusercontent.com/ClickHouse/ClickHouse/master/dbms/programs/server/users.xml
+mkdir config.d
+wget https://raw.githubusercontent.com/ClickHouse/ClickHouse/master/dbms/programs/server/config.d/path.xml -O config.d/path.xml
+wget https://raw.githubusercontent.com/ClickHouse/ClickHouse/master/dbms/programs/server/config.d/log_to_console.xml -O config.d/log_to_console.xml
+```
+
+6. Download benchmark files:
+```
+wget https://raw.githubusercontent.com/ClickHouse/ClickHouse/master/dbms/benchmark/clickhouse/benchmark-new.sh
+chmod a+x benchmark-new.sh
+wget https://raw.githubusercontent.com/ClickHouse/ClickHouse/master/dbms/benchmark/clickhouse/queries.sql
+```
+
+7. Download test data:
+According to the instruction:
+https://clickhouse.yandex/docs/en/getting_started/example_datasets/metrica/
+("hits" table containing 100 million rows)
+
+```
+wget https://clickhouse-datasets.s3.yandex.net/hits/partitions/hits_100m_obfuscated_v1.tar.xz
+tar xvf hits_100m_obfuscated_v1.tar.xz -C .
+mv hits_100m_obfuscated_v1/* .
+```
+
+8. Run the server:
+```
+./clickhouse server
+```
+
+9. Check the data:
+ssh to the server in another terminal
+```
+./clickhouse client --query "SELECT count() FROM hits_100m_obfuscated"
+100000000
+```
+
+10. Edit the benchmark-new.sh, change "clickhouse-client" to "./clickhouse client" and add "--max_memory_usage 100000000000" parameter.
+```
+mcedit benchmark-new.sh
+```
+
+11. Run the benchmark:
+```
+./benchmark-new.sh hits_100m_obfuscated
+```
+
+12. Send the numbers and the info about your hardware configuration to clickhouse-feedback@yandex-team.com

--- a/docs/fa/operations/performance_test.md
+++ b/docs/fa/operations/performance_test.md
@@ -1,0 +1,1 @@
+docs/en/operations/performance_test.md

--- a/docs/ja/operations/performance_test.md
+++ b/docs/ja/operations/performance_test.md
@@ -1,0 +1,1 @@
+docs/en/operations/performance_test.md

--- a/docs/ru/operations/index.md
+++ b/docs/ru/operations/index.md
@@ -13,6 +13,7 @@
   - [Квоты](quotas.md)
   - [Системные таблицы](system_tables.md)
   - [Конфигурационные параметры сервера](server_settings/index.md)
+  - [Тестирование севреров с помощью ClickHouse](performance_test.md)
   - [Настройки](settings/index.md)
   - [Утилиты](utils/index.md)
 

--- a/docs/ru/operations/performance_test.md
+++ b/docs/ru/operations/performance_test.md
@@ -1,0 +1,1 @@
+docs/en/operations/performance_test.md

--- a/docs/zh/operations/performance_test.md
+++ b/docs/zh/operations/performance_test.md
@@ -1,0 +1,1 @@
+docs/en/operations/performance_test.md


### PR DESCRIPTION
Changelog category (leave one):
- Documentation

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Added quick instruction on how to test server hardware with ClickHouse.