### PR TITLE
Support MongoDB URI

### DIFF
--- a/docker/test/integration/compose/docker_compose_mongo.yml
+++ b/docker/test/integration/compose/docker_compose_mongo.yml
@@ -8,3 +8,4 @@ services:
             MONGO_INITDB_ROOT_PASSWORD: clickhouse
         ports:
           - 27018:27017
+        command: --profile=2 --verbose

--- a/src/Dictionaries/DictionaryFactory.cpp
+++ b/src/Dictionaries/DictionaryFactory.cpp
@@ -5,6 +5,8 @@
 #include "DictionaryStructure.h"
 #include "getDictionaryConfigurationFromAST.h"
 
+#include <common/logger_useful.h>
+
 namespace DB
 {
 namespace ErrorCodes
@@ -41,6 +43,9 @@ DictionaryPtr DictionaryFactory::create(
     const DictionaryStructure dict_struct{config, config_prefix + ".structure"};
 
     DictionarySourcePtr source_ptr = DictionarySourceFactory::instance().create(name, config, config_prefix + ".source", dict_struct, context, check_source_config);
+    LOG_TRACE(&Poco::Logger::get("DictionaryFactory"),
+        "Created dictionary source '" << source_ptr->toString()
+        << "' for dictionary '" << name << "'");
 
     const auto & layout_type = keys.front();
 

--- a/src/Dictionaries/MongoDBDictionarySource.cpp
+++ b/src/Dictionaries/MongoDBDictionarySource.cpp
@@ -8,15 +8,27 @@ namespace DB
 
 void registerDictionarySourceMongoDB(DictionarySourceFactory & factory)
 {
-    auto create_table_source = [=](const DictionaryStructure & dict_struct,
-                                   const Poco::Util::AbstractConfiguration & config,
-                                   const std::string & config_prefix,
-                                   Block & sample_block,
-                                   const Context & /* context */,
-                                   bool /* check_config */) -> DictionarySourcePtr {
-        return std::make_unique<MongoDBDictionarySource>(dict_struct, config, config_prefix + ".mongodb", sample_block);
+    auto createMongoDBDictionary = [](
+        const DictionaryStructure & dict_struct,
+        const Poco::Util::AbstractConfiguration & config,
+        const std::string & config_prefix,
+        Block & sample_block,
+        const Context &,
+        bool /* check_config */)
+    {
+        return std::make_unique<MongoDBDictionarySource>(dict_struct,
+            config.getString(config_prefix + ".uri"),
+            config.getString(config_prefix + ".host"),
+            config.getUInt(config_prefix + ".port"),
+            config.getString(config_prefix + ".user", ""),
+            config.getString(config_prefix + ".password", ""),
+            config.getString(config_prefix + ".method", ""),
+            config.getString(config_prefix + ".db", ""),
+            config.getString(config_prefix + ".collection"),
+            sample_block);
     };
-    factory.registerSource("mongodb", create_table_source);
+
+    factory.registerSource("mongodb", createMongoDBDictionary);
 }
 
 }
@@ -155,6 +167,7 @@ authenticate(Poco::MongoDB::Connection & connection, const std::string & databas
 
 MongoDBDictionarySource::MongoDBDictionarySource(
     const DictionaryStructure & dict_struct_,
+    const std::string & uri_,
     const std::string & host_,
     UInt16 port_,
     const std::string & user_,
@@ -164,6 +177,7 @@ MongoDBDictionarySource::MongoDBDictionarySource(
     const std::string & collection_,
     const Block & sample_block_)
     : dict_struct{dict_struct_}
+    , uri{uri_}
     , host{host_}
     , port{port_}
     , user{user_}
@@ -174,41 +188,31 @@ MongoDBDictionarySource::MongoDBDictionarySource(
     , sample_block{sample_block_}
     , connection{std::make_shared<Poco::MongoDB::Connection>(host, port)}
 {
-    if (!user.empty())
+    if (!uri.empty())
     {
-#if POCO_VERSION >= 0x01070800
-        Poco::MongoDB::Database poco_db(db);
-        if (!poco_db.authenticate(*connection, user, password, method.empty() ? Poco::MongoDB::Database::AUTH_SCRAM_SHA1 : method))
-            throw Exception("Cannot authenticate in MongoDB, incorrect user or password", ErrorCodes::MONGODB_CANNOT_AUTHENTICATE);
-#else
-        authenticate(*connection, db, user, password);
-#endif
+        Poco::MongoDB::Connection::SocketFactory socket_factory;
+        connection->connect(uri, socket_factory);
     }
-}
-
-
-MongoDBDictionarySource::MongoDBDictionarySource(
-    const DictionaryStructure & dict_struct_,
-    const Poco::Util::AbstractConfiguration & config,
-    const std::string & config_prefix,
-    Block & sample_block_)
-    : MongoDBDictionarySource(
-        dict_struct_,
-        config.getString(config_prefix + ".host"),
-        config.getUInt(config_prefix + ".port"),
-        config.getString(config_prefix + ".user", ""),
-        config.getString(config_prefix + ".password", ""),
-        config.getString(config_prefix + ".method", ""),
-        config.getString(config_prefix + ".db", ""),
-        config.getString(config_prefix + ".collection"),
-        sample_block_)
-{
+    else
+    {
+        connection->connect(host, port);
+        if (!user.empty())
+        {
+#if POCO_VERSION >= 0x01070800
+            Poco::MongoDB::Database poco_db(db);
+            if (!poco_db.authenticate(*connection, user, password, method.empty() ? Poco::MongoDB::Database::AUTH_SCRAM_SHA1 : method))
+                throw Exception("Cannot authenticate in MongoDB, incorrect user or password", ErrorCodes::MONGODB_CANNOT_AUTHENTICATE);
+#else
+            authenticate(*connection, db, user, password);
+#endif
+        }
+    }
 }
 
 
 MongoDBDictionarySource::MongoDBDictionarySource(const MongoDBDictionarySource & other)
     : MongoDBDictionarySource{
-        other.dict_struct, other.host, other.port, other.user, other.password, other.method, other.db, other.collection, other.sample_block}
+        other.dict_struct, other.uri, other.host, other.port, other.user, other.password, other.method, other.db, other.collection, other.sample_block}
 {
 }
 

--- a/src/Dictionaries/MongoDBDictionarySource.cpp
+++ b/src/Dictionaries/MongoDBDictionarySource.cpp
@@ -11,11 +11,12 @@ void registerDictionarySourceMongoDB(DictionarySourceFactory & factory)
     auto create_mongo_db_dictionary = [](
         const DictionaryStructure & dict_struct,
         const Poco::Util::AbstractConfiguration & config,
-        const std::string & config_prefix,
+        const std::string & root_config_prefix,
         Block & sample_block,
         const Context &,
         bool /* check_config */)
     {
+        const auto config_prefix = root_config_prefix + ".mongodb";
         return std::make_unique<MongoDBDictionarySource>(dict_struct,
             config.getString(config_prefix + ".uri", ""),
             config.getString(config_prefix + ".host", ""),

--- a/src/Dictionaries/MongoDBDictionarySource.cpp
+++ b/src/Dictionaries/MongoDBDictionarySource.cpp
@@ -17,9 +17,9 @@ void registerDictionarySourceMongoDB(DictionarySourceFactory & factory)
         bool /* check_config */)
     {
         return std::make_unique<MongoDBDictionarySource>(dict_struct,
-            config.getString(config_prefix + ".uri"),
-            config.getString(config_prefix + ".host"),
-            config.getUInt(config_prefix + ".port"),
+            config.getString(config_prefix + ".uri", ""),
+            config.getString(config_prefix + ".host", ""),
+            config.getUInt(config_prefix + ".port", 0),
             config.getString(config_prefix + ".user", ""),
             config.getString(config_prefix + ".password", ""),
             config.getString(config_prefix + ".method", ""),

--- a/src/Dictionaries/MongoDBDictionarySource.cpp
+++ b/src/Dictionaries/MongoDBDictionarySource.cpp
@@ -8,7 +8,7 @@ namespace DB
 
 void registerDictionarySourceMongoDB(DictionarySourceFactory & factory)
 {
-    auto createMongoDBDictionary = [](
+    auto create_mongo_db_dictionary = [](
         const DictionaryStructure & dict_struct,
         const Poco::Util::AbstractConfiguration & config,
         const std::string & config_prefix,
@@ -28,7 +28,7 @@ void registerDictionarySourceMongoDB(DictionarySourceFactory & factory)
             sample_block);
     };
 
-    factory.registerSource("mongodb", createMongoDBDictionary);
+    factory.registerSource("mongodb", create_mongo_db_dictionary);
 }
 
 }

--- a/src/Dictionaries/MongoDBDictionarySource.h
+++ b/src/Dictionaries/MongoDBDictionarySource.h
@@ -29,8 +29,10 @@ namespace ErrorCodes
 /// Allows loading dictionaries from a MongoDB collection
 class MongoDBDictionarySource final : public IDictionarySource
 {
+public:
     MongoDBDictionarySource(
         const DictionaryStructure & dict_struct_,
+        const std::string & uri_,
         const std::string & host_,
         UInt16 port_,
         const std::string & user_,
@@ -39,13 +41,6 @@ class MongoDBDictionarySource final : public IDictionarySource
         const std::string & db_,
         const std::string & collection_,
         const Block & sample_block_);
-
-public:
-    MongoDBDictionarySource(
-        const DictionaryStructure & dict_struct,
-        const Poco::Util::AbstractConfiguration & config,
-        const std::string & config_prefix,
-        Block & sample_block);
 
     MongoDBDictionarySource(const MongoDBDictionarySource & other);
 
@@ -76,6 +71,7 @@ public:
 
 private:
     const DictionaryStructure dict_struct;
+    const std::string uri;
     const std::string host;
     const UInt16 port;
     const std::string user;

--- a/src/Dictionaries/MongoDBDictionarySource.h
+++ b/src/Dictionaries/MongoDBDictionarySource.h
@@ -72,12 +72,12 @@ public:
 private:
     const DictionaryStructure dict_struct;
     const std::string uri;
-    const std::string host;
-    const UInt16 port;
-    const std::string user;
+    std::string host;
+    UInt16 port;
+    std::string user;
     const std::string password;
     const std::string method;
-    const std::string db;
+    std::string db;
     const std::string collection;
     Block sample_block;
 

--- a/tests/integration/test_dictionaries_all_layouts_and_sources/external_sources.py
+++ b/tests/integration/test_dictionaries_all_layouts_and_sources/external_sources.py
@@ -178,6 +178,21 @@ class SourceMongo(ExternalSource):
 
         result = tbl.insert_many(to_insert)
 
+class SourceMongoURI(SourceMongo):
+    def get_source_str(self, table_name):
+        return '''
+            <mongodb>
+                <uri>mongodb://{user}:{password}@{host}:{port}/test</uri>
+                <collection>{tbl}</collection>
+            </mongodb>
+        '''.format(
+            host=self.docker_hostname,
+            port=self.docker_port,
+            user=self.user,
+            password=self.password,
+            tbl=table_name,
+        )
+
 class SourceClickHouse(ExternalSource):
 
     def get_source_str(self, table_name):

--- a/tests/integration/test_dictionaries_all_layouts_and_sources/external_sources.py
+++ b/tests/integration/test_dictionaries_all_layouts_and_sources/external_sources.py
@@ -179,6 +179,11 @@ class SourceMongo(ExternalSource):
         result = tbl.insert_many(to_insert)
 
 class SourceMongoURI(SourceMongo):
+    def compatible_with_layout(self, layout):
+        # It is enough to test one layout for this dictionary, since we're
+        # only testing that the connection with URI works.
+        return layout.name == 'flat'
+
     def get_source_str(self, table_name):
         return '''
             <mongodb>

--- a/tests/integration/test_dictionaries_all_layouts_and_sources/test.py
+++ b/tests/integration/test_dictionaries_all_layouts_and_sources/test.py
@@ -4,7 +4,7 @@ import os
 from helpers.cluster import ClickHouseCluster
 from dictionary import Field, Row, Dictionary, DictionaryStructure, Layout
 from external_sources import SourceMySQL, SourceClickHouse, SourceFile, SourceExecutableCache, SourceExecutableHashed
-from external_sources import SourceMongo, SourceHTTP, SourceHTTPS, SourceRedis
+from external_sources import SourceMongo, SourceMongoURI, SourceHTTP, SourceHTTPS, SourceRedis
 import math
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -117,6 +117,7 @@ LAYOUTS = [
 
 SOURCES = [
     SourceMongo("MongoDB", "localhost", "27018", "mongo1", "27017", "root", "clickhouse"),
+    SourceMongoURI("MongoDB", "localhost", "27018", "mongo1", "27017", "root", "clickhouse"),
     SourceMySQL("MySQL", "localhost", "3308", "mysql1", "3306", "root", "clickhouse"),
     SourceClickHouse("RemoteClickHouse", "localhost", "9000", "clickhouse1", "9000", "default", ""),
     SourceClickHouse("LocalClickHouse", "localhost", "9000", "node", "9000", "default", ""),

--- a/tests/integration/test_dictionaries_all_layouts_and_sources/test.py
+++ b/tests/integration/test_dictionaries_all_layouts_and_sources/test.py
@@ -106,9 +106,9 @@ VALUES = {
 
 
 LAYOUTS = [
+    Layout("flat"),
     Layout("hashed"),
     Layout("cache"),
-    Layout("flat"),
     Layout("complex_key_hashed"),
     Layout("complex_key_cache"),
     Layout("range_hashed"),
@@ -117,7 +117,7 @@ LAYOUTS = [
 
 SOURCES = [
     SourceMongo("MongoDB", "localhost", "27018", "mongo1", "27017", "root", "clickhouse"),
-    SourceMongoURI("MongoDB", "localhost", "27018", "mongo1", "27017", "root", "clickhouse"),
+    SourceMongoURI("MongoDB_URI", "localhost", "27018", "mongo1", "27017", "root", "clickhouse"),
     SourceMySQL("MySQL", "localhost", "3308", "mysql1", "3306", "root", "clickhouse"),
     SourceClickHouse("RemoteClickHouse", "localhost", "9000", "clickhouse1", "9000", "default", ""),
     SourceClickHouse("LocalClickHouse", "localhost", "9000", "node", "9000", "default", ""),


### PR DESCRIPTION
Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow specifying `mongodb://` URI for MongoDB dictionaries.