### PR TITLE
Fix issue #11286; add a test

### DIFF
--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -181,8 +181,11 @@ const KeyCondition::AtomMap KeyCondition::atom_map
     },
     {
         "empty",
-        [] (RPNElement & out, const Field &)
+        [] (RPNElement & out, const Field & value)
         {
+            if (value.getType() != Field::Types::String)
+                return false;
+
             out.function = RPNElement::FUNCTION_IN_RANGE;
             out.range = Range("");
             return true;
@@ -190,8 +193,11 @@ const KeyCondition::AtomMap KeyCondition::atom_map
     },
     {
         "notEmpty",
-        [] (RPNElement & out, const Field &)
+        [] (RPNElement & out, const Field & value)
         {
+            if (value.getType() != Field::Types::String)
+                return false;
+
             out.function = RPNElement::FUNCTION_NOT_IN_RANGE;
             out.range = Range("");
             return true;

--- a/tests/queries/0_stateless/01290_empty_array_index_analysis.reference
+++ b/tests/queries/0_stateless/01290_empty_array_index_analysis.reference
@@ -1,0 +1,50 @@
+--- notEmpty
+	['a']	2
+	['a','b','c']	3
+	['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']	4
+--- empty
+	[]	1
+--- = []
+	[]	1
+--- != []
+	['a']	2
+	['a','b','c']	3
+	['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']	4
+--- > []
+	['a']	2
+	['a','b','c']	3
+	['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']	4
+--- < []
+--- >= []
+	[]	1
+	['a']	2
+	['a','b','c']	3
+	['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']	4
+--- <= []
+	[]	1
+---
+--- notEmpty
+	['a']	2
+	['a','b','c']	3
+	['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']	4
+--- empty
+	[]	1
+--- = []
+	[]	1
+--- != []
+	['a']	2
+	['a','b','c']	3
+	['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']	4
+--- > []
+	['a']	2
+	['a','b','c']	3
+	['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']	4
+--- < []
+--- >= []
+	[]	1
+	['a']	2
+	['a','b','c']	3
+	['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']	4
+--- <= []
+	[]	1
+---

--- a/tests/queries/0_stateless/01290_empty_array_index_analysis.sql
+++ b/tests/queries/0_stateless/01290_empty_array_index_analysis.sql
@@ -1,0 +1,66 @@
+drop table if exists count_lc_test;
+
+CREATE TABLE count_lc_test
+(
+    `s` LowCardinality(String),
+    `arr` Array(LowCardinality(String)),
+    `num` UInt64
+)
+ENGINE = MergeTree
+ORDER BY (s, arr);
+
+INSERT INTO count_lc_test(num, arr) VALUES (1,[]),(2,['a']),(3,['a','b','c']),(4,['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']);
+
+SELECT '--- notEmpty';
+select * from count_lc_test where notEmpty(arr);
+SELECT '--- empty';
+select * from count_lc_test where empty(arr);
+SELECT '--- = []';
+select * from count_lc_test where arr = [];
+SELECT '--- != []';
+select * from count_lc_test where arr != [];
+SELECT '--- > []';
+select * from count_lc_test where arr > [];
+SELECT '--- < []';
+select * from count_lc_test where arr < [];
+SELECT '--- >= []';
+select * from count_lc_test where arr >= [];
+SELECT '--- <= []';
+select * from count_lc_test where arr <= [];
+SELECT '---';
+
+DROP TABLE count_lc_test;
+
+
+drop table if exists count_lc_test;
+
+CREATE TABLE count_lc_test
+(
+    `s` LowCardinality(String),
+    `arr` Array(String),
+    `num` UInt64
+)
+ENGINE = MergeTree
+ORDER BY (s, arr);
+
+INSERT INTO count_lc_test(num, arr) VALUES (1,[]),(2,['a']),(3,['a','b','c']),(4,['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']);
+
+SELECT '--- notEmpty';
+select * from count_lc_test where notEmpty(arr);
+SELECT '--- empty';
+select * from count_lc_test where empty(arr);
+SELECT '--- = []';
+select * from count_lc_test where arr = [];
+SELECT '--- != []';
+select * from count_lc_test where arr != [];
+SELECT '--- > []';
+select * from count_lc_test where arr > [];
+SELECT '--- < []';
+select * from count_lc_test where arr < [];
+SELECT '--- >= []';
+select * from count_lc_test where arr >= [];
+SELECT '--- <= []';
+select * from count_lc_test where arr <= [];
+SELECT '---';
+
+DROP TABLE count_lc_test;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix the issue when index analysis cannot work if a table has Array column in primary key and if a query is filtering by this column with `empty` or `notEmpty` functions. This fixes #11286 


Detailed description / Documentation draft:
Note that the usage of Array in primary key is mistake in 99% of cases.