### PR TITLE
Finalize mutations in background

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -126,9 +126,10 @@ namespace ActionLocks
 }
 
 
-static const auto QUEUE_UPDATE_ERROR_SLEEP_MS     = 1 * 1000;
-static const auto MERGE_SELECTING_SLEEP_MS        = 5 * 1000;
-static const auto MUTATIONS_FINALIZING_SLEEP_MS   = 1 * 1000;
+static const auto QUEUE_UPDATE_ERROR_SLEEP_MS        = 1 * 1000;
+static const auto MERGE_SELECTING_SLEEP_MS           = 5 * 1000;
+static const auto MUTATIONS_FINALIZING_SLEEP_MS      = 1 * 1000;
+static const auto MUTATIONS_FINALIZING_IDLE_SLEEP_MS = 5 * 1000;
 
 
 void StorageReplicatedMergeTree::setZooKeeper(zkutil::ZooKeeperPtr zookeeper)
@@ -2284,7 +2285,18 @@ void StorageReplicatedMergeTree::mutationsFinalizingTask()
     }
 
     if (needs_reschedule)
+    {
         mutations_finalizing_task->scheduleAfter(MUTATIONS_FINALIZING_SLEEP_MS);
+    }
+    else
+    {
+        /// Even if no mutations seems to be done or appeared we are trying to
+        /// finalize them in background because manual control the launch of
+        /// this function is error prone. This can lead to mutations that
+        /// processed all the parts but have is_done=0 state for a long time. Or
+        /// killed mutations, which are also considered as undone.
+        mutations_finalizing_task->scheduleAfter(MUTATIONS_FINALIZING_IDLE_SLEEP_MS);
+    }
 }
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now the situation, when mutation finished all parts, but hung up in `is_done=0`, is impossible.