### PR TITLE
Report BAD_ARGUMENTS for a wrong user-supplied enum value.

### DIFF
--- a/dbms/src/DataTypes/DataTypeEnum.h
+++ b/dbms/src/DataTypes/DataTypeEnum.h
@@ -13,7 +13,7 @@ namespace DB
 
 namespace ErrorCodes
 {
-    extern const int LOGICAL_ERROR;
+    extern const int BAD_ARGUMENTS;
 }
 
 
@@ -70,7 +70,7 @@ public:
     {
         const auto it = value_to_name_map.find(value);
         if (it == std::end(value_to_name_map))
-            throw Exception{"Unexpected value " + toString(value) + " for type " + getName(), ErrorCodes::LOGICAL_ERROR};
+            throw Exception{"Unexpected value " + toString(value) + " for type " + getName(), ErrorCodes::BAD_ARGUMENTS};
 
         return it->second;
     }
@@ -79,7 +79,7 @@ public:
     {
         const auto it = name_to_value_map.find(field_name);
         if (!it)
-            throw Exception{"Unknown element '" + field_name.toString() + "' for type " + getName(), ErrorCodes::LOGICAL_ERROR};
+            throw Exception{"Unknown element '" + field_name.toString() + "' for type " + getName(), ErrorCodes::BAD_ARGUMENTS};
 
         return it->getMapped();
     }

--- a/dbms/tests/queries/0_stateless/00453_cast_enum.sql
+++ b/dbms/tests/queries/0_stateless/00453_cast_enum.sql
@@ -11,4 +11,6 @@ INSERT INTO cast_enums SELECT 2 AS type, toDate('2017-01-01') AS date, number AS
 
 SELECT type, date, id FROM cast_enums ORDER BY type, id;
 
+INSERT INTO cast_enums VALUES ('wrong_value', '2017-01-02', 7); -- { clientError 36 }
+
 DROP TABLE IF EXISTS cast_enums;


### PR DESCRIPTION
Before we reported LOGICAL_ERROR which must not be reported for user errors.

Changelog category (leave one):
- Non-significant (changelog entry is not required)
