### PR TITLE
Remove unused (obsolete) code from ThreadPool

### DIFF
--- a/dbms/src/Common/ThreadPool.cpp
+++ b/dbms/src/Common/ThreadPool.cpp
@@ -270,36 +270,6 @@ template class ThreadPoolImpl<std::thread>;
 template class ThreadPoolImpl<ThreadFromGlobalPool>;
 
 
-void ExceptionHandler::setException(std::exception_ptr exception)
-{
-    std::unique_lock lock(mutex);
-    if (!first_exception)
-        first_exception = std::move(exception); // NOLINT
-}
-
-void ExceptionHandler::throwIfException()
-{
-    std::unique_lock lock(mutex);
-    if (first_exception)
-        std::rethrow_exception(first_exception);
-}
-
-
-ThreadPool::Job createExceptionHandledJob(ThreadPool::Job job, ExceptionHandler & handler)
-{
-    return [job{std::move(job)}, &handler] ()
-    {
-        try
-        {
-            job();
-        }
-        catch (...)
-        {
-            handler.setException(std::current_exception());
-        }
-    };
-}
-
 GlobalThreadPool & GlobalThreadPool::instance()
 {
     static GlobalThreadPool ret;

--- a/dbms/src/Common/ThreadPool.h
+++ b/dbms/src/Common/ThreadPool.h
@@ -216,18 +216,3 @@ private:
 
 /// Recommended thread pool for the case when multiple thread pools are created and destroyed.
 using ThreadPool = ThreadPoolImpl<ThreadFromGlobalPool>;
-
-
-/// Allows to save first catched exception in jobs and postpone its rethrow.
-class ExceptionHandler
-{
-public:
-    void setException(std::exception_ptr exception);
-    void throwIfException();
-
-private:
-    std::exception_ptr first_exception;
-    std::mutex mutex;
-};
-
-ThreadPool::Job createExceptionHandledJob(ThreadPool::Job job, ExceptionHandler & handler);


### PR DESCRIPTION
Changelog category (leave one):
- Non-significant (changelog entry is not required)
