### PR TITLE
Add performance test for non-constant polygons

### DIFF
--- a/tests/performance/point_in_polygon.xml
+++ b/tests/performance/point_in_polygon.xml
@@ -1,0 +1,13 @@
+<test>
+    <create_query>CREATE TABLE polygons (polygon Array(Array(Tuple(Float64, Float64)))) ENGINE = Memory</create_query>
+    <create_query>
+        INSERT INTO polygons
+        WITH number + 1 AS radius
+        SELECT [arrayMap(x -> (cos(x / 90. * pi()) * radius, sin(x / 90. * pi()) * radius), range(180))]
+        FROM numbers(1000)
+    </create_query>
+
+    <query>SELECT pointInPolygon((100, 100), polygon) FROM polygons</query>
+
+    <drop_query>DROP TABLE IF EXISTS polygons</drop_query>
+</test>


### PR DESCRIPTION
Continuation of #10623

Performance is so low that it makes this function borderline useless. @livace

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add performance test for non-constant polygons.