### PR TITLE
Fix http readonly request stucks on client close

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "contrib/poco"]
 	path = contrib/poco
-	url = https://github.com/tavplubix/poco
-	branch = respect_msg_dontwait
+	url = https://github.com/ClickHouse-Extras/poco
+	branch = clickhouse
 [submodule "contrib/zstd"]
 	path = contrib/zstd
 	url = https://github.com/facebook/zstd.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "contrib/poco"]
 	path = contrib/poco
-	url = https://github.com/ClickHouse-Extras/poco
-	branch = clickhouse
+	url = https://github.com/tavplubix/poco
+	branch = respect_msg_dontwait
 [submodule "contrib/zstd"]
 	path = contrib/zstd
 	url = https://github.com/facebook/zstd.git

--- a/programs/server/HTTPHandler.cpp
+++ b/programs/server/HTTPHandler.cpp
@@ -567,7 +567,6 @@ void HTTPHandler::processQuery(
             try
             {
                 char b;
-                //FIXME looks like MSG_DONTWAIT is useless because of POCO_BROKEN_TIMEOUTS
                 int status = socket.receiveBytes(&b, 1, MSG_DONTWAIT | MSG_PEEK);
                 if (status == 0)
                     context.killCurrentQuery();

--- a/tests/queries/0_stateless/00834_cancel_http_readonly_queries_on_client_close.sh
+++ b/tests/queries/0_stateless/00834_cancel_http_readonly_queries_on_client_close.sh
@@ -10,3 +10,10 @@ do
     ${CLICKHOUSE_CURL} -sS --data "SELECT count() FROM system.processes WHERE query_id = 'cancel_http_readonly_queries_on_client_close'" "${CLICKHOUSE_URL}" | grep '0' && break
     sleep 0.2
 done
+
+${CLICKHOUSE_CURL} -sS -X POST "${CLICKHOUSE_URL}&session_id=test_00834_session&readonly=2&cancel_http_readonly_queries_on_client_close=1" -d "CREATE TEMPORARY TABLE table_tmp AS SELECT 1 FORMAT JSON"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&session_id=test_00834_session&query=DROP+TEMPORARY+TABLE+table_tmp"
+
+url_https="https://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_HTTPS}/?session_id=test_00834_session"
+${CLICKHOUSE_CURL} -sSk "$url_https&readonly=2&cancel_http_readonly_queries_on_client_close=1" -d "CREATE TEMPORARY TABLE table_tmp AS SELECT 1 FORMAT JSON"
+${CLICKHOUSE_CURL} -sSk "$url_https&session_id=test_00834_session&query=DROP+TEMPORARY+TABLE+table_tmp"

--- a/tests/queries/0_stateless/00834_cancel_http_readonly_queries_on_client_close.sh
+++ b/tests/queries/0_stateless/00834_cancel_http_readonly_queries_on_client_close.sh
@@ -15,5 +15,5 @@ ${CLICKHOUSE_CURL} -sS -X POST "${CLICKHOUSE_URL}&session_id=test_00834_session&
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&session_id=test_00834_session&query=DROP+TEMPORARY+TABLE+table_tmp"
 
 url_https="https://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_HTTPS}/?session_id=test_00834_session"
-${CLICKHOUSE_CURL} -sSk "$url_https&readonly=2&cancel_http_readonly_queries_on_client_close=1" -d "CREATE TEMPORARY TABLE table_tmp AS SELECT 1 FORMAT JSON"
+${CLICKHOUSE_CURL} -sSk -X POST "$url_https&readonly=2&cancel_http_readonly_queries_on_client_close=1" -d "CREATE TEMPORARY TABLE table_tmp AS SELECT 1 FORMAT JSON"
 ${CLICKHOUSE_CURL} -sSk "$url_https&session_id=test_00834_session&query=DROP+TEMPORARY+TABLE+table_tmp"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed bug, which causes http requests stuck on client close when `readonly=2` and `cancel_http_readonly_queries_on_client_close=1`.
Fixes #7939, #7019, #7736, #7091
