### PR TITLE
clickhouse-docker-util

### DIFF
--- a/utils/clickhouse-docker
+++ b/utils/clickhouse-docker
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+if [ $# -lt 1 ]
+then
+cat << HELP
+
+clickhouse-docker -- open clickhouse-client of desired version in docker container (automatically removed after you exit bash shell).
+
+EXAMPLE:
+    - start latest version:
+       clickhouse-docker latest
+
+    - start version 20.1:
+       clickhouse-docker 20.1
+
+    - list avaliable versions:
+       clickhouse-docker list
+HELP
+exit
+fi
+
+param="$1"
+
+if [ "${param}" = "list" ]
+then
+    # https://stackoverflow.com/a/39454426/1555175
+    wget -q https://registry.hub.docker.com/v1/repositories/yandex/clickhouse-server/tags -O -  | sed -e 's/[][]//g' -e 's/"//g' -e 's/ //g' | tr '}' '\n'  | awk -F: '{print $3}'
+else
+    docker pull yandex/clickhouse-server:${param}
+    tmp_dir=$(mktemp -d -t ci-XXXXXXXXXX) # older version require /nonexistent folder to exist to run clickhouse client :D
+    chmod 777 ${tmp_dir}
+    set -e
+    containerid=`docker run -v${tmp_dir}:/nonexistent -d yandex/clickhouse-server:${param}`
+    set +e
+    while :
+    do
+        # that trick with init-file allows to start clickhouse client inside bash shell (nice if you need exit to bash, check smth, and get back to clickhouse-client)
+        docker exec -it ${containerid} bash -c 'bash --init-file <(echo "clickhouse client -m")'
+
+        printf "\n\nYou exited the session. What next?\n"
+        echo " [Q]uit and remove container."
+        echo " [R]estart clickhouse and run clickhouse-client in shell again."
+        echo "You can also hit Ctrl+C to exit and keep container running."
+
+        while :
+        do
+            read -p "Quit or restart [Q/R]?" choice
+            case "$choice" in
+            q|Q|exit ) break 2;;
+            r|R|restart ) echo "Restarting container ..."; docker restart ${containerid} > /dev/null; break 1;;
+            * ) echo "I don't understand. Please type Q or R" ;;
+            esac
+        done
+    done
+    docker rm -f ${containerid} > /dev/null
+    rm -rf ${tmp_dir}
+fi


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
`clickhouse-docker` util. Starts clickhouse-server of requested version in docker, and opens shell in that. Nice for checking behaviour of different clickhouse versions. 

Detailed description / Documentation draft:
![Peek 2020-04-09 15-25](https://user-images.githubusercontent.com/1549571/78900077-9d2e2c80-7a76-11ea-96f6-8ffb6ff6b18b.gif)
