### PR TITLE
Increasing timeout when opening a client in tests/0_stateless/helpers/client.py

### DIFF
--- a/tests/queries/0_stateless/helpers/client.py
+++ b/tests/queries/0_stateless/helpers/client.py
@@ -20,7 +20,7 @@ class client(object):
         self.client.eol('\r')
         self.client.logger(log, prefix=name)
         self.client.timeout(20)
-        self.client.expect('[#\$] ', timeout=2)
+        self.client.expect('[#\$] ', timeout=60)
         self.client.send(command)
 
     def __enter__(self):


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Increasing timeout when opening a client in tests/queries/0_stateless/helpers/client.py

Detailed description / Documentation draft:
Increasing timeout when opening a client in tests/queries/0_stateless/helpers/client.py
