### PR TITLE
Handle no node error during ON CLUSTER query

### DIFF
--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -922,7 +922,7 @@ void DDLWorker::createStatusDirs(const std::string & node_path, const ZooKeeperP
     }
     Coordination::Responses responses;
     int code = zookeeper->tryMulti(ops, responses);
-    if (code && code != Coordination::ZNODEEXISTS)
+    if (code && code != Coordination::ZNODEEXISTS && code != Coordination::ZNONODE)
         throw Coordination::Exception(code);
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Handle zookeeper no node error during distributed query

Detailed description / Documentation draft:

When one thread is trying to process the query there's a chance
that cleanup thread in another clickhouse instance deletes the
corresponding zk node.

Fix issue https://github.com/ClickHouse/ClickHouse/issues/6639
