### PR TITLE
Parquet performance improvements

### DIFF
--- a/cmake/find/parquet.cmake
+++ b/cmake/find/parquet.cmake
@@ -4,7 +4,7 @@ endif()
 
 if (ENABLE_PARQUET)
 
-if (NOT OS_FREEBSD AND NOT OS_DARWIN) # Freebsd: ../contrib/arrow/cpp/src/arrow/util/bit-util.h:27:10: fatal error: endian.h: No such file or directory
+if (NOT OS_FREEBSD) # Freebsd: ../contrib/arrow/cpp/src/arrow/util/bit-util.h:27:10: fatal error: endian.h: No such file or directory
     option(USE_INTERNAL_PARQUET_LIBRARY "Set to FALSE to use system parquet library instead of bundled" ${NOT_UNBUNDLED})
 endif()
 

--- a/dbms/src/Processors/Formats/Impl/ArrowColumnToCHColumn.cpp
+++ b/dbms/src/Processors/Formats/Impl/ArrowColumnToCHColumn.cpp
@@ -260,13 +260,6 @@ namespace DB
             throw Exception{"Error while reading " + format_name + " data: " + read_status.ToString(),
                             ErrorCodes::CANNOT_READ_ALL_DATA};
 
-        if (0 == table->num_rows())
-            throw Exception{"Empty table in input data", ErrorCodes::EMPTY_DATA_PASSED};
-
-        if (header.columns() > static_cast<size_t>(table->num_columns()))
-            // TODO: What if some columns were not presented? Insert NULLs? What if a column is not nullable?
-            throw Exception{"Number of columns is less than the table has", ErrorCodes::SIZES_OF_COLUMNS_DOESNT_MATCH};
-
         ++row_group_current;
 
         NameToColumnPtr name_to_column_ptr;

--- a/dbms/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
@@ -4,91 +4,171 @@
 #include <Formats/FormatFactory.h>
 #include <IO/BufferBase.h>
 #include <IO/ReadBufferFromMemory.h>
+#include <IO/ReadBufferFromFileDescriptor.h>
 #include <IO/WriteBufferFromString.h>
 #include <IO/WriteHelpers.h>
 #include <IO/copyData.h>
 #include <arrow/api.h>
+#include <arrow/io/api.h>
+#include <arrow/status.h>
 #include <parquet/arrow/reader.h>
 #include <parquet/file_reader.h>
 #include "ArrowColumnToCHColumn.h"
 
+#include <common/logger_useful.h>
+
+
+#include <sys/stat.h>
+
 namespace DB
 {
 
-    ParquetBlockInputFormat::ParquetBlockInputFormat(ReadBuffer & in_, Block header_)
-            : IInputFormat(std::move(header_), in_)
+class RandomAccessFileFromSeekableReadBuffer : public arrow::io::RandomAccessFile
+{
+public:
+    RandomAccessFileFromSeekableReadBuffer(SeekableReadBuffer& in_, off_t file_size_)
+        : in(in_)
+        , file_size(file_size_)
+        , is_closed(false)
     {
+
     }
 
-    Chunk ParquetBlockInputFormat::generate()
+    virtual arrow::Status GetSize(int64_t* size) override
     {
-        Chunk res;
-        auto &header = getPort().getHeader();
+        *size = file_size;
+        return arrow::Status::OK();
+    }
 
-        if (!in.eof())
+    virtual arrow::Status Close() override
+    {
+        is_closed = true;
+        return arrow::Status::OK();
+    }
+
+    virtual arrow::Status Tell(int64_t* position) const override
+    {
+        *position = in.getPosition();
+        return arrow::Status::OK();
+    }
+
+    virtual bool closed() const override { return is_closed; }
+
+    virtual arrow::Status Read(int64_t nbytes, int64_t* bytes_read, void* out) override
+    {
+        *bytes_read = in.readBig(reinterpret_cast<char *>(out), nbytes);
+        return arrow::Status::OK();
+    }
+
+    virtual arrow::Status Read(int64_t nbytes, std::shared_ptr<arrow::Buffer>* out) override
+    {
+        std::shared_ptr<arrow::Buffer> buf;
+        ARROW_RETURN_NOT_OK(arrow::AllocateBuffer(nbytes, &buf));
+        size_t n = in.readBig(reinterpret_cast<char *>(buf->mutable_data()), nbytes);
+        *out = arrow::SliceBuffer(buf, 0, n);
+        return arrow::Status::OK();
+    }
+
+    virtual arrow::Status Seek(int64_t position) override
+    {
+        in.seek(position, SEEK_SET);
+        return arrow::Status::OK();
+    }
+
+private:
+    SeekableReadBuffer& in;
+    off_t file_size;
+    bool is_closed;
+};
+
+
+static std::shared_ptr<arrow::io::RandomAccessFile>  as_arrow_file(ReadBuffer & in)
+{
+    if (auto fd_in = dynamic_cast<ReadBufferFromFileDescriptor*>(&in))
+    {
+        struct stat stat;
+        ::fstat(fd_in->getFD(), &stat);
+        // if fd is a regular file i.e. not stdin
+        if (S_ISREG(stat.st_mode))
         {
-            /*
-               First we load whole stream into string (its very bad and limiting .parquet file size to half? of RAM)
-               Then producing blocks for every row_group (dont load big .parquet files with one row_group - it can eat x10+ RAM from .parquet file size)
-            */
-
-            if (row_group_current < row_group_total)
-                throw Exception{"Got new data, but data from previous chunks was not read " +
-                                std::to_string(row_group_current) + "/" + std::to_string(row_group_total),
-                                ErrorCodes::CANNOT_READ_ALL_DATA};
-
-            file_data.clear();
-            {
-                WriteBufferFromString file_buffer(file_data);
-                copyData(in, file_buffer);
-            }
-
-            buffer = std::make_unique<arrow::Buffer>(file_data);
-            // TODO: maybe use parquet::RandomAccessSource?
-            auto status = parquet::arrow::FileReader::Make(
-                    ::arrow::default_memory_pool(),
-                    parquet::ParquetFileReader::Open(std::make_shared<::arrow::io::BufferReader>(*buffer)),
-                    &file_reader);
-
-            row_group_total = file_reader->num_row_groups();
-            row_group_current = 0;
+            return std::make_shared<RandomAccessFileFromSeekableReadBuffer>(*fd_in, stat.st_size);
         }
-        //DUMP(row_group_current, row_group_total);
-        if (row_group_current >= row_group_total)
-            return res;
+    }
 
-        // TODO: also catch a ParquetException thrown by filereader?
-        //arrow::Status read_status = filereader.ReadTable(&table);
-        std::shared_ptr<arrow::Table> table;
-        arrow::Status read_status = file_reader->ReadRowGroup(row_group_current, &table);
+    // fallback to loading the entire file in memory
+    std::string file_data;
+    {
+        WriteBufferFromString file_buffer(file_data);
+        copyData(in, file_buffer);
+    }
+    return std::make_shared<arrow::io::BufferReader>(arrow::Buffer::FromString(std::move(file_data)));
+}
 
-        ArrowColumnToCHColumn::arrowTableToCHChunk(res, table, read_status, header, row_group_current, "Parquet");
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+}
+
+#define THROW_ARROW_NOT_OK(status)                                          \
+  do {                                                                      \
+    ::arrow::Status __s = (status);                                         \
+    if(!__s.ok())                                                           \
+        throw Exception(__s.ToString(), ErrorCodes::BAD_ARGUMENTS);\
+  } while (false)
+
+ParquetBlockInputFormat::ParquetBlockInputFormat(ReadBuffer & in_, Block header_)
+    : IInputFormat(std::move(header_), in_)
+{
+    THROW_ARROW_NOT_OK(parquet::arrow::OpenFile(as_arrow_file(in_), arrow::default_memory_pool(), &file_reader));
+    row_group_total = file_reader->num_row_groups();
+
+    std::shared_ptr<arrow::Schema> schema;
+    THROW_ARROW_NOT_OK(file_reader->GetSchema(&schema));
+
+    for (int i = 0; i < schema->num_fields(); ++i)
+    {
+        if (getPort().getHeader().has(schema->field(i)->name()))
+        {
+            column_indices.push_back(i);
+        }
+    }
+}
+
+Chunk ParquetBlockInputFormat::generate()
+{
+    Chunk res;
+    auto &header = getPort().getHeader();
+
+    if (row_group_current >= row_group_total)
         return res;
-    }
 
-    void ParquetBlockInputFormat::resetParser()
-    {
-        IInputFormat::resetParser();
+    std::shared_ptr<arrow::Table> table;
+    arrow::Status read_status = file_reader->ReadRowGroup(row_group_current, column_indices, &table);
+    ArrowColumnToCHColumn::arrowTableToCHChunk(res, table, read_status, header, row_group_current, "Parquet");
+    return res;
+}
 
-        file_reader.reset();
-        file_data.clear();
-        buffer.reset();
-        row_group_total = 0;
-        row_group_current = 0;
-    }
+void ParquetBlockInputFormat::resetParser()
+{
+    IInputFormat::resetParser();
 
-    void registerInputFormatProcessorParquet(FormatFactory &factory)
-    {
-        factory.registerInputFormatProcessor(
-                "Parquet",
-                [](ReadBuffer &buf,
-                   const Block &sample,
-                   const RowInputFormatParams &,
-                   const FormatSettings & /* settings */)
-                {
-                    return std::make_shared<ParquetBlockInputFormat>(buf, sample);
-                });
-    }
+    file_reader.reset();
+    row_group_total = 0;
+    row_group_current = 0;
+}
+
+void registerInputFormatProcessorParquet(FormatFactory &factory)
+{
+    factory.registerInputFormatProcessor(
+            "Parquet",
+            [](ReadBuffer &buf,
+                const Block &sample,
+                const RowInputFormatParams &,
+                const FormatSettings & /* settings */)
+            {
+                return std::make_shared<ParquetBlockInputFormat>(buf, sample);
+            });
+}
 
 }
 

--- a/dbms/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
+++ b/dbms/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
@@ -109,12 +109,12 @@ namespace ErrorCodes
     extern const int BAD_ARGUMENTS;
 }
 
-#define THROW_ARROW_NOT_OK(status)                                  \
-  do                                                                \
-  {                                                                 \
-    if (::arrow::Status _s = (status); !_s.ok())                    \
-        throw Exception(_s.ToString(), ErrorCodes::BAD_ARGUMENTS);  \
-  } while (false)
+#define THROW_ARROW_NOT_OK(status)                                     \
+    do                                                                 \
+    {                                                                  \
+        if (::arrow::Status _s = (status); !_s.ok())                   \
+            throw Exception(_s.ToString(), ErrorCodes::BAD_ARGUMENTS); \
+    } while (false)
 
 ParquetBlockInputFormat::ParquetBlockInputFormat(ReadBuffer & in_, Block header_)
     : IInputFormat(std::move(header_), in_)

--- a/dbms/src/Processors/Formats/Impl/ParquetBlockInputFormat.h
+++ b/dbms/src/Processors/Formats/Impl/ParquetBlockInputFormat.h
@@ -27,13 +27,10 @@ protected:
     Chunk generate() override;
 
 private:
-
-    // TODO: check that this class implements every part of its parent
-
     std::unique_ptr<parquet::arrow::FileReader> file_reader;
-    std::string file_data;
-    std::unique_ptr<arrow::Buffer> buffer;
     int row_group_total = 0;
+    // indices of columns to read from Parquet file
+    std::vector<int> column_indices;
     int row_group_current = 0;
 };
 

--- a/dbms/tests/queries/0_stateless/00900_parquet_load.reference
+++ b/dbms/tests/queries/0_stateless/00900_parquet_load.reference
@@ -174,16 +174,16 @@ Code: 8. DB::Ex---tion: Column "element" is not presented in input data
 Code: 33. DB::Ex---tion: Error while reading Parquet data: NotImplemented: Reading lists of structs from Parquet files not yet supported: key_value: list<key_value: struct<key: string not null, value: struct<key_value: list<key_value: struct<key: int32 not null, value: bool not null> not null> not null>> not null> not null
 
 === Try load data from nonnullable.impala.parquet
-Code: 33. DB::Ex---tion: Error while reading Parquet data: NotImplemented: Reading lists of structs from Parquet files not yet supported: map: list<map: struct<key: string not null, value: int32 not null> not null> not null
+Code: 8. DB::Ex---tion: Column "element" is not presented in input data
 
 === Try load data from nullable.impala.parquet
-Code: 33. DB::Ex---tion: Error while reading Parquet data: NotImplemented: Reading lists of structs from Parquet files not yet supported: map: list<map: struct<key: string not null, value: int32> not null> not null
+Code: 8. DB::Ex---tion: Column "element" is not presented in input data
 
 === Try load data from nulls.snappy.parquet
 Code: 8. DB::Ex---tion: Column "b_c_int" is not presented in input data
 
 === Try load data from repeated_no_annotation.parquet
-Code: 33. DB::Ex---tion: Error while reading Parquet data: NotImplemented: Reading lists of structs from Parquet files not yet supported: phone: list<phone: struct<number: int64 not null, kind: string> not null> not null
+Code: 8. DB::Ex---tion: Column "number" is not presented in input data
 
 === Try load data from userdata1.parquet
 1454486129	1	Amanda	Jordan	ajordan0@com.com	Female	1.197.201.2	6759521864920116	Indonesia	3/8/1971	49756.53	Internal Auditor	1E+02


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

**Changelog category (leave one):**
- Performance Improvement

**Changelog entry:**

Parquet performance: read only required columns.  
Parquet performance: avoid reading the entire file to RAM when possible
This fixes https://github.com/ClickHouse/ClickHouse/issues/5863



**Detailed description**
- Allow using internal parquet/arrow on darwin
- Read only required columns
- Avoid reading the entire file to RAM when possible
^ i.e. when `ReadBuffer` is a `ReadBufferFromFileDescriptor` and file descriptor is a regular file.

