### PR TITLE
Fix replicated tables startup when updating from old version

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -256,6 +256,15 @@ StorageReplicatedMergeTree::StorageReplicatedMergeTree(
     }
     else
     {
+        /// In old tables this node may missing
+        String replica_metadata;
+        bool replica_metadata_exists = current_zookeeper->tryGet(replica_path + "/metadata", replica_metadata);
+        if (!replica_metadata_exists || replica_metadata.empty())
+        {
+            ReplicatedMergeTreeTableMetadata current_metadata(*this);
+            current_zookeeper->createOrUpdate(replica_path + "/metadata", current_metadata.toString(), zkutil::CreateMode::Persistent);
+        }
+
         checkTableStructure(replica_path);
         checkParts(skip_sanity_checks);
 
@@ -263,8 +272,13 @@ StorageReplicatedMergeTree::StorageReplicatedMergeTree(
         {
             metadata_version = parse<int>(current_zookeeper->get(replica_path + "/metadata_version"));
         }
-        else /// This replica was created on old version, so we have to take version of global node
+        else
         {
+            /// This replica was created with old clickhouse version, so we have
+            /// to take version of global node. If somebody will alter our
+            /// table, than we will fill /metadata_version node in zookeeper.
+            /// Otherwise on the next restart we can again use version from
+            /// shared metadata node because it was not changed.
             Coordination::Stat metadata_stat;
             current_zookeeper->get(zookeeper_path + "/metadata", &metadata_stat);
             metadata_version = metadata_stat.version;

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -256,7 +256,7 @@ StorageReplicatedMergeTree::StorageReplicatedMergeTree(
     }
     else
     {
-        /// In old tables this node may missing
+        /// In old tables this node may missing or be empty
         String replica_metadata;
         bool replica_metadata_exists = current_zookeeper->tryGet(replica_path + "/metadata", replica_metadata);
         if (!replica_metadata_exists || replica_metadata.empty())

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -276,7 +276,7 @@ StorageReplicatedMergeTree::StorageReplicatedMergeTree(
         {
             /// This replica was created with old clickhouse version, so we have
             /// to take version of global node. If somebody will alter our
-            /// table, than we will fill /metadata_version node in zookeeper.
+            /// table, then we will fill /metadata_version node in zookeeper.
             /// Otherwise on the next restart we can again use version from
             /// shared metadata node because it was not changed.
             Coordination::Stat metadata_stat;

--- a/tests/integration/test_no_local_metadata_node/test.py
+++ b/tests/integration/test_no_local_metadata_node/test.py
@@ -1,0 +1,54 @@
+import time
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node1 = cluster.add_instance('node1', with_zookeeper=True)
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_table_start_without_metadata(start_cluster):
+    node1.query("""
+        CREATE TABLE test (date Date)
+        ENGINE = ReplicatedMergeTree('/clickhouse/table/test_table', '1')
+        ORDER BY tuple()
+    """)
+
+    node1.query("INSERT INTO test VALUES(toDate('2019-12-01'))")
+
+    assert node1.query("SELECT date FROM test") == "2019-12-01\n"
+
+    # some fake alter
+    node1.query("ALTER TABLE test MODIFY COLUMN date Date DEFAULT toDate('2019-10-01')")
+
+    assert node1.query("SELECT date FROM test") == "2019-12-01\n"
+
+    node1.query("DETACH TABLE test")
+    zk_cli = cluster.get_kazoo_client('zoo1')
+
+    # simulate update from old version
+    zk_cli.delete("/clickhouse/table/test_table/replicas/1/metadata")
+    zk_cli.delete("/clickhouse/table/test_table/replicas/1/metadata_version")
+
+    node1.query("ATTACH TABLE test")
+
+    assert node1.query("SELECT date FROM test") == "2019-12-01\n"
+
+    node1.query("ALTER TABLE test MODIFY COLUMN date Date DEFAULT toDate('2019-09-01')")
+
+    node1.query("DETACH TABLE test")
+
+    zk_cli.set("/clickhouse/table/test_table/replicas/1/metadata", "")
+
+    node1.query("ATTACH TABLE test")
+
+    assert node1.query("SELECT date FROM test") == "2019-12-01\n"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed replicated tables startup when updating from an old ClickHouse version where `/table/replicas/replica_name/metadata` node doesn't exist. Fixes #10037.