### PR TITLE
Fix nullptr dereference in StorageBuffer

### DIFF
--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -81,11 +81,6 @@ StorageBuffer::StorageBuffer(
     setConstraints(constraints_);
 }
 
-StorageBuffer::~StorageBuffer()
-{
-    flush_handle->deactivate();
-}
-
 
 /// Reads from one buffer (from one block) under its mutex.
 class BufferSource : public SourceWithProgress

--- a/src/Storages/StorageBuffer.h
+++ b/src/Storages/StorageBuffer.h
@@ -94,8 +94,6 @@ public:
     std::optional<UInt64> totalRows() const override;
     std::optional<UInt64> totalBytes() const override;
 
-    ~StorageBuffer() override;
-
 private:
     Context global_context;
 


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix nullptr dereference in StorageBuffer if server was shutdown before table startup.

Detailed description / Documentation draft:
This bug was introduced in #10315. The bug was first noticed and reported by @qoega.