### PR TITLE
Add an option to use Cotire unity build to improve build times

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -144,3 +144,6 @@
 	path = contrib/avro
 	url = https://github.com/ClickHouse-Extras/avro.git
 	ignore = untracked
+[submodule "contrib/cotire"]
+	path = contrib/cotire
+	url = git@github.com:sakra/cotire.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -146,4 +146,4 @@
 	ignore = untracked
 [submodule "contrib/cotire"]
 	path = contrib/cotire
-	url = git@github.com:sakra/cotire.git
+	url = https://github.com/sakra/cotire.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,12 @@ endforeach()
 
 project(ClickHouse)
 
+option(ENABLE_COTIRE "Enable cotire unity build" ON)
+
+if (ENABLE_COTIRE)
+include (contrib/cotire/CMake/cotire.cmake)
+endif()
+
 include (cmake/arch.cmake)
 include (cmake/target.cmake)
 include (cmake/tools.cmake)

--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -277,6 +277,9 @@ macro(add_object_library name common_path)
         add_headers_and_sources(${name} ${common_path})
         add_library(${name} SHARED ${${name}_sources} ${${name}_headers})
         target_link_libraries (${name} PRIVATE -Wl,--unresolved-symbols=ignore-all)
+        if (ENABLE_COTIRE)
+            cotire (${name})
+        endif()
     endif ()
 endmacro()
 
@@ -579,6 +582,13 @@ target_include_directories (clickhouse_common_io SYSTEM BEFORE PUBLIC ${DOUBLE_C
 
 # also for copy_headers.sh:
 target_include_directories (clickhouse_common_io BEFORE PRIVATE ${COMMON_INCLUDE_DIR})
+
+if (ENABLE_COTIRE)
+    cotire (clickhouse_common_io)
+    if (MAKE_STATIC_LIBRARIES OR NOT SPLIT_SHARED_LIBRARIES)
+        cotire (dbms)
+    endif ()
+endif()
 
 add_subdirectory (programs)
 add_subdirectory (tests)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add an option to use Cotire unity build to improve build times