### PR TITLE
Kafka exceptions from destructors

### DIFF
--- a/dbms/src/Storages/Kafka/KafkaBlockInputStream.cpp
+++ b/dbms/src/Storages/Kafka/KafkaBlockInputStream.cpp
@@ -199,8 +199,6 @@ Block KafkaBlockInputStream::readImpl()
 
 void KafkaBlockInputStream::readSuffixImpl()
 {
-    broken = false;
-
     if (commit_in_suffix)
         commit();
 }
@@ -211,6 +209,8 @@ void KafkaBlockInputStream::commit()
         return;
 
     buffer->commit();
+
+    broken = false;
 }
 
 }

--- a/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
+++ b/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
@@ -78,14 +78,16 @@ ReadBufferFromKafkaConsumer::ReadBufferFromKafkaConsumer(
 ReadBufferFromKafkaConsumer::~ReadBufferFromKafkaConsumer()
 {
     /// NOTE: see https://github.com/edenhill/librdkafka/issues/2077
-    try {
+    try
+    {
         if (!consumer->get_subscription().empty())
             consumer->unsubscribe();
-        if (!assignment.empty()) {
+        if (!assignment.empty())
             consumer->unassign();
-        }
         while (consumer->get_consumer_queue().next_event(100ms));
-    } catch (const cppkafka::HandleException & e) {
+    }
+    catch (const cppkafka::HandleException & e)
+    {
         LOG_ERROR(log, "Exception from ReadBufferFromKafkaConsumer destructor: " << e.what());
     }
 }
@@ -192,10 +194,13 @@ void ReadBufferFromKafkaConsumer::unsubscribe()
     BufferBase::set(nullptr, 0, 0);
 
     // it should not raise exception as used in destructor
-    try {
+    try
+    {
         if (!consumer->get_subscription().empty())
             consumer->unsubscribe();
-    } catch (const cppkafka::HandleException &e) {
+    }
+    catch (const cppkafka::HandleException & e)
+    {
         LOG_ERROR(log, "Exception from ReadBufferFromKafkaConsumer::unsubscribe: " << e.what());
     }
 

--- a/dbms/tests/integration/test_storage_kafka/test.py
+++ b/dbms/tests/integration/test_storage_kafka/test.py
@@ -1142,7 +1142,8 @@ def test_kafka_no_holes_when_write_suffix_failed(kafka_cluster):
         pm.heal_all
 
     # connection restored and it will take a while until next block will be flushed
-    time.sleep(40)
+    # it takes years on CI :\
+    time.sleep(90)
 
     # as it's a bit tricky to hit the proper moment - let's check in logs if we did it correctly
     assert instance.contains_in_log("ZooKeeper session has been expired.: while write prefix to view")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bug leading to server termination when trying to use / drop Kafka table created with wrong parameters. 

Detailed description / Documentation draft:
Fixes #9494. I didn't add more sanitizing for now, as destructors should not fail even if something went wrong in the underlying library.
Incorporates #9507