### PR TITLE
Remove obsolete TSan suppressions

### DIFF
--- a/cmake/sanitize.cmake
+++ b/cmake/sanitize.cmake
@@ -36,8 +36,10 @@ if (SANITIZE)
         endif ()
 
     elseif (SANITIZE STREQUAL "thread")
-        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SAN_FLAGS} -fsanitize=thread")
-        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SAN_FLAGS} -fsanitize=thread")
+        set (TSAN_FLAGS "-fsanitize=thread -fsanitize-blacklist=${CMAKE_SOURCE_DIR}/tests/tsan_suppressions.txt")
+
+        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SAN_FLAGS} ${TSAN_FLAGS}")
+        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SAN_FLAGS} ${TSAN_FLAGS}")
         if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
             set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=thread")
         endif()

--- a/tests/tsan_suppressions.txt
+++ b/tests/tsan_suppressions.txt
@@ -1,5 +1,1 @@
-# libc++
-race:locale
-
-# Too many mutexes: https://github.com/google/sanitizers/issues/950
-deadlock:DB::MergeTreeReadPool::fillPerPartInfo
+# Fortunately, we have no suppressions!


### PR DESCRIPTION
Changelog category (leave one):
- Non-significant (changelog entry is not required)


Looks like they were not used anyway.