### PR TITLE
Fix JEMalloc conf after #11084

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -22,15 +22,6 @@ add_subdirectory (consistent-hashing)
 add_subdirectory (croaring)
 add_subdirectory (FastMemcpy)
 add_subdirectory (grpc-cmake)
-# ThreadPool select job randomly, and there can be some threads that had been
-# performed some memory heavy task before and will be inactive for some time,
-# but until it will became active again, the memory will not be freed since by
-# default each thread has it's own arena, but there should be not more then
-# 4*CPU arenas (see opt.nareans description).
-#
-# By enabling percpu_arena number of arenas limited to number of CPUs and hence
-# this problem should go away.
-set(JEMALLOC_CONFIG_MALLOC_CONF "percpu_arena:percpu")
 add_subdirectory (jemalloc-cmake)
 add_subdirectory (libcpuid-cmake)
 add_subdirectory (murmurhash)

--- a/contrib/jemalloc-cmake/CMakeLists.txt
+++ b/contrib/jemalloc-cmake/CMakeLists.txt
@@ -9,7 +9,15 @@ if (ENABLE_JEMALLOC)
     option (USE_INTERNAL_JEMALLOC "Use internal jemalloc library" ${NOT_UNBUNDLED})
 
     if (USE_INTERNAL_JEMALLOC)
-        option (JEMALLOC_CONFIG_MALLOC_CONF "Change default configuration string" "")
+        # ThreadPool select job randomly, and there can be some threads that had been
+        # performed some memory heavy task before and will be inactive for some time,
+        # but until it will became active again, the memory will not be freed since by
+        # default each thread has it's own arena, but there should be not more then
+        # 4*CPU arenas (see opt.nareans description).
+        #
+        # By enabling percpu_arena number of arenas limited to number of CPUs and hence
+        # this problem should go away.
+        set (JEMALLOC_CONFIG_MALLOC_CONF "percpu_arena:percpu" CACHE STRING "Change default configuration string of JEMalloc" )
         message (STATUS "jemalloc malloc_conf: ${JEMALLOC_CONFIG_MALLOC_CONF}")
 
         set (LIBRARY_DIR "${ClickHouse_SOURCE_DIR}/contrib/jemalloc")


### PR DESCRIPTION
#11084

Changelog category (leave one):
- Non-significant (changelog entry is not required)


Three errors were fixed:
1. `option` in CMake is for boolean values - it can only switch between on and off. Replaced to `set ... CACHE`.
2. If normal variable has already been set, then subsequent definitions of cache variable does not change anything.
3. Moved the code to more appropriate place where it's more easy to find.