### PR TITLE
If server is run from terminal, highlight thread number, query id and log priority by colors.

### DIFF
--- a/libs/libloggers/loggers/Loggers.cpp
+++ b/libs/libloggers/loggers/Loggers.cpp
@@ -133,10 +133,13 @@ void Loggers::buildLoggers(Poco::Util::AbstractConfiguration & config, Poco::Log
         split->addChannel(log);
     }
 
+    bool is_tty = isatty(STDIN_FILENO) || isatty(STDERR_FILENO);
+
     if (config.getBool("logger.console", false)
-        || (!config.hasProperty("logger.console") && !is_daemon && (isatty(STDIN_FILENO) || isatty(STDERR_FILENO))))
+        || (!config.hasProperty("logger.console") && !is_daemon && is_tty))
     {
-        Poco::AutoPtr<DB::OwnFormattingChannel> log = new DB::OwnFormattingChannel(new OwnPatternFormatter(this), new Poco::ConsoleChannel);
+        Poco::AutoPtr<OwnPatternFormatter> pf = new OwnPatternFormatter(this, OwnPatternFormatter::ADD_NOTHING, is_tty);
+        Poco::AutoPtr<DB::OwnFormattingChannel> log = new DB::OwnFormattingChannel(pf, new Poco::ConsoleChannel);
         logger.warning("Logging " + log_level + " to console");
         split->addChannel(log);
     }

--- a/libs/libloggers/loggers/OwnPatternFormatter.cpp
+++ b/libs/libloggers/loggers/OwnPatternFormatter.cpp
@@ -55,7 +55,7 @@ static const char * setColorForLogPriority(int priority)
         "\033[0;31m",   /// Warning
         "\033[0;33m",   /// Notice
         "\033[1m",      /// Information
-        "\033[0;32m",   /// Debug
+        "",             /// Debug
         "\033[1;30m",   /// Trace
     };
 

--- a/libs/libloggers/loggers/OwnPatternFormatter.cpp
+++ b/libs/libloggers/loggers/OwnPatternFormatter.cpp
@@ -124,9 +124,10 @@ void OwnPatternFormatter::formatExtended(const DB::ExtendedLogMessage & msg_ext,
     writeCString("} ", wb);
 
     writeCString("<", wb);
+    int priority = static_cast<int>(msg.getPriority());
     if (color)
         writeCString(setColorForLogPriority(priority), wb);
-    DB::writeString(getPriorityName(static_cast<int>(msg.getPriority())), wb);
+    DB::writeString(getPriorityName(priority), wb);
     if (color)
         writeCString(resetColor(), wb);
     writeCString("> ", wb);

--- a/libs/libloggers/loggers/OwnPatternFormatter.cpp
+++ b/libs/libloggers/loggers/OwnPatternFormatter.cpp
@@ -47,7 +47,6 @@ static const char * setColorForLogPriority(int priority)
 
     static const char * colors[] =
     {
-        /// Black on black is meaningless and low intense blue on black is too dark.
         "",
         "\033[1;41m",   /// Fatal
         "\033[0;41m",   /// Critical

--- a/libs/libloggers/loggers/OwnPatternFormatter.h
+++ b/libs/libloggers/loggers/OwnPatternFormatter.h
@@ -31,7 +31,7 @@ public:
         ADD_LAYER_TAG = 1 << 0
     };
 
-    OwnPatternFormatter(const Loggers * loggers_, Options options_ = ADD_NOTHING);
+    OwnPatternFormatter(const Loggers * loggers_, Options options_ = ADD_NOTHING, bool color_ = false);
 
     void format(const Poco::Message & msg, std::string & text) override;
     void formatExtended(const DB::ExtendedLogMessage & msg_ext, std::string & text);
@@ -39,4 +39,5 @@ public:
 private:
     const Loggers * loggers;
     Options options;
+    bool color;
 };


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
If server is run from terminal, highlight thread number, query id and log priority by colors. This is for improved readability of correlated log messages for developers.