### PR TITLE
Add PHP simpod/clickhouse-client

### DIFF
--- a/docs/en/interfaces/third-party/client_libraries.md
+++ b/docs/en/interfaces/third-party/client_libraries.md
@@ -12,6 +12,7 @@
     -   [smi2/phpclickhouse](https://packagist.org/packages/smi2/phpClickHouse)
     -   [8bitov/clickhouse-php-client](https://packagist.org/packages/8bitov/clickhouse-php-client)
     -   [bozerkins/clickhouse-client](https://packagist.org/packages/bozerkins/clickhouse-client)
+    -   [simpod/clickhouse-client](https://packagist.org/packages/simpod/clickhouse-client)
     -   [seva-code/php-click-house-client](https://packagist.org/packages/seva-code/php-click-house-client)
     -   [SeasClick C++ client](https://github.com/SeasX/SeasClick)
 -   Go

--- a/docs/es/interfaces/third-party/client_libraries.md
+++ b/docs/es/interfaces/third-party/client_libraries.md
@@ -12,6 +12,7 @@
     -   [smi2/phpclickhouse](https://packagist.org/packages/smi2/phpClickHouse)
     -   [8bitov/clickhouse-php-client](https://packagist.org/packages/8bitov/clickhouse-php-client)
     -   [bozerkins/clickhouse-client](https://packagist.org/packages/bozerkins/clickhouse-client)
+    -   [simpod/clickhouse-client](https://packagist.org/packages/simpod/clickhouse-client)
     -   [seva-code/php-click-house-client](https://packagist.org/packages/seva-code/php-click-house-client)
     -   [SeasClick C++ client](https://github.com/SeasX/SeasClick)
 -   Ve

--- a/docs/fa/interfaces/third-party/client_libraries.md
+++ b/docs/fa/interfaces/third-party/client_libraries.md
@@ -13,6 +13,7 @@
     -   [smi2/phpclickhouse](https://packagist.org/packages/smi2/phpClickHouse)
     -   [8bitov/clickhouse-php-client](https://packagist.org/packages/8bitov/clickhouse-php-client)
     -   [bozerkins/clickhouse-client](https://packagist.org/packages/bozerkins/clickhouse-client)
+    -   [simpod/clickhouse-client](https://packagist.org/packages/simpod/clickhouse-client)
     -   [seva-code/php-click-house-client](https://packagist.org/packages/seva-code/php-click-house-client)
     -   [SeasClick C++ client](https://github.com/SeasX/SeasClick)
 -   Go

--- a/docs/ru/interfaces/third-party/client_libraries.md
+++ b/docs/ru/interfaces/third-party/client_libraries.md
@@ -12,6 +12,7 @@
     -   [smi2/phpclickhouse](https://packagist.org/packages/smi2/phpClickHouse)
     -   [8bitov/clickhouse-php-client](https://packagist.org/packages/8bitov/clickhouse-php-client)
     -   [bozerkins/clickhouse-client](https://packagist.org/packages/bozerkins/clickhouse-client)
+    -   [simpod/clickhouse-client](https://packagist.org/packages/simpod/clickhouse-client)
     -   [seva-code/php-click-house-client](https://packagist.org/packages/seva-code/php-click-house-client)
     -   [SeasClick C++ client](https://github.com/SeasX/SeasClick)
 -   Go

--- a/docs/zh/interfaces/third-party/client_libraries.md
+++ b/docs/zh/interfaces/third-party/client_libraries.md
@@ -11,6 +11,7 @@
     -   [smi2/phpclickhouse](https://packagist.org/packages/smi2/phpClickHouse)
     -   [8bitov/clickhouse-php-client](https://packagist.org/packages/8bitov/clickhouse-php-client)
     -   [bozerkins/clickhouse-client](https://packagist.org/packages/bozerkins/clickhouse-client)
+    -   [simpod/clickhouse-client](https://packagist.org/packages/simpod/clickhouse-client)
     -   [seva-code/php-click-house-client](https://packagist.org/packages/seva-code/php-click-house-client)
     -   [SeasClick C++ client](https://github.com/SeasX/SeasClick)
 -   Go


### PR DESCRIPTION
Yet another ClickHouse client

- all formats support leveraging PHP generics for type safety
- lightweight
- swappable http client
- guarded by Infection + PHPStan and PSalm max levels

- sort libs by usages

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)