### PR TITLE
Initialize query profiler for all threads in a group

### DIFF
--- a/dbms/src/Common/ThreadStatus.h
+++ b/dbms/src/Common/ThreadStatus.h
@@ -203,6 +203,9 @@ protected:
 
     /// Set to non-nullptr only if we have enough capabilities.
     std::unique_ptr<TaskStatsInfoGetter> taskstats_getter;
+
+private:
+    void setupState(const ThreadGroupStatusPtr & thread_group_);
 };
 
 }

--- a/dbms/src/Interpreters/ThreadStatusExt.cpp
+++ b/dbms/src/Interpreters/ThreadStatusExt.cpp
@@ -50,40 +50,11 @@ void CurrentThread::defaultThreadDeleter()
     current_thread->detachQuery(true, true);
 }
 
-void ThreadStatus::initializeQuery()
+void ThreadStatus::setupState(const ThreadGroupStatusPtr & thread_group_)
 {
     assertState({ThreadState::DetachedFromQuery}, __PRETTY_FUNCTION__);
 
-    thread_group = std::make_shared<ThreadGroupStatus>();
-
-    performance_counters.setParent(&thread_group->performance_counters);
-    memory_tracker.setParent(&thread_group->memory_tracker);
-    thread_group->memory_tracker.setDescription("(for query)");
-
-    thread_group->thread_numbers.emplace_back(thread_number);
-    thread_group->os_thread_ids.emplace_back(os_thread_id);
-    thread_group->master_thread_number = thread_number;
-    thread_group->master_thread_os_id = os_thread_id;
-
-    initPerformanceCounters();
-    thread_state = ThreadState::AttachedToQuery;
-}
-
-void ThreadStatus::attachQuery(const ThreadGroupStatusPtr & thread_group_, bool check_detached)
-{
-    if (thread_state == ThreadState::AttachedToQuery)
-    {
-        if (check_detached)
-            throw Exception("Can't attach query to the thread, it is already attached", ErrorCodes::LOGICAL_ERROR);
-        return;
-    }
-
-    assertState({ThreadState::DetachedFromQuery}, __PRETTY_FUNCTION__);
-
-    if (!thread_group_)
-        throw Exception("Attempt to attach to nullptr thread group", ErrorCodes::LOGICAL_ERROR);
-
-    /// Attach current thread to thread group and copy useful information from it
+    /// Attach or init current thread to thread group and copy useful information from it
     thread_group = thread_group_;
 
     performance_counters.setParent(&thread_group->performance_counters);
@@ -92,22 +63,22 @@ void ThreadStatus::attachQuery(const ThreadGroupStatusPtr & thread_group_, bool 
     {
         std::lock_guard lock(thread_group->mutex);
 
+        /// NOTE: thread may be attached multiple times if it is reused from a thread pool.
+        thread_group->thread_numbers.emplace_back(thread_number);
+        thread_group->os_thread_ids.emplace_back(os_thread_id);
+
         logs_queue_ptr = thread_group->logs_queue_ptr;
         query_context = thread_group->query_context;
 
         if (!global_context)
             global_context = thread_group->global_context;
-
-        /// NOTE: A thread may be attached multiple times if it is reused from a thread pool.
-        thread_group->thread_numbers.emplace_back(thread_number);
-        thread_group->os_thread_ids.emplace_back(os_thread_id);
     }
 
     if (query_context)
     {
         query_id = query_context->getCurrentQueryId();
 
-#if defined(__linux__)
+#if defined(OS_LINUX)
         /// Set "nice" value if required.
         Int32 new_os_thread_priority = query_context->getSettingsRef().os_thread_priority;
         if (new_os_thread_priority && hasLinuxCapability(CAP_SYS_NICE))
@@ -126,6 +97,31 @@ void ThreadStatus::attachQuery(const ThreadGroupStatusPtr & thread_group_, bool 
     initQueryProfiler();
 
     thread_state = ThreadState::AttachedToQuery;
+}
+
+void ThreadStatus::initializeQuery()
+{
+    setupState(std::make_shared<ThreadGroupStatus>());
+
+    /// No need to lock on mutex here
+    thread_group->memory_tracker.setDescription("(for query)");
+    thread_group->master_thread_number = thread_number;
+    thread_group->master_thread_os_id = os_thread_id;
+}
+
+void ThreadStatus::attachQuery(const ThreadGroupStatusPtr & thread_group_, bool check_detached)
+{
+    if (thread_state == ThreadState::AttachedToQuery)
+    {
+        if (check_detached)
+            throw Exception("Can't attach query to the thread, it is already attached", ErrorCodes::LOGICAL_ERROR);
+        return;
+    }
+
+    if (!thread_group_)
+        throw Exception("Attempt to attach to nullptr thread group", ErrorCodes::LOGICAL_ERROR);
+
+    setupState(thread_group_);
 }
 
 void ThreadStatus::finalizePerformanceCounters()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Initialize query profiler for all threads in a group, e.g. it allows to fully profile insert-queries