### PR TITLE
Fixed inconsistent whitespaces in log messages of Processors

### DIFF
--- a/dbms/src/Processors/Executors/PipelineExecutor.cpp
+++ b/dbms/src/Processors/Executors/PipelineExecutor.cpp
@@ -658,11 +658,12 @@ void PipelineExecutor::executeSingleThread(size_t thread_num, size_t num_threads
     total_time_ns = total_time_watch.elapsed();
     wait_time_ns = total_time_ns - execution_time_ns - processing_time_ns;
 
-    LOG_TRACE(log, "Thread finished."
-                     << " Total time: " << (total_time_ns / 1e9) << " sec."
-                     << " Execution time: " << (execution_time_ns / 1e9) << " sec."
-                     << " Processing time: " << (processing_time_ns / 1e9) << " sec."
-                     << " Wait time: " << (wait_time_ns / 1e9) << "sec.");
+    LOG_TRACE(log, std::fixed << std::setprecision(3)
+        << "Thread finished."
+        << " Total time: " << (total_time_ns / 1e9) << " sec."
+        << " Execution time: " << (execution_time_ns / 1e9) << " sec."
+        << " Processing time: " << (processing_time_ns / 1e9) << " sec."
+        << " Wait time: " << (wait_time_ns / 1e9) << " sec.");
 #endif
 }
 


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed inconsistent whitespaces in log messages of Processors.

Detailed description / Documentation draft:
It was looking like this:
```
Thread finished. Total time: 0.00126747 sec. Execution time: 2.4616e-05 sec. Processing time: 0.000555551 sec. Wait time: 0.000687308sec.
```

Note the lack of whitespace before `sec.` in last part. It is a bug.