### PR TITLE
Attempt to fix flacky test 01108_restart_replicas_rename_deadlock.sh

### DIFF
--- a/tests/queries/0_stateless/01108_restart_replicas_rename_deadlock.reference
+++ b/tests/queries/0_stateless/01108_restart_replicas_rename_deadlock.reference
@@ -1,1 +1,5 @@
+replica_01108_1_tmp
+replica_01108_2_tmp
+replica_01108_3_tmp
+replica_01108_4_tmp
 1180	40

--- a/tests/queries/0_stateless/01108_restart_replicas_rename_deadlock.reference
+++ b/tests/queries/0_stateless/01108_restart_replicas_rename_deadlock.reference
@@ -1,5 +1,5 @@
-replica_01108_1_tmp
-replica_01108_2_tmp
-replica_01108_3_tmp
-replica_01108_4_tmp
+replica_01108_1
+replica_01108_2
+replica_01108_3
+replica_01108_4
 1180	40

--- a/tests/queries/0_stateless/01108_restart_replicas_rename_deadlock.sh
+++ b/tests/queries/0_stateless/01108_restart_replicas_rename_deadlock.sh
@@ -63,6 +63,12 @@ timeout $TIMEOUT bash -c restart_thread_2 2> /dev/null &
 wait
 sleep 3
 
+for i in `seq 4`; do
+    $CLICKHOUSE_CLIENT -q "SYSTEM SYNC REPLICA replica_01108_$i" >/dev/null 2>&1
+    $CLICKHOUSE_CLIENT -q "SYSTEM SYNC REPLICA replica_01108_${i}_tmp" >/dev/null 2>&1
+done
+
+$CLICKHOUSE_CLIENT -q "SHOW TABLES LIKE 'replica\\_01108\\_%'"
 $CLICKHOUSE_CLIENT -q "SELECT sum(n), count(n) FROM merge(currentDatabase(), '^replica_01108_') GROUP BY position(_table, 'tmp')"
 
 

--- a/tests/queries/0_stateless/01108_restart_replicas_rename_deadlock.sh
+++ b/tests/queries/0_stateless/01108_restart_replicas_rename_deadlock.sh
@@ -53,7 +53,7 @@ export -f rename_thread_2;
 export -f restart_thread_1;
 export -f restart_thread_2;
 
-TIMEOUT=30
+TIMEOUT=10
 
 timeout $TIMEOUT bash -c rename_thread_1 2> /dev/null &
 timeout $TIMEOUT bash -c rename_thread_2 2> /dev/null &
@@ -68,7 +68,7 @@ for i in `seq 4`; do
     $CLICKHOUSE_CLIENT -q "SYSTEM SYNC REPLICA replica_01108_${i}_tmp" >/dev/null 2>&1
 done
 
-$CLICKHOUSE_CLIENT -q "SHOW TABLES LIKE 'replica\\_01108\\_%'"
+$CLICKHOUSE_CLIENT -q "SELECT replaceOne(name, '_tmp', '') FROM system.tables WHERE database = currentDatabase() AND match(name, '^replica_01108_')"
 $CLICKHOUSE_CLIENT -q "SELECT sum(n), count(n) FROM merge(currentDatabase(), '^replica_01108_') GROUP BY position(_table, 'tmp')"
 
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


It does not look like a fix but it will help to investigate subsequent test failures.
