### PR TITLE
Wait for odbc-bridge with exponential backoff

### DIFF
--- a/src/Common/XDBCBridgeHelper.h
+++ b/src/Common/XDBCBridgeHelper.h
@@ -151,16 +151,22 @@ public:
             LOG_TRACE(log, BridgeHelperMixin::serviceAlias() + " is not running, will try to start it");
             startBridge();
             bool started = false;
-            for (size_t counter : ext::range(1, 20))
+
+            uint64_t milliseconds_to_wait = 10; /// Exponential backoff
+            uint64_t counter = 0;
+            while (milliseconds_to_wait < 10000)
             {
+                ++counter;
                 LOG_TRACE(log, "Checking " + BridgeHelperMixin::serviceAlias() + " is running, try " << counter);
                 if (checkBridgeIsRunning())
                 {
                     started = true;
                     break;
                 }
-                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+                std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds_to_wait));
+                milliseconds_to_wait *= 2;
             }
+
             if (!started)
                 throw Exception(BridgeHelperMixin::getName() + "BridgeHelper: " + BridgeHelperMixin::serviceAlias() + " is not responding",
                     ErrorCodes::EXTERNAL_SERVER_IS_NOT_RESPONDING);


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Wait for odbc-bridge with exponential backoff. Previous wait time of 200 ms was not enough in our CI environment.

See https://github.com/ClickHouse/ClickHouse/pull/9516