### PR TITLE
Add prefix & facility to librdkafka logs

### DIFF
--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -324,10 +324,10 @@ void StorageKafka::updateConfiguration(cppkafka::Configuration & conf)
     }
 
     // No need to add any prefix, messages can be distinguished
-    conf.set_log_callback([this](cppkafka::KafkaHandleBase &, int level, const std::string & /* facility */, const std::string & message)
+    conf.set_log_callback([this](cppkafka::KafkaHandleBase &, int level, const std::string & facility, const std::string & message)
     {
         auto [poco_level, client_logs_level] = parseSyslogLevel(level);
-        LOG_IMPL(log, client_logs_level, poco_level, message);
+        LOG_IMPL(log, client_logs_level, poco_level, "[rdk:{}] {}", facility, message);
     });
 
     // Configure interceptor to change thread name


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add common prefix & facility to librdkafka related logs

Detailed description / Documentation draft:
After #10983 it's hard to distinguish logs from librdkafka (which are quite noisy) from ClickHouse logs. Adding some common prefix and facility should help when greping.

Before
```
2020.05.28 20:47:43.327793 [ 34 ] {} <Debug> StorageKafka (kafka): Started streaming to 1 attached views
2020.05.28 20:47:43.336292 [ 67 ] {} <Debug> StorageKafka (kafka): [thrd:main]: Group "virt2" received op GET_SUBSCRIPTION (v0) in state init (join state init, v1 vs 0)
2020.05.28 20:47:43.336636 [ 34 ] {} <Trace> StorageKafka (kafka): Already subscribed to topics: []
2020.05.28 20:47:43.336582 [ 67 ] {} <Debug> StorageKafka (kafka): [thrd:main]: Group "virt2" changed state init -> query-coord (v1, join-state init)
2020.05.28 20:47:43.336730 [ 34 ] {} <Trace> StorageKafka (kafka): Already assigned to: [  ]
2020.05.28 20:47:43.336849 [ 67 ] {} <Debug> StorageKafka (kafka): [thrd:main]: Group "virt2": no broker available for coordinator query: intervaled in state query-coord
2020.05.28 20:47:43.336936 [ 67 ] {} <Debug> StorageKafka (kafka): [thrd:main]: Group "virt2" received op GET_SUBSCRIPTION (v0) in state query-coord (join state init, v1 vs 0)
2020.05.28 20:47:43.337133 [ 67 ] {} <Debug> StorageKafka (kafka): [thrd:main]: Group "virt2" received op SUBSCRIBE (v0) in state query-coord (join state init, v1 vs 0)
2020.05.28 20:47:43.337210 [ 67 ] {} <Debug> StorageKafka (kafka): [thrd:main]: Group "virt2": subscribe to new subscription of 2 topics (join state init)
2020.05.28 20:47:43.337383 [ 67 ] {} <Debug> StorageKafka (kafka): [thrd:main]: Group "virt2": unsubscribe from current unset subscription of 0 topics (leave group=no, join state init, v1)
2020.05.28 20:47:43.337547 [ 67 ] {} <Debug> StorageKafka (kafka): [thrd:main]: Group "virt2": resetting group leader info: unsubscribe
2020.05.28 20:47:43.337633 [ 67 ] {} <Debug> StorageKafka (kafka): [thrd:main]: Group "virt2" is rebalancing in state query-coord (join-state init) without assignment: unsubscribe
2020.05.28 20:47:43.337711 [ 67 ] {} <Debug> StorageKafka (kafka): [thrd:main]: Group "virt2" changed join state init -> wait-unassign (v1, state query-coord)
2020.05.28 20:47:43.337778 [ 67 ] {} <Debug> StorageKafka (kafka): [thrd:main]: Group "virt2": unassign done in state query-coord (join state wait-unassign): without new assignment: unassign (no previous assignment)
2020.05.28 20:47:43.337925 [ 67 ] {} <Debug> StorageKafka (kafka): [thrd:main]: Group "virt2" changed join state wait-unassign -> init (v1, state query-coord)
2020.05.28 20:47:43.338153 [ 67 ] {} <Debug> StorageKafka (kafka): [thrd:main]: Group "virt2" received op GET_SUBSCRIPTION (v0) in state query-coord (join state init, v1 vs 0)
2020.05.28 20:47:43.338781 [ 69 ] {} <Debug> StorageKafka (kafka): [thrd:kafka1:19092/bootstrap]: kafka1:19092/bootstrap: Connected (#1)
2020.05.28 20:47:43.339273 [ 69 ] {} <Debug> StorageKafka (kafka): [thrd:kafka1:19092/bootstrap]: kafka1:19092/bootstrap: Updated enabled protocol features +ApiVersion to ApiVersion
2020.05.28 20:47:43.339887 [ 69 ] {} <Debug> StorageKafka (kafka): [thrd:kafka1:19092/bootstrap]: kafka1:19092/bootstrap: Sent ApiVersionRequest (v0, 37 bytes @ 0, CorrId 1)
2020.05.28 20:47:43.340515 [ 69 ] {} <Debug> StorageKafka (kafka): [thrd:kafka1:19092/bootstrap]: kafka1:19092/bootstrap: Received ApiVersionResponse (v0, 270 bytes, CorrId 1, rtt 0.73ms)
2020.05.28 20:47:43.340757 [ 69 ] {} <Debug> StorageKafka (kafka): [thrd:kafka1:19092/bootstrap]: kafka1:19092/bootstrap: Sent MetadataRequest (v2, 37 bytes @ 0, CorrId 2)
2020.05.28 20:47:43.341577 [ 69 ] {} <Debug> StorageKafka (kafka): [thrd:kafka1:19092/bootstrap]: kafka1:19092/bootstrap: Received MetadataResponse (v2, 54 bytes, CorrId 2, rtt 0.81ms)
```


After
```
2020.05.28 20:50:25.988281 [ 30 ] {} <Debug> StorageKafka (kafka): Started streaming to 1 attached views
2020.05.28 20:50:26.000586 [ 67 ] {} <Debug> StorageKafka (kafka): [rdk:CGRPOP] [thrd:main]: Group "virt2" received op GET_SUBSCRIPTION (v0) in state init (join state init, v1 vs 0)
2020.05.28 20:50:26.000841 [ 67 ] {} <Debug> StorageKafka (kafka): [rdk:CGRPSTATE] [thrd:main]: Group "virt2" changed state init -> query-coord (v1, join-state init)
2020.05.28 20:50:26.000895 [ 30 ] {} <Trace> StorageKafka (kafka): Already subscribed to topics: []
2020.05.28 20:50:26.000959 [ 67 ] {} <Debug> StorageKafka (kafka): [rdk:CGRPQUERY] [thrd:main]: Group "virt2": no broker available for coordinator query: intervaled in state query-coord
2020.05.28 20:50:26.000982 [ 30 ] {} <Trace> StorageKafka (kafka): Already assigned to: [  ]
2020.05.28 20:50:26.001093 [ 67 ] {} <Debug> StorageKafka (kafka): [rdk:CGRPOP] [thrd:main]: Group "virt2" received op GET_SUBSCRIPTION (v0) in state query-coord (join state init, v1 vs 0)
2020.05.28 20:50:26.001348 [ 67 ] {} <Debug> StorageKafka (kafka): [rdk:CGRPOP] [thrd:main]: Group "virt2" received op SUBSCRIBE (v0) in state query-coord (join state init, v1 vs 0)
2020.05.28 20:50:26.001467 [ 67 ] {} <Debug> StorageKafka (kafka): [rdk:SUBSCRIBE] [thrd:main]: Group "virt2": subscribe to new subscription of 2 topics (join state init)
2020.05.28 20:50:26.001608 [ 67 ] {} <Debug> StorageKafka (kafka): [rdk:UNSUBSCRIBE] [thrd:main]: Group "virt2": unsubscribe from current unset subscription of 0 topics (leave group=no, join state init, v1)
2020.05.28 20:50:26.001708 [ 67 ] {} <Debug> StorageKafka (kafka): [rdk:GRPLEADER] [thrd:main]: Group "virt2": resetting group leader info: unsubscribe
2020.05.28 20:50:26.001802 [ 67 ] {} <Debug> StorageKafka (kafka): [rdk:REBALANCE] [thrd:main]: Group "virt2" is rebalancing in state query-coord (join-state init) without assignment: unsubscribe
2020.05.28 20:50:26.001883 [ 67 ] {} <Debug> StorageKafka (kafka): [rdk:CGRPJOINSTATE] [thrd:main]: Group "virt2" changed join state init -> wait-unassign (v1, state query-coord)
2020.05.28 20:50:26.001959 [ 67 ] {} <Debug> StorageKafka (kafka): [rdk:UNASSIGN] [thrd:main]: Group "virt2": unassign done in state query-coord (join state wait-unassign): without new assignment: unassign (no previous assignment)
2020.05.28 20:50:26.002040 [ 67 ] {} <Debug> StorageKafka (kafka): [rdk:CGRPJOINSTATE] [thrd:main]: Group "virt2" changed join state wait-unassign -> init (v1, state query-coord)
2020.05.28 20:50:26.002270 [ 67 ] {} <Debug> StorageKafka (kafka): [rdk:CGRPOP] [thrd:main]: Group "virt2" received op GET_SUBSCRIPTION (v0) in state query-coord (join state init, v1 vs 0)
2020.05.28 20:50:26.003109 [ 69 ] {} <Debug> StorageKafka (kafka): [rdk:CONNECTED] [thrd:kafka1:19092/bootstrap]: kafka1:19092/bootstrap: Connected (#1)
2020.05.28 20:50:26.003586 [ 69 ] {} <Debug> StorageKafka (kafka): [rdk:FEATURE] [thrd:kafka1:19092/bootstrap]: kafka1:19092/bootstrap: Updated enabled protocol features +ApiVersion to ApiVersion
2020.05.28 20:50:26.004139 [ 69 ] {} <Debug> StorageKafka (kafka): [rdk:SEND] [thrd:kafka1:19092/bootstrap]: kafka1:19092/bootstrap: Sent ApiVersionRequest (v0, 37 bytes @ 0, CorrId 1)
2020.05.28 20:50:26.005246 [ 69 ] {} <Debug> StorageKafka (kafka): [rdk:RECV] [thrd:kafka1:19092/bootstrap]: kafka1:19092/bootstrap: Received ApiVersionResponse (v0, 270 bytes, CorrId 1, rtt 1.10ms)
2020.05.28 20:50:26.005597 [ 69 ] {} <Debug> StorageKafka (kafka): [rdk:SEND] [thrd:kafka1:19092/bootstrap]: kafka1:19092/bootstrap: Sent MetadataRequest (v2, 37 bytes @ 0, CorrId 2)
2020.05.28 20:50:26.006433 [ 69 ] {} <Debug> StorageKafka (kafka): [rdk:RECV] [thrd:kafka1:19092/bootstrap]: kafka1:19092/bootstrap: Received MetadataResponse (v2, 54 bytes, CorrId 2, rtt 0.82ms)
```