### PR TITLE
Fix SIGSEGV on INSERT into Distributed on different struct with underlying

### DIFF
--- a/src/Storages/Distributed/DistributedBlockOutputStream.cpp
+++ b/src/Storages/Distributed/DistributedBlockOutputStream.cpp
@@ -305,7 +305,9 @@ ThreadPool::Job DistributedBlockOutputStream::runWritingJob(DistributedBlockOutp
                 job.local_context = std::make_unique<Context>(context);
 
                 InterpreterInsertQuery interp(query_ast, *job.local_context);
-                job.stream = interp.execute().out;
+                auto block_io = interp.execute();
+                assertBlocksHaveEqualStructure(block_io.out->getHeader(), shard_block, "flushing shard block for " + storage.getStorageID().getNameForLogs());
+                job.stream = block_io.out;
                 job.stream->writePrefix();
             }
 
@@ -544,6 +546,9 @@ void DistributedBlockOutputStream::writeToLocal(const Block & block, const size_
     InterpreterInsertQuery interp(query_ast, context);
 
     auto block_io = interp.execute();
+
+    assertBlocksHaveEqualStructure(block_io.out->getHeader(), block, "flushing " + storage.getStorageID().getNameForLogs());
+
     block_io.out->writePrefix();
 
     for (size_t i = 0; i < repeats; ++i)

--- a/tests/queries/0_stateless/00967_insert_into_distributed_different_types.sql
+++ b/tests/queries/0_stateless/00967_insert_into_distributed_different_types.sql
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS dist_00967;
+DROP TABLE IF EXISTS underlying_00967;
+
+CREATE TABLE dist_00967 (key UInt64) Engine=Distributed('test_shard_localhost', currentDatabase(), underlying_00967);
+-- fails for TinyLog()/MergeTree()/... but not for Memory()
+CREATE TABLE underlying_00967 (key Nullable(UInt64)) Engine=TinyLog();
+INSERT INTO dist_00967 SELECT toUInt64(number) FROM system.numbers LIMIT 1; -- { serverError 171; }
+
+SELECT * FROM dist_00967;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix SIGSEGV on INSERT into Distributed table when its structure differs from the underlying tables.

P.S. or maybe it is better to add conversion?