### PR TITLE
Remove obsolete MSan suppression

### DIFF
--- a/base/common/demangle.cpp
+++ b/base/common/demangle.cpp
@@ -1,18 +1,6 @@
 #include <common/demangle.h>
 
-#if defined(__has_feature)
-    #if __has_feature(memory_sanitizer)
-        #define MEMORY_SANITIZER 1
-    #else
-        #define MEMORY_SANITIZER 0
-    #endif
-#elif defined(__MEMORY_SANITIZER__)
-    #define MEMORY_SANITIZER 1
-#else
-    #define MEMORY_SANITIZER 0
-#endif
-
-#if defined(_MSC_VER) || MEMORY_SANITIZER
+#if defined(_MSC_VER)
 
 DemangleResult tryDemangle(const char *)
 {


### PR DESCRIPTION
Changelog category (leave one):
- Non-significant (changelog entry is not required)

Suppression for `demangle` function had meaning only before we have switched to using libc++ from contrib.