### PR TITLE
Change PHP client names to <vendor/lib> format

### DIFF
--- a/docs/en/interfaces/third-party/client_libraries.md
+++ b/docs/en/interfaces/third-party/client_libraries.md
@@ -9,11 +9,11 @@
     -   [clickhouse-client](https://github.com/yurial/clickhouse-client)
     -   [aiochclient](https://github.com/maximdanilchenko/aiochclient)
 -   PHP
-    -   [SeasClick](https://github.com/SeasX/SeasClick)
-    -   [phpClickHouse](https://github.com/smi2/phpClickHouse)
-    -   [clickhouse-php-client](https://github.com/8bitov/clickhouse-php-client)
-    -   [clickhouse-client](https://github.com/bozerkins/clickhouse-client)
-    -   [PhpClickHouseClient](https://github.com/SevaCode/PhpClickHouseClient)
+    -   [smi2/phpclickhouse](https://packagist.org/packages/smi2/phpClickHouse)
+    -   [8bitov/clickhouse-php-client](https://packagist.org/packages/8bitov/clickhouse-php-client)
+    -   [bozerkins/clickhouse-client](https://packagist.org/packages/bozerkins/clickhouse-client)
+    -   [seva-code/php-click-house-client](https://packagist.org/packages/seva-code/php-click-house-client)
+    -   [SeasClick C++ client](https://github.com/SeasX/SeasClick)
 -   Go
     -   [clickhouse](https://github.com/kshvakov/clickhouse/)
     -   [go-clickhouse](https://github.com/roistat/go-clickhouse)

--- a/docs/es/interfaces/third-party/client_libraries.md
+++ b/docs/es/interfaces/third-party/client_libraries.md
@@ -9,11 +9,11 @@
     -   [Casa de clics-cliente](https://github.com/yurial/clickhouse-client)
     -   [Aiochclient](https://github.com/maximdanilchenko/aiochclient)
 -   PHP
-    -   [Método de codificación de datos:](https://github.com/SeasX/SeasClick)
-    -   [Inicio](https://github.com/smi2/phpClickHouse)
-    -   [Sistema abierto.](https://github.com/8bitov/clickhouse-php-client)
-    -   [Casa de clics-cliente](https://github.com/bozerkins/clickhouse-client)
-    -   [PhpClickHouseClient](https://github.com/SevaCode/PhpClickHouseClient)
+    -   [smi2/phpclickhouse](https://packagist.org/packages/smi2/phpClickHouse)
+    -   [8bitov/clickhouse-php-client](https://packagist.org/packages/8bitov/clickhouse-php-client)
+    -   [bozerkins/clickhouse-client](https://packagist.org/packages/bozerkins/clickhouse-client)
+    -   [seva-code/php-click-house-client](https://packagist.org/packages/seva-code/php-click-house-client)
+    -   [SeasClick C++ client](https://github.com/SeasX/SeasClick)
 -   Ve
     -   [Casa de clics](https://github.com/kshvakov/clickhouse/)
     -   [Sistema abierto.](https://github.com/roistat/go-clickhouse)

--- a/docs/fa/interfaces/third-party/client_libraries.md
+++ b/docs/fa/interfaces/third-party/client_libraries.md
@@ -10,10 +10,11 @@
     -   [clickhouse-driver](https://github.com/mymarilyn/clickhouse-driver)
     -   [clickhouse-client](https://github.com/yurial/clickhouse-client)
 -   PHP
-    -   [phpClickHouse](https://github.com/smi2/phpClickHouse)
-    -   [clickhouse-php-client](https://github.com/8bitov/clickhouse-php-client)
-    -   [clickhouse-client](https://github.com/bozerkins/clickhouse-client)
-    -   [PhpClickHouseClient](https://github.com/SevaCode/PhpClickHouseClient)
+    -   [smi2/phpclickhouse](https://packagist.org/packages/smi2/phpClickHouse)
+    -   [8bitov/clickhouse-php-client](https://packagist.org/packages/8bitov/clickhouse-php-client)
+    -   [bozerkins/clickhouse-client](https://packagist.org/packages/bozerkins/clickhouse-client)
+    -   [seva-code/php-click-house-client](https://packagist.org/packages/seva-code/php-click-house-client)
+    -   [SeasClick C++ client](https://github.com/SeasX/SeasClick)
 -   Go
     -   [clickhouse](https://github.com/kshvakov/clickhouse/)
     -   [go-clickhouse](https://github.com/roistat/go-clickhouse)

--- a/docs/ru/interfaces/third-party/client_libraries.md
+++ b/docs/ru/interfaces/third-party/client_libraries.md
@@ -9,10 +9,11 @@
     -   [clickhouse-client](https://github.com/yurial/clickhouse-client)
     -   [aiochclient](https://github.com/maximdanilchenko/aiochclient)
 -   PHP
-    -   [phpClickHouse](https://github.com/smi2/phpClickHouse)
-    -   [clickhouse-php-client](https://github.com/8bitov/clickhouse-php-client)
-    -   [clickhouse-client](https://github.com/bozerkins/clickhouse-client)
-    -   [PhpClickHouseClient](https://github.com/SevaCode/PhpClickHouseClient)
+    -   [smi2/phpclickhouse](https://packagist.org/packages/smi2/phpClickHouse)
+    -   [8bitov/clickhouse-php-client](https://packagist.org/packages/8bitov/clickhouse-php-client)
+    -   [bozerkins/clickhouse-client](https://packagist.org/packages/bozerkins/clickhouse-client)
+    -   [seva-code/php-click-house-client](https://packagist.org/packages/seva-code/php-click-house-client)
+    -   [SeasClick C++ client](https://github.com/SeasX/SeasClick)
 -   Go
     -   [clickhouse](https://github.com/kshvakov/clickhouse/)
     -   [go-clickhouse](https://github.com/roistat/go-clickhouse)

--- a/docs/zh/interfaces/third-party/client_libraries.md
+++ b/docs/zh/interfaces/third-party/client_libraries.md
@@ -8,11 +8,11 @@
     -   [clickhouse-driver](https://github.com/mymarilyn/clickhouse-driver)
     -   [clickhouse-client](https://github.com/yurial/clickhouse-client)
 -   PHP
-    -   [SeasClick](https://github.com/SeasX/SeasClick)
-    -   [phpClickHouse](https://github.com/smi2/phpClickHouse)
-    -   [clickhouse-php-client](https://github.com/8bitov/clickhouse-php-client)
-    -   [clickhouse-client](https://github.com/bozerkins/clickhouse-client)
-    -   [PhpClickHouseClient](https://github.com/SevaCode/PhpClickHouseClient)
+    -   [smi2/phpclickhouse](https://packagist.org/packages/smi2/phpClickHouse)
+    -   [8bitov/clickhouse-php-client](https://packagist.org/packages/8bitov/clickhouse-php-client)
+    -   [bozerkins/clickhouse-client](https://packagist.org/packages/bozerkins/clickhouse-client)
+    -   [seva-code/php-click-house-client](https://packagist.org/packages/seva-code/php-click-house-client)
+    -   [SeasClick C++ client](https://github.com/SeasX/SeasClick)
 -   Go
     -   [clickhouse](https://github.com/kshvakov/clickhouse/)
     -   [go-clickhouse](https://github.com/roistat/go-clickhouse)


### PR DESCRIPTION
- change name format to help distinguish clients
- use packagist links that are more helpful for library consumers

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)