### PR TITLE
Remove vagrant build

### DIFF
--- a/docker/packager/README.md
+++ b/docker/packager/README.md
@@ -3,10 +3,10 @@ compilers and build settings. Correctly configured Docker daemon is single depen
 
 Usage:
 
-Build deb package with `gcc-8` in `debug` mode:
+Build deb package with `gcc-9` in `debug` mode:
 ```
 $ mkdir deb/test_output
-$ ./packager --output-dir deb/test_output/ --package-type deb --compiler=gcc-8 --build-type=debug
+$ ./packager --output-dir deb/test_output/ --package-type deb --compiler=gcc-9 --build-type=debug
 $ ls -l deb/test_output
 -rw-r--r-- 1 root root      3730 clickhouse-client_18.14.2+debug_all.deb
 -rw-r--r-- 1 root root  84221888 clickhouse-common-static_18.14.2+debug_amd64.deb
@@ -18,11 +18,11 @@ $ ls -l deb/test_output
 
 ```
 
-Build ClickHouse binary with `clang-6.0` and `address` sanitizer in `relwithdebuginfo`
+Build ClickHouse binary with `clang-9.0` and `address` sanitizer in `relwithdebuginfo`
 mode:
 ```
 $ mkdir $HOME/some_clickhouse
-$ ./packager --output-dir=$HOME/some_clickhouse --package-type binary --compiler=clang-6.0 --sanitizer=address
+$ ./packager --output-dir=$HOME/some_clickhouse --package-type binary --compiler=clang-9.0 --sanitizer=address
 $ ls -l $HOME/some_clickhouse
 -rwxr-xr-x 1 root root 787061952  clickhouse
 lrwxrwxrwx 1 root root        10  clickhouse-benchmark -> clickhouse

--- a/docker/packager/freebsd/Vagrantfile
+++ b/docker/packager/freebsd/Vagrantfile
@@ -1,4 +1,0 @@
-Vagrant.configure("2") do |config|
-  config.vm.box = "robot-clickhouse/clickhouse-freebsd"
-  config.vm.synced_folder ".", "/vagrant", disabled: true
-end

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -11,47 +11,7 @@ SCRIPT_PATH = os.path.realpath(__file__)
 IMAGE_MAP = {
     "deb": "yandex/clickhouse-deb-builder",
     "binary": "yandex/clickhouse-binary-builder",
-    "freebsd": os.path.join(os.path.dirname(SCRIPT_PATH), "freebsd"),
 }
-
-class Vagrant(object):
-    def __init__(self, path_to_vagrant_file):
-        self.prefix = "VAGRANT_CWD=" + path_to_vagrant_file
-
-    def __enter__(self):
-        subprocess.check_call("{} vagrant up".format(self.prefix), shell=True)
-        self.ssh_path = "/tmp/vagrant-ssh"
-        subprocess.check_call("{} vagrant ssh-config > {}".format(self.prefix, self.ssh_path), shell=True)
-        return self
-
-    def copy_to_image(self, local_path, remote_path):
-        cmd = "scp -F {ssh} -r {lpath} default:{rpath}".format(ssh=self.ssh_path, lpath=local_path, rpath=remote_path)
-        logging.info("Copying to image %s", cmd)
-        subprocess.check_call(
-            cmd,
-            shell=True
-        )
-
-    def copy_from_image(self, remote_path, local_path):
-        cmd = "scp -F {ssh} -r default:{rpath} {lpath}".format(ssh=self.ssh_path, rpath=remote_path, lpath=local_path)
-        logging.info("Copying from image %s", cmd)
-        subprocess.check_call(
-            cmd,
-            shell=True
-        )
-
-    def execute_cmd(self, cmd):
-        cmd = '{} vagrant ssh -c "{}"'.format(self.prefix, cmd)
-        logging.info("Executin cmd %s", cmd)
-        subprocess.check_call(
-            cmd,
-            shell=True
-        )
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        logging.info("Destroying image")
-        subprocess.check_call("{} vagrant destroy --force".format(self.prefix), shell=True)
-
 
 def check_image_exists_locally(image_name):
     try:
@@ -93,15 +53,6 @@ def run_docker_image_with_env(image_name, output, env_variables, ch_root, ccache
     logging.info("Will build ClickHouse pkg with cmd: '{}'".format(cmd))
 
     subprocess.check_call(cmd, shell=True)
-
-def run_vagrant_box_with_env(image_path, output_dir, ch_root):
-    with Vagrant(image_path) as vagrant:
-        logging.info("Copying folder to vagrant machine")
-        vagrant.copy_to_image(ch_root, "~/ClickHouse")
-        logging.info("Running build")
-        vagrant.execute_cmd("cd ~/ClickHouse && cmake . && ninja")
-        logging.info("Copying binary back")
-        vagrant.copy_from_image("~/ClickHouse/programs/clickhouse", output_dir)
 
 def parse_env_variables(build_type, compiler, sanitizer, package_type, image_type, cache, distcc_hosts, unbundled, split_binary, clang_tidy, version, author, official, alien_pkgs, with_coverage):
     CLANG_PREFIX = "clang"
@@ -210,7 +161,7 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')
     parser = argparse.ArgumentParser(description="ClickHouse building script using prebuilt Docker image")
     # 'performance' creates a combined .tgz with server and configs to be used for performance test.
-    parser.add_argument("--package-type", choices=['deb', 'binary', 'performance', 'freebsd'], required=True)
+    parser.add_argument("--package-type", choices=['deb', 'binary', 'performance'], required=True)
     parser.add_argument("--clickhouse-repo-path", default="../../")
     parser.add_argument("--output-dir", required=True)
     parser.add_argument("--build-type", choices=("debug", ""), default="")
@@ -252,9 +203,5 @@ if __name__ == "__main__":
         args.build_type, args.compiler, args.sanitizer, args.package_type, image_type,
         args.cache, args.distcc_hosts, args.unbundled, args.split_binary, args.clang_tidy,
         args.version, args.author, args.official, args.alien_pkgs, args.with_coverage)
-    if image_type != "freebsd":
-        run_docker_image_with_env(image_name, args.output_dir, env_prepared, ch_root, args.ccache_dir)
-    else:
-        logging.info("Running freebsd build, arguments will be ignored")
-        run_vagrant_box_with_env(image_name, args.output_dir, ch_root)
+    run_docker_image_with_env(image_name, args.output_dir, env_prepared, ch_root, args.ccache_dir)
     logging.info("Output placed into {}".format(args.output_dir))


### PR DESCRIPTION
Changelog category (leave one):
- Non-significant (changelog entry is not required)

Remove support for Vagrant build. It was intended for FreeBSD but it doesn't work inside Sandbox. Now we have build for FreeBSD via cross-compilation on Linux and it makes Vagrant build obsolete.