### PR TITLE
Fix uninitialized memory in conversion

### DIFF
--- a/src/Functions/FunctionsConversion.h
+++ b/src/Functions/FunctionsConversion.h
@@ -146,7 +146,7 @@ struct ConvertImpl
                     else if constexpr (IsDataTypeNumber<FromDataType> && IsDataTypeDecimal<ToDataType>)
                         vec_to[i] = convertToDecimal<FromDataType, ToDataType>(vec_from[i], vec_to.getScale());
                     else
-                        throw Exception("Unsupported data type in conversion function", ErrorCodes::NOT_IMPLEMENTED);
+                        throw Exception("Unsupported data type in conversion function", ErrorCodes::CANNOT_CONVERT_TYPE);
                 }
                 else
                     vec_to[i] = static_cast<ToFieldType>(vec_from[i]);

--- a/src/Functions/FunctionsConversion.h
+++ b/src/Functions/FunctionsConversion.h
@@ -145,6 +145,8 @@ struct ConvertImpl
                         vec_to[i] = convertFromDecimal<FromDataType, ToDataType>(vec_from[i], vec_from.getScale());
                     else if constexpr (IsDataTypeNumber<FromDataType> && IsDataTypeDecimal<ToDataType>)
                         vec_to[i] = convertToDecimal<FromDataType, ToDataType>(vec_from[i], vec_to.getScale());
+                    else
+                        throw Exception("Unsupported data type in conversion function", ErrorCodes::NOT_IMPLEMENTED);
                 }
                 else
                     vec_to[i] = static_cast<ToFieldType>(vec_from[i]);

--- a/tests/queries/0_stateless/01291_unsupported_conversion_from_decimal.sql
+++ b/tests/queries/0_stateless/01291_unsupported_conversion_from_decimal.sql
@@ -1,0 +1,5 @@
+SELECT toIntervalSecond(now64()); -- { serverError 70 }
+SELECT CAST(now64() AS IntervalSecond); -- { serverError 70 }
+
+SELECT toIntervalSecond(now64()); -- { serverError 70 }
+SELECT CAST(now64() AS IntervalSecond); -- { serverError 70 }


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix potential uninitialized memory in conversion. Example: `SELECT toIntervalSecond(now64())`.