### PR TITLE
Simple server wide memory profiler

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -617,9 +617,19 @@ int Server::main(const std::vector<std::string> & /*args*/)
     /// Look at compiler-rt/lib/sanitizer_common/sanitizer_stacktrace.h
     ///
 #if USE_UNWIND && !WITH_COVERAGE && !defined(SANITIZER)
-    /// QueryProfiler cannot work reliably with any other libunwind or without PHDR cache.
+    /// Profilers cannot work reliably with any other libunwind or without PHDR cache.
     if (hasPHDRCache())
+    {
         global_context->initializeTraceCollector();
+
+        /// Set up server-wide memory profiler (for total memory tracker).
+        UInt64 total_memory_profiler_step = config().getUInt64("total_memory_profiler_step", 0);
+        if (total_memory_profiler_step)
+        {
+            total_memory_tracker.setOrRaiseProfilerLimit(total_memory_profiler_step);
+            total_memory_tracker.setProfilerStep(total_memory_profiler_step);
+        }
+    }
 #endif
 
     /// Describe multiple reasons when query profiler cannot work.

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -107,6 +107,12 @@
       -->
     <max_server_memory_usage_to_ram_ratio>0.9</max_server_memory_usage_to_ram_ratio>
 
+    <!-- Simple server-wide memory profiler. Collect a stack trace at every peak allocation step (in bytes).
+         Data will be stored in system.trace_log table with query_id = empty string.
+         Zero means disabled. Minimal effective value is 4 MiB.
+      -->
+    <total_memory_profiler_step>4194304</total_memory_profiler_step>
+
     <!-- Set limit on number of open files (default: maximum). This setting makes sense on Mac OS X because getrlimit() fails to retrieve
          correct maximum value. -->
     <!-- <max_open_files>262144</max_open_files> -->

--- a/src/Common/TraceCollector.cpp
+++ b/src/Common/TraceCollector.cpp
@@ -65,7 +65,7 @@ void TraceCollector::collect(TraceType trace_type, const StackTrace & stack_trac
         sizeof(StackTrace::Frames) +           // collected stack trace, maximum capacity
         sizeof(TraceType) +                    // trace type
         sizeof(UInt64) +                       // thread_id
-        sizeof(UInt64);                         // size
+        sizeof(UInt64);                        // size
     char buffer[buf_size];
     WriteBufferFromFileDescriptorDiscardOnFailure out(pipe.fds_rw[1], buf_size, buffer);
 


### PR DESCRIPTION
Changelog category (leave one):
- New Feature


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add simple server wide memory profiler that will collect allocation contexts when server memory usage becomes higher than the next allocation threshold. Currently the use of this profiler is limited because it only collects allocations in contexts when memory tracker is available. It's also limited because it fires only when peak memory usage is changed, so the possibility to detect small leaks is in question.