### PR TITLE
[Doc] fix Chinese directory name

### DIFF
--- a/docs/zh/engines/index.md
+++ b/docs/zh/engines/index.md
@@ -1,7 +1,7 @@
 ---
 machine_translated: true
 machine_translated_rev: 72537a2d527c63c07aa5d2361a8829f3895cf2bd
-toc_folder_title: "\u8868\u5f15\u64ce"
+toc_folder_title: "\u5f15\u64ce"
 toc_priority: 25
 ---
 

--- a/docs/zh/engines/index.md
+++ b/docs/zh/engines/index.md
@@ -1,7 +1,7 @@
 ---
 machine_translated: true
 machine_translated_rev: 72537a2d527c63c07aa5d2361a8829f3895cf2bd
-toc_folder_title: "\u53D1\u52A8\u673A"
+toc_folder_title: "\u8868\u5f15\u64ce"
 toc_priority: 25
 ---
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):


Detailed description / Documentation draft:

Fix Chinese documentation, use "引擎" instead of "发动机" in directory which will show on the website as top level name of the directory tree.
