### PR TITLE
Remove data on DROP DATABASE for DatabaseMemory

### DIFF
--- a/src/Databases/DatabaseMemory.cpp
+++ b/src/Databases/DatabaseMemory.cpp
@@ -5,6 +5,7 @@
 #include <Parsers/ASTCreateQuery.h>
 #include <Storages/IStorage.h>
 #include <Poco/File.h>
+#include <filesystem>
 
 
 namespace DB
@@ -82,6 +83,12 @@ UUID DatabaseMemory::tryGetTableUUID(const String & table_name) const
     if (auto table = tryGetTable(table_name))
         return table->getStorageID().uuid;
     return UUIDHelpers::Nil;
+}
+
+void DatabaseMemory::drop(const Context & context)
+{
+    /// Remove data on explicit DROP DATABASE
+    std::filesystem::remove_all(context.getPath() + data_path);
 }
 
 }

--- a/src/Databases/DatabaseMemory.h
+++ b/src/Databases/DatabaseMemory.h
@@ -46,6 +46,8 @@ public:
 
     UUID tryGetTableUUID(const String & table_name) const override;
 
+    void drop(const Context & context) override;
+
 private:
     String data_path;
     using NameToASTCreate = std::unordered_map<String, ASTPtr>;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove data on explicit `DROP DATABASE` for `Memory` database engine. Fixes #10557