### PR TITLE
Add ruby library clickhouse-activerecord to list in docs

### DIFF
--- a/docs/en/interfaces/third-party/client_libraries.md
+++ b/docs/en/interfaces/third-party/client_libraries.md
@@ -34,6 +34,7 @@ toc_title: Client Libraries
     -   [AnyEvent-ClickHouse](https://metacpan.org/release/AnyEvent-ClickHouse)
 -   Ruby
     -   [ClickHouse (Ruby)](https://github.com/shlima/click_house)
+    -   [clickhouse-activerecord](https://github.com/PNixx/clickhouse-activerecord)
 -   R
     -   [clickhouse-r](https://github.com/hannesmuehleisen/clickhouse-r)
     -   [RClickhouse](https://github.com/IMSMWU/RClickhouse)

--- a/docs/es/interfaces/third-party/client_libraries.md
+++ b/docs/es/interfaces/third-party/client_libraries.md
@@ -36,6 +36,7 @@ toc_title: Bibliotecas de clientes
     -   [Cualquier evento-ClickHouse](https://metacpan.org/release/AnyEvent-ClickHouse)
 -   Rubí
     -   [Haga clic en Casa (Ruby)](https://github.com/shlima/click_house)
+    -   [clickhouse-activerecord](https://github.com/PNixx/clickhouse-activerecord)
 -   R
     -   [Sistema abierto.](https://github.com/hannesmuehleisen/clickhouse-r)
     -   [Bienvenidos al Portal de LicitaciÃ³n ElectrÃ³nica de LicitaciÃ³n ElectrÃ³nica](https://github.com/IMSMWU/RClickhouse)

--- a/docs/fa/interfaces/third-party/client_libraries.md
+++ b/docs/fa/interfaces/third-party/client_libraries.md
@@ -37,6 +37,7 @@ toc_title: "\u06A9\u062A\u0627\u0628\u062E\u0627\u0646\u0647 \u0647\u0627\u06CC 
     -   [هرفنت-کلیکهاوس](https://metacpan.org/release/AnyEvent-ClickHouse)
 -   روبی
     -   [تاتر (روبی)](https://github.com/shlima/click_house)
+    -   [clickhouse-activerecord](https://github.com/PNixx/clickhouse-activerecord)
 -   R
     -   [کلیک تحقیق](https://github.com/hannesmuehleisen/clickhouse-r)
     -   [خانه روستایی](https://github.com/IMSMWU/RClickhouse)

--- a/docs/fr/interfaces/third-party/client_libraries.md
+++ b/docs/fr/interfaces/third-party/client_libraries.md
@@ -36,6 +36,7 @@ toc_title: "Biblioth\xE8ques Clientes"
     -   [AnyEvent-ClickHouse](https://metacpan.org/release/AnyEvent-ClickHouse)
 -   Rubis
     -   [ClickHouse (Ruby)](https://github.com/shlima/click_house)
+    -   [clickhouse-activerecord](https://github.com/PNixx/clickhouse-activerecord)
 -   R
     -   [clickhouse-r](https://github.com/hannesmuehleisen/clickhouse-r)
     -   [RClickhouse](https://github.com/IMSMWU/RClickhouse)

--- a/docs/ja/interfaces/third-party/client_libraries.md
+++ b/docs/ja/interfaces/third-party/client_libraries.md
@@ -36,6 +36,7 @@ toc_title: "\u30AF\u30E9\u30A4\u30A2\u30F3\u30C8"
     -   [AnyEvent-ClickHouse](https://metacpan.org/release/AnyEvent-ClickHouse)
 -   Ruby
     -   [クリックハウス(ruby)](https://github.com/shlima/click_house)
+    -   [clickhouse-activerecord](https://github.com/PNixx/clickhouse-activerecord)
 -   R
     -   [クリックハウス-r](https://github.com/hannesmuehleisen/clickhouse-r)
     -   [Rクリックハウス](https://github.com/IMSMWU/RClickhouse)

--- a/docs/ru/interfaces/third-party/client_libraries.md
+++ b/docs/ru/interfaces/third-party/client_libraries.md
@@ -29,6 +29,7 @@
     -   [AnyEvent-ClickHouse](https://metacpan.org/release/AnyEvent-ClickHouse)
 -   Ruby
     -   [ClickHouse (Ruby)](https://github.com/shlima/click_house)
+    -   [clickhouse-activerecord](https://github.com/PNixx/clickhouse-activerecord)
 -   R
     -   [clickhouse-r](https://github.com/hannesmuehleisen/clickhouse-r)
     -   [RClickhouse](https://github.com/IMSMWU/RClickhouse)

--- a/docs/zh/interfaces/third-party/client_libraries.md
+++ b/docs/zh/interfaces/third-party/client_libraries.md
@@ -28,6 +28,7 @@
     -   [AnyEvent-ClickHouse](https://metacpan.org/release/AnyEvent-ClickHouse)
 -   Ruby
     -   [ClickHouse (Ruby)](https://github.com/shlima/click_house)
+    -   [clickhouse-activerecord](https://github.com/PNixx/clickhouse-activerecord)
 -   R
     -   [clickhouse-r](https://github.com/hannesmuehleisen/clickhouse-r)
     -   [RClickhouse](https://github.com/IMSMWU/RClickhouse)


### PR DESCRIPTION
Changelog category:
- Documentation

Add another client library [clickhouse-activerecord](https://github.com/PNixx/clickhouse-activerecord) to list in docs(en/ru).