### PR TITLE
Simplier alter prepare

### DIFF
--- a/dbms/src/Interpreters/InterpreterAlterQuery.cpp
+++ b/dbms/src/Interpreters/InterpreterAlterQuery.cpp
@@ -109,7 +109,7 @@ BlockIO InterpreterAlterQuery::execute()
         auto table_lock_holder = table->lockAlterIntention(context.getCurrentQueryId());
         StorageInMemoryMetadata metadata = table->getInMemoryMetadata();
         alter_commands.validate(metadata, context);
-        alter_commands.prepare(metadata, context);
+        alter_commands.prepare(metadata);
         table->checkAlterIsPossible(alter_commands, context.getSettingsRef());
         table->alter(alter_commands, context, table_lock_holder);
     }

--- a/dbms/src/Interpreters/evaluateMissingDefaults.cpp
+++ b/dbms/src/Interpreters/evaluateMissingDefaults.cpp
@@ -7,6 +7,8 @@
 #include <Interpreters/ExpressionActions.h>
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTWithAlias.h>
+#include <Parsers/ASTLiteral.h>
+#include <Parsers/ASTFunction.h>
 #include <utility>
 #include <DataTypes/DataTypesNumber.h>
 

--- a/dbms/src/Interpreters/evaluateMissingDefaults.cpp
+++ b/dbms/src/Interpreters/evaluateMissingDefaults.cpp
@@ -27,8 +27,10 @@ static ASTPtr requiredExpressions(Block & block, const NamesAndTypesList & requi
 
         /// expressions must be cloned to prevent modification by the ExpressionAnalyzer
         if (it != column_defaults.end())
-            default_expr_list->children.emplace_back(
-                setAlias(it->second.expression->clone(), it->first));
+        {
+            auto cast_func = makeASTFunction("CAST", it->second.expression->clone(), std::make_shared<ASTLiteral>(column.type->getName()));
+            default_expr_list->children.emplace_back(setAlias(cast_func, it->first));
+        }
     }
 
     if (default_expr_list->children.empty())

--- a/dbms/src/Storages/AlterCommands.cpp
+++ b/dbms/src/Storages/AlterCommands.cpp
@@ -517,7 +517,7 @@ void AlterCommands::prepare(const StorageInMemoryMetadata & metadata, const Cont
             if (!has_column && command.if_exists)
                 command.ignore = true;
 
-            if (has_column)
+            if (has_column && command.data_type)
             {
                 auto column_from_table = columns.get(command.column_name);
                 if (!command.default_expression && column_from_table.default_desc.expression)

--- a/dbms/src/Storages/AlterCommands.cpp
+++ b/dbms/src/Storages/AlterCommands.cpp
@@ -7,6 +7,12 @@
 #include <Interpreters/SyntaxAnalyzer.h>
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <Interpreters/ExpressionActions.h>
+#include <Parsers/ASTAlterQuery.h>
+#include <Parsers/ASTColumnDeclaration.h>
+#include <Parsers/ASTConstraintDeclaration.h>
+#include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTExpressionList.h>
+#include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTIndexDeclaration.h>
 #include <Parsers/ASTConstraintDeclaration.h>
@@ -498,162 +504,37 @@ void AlterCommands::apply(StorageInMemoryMetadata & metadata) const
 }
 
 
-void AlterCommands::prepare(const StorageInMemoryMetadata & metadata, const Context & context)
+void AlterCommands::prepare(const StorageInMemoryMetadata & metadata, const Context & /*context*/)
 {
-    /// A temporary object that is used to keep track of the current state of columns after applying a subset of commands.
     auto columns = metadata.columns;
-
-    /// Default expressions will be added to this list for type deduction.
-    auto default_expr_list = std::make_shared<ASTExpressionList>();
-    /// We will save ALTER ADD/MODIFY command indices (only the last for each column) for possible modification
-    /// (we might need to add deduced types or modify default expressions).
-    /// Saving indices because we can add new commands later and thus cause vector resize.
-    std::unordered_map<String, size_t> column_to_command_idx;
 
     for (size_t i = 0; i < size(); ++i)
     {
         auto & command = (*this)[i];
-        if (command.type == AlterCommand::ADD_COLUMN || command.type == AlterCommand::MODIFY_COLUMN)
+        bool has_column = columns.has(command.column_name);
+        if (command.type == AlterCommand::MODIFY_COLUMN)
         {
-            const auto & column_name = command.column_name;
-
-            if (command.type == AlterCommand::ADD_COLUMN)
+            if (!has_column && command.if_exists)
             {
-                if (columns.has(column_name) || columns.hasNested(column_name))
-                {
-                    if (command.if_not_exists)
-                        command.ignore = true;
-                }
-            }
-            else if (command.type == AlterCommand::MODIFY_COLUMN)
-            {
-                if (!columns.has(column_name))
-                    if (command.if_exists)
-                        command.ignore = true;
-
-                if (!command.ignore)
-                    columns.remove(column_name);
-            }
-
-            if (!command.ignore)
-            {
-                column_to_command_idx[column_name] = i;
-
-                /// we're creating dummy DataTypeUInt8 in order to prevent the NullPointerException in ExpressionActions
-                columns.add(
-                    ColumnDescription(column_name, command.data_type ? command.data_type : std::make_shared<DataTypeUInt8>(), false));
-
-                if (command.default_expression)
-                {
-                    if (command.data_type)
-                    {
-                        const auto & final_column_name = column_name;
-                        const auto tmp_column_name = final_column_name + "_tmp";
-
-                        default_expr_list->children.emplace_back(setAlias(
-                            makeASTFunction("CAST", std::make_shared<ASTIdentifier>(tmp_column_name),
-                                std::make_shared<ASTLiteral>(command.data_type->getName())),
-                            final_column_name));
-
-                        default_expr_list->children.emplace_back(setAlias(command.default_expression->clone(), tmp_column_name));
-                    }
-                    else
-                    {
-                        /// no type explicitly specified, will deduce later
-                        default_expr_list->children.emplace_back(
-                            setAlias(command.default_expression->clone(), column_name));
-                    }
-                }
-            }
-        }
-        else if (command.type == AlterCommand::DROP_COLUMN)
-        {
-            if (columns.has(command.column_name) || columns.hasNested(command.column_name))
-                columns.remove(command.column_name);
-            else if (command.if_exists)
                 command.ignore = true;
-        }
-        else if (command.type == AlterCommand::COMMENT_COLUMN)
-        {
-            if (!columns.has(command.column_name) && command.if_exists)
-                command.ignore = true;
-        }
-    }
+            }
 
-    /** Existing defaulted columns may require default expression extensions with a type conversion,
-        *  therefore we add them to default_expr_list to recalculate their types */
-    for (const auto & column : columns)
-    {
-        if (column.default_desc.expression)
-        {
-            const auto tmp_column_name = column.name + "_tmp";
-
-            default_expr_list->children.emplace_back(setAlias(
-                    makeASTFunction("CAST", std::make_shared<ASTIdentifier>(tmp_column_name),
-                        std::make_shared<ASTLiteral>(column.type->getName())),
-                    column.name));
-
-            default_expr_list->children.emplace_back(setAlias(column.default_desc.expression->clone(), tmp_column_name));
-        }
-    }
-
-    ASTPtr query = default_expr_list;
-    auto syntax_result = SyntaxAnalyzer(context).analyze(query, columns.getAll());
-    const auto actions = ExpressionAnalyzer(query, syntax_result, context).getActions(true);
-    const auto block = actions->getSampleBlock();
-
-    /// set deduced types, modify default expression if necessary
-    for (const auto & column : columns)
-    {
-        AlterCommand * command = nullptr;
-        auto command_it = column_to_command_idx.find(column.name);
-        if (command_it != column_to_command_idx.end())
-            command = &(*this)[command_it->second];
-
-        if (!(command && command->default_expression) && !column.default_desc.expression)
-            continue;
-
-        const DataTypePtr & explicit_type = command ? command->data_type : column.type;
-        if (explicit_type)
-        {
-            const auto & tmp_column = block.getByName(column.name + "_tmp");
-            const auto & deduced_type = tmp_column.type;
-            if (!explicit_type->equals(*deduced_type))
+            if (has_column)
             {
-                if (!command)
+                auto column_from_table = columns.get(command.column_name);
+                if (!command.default_expression && column_from_table.default_desc.expression)
                 {
-#if !__clang__
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#endif
-                    /// We completely sure, that we initialize all required fields
-                    AlterCommand aux_command{
-                        .type = AlterCommand::MODIFY_COLUMN,
-                        .column_name = column.name,
-                        .data_type = explicit_type,
-                        .default_kind = column.default_desc.kind,
-                        .default_expression = column.default_desc.expression
-                    };
-#if !__clang__
-#    pragma GCC diagnostic pop
-#endif
-
-                    /// column has no associated alter command, let's create it
-                    /// add a new alter command to modify existing column
-                    this->emplace_back(aux_command);
-
-                    command = &back();
+                    command.default_kind = column_from_table.default_desc.kind;
+                    command.default_expression = column_from_table.default_desc.expression;
                 }
-
-                command->default_expression = makeASTFunction("CAST",
-                    command->default_expression->clone(),
-                    std::make_shared<ASTLiteral>(explicit_type->getName()));
             }
         }
-        else
+        else if (command.type == AlterCommand::ADD_COLUMN
+            || command.type == AlterCommand::DROP_COLUMN
+            || command.type == AlterCommand::COMMENT_COLUMN)
         {
-            /// just set deduced type
-            command->data_type = block.getByName(column.name).type;
+            if (!has_column && command.if_exists)
+                command.ignore = true;
         }
     }
     prepared = true;
@@ -664,23 +545,35 @@ void AlterCommands::validate(const StorageInMemoryMetadata & metadata, const Con
     for (size_t i = 0; i < size(); ++i)
     {
         auto & command = (*this)[i];
-        if (command.type == AlterCommand::ADD_COLUMN || command.type == AlterCommand::MODIFY_COLUMN)
+
+        const auto & column_name = command.column_name;
+        if (command.type == AlterCommand::ADD_COLUMN)
         {
-            const auto & column_name = command.column_name;
+            if (metadata.columns.has(column_name) || metadata.columns.hasNested(column_name))
+                if (!command.if_not_exists)
+                    throw Exception{"Cannot add column " + column_name + ": column with this name already exists", ErrorCodes::ILLEGAL_COLUMN};
 
-            if (command.type == AlterCommand::ADD_COLUMN)
-            {
-                if (metadata.columns.has(column_name) || metadata.columns.hasNested(column_name))
-                    if (!command.if_not_exists)
-                        throw Exception{"Cannot add column " + column_name + ": column with this name already exists", ErrorCodes::ILLEGAL_COLUMN};
-            }
-            else if (command.type == AlterCommand::MODIFY_COLUMN)
-            {
-                if (!metadata.columns.has(column_name))
-                    if (!command.if_exists)
-                        throw Exception{"Wrong column name. Cannot find column " + column_name + " to modify", ErrorCodes::ILLEGAL_COLUMN};
-            }
+            if (!command.data_type)
+                throw Exception{"Data type have to be specified for column " + column_name + " to add", ErrorCodes::ILLEGAL_COLUMN};
 
+            if (command.default_expression)
+                validateDefaultExpressionForNewColumn(command.default_expression, column_name, command.data_type, metadata.columns, context);
+        }
+        else if (command.type == AlterCommand::MODIFY_COLUMN)
+        {
+            if (!metadata.columns.has(column_name))
+                if (!command.if_exists)
+                    throw Exception{"Wrong column name. Cannot find column " + column_name + " to modify", ErrorCodes::ILLEGAL_COLUMN};
+
+            if (command.default_expression)
+            {
+                if (!command.data_type)
+                    validateDefaultExpressionForNewColumn(
+                        command.default_expression, column_name, metadata.columns.get(column_name).type, metadata.columns, context);
+                else
+                    validateDefaultExpressionForNewColumn(
+                        command.default_expression, column_name, command.data_type, metadata.columns, context);
+            }
         }
         else if (command.type == AlterCommand::DROP_COLUMN)
         {
@@ -689,18 +582,18 @@ void AlterCommands::validate(const StorageInMemoryMetadata & metadata, const Con
                 for (const ColumnDescription & column : metadata.columns)
                 {
                     const auto & default_expression = column.default_desc.expression;
-                    if (!default_expression)
-                        continue;
+                    if (default_expression)
+                    {
+                        ASTPtr query = default_expression->clone();
+                        auto syntax_result = SyntaxAnalyzer(context).analyze(query, metadata.columns.getAll());
+                        const auto actions = ExpressionAnalyzer(query, syntax_result, context).getActions(true);
+                        const auto required_columns = actions->getRequiredColumns();
 
-                    ASTPtr query = default_expression->clone();
-                    auto syntax_result = SyntaxAnalyzer(context).analyze(query, metadata.columns.getAll());
-                    const auto actions = ExpressionAnalyzer(query, syntax_result, context).getActions(true);
-                    const auto required_columns = actions->getRequiredColumns();
-
-                    if (required_columns.end() != std::find(required_columns.begin(), required_columns.end(), command.column_name))
-                        throw Exception(
-                            "Cannot drop column " + command.column_name + ", because column " + column.name +
-                            " depends on it", ErrorCodes::ILLEGAL_COLUMN);
+                        if (required_columns.end() != std::find(required_columns.begin(), required_columns.end(), command.column_name))
+                            throw Exception(
+                                "Cannot drop column " + command.column_name + ", because column " + column.name + " depends on it",
+                                ErrorCodes::ILLEGAL_COLUMN);
+                    }
                 }
             }
             else if (!command.if_exists)
@@ -715,6 +608,49 @@ void AlterCommands::validate(const StorageInMemoryMetadata & metadata, const Con
                     throw Exception{"Wrong column name. Cannot find column " + command.column_name + " to comment", ErrorCodes::ILLEGAL_COLUMN};
             }
         }
+    }
+}
+DataTypePtr AlterCommands::getDefaultExpressionType(
+    const ASTPtr default_expression,
+    const String & column_name,
+    const ColumnsDescription & all_columns,
+    const Context & context) const
+{
+    String tmp_column_name = "__tmp" + column_name;
+    auto copy_expression = default_expression->clone();
+    auto query_with_alias = setAlias(copy_expression, tmp_column_name);
+    auto syntax_result = SyntaxAnalyzer(context).analyze(query_with_alias, all_columns.getAll());
+    const auto actions = ExpressionAnalyzer(query_with_alias, syntax_result, context).getActions(true);
+    const auto & sample_block = actions->getSampleBlock();
+
+    auto result_column = sample_block.getByName(tmp_column_name);
+
+    return result_column.type;
+}
+
+
+void AlterCommands::validateDefaultExpressionForNewColumn(
+    const ASTPtr default_expression,
+    const String & column_name,
+    const DataTypePtr column_type,
+    const ColumnsDescription & all_columns,
+    const Context & context) const
+{
+
+    try
+    {
+        String tmp_column_name = "__tmp" + column_name;
+        auto copy_expression = default_expression->clone();
+        auto default_with_cast = makeASTFunction("CAST", copy_expression, std::make_shared<ASTLiteral>(column_type->getName()));
+        auto query_with_alias = setAlias(default_with_cast, tmp_column_name);
+        auto syntax_result = SyntaxAnalyzer(context).analyze(query_with_alias, all_columns.getAll());
+        const auto actions = ExpressionAnalyzer(query_with_alias, syntax_result, context).getActions(true);
+        auto sample_block = actions->getSampleBlock();
+    }
+    catch (Exception & ex)
+    {
+        ex.addMessage("default expression and column type are incompatible. Cannot alter column '" + column_name + "'");
+        throw(ex);
     }
 }
 

--- a/dbms/src/Storages/AlterCommands.cpp
+++ b/dbms/src/Storages/AlterCommands.cpp
@@ -511,13 +511,11 @@ void AlterCommands::prepare(const StorageInMemoryMetadata & metadata, const Cont
     for (size_t i = 0; i < size(); ++i)
     {
         auto & command = (*this)[i];
-        bool has_column = columns.has(command.column_name);
+        bool has_column = columns.has(command.column_name) || columns.hasNested(command.column_name);
         if (command.type == AlterCommand::MODIFY_COLUMN)
         {
             if (!has_column && command.if_exists)
-            {
                 command.ignore = true;
-            }
 
             if (has_column)
             {
@@ -529,9 +527,13 @@ void AlterCommands::prepare(const StorageInMemoryMetadata & metadata, const Cont
                 }
             }
         }
-        else if (command.type == AlterCommand::ADD_COLUMN
-            || command.type == AlterCommand::DROP_COLUMN
-            || command.type == AlterCommand::COMMENT_COLUMN)
+        else if (command.type == AlterCommand::ADD_COLUMN)
+        {
+            if (has_column && command.if_not_exists)
+                command.ignore = true;
+        }
+        else if (command.type == AlterCommand::DROP_COLUMN
+                || command.type == AlterCommand::COMMENT_COLUMN)
         {
             if (!has_column && command.if_exists)
                 command.ignore = true;
@@ -542,6 +544,7 @@ void AlterCommands::prepare(const StorageInMemoryMetadata & metadata, const Cont
 
 void AlterCommands::validate(const StorageInMemoryMetadata & metadata, const Context & context) const
 {
+    auto all_columns = metadata.columns;
     for (size_t i = 0; i < size(); ++i)
     {
         auto & command = (*this)[i];
@@ -550,29 +553,45 @@ void AlterCommands::validate(const StorageInMemoryMetadata & metadata, const Con
         if (command.type == AlterCommand::ADD_COLUMN)
         {
             if (metadata.columns.has(column_name) || metadata.columns.hasNested(column_name))
+            {
                 if (!command.if_not_exists)
                     throw Exception{"Cannot add column " + column_name + ": column with this name already exists", ErrorCodes::ILLEGAL_COLUMN};
+                else
+                    continue;
+            }
 
             if (!command.data_type)
                 throw Exception{"Data type have to be specified for column " + column_name + " to add", ErrorCodes::ILLEGAL_COLUMN};
 
             if (command.default_expression)
-                validateDefaultExpressionForNewColumn(command.default_expression, column_name, command.data_type, metadata.columns, context);
+                validateDefaultExpressionForNewColumn(command.default_expression, column_name, command.data_type, all_columns, context);
+
+            all_columns.add(ColumnDescription(column_name, command.data_type, false));
         }
         else if (command.type == AlterCommand::MODIFY_COLUMN)
         {
             if (!metadata.columns.has(column_name))
+            {
                 if (!command.if_exists)
                     throw Exception{"Wrong column name. Cannot find column " + column_name + " to modify", ErrorCodes::ILLEGAL_COLUMN};
+                else
+                    continue;
+            }
 
+            auto column_in_table = metadata.columns.get(column_name);
             if (command.default_expression)
             {
                 if (!command.data_type)
                     validateDefaultExpressionForNewColumn(
-                        command.default_expression, column_name, metadata.columns.get(column_name).type, metadata.columns, context);
+                        command.default_expression, column_name, column_in_table.type, all_columns, context);
                 else
                     validateDefaultExpressionForNewColumn(
-                        command.default_expression, column_name, command.data_type, metadata.columns, context);
+                        command.default_expression, column_name, command.data_type, all_columns, context);
+            }
+            else if (column_in_table.default_desc.expression && command.data_type)
+            {
+                validateDefaultExpressionForNewColumn(
+                    column_in_table.default_desc.expression, column_name, command.data_type, all_columns, context);
             }
         }
         else if (command.type == AlterCommand::DROP_COLUMN)

--- a/dbms/src/Storages/AlterCommands.cpp
+++ b/dbms/src/Storages/AlterCommands.cpp
@@ -645,8 +645,7 @@ void AlterCommands::validateDefaultExpressionForColumn(
         auto default_with_cast = makeASTFunction("CAST", copy_expression, std::make_shared<ASTLiteral>(column_type->getName()));
         auto query_with_alias = setAlias(default_with_cast, tmp_column_name);
         auto syntax_result = SyntaxAnalyzer(context).analyze(query_with_alias, all_columns.getAll());
-        const auto actions = ExpressionAnalyzer(query_with_alias, syntax_result, context).getActions(true);
-        auto sample_block = actions->getSampleBlock();
+        ExpressionAnalyzer(query_with_alias, syntax_result, context).getActions(true);
     }
     catch (Exception & ex)
     {

--- a/dbms/src/Storages/AlterCommands.cpp
+++ b/dbms/src/Storages/AlterCommands.cpp
@@ -10,17 +10,11 @@
 #include <Parsers/ASTAlterQuery.h>
 #include <Parsers/ASTColumnDeclaration.h>
 #include <Parsers/ASTConstraintDeclaration.h>
-#include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTIndexDeclaration.h>
-#include <Parsers/ASTConstraintDeclaration.h>
-#include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTLiteral.h>
-#include <Parsers/ASTFunction.h>
-#include <Parsers/ASTAlterQuery.h>
-#include <Parsers/ASTColumnDeclaration.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Common/typeid_cast.h>
@@ -36,8 +30,10 @@ namespace ErrorCodes
 {
     extern const int ILLEGAL_COLUMN;
     extern const int BAD_ARGUMENTS;
+    extern const int NOT_FOUND_COLUMN_IN_BLOCK;
     extern const int LOGICAL_ERROR;
     extern const int UNKNOWN_SETTING;
+    extern const int DUPLICATE_COLUMN;
 }
 
 
@@ -504,7 +500,7 @@ void AlterCommands::apply(StorageInMemoryMetadata & metadata) const
 }
 
 
-void AlterCommands::prepare(const StorageInMemoryMetadata & metadata, const Context & /*context*/)
+void AlterCommands::prepare(const StorageInMemoryMetadata & metadata)
 {
     auto columns = metadata.columns;
 
@@ -555,13 +551,15 @@ void AlterCommands::validate(const StorageInMemoryMetadata & metadata, const Con
             if (metadata.columns.has(column_name) || metadata.columns.hasNested(column_name))
             {
                 if (!command.if_not_exists)
-                    throw Exception{"Cannot add column " + column_name + ": column with this name already exists", ErrorCodes::ILLEGAL_COLUMN};
+                    throw Exception{"Cannot add column " + backQuote(column_name) + ": column with this name already exists",
+                                    ErrorCodes::DUPLICATE_COLUMN};
                 else
                     continue;
             }
 
             if (!command.data_type)
-                throw Exception{"Data type have to be specified for column " + column_name + " to add", ErrorCodes::ILLEGAL_COLUMN};
+                throw Exception{"Data type have to be specified for column " + backQuote(column_name) + " to add",
+                                ErrorCodes::BAD_ARGUMENTS};
 
             if (command.default_expression)
                 validateDefaultExpressionForColumn(command.default_expression, column_name, command.data_type, all_columns, context);
@@ -573,7 +571,8 @@ void AlterCommands::validate(const StorageInMemoryMetadata & metadata, const Con
             if (!metadata.columns.has(column_name))
             {
                 if (!command.if_exists)
-                    throw Exception{"Wrong column name. Cannot find column " + column_name + " to modify", ErrorCodes::ILLEGAL_COLUMN};
+                    throw Exception{"Wrong column name. Cannot find column " + backQuote(column_name) + " to modify",
+                                    ErrorCodes::NOT_FOUND_COLUMN_IN_BLOCK};
                 else
                     continue;
             }
@@ -610,21 +609,23 @@ void AlterCommands::validate(const StorageInMemoryMetadata & metadata, const Con
 
                         if (required_columns.end() != std::find(required_columns.begin(), required_columns.end(), command.column_name))
                             throw Exception(
-                                "Cannot drop column " + command.column_name + ", because column " + column.name + " depends on it",
+                                "Cannot drop column " + backQuote(command.column_name) + ", because column " + backQuote(column.name) + " depends on it",
                                 ErrorCodes::ILLEGAL_COLUMN);
                     }
                 }
             }
             else if (!command.if_exists)
-                throw Exception("Wrong column name. Cannot find column " + command.column_name + " to drop",
-                    ErrorCodes::ILLEGAL_COLUMN);
+                throw Exception(
+                    "Wrong column name. Cannot find column " + backQuote(command.column_name) + " to drop",
+                    ErrorCodes::NOT_FOUND_COLUMN_IN_BLOCK);
         }
         else if (command.type == AlterCommand::COMMENT_COLUMN)
         {
             if (!metadata.columns.has(command.column_name))
             {
                 if (!command.if_exists)
-                    throw Exception{"Wrong column name. Cannot find column " + command.column_name + " to comment", ErrorCodes::ILLEGAL_COLUMN};
+                    throw Exception{"Wrong column name. Cannot find column " + backQuote(command.column_name) + " to comment",
+                                    ErrorCodes::NOT_FOUND_COLUMN_IN_BLOCK};
             }
         }
     }
@@ -649,8 +650,8 @@ void AlterCommands::validateDefaultExpressionForColumn(
     }
     catch (Exception & ex)
     {
-        ex.addMessage("default expression and column type are incompatible. Cannot alter column '" + column_name + "'");
-        throw(ex);
+        ex.addMessage("default expression and column type are incompatible. Cannot alter column " + backQuote(column_name));
+        throw;
     }
 }
 

--- a/dbms/src/Storages/AlterCommands.h
+++ b/dbms/src/Storages/AlterCommands.h
@@ -118,13 +118,8 @@ class AlterCommands : public std::vector<AlterCommand>
 private:
     bool prepared = false;
 private:
-    DataTypePtr getDefaultExpressionType(
-        const ASTPtr default_expression,
-        const String & column_name,
-        const ColumnsDescription & all_columns,
-        const Context & context) const;
 
-    void validateDefaultExpressionForNewColumn(
+    void validateDefaultExpressionForColumn(
         const ASTPtr default_expression,
         const String & column_name,
         const DataTypePtr column_type,

--- a/dbms/src/Storages/AlterCommands.h
+++ b/dbms/src/Storages/AlterCommands.h
@@ -119,6 +119,8 @@ private:
     bool prepared = false;
 private:
 
+    /// Validate that default expression and type are compatible, i.e. default
+    /// expression result can be casted to column_type
     void validateDefaultExpressionForColumn(
         const ASTPtr default_expression,
         const String & column_name,
@@ -133,8 +135,8 @@ public:
     /// More accurate check have to be performed with storage->checkAlterIsPossible.
     void validate(const StorageInMemoryMetadata & metadata, const Context & context) const;
 
-    /// Prepare alter commands. Set ignore flag to some of them
-    /// and additional commands for dependent columns.
+    /// Prepare alter commands. Set ignore flag to some of them and set some
+    /// parts to commands from storage's metadata (for example, absent default)
     void prepare(const StorageInMemoryMetadata & metadata, const Context & context);
 
     /// Apply all alter command in sequential order to storage metadata.

--- a/dbms/src/Storages/AlterCommands.h
+++ b/dbms/src/Storages/AlterCommands.h
@@ -137,7 +137,7 @@ public:
 
     /// Prepare alter commands. Set ignore flag to some of them and set some
     /// parts to commands from storage's metadata (for example, absent default)
-    void prepare(const StorageInMemoryMetadata & metadata, const Context & context);
+    void prepare(const StorageInMemoryMetadata & metadata);
 
     /// Apply all alter command in sequential order to storage metadata.
     /// Commands have to be prepared before apply.

--- a/dbms/src/Storages/AlterCommands.h
+++ b/dbms/src/Storages/AlterCommands.h
@@ -4,7 +4,7 @@
 #include <Core/NamesAndTypes.h>
 #include <Storages/IStorage_fwd.h>
 #include <Storages/StorageInMemoryMetadata.h>
-
+#include <Storages/ColumnsDescription.h>
 
 #include <Common/SettingsChanges.h>
 
@@ -117,6 +117,20 @@ class AlterCommands : public std::vector<AlterCommand>
 {
 private:
     bool prepared = false;
+private:
+    DataTypePtr getDefaultExpressionType(
+        const ASTPtr default_expression,
+        const String & column_name,
+        const ColumnsDescription & all_columns,
+        const Context & context) const;
+
+    void validateDefaultExpressionForNewColumn(
+        const ASTPtr default_expression,
+        const String & column_name,
+        const DataTypePtr column_type,
+        const ColumnsDescription & all_columns,
+        const Context & context) const;
+
 public:
     /// Validate that commands can be applied to metadata.
     /// Checks that all columns exist and dependecies between them.

--- a/dbms/tests/queries/0_stateless/00061_merge_tree_alter.reference
+++ b/dbms/tests/queries/0_stateless/00061_merge_tree_alter.reference
@@ -38,8 +38,8 @@ k	UInt64
 i32	Int32					
 n.ui8	Array(UInt8)					
 n.s	Array(String)					
-s	Int64					
-CREATE TABLE default.alter_00061 (`d` Date, `k` UInt64, `i32` Int32, `n.ui8` Array(UInt8), `n.s` Array(String), `s` Int64) ENGINE = MergeTree(d, k, 8192)
+s	Int64	DEFAULT	\'0\'			
+CREATE TABLE default.alter_00061 (`d` Date, `k` UInt64, `i32` Int32, `n.ui8` Array(UInt8), `n.s` Array(String), `s` Int64 DEFAULT \'0\') ENGINE = MergeTree(d, k, 8192)
 2015-01-01	6	38	[10,20,30]	['asd','qwe','qwe']	100500
 2015-01-01	7	39	[10,20,30]	['120','130','140']	0
 2015-01-01	8	40	[1,2,3]	['12','13','14']	0
@@ -49,9 +49,9 @@ k	UInt64
 i32	Int32					
 n.ui8	Array(UInt8)					
 n.s	Array(String)					
-s	UInt32					
+s	UInt32	DEFAULT	\'0\'			
 n.d	Array(Date)					
-CREATE TABLE default.alter_00061 (`d` Date, `k` UInt64, `i32` Int32, `n.ui8` Array(UInt8), `n.s` Array(String), `s` UInt32, `n.d` Array(Date)) ENGINE = MergeTree(d, k, 8192)
+CREATE TABLE default.alter_00061 (`d` Date, `k` UInt64, `i32` Int32, `n.ui8` Array(UInt8), `n.s` Array(String), `s` UInt32 DEFAULT \'0\', `n.d` Array(Date)) ENGINE = MergeTree(d, k, 8192)
 2015-01-01	6	38	[10,20,30]	['asd','qwe','qwe']	100500	['0000-00-00','0000-00-00','0000-00-00']
 2015-01-01	7	39	[10,20,30]	['120','130','140']	0	['0000-00-00','0000-00-00','0000-00-00']
 2015-01-01	8	40	[1,2,3]	['12','13','14']	0	['0000-00-00','0000-00-00','0000-00-00']
@@ -64,8 +64,8 @@ d	Date
 k	UInt64					
 i32	Int32					
 n.s	Array(String)					
-s	UInt32					
-CREATE TABLE default.alter_00061 (`d` Date, `k` UInt64, `i32` Int32, `n.s` Array(String), `s` UInt32) ENGINE = MergeTree(d, k, 8192)
+s	UInt32	DEFAULT	\'0\'			
+CREATE TABLE default.alter_00061 (`d` Date, `k` UInt64, `i32` Int32, `n.s` Array(String), `s` UInt32 DEFAULT \'0\') ENGINE = MergeTree(d, k, 8192)
 2015-01-01	6	38	['asd','qwe','qwe']	100500
 2015-01-01	7	39	['120','130','140']	0
 2015-01-01	8	40	['12','13','14']	0
@@ -73,8 +73,8 @@ CREATE TABLE default.alter_00061 (`d` Date, `k` UInt64, `i32` Int32, `n.s` Array
 d	Date					
 k	UInt64					
 i32	Int32					
-s	UInt32					
-CREATE TABLE default.alter_00061 (`d` Date, `k` UInt64, `i32` Int32, `s` UInt32) ENGINE = MergeTree(d, k, 8192)
+s	UInt32	DEFAULT	\'0\'			
+CREATE TABLE default.alter_00061 (`d` Date, `k` UInt64, `i32` Int32, `s` UInt32 DEFAULT \'0\') ENGINE = MergeTree(d, k, 8192)
 2015-01-01	6	38	100500
 2015-01-01	7	39	0
 2015-01-01	8	40	0
@@ -82,10 +82,10 @@ CREATE TABLE default.alter_00061 (`d` Date, `k` UInt64, `i32` Int32, `s` UInt32)
 d	Date					
 k	UInt64					
 i32	Int32					
-s	UInt32					
+s	UInt32	DEFAULT	\'0\'			
 n.s	Array(String)					
 n.d	Array(Date)					
-CREATE TABLE default.alter_00061 (`d` Date, `k` UInt64, `i32` Int32, `s` UInt32, `n.s` Array(String), `n.d` Array(Date)) ENGINE = MergeTree(d, k, 8192)
+CREATE TABLE default.alter_00061 (`d` Date, `k` UInt64, `i32` Int32, `s` UInt32 DEFAULT \'0\', `n.s` Array(String), `n.d` Array(Date)) ENGINE = MergeTree(d, k, 8192)
 2015-01-01	6	38	100500	[]	[]
 2015-01-01	7	39	0	[]	[]
 2015-01-01	8	40	0	[]	[]
@@ -93,8 +93,8 @@ CREATE TABLE default.alter_00061 (`d` Date, `k` UInt64, `i32` Int32, `s` UInt32,
 d	Date					
 k	UInt64					
 i32	Int32					
-s	UInt32					
-CREATE TABLE default.alter_00061 (`d` Date, `k` UInt64, `i32` Int32, `s` UInt32) ENGINE = MergeTree(d, k, 8192)
+s	UInt32	DEFAULT	\'0\'			
+CREATE TABLE default.alter_00061 (`d` Date, `k` UInt64, `i32` Int32, `s` UInt32 DEFAULT \'0\') ENGINE = MergeTree(d, k, 8192)
 2015-01-01	6	38	100500
 2015-01-01	7	39	0
 2015-01-01	8	40	0

--- a/dbms/tests/queries/0_stateless/00062_replicated_merge_tree_alter_zookeeper.reference
+++ b/dbms/tests/queries/0_stateless/00062_replicated_merge_tree_alter_zookeeper.reference
@@ -85,16 +85,16 @@ i32	Int32
 dt	DateTime					
 n.ui8	Array(UInt8)					
 n.s	Array(String)					
-s	Int64					
-CREATE TABLE test.replicated_alter1 (`d` Date, `k` UInt64, `i32` Int32, `dt` DateTime, `n.ui8` Array(UInt8), `n.s` Array(String), `s` Int64) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r1\', d, k, 8192)
+s	Int64	DEFAULT	\'0\'			
+CREATE TABLE test.replicated_alter1 (`d` Date, `k` UInt64, `i32` Int32, `dt` DateTime, `n.ui8` Array(UInt8), `n.s` Array(String), `s` Int64 DEFAULT \'0\') ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r1\', d, k, 8192)
 d	Date					
 k	UInt64					
 i32	Int32					
 dt	DateTime					
 n.ui8	Array(UInt8)					
 n.s	Array(String)					
-s	Int64					
-CREATE TABLE test.replicated_alter2 (`d` Date, `k` UInt64, `i32` Int32, `dt` DateTime, `n.ui8` Array(UInt8), `n.s` Array(String), `s` Int64) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r2\', d, k, 8192)
+s	Int64	DEFAULT	\'0\'			
+CREATE TABLE test.replicated_alter2 (`d` Date, `k` UInt64, `i32` Int32, `dt` DateTime, `n.ui8` Array(UInt8), `n.s` Array(String), `s` Int64 DEFAULT \'0\') ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r2\', d, k, 8192)
 2015-01-01	6	38	2014-07-15 13:26:50	[10,20,30]	['asd','qwe','qwe']	100500
 2015-01-01	7	39	2014-07-14 13:26:50	[10,20,30]	['120','130','140']	0
 2015-01-01	8	40	2012-12-12 12:12:12	[1,2,3]	['12','13','14']	0
@@ -106,18 +106,18 @@ i32	Int32
 dt	DateTime					
 n.ui8	Array(UInt8)					
 n.s	Array(String)					
-s	UInt32					
+s	UInt32	DEFAULT	\'0\'			
 n.d	Array(Date)					
-CREATE TABLE test.replicated_alter1 (`d` Date, `k` UInt64, `i32` Int32, `dt` DateTime, `n.ui8` Array(UInt8), `n.s` Array(String), `s` UInt32, `n.d` Array(Date)) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r1\', d, k, 8192)
+CREATE TABLE test.replicated_alter1 (`d` Date, `k` UInt64, `i32` Int32, `dt` DateTime, `n.ui8` Array(UInt8), `n.s` Array(String), `s` UInt32 DEFAULT \'0\', `n.d` Array(Date)) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r1\', d, k, 8192)
 d	Date					
 k	UInt64					
 i32	Int32					
 dt	DateTime					
 n.ui8	Array(UInt8)					
 n.s	Array(String)					
-s	UInt32					
+s	UInt32	DEFAULT	\'0\'			
 n.d	Array(Date)					
-CREATE TABLE test.replicated_alter2 (`d` Date, `k` UInt64, `i32` Int32, `dt` DateTime, `n.ui8` Array(UInt8), `n.s` Array(String), `s` UInt32, `n.d` Array(Date)) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r2\', d, k, 8192)
+CREATE TABLE test.replicated_alter2 (`d` Date, `k` UInt64, `i32` Int32, `dt` DateTime, `n.ui8` Array(UInt8), `n.s` Array(String), `s` UInt32 DEFAULT \'0\', `n.d` Array(Date)) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r2\', d, k, 8192)
 2015-01-01	6	38	2014-07-15 13:26:50	[10,20,30]	['asd','qwe','qwe']	100500	['0000-00-00','0000-00-00','0000-00-00']
 2015-01-01	7	39	2014-07-14 13:26:50	[10,20,30]	['120','130','140']	0	['0000-00-00','0000-00-00','0000-00-00']
 2015-01-01	8	40	2012-12-12 12:12:12	[1,2,3]	['12','13','14']	0	['0000-00-00','0000-00-00','0000-00-00']
@@ -128,15 +128,15 @@ k	UInt64
 i32	Int32					
 dt	DateTime					
 n.s	Array(String)					
-s	UInt32					
-CREATE TABLE test.replicated_alter1 (`d` Date, `k` UInt64, `i32` Int32, `dt` DateTime, `n.s` Array(String), `s` UInt32) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r1\', d, k, 8192)
+s	UInt32	DEFAULT	\'0\'			
+CREATE TABLE test.replicated_alter1 (`d` Date, `k` UInt64, `i32` Int32, `dt` DateTime, `n.s` Array(String), `s` UInt32 DEFAULT \'0\') ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r1\', d, k, 8192)
 d	Date					
 k	UInt64					
 i32	Int32					
 dt	DateTime					
 n.s	Array(String)					
-s	UInt32					
-CREATE TABLE test.replicated_alter2 (`d` Date, `k` UInt64, `i32` Int32, `dt` DateTime, `n.s` Array(String), `s` UInt32) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r2\', d, k, 8192)
+s	UInt32	DEFAULT	\'0\'			
+CREATE TABLE test.replicated_alter2 (`d` Date, `k` UInt64, `i32` Int32, `dt` DateTime, `n.s` Array(String), `s` UInt32 DEFAULT \'0\') ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r2\', d, k, 8192)
 2015-01-01	6	38	2014-07-15 13:26:50	['asd','qwe','qwe']	100500
 2015-01-01	7	39	2014-07-14 13:26:50	['120','130','140']	0
 2015-01-01	8	40	2012-12-12 12:12:12	['12','13','14']	0
@@ -146,14 +146,14 @@ d	Date
 k	UInt64					
 i32	Int32					
 dt	DateTime					
-s	UInt32					
-CREATE TABLE test.replicated_alter1 (`d` Date, `k` UInt64, `i32` Int32, `dt` DateTime, `s` UInt32) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r1\', d, k, 8192)
+s	UInt32	DEFAULT	\'0\'			
+CREATE TABLE test.replicated_alter1 (`d` Date, `k` UInt64, `i32` Int32, `dt` DateTime, `s` UInt32 DEFAULT \'0\') ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r1\', d, k, 8192)
 d	Date					
 k	UInt64					
 i32	Int32					
 dt	DateTime					
-s	UInt32					
-CREATE TABLE test.replicated_alter2 (`d` Date, `k` UInt64, `i32` Int32, `dt` DateTime, `s` UInt32) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r2\', d, k, 8192)
+s	UInt32	DEFAULT	\'0\'			
+CREATE TABLE test.replicated_alter2 (`d` Date, `k` UInt64, `i32` Int32, `dt` DateTime, `s` UInt32 DEFAULT \'0\') ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r2\', d, k, 8192)
 2015-01-01	6	38	2014-07-15 13:26:50	100500
 2015-01-01	7	39	2014-07-14 13:26:50	0
 2015-01-01	8	40	2012-12-12 12:12:12	0
@@ -163,18 +163,18 @@ d	Date
 k	UInt64					
 i32	Int32					
 dt	DateTime					
-s	UInt32					
+s	UInt32	DEFAULT	\'0\'			
 n.s	Array(String)					
 n.d	Array(Date)					
-CREATE TABLE test.replicated_alter1 (`d` Date, `k` UInt64, `i32` Int32, `dt` DateTime, `s` UInt32, `n.s` Array(String), `n.d` Array(Date)) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r1\', d, k, 8192)
+CREATE TABLE test.replicated_alter1 (`d` Date, `k` UInt64, `i32` Int32, `dt` DateTime, `s` UInt32 DEFAULT \'0\', `n.s` Array(String), `n.d` Array(Date)) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r1\', d, k, 8192)
 d	Date					
 k	UInt64					
 i32	Int32					
 dt	DateTime					
-s	UInt32					
+s	UInt32	DEFAULT	\'0\'			
 n.s	Array(String)					
 n.d	Array(Date)					
-CREATE TABLE test.replicated_alter2 (`d` Date, `k` UInt64, `i32` Int32, `dt` DateTime, `s` UInt32, `n.s` Array(String), `n.d` Array(Date)) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r2\', d, k, 8192)
+CREATE TABLE test.replicated_alter2 (`d` Date, `k` UInt64, `i32` Int32, `dt` DateTime, `s` UInt32 DEFAULT \'0\', `n.s` Array(String), `n.d` Array(Date)) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r2\', d, k, 8192)
 2015-01-01	6	38	2014-07-15 13:26:50	100500	[]	[]
 2015-01-01	7	39	2014-07-14 13:26:50	0	[]	[]
 2015-01-01	8	40	2012-12-12 12:12:12	0	[]	[]
@@ -184,14 +184,14 @@ d	Date
 k	UInt64					
 i32	Int32					
 dt	DateTime					
-s	UInt32					
-CREATE TABLE test.replicated_alter1 (`d` Date, `k` UInt64, `i32` Int32, `dt` DateTime, `s` UInt32) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r1\', d, k, 8192)
+s	UInt32	DEFAULT	\'0\'			
+CREATE TABLE test.replicated_alter1 (`d` Date, `k` UInt64, `i32` Int32, `dt` DateTime, `s` UInt32 DEFAULT \'0\') ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r1\', d, k, 8192)
 d	Date					
 k	UInt64					
 i32	Int32					
 dt	DateTime					
-s	UInt32					
-CREATE TABLE test.replicated_alter2 (`d` Date, `k` UInt64, `i32` Int32, `dt` DateTime, `s` UInt32) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r2\', d, k, 8192)
+s	UInt32	DEFAULT	\'0\'			
+CREATE TABLE test.replicated_alter2 (`d` Date, `k` UInt64, `i32` Int32, `dt` DateTime, `s` UInt32 DEFAULT \'0\') ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r2\', d, k, 8192)
 2015-01-01	6	38	2014-07-15 13:26:50	100500
 2015-01-01	7	39	2014-07-14 13:26:50	0
 2015-01-01	8	40	2012-12-12 12:12:12	0
@@ -201,14 +201,14 @@ d	Date
 k	UInt64					
 i32	Int32					
 dt	Date					
-s	DateTime					
-CREATE TABLE test.replicated_alter1 (`d` Date, `k` UInt64, `i32` Int32, `dt` Date, `s` DateTime) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r1\', d, k, 8192)
+s	DateTime	DEFAULT	\'0000-00-00 00:00:00\'			
+CREATE TABLE test.replicated_alter1 (`d` Date, `k` UInt64, `i32` Int32, `dt` Date, `s` DateTime DEFAULT \'0000-00-00 00:00:00\') ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r1\', d, k, 8192)
 d	Date					
 k	UInt64					
 i32	Int32					
 dt	Date					
-s	DateTime					
-CREATE TABLE test.replicated_alter2 (`d` Date, `k` UInt64, `i32` Int32, `dt` Date, `s` DateTime) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r2\', d, k, 8192)
+s	DateTime	DEFAULT	\'0000-00-00 00:00:00\'			
+CREATE TABLE test.replicated_alter2 (`d` Date, `k` UInt64, `i32` Int32, `dt` Date, `s` DateTime DEFAULT \'0000-00-00 00:00:00\') ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/test/alter\', \'r2\', d, k, 8192)
 2015-01-01	6	38	2014-07-15	1970-01-02 06:55:00
 2015-01-01	7	39	2014-07-14	0000-00-00 00:00:00
 2015-01-01	8	40	2012-12-12	0000-00-00 00:00:00

--- a/dbms/tests/queries/0_stateless/00062_replicated_merge_tree_alter_zookeeper.sql
+++ b/dbms/tests/queries/0_stateless/00062_replicated_merge_tree_alter_zookeeper.sql
@@ -95,7 +95,7 @@ DESC TABLE test.replicated_alter2;
 SHOW CREATE TABLE test.replicated_alter2;
 SELECT * FROM test.replicated_alter1 ORDER BY k;
 
-ALTER TABLE test.replicated_alter1 MODIFY COLUMN dt Date, MODIFY COLUMN s DateTime;
+ALTER TABLE test.replicated_alter1 MODIFY COLUMN dt Date, MODIFY COLUMN s DateTime DEFAULT '0000-00-00 00:00:00';
 
 DESC TABLE test.replicated_alter1;
 SHOW CREATE TABLE test.replicated_alter1;

--- a/dbms/tests/queries/0_stateless/00079_defaulted_columns.reference
+++ b/dbms/tests/queries/0_stateless/00079_defaulted_columns.reference
@@ -28,13 +28,13 @@ some string	11
 payload	String					
 date	Date	MATERIALIZED	today()			
 key	UInt64	MATERIALIZED	0 * rand()			
-payload_length	UInt16	DEFAULT	length(payload) % 65535			
+payload_length	UInt64	DEFAULT	length(payload) % 65535			
 hello clickhouse	16
 some string	11
 payload	String					
 date	Date	MATERIALIZED	today()			
 key	UInt64	MATERIALIZED	0 * rand()			
-payload_length	UInt16	DEFAULT	CAST(length(payload), \'UInt16\')			
+payload_length	UInt16	DEFAULT	length(payload)			
 payload	String					
 date	Date	MATERIALIZED	today()			
 key	UInt64	MATERIALIZED	0 * rand()			

--- a/dbms/tests/queries/0_stateless/00079_defaulted_columns.sql
+++ b/dbms/tests/queries/0_stateless/00079_defaulted_columns.sql
@@ -20,7 +20,7 @@ create table defaulted (payload String, date materialized today(), key materiali
 desc table defaulted;
 insert into defaulted (payload) values ('hello clickhouse');
 select * from defaulted;
-alter table defaulted add column payload_length materialized length(payload);
+alter table defaulted add column payload_length UInt64 materialized length(payload);
 desc table defaulted;
 select *, payload_length from defaulted;
 insert into defaulted (payload) values ('some string');

--- a/dbms/tests/queries/0_stateless/00229_prewhere_column_missing.sql
+++ b/dbms/tests/queries/0_stateless/00229_prewhere_column_missing.sql
@@ -16,7 +16,7 @@ select *, length(arr) as l from prewhere_column_missing;
 select *, length(arr) as l from prewhere_column_missing where l = 0;
 select *, length(arr) as l from prewhere_column_missing prewhere l = 0;
 
-alter table prewhere_column_missing add column hash_x default intHash64(x);
+alter table prewhere_column_missing add column hash_x UInt64 default intHash64(x);
 
 select * from prewhere_column_missing;
 select * from prewhere_column_missing where hash_x = intHash64(x);

--- a/dbms/tests/queries/0_stateless/00262_alter_alias.sql
+++ b/dbms/tests/queries/0_stateless/00262_alter_alias.sql
@@ -11,7 +11,7 @@ select array from aliases_test;
 alter table aliases_test modify column array default [0, 1, 2];
 select array from aliases_test;
 
-alter table aliases_test add column struct.key default [0, 1, 2], add column struct.value default array;
+alter table aliases_test add column struct.key Array(UInt8) default [0, 1, 2], add column struct.value Array(UInt8) default array;
 select struct.key, struct.value from aliases_test;
 
 alter table aliases_test modify column struct.value alias array;

--- a/dbms/tests/queries/0_stateless/00575_illegal_column_exception_when_drop_depen_column.sh
+++ b/dbms/tests/queries/0_stateless/00575_illegal_column_exception_when_drop_depen_column.sh
@@ -4,7 +4,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . $CURDIR/../shell_config.sh
 
 
-exception_pattern="Code: 44.*Cannot drop column id, because column id2 depends on it"
+exception_pattern="Code: 44.*Cannot drop column \`id\`, because column \`id2\` depends on it"
 
 ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS test_00575;"
 ${CLICKHOUSE_CLIENT} --query "CREATE TABLE test_00575 (dt Date DEFAULT now(), id UInt32, id2 UInt32 DEFAULT id + 1) ENGINE = MergeTree(dt, dt, 8192);"

--- a/dbms/tests/queries/0_stateless/00721_force_by_identical_result_after_merge_zookeeper.sql
+++ b/dbms/tests/queries/0_stateless/00721_force_by_identical_result_after_merge_zookeeper.sql
@@ -9,7 +9,7 @@ SYSTEM SYNC REPLICA byte_identical_r2;
 
 -- Add a column with a default expression that will yield different values on different replicas.
 -- Call optimize to materialize it. Replicas should compare checksums and restore consistency.
-ALTER TABLE byte_identical_r1 ADD COLUMN y DEFAULT rand();
+ALTER TABLE byte_identical_r1 ADD COLUMN y UInt64 DEFAULT rand();
 OPTIMIZE TABLE byte_identical_r1 PARTITION tuple() FINAL;
 
 SELECT x, t1.y - t2.y FROM byte_identical_r1 t1 SEMI LEFT JOIN byte_identical_r2 t2 USING x ORDER BY x;

--- a/dbms/tests/queries/0_stateless/00916_add_materialized_column_after.sql
+++ b/dbms/tests/queries/0_stateless/00916_add_materialized_column_after.sql
@@ -1,7 +1,7 @@
 DROP TABLE IF EXISTS add_materialized_column_after;
 
 CREATE TABLE add_materialized_column_after (x UInt32, z UInt64) ENGINE MergeTree ORDER BY x;
-ALTER TABLE add_materialized_column_after ADD COLUMN y MATERIALIZED toString(x) AFTER x;
+ALTER TABLE add_materialized_column_after ADD COLUMN y String MATERIALIZED toString(x) AFTER x;
 
 DESC TABLE add_materialized_column_after;
 

--- a/dbms/tests/queries/0_stateless/01079_alter_default_zookeeper.reference
+++ b/dbms/tests/queries/0_stateless/01079_alter_default_zookeeper.reference
@@ -1,0 +1,11 @@
+CREATE TABLE default.alter_default (`date` Date, `key` UInt64, `value` String DEFAULT \'10\') ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/alter_default\', \'1\') ORDER BY key SETTINGS index_granularity = 8192
+1000
+CREATE TABLE default.alter_default (`date` Date, `key` UInt64, `value` UInt64 DEFAULT \'10\') ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/alter_default\', \'1\') ORDER BY key SETTINGS index_granularity = 8192
+CREATE TABLE default.alter_default (`date` Date, `key` UInt64, `value` UInt64 DEFAULT 10) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/alter_default\', \'1\') ORDER BY key SETTINGS index_granularity = 8192
+1000
+CREATE TABLE default.alter_default (`date` Date, `key` UInt64, `value` UInt64 DEFAULT 100) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/alter_default\', \'1\') ORDER BY key SETTINGS index_granularity = 8192
+CREATE TABLE default.alter_default (`date` Date, `key` UInt64, `value` UInt16 DEFAULT 100) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/alter_default\', \'1\') ORDER BY key SETTINGS index_granularity = 8192
+10000
+CREATE TABLE default.alter_default (`date` Date, `key` UInt64, `value` UInt8 DEFAULT 10) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/alter_default\', \'1\') ORDER BY key SETTINGS index_granularity = 8192
+CREATE TABLE default.alter_default (`date` Date, `key` UInt64, `value` UInt8 DEFAULT 10, `better_column` UInt8 DEFAULT \'1\') ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/alter_default\', \'1\') ORDER BY key SETTINGS index_granularity = 8192
+CREATE TABLE default.alter_default (`date` Date, `key` UInt64, `value` UInt8 DEFAULT 10, `better_column` UInt8 DEFAULT \'1\', `other_date` String DEFAULT 1) ENGINE = ReplicatedMergeTree(\'/clickhouse/tables/alter_default\', \'1\') ORDER BY key SETTINGS index_granularity = 8192

--- a/dbms/tests/queries/0_stateless/01079_alter_default_zookeeper.sql
+++ b/dbms/tests/queries/0_stateless/01079_alter_default_zookeeper.sql
@@ -1,0 +1,60 @@
+DROP TABLE IF EXISTS alter_default;
+
+CREATE TABLE alter_default
+(
+  date Date,
+  key UInt64
+)
+ENGINE ReplicatedMergeTree('/clickhouse/tables/alter_default', '1')
+ORDER BY key;
+
+INSERT INTO alter_default select toDate('2020-01-05'), number from system.numbers limit 100;
+
+-- Cannot add column without type
+ALTER TABLE alter_default ADD COLUMN value DEFAULT '10'; --{serverError 44}
+
+ALTER TABLE alter_default ADD COLUMN value String DEFAULT '10';
+
+SHOW CREATE TABLE alter_default;
+
+SELECT sum(cast(value as UInt64)) FROM alter_default;
+
+ALTER TABLE alter_default MODIFY COLUMN value UInt64;
+
+SHOW CREATE TABLE alter_default;
+
+ALTER TABLE alter_default MODIFY COLUMN value UInt64 DEFAULT 10;
+
+SHOW CREATE TABLE alter_default;
+
+SELECT sum(value) from alter_default;
+
+ALTER TABLE alter_default MODIFY COLUMN value DEFAULT 100;
+
+SHOW CREATE TABLE alter_default;
+
+ALTER TABLE alter_default MODIFY COLUMN value UInt16 DEFAULT 100;
+
+SHOW CREATE TABLE alter_default;
+
+SELECT sum(value) from alter_default;
+
+ALTER TABLE alter_default MODIFY COLUMN value UInt8 DEFAULT 10;
+
+SHOW CREATE TABLE alter_default;
+
+ALTER TABLE alter_default ADD COLUMN bad_column UInt8 DEFAULT 'q'; --{serverError 6}
+
+ALTER TABLE alter_default ADD COLUMN better_column UInt8 DEFAULT '1';
+
+SHOW CREATE TABLE alter_default;
+
+ALTER TABLE alter_default ADD COLUMN other_date String DEFAULT '0';
+
+ALTER TABLE alter_default MODIFY COLUMN other_date DateTime; --{serverError 41}
+
+ALTER TABLE alter_default MODIFY COLUMN other_date DEFAULT 1;
+
+SHOW CREATE TABLE alter_default;
+
+DROP TABLE IF EXISTS alter_default;

--- a/dbms/tests/queries/0_stateless/01079_alter_default_zookeeper.sql
+++ b/dbms/tests/queries/0_stateless/01079_alter_default_zookeeper.sql
@@ -11,7 +11,7 @@ ORDER BY key;
 INSERT INTO alter_default select toDate('2020-01-05'), number from system.numbers limit 100;
 
 -- Cannot add column without type
-ALTER TABLE alter_default ADD COLUMN value DEFAULT '10'; --{serverError 44}
+ALTER TABLE alter_default ADD COLUMN value DEFAULT '10'; --{serverError 36}
 
 ALTER TABLE alter_default ADD COLUMN value String DEFAULT '10';
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Backward Incompatible Change

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improved `ALTER MODIFY/ADD` queries logic. Now you cannot `ADD` column without type, `MODIFY` default expression doesn't change type of column and `MODIFY` type doesn't loose default expression value. Fixes #8669.

Documentation can be found in Changelog entry.
