### PR TITLE
Fix TSan report in CPUID

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -156,4 +156,4 @@
 	url = https://github.com/msgpack/msgpack-c
 [submodule "contrib/libcpuid"]
 	path = contrib/libcpuid
-	url = https://github.com/anrieff/libcpuid.git
+	url = https://github.com/ClickHouse-Extras/libcpuid.git


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Restore a patch that was accidentially deleted in #10396