### PR TITLE
Remove redundant code from merge tree

### DIFF
--- a/dbms/src/Interpreters/PartLog.cpp
+++ b/dbms/src/Interpreters/PartLog.cpp
@@ -131,7 +131,7 @@ bool PartLog::addNewParts(Context & current_context, const PartLog::MutableDataP
             elem.part_name = part->name;
             elem.path_on_disk = part->getFullPath();
 
-            elem.bytes_compressed_on_disk = part->bytes_on_disk;
+            elem.bytes_compressed_on_disk = part->getBytesOnDisk();
             elem.rows = part->rows_count;
 
             elem.error = static_cast<UInt16>(execution_status.code);

--- a/dbms/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/dbms/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -892,8 +892,8 @@ ColumnSize IMergeTreeDataPart::getColumnSize(const String & column_name, const I
 
 void IMergeTreeDataPart::accumulateColumnSizes(ColumnToSize & column_to_size) const
 {
-    for (const auto & [name, size] : columns_sizes)
-        column_to_size[name] = size.data_compressed;
+    for (const auto & [column_name, size] : columns_sizes)
+        column_to_size[column_name] = size.data_compressed;
 }
 
 bool isCompactPart(const MergeTreeDataPartPtr & data_part)

--- a/dbms/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/dbms/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -229,10 +229,7 @@ void IMergeTreeDataPart::setColumns(const NamesAndTypesList & new_columns)
     column_name_to_position.reserve(new_columns.size());
     size_t pos = 0;
     for (const auto & column : columns)
-    {
         column_name_to_position.emplace(column.name, pos++);
-    }
-    total_columns_size = getTotalColumnsSize();
 }
 
 IMergeTreeDataPart::~IMergeTreeDataPart() = default;

--- a/dbms/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/dbms/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -92,8 +92,10 @@ public:
     virtual bool supportsVerticalMerge() const { return false; }
 
     /// NOTE: Returns zeros if column files are not found in checksums.
+    /// Otherwise return information about column size on disk.
     ColumnSize getColumnSize(const String & column_name, const IDataType & /* type */) const;
 
+    /// Return information about column size on disk for all columns in part
     ColumnSize getTotalColumnsSize() const { return total_columns_size; }
 
     virtual String getFileNameForColumn(const NameAndTypePair & column) const = 0;

--- a/dbms/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/dbms/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -156,8 +156,6 @@ public:
 
     size_t rows_count = 0;
 
-    std::atomic<UInt64> bytes_on_disk {0};  /// 0 - if not counted;
-                                            /// May not contain size of checksums.txt and columns.txt
 
     time_t modification_time = 0;
     /// When the part is removed from the working set. Changes once.
@@ -278,6 +276,9 @@ public:
     UInt64 getIndexSizeInAllocatedBytes() const;
     UInt64 getMarksCount() const;
 
+    UInt64 getBytesOnDisk() const { return bytes_on_disk; }
+    void setBytesOnDisk(UInt64 bytes_on_disk_) { bytes_on_disk = bytes_on_disk_; }
+
     size_t getFileSizeOrZero(const String & file_name) const;
     String getFullRelativePath() const;
     String getFullPath() const;
@@ -300,6 +301,10 @@ protected:
 
     /// Size for each column, calculated once in calcuateColumnSizesOnDisk
     ColumnSizeByName columns_sizes;
+
+    /// Total size on disk, not only columns. May not contain size of
+    /// checksums.txt and columns.txt. 0 - if not counted;
+    UInt64 bytes_on_disk{0};
 
     /// Columns description. Cannot be changed, after part initialiation.
     NamesAndTypesList columns;

--- a/dbms/src/Storages/MergeTree/MergeList.cpp
+++ b/dbms/src/Storages/MergeTree/MergeList.cpp
@@ -27,7 +27,7 @@ MergeListElement::MergeListElement(const std::string & database_, const std::str
         source_part_names.emplace_back(source_part->name);
         source_part_paths.emplace_back(source_part->getFullPath());
 
-        total_size_bytes_compressed += source_part->bytes_on_disk;
+        total_size_bytes_compressed += source_part->getBytesOnDisk();
         total_size_marks += source_part->getMarksCount();
         total_rows_count += source_part->index_granularity.getTotalRows();
     }

--- a/dbms/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1254,7 +1254,7 @@ void MergeTreeData::removePartsFinally(const MergeTreeData::DataPartsVector & pa
         {
             part_log_elem.partition_id = part->info.partition_id;
             part_log_elem.part_name = part->name;
-            part_log_elem.bytes_compressed_on_disk = part->bytes_on_disk;
+            part_log_elem.bytes_compressed_on_disk = part->getBytesOnDisk();
             part_log_elem.rows = part->rows_count;
 
             part_log->add(part_log_elem);
@@ -2135,7 +2135,7 @@ size_t MergeTreeData::getTotalActiveSizeInBytes() const
         auto lock = lockParts();
 
         for (auto & part : getDataPartsStateRange(DataPartState::Committed))
-            res += part->bytes_on_disk;
+            res += part->getBytesOnDisk();
     }
 
     return res;
@@ -3190,7 +3190,7 @@ MergeTreeData::MutableDataPartPtr MergeTreeData::cloneAndLoadDataPartOnSameDisk(
     String dst_part_name = src_part->getNewName(dst_part_info);
     String tmp_dst_part_name = tmp_part_prefix + dst_part_name;
 
-    auto reservation = reserveSpace(src_part->bytes_on_disk, src_part->disk);
+    auto reservation = reserveSpace(src_part->getBytesOnDisk(), src_part->disk);
     auto disk = reservation->getDisk();
     String src_part_path = src_part->getFullRelativePath();
     String dst_part_path = relative_data_path + tmp_dst_part_name;
@@ -3340,7 +3340,7 @@ try
     if (result_part)
     {
         part_log_elem.path_on_disk = result_part->getFullPath();
-        part_log_elem.bytes_compressed_on_disk = result_part->bytes_on_disk;
+        part_log_elem.bytes_compressed_on_disk = result_part->getBytesOnDisk();
         part_log_elem.rows = result_part->rows_count;
     }
 
@@ -3452,7 +3452,7 @@ MergeTreeData::CurrentlyMovingPartsTagger MergeTreeData::checkPartsForMove(const
     MergeTreeMovingParts parts_to_move;
     for (const auto & part : parts)
     {
-        auto reservation = space->reserve(part->bytes_on_disk);
+        auto reservation = space->reserve(part->getBytesOnDisk());
         if (!reservation)
             throw Exception("Move is not possible. Not enough space on '" + space->getName() + "'", ErrorCodes::NOT_ENOUGH_SPACE);
 

--- a/dbms/src/Storages/MergeTree/MergeTreeData.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeData.h
@@ -580,13 +580,6 @@ public:
         return column_sizes;
     }
 
-    /// Calculates column sizes in compressed form for the current state of data_parts.
-    void recalculateColumnSizes()
-    {
-        auto lock = lockParts();
-        calculateColumnSizesImpl();
-    }
-
     /// For ATTACH/DETACH/DROP PARTITION.
     String getPartitionIDFromQuery(const ASTPtr & ast, const Context & context);
 

--- a/dbms/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
@@ -231,7 +231,7 @@ bool MergeTreeDataMergerMutator::selectPartsToMerge(
         }
 
         IMergeSelector::Part part_info;
-        part_info.size = part->bytes_on_disk;
+        part_info.size = part->getBytesOnDisk();
         part_info.age = current_time - part->modification_time;
         part_info.level = part->info.level;
         part_info.data = &part;
@@ -333,7 +333,7 @@ bool MergeTreeDataMergerMutator::selectAllPartsToMergeWithinPartition(
             return false;
         }
 
-        sum_bytes += (*it)->bytes_on_disk;
+        sum_bytes += (*it)->getBytesOnDisk();
 
         prev_it = it;
         ++it;
@@ -671,7 +671,7 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataMergerMutator::mergePartsToTempor
         size_t total_size = 0;
         for (const auto & part : parts)
         {
-            total_size += part->bytes_on_disk;
+            total_size += part->getBytesOnDisk();
             if (total_size >= data_settings->min_merge_bytes_to_use_direct_io)
             {
                 LOG_DEBUG(log, "Will merge parts reading files in O_DIRECT");
@@ -1021,8 +1021,8 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataMergerMutator::mutatePartToTempor
     /// the order is reverse. This annoys TSan even though one lock is locked in shared mode and thus
     /// deadlock is impossible.
     auto compression_codec = context.chooseCompressionCodec(
-        source_part->bytes_on_disk,
-        static_cast<double>(source_part->bytes_on_disk) / data.getTotalActiveSizeInBytes());
+        source_part->getBytesOnDisk(),
+        static_cast<double>(source_part->getBytesOnDisk()) / data.getTotalActiveSizeInBytes());
 
 
     disk->createDirectories(new_part_tmp_path);
@@ -1193,7 +1193,7 @@ size_t MergeTreeDataMergerMutator::estimateNeededDiskSpace(const MergeTreeData::
 {
     size_t res = 0;
     for (const MergeTreeData::DataPartPtr & part : source_parts)
-        res += part->bytes_on_disk;
+        res += part->getBytesOnDisk();
 
     return static_cast<size_t>(res * DISK_USAGE_COEFFICIENT_TO_RESERVE);
 }
@@ -1562,8 +1562,8 @@ void MergeTreeDataMergerMutator::finalizeMutatedPart(
     new_data_part->index = source_part->index;
     new_data_part->minmax_idx = source_part->minmax_idx;
     new_data_part->modification_time = time(nullptr);
-    new_data_part->bytes_on_disk
-        = MergeTreeData::DataPart::calculateTotalSizeOnDisk(new_data_part->disk, new_data_part->getFullRelativePath());
+    new_data_part->setBytesOnDisk(
+        MergeTreeData::DataPart::calculateTotalSizeOnDisk(new_data_part->disk, new_data_part->getFullRelativePath()));
     new_data_part->calculateColumnsSizesOnDisk();
 }
 

--- a/dbms/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
@@ -1564,7 +1564,7 @@ void MergeTreeDataMergerMutator::finalizeMutatedPart(
     new_data_part->modification_time = time(nullptr);
     new_data_part->bytes_on_disk
         = MergeTreeData::DataPart::calculateTotalSizeOnDisk(new_data_part->disk, new_data_part->getFullRelativePath());
-
+    new_data_part->calculateColumnsSizesOnDisk();
 }
 
 

--- a/dbms/src/Storages/MergeTree/MergeTreeDataPartCompact.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataPartCompact.cpp
@@ -73,9 +73,9 @@ IMergeTreeDataPart::MergeTreeWriterPtr MergeTreeDataPartCompact::getWriter(
         default_codec, writer_settings, computed_index_granularity);
 }
 
-ColumnSize MergeTreeDataPartCompact::getTotalColumnsSize() const
+
+void MergeTreeDataPartCompact::calculateEachColumnSizesOnDisk(ColumnSizeByName & /*each_columns_size*/, ColumnSize & total_size) const
 {
-    ColumnSize total_size;
     auto bin_checksum = checksums.files.find(DATA_FILE_NAME_WITH_EXTENSION);
     if (bin_checksum != checksums.files.end())
     {
@@ -86,8 +86,6 @@ ColumnSize MergeTreeDataPartCompact::getTotalColumnsSize() const
     auto mrk_checksum = checksums.files.find(DATA_FILE_NAME + index_granularity_info.marks_file_extension);
     if (mrk_checksum != checksums.files.end())
         total_size.marks += mrk_checksum->second.file_size;
-
-    return total_size;
 }
 
 void MergeTreeDataPartCompact::loadIndexGranularity()

--- a/dbms/src/Storages/MergeTree/MergeTreeDataPartCompact.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataPartCompact.h
@@ -54,8 +54,6 @@ public:
 
     bool isStoredOnDisk() const override { return true; }
 
-    ColumnSize getTotalColumnsSize() const override;
-
     bool hasColumnFiles(const String & column_name, const IDataType & type) const override;
 
     String getFileNameForColumn(const NameAndTypePair & /* column */) const override { return DATA_FILE_NAME; }
@@ -67,6 +65,9 @@ private:
 
     /// Loads marks index granularity into memory
     void loadIndexGranularity() override;
+
+    /// Compact parts doesn't support per column size, only total size
+    void calculateEachColumnSizesOnDisk(ColumnSizeByName & each_columns_size, ColumnSize & total_size) const override;
 };
 
 }

--- a/dbms/src/Storages/MergeTree/MergeTreeDataPartWide.h
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataPartWide.h
@@ -48,13 +48,7 @@ public:
 
     bool supportsVerticalMerge() const override { return true; }
 
-    void accumulateColumnSizes(ColumnToSize & column_to_size) const override;
-
     String getFileNameForColumn(const NameAndTypePair & column) const override;
-
-    ColumnSize getTotalColumnsSize() const override;
-
-    ColumnSize getColumnSize(const String & column_name, const IDataType & type) const override;
 
     ~MergeTreeDataPartWide() override;
 
@@ -67,6 +61,8 @@ private:
     void loadIndexGranularity() override;
 
     ColumnSize getColumnSizeImpl(const String & name, const IDataType & type, std::unordered_set<String> * processed_substreams) const;
+
+    void calculateEachColumnSizesOnDisk(ColumnSizeByName & each_columns_size, ColumnSize & total_size) const override;
 };
 
 }

--- a/dbms/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -302,7 +302,7 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataWriter::writeTempPart(BlockWithPa
 
     ProfileEvents::increment(ProfileEvents::MergeTreeDataWriterRows, block.rows());
     ProfileEvents::increment(ProfileEvents::MergeTreeDataWriterUncompressedBytes, block.bytes());
-    ProfileEvents::increment(ProfileEvents::MergeTreeDataWriterCompressedBytes, new_data_part->bytes_on_disk);
+    ProfileEvents::increment(ProfileEvents::MergeTreeDataWriterCompressedBytes, new_data_part->getBytesOnDisk());
 
     return new_data_part;
 }

--- a/dbms/src/Storages/MergeTree/MergeTreePartsMover.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreePartsMover.cpp
@@ -24,7 +24,9 @@ class LargestPartsWithRequiredSize
         bool operator()(const MergeTreeData::DataPartPtr & f, const MergeTreeData::DataPartPtr & s) const
         {
             /// If parts have equal sizes, than order them by names (names are unique)
-            return std::tie(f->bytes_on_disk, f->name) < std::tie(s->bytes_on_disk, s->name);
+            UInt64 first_part_size = f->getBytesOnDisk();
+            UInt64 second_part_size = s->getBytesOnDisk();
+            return std::tie(first_part_size, f->name) < std::tie(second_part_size, s->name);
         }
     };
 
@@ -40,16 +42,16 @@ public:
         if (current_size_sum < required_size_sum)
         {
             elems.emplace(part);
-            current_size_sum += part->bytes_on_disk;
+            current_size_sum += part->getBytesOnDisk();
             return;
         }
 
         /// Adding smaller element
-        if (!elems.empty() && (*elems.begin())->bytes_on_disk >= part->bytes_on_disk)
+        if (!elems.empty() && (*elems.begin())->getBytesOnDisk() >= part->getBytesOnDisk())
             return;
 
         elems.emplace(part);
-        current_size_sum += part->bytes_on_disk;
+        current_size_sum += part->getBytesOnDisk();
 
         removeRedundantElements();
     }
@@ -73,9 +75,9 @@ public:
 private:
     void removeRedundantElements()
     {
-        while (!elems.empty() && (current_size_sum - (*elems.begin())->bytes_on_disk >= required_size_sum))
+        while (!elems.empty() && (current_size_sum - (*elems.begin())->getBytesOnDisk() >= required_size_sum))
         {
-            current_size_sum -= (*elems.begin())->bytes_on_disk;
+            current_size_sum -= (*elems.begin())->getBytesOnDisk();
             elems.erase(elems.begin());
         }
     }
@@ -133,7 +135,7 @@ bool MergeTreePartsMover::selectPartsForMove(
         {
             auto destination = ttl_entry->getDestination(policy);
             if (destination && !ttl_entry->isPartInDestination(policy, *part))
-                reservation = part->storage.tryReserveSpace(part->bytes_on_disk, ttl_entry->getDestination(policy));
+                reservation = part->storage.tryReserveSpace(part->getBytesOnDisk(), ttl_entry->getDestination(policy));
         }
 
         if (reservation) /// Found reservation by TTL rule.
@@ -144,10 +146,10 @@ bool MergeTreePartsMover::selectPartsForMove(
             /// possibly to zero.
             if (to_insert != need_to_move.end())
             {
-                to_insert->second.decreaseRequiredSizeAndRemoveRedundantParts(part->bytes_on_disk);
+                to_insert->second.decreaseRequiredSizeAndRemoveRedundantParts(part->getBytesOnDisk());
             }
             ++parts_to_move_by_ttl_rules;
-            parts_to_move_total_size_bytes += part->bytes_on_disk;
+            parts_to_move_total_size_bytes += part->getBytesOnDisk();
         }
         else
         {
@@ -161,7 +163,7 @@ bool MergeTreePartsMover::selectPartsForMove(
         auto min_volume_index = policy->getVolumeIndexByDisk(move.first) + 1;
         for (auto && part : move.second.getAccumulatedParts())
         {
-            auto reservation = policy->reserve(part->bytes_on_disk, min_volume_index);
+            auto reservation = policy->reserve(part->getBytesOnDisk(), min_volume_index);
             if (!reservation)
             {
                 /// Next parts to move from this disk has greater size and same min volume index.
@@ -171,7 +173,7 @@ bool MergeTreePartsMover::selectPartsForMove(
             }
             parts_to_move.emplace_back(part, std::move(reservation));
             ++parts_to_move_by_policy_rules;
-            parts_to_move_total_size_bytes += part->bytes_on_disk;
+            parts_to_move_total_size_bytes += part->getBytesOnDisk();
         }
     }
 

--- a/dbms/src/Storages/MergeTree/MergedBlockOutputStream.cpp
+++ b/dbms/src/Storages/MergeTree/MergedBlockOutputStream.cpp
@@ -141,7 +141,7 @@ void MergedBlockOutputStream::writeSuffixAndFinalizePart(
     new_part->modification_time = time(nullptr);
     new_part->index = writer->releaseIndexColumns();
     new_part->checksums = checksums;
-    new_part->bytes_on_disk = checksums.getTotalSizeOnDisk();
+    new_part->setBytesOnDisk(checksums.getTotalSizeOnDisk());
     new_part->index_granularity = writer->getIndexGranularity();
     new_part->calculateColumnsSizesOnDisk();
 }

--- a/dbms/src/Storages/MergeTree/MergedBlockOutputStream.cpp
+++ b/dbms/src/Storages/MergeTree/MergedBlockOutputStream.cpp
@@ -143,6 +143,7 @@ void MergedBlockOutputStream::writeSuffixAndFinalizePart(
     new_part->checksums = checksums;
     new_part->bytes_on_disk = checksums.getTotalSizeOnDisk();
     new_part->index_granularity = writer->getIndexGranularity();
+    new_part->calculateColumnsSizesOnDisk();
 }
 
 void MergedBlockOutputStream::writeImpl(const Block & block, const IColumn::Permutation * permutation)

--- a/dbms/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/dbms/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -1011,7 +1011,7 @@ bool ReplicatedMergeTreeQueue::shouldExecuteLogEntry(
 
             auto part = data.getPartIfExists(name, {MergeTreeDataPartState::PreCommitted, MergeTreeDataPartState::Committed, MergeTreeDataPartState::Outdated});
             if (part)
-                sum_parts_size_in_bytes += part->bytes_on_disk;
+                sum_parts_size_in_bytes += part->getBytesOnDisk();
         }
 
         if (merger_mutator.merges_blocker.isCancelled())

--- a/dbms/src/Storages/StorageMergeTree.cpp
+++ b/dbms/src/Storages/StorageMergeTree.cpp
@@ -159,14 +159,12 @@ BlockOutputStreamPtr StorageMergeTree::write(const ASTPtr & /*query*/, const Con
 void StorageMergeTree::checkTableCanBeDropped() const
 {
     auto table_id = getStorageID();
-    const_cast<StorageMergeTree &>(*this).recalculateColumnSizes();
     global_context.checkTableCanBeDropped(table_id.database_name, table_id.table_name, getTotalActiveSizeInBytes());
 }
 
 void StorageMergeTree::checkPartitionCanBeDropped(const ASTPtr & partition)
 {
     auto table_id = getStorageID();
-    const_cast<StorageMergeTree &>(*this).recalculateColumnSizes();
 
     const String partition_id = getPartitionIDFromQuery(partition, global_context);
     auto parts_to_remove = getDataPartsVectorInPartition(MergeTreeDataPartState::Committed, partition_id);

--- a/dbms/src/Storages/StorageMergeTree.cpp
+++ b/dbms/src/Storages/StorageMergeTree.cpp
@@ -173,7 +173,7 @@ void StorageMergeTree::checkPartitionCanBeDropped(const ASTPtr & partition)
 
     for (const auto & part : parts_to_remove)
     {
-        partition_size += part->bytes_on_disk;
+        partition_size += part->getBytesOnDisk();
     }
     global_context.checkPartitionCanBeDropped(table_id.database_name, table_id.table_name, partition_size);
 }
@@ -673,7 +673,7 @@ bool StorageMergeTree::tryMutatePart()
             if (mutations_begin_it == mutations_end_it)
                 continue;
 
-            if (merger_mutator.getMaxSourcePartSizeForMutation() < part->bytes_on_disk)
+            if (merger_mutator.getMaxSourcePartSizeForMutation() < part->getBytesOnDisk())
                 continue;
 
             size_t current_ast_elements = 0;

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -998,7 +998,7 @@ bool StorageReplicatedMergeTree::tryExecuteMerge(const LogEntry & entry)
 
         size_t sum_parts_bytes_on_disk = 0;
         for (const auto & part : parts)
-            sum_parts_bytes_on_disk += part->bytes_on_disk;
+            sum_parts_bytes_on_disk += part->getBytesOnDisk();
 
         if (sum_parts_bytes_on_disk >= storage_settings_ptr->prefer_fetch_merged_part_size_threshold)
         {
@@ -2203,7 +2203,7 @@ void StorageReplicatedMergeTree::mergeSelectingTask()
                 DataPartsVector data_parts = getDataPartsVector();
                 for (const auto & part : data_parts)
                 {
-                    if (part->bytes_on_disk > max_source_part_size_for_mutation)
+                    if (part->getBytesOnDisk() > max_source_part_size_for_mutation)
                         continue;
 
                     std::optional<std::pair<Int64, int>> desired_mutation_version = merge_pred.getDesiredMutationVersion(part);
@@ -3567,7 +3567,7 @@ void StorageReplicatedMergeTree::checkPartitionCanBeDropped(const ASTPtr & parti
     UInt64 partition_size = 0;
 
     for (const auto & part : parts_to_remove)
-        partition_size += part->bytes_on_disk;
+        partition_size += part->getBytesOnDisk();
 
     auto table_id = getStorageID();
     global_context.checkPartitionCanBeDropped(table_id.database_name, table_id.table_name, partition_size);

--- a/dbms/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/dbms/src/Storages/StorageReplicatedMergeTree.cpp
@@ -3160,8 +3160,6 @@ bool StorageReplicatedMergeTree::executeMetadataAlter(const StorageReplicatedMer
     /// This transaction may not happen, but it's OK, because on the next retry we will eventually create/update this node
     zookeeper->createOrUpdate(replica_path + "/metadata_version", std::to_string(metadata_version), zkutil::CreateMode::Persistent);
 
-    recalculateColumnSizes();
-
     return true;
 }
 
@@ -3556,8 +3554,6 @@ void StorageReplicatedMergeTree::attachPartition(const ASTPtr & partition, bool 
 
 void StorageReplicatedMergeTree::checkTableCanBeDropped() const
 {
-    /// Consider only synchronized data
-    const_cast<StorageReplicatedMergeTree &>(*this).recalculateColumnSizes();
     auto table_id = getStorageID();
     global_context.checkTableCanBeDropped(table_id.database_name, table_id.table_name, getTotalActiveSizeInBytes());
 }
@@ -3565,8 +3561,6 @@ void StorageReplicatedMergeTree::checkTableCanBeDropped() const
 
 void StorageReplicatedMergeTree::checkPartitionCanBeDropped(const ASTPtr & partition)
 {
-    const_cast<StorageReplicatedMergeTree &>(*this).recalculateColumnSizes();
-
     const String partition_id = getPartitionIDFromQuery(partition, global_context);
     auto parts_to_remove = getDataPartsVectorInPartition(MergeTreeDataPartState::Committed, partition_id);
 

--- a/dbms/src/Storages/System/StorageSystemParts.cpp
+++ b/dbms/src/Storages/System/StorageSystemParts.cpp
@@ -83,7 +83,7 @@ void StorageSystemParts::processNextStorage(MutableColumns & columns_, const Sto
         columns_[i++]->insert(part_state == State::Committed);
         columns_[i++]->insert(part->getMarksCount());
         columns_[i++]->insert(part->rows_count);
-        columns_[i++]->insert(part->bytes_on_disk.load(std::memory_order_relaxed));
+        columns_[i++]->insert(part->getBytesOnDisk());
         columns_[i++]->insert(columns_size.data_compressed);
         columns_[i++]->insert(columns_size.data_uncompressed);
         columns_[i++]->insert(columns_size.marks);

--- a/dbms/src/Storages/System/StorageSystemPartsColumns.cpp
+++ b/dbms/src/Storages/System/StorageSystemPartsColumns.cpp
@@ -116,7 +116,7 @@ void StorageSystemPartsColumns::processNextStorage(MutableColumns & columns_, co
             columns_[j++]->insert(part->getMarksCount());
 
             columns_[j++]->insert(part->rows_count);
-            columns_[j++]->insert(part->bytes_on_disk.load(std::memory_order_relaxed));
+            columns_[j++]->insert(part->getBytesOnDisk());
             columns_[j++]->insert(columns_size.data_compressed);
             columns_[j++]->insert(columns_size.data_uncompressed);
             columns_[j++]->insert(columns_size.marks);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now columns size calculated only once for MergeTree data parts.
