### PR TITLE
Fix and improve OneTypeMatcher

### DIFF
--- a/src/Interpreters/CrossToInnerJoinVisitor.cpp
+++ b/src/Interpreters/CrossToInnerJoinVisitor.cpp
@@ -214,7 +214,7 @@ private:
     }
 };
 
-using CheckExpressionMatcher = ConstOneTypeMatcher<CheckExpressionVisitorData, false>;
+using CheckExpressionMatcher = ConstOneTypeMatcher<CheckExpressionVisitorData, NeedChild::none>;
 using CheckExpressionVisitor = ConstInDepthNodeVisitor<CheckExpressionMatcher, true>;
 
 

--- a/src/Interpreters/InDepthNodeVisitor.h
+++ b/src/Interpreters/InDepthNodeVisitor.h
@@ -53,14 +53,14 @@ using ConstInDepthNodeVisitor = InDepthNodeVisitor<Matcher, top_to_bottom, const
 
 struct NeedChild
 {
-    typedef bool (*Function)(const ASTPtr & node, const ASTPtr & child);
+    using Condition = bool (*)(const ASTPtr & node, const ASTPtr & child);
 
     static bool all(const ASTPtr &, const ASTPtr &) { return true; }
     static bool none(const ASTPtr &, const ASTPtr &) { return false; }
 };
 
 /// Simple matcher for one node type. Use need_child function for complex traversal logic.
-template <typename Data_, NeedChild::Function need_child = NeedChild::all, typename T = ASTPtr>
+template <typename Data_, NeedChild::Condition need_child = NeedChild::all, typename T = ASTPtr>
 class OneTypeMatcher
 {
 public:
@@ -76,7 +76,7 @@ public:
     }
 };
 
-template <typename Data, NeedChild::Function need_child = NeedChild::all>
+template <typename Data, NeedChild::Condition need_child = NeedChild::all>
 using ConstOneTypeMatcher = OneTypeMatcher<Data, need_child, const ASTPtr>;
 
 }

--- a/src/Interpreters/InDepthNodeVisitor.h
+++ b/src/Interpreters/InDepthNodeVisitor.h
@@ -51,21 +51,23 @@ private:
 template <typename Matcher, bool top_to_bottom>
 using ConstInDepthNodeVisitor = InDepthNodeVisitor<Matcher, top_to_bottom, const ASTPtr>;
 
-/// Simple matcher for one node type without complex traversal logic.
-template <typename Data_, bool visit_children = true, typename T = ASTPtr>
+struct NeedChild
+{
+    typedef bool (*Function)(const ASTPtr & node, const ASTPtr & child);
+
+    static bool all(const ASTPtr &, const ASTPtr &) { return true; }
+    static bool none(const ASTPtr &, const ASTPtr &) { return false; }
+};
+
+/// Simple matcher for one node type. Use need_child function for complex traversal logic.
+template <typename Data_, NeedChild::Function need_child = NeedChild::all, typename T = ASTPtr>
 class OneTypeMatcher
 {
 public:
     using Data = Data_;
     using TypeToVisit = typename Data::TypeToVisit;
 
-    static bool needChildVisit(const ASTPtr & node, const ASTPtr &)
-    {
-        if (node && node->as<TypeToVisit>())
-            return visit_children;
-
-        return true;
-    }
+    static bool needChildVisit(const ASTPtr & node, const ASTPtr & child) { return need_child(node, child); }
 
     static void visit(T & ast, Data & data)
     {
@@ -74,7 +76,7 @@ public:
     }
 };
 
-template <typename Data, bool visit_children = true>
-using ConstOneTypeMatcher = OneTypeMatcher<Data, visit_children, const ASTPtr>;
+template <typename Data, NeedChild::Function need_child = NeedChild::all>
+using ConstOneTypeMatcher = OneTypeMatcher<Data, need_child, const ASTPtr>;
 
 }

--- a/src/Interpreters/PredicateRewriteVisitor.h
+++ b/src/Interpreters/PredicateRewriteVisitor.h
@@ -16,6 +16,14 @@ public:
 
     void visit(ASTSelectWithUnionQuery & union_select_query, ASTPtr &);
 
+    static bool needChild(const ASTPtr & node, const ASTPtr &)
+    {
+        if (node && node->as<TypeToVisit>())
+            return false;
+
+        return true;
+    }
+
     PredicateRewriteVisitorData(const Context & context_, const ASTs & predicates_, const Names & column_names_, bool optimize_final_);
 
 private:
@@ -31,6 +39,6 @@ private:
     bool rewriteSubquery(ASTSelectQuery & subquery, const Names & outer_columns, const Names & inner_columns);
 };
 
-using PredicateRewriteMatcher = OneTypeMatcher<PredicateRewriteVisitorData, false>;
+using PredicateRewriteMatcher = OneTypeMatcher<PredicateRewriteVisitorData, PredicateRewriteVisitorData::needChild>;
 using PredicateRewriteVisitor = InDepthNodeVisitor<PredicateRewriteMatcher, true>;
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Non-significant (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Undo dangerous change in OneTypeMatcher.
