### PR TITLE
Fix typo in Table Engines -> Introduction

### DIFF
--- a/docs/en/operations/table_engines/index.md
+++ b/docs/en/operations/table_engines/index.md
@@ -35,7 +35,7 @@ Engines in the family:
 -   [StripeLog](stripelog.md)
 -   [Log](log.md)
 
-### Intergation engines {#intergation-engines}
+### Integration engines {#integration-engines}
 
 Engines for communicating with other data storage and processing systems.
 

--- a/docs/es/operations/table_engines/index.md
+++ b/docs/es/operations/table_engines/index.md
@@ -39,7 +39,7 @@ Motores en la familia:
 -   [StripeLog](stripelog.md)
 -   [Registro](log.md)
 
-### Motores de intergación {#intergation-engines}
+### Motores de integración {#integration-engines}
 
 Motores para comunicarse con otros sistemas de almacenamiento y procesamiento de datos.
 

--- a/docs/fr/operations/table_engines/index.md
+++ b/docs/fr/operations/table_engines/index.md
@@ -39,7 +39,7 @@ Moteurs dans la famille:
 -   [StripeLog](stripelog.md)
 -   [Journal](log.md)
 
-### Moteurs d'Intergation {#intergation-engines}
+### Moteurs d'Integration {#integration-engines}
 
 Moteurs de communication avec d'autres systèmes de stockage et de traitement de données.
 

--- a/docs/zh/operations/table_engines/index.md
+++ b/docs/zh/operations/table_engines/index.md
@@ -34,7 +34,7 @@
 -   \[StripeLog\](stripelog/）
 -   [Log](#log)(log/）
 
-## Intergation engines {#intergation-engines}
+## Integration engines {#integration-engines}
 
 用于与其他的数据存储与处理系统集成的引擎。
 该类型的引擎：


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)

Detailed description:

Fix typo in documentation about table engines: "Intergation" -> "Integration"