### PR TITLE
Remove unused flags from MergedColumnOnlyOutputStream.

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPartWriter.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPartWriter.h
@@ -107,7 +107,7 @@ public:
     void initSkipIndices();
     void initPrimaryIndex();
 
-    virtual void finishDataSerialization(IMergeTreeDataPart::Checksums & checksums, bool sync = false) = 0;
+    virtual void finishDataSerialization(IMergeTreeDataPart::Checksums & checksums) = 0;
     void finishPrimaryIndexSerialization(MergeTreeData::DataPart::Checksums & checksums);
     void finishSkipIndicesSerialization(MergeTreeData::DataPart::Checksums & checksums);
 

--- a/src/Storages/MergeTree/IMergedBlockOutputStream.h
+++ b/src/Storages/MergeTree/IMergedBlockOutputStream.h
@@ -25,7 +25,7 @@ public:
 protected:
     using SerializationState = IDataType::SerializeBinaryBulkStatePtr;
 
-    IDataType::OutputStreamGetter createStreamGetter(const String & name, WrittenOffsetColumns & offset_columns, bool skip_offsets);
+    IDataType::OutputStreamGetter createStreamGetter(const String & name, WrittenOffsetColumns & offset_columns);
 
     /// Remove all columns marked expired in data_part. Also, clears checksums
     /// and columns array. Return set of removed files names.

--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
@@ -876,9 +876,7 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataMergerMutator::mergePartsToTempor
             MergedColumnOnlyOutputStream column_to(
                 new_data_part,
                 column_gathered_stream.getHeader(),
-                false,
                 compression_codec,
-                false,
                 /// we don't need to recalc indices here
                 /// because all of them were already recalculated and written
                 /// as key part of vertical merge
@@ -1588,9 +1586,7 @@ void MergeTreeDataMergerMutator::mutateSomePartColumns(
     MergedColumnOnlyOutputStream out(
         new_data_part,
         mutation_header,
-        /* sync = */ false,
         compression_codec,
-        /* skip_offsets = */ false,
         std::vector<MergeTreeIndexPtr>(indices_to_recalc.begin(), indices_to_recalc.end()),
         nullptr,
         source_part->index_granularity,

--- a/src/Storages/MergeTree/MergeTreeDataPartCompact.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartCompact.h
@@ -20,7 +20,6 @@ class MergeTreeDataPartCompact : public IMergeTreeDataPart
 public:
     static constexpr auto DATA_FILE_NAME = "data";
     static constexpr auto DATA_FILE_EXTENSION = ".bin";
-    static constexpr auto TEMP_FILE_SUFFIX = "_temp";
     static constexpr auto DATA_FILE_NAME_WITH_EXTENSION = "data.bin";
 
     MergeTreeDataPartCompact(

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.cpp
@@ -22,8 +22,6 @@ MergeTreeDataPartWriterCompact::MergeTreeDataPartWriterCompact(
 {
     using DataPart = MergeTreeDataPartCompact;
     String data_file_name = DataPart::DATA_FILE_NAME;
-    if (settings.is_writing_temp_files)
-        data_file_name += DataPart::TEMP_FILE_SUFFIX;
 
     stream = std::make_unique<Stream>(
         data_file_name,
@@ -145,7 +143,7 @@ void MergeTreeDataPartWriterCompact::writeColumnSingleGranule(const ColumnWithTy
     column.type->serializeBinaryBulkStateSuffix(serialize_settings, state);
 }
 
-void MergeTreeDataPartWriterCompact::finishDataSerialization(IMergeTreeDataPart::Checksums & checksums, bool sync)
+void MergeTreeDataPartWriterCompact::finishDataSerialization(IMergeTreeDataPart::Checksums & checksums)
 {
     if (columns_buffer.size() != 0)
         writeBlock(header.cloneWithColumns(columns_buffer.releaseColumns()));
@@ -161,8 +159,6 @@ void MergeTreeDataPartWriterCompact::finishDataSerialization(IMergeTreeDataPart:
     }
 
     stream->finalize();
-    if (sync)
-        stream->sync();
     stream->addToChecksums(checksums);
     stream.reset();
 }

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.h
@@ -21,7 +21,7 @@ public:
     void write(const Block & block, const IColumn::Permutation * permutation,
         const Block & primary_key_block, const Block & skip_indexes_block) override;
 
-    void finishDataSerialization(IMergeTreeDataPart::Checksums & checksums, bool sync) override;
+    void finishDataSerialization(IMergeTreeDataPart::Checksums & checksums) override;
 
 private:
     /// Write single granule of one column (rows between 2 marks)

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterWide.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterWide.h
@@ -24,7 +24,7 @@ public:
     void write(const Block & block, const IColumn::Permutation * permutation,
         const Block & primary_key_block, const Block & skip_indexes_block) override;
 
-    void finishDataSerialization(IMergeTreeDataPart::Checksums & checksums, bool sync) override;
+    void finishDataSerialization(IMergeTreeDataPart::Checksums & checksums) override;
 
     IDataType::OutputStreamGetter createStreamGetter(const String & name, WrittenOffsetColumns & offset_columns);
 

--- a/src/Storages/MergeTree/MergeTreeIOSettings.h
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.h
@@ -30,10 +30,7 @@ struct MergeTreeWriterSettings
     size_t aio_threshold;
     bool can_use_adaptive_granularity;
     bool blocks_are_granules_size;
-    /// true if we write temporary files during alter.
-    bool is_writing_temp_files = false;
+
     size_t estimated_size = 0;
-    /// used when ALTERing columns if we know that array offsets are not altered.
-    bool skip_offsets = false;
 };
 }

--- a/src/Storages/MergeTree/MergedColumnOnlyOutputStream.cpp
+++ b/src/Storages/MergeTree/MergedColumnOnlyOutputStream.cpp
@@ -8,15 +8,14 @@ namespace ErrorCodes
 }
 
 MergedColumnOnlyOutputStream::MergedColumnOnlyOutputStream(
-    const MergeTreeDataPartPtr & data_part, const Block & header_, bool sync_,
-    CompressionCodecPtr default_codec, bool skip_offsets_,
+    const MergeTreeDataPartPtr & data_part,
+    const Block & header_,
+    CompressionCodecPtr default_codec,
     const std::vector<MergeTreeIndexPtr> & indices_to_recalc,
     WrittenOffsetColumns * offset_columns_,
     const MergeTreeIndexGranularity & index_granularity,
-    const MergeTreeIndexGranularityInfo * index_granularity_info,
-    bool is_writing_temp_files)
-    : IMergedBlockOutputStream(data_part),
-    header(header_), sync(sync_)
+    const MergeTreeIndexGranularityInfo * index_granularity_info)
+    : IMergedBlockOutputStream(data_part), header(header_)
 {
     const auto & global_settings = data_part->storage.global_context.getSettings();
     MergeTreeWriterSettings writer_settings(
@@ -24,11 +23,13 @@ MergedColumnOnlyOutputStream::MergedColumnOnlyOutputStream(
         index_granularity_info ? index_granularity_info->is_adaptive : data_part->storage.canUseAdaptiveGranularity(),
         global_settings.min_bytes_to_use_direct_io);
 
-    writer_settings.is_writing_temp_files = is_writing_temp_files;
-    writer_settings.skip_offsets = skip_offsets_;
+    writer = data_part->getWriter(
+        header.getNamesAndTypesList(),
+        indices_to_recalc,
+        default_codec,
+        std::move(writer_settings),
+        index_granularity);
 
-    writer = data_part->getWriter(header.getNamesAndTypesList(), indices_to_recalc,
-        default_codec,std::move(writer_settings), index_granularity);
     writer->setWrittenOffsetColumns(offset_columns_);
     writer->initSkipIndices();
 }
@@ -62,7 +63,7 @@ MergedColumnOnlyOutputStream::writeSuffixAndGetChecksums(MergeTreeData::MutableD
 {
     /// Finish columns serialization.
     MergeTreeData::DataPart::Checksums checksums;
-    writer->finishDataSerialization(checksums, sync);
+    writer->finishDataSerialization(checksums);
     writer->finishSkipIndicesSerialization(checksums);
 
     auto columns = new_part->getColumns();

--- a/src/Storages/MergeTree/MergedColumnOnlyOutputStream.h
+++ b/src/Storages/MergeTree/MergedColumnOnlyOutputStream.h
@@ -11,17 +11,16 @@ class MergeTreeDataPartWriterWide;
 class MergedColumnOnlyOutputStream final : public IMergedBlockOutputStream
 {
 public:
-    /// skip_offsets: used when ALTERing columns if we know that array offsets are not altered.
     /// Pass empty 'already_written_offset_columns' first time then and pass the same object to subsequent instances of MergedColumnOnlyOutputStream
     ///  if you want to serialize elements of Nested data structure in different instances of MergedColumnOnlyOutputStream.
     MergedColumnOnlyOutputStream(
-        const MergeTreeDataPartPtr & data_part, const Block & header_, bool sync_,
-        CompressionCodecPtr default_codec_, bool skip_offsets_,
+        const MergeTreeDataPartPtr & data_part,
+        const Block & header_,
+        CompressionCodecPtr default_codec_,
         const std::vector<MergeTreeIndexPtr> & indices_to_recalc_,
         WrittenOffsetColumns * offset_columns_ = nullptr,
         const MergeTreeIndexGranularity & index_granularity = {},
-        const MergeTreeIndexGranularityInfo * index_granularity_info_ = nullptr,
-        bool is_writing_temp_files = false);
+        const MergeTreeIndexGranularityInfo * index_granularity_info_ = nullptr);
 
     Block getHeader() const override { return header; }
     void write(const Block & block) override;
@@ -31,7 +30,6 @@ public:
 
 private:
     Block header;
-    bool sync;
 };
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Non-significant (changelog entry is not required)

Detailed description / Documentation draft:
They were used in previous implementation of alters.