### PR TITLE
Fix sending no data to client with Null format.

### DIFF
--- a/dbms/src/DataStreams/BlockIO.h
+++ b/dbms/src/DataStreams/BlockIO.h
@@ -66,6 +66,8 @@ struct BlockIO
         finish_callback         = rhs.finish_callback;
         exception_callback      = rhs.exception_callback;
 
+        null_format             = rhs.null_format;
+
         return *this;
     }
 };


### PR DESCRIPTION
Looks like before it could only work accidentally due to some mighty
NRVO.

Changelog category (leave one):
- Bug Fix

Changelog entry (short description of added functionality):
Make sure that `FORMAT Null` sends no data to the client.