### PR TITLE
Fix for the hang during deletion of engine=Kafka

### DIFF
--- a/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
+++ b/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
@@ -80,31 +80,9 @@ ReadBufferFromKafkaConsumer::ReadBufferFromKafkaConsumer(
     });
 }
 
-ReadBufferFromKafkaConsumer::~ReadBufferFromKafkaConsumer()
-{
-    try
-    {
-        if (!consumer->get_subscription().empty())
-            consumer->unsubscribe();
-    }
-    catch (const cppkafka::HandleException & e)
-    {
-        LOG_ERROR(log, "Exception from ReadBufferFromKafkaConsumer destructor (unsubscribe): " << e.what());
-    }
-
-    try
-    {
-        // we need to drain rest of the messages / queued callback calls from the consumer
-        // after unsubscribe, otherwise consumer will hang on destruction
-        // see https://github.com/edenhill/librdkafka/issues/2077
-        //     https://github.com/confluentinc/confluent-kafka-go/issues/189 etc.
-        while (consumer->poll(100ms));
-    }
-    catch (const cppkafka::HandleException & e)
-    {
-        LOG_ERROR(log, "Exception from ReadBufferFromKafkaConsumer destructor (drain): " << e.what());
-    }
-}
+// NOTE on removed desctuctor: There is no need to unsubscribe prior to calling rd_kafka_consumer_close().
+// check: https://github.com/edenhill/librdkafka/blob/master/INTRODUCTION.md#termination
+// manual destruction was source of weird errors (hangs during droping kafka table, etc.)
 
 void ReadBufferFromKafkaConsumer::commit()
 {
@@ -235,8 +213,13 @@ void ReadBufferFromKafkaConsumer::unsubscribe()
     // it should not raise exception as used in destructor
     try
     {
-        if (!consumer->get_subscription().empty())
-            consumer->unsubscribe();
+        // From docs: Any previous subscription will be unassigned and unsubscribed first.
+        consumer->subscribe(topics);
+
+        // I wanted to avoid explicit unsubscribe as it requires draining the messages
+        // to close the consumer safely after unsubscribe
+        // see https://github.com/edenhill/librdkafka/issues/2077
+        //     https://github.com/confluentinc/confluent-kafka-go/issues/189 etc.
     }
     catch (const cppkafka::HandleException & e)
     {

--- a/src/Storages/Kafka/ReadBufferFromKafkaConsumer.h
+++ b/src/Storages/Kafka/ReadBufferFromKafkaConsumer.h
@@ -28,7 +28,6 @@ public:
         const std::atomic<bool> & stopped_,
         const Names & _topics
     );
-    ~ReadBufferFromKafkaConsumer() override;
 
     void allowNext() { allowed = true; } // Allow to read next message.
     void commit(); // Commit all processed messages.
@@ -64,10 +63,13 @@ private:
 
     const std::atomic<bool> & stopped;
 
+    // order is important, need to be destructed before consumer
     Messages messages;
     Messages::const_iterator current;
 
     bool rebalance_happened = false;
+
+    // order is important, need to be destructed before consumer
     cppkafka::TopicPartitionList assignment;
     const Names topics;
 

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -235,14 +235,19 @@ ProducerBufferPtr StorageKafka::createWriteBuffer(const Block & header)
 ConsumerBufferPtr StorageKafka::createReadBuffer()
 {
     cppkafka::Configuration conf;
+
     conf.set("metadata.broker.list", brokers);
     conf.set("group.id", group);
     conf.set("client.id", VERSION_FULL);
+
     conf.set("auto.offset.reset", "smallest");     // If no offset stored for this group, read all messages from the start
+
+    updateConfiguration(conf);
+
+    // those settings should not be changed by users.
     conf.set("enable.auto.commit", "false");       // We manually commit offsets after a stream successfully finished
     conf.set("enable.auto.offset.store", "false"); // Update offset automatically - to commit them all at once.
     conf.set("enable.partition.eof", "false");     // Ignore EOF messages
-    updateConfiguration(conf);
 
     // Create a consumer and subscribe to topics
     auto consumer = std::make_shared<cppkafka::Consumer>(conf);

--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -242,9 +242,6 @@ def test_kafka_consumer_hang(kafka_cluster):
     # BROKERFAIL -> |ASSIGN| -> REBALANCE_IN_PROGRESS -> "waiting for rebalance_cb" (repeated forever)
     # so it was waiting forever while the application will execute queued rebalance callback
 
-    # now we drain all queued callbacks (visible as 'Rebalance initiated' after 'Waiting for cleanup')
-    instance.exec_in_container(["bash", "-c", "tail -n 500 /var/log/clickhouse-server/clickhouse-server.log | grep 'Waiting for cleanup' -A 500 | grep -q 'Rebalance initiated. Revoking partitions'"])
-
     # from a user perspective: we expect no hanging 'drop' queries
     # 'dr'||'op' to avoid self matching
     assert int(instance.query("select count() from system.processes where position(lower(query),'dr'||'op')>0")) == 0

--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -238,7 +238,7 @@ def test_kafka_consumer_hang(kafka_cluster):
         DROP TABLE test.view;
     ''')
 
-    # original problem appearance was a sequence of the following messages in kafka logs:
+    # original problem appearance was a sequence of the following messages in librdkafka logs:
     # BROKERFAIL -> |ASSIGN| -> REBALANCE_IN_PROGRESS -> "waiting for rebalance_cb" (repeated forever)
     # so it was waiting forever while the application will execute queued rebalance callback
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix for the hang which was happening sometimes during DROP of table engine=Kafka (or during server restarts).

Detailed description / Documentation draft:
In general, it looks like the shutdown sequence was a bit incorrect, and librdkafka is very restrictive in that part.

Kudos to @azat for test case (#10656)

Fixes #7260 #10740
