### PR TITLE
Make one unit test more maintainable

### DIFF
--- a/dbms/src/Common/ZooKeeper/tests/gtest_zkutil_test_multi_exception.cpp
+++ b/dbms/src/Common/ZooKeeper/tests/gtest_zkutil_test_multi_exception.cpp
@@ -85,7 +85,7 @@ TEST(zkutil, multi_async)
         ops.clear();
 
         auto res = fut.get();
-        ASSERT_TRUE(res.error == Coordination::ZOK);
+        ASSERT_EQ(res.error, Coordination::ZOK);
         ASSERT_EQ(res.responses.size(), 2);
     }
 
@@ -121,7 +121,7 @@ TEST(zkutil, multi_async)
         ops.clear();
 
         auto res = fut.get();
-        ASSERT_TRUE(res.error == Coordination::ZNODEEXISTS);
+        ASSERT_EQ(res.error, Coordination::ZNODEEXISTS);
         ASSERT_EQ(res.responses.size(), 2);
     }
 }


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Progress towards fixing one flacky test.