### PR TITLE
Suppress output of cancelled queries in clickhouse-client #9473

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -1178,7 +1178,7 @@ private:
                     break;
             }
 
-            if (!receiveAndProcessPacket())
+            if (!receiveAndProcessPacket(cancelled))
                 break;
         }
 
@@ -1189,14 +1189,16 @@ private:
 
     /// Receive a part of the result, or progress info or an exception and process it.
     /// Returns true if one should continue receiving packets.
-    bool receiveAndProcessPacket()
+    /// Output of result is suppressed if query was cancelled.
+    bool receiveAndProcessPacket(bool cancelled)
     {
         Packet packet = connection->receivePacket();
 
         switch (packet.type)
         {
             case Protocol::Server::Data:
-                onData(packet.block);
+                if (!cancelled)
+                    onData(packet.block);
                 return true;
 
             case Protocol::Server::Progress:
@@ -1208,11 +1210,13 @@ private:
                 return true;
 
             case Protocol::Server::Totals:
-                onTotals(packet.block);
+                if (!cancelled)
+                    onTotals(packet.block);
                 return true;
 
             case Protocol::Server::Extremes:
-                onExtremes(packet.block);
+                if (!cancelled)
+                    onExtremes(packet.block);
                 return true;
 
             case Protocol::Server::Exception:
@@ -1304,7 +1308,7 @@ private:
 
         while (packet_type && *packet_type == Protocol::Server::Log)
         {
-            receiveAndProcessPacket();
+            receiveAndProcessPacket(false);
             packet_type = connection->checkPacket();
         }
     }


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Suppress output of cancelled queries in clickhouse-client. In previous versions result may continue to print in terminal even after you press Ctrl+C to cancel query. This closes #9473.


Detailed description:
No test will be provided for this improvement.