### PR TITLE
Static mutate

### DIFF
--- a/programs/obfuscator/Obfuscator.cpp
+++ b/programs/obfuscator/Obfuscator.cpp
@@ -858,7 +858,7 @@ public:
 
         ColumnPtr new_nested_column = nested_model->generate(nested_column);
 
-        return ColumnArray::create((*std::move(new_nested_column)).mutate(), (*std::move(column_array.getOffsetsPtr())).mutate());
+        return ColumnArray::create(IColumn::mutate(std::move(new_nested_column)), IColumn::mutate(std::move(column_array.getOffsetsPtr())));
     }
 
     void updateSeed() override
@@ -896,7 +896,7 @@ public:
 
         ColumnPtr new_nested_column = nested_model->generate(nested_column);
 
-        return ColumnNullable::create((*std::move(new_nested_column)).mutate(), (*std::move(column_nullable.getNullMapColumnPtr())).mutate());
+        return ColumnNullable::create(IColumn::mutate(std::move(new_nested_column)), IColumn::mutate(std::move(column_nullable.getNullMapColumnPtr())));
     }
 
     void updateSeed() override

--- a/src/Columns/ColumnLowCardinality.cpp
+++ b/src/Columns/ColumnLowCardinality.cpp
@@ -190,7 +190,7 @@ void ColumnLowCardinality::insertRangeFrom(const IColumn & src, size_t start, si
 
         /// TODO: Support native insertion from other unique column. It will help to avoid null map creation.
 
-        auto sub_idx = (*low_cardinality_src->getIndexes().cut(start, length)).mutate();
+        auto sub_idx = IColumn::mutate(low_cardinality_src->getIndexes().cut(start, length));
         auto idx_map = mapUniqueIndex(*sub_idx);
 
         auto src_nested = low_cardinality_src->getDictionary().getNestedColumn();
@@ -268,7 +268,7 @@ MutableColumnPtr ColumnLowCardinality::cloneResized(size_t size) const
     if (size == 0)
         unique_ptr = unique_ptr->cloneEmpty();
 
-    return ColumnLowCardinality::create((*std::move(unique_ptr)).mutate(), getIndexes().cloneResized(size));
+    return ColumnLowCardinality::create(IColumn::mutate(std::move(unique_ptr)), getIndexes().cloneResized(size));
 }
 
 int ColumnLowCardinality::compareAt(size_t n, size_t m, const IColumn & rhs, int nan_direction_hint) const
@@ -320,7 +320,7 @@ std::vector<MutableColumnPtr> ColumnLowCardinality::scatter(ColumnIndex num_colu
     for (auto & column : columns)
     {
         auto unique_ptr = dictionary.getColumnUniquePtr();
-        column = ColumnLowCardinality::create((*std::move(unique_ptr)).mutate(), std::move(column));
+        column = ColumnLowCardinality::create(IColumn::mutate(std::move(unique_ptr)), std::move(column));
     }
 
     return columns;
@@ -337,7 +337,7 @@ void ColumnLowCardinality::setSharedDictionary(const ColumnPtr & column_unique)
 
 ColumnLowCardinality::MutablePtr ColumnLowCardinality::cutAndCompact(size_t start, size_t length) const
 {
-    auto sub_positions = (*idx.getPositions()->cut(start, length)).mutate();
+    auto sub_positions = IColumn::mutate(idx.getPositions()->cut(start, length));
     /// Create column with new indexes and old dictionary.
     /// Dictionary is shared, but will be recreated after compactInplace call.
     auto column = ColumnLowCardinality::create(getDictionary().assumeMutable(), std::move(sub_positions));
@@ -364,7 +364,7 @@ void ColumnLowCardinality::compactIfSharedDictionary()
 ColumnLowCardinality::DictionaryEncodedColumn
 ColumnLowCardinality::getMinimalDictionaryEncodedColumn(UInt64 offset, UInt64 limit) const
 {
-    MutableColumnPtr sub_indexes = (*std::move(idx.getPositions()->cut(offset, limit))).mutate();
+    MutableColumnPtr sub_indexes = IColumn::mutate(idx.getPositions()->cut(offset, limit));
     auto indexes_map = mapUniqueIndex(*sub_indexes);
     auto sub_keys = getDictionary().getNestedColumn()->index(*indexes_map, 0);
 
@@ -710,7 +710,7 @@ void ColumnLowCardinality::Dictionary::compact(ColumnPtr & positions)
     auto sub_keys = unique.getNestedColumn()->index(*indexes, 0);
     auto new_indexes = new_unique.uniqueInsertRangeFrom(*sub_keys, 0, sub_keys->size());
 
-    positions = (*new_indexes->index(*positions, 0)).mutate();
+    positions = IColumn::mutate(new_indexes->index(*positions, 0));
     column_unique = std::move(new_column_unique);
 
     shared = false;

--- a/src/Columns/FilterDescription.cpp
+++ b/src/Columns/FilterDescription.cpp
@@ -64,7 +64,7 @@ FilterDescription::FilterDescription(const IColumn & column_)
     if (const auto * nullable_column = checkAndGetColumn<ColumnNullable>(column))
     {
         ColumnPtr nested_column = nullable_column->getNestedColumnPtr();
-        MutableColumnPtr mutable_holder = (*std::move(nested_column)).mutate();
+        MutableColumnPtr mutable_holder = IColumn::mutate(std::move(nested_column));
 
         ColumnUInt8 * concrete_column = typeid_cast<ColumnUInt8 *>(mutable_holder.get());
         if (!concrete_column)

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -304,10 +304,10 @@ public:
     }
 
 
-    MutablePtr mutate() const &&
+    static MutablePtr mutate(Ptr ptr)
     {
-        MutablePtr res = shallowMutate();
-        res->forEachSubcolumn([](WrappedPtr & subcolumn) { subcolumn = std::move(*subcolumn).mutate(); });
+        MutablePtr res = ptr->shallowMutate();
+        res->forEachSubcolumn([](WrappedPtr & subcolumn) { subcolumn = IColumn::mutate(std::move(subcolumn)); });
         return res;
     }
 

--- a/src/Common/COW.h
+++ b/src/Common/COW.h
@@ -177,7 +177,7 @@ protected:
 public:
     static MutablePtr mutate(Ptr ptr)
     {
-        return ptr.shallowMutate();
+        return ptr->shallowMutate();
     }
 
     MutablePtr assumeMutable() const

--- a/src/Common/COW.h
+++ b/src/Common/COW.h
@@ -79,22 +79,12 @@ private:
     Derived * derived() { return static_cast<Derived *>(this); }
     const Derived * derived() const { return static_cast<const Derived *>(this); }
 
-    template <typename T>
-    class IntrusivePtr : public boost::intrusive_ptr<T>
-    {
-    public:
-        using boost::intrusive_ptr<T>::intrusive_ptr;
-
-        T & operator*() const & { return boost::intrusive_ptr<T>::operator*(); }
-        T && operator*() const && { return const_cast<typename std::remove_const<T>::type &&>(*boost::intrusive_ptr<T>::get()); }
-    };
-
 protected:
     template <typename T>
-    class mutable_ptr : public IntrusivePtr<T>
+    class mutable_ptr : public boost::intrusive_ptr<T>
     {
     private:
-        using Base = IntrusivePtr<T>;
+        using Base = boost::intrusive_ptr<T>;
 
         template <typename> friend class COW;
         template <typename, typename> friend class COWHelper;
@@ -123,10 +113,10 @@ public:
 
 protected:
     template <typename T>
-    class immutable_ptr : public IntrusivePtr<const T>
+    class immutable_ptr : public boost::intrusive_ptr<const T>
     {
     private:
-        using Base = IntrusivePtr<const T>;
+        using Base = boost::intrusive_ptr<const T>;
 
         template <typename> friend class COW;
         template <typename, typename> friend class COWHelper;

--- a/src/Common/COW.h
+++ b/src/Common/COW.h
@@ -50,7 +50,7 @@
     /// Change value of x.
     {
         /// Creating mutable ptr. It can clone an object under the hood if it was shared.
-        Column::MutablePtr mutate_x = std::move(*x).mutate();
+        Column::MutablePtr mutate_x = IColumn::mutate(std::move(x));
         /// Using non-const methods of an object.
         mutate_x->set(2);
         /// Assigning pointer 'x' to mutated object.
@@ -185,9 +185,9 @@ protected:
     }
 
 public:
-    MutablePtr mutate() const &&
+    static MutablePtr mutate(Ptr ptr)
     {
-        return shallowMutate();
+        return ptr.shallowMutate();
     }
 
     MutablePtr assumeMutable() const

--- a/src/Common/tests/cow_columns.cpp
+++ b/src/Common/tests/cow_columns.cpp
@@ -53,7 +53,7 @@ int main(int, char **)
     std::cerr << "addresses: " << x.get() << ", " << y.get() << "\n";
 
     {
-        MutableColumnPtr mut = std::move(*y).mutate();
+        MutableColumnPtr mut = IColumn::mutate(std::move(y));
         mut->set(2);
 
         std::cerr << "refcounts: " << x->use_count() << ", " << y->use_count() << ", " << mut->use_count() << "\n";
@@ -72,7 +72,7 @@ int main(int, char **)
     std::cerr << "addresses: " << x.get() << ", " << y.get() << "\n";
 
     {
-        MutableColumnPtr mut = std::move(*y).mutate();
+        MutableColumnPtr mut = IColumn::mutate(std::move(y));
         mut->set(3);
 
         std::cerr << "refcounts: " << x->use_count() << ", " << y->use_count() << ", " << mut->use_count() << "\n";

--- a/src/Common/tests/cow_compositions.cpp
+++ b/src/Common/tests/cow_compositions.cpp
@@ -18,7 +18,7 @@ public:
     virtual int get() const = 0;
     virtual void set(int value) = 0;
 
-    MutablePtr mutate() const && { return deepMutate(); }
+    static MutablePtr mutate(Ptr ptr) { return ptr->deepMutate(); }
 };
 
 using ColumnPtr = IColumn::Ptr;
@@ -52,7 +52,7 @@ private:
     {
         std::cerr << "Mutating\n";
         auto res = shallowMutate();
-        res->wrapped = std::move(*wrapped).mutate();
+        res->wrapped = IColumn::mutate(std::move(wrapped));
         return res;
     }
 
@@ -72,7 +72,7 @@ int main(int, char **)
     std::cerr << "addresses: " << x.get() << ", " << y.get() << "\n";
 
     {
-        MutableColumnPtr mut = std::move(*y).mutate();
+        MutableColumnPtr mut = IColumn::mutate(std::move(y));
         mut->set(2);
 
         std::cerr << "refcounts: " << x->use_count() << ", " << y->use_count() << ", " << mut->use_count() << "\n";
@@ -91,7 +91,7 @@ int main(int, char **)
     std::cerr << "addresses: " << x.get() << ", " << y.get() << "\n";
 
     {
-        MutableColumnPtr mut = std::move(*y).mutate();
+        MutableColumnPtr mut = IColumn::mutate(std::move(y));
         mut->set(3);
 
         std::cerr << "refcounts: " << x->use_count() << ", " << y->use_count() << ", " << mut->use_count() << "\n";

--- a/src/Core/Block.cpp
+++ b/src/Core/Block.cpp
@@ -335,7 +335,7 @@ MutableColumns Block::mutateColumns()
     size_t num_columns = data.size();
     MutableColumns columns(num_columns);
     for (size_t i = 0; i < num_columns; ++i)
-        columns[i] = data[i].column ? (*std::move(data[i].column)).mutate() : data[i].type->createColumn();
+        columns[i] = data[i].column ? IColumn::mutate(std::move(data[i].column)) : data[i].type->createColumn();
     return columns;
 }
 

--- a/src/DataStreams/AddingDefaultsBlockInputStream.cpp
+++ b/src/DataStreams/AddingDefaultsBlockInputStream.cpp
@@ -191,7 +191,7 @@ Block AddingDefaultsBlockInputStream::readImpl()
             /// TODO: FixedString
             if (isColumnedAsNumber(column_read.type) || isDecimal(column_read.type))
             {
-                MutableColumnPtr column_mixed = (*std::move(column_read.column)).mutate();
+                MutableColumnPtr column_mixed = IColumn::mutate(std::move(column_read.column));
                 mixNumberColumns(column_read.type->getTypeId(), column_mixed, column_def.column, defaults_mask);
                 column_read.column = std::move(column_mixed);
             }

--- a/src/DataStreams/MergingSortedBlockInputStream.cpp
+++ b/src/DataStreams/MergingSortedBlockInputStream.cpp
@@ -198,7 +198,7 @@ void MergingSortedBlockInputStream::merge(MutableColumns & merged_columns, TSort
                 for (size_t i = 0; i < num_columns; ++i)
                 {
                     auto & column = merged_columns[i];
-                    column = (*column->cut(0, merged_rows)).mutate();
+                    column = IColumn::mutate(column->cut(0, merged_rows));
                 }
 
                 cancel(false);

--- a/src/DataStreams/MergingSortedBlockInputStream.cpp
+++ b/src/DataStreams/MergingSortedBlockInputStream.cpp
@@ -185,7 +185,7 @@ void MergingSortedBlockInputStream::merge(MutableColumns & merged_columns, TSort
                 throw Exception("Logical error in MergingSortedBlockInputStream", ErrorCodes::LOGICAL_ERROR);
 
             for (size_t i = 0; i < num_columns; ++i)
-                merged_columns[i] = (*std::move(source_blocks[source_num].getByPosition(i).column)).mutate();
+                merged_columns[i] = IColumn::mutate(std::move(source_blocks[source_num].getByPosition(i).column));
 
 //            std::cerr << "copied columns\n";
 

--- a/src/DataStreams/SquashingTransform.cpp
+++ b/src/DataStreams/SquashingTransform.cpp
@@ -95,8 +95,7 @@ void SquashingTransform::append(ReferenceType input_block)
     {
         const auto source_column = input_block.getByPosition(i).column;
 
-        auto mutable_column = (*std::move(
-            accumulated_block.getByPosition(i).column)).mutate();
+        auto mutable_column = IColumn::mutate(std::move(accumulated_block.getByPosition(i).column));
 
         if (reserve_memory)
         {

--- a/src/DataStreams/finalizeBlock.cpp
+++ b/src/DataStreams/finalizeBlock.cpp
@@ -18,7 +18,7 @@ namespace DB
                 current.type = unfinalized_type->getReturnType();
                 if (current.column)
                 {
-                    auto mut_column = (*std::move(current.column)).mutate();
+                    auto mut_column = IColumn::mutate(std::move(current.column));
                     current.column = ColumnAggregateFunction::convertToValues(std::move(mut_column));
                 }
             }

--- a/src/DataStreams/tests/finish_sorting_stream.cpp
+++ b/src/DataStreams/tests/finish_sorting_stream.cpp
@@ -80,7 +80,7 @@ int main(int argc, char ** argv)
             {
                 for (size_t i = 0; i < block.columns(); ++i)
                 {
-                    MutableColumnPtr ptr = (*std::move(res_block.getByPosition(i).column)).mutate();
+                    MutableColumnPtr ptr = IColumn::mutate(std::move(res_block.getByPosition(i).column));
                     ptr->insertRangeFrom(*block.getByPosition(i).column.get(), 0, block.rows());
                 }
             }

--- a/src/DataTypes/DataTypeLowCardinality.cpp
+++ b/src/DataTypes/DataTypeLowCardinality.cpp
@@ -672,7 +672,7 @@ void DataTypeLowCardinality::deserializeBinaryBulkWithMultipleStreams(
             ColumnLowCardinality::Index(indexes_column->getPtr()).check(
                     maps.dictionary_map->size() + maps.additional_keys_map->size());
 
-            auto used_keys = (*std::move(global_dictionary->getNestedColumn()->index(*maps.dictionary_map, 0))).mutate();
+            auto used_keys = IColumn::mutate(global_dictionary->getNestedColumn()->index(*maps.dictionary_map, 0));
 
             if (!maps.additional_keys_map->empty())
             {

--- a/src/Dictionaries/PolygonDictionary.cpp
+++ b/src/Dictionaries/PolygonDictionary.cpp
@@ -200,7 +200,7 @@ void IPolygonDictionary::blockToAttributes(const DB::Block &block)
         const auto & column = block.safeGetByPosition(i + 1);
         if (attributes[i])
         {
-            MutableColumnPtr mutated = std::move(*attributes[i]).mutate();
+            MutableColumnPtr mutated = IColumn::mutate(std::move(attributes[i]));
             mutated->insertRangeFrom(*column.column, 0, column.column->size());
             attributes[i] = std::move(mutated);
         }

--- a/src/Functions/FunctionsExternalModels.cpp
+++ b/src/Functions/FunctionsExternalModels.cpp
@@ -100,7 +100,7 @@ void FunctionModelEvaluate::executeImpl(Block & block, const ColumnNumbers & arg
                 null_map = col_nullable->getNullMapColumnPtr();
             else
             {
-                auto mut_null_map = (*std::move(null_map)).mutate();
+                auto mut_null_map = IColumn::mutate(std::move(null_map));
 
                 NullMap & result_null_map = assert_cast<ColumnUInt8 &>(*mut_null_map).getData();
                 const NullMap & src_null_map = col_nullable->getNullMapColumn().getData();

--- a/src/Functions/IFunction.cpp
+++ b/src/Functions/IFunction.cpp
@@ -147,7 +147,7 @@ ColumnPtr wrapInNullable(const ColumnPtr & src, const Block & block, const Colum
             }
             else
             {
-                MutableColumnPtr mutable_result_null_map_column = (*std::move(result_null_map_column)).mutate();
+                MutableColumnPtr mutable_result_null_map_column = IColumn::mutate(std::move(result_null_map_column));
 
                 NullMap & result_null_map = assert_cast<ColumnUInt8 &>(*mutable_result_null_map_column).getData();
                 const NullMap & src_null_map = assert_cast<const ColumnUInt8 &>(*null_map_column).getData();

--- a/src/Functions/array/FunctionArrayMapped.h
+++ b/src/Functions/array/FunctionArrayMapped.h
@@ -222,7 +222,7 @@ public:
             }
 
             /// Put all the necessary columns multiplied by the sizes of arrays into the block.
-            auto replicated_column_function_ptr = (*column_function->replicate(column_first_array->getOffsets())).mutate();
+            auto replicated_column_function_ptr = IColumn::mutate(column_function->replicate(column_first_array->getOffsets()));
             auto * replicated_column_function = typeid_cast<ColumnFunction *>(replicated_column_function_ptr.get());
             replicated_column_function->appendArguments(arrays);
 

--- a/src/Functions/array/arrayUniq.cpp
+++ b/src/Functions/array/arrayUniq.cpp
@@ -119,7 +119,8 @@ private:
 void FunctionArrayUniq::executeImpl(Block & block, const ColumnNumbers & arguments, size_t result, size_t /*input_rows_count*/)
 {
     const ColumnArray::Offsets * offsets = nullptr;
-    size_t num_arguments = arguments.size();
+    const size_t num_arguments = arguments.size();
+    assert(num_arguments > 0);
     ColumnRawPtrs data_columns(num_arguments);
 
     Columns array_holders;

--- a/src/Functions/concat.cpp
+++ b/src/Functions/concat.cpp
@@ -116,16 +116,17 @@ private:
 
     void executeFormatImpl(Block & block, const ColumnNumbers & arguments, const size_t result, size_t input_rows_count)
     {
-        assert(arguments.size() > 2);
+        const size_t num_arguments = arguments.size();
+        assert(num_arguments > 2);
 
         auto c_res = ColumnString::create();
-        std::vector<const ColumnString::Chars *> data(arguments.size());
-        std::vector<const ColumnString::Offsets *> offsets(arguments.size());
-        std::vector<size_t> fixed_string_sizes(arguments.size());
-        std::vector<String> constant_strings(arguments.size());
+        std::vector<const ColumnString::Chars *> data(num_arguments);
+        std::vector<const ColumnString::Offsets *> offsets(num_arguments);
+        std::vector<size_t> fixed_string_sizes(num_arguments);
+        std::vector<String> constant_strings(num_arguments);
         bool has_column_string = false;
         bool has_column_fixed_string = false;
-        for (size_t i = 0; i < arguments.size(); ++i)
+        for (size_t i = 0; i < num_arguments; ++i)
         {
             const ColumnPtr & column = block.getByPosition(arguments[i]).column;
             if (const ColumnString * col = checkAndGetColumn<ColumnString>(column.get()))
@@ -150,9 +151,9 @@ private:
         }
 
         String pattern;
-        pattern.reserve(2 * arguments.size());
+        pattern.reserve(2 * num_arguments);
 
-        for (size_t i = 0; i < arguments.size(); ++i)
+        for (size_t i = 0; i < num_arguments; ++i)
             pattern += "{}";
 
         FormatImpl::formatExecute(

--- a/src/Functions/concat.cpp
+++ b/src/Functions/concat.cpp
@@ -73,6 +73,12 @@ public:
 
     void executeImpl(Block & block, const ColumnNumbers & arguments, size_t result, size_t input_rows_count) override
     {
+        if (arguments.size() < 2)
+            throw Exception(
+                    "Number of arguments for function " + getName() + " doesn't match: passed " + toString(arguments.size())
+                    + ", should be at least 2.",
+                    ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
+
         /// Format function is not proven to be faster for two arguments.
         /// Actually there is overhead of 2 to 5 extra instructions for each string for checking empty strings in FormatImpl.
         /// Though, benchmarks are really close, for most examples we saw executeBinary is slightly faster (0-3%).

--- a/src/Functions/concat.cpp
+++ b/src/Functions/concat.cpp
@@ -73,12 +73,6 @@ public:
 
     void executeImpl(Block & block, const ColumnNumbers & arguments, size_t result, size_t input_rows_count) override
     {
-        if (arguments.size() < 2)
-            throw Exception(
-                    "Number of arguments for function " + getName() + " doesn't match: passed " + toString(arguments.size())
-                    + ", should be at least 2.",
-                    ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
-
         /// Format function is not proven to be faster for two arguments.
         /// Actually there is overhead of 2 to 5 extra instructions for each string for checking empty strings in FormatImpl.
         /// Though, benchmarks are really close, for most examples we saw executeBinary is slightly faster (0-3%).
@@ -122,6 +116,8 @@ private:
 
     void executeFormatImpl(Block & block, const ColumnNumbers & arguments, const size_t result, size_t input_rows_count)
     {
+        assert(arguments.size() > 2);
+
         auto c_res = ColumnString::create();
         std::vector<const ColumnString::Chars *> data(arguments.size());
         std::vector<const ColumnString::Offsets *> offsets(arguments.size());

--- a/src/Functions/concat.cpp
+++ b/src/Functions/concat.cpp
@@ -117,7 +117,7 @@ private:
     void executeFormatImpl(Block & block, const ColumnNumbers & arguments, const size_t result, size_t input_rows_count)
     {
         const size_t num_arguments = arguments.size();
-        assert(num_arguments > 2);
+        assert(num_arguments >= 2);
 
         auto c_res = ColumnString::create();
         std::vector<const ColumnString::Chars *> data(num_arguments);

--- a/src/Functions/finalizeAggregation.cpp
+++ b/src/Functions/finalizeAggregation.cpp
@@ -65,7 +65,7 @@ public:
                 ErrorCodes::ILLEGAL_COLUMN);
 
         /// Column is copied here, because there is no guarantee that we own it.
-        auto mut_column = (*std::move(column)).mutate();
+        auto mut_column = IColumn::mutate(std::move(column));
         block.getByPosition(result).column = ColumnAggregateFunction::convertToValues(std::move(mut_column));
     }
 };

--- a/src/Functions/if.cpp
+++ b/src/Functions/if.cpp
@@ -816,7 +816,7 @@ private:
                 if (isColumnNullable(*arg_else.column))
                 {
                     auto arg_else_column = arg_else.column;
-                    auto result_column = (*std::move(arg_else_column)).mutate();
+                    auto result_column = IColumn::mutate(std::move(arg_else_column));
                     assert_cast<ColumnNullable &>(*result_column).applyNullMap(assert_cast<const ColumnUInt8 &>(*arg_cond.column));
                     block.getByPosition(result).column = std::move(result_column);
                 }
@@ -858,7 +858,7 @@ private:
                 if (isColumnNullable(*arg_then.column))
                 {
                     auto arg_then_column = arg_then.column;
-                    auto result_column = (*std::move(arg_then_column)).mutate();
+                    auto result_column = IColumn::mutate(std::move(arg_then_column));
                     assert_cast<ColumnNullable &>(*result_column).applyNegatedNullMap(assert_cast<const ColumnUInt8 &>(*arg_cond.column));
                     block.getByPosition(result).column = std::move(result_column);
                 }

--- a/src/Interpreters/DictionaryReader.cpp
+++ b/src/Interpreters/DictionaryReader.cpp
@@ -119,7 +119,7 @@ void DictionaryReader::readKeys(const IColumn & keys, Block & out_block, ColumnV
     /// calculate and extract dictHas()
     function_has->execute(working_block, size);
     ColumnWithTypeAndName & has_column = working_block.getByPosition(has_position);
-    auto mutable_has = (*std::move(has_column.column)).mutate();
+    auto mutable_has = IColumn::mutate(std::move(has_column.column));
     found.swap(typeid_cast<ColumnVector<UInt8> &>(*mutable_has).getData());
     has_column.column = nullptr;
 

--- a/src/Interpreters/HashJoin.cpp
+++ b/src/Interpreters/HashJoin.cpp
@@ -108,7 +108,7 @@ static ColumnWithTypeAndName correctNullability(ColumnWithTypeAndName && column,
         JoinCommon::convertColumnToNullable(column);
         if (column.type->isNullable() && !negative_null_map.empty())
         {
-            MutableColumnPtr mutable_column = (*std::move(column.column)).mutate();
+            MutableColumnPtr mutable_column = IColumn::mutate(std::move(column.column));
             assert_cast<ColumnNullable &>(*mutable_column).applyNegatedNullMap(negative_null_map);
             column.column = std::move(mutable_column);
         }
@@ -127,7 +127,7 @@ static void changeNullability(MutableColumnPtr & mutable_column)
     else
         column = makeNullable(column);
 
-    mutable_column = (*std::move(column)).mutate();
+    mutable_column = IColumn::mutate(std::move(column));
 }
 
 static ColumnPtr emptyNotNullableClone(const ColumnPtr & column)

--- a/src/Interpreters/MetricLog.cpp
+++ b/src/Interpreters/MetricLog.cpp
@@ -50,6 +50,8 @@ void MetricLogElement::appendToBlock(Block & block) const
 
     for (size_t i = 0, end = CurrentMetrics::end(); i < end; ++i)
         columns[column_idx++]->insert(current_metrics[i]);
+
+    block.setColumns(std::move(columns));
 }
 
 

--- a/src/Interpreters/NullableUtils.cpp
+++ b/src/Interpreters/NullableUtils.cpp
@@ -33,7 +33,7 @@ ColumnPtr extractNestedColumnsAndNullMap(ColumnRawPtrs & key_columns, ConstNullM
                 }
                 else
                 {
-                    MutableColumnPtr mutable_null_map_holder = (*std::move(null_map_holder)).mutate();
+                    MutableColumnPtr mutable_null_map_holder = IColumn::mutate(std::move(null_map_holder));
 
                     PaddedPODArray<UInt8> & mutable_null_map = assert_cast<ColumnUInt8 &>(*mutable_null_map_holder).getData();
                     const PaddedPODArray<UInt8> & other_null_map = column_nullable->getNullMapData();

--- a/src/Interpreters/QueryThreadLog.cpp
+++ b/src/Interpreters/QueryThreadLog.cpp
@@ -107,6 +107,8 @@ void QueryThreadLogElement::appendToBlock(Block & block) const
         columns[i++]->insertDefault();
         columns[i++]->insertDefault();
     }
+
+    block.setColumns(std::move(columns));
 }
 
 }

--- a/src/Interpreters/TextLog.cpp
+++ b/src/Interpreters/TextLog.cpp
@@ -68,6 +68,8 @@ void TextLogElement::appendToBlock(Block & block) const
 
     columns[i++]->insert(source_file);
     columns[i++]->insert(source_line);
+
+    block.setColumns(std::move(columns));
 }
 
 TextLog::TextLog(Context & context_, const String & database_name_,

--- a/src/Interpreters/join_common.cpp
+++ b/src/Interpreters/join_common.cpp
@@ -43,7 +43,7 @@ void removeColumnNullability(ColumnWithTypeAndName & column)
     {
         const auto * nullable_column = checkAndGetColumn<ColumnNullable>(*column.column);
         ColumnPtr nested_column = nullable_column->getNestedColumnPtr();
-        MutableColumnPtr mutable_column = (*std::move(nested_column)).mutate();
+        MutableColumnPtr mutable_column = IColumn::mutate(std::move(nested_column));
         column.column = std::move(mutable_column);
     }
 }

--- a/src/Processors/Chunk.cpp
+++ b/src/Processors/Chunk.cpp
@@ -76,7 +76,7 @@ MutableColumns Chunk::mutateColumns()
     size_t num_columns = columns.size();
     MutableColumns mut_columns(num_columns);
     for (size_t i = 0; i < num_columns; ++i)
-        mut_columns[i] = (*std::move(columns[i])).mutate();
+        mut_columns[i] = IColumn::mutate(std::move(columns[i]));
 
     columns.clear();
     num_rows = 0;

--- a/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
@@ -70,7 +70,7 @@ Chunk ValuesBlockInputFormat::generate()
         if (!templates[i] || !templates[i]->rowsCount())
             continue;
         if (columns[i]->empty())
-            columns[i] = std::move(*templates[i]->evaluateAll(block_missing_values, i)).mutate();
+            columns[i] = IColumn::mutate(templates[i]->evaluateAll(block_missing_values, i));
         else
         {
             ColumnPtr evaluated = templates[i]->evaluateAll(block_missing_values, i, columns[i]->size());
@@ -134,7 +134,7 @@ bool ValuesBlockInputFormat::tryParseExpressionUsingTemplate(MutableColumnPtr & 
     /// Expression in the current row is not match template deduced on the first row.
     /// Evaluate expressions, which were parsed using this template.
     if (column->empty())
-        column = std::move(*templates[column_idx]->evaluateAll(block_missing_values, column_idx)).mutate();
+        column = IColumn::mutate(templates[column_idx]->evaluateAll(block_missing_values, column_idx));
     else
     {
         ColumnPtr evaluated = templates[column_idx]->evaluateAll(block_missing_values, column_idx, column->size());

--- a/src/Processors/Merges/Algorithms/MergedData.h
+++ b/src/Processors/Merges/Algorithms/MergedData.h
@@ -44,7 +44,7 @@ public:
         {
             num_rows = limit_rows;
             for (auto & column : columns)
-                column = (*column->cut(0, num_rows)).mutate();
+                column = IColumn::mutate(column->cut(0, num_rows));
         }
 
         need_flush = true;

--- a/src/Processors/Transforms/TotalsHavingTransform.cpp
+++ b/src/Processors/Transforms/TotalsHavingTransform.cpp
@@ -24,7 +24,7 @@ void finalizeChunk(Chunk & chunk)
     {
         if (typeid_cast<const ColumnAggregateFunction *>(column.get()))
         {
-            auto mut_column = (*std::move(column)).mutate();
+            auto mut_column = IColumn::mutate(std::move(column));
             column = ColumnAggregateFunction::convertToValues(std::move(mut_column));
         }
     }

--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -286,7 +286,7 @@ static void appendBlock(const Block & from, Block & to)
         for (size_t column_no = 0, columns = to.columns(); column_no < columns; ++column_no)
         {
             const IColumn & col_from = *from.getByPosition(column_no).column.get();
-            MutableColumnPtr col_to = (*std::move(to.getByPosition(column_no).column)).mutate();
+            MutableColumnPtr col_to = IColumn::mutate(std::move(to.getByPosition(column_no).column));
 
             col_to->insertRangeFrom(col_from, 0, rows);
 
@@ -302,7 +302,7 @@ static void appendBlock(const Block & from, Block & to)
             {
                 ColumnPtr & col_to = to.getByPosition(column_no).column;
                 if (col_to->size() != old_rows)
-                    col_to = (*std::move(col_to)).mutate()->cut(0, old_rows);
+                    col_to = col_to->cut(0, old_rows);
             }
         }
         catch (...)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Non-significant (changelog entry is not required)

Make `IColumn::mutate` static.
Because &&-qualified `mutate() &&` does not guarantee that we own column.
```cpp
ColumnPtr column = <create column>; /// use_count = 1
/// use_count == 1 inside mutate, don't copy column.
auto mutable_column = (*std::move(column)).mutate(); 
/// use_count is 2 now
column->doSomething(); /// use-after-move, is not always detected by compiler
```

After changes:
```cpp
ColumnPtr column = <create column>; /// use_count = 1
/// forget make std::move().  use_count == 2 inside mutate, copy column
auto mutable_column = IColumn::mutate(column);
column->doSomething(); /// it's fine

ColumnPtr column2 = <create column>; /// use_count = 1
 /// use_count == 1 inside mutate, don't copy column.
auto mutable_column = IColumn::mutate(std::move(column));
column2->doSomething(); /// segfault, because column2 is nullptr
```