### PR TITLE
Fix radix sort after #10981

### DIFF
--- a/src/AggregateFunctions/QuantileTDigest.h
+++ b/src/AggregateFunctions/QuantileTDigest.h
@@ -109,6 +109,7 @@ class QuantileTDigest
         using KeyBits = UInt32;
 
         static constexpr size_t PART_SIZE_BITS = 8;
+        static constexpr bool DIRECT_WRITE_TO_DESTINATION = false;
 
         using Transform = RadixSortFloatTransform<KeyBits>;
         using Allocator = RadixSortMallocAllocator;

--- a/src/AggregateFunctions/QuantileTDigest.h
+++ b/src/AggregateFunctions/QuantileTDigest.h
@@ -109,7 +109,6 @@ class QuantileTDigest
         using KeyBits = UInt32;
 
         static constexpr size_t PART_SIZE_BITS = 8;
-        static constexpr bool DIRECT_WRITE_TO_DESTINATION = false;
 
         using Transform = RadixSortFloatTransform<KeyBits>;
         using Allocator = RadixSortMallocAllocator;

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -119,6 +119,8 @@ namespace
     {
         using Element = ValueWithIndex<T>;
         using Result = size_t;
+        static constexpr bool DIRECT_WRITE_TO_DESTINATION = true;
+
         static T & extractKey(Element & elem) { return elem.value; }
         static size_t extractResult(Element & elem) { return elem.index; }
     };

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -119,7 +119,6 @@ namespace
     {
         using Element = ValueWithIndex<T>;
         using Result = size_t;
-        static constexpr bool DIRECT_WRITE_TO_DESTINATION = true;
 
         static T & extractKey(Element & elem) { return elem.value; }
         static size_t extractResult(Element & elem) { return elem.index; }


### PR DESCRIPTION
Continuation of #10981

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Detailed description / Documentation draft:
```
Alexey Milovidov, [23.05.20 17:36]
Придумал тест - прекрасно видна разница в 5-10%.
(При этом сам Radix Sort меньше половины времени работы теста.)

G. Arslan, [23.05.20 17:46]
[In reply to Alexey Milovidov]
о, это приятно слышать, а как выглядит тест?

Alexey Milovidov, [23.05.20 18:02]
Только что закоммитил, см. ссылку в конце в своём PR.

G. Arslan, [23.05.20 18:07]
супер, спасибо

Alexey Milovidov, [23.05.20 18:10]
Впрочем, там несколько ошибок, влияющих на производительность.

И я случайно сравниваю разные сборки (gcc и clang), так что слова преждевременные.

Но не беспокойся, сейчас исправлю пару проблем и будет лучше.

Alexey Milovidov, [23.05.20 18:31]
Оказывается, твой код стал не быстрее, а медленнее :)

Потому что условие
pass < NUM_PASSES - direct_copy_to_destination
в цикле
правая часть стала не compile time константой
и это подавило разворачивание цикла.

Я сейчас починил, пришлю PR.
```