### PR TITLE
Make possible adding nested storages to MultipleAccessStorage in run-time

### DIFF
--- a/src/Access/MultipleAccessStorage.cpp
+++ b/src/Access/MultipleAccessStorage.cpp
@@ -143,6 +143,14 @@ const IAccessStorage & MultipleAccessStorage::getStorage(const UUID & id) const
     return const_cast<MultipleAccessStorage *>(this)->getStorage(id);
 }
 
+void MultipleAccessStorage::addStorage(std::unique_ptr<Storage> nested_storage)
+{
+    /// Note that IStorage::storage_name is not changed. It is ok as this method
+    /// is considered as a temporary solution allowing third-party Arcadia applications
+    /// using CH as a library to register their own access storages. Do not remove
+    /// this method without providing any alternative :)
+    nested_storages.emplace_back(std::move(nested_storage));
+}
 
 AccessEntityPtr MultipleAccessStorage::readImpl(const UUID & id) const
 {

--- a/src/Access/MultipleAccessStorage.h
+++ b/src/Access/MultipleAccessStorage.h
@@ -25,6 +25,8 @@ public:
     const Storage & getStorage(const UUID & id) const;
     Storage & getStorage(const UUID & id);
 
+    void addStorage(std::unique_ptr<Storage> nested_storage);
+
     Storage & getStorageByIndex(size_t i) { return *(nested_storages[i]); }
     const Storage & getStorageByIndex(size_t i) const { return *(nested_storages[i]); }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Make it possible to add storages to MultipleAccessStorage in run-time. See Yandex CLICKHOUSE-4878 issue for details.