### PR TITLE
Add libsasl2-dev and heimdal-multidev in CI Docker image

### DIFF
--- a/docker/packager/deb/Dockerfile
+++ b/docker/packager/deb/Dockerfile
@@ -80,7 +80,9 @@ RUN apt-get --allow-unauthenticated update -y \
             pigz \
             moreutils \
             libcctz-dev \
-            libldap2-dev
+            libldap2-dev \
+            libsasl2-dev \
+            heimdal-multidev
 
 
 


### PR DESCRIPTION
...since they are required by static system OpenLDAP libraries during `UNBUNDLED=ON` CI builds.

Changelog category:
- Not for changelog (changelog entry is not required)
