### PR TITLE
It looks like GitHub have improved the code owners feature

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,7 @@
+base/* @ClickHouse/core
+cmake/* @ClickHouse/core
+contrib/* @ClickHouse/core
+dbms/* @ClickHouse/core
 docs/* @ClickHouse/docs
 docs/zh/* @ClickHouse/docs-zh
+website/* @ClickHouse/docs


### PR DESCRIPTION
Changelog category (leave one):
- Non-significant (changelog entry is not required)