### PR TITLE
Do not dump pipeline in exception message.

### DIFF
--- a/dbms/src/Processors/Executors/PipelineExecutor.cpp
+++ b/dbms/src/Processors/Executors/PipelineExecutor.cpp
@@ -464,7 +464,7 @@ void PipelineExecutor::execute(size_t num_threads)
             if (node.execution_state->exception)
                 std::rethrow_exception(node.execution_state->exception);
     }
-    catch (Exception & exception)
+    catch (...)
     {
 #ifndef N_DEBUG
         LOG_TRACE(log, "Exception while executing query. Current state:\n" << dumpPipeline());

--- a/dbms/src/Processors/Executors/PipelineExecutor.cpp
+++ b/dbms/src/Processors/Executors/PipelineExecutor.cpp
@@ -11,9 +11,6 @@
 #include <Processors/ISource.h>
 #include <Common/setThreadName.h>
 
-#if !defined(__APPLE__) && !defined(__FreeBSD__)
-#include <sched.h>
-#endif
 
 namespace DB
 {
@@ -143,8 +140,7 @@ static void executeJob(IProcessor * processor)
     catch (Exception & exception)
     {
         if (checkCanAddAdditionalInfoToException(exception))
-            exception.addMessage("While executing " + processor->getName() + " ("
-                                 + toString(reinterpret_cast<std::uintptr_t>(processor)) + ") ");
+            exception.addMessage("While executing " + processor->getName());
         throw;
     }
 }
@@ -265,7 +261,9 @@ bool PipelineExecutor::prepareProcessor(UInt64 pid, size_t thread_number, Queue 
     std::vector<Edge *> updated_direct_edges;
 
     {
-        /// Stopwatch watch;
+#ifndef N_DEBUG
+        Stopwatch watch;
+#endif
 
         std::unique_lock<std::mutex> lock(std::move(node_lock));
 
@@ -279,7 +277,9 @@ bool PipelineExecutor::prepareProcessor(UInt64 pid, size_t thread_number, Queue 
             return false;
         }
 
-        /// node.execution_state->preparation_time_ns += watch.elapsed();
+#ifndef N_DEBUG
+        node.execution_state->preparation_time_ns += watch.elapsed();
+#endif
 
         node.updated_input_ports.clear();
         node.updated_output_ports.clear();
@@ -466,9 +466,9 @@ void PipelineExecutor::execute(size_t num_threads)
     }
     catch (Exception & exception)
     {
-        if (checkCanAddAdditionalInfoToException(exception))
-            exception.addMessage("\nCurrent state:\n" + dumpPipeline());
-
+#ifndef N_DEBUG
+        LOG_TRACE(log, "Exception while executing query. Current state:\n" << dumpPipeline());
+#endif
         throw;
     }
 
@@ -486,28 +486,15 @@ void PipelineExecutor::execute(size_t num_threads)
 
 void PipelineExecutor::executeSingleThread(size_t thread_num, size_t num_threads)
 {
-#if !defined(__APPLE__) && !defined(__FreeBSD__)
-    /// Specify CPU core for thread if can.
-    /// It may reduce the number of context swithches.
-    /*
-    if (num_threads > 1)
-    {
-        cpu_set_t cpu_set;
-        CPU_ZERO(&cpu_set);
-        CPU_SET(thread_num, &cpu_set);
+#ifndef N_DEBUG
+    UInt64 total_time_ns = 0;
+    UInt64 execution_time_ns = 0;
+    UInt64 processing_time_ns = 0;
+    UInt64 wait_time_ns = 0;
 
-        if (sched_setaffinity(0, sizeof(cpu_set_t), &cpu_set) == -1)
-            LOG_TRACE(log, "Cannot set affinity for thread " << num_threads);
-    }
-    */
+    Stopwatch total_time_watch;
 #endif
 
-//    UInt64 total_time_ns = 0;
-//    UInt64 execution_time_ns = 0;
-//    UInt64 processing_time_ns = 0;
-//    UInt64 wait_time_ns = 0;
-
-//    Stopwatch total_time_watch;
     ExecutionState * state = nullptr;
 
     auto prepare_processor = [&](UInt64 pid, Queue & queue)
@@ -585,9 +572,15 @@ void PipelineExecutor::executeSingleThread(size_t thread_num, size_t num_threads
             addJob(state);
 
             {
-                // Stopwatch execution_time_watch;
+#ifndef N_DEBUG
+                Stopwatch execution_time_watch;
+#endif
+
                 state->job();
-                // execution_time_ns += execution_time_watch.elapsed();
+
+#ifndef N_DEBUG
+                execution_time_ns += execution_time_watch.elapsed();
+#endif
             }
 
             if (state->exception)
@@ -596,7 +589,9 @@ void PipelineExecutor::executeSingleThread(size_t thread_num, size_t num_threads
             if (finished)
                 break;
 
-            // Stopwatch processing_time_watch;
+#ifndef N_DEBUG
+            Stopwatch processing_time_watch;
+#endif
 
             /// Try to execute neighbour processor.
             {
@@ -648,19 +643,22 @@ void PipelineExecutor::executeSingleThread(size_t thread_num, size_t num_threads
                     doExpandPipeline(task, false);
             }
 
-            // processing_time_ns += processing_time_watch.elapsed();
+#ifndef N_DEBUG
+            processing_time_ns += processing_time_watch.elapsed();
+#endif
         }
     }
 
-//    total_time_ns = total_time_watch.elapsed();
-//    wait_time_ns = total_time_ns - execution_time_ns - processing_time_ns;
-/*
+#ifndef N_DEBUG
+    total_time_ns = total_time_watch.elapsed();
+    wait_time_ns = total_time_ns - execution_time_ns - processing_time_ns;
+
     LOG_TRACE(log, "Thread finished."
                      << " Total time: " << (total_time_ns / 1e9) << " sec."
                      << " Execution time: " << (execution_time_ns / 1e9) << " sec."
                      << " Processing time: " << (processing_time_ns / 1e9) << " sec."
                      << " Wait time: " << (wait_time_ns / 1e9) << "sec.");
-*/
+#endif
 }
 
 void PipelineExecutor::executeImpl(size_t num_threads)
@@ -762,10 +760,18 @@ String PipelineExecutor::dumpPipeline() const
     for (auto & node : graph)
     {
         if (node.execution_state)
-            node.processor->setDescription(
-                    "(" + std::to_string(node.execution_state->num_executed_jobs) + " jobs, execution time: "
-                    + std::to_string(node.execution_state->execution_time_ns / 1e9) + " sec., preparation time: "
-                    + std::to_string(node.execution_state->preparation_time_ns / 1e9) + " sec.)");
+        {
+            WriteBufferFromOwnString buffer;
+            buffer << "(" << node.execution_state->num_executed_jobs << " jobs";
+
+#ifndef N_DEBUG
+            buffer << ", execution time: " << node.execution_state->execution_time_ns / 1e9 << " sec.";
+            buffer << ", preparation time: " << node.execution_state->preparation_time_ns / 1e9 << " sec.";
+#endif
+
+            buffer << ")";
+            node.processor->setDescription(buffer.str());
+        }
     }
 
     std::vector<IProcessor::Status> statuses;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Non-significant (changelog entry is not required)

Dump processors pipeline to log, not exception massage (except if pipeline stuck). Only in debug mode.