### PR TITLE
Fixing and re-enabling 00979_live_view_watch_continuous_aggregates.py test.

### DIFF
--- a/tests/queries/0_stateless/00979_live_view_watch_continuous_aggregates.py
+++ b/tests/queries/0_stateless/00979_live_view_watch_continuous_aggregates.py
@@ -30,6 +30,7 @@ with client(name='client1>', log=log) as client1, client(name='client2>', log=lo
     client1.send('CREATE LIVE VIEW test.lv AS SELECT toStartOfDay(time) AS day, location, avg(temperature) FROM test.mt GROUP BY day, location ORDER BY day, location')
     client1.expect(prompt)
     client1.send('WATCH test.lv FORMAT CSV')
+    client1.expect(r'0.*1' + end_of_block)
     client2.send("INSERT INTO test.mt VALUES ('2019-01-01 00:00:00','New York',60),('2019-01-01 00:10:00','New York',70)")
     client2.expect(prompt)
     client1.expect(r'"2019-01-01 00:00:00","New York",65,2')

--- a/tests/queries/0_stateless/helpers/uexpect.py
+++ b/tests/queries/0_stateless/helpers/uexpect.py
@@ -39,8 +39,8 @@ class ExpectTimeoutError(Exception):
         if self.pattern:
             s += 'for %s ' % repr(self.pattern.pattern)
         if self.buffer:
-            s += 'buffer %s ' % repr(self.buffer[:])
-            s += 'or \'%s\'' % ','.join(['%x' % ord(c) for c in self.buffer[:]])
+            s += 'buffer %s' % repr(self.buffer[:])
+            #s += ' or \'%s\'' % ','.join(['%x' % ord(c) for c in self.buffer[:]])
         return s
 
 class IO(object):


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixing and re-enabling 00979_live_view_watch_continuous_aggregates.py test.

Detailed description / Documentation draft:
Fixing and re-enabling 00979_live_view_watch_continuous_aggregates.py test.
Updating uexpect.py to remove noisy hex output when expect fails.

