### PR TITLE
Update base64

### DIFF
--- a/dbms/tests/queries/0_stateless/01092_base64.reference
+++ b/dbms/tests/queries/0_stateless/01092_base64.reference
@@ -1,0 +1,1 @@
+TEcgT3B0aW11cw==

--- a/dbms/tests/queries/0_stateless/01092_base64.sql
+++ b/dbms/tests/queries/0_stateless/01092_base64.sql
@@ -1,0 +1,2 @@
+-- This query reproduces a bug in TurboBase64 library.
+select distinct base64Encode(materialize('LG Optimus')) from numbers(100);


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed the issue when padding at the end of base64 encoded value can be malformed. Update base64 library. This fixes #9491, closes #9492
