### PR TITLE
Add force_optimize_skip_unused_shards_no_nested

### DIFF
--- a/dbms/src/Core/Settings.h
+++ b/dbms/src/Core/Settings.h
@@ -114,6 +114,7 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingBool, distributed_group_by_no_merge, false, "Do not merge aggregation states from different servers for distributed query processing - in case it is for certain that there are different keys on different shards.", 0) \
     M(SettingBool, optimize_skip_unused_shards, false, "Assumes that data is distributed by sharding_key. Optimization to skip unused shards if SELECT query filters by sharding_key.", 0) \
     M(SettingUInt64, force_optimize_skip_unused_shards, 0, "Throw an exception if unused shards cannot be skipped (1 - throw only if the table has the sharding key, 2 - always throw.", 0) \
+    M(SettingBool, force_optimize_skip_unused_shards_no_nested, false, "Do not apply force_optimize_skip_unused_shards for nested Distributed tables.", 0) \
     \
     M(SettingBool, input_format_parallel_parsing, true, "Enable parallel parsing for some data formats.", 0) \
     M(SettingUInt64, min_chunk_bytes_for_parallel_parsing, (1024 * 1024), "The minimum chunk size in bytes, which each thread will parse in parallel.", 0) \

--- a/dbms/src/Interpreters/ClusterProxy/executeQuery.cpp
+++ b/dbms/src/Interpreters/ClusterProxy/executeQuery.cpp
@@ -31,6 +31,12 @@ Context removeUserRestrictionsFromSettings(const Context & context, const Settin
     new_settings.max_memory_usage_for_user.changed = false;
     new_settings.max_memory_usage_for_all_queries.changed = false;
 
+    if (settings.force_optimize_skip_unused_shards_no_nested)
+    {
+        new_settings.force_optimize_skip_unused_shards = 0;
+        new_settings.force_optimize_skip_unused_shards.changed = false;
+    }
+
     Context new_context(context);
     new_context.setSettings(new_settings);
 

--- a/dbms/tests/queries/0_stateless/01071_force_optimize_skip_unused_shards.sql
+++ b/dbms/tests/queries/0_stateless/01071_force_optimize_skip_unused_shards.sql
@@ -2,6 +2,9 @@ set optimize_skip_unused_shards=1;
 
 drop table if exists data_01071;
 drop table if exists dist_01071;
+drop table if exists data2_01071;
+drop table if exists dist2_01071;
+drop table if exists dist2_layer_01071;
 
 create table data_01071 (key Int) Engine=Null();
 
@@ -24,3 +27,16 @@ select * from dist_01071; -- { serverError 507 }
 
 drop table if exists data_01071;
 drop table if exists dist_01071;
+
+-- Distributed on Distributed
+set distributed_group_by_no_merge=1;
+set force_optimize_skip_unused_shards=2;
+create table data2_01071 (key Int, sub_key Int) Engine=Null();
+create table dist2_layer_01071 as data2_01071 Engine=Distributed(test_cluster_two_shards, currentDatabase(), data2_01071, sub_key%2);
+create table dist2_01071 as data2_01071 Engine=Distributed(test_cluster_two_shards, currentDatabase(), dist2_layer_01071, key%2);
+select * from dist2_01071 where key = 1; -- { serverError 507 }
+set force_optimize_skip_unused_shards_no_nested=1;
+select * from dist2_01071 where key = 1;
+drop table if exists data2_01071;
+drop table if exists dist2_layer_01071;
+drop table if exists dist2_01071;

--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -976,7 +976,7 @@ Enables or disables skipping of unused shards for SELECT queries that have shard
 
 Default value: 0
 
-## force\_optimize\_skip\_unused\_shards {#settings-force-optimize-skip-unused-shards}
+## force\_optimize\_skip\_unused\_shards {#settings-force_optimize_skip_unused_shards}
 
 Enables or disables query execution if [`optimize_skip_unused_shards`](#settings-optimize_skip_unused_shards) enabled and skipping of unused shards is not possible. If the skipping is not possible and the setting is enabled exception will be thrown.
 

--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -988,6 +988,17 @@ Possible values:
 
 Default value: 0
 
+## force\_optimize\_skip\_unused\_shards\_no\_nested {#settings-force_optimize_skip_unused_shards_no_nested}
+
+Reset [`optimize_skip_unused_shards`](#settings-force_optimize_skip_unused_shards) for nested `Distributed` table
+
+Possible values:
+
+-   1 — Enabled.
+-   0 — Disabled.
+
+Default value: 0.
+
 ## optimize\_throw\_if\_noop {#setting-optimize_throw_if_noop}
 
 Enables or disables throwing an exception if an [OPTIMIZE](../../query_language/misc.md#misc_operations-optimize) query didn’t perform a merge.

--- a/docs/es/operations/settings/settings.md
+++ b/docs/es/operations/settings/settings.md
@@ -976,7 +976,7 @@ Habilita o deshabilita la omisión de fragmentos no utilizados para las consulta
 
 Valor predeterminado: 0
 
-## Fuerza\_optimize\_skip\_unused\_shards {#settings-force-optimize-skip-unused-shards}
+## Fuerza\_optimize\_skip\_unused\_shards {#settings-force_optimize_skip_unused_shards}
 
 Habilita o deshabilita la ejecución de consultas si [`optimize_skip_unused_shards`](#settings-optimize_skip_unused_shards) no es posible omitir fragmentos no utilizados. Si la omisión no es posible y la configuración está habilitada, se lanzará una excepción.
 


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add force_optimize_skip_unused_shards_no_nested that will disable force_optimize_skip_unused_shards for nested Distributed table

Detailed description / Documentation draft:
Can be useful for multi-layred/bi-level sharding.