### PR TITLE
Update zstd to 1.4.4

### DIFF
--- a/contrib/zstd-cmake/CMakeLists.txt
+++ b/contrib/zstd-cmake/CMakeLists.txt
@@ -49,7 +49,10 @@ FILE(READ ${LIBRARY_DIR}/zstd.h HEADER_CONTENT)
 GetLibraryVersion("${HEADER_CONTENT}" LIBVER_MAJOR LIBVER_MINOR LIBVER_RELEASE)
 MESSAGE(STATUS "ZSTD VERSION ${LIBVER_MAJOR}.${LIBVER_MINOR}.${LIBVER_RELEASE}")
 
+# cd contrib/zstd/lib
+# find . -name '*.c' | grep -vP 'deprecated|legacy' | sort | sed 's/^\./        ${LIBRARY_DIR}/'
 SET(Sources
+        ${LIBRARY_DIR}/common/debug.c
         ${LIBRARY_DIR}/common/entropy_common.c
         ${LIBRARY_DIR}/common/error_private.c
         ${LIBRARY_DIR}/common/fse_decompress.c
@@ -58,8 +61,11 @@ SET(Sources
         ${LIBRARY_DIR}/common/xxhash.c
         ${LIBRARY_DIR}/common/zstd_common.c
         ${LIBRARY_DIR}/compress/fse_compress.c
+        ${LIBRARY_DIR}/compress/hist.c
         ${LIBRARY_DIR}/compress/huf_compress.c
         ${LIBRARY_DIR}/compress/zstd_compress.c
+        ${LIBRARY_DIR}/compress/zstd_compress_literals.c
+        ${LIBRARY_DIR}/compress/zstd_compress_sequences.c
         ${LIBRARY_DIR}/compress/zstd_double_fast.c
         ${LIBRARY_DIR}/compress/zstd_fast.c
         ${LIBRARY_DIR}/compress/zstd_lazy.c
@@ -67,16 +73,21 @@ SET(Sources
         ${LIBRARY_DIR}/compress/zstdmt_compress.c
         ${LIBRARY_DIR}/compress/zstd_opt.c
         ${LIBRARY_DIR}/decompress/huf_decompress.c
+        ${LIBRARY_DIR}/decompress/zstd_ddict.c
+        ${LIBRARY_DIR}/decompress/zstd_decompress_block.c
         ${LIBRARY_DIR}/decompress/zstd_decompress.c
-        ${LIBRARY_DIR}/deprecated/zbuff_common.c
-        ${LIBRARY_DIR}/deprecated/zbuff_compress.c
-        ${LIBRARY_DIR}/deprecated/zbuff_decompress.c
         ${LIBRARY_DIR}/dictBuilder/cover.c
         ${LIBRARY_DIR}/dictBuilder/divsufsort.c
+        ${LIBRARY_DIR}/dictBuilder/fastcover.c
         ${LIBRARY_DIR}/dictBuilder/zdict.c)
 
+# cd contrib/zstd/lib
+# find . -name '*.h' | grep -vP 'deprecated|legacy' | sort | sed 's/^\./        ${LIBRARY_DIR}/'
 SET(Headers
         ${LIBRARY_DIR}/common/bitstream.h
+        ${LIBRARY_DIR}/common/compiler.h
+        ${LIBRARY_DIR}/common/cpu.h
+        ${LIBRARY_DIR}/common/debug.h
         ${LIBRARY_DIR}/common/error_private.h
         ${LIBRARY_DIR}/common/fse.h
         ${LIBRARY_DIR}/common/huf.h
@@ -86,14 +97,21 @@ SET(Headers
         ${LIBRARY_DIR}/common/xxhash.h
         ${LIBRARY_DIR}/common/zstd_errors.h
         ${LIBRARY_DIR}/common/zstd_internal.h
+        ${LIBRARY_DIR}/compress/hist.h
+        ${LIBRARY_DIR}/compress/zstd_compress_internal.h
+        ${LIBRARY_DIR}/compress/zstd_compress_literals.h
+        ${LIBRARY_DIR}/compress/zstd_compress_sequences.h
+        ${LIBRARY_DIR}/compress/zstd_cwksp.h
         ${LIBRARY_DIR}/compress/zstd_double_fast.h
         ${LIBRARY_DIR}/compress/zstd_fast.h
         ${LIBRARY_DIR}/compress/zstd_lazy.h
         ${LIBRARY_DIR}/compress/zstd_ldm.h
         ${LIBRARY_DIR}/compress/zstdmt_compress.h
         ${LIBRARY_DIR}/compress/zstd_opt.h
-        ${LIBRARY_DIR}/compress/zstd_ldm.h
-        ${LIBRARY_DIR}/deprecated/zbuff.h
+        ${LIBRARY_DIR}/decompress/zstd_ddict.h
+        ${LIBRARY_DIR}/decompress/zstd_decompress_block.h
+        ${LIBRARY_DIR}/decompress/zstd_decompress_internal.h
+        ${LIBRARY_DIR}/dictBuilder/cover.h
         ${LIBRARY_DIR}/dictBuilder/divsufsort.h
         ${LIBRARY_DIR}/dictBuilder/zdict.h
         ${LIBRARY_DIR}/zstd.h)


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Update zstd to 1.4.4. It has some minor improvements in performance and compression ratio. If you run replicas with different versions of ClickHouse you may see reasonable error messages `Data after merge is not byte-identical to data on another replicas.` with explanation. These messages are Ok and you should not worry.

Note: there were some changes in the meaning of compression levels. We should check it with extra care. (Silent change of compression to more heavy level is unacceptable.)