### PR TITLE
Added the prestable tag

### DIFF
--- a/docs/en/getting_started/install.md
+++ b/docs/en/getting_started/install.md
@@ -56,7 +56,7 @@ sudo rpm --import https://repo.yandex.ru/clickhouse/CLICKHOUSE-KEY.GPG
 sudo yum-config-manager --add-repo https://repo.yandex.ru/clickhouse/rpm/stable/x86_64
 ```
 
-If you want to use the most recent version, replace `stable` with `testing` (this is recommended for your testing environments).
+If you want to use the most recent version, replace `stable` with `testing` (this is recommended for your testing environments). The `prestable` tag is sometimes available too.
 
 Then run these commands to actually install packages:
 


### PR DESCRIPTION
The prestable tag for RPMs is sometimes available (and recently it happens more often)

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:

The prestable folder is used for RPM like the stable and testing ones but it was not documented. I know: it is a very little update in the documentation...

