### PR TITLE
Force black background for all colors (for colored logging in terminal)

### DIFF
--- a/libs/libloggers/loggers/OwnPatternFormatter.cpp
+++ b/libs/libloggers/loggers/OwnPatternFormatter.cpp
@@ -20,21 +20,21 @@ static const char * setColor(UInt64 num)
     static const char * colors[num_colors] =
     {
         /// Black on black is meaningless
-        "\033[0;31m",
-        "\033[0;32m",
-        "\033[0;33m",
+        "\033[40m\033[0;31m",
+        "\033[40m\033[0;32m",
+        "\033[40m\033[0;33m",
         /// Low intense blue on black is too dark.
-        "\033[0;35m",
-        "\033[0;36m",
-        "\033[0;37m",
-        "\033[1;30m",
-        "\033[1;31m",
-        "\033[1;32m",
-        "\033[1;33m",
-        "\033[1;34m",
-        "\033[1;35m",
-        "\033[1;36m",
-        "\033[1m",  /// Not as white but just as high intense - for readability on white background.
+        "\033[40m\033[0;35m",
+        "\033[40m\033[0;36m",
+        "\033[40m\033[0;37m",
+        "\033[40m\033[1;30m",
+        "\033[40m\033[1;31m",
+        "\033[40m\033[1;32m",
+        "\033[40m\033[1;33m",
+        "\033[40m\033[1;34m",
+        "\033[40m\033[1;35m",
+        "\033[40m\033[1;36m",
+        "\033[40m\033[1m",  /// Not as white but just as high intense - for readability on white background.
     };
 
     return colors[num % num_colors];
@@ -48,14 +48,14 @@ static const char * setColorForLogPriority(int priority)
     static const char * colors[] =
     {
         "",
-        "\033[1;41m",   /// Fatal
-        "\033[0;41m",   /// Critical
-        "\033[1;31m",   /// Error
-        "\033[0;31m",   /// Warning
-        "\033[0;33m",   /// Notice
-        "\033[1m",      /// Information
+        "\033[40m\033[1;41m",   /// Fatal
+        "\033[40m\033[0;41m",   /// Critical
+        "\033[40m\033[1;31m",   /// Error
+        "\033[40m\033[0;31m",   /// Warning
+        "\033[40m\033[0;33m",   /// Notice
+        "\033[40m\033[1m",      /// Information
         "",             /// Debug
-        "\033[1;30m",   /// Trace
+        "\033[40m\033[1;30m",   /// Trace
     };
 
     return colors[priority];


### PR DESCRIPTION
This will fix the black color with solarized theme.

Suggested-by: @alexey-milovidov
Refs: https://github.com/ClickHouse/ClickHouse/pull/8961#discussion_r374249503
Follow-up: #8961

Changelog category (leave one):
- Non-significant (changelog entry is not required)
