### PR TITLE
Expose ProcessListForUserInfo structure from ProcessList.

### DIFF
--- a/dbms/src/Interpreters/ProcessList.h
+++ b/dbms/src/Interpreters/ProcessList.h
@@ -197,6 +197,17 @@ public:
 };
 
 
+/// Information of process list for user.
+struct ProcessListForUserInfo
+{
+    Int64 memory_usage;
+    Int64 peak_memory_usage;
+
+    // Optional field, filled by request.
+    std::shared_ptr<ProfileEvents::Counters> profile_counters;
+};
+
+
 /// Data about queries for one user.
 struct ProcessListForUser
 {
@@ -212,6 +223,8 @@ struct ProcessListForUser
 
     /// Count network usage for all simultaneously running queries of single user.
     ThrottlerPtr user_throttler;
+
+    ProcessListForUserInfo getInfo(bool get_profile_events = false) const;
 
     /// Clears MemoryTracker for the user.
     /// Sometimes it is important to reset the MemoryTracker, because it may accumulate skew
@@ -261,6 +274,8 @@ public:
     /// list, for iterators not to invalidate. NOTE: could replace with cyclic buffer, but not worth.
     using Container = std::list<Element>;
     using Info = std::vector<QueryStatusInfo>;
+    using UserInfo = std::unordered_map<String, ProcessListForUserInfo>;
+
     /// User -> queries
     using UserToQueries = std::unordered_map<String, ProcessListForUser>;
 
@@ -306,6 +321,9 @@ public:
 
     /// Get current state of process list.
     Info getInfo(bool get_thread_list = false, bool get_profile_events = false, bool get_settings = false) const;
+
+    /// Get current state of process list per user.
+    UserInfo getUserInfo(bool get_profile_events = false) const;
 
     void setMaxSize(size_t max_size_)
     {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Similarly to `QueryStatusInfo`, which may be retrieved to get information about `QueryStatuses` via `ProcessList::getInfo()`, we introduce new structure `ProcessListForUserInfo`, which represents `ProcessListForUser`. It allows third-party code using ClickHouse as a library to retrieve per-user statistics like peak memory usage or profile counters, which is currently impossible to do.

Changelog category (leave one):
- Non-significant (changelog entry is not required)

