### PR TITLE
Ability to set logger level for loggers that have non allowed in xml tags symbols

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -11,7 +11,18 @@
         <size>1000M</size>
         <count>10</count>
         <!-- <console>1</console> --> <!-- Default behavior is autodetection (log to console if not daemon mode and is tty) -->
+
+        <!-- Per level overrides:
+
+        For example to suppress logging of the ConfigReloader you can use:
+        -->
+        <!--
+        <levels>
+          <ConfigReloader>none</ConfigReloader>
+        </levels>
+        -->
     </logger>
+
     <!--display_name>production</display_name--> <!-- It is the name that will be shown in the client -->
     <http_port>8123</http_port>
     <tcp_port>9000</tcp_port>

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -12,13 +12,32 @@
         <count>10</count>
         <!-- <console>1</console> --> <!-- Default behavior is autodetection (log to console if not daemon mode and is tty) -->
 
-        <!-- Per level overrides:
+        <!-- Per level overrides (legacy):
 
         For example to suppress logging of the ConfigReloader you can use:
+        NOTE: levels.logger is reserved, see below.
         -->
         <!--
         <levels>
           <ConfigReloader>none</ConfigReloader>
+        </levels>
+        -->
+
+        <!-- Per level overrides:
+
+        For example to suppress logging of the RBAC for default user you can use:
+        (But please note that the logger name maybe changed from version to version, even after minor upgrade)
+        -->
+        <!--
+        <levels>
+          <logger>
+            <name>ContextAccess (default)</name>
+            <level>none</level>
+          </logger>
+          <logger>
+            <name>DatabaseOrdinary (test)</name>
+            <level>none</level>
+          </logger>
         </levels>
         -->
     </logger>


### PR DESCRIPTION
Changelog category (leave one):
- Non-significant (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Ability to set logger level for loggers that have non allowed in xml tags symbols

Example:

```xml
<yandex>
    <logger>
        <!-- But please note that the logger name maybe changed from version to version, even after minor upgrade -->
        <levels>
          <!-- legacy -->
          <ConfigReloader>none</ConfigReloader>

          <!-- new -->
          <logger>
            <name>ContextAccess (default)</name>
            <level>none</level>
          </logger>
          <logger>
            <name>DatabaseOrdinary (test)</name>
            <level>none</level>
          </logger>
        </levels>
    </logger>
</yandex>
```

Refs: #10483

P.S. there is no logger with name `logger`, so this should be ok