### PR TITLE
Fix logged number of inserted rows into ReplicatedMergeTree

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeBlockOutputStream.cpp
@@ -147,11 +147,11 @@ void ReplicatedMergeTreeBlockOutputStream::write(const Block & block)
             /// That is, do not insert the same data to the same partition twice.
             block_id = part->info.partition_id + "_" + toString(hash_value.words[0]) + "_" + toString(hash_value.words[1]);
 
-            LOG_DEBUG(log, "Wrote block with ID '" << block_id << "', " << block.rows() << " rows");
+            LOG_DEBUG(log, "Wrote block with ID '" << block_id << "', " << current_block.block.rows() << " rows");
         }
         else
         {
-            LOG_DEBUG(log, "Wrote block with " << block.rows() << " rows");
+            LOG_DEBUG(log, "Wrote block with " << current_block.block.rows() << " rows");
         }
 
         try


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The number of rows was logged incorrectly (as sum across all parts) when inserted block is split by parts with partition key.

Detailed description / Documentation draft:
The issue has been found by **Sergey Veletskiy**, operations group of Yandex Metrica.