### PR TITLE
Doc change explanation that `max_result_rows result_overflow_mode=break ` depends of max_block_size

### DIFF
--- a/docs/ru/operations/settings/query_complexity.md
+++ b/docs/ru/operations/settings/query_complexity.md
@@ -109,7 +109,7 @@
 
 Что делать, если объём результата превысил одно из ограничений: throw или break. По умолчанию: throw.
 
-Использование break по смыслу похоже на LIMIT. Break прерывает выполнение только на уровне блока. Т.е. число строк которые вернет запрос будет кратно [max_block_size](settings.md#max_block_size) и зависит от [max_threads](settings.md#settings-max_threads).
+Использование break по смыслу похоже на LIMIT. Break прерывает выполнение только на уровне блока. Т.е. число строк которые вернет запрос будет больше чем ограничение [max_result_rows](#max_result_rows), кратно [max_block_size](settings.md#max_block_size) и зависит от [max_threads](settings.md#settings-max_threads).
 
 Пример:
 ```sql

--- a/docs/ru/operations/settings/query_complexity.md
+++ b/docs/ru/operations/settings/query_complexity.md
@@ -108,7 +108,24 @@
 ## result_overflow_mode
 
 Что делать, если объём результата превысил одно из ограничений: throw или break. По умолчанию: throw.
-Использование break по смыслу похоже на LIMIT.
+
+Использование break по смыслу похоже на LIMIT. Break прерывает выполнение только на уровне блока. Т.е. число строк которые вернет запрос будет кратно [max_block_size](settings.md#max_block_size) и зависит от [max_threads](settings.md#settings-max_threads).
+
+Пример:
+```sql
+SET max_threads = 3, max_block_size = 3333; 
+SET max_result_rows = 3334, result_overflow_mode = 'break';
+
+SELECT *
+FROM numbers_mt(100000)
+FORMAT Null;
+```
+
+Результат:
+
+```text
+6666 rows in set. ...
+```
 
 ## max_execution_time
 


### PR DESCRIPTION
explanation that `max_result_rows result_overflow_mode=break ` depends of max_block_size

https://github.com/ClickHouse/ClickHouse/issues/9271

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)
