### PR TITLE
Fix race after cancel of RemoteBlockInputStream.

### DIFF
--- a/src/DataStreams/RemoteBlockInputStream.h
+++ b/src/DataStreams/RemoteBlockInputStream.h
@@ -135,7 +135,8 @@ private:
       * - data size is already satisfactory (when using LIMIT, for example)
       * - an exception was thrown from client side
       */
-    std::atomic<bool> was_cancelled { false };
+    bool was_cancelled { false };
+    std::mutex was_cancelled_mutex;
 
     /** An exception from replica was received. No need in receiving more packets or
       * requesting to cancel query execution


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix rare possible exception `Cannot drain connections: cancel first`.

Race in `RemoteBlockInputStream::tryCancel`. It was possible that first thread changed value of `was_cancelled`, but didn't call `multiplexed_connections->sendCancel()` yet. And at this moment the second thread calls `readSuffix`, read `was_cancelled` and drain connection before `sendCancel()` was actually called.

https://clickhouse-test-reports.s3.yandex.net/0/d1c436788b5292b2348480acbb1432ddeaf3cfaa/functional_stateful_tests_(address)/clickhouse-server.log