### PR TITLE
Fix sync_async test (remove timeout)

### DIFF
--- a/tests/integration/test_insert_into_distributed_sync_async/test.py
+++ b/tests/integration/test_insert_into_distributed_sync_async/test.py
@@ -86,7 +86,7 @@ def test_insertion_sync_fails_with_timeout(started_cluster):
     with pytest.raises(QueryRuntimeException):
         node1.query('''
         SET insert_distributed_sync = 1, insert_distributed_timeout = 1;
-        INSERT INTO distributed_table SELECT today() as date, number as val FROM system.numbers''', timeout=5)
+        INSERT INTO distributed_table SELECT today() as date, number as val FROM system.numbers''')
 
 
 def test_insertion_without_sync_ignores_timeout(started_cluster):


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove redundant timeout from integration test `test_insertion_sync_fails_with_timeout`.