### PR TITLE
extractAllGroups(haystack, re_needle) function

### DIFF
--- a/src/Functions/FunctionsStringRegex.cpp
+++ b/src/Functions/FunctionsStringRegex.cpp
@@ -44,6 +44,7 @@ namespace ErrorCodes
     extern const int TOO_MANY_BYTES;
     extern const int NOT_IMPLEMENTED;
     extern const int HYPERSCAN_CANNOT_SCAN_TEXT;
+    extern const int CANNOT_COMPILE_REGEXP;
 }
 
 /// Is the LIKE expression reduced to finding a substring in a string?
@@ -1081,6 +1082,148 @@ public:
     }
 };
 
+/** Match all groups of given input string with given re, return array of arrays of matches.
+ *
+ *  SELECT extractAllGroups('abc=111, def=222, ghi=333', '("[^"]+"|\\w+)=("[^"]+"|\\w+)')
+ * should produce:
+ *   [['abc','def','ghi'], ['111','333','333']]
+ */
+class FunctionExtractAllGroups : public IFunction
+{
+public:
+    static constexpr auto name = "extractAllGroups";
+    static FunctionPtr create(const Context &) { return std::make_shared<FunctionExtractAllGroups>(); }
+
+    String getName() const override { return name; }
+
+    size_t getNumberOfArguments() const override { return 2; }
+
+    bool useDefaultImplementationForConstants() const override { return false; }
+    ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {1}; }
+
+    DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
+    {
+        FunctionArgumentDescriptors args{
+            {"haystack", isStringOrFixedString, nullptr, "const String or const FixedString"},
+            {"needle", isStringOrFixedString, isColumnConst, "const String or const FixedString"},
+        };
+        validateFunctionArgumentTypes(*this, arguments, args);
+
+        // twodimensional array of strings, each `row` of root array represents a group match.
+        return std::make_shared<DataTypeArray>(std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>()));
+    }
+
+    void executeImpl(Block & block, const ColumnNumbers & arguments, size_t result, size_t /*input_rows_count*/) override
+    {
+        const ColumnPtr column_haystack = block.getByPosition(arguments[0]).column;
+        const ColumnPtr column_needle = block.getByPosition(arguments[1]).column;
+
+        const auto needle = typeid_cast<const ColumnConst &>(*column_needle).getDataAt(0);
+
+        if (needle.size == 0)
+            throw Exception(getName() + " length of 'needle' argument must be greater than 0.", ErrorCodes::ARGUMENT_OUT_OF_BOUND);
+
+        re2::RE2 re{re2::StringPiece(needle.data, needle.size)};
+        if (!re.ok())
+            throw Exception(getName() + " invalid regular expression: " + re.error(), ErrorCodes::CANNOT_COMPILE_REGEXP);
+
+        const size_t groups_count = re.NumberOfCapturingGroups();
+        std::vector<re2::StringPiece> all_matches;
+        // number of times RE matched on each row of haystack column.
+        std::vector<size_t> number_of_matches_per_row;
+
+        // we expect RE to match multiple times on each row, `* 8` is arbitrary to reduce number of re-allocations.
+        all_matches.reserve(column_haystack->size() * groups_count * 8);
+        number_of_matches_per_row.reserve(column_haystack->size());
+
+        // including 0-group, which is the whole RE
+        std::vector<re2::StringPiece> matched_groups(groups_count + 1);
+
+        for (size_t i = 0; i < column_haystack->size(); ++i)
+        {
+            size_t matches_per_row = 0;
+            const auto & current_row = column_haystack->getDataAt(i);
+            const auto haystack = re2::StringPiece(current_row.data, current_row.size);
+
+            // Extract all non-intersecting matches from haystack except group #0.
+            size_t start_pos = 0;
+            while (start_pos < haystack.size() && re.Match(haystack,
+                    start_pos, haystack.size(),
+                    re2::RE2::UNANCHORED,
+                    matched_groups.data(), matched_groups.size()))
+            {
+                // +1 is to exclude group #0 which is whole re match.
+                all_matches.insert(all_matches.end(), matched_groups.begin() + 1, matched_groups.end());
+                start_pos = (matched_groups[0].begin() - haystack.begin()) + matched_groups[0].size();
+
+                ++matches_per_row;
+            }
+
+            number_of_matches_per_row.push_back(matches_per_row);
+        }
+
+        ColumnString::MutablePtr data_col = ColumnString::create();
+        {
+            size_t total_matched_groups_string_len = 0;
+            for (const auto & m : all_matches)
+                total_matched_groups_string_len += m.length();
+
+            data_col->reserve(total_matched_groups_string_len);
+        }
+
+        ColumnArray::ColumnOffsets::MutablePtr nested_offsets_col = ColumnArray::ColumnOffsets::create();
+        ColumnArray::ColumnOffsets::MutablePtr root_offsets_col = ColumnArray::ColumnOffsets::create();
+        nested_offsets_col->reserve(matched_groups.size());
+        root_offsets_col->reserve(groups_count);
+
+        // Re-arrange `all_matches` from:
+        // [
+        //      "ROW 0: 1st group 1st match",
+        //      "ROW 0: 2nd group 1st match",
+        //      ...,
+        //      "ROW 0: 1st group 2nd match",
+        //      "ROW 0: 2nd group 2nd match",
+        //      ...,
+        //      "ROW 1: 1st group 1st match",
+        //      ...
+        // ]
+        //
+        // into column of 2D arrays:
+        // [
+        //      /* all matchig groups from ROW 0 of haystack column */
+        //      ["ROW 0: 1st group 1st match", "ROW 0: 1st group 2nd match", ...],
+        //      ["ROW 0: 2nd group 1st match", "ROW 0: 2nd group 2nd match", ...],
+        //      ...
+        // ],
+        // [
+        //      /* all matchig groups from row 1 of haystack column */
+        //      ["ROW 1: 1st group 1st match", ...],
+        //      ...
+        // ]
+
+        size_t row_offset = 0;
+        for (const auto matches_per_row : number_of_matches_per_row)
+        {
+            const size_t next_row_offset = row_offset + matches_per_row * groups_count;
+            for (size_t group_id = 0; group_id < groups_count; ++group_id)
+            {
+                for (size_t i = row_offset + group_id; i < next_row_offset && i < all_matches.size(); i += groups_count)
+                {
+                    const auto & match = all_matches[i];
+                    data_col->insertData(match.begin(), match.length());
+                }
+                nested_offsets_col->insertValue(data_col->size());
+            }
+            root_offsets_col->insertValue(nested_offsets_col->size());
+            row_offset = next_row_offset;
+        }
+
+        ColumnArray::MutablePtr nested_array_col = ColumnArray::create(std::move(data_col), std::move(nested_offsets_col));
+        ColumnArray::MutablePtr root_array_col = ColumnArray::create(std::move(nested_array_col), std::move(root_offsets_col));
+        block.getByPosition(result).column = std::move(root_array_col);
+    }
+};
+
 struct NameMatch
 {
     static constexpr auto name = "match";
@@ -1198,5 +1341,7 @@ void registerFunctionsStringRegex(FunctionFactory & factory)
     factory.registerFunction<FunctionMultiFuzzyMatchAnyIndex>();
     factory.registerFunction<FunctionMultiFuzzyMatchAllIndices>();
     factory.registerAlias("replace", NameReplaceAll::name, FunctionFactory::CaseInsensitive);
+
+    factory.registerFunction<FunctionExtractAllGroups>();
 }
 }

--- a/tests/queries/0_stateless/01246_extractAllGroups.reference
+++ b/tests/queries/0_stateless/01246_extractAllGroups.reference
@@ -1,0 +1,23 @@
+0 groups, zero matches
+[]
+1 group, multiple matches, String and FixedString
+[['hello','world']]
+[['hello','world']]
+[['hello','world']]
+[['hello','world']]
+[['hello','world']]
+[['hello','world']]
+mutiple groups, multiple matches
+[['abc','def','ghi','"jkl mno"'],['111','222','333','"444 foo bar"']]
+big match
+0	1	0	[]
+260	1	1	[156]
+520	1	3	[156,156,156]
+lots of matches
+0	1	0	0
+260	1	260	260
+520	1	520	520
+lots of groups
+0	100	0	[]
+260	100	2	[1,1]
+520	100	5	[1,1,1,1,1]

--- a/tests/queries/0_stateless/01246_extractAllGroups.sql
+++ b/tests/queries/0_stateless/01246_extractAllGroups.sql
@@ -1,0 +1,51 @@
+-- error cases
+SELECT extractAllGroups();  --{serverError 42} not enough arguments
+SELECT extractAllGroups('hello');  --{serverError 42} not enough arguments
+SELECT extractAllGroups('hello', 123);  --{serverError 43} invalid argument type
+SELECT extractAllGroups(123, 'world');  --{serverError 43}  invalid argument type
+SELECT extractAllGroups('hello world', '((('); --{serverError 427}  invalid re
+SELECT extractAllGroups('hello world', materialize('\\w+')); --{serverError 44} non-cons needle
+
+SELECT '0 groups, zero matches';
+SELECT extractAllGroups('hello world', '\\w+');
+
+SELECT '1 group, multiple matches, String and FixedString';
+SELECT extractAllGroups('hello world', '(\\w+)');
+SELECT extractAllGroups('hello world', CAST('(\\w+)' as FixedString(5)));
+SELECT extractAllGroups(CAST('hello world' AS FixedString(12)), '(\\w+)');
+SELECT extractAllGroups(CAST('hello world' AS FixedString(12)), CAST('(\\w+)' as FixedString(5)));
+SELECT extractAllGroups(materialize(CAST('hello world' AS FixedString(12))), '(\\w+)');
+SELECT extractAllGroups(materialize(CAST('hello world' AS FixedString(12))), CAST('(\\w+)' as FixedString(5)));
+
+SELECT 'mutiple groups, multiple matches';
+SELECT extractAllGroups('abc=111, def=222, ghi=333 "jkl mno"="444 foo bar"', '("[^"]+"|\\w+)=("[^"]+"|\\w+)');
+
+SELECT 'big match';
+SELECT
+	length(haystack), length(matches), length(matches[1]), arrayMap((x) -> length(x), matches[1])
+FROM (
+	SELECT
+		repeat('abcdefghijklmnopqrstuvwxyz', number * 10) AS haystack,
+		extractAllGroups(haystack, '(abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz)') AS matches
+	FROM numbers(3)
+);
+
+SELECT 'lots of matches';
+SELECT
+	length(haystack), length(matches), length(matches[1]), arrayReduce('sum', arrayMap((x) -> length(x), matches[1]))
+FROM (
+	SELECT
+		repeat('abcdefghijklmnopqrstuvwxyz', number * 10) AS haystack,
+		extractAllGroups(haystack, '(\\w)') AS matches
+	FROM numbers(3)
+);
+
+SELECT 'lots of groups';
+SELECT
+	length(haystack), length(matches), length(matches[1]), arrayMap((x) -> length(x), matches[1])
+FROM (
+	SELECT
+		repeat('abcdefghijklmnopqrstuvwxyz', number * 10) AS haystack,
+		extractAllGroups(haystack, repeat('(\\w)', 100)) AS matches
+	FROM numbers(3)
+);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Function that extracts from haystack all matching non-overlapping groups with regular expressions,
and put those into `Array(Array(String))` column.

Detailed description / Documentation draft:
## extractAllGroups(`haystack`, `re_needle`)

Matches `re_needle` against `haystack` and extracts from it all non-overlapping capturing groups.

* `haystack` - `String` or `FixedString` const or non-const column with text to apply regular expression against
* `re_needle` - const `String` or `const FixedString` column with regular expression.
* `return` - an `Array(Array(String))` column of matches, clustered by group_id (1 to N, where N is number of capturing groups in `needle_re`).

Example:
``` sql
SELECT
    extractAllGroups('abc=111, def=222, "jkl mno"="444 foo bar"', '("[^"]+"|\\w+)=("[^"]+"|\\w+)');
```

``` text
┌─extractAllGroups('abc=111, def=222, "jkl mno"="444 foo bar"', '("[^"]+"|\\w+)=("[^"]+"|\\w+)')─┐
│ [['abc','def','"jkl mno"'],['111','222','"444 foo bar"']]                                      │
└────────────────────────────────────────────────────────────────────────────────────────────────┘
```
...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.

closes #9990 
