### PR TITLE
Fix segfault in StorageBuffer when exception on server startup

### DIFF
--- a/src/Core/BackgroundSchedulePool.h
+++ b/src/Core/BackgroundSchedulePool.h
@@ -161,6 +161,8 @@ public:
             task_info->deactivate();
     }
 
+    operator bool () const { return task_info != nullptr; }
+
     BackgroundSchedulePoolTaskInfo * operator->() { return task_info.get(); }
     const BackgroundSchedulePoolTaskInfo * operator->() const { return task_info.get(); }
 

--- a/src/Core/BackgroundSchedulePool.h
+++ b/src/Core/BackgroundSchedulePool.h
@@ -161,7 +161,7 @@ public:
             task_info->deactivate();
     }
 
-    operator bool () const { return task_info != nullptr; }
+    operator bool() const { return task_info != nullptr; }
 
     BackgroundSchedulePoolTaskInfo * operator->() { return task_info.get(); }
     const BackgroundSchedulePoolTaskInfo * operator->() const { return task_info.get(); }

--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -468,6 +468,9 @@ void StorageBuffer::startup()
 
 void StorageBuffer::shutdown()
 {
+    if (!flush_handle)
+        return;
+
     flush_handle->deactivate();
 
     try


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix segfault in StorageBuffer when exception on server startup. Fixes #10550

