### PR TITLE
Fix scalar optimization in ALTER mutations

### DIFF
--- a/dbms/src/Interpreters/MutationsInterpreter.cpp
+++ b/dbms/src/Interpreters/MutationsInterpreter.cpp
@@ -558,6 +558,10 @@ ASTPtr MutationsInterpreter::prepareInterpreterSelectQuery(std::vector<Stage> & 
             all_asts->children.push_back(std::make_shared<ASTIdentifier>(column));
 
         auto syntax_result = SyntaxAnalyzer(context).analyze(all_asts, all_columns);
+        if (context.hasQueryContext())
+            for (const auto & it : syntax_result->getScalars())
+                context.getQueryContext().addScalar(it.first, it.second);
+
         stage.analyzer = std::make_unique<ExpressionAnalyzer>(all_asts, syntax_result, context);
 
         ExpressionActionsChain & actions_chain = stage.expressions_chain;

--- a/dbms/src/Interpreters/MutationsInterpreter.h
+++ b/dbms/src/Interpreters/MutationsInterpreter.h
@@ -47,7 +47,7 @@ private:
 
     StoragePtr storage;
     MutationCommands commands;
-    const Context & context;
+    Context context;
     bool can_execute;
 
     ASTPtr mutation_ast;

--- a/dbms/tests/queries/0_stateless/01220_scalar_optimization_in_alter.sql
+++ b/dbms/tests/queries/0_stateless/01220_scalar_optimization_in_alter.sql
@@ -1,0 +1,9 @@
+drop table if exists cdp_segments;
+drop table if exists cdp_customers;
+
+create table cdp_segments (seg_id String, mid_seqs AggregateFunction(groupBitmap, UInt32)) engine=ReplacingMergeTree() order by (seg_id);
+create table cdp_customers (mid String, mid_seq UInt32) engine=ReplacingMergeTree() order by (mid_seq);
+alter table cdp_segments update mid_seqs = bitmapOr(mid_seqs, (select groupBitmapState(mid_seq) from cdp_customers where mid in ('6bf3c2ee-2b33-3030-9dc2-25c6c618d141'))) where seg_id = '1234567890';
+
+drop table cdp_segments;
+drop table cdp_customers;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix "scalar doesn't exist" error in ALTERs (#9878).

Not sure what's the consequence of having Context copied in MutationInterpreter.


