### PR TITLE
Fix very rare race condition in ThreadPool

### DIFF
--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -234,14 +234,6 @@ void ThreadPoolImpl<Thread>::worker(typename std::list<Thread>::iterator thread_
                     --scheduled_jobs;
                 }
 
-                DB::tryLogCurrentException("ThreadPool",
-                    std::string("Exception in ThreadPool(") +
-                    "max_threads: " + std::to_string(max_threads)
-                    + ", max_free_threads: " + std::to_string(max_free_threads)
-                    + ", queue_size: " + std::to_string(queue_size)
-                    + ", shutdown_on_exception: " + std::to_string(shutdown_on_exception)
-                    + ").");
-
                 job_finished.notify_all();
                 new_job_or_shutdown.notify_all();
                 return;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix very rare race condition in ThreadPool.


Detailed description / Documentation draft:
It was introduced in #9154. The reason it that we access `exception` object without locking mutex. At the same time, exception may be rethrown in another thread, then catched by non-const reference and modified. See [link](https://clickhouse-test-reports.s3.yandex.net/11301/8a4c2380ddd7a1e316f4d3d1eb5d178bccabec1f/stress_test_(thread)/stderr.log). Found here: https://github.com/ClickHouse/ClickHouse/pull/11301