### PR TITLE
Fix use-after-free at syntax error

### DIFF
--- a/dbms/src/Parsers/ExpressionElementParsers.cpp
+++ b/dbms/src/Parsers/ExpressionElementParsers.cpp
@@ -1026,8 +1026,7 @@ bool ParserCollectionOfLiterals<Collection>::parseImpl(Pos & pos, ASTPtr & node,
             }
             else
             {
-                String message = String("comma or ") + getTokenName(closing_bracket);
-                expected.add(pos, message.c_str());
+                expected.add(pos, "comma or closing bracket");
                 return false;
             }
         }

--- a/dbms/tests/queries/0_stateless/01107_tuples_arrays_parsing_exceptions.reference
+++ b/dbms/tests/queries/0_stateless/01107_tuples_arrays_parsing_exceptions.reference
@@ -1,0 +1,2 @@
+Syntax error
+Syntax error

--- a/dbms/tests/queries/0_stateless/01107_tuples_arrays_parsing_exceptions.sh
+++ b/dbms/tests/queries/0_stateless/01107_tuples_arrays_parsing_exceptions.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. $CURDIR/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "SELECT (1, 2 2)" 2>&1 | grep -o "Syntax error"
+$CLICKHOUSE_CLIENT -q "SELECT [1, 2 2]" 2>&1 | grep -o "Syntax error"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Non-significant (changelog entry is not required)

Detailed description / Documentation draft:
No release is affected.
