### PR TITLE
Added workaround for Google Cloud Run

### DIFF
--- a/dbms/src/Common/QueryProfiler.cpp
+++ b/dbms/src/Common/QueryProfiler.cpp
@@ -143,6 +143,7 @@ QueryProfilerBase<ProfilerImpl>::QueryProfilerBase(const Int32 thread_id, const 
         if (timer_create(clock_type, &sev, &timer_id))
         {
             /// In Google Cloud Runner, the function "timer_create" is implemented incorrectly as of 2020-01-25.
+            /// https://mybranch.dev/posts/clickhouse-on-cloud-run/
             if (errno == 0)
                 throw Exception("Failed to create thread timer. The function 'timer_create' returned non-zero but didn't set errno. This is bug in your OS.",
                     ErrorCodes::CANNOT_CREATE_TIMER);

--- a/dbms/src/Common/QueryProfiler.cpp
+++ b/dbms/src/Common/QueryProfiler.cpp
@@ -142,7 +142,7 @@ QueryProfilerBase<ProfilerImpl>::QueryProfilerBase(const Int32 thread_id, const 
 #endif
         if (timer_create(clock_type, &sev, &timer_id))
         {
-            /// In Google Cloud Runner, the function "timer_create" is implemented incorrectly as of 2020-01-25.
+            /// In Google Cloud Run, the function "timer_create" is implemented incorrectly as of 2020-01-25.
             /// https://mybranch.dev/posts/clickhouse-on-cloud-run/
             if (errno == 0)
                 throw Exception("Failed to create thread timer. The function 'timer_create' returned non-zero but didn't set errno. This is bug in your OS.",

--- a/dbms/src/Interpreters/ThreadStatusExt.cpp
+++ b/dbms/src/Interpreters/ThreadStatusExt.cpp
@@ -160,15 +160,23 @@ void ThreadStatus::initQueryProfiler()
 
     const auto & settings = query_context->getSettingsRef();
 
-    if (settings.query_profiler_real_time_period_ns > 0)
-        query_profiler_real = std::make_unique<QueryProfilerReal>(
-            /* thread_id */ os_thread_id,
-            /* period */ static_cast<UInt32>(settings.query_profiler_real_time_period_ns));
+    try
+    {
+        if (settings.query_profiler_real_time_period_ns > 0)
+            query_profiler_real = std::make_unique<QueryProfilerReal>(
+                /* thread_id */ os_thread_id,
+                /* period */ static_cast<UInt32>(settings.query_profiler_real_time_period_ns));
 
-    if (settings.query_profiler_cpu_time_period_ns > 0)
-        query_profiler_cpu = std::make_unique<QueryProfilerCpu>(
-            /* thread_id */ os_thread_id,
-            /* period */ static_cast<UInt32>(settings.query_profiler_cpu_time_period_ns));
+        if (settings.query_profiler_cpu_time_period_ns > 0)
+            query_profiler_cpu = std::make_unique<QueryProfilerCpu>(
+                /* thread_id */ os_thread_id,
+                /* period */ static_cast<UInt32>(settings.query_profiler_cpu_time_period_ns));
+    }
+    catch (...)
+    {
+        /// QueryProfiler is optional.
+        tryLogCurrentException("ThreadStatus", "Cannot initialize QueryProfiler");
+    }
 }
 
 void ThreadStatus::finalizeQueryProfiler()


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added workaround if OS returns wrong result for `timer_create` function.

Detailed description / Documentation draft:
According to the blog post of Alex Reid: https://mybranch.dev/posts/clickhouse-on-cloud-run/
ClickHouse should work perfectly but Google Cloud Run has bugs in implementation of some syscalls.
