### PR TITLE
Make system log engine customizable via config.

### DIFF
--- a/dbms/src/Interpreters/SystemLog.cpp
+++ b/dbms/src/Interpreters/SystemLog.cpp
@@ -11,6 +11,11 @@
 
 namespace DB
 {
+    
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+}
 
 namespace
 {
@@ -33,8 +38,12 @@ std::shared_ptr<TSystemLog> createSystemLog(
     String table = config.getString(config_prefix + ".table", default_table_name);
 
     String engine;
-    if (config.has(config_prefix + ".custom_engine"))
-        engine = config.getString(config_prefix + ".custom_engine");
+    if (config.has(config_prefix + ".engine"))
+    {
+        if (config.has(config_prefix + ".partition_by"))
+            throw Exception("If 'engine' is specified for system table, PARTITION BY parameters should be specified directly inside 'engine' and 'partition_by' setting doesn't make sense", ErrorCodes::BAD_ARGUMENTS);
+        engine = config.getString(config_prefix + ".engine");
+    }
     else
     {
         String partition_by = config.getString(config_prefix + ".partition_by", "toYYYYMM(event_date)");

--- a/dbms/src/Interpreters/SystemLog.cpp
+++ b/dbms/src/Interpreters/SystemLog.cpp
@@ -11,7 +11,7 @@
 
 namespace DB
 {
-    
+
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;

--- a/dbms/src/Interpreters/SystemLog.cpp
+++ b/dbms/src/Interpreters/SystemLog.cpp
@@ -31,8 +31,15 @@ std::shared_ptr<TSystemLog> createSystemLog(
 
     String database = config.getString(config_prefix + ".database", default_database_name);
     String table = config.getString(config_prefix + ".table", default_table_name);
-    String partition_by = config.getString(config_prefix + ".partition_by", "toYYYYMM(event_date)");
-    String engine = "ENGINE = MergeTree PARTITION BY (" + partition_by + ") ORDER BY (event_date, event_time)";
+
+    String engine;
+    if (config.has(config_prefix + ".custom_engine"))
+        engine = config.getString(config_prefix + ".custom_engine");
+    else
+    {
+        String partition_by = config.getString(config_prefix + ".partition_by", "toYYYYMM(event_date)");
+        engine = "ENGINE = MergeTree PARTITION BY (" + partition_by + ") ORDER BY (event_date, event_time) SETTINGS index_granularity = 1024";
+    }
 
     size_t flush_interval_milliseconds = config.getUInt64(config_prefix + ".flush_interval_milliseconds", DEFAULT_SYSTEM_LOG_FLUSH_INTERVAL_MILLISECONDS);
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Add an option allowing to customize system log engine specification. Useful for internal CHYT project which does not want to store query log etc using MergeTree engine.

Changelog category (leave one):
- Non-significant (changelog entry is not required)


