### PR TITLE
Add SO_KEEPALIVE socket option to avoid server keeping dead connectio…

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -847,6 +847,10 @@ int Server::main(const std::vector<std::string> & /*args*/)
                 auto address = socket_bind_listen(socket, listen_host, port);
                 socket.setReceiveTimeout(settings.receive_timeout);
                 socket.setSendTimeout(settings.send_timeout);
+                if (config().getBool("use_tcp_keep_alive", false))
+                {
+                    socket.setKeepAlive(true);
+                }
                 servers.emplace_back(std::make_unique<Poco::Net::TCPServer>(
                     new TCPHandlerFactory(*this),
                     server_pool,
@@ -864,6 +868,10 @@ int Server::main(const std::vector<std::string> & /*args*/)
                 auto address = socket_bind_listen(socket, listen_host, port, /* secure = */ true);
                 socket.setReceiveTimeout(settings.receive_timeout);
                 socket.setSendTimeout(settings.send_timeout);
+                if (config().getBool("use_tcp_keep_alive", false))
+                {
+                    socket.setKeepAlive(true);
+                }
                 servers.emplace_back(std::make_unique<Poco::Net::TCPServer>(
                     new TCPHandlerFactory(*this, /* secure= */ true),
                     server_pool,

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -632,4 +632,7 @@
 
     <!-- Uncomment to disable ClickHouse internal DNS caching. -->
     <!-- <disable_internal_dns_cache>1</disable_internal_dns_cache> -->
+
+    <!-- Uncomment to enable tcp_keep_alive for native protocol -->
+    <!-- <use_tcp_keep_alive>true</use_tcp_keep_alive> -->
 </yandex>


### PR DESCRIPTION
…ns forever

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add SO_KEEPALIVE socket option to avoid server keeping dead connections forever


Detailed description / Documentation draft:
If client process established a TCP connection with a server and then keeps it's idle - we can walk away for hours, days, weeks, or months, and the connection should remain up. In case if network get partitioned and the client disappears, leaving the half-open connection on the server’s end, and the server is waiting for some data from the client, the server will wait forever. The keepalive feature is intended to detect these half-open connections from the server side to prevent run out of available connections on server.