### PR TITLE
Fix reusing connection after changing user's default settings

### DIFF
--- a/dbms/programs/server/TCPHandler.cpp
+++ b/dbms/programs/server/TCPHandler.cpp
@@ -147,6 +147,10 @@ void TCPHandler::runImpl()
         if (server.isCancelled() || in->eof())
             break;
 
+        /// receiveHello() has set the default settings for the current user,
+        /// but this default itself could change while we were waiting for a packet from the client.
+        connection_context.resetSettingsToDefault();
+
         /// Set context of request.
         query_context = connection_context;
 

--- a/dbms/src/Access/ContextAccess.cpp
+++ b/dbms/src/Access/ContextAccess.cpp
@@ -540,14 +540,14 @@ std::shared_ptr<const ContextAccess> ContextAccess::getFullAccess()
 std::shared_ptr<const Settings> ContextAccess::getDefaultSettings() const
 {
     std::lock_guard lock{mutex};
-    return enabled_settings->getSettings();
+    return enabled_settings ? enabled_settings->getSettings() : nullptr;
 }
 
 
 std::shared_ptr<const SettingsConstraints> ContextAccess::getSettingsConstraints() const
 {
     std::lock_guard lock{mutex};
-    return enabled_settings->getConstraints();
+    return enabled_settings ? enabled_settings->getConstraints() : nullptr;
 }
 
 }

--- a/dbms/src/Interpreters/Context.cpp
+++ b/dbms/src/Interpreters/Context.cpp
@@ -909,6 +909,7 @@ void Context::setSettings(const Settings & settings_)
     auto old_allow_introspection_functions = settings.allow_introspection_functions;
 
     settings = settings_;
+    active_default_settings = nullptr;
 
     if ((settings.readonly != old_readonly) || (settings.allow_ddl != old_allow_ddl) || (settings.allow_introspection_functions != old_allow_introspection_functions))
         calculateAccessRights();
@@ -918,6 +919,7 @@ void Context::setSettings(const Settings & settings_)
 void Context::setSetting(const StringRef & name, const String & value)
 {
     auto lock = getLock();
+    active_default_settings = nullptr;
     if (name == "profile")
     {
         setProfile(value);
@@ -933,6 +935,7 @@ void Context::setSetting(const StringRef & name, const String & value)
 void Context::setSetting(const StringRef & name, const Field & value)
 {
     auto lock = getLock();
+    active_default_settings = nullptr;
     if (name == "profile")
     {
         setProfile(value.safeGet<String>());
@@ -956,6 +959,20 @@ void Context::applySettingsChanges(const SettingsChanges & changes)
     auto lock = getLock();
     for (const SettingChange & change : changes)
         applySettingChange(change);
+}
+
+
+void Context::resetSettingsToDefault()
+{
+    auto lock = getLock();
+    auto default_settings = getAccess()->getDefaultSettings();
+    if (default_settings && (default_settings == active_default_settings))
+        return;
+    if (default_settings)
+        setSettings(*default_settings);
+    else
+        setSettings(Settings{});
+    active_default_settings = default_settings;
 }
 
 

--- a/dbms/src/Interpreters/Context.h
+++ b/dbms/src/Interpreters/Context.h
@@ -151,6 +151,7 @@ private:
     bool use_default_roles = false;
     std::shared_ptr<const ContextAccess> access;
     std::shared_ptr<const EnabledRowPolicies> initial_row_policy;
+    std::shared_ptr<const Settings> active_default_settings;
     String current_database;
     Settings settings;                                  /// Setting for query execution.
     using ProgressCallback = std::function<void(const Progress & progress)>;
@@ -344,6 +345,9 @@ public:
     void setSetting(const StringRef & name, const Field & value);
     void applySettingChange(const SettingChange & change);
     void applySettingsChanges(const SettingsChanges & changes);
+
+    /// Reset settings to the default values for the current user.
+    void resetSettingsToDefault();
 
     /// Checks the constraints.
     void checkSettingsConstraints(const SettingChange & change) const;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Bug Fix

Changelog entry:
Fix reusing connection after changing user's default settings via `ALTER USER` or `ALTER SETTINGS PROFILE`. This fixes integration test `test_settings_constraints_distributed`.