### PR TITLE
Not remove metadata directory when attach database fails

### DIFF
--- a/src/Databases/DatabaseFactory.cpp
+++ b/src/Databases/DatabaseFactory.cpp
@@ -36,18 +36,18 @@ namespace ErrorCodes
 DatabasePtr DatabaseFactory::get(
     const String & database_name, const String & metadata_path, const ASTStorage * engine_define, Context & context)
 {
-    bool create = false;
+    bool created = false;
 
     try
     {
-        create = Poco::File(metadata_path).createDirectory();
+        created = Poco::File(metadata_path).createDirectory();
         return getImpl(database_name, metadata_path, engine_define, context);
     }
     catch (...)
     {
         Poco::File metadata_dir(metadata_path);
 
-        if (create && metadata_dir.exists())
+        if (created && metadata_dir.exists())
             metadata_dir.remove(true);
 
         throw;

--- a/src/Databases/DatabaseFactory.cpp
+++ b/src/Databases/DatabaseFactory.cpp
@@ -36,16 +36,18 @@ namespace ErrorCodes
 DatabasePtr DatabaseFactory::get(
     const String & database_name, const String & metadata_path, const ASTStorage * engine_define, Context & context)
 {
+    bool create = false;
+
     try
     {
-        Poco::File(metadata_path).createDirectory();
+        create = Poco::File(metadata_path).createDirectory();
         return getImpl(database_name, metadata_path, engine_define, context);
     }
     catch (...)
     {
         Poco::File metadata_dir(metadata_path);
 
-        if (metadata_dir.exists())
+        if (create && metadata_dir.exists())
             metadata_dir.remove(true);
 
         throw;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Not remove metadata directory when attach database fails
