### PR TITLE
Allow fallback for timezones with unbundled CCTZ in debug

### DIFF
--- a/base/common/CMakeLists.txt
+++ b/base/common/CMakeLists.txt
@@ -39,6 +39,10 @@ else ()
     target_compile_definitions(common PUBLIC WITH_COVERAGE=0)
 endif ()
 
+if (USE_INTERNAL_CCTZ)
+    set_source_files_properties(DateLUTImpl.cpp PROPERTIES COMPILE_DEFINITIONS USE_INTERNAL_CCTZ)
+endif()
+
 target_include_directories(common PUBLIC .. ${CMAKE_CURRENT_BINARY_DIR}/..)
 
 if (NOT USE_INTERNAL_BOOST_LIBRARY)

--- a/base/common/DateLUTImpl.cpp
+++ b/base/common/DateLUTImpl.cpp
@@ -223,10 +223,11 @@ namespace cctz_extension
             if (sym_data && sym_size)
                 return std::make_unique<Source>(static_cast<const char *>(sym_data), unalignedLoad<size_t>(&sym_size));
 
-#if defined(NDEBUG)
+#if defined(NDEBUG) || !defined(USE_INTERNAL_CCTZ)
             return fallback(name);
 #else
-            /// In debug builds, ensure that only embedded timezones can be loaded - this is intended for tests.
+            /// In debug builds with internal cctz,
+            /// ensure that only embedded timezones can be loaded - this is intended for tests.
             (void)fallback;
             return nullptr;
 #endif


### PR DESCRIPTION
Changelog category (leave one):
- Non-significant (changelog entry is not required)

Follow-up-for: #10425 