### PR TITLE
fix path to changelog 2018 2017

### DIFF
--- a/docs/en/whats_new/changelog/2018.md
+++ b/docs/en/whats_new/changelog/2018.md
@@ -1058,4 +1058,4 @@ This release contains bug fixes for the previous release 1.1.54337:
 -   When doing a rolling update on a cluster, at the point when some of the replicas are running the old version of ClickHouse and some are running the new version, replication is temporarily stopped and the message `unknown parameter 'shard'` appears in the log. Replication will continue after all replicas of the cluster are updated.
 -   If different versions of ClickHouse are running on the cluster servers, it is possible that distributed queries using the following functions will have incorrect results: `varSamp`, `varPop`, `stddevSamp`, `stddevPop`, `covarSamp`, `covarPop`, `corr`. You should update all cluster nodes.
 
-## [Changelog for 2017](https://github.com/ClickHouse/ClickHouse/blob/master/docs/en/changelog/2017.md)
+## [Changelog for 2017](./2017.md)

--- a/docs/en/whats_new/changelog/2019.md
+++ b/docs/en/whats_new/changelog/2019.md
@@ -2069,4 +2069,4 @@ This release contains exactly the same set of patches as 19.3.6.
 -   Fixed misspells in comments and string literals under `dbms`. [\#4122](https://github.com/ClickHouse/ClickHouse/pull/4122) ([maiha](https://github.com/maiha))
 -   Fixed typos in comments. [\#4089](https://github.com/ClickHouse/ClickHouse/pull/4089) ([Evgenii Pravda](https://github.com/kvinty))
 
-## [Changelog for 2018](https://github.com/ClickHouse/ClickHouse/blob/master/docs/en/changelog/2018.md)
+## [Changelog for 2018](./2018.md)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)
