### PR TITLE
Fix alter codec bug

### DIFF
--- a/dbms/src/Storages/AlterCommands.cpp
+++ b/dbms/src/Storages/AlterCommands.cpp
@@ -249,6 +249,9 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata) const
                 /// let's use info about old type
                 if (data_type == nullptr)
                     codec->useInfoAboutType(column.type);
+                else /// use info about new DataType
+                    codec->useInfoAboutType(data_type);
+
                 column.codec = codec;
             }
 

--- a/dbms/tests/queries/0_stateless/01061_alter_codec_with_type.reference
+++ b/dbms/tests/queries/0_stateless/01061_alter_codec_with_type.reference
@@ -1,0 +1,5 @@
+epoch	UInt64	CODEC(Delta(8), LZ4)
+_time_dec	Float64	
+epoch	UInt64	toUInt64(_time_dec)	CODEC(Delta(8), LZ4)
+_time_dec	Float64		
+1577351080	1577351080

--- a/dbms/tests/queries/0_stateless/01061_alter_codec_with_type.sql
+++ b/dbms/tests/queries/0_stateless/01061_alter_codec_with_type.sql
@@ -1,0 +1,19 @@
+DROP TABLE IF EXISTS alter_bug;
+
+create table alter_bug (
+  epoch UInt64 CODEC(Delta,LZ4),
+  _time_dec Float64
+) Engine = MergeTree ORDER BY (epoch);
+
+
+SELECT name, type, compression_codec FROM system.columns WHERE table='alter_bug' AND database=currentDatabase();
+
+ALTER TABLE alter_bug MODIFY COLUMN epoch DEFAULT toUInt64(_time_dec) CODEC(Delta,LZ4);
+
+SELECT name, type, default_expression, compression_codec FROM system.columns WHERE table='alter_bug' AND database=currentDatabase();
+
+INSERT INTO alter_bug(_time_dec) VALUES(1577351080);
+
+SELECT * FROM alter_bug;
+
+DROP TABLE IF EXISTS alter_bug;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Fix bug in `ALTER ... MODIFY ... CODEC` query, when user specify both default expression and codec. Fixes [8593](https://github.com/ClickHouse/ClickHouse/issues/8593).