### PR TITLE
[WIP] Set databases for dictionaries' creating queries sooner

### DIFF
--- a/src/Databases/DatabaseOrdinary.cpp
+++ b/src/Databases/DatabaseOrdinary.cpp
@@ -84,7 +84,7 @@ namespace
         try
         {
             Poco::File meta_file(metadata_path);
-            auto config = getDictionaryConfigurationFromAST(create_query, database.getDatabaseName());
+            auto config = getDictionaryConfigurationFromAST(create_query);
             time_t modification_time = meta_file.getLastModified().epochTime();
             database.attachDictionary(create_query.table, DictionaryAttachInfo{query, config, modification_time});
         }
@@ -137,6 +137,8 @@ void DatabaseOrdinary::loadStoredObjects(
             if (ast)
             {
                 auto * create_query = ast->as<ASTCreateQuery>();
+                create_query->attach = false;
+                create_query->database = getDatabaseName();
                 file_names[file_name] = ast;
                 total_dictionaries += create_query->is_dictionary;
             }

--- a/src/Databases/DatabaseWithDictionaries.cpp
+++ b/src/Databases/DatabaseWithDictionaries.cpp
@@ -230,13 +230,7 @@ ASTPtr DatabaseWithDictionaries::getCreateDictionaryQueryImpl(
         std::lock_guard lock{mutex};
         auto it = dictionaries.find(dictionary_name);
         if (it != dictionaries.end())
-        {
-            ASTPtr ast = it->second.create_query->clone();
-            auto & create_query = ast->as<ASTCreateQuery &>();
-            create_query.attach = false;
-            create_query.database = getDatabaseName();
-            return ast;
-        }
+            return it->second.create_query;
     }
 
     /// Try to get create query for non-attached dictionary.

--- a/src/Dictionaries/getDictionaryConfigurationFromAST.cpp
+++ b/src/Dictionaries/getDictionaryConfigurationFromAST.cpp
@@ -420,7 +420,7 @@ void checkPrimaryKey(const NamesToTypeNames & all_attrs, const Names & key_attrs
 }
 
 
-DictionaryConfigurationPtr getDictionaryConfigurationFromAST(const ASTCreateQuery & query, const std::string & database_)
+DictionaryConfigurationPtr getDictionaryConfigurationFromAST(const ASTCreateQuery & query)
 {
     checkAST(query);
 
@@ -438,7 +438,7 @@ DictionaryConfigurationPtr getDictionaryConfigurationFromAST(const ASTCreateQuer
 
     AutoPtr<Poco::XML::Element> database_element(xml_document->createElement("database"));
     current_dictionary->appendChild(database_element);
-    AutoPtr<Text> database(xml_document->createTextNode(!database_.empty() ? database_ : query.database));
+    AutoPtr<Text> database(xml_document->createTextNode(query.database));
     database_element->appendChild(database);
 
     AutoPtr<Element> structure_element(xml_document->createElement("structure"));

--- a/src/Dictionaries/getDictionaryConfigurationFromAST.h
+++ b/src/Dictionaries/getDictionaryConfigurationFromAST.h
@@ -10,5 +10,5 @@ using DictionaryConfigurationPtr = Poco::AutoPtr<Poco::Util::AbstractConfigurati
 /// Convert dictionary AST to Poco::AbstractConfiguration
 /// This function is necessary because all loadable objects configuration are Poco::AbstractConfiguration
 /// Can throw exception if query is ill-formed
-DictionaryConfigurationPtr getDictionaryConfigurationFromAST(const ASTCreateQuery & query, const std::string & database_ = "");
+DictionaryConfigurationPtr getDictionaryConfigurationFromAST(const ASTCreateQuery & query);
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Non-significant

Set databases for dictionaries' creating queries immediately after parsing.
