### PR TITLE
Fix generate random with nested

### DIFF
--- a/src/Storages/StorageGenerateRandom.cpp
+++ b/src/Storages/StorageGenerateRandom.cpp
@@ -338,43 +338,46 @@ class GenerateSource : public SourceWithProgress
 {
 public:
     GenerateSource(UInt64 block_size_, UInt64 max_array_length_, UInt64 max_string_length_, UInt64 random_seed_, Block block_header_, const Context & context_)
-        : SourceWithProgress(block_header_), block_size(block_size_), max_array_length(max_array_length_), max_string_length(max_string_length_)
-        , block_header(block_header_), rng(random_seed_), context(context_) {}
+        : SourceWithProgress(Nested::flatten(prepareBlockToFill(block_header_)))
+        , block_size(block_size_), max_array_length(max_array_length_), max_string_length(max_string_length_)
+        , block_to_fill(std::move(block_header_)), rng(random_seed_), context(context_) {}
 
     String getName() const override { return "GenerateRandom"; }
 
 protected:
     Chunk generate() override
     {
-        /// To support Nested types, we will collect them to single Array of Tuple.
-        auto names_and_types = Nested::collect(block_header.getNamesAndTypesList());
-
         Columns columns;
-        columns.reserve(names_and_types.size());
+        columns.reserve(block_to_fill.columns());
 
-        Block compact_block;
-        for (const auto & elem : names_and_types)
-        {
-            compact_block.insert(
-            {
-                fillColumnWithRandomData(elem.type, block_size, max_array_length, max_string_length, rng, context),
-                elem.type,
-                elem.name
-            });
-        }
+        for (const auto & elem : block_to_fill)
+            columns.emplace_back(fillColumnWithRandomData(elem.type, block_size, max_array_length, max_string_length, rng, context));
 
-        return {Nested::flatten(compact_block).getColumns(), block_size};
+        columns = Nested::flatten(block_to_fill.cloneWithColumns(std::move(columns))).getColumns();
+        return {std::move(columns), block_size};
     }
 
 private:
     UInt64 block_size;
     UInt64 max_array_length;
     UInt64 max_string_length;
-    Block block_header;
+    Block block_to_fill;
 
     pcg64 rng;
 
     const Context & context;
+
+    static Block & prepareBlockToFill(Block & block)
+    {
+        /// To support Nested types, we will collect them to single Array of Tuple.
+        auto names_and_types = Nested::collect(block.getNamesAndTypesList());
+        block.clear();
+
+        for (auto & column : names_and_types)
+            block.insert(ColumnWithTypeAndName(column.type, column.name));
+
+        return block;
+    }
 };
 
 }

--- a/tests/queries/0_stateless/01274_generate_random_nested.sh
+++ b/tests/queries/0_stateless/01274_generate_random_nested.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. $CURDIR/../shell_config.sh
+
+${CLICKHOUSE_CURL} -sS $CLICKHOUSE_URL -d "SELECT * FROM generateRandom('\"ParsedParams.Key1\" Array(String), \"ParsedParams.Key2\" Array(Float64), x String', 1, 10, 2) LIMIT 10" > /dev/null;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix crash in `generateRandom` with nested types. Fixes #10583.