### PR TITLE
 Try to add better users_config.d explanation

### DIFF
--- a/docs/en/operations/configuration_files.md
+++ b/docs/en/operations/configuration_files.md
@@ -17,9 +17,12 @@ The config can also define “substitutions”. If an element has the `incl` att
 
 Substitutions can also be performed from ZooKeeper. To do this, specify the attribute `from_zk = "/path/to/node"`. The element value is replaced with the contents of the node at `/path/to/node` in ZooKeeper. You can also put an entire XML subtree on the ZooKeeper node and it will be fully inserted into the source element.
 
-The `config.xml` file can specify a separate config with user settings, profiles, and quotas. The relative path to this config is set in the ‘users\_config’ element. By default, it is `users.xml`. If `users_config` is omitted, the user settings, profiles, and quotas are specified directly in `config.xml`.
+The `config.xml` file can specify a separate config with user settings, profiles, and quotas. The relative path to this config is set in the `users_config` element. By default, it is `users.xml`. If `users_config` is omitted, the user settings, profiles, and quotas are specified directly in `config.xml`.
 
-In addition, `users_config` may have overrides in files from the `users_config.d` directory (for example, `users.d`) and substitutions. For example, you can have separate config file for each user like this:
+Users configuration can be splitted into separate files similar to `config.xml` and `config.d/`.
+Directory name is defined as `users_config` setting without `.xml` postfix concatenated with `.d`.
+Directory `users.d` is used by default, as `users_config` defaults to `users.xml`.
+For example, you can have separate config file for each user like this:
 
 ``` bash
 $ cat /etc/clickhouse-server/users.d/alice.xml


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

 Try to add better users_config.d explanation

Detailed description / Documentation draft:

https://github.com/ClickHouse/ClickHouse/issues/9858#issuecomment-603800608

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.
