### PR TITLE
Enable terminal colors for log by default.

### DIFF
--- a/libs/libloggers/loggers/Loggers.cpp
+++ b/libs/libloggers/loggers/Loggers.cpp
@@ -138,7 +138,7 @@ void Loggers::buildLoggers(Poco::Util::AbstractConfiguration & config, Poco::Log
     if (config.getBool("logger.console", false)
         || (!config.hasProperty("logger.console") && !is_daemon && is_tty))
     {
-        bool color_enabled = config.getBool("logger.colored_console", false) && is_tty;
+        bool color_enabled = config.getBool("logger.color_terminal", true) && is_tty;
 
         Poco::AutoPtr<OwnPatternFormatter> pf = new OwnPatternFormatter(this, OwnPatternFormatter::ADD_NOTHING, color_enabled);
         Poco::AutoPtr<DB::OwnFormattingChannel> log = new DB::OwnFormattingChannel(pf, new Poco::ConsoleChannel);


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Already covered by previous changelog entry.

Detailed description / Documentation draft:
Thanks to the changes made by @Akazz, now the colors are safe to use by default.