### PR TITLE
Enable log_queries by default

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -156,7 +156,7 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingUInt64, priority, 0, "Priority of the query. 1 - the highest, higher value - lower priority; 0 - do not use priorities.", 0) \
     M(SettingInt64, os_thread_priority, 0, "If non zero - set corresponding 'nice' value for query processing threads. Can be used to adjust query priority for OS scheduler.", 0) \
     \
-    M(SettingBool, log_queries, 0, "Log requests and write the log to the system table.", 0) \
+    M(SettingBool, log_queries, 1, "Log requests and write the log to the system table.", 0) \
     M(SettingLogQueriesType, log_queries_min_type, QueryLogElementType::QUERY_START, "query_log minimal type to log, possible values (from low to high): QUERY_START, QUERY_FINISH, EXCEPTION_BEFORE_START, EXCEPTION_WHILE_PROCESSING.", 0) \
     M(SettingUInt64, log_queries_cut_to_length, 100000, "If query length is greater than specified threshold (in bytes), then cut query when writing to query log. Also limit length of printed query in ordinary text log.", 0) \
     \

--- a/tests/integration/test_system_queries/test.py
+++ b/tests/integration/test_system_queries/test.py
@@ -97,6 +97,7 @@ def test_SYSTEM_FLUSH_LOGS(started_cluster):
     instance = cluster.instances['ch1']
     instance.query('''
         SET log_queries = 0;
+        SYSTEM FLUSH LOGS;
         TRUNCATE TABLE system.query_log;
     ''')
     for i in range(4):
@@ -104,13 +105,13 @@ def test_SYSTEM_FLUSH_LOGS(started_cluster):
         # by expiration of flush_interval_millisecond and test probable race condition.
         time.sleep(0.5)
         result = instance.query('''
-            SET log_queries = 1;
             SELECT 1 FORMAT Null;
             SET log_queries = 0;
             SYSTEM FLUSH LOGS;
             SELECT count() FROM system.query_log;''')
         instance.query('''
             SET log_queries = 0;
+            SYSTEM FLUSH LOGS;
             TRUNCATE TABLE system.query_log;
         ''')
         assert TSV(result) == TSV('4')

--- a/tests/integration/test_system_queries/test.py
+++ b/tests/integration/test_system_queries/test.py
@@ -95,6 +95,10 @@ def test_RELOAD_CONFIG_AND_MACROS(started_cluster):
 
 def test_SYSTEM_FLUSH_LOGS(started_cluster):
     instance = cluster.instances['ch1']
+    instance.query('''
+        SET log_queries = 0;
+        TRUNCATE TABLE system.query_log;
+    ''')
     for i in range(4):
         # Sleep to execute flushing from background thread at first query
         # by expiration of flush_interval_millisecond and test probable race condition.
@@ -105,7 +109,10 @@ def test_SYSTEM_FLUSH_LOGS(started_cluster):
             SET log_queries = 0;
             SYSTEM FLUSH LOGS;
             SELECT count() FROM system.query_log;''')
-        instance.query('TRUNCATE TABLE system.query_log')
+        instance.query('''
+            SET log_queries = 0;
+            TRUNCATE TABLE system.query_log;
+        ''')
         assert TSV(result) == TSV('4')
 
 


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

The query log is now enabled by default.