### PR TITLE
dictGet with table name

### DIFF
--- a/src/Interpreters/ActionsVisitor.cpp
+++ b/src/Interpreters/ActionsVisitor.cpp
@@ -471,7 +471,7 @@ void ActionsMatcher::visit(const ASTFunction & node, const ASTPtr & ast, Data & 
             argument_types.push_back(column.type);
             argument_names.push_back(column.name);
         }
-        else if (identifier && node.name == "joinGet" && arg == 0)
+        else if (identifier && functionIsJoinGetOrDictGet(node.name) && arg == 0)
         {
             auto table_id = IdentifierSemantic::extractDatabaseAndTable(*identifier);
             table_id = data.context.resolveStorageID(table_id, Context::ResolveOrdinary);
@@ -480,7 +480,7 @@ void ActionsMatcher::visit(const ASTFunction & node, const ASTPtr & ast, Data & 
             ColumnWithTypeAndName column(
                 ColumnConst::create(std::move(column_string), 1),
                 std::make_shared<DataTypeString>(),
-                data.getUniqueName("__joinGet"));
+                data.getUniqueName("__joinGetOrDictGet"));
             data.addAction(ExpressionAction::addColumn(column));
             argument_types.push_back(column.type);
             argument_names.push_back(column.name);

--- a/src/Interpreters/ActionsVisitor.cpp
+++ b/src/Interpreters/ActionsVisitor.cpp
@@ -471,7 +471,7 @@ void ActionsMatcher::visit(const ASTFunction & node, const ASTPtr & ast, Data & 
             argument_types.push_back(column.type);
             argument_names.push_back(column.name);
         }
-        else if (identifier && functionIsJoinGetOrDictGet(node.name) && arg == 0)
+        else if (identifier && (functionIsJoinGet(node.name) || functionIsDictGet(node.name)) && arg == 0)
         {
             auto table_id = IdentifierSemantic::extractDatabaseAndTable(*identifier);
             table_id = data.context.resolveStorageID(table_id, Context::ResolveOrdinary);
@@ -480,7 +480,7 @@ void ActionsMatcher::visit(const ASTFunction & node, const ASTPtr & ast, Data & 
             ColumnWithTypeAndName column(
                 ColumnConst::create(std::move(column_string), 1),
                 std::make_shared<DataTypeString>(),
-                data.getUniqueName("__joinGetOrDictGet"));
+                data.getUniqueName("__" + node.name));
             data.addAction(ExpressionAction::addColumn(column));
             argument_types.push_back(column.type);
             argument_names.push_back(column.name);

--- a/src/Interpreters/MarkTableIdentifiersVisitor.cpp
+++ b/src/Interpreters/MarkTableIdentifiersVisitor.cpp
@@ -44,7 +44,7 @@ void MarkTableIdentifiersMatcher::visit(const ASTFunction & func, ASTPtr &, Data
     }
 
     // first argument of joinGet can be a table identifier
-    if (func.name == "joinGet")
+    if (functionIsJoinGetOrDictGet(func.name))
     {
         auto & ast = func.arguments->children.at(0);
         if (auto opt_name = tryGetIdentifierName(ast))

--- a/src/Interpreters/MarkTableIdentifiersVisitor.cpp
+++ b/src/Interpreters/MarkTableIdentifiersVisitor.cpp
@@ -38,16 +38,18 @@ void MarkTableIdentifiersMatcher::visit(const ASTFunction & func, ASTPtr &, Data
     if (functionIsInOrGlobalInOperator(func.name))
     {
         auto & ast = func.arguments->children.at(1);
-        if (auto opt_name = tryGetIdentifierName(ast))
-            if (!data.aliases.count(*opt_name))
-                setIdentifierSpecial(ast);
+        auto opt_name = tryGetIdentifierName(ast);
+        if (opt_name && !data.aliases.count(*opt_name))
+            setIdentifierSpecial(ast);
     }
 
-    // first argument of joinGet can be a table identifier
-    if (functionIsJoinGetOrDictGet(func.name))
+    // First argument of joinGet can be a table name, perhaps with a database.
+    // First argument of dictGet can be a dictionary name, perhaps with a database.
+    if (functionIsJoinGet(func.name) || functionIsDictGet(func.name))
     {
         auto & ast = func.arguments->children.at(0);
-        if (auto opt_name = tryGetIdentifierName(ast))
+        auto opt_name = tryGetIdentifierName(ast);
+        if (opt_name && !data.aliases.count(*opt_name))
             setIdentifierSpecial(ast);
     }
 }

--- a/src/Interpreters/misc.h
+++ b/src/Interpreters/misc.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <Common/StringUtils/StringUtils.h>
+
 namespace DB
 {
 
@@ -16,6 +18,11 @@ inline bool functionIsInOrGlobalInOperator(const std::string & name)
 inline bool functionIsLikeOperator(const std::string & name)
 {
     return name == "like" || name == "notLike";
+}
+
+inline bool functionIsJoinGetOrDictGet(const std::string & name)
+{
+    return name == "joinGet" || startsWith(name, "dictGet");
 }
 
 }

--- a/src/Interpreters/misc.h
+++ b/src/Interpreters/misc.h
@@ -20,9 +20,14 @@ inline bool functionIsLikeOperator(const std::string & name)
     return name == "like" || name == "notLike";
 }
 
-inline bool functionIsJoinGetOrDictGet(const std::string & name)
+inline bool functionIsJoinGet(const std::string & name)
 {
     return name == "joinGet" || startsWith(name, "dictGet");
+}
+
+inline bool functionIsDictGet(const std::string & name)
+{
+    return startsWith(name, "dictGet") || (name == "dictHas") || (name == "dictIsIn");
 }
 
 }

--- a/tests/queries/0_stateless/01018_ddl_dictionaries_select.reference
+++ b/tests/queries/0_stateless/01018_ddl_dictionaries_select.reference
@@ -20,4 +20,5 @@ database_for_dict	dict2	Hashed
 6
 6
 6
+database_for_dict.dict3	6
 6

--- a/tests/queries/0_stateless/01018_ddl_dictionaries_select.reference
+++ b/tests/queries/0_stateless/01018_ddl_dictionaries_select.reference
@@ -17,3 +17,7 @@ database_for_dict	dict1	ComplexKeyCache
 database_for_dict	dict2	Hashed
 6
 6
+6
+6
+6
+6

--- a/tests/queries/0_stateless/01018_ddl_dictionaries_select.sql
+++ b/tests/queries/0_stateless/01018_ddl_dictionaries_select.sql
@@ -115,6 +115,9 @@ SELECT dictGet(database_for_dict.dict3, 'some_column', toUInt64(12));
 SELECT dictGet(default.dict3, 'some_column', toUInt64(12)); -- {serverError 36}
 USE default;
 
+-- alias should be handled correctly
+SELECT 'database_for_dict.dict3' as n, dictGet(n, 'some_column', toUInt64(12));
+
 DROP TABLE database_for_dict.table_for_dict;
 
 SYSTEM RELOAD DICTIONARIES; -- {serverError 60}

--- a/tests/queries/0_stateless/01018_ddl_dictionaries_select.sql
+++ b/tests/queries/0_stateless/01018_ddl_dictionaries_select.sql
@@ -105,6 +105,16 @@ LAYOUT(HASHED());
 
 SELECT dictGetString('database_for_dict.dict3', 'some_column', toUInt64(12));
 
+-- dictGet with table name
+USE database_for_dict;
+SELECT dictGetString(dict3, 'some_column', toUInt64(12));
+SELECT dictGetString(database_for_dict.dict3, 'some_column', toUInt64(12));
+SELECT dictGetString(default.dict3, 'some_column', toUInt64(12)); -- {serverError 36}
+SELECT dictGet(dict3, 'some_column', toUInt64(12));
+SELECT dictGet(database_for_dict.dict3, 'some_column', toUInt64(12));
+SELECT dictGet(default.dict3, 'some_column', toUInt64(12)); -- {serverError 36}
+USE default;
+
 DROP TABLE database_for_dict.table_for_dict;
 
 SYSTEM RELOAD DICTIONARIES; -- {serverError 60}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Improvement

Changelog entry:
Now `dictGet*` functions accept table names.

This PR is created to finish the work started by Amos Bird in https://github.com/ClickHouse/ClickHouse/pull/8329.