### PR TITLE
Initial commit to fix IParser::Pos.max_depth issue

### DIFF
--- a/dbms/src/Core/Settings.h
+++ b/dbms/src/Core/Settings.h
@@ -394,6 +394,7 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingBool, allow_experimental_data_skipping_indices, true, "Obsolete setting, does nothing. Will be removed after 2020-05-31", 0) \
     M(SettingBool, merge_tree_uniform_read_distribution, true, "Obsolete setting, does nothing. Will be removed after 2020-05-20", 0) \
     M(SettingUInt64, mark_cache_min_lifetime, 0, "Obsolete setting, does nothing. Will be removed after 2020-05-31", 0) \
+    M(SettingUInt64, max_parser_depth, 1000, "Maximum parser depth.", 0) \
 
     DECLARE_SETTINGS_COLLECTION(LIST_OF_SETTINGS)
 

--- a/dbms/src/Databases/DatabaseDictionary.cpp
+++ b/dbms/src/Databases/DatabaseDictionary.cpp
@@ -109,11 +109,12 @@ ASTPtr DatabaseDictionary::getCreateTableQueryImpl(const Context & context,
         buffer << ") Engine = Dictionary(" << backQuoteIfNeed(table_name) << ")";
     }
 
+    auto settings = context.getSettingsRef();
     ParserCreateQuery parser;
     const char * pos = query.data();
     std::string error_message;
     auto ast = tryParseQuery(parser, pos, pos + query.size(), error_message,
-            /* hilite = */ false, "", /* allow_multi_statements = */ false, 0);
+            /* hilite = */ false, "", /* allow_multi_statements = */ false, 0, settings.max_parser_depth);
 
     if (!ast && throw_on_error)
         throw Exception(error_message, ErrorCodes::SYNTAX_ERROR);
@@ -121,15 +122,16 @@ ASTPtr DatabaseDictionary::getCreateTableQueryImpl(const Context & context,
     return ast;
 }
 
-ASTPtr DatabaseDictionary::getCreateDatabaseQuery() const
+ASTPtr DatabaseDictionary::getCreateDatabaseQuery(const Context & context) const
 {
     String query;
     {
         WriteBufferFromString buffer(query);
         buffer << "CREATE DATABASE " << backQuoteIfNeed(database_name) << " ENGINE = Dictionary";
     }
+    auto settings = context.getSettingsRef();
     ParserCreateQuery parser;
-    return parseQuery(parser, query.data(), query.data() + query.size(), "", 0);
+    return parseQuery(parser, query.data(), query.data() + query.size(), "", 0, settings.max_parser_depth);
 }
 
 void DatabaseDictionary::shutdown()

--- a/dbms/src/Databases/DatabaseDictionary.h
+++ b/dbms/src/Databases/DatabaseDictionary.h
@@ -41,7 +41,7 @@ public:
 
     bool empty(const Context & context) const override;
 
-    ASTPtr getCreateDatabaseQuery() const override;
+    ASTPtr getCreateDatabaseQuery(const Context & context) const override;
 
     void shutdown() override;
 

--- a/dbms/src/Databases/DatabaseLazy.cpp
+++ b/dbms/src/Databases/DatabaseLazy.cpp
@@ -230,7 +230,7 @@ StoragePtr DatabaseLazy::loadTable(const Context & context, const String & table
         StoragePtr table;
         Context context_copy(context); /// some tables can change context, but not LogTables
 
-        auto ast = parseQueryFromMetadata(table_metadata_path, /*throw_on_error*/ true, /*remove_empty*/false);
+        auto ast = parseQueryFromMetadata(context, table_metadata_path, /*throw_on_error*/ true, /*remove_empty*/false);
         if (ast)
         {
             auto & ast_create = ast->as<const ASTCreateQuery &>();

--- a/dbms/src/Databases/DatabaseMemory.cpp
+++ b/dbms/src/Databases/DatabaseMemory.cpp
@@ -27,7 +27,7 @@ void DatabaseMemory::removeTable(
     detachTable(table_name);
 }
 
-ASTPtr DatabaseMemory::getCreateDatabaseQuery() const
+ASTPtr DatabaseMemory::getCreateDatabaseQuery(const Context & /*context*/) const
 {
     auto create_query = std::make_shared<ASTCreateQuery>();
     create_query->database = database_name;

--- a/dbms/src/Databases/DatabaseMemory.h
+++ b/dbms/src/Databases/DatabaseMemory.h
@@ -31,7 +31,7 @@ public:
         const Context & context,
         const String & table_name) override;
 
-    ASTPtr getCreateDatabaseQuery() const override;
+    ASTPtr getCreateDatabaseQuery(const Context & /*context*/) const override;
 };
 
 }

--- a/dbms/src/Databases/DatabaseMySQL.cpp
+++ b/dbms/src/Databases/DatabaseMySQL.cpp
@@ -181,7 +181,7 @@ time_t DatabaseMySQL::getObjectMetadataModificationTime(const String & table_nam
     return time_t(local_tables_cache[table_name].first);
 }
 
-ASTPtr DatabaseMySQL::getCreateDatabaseQuery() const
+ASTPtr DatabaseMySQL::getCreateDatabaseQuery(const Context & /*context*/) const
 {
     const auto & create_query = std::make_shared<ASTCreateQuery>();
     create_query->database = database_name;

--- a/dbms/src/Databases/DatabaseMySQL.h
+++ b/dbms/src/Databases/DatabaseMySQL.h
@@ -32,7 +32,7 @@ public:
 
     DatabaseTablesIteratorPtr getTablesIterator(const Context & context, const FilterByNameFunction & filter_by_table_name = {}) override;
 
-    ASTPtr getCreateDatabaseQuery() const override;
+    ASTPtr getCreateDatabaseQuery(const Context & /*context*/) const override;
 
     bool isTableExist(const Context & context, const String & name) const override;
 

--- a/dbms/src/Databases/DatabaseOnDisk.cpp
+++ b/dbms/src/Databases/DatabaseOnDisk.cpp
@@ -211,7 +211,7 @@ void DatabaseOnDisk::renameTable(
     if (!table)
         throw Exception("Table " + backQuote(getDatabaseName()) + "." + backQuote(table_name) + " doesn't exist.", ErrorCodes::UNKNOWN_TABLE);
 
-    ASTPtr ast = parseQueryFromMetadata(getObjectMetadataPath(table_name));
+    ASTPtr ast = parseQueryFromMetadata(context, getObjectMetadataPath(table_name));
     if (!ast)
         throw Exception("There is no metadata file for table " + backQuote(table_name) + ".", ErrorCodes::FILE_DOESNT_EXIST);
     auto & create = ast->as<ASTCreateQuery &>();
@@ -244,7 +244,7 @@ ASTPtr DatabaseOnDisk::getCreateTableQueryImpl(const Context & context, const St
     ASTPtr ast;
 
     auto table_metadata_path = getObjectMetadataPath(table_name);
-    ast = getCreateQueryFromMetadata(table_metadata_path, throw_on_error);
+    ast = getCreateQueryFromMetadata(context, table_metadata_path, throw_on_error);
     if (!ast && throw_on_error)
     {
         /// Handle system.* tables for which there are no table.sql files.
@@ -260,20 +260,21 @@ ASTPtr DatabaseOnDisk::getCreateTableQueryImpl(const Context & context, const St
     return ast;
 }
 
-ASTPtr DatabaseOnDisk::getCreateDatabaseQuery() const
+ASTPtr DatabaseOnDisk::getCreateDatabaseQuery(const Context & context) const
 {
     ASTPtr ast;
 
+    auto settings = context.getSettingsRef();
     auto metadata_dir_path = getMetadataPath();
     auto database_metadata_path = metadata_dir_path.substr(0, metadata_dir_path.size() - 1) + ".sql";
-    ast = getCreateQueryFromMetadata(database_metadata_path, true);
+    ast = getCreateQueryFromMetadata(context, database_metadata_path, true);
     if (!ast)
     {
         /// Handle databases (such as default) for which there are no database.sql files.
         /// If database.sql doesn't exist, then engine is Ordinary
         String query = "CREATE DATABASE " + backQuoteIfNeed(getDatabaseName()) + " ENGINE = Ordinary";
         ParserCreateQuery parser;
-        ast = parseQuery(parser, query.data(), query.data() + query.size(), "", 0);
+        ast = parseQuery(parser, query.data(), query.data() + query.size(), "", 0, settings.max_parser_depth);
     }
 
     return ast;
@@ -353,7 +354,7 @@ void DatabaseOnDisk::iterateMetadataFiles(const Context & context, const Iterati
     }
 }
 
-ASTPtr DatabaseOnDisk::parseQueryFromMetadata(const String & metadata_file_path, bool throw_on_error /*= true*/, bool remove_empty /*= false*/) const
+ASTPtr DatabaseOnDisk::parseQueryFromMetadata(const Context & context, const String & metadata_file_path, bool throw_on_error /*= true*/, bool remove_empty /*= false*/) const
 {
     String query;
 
@@ -380,11 +381,12 @@ ASTPtr DatabaseOnDisk::parseQueryFromMetadata(const String & metadata_file_path,
         return nullptr;
     }
 
+    auto settings = context.getSettingsRef();
     ParserCreateQuery parser;
     const char * pos = query.data();
     std::string error_message;
     auto ast = tryParseQuery(parser, pos, pos + query.size(), error_message, /* hilite = */ false,
-                             "in file " + getMetadataPath(), /* allow_multi_statements = */ false, 0);
+                             "in file " + getMetadataPath(), /* allow_multi_statements = */ false, 0, settings.max_parser_depth);
 
     if (!ast && throw_on_error)
         throw Exception(error_message, ErrorCodes::SYNTAX_ERROR);
@@ -394,9 +396,9 @@ ASTPtr DatabaseOnDisk::parseQueryFromMetadata(const String & metadata_file_path,
     return ast;
 }
 
-ASTPtr DatabaseOnDisk::getCreateQueryFromMetadata(const String & database_metadata_path, bool throw_on_error) const
+ASTPtr DatabaseOnDisk::getCreateQueryFromMetadata(const Context & context, const String & database_metadata_path, bool throw_on_error) const
 {
-    ASTPtr ast = parseQueryFromMetadata(database_metadata_path, throw_on_error);
+    ASTPtr ast = parseQueryFromMetadata(context, database_metadata_path, throw_on_error);
 
     if (ast)
     {

--- a/dbms/src/Databases/DatabaseOnDisk.h
+++ b/dbms/src/Databases/DatabaseOnDisk.h
@@ -52,7 +52,7 @@ public:
         const String & to_table_name,
         TableStructureWriteLockHolder & lock) override;
 
-    ASTPtr getCreateDatabaseQuery() const override;
+    ASTPtr getCreateDatabaseQuery(const Context & context) const override;
 
     void drop(const Context & context) override;
 
@@ -74,8 +74,8 @@ protected:
         const String & table_name,
         bool throw_on_error) const override;
 
-    ASTPtr parseQueryFromMetadata(const String & metadata_file_path, bool throw_on_error = true, bool remove_empty = false) const;
-    ASTPtr getCreateQueryFromMetadata(const String & metadata_path, bool throw_on_error) const;
+    ASTPtr parseQueryFromMetadata(const Context & context, const String & metadata_file_path, bool throw_on_error = true, bool remove_empty = false) const;
+    ASTPtr getCreateQueryFromMetadata(const Context & context, const String & metadata_path, bool throw_on_error) const;
 
 
     const String metadata_path;

--- a/dbms/src/Databases/DatabaseOrdinary.cpp
+++ b/dbms/src/Databases/DatabaseOrdinary.cpp
@@ -122,12 +122,12 @@ void DatabaseOrdinary::loadStoredObjects(
     FileNames file_names;
 
     size_t total_dictionaries = 0;
-    iterateMetadataFiles(context, [&file_names, &total_dictionaries, this](const String & file_name)
+    iterateMetadataFiles(context, [context, &file_names, &total_dictionaries, this](const String & file_name)
     {
         String full_path = getMetadataPath() + file_name;
         try
         {
-            auto ast = parseQueryFromMetadata(full_path, /*throw_on_error*/ true, /*remove_empty*/false);
+            auto ast = parseQueryFromMetadata(context, full_path, /*throw_on_error*/ true, /*remove_empty*/false);
             if (ast)
             {
                 auto * create_query = ast->as<ASTCreateQuery>();

--- a/dbms/src/Databases/DatabaseOrdinary.cpp
+++ b/dbms/src/Databases/DatabaseOrdinary.cpp
@@ -122,7 +122,7 @@ void DatabaseOrdinary::loadStoredObjects(
     FileNames file_names;
 
     size_t total_dictionaries = 0;
-    iterateMetadataFiles(context, [context, &file_names, &total_dictionaries, this](const String & file_name)
+    iterateMetadataFiles(context, [&context, &file_names, &total_dictionaries, this](const String & file_name)
     {
         String full_path = getMetadataPath() + file_name;
         try

--- a/dbms/src/Databases/DatabaseWithDictionaries.cpp
+++ b/dbms/src/Databases/DatabaseWithDictionaries.cpp
@@ -235,7 +235,7 @@ ASTPtr DatabaseWithDictionaries::getCreateDictionaryQueryImpl(
     ASTPtr ast;
 
     auto dictionary_metadata_path = getObjectMetadataPath(dictionary_name);
-    ast = getCreateQueryFromMetadata(dictionary_metadata_path, throw_on_error);
+    ast = getCreateQueryFromMetadata(context, dictionary_metadata_path, throw_on_error);
     if (!ast && throw_on_error)
     {
         /// Handle system.* tables for which there are no table.sql files.

--- a/dbms/src/Databases/IDatabase.h
+++ b/dbms/src/Databases/IDatabase.h
@@ -262,7 +262,7 @@ public:
     }
 
     /// Get the CREATE DATABASE query for current database.
-    virtual ASTPtr getCreateDatabaseQuery() const = 0;
+    virtual ASTPtr getCreateDatabaseQuery(const Context & /*context*/) const = 0;
 
     /// Get name of database.
     String getDatabaseName() const { return database_name; }

--- a/dbms/src/Interpreters/InterpreterShowCreateQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterShowCreateQuery.cpp
@@ -55,7 +55,7 @@ BlockInputStreamPtr InterpreterShowCreateQuery::executeImpl()
     {
         if (show_query->temporary)
             throw Exception("Temporary databases are not possible.", ErrorCodes::SYNTAX_ERROR);
-        create_query = context.getDatabase(show_query->database)->getCreateDatabaseQuery();
+        create_query = context.getDatabase(show_query->database)->getCreateDatabaseQuery(context);
     }
     else if ((show_query = query_ptr->as<ASTShowCreateDictionaryQuery>()))
     {

--- a/dbms/src/Interpreters/executeQuery.cpp
+++ b/dbms/src/Interpreters/executeQuery.cpp
@@ -214,7 +214,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
     try
     {
         /// TODO Parser should fail early when max_query_size limit is reached.
-        ast = parseQuery(parser, begin, end, "", max_query_size);
+        ast = parseQuery(parser, begin, end, "", max_query_size, settings.max_parser_depth);
 
         auto * insert_query = ast->as<ASTInsertQuery>();
 

--- a/dbms/src/Parsers/IParser.h
+++ b/dbms/src/Parsers/IParser.h
@@ -5,6 +5,8 @@
 
 #include <Core/Defines.h>
 #include <Core/Types.h>
+#include <Core/Settings.h>
+#include <IO/WriteHelpers.h>
 #include <Parsers/IAST.h>
 #include <Parsers/TokenIterator.h>
 
@@ -57,13 +59,15 @@ public:
         using TokenIterator::TokenIterator;
 
         uint32_t depth = 0;
-        uint32_t max_depth = 1000;
+        uint32_t max_depth = 0;
+
+        Pos(Tokens & tokens_, uint32_t max_depth_) : TokenIterator(tokens_), max_depth(max_depth_) {}
 
         void increaseDepth()
         {
             ++depth;
-            if (depth > max_depth)
-                throw Exception("Maximum parse depth exceeded", ErrorCodes::TOO_DEEP_RECURSION);
+            if (max_depth > 0 && depth > max_depth)
+                throw Exception("Maximum parse depth (" + toString(max_depth) + ") exceeded. Consider rising max_parser_depth parameter.", ErrorCodes::TOO_DEEP_RECURSION);
         }
 
         void decreaseDepth()

--- a/dbms/src/Parsers/parseQuery.cpp
+++ b/dbms/src/Parsers/parseQuery.cpp
@@ -215,10 +215,11 @@ ASTPtr tryParseQuery(
     bool hilite,
     const std::string & query_description,
     bool allow_multi_statements,
-    size_t max_query_size)
+    size_t max_query_size,
+    size_t max_parser_depth)
 {
     Tokens tokens(pos, end, max_query_size);
-    IParser::Pos token_iterator(tokens);
+    IParser::Pos token_iterator(tokens, max_parser_depth);
 
     if (token_iterator->isEnd()
         || token_iterator->type == TokenType::Semicolon)
@@ -297,10 +298,11 @@ ASTPtr parseQueryAndMovePosition(
     const char * end,
     const std::string & query_description,
     bool allow_multi_statements,
-    size_t max_query_size)
+    size_t max_query_size,
+    size_t max_parser_depth)
 {
     std::string error_message;
-    ASTPtr res = tryParseQuery(parser, pos, end, error_message, false, query_description, allow_multi_statements, max_query_size);
+    ASTPtr res = tryParseQuery(parser, pos, end, error_message, false, query_description, allow_multi_statements, max_query_size, max_parser_depth);
 
     if (res)
         return res;
@@ -314,10 +316,11 @@ ASTPtr parseQuery(
     const char * begin,
     const char * end,
     const std::string & query_description,
-    size_t max_query_size)
+    size_t max_query_size,
+    size_t max_parser_depth)
 {
     auto pos = begin;
-    return parseQueryAndMovePosition(parser, pos, end, query_description, false, max_query_size);
+    return parseQueryAndMovePosition(parser, pos, end, query_description, false, max_query_size, max_parser_depth);
 }
 
 

--- a/dbms/src/Parsers/parseQuery.h
+++ b/dbms/src/Parsers/parseQuery.h
@@ -15,8 +15,9 @@ ASTPtr tryParseQuery(
     bool hilite,
     const std::string & description,
     bool allow_multi_statements,    /// If false, check for non-space characters after semicolon and set error message if any.
-    size_t max_query_size);         /// If (end - pos) > max_query_size and query is longer than max_query_size then throws "Max query size exceeded".
+    size_t max_query_size,          /// If (end - pos) > max_query_size and query is longer than max_query_size then throws "Max query size exceeded".
                                     /// Disabled if zero. Is used in order to check query size if buffer can contains data for INSERT query.
+    size_t max_parser_depth = 0);
 
 
 /// Parse query or throw an exception with error message.
@@ -26,15 +27,16 @@ ASTPtr parseQueryAndMovePosition(
     const char * end,
     const std::string & description,
     bool allow_multi_statements,
-    size_t max_query_size);
-
+    size_t max_query_size = 0,
+    size_t max_parser_depth = 0);
 
 ASTPtr parseQuery(
     IParser & parser,
     const char * begin,
     const char * end,
     const std::string & description,
-    size_t max_query_size);
+    size_t max_query_size,
+    size_t max_parser_depth = 0);
 
 ASTPtr parseQuery(
     IParser & parser,

--- a/dbms/src/Processors/Formats/Impl/ConstantExpressionTemplate.h
+++ b/dbms/src/Processors/Formats/Impl/ConstantExpressionTemplate.h
@@ -66,7 +66,7 @@ public:
 
     /// Read expression from istr, assert it has the same structure and the same types of literals (template matches)
     /// and parse literals into temporary columns
-    bool parseExpression(ReadBuffer & istr, const FormatSettings & settings);
+    bool parseExpression(ReadBuffer & istr, const FormatSettings & format_settings, const Settings & settings);
 
     /// Evaluate batch of expressions were parsed using template.
     /// If template was deduced with null_as_default == true, set bits in nulls for NULL values in column_idx, starting from offset.
@@ -75,8 +75,8 @@ public:
     size_t rowsCount() const { return rows_count; }
 
 private:
-    bool tryParseExpression(ReadBuffer & istr, const FormatSettings & settings, size_t & cur_column);
-    bool parseLiteralAndAssertType(ReadBuffer & istr, const IDataType * type, size_t column_idx);
+    bool tryParseExpression(ReadBuffer & istr, const FormatSettings & format_settings, size_t & cur_column, const Settings & settings);
+    bool parseLiteralAndAssertType(ReadBuffer & istr, const IDataType * type, size_t column_idx, const Settings & settings);
 
 private:
     TemplateStructurePtr structure;

--- a/dbms/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
@@ -129,7 +129,8 @@ void ValuesBlockInputFormat::readRow(MutableColumns & columns, size_t row_num)
 bool ValuesBlockInputFormat::tryParseExpressionUsingTemplate(MutableColumnPtr & column, size_t column_idx)
 {
     /// Try to parse expression using template if one was successfully deduced while parsing the first row
-    if (templates[column_idx]->parseExpression(buf, format_settings))
+    auto settings = context->getSettingsRef();
+    if (templates[column_idx]->parseExpression(buf, format_settings, settings))
     {
         ++rows_parsed_using_template[column_idx];
         return true;
@@ -187,6 +188,7 @@ bool ValuesBlockInputFormat::parseExpression(IColumn & column, size_t column_idx
 {
     const Block & header = getPort().getHeader();
     const IDataType & type = *header.getByPosition(column_idx).type;
+    auto settings = context->getSettingsRef();
 
     /// We need continuous memory containing the expression to use Lexer
     skipToNextRow(0, 1);
@@ -195,7 +197,7 @@ bool ValuesBlockInputFormat::parseExpression(IColumn & column, size_t column_idx
 
     Expected expected;
     Tokens tokens(buf.position(), buf.buffer().end());
-    IParser::Pos token_iterator(tokens);
+    IParser::Pos token_iterator(tokens, settings.max_parser_depth);
     ASTPtr ast;
 
     bool parsed = parser.parse(token_iterator, ast, expected);
@@ -265,7 +267,7 @@ bool ValuesBlockInputFormat::parseExpression(IColumn & column, size_t column_idx
                 ++attempts_to_deduce_template[column_idx];
 
             buf.rollbackToCheckpoint();
-            if (templates[column_idx]->parseExpression(buf, format_settings))
+            if (templates[column_idx]->parseExpression(buf, format_settings, settings))
             {
                 ++rows_parsed_using_template[column_idx];
                 parser_type_for_column[column_idx] = ParserType::BatchTemplate;

--- a/dbms/src/TableFunctions/parseColumnsListForTableFunction.cpp
+++ b/dbms/src/TableFunctions/parseColumnsListForTableFunction.cpp
@@ -18,6 +18,8 @@ ColumnsDescription parseColumnsListFromString(const std::string & structure, con
 
     Tokens tokens(structure.c_str(), structure.c_str() + structure.size());
     IParser::Pos token_iterator(tokens);
+    const Settings & settings = context.getSettingsRef();
+    token_iterator.max_depth = settings.max_parser_depth;
 
     ParserColumnDeclarationList parser;
     ASTPtr columns_list_raw;

--- a/dbms/tests/queries/0_stateless/01062_max_parser_depth.reference
+++ b/dbms/tests/queries/0_stateless/01062_max_parser_depth.reference
@@ -1,0 +1,4 @@
+-
+Maximum parse depth (40) exceeded.
+-
+Maximum parse depth (20) exceeded.

--- a/dbms/tests/queries/0_stateless/01062_max_parser_depth.sh
+++ b/dbms/tests/queries/0_stateless/01062_max_parser_depth.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. $CURDIR/../shell_config.sh
+
+echo 'select 1' | ${CLICKHOUSE_CURL} -sSg "${CLICKHOUSE_URL}&max_parser_depth=40" -d @- 2>&1 | grep -oP "Maximum parse depth .* exceeded."
+echo -
+echo 'select (1+1)*(2+1)' | ${CLICKHOUSE_CURL} -sSg "${CLICKHOUSE_URL}&max_parser_depth=40" -d @- 2>&1 | grep -oP "Maximum parse depth .* exceeded."
+echo -
+echo 'select 1' | ${CLICKHOUSE_CURL} -sSg "${CLICKHOUSE_URL}&max_parser_depth=20" -d @- 2>&1 | grep -oP "Maximum parse depth .* exceeded."


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):

New setting introduced: max_parser_depth. To control maximum stack size and allow long complex queries. This fixes #6681 and #7668.
