### PR TITLE
random seed by default in groupArraySample

### DIFF
--- a/dbms/src/AggregateFunctions/AggregateFunctionGroupArray.cpp
+++ b/dbms/src/AggregateFunctions/AggregateFunctionGroupArray.cpp
@@ -88,7 +88,7 @@ AggregateFunctionPtr createAggregateFunctionGroupArraySample(const std::string &
     assertUnary(name, argument_types);
 
     UInt64 max_elems = std::numeric_limits<UInt64>::max();
-    UInt64 seed = 123456;
+    UInt64 seed = thread_local_rng();
 
     UInt64 * params[2] = {&max_elems, &seed};
     if (parameters.size() != 1 && parameters.size() != 2)

--- a/dbms/tests/queries/0_stateless/01050_group_array_sample.sql
+++ b/dbms/tests/queries/0_stateless/01050_group_array_sample.sql
@@ -1,4 +1,4 @@
-select k, groupArraySample(10)(v) from (select number % 4 as k, number as v from numbers(1024)) group by k;
+select k, groupArraySample(10, 123456)(v) from (select number % 4 as k, number as v from numbers(1024)) group by k;
 
 -- different seed
 select k, groupArraySample(10, 1)(v) from (select number % 4 as k, number as v from numbers(1024)) group by k;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Non-significant (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Deterministic samples should only be derived by manually supplying a seed value.