### PR TITLE
Add high-precision timestamp to trace_log

### DIFF
--- a/dbms/programs/server/clickhouse-server.cpp
+++ b/dbms/programs/server/clickhouse-server.cpp
@@ -1,2 +1,24 @@
+#include <new>
+
+#include <common/phdr_cache.h>
+
+
 int mainEntryClickHouseServer(int argc, char ** argv);
-int main(int argc_, char ** argv_) { return mainEntryClickHouseServer(argc_, argv_); }
+
+/**
+  * This is the entry-point for the split build server. The initialization
+  * is copied from single-binary entry point in main.cpp.
+  */
+int main(int argc_, char ** argv_)
+{
+    /// Reset new handler to default (that throws std::bad_alloc)
+    /// It is needed because LLVM library clobbers it.
+    std::set_new_handler(nullptr);
+
+    /// PHDR cache is required for query profiler to work reliably
+    /// It also speed up exception handling, but exceptions from dynamically loaded libraries (dlopen)
+    ///  will work only after additional call of this function.
+    updatePHDRCache();
+
+    return mainEntryClickHouseServer(argc_, argv_);
+}

--- a/dbms/src/Common/Stopwatch.h
+++ b/dbms/src/Common/Stopwatch.h
@@ -6,14 +6,11 @@
 #include <atomic>
 
 
-namespace StopWatchDetail
+inline UInt64 clock_gettime_ns(clockid_t clock_type = CLOCK_MONOTONIC)
 {
-    inline UInt64 nanoseconds(clockid_t clock_type)
-    {
-        struct timespec ts;
-        clock_gettime(clock_type, &ts);
-        return UInt64(ts.tv_sec * 1000000000LL + ts.tv_nsec);
-    }
+    struct timespec ts;
+    clock_gettime(clock_type, &ts);
+    return UInt64(ts.tv_sec * 1000000000LL + ts.tv_nsec);
 }
 
 
@@ -44,7 +41,7 @@ private:
     clockid_t clock_type;
     bool is_running = false;
 
-    UInt64 nanoseconds() const { return StopWatchDetail::nanoseconds(clock_type); }
+    UInt64 nanoseconds() const { return clock_gettime_ns(clock_type); }
 };
 
 
@@ -131,7 +128,7 @@ private:
     clockid_t clock_type;
 
     /// Most significant bit is a lock. When it is set, compareAndRestartDeferred method will return false.
-    UInt64 nanoseconds() const { return StopWatchDetail::nanoseconds(clock_type) & 0x7FFFFFFFFFFFFFFFULL; }
+    UInt64 nanoseconds() const { return clock_gettime_ns(clock_type) & 0x7FFFFFFFFFFFFFFFULL; }
 };
 
 

--- a/dbms/src/Common/TraceCollector.cpp
+++ b/dbms/src/Common/TraceCollector.cpp
@@ -144,7 +144,7 @@ void TraceCollector::run()
 
         if (trace_log)
         {
-            TraceLogElement element{std::time(nullptr), trace_type, thread_id, query_id, trace, size};
+            TraceLogElement element{std::time(nullptr), clock_gettime_ns(), trace_type, thread_id, query_id, trace, size};
             trace_log->add(element);
         }
     }

--- a/dbms/src/Interpreters/TraceLog.cpp
+++ b/dbms/src/Interpreters/TraceLog.cpp
@@ -24,6 +24,7 @@ Block TraceLogElement::createBlock()
     {
         {std::make_shared<DataTypeDate>(),                                    "event_date"},
         {std::make_shared<DataTypeDateTime>(),                                "event_time"},
+        {std::make_shared<DataTypeUInt64>(),                                  "timestamp_ns"},
         {std::make_shared<DataTypeUInt32>(),                                  "revision"},
         {std::make_shared<TraceDataType>(trace_values),                       "trace_type"},
         {std::make_shared<DataTypeUInt64>(),                                  "thread_id"},
@@ -41,6 +42,7 @@ void TraceLogElement::appendToBlock(Block & block) const
 
     columns[i++]->insert(DateLUT::instance().toDayNum(event_time));
     columns[i++]->insert(event_time);
+    columns[i++]->insert(timestamp_ns);
     columns[i++]->insert(ClickHouseRevision::get());
     columns[i++]->insert(static_cast<UInt8>(trace_type));
     columns[i++]->insert(thread_id);

--- a/dbms/src/Interpreters/TraceLog.h
+++ b/dbms/src/Interpreters/TraceLog.h
@@ -15,6 +15,7 @@ struct TraceLogElement
     static const TraceDataType::Values trace_values;
 
     time_t event_time{};
+    UInt64 timestamp_ns{};
     TraceType trace_type{};
     UInt64 thread_id{};
     String query_id{};


### PR DESCRIPTION
This allows to build flame charts, i.e. a timeline of thread profiles. Wanted to make it `codec (DoubleDelta, LZ4)`, but it's impossible to specify in the current system -- probably should switch to just writing out the log table definition in code, instead of columns like we do now. No compression is not so bad, because the timestamp is only a size of a stack frame.

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add a `timestamp_ns` column to `system.trace_log`. It contains a high-definition timestamp of the trace event, and allows to build timelines of thread profiles ("flame charts").