### PR TITLE
Add missing reference to stream-loader in Third Party Integration english docs

### DIFF
--- a/docs/en/interfaces/third-party/integrations.md
+++ b/docs/en/interfaces/third-party/integrations.md
@@ -25,6 +25,7 @@ toc_title: Integrations
 -   Message queues
     -   [Kafka](https://kafka.apache.org)
         -   [clickhouse\_sinker](https://github.com/housepower/clickhouse_sinker) (uses [Go client](https://github.com/ClickHouse/clickhouse-go/))
+        -   [stream-loader-clickhouse](https://github.com/adform/stream-loader)
 -   Stream processing
     -   [Flink](https://flink.apache.org)
         -   [flink-clickhouse-sink](https://github.com/ivi-ru/flink-clickhouse-sink)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category
- Documentation

Detailed description:

Add missing link to the [stream-loader](https://github.com/adform/stream-loader) project under `Interfaces / Third Party / Integrations / Kafka` in the english documentation, as it was forgotten in the original PR: https://github.com/ClickHouse/ClickHouse/pull/11040/files :man_facepalming: 