### PR TITLE
Do not crash if the row template file is empty.

### DIFF
--- a/dbms/src/Formats/ParsedTemplateFormatString.cpp
+++ b/dbms/src/Formats/ParsedTemplateFormatString.cpp
@@ -16,20 +16,10 @@ namespace ErrorCodes
 
 ParsedTemplateFormatString::ParsedTemplateFormatString(const FormatSchemaInfo & schema, const ColumnIdxGetter & idx_by_name)
 {
-    try
-    {
-        ReadBufferFromFile schema_file(schema.absoluteSchemaPath(), 4096);
-        String format_string;
-        readStringUntilEOF(format_string, schema_file);
-        parse(format_string, idx_by_name);
-    }
-    catch (DB::Exception & e)
-    {
-        if (e.code() != ErrorCodes::INVALID_TEMPLATE_FORMAT)
-            throwInvalidFormat(e.message(), columnsCount());
-        else
-            throw;
-    }
+    ReadBufferFromFile schema_file(schema.absoluteSchemaPath(), 4096);
+    String format_string;
+    readStringUntilEOF(format_string, schema_file);
+    parse(format_string, idx_by_name);
 }
 
 
@@ -193,8 +183,11 @@ const char * ParsedTemplateFormatString::readMayBeQuotedColumnNameInto(const cha
 String ParsedTemplateFormatString::dump() const
 {
     WriteBufferFromOwnString res;
-    res << "Delimiter " << 0 << ": ";
-    verbosePrintString(delimiters.front().c_str(), delimiters.front().c_str() + delimiters.front().size(), res);
+    res << "\nDelimiter " << 0 << ": ";
+    if (delimiters.size() <= 1)
+        res << "<ERROR>";
+    else
+        verbosePrintString(delimiters[0].c_str(), delimiters[0].c_str() + delimiters[0].size(), res);
 
     size_t num_columns = std::max(formats.size(), format_idx_to_column_idx.size());
     for (size_t i = 0; i < num_columns; ++i)

--- a/dbms/src/Formats/ParsedTemplateFormatString.cpp
+++ b/dbms/src/Formats/ParsedTemplateFormatString.cpp
@@ -19,7 +19,17 @@ ParsedTemplateFormatString::ParsedTemplateFormatString(const FormatSchemaInfo & 
     ReadBufferFromFile schema_file(schema.absoluteSchemaPath(), 4096);
     String format_string;
     readStringUntilEOF(format_string, schema_file);
-    parse(format_string, idx_by_name);
+    try
+    {
+        parse(format_string, idx_by_name);
+    }
+    catch (DB::Exception & e)
+    {
+        if (e.code() != ErrorCodes::INVALID_TEMPLATE_FORMAT)
+            throwInvalidFormat(e.message(), columnsCount());
+        else
+            throw;
+    }
 }
 
 

--- a/dbms/src/Formats/ParsedTemplateFormatString.cpp
+++ b/dbms/src/Formats/ParsedTemplateFormatString.cpp
@@ -194,10 +194,7 @@ String ParsedTemplateFormatString::dump() const
 {
     WriteBufferFromOwnString res;
     res << "\nDelimiter " << 0 << ": ";
-    if (delimiters.size() <= 1)
-        res << "<ERROR>";
-    else
-        verbosePrintString(delimiters[0].c_str(), delimiters[0].c_str() + delimiters[0].size(), res);
+    verbosePrintString(delimiters.front().c_str(), delimiters.front().c_str() + delimiters.front().size(), res);
 
     size_t num_columns = std::max(formats.size(), format_idx_to_column_idx.size());
     for (size_t i = 0; i < num_columns; ++i)

--- a/dbms/tests/queries/0_stateless/01070_template_empty_file.sql
+++ b/dbms/tests/queries/0_stateless/01070_template_empty_file.sql
@@ -1,0 +1,2 @@
+select 1 format Template settings format_template_row='01070_nonexistent_file.txt'; -- { clientError 107 }
+select 1 format Template settings format_template_row='/dev/null'; -- { clientError 474 }


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not crash when using Template format with empty row template.