### PR TITLE
Use correct implementation for reinterpretAsFixedString

### DIFF
--- a/dbms/src/Functions/FunctionsReinterpret.h
+++ b/dbms/src/Functions/FunctionsReinterpret.h
@@ -261,7 +261,7 @@ using FunctionReinterpretAsDate = FunctionReinterpretStringAs<DataTypeDate,     
 using FunctionReinterpretAsDateTime = FunctionReinterpretStringAs<DataTypeDateTime, NameReinterpretAsDateTime>;
 
 using FunctionReinterpretAsString = FunctionReinterpretAsStringImpl<NameReinterpretAsString>;
-using FunctionReinterpretAsFixedString = FunctionReinterpretAsStringImpl<NameReinterpretAsFixedString>;
+using FunctionReinterpretAsFixedString = FunctionReinterpretAsFixedStringImpl<NameReinterpretAsFixedString>;
 
 
 }

--- a/dbms/tests/queries/0_stateless/01079_reinterpret_as_fixed_string.reference
+++ b/dbms/tests/queries/0_stateless/01079_reinterpret_as_fixed_string.reference
@@ -1,0 +1,1 @@
+FixedString(4)

--- a/dbms/tests/queries/0_stateless/01079_reinterpret_as_fixed_string.sql
+++ b/dbms/tests/queries/0_stateless/01079_reinterpret_as_fixed_string.sql
@@ -1,0 +1,1 @@
+select toTypeName(reinterpretAsFixedString(0xdeadbeef));


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix `reinterpretAsFixedString` to return `FixedString` instead of `String`. 