### PR TITLE
Add setting always_fetch_merged_part

### DIFF
--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -57,6 +57,7 @@ struct MergeTreeSettings : public SettingsCollection<MergeTreeSettings>
     M(SettingUInt64, min_replicated_logs_to_keep, 100, "Keep about this number of last records in ZooKeeper log, even if they are obsolete. It doesn't affect work of tables: used only to diagnose ZooKeeper log before cleaning.", 0) \
     M(SettingSeconds, prefer_fetch_merged_part_time_threshold, 3600, "If time passed after replication log entry creation exceeds this threshold and sum size of parts is greater than \"prefer_fetch_merged_part_size_threshold\", prefer fetching merged part from replica instead of doing merge locally. To speed up very long merges.", 0) \
     M(SettingUInt64, prefer_fetch_merged_part_size_threshold, 10ULL * 1024 * 1024 * 1024, "If sum size of parts exceeds this threshold and time passed after replication log entry creation is greater than \"prefer_fetch_merged_part_time_threshold\", prefer fetching merged part from replica instead of doing merge locally. To speed up very long merges.", 0) \
+    M(SettingBool, always_fetch_merged_part, 0, "If true, replica never merge parts and always download merged parts from other replicas.", 0) \
     M(SettingUInt64, max_suspicious_broken_parts, 10, "Max broken parts, if more - deny automatic deletion.", 0) \
     M(SettingUInt64, max_files_to_modify_in_alter_columns, 75, "Not apply ALTER if number of files for modification(deletion, addition) more than this.", 0) \
     M(SettingUInt64, max_files_to_remove_in_alter_columns, 50, "Not apply ALTER, if number of files for deletion more than this.", 0) \

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -985,6 +985,14 @@ bool StorageReplicatedMergeTree::tryExecuteMerge(const LogEntry & entry)
         LOG_TRACE(log, log_message.rdbuf());
     }
 
+    const auto storage_settings_ptr = getSettings();
+
+    if (storage_settings_ptr->always_fetch_merged_part)
+    {
+        LOG_INFO(log, "Will fetch part " << entry.new_part_name << " because setting always_fetch_merged_part is set to 1");
+        return false;
+    }
+
     DataPartsVector parts;
     bool have_all_parts = true;
     for (const String & name : entry.source_parts)
@@ -1005,7 +1013,6 @@ bool StorageReplicatedMergeTree::tryExecuteMerge(const LogEntry & entry)
         parts.push_back(part);
     }
 
-    const auto storage_settings_ptr = getSettings();
     if (!have_all_parts)
     {
         /// If you do not have all the necessary parts, try to take some already merged part from someone.

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -989,7 +989,7 @@ bool StorageReplicatedMergeTree::tryExecuteMerge(const LogEntry & entry)
 
     if (storage_settings_ptr->always_fetch_merged_part)
     {
-        LOG_INFO(log, "Will fetch part " << entry.new_part_name << " because setting always_fetch_merged_part is set to 1");
+        LOG_INFO(log, "Will fetch part " << entry.new_part_name << " because setting 'always_fetch_merged_part' is true");
         return false;
     }
 

--- a/tests/integration/test_always_fetch_merged/test.py
+++ b/tests/integration/test_always_fetch_merged/test.py
@@ -57,7 +57,6 @@ def test_replica_always_download(started_cluster):
 
     time.sleep(3)
 
-    # all merged
     node1_parts = node1.query("SELECT COUNT() FROM system.parts WHERE table = 'test_table' and active=1").strip()
     node2_parts = node2.query("SELECT COUNT() FROM system.parts WHERE table = 'test_table' and active=1").strip()
     assert node1_parts < '10'  # something merged

--- a/tests/integration/test_always_fetch_merged/test.py
+++ b/tests/integration/test_always_fetch_merged/test.py
@@ -1,0 +1,64 @@
+import pytest
+import time
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
+
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance('node1', with_zookeeper=True)
+node2 = cluster.add_instance('node2', with_zookeeper=True)
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def test_replica_always_download(started_cluster):
+    node1.query("""
+        CREATE TABLE test_table(
+            key UInt64,
+            value String
+        ) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test_table/replicated', '1')
+        ORDER BY tuple()
+    """)
+    node2.query("""
+        CREATE TABLE test_table(
+            key UInt64,
+            value String
+        ) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test_table/replicated', '2')
+        ORDER BY tuple()
+        SETTINGS always_fetch_merged_part=1
+    """)
+
+    # Stop merges on single node
+    node1.query("SYSTEM STOP MERGES")
+
+    for i in range(0, 10):
+        node1.query("INSERT INTO test_table VALUES ({}, '{}')".format(i, i))
+
+    assert node1.query("SELECT COUNT() FROM test_table") == "10\n"
+    assert_eq_with_retry(node2, "SELECT COUNT() FROM test_table", "10\n")
+
+    time.sleep(3)
+
+    # Nothing is merged
+    assert node1.query("SELECT COUNT() FROM system.parts WHERE table = 'test_table' and active=1") == "10\n"
+
+    assert node2.query("SELECT COUNT() FROM system.parts WHERE table = 'test_table' and active=1") == "10\n"
+
+    node1.query("SYSTEM START MERGES")
+
+    time.sleep(3)
+
+    # all merged
+    node1_parts = node1.query("SELECT COUNT() FROM system.parts WHERE table = 'test_table' and active=1").strip()
+    node2_parts = node2.query("SELECT COUNT() FROM system.parts WHERE table = 'test_table' and active=1").strip()
+    assert node1_parts < '10'  # something merged
+    assert node2_parts < '10'

--- a/tests/integration/test_always_fetch_merged/test.py
+++ b/tests/integration/test_always_fetch_merged/test.py
@@ -59,5 +59,5 @@ def test_replica_always_download(started_cluster):
 
     node1_parts = node1.query("SELECT COUNT() FROM system.parts WHERE table = 'test_table' and active=1").strip()
     node2_parts = node2.query("SELECT COUNT() FROM system.parts WHERE table = 'test_table' and active=1").strip()
-    assert node1_parts < '10'  # something merged
-    assert node2_parts < '10'
+    assert int(node1_parts) < 10  # something merged
+    assert int(node2_parts) < 10


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add setting `always_fetch_merged_part` which restrict replica to merge parts by itself and always prefer dowloading from other replicas.


Detailed description / Documentation draft:
Almost all information about setting in changelog entry.
