### PR TITLE
Add setting for a new format of distributed parts

### DIFF
--- a/dbms/src/Core/Settings.h
+++ b/dbms/src/Core/Settings.h
@@ -397,6 +397,7 @@ struct Settings : public SettingsCollection<Settings>
     \
     M(SettingBool, partial_revokes, false, "Makes it possible to revoke privileges partially.", 0) \
     M(SettingBool, deduplicate_blocks_in_dependent_materialized_views, false, "Should deduplicate blocks for materialized views if the block is not a duplicate for the table. Use true to always deduplicate in dependent tables.", 0) \
+    M(SettingBool, use_compact_format_in_distributed_parts_names, false, "Changes format of directories names for distributed table insert parts.", 0) \
     \
     /** Obsolete settings that do nothing but left for compatibility reasons. Remove each one after half a year of obsolescence. */ \
     \

--- a/dbms/src/Interpreters/Cluster.cpp
+++ b/dbms/src/Interpreters/Cluster.cpp
@@ -135,11 +135,22 @@ std::pair<String, UInt16> Cluster::Address::fromString(const String & host_port_
 }
 
 
-String Cluster::Address::toFullString() const
+String Cluster::Address::toFullString(bool use_compact_format) const
 {
-    return
-        ((shard_index == 0) ? "" : "shard" + std::to_string(shard_index)) +
-        ((replica_index == 0) ? "" : "_replica" + std::to_string(replica_index));
+    if (use_compact_format)
+    {
+        return ((shard_index == 0) ? "" : "shard" + std::to_string(shard_index))
+            + ((replica_index == 0) ? "" : "_replica" + std::to_string(replica_index));
+    }
+    else
+    {
+        return
+            escapeForFileName(user)
+            + (password.empty() ? "" : (':' + escapeForFileName(password))) + '@'
+            + escapeForFileName(host_name) + ':' + std::to_string(port)
+            + (default_database.empty() ? "" : ('#' + escapeForFileName(default_database)))
+            + ((secure == Protocol::Secure::Enable) ? "+secure" : "");
+    }
 }
 
 Cluster::Address Cluster::Address::fromFullString(const String & full_string)
@@ -333,7 +344,7 @@ Cluster::Cluster(const Poco::Util::AbstractConfiguration & config, const Setting
                     {
                         if (internal_replication)
                         {
-                            auto dir_name = replica_addresses.back().toFullString();
+                            auto dir_name = replica_addresses.back().toFullString(settings.use_compact_format_in_distributed_parts_names);
                             if (first)
                                 dir_name_for_internal_replication = dir_name;
                             else

--- a/dbms/src/Interpreters/Cluster.h
+++ b/dbms/src/Interpreters/Cluster.h
@@ -74,8 +74,17 @@ public:
         Protocol::Secure secure = Protocol::Secure::Disable;
 
         Address() = default;
-        Address(const Poco::Util::AbstractConfiguration & config, const String & config_prefix, UInt32 shard_index_ = 0, UInt32 replica_index_ = 0);
-        Address(const String & host_port_, const String & user_, const String & password_, UInt16 clickhouse_port, bool secure_ = false);
+        Address(
+            const Poco::Util::AbstractConfiguration & config,
+            const String & config_prefix,
+            UInt32 shard_index_ = 0,
+            UInt32 replica_index_ = 0);
+        Address(
+            const String & host_port_,
+            const String & user_,
+            const String & password_,
+            UInt16 clickhouse_port,
+            bool secure_ = false);
 
         /// Returns 'escaped_host_name:port'
         String toString() const;
@@ -87,8 +96,10 @@ public:
 
         static std::pair<String, UInt16> fromString(const String & host_port_string);
 
-        /// Returns escaped shard{shard_index}_replica{replica_index}
-        String toFullString() const;
+        /// Returns escaped shard{shard_index}_replica{replica_index} or escaped
+        /// user:password@resolved_host_address:resolved_host_port#default_database
+        /// depending on use_compact_format flag
+        String toFullString(bool use_compact_format) const;
 
         /// Returns address with only shard index and replica index or full address without shard index and replica index
         static Address fromFullString(const String & address_full_string);

--- a/dbms/src/Storages/Distributed/DistributedBlockOutputStream.cpp
+++ b/dbms/src/Storages/Distributed/DistributedBlockOutputStream.cpp
@@ -530,7 +530,7 @@ void DistributedBlockOutputStream::writeAsyncImpl(const Block & block, const siz
         std::vector<std::string> dir_names;
         for (const auto & address : cluster->getShardsAddresses()[shard_id])
             if (!address.is_local)
-                dir_names.push_back(address.toFullString());
+                dir_names.push_back(address.toFullString(context.getSettingsRef().use_compact_format_in_distributed_parts_names));
 
         if (!dir_names.empty())
             writeToShard(block, dir_names);

--- a/dbms/tests/integration/test_distributed_format/test.py
+++ b/dbms/tests/integration/test_distributed_format/test.py
@@ -22,9 +22,9 @@ def started_cluster():
         cluster.shutdown()
 
 
-def test_single_file(started_cluster):
+def test_single_file_new(started_cluster):
     node.query("create table distr_1 (x UInt64, s String) engine = Distributed('test_cluster', database, table)")
-    node.query("insert into distr_1 values (1, 'a'), (2, 'bb'), (3, 'ccc')")
+    node.query("insert into distr_1 values (1, 'a'), (2, 'bb'), (3, 'ccc')", settings={"use_compact_format_in_distributed_parts_names": "1"})
 
     query = "select * from file('/var/lib/clickhouse/data/default/distr_1/shard1_replica1/1.bin', 'Distributed')"
     out = node.exec_in_container(['/usr/bin/clickhouse', 'local', '--stacktrace', '-q', query])
@@ -42,8 +42,8 @@ def test_single_file(started_cluster):
 
 def test_two_files(started_cluster):
     node.query("create table distr_2 (x UInt64, s String) engine = Distributed('test_cluster', database, table)")
-    node.query("insert into distr_2 values (0, '_'), (1, 'a')")
-    node.query("insert into distr_2 values (2, 'bb'), (3, 'ccc')")
+    node.query("insert into distr_2 values (0, '_'), (1, 'a')", settings={"use_compact_format_in_distributed_parts_names": "1"})
+    node.query("insert into distr_2 values (2, 'bb'), (3, 'ccc')", settings={"use_compact_format_in_distributed_parts_names": "1"})
 
     query = "select * from file('/var/lib/clickhouse/data/default/distr_2/shard1_replica1/{1,2,3,4}.bin', 'Distributed') order by x"
     out = node.exec_in_container(['/usr/bin/clickhouse', 'local', '--stacktrace', '-q', query])
@@ -57,3 +57,21 @@ def test_two_files(started_cluster):
     assert out == '0\t_\n1\ta\n2\tbb\n3\tccc\n'
 
     node.query("drop table distr_2")
+
+
+def test_single_file_old(started_cluster):
+    node.query("create table distr_3 (x UInt64, s String) engine = Distributed('test_cluster', database, table)")
+    node.query("insert into distr_3 values (1, 'a'), (2, 'bb'), (3, 'ccc')")
+
+    query = "select * from file('/var/lib/clickhouse/data/default/distr_3/default@not_existing:9000/1.bin', 'Distributed')"
+    out = node.exec_in_container(['/usr/bin/clickhouse', 'local', '--stacktrace', '-q', query])
+
+    assert out == '1\ta\n2\tbb\n3\tccc\n'
+
+    query = "create table t (dummy UInt32) engine = File('Distributed', '/var/lib/clickhouse/data/default/distr_3/default@not_existing:9000/1.bin');" \
+            "select * from t"
+    out = node.exec_in_container(['/usr/bin/clickhouse', 'local', '--stacktrace', '-q', query])
+
+    assert out == '1\ta\n2\tbb\n3\tccc\n'
+
+    node.query("drop table distr_3")

--- a/dbms/tests/integration/test_distributed_storage_configuration/test.py
+++ b/dbms/tests/integration/test_distributed_storage_configuration/test.py
@@ -25,7 +25,7 @@ def _files_in_dist_mon(node, root, table):
         'bash',
         '-c',
         # `-maxdepth 1` to avoid /tmp/ subdirectory
-        'find /{root}/data/default/{table}/shard2_replica1 -maxdepth 1 -type f | wc -l'.format(root=root, table=table)
+        'find /{root}/data/default/{table}/default@127%2E0%2E0%2E2:9000 -maxdepth 1 -type f | wc -l'.format(root=root, table=table)
     ]).split('\n')[0])
 
 def test_different_versions(start_cluster):


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add setting `use_compact_format_in_distributed_parts_names` which allows to write files for `INSERT` queries into `Distributed` table with more compact format. This fixes #9647.