### PR TITLE
Fix cctz linking with dirty hack

### DIFF
--- a/contrib/cctz-cmake/CMakeLists.txt
+++ b/contrib/cctz-cmake/CMakeLists.txt
@@ -623,7 +623,7 @@ if (USE_INTERNAL_CCTZ)
         # libraries in linker command. To avoid this we hardcode whole-archive
         # library into single string.
         add_dependencies(cctz tzdata)
-        target_link_libraries(cctz PRIVATE "-Wl,--whole-archive contrib/cctz-cmake/libtzdata.a -Wl,--no-whole-archive")
+        target_link_libraries(cctz PUBLIC "-Wl,--whole-archive contrib/cctz-cmake/libtzdata.a -Wl,--no-whole-archive")
     endif ()
 
 else ()

--- a/contrib/cctz-cmake/CMakeLists.txt
+++ b/contrib/cctz-cmake/CMakeLists.txt
@@ -623,7 +623,7 @@ if (USE_INTERNAL_CCTZ)
         # libraries in linker command. To avoid this we hardcode whole-archive
         # library into single string.
         add_dependencies(cctz tzdata)
-        target_link_libraries(cctz INTERFACE "-Wl,--whole-archive contrib/cctz-cmake/libtzdata.a -Wl,--no-whole-archive")
+        target_link_libraries(cctz INTERFACE "-Wl,--whole-archive $<TARGET_FILE:tzdata> -Wl,--no-whole-archive")
     endif ()
 
 else ()

--- a/contrib/cctz-cmake/CMakeLists.txt
+++ b/contrib/cctz-cmake/CMakeLists.txt
@@ -622,7 +622,8 @@ if (USE_INTERNAL_CCTZ)
         # CMake can shuffle each of target_link_libraries arguments with other
         # libraries in linker command. To avoid this we hardcode whole-archive
         # library into single string.
-        target_link_libraries(cctz PUBLIC "-Wl,--whole-archive contrib/cctz-cmake/libtzdata.a -Wl,--no-whole-archive")
+        add_dependencies(cctz tzdata)
+        target_link_libraries(cctz PRIVATE "-Wl,--whole-archive contrib/cctz-cmake/libtzdata.a -Wl,--no-whole-archive")
     endif ()
 
 else ()

--- a/contrib/cctz-cmake/CMakeLists.txt
+++ b/contrib/cctz-cmake/CMakeLists.txt
@@ -618,7 +618,11 @@ if (USE_INTERNAL_CCTZ)
 
         add_library(tzdata STATIC ${TZ_OBJS})
         set_target_properties(tzdata PROPERTIES LINKER_LANGUAGE C)
-        target_link_libraries(cctz -Wl,--whole-archive tzdata -Wl,--no-whole-archive) # whole-archive prevents symbols from being discarded
+        # whole-archive prevents symbols from being discarded for unknown reason
+        # CMake can shuffle each of target_link_libraries arguments with other
+        # libraries in linker command. To avoid this we hardcode whole-archive
+        # library into single string.
+        target_link_libraries(cctz PUBLIC "-Wl,--whole-archive contrib/cctz-cmake/libtzdata.a -Wl,--no-whole-archive")
     endif ()
 
 else ()

--- a/contrib/cctz-cmake/CMakeLists.txt
+++ b/contrib/cctz-cmake/CMakeLists.txt
@@ -623,7 +623,7 @@ if (USE_INTERNAL_CCTZ)
         # libraries in linker command. To avoid this we hardcode whole-archive
         # library into single string.
         add_dependencies(cctz tzdata)
-        target_link_libraries(cctz PUBLIC "-Wl,--whole-archive contrib/cctz-cmake/libtzdata.a -Wl,--no-whole-archive")
+        target_link_libraries(cctz INTERFACE "-Wl,--whole-archive contrib/cctz-cmake/libtzdata.a -Wl,--no-whole-archive")
     endif ()
 
 else ()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now parts of linker command for `cctz` library will not be shuffled with other libraries.
