### PR TITLE
Get rid of removeEmptyColumnsFromPart method based on alterDataPart.

### DIFF
--- a/dbms/src/Storages/MergeTree/IMergedBlockOutputStream.cpp
+++ b/dbms/src/Storages/MergeTree/IMergedBlockOutputStream.cpp
@@ -6,6 +6,11 @@
 namespace DB
 {
 
+namespace ErrorCodes
+{
+    extern const int CANNOT_UNLINK;
+}
+
 IMergedBlockOutputStream::IMergedBlockOutputStream(
     const MergeTreeDataPartPtr & data_part)
     : storage(data_part->storage)
@@ -31,6 +36,79 @@ Block IMergedBlockOutputStream::getBlockAndPermute(const Block & block, const Na
     }
 
     return result;
+}
+
+NameSet IMergedBlockOutputStream::removeEmptyColumnsFromPart(
+    const MergeTreeDataPartPtr & data_part,
+    NamesAndTypesList & columns,
+    MergeTreeData::DataPart::Checksums & checksums)
+{
+    const NameSet & empty_columns = data_part->expired_columns;
+
+    /// For compact part we have to override whole file with data, it's not
+    /// worth it
+    if (empty_columns.empty() || isCompactPart(data_part))
+        return {};
+
+    /// Collect counts for shared streams of different columns. As an example, Nested columns have shared stream with array sizes.
+    std::map<String, size_t> stream_counts;
+    for (const NameAndTypePair & column : columns)
+    {
+        column.type->enumerateStreams(
+            [&](const IDataType::SubstreamPath & substream_path)
+            {
+                ++stream_counts[IDataType::getFileNameForStream(column.name, substream_path)];
+            },
+            {});
+    }
+
+    NameSet remove_files;
+    const String mrk_extension = data_part->getMarksFileExtension();
+    for (const auto & column_name : empty_columns)
+    {
+        IDataType::StreamCallback callback = [&](const IDataType::SubstreamPath & substream_path) {
+            String stream_name = IDataType::getFileNameForStream(column_name, substream_path);
+            /// Delete files if they are no longer shared with another column.
+            if (--stream_counts[stream_name] == 0)
+            {
+                remove_files.emplace(stream_name + ".bin");
+                remove_files.emplace(stream_name + mrk_extension);
+            }
+        };
+        IDataType::SubstreamPath stream_path;
+        auto column_with_type = columns.tryGetByName(column_name);
+        if (column_with_type)
+            column_with_type->type->enumerateStreams(callback, stream_path);
+    }
+
+    /// Remove files on disk and checksums
+    for (const String & removed_file : remove_files)
+    {
+        if (checksums.files.count(removed_file))
+        {
+            String path_to_remove = data_part->getFullPath() + removed_file;
+
+            if (0 != unlink(path_to_remove.c_str()))
+                throwFromErrnoWithPath("Cannot unlink file " + path_to_remove, path_to_remove, ErrorCodes::CANNOT_UNLINK);
+
+            checksums.files.erase(removed_file);
+        }
+    }
+
+    /// Remove columns from columns array
+    for (const String & empty_column_name : empty_columns)
+    {
+        auto find_func = [&empty_column_name](const auto & pair) -> bool
+        {
+            return pair.name == empty_column_name;
+        };
+        auto remove_it
+            = std::find_if(columns.begin(), columns.end(), find_func);
+
+        if (remove_it != columns.end())
+            columns.erase(remove_it);
+    }
+    return remove_files;
 }
 
 }

--- a/dbms/src/Storages/MergeTree/IMergedBlockOutputStream.h
+++ b/dbms/src/Storages/MergeTree/IMergedBlockOutputStream.h
@@ -27,6 +27,13 @@ protected:
 
     IDataType::OutputStreamGetter createStreamGetter(const String & name, WrittenOffsetColumns & offset_columns, bool skip_offsets);
 
+    /// Remove all columns marked expired in data_part. Also, clears checksums
+    /// and columns array. Return set of removed files names.
+    NameSet removeEmptyColumnsFromPart(
+        const MergeTreeDataPartPtr & data_part,
+        NamesAndTypesList & columns,
+        MergeTreeData::DataPart::Checksums & checksums);
+
 protected:
     const MergeTreeData & storage;
 

--- a/dbms/src/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.h
@@ -572,9 +572,6 @@ public:
            const ASTPtr & new_settings,
            TableStructureWriteLockHolder & table_lock_holder);
 
-    /// Remove columns, that have been marked as empty after zeroing values with expired ttl
-    void removeEmptyColumnsFromPart(MergeTreeData::MutableDataPartPtr & data_part);
-
     /// Freezes all parts.
     void freezeAll(const String & with_name, const Context & context, TableStructureReadLockHolder & table_lock_holder);
 

--- a/dbms/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
@@ -894,7 +894,8 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataMergerMutator::mergePartsToTempor
                 throw Exception("Cancelled merging parts", ErrorCodes::ABORTED);
 
             column_gathered_stream.readSuffix();
-            checksums_gathered_columns.add(column_to.writeSuffixAndGetChecksums());
+            auto changed_checksums = column_to.writeSuffixAndGetChecksums(new_data_part, checksums_gathered_columns);
+            checksums_gathered_columns.add(std::move(changed_checksums));
 
             if (rows_written != column_elems_written)
             {
@@ -1173,7 +1174,7 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataMergerMutator::mutatePartToTempor
 
             in->readSuffix();
 
-            auto changed_checksums = out.writeSuffixAndGetChecksums();
+            auto changed_checksums = out.writeSuffixAndGetChecksums(new_data_part, new_data_part->checksums);
 
             new_data_part->checksums.add(std::move(changed_checksums));
         }

--- a/dbms/src/Storages/MergeTree/MergedBlockOutputStream.cpp
+++ b/dbms/src/Storages/MergeTree/MergedBlockOutputStream.cpp
@@ -89,8 +89,11 @@ void MergedBlockOutputStream::writeSuffixAndFinalizePart(
     writer->finishPrimaryIndexSerialization(checksums);
     writer->finishSkipIndicesSerialization(checksums);
 
+    NamesAndTypesList part_columns;
     if (!total_columns_list)
-        total_columns_list = &columns_list;
+        part_columns = columns_list;
+    else
+        part_columns = *total_columns_list;
 
     if (storage.format_version >= MERGE_TREE_DATA_MIN_FORMAT_VERSION_WITH_CUSTOM_PARTITIONING || isCompactPart(new_part))
     {
@@ -119,10 +122,12 @@ void MergedBlockOutputStream::writeSuffixAndFinalizePart(
         checksums.files["ttl.txt"].file_hash = out_hashing.getHash();
     }
 
+    removeEmptyColumnsFromPart(new_part, part_columns, checksums);
+
     {
         /// Write a file with a description of columns.
         auto out = disk->writeFile(part_path + "columns.txt", 4096);
-        total_columns_list->writeText(*out);
+        part_columns.writeText(*out);
     }
 
     {
@@ -131,6 +136,7 @@ void MergedBlockOutputStream::writeSuffixAndFinalizePart(
         checksums.write(*out);
     }
 
+    new_part->setColumns(part_columns);
     new_part->rows_count = rows_count;
     new_part->modification_time = time(nullptr);
     new_part->index = writer->releaseIndexColumns();

--- a/dbms/src/Storages/MergeTree/MergedColumnOnlyOutputStream.h
+++ b/dbms/src/Storages/MergeTree/MergedColumnOnlyOutputStream.h
@@ -26,7 +26,8 @@ public:
     Block getHeader() const override { return header; }
     void write(const Block & block) override;
     void writeSuffix() override;
-    MergeTreeData::DataPart::Checksums writeSuffixAndGetChecksums();
+    MergeTreeData::DataPart::Checksums
+    writeSuffixAndGetChecksums(MergeTreeData::MutableDataPartPtr & new_part, MergeTreeData::DataPart::Checksums & all_checksums);
 
 private:
     Block header;

--- a/dbms/src/Storages/StorageMergeTree.cpp
+++ b/dbms/src/Storages/StorageMergeTree.cpp
@@ -666,7 +666,6 @@ bool StorageMergeTree::merge(
             future_part, *merge_entry, table_lock_holder, time(nullptr),
             merging_tagger->reserved_space, deduplicate, force_ttl);
         merger_mutator.renameMergedTemporaryPart(new_part, future_part.parts, nullptr);
-        removeEmptyColumnsFromPart(new_part);
 
         merging_tagger->is_successful = true;
         write_part_log({});
@@ -787,7 +786,6 @@ bool StorageMergeTree::tryMutatePart()
             time(nullptr), global_context, tagger->reserved_space, table_lock_holder);
 
         renameTempPartAndReplace(new_part);
-        removeEmptyColumnsFromPart(new_part);
 
         tagger->is_successful = true;
         write_part_log({});

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1064,7 +1064,6 @@ bool StorageReplicatedMergeTree::tryExecuteMerge(const LogEntry & entry)
             future_merged_part, *merge_entry, table_lock, entry.create_time, reserved_space, entry.deduplicate, entry.force_ttl);
 
         merger_mutator.renameMergedTemporaryPart(part, parts, &transaction);
-        removeEmptyColumnsFromPart(part);
 
         try
         {
@@ -1198,7 +1197,6 @@ bool StorageReplicatedMergeTree::tryExecutePartMutation(const StorageReplicatedM
     {
         new_part = merger_mutator.mutatePartToTemporaryPart(future_mutated_part, commands, *merge_entry, entry.create_time, global_context, reserved_space, table_lock);
         renameTempPartAndReplace(new_part, nullptr, &transaction);
-        removeEmptyColumnsFromPart(new_part);
 
         try
         {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Non-significant (changelog entry is not required)

Just trying to remove alterDataPart from all available places.