### PR TITLE
Fix alter-mutations assignment

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -1861,10 +1861,17 @@ std::optional<std::pair<Int64, int>> ReplicatedMergeTreeMergePredicate::getDesir
     for (auto [mutation_version, mutation_status] : in_partition->second)
     {
         max_version = mutation_version;
-        if (mutation_version > current_version && mutation_status->entry->alter_version != -1)
+        if (mutation_status->entry->isAlterMutation())
         {
-            alter_version = mutation_status->entry->alter_version;
-            break;
+            /// We want to assign mutations for part which version is bigger
+            /// than part current version. But it doesn't make sence to assign
+            /// more fresh versions of alter-mutations if previous alter still
+            /// not done because alters execute one by one in strict order.
+            if (mutation_version > current_version || !mutation_status->is_done)
+            {
+                alter_version = mutation_status->entry->alter_version;
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bug which locks concurrent alters when table has a lot of parts.