### PR TITLE
[RFC] Disable -Wsequence-point on gcc10 (otherwise it stuck on GatherUtils compiling)

### DIFF
--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -162,4 +162,10 @@ elseif (COMPILER_GCC)
     add_cxx_compile_options(-Wunused)
     # Warn if vector operation is not implemented via SIMD capabilities of the architecture
     add_cxx_compile_options(-Wvector-operation-performance)
+
+    # XXX: gcc10 stuck with this option while compiling GatherUtils code
+    # (anyway there are builds with clang, that will warn)
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+        add_cxx_compile_options(-Wno-sequence-point)
+    endif()
 endif ()


### PR DESCRIPTION
clang (10.0.0 is fine BTW) will warn about this anyway on CI.

For the debug build gcc10 (10.1.0):

- before patch:
  - concat.cpp -> >5m (stuck on cc1plus, not as)
  - has.cpp    -> >10m (stuck on cc1plus, not as)

- after this patch:
  - concat.cpp -> 1m16s
  - has.cpp    -> 4m (and most of the time eats, as from binutils 2.34.50.20200508)

Command for build:
- ninja src/Functions/GatherUtils/CMakeFiles/clickhouse_functions_gatherutils.dir/concat.cpp.o
- ninja src/Functions/GatherUtils/CMakeFiles/clickhouse_functions_gatherutils.dir/has.cpp.o

The test case should be reduced and then it can be reported to the gcc
bugzilla.

P.S. Looks like a signal not to switch to gcc10 for now

Changelog category (leave one):
- Non-significant (changelog entry is not required)