### PR TITLE
Check for error code in part check

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -94,15 +94,11 @@ namespace ErrorCodes
     extern const int CORRUPTED_DATA;
     extern const int BAD_TYPE_OF_FIELD;
     extern const int BAD_ARGUMENTS;
-    extern const int MEMORY_LIMIT_EXCEEDED;
     extern const int INVALID_PARTITION_VALUE;
     extern const int METADATA_MISMATCH;
     extern const int PART_IS_TEMPORARILY_LOCKED;
     extern const int TOO_MANY_PARTS;
     extern const int INCOMPATIBLE_COLUMNS;
-    extern const int CANNOT_ALLOCATE_MEMORY;
-    extern const int CANNOT_MUNMAP;
-    extern const int CANNOT_MREMAP;
     extern const int BAD_TTL_EXPRESSION;
     extern const int INCORRECT_FILE_NAME;
     extern const int BAD_DATA_PART_NAME;
@@ -954,10 +950,7 @@ void MergeTreeData::loadDataParts(bool skip_sanity_checks)
                 /// Don't count the part as broken if there is not enough memory to load it.
                 /// In fact, there can be many similar situations.
                 /// But it is OK, because there is a safety guard against deleting too many parts.
-                if (e.code() == ErrorCodes::MEMORY_LIMIT_EXCEEDED
-                    || e.code() == ErrorCodes::CANNOT_ALLOCATE_MEMORY
-                    || e.code() == ErrorCodes::CANNOT_MUNMAP
-                    || e.code() == ErrorCodes::CANNOT_MREMAP)
+                if (isNotEnoughMemoryErrorCode(e.code()))
                     throw;
 
                 broken = true;

--- a/src/Storages/MergeTree/ReplicatedMergeTreePartCheckThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreePartCheckThread.cpp
@@ -248,9 +248,13 @@ CheckResult ReplicatedMergeTreePartCheckThread::checkPart(const String & part_na
 
                 LOG_INFO(log, "Part " << part_name << " looks good.");
             }
-            catch (const Exception &)
+            catch (const Exception & e)
             {
-                /// TODO Better to check error code.
+                /// Don't count the part as broken if there is not enough memory to load it.
+                /// In fact, there can be many similar situations.
+                /// But it is OK, because there is a safety guard against deleting too many parts.
+                if (isNotEnoughMemoryErrorCode(e.code()))
+                    throw;
 
                 tryLogCurrentException(log, __PRETTY_FUNCTION__);
 

--- a/src/Storages/MergeTree/checkDataPart.cpp
+++ b/src/Storages/MergeTree/checkDataPart.cpp
@@ -24,6 +24,22 @@ namespace ErrorCodes
 {
     extern const int CORRUPTED_DATA;
     extern const int UNKNOWN_PART_TYPE;
+    extern const int MEMORY_LIMIT_EXCEEDED;
+    extern const int CANNOT_ALLOCATE_MEMORY;
+    extern const int CANNOT_MUNMAP;
+    extern const int CANNOT_MREMAP;
+}
+
+
+bool isNotEnoughMemoryErrorCode(int code)
+{
+    /// Don't count the part as broken if there is not enough memory to load it.
+    /// In fact, there can be many similar situations.
+    /// But it is OK, because there is a safety guard against deleting too many parts.
+    return code == ErrorCodes::MEMORY_LIMIT_EXCEEDED
+        || code == ErrorCodes::CANNOT_ALLOCATE_MEMORY
+        || code == ErrorCodes::CANNOT_MUNMAP
+        || code == ErrorCodes::CANNOT_MREMAP;
 }
 
 

--- a/src/Storages/MergeTree/checkDataPart.h
+++ b/src/Storages/MergeTree/checkDataPart.h
@@ -19,4 +19,7 @@ IMergeTreeDataPart::Checksums checkDataPart(
     const MergeTreeDataPartType & part_type,
     bool require_checksums,
     std::function<bool()> is_cancelled = []{ return false; });
+
+bool isNotEnoughMemoryErrorCode(int code);
+
 }


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Check for error code when checking parts and don't mark part as broken if the error is like "not enough memory". This fixes #6269