### PR TITLE
Add graphite-ch-optimizer to third-party integration

### DIFF
--- a/docs/en/interfaces/third-party/integrations.md
+++ b/docs/en/interfaces/third-party/integrations.md
@@ -33,7 +33,9 @@
 - Monitoring
     - [Graphite](https://graphiteapp.org)
         - [graphouse](https://github.com/yandex/graphouse)
-        - [carbon-clickhouse](https://github.com/lomik/carbon-clickhouse)
+        - [carbon-clickhouse](https://github.com/lomik/carbon-clickhouse) +
+        - [graphite-clickhouse](https://github.com/lomik/graphite-clickhouse)
+        - [graphite-ch-optimizer](https://github.com/innogames/graphite-ch-optimizer) - optimizes staled partitions in [\*GraphiteMergeTree](../../operations/table_engines/graphitemergetree.md#graphitemergetree) if rules from [rollup configuration](../../operations/table_engines/graphitemergetree.md#rollup-configuration) could be applied
     - [Grafana](https://grafana.com/)
         - [clickhouse-grafana](https://github.com/Vertamedia/clickhouse-grafana)
     - [Prometheus](https://prometheus.io/)

--- a/docs/en/operations/table_engines/graphitemergetree.md
+++ b/docs/en/operations/table_engines/graphitemergetree.md
@@ -1,5 +1,4 @@
-
-# GraphiteMergeTree
+# GraphiteMergeTree {#graphitemergetree}
 
 This engine is designed for thinning and aggregating/averaging (rollup) [Graphite](http://graphite.readthedocs.io/en/latest/index.html) data. It may be helpful to developers who want to use ClickHouse as a data store for Graphite.
 
@@ -7,7 +6,7 @@ You can use any ClickHouse table engine to store the Graphite data if you don't 
 
 The engine inherits properties from [MergeTree](mergetree.md).
 
-## Creating a Table
+## Creating a Table {#creating-table}
 
 ```sql
 CREATE TABLE [IF NOT EXISTS] [db.]table_name [ON CLUSTER cluster]
@@ -67,7 +66,7 @@ All of the parameters excepting `config_section` have the same meaning as in `Me
 - `config_section` — Name of the section in the configuration file, where are the rules of rollup set.
 </details>
 
-## Rollup configuration
+## Rollup configuration {#rollup-configuration}
 
 The settings for rollup are defined by the [graphite_rollup](../server_settings/settings.md#server_settings-graphite_rollup) parameter in the server configuration. The name of the parameter could be any. You can create several configurations and use them for different tables.
 
@@ -78,14 +77,14 @@ required-columns
 patterns
 ```
 
-### Required Columns
+### Required Columns {#required-columns}
 
 - `path_column_name` — The name of the column storing the metric name (Graphite sensor). Default value: `Path`.
 - `time_column_name` — The name of the column storing the time of measuring the metric. Default value: `Time`.
 - `value_column_name` — The name of the column storing the value of the metric at the time set in `time_column_name`. Default value: `Value`.
 - `version_column_name` — The name of the column storing the version of the metric. Default value: `Timestamp`.
 
-### Patterns
+### Patterns {#patterns}
 
 Structure of the `patterns` section:
 
@@ -127,7 +126,7 @@ Fields for `pattern` and `default` sections:
 - `function` – The name of the aggregating function to apply to data whose age falls within the range `[age, age + precision]`.
 
 
-### Configuration Example
+### Configuration Example {#configuration-example}
 
 ```xml
 <graphite_rollup>

--- a/docs/fa/interfaces/third-party/integrations.md
+++ b/docs/fa/interfaces/third-party/integrations.md
@@ -34,7 +34,9 @@
 - نظارت بر
     - [Graphite](https://graphiteapp.org)
         - [graphouse](https://github.com/yandex/graphouse)
-        - [carbon-clickhouse](https://github.com/lomik/carbon-clickhouse)
+        - [carbon-clickhouse](https://github.com/lomik/carbon-clickhouse) +
+        - [graphite-clickhouse](https://github.com/lomik/graphite-clickhouse)
+        - [graphite-ch-optimizer](https://github.com/innogames/graphite-ch-optimizer) - optimizes staled partitions in [\*GraphiteMergeTree](../../operations/table_engines/graphitemergetree.md#graphitemergetree) if rules from [rollup configuration](../../operations/table_engines/graphitemergetree.md#rollup-configuration) could be applied
     - [Grafana](https://grafana.com/)
         - [clickhouse-grafana](https://github.com/Vertamedia/clickhouse-grafana)
     - [Prometheus](https://prometheus.io/)

--- a/docs/ru/interfaces/third-party/integrations.md
+++ b/docs/ru/interfaces/third-party/integrations.md
@@ -32,7 +32,9 @@
 - Мониторинг
     - [Graphite](https://graphiteapp.org)
         - [graphouse](https://github.com/yandex/graphouse)
-        - [carbon-clickhouse](https://github.com/lomik/carbon-clickhouse)
+        - [carbon-clickhouse](https://github.com/lomik/carbon-clickhouse) +
+        - [graphite-clickhouse](https://github.com/lomik/graphite-clickhouse)
+        - [graphite-ch-optimizer](https://github.com/innogames/graphite-ch-optimizer) - оптимизирует партиции таблиц [\*GraphiteMergeTree](../../operations/table_engines/graphitemergetree.md#graphitemergetree) согласно правилам в [конфигурации rollup](../../operations/table_engines/graphitemergetree.md#rollup-configuration)
     - [Grafana](https://grafana.com/)
         - [clickhouse-grafana](https://github.com/Vertamedia/clickhouse-grafana)
     - [Prometheus](https://prometheus.io/)

--- a/docs/ru/operations/table_engines/graphitemergetree.md
+++ b/docs/ru/operations/table_engines/graphitemergetree.md
@@ -1,4 +1,4 @@
-# GraphiteMergeTree
+# GraphiteMergeTree {#graphitemergetree}
 
 Движок предназначен для прореживания и агрегирования/усреднения (rollup) данных [Graphite](http://graphite.readthedocs.io/en/latest/index.html). Он может быть интересен разработчикам, которые хотят использовать ClickHouse как хранилище данных для Graphite.
 
@@ -6,7 +6,7 @@
 
 Движок наследует свойства от [MergeTree](mergetree.md).
 
-## Создание таблицы
+## Создание таблицы {#creating-table}
 
 ```sql
 CREATE TABLE [IF NOT EXISTS] [db.]table_name [ON CLUSTER cluster]
@@ -70,7 +70,7 @@ CREATE TABLE [IF NOT EXISTS] [db.]table_name [ON CLUSTER cluster]
 
 </details>
 
-## Конфигурация rollup
+## Конфигурация rollup {#rollup-configuration}
 
 Настройки прореживания данных задаются параметром [graphite_rollup](../server_settings/settings.md#server_settings-graphite_rollup) в конфигурации сервера . Имя параметра может быть любым. Можно создать несколько конфигураций и использовать их для разных таблиц.
 
@@ -81,14 +81,14 @@ required-columns
 patterns
 ```
 
-### Требуемые столбцы (required-columns)
+### Требуемые столбцы (required-columns) {#required-columns}
 
 - `path_column_name` — столбец, в котором хранится название метрики (сенсор Graphite). Значение по умолчанию: `Path`.
 - `time_column_name` — столбец, в котором хранится время измерения метрики. Значение по умолчанию: `Time`.
 - `value_column_name` — столбец со значением метрики в момент времени, установленный в `time_column_name`. Значение по умолчанию: `Value`.
 - `version_column_name` — столбец, в котором хранится версия метрики. Значение по умолчанию: `Timestamp`.
 
-### Правила (patterns)
+### Правила (patterns) {#patterns}
 
 Структура раздела `patterns`:
 
@@ -129,7 +129,7 @@ default
 - `precision` – точность определения возраста данных в секундах. Должен быть делителем для 86400 (количество секунд в сутках).
 - `function` – имя агрегирующей функции, которую следует применить к данным, чей возраст оказался в интервале `[age, age + precision]`.
 
-### Пример конфигурации
+### Пример конфигурации {#configuration-example}
 
 ```xml
 <graphite_rollup>

--- a/docs/zh/interfaces/third-party/integrations.md
+++ b/docs/zh/interfaces/third-party/integrations.md
@@ -31,7 +31,9 @@
 - 监控
     - [Graphite](https://graphiteapp.org)
         - [graphouse](https://github.com/yandex/graphouse)
-        - [carbon-clickhouse](https://github.com/lomik/carbon-clickhouse)
+        - [carbon-clickhouse](https://github.com/lomik/carbon-clickhouse) +
+        - [graphite-clickhouse](https://github.com/lomik/graphite-clickhouse)
+        - [graphite-ch-optimizer](https://github.com/innogames/graphite-ch-optimizer) - optimizes staled partitions in [\*GraphiteMergeTree](../../operations/table_engines/graphitemergetree.md#graphitemergetree) if rules from [rollup configuration](../../operations/table_engines/graphitemergetree.md#rollup-configuration) could be applied
     - [Grafana](https://grafana.com/)
         - [clickhouse-grafana](https://github.com/Vertamedia/clickhouse-grafana)
     - [Prometheus](https://prometheus.io/)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation


Detailed description (optional):

Add graphite-clickhouse and graphite-ch-optimizer into third-party integrations for graphite-web.
