### PR TITLE
Fix backquoting in dictionary ddl

### DIFF
--- a/dbms/src/Dictionaries/getDictionaryConfigurationFromAST.cpp
+++ b/dbms/src/Dictionaries/getDictionaryConfigurationFromAST.cpp
@@ -1,7 +1,5 @@
 #include <Dictionaries/getDictionaryConfigurationFromAST.h>
 
-#include <IO/ReadBufferFromString.h>
-#include <IO/ReadHelpers.h>
 #include <Poco/DOM/AutoPtr.h>
 #include <Poco/DOM/Document.h>
 #include <Poco/DOM/Element.h>

--- a/dbms/src/Dictionaries/getDictionaryConfigurationFromAST.cpp
+++ b/dbms/src/Dictionaries/getDictionaryConfigurationFromAST.cpp
@@ -39,8 +39,9 @@ String getUnescapedFieldString(const Field & field)
     if (!string.empty() && string.front() == '\'' && string.back() == '\'')
         string = string.substr(1, string.size() - 2);
 
-    /// Backqouting will be performed on dictionary providers side
+    /// Escaping will be performed on dictionary providers side
     boost::replace_all(string, "\\'", "'");
+    boost::replace_all(string, "\\\\", "\\");
     return string;
 }
 

--- a/dbms/src/Dictionaries/getDictionaryConfigurationFromAST.cpp
+++ b/dbms/src/Dictionaries/getDictionaryConfigurationFromAST.cpp
@@ -1,5 +1,6 @@
 #include <Dictionaries/getDictionaryConfigurationFromAST.h>
 
+#include <boost/algorithm/string/replace.hpp>
 #include <Poco/DOM/AutoPtr.h>
 #include <Poco/DOM/Document.h>
 #include <Poco/DOM/Element.h>
@@ -34,8 +35,12 @@ using NamesToTypeNames = std::unordered_map<std::string, std::string>;
 String getUnescapedFieldString(const Field & field)
 {
     String string = applyVisitor(FieldVisitorToString(), field);
+
     if (!string.empty() && string.front() == '\'' && string.back() == '\'')
-        return string.substr(1, string.size() - 2);
+        string = string.substr(1, string.size() - 2);
+
+    /// Backqouting will be performed on dictionary providers side
+    boost::replace_all(string, "\\'", "'");
     return string;
 }
 

--- a/dbms/src/Dictionaries/getDictionaryConfigurationFromAST.cpp
+++ b/dbms/src/Dictionaries/getDictionaryConfigurationFromAST.cpp
@@ -33,17 +33,11 @@ namespace
 using NamesToTypeNames = std::unordered_map<std::string, std::string>;
 /// Get value from field and convert it to string.
 /// Also remove quotes from strings.
-String getUnquotedFieldString(const Field & field)
+String getFieldAsString(const Field & field)
 {
-    String string = applyVisitor(FieldVisitorToString(), field);
-    if (string.front() == '\'')
-    {
-        String result;
-        ReadBufferFromString buf(string);
-        readQuotedString(result, buf);
-        return result;
-    }
-    return string;
+    if (field.getType() == Field::Types::Which::String)
+        return field.get<String>();
+    return applyVisitor(FieldVisitorToString(), field);
 }
 
 
@@ -190,7 +184,7 @@ void buildSingleAttribute(
      AutoPtr<Element> null_value_element(doc->createElement("null_value"));
      String null_value_str;
      if (dict_attr->default_value)
-         null_value_str = getUnquotedFieldString(dict_attr->default_value->as<ASTLiteral>()->value);
+         null_value_str = getFieldAsString(dict_attr->default_value->as<ASTLiteral>()->value);
      AutoPtr<Text> null_value(doc->createTextNode(null_value_str));
      null_value_element->appendChild(null_value);
      attribute_element->appendChild(null_value_element);
@@ -204,7 +198,7 @@ void buildSingleAttribute(
         if (const auto * literal = dict_attr->expression->as<ASTLiteral>();
                 literal && literal->value.getType() == Field::Types::String)
         {
-            expression_str = getUnquotedFieldString(literal->value);
+            expression_str = getFieldAsString(literal->value);
         }
         else
             expression_str = queryToString(dict_attr->expression);
@@ -353,7 +347,7 @@ void buildConfigurationFromFunctionWithKeyValueArguments(
         }
         else if (auto literal = pair->second->as<const ASTLiteral>(); literal)
         {
-            AutoPtr<Text> value(doc->createTextNode(getUnquotedFieldString(literal->value)));
+            AutoPtr<Text> value(doc->createTextNode(getFieldAsString(literal->value)));
             current_xml_element->appendChild(value);
         }
         else if (auto list = pair->second->as<const ASTExpressionList>(); list)

--- a/dbms/tests/integration/test_dictionaries_ddl/test.py
+++ b/dbms/tests/integration/test_dictionaries_ddl/test.py
@@ -234,7 +234,7 @@ def test_dictionary_with_where(started_cluster):
         DB 'clickhouse'
         TABLE 'special_table'
         REPLICA(PRIORITY 1 HOST 'mysql1' PORT 3306)
-        WHERE 'value1 = \\'qweqwe\\''
+        WHERE 'value1 = \\'qweqwe\\' OR value1 = \\'\\\\u3232\\''
     ))
     LAYOUT(FLAT())
     LIFETIME(MIN 1 MAX 3)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bug in backquoting in external dictionaries DDL. Fixes #9619.