### PR TITLE
Fix (false) MSan report in MergeTreeIndexFullText

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexFullText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexFullText.cpp
@@ -14,6 +14,7 @@
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTSubquery.h>
+#include <Core/Defines.h>
 
 #include <Poco/Logger.h>
 
@@ -617,7 +618,7 @@ bool SplitTokenExtractor::next(const char * data, size_t len, size_t * pos, size
 
     while (*pos < len)
     {
-#if defined(__SSE2__)
+#if defined(__SSE2__) && !defined(MEMORY_SANITIZER) /// We read uninitialized bytes and decide on the calcualted mask
         // NOTE: we assume that `data` string is padded from the right with 15 bytes.
         const __m128i haystack = _mm_loadu_si128(reinterpret_cast<const __m128i *>(data + *pos));
         const size_t haystack_length = 16;
@@ -691,7 +692,7 @@ bool SplitTokenExtractor::next(const char * data, size_t len, size_t * pos, size
 #endif
     }
 
-#if defined(__SSE2__)
+#if defined(__SSE2__) && !defined(MEMORY_SANITIZER)
     // Could happen only if string is not padded with zeroes, and we accidentally hopped over end of data.
     if (*token_start > len)
         return false;


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix (false) MSan report in MergeTreeIndexFullText. The issue first appeared in #9968.