### PR TITLE
Avoid stale log files.

### DIFF
--- a/dbms/programs/server/Server.cpp
+++ b/dbms/programs/server/Server.cpp
@@ -436,8 +436,10 @@ int Server::main(const std::vector<std::string> & /*args*/)
         main_config_zk_changed_event,
         [&](ConfigurationPtr config)
         {
-            setTextLog(global_context->getTextLog());
-            buildLoggers(*config, logger());
+            // FIXME logging-related things need synchronization -- see the 'Logger * log' saved
+            // in a lot of places. For now, disable updating log configuration without server restart.
+            //setTextLog(global_context->getTextLog());
+            //buildLoggers(*config, logger());
             global_context->setClustersConfig(config);
             global_context->setMacros(std::make_unique<Macros>(*config, "macros"));
 
@@ -861,6 +863,9 @@ int Server::main(const std::vector<std::string> & /*args*/)
 
         for (auto & server : servers)
             server->start();
+
+        setTextLog(global_context->getTextLog());
+        buildLoggers(config(), logger());
 
         main_config_reloader->start();
         users_config_reloader->start();


### PR DESCRIPTION
When the logging configuration changes, the logging-related data
structures on the server are not properly updated. This leads to a bug
where logs are written to old files, and it is impossible to fix without
restarting the server. The log file grows indefinitely and eventually
makes the server run out of disk space (see #8696). To avoid
catastrophic consequences, require that the server is restarted to apply
logging configuration changes, until the proper fix is developed.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Backward Incompatible Change

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Require server to be restarted to apply the changes in logging configuration. This is a temporary workaround to avoid the bug where the server logs to a deleted log file (see #8696).