### PR TITLE
Fix error in multiple rename commands in a single query.

### DIFF
--- a/src/Core/Names.h
+++ b/src/Core/Names.h
@@ -15,6 +15,7 @@ using NameSet = std::unordered_set<std::string>;
 using NameOrderedSet = std::set<std::string>;
 using NameToNameMap = std::unordered_map<std::string, std::string>;
 using NameToNameSetMap = std::unordered_map<std::string, NameSet>;
+using NameToNameVector = std::vector<std::pair<std::string, std::string>>;
 
 using NameWithAlias = std::pair<std::string, std::string>;
 using NamesWithAliases = std::vector<NameWithAlias>;

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -814,7 +814,7 @@ void AlterCommands::validate(const StorageInMemoryMetadata & metadata, const Con
                if (next_command.type == AlterCommand::RENAME_COLUMN)
                {
                    if (next_command.column_name == command.rename_to)
-                       throw Exception{"Transitive renames in a single ALTER query are not allowed (don't make sence)",
+                       throw Exception{"Transitive renames in a single ALTER query are not allowed (don't make sense)",
                                                             ErrorCodes::NOT_IMPLEMENTED};
                    else if (next_command.column_name == command.column_name)
                        throw Exception{"Cannot rename column '" + backQuote(command.column_name)

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -128,6 +128,10 @@ public:
     String getNewName(const MergeTreePartInfo & new_part_info) const;
 
     /// Returns column position in part structure or std::nullopt if it's missing in part.
+    ///
+    /// NOTE: Doesn't take column renames into account, if some column renames
+    /// take place, you must take original name of column for this part from
+    /// storage and pass it to this method.
     std::optional<size_t> getColumnPosition(const String & column_name) const;
 
     /// Returns the name of a column with minimum compressed size (as returned by getColumnSize()).
@@ -291,7 +295,11 @@ public:
     /// Makes full clone of part in detached/ on another disk
     void makeCloneOnDiskDetached(const ReservationPtr & reservation) const;
 
-    /// Checks that .bin and .mrk files exist
+    /// Checks that .bin and .mrk files exist.
+    ///
+    /// NOTE: Doesn't take column renames into account, if some column renames
+    /// take place, you must take original name of column for this part from
+    /// storage and pass it to this method.
     virtual bool hasColumnFiles(const String & /* column */, const IDataType & /* type */) const{ return false; }
 
     static UInt64 calculateTotalSizeOnDisk(const DiskPtr & disk_, const String & from);

--- a/src/Storages/MergeTree/IMergeTreeReader.cpp
+++ b/src/Storages/MergeTree/IMergeTreeReader.cpp
@@ -187,16 +187,16 @@ void IMergeTreeReader::evaluateMissingDefaults(Block additional_columns, Columns
 
 NameAndTypePair IMergeTreeReader::getColumnFromPart(const NameAndTypePair & required_column) const
 {
-    auto it = columns_from_part.find(required_column.name);
-    if (it != columns_from_part.end())
-        return {it->first, it->second};
-
     if (alter_conversions.isColumnRenamed(required_column.name))
     {
         String old_name = alter_conversions.getColumnOldName(required_column.name);
-        it = columns_from_part.find(old_name);
+        auto it = columns_from_part.find(old_name);
         if (it != columns_from_part.end())
             return {it->first, it->second};
+    }
+    else if (auto it = columns_from_part.find(required_column.name); it != columns_from_part.end())
+    {
+        return {it->first, it->second};
     }
 
     return required_column;

--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
@@ -1085,7 +1085,7 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataMergerMutator::mutatePartToTempor
         auto indices_to_recalc = getIndicesToRecalculate(in, storage_from_source_part, updated_header.getNamesAndTypesList(), context);
 
         NameSet files_to_skip = collectFilesToSkip(updated_header, indices_to_recalc, mrk_extension);
-        NameToNameMap files_to_rename = collectFilesForRenames(source_part, for_file_renames, mrk_extension);
+        NameToNameVector files_to_rename = collectFilesForRenames(source_part, for_file_renames, mrk_extension);
 
         if (need_remove_expired_values)
             files_to_skip.insert("ttl.txt");
@@ -1097,7 +1097,8 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataMergerMutator::mutatePartToTempor
                 continue;
 
             String destination = new_part_tmp_path + "/";
-            auto rename_it = files_to_rename.find(it->name());
+            String file_name = it->name();
+            auto rename_it = std::find_if(files_to_rename.begin(), files_to_rename.end(), [&file_name](const auto & rename_pair) { return rename_pair.first == file_name; });
             if (rename_it != files_to_rename.end())
             {
                 if (rename_it->second.empty())
@@ -1328,7 +1329,7 @@ void MergeTreeDataMergerMutator::splitMutationCommands(
 }
 
 
-NameToNameMap MergeTreeDataMergerMutator::collectFilesForRenames(
+NameToNameVector MergeTreeDataMergerMutator::collectFilesForRenames(
     MergeTreeData::DataPartPtr source_part, const MutationCommands & commands_for_removes, const String & mrk_extension)
 {
     /// Collect counts for shared streams of different columns. As an example, Nested columns have shared stream with array sizes.
@@ -1343,14 +1344,14 @@ NameToNameMap MergeTreeDataMergerMutator::collectFilesForRenames(
             {});
     }
 
-    NameToNameMap rename_map;
+    NameToNameVector rename_vector;
     /// Remove old indices
     for (const auto & command : commands_for_removes)
     {
         if (command.type == MutationCommand::Type::DROP_INDEX)
         {
-            rename_map.emplace("skp_idx_" + command.column_name + ".idx", "");
-            rename_map.emplace("skp_idx_" + command.column_name + mrk_extension, "");
+            rename_vector.emplace_back("skp_idx_" + command.column_name + ".idx", "");
+            rename_vector.emplace_back("skp_idx_" + command.column_name + mrk_extension, "");
         }
         else if (command.type == MutationCommand::Type::DROP_COLUMN)
         {
@@ -1360,8 +1361,8 @@ NameToNameMap MergeTreeDataMergerMutator::collectFilesForRenames(
                 /// Delete files if they are no longer shared with another column.
                 if (--stream_counts[stream_name] == 0)
                 {
-                    rename_map.emplace(stream_name + ".bin", "");
-                    rename_map.emplace(stream_name + mrk_extension, "");
+                    rename_vector.emplace_back(stream_name + ".bin", "");
+                    rename_vector.emplace_back(stream_name + mrk_extension, "");
                 }
             };
 
@@ -1383,8 +1384,8 @@ NameToNameMap MergeTreeDataMergerMutator::collectFilesForRenames(
 
                 if (stream_from != stream_to)
                 {
-                    rename_map.emplace(stream_from + ".bin", stream_to + ".bin");
-                    rename_map.emplace(stream_from + mrk_extension, stream_to + mrk_extension);
+                    rename_vector.emplace_back(stream_from + ".bin", stream_to + ".bin");
+                    rename_vector.emplace_back(stream_from + mrk_extension, stream_to + mrk_extension);
                 }
             };
             IDataType::SubstreamPath stream_path;
@@ -1394,7 +1395,7 @@ NameToNameMap MergeTreeDataMergerMutator::collectFilesForRenames(
         }
     }
 
-    return rename_map;
+    return rename_vector;
 }
 
 NameSet MergeTreeDataMergerMutator::collectFilesToSkip(

--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
@@ -143,8 +143,10 @@ private:
         MutationCommands & for_interpreter,
         MutationCommands & for_file_renames);
 
-    /// Apply commands to source_part i.e. remove some columns in source_part
-    /// and return set of files, that have to be removed from filesystem and checksums
+    /// Apply commands to source_part i.e. remove and rename some columns in
+    /// source_part and return set of files, that have to be removed or renamed
+    /// from filesystem and in-memory checksums. Ordered result is important,
+    /// because we can apply renames that affects each other: x -> z, y -> x.
     static NameToNameVector collectFilesForRenames(MergeTreeData::DataPartPtr source_part, const MutationCommands & commands_for_removes, const String & mrk_extension);
 
     /// Files, that we don't need to remove and don't need to hardlink, for example columns.txt and checksums.txt.

--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
@@ -143,10 +143,9 @@ private:
         MutationCommands & for_interpreter,
         MutationCommands & for_file_renames);
 
-
     /// Apply commands to source_part i.e. remove some columns in source_part
     /// and return set of files, that have to be removed from filesystem and checksums
-    static NameToNameMap collectFilesForRenames(MergeTreeData::DataPartPtr source_part, const MutationCommands & commands_for_removes, const String & mrk_extension);
+    static NameToNameVector collectFilesForRenames(MergeTreeData::DataPartPtr source_part, const MutationCommands & commands_for_removes, const String & mrk_extension);
 
     /// Files, that we don't need to remove and don't need to hardlink, for example columns.txt and checksums.txt.
     /// Because we will generate new versions of them after we perform mutation.

--- a/tests/queries/0_stateless/01213_alter_rename_column.sql
+++ b/tests/queries/0_stateless/01213_alter_rename_column.sql
@@ -24,7 +24,7 @@ SELECT * FROM table_for_rename WHERE key = 1 FORMAT TSVWithNames;
 
 ALTER TABLE table_for_rename RENAME COLUMN value3 to value2; --{serverError 15}
 ALTER TABLE table_for_rename RENAME COLUMN value3 TO r1, RENAME COLUMN value3 TO r2; --{serverError 36}
-ALTER TABLE table_for_rename RENAME COLUMN value3 TO r1, RENAME COLUMN r1 TO value1; --{serverError 10}
+ALTER TABLE table_for_rename RENAME COLUMN value3 TO r1, RENAME COLUMN r1 TO value1; --{serverError 48}
 
 ALTER TABLE table_for_rename RENAME COLUMN value2 TO renamed_value2, RENAME COLUMN value3 TO renamed_value3;
 

--- a/tests/queries/0_stateless/01278_alter_rename_combination.reference
+++ b/tests/queries/0_stateless/01278_alter_rename_combination.reference
@@ -9,3 +9,7 @@ k	v1	v2
 CREATE TABLE default.rename_table_polymorphic\n(\n    `key` Int32, \n    `old_value1` Int32, \n    `value1` Int32\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS min_rows_for_wide_part = 10000, index_granularity = 8192
 key	old_value1	value1
 1	2	3
+CREATE TABLE default.rename_table_polymorphic\n(\n    `k` Int32, \n    `v1` Int32, \n    `v2` Int32\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS min_rows_for_wide_part = 10000, index_granularity = 8192
+k	v1	v2
+1	2	3
+4	5	6

--- a/tests/queries/0_stateless/01278_alter_rename_combination.reference
+++ b/tests/queries/0_stateless/01278_alter_rename_combination.reference
@@ -1,3 +1,11 @@
 CREATE TABLE default.rename_table\n(\n    `key` Int32, \n    `old_value1` Int32, \n    `value1` Int32\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
 key	old_value1	value1
 1	2	3
+CREATE TABLE default.rename_table\n(\n    `k` Int32, \n    `v1` Int32, \n    `v2` Int32\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+k	v1	v2
+1	2	3
+4	5	6
+---polymorphic---
+CREATE TABLE default.rename_table_polymorphic\n(\n    `key` Int32, \n    `old_value1` Int32, \n    `value1` Int32\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS min_rows_for_wide_part = 10000, index_granularity = 8192
+key	old_value1	value1
+1	2	3

--- a/tests/queries/0_stateless/01278_alter_rename_combination.reference
+++ b/tests/queries/0_stateless/01278_alter_rename_combination.reference
@@ -1,0 +1,3 @@
+CREATE TABLE default.rename_table\n(\n    `key` Int32, \n    `old_value1` Int32, \n    `value1` Int32\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+key	old_value1	value1
+1	2	3

--- a/tests/queries/0_stateless/01278_alter_rename_combination.sql
+++ b/tests/queries/0_stateless/01278_alter_rename_combination.sql
@@ -1,0 +1,14 @@
+DROP TABLE IF EXISTS rename_table;
+
+CREATE TABLE rename_table (key Int32, value1 Int32, value2 Int32) ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO rename_table VALUES (1, 2, 3);
+
+-- replace one with other
+ALTER TABLE rename_table RENAME COLUMN value1 TO old_value1, RENAME COLUMN value2 TO value1;
+
+SHOW CREATE TABLE rename_table;
+
+SELECT * FROM rename_table FORMAT TSVWithNames;
+
+DROP TABLE IF EXISTS rename_table;

--- a/tests/queries/0_stateless/01278_alter_rename_combination.sql
+++ b/tests/queries/0_stateless/01278_alter_rename_combination.sql
@@ -43,4 +43,13 @@ SHOW CREATE TABLE rename_table_polymorphic;
 
 SELECT * FROM rename_table_polymorphic FORMAT TSVWithNames;
 
+INSERT INTO rename_table_polymorphic VALUES (4, 5, 6);
+
+-- rename all columns simultaneously
+ALTER TABLE rename_table_polymorphic RENAME COLUMN old_value1 TO v1, RENAME COLUMN value1 TO v2, RENAME COLUMN key to k;
+
+SHOW CREATE TABLE rename_table_polymorphic;
+
+SELECT * FROM rename_table_polymorphic ORDER BY k FORMAT TSVWithNames;
+
 DROP TABLE IF EXISTS rename_table_polymorphic;

--- a/tests/queries/0_stateless/01278_alter_rename_combination.sql
+++ b/tests/queries/0_stateless/01278_alter_rename_combination.sql
@@ -11,4 +11,36 @@ SHOW CREATE TABLE rename_table;
 
 SELECT * FROM rename_table FORMAT TSVWithNames;
 
+INSERT INTO rename_table VALUES (4, 5, 6);
+
+-- rename all columns simultaneously
+ALTER TABLE rename_table RENAME COLUMN old_value1 TO v1, RENAME COLUMN value1 TO v2, RENAME COLUMN key to k;
+
+SHOW CREATE TABLE rename_table;
+
+SELECT * FROM rename_table ORDER BY k FORMAT TSVWithNames;
+
 DROP TABLE IF EXISTS rename_table;
+
+SELECT '---polymorphic---';
+
+DROP TABLE IF EXISTS rename_table_polymorphic;
+
+CREATE TABLE rename_table_polymorphic (
+  key Int32,
+  value1 Int32,
+  value2 Int32
+)
+ENGINE = MergeTree
+ORDER BY tuple()
+SETTINGS min_rows_for_wide_part = 10000;
+
+INSERT INTO rename_table_polymorphic VALUES (1, 2, 3);
+
+ALTER TABLE rename_table_polymorphic RENAME COLUMN value1 TO old_value1, RENAME COLUMN value2 TO value1;
+
+SHOW CREATE TABLE rename_table_polymorphic;
+
+SELECT * FROM rename_table_polymorphic FORMAT TSVWithNames;
+
+DROP TABLE IF EXISTS rename_table_polymorphic;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now it's possible to execute multiple `ALTER RENAME` like `a TO b, c TO a`.
