### PR TITLE
Fix potential incorrect usage of fmtlib

### DIFF
--- a/src/Common/tests/gtest_log.cpp
+++ b/src/Common/tests/gtest_log.cpp
@@ -1,0 +1,19 @@
+#include <string>
+#include <vector>
+#include <common/logger_useful.h>
+#include <gtest/gtest.h>
+
+#include <Poco/Logger.h>
+#include <Poco/AutoPtr.h>
+#include <Poco/NullChannel.h>
+
+
+TEST(Logger, Log)
+{
+    Poco::Logger::root().setLevel("none");
+    Poco::Logger::root().setChannel(Poco::AutoPtr<Poco::NullChannel>(new Poco::NullChannel()));
+    Logger * log = &Logger::get("Log");
+
+    /// This test checks that we don't pass this string to fmtlib, because it is the only argument.
+    EXPECT_NO_THROW(LOG_INFO(log, "Hello {} World"));
+}


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Addition to #11137 