### PR TITLE
Rename ANY INNER to SEMI JOIN for partial merge join

### DIFF
--- a/dbms/src/Core/Settings.h
+++ b/dbms/src/Core/Settings.h
@@ -314,7 +314,7 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingUInt64, max_bytes_in_join, 0, "Maximum size of the hash table for JOIN (in number of bytes in memory).", 0) \
     M(SettingOverflowMode, join_overflow_mode, OverflowMode::THROW, "What to do when the limit is exceeded.", 0) \
     M(SettingBool, join_any_take_last_row, false, "When disabled (default) ANY JOIN will take the first found row for a key. When enabled, it will take the last row seen if there are multiple rows for the same key.", IMPORTANT) \
-    M(SettingBool, partial_merge_join, false, "Use partial merge join instead of hash join for LEFT and INNER JOINs.", 0) \
+    M(SettingBool, partial_merge_join, false, "Use partial merge join instead of hash join for joins (ANY|ALL|SEMI LEFT and ALL INNER are supported for now).", 0) \
     M(SettingBool, partial_merge_join_optimizations, false, "Enable optimizations in partial merge join", 0) \
     M(SettingUInt64, default_max_bytes_in_join, 100000000, "Maximum size of right-side table if limit is required but max_bytes_in_join is not set.", 0) \
     M(SettingUInt64, partial_merge_join_rows_in_right_blocks, 10000, "Split right-hand joining data in blocks of specified size. It's a portion of data indexed by min-max values and possibly unloaded on disk.", 0) \

--- a/dbms/src/Interpreters/AnalyzedJoin.cpp
+++ b/dbms/src/Interpreters/AnalyzedJoin.cpp
@@ -213,6 +213,22 @@ bool AnalyzedJoin::sameJoin(const AnalyzedJoin * x, const AnalyzedJoin * y)
         && x->columns_added_by_join == y->columns_added_by_join;
 }
 
+bool AnalyzedJoin::sameStrictnessAndKind(ASTTableJoin::Strictness strictness_, ASTTableJoin::Kind kind_) const
+{
+    if (strictness_ == strictness() && kind_ == kind())
+        return true;
+
+    /// Compatibility: old ANY INNER == new SEMI LEFT
+    if (strictness_ == ASTTableJoin::Strictness::Semi && isLeft(kind_) &&
+        strictness() == ASTTableJoin::Strictness::RightAny && isInner(kind()))
+        return true;
+    if (strictness() == ASTTableJoin::Strictness::Semi && isLeft(kind()) &&
+        strictness_ == ASTTableJoin::Strictness::RightAny && isInner(kind_))
+        return true;
+
+    return false;
+}
+
 JoinPtr makeJoin(std::shared_ptr<AnalyzedJoin> table_join, const Block & right_sample_block)
 {
     auto kind = table_join->kind();

--- a/dbms/src/Interpreters/AnalyzedJoin.h
+++ b/dbms/src/Interpreters/AnalyzedJoin.h
@@ -84,6 +84,7 @@ public:
 
     ASTTableJoin::Kind kind() const { return table_join.kind; }
     ASTTableJoin::Strictness strictness() const { return table_join.strictness; }
+    bool sameStrictnessAndKind(ASTTableJoin::Strictness, ASTTableJoin::Kind) const;
     const SizeLimits & sizeLimits() const { return size_limits; }
     VolumePtr getTemporaryVolume() { return tmp_volume; }
 

--- a/dbms/src/Interpreters/MergeJoin.h
+++ b/dbms/src/Interpreters/MergeJoin.h
@@ -95,7 +95,9 @@ private:
     size_t right_blocks_bytes = 0;
     bool is_in_memory = true;
     const bool nullable_right_side;
+    const bool is_any_join;
     const bool is_all_join;
+    const bool is_semi_join;
     const bool is_inner;
     const bool is_left;
     const bool skip_not_intersected;
@@ -118,12 +120,13 @@ private:
     template <bool in_memory>
     std::shared_ptr<Block> loadRightBlock(size_t pos);
 
-    template <bool is_all>
+    template <bool is_all> /// ALL or ANY
     bool leftJoin(MergeJoinCursor & left_cursor, const Block & left_block, const Block & right_block,
                   MutableColumns & left_columns, MutableColumns & right_columns, size_t & left_key_tail, size_t & skip_right);
-    template <bool is_all>
-    bool innerJoin(MergeJoinCursor & left_cursor, const Block & left_block, const Block & right_block,
-                   MutableColumns & left_columns, MutableColumns & right_columns, size_t & left_key_tail, size_t & skip_right);
+    bool semiLeftJoin(MergeJoinCursor & left_cursor, const Block & left_block, const Block & right_block,
+                  MutableColumns & left_columns, MutableColumns & right_columns);
+    bool allInnerJoin(MergeJoinCursor & left_cursor, const Block & left_block, const Block & right_block,
+                  MutableColumns & left_columns, MutableColumns & right_columns, size_t & left_key_tail, size_t & skip_right);
 
     bool saveRightBlock(Block && block);
     void flushRightBlocks();

--- a/dbms/src/Storages/StorageJoin.cpp
+++ b/dbms/src/Storages/StorageJoin.cpp
@@ -70,7 +70,7 @@ void StorageJoin::truncate(const ASTPtr &, const Context &, TableStructureWriteL
 
 HashJoinPtr StorageJoin::getJoin(std::shared_ptr<AnalyzedJoin> analyzed_join) const
 {
-    if (kind != analyzed_join->kind() || strictness != analyzed_join->strictness())
+    if (!analyzed_join->sameStrictnessAndKind(strictness, kind))
         throw Exception("Table " + getStorageID().getNameForLogs() + " has incompatible type of JOIN.", ErrorCodes::INCOMPATIBLE_TYPE_OF_JOIN);
 
     if ((analyzed_join->forceNullableRight() && !use_nulls) ||

--- a/dbms/tests/queries/0_stateless/01031_pmj_new_any_semi_join.reference
+++ b/dbms/tests/queries/0_stateless/01031_pmj_new_any_semi_join.reference
@@ -1,0 +1,47 @@
+any left
+0	a1	0	
+1	a2	0	
+2	a3	2	b1
+3	a4	0	
+4	a5	4	b3
+any left (rev)
+0		5	b6
+2	a3	2	b1
+2	a3	2	b2
+4	a5	4	b3
+4	a5	4	b4
+4	a5	4	b5
+any inner
+2	a3	2	b1
+4	a5	4	b3
+any inner (rev)
+2	a3	2	b1
+4	a5	4	b3
+any right
+0		5	b6
+2	a3	2	b1
+2	a3	2	b2
+4	a5	4	b3
+4	a5	4	b4
+4	a5	4	b5
+any right (rev)
+0	a1	0	
+1	a2	0	
+2	a3	2	b1
+3	a4	0	
+4	a5	4	b3
+semi left
+2	a3	2	b1
+4	a5	4	b3
+semi right
+2	a3	2	b1
+2	a3	2	b2
+4	a5	4	b3
+4	a5	4	b4
+4	a5	4	b5
+anti left
+0	a1	0	
+1	a2	1	
+3	a4	3	
+anti right
+0		5	b6

--- a/dbms/tests/queries/0_stateless/01031_pmj_new_any_semi_join.sql
+++ b/dbms/tests/queries/0_stateless/01031_pmj_new_any_semi_join.sql
@@ -1,0 +1,45 @@
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t2;
+
+CREATE TABLE t1 (x UInt32, s String) engine = Memory;
+CREATE TABLE t2 (x UInt32, s String) engine = Memory;
+
+INSERT INTO t1 (x, s) VALUES (0, 'a1'), (1, 'a2'), (2, 'a3'), (3, 'a4'), (4, 'a5');
+INSERT INTO t2 (x, s) VALUES (2, 'b1'), (2, 'b2'), (4, 'b3'), (4, 'b4'), (4, 'b5'), (5, 'b6');
+
+SET partial_merge_join = 1;
+SET join_use_nulls = 0;
+SET any_join_distinct_right_table_keys = 0;
+
+SELECT 'any left';
+SELECT t1.*, t2.* FROM t1 ANY LEFT JOIN t2 USING(x) ORDER BY t1.x, t2.x;
+
+SELECT 'any left (rev)';
+SELECT t1.*, t2.* FROM t2 ANY LEFT JOIN t1 USING(x) ORDER BY t1.x, t2.x;
+
+SELECT 'any inner';
+SELECT t1.*, t2.* FROM t1 ANY INNER JOIN t2 USING(x) ORDER BY t1.x, t2.x;
+
+SELECT 'any inner (rev)';
+SELECT t1.*, t2.* FROM t2 ANY INNER JOIN t1 USING(x) ORDER BY t1.x, t2.x;
+
+SELECT 'any right';
+SELECT t1.*, t2.* FROM t1 ANY RIGHT JOIN t2 USING(x) ORDER BY t1.x, t2.x;
+
+SELECT 'any right (rev)';
+SELECT t1.*, t2.* FROM t2 ANY RIGHT JOIN t1 USING(x) ORDER BY t1.x, t2.x;
+
+SELECT 'semi left';
+SELECT t1.*, t2.* FROM t1 SEMI LEFT JOIN t2 USING(x) ORDER BY t1.x, t2.x;
+
+SELECT 'semi right';
+SELECT t1.*, t2.* FROM t1 SEMI RIGHT JOIN t2 USING(x) ORDER BY t1.x, t2.x;
+
+SELECT 'anti left';
+SELECT t1.*, t2.* FROM t1 ANTI LEFT JOIN t2 USING(x) ORDER BY t1.x, t2.x;
+
+SELECT 'anti right';
+SELECT t1.*, t2.* FROM t1 ANTI RIGHT JOIN t2 USING(x) ORDER BY t1.x, t2.x;
+
+DROP TABLE t1;
+DROP TABLE t2;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use new ANY JOIN logic with `partial_merge_join` setting. It's possible to make `ANY|ALL|SEMI LEFT` and `ALL INNER` joins with `partial_merge_join=1` now.

Detailed description / Documentation draft:
Fix ANY INNER and LEFT SEMI JOINs when used with `partial_merge_join=1`.
