### PR TITLE
Fix primary key check

### DIFF
--- a/src/Storages/IStorage.cpp
+++ b/src/Storages/IStorage.cpp
@@ -444,9 +444,14 @@ void IStorage::setPartitionKey(const StorageMetadataKeyField & partition_key_)
     partition_key = partition_key_;
 }
 
+bool IStorage::isPartitionKeyDefined() const
+{
+    return partition_key.definition_ast != nullptr;
+}
+
 bool IStorage::hasPartitionKey() const
 {
-    return partition_key.expression != nullptr;
+    return !partition_key.column_names.empty();
 }
 
 Names IStorage::getColumnsRequiredForPartitionKey() const
@@ -466,9 +471,14 @@ void IStorage::setSortingKey(const StorageMetadataKeyField & sorting_key_)
     sorting_key = sorting_key_;
 }
 
+bool IStorage::isSortingKeyDefined() const
+{
+    return sorting_key.definition_ast != nullptr;
+}
+
 bool IStorage::hasSortingKey() const
 {
-    return sorting_key.expression != nullptr;
+    return !sorting_key.column_names.empty();
 }
 
 Names IStorage::getColumnsRequiredForSortingKey() const
@@ -502,7 +512,7 @@ bool IStorage::isPrimaryKeyDefined() const
 
 bool IStorage::hasPrimaryKey() const
 {
-    return primary_key.expression != nullptr;
+    return !primary_key.column_names.empty();
 }
 
 Names IStorage::getColumnsRequiredForPrimaryKey() const
@@ -529,9 +539,15 @@ void IStorage::setSamplingKey(const StorageMetadataKeyField & sampling_key_)
     sampling_key = sampling_key_;
 }
 
+
+bool IStorage::isSamplingKeyDefined() const
+{
+    return sampling_key.definition_ast != nullptr;
+}
+
 bool IStorage::hasSamplingKey() const
 {
-    return sampling_key.expression != nullptr;
+    return !sampling_key.column_names.empty();
 }
 
 Names IStorage::getColumnsRequiredForSampling() const

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -453,6 +453,8 @@ public:
     void setPartitionKey(const StorageMetadataKeyField & partition_key_);
     /// Returns ASTExpressionList of partition key expression for storage or nullptr if there is none.
     ASTPtr getPartitionKeyAST() const { return partition_key.definition_ast; }
+    /// Storage has user-defined (in CREATE query) partition key.
+    bool isPartitionKeyDefined() const;
     /// Storage has partition key.
     bool hasPartitionKey() const;
     /// Returns column names that need to be read to calculate partition key.
@@ -466,7 +468,9 @@ public:
     void setSortingKey(const StorageMetadataKeyField & sorting_key_);
     /// Returns ASTExpressionList of sorting key expression for storage or nullptr if there is none.
     ASTPtr getSortingKeyAST() const { return sorting_key.definition_ast; }
-    /// Storage has sorting key.
+    /// Storage has user-defined (in CREATE query) sorting key.
+    bool isSortingKeyDefined() const;
+    /// Storage has sorting key. It means, that it contains at least one column.
     bool hasSortingKey() const;
     /// Returns column names that need to be read to calculate sorting key.
     Names getColumnsRequiredForSortingKey() const;
@@ -483,7 +487,8 @@ public:
     ASTPtr getPrimaryKeyAST() const { return primary_key.definition_ast; }
     /// Storage has user-defined (in CREATE query) sorting key.
     bool isPrimaryKeyDefined() const;
-    /// Storage has primary key (maybe part of some other key).
+    /// Storage has primary key (maybe part of some other key). It means, that
+    /// it contains at least one column.
     bool hasPrimaryKey() const;
     /// Returns column names that need to be read to calculate primary key.
     Names getColumnsRequiredForPrimaryKey() const;
@@ -498,6 +503,8 @@ public:
     void setSamplingKey(const StorageMetadataKeyField & sampling_key_);
     /// Returns sampling expression AST for storage or nullptr if there is none.
     ASTPtr getSamplingKeyAST() const { return sampling_key.definition_ast; }
+    /// Storage has user-defined (in CREATE query) sampling key.
+    bool isSamplingKeyDefined() const;
     /// Storage has sampling key.
     bool hasSamplingKey() const;
     /// Returns column names that need to be read to calculate sampling key.

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -841,7 +841,7 @@ void IMergeTreeDataPart::checkConsistencyBase() const
 
     if (!checksums.empty())
     {
-        if (storage.isPrimaryKeyDefined() && !checksums.files.count("primary.idx"))
+        if (storage.hasPrimaryKey() && !checksums.files.count("primary.idx"))
             throw Exception("No checksum for primary.idx", ErrorCodes::NO_FILE_IN_DATA_PART);
 
         if (storage.format_version >= MERGE_TREE_DATA_MIN_FORMAT_VERSION_WITH_CUSTOM_PARTITIONING)
@@ -875,7 +875,7 @@ void IMergeTreeDataPart::checkConsistencyBase() const
         };
 
         /// Check that the primary key index is not empty.
-        if (storage.isPrimaryKeyDefined())
+        if (storage.hasPrimaryKey())
             check_file_not_empty(volume->getDisk(), path + "primary.idx");
 
         if (storage.format_version >= MERGE_TREE_DATA_MIN_FORMAT_VERSION_WITH_CUSTOM_PARTITIONING)

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -841,7 +841,7 @@ void IMergeTreeDataPart::checkConsistencyBase() const
 
     if (!checksums.empty())
     {
-        if (storage.hasPrimaryKey() && !checksums.files.count("primary.idx"))
+        if (storage.isPrimaryKeyDefined() && !checksums.files.count("primary.idx"))
             throw Exception("No checksum for primary.idx", ErrorCodes::NO_FILE_IN_DATA_PART);
 
         if (storage.format_version >= MERGE_TREE_DATA_MIN_FORMAT_VERSION_WITH_CUSTOM_PARTITIONING)
@@ -875,7 +875,7 @@ void IMergeTreeDataPart::checkConsistencyBase() const
         };
 
         /// Check that the primary key index is not empty.
-        if (storage.hasPrimaryKey())
+        if (storage.isPrimaryKeyDefined())
             check_file_not_empty(volume->getDisk(), path + "primary.idx");
 
         if (storage.format_version >= MERGE_TREE_DATA_MIN_FORMAT_VERSION_WITH_CUSTOM_PARTITIONING)

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -250,10 +250,10 @@ StorageInMemoryMetadata MergeTreeData::getInMemoryMetadata() const
 {
     StorageInMemoryMetadata metadata(getColumns(), getIndices(), getConstraints());
 
-    if (hasPartitionKey())
+    if (isPartitionKeyDefined())
         metadata.partition_by_ast = getPartitionKeyAST()->clone();
 
-    if (hasSortingKey())
+    if (isSortingKeyDefined())
         metadata.order_by_ast = getSortingKeyAST()->clone();
 
     if (isPrimaryKeyDefined())
@@ -262,7 +262,7 @@ StorageInMemoryMetadata MergeTreeData::getInMemoryMetadata() const
     if (ttl_table_ast)
         metadata.ttl_for_table_ast = ttl_table_ast->clone();
 
-    if (hasSamplingKey())
+    if (isSamplingKeyDefined())
         metadata.sample_by_ast = getSamplingKeyAST()->clone();
 
     if (settings_ast)

--- a/tests/integration/test_version_update_after_mutation/test.py
+++ b/tests/integration/test_version_update_after_mutation/test.py
@@ -6,9 +6,9 @@ from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 
-node1 = cluster.add_instance('node1', with_zookeeper=True, image='yandex/clickhouse-server:20.1.6.3', with_installed_binary=True, stay_alive=True)
-node2 = cluster.add_instance('node2', with_zookeeper=True, image='yandex/clickhouse-server:20.1.6.3', with_installed_binary=True, stay_alive=True)
-node3 = cluster.add_instance('node3', with_zookeeper=True, image='yandex/clickhouse-server:20.1.6.3', with_installed_binary=True, stay_alive=True)
+node1 = cluster.add_instance('node1', with_zookeeper=True, image='yandex/clickhouse-server:20.1.10.70', with_installed_binary=True, stay_alive=True)
+node2 = cluster.add_instance('node2', with_zookeeper=True, image='yandex/clickhouse-server:20.1.10.70', with_installed_binary=True, stay_alive=True)
+node3 = cluster.add_instance('node3', with_zookeeper=True, image='yandex/clickhouse-server:20.1.10.70', with_installed_binary=True, stay_alive=True)
 
 @pytest.fixture(scope="module")
 def start_cluster():


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now `primary.idx` will be checked if it's defined in `CREATE` query.