### PR TITLE
Fix incompatibility of two-level aggregation between 19.16 and 20.1

### DIFF
--- a/src/Core/Defines.h
+++ b/src/Core/Defines.h
@@ -58,7 +58,7 @@
 /// Minimum revision with exactly the same set of aggregation methods and rules to select them.
 /// Two-level (bucketed) aggregation is incompatible if servers are inconsistent in these rules
 /// (keys will be placed in different buckets and result will not be fully aggregated).
-#define DBMS_MIN_REVISION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD 54408
+#define DBMS_MIN_REVISION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD 54431
 #define DBMS_MIN_REVISION_WITH_COLUMN_DEFAULTS_METADATA 54410
 
 #define DBMS_MIN_REVISION_WITH_LOW_CARDINALITY_TYPE 54405

--- a/tests/integration/test_backward_compatability/test_short_strings_aggregation.py
+++ b/tests/integration/test_backward_compatability/test_short_strings_aggregation.py
@@ -1,0 +1,28 @@
+import pytest
+
+import helpers.client as client
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node1 = cluster.add_instance('node1', with_zookeeper=False, image='yandex/clickhouse-server:19.16.9.37', stay_alive=True, with_installed_binary=True)
+node2 = cluster.add_instance('node2', with_zookeeper=False, image='yandex/clickhouse-server:19.16.9.37', stay_alive=True, with_installed_binary=True)
+node3 = cluster.add_instance('node3', with_zookeeper=False)
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def test_backward_compatability(start_cluster):
+    node1.query("create table tab (s String) engine = MergeTree order by s")
+    node2.query("create table tab (s String) engine = MergeTree order by s")
+    node1.query("insert into tab select number from numbers(50)")
+    node2.query("insert into tab select number from numbers(1000000)")
+    res = node3.query("select s, count() from remote('node{1,2}', default, tab) group by s order by toUInt64(s) limit 50")
+    print(res)
+    assert res == ''.join('{}\t2\n'.format(i) for i in range(50))


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix incompatibility of two-level aggregation between versions 20.1 and earlier. This incompatibility happens when different versions of ClickHouse are used on initiator node and remote nodes and the size of GROUP BY result is large and aggregation is performed by a single String field. It leads to several unmerged rows for a single key in result.


Detailed description / Documentation draft:
Did not notice the change on the way how the keys are split to buckets.
Similar to https://github.com/ClickHouse/ClickHouse/pull/3254