### PR TITLE
Fix StorageFile too many open files error

### DIFF
--- a/dbms/src/Storages/StorageFile.cpp
+++ b/dbms/src/Storages/StorageFile.cpp
@@ -255,6 +255,7 @@ public:
                 compression_method);
 
             reader = FormatFactory::instance().getInput(storage->format_name, *read_buf, storage->getSampleBlock(), context, max_block_size);
+            reader->readPrefix();
         }
 
         auto res = reader->read();
@@ -277,6 +278,7 @@ public:
         /// Close file prematurally if stream was ended.
         if (!res)
         {
+            reader->readSuffix();
             reader.reset();
             read_buf.reset();
         }
@@ -297,16 +299,6 @@ public:
         }
 
         return res;
-    }
-
-    void readPrefixImpl() override
-    {
-        reader->readPrefix();
-    }
-
-    void readSuffixImpl() override
-    {
-        reader->readSuffix();
     }
 
 private:

--- a/dbms/src/Storages/StorageFile.cpp
+++ b/dbms/src/Storages/StorageFile.cpp
@@ -204,11 +204,12 @@ class StorageFileBlockInputStream : public IBlockInputStream
 {
 public:
     StorageFileBlockInputStream(std::shared_ptr<StorageFile> storage_,
-        const Context & context, UInt64 max_block_size,
+        const Context & context_, UInt64 max_block_size_,
         std::string file_path_, bool need_path, bool need_file,
-        const CompressionMethod compression_method,
+        const CompressionMethod compression_method_,
         BlockInputStreamPtr prepared_reader = nullptr)
-        : storage(std::move(storage_)), reader(std::move(prepared_reader))
+        : storage(std::move(storage_)), reader(std::move(prepared_reader)),
+        context(context_), max_block_size(max_block_size_), compression_method(compression_method_)
     {
         if (storage->use_table_fd)
         {
@@ -314,6 +315,10 @@ private:
     Block sample_block;
     std::unique_ptr<ReadBuffer> read_buf;
     BlockInputStreamPtr reader;
+
+    const Context & context;    /// TODO Untangle potential issues with context lifetime.
+    UInt64 max_block_size;
+    const CompressionMethod compression_method;
 
     std::shared_lock<std::shared_mutex> shared_lock;
     std::unique_lock<std::shared_mutex> unique_lock;

--- a/dbms/src/Storages/StorageFile.cpp
+++ b/dbms/src/Storages/StorageFile.cpp
@@ -286,7 +286,8 @@ public:
 
     Block getHeader() const override
     {
-        auto res = reader->getHeader();
+        auto res = storage->getSampleBlock();
+
         if (res && file_path)
         {
             if (with_path_column)
@@ -294,6 +295,7 @@ public:
             if (with_file_column)
                 res.insert({DataTypeString().createColumn(), std::make_shared<DataTypeString>(), "_file"});
         }
+
         return res;
     }
 


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed the issue when "Too many open files" error may happen if there are too many files matching glob pattern in `File` table or `file` table function. Now files are opened lazily. This fixes #8857