### PR TITLE
Better check for hung queries in clickhouse-test

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -502,7 +502,14 @@ def main(args):
             total_tests_run += tests_n
 
     if args.hung_check:
-        processlist = get_processlist(args.client)
+
+        # Some queries may execute in background for some time after test was finished. This is normal.
+        for n in range(1, 60):
+            processlist = get_processlist(args.client)
+            if not processlist:
+                break
+            sleep(1)
+
         if processlist:
             print(colored("\nFound hung queries in processlist:", args, "red", attrs=["bold"]))
             print(processlist)


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Better check for hung queries in clickhouse-test.


Detailed description:

Some queries may execute in background for some time after test was finished. This is normal.

See https://clickhouse-test-reports.s3.yandex.net/11318/70eaae38f2fe5c91d6a43b5166df623996826042/functional_stateless_tests_(memory)/test_run.txt.out.log
