### PR TITLE
Make logger name colored in client too

### DIFF
--- a/src/DataStreams/InternalTextLogsRowOutputStream.cpp
+++ b/src/DataStreams/InternalTextLogsRowOutputStream.cpp
@@ -88,7 +88,11 @@ void InternalTextLogsRowOutputStream::write(const Block & block)
         writeCString("> ", wb);
 
         auto source = column_source.getDataAt(row_num);
-        writeString(source, wb);
+        if (color)
+            writeString(setColor(StringRefHash()(source)), wb);
+        DB::writeString(source, wb);
+        if (color)
+            writeCString(resetColor(), wb);
         writeCString(": ", wb);
 
         auto text = column_text.getDataAt(row_num);


### PR DESCRIPTION
Changelog category (leave one):
- Non-significant (changelog entry is not required)

Follow-up-for: #10343