### PR TITLE
Add link to clickhouse-plantuml

### DIFF
--- a/docs/en/interfaces/third-party/gui.md
+++ b/docs/en/interfaces/third-party/gui.md
@@ -91,6 +91,9 @@ Features:
 
 [clickhouse-flamegraph](https://github.com/Slach/clickhouse-flamegraph) is a specialized tool to visualize the `system.trace_log` as [flamegraph](http://www.brendangregg.com/flamegraphs.html).
 
+### clickhouse-plantuml {#clickhouse-plantuml}
+[cickhouse-plantuml](https://pypi.org/project/clickhouse-plantuml/) is a script to generate [PlantUML](https://plantuml.com/) diagram of tables' schemes.
+
 ## Commercial {#commercial}
 
 ### DataGrip {#datagrip}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)


Detailed description / Documentation draft:
Add link to PlantUML diagrams generator for tables' schemes.