### PR TITLE
Fix capnproto version check for capnp::UnalignedFlatArrayMessageReader

### DIFF
--- a/src/Processors/Formats/Impl/CapnProtoRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/CapnProtoRowInputFormat.cpp
@@ -240,7 +240,7 @@ bool CapnProtoRowInputFormat::readRow(MutableColumns & columns, RowReadExtension
 
     auto array = readMessage();
 
-#if CAPNP_VERSION >= 8000
+#if CAPNP_VERSION >= 7000 && CAPNP_VERSION < 8000
     capnp::UnalignedFlatArrayMessageReader msg(array);
 #else
     capnp::FlatArrayMessageReader msg(array);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix `capnproto` version check for `capnp::UnalignedFlatArrayMessageReader`.

...

capnp::UnalignedFlatArrayMessageReader was introduced in https://github.com/capnproto/capnproto/commit/3aa2b2aa02edb1c160b154ad74c08c929a02512a (which is a part of 0.7.0 release). Unfortunately, capnp::UnalignedFlatArrayMessageReader was removed in https://github.com/capnproto/capnproto/commit/3f0fee61c65475c8debfdf8c01f96c2f7e7eeb14 (which is a part of 0.8.0 release)

So change `CAPNP_VERSION` check accordingly.

...
