### PR TITLE
Added cluster names to suggestions in interactive mode in clickhouse-client

### DIFF
--- a/dbms/programs/client/Suggest.h
+++ b/dbms/programs/client/Suggest.h
@@ -87,6 +87,8 @@ private:
             " UNION ALL "
             "SELECT name FROM system.settings"
             " UNION ALL "
+            "SELECT cluster FROM system.clusters"
+            " UNION ALL "
             "SELECT concat(func.name, comb.name) FROM system.functions AS func CROSS JOIN system.aggregate_function_combinators AS comb WHERE is_aggregate";
 
         /// The user may disable loading of databases, tables, columns by setting suggestion_limit to zero.


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Added names of clusters to suggestions in interactive mode in clickhouse-client.

Detailed description (optional):
I get tired typing cluster names or querying them from system.clusters.