### PR TITLE
Revert resetting settings in TCPHandler

### DIFF
--- a/programs/server/TCPHandler.cpp
+++ b/programs/server/TCPHandler.cpp
@@ -147,10 +147,6 @@ void TCPHandler::runImpl()
         if (server.isCancelled() || in->eof())
             break;
 
-        /// receiveHello() has set the default settings for the current user,
-        /// but this default itself could change while we were waiting for a packet from the client.
-        connection_context.resetSettingsToDefault();
-
         /// Set context of request.
         query_context = connection_context;
 

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -907,7 +907,6 @@ void Context::setSettings(const Settings & settings_)
     auto old_allow_introspection_functions = settings.allow_introspection_functions;
 
     settings = settings_;
-    active_default_settings = nullptr;
 
     if ((settings.readonly != old_readonly) || (settings.allow_ddl != old_allow_ddl) || (settings.allow_introspection_functions != old_allow_introspection_functions))
         calculateAccessRights();
@@ -917,7 +916,6 @@ void Context::setSettings(const Settings & settings_)
 void Context::setSetting(const StringRef & name, const String & value)
 {
     auto lock = getLock();
-    active_default_settings = nullptr;
     if (name == "profile")
     {
         setProfile(value);
@@ -933,7 +931,6 @@ void Context::setSetting(const StringRef & name, const String & value)
 void Context::setSetting(const StringRef & name, const Field & value)
 {
     auto lock = getLock();
-    active_default_settings = nullptr;
     if (name == "profile")
     {
         setProfile(value.safeGet<String>());
@@ -957,20 +954,6 @@ void Context::applySettingsChanges(const SettingsChanges & changes)
     auto lock = getLock();
     for (const SettingChange & change : changes)
         applySettingChange(change);
-}
-
-
-void Context::resetSettingsToDefault()
-{
-    auto lock = getLock();
-    auto default_settings = getAccess()->getDefaultSettings();
-    if (default_settings && (default_settings == active_default_settings))
-        return;
-    if (default_settings)
-        setSettings(*default_settings);
-    else
-        setSettings(Settings{});
-    active_default_settings = default_settings;
 }
 
 

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -151,7 +151,6 @@ private:
     bool use_default_roles = false;
     std::shared_ptr<const ContextAccess> access;
     std::shared_ptr<const EnabledRowPolicies> initial_row_policy;
-    std::shared_ptr<const Settings> active_default_settings;
     String current_database;
     Settings settings;                                  /// Setting for query execution.
     using ProgressCallback = std::function<void(const Progress & progress)>;
@@ -345,9 +344,6 @@ public:
     void setSetting(const StringRef & name, const Field & value);
     void applySettingChange(const SettingChange & change);
     void applySettingsChanges(const SettingsChanges & changes);
-
-    /// Reset settings to the default values for the current user.
-    void resetSettingsToDefault();
 
     /// Checks the constraints.
     void checkSettingsConstraints(const SettingChange & change) const;

--- a/tests/integration/test_settings_constraints_distributed/test.py
+++ b/tests/integration/test_settings_constraints_distributed/test.py
@@ -10,10 +10,10 @@ cluster = ClickHouseCluster(__file__)
 
 node1 = cluster.add_instance('node1')
 node2 = cluster.add_instance('node2')
-distributed = cluster.add_instance('distributed', main_configs=["configs/remote_servers.xml"])
+distributed = cluster.add_instance('distributed', main_configs=["configs/remote_servers.xml"], stay_alive=True)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module", autouse=True)
 def started_cluster():
     try:
         cluster.start()
@@ -35,7 +35,15 @@ def started_cluster():
         cluster.shutdown()
 
 
-def test_select_clamps_settings(started_cluster):
+@pytest.fixture(autouse=True)
+def restart_distributed():
+    # Magic: Distributed table tries to keep connections to shards open, and after changing shards' default settings
+    # we need to reset connections to force the shards to reset sessions and therefore to reset current settings
+    # to their new defaults.
+    distributed.restart_clickhouse()
+
+
+def test_select_clamps_settings():
     distributed.query("CREATE USER normal DEFAULT ROLE admin SETTINGS max_memory_usage = 80000000")
     distributed.query("CREATE USER wasteful DEFAULT ROLE admin SETTINGS max_memory_usage = 2000000000")
     distributed.query("CREATE USER readonly DEFAULT ROLE admin SETTINGS readonly = 1")
@@ -89,7 +97,7 @@ def test_select_clamps_settings(started_cluster):
                                                                                                  'node2\tmax_memory_usage\t10000000000\n'\
                                                                                                  'node2\treadonly\t1\n'
 
-def test_insert_clamps_settings(started_cluster):
+def test_insert_clamps_settings():
     node1.query("ALTER USER shard SETTINGS max_memory_usage = 50000000 MIN 11111111 MAX 99999999")
     node2.query("ALTER USER shard SETTINGS max_memory_usage = 50000000 MIN 11111111 MAX 99999999")
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Bug Fix

Changelog entry:
Revert resetting the settings to their defaults after each query in TCPHandler. This PR reverts https://github.com/ClickHouse/ClickHouse/pull/9970
