### PR TITLE
extended test for deduplicate_blocks_in_dependent_materialized_views

### DIFF
--- a/dbms/tests/integration/test_force_deduplication/test.py
+++ b/dbms/tests/integration/test_force_deduplication/test.py
@@ -24,15 +24,26 @@ def test_basic(start_cluster):
         node.query(
             '''
             CREATE TABLE test (A Int64) ENGINE = ReplicatedMergeTree ('/clickhouse/test/tables/test','1') ORDER BY tuple();
-            CREATE MATERIALIZED VIEW test_mv Engine=ReplicatedMergeTree ('/clickhouse/test/tables/test_mv','1') partition by A order by tuple() AS SELECT A FROM test;
+            CREATE MATERIALIZED VIEW test_mv_a Engine=ReplicatedMergeTree ('/clickhouse/test/tables/test_mv_a','1') order by tuple() AS SELECT A FROM test;
+            CREATE MATERIALIZED VIEW test_mv_b Engine=ReplicatedMergeTree ('/clickhouse/test/tables/test_mv_b','1') partition by A order by tuple() AS SELECT A FROM test;
+            CREATE MATERIALIZED VIEW test_mv_c Engine=ReplicatedMergeTree ('/clickhouse/test/tables/test_mv_c','1') order by tuple() AS SELECT A FROM test;
+            INSERT INTO test values(999);
+            INSERT INTO test values(999);
             SET max_partitions_per_insert_block = 3;
             INSERT INTO test SELECT number FROM numbers(10);
             '''
         )
 
+    assert int(node.query("SELECT count() FROM test")) == 11
+    assert int(node.query("SELECT count() FROM test_mv_a")) == 11
+    assert int(node.query("SELECT count() FROM test_mv_b")) == 1
+    assert int(node.query("SELECT count() FROM test_mv_c")) == 1
+
     node.query("INSERT INTO test SELECT number FROM numbers(10)")
-    assert int(node.query("SELECT count() FROM test")) == 10
-    assert int(node.query("SELECT count() FROM test_mv")) == 0
+    assert int(node.query("SELECT count() FROM test")) == 11
+    assert int(node.query("SELECT count() FROM test_mv_a")) == 11
+    assert int(node.query("SELECT count() FROM test_mv_b")) == 1
+    assert int(node.query("SELECT count() FROM test_mv_c")) == 1
 
     node.query(
         '''
@@ -40,5 +51,7 @@ def test_basic(start_cluster):
         INSERT INTO test SELECT number FROM numbers(10);
         '''
     )
-    assert int(node.query("SELECT count() FROM test")) == 10
-    assert int(node.query("SELECT count() FROM test_mv")) == 10
+    assert int(node.query("SELECT count() FROM test")) == 11
+    assert int(node.query("SELECT count() FROM test_mv_a")) == 21  # first insert was succesfull with disabled dedup..
+    assert int(node.query("SELECT count() FROM test_mv_b")) == 11
+    assert int(node.query("SELECT count() FROM test_mv_c")) == 11


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Non-significant (changelog entry is not required)

