### PR TITLE
Disable flacky test #8840

### DIFF
--- a/tests/integration/test_ttl_move/test.py
+++ b/tests/integration/test_ttl_move/test.py
@@ -834,6 +834,7 @@ def test_concurrent_alter_with_ttl_move(started_cluster, name, engine):
     finally:
         node1.query("DROP TABLE IF EXISTS {name}".format(name=name))
 
+@pytest.mark.skip(reason="Flacky test")
 @pytest.mark.parametrize("name,positive", [
     ("test_double_move_while_select_negative", 0),
     ("test_double_move_while_select_positive", 1),


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

This commit partially reverts #8840
Note that MOVE TTL is considered experimental (not for production usage) before these tests will be enabled. @excitoon 

Update: I have read that test and figured out that it's totally wrong (synchronization with sleeps) and should not exist at all.