### PR TITLE
Added `move_ttl_info` to `system.parts`

### DIFF
--- a/src/Storages/System/StorageSystemParts.cpp
+++ b/src/Storages/System/StorageSystemParts.cpp
@@ -54,6 +54,9 @@ StorageSystemParts::StorageSystemParts(const std::string & name_)
         {"hash_of_uncompressed_files",                  std::make_shared<DataTypeString>()},
         {"uncompressed_hash_of_compressed_files",       std::make_shared<DataTypeString>()},
 
+        {"delete_ttl_info_min",                         std::make_shared<DataTypeArray>(std::make_shared<DataTypeDateTime>())},
+        {"delete_ttl_info_max",                         std::make_shared<DataTypeArray>(std::make_shared<DataTypeDateTime>())},
+
         {"move_ttl_info.expression",                    std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>())},
         {"move_ttl_info.min",                           std::make_shared<DataTypeArray>(std::make_shared<DataTypeDateTime>())},
         {"move_ttl_info.max",                           std::make_shared<DataTypeArray>(std::make_shared<DataTypeDateTime>())},
@@ -133,6 +136,12 @@ void StorageSystemParts::processNextStorage(MutableColumns & columns_, const Sto
 
         checksum = helper.uncompressed_hash_of_compressed_files;
         columns_[i++]->insert(getHexUIntLowercase(checksum.first) + getHexUIntLowercase(checksum.second));
+
+        /// delete_ttl_info
+        {
+            columns_[i++]->insert(static_cast<UInt32>(part->ttl_infos.table_ttl.min));
+            columns_[i++]->insert(static_cast<UInt32>(part->ttl_infos.table_ttl.max));
+        }
 
         /// move_ttl_info
         {

--- a/src/Storages/System/StorageSystemParts.cpp
+++ b/src/Storages/System/StorageSystemParts.cpp
@@ -54,8 +54,8 @@ StorageSystemParts::StorageSystemParts(const std::string & name_)
         {"hash_of_uncompressed_files",                  std::make_shared<DataTypeString>()},
         {"uncompressed_hash_of_compressed_files",       std::make_shared<DataTypeString>()},
 
-        {"delete_ttl_info_min",                         std::make_shared<DataTypeArray>(std::make_shared<DataTypeDateTime>())},
-        {"delete_ttl_info_max",                         std::make_shared<DataTypeArray>(std::make_shared<DataTypeDateTime>())},
+        {"delete_ttl_info_min",                         std::make_shared<DataTypeDateTime>()},
+        {"delete_ttl_info_max",                         std::make_shared<DataTypeDateTime>()},
 
         {"move_ttl_info.expression",                    std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>())},
         {"move_ttl_info.min",                           std::make_shared<DataTypeArray>(std::make_shared<DataTypeDateTime>())},


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Added `move_ttl_info` to `system.parts` in order to provide introspection of move TTL functionality.
