### PR TITLE
Fix visitParamExtractRaw for strings with unbalanced { or [.

### DIFF
--- a/src/Functions/visitParamExtractRaw.cpp
+++ b/src/Functions/visitParamExtractRaw.cpp
@@ -22,6 +22,14 @@ struct ExtractRaw
                 expects_end.pop_back();
                 current_expect_end = expects_end.empty() ? 0 : expects_end.back();
             }
+            else if (current_expect_end == '"')
+            {
+                /// skip backslash
+                if (*pos == '\\' && pos + 1 < end && pos[1] == '"')
+                {
+                    pos++;
+                }
+            }
             else
             {
                 switch (*pos)
@@ -37,11 +45,6 @@ struct ExtractRaw
                     case '"' :
                         current_expect_end = '"';
                         expects_end.push_back(current_expect_end);
-                        break;
-                    case '\\':
-                        /// skip backslash
-                        if (pos + 1 < end && pos[1] == '"')
-                            pos++;
                         break;
                     default:
                         if (!current_expect_end && (*pos == ',' || *pos == '}'))

--- a/tests/queries/0_stateless/00539_functions_for_working_with_json.reference
+++ b/tests/queries/0_stateless/00539_functions_for_working_with_json.reference
@@ -9,5 +9,7 @@ test"string
  "test_string"
  "test\\"string"
  "test\\"string"
+ "{"
+ "["
  ["]", "2", "3"]
  {"nested" : [1,2,3]}

--- a/tests/queries/0_stateless/00539_functions_for_working_with_json.sql
+++ b/tests/queries/0_stateless/00539_functions_for_working_with_json.sql
@@ -11,5 +11,7 @@ SELECT visitParamExtractRaw('{"myparam":"test_string"}', 'myparam');
 SELECT visitParamExtractRaw('{"myparam": "test_string"}', 'myparam');
 SELECT visitParamExtractRaw('{"myparam": "test\\"string"}', 'myparam');
 SELECT visitParamExtractRaw('{"myparam": "test\\"string", "other":123}', 'myparam');
+SELECT visitParamExtractRaw('{"myparam": "{"}', 'myparam');
+SELECT visitParamExtractRaw('{"myparam": "["}', 'myparam');
 SELECT visitParamExtractRaw('{"myparam": ["]", "2", "3"], "other":123}', 'myparam');
 SELECT visitParamExtractRaw('{"myparam": {"nested" : [1,2,3]}, "other":123}', 'myparam');


### PR DESCRIPTION
Closes #11254 .

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix visitParamExtractRaw when extracted JSON has strings with unbalanced { or [.
