### PR TITLE
[WIP] Run test_kafka_consumer_hang integration test on CI

### DIFF
--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -198,7 +198,6 @@ def test_kafka_settings_new_syntax(kafka_cluster):
     kafka_check_result(result, True)
 
 
-@pytest.mark.skip(reason="https://github.com/edenhill/librdkafka/issues/2077")
 @pytest.mark.timeout(180)
 def test_kafka_consumer_hang(kafka_cluster):
 


### PR DESCRIPTION
Changelog category (leave one):
- Non-significant (changelog entry is not required)

Let's see if the test will fail on CI (since it does not fails on @filimonov env, while fails on mine)

Cc: @filimonov 
Refs: #10656 

P.S You may find this [script](https://gist.github.com/azat/d3becd178f4c85a3756925cbd4c7ebe7) useful (will add colors for kafka debug logs)