### PR TITLE
Fix various small issues in interactive mode of clickhouse-client

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -82,16 +82,8 @@
 #endif
 
 /// http://en.wikipedia.org/wiki/ANSI_escape_code
-
-/// Similar codes \e[s, \e[u don't work in VT100 and Mosh.
-#define SAVE_CURSOR_POSITION "\033""7"
-#define RESTORE_CURSOR_POSITION "\033""8"
-
 #define CLEAR_TO_END_OF_LINE "\033[K"
 
-/// This codes are possibly not supported everywhere.
-#define DISABLE_LINE_WRAPPING "\033[?7l"
-#define ENABLE_LINE_WRAPPING "\033[?7h"
 
 namespace DB
 {
@@ -132,8 +124,6 @@ private:
     bool print_time_to_stderr = false;   /// Output execution time to stderr in batch mode.
     bool stdin_is_a_tty = false;         /// stdin is a terminal.
     bool stdout_is_a_tty = false;        /// stdout is a terminal.
-
-    uint16_t terminal_width = 0;         /// Terminal width is needed to render progress bar.
 
     std::unique_ptr<Connection> connection;    /// Connection to DB.
     String query_id;                     /// Current query_id.
@@ -1122,11 +1112,16 @@ private:
                 /// to avoid losing sync.
                 if (!cancelled)
                 {
-                    auto cancel_query = [&] {
+                    auto cancel_query = [&]
+                    {
                         connection->sendCancel();
                         cancelled = true;
                         if (is_interactive)
+                        {
+                            if (written_progress_chars)
+                                clearProgress();
                             std::cout << "Cancelling query." << std::endl;
+                        }
 
                         /// Pressing Ctrl+C twice results in shut down.
                         interrupt_listener.unblock();
@@ -1436,7 +1431,7 @@ private:
     {
         written_progress_chars = 0;
         if (!send_logs)
-            std::cerr << RESTORE_CURSOR_POSITION CLEAR_TO_END_OF_LINE;
+            std::cerr << "\r" CLEAR_TO_END_OF_LINE;
     }
 
 
@@ -1461,20 +1456,14 @@ private:
             "\033[1m↗\033[0m",
         };
 
-        if (!send_logs)
-        {
-            if (written_progress_chars)
-                message << RESTORE_CURSOR_POSITION CLEAR_TO_END_OF_LINE;
-            else
-                message << SAVE_CURSOR_POSITION;
-        }
+        auto indicator = indicators[increment % 8];
 
-        message << DISABLE_LINE_WRAPPING;
+        if (!send_logs && written_progress_chars)
+            message << '\r';
 
         size_t prefix_size = message.count();
 
-        message << indicators[increment % 8]
-            << " Progress: ";
+        message << indicator << " Progress: ";
 
         message
             << formatReadableQuantity(progress.read_rows) << " rows, "
@@ -1488,7 +1477,7 @@ private:
         else
             message << ". ";
 
-        written_progress_chars = message.count() - prefix_size - (increment % 8 == 7 ? 10 : 13);    /// Don't count invisible output (escape sequences).
+        written_progress_chars = message.count() - prefix_size - (strlen(indicator) - 2); /// Don't count invisible output (escape sequences).
 
         /// If the approximate number of rows to process is known, we can display a progress bar and percentage.
         if (progress.total_rows_to_read > 0)
@@ -1506,7 +1495,7 @@ private:
 
                 if (show_progress_bar)
                 {
-                    ssize_t width_of_progress_bar = static_cast<ssize_t>(terminal_width) - written_progress_chars - strlen(" 99%");
+                    ssize_t width_of_progress_bar = static_cast<ssize_t>(getTerminalWidth()) - written_progress_chars - strlen(" 99%");
                     if (width_of_progress_bar > 0)
                     {
                         std::string bar = UnicodeBar::render(UnicodeBar::getWidth(progress.read_rows, 0, total_rows_corrected, width_of_progress_bar));
@@ -1521,7 +1510,8 @@ private:
             message << ' ' << (99 * progress.read_rows / total_rows_corrected) << '%';
         }
 
-        message << ENABLE_LINE_WRAPPING;
+        message << CLEAR_TO_END_OF_LINE;
+
         if (send_logs)
             message << '\n';
 
@@ -1589,7 +1579,11 @@ private:
         resetOutput();
 
         if (is_interactive && !written_first_block)
+        {
+            if (written_progress_chars)
+                clearProgress();
             std::cout << "Ok." << std::endl;
+        }
     }
 
     static void showClientVersion()
@@ -1687,6 +1681,7 @@ public:
         stdin_is_a_tty = isatty(STDIN_FILENO);
         stdout_is_a_tty = isatty(STDOUT_FILENO);
 
+        uint64_t terminal_width = 0;
         if (stdin_is_a_tty)
             terminal_width = getTerminalWidth();
 


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
`clickhouse-client` works correctly in Kitty terminal in interactive mode. This fixes #10189. The width of progress bar is determined correctly after the terminal was resized. This fixes #5908.
