### PR TITLE
Fix http code in case of some parse errors.

### DIFF
--- a/programs/server/HTTPHandler.cpp
+++ b/programs/server/HTTPHandler.cpp
@@ -58,6 +58,7 @@ namespace ErrorCodes
     extern const int CANNOT_PARSE_DATE;
     extern const int CANNOT_PARSE_DATETIME;
     extern const int CANNOT_PARSE_NUMBER;
+    extern const int CANNOT_PARSE_INPUT_ASSERTION_FAILED;
     extern const int CANNOT_OPEN_FILE;
     extern const int CANNOT_COMPILE_REGEXP;
 
@@ -105,25 +106,27 @@ static Poco::Net::HTTPResponse::HTTPStatus exceptionCodeToHTTPStatus(int excepti
     using namespace Poco::Net;
 
     if (exception_code == ErrorCodes::REQUIRED_PASSWORD)
+    {
         return HTTPResponse::HTTP_UNAUTHORIZED;
+    }
     else if (exception_code == ErrorCodes::CANNOT_PARSE_TEXT ||
              exception_code == ErrorCodes::CANNOT_PARSE_ESCAPE_SEQUENCE ||
              exception_code == ErrorCodes::CANNOT_PARSE_QUOTED_STRING ||
              exception_code == ErrorCodes::CANNOT_PARSE_DATE ||
              exception_code == ErrorCodes::CANNOT_PARSE_DATETIME ||
              exception_code == ErrorCodes::CANNOT_PARSE_NUMBER ||
-
+             exception_code == ErrorCodes::CANNOT_PARSE_INPUT_ASSERTION_FAILED ||
              exception_code == ErrorCodes::UNKNOWN_ELEMENT_IN_AST ||
              exception_code == ErrorCodes::UNKNOWN_TYPE_OF_AST_NODE ||
              exception_code == ErrorCodes::TOO_DEEP_AST ||
              exception_code == ErrorCodes::TOO_BIG_AST ||
              exception_code == ErrorCodes::UNEXPECTED_AST_STRUCTURE ||
-
              exception_code == ErrorCodes::SYNTAX_ERROR ||
-
              exception_code == ErrorCodes::INCORRECT_DATA ||
              exception_code == ErrorCodes::TYPE_MISMATCH)
+    {
         return HTTPResponse::HTTP_BAD_REQUEST;
+    }
     else if (exception_code == ErrorCodes::UNKNOWN_TABLE ||
              exception_code == ErrorCodes::UNKNOWN_FUNCTION ||
              exception_code == ErrorCodes::UNKNOWN_IDENTIFIER ||
@@ -135,18 +138,27 @@ static Poco::Net::HTTPResponse::HTTPStatus exceptionCodeToHTTPStatus(int excepti
              exception_code == ErrorCodes::UNKNOWN_AGGREGATE_FUNCTION ||
              exception_code == ErrorCodes::UNKNOWN_FORMAT ||
              exception_code == ErrorCodes::UNKNOWN_DATABASE_ENGINE ||
-
              exception_code == ErrorCodes::UNKNOWN_TYPE_OF_QUERY)
+    {
         return HTTPResponse::HTTP_NOT_FOUND;
+    }
     else if (exception_code == ErrorCodes::QUERY_IS_TOO_LARGE)
+    {
         return HTTPResponse::HTTP_REQUESTENTITYTOOLARGE;
+    }
     else if (exception_code == ErrorCodes::NOT_IMPLEMENTED)
+    {
         return HTTPResponse::HTTP_NOT_IMPLEMENTED;
+    }
     else if (exception_code == ErrorCodes::SOCKET_TIMEOUT ||
              exception_code == ErrorCodes::CANNOT_OPEN_FILE)
+    {
         return HTTPResponse::HTTP_SERVICE_UNAVAILABLE;
+    }
     else if (exception_code == ErrorCodes::HTTP_LENGTH_REQUIRED)
+    {
         return HTTPResponse::HTTP_LENGTH_REQUIRED;
+    }
 
     return HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
 }

--- a/src/Common/Exception.h
+++ b/src/Common/Exception.h
@@ -14,10 +14,6 @@ namespace Poco { class Logger; }
 namespace DB
 {
 
-namespace ErrorCodes
-{
-}
-
 class Exception : public Poco::Exception
 {
 public:

--- a/tests/queries/0_stateless/01271_http_code_parse_error.reference
+++ b/tests/queries/0_stateless/01271_http_code_parse_error.reference
@@ -1,0 +1,1 @@
+< HTTP/1.1 400 Bad Request

--- a/tests/queries/0_stateless/01271_http_code_parse_error.sh
+++ b/tests/queries/0_stateless/01271_http_code_parse_error.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. $CURDIR/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS test"
+${CLICKHOUSE_CLIENT} --query "CREATE TABLE test (f1 String, f2 String) ENGINE = Memory"
+
+${CLICKHOUSE_CURL} -vsS "${CLICKHOUSE_URL}" --data-binary 'insert into test (f1, f2) format TSV 1' 2>&1 | grep -F '< HTTP/'
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE test"


### PR DESCRIPTION
This task is requested by Yandex Cloud.

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Change HTTP response code in case of some parse errors to 400 Bad Request. This fix #10636
