### PR TITLE
Fix reading HashTable from buffer

### DIFF
--- a/src/Common/HashTable/HashSet.h
+++ b/src/Common/HashTable/HashSet.h
@@ -43,7 +43,7 @@ public:
 
         for (size_t i = 0; i < rhs.grower.bufSize(); ++i)
             if (!rhs.buf[i].isZero(*this))
-                this->insert(Cell::getKey(rhs.buf[i].getValue()));
+                this->insert(rhs.buf[i].getValue());
     }
 
 
@@ -60,7 +60,7 @@ public:
         {
             Cell x;
             x.read(rb);
-            this->insert(Cell::getKey(x.getValue()));
+            this->insert(x.getValue());
         }
     }
 };

--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -981,7 +981,7 @@ public:
         {
             Cell x;
             x.read(rb);
-            insert(Cell::getKey(x.getValue()));
+            insert(x.getValue());
         }
     }
 
@@ -1006,7 +1006,7 @@ public:
             Cell x;
             DB::assertChar(',', rb);
             x.readText(rb);
-            insert(Cell::getKey(x.getValue()));
+            insert(x.getValue());
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed wrong behavior in HashTable that caused compilation error when trying to read HashMap from buffer.