### PR TITLE
Fix race condition in ReplicatedMergeTreeQueue

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -2954,6 +2954,7 @@ void StorageReplicatedMergeTree::startup()
     /// If we don't separate create/start steps, race condition will happen
     /// between the assignment of queue_task_handle and queueTask that use the queue_task_handle.
     {
+        auto lock = queue.lockQueue();
         auto & pool = global_context.getBackgroundPool();
         queue_task_handle = pool.createTask([this] { return queueTask(); });
         pool.startTask(queue_task_handle);
@@ -2992,7 +2993,6 @@ void StorageReplicatedMergeTree::shutdown()
         auto lock = queue.lockQueue();
         queue_task_handle.reset();
     }
-
 
     if (move_parts_task_handle)
         global_context.getBackgroundMovePool().removeTask(move_parts_task_handle);


### PR DESCRIPTION
Changelog category (leave one):
- Non-significant (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
It's most likely false TSan report because there is implicit full memory barrier.

https://clickhouse-test-reports.s3.yandex.net/10068/2654f131cc19c26623045e9b7e6c2a481fa253c1/functional_stateless_tests_(thread).html

There was previous try to fix this issue, but it was not enough: https://github.com/ClickHouse/ClickHouse/pull/9552