### PR TITLE
Fix wrong markup in documentation

### DIFF
--- a/website/css/docs.css
+++ b/website/css/docs.css
@@ -69,7 +69,6 @@ summary {
 #content code {
     color: #111;
     background: #eee;
-    padding: 2px;
 }
 
 


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix wrong markup in documentation.


Detailed description / Documentation draft:
![Screenshot_20200526_201832](https://user-images.githubusercontent.com/18581488/83184836-b5dfc800-a132-11ea-93e2-e7fd6e2d939b.png)
![Screenshot_20200526_202108](https://user-images.githubusercontent.com/18581488/83184838-b710f500-a132-11ea-8546-82135788acb5.png)

No idea why it was there. CC @blinkov 
This two pixel discrepancy contributed to the general impression of the ugliness of documentation.