### PR TITLE
Fixed bug with `MergeTreeReadPool`

### DIFF
--- a/dbms/src/Storages/MergeTree/MergeTreeReadPool.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeReadPool.cpp
@@ -217,7 +217,7 @@ std::vector<size_t> MergeTreeReadPool::fillPerPartInfo(
 
         per_part_sum_marks.push_back(sum_marks);
 
-        per_part_columns_lock.emplace_back(part.data_part->columns_lock);
+        per_part_columns_lock.emplace_back(part.data_part, part.data_part->columns_lock);
 
         auto [required_columns, required_pre_columns, should_reorder] =
             getReadTaskColumns(data, part.data_part, column_names, prewhere_info, check_columns);

--- a/dbms/src/Storages/MergeTree/MergeTreeReadPool.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeReadPool.h
@@ -3,6 +3,7 @@
 #include <Core/NamesAndTypes.h>
 #include <Storages/MergeTree/RangesInDataPart.h>
 #include <Storages/MergeTree/MergeTreeBlockReadUtils.h>
+#include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/SelectQueryInfo.h>
 #include <mutex>
 
@@ -93,7 +94,7 @@ private:
         const size_t threads, const size_t sum_marks, std::vector<size_t> per_part_sum_marks,
         RangesInDataParts & parts, const size_t min_marks_for_concurrent_read);
 
-    std::vector<std::shared_lock<std::shared_mutex>> per_part_columns_lock;
+    std::vector<std::pair<MergeTreeData::DataPartPtr, std::shared_lock<std::shared_mutex>>> per_part_columns_lock;
     const MergeTreeData & data;
     Names column_names;
     bool do_not_steal_tasks;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixed memory management problem in `MergeTreeReadPool`.
