### PR TITLE
Trash fix multiple dlopen calls in LibraryDictionarySource

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -60,6 +60,7 @@
 #include <Common/SensitiveDataMasker.h>
 #include <Common/ThreadFuzzer.h>
 #include "MySQLHandlerFactory.h"
+#include <Common/SharedLibrary.h>
 
 #if !defined(ARCADIA_BUILD)
 #    include <common/config_common.h>
@@ -1004,6 +1005,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
             dns_cache_updater.reset();
             main_config_reloader.reset();
             users_config_reloader.reset();
+            SharedLibraryFactory::instance().unloadAll();
 
             if (current_connections)
             {

--- a/src/Common/SharedLibrary.cpp
+++ b/src/Common/SharedLibrary.cpp
@@ -46,4 +46,39 @@ void * SharedLibrary::getImpl(const std::string & name, bool no_throw)
 
     return res;
 }
+
+SharedLibraryFactory & SharedLibraryFactory::instance()
+{
+    static SharedLibraryFactory ret;
+    return ret;
+}
+
+
+SharedLibraryPtr SharedLibraryFactory::get(const std::string & path, int flags)
+{
+    std::lock_guard lock(libraries_mutex);
+    if (!libraries.count(path))
+        libraries[path] = std::make_shared<SharedLibrary>(path, flags);
+
+    return libraries[path].get();
+}
+
+
+bool SharedLibraryFactory::tryUnload(const std::string & path)
+{
+    std::lock_guard lock(libraries_mutex);
+    if (libraries.count(path))
+    {
+        libraries.erase(path);
+        return true;
+    }
+    return false;
+}
+
+void SharedLibraryFactory::unloadAll()
+{
+    std::lock_guard lock(libraries_mutex);
+    libraries.clear();
+}
+
 }

--- a/src/Dictionaries/LibraryDictionarySource.cpp
+++ b/src/Dictionaries/LibraryDictionarySource.cpp
@@ -145,7 +145,7 @@ LibraryDictionarySource::LibraryDictionarySource(
             ErrorCodes::FILE_DOESNT_EXIST);
 
     description.init(sample_block);
-    library = std::make_shared<SharedLibrary>(path, RTLD_LAZY
+    library = SharedLibraryFactory::instance().get(path, RTLD_LAZY
 #if defined(RTLD_DEEPBIND) && !defined(ADDRESS_SANITIZER) // Does not exists in FreeBSD. Cannot work with Address Sanitizer.
         | RTLD_DEEPBIND
 #endif

--- a/src/Interpreters/CatBoostModel.cpp
+++ b/src/Interpreters/CatBoostModel.cpp
@@ -439,7 +439,12 @@ private:
 class CatBoostLibHolder: public CatBoostWrapperAPIProvider
 {
 public:
-    explicit CatBoostLibHolder(std::string lib_path_) : lib_path(std::move(lib_path_)), lib(lib_path) { initAPI(); }
+    explicit CatBoostLibHolder(std::string lib_path_)
+        : lib_path(std::move(lib_path_))
+    {
+        lib = SharedLibraryFactory::instance().get(lib_path);
+        initAPI();
+    }
 
     const CatBoostWrapperAPI & getAPI() const override { return api; }
     const std::string & getCurrentPath() const { return lib_path; }
@@ -447,15 +452,15 @@ public:
 private:
     CatBoostWrapperAPI api;
     std::string lib_path;
-    SharedLibrary lib;
+    SharedLibraryPtr lib;
 
     void initAPI();
 
     template <typename T>
-    void load(T& func, const std::string & name) { func = lib.get<T>(name); }
+    void load(T& func, const std::string & name) { func = lib->get<T>(name); }
 
     template <typename T>
-    void tryLoad(T& func, const std::string & name) { func = lib.tryGet<T>(name); }
+    void tryLoad(T& func, const std::string & name) { func = lib->tryGet<T>(name); }
 };
 
 void CatBoostLibHolder::initAPI()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now each library in external library dictionary source will be dlopened once.