### PR TITLE
Prefer fallback_to_stale_replicas over skip_unavailable_shards

### DIFF
--- a/src/Common/PoolWithFailoverBase.h
+++ b/src/Common/PoolWithFailoverBase.h
@@ -274,18 +274,18 @@ PoolWithFailoverBase<TNestedPool>::getMany(
                     < std::forward_as_tuple(!right.is_up_to_date, right.staleness);
             });
 
-    if (up_to_date_count >= min_entries)
-    {
-        /// There is enough up-to-date entries.
-        try_results.resize(up_to_date_count);
-    }
-    else if (fallback_to_stale_replicas)
+    if (fallback_to_stale_replicas)
     {
         /// There is not enough up-to-date entries but we are allowed to return stale entries.
         /// Gather all up-to-date ones and least-bad stale ones.
 
         size_t size = std::min(try_results.size(), max_entries);
         try_results.resize(size);
+    }
+    else if (up_to_date_count >= min_entries)
+    {
+        /// There is enough up-to-date entries.
+        try_results.resize(up_to_date_count);
     }
     else
         throw DB::Exception(

--- a/tests/integration/test_delayed_replica_failover/test.py
+++ b/tests/integration/test_delayed_replica_failover/test.py
@@ -81,6 +81,14 @@ SELECT sum(x) FROM distributed SETTINGS
     max_replica_delay_for_distributed_queries=1
 ''').strip() == '3'
 
+        # Regression for skip_unavailable_shards in conjunction with skip_unavailable_shards
+        assert instance_with_dist_table.query('''
+SELECT sum(x) FROM distributed SETTINGS
+    load_balancing='in_order',
+    skip_unavailable_shards=1,
+    max_replica_delay_for_distributed_queries=1
+''').strip() == '3'
+
         # If we forbid stale replicas, the query must fail.
         with pytest.raises(Exception):
             print instance_with_dist_table.query('''


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Prefer `fallback_to_stale_replicas` over `skip_unavailable_shards`, otherwise when both settings specified and there are no up-to-date replicas the query will fail (patch from @alex-zaitsev )

Fixes: #2564