### PR TITLE
Split fuzzers and sanitizers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,9 +84,10 @@ option (ENABLE_FUZZING "Enables fuzzing instrumentation" OFF)
 if (ENABLE_FUZZING)
     message (STATUS "Fuzzing instrumentation enabled")
     set (WITH_COVERAGE ON)
-    set (SANITIZE "libfuzzer")
+    set (FUZZER "libfuzzer")
 endif()
 
+include (cmake/fuzzer.cmake)
 include (cmake/sanitize.cmake)
 
 if (CMAKE_GENERATOR STREQUAL "Ninja" AND NOT DISABLE_COLORED_BUILD)

--- a/cmake/fuzzer.cmake
+++ b/cmake/fuzzer.cmake
@@ -1,0 +1,21 @@
+option (FUZZER "Enable fuzzer: libfuzzer")
+
+if (FUZZER)
+    if (FUZZER STREQUAL "libfuzzer")
+        # NOTE: Eldar Zaitov decided to name it "libfuzzer" instead of "fuzzer" to keep in mind another possible fuzzer backends.
+        # NOTE: no-link means that all the targets are built with instrumentation for fuzzer, but only some of them (tests) have entry point for fuzzer and it's not checked.
+        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SAN_FLAGS} -fsanitize=fuzzer-no-link")
+        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SAN_FLAGS} -fsanitize=fuzzer-no-link")
+        if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+            set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=fuzzer-no-link")
+        endif()
+
+        # NOTE: oss-fuzz can change LIB_FUZZING_ENGINE variable
+        if (NOT LIB_FUZZING_ENGINE)
+            set (LIB_FUZZING_ENGINE "-fsanitize=fuzzer")
+        endif ()
+
+    else ()
+        message (FATAL_ERROR "Unknown fuzzer type: ${FUZZER}")
+    endif ()
+endif()

--- a/cmake/sanitize.cmake
+++ b/cmake/sanitize.cmake
@@ -58,18 +58,6 @@ if (SANITIZE)
         # llvm-tblgen, that is used during LLVM build, doesn't work with UBSan.
         set (ENABLE_EMBEDDED_COMPILER 0 CACHE BOOL "")
 
-    elseif (SANITIZE STREQUAL "libfuzzer")
-        # NOTE: Eldar Zaitov decided to name it "libfuzzer" instead of "fuzzer" to keep in mind another possible fuzzer backends.
-        # NOTE: no-link means that all the targets are built with instrumentation for fuzzer, but only some of them (tests) have entry point for fuzzer and it's not checked.
-        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SAN_FLAGS} -fsanitize=fuzzer-no-link,address,undefined -fsanitize-address-use-after-scope")
-        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SAN_FLAGS} -fsanitize=fuzzer-no-link,address,undefined -fsanitize-address-use-after-scope")
-        if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-            set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=fuzzer-no-link,address,undefined -fsanitize-address-use-after-scope")
-        endif()
-        if (MAKE_STATIC_LIBRARIES AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-            set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libasan -static-libubsan")
-        endif ()
-        set (LIBFUZZER_CMAKE_CXX_FLAGS "-fsanitize=fuzzer,address,undefined -fsanitize-address-use-after-scope")
     else ()
         message (FATAL_ERROR "Unknown sanitizer type: ${SANITIZE}")
     endif ()

--- a/src/Compression/tests/CMakeLists.txt
+++ b/src/Compression/tests/CMakeLists.txt
@@ -6,6 +6,5 @@ target_link_libraries (cached_compressed_read_buffer PRIVATE dbms)
 
 if (ENABLE_FUZZING)
     add_executable (compressed_buffer_fuzz compressed_buffer_fuzz.cpp)
-    target_link_libraries (compressed_buffer_fuzz PRIVATE dbms)
-    set_target_properties(compressed_buffer_fuzz PROPERTIES LINK_FLAGS ${LIBFUZZER_CMAKE_CXX_FLAGS})
+    target_link_libraries (compressed_buffer_fuzz PRIVATE dbms ${LIB_FUZZING_ENGINE})
 endif ()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Split fuzzer and sanitizer configurations to make build config compatible with Oss-fuzz.
