### PR TITLE
Blind fix for AppleClang version and char8_t support check

### DIFF
--- a/cmake/tools.cmake
+++ b/cmake/tools.cmake
@@ -1,9 +1,14 @@
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set (COMPILER_GCC 1)
 elseif (CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
-    # It's very difficult to check what is the correspondence between clang and AppleClang versions.
-    # There are many complaints that some version of AppleClang does not work, but we are not able to dig into it.
-    message(FATAL_ERROR "AppleClang compiler is not supported. You have to use the latest clang version.")
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.0.1) # AppleClang 10.0.1 (Xcode 10.2) is the lowest version that corresponds to LLVM/Clang upstream version not older than 7.0.0.
+        message(FATAL_ERROR "AppleClang ${CMAKE_CXX_COMPILER_VERSION} compiler is not supported. Compiler version must be at least 10.0.1 (Xcode 10.2).")
+    elseif (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11.0.0) # AppleClang 11.0.0 (Xcode 11.0) is the lowest version that corresponds to LLVM/Clang upstream version not older than 8.0.0.
+        # char8_t is available staring (upstream vanilla) Clang 7, but prior to Clang 8, it is not enabled by -std=c++20 and can be enabled with -fchar8_t.
+        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fchar8_t")
+        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fchar8_t")
+    endif()
+    set (COMPILER_CLANG 1)
 elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set (COMPILER_CLANG 1)
 endif ()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Non-significant (changelog entry is not required)

Detailed description:
Added checks for AppleClang versions to allow them if it is Xcode 10.2+. Main known issue was `char8_t` support, which was added in Clang 7 (enabled with `-std=c++20 -fchar8_t`) and is enabled by default starting Clang 8 if only `-std=c++20` is specified, according to https://clang.llvm.org/cxx_status.html
This is blind fix, verified to work only on Xcode 11.4.1.

The correspondence between AppleClang and upstream Clang versions is guessed based on:
- https://en.wikipedia.org/wiki/Xcode#Xcode_7.0_-_11.x_(since_Free_On-Device_Development) (see LLVM version)
- https://github.com/apple/llvm-project/blob/5b5d130d46d8289292fee9a740edef22bf76e6d2/clang/CMakeLists.txt#L375-L387
- various comments on web suggesting this is right way of matching them