### PR TITLE
Remove order by from mutations interpreter and add check

### DIFF
--- a/dbms/src/DataStreams/CheckSortedBlockInputStream.cpp
+++ b/dbms/src/DataStreams/CheckSortedBlockInputStream.cpp
@@ -1,0 +1,92 @@
+#include <DataStreams/CheckSortedBlockInputStream.h>
+#include <Core/SortDescription.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+extern const int LOGICAL_ERROR;
+}
+
+CheckSortedBlockInputStream::CheckSortedBlockInputStream(
+    const BlockInputStreamPtr & input_,
+    const SortDescription & sort_description_)
+    : header(input_->getHeader())
+    , sort_description_map(addPositionsToSortDescriptions(sort_description_))
+{
+    children.push_back(input_);
+}
+
+SortDescriptionsWithPositions
+CheckSortedBlockInputStream::addPositionsToSortDescriptions(const SortDescription & sort_description)
+{
+    SortDescriptionsWithPositions result;
+
+    for (SortColumnDescription description_copy : sort_description)
+    {
+        if (!description_copy.column_name.empty())
+            description_copy.column_number = header.getPositionByName(description_copy.column_name);
+
+        result.push_back(description_copy);
+    }
+
+    return result;
+}
+
+/// Compares values in columns. Columns must have equal types.
+struct SortingLessComparator
+{
+    const SortDescriptionsWithPositions & sort_description;
+
+    SortingLessComparator(const SortDescriptionsWithPositions & sort_description_)
+        : sort_description(sort_description_) {}
+
+    bool operator()(const Columns & left, size_t left_index, const Columns & right, size_t right_index) const
+    {
+        for (const auto & elem : sort_description)
+        {
+            size_t column_number = elem.column_number;
+
+            const IColumn * left_col = left[column_number].get();
+            const IColumn * right_col = right[column_number].get();
+
+            int res = elem.direction * left_col->compareAt(left_index, right_index, *right_col, elem.nulls_direction);
+            if (res < 0)
+                return true;
+            else if (res > 0)
+                return false;
+        }
+        return true;
+    }
+};
+
+Block CheckSortedBlockInputStream::readImpl()
+{
+    Block block = children.back()->read();
+    if (!block)
+        return block;
+
+    SortingLessComparator less(sort_description_map);
+
+    auto block_columns = block.getColumns();
+    if (!last_row.empty() && !less(last_row, 0, block_columns, 0))
+        throw Exception("Sort order of blocks violated", ErrorCodes::LOGICAL_ERROR);
+
+    size_t rows = block.rows();
+    for (size_t i = 1; i < rows; ++i)
+        if (!less(block_columns, i - 1, block_columns, i))
+            throw Exception("Sort order of blocks violated", ErrorCodes::LOGICAL_ERROR);
+
+    last_row.clear();
+    for (size_t i = 0; i < block.columns(); ++i)
+    {
+        auto column = block_columns[i]->cloneEmpty();
+        column->insertFrom(*block_columns[i], rows - 1);
+        last_row.emplace_back(std::move(column));
+    }
+
+    return block;
+}
+
+}

--- a/dbms/src/DataStreams/CheckSortedBlockInputStream.cpp
+++ b/dbms/src/DataStreams/CheckSortedBlockInputStream.cpp
@@ -39,7 +39,7 @@ struct SortingLessComparator
 {
     const SortDescriptionsWithPositions & sort_description;
 
-    SortingLessComparator(const SortDescriptionsWithPositions & sort_description_)
+    explicit SortingLessComparator(const SortDescriptionsWithPositions & sort_description_)
         : sort_description(sort_description_) {}
 
     bool operator()(const Columns & left, size_t left_index, const Columns & right, size_t right_index) const

--- a/dbms/src/DataStreams/CheckSortedBlockInputStream.h
+++ b/dbms/src/DataStreams/CheckSortedBlockInputStream.h
@@ -1,0 +1,35 @@
+#pragma once
+#include <DataStreams/IBlockInputStream.h>
+#include <Core/SortDescription.h>
+#include <Columns/IColumn.h>
+
+namespace DB
+{
+using SortDescriptionsWithPositions = std::vector<SortColumnDescription>;
+
+/// Streams checks that flow of blocks is sorted in the sort_description order
+/// Othrewise throws exception in readImpl function.
+class CheckSortedBlockInputStream : public IBlockInputStream
+{
+public:
+    CheckSortedBlockInputStream(
+        const BlockInputStreamPtr & input_,
+        const SortDescription & sort_description_);
+
+    String getName() const override { return "CheckingSorted"; }
+
+    Block getHeader() const override { return header; }
+
+protected:
+    Block readImpl() override;
+
+private:
+    Block header;
+    SortDescriptionsWithPositions sort_description_map;
+    Columns last_row;
+
+private:
+    /// Just checks, that all sort_descriptions has column_number
+    SortDescriptionsWithPositions addPositionsToSortDescriptions(const SortDescription & sort_description);
+};
+}

--- a/dbms/src/DataStreams/tests/gtest_check_sorted_stream.cpp
+++ b/dbms/src/DataStreams/tests/gtest_check_sorted_stream.cpp
@@ -1,0 +1,181 @@
+#include <Core/Block.h>
+#include <gtest/gtest.h>
+
+#include <Columns/ColumnsNumber.h>
+#include <DataStreams/BlocksListBlockInputStream.h>
+#include <DataStreams/CheckSortedBlockInputStream.h>
+#include <DataTypes/DataTypesNumber.h>
+
+
+using namespace DB;
+
+
+static SortDescription getSortDescription(const std::vector<std::string> & column_names)
+{
+    SortDescription descr;
+    for (const auto & column : column_names)
+    {
+        descr.emplace_back(column, 1, 1);
+    }
+    return descr;
+}
+
+static Block getSortedBlockWithSize(
+    const std::vector<std::string> & columns,
+    size_t rows, size_t stride, size_t start)
+{
+    ColumnsWithTypeAndName cols;
+    size_t size_of_row_in_bytes = columns.size() * sizeof(UInt64);
+    for (size_t i = 0; i * sizeof(UInt64) < size_of_row_in_bytes; i++)
+    {
+        auto column = ColumnUInt64::create(rows, 0);
+        for (size_t j = 0; j < rows; ++j)
+        {
+            column->getElement(j) = start;
+            start += stride;
+        }
+        cols.emplace_back(std::move(column), std::make_shared<DataTypeUInt64>(), columns[i]);
+    }
+    return Block(cols);
+}
+
+
+static Block getUnSortedBlockWithSize(const std::vector<std::string> & columns, size_t rows, size_t stride, size_t start, size_t bad_row, size_t bad_column, size_t bad_value)
+{
+    ColumnsWithTypeAndName cols;
+    size_t size_of_row_in_bytes = columns.size() * sizeof(UInt64);
+    for (size_t i = 0; i * sizeof(UInt64) < size_of_row_in_bytes; i++)
+    {
+        auto column = ColumnUInt64::create(rows, 0);
+        for (size_t j = 0; j < rows; ++j)
+        {
+            if (bad_row == j && bad_column == i)
+                column->getElement(j) = bad_value;
+            else if (i < bad_column)
+                column->getElement(j) = 0;
+            else
+                column->getElement(j) = start;
+
+            start += stride;
+        }
+        cols.emplace_back(std::move(column), std::make_shared<DataTypeUInt64>(), columns[i]);
+    }
+    return Block(cols);
+}
+
+static Block getEqualValuesBlockWithSize(
+    const std::vector<std::string> & columns, size_t rows)
+{
+    ColumnsWithTypeAndName cols;
+    size_t size_of_row_in_bytes = columns.size() * sizeof(UInt64);
+    for (size_t i = 0; i * sizeof(UInt64) < size_of_row_in_bytes; i++)
+    {
+        auto column = ColumnUInt64::create(rows, 0);
+        for (size_t j = 0; j < rows; ++j)
+            column->getElement(j) = 0;
+
+        cols.emplace_back(std::move(column), std::make_shared<DataTypeUInt64>(), columns[i]);
+    }
+    return Block(cols);
+}
+
+
+TEST(CheckSortedBlockInputStream, CheckGoodCase)
+{
+    std::vector<std::string> key_columns{"K1", "K2", "K3"};
+    auto sort_description = getSortDescription(key_columns);
+
+    BlocksList blocks;
+    for (size_t i = 0; i < 3; ++i)
+        blocks.push_back(getSortedBlockWithSize(key_columns, 10, 1, i * 10));
+
+    BlockInputStreamPtr stream = std::make_shared<BlocksListBlockInputStream>(std::move(blocks));
+
+    CheckSortedBlockInputStream sorted(stream, sort_description);
+
+    EXPECT_NO_THROW(sorted.read());
+    EXPECT_NO_THROW(sorted.read());
+    EXPECT_NO_THROW(sorted.read());
+    EXPECT_EQ(sorted.read(), Block());
+}
+
+TEST(CheckSortedBlockInputStream, CheckBadLastRow)
+{
+    std::vector<std::string> key_columns{"K1", "K2", "K3"};
+    auto sort_description = getSortDescription(key_columns);
+    BlocksList blocks;
+    blocks.push_back(getSortedBlockWithSize(key_columns, 100, 1, 100));
+    blocks.push_back(getSortedBlockWithSize(key_columns, 100, 1, 200));
+    blocks.push_back(getSortedBlockWithSize(key_columns, 100, 1, 0));
+    blocks.push_back(getSortedBlockWithSize(key_columns, 100, 1, 300));
+
+    BlockInputStreamPtr stream = std::make_shared<BlocksListBlockInputStream>(std::move(blocks));
+
+    CheckSortedBlockInputStream sorted(stream, sort_description);
+
+
+    EXPECT_NO_THROW(sorted.read());
+    EXPECT_NO_THROW(sorted.read());
+    EXPECT_THROW(sorted.read(), DB::Exception);
+}
+
+
+TEST(CheckSortedBlockInputStream, CheckUnsortedBlock1)
+{
+    std::vector<std::string> key_columns{"K1", "K2", "K3"};
+    auto sort_description = getSortDescription(key_columns);
+    BlocksList blocks;
+    blocks.push_back(getUnSortedBlockWithSize(key_columns, 100, 1, 0, 5, 1, 77));
+
+    BlockInputStreamPtr stream = std::make_shared<BlocksListBlockInputStream>(std::move(blocks));
+
+    CheckSortedBlockInputStream sorted(stream, sort_description);
+
+    EXPECT_THROW(sorted.read(), DB::Exception);
+}
+
+TEST(CheckSortedBlockInputStream, CheckUnsortedBlock2)
+{
+    std::vector<std::string> key_columns{"K1", "K2", "K3"};
+    auto sort_description = getSortDescription(key_columns);
+    BlocksList blocks;
+    blocks.push_back(getUnSortedBlockWithSize(key_columns, 100, 1, 0, 99, 2, 77));
+
+    BlockInputStreamPtr stream = std::make_shared<BlocksListBlockInputStream>(std::move(blocks));
+
+    CheckSortedBlockInputStream sorted(stream, sort_description);
+
+    EXPECT_THROW(sorted.read(), DB::Exception);
+}
+
+TEST(CheckSortedBlockInputStream, CheckUnsortedBlock3)
+{
+    std::vector<std::string> key_columns{"K1", "K2", "K3"};
+    auto sort_description = getSortDescription(key_columns);
+    BlocksList blocks;
+    blocks.push_back(getUnSortedBlockWithSize(key_columns, 100, 1, 0, 50, 0, 77));
+
+    BlockInputStreamPtr stream = std::make_shared<BlocksListBlockInputStream>(std::move(blocks));
+
+    CheckSortedBlockInputStream sorted(stream, sort_description);
+
+    EXPECT_THROW(sorted.read(), DB::Exception);
+}
+
+TEST(CheckSortedBlockInputStream, CheckEqualBlock)
+{
+    std::vector<std::string> key_columns{"K1", "K2", "K3"};
+    auto sort_description = getSortDescription(key_columns);
+    BlocksList blocks;
+    blocks.push_back(getEqualValuesBlockWithSize(key_columns, 100));
+    blocks.push_back(getEqualValuesBlockWithSize(key_columns, 10));
+    blocks.push_back(getEqualValuesBlockWithSize(key_columns, 1));
+
+    BlockInputStreamPtr stream = std::make_shared<BlocksListBlockInputStream>(std::move(blocks));
+
+    CheckSortedBlockInputStream sorted(stream, sort_description);
+
+    EXPECT_NO_THROW(sorted.read());
+    EXPECT_NO_THROW(sorted.read());
+    EXPECT_NO_THROW(sorted.read());
+}

--- a/dbms/src/Interpreters/MutationsInterpreter.h
+++ b/dbms/src/Interpreters/MutationsInterpreter.h
@@ -43,6 +43,8 @@ private:
     ASTPtr prepareInterpreterSelectQuery(std::vector<Stage> &prepared_stages, bool dry_run);
     BlockInputStreamPtr addStreamsForLaterStages(const std::vector<Stage> & prepared_stages, BlockInputStreamPtr in) const;
 
+    std::optional<SortDescription> getStorageSortDescriptionIfPossible(const Block & header) const;
+
     StoragePtr storage;
     MutationCommands commands;
     const Context & context;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove order by stage from mutations because we read from a single ordered part in a single thread. Also add check that the order of rows in mutation is ordered in sorting key order and this order is not violated.
