### PR TITLE
Enable OpenSSL support in Curl

### DIFF
--- a/contrib/curl-cmake/CMakeLists.txt
+++ b/contrib/curl-cmake/CMakeLists.txt
@@ -146,3 +146,5 @@ target_compile_definitions(curl PRIVATE HAVE_CONFIG_H BUILDING_LIBCURL CURL_HIDD
 target_include_directories(curl PUBLIC ${CURL_DIR}/include ${CURL_DIR}/lib .)
 
 target_compile_definitions(curl PRIVATE OS="${CMAKE_SYSTEM_NAME}")
+
+target_link_libraries(curl PRIVATE ssl)

--- a/contrib/curl-cmake/curl_config.h
+++ b/contrib/curl-cmake/curl_config.h
@@ -1,3 +1,4 @@
+#define CURL_CA_BUNDLE "/etc/ssl/certs/ca-certificates.crt"
 #define CURL_DISABLE_FTP
 #define CURL_DISABLE_TFTP
 #define CURL_DISABLE_LDAP

--- a/contrib/curl-cmake/curl_config.h
+++ b/contrib/curl-cmake/curl_config.h
@@ -9,9 +9,14 @@
 #define SIZEOF_CURL_OFF_T 8
 #define SIZEOF_SIZE_T 8
 
+#define HAVE_ALARM
 #define HAVE_FCNTL_O_NONBLOCK
+#define HAVE_GETADDRINFO
 #define HAVE_LONGLONG
 #define HAVE_POLL_FINE
+#define HAVE_SIGACTION
+#define HAVE_SIGNAL
+#define HAVE_SIGSETJMP
 #define HAVE_SOCKET
 #define HAVE_STRUCT_TIMEVAL
 
@@ -35,7 +40,10 @@
 #define HAVE_FCNTL_H
 #define HAVE_NETDB_H
 #define HAVE_NETINET_IN_H
+#define HAVE_SETJMP_H
 #define HAVE_SYS_STAT_H
 #define HAVE_UNISTD_H
 
+#define ENABLE_IPV6
 #define USE_OPENSSL
+#define USE_THREADS_POSIX

--- a/contrib/curl-cmake/curl_config.h
+++ b/contrib/curl-cmake/curl_config.h
@@ -34,5 +34,8 @@
 #define HAVE_ERRNO_H
 #define HAVE_FCNTL_H
 #define HAVE_NETDB_H
+#define HAVE_NETINET_IN_H
 #define HAVE_SYS_STAT_H
 #define HAVE_UNISTD_H
+
+#define USE_OPENSSL


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Repair curl+ssl for S3 connections