### PR TITLE
table name typo fix

### DIFF
--- a/docs/en/engines/table-engines/integrations/kafka.md
+++ b/docs/en/engines/table-engines/integrations/kafka.md
@@ -72,7 +72,7 @@ Examples:
                             kafka_format = 'JSONEachRow',
                             kafka_num_consumers = 4;
 
-  CREATE TABLE queue2 (
+  CREATE TABLE queue3 (
     timestamp UInt64,
     level String,
     message String


### PR DESCRIPTION
According to the context, the table name of queue2 should be queue3.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)