### PR TITLE
Slightly better test

### DIFF
--- a/tests/queries/0_stateless/01070_exception_code_in_query_log_table.sql
+++ b/tests/queries/0_stateless/01070_exception_code_in_query_log_table.sql
@@ -3,5 +3,5 @@ SELECT * FROM test_table_for_01070_exception_code_in_query_log_table; -- { serve
 CREATE TABLE test_table_for_01070_exception_code_in_query_log_table (value UInt64) ENGINE=Memory();
 SELECT * FROM test_table_for_01070_exception_code_in_query_log_table;
 SYSTEM FLUSH LOGS;
-SELECT exception_code FROM system.query_log WHERE query='SELECT * FROM test_table_for_01070_exception_code_in_query_log_table' ORDER BY exception_code;
+SELECT exception_code FROM system.query_log WHERE query = 'SELECT * FROM test_table_for_01070_exception_code_in_query_log_table' AND event_date >= yesterday() AND event_time > now() - INTERVAL 5 MINUTE ORDER BY exception_code;
 DROP TABLE IF EXISTS test_table_for_01070_exception_code_in_query_log_table;


### PR DESCRIPTION
Changelog category (leave one):
- Non-significant (changelog entry is not required)

Some tests work in CI but don't work when run locally many times. That's annoying.