### PR TITLE
Fix crash in corner case of MergeTreeRangeReader::ReadResult::shrink

### DIFF
--- a/dbms/src/Storages/MergeTree/MergeTreeRangeReader.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeRangeReader.cpp
@@ -263,7 +263,7 @@ void MergeTreeRangeReader::ReadResult::shrink(Columns & old_columns)
             continue;
         auto new_column = old_columns[i]->cloneEmpty();
         new_column->reserve(total_rows_per_granule);
-        for (size_t j = 0, pos = 0; j < rows_per_granule_original.size(); pos += rows_per_granule_original[i], ++j)
+        for (size_t j = 0, pos = 0; j < rows_per_granule_original.size(); pos += rows_per_granule_original[j++])
         {
             if (rows_per_granule[j])
                 new_column->insertRangeFrom(*old_columns[i], pos, rows_per_granule[j]);


### PR DESCRIPTION
Closes: #7713

It looks like most times the original number of rows per granule is pretty much consistent across all granules, except for the last one, however there seems to be cases (Issue #7713) where that's not the case.

The only way I have to reproduce the crash involves using proprietary data, and unfortunately I haven't been able to come up with a test case that would highlight the problem - just like the person who opened issue #7713, I can't share my dataset.

Reading the code, it looks pretty obvious to me here - unless I'm missing something, that the intention here is to copy the corresponding granules to one another so it makes sense to index rows_per_granule_original with the same variable as rows_per_granule.

I have spent a couple hours trying to piggy back off this test case: ```0_stateless/00160_merge_and_index_in_in.sql``` because it hits the ```shrink()``` method, but unfortunately I haven't been able to make it hit the corner case where the granules are not all the same size (even by setting ```enable_mixed_granularity_parts``` to 1).

Signed-off-by: Baudouin Giard <bgiard@bloomberg.net>

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix "Parameter out of bound" exception in optimized queries


I was asked to attach a copy of the DCO to my PR:

```
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

