### PR TITLE
Do not break DROP DICTIONARY with DROP TABLE

### DIFF
--- a/src/Databases/DatabasesCommon.cpp
+++ b/src/Databases/DatabasesCommon.cpp
@@ -70,8 +70,6 @@ StoragePtr DatabaseWithOwnTablesBase::detachTable(const String & table_name)
 StoragePtr DatabaseWithOwnTablesBase::detachTableUnlocked(const String & table_name)
 {
     StoragePtr res;
-    if (dictionaries.count(table_name))
-        throw Exception("Cannot detach dictionary " + database_name + "." + table_name + " as table, use DETACH DICTIONARY query.", ErrorCodes::UNKNOWN_TABLE);
 
     auto it = tables.find(table_name);
     if (it == tables.end())

--- a/src/Storages/StorageDictionary.cpp
+++ b/src/Storages/StorageDictionary.cpp
@@ -11,6 +11,7 @@
 #include <Parsers/ASTLiteral.h>
 #include <common/logger_useful.h>
 #include <Common/typeid_cast.h>
+#include <Common/quoteString.h>
 #include <Processors/Sources/SourceFromInputStream.h>
 #include <Processors/Pipe.h>
 
@@ -22,6 +23,7 @@ namespace ErrorCodes
 {
     extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
     extern const int THERE_IS_NO_COLUMN;
+    extern const int UNKNOWN_TABLE;
 }
 
 
@@ -43,6 +45,11 @@ StorageDictionary::StorageDictionary(
         const DictionaryStructure & dictionary_structure = dictionary->getStructure();
         checkNamesAndTypesCompatibleWithDictionary(dictionary_structure);
     }
+}
+
+void StorageDictionary::checkTableCanBeDropped() const
+{
+    throw Exception("Cannot detach dictionary " + backQuoteIfNeed(dictionary_name) + " as table, use DETACH DICTIONARY query.", ErrorCodes::UNKNOWN_TABLE);
 }
 
 Pipes StorageDictionary::read(

--- a/src/Storages/StorageDictionary.h
+++ b/src/Storages/StorageDictionary.h
@@ -25,6 +25,8 @@ class StorageDictionary final : public ext::shared_ptr_helper<StorageDictionary>
 public:
     std::string getName() const override { return "Dictionary"; }
 
+    void checkTableCanBeDropped() const override;
+
     Pipes read(const Names & column_names,
         const SelectQueryInfo & query_info,
         const Context & context,

--- a/tests/queries/0_stateless/01225_drop_dictionary_as_table.sql
+++ b/tests/queries/0_stateless/01225_drop_dictionary_as_table.sql
@@ -1,0 +1,20 @@
+DROP DATABASE IF EXISTS dict_db_01225;
+CREATE DATABASE dict_db_01225;
+
+CREATE TABLE dict_db_01225.dict_data (key UInt64, val UInt64) Engine=Memory();
+CREATE DICTIONARY dict_db_01225.dict
+(
+  key UInt64 DEFAULT 0,
+  val UInt64 DEFAULT 10
+)
+PRIMARY KEY key
+SOURCE(CLICKHOUSE(HOST 'localhost' PORT 9000 USER 'default' TABLE 'dict_data' PASSWORD '' DB 'dict_db_01225'))
+LIFETIME(MIN 0 MAX 0)
+LAYOUT(FLAT());
+
+SYSTEM RELOAD DICTIONARY dict_db_01225.dict;
+DROP TABLE dict_db_01225.dict; -- { serverError 60; }
+-- Regression:
+--     Code: 1000. DB::Exception: Received from localhost:9000. DB::Exception: File not found: ./metadata/dict_db_01225/dict.sql.
+DROP DICTIONARY dict_db_01225.dict;
+DROP DATABASE dict_db_01225;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not break DROP DICTIONARY with DROP TABLE (otherwise after this error you will not be able to remove database)