### PR TITLE
last_successful_update_time in system.dictionaries

### DIFF
--- a/dbms/src/Interpreters/ExternalLoader.cpp
+++ b/dbms/src/Interpreters/ExternalLoader.cpp
@@ -696,6 +696,7 @@ private:
                 result.object = object;
                 result.exception = exception;
                 result.loading_start_time = loading_start_time;
+                result.last_successful_update_time = last_successful_update_time;
                 result.loading_duration = loadingDuration();
                 result.origin = object_config.path;
                 result.repository_name = object_config.repository_name;
@@ -713,6 +714,7 @@ private:
         ObjectConfig object_config;
         TimePoint loading_start_time;
         TimePoint loading_end_time;
+        TimePoint last_successful_update_time;
         size_t state_id = 0; /// Index of the current state of this `info`, this index is incremented every loading.
         size_t loading_id = 0; /// The value which will be stored in `state_id` after finishing the current loading.
         size_t error_count = 0; /// Numbers of errors since last successful loading.
@@ -1010,7 +1012,10 @@ private:
 
         info->exception = new_exception;
         info->error_count = error_count;
-        info->loading_end_time = std::chrono::system_clock::now();
+        const auto current_time = std::chrono::system_clock::now();
+        info->loading_end_time = current_time;
+        if (!info->exception)
+            info->last_successful_update_time = current_time;
         info->state_id = info->loading_id;
         info->next_update_time = next_update_time;
     }

--- a/dbms/src/Interpreters/ExternalLoader.h
+++ b/dbms/src/Interpreters/ExternalLoader.h
@@ -71,6 +71,7 @@ public:
         LoadablePtr object;
         String origin;
         TimePoint loading_start_time;
+        TimePoint last_successful_update_time;
         Duration loading_duration;
         std::exception_ptr exception;
         std::string repository_name;

--- a/dbms/src/Storages/System/StorageSystemDictionaries.cpp
+++ b/dbms/src/Storages/System/StorageSystemDictionaries.cpp
@@ -40,6 +40,7 @@ NamesAndTypesList StorageSystemDictionaries::getNamesAndTypes()
         {"lifetime_min", std::make_shared<DataTypeUInt64>()},
         {"lifetime_max", std::make_shared<DataTypeUInt64>()},
         {"loading_start_time", std::make_shared<DataTypeDateTime>()},
+        {"last_successful_update_time", std::make_shared<DataTypeDateTime>()},
         {"loading_duration", std::make_shared<DataTypeFloat32>()},
         //{ "creation_time", std::make_shared<DataTypeDateTime>() },
         {"last_exception", std::make_shared<DataTypeString>()}
@@ -112,6 +113,7 @@ void StorageSystemDictionaries::fillData(MutableColumns & res_columns, const Con
         }
 
         res_columns[i++]->insert(static_cast<UInt64>(std::chrono::system_clock::to_time_t(load_result.loading_start_time)));
+        res_columns[i++]->insert(static_cast<UInt64>(std::chrono::system_clock::to_time_t(load_result.last_successful_update_time)));
         res_columns[i++]->insert(std::chrono::duration_cast<std::chrono::duration<float>>(load_result.loading_duration).count());
 
         if (last_exception)

--- a/dbms/tests/integration/test_dictionaries_update_and_reload/test.py
+++ b/dbms/tests/integration/test_dictionaries_update_and_reload/test.py
@@ -38,6 +38,12 @@ def get_loading_start_time(dictionary_name):
         return None
     return time.strptime(s, "%Y-%m-%d %H:%M:%S")
 
+def get_last_successful_update_time(dictionary_name):
+    s = instance.query("SELECT last_successful_update_time FROM system.dictionaries WHERE name='" + dictionary_name + "'").rstrip("\n")
+    if s == "0000-00-00 00:00:00":
+        return None
+    return time.strptime(s, "%Y-%m-%d %H:%M:%S")
+
 
 def get_loading_duration(dictionary_name):
     return float(instance.query("SELECT loading_duration FROM system.dictionaries WHERE name='" + dictionary_name + "'"))
@@ -92,6 +98,9 @@ def test_reload_while_loading(started_cluster):
 
     # This time loading should finish quickly.
     assert get_status('slow') == "LOADED"
+
+    last_successful_update_time = get_last_successful_update_time('slow')
+    assert last_successful_update_time > start_time
     assert query("SELECT dictGetInt32('slow', 'a', toUInt64(5))") == "6\n"
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
`last_successful_update_time` field added to system.dictionaries table. This feature will help to monitor some troubles with external sources and force you to will investigate why is it so.
