### PR TITLE
IRowInputFormat performance fix

### DIFF
--- a/src/Processors/Formats/IRowInputFormat.cpp
+++ b/src/Processors/Formats/IRowInputFormat.cpp
@@ -49,13 +49,14 @@ Chunk IRowInputFormat::generate()
 
     try
     {
+        RowReadExtension info;
         for (size_t rows = 0; rows < params.max_block_size; ++rows)
         {
             try
             {
                 ++total_rows;
 
-                RowReadExtension info;
+                info.read_columns.clear();
                 if (!readRow(columns, info))
                     break;
                 if (params.callback)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Performance Improvement

Short description:
Improved performance of row-oriented formats (more than 10% for CSV and more than 35% for Avro in case of narrow tables).

Detailed description:

I noticed a performance drop  after I added `RowReadExtension` support to Avro format and the only thing I could see is that  `read_columns` is not reused between rows.

Some results on my local machine:

**AVRO, 1.4M rows**

`hyperfine -w 10 -r 10 "clickhouse local --file data.avro  --input-format Avro  -S  'col1 Int64' -q 'select count() from table'"`

BEFORE: 
```
Time (mean ± σ):     554.5 ms ±   4.9 ms    [User: 482.2 ms, System: 67.6 ms]
Range (min … max):   548.5 ms … 564.3 ms    10 runs
```
AFTER:
```
Time (mean ± σ):     401.9 ms ±   5.8 ms    [User: 347.6 ms, System: 48.5 ms]
Range (min … max):   390.5 ms … 409.1 ms    10 runs
```

**CSV, 2.3M rows**

`hyperfine -w 10 -r 10 "clickhouse-local --file data.csv --input-format CSVWithNames -S 'col1 String ,col2 String, col3 String, col4 String ,col5  String ,col6 String' -q 'select count() from table'"`

BEFORE: 
```
Time (mean ± σ):      2.916 s ±  0.029 s    [User: 1.943 s, System: 0.967 s]
Range (min … max):    2.877 s …  2.963 s    10 runs
```
AFTER:
```
Time (mean ± σ):      2.682 s ±  0.029 s    [User: 1.712 s, System: 0.963 s]
Range (min … max):    2.639 s …  2.732 s    10 runs
```