### PR TITLE
MySQLHandler: max_allowed_packet returned by default

### DIFF
--- a/programs/server/MySQLHandler.cpp
+++ b/programs/server/MySQLHandler.cpp
@@ -284,15 +284,17 @@ void MySQLHandler::comQuery(ReadBuffer & payload)
     }
     else
     {
-        String replacement_query = "select ''";
+        String replacement_query = "SELECT ''";
         bool should_replace = false;
         bool with_output = false;
 
         // Translate query from MySQL to ClickHouse.
-        // This is a temporary workaround until ClickHouse supports the syntax "@@var_name".
+        // Required parameters when setup:
+        // * max_allowed_packet, default 64MB, https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_allowed_packet
         if (isFederatedServerSetupSelectVarCommand(query))
         {
             should_replace = true;
+            replacement_query = "SELECT 67108864 AS max_allowed_packet";
         }
 
         // This is a workaround in order to support adding ClickHouse to MySQL using federated server.

--- a/tests/integration/test_mysql_protocol/clients/java/0.reference
+++ b/tests/integration/test_mysql_protocol/clients/java/0.reference
@@ -1,5 +1,5 @@
-33jdbc
-44ck
+33jdbcnull
+44cknull
 0
 1
 2

--- a/tests/integration/test_mysql_protocol/clients/java/Test.java
+++ b/tests/integration/test_mysql_protocol/clients/java/Test.java
@@ -5,8 +5,8 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 class JavaConnectorTest {
-    private static final String CREATE_TABLE_SQL = "CREATE TABLE IF NOT EXISTS default.test1 (age Int32, name String) Engine = Memory";
-    private static final String INSERT_SQL = "INSERT INTO default.test1 VALUES(33, 'jdbc'),(44, 'ck')";
+    private static final String CREATE_TABLE_SQL = "CREATE TABLE IF NOT EXISTS default.test1 (`age` Int32, `name` String, `int_nullable` Nullable(Int32)) Engine = Memory";
+    private static final String INSERT_SQL = "INSERT INTO default.test1(`age`, `name`) VALUES(33, 'jdbc'),(44, 'ck')";
     private static final String SELECT_SQL = "SELECT * FROM default.test1";
     private static final String SELECT_NUMBER_SQL = "SELECT * FROM system.numbers LIMIT 13";
     private static final String DROP_TABLE_SQL = "DROP TABLE default.test1";
@@ -41,7 +41,7 @@ class JavaConnectorTest {
             }
         }
 
-        String jdbcUrl = String.format("jdbc:mysql://%s:%s/%s?maxAllowedPacket=67108864&useSSL=false", host, port, database);
+        String jdbcUrl = String.format("jdbc:mysql://%s:%s/%s", host, port, database);
 
         Connection conn = null;
         Statement stmt = null;
@@ -55,6 +55,7 @@ class JavaConnectorTest {
             while (rs.next()) {
                 System.out.print(rs.getString("age"));
                 System.out.print(rs.getString("name"));
+                System.out.print(rs.getString("int_nullable"));
                 System.out.println();
             }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Provide `max_allowed_packed` in MySQL compatibility interface that will help some clients to communicate with ClickHouse via MySQL protocol.

...

Detailed description / Documentation draft:
Some variables need to be negotiated between the server-side and the client/driver-side.
When the client/driver requests 'select @@max_allowed_packet ...' to the server, if we return null(SELECT '' by MySQLHandler.cpp), the handshake will be broken.
We can manually add maxAllowedPacket(JDBC style) to the client/driver to solve it, but it's not a better way.
This patch returns max_allowed_packet to client/driver by default, so that the client/driver doesn't have to do any manual configuration.

Tests:
Integration/test_mysql_protocol all PASSED.
