### PR TITLE
Enable background memory purging to reduce memory usage due to ThreadPool

### DIFF
--- a/programs/server/CMakeLists.txt
+++ b/programs/server/CMakeLists.txt
@@ -12,6 +12,11 @@ set(CLICKHOUSE_SERVER_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/TCPHandler.cpp
 )
 
+if (ENABLE_JEMALLOC)
+    set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/Server.cpp PROPERTIES
+        COMPILE_DEFINITIONS ENABLE_JEMALLOC)
+endif()
+
 set(CLICKHOUSE_SERVER_SOURCES
     ${CLICKHOUSE_SERVER_SOURCES}
     ${CMAKE_CURRENT_SOURCE_DIR}/MySQLHandler.cpp
@@ -24,6 +29,7 @@ set (CLICKHOUSE_SERVER_LINK
         clickhouse_common_config
         clickhouse_common_io
         clickhouse_common_zookeeper
+        clickhouse_common_memory
         clickhouse_dictionaries
         clickhouse_functions
         clickhouse_parsers

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -31,6 +31,7 @@
 #include <Common/getExecutablePath.h>
 #include <Common/ThreadProfileEvents.h>
 #include <Common/ThreadStatus.h>
+#include <Common/Memory.h>
 #include <IO/HTTPCommon.h>
 #include <IO/UseSSL.h>
 #include <Interpreters/AsynchronousMetrics.h>
@@ -223,6 +224,9 @@ int Server::main(const std::vector<std::string> & /*args*/)
     registerStorages();
     registerDictionaries();
     registerDisks();
+
+    if (!enableBackgroundMemoryPurge())
+        LOG_ERROR(log, "Cannot enable background_thread for jemalloc. Memory usage may be higher.");
 
 #if !defined(ARCADIA_BUILD)
 #if USE_OPENCL

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,7 +66,7 @@ set(dbms_sources)
 add_headers_and_sources(clickhouse_common_io Common)
 add_headers_and_sources(clickhouse_common_io Common/HashTable)
 add_headers_and_sources(clickhouse_common_io IO)
-list (REMOVE_ITEM clickhouse_common_io_sources Common/malloc.cpp Common/new_delete.cpp)
+list (REMOVE_ITEM clickhouse_common_io_sources Common/malloc.cpp Common/new_delete.cpp Common/Memory.cpp)
 
 if(USE_RDKAFKA)
     add_headers_and_sources(dbms Storages/Kafka)
@@ -114,6 +114,9 @@ set_source_files_properties(Common/malloc.cpp PROPERTIES COMPILE_FLAGS "-fno-bui
 
 add_library (clickhouse_new_delete STATIC Common/new_delete.cpp)
 target_link_libraries (clickhouse_new_delete PRIVATE clickhouse_common_io jemalloc)
+
+add_library (clickhouse_common_memory STATIC Common/Memory.cpp)
+target_link_libraries (clickhouse_common_memory PRIVATE jemalloc)
 
 add_subdirectory(Common/ZooKeeper)
 add_subdirectory(Common/Config)

--- a/src/Common/Memory.cpp
+++ b/src/Common/Memory.cpp
@@ -1,0 +1,37 @@
+#include "Memory.h"
+
+#if USE_JEMALLOC
+#include <jemalloc/jemalloc.h>
+
+bool enableBackgroundMemoryPurge()
+{
+    bool value = true;
+    // background threads for purging memory asynchronously will help with the
+    // memory not freed by inactive threads, since ThreadPool select job
+    // randomly there can be some threads that had been performed some memory
+    // heavy task and will be inactive for some time, and until it will became
+    // active again, the memory will not be freed (note that default number of
+    // areans is 4*CPU).
+    //
+    // There are the following metrics in the system.asynchronous_metrics that
+    // will show how active threads are:
+    // - jemalloc.background_thread.num_runs
+    // - jemalloc.background_thread.run_interval
+    //
+    // It is enabled for server only (and not via JEMALLOC_CONFIG_MALLOC_CONF
+    // in jemalloc-cmake/**/jemalloc_internal_defs.h), since this is threads
+    // and other utils are not that hot to requires this.
+    if (mallctl("background_thread", nullptr, nullptr, reinterpret_cast<void *>(&value), sizeof(value)))
+        return false;
+
+    size_t size = sizeof(value);
+    value = false;
+    if (mallctl("background_thread", reinterpret_cast<void *>(&value), &size, nullptr, 0))
+        return false;
+
+    return value;
+}
+
+#else
+bool enableBackgroundMemoryPurge() { return false; }
+#endif

--- a/src/Common/Memory.h
+++ b/src/Common/Memory.h
@@ -1,0 +1,3 @@
+#pragma once
+
+bool enableBackgroundMemoryPurge();


### PR DESCRIPTION
**Conflicts with: #11084**

Let's see on performance test results.

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Enable background memory purging to reduce memory usage due to ThreadPool (jemalloc background_thread).

Detailed:

background threads for purging memory asynchronously will help with the
memory not freed by inactive threads, since ThreadPool select job
randomly there can be some threads that had been performed some memory
heavy task and will be inactive for some time, and until it will became
active again, the memory will not be freed.

There are the following metrics in the system.asynchronous_metrics that
will show how active threads are:
- jemalloc.background_thread.num_runs
- jemalloc.background_thread.run_interval

It is enabled for server only (and not via JEMALLOC_CONFIG_MALLOC_CONF
in jemalloc-cmake/**/jemalloc_internal_defs.h), since this is threads
and other utils are not that hot to requires this.

Refs: #10818