### PR TITLE
Use clang-10 in CI

### DIFF
--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:19.10
 
+RUN echo "deb [trusted=yes] http://apt.llvm.org/eoan/ llvm-toolchain-eoan-10 main" >> /etc/apt/sources.list
+
 RUN apt-get update -y \
     && env DEBIAN_FRONTEND=noninteractive \
         apt-get install --yes --no-install-recommends \
@@ -19,10 +21,10 @@ RUN apt-get update -y \
             python-termcolor \
             sudo \
             tzdata \
-            clang \
-            clang-tidy \
-            lld \
-            lldb
+            clang-10 \
+            clang-tidy-10 \
+            lld-10 \
+            lldb-10
 
 COPY build.sh /
 

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:19.10
 
+RUN apt-get --allow-unauthenticated update -y && apt-get install --yes wget gnupg
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN echo "deb [trusted=yes] http://apt.llvm.org/eoan/ llvm-toolchain-eoan-10 main" >> /etc/apt/sources.list
 
 RUN apt-get update -y \

--- a/docker/packager/binary/Dockerfile
+++ b/docker/packager/binary/Dockerfile
@@ -2,6 +2,8 @@
 # docker build -t yandex/clickhouse-binary-builder .
 FROM ubuntu:19.10
 
+RUN echo "deb [trusted=yes] http://apt.llvm.org/eoan/ llvm-toolchain-eoan-10 main" >> /etc/apt/sources.list
+
 RUN apt-get --allow-unauthenticated update -y \
     && env DEBIAN_FRONTEND=noninteractive \
         apt-get --allow-unauthenticated install --yes --no-install-recommends \
@@ -23,6 +25,9 @@ RUN apt-get update -y \
             curl \
             gcc-9 \
             g++-9 \
+            clang-10 \
+            lld-10 \
+            clang-tidy-10 \
             clang-9 \
             lld-9 \
             clang-tidy-9 \
@@ -43,10 +48,10 @@ RUN apt-get update -y \
             build-essential
 
 # This symlink required by gcc to find lld compiler
-RUN ln -s /usr/bin/lld-9 /usr/bin/ld.lld
+RUN ln -s /usr/bin/lld-10 /usr/bin/ld.lld
 
-ENV CC=clang-9
-ENV CXX=clang++-9
+ENV CC=clang-10
+ENV CXX=clang++-10
 
 # libtapi is required to support .tbh format from recent MacOS SDKs
 RUN git clone https://github.com/tpoechtrager/apple-libtapi.git

--- a/docker/packager/binary/Dockerfile
+++ b/docker/packager/binary/Dockerfile
@@ -2,6 +2,8 @@
 # docker build -t yandex/clickhouse-binary-builder .
 FROM ubuntu:19.10
 
+RUN apt-get --allow-unauthenticated update -y && apt-get install --yes wget gnupg
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN echo "deb [trusted=yes] http://apt.llvm.org/eoan/ llvm-toolchain-eoan-10 main" >> /etc/apt/sources.list
 
 RUN apt-get --allow-unauthenticated update -y \

--- a/docker/packager/deb/Dockerfile
+++ b/docker/packager/deb/Dockerfile
@@ -1,6 +1,8 @@
 # docker build -t yandex/clickhouse-deb-builder .
 FROM ubuntu:19.10
 
+RUN apt-get --allow-unauthenticated update -y && apt-get install --yes wget gnupg
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN echo "deb [trusted=yes] http://apt.llvm.org/eoan/ llvm-toolchain-eoan-10 main" >> /etc/apt/sources.list
 
 RUN apt-get --allow-unauthenticated update -y \

--- a/docker/packager/deb/Dockerfile
+++ b/docker/packager/deb/Dockerfile
@@ -1,6 +1,8 @@
 # docker build -t yandex/clickhouse-deb-builder .
 FROM ubuntu:19.10
 
+RUN echo "deb [trusted=yes] http://apt.llvm.org/eoan/ llvm-toolchain-eoan-10 main" >> /etc/apt/sources.list
+
 RUN apt-get --allow-unauthenticated update -y \
     && env DEBIAN_FRONTEND=noninteractive \
         apt-get --allow-unauthenticated install --yes --no-install-recommends \
@@ -19,6 +21,9 @@ RUN apt-get --allow-unauthenticated update -y \
         apt-get --allow-unauthenticated install --yes --no-install-recommends \
             gcc-9 \
             g++-9 \
+            clang-10 \
+            lld-10 \
+            clang-tidy-10 \
             clang-9 \
             lld-9 \
             clang-tidy-9 \
@@ -69,7 +74,7 @@ RUN chmod +x dpkg-deb
 RUN cp dpkg-deb /usr/bin
 
 # This symlink required by gcc to find lld compiler
-RUN ln -s /usr/bin/lld-9 /usr/bin/ld.lld
+RUN ln -s /usr/bin/lld-10 /usr/bin/ld.lld
 
 COPY build.sh /
 


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow to use `clang-10` in CI. This is to ensure that #10238 is fixed.
