### PR TITLE
Try to remove redundant data move in radix sort

### DIFF
--- a/src/AggregateFunctions/QuantileTDigest.h
+++ b/src/AggregateFunctions/QuantileTDigest.h
@@ -103,6 +103,7 @@ class QuantileTDigest
     struct RadixSortTraits
     {
         using Element = Centroid;
+        using Index = Element;
         using Key = Value;
         using CountType = UInt32;
         using KeyBits = UInt32;
@@ -114,6 +115,7 @@ class QuantileTDigest
 
         /// The function to get the key from an array element.
         static Key & extractKey(Element & elem) { return elem.mean; }
+        static Index & extractIndex(Element & elem) { return elem; }
     };
 
     /** Adds a centroid `c` to the digest

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -125,15 +125,18 @@ namespace
 }
 
 template <typename T>
-void shiftArrayRight(T& arr, size_t bound)
+void shiftArrayRight(T & arr, size_t bound)
 {
     bound %= arr.size();
     size_t gcd = std::gcd(arr.size(), bound);
-    for (size_t i = 0; i < gcd; ++i) {
+    for (size_t i = 0; i < gcd; ++i)
+    {
         size_t j = i;
-        do {
+        do
+        {
             size_t next = j + bound;
-            if (next >= arr.size()) next -= arr.size();
+            if (next >= arr.size())
+                next -= arr.size();
             std::swap(arr[j], arr[next]);
             j = next;
         } while (j != i);

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -125,25 +125,6 @@ namespace
 }
 
 template <typename T>
-void shiftArrayRight(T & arr, size_t bound)
-{
-    bound %= arr.size();
-    size_t gcd = std::gcd(arr.size(), bound);
-    for (size_t i = 0; i < gcd; ++i)
-    {
-        size_t j = i;
-        do
-        {
-            size_t next = j + bound;
-            if (next >= arr.size())
-                next -= arr.size();
-            std::swap(arr[j], arr[next]);
-            j = next;
-        } while (j != i);
-    }
-}
-
-template <typename T>
 void ColumnVector<T>::getSpecialPermutation(bool reverse, size_t limit, int nan_direction_hint, IColumn::Permutation & res,
                                             IColumn::SpecialSort special_sort) const
 {
@@ -219,7 +200,7 @@ void ColumnVector<T>::getPermutation(bool reverse, size_t limit, int nan_directi
 
                     if (nans_to_move)
                     {
-                        shiftArrayRight(res, reverse ? s - nans_to_move : nans_to_move);
+                        std::rotate(std::begin(res), std::begin(res) + (reverse ? nans_to_move : s - nans_to_move), std::end(res));
                     }
                 }
                 return;

--- a/src/Common/RadixSort.h
+++ b/src/Common/RadixSort.h
@@ -390,7 +390,8 @@ public:
                     /// Place the element on the next free position.
                     writer[size - 1 - (++histograms[pass * HISTOGRAM_SIZE + pos])] = Traits::extractIndex(reader[i]);
                 }
-            } else
+            }
+            else
             {
                 for (size_t i = 0; i < size; ++i)
                 {

--- a/src/Common/RadixSort.h
+++ b/src/Common/RadixSort.h
@@ -381,15 +381,24 @@ public:
             Index * writer = destination;
             Element * reader = pass % 2 ? swap_buffer : arr;
 
-            for (size_t i = 0; i < size; ++i)
+            if (reverse)
             {
-                size_t pos = getPart(pass, keyToBits(Traits::extractKey(reader[i])));
+                for (size_t i = 0; i < size; ++i)
+                {
+                    size_t pos = getPart(pass, keyToBits(Traits::extractKey(reader[i])));
 
-                /// Place the element on the next free position.
-                if (reverse)
+                    /// Place the element on the next free position.
                     writer[size - 1 - (++histograms[pass * HISTOGRAM_SIZE + pos])] = Traits::extractIndex(reader[i]);
-                else
+                }
+            } else
+            {
+                for (size_t i = 0; i < size; ++i)
+                {
+                    size_t pos = getPart(pass, keyToBits(Traits::extractKey(reader[i])));
+
+                    /// Place the element on the next free position.
                     writer[++histograms[pass * HISTOGRAM_SIZE + pos]] = Traits::extractIndex(reader[i]);
+                }
             }
         } else if (NUM_PASSES % 2)
         {

--- a/src/Common/RadixSort.h
+++ b/src/Common/RadixSort.h
@@ -313,7 +313,7 @@ private:
 
 public:
     /// Least significant digit radix sort (stable)
-    static void executeLSD(Element * arr, size_t size, Index * destination = NULL)
+    static void executeLSD(Element * arr, size_t size, bool reverse = false, Index * destination = nullptr)
     {
         /// If the array is smaller than 256, then it is better to use another algorithm.
 
@@ -386,13 +386,19 @@ public:
                 size_t pos = getPart(pass, keyToBits(Traits::extractKey(reader[i])));
 
                 /// Place the element on the next free position.
-                writer[++histograms[pass * HISTOGRAM_SIZE + pos]] = Traits::extractIndex(reader[i]);
+                if (reverse)
+                    writer[size - 1 - (++histograms[pass * HISTOGRAM_SIZE + pos])] = Traits::extractIndex(reader[i]);
+                else
+                    writer[++histograms[pass * HISTOGRAM_SIZE + pos]] = Traits::extractIndex(reader[i]);
             }
         } else if (NUM_PASSES % 2)
         {
             /// If the number of passes is odd, the result array is in a temporary buffer. Copy it to the place of the original array.
             /// NOTE Sometimes it will be more optimal to provide non-destructive interface, that will not modify original array.
             memcpy(arr, swap_buffer, size * sizeof(Element));
+        } else if (reverse)
+        {
+            std::reverse(arr, arr + size);
         }
 
         allocator.deallocate(swap_buffer, size * sizeof(Element));


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Improving radix sort by removing some redundant data moves


Detailed description / Documentation draft:

...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.
