### PR TITLE
Show Queries more like MySQL did

### DIFF
--- a/dbms/src/Interpreters/InterpreterShowTablesQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterShowTablesQuery.cpp
@@ -60,7 +60,7 @@ String InterpreterShowTablesQuery::getRewrittenQuery()
     if (!query.like.empty())
         rewritten_query << " AND name " << (query.not_like ? "NOT " : "") << "LIKE " << std::quoted(query.like, '\'');
     else if (query.where_expression)
-        rewritten_query << " AND ( " << query.where_expression << " )";
+        rewritten_query << " AND (" << query.where_expression << ")";
 
     if (query.limit_length)
         rewritten_query << " LIMIT " << query.limit_length;

--- a/dbms/src/Interpreters/InterpreterShowTablesQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterShowTablesQuery.cpp
@@ -59,6 +59,8 @@ String InterpreterShowTablesQuery::getRewrittenQuery()
 
     if (!query.like.empty())
         rewritten_query << " AND name " << (query.not_like ? "NOT " : "") << "LIKE " << std::quoted(query.like, '\'');
+    else if (query.where_expression)
+        rewritten_query << " AND ( " << query.where_expression << " )";
 
     if (query.limit_length)
         rewritten_query << " LIMIT " << query.limit_length;

--- a/dbms/src/Parsers/ASTShowTablesQuery.cpp
+++ b/dbms/src/Parsers/ASTShowTablesQuery.cpp
@@ -32,6 +32,11 @@ void ASTShowTablesQuery::formatQueryImpl(const FormatSettings & settings, Format
         if (!like.empty())
             settings.ostr << (settings.hilite ? hilite_keyword : "") << (not_like ? " NOT" : "") << " LIKE " << (settings.hilite ? hilite_none : "")
                 << std::quoted(like, '\'');
+        else if (where_expression)
+        {
+            settings.ostr << (settings.hilite ? hilite_keyword : "") << " WHERE " << (settings.hilite ? hilite_none : "");
+            where_expression->formatImpl(settings, state, frame);
+        }
 
         if (limit_length)
         {

--- a/dbms/src/Parsers/ASTShowTablesQuery.h
+++ b/dbms/src/Parsers/ASTShowTablesQuery.h
@@ -20,6 +20,7 @@ public:
     String from;
     String like;
     bool not_like{false};
+    ASTPtr where_expression;
     ASTPtr limit_length;
 
     /** Get the text that identifies this element. */

--- a/dbms/src/Parsers/ParserShowTablesQuery.cpp
+++ b/dbms/src/Parsers/ParserShowTablesQuery.cpp
@@ -22,12 +22,14 @@ bool ParserShowTablesQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     ParserKeyword s_databases("DATABASES");
     ParserKeyword s_dictionaries("DICTIONARIES");
     ParserKeyword s_from("FROM");
+    ParserKeyword s_in("IN");
     ParserKeyword s_not("NOT");
     ParserKeyword s_like("LIKE");
+    ParserKeyword s_where("WHERE");
     ParserKeyword s_limit("LIMIT");
     ParserStringLiteral like_p;
     ParserIdentifier name_p;
-    ParserExpressionWithOptionalAlias limit_p(false);
+    ParserExpressionWithOptionalAlias exp_elem(false);
 
     ASTPtr like;
     ASTPtr database;
@@ -54,7 +56,7 @@ bool ParserShowTablesQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
                 return false;
         }
 
-        if (s_from.ignore(pos, expected))
+        if (s_from.ignore(pos, expected) || s_in.ignore(pos, expected))
         {
             if (!name_p.parse(pos, database, expected))
                 return false;
@@ -70,10 +72,15 @@ bool ParserShowTablesQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
         }
         else if (query->not_like)
             return false;
+        else if (s_where.ignore(pos, expected))
+        {
+            if (!exp_elem.parse(pos, query->where_expression, expected))
+                return false;
+        }
 
         if (s_limit.ignore(pos, expected))
         {
-            if (!limit_p.parse(pos, query->limit_length, expected))
+            if (!exp_elem.parse(pos, query->limit_length, expected))
                 return false;
         }
     }

--- a/dbms/tests/queries/0_stateless/00080_show_tables_and_system_tables.reference
+++ b/dbms/tests/queries/0_stateless/00080_show_tables_and_system_tables.reference
@@ -1,5 +1,6 @@
 A
 B
+A
 A	1	TinyLog	CREATE TABLE test_show_tables.A (`A` UInt8) ENGINE = TinyLog
 B	1	TinyLog	CREATE TABLE test_show_tables.B (`A` UInt8) ENGINE = TinyLog
 test_temporary_table

--- a/dbms/tests/queries/0_stateless/00080_show_tables_and_system_tables.reference
+++ b/dbms/tests/queries/0_stateless/00080_show_tables_and_system_tables.reference
@@ -1,6 +1,7 @@
 A
 B
-A
+numbers
+one
 A	1	TinyLog	CREATE TABLE test_show_tables.A (`A` UInt8) ENGINE = TinyLog
 B	1	TinyLog	CREATE TABLE test_show_tables.B (`A` UInt8) ENGINE = TinyLog
 test_temporary_table

--- a/dbms/tests/queries/0_stateless/00080_show_tables_and_system_tables.sql
+++ b/dbms/tests/queries/0_stateless/00080_show_tables_and_system_tables.sql
@@ -6,7 +6,7 @@ CREATE TABLE test_show_tables.A (A UInt8) ENGINE = TinyLog;
 CREATE TABLE test_show_tables.B (A UInt8) ENGINE = TinyLog;
 
 SHOW TABLES from test_show_tables;
-SHOW TABLES in test_show_tables where name = 'A';
+SHOW TABLES in system where engine like '%System%' and name in ('numbers', 'one');
 
 SELECT name, toUInt32(metadata_modification_time) > 0, engine_full, create_table_query FROM system.tables WHERE database = 'test_show_tables' ORDER BY name FORMAT TSVRaw;
 

--- a/dbms/tests/queries/0_stateless/00080_show_tables_and_system_tables.sql
+++ b/dbms/tests/queries/0_stateless/00080_show_tables_and_system_tables.sql
@@ -6,6 +6,7 @@ CREATE TABLE test_show_tables.A (A UInt8) ENGINE = TinyLog;
 CREATE TABLE test_show_tables.B (A UInt8) ENGINE = TinyLog;
 
 SHOW TABLES from test_show_tables;
+SHOW TABLES in test_show_tables where name = 'A';
 
 SELECT name, toUInt32(metadata_modification_time) > 0, engine_full, create_table_query FROM system.tables WHERE database = 'test_show_tables' ORDER BY name FORMAT TSVRaw;
 

--- a/docs/en/query_language/show.md
+++ b/docs/en/query_language/show.md
@@ -38,7 +38,7 @@ $ watch -n1 "clickhouse-client --query='SHOW PROCESSLIST'"
 Displays a list of tables.
 
 ```sql
-SHOW [TEMPORARY] TABLES [FROM <db>] [LIKE '<pattern>'] [LIMIT <N>] [INTO OUTFILE <filename>] [FORMAT <format>]
+SHOW [TEMPORARY] TABLES [{FROM | IN} <db>] [LIKE '<pattern>' | WHERE expr] [LIMIT <N>] [INTO OUTFILE <filename>] [FORMAT <format>]
 ```
 
 If the `FROM` clause is not specified, the query returns the list of tables from the current database.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Make show tables/database queries support the `where expressions`  and `{FROM | IN }`

Detailed description / Documentation draft:

Make show tables/database queries support the `where expressions`  and `{FROM | IN }` as [mysql doc](https://dev.mysql.com/doc/refman/8.0/en/show-tables.html)