### PR TITLE
Fix unit tests under MSan

### DIFF
--- a/base/common/phdr_cache.cpp
+++ b/base/common/phdr_cache.cpp
@@ -1,20 +1,6 @@
 /// This code was based on the code by Fedor Korotkiy (prime@yandex-team.ru) for YT product in Yandex.
 
-#if defined(__has_feature)
-    #if __has_feature(address_sanitizer)
-        #define ADDRESS_SANITIZER 1
-    #endif
-    #if __has_feature(thread_sanitizer)
-        #define THREAD_SANITIZER 1
-    #endif
-#else
-    #if defined(__SANITIZE_ADDRESS__)
-        #define ADDRESS_SANITIZER 1
-    #endif
-    #if defined(__SANITIZE_THREAD__)
-        #define THREAD_SANITIZER 1
-    #endif
-#endif
+#include <common/defines.h>
 
 #if defined(__linux__) && !defined(THREAD_SANITIZER)
     #define USE_PHDR_CACHE 1

--- a/src/Common/tests/gtest_rw_lock.cpp
+++ b/src/Common/tests/gtest_rw_lock.cpp
@@ -5,6 +5,7 @@
 #include <Common/Stopwatch.h>
 #include <common/types.h>
 #include <Common/ThreadPool.h>
+#include <common/phdr_cache.h>
 #include <random>
 #include <pcg_random.hpp>
 #include <thread>
@@ -25,6 +26,13 @@ namespace DB
 
 TEST(Common, RWLock1)
 {
+    /// Tests with threads require this, because otherwise
+    ///  when tested under Memory Sanitizer,
+    ///  it tries to obtain stack trace on 'free' invocation at thread exit,
+    ///  but cannot do that due to infinite recursion.
+    /// Alternative solution: disable PHDR Cache under memory sanitizer.
+    updatePHDRCache();
+
     constexpr int cycles = 1000;
     const std::vector<size_t> pool_sizes{1, 2, 4, 8};
 
@@ -92,6 +100,8 @@ TEST(Common, RWLock1)
 
 TEST(Common, RWLockRecursive)
 {
+    updatePHDRCache();
+
     constexpr auto cycles = 10000;
 
     static auto fifo_lock = RWLockImpl::create();
@@ -134,6 +144,8 @@ TEST(Common, RWLockRecursive)
 
 TEST(Common, RWLockDeadlock)
 {
+    updatePHDRCache();
+
     static auto lock1 = RWLockImpl::create();
     static auto lock2 = RWLockImpl::create();
 
@@ -216,6 +228,8 @@ TEST(Common, RWLockDeadlock)
 
 TEST(Common, RWLockPerfTestReaders)
 {
+    updatePHDRCache();
+
     constexpr int cycles = 100000; // 100k
     const std::vector<size_t> pool_sizes{1, 2, 4, 8};
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Detailed description / Documentation draft:
Fix failure of unit tests under Memory Sanitizer due to infinite recursion in `dl_iterate_phdr` function. See https://clickhouse-test-reports.s3.yandex.net/0/19c6e0e5ae0c2385aaa5d029adc8c436007b9306/unit_tests_msan_clang-10/test_result.txt
This was a false test failure and it does not indicate any bugs.