### PR TITLE
Introduce macro for disabling allocator mmapping.

### DIFF
--- a/dbms/src/Common/Allocator.h
+++ b/dbms/src/Common/Allocator.h
@@ -51,7 +51,13 @@
   * P.S. This is also required, because tcmalloc can not allocate a chunk of
   * memory greater than 16 GB.
   */
-#ifdef NDEBUG
+
+#ifdef DISABLE_MMAP
+    /**
+     * If we are explicitly asked to disable mmapping, set MMAP_THRESHOLD to effective infinity.
+     */
+    static constexpr size_t MMAP_THRESHOLD = (size_t)-1;
+#elif NDEBUG
     static constexpr size_t MMAP_THRESHOLD = 64 * (1ULL << 20);
 #else
     /**


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Non-significant (changelog entry is not required)

When using ClickHouse as a library in another application, raw mmap syscalls may interfere with application's custom allocator (which implements its own logic of mmapping by overriding malloc/free). In this case it should be possible to disable mmapping in compile time. We introduce DISABLE_MMAP macro here.