### PR TITLE
Support numeric parameters in Number and String data types

### DIFF
--- a/src/DataTypes/DataTypeString.cpp
+++ b/src/DataTypes/DataTypeString.cpp
@@ -15,6 +15,9 @@
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeFactory.h>
 
+#include <Parsers/IAST.h>
+#include <Parsers/ASTLiteral.h>
+
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
 #include <IO/VarInt.h>
@@ -26,6 +29,14 @@
 
 namespace DB
 {
+
+
+namespace ErrorCodes
+{
+    extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+    extern const int UNEXPECTED_AST_STRUCTURE;
+}
+
 
 void DataTypeString::serializeBinary(const Field & field, WriteBuffer & ostr) const
 {
@@ -366,12 +377,24 @@ bool DataTypeString::equals(const IDataType & rhs) const
     return typeid(rhs) == typeid(*this);
 }
 
+static DataTypePtr create(const ASTPtr & arguments)
+{
+    if (arguments) {
+        if (arguments->children.size() > 1)
+            throw Exception("String data type family mustnt have more than one argument - size in characters", ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
+
+        const auto * argument = arguments->children[0]->as<ASTLiteral>();
+        if (!argument || argument->value.getType() != Field::Types::UInt64 || argument->value.get<UInt64>() == 0)
+            throw Exception("FixedString data type family may have only a number (positive integer) as its argument", ErrorCodes::UNEXPECTED_AST_STRUCTURE);
+    }
+
+    return std::make_shared<DataTypeString>();
+}
+
 
 void registerDataTypeString(DataTypeFactory & factory)
 {
-    auto creator = static_cast<DataTypePtr(*)()>([] { return DataTypePtr(std::make_shared<DataTypeString>()); });
-
-    factory.registerSimpleDataType("String", creator);
+    factory.registerDataType("String", create);
 
     /// These synonyms are added for compatibility.
 

--- a/src/DataTypes/DataTypeString.cpp
+++ b/src/DataTypes/DataTypeString.cpp
@@ -379,7 +379,8 @@ bool DataTypeString::equals(const IDataType & rhs) const
 
 static DataTypePtr create(const ASTPtr & arguments)
 {
-    if (arguments) {
+    if (arguments)
+    {
         if (arguments->children.size() > 1)
             throw Exception("String data type family mustnt have more than one argument - size in characters", ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
 
@@ -410,5 +411,4 @@ void registerDataTypeString(DataTypeFactory & factory)
     factory.registerAlias("MEDIUMBLOB", "String", DataTypeFactory::CaseInsensitive);
     factory.registerAlias("LONGBLOB", "String", DataTypeFactory::CaseInsensitive);
 }
-
 }

--- a/src/DataTypes/DataTypesNumber.cpp
+++ b/src/DataTypes/DataTypesNumber.cpp
@@ -46,8 +46,8 @@ void registerDataTypeNumbers(DataTypeFactory & factory)
     factory.registerDataType("Int16", createNumericDataType<Int16>);
     factory.registerDataType("Int32", createNumericDataType<Int32>);
     factory.registerDataType("Int64", createNumericDataType<Int64>);
-    factory.registerDataType("Float32", createNumericDataType<Int32>);
-    factory.registerDataType("Float64", createNumericDataType<Int64>);
+    factory.registerDataType("Float32", createNumericDataType<Float32>);
+    factory.registerDataType("Float64", createNumericDataType<Float64>);
 
     /// These synonyms are added for compatibility.
 

--- a/src/DataTypes/DataTypesNumber.cpp
+++ b/src/DataTypes/DataTypesNumber.cpp
@@ -12,7 +12,6 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
-    extern const int UNEXPECTED_AST_STRUCTURE;
 }
 
 template <typename T>

--- a/src/DataTypes/DataTypesNumber.cpp
+++ b/src/DataTypes/DataTypesNumber.cpp
@@ -2,8 +2,114 @@
 #include <DataTypes/DataTypeFactory.h>
 
 
+#include <Parsers/IAST.h>
+#include <Parsers/ASTLiteral.h>
+
+
 namespace DB
 {
+
+namespace ErrorCodes
+{
+    extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+    extern const int UNEXPECTED_AST_STRUCTURE;
+}
+
+static DataTypePtr createForInt8(const ASTPtr & arguments)
+{
+    if (arguments) {
+        if (arguments->children.size() > 1)
+            throw Exception("INT8 data type family must not have more than one argument - display width", ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
+
+        const auto * argument = arguments->children[0]->as<ASTLiteral>();
+        if (!argument || argument->value.getType() != Field::Types::UInt64 || argument->value.get<UInt64>() == 0)
+            throw Exception("INT8 data type family may have only a number (positive integer) as its argument", ErrorCodes::UNEXPECTED_AST_STRUCTURE);
+    }
+
+    return std::make_shared<DataTypeInt8>();
+}
+
+static DataTypePtr createForInt16(const ASTPtr & arguments)
+{
+    if (arguments) {
+        if (arguments->children.size() > 1)
+            throw Exception("INT16 data type family must not have more than one argument - display width", ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
+
+        const auto * argument = arguments->children[0]->as<ASTLiteral>();
+        if (!argument || argument->value.getType() != Field::Types::UInt64 || argument->value.get<UInt64>() == 0)
+            throw Exception("INT16 data type family may have only a number (positive integer) as its argument", ErrorCodes::UNEXPECTED_AST_STRUCTURE);
+    }
+
+    return std::make_shared<DataTypeInt16>();
+}
+
+static DataTypePtr createForInt32(const ASTPtr & arguments)
+{
+    if (arguments) {
+        if (arguments->children.size() > 1)
+            throw Exception("INT32 data type family must not have more than one argument - display width", ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
+
+        const auto * argument = arguments->children[0]->as<ASTLiteral>();
+        if (!argument || argument->value.getType() != Field::Types::UInt64 || argument->value.get<UInt64>() == 0)
+            throw Exception("INT32 data type family may have only a number (positive integer) as its argument", ErrorCodes::UNEXPECTED_AST_STRUCTURE);
+    }
+
+    return std::make_shared<DataTypeInt32>();
+}
+
+static DataTypePtr createForInt64(const ASTPtr & arguments)
+{
+    if (arguments) {
+        if (arguments->children.size() > 1)
+            throw Exception("INT64 data type family must not have more than one argument - display width", ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
+
+        const auto * argument = arguments->children[0]->as<ASTLiteral>();
+        if (!argument || argument->value.getType() != Field::Types::UInt64 || argument->value.get<UInt64>() == 0)
+            throw Exception("INT64 data type family may have only a number (positive integer) as its argument", ErrorCodes::UNEXPECTED_AST_STRUCTURE);
+    }
+
+    return std::make_shared<DataTypeInt64>();
+}
+
+static DataTypePtr createForFloat32(const ASTPtr & arguments)
+{
+    if (arguments) {
+        if (arguments->children.size() > 2)
+            throw Exception("FLOAT32 data type family must not have more than two arguments - total number of digits and number of digits following the decimal point", ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
+         else if (arguments->children.size() == 1) {
+            const auto * argument = arguments->children[0]->as<ASTLiteral>();
+            if (!argument || argument->value.getType() != Field::Types::UInt64)
+                throw Exception("FLOAT32 data type family may have  a non negative number as its argument", ErrorCodes::UNEXPECTED_AST_STRUCTURE);
+        } else if (arguments->children.size() == 2) {
+            const auto * beforePoint = arguments->children[0]->as<ASTLiteral>();
+            const auto * afterPoint = arguments->children[1]->as<ASTLiteral>();
+            if (!beforePoint || beforePoint->value.getType() != Field::Types::UInt64 ||
+                !afterPoint|| afterPoint->value.getType() != Field::Types::UInt64)
+                throw Exception("FLOAT32 data type family may have  a non negative number as its arguments", ErrorCodes::UNEXPECTED_AST_STRUCTURE);
+        }
+    }
+
+    return std::make_shared<DataTypeFloat32>();
+}
+
+static DataTypePtr createForFloat64(const ASTPtr & arguments)
+{
+    if (arguments) {
+        if (arguments->children.size() != 2)
+            throw Exception("FLOAT64 data type family must have only two arguments - total number of digits and number of digits following the decimal point", ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
+        else {
+            const auto * beforePoint = arguments->children[0]->as<ASTLiteral>();
+            const auto * afterPoint = arguments->children[1]->as<ASTLiteral>();
+            if (!beforePoint || beforePoint->value.getType() != Field::Types::UInt64 ||
+                !afterPoint|| afterPoint->value.getType() != Field::Types::UInt64)
+                throw Exception("FLOAT64 data type family may have  a non negative number as its arguments", ErrorCodes::UNEXPECTED_AST_STRUCTURE);
+        }
+    }
+
+    return std::make_shared<DataTypeFloat64>();
+}
+
+
 
 void registerDataTypeNumbers(DataTypeFactory & factory)
 {
@@ -12,13 +118,12 @@ void registerDataTypeNumbers(DataTypeFactory & factory)
     factory.registerSimpleDataType("UInt32", [] { return DataTypePtr(std::make_shared<DataTypeUInt32>()); });
     factory.registerSimpleDataType("UInt64", [] { return DataTypePtr(std::make_shared<DataTypeUInt64>()); });
 
-    factory.registerSimpleDataType("Int8", [] { return DataTypePtr(std::make_shared<DataTypeInt8>()); });
-    factory.registerSimpleDataType("Int16", [] { return DataTypePtr(std::make_shared<DataTypeInt16>()); });
-    factory.registerSimpleDataType("Int32", [] { return DataTypePtr(std::make_shared<DataTypeInt32>()); });
-    factory.registerSimpleDataType("Int64", [] { return DataTypePtr(std::make_shared<DataTypeInt64>()); });
-
-    factory.registerSimpleDataType("Float32", [] { return DataTypePtr(std::make_shared<DataTypeFloat32>()); });
-    factory.registerSimpleDataType("Float64", [] { return DataTypePtr(std::make_shared<DataTypeFloat64>()); });
+    factory.registerDataType("Int8", createForInt8);
+    factory.registerDataType("Int16", createForInt16);
+    factory.registerDataType("Int32", createForInt32);
+    factory.registerDataType("Int64", createForInt64);
+    factory.registerDataType("Float32", createForFloat32);
+    factory.registerDataType("Float64", createForFloat64);
 
     /// These synonyms are added for compatibility.
 

--- a/tests/queries/0_stateless/01268_data_numeric_parameters.reference
+++ b/tests/queries/0_stateless/01268_data_numeric_parameters.reference
@@ -1,0 +1,3 @@
+Int8	Int8	Int16	Int16	Int32	Int32	Int64	Int64
+Float32	Float32	Float32	Float64	Float64	Float64
+String	String

--- a/tests/queries/0_stateless/01268_data_numeric_parameters.sql
+++ b/tests/queries/0_stateless/01268_data_numeric_parameters.sql
@@ -1,0 +1,42 @@
+DROP TABLE IF EXISTS ints;
+DROP TABLE IF EXISTS floats;
+DROP TABLE IF EXISTS strings;
+
+CREATE TABLE ints (
+    a TINYINT,
+    b TINYINT(8),
+    c SMALLINT,
+    d SMALLINT(16),
+    e INT,
+    f INT(32),
+    g BIGINT,
+    h BIGINT(64)
+) engine=Memory;
+
+INSERT INTO ints VALUES (1, 8, 11, 16, 21, 32, 41, 64);
+
+SELECT  toTypeName(a), toTypeName(b), toTypeName(c), toTypeName(d), toTypeName(e), toTypeName(f), toTypeName(g), toTypeName(h) FROM ints;
+
+CREATE TABLE floats (
+    a FLOAT,
+    b FLOAT(12),
+    c FLOAT(15, 22),
+    d DOUBLE,
+    e DOUBLE(12),
+    f DOUBLE(4, 18)
+
+) engine=Memory;
+
+INSERT INTO floats VALUES (1.1, 1.2, 1.3, 41.1, 41.1, 42.1);
+
+SELECT  toTypeName(a), toTypeName(b), toTypeName(c), toTypeName(d), toTypeName(e), toTypeName(f) FROM floats;
+
+
+CREATE TABLE strings (
+    a VARCHAR,
+    b VARCHAR(11)
+) engine=Memory;
+
+INSERT INTO strings VALUES ('test', 'string');
+
+SELECT  toTypeName(a), toTypeName(b)  FROM strings;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Non-significant


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support numeric parameters in VARCHAR, VARBINARY, INT... data types (e.g. VARCHAR(255)) and ignore them completely.

Detailed description / Documentation draft:
Now Number and String data types can be created with numeric parameters like other [DBMS](https://dev.mysql.com/doc/refman/8.0/en/data-types.html). But them will ignore completely.



