### PR TITLE
Fix CROSS to INNER JOIN rewrite with [NOT] LIKE

### DIFF
--- a/dbms/src/Interpreters/CrossToInnerJoinVisitor.cpp
+++ b/dbms/src/Interpreters/CrossToInnerJoinVisitor.cpp
@@ -124,6 +124,10 @@ public:
         {
             /// leave other comparisons as is
         }
+        else if (functionIsLikeOperator(node.name)) /// LIKE, NOT LIKE
+        {
+            /// leave as is
+        }
         else if (functionIsInOperator(node.name)) /// IN, NOT IN
         {
             if (auto ident = node.arguments->children.at(0)->as<ASTIdentifier>())

--- a/dbms/src/Interpreters/misc.h
+++ b/dbms/src/Interpreters/misc.h
@@ -13,4 +13,9 @@ inline bool functionIsInOrGlobalInOperator(const std::string & name)
     return functionIsInOperator(name) || name == "globalIn" || name == "globalNotIn";
 }
 
+inline bool functionIsLikeOperator(const std::string & name)
+{
+    return name == "like" || name == "notLike";
+}
+
 }

--- a/dbms/tests/queries/0_stateless/01083_cross_to_inner_with_like.reference
+++ b/dbms/tests/queries/0_stateless/01083_cross_to_inner_with_like.reference
@@ -1,0 +1,3 @@
+SELECT \n    k, \n    r.k, \n    name\nFROM n\nALL INNER JOIN \n(\n    SELECT *\n    FROM r\n    HAVING name = \'A\'\n) AS r ON k = r.k\nWHERE (k = r.k) AND (name = \'A\')
+SELECT \n    k, \n    r.k, \n    name\nFROM n\nALL INNER JOIN \n(\n    SELECT *\n    FROM r\n    HAVING name LIKE \'A%\'\n) AS r ON k = r.k\nWHERE (k = r.k) AND (name LIKE \'A%\')
+SELECT \n    k, \n    r.k, \n    name\nFROM n\nALL INNER JOIN \n(\n    SELECT *\n    FROM r\n    HAVING name NOT LIKE \'A%\'\n) AS r ON k = r.k\nWHERE (k = r.k) AND (name NOT LIKE \'A%\')

--- a/dbms/tests/queries/0_stateless/01083_cross_to_inner_with_like.reference
+++ b/dbms/tests/queries/0_stateless/01083_cross_to_inner_with_like.reference
@@ -1,3 +1,3 @@
-SELECT \n    k, \n    r.k, \n    name\nFROM n\nALL INNER JOIN \n(\n    SELECT *\n    FROM r\n    HAVING name = \'A\'\n) AS r ON k = r.k\nWHERE (k = r.k) AND (name = \'A\')
-SELECT \n    k, \n    r.k, \n    name\nFROM n\nALL INNER JOIN \n(\n    SELECT *\n    FROM r\n    HAVING name LIKE \'A%\'\n) AS r ON k = r.k\nWHERE (k = r.k) AND (name LIKE \'A%\')
-SELECT \n    k, \n    r.k, \n    name\nFROM n\nALL INNER JOIN \n(\n    SELECT *\n    FROM r\n    HAVING name NOT LIKE \'A%\'\n) AS r ON k = r.k\nWHERE (k = r.k) AND (name NOT LIKE \'A%\')
+SELECT \n    k, \n    r.k, \n    name\nFROM n\nALL INNER JOIN r ON k = r.k\nWHERE (k = r.k) AND (name = \'A\')
+SELECT \n    k, \n    r.k, \n    name\nFROM n\nALL INNER JOIN r ON k = r.k\nWHERE (k = r.k) AND (name LIKE \'A%\')
+SELECT \n    k, \n    r.k, \n    name\nFROM n\nALL INNER JOIN r ON k = r.k\nWHERE (k = r.k) AND (name NOT LIKE \'A%\')

--- a/dbms/tests/queries/0_stateless/01083_cross_to_inner_with_like.sql
+++ b/dbms/tests/queries/0_stateless/01083_cross_to_inner_with_like.sql
@@ -5,6 +5,7 @@ CREATE TABLE n (k UInt32) ENGINE = Memory;
 CREATE TABLE r (k UInt32, name String) ENGINE = Memory;
 
 SET enable_debug_queries = 1;
+SET enable_optimize_predicate_expression = 0;
 
 ANALYZE SELECT * FROM n, r WHERE n.k = r.k AND r.name = 'A';
 ANALYZE SELECT * FROM n, r WHERE n.k = r.k AND r.name LIKE 'A%';

--- a/dbms/tests/queries/0_stateless/01083_cross_to_inner_with_like.sql
+++ b/dbms/tests/queries/0_stateless/01083_cross_to_inner_with_like.sql
@@ -1,0 +1,14 @@
+DROP TABLE IF EXISTS n;
+DROP TABLE IF EXISTS r;
+
+CREATE TABLE n (k UInt32) ENGINE = Memory;
+CREATE TABLE r (k UInt32, name String) ENGINE = Memory;
+
+SET enable_debug_queries = 1;
+
+ANALYZE SELECT * FROM n, r WHERE n.k = r.k AND r.name = 'A';
+ANALYZE SELECT * FROM n, r WHERE n.k = r.k AND r.name LIKE 'A%';
+ANALYZE SELECT * FROM n, r WHERE n.k = r.k AND r.name NOT LIKE 'A%';
+
+DROP TABLE n;
+DROP TABLE r;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow to rewrite CROSS to INNER JOIN if there's [NOT] LIKE operator in WHERE section.

Fixes #9191