### PR TITLE
Enable parallel INSERT for materialized view

### DIFF
--- a/src/Storages/StorageMaterializedView.h
+++ b/src/Storages/StorageMaterializedView.h
@@ -31,6 +31,7 @@ public:
     bool supportsPrewhere() const override { return getTargetTable()->supportsPrewhere(); }
     bool supportsFinal() const override { return getTargetTable()->supportsFinal(); }
     bool supportsIndexForIn() const override { return getTargetTable()->supportsIndexForIn(); }
+    bool supportsParallelInsert() const override { return getTargetTable()->supportsParallelInsert(); }
     bool mayBenefitFromIndexForIn(const ASTPtr & left_in_operand, const Context & query_context) const override
     {
         return getTargetTable()->mayBenefitFromIndexForIn(left_in_operand, query_context);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Enable parallel insert of materialized view when its target table supports.

Detailed description / Documentation draft:

Enable parallel insert of materialized view when its target table supports. this can benefit when pushing data by using `INSERT SELECT` query.
