### PR TITLE
Fix race when executing SYSTEM RELOAD ALL DICTIONARIES.

### DIFF
--- a/dbms/src/Interpreters/ExternalLoader.cpp
+++ b/dbms/src/Interpreters/ExternalLoader.cpp
@@ -540,6 +540,7 @@ public:
 
     Strings getAllTriedToLoadNames() const
     {
+        std::lock_guard lock{mutex};
         Strings names;
         for (auto & [name, info] : infos)
             if (info.triedToLoad())


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Bug Fix

Changelog entry:
Fix race which could happen when SYSTEM RELOAD ALL DICTIONARIES is executed while some dictionary is being modified/added/removed.