### PR TITLE
Build fix: relocation R_X86_64_PC32 cannot be used

### DIFF
--- a/contrib/libunwind-cmake/CMakeLists.txt
+++ b/contrib/libunwind-cmake/CMakeLists.txt
@@ -30,6 +30,7 @@ set(LIBUNWIND_SOURCES
     ${LIBUNWIND_ASM_SOURCES})
 
 add_library(unwind ${LIBUNWIND_SOURCES})
+set_property(TARGET unwind PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 target_include_directories(unwind SYSTEM BEFORE PUBLIC $<BUILD_INTERFACE:${LIBUNWIND_SOURCE_DIR}/include>)
 target_compile_definitions(unwind PRIVATE -D_LIBUNWIND_NO_HEAP=1 -D_DEBUG -D_LIBUNWIND_IS_NATIVE_ONLY)


### PR DESCRIPTION
```
ld.lld: error: relocation R_X86_64_PC32 cannot be used against symbol stderr; recompile with -fPIC
>>> defined in /lib64/libc.so.6
>>> referenced by libunwind.cpp
>>>               libunwind.cpp.o:(libunwind::Registers_x86_64::getRegister(int) const (.part.0)) in archive contrib/libunwind-cmake/l
ibunwind.a
```

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes #9003

Detailed description / Documentation draft: