### PR TITLE
Proper processing of exception in write_suffix in Kafka

### DIFF
--- a/dbms/src/Storages/Kafka/KafkaBlockInputStream.cpp
+++ b/dbms/src/Storages/Kafka/KafkaBlockInputStream.cpp
@@ -199,8 +199,6 @@ Block KafkaBlockInputStream::readImpl()
 
 void KafkaBlockInputStream::readSuffixImpl()
 {
-    broken = false;
-
     if (commit_in_suffix)
         commit();
 }
@@ -211,6 +209,8 @@ void KafkaBlockInputStream::commit()
         return;
 
     buffer->commit();
+
+    broken = false;
 }
 
 }

--- a/dbms/tests/integration/test_storage_kafka/test.py
+++ b/dbms/tests/integration/test_storage_kafka/test.py
@@ -1142,7 +1142,8 @@ def test_kafka_no_holes_when_write_suffix_failed(kafka_cluster):
         pm.heal_all
 
     # connection restored and it will take a while until next block will be flushed
-    time.sleep(40)
+    # it takes years on CI :\
+    time.sleep(90)
 
     # as it's a bit tricky to hit the proper moment - let's check in logs if we did it correctly
     assert instance.contains_in_log("ZooKeeper session has been expired.: while write prefix to view")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Prevent losing data in Kafka in rare cases when exception happens after reading suffix but before commit. Fixes #9378

Detailed description / Documentation draft:
Related: #7175