### PR TITLE
Fix marks count for non-adaptive parts

### DIFF
--- a/dbms/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/dbms/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -406,8 +406,8 @@ void IMergeTreeDataPart::loadColumnsChecksumsIndexes(bool require_columns_checks
 
     loadColumns(require_columns_checksums);
     loadChecksums(require_columns_checksums);
-    calculateColumnsSizesOnDisk();
     loadIndexGranularity();
+    calculateColumnsSizesOnDisk();
     loadIndex();     /// Must be called after loadIndexGranularity as it uses the value of `index_granularity`
     loadRowsCount(); /// Must be called after loadIndex() as it uses the value of `index_granularity`.
     loadPartitionAndMinMaxIndex();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Non-significant (changelog entry is not required)

Detailed description / Documentation draft:
No release is affected.
Test case for this fix is quite complex. The bug appeares for tables created in old versions, because `index_granularity_bytes` is missing for them in `CREATE` statement, but tables has non-adaptive granularity. At startup of new version we treat part as adaptive (according to default) until we will determine real granularity by `changeGranularityIfRequired` method in `loadIndexGranularity`. So, `loadIndexGranularity` should be called before `calculateColumnsSizesOnDisk`, as last requires proper mark extension.