### PR TITLE
Fix SIGSEGV with optimize_skip_unused_shards when type cannot be converted

### DIFF
--- a/dbms/src/Interpreters/evaluateConstantExpression.cpp
+++ b/dbms/src/Interpreters/evaluateConstantExpression.cpp
@@ -116,8 +116,10 @@ namespace
             if (name == identifier->name)
             {
                 ColumnWithTypeAndName column;
-                // FIXME: what to do if field is not convertable?
-                column.column = type->createColumnConst(1, convertFieldToType(literal->value, *type));
+                Field value = convertFieldToType(literal->value, *type);
+                if (!literal->value.isNull() && value.isNull())
+                    return {};
+                column.column = type->createColumnConst(1, value);
                 column.name = name;
                 column.type = type;
                 return {{std::move(column)}};

--- a/dbms/tests/queries/0_stateless/02000_optimize_skip_unused_shards_type_mismatch.sql
+++ b/dbms/tests/queries/0_stateless/02000_optimize_skip_unused_shards_type_mismatch.sql
@@ -1,0 +1,14 @@
+set optimize_skip_unused_shards=1;
+
+drop table if exists data_02000;
+drop table if exists dist_02000;
+
+create table data_02000 (key Int) Engine=Null();
+create table dist_02000 as data_02000 Engine=Distributed(test_cluster_two_shards, currentDatabase(), data_02000, key);
+
+select * from data_02000 where key = 0xdeadbeafdeadbeaf;
+select * from dist_02000 where key = 0xdeadbeafdeadbeaf settings force_optimize_skip_unused_shards=2; -- { serverError 507; }
+select * from dist_02000 where key = 0xdeadbeafdeadbeaf;
+
+drop table data_02000;
+drop table dist_02000;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix SIGSEGV with optimize_skip_unused_shards when type cannot be converted