### PR TITLE
Fix exception message after server shutdown

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -2998,7 +2998,6 @@ void StorageReplicatedMergeTree::shutdown()
         queue.pull_log_blocker.cancelForever();
     }
 
-
     if (move_parts_task_handle)
         global_context.getBackgroundMovePool().removeTask(move_parts_task_handle);
     move_parts_task_handle.reset();

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -2993,7 +2993,7 @@ void StorageReplicatedMergeTree::shutdown()
         queue_task_handle.reset();
     }
 
-    /// Block logs pulling after background task were cancelled. It's still
+    /// Cancel logs pulling after background task were cancelled. It's still
     /// required because we can trigger pullLogsToQueue during manual OPTIMIZE,
     /// MUTATE, etc query.
     queue.pull_log_blocker.cancelForever();

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -2980,7 +2980,6 @@ void StorageReplicatedMergeTree::shutdown()
     fetcher.blocker.cancelForever();
     merger_mutator.merges_blocker.cancelForever();
     parts_mover.moves_blocker.cancelForever();
-    queue.pull_log_blocker.cancelForever();
 
     restarting_thread.shutdown();
 
@@ -2993,6 +2992,11 @@ void StorageReplicatedMergeTree::shutdown()
         auto lock = queue.lockQueue();
         queue_task_handle.reset();
     }
+
+    /// Block logs pulling after background task were cancelled. It's still
+    /// required because we can trigger pullLogsToQueue during manual OPTIMIZE,
+    /// MUTATE, etc query.
+    queue.pull_log_blocker.cancelForever();
 
     if (move_parts_task_handle)
         global_context.getBackgroundMovePool().removeTask(move_parts_task_handle);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Get rid of exception from replicated queue during server shutdown. Fixes #10819.