### PR TITLE
fix order of params in AggregatingTransform constructor

### DIFF
--- a/src/Processors/Transforms/AggregatingTransform.cpp
+++ b/src/Processors/Transforms/AggregatingTransform.cpp
@@ -397,7 +397,7 @@ AggregatingTransform::AggregatingTransform(Block header, AggregatingTransformPar
 
 AggregatingTransform::AggregatingTransform(
     Block header, AggregatingTransformParamsPtr params_, ManyAggregatedDataPtr many_data_,
-    size_t current_variant, size_t temporary_data_merge_threads_, size_t max_threads_)
+    size_t current_variant, size_t max_threads_, size_t temporary_data_merge_threads_)
     : IProcessor({std::move(header)}, {params_->getHeader()}), params(std::move(params_))
     , key_columns(params->params.keys_size)
     , aggregate_columns(params->params.aggregates_size)

--- a/src/Processors/Transforms/AggregatingTransform.h
+++ b/src/Processors/Transforms/AggregatingTransform.h
@@ -72,7 +72,7 @@ public:
     /// For Parallel aggregating.
     AggregatingTransform(Block header, AggregatingTransformParamsPtr params_,
                          ManyAggregatedDataPtr many_data, size_t current_variant,
-                         size_t temporary_data_merge_threads, size_t max_threads);
+                         size_t max_threads, size_t temporary_data_merge_threads);
     ~AggregatingTransform() override;
 
     String getName() const override { return "AggregatingTransform"; }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix order of parameters in AggregateTransform constructor.

Detailed description / Documentation draft:
Fix logic for `aggregation_memory_efficient_merge_threads` setting. It was swapped with `max_threads` when enabled.

Wrong order of parameters 'max_threads_' and 'temporary_data_merge_threads_' in AggregateTransform constructor leads to incorrect behaviour if 'aggregation_memory_efficient_merge_threads' setting differs from default value.