### PR TITLE
Fix possible race in BlockIO.

### DIFF
--- a/dbms/src/DataStreams/BlockIO.h
+++ b/dbms/src/DataStreams/BlockIO.h
@@ -18,8 +18,8 @@ struct BlockIO
     BlockIO(const BlockIO &) = default;
     ~BlockIO() = default;
 
-    /** process_list_entry should be destroyed after in and after out,
-      *  since in and out contain pointer to objects inside process_list_entry (query-level MemoryTracker for example),
+    /** process_list_entry should be destroyed after in, after out and after pipeline,
+      *  since in, out and pipeline contain pointer to objects inside process_list_entry (query-level MemoryTracker for example),
       *  which could be used before destroying of in and out.
       */
     std::shared_ptr<ProcessListEntry> process_list_entry;
@@ -56,6 +56,7 @@ struct BlockIO
 
         out.reset();
         in.reset();
+        pipeline = QueryPipeline();
         process_list_entry.reset();
 
         process_list_entry      = rhs.process_list_entry;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible [race](https://clickhouse-test-reports.s3.yandex.net/0/94b52c08582a1f8e91e8246714dd323f4bf8a17b/functional_stateless_tests_(address)/stderr.log) in `BlockIO`.

What is possibly happened:
* `QueryPipeline` contained wrapper for `IBlockInputStream`, which contained `UnionBlockInputStream`.
* After query was finished, `pipeline` in `BlockIO` was deleted before `process_list_entry`, so did `UnionBlockInputStream`.
* `UnionBlockInputStream` contained threads which were still running, so we got race on `process_list_entry`.