### PR TITLE
Add type column into system.settings/merge_tree_settings

### DIFF
--- a/dbms/src/Core/SettingsCollection.h
+++ b/dbms/src/Core/SettingsCollection.h
@@ -345,6 +345,7 @@ private:
 
         StringRef name;
         StringRef description;
+        StringRef type;
         bool is_important;
         IsChangedFunction is_changed;
         GetStringFunction get_string;
@@ -391,6 +392,7 @@ public:
         const_reference(const const_reference & src) = default;
         const StringRef & getName() const { return member->name; }
         const StringRef & getDescription() const { return member->description; }
+        const StringRef & getType() const { return member->type; }
         bool isChanged() const { return member->is_changed(*collection); }
         Field getValue() const;
         String getValueAsString() const { return member->get_string(*collection); }

--- a/dbms/src/Core/SettingsCollectionImpl.h
+++ b/dbms/src/Core/SettingsCollectionImpl.h
@@ -323,7 +323,9 @@ void SettingsCollection<Derived>::deserialize(ReadBuffer & buf, SettingsBinaryFo
 
 
 #define IMPLEMENT_SETTINGS_COLLECTION_ADD_MEMBER_INFO_HELPER_(TYPE, NAME, DEFAULT, DESCRIPTION, FLAGS) \
-    add({StringRef(#NAME, strlen(#NAME)), StringRef(DESCRIPTION, strlen(DESCRIPTION)), \
+    add({StringRef(#NAME, strlen(#NAME)), \
+         StringRef(DESCRIPTION, strlen(DESCRIPTION)), \
+         StringRef(#TYPE, strlen(#TYPE)), \
          FLAGS & IMPORTANT, \
          [](const Derived & d) { return d.NAME.changed; }, \
          &Functions::NAME##_getString, &Functions::NAME##_getField, \

--- a/dbms/src/Storages/System/StorageSystemMergeTreeSettings.cpp
+++ b/dbms/src/Storages/System/StorageSystemMergeTreeSettings.cpp
@@ -14,6 +14,7 @@ NamesAndTypesList SystemMergeTreeSettings::getNamesAndTypes()
         {"value",       std::make_shared<DataTypeString>()},
         {"changed",     std::make_shared<DataTypeUInt8>()},
         {"description", std::make_shared<DataTypeString>()},
+        {"type",        std::make_shared<DataTypeString>()},
     };
 }
 
@@ -25,6 +26,7 @@ void SystemMergeTreeSettings::fillData(MutableColumns & res_columns, const Conte
         res_columns[1]->insert(setting.getValueAsString());
         res_columns[2]->insert(setting.isChanged());
         res_columns[3]->insert(setting.getDescription().toString());
+        res_columns[4]->insert(setting.getType().toString());
     }
 }
 

--- a/dbms/src/Storages/System/StorageSystemSettings.cpp
+++ b/dbms/src/Storages/System/StorageSystemSettings.cpp
@@ -17,7 +17,8 @@ NamesAndTypesList StorageSystemSettings::getNamesAndTypes()
         {"description", std::make_shared<DataTypeString>()},
         {"min", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeString>())},
         {"max", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeString>())},
-        {"readonly", std::make_shared<DataTypeUInt8>()}
+        {"readonly", std::make_shared<DataTypeUInt8>()},
+        {"type", std::make_shared<DataTypeString>()},
     };
 }
 
@@ -59,6 +60,7 @@ void StorageSystemSettings::fillData(MutableColumns & res_columns, const Context
         res_columns[4]->insert(min);
         res_columns[5]->insert(max);
         res_columns[6]->insert(read_only);
+        res_columns[7]->insert(setting.getType().toString());
     }
 }
 

--- a/dbms/tests/queries/0_stateless/01221_system_settings.reference
+++ b/dbms/tests/queries/0_stateless/01221_system_settings.reference
@@ -1,0 +1,4 @@
+send_timeout	300	0		\N	\N	0	SettingSeconds
+replicated_max_parallel_sends	0	0	Limit parallel sends.	SettingUInt64
+1
+1

--- a/dbms/tests/queries/0_stateless/01221_system_settings.sql
+++ b/dbms/tests/queries/0_stateless/01221_system_settings.sql
@@ -1,0 +1,34 @@
+select * from system.settings where name = 'send_timeout';
+select * from system.merge_tree_settings order by length(description) limit 1;
+
+with [
+    'SettingSeconds',
+    'SettingBool',
+    'SettingInt64',
+    'SettingString',
+    'SettingChar',
+    'SettingLogsLevel',
+    'SettingURI',
+    'SettingFloat',
+    'SettingUInt64',
+    'SettingMaxThreads',
+    'SettingMilliseconds',
+    'SettingJoinStrictness',
+    'SettingJoinAlgorithm',
+    'SettingOverflowMode',
+    'SettingTotalsMode',
+    'SettingLoadBalancing',
+    'SettingOverflowModeGroupBy',
+    'SettingDateTimeInputFormat',
+    'SettingDistributedProductMode'
+] as types select hasAll(arrayDistinct(groupArray(type)), types) from system.settings;
+
+with [
+    'SettingSeconds',
+    'SettingBool',
+    'SettingInt64',
+    'SettingString',
+    'SettingFloat',
+    'SettingUInt64',
+    'SettingMaxThreads'
+] as types select hasAll(arrayDistinct(groupArray(type)), types) from system.merge_tree_settings;

--- a/docs/en/operations/system_tables.md
+++ b/docs/en/operations/system_tables.md
@@ -841,24 +841,41 @@ Columns:
 
 -   `name` (String) — Setting name.
 -   `value` (String) — Setting value.
+-   `description` (String) — Setting description.
+-   `type` (String) — Setting type.
 -   `changed` (UInt8) — Whether the setting was explicitly defined in the config or explicitly changed.
+-   `min` (Nullable(String)) — Get minimum allowed value (if any is set via [constraints](settings/constraints_on_settings.md#constraints-on-settings)).
+-   `max` (Nullable(String)) — Get maximum allowed value (if any is set via [constraints](settings/constraints_on_settings.md#constraints-on-settings)).
+-   `readonly` (UInt8) — Can user change this setting (for more info, look into [constraints](settings/constraints_on_settings.md#constraints-on-settings)).
 
 Example:
 
 ``` sql
-SELECT *
+SELECT name, value
 FROM system.settings
 WHERE changed
 ```
 
 ``` text
-┌─name───────────────────┬─value───────┬─changed─┐
-│ max_threads            │ 8           │       1 │
-│ use_uncompressed_cache │ 0           │       1 │
-│ load_balancing         │ random      │       1 │
-│ max_memory_usage       │ 10000000000 │       1 │
-└────────────────────────┴─────────────┴─────────┘
+┌─name───────────────────┬─value───────┐
+│ max_threads            │ 8           │
+│ use_uncompressed_cache │ 0           │
+│ load_balancing         │ random      │
+│ max_memory_usage       │ 10000000000 │
+└────────────────────────┴─────────────┘
 ```
+
+## system.merge\_tree\_settings {#system-merge_tree_settings}
+
+Contains information about settings for `MergeTree` tables.
+
+Columns:
+
+-   `name` (String) — Setting name.
+-   `value` (String) — Setting value.
+-   `description` (String) — Setting description.
+-   `type` (String) — Setting type.
+-   `changed` (UInt8) — Whether the setting was explicitly defined in the config or explicitly changed.
 
 ## system.table\_engines {#system-table-engines}
 

--- a/docs/en/operations/system_tables.md
+++ b/docs/en/operations/system_tables.md
@@ -842,7 +842,7 @@ Columns:
 -   `name` (String) — Setting name.
 -   `value` (String) — Setting value.
 -   `description` (String) — Setting description.
--   `type` (String) — Setting type.
+-   `type` (String) — Setting type (implementation specific string value).
 -   `changed` (UInt8) — Whether the setting was explicitly defined in the config or explicitly changed.
 -   `min` (Nullable(String)) — Get minimum allowed value (if any is set via [constraints](settings/constraints_on_settings.md#constraints-on-settings)).
 -   `max` (Nullable(String)) — Get maximum allowed value (if any is set via [constraints](settings/constraints_on_settings.md#constraints-on-settings)).
@@ -874,7 +874,7 @@ Columns:
 -   `name` (String) — Setting name.
 -   `value` (String) — Setting value.
 -   `description` (String) — Setting description.
--   `type` (String) — Setting type.
+-   `type` (String) — Setting type (implementation specific string value).
 -   `changed` (UInt8) — Whether the setting was explicitly defined in the config or explicitly changed.
 
 ## system.table\_engines {#system-table-engines}


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add type column into system.settings/merge_tree_settings

Detailed description / Documentation draft:
This can be useful for various drivers to know the type.
