### PR TITLE
Fixed race condition in text_log

### DIFF
--- a/base/loggers/OwnSplitChannel.cpp
+++ b/base/loggers/OwnSplitChannel.cpp
@@ -71,7 +71,8 @@ void OwnSplitChannel::logSplit(const Poco::Message & msg)
 
 
     /// Also log to system.text_log table, if message is not too noisy
-    if (text_log_max_priority && msg.getPriority() <= text_log_max_priority)
+    auto text_log_max_priority_loaded = text_log_max_priority.load(std::memory_order_relaxed);
+    if (text_log_max_priority_loaded && msg.getPriority() <= text_log_max_priority_loaded)
     {
         TextLogElement elem;
 
@@ -108,7 +109,7 @@ void OwnSplitChannel::addTextLog(std::shared_ptr<DB::TextLog> log, int max_prior
 {
     std::lock_guard<std::mutex> lock(text_log_mutex);
     text_log = log;
-    text_log_max_priority = max_priority;
+    text_log_max_priority.store(max_priority, std::memory_order_relaxed);
 }
 
 }

--- a/base/loggers/OwnSplitChannel.h
+++ b/base/loggers/OwnSplitChannel.h
@@ -33,7 +33,7 @@ private:
     std::mutex text_log_mutex;
 
     std::weak_ptr<DB::TextLog> text_log;
-    int text_log_max_priority = -1;
+    std::atomic<int> text_log_max_priority = -1;
 };
 
 }


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed data race in `text_log`. It does not correspond to any real bug.


Detailed description / Documentation draft:
```
WARNING: ThreadSanitizer: data race (pid=333)
  Write of size 4 at 0x7b1c00000688 by main thread (mutexes: write M714518851080947280):
    #0 DB::OwnSplitChannel::addTextLog(std::__1::shared_ptr<DB::TextLog>, int) /build/obj-x86_64-linux-gnu/../base/loggers/OwnSplitChannel.cpp:111:27 (clickhouse+0x965cb3e)
    #1 Loggers::buildLoggers(Poco::Util::AbstractConfiguration&, Poco::Logger&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /build/obj-x86_64-linux-gnu/../base/loggers/Loggers.cpp:40:20 (clickhouse+0x9655087)
    #2 DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) /build/obj-x86_64-linux-gnu/../dbms/programs/server/Server.cpp:923:9 (clickhouse+0x942ac92)
    #3 Poco::Util::Application::run() /build/obj-x86_64-linux-gnu/../contrib/poco/Util/src/Application.cpp:335:8 (clickhouse+0x10fdce7d)
    #4 DB::Server::run() /build/obj-x86_64-linux-gnu/../dbms/programs/server/Server.cpp:178:25 (clickhouse+0x9419303)
    #5 Poco::Util::ServerApplication::run(int, char**) /build/obj-x86_64-linux-gnu/../contrib/poco/Util/src/ServerApplication.cpp:618:9 (clickhouse+0x10ffa5e8)
    #6 mainEntryClickHouseServer(int, char**) /build/obj-x86_64-linux-gnu/../dbms/programs/server/Server.cpp:1042:20 (clickhouse+0x9435df3)
    #7 main /build/obj-x86_64-linux-gnu/../dbms/programs/main.cpp:166:12 (clickhouse+0x9412f42)

  Previous read of size 4 at 0x7b1c00000688 by thread T15:
    #0 DB::OwnSplitChannel::logSplit(Poco::Message const&) /build/obj-x86_64-linux-gnu/../base/loggers/OwnSplitChannel.cpp:74:9 (clickhouse+0x965c339)
    #1 DB::OwnSplitChannel::log(Poco::Message const&) /build/obj-x86_64-linux-gnu/../base/loggers/OwnSplitChannel.cpp:35:5 (clickhouse+0x965bbb1)
    #2 DB::MergeTreeSequentialBlockInputStream::MergeTreeSequentialBlockInputStream(DB::MergeTreeData const&, std::__1::shared_ptr<DB::IMergeTreeDataPart const> const&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >, bool, bool, bool) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/MergeTreeSequentialBlockInputStream.cpp:31:9 (clickhouse+0x1077eaaa)
    #3 std::__1::__unique_if<DB::MergeTreeSequentialBlockInputStream>::__unique_single std::__1::make_unique<DB::MergeTreeSequentialBlockInputStream, DB::MergeTreeData&, std::__1::shared_ptr<DB::IMergeTreeDataPart const> const&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >&, bool&, bool>(DB::MergeTreeData&, std::__1::shared_ptr<DB::IMergeTreeDataPart const> const&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >&, bool&, bool&&) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/memory:3028:32 (clickhouse+0x10682714)
    #4 DB::MergeTreeDataMergerMutator::mergePartsToTemporaryPart(DB::FutureMergedMutatedPart const&, DB::MergeListEntry&, DB::TableStructureReadLockHolder&, long, std::__1::unique_ptr<DB::IReservation, std::__1::default_delete<DB::IReservation> > const&, bool, bool) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp:691:22 (clickhouse+0x1066e774)
    #5 DB::StorageMergeTree::merge(bool, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, bool, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageMergeTree.cpp:606:35 (clickhouse+0x1049561a)
    #6 DB::StorageMergeTree::mergeMutateTask() /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageMergeTree.cpp:793:13 (clickhouse+0x10498ccf)
    #7 DB::StorageMergeTree::startup()::$_0::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageMergeTree.cpp:99:99 (clickhouse+0x104a10a3)
    #8 decltype(std::__1::forward<DB::StorageMergeTree::startup()::$_0&>(fp)()) std::__1::__invoke<DB::StorageMergeTree::startup()::$_0&>(DB::StorageMergeTree::startup()::$_0&) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/type_traits:3519 (clickhouse+0x104a10a3)
    #9 DB::BackgroundProcessingPoolTaskResult std::__1::__invoke_void_return_wrapper<DB::BackgroundProcessingPoolTaskResult>::__call<DB::StorageMergeTree::startup()::$_0&>(DB::StorageMergeTree::startup()::$_0&) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/__functional_base:317 (clickhouse+0x104a10a3)
    #10 std::__1::__function::__alloc_func<DB::StorageMergeTree::startup()::$_0, std::__1::allocator<DB::StorageMergeTree::startup()::$_0>, DB::BackgroundProcessingPoolTaskResult ()>::operator()() /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:1540 (clickhouse+0x104a10a3)
    #11 std::__1::__function::__func<DB::StorageMergeTree::startup()::$_0, std::__1::allocator<DB::StorageMergeTree::startup()::$_0>, DB::BackgroundProcessingPoolTaskResult ()>::operator()() /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:1714 (clickhouse+0x104a10a3)
    #12 std::__1::__function::__value_func<DB::BackgroundProcessingPoolTaskResult ()>::operator()() const /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:1867:16 (clickhouse+0x105d8f05)
    #13 std::__1::function<DB::BackgroundProcessingPoolTaskResult ()>::operator()() const /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:2473 (clickhouse+0x105d8f05)
    #14 DB::BackgroundProcessingPool::threadFunction() /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/BackgroundProcessingPool.cpp:200 (clickhouse+0x105d8f05)
    #15 DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/BackgroundProcessingPool.cpp:59:48 (clickhouse+0x105d981b)
    #16 decltype(std::__1::forward<DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0 const&>(fp)()) std::__1::__invoke_constexpr<DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0 const&>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0 const&) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/type_traits:3525 (clickhouse+0x105d981b)
    #17 decltype(auto) std::__1::__apply_tuple_impl<DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0 const&, std::__1::tuple<> const&>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0 const&, std::__1::tuple<> const&, std::__1::__tuple_indices<>) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/tuple:1415 (clickhouse+0x105d981b)
    #18 decltype(auto) std::__1::apply<DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0 const&, std::__1::tuple<> const&>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0 const&, std::__1::tuple<> const&) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/tuple:1424 (clickhouse+0x105d981b)
    #19 ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0&&)::'lambda'()::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.h:159 (clickhouse+0x105d981b)
    #20 decltype(std::__1::forward<DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0>(fp)()) std::__1::__invoke<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0&&)::'lambda'()&>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0&&) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/type_traits:3519 (clickhouse+0x105d981b)
    #21 void std::__1::__invoke_void_return_wrapper<void>::__call<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0&&)::'lambda'()&>(ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0&&)::'lambda'()&) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/__functional_base:348 (clickhouse+0x105d981b)
    #22 std::__1::__function::__alloc_func<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0&&)::'lambda'(), std::__1::allocator<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0&&)::'lambda'()>, void ()>::operator()() /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:1540 (clickhouse+0x105d981b)
    #23 std::__1::__function::__func<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0&&)::'lambda'(), std::__1::allocator<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0&&)::'lambda'()>, void ()>::operator()() /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:1714 (clickhouse+0x105d981b)
    #24 std::__1::__function::__value_func<void ()>::operator()() const /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:1867:16 (clickhouse+0x9485d4d)
    #25 std::__1::function<void ()>::operator()() const /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:2473 (clickhouse+0x9485d4d)
    #26 ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:221 (clickhouse+0x9485d4d)
    #27 void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:102:73 (clickhouse+0x948957c)
    #28 decltype(std::__1::forward<void>(fp)()) std::__1::__invoke<void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(void&&) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/type_traits:3519 (clickhouse+0x948957c)
    #29 void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(std::__1::tuple<void, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>&, std::__1::__tuple_indices<>) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/thread:273 (clickhouse+0x948957c)
    #30 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()> >(void*) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/thread:284 (clickhouse+0x948957c)
    #31 <null> <null> (clickhouse+0x9387422)

  Location is heap block of size 112 at 0x7b1c00000620 allocated by main thread:
    #0 operator new(unsigned long) <null> (clickhouse+0x9410b1d)
    #1 Loggers::buildLoggers(Poco::Util::AbstractConfiguration&, Poco::Logger&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /build/obj-x86_64-linux-gnu/../base/loggers/Loggers.cpp:52:13 (clickhouse+0x9655337)
    #2 BaseDaemon::initialize(Poco::Util::Application&) /build/obj-x86_64-linux-gnu/../base/daemon/BaseDaemon.cpp:698:5 (clickhouse+0x96485dd)
    #3 DB::Server::initialize(Poco::Util::Application&) /build/obj-x86_64-linux-gnu/../dbms/programs/server/Server.cpp:183:17 (clickhouse+0x9419597)
    #4 Poco::Util::Application::run() /build/obj-x86_64-linux-gnu/../contrib/poco/Util/src/Application.cpp:330:2 (clickhouse+0x10fdce64)
    #5 DB::Server::run() /build/obj-x86_64-linux-gnu/../dbms/programs/server/Server.cpp:178:25 (clickhouse+0x9419303)
    #6 Poco::Util::ServerApplication::run(int, char**) /build/obj-x86_64-linux-gnu/../contrib/poco/Util/src/ServerApplication.cpp:618:9 (clickhouse+0x10ffa5e8)
    #7 mainEntryClickHouseServer(int, char**) /build/obj-x86_64-linux-gnu/../dbms/programs/server/Server.cpp:1042:20 (clickhouse+0x9435df3)
    #8 main /build/obj-x86_64-linux-gnu/../dbms/programs/main.cpp:166:12 (clickhouse+0x9412f42)

  Mutex M714518851080947280 is already destroyed.

  Thread T15 'BackgrProcPool' (tid=351, running) created by thread T5 at:
    #0 pthread_create <null> (clickhouse+0x93874a5)
    #1 std::__1::__libcpp_thread_create(unsigned long*, void* (*)(void*), void*) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/__threading_support:394:10 (clickhouse+0x9488b41)
    #2 std::__1::thread::thread<void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'(), void>(void&&) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/thread:300 (clickhouse+0x9488b41)
    #3 void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:102:35 (clickhouse+0x94847dc)
    #4 ThreadPoolImpl<std::__1::thread>::scheduleOrThrow(std::__1::function<void ()>, int, unsigned long) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:138:5 (clickhouse+0x9485208)
    #5 ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0>(DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*)::$_0&&) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.h:149:38 (clickhouse+0x105d78d1)
    #6 DB::BackgroundProcessingPool::BackgroundProcessingPool(int, DB::BackgroundProcessingPool::PoolSettings const&, char const*, char const*) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/BackgroundProcessingPool.cpp:59 (clickhouse+0x105d78d1)
    #7 void std::__1::__optional_storage_base<DB::BackgroundProcessingPool, false>::__construct<DB::SettingNumber<unsigned long>&>(DB::SettingNumber<unsigned long>&) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/optional:323:54 (clickhouse+0xfb6115f)
    #8 DB::BackgroundProcessingPool& std::__1::optional<DB::BackgroundProcessingPool>::emplace<DB::SettingNumber<unsigned long>&, void>(DB::SettingNumber<unsigned long>&) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/optional:829 (clickhouse+0xfb6115f)
    #9 DB::Context::getBackgroundPool() /build/obj-x86_64-linux-gnu/../dbms/src/Interpreters/Context.cpp:1324 (clickhouse+0xfb6115f)
    #10 DB::StorageMergeTree::StorageMergeTree(DB::StorageID const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::StorageInMemoryMetadata const&, bool, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::MergeTreeData::MergingParams const&, std::__1::unique_ptr<DB::MergeTreeSettings, std::__1::default_delete<DB::MergeTreeSettings> >, bool) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageMergeTree.cpp:75:44 (clickhouse+0x1048d8eb)
    #11 std::__1::shared_ptr<DB::StorageMergeTree> ext::shared_ptr_helper<DB::StorageMergeTree>::create<DB::StorageID const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::StorageInMemoryMetadata&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::MergeTreeData::MergingParams&, std::__1::unique_ptr<DB::MergeTreeSettings, std::__1::default_delete<DB::MergeTreeSettings> >, bool const&>(DB::StorageID const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::StorageInMemoryMetadata&, bool const&, DB::Context&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::MergeTreeData::MergingParams&, std::__1::unique_ptr<DB::MergeTreeSettings, std::__1::default_delete<DB::MergeTreeSettings> >&&, bool const&) /build/obj-x86_64-linux-gnu/../base/common/../ext/shared_ptr_helper.h:19:39 (clickhouse+0x1080da34)
    #12 DB::create(DB::StorageFactory::Arguments const&) /build/obj-x86_64-linux-gnu/../dbms/src/Storages/MergeTree/registerStorageMergeTree.cpp:668:16 (clickhouse+0x108078de)
    #13 decltype(std::__1::forward<std::__1::shared_ptr<DB::IStorage> (*&)(DB::StorageFactory::Arguments const&)>(fp)(std::__1::forward<DB::StorageFactory::Arguments const&>(fp0))) std::__1::__invoke<std::__1::shared_ptr<DB::IStorage> (*&)(DB::StorageFactory::Arguments const&), DB::StorageFactory::Arguments const&>(std::__1::shared_ptr<DB::IStorage> (*&)(DB::StorageFactory::Arguments const&), DB::StorageFactory::Arguments const&) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/type_traits:3519:1 (clickhouse+0x1080e64d)
    #14 std::__1::shared_ptr<DB::IStorage> std::__1::__invoke_void_return_wrapper<std::__1::shared_ptr<DB::IStorage> >::__call<std::__1::shared_ptr<DB::IStorage> (*&)(DB::StorageFactory::Arguments const&), DB::StorageFactory::Arguments const&>(std::__1::shared_ptr<DB::IStorage> (*&)(DB::StorageFactory::Arguments const&), DB::StorageFactory::Arguments const&) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/__functional_base:317 (clickhouse+0x1080e64d)
    #15 std::__1::__function::__alloc_func<std::__1::shared_ptr<DB::IStorage> (*)(DB::StorageFactory::Arguments const&), std::__1::allocator<std::__1::shared_ptr<DB::IStorage> (*)(DB::StorageFactory::Arguments const&)>, std::__1::shared_ptr<DB::IStorage> (DB::StorageFactory::Arguments const&)>::operator()(DB::StorageFactory::Arguments const&) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:1540 (clickhouse+0x1080e64d)
    #16 std::__1::__function::__func<std::__1::shared_ptr<DB::IStorage> (*)(DB::StorageFactory::Arguments const&), std::__1::allocator<std::__1::shared_ptr<DB::IStorage> (*)(DB::StorageFactory::Arguments const&)>, std::__1::shared_ptr<DB::IStorage> (DB::StorageFactory::Arguments const&)>::operator()(DB::StorageFactory::Arguments const&) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:1714 (clickhouse+0x1080e64d)
    #17 std::__1::__function::__value_func<std::__1::shared_ptr<DB::IStorage> (DB::StorageFactory::Arguments const&)>::operator()(DB::StorageFactory::Arguments const&) const /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:1867:16 (clickhouse+0x103fd458)
    #18 std::__1::function<std::__1::shared_ptr<DB::IStorage> (DB::StorageFactory::Arguments const&)>::operator()(DB::StorageFactory::Arguments const&) const /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:2473 (clickhouse+0x103fd458)
    #19 DB::StorageFactory::get(DB::ASTCreateQuery const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::Context&, DB::Context&, DB::ColumnsDescription const&, DB::ConstraintsDescription const&, bool) const /build/obj-x86_64-linux-gnu/../dbms/src/Storages/StorageFactory.cpp:183 (clickhouse+0x103fd458)
    #20 DB::createTableFromAST(DB::ASTCreateQuery, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::Context&, bool) /build/obj-x86_64-linux-gnu/../dbms/src/Databases/DatabaseOnDisk.cpp:72:36 (clickhouse+0xfbf4eb9)
    #21 DB::(anonymous namespace)::tryAttachTable(DB::Context&, DB::ASTCreateQuery const&, DB::DatabaseOrdinary&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool) /build/obj-x86_64-linux-gnu/../dbms/src/Databases/DatabaseOrdinary.cpp:63:19 (clickhouse+0xfc0d79b)
    #22 DB::DatabaseOrdinary::loadStoredObjects(DB::Context&, bool)::$_1::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Databases/DatabaseOrdinary.cpp:162 (clickhouse+0xfc0d79b)
    #23 decltype(std::__1::forward<DB::DatabaseOrdinary::loadStoredObjects(DB::Context&, bool)::$_1&>(fp)()) std::__1::__invoke<DB::DatabaseOrdinary::loadStoredObjects(DB::Context&, bool)::$_1&>(DB::DatabaseOrdinary::loadStoredObjects(DB::Context&, bool)::$_1&) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/type_traits:3519 (clickhouse+0xfc0d79b)
    #24 void std::__1::__invoke_void_return_wrapper<void>::__call<DB::DatabaseOrdinary::loadStoredObjects(DB::Context&, bool)::$_1&>(DB::DatabaseOrdinary::loadStoredObjects(DB::Context&, bool)::$_1&) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/__functional_base:348 (clickhouse+0xfc0d79b)
    #25 std::__1::__function::__alloc_func<DB::DatabaseOrdinary::loadStoredObjects(DB::Context&, bool)::$_1, std::__1::allocator<DB::DatabaseOrdinary::loadStoredObjects(DB::Context&, bool)::$_1>, void ()>::operator()() /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:1540 (clickhouse+0xfc0d79b)
    #26 std::__1::__function::__func<DB::DatabaseOrdinary::loadStoredObjects(DB::Context&, bool)::$_1, std::__1::allocator<DB::DatabaseOrdinary::loadStoredObjects(DB::Context&, bool)::$_1>, void ()>::operator()() /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:1714 (clickhouse+0xfc0d79b)
    #27 std::__1::__function::__value_func<void ()>::operator()() const /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:1867:16 (clickhouse+0x948832d)
    #28 std::__1::function<void ()>::operator()() const /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:2473 (clickhouse+0x948832d)
    #29 ThreadPoolImpl<ThreadFromGlobalPool>::worker(std::__1::__list_iterator<ThreadFromGlobalPool, void*>) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:221 (clickhouse+0x948832d)
    #30 void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:102:73 (clickhouse+0x948b407)
    #31 decltype(std::__1::forward<void>(fp)()) std::__1::__invoke_constexpr<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'() const&>(void&&) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/type_traits:3525 (clickhouse+0x948b407)
    #32 decltype(auto) std::__1::__apply_tuple_impl<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'() const&, std::__1::tuple<> const&>(void&&, std::__1::tuple<> const&, std::__1::__tuple_indices<>) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/tuple:1415 (clickhouse+0x948b407)
    #33 decltype(auto) std::__1::apply<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'() const&, std::__1::tuple<> const&>(void&&, std::__1::tuple<> const&) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/tuple:1424 (clickhouse+0x948b407)
    #34 ThreadFromGlobalPool::ThreadFromGlobalPool<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(void&&)::'lambda'()::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.h:159 (clickhouse+0x948b407)
    #35 decltype(std::__1::forward<void>(fp)()) std::__1::__invoke<ThreadFromGlobalPool::ThreadFromGlobalPool<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(void&&)::'lambda'()&>(void&&) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/type_traits:3519:1 (clickhouse+0x948b32d)
    #36 void std::__1::__invoke_void_return_wrapper<void>::__call<ThreadFromGlobalPool::ThreadFromGlobalPool<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(void&&)::'lambda'()&>(ThreadFromGlobalPool::ThreadFromGlobalPool<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(void&&)::'lambda'()&) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/__functional_base:348 (clickhouse+0x948b32d)
    #37 std::__1::__function::__alloc_func<ThreadFromGlobalPool::ThreadFromGlobalPool<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(void&&)::'lambda'(), std::__1::allocator<ThreadFromGlobalPool::ThreadFromGlobalPool<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(void&&)::'lambda'()>, void ()>::operator()() /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:1540 (clickhouse+0x948b32d)
    #38 std::__1::__function::__func<ThreadFromGlobalPool::ThreadFromGlobalPool<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(void&&)::'lambda'(), std::__1::allocator<ThreadFromGlobalPool::ThreadFromGlobalPool<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(void&&)::'lambda'()>, void ()>::operator()() /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:1714 (clickhouse+0x948b32d)
    #39 std::__1::__function::__value_func<void ()>::operator()() const /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:1867:16 (clickhouse+0x9485d4d)
    #40 std::__1::function<void ()>::operator()() const /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:2473 (clickhouse+0x9485d4d)
    #41 ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:221 (clickhouse+0x9485d4d)
    #42 void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()::operator()() const /build/obj-x86_64-linux-gnu/../dbms/src/Common/ThreadPool.cpp:102:73 (clickhouse+0x948957c)
    #43 decltype(std::__1::forward<void>(fp)()) std::__1::__invoke<void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(void&&) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/type_traits:3519 (clickhouse+0x948957c)
    #44 void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(std::__1::tuple<void, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>&, std::__1::__tuple_indices<>) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/thread:273 (clickhouse+0x948957c)
    #45 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()> >(void*) /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/thread:284 (clickhouse+0x948957c)
    #46 <null> <null> (clickhouse+0x9387422)

SUMMARY: ThreadSanitizer: data race /build/obj-x86_64-linux-gnu/../base/loggers/OwnSplitChannel.cpp:111:27 in DB::OwnSplitChannel::addTextLog(std::__1::shared_ptr<DB::TextLog>, int)
==================

```