### PR TITLE
Fixed DateLUTImpl constructors to avoid accidental copying

### DIFF
--- a/base/common/DateLUTImpl.h
+++ b/base/common/DateLUTImpl.h
@@ -37,7 +37,12 @@ using YearWeek = std::pair<UInt16, UInt8>;
 class DateLUTImpl
 {
 public:
-    DateLUTImpl(const std::string & time_zone);
+    explicit DateLUTImpl(const std::string & time_zone);
+
+    DateLUTImpl(const DateLUTImpl &) = delete;
+    DateLUTImpl & operator=(const DateLUTImpl &) = delete;
+    DateLUTImpl(const DateLUTImpl &&) = delete;
+    DateLUTImpl & operator=(const DateLUTImpl &&) = delete;
 
 public:
     /// The order of fields matters for alignment and sizeof.

--- a/src/DataStreams/TTLBlockInputStream.h
+++ b/src/DataStreams/TTLBlockInputStream.h
@@ -45,7 +45,7 @@ private:
 
     size_t rows_removed = 0;
     Logger * log;
-    DateLUTImpl date_lut;
+    const DateLUTImpl & date_lut;
 
     /// TODO rewrite defaults logic to evaluteMissingDefaults
     std::unordered_map<String, String> defaults_result_column;


### PR DESCRIPTION
Fixed one case of copying DateLUTImpl

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Non-significant (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...

