### PR TITLE
Fix package name in docker file: tzata -> tzdata

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
             locales \
             ca-certificates \
             wget \
-            tzata \
+            tzdata \
     && rm -rf \
         /var/lib/apt/lists/* \
         /var/cache/debconf \


### PR DESCRIPTION
Changelog category:
* Not for changelog


Dockerfile package name fix. There is no package "tzata"