### PR TITLE
Disable query optimizations for ignore().

### DIFF
--- a/dbms/src/Functions/identity.cpp
+++ b/dbms/src/Functions/identity.cpp
@@ -33,6 +33,11 @@ public:
     {
         block.getByPosition(result).column = block.getByPosition(arguments.front()).column;
     }
+
+    // This funciton should never be optimized in any way when planning the
+    // query, so we mark it as having side effects.
+    bool isDeterministic() const override { return false; }
+    bool isDeterministicInScopeOfQuery() const override { return false; }
 };
 
 

--- a/dbms/src/Functions/ignore.cpp
+++ b/dbms/src/Functions/ignore.cpp
@@ -47,6 +47,11 @@ public:
     {
         return DataTypeUInt8().createColumnConst(1, 0u);
     }
+
+    // This funciton should never be optimized in any way when planning the
+    // query, so we mark it as having side effects.
+    bool isDeterministic() const override { return false; }
+    bool isDeterministicInScopeOfQuery() const override { return false; }
 };
 
 


### PR DESCRIPTION
Its main purpose is testing, so we should not try to fold it to a
constant or something like that. Mark it as non-deterministic.

Changelog category (leave one):
- Non-significant (changelog entry is not required)