### PR TITLE
Add util to test results upload in CI ClickHouse

### DIFF
--- a/utils/upload_test_results/README.md
+++ b/utils/upload_test_results/README.md
@@ -1,0 +1,34 @@
+## Tool to upload results to CI ClickHouse
+
+Currently allows to upload results from `junit_to_html` tool to  ClickHouse CI
+
+```
+usage: upload_test_results [-h] --sha SHA --pr PR --file FILE --type
+                           {suites,cases} [--user USER] --password PASSWORD
+                           [--ca-cert CA_CERT] [--host HOST] [--db DB]
+
+Upload test result to CI ClickHouse.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --sha SHA             sha of current commit
+  --pr PR               pr of current commit. 0 for master
+  --file FILE           file to upload
+  --type {suites,cases}
+                        Export type
+  --user USER           user name
+  --password PASSWORD   password
+  --ca-cert CA_CERT     CA certificate path
+  --host HOST           CI ClickHouse host
+  --db DB               CI ClickHouse database name
+```
+
+$ ./upload_test_results --sha "cf7eaee3301d4634acdacbfa308ddbe0cc6a061d" --pr "0" --file xyz/cases.jer --type cases --password $PASSWD
+
+CI checks has single commit sha and pr identifier.
+While uploading your local results for testing purposes try to use correct sha and pr.
+
+CA Certificate for ClickHouse CI can be obtained from Yandex.Cloud where CI database is hosted
+``` bash
+wget "https://storage.yandexcloud.net/cloud-certs/CA.pem" -O YandexInternalRootCA.crt
+```

--- a/utils/upload_test_results/upload_test_results
+++ b/utils/upload_test_results/upload_test_results
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+import requests
+import argparse
+
+# CREATE TABLE test_suites
+# (
+# sha String,
+# pr UInt16,
+# suite String,
+# errors UInt16,
+# failures UInt16,
+# hostname String,
+# skipped UInt16,
+# duration Double,
+# timestamp DateTime
+# ) ENGINE = MergeTree ORDER BY tuple(timestamp, suite);
+
+QUERY_SUITES="INSERT INTO test_suites "\
+             "SELECT '{sha}' AS sha, "\
+             "{pr} AS pr, "\
+             "suite, "\
+             "errors, "\
+             "failures, "\
+             "hostname, "\
+             "skipped, "\
+             "duration, "\
+             "timestamp "\
+             "FROM input('"\
+             "suite String, "\
+             "errors UInt16, "\
+             "failures UInt16, "\
+             "hostname String, "\
+             "skipped UInt16, "\
+             "duration Double, "\
+             "timestamp DateTime"\
+             "') FORMAT JSONEachRow"
+
+# CREATE TABLE test_cases
+# (
+# sha String,
+# pr UInt16,
+# hostname String,
+# suite String,
+# timestamp DateTime,
+# testname String,
+# classname String,
+# file String,
+# line UInt16,
+# duration Double,
+# suite_duration Double,
+# stderr String,
+# stdout String
+# ) ENGINE = MergeTree ORDER BY tuple(timestamp, testname);
+
+QUERY_CASES="INSERT INTO test_cases "\
+             "SELECT '{sha}' AS sha, "\
+             "{pr} AS pr, "\
+             "hostname, "\
+             "suite, "\
+             "timestamp, "\
+             "testname, "\
+             "classname, "\
+             "file, "\
+             "line, "\
+             "duration, "\
+             "suite_duration, "\
+             "stderr,"\
+             "stdout "\
+             "FROM input('"\
+             "hostname String, "\
+             "suite String, "\
+             "timestamp DateTime, "\
+             "testname String, "\
+             "classname String, "\
+             "file String, "\
+             "line UInt16, "\
+             "duration Double, "\
+             "suite_duration Double, "\
+             "stderr String, "\
+             "stdout String"\
+             "') FORMAT JSONEachRow"
+
+
+def upload_request(sha, pr, file, q_type, user, password, ca_cert, host, db):
+    with open(file) as upload_f:
+        query = QUERY_SUITES if q_type=="suites" else QUERY_CASES
+        query = query.format(sha=sha, pr=pr)
+        url = 'https://{host}:8443/?database={db}&query={query}&date_time_input_format=best_effort'.format(
+            host=host,
+            db=db,
+            query=query
+        )
+        data=upload_f
+        auth = {
+            'X-ClickHouse-User': user,
+            'X-ClickHouse-Key': password,
+        }
+
+        print query;
+
+        res = requests.post(
+            url,
+            data=data,
+            headers=auth,
+            verify=ca_cert)
+        res.raise_for_status()
+        return res.text
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description='Upload test result to CI ClickHouse.')
+    parser.add_argument('--sha', help='sha of current commit', type=str, required=True)
+    parser.add_argument('--pr', help='pr of current commit. 0 for master', type=int, required=True)
+    parser.add_argument('--file', help='file to upload', required=True)
+    parser.add_argument('--type', help='Export type', choices=['suites', 'cases'] , required=True)
+    parser.add_argument('--user', help='user name', type=str, default="clickhouse-ci")
+    parser.add_argument('--password', help='password', type=str, required=True)
+    parser.add_argument('--ca-cert', help='CA certificate path', type=str, default="/usr/local/share/ca-certificates/YandexInternalRootCA.crt")
+    parser.add_argument('--host', help='CI ClickHouse host', type=str, default="c1a-ity5agjmuhyu6nu9.mdb.yandexcloud.net")
+    parser.add_argument('--db', help='CI ClickHouse database name', type=str, default="clickhouse-ci")
+
+    args = parser.parse_args()
+
+    print(upload_request(args.sha, args.pr, args.file, args.type, args.user, args.password, args.ca_cert, args.host, args.db))
+
+
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add util to test results upload in CI ClickHouse

Detailed description / Documentation draft:

Currently allows to upload results from `junit_to_html` tool to ClickHouse CI

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.
