### PR TITLE
Try to fix use-after-free error in MergeTree

### DIFF
--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -93,9 +93,18 @@ void StorageMergeTree::startup()
 
     /// NOTE background task will also do the above cleanups periodically.
     time_after_previous_cleanup.restart();
-    merging_mutating_task_handle = global_context.getBackgroundPool().addTask([this] { return mergeMutateTask(); });
+
+    auto & pool = global_context.getBackgroundPool();
+
+    merging_mutating_task_handle = pool.createTask([this] { return mergeMutateTask(); });
+    /// Ensure that thread started only after assignment to 'merging_mutating_task_handle' is done.
+    pool.startTask(merging_mutating_task_handle);
+
     if (areBackgroundMovesNeeded())
-        moving_task_handle = global_context.getBackgroundMovePool().addTask([this] { return movePartsTask(); });
+    {
+        moving_task_handle = pool.createTask([this] { return movePartsTask(); });
+        pool.startTask(moving_task_handle);
+    }
 }
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog

Was reverted by https://github.com/ClickHouse/ClickHouse/pull/10985


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix very rare potential use-after-free error in MergeTree if table was not created successfully.