### PR TITLE
Fix PREWHERE with distributed IN

### DIFF
--- a/dbms/src/Interpreters/InJoinSubqueriesPreprocessor.cpp
+++ b/dbms/src/Interpreters/InJoinSubqueriesPreprocessor.cpp
@@ -45,11 +45,7 @@ struct NonGlobalTableData
     {
         ASTPtr & database_and_table = node.database_and_table_name;
         if (database_and_table)
-        {
             renameIfNeeded(database_and_table);
-            node.children.clear();
-            node.children.push_back(database_and_table);
-        }
     }
 
 private:
@@ -102,8 +98,8 @@ private:
                 throw Exception("Distributed table should have an alias when distributed_product_mode set to local.",
                                 ErrorCodes::DISTRIBUTED_IN_JOIN_SUBQUERY_DENIED);
 
-            database_and_table = createTableIdentifier(database, table);
-            database_and_table->setAlias(alias);
+            auto & identifier = database_and_table->as<ASTIdentifier &>();
+            identifier.resetTable(database, table);
         }
         else
             throw Exception("InJoinSubqueriesPreprocessor: unexpected value of 'distributed_product_mode' setting",

--- a/dbms/src/Interpreters/InJoinSubqueriesPreprocessor.cpp
+++ b/dbms/src/Interpreters/InJoinSubqueriesPreprocessor.cpp
@@ -45,7 +45,11 @@ struct NonGlobalTableData
     {
         ASTPtr & database_and_table = node.database_and_table_name;
         if (database_and_table)
+        {
             renameIfNeeded(database_and_table);
+            node.children.clear();
+            node.children.push_back(database_and_table);
+        }
     }
 
 private:

--- a/dbms/src/Parsers/ASTIdentifier.cpp
+++ b/dbms/src/Parsers/ASTIdentifier.cpp
@@ -101,6 +101,15 @@ void ASTIdentifier::appendColumnNameImpl(WriteBuffer & ostr) const
     writeString(name, ostr);
 }
 
+void ASTIdentifier::resetTable(const String & database_name, const String & table_name)
+{
+    auto ast = createTableIdentifier(database_name, table_name);
+    auto & ident = ast->as<ASTIdentifier &>();
+    name.swap(ident.name);
+    name_parts.swap(ident.name_parts);
+    uuid = ident.uuid;
+}
+
 ASTPtr createTableIdentifier(const String & database_name, const String & table_name)
 {
     assert(database_name != "_temporary_and_external_tables");

--- a/dbms/src/Parsers/ASTIdentifier.h
+++ b/dbms/src/Parsers/ASTIdentifier.h
@@ -49,6 +49,8 @@ public:
         return name;
     }
 
+    void resetTable(const String & database_name, const String & table_name);
+
 protected:
     void formatImplWithoutAlias(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
     void appendColumnNameImpl(WriteBuffer & ostr) const override;

--- a/dbms/tests/queries/0_stateless/01102_distributed_local_in_bug.sql
+++ b/dbms/tests/queries/0_stateless/01102_distributed_local_in_bug.sql
@@ -1,0 +1,24 @@
+DROP TABLE IF EXISTS hits;
+DROP TABLE IF EXISTS visits;
+DROP TABLE IF EXISTS hits_layer;
+DROP TABLE IF EXISTS visits_layer;
+
+CREATE TABLE visits(StartDate Date) ENGINE MergeTree ORDER BY(StartDate);
+CREATE TABLE hits(EventDate Date, WatchID UInt8) ENGINE MergeTree ORDER BY(EventDate);
+
+CREATE TABLE visits_layer(StartDate Date) ENGINE Distributed(test_cluster_two_shards_localhost,  currentDatabase(), 'visits');
+CREATE TABLE hits_layer(EventDate Date, WatchID UInt8) ENGINE Distributed(test_cluster_two_shards_localhost,  currentDatabase(), 'hits');
+
+SET distributed_product_mode = 'local';
+
+SELECT 0 FROM hits_layer AS hl
+PREWHERE WatchID IN
+(
+    SELECT 0 FROM visits_layer AS vl
+)
+WHERE 0;
+
+DROP TABLE hits;
+DROP TABLE visits;
+DROP TABLE hits_layer;
+DROP TABLE visits_layer;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix 'Different expressions with the same alias' error when query has PREWHERE and WHERE on distributed table and `SET distributed_product_mode = 'local'`.

Detailed description / Documentation draft:
Wrong AST rewrite in InJoinSubqueriesPreprocessor