### PR TITLE
Fix num threads in distributed

### DIFF
--- a/dbms/src/Processors/Pipe.cpp
+++ b/dbms/src/Processors/Pipe.cpp
@@ -63,6 +63,7 @@ Pipe::Pipe(ProcessorPtr source)
         totals = &source->getOutputs().back();
 
     processors.emplace_back(std::move(source));
+    max_parallel_streams = 1;
 }
 
 Pipe::Pipe(Processors processors_, OutputPort * output_port_, OutputPort * totals_)
@@ -82,6 +83,7 @@ Pipe::Pipe(Pipes && pipes, ProcessorPtr transform)
         connect(*pipe.output_port, *it);
         ++it;
 
+        max_parallel_streams += pipe.max_parallel_streams;
         processors.insert(processors.end(), pipe.processors.begin(), pipe.processors.end());
     }
 

--- a/dbms/src/Processors/Pipe.h
+++ b/dbms/src/Processors/Pipe.h
@@ -50,6 +50,8 @@ public:
     void setTotalsPort(OutputPort * totals_) { totals = totals_; }
     OutputPort * getTotalsPort() const { return totals; }
 
+    size_t maxParallelStreams() const { return max_parallel_streams; }
+
     /// Do not allow to change the table while the processors of pipe are alive.
     /// TODO: move it to pipeline.
     void addTableLock(const TableStructureReadLockHolder & lock) { table_locks.push_back(lock); }
@@ -65,6 +67,9 @@ private:
     Processors processors;
     OutputPort * output_port = nullptr;
     OutputPort * totals = nullptr;
+
+    /// It is the max number of processors which can be executed in parallel for each step. See QueryPipeline::Streams.
+    size_t max_parallel_streams = 0;
 
     std::vector<TableStructureReadLockHolder> table_locks;
 

--- a/dbms/src/Processors/QueryPipeline.cpp
+++ b/dbms/src/Processors/QueryPipeline.cpp
@@ -645,6 +645,7 @@ Pipe QueryPipeline::getPipe() &&
 {
     resize(1);
     Pipe pipe(std::move(processors), streams.at(0), totals_having_port);
+    pipe.max_parallel_streams = streams.maxParallelStreams();
 
     for (auto & lock : table_locks)
         pipe.addTableLock(lock);

--- a/dbms/src/Processors/QueryPipeline.cpp
+++ b/dbms/src/Processors/QueryPipeline.cpp
@@ -98,7 +98,7 @@ void QueryPipeline::init(Pipes pipes)
             totals.emplace_back(totals_port);
         }
 
-        streams.addStream(&pipe.getPort());
+        streams.addStream(&pipe.getPort(), pipe.maxParallelStreams());
         auto cur_processors = std::move(pipe).detachProcessors();
         processors.insert(processors.end(), cur_processors.begin(), cur_processors.end());
     }
@@ -226,7 +226,7 @@ void QueryPipeline::addPipe(Processors pipe)
     streams.reserve(last->getOutputs().size());
     for (auto & output : last->getOutputs())
     {
-        streams.addStream(&output);
+        streams.addStream(&output, 0);
         if (header)
             assertBlocksHaveEqualStructure(header, output.getHeader(), "QueryPipeline");
         else
@@ -245,7 +245,7 @@ void QueryPipeline::addDelayedStream(ProcessorPtr source)
     assertBlocksHaveEqualStructure(current_header, source->getOutputs().front().getHeader(), "QueryPipeline");
 
     IProcessor::PortNumbers delayed_streams = { streams.size() };
-    streams.addStream(&source->getOutputs().front());
+    streams.addStream(&source->getOutputs().front(), 0);
     processors.emplace_back(std::move(source));
 
     auto processor = std::make_shared<DelayedPortsProcessor>(current_header, streams.size(), delayed_streams);
@@ -275,7 +275,7 @@ void QueryPipeline::resize(size_t num_streams, bool force, bool strict)
     streams.clear();
     streams.reserve(num_streams);
     for (auto & output : resize->getOutputs())
-        streams.addStream(&output);
+        streams.addStream(&output, 0);
 
     processors.emplace_back(std::move(resize));
 }

--- a/dbms/src/Processors/QueryPipeline.h
+++ b/dbms/src/Processors/QueryPipeline.h
@@ -38,16 +38,16 @@ private:
         void clear() { data.clear(); }
         void reserve(size_t size_) { data.reserve(size_); }
 
-        void addStream(OutputPort * port)
+        void addStream(OutputPort * port, size_t port_max_parallel_streams)
         {
             data.push_back(port);
-            max_parallel_streams = std::max<size_t>(max_parallel_streams, data.size());
+            max_parallel_streams = std::max<size_t>(max_parallel_streams + port_max_parallel_streams, data.size());
         }
 
         void addStreams(Streams & other)
         {
             data.insert(data.end(), other.begin(), other.end());
-            max_parallel_streams = std::max<size_t>(max_parallel_streams, data.size());
+            max_parallel_streams = std::max<size_t>(max_parallel_streams + other.max_parallel_streams, data.size());
         }
 
         void assign(std::initializer_list<OutputPort *> list)

--- a/dbms/tests/performance/distributed_aggregation.xml
+++ b/dbms/tests/performance/distributed_aggregation.xml
@@ -1,0 +1,18 @@
+<test>
+    <stop_conditions>
+        <all_of>
+            <iterations>10</iterations>
+            <min_time_not_changing_for_ms>1000</min_time_not_changing_for_ms>
+        </all_of>
+        <any_of>
+            <iterations>50</iterations>
+            <total_time_ms>60000</total_time_ms>
+        </any_of>
+    </stop_conditions>
+
+    <query>select count() from (select sipHash64(zero) from zeros_mt(100000000) union all select sipHash64(zero) from zeros_mt(100000000))</query>
+    <query>select count(sipHash64(zero)) from remote('127.0.0.{1,1}', zeros_mt(100000000))</query>
+    <query>select count(sipHash64(zero)) from remote('127.0.0.{1,2}', zeros_mt(100000000))</query>
+    <query>select count(sipHash64(zero)) from remote('127.0.0.{2,3}', zeros_mt(100000000))</query>
+
+</test>

--- a/dbms/tests/performance/distributed_aggregation.xml
+++ b/dbms/tests/performance/distributed_aggregation.xml
@@ -11,8 +11,8 @@
     </stop_conditions>
 
     <query>select count() from (select sipHash64(zero) from zeros_mt(100000000) union all select sipHash64(zero) from zeros_mt(100000000))</query>
-    <query>select count(sipHash64(zero)) from remote('127.0.0.{1,1}', zeros_mt(100000000))</query>
-    <query>select count(sipHash64(zero)) from remote('127.0.0.{1,2}', zeros_mt(100000000))</query>
-    <query>select count(sipHash64(zero)) from remote('127.0.0.{2,3}', zeros_mt(100000000))</query>
+    <query>select count(sipHash64(zero)) from remote('127.0.0.{{1,1}}', zeros_mt(100000000))</query>
+    <query>select count(sipHash64(zero)) from remote('127.0.0.{{1,2}}', zeros_mt(100000000))</query>
+    <query>select count(sipHash64(zero)) from remote('127.0.0.{{2,3}}', zeros_mt(100000000))</query>
 
 </test>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix the number of threads used for remote query execution (performance regression, since 20.3). This happened when query from `Distributed` table was executed simultaneously on local and remote shards. Fixes #9965