### PR TITLE
Fix typo in the getting started tutorial: "it's" -> "its"

### DIFF
--- a/docs/en/getting_started/tutorial.md
+++ b/docs/en/getting_started/tutorial.md
@@ -108,7 +108,7 @@ Syntax for creating tables is way more complicated compared to databases (see [r
 
 1.  Name of table to create.
 2.  Table schema, i.e. list of columns and their [data types](../sql_reference/data_types/index.md).
-3.  [Table engine](../engines/table_engines/index.md) and it’s settings, which determines all the details on how queries to this table will be physically executed.
+3.  [Table engine](../engines/table_engines/index.md) and its settings, which determines all the details on how queries to this table will be physically executed.
 
 Yandex.Metrica is a web analytics service, and sample dataset doesn’t cover its full functionality, so there are only two tables to create:
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)

Detailed description / Documentation draft:

```diff
- Table engine and it's settings
+ Table engine and its settings
```
