### PR TITLE
Enable clang-tidy for programs and utils

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,7 +9,7 @@ Checks: '-*,
     misc-unused-alias-decls,
     misc-unused-parameters,
     misc-unused-using-decls,
-    
+
     modernize-avoid-bind,
     modernize-loop-convert,
     modernize-make-shared,
@@ -33,7 +33,7 @@ Checks: '-*,
     performance-no-automatic-move,
     performance-trivially-destructible,
     performance-unnecessary-copy-initialization,
-    
+
     readability-avoid-const-params-in-decls,
     readability-const-return-type,
     readability-container-size-empty,
@@ -58,7 +58,7 @@ Checks: '-*,
     readability-simplify-boolean-expr,
     readability-inconsistent-declaration-parameter-name,
     readability-identifier-naming,
-    
+
     bugprone-undelegated-constructor,
     bugprone-argument-comment,
     bugprone-bad-signal-to-kill-thread,
@@ -102,7 +102,7 @@ Checks: '-*,
     bugprone-unused-return-value,
     bugprone-use-after-move,
     bugprone-virtual-near-miss,
-    
+
     cert-dcl21-cpp,
     cert-dcl50-cpp,
     cert-env33-c,
@@ -112,7 +112,7 @@ Checks: '-*,
     cert-mem57-cpp,
     cert-msc50-cpp,
     cert-oop58-cpp,
-    
+
     google-build-explicit-make-pair,
     google-build-namespaces,
     google-default-arguments,
@@ -121,9 +121,9 @@ Checks: '-*,
     google-readability-avoid-underscore-in-googletest-name,
     google-runtime-int,
     google-runtime-operator,
-    
+
     hicpp-exception-baseclass,
-    
+
     clang-analyzer-core.CallAndMessage,
     clang-analyzer-core.DivideZero,
     clang-analyzer-core.NonNullParamChecker,

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -1,3 +1,7 @@
+if (USE_CLANG_TIDY)
+    set (CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_PATH}")
+endif ()
+
 # 'clickhouse' binary is a multi purpose tool,
 # that contain multiple execution modes (client, server, etc.)
 # each of them is built and linked as a separate library, defined below.

--- a/programs/benchmark/Benchmark.cpp
+++ b/programs/benchmark/Benchmark.cpp
@@ -289,7 +289,7 @@ private:
                     connection_entries.emplace_back(std::make_shared<Entry>(
                             connection->get(ConnectionTimeouts::getTCPTimeoutsWithoutFailover(settings))));
 
-                pool.scheduleOrThrowOnError(std::bind(&Benchmark::thread, this, connection_entries));
+                pool.scheduleOrThrowOnError([this, connection_entries]() mutable { thread(connection_entries); });
             }
         }
         catch (...)

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -485,7 +485,7 @@ private:
                 history_file = config().getString("history_file");
             else
             {
-                auto history_file_from_env = getenv("CLICKHOUSE_HISTORY_FILE");
+                auto * history_file_from_env = getenv("CLICKHOUSE_HISTORY_FILE");
                 if (history_file_from_env)
                     history_file = history_file_from_env;
                 else if (!home_path.empty())
@@ -1480,7 +1480,7 @@ private:
             "\033[1m↗\033[0m",
         };
 
-        auto indicator = indicators[increment % 8];
+        const char * indicator = indicators[increment % 8];
 
         if (!send_logs && written_progress_chars)
             message << '\r';

--- a/programs/client/ConnectionParameters.cpp
+++ b/programs/client/ConnectionParameters.cpp
@@ -51,7 +51,7 @@ ConnectionParameters::ConnectionParameters(const Poco::Util::AbstractConfigurati
     {
         std::string prompt{"Password for user (" + user + "): "};
         char buf[1000] = {};
-        if (auto result = readpassphrase(prompt.c_str(), buf, sizeof(buf), 0))
+        if (auto * result = readpassphrase(prompt.c_str(), buf, sizeof(buf), 0))
             password = result;
     }
 

--- a/programs/copier/ClusterCopier.cpp
+++ b/programs/copier/ClusterCopier.cpp
@@ -442,7 +442,7 @@ bool ClusterCopier::checkPartitionPieceIsDone(const TaskTable & task_table, cons
 
     /// Collect all shards that contain partition piece number piece_number.
     Strings piece_status_paths;
-    for (auto & shard : shards_with_partition)
+    for (const auto & shard : shards_with_partition)
     {
         ShardPartition & task_shard_partition = shard->partition_tasks.find(partition_name)->second;
         ShardPartitionPiece & shard_partition_piece = task_shard_partition.pieces[piece_number];
@@ -702,7 +702,7 @@ ASTPtr ClusterCopier::removeAliasColumnsFromCreateQuery(const ASTPtr & query_ast
 
     auto new_columns_list = std::make_shared<ASTColumns>();
     new_columns_list->set(new_columns_list->columns, new_columns);
-    if (auto indices = query_ast->as<ASTCreateQuery>()->columns_list->indices)
+    if (const auto * indices = query_ast->as<ASTCreateQuery>()->columns_list->indices)
         new_columns_list->set(new_columns_list->indices, indices->clone());
 
     new_query.replace(new_query.columns_list, new_columns_list);

--- a/programs/copier/ClusterCopierApp.cpp
+++ b/programs/copier/ClusterCopierApp.cpp
@@ -94,7 +94,7 @@ void ClusterCopierApp::mainImpl()
     StatusFile status_file(process_path + "/status");
     ThreadStatus thread_status;
 
-    auto log = &logger();
+    auto * log = &logger();
     LOG_INFO(log, "Starting clickhouse-copier ("
         << "id " << process_id << ", "
         << "host_id " << host_id << ", "

--- a/programs/copier/Internals.cpp
+++ b/programs/copier/Internals.cpp
@@ -260,7 +260,7 @@ ShardPriority getReplicasPriority(const Cluster::Addresses & replicas, const std
         return res;
 
     res.is_remote = 1;
-    for (auto & replica : replicas)
+    for (const auto & replica : replicas)
     {
         if (isLocalAddress(DNSResolver::instance().resolveHost(replica.host_name)))
         {
@@ -270,7 +270,7 @@ ShardPriority getReplicasPriority(const Cluster::Addresses & replicas, const std
     }
 
     res.hostname_difference = std::numeric_limits<size_t>::max();
-    for (auto & replica : replicas)
+    for (const auto & replica : replicas)
     {
         size_t difference = getHostNameDifference(local_hostname, replica.host_name);
         res.hostname_difference = std::min(difference, res.hostname_difference);

--- a/programs/obfuscator/Obfuscator.cpp
+++ b/programs/obfuscator/Obfuscator.cpp
@@ -937,10 +937,10 @@ public:
         if (typeid_cast<const DataTypeFixedString *>(&data_type))
             return std::make_unique<FixedStringModel>(seed);
 
-        if (auto type = typeid_cast<const DataTypeArray *>(&data_type))
+        if (const auto * type = typeid_cast<const DataTypeArray *>(&data_type))
             return std::make_unique<ArrayModel>(get(*type->getNestedType(), seed, markov_model_params));
 
-        if (auto type = typeid_cast<const DataTypeNullable *>(&data_type))
+        if (const auto * type = typeid_cast<const DataTypeNullable *>(&data_type))
             return std::make_unique<NullableModel>(get(*type->getNestedType(), seed, markov_model_params));
 
         throw Exception("Unsupported data type", ErrorCodes::NOT_IMPLEMENTED);

--- a/programs/odbc-bridge/ODBCBlockOutputStream.cpp
+++ b/programs/odbc-bridge/ODBCBlockOutputStream.cpp
@@ -24,8 +24,8 @@ namespace
         query.table_id.table_name = table_name;
         query.columns = std::make_shared<ASTExpressionList>(',');
         query.children.push_back(query.columns);
-        for (size_t i = 0; i < columns.size(); ++i)
-            query.columns->children.emplace_back(std::make_shared<ASTIdentifier>(columns[i].name));
+        for (const auto & column : columns)
+            query.columns->children.emplace_back(std::make_shared<ASTIdentifier>(column.name));
 
         std::stringstream ss;
         IAST::FormatSettings settings(ss, true);

--- a/programs/server/HTTPHandler.cpp
+++ b/programs/server/HTTPHandler.cpp
@@ -195,7 +195,7 @@ void HTTPHandler::pushDelayedResults(Output & used_output)
     std::vector<ReadBufferPtr> read_buffers;
     std::vector<ReadBuffer *> read_buffers_raw_ptr;
 
-    auto cascade_buffer = typeid_cast<CascadeWriteBuffer *>(used_output.out_maybe_delayed_and_compressed.get());
+    auto * cascade_buffer = typeid_cast<CascadeWriteBuffer *>(used_output.out_maybe_delayed_and_compressed.get());
     if (!cascade_buffer)
         throw Exception("Expected CascadeWriteBuffer", ErrorCodes::LOGICAL_ERROR);
 
@@ -383,7 +383,7 @@ void HTTPHandler::processQuery(
         {
             auto push_memory_buffer_and_continue = [next_buffer = used_output.out_maybe_compressed] (const WriteBufferPtr & prev_buf)
             {
-                auto prev_memory_buffer = typeid_cast<MemoryWriteBuffer *>(prev_buf.get());
+                auto * prev_memory_buffer = typeid_cast<MemoryWriteBuffer *>(prev_buf.get());
                 if (!prev_memory_buffer)
                     throw Exception("Expected MemoryWriteBuffer", ErrorCodes::LOGICAL_ERROR);
 

--- a/programs/server/HTTPHandlerFactory.cpp
+++ b/programs/server/HTTPHandlerFactory.cpp
@@ -28,7 +28,7 @@ HTTPRequestHandlerFactoryMain::HTTPRequestHandlerFactoryMain(const std::string &
 {
 }
 
-Poco::Net::HTTPRequestHandler * HTTPRequestHandlerFactoryMain::createRequestHandler(const Poco::Net::HTTPServerRequest & request) // override
+Poco::Net::HTTPRequestHandler * HTTPRequestHandlerFactoryMain::createRequestHandler(const Poco::Net::HTTPServerRequest & request)
 {
     LOG_TRACE(log, "HTTP Request for " << name << ". "
         << "Method: " << request.getMethod()
@@ -40,7 +40,7 @@ Poco::Net::HTTPRequestHandler * HTTPRequestHandlerFactoryMain::createRequestHand
 
     for (auto & handler_factory : child_factories)
     {
-        auto handler = handler_factory->createRequestHandler(request);
+        auto * handler = handler_factory->createRequestHandler(request);
         if (handler != nullptr)
             return handler;
     }
@@ -72,80 +72,96 @@ HTTPRequestHandlerFactoryMain::TThis * HTTPRequestHandlerFactoryMain::addHandler
 
 static inline auto createHandlersFactoryFromConfig(IServer & server, const std::string & name, const String & prefix)
 {
-    auto main_handler_factory = new HTTPRequestHandlerFactoryMain(name);
+    auto main_handler_factory = std::make_unique<HTTPRequestHandlerFactoryMain>(name);
 
-    try
+    Poco::Util::AbstractConfiguration::Keys keys;
+    server.config().keys(prefix, keys);
+
+    for (const auto & key : keys)
     {
-        Poco::Util::AbstractConfiguration::Keys keys;
-        server.config().keys(prefix, keys);
+        if (!startsWith(key, "rule"))
+            throw Exception("Unknown element in config: " + prefix + "." + key + ", must be 'rule'", ErrorCodes::UNKNOWN_ELEMENT_IN_CONFIG);
 
-        for (const auto & key : keys)
-        {
-            if (!startsWith(key, "rule"))
-                throw Exception("Unknown element in config: " + prefix + "." + key + ", must be 'rule'", ErrorCodes::UNKNOWN_ELEMENT_IN_CONFIG);
+        const auto & handler_type = server.config().getString(prefix + "." + key + ".handler.type", "");
 
-            const auto & handler_type = server.config().getString(prefix + "." + key + ".handler.type", "");
-
-            if (handler_type == "static")
-                main_handler_factory->addHandler(createStaticHandlerFactory(server, prefix + "." + key));
-            else if (handler_type == "dynamic_query_handler")
-                main_handler_factory->addHandler(createDynamicHandlerFactory(server, prefix + "." + key));
-            else if (handler_type == "predefined_query_handler")
-                main_handler_factory->addHandler(createPredefinedHandlerFactory(server, prefix + "." + key));
-            else if (handler_type.empty())
-                throw Exception("Handler type in config is not specified here: " +
-                                prefix + "." + key + ".handler.type", ErrorCodes::INVALID_CONFIG_PARAMETER);
-            else
-                throw Exception("Unknown handler type '" + handler_type +"' in config here: " +
-                                prefix + "." + key + ".handler.type",ErrorCodes::INVALID_CONFIG_PARAMETER);
-        }
-
-        return main_handler_factory;
+        if (handler_type == "static")
+            main_handler_factory->addHandler(createStaticHandlerFactory(server, prefix + "." + key));
+        else if (handler_type == "dynamic_query_handler")
+            main_handler_factory->addHandler(createDynamicHandlerFactory(server, prefix + "." + key));
+        else if (handler_type == "predefined_query_handler")
+            main_handler_factory->addHandler(createPredefinedHandlerFactory(server, prefix + "." + key));
+        else if (handler_type.empty())
+            throw Exception("Handler type in config is not specified here: " +
+                            prefix + "." + key + ".handler.type", ErrorCodes::INVALID_CONFIG_PARAMETER);
+        else
+            throw Exception("Unknown handler type '" + handler_type +"' in config here: " +
+                            prefix + "." + key + ".handler.type",ErrorCodes::INVALID_CONFIG_PARAMETER);
     }
-    catch (...)
-    {
-        delete main_handler_factory;
-        throw;
-    }
+
+    return main_handler_factory.release();
 }
 
 static const auto ping_response_expression = "Ok.\n";
 static const auto root_response_expression = "config://http_server_default_response";
 
-static inline Poco::Net::HTTPRequestHandlerFactory * createHTTPHandlerFactory(IServer & server, const std::string & name, AsynchronousMetrics & async_metrics)
+static inline Poco::Net::HTTPRequestHandlerFactory * createHTTPHandlerFactory(
+    IServer & server, const std::string & name, AsynchronousMetrics & async_metrics)
 {
     if (server.config().has("http_handlers"))
         return createHandlersFactoryFromConfig(server, name, "http_handlers");
     else
     {
-        auto factory = (new HTTPRequestHandlerFactoryMain(name))
-            ->addHandler((new HandlingRuleHTTPHandlerFactory<StaticRequestHandler>(server, root_response_expression))
-                ->attachStrictPath("/")->allowGetAndHeadRequest())
-            ->addHandler((new HandlingRuleHTTPHandlerFactory<StaticRequestHandler>(server, ping_response_expression))
-                ->attachStrictPath("/ping")->allowGetAndHeadRequest())
-            ->addHandler((new HandlingRuleHTTPHandlerFactory<ReplicasStatusHandler>(server))
-                ->attachNonStrictPath("/replicas_status")->allowGetAndHeadRequest())
-            ->addHandler((new HandlingRuleHTTPHandlerFactory<DynamicQueryHandler>(server, "query"))->allowPostAndGetParamsRequest());
+        auto factory = std::make_unique<HTTPRequestHandlerFactoryMain>(name);
+
+        auto root_handler = std::make_unique<HandlingRuleHTTPHandlerFactory<StaticRequestHandler>>(server, root_response_expression);
+        root_handler->attachStrictPath("/")->allowGetAndHeadRequest();
+        factory->addHandler(root_handler.release());
+
+        auto ping_handler = std::make_unique<HandlingRuleHTTPHandlerFactory<StaticRequestHandler>>(server, ping_response_expression);
+        ping_handler->attachStrictPath("/ping")->allowGetAndHeadRequest();
+        factory->addHandler(ping_handler.release());
+
+        auto replicas_status_handler = std::make_unique<HandlingRuleHTTPHandlerFactory<ReplicasStatusHandler>>(server);
+        replicas_status_handler->attachNonStrictPath("/replicas_status")->allowGetAndHeadRequest();
+        factory->addHandler(replicas_status_handler.release());
+
+        auto query_handler = std::make_unique<HandlingRuleHTTPHandlerFactory<DynamicQueryHandler>>(server, "query");
+        query_handler->allowPostAndGetParamsRequest();
+        factory->addHandler(query_handler.release());
 
         if (server.config().has("prometheus") && server.config().getInt("prometheus.port", 0) == 0)
-            factory->addHandler((new HandlingRuleHTTPHandlerFactory<PrometheusRequestHandler>(
-                server, PrometheusMetricsWriter(server.config(), "prometheus", async_metrics)))
-                    ->attachStrictPath(server.config().getString("prometheus.endpoint", "/metrics"))->allowGetAndHeadRequest());
+        {
+            auto prometheus_handler = std::make_unique<HandlingRuleHTTPHandlerFactory<PrometheusRequestHandler>>(
+                server, PrometheusMetricsWriter(server.config(), "prometheus", async_metrics));
+            prometheus_handler->attachStrictPath(server.config().getString("prometheus.endpoint", "/metrics"))->allowGetAndHeadRequest();
+            factory->addHandler(prometheus_handler.release());
+        }
 
-        return factory;
+        return factory.release();
     }
 }
 
 static inline Poco::Net::HTTPRequestHandlerFactory * createInterserverHTTPHandlerFactory(IServer & server, const std::string & name)
 {
-    return (new HTTPRequestHandlerFactoryMain(name))
-        ->addHandler((new HandlingRuleHTTPHandlerFactory<StaticRequestHandler>(server, root_response_expression))
-            ->attachStrictPath("/")->allowGetAndHeadRequest())
-        ->addHandler((new HandlingRuleHTTPHandlerFactory<StaticRequestHandler>(server, ping_response_expression))
-            ->attachStrictPath("/ping")->allowGetAndHeadRequest())
-        ->addHandler((new HandlingRuleHTTPHandlerFactory<ReplicasStatusHandler>(server))
-            ->attachNonStrictPath("/replicas_status")->allowGetAndHeadRequest())
-        ->addHandler((new HandlingRuleHTTPHandlerFactory<InterserverIOHTTPHandler>(server))->allowPostAndGetParamsRequest());
+    auto factory = std::make_unique<HTTPRequestHandlerFactoryMain>(name);
+
+    auto root_handler = std::make_unique<HandlingRuleHTTPHandlerFactory<StaticRequestHandler>>(server, root_response_expression);
+    root_handler->attachStrictPath("/")->allowGetAndHeadRequest();
+    factory->addHandler(root_handler.release());
+
+    auto ping_handler = std::make_unique<HandlingRuleHTTPHandlerFactory<StaticRequestHandler>>(server, ping_response_expression);
+    ping_handler->attachStrictPath("/ping")->allowGetAndHeadRequest();
+    factory->addHandler(ping_handler.release());
+
+    auto replicas_status_handler = std::make_unique<HandlingRuleHTTPHandlerFactory<ReplicasStatusHandler>>(server);
+    replicas_status_handler->attachNonStrictPath("/replicas_status")->allowGetAndHeadRequest();
+    factory->addHandler(replicas_status_handler.release());
+
+    auto main_handler = std::make_unique<HandlingRuleHTTPHandlerFactory<InterserverIOHTTPHandler>>(server);
+    main_handler->allowPostAndGetParamsRequest();
+    factory->addHandler(main_handler.release());
+
+    return factory.release();
 }
 
 Poco::Net::HTTPRequestHandlerFactory * createHandlerFactory(IServer & server, AsynchronousMetrics & async_metrics, const std::string & name)
@@ -155,9 +171,14 @@ Poco::Net::HTTPRequestHandlerFactory * createHandlerFactory(IServer & server, As
     else if (name == "InterserverIOHTTPHandler-factory" || name == "InterserverIOHTTPSHandler-factory")
         return createInterserverHTTPHandlerFactory(server, name);
     else if (name == "PrometheusHandler-factory")
-        return (new HTTPRequestHandlerFactoryMain(name))->addHandler((new HandlingRuleHTTPHandlerFactory<PrometheusRequestHandler>(
-            server, PrometheusMetricsWriter(server.config(), "prometheus", async_metrics)))
-                ->attachStrictPath(server.config().getString("prometheus.endpoint", "/metrics"))->allowGetAndHeadRequest());
+    {
+        auto factory = std::make_unique<HTTPRequestHandlerFactoryMain>(name);
+        auto handler = std::make_unique<HandlingRuleHTTPHandlerFactory<PrometheusRequestHandler>>(
+            server, PrometheusMetricsWriter(server.config(), "prometheus", async_metrics));
+        handler->attachStrictPath(server.config().getString("prometheus.endpoint", "/metrics"))->allowGetAndHeadRequest();
+        factory->addHandler(handler.release());
+        return factory.release();
+    }
 
     throw Exception("LOGICAL ERROR: Unknown HTTP handler factory name.", ErrorCodes::LOGICAL_ERROR);
 }

--- a/programs/server/HTTPHandlerFactory.cpp
+++ b/programs/server/HTTPHandlerFactory.cpp
@@ -129,6 +129,8 @@ static inline Poco::Net::HTTPRequestHandlerFactory * createHTTPHandlerFactory(
         query_handler->allowPostAndGetParamsRequest();
         factory->addHandler(query_handler.release());
 
+        /// We check that prometheus handler will be served on current (default) port.
+        /// Otherwise it will be created separately, see below.
         if (server.config().has("prometheus") && server.config().getInt("prometheus.port", 0) == 0)
         {
             auto prometheus_handler = std::make_unique<HandlingRuleHTTPHandlerFactory<PrometheusRequestHandler>>(

--- a/programs/server/ReplicasStatusHandler.cpp
+++ b/programs/server/ReplicasStatusHandler.cpp
@@ -46,7 +46,7 @@ void ReplicasStatusHandler::handleRequest(Poco::Net::HTTPServerRequest & request
 
             for (auto iterator = db.second->getTablesIterator(); iterator->isValid(); iterator->next())
             {
-                auto & table = iterator->table();
+                const auto & table = iterator->table();
                 StorageReplicatedMergeTree * table_replicated = dynamic_cast<StorageReplicatedMergeTree *>(table.get());
 
                 if (!table_replicated)

--- a/src/Common/tests/cow_columns.cpp
+++ b/src/Common/tests/cow_columns.cpp
@@ -56,8 +56,8 @@ int main(int, char **)
         MutableColumnPtr mut = IColumn::mutate(std::move(y));
         mut->set(2);
 
-        std::cerr << "refcounts: " << x->use_count() << ", " << y->use_count() << ", " << mut->use_count() << "\n";
-        std::cerr << "addresses: " << x.get() << ", " << y.get() << ", " << mut.get() << "\n";
+        std::cerr << "refcounts: " << x->use_count() << ", " << mut->use_count() << "\n";
+        std::cerr << "addresses: " << x.get() << ", " << mut.get() << "\n";
         y = std::move(mut);
     }
 
@@ -75,8 +75,8 @@ int main(int, char **)
         MutableColumnPtr mut = IColumn::mutate(std::move(y));
         mut->set(3);
 
-        std::cerr << "refcounts: " << x->use_count() << ", " << y->use_count() << ", " << mut->use_count() << "\n";
-        std::cerr << "addresses: " << x.get() << ", " << y.get() << ", " << mut.get() << "\n";
+        std::cerr << "refcounts: " << x->use_count() << ", " << mut->use_count() << "\n";
+        std::cerr << "addresses: " << x.get() << ", " << mut.get() << "\n";
         y = std::move(mut);
     }
 

--- a/src/Common/tests/cow_compositions.cpp
+++ b/src/Common/tests/cow_compositions.cpp
@@ -75,8 +75,8 @@ int main(int, char **)
         MutableColumnPtr mut = IColumn::mutate(std::move(y));
         mut->set(2);
 
-        std::cerr << "refcounts: " << x->use_count() << ", " << y->use_count() << ", " << mut->use_count() << "\n";
-        std::cerr << "addresses: " << x.get() << ", " << y.get() << ", " << mut.get() << "\n";
+        std::cerr << "refcounts: " << x->use_count() << ", " << mut->use_count() << "\n";
+        std::cerr << "addresses: " << x.get() << ", " << mut.get() << "\n";
         y = std::move(mut);
     }
 
@@ -94,8 +94,8 @@ int main(int, char **)
         MutableColumnPtr mut = IColumn::mutate(std::move(y));
         mut->set(3);
 
-        std::cerr << "refcounts: " << x->use_count() << ", " << y->use_count() << ", " << mut->use_count() << "\n";
-        std::cerr << "addresses: " << x.get() << ", " << y.get() << ", " << mut.get() << "\n";
+        std::cerr << "refcounts: " << x->use_count() << ", " << mut->use_count() << "\n";
+        std::cerr << "addresses: " << x.get() << ", " << ", " << mut.get() << "\n";
         y = std::move(mut);
     }
 

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,3 +1,7 @@
+if (USE_CLANG_TIDY)
+    set (CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_PATH}")
+endif ()
+
 if(MAKE_STATIC_LIBRARIES)
     set(MAX_LINKER_MEMORY 3500)
 else()

--- a/utils/convert-month-partitioned-parts/main.cpp
+++ b/utils/convert-month-partitioned-parts/main.cpp
@@ -30,7 +30,7 @@ void run(String part_path, String date_column, String dest_path)
 {
     std::shared_ptr<IDisk> disk = std::make_shared<DiskLocal>("local", "/", 0);
     auto old_part_path = Poco::Path::forDirectory(part_path);
-    String old_part_name = old_part_path.directory(old_part_path.depth() - 1);
+    const String & old_part_name = old_part_path.directory(old_part_path.depth() - 1);
     String old_part_path_str = old_part_path.toString();
 
     auto part_info = MergeTreePartInfo::fromPartName(old_part_name, MergeTreeDataFormatVersion(0));

--- a/utils/iotest/iotest.cpp
+++ b/utils/iotest/iotest.cpp
@@ -59,9 +59,9 @@ void thread(int fd, int mode, size_t min_offset, size_t max_offset, size_t block
 
     for (size_t i = 0; i < count; ++i)
     {
-        long rand_result1 = rng();
-        long rand_result2 = rng();
-        long rand_result3 = rng();
+        uint64_t rand_result1 = rng();
+        uint64_t rand_result2 = rng();
+        uint64_t rand_result3 = rng();
 
         size_t rand_result = rand_result1 ^ (rand_result2 << 22) ^ (rand_result3 << 43);
         size_t offset;
@@ -152,7 +152,7 @@ int mainImpl(int argc, char ** argv)
     Stopwatch watch;
 
     for (size_t i = 0; i < threads; ++i)
-        pool.scheduleOrThrowOnError(std::bind(thread, fd, mode, min_offset, max_offset, block_size, count));
+        pool.scheduleOrThrowOnError([=]{ thread(fd, mode, min_offset, max_offset, block_size, count); });
     pool.wait();
 
     fsync(fd);

--- a/utils/iotest/iotest_aio.cpp
+++ b/utils/iotest/iotest_aio.cpp
@@ -13,6 +13,8 @@ int main(int, char **) { return 0; }
 #include <Common/Exception.h>
 #include <Common/ThreadPool.h>
 #include <Common/Stopwatch.h>
+#include <Common/randomSeed.h>
+#include <pcg_random.hpp>
 #include <IO/BufferWithOwnMemory.h>
 #include <IO/ReadHelpers.h>
 #include <stdio.h>
@@ -52,10 +54,7 @@ void thread(int fd, int mode, size_t min_offset, size_t max_offset, size_t block
     for (size_t i = 0; i < buffers_count; ++i)
         buffers[i] = Memory<>(block_size, sysconf(_SC_PAGESIZE));
 
-    drand48_data rand_data;
-    timespec times;
-    clock_gettime(CLOCK_THREAD_CPUTIME_ID, &times);
-    srand48_r(times.tv_nsec, &rand_data);
+    pcg64_fast rng(randomSeed());
 
     size_t in_progress = 0;
     size_t blocks_sent = 0;
@@ -82,12 +81,9 @@ void thread(int fd, int mode, size_t min_offset, size_t max_offset, size_t block
 
             char * buf = buffers[i].data();
 
-            long rand_result1 = 0;
-            long rand_result2 = 0;
-            long rand_result3 = 0;
-            lrand48_r(&rand_data, &rand_result1);
-            lrand48_r(&rand_data, &rand_result2);
-            lrand48_r(&rand_data, &rand_result3);
+            uint64_t rand_result1 = rng();
+            uint64_t rand_result2 = rng();
+            uint64_t rand_result3 = rng();
 
             size_t rand_result = rand_result1 ^ (rand_result2 << 22) ^ (rand_result3 << 43);
             size_t offset = min_offset + rand_result % ((max_offset - min_offset) / block_size) * block_size;
@@ -172,7 +168,7 @@ int mainImpl(int argc, char ** argv)
     Stopwatch watch;
 
     for (size_t i = 0; i < threads_count; ++i)
-        pool.scheduleOrThrowOnError(std::bind(thread, fd, mode, min_offset, max_offset, block_size, buffers_count, count));
+        pool.scheduleOrThrowOnError([=]{ thread(fd, mode, min_offset, max_offset, block_size, buffers_count, count); });
     pool.wait();
 
     watch.stop();

--- a/utils/iotest/iotest_nonblock.cpp
+++ b/utils/iotest/iotest_nonblock.cpp
@@ -113,9 +113,9 @@ int mainImpl(int argc, char ** argv)
             polls[i].revents = 0;
             ++ops;
 
-            long rand_result1 = rng();
-            long rand_result2 = rng();
-            long rand_result3 = rng();
+            uint64_t rand_result1 = rng();
+            uint64_t rand_result2 = rng();
+            uint64_t rand_result3 = rng();
 
             size_t rand_result = rand_result1 ^ (rand_result2 << 22) ^ (rand_result3 << 43);
             size_t offset;

--- a/utils/test-data-generator/CMakeLists.txt
+++ b/utils/test-data-generator/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Disable clang-tidy for protobuf generated files
+set (CMAKE_CXX_CLANG_TIDY "")
+
 add_compile_options(-Wno-zero-as-null-pointer-constant -Wno-array-bounds) # Protobuf generated files
 
 if (USE_PROTOBUF)

--- a/utils/zookeeper-adjust-block-numbers-to-parts/main.cpp
+++ b/utils/zookeeper-adjust-block-numbers-to-parts/main.cpp
@@ -199,7 +199,7 @@ void setCurrentBlockNumber(zkutil::ZooKeeper & zk, const std::string & path, Int
     create_ephemeral_nodes(1); /// Firstly try to create just a single node.
 
     /// Create other nodes in batches of 50 nodes.
-    while (current_block_number + 50 <= new_current_block_number)
+    while (current_block_number + 50 <= new_current_block_number) // NOLINT: clang-tidy thinks that the loop is infinite
         create_ephemeral_nodes(50);
 
     create_ephemeral_nodes(new_current_block_number - current_block_number);

--- a/utils/zookeeper-adjust-block-numbers-to-parts/main.cpp
+++ b/utils/zookeeper-adjust-block-numbers-to-parts/main.cpp
@@ -102,7 +102,7 @@ std::unordered_map<std::string, Int64> getPartitionsNeedAdjustingBlockNumbers(
         std::cout << "Shard: " << shard << std::endl;
         std::vector<std::string> use_tables = tables.empty() ? getAllTables(zk, root, shard) : removeNotExistingTables(zk, root, shard, tables);
 
-        for (auto table : use_tables)
+        for (const auto & table : use_tables)
         {
             std::cout << "\tTable: " << table << std::endl;
             std::string table_path = root + "/" + shard + "/" + table;
@@ -121,7 +121,7 @@ std::unordered_map<std::string, Int64> getPartitionsNeedAdjustingBlockNumbers(
                 continue;
             }
 
-            for (auto partition : partitions)
+            for (const auto & partition : partitions)
             {
                 try
                 {

--- a/utils/zookeeper-cli/zookeeper-cli.cpp
+++ b/utils/zookeeper-cli/zookeeper-cli.cpp
@@ -97,10 +97,8 @@ int main(int argc, char ** argv)
                     bool watch = w == "w";
                     zkutil::EventPtr event = watch ? std::make_shared<Poco::Event>() : nullptr;
                     std::vector<std::string> v = zk.getChildren(path, nullptr, event);
-                    for (size_t i = 0; i < v.size(); ++i)
-                    {
-                        std::cout << v[i] << std::endl;
-                    }
+                    for (const auto & child : v)
+                        std::cout << child << std::endl;
                     if (watch)
                         waitForWatch(event);
                 }
@@ -193,7 +191,7 @@ int main(int argc, char ** argv)
                     zk.set(path, data, version, &stat);
                     printStat(stat);
                 }
-                else if (cmd != "")
+                else if (!cmd.empty())
                 {
                     std::cout << "commands:\n";
                     std::cout << "  q\n";


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Enable clang-tidy for programs and utils.