### PR TITLE
Fix code wrapping for non-code part

### DIFF
--- a/docs/en/sql_reference/statements/create.md
+++ b/docs/en/sql_reference/statements/create.md
@@ -24,10 +24,9 @@ CREATE DATABASE [IF NOT EXISTS] db_name [ON CLUSTER cluster] [ENGINE = engine(..
     ClickHouse creates the `db_name` database on all the servers of a specified cluster.
 
 -   `ENGINE`
-    - [MySQL](../engines/database_engines/mysql.md)  
-    Allows you to retrieve data from the remote MySQL server.
-
-        By default, ClickHouse uses its own [database engine](../engines/database_engines/index.md).
+    - [MySQL](../../engines/database_engines/mysql.md)  
+    Allows you to retrieve data from the remote MySQL server.  
+  By default, ClickHouse uses its own [database engine](../../engines/database_engines/index.md).
 
 ## CREATE TABLE {#create-table-query}
 

--- a/docs/en/sql_reference/statements/create.md
+++ b/docs/en/sql_reference/statements/create.md
@@ -15,22 +15,17 @@ CREATE DATABASE [IF NOT EXISTS] db_name [ON CLUSTER cluster] [ENGINE = engine(..
 
 ### Clauses {#clauses}
 
--   `IF NOT EXISTS`
+-   `IF NOT EXISTS`  
+  If the `db_name` database already exists, then ClickHouse doesn't create a new database and:
+    - Doesn't throw an exception if clause is specified.
+    - Throws an exception if clause isn't specified.
 
-        If the `db_name` database already exists, then ClickHouse doesn't create a new database and:
-
-        - Doesn't throw an exception if clause is specified.
-        - Throws an exception if clause isn't specified.
-
--   `ON CLUSTER`
-
-        ClickHouse creates the `db_name` database on all the servers of a specified cluster.
+-   `ON CLUSTER`  
+    ClickHouse creates the `db_name` database on all the servers of a specified cluster.
 
 -   `ENGINE`
-
-        - [MySQL](../engines/database_engines/mysql.md)
-
-            Allows you to retrieve data from the remote MySQL server.
+    - [MySQL](../engines/database_engines/mysql.md)  
+    Allows you to retrieve data from the remote MySQL server.
 
         By default, ClickHouse uses its own [database engine](../engines/database_engines/index.md).
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)


Detailed description / Documentation draft:
By some reason, the part of the documentation is wrapped as a code https://clickhouse.tech/docs/en/sql_reference/statements/create/#clauses 