### PR TITLE
Multiple disks/volumes for storing data for send in Distributed engine

### DIFF
--- a/dbms/src/Storages/Distributed/DirectoryMonitor.cpp
+++ b/dbms/src/Storages/Distributed/DirectoryMonitor.cpp
@@ -80,12 +80,11 @@ namespace
 
 
 StorageDistributedDirectoryMonitor::StorageDistributedDirectoryMonitor(
-    StorageDistributed & storage_, std::string name_, ConnectionPoolPtr pool_, ActionBlocker & monitor_blocker_)
+    StorageDistributed & storage_, std::string path_, ConnectionPoolPtr pool_, ActionBlocker & monitor_blocker_)
     /// It's important to initialize members before `thread` to avoid race.
     : storage(storage_)
     , pool(std::move(pool_))
-    , name(std::move(name_))
-    , path{storage.path + name + '/'}
+    , path{path_ + '/'}
     , should_batch_inserts(storage.global_context.getSettingsRef().distributed_directory_monitor_batch_inserts)
     , min_batched_block_size_rows(storage.global_context.getSettingsRef().min_insert_block_size_rows)
     , min_batched_block_size_bytes(storage.global_context.getSettingsRef().min_insert_block_size_bytes)
@@ -692,10 +691,10 @@ std::string StorageDistributedDirectoryMonitor::getLoggerName() const
     return storage.getStorageID().getFullTableName() + ".DirectoryMonitor";
 }
 
-void StorageDistributedDirectoryMonitor::updatePath()
+void StorageDistributedDirectoryMonitor::updatePath(const std::string & new_path)
 {
     std::lock_guard lock{mutex};
-    path = storage.path + name + '/';
+    path = new_path;
     current_batch_file_path = path + "current_batch.txt";
 }
 

--- a/dbms/src/Storages/Distributed/DirectoryMonitor.h
+++ b/dbms/src/Storages/Distributed/DirectoryMonitor.h
@@ -20,13 +20,13 @@ class StorageDistributedDirectoryMonitor
 {
 public:
     StorageDistributedDirectoryMonitor(
-        StorageDistributed & storage_, std::string name_, ConnectionPoolPtr pool_, ActionBlocker & monitor_blocker_);
+        StorageDistributed & storage_, std::string path_, ConnectionPoolPtr pool_, ActionBlocker & monitor_blocker_);
 
     ~StorageDistributedDirectoryMonitor();
 
     static ConnectionPoolPtr createPool(const std::string & name, const StorageDistributed & storage);
 
-    void updatePath();
+    void updatePath(const std::string & new_path);
 
     void flushAllData();
 
@@ -47,7 +47,6 @@ private:
 
     StorageDistributed & storage;
     const ConnectionPoolPtr pool;
-    const std::string name;
     std::string path;
 
     const bool should_batch_inserts = false;

--- a/dbms/src/Storages/StorageDistributed.cpp
+++ b/dbms/src/Storages/StorageDistributed.cpp
@@ -3,6 +3,8 @@
 #include <DataStreams/OneBlockInputStream.h>
 
 #include <Databases/IDatabase.h>
+#include <Disks/DiskSpaceMonitor.h>
+#include <Disks/DiskLocal.h>
 
 #include <DataTypes/DataTypeFactory.h>
 #include <DataTypes/DataTypesNumber.h>
@@ -146,12 +148,6 @@ UInt64 getMaximumFileNumber(const std::string & dir_path)
     return res;
 }
 
-void initializeFileNamesIncrement(const std::string & path, SimpleIncrement & increment)
-{
-    if (!path.empty())
-        increment.set(getMaximumFileNumber(path));
-}
-
 /// the same as DistributedBlockOutputStream::createSelector, should it be static?
 IColumn::Selector createSelector(const ClusterPtr cluster, const ColumnWithTypeAndName & result)
 {
@@ -204,6 +200,7 @@ static ExpressionActionsPtr buildShardingKeyExpression(const ASTPtr & sharding_k
     return ExpressionAnalyzer(query, syntax_result, context).getActions(project);
 }
 
+
 StorageDistributed::StorageDistributed(
     const StorageID & id_,
     const ColumnsDescription & columns_,
@@ -213,6 +210,7 @@ StorageDistributed::StorageDistributed(
     const String & cluster_name_,
     const Context & context_,
     const ASTPtr & sharding_key_,
+    const String & storage_policy_,
     const String & relative_data_path_,
     bool attach_)
     : IStorage(id_,
@@ -226,7 +224,8 @@ StorageDistributed::StorageDistributed(
     , global_context(context_)
     , cluster_name(global_context.getMacros()->expand(cluster_name_))
     , has_sharding_key(sharding_key_)
-    , path(relative_data_path_.empty() ? "" : (context_.getPath() + relative_data_path_))
+    , storage_policy(storage_policy_)
+    , relative_data_path(relative_data_path_)
 {
     setColumns(columns_);
     setConstraints(constraints_);
@@ -236,6 +235,9 @@ StorageDistributed::StorageDistributed(
         sharding_key_expr = buildShardingKeyExpression(sharding_key_, global_context, getColumns().getAllPhysical(), false);
         sharding_key_column_name = sharding_key_->getColumnName();
     }
+
+    if (!relative_data_path.empty())
+        createStorage();
 
     /// Sanity check. Skip check if the table is already created to allow the server to start.
     if (!attach_ && !cluster_name.empty())
@@ -255,13 +257,34 @@ StorageDistributed::StorageDistributed(
     const String & cluster_name_,
     const Context & context_,
     const ASTPtr & sharding_key_,
+    const String & storage_policy_,
     const String & relative_data_path_,
     bool attach)
-    : StorageDistributed(id_, columns_, constraints_, String{}, String{}, cluster_name_, context_, sharding_key_, relative_data_path_, attach)
+    : StorageDistributed(id_, columns_, constraints_, String{}, String{}, cluster_name_, context_, sharding_key_, storage_policy_, relative_data_path_, attach)
 {
     remote_table_function_ptr = std::move(remote_table_function_ptr_);
 }
 
+void StorageDistributed::createStorage()
+{
+    /// Create default policy with the relative_data_path_
+    if (storage_policy.empty())
+    {
+        std::string path(global_context.getPath());
+        /// Disk must ends with '/'
+        if (!path.ends_with('/'))
+            path += '/';
+        auto disk = std::make_shared<DiskLocal>("default", path, 0);
+        volume = std::make_shared<Volume>("default", std::vector<DiskPtr>{disk}, 0);
+    }
+    else
+    {
+        auto policy = global_context.getStoragePolicySelector()[storage_policy];
+        if (policy->getVolumes().size() != 1)
+             throw Exception("Policy for Distributed table, should have exactly one volume", ErrorCodes::BAD_ARGUMENTS);
+        volume = policy->getVolume(0);
+    }
+}
 
 StoragePtr StorageDistributed::createWithOwnCluster(
     const StorageID & table_id_,
@@ -271,7 +294,7 @@ StoragePtr StorageDistributed::createWithOwnCluster(
     ClusterPtr owned_cluster_,
     const Context & context_)
 {
-    auto res = create(table_id_, columns_, ConstraintsDescription{}, remote_database_, remote_table_, String{}, context_, ASTPtr(), String(), false);
+    auto res = create(table_id_, columns_, ConstraintsDescription{}, remote_database_, remote_table_, String{}, context_, ASTPtr(), String(), String(), false);
     res->owned_cluster = std::move(owned_cluster_);
     return res;
 }
@@ -284,7 +307,7 @@ StoragePtr StorageDistributed::createWithOwnCluster(
     ClusterPtr & owned_cluster_,
     const Context & context_)
 {
-    auto res = create(table_id_, columns_, ConstraintsDescription{}, remote_table_function_ptr_, String{}, context_, ASTPtr(), String(), false);
+    auto res = create(table_id_, columns_, ConstraintsDescription{}, remote_table_function_ptr_, String{}, context_, ASTPtr(), String(), String(), false);
     res->owned_cluster = owned_cluster_;
     return res;
 }
@@ -373,7 +396,7 @@ BlockOutputStreamPtr StorageDistributed::write(const ASTPtr &, const Context & c
     const auto & settings = context.getSettingsRef();
 
     /// Ban an attempt to make async insert into the table belonging to DatabaseMemory
-    if (path.empty() && !owned_cluster && !settings.insert_distributed_sync)
+    if (!volume && !owned_cluster && !settings.insert_distributed_sync)
     {
         throw Exception("Storage " + getName() + " must has own data directory to enable asynchronous inserts",
                         ErrorCodes::BAD_ARGUMENTS);
@@ -426,8 +449,19 @@ void StorageDistributed::alter(const AlterCommands & params, const Context & con
 
 void StorageDistributed::startup()
 {
-    createDirectoryMonitors();
-    initializeFileNamesIncrement(path, file_names_increment);
+    if (!volume)
+        return;
+
+    for (const DiskPtr & disk : volume->disks)
+        createDirectoryMonitors(disk->getPath());
+
+    for (const String & path : getDataPaths())
+    {
+        UInt64 inc = getMaximumFileNumber(path);
+        if (inc > file_names_increment.value)
+            file_names_increment.value.store(inc);
+    }
+    LOG_DEBUG(log, "Auto-increment is " << file_names_increment.value);
 }
 
 
@@ -436,6 +470,18 @@ void StorageDistributed::shutdown()
     cluster_nodes_data.clear();
 }
 
+Strings StorageDistributed::getDataPaths() const
+{
+    Strings paths;
+
+    if (relative_data_path.empty())
+        return paths;
+
+    for (const DiskPtr & disk : volume->disks)
+        paths.push_back(disk->getPath() + relative_data_path);
+
+    return paths;
+}
 
 void StorageDistributed::truncate(const ASTPtr &, const Context &, TableStructureWriteLockHolder &)
 {
@@ -481,33 +527,28 @@ bool StorageDistributed::hasColumn(const String & column_name) const
     return virtual_columns.count(column_name) || getColumns().hasPhysical(column_name);
 }
 
-void StorageDistributed::createDirectoryMonitors()
+void StorageDistributed::createDirectoryMonitors(const std::string & disk)
 {
-    if (path.empty())
-        return;
-
+    const std::string path(disk + relative_data_path);
     Poco::File{path}.createDirectories();
 
     std::filesystem::directory_iterator begin(path);
     std::filesystem::directory_iterator end;
     for (auto it = begin; it != end; ++it)
         if (std::filesystem::is_directory(*it))
-            requireDirectoryMonitor(it->path().filename().string());
+            requireDirectoryMonitor(disk, it->path().filename().string());
 }
 
 
-void StorageDistributed::requireDirectoryMonitor(const std::string & name)
+void StorageDistributed::requireDirectoryMonitor(const std::string & disk, const std::string & name)
 {
-    std::lock_guard lock(cluster_nodes_mutex);
-    cluster_nodes_data[name].requireDirectoryMonitor(name, *this, monitors_blocker);
-}
+    const std::string path(disk + relative_data_path + name);
+    const std::string key(disk + name);
 
-ConnectionPoolPtr StorageDistributed::requireConnectionPool(const std::string & name)
-{
     std::lock_guard lock(cluster_nodes_mutex);
-    auto & node_data = cluster_nodes_data[name];
-    node_data.requireConnectionPool(name, *this);
-    return node_data.conneciton_pool;
+    auto & node_data = cluster_nodes_data[key];
+    node_data.conneciton_pool = StorageDistributedDirectoryMonitor::createPool(name, *this);
+    node_data.directory_monitor = std::make_unique<StorageDistributedDirectoryMonitor>(*this, path, node_data.conneciton_pool, monitors_blocker);
 }
 
 size_t StorageDistributed::getShardCount() const
@@ -515,23 +556,14 @@ size_t StorageDistributed::getShardCount() const
     return getCluster()->getShardCount();
 }
 
+std::pair<const std::string &, const std::string &> StorageDistributed::getPath()
+{
+    return {volume->getNextDisk()->getPath(), relative_data_path};
+}
+
 ClusterPtr StorageDistributed::getCluster() const
 {
     return owned_cluster ? owned_cluster : global_context.getCluster(cluster_name);
-}
-
-void StorageDistributed::ClusterNodeData::requireConnectionPool(const std::string & name, const StorageDistributed & storage)
-{
-    if (!conneciton_pool)
-        conneciton_pool = StorageDistributedDirectoryMonitor::createPool(name, storage);
-}
-
-void StorageDistributed::ClusterNodeData::requireDirectoryMonitor(
-    const std::string & name, StorageDistributed & storage, ActionBlocker & monitor_blocker)
-{
-    requireConnectionPool(name, storage);
-    if (!directory_monitor)
-        directory_monitor = std::make_unique<StorageDistributedDirectoryMonitor>(storage, name, conneciton_pool, monitor_blocker);
 }
 
 void StorageDistributed::ClusterNodeData::flushAllData()
@@ -613,16 +645,26 @@ void StorageDistributed::flushClusterNodesAllData()
 void StorageDistributed::rename(const String & new_path_to_table_data, const String & new_database_name, const String & new_table_name,
                                 TableStructureWriteLockHolder &)
 {
-    if (!path.empty())
+    if (!relative_data_path.empty())
+        renameOnDisk(new_path_to_table_data);
+    renameInMemory(new_database_name, new_table_name);
+}
+void StorageDistributed::renameOnDisk(const String & new_path_to_table_data)
+{
+    for (const DiskPtr & disk : volume->disks)
     {
-        auto new_path = global_context.getPath() + new_path_to_table_data;
-        Poco::File(path).renameTo(new_path);
-        path = new_path;
+        const String path(disk->getPath());
+        auto new_path = path + new_path_to_table_data;
+        Poco::File(path + relative_data_path).renameTo(new_path);
+
+        LOG_DEBUG(log, "Updating path to " << new_path);
+
         std::lock_guard lock(cluster_nodes_mutex);
         for (auto & node : cluster_nodes_data)
-            node.second.directory_monitor->updatePath();
+            node.second.directory_monitor->updatePath(new_path);
     }
-    renameInMemory(new_database_name, new_table_name);
+
+    relative_data_path = new_path_to_table_data;
 }
 
 
@@ -634,6 +676,7 @@ void registerStorageDistributed(StorageFactory & factory)
           * - name of cluster in configuration;
           * - name of remote database;
           * - name of remote table;
+          * - policy to store data in;
           *
           * Remote database may be specified in following form:
           * - identifier;
@@ -644,10 +687,15 @@ void registerStorageDistributed(StorageFactory & factory)
 
         ASTs & engine_args = args.engine_args;
 
-        if (!(engine_args.size() == 3 || engine_args.size() == 4))
-            throw Exception("Storage Distributed requires 3 or 4 parameters"
-                " - name of configuration section with list of remote servers, name of remote database, name of remote table,"
-                " sharding key expression (optional).", ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
+        if (engine_args.size() < 3 || engine_args.size() > 5)
+            throw Exception(
+                "Storage Distributed requires from 3 to 5 parameters - "
+                "name of configuration section with list of remote servers, "
+                "name of remote database, "
+                "name of remote table, "
+                "sharding key expression (optional), "
+                "policy to store data in (optional).",
+                ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
 
         String cluster_name = getClusterName(*engine_args[0]);
 
@@ -657,7 +705,8 @@ void registerStorageDistributed(StorageFactory & factory)
         String remote_database = engine_args[1]->as<ASTLiteral &>().value.safeGet<String>();
         String remote_table = engine_args[2]->as<ASTLiteral &>().value.safeGet<String>();
 
-        const auto & sharding_key = engine_args.size() == 4 ? engine_args[3] : nullptr;
+        const auto & sharding_key = engine_args.size() >= 4 ? engine_args[3] : nullptr;
+        const auto & storage_policy = engine_args.size() >= 5 ? engine_args[4]->as<ASTLiteral &>().value.safeGet<String>() : "";
 
         /// Check that sharding_key exists in the table and has numeric type.
         if (sharding_key)
@@ -678,7 +727,10 @@ void registerStorageDistributed(StorageFactory & factory)
         return StorageDistributed::create(
             args.table_id, args.columns, args.constraints,
             remote_database, remote_table, cluster_name,
-            args.context, sharding_key, args.relative_data_path,
+            args.context,
+            sharding_key,
+            storage_policy,
+            args.relative_data_path,
             args.attach);
     });
 }

--- a/dbms/tests/integration/test_distributed_storage_configuration/configs/config.d/storage_configuration.xml
+++ b/dbms/tests/integration/test_distributed_storage_configuration/configs/config.d/storage_configuration.xml
@@ -1,0 +1,23 @@
+<yandex>
+    <storage_configuration>
+        <disks>
+            <disk1>
+                <path>/disk1/</path>
+            </disk1>
+            <disk2>
+                <path>/disk2/</path>
+            </disk2>
+        </disks>
+
+        <policies>
+            <default>
+                <volumes>
+                    <main>
+                        <disk>disk1</disk>
+                        <disk>disk2</disk>
+                    </main>
+                </volumes>
+            </default>
+        </policies>
+    </storage_configuration>
+</yandex>

--- a/dbms/tests/integration/test_distributed_storage_configuration/test.py
+++ b/dbms/tests/integration/test_distributed_storage_configuration/test.py
@@ -1,0 +1,65 @@
+# pylint: disable=unused-argument
+# pylint: disable=redefined-outer-name
+# pylint: disable=line-too-long
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance('node',
+            config_dir='configs',
+            tmpfs=['/disk1:size=100M', '/disk2:size=100M'])
+
+@pytest.fixture(scope='module')
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+def _files_in_dist_mon(node, root, table):
+    return int(node.exec_in_container([
+        'bash',
+        '-c',
+        # `-maxdepth 1` to avoid /tmp/ subdirectory
+        'find /{root}/data/default/{table}/default@127%2E0%2E0%2E2:9000 -maxdepth 1 -type f | wc -l'.format(root=root, table=table)
+    ]).split('\n')[0])
+
+def test_different_versions(start_cluster):
+    node.query('CREATE TABLE foo (key Int) Engine=Memory()')
+    node.query("""
+    CREATE TABLE dist_foo (key Int)
+    Engine=Distributed(
+        test_cluster_two_shards,
+        currentDatabase(),
+        foo,
+        key%2,
+        'default'
+    )
+    """)
+    # manual only
+    node.query('SYSTEM STOP DISTRIBUTED SENDS dist_foo')
+
+    node.query('INSERT INTO dist_foo SELECT * FROM numbers(100)')
+    assert _files_in_dist_mon(node, 'disk1', 'dist_foo') == 1
+    assert _files_in_dist_mon(node, 'disk2', 'dist_foo') == 0
+
+    assert node.query('SELECT count() FROM dist_foo') == '100\n'
+    node.query('SYSTEM FLUSH DISTRIBUTED dist_foo')
+    assert node.query('SELECT count() FROM dist_foo') == '200\n'
+
+    #
+    # RENAME
+    #
+    node.query('RENAME TABLE dist_foo TO dist2_foo')
+
+    node.query('INSERT INTO dist2_foo SELECT * FROM numbers(100)')
+    assert _files_in_dist_mon(node, 'disk1', 'dist2_foo') == 0
+    assert _files_in_dist_mon(node, 'disk2', 'dist2_foo') == 1
+
+    assert node.query('SELECT count() FROM dist2_foo') == '300\n'
+    node.query('SYSTEM FLUSH DISTRIBUTED dist2_foo')
+    assert node.query('SELECT count() FROM dist2_foo') == '400\n'

--- a/docs/en/operations/table_engines/distributed.md
+++ b/docs/en/operations/table_engines/distributed.md
@@ -3,11 +3,23 @@
 
 **The Distributed engine does not store data itself**, but allows distributed query processing on multiple servers.
 Reading is automatically parallelized. During a read, the table indexes on remote servers are used, if there are any.
-The Distributed engine accepts parameters: the cluster name in the server's config file, the name of a remote database, the name of a remote table, and (optionally) a sharding key.
+
+The Distributed engine accepts parameters:
+
+- the cluster name in the server's config file
+- the name of a remote database
+- the name of a remote table
+- (optionally) sharding key
+- (optionally) policy name, it will be used to store temporary files for async send
+
+  See also:
+  - `insert_distributed_sync` setting
+  - [MergeTree](../mergetree.md#table_engine-mergetree-multiple-volumes) for the examples
+
 Example:
 
 ```sql
-Distributed(logs, default, hits[, sharding_key])
+Distributed(logs, default, hits[, sharding_key[, policy_name]])
 ```
 
 Data will be read from all servers in the 'logs' cluster, from the default.hits table located on every server in the cluster.


### PR DESCRIPTION
Changelog category (leave one):
- New Feature

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Multiple disks/volumes for storing data for send in Distributed engine

Detailed description (optional):

Usage example:

```sql
CREATE TABLE foo (key Int) Engine=Distributed(test_shard_localhost, currentDatabase(), some_table, key%2, 'default');
```

Follow-up: #4918

v2: use `storage_policy` over introducing separate `distributed_storage_policy`