### PR TITLE
Enable mlock of clickhouse binary by default

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -227,7 +227,7 @@
           and to prevent clickhouse executable from being paged out under high IO load.
          Enabling this option is recommended but will lead to increased startup time for up to a few seconds.
     -->
-    <mlock_executable>false</mlock_executable>
+    <mlock_executable>true</mlock_executable>
 
     <!-- Configuration of clusters that could be used in Distributed tables.
          https://clickhouse.tech/docs/en/operations/table_engines/distributed/


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Enable mlock of clickhouse binary by default. It will prevent clickhouse executable from being paged out under high IO load.