### PR TITLE
Add GCC warning to suggest virtual function override

### DIFF
--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -177,7 +177,7 @@ elseif (COMPILER_GCC)
     # Warn for suspicious length parameters to certain string and memory built-in functions if the argument uses sizeof
     add_cxx_compile_options(-Wsizeof-pointer-memaccess)
     # Warn about overriding virtual functions that are not marked with the override keyword
-    # add_cxx_compile_options(-Wsuggest-override)
+    add_cxx_compile_options(-Wsuggest-override)
     # Warn whenever a switch statement has an index of boolean type and the case values are outside the range of a boolean type
     add_cxx_compile_options(-Wswitch-bool)
     # Warn if a self-comparison always evaluates to true or false

--- a/dbms/programs/benchmark/Benchmark.cpp
+++ b/dbms/programs/benchmark/Benchmark.cpp
@@ -101,7 +101,7 @@ public:
 
     }
 
-    void initialize(Poco::Util::Application & self [[maybe_unused]])
+    void initialize(Poco::Util::Application & self [[maybe_unused]]) override
     {
         std::string home_path;
         const char * home_path_cstr = getenv("HOME");
@@ -111,7 +111,7 @@ public:
         configReadClient(config(), home_path);
     }
 
-    int main(const std::vector<std::string> &)
+    int main(const std::vector<std::string> &) override
     {
         if (!json_path.empty() && Poco::File(json_path).exists()) /// Clear file with previous results
             Poco::File(json_path).remove();

--- a/dbms/programs/benchmark/Benchmark.cpp
+++ b/dbms/programs/benchmark/Benchmark.cpp
@@ -492,7 +492,7 @@ private:
 
 public:
 
-    ~Benchmark()
+    ~Benchmark() override
     {
         shutdown = true;
     }

--- a/dbms/programs/client/Client.cpp
+++ b/dbms/programs/client/Client.cpp
@@ -242,7 +242,7 @@ private:
 
     ConnectionParameters connection_parameters;
 
-    void initialize(Poco::Util::Application & self)
+    void initialize(Poco::Util::Application & self) override
     {
         Poco::Util::Application::initialize(self);
 
@@ -270,7 +270,7 @@ private:
     }
 
 
-    int main(const std::vector<std::string> & /*args*/)
+    int main(const std::vector<std::string> & /*args*/) override
     {
         try
         {

--- a/dbms/programs/server/TCPHandler.h
+++ b/dbms/programs/server/TCPHandler.h
@@ -111,7 +111,7 @@ public:
         server_display_name = server.config().getString("display_name", getFQDNOrHostName());
     }
 
-    void run();
+    void run() override;
 
     /// This method is called right before the query execution.
     virtual void customizeContext(DB::Context & /*context*/) {}

--- a/dbms/src/Core/ExternalTable.h
+++ b/dbms/src/Core/ExternalTable.h
@@ -99,7 +99,7 @@ class ExternalTablesHandler : public Poco::Net::PartHandler, BaseExternalTable
 public:
     ExternalTablesHandler(Context & context_, const Poco::Net::NameValueCollection & params_) : context(context_), params(params_) {}
 
-    void handlePart(const Poco::Net::MessageHeader & header, std::istream & stream);
+    void handlePart(const Poco::Net::MessageHeader & header, std::istream & stream) override;
 
 private:
     Context & context;

--- a/dbms/src/DataTypes/tests/gtest_data_type_get_common_type.cpp
+++ b/dbms/src/DataTypes/tests/gtest_data_type_get_common_type.cpp
@@ -60,7 +60,7 @@ std::ostream & operator<<(std::ostream & ostr, const TypesTestCase & test_case)
 class TypeTest : public ::testing::TestWithParam<TypesTestCase>
 {
 public:
-    void SetUp()
+    void SetUp() override
     {
         const auto & p = GetParam();
         from_types = typesFromString(p.from_types);

--- a/dbms/src/Databases/IDatabase.h
+++ b/dbms/src/Databases/IDatabase.h
@@ -56,13 +56,13 @@ public:
 
     DatabaseTablesSnapshotIterator(Tables && tables_) : tables(tables_), it(tables.begin()) {}
 
-    void next() { ++it; }
+    void next() override { ++it; }
 
-    bool isValid() const { return it != tables.end(); }
+    bool isValid() const override { return it != tables.end(); }
 
-    const String & name() const { return it->first; }
+    const String & name() const override { return it->first; }
 
-    const StoragePtr & table() const { return it->second; }
+    const StoragePtr & table() const override { return it->second; }
 };
 
 /// Copies list of dictionaries and iterates through such snapshot.

--- a/dbms/src/Disks/tests/gtest_disk.cpp
+++ b/dbms/src/Disks/tests/gtest_disk.cpp
@@ -5,6 +5,10 @@
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
 
+#if !__clang__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsuggest-override"
+#endif
 
 template <typename T>
 DB::DiskPtr createDisk();

--- a/dbms/src/Functions/GatherUtils/Sources.h
+++ b/dbms/src/Functions/GatherUtils/Sources.h
@@ -121,6 +121,11 @@ struct NumericArraySource : public ArraySourceImpl<NumericArraySource<T>>
     }
 };
 
+#if !__clang__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsuggest-override"
+#endif
+
 template <typename Base>
 struct ConstSource : public Base
 {
@@ -198,6 +203,10 @@ struct ConstSource : public Base
         return true;
     }
 };
+
+#if !__clang__
+#pragma GCC diagnostic pop
+#endif
 
 struct StringSource
 {

--- a/dbms/src/IO/WriteBufferFromHTTP.h
+++ b/dbms/src/IO/WriteBufferFromHTTP.h
@@ -29,7 +29,7 @@ public:
         size_t buffer_size_ = DBMS_DEFAULT_BUFFER_SIZE);
 
     /// Receives response from the server after sending all data.
-    void finalize();
+    void finalize() override;
 };
 
 }

--- a/dbms/src/Parsers/ExpressionElementParsers.h
+++ b/dbms/src/Parsers/ExpressionElementParsers.h
@@ -10,8 +10,8 @@ namespace DB
 class ParserArray : public IParserBase
 {
 protected:
-    const char * getName() const { return "array"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "array"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -22,8 +22,8 @@ protected:
 class ParserParenthesisExpression : public IParserBase
 {
 protected:
-    const char * getName() const { return "parenthesized expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "parenthesized expression"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -32,8 +32,8 @@ protected:
 class ParserSubquery : public IParserBase
 {
 protected:
-    const char * getName() const { return "SELECT subquery"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "SELECT subquery"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -42,8 +42,8 @@ protected:
 class ParserIdentifier : public IParserBase
 {
 protected:
-    const char * getName() const { return "identifier"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "identifier"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -52,16 +52,16 @@ protected:
 class ParserCompoundIdentifier : public IParserBase
 {
 protected:
-    const char * getName() const { return "compound identifier"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "compound identifier"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 /// Just *
 class ParserAsterisk : public IParserBase
 {
 protected:
-    const char * getName() const { return "asterisk"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "asterisk"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 /** Something like t.* or db.table.*
@@ -69,8 +69,8 @@ protected:
 class ParserQualifiedAsterisk : public IParserBase
 {
 protected:
-    const char * getName() const { return "qualified asterisk"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "qualified asterisk"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 /** COLUMNS('<regular expression>')
@@ -78,8 +78,8 @@ protected:
 class ParserColumnsMatcher : public IParserBase
 {
 protected:
-    const char * getName() const { return "COLUMNS matcher"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "COLUMNS matcher"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 /** A function, for example, f(x, y + 1, g(z)).
@@ -93,16 +93,16 @@ class ParserFunction : public IParserBase
 public:
     ParserFunction(bool allow_function_parameters_ = true) : allow_function_parameters(allow_function_parameters_) {}
 protected:
-    const char * getName() const { return "function"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "function"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
     bool allow_function_parameters;
 };
 
 class ParserCodecDeclarationList : public IParserBase
 {
 protected:
-    const char * getName() const { return "codec declaration list"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "codec declaration list"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 /** Parse compression codec
@@ -111,8 +111,8 @@ protected:
 class ParserCodec : public IParserBase
 {
 protected:
-    const char * getName() const { return "codec"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "codec"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 class ParserCastExpression : public IParserBase
@@ -176,8 +176,8 @@ protected:
 class ParserNull : public IParserBase
 {
 protected:
-    const char * getName() const { return "NULL"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "NULL"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -186,8 +186,8 @@ protected:
 class ParserNumber : public IParserBase
 {
 protected:
-    const char * getName() const { return "number"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "number"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 /** Unsigned integer, used in right hand side of tuple access operator (x.1).
@@ -195,8 +195,8 @@ protected:
 class ParserUnsignedInteger : public IParserBase
 {
 protected:
-    const char * getName() const { return "unsigned integer"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "unsigned integer"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -205,8 +205,8 @@ protected:
 class ParserStringLiteral : public IParserBase
 {
 protected:
-    const char * getName() const { return "string literal"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "string literal"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -219,8 +219,8 @@ protected:
 class ParserArrayOfLiterals : public IParserBase
 {
 protected:
-    const char * getName() const { return "array"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "array"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -229,8 +229,8 @@ protected:
 class ParserLiteral : public IParserBase
 {
 protected:
-    const char * getName() const { return "literal"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "literal"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -246,8 +246,8 @@ private:
 
     bool allow_alias_without_as_keyword;
 
-    const char * getName() const { return "alias"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "alias"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -257,8 +257,8 @@ private:
 class ParserSubstitution : public IParserBase
 {
 protected:
-    const char * getName() const { return "substitution"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "substitution"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -267,8 +267,8 @@ protected:
 class ParserExpressionElement : public IParserBase
 {
 protected:
-    const char * getName() const { return "element of expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "element of expression"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -283,8 +283,8 @@ protected:
     ParserPtr elem_parser;
     bool allow_alias_without_as_keyword;
 
-    const char * getName() const { return "element of expression with optional alias"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "element of expression with optional alias"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -296,8 +296,8 @@ protected:
 class ParserOrderByElement : public IParserBase
 {
 protected:
-    const char * getName() const { return "element of ORDER BY expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "element of ORDER BY expression"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 /** Parser for function with arguments like KEY VALUE (space separated)
@@ -316,8 +316,8 @@ protected:
 class ParserIdentifierWithOptionalParameters : public IParserBase
 {
 protected:
-    const char * getName() const { return "identifier with optional parameters"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const  override{ return "identifier with optional parameters"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 /** Element of TTL expression - same as expression element, but in addition,
@@ -326,8 +326,8 @@ protected:
 class ParserTTLElement : public IParserBase
 {
 protected:
-    const char * getName() const { return "element of TTL expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "element of TTL expression"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 }

--- a/dbms/src/Parsers/ExpressionListParsers.h
+++ b/dbms/src/Parsers/ExpressionListParsers.h
@@ -27,8 +27,8 @@ public:
     {
     }
 protected:
-    const char * getName() const { return "list of elements"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "list of elements"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 private:
     ParserPtr elem_parser;
     ParserPtr separator_parser;
@@ -63,9 +63,9 @@ public:
     }
 
 protected:
-    const char * getName() const { return "list, delimited by binary operators"; }
+    const char * getName() const override { return "list, delimited by binary operators"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -86,9 +86,9 @@ public:
     }
 
 protected:
-    const char * getName() const { return "list, delimited by operator of variable arity"; }
+    const char * getName() const override { return "list, delimited by operator of variable arity"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -110,8 +110,8 @@ public:
     }
 
 protected:
-    const char * getName() const { return "expression with prefix unary operator"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "expression with prefix unary operator"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -121,9 +121,9 @@ private:
     static const char * operators[];
 
 protected:
-    const char * getName() const { return "array element expression"; }
+    const char * getName() const  override{ return "array element expression"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -133,9 +133,9 @@ private:
     static const char * operators[];
 
 protected:
-    const char * getName() const { return "tuple element expression"; }
+    const char * getName() const override { return "tuple element expression"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -146,9 +146,9 @@ private:
     ParserPrefixUnaryOperatorExpression operator_parser {operators, std::make_unique<ParserTupleElementExpression>()};
 
 protected:
-    const char * getName() const { return "unary minus expression"; }
+    const char * getName() const override { return "unary minus expression"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -159,9 +159,9 @@ private:
     ParserLeftAssociativeBinaryOperatorList operator_parser {operators, std::make_unique<ParserUnaryMinusExpression>()};
 
 protected:
-    const char * getName() const { return "multiplicative expression"; }
+    const char * getName() const  override{ return "multiplicative expression"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
     {
         return operator_parser.parse(pos, node, expected);
     }
@@ -174,8 +174,8 @@ class ParserIntervalOperatorExpression : public IParserBase
 protected:
     ParserMultiplicativeExpression next_parser;
 
-    const char * getName() const { return "INTERVAL operator expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const  override{ return "INTERVAL operator expression"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -186,9 +186,9 @@ private:
     ParserLeftAssociativeBinaryOperatorList operator_parser {operators, std::make_unique<ParserIntervalOperatorExpression>()};
 
 protected:
-    const char * getName() const { return "additive expression"; }
+    const char * getName() const  override{ return "additive expression"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
     {
         return operator_parser.parse(pos, node, expected);
     }
@@ -200,9 +200,9 @@ class ParserConcatExpression : public IParserBase
     ParserVariableArityOperatorList operator_parser {"||", "concat", std::make_unique<ParserAdditiveExpression>()};
 
 protected:
-    const char * getName() const { return "string concatenation expression"; }
+    const char * getName() const override { return "string concatenation expression"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
     {
         return operator_parser.parse(pos, node, expected);
     }
@@ -215,9 +215,9 @@ private:
     ParserConcatExpression elem_parser;
 
 protected:
-    const char * getName() const { return "BETWEEN expression"; }
+    const char * getName() const override { return "BETWEEN expression"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -228,9 +228,9 @@ private:
     ParserLeftAssociativeBinaryOperatorList operator_parser {operators, std::make_unique<ParserBetweenExpression>()};
 
 protected:
-    const char * getName() const { return "comparison expression"; }
+    const char * getName() const  override{ return "comparison expression"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
     {
         return operator_parser.parse(pos, node, expected);
     }
@@ -257,9 +257,9 @@ private:
     ParserPrefixUnaryOperatorExpression operator_parser {operators, std::make_unique<ParserNullityChecking>()};
 
 protected:
-    const char * getName() const { return "logical-NOT expression"; }
+    const char * getName() const  override{ return "logical-NOT expression"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
     {
         return operator_parser.parse(pos, node, expected);
     }
@@ -272,9 +272,9 @@ private:
     ParserVariableArityOperatorList operator_parser {"AND", "and", std::make_unique<ParserLogicalNotExpression>()};
 
 protected:
-    const char * getName() const { return "logical-AND expression"; }
+    const char * getName() const override { return "logical-AND expression"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
     {
         return operator_parser.parse(pos, node, expected);
     }
@@ -287,9 +287,9 @@ private:
     ParserVariableArityOperatorList operator_parser {"OR", "or", std::make_unique<ParserLogicalAndExpression>()};
 
 protected:
-    const char * getName() const { return "logical-OR expression"; }
+    const char * getName() const override { return "logical-OR expression"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
     {
         return operator_parser.parse(pos, node, expected);
     }
@@ -305,9 +305,9 @@ private:
     ParserLogicalOrExpression elem_parser;
 
 protected:
-    const char * getName() const { return "expression with ternary operator"; }
+    const char * getName() const override { return "expression with ternary operator"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -317,9 +317,9 @@ private:
     ParserTernaryOperatorExpression elem_parser;
 
 protected:
-    const char * getName() const { return "lambda expression"; }
+    const char * getName() const override { return "lambda expression"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -333,9 +333,9 @@ public:
 protected:
     ParserPtr impl;
 
-    const char * getName() const { return "expression with optional alias"; }
+    const char * getName() const override { return "expression with optional alias"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
     {
         return impl->parse(pos, node, expected);
     }
@@ -352,8 +352,8 @@ public:
 protected:
     bool allow_alias_without_as_keyword;
 
-    const char * getName() const { return "list of expressions"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "list of expressions"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -365,16 +365,16 @@ public:
 private:
     ParserExpressionList nested_parser;
 protected:
-    const char * getName() const { return "not empty list of expressions"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "not empty list of expressions"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
 class ParserOrderByExpressionList : public IParserBase
 {
 protected:
-    const char * getName() const { return "order by expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "order by expression"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -399,8 +399,8 @@ protected:
 class ParserTTLExpressionList : public IParserBase
 {
 protected:
-    const char * getName() const { return "ttl expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "ttl expression"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 }

--- a/dbms/src/Parsers/IParserBase.h
+++ b/dbms/src/Parsers/IParserBase.h
@@ -35,7 +35,7 @@ public:
         return res;
     }
 
-    bool parse(Pos & pos, ASTPtr & node, Expected & expected);
+    bool parse(Pos & pos, ASTPtr & node, Expected & expected) override;
 
 protected:
     virtual bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) = 0;

--- a/dbms/src/Parsers/ParserAlterQuery.h
+++ b/dbms/src/Parsers/ParserAlterQuery.h
@@ -27,16 +27,16 @@ namespace DB
 class ParserAlterQuery : public IParserBase
 {
 protected:
-    const char * getName() const { return "ALTER query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const  override{ return "ALTER query"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
 class ParserAlterCommandList : public IParserBase
 {
 protected:
-    const char * getName() const { return "a list of ALTER commands"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const  override{ return "a list of ALTER commands"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 
 public:
     bool is_live_view;
@@ -48,8 +48,8 @@ public:
 class ParserAlterCommand : public IParserBase
 {
 protected:
-    const char * getName() const { return "ALTER command"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const  override{ return "ALTER command"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 
 public:
     bool is_live_view;
@@ -62,8 +62,8 @@ public:
 class ParserAssignment : public IParserBase
 {
 protected:
-    const char * getName() const { return "column assignment"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const  override{ return "column assignment"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 }

--- a/dbms/src/Parsers/ParserCheckQuery.h
+++ b/dbms/src/Parsers/ParserCheckQuery.h
@@ -10,8 +10,8 @@ namespace DB
 class ParserCheckQuery : public IParserBase
 {
 protected:
-    const char * getName() const { return "ALTER query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const  override{ return "ALTER query"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 }

--- a/dbms/src/Parsers/ParserCreateQuery.h
+++ b/dbms/src/Parsers/ParserCreateQuery.h
@@ -19,8 +19,8 @@ namespace DB
 class ParserNestedTable : public IParserBase
 {
 protected:
-    const char * getName() const { return "nested table"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "nested table"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -33,16 +33,16 @@ protected:
 class ParserIdentifierWithParameters : public IParserBase
 {
 protected:
-    const char * getName() const { return "identifier with parameters"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "identifier with parameters"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 template <typename NameParser>
 class IParserNameTypePair : public IParserBase
 {
 protected:
-    const char * getName() const { return "name and type pair"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const  override{ return "name and type pair"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 /** The name and type are separated by a space. For example, URL String. */
@@ -75,16 +75,16 @@ bool IParserNameTypePair<NameParser>::parseImpl(Pos & pos, ASTPtr & node, Expect
 class ParserNameTypePairList : public IParserBase
 {
 protected:
-    const char * getName() const { return "name and type pair list"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "name and type pair list"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 /** List of table names. */
 class ParserNameList : public IParserBase
 {
 protected:
-    const char * getName() const { return "name list"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "name list"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -99,9 +99,9 @@ public:
 protected:
     using ASTDeclarePtr = std::shared_ptr<ASTColumnDeclaration>;
 
-    const char * getName() const { return "column declaration"; }
+    const char * getName() const  override{ return "column declaration"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 
     bool require_type = true;
 };
@@ -224,8 +224,8 @@ bool IParserColumnDeclaration<NameParser>::parseImpl(Pos & pos, ASTPtr & node, E
 class ParserColumnDeclarationList : public IParserBase
 {
 protected:
-    const char * getName() const { return "column declaration list"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "column declaration list"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -284,8 +284,8 @@ protected:
 class ParserStorage : public IParserBase
 {
 protected:
-    const char * getName() const { return "storage definition"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "storage definition"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 /** Query like this:
@@ -308,32 +308,32 @@ protected:
 class ParserCreateTableQuery : public IParserBase
 {
 protected:
-    const char * getName() const { return "CREATE TABLE or ATTACH TABLE query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "CREATE TABLE or ATTACH TABLE query"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 /// CREATE|ATTACH LIVE VIEW [IF NOT EXISTS] [db.]name [TO [db.]name] AS SELECT ...
 class ParserCreateLiveViewQuery : public IParserBase
 {
 protected:
-    const char * getName() const { return "CREATE LIVE VIEW query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "CREATE LIVE VIEW query"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 /// CREATE|ATTACH DATABASE db [ENGINE = engine]
 class ParserCreateDatabaseQuery : public IParserBase
 {
 protected:
-    const char * getName() const { return "CREATE DATABASE query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "CREATE DATABASE query"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 /// CREATE[OR REPLACE]|ATTACH [[MATERIALIZED] VIEW] | [VIEW]] [IF NOT EXISTS] [db.]name [TO [db.]name] [ENGINE = engine] [POPULATE] AS SELECT ...
 class ParserCreateViewQuery : public IParserBase
 {
 protected:
-    const char * getName() const { return "CREATE VIEW query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "CREATE VIEW query"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 /// Parses complete dictionary create query. Uses ParserDictionary and
@@ -372,8 +372,8 @@ protected:
 class ParserCreateQuery : public IParserBase
 {
 protected:
-    const char * getName() const { return "CREATE TABLE or ATTACH TABLE query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "CREATE TABLE or ATTACH TABLE query"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 }

--- a/dbms/src/Parsers/ParserDescribeTableQuery.h
+++ b/dbms/src/Parsers/ParserDescribeTableQuery.h
@@ -13,8 +13,8 @@ namespace DB
 class ParserDescribeTableQuery : public IParserBase
 {
 protected:
-    const char * getName() const { return "DESCRIBE query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "DESCRIBE query"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 }

--- a/dbms/src/Parsers/ParserDictionaryAttributeDeclaration.h
+++ b/dbms/src/Parsers/ParserDictionaryAttributeDeclaration.h
@@ -25,8 +25,8 @@ protected:
 class ParserDictionaryAttributeDeclarationList : public IParserBase
 {
 protected:
-    const char * getName() const { return "attribute declaration list"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const  override{ return "attribute declaration list"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 }

--- a/dbms/src/Parsers/ParserDropQuery.h
+++ b/dbms/src/Parsers/ParserDropQuery.h
@@ -19,8 +19,8 @@ namespace DB
 class ParserDropQuery : public IParserBase
 {
 protected:
-    const char * getName() const { return "DROP query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const  override{ return "DROP query"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 
     bool parseDropQuery(Pos & pos, ASTPtr & node, Expected & expected);
     bool parseDetachQuery(Pos & pos, ASTPtr & node, Expected & expected);

--- a/dbms/src/Parsers/ParserOptimizeQuery.h
+++ b/dbms/src/Parsers/ParserOptimizeQuery.h
@@ -12,8 +12,8 @@ namespace DB
 class ParserOptimizeQuery : public IParserBase
 {
 protected:
-    const char * getName() const { return "OPTIMIZE query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "OPTIMIZE query"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 }

--- a/dbms/src/Parsers/ParserRenameQuery.h
+++ b/dbms/src/Parsers/ParserRenameQuery.h
@@ -14,8 +14,8 @@ namespace DB
 class ParserRenameQuery : public IParserBase
 {
 protected:
-    const char * getName() const { return "RENAME query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const  override{ return "RENAME query"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 }

--- a/dbms/src/Parsers/ParserRoleList.h
+++ b/dbms/src/Parsers/ParserRoleList.h
@@ -11,8 +11,8 @@ namespace DB
 class ParserRoleList : public IParserBase
 {
 protected:
-    const char * getName() const { return "RoleList"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "RoleList"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 }

--- a/dbms/src/Parsers/ParserSampleRatio.h
+++ b/dbms/src/Parsers/ParserSampleRatio.h
@@ -12,8 +12,8 @@ namespace DB
 class ParserSampleRatio : public IParserBase
 {
 protected:
-    const char * getName() const { return "Sample ratio or offset"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "Sample ratio or offset"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 }

--- a/dbms/src/Parsers/ParserShowProcesslistQuery.h
+++ b/dbms/src/Parsers/ParserShowProcesslistQuery.h
@@ -14,9 +14,9 @@ namespace DB
 class ParserShowProcesslistQuery : public IParserBase
 {
 protected:
-    const char * getName() const { return "SHOW PROCESSLIST query"; }
+    const char * getName() const override { return "SHOW PROCESSLIST query"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
     {
         auto query = std::make_shared<ASTShowProcesslistQuery>();
 

--- a/dbms/src/Parsers/ParserShowTablesQuery.h
+++ b/dbms/src/Parsers/ParserShowTablesQuery.h
@@ -14,8 +14,8 @@ namespace DB
 class ParserShowTablesQuery : public IParserBase
 {
 protected:
-    const char * getName() const { return "SHOW [TEMPORARY] TABLES|DATABASES [[NOT] LIKE 'str'] [LIMIT expr]"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "SHOW [TEMPORARY] TABLES|DATABASES [[NOT] LIKE 'str'] [LIMIT expr]"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 }

--- a/dbms/src/Parsers/ParserTablesInSelectQuery.h
+++ b/dbms/src/Parsers/ParserTablesInSelectQuery.h
@@ -11,8 +11,8 @@ namespace DB
 class ParserTablesInSelectQuery : public IParserBase
 {
 protected:
-    const char * getName() const { return "table, table function, subquery or list of joined tables"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "table, table function, subquery or list of joined tables"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
@@ -22,8 +22,8 @@ public:
     ParserTablesInSelectQueryElement(bool is_first_) : is_first(is_first_) {}
 
 protected:
-    const char * getName() const { return "table, table function, subquery or list of joined tables"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "table, table function, subquery or list of joined tables"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 
 private:
     bool is_first;
@@ -33,16 +33,16 @@ private:
 class ParserTableExpression : public IParserBase
 {
 protected:
-    const char * getName() const { return "table or subquery or table function"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "table or subquery or table function"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 
 class ParserArrayJoin : public IParserBase
 {
 protected:
-    const char * getName() const { return "array join"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "array join"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 

--- a/dbms/src/Parsers/ParserUseQuery.h
+++ b/dbms/src/Parsers/ParserUseQuery.h
@@ -11,8 +11,8 @@ namespace DB
 class ParserUseQuery : public IParserBase
 {
 protected:
-    const char * getName() const { return "USE query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const  override{ return "USE query"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 }

--- a/dbms/src/Parsers/ParserWatchQuery.h
+++ b/dbms/src/Parsers/ParserWatchQuery.h
@@ -23,8 +23,8 @@ namespace DB
 class ParserWatchQuery : public IParserBase
 {
 protected:
-    const char * getName() const { return "WATCH query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected);
+    const char * getName() const override { return "WATCH query"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
 }

--- a/libs/libcommon/include/common/ErrorHandlers.h
+++ b/libs/libcommon/include/common/ErrorHandlers.h
@@ -12,9 +12,9 @@
 class KillingErrorHandler : public Poco::ErrorHandler
 {
 public:
-    void exception(const Poco::Exception &) { std::terminate(); }
-    void exception(const std::exception &)  { std::terminate(); }
-    void exception()                        { std::terminate(); }
+    void exception(const Poco::Exception &) override { std::terminate(); }
+    void exception(const std::exception &)  override { std::terminate(); }
+    void exception()                        override { std::terminate(); }
 };
 
 
@@ -23,9 +23,9 @@ public:
 class ServerErrorHandler : public Poco::ErrorHandler
 {
 public:
-    void exception(const Poco::Exception &) { logException(); }
-    void exception(const std::exception &)  { logException(); }
-    void exception()                        { logException(); }
+    void exception(const Poco::Exception &) override { logException(); }
+    void exception(const std::exception &)  override { logException(); }
+    void exception()                        override { logException(); }
 
 private:
     Logger * log = &Logger::get("ServerErrorHandler");

--- a/libs/libmysqlxx/include/mysqlxx/Exception.h
+++ b/libs/libmysqlxx/include/mysqlxx/Exception.h
@@ -1,49 +1,46 @@
 #pragma once
 
 #include <sstream>
-#include <mysqlxx/Types.h>
 #include <Poco/Exception.h>
+#include <mysqlxx/Types.h>
 
 
 namespace mysqlxx
 {
-
-/** Общий класс исключений, которые могут быть выкинуты функциями из библиотеки.
-  * Функции code() и errnum() возвращают номер ошибки MySQL. (см. mysqld_error.h)
-  */
+/// Common exception class for MySQL library. Functions code() and errnum() return error numbers from MySQL, for details see mysqld_error.h
 struct Exception : public Poco::Exception
 {
     Exception(const std::string & msg, int code = 0) : Poco::Exception(msg, code) {}
     int errnum() const { return code(); }
-    const char * name() const throw() { return "mysqlxx::Exception"; }
-    const char * className() const throw() { return "mysqlxx::Exception"; }
+    const char * name() const throw() override { return "mysqlxx::Exception"; }
+    const char * className() const throw() override { return "mysqlxx::Exception"; }
 };
 
 
-/// Не удалось соединиться с сервером.
+/// Cannot connect to MySQL server
 struct ConnectionFailed : public Exception
 {
     ConnectionFailed(const std::string & msg, int code = 0) : Exception(msg, code) {}
-    const char * name() const throw() { return "mysqlxx::ConnectionFailed"; }
-    const char * className() const throw() { return "mysqlxx::ConnectionFailed"; }
+    const char * name() const throw() override { return "mysqlxx::ConnectionFailed"; }
+    const char * className() const throw() override { return "mysqlxx::ConnectionFailed"; }
 };
 
 
-/// Запрос содержит ошибку.
+/// Erroneous query.
 struct BadQuery : public Exception
 {
     BadQuery(const std::string & msg, int code = 0) : Exception(msg, code) {}
-    const char * name() const throw() { return "mysqlxx::BadQuery"; }
-    const char * className() const throw() { return "mysqlxx::BadQuery"; }
+    const char * name() const throw() override { return "mysqlxx::BadQuery"; }
+    const char * className() const throw() override { return "mysqlxx::BadQuery"; }
 };
 
 
-/// Невозможно распарсить значение.
+/// Value parsing failure
 struct CannotParseValue : public Exception
 {
     CannotParseValue(const std::string & msg, int code = 0) : Exception(msg, code) {}
-    const char * name() const throw() { return "mysqlxx::CannotParseValue"; }
-    const char * className() const throw() { return "mysqlxx::CannotParseValue"; }
+    const char * name() const throw() override { return "mysqlxx::CannotParseValue"; }
+    const char * className() const throw() override { return "mysqlxx::CannotParseValue"; }
 };
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):
Add GCC warning `-Wsuggest-override` to locate and fix all places where `override` keyword must be used.