### PR TITLE
add CA certificates to clickhouse-server docker image

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update \
             clickhouse-client=$version \
             clickhouse-server=$version \
             locales \
+            ca-certificates \
             wget \
     && rm -rf \
         /var/lib/apt/lists/* \


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
add CA certificates to clickhouse-server docker image


Detailed description / Documentation draft:
Fixes #10468