### PR TITLE
lock storage policy when moving parts

### DIFF
--- a/dbms/src/Disks/DiskSpaceMonitor.h
+++ b/dbms/src/Disks/DiskSpaceMonitor.h
@@ -157,6 +157,9 @@ public:
         return getVolume(it->second);
     }
 
+    /// Mutex for background moves of this policy
+    mutable std::mutex moving_parts_mutex;
+
 private:
     Volumes volumes;
     const String name;

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3784,6 +3784,9 @@ bool MergeTreeData::selectPartsAndMove()
 {
     if (parts_mover.moves_blocker.isCancelled())
         return false;
+    std::unique_lock<std::mutex> lock(storage_policy->moving_parts_mutex, std::try_to_lock);
+    if (!lock.owns_lock())
+        return false;
 
     auto moving_tagger = selectPartsForMove();
     if (moving_tagger.parts_to_move.empty())


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Lock storage policy when moving parts in order to move parts as less as possible per policy. Fix #8524.

