### PR TITLE
DROP TEMPORARY TABLE now drops only temporary table.

### DIFF
--- a/dbms/src/Interpreters/InterpreterDropQuery.h
+++ b/dbms/src/Interpreters/InterpreterDropQuery.h
@@ -30,9 +30,9 @@ private:
 
     BlockIO executeToDatabase(String & database_name, ASTDropQuery::Kind kind, bool if_exists);
 
-    BlockIO executeToTable(String & database_name, String & table_name, ASTDropQuery::Kind kind, bool if_exists, bool if_temporary, bool no_ddl_lock);
+    BlockIO executeToTable(String & database_name, String & table_name, ASTDropQuery::Kind kind, bool if_exists, bool is_temporary, bool no_ddl_lock);
 
-    BlockIO executeToDictionary(String & database_name, String & table_name, ASTDropQuery::Kind kind, bool if_exists, bool if_temporary, bool no_ddl_lock);
+    BlockIO executeToDictionary(String & database_name, String & table_name, ASTDropQuery::Kind kind, bool if_exists, bool is_temporary, bool no_ddl_lock);
 
     DatabasePtr tryGetDatabase(String & database_name, bool exists);
 

--- a/dbms/tests/queries/0_stateless/00626_replace_partition_from_table_zookeeper.sh
+++ b/dbms/tests/queries/0_stateless/00626_replace_partition_from_table_zookeeper.sh
@@ -83,7 +83,7 @@ $CLICKHOUSE_CLIENT --query="SELECT count(), sum(d) FROM test.dst_r2;"
 
 $CLICKHOUSE_CLIENT --query="INSERT INTO test_block_numbers SELECT max(max_block_number) AS m FROM system.parts WHERE database='test' AND  table='dst_r1' AND active AND name LIKE '1_%';"
 $CLICKHOUSE_CLIENT --query="SELECT (max(m) - min(m) > 1) AS new_block_is_generated FROM test_block_numbers;"
-$CLICKHOUSE_CLIENT --query="DROP TEMPORARY TABLE test_block_numbers;"
+$CLICKHOUSE_CLIENT --query="DROP TABLE test_block_numbers;"
 
 
 $CLICKHOUSE_CLIENT --query="SELECT 'ATTACH FROM';"

--- a/dbms/tests/queries/0_stateless/01072_drop_temporary_table_with_same_name.sql
+++ b/dbms/tests/queries/0_stateless/01072_drop_temporary_table_with_same_name.sql
@@ -1,0 +1,15 @@
+DROP TEMPORARY TABLE IF EXISTS table_to_drop;
+DROP TABLE IF EXISTS table_to_drop;
+
+CREATE TABLE table_to_drop(x Int8) ENGINE=Log;
+CREATE TEMPORARY TABLE table_to_drop(x Int8);
+DROP TEMPORARY TABLE table_to_drop;
+DROP TEMPORARY TABLE table_to_drop; -- { serverError 60 }
+DROP TABLE table_to_drop;
+DROP TABLE table_to_drop; -- { serverError 60 }
+
+CREATE TABLE table_to_drop(x Int8) ENGINE=Log;
+CREATE TEMPORARY TABLE table_to_drop(x Int8);
+DROP TABLE table_to_drop;
+DROP TABLE table_to_drop;
+DROP TABLE table_to_drop; -- { serverError 60 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Bug Fix

Changelog entry:
`DROP TEMPORARY TABLE name` now drops the table `name` only if it's a temporary table, and doesn't try to drop the table in the current database.