### PR TITLE
AvroConfluent fixes

### DIFF
--- a/dbms/src/Core/Settings.h
+++ b/dbms/src/Core/Settings.h
@@ -189,7 +189,7 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingBool, input_format_values_interpret_expressions, true, "For Values format: if the field could not be parsed by streaming parser, run SQL parser and try to interpret it as SQL expression.", 0) \
     M(SettingBool, input_format_values_deduce_templates_of_expressions, true, "For Values format: if the field could not be parsed by streaming parser, run SQL parser, deduce template of the SQL expression, try to parse all rows using template and then interpret expression for all rows.", 0) \
     M(SettingBool, input_format_values_accurate_types_of_literals, true, "For Values format: when parsing and interpreting expressions using template, check actual type of literal to avoid possible overflow and precision issues.", 0) \
-    M(SettingString, input_format_avro_schema_registry_url, "", "For AvroConfluent format: Confluent Schema Registry URL.", 0) \
+    M(SettingURI, format_avro_schema_registry_url, {}, "For AvroConfluent format: Confluent Schema Registry URL.", 0) \
     \
     M(SettingBool, output_format_json_quote_64bit_integers, true, "Controls quoting of 64-bit integers in JSON output format.", 0) \
     \

--- a/dbms/src/Core/SettingsCollection.cpp
+++ b/dbms/src/Core/SettingsCollection.cpp
@@ -396,6 +396,54 @@ void SettingEnum<EnumType, Tag>::set(const Field & x)
 }
 
 
+
+String SettingURI::toString() const
+{
+    return value.toString();
+}
+
+Field SettingURI::toField() const
+{
+    return value.toString();
+}
+
+void SettingURI::set(const Poco::URI & x)
+{
+    value = x;
+    changed = true;
+}
+
+void SettingURI::set(const Field & x)
+{
+    const String & s = safeGet<const String &>(x);
+    set(s);
+}
+
+void SettingURI::set(const String & x)
+{
+    try {
+        Poco::URI uri(x);
+        set(uri);
+    }
+    catch (const Poco::Exception& e)
+    {
+        throw Exception{Exception::CreateFromPoco, e};
+    }
+}
+
+void SettingURI::serialize(WriteBuffer & buf, SettingsBinaryFormat) const
+{
+    writeStringBinary(toString(), buf);
+}
+
+void SettingURI::deserialize(ReadBuffer & buf, SettingsBinaryFormat)
+{
+    String s;
+    readStringBinary(s, buf);
+    set(s);
+}
+
+
 #define IMPLEMENT_SETTING_ENUM(ENUM_NAME, LIST_OF_NAMES_MACRO, ERROR_CODE_FOR_UNEXPECTED_NAME) \
     IMPLEMENT_SETTING_ENUM_WITH_TAG(ENUM_NAME, void, LIST_OF_NAMES_MACRO, ERROR_CODE_FOR_UNEXPECTED_NAME)
 

--- a/dbms/src/Core/SettingsCollection.h
+++ b/dbms/src/Core/SettingsCollection.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Poco/Timespan.h>
+#include <Poco/URI.h>
 #include <DataStreams/SizeLimits.h>
 #include <Formats/FormatSettings.h>
 #include <common/StringRef.h>
@@ -196,6 +197,26 @@ struct SettingEnum
     void deserialize(ReadBuffer & buf, SettingsBinaryFormat format);
 };
 
+struct SettingURI
+{
+    Poco::URI value;
+    bool changed = false;
+
+    SettingURI(const Poco::URI & x = Poco::URI{}) : value(x) {}
+
+    operator Poco::URI() const { return value; }
+    SettingURI & operator= (const Poco::URI & x) { set(x); return *this; }
+
+    String toString() const;
+    Field toField() const;
+
+    void set(const Poco::URI & x);
+    void set(const Field & x);
+    void set(const String & x);
+
+    void serialize(WriteBuffer & buf, SettingsBinaryFormat format) const;
+    void deserialize(ReadBuffer & buf, SettingsBinaryFormat format);
+};
 
 enum class LoadBalancing
 {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Other


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add AvroConfluent format
...

Continuation of #8717

- fix AvroConfluent based on feedback
- validate URL against RemoteHostFilter
- add caches

todo:
add test
add docs