### PR TITLE
clickhouse-client: bind C-p/C-n to history-previous/history-next (like readline)

### DIFF
--- a/base/common/ReplxxLineReader.cpp
+++ b/base/common/ReplxxLineReader.cpp
@@ -3,6 +3,7 @@
 #include <errno.h>
 #include <string.h>
 #include <unistd.h>
+#include <functional>
 
 namespace
 {
@@ -18,18 +19,31 @@ void trim(String & s)
 ReplxxLineReader::ReplxxLineReader(const Suggest & suggest, const String & history_file_path_, char extender_, char delimiter_)
     : LineReader(history_file_path_, extender_, delimiter_)
 {
+    using namespace std::placeholders;
+    using Replxx = replxx::Replxx;
+
     if (!history_file_path.empty())
         rx.history_load(history_file_path);
 
     auto callback = [&suggest] (const String & context, size_t context_size)
     {
         auto range = suggest.getCompletions(context, context_size);
-        return replxx::Replxx::completions_t(range.first, range.second);
+        return Replxx::completions_t(range.first, range.second);
     };
 
     rx.set_completion_callback(callback);
     rx.set_complete_on_empty(false);
     rx.set_word_break_characters(word_break_characters);
+
+    /// By default C-p/C-n binded to COMPLETE_NEXT/COMPLETE_PREV,
+    /// bind C-p/C-n to history-previous/history-next like readline.
+    rx.bind_key(Replxx::KEY::control('N'), std::bind(&Replxx::invoke, &rx, Replxx::ACTION::HISTORY_NEXT,      _1));
+    rx.bind_key(Replxx::KEY::control('P'), std::bind(&Replxx::invoke, &rx, Replxx::ACTION::HISTORY_PREVIOUS,  _1));
+    /// By default COMPLETE_NEXT/COMPLETE_PREV was binded to C-p/C-n, re-bind
+    /// to M-P/M-N (that was used for HISTORY_COMMON_PREFIX_SEARCH before, but
+    /// it also binded to M-p/M-n).
+    rx.bind_key(Replxx::KEY::meta('N'), std::bind(&Replxx::invoke, &rx, Replxx::ACTION::COMPLETE_NEXT,     _1));
+    rx.bind_key(Replxx::KEY::meta('P'), std::bind(&Replxx::invoke, &rx, Replxx::ACTION::COMPLETE_PREVIOUS, _1));
 }
 
 ReplxxLineReader::~ReplxxLineReader()


### PR DESCRIPTION
Changelog category (leave one):
- Non-significant (changelog entry is not required)

It is not easy to keep in mind that C-p/C-n is not
history-previous/history-next in replxx, thus it is pretty easy to
mistype.

Previous COMPLETE_NEXT/COMPLETE_PREV bindings has been binded to the
M-P/M-N (that was used for HISTORY_COMMON_PREFIX_SEARCH before, but it
also binded to M-p/M-n).

Plus clickhouse-client can be compiled with readline, so it is better to
make bindings the same.