### PR TITLE
Move initialization of DatabaseWithDictionaries to constructor.

### DIFF
--- a/src/Databases/DatabaseOrdinary.cpp
+++ b/src/Databases/DatabaseOrdinary.cpp
@@ -179,7 +179,6 @@ void DatabaseOrdinary::loadStoredObjects(
     startupTables(pool);
 
     /// Attach dictionaries.
-    attachToExternalDictionariesLoader(context);
     for (const auto & [name, query] : file_names)
     {
         auto create_query = query->as<const ASTCreateQuery &>();

--- a/src/Interpreters/ExternalLoader.cpp
+++ b/src/Interpreters/ExternalLoader.cpp
@@ -1260,7 +1260,7 @@ ExternalLoader::ExternalLoader(const String & type_name_, Logger * log_)
 
 ExternalLoader::~ExternalLoader() = default;
 
-ext::scope_guard ExternalLoader::addConfigRepository(std::unique_ptr<IExternalLoaderConfigRepository> repository)
+ext::scope_guard ExternalLoader::addConfigRepository(std::unique_ptr<IExternalLoaderConfigRepository> repository) const
 {
     auto * ptr = repository.get();
     String name = ptr->getName();

--- a/src/Interpreters/ExternalLoader.h
+++ b/src/Interpreters/ExternalLoader.h
@@ -86,7 +86,7 @@ public:
     virtual ~ExternalLoader();
 
     /// Adds a repository which will be used to read configurations from.
-    ext::scope_guard addConfigRepository(std::unique_ptr<IExternalLoaderConfigRepository> config_repository);
+    ext::scope_guard addConfigRepository(std::unique_ptr<IExternalLoaderConfigRepository> config_repository) const;
 
     void setConfigSettings(const ExternalLoaderConfigSettings & settings_);
 

--- a/src/Interpreters/ExternalLoaderDatabaseConfigRepository.cpp
+++ b/src/Interpreters/ExternalLoaderDatabaseConfigRepository.cpp
@@ -12,49 +12,46 @@ namespace ErrorCodes
 
 namespace
 {
-    String trimDatabaseName(const std::string & loadable_definition_name, const IDatabase & database)
+    String trimDatabaseName(const std::string & loadable_definition_name, const String & database_name)
     {
-        const auto & dbname = database.getDatabaseName();
-        if (!startsWith(loadable_definition_name, dbname))
+        if (!startsWith(loadable_definition_name, database_name))
             throw Exception(
-                "Loadable '" + loadable_definition_name + "' is not from database '" + database.getDatabaseName(), ErrorCodes::UNKNOWN_DICTIONARY);
+                "Loadable '" + loadable_definition_name + "' is not from database '" + database_name, ErrorCodes::UNKNOWN_DICTIONARY);
         ///    dbname.loadable_name
         ///--> remove <---
-        return loadable_definition_name.substr(dbname.length() + 1);
+        return loadable_definition_name.substr(database_name.length() + 1);
     }
 }
 
 
-ExternalLoaderDatabaseConfigRepository::ExternalLoaderDatabaseConfigRepository(IDatabase & database_, const Context & context_)
-    : name(database_.getDatabaseName())
+ExternalLoaderDatabaseConfigRepository::ExternalLoaderDatabaseConfigRepository(IDatabase & database_)
+    : database_name(database_.getDatabaseName())
     , database(database_)
-    , context(context_)
 {
 }
 
 LoadablesConfigurationPtr ExternalLoaderDatabaseConfigRepository::load(const std::string & loadable_definition_name)
 {
-    return database.getDictionaryConfiguration(trimDatabaseName(loadable_definition_name, database));
+    return database.getDictionaryConfiguration(trimDatabaseName(loadable_definition_name, database_name));
 }
 
 bool ExternalLoaderDatabaseConfigRepository::exists(const std::string & loadable_definition_name)
 {
-    return database.isDictionaryExist(trimDatabaseName(loadable_definition_name, database));
+    return database.isDictionaryExist(trimDatabaseName(loadable_definition_name, database_name));
 }
 
 Poco::Timestamp ExternalLoaderDatabaseConfigRepository::getUpdateTime(const std::string & loadable_definition_name)
 {
-    return database.getObjectMetadataModificationTime(trimDatabaseName(loadable_definition_name, database));
+    return database.getObjectMetadataModificationTime(trimDatabaseName(loadable_definition_name, database_name));
 }
 
 std::set<std::string> ExternalLoaderDatabaseConfigRepository::getAllLoadablesDefinitionNames()
 {
     std::set<std::string> result;
-    const auto & dbname = database.getDatabaseName();
     auto itr = database.getDictionariesIterator();
     while (itr && itr->isValid())
     {
-        result.insert(dbname + "." + itr->name());
+        result.insert(database_name + "." + itr->name());
         itr->next();
     }
     return result;

--- a/src/Interpreters/ExternalLoaderDatabaseConfigRepository.h
+++ b/src/Interpreters/ExternalLoaderDatabaseConfigRepository.h
@@ -2,7 +2,7 @@
 
 #include <Interpreters/IExternalLoaderConfigRepository.h>
 #include <Databases/IDatabase.h>
-#include <Interpreters/Context.h>
+
 
 namespace DB
 {
@@ -12,9 +12,9 @@ namespace DB
 class ExternalLoaderDatabaseConfigRepository : public IExternalLoaderConfigRepository
 {
 public:
-    ExternalLoaderDatabaseConfigRepository(IDatabase & database_, const Context & context_);
+    ExternalLoaderDatabaseConfigRepository(IDatabase & database_);
 
-    const std::string & getName() const override { return name; }
+    const std::string & getName() const override { return database_name; }
 
     std::set<std::string> getAllLoadablesDefinitionNames() override;
 
@@ -25,9 +25,8 @@ public:
     LoadablesConfigurationPtr load(const std::string & loadable_definition_name) override;
 
 private:
-    const String name;
+    const String database_name;
     IDatabase & database;
-    Context context;
 };
 
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Bug Fix

Changelog entry:
This PR fixes possible crash when `createDictionary()` is called before `loadStoredObject()` has finished.

