### PR TITLE
Force clickhouse-test to use python2

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 from __future__ import print_function
 import sys
 import os


### PR DESCRIPTION
Changelog category (leave one):
- Non-significant (changelog entry is not required)