### PR TITLE
Fix memory tracking for two-level GROUP BY when not all rows read from Aggregator (TCP)

### DIFF
--- a/programs/server/TCPHandler.cpp
+++ b/programs/server/TCPHandler.cpp
@@ -278,8 +278,11 @@ void TCPHandler::runImpl()
             sendLogs();
             sendEndOfStream();
 
-            query_scope.reset();
+            /// QueryState should be cleared before QueryScope, since otherwise
+            /// the MemoryTracker will be wrong for possible deallocations.
+            /// (i.e. deallocations from the Aggregator with two-level aggregation)
             state.reset();
+            query_scope.reset();
         }
         catch (const Exception & e)
         {
@@ -359,8 +362,11 @@ void TCPHandler::runImpl()
 
         try
         {
-            query_scope.reset();
+            /// QueryState should be cleared before QueryScope, since otherwise
+            /// the MemoryTracker will be wrong for possible deallocations.
+            /// (i.e. deallocations from the Aggregator with two-level aggregation)
             state.reset();
+            query_scope.reset();
         }
         catch (...)
         {

--- a/tests/queries/0_stateless/01281_group_by_limit_memory_tracking.sql
+++ b/tests/queries/0_stateless/01281_group_by_limit_memory_tracking.sql
@@ -1,0 +1,84 @@
+DROP TABLE IF EXISTS trace_log_01281;
+DROP TABLE IF EXISTS trace_log_01281_mv;
+DROP TABLE IF EXISTS trace_log_01281_assert;
+
+-- better alternative will be to TRUNCATE TABLE system.*_log
+-- but this will be a separate issue
+CREATE TABLE trace_log_01281 AS system.trace_log Engine=Memory();
+CREATE MATERIALIZED VIEW trace_log_01281_mv TO trace_log_01281 AS SELECT * FROM system.trace_log WHERE trace_type = 'MemorySample';
+CREATE VIEW trace_log_01281_assert AS SELECT
+        *,
+        throwIf(cnt < 0,                   'no memory profile captured'),
+        throwIf(queries != 1,              'too much queries'),
+        throwIf(alloc < 100e6,             'minimal allocation had not been done'),
+        throwIf((alloc+free)/alloc > 0.05, 'memory accounting leaked more than 5%')
+    FROM (
+        SELECT
+            count() cnt,
+            uniq(query_id) queries,
+            sumIf(size, size > 0) alloc,
+            sumIf(size, size < 0) free
+        FROM trace_log_01281
+    );
+
+--
+-- Basic
+-- NOTE: 0 (and even 1e6) is too small, will make SYSTEM FLUSH LOGS too slow
+-- (in debug build at least)
+--
+SET max_untracked_memory=4e6;
+
+TRUNCATE TABLE trace_log_01281;
+-- single {
+SET max_threads=1;
+SET memory_profiler_sample_probability=1;
+SELECT uniqExactState(number) FROM numbers(toUInt64(2e6)) GROUP BY number % 2e5 FORMAT Null;
+SET memory_profiler_sample_probability=0;
+SYSTEM FLUSH LOGS;
+-- }
+SELECT * FROM trace_log_01281_assert FORMAT Null;
+
+TRUNCATE TABLE trace_log_01281;
+-- single limit {
+SET max_threads=1;
+SET memory_profiler_sample_probability=1;
+SELECT uniqExactState(number) FROM numbers(toUInt64(2e6)) GROUP BY number % 2e5 LIMIT 10 FORMAT Null;
+SET memory_profiler_sample_probability=0;
+SYSTEM FLUSH LOGS;
+-- }
+SELECT * FROM trace_log_01281_assert FORMAT Null;
+
+TRUNCATE TABLE trace_log_01281;
+-- two-level {
+-- need to have multiple threads for two-level aggregation
+SET max_threads=2;
+SET memory_profiler_sample_probability=1;
+SELECT uniqExactState(number) FROM numbers_mt(toUInt64(2e6)) GROUP BY number % 2e5 FORMAT Null;
+SET memory_profiler_sample_probability=0;
+SYSTEM FLUSH LOGS;
+-- }
+SELECT * FROM trace_log_01281_assert FORMAT Null;
+
+TRUNCATE TABLE trace_log_01281;
+-- two-level limit {
+-- need to have multiple threads for two-level aggregation
+SET max_threads=2;
+SET memory_profiler_sample_probability=1;
+SELECT uniqExactState(number) FROM numbers_mt(toUInt64(2e6)) GROUP BY number % 2e5 LIMIT 10 FORMAT Null;
+SET memory_profiler_sample_probability=0;
+SYSTEM FLUSH LOGS;
+-- }
+SELECT * FROM trace_log_01281_assert FORMAT Null;
+
+TRUNCATE TABLE trace_log_01281;
+-- two-level MEMORY_LIMIT_EXCEEDED {
+-- need to have multiple threads for two-level aggregation
+SET max_threads=2;
+SET memory_profiler_sample_probability=1;
+SET max_memory_usage='150M';
+SELECT uniqExactState(number) FROM numbers_mt(toUInt64(10e6)) GROUP BY number % 1e6 FORMAT Null; -- { serverError 241; }
+SET memory_profiler_sample_probability=0;
+SET max_memory_usage=0;
+SYSTEM FLUSH LOGS;
+-- }
+SELECT * FROM trace_log_01281_assert FORMAT Null;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix memory tracking for two-level GROUP BY when not all rows read from Aggregator (TCP)

Detailed description / Documentation draft:
Example of such cases:
- SELECT GROUP BY LIMIT
- SELECT GROUP BY with subsequent MEMORY_LIMIT_EXCEEDED error

And it should be two-level aggregation, since otherwise there will be
only one hashtable which will be cleared correctly, only if you have
two-level GROUP BY some of hashtables will not be cleared since nobody
consume rows.

Before this patch:
```
    09:39.015292 [ 3070801 ] {609a0610-e377-4132-9cf3-f49454cf3c96} <Information> executeQuery: Read 1000000 rows, 7.63 MiB in 0.707 sec., 1413826 rows/sec., 10.79 MiB/sec.
    09:39.015348 [ 3070801 ] {609a0610-e377-4132-9cf3-f49454cf3c96} <Debug> MemoryTracker: Peak memory usage (for query): 51.93 MiB.
    09:39.015942 [ 3070801 ] {} <Trace> Aggregator: Destroying aggregate states <-- **problem**
    09:39.017057 [ 3070801 ] {} <Trace> Aggregator: Destroying aggregate states <--
    09:39.017961 [ 3070801 ] {} <Debug> MemoryTracker: Peak memory usage (for query): 51.93 MiB.
    09:39.018029 [ 3070801 ] {} <Information> TCPHandler: Processed in 0.711 sec.
```

After this patch:
```
    16:24.544030 [ 3087333 ] {79da208a-b3c0-48d4-9943-c974a3cbb6ea} <Information> executeQuery: Read 1000000 rows, 7.63 MiB in 0.599 sec., 1670199 rows/sec., 12.74 MiB/sec.
    16:24.544084 [ 3087333 ] {79da208a-b3c0-48d4-9943-c974a3cbb6ea} <Debug> MemoryTracker: Peak memory usage (for query): 72.11 MiB.
    16:24.544398 [ 3087333 ] {79da208a-b3c0-48d4-9943-c974a3cbb6ea} <Trace> Aggregator: Destroying aggregate states
    16:24.545485 [ 3087333 ] {79da208a-b3c0-48d4-9943-c974a3cbb6ea} <Trace> Aggregator: Destroying aggregate states
    16:24.547053 [ 3087333 ] {} <Debug> MemoryTracker: Peak memory usage (for query): 72.11 MiB.
    16:24.547093 [ 3087333 ] {} <Information> TCPHandler: Processed in 0.603 sec.
```