### PR TITLE
Remove extra copying from addressToLine

### DIFF
--- a/src/Functions/addressToLine.cpp
+++ b/src/Functions/addressToLine.cpp
@@ -118,9 +118,7 @@ private:
                 writeChar(':', out);
                 writeIntText(location.line, out);
 
-                StringRef out_str = out.finish();
-                out_str.data = arena.insert(out_str.data, out_str.size);
-                return out_str;
+                return out.finish();
             }
             else
             {

--- a/tests/queries/0_stateless/00974_query_profiler.sql
+++ b/tests/queries/0_stateless/00974_query_profiler.sql
@@ -5,7 +5,9 @@ SET log_queries = 1;
 SELECT sleep(0.5), ignore('test real time query profiler');
 SET log_queries = 0;
 SYSTEM FLUSH LOGS;
-WITH addressToSymbol(arrayJoin(trace)) AS symbol SELECT count() > 0 FROM system.trace_log t WHERE query_id = (SELECT query_id FROM system.query_log WHERE query LIKE '%test real time query profiler%' AND query NOT LIKE '%system%' ORDER BY event_time DESC LIMIT 1) AND symbol LIKE '%FunctionSleep%';
+
+WITH addressToLine(arrayJoin(trace) AS addr) || '#' || demangle(addressToSymbol(addr)) AS symbol
+SELECT count() > 0 FROM system.trace_log t WHERE query_id = (SELECT query_id FROM system.query_log WHERE query LIKE '%test real time query profiler%' AND query NOT LIKE '%system%' ORDER BY event_time DESC LIMIT 1) AND symbol LIKE '%FunctionSleep%';
 
 SET query_profiler_real_time_period_ns = 0;
 SET query_profiler_cpu_time_period_ns = 1000000;
@@ -13,4 +15,6 @@ SET log_queries = 1;
 SELECT count(), ignore('test cpu time query profiler') FROM numbers(1000000000);
 SET log_queries = 0;
 SYSTEM FLUSH LOGS;
-WITH addressToSymbol(arrayJoin(trace)) AS symbol SELECT count() > 0 FROM system.trace_log t WHERE query_id = (SELECT query_id FROM system.query_log WHERE query LIKE '%test cpu time query profiler%' AND query NOT LIKE '%system%' ORDER BY event_time DESC LIMIT 1) AND symbol LIKE '%Source%';
+
+WITH addressToLine(arrayJoin(trace) AS addr) || '#' || demangle(addressToSymbol(addr)) AS symbol
+SELECT count() > 0 FROM system.trace_log t WHERE query_id = (SELECT query_id FROM system.query_log WHERE query LIKE '%test cpu time query profiler%' AND query NOT LIKE '%system%' ORDER BY event_time DESC LIMIT 1) AND symbol LIKE '%Source%';


### PR DESCRIPTION
The line is already serialized to the same arena, so there is no need to
copy it. Also add this function to query profiler test, so that it has
some coverage.

Changelog category (leave one):
- Non-significant (changelog entry is not required)