### PR TITLE
Fix parsing multiple hosts in CREATE USER command.

### DIFF
--- a/dbms/src/Parsers/ParserCreateUserQuery.cpp
+++ b/dbms/src/Parsers/ParserCreateUserQuery.cpp
@@ -4,6 +4,7 @@
 #include <Parsers/parseUserName.h>
 #include <Parsers/parseIdentifierOrStringLiteral.h>
 #include <Parsers/ExpressionElementParsers.h>
+#include <Parsers/ExpressionListParsers.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTExtendedRoleSet.h>
 #include <Parsers/ParserExtendedRoleSet.h>
@@ -168,34 +169,38 @@ namespace
                 else if (ParserKeyword{"NAME REGEXP"}.ignore(pos, expected))
                 {
                     ASTPtr ast;
-                    if (!ParserStringLiteral{}.parse(pos, ast, expected))
+                    if (!ParserList{std::make_unique<ParserStringLiteral>(), std::make_unique<ParserToken>(TokenType::Comma), false}.parse(pos, ast, expected))
                         return false;
 
-                    new_hosts.addNameRegexp(ast->as<const ASTLiteral &>().value.safeGet<String>());
+                    for (const auto & name_regexp_ast : ast->children)
+                        new_hosts.addNameRegexp(name_regexp_ast->as<const ASTLiteral &>().value.safeGet<String>());
                 }
                 else if (ParserKeyword{"NAME"}.ignore(pos, expected))
                 {
                     ASTPtr ast;
-                    if (!ParserStringLiteral{}.parse(pos, ast, expected))
+                    if (!ParserList{std::make_unique<ParserStringLiteral>(), std::make_unique<ParserToken>(TokenType::Comma), false}.parse(pos, ast, expected))
                         return false;
 
-                    new_hosts.addName(ast->as<const ASTLiteral &>().value.safeGet<String>());
+                    for (const auto & name_ast : ast->children)
+                        new_hosts.addName(name_ast->as<const ASTLiteral &>().value.safeGet<String>());
                 }
                 else if (ParserKeyword{"IP"}.ignore(pos, expected))
                 {
                     ASTPtr ast;
-                    if (!ParserStringLiteral{}.parse(pos, ast, expected))
+                    if (!ParserList{std::make_unique<ParserStringLiteral>(), std::make_unique<ParserToken>(TokenType::Comma), false}.parse(pos, ast, expected))
                         return false;
 
-                    new_hosts.addSubnet(ast->as<const ASTLiteral &>().value.safeGet<String>());
+                    for (const auto & subnet_ast : ast->children)
+                        new_hosts.addSubnet(subnet_ast->as<const ASTLiteral &>().value.safeGet<String>());
                 }
                 else if (ParserKeyword{"LIKE"}.ignore(pos, expected))
                 {
                     ASTPtr ast;
-                    if (!ParserStringLiteral{}.parse(pos, ast, expected))
+                    if (!ParserList{std::make_unique<ParserStringLiteral>(), std::make_unique<ParserToken>(TokenType::Comma), false}.parse(pos, ast, expected))
                         return false;
 
-                    new_hosts.addLikePattern(ast->as<const ASTLiteral &>().value.safeGet<String>());
+                    for (const auto & pattern_ast : ast->children)
+                        new_hosts.addLikePattern(pattern_ast->as<const ASTLiteral &>().value.safeGet<String>());
                 }
                 else
                     return false;

--- a/dbms/tests/queries/0_stateless/01075_allowed_client_hosts.reference
+++ b/dbms/tests/queries/0_stateless/01075_allowed_client_hosts.reference
@@ -9,6 +9,9 @@ CREATE USER test_user_01075 HOST LOCAL
 CREATE USER test_user_01075 HOST NONE
 CREATE USER test_user_01075 HOST LIKE \'@.somesite.com\'
 CREATE USER test_user_01075 HOST NAME REGEXP \'.*.anothersite.com\'
+CREATE USER test_user_01075 HOST NAME REGEXP \'.*.anothersite.com\', \'.*.anothersite.org\'
+CREATE USER test_user_01075 HOST NAME REGEXP \'.*.anothersite2.com\', \'.*.anothersite2.org\'
+CREATE USER test_user_01075 HOST NAME REGEXP \'.*.anothersite3.com\', \'.*.anothersite3.org\'
 CREATE USER `test_user_01075_x@localhost` HOST LOCAL
 CREATE USER test_user_01075_x
 CREATE USER `test_user_01075_x@192.168.23.15` HOST LIKE \'192.168.23.15\'

--- a/dbms/tests/queries/0_stateless/01075_allowed_client_hosts.sql
+++ b/dbms/tests/queries/0_stateless/01075_allowed_client_hosts.sql
@@ -33,6 +33,15 @@ SHOW CREATE USER test_user_01075;
 ALTER USER test_user_01075 HOST NAME REGEXP '.*\.anothersite\.com';
 SHOW CREATE USER test_user_01075;
 
+ALTER USER test_user_01075 HOST NAME REGEXP '.*\.anothersite\.com', '.*\.anothersite\.org';
+SHOW CREATE USER test_user_01075;
+
+ALTER USER test_user_01075 HOST NAME REGEXP '.*\.anothersite2\.com', NAME REGEXP '.*\.anothersite2\.org';
+SHOW CREATE USER test_user_01075;
+
+ALTER USER test_user_01075 HOST NAME REGEXP '.*\.anothersite3\.com' HOST NAME REGEXP '.*\.anothersite3\.org';
+SHOW CREATE USER test_user_01075;
+
 DROP USER test_user_01075;
 
 CREATE USER test_user_01075_x@localhost;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Bug Fix

Changelog entry:
Fix parsing multiple hosts set in the CREATE USER command, e.g.
`CREATE USER user6 HOST NAME REGEXP 'lo.?*host', NAME REGEXP 'lo*host'`
