### PR TITLE
Drop unused ALL_ADDRESSES const (fixes poco 1.7.6+dfsg1-5+deb9u1)

### DIFF
--- a/dbms/src/Access/AllowedClientHosts.cpp
+++ b/dbms/src/Access/AllowedClientHosts.cpp
@@ -22,7 +22,6 @@ namespace
 {
     using IPAddress = Poco::Net::IPAddress;
     using IPSubnet = AllowedClientHosts::IPSubnet;
-    const IPSubnet ALL_ADDRESSES{IPAddress{IPAddress::IPv6}, IPAddress{IPAddress::IPv6}};
 
     /// Converts an address to IPv6.
     /// The loopback address "127.0.0.1" (or any "127.x.y.z") is converted to "::1".


### PR DESCRIPTION
Changelog category (leave one):
- Non-significant (changelog entry is not required)

With `poco 1.7.6+dfsg1-5+deb9u1`:

```
  5  0x00007f9921e48085 in __cxa_throw ()
  6  0x00007f9918dfca88 in Poco::Net::IPAddress::IPAddress(void const*, unsigned int, unsigned int) () from /usr/lib/libPocoNet.so.46
  7  0x00007f9918dfcf91 in Poco::Net::IPAddress::operator&(Poco::Net::IPAddress const&) const () from /usr/lib/libPocoNet.so.46
  8  0x00007f991737a623 in DB::AllowedClientHosts::IPSubnet::set (this=0x7f991742afa0 <DB::(anonymous namespace)::ALL_ADDRESSES>, prefix_=..., mask_=...) at AllowedClientHosts.h:146
  9  0x00007f991737a2da in DB::AllowedClientHosts::IPSubnet::IPSubnet (this=0x7f991742afa0 <DB::(anonymous namespace)::ALL_ADDRESSES>, prefix_=..., mask_=...) at AllowedClientHosts.h:24
  10 0x00007f991737a0a2 in __static_initialization_and_destruction_0 (__initialize_p=1, __priority=65535) at AllowedClientHosts.cpp:25
```

Fixes: 2e4174a54cd