### PR TITLE
add option to force deduplicate children

### DIFF
--- a/dbms/src/Core/Settings.h
+++ b/dbms/src/Core/Settings.h
@@ -395,6 +395,7 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingBool, enable_early_constant_folding, true, "Enable query optimization where we analyze function and subqueries results and rewrite query if there're constants there", 0) \
     \
     M(SettingBool, partial_revokes, false, "Makes it possible to revoke privileges partially.", 0) \
+    M(SettingBool, force_deduplicate_childrens, false, "If the 'root' table deduplicates blocks, there are no need to make deduplication for children. Use true to always deduplicate childrens.", 0) \
     \
     /** Obsolete settings that do nothing but left for compatibility reasons. Remove each one after half a year of obsolescence. */ \
     \

--- a/dbms/src/Core/Settings.h
+++ b/dbms/src/Core/Settings.h
@@ -395,7 +395,7 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingBool, enable_early_constant_folding, true, "Enable query optimization where we analyze function and subqueries results and rewrite query if there're constants there", 0) \
     \
     M(SettingBool, partial_revokes, false, "Makes it possible to revoke privileges partially.", 0) \
-    M(SettingBool, force_deduplicate_childrens, false, "If the 'root' table deduplicates blocks, there are no need to make deduplication for children. Use true to always deduplicate childrens.", 0) \
+    M(SettingBool, deduplicate_blocks_in_dependent_materialized_views, false, "Should deduplicate blocks for materialized views if the block is not a duplicate for the table. Use true to always deduplicate in dependent tables.", 0) \
     \
     /** Obsolete settings that do nothing but left for compatibility reasons. Remove each one after half a year of obsolescence. */ \
     \

--- a/dbms/src/DataStreams/PushingToViewsBlockOutputStream.cpp
+++ b/dbms/src/DataStreams/PushingToViewsBlockOutputStream.cpp
@@ -29,7 +29,9 @@ PushingToViewsBlockOutputStream::PushingToViewsBlockOutputStream(
 
     /// If the "root" table deduplactes blocks, there are no need to make deduplication for children
     /// Moreover, deduplication for AggregatingMergeTree children could produce false positives due to low size of inserting blocks
-    bool disable_deduplication_for_children = !no_destination && storage->supportsDeduplication();
+    bool disable_deduplication_for_children = false;
+    if (!context.getSettingsRef().force_deduplicate_childrens)
+        disable_deduplication_for_children = !no_destination && storage->supportsDeduplication();
 
     auto table_id = storage->getStorageID();
     Dependencies dependencies = context.getDependencies(table_id);
@@ -130,7 +132,7 @@ void PushingToViewsBlockOutputStream::write(const Block & block)
     }
 
     /// Don't process materialized views if this block is duplicate
-    if (replicated_output && replicated_output->lastBlockIsDuplicate())
+    if (!context.getSettingsRef().force_deduplicate_childrens && replicated_output && replicated_output->lastBlockIsDuplicate())
         return;
 
     // Insert data into materialized views only after successful insert into main table

--- a/dbms/src/DataStreams/PushingToViewsBlockOutputStream.cpp
+++ b/dbms/src/DataStreams/PushingToViewsBlockOutputStream.cpp
@@ -30,7 +30,7 @@ PushingToViewsBlockOutputStream::PushingToViewsBlockOutputStream(
     /// If the "root" table deduplactes blocks, there are no need to make deduplication for children
     /// Moreover, deduplication for AggregatingMergeTree children could produce false positives due to low size of inserting blocks
     bool disable_deduplication_for_children = false;
-    if (!context.getSettingsRef().force_deduplicate_childrens)
+    if (!context.getSettingsRef().deduplicate_blocks_in_dependent_materialized_views)
         disable_deduplication_for_children = !no_destination && storage->supportsDeduplication();
 
     auto table_id = storage->getStorageID();
@@ -132,7 +132,7 @@ void PushingToViewsBlockOutputStream::write(const Block & block)
     }
 
     /// Don't process materialized views if this block is duplicate
-    if (!context.getSettingsRef().force_deduplicate_childrens && replicated_output && replicated_output->lastBlockIsDuplicate())
+    if (!context.getSettingsRef().deduplicate_blocks_in_dependent_materialized_views && replicated_output && replicated_output->lastBlockIsDuplicate())
         return;
 
     // Insert data into materialized views only after successful insert into main table

--- a/dbms/tests/integration/test_force_deduplication/test.py
+++ b/dbms/tests/integration/test_force_deduplication/test.py
@@ -36,7 +36,7 @@ def test_basic(start_cluster):
 
     node.query(
         '''
-        SET force_deduplicate_childrens=1;
+        SET deduplicate_blocks_in_dependent_materialized_views = 1;
         INSERT INTO test SELECT number FROM numbers(10);
         '''
     )

--- a/dbms/tests/integration/test_force_deduplication/test.py
+++ b/dbms/tests/integration/test_force_deduplication/test.py
@@ -1,0 +1,44 @@
+# pylint: disable=unused-argument
+# pylint: disable=redefined-outer-name
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.client import QueryRuntimeException
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance('node', with_zookeeper=True)
+
+@pytest.fixture(scope='module')
+def start_cluster():
+    try:
+        cluster.start()
+
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+def test_basic(start_cluster):
+    with pytest.raises(QueryRuntimeException):
+        node.query(
+            '''
+            CREATE TABLE test (A Int64) ENGINE = ReplicatedMergeTree ('/clickhouse/test/tables/test','1') ORDER BY tuple();
+            CREATE MATERIALIZED VIEW test_mv Engine=ReplicatedMergeTree ('/clickhouse/test/tables/test_mv','1') partition by A order by tuple() AS SELECT A FROM test;
+            SET max_partitions_per_insert_block = 3;
+            INSERT INTO test SELECT number FROM numbers(10);
+            '''
+        )
+
+    node.query("INSERT INTO test SELECT number FROM numbers(10)")
+    assert int(node.query("SELECT count() FROM test")) == 10
+    assert int(node.query("SELECT count() FROM test_mv")) == 0
+
+    node.query(
+        '''
+        SET force_deduplicate_childrens=1;
+        INSERT INTO test SELECT number FROM numbers(10);
+        '''
+    )
+    assert int(node.query("SELECT count() FROM test")) == 10
+    assert int(node.query("SELECT count() FROM test_mv")) == 10


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

reduce dataloss chance on insert into table with mv.

Detailed description / Documentation draft:

if you insert data into replicated table with mv, there is a chance, that ZooKeeper exception can cause data inserted into table only, since if CH do not try to insert into mv if block already deduplicated by main table. Usually this works well, but if ZooKeeper error occures after insert into main table, this block will never reach MV. If u set `force_deduplicate_childrens=1`, then CH will try to insert block into MV even if it deduplicated by parent table.

partial fix for #2621
