### PR TITLE
Fixed improper logging of failures in destructors of certain metrics

### DIFF
--- a/src/Common/MemoryStatisticsOS.cpp
+++ b/src/Common/MemoryStatisticsOS.cpp
@@ -9,6 +9,7 @@
 #include <Common/Exception.h>
 #include <IO/ReadBufferFromMemory.h>
 #include <IO/ReadHelpers.h>
+#include <common/logger_useful.h>
 
 
 namespace DB
@@ -19,6 +20,7 @@ namespace ErrorCodes
     extern const int FILE_DOESNT_EXIST;
     extern const int CANNOT_OPEN_FILE;
     extern const int CANNOT_READ_FROM_FILE_DESCRIPTOR;
+    extern const int CANNOT_CLOSE_FILE;
 }
 
 static constexpr auto filename = "/proc/self/statm";
@@ -35,7 +37,18 @@ MemoryStatisticsOS::MemoryStatisticsOS()
 MemoryStatisticsOS::~MemoryStatisticsOS()
 {
     if (0 != ::close(fd))
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+    {
+        try
+        {
+            throwFromErrno(
+                    "File descriptor for \"" + std::string(filename) + "\" could not be closed. "
+                    "Something seems to have gone wrong. Inspect errno.", ErrorCodes::CANNOT_CLOSE_FILE);
+        }
+        catch (const ErrnoException &)
+        {
+            DB::tryLogCurrentException(__PRETTY_FUNCTION__);
+        }
+    }
 }
 
 MemoryStatisticsOS::Data MemoryStatisticsOS::get() const


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
