### PR TITLE
Issue 8864 show create table bad error message

### DIFF
--- a/dbms/src/Databases/DatabaseOnDisk.cpp
+++ b/dbms/src/Databases/DatabaseOnDisk.cpp
@@ -245,6 +245,8 @@ void DatabaseOnDisk::renameTable(
 ASTPtr DatabaseOnDisk::getCreateTableQueryImpl(const Context & context, const String & table_name, bool throw_on_error) const
 {
     ASTPtr ast;
+    bool ht = tryGetTable(context, table_name) != nullptr;
+    std::cerr << "HAS_TABLE: " << ht << "\n";
 
     auto table_metadata_path = getObjectMetadataPath(table_name);
     ast = getCreateQueryFromMetadata(context, table_metadata_path, throw_on_error);

--- a/dbms/src/Databases/IDatabase.h
+++ b/dbms/src/Databases/IDatabase.h
@@ -28,7 +28,6 @@ namespace ErrorCodes
 {
     extern const int NOT_IMPLEMENTED;
     extern const int CANNOT_GET_CREATE_TABLE_QUERY;
-    extern const int CANNOT_GET_CREATE_TABLE_QUERY;
     extern const int CANNOT_GET_CREATE_DICTIONARY_QUERY;
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bug in which a misleading error message was shown when running "SHOW CREATE TABLE a_table_that_does_not_exist".

Fixes #8864.
