### PR TITLE
Update librdkafka to version 1.4.2

### DIFF
--- a/contrib/librdkafka-cmake/CMakeLists.txt
+++ b/contrib/librdkafka-cmake/CMakeLists.txt
@@ -3,20 +3,30 @@ set(RDKAFKA_SOURCE_DIR ${ClickHouse_SOURCE_DIR}/contrib/librdkafka/src)
 set(SRCS
   ${RDKAFKA_SOURCE_DIR}/crc32c.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_zstd.c
+#  ${RDKAFKA_SOURCE_DIR}/lz4.c
+#  ${RDKAFKA_SOURCE_DIR}/lz4frame.c
+#  ${RDKAFKA_SOURCE_DIR}/lz4hc.c
+#  ${RDKAFKA_SOURCE_DIR}/rdxxhash.c
+#  ${RDKAFKA_SOURCE_DIR}/regexp.c
   ${RDKAFKA_SOURCE_DIR}/rdaddr.c
   ${RDKAFKA_SOURCE_DIR}/rdavl.c
   ${RDKAFKA_SOURCE_DIR}/rdbuf.c
   ${RDKAFKA_SOURCE_DIR}/rdcrc32.c
   ${RDKAFKA_SOURCE_DIR}/rddl.c
+  ${RDKAFKA_SOURCE_DIR}/rdfnv1a.c
   ${RDKAFKA_SOURCE_DIR}/rdhdrhistogram.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka.c
+  ${RDKAFKA_SOURCE_DIR}/rdkafka_admin.c # looks optional
   ${RDKAFKA_SOURCE_DIR}/rdkafka_assignor.c
+  ${RDKAFKA_SOURCE_DIR}/rdkafka_aux.c # looks optional
   ${RDKAFKA_SOURCE_DIR}/rdkafka_background.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_broker.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_buf.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_cert.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_cgrp.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_conf.c
+  ${RDKAFKA_SOURCE_DIR}/rdkafka_coord.c
+  ${RDKAFKA_SOURCE_DIR}/rdkafka_error.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_event.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_feature.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_idempotence.c
@@ -24,6 +34,7 @@ set(SRCS
   ${RDKAFKA_SOURCE_DIR}/rdkafka_metadata.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_metadata_cache.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_mock.c
+  ${RDKAFKA_SOURCE_DIR}/rdkafka_mock_cgrp.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_mock_handlers.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_msg.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_msgset_reader.c
@@ -38,9 +49,11 @@ set(SRCS
   ${RDKAFKA_SOURCE_DIR}/rdkafka_request.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_roundrobin_assignor.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_sasl.c
+#  ${RDKAFKA_SOURCE_DIR}/rdkafka_sasl_cyrus.c # needed to support Kerberos, requires cyrus-sasl
   ${RDKAFKA_SOURCE_DIR}/rdkafka_sasl_oauthbearer.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_sasl_plain.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_sasl_scram.c
+#  ${RDKAFKA_SOURCE_DIR}/rdkafka_sasl_win32.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_ssl.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_subscription.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_timer.c
@@ -48,6 +61,7 @@ set(SRCS
   ${RDKAFKA_SOURCE_DIR}/rdkafka_transport.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_interceptor.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_header.c
+  ${RDKAFKA_SOURCE_DIR}/rdkafka_txnmgr.c
   ${RDKAFKA_SOURCE_DIR}/rdlist.c
   ${RDKAFKA_SOURCE_DIR}/rdlog.c
   ${RDKAFKA_SOURCE_DIR}/rdmurmur2.c


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Update librdkafka to version [1.4.2](https://github.com/edenhill/librdkafka/releases/tag/v1.4.2)

Detailed description / Documentation draft:
I think it closes https://github.com/ClickHouse/ClickHouse/issues/5637 (See also: https://github.com/edenhill/librdkafka/pull/2183#issuecomment-582333561 )
