### PR TITLE
wrong tag zookeeper-servers instead of zookeeper in  tutorial.md

### DIFF
--- a/docs/en/getting_started/tutorial.md
+++ b/docs/en/getting_started/tutorial.md
@@ -602,7 +602,7 @@ ZooKeeper is not a strict requirement: in some simple cases you can duplicate th
 
 ZooKeeper locations need to be specified in configuration file:
 ``` xml
-<zookeeper-servers>
+<zookeeper>
     <node>
         <host>zoo01.yandex.ru</host>
         <port>2181</port>
@@ -615,7 +615,7 @@ ZooKeeper locations need to be specified in configuration file:
         <host>zoo03.yandex.ru</host>
         <port>2181</port>
     </node>
-</zookeeper-servers>
+</zookeeper>
 ```
 
 Also we need to set macros for identifying each shard and replica, it will be used on table creation:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)

Seems previous fix (#7912) lost during html -> md move