### PR TITLE
Kafka retry commits on failure

### DIFF
--- a/dbms/src/Common/ErrorCodes.cpp
+++ b/dbms/src/Common/ErrorCodes.cpp
@@ -489,6 +489,7 @@ namespace ErrorCodes
     extern const int INCORRECT_ACCESS_ENTITY_DEFINITION = 515;
     extern const int AUTHENTICATION_FAILED = 516;
     extern const int CANNOT_ASSIGN_ALTER = 517;
+    extern const int CANNOT_COMMIT_OFFSET = 518;
 
     extern const int KEEPER_EXCEPTION = 999;
     extern const int POCO_EXCEPTION = 1000;

--- a/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
+++ b/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
@@ -36,14 +36,14 @@ ReadBufferFromKafkaConsumer::ReadBufferFromKafkaConsumer(
     , topics(_topics)
 {
     // called (synchroniously, during poll) when we enter the consumer group
-    consumer->set_assignment_callback([this](const cppkafka::TopicPartitionList& topic_partitions)
+    consumer->set_assignment_callback([this](const cppkafka::TopicPartitionList & topic_partitions)
     {
         LOG_TRACE(log, "Topics/partitions assigned: " << topic_partitions);
         assignment = topic_partitions;
     });
 
     // called (synchroniously, during poll) when we leave the consumer group
-    consumer->set_revocation_callback([this](const cppkafka::TopicPartitionList& topic_partitions)
+    consumer->set_revocation_callback([this](const cppkafka::TopicPartitionList & topic_partitions)
     {
         // Rebalance is happening now, and now we have a chance to finish the work
         // with topics/partitions we were working with before rebalance
@@ -149,7 +149,7 @@ void ReadBufferFromKafkaConsumer::commit()
         size_t max_retries = 5;
         bool commited = false;
 
-        while (!commited && max_retries>0)
+        while (!commited && max_retries > 0)
         {
             try
             {
@@ -165,7 +165,7 @@ void ReadBufferFromKafkaConsumer::commit()
             {
                 LOG_ERROR(log, "Exception during commit attempt: " << e.what());
             }
-            max_retries--;
+            --max_retries;
         }
 
         if (!commited)

--- a/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
+++ b/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
@@ -176,11 +176,10 @@ void ReadBufferFromKafkaConsumer::commit()
     }
     else
     {
-        LOG_TRACE(log,"Nothing to commit.");
+        LOG_TRACE(log, "Nothing to commit.");
     }
 
     offsets_stored = 0;
-
     stalled = false;
 }
 

--- a/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
+++ b/dbms/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
@@ -253,8 +253,7 @@ void ReadBufferFromKafkaConsumer::resetToLastCommitted(const char * msg)
     }
     auto committed_offset = consumer->get_offsets_committed(consumer->get_assignment());
     consumer->assign(committed_offset);
-    LOG_TRACE(log, msg << "Returned to committed position: " << committed_offset);
-
+    LOG_TRACE(log, msg << " Returned to committed position: " << committed_offset);
 }
 
 /// Do commit messages implicitly after we processed the previous batch.

--- a/dbms/tests/integration/helpers/cluster.py
+++ b/dbms/tests/integration/helpers/cluster.py
@@ -474,7 +474,7 @@ class ClickHouseCluster:
                 instance.client = Client(instance.ip_address, command=self.client_bin_path)
 
             self.is_up = True
-        
+
         except BaseException, e:
             print "Failed to start cluster: "
             print str(e)
@@ -506,6 +506,13 @@ class ClickHouseCluster:
         if sanitizer_assert_instance is not None:
             raise Exception("Sanitizer assert found in {} for instance {}".format(self.docker_logs_path, sanitizer_assert_instance))
 
+    def pause_container(self, instance_name):
+        subprocess_check_call(self.base_cmd + ['pause', instance_name])
+    #    subprocess_check_call(self.base_cmd + ['kill', '-s SIGSTOP', instance_name])
+
+    def unpause_container(self, instance_name):
+        subprocess_check_call(self.base_cmd + ['unpause', instance_name])
+    #    subprocess_check_call(self.base_cmd + ['kill', '-s SIGCONT', instance_name])
 
     def open_bash_shell(self, instance_name):
         os.system(' '.join(self.base_cmd + ['exec', instance_name, '/bin/bash']))


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Introduce commit retry logic to decrease the possibility of getting duplicates from Kafka in rare cases when offset commit was failed.

Detailed description / Documentation draft:
Sometimes broker can reject commit if during `offsets.commit.timeout.ms` (broker setting, 5000 by default) there were no enough replicas available for the `__consumer_offsets` topic, also some other temporary issues like client-server connectivity problems are possible. Retries make that part more robust.

See also https://github.com/edenhill/librdkafka/issues/1470