### PR TITLE
add documentation for system.metric_log table

### DIFF
--- a/docs/en/operations/system_tables.md
+++ b/docs/en/operations/system_tables.md
@@ -285,7 +285,7 @@ SELECT * FROM system.metrics LIMIT 10
 
 ## system.metric_log {#system_tables-metric_log}
 
-Contains history of metrics values from tables `system.metrics` и `system.events`, periodically flush to disc with MegreTree() table engine
+Contains history of metrics values from tables `system.metrics` and `system.events`, periodically flushed to disk.
 For turn on metrics history collection on `system.metric_log`, create `/etc/clickhouse-server/config.d/metric_log.xml` with following content:
 ```xml
 <yandex>

--- a/docs/en/operations/system_tables.md
+++ b/docs/en/operations/system_tables.md
@@ -286,7 +286,7 @@ SELECT * FROM system.metrics LIMIT 10
 ## system.metric_log {#system_tables-metric_log}
 
 Contains history of metrics values from tables `system.metrics` and `system.events`, periodically flushed to disk.
-For turn on metrics history collection on `system.metric_log`, create `/etc/clickhouse-server/config.d/metric_log.xml` with following content:
+To turn on metrics history collection on `system.metric_log`, create `/etc/clickhouse-server/config.d/metric_log.xml` with following content:
 ```xml
 <yandex>
     <metric_log>

--- a/docs/en/operations/system_tables.md
+++ b/docs/en/operations/system_tables.md
@@ -41,6 +41,7 @@ SELECT * FROM system.asynchronous_metrics LIMIT 10
 - [Monitoring](monitoring.md) — Base concepts of ClickHouse monitoring.
 - [system.metrics](#system_tables-metrics) — Contains instantly calculated metrics.
 - [system.events](#system_tables-events) — Contains a number of events that have occurred.
+- [system.metric_log](#system_tables-metric_log) — Contains a history of metrics values from tables `system.metrics` и `system.events`.
 
 ## system.clusters
 
@@ -193,6 +194,7 @@ SELECT * FROM system.events LIMIT 5
 
 - [system.asynchronous_metrics](#system_tables-asynchronous_metrics) — Contains periodically calculated metrics.
 - [system.metrics](#system_tables-metrics) — Contains instantly calculated metrics.
+- [system.metric_log](#system_tables-metric_log) — Contains a history of metrics values from tables `system.metrics` и `system.events`.
 - [Monitoring](monitoring.md) — Base concepts of ClickHouse monitoring.
 
 ## system.functions
@@ -273,10 +275,68 @@ SELECT * FROM system.metrics LIMIT 10
 │ DistributedSend            │     0 │ Number of connections to remote servers sending data that was INSERTed into Distributed tables. Both synchronous and asynchronous mode.                                                          │
 └────────────────────────────┴───────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
+
 **See Also**
 
 - [system.asynchronous_metrics](#system_tables-asynchronous_metrics) — Contains periodically calculated metrics.
 - [system.events](#system_tables-events) — Contains a number of events that occurred.
+- [system.metric_log](#system_tables-metric_log) — Contains a history of metrics values from tables `system.metrics` и `system.events`.
+- [Monitoring](monitoring.md) — Base concepts of ClickHouse monitoring.
+
+## system.metric_log {#system_tables-metric_log}
+
+Contains history of metrics values from tables `system.metrics` и `system.events`, periodically flush to disc with MegreTree() table engine
+For turn on metrics history collection on `system.metric_log`, create `/etc/clickhouse-server/config.d/metric_log.xml` with following content:
+```xml
+<yandex>
+    <metric_log>
+        <database>system</database>
+        <table>metric_log</table>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+        <collect_interval_milliseconds>1000</collect_interval_milliseconds>
+    </metric_log>
+</yandex>
+```
+
+**Example**
+
+```sql
+SELECT * FROM system.metric_log LIMIT 1 FORMAT Vertical;
+```
+
+
+```text
+Row 1:
+──────
+event_date:                                                 2020-02-18
+event_time:                                                 2020-02-18 07:15:33
+milliseconds:                                               554
+ProfileEvent_Query:                                         0
+ProfileEvent_SelectQuery:                                   0
+ProfileEvent_InsertQuery:                                   0
+ProfileEvent_FileOpen:                                      0
+ProfileEvent_Seek:                                          0
+ProfileEvent_ReadBufferFromFileDescriptorRead:              1
+ProfileEvent_ReadBufferFromFileDescriptorReadFailed:        0
+ProfileEvent_ReadBufferFromFileDescriptorReadBytes:         0
+ProfileEvent_WriteBufferFromFileDescriptorWrite:            1
+ProfileEvent_WriteBufferFromFileDescriptorWriteFailed:      0
+ProfileEvent_WriteBufferFromFileDescriptorWriteBytes:       56
+...
+CurrentMetric_Query:                                        0
+CurrentMetric_Merge:                                        0
+CurrentMetric_PartMutation:                                 0
+CurrentMetric_ReplicatedFetch:                              0
+CurrentMetric_ReplicatedSend:                               0
+CurrentMetric_ReplicatedChecks:                             0
+...    
+```
+
+**See also**
+
+- [system.asynchronous_metrics](#system_tables-asynchronous_metrics) — Contains periodically calculated metrics.
+- [system.events](#system_tables-events) — Contains a number of events that occurred.
+- [system.metrics](#system_tables-metrics) — Contains instantly calculated metrics.
 - [Monitoring](monitoring.md) — Base concepts of ClickHouse monitoring.
 
 ## system.numbers

--- a/docs/ru/operations/system_tables.md
+++ b/docs/ru/operations/system_tables.md
@@ -277,7 +277,7 @@ SELECT * FROM system.metrics LIMIT 10
 
 ## system.metric_log {#system_tables-metric_log}
 
-Содержит историю значений метрик из таблиц `system.metrics` и `system.events`, периодически сбрасываемую на диск с помощью MegreTree()
+Содержит историю значений метрик из таблиц `system.metrics` и `system.events`, периодически сбрасываемую на диск.
 Для включения сбора истории метрик в таблице `system.metric_log`  создайте `/etc/clickhouse-server/config.d/metric_log.xml` следующего содержания:
 ```xml
 <yandex>

--- a/docs/ru/operations/system_tables.md
+++ b/docs/ru/operations/system_tables.md
@@ -41,6 +41,7 @@ SELECT * FROM system.asynchronous_metrics LIMIT 10
 - [Мониторинг](monitoring.md) — основы мониторинга в ClickHouse.
 - [system.metrics](#system_tables-metrics) — таблица с мгновенно вычисляемыми метриками.
 - [system.events](#system_tables-events) — таблица с количеством произошедших событий.
+- [system.metric_log](#system_tables-metric_log) — таблица фиксирующая историю значений метрик из `system.metrics` и `system.events`.
 
 ## system.clusters
 
@@ -185,6 +186,7 @@ SELECT * FROM system.events LIMIT 5
 
 - [system.asynchronous_metrics](#system_tables-asynchronous_metrics) — таблица с периодически вычисляемыми метриками.
 - [system.metrics](#system_tables-metrics) — таблица с мгновенно вычисляемыми метриками.
+- [system.metric_log](#system_tables-metric_log) — таблица фиксирующая историю значений метрик из `system.metrics` и `system.events`.
 - [Мониторинг](monitoring.md) — основы мониторинга в ClickHouse.
 
 ## system.functions
@@ -270,6 +272,63 @@ SELECT * FROM system.metrics LIMIT 10
 
 - [system.asynchronous_metrics](#system_tables-asynchronous_metrics) — таблица с периодически вычисляемыми метриками.
 - [system.events](#system_tables-events) — таблица с количеством произошедших событий.
+- [system.metric_log](#system_tables-metric_log) — таблица фиксирующая историю значений метрик из `system.metrics` и `system.events`.
+- [Мониторинг](monitoring.md) — основы мониторинга в ClickHouse.
+
+## system.metric_log {#system_tables-metric_log}
+
+Содержит историю значений метрик из таблиц `system.metrics` и `system.events`, периодически сбрасываемую на диск с помощью MegreTree()
+Для включения сбора истории метрик в таблице `system.metric_log`  создайте `/etc/clickhouse-server/config.d/metric_log.xml` следующего содержания:
+```xml
+<yandex>
+    <metric_log>
+        <database>system</database>
+        <table>metric_log</table>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+        <collect_interval_milliseconds>1000</collect_interval_milliseconds>
+    </metric_log>
+</yandex>
+```
+
+**Пример**
+
+```sql
+SELECT * FROM system.metric_log LIMIT 1 FORMAT Vertical;
+```
+
+
+```text
+Row 1:
+──────
+event_date:                                                 2020-02-18
+event_time:                                                 2020-02-18 07:15:33
+milliseconds:                                               554
+ProfileEvent_Query:                                         0
+ProfileEvent_SelectQuery:                                   0
+ProfileEvent_InsertQuery:                                   0
+ProfileEvent_FileOpen:                                      0
+ProfileEvent_Seek:                                          0
+ProfileEvent_ReadBufferFromFileDescriptorRead:              1
+ProfileEvent_ReadBufferFromFileDescriptorReadFailed:        0
+ProfileEvent_ReadBufferFromFileDescriptorReadBytes:         0
+ProfileEvent_WriteBufferFromFileDescriptorWrite:            1
+ProfileEvent_WriteBufferFromFileDescriptorWriteFailed:      0
+ProfileEvent_WriteBufferFromFileDescriptorWriteBytes:       56
+...
+CurrentMetric_Query:                                        0
+CurrentMetric_Merge:                                        0
+CurrentMetric_PartMutation:                                 0
+CurrentMetric_ReplicatedFetch:                              0
+CurrentMetric_ReplicatedSend:                               0
+CurrentMetric_ReplicatedChecks:                             0
+...    
+```
+
+**Смотрите также**
+
+- [system.asynchronous_metrics](#system_tables-asynchronous_metrics) — таблица с периодически вычисляемыми метриками.
+- [system.events](#system_tables-events) — таблица с количеством произошедших событий.
+- [system.metrics](#system_tables-metrics) — таблица с мгновенно вычисляемыми метриками.
 - [Мониторинг](monitoring.md) — основы мониторинга в ClickHouse.
 
 ## system.numbers


### PR DESCRIPTION
Signed-off-by: Slach <bloodjazman@gmail.com>

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
add documentation to `system.metric_log` table