### PR TITLE
Convert test results to JSONEachRow format

### DIFF
--- a/tests/integration/pytest.ini
+++ b/tests/integration/pytest.ini
@@ -3,3 +3,4 @@ python_files = test*.py
 norecursedirs = _instances
 timeout = 300
 junit_duration_report = call
+junit_suite_name = integration

--- a/utils/junit_to_html/junit_to_html
+++ b/utils/junit_to_html/junit_to_html
@@ -3,22 +3,62 @@
 import os
 import sys
 import lxml.etree as etree
+import json
 
-def _convert_junit_to_html(junit_path, html_path):
+def export_testcases_json(report, path):
+    with open(os.path.join(path, "cases.jer"), "w") as testcases_file:
+        for testsuite in report.getroot():
+            for testcase in testsuite:
+                row = {}
+                row["hostname"] = testsuite.get("hostname")
+                row["hostname"] = testsuite.get("hostname")
+                row["timestamp"] = testsuite.get("timestamp")
+                row["testname"] = testcase.get("name")
+                row["classname"] = testcase.get("classname")
+                row["file"] = testcase.get("file")
+                row["line"] = testcase.get("line")
+                row["duration"] = testcase.get("time")
+                for el in testcase:
+                    if el.tag == "system-err":
+                        row["stderr"] = el.text
+                    if el.tag == "system-out":
+                        row["stdout"] = el.text
+                json.dump(row, testcases_file)
+
+def export_testsuites_json(report, path):
+    with open(os.path.join(path, "suites.jer"), "w") as testsuites_file:
+        for testsuite in report.getroot():
+            row = {}
+            row["name"] = testsuite.get("name")
+            row["errors"] = testsuite.get("errors")
+            row["failures"] = testsuite.get("failures")
+            row["hostname"] = testsuite.get("hostname")
+            row["skipped"] = testsuite.get("skipped")
+            row["duration"] = testsuite.get("time")
+            row["timestamp"] = testsuite.get("timestamp")
+            json.dump(row, testsuites_file)
+
+
+def _convert_junit_to_html(junit_path, result_path):
     with open(os.path.join(os.path.dirname(__file__), "junit-noframes.xsl")) as xslt_file:
         junit_to_html_xslt = etree.parse(xslt_file)
+        if not os.path.exists(result_path):
+            os.makedirs(result_path)
+
         with open(junit_path) as junit_file:
             junit_xml = etree.parse(junit_file)
+
+            export_testsuites_json(junit_xml, result_path)
+            export_testcases_json(junit_xml, result_path)
             transform = etree.XSLT(junit_to_html_xslt)
             html = etree.tostring(transform(junit_xml), encoding="utf-8")
-            html_dir = os.path.dirname(html_path)
-            if not os.path.exists(html_dir):
-                os.makedirs(html_dir)
-            with open(html_path, "w") as html_file:
+
+            with open(os.path.join(result_path, "result.html"), "w") as html_file:
                 html_file.write(html)
 
 if __name__ == "__main__":
     if len(sys.argv) < 3:
-        raise "Insufficient arguments: junit.xml result.html", level
-    junit_path, html_path = sys.argv[1] , sys.argv[2]
-    _convert_junit_to_html(junit_path, html_path)
+        raise "Insufficient arguments: junit.xml result_path ", level
+    junit_path, result_path = sys.argv[1] , sys.argv[2]
+    print "junit_path: {}, result_path: {}".format(junit_path, result_path)
+    _convert_junit_to_html(junit_path, result_path)

--- a/utils/junit_to_html/junit_to_html
+++ b/utils/junit_to_html/junit_to_html
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import os
-import sys
 import lxml.etree as etree
 import json
+import argparse
 
 def export_testcases_json(report, path):
     with open(os.path.join(path, "cases.jer"), "w") as testcases_file:
@@ -11,7 +11,8 @@ def export_testcases_json(report, path):
             for testcase in testsuite:
                 row = {}
                 row["hostname"] = testsuite.get("hostname")
-                row["hostname"] = testsuite.get("hostname")
+                row["suite"] = testsuite.get("name")
+                row["suite_duration"] = testsuite.get("time")
                 row["timestamp"] = testsuite.get("timestamp")
                 row["testname"] = testcase.get("name")
                 row["classname"] = testcase.get("classname")
@@ -24,12 +25,13 @@ def export_testcases_json(report, path):
                     if el.tag == "system-out":
                         row["stdout"] = el.text
                 json.dump(row, testcases_file)
+                testcases_file.write("\n")
 
 def export_testsuites_json(report, path):
     with open(os.path.join(path, "suites.jer"), "w") as testsuites_file:
         for testsuite in report.getroot():
             row = {}
-            row["name"] = testsuite.get("name")
+            row["suite"] = testsuite.get("name")
             row["errors"] = testsuite.get("errors")
             row["failures"] = testsuite.get("failures")
             row["hostname"] = testsuite.get("hostname")
@@ -37,9 +39,10 @@ def export_testsuites_json(report, path):
             row["duration"] = testsuite.get("time")
             row["timestamp"] = testsuite.get("timestamp")
             json.dump(row, testsuites_file)
+            testsuites_file.write("\n")
 
 
-def _convert_junit_to_html(junit_path, result_path):
+def _convert_junit_to_html(junit_path, result_path, export_cases, export_suites):
     with open(os.path.join(os.path.dirname(__file__), "junit-noframes.xsl")) as xslt_file:
         junit_to_html_xslt = etree.parse(xslt_file)
         if not os.path.exists(result_path):
@@ -48,8 +51,10 @@ def _convert_junit_to_html(junit_path, result_path):
         with open(junit_path) as junit_file:
             junit_xml = etree.parse(junit_file)
 
-            export_testsuites_json(junit_xml, result_path)
-            export_testcases_json(junit_xml, result_path)
+            if export_suites:
+                export_testsuites_json(junit_xml, result_path)
+            if export_cases:
+                export_testcases_json(junit_xml, result_path)
             transform = etree.XSLT(junit_to_html_xslt)
             html = etree.tostring(transform(junit_xml), encoding="utf-8")
 
@@ -57,8 +62,19 @@ def _convert_junit_to_html(junit_path, result_path):
                 html_file.write(html)
 
 if __name__ == "__main__":
-    if len(sys.argv) < 3:
-        raise "Insufficient arguments: junit.xml result_path ", level
-    junit_path, result_path = sys.argv[1] , sys.argv[2]
-    print "junit_path: {}, result_path: {}".format(junit_path, result_path)
-    _convert_junit_to_html(junit_path, result_path)
+
+    parser = argparse.ArgumentParser(description='Convert JUnit XML.')
+    parser.add_argument('junit', help='path to junit.xml report')
+    parser.add_argument('result_dir', nargs='?', help='directory for result files. Default to junit.xml directory')
+    parser.add_argument('--export-cases', help='Export JSONEachRow result for testcases to upload in CI', action='store_true')
+    parser.add_argument('--export-suites', help='Export JSONEachRow result for testsuites to upload in CI', action='store_true')
+
+    args = parser.parse_args()
+
+    junit_path = args.junit
+    if args.result_dir:
+        result_path = args.result_dir
+    else:
+        result_path = os.path.dirname(junit_path)
+    print "junit_path: {}, result_path: {}, export cases:{}, export suites: {}".format(junit_path, result_path, args.export_cases, args.export_suites)
+    _convert_junit_to_html(junit_path, result_path, args.export_cases, args.export_suites)

--- a/utils/junit_to_html/junit_to_html
+++ b/utils/junit_to_html/junit_to_html
@@ -22,8 +22,14 @@ def export_testcases_json(report, path):
                 for el in testcase:
                     if el.tag == "system-err":
                         row["stderr"] = el.text
+                    else:
+                        row["stderr"] = ""
+
                     if el.tag == "system-out":
                         row["stdout"] = el.text
+                    else:
+                        row["stdout"] = ""
+
                 json.dump(row, testcases_file)
                 testcases_file.write("\n")
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Convert test results to JSONEachRow format in junit_to_html tool 

Detailed description / Documentation draft:

- add name for integration suit
- export json 

tested only for integration test for now

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.
