### PR TITLE
Fix "odbc-bridge" test

### DIFF
--- a/base/common/DateLUTImpl.cpp
+++ b/base/common/DateLUTImpl.cpp
@@ -223,14 +223,7 @@ namespace cctz_extension
             if (sym_data && sym_size)
                 return std::make_unique<Source>(static_cast<const char *>(sym_data), unalignedLoad<size_t>(&sym_size));
 
-#if defined(NDEBUG) || !defined(USE_INTERNAL_CCTZ)
             return fallback(name);
-#else
-            /// In debug builds with internal cctz,
-            /// ensure that only embedded timezones can be loaded - this is intended for tests.
-            (void)fallback;
-            return nullptr;
-#endif
         }
     }
 


### PR DESCRIPTION
Changelog category (leave one):
- Non-significant (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Overcomes the issue in #10453