### PR TITLE
Add reference to stream-loader in Third Party Integration docs

### DIFF
--- a/docs/es/interfaces/third-party/integrations.md
+++ b/docs/es/interfaces/third-party/integrations.md
@@ -25,6 +25,7 @@ toc_title: Integrations
 -   Message queues
     -   [Kafka](https://kafka.apache.org)
         -   [clickhouse\_sinker](https://github.com/housepower/clickhouse_sinker) (uses [Go client](https://github.com/ClickHouse/clickhouse-go/))
+        -   [stream-loader-clickhouse](https://github.com/adform/stream-loader)
 -   Stream processing
     -   [Flink](https://flink.apache.org)
         -   [flink-clickhouse-sink](https://github.com/ivi-ru/flink-clickhouse-sink)

--- a/docs/fa/interfaces/third-party/integrations.md
+++ b/docs/fa/interfaces/third-party/integrations.md
@@ -27,6 +27,7 @@ toc_title: "\u06CC\u06A9\u067E\u0627\u0631\u0686\u06AF\u06CC"
 -   صف پیام
     -   [کافکا](https://kafka.apache.org)
         -   [در حال بارگذاری](https://github.com/housepower/clickhouse_sinker) (استفاده [برو کارگیر](https://github.com/ClickHouse/clickhouse-go/))
+        -   [stream-loader-clickhouse](https://github.com/adform/stream-loader)
 -   پردازش جریان
     -   [لرزش](https://flink.apache.org)
         -   [سینک فلینک-کلیک](https://github.com/ivi-ru/flink-clickhouse-sink)

--- a/docs/fr/interfaces/third-party/integrations.md
+++ b/docs/fr/interfaces/third-party/integrations.md
@@ -27,6 +27,7 @@ toc_title: "Int\xE9gration"
 -   Files d'attente de messages
     -   [Kafka](https://kafka.apache.org)
         -   [clickhouse\_sinker](https://github.com/housepower/clickhouse_sinker) (utiliser [Allez client](https://github.com/ClickHouse/clickhouse-go/))
+        -   [stream-loader-clickhouse](https://github.com/adform/stream-loader)
 -   Traitement de flux
     -   [Flink](https://flink.apache.org)
         -   [flink-clickhouse-évier](https://github.com/ivi-ru/flink-clickhouse-sink)

--- a/docs/ja/interfaces/third-party/integrations.md
+++ b/docs/ja/interfaces/third-party/integrations.md
@@ -27,6 +27,7 @@ toc_title: "\u7D71\u5408"
 -   メッセージキュ
     -   [カフカ](https://kafka.apache.org)
         -   [clickhouse\_sinker](https://github.com/housepower/clickhouse_sinker) （用途 [Goクライアント](https://github.com/ClickHouse/clickhouse-go/))
+        -   [stream-loader-clickhouse](https://github.com/adform/stream-loader)
 -   ストリーム処理
     -   [フリンク](https://flink.apache.org)
         -   [フリンク-クリックハウス-シンク](https://github.com/ivi-ru/flink-clickhouse-sink)

--- a/docs/ru/interfaces/third-party/integrations.md
+++ b/docs/ru/interfaces/third-party/integrations.md
@@ -20,6 +20,7 @@
 -   Очереди сообщений
     -   [Kafka](https://kafka.apache.org)
         -   [clickhouse\_sinker](https://github.com/housepower/clickhouse_sinker) (использует [Go client](https://github.com/ClickHouse/clickhouse-go/))
+        -   [stream-loader-clickhouse](https://github.com/adform/stream-loader)
 -   Потоковая обработка
     -   [Flink](https://flink.apache.org)
         -   [flink-clickhouse-sink](https://github.com/ivi-ru/flink-clickhouse-sink)

--- a/docs/tr/interfaces/third-party/integrations.md
+++ b/docs/tr/interfaces/third-party/integrations.md
@@ -27,6 +27,7 @@ toc_title: Entegrasyonlar
 -   Mesaj kuyrukları
     -   [Kafka](https://kafka.apache.org)
         -   [clickhouse\_sinker](https://github.com/housepower/clickhouse_sinker) (kullanma [Go client](https://github.com/ClickHouse/clickhouse-go/))
+        -   [stream-loader-clickhouse](https://github.com/adform/stream-loader)
 -   Akış işleme
     -   [Flink](https://flink.apache.org)
         -   [flink-clickhouse-lavabo](https://github.com/ivi-ru/flink-clickhouse-sink)

--- a/docs/zh/interfaces/third-party/integrations.md
+++ b/docs/zh/interfaces/third-party/integrations.md
@@ -19,6 +19,7 @@
 -   消息队列
     -   [卡夫卡](https://kafka.apache.org)
         -   [clickhouse\_sinker](https://github.com/housepower/clickhouse_sinker) (使用 [去客户](https://github.com/ClickHouse/clickhouse-go/))
+        -   [stream-loader-clickhouse](https://github.com/adform/stream-loader)
 -   流处理
     -   [Flink](https://flink.apache.org)
         -   [flink-clickhouse-sink](https://github.com/ivi-ru/flink-clickhouse-sink)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Documentation

Detailed description:

Add link to the [stream-loader](https://github.com/adform/stream-loader) project under `Interfaces / Third Party / Integrations / Kafka`. The stream loader library allows one to consume Kafka, encode data in RowBinary format (or CSV/parquet) and store it to ClickHouse using exactly once semantics.