### PR TITLE
Fix visible drift of MemoryTracking metric

### DIFF
--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -22,6 +22,12 @@
 #endif
 
 
+namespace CurrentMetrics
+{
+    extern const Metric MemoryTracking;
+}
+
+
 namespace DB
 {
 
@@ -146,6 +152,7 @@ void AsynchronousMetrics::update()
         /// Otherwise it might be calculated incorrectly - it can include a "drift" of memory amount.
         /// See https://github.com/ClickHouse/ClickHouse/issues/10293
         total_memory_tracker.set(data.resident);
+        CurrentMetrics::set(CurrentMetrics::MemoryTracking, data.resident);
     }
 #endif
 


### PR DESCRIPTION
Changelog category (leave one):
- Non-significant (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Addition to #10293