### PR TITLE
Better exception message in case when there is shortage of memory mappings

### DIFF
--- a/src/Common/Exception.cpp
+++ b/src/Common/Exception.cpp
@@ -209,6 +209,8 @@ static void getNotEnoughMemoryMessage(std::string & msg)
     {
         msg += "\nCannot obtain additional info about memory usage.";
     }
+#else
+    (void)msg;
 #endif
 }
 

--- a/src/Functions/trap.cpp
+++ b/src/Functions/trap.cpp
@@ -24,6 +24,7 @@ namespace ErrorCodes
     extern const int ILLEGAL_COLUMN;
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
     extern const int BAD_ARGUMENTS;
+    extern const int CANNOT_ALLOCATE_MEMORY;
 }
 
 


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Better exception message in case when there is shortage of memory mappings. This closes #11027