### PR TITLE
Make checkStackSize symbol weak.

### DIFF
--- a/dbms/src/Common/checkStackSize.cpp
+++ b/dbms/src/Common/checkStackSize.cpp
@@ -1,5 +1,6 @@
 #include <Common/checkStackSize.h>
 #include <Common/Exception.h>
+#include <Core/Defines.h>
 #include <ext/scope_guard.h>
 #include <pthread.h>
 #include <cstdint>
@@ -23,7 +24,7 @@ namespace DB
 static thread_local void * stack_address = nullptr;
 static thread_local size_t max_stack_size = 0;
 
-void checkStackSize()
+CH_WEAK void checkStackSize()
 {
     using namespace DB;
 

--- a/dbms/src/Common/checkStackSize.cpp
+++ b/dbms/src/Common/checkStackSize.cpp
@@ -1,6 +1,5 @@
 #include <Common/checkStackSize.h>
 #include <Common/Exception.h>
-#include <Core/Defines.h>
 #include <ext/scope_guard.h>
 #include <pthread.h>
 #include <cstdint>
@@ -24,7 +23,7 @@ namespace DB
 static thread_local void * stack_address = nullptr;
 static thread_local size_t max_stack_size = 0;
 
-CH_WEAK void checkStackSize()
+__attribute__((__weak__)) void checkStackSize()
 {
     using namespace DB;
 

--- a/dbms/src/Common/checkStackSize.cpp
+++ b/dbms/src/Common/checkStackSize.cpp
@@ -23,6 +23,13 @@ namespace DB
 static thread_local void * stack_address = nullptr;
 static thread_local size_t max_stack_size = 0;
 
+/** It works fine when interpreters are instantiated by ClickHouse code in properly prepared threads, 
+  *  but there are cases when ClickHouse runs as a library inside another application. 
+  * If application is using user-space lightweight threads with manually allocated stacks, 
+  *  current implementation is not reasonable, as it has no way to properly check the remaining 
+  *  stack size without knowing the details of how stacks are allocated.
+  * We mark this function as weak symbol to be able to replace it in another ClickHouse-based products.
+  */
 __attribute__((__weak__)) void checkStackSize()
 {
     using namespace DB;

--- a/dbms/src/Core/Defines.h
+++ b/dbms/src/Core/Defines.h
@@ -162,12 +162,3 @@
 /// A macro for suppressing warnings about unused variables or function results.
 /// Useful for structured bindings which have no standard way to declare this.
 #define UNUSED(...) (void)(__VA_ARGS__)
-
-/// A macro for declaring global symbols weak. Useful when certain global function
-/// may be substituted by different implementation by another application using
-/// ClickHouse as a library (i.e. checkStackSize()).
-#if defined(__GNUC__)
-    #define CH_WEAK __attribute__((weak))
-#else
-    #define CH_WEAK
-#endif

--- a/dbms/src/Core/Defines.h
+++ b/dbms/src/Core/Defines.h
@@ -162,3 +162,12 @@
 /// A macro for suppressing warnings about unused variables or function results.
 /// Useful for structured bindings which have no standard way to declare this.
 #define UNUSED(...) (void)(__VA_ARGS__)
+
+/// A macro for declaring global symbols weak. Useful when certain global function
+/// may be substituted by different implementation by another application using
+/// ClickHouse as a library (i.e. checkStackSize()).
+#if defined(__GNUC__)
+    #define CH_WEAK __attribute__((weak))
+#else
+    #define CH_WEAK
+#endif


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Non-significant (changelog entry is not required)

There is a sanity check implemented by `checkStackSize()` call. It works fine when interpreters are instantiated by ClickHouse code in properly prepared threads, but there are cases when ClickHouse runs as a library inside another application. If application is using user-space lightweight threads with manually allocated stacks, current implementation is not reasonable, as it has no way to properly check the remaining stack size without knowing the details of how stacks are allocated.

Fortunately, `checkStackSize()` is a global routine, so it is pretty easy to make it customizable by declaring it [weak](https://en.wikipedia.org/wiki/Weak_symbol), so that it can be replaced by linker with a more suitable implementation.

This PR adds macro for marking symbol weak and marks `checkStackSize()` as weak.