### PR TITLE
Explicitly specify storage features

### DIFF
--- a/dbms/src/Storages/Kafka/StorageKafka.cpp
+++ b/dbms/src/Storages/Kafka/StorageKafka.cpp
@@ -411,7 +411,7 @@ bool StorageKafka::streamToViews()
 
 void registerStorageKafka(StorageFactory & factory)
 {
-    factory.registerStorage("Kafka", [](const StorageFactory::Arguments & args)
+    auto creator_fn = [](const StorageFactory::Arguments & args)
     {
         ASTs & engine_args = args.engine_args;
         size_t args_count = engine_args.size();
@@ -636,7 +636,9 @@ void registerStorageKafka(StorageFactory & factory)
         return StorageKafka::create(
             args.table_id, args.context, args.columns,
             brokers, group, topics, format, row_delimiter, schema, num_consumers, max_block_size, skip_broken, intermediate_commit);
-    });
+    };
+
+    factory.registerStorage("Kafka", creator_fn, StorageFactory::StorageFeatures{ .supports_settings = true, });
 }
 
 

--- a/dbms/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/dbms/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -669,21 +669,28 @@ static StoragePtr create(const StorageFactory::Arguments & args)
 
 void registerStorageMergeTree(StorageFactory & factory)
 {
-    factory.registerStorage("MergeTree", create);
-    factory.registerStorage("CollapsingMergeTree", create);
-    factory.registerStorage("ReplacingMergeTree", create);
-    factory.registerStorage("AggregatingMergeTree", create);
-    factory.registerStorage("SummingMergeTree", create);
-    factory.registerStorage("GraphiteMergeTree", create);
-    factory.registerStorage("VersionedCollapsingMergeTree", create);
+    StorageFactory::StorageFeatures features{
+        .supports_settings = true,
+        .supports_skipping_indices = true,
+        .supports_sort_order = true,
+        .supports_ttl = true,
+    };
 
-    factory.registerStorage("ReplicatedMergeTree", create);
-    factory.registerStorage("ReplicatedCollapsingMergeTree", create);
-    factory.registerStorage("ReplicatedReplacingMergeTree", create);
-    factory.registerStorage("ReplicatedAggregatingMergeTree", create);
-    factory.registerStorage("ReplicatedSummingMergeTree", create);
-    factory.registerStorage("ReplicatedGraphiteMergeTree", create);
-    factory.registerStorage("ReplicatedVersionedCollapsingMergeTree", create);
+    factory.registerStorage("MergeTree", create, features);
+    factory.registerStorage("CollapsingMergeTree", create, features);
+    factory.registerStorage("ReplacingMergeTree", create, features);
+    factory.registerStorage("AggregatingMergeTree", create, features);
+    factory.registerStorage("SummingMergeTree", create, features);
+    factory.registerStorage("GraphiteMergeTree", create, features);
+    factory.registerStorage("VersionedCollapsingMergeTree", create, features);
+
+    factory.registerStorage("ReplicatedMergeTree", create, features);
+    factory.registerStorage("ReplicatedCollapsingMergeTree", create, features);
+    factory.registerStorage("ReplicatedReplacingMergeTree", create, features);
+    factory.registerStorage("ReplicatedAggregatingMergeTree", create, features);
+    factory.registerStorage("ReplicatedSummingMergeTree", create, features);
+    factory.registerStorage("ReplicatedGraphiteMergeTree", create, features);
+    factory.registerStorage("ReplicatedVersionedCollapsingMergeTree", create, features);
 }
 
 }

--- a/dbms/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/dbms/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -684,6 +684,9 @@ void registerStorageMergeTree(StorageFactory & factory)
     factory.registerStorage("GraphiteMergeTree", create, features);
     factory.registerStorage("VersionedCollapsingMergeTree", create, features);
 
+    features.supports_replication = true;
+    features.supports_deduplication = true;
+
     factory.registerStorage("ReplicatedMergeTree", create, features);
     factory.registerStorage("ReplicatedCollapsingMergeTree", create, features);
     factory.registerStorage("ReplicatedReplacingMergeTree", create, features);

--- a/dbms/src/Storages/StorageFactory.cpp
+++ b/dbms/src/Storages/StorageFactory.cpp
@@ -142,7 +142,6 @@ StoragePtr StorageFactory::get(
         }
     };
 
-    //if (storage_def->settings && !endsWith(name, "MergeTree") && name != "Kafka" && name != "Join")
     if (storage_def->settings)
         checkFeature(
             "SETTINGS clause",

--- a/dbms/src/Storages/StorageFactory.cpp
+++ b/dbms/src/Storages/StorageFactory.cpp
@@ -127,7 +127,8 @@ StoragePtr StorageFactory::get(
 
     auto checkFeature = [&](String feature_description, FeatureMatcherFn feature_matcher_fn)
     {
-        if (!feature_matcher_fn(it->second.features)) {
+        if (!feature_matcher_fn(it->second.features))
+        {
             String msg = "Engine " + name + " doesn't support " + feature_description + ". "
                 "Currently only the following engines have support for the feature: [";
             auto supporting_engines = getAllRegisteredNamesByFeatureMatcherFn(feature_matcher_fn);

--- a/dbms/src/Storages/StorageFactory.cpp
+++ b/dbms/src/Storages/StorageFactory.cpp
@@ -143,20 +143,23 @@ StoragePtr StorageFactory::get(
         }
     };
 
-    if (storage_def->settings)
-        checkFeature(
-            "SETTINGS clause",
-            [](StorageFeatures features) { return features.supports_settings; });
+    if (storage_def)
+    {
+        if (storage_def->settings)
+            checkFeature(
+                "SETTINGS clause",
+                [](StorageFeatures features) { return features.supports_settings; });
 
-    if (storage_def->partition_by || storage_def->primary_key || storage_def->order_by || storage_def->sample_by)
-        checkFeature(
-            "PARTITION_BY, PRIMARY_KEY, ORDER_BY or SAMPLE_BY clauses",
-            [](StorageFeatures features) { return features.supports_sort_order; });
+        if (storage_def->partition_by || storage_def->primary_key || storage_def->order_by || storage_def->sample_by)
+            checkFeature(
+                "PARTITION_BY, PRIMARY_KEY, ORDER_BY or SAMPLE_BY clauses",
+                [](StorageFeatures features) { return features.supports_sort_order; });
 
-    if (storage_def->ttl_table || !columns.getColumnTTLs().empty())
-        checkFeature(
-            "TTL clause",
-            [](StorageFeatures features) { return features.supports_ttl; });
+        if (storage_def->ttl_table || !columns.getColumnTTLs().empty())
+            checkFeature(
+                "TTL clause",
+                [](StorageFeatures features) { return features.supports_ttl; });
+    }
 
     if (query.columns_list && query.columns_list->indices && !query.columns_list->indices->children.empty())
         checkFeature(

--- a/dbms/src/Storages/StorageFactory.h
+++ b/dbms/src/Storages/StorageFactory.h
@@ -52,6 +52,8 @@ public:
         bool supports_skipping_indices = false;
         bool supports_sort_order = false;
         bool supports_ttl = false;
+        bool supports_replication = false;
+        bool supports_deduplication = false;
     };
 
     using CreatorFn = std::function<StoragePtr(const Arguments & arguments)>;
@@ -79,6 +81,8 @@ public:
         .supports_skipping_indices = false,
         .supports_sort_order = false,
         .supports_ttl = false,
+        .supports_replication = false,
+        .supports_deduplication = false,
     });
 
     const Storages & getAllStorages() const

--- a/dbms/src/Storages/StorageJoin.cpp
+++ b/dbms/src/Storages/StorageJoin.cpp
@@ -95,7 +95,7 @@ size_t StorageJoin::getSize() const { return join->getTotalRowCount(); }
 
 void registerStorageJoin(StorageFactory & factory)
 {
-    factory.registerStorage("Join", [](const StorageFactory::Arguments & args)
+    auto creator_fn = [](const StorageFactory::Arguments & args)
     {
         /// Join(ANY, LEFT, k1, k2, ...)
 
@@ -209,7 +209,9 @@ void registerStorageJoin(StorageFactory & factory)
             args.constraints,
             join_any_take_last_row,
             args.context);
-    });
+    };
+
+    factory.registerStorage("Join", creator_fn, StorageFactory::StorageFeatures{ .supports_settings = true, });
 }
 
 template <typename T>

--- a/dbms/src/Storages/System/StorageSystemTableEngines.cpp
+++ b/dbms/src/Storages/System/StorageSystemTableEngines.cpp
@@ -1,4 +1,5 @@
 #include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <Storages/StorageFactory.h>
 #include <Storages/System/StorageSystemTableEngines.h>
 
@@ -7,15 +8,22 @@ namespace DB
 
 NamesAndTypesList StorageSystemTableEngines::getNamesAndTypes()
 {
-    return {{"name", std::make_shared<DataTypeString>()}};
+    return {{"name", std::make_shared<DataTypeString>()},
+            {"supports_settings", std::make_shared<DataTypeUInt8>()},
+            {"supports_skipping_indices", std::make_shared<DataTypeUInt8>()},
+            {"supports_sort_order", std::make_shared<DataTypeUInt8>()},
+            {"supports_ttl", std::make_shared<DataTypeUInt8>()}};
 }
 
 void StorageSystemTableEngines::fillData(MutableColumns & res_columns, const Context &, const SelectQueryInfo &) const
 {
-    const auto & storages = StorageFactory::instance().getAllStorages();
-    for (const auto & pair : storages)
+    for (const auto & pair : StorageFactory::instance().getAllStorages())
     {
         res_columns[0]->insert(pair.first);
+        res_columns[1]->insert(pair.second.features.supports_settings);
+        res_columns[2]->insert(pair.second.features.supports_skipping_indices);
+        res_columns[3]->insert(pair.second.features.supports_sort_order);
+        res_columns[4]->insert(pair.second.features.supports_ttl);
     }
 }
 

--- a/dbms/src/Storages/System/StorageSystemTableEngines.cpp
+++ b/dbms/src/Storages/System/StorageSystemTableEngines.cpp
@@ -12,7 +12,9 @@ NamesAndTypesList StorageSystemTableEngines::getNamesAndTypes()
             {"supports_settings", std::make_shared<DataTypeUInt8>()},
             {"supports_skipping_indices", std::make_shared<DataTypeUInt8>()},
             {"supports_sort_order", std::make_shared<DataTypeUInt8>()},
-            {"supports_ttl", std::make_shared<DataTypeUInt8>()}};
+            {"supports_ttl", std::make_shared<DataTypeUInt8>()},
+            {"supports_replication", std::make_shared<DataTypeUInt8>()},
+            {"supports_deduplication", std::make_shared<DataTypeUInt8>()}};
 }
 
 void StorageSystemTableEngines::fillData(MutableColumns & res_columns, const Context &, const SelectQueryInfo &) const
@@ -24,6 +26,8 @@ void StorageSystemTableEngines::fillData(MutableColumns & res_columns, const Con
         res_columns[2]->insert(pair.second.features.supports_skipping_indices);
         res_columns[3]->insert(pair.second.features.supports_sort_order);
         res_columns[4]->insert(pair.second.features.supports_ttl);
+        res_columns[5]->insert(pair.second.features.supports_replication);
+        res_columns[6]->insert(pair.second.features.supports_deduplication);
     }
 }
 

--- a/docs/en/operations/system_tables.md
+++ b/docs/en/operations/system_tables.md
@@ -744,6 +744,40 @@ WHERE changed
 └────────────────────────┴─────────────┴─────────┘
 ```
 
+## system.table_engines
+
+Contains description of table engines supported by server and their feature support information. 
+
+This table contains the following columns (the column type is shown in brackets):
+
+- `name` (String) — The name of table engine.
+- `supports_settings` (UInt8) — Flag that indicates if table engine supports `SETTINGS` clause.
+- `supports_skipping_indices` (UInt8) — Flag that indicates if table engine supports [skipping indices](table_engines/mergetree/#table_engine-mergetree-data_skipping-indexes). 
+- `supports_ttl` (UInt8) — Flag that indicates if table engine supports [TTL](table_engines/mergetree/#table_engine-mergetree-ttl).
+- `supports_sort_order` (UInt8) — Flag that indicates if table engine supports clauses `PARTITION_BY`, `PRIMARY_KEY`, `ORDER_BY` and `SAMPLE_BY`.  
+
+Example:
+
+```sql
+SELECT *
+FROM system.table_engines
+WHERE name in ('Kafka', 'MergeTree')
+```
+
+```text
+┌─name──────┬─supports_settings─┬─supports_skipping_indices─┬─supports_sort_order─┬─supports_ttl─┐
+│ Kafka     │                 1 │                         0 │                   0 │            0 │
+│ MergeTree │                 1 │                         1 │                   1 │            1 │
+└───────────┴───────────────────┴───────────────────────────┴─────────────────────┴──────────────┘
+```
+
+**See also**
+
+- MergeTree family [query clauses](table_engines/mergetree/#sektsii-zaprosa)
+- Kafka [settings](table_engines/kafka.md#table_engine-kafka-creating-a-table)
+- Join [settings](table_engines/join/#limitations-and-settings) 
+
+
 ## system.tables
 
 Contains metadata of each table that the server knows about. Detached tables are not shown in `system.tables`.

--- a/docs/en/operations/system_tables.md
+++ b/docs/en/operations/system_tables.md
@@ -755,20 +755,23 @@ This table contains the following columns (the column type is shown in brackets)
 - `supports_skipping_indices` (UInt8) — Flag that indicates if table engine supports [skipping indices](table_engines/mergetree/#table_engine-mergetree-data_skipping-indexes). 
 - `supports_ttl` (UInt8) — Flag that indicates if table engine supports [TTL](table_engines/mergetree/#table_engine-mergetree-ttl).
 - `supports_sort_order` (UInt8) — Flag that indicates if table engine supports clauses `PARTITION_BY`, `PRIMARY_KEY`, `ORDER_BY` and `SAMPLE_BY`.  
+- `supports_replication` (UInt8) — Flag that indicates if table engine supports [data replication](table_engines/replication/).
+- `supports_duduplication` (UInt8) — Flag that indicates if table engine supports data deduplication.
 
 Example:
 
 ```sql
 SELECT *
 FROM system.table_engines
-WHERE name in ('Kafka', 'MergeTree')
+WHERE name in ('Kafka', 'MergeTree', 'ReplicatedCollapsingMergeTree')
 ```
 
 ```text
-┌─name──────┬─supports_settings─┬─supports_skipping_indices─┬─supports_sort_order─┬─supports_ttl─┐
-│ Kafka     │                 1 │                         0 │                   0 │            0 │
-│ MergeTree │                 1 │                         1 │                   1 │            1 │
-└───────────┴───────────────────┴───────────────────────────┴─────────────────────┴──────────────┘
+┌─name──────────────────────────┬─supports_settings─┬─supports_skipping_indices─┬─supports_sort_order─┬─supports_ttl─┬─supports_replication─┬─supports_deduplication─┐
+│ Kafka                         │                 1 │                         0 │                   0 │            0 │                    0 │                      0 │
+│ MergeTree                     │                 1 │                         1 │                   1 │            1 │                    0 │                      0 │
+│ ReplicatedCollapsingMergeTree │                 1 │                         1 │                   1 │            1 │                    1 │                      1 │
+└───────────────────────────────┴───────────────────┴───────────────────────────┴─────────────────────┴──────────────┴──────────────────────┴────────────────────────┘
 ```
 
 **See also**

--- a/docs/ru/operations/system_tables.md
+++ b/docs/ru/operations/system_tables.md
@@ -695,6 +695,40 @@ WHERE changed
 └────────────────────────┴─────────────┴─────────┘
 ```
 
+## system.table_engines
+
+Содержит информацию про движки таблиц, поддерживаемые сервером, а также об их возможностях. 
+
+Эта таблица содержит следующие столбцы (тип столбца показан в скобках):
+
+- `name` (String) — имя движка.
+- `supports_settings` (UInt8) — флаг, показывающий поддержку секции `SETTINGS`.
+- `supports_skipping_indices` (UInt8) — флаг, показывающий поддержку [индексов пропуска данных](table_engines/mergetree/#table_engine-mergetree-data_skipping-indexes). 
+- `supports_ttl` (UInt8) — флаг, показывающий поддержку [TTL](table_engines/mergetree/#table_engine-mergetree-ttl).
+- `supports_sort_order` (UInt8) — флаг, показывающий поддержку секций `PARTITION_BY`, `PRIMARY_KEY`, `ORDER_BY` и `SAMPLE_BY`.  
+
+Пример:
+
+```sql
+SELECT *
+FROM system.table_engines
+WHERE name in ('Kafka', 'MergeTree')
+```
+
+```text
+┌─name──────┬─supports_settings─┬─supports_skipping_indices─┬─supports_sort_order─┬─supports_ttl─┐
+│ Kafka     │                 1 │                         0 │                   0 │            0 │
+│ MergeTree │                 1 │                         1 │                   1 │            1 │
+└───────────┴───────────────────┴───────────────────────────┴─────────────────────┴──────────────┘
+```
+
+**Смотрите также**
+
+- [Секции движка](table_engines/mergetree/#sektsii-zaprosa) семейства MergeTree 
+- [Настройки](table_engines/kafka.md#table_engine-kafka-creating-a-table) Kafka
+- [Настройки](table_engines/join/#limitations-and-settings) Join
+
+
 ## system.tables
 
 Содержит метаданные каждой таблицы, о которой знает сервер. Отсоединённые таблицы не отображаются в `system.tables`.

--- a/docs/ru/operations/system_tables.md
+++ b/docs/ru/operations/system_tables.md
@@ -706,20 +706,23 @@ WHERE changed
 - `supports_skipping_indices` (UInt8) — флаг, показывающий поддержку [индексов пропуска данных](table_engines/mergetree/#table_engine-mergetree-data_skipping-indexes). 
 - `supports_ttl` (UInt8) — флаг, показывающий поддержку [TTL](table_engines/mergetree/#table_engine-mergetree-ttl).
 - `supports_sort_order` (UInt8) — флаг, показывающий поддержку секций `PARTITION_BY`, `PRIMARY_KEY`, `ORDER_BY` и `SAMPLE_BY`.  
+- `supports_replication` (UInt8) — флаг, показвыающий поддержку [репликации](table_engines/replication/).
+- `supports_duduplication` (UInt8) — флаг, показывающий наличие в движке дедупликации данных.
 
 Пример:
 
 ```sql
 SELECT *
 FROM system.table_engines
-WHERE name in ('Kafka', 'MergeTree')
+WHERE name in ('Kafka', 'MergeTree', 'ReplicatedCollapsingMergeTree')
 ```
 
 ```text
-┌─name──────┬─supports_settings─┬─supports_skipping_indices─┬─supports_sort_order─┬─supports_ttl─┐
-│ Kafka     │                 1 │                         0 │                   0 │            0 │
-│ MergeTree │                 1 │                         1 │                   1 │            1 │
-└───────────┴───────────────────┴───────────────────────────┴─────────────────────┴──────────────┘
+┌─name──────────────────────────┬─supports_settings─┬─supports_skipping_indices─┬─supports_sort_order─┬─supports_ttl─┬─supports_replication─┬─supports_deduplication─┐
+│ Kafka                         │                 1 │                         0 │                   0 │            0 │                    0 │                      0 │
+│ MergeTree                     │                 1 │                         1 │                   1 │            1 │                    0 │                      0 │
+│ ReplicatedCollapsingMergeTree │                 1 │                         1 │                   1 │            1 │                    1 │                      1 │
+└───────────────────────────────┴───────────────────┴───────────────────────────┴─────────────────────┴──────────────┴──────────────────────┴────────────────────────┘
 ```
 
 **Смотрите также**


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

There are several features that are supported by a certain subset of storages like support of TTL, key/sort order specification, settings specification or skipping indices support. As for today, ClickHouse checks if given table engine supports these features in storage factory by hard-coded rules like "if ORDER BY is specified then storage name should end with MergeTree". Such logic blocks third-party storage engines to support similar features, for example, if ClickHouse is used as a library in third-party application which provides its own storage engine supporting TTLs, there is no way to use it as StorageFactory will throw an exception.

This PR does the following:
- A notion of storage property introduced; namely, there are currently four properties `supports_settings`, `supports_skipping_indices`, `supports_ttl` and `supports_sort_order`;
- Storage registration is extended by optional specification of supported properties;
- System table `system.table_engines` is extended with information about feature support in following manner:
```
max42-dev.sas.yp-c.yandex.net :) select * from system.table_engines

SELECT *
FROM system.table_engines

┌─name───────────────────────────────────┬─supports_settings─┬─supports_skipping_indices─┬─supports_sort_order─┬─supports_ttl─┬─supports_replication─┬─supports_deduplication──┐
│ Kafka                                  │                 1 │                         0 │                   0 │            0 │                    0 │                       0 │
│ MySQL                                  │                 0 │                         0 │                   0 │            0 │                    0 │                       0 │
│ HDFS                                   │                 0 │                         0 │                   0 │            0 │                    0 │                       0 │
│ S3                                     │                 0 │                         0 │                   0 │            0 │                    0 │                       0 │
│ MaterializedView                       │                 0 │                         0 │                   0 │            0 │                    0 │                       0 │
│ View                                   │                 0 │                         0 │                   0 │            0 │                    0 │                       0 │
│ JDBC                                   │                 0 │                         0 │                   0 │            0 │                    0 │                       0 │
│ Join                                   │                 1 │                         0 │                   0 │            0 │                    0 │                       0 │
│ Set                                    │                 0 │                         0 │                   0 │            0 │                    0 │                       0 │
│ Dictionary                             │                 0 │                         0 │                   0 │            0 │                    0 │                       0 │
│ LiveView                               │                 0 │                         0 │                   0 │            0 │                    0 │                       0 │
│ MergeTree                              │                 1 │                         1 │                   1 │            1 │                    0 │                       0 │
│ Memory                                 │                 0 │                         0 │                   0 │            0 │                    0 │                       0 │
│ Buffer                                 │                 0 │                         0 │                   0 │            0 │                    0 │                       0 │
│ URL                                    │                 0 │                         0 │                   0 │            0 │                    0 │                       0 │
│ ReplicatedVersionedCollapsingMergeTree │                 1 │                         1 │                   1 │            1 │                    1 │                       1 │
│ ReplacingMergeTree                     │                 1 │                         1 │                   1 │            1 │                    0 │                       0 │
│ ReplicatedSummingMergeTree             │                 1 │                         1 │                   1 │            1 │                    1 │                       1 │
│ ReplicatedAggregatingMergeTree         │                 1 │                         1 │                   1 │            1 │                    1 │                       1 │
│ ReplicatedCollapsingMergeTree          │                 1 │                         1 │                   1 │            1 │                    1 │                       1 │
│ File                                   │                 0 │                         0 │                   0 │            0 │                    0 │                       0 │
│ ReplicatedGraphiteMergeTree            │                 1 │                         1 │                   1 │            1 │                    1 │                       1 │
│ ReplicatedMergeTree                    │                 1 │                         1 │                   1 │            1 │                    1 │                       1 │
│ ReplicatedReplacingMergeTree           │                 1 │                         1 │                   1 │            1 │                    1 │                       1 │
│ VersionedCollapsingMergeTree           │                 1 │                         1 │                   1 │            1 │                    0 │                       0 │
│ SummingMergeTree                       │                 1 │                         1 │                   1 │            1 │                    0 │                       0 │
│ Distributed                            │                 0 │                         0 │                   0 │            0 │                    0 │                       0 │
│ TinyLog                                │                 0 │                         0 │                   0 │            0 │                    0 │                       0 │
│ GraphiteMergeTree                      │                 1 │                         1 │                   1 │            1 │                    0 │                       0 │
│ CollapsingMergeTree                    │                 1 │                         1 │                   1 │            1 │                    0 │                       0 │
│ Merge                                  │                 0 │                         0 │                   0 │            0 │                    0 │                       0 │
│ AggregatingMergeTree                   │                 1 │                         1 │                   1 │            1 │                    0 │                       0 │
│ ODBC                                   │                 0 │                         0 │                   0 │            0 │                    0 │                       0 │
│ Null                                   │                 0 │                         0 │                   0 │            0 │                    0 │                       0 │
│ StripeLog                              │                 0 │                         0 │                   0 │            0 │                    0 │                       0 │
│ Log                                    │                 0 │                         0 │                   0 │            0 │                    0 │                       0 │
└────────────────────────────────────────┴───────────────────┴───────────────────────────┴─────────────────────┴──────────────┴──────────────────────┴─────────────────────────┘

36 rows in set. Elapsed: 0.006 sec. 
```

**Disclaimer**: I divided features into these four groups according to my understanding of their logic. Feel free to suggest a better division into groups or better naming.

Specify supported properties for each storage engine, expose them via system.table_engines table, properly check property support in storage factory.

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
System table `system.table_engine` now provides information about feature support (like `supports_ttl` or `supports_sort_order`).

Detailed description / Documentation draft:

System table system.table_engines is currently not documented at all, so a documentation draft for this table is included as a second commit.
