### PR TITLE
Allow expected number of slower queries in performance test

### DIFF
--- a/docker/test/performance-comparison/report.py
+++ b/docker/test/performance-comparison/report.py
@@ -340,7 +340,8 @@ if args.report == 'main':
         message_array.append(str(faster_queries) + ' faster')
 
     if slower_queries:
-        status = 'failure'
+        if slower_queries > 3:
+            status = 'failure'
         message_array.append(str(slower_queries) + ' slower')
 
     if unstable_queries:


### PR DESCRIPTION
Changelog category (leave one):
- Non-significant (changelog entry is not required)

@akuzm explained that some number of slower queries is expected.
We should check how big is the slowdown even for this queries,
I encourage @akuzm to do it in next PR.