### PR TITLE
Fix Arcadia #10569

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
@@ -109,7 +109,7 @@ std::unique_ptr<IMergeTreeIndex> bloomFilterIndexCreatorNew(
         if (!attach)    /// This is for backward compatibility.
             throw Exception("BloomFilter index cannot have more than one parameter.", ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
 
-        arguments->children.erase(++arguments->children.begin(), arguments->children.end());
+        arguments->children = { arguments->children[0] };
     }
 
 


### PR DESCRIPTION
Changelog category (leave one):
- Non-significant (changelog entry is not required)


Arcadia is using different version of libc++.