### PR TITLE
Add JSONAsStringRowInputFormat

### DIFF
--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -358,11 +358,13 @@ FormatFactory::FormatFactory()
     registerInputFormatProcessorRegexp(*this);
     registerInputFormatProcessorMsgPack(*this);
     registerOutputFormatProcessorMsgPack(*this);
+    registerInputFormatProcessorJSONAsString(*this);
 
     registerFileSegmentationEngineTabSeparated(*this);
     registerFileSegmentationEngineCSV(*this);
     registerFileSegmentationEngineJSONEachRow(*this);
     registerFileSegmentationEngineRegexp(*this);
+    registerFileSegmentationEngineJSONAsString(*this);
 
     registerOutputFormatNull(*this);
 

--- a/src/Formats/FormatFactory.h
+++ b/src/Formats/FormatFactory.h
@@ -181,6 +181,7 @@ void registerFileSegmentationEngineTabSeparated(FormatFactory & factory);
 void registerFileSegmentationEngineCSV(FormatFactory & factory);
 void registerFileSegmentationEngineJSONEachRow(FormatFactory & factory);
 void registerFileSegmentationEngineRegexp(FormatFactory & factory);
+void registerFileSegmentationEngineJSONAsString(FormatFactory & factory);
 
 /// Output only (presentational) formats.
 
@@ -203,5 +204,6 @@ void registerOutputFormatProcessorMarkdown(FormatFactory & factory);
 /// Input only formats.
 void registerInputFormatProcessorCapnProto(FormatFactory & factory);
 void registerInputFormatProcessorRegexp(FormatFactory & factory);
+void registerInputFormatProcessorJSONAsString(FormatFactory & factory);
 
 }

--- a/src/Formats/JSONEachRowUtils.cpp
+++ b/src/Formats/JSONEachRowUtils.cpp
@@ -1,0 +1,67 @@
+#include <IO/ReadHelpers.h>
+#include <common/find_symbols.h>
+
+namespace DB
+{
+
+bool fileSegmentationEngineJSONEachRowImpl(ReadBuffer & in, DB::Memory<> & memory, size_t min_chunk_size)
+{
+    skipWhitespaceIfAny(in);
+
+    char * pos = in.position();
+    size_t balance = 0;
+    bool quotes = false;
+
+    while (loadAtPosition(in, memory, pos)  && (balance || memory.size() + static_cast<size_t>(pos - in.position()) < min_chunk_size))
+    {
+        if (quotes)
+        {
+            pos = find_first_symbols<'\\', '"'>(pos, in.buffer().end());
+            if (pos == in.buffer().end())
+                continue;
+            if (*pos == '\\')
+            {
+                ++pos;
+                if (loadAtPosition(in, memory, pos))
+                    ++pos;
+            }
+            else if (*pos == '"')
+            {
+                ++pos;
+                quotes = false;
+            }
+        }
+        else
+        {
+            pos = find_first_symbols<'{', '}', '\\', '"'>(pos, in.buffer().end());
+            if (pos == in.buffer().end())
+                continue;
+            if (*pos == '{')
+            {
+                ++balance;
+                ++pos;
+            }
+            else if (*pos == '}')
+            {
+                --balance;
+                ++pos;
+            }
+            else if (*pos == '\\')
+            {
+                ++pos;
+                if (loadAtPosition(in, memory, pos))
+                    ++pos;
+            }
+            else if (*pos == '"')
+            {
+                quotes = true;
+                ++pos;
+            }
+        }
+    }
+
+    saveUpToPosition(in, memory, pos);
+    return loadAtPosition(in, memory, pos);
+}
+
+}

--- a/src/Formats/JSONEachRowUtils.cpp
+++ b/src/Formats/JSONEachRowUtils.cpp
@@ -12,7 +12,7 @@ bool fileSegmentationEngineJSONEachRowImpl(ReadBuffer & in, DB::Memory<> & memor
     size_t balance = 0;
     bool quotes = false;
 
-    while (loadAtPosition(in, memory, pos)  && (balance || memory.size() + static_cast<size_t>(pos - in.position()) < min_chunk_size))
+    while (loadAtPosition(in, memory, pos) && (balance || memory.size() + static_cast<size_t>(pos - in.position()) < min_chunk_size))
     {
         if (quotes)
         {

--- a/src/Formats/JSONEachRowUtils.h
+++ b/src/Formats/JSONEachRowUtils.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace DB
+{
+
+bool fileSegmentationEngineJSONEachRowImpl(ReadBuffer & in, DB::Memory<> & memory, size_t min_chunk_size);
+
+}

--- a/src/IO/PeekableReadBuffer.cpp
+++ b/src/IO/PeekableReadBuffer.cpp
@@ -245,6 +245,7 @@ void PeekableReadBuffer::makeContinuousMemoryFromCheckpointToPos()
     memcpy(memory.data() + peeked_size, sub_buf.position(), bytes_to_append);
     sub_buf.position() = pos;
     peeked_size += bytes_to_append;
+    BufferBase::set(memory.data(), peeked_size, peeked_size);
 }
 
 PeekableReadBuffer::~PeekableReadBuffer()

--- a/src/Processors/Formats/Impl/JSONAsStringRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONAsStringRowInputFormat.cpp
@@ -1,0 +1,149 @@
+#include <Processors/Formats/Impl/JSONAsStringRowInputFormat.h>
+#include <Formats/JSONEachRowUtils.h>
+#include <common/find_symbols.h>
+#include <IO/ReadHelpers.h>
+
+namespace DB
+{
+
+extern bool fileSegmentationEngineJSONEachRowImpl(ReadBuffer & in, DB::Memory<> & memory, size_t min_chunk_size);
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+    extern const int INCORRECT_DATA;
+}
+
+JSONAsStringRowInputFormat::JSONAsStringRowInputFormat(const Block & header_, ReadBuffer & in_, Params params_) :
+    IRowInputFormat(header_, in_, std::move(params_)), buf(in)
+{
+    if (header_.columns() > 1 || header_.getDataTypes()[0]->getTypeId() != TypeIndex::String)
+    {
+        throw Exception("This input format is only suitable for tables with a single column of type String.",  ErrorCodes::LOGICAL_ERROR);
+    }
+}
+
+void JSONAsStringRowInputFormat::readJSONObject(IColumn & column)
+{
+    PeekableReadBufferCheckpoint checkpoint{buf};
+    size_t balance = 0;
+    size_t object_size = 0;
+    bool quotes = false;
+
+    if (*buf.position() != '{')
+        throw Exception("JSON object must begin with '{'.",  ErrorCodes::INCORRECT_DATA);
+
+    ++buf.position();
+    ++object_size;
+    ++balance;
+
+    char * pos;
+
+    while (balance)
+    {
+        if (buf.eof())
+            throw Exception("Unexpected end of file while parsing JSON object.",  ErrorCodes::INCORRECT_DATA);
+
+        if (quotes)
+        {
+            pos = find_first_symbols<'"', '\\'>(buf.position(), buf.buffer().end());
+            object_size += pos - buf.position();
+            buf.position() = pos;
+            if (buf.position() == buf.buffer().end())
+                continue;
+            if (*buf.position() == '"')
+            {
+                quotes = false;
+                ++buf.position();
+                ++object_size;
+            }
+            else if (*buf.position() == '\\')
+            {
+                ++buf.position();
+                ++object_size;
+                if (!buf.eof())
+                {
+                    ++buf.position();
+                    ++object_size;
+                }
+            }
+        }
+        else
+        {
+            pos = find_first_symbols<'"', '{', '}', '\\'>(buf.position(), buf.buffer().end());
+            object_size += pos - buf.position();
+            buf.position() = pos;
+            if (buf.position() == buf.buffer().end())
+                continue;
+            if (*buf.position() == '{')
+            {
+                ++balance;
+                ++buf.position();
+                ++object_size;
+            }
+            else if (*buf.position() == '}')
+            {
+                --balance;
+                ++buf.position();
+                ++object_size;
+            }
+            else if (*buf.position() == '\\')
+            {
+                ++buf.position();
+                ++object_size;
+                if (!buf.eof())
+                {
+                    ++buf.position();
+                    ++object_size;
+                }
+            }
+            else if (*buf.position() == '"')
+            {
+                quotes = true;
+                ++buf.position();
+                ++object_size;
+            }
+        }
+    }
+    buf.makeContinuousMemoryFromCheckpointToPos();
+    buf.rollbackToCheckpoint();
+    column.insertData(buf.position(), object_size);
+    buf.position() += object_size;
+}
+
+bool JSONAsStringRowInputFormat::readRow(MutableColumns & columns, RowReadExtension &)
+{
+    skipWhitespaceIfAny(buf);
+
+    if (!buf.eof())
+        readJSONObject(*columns[0]);
+
+    skipWhitespaceIfAny(buf);
+    if (!buf.eof() && *buf.position() == ',')
+        ++buf.position();
+    skipWhitespaceIfAny(buf);
+
+    if (buf.eof())
+        return false;
+
+    return true;
+}
+
+void registerInputFormatProcessorJSONAsString(FormatFactory & factory)
+{
+    factory.registerInputFormatProcessor("JSONAsString", [](
+            ReadBuffer & buf,
+            const Block & sample,
+            const RowInputFormatParams & params,
+            const FormatSettings &)
+    {
+        return std::make_shared<JSONAsStringRowInputFormat>(sample, buf, params);
+    });
+}
+
+void registerFileSegmentationEngineJSONAsString(FormatFactory & factory)
+{
+    factory.registerFileSegmentationEngine("JSONAsString", &fileSegmentationEngineJSONEachRowImpl);
+}
+
+}

--- a/src/Processors/Formats/Impl/JSONAsStringRowInputFormat.h
+++ b/src/Processors/Formats/Impl/JSONAsStringRowInputFormat.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <Processors/Formats/IRowInputFormat.h>
+#include <Formats/FormatFactory.h>
+#include <IO/PeekableReadBuffer.h>
+
+namespace DB
+{
+
+class ReadBuffer;
+
+/// This format parses a sequence of JSON objects separated by newlines, spaces and/or comma.
+/// Each JSON object is parsed as a whole to string.
+/// This format can only parse a table with single field of type String.
+
+class JSONAsStringRowInputFormat : public IRowInputFormat
+{
+public:
+    JSONAsStringRowInputFormat(const Block & header_, ReadBuffer & in_, Params params_);
+
+    bool readRow(MutableColumns & columns, RowReadExtension & ext) override;
+    String getName() const override { return "JSONAsStringRowInputFormat"; }
+
+private:
+    void readJSONObject(IColumn & column);
+
+    PeekableReadBuffer buf;
+};
+
+}

--- a/tests/queries/0_stateless/01232_json_as_string_format.reference
+++ b/tests/queries/0_stateless/01232_json_as_string_format.reference
@@ -1,3 +1,3 @@
-{"id" : 1, "date" : "01.01.2020", "string" : "123{{{\\"\\\\", "array" : [1, 2, 3], "map": {"a" : 1, "b" : 2, "c" : 3}}
-{"id" : 2, "date" : "01.02.2020", "string" : "{another\\" string}}", "array" : [3, 2, 1], "map" : {"z" : 1, "y" : 2, "x" : 3}}
-{"id" : 3, "date" : "01.03.2020", "string" : "one more string", "array" : [3,1,2], "map" : {"{" : 1, "}}" : 2}}
+{\n    "id" : 1,\n    "date" : "01.01.2020",\n    "string" : "123{{{\\"\\\\",\n    "array" : [1, 2, 3],\n    "map": {\n        "a" : 1,\n        "b" : 2,\n        "c" : 3\n    }\n}
+{\n    "id" : 2,\n    "date" : "01.02.2020",\n    "string" : "{another\\"\n    string}}",\n    "array" : [3, 2, 1],\n    "map" : {\n        "z" : 1,\n        "y" : 2, \n        "x" : 3\n    }\n}
+{\n    "id" : 3, \n    "date" : "01.03.2020", \n    "string" : "one more string", \n    "array" : [3,1,2], \n    "map" : {\n        "{" : 1, \n        "}}" : 2\n    }\n}

--- a/tests/queries/0_stateless/01232_json_as_string_format.reference
+++ b/tests/queries/0_stateless/01232_json_as_string_format.reference
@@ -1,0 +1,3 @@
+{"id" : 1, "date" : "01.01.2020", "string" : "123{{{\\"\\\\", "array" : [1, 2, 3], "map": {"a" : 1, "b" : 2, "c" : 3}}
+{"id" : 2, "date" : "01.02.2020", "string" : "{another\\" string}}", "array" : [3, 2, 1], "map" : {"z" : 1, "y" : 2, "x" : 3}}
+{"id" : 3, "date" : "01.03.2020", "string" : "one more string", "array" : [3,1,2], "map" : {"{" : 1, "}}" : 2}}

--- a/tests/queries/0_stateless/01232_json_as_string_format.sh
+++ b/tests/queries/0_stateless/01232_json_as_string_format.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. $CURDIR/../shell_config.sh
+
+$CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS json_as_string";
+
+$CLICKHOUSE_CLIENT --query="CREATE TABLE json_as_string (field String) ENGINE = Memory";
+
+echo '
+{
+    "id" : 1,
+    "date" : "01.01.2020",
+    "string" : "123{{{\"\\",
+    "array" : [1, 2, 3],
+    "map": {
+        "a" : 1,
+        "b" : 2,
+        "c" : 3
+    }
+},
+{
+    "id" : 2,
+    "date" : "01.02.2020",
+    "string" : "{another\"
+    string}}",
+    "array" : [3, 2, 1],
+    "map" : {
+        "z" : 1,
+        "y" : 2, 
+        "x" : 3
+    }
+}
+{
+    "id" : 3, 
+    "date" : "01.03.2020", 
+    "string" : "one more string", 
+    "array" : [3,1,2], 
+    "map" : {
+        "{" : 1, 
+        "}}" : 2
+    }
+}' | $CLICKHOUSE_CLIENT --query="INSERT INTO json_as_string FORMAT JSONAsString";
+
+$CLICKHOUSE_CLIENT --query="SELECT * FROM json_as_string";
+$CLICKHOUSE_CLIENT --query="DROP TABLE json_as_string"
+

--- a/tests/queries/0_stateless/01232_json_as_string_format.sql
+++ b/tests/queries/0_stateless/01232_json_as_string_format.sql
@@ -1,7 +1,0 @@
-DROP TABLE IF EXISTS json_as_string;
-CREATE TABLE json_as_string (field String) ENGINE = Memory;
-
-INSERT INTO json_as_string FORMAT JSONAsString {"id" : 1, "date" : "01.01.2020", "string" : "123{{{\"\\", "array" : [1, 2, 3], "map": {"a" : 1, "b" : 2, "c" : 3}} , {"id" : 2, "date" : "01.02.2020", "string" : "{another\" string}}", "array" : [3, 2, 1], "map" : {"z" : 1, "y" : 2, "x" : 3}} {"id" : 3, "date" : "01.03.2020", "string" : "one more string", "array" : [3,1,2], "map" : {"{" : 1, "}}" : 2}}
-
-SELECT * FROM json_as_string;
-DROP TABLE json_as_string;

--- a/tests/queries/0_stateless/01232_json_as_string_format.sql
+++ b/tests/queries/0_stateless/01232_json_as_string_format.sql
@@ -1,0 +1,7 @@
+DROP TABLE IF EXISTS json_as_string;
+CREATE TABLE json_as_string (field String) ENGINE = Memory;
+
+INSERT INTO json_as_string FORMAT JSONAsString {"id" : 1, "date" : "01.01.2020", "string" : "123{{{\"\\", "array" : [1, 2, 3], "map": {"a" : 1, "b" : 2, "c" : 3}} , {"id" : 2, "date" : "01.02.2020", "string" : "{another\" string}}", "array" : [3, 2, 1], "map" : {"z" : 1, "y" : 2, "x" : 3}} {"id" : 3, "date" : "01.03.2020", "string" : "one more string", "array" : [3,1,2], "map" : {"{" : 1, "}}" : 2}}
+
+SELECT * FROM json_as_string;
+DROP TABLE json_as_string;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add new input format `JSONAsString` that accepts a sequence of JSON objects separated by newlines, spaces and/or commas.

Detailed description / Documentation draft:

### JSONAsString input format
This format parses a sequence of JSON objects separated by newlines, spaces and/or comma.
Each JSON object is parsed as a whole to string. This format can only parse a table with single field of type String.
