### PR TITLE
ensure network be up

### DIFF
--- a/debian/clickhouse-server.init
+++ b/debian/clickhouse-server.init
@@ -3,8 +3,8 @@
 # Provides:          clickhouse-server
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Required-Start:
-# Required-Stop:
+# Required-Start:    $network
+# Required-Stop:     $network
 # Short-Description: Yandex clickhouse-server daemon
 ### END INIT INFO
 

--- a/debian/clickhouse-server.service
+++ b/debian/clickhouse-server.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=ClickHouse Server (analytic DBMS for big data)
+Requires=network-online.target
+After=network-online.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Ensure network be up before starting clickhouse-server. Fix #7507.

