### PR TITLE
[RFC] Set O_CLOEXEC

### DIFF
--- a/dbms/src/Common/CounterInFile.h
+++ b/dbms/src/Common/CounterInFile.h
@@ -65,7 +65,7 @@ public:
             "You must create it manulally with appropriate value or 0 for first start.");
         }
 
-        int fd = ::open(path.c_str(), O_RDWR | O_CREAT, 0666);
+        int fd = ::open(path.c_str(), O_RDWR | O_CREAT | O_CLOEXEC, 0666);
         if (-1 == fd)
             DB::throwFromErrnoWithPath("Cannot open file " + path, path, DB::ErrorCodes::CANNOT_OPEN_FILE);
 
@@ -139,7 +139,7 @@ public:
     {
         bool file_exists = Poco::File(path).exists();
 
-        int fd = ::open(path.c_str(), O_RDWR | O_CREAT, 0666);
+        int fd = ::open(path.c_str(), O_RDWR | O_CREAT | O_CLOEXEC, 0666);
         if (-1 == fd)
             DB::throwFromErrnoWithPath("Cannot open file " + path, path, DB::ErrorCodes::CANNOT_OPEN_FILE);
 

--- a/dbms/src/Common/StatusFile.cpp
+++ b/dbms/src/Common/StatusFile.cpp
@@ -48,7 +48,7 @@ StatusFile::StatusFile(const std::string & path_)
             LOG_INFO(&Logger::get("StatusFile"), "Status file " << path << " already exists and is empty - probably unclean hardware restart.");
     }
 
-    fd = ::open(path.c_str(), O_WRONLY | O_CREAT, 0666);
+    fd = ::open(path.c_str(), O_WRONLY | O_CREAT | O_CLOEXEC, 0666);
 
     if (-1 == fd)
         throwFromErrnoWithPath("Cannot open file " + path, path, ErrorCodes::CANNOT_OPEN_FILE);

--- a/dbms/src/IO/MMapReadBufferFromFile.cpp
+++ b/dbms/src/IO/MMapReadBufferFromFile.cpp
@@ -26,7 +26,7 @@ void MMapReadBufferFromFile::open()
 {
     ProfileEvents::increment(ProfileEvents::FileOpen);
 
-    fd = ::open(file_name.c_str(), O_RDONLY);
+    fd = ::open(file_name.c_str(), O_RDONLY | O_CLOEXEC);
 
     if (-1 == fd)
         throwFromErrnoWithPath("Cannot open file " + file_name, file_name,

--- a/dbms/src/IO/ReadBufferAIO.cpp
+++ b/dbms/src/IO/ReadBufferAIO.cpp
@@ -49,6 +49,7 @@ ReadBufferAIO::ReadBufferAIO(const std::string & filename_, size_t buffer_size_,
 
     int open_flags = (flags_ == -1) ? O_RDONLY : flags_;
     open_flags |= O_DIRECT;
+    open_flags |= O_CLOEXEC;
 
     fd = ::open(filename.c_str(), open_flags);
     if (fd == -1)

--- a/dbms/src/IO/ReadBufferFromFile.cpp
+++ b/dbms/src/IO/ReadBufferFromFile.cpp
@@ -38,7 +38,7 @@ ReadBufferFromFile::ReadBufferFromFile(
     if (o_direct)
         flags = flags & ~O_DIRECT;
 #endif
-    fd = ::open(file_name.c_str(), flags == -1 ? O_RDONLY : flags);
+    fd = ::open(file_name.c_str(), flags == -1 ? O_RDONLY | O_CLOEXEC : flags | O_CLOEXEC);
 
     if (-1 == fd)
         throwFromErrnoWithPath("Cannot open file " + file_name, file_name,

--- a/dbms/src/IO/WriteBufferAIO.cpp
+++ b/dbms/src/IO/WriteBufferAIO.cpp
@@ -58,6 +58,7 @@ WriteBufferAIO::WriteBufferAIO(const std::string & filename_, size_t buffer_size
 
     int open_flags = (flags_ == -1) ? (O_RDWR | O_TRUNC | O_CREAT) : flags_;
     open_flags |= O_DIRECT;
+    open_flags |= O_CLOEXEC;
 
     fd = ::open(filename.c_str(), open_flags, mode_);
     if (fd == -1)

--- a/dbms/src/IO/WriteBufferFromFile.cpp
+++ b/dbms/src/IO/WriteBufferFromFile.cpp
@@ -41,7 +41,7 @@ WriteBufferFromFile::WriteBufferFromFile(
         flags = flags & ~O_DIRECT;
 #endif
 
-    fd = ::open(file_name.c_str(), flags == -1 ? O_WRONLY | O_TRUNC | O_CREAT : flags, mode);
+    fd = ::open(file_name.c_str(), flags == -1 ? O_WRONLY | O_TRUNC | O_CREAT | O_CLOEXEC : flags | O_CLOEXEC, mode);
 
     if (-1 == fd)
         throwFromErrnoWithPath("Cannot open file " + file_name, file_name,


### PR DESCRIPTION
Changelog category (leave one):
- Non-significant (changelog entry is not required)

Since clickhouse allows to execute user-specified command (i.e.
for dictionary loading), it is better not to expose them.

But there is something left for now:
```
- 10 -> socket:[14422712]
- 11 -> socket:[14422714]
- 12 -> anon_inode:[eventpoll]
- 13 -> anon_inode:[eventpoll]
- 14 -> anon_inode:[eventpoll]
- 15 -> socket:[14426310]
- 16 -> anon_inode:[eventpoll]
- 3 -> /proc/2739071/fd
- 6 -> socket:[14422708]
- 9 -> socket:[14422710]
```

And most of these (`eventpoll`) went from `poco`, for which `O_CLOEXEC` **cannot
be passed**.