### PR TITLE
gcc10 unbundled build fixes

### DIFF
--- a/cmake/linux/default_libs.cmake
+++ b/cmake/linux/default_libs.cmake
@@ -21,7 +21,7 @@ set(CMAKE_C_STANDARD_LIBRARIES ${DEFAULT_LIBS})
 # glibc-compatibility library relies to fixed version of libc headers
 # (because minor changes in function attributes between different glibc versions will introduce incompatibilities)
 # This is for x86_64. For other architectures we have separate toolchains.
-if (ARCH_AMD64)
+if (ARCH_AMD64 AND NOT_UNBUNDLED)
     set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${ClickHouse_SOURCE_DIR}/contrib/libc-headers/x86_64-linux-gnu ${ClickHouse_SOURCE_DIR}/contrib/libc-headers)
     set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${ClickHouse_SOURCE_DIR}/contrib/libc-headers/x86_64-linux-gnu ${ClickHouse_SOURCE_DIR}/contrib/libc-headers)
 endif ()

--- a/src/Common/Dwarf.cpp
+++ b/src/Common/Dwarf.cpp
@@ -104,7 +104,7 @@ namespace
 
 // Read (bitwise) one object of type T
 template <typename T>
-std::enable_if_t<std::is_pod_v<T>, T> read(std::string_view & sp)
+std::enable_if_t<std::is_trivial_v<T> && std::is_standard_layout_v<T>, T> read(std::string_view & sp)
 {
     SAFE_CHECK(sp.size() >= sizeof(T), "underflow");
     T x;

--- a/src/Interpreters/addMissingDefaults.h
+++ b/src/Interpreters/addMissingDefaults.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <unordered_map>
+#include <string>
 
 
 namespace DB


### PR DESCRIPTION
I guess only unbundled is affected, since bundled uses bundled libc++

Changelog category (leave one):
- Non-significant (changelog entry is not required)