### PR TITLE
Log error message before aborting on LOGICAL_ERROR.

### DIFF
--- a/dbms/src/Common/Exception.cpp
+++ b/dbms/src/Common/Exception.cpp
@@ -35,7 +35,14 @@ Exception::Exception(const std::string & msg, int code)
     : Poco::Exception(msg, code)
 {
     // In debug builds, treat LOGICAL_ERROR as an assertion failure.
-    assert(code != ErrorCodes::LOGICAL_ERROR);
+    // Log the message before we fail.
+#ifndef NDEBUG
+    if (code == ErrorCodes::LOGICAL_ERROR)
+    {
+        LOG_ERROR(&Poco::Logger::root(), "Logical error: '" + msg + "'.");
+        assert(false);
+    }
+#endif
 }
 
 Exception::Exception(CreateFromPocoTag, const Poco::Exception & exc)


### PR DESCRIPTION
Changelog category (leave one):
- Non-significant (changelog entry is not required)