### PR TITLE
Remove garbage from FunctionsComparison; better build time and less template instantiations

### DIFF
--- a/dbms/src/Functions/equals.cpp
+++ b/dbms/src/Functions/equals.cpp
@@ -18,7 +18,10 @@ void FunctionComparison<EqualsOp, NameEquals>::executeTupleImpl(Block & block, s
                                                                 const ColumnsWithTypeAndName & y, size_t tuple_size,
                                                                 size_t input_rows_count)
 {
-    return executeTupleEqualityImpl<FunctionEquals, FunctionAnd>(block, result, x, y, tuple_size, input_rows_count);
+    return executeTupleEqualityImpl(
+        FunctionFactory::instance().get("equals", context),
+        FunctionFactory::instance().get("and", context),
+        block, result, x, y, tuple_size, input_rows_count);
 }
 
 }

--- a/dbms/src/Functions/greater.cpp
+++ b/dbms/src/Functions/greater.cpp
@@ -17,7 +17,15 @@ void FunctionComparison<GreaterOp, NameGreater>::executeTupleImpl(Block & block,
                                                                   const ColumnsWithTypeAndName & y, size_t tuple_size,
                                                                   size_t input_rows_count)
 {
-    return executeTupleLessGreaterImpl<FunctionGreater, FunctionGreater>(block, result, x, y, tuple_size, input_rows_count);
+    auto greater = FunctionFactory::instance().get("greater", context);
+
+    return executeTupleLessGreaterImpl(
+        greater,
+        greater,
+        FunctionFactory::instance().get("and", context),
+        FunctionFactory::instance().get("or", context),
+        FunctionFactory::instance().get("equals", context),
+        block, result, x, y, tuple_size, input_rows_count);
 }
 
 }

--- a/dbms/src/Functions/greaterOrEquals.cpp
+++ b/dbms/src/Functions/greaterOrEquals.cpp
@@ -17,9 +17,13 @@ void FunctionComparison<GreaterOrEqualsOp, NameGreaterOrEquals>::executeTupleImp
                                                                                   const ColumnsWithTypeAndName & y, size_t tuple_size,
                                                                                   size_t input_rows_count)
 {
-    return executeTupleLessGreaterImpl<
-        FunctionComparison<GreaterOp, NameGreater>,
-        FunctionGreaterOrEquals>(block, result, x, y, tuple_size, input_rows_count);
+    return executeTupleLessGreaterImpl(
+        FunctionFactory::instance().get("greater", context),
+        FunctionFactory::instance().get("greaterOrEquals", context),
+        FunctionFactory::instance().get("and", context),
+        FunctionFactory::instance().get("or", context),
+        FunctionFactory::instance().get("equals", context),
+        block, result, x, y, tuple_size, input_rows_count);
 }
 
 }

--- a/dbms/src/Functions/less.cpp
+++ b/dbms/src/Functions/less.cpp
@@ -17,7 +17,15 @@ void FunctionComparison<LessOp, NameLess>::executeTupleImpl(Block & block, size_
                                                             const ColumnsWithTypeAndName & y, size_t tuple_size,
                                                             size_t input_rows_count)
 {
-    return executeTupleLessGreaterImpl<FunctionLess, FunctionLess>(block, result, x, y, tuple_size, input_rows_count);
+    auto less = FunctionFactory::instance().get("less", context);
+
+    return executeTupleLessGreaterImpl(
+        less,
+        less,
+        FunctionFactory::instance().get("and", context),
+        FunctionFactory::instance().get("or", context),
+        FunctionFactory::instance().get("equals", context),
+        block, result, x, y, tuple_size, input_rows_count);
 }
 
 }

--- a/dbms/src/Functions/lessOrEquals.cpp
+++ b/dbms/src/Functions/lessOrEquals.cpp
@@ -17,9 +17,13 @@ void FunctionComparison<LessOrEqualsOp, NameLessOrEquals>::executeTupleImpl(Bloc
                                                                             const ColumnsWithTypeAndName & y, size_t tuple_size,
                                                                             size_t input_rows_count)
 {
-    return executeTupleLessGreaterImpl<
-        FunctionComparison<LessOp, NameLess>,
-        FunctionLessOrEquals>(block, result, x, y, tuple_size, input_rows_count);
+    return executeTupleLessGreaterImpl(
+        FunctionFactory::instance().get("less", context),
+        FunctionFactory::instance().get("lessOrEquals", context),
+        FunctionFactory::instance().get("and", context),
+        FunctionFactory::instance().get("or", context),
+        FunctionFactory::instance().get("equals", context),
+        block, result, x, y, tuple_size, input_rows_count);
 }
 
 }

--- a/dbms/src/Functions/notEquals.cpp
+++ b/dbms/src/Functions/notEquals.cpp
@@ -17,7 +17,10 @@ void FunctionComparison<NotEqualsOp, NameNotEquals>::executeTupleImpl(Block & bl
                                                                       const ColumnsWithTypeAndName & y, size_t tuple_size,
                                                                       size_t input_rows_count)
 {
-    return executeTupleEqualityImpl<FunctionNotEquals, FunctionOr>(block, result, x, y, tuple_size, input_rows_count);
+    return executeTupleEqualityImpl(
+        FunctionFactory::instance().get("notEquals", context),
+        FunctionFactory::instance().get("or", context),
+        block, result, x, y, tuple_size, input_rows_count);
 }
 
 }


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Better build time and less template instantiations in FunctionsComparison.