### PR TITLE
Add _timestamp_ms virtual columns to Kafka engine

### DIFF
--- a/src/Storages/Kafka/KafkaBlockInputStream.cpp
+++ b/src/Storages/Kafka/KafkaBlockInputStream.cpp
@@ -19,8 +19,8 @@ KafkaBlockInputStream::KafkaBlockInputStream(
     , column_names(columns)
     , max_block_size(max_block_size_)
     , commit_in_suffix(commit_in_suffix_)
-    , non_virtual_header(storage.getSampleBlockNonMaterialized()) /// FIXME: add materialized columns support
-    , virtual_header(storage.getSampleBlockForColumns({"_topic", "_key", "_offset", "_partition", "_timestamp"}))
+    , non_virtual_header(storage.getSampleBlockNonMaterialized())
+    , virtual_header(storage.getSampleBlockForColumns({"_topic", "_key", "_offset", "_partition", "_timestamp","_timestamp_ms"}))
 
 {
     context.setSetting("input_format_skip_unknown_fields", 1u); // Always skip unknown fields regardless of the context (JSON or TSKV)
@@ -141,8 +141,7 @@ Block KafkaBlockInputStream::readImpl()
         auto offset        = buffer->currentOffset();
         auto partition     = buffer->currentPartition();
         auto timestamp_raw = buffer->currentTimestamp();
-        auto timestamp     = timestamp_raw ? std::chrono::duration_cast<std::chrono::seconds>(timestamp_raw->get_timestamp()).count()
-                                                : 0;
+
         for (size_t i = 0; i < new_rows; ++i)
         {
             virtual_columns[0]->insert(topic);
@@ -151,11 +150,14 @@ Block KafkaBlockInputStream::readImpl()
             virtual_columns[3]->insert(partition);
             if (timestamp_raw)
             {
-                virtual_columns[4]->insert(timestamp);
+                auto ts = timestamp_raw->get_timestamp();
+                virtual_columns[4]->insert(std::chrono::duration_cast<std::chrono::seconds>(ts).count());
+                virtual_columns[5]->insert(DecimalField<Decimal64>(std::chrono::duration_cast<std::chrono::milliseconds>(ts).count(),3));
             }
             else
             {
                 virtual_columns[4]->insertDefault();
+                virtual_columns[5]->insertDefault();
             }
         }
 

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -6,6 +6,7 @@
 #include <DataStreams/UnionBlockInputStream.h>
 #include <DataStreams/copyData.h>
 #include <DataTypes/DataTypeDateTime.h>
+#include <DataTypes/DataTypeDateTime64.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeString.h>
@@ -34,6 +35,7 @@
 #include <Common/quoteString.h>
 #include <Processors/Sources/SourceFromInputStream.h>
 #include <librdkafka/rdkafka.h>
+
 
 
 namespace DB
@@ -724,7 +726,8 @@ NamesAndTypesList StorageKafka::getVirtuals() const
         {"_key", std::make_shared<DataTypeString>()},
         {"_offset", std::make_shared<DataTypeUInt64>()},
         {"_partition", std::make_shared<DataTypeUInt64>()},
-        {"_timestamp", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeDateTime>())}
+        {"_timestamp", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeDateTime>())},
+        {"_timestamp_ms", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeDateTime64>(3))}
     };
 }
 

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -37,7 +37,6 @@
 #include <librdkafka/rdkafka.h>
 
 
-
 namespace DB
 {
 

--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -840,28 +840,28 @@ def test_kafka_virtual_columns2(kafka_cluster):
                      kafka_format = 'JSONEachRow';
 
         CREATE MATERIALIZED VIEW test.view Engine=Log AS
-        SELECT value, _key, _topic, _partition, _offset, toUnixTimestamp(_timestamp) FROM test.kafka;
+        SELECT value, _key, _topic, _partition, _offset, toUnixTimestamp(_timestamp), toUnixTimestamp64Milli(_timestamp_ms) FROM test.kafka;
         ''')
 
     producer = KafkaProducer(bootstrap_servers="localhost:9092")
 
-    producer.send(topic='virt2_0', value=json.dumps({'value': 1}), partition=0, key='k1', timestamp_ms=1577836801000)
-    producer.send(topic='virt2_0', value=json.dumps({'value': 2}), partition=0, key='k2', timestamp_ms=1577836802000)
+    producer.send(topic='virt2_0', value=json.dumps({'value': 1}), partition=0, key='k1', timestamp_ms=1577836801001)
+    producer.send(topic='virt2_0', value=json.dumps({'value': 2}), partition=0, key='k2', timestamp_ms=1577836802002)
     producer.flush()
     time.sleep(1)
 
-    producer.send(topic='virt2_0', value=json.dumps({'value': 3}), partition=1, key='k3', timestamp_ms=1577836803000)
-    producer.send(topic='virt2_0', value=json.dumps({'value': 4}), partition=1, key='k4', timestamp_ms=1577836804000)
+    producer.send(topic='virt2_0', value=json.dumps({'value': 3}), partition=1, key='k3', timestamp_ms=1577836803003)
+    producer.send(topic='virt2_0', value=json.dumps({'value': 4}), partition=1, key='k4', timestamp_ms=1577836804004)
     producer.flush()
     time.sleep(1)
 
-    producer.send(topic='virt2_1', value=json.dumps({'value': 5}), partition=0, key='k5', timestamp_ms=1577836805000)
-    producer.send(topic='virt2_1', value=json.dumps({'value': 6}), partition=0, key='k6', timestamp_ms=1577836806000)
+    producer.send(topic='virt2_1', value=json.dumps({'value': 5}), partition=0, key='k5', timestamp_ms=1577836805005)
+    producer.send(topic='virt2_1', value=json.dumps({'value': 6}), partition=0, key='k6', timestamp_ms=1577836806006)
     producer.flush()
     time.sleep(1)
 
-    producer.send(topic='virt2_1', value=json.dumps({'value': 7}), partition=1, key='k7', timestamp_ms=1577836807000)
-    producer.send(topic='virt2_1', value=json.dumps({'value': 8}), partition=1, key='k8', timestamp_ms=1577836808000)
+    producer.send(topic='virt2_1', value=json.dumps({'value': 7}), partition=1, key='k7', timestamp_ms=1577836807007)
+    producer.send(topic='virt2_1', value=json.dumps({'value': 8}), partition=1, key='k8', timestamp_ms=1577836808008)
     producer.flush()
 
     time.sleep(10)
@@ -869,14 +869,14 @@ def test_kafka_virtual_columns2(kafka_cluster):
     result = instance.query("SELECT * FROM test.view ORDER BY value", ignore_error=True)
 
     expected = '''\
-1	k1	virt2_0	0	0	1577836801
-2	k2	virt2_0	0	1	1577836802
-3	k3	virt2_0	1	0	1577836803
-4	k4	virt2_0	1	1	1577836804
-5	k5	virt2_1	0	0	1577836805
-6	k6	virt2_1	0	1	1577836806
-7	k7	virt2_1	1	0	1577836807
-8	k8	virt2_1	1	1	1577836808
+1	k1	virt2_0	0	0	1577836801	1577836801001
+2	k2	virt2_0	0	1	1577836802	1577836802002
+3	k3	virt2_0	1	0	1577836803	1577836803003
+4	k4	virt2_0	1	1	1577836804	1577836804004
+5	k5	virt2_1	0	0	1577836805	1577836805005
+6	k6	virt2_1	0	1	1577836806	1577836806006
+7	k7	virt2_1	1	0	1577836807	1577836807007
+8	k8	virt2_1	1	1	1577836808	1577836808008
 '''
 
     assert TSV(result) == TSV(expected)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add `_timestamp_ms` virtual column for Kafka engine (type is `Nullable(DateTime64(3))`)

Detailed description / Documentation draft:
Resolves #10565