### PR TITLE
fix printing changelog with non-ascii chars

### DIFF
--- a/utils/make_changelog.py
+++ b/utils/make_changelog.py
@@ -455,7 +455,7 @@ def make_changelog(new_tag, prev_tag, pull_requests_nums, repo, repo_folder, sta
     # Remove double whitespaces and trailing whitespaces
     changelog = re.sub(r' {2,}| +$', r''.format(repo), changelog)
 
-    print(changelog)
+    print(changelog.encode('utf-8'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Non-significant (changelog entry is not needed)

Detailed description (optional):
similar to #8565
fixes unicode output when stdout is redirected to file
```
./make_changelog.py --token ... v19.13.1.1088-testing v19.16.10.44-stable > changelog_1916.txt

Traceback (most recent call last):
  File "./make_changelog.py", line 498, in <module>
    make_changelog(new_release_tag, prev_release_tag, pull_requests, repo, repo_folder, state_file, token, max_retry, retry_timeout)
  File "./make_changelog.py", line 458, in make_changelog
    print(changelog)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u0410' in position 19344: ordinal not in range(128)
```