### PR TITLE
Do not interpolate quantiles in clickhouse-benchmark

### DIFF
--- a/dbms/programs/benchmark/Benchmark.cpp
+++ b/dbms/programs/benchmark/Benchmark.cpp
@@ -418,7 +418,7 @@ private:
             std::cerr << percent << "%\t\t";
             for (const auto & info : infos)
             {
-                std::cerr << info->sampler.quantileInterpolated(percent / 100.0) << " sec." << "\t";
+                std::cerr << info->sampler.quantileNearest(percent / 100.0) << " sec." << "\t";
             }
             std::cerr << "\n";
         };
@@ -453,7 +453,7 @@ private:
 
         auto print_percentile = [&json_out](Stats & info, auto percent, bool with_comma = true)
         {
-            json_out << "\"" << percent << "\"" << ": " << info.sampler.quantileInterpolated(percent / 100.0) << (with_comma ? ",\n" : "\n");
+            json_out << "\"" << percent << "\"" << ": " << info.sampler.quantileNearest(percent / 100.0) << (with_comma ? ",\n" : "\n");
         };
 
         json_out << "{\n";


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Show nearest query execution time for quantiles in `clickhouse-benchmark` output instead of interpolated values. It's better to show values that correspond to the execution time of some queries.

Detailed description:

Look here:
```
Queries executed: 371.

localhost:9000, queries 1, QPS: 1.145, RPS: 114470255.382, MiB/s: 11568.352, result RPS: 11.447, result MiB/s: 0.006.

0.000%          0.874 sec.
10.000%         0.874 sec.
20.000%         0.874 sec.
30.000%         0.874 sec.
40.000%         0.874 sec.
50.000%         0.874 sec.
60.000%         0.874 sec.
70.000%         0.874 sec.
80.000%         0.874 sec.
90.000%         0.874 sec.
95.000%         0.874 sec.
99.000%         0.874 sec.
99.900%         0.874 sec.
99.990%         0.874 sec.



Queries executed: 373.

localhost:9000, queries 2, QPS: 1.107, RPS: 110678086.725, MiB/s: 11185.116, result RPS: 11.068, result MiB/s: 0.006.

0.000%          0.885 sec.
10.000%         0.889 sec.
20.000%         0.892 sec.
30.000%         0.896 sec.
40.000%         0.900 sec.
50.000%         0.904 sec.
60.000%         0.907 sec.
70.000%         0.911 sec.
80.000%         0.915 sec.
90.000%         0.918 sec.
95.000%         0.920 sec.
99.000%         0.922 sec.
99.900%         0.922 sec.
99.990%         0.922 sec.



Queries executed: 374.

localhost:9000, queries 1, QPS: 1.139, RPS: 113930016.441, MiB/s: 11513.756, result RPS: 11.393, result MiB/s: 0.006.

0.000%          0.878 sec.
10.000%         0.878 sec.
20.000%         0.878 sec.
30.000%         0.878 sec.
40.000%         0.878 sec.
50.000%         0.878 sec.
60.000%         0.878 sec.
70.000%         0.878 sec.
80.000%         0.878 sec.
90.000%         0.878 sec.
95.000%         0.878 sec.
99.000%         0.878 sec.
99.900%         0.878 sec.
99.990%         0.878 sec.
```

Sometime only one query is finished in a second, sometimes two. When two queries are finished, a range of interpolated values from 0.885 sec. to 0.922 sec. is displayed. This can be non-intuitive.