### PR TITLE
Fix LiveView dependencies

### DIFF
--- a/dbms/src/Storages/LiveView/StorageLiveView.h
+++ b/dbms/src/Storages/LiveView/StorageLiveView.h
@@ -53,7 +53,7 @@ public:
     {
         return StorageID("", getStorageID().table_name + "_blocks");
     }
-    StoragePtr getParentStorage() const { return parent_storage; }
+    StoragePtr getParentStorage() const { return global_context.getTable(select_table_id); }
 
     NameAndTypePair getColumn(const String & column_name) const override;
     bool hasColumn(const String & column_name) const override;
@@ -65,12 +65,7 @@ public:
             return inner_subquery->clone();
         return nullptr;
     }
-    ASTPtr getInnerBlocksQuery() const
-    {
-        if (inner_blocks_query)
-            return inner_blocks_query->clone();
-        return nullptr;
-    }
+    ASTPtr getInnerBlocksQuery();
 
     /// It is passed inside the query and solved at its level.
     bool supportsSampling() const override { return true; }
@@ -177,10 +172,9 @@ private:
     ASTPtr inner_blocks_query; /// query over the mergeable blocks to produce final result
     Context & global_context;
     std::unique_ptr<Context> live_view_context;
-    StoragePtr parent_storage;
 
     bool is_temporary = false;
-    /// Mutex to protect access to sample block
+    /// Mutex to protect access to sample block and inner_blocks_query
     mutable std::mutex sample_block_lock;
     mutable Block sample_block;
 

--- a/dbms/tests/queries/0_stateless/01060_shutdown_table_after_detach.sql
+++ b/dbms/tests/queries/0_stateless/01060_shutdown_table_after_detach.sql
@@ -1,4 +1,5 @@
-CREATE TABLE IF NOT EXISTS test Engine = MergeTree ORDER BY number AS SELECT number, toString(rand()) x from numbers(10000000);
+DROP TABLE IF EXISTS test;
+CREATE TABLE test Engine = MergeTree ORDER BY number AS SELECT number, toString(rand()) x from numbers(10000000);
 
 SELECT count() FROM test;
 

--- a/dbms/tests/queries/0_stateless/01071_live_view_detach_dependency.sql
+++ b/dbms/tests/queries/0_stateless/01071_live_view_detach_dependency.sql
@@ -1,0 +1,8 @@
+SET allow_experimental_live_view = 1;
+DROP TABLE IF EXISTS test;
+DROP TABLE IF EXISTS lv;
+CREATE TABLE test (n Int8) ENGINE = Memory;
+CREATE LIVE VIEW lv AS SELECT * FROM test;
+DETACH TABLE lv;
+INSERT INTO test VALUES (42);
+DROP TABLE test;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
During server startup do not access table, which `LiveView` depends on, so server will be able to start. Also remove `LiveView` dependencies when detaching `LiveView`
