### PR TITLE
WIP. Add "fast-forward" optimization for merge sorting with offset

### DIFF
--- a/dbms/src/Core/Settings.h
+++ b/dbms/src/Core/Settings.h
@@ -273,6 +273,8 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingOverflowMode, sort_overflow_mode, OverflowMode::THROW, "What to do when the limit is exceeded.", 0) \
     M(SettingUInt64, max_bytes_before_external_sort, 0, "", 0) \
     M(SettingUInt64, max_bytes_before_remerge_sort, 1000000000, "In case of ORDER BY with LIMIT, when memory usage is higher than specified threshold, perform additional steps of merging blocks before final merge to keep just top LIMIT rows.", 0) \
+    M(SettingBool, enable_parallel_merge_sort, 1, "Perform preliminary merging of sorted streams in multiple threads. This speed up queries with heavy sorting significantly.", 0) \
+    M(SettingUInt64, min_rows_to_parallel_merge_sort, 10000, "Apply parallel merge sorting only if the query has large enough LIMIT (regardless to offset).", 0) \
     \
     M(SettingUInt64, max_result_rows, 0, "Limit on result size in rows. Also checked for intermediate data sent from remote servers.", 0) \
     M(SettingUInt64, max_result_bytes, 0, "Limit on result size in bytes (uncompressed). Also checked for intermediate data sent from remote servers.", 0) \

--- a/dbms/src/Core/Settings.h
+++ b/dbms/src/Core/Settings.h
@@ -274,8 +274,6 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingUInt64, max_bytes_before_external_sort, 0, "", 0) \
     M(SettingUInt64, max_bytes_before_remerge_sort, 1000000000, "In case of ORDER BY with LIMIT, when memory usage is higher than specified threshold, perform additional steps of merging blocks before final merge to keep just top LIMIT rows.", 0) \
     M(SettingBool, enable_parallel_merge_sort, 1, "Perform preliminary merging of sorted streams in multiple threads. This speed up queries with heavy sorting significantly.", 0) \
-    M(SettingUInt64, min_rows_to_parallel_merge_sort, 10000, "Apply parallel merge sorting only if the query has large enough LIMIT (regardless to offset).", 0) \
-    \
     M(SettingUInt64, max_result_rows, 0, "Limit on result size in rows. Also checked for intermediate data sent from remote servers.", 0) \
     M(SettingUInt64, max_result_bytes, 0, "Limit on result size in bytes (uncompressed). Also checked for intermediate data sent from remote servers.", 0) \
     M(SettingOverflowMode, result_overflow_mode, OverflowMode::THROW, "What to do when the limit is exceeded.", 0) \

--- a/dbms/src/Core/SortCursor.h
+++ b/dbms/src/Core/SortCursor.h
@@ -141,6 +141,18 @@ struct SortCursorHelper
         /// The last row of this cursor is no larger than the first row of the another cursor.
         return !derived().greaterAt(rhs.derived(), impl->rows - 1, 0);
     }
+
+    /// Chacks that the last row in the current block is less that the last row in the block of another cursor.
+    bool willBeFinishedEarlier(const SortCursorHelper & rhs) const
+    {
+        if (impl->rows == 0)
+            return true;    /// NOTE This is not a strict order.
+        if (rhs.impl->rows == 0)
+            return false;
+
+        /// The last row of this cursor is no larger than the last row of the another cursor.
+        return !derived().greaterAt(rhs.derived(), impl->rows - 1, rhs.impl->rows - 1);
+    }
 };
 
 
@@ -274,6 +286,11 @@ public:
         queue.emplace_back(&cursor);
         std::push_heap(queue.begin(), queue.end());
         next_idx = 0;
+    }
+
+    auto & container()
+    {
+        return queue;
     }
 
 private:

--- a/dbms/src/Core/SortCursor.h
+++ b/dbms/src/Core/SortCursor.h
@@ -142,7 +142,7 @@ struct SortCursorHelper
         return !derived().greaterAt(rhs.derived(), impl->rows - 1, 0);
     }
 
-    /// Chacks that the last row in the current block is less that the last row in the block of another cursor.
+    /// Checks that the last row in the current block is less that the last row in the block of another cursor.
     bool willBeFinishedEarlier(const SortCursorHelper & rhs) const
     {
         if (impl->rows == 0)

--- a/dbms/src/Core/SortCursor.h
+++ b/dbms/src/Core/SortCursor.h
@@ -244,7 +244,7 @@ public:
         for (size_t i = 0; i < size; ++i)
             if (!cursors[i].empty())
                 queue.emplace_back(&cursors[i]);
-        std::make_heap(queue.begin(), queue.end());
+        rebuild();
     }
 
     bool isValid() const { return !queue.empty(); }
@@ -293,8 +293,14 @@ public:
         return queue;
     }
 
-private:
+    void rebuild()
+    {
+        std::make_heap(queue.begin(), queue.end());
+    }
+
     using Container = std::vector<Cursor>;
+
+private:
     Container queue;
 
     /// Cache comparison between first and second child if the order in queue has not been changed.

--- a/dbms/src/DataStreams/CollapsingSortedBlockInputStream.h
+++ b/dbms/src/DataStreams/CollapsingSortedBlockInputStream.h
@@ -28,7 +28,7 @@ public:
             BlockInputStreams inputs_, const SortDescription & description_,
             const String & sign_column, size_t max_block_size_,
             WriteBuffer * out_row_sources_buf_ = nullptr, bool average_block_sizes_ = false)
-        : MergingSortedBlockInputStream(inputs_, description_, max_block_size_, 0, out_row_sources_buf_, false, average_block_sizes_)
+        : MergingSortedBlockInputStream(inputs_, description_, max_block_size_, 0, 0, out_row_sources_buf_, false, average_block_sizes_)
     {
         sign_column_number = header.getPositionByName(sign_column);
     }

--- a/dbms/src/DataStreams/MergeSortingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/MergeSortingBlockInputStream.cpp
@@ -18,6 +18,12 @@ namespace ProfileEvents
 namespace DB
 {
 
+namespace ErrorCodes
+{
+    extern const int NOT_ENOUGH_SPACE;
+}
+
+
 MergeSortingBlockInputStream::MergeSortingBlockInputStream(
     const BlockInputStreamPtr & input, SortDescription & description_,
     size_t max_merged_block_size_, UInt64 limit_, size_t max_bytes_before_remerge_,

--- a/dbms/src/DataStreams/MergeSortingBlockInputStream.h
+++ b/dbms/src/DataStreams/MergeSortingBlockInputStream.h
@@ -25,13 +25,15 @@ struct TemporaryFileStream;
 
 /** Part of implementation. Merging array of ready (already read from somewhere) blocks.
   * Returns result of merge as stream of blocks, not more than 'max_merged_block_size' rows in each.
+  *
+  * offset - it's permitted to output first offet rows with arbitrary implementation specific data as they will be ignored.
   */
 class MergeSortingBlocksBlockInputStream : public IBlockInputStream
 {
 public:
     /// limit - if not 0, allowed to return just first 'limit' rows in sorted order.
     MergeSortingBlocksBlockInputStream(Blocks & blocks_, const SortDescription & description_,
-        size_t max_merged_block_size_, UInt64 limit_ = 0);
+        size_t max_merged_block_size_, UInt64 limit_ = 0, UInt64 offset_ = 0);
 
     String getName() const override { return "MergeSortingBlocks"; }
 
@@ -49,7 +51,9 @@ private:
     SortDescription description;
     size_t max_merged_block_size;
     UInt64 limit;
+    UInt64 offset;
     size_t total_merged_rows = 0;
+    size_t total_rows_in_blocks = 0;
 
     SortCursorImpls cursors;
 
@@ -72,7 +76,7 @@ class MergeSortingBlockInputStream : public IBlockInputStream
 public:
     /// limit - if not 0, allowed to return just first 'limit' rows in sorted order.
     MergeSortingBlockInputStream(const BlockInputStreamPtr & input, SortDescription & description_,
-        size_t max_merged_block_size_, UInt64 limit_,
+        size_t max_merged_block_size_, UInt64 limit_, UInt64 offset_,
         size_t max_bytes_before_remerge_,
         size_t max_bytes_before_external_sort_, const std::string & tmp_path_,
         size_t min_free_disk_space_);
@@ -91,6 +95,7 @@ private:
     SortDescription description;
     size_t max_merged_block_size;
     UInt64 limit;
+    UInt64 offset;
 
     size_t max_bytes_before_remerge;
     size_t max_bytes_before_external_sort;

--- a/dbms/src/DataStreams/MergeSortingBlockInputStream.h
+++ b/dbms/src/DataStreams/MergeSortingBlockInputStream.h
@@ -18,10 +18,7 @@ namespace DB
 
 struct TemporaryFileStream;
 
-namespace ErrorCodes
-{
-    extern const int NOT_ENOUGH_SPACE;
-}
+
 /** Merges stream of sorted each-separately blocks to sorted as-a-whole stream of blocks.
   * If data to sort is too much, could use external sorting, with temporary files.
   */

--- a/dbms/src/DataStreams/MergingSortedBlockInputStream.cpp
+++ b/dbms/src/DataStreams/MergingSortedBlockInputStream.cpp
@@ -243,7 +243,7 @@ void MergingSortedBlockInputStream::merge(MutableColumns & merged_columns, TSort
 //                std::cerr << "Fast-forward " << num_rows_to_skip << " rows.\n";
 
                 for (size_t i = 0; i < num_columns; ++i)
-                    merged_columns[i] = header.getByPosition(i).column->cloneResized(num_rows_to_skip);
+                    merged_columns[i] = merged_columns[i]->cloneResized(num_rows_to_skip);
 
                 skipBlock(smallest_cursor, queue);
                 total_merged_rows += num_rows_to_skip;

--- a/dbms/src/DataStreams/MergingSortedBlockInputStream.h
+++ b/dbms/src/DataStreams/MergingSortedBlockInputStream.h
@@ -29,12 +29,13 @@ class MergingSortedBlockInputStream : public IBlockInputStream
 {
 public:
     /** limit - if isn't 0, then we can produce only first limit rows in sorted order.
+      * offset - it's permitted to output first offet rows with arbitrary implementation specific data as they will be ignored.
       * out_row_sources - if isn't nullptr, then at the end of execution it should contain part numbers of each readed row (and needed flag)
       * quiet - don't log profiling info
       */
     MergingSortedBlockInputStream(
         const BlockInputStreams & inputs_, const SortDescription & description_, size_t max_block_size_,
-        UInt64 limit_ = 0, WriteBuffer * out_row_sources_buf_ = nullptr, bool quiet_ = false, bool average_block_sizes_ = false);
+        UInt64 limit_ = 0, UInt64 offset_ = 0, WriteBuffer * out_row_sources_buf_ = nullptr, bool quiet_ = false, bool average_block_sizes_ = false);
 
     String getName() const override { return "MergingSorted"; }
 
@@ -93,6 +94,7 @@ protected:
     const SortDescription description;
     const size_t max_block_size;
     UInt64 limit;
+    UInt64 offset;
     UInt64 total_merged_rows = 0;
 
     bool first = true;

--- a/dbms/src/DataStreams/MergingSortedBlockInputStream.h
+++ b/dbms/src/DataStreams/MergingSortedBlockInputStream.h
@@ -88,6 +88,10 @@ protected:
     template <typename TSortCursor>
     void fetchNextBlock(const TSortCursor & current, SortingHeap<TSortCursor> & queue);
 
+    /// Skip to next block in one of cursors.
+    template <typename TSortCursor>
+    void skipBlock(typename SortingHeap<TSortCursor>::Container::iterator it, SortingHeap<TSortCursor> & queue);
+
 
     Block header;
 

--- a/dbms/src/DataStreams/PartialSortingBlockInputStream.cpp
+++ b/dbms/src/DataStreams/PartialSortingBlockInputStream.cpp
@@ -9,6 +9,10 @@ namespace DB
 
 Block PartialSortingBlockInputStream::readImpl()
 {
+    /// TODO. If there is a limit, maintain "greatest" value,
+    /// then skip all blocks that are greater or equal
+    /// and filter other blocks by this value.
+
     Block res = children.back()->read();
     sortBlock(res, description, limit);
     return res;

--- a/dbms/src/DataStreams/ReplacingSortedBlockInputStream.h
+++ b/dbms/src/DataStreams/ReplacingSortedBlockInputStream.h
@@ -20,7 +20,7 @@ public:
         const BlockInputStreams & inputs_, const SortDescription & description_,
         const String & version_column, size_t max_block_size_, WriteBuffer * out_row_sources_buf_ = nullptr,
         bool average_block_sizes_ = false)
-        : MergingSortedBlockInputStream(inputs_, description_, max_block_size_, 0, out_row_sources_buf_, false, average_block_sizes_)
+        : MergingSortedBlockInputStream(inputs_, description_, max_block_size_, 0, 0, out_row_sources_buf_, false, average_block_sizes_)
     {
         if (!version_column.empty())
             version_column_number = header.getPositionByName(version_column);

--- a/dbms/src/DataStreams/VersionedCollapsingSortedBlockInputStream.cpp
+++ b/dbms/src/DataStreams/VersionedCollapsingSortedBlockInputStream.cpp
@@ -18,7 +18,7 @@ VersionedCollapsingSortedBlockInputStream::VersionedCollapsingSortedBlockInputSt
     const BlockInputStreams & inputs_, const SortDescription & description_,
     const String & sign_column_, size_t max_block_size_,
     WriteBuffer * out_row_sources_buf_, bool average_block_sizes_)
-    : MergingSortedBlockInputStream(inputs_, description_, max_block_size_, 0, out_row_sources_buf_, false, average_block_sizes_)
+    : MergingSortedBlockInputStream(inputs_, description_, max_block_size_, 0, 0, out_row_sources_buf_, false, average_block_sizes_)
     , max_rows_in_queue(std::min(std::max<size_t>(3, max_block_size_), MAX_ROWS_IN_MULTIVERSION_QUEUE) - 2)
     , current_keys(max_rows_in_queue + 1)
 {

--- a/dbms/src/DataStreams/tests/gtest_blocks_size_merging_streams.cpp
+++ b/dbms/src/DataStreams/tests/gtest_blocks_size_merging_streams.cpp
@@ -79,7 +79,7 @@ TEST(MergingSortedTest, SimpleBlockSizeTest)
 
     EXPECT_EQ(streams.size(), 3);
 
-    MergingSortedBlockInputStream stream(streams, sort_description, DEFAULT_MERGE_BLOCK_SIZE, 0, nullptr, false, true);
+    MergingSortedBlockInputStream stream(streams, sort_description, DEFAULT_MERGE_BLOCK_SIZE, 0, 0, nullptr, false, true);
 
     size_t total_rows = 0;
     auto block1 = stream.read();
@@ -116,7 +116,7 @@ TEST(MergingSortedTest, MoreInterestingBlockSizes)
 
     EXPECT_EQ(streams.size(), 3);
 
-    MergingSortedBlockInputStream stream(streams, sort_description, DEFAULT_MERGE_BLOCK_SIZE, 0, nullptr, false, true);
+    MergingSortedBlockInputStream stream(streams, sort_description, DEFAULT_MERGE_BLOCK_SIZE, 0, 0, nullptr, false, true);
 
     auto block1 = stream.read();
     auto block2 = stream.read();

--- a/dbms/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterSelectQuery.cpp
@@ -2235,7 +2235,7 @@ void InterpreterSelectQuery::executeOrder(Pipeline & pipeline, InputSortingInfoP
     if (!can_skip_offset)
         offset = 0;
 
-    bool parallel_merge_sort = settings.enable_parallel_merge_sort && limit - offset < settings.min_rows_to_parallel_merge_sort;
+    bool parallel_merge_sort = settings.enable_parallel_merge_sort && limit - offset > settings.min_rows_to_parallel_merge_sort;
 
     if (input_sorting_info)
     {

--- a/dbms/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterSelectQuery.cpp
@@ -2235,8 +2235,6 @@ void InterpreterSelectQuery::executeOrder(Pipeline & pipeline, InputSortingInfoP
     if (!can_skip_offset)
         offset = 0;
 
-    bool parallel_merge_sort = settings.enable_parallel_merge_sort && limit - offset > settings.min_rows_to_parallel_merge_sort;
-
     if (input_sorting_info)
     {
         /* Case of sorting with optimization using sorting key.
@@ -2280,7 +2278,7 @@ void InterpreterSelectQuery::executeOrder(Pipeline & pipeline, InputSortingInfoP
 
             stream = sorting_stream;
 
-            if (parallel_merge_sort)
+            if (settings.enable_parallel_merge_sort)
             {
                 auto merging_stream = std::make_shared<MergeSortingBlockInputStream>(
                     stream, output_order_descr, settings.max_block_size, limit, 0,
@@ -2292,7 +2290,7 @@ void InterpreterSelectQuery::executeOrder(Pipeline & pipeline, InputSortingInfoP
             }
         });
 
-        if (parallel_merge_sort)
+        if (settings.enable_parallel_merge_sort)
         {
             executeMergeSorted(pipeline, output_order_descr, limit, offset);
         }

--- a/dbms/src/Interpreters/InterpreterSelectQuery.h
+++ b/dbms/src/Interpreters/InterpreterSelectQuery.h
@@ -213,9 +213,9 @@ private:
     void executeTotalsAndHaving(Pipeline & pipeline, bool has_having, const ExpressionActionsPtr & expression, bool overflow_row, bool final);
     void executeHaving(Pipeline & pipeline, const ExpressionActionsPtr & expression);
     void executeExpression(Pipeline & pipeline, const ExpressionActionsPtr & expression);
-    void executeOrder(Pipeline & pipeline, InputSortingInfoPtr sorting_info);
+    void executeOrder(Pipeline & pipeline, InputSortingInfoPtr sorting_info, bool can_skip_offset);
     void executeWithFill(Pipeline & pipeline);
-    void executeMergeSorted(Pipeline & pipeline);
+    void executeMergeSorted(Pipeline & pipeline, bool can_skip_offset);
     void executePreLimit(Pipeline & pipeline);
     void executeUnion(Pipeline & pipeline, Block header);
     void executeLimitBy(Pipeline & pipeline);
@@ -224,7 +224,7 @@ private:
     void executeDistinct(Pipeline & pipeline, bool before_order, Names columns);
     void executeExtremes(Pipeline & pipeline);
     void executeSubqueriesInSetsAndJoins(Pipeline & pipeline, std::unordered_map<String, SubqueryForSet> & subqueries_for_sets);
-    void executeMergeSorted(Pipeline & pipeline, const SortDescription & sort_description, UInt64 limit);
+    void executeMergeSorted(Pipeline & pipeline, const SortDescription & sort_description, UInt64 limit, UInt64 offset);
 
     void executeWhere(QueryPipeline & pipeline, const ExpressionActionsPtr & expression, bool remove_fiter);
     void executeAggregation(QueryPipeline & pipeline, const ExpressionActionsPtr & expression, bool overflow_row, bool final);
@@ -232,9 +232,9 @@ private:
     void executeTotalsAndHaving(QueryPipeline & pipeline, bool has_having, const ExpressionActionsPtr & expression, bool overflow_row, bool final);
     void executeHaving(QueryPipeline & pipeline, const ExpressionActionsPtr & expression);
     void executeExpression(QueryPipeline & pipeline, const ExpressionActionsPtr & expression);
-    void executeOrder(QueryPipeline & pipeline, InputSortingInfoPtr sorting_info);
+    void executeOrder(QueryPipeline & pipeline, InputSortingInfoPtr sorting_info, bool can_skip_offset);
     void executeWithFill(QueryPipeline & pipeline);
-    void executeMergeSorted(QueryPipeline & pipeline);
+    void executeMergeSorted(QueryPipeline & pipeline, bool can_skip_offset);
     void executePreLimit(QueryPipeline & pipeline);
     void executeLimitBy(QueryPipeline & pipeline);
     void executeLimit(QueryPipeline & pipeline);
@@ -242,7 +242,7 @@ private:
     void executeDistinct(QueryPipeline & pipeline, bool before_order, Names columns);
     void executeExtremes(QueryPipeline & pipeline);
     void executeSubqueriesInSetsAndJoins(QueryPipeline & pipeline, std::unordered_map<String, SubqueryForSet> & subqueries_for_sets);
-    void executeMergeSorted(QueryPipeline & pipeline, const SortDescription & sort_description, UInt64 limit);
+    void executeMergeSorted(QueryPipeline & pipeline, const SortDescription & sort_description, UInt64 limit, UInt64 offset);
 
     /// Add ConvertingBlockInputStream to specified header.
     void unifyStreams(Pipeline & pipeline, Block header);

--- a/dbms/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
@@ -697,7 +697,7 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataMergerMutator::mergePartsToTempor
     {
         case MergeTreeData::MergingParams::Ordinary:
             merged_stream = std::make_unique<MergingSortedBlockInputStream>(
-                src_streams, sort_description, merge_block_size, 0, rows_sources_write_buf.get(), true, blocks_are_granules_size);
+                src_streams, sort_description, merge_block_size, 0, 0, rows_sources_write_buf.get(), true, blocks_are_granules_size);
             break;
 
         case MergeTreeData::MergingParams::Collapsing:

--- a/dbms/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -43,7 +43,6 @@ namespace std
 #include <DataStreams/CollapsingFinalBlockInputStream.h>
 #include <DataStreams/AddingConstColumnBlockInputStream.h>
 #include <DataStreams/CreatingSetsBlockInputStream.h>
-#include <DataStreams/MergingSortedBlockInputStream.h>
 #include <DataStreams/NullBlockInputStream.h>
 #include <DataStreams/SummingSortedBlockInputStream.h>
 #include <DataStreams/ReplacingSortedBlockInputStream.h>


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Improved performance of pagination queries (ORDER BY with LIMIT with offset) when offset is large.