### PR TITLE
Added `allow_merges` option for volumes in multi-disk configuration

### DIFF
--- a/src/Disks/StoragePolicy.cpp
+++ b/src/Disks/StoragePolicy.cpp
@@ -252,10 +252,10 @@ StoragePolicySelector::StoragePolicySelector(
     constexpr auto default_volume_name = "default";
     constexpr auto default_disk_name = "default";
 
-    /// Add default policy if it's not specified explicetly
+    /// Add default policy if it isn't explicitly specified.
     if (policies.find(default_storage_policy_name) == policies.end())
     {
-        auto default_volume = std::make_shared<VolumeJBOD>(default_volume_name, std::vector<DiskPtr>{disks->get(default_disk_name)}, 0);
+        auto default_volume = std::make_shared<VolumeJBOD>(default_volume_name, std::vector<DiskPtr>{disks->get(default_disk_name)}, 0, true);
 
         auto default_policy = std::make_shared<StoragePolicy>(default_storage_policy_name, VolumesJBOD{default_volume}, 0.0);
         policies.emplace(default_storage_policy_name, default_policy);
@@ -278,6 +278,12 @@ StoragePolicySelectorPtr StoragePolicySelector::updateFromConfig(const Poco::Uti
             throw Exception("Storage policy " + backQuote(name) + " is missing in new configuration", ErrorCodes::BAD_ARGUMENTS);
 
         policy->checkCompatibleWith(result->policies[name]);
+
+        /// Transfer state of Volume.
+        for (const auto & volume : policy->getVolumes())
+        {
+            result->get(name)->getVolumeByName(volume->getName())->are_merges_allowed_from_query = volume->are_merges_allowed_from_query;
+        }
     }
 
     return result;

--- a/src/Disks/VolumeJBOD.cpp
+++ b/src/Disks/VolumeJBOD.cpp
@@ -53,6 +53,8 @@ VolumeJBOD::VolumeJBOD(
     static constexpr UInt64 MIN_PART_SIZE = 8u * 1024u * 1024u;
     if (max_data_part_size != 0 && max_data_part_size < MIN_PART_SIZE)
         LOG_WARNING(logger, "Volume {} max_data_part_size is too low ({} < {})", backQuote(name), ReadableSize(max_data_part_size), ReadableSize(MIN_PART_SIZE));
+
+    are_merges_allowed_in_config = config.getBool(config_prefix + ".allow_merges", true);
 }
 
 DiskPtr VolumeJBOD::getNextDisk()
@@ -81,6 +83,20 @@ ReservationPtr VolumeJBOD::reserve(UInt64 bytes)
             return reservation;
     }
     return {};
+}
+
+bool VolumeJBOD::areMergesAllowed() const
+{
+    return (are_merges_allowed_from_query && *are_merges_allowed_from_query && are_merges_allowed_in_config)
+        || (!are_merges_allowed_from_query && are_merges_allowed_in_config);
+}
+
+void VolumeJBOD::setAllowMergesFromQuery(bool allow)
+{
+    if (are_merges_allowed_from_query)
+        *are_merges_allowed_from_query = allow;
+    else
+        are_merges_allowed_from_query = std::make_shared<bool>(allow);
 }
 
 }

--- a/src/Disks/VolumeJBOD.h
+++ b/src/Disks/VolumeJBOD.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include <Disks/IVolume.h>
 
 namespace DB
@@ -13,8 +15,10 @@ namespace DB
 class VolumeJBOD : public IVolume
 {
 public:
-    VolumeJBOD(String name_, Disks disks_, UInt64 max_data_part_size_)
-        : IVolume(name_, disks_), max_data_part_size(max_data_part_size_)
+    VolumeJBOD(String name_, Disks disks_, UInt64 max_data_part_size_, bool are_merges_allowed_in_config_)
+        : IVolume(name_, disks_)
+        , max_data_part_size(max_data_part_size_)
+        , are_merges_allowed_in_config(are_merges_allowed_in_config_)
     {
     }
 
@@ -40,6 +44,16 @@ public:
 
     /// Max size of reservation
     UInt64 max_data_part_size = 0;
+
+    bool areMergesAllowed() const;
+
+    void setAllowMergesFromQuery(bool allow);
+
+    /// True if parts on this volume participate in merges according to configuration.
+    bool are_merges_allowed_in_config = true;
+
+    /// True if parts on this volume participate in merges according to START/STOP MERGES ON VOLUME.
+    std::shared_ptr<bool> are_merges_allowed_from_query;
 private:
     mutable std::atomic<size_t> last_used = 0;
 };

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -581,7 +581,7 @@ VolumeJBODPtr Context::setTemporaryStorage(const String & path, const String & p
             shared->tmp_path += '/';
 
         auto disk = std::make_shared<DiskLocal>("_tmp_default", shared->tmp_path, 0);
-        shared->tmp_volume = std::make_shared<VolumeJBOD>("_tmp_default", std::vector<DiskPtr>{disk}, 0);
+        shared->tmp_volume = std::make_shared<VolumeJBOD>("_tmp_default", std::vector<DiskPtr>{disk}, 0, true);
     }
     else
     {

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -153,7 +153,9 @@ void InterpreterSystemQuery::startStopAction(StorageActionBlockType action_type,
                 if (!access->isGranted(log, getRequiredAccessType(action_type), elem.first, iterator->name()))
                     continue;
 
-                if (start)
+                if (volume_ptr && action_type == ActionLocks::PartsMerge)
+                    volume_ptr->setAllowMergesFromQuery(start);
+                else if (start)
                     manager->remove(table, action_type);
                 else
                     manager->add(table, action_type);
@@ -188,6 +190,10 @@ BlockIO InterpreterSystemQuery::execute()
 
     if (!query.target_dictionary.empty() && !query.database.empty())
         query.target_dictionary = query.database + "." + query.target_dictionary;
+
+    volume_ptr = {};
+    if (!query.storage_policy.empty() || !query.volume.empty())
+        volume_ptr = context.getStoragePolicy(query.storage_policy)->getVolumeByName(query.volume);
 
     switch (query.type)
     {

--- a/src/Interpreters/InterpreterSystemQuery.h
+++ b/src/Interpreters/InterpreterSystemQuery.h
@@ -5,6 +5,7 @@
 #include <Storages/IStorage_fwd.h>
 #include <Interpreters/StorageID.h>
 #include <Common/ActionLock.h>
+#include <Disks/VolumeJBOD.h>
 
 
 namespace Poco { class Logger; }
@@ -31,6 +32,7 @@ private:
     Context & context;
     Poco::Logger * log = nullptr;
     StorageID table_id = StorageID::createEmpty();      /// Will be set up if query contains table name
+    VolumeJBODPtr volume_ptr;
 
     /// Tries to get a replicated table and restart it
     /// Returns pointer to a newly created table if the restart was successful

--- a/src/Parsers/ASTSystemQuery.cpp
+++ b/src/Parsers/ASTSystemQuery.cpp
@@ -116,6 +116,16 @@ void ASTSystemQuery::formatImpl(const FormatSettings & settings, FormatState &, 
                       << (settings.hilite ? hilite_none : "");
     };
 
+    auto print_on_volume = [&]
+    {
+        settings.ostr << " ON VOLUME "
+                      << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(storage_policy)
+                      << (settings.hilite ? hilite_none : "")
+                      << "."
+                      << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(volume)
+                      << (settings.hilite ? hilite_none : "");
+    };
+
     if (!cluster.empty())
         formatOnCluster(settings);
 
@@ -136,6 +146,8 @@ void ASTSystemQuery::formatImpl(const FormatSettings & settings, FormatState &, 
     {
         if (!table.empty())
             print_database_table();
+        else if (!volume.empty())
+            print_on_volume();
     }
     else if (type == Type::RESTART_REPLICA || type == Type::SYNC_REPLICA || type == Type::FLUSH_DISTRIBUTED)
     {

--- a/src/Parsers/ASTSystemQuery.h
+++ b/src/Parsers/ASTSystemQuery.h
@@ -61,6 +61,8 @@ public:
     String target_dictionary;
     String database;
     String table;
+    String storage_policy;
+    String volume;
 
     String getID(char) const override { return "SYSTEM query"; }
 

--- a/src/Parsers/ParserSystemQuery.cpp
+++ b/src/Parsers/ParserSystemQuery.cpp
@@ -86,6 +86,33 @@ bool ParserSystemQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expected & 
 
         case Type::STOP_MERGES:
         case Type::START_MERGES:
+        {
+            String storage_policy_str;
+            String volume_str;
+
+            if (ParserKeyword{"ON VOLUME"}.ignore(pos, expected))
+            {
+                ASTPtr ast;
+                if (ParserStringLiteral{}.parse(pos, ast, expected))
+                    storage_policy_str = ast->as<ASTLiteral &>().value.safeGet<String>();
+                else
+                    return false;
+
+                if (!ParserToken{TokenType::Dot}.ignore(pos, expected))
+                    return false;
+
+                if (ParserStringLiteral{}.parse(pos, ast, expected))
+                    volume_str = ast->as<ASTLiteral &>().value.safeGet<String>();
+                else
+                    return false;
+            }
+            res->storage_policy = storage_policy_str;
+            res->volume = volume_str;
+            if (res->volume.empty() && res->storage_policy.empty())
+                parseDatabaseAndTableName(pos, expected, res->database, res->table);
+            break;
+        }
+
         case Type::STOP_TTL_MERGES:
         case Type::START_TTL_MERGES:
         case Type::STOP_MOVES:

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -641,6 +641,16 @@ void IMergeTreeDataPart::loadColumns(bool require)
         column_name_to_position.emplace(column.name, pos++);
 }
 
+bool IMergeTreeDataPart::areMergesAllowed() const
+{
+    auto storage_policy = storage.getStoragePolicy();
+
+    /// One need to get volume description for given volume.
+    auto volume_ptr = storage_policy->getVolume(storage_policy->getVolumeIndexByDisk(volume->getDisk()));
+
+    return volume_ptr->areMergesAllowed();
+}
+
 UInt64 IMergeTreeDataPart::calculateTotalSizeOnDisk(const DiskPtr & disk_, const String & from)
 {
     if (disk_->isFile(from))

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -321,6 +321,9 @@ public:
     /// storage and pass it to this method.
     virtual bool hasColumnFiles(const String & /* column */, const IDataType & /* type */) const{ return false; }
 
+    /// Checks if there any objections to merge this part on per-part basis.
+    bool areMergesAllowed() const;
+
     /// Calculate the total size of the entire directory with all the files
     static UInt64 calculateTotalSizeOnDisk(const DiskPtr & disk_, const String & from);
     void calculateColumnsSizesOnDisk();

--- a/src/Storages/MergeTree/SimpleMergeSelector.cpp
+++ b/src/Storages/MergeTree/SimpleMergeSelector.cpp
@@ -1,4 +1,6 @@
 #include <Storages/MergeTree/SimpleMergeSelector.h>
+
+#include <Storages/MergeTree/IMergeTreeDataPart.h>
 #include <Common/interpolate.h>
 
 #include <cmath>
@@ -152,6 +154,9 @@ void selectWithinPartition(
         if (begin > 1000)
             break;
 
+        if (!static_cast<const IMergeTreeDataPart *>(parts[begin].data)->areMergesAllowed())
+            continue;
+
         size_t sum_size = parts[begin].size;
         size_t max_size = parts[begin].size;
         size_t min_age = parts[begin].age;
@@ -159,6 +164,9 @@ void selectWithinPartition(
         for (size_t end = begin + 2; end <= parts_count; ++end)
         {
             if (settings.max_parts_to_merge_at_once && end - begin > settings.max_parts_to_merge_at_once)
+                break;
+
+            if (!static_cast<const IMergeTreeDataPart *>(parts[end - 1].data)->areMergesAllowed())
                 break;
 
             size_t cur_size = parts[end - 1].size;

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -331,7 +331,7 @@ void StorageDistributed::createStorage()
         if (!path.ends_with('/'))
             path += '/';
         auto disk = std::make_shared<DiskLocal>("default", path, 0);
-        volume = std::make_shared<VolumeJBOD>("default", std::vector<DiskPtr>{disk}, 0);
+        volume = std::make_shared<VolumeJBOD>("default", std::vector<DiskPtr>{disk}, 0, true);
     }
     else
     {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Added `allow_merges` option for volumes in multi-disk configuration.
