### PR TITLE
Add performance test for parallel insert of materialized view

### DIFF
--- a/tests/performance/materialized_view_parallel_insert.xml
+++ b/tests/performance/materialized_view_parallel_insert.xml
@@ -1,10 +1,4 @@
 <test>
-    <stop_conditions>
-        <any_of>
-            <iterations>2</iterations>
-        </any_of>
-    </stop_conditions>
-
     <preconditions>
         <table_exists>hits_10m_single</table_exists>
     </preconditions>

--- a/tests/performance/materialized_view_parallel_insert.xml
+++ b/tests/performance/materialized_view_parallel_insert.xml
@@ -1,0 +1,38 @@
+<test>
+    <stop_conditions>
+        <any_of>
+            <iterations>2</iterations>
+        </any_of>
+    </stop_conditions>
+
+    <preconditions>
+        <table_exists>hits_10m_single</table_exists>
+    </preconditions>
+
+    <create_query>
+        CREATE MATERIALIZED VIEW hits_mv ENGINE MergeTree
+        PARTITION BY toYYYYMM(EventDate)
+        ORDER BY (CounterID, EventDate, intHash32(UserID))
+        SAMPLE BY intHash32(UserID)
+        SETTINGS
+            parts_to_delay_insert = 5000,
+            parts_to_throw_insert = 5000
+        AS
+            -- don't select all columns to keep the run time down
+            SELECT CounterID, EventDate, UserID, Title
+            FROM hits_10m_single
+            -- do not select anything because we only need column types
+            LIMIT 0
+    </create_query>
+    <fill_query>SET max_insert_threads=8</fill_query>
+    <fill_query>SYSTEM STOP MERGES</fill_query>
+
+    <query>
+        INSERT INTO hits_mv
+        SELECT CounterID, EventDate, UserID, Title
+        FROM hits_10m_single
+    </query>
+
+    <drop_query>SYSTEM START MERGES</drop_query>
+    <drop_query>DROP TABLE IF EXISTS hits_mv</drop_query>
+</test>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

This PR adds the performance test for  [Parallel INSERT for materialized view](https://github.com/ClickHouse/ClickHouse/pull/10052).