### PR TITLE
CRLF in TSV output format

### DIFF
--- a/dbms/src/Core/Settings.h
+++ b/dbms/src/Core/Settings.h
@@ -203,6 +203,7 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingUInt64, output_format_parquet_row_group_size, 1000000, "Row group size in rows.", 0) \
     M(SettingString, output_format_avro_codec, "", "Compression codec used for output. Possible values: 'null', 'deflate', 'snappy'.", 0) \
     M(SettingUInt64, output_format_avro_sync_interval, 16 * 1024, "Sync interval in bytes.", 0) \
+    M(SettingBool, output_format_tsv_crlf_end_of_line, false, "If it is set true, end of line in TSV format will be \\r\\n instead of \\n.", 0) \
     \
     M(SettingBool, use_client_time_zone, false, "Use client timezone for interpreting DateTime string values, instead of adopting server timezone.", 0) \
     \
@@ -338,7 +339,7 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingChar, format_csv_delimiter, ',', "The character to be considered as a delimiter in CSV data. If setting with a string, a string has to have a length of 1.", 0) \
     M(SettingBool, format_csv_allow_single_quotes, 1, "If it is set to true, allow strings in single quotes.", 0) \
     M(SettingBool, format_csv_allow_double_quotes, 1, "If it is set to true, allow strings in double quotes.", 0) \
-    M(SettingBool, output_format_csv_crlf_end_of_line, false, "If it is set true, end of line will be \\r\\n instead of \\n.", 0) \
+    M(SettingBool, output_format_csv_crlf_end_of_line, false, "If it is set true, end of line in CSV format will be \\r\\n instead of \\n.", 0) \
     M(SettingBool, input_format_csv_unquoted_null_literal_as_null, false, "Consider unquoted NULL literal as \\N", 0) \
     \
     M(SettingDateTimeInputFormat, date_time_input_format, FormatSettings::DateTimeInputFormat::Basic, "Method to read DateTime from text input formats. Possible values: 'basic' and 'best_effort'.", 0) \

--- a/dbms/src/Formats/FormatFactory.cpp
+++ b/dbms/src/Formats/FormatFactory.cpp
@@ -97,6 +97,7 @@ static FormatSettings getOutputFormatSetting(const Settings & settings, const Co
     format_settings.template_settings.resultset_format = settings.format_template_resultset;
     format_settings.template_settings.row_format = settings.format_template_row;
     format_settings.template_settings.row_between_delimiter = settings.format_template_rows_between_delimiter;
+    format_settings.tsv.crlf_end_of_line = settings.output_format_tsv_crlf_end_of_line;
     format_settings.write_statistics = settings.output_format_write_statistics;
     format_settings.parquet.row_group_size = settings.output_format_parquet_row_group_size;
     format_settings.schema.format_schema = settings.format_schema;

--- a/dbms/src/Formats/FormatSettings.h
+++ b/dbms/src/Formats/FormatSettings.h
@@ -64,6 +64,7 @@ struct FormatSettings
     struct TSV
     {
         bool empty_as_default = false;
+        bool crlf_end_of_line = false;
     };
 
     TSV tsv;

--- a/dbms/src/Processors/Formats/Impl/TabSeparatedRowOutputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/TabSeparatedRowOutputFormat.cpp
@@ -57,6 +57,8 @@ void TabSeparatedRowOutputFormat::writeFieldDelimiter()
 
 void TabSeparatedRowOutputFormat::writeRowEndDelimiter()
 {
+    if (format_settings.tsv.crlf_end_of_line)
+        writeChar('\r', out);
     writeChar('\n', out);
 }
 

--- a/dbms/tests/queries/0_stateless/01073_crlf_end_of_line.reference
+++ b/dbms/tests/queries/0_stateless/01073_crlf_end_of_line.reference
@@ -2,3 +2,7 @@
 2,"world"
 1,"hello"
 2,"world"
+1	hello
+2	world
+1	hello
+2	world

--- a/dbms/tests/queries/0_stateless/01073_crlf_end_of_line.sql
+++ b/dbms/tests/queries/0_stateless/01073_crlf_end_of_line.sql
@@ -1,0 +1,8 @@
+DROP TABLE IF EXISTS test_01073_crlf_end_of_line;
+CREATE TABLE test_01073_crlf_end_of_line (value UInt8, word String) ENGINE = MergeTree() ORDER BY value;
+INSERT INTO test_01073_crlf_end_of_line VALUES (1, 'hello'), (2, 'world');
+SELECT * FROM test_01073_crlf_end_of_line FORMAT CSV SETTINGS output_format_csv_crlf_end_of_line = 1;
+SELECT * FROM test_01073_crlf_end_of_line FORMAT CSV SETTINGS output_format_csv_crlf_end_of_line = 0;
+SELECT * FROM test_01073_crlf_end_of_line FORMAT TSV SETTINGS output_format_tsv_crlf_end_of_line = 1;
+SELECT * FROM test_01073_crlf_end_of_line FORMAT TSV SETTINGS output_format_tsv_crlf_end_of_line = 0;
+DROP TABLE IF EXISTS test_01073_crlf_end_of_line;

--- a/dbms/tests/queries/0_stateless/01073_crlf_in_output_csv_format.sql
+++ b/dbms/tests/queries/0_stateless/01073_crlf_in_output_csv_format.sql
@@ -1,8 +1,0 @@
-DROP TABLE IF EXISTS test_01073_crlf_in_output_csv_format;
-CREATE TABLE test_01073_crlf_in_output_csv_format (value UInt8, word String) ENGINE = MergeTree() ORDER BY value;
-INSERT INTO test_01073_crlf_in_output_csv_format VALUES (1, 'hello'), (2, 'world');
-SET output_format_csv_crlf_end_of_line = 1;
-SELECT * FROM test_01073_crlf_in_output_csv_format FORMAT CSV;
-SET output_format_csv_crlf_end_of_line = 0;
-SELECT * FROM test_01073_crlf_in_output_csv_format FORMAT CSV;
-DROP TABLE IF EXISTS test_01073_crlf_in_output_csv_format;

--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -797,6 +797,10 @@ For CSV input format enables or disables parsing of unquoted `NULL` as literal (
 
 Use DOS/Windows style line separator (CRLF) in CSV instead of Unix style (LF).
 
+## output_format_tsv_crlf_end_of_line {#settings-output_format_tsv_crlf_end_of_line}
+
+Use DOC/Windows style line separator (CRLF) in TSV instead of Unix style (LF).
+
 ## insert_quorum {#settings-insert_quorum}
 
 Enables quorum writes.

--- a/docs/ru/operations/settings/settings.md
+++ b/docs/ru/operations/settings/settings.md
@@ -780,6 +780,10 @@ load_balancing = first_or_random
 
 Использовать в качестве разделителя строк для CSV формата CRLF (DOS/Windows стиль) вместо LF (Unix стиль).
 
+## output_format_tsv_crlf_end_of_line {#settings-output_format_tsv_crlf_end_of_line}
+
+Использовать в качестве разделителя строк для TSV формата CRLF (DOC/Windows стиль) вместо LF (Unix стиль).
+
 ## insert_quorum {#settings-insert_quorum}
 
 Включает кворумную запись.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Created ability to use CRLF end of line in TSV output format with setting output_format_tsv_crlf_end_of_line=1
...


Detailed description / Documentation draft:
#8935
...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.