### PR TITLE
Avoid error message on RST

### DIFF
--- a/programs/server/TCPHandlerFactory.h
+++ b/programs/server/TCPHandlerFactory.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Poco/Net/TCPServerConnectionFactory.h>
+#include <Poco/Net/NetException.h>
 #include <common/logger_useful.h>
 #include "IServer.h"
 #include "TCPHandler.h"
@@ -16,6 +17,13 @@ private:
     IServer & server;
     Poco::Logger * log;
 
+    class DummyTCPHandler : public Poco::Net::TCPServerConnection
+    {
+    public:
+        using Poco::Net::TCPServerConnection::TCPServerConnection;
+        void run() override {}
+    };
+
 public:
     explicit TCPHandlerFactory(IServer & server_, bool secure_ = false)
         : server(server_)
@@ -25,12 +33,16 @@ public:
 
     Poco::Net::TCPServerConnection * createConnection(const Poco::Net::StreamSocket & socket) override
     {
-        LOG_TRACE(log,
-            "TCP Request. "
-                << "Address: "
-                << socket.peerAddress().toString());
-
-        return new TCPHandler(server, socket);
+        try
+        {
+            LOG_TRACE(log, "TCP Request. Address: " << socket.peerAddress().toString());
+            return new TCPHandler(server, socket);
+        }
+        catch (const Poco::Net::NetException & e)
+        {
+            LOG_TRACE(log, "TCP Request. Client is not connected (most likely RST packet was sent).");
+            return new DummyTCPHandler(socket);
+        }
     }
 };
 


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Avoid printing error message in log if client sends RST packet immediately on connect. It is typical behaviour of IPVS balancer with keepalived and VRRP. This fixes #1851
