### PR TITLE
Attempt to fix flacky test '00910_zookeeper_test_alter_compression_codecs'

### DIFF
--- a/dbms/tests/queries/0_stateless/00910_zookeeper_test_alter_compression_codecs.sql
+++ b/dbms/tests/queries/0_stateless/00910_zookeeper_test_alter_compression_codecs.sql
@@ -1,65 +1,67 @@
 SET send_logs_level = 'none';
 
-DROP TABLE IF EXISTS test.alter_compression_codec1;
-DROP TABLE IF EXISTS test.alter_compression_codec2;
+DROP TABLE IF EXISTS alter_compression_codec1;
+DROP TABLE IF EXISTS alter_compression_codec2;
 
-CREATE TABLE test.alter_compression_codec1 (
+CREATE TABLE alter_compression_codec1 (
     somedate Date CODEC(LZ4),
     id UInt64 CODEC(NONE)
 ) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/alter_compression_codecs', '1') PARTITION BY somedate ORDER BY id;
 
-CREATE TABLE test.alter_compression_codec2 (
+CREATE TABLE alter_compression_codec2 (
   somedate Date CODEC(LZ4),
   id UInt64 CODEC(NONE)
 ) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/alter_compression_codecs', '2') PARTITION BY somedate ORDER BY id;
 
-INSERT INTO test.alter_compression_codec1 VALUES('2018-01-01', 1);
-INSERT INTO test.alter_compression_codec1 VALUES('2018-01-01', 2);
-SYSTEM SYNC REPLICA test.alter_compression_codec2;
+INSERT INTO alter_compression_codec1 VALUES('2018-01-01', 1);
+INSERT INTO alter_compression_codec1 VALUES('2018-01-01', 2);
+SYSTEM SYNC REPLICA alter_compression_codec2;
 
-SELECT * FROM test.alter_compression_codec1 ORDER BY id;
-SELECT * FROM test.alter_compression_codec2 ORDER BY id;
+SELECT * FROM alter_compression_codec1 ORDER BY id;
+SELECT * FROM alter_compression_codec2 ORDER BY id;
 
-ALTER TABLE test.alter_compression_codec1 ADD COLUMN alter_column String DEFAULT 'default_value' CODEC(ZSTD);
-SYSTEM SYNC REPLICA test.alter_compression_codec2;
+ALTER TABLE alter_compression_codec1 ADD COLUMN alter_column String DEFAULT 'default_value' CODEC(ZSTD);
+SYSTEM SYNC REPLICA alter_compression_codec1;
+SYSTEM SYNC REPLICA alter_compression_codec2;
 
-SELECT compression_codec FROM system.columns WHERE database = 'test' AND table = 'alter_compression_codec1' AND name = 'alter_column';
-SELECT compression_codec FROM system.columns WHERE database = 'test' AND table = 'alter_compression_codec2' AND name = 'alter_column';
+SELECT compression_codec FROM system.columns WHERE table = 'alter_compression_codec1' AND name = 'alter_column';
+SELECT compression_codec FROM system.columns WHERE table = 'alter_compression_codec2' AND name = 'alter_column';
 
-INSERT INTO test.alter_compression_codec1 VALUES('2018-01-01', 3, '3');
-INSERT INTO test.alter_compression_codec1 VALUES('2018-01-01', 4, '4');
-SYSTEM SYNC REPLICA test.alter_compression_codec2;
+INSERT INTO alter_compression_codec1 VALUES('2018-01-01', 3, '3');
+INSERT INTO alter_compression_codec1 VALUES('2018-01-01', 4, '4');
+SYSTEM SYNC REPLICA alter_compression_codec1;
+SYSTEM SYNC REPLICA alter_compression_codec2;
 
-SELECT * FROM test.alter_compression_codec1 ORDER BY id;
-SELECT * FROM test.alter_compression_codec2 ORDER BY id;
+SELECT * FROM alter_compression_codec1 ORDER BY id;
+SELECT * FROM alter_compression_codec2 ORDER BY id;
 
-ALTER TABLE test.alter_compression_codec1 MODIFY COLUMN alter_column CODEC(NONE);
-SELECT compression_codec FROM system.columns WHERE database = 'test' AND table = 'alter_compression_codec1' AND name = 'alter_column';
-SELECT compression_codec FROM system.columns WHERE database = 'test' AND table = 'alter_compression_codec2' AND name = 'alter_column';
+ALTER TABLE alter_compression_codec1 MODIFY COLUMN alter_column CODEC(NONE);
+SELECT compression_codec FROM system.columns WHERE table = 'alter_compression_codec1' AND name = 'alter_column';
+SELECT compression_codec FROM system.columns WHERE table = 'alter_compression_codec2' AND name = 'alter_column';
 
-INSERT INTO test.alter_compression_codec2 VALUES('2018-01-01', 5, '5');
-INSERT INTO test.alter_compression_codec2 VALUES('2018-01-01', 6, '6');
-SYSTEM SYNC REPLICA test.alter_compression_codec1;
-SELECT * FROM test.alter_compression_codec1 ORDER BY id;
-SELECT * FROM test.alter_compression_codec2 ORDER BY id;
+INSERT INTO alter_compression_codec2 VALUES('2018-01-01', 5, '5');
+INSERT INTO alter_compression_codec2 VALUES('2018-01-01', 6, '6');
+SYSTEM SYNC REPLICA alter_compression_codec1;
+SELECT * FROM alter_compression_codec1 ORDER BY id;
+SELECT * FROM alter_compression_codec2 ORDER BY id;
 
-ALTER TABLE test.alter_compression_codec1 MODIFY COLUMN alter_column CODEC(ZSTD, LZ4HC, LZ4, LZ4, NONE);
-SYSTEM SYNC REPLICA test.alter_compression_codec1;
-SYSTEM SYNC REPLICA test.alter_compression_codec2;
-SELECT compression_codec FROM system.columns WHERE database = 'test' AND table = 'alter_compression_codec1' AND name = 'alter_column';
-SELECT compression_codec FROM system.columns WHERE database = 'test' AND table = 'alter_compression_codec2' AND name = 'alter_column';
+ALTER TABLE alter_compression_codec1 MODIFY COLUMN alter_column CODEC(ZSTD, LZ4HC, LZ4, LZ4, NONE);
+SYSTEM SYNC REPLICA alter_compression_codec1;
+SYSTEM SYNC REPLICA alter_compression_codec2;
+SELECT compression_codec FROM system.columns WHERE table = 'alter_compression_codec1' AND name = 'alter_column';
+SELECT compression_codec FROM system.columns WHERE table = 'alter_compression_codec2' AND name = 'alter_column';
 
-INSERT INTO test.alter_compression_codec1 VALUES('2018-01-01', 7, '7');
-INSERT INTO test.alter_compression_codec2 VALUES('2018-01-01', 8, '8');
-SYSTEM SYNC REPLICA test.alter_compression_codec2;
-SYSTEM SYNC REPLICA test.alter_compression_codec1;
-SELECT * FROM test.alter_compression_codec1 ORDER BY id;
-SELECT * FROM test.alter_compression_codec2 ORDER BY id;
+INSERT INTO alter_compression_codec1 VALUES('2018-01-01', 7, '7');
+INSERT INTO alter_compression_codec2 VALUES('2018-01-01', 8, '8');
+SYSTEM SYNC REPLICA alter_compression_codec2;
+SYSTEM SYNC REPLICA alter_compression_codec1;
+SELECT * FROM alter_compression_codec1 ORDER BY id;
+SELECT * FROM alter_compression_codec2 ORDER BY id;
 
-ALTER TABLE test.alter_compression_codec1 MODIFY COLUMN alter_column FixedString(100);
-SYSTEM SYNC REPLICA test.alter_compression_codec2;
-SELECT compression_codec FROM system.columns WHERE database = 'test' AND table = 'alter_compression_codec1' AND name = 'alter_column';
-SELECT compression_codec FROM system.columns WHERE database = 'test' AND table = 'alter_compression_codec2' AND name = 'alter_column';
+ALTER TABLE alter_compression_codec1 MODIFY COLUMN alter_column FixedString(100);
+SYSTEM SYNC REPLICA alter_compression_codec2;
+SELECT compression_codec FROM system.columns WHERE table = 'alter_compression_codec1' AND name = 'alter_column';
+SELECT compression_codec FROM system.columns WHERE table = 'alter_compression_codec2' AND name = 'alter_column';
 
-DROP TABLE IF EXISTS test.alter_compression_codec1;
-DROP TABLE IF EXISTS test.alter_compression_codec2;
+DROP TABLE IF EXISTS alter_compression_codec1;
+DROP TABLE IF EXISTS alter_compression_codec2;

--- a/dbms/tests/queries/0_stateless/00910_zookeeper_test_alter_compression_codecs.sql
+++ b/dbms/tests/queries/0_stateless/00910_zookeeper_test_alter_compression_codecs.sql
@@ -1,4 +1,5 @@
 SET send_logs_level = 'none';
+SET replication_alter_partitions_sync = 2;
 
 DROP TABLE IF EXISTS alter_compression_codec1;
 DROP TABLE IF EXISTS alter_compression_codec2;


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix flacky test `00910_zookeeper_test_alter_compression_codecs`.


Detailed description / Documentation draft:
```
Alexey Milovidov, [05.03.20 15:14]
00910_zookeeper_test_alter_compression_codecs
- странно, стал не проходить почти всё время.

Alexander Sapin, [05.03.20 15:29]
[In reply to Alexey Milovidov]
Там нужно выставить настройку, чтобы альтер синхронно делался на всех репликах . А то мы запускаем альтер и сразу идём в system.columns и срабатывает твоя защита. Видимо старый успевал, а новый иногда не успевает.

Alexey Milovidov, [05.03.20 15:32]
[In reply to Alexander Sapin]
Понял, банальный рейс в тесте. Сейчас попробую выставить.

Alexey Milovidov, [05.03.20 15:35]
@Alesapin Я не понял, какую именно настройку выставлять, сейчас запутано. Есть mutations_sync и replication_alter_partitions_sync. Вторая точно не влияет, а первая теперь влияет на ALTER столбцов?

Alexey Milovidov, [05.03.20 15:38]
@Alesapin А разве не во время запроса, а во время применения ALTER, берётся табличный RWLock? А зачем?

Иван Блинков, [05.03.20 15:43]
[In reply to Alexey Milovidov]
Саша говорит, что надо выставить replication_alter_partitions_sync=2

Alexey Milovidov, [05.03.20 15:44]
[In reply to Иван Блинков]
Какой ужас. При чём тут партиции :(

Иван Блинков, [05.03.20 15:47]
[In reply to Alexey Milovidov]
Саша говорит, что она уже так называлась раньше. Не переименовывать же.
```