### PR TITLE
Fix Expression transform for empty totals.

### DIFF
--- a/dbms/src/Processors/Transforms/ExpressionTransform.cpp
+++ b/dbms/src/Processors/Transforms/ExpressionTransform.cpp
@@ -29,7 +29,7 @@ void ExpressionTransform::transform(Chunk & chunk)
         if (expression->resultIsAlwaysEmpty())
         {
             stopReading();
-            chunk = Chunk(getOutputPort().getHeader().getColumns(), 0);
+            chunk.clear();
             return;
         }
     }

--- a/dbms/src/Processors/Transforms/InflatingExpressionTransform.cpp
+++ b/dbms/src/Processors/Transforms/InflatingExpressionTransform.cpp
@@ -28,7 +28,7 @@ void InflatingExpressionTransform::transform(Chunk & chunk)
         if (expression->resultIsAlwaysEmpty())
         {
             stopReading();
-            chunk = Chunk(getOutputPort().getHeader().getColumns(), 0);
+            chunk.clear();
             return;
         }
     }

--- a/dbms/tests/queries/0_stateless/02001_empty_join_and_totals.sql
+++ b/dbms/tests/queries/0_stateless/02001_empty_join_and_totals.sql
@@ -1,0 +1,11 @@
+select * from system.one t1
+join system.one t2
+on t1.dummy = t2.dummy
+limit 0
+FORMAT TabSeparated;
+
+select * from system.one t1
+join system.one t2
+on t1.dummy = t2.dummy
+where t2.dummy > 0
+FORMAT TabSeparated;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible exception `Got 0 in totals chunk, expected 1` on client. It happened for queries with `JOIN` in case if right joined table had zero rows. Example: `select * from system.one t1 join system.one t2 on t1.dummy = t2.dummy limit 0 FORMAT TabSeparated;`. Fixes #9777.

Exception happened because empty chunk was sent for totals. I happened because this empty chunk was created in `ExpressionTransform` after empty-right-joined-table optimization.