### PR TITLE
Fix wrong data path in DatabaseMemory

### DIFF
--- a/dbms/src/Databases/DatabaseMemory.cpp
+++ b/dbms/src/Databases/DatabaseMemory.cpp
@@ -9,6 +9,7 @@ namespace DB
 
 DatabaseMemory::DatabaseMemory(const String & name_)
     : DatabaseWithOwnTablesBase(name_, "DatabaseMemory(" + name_ + ")")
+    , data_path("data/" + escapeForFileName(database_name) + "/")
 {}
 
 void DatabaseMemory::createTable(

--- a/dbms/src/Databases/DatabaseMemory.h
+++ b/dbms/src/Databases/DatabaseMemory.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <Databases/DatabasesCommon.h>
+#include <Common/escapeForFileName.h>
+#include <Parsers/ASTCreateQuery.h>
 
 
 namespace Poco { class Logger; }
@@ -32,6 +34,16 @@ public:
         const String & table_name) override;
 
     ASTPtr getCreateDatabaseQuery(const Context & /*context*/) const override;
+
+    /// DatabaseMemory allows to create tables, which store data on disk.
+    /// It's needed to create such tables in default database of clickhouse-local.
+    /// TODO May be it's better to use DiskMemory for such tables.
+    ///      To save data on disk it's possible to explicitly CREATE DATABASE db ENGINE=Ordinary in clickhouse-local.
+    String getTableDataPath(const String & table_name) const override { return data_path + escapeForFileName(table_name) + "/"; }
+    String getTableDataPath(const ASTCreateQuery & query) const override { return getTableDataPath(query.table); }
+
+private:
+    String data_path;
 };
 
 }

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -138,6 +138,9 @@ MergeTreeData::MergeTreeData(
     , data_parts_by_state_and_info(data_parts_indexes.get<TagByStateAndInfo>())
     , parts_mover(this)
 {
+    if (relative_data_path.empty())
+        throw Exception("MergeTree storages require data path", ErrorCodes::INCORRECT_FILE_NAME);
+
     const auto settings = getSettings();
     setProperties(metadata);
 

--- a/dbms/src/Storages/StorageFactory.cpp
+++ b/dbms/src/Storages/StorageFactory.cpp
@@ -132,12 +132,6 @@ StoragePtr StorageFactory::get(
         }
     }
 
-    if (relative_data_path.empty())
-    {
-        if (endsWith(name, "MergeTree") || endsWith(name, "Log") || name == "Join" || name == "Set")
-            throw Exception("Data path cannot be empty for table with engine " + name, ErrorCodes::LOGICAL_ERROR);
-    }
-
     auto it = storages.find(name);
     if (it == storages.end())
     {

--- a/dbms/src/Storages/StorageFactory.cpp
+++ b/dbms/src/Storages/StorageFactory.cpp
@@ -132,6 +132,12 @@ StoragePtr StorageFactory::get(
         }
     }
 
+    if (relative_data_path.empty())
+    {
+        if (endsWith(name, "MergeTree") || endsWith(name, "Log") || name == "Join" || name == "Set")
+            throw Exception("Data path cannot be empty for table with engine " + name, ErrorCodes::LOGICAL_ERROR);
+    }
+
     auto it = storages.find(name);
     if (it == storages.end())
     {

--- a/dbms/tests/queries/0_stateless/01069_database_memory.reference
+++ b/dbms/tests/queries/0_stateless/01069_database_memory.reference
@@ -1,0 +1,7 @@
+CREATE DATABASE memory_01069 ENGINE = Memory()
+1
+2
+3
+4
+3
+4

--- a/dbms/tests/queries/0_stateless/01069_database_memory.sql
+++ b/dbms/tests/queries/0_stateless/01069_database_memory.sql
@@ -1,0 +1,18 @@
+DROP DATABASE IF EXISTS memory_01069;
+CREATE DATABASE memory_01069 ENGINE = Memory;
+SHOW CREATE DATABASE memory_01069;
+
+CREATE TABLE memory_01069.mt (n UInt8) ENGINE = MergeTree() ORDER BY n;
+CREATE TABLE memory_01069.file (n UInt8) ENGINE = File(CSV);
+
+INSERT INTO memory_01069.mt VALUES (1), (2);
+INSERT INTO memory_01069.file VALUES (3), (4);
+
+SELECT * FROM memory_01069.mt ORDER BY n;
+SELECT * FROM memory_01069.file ORDER BY n;
+
+DROP TABLE memory_01069.mt;
+SELECT * FROM memory_01069.mt ORDER BY n; -- { serverError 60 }
+SELECT * FROM memory_01069.file ORDER BY n;
+
+DROP DATABASE memory_01069;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
In 20.1.1 `Memory` databases use empty data path, so tables are created in `path` directory (e.g. `/var/lib/clickhouse/`), not in data directory of database (e.g. `/var/lib/clickhouse/db_name`).