### PR TITLE
Backport 8549 to 19.16 [Do not allow to merge data moving it against storage policy volume order]

### DIFF
--- a/dbms/src/Storages/StorageMergeTree.cpp
+++ b/dbms/src/Storages/StorageMergeTree.cpp
@@ -346,7 +346,13 @@ public:
         if (is_mutation)
             reserved_space = future_part_.parts[0]->disk->reserve(total_size);
         else
-            reserved_space = storage.reserveSpace(total_size);
+        {
+            size_t max_volume_index = 0;
+            for (auto & part_ptr : future_part_.parts)
+                max_volume_index = std::max(max_volume_index, storage.getStoragePolicy()->getVolumeIndexByDisk(part_ptr->disk));
+
+            reserved_space = storage.reserveSpace(total_size, max_volume_index);
+        }
         if (!reserved_space)
         {
             if (is_mutation)

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1005,8 +1005,12 @@ bool StorageReplicatedMergeTree::tryExecuteMerge(const LogEntry & entry)
     /// Start to make the main work
     size_t estimated_space_for_merge = MergeTreeDataMergerMutator::estimateNeededDiskSpace(parts);
 
+    size_t max_volume_index = 0;
+    for (auto & part_ptr : parts)
+        max_volume_index = std::max(max_volume_index, getStoragePolicy()->getVolumeIndexByDisk(part_ptr->disk));
+
     /// Can throw an exception.
-    DiskSpace::ReservationPtr reserved_space = reserveSpace(estimated_space_for_merge);
+    DiskSpace::ReservationPtr reserved_space = reserveSpace(estimated_space_for_merge, max_volume_index);
 
     auto table_lock = lockStructureForShare(false, RWLockImpl::NO_QUERY);
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (up to few sentences, required except for Non-significant/Documentation categories):

Do not allow to merge data moving it against storage policy volume order

See #8549
