### PR TITLE
Send string columns to mysql client as utf8

### DIFF
--- a/dbms/src/Core/MySQLProtocol.cpp
+++ b/dbms/src/Core/MySQLProtocol.cpp
@@ -103,6 +103,7 @@ size_t getLengthEncodedStringSize(const String & s)
 ColumnDefinition getColumnDefinition(const String & column_name, const TypeIndex type_index)
 {
     ColumnType column_type;
+    CharacterSet charset = CharacterSet::binary;
     int flags = 0;
     switch (type_index)
     {
@@ -157,12 +158,14 @@ ColumnDefinition getColumnDefinition(const String & column_name, const TypeIndex
         case TypeIndex::String:
         case TypeIndex::FixedString:
             column_type = ColumnType::MYSQL_TYPE_STRING;
+            charset = CharacterSet::utf8_general_ci;
             break;
         default:
             column_type = ColumnType::MYSQL_TYPE_STRING;
+            charset = CharacterSet::utf8_general_ci;
             break;
     }
-    return ColumnDefinition(column_name, CharacterSet::binary, 0, column_type, flags, 0);
+    return ColumnDefinition(column_name, charset, 0, column_type, flags, 0);
 }
 
 }

--- a/dbms/tests/integration/test_mysql_protocol/clients/golang/0.reference
+++ b/dbms/tests/integration/test_mysql_protocol/clients/golang/0.reference
@@ -9,7 +9,7 @@ Columns:
 name
 a
 Column types:
-name BINARY
+name CHAR
 a TINYINT
 Result:
 tables 1
@@ -17,7 +17,7 @@ Columns:
 a
 b
 Column types:
-a BINARY
+a CHAR
 b TINYINT
 Result:
 тест 1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
After recent changes mysql client started to print binary strings in hex thereby making them not readable (#9032). The workaround in ClickHouse is to mark string columns as utf8, which is not always, but usually the case.
