### PR TITLE
make_changelog.py::process_unknown_commits unicode fix

### DIFF
--- a/utils/make_changelog.py
+++ b/utils/make_changelog.py
@@ -207,7 +207,7 @@ def get_users_info(pull_requests, commits_info, token, max_retries, retry_timeou
 # List of unknown commits -> text description.
 def process_unknown_commits(commits, commits_info, users):
 
-    pattern = 'Commit: [{}]({})\nAuthor: {}\nMessage: {}'
+    pattern = u'Commit: [{}]({})\nAuthor: {}\nMessage: {}'
 
     texts = []
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Non-significant (changelog entry is not needed)

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Fixes exception:
```
Traceback (most recent call last):
  File "./make_changelog.py", line 499, in <module>
    make_changelog(new_release_tag, prev_release_tag, pull_requests, repo, repo_folder, state_file, token, max_retry, retry_timeout)
  File "./make_changelog.py", line 451, in make_changelog
    changelog = u'{}\n\n{}'.format(process_pull_requests(pull_requests, users, repo), process_unknown_commits(unknown_commits, commits_info, users))
  File "./make_changelog.py", line 247, in process_unknown_commits
    aaaa = pattern.format(commit, html_url, author, msg)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2192' in position 38: ordinal not in range(128)
```