### PR TITLE
Fix bug with wrong implementation in ZooKeeper API

### DIFF
--- a/dbms/src/Common/ZooKeeper/ZooKeeper.cpp
+++ b/dbms/src/Common/ZooKeeper/ZooKeeper.cpp
@@ -108,9 +108,9 @@ void ZooKeeper::init(const std::string & implementation_, const std::string & ho
 }
 
 ZooKeeper::ZooKeeper(const std::string & hosts_, const std::string & identity_, int32_t session_timeout_ms_,
-                     int32_t operation_timeout_ms_, const std::string & chroot_, const std::string & implementation)
+                     int32_t operation_timeout_ms_, const std::string & chroot_, const std::string & implementation_)
 {
-    init(implementation, hosts_, identity_, session_timeout_ms_, operation_timeout_ms_, chroot_);
+    init(implementation_, hosts_, identity_, session_timeout_ms_, operation_timeout_ms_, chroot_);
 }
 
 struct ZooKeeperArgs

--- a/dbms/src/Common/ZooKeeper/ZooKeeper.cpp
+++ b/dbms/src/Common/ZooKeeper/ZooKeeper.cpp
@@ -45,7 +45,7 @@ static void check(int32_t code, const std::string & path)
 }
 
 
-void ZooKeeper::init(const std::string & implementation, const std::string & hosts_, const std::string & identity_,
+void ZooKeeper::init(const std::string & implementation_, const std::string & hosts_, const std::string & identity_,
                      int32_t session_timeout_ms_, int32_t operation_timeout_ms_, const std::string & chroot_)
 {
     log = &Logger::get("ZooKeeper");
@@ -54,6 +54,7 @@ void ZooKeeper::init(const std::string & implementation, const std::string & hos
     session_timeout_ms = session_timeout_ms_;
     operation_timeout_ms = operation_timeout_ms_;
     chroot = chroot_;
+    implementation = implementation_;
 
     if (implementation == "zookeeper")
     {
@@ -671,7 +672,7 @@ void ZooKeeper::waitForDisappear(const std::string & path)
 
 ZooKeeperPtr ZooKeeper::startNewSession() const
 {
-    return std::make_shared<ZooKeeper>(hosts, identity, session_timeout_ms, operation_timeout_ms, chroot);
+    return std::make_shared<ZooKeeper>(hosts, identity, session_timeout_ms, operation_timeout_ms, chroot, implementation);
 }
 
 

--- a/dbms/src/Common/ZooKeeper/ZooKeeper.cpp
+++ b/dbms/src/Common/ZooKeeper/ZooKeeper.cpp
@@ -66,13 +66,13 @@ void ZooKeeper::init(const std::string & implementation_, const std::string & ho
         Coordination::ZooKeeper::Addresses addresses;
         addresses.reserve(addresses_strings.size());
 
-        for (const auto &address_string : addresses_strings)
+        for (const auto & address_string : addresses_strings)
         {
             try
             {
                 addresses.emplace_back(address_string);
             }
-            catch (const Poco::Net::DNSException &e)
+            catch (const Poco::Net::DNSException & e)
             {
                 LOG_ERROR(log, "Cannot use ZooKeeper address " << address_string << ", reason: " << e.displayText());
             }

--- a/dbms/src/Common/ZooKeeper/ZooKeeper.h
+++ b/dbms/src/Common/ZooKeeper/ZooKeeper.h
@@ -258,6 +258,7 @@ private:
     int32_t session_timeout_ms;
     int32_t operation_timeout_ms;
     std::string chroot;
+    std::string implementation;
 
     std::mutex mutex;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Non-significant (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `startNewSession` method in ZooKeeper API for non default ZooKeeper implementations. 