### PR TITLE
Check for suspicious codecs #4966

### DIFF
--- a/programs/compressor/Compressor.cpp
+++ b/programs/compressor/Compressor.cpp
@@ -63,6 +63,8 @@ void checkAndWriteHeader(DB::ReadBuffer & in, DB::WriteBuffer & out)
 
 int mainEntryClickHouseCompressor(int argc, char ** argv)
 {
+    using namespace DB;
+
     boost::program_options::options_description desc = createOptionsDescription("Allowed options", getTerminalWidth());
     desc.add_options()
         ("help,h", "produce help message")
@@ -99,10 +101,10 @@ int mainEntryClickHouseCompressor(int argc, char ** argv)
             codecs = options["codec"].as<std::vector<std::string>>();
 
         if ((use_lz4hc || use_zstd || use_none) && !codecs.empty())
-            throw DB::Exception("Wrong options, codec flags like --zstd and --codec options are mutually exclusive", DB::ErrorCodes::BAD_ARGUMENTS);
+            throw Exception("Wrong options, codec flags like --zstd and --codec options are mutually exclusive", ErrorCodes::BAD_ARGUMENTS);
 
         if (!codecs.empty() && options.count("level"))
-            throw DB::Exception("Wrong options, --level is not compatible with --codec list", DB::ErrorCodes::BAD_ARGUMENTS);
+            throw Exception("Wrong options, --level is not compatible with --codec list", ErrorCodes::BAD_ARGUMENTS);
 
         std::string method_family = "LZ4";
 
@@ -117,22 +119,21 @@ int mainEntryClickHouseCompressor(int argc, char ** argv)
         if (options.count("level"))
             level = options["level"].as<int>();
 
-
-        DB::CompressionCodecPtr codec;
+        CompressionCodecPtr codec;
         if (!codecs.empty())
         {
-            DB::ParserCodec codec_parser;
+            ParserCodec codec_parser;
 
             std::string codecs_line = boost::algorithm::join(codecs, ",");
-            auto ast = DB::parseQuery(codec_parser, "(" + codecs_line + ")", 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
-            codec = DB::CompressionCodecFactory::instance().get(ast, nullptr);
+            auto ast = parseQuery(codec_parser, "(" + codecs_line + ")", 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
+            codec = CompressionCodecFactory::instance().get(ast, nullptr, false);
         }
         else
-            codec = DB::CompressionCodecFactory::instance().get(method_family, level);
+            codec = CompressionCodecFactory::instance().get(method_family, level, false);
 
 
-        DB::ReadBufferFromFileDescriptor rb(STDIN_FILENO);
-        DB::WriteBufferFromFileDescriptor wb(STDOUT_FILENO);
+        ReadBufferFromFileDescriptor rb(STDIN_FILENO);
+        WriteBufferFromFileDescriptor wb(STDOUT_FILENO);
 
         if (stat_mode)
         {
@@ -142,20 +143,20 @@ int mainEntryClickHouseCompressor(int argc, char ** argv)
         else if (decompress)
         {
             /// Decompression
-            DB::CompressedReadBuffer from(rb);
-            DB::copyData(from, wb);
+            CompressedReadBuffer from(rb);
+            copyData(from, wb);
         }
         else
         {
             /// Compression
-            DB::CompressedWriteBuffer to(wb, codec, block_size);
-            DB::copyData(rb, to);
+            CompressedWriteBuffer to(wb, codec, block_size);
+            copyData(rb, to);
         }
     }
     catch (...)
     {
-        std::cerr << DB::getCurrentExceptionMessage(true);
-        return DB::getCurrentExceptionCode();
+        std::cerr << getCurrentExceptionMessage(true);
+        return getCurrentExceptionCode();
     }
 
     return 0;

--- a/programs/server/TCPHandler.cpp
+++ b/programs/server/TCPHandler.cpp
@@ -1066,14 +1066,16 @@ void TCPHandler::initBlockOutput(const Block & block)
     {
         if (!state.maybe_compressed_out)
         {
-            std::string method = Poco::toUpper(query_context->getSettingsRef().network_compression_method.toString());
+            const Settings & query_settings = query_context->getSettingsRef();
+
+            std::string method = Poco::toUpper(query_settings.network_compression_method.toString());
             std::optional<int> level;
             if (method == "ZSTD")
-                level = query_context->getSettingsRef().network_zstd_compression_level;
+                level = query_settings.network_zstd_compression_level;
 
             if (state.compression == Protocol::Compression::Enable)
                 state.maybe_compressed_out = std::make_shared<CompressedWriteBuffer>(
-                    *out, CompressionCodecFactory::instance().get(method, level));
+                    *out, CompressionCodecFactory::instance().get(method, level, !query_settings.allow_suspicious_codecs));
             else
                 state.maybe_compressed_out = out;
         }

--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -379,7 +379,7 @@ void Connection::sendQuery(
         if (method == "ZSTD")
             level = settings->network_zstd_compression_level;
 
-        compression_codec = CompressionCodecFactory::instance().get(method, level);
+        compression_codec = CompressionCodecFactory::instance().get(method, level, !settings->allow_suspicious_codecs);
     }
     else
         compression_codec = CompressionCodecFactory::instance().getDefaultCodec();

--- a/src/Compression/CompressionCodecDelta.h
+++ b/src/Compression/CompressionCodecDelta.h
@@ -23,6 +23,8 @@ protected:
 
     UInt32 getMaxCompressedDataSize(UInt32 uncompressed_size) const override { return uncompressed_size + 2; }
 
+    bool isCompression() const override { return false; }
+    bool isGenericCompression() const override { return false; }
 
 private:
     UInt8 delta_bytes_size;

--- a/src/Compression/CompressionCodecDoubleDelta.h
+++ b/src/Compression/CompressionCodecDoubleDelta.h
@@ -109,6 +109,9 @@ protected:
 
     UInt32 getMaxCompressedDataSize(UInt32 uncompressed_size) const override;
 
+    bool isCompression() const override { return true; }
+    bool isGenericCompression() const override { return false; }
+
 private:
     UInt8 data_bytes_size;
 };

--- a/src/Compression/CompressionCodecGorilla.h
+++ b/src/Compression/CompressionCodecGorilla.h
@@ -106,6 +106,9 @@ protected:
 
     UInt32 getMaxCompressedDataSize(UInt32 uncompressed_size) const override;
 
+    bool isCompression() const override { return true; }
+    bool isGenericCompression() const override { return false; }
+
 private:
     UInt8 data_bytes_size;
 };

--- a/src/Compression/CompressionCodecLZ4.h
+++ b/src/Compression/CompressionCodecLZ4.h
@@ -21,6 +21,9 @@ public:
 protected:
     UInt32 doCompressData(const char * source, UInt32 source_size, char * dest) const override;
 
+    bool isCompression() const override { return true; }
+    bool isGenericCompression() const override { return true; }
+
 private:
     void doDecompressData(const char * source, UInt32 source_size, char * dest, UInt32 uncompressed_size) const override;
 

--- a/src/Compression/CompressionCodecMultiple.cpp
+++ b/src/Compression/CompressionCodecMultiple.cpp
@@ -17,12 +17,34 @@ namespace DB
 
 namespace ErrorCodes
 {
-extern const int CORRUPTED_DATA;
+    extern const int CORRUPTED_DATA;
+    extern const int BAD_ARGUMENTS;
 }
 
-CompressionCodecMultiple::CompressionCodecMultiple(Codecs codecs_)
+CompressionCodecMultiple::CompressionCodecMultiple(Codecs codecs_, bool sanity_check)
     : codecs(codecs_)
 {
+    if (sanity_check)
+    {
+        /// It does not make sense to apply any transformations after generic compression algorithm
+        /// So, generic compression can be only one and only at the end.
+        bool has_generic_compression = false;
+        for (const auto & codec : codecs)
+        {
+            if (codec->isNone())
+                throw Exception("It does not make sense to have codec NONE along with other compression codecs: " + getCodecDescImpl()
+                    + " (Note: you can enable setting 'allow_suspicious_codecs' to skip this check).",
+                    ErrorCodes::BAD_ARGUMENTS);
+
+            if (has_generic_compression)
+                throw Exception("The combination of compression codecs " + getCodecDescImpl() + " is meaningless, "
+                    " because it does not make sense to apply any transformations after generic compression algorithm."
+                    " (Note: you can enable setting 'allow_suspicious_codecs' to skip this check).", ErrorCodes::BAD_ARGUMENTS);
+
+            if (codec->isGenericCompression())
+                has_generic_compression = true;
+        }
+    }
 }
 
 uint8_t CompressionCodecMultiple::getMethodByte() const
@@ -31,6 +53,11 @@ uint8_t CompressionCodecMultiple::getMethodByte() const
 }
 
 String CompressionCodecMultiple::getCodecDesc() const
+{
+    return getCodecDescImpl();
+}
+
+String CompressionCodecMultiple::getCodecDescImpl() const
 {
     WriteBufferFromOwnString out;
     for (size_t idx = 0; idx < codecs.size(); ++idx)
@@ -118,6 +145,14 @@ void CompressionCodecMultiple::doDecompressData(const char * source, UInt32 sour
     }
 
     memcpy(dest, compressed_buf.data(), decompressed_size);
+}
+
+bool CompressionCodecMultiple::isCompression() const
+{
+    for (const auto & codec : codecs)
+        if (codec->isCompression())
+            return true;
+    return false;
 }
 
 void registerCodecMultiple(CompressionCodecFactory & factory)

--- a/src/Compression/CompressionCodecMultiple.cpp
+++ b/src/Compression/CompressionCodecMultiple.cpp
@@ -37,7 +37,7 @@ CompressionCodecMultiple::CompressionCodecMultiple(Codecs codecs_, bool sanity_c
                     ErrorCodes::BAD_ARGUMENTS);
 
             if (has_generic_compression)
-                throw Exception("The combination of compression codecs " + getCodecDescImpl() + " is meaningless, "
+                throw Exception("The combination of compression codecs " + getCodecDescImpl() + " is meaningless,"
                     " because it does not make sense to apply any transformations after generic compression algorithm."
                     " (Note: you can enable setting 'allow_suspicious_codecs' to skip this check).", ErrorCodes::BAD_ARGUMENTS);
 

--- a/src/Compression/CompressionCodecMultiple.cpp
+++ b/src/Compression/CompressionCodecMultiple.cpp
@@ -33,7 +33,7 @@ CompressionCodecMultiple::CompressionCodecMultiple(Codecs codecs_, bool sanity_c
         {
             if (codec->isNone())
                 throw Exception("It does not make sense to have codec NONE along with other compression codecs: " + getCodecDescImpl()
-                    + " (Note: you can enable setting 'allow_suspicious_codecs' to skip this check).",
+                    + ". (Note: you can enable setting 'allow_suspicious_codecs' to skip this check).",
                     ErrorCodes::BAD_ARGUMENTS);
 
             if (has_generic_compression)

--- a/src/Compression/CompressionCodecMultiple.h
+++ b/src/Compression/CompressionCodecMultiple.h
@@ -9,7 +9,7 @@ class CompressionCodecMultiple final : public ICompressionCodec
 {
 public:
     CompressionCodecMultiple() = default;
-    explicit CompressionCodecMultiple(Codecs codecs_);
+    CompressionCodecMultiple(Codecs codecs_, bool sanity_check);
 
     uint8_t getMethodByte() const override;
 
@@ -24,9 +24,13 @@ protected:
 
     void doDecompressData(const char * source, UInt32 source_size, char * dest, UInt32 decompressed_size) const override;
 
+    bool isCompression() const override;
+    bool isGenericCompression() const override { return false; }
+
 private:
     Codecs codecs;
 
+    String getCodecDescImpl() const;
 };
 
 

--- a/src/Compression/CompressionCodecNone.h
+++ b/src/Compression/CompressionCodecNone.h
@@ -20,6 +20,9 @@ protected:
 
     void doDecompressData(const char * source, UInt32 source_size, char * dest, UInt32 uncompressed_size) const override;
 
+    bool isCompression() const override { return false; }
+    bool isGenericCompression() const override { return false; }
+    bool isNone() const override { return true; }
 };
 
 class CompressionCodecFactory;

--- a/src/Compression/CompressionCodecT64.h
+++ b/src/Compression/CompressionCodecT64.h
@@ -48,6 +48,9 @@ protected:
         return uncompressed_size + MAX_COMPRESSED_BLOCK_SIZE + HEADER_SIZE;
     }
 
+    bool isCompression() const override { return true; }
+    bool isGenericCompression() const override { return false; }
+
 private:
     TypeIndex type_idx;
     Variant variant;

--- a/src/Compression/CompressionCodecZSTD.h
+++ b/src/Compression/CompressionCodecZSTD.h
@@ -26,6 +26,9 @@ protected:
 
     void doDecompressData(const char * source, UInt32 source_size, char * dest, UInt32 uncompressed_size) const override;
 
+    bool isCompression() const override { return true; }
+    bool isGenericCompression() const override { return true; }
+
 private:
     const int level;
 };

--- a/src/Compression/CompressionFactory.cpp
+++ b/src/Compression/CompressionFactory.cpp
@@ -68,8 +68,11 @@ CompressionCodecPtr CompressionCodecFactory::get(const ASTPtr & ast, DataTypePtr
         else if (codecs.size() > 1)
             res = std::make_shared<CompressionCodecMultiple>(codecs, sanity_check);
 
-        if (sanity_check && !res->isCompression())
-            throw Exception("The combination of compression codecs " + res->getCodecDesc() + " does not compress anything."
+        /// Allow to explicitly specify single NONE codec if user don't want any compression.
+        /// But applying other transformations solely without compression (e.g. Delta) does not make sense.
+        if (sanity_check && !res->isCompression() && !res->isNone())
+            throw Exception("Compression codec " + res->getCodecDesc() + " does not compress anything."
+                " You may want to add generic compression algorithm after other transformations, like: " + res->getCodecDesc() + ", LZ4."
                 " (Note: you can enable setting 'allow_suspicious_codecs' to skip this check).",
                 ErrorCodes::BAD_ARGUMENTS);
 

--- a/src/Compression/CompressionFactory.cpp
+++ b/src/Compression/CompressionFactory.cpp
@@ -19,6 +19,7 @@ namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
     extern const int UNKNOWN_CODEC;
+    extern const int BAD_ARGUMENTS;
     extern const int UNEXPECTED_AST_STRUCTURE;
     extern const int DATA_TYPE_CANNOT_HAVE_ARGUMENTS;
 }

--- a/src/Compression/CompressionFactory.h
+++ b/src/Compression/CompressionFactory.h
@@ -40,13 +40,13 @@ public:
     /// Get codec by AST and possible column_type
     /// some codecs can use information about type to improve inner settings
     /// but every codec should be able to work without information about type
-    CompressionCodecPtr get(const ASTPtr & ast, DataTypePtr column_type = nullptr) const;
+    CompressionCodecPtr get(const ASTPtr & ast, DataTypePtr column_type, bool sanity_check) const;
 
     /// Get codec by method byte (no params available)
     CompressionCodecPtr get(const uint8_t byte_code) const;
 
     /// For backward compatibility with config settings
-    CompressionCodecPtr get(const String & family_name, std::optional<int> level) const;
+    CompressionCodecPtr get(const String & family_name, std::optional<int> level, bool sanity_check) const;
 
     /// Register codec with parameters and column type
     void registerCompressionCodecWithType(const String & family_name, std::optional<uint8_t> byte_code, CreatorWithType creator);

--- a/src/Compression/ICompressionCodec.h
+++ b/src/Compression/ICompressionCodec.h
@@ -57,7 +57,16 @@ public:
     static uint8_t readMethod(const char * source);
 
     /// Some codecs may use information about column type which appears after codec creation
-    virtual void useInfoAboutType(DataTypePtr /* data_type */) { }
+    virtual void useInfoAboutType(DataTypePtr /* data_type */) {}
+
+    /// Return true if this codec actually compressing something. Otherwise it can be just transformation that helps compression (e.g. Delta).
+    virtual bool isCompression() const = 0;
+
+    /// Is it a generic compression algorithm like lz4, zstd. Usually it does not make sense to apply generic compression more than single time.
+    virtual bool isGenericCompression() const = 0;
+
+    /// If it does nothing.
+    virtual bool isNone() const { return false; }
 
 protected:
 

--- a/src/Compression/tests/gtest_compressionCodec.cpp
+++ b/src/Compression/tests/gtest_compressionCodec.cpp
@@ -470,7 +470,7 @@ CompressionCodecPtr makeCodec(const std::string & codec_string, const DataTypePt
 
     parser.parse(token_iterator, codec_ast, expected);
 
-    return CompressionCodecFactory::instance().get(codec_ast, data_type);
+    return CompressionCodecFactory::instance().get(codec_ast, data_type, false);
 }
 
 template <typename Timer>

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -265,6 +265,7 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingBool, joined_subquery_requires_alias, true, "Force joined subqueries and table functions to have aliases for correct name qualification.", 0) \
     M(SettingBool, empty_result_for_aggregation_by_empty_set, false, "Return empty result when aggregating without keys on empty set.", 0) \
     M(SettingBool, allow_distributed_ddl, true, "If it is set to true, then a user is allowed to executed distributed DDL queries.", 0) \
+    M(SettingBool, allow_suspicious_codecs, false, "If it is set to true, allow to specify meaningless compression codecs.", 0) \
     M(SettingUInt64, odbc_max_field_size, 1024, "Max size of filed can be read from ODBC dictionary. Long strings are truncated.", 0) \
     M(SettingUInt64, query_profiler_real_time_period_ns, 1000000000, "Period for real clock timer of query profiler (in nanoseconds). Set 0 value to turn off the real clock query profiler. Recommended value is at least 10000000 (100 times a second) for single queries or 1000000000 (once a second) for cluster-wide profiling.", 0) \
     M(SettingUInt64, query_profiler_cpu_time_period_ns, 1000000000, "Period for CPU clock timer of query profiler (in nanoseconds). Set 0 value to turn off the CPU clock query profiler. Recommended value is at least 10000000 (100 times a second) for single queries or 1000000000 (once a second) for cluster-wide profiling.", 0) \

--- a/src/DataStreams/TemporaryFileStream.h
+++ b/src/DataStreams/TemporaryFileStream.h
@@ -37,7 +37,7 @@ struct TemporaryFileStream
                       std::atomic<bool> * is_cancelled, const std::string & codec)
     {
         WriteBufferFromFile file_buf(path);
-        CompressedWriteBuffer compressed_buf(file_buf, CompressionCodecFactory::instance().get(codec, {}));
+        CompressedWriteBuffer compressed_buf(file_buf, CompressionCodecFactory::instance().get(codec, {}, false));
         NativeBlockOutputStream output(compressed_buf, 0, header);
         copyData(input, output, is_cancelled);
     }

--- a/src/Databases/DatabaseOnDisk.cpp
+++ b/src/Databases/DatabaseOnDisk.cpp
@@ -65,7 +65,7 @@ std::pair<String, StoragePtr> createTableFromAST(
     if (!ast_create_query.columns_list || !ast_create_query.columns_list->columns)
         throw Exception("Missing definition of columns.", ErrorCodes::EMPTY_LIST_OF_COLUMNS_PASSED);
 
-    ColumnsDescription columns = InterpreterCreateQuery::getColumnsDescription(*ast_create_query.columns_list->columns, context);
+    ColumnsDescription columns = InterpreterCreateQuery::getColumnsDescription(*ast_create_query.columns_list->columns, context, false);
     ConstraintsDescription constraints = InterpreterCreateQuery::getConstraintsDescription(ast_create_query.columns_list->constraints);
 
     return

--- a/src/Interpreters/InterpreterAlterQuery.cpp
+++ b/src/Interpreters/InterpreterAlterQuery.cpp
@@ -56,7 +56,7 @@ BlockIO InterpreterAlterQuery::execute()
     LiveViewCommands live_view_commands;
     for (ASTAlterCommand * command_ast : alter.command_list->commands)
     {
-        if (auto alter_command = AlterCommand::parse(command_ast))
+        if (auto alter_command = AlterCommand::parse(command_ast, !context.getSettingsRef().allow_suspicious_codecs))
             alter_commands.emplace_back(std::move(*alter_command));
         else if (auto partition_command = PartitionCommand::parse(command_ast))
         {

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -267,7 +267,8 @@ ASTPtr InterpreterCreateQuery::formatConstraints(const ConstraintsDescription & 
     return res;
 }
 
-ColumnsDescription InterpreterCreateQuery::getColumnsDescription(const ASTExpressionList & columns_ast, const Context & context)
+ColumnsDescription InterpreterCreateQuery::getColumnsDescription(
+    const ASTExpressionList & columns_ast, const Context & context, bool sanity_check_compression_codecs)
 {
     /// First, deduce implicit types.
 
@@ -355,7 +356,7 @@ ColumnsDescription InterpreterCreateQuery::getColumnsDescription(const ASTExpres
             column.comment = col_decl.comment->as<ASTLiteral &>().value.get<String>();
 
         if (col_decl.codec)
-            column.codec = CompressionCodecFactory::instance().get(col_decl.codec, column.type);
+            column.codec = CompressionCodecFactory::instance().get(col_decl.codec, column.type, sanity_check_compression_codecs);
 
         if (col_decl.ttl)
             column.ttl = col_decl.ttl;
@@ -390,7 +391,10 @@ InterpreterCreateQuery::TableProperties InterpreterCreateQuery::setProperties(AS
     if (create.columns_list)
     {
         if (create.columns_list->columns)
-            properties.columns = getColumnsDescription(*create.columns_list->columns, context);
+        {
+            bool sanity_check_compression_codecs = !create.attach && !context.getSettingsRef().allow_suspicious_codecs;
+            properties.columns = getColumnsDescription(*create.columns_list->columns, context, sanity_check_compression_codecs);
+        }
 
         if (create.columns_list->indices)
             for (const auto & index : create.columns_list->indices->children)

--- a/src/Interpreters/InterpreterCreateQuery.h
+++ b/src/Interpreters/InterpreterCreateQuery.h
@@ -46,7 +46,7 @@ public:
     }
 
     /// Obtain information about columns, their types, default values and column comments, for case when columns in CREATE query is specified explicitly.
-    static ColumnsDescription getColumnsDescription(const ASTExpressionList & columns, const Context & context);
+    static ColumnsDescription getColumnsDescription(const ASTExpressionList & columns, const Context & context, bool sanity_check_compression_codecs);
     static ConstraintsDescription getConstraintsDescription(const ASTExpressionList * constraints);
 
 private:

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -343,7 +343,7 @@ StoragePtr InterpreterSystemQuery::tryRestartReplica(const StorageID & replica, 
     auto & create = create_ast->as<ASTCreateQuery &>();
     create.attach = true;
 
-    auto columns = InterpreterCreateQuery::getColumnsDescription(*create.columns_list->columns, system_context);
+    auto columns = InterpreterCreateQuery::getColumnsDescription(*create.columns_list->columns, system_context, false);
     auto constraints = InterpreterCreateQuery::getConstraintsDescription(create.columns_list->constraints);
     auto data_path = database->getTableDataPath(create);
 

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -44,7 +44,7 @@ namespace ErrorCodes
 }
 
 
-std::optional<AlterCommand> AlterCommand::parse(const ASTAlterCommand * command_ast)
+std::optional<AlterCommand> AlterCommand::parse(const ASTAlterCommand * command_ast, bool sanity_check_compression_codecs)
 {
     const DataTypeFactory & data_type_factory = DataTypeFactory::instance();
     const CompressionCodecFactory & compression_codec_factory = CompressionCodecFactory::instance();
@@ -75,7 +75,7 @@ std::optional<AlterCommand> AlterCommand::parse(const ASTAlterCommand * command_
         }
 
         if (ast_col_decl.codec)
-            command.codec = compression_codec_factory.get(ast_col_decl.codec, command.data_type);
+            command.codec = compression_codec_factory.get(ast_col_decl.codec, command.data_type, sanity_check_compression_codecs);
 
         if (command_ast->column)
             command.after_column = getIdentifierName(command_ast->column);
@@ -131,7 +131,7 @@ std::optional<AlterCommand> AlterCommand::parse(const ASTAlterCommand * command_
             command.ttl = ast_col_decl.ttl;
 
         if (ast_col_decl.codec)
-            command.codec = compression_codec_factory.get(ast_col_decl.codec, command.data_type);
+            command.codec = compression_codec_factory.get(ast_col_decl.codec, command.data_type, sanity_check_compression_codecs);
 
         command.if_exists = command_ast->if_exists;
 

--- a/src/Storages/AlterCommands.h
+++ b/src/Storages/AlterCommands.h
@@ -100,7 +100,7 @@ struct AlterCommand
     /// Target column name
     String rename_to;
 
-    static std::optional<AlterCommand> parse(const ASTAlterCommand * command);
+    static std::optional<AlterCommand> parse(const ASTAlterCommand * command, bool sanity_check_compression_codecs);
 
     void apply(StorageInMemoryMetadata & metadata) const;
 

--- a/src/Storages/ColumnsDescription.cpp
+++ b/src/Storages/ColumnsDescription.cpp
@@ -120,7 +120,7 @@ void ColumnDescription::readText(ReadBuffer & buf)
             comment = col_ast->comment->as<ASTLiteral &>().value.get<String>();
 
         if (col_ast->codec)
-            codec = CompressionCodecFactory::instance().get(col_ast->codec, type);
+            codec = CompressionCodecFactory::instance().get(col_ast->codec, type, false);
 
         if (col_ast->ttl)
             ttl = col_ast->ttl;

--- a/src/Storages/CompressionCodecSelector.h
+++ b/src/Storages/CompressionCodecSelector.h
@@ -91,7 +91,7 @@ public:
 
         for (const auto & element : elements)
             if (element.check(part_size, part_size_ratio))
-                res = factory.get(element.family_name, element.level);
+                res = factory.get(element.family_name, element.level, false);
 
         return res;
     }

--- a/src/TableFunctions/parseColumnsListForTableFunction.cpp
+++ b/src/TableFunctions/parseColumnsListForTableFunction.cpp
@@ -31,7 +31,7 @@ ColumnsDescription parseColumnsListFromString(const std::string & structure, con
     if (!columns_list)
         throw Exception("Could not cast AST to ASTExpressionList", ErrorCodes::LOGICAL_ERROR);
 
-    return InterpreterCreateQuery::getColumnsDescription(*columns_list, context);
+    return InterpreterCreateQuery::getColumnsDescription(*columns_list, context, !context.getSettingsRef().allow_suspicious_codecs);
 }
 
 }

--- a/tests/integration/test_non_default_compression/configs/allow_suspicious_codecs.xml
+++ b/tests/integration/test_non_default_compression/configs/allow_suspicious_codecs.xml
@@ -1,7 +1,7 @@
 <yandex>
     <profiles>
         <default>
-            <use_uncompressed_cache>1</use_uncompressed_cache>
+            <allow_suspicious_codecs>1</allow_suspicious_codecs>
         </default>
     </profiles>
 </yandex>

--- a/tests/integration/test_non_default_compression/test.py
+++ b/tests/integration/test_non_default_compression/test.py
@@ -7,11 +7,11 @@ from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 
-node1 = cluster.add_instance('node1', main_configs=['configs/zstd_compression_by_default.xml'])
-node2 = cluster.add_instance('node2', main_configs=['configs/lz4hc_compression_by_default.xml'])
-node3 = cluster.add_instance('node3', main_configs=['configs/custom_compression_by_default.xml'])
-node4 = cluster.add_instance('node4', user_configs=['configs/enable_uncompressed_cache.xml'])
-node5 = cluster.add_instance('node5', main_configs=['configs/zstd_compression_by_default.xml'], user_configs=['configs/enable_uncompressed_cache.xml'])
+node1 = cluster.add_instance('node1', main_configs=['configs/zstd_compression_by_default.xml'], user_configs=['configs/allow_suspicious_codecs.xml'])
+node2 = cluster.add_instance('node2', main_configs=['configs/lz4hc_compression_by_default.xml'], user_configs=['configs/allow_suspicious_codecs.xml'])
+node3 = cluster.add_instance('node3', main_configs=['configs/custom_compression_by_default.xml'], user_configs=['configs/allow_suspicious_codecs.xml'])
+node4 = cluster.add_instance('node4', user_configs=['configs/enable_uncompressed_cache.xml', 'configs/allow_suspicious_codecs.xml'])
+node5 = cluster.add_instance('node5', main_configs=['configs/zstd_compression_by_default.xml'], user_configs=['configs/enable_uncompressed_cache.xml', 'configs/allow_suspicious_codecs.xml'])
 
 @pytest.fixture(scope="module")
 def start_cluster():

--- a/tests/queries/0_stateless/00804_test_alter_compression_codecs.sql
+++ b/tests/queries/0_stateless/00804_test_alter_compression_codecs.sql
@@ -28,6 +28,7 @@ SELECT * FROM alter_compression_codec ORDER BY id;
 OPTIMIZE TABLE alter_compression_codec FINAL;
 SELECT * FROM alter_compression_codec ORDER BY id;
 
+SET allow_suspicious_codecs = 1;
 ALTER TABLE alter_compression_codec MODIFY COLUMN alter_column CODEC(ZSTD, LZ4HC, LZ4, LZ4, NONE);
 SELECT compression_codec FROM system.columns WHERE database = currentDatabase() AND table = 'alter_compression_codec' AND name = 'alter_column';
 

--- a/tests/queries/0_stateless/00804_test_custom_compression_codecs.sql
+++ b/tests/queries/0_stateless/00804_test_custom_compression_codecs.sql
@@ -1,4 +1,5 @@
 SET send_logs_level = 'none';
+SET allow_suspicious_codecs = 1;
 
 DROP TABLE IF EXISTS compression_codec;
 

--- a/tests/queries/0_stateless/00804_test_custom_compression_codes_log_storages.sql
+++ b/tests/queries/0_stateless/00804_test_custom_compression_codes_log_storages.sql
@@ -1,4 +1,5 @@
 SET send_logs_level = 'none';
+SET allow_suspicious_codecs = 1;
 
 -- copy-paste for storage log
 

--- a/tests/queries/0_stateless/00804_test_delta_codec_no_type_alter.sql
+++ b/tests/queries/0_stateless/00804_test_delta_codec_no_type_alter.sql
@@ -1,4 +1,5 @@
 SET send_logs_level = 'none';
+SET allow_suspicious_codecs = 1;
 
 DROP TABLE IF EXISTS delta_codec_for_alter;
 CREATE TABLE delta_codec_for_alter (date Date, x UInt32 Codec(Delta), s FixedString(128)) ENGINE = MergeTree ORDER BY tuple();

--- a/tests/queries/0_stateless/00910_zookeeper_custom_compression_codecs_replicated.sql
+++ b/tests/queries/0_stateless/00910_zookeeper_custom_compression_codecs_replicated.sql
@@ -1,4 +1,5 @@
 SET send_logs_level = 'none';
+SET allow_suspicious_codecs = 1;
 
 DROP TABLE IF EXISTS test.compression_codec_replicated1;
 DROP TABLE IF EXISTS test.compression_codec_replicated2;

--- a/tests/queries/0_stateless/00910_zookeeper_test_alter_compression_codecs.sql
+++ b/tests/queries/0_stateless/00910_zookeeper_test_alter_compression_codecs.sql
@@ -46,6 +46,7 @@ SYSTEM SYNC REPLICA alter_compression_codec1;
 SELECT * FROM alter_compression_codec1 ORDER BY id;
 SELECT * FROM alter_compression_codec2 ORDER BY id;
 
+SET allow_suspicious_codecs = 1;
 ALTER TABLE alter_compression_codec1 MODIFY COLUMN alter_column CODEC(ZSTD, LZ4HC, LZ4, LZ4, NONE);
 SYSTEM SYNC REPLICA alter_compression_codec1;
 SYSTEM SYNC REPLICA alter_compression_codec2;

--- a/tests/queries/0_stateless/00926_adaptive_index_granularity_pk.sql
+++ b/tests/queries/0_stateless/00926_adaptive_index_granularity_pk.sql
@@ -57,6 +57,7 @@ SET force_primary_key = 0;
 DROP TABLE IF EXISTS large_alter_table_00926;
 DROP TABLE IF EXISTS store_of_hash_00926;
 
+SET allow_suspicious_codecs = 1;
 CREATE TABLE large_alter_table_00926 (
     somedate Date CODEC(ZSTD, ZSTD, ZSTD(12), LZ4HC(12)),
     id UInt64 CODEC(LZ4, ZSTD, NONE, LZ4HC),

--- a/tests/queries/0_stateless/00957_delta_diff_bug.sql
+++ b/tests/queries/0_stateless/00957_delta_diff_bug.sql
@@ -1,3 +1,5 @@
+SET allow_suspicious_codecs = 1;
+
 DROP TABLE IF EXISTS segfault_table;
 
 CREATE TABLE segfault_table (id UInt16 CODEC(Delta(2))) ENGINE MergeTree() order by tuple();

--- a/tests/queries/0_stateless/01272_suspicious_codecs.reference
+++ b/tests/queries/0_stateless/01272_suspicious_codecs.reference
@@ -1,0 +1,16 @@
+CREATE TABLE default.codecs1\n(\n    `a` UInt8 CODEC(NONE, NONE)\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.codecs2\n(\n    `a` UInt8 CODEC(NONE, LZ4)\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.codecs3\n(\n    `a` UInt8 CODEC(LZ4, NONE)\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.codecs4\n(\n    `a` UInt8 CODEC(LZ4, LZ4)\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.codecs5\n(\n    `a` UInt8 CODEC(LZ4, ZSTD(1))\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.codecs6\n(\n    `a` UInt8 CODEC(Delta(1))\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.codecs7\n(\n    `a` UInt8 CODEC(Delta(1), Delta(1))\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.codecs8\n(\n    `a` UInt8 CODEC(LZ4, Delta(1))\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.codecs1\n(\n    `a` UInt8 CODEC(NONE, NONE)\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.codecs2\n(\n    `a` UInt8 CODEC(NONE, LZ4)\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.codecs3\n(\n    `a` UInt8 CODEC(LZ4, NONE)\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.codecs4\n(\n    `a` UInt8 CODEC(LZ4, LZ4)\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.codecs5\n(\n    `a` UInt8 CODEC(LZ4, ZSTD(1))\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.codecs6\n(\n    `a` UInt8 CODEC(Delta(1))\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.codecs7\n(\n    `a` UInt8 CODEC(Delta(1), Delta(1))\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.codecs8\n(\n    `a` UInt8 CODEC(LZ4, Delta(1))\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192

--- a/tests/queries/0_stateless/01272_suspicious_codecs.sql
+++ b/tests/queries/0_stateless/01272_suspicious_codecs.sql
@@ -1,0 +1,107 @@
+DROP TABLE IF EXISTS codecs;
+
+-- test what should work
+
+CREATE TABLE codecs
+(
+    a UInt8 CODEC(LZ4),
+    b UInt16 CODEC(ZSTD),
+    c Float32 CODEC(Gorilla),
+    d UInt8 CODEC(Delta, LZ4),
+    e Float64 CODEC(Gorilla, ZSTD),
+    f UInt32 CODEC(Delta, Delta, Gorilla),
+    g DateTime CODEC(DoubleDelta),
+    h DateTime64 CODEC(DoubleDelta, LZ4),
+    i String CODEC(NONE)
+) ENGINE = MergeTree ORDER BY tuple();
+
+DROP TABLE codecs;
+
+-- test what should not work
+
+CREATE TABLE codecs (a UInt8 CODEC(NONE, NONE)) ENGINE = MergeTree ORDER BY tuple(); -- { serverError 36 }
+CREATE TABLE codecs (a UInt8 CODEC(NONE, LZ4)) ENGINE = MergeTree ORDER BY tuple(); -- { serverError 36 }
+CREATE TABLE codecs (a UInt8 CODEC(LZ4, NONE)) ENGINE = MergeTree ORDER BY tuple(); -- { serverError 36 }
+CREATE TABLE codecs (a UInt8 CODEC(LZ4, LZ4)) ENGINE = MergeTree ORDER BY tuple(); -- { serverError 36 }
+CREATE TABLE codecs (a UInt8 CODEC(LZ4, ZSTD)) ENGINE = MergeTree ORDER BY tuple(); -- { serverError 36 }
+CREATE TABLE codecs (a UInt8 CODEC(Delta)) ENGINE = MergeTree ORDER BY tuple(); -- { serverError 36 }
+CREATE TABLE codecs (a UInt8 CODEC(Delta, Delta)) ENGINE = MergeTree ORDER BY tuple(); -- { serverError 36 }
+CREATE TABLE codecs (a UInt8 CODEC(LZ4, Delta)) ENGINE = MergeTree ORDER BY tuple(); -- { serverError 36 }
+
+-- test that sanity check is not performed in ATTACH query
+
+DROP TABLE IF EXISTS codecs1;
+DROP TABLE IF EXISTS codecs2;
+DROP TABLE IF EXISTS codecs3;
+DROP TABLE IF EXISTS codecs4;
+DROP TABLE IF EXISTS codecs5;
+DROP TABLE IF EXISTS codecs6;
+DROP TABLE IF EXISTS codecs7;
+DROP TABLE IF EXISTS codecs8;
+
+SET allow_suspicious_codecs = 1;
+
+CREATE TABLE codecs1 (a UInt8 CODEC(NONE, NONE)) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE codecs2 (a UInt8 CODEC(NONE, LZ4)) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE codecs3 (a UInt8 CODEC(LZ4, NONE)) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE codecs4 (a UInt8 CODEC(LZ4, LZ4)) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE codecs5 (a UInt8 CODEC(LZ4, ZSTD)) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE codecs6 (a UInt8 CODEC(Delta)) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE codecs7 (a UInt8 CODEC(Delta, Delta)) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE codecs8 (a UInt8 CODEC(LZ4, Delta)) ENGINE = MergeTree ORDER BY tuple();
+
+SET allow_suspicious_codecs = 0;
+
+SHOW CREATE TABLE codecs1;
+SHOW CREATE TABLE codecs2;
+SHOW CREATE TABLE codecs3;
+SHOW CREATE TABLE codecs4;
+SHOW CREATE TABLE codecs5;
+SHOW CREATE TABLE codecs6;
+SHOW CREATE TABLE codecs7;
+SHOW CREATE TABLE codecs8;
+
+DETACH TABLE codecs1;
+DETACH TABLE codecs2;
+DETACH TABLE codecs3;
+DETACH TABLE codecs4;
+DETACH TABLE codecs5;
+DETACH TABLE codecs6;
+DETACH TABLE codecs7;
+DETACH TABLE codecs8;
+
+ATTACH TABLE codecs1;
+ATTACH TABLE codecs2;
+ATTACH TABLE codecs3;
+ATTACH TABLE codecs4;
+ATTACH TABLE codecs5;
+ATTACH TABLE codecs6;
+ATTACH TABLE codecs7;
+ATTACH TABLE codecs8;
+
+SHOW CREATE TABLE codecs1;
+SHOW CREATE TABLE codecs2;
+SHOW CREATE TABLE codecs3;
+SHOW CREATE TABLE codecs4;
+SHOW CREATE TABLE codecs5;
+SHOW CREATE TABLE codecs6;
+SHOW CREATE TABLE codecs7;
+SHOW CREATE TABLE codecs8;
+
+SELECT * FROM codecs1;
+SELECT * FROM codecs2;
+SELECT * FROM codecs3;
+SELECT * FROM codecs4;
+SELECT * FROM codecs5;
+SELECT * FROM codecs6;
+SELECT * FROM codecs7;
+SELECT * FROM codecs8;
+
+DROP TABLE codecs1;
+DROP TABLE codecs2;
+DROP TABLE codecs3;
+DROP TABLE codecs4;
+DROP TABLE codecs5;
+DROP TABLE codecs6;
+DROP TABLE codecs7;
+DROP TABLE codecs8;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added a check for meaningless codecs and a setting `allow_suspicious_codecs` to control this check. This closes #4966