### PR TITLE
Fix typo in file name when reporting version file duplicates

### DIFF
--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -196,14 +196,15 @@ MergeTreeData::MergeTreeData(
     {
         Poco::File(path).createDirectories();
         Poco::File(path + "detached").createDirectory();
-        if (Poco::File{path + "format_version.txt"}.exists())
+        auto current_version_file_path = path + "format_version.txt";
+        if (Poco::File{current_version_file_path}.exists())
         {
             if (!version_file_path.empty())
             {
-                LOG_ERROR(log, "Duplication of version file " << version_file_path << " and " << path << "format_file.txt");
+                LOG_ERROR(log, "Duplication of version file " << version_file_path << " and " << current_version_file_path);
                 throw Exception("Multiple format_version.txt file", ErrorCodes::CORRUPTED_DATA);
             }
-            version_file_path = path + "format_version.txt";
+            version_file_path = current_version_file_path;
         }
     }
 


### PR DESCRIPTION
Haven't tested this code path after PR, but looks sane :)

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Non-significant (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:

...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.
