### PR TITLE
Add Kafka client.id

### DIFF
--- a/src/Storages/Kafka/KafkaSettings.h
+++ b/src/Storages/Kafka/KafkaSettings.h
@@ -19,6 +19,7 @@ struct KafkaSettings : public SettingsCollection<KafkaSettings>
     M(SettingString, kafka_broker_list, "", "A comma-separated list of brokers for Kafka engine.", 0) \
     M(SettingString, kafka_topic_list, "", "A list of Kafka topics.", 0) \
     M(SettingString, kafka_group_name, "", "A group of Kafka consumers.", 0) \
+    M(SettingString, kafka_client_id, "", "A client id of Kafka consumer.", 0) \
     M(SettingString, kafka_format, "", "The message format for Kafka engine.", 0) \
     M(SettingChar, kafka_row_delimiter, '\0', "The character to be considered as a delimiter in Kafka message.", 0) \
     M(SettingString, kafka_schema, "", "Schema identifier (used by schema-based formats) for Kafka engine", 0) \

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -117,6 +117,7 @@ StorageKafka::StorageKafka(
     const ColumnsDescription & columns_,
     const String & brokers_,
     const String & group_,
+    const String & client_id_,
     const Names & topics_,
     const String & format_name_,
     char row_delimiter_,
@@ -131,6 +132,7 @@ StorageKafka::StorageKafka(
     , topics(global_context.getMacros()->expand(topics_))
     , brokers(global_context.getMacros()->expand(brokers_))
     , group(global_context.getMacros()->expand(group_))
+    , client_id(global_context.getMacros()->expand(client_id_))
     , format_name(global_context.getMacros()->expand(format_name_))
     , row_delimiter(row_delimiter_)
     , schema_name(global_context.getMacros()->expand(schema_name_))
@@ -261,7 +263,7 @@ ProducerBufferPtr StorageKafka::createWriteBuffer(const Block & header)
     cppkafka::Configuration conf;
     conf.set("metadata.broker.list", brokers);
     conf.set("group.id", group);
-    conf.set("client.id", VERSION_FULL);
+    conf.set("client.id", client_id);
     // TODO: fill required settings
     updateConfiguration(conf);
 
@@ -280,7 +282,7 @@ ConsumerBufferPtr StorageKafka::createReadBuffer()
 
     conf.set("metadata.broker.list", brokers);
     conf.set("group.id", group);
-    conf.set("client.id", VERSION_FULL);
+    conf.set("client.id", client_id);
 
     conf.set("auto.offset.reset", "smallest");     // If no offset stored for this group, read all messages from the start
 
@@ -484,6 +486,7 @@ void registerStorageKafka(StorageFactory & factory)
           * - Kafka broker list
           * - List of topics
           * - Group ID (may be a constaint expression with a string result)
+          * - Client ID
           * - Message format (string)
           * - Row delimiter
           * - Schema (optional, if the format supports it)
@@ -526,6 +529,7 @@ void registerStorageKafka(StorageFactory & factory)
         CHECK_KAFKA_STORAGE_ARGUMENT(8, kafka_max_block_size)
         CHECK_KAFKA_STORAGE_ARGUMENT(9, kafka_skip_broken_messages)
         CHECK_KAFKA_STORAGE_ARGUMENT(10, kafka_commit_every_batch)
+        CHECK_KAFKA_STORAGE_ARGUMENT(11, kafka_client_id)
 
         #undef CHECK_KAFKA_STORAGE_ARGUMENT
 
@@ -690,9 +694,17 @@ void registerStorageKafka(StorageFactory & factory)
             }
         }
 
+        // Get and check client id
+         String client_id = kafka_settings.kafka_client_id.value;
+        if (args_count >= 11)
+        {
+            engine_args[10] = evaluateConstantExpressionOrIdentifierAsLiteral(engine_args[10], args.local_context);
+            client_id = engine_args[10]->as<ASTLiteral &>().value.safeGet<String>();
+        }
+
         return StorageKafka::create(
             args.table_id, args.context, args.columns,
-            brokers, group, topics, format, row_delimiter, schema, num_consumers, max_block_size, skip_broken, intermediate_commit);
+            brokers, group, client_id, topics, format, row_delimiter, schema, num_consumers, max_block_size, skip_broken, intermediate_commit);
     };
 
     factory.registerStorage("Kafka", creator_fn, StorageFactory::StorageFeatures{ .supports_settings = true, });

--- a/src/Storages/Kafka/StorageKafka.h
+++ b/src/Storages/Kafka/StorageKafka.h
@@ -67,6 +67,7 @@ protected:
         const ColumnsDescription & columns_,
         const String & brokers_,
         const String & group_,
+        const String & client_id_,
         const Names & topics_,
         const String & format_name_,
         char row_delimiter_,
@@ -83,6 +84,7 @@ private:
     Names topics;
     const String brokers;
     const String group;
+    const String client_id;
     const String format_name;
     char row_delimiter; /// optional row delimiter for generating char delimited stream in order to make various input stream parsers happy.
     const String schema_name;


### PR DESCRIPTION
This PR supports kafka setting `kafka_client_id`.

Related issue: https://github.com/ClickHouse/ClickHouse/issues/10723


I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Support `kafka_client_id` parameter when consuming data from kafka.
