### PR TITLE
Configurable ignore replication check for distributed ALTER

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -240,6 +240,7 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingBool, insert_distributed_sync, false, "If setting is enabled, insert query into distributed waits until data will be sent to all nodes in cluster.", 0) \
     M(SettingUInt64, insert_distributed_timeout, 0, "Timeout for insert query into distributed. Setting is used only with insert_distributed_sync enabled. Zero value means no timeout.", 0) \
     M(SettingInt64, distributed_ddl_task_timeout, 180, "Timeout for DDL query responses from all hosts in cluster. If a ddl request has not been performed on all hosts, a response will contain a timeout error and a request will be executed in an async mode. Negative value means infinite.", 0) \
+    M(SettingBool, distributed_ddl_replication_check, true, "Should a table's engine definition and cluster's config definition be checked against each other. Without setting it to `false` it's impossible to ALTER unreplicated tables, e.g., VIEW and MATERIALIZED VIEW, on clusters with replicated shards.", 0) \
     M(SettingMilliseconds, stream_flush_interval_ms, 7500, "Timeout for flushing data from streaming storages.", 0) \
     M(SettingMilliseconds, stream_poll_timeout_ms, 500, "Timeout for polling data from/to streaming storages.", 0) \
     \

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -230,7 +230,6 @@ DDLWorker::DDLWorker(const std::string & zk_root_dir, Context & context_, const 
         task_max_lifetime = config->getUInt64(prefix + ".task_max_lifetime", static_cast<UInt64>(task_max_lifetime));
         cleanup_delay_period = config->getUInt64(prefix + ".cleanup_delay_period", static_cast<UInt64>(cleanup_delay_period));
         max_tasks_in_queue = std::max<UInt64>(1, config->getUInt64(prefix + ".max_tasks_in_queue", max_tasks_in_queue));
-        distributed_ddl_replication_check = config->getBool(prefix + ".distributed_ddl_replication_check", distributed_ddl_replication_check);
 
         if (config->has(prefix + ".profile"))
             context.setSetting("profile", config->getString(prefix + ".profile"));
@@ -713,7 +712,7 @@ void DDLWorker::checkShardConfig(const String & table, const DDLTask & task, Sto
             ErrorCodes::INCONSISTENT_CLUSTER_DEFINITION);
     }
 
-    if (!storage->supportsReplication() && config_is_replicated_shard && distributed_ddl_replication_check)
+    if (!storage->supportsReplication() && config_is_replicated_shard && context.getSettingsRef().distributed_ddl_replication_check)
     {
         throw Exception("Table " + backQuote(table) + " isn't replicated, but shard #" + toString(task.host_shard_num + 1) +
             " is replicated according to its cluster definition", ErrorCodes::INCONSISTENT_CLUSTER_DEFINITION);

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -705,7 +705,7 @@ void DDLWorker::checkShardConfig(const String & table, const DDLTask & task, Sto
         return;
     }
 
-    if (storage->supportsReplication() && !config_is_replicated_shard && distributed_ddl_replication_check)
+    if (storage->supportsReplication() && !config_is_replicated_shard)
     {
         throw Exception("Table " + backQuote(table) + " is replicated, but shard #" + toString(task.host_shard_num + 1) +
             " isn't replicated according to its cluster definition."

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -230,6 +230,7 @@ DDLWorker::DDLWorker(const std::string & zk_root_dir, Context & context_, const 
         task_max_lifetime = config->getUInt64(prefix + ".task_max_lifetime", static_cast<UInt64>(task_max_lifetime));
         cleanup_delay_period = config->getUInt64(prefix + ".cleanup_delay_period", static_cast<UInt64>(cleanup_delay_period));
         max_tasks_in_queue = std::max<UInt64>(1, config->getUInt64(prefix + ".max_tasks_in_queue", max_tasks_in_queue));
+        distributed_ddl_replication_check = config->getBool(prefix + ".distributed_ddl_replication_check", distributed_ddl_replication_check);
 
         if (config->has(prefix + ".profile"))
             context.setSetting("profile", config->getString(prefix + ".profile"));
@@ -704,7 +705,7 @@ void DDLWorker::checkShardConfig(const String & table, const DDLTask & task, Sto
         return;
     }
 
-    if (storage->supportsReplication() && !config_is_replicated_shard)
+    if (storage->supportsReplication() && !config_is_replicated_shard && distributed_ddl_replication_check)
     {
         throw Exception("Table " + backQuote(table) + " is replicated, but shard #" + toString(task.host_shard_num + 1) +
             " isn't replicated according to its cluster definition."
@@ -712,7 +713,7 @@ void DDLWorker::checkShardConfig(const String & table, const DDLTask & task, Sto
             ErrorCodes::INCONSISTENT_CLUSTER_DEFINITION);
     }
 
-    if (!storage->supportsReplication() && config_is_replicated_shard)
+    if (!storage->supportsReplication() && config_is_replicated_shard && distributed_ddl_replication_check)
     {
         throw Exception("Table " + backQuote(table) + " isn't replicated, but shard #" + toString(task.host_shard_num + 1) +
             " is replicated according to its cluster definition", ErrorCodes::INCONSISTENT_CLUSTER_DEFINITION);

--- a/src/Interpreters/DDLWorker.h
+++ b/src/Interpreters/DDLWorker.h
@@ -125,6 +125,8 @@ private:
     Int64 task_max_lifetime = 7 * 24 * 60 * 60; // week (in seconds)
     /// How many tasks could be in the queue
     size_t max_tasks_in_queue = 1000;
+    /// Should cluster config and table engine be checked against each other
+    bool distributed_ddl_replication_check = true;
 
     ThreadGroupStatusPtr thread_group;
 

--- a/src/Interpreters/DDLWorker.h
+++ b/src/Interpreters/DDLWorker.h
@@ -125,8 +125,6 @@ private:
     Int64 task_max_lifetime = 7 * 24 * 60 * 60; // week (in seconds)
     /// How many tasks could be in the queue
     size_t max_tasks_in_queue = 1000;
-    /// Should cluster config and table engine be checked against each other
-    bool distributed_ddl_replication_check = true;
 
     ThreadGroupStatusPtr thread_group;
 

--- a/tests/integration/test_distributed_ddl/test_replicated_alter.py
+++ b/tests/integration/test_distributed_ddl/test_replicated_alter.py
@@ -104,7 +104,7 @@ CREATE VIEW IF NOT EXISTS view ON CLUSTER cluster AS SELECT * FROM system.settin
 """)
     instance.query("""
 ALTER TABLE view ON CLUSTER cluster MODIFY QUERY SELECT * FROM system.settings WHERE changed
-""", settings={'distributed_ddl_replication_check': 1})
+""", settings={'distributed_ddl_replication_check': 0})
     test_cluster.ddl_check_query(instance, "DROP TABLE view ON CLUSTER cluster")
 
     # Enable random ZK packet drops


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

This PR implements a setting to suppress the replication consistency check for tables on a cluster. It's possible now to set `distributed_ddl_replication_check=0` and execute `ALTER materialized_view ON CLUSTER cluster_with_replicas`


Detailed description / Documentation draft:

`distributed_ddl_replication_check=0` setting will suppress replication consistency check during `ALTER materialized_view ON CLUSTER cluster_with_replicas`