### PR TITLE
Repeat test on curl timeout

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -31,6 +31,7 @@ MESSAGES_TO_RETRY = [
     "DB::Exception: ZooKeeper session has been expired",
     "Coordination::Exception: Connection loss",
     "Operation timed out",
+    "ConnectionPoolWithFailover: Connection failed at try",
 ]
 
 

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -30,6 +30,7 @@ from contextlib import closing
 MESSAGES_TO_RETRY = [
     "DB::Exception: ZooKeeper session has been expired",
     "Coordination::Exception: Connection loss",
+    "Operation timed out",
 ]
 
 


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Repeat test in CI if `curl` invocation was timed out. It is possible due to system hangups for 10+ seconds that are typical in our CI infrastructure. This fixes #11267


Detailed description:
I'm lucky to find that this functionality is already supported in `clickhouse-test`. But looks like it was unused for a long time because the existing checks (look at the diff) like `ZooKeeper session has been expired` are not relevant after using TestKeeper. But they will remain for the case of testing with real ZooKeeper.