### PR TITLE
Turn on polymorphic parts for log tables

### DIFF
--- a/dbms/src/Interpreters/SystemLog.cpp
+++ b/dbms/src/Interpreters/SystemLog.cpp
@@ -57,7 +57,8 @@ std::shared_ptr<TSystemLog> createSystemLog(
     else
     {
         String partition_by = config.getString(config_prefix + ".partition_by", "toYYYYMM(event_date)");
-        engine = "ENGINE = MergeTree PARTITION BY (" + partition_by + ") ORDER BY (event_date, event_time) SETTINGS index_granularity = 1024";
+        engine = "ENGINE = MergeTree PARTITION BY (" + partition_by + ") ORDER BY (event_date, event_time)"
+            "SETTINGS index_granularity = 1024, min_bytes_for_wide_part = 10485760"; /// Use polymorphic parts for log tables by default
     }
 
     size_t flush_interval_milliseconds = config.getUInt64(config_prefix + ".flush_interval_milliseconds", DEFAULT_SYSTEM_LOG_FLUSH_INTERVAL_MILLISECONDS);

--- a/dbms/src/Interpreters/SystemLog.cpp
+++ b/dbms/src/Interpreters/SystemLog.cpp
@@ -58,7 +58,7 @@ std::shared_ptr<TSystemLog> createSystemLog(
     {
         String partition_by = config.getString(config_prefix + ".partition_by", "toYYYYMM(event_date)");
         engine = "ENGINE = MergeTree PARTITION BY (" + partition_by + ") ORDER BY (event_date, event_time)"
-            "SETTINGS index_granularity = 1024, min_bytes_for_wide_part = 10485760"; /// Use polymorphic parts for log tables by default
+            "SETTINGS min_bytes_for_wide_part = '10M'"; /// Use polymorphic parts for log tables by default
     }
 
     size_t flush_interval_milliseconds = config.getUInt64(config_prefix + ".flush_interval_milliseconds", DEFAULT_SYSTEM_LOG_FLUSH_INTERVAL_MILLISECONDS);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
System log tables now use polymorpic parts by default.