### PR TITLE
Fix parallel distributed insert select

### DIFF
--- a/dbms/Interpreters/InterpreterInsertQuery.cpp
+++ b/dbms/Interpreters/InterpreterInsertQuery.cpp
@@ -176,7 +176,7 @@ BlockIO InterpreterInsertQuery::execute()
                             "Expected exactly one connection for shard " + toString(shard_info.shard_num), ErrorCodes::LOGICAL_ERROR);
 
                     ///  INSERT SELECT query returns empty block
-                    auto in_stream = std::make_shared<RemoteBlockInputStream>(*connections.front(), new_query_str, Block{}, context);
+                    auto in_stream = std::make_shared<RemoteBlockInputStream>(std::move(connections), new_query_str, Block{}, context);
                     in_streams.push_back(in_stream);
                 }
                 out_streams.push_back(std::make_shared<NullBlockOutputStream>(Block()));


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix parallel distributed INSERT SELECT for remote table. This PR fixes the solution provided in [#9759](https://github.com/ClickHouse/ClickHouse/pull/9759)

This PR fixes the segfault https://clickhouse-test-reports.s3.yandex.net/9857/df3c7094d5a33a39fada1afad4ff765554f00467/functional_stateless_tests_(debug)/clickhouse-server.log