### PR TITLE
Allow to parse +inf

### DIFF
--- a/tests/queries/0_stateless/01198_plus_inf.reference
+++ b/tests/queries/0_stateless/01198_plus_inf.reference
@@ -1,0 +1,3 @@
+inf
+-inf
+inf

--- a/tests/queries/0_stateless/01198_plus_inf.sql
+++ b/tests/queries/0_stateless/01198_plus_inf.sql
@@ -1,0 +1,3 @@
+SELECT DISTINCT toFloat64(arrayJoin(['+inf', '+Inf', '+INF', '+infinity', '+Infinity']));
+SELECT DISTINCT toFloat64(arrayJoin(['-inf', '-Inf', '-INF', '-infinity', '-Infinity']));
+SELECT DISTINCT toFloat64(arrayJoin(['inf', 'Inf', 'INF', 'infinity', 'Infinity']));


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow to parse `+inf` for floating point types. This closes #1839
