### PR TITLE
Fix the issue with ODBC bridge and identifier_quoting_style = None #7984

### DIFF
--- a/src/Storages/transformQueryForExternalDatabase.cpp
+++ b/src/Storages/transformQueryForExternalDatabase.cpp
@@ -194,8 +194,8 @@ String transformQueryForExternalDatabase(
 
     std::stringstream out;
     IAST::FormatSettings settings(out, true);
-    settings.always_quote_identifiers = true;
     settings.identifier_quoting_style = identifier_quoting_style;
+    settings.always_quote_identifiers = identifier_quoting_style != IdentifierQuotingStyle::None;
 
     select->format(settings);
 


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix the issue with ODBC bridge when no quoting of identifiers is requested. This fixes #7984.
