### PR TITLE
set signal before rethrowing exception

### DIFF
--- a/dbms/src/Common/ThreadPool.h
+++ b/dbms/src/Common/ThreadPool.h
@@ -151,9 +151,15 @@ public:
             func = std::forward<Function>(func),
             args = std::make_tuple(std::forward<Args>(args)...)]
         {
+            try
             {
                 DB::ThreadStatus thread_status;
                 std::apply(func, args);
+            }
+            catch (...)
+            {
+                state->set();
+                throw;
             }
             state->set();
         });

--- a/dbms/src/Common/ThreadPool.h
+++ b/dbms/src/Common/ThreadPool.h
@@ -153,6 +153,8 @@ public:
         {
             try
             {
+                /// Thread status holds raw pointer on query context, thus it always must be destroyed
+                /// before sending signal that permits to join this thread.
                 DB::ThreadStatus thread_status;
                 std::apply(func, args);
             }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Signal termination of thread to the thread pool even if the thread has thrown exception
...


Detailed description (optional):
Fix #8569 

This pull request attempts to improve thread handling, so that when the `ThreadPool`s are dropped, they will not be blocked by threads that have thrown exception before.
...
