### PR TITLE
Added part_log to example config for developers

### DIFF
--- a/dbms/programs/server/config.d/part_log.xml
+++ b/dbms/programs/server/config.d/part_log.xml
@@ -1,0 +1,7 @@
+<yandex>
+    <part_log>
+        <database>system</database>
+        <table>part_log</table>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    </part_log>
+</yandex>


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Enable `part_log` in example config for developers.

Detailed description (optional):
This is needed to check the hypothesis that merging of another system table is unbalanced.