### PR TITLE
Fix regression caused by malloc symbols cleanup #7134

### DIFF
--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -566,7 +566,7 @@ if (USE_JEMALLOC)
 
     if(NOT MAKE_STATIC_LIBRARIES)
         target_link_libraries(clickhouse_common_io PRIVATE ${JEMALLOC_LIBRARIES})
-	    if (${JEMALLOC_LIBRARIES} MATCHES "${CMAKE_STATIC_LIBRARY_SUFFIX}$")
+        if (${JEMALLOC_LIBRARIES} MATCHES "${CMAKE_STATIC_LIBRARY_SUFFIX}$")
             # mallctl in dbms/src/Interpreters/AsynchronousMetrics.cpp
             # Actually we link JEMALLOC to almost all libraries.
             # This is just hotfix for some uninvestigated problem.

--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -564,7 +564,7 @@ if (USE_JEMALLOC)
     dbms_target_include_directories (SYSTEM BEFORE PRIVATE ${JEMALLOC_INCLUDE_DIR}) # used in Interpreters/AsynchronousMetrics.cpp
     target_include_directories (clickhouse_new_delete SYSTEM BEFORE PRIVATE ${JEMALLOC_INCLUDE_DIR})
 
-    if(NOT MAKE_STATIC_LIBRARIES)
+    if (NOT MAKE_STATIC_LIBRARIES)
         target_link_libraries(clickhouse_common_io PRIVATE ${JEMALLOC_LIBRARIES})
         if (${JEMALLOC_LIBRARIES} MATCHES "${CMAKE_STATIC_LIBRARY_SUFFIX}$")
             # mallctl in dbms/src/Interpreters/AsynchronousMetrics.cpp

--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -564,11 +564,14 @@ if (USE_JEMALLOC)
     dbms_target_include_directories (SYSTEM BEFORE PRIVATE ${JEMALLOC_INCLUDE_DIR}) # used in Interpreters/AsynchronousMetrics.cpp
     target_include_directories (clickhouse_new_delete SYSTEM BEFORE PRIVATE ${JEMALLOC_INCLUDE_DIR})
 
-    if(NOT MAKE_STATIC_LIBRARIES AND ${JEMALLOC_LIBRARIES} MATCHES "${CMAKE_STATIC_LIBRARY_SUFFIX}$")
-        # mallctl in dbms/src/Interpreters/AsynchronousMetrics.cpp
-        # Actually we link JEMALLOC to almost all libraries.
-        # This is just hotfix for some uninvestigated problem.
-        target_link_libraries(clickhouse_interpreters PRIVATE ${JEMALLOC_LIBRARIES})
+    if(NOT MAKE_STATIC_LIBRARIES)
+        target_link_libraries(clickhouse_common_io PRIVATE ${JEMALLOC_LIBRARIES})
+	    if (${JEMALLOC_LIBRARIES} MATCHES "${CMAKE_STATIC_LIBRARY_SUFFIX}$")
+            # mallctl in dbms/src/Interpreters/AsynchronousMetrics.cpp
+            # Actually we link JEMALLOC to almost all libraries.
+            # This is just hotfix for some uninvestigated problem.
+            target_link_libraries(clickhouse_interpreters PRIVATE ${JEMALLOC_LIBRARIES})
+        endif()
     endif()
 endif ()
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes #9005.


Detailed description / Documentation draft:

Commit dadc613072143eaea2b8f7e0a09965a9ff8358c0 causes libclickhouse.so
link failure (shared libraries, USE_JEMALLOC=1) for unbundled build:
```
ld.lld: error: undefined symbol: mallctl
>>> referenced by AsynchronousMetrics.cpp
>>>               AsynchronousMetrics.cpp.o:(DB::AsynchronousMetrics::update()) in archive dbms/libdbms.a
```