### PR TITLE
Return tzdata

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -28,7 +28,7 @@ Description: Client binary for ClickHouse
 
 Package: clickhouse-common-static
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, tzdata
 Suggests: clickhouse-common-static-dbg
 Replaces: clickhouse-common, clickhouse-server-base
 Provides: clickhouse-common, clickhouse-server-base

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update \
             clickhouse-client=$version \
             clickhouse-common-static=$version \
             locales \
+            tzdata \
     && rm -rf /var/lib/apt/lists/* /var/cache/debconf \
     && apt-get clean
 

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update \
             locales \
             ca-certificates \
             wget \
+            tzata \
     && rm -rf \
         /var/lib/apt/lists/* \
         /var/cache/debconf \


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Return tzdata to build images and as dependency to .deb package.