### PR TITLE
Improve DROP DNS CACHE

### DIFF
--- a/src/Access/AllowedClientHosts.cpp
+++ b/src/Access/AllowedClientHosts.cpp
@@ -93,12 +93,17 @@ namespace
         return false;
     }
 
+    auto & getIsAddressOfHostCache()
+    {
+        static SimpleCache<decltype(isAddressOfHostImpl), isAddressOfHostImpl> cache;
+        return cache;
+    }
+
     /// Whether a specified address is one of the addresses of a specified host.
     bool isAddressOfHost(const IPAddress & address, const String & host)
     {
         /// We need to cache DNS requests.
-        static SimpleCache<decltype(isAddressOfHostImpl), isAddressOfHostImpl> cache;
-        return cache(address, host);
+        return getIsAddressOfHostCache()(address, host);
     }
 
     /// Helper function for isAddressOfLocalhost().
@@ -160,12 +165,17 @@ namespace
         return host;
     }
 
+    auto & getHostByAddressCache()
+    {
+        static SimpleCache<decltype(getHostByAddressImpl), &getHostByAddressImpl> cache;
+        return cache;
+    }
+
     /// Returns the host name by its address.
     String getHostByAddress(const IPAddress & address)
     {
         /// We need to cache DNS requests.
-        static SimpleCache<decltype(getHostByAddressImpl), &getHostByAddressImpl> cache;
-        return cache(address);
+        return getHostByAddressCache()(address);
     }
 
 
@@ -364,6 +374,12 @@ bool AllowedClientHosts::contains(const IPAddress & client_address) const
             return true;
 
     return false;
+}
+
+void AllowedClientHosts::dropDNSCaches()
+{
+    getIsAddressOfHostCache().drop();
+    getHostByAddressCache().drop();
 }
 
 }

--- a/src/Access/AllowedClientHosts.h
+++ b/src/Access/AllowedClientHosts.h
@@ -114,6 +114,8 @@ public:
     friend bool operator ==(const AllowedClientHosts & lhs, const AllowedClientHosts & rhs);
     friend bool operator !=(const AllowedClientHosts & lhs, const AllowedClientHosts & rhs) { return !(lhs == rhs); }
 
+    static void dropDNSCaches();
+
 private:
     std::vector<IPAddress> addresses;
     std::vector<IPSubnet> subnets;

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -21,6 +21,7 @@
 #include <Interpreters/TextLog.h>
 #include <Interpreters/MetricLog.h>
 #include <Access/ContextAccess.h>
+#include <Access/AllowedClientHosts.h>
 #include <Databases/IDatabase.h>
 #include <Storages/StorageDistributed.h>
 #include <Storages/StorageReplicatedMergeTree.h>
@@ -198,6 +199,7 @@ BlockIO InterpreterSystemQuery::execute()
         case Type::DROP_DNS_CACHE:
             context.checkAccess(AccessType::SYSTEM_DROP_DNS_CACHE);
             DNSResolver::instance().dropCache();
+            AllowedClientHosts::dropDNSCaches();
             /// Reinitialize clusters to update their resolved_addresses
             system_context.reloadClusterConfig();
             break;

--- a/tests/integration/test_host_ip_change/configs/users_with_hostname.xml
+++ b/tests/integration/test_host_ip_change/configs/users_with_hostname.xml
@@ -1,0 +1,13 @@
+<yandex>
+    <users>
+        <default>
+            <networks>
+                <host>node3</host>
+                <host_regexp>[a-z]+4</host_regexp>
+                <ip>::1</ip>
+                <ip>127.0.0.1</ip>
+            </networks>
+            <profile>default</profile>
+        </default>
+    </users>
+</yandex>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
On `SYSTEM DROP DNS CACHE` query also drop caches, which are used to check if user is allowed to connect from some IP addresses

