### PR TITLE
Better log messages in ConfigReloader

### DIFF
--- a/src/Common/Config/ConfigReloader.cpp
+++ b/src/Common/Config/ConfigReloader.cpp
@@ -85,10 +85,11 @@ void ConfigReloader::reloadIfNewer(bool force, bool throw_on_error, bool fallbac
     {
         ConfigProcessor config_processor(path);
         ConfigProcessor::LoadedConfig loaded_config;
+
+        LOG_DEBUG(log, "Loading config '{}'", path);
+
         try
         {
-            LOG_DEBUG(log, "Loading config '{}'", path);
-
             loaded_config = config_processor.loadConfig(/* allow_zk_includes = */ true);
             if (loaded_config.has_zk_includes)
                 loaded_config = config_processor.loadConfigWithZooKeeperIncludes(
@@ -126,6 +127,8 @@ void ConfigReloader::reloadIfNewer(bool force, bool throw_on_error, bool fallbac
             need_reload_from_zk = false;
         }
 
+        LOG_DEBUG(log, "Loaded config '{}', performing update on configuration", path);
+
         try
         {
             updater(loaded_config.configuration);
@@ -136,6 +139,8 @@ void ConfigReloader::reloadIfNewer(bool force, bool throw_on_error, bool fallbac
                 throw;
             tryLogCurrentException(log, "Error updating configuration from '" + path + "' config.");
         }
+
+        LOG_DEBUG(log, "Loaded config '{}', performed update on configuration", path);
     }
 }
 


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Better log messages in while reloading configuration.
