### PR TITLE
Change AWS SDK modules path to ClickHouse-Extras

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -110,16 +110,16 @@
 	branch = v1.25.0
 [submodule "contrib/aws"]
 	path = contrib/aws
-	url = https://github.com/aws/aws-sdk-cpp.git
+	url = https://github.com/ClickHouse-Extras/aws-sdk-cpp.git
 [submodule "aws-c-event-stream"]
 	path = contrib/aws-c-event-stream
-	url = https://github.com/awslabs/aws-c-event-stream.git
+	url = https://github.com/ClickHouse-Extras/aws-c-event-stream.git
 [submodule "aws-c-common"]
 	path = contrib/aws-c-common
-	url = https://github.com/awslabs/aws-c-common.git
+	url = https://github.com/ClickHouse-Extras/aws-c-common.git
 [submodule "aws-checksums"]
 	path = contrib/aws-checksums
-	url = https://github.com/awslabs/aws-checksums.git
+	url = https://github.com/ClickHouse-Extras/aws-checksums.git
 [submodule "contrib/curl"]
 	path = contrib/curl
 	url = https://github.com/curl/curl.git


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use AWS SDK libraries from ClickHouse-Extras

Detailed description / Documentation draft:
Use AWS SDK libraries from ClickHouse-Extras to make patches for S3 interaction.
