### PR TITLE
ColumnVector::replicate() is even more readily vectorized now

### DIFF
--- a/dbms/src/Columns/ColumnVector.cpp
+++ b/dbms/src/Columns/ColumnVector.cpp
@@ -339,7 +339,7 @@ ColumnPtr ColumnVector<T>::index(const IColumn & indexes, size_t limit) const
 template <typename T>
 ColumnPtr ColumnVector<T>::replicate(const IColumn::Offsets & offsets) const
 {
-    size_t size = data.size();
+    const size_t size = data.size();
     if (size != offsets.size())
         throw Exception("Size of offsets doesn't match size of column.", ErrorCodes::SIZES_OF_COLUMNS_DOESNT_MATCH);
 
@@ -348,12 +348,13 @@ ColumnPtr ColumnVector<T>::replicate(const IColumn::Offsets & offsets) const
 
     auto res = this->create(offsets.back());
 
-    auto it = res->getData().begin();
+    typename Self::Container::value_type * const start = res->getData().data();
+    typename Self::Container::value_type * curr = start;
     for (size_t i = 0; i < size; ++i)
     {
-        const auto span_end = res->getData().begin() + offsets[i];
-        for (; it < span_end; ++it)
-            *it = data[i];
+        const auto span_end = start + offsets[i];
+        while (curr < span_end)
+            *curr++ = data[i];
     }
 
     return res;

--- a/dbms/src/Columns/ColumnVector.cpp
+++ b/dbms/src/Columns/ColumnVector.cpp
@@ -348,13 +348,12 @@ ColumnPtr ColumnVector<T>::replicate(const IColumn::Offsets & offsets) const
 
     auto res = this->create(offsets.back());
 
-    typename Self::Container::value_type * const start = res->getData().data();
-    typename Self::Container::value_type * curr = start;
+    auto it = res->getData().begin();
     for (size_t i = 0; i < size; ++i)
     {
-        const auto span_end = start + offsets[i];
-        while (curr < span_end)
-            *curr++ = data[i];
+        const auto span_end = res->getData().begin() + offsets[i];
+        for (; it != span_end; ++it)
+            *it = data[i];
     }
 
     return res;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Performance Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Another minor performance improvement to ColumnVector::replicate() - an even further improvement to #9293

_This is most useful for generating synthetic data in (performance) tests._

Notice the overhead decrease:
```
"Before":

  25.18%  QueryPipelineEx  clickhouse  [.] DB::ColumnVector<unsigned short>::replicate                                                                                                                                                              
  23.18%  QueryPipelineEx  clickhouse  [.] DB::ColumnVector<unsigned int>::replicate                                                                                                                                                                
  19.81%  QueryPipelineEx  clickhouse  [.] DB::(anonymous namespace)::TypedExecutorInvoker<DB::FunctionsLogicalDetail::AndImpl, ... >::apply
  11.98%  QueryPipelineEx  clickhouse  [.] DB::(anonymous namespace)::NumbersSource::generate
  ...

"After":

  33.29%  QueryPipelineEx  clickhouse  [.] DB::(anonymous namespace)::TypedExecutorInvoker<DB::FunctionsLogicalDetail::AndImpl, ... >::apply
  22.21%  QueryPipelineEx  clickhouse  [.] DB::(anonymous namespace)::NumbersSource::generate
   9.35%  QueryPipelineEx  clickhouse  [.] DB::ColumnVector<unsigned int>::replicate
   4.43%  QueryPipelineEx  clickhouse  [.] DB::ColumnVector<unsigned short>::replicate
  ...
```
