### PR TITLE
Avoid extra copying when demangling names.

### DIFF
--- a/dbms/src/Functions/demange.cpp
+++ b/dbms/src/Functions/demange.cpp
@@ -73,9 +73,15 @@ public:
         for (size_t i = 0; i < input_rows_count; ++i)
         {
             StringRef source = column_concrete->getDataAt(i);
-            int status = 0;
-            std::string demangled = demangle(source.data, status);
-            result_column->insertDataWithTerminatingZero(demangled.data(), demangled.size() + 1);
+            auto demangled = try_demangle(source.data);
+            if (demangled.data)
+            {
+                result_column->insertDataWithTerminatingZero(demangled.data, demangled.size);
+            }
+            else
+            {
+                result_column->insertDataWithTerminatingZero(source.data, source.size);
+            }
         }
 
         block.getByPosition(result).column = std::move(result_column);

--- a/dbms/src/Functions/demange.cpp
+++ b/dbms/src/Functions/demange.cpp
@@ -74,9 +74,9 @@ public:
         {
             StringRef source = column_concrete->getDataAt(i);
             auto demangled = tryDemangle(source.data);
-            if (demangled.data)
+            if (demangled)
             {
-                result_column->insertDataWithTerminatingZero(demangled.data, demangled.size);
+                result_column->insertDataWithTerminatingZero(demangled.get(), strlen(demangled.get()));
             }
             else
             {

--- a/dbms/src/Functions/demange.cpp
+++ b/dbms/src/Functions/demange.cpp
@@ -73,7 +73,7 @@ public:
         for (size_t i = 0; i < input_rows_count; ++i)
         {
             StringRef source = column_concrete->getDataAt(i);
-            auto demangled = try_demangle(source.data);
+            auto demangled = tryDemangle(source.data);
             if (demangled.data)
             {
                 result_column->insertDataWithTerminatingZero(demangled.data, demangled.size);

--- a/libs/libcommon/include/common/demangle.h
+++ b/libs/libcommon/include/common/demangle.h
@@ -14,3 +14,28 @@ inline std::string demangle(const char * name)
     int status = 0;
     return demangle(name, status);
 }
+
+// abi::__cxa_demangle returns a C string of known size that should be deleted
+// with free().
+struct DemangleResult
+{
+    char * data = nullptr;
+    size_t size = 0;
+
+    DemangleResult() = default;
+    DemangleResult(DemangleResult &) = delete;
+    DemangleResult(DemangleResult && other)
+    {
+        std::swap(data, other.data);
+        std::swap(size, other.size);
+    }
+    ~DemangleResult()
+    {
+        if (data)
+        {
+            free(data);
+        }
+    }
+};
+
+DemangleResult try_demangle(const char * name);

--- a/libs/libcommon/include/common/demangle.h
+++ b/libs/libcommon/include/common/demangle.h
@@ -17,25 +17,15 @@ inline std::string demangle(const char * name)
 
 // abi::__cxa_demangle returns a C string of known size that should be deleted
 // with free().
-struct DemangleResult
+struct FreeingDeleter
 {
-    char * data = nullptr;
-    size_t size = 0;
-
-    DemangleResult() = default;
-    DemangleResult(DemangleResult &) = delete;
-    DemangleResult(DemangleResult && other)
+    template <typename PointerType>
+    void operator() (PointerType ptr)
     {
-        std::swap(data, other.data);
-        std::swap(size, other.size);
-    }
-    ~DemangleResult()
-    {
-        if (data)
-        {
-            free(data);
-        }
+        std::free(ptr);
     }
 };
+
+typedef std::unique_ptr<char, FreeingDeleter> DemangleResult;
 
 DemangleResult tryDemangle(const char * name);

--- a/libs/libcommon/include/common/demangle.h
+++ b/libs/libcommon/include/common/demangle.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 
 

--- a/libs/libcommon/include/common/demangle.h
+++ b/libs/libcommon/include/common/demangle.h
@@ -38,4 +38,4 @@ struct DemangleResult
     }
 };
 
-DemangleResult try_demangle(const char * name);
+DemangleResult tryDemangle(const char * name);

--- a/libs/libcommon/src/demangle.cpp
+++ b/libs/libcommon/src/demangle.cpp
@@ -10,6 +10,11 @@
 
 #if _MSC_VER || MEMORY_SANITIZER
 
+DemangleResult tryDemangle(const char * name)
+{
+    return DemangleResult{};
+}
+
 std::string demangle(const char * name, int & status)
 {
     status = 0;
@@ -21,22 +26,22 @@ std::string demangle(const char * name, int & status)
 #include <stdlib.h>
 #include <cxxabi.h>
 
-static DemangleResult try_demangle(const char * name, int & status)
+static DemangleResult tryDemangle(const char * name, int & status)
 {
     DemangleResult result;
     result.data = abi::__cxa_demangle(name, nullptr, &result.size, &status);
     return result;
 }
 
-DemangleResult try_demangle(const char * name)
+DemangleResult tryDemangle(const char * name)
 {
     int status = 0;
-    return try_demangle(name, status);
+    return tryDemangle(name, status);
 }
 
 std::string demangle(const char * name, int & status)
 {
-    auto result = try_demangle(name, status);
+    auto result = tryDemangle(name, status);
     if (result.data)
     {
         return std::string(result.data, result.size - 1);

--- a/libs/libcommon/src/demangle.cpp
+++ b/libs/libcommon/src/demangle.cpp
@@ -21,28 +21,29 @@ std::string demangle(const char * name, int & status)
 #include <stdlib.h>
 #include <cxxabi.h>
 
+static DemangleResult try_demangle(const char * name, int & status)
+{
+    DemangleResult result;
+    result.data = abi::__cxa_demangle(name, nullptr, &result.size, &status);
+    return result;
+}
+
+DemangleResult try_demangle(const char * name)
+{
+    int status = 0;
+    return try_demangle(name, status);
+}
+
 std::string demangle(const char * name, int & status)
 {
-    std::string res;
-
-    char * demangled_str = abi::__cxa_demangle(name, 0, 0, &status);
-    if (demangled_str)
+    auto result = try_demangle(name, status);
+    if (result.data)
     {
-        try
-        {
-            res = demangled_str;
-        }
-        catch (...)
-        {
-            free(demangled_str);
-            throw;
-        }
-        free(demangled_str);
+        return std::string(result.data, result.size - 1);
     }
-    else
-        res = name;
 
-    return res;
+    return name;
 }
+
 
 #endif

--- a/libs/libcommon/src/demangle.cpp
+++ b/libs/libcommon/src/demangle.cpp
@@ -28,9 +28,7 @@ std::string demangle(const char * name, int & status)
 
 static DemangleResult tryDemangle(const char * name, int & status)
 {
-    DemangleResult result;
-    result.data = abi::__cxa_demangle(name, nullptr, &result.size, &status);
-    return result;
+    return DemangleResult(abi::__cxa_demangle(name, nullptr, nullptr, &status));
 }
 
 DemangleResult tryDemangle(const char * name)
@@ -42,9 +40,9 @@ DemangleResult tryDemangle(const char * name)
 std::string demangle(const char * name, int & status)
 {
     auto result = tryDemangle(name, status);
-    if (result.data)
+    if (result)
     {
-        return std::string(result.data, result.size - 1);
+        return std::string(result.get());
     }
 
     return name;


### PR DESCRIPTION
Before this change, for each demangled string we converted it to std::string, allocating memory and calculating its size. In `demangle` SQL function, this is not needed because we can use the buffer and the size returned by `abi::__cxa_demangle`.

Changelog category (leave one):
- Non-significant (changelog entry is not required)
