### PR TITLE
Fix "GenericRoleSet previously declared as class" warning

### DIFF
--- a/dbms/src/Interpreters/InterpreterSetRoleQuery.h
+++ b/dbms/src/Interpreters/InterpreterSetRoleQuery.h
@@ -7,7 +7,7 @@
 namespace DB
 {
 class ASTSetRoleQuery;
-class GenericRoleSet;
+struct GenericRoleSet;
 struct User;
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Non-significant (changelog entry is not required)
