### PR TITLE
Do not send `readonly` setting to remote servers

### DIFF
--- a/src/Interpreters/ClusterProxy/executeQuery.cpp
+++ b/src/Interpreters/ClusterProxy/executeQuery.cpp
@@ -25,11 +25,16 @@ Context removeUserRestrictionsFromSettings(const Context & context, const Settin
     new_settings.max_memory_usage_for_user = 0;
     /// This setting is really not for user and should not be sent to remote server.
     new_settings.max_memory_usage_for_all_queries = 0;
+    /** This is validated and enforced on executor server and doesn't make sense to be sent to leafs.
+      * If sent, it precludes using a readonly>0 profile on remote server.
+      */
+    new_settings.readonly = 0;
 
     /// Set as unchanged to avoid sending to remote server.
     new_settings.max_concurrent_queries_for_user.changed = false;
     new_settings.max_memory_usage_for_user.changed = false;
     new_settings.max_memory_usage_for_all_queries.changed = false;
+    new_settings.readonly.changed = false;
 
     if (settings.force_optimize_skip_unused_shards_no_nested)
     {


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Significant (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Do not send `readonly` setting to remote servers


Detailed description / Documentation draft:

Consider a case where initial query is sent by a user which has
readonly=1 on the profile and the query is sent to a node under a different
user which has readonly=2.

Queries will fail on the leaf with the following exception:

> `Cannot modify 'readonly' setting in readonly mode.`.

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.
