### PR TITLE
Fix integration test test_settings_constraints

### DIFF
--- a/dbms/tests/integration/test_settings_constraints/test.py
+++ b/dbms/tests/integration/test_settings_constraints/test.py
@@ -110,7 +110,7 @@ def assert_query_settings(instance, query, settings, result=None, exception=None
 
     # http level settings
     if exception:
-        assert exception in instance.http_query(query, params=settings, user=user)
+        assert exception in instance.http_query_and_get_error(query, params=settings, user=user)
     else:
         assert instance.http_query(query, params=settings, user=user).strip() == result
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Build/Testing/Packaging Improvement

Changelog entry:
Fix integration test `test_settings_constraints`.


```
    def http_query(self, sql, data=None, params=None, user=None, password=None, expect_fail_and_get_error=False):
        if params is None:
            params = {}
        else:
            params = params.copy()
    
        params["query"] = sql
    
        auth = ""
        if user and password:
            auth = "{}:{}@".format(user, password)
        elif user:
            auth = "{}@".format(user)
    
        url = "http://" + auth + self.ip_address + ":8123/?" + urllib.urlencode(params)
    
        open_result = urllib.urlopen(url, data)
    
        def http_code_and_message():
            return str(open_result.getcode()) + " " + httplib.responses[open_result.getcode()] + ": " + open_result.read()
    
        if expect_fail_and_get_error:
            if open_result.getcode() == 200:
                raise Exception("ClickHouse HTTP server is expected to fail, but succeeded: " + open_result.read())
            return http_code_and_message()
        else:
            if open_result.getcode() != 200:
>               raise Exception("ClickHouse HTTP server returned " + http_code_and_message())
E               Exception: ClickHouse HTTP server returned 500 Internal Server Error: Code: 452, e.displayText() = DB::Exception: Setting max_memory_usage shouldn't be less than 5000000000 (version 20.3.6.24 (official build))

helpers/cluster.py:683: Exception
```