### PR TITLE
minor fixes in build-gcc script

### DIFF
--- a/utils/ci/build-gcc-from-sources.sh
+++ b/utils/ci/build-gcc-from-sources.sh
@@ -32,8 +32,8 @@ $SUDO make install
 popd
 popd
 
-$SUDO ln -sf /usr/local/bin/gcc /usr/local/bin/gcc-${GCC_GCC_SOURCES_VERSION_SHORT}
-$SUDO ln -sf /usr/local/bin/g++ /usr/local/bin/g++-${GCC_GCC_SOURCES_VERSION_SHORT}
+$SUDO ln -sf /usr/local/bin/gcc /usr/local/bin/gcc-${GCC_VERSION_SHORT}
+$SUDO ln -sf /usr/local/bin/g++ /usr/local/bin/g++-${GCC_VERSION_SHORT}
 $SUDO ln -sf /usr/local/bin/gcc /usr/local/bin/cc
 $SUDO ln -sf /usr/local/bin/g++ /usr/local/bin/c++
 
@@ -43,5 +43,5 @@ $SUDO ldconfig
 hash gcc g++
 gcc --version
 
-export CC=gcc
-export CXX=g++
+export CC=gcc-${GCC_VERSION_SHORT}
+export CXX=g++-${GCC_VERSION_SHORT}


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement

Detailed description / Documentation draft:

- fix creating gcc-9 g++-9 symbolic links
- set `CC` and `CXX` variables to those links (prevent the use of system compilers)