### PR TITLE
Save errno in signal handlers

### DIFF
--- a/dbms/src/Common/QueryProfiler.cpp
+++ b/dbms/src/Common/QueryProfiler.cpp
@@ -21,6 +21,8 @@ namespace
 {
     void writeTraceInfo(TraceType trace_type, int /* sig */, siginfo_t * info, void * context)
     {
+        auto saved_errno = errno;   /// We must restore previous value of errno in signal handler.
+
         int overrun_count = 0;
 #if defined(OS_LINUX)
         if (info)
@@ -33,6 +35,8 @@ namespace
         const StackTrace stack_trace(signal_context);
 
         ext::Singleton<TraceCollector>()->collect(trace_type, stack_trace, overrun_count);
+
+        errno = saved_errno;
     }
 
     [[maybe_unused]] const UInt32 TIMER_PRECISION = 1e9;

--- a/dbms/src/Storages/System/StorageSystemStackTrace.cpp
+++ b/dbms/src/Storages/System/StorageSystemStackTrace.cpp
@@ -47,6 +47,8 @@ namespace
 
     void signalHandler(int, siginfo_t * info, void * context)
     {
+        auto saved_errno = errno;   /// We must restore previous value of errno in signal handler.
+
         /// In case malicious user is sending signals manually (for unknown reason).
         /// If we don't check - it may break our synchronization.
         if (info->si_pid != expected_pid)
@@ -69,6 +71,8 @@ namespace
 
         /// We cannot do anything if write failed.
         (void)res;
+
+        errno = saved_errno;
     }
 
     /// Wait for data in pipe and read it.


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Avoid extremely rare cases when the user can get wrong error message (`Success` instead of detailed error description).


Detailed description / Documentation draft:
This was clearly a bug. But it's very unlikely to reproduce. It requires query profiler enabled with some high frequency (by default it is enabled with the frequency of one second) and we should have some error when we check errno (example: cannot read from file) and the profiling signal should come exactly in the instruction when we already get the error but before we have checked for errno. I have not seen this bug in practice yet. The fix comes only from theoretical observations and no test will be attached.