### PR TITLE
Fix cctz linking for odbc-bridge

### DIFF
--- a/contrib/cctz-cmake/CMakeLists.txt
+++ b/contrib/cctz-cmake/CMakeLists.txt
@@ -614,7 +614,9 @@ if (USE_INTERNAL_CCTZ)
 
         add_library(tzdata STATIC ${TZ_OBJS})
         set_target_properties(tzdata PROPERTIES LINKER_LANGUAGE C)
-        target_link_libraries(cctz -Wl,--whole-archive tzdata -Wl,--no-whole-archive) # whole-archive prevents symbols from being discarded
+        # whole-archive prevents symbols from being discarded
+        # export-dynamic allows to search bundled symbols with dlsym
+        target_link_libraries(cctz -Wl,--push-state,--whole-archive,--export-dynamic tzdata -Wl,--pop-state)
     endif ()
 
 else ()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix linking of cctz (timezones) with `odbc-bridge`.