### PR TITLE
Fix UBSan report in HashTable

### DIFF
--- a/contrib/zstd-cmake/CMakeLists.txt
+++ b/contrib/zstd-cmake/CMakeLists.txt
@@ -128,3 +128,4 @@ ENDIF (ZSTD_LEGACY_SUPPORT)
 ADD_LIBRARY(zstd ${Sources} ${Headers})
 
 target_include_directories (zstd PUBLIC ${LIBRARY_DIR})
+target_compile_options(zstd PRIVATE -fno-sanitize=undefined)

--- a/src/AggregateFunctions/AggregateFunctionGroupUniqArray.h
+++ b/src/AggregateFunctions/AggregateFunctionGroupUniqArray.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cassert>
+
 #include <IO/WriteHelpers.h>
 #include <IO/ReadHelpers.h>
 
@@ -139,7 +141,8 @@ static void deserializeAndInsertImpl(StringRef str, IColumn & data_to);
  */
 template <bool is_plain_column = false, typename Tlimit_num_elem = std::false_type>
 class AggregateFunctionGroupUniqArrayGeneric
-    : public IAggregateFunctionDataHelper<AggregateFunctionGroupUniqArrayGenericData, AggregateFunctionGroupUniqArrayGeneric<is_plain_column, Tlimit_num_elem>>
+    : public IAggregateFunctionDataHelper<AggregateFunctionGroupUniqArrayGenericData,
+        AggregateFunctionGroupUniqArrayGeneric<is_plain_column, Tlimit_num_elem>>
 {
     DataTypePtr & input_data_type;
 
@@ -158,6 +161,7 @@ class AggregateFunctionGroupUniqArrayGeneric
         {
             const char * begin = nullptr;
             StringRef serialized = column.serializeValueIntoArena(row_num, arena, begin);
+            assert(serialized.data != nullptr);
             return SerializedKeyHolder{serialized, arena};
         }
     }
@@ -204,9 +208,7 @@ public:
         //TODO: set.reserve(size);
 
         for (size_t i = 0; i < size; ++i)
-        {
             set.insert(readStringBinaryInto(*arena, buf));
-        }
     }
 
     void add(AggregateDataPtr place, const IColumn ** columns, size_t row_num, Arena * arena) const override
@@ -249,9 +251,7 @@ public:
         offsets_to.push_back(offsets_to.back() + set.size());
 
         for (auto & elem : set)
-        {
             deserializeAndInsert(elem.getValue(), data_to);
-        }
     }
 };
 

--- a/src/Columns/ColumnArray.cpp
+++ b/src/Columns/ColumnArray.cpp
@@ -159,13 +159,17 @@ void ColumnArray::insertData(const char * pos, size_t length)
 
     size_t field_size = data->sizeOfValueIfFixed();
 
-    const char * end = pos + length;
     size_t elems = 0;
-    for (; pos + field_size <= end; pos += field_size, ++elems)
-        data->insertData(pos, field_size);
 
-    if (pos != end)
-        throw Exception("Incorrect length argument for method ColumnArray::insertData", ErrorCodes::BAD_ARGUMENTS);
+    if (length)
+    {
+        const char * end = pos + length;
+        for (; pos + field_size <= end; pos += field_size, ++elems)
+            data->insertData(pos, field_size);
+
+        if (pos != end)
+            throw Exception("Incorrect length argument for method ColumnArray::insertData", ErrorCodes::BAD_ARGUMENTS);
+    }
 
     getOffsets().push_back(getOffsets().back() + elems);
 }

--- a/src/Common/HashTable/HashTableKeyHolder.h
+++ b/src/Common/HashTable/HashTableKeyHolder.h
@@ -98,8 +98,7 @@ inline void ALWAYS_INLINE keyHolderDiscardKey(DB::ArenaKeyHolder &)
 namespace DB
 {
 
-/**
-  * SerializedKeyHolder is a key holder for a StringRef key that is already
+/** SerializedKeyHolder is a key holder for a StringRef key that is already
   * serialized to an Arena. The key must be the last allocation in this Arena,
   * and is discarded by rolling back the allocation.
   */


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix UBSan report (adding zero to nullptr) in HashTable that appeared after migration to clang-10.
