### PR TITLE
Added multiple query formatting on clickhouse-format

### DIFF
--- a/programs/format/Format.cpp
+++ b/programs/format/Format.cpp
@@ -65,7 +65,7 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
                     std::cout << "\n;\n";
                 std::cout << std::endl;
             }
-        } while(multiple && pos != end);
+        } while (multiple && pos != end);
     }
     catch (...)
     {

--- a/programs/format/Format.cpp
+++ b/programs/format/Format.cpp
@@ -55,14 +55,14 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
         const char * end = pos + query.size();
 
         ParserQuery parser(end);
-        do {
+        do
+        {
             ASTPtr res = parseQueryAndMovePosition(parser, pos, end, "query", multiple, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
             if (!quiet)
             {
                 formatAST(*res, std::cout, hilite, oneline);
-                if (multiple) {
+                if (multiple)
                     std::cout << "\n;\n";
-                }
                 std::cout << std::endl;
             }
         } while(multiple && pos != end);

--- a/tests/queries/0_stateless/01278_format_multiple_queries.reference
+++ b/tests/queries/0_stateless/01278_format_multiple_queries.reference
@@ -1,0 +1,16 @@
+SELECT 
+    a, 
+    b AS x
+FROM table AS t
+INNER JOIN table2 AS t2 ON t.id = t2.t_id
+WHERE 1 = 1
+;
+
+SELECT 
+    a, 
+    b AS x, 
+    if(x = 0, a, b)
+FROM table2 AS t
+WHERE t.id != 0
+;
+

--- a/tests/queries/0_stateless/01278_format_multiple_queries.sh
+++ b/tests/queries/0_stateless/01278_format_multiple_queries.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. $CURDIR/../shell_config.sh
+
+set -e
+
+format="$CLICKHOUSE_FORMAT -n"
+
+$format <<EOF
+SELECT a, b AS x FROM table AS t
+    JOIN table2   AS   t2   ON   (t.id = t2.t_id) 
+    WHERE 1 = 1
+;
+SELECT a, b AS x,
+    x == 0 ? a : b
+FROM table2 AS t   WHERE t.id  !=  0
+EOF


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

The `clickhouse-format` tool is now able to format multiple queries when the `-n` argument is used.


Detailed description / Documentation draft:

If the `-n` is specified `clickhouse-format` will be able to format multiple queries printing `\n;\n`
as separation string between them.


By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.
