### PR TITLE
Support of s3_min_upload_part_size setting in DiskS3

### DIFF
--- a/dbms/src/Disks/DiskS3.h
+++ b/dbms/src/Disks/DiskS3.h
@@ -21,7 +21,8 @@ class DiskS3 : public IDisk
 public:
     friend class DiskS3Reservation;
 
-    DiskS3(String name_, std::shared_ptr<Aws::S3::S3Client> client_, String bucket_, String s3_root_path_, String metadata_path_);
+    DiskS3(String name_, std::shared_ptr<Aws::S3::S3Client> client_, String bucket_, String s3_root_path_,
+           String metadata_path_, size_t min_upload_part_size_);
 
     const String & getName() const override { return name; }
 
@@ -82,6 +83,7 @@ private:
     const String bucket;
     const String s3_root_path;
     const String metadata_path;
+    size_t min_upload_part_size;
 
     UInt64 reserved_bytes = 0;
     UInt64 reservation_count = 0;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:

...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.
