### PR TITLE
Fix a race between DDLWorker and DDLWorkerClnr during startup

### DIFF
--- a/dbms/src/Interpreters/DDLWorker.cpp
+++ b/dbms/src/Interpreters/DDLWorker.cpp
@@ -421,6 +421,18 @@ void DDLWorker::processTasks()
             {
                 processTask(task, zookeeper);
             }
+            catch (const Coordination::Exception & e)
+            {
+                if (server_startup && e.code == Coordination::ZNONODE)
+                {
+                    LOG_WARNING(log, "ZooKeeper NONODE error during startup. Ignoring entry " <<
+                                task.entry_name << " (" << task.entry.query << ") : " << getCurrentExceptionMessage(true));
+                }
+                else
+                {
+                     throw;
+                }
+            }
             catch (...)
             {
                 LOG_WARNING(log, "An error occurred while processing task " << task.entry_name << " (" << task.entry.query << ") : "


### PR DESCRIPTION
… that causes DDLWorker to exit because of ZooKeeper NONODE error.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md): 
Fix a bug with `ON CLUSTER` DDL queries freezing on server startup.

Detailed description / Documentation draft:

Fix a race between DDLWorker and DDLWorkerClnr during startup that can cause the DDLWorker to exit and all future DDL queries to hang.

DDLWorker thread reads a snapshot of all ddl queries in zookeeper queue during startup and iterates over them, to see which one need to be processed. It skips over the ones that have already been processed. While DDLWorker is working on it's read snapshot, DDLWorkerClnr can delete entries in zookeeper. If DDLWorker encounters a deleted entry, it raises an exception and exits. Once DDLWorker exits, it's not restarted, causing all future ddl queries to hang. 

