### PR TITLE
Revert "Partial fix of clang build stack unwinding (omit-frame-pointer)"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,11 @@ set (CMAKE_C_FLAGS_RELWITHDEBINFO        "${CMAKE_C_FLAGS_RELWITHDEBINFO} -O3 ${
 set (CMAKE_C_FLAGS_DEBUG                 "${CMAKE_C_FLAGS_DEBUG} -O0 -g3 -ggdb3 -fno-inline ${CMAKE_C_FLAGS_ADD}")
 
 if (COMPILER_CLANG)
+    # Exception unwinding doesn't work in clang release build without this option
+    # TODO investigate that
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-omit-frame-pointer")
+
     if (OS_DARWIN)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-U,_inside_main")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -271,11 +271,6 @@ endif ()
 
 add_library(clickhouse_common_io ${clickhouse_common_io_headers} ${clickhouse_common_io_sources})
 
-# Exception unwinding doesn't work in clang release build without this option
-# TODO investigate that
-set_source_files_properties(Interpreters/InterpreterSelectQuery.cpp PROPERTIES COMPILE_FLAGS "-fno-omit-frame-pointer")
-set_source_files_properties(Interpreters/executeQuery.cpp PROPERTIES COMPILE_FLAGS "-fno-omit-frame-pointer")
-
 add_library (clickhouse_malloc OBJECT Common/malloc.cpp)
 set_source_files_properties(Common/malloc.cpp PROPERTIES COMPILE_FLAGS "-fno-builtin")
 


### PR DESCRIPTION
Changelog category:
* Not for changelog

Reverts ClickHouse/ClickHouse#10625