### PR TITLE
DiskS3 hardlinks optimal implementation

### DIFF
--- a/dbms/src/Disks/DiskS3.cpp
+++ b/dbms/src/Disks/DiskS3.cpp
@@ -209,10 +209,10 @@ namespace
         std::unique_ptr<ReadBufferFromS3> initialize()
         {
             size_t offset = absolute_position;
-            for (UInt32 i = 0; i < metadata.s3_objects.size(); ++i)
+            for (size_t i = 0; i < metadata.s3_objects.size(); ++i)
             {
                 current_buf_idx = i;
-                auto [path, size] = metadata.s3_objects[i];
+                auto & [path, size] = metadata.s3_objects[i];
                 if (size > offset)
                 {
                     auto buf = std::make_unique<ReadBufferFromS3>(client_ptr, bucket, path, buf_size);
@@ -243,7 +243,7 @@ namespace
                 return false;
 
             ++current_buf_idx;
-            auto path = metadata.s3_objects[current_buf_idx].first;
+            auto & path = metadata.s3_objects[current_buf_idx].first;
             current_buf = std::make_unique<ReadBufferFromS3>(client_ptr, bucket, path, buf_size);
             current_buf->next();
             working_buffer = current_buf->buffer();
@@ -259,7 +259,7 @@ namespace
         size_t buf_size;
 
         size_t absolute_position = 0;
-        UInt32 current_buf_idx = 0;
+        size_t current_buf_idx = 0;
         std::unique_ptr<ReadBufferFromS3> current_buf;
     };
 

--- a/dbms/src/Disks/DiskS3.cpp
+++ b/dbms/src/Disks/DiskS3.cpp
@@ -571,7 +571,7 @@ void DiskS3::remove(const String & path)
         }
         else /// In other case decrement number of references, save metadata and delete file.
         {
-            metadata.ref_count--;
+            --metadata.ref_count;
             metadata.save();
             file.remove();
         }
@@ -641,7 +641,7 @@ void DiskS3::createHardLink(const String & src_path, const String & dst_path)
 {
     /// Increment number of references.
     Metadata src(metadata_path, src_path);
-    src.ref_count++;
+    ++src.ref_count;
     src.save();
 
     /// Create FS hardlink to metadata file.

--- a/dbms/src/Disks/DiskS3.cpp
+++ b/dbms/src/Disks/DiskS3.cpp
@@ -14,6 +14,7 @@
 #    include <IO/WriteHelpers.h>
 #    include <Poco/File.h>
 #    include <Common/checkStackSize.h>
+#    include <Common/createHardLink.h>
 #    include <Common/quoteString.h>
 #    include <Common/thread_local_rng.h>
 
@@ -65,37 +66,38 @@ namespace
 
         using PathAndSize = std::pair<String, size_t>;
 
-        /// Path to metadata file on local FS.
+        /// Disk path.
+        const String & disk_path;
+        /// Relative path to metadata file on local FS.
         String metadata_file_path;
-        /// S3 object references count.
-        UInt32 s3_objects_count;
         /// Total size of all S3 objects.
         size_t total_size;
         /// S3 objects paths and their sizes.
         std::vector<PathAndSize> s3_objects;
-
-        explicit Metadata(const Poco::File & file) : Metadata(file.path(), false) {}
+        /// Number of references (hardlinks) to this metadata file.
+        UInt32 ref_count;
 
         /// Load metadata by path or create empty if `create` flag is set.
-        explicit Metadata(const String & file_path, bool create = false)
-            : metadata_file_path(file_path), s3_objects_count(0), total_size(0), s3_objects(0)
+        explicit Metadata(const String & disk_path_, const String & metadata_file_path_, bool create = false)
+            : disk_path(disk_path_), metadata_file_path(metadata_file_path_), total_size(0), s3_objects(0), ref_count(0)
         {
             if (create)
                 return;
 
-            ReadBufferFromFile buf(file_path, 1024); /* reasonable buffer size for small file */
+            ReadBufferFromFile buf(disk_path + metadata_file_path, 1024); /* reasonable buffer size for small file */
 
             UInt32 version;
             readIntText(version, buf);
 
             if (version != VERSION)
                 throw Exception(
-                    "Unknown metadata file version. Path: " + file_path + ", Version: " + std::to_string(version)
-                        + ", Expected version: " + std::to_string(VERSION),
+                    "Unknown metadata file version. Path: " + disk_path + metadata_file_path
+                        + " Version: " + std::to_string(version) + ", Expected version: " + std::to_string(VERSION),
                     ErrorCodes::UNKNOWN_FORMAT);
 
             assertChar('\n', buf);
 
+            UInt32 s3_objects_count;
             readIntText(s3_objects_count, buf);
             assertChar('\t', buf);
             readIntText(total_size, buf);
@@ -103,19 +105,21 @@ namespace
             s3_objects.resize(s3_objects_count);
             for (UInt32 i = 0; i < s3_objects_count; ++i)
             {
-                String path;
-                size_t size;
-                readIntText(size, buf);
+                String s3_object_path;
+                size_t s3_object_size;
+                readIntText(s3_object_size, buf);
                 assertChar('\t', buf);
-                readEscapedString(path, buf);
+                readEscapedString(s3_object_path, buf);
                 assertChar('\n', buf);
-                s3_objects[i] = std::make_pair(path, size);
+                s3_objects[i] = {s3_object_path, s3_object_size};
             }
+
+            readIntText(ref_count, buf);
+            assertChar('\n', buf);
         }
 
         void addObject(const String & path, size_t size)
         {
-            ++s3_objects_count;
             total_size += size;
             s3_objects.emplace_back(path, size);
         }
@@ -123,23 +127,26 @@ namespace
         /// Fsync metadata file if 'sync' flag is set.
         void save(bool sync = false)
         {
-            WriteBufferFromFile buf(metadata_file_path, 1024);
+            WriteBufferFromFile buf(disk_path + metadata_file_path, 1024);
 
             writeIntText(VERSION, buf);
             writeChar('\n', buf);
 
-            writeIntText(s3_objects_count, buf);
+            writeIntText(s3_objects.size(), buf);
             writeChar('\t', buf);
             writeIntText(total_size, buf);
             writeChar('\n', buf);
-            for (UInt32 i = 0; i < s3_objects_count; ++i)
+            for (const auto & [s3_object_path, s3_object_size] : s3_objects)
             {
-                auto path_and_size = s3_objects[i];
-                writeIntText(path_and_size.second, buf);
+                writeIntText(s3_object_size, buf);
                 writeChar('\t', buf);
-                writeEscapedString(path_and_size.first, buf);
+                writeEscapedString(s3_object_path, buf);
                 writeChar('\n', buf);
             }
+
+            writeIntText(ref_count, buf);
+            writeChar('\n', buf);
+
             buf.finalize();
             if (sync)
                 buf.sync();
@@ -152,10 +159,7 @@ namespace
     public:
         ReadIndirectBufferFromS3(
             std::shared_ptr<Aws::S3::S3Client> client_ptr_, const String & bucket_, Metadata metadata_, size_t buf_size_)
-            : client_ptr(std::move(client_ptr_)),
-            bucket(bucket_),
-            metadata(std::move(metadata_)),
-            buf_size(buf_size_)
+            : client_ptr(std::move(client_ptr_)), bucket(bucket_), metadata(std::move(metadata_)), buf_size(buf_size_)
         {
         }
 
@@ -205,7 +209,7 @@ namespace
         std::unique_ptr<ReadBufferFromS3> initialize()
         {
             size_t offset = absolute_position;
-            for (UInt32 i = 0; i < metadata.s3_objects_count; ++i)
+            for (UInt32 i = 0; i < metadata.s3_objects.size(); ++i)
             {
                 current_buf_idx = i;
                 auto [path, size] = metadata.s3_objects[i];
@@ -235,7 +239,7 @@ namespace
             }
 
             /// If there is no available buffers - nothing to read.
-            if (current_buf_idx + 1 >= metadata.s3_objects_count)
+            if (current_buf_idx + 1 >= metadata.s3_objects.size())
                 return false;
 
             ++current_buf_idx;
@@ -429,7 +433,7 @@ bool DiskS3::isDirectory(const String & path) const
 
 size_t DiskS3::getFileSize(const String & path) const
 {
-    Metadata metadata(metadata_path + path);
+    Metadata metadata(metadata_path, path);
     return metadata.total_size;
 }
 
@@ -482,8 +486,8 @@ void DiskS3::copyFile(const String & from_path, const String & to_path)
     if (exists(to_path))
         remove(to_path);
 
-    Metadata from(metadata_path + from_path);
-    Metadata to(metadata_path + to_path, true);
+    Metadata from(metadata_path, from_path);
+    Metadata to(metadata_path, to_path, true);
 
     for (const auto & [path, size] : from.s3_objects)
     {
@@ -502,11 +506,11 @@ void DiskS3::copyFile(const String & from_path, const String & to_path)
 
 std::unique_ptr<ReadBufferFromFileBase> DiskS3::readFile(const String & path, size_t buf_size, size_t, size_t, size_t) const
 {
-    Metadata metadata(metadata_path + path);
+    Metadata metadata(metadata_path, path);
 
     LOG_DEBUG(
         &Logger::get("DiskS3"),
-        "Read from file by path: " << backQuote(metadata_path + path) << " Existing S3 objects: " << metadata.s3_objects_count);
+        "Read from file by path: " << backQuote(metadata_path + path) << " Existing S3 objects: " << metadata.s3_objects.size());
 
     return std::make_unique<ReadIndirectBufferFromS3>(client, bucket, metadata, buf_size);
 }
@@ -522,7 +526,7 @@ std::unique_ptr<WriteBufferFromFileBase> DiskS3::writeFile(const String & path, 
         if (exist)
             remove(path);
 
-        Metadata metadata(metadata_path + path, true);
+        Metadata metadata(metadata_path, path, true);
         /// Save empty metadata to disk to have ability to get file size while buffer is not finalized.
         metadata.save();
 
@@ -532,12 +536,12 @@ std::unique_ptr<WriteBufferFromFileBase> DiskS3::writeFile(const String & path, 
     }
     else
     {
-        Metadata metadata(metadata_path + path);
+        Metadata metadata(metadata_path, path);
 
         LOG_DEBUG(
             &Logger::get("DiskS3"),
             "Append to file by path: " << backQuote(metadata_path + path) << " New S3 path: " << s3_path
-                                       << " Existing S3 objects: " << metadata.s3_objects_count);
+                                       << " Existing S3 objects: " << metadata.s3_objects.size());
 
         return std::make_unique<WriteIndirectBufferFromS3>(client, bucket, metadata, s3_path, min_upload_part_size, buf_size);
     }
@@ -550,19 +554,28 @@ void DiskS3::remove(const String & path)
     Poco::File file(metadata_path + path);
     if (file.isFile())
     {
-        Metadata metadata(file);
-        for (UInt32 i = 0; i < metadata.s3_objects_count; ++i)
-        {
-            auto s3_path = metadata.s3_objects[i].first;
+        Metadata metadata(metadata_path, path);
 
-            /// TODO: Make operation idempotent. Do not throw exception if key is already deleted.
-            Aws::S3::Model::DeleteObjectRequest request;
-            request.SetBucket(bucket);
-            request.SetKey(s3_path);
-            throwIfError(client->DeleteObject(request));
+        /// If there is no references - delete content from S3.
+        if (metadata.ref_count == 0)
+        {
+            file.remove();
+            for (const auto & [s3_object_path, _] : metadata.s3_objects)
+            {
+                /// TODO: Make operation idempotent. Do not throw exception if key is already deleted.
+                Aws::S3::Model::DeleteObjectRequest request;
+                request.SetBucket(bucket);
+                request.SetKey(s3_object_path);
+                throwIfError(client->DeleteObject(request));
+            }
+        }
+        else /// In other case decrement number of references, save metadata and delete file.
+        {
+            metadata.ref_count--;
+            metadata.save();
+            file.remove();
         }
     }
-    file.remove();
 }
 
 void DiskS3::removeRecursive(const String & path)
@@ -626,18 +639,19 @@ Poco::Timestamp DiskS3::getLastModified(const String & path)
 
 void DiskS3::createHardLink(const String & src_path, const String & dst_path)
 {
-    /**
-     * TODO: Replace with optimal implementation:
-     * Store links into a list in metadata file.
-     * Hardlink creation is adding new link to list and just metadata file copy.
-     */
-    copyFile(src_path, dst_path);
+    /// Increment number of references.
+    Metadata src(metadata_path, src_path);
+    src.ref_count++;
+    src.save();
+
+    /// Create FS hardlink to metadata file.
+    DB::createHardLink(metadata_path + src_path, metadata_path + dst_path);
 }
 
 void DiskS3::createFile(const String & path)
 {
     /// Create empty metadata file.
-    Metadata metadata(metadata_path + path, true);
+    Metadata metadata(metadata_path, path, true);
     metadata.save();
 }
 

--- a/dbms/src/Disks/DiskS3.cpp
+++ b/dbms/src/Disks/DiskS3.cpp
@@ -212,7 +212,7 @@ namespace
             for (size_t i = 0; i < metadata.s3_objects.size(); ++i)
             {
                 current_buf_idx = i;
-                auto & [path, size] = metadata.s3_objects[i];
+                const auto & [path, size] = metadata.s3_objects[i];
                 if (size > offset)
                 {
                     auto buf = std::make_unique<ReadBufferFromS3>(client_ptr, bucket, path, buf_size);
@@ -243,7 +243,7 @@ namespace
                 return false;
 
             ++current_buf_idx;
-            auto & path = metadata.s3_objects[current_buf_idx].first;
+            const auto & path = metadata.s3_objects[current_buf_idx].first;
             current_buf = std::make_unique<ReadBufferFromS3>(client_ptr, bucket, path, buf_size);
             current_buf->next();
             working_buffer = current_buf->buffer();
@@ -576,6 +576,8 @@ void DiskS3::remove(const String & path)
             file.remove();
         }
     }
+    else
+        file.remove();
 }
 
 void DiskS3::removeRecursive(const String & path)

--- a/dbms/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/dbms/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -706,7 +706,7 @@ void IMergeTreeDataPart::remove() const
 
         try
         {
-            disk->removeRecursive(to);
+            disk->removeRecursive(to + "/");
         }
         catch (...)
         {

--- a/dbms/tests/integration/test_merge_tree_s3/test.py
+++ b/dbms/tests/integration/test_merge_tree_s3/test.py
@@ -54,11 +54,11 @@ def generate_values(date_str, count, sign=1):
     return ",".join(["('{}',{},'{}')".format(x, y, z) for x, y, z in data])
 
 
-def create_table(cluster, additional_settings=None):
+def create_table(cluster, table_name, additional_settings=None):
     node = cluster.instances["node"]
 
     create_table_statement = """
-        CREATE TABLE s3_test(
+        CREATE TABLE {} (
             dt Date,
             id Int64,
             data String,
@@ -68,7 +68,7 @@ def create_table(cluster, additional_settings=None):
         ORDER BY (dt, id)
         SETTINGS 
             old_parts_lifetime=0, index_granularity=512
-        """
+        """.format(table_name)
 
     if additional_settings:
         create_table_statement += ","
@@ -83,7 +83,7 @@ def drop_table(cluster):
     node = cluster.instances["node"]
     minio = cluster.minio_client
 
-    node.query("DROP TABLE s3_test")
+    node.query("DROP TABLE IF EXISTS s3_test")
     assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == 0
 
 
@@ -95,7 +95,7 @@ def drop_table(cluster):
     ]
 )
 def test_simple_insert_select(cluster, min_rows_for_wide_part, files_per_part):
-    create_table(cluster, "min_rows_for_wide_part={}".format(min_rows_for_wide_part))
+    create_table(cluster, "s3_test", additional_settings="min_rows_for_wide_part={}".format(min_rows_for_wide_part))
 
     node = cluster.instances["node"]
     minio = cluster.minio_client
@@ -123,7 +123,7 @@ def test_insert_same_partition_and_merge(cluster, merge_vertical):
             vertical_merge_algorithm_min_rows_to_activate=0,
             vertical_merge_algorithm_min_columns_to_activate=0
         """
-    create_table(cluster, settings)
+    create_table(cluster, "s3_test", additional_settings=settings)
 
     node = cluster.instances["node"]
     minio = cluster.minio_client
@@ -149,7 +149,7 @@ def test_insert_same_partition_and_merge(cluster, merge_vertical):
 
 
 def test_alter_table_columns(cluster):
-    create_table(cluster)
+    create_table(cluster, "s3_test")
 
     node = cluster.instances["node"]
     minio = cluster.minio_client
@@ -177,7 +177,7 @@ def test_alter_table_columns(cluster):
 
 
 def test_attach_detach_partition(cluster):
-    create_table(cluster)
+    create_table(cluster, "s3_test")
 
     node = cluster.instances["node"]
     minio = cluster.minio_client
@@ -205,8 +205,8 @@ def test_attach_detach_partition(cluster):
     assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD
 
 
-def test_move_partition(cluster):
-    create_table(cluster)
+def test_move_partition_to_another_disk(cluster):
+    create_table(cluster, "s3_test")
 
     node = cluster.instances["node"]
     minio = cluster.minio_client
@@ -222,7 +222,7 @@ def test_move_partition(cluster):
 
 
 def test_table_manipulations(cluster):
-    create_table(cluster)
+    create_table(cluster, "s3_test")
 
     node = cluster.instances["node"]
     minio = cluster.minio_client
@@ -246,3 +246,64 @@ def test_table_manipulations(cluster):
     node.query("TRUNCATE TABLE s3_test")
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(0)"
     assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD
+
+
+def test_move_replace_partition_to_another_table(cluster):
+    create_table(cluster, "s3_test")
+
+    node = cluster.instances["node"]
+    minio = cluster.minio_client
+
+    node.query("INSERT INTO s3_test VALUES {}".format(generate_values('2020-01-03', 4096)))
+    node.query("INSERT INTO s3_test VALUES {}".format(generate_values('2020-01-04', 4096)))
+    node.query("INSERT INTO s3_test VALUES {}".format(generate_values('2020-01-05', 4096, -1)))
+    node.query("INSERT INTO s3_test VALUES {}".format(generate_values('2020-01-06', 4096, -1)))
+    assert node.query("SELECT sum(id) FROM s3_test FORMAT Values") == "(0)"
+    assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(16384)"
+    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE*4
+
+    create_table(cluster, "s3_clone")
+
+    node.query("ALTER TABLE s3_test MOVE PARTITION '2020-01-03' TO TABLE s3_clone")
+    node.query("ALTER TABLE s3_test MOVE PARTITION '2020-01-05' TO TABLE s3_clone")
+    assert node.query("SELECT sum(id) FROM s3_test FORMAT Values") == "(0)"
+    assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(8192)"
+    assert node.query("SELECT sum(id) FROM s3_clone FORMAT Values") == "(0)"
+    assert node.query("SELECT count(*) FROM s3_clone FORMAT Values") == "(8192)"
+    # Number of objects in S3 should be unchanged.
+    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD*2 + FILES_OVERHEAD_PER_PART_WIDE*4
+
+    # Add new partitions to source table, but with different values and replace them from copied table.
+    node.query("INSERT INTO s3_test VALUES {}".format(generate_values('2020-01-03', 4096, -1)))
+    node.query("INSERT INTO s3_test VALUES {}".format(generate_values('2020-01-05', 4096)))
+    assert node.query("SELECT sum(id) FROM s3_test FORMAT Values") == "(0)"
+    assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(16384)"
+    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD*2 + FILES_OVERHEAD_PER_PART_WIDE*6
+
+    node.query("ALTER TABLE s3_test REPLACE PARTITION '2020-01-03' FROM s3_clone")
+    node.query("ALTER TABLE s3_test REPLACE PARTITION '2020-01-05' FROM s3_clone")
+    assert node.query("SELECT sum(id) FROM s3_test FORMAT Values") == "(0)"
+    assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(16384)"
+    assert node.query("SELECT sum(id) FROM s3_clone FORMAT Values") == "(0)"
+    assert node.query("SELECT count(*) FROM s3_clone FORMAT Values") == "(8192)"
+
+    # Wait for outdated partitions deletion.
+    time.sleep(3)
+    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD*2 + FILES_OVERHEAD_PER_PART_WIDE*4
+
+    node.query("DROP TABLE s3_clone")
+    assert node.query("SELECT sum(id) FROM s3_test FORMAT Values") == "(0)"
+    assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(16384)"
+    # Data should remain in S3
+    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE*4
+
+    node.query("ALTER TABLE s3_test FREEZE")
+    # Number S3 objects should be unchanged.
+    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE*4
+
+    node.query("DROP TABLE s3_test")
+    # Backup data should remain in S3.
+    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD_PER_PART_WIDE*4
+
+    for obj in list(minio.list_objects(cluster.minio_bucket, 'data/')):
+        minio.remove_object(cluster.minio_bucket, obj.object_name)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
DiskS3 hard links optimal implementation.

Detailed description / Documentation draft:
Each metadata file now holds number references (hard links) to itself.
When we create a hard link in DiskS3 we increment the number of references in the metadata file on what we create a hard link and then create a real FS hard link to that file.
When we remove the file we decrement the number of references in the metadata file. If the number of references is zero - we delete content from S3.
New tests for partitions moving/replacing/freezing that use hard links underneath have added.