### PR TITLE
using nongnu libunwind

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -88,7 +88,7 @@
 	url = https://github.com/ClickHouse-Extras/hyperscan.git
 [submodule "contrib/libunwind"]
 	path = contrib/libunwind
-	url = https://github.com/ClickHouse-Extras/libunwind.git
+	url = https://github.com/libunwind/libunwind.git
 [submodule "contrib/simdjson"]
 	path = contrib/simdjson
 	url = https://github.com/lemire/simdjson.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,11 +214,6 @@ set (CMAKE_C_FLAGS_RELWITHDEBINFO        "${CMAKE_C_FLAGS_RELWITHDEBINFO} -O3 ${
 set (CMAKE_C_FLAGS_DEBUG                 "${CMAKE_C_FLAGS_DEBUG} -O0 -g3 -ggdb3 -fno-inline ${CMAKE_C_FLAGS_ADD}")
 
 if (COMPILER_CLANG)
-    # Exception unwinding doesn't work in clang release build without this option
-    # TODO investigate that
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-omit-frame-pointer")
-
     if (OS_DARWIN)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-U,_inside_main")

--- a/cmake/find/unwind.cmake
+++ b/cmake/find/unwind.cmake
@@ -2,7 +2,7 @@ option (USE_UNWIND "Enable libunwind (better stacktraces)" ${ENABLE_LIBRARIES})
 
 if (USE_UNWIND)
     add_subdirectory(contrib/libunwind-cmake)
-    set (UNWIND_LIBRARIES unwind)
+    set (UNWIND_LIBRARIES unwind-override)
     set (EXCEPTION_HANDLING_LIBRARY ${UNWIND_LIBRARIES})
 
     message (STATUS "Using libunwind: ${UNWIND_LIBRARIES}")

--- a/contrib/libunwind-cmake/CMakeLists.txt
+++ b/contrib/libunwind-cmake/CMakeLists.txt
@@ -1,58 +1,54 @@
-include(CheckCCompilerFlag)
-include(CheckCXXCompilerFlag)
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
+    set (Unwind_ARCH "arm")
+elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64")
+    set (Unwind_ARCH "aarch64")
+elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR
+        CMAKE_SYSTEM_PROCESSOR STREQUAL "amd64" OR
+        CMAKE_SYSTEM_PROCESSOR STREQUAL "corei7-64")
+    set (Unwind_ARCH "x86_64")
+elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^i.86$")
+    set (Unwind_ARCH "x86")
+elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^ppc64")
+    set (Unwind_ARCH "ppc64")
+elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^ppc")
+    set (Unwind_ARCH "ppc32")
+elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^mips")
+    set (Unwind_ARCH "mips")
+elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^hppa")
+    set (Unwind_ARCH "hppa")
+elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^ia64")
+    set (Unwind_ARCH "ia64")
+endif (CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
 
 set(LIBUNWIND_SOURCE_DIR ${ClickHouse_SOURCE_DIR}/contrib/libunwind)
+set(LIBUNWIND_BINARY_DIR ${ClickHouse_BINARY_DIR}/contrib/libunwind)
+set(LIBUNWIND_STATIC_LIBS ${LIBUNWIND_BINARY_DIR}/lib/libunwind.a ${LIBUNWIND_BINARY_DIR}/lib/libunwind-${Unwind_ARCH}.a)
+set(LIBUNWIND_SHARED_LIBS ${LIBUNWIND_BINARY_DIR}/lib/libunwind.so ${LIBUNWIND_BINARY_DIR}/lib/libunwind-${Unwind_ARCH}.so)
+set(LIBUNWIND_INCLUDE_DIR ${LIBUNWIND_BINARY_DIR}/include)
+file(MAKE_DIRECTORY ${LIBUNWIND_INCLUDE_DIR})
 
-set(LIBUNWIND_CXX_SOURCES
-    ${LIBUNWIND_SOURCE_DIR}/src/libunwind.cpp
-    ${LIBUNWIND_SOURCE_DIR}/src/Unwind-EHABI.cpp
-    ${LIBUNWIND_SOURCE_DIR}/src/Unwind-seh.cpp)
-if (APPLE)
-    set(LIBUNWIND_CXX_SOURCES ${LIBUNWIND_CXX_SOURCES} ${LIBUNWIND_SOURCE_DIR}/src/Unwind_AppleExtras.cpp)
-endif ()
-
-set(LIBUNWIND_C_SOURCES
-    ${LIBUNWIND_SOURCE_DIR}/src/UnwindLevel1.c
-    ${LIBUNWIND_SOURCE_DIR}/src/UnwindLevel1-gcc-ext.c
-    ${LIBUNWIND_SOURCE_DIR}/src/Unwind-sjlj.c
-    # Use unw_backtrace to override libgcc's backtrace symbol for better ABI compatibility
-    unwind-override.c)
-set_source_files_properties(${LIBUNWIND_C_SOURCES} PROPERTIES COMPILE_FLAGS "-std=c99")
-
-set(LIBUNWIND_ASM_SOURCES
-    ${LIBUNWIND_SOURCE_DIR}/src/UnwindRegistersRestore.S
-    ${LIBUNWIND_SOURCE_DIR}/src/UnwindRegistersSave.S)
-set_source_files_properties(${LIBUNWIND_ASM_SOURCES} PROPERTIES LANGUAGE C)
-
-set(LIBUNWIND_SOURCES
-    ${LIBUNWIND_CXX_SOURCES}
-    ${LIBUNWIND_C_SOURCES}
-    ${LIBUNWIND_ASM_SOURCES})
-
-add_library(unwind ${LIBUNWIND_SOURCES})
-
-target_include_directories(unwind SYSTEM BEFORE PUBLIC $<BUILD_INTERFACE:${LIBUNWIND_SOURCE_DIR}/include>)
-target_compile_definitions(unwind PRIVATE -D_LIBUNWIND_NO_HEAP=1 -D_DEBUG -D_LIBUNWIND_IS_NATIVE_ONLY)
-target_compile_options(unwind PRIVATE -fno-exceptions -funwind-tables -fno-sanitize=all $<$<COMPILE_LANGUAGE:CXX>:-nostdinc++ -fno-rtti>)
-
-check_c_compiler_flag(-Wunused-but-set-variable HAVE_WARNING_UNUSED_BUT_SET_VARIABLE)
-if (HAVE_WARNING_UNUSED_BUT_SET_VARIABLE)
-    target_compile_options(unwind PRIVATE -Wno-unused-but-set-variable)
-endif ()
-
-check_cxx_compiler_flag(-Wmissing-attributes HAVE_WARNING_MISSING_ATTRIBUTES)
-if (HAVE_WARNING_MISSING_ATTRIBUTES)
-    target_compile_options(unwind PRIVATE -Wno-missing-attributes)
-endif ()
-
-check_cxx_compiler_flag(-Wmaybe-uninitialized HAVE_WARNING_MAYBE_UNINITIALIZED)
-if (HAVE_WARNING_MAYBE_UNINITIALIZED)
-    target_compile_options(unwind PRIVATE -Wno-maybe-uninitialized)
-endif ()
-
-install(
-    TARGETS unwind
-    EXPORT global
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
+include(ExternalProject)
+ExternalProject_Add(
+    libunwind
+    PREFIX ${LIBUNWIND_BINARY_DIR}
+    SOURCE_DIR ${LIBUNWIND_SOURCE_DIR}
+    CONFIGURE_COMMAND ${LIBUNWIND_SOURCE_DIR}/autogen.sh CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} --enable-cxx-exceptions --enable-coredump --enable-ptrace --enable-setjmp --disable-minidebuginfo --disable-documentation --disable-tests --prefix=${LIBUNWIND_BINARY_DIR}
+    BUILD_COMMAND make
+    INSTALL_COMMAND make install
+    BUILD_BYPRODUCTS ${LIBUNWIND_STATIC_LIBS} ${LIBUNWIND_SHARED_LIBS}
 )
+
+add_library (unwind INTERFACE IMPORTED)
+add_dependencies(unwind libunwind)
+set_property (TARGET unwind PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${LIBUNWIND_INCLUDE_DIR})
+if (MAKE_STATIC_LIBRARIES)
+    set_property (TARGET unwind PROPERTY INTERFACE_LINK_LIBRARIES ${LIBUNWIND_STATIC_LIBS})
+else ()
+    set_property (TARGET unwind PROPERTY INTERFACE_LINK_LIBRARIES ${LIBUNWIND_SHARED_LIBS})
+endif ()
+set_property (TARGET unwind PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+
+add_library(unwind-override unwind-override.c)
+target_link_libraries(unwind-override PUBLIC unwind)
+
+# TODO Do we need an install function here ?


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

llvm-libunwind has mysterious bug when unwinding stacks without frame pointers. Use nongnu libunwind instead.  https://github.com/ClickHouse/ClickHouse/pull/10625  https://github.com/ClickHouse/ClickHouse/pull/8151