### PR TITLE
Add more logs to debug trace_log overflow

### DIFF
--- a/docker/test/performance-comparison/compare.sh
+++ b/docker/test/performance-comparison/compare.sh
@@ -27,7 +27,7 @@ function configure
     kill -0 $left_pid
     disown $left_pid
     set +m
-    while ! clickhouse-client --port 9001 --query "select 1" ; do kill -0 $left_pid ; echo . ; sleep 1 ; done
+    while ! clickhouse-client --port 9001 --query "select 1" && kill -0 $left_pid ; do echo . ; sleep 1 ; done
     echo server for setup started
 
     clickhouse-client --port 9001 --query "create database test" ||:
@@ -71,9 +71,9 @@ function restart
 
     set +m
 
-    while ! clickhouse-client --port 9001 --query "select 1" ; do kill -0 $left_pid ; echo . ; sleep 1 ; done
+    while ! clickhouse-client --port 9001 --query "select 1" && kill -0 $left_pid ; do echo . ; sleep 1 ; done
     echo left ok
-    while ! clickhouse-client --port 9002 --query "select 1" ; do kill -0 $right_pid ; echo . ; sleep 1 ; done
+    while ! clickhouse-client --port 9002 --query "select 1" && kill -0 $right_pid ; do echo . ; sleep 1 ; done
     echo right ok
 
     clickhouse-client --port 9001 --query "select * from system.tables where database != 'system'"
@@ -263,7 +263,7 @@ done
 wait
 unset IFS
 
-parallel --verbose --null < analyze-commands.txt
+parallel --null < analyze-commands.txt
 }
 
 # Analyze results
@@ -542,7 +542,7 @@ case "$stage" in
     # to collect the logs. Prefer not to restart, because addresses might change
     # and we won't be able to process trace_log data. Start in a subshell, so that
     # it doesn't interfere with the watchdog through `wait`.
-    ( time get_profiles || restart || get_profiles ||: ) 2>> profile-errors.log
+    ( get_profiles || restart || get_profiles ||: )
 
     # Kill the whole process group, because somehow when the subshell is killed,
     # the sleep inside remains alive and orphaned.

--- a/docker/test/performance-comparison/compare.sh
+++ b/docker/test/performance-comparison/compare.sh
@@ -542,7 +542,7 @@ case "$stage" in
     # to collect the logs. Prefer not to restart, because addresses might change
     # and we won't be able to process trace_log data. Start in a subshell, so that
     # it doesn't interfere with the watchdog through `wait`.
-    ( time get_profiles || restart || get_profiles ||: )
+    ( time get_profiles || restart || get_profiles ||: ) 2>> profile-errors.log
 
     # Kill the whole process group, because somehow when the subshell is killed,
     # the sleep inside remains alive and orphaned.

--- a/src/Interpreters/SystemLog.h
+++ b/src/Interpreters/SystemLog.h
@@ -344,7 +344,8 @@ void SystemLog<LogElement>::savingThreadFunction()
                 std::unique_lock lock(mutex);
                 const bool predicate = flush_event.wait_for(lock,
                     std::chrono::milliseconds(flush_interval_milliseconds),
-                    [&] () {
+                    [&] ()
+                    {
                         return requested_flush_before > flushed_before
                             || is_shutdown;
                     }


### PR DESCRIPTION
I am investigating this report:
https://clickhouse-test-reports.s3.yandex.net/10956/bd9e5556e3c022a8968fd17142c01551bde32421/performance_comparison/report.html

The trace log export times out, and the server log is full of `Queue is full for system log 'DB::TraceLog'`. Reproduces more often that we'd want.

Changelog category (leave one):
- Non-significant (changelog entry is not required)
