### PR TITLE
Evaluate constant expressions for optimize_skip_unused_shards

### DIFF
--- a/dbms/src/Storages/StorageDistributed.cpp
+++ b/dbms/src/Storages/StorageDistributed.cpp
@@ -193,19 +193,60 @@ std::string makeFormattedListOfShards(const ClusterPtr & cluster)
     return os.str();
 }
 
-}
-
-
-/// For destruction of std::unique_ptr of type that is incomplete in class definition.
-StorageDistributed::~StorageDistributed() = default;
-
-static ExpressionActionsPtr buildShardingKeyExpression(const ASTPtr & sharding_key, const Context & context, NamesAndTypesList columns, bool project)
+ExpressionActionsPtr buildShardingKeyExpression(const ASTPtr & sharding_key, const Context & context, const NamesAndTypesList & columns, bool project)
 {
     ASTPtr query = sharding_key;
     auto syntax_result = SyntaxAnalyzer(context).analyze(query, columns);
     return ExpressionAnalyzer(query, syntax_result, context).getActions(project);
 }
 
+class ReplacingConstantExpressionsMatcher
+{
+public:
+    using Data = Block;
+
+    static bool needChildVisit(ASTPtr &, const ASTPtr &)
+    {
+        return true;
+    }
+
+    static void visit(ASTPtr & node, Block & block_with_constants)
+    {
+        if (!node->as<ASTFunction>())
+            return;
+
+        std::string name = node->getColumnName();
+        if (block_with_constants.has(name))
+        {
+            auto result = block_with_constants.getByName(name);
+            if (!isColumnConst(*result.column))
+                return;
+
+            if (result.column->isNullAt(0))
+            {
+                node = std::make_shared<ASTLiteral>(Field());
+            }
+            else
+            {
+                node = std::make_shared<ASTLiteral>(assert_cast<const ColumnConst &>(*result.column).getField());
+            }
+        }
+    }
+};
+void replaceConstantExpressions(ASTPtr & node, const Context & context, const NamesAndTypesList & columns)
+{
+    auto syntax_result = SyntaxAnalyzer(context).analyze(node, columns);
+    Block block_with_constants = KeyCondition::getBlockWithConstants(node, syntax_result, context);
+
+    InDepthNodeVisitor<ReplacingConstantExpressionsMatcher, true> visitor(block_with_constants);
+    visitor.visit(node);
+}
+
+} // \anonymous
+
+
+/// For destruction of std::unique_ptr of type that is incomplete in class definition.
+StorageDistributed::~StorageDistributed() = default;
 
 StorageDistributed::StorageDistributed(
     const StorageID & id_,
@@ -378,7 +419,7 @@ Pipes StorageDistributed::read(
 
         if (has_sharding_key)
         {
-            smaller_cluster = skipUnusedShards(cluster, query_info);
+            smaller_cluster = skipUnusedShards(cluster, query_info, context);
 
             if (smaller_cluster)
             {
@@ -608,7 +649,7 @@ void StorageDistributed::ClusterNodeData::shutdownAndDropAllData()
 
 /// Returns a new cluster with fewer shards if constant folding for `sharding_key_expr` is possible
 /// using constraints from "PREWHERE" and "WHERE" conditions, otherwise returns `nullptr`
-ClusterPtr StorageDistributed::skipUnusedShards(ClusterPtr cluster, const SelectQueryInfo & query_info)
+ClusterPtr StorageDistributed::skipUnusedShards(ClusterPtr cluster, const SelectQueryInfo & query_info, const Context & context)
 {
     const auto & select = query_info.query->as<ASTSelectQuery &>();
 
@@ -627,6 +668,7 @@ ClusterPtr StorageDistributed::skipUnusedShards(ClusterPtr cluster, const Select
         condition_ast = select.prewhere() ? select.prewhere()->clone() : select.where()->clone();
     }
 
+    replaceConstantExpressions(condition_ast, context, getColumns().getAllPhysical() /** TODO: sharding_key_column_name */);
     const auto blocks = evaluateExpressionOverConstantCondition(condition_ast, sharding_key_expr);
 
     // Can't get definite answer if we can skip any shards

--- a/dbms/src/Storages/StorageDistributed.cpp
+++ b/dbms/src/Storages/StorageDistributed.cpp
@@ -222,17 +222,11 @@ public:
             if (!isColumnConst(*result.column))
                 return;
 
-            if (result.column->isNullAt(0))
-            {
-                node = std::make_shared<ASTLiteral>(Field());
-            }
-            else
-            {
-                node = std::make_shared<ASTLiteral>(assert_cast<const ColumnConst &>(*result.column).getField());
-            }
+            node = std::make_shared<ASTLiteral>(assert_cast<const ColumnConst &>(*result.column).getField());
         }
     }
 };
+
 void replaceConstantExpressions(ASTPtr & node, const Context & context, const NamesAndTypesList & columns)
 {
     auto syntax_result = SyntaxAnalyzer(context).analyze(node, columns);
@@ -242,7 +236,7 @@ void replaceConstantExpressions(ASTPtr & node, const Context & context, const Na
     visitor.visit(node);
 }
 
-} // \anonymous
+}
 
 
 /// For destruction of std::unique_ptr of type that is incomplete in class definition.

--- a/dbms/src/Storages/StorageDistributed.h
+++ b/dbms/src/Storages/StorageDistributed.h
@@ -164,7 +164,7 @@ protected:
         const String & relative_data_path_,
         bool attach);
 
-    ClusterPtr skipUnusedShards(ClusterPtr cluster, const SelectQueryInfo & query_info);
+    ClusterPtr skipUnusedShards(ClusterPtr cluster, const SelectQueryInfo & query_info, const Context & context);
 
     void createStorage();
 

--- a/dbms/src/Storages/transformQueryForExternalDatabase.cpp
+++ b/dbms/src/Storages/transformQueryForExternalDatabase.cpp
@@ -26,7 +26,8 @@ namespace ErrorCodes
 namespace
 {
 
-class ReplacingConstantExpressionsMatcher
+/// Everything except numbers is put as string literal.
+class ReplacingConstantExpressionsMatcherNumOrStr
 {
 public:
     using Data = Block;
@@ -75,7 +76,7 @@ void replaceConstantExpressions(ASTPtr & node, const Context & context, const Na
     auto syntax_result = SyntaxAnalyzer(context).analyze(node, all_columns);
     Block block_with_constants = KeyCondition::getBlockWithConstants(node, syntax_result, context);
 
-    InDepthNodeVisitor<ReplacingConstantExpressionsMatcher, true> visitor(block_with_constants);
+    InDepthNodeVisitor<ReplacingConstantExpressionsMatcherNumOrStr, true> visitor(block_with_constants);
     visitor.visit(node);
 }
 

--- a/dbms/tests/queries/0_stateless/01072_optimize_skip_unused_shards_const_expr_eval.sql
+++ b/dbms/tests/queries/0_stateless/01072_optimize_skip_unused_shards_const_expr_eval.sql
@@ -1,0 +1,49 @@
+drop table if exists data_01072;
+drop table if exists dist_01072;
+
+set optimize_skip_unused_shards=1;
+set force_optimize_skip_unused_shards=1;
+
+create table data_01072 (key Int, value Int, str String) Engine=Null();
+create table dist_01072 (key Int, value Int, str String) Engine=Distributed(test_cluster_two_shards, currentDatabase(), data_01072, key%2);
+
+select * from dist_01072 where key=0 and length(str)=0;
+select * from dist_01072 where key=0 and str='';
+select * from dist_01072 where xxHash64(0)==xxHash64(0) and key=0;
+select * from dist_01072 where key=toInt32OrZero(toString(xxHash64(0)));
+select * from dist_01072 where key=toInt32(xxHash32(0));
+select * from dist_01072 where key=toInt32(toInt32(xxHash32(0)));
+select * from dist_01072 where key=toInt32(toInt32(toInt32(xxHash32(0))));
+select * from dist_01072 where key=value; -- { serverError 507; }
+select * from dist_01072 where key=toInt32(value); -- { serverError 507; }
+select * from dist_01072 where key=value settings force_optimize_skip_unused_shards=0;
+select * from dist_01072 where key=toInt32(value) settings force_optimize_skip_unused_shards=0;
+
+drop table dist_01072;
+create table dist_01072 (key Int, value Nullable(Int), str String) Engine=Distributed(test_cluster_two_shards, currentDatabase(), data_01072, key%2);
+select * from dist_01072 where key=toInt32(xxHash32(0));
+select * from dist_01072 where key=value; -- { serverError 507; }
+select * from dist_01072 where key=toInt32(value); -- { serverError 507; }
+select * from dist_01072 where key=value settings force_optimize_skip_unused_shards=0;
+select * from dist_01072 where key=toInt32(value) settings force_optimize_skip_unused_shards=0;
+
+set allow_suspicious_low_cardinality_types=1;
+
+drop table dist_01072;
+create table dist_01072 (key Int, value LowCardinality(Int), str String) Engine=Distributed(test_cluster_two_shards, currentDatabase(), data_01072, key%2);
+select * from dist_01072 where key=toInt32(xxHash32(0));
+select * from dist_01072 where key=value; -- { serverError 507; }
+select * from dist_01072 where key=toInt32(value); -- { serverError 507; }
+select * from dist_01072 where key=value settings force_optimize_skip_unused_shards=0;
+select * from dist_01072 where key=toInt32(value) settings force_optimize_skip_unused_shards=0;
+
+drop table dist_01072;
+create table dist_01072 (key Int, value LowCardinality(Nullable(Int)), str String) Engine=Distributed(test_cluster_two_shards, currentDatabase(), data_01072, key%2);
+select * from dist_01072 where key=toInt32(xxHash32(0));
+select * from dist_01072 where key=value; -- { serverError 507; }
+select * from dist_01072 where key=toInt32(value); -- { serverError 507; }
+select * from dist_01072 where key=value settings force_optimize_skip_unused_shards=0;
+select * from dist_01072 where key=toInt32(value) settings force_optimize_skip_unused_shards=0;
+
+drop table data_01072;
+drop table dist_01072;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Evaluate constant expressions for optimize_skip_unused_shards (i.e. `SELECT * FROM foo_dist WHERE key=xxHash32(0)`)