### PR TITLE
Do not reserve extra threads after max threads optimization for simple queries

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1533,7 +1533,7 @@ void InterpreterSelectQuery::executeFetchColumns(
         if constexpr (pipeline_with_processors)
         {
             if (streams.size() == 1 || pipes.size() == 1)
-                pipeline.setMaxThreads(streams.size());
+                pipeline.setMaxThreads(1);
 
             /// Unify streams. They must have same headers.
             if (streams.size() > 1)

--- a/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
+++ b/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
@@ -275,7 +275,7 @@ QueryPipeline InterpreterSelectWithUnionQuery::executeWithProcessors()
         // nested queries can force 1 thread (due to simplicity)
         // but in case of union this cannot be done.
         UInt64 max_threads = context->getSettingsRef().max_threads;
-        main_pipeline.setMaxThreads(std::min(nested_interpreters.size(), max_threads));
+        main_pipeline.setMaxThreads(std::min<UInt64>(nested_interpreters.size(), max_threads));
     }
 
     main_pipeline.addInterpreterContext(context);

--- a/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
+++ b/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
@@ -271,6 +271,11 @@ QueryPipeline InterpreterSelectWithUnionQuery::executeWithProcessors()
     {
         auto common_header = getCommonHeaderForUnion(headers);
         main_pipeline.unitePipelines(std::move(pipelines), common_header);
+
+        // nested queries can force 1 thread (due to simplicity)
+        // but in case of union this cannot be done.
+        UInt64 max_threads = context->getSettingsRef().max_threads;
+        main_pipeline.setMaxThreads(std::min(nested_interpreters.size(), max_threads));
     }
 
     main_pipeline.addInterpreterContext(context);

--- a/tests/queries/0_stateless/01283_max_threads_simple_query_optimization.sql
+++ b/tests/queries/0_stateless/01283_max_threads_simple_query_optimization.sql
@@ -1,0 +1,21 @@
+DROP TABLE IF EXISTS data_01283;
+
+CREATE TABLE data_01283 engine=MergeTree()
+ORDER BY key
+PARTITION BY key
+AS SELECT number key FROM numbers(10);
+
+SET log_queries=1;
+SELECT * FROM data_01283 LIMIT 1 FORMAT Null;
+SET log_queries=0;
+SYSTEM FLUSH LOGS;
+
+-- 1 for PullingAsyncPipelineExecutor::pull
+-- 1 for AsynchronousBlockInputStream
+SELECT
+    throwIf(count() != 1, 'no query was logged'),
+    throwIf(length(thread_ids) != 2, 'too many threads used')
+FROM system.query_log
+WHERE type = 'QueryFinish' AND query LIKE '%data_01283 LIMIT 1%'
+GROUP BY thread_ids
+FORMAT Null;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix excessive reserving of threads for simple queries (optimization for reducing the number of threads, which was partly broken after changes in pipeline).

Do not reserve extra threads after max threads optimization for simple queries

Cc: @KochetovNicolai 
Refs: #11104 