### PR TITLE
More parallel MV processing.

### DIFF
--- a/src/DataStreams/PushingToViewsBlockOutputStream.cpp
+++ b/src/DataStreams/PushingToViewsBlockOutputStream.cpp
@@ -153,7 +153,7 @@ void PushingToViewsBlockOutputStream::write(const Block & block)
     const Settings & settings = context.getSettingsRef();
     if (settings.parallel_view_processing && views.size() > 1)
     {
-        // Push to views concurrently if enabled, and more than one view is attached
+        // Push to views concurrently if enabled and more than one view is attached
         ThreadPool pool(std::min(size_t(settings.max_threads), views.size()));
         for (size_t view_num = 0; view_num < views.size(); ++view_num)
         {

--- a/src/DataStreams/PushingToViewsBlockOutputStream.cpp
+++ b/src/DataStreams/PushingToViewsBlockOutputStream.cpp
@@ -218,7 +218,7 @@ void PushingToViewsBlockOutputStream::writeSuffix()
     {
         parallel_processing = true;
 
-        // Push to views concurrently if enabled, and more than one view is attached
+        // Push to views concurrently if enabled and more than one view is attached
         ThreadPool pool(std::min(size_t(settings.max_threads), views.size()));
         auto thread_group = CurrentThread::getGroup();
 

--- a/tests/performance/parallel_mv.xml
+++ b/tests/performance/parallel_mv.xml
@@ -1,15 +1,19 @@
 <test>
+    <settings>
+        <parallel_view_processing>1</parallel_view_processing>
+    </settings>
+
     <create_query>create table main_table (number UInt64) engine = MergeTree order by tuple();</create_query>
     <create_query>create materialized view mv_1 engine = MergeTree order by tuple() as
-        select number % 100000 as key, sum(number) from main_table where number % 13 != 0 group by key;</create_query>
+        select number, toString(number) from main_table where number % 13 != 0;</create_query>
     <create_query>create materialized view mv_2 engine = MergeTree order by tuple() as
-        select number % 100000 as key, sum(number) from main_table where number % 13 != 1 group by key;</create_query>
+        select number, toString(number) from main_table where number % 13 != 1;</create_query>
     <create_query>create materialized view mv_3 engine = MergeTree order by tuple() as
-        select number % 100000 as key, sum(number) from main_table where number % 13 != 3 group by key;</create_query>
+        select number, toString(number) from main_table where number % 13 != 3;</create_query>
     <create_query>create materialized view mv_4 engine = MergeTree order by tuple() as
-        select number % 100000 as key, sum(number) from main_table where number % 13 != 4 group by key;</create_query>
+        select number, toString(number) from main_table where number % 13 != 4;</create_query>
 
-    <query>insert into main_table select number from numbers(100000)</query>
+    <!--<query>insert into main_table select number from numbers(100000)</query>-->
     <query>insert into main_table select number from numbers(1000000)</query>
 
     <drop_query>drop table if exists main_table;</drop_query>

--- a/tests/performance/parallel_mv.xml
+++ b/tests/performance/parallel_mv.xml
@@ -1,0 +1,20 @@
+<test>
+    <create_query>create table main_table (number UInt64) engine = MergeTree order by tuple();</create_query>
+    <create_query>create materialized view mv_1 engine = MergeTree order by tuple() as
+        select number % 100000 as key, sum(number) from main_table where number % 13 != 0 group by key;</create_query>
+    <create_query>create materialized view mv_2 engine = MergeTree order by tuple() as
+        select number % 100000 as key, sum(number) from main_table where number % 13 != 1 group by key;</create_query>
+    <create_query>create materialized view mv_3 engine = MergeTree order by tuple() as
+        select number % 100000 as key, sum(number) from main_table where number % 13 != 3 group by key;</create_query>
+    <create_query>create materialized view mv_4 engine = MergeTree order by tuple() as
+        select number % 100000 as key, sum(number) from main_table where number % 13 != 4 group by key;</create_query>
+
+    <query>insert into main_table select number from numbers(100000)</query>
+    <query>insert into main_table select number from numbers(1000000)</query>
+
+    <drop_query>drop table if exists main_table;</drop_query>
+    <drop_query>drop table if exists mv_1;</drop_query>
+    <drop_query>drop table if exists mv_2;</drop_query>
+    <drop_query>drop table if exists mv_3;</drop_query>
+    <drop_query>drop table if exists mv_4;</drop_query>
+</test>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make writing to `MATERIALIZED VIEW` with setting `parallel_view_processing = 1` parallel again. Fixes #10241