### PR TITLE
Asserts in DateLUTImpl

### DIFF
--- a/base/common/DateLUTImpl.cpp
+++ b/base/common/DateLUTImpl.cpp
@@ -75,6 +75,11 @@ DateLUTImpl::DateLUTImpl(const std::string & time_zone_)
         values.day_of_week = getDayOfWeek(date);
         values.date = start_of_day;
 
+        assert(values.year >= DATE_LUT_MIN_YEAR && values.year <= DATE_LUT_MAX_YEAR);
+        assert(values.month >= 1 && values.month <= 12);
+        assert(values.day_of_month >= 1 && values.day_of_month <= 31);
+        assert(values.day_of_week >= 1 && values.day_of_week <= 7);
+
         if (values.day_of_month == 1)
         {
             cctz::civil_month month(date);


### PR DESCRIPTION
Changelog category (leave one):
- Non-significant (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Added some asserts to faciliate debugging of one rare issue: https://clickhouse-test-reports.s3.yandex.net/10413/2ff06779e9af5ab701c8a4f497ec09ec71ac1cd2/functional_stateless_tests_(ubsan).html

It looks like that this issue is already gone after https://github.com/ClickHouse/ClickHouse/pull/10425 but I'm not sure because it reproduces extremely rarely (two times a month).