### PR TITLE
ALTER UPDATE/DELETE on Replicated* storages: Fixed "Unknown function lambda." error

### DIFF
--- a/src/Interpreters/MutationsInterpreter.cpp
+++ b/src/Interpreters/MutationsInterpreter.cpp
@@ -59,9 +59,8 @@ public:
 
         if (const auto * function = typeid_cast<const ASTFunction *>(node.get()))
         {
-            /// Lambda functions also may be non-deterministic. But we skip them for simplicity.
-            /// Replication will work correctly even if non-deterministic function is used, 
-            ///  it will select any of the results and discard other.
+            /// Property of being deterministic for lambda expression is completely determined
+            /// by the contents of its definition, so we just proceed to it.
             if (function->name != "lambda")
             {
                 const auto func = FunctionFactory::instance().get(function->name, data.context);
@@ -76,7 +75,7 @@ using FirstNonDeterministicFuncFinder = InDepthNodeVisitor<FirstNonDeterministic
 
 std::optional<String> findFirstNonDeterministicFuncName(const MutationCommand & command, const Context & context)
 {
-    FirstNonDeterministicFuncMatcher::Data finder_data{context};
+    FirstNonDeterministicFuncMatcher::Data finder_data{context, std::nullopt};
 
     switch (command.type)
     {

--- a/src/Interpreters/MutationsInterpreter.cpp
+++ b/src/Interpreters/MutationsInterpreter.cpp
@@ -59,6 +59,9 @@ public:
 
         if (const auto * function = typeid_cast<const ASTFunction *>(node.get()))
         {
+            /// Lambda functions also may be non-deterministic. But we skip them for simplicity.
+            /// Replication will work correctly even if non-deterministic function is used, 
+            ///  it will select any of the results and discard other.
             if (function->name != "lambda")
             {
                 const auto func = FunctionFactory::instance().get(function->name, data.context);

--- a/src/Interpreters/MutationsInterpreter.cpp
+++ b/src/Interpreters/MutationsInterpreter.cpp
@@ -40,7 +40,8 @@ namespace
 class FirstNonDeterministicFuncMatcher
 {
 public:
-    struct Data {
+    struct Data
+    {
         const Context & context;
         std::optional<String> nondeterministic_function_name;
     };
@@ -68,8 +69,7 @@ public:
     }
 };
 
-using FirstNonDeterministicFuncFinder =
-        InDepthNodeVisitor<FirstNonDeterministicFuncMatcher, true>;
+using FirstNonDeterministicFuncFinder = InDepthNodeVisitor<FirstNonDeterministicFuncMatcher, true>;
 
 std::optional<String> findFirstNonDeterministicFuncName(const MutationCommand & command, const Context & context)
 {

--- a/tests/queries/0_stateless/01017_mutations_with_nondeterministic_functions_zookeeper.reference
+++ b/tests/queries/0_stateless/01017_mutations_with_nondeterministic_functions_zookeeper.reference
@@ -5,3 +5,5 @@ OK
 OK
 OK
 OK
+OK
+OK

--- a/tests/queries/0_stateless/01017_mutations_with_nondeterministic_functions_zookeeper.sh
+++ b/tests/queries/0_stateless/01017_mutations_with_nondeterministic_functions_zookeeper.sh
@@ -43,6 +43,12 @@ ${CLICKHOUSE_CLIENT} --query "ALTER TABLE $R1 DELETE WHERE ignore(rand())" 2>&1 
 ${CLICKHOUSE_CLIENT} --query "ALTER TABLE $R1 UPDATE y = y + rand() % 1 WHERE not ignore()" 2>&1 \
 | fgrep -q "must use only deterministic functions" && echo 'OK' || echo 'FAIL'
 
+${CLICKHOUSE_CLIENT} --query "ALTER TABLE $R1 UPDATE y = x + arrayCount(x -> (x + y) % 2, range(y)) WHERE not ignore()" 2>&1 > /dev/null \
+&& echo 'OK' || echo 'FAIL'
+
+${CLICKHOUSE_CLIENT} --query "ALTER TABLE $R1 UPDATE y = x + arrayCount(x -> (rand() + x) % 2, range(y)) WHERE not ignore()" 2>&1 \
+| fgrep -q "must use only deterministic functions" && echo 'OK' || echo 'FAIL'
+
 
 # For regular tables we do not enforce deterministic functions
 ${CLICKHOUSE_CLIENT} --query "ALTER TABLE $T1 DELETE WHERE rand() = 0" 2>&1 > /dev/null \


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed bug where ClickHouse would throw "Unknown function lambda." error message when user tries to run ALTER UPDATE/DELETE on tables with ENGINE =  Replicated*. Check for nondeterministic functions now handles lambda expressions correctly.


This fixes #8109