### PR TITLE
add USE_DEBUG_HELPERS flag to enable DUMP

### DIFF
--- a/base/common/CMakeLists.txt
+++ b/base/common/CMakeLists.txt
@@ -26,6 +26,11 @@ if (ENABLE_REPLXX)
     )
 endif ()
 
+if (USE_DEBUG_HELPERS)
+    set (INCLUDE_DEBUG_HELPERS "-include ${ClickHouse_SOURCE_DIR}/base/common/iostream_debug_helpers.h")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${INCLUDE_DEBUG_HELPERS}")
+endif ()
+
 add_library (common ${SRCS})
 
 target_include_directories(common PUBLIC .. ${CMAKE_CURRENT_BINARY_DIR}/..)

--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -36,6 +36,11 @@ if (NOT MSVC)
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
 endif ()
 
+if (USE_DEBUG_HELPERS)
+    set (INCLUDE_DEBUG_HELPERS "-I${ClickHouse_SOURCE_DIR}/base -include ${ClickHouse_SOURCE_DIR}/dbms/src/Core/iostream_debug_helpers.h")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${INCLUDE_DEBUG_HELPERS}")
+endif ()
+
 # Add some warnings that are not available even with -Wall -Wextra -Wpedantic.
 
 option (WEVERYTHING "Enables -Weverything option with some exceptions. This is intended for exploration of new compiler warnings that may be found to be useful. Only makes sense for clang." ON)

--- a/dbms/src/Parsers/CMakeLists.txt
+++ b/dbms/src/Parsers/CMakeLists.txt
@@ -4,6 +4,11 @@ add_library(clickhouse_parsers ${clickhouse_parsers_headers} ${clickhouse_parser
 target_link_libraries(clickhouse_parsers PUBLIC clickhouse_common_io)
 target_include_directories(clickhouse_parsers PUBLIC ${DBMS_INCLUDE_DIR})
 
+if (USE_DEBUG_HELPERS)
+    set (INCLUDE_DEBUG_HELPERS "-I${ClickHouse_SOURCE_DIR}/base -include ${ClickHouse_SOURCE_DIR}/dbms/src/Parsers/iostream_debug_helpers.h")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${INCLUDE_DEBUG_HELPERS}")
+endif ()
+
 if(ENABLE_TESTS)
     add_subdirectory(tests)
 endif()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Non-significant (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

`USE_DEBUG_HELPERS` cmake flag is used so that `DUMP` is available without header files. This flag somehow gets removed in recent commits. This PR resurrents it and extends it.