### PR TITLE
Keep the value of DistributedFilesToInsert metric on exceptions

### DIFF
--- a/src/Common/CurrentMetrics.h
+++ b/src/Common/CurrentMetrics.h
@@ -94,6 +94,12 @@ namespace CurrentMetrics
             amount = new_amount;
         }
 
+        void sub(Value value = 1)
+        {
+            what->fetch_sub(value, std::memory_order_relaxed);
+            amount -= value;
+        }
+
         /// Subtract value before destructor.
         void destroy()
         {

--- a/src/Storages/Distributed/DirectoryMonitor.h
+++ b/src/Storages/Distributed/DirectoryMonitor.h
@@ -9,6 +9,8 @@
 #include <IO/ReadBufferFromFile.h>
 
 
+namespace CurrentMetrics { class Increment; }
+
 namespace DB
 {
 
@@ -37,9 +39,9 @@ public:
     bool scheduleAfter(size_t ms);
 private:
     void run();
-    bool processFiles();
-    void processFile(const std::string & file_path);
-    void processFilesWithBatching(const std::map<UInt64, std::string> & files);
+    bool processFiles(CurrentMetrics::Increment & metric_pending_files);
+    void processFile(const std::string & file_path, CurrentMetrics::Increment & metric_pending_files);
+    void processFilesWithBatching(const std::map<UInt64, std::string> & files, CurrentMetrics::Increment & metric_pending_files);
 
     static bool isFileBrokenErrorCode(int code);
     void markAsBroken(const std::string & file_path) const;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Keep the value of `DistributedFilesToInsert` metric on exceptions. In previous versions, the value was set when we are going to send some files, but it is zero, if there was an exception and some files are still pending. Now it corresponds to the number of pending files in filesystem.