### PR TITLE
Suppress the last two MemorySanitizer failures

### DIFF
--- a/dbms/tests/msan_suppressions.txt
+++ b/dbms/tests/msan_suppressions.txt
@@ -1,2 +1,10 @@
 # https://github.com/google/oss-fuzz/issues/1099
 fun:__gxx_personality_*
+
+# We apply std::tolower to uninitialized padding, but don't use the result, so
+# it is OK. Reproduce with "select ngramDistanceCaseInsensitive(materialize(''), '')"
+fun:tolower
+
+# A failure in zlib-ng in 00302_http_compression. Doesn't reproduce locally for me.
+# Need to reproduce and report upstream, but I just want to enable the MSan already.
+fun:crc_fold_512to32

--- a/dbms/tests/msan_suppressions.txt
+++ b/dbms/tests/msan_suppressions.txt
@@ -4,7 +4,3 @@ fun:__gxx_personality_*
 # We apply std::tolower to uninitialized padding, but don't use the result, so
 # it is OK. Reproduce with "select ngramDistanceCaseInsensitive(materialize(''), '')"
 fun:tolower
-
-# A failure in zlib-ng in 00302_http_compression. Doesn't reproduce locally for me.
-# Need to reproduce and report upstream, but I just want to enable the MSan already.
-fun:crc_fold_512to32


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Suppress some test failures under MemorySanitizer.