### PR TITLE
Update documentation for dictionary regarding ON CLUSTER clause for C…

### DIFF
--- a/docs/en/query_language/create.md
+++ b/docs/en/query_language/create.md
@@ -278,7 +278,7 @@ There isn’t a separate query for deleting views. To delete a view, use `DROP T
 ## CREATE DICTIONARY {#create-dictionary-query}
 
 ``` sql
-CREATE DICTIONARY [IF NOT EXISTS] [db.]dictionary_name
+CREATE DICTIONARY [IF NOT EXISTS] [db.]dictionary_name [ON CLUSTER cluster]
 (
     key1 type1  [DEFAULT|EXPRESSION expr1] [HIERARCHICAL|INJECTIVE|IS_OBJECT_ID],
     key2 type2  [DEFAULT|EXPRESSION expr2] [HIERARCHICAL|INJECTIVE|IS_OBJECT_ID],

--- a/docs/es/query_language/create.md
+++ b/docs/es/query_language/create.md
@@ -278,7 +278,7 @@ No hay una consulta independiente para eliminar vistas. Para eliminar una vista,
 ## CREAR DICCIONARIO {#create-dictionary-query}
 
 ``` sql
-CREATE DICTIONARY [IF NOT EXISTS] [db.]dictionary_name
+CREATE DICTIONARY [IF NOT EXISTS] [db.]dictionary_name [ON CLUSTER cluster]
 (
     key1 type1  [DEFAULT|EXPRESSION expr1] [HIERARCHICAL|INJECTIVE|IS_OBJECT_ID],
     key2 type2  [DEFAULT|EXPRESSION expr2] [HIERARCHICAL|INJECTIVE|IS_OBJECT_ID],

--- a/docs/ru/query_language/create.md
+++ b/docs/ru/query_language/create.md
@@ -276,7 +276,7 @@ SELECT a, b, c FROM (SELECT ...)
 ## CREATE DICTIONARY {#create-dictionary-query}
 
 ``` sql
-CREATE DICTIONARY [IF NOT EXISTS] [db.]dictionary_name
+CREATE DICTIONARY [IF NOT EXISTS] [db.]dictionary_name [ON CLUSTER cluster]
 (
     key1 type1  [DEFAULT|EXPRESSION expr1] [HIERARCHICAL|INJECTIVE|IS_OBJECT_ID],
     key2 type2  [DEFAULT|EXPRESSION expr2] [HIERARCHICAL|INJECTIVE|IS_OBJECT_ID],

--- a/docs/zh/query_language/create.md
+++ b/docs/zh/query_language/create.md
@@ -249,7 +249,7 @@ SELECT a, b, c FROM (SELECT ...)
 ## CREATE DICTIONARY {#create-dictionary-query}
 
 ``` sql
-CREATE DICTIONARY [IF NOT EXISTS] [db.]dictionary_name
+CREATE DICTIONARY [IF NOT EXISTS] [db.]dictionary_name [ON CLUSTER cluster]
 (
     key1 type1  [DEFAULT|EXPRESSION expr1] [HIERARCHICAL|INJECTIVE|IS_OBJECT_ID],
     key2 type2  [DEFAULT|EXPRESSION expr2] [HIERARCHICAL|INJECTIVE|IS_OBJECT_ID],


### PR DESCRIPTION
…REATE DICTIONARY

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

#9768 conflict fix


Detailed description / Documentation draft:

...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.
