### PR TITLE
Print verbose diagnostic info if Decimal value cannot be parsed.

### DIFF
--- a/src/Processors/Formats/IRowInputFormat.cpp
+++ b/src/Processors/Formats/IRowInputFormat.cpp
@@ -18,6 +18,7 @@ namespace ErrorCodes
     extern const int CANNOT_PARSE_UUID;
     extern const int TOO_LARGE_STRING_SIZE;
     extern const int INCORRECT_NUMBER_OF_COLUMNS;
+    extern const int ARGUMENT_OUT_OF_BOUND;
 }
 
 
@@ -30,7 +31,8 @@ bool isParseError(int code)
         || code == ErrorCodes::CANNOT_READ_ARRAY_FROM_TEXT
         || code == ErrorCodes::CANNOT_PARSE_NUMBER
         || code == ErrorCodes::CANNOT_PARSE_UUID
-        || code == ErrorCodes::TOO_LARGE_STRING_SIZE;
+        || code == ErrorCodes::TOO_LARGE_STRING_SIZE
+        || code == ErrorCodes::ARGUMENT_OUT_OF_BOUND;
 }
 
 

--- a/tests/queries/0_stateless/01119_decimal_parse_verbose_diagnostics.reference
+++ b/tests/queries/0_stateless/01119_decimal_parse_verbose_diagnostics.reference
@@ -1,0 +1,8 @@
+Code: 69, e.displayText() = DB::Exception: Decimal value is too big: (at row 2)
+
+Row 1:
+Column 0,   name: d, type: Decimal(18, 10), parsed text: "12345678"
+
+Row 2:
+Column 0,   name: d, type: Decimal(18, 10), parsed text: <EMPTY>ERROR
+

--- a/tests/queries/0_stateless/01119_decimal_parse_verbose_diagnostics.reference
+++ b/tests/queries/0_stateless/01119_decimal_parse_verbose_diagnostics.reference
@@ -1,4 +1,4 @@
-Code: 69, e.displayText() = DB::Exception: Decimal value is too big: (at row 2)
+Code: 69, e.displayText() = DB::: Decimal value is too big: (at row 2)
 
 Row 1:
 Column 0,   name: d, type: Decimal(18, 10), parsed text: "12345678"

--- a/tests/queries/0_stateless/01119_decimal_parse_verbose_diagnostics.sh
+++ b/tests/queries/0_stateless/01119_decimal_parse_verbose_diagnostics.sh
@@ -3,4 +3,4 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . $CURDIR/../shell_config.sh
 
-$CLICKHOUSE_LOCAL --query "SELECT * FROM table" --input-format CSV --structure 'd Decimal64(10)' <<<'12345678'$'\n''123456789' 2>&1 | grep -v -F 'version'
+$CLICKHOUSE_LOCAL --query "SELECT * FROM table" --input-format CSV --structure 'd Decimal64(10)' <<<'12345678'$'\n''123456789' 2>&1 | grep -v -F 'version' | sed 's/Exception//';

--- a/tests/queries/0_stateless/01119_decimal_parse_verbose_diagnostics.sh
+++ b/tests/queries/0_stateless/01119_decimal_parse_verbose_diagnostics.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. $CURDIR/../shell_config.sh
+
+$CLICKHOUSE_LOCAL --query "SELECT * FROM table" --input-format CSV --structure 'd Decimal64(10)' <<<'12345678'$'\n''123456789' 2>&1 | grep -v -F 'version'


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Print verbose diagnostic info if Decimal value cannot be parsed from text input format.
