### PR TITLE
Fix SIGSEGV in StringHashTable (if such key does not exist)

### DIFF
--- a/src/Common/HashTable/StringHashTable.h
+++ b/src/Common/HashTable/StringHashTable.h
@@ -333,7 +333,11 @@ public:
         template <typename Submap, typename SubmapKey>
         auto ALWAYS_INLINE operator()(Submap & map, const SubmapKey & key, size_t hash)
         {
-            return &map.find(key, hash)->getMapped();
+            auto it = map.find(key, hash);
+            if (!it)
+                return decltype(&it->getMapped()){};
+            else
+                return &it->getMapped();
         }
     };
 

--- a/tests/queries/0_stateless/01279_dist_group_by.sql
+++ b/tests/queries/0_stateless/01279_dist_group_by.sql
@@ -1,0 +1,9 @@
+drop table if exists data_01279;
+
+create table data_01279 (key String) Engine=TinyLog();
+insert into data_01279 select reinterpretAsString(number) from numbers(100000);
+
+set max_rows_to_group_by=10;
+set group_by_overflow_mode='any';
+set group_by_two_level_threshold=100;
+select * from data_01279 group by key format Null;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix SIGSEGV in StringHashTable (if such key does not exist)

Fixes: #10797