### PR TITLE
Avoid std::terminate in case of exception from SystemLogs::SystemLogs

### DIFF
--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -98,11 +98,21 @@ SystemLogs::SystemLogs(Context & global_context, const Poco::Util::AbstractConfi
         logs.emplace_back(metric_log.get());
 
     bool lazy_load = config.getBool("system_tables_lazy_load", true);
-    for (auto & log : logs)
+
+    try
     {
-        if (!lazy_load)
-            log->prepareTable();
-        log->startup();
+        for (auto & log : logs)
+        {
+            if (!lazy_load)
+                log->prepareTable();
+            log->startup();
+        }
+    }
+    catch (...)
+    {
+        /// join threads
+        shutdown();
+        throw;
     }
 }
 

--- a/src/Interpreters/SystemLog.h
+++ b/src/Interpreters/SystemLog.h
@@ -208,6 +208,7 @@ SystemLog<LogElement>::SystemLog(Context & context_,
 template <typename LogElement>
 void SystemLog<LogElement>::startup()
 {
+    std::unique_lock lock(mutex);
     saving_thread = ThreadFromGlobalPool([this] { savingThreadFunction(); });
 }
 
@@ -287,6 +288,11 @@ void SystemLog<LogElement>::stopFlushThread()
 {
     {
         std::unique_lock lock(mutex);
+
+        if (!saving_thread.joinable())
+        {
+            return;
+        }
 
         if (is_shutdown)
         {


### PR DESCRIPTION
Since, at least, this will hide the real exception

Changelog category (leave one):
- Non-significant (changelog entry is not required)