### PR TITLE
In LogicalFunctions performance tests: Adjusted test queries execution times

### DIFF
--- a/dbms/tests/performance/logical_functions_large.xml
+++ b/dbms/tests/performance/logical_functions_large.xml
@@ -18,16 +18,16 @@
     </settings>
 
     <query>SELECT count() FROM
-        (SELECT materialize(1) AS x1, materialize(1) AS x2, materialize(1) AS x3, materialize(1) AS x4, materialize(1) AS x5, materialize(1) AS x6, materialize(1) AS x7, materialize(1) AS x8, materialize(1) AS x9, materialize(1) AS x10 FROM numbers(40000000))
+        (SELECT materialize(1) AS x1, materialize(1) AS x2, materialize(1) AS x3, materialize(1) AS x4, materialize(1) AS x5, materialize(1) AS x6, materialize(1) AS x7, materialize(1) AS x8, materialize(1) AS x9, materialize(1) AS x10 FROM numbers(20000000))
     WHERE NOT ignore(and(x1,x2,x3,x4,x5,x6,x7,x8,x9,x10))</query>
     <query>SELECT count() FROM
-        (SELECT materialize(0) AS x1, materialize(0) AS x2, materialize(0) AS x3, materialize(0) AS x4, materialize(0) AS x5, materialize(0) AS x6, materialize(0) AS x7, materialize(0) AS x8, materialize(0) AS x9, materialize(0) AS x10 FROM numbers(200000000))
+        (SELECT materialize(0) AS x1, materialize(0) AS x2, materialize(0) AS x3, materialize(0) AS x4, materialize(0) AS x5, materialize(0) AS x6, materialize(0) AS x7, materialize(0) AS x8, materialize(0) AS x9, materialize(0) AS x10 FROM numbers(150000000))
     WHERE NOT ignore(and(x1,x2,x3,x4,x5,x6,x7,x8,x9,x10))</query>
     <query>SELECT count() FROM
-        (SELECT materialize(0) AS x1, materialize(0) AS x2, materialize(0) AS x3, materialize(0) AS x4, materialize(0) AS x5, materialize(0) AS x6, materialize(0) AS x7, materialize(0) AS x8, materialize(0) AS x9, materialize(0) AS x10 FROM numbers(40000000))
+        (SELECT materialize(0) AS x1, materialize(0) AS x2, materialize(0) AS x3, materialize(0) AS x4, materialize(0) AS x5, materialize(0) AS x6, materialize(0) AS x7, materialize(0) AS x8, materialize(0) AS x9, materialize(0) AS x10 FROM numbers(20000000))
     WHERE NOT ignore(or(x1,x2,x3,x4,x5,x6,x7,x8,x9,x10))</query>
     <query>SELECT count() FROM
-        (SELECT materialize(1) AS x1, materialize(1) AS x2, materialize(1) AS x3, materialize(1) AS x4, materialize(1) AS x5, materialize(1) AS x6, materialize(1) AS x7, materialize(1) AS x8, materialize(1) AS x9, materialize(1) AS x10 FROM numbers(200000000))
+        (SELECT materialize(1) AS x1, materialize(1) AS x2, materialize(1) AS x3, materialize(1) AS x4, materialize(1) AS x5, materialize(1) AS x6, materialize(1) AS x7, materialize(1) AS x8, materialize(1) AS x9, materialize(1) AS x10 FROM numbers(100000000))
     WHERE NOT ignore(or(x1,x2,x3,x4,x5,x6,x7,x8,x9,x10))</query>
     <query>SELECT count() FROM
         (SELECT materialize(1) AS x1, materialize(1) AS x2, materialize(1) AS x3, materialize(1) AS x4, materialize(1) AS x5, materialize(1) AS x6, materialize(1) AS x7, materialize(1) AS x8, materialize(1) AS x9, materialize(1) AS x10 FROM numbers(500000000))
@@ -43,9 +43,9 @@
         (SELECT materialize(toUInt8(0)) AS x1, materialize(toUInt16(0)) AS x2, materialize(toUInt32(0)) AS x3, materialize(toUInt64(0)) AS x4, materialize(toInt8(0)) AS x5, materialize(toInt16(0)) AS x6, materialize(toInt32(0)) AS x7, materialize(toInt64(0)) AS x8, materialize(toFloat32(0)) AS x9, materialize(toFloat64(0)) AS x10 FROM numbers(20000000))
     WHERE NOT ignore(or(x1,x2,x3,x4,x5,x6,x7,x8,x9,x10))</query>
     <query>SELECT count() FROM
-        (SELECT materialize(toUInt8(1)) AS x1, materialize(toUInt16(1)) AS x2, materialize(toUInt32(1)) AS x3, materialize(toUInt64(1)) AS x4, materialize(toInt8(1)) AS x5, materialize(toInt16(1)) AS x6, materialize(toInt32(1)) AS x7, materialize(toInt64(1)) AS x8, materialize(toFloat32(1)) AS x9, materialize(toFloat64(1)) AS x10 FROM numbers(40000000))
+        (SELECT materialize(toUInt8(1)) AS x1, materialize(toUInt16(1)) AS x2, materialize(toUInt32(1)) AS x3, materialize(toUInt64(1)) AS x4, materialize(toInt8(1)) AS x5, materialize(toInt16(1)) AS x6, materialize(toInt32(1)) AS x7, materialize(toInt64(1)) AS x8, materialize(toFloat32(1)) AS x9, materialize(toFloat64(1)) AS x10 FROM numbers(20000000))
     WHERE NOT ignore(or(x1,x2,x3,x4,x5,x6,x7,x8,x9,x10))</query>
     <query>SELECT count() FROM
-        (SELECT materialize(toUInt8(1)) AS x1, materialize(toUInt16(1)) AS x2, materialize(toUInt32(1)) AS x3, materialize(toUInt64(1)) AS x4, materialize(toInt8(1)) AS x5, materialize(toInt16(1)) AS x6, materialize(toInt32(1)) AS x7, materialize(toInt64(1)) AS x8, materialize(toFloat32(1)) AS x9, materialize(toFloat64(1)) AS x10 FROM numbers(50000000))
+        (SELECT materialize(toUInt8(1)) AS x1, materialize(toUInt16(1)) AS x2, materialize(toUInt32(1)) AS x3, materialize(toUInt64(1)) AS x4, materialize(toInt8(1)) AS x5, materialize(toInt16(1)) AS x6, materialize(toInt32(1)) AS x7, materialize(toInt64(1)) AS x8, materialize(toFloat32(1)) AS x9, materialize(toFloat64(1)) AS x10 FROM numbers(20000000))
     WHERE NOT ignore(xor(x1,x2,x3,x4,x5,x6,x7,x8,x9,x10))</query>
 </test>

--- a/dbms/tests/performance/logical_functions_medium.xml
+++ b/dbms/tests/performance/logical_functions_medium.xml
@@ -17,26 +17,26 @@
         <max_threads>1</max_threads>
     </settings>
 
-    <query>SELECT count() FROM (SELECT materialize(1) AS x1, materialize(1) AS x2, materialize(1) AS x3 FROM numbers(200000000)) WHERE NOT ignore(and(x1,x2,x3))</query>
-    <query>SELECT count() FROM (SELECT materialize(0) AS x1, materialize(0) AS x2, materialize(0) AS x3 FROM numbers(400000000)) WHERE NOT ignore(and(x1,x2,x3))</query>
-    <query>SELECT count() FROM (SELECT materialize(0) AS x1, materialize(0) AS x2, materialize(0) AS x3 FROM numbers(200000000)) WHERE NOT ignore(or(x1,x2,x3))</query>
-    <query>SELECT count() FROM (SELECT materialize(1) AS x1, materialize(1) AS x2, materialize(1) AS x3 FROM numbers(200000000)) WHERE NOT ignore(or(x1,x2,x3))</query>
+    <query>SELECT count() FROM (SELECT materialize(1) AS x1, materialize(1) AS x2, materialize(1) AS x3 FROM numbers(100000000)) WHERE NOT ignore(and(x1,x2,x3))</query>
+    <query>SELECT count() FROM (SELECT materialize(0) AS x1, materialize(0) AS x2, materialize(0) AS x3 FROM numbers(200000000)) WHERE NOT ignore(and(x1,x2,x3))</query>
+    <query>SELECT count() FROM (SELECT materialize(0) AS x1, materialize(0) AS x2, materialize(0) AS x3 FROM numbers(100000000)) WHERE NOT ignore(or(x1,x2,x3))</query>
+    <query>SELECT count() FROM (SELECT materialize(1) AS x1, materialize(1) AS x2, materialize(1) AS x3 FROM numbers(100000000)) WHERE NOT ignore(or(x1,x2,x3))</query>
 
     <!-- Check with bigger types -->
-    <query>SELECT count() FROM (SELECT materialize(1) AS x1, materialize(toUInt32(1)) AS x2, materialize(toUInt64(1)) AS x3 FROM numbers(100000000)) WHERE NOT ignore(and(x1,x2,x3))</query>
-    <query>SELECT count() FROM (SELECT materialize(0) AS x1, materialize(toUInt32(0)) AS x2, materialize(toUInt64(0)) AS x3 FROM numbers(200000000)) WHERE NOT ignore(and(x1,x2,x3))</query>
-    <query>SELECT count() FROM (SELECT materialize(0) AS x1, materialize(toUInt32(0)) AS x2, materialize(toUInt64(0)) AS x3 FROM numbers(100000000)) WHERE NOT ignore(or(x1,x2,x3))</query>
-    <query>SELECT count() FROM (SELECT materialize(1) AS x1, materialize(toUInt32(1)) AS x2, materialize(toUInt64(1)) AS x3 FROM numbers(200000000)) WHERE NOT ignore(or(x1,x2,x3))</query>
+    <query>SELECT count() FROM (SELECT materialize(1) AS x1, materialize(toUInt32(1)) AS x2, materialize(toUInt64(1)) AS x3 FROM numbers(50000000)) WHERE NOT ignore(and(x1,x2,x3))</query>
+    <query>SELECT count() FROM (SELECT materialize(0) AS x1, materialize(toUInt32(0)) AS x2, materialize(toUInt64(0)) AS x3 FROM numbers(100000000)) WHERE NOT ignore(and(x1,x2,x3))</query>
+    <query>SELECT count() FROM (SELECT materialize(0) AS x1, materialize(toUInt32(0)) AS x2, materialize(toUInt64(0)) AS x3 FROM numbers(50000000)) WHERE NOT ignore(or(x1,x2,x3))</query>
+    <query>SELECT count() FROM (SELECT materialize(1) AS x1, materialize(toUInt32(1)) AS x2, materialize(toUInt64(1)) AS x3 FROM numbers(100000000)) WHERE NOT ignore(or(x1,x2,x3))</query>
 
-    <query>SELECT count() FROM (SELECT materialize(toNullable(1)) AS x1, materialize(toNullable(1)) AS x2, materialize(toNullable(1)) AS x3 FROM numbers(30000000)) WHERE NOT ignore(and(x1,x2,x3))</query>
-    <query>SELECT count() FROM (SELECT materialize(toNullable(0)) AS x1, materialize(toNullable(0)) AS x2, materialize(toNullable(0)) AS x3 FROM numbers(100000000)) WHERE NOT ignore(and(x1,x2,x3))</query>
-    <query>SELECT count() FROM (SELECT materialize(toNullable(0)) AS x1, materialize(toNullable(0)) AS x2, materialize(toNullable(0)) AS x3 FROM numbers(50000000)) WHERE NOT ignore(or(x1,x2,x3))</query>
-    <query>SELECT count() FROM (SELECT materialize(toNullable(1)) AS x1, materialize(toNullable(1)) AS x2, materialize(toNullable(1)) AS x3 FROM numbers(100000000)) WHERE NOT ignore(or(x1,x2,x3))</query>
+    <query>SELECT count() FROM (SELECT materialize(toNullable(1)) AS x1, materialize(toNullable(1)) AS x2, materialize(toNullable(1)) AS x3 FROM numbers(20000000)) WHERE NOT ignore(and(x1,x2,x3))</query>
+    <query>SELECT count() FROM (SELECT materialize(toNullable(0)) AS x1, materialize(toNullable(0)) AS x2, materialize(toNullable(0)) AS x3 FROM numbers(50000000)) WHERE NOT ignore(and(x1,x2,x3))</query>
+    <query>SELECT count() FROM (SELECT materialize(toNullable(0)) AS x1, materialize(toNullable(0)) AS x2, materialize(toNullable(0)) AS x3 FROM numbers(20000000)) WHERE NOT ignore(or(x1,x2,x3))</query>
+    <query>SELECT count() FROM (SELECT materialize(toNullable(1)) AS x1, materialize(toNullable(1)) AS x2, materialize(toNullable(1)) AS x3 FROM numbers(50000000)) WHERE NOT ignore(or(x1,x2,x3))</query>
 
-    <query>SELECT count() FROM (SELECT materialize(toNullable(toUInt16(1))) AS x1, materialize(toNullable(toUInt32(1))) AS x2, materialize(toNullable(toUInt64(1))) AS x3 FROM numbers(30000000)) WHERE NOT ignore(and(x1,x2,x3))</query>
-    <query>SELECT count() FROM (SELECT materialize(toNullable(toUInt16(0))) AS x1, materialize(toNullable(toUInt32(0))) AS x2, materialize(toNullable(toUInt64(0))) AS x3 FROM numbers(100000000)) WHERE NOT ignore(and(x1,x2,x3))</query>
-    <query>SELECT count() FROM (SELECT materialize(toNullable(toUInt16(0))) AS x1, materialize(toNullable(toUInt32(0))) AS x2, materialize(toNullable(toUInt64(0))) AS x3 FROM numbers(50000000)) WHERE NOT ignore(or(x1,x2,x3))</query>
-    <query>SELECT count() FROM (SELECT materialize(toNullable(toUInt16(1))) AS x1, materialize(toNullable(toUInt32(1))) AS x2, materialize(toNullable(toUInt64(1))) AS x3 FROM numbers(100000000)) WHERE NOT ignore(or(x1,x2,x3))</query>
+    <query>SELECT count() FROM (SELECT materialize(toNullable(toUInt16(1))) AS x1, materialize(toNullable(toUInt32(1))) AS x2, materialize(toNullable(toUInt64(1))) AS x3 FROM numbers(20000000)) WHERE NOT ignore(and(x1,x2,x3))</query>
+    <query>SELECT count() FROM (SELECT materialize(toNullable(toUInt16(0))) AS x1, materialize(toNullable(toUInt32(0))) AS x2, materialize(toNullable(toUInt64(0))) AS x3 FROM numbers(50000000)) WHERE NOT ignore(and(x1,x2,x3))</query>
+    <query>SELECT count() FROM (SELECT materialize(toNullable(toUInt16(0))) AS x1, materialize(toNullable(toUInt32(0))) AS x2, materialize(toNullable(toUInt64(0))) AS x3 FROM numbers(20000000)) WHERE NOT ignore(or(x1,x2,x3))</query>
+    <query>SELECT count() FROM (SELECT materialize(toNullable(toUInt16(1))) AS x1, materialize(toNullable(toUInt32(1))) AS x2, materialize(toNullable(toUInt64(1))) AS x3 FROM numbers(50000000)) WHERE NOT ignore(or(x1,x2,x3))</query>
 
     <!-- We have to check the high performing XOR function against in-memory data to avoid the overhead of data generating code -->
     <create_query>CREATE DATABASE IF NOT EXISTS test_logical_functions</create_query>
@@ -46,9 +46,9 @@
     <create_query>CREATE TABLE test_logical_functions._4_1_Nullable_UInt8 (x1 Nullable(UInt8), x2 Nullable(UInt8), x3 Nullable(UInt8), x4 Nullable(UInt8)) ENGINE = Memory</create_query>
     <create_query>CREATE TABLE test_logical_functions._4_1_Nullable_Mixed (x1 Nullable(UInt16), x2 Nullable(UInt32), x3 Nullable(UInt64), x4 Nullable(Float64)) ENGINE = Memory</create_query>
     <fill_query>INSERT INTO test_logical_functions._4_1_UInt8 SELECT materialize(1), materialize(1), materialize(1), materialize(1) FROM numbers(500000000)</fill_query>
-    <fill_query>INSERT INTO test_logical_functions._4_1_Mixed SELECT materialize(1), materialize(1), materialize(1), materialize(1) FROM numbers(200000000)</fill_query>
-    <fill_query>INSERT INTO test_logical_functions._4_1_Nullable_UInt8 SELECT materialize(1), materialize(1), materialize(1), materialize(1) FROM numbers(200000000)</fill_query>
-    <fill_query>INSERT INTO test_logical_functions._4_1_Nullable_Mixed SELECT materialize(1), materialize(1), materialize(1), materialize(1.0) FROM numbers(100000000)</fill_query>
+    <fill_query>INSERT INTO test_logical_functions._4_1_Mixed SELECT materialize(1), materialize(1), materialize(1), materialize(1) FROM numbers(150000000)</fill_query>
+    <fill_query>INSERT INTO test_logical_functions._4_1_Nullable_UInt8 SELECT materialize(1), materialize(1), materialize(1), materialize(1) FROM numbers(150000000)</fill_query>
+    <fill_query>INSERT INTO test_logical_functions._4_1_Nullable_Mixed SELECT materialize(1), materialize(1), materialize(1), materialize(1.0) FROM numbers(50000000)</fill_query>
 
     <query>SELECT count() FROM test_logical_functions._4_1_UInt8 WHERE NOT ignore(xor(x1,x2,x3,x4))</query>
     <query>SELECT count() FROM test_logical_functions._4_1_Mixed WHERE NOT ignore(xor(x1,x2,x3,x4))</query>

--- a/dbms/tests/performance/logical_functions_small.xml
+++ b/dbms/tests/performance/logical_functions_small.xml
@@ -17,6 +17,7 @@
         <max_threads>1</max_threads>
     </settings>
 
+    <!-- Individual execution times are adjusted for all test queries to be between 200 and 300 milliseconds -->
     <!-- We have to use Memory table engine for very fast operations (to avoid the slow code that materializes the data),
          so that the weight of their execution time keeps high and performance test results make sense
     -->
@@ -25,8 +26,8 @@
     <create_query>CREATE TABLE test_logical_functions._2_0_UInt8 (x1 UInt8, x2 UInt8) ENGINE = Memory</create_query>
     <create_query>CREATE TABLE test_logical_functions._2_1_UInt8 (x1 UInt8, x2 UInt8) ENGINE = Memory</create_query>
 
-    <fill_query>INSERT INTO test_logical_functions._2_0_UInt8 SELECT materialize(0) AS x1, materialize(0) AS x2 FROM numbers(2000000000)</fill_query>
-    <fill_query>INSERT INTO test_logical_functions._2_1_UInt8 SELECT materialize(1) AS x1, materialize(1) AS x2 FROM numbers(2000000000)</fill_query>
+    <fill_query>INSERT INTO test_logical_functions._2_0_UInt8 SELECT materialize(0) AS x1, materialize(0) AS x2 FROM numbers(1000000000)</fill_query>
+    <fill_query>INSERT INTO test_logical_functions._2_1_UInt8 SELECT materialize(1) AS x1, materialize(1) AS x2 FROM numbers(1000000000)</fill_query>
 
     <query>SELECT count() FROM test_logical_functions._2_1_UInt8 WHERE NOT ignore(and(x1,x2))</query>
     <query>SELECT count() FROM test_logical_functions._2_0_UInt8 WHERE NOT ignore(and(x1,x2))</query>
@@ -34,20 +35,20 @@
     <query>SELECT count() FROM test_logical_functions._2_1_UInt8 WHERE NOT ignore(or(x1,x2))</query>
     <query>SELECT count() FROM test_logical_functions._2_1_UInt8 WHERE NOT ignore(xor(x1,x2))</query>
 
-    <query>SELECT count() FROM (SELECT toNullable(materialize(1)) AS x1, toNullable(materialize(1)) AS x2 FROM numbers(50000000)) WHERE NOT ignore(and(x1,x2))</query>
-    <query>SELECT count() FROM (SELECT toNullable(materialize(0)) AS x1, toNullable(materialize(0)) AS x2 FROM numbers(50000000)) WHERE NOT ignore(and(x1,x2))</query>
-    <query>SELECT count() FROM (SELECT toNullable(materialize(0)) AS x1, toNullable(materialize(0)) AS x2 FROM numbers(50000000)) WHERE NOT ignore(or(x1,x2))</query>
-    <query>SELECT count() FROM (SELECT toNullable(materialize(1)) AS x1, toNullable(materialize(1)) AS x2 FROM numbers(50000000)) WHERE NOT ignore(or(x1,x2))</query>
-    <query>SELECT count() FROM (SELECT toNullable(materialize(1)) AS x1, toNullable(materialize(1)) AS x2 FROM numbers(200000000)) WHERE NOT ignore(xor(x1,x2))</query>
+    <query>SELECT count() FROM (SELECT toNullable(materialize(1)) AS x1, toNullable(materialize(1)) AS x2 FROM numbers(30000000)) WHERE NOT ignore(and(x1,x2))</query>
+    <query>SELECT count() FROM (SELECT toNullable(materialize(0)) AS x1, toNullable(materialize(0)) AS x2 FROM numbers(40000000)) WHERE NOT ignore(and(x1,x2))</query>
+    <query>SELECT count() FROM (SELECT toNullable(materialize(0)) AS x1, toNullable(materialize(0)) AS x2 FROM numbers(40000000)) WHERE NOT ignore(or(x1,x2))</query>
+    <query>SELECT count() FROM (SELECT toNullable(materialize(1)) AS x1, toNullable(materialize(1)) AS x2 FROM numbers(30000000)) WHERE NOT ignore(or(x1,x2))</query>
+    <query>SELECT count() FROM (SELECT toNullable(materialize(1)) AS x1, toNullable(materialize(1)) AS x2 FROM numbers(100000000)) WHERE NOT ignore(xor(x1,x2))</query>
 
     <!-- Check with bigger types: UInt16, UInt32, UInt64, Float64 -->
     <query>SELECT count() FROM (SELECT materialize(toUInt16(1)) AS x1, materialize(toUInt32(1)) AS x2 FROM numbers(200000000)) WHERE NOT ignore(and(x1,x2))</query>
-    <query>SELECT count() FROM (SELECT materialize(toUInt32(1)) AS x1, materialize(toUInt64(1)) AS x2 FROM numbers(200000000)) WHERE NOT ignore(and(x1,x2))</query>
-    <query>SELECT count() FROM (SELECT materialize(toUInt64(1)) AS x1, materialize(0.1) AS x2 FROM numbers(200000000)) WHERE NOT ignore(and(x1,x2))</query>
+    <query>SELECT count() FROM (SELECT materialize(toUInt32(1)) AS x1, materialize(toUInt64(1)) AS x2 FROM numbers(100000000)) WHERE NOT ignore(and(x1,x2))</query>
+    <query>SELECT count() FROM (SELECT materialize(toUInt64(1)) AS x1, materialize(0.1) AS x2 FROM numbers(100000000)) WHERE NOT ignore(and(x1,x2))</query>
     <query>SELECT count() FROM (SELECT materialize(toUInt16(1)) AS x1, materialize(toUInt32(1)) AS x2 FROM numbers(200000000)) WHERE NOT ignore(or(x1,x2))</query>
-    <query>SELECT count() FROM (SELECT materialize(toUInt32(1)) AS x1, materialize(toUInt64(1)) AS x2 FROM numbers(200000000)) WHERE NOT ignore(or(x1,x2))</query>
-    <query>SELECT count() FROM (SELECT materialize(toUInt64(1)) AS x1, materialize(0.1) AS x2 FROM numbers(200000000)) WHERE NOT ignore(or(x1,x2))</query>
-    <query>SELECT count() FROM (SELECT materialize(toUInt64(1)) AS x1, materialize(toUInt64(1)) AS x2 FROM numbers(200000000)) WHERE NOT ignore(xor(x1,x2))</query>
+    <query>SELECT count() FROM (SELECT materialize(toUInt32(1)) AS x1, materialize(toUInt64(1)) AS x2 FROM numbers(100000000)) WHERE NOT ignore(or(x1,x2))</query>
+    <query>SELECT count() FROM (SELECT materialize(toUInt64(1)) AS x1, materialize(0.1) AS x2 FROM numbers(100000000)) WHERE NOT ignore(or(x1,x2))</query>
+    <query>SELECT count() FROM (SELECT materialize(toUInt64(1)) AS x1, materialize(toUInt64(1)) AS x2 FROM numbers(100000000)) WHERE NOT ignore(xor(x1,x2))</query>
 
     <drop_query>DROP TABLE test_logical_functions._2_0_UInt8</drop_query>
     <drop_query>DROP TABLE test_logical_functions._2_1_UInt8</drop_query>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Non-significant (changelog entry is not required)


Execution times for all tests queries are adjusted to fall between 200 and 300 milliseconds to better suit the new "Performance Comparison Test"