### PR TITLE
Extended BackgroundProcessingPool::startTask() to control task execution concurrency

### DIFF
--- a/src/Storages/MergeTree/BackgroundProcessingPool.cpp
+++ b/src/Storages/MergeTree/BackgroundProcessingPool.cpp
@@ -16,7 +16,7 @@
 namespace DB
 {
 
-void BackgroundProcessingPoolTaskInfo::wake()
+void BackgroundProcessingPoolTaskInfo::signalReadyToRun()
 {
     Poco::Timestamp current_time;
     {

--- a/src/Storages/MergeTree/BackgroundProcessingPool.cpp
+++ b/src/Storages/MergeTree/BackgroundProcessingPool.cpp
@@ -45,8 +45,8 @@ BackgroundProcessingPool::BackgroundProcessingPool(int size_,
     , thread_name(thread_name_)
     , settings(pool_settings)
 {
-    logger = &Logger::get(log_name);
-    LOG_INFO(logger, "Create " << log_name << " with " << size << " threads");
+    logger = &Poco::Logger::get(log_name);
+    LOG_INFO(logger, "Create {} with {} threads", log_name, size);
 
     threads.resize(size);
     for (auto & thread : threads)

--- a/src/Storages/MergeTree/BackgroundProcessingPool.cpp
+++ b/src/Storages/MergeTree/BackgroundProcessingPool.cpp
@@ -138,7 +138,7 @@ void BackgroundProcessingPool::workLoopFunc()
     }
 
     SCOPE_EXIT({ CurrentThread::detachQueryIfNotDetached(); });
-    if (const auto memory_tracker = CurrentThread::getMemoryTracker())
+    if (auto const memory_tracker = CurrentThread::getMemoryTracker())
         memory_tracker->setMetric(settings.memory_metric);
 
     pcg64 rng(randomSeed());

--- a/src/Storages/MergeTree/BackgroundProcessingPool.cpp
+++ b/src/Storages/MergeTree/BackgroundProcessingPool.cpp
@@ -138,7 +138,7 @@ void BackgroundProcessingPool::workLoopFunc()
     }
 
     SCOPE_EXIT({ CurrentThread::detachQueryIfNotDetached(); });
-    if (auto const memory_tracker = CurrentThread::getMemoryTracker())
+    if (auto * const memory_tracker = CurrentThread::getMemoryTracker())
         memory_tracker->setMetric(settings.memory_metric);
 
     pcg64 rng(randomSeed());

--- a/src/Storages/MergeTree/BackgroundProcessingPool.h
+++ b/src/Storages/MergeTree/BackgroundProcessingPool.h
@@ -135,8 +135,7 @@ class BackgroundProcessingPoolTaskInfo
 {
 public:
     /// Signals random idle thread from the pool that this task is ready to be executed.
-    void wake();
-    void signalReadyToRun(); /// TODO: Rename this properly
+    void signalReadyToRun();
 
     BackgroundProcessingPoolTaskInfo(BackgroundProcessingPool & pool_, const BackgroundProcessingPool::Task & function_)
         : pool(pool_), task_function(function_) {}

--- a/src/Storages/MergeTree/BackgroundProcessingPool.h
+++ b/src/Storages/MergeTree/BackgroundProcessingPool.h
@@ -82,7 +82,7 @@ public:
         return size;
     }
 
-    /// Create task and start it. It is used internally.
+    /// Create task and start it.
     TaskHandle addTask(const Task & task);
 
     /// The following two methods are invoked by Storage*MergeTree at startup

--- a/src/Storages/MergeTree/MergeTreeBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/MergeTreeBlockOutputStream.cpp
@@ -28,7 +28,7 @@ void MergeTreeBlockOutputStream::write(const Block & block)
 
         /// Initiate async merge - it will be done if it's good time for merge and if there are space in 'background_pool'.
         if (storage.merging_mutating_task_handle)
-            storage.merging_mutating_task_handle->wake();
+            storage.merging_mutating_task_handle->signalReadyToRun();
     }
 }
 

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -559,7 +559,7 @@ void ReplicatedMergeTreeQueue::pullLogsToQueue(zkutil::ZooKeeperPtr zookeeper, C
         }
 
         if (storage.queue_task_handle)
-            storage.queue_task_handle->wake();
+            storage.queue_task_handle->signalReadyToRun();
     }
 }
 
@@ -641,7 +641,7 @@ void ReplicatedMergeTreeQueue::updateMutations(zkutil::ZooKeeperPtr zookeeper, C
     }
 
     if (some_active_mutations_were_killed)
-        storage.queue_task_handle->wake();
+        storage.queue_task_handle->signalReadyToRun();
 
     if (!entries_to_load.empty())
     {
@@ -754,7 +754,7 @@ ReplicatedMergeTreeMutationEntryPtr ReplicatedMergeTreeQueue::removeMutation(
     }
 
     if (mutation_was_active)
-        storage.queue_task_handle->wake();
+        storage.queue_task_handle->signalReadyToRun();
 
     return entry;
 }

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -388,7 +388,7 @@ Int64 StorageMergeTree::startMutation(const MutationCommands & commands, String 
     current_mutations_by_version.emplace(version, insertion.first->second);
 
     LOG_INFO(log, "Added mutation: {}", mutation_file_name);
-    merging_mutating_task_handle->wake();
+    merging_mutating_task_handle->signalReadyToRun();
     return version;
 }
 
@@ -521,7 +521,7 @@ CancellationCode StorageMergeTree::killMutation(const String & mutation_id)
     }
 
     /// Maybe there is another mutation that was blocked by the killed one. Try to execute it immediately.
-    merging_mutating_task_handle->wake();
+    merging_mutating_task_handle->signalReadyToRun();
 
     return CancellationCode::CancelSent;
 }

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -5308,7 +5308,7 @@ bool StorageReplicatedMergeTree::waitForShrinkingQueueSize(size_t queue_size, UI
     queue.pullLogsToQueue(getZooKeeper());
     /// This is significant, because the execution of this task could be delayed at BackgroundPool.
     /// And we force it to be executed.
-    queue_task_handle->wake();
+    queue_task_handle->signalReadyToRun();
 
     Poco::Event target_size_event;
     auto callback = [&target_size_event, queue_size] (size_t new_queue_size)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


What's changed:
+ `BackgroundProcessingPool::startTask()` method is extended to allow explicitly disable running a task by multiple pool workers in parallel.
+ Somewhat reworked synchronization for other parts of `BackgroundProcessingPool`.