### PR TITLE
Fixes the potential missed data during termination of Kafka engine table

### DIFF
--- a/src/Storages/Kafka/KafkaBlockInputStream.cpp
+++ b/src/Storages/Kafka/KafkaBlockInputStream.cpp
@@ -134,12 +134,7 @@ Block KafkaBlockInputStream::readImpl()
 
         auto new_rows = read_kafka_message();
 
-        // we can't store the offser after rebalance, when consumer is stalled, or if it's terminating
-        if (!buffer->storeLastReadMessageOffset())
-        {
-            total_rows = 0;
-            break;
-        }
+        buffer->storeLastReadMessageOffset();
 
         auto topic         = buffer->currentTopic();
         auto key           = buffer->currentKey();
@@ -177,7 +172,7 @@ Block KafkaBlockInputStream::readImpl()
         }
     }
 
-    if (total_rows == 0)
+    if (buffer->polledDataUnusable() || total_rows == 0)
         return Block();
 
     /// MATERIALIZED columns can be added here, but I think

--- a/src/Storages/Kafka/KafkaBlockInputStream.cpp
+++ b/src/Storages/Kafka/KafkaBlockInputStream.cpp
@@ -135,7 +135,8 @@ Block KafkaBlockInputStream::readImpl()
         auto new_rows = read_kafka_message();
 
         // we can't store the offser after rebalance, when consumer is stalled, or if it's terminating
-        if (!buffer->storeLastReadMessageOffset()) {
+        if (!buffer->storeLastReadMessageOffset())
+        {
             total_rows = 0;
             break;
         }

--- a/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
+++ b/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
@@ -336,12 +336,17 @@ bool ReadBufferFromKafkaConsumer::nextImpl()
     return true;
 }
 
-void ReadBufferFromKafkaConsumer::storeLastReadMessageOffset()
+bool ReadBufferFromKafkaConsumer::storeLastReadMessageOffset()
 {
-    if (!stalled && !rebalance_happened)
+    if (!stalled && !rebalance_happened && !stopped)
     {
         consumer->store_offset(*(current - 1));
         ++offsets_stored;
+        return true;
+    }
+    else
+    {
+        return false;
     }
 }
 

--- a/src/Storages/Kafka/ReadBufferFromKafkaConsumer.h
+++ b/src/Storages/Kafka/ReadBufferFromKafkaConsumer.h
@@ -37,8 +37,9 @@ public:
     auto pollTimeout() const { return poll_timeout; }
 
     bool hasMorePolledMessages() const;
+    bool polledDataUnusable() const { return (was_stopped || rebalance_happened); }
 
-    bool storeLastReadMessageOffset();
+    void storeLastReadMessageOffset();
     void resetToLastCommitted(const char * msg);
 
     // Return values for the message that's being read.
@@ -67,6 +68,8 @@ private:
     Messages::const_iterator current;
 
     bool rebalance_happened = false;
+
+    bool was_stopped = false;
 
     // order is important, need to be destructed before consumer
     cppkafka::TopicPartitionList assignment;

--- a/src/Storages/Kafka/ReadBufferFromKafkaConsumer.h
+++ b/src/Storages/Kafka/ReadBufferFromKafkaConsumer.h
@@ -37,9 +37,8 @@ public:
     auto pollTimeout() const { return poll_timeout; }
 
     bool hasMorePolledMessages() const;
-    auto rebalanceHappened() const { return rebalance_happened; }
 
-    void storeLastReadMessageOffset();
+    bool storeLastReadMessageOffset();
     void resetToLastCommitted(const char * msg);
 
     // Return values for the message that's being read.

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -454,7 +454,10 @@ bool StorageKafka::streamToViews()
     else
         in = streams[0];
 
-    copyData(*in, *block_io.out, &stream_cancelled);
+    // We can't cancel during copyData, as it's not aware of commits and other kafka-related stuff.
+    // It will be cancelled on underlying layer (kafka buffer)
+    std::atomic<bool> stub = {false};
+    copyData(*in, *block_io.out, &stub);
     for (auto & stream : streams)
         stream->as<KafkaBlockInputStream>()->commit();
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes the potential missed data during termination of Kafka engine table

Detailed description / Documentation draft:
During termination of the table, it was possible to stop reading in the middle of the polled batch but commit the whole batch. After continuing consumption it would lead to skipped messages. 

Now after termination start we return don't store / commit the offset.

Closes #11034

/cc @azat 