### PR TITLE
Allow disabling mmapping

### DIFF
--- a/dbms/src/Common/Allocator.h
+++ b/dbms/src/Common/Allocator.h
@@ -50,16 +50,21 @@
   *
   * P.S. This is also required, because tcmalloc can not allocate a chunk of
   * memory greater than 16 GB.
+  *
+  * P.P.S. Note that MMAP_THRESHOLD symbol is intentionally made weak. It allows
+  * to override it during linkage when using ClickHouse as a library in
+  * third-party applications which may already use own allocator doing mmaps
+  * in the implementation of alloc/realloc.
   */
 #ifdef NDEBUG
-    static constexpr size_t MMAP_THRESHOLD = 64 * (1ULL << 20);
+    __attribute__((__weak__)) extern const size_t MMAP_THRESHOLD = 64 * (1ULL << 20);
 #else
     /**
       * In debug build, use small mmap threshold to reproduce more memory
       * stomping bugs. Along with ASLR it will hopefully detect more issues than
       * ASan. The program may fail due to the limit on number of memory mappings.
       */
-    static constexpr size_t MMAP_THRESHOLD = 4096;
+    __attribute__((__weak__)) extern const size_t MMAP_THRESHOLD = 4096;
 #endif
 
 static constexpr size_t MMAP_MIN_ALIGNMENT = 4096;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

When using ClickHouse as a library in another application, raw mmap syscalls may interfere with application's custom allocator (which implements its own logic of mmapping by overriding malloc/free). In this case it should be possible to disable mmapping from third-party application side. In this PR it is done by making MMAP_THRESHOLD a weak const size_t symbol, which may be overridden during linkage time (for example, by setting it to effective infinity).

This PR consists of two commits, The main one is the first one. The second one is a rough synthetic benchmark showing that no performance degradation is imposed by replacing constant which is now in compile-time with a weak extern linkage constant.

Benchmark results with the existing implementation (static constexpr):
```
Benchmarking alloc/free:
 * 8: 0.168296 sec, 2.00625e-08 per allocation
 * 16: 0.167921 sec, 2.00177e-08 per allocation
 * 32: 0.168438 sec, 2.00793e-08 per allocation
 * 64: 0.167651 sec, 1.99856e-08 per allocation
 * 128: 0.16908 sec, 2.01559e-08 per allocation
 * 256: 0.167635 sec, 1.99837e-08 per allocation
 * 512: 0.166951 sec, 1.99021e-08 per allocation
 * 1024: 0.168118 sec, 2.00413e-08 per allocation
 * 2048: 0.167313 sec, 1.99453e-08 per allocation
 * 4096: 0.167451 sec, 1.99617e-08 per allocation
 * 8192: 0.2111 sec, 2.51651e-08 per allocation
 * 16384: 0.21892 sec, 2.60973e-08 per allocation
 * 32768: 0.218687 sec, 2.60695e-08 per allocation
 * 65536: 4.70532 sec, 5.60917e-07 per allocation
 * 131072: 2.29375 sec, 2.73436e-07 per allocation
 * 262144: 2.31657 sec, 2.76157e-07 per allocation
 * 524288: 2.37891 sec, 2.83589e-07 per allocation
 * 1048576: 2.40394 sec, 2.86572e-07 per allocation
 * 2097152: 2.10322 sec, 2.50723e-07 per allocation
 * 4194304: 2.01656 sec, 2.40392e-07 per allocation
 * 8388608: 2.08836 sec, 2.48952e-07 per allocation
 * 16777216: 2.01294 sec, 2.39961e-07 per allocation
 * 33554432: 2.08242 sec, 2.48243e-07 per allocation
 * 67108864: 14.4654 sec, 1.72441e-06 per allocation
 * 134217728: 17.2539 sec, 2.05683e-06 per allocation
Benchmarking realloc:
 * 8 <-> 16: 0.000694049 sec, 8.47228e-08 per reallocation pair
 * 16 <-> 32: 0.000765583 sec, 9.3455e-08 per reallocation pair
 * 32 <-> 64: 0.000696218 sec, 8.49875e-08 per reallocation pair
 * 64 <-> 128: 0.000712565 sec, 8.6983e-08 per reallocation pair
 * 128 <-> 256: 0.000737152 sec, 8.99844e-08 per reallocation pair
 * 256 <-> 512: 0.00077664 sec, 9.48047e-08 per reallocation pair
 * 512 <-> 1024: 0.00091416 sec, 1.11592e-07 per reallocation pair
 * 1024 <-> 2048: 0.0010347 sec, 1.26307e-07 per reallocation pair
 * 2048 <-> 4096: 0.0013959 sec, 1.70398e-07 per reallocation pair
 * 4096 <-> 8192: 0.00256135 sec, 3.12665e-07 per reallocation pair
 * 8192 <-> 16384: 0.00395076 sec, 4.82271e-07 per reallocation pair
 * 16384 <-> 32768: 0.0050764 sec, 6.19678e-07 per reallocation pair
 * 32768 <-> 65536: 0.00495192 sec, 6.04483e-07 per reallocation pair
 * 65536 <-> 131072: 0.00495573 sec, 6.04947e-07 per reallocation pair
 * 131072 <-> 262144: 0.00497768 sec, 6.07626e-07 per reallocation pair
 * 262144 <-> 524288: 0.00522553 sec, 6.37883e-07 per reallocation pair
 * 524288 <-> 1048576: 0.00530204 sec, 6.47222e-07 per reallocation pair
 * 1048576 <-> 2097152: 0.00482683 sec, 5.89213e-07 per reallocation pair
 * 2097152 <-> 4194304: 0.00505098 sec, 6.16575e-07 per reallocation pair
 * 4194304 <-> 8388608: 0.00488619 sec, 5.96459e-07 per reallocation pair
 * 8388608 <-> 16777216: 0.0048275 sec, 5.89294e-07 per reallocation pair
 * 16777216 <-> 33554432: 0.00497286 sec, 6.07039e-07 per reallocation pair
 ```

Benchmark results with the suggested implementation (weak extern const):
```
Benchmarking alloc/free:
 * 8: 0.168912 sec, 2.01359e-08 per allocation
 * 16: 0.167237 sec, 1.99362e-08 per allocation
 * 32: 0.167165 sec, 1.99276e-08 per allocation
 * 64: 0.173682 sec, 2.07045e-08 per allocation
 * 128: 0.167782 sec, 2.00012e-08 per allocation
 * 256: 0.166902 sec, 1.98963e-08 per allocation
 * 512: 0.166797 sec, 1.98838e-08 per allocation
 * 1024: 0.167118 sec, 1.9922e-08 per allocation
 * 2048: 0.16864 sec, 2.01034e-08 per allocation
 * 4096: 0.167595 sec, 1.99789e-08 per allocation
 * 8192: 0.217758 sec, 2.59588e-08 per allocation
 * 16384: 0.219371 sec, 2.6151e-08 per allocation
 * 32768: 0.212892 sec, 2.53788e-08 per allocation
 * 65536: 4.87818 sec, 5.81525e-07 per allocation
 * 131072: 2.02467 sec, 2.4136e-07 per allocation
 * 262144: 2.43595 sec, 2.90388e-07 per allocation
 * 524288: 2.30736 sec, 2.75059e-07 per allocation
 * 1048576: 2.30911 sec, 2.75268e-07 per allocation
 * 2097152: 2.12605 sec, 2.53445e-07 per allocation
 * 4194304: 2.089 sec, 2.49028e-07 per allocation
 * 8388608: 2.13425 sec, 2.54423e-07 per allocation
 * 16777216: 2.04373 sec, 2.43632e-07 per allocation
 * 33554432: 2.16242 sec, 2.57781e-07 per allocation
 * 67108864: 15.0426 sec, 1.79321e-06 per allocation
 * 134217728: 17.3127 sec, 2.06384e-06 per allocation
Benchmarking realloc:
 * 8 <-> 16: 0.000678175 sec, 8.2785e-08 per reallocation pair
 * 16 <-> 32: 0.000639766 sec, 7.80964e-08 per reallocation pair
 * 32 <-> 64: 0.000759808 sec, 9.275e-08 per reallocation pair
 * 64 <-> 128: 0.000724668 sec, 8.84604e-08 per reallocation pair
 * 128 <-> 256: 0.000733349 sec, 8.95201e-08 per reallocation pair
 * 256 <-> 512: 0.000721675 sec, 8.80951e-08 per reallocation pair
 * 512 <-> 1024: 0.000914093 sec, 1.11584e-07 per reallocation pair
 * 1024 <-> 2048: 0.0010684 sec, 1.3042e-07 per reallocation pair
 * 2048 <-> 4096: 0.00135418 sec, 1.65305e-07 per reallocation pair
 * 4096 <-> 8192: 0.00249167 sec, 3.04159e-07 per reallocation pair
 * 8192 <-> 16384: 0.00379181 sec, 4.62868e-07 per reallocation pair
 * 16384 <-> 32768: 0.00492873 sec, 6.01651e-07 per reallocation pair
 * 32768 <-> 65536: 0.00461508 sec, 5.63365e-07 per reallocation pair
 * 65536 <-> 131072: 0.00480086 sec, 5.86043e-07 per reallocation pair
 * 131072 <-> 262144: 0.00487992 sec, 5.95693e-07 per reallocation pair
 * 262144 <-> 524288: 0.00486001 sec, 5.93263e-07 per reallocation pair
 * 524288 <-> 1048576: 0.00492805 sec, 6.01568e-07 per reallocation pair
 * 1048576 <-> 2097152: 0.00458975 sec, 5.60272e-07 per reallocation pair
 * 2097152 <-> 4194304: 0.00473885 sec, 5.78473e-07 per reallocation pair
 * 4194304 <-> 8388608: 0.00490685 sec, 5.98981e-07 per reallocation pair
 * 8388608 <-> 16777216: 0.00498573 sec, 6.0861e-07 per reallocation pair
 * 16777216 <-> 33554432: 0.00502484 sec, 6.13383e-07 per reallocation pair
```

In release build under g++-8.3 from Ubuntu 18.04 repo benchmark shows no significant difference in performance.

Changelog category (leave one):
- Non-significant (changelog entry is not required)
