### PR TITLE
Disable buffering of the stderr (C file IO)

### DIFF
--- a/base/daemon/BaseDaemon.cpp
+++ b/base/daemon/BaseDaemon.cpp
@@ -547,6 +547,9 @@ void BaseDaemon::initialize(Application & self)
         std::string stderr_path = config().getString("logger.stderr", log_path + "/stderr.log");
         if (!freopen(stderr_path.c_str(), "a+", stderr))
             throw Poco::OpenFileException("Cannot attach stderr to " + stderr_path);
+
+        /// Disable buffering for stderr
+        setbuf(stderr, nullptr);
     }
 
     if ((!log_path.empty() && is_daemon) || config().has("logger.stdout"))


### PR DESCRIPTION
Changelog category (leave one):
- Non-significant (changelog entry is not required)

There are some 3d party libs that are used by clickhouse that uses
stderr, for example rdkafka, and buffering of rdkafka logs may be a
problem in tests at least.