### PR TITLE
docs: tell the cutIPv6() is cutting bytes not bits

### DIFF
--- a/docs/en/sql_reference/functions/ip_address_functions.md
+++ b/docs/en/sql_reference/functions/ip_address_functions.md
@@ -132,9 +132,9 @@ SELECT IPv6NumToString(IPv4ToIPv6(IPv4StringToNum('192.168.0.1'))) AS addr
 └────────────────────┘
 ```
 
-## cutIPv6(x, bitsToCutForIPv6, bitsToCutForIPv4) {#cutipv6x-bitstocutforipv6-bitstocutforipv4}
+## cutIPv6(x, bytesToCutForIPv6, bytesToCutForIPv4) {#cutipv6x-bytestocutforipv6-bytestocutforipv4}
 
-Accepts a FixedString(16) value containing the IPv6 address in binary format. Returns a string containing the address of the specified number of bits removed in text format. For example:
+Accepts a FixedString(16) value containing the IPv6 address in binary format. Returns a string containing the address of the specified number of bytes removed in text format. For example:
 
 ``` sql
 WITH


### PR DESCRIPTION
The IPv6CIDRToRange() appears to use bits while cutIPv6() will cut in bytes.

    WITH IPv6StringToNum('FFFF:FFFF:FFFF:FFFF:AAAA:AAAA:AAAA:AAAA') AS ipv6
    SELECT
      cutIPv6(ipv6, 8, 0),
      tupleElement(IPv6CIDRToRange(ipv6, 64), 1)

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
* Documentation