### PR TITLE
[RFC] Make logger name colored

### DIFF
--- a/base/loggers/OwnPatternFormatter.cpp
+++ b/base/loggers/OwnPatternFormatter.cpp
@@ -75,7 +75,11 @@ void OwnPatternFormatter::formatExtended(const DB::ExtendedLogMessage & msg_ext,
     if (color)
         writeCString(resetColor(), wb);
     writeCString("> ", wb);
+    if (color)
+        writeString(setColor(std::hash<std::string>()(msg.getSource())), wb);
     DB::writeString(msg.getSource(), wb);
+    if (color)
+        writeCString(resetColor(), wb);
     writeCString(": ", wb);
     DB::writeString(msg.getText(), wb);
 }


### PR DESCRIPTION
Changelog category (leave one):
- Non-significant (changelog entry is not required)

P.S. not sure that this not too much coloring, but looks useful (for distinguish loggers of the different buffer tables), anyway this can be done separately ([by coloring the on disk log](https://gist.github.com/azat/b47e2c6ef09a3b17b54bba2e37a869d8)).