### PR TITLE
Partial fix of clang build stack unwinding (omit-frame-pointer)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,11 +210,6 @@ set (CMAKE_C_FLAGS_RELWITHDEBINFO        "${CMAKE_C_FLAGS_RELWITHDEBINFO} -O3 ${
 set (CMAKE_C_FLAGS_DEBUG                 "${CMAKE_C_FLAGS_DEBUG} -O0 -g3 -ggdb3 -fno-inline ${CMAKE_C_FLAGS_ADD}")
 
 if (COMPILER_CLANG)
-    # Exception unwinding doesn't work in clang release build without this option
-    # TODO investigate that
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-omit-frame-pointer")
-
     if (OS_DARWIN)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -Wl,-U,_inside_main")
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wl,-U,_inside_main")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -268,6 +268,11 @@ endif ()
 
 add_library(clickhouse_common_io ${clickhouse_common_io_headers} ${clickhouse_common_io_sources})
 
+# Exception unwinding doesn't work in clang release build without this option
+# TODO investigate that
+set_source_files_properties(Interpreters/InterpreterSelectQuery.cpp PROPERTIES COMPILE_FLAGS "-fno-omit-frame-pointer")
+set_source_files_properties(Interpreters/executeQuery.cpp PROPERTIES COMPILE_FLAGS "-fno-omit-frame-pointer")
+
 add_library (clickhouse_malloc OBJECT Common/malloc.cpp)
 set_source_files_properties(Common/malloc.cpp PROPERTIES COMPILE_FLAGS "-fno-builtin")
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Non-significant (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Follow up https://github.com/ClickHouse/ClickHouse/pull/8151

Needed by https://github.com/ClickHouse/ClickHouse/pull/10585