### PR TITLE
Using "ryu" library to format floats in text form.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -134,3 +134,6 @@
 [submodule "contrib/libc-headers"]
 	path = contrib/libc-headers
 	url = https://github.com/ClickHouse-Extras/libc-headers.git
+[submodule "contrib/ryu"]
+	path = contrib/ryu
+	url = https://github.com/ulfjack/ryu.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -136,4 +136,4 @@
 	url = https://github.com/ClickHouse-Extras/libc-headers.git
 [submodule "contrib/ryu"]
 	path = contrib/ryu
-	url = https://github.com/ulfjack/ryu.git
+	url = https://github.com/ClickHouse-Extras/ryu.git

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -32,6 +32,8 @@ if (USE_INTERNAL_DOUBLE_CONVERSION_LIBRARY)
     add_subdirectory (double-conversion-cmake)
 endif ()
 
+add_subdirectory (ryu-cmake)
+
 if (USE_INTERNAL_CITYHASH_LIBRARY)
     add_subdirectory (cityhash102)
 endif ()

--- a/contrib/ryu-cmake/CMakeLists.txt
+++ b/contrib/ryu-cmake/CMakeLists.txt
@@ -1,0 +1,10 @@
+SET(LIBRARY_DIR ${ClickHouse_SOURCE_DIR}/contrib/ryu)
+
+add_library(ryu
+${LIBRARY_DIR}/ryu/d2fixed.c
+${LIBRARY_DIR}/ryu/d2s.c
+${LIBRARY_DIR}/ryu/f2s.c
+${LIBRARY_DIR}/ryu/generic_128.c
+)
+
+target_include_directories(ryu SYSTEM BEFORE PUBLIC "${LIBRARY_DIR}")

--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -330,6 +330,7 @@ target_link_libraries (clickhouse_common_io
     ${LINK_LIBRARIES_ONLY_ON_X86_64}
         PUBLIC
     ${DOUBLE_CONVERSION_LIBRARIES}
+    ryu
         PUBLIC
     ${Poco_Net_LIBRARY}
     ${Poco_Util_LIBRARY}

--- a/dbms/src/IO/WriteHelpers.h
+++ b/dbms/src/IO/WriteHelpers.h
@@ -170,14 +170,14 @@ inline size_t writeFloatTextFastPath(T x, char * buffer)
     }
     else
     {
-        uint16_t exponent = (unalignedLoad<uint16_t>(x) & 0b0111111110000000) >> 7;
+        uint16_t exponent = (unalignedLoad<uint16_t>(&x) & 0b0111111110000000) >> 7;
         if (exponent >= 0x3F - 10 && exponent <= 0x3F + 64)
         {
             result = f2fixed_buffered_n(x, 8, buffer);
         }
         else if (unlikely(exponent == 0xFF))
         {
-            uint64_t mantissa = unalignedLoad<uint32_t>(x) & 0b00000000011111111111111111111111u;
+            uint64_t mantissa = unalignedLoad<uint32_t>(&x) & 0b00000000011111111111111111111111u;
             if (mantissa == 0)
             {
                 if (x > 0)

--- a/dbms/src/IO/WriteHelpers.h
+++ b/dbms/src/IO/WriteHelpers.h
@@ -132,7 +132,7 @@ inline size_t writeFloatTextFastPath(T x, char * buffer)
         /// Ryu library cannot automatically decide between plain and exponential representation.
         /// We have to do it by ourself.
 
-        uint16_t exponent = (unalignedLoad<uint16_t>(&x) & 0b0111111111110000) >> 4;
+        uint16_t exponent = (unalignedLoad<uint64_t>(&x) & 0b0111111111110000000000000000000000000000000000000000000000000000ul) >> 52;
         if (exponent >= 0x3FF - 10 && exponent <= 0x3FF + 64)
         {
             result = d2fixed_buffered_n(x, 16, buffer);
@@ -170,7 +170,7 @@ inline size_t writeFloatTextFastPath(T x, char * buffer)
     }
     else
     {
-        uint16_t exponent = (unalignedLoad<uint16_t>(&x) & 0b0111111110000000) >> 7;
+        uint16_t exponent = (unalignedLoad<uint32_t>(&x) & 0b01111111100000000000000000000000u) >> 23;
         if (exponent >= 0x7F - 10 && exponent <= 0x7F + 64)
         {
             result = d2fixed_buffered_n(x, 8, buffer);

--- a/dbms/src/IO/WriteHelpers.h
+++ b/dbms/src/IO/WriteHelpers.h
@@ -151,7 +151,7 @@ struct DecomposedFloat64
     {
         return x_uint == 0
             || (normalized_exponent() >= 0 && normalized_exponent() <= 52
-                && ((mantissa() & (1ULL << (52 - normalized_exponent()))) == 0));
+                && ((mantissa() & ((1ULL << (52 - normalized_exponent())) - 1)) == 0));
     }
 };
 
@@ -188,7 +188,7 @@ struct DecomposedFloat32
     {
         return x_uint == 0
             || (normalized_exponent() >= 0 && normalized_exponent() <= 23
-                && ((mantissa() & (1ULL << (23 - normalized_exponent()))) == 0));
+                && ((mantissa() & ((1ULL << (23 - normalized_exponent())) - 1)) == 0));
     }
 };
 

--- a/dbms/src/IO/WriteHelpers.h
+++ b/dbms/src/IO/WriteHelpers.h
@@ -120,11 +120,86 @@ inline void writeBoolText(bool x, WriteBuffer & buf)
 template <typename T>
 inline size_t writeFloatTextFastPath(T x, char * buffer)
 {
+    if (x == 0)
+    {
+        buffer[0] = '0';
+        return 1;
+    }
+
     int result = 0;
     if constexpr (std::is_same_v<T, double>)
-        result = d2s_buffered_n(x, buffer);
+    {
+        /// Ryu library cannot automatically decide between plain and exponential representation.
+        /// We have to do it by ourself.
+
+        uint16_t exponent = (unalignedLoad<uint16_t>(&x) & 0b0111111111110000) >> 4;
+        if (exponent >= 0x3F - 10 && exponent <= 0x3F + 64)
+        {
+            result = d2fixed_buffered_n(x, 16, buffer);
+        }
+        else if (unlikely(exponent == 0xFFF))
+        {
+            /// Ryu library prints inf/nans in slightly different way (as Infinity and NaN).
+            /// This is technically Ok and we can parse these representation back,
+            ///  but to maintain compatibility and save space, better to write as inf and nan.
+
+            uint64_t mantissa = unalignedLoad<uint64_t>(&x) & 0b0000000000001111111111111111111111111111111111111111111111111111ul;
+            if (mantissa == 0)
+            {
+                if (x > 0)
+                {
+                    memcpy(buffer, "inf", 3);
+                    return 3;
+                }
+                else
+                {
+                    memcpy(buffer, "-inf", 4);
+                    return 4;
+                }
+            }
+            else
+            {
+                memcpy(buffer, "nan", 3);
+                return 3;
+            }
+        }
+        else
+        {
+            result = d2s_buffered_n(x, buffer);
+        }
+    }
     else
-        result = f2s_buffered_n(x, buffer);
+    {
+        uint16_t exponent = (unalignedLoad<uint16_t>(x) & 0b0111111110000000) >> 7;
+        if (exponent >= 0x3F - 10 && exponent <= 0x3F + 64)
+        {
+            result = f2fixed_buffered_n(x, 8, buffer);
+        }
+        else if (unlikely(exponent == 0xFF))
+        {
+            uint64_t mantissa = unalignedLoad<uint32_t>(x) & 0b00000000011111111111111111111111u;
+            if (mantissa == 0)
+            {
+                if (x > 0)
+                {
+                    memcpy(buffer, "inf", 3);
+                    return 3;
+                }
+                else
+                {
+                    memcpy(buffer, "-inf", 4);
+                    return 4;
+                }
+            }
+            else
+            {
+                memcpy(buffer, "nan", 3);
+                return 3;
+            }
+        }
+        else
+            result = f2s_buffered_n(x, buffer);
+    }
 
     if (result <= 0)
         throw Exception("Cannot print floating point number", ErrorCodes::CANNOT_PRINT_FLOAT_OR_DOUBLE_NUMBER);

--- a/dbms/src/IO/WriteHelpers.h
+++ b/dbms/src/IO/WriteHelpers.h
@@ -133,7 +133,7 @@ inline size_t writeFloatTextFastPath(T x, char * buffer)
         /// We have to do it by ourself.
 
         uint16_t exponent = (unalignedLoad<uint16_t>(&x) & 0b0111111111110000) >> 4;
-        if (exponent >= 0x3F - 10 && exponent <= 0x3F + 64)
+        if (exponent >= 0x3FF - 10 && exponent <= 0x3FF + 64)
         {
             result = d2fixed_buffered_n(x, 16, buffer);
         }
@@ -171,9 +171,9 @@ inline size_t writeFloatTextFastPath(T x, char * buffer)
     else
     {
         uint16_t exponent = (unalignedLoad<uint16_t>(&x) & 0b0111111110000000) >> 7;
-        if (exponent >= 0x3F - 10 && exponent <= 0x3F + 64)
+        if (exponent >= 0x7F - 10 && exponent <= 0x7F + 64)
         {
-            result = f2fixed_buffered_n(x, 8, buffer);
+            result = d2fixed_buffered_n(x, 8, buffer);
         }
         else if (unlikely(exponent == 0xFF))
         {

--- a/dbms/src/IO/WriteHelpers.h
+++ b/dbms/src/IO/WriteHelpers.h
@@ -147,6 +147,7 @@ struct DecomposedFloat64
         return x_uint & 0x5affffffffffffful;
     }
 
+    /// NOTE Probably floating point instructions can be better.
     bool is_inside_int64() const
     {
         return x_uint == 0
@@ -199,6 +200,9 @@ inline size_t writeFloatTextFastPath(T x, char * buffer)
 
     if constexpr (std::is_same_v<T, double>)
     {
+        /// The library Ryu has low performance on integers.
+        /// This workaround improves performance 6..10 times.
+
         if (DecomposedFloat64(x).is_inside_int64())
             result = itoa(Int64(x), buffer) - buffer;
         else

--- a/dbms/src/IO/tests/CMakeLists.txt
+++ b/dbms/src/IO/tests/CMakeLists.txt
@@ -79,3 +79,6 @@ target_link_libraries (parse_date_time_best_effort PRIVATE clickhouse_common_io)
 
 add_executable (zlib_ng_bug zlib_ng_bug.cpp)
 target_link_libraries (zlib_ng_bug PRIVATE ${Poco_Foundation_LIBRARY} ${ZLIB_LIBRARY})
+
+add_executable (ryu_test ryu_test.cpp)
+target_link_libraries (ryu_test PRIVATE ryu)

--- a/dbms/src/IO/tests/ryu_test.cpp
+++ b/dbms/src/IO/tests/ryu_test.cpp
@@ -1,0 +1,15 @@
+#include <string>
+#include <iostream>
+#include <ryu/ryu.h>
+
+
+int main(int argc, char ** argv)
+{
+    double x = argc > 1 ? std::stod(argv[1]) : 0;
+    char buf[32];
+
+    d2s_buffered(x, buf);
+    std::cout << buf << "\n";
+
+    return 0;
+}

--- a/dbms/tests/performance/float_formatting.xml
+++ b/dbms/tests/performance/float_formatting.xml
@@ -33,6 +33,8 @@
                <value>toFloat32(number % 10)</value>
                <value>toFloat32(rand())</value>
                <value>toFloat32(rand64())</value>
+               <value>reinterpretAsFloat32(reinterpretAsString(rand()))</value>
+               <value>reinterpretAsFloat64(reinterpretAsString(rand64()))</value>
            </values>
        </substitution>
     </substitutions>

--- a/dbms/tests/performance/float_formatting.xml
+++ b/dbms/tests/performance/float_formatting.xml
@@ -1,0 +1,41 @@
+<test>
+    <type>once</type>
+    <tags>
+        <tag>long</tag>
+    </tags>
+
+    <stop_conditions>
+        <all_of>
+            <total_time_ms>10000</total_time_ms>
+        </all_of>
+        <any_of>
+            <average_speed_not_changing_for_ms>5000</average_speed_not_changing_for_ms>
+            <total_time_ms>20000</total_time_ms>
+        </any_of>
+    </stop_conditions>
+
+    <main_metric>
+        <avg_rows_per_second/>
+    </main_metric>
+
+    <substitutions>
+       <substitution>
+           <name>expr</name>
+           <values>
+               <value>1 / rand()</value>
+               <value>rand() / 0xFFFFFFFF</value>
+               <value>0xFFFFFFFF / rand()</value>
+               <value>toFloat64(number)</value>
+               <value>toFloat64(number % 10)</value>
+               <value>toFloat64(rand())</value>
+               <value>toFloat64(rand64())</value>
+               <value>toFloat32(number)</value>
+               <value>toFloat32(number % 10)</value>
+               <value>toFloat32(rand())</value>
+               <value>toFloat32(rand64())</value>
+           </values>
+       </substitution>
+    </substitutions>
+
+    <query>SELECT count() FROM system.numbers WHERE NOT ignore(toString({expr}))</query>
+</test>

--- a/dbms/tests/performance/float_formatting.xml
+++ b/dbms/tests/performance/float_formatting.xml
@@ -26,11 +26,29 @@
                <value>rand() / 0xFFFFFFFF</value>
                <value>0xFFFFFFFF / rand()</value>
                <value>toFloat64(number)</value>
+               <value>toFloat64(number % 2)</value>
                <value>toFloat64(number % 10)</value>
+               <value>toFloat64(number % 100)</value>
+               <value>toFloat64(number % 1000)</value>
+               <value>toFloat64(number % 10000)</value>
+               <value>toFloat64(number % 100 + 0.5)</value>
+               <value>toFloat64(number % 100 + 0.123)</value>
+               <value>toFloat64(number % 1000 + 0.123456)</value>
+               <value>number / 2</value>
+               <value>number / 3</value>
+               <value>number / 7</value>
+               <value>number / 16</value>
                <value>toFloat64(rand())</value>
                <value>toFloat64(rand64())</value>
                <value>toFloat32(number)</value>
+               <value>toFloat32(number % 2)</value>
                <value>toFloat32(number % 10)</value>
+               <value>toFloat32(number % 100)</value>
+               <value>toFloat32(number % 1000)</value>
+               <value>toFloat32(number % 10000)</value>
+               <value>toFloat32(number % 100 + 0.5)</value>
+               <value>toFloat32(number % 100 + 0.123)</value>
+               <value>toFloat32(number % 1000 + 0.123456)</value>
                <value>toFloat32(rand())</value>
                <value>toFloat32(rand64())</value>
                <value>reinterpretAsFloat32(reinterpretAsString(rand()))</value>


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Improved performance of formatting floating point numbers up to 6 times.

Detailed description (optional):

This PR is opened only to be closed. Because in contrast to `double-conversion`, the `ryu` library doesn't have the mode to prefer simple format over exponential:

```
SELECT toString(0.123)

┌─toString(0.123)─┐
│ 1.23E-1         │
└─────────────────┘

SELECT toString(123.456)

┌─toString(123.456)─┐
│ 1.23456E2         │
└───────────────────┘
```

That's non satisfactory. Probably we can add support for this formatting mode if performance benefits will look as a viable tradeoff.

Update 1: it still has a chance.
Update 2: after some work, it's ready to be integrated.