### PR TITLE
Reformat stack traces for readability.

### DIFF
--- a/dbms/src/Common/StackTrace.cpp
+++ b/dbms/src/Common/StackTrace.cpp
@@ -265,7 +265,19 @@ static void toStringEveryLineImpl(const StackTrace::Frames & frames, size_t offs
         uintptr_t virtual_offset = object ? uintptr_t(object->address_begin) : 0;
         const void * physical_addr = reinterpret_cast<const void *>(uintptr_t(virtual_addr) - virtual_offset);
 
-        out << i << ". " << physical_addr << " ";
+        out << i << ". ";
+
+        if (object)
+        {
+            if (std::filesystem::exists(object->name))
+            {
+                auto dwarf_it = dwarfs.try_emplace(object->name, *object->elf).first;
+
+                DB::Dwarf::LocationInfo location;
+                if (dwarf_it->second.findAddress(uintptr_t(physical_addr), location, DB::Dwarf::LocationInfoMode::FAST))
+                    out << location.file.toString() << ":" << location.line << ": ";
+            }
+        }
 
         auto symbol = symbol_index.findSymbol(virtual_addr);
         if (symbol)
@@ -276,22 +288,8 @@ static void toStringEveryLineImpl(const StackTrace::Frames & frames, size_t offs
         else
             out << "?";
 
-        out << " ";
-
-        if (object)
-        {
-            if (std::filesystem::exists(object->name))
-            {
-                auto dwarf_it = dwarfs.try_emplace(object->name, *object->elf).first;
-
-                DB::Dwarf::LocationInfo location;
-                if (dwarf_it->second.findAddress(uintptr_t(physical_addr), location, DB::Dwarf::LocationInfoMode::FAST))
-                    out << location.file.toString() << ":" << location.line;
-            }
-            out << " in " << object->name;
-        }
-        else
-            out << "?";
+        out << " @ " << physical_addr;
+        out << " in " << (object ? object->name : "?");
 
         callback(out.str());
         out.str({});


### PR DESCRIPTION
Changelog category (leave one):
- Non-significant

```
before:
0. 0xe7ef078 std::exception::capture() /home/akuzm/ch2/ch/contrib/libcxx/include/exception:129 in /home/akuzm/ch2/build-clang9/dbms/programs/clickhouse-server

after:
0. /home/akuzm/ch2/ch/contrib/libcxx/include/exception:129: std::exception::capture() @ 0xe7f3d08 in /home/akuzm/ch1/build-clang9/dbms/programs/clickhouse-server
```

Make stack traces more human-readable:
* move file/line info to the front because our method names are very long and you can't see where they end
* move address to the back because who needs it anyway