### PR TITLE
Added range check to function h3EdgeLengthM

### DIFF
--- a/dbms/src/Functions/h3EdgeLengthM.cpp
+++ b/dbms/src/Functions/h3EdgeLengthM.cpp
@@ -4,14 +4,22 @@
 #    include <DataTypes/DataTypesNumber.h>
 #    include <Functions/FunctionFactory.h>
 #    include <Functions/IFunction.h>
+#    include <IO/WriteHelpers.h>
 #    include <Common/typeid_cast.h>
 #    include <ext/range.h>
 
 #    include <h3api.h>
+#    include <constants.h>
 
 
 namespace DB
 {
+
+namespace ErrorCodes
+{
+    extern const int ARGUMENT_OUT_OF_BOUND;
+}
+
 // Average metric edge length of H3 hexagon. The edge length `e` for given resolution `res` can
 // be used for converting metric search radius `radius` to hexagon search ring size `k` that is
 // used by `H3kRing` function. For small enough search area simple flat approximation can be used,
@@ -50,7 +58,10 @@ public:
 
         for (const auto row : ext::range(0, input_rows_count))
         {
-            const int resolution = col_hindex->getUInt(row);
+            const UInt64 resolution = col_hindex->getUInt(row);
+            if (resolution > MAX_H3_RES)
+                throw Exception("The argument 'resolution' (" + toString(resolution) + ") of function " + getName()
+                    + " is out of bounds because the maximum resolution in H3 library is " + toString(MAX_H3_RES), ErrorCodes::ARGUMENT_OUT_OF_BOUND);
 
             Float64 res = edgeLengthM(resolution);
 

--- a/dbms/tests/queries/0_stateless/01074_h3_range_check.sql
+++ b/dbms/tests/queries/0_stateless/01074_h3_range_check.sql
@@ -1,0 +1,1 @@
+SELECT h3EdgeLengthM(100); -- { serverError 69 }


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added range check to function `h3EdgeLengthM`. Without this check, buffer overflow is possible.