### PR TITLE
Update settings.md

### DIFF
--- a/docs/en/operations/server_configuration_parameters/settings.md
+++ b/docs/en/operations/server_configuration_parameters/settings.md
@@ -207,7 +207,7 @@ If `http_port` is specified, the OpenSSL configuration is ignored even if it is 
 **Example**
 
 ``` xml
-<https>0000</https>
+<https_port>0000</https_port>
 ```
 
 ## http\_server\_default\_response {#server_configuration_parameters-http_server_default_response}


### PR DESCRIPTION
https_port not https?

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:
https_port example wrong
...

