### PR TITLE
Fix columns order after Block::sortColumns()

### DIFF
--- a/src/Core/Block.cpp
+++ b/src/Core/Block.cpp
@@ -13,6 +13,7 @@
 
 #include <iterator>
 #include <memory>
+#include <map>
 
 
 namespace DB
@@ -403,7 +404,12 @@ Block Block::sortColumns() const
 {
     Block sorted_block;
 
+    /// std::unordered_map cannot be used to guarantee the sort order
+    std::map<String, size_t> sorted_index_by_name;
     for (const auto & name : index_by_name)
+        sorted_index_by_name[name.first] = name.second;
+
+    for (const auto & name : sorted_index_by_name)
         sorted_block.insert(data[name.second]);
 
     return sorted_block;

--- a/src/Core/Block.cpp
+++ b/src/Core/Block.cpp
@@ -410,7 +410,8 @@ Block Block::sortColumns() const
         for (auto it = index_by_name.begin(); it != index_by_name.end(); ++it)
             sorted_index_by_name[i++] = it;
     }
-    std::sort(sorted_index_by_name.begin(), sorted_index_by_name.end(), [](const auto & lhs, const auto & rhs) {
+    std::sort(sorted_index_by_name.begin(), sorted_index_by_name.end(), [](const auto & lhs, const auto & rhs)
+    {
         return lhs->first < rhs->first;
     });
 

--- a/src/Core/Block.cpp
+++ b/src/Core/Block.cpp
@@ -13,7 +13,6 @@
 
 #include <iterator>
 #include <memory>
-#include <map>
 
 
 namespace DB
@@ -404,10 +403,11 @@ Block Block::sortColumns() const
 {
     Block sorted_block;
 
-    /// std::unordered_map cannot be used to guarantee the sort order
-    std::map<String, size_t> sorted_index_by_name;
-    for (const auto & name : index_by_name)
-        sorted_index_by_name[name.first] = name.second;
+    /// std::unordered_map (index_by_name) cannot be used to guarantee the sort order
+    std::vector<std::pair<String, size_t>> sorted_index_by_name(index_by_name.begin(), index_by_name.end());
+    std::sort(sorted_index_by_name.begin(), sorted_index_by_name.end(), [](const auto & lhs, const auto & rhs) {
+        return lhs.first < rhs.first;
+    });
 
     for (const auto & name : sorted_index_by_name)
         sorted_block.insert(data[name.second]);

--- a/src/Core/Block.cpp
+++ b/src/Core/Block.cpp
@@ -404,13 +404,18 @@ Block Block::sortColumns() const
     Block sorted_block;
 
     /// std::unordered_map (index_by_name) cannot be used to guarantee the sort order
-    std::vector<std::pair<String, size_t>> sorted_index_by_name(index_by_name.begin(), index_by_name.end());
+    std::vector<decltype(index_by_name.begin())> sorted_index_by_name(index_by_name.size());
+    {
+        size_t i = 0;
+        for (auto it = index_by_name.begin(); it != index_by_name.end(); ++it)
+            sorted_index_by_name[i++] = it;
+    }
     std::sort(sorted_index_by_name.begin(), sorted_index_by_name.end(), [](const auto & lhs, const auto & rhs) {
-        return lhs.first < rhs.first;
+        return lhs->first < rhs->first;
     });
 
-    for (const auto & name : sorted_index_by_name)
-        sorted_block.insert(data[name.second]);
+    for (const auto & it : sorted_index_by_name)
+        sorted_block.insert(data[it->second]);
 
     return sorted_block;
 }

--- a/tests/queries/0_stateless/01277_buffer_column_order.sql
+++ b/tests/queries/0_stateless/01277_buffer_column_order.sql
@@ -1,0 +1,59 @@
+-- Check for Block::sortColumns(), can be done using Buffer.
+
+drop table if exists out_01277;
+drop table if exists in_01277;
+drop table if exists buffer_01277;
+drop table if exists mv_01277_1;
+drop table if exists mv_01277_2;
+
+create table out_01277
+(
+    k1 Int,
+    k2 Int,
+    a1 Int,
+    a2 Int,
+    b1 Int,
+    b2 Int,
+    c  Int
+) Engine=Null();
+create table buffer_01277 as out_01277 Engine=Buffer(currentDatabase(), out_01277, 1,
+    86400, 86400,
+    1e5, 1e6,
+    10e6, 100e6);
+create table in_01277 as out_01277 Engine=Null();
+
+-- differs in order of fields in SELECT clause
+create materialized view mv_01277_1 to buffer_01277 as select k1, k2, a1, a2, b1, b2, c from in_01277;
+create materialized view mv_01277_2 to buffer_01277 as select a1, a2, k1, k2, b1, b2, c from in_01277;
+
+-- column order is ignored, just for humans
+insert into mv_01277_1 select
+    number k1,
+    number k2,
+    number a1,
+    number a2,
+    number b1,
+    number b2,
+    number c
+from numbers(1);
+
+-- with wrong order in Block::sortColumns() triggers:
+--
+--     Code: 171. DB::Exception: Received from localhost:9000. DB::Exception: Block structure mismatch in Buffer stream: different names of columns:
+--     c Int32 Int32(size = 1), b2 Int32 Int32(size = 1), a2 Int32 Int32(size = 1), a1 Int32 Int32(size = 1), k2 Int32 Int32(size = 1), b1 Int32 Int32(size = 1), k1 Int32 Int32(size = 1)
+--     c Int32 Int32(size = 1), b2 Int32 Int32(size = 1), k2 Int32 Int32(size = 1), a1 Int32 Int32(size = 1), b1 Int32 Int32(size = 1), k1 Int32 Int32(size = 1), a2 Int32 Int32(size = 1).
+insert into mv_01277_2 select
+    number a1,
+    number a2,
+    number k1,
+    number k2,
+    number b1,
+    number b2,
+    number c
+from numbers(1);
+
+drop table mv_01277_1;
+drop table mv_01277_2;
+drop table buffer_01277;
+drop table out_01277;
+drop table in_01277;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix columns order after Block::sortColumns() (also add a test that shows that it affects some real use case - Buffer engine)

Fixes: #9950