### PR TITLE
add NetworkErrors metric description in system.events 

### DIFF
--- a/dbms/src/Common/ProfileEvents.cpp
+++ b/dbms/src/Common/ProfileEvents.cpp
@@ -160,7 +160,7 @@
     M(RWLockAcquiredWriteLocks, "") \
     M(RWLockReadersWaitMilliseconds, "") \
     M(RWLockWritersWaitMilliseconds, "") \
-    M(NetworkErrors, "") \
+    M(NetworkErrors, "Total count of errors in Network communication, currently only errors in DNS cache host resolve") \
     \
     M(RealTimeMicroseconds, "Total (wall clock) time spent in processing (queries and other tasks) threads (not that this is a sum).") \
     M(UserTimeMicroseconds, "Total time spent in processing (queries and other tasks) threads executing CPU instructions in user space. This include time CPU pipeline was stalled due to cache misses, branch mispredictions, hyper-threading, etc.") \


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
Signed-off-by: Slach <bloodjazman@gmail.com>

Changelog category (leave one):
- Documentation (changelog entry is not required)

Description added according to usage this event look at https://github.com/ClickHouse/ClickHouse/search?q=NetworkErrors

