### PR TITLE
CacheDictionaryUpdateQueueSize metric added

### DIFF
--- a/dbms/src/Common/CurrentMetrics.cpp
+++ b/dbms/src/Common/CurrentMetrics.cpp
@@ -12,7 +12,8 @@
     M(BackgroundPoolTask, "Number of active tasks in BackgroundProcessingPool (merges, mutations, fetches, or replication queue bookkeeping)") \
     M(BackgroundMovePoolTask, "Number of active tasks in BackgroundProcessingPool for moves") \
     M(BackgroundSchedulePoolTask, "Number of active tasks in BackgroundSchedulePool. This pool is used for periodic ReplicatedMergeTree tasks, like cleaning old data parts, altering data parts, replica re-initialization, etc.") \
-    M(CacheDictionaryUpdateQueueSize, "Number of 'units' (a set of keys) in update queue in CacheDictionaries.") \
+    M(CacheDictionaryUpdateQueueBatches, "Number of 'batches' (a set of keys) in update queue in CacheDictionaries.") \
+    M(CacheDictionaryUpdateQueueKeys, "Exact number of keys in update queue in CacheDictionaries.") \
     M(DiskSpaceReservedForMerge, "Disk space reserved for currently running background merges. It is slightly more than the total size of currently merging parts.") \
     M(DistributedSend, "Number of connections to remote servers sending data that was INSERTed into Distributed tables. Both synchronous and asynchronous mode.") \
     M(QueryPreempted, "Number of queries that are stopped and waiting due to 'priority' setting.") \

--- a/dbms/src/Common/CurrentMetrics.cpp
+++ b/dbms/src/Common/CurrentMetrics.cpp
@@ -12,6 +12,7 @@
     M(BackgroundPoolTask, "Number of active tasks in BackgroundProcessingPool (merges, mutations, fetches, or replication queue bookkeeping)") \
     M(BackgroundMovePoolTask, "Number of active tasks in BackgroundProcessingPool for moves") \
     M(BackgroundSchedulePoolTask, "Number of active tasks in BackgroundSchedulePool. This pool is used for periodic ReplicatedMergeTree tasks, like cleaning old data parts, altering data parts, replica re-initialization, etc.") \
+    M(CacheDictionaryUpdateQueueSize, "Number of 'units' (a set of keys) in update queue in CacheDictionaries.") \
     M(DiskSpaceReservedForMerge, "Disk space reserved for currently running background merges. It is slightly more than the total size of currently merging parts.") \
     M(DistributedSend, "Number of connections to remote servers sending data that was INSERTed into Distributed tables. Both synchronous and asynchronous mode.") \
     M(QueryPreempted, "Number of queries that are stopped and waiting due to 'priority' setting.") \

--- a/dbms/src/Dictionaries/CacheDictionary.h
+++ b/dbms/src/Dictionaries/CacheDictionary.h
@@ -22,6 +22,11 @@
 #include "IDictionary.h"
 #include "IDictionarySource.h"
 
+namespace CurrentMetrics
+{
+    extern const Metric CacheDictionaryUpdateQueueSize;
+}
+
 
 namespace DB
 {
@@ -364,6 +369,9 @@ private:
 
         std::atomic<bool> is_done{false};
         std::exception_ptr current_exception{nullptr};
+
+        /// While UpdateUnit is alive, it is accounted in update_queue size.
+        CurrentMetrics::Increment alive_update_unit{CurrentMetrics::CacheDictionaryUpdateQueueSize};
     };
 
     using UpdateUnitPtr = std::shared_ptr<UpdateUnit>;

--- a/dbms/src/Dictionaries/CacheDictionary.h
+++ b/dbms/src/Dictionaries/CacheDictionary.h
@@ -24,7 +24,8 @@
 
 namespace CurrentMetrics
 {
-    extern const Metric CacheDictionaryUpdateQueueSize;
+    extern const Metric CacheDictionaryUpdateQueueBatches;
+    extern const Metric CacheDictionaryUpdateQueueKeys;
 }
 
 
@@ -356,12 +357,14 @@ private:
                 AbsentIdHandler absent_id_handler_) :
                 requested_ids(std::move(requested_ids_)),
                 present_id_handler(present_id_handler_),
-                absent_id_handler(absent_id_handler_) {}
+                absent_id_handler(absent_id_handler_),
+                alive_keys(CurrentMetrics::CacheDictionaryUpdateQueueKeys, requested_ids.size()){}
 
         explicit UpdateUnit(std::vector<Key> requested_ids_) :
                 requested_ids(std::move(requested_ids_)),
                 present_id_handler([](Key, size_t){}),
-                absent_id_handler([](Key, size_t){}) {}
+                absent_id_handler([](Key, size_t){}),
+                alive_keys(CurrentMetrics::CacheDictionaryUpdateQueueKeys, requested_ids.size()){}
 
         std::vector<Key> requested_ids;
         PresentIdHandler present_id_handler;
@@ -371,7 +374,8 @@ private:
         std::exception_ptr current_exception{nullptr};
 
         /// While UpdateUnit is alive, it is accounted in update_queue size.
-        CurrentMetrics::Increment alive_update_unit{CurrentMetrics::CacheDictionaryUpdateQueueSize};
+        CurrentMetrics::Increment alive_batch{CurrentMetrics::CacheDictionaryUpdateQueueBatches};
+        CurrentMetrics::Increment alive_keys;
     };
 
     using UpdateUnitPtr = std::shared_ptr<UpdateUnit>;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now you can monitor the size of update queue in CacheDictionaries from system.metric_log.