### PR TITLE
Specialization for sorting by single column in MergingSorted transform

### DIFF
--- a/dbms/src/DataStreams/MergingSortedBlockInputStream.cpp
+++ b/dbms/src/DataStreams/MergingSortedBlockInputStream.cpp
@@ -60,8 +60,10 @@ void MergingSortedBlockInputStream::init(MutableColumns & merged_columns)
 
         if (has_collation)
             queue_with_collation = SortingHeap<SortCursorWithCollation>(cursors);
-        else
+        else if (description.size() > 1)
             queue_without_collation = SortingHeap<SortCursor>(cursors);
+        else
+            queue_simple = SortingHeap<SimpleSortCursor>(cursors);
     }
 
     /// Let's check that all source blocks have the same structure.
@@ -98,8 +100,10 @@ Block MergingSortedBlockInputStream::readImpl()
 
     if (has_collation)
         merge(merged_columns, queue_with_collation);
-    else
+    else if (description.size() > 1)
         merge(merged_columns, queue_without_collation);
+    else
+        merge(merged_columns, queue_simple);
 
     return header.cloneWithColumns(std::move(merged_columns));
 }

--- a/dbms/src/DataStreams/MergingSortedBlockInputStream.h
+++ b/dbms/src/DataStreams/MergingSortedBlockInputStream.h
@@ -110,6 +110,7 @@ protected:
     SortCursorImpls cursors;
 
     SortingHeap<SortCursor> queue_without_collation;
+    SortingHeap<SimpleSortCursor> queue_simple;
     SortingHeap<SortCursorWithCollation> queue_with_collation;
 
     /// Used in Vertical merge algorithm to gather non-PK/non-index columns (on next step)

--- a/dbms/src/Processors/Transforms/MergingSortedTransform.cpp
+++ b/dbms/src/Processors/Transforms/MergingSortedTransform.cpp
@@ -149,8 +149,10 @@ IProcessor::Status MergingSortedTransform::prepare()
 
         if (has_collation)
             queue_with_collation = SortingHeap<SortCursorWithCollation>(cursors);
-        else
+        else if (description.size() > 1)
             queue_without_collation = SortingHeap<SortCursor>(cursors);
+        else
+            queue_simple = SortingHeap<SimpleSortCursor>(cursors);
 
         is_initialized = true;
         return Status::Ready;
@@ -185,8 +187,10 @@ IProcessor::Status MergingSortedTransform::prepare()
 
                 if (has_collation)
                     queue_with_collation.push(cursors[next_input_to_read]);
-                else
+                else if (description.size() > 1)
                     queue_without_collation.push(cursors[next_input_to_read]);
+                else
+                    queue_simple.push(cursors[next_input_to_read]);
             }
 
             need_data = false;
@@ -200,8 +204,10 @@ void MergingSortedTransform::work()
 {
     if (has_collation)
         merge(queue_with_collation);
-    else
+    else if (description.size() > 1)
         merge(queue_without_collation);
+    else
+        merge(queue_simple);
 }
 
 template <typename TSortingHeap>

--- a/dbms/src/Processors/Transforms/MergingSortedTransform.h
+++ b/dbms/src/Processors/Transforms/MergingSortedTransform.h
@@ -114,6 +114,7 @@ protected:
     SortCursorImpls cursors;
 
     SortingHeap<SortCursor> queue_without_collation;
+    SortingHeap<SimpleSortCursor> queue_simple;
     SortingHeap<SortCursorWithCollation> queue_with_collation;
 
 private:


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Improved performance of sorting by single column (the merging-sorted pass).


Detailed description (optional):
This was seen in perf top in AArch64 machine when I did a huge sorting in external memory.