### PR TITLE
Use background thread pool for background buffer flushes

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -78,6 +78,7 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingBool, extremes, false, "Calculate minimums and maximums of the result columns. They can be output in JSON-formats.", IMPORTANT) \
     M(SettingBool, use_uncompressed_cache, true, "Whether to use the cache of uncompressed blocks.", 0) \
     M(SettingBool, replace_running_query, false, "Whether the running request should be canceled with the same id as the new one.", 0) \
+    M(SettingUInt64, background_buffer_flush_schedule_pool_size, 16, "Number of threads performing background flush for tables with Buffer engine. Only has meaning at server startup.", 0) \
     M(SettingUInt64, background_pool_size, 16, "Number of threads performing background work for tables (for example, merging in merge tree). Only has meaning at server startup.", 0) \
     M(SettingUInt64, background_move_pool_size, 8, "Number of threads performing background moves for tables. Only has meaning at server startup.", 0) \
     M(SettingUInt64, background_schedule_pool_size, 16, "Number of threads performing background tasks for replicated tables. Only has meaning at server startup.", 0) \

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -468,6 +468,7 @@ public:
       */
     void dropCaches() const;
 
+    BackgroundSchedulePool & getBufferFlushSchedulePool();
     BackgroundProcessingPool & getBackgroundPool();
     BackgroundProcessingPool & getBackgroundMovePool();
     BackgroundSchedulePool & getSchedulePool();

--- a/src/Storages/StorageBuffer.h
+++ b/src/Storages/StorageBuffer.h
@@ -4,7 +4,7 @@
 #include <thread>
 #include <ext/shared_ptr_helper.h>
 #include <Core/NamesAndTypes.h>
-#include <Common/ThreadPool.h>
+#include <Core/BackgroundSchedulePool.h>
 #include <Storages/IStorage.h>
 #include <DataStreams/IBlockOutputStream.h>
 #include <Poco/Event.h>
@@ -118,10 +118,6 @@ private:
 
     Poco::Logger * log;
 
-    Poco::Event shutdown_event;
-    /// Resets data by timeout.
-    ThreadFromGlobalPool flush_thread;
-
     void flushAllBuffers(bool check_thresholds = true);
     /// Reset the buffer. If check_thresholds is set - resets only if thresholds are exceeded.
     void flushBuffer(Buffer & buffer, bool check_thresholds, bool locked = false);
@@ -131,7 +127,11 @@ private:
     /// `table` argument is passed, as it is sometimes evaluated beforehand. It must match the `destination`.
     void writeBlockToDestination(const Block & block, StoragePtr table);
 
-    void flushThread();
+    void flushBack();
+    void reschedule();
+
+    BackgroundSchedulePool & bg_pool;
+    BackgroundSchedulePoolTaskHolder flush_handle;
 
 protected:
     /** num_shards - the level of internal parallelism (the number of independent buffers)

--- a/tests/queries/0_stateless/01246_buffer_flush.reference
+++ b/tests/queries/0_stateless/01246_buffer_flush.reference
@@ -1,0 +1,10 @@
+min
+0
+5
+max
+5
+10
+direct
+20
+drop
+30

--- a/tests/queries/0_stateless/01246_buffer_flush.sql
+++ b/tests/queries/0_stateless/01246_buffer_flush.sql
@@ -1,0 +1,44 @@
+drop table if exists data_01256;
+drop table if exists buffer_01256;
+
+create table data_01256 as system.numbers Engine=Memory();
+
+select 'min';
+create table buffer_01256 as system.numbers Engine=Buffer(currentDatabase(), data_01256, 1,
+    2, 100, /* time */
+    4, 100, /* rows */
+    1, 1e6  /* bytes */
+);
+insert into buffer_01256 select * from system.numbers limit 5;
+select count() from data_01256;
+-- sleep 2 (min time) + 1 (round up) + bias (1) = 4
+select sleepEachRow(2) from numbers(2) FORMAT Null;
+select count() from data_01256;
+drop table buffer_01256;
+
+select 'max';
+create table buffer_01256 as system.numbers Engine=Buffer(currentDatabase(), data_01256, 1,
+    100, 2,   /* time */
+    0,   100, /* rows */
+    0,   1e6  /* bytes */
+);
+insert into buffer_01256 select * from system.numbers limit 5;
+select count() from data_01256;
+-- sleep 2 (min time) + 1 (round up) + bias (1) = 4
+select sleepEachRow(2) from numbers(2) FORMAT Null;
+select count() from data_01256;
+drop table buffer_01256;
+
+select 'direct';
+create table buffer_01256 as system.numbers Engine=Buffer(currentDatabase(), data_01256, 1,
+    100, 100, /* time */
+    0,   9,   /* rows */
+    0,   1e6  /* bytes */
+);
+insert into buffer_01256 select * from system.numbers limit 10;
+select count() from data_01256;
+
+select 'drop';
+insert into buffer_01256 select * from system.numbers limit 10;
+drop table if exists buffer_01256;
+select count() from data_01256;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use background thread pool for background buffer flushes (this will allow to avoid occupation threads when there are no insert's)

Refs: https://github.com/ClickHouse/ClickHouse/issues/6833#issuecomment-581659162 (does this resolves this issue after other fixes and this one?)

P.S. I placed some code (settings and changes in context) a little bit "non grouped" to avoid conflicts with #10263 