### PR TITLE
Fix 'Cannot add column' in DDL dictionary

### DIFF
--- a/src/Storages/StorageDictionary.cpp
+++ b/src/Storages/StorageDictionary.cpp
@@ -75,16 +75,30 @@ NamesAndTypesList StorageDictionary::getNamesAndTypes(const DictionaryStructure 
 
     if (dictionary_structure.id)
         dictionary_names_and_types.emplace_back(dictionary_structure.id->name, std::make_shared<DataTypeUInt64>());
+
+    /// In old-style (XML) configuration we don't have this attributes in the
+    /// main attribute list, so we have to add them to columns list explicitly.
+    /// In the new configuration (DDL) we have them both in range_* nodes and
+    /// main attribute list, but for compatibility we add them before main
+    /// attributes list.
     if (dictionary_structure.range_min)
         dictionary_names_and_types.emplace_back(dictionary_structure.range_min->name, dictionary_structure.range_min->type);
+
     if (dictionary_structure.range_max)
         dictionary_names_and_types.emplace_back(dictionary_structure.range_max->name, dictionary_structure.range_max->type);
+
     if (dictionary_structure.key)
+    {
         for (const auto & attribute : *dictionary_structure.key)
             dictionary_names_and_types.emplace_back(attribute.name, attribute.type);
+    }
 
     for (const auto & attribute : dictionary_structure.attributes)
-        dictionary_names_and_types.emplace_back(attribute.name, attribute.type);
+    {
+        /// Some attributes can be already added (range_min and range_max)
+        if (!dictionary_names_and_types.contains(attribute.name))
+            dictionary_names_and_types.emplace_back(attribute.name, attribute.type);
+    }
 
     return dictionary_names_and_types;
 }

--- a/tests/queries/0_stateless/01125_dict_ddl_cannot_add_column.reference
+++ b/tests/queries/0_stateless/01125_dict_ddl_cannot_add_column.reference
@@ -1,0 +1,3 @@
+1	2019-01-05	2020-01-10	1
+date_table
+somedict

--- a/tests/queries/0_stateless/01125_dict_ddl_cannot_add_column.sql
+++ b/tests/queries/0_stateless/01125_dict_ddl_cannot_add_column.sql
@@ -1,0 +1,34 @@
+DROP DATABASE IF EXISTS database_for_dict;
+
+CREATE DATABASE database_for_dict;
+
+use database_for_dict;
+
+CREATE TABLE date_table
+(
+  id UInt32,
+  val String,
+  start Date,
+  end Date
+) Engine = Memory();
+
+INSERT INTO date_table VALUES(1, '1', toDate('2019-01-05'), toDate('2020-01-10'));
+
+CREATE DICTIONARY somedict
+(
+  id UInt32,
+  val String,
+  start Date,
+  end Date
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(HOST 'localhost' PORT 9000 USER 'default' TABLE 'date_table' DB 'database_for_dict'))
+LAYOUT(RANGE_HASHED())
+RANGE (MIN start MAX end)
+LIFETIME(MIN 300 MAX 360);
+
+SELECT * from somedict;
+
+SHOW TABLES;
+
+DROP DATABASE IF EXISTS database_for_dict;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `'Cannot add column'` error while creating `range_hashed` dictionary using DDL query. Fixes #10093.
