### PR TITLE
Improve HashJoin memory usage

### DIFF
--- a/src/Interpreters/HashJoin.cpp
+++ b/src/Interpreters/HashJoin.cpp
@@ -648,7 +648,7 @@ bool HashJoin::addJoinedBlock(const Block & source_block, bool check_limits)
     if (overDictionary())
         throw Exception("Logical error: insert into hash-map in HashJoin over dictionary", ErrorCodes::LOGICAL_ERROR);
 
-    /// RowRef::SizeT is uint32_t (not size_t) for hash table Cell memory efficient.
+    /// RowRef::SizeT is uint32_t (not size_t) for hash table Cell memory efficiency.
     /// It's possible to split bigger blocks and insert them by parts here. But it would be a dead code.
     if (unlikely(source_block.rows() > std::numeric_limits<RowRef::SizeT>::max()))
         throw Exception("Too many rows in right table block for HashJoin: " + toString(source_block.rows()), ErrorCodes::NOT_IMPLEMENTED);

--- a/src/Interpreters/HashJoin.cpp
+++ b/src/Interpreters/HashJoin.cpp
@@ -1,4 +1,5 @@
 #include <any>
+#include <limits>
 
 #include <common/logger_useful.h>
 
@@ -646,6 +647,11 @@ bool HashJoin::addJoinedBlock(const Block & source_block, bool check_limits)
         throw Exception("Logical error: HashJoin was not initialized", ErrorCodes::LOGICAL_ERROR);
     if (overDictionary())
         throw Exception("Logical error: insert into hash-map in HashJoin over dictionary", ErrorCodes::LOGICAL_ERROR);
+
+    /// RowRef::SizeT is uint32_t (not size_t) for hash table Cell memory efficient.
+    /// It's possible to split bigger blocks and insert them by parts here. But it would be a dead code.
+    if (unlikely(source_block.rows() > std::numeric_limits<RowRef::SizeT>::max()))
+        throw Exception("Too many rows in right table block for HashJoin: " + toString(source_block.rows()), ErrorCodes::NOT_IMPLEMENTED);
 
     /// There's no optimization for right side const columns. Remove constness if any.
     Block block = materializeBlock(source_block);

--- a/src/Interpreters/RowRefs.h
+++ b/src/Interpreters/RowRefs.h
@@ -18,8 +18,10 @@ class Block;
 /// Reference to the row in block.
 struct RowRef
 {
+    using SizeT = uint32_t; /// Do not use size_t cause of memory economy
+
     const Block * block = nullptr;
-    size_t row_num = 0;
+    SizeT row_num = 0;
 
     RowRef() {}
     RowRef(const Block * block_, size_t row_num_) : block(block_), row_num(row_num_) {}
@@ -33,7 +35,7 @@ struct RowRefList : RowRef
     {
         static constexpr size_t MAX_SIZE = 7; /// Adequate values are 3, 7, 15, 31.
 
-        size_t size = 0;
+        SizeT size = 0; /// It's smaller than size_t but keeps align in Arena.
         Batch * next;
         RowRef row_refs[MAX_SIZE];
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use less memory for hash table in HashJoin.

Detailed description / Documentation draft:
Use 4-byte types for block sizes in HashJoin to use less memory in HashTable Cell. There're no 4Gb blocks in practice.