### PR TITLE
[CANCELED] Ability to preserve user for distributed queries

### DIFF
--- a/programs/benchmark/Benchmark.cpp
+++ b/programs/benchmark/Benchmark.cpp
@@ -79,7 +79,10 @@ public:
             UInt16 cur_port = i >= ports_.size() ? 9000 : ports_[i];
             std::string cur_host = i >= hosts_.size() ? "localhost" : hosts_[i];
 
-            connections.emplace_back(std::make_unique<ConnectionPool>(concurrency, cur_host, cur_port, default_database_, user_, password_, "benchmark", Protocol::Compression::Enable, secure));
+            connections.emplace_back(std::make_unique<ConnectionPool>(concurrency,
+                    cur_host, cur_port, default_database_,
+                    user_, true /* user_specified */, password_,
+                    "benchmark", Protocol::Compression::Enable, secure));
             comparison_info_per_interval.emplace_back(std::make_shared<Stats>());
             comparison_info_total.emplace_back(std::make_shared<Stats>());
         }

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -595,6 +595,7 @@ private:
             connection_parameters.port,
             connection_parameters.default_database,
             connection_parameters.user,
+            true /* user_specified */,
             connection_parameters.password,
             "client",
             connection_parameters.compression,

--- a/programs/client/Suggest.cpp
+++ b/programs/client/Suggest.cpp
@@ -25,6 +25,7 @@ void Suggest::load(const ConnectionParameters & connection_parameters, size_t su
                     connection_parameters.port,
                     connection_parameters.default_database,
                     connection_parameters.user,
+                    true /* user_specified */,
                     connection_parameters.password,
                     "client",
                     connection_parameters.compression,

--- a/src/Client/ConnectionPool.h
+++ b/src/Client/ConnectionPool.h
@@ -51,6 +51,7 @@ public:
             UInt16 port_,
             const String & default_database_,
             const String & user_,
+            bool user_specified_,
             const String & password_,
             const String & client_name_ = "client",
             Protocol::Compression compression_ = Protocol::Compression::Enable,
@@ -61,10 +62,11 @@ public:
         port(port_),
         default_database(default_database_),
         user(user_),
+        user_specified(user_specified_),
         password(password_),
         client_name(client_name_),
         compression(compression_),
-        secure{secure_}
+        secure(secure_)
     {
     }
 
@@ -99,7 +101,9 @@ protected:
     {
         return std::make_shared<Connection>(
             host, port,
-            default_database, user, password,
+            default_database,
+            user, user_specified,
+            password,
             client_name, compression, secure);
     }
 
@@ -108,12 +112,12 @@ private:
     UInt16 port;
     String default_database;
     String user;
+    bool user_specified = false;
     String password;
 
     String client_name;
     Protocol::Compression compression;        /// Whether to compress data when interacting with the server.
     Protocol::Secure secure;          /// Whether to encrypt data when interacting with the server.
-
 };
 
 }

--- a/src/Dictionaries/ClickHouseDictionarySource.cpp
+++ b/src/Dictionaries/ClickHouseDictionarySource.cpp
@@ -39,6 +39,7 @@ static ConnectionPoolWithFailoverPtr createPool(
         port,
         db,
         user,
+        true /* user_specified */,
         password,
         "ClickHouseDictionarySource",
         Protocol::Compression::Enable,

--- a/src/Interpreters/Cluster.cpp
+++ b/src/Interpreters/Cluster.cpp
@@ -91,7 +91,7 @@ Cluster::Address::Address(const Poco::Util::AbstractConfiguration & config, cons
 
 
 Cluster::Address::Address(const String & host_port_, const String & user_, const String & password_, UInt16 clickhouse_port, bool secure_)
-    : user(user_), password(password_)
+    : user(user_), password(password_), user_specified(true)
 {
     auto parsed_host_port = parseAddress(host_port_, clickhouse_port);
     host_name = parsed_host_port.first;

--- a/src/Interpreters/Cluster.cpp
+++ b/src/Interpreters/Cluster.cpp
@@ -297,7 +297,9 @@ Cluster::Cluster(const Poco::Util::AbstractConfiguration & config, const Setting
             ConnectionPoolPtr pool = std::make_shared<ConnectionPool>(
                 settings.distributed_connections_pool_size,
                 address.host_name, address.port,
-                address.default_database, address.user, address.password,
+                address.default_database,
+                address.user, address.user_specified,
+                address.password,
                 "server", address.compression, address.secure);
 
             info.pool = std::make_shared<ConnectionPoolWithFailover>(
@@ -370,7 +372,9 @@ Cluster::Cluster(const Poco::Util::AbstractConfiguration & config, const Setting
                 auto replica_pool = std::make_shared<ConnectionPool>(
                     settings.distributed_connections_pool_size,
                     replica.host_name, replica.port,
-                    replica.default_database, replica.user, replica.password,
+                    replica.default_database,
+                    replica.user, replica.user_specified,
+                    replica.password,
                     "server", replica.compression, replica.secure);
 
                 all_replicas_pools.emplace_back(replica_pool);
@@ -431,7 +435,9 @@ Cluster::Cluster(const Settings & settings, const std::vector<std::vector<String
             auto replica_pool = std::make_shared<ConnectionPool>(
                         settings.distributed_connections_pool_size,
                         replica.host_name, replica.port,
-                        replica.default_database, replica.user, replica.password,
+                        replica.default_database,
+                        replica.user, replica.user_specified,
+                        replica.password,
                         "server", replica.compression, replica.secure);
             all_replicas.emplace_back(replica_pool);
             if (replica.is_local && !treat_local_as_remote)
@@ -535,6 +541,7 @@ Cluster::Cluster(Cluster::ReplicasAsShardsTag, const Cluster & from, const Setti
                 address.port,
                 address.default_database,
                 address.user,
+                address.user_specified,
                 address.password,
                 "server",
                 address.compression,

--- a/src/Storages/Distributed/DirectoryMonitor.cpp
+++ b/src/Storages/Distributed/DirectoryMonitor.cpp
@@ -212,7 +212,9 @@ ConnectionPoolPtr StorageDistributedDirectoryMonitor::createPool(const std::stri
         }
 
         return std::make_shared<ConnectionPool>(
-            1, address.host_name, address.port, address.default_database, address.user, address.password,
+            1,
+            address.host_name, address.port, address.default_database,
+            address.user, address.user_specified, address.password,
             storage.getName() + '_' + address.user, Protocol::Compression::Enable, address.secure);
     };
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -4087,7 +4087,8 @@ void StorageReplicatedMergeTree::sendRequestToLeaderReplica(const ASTPtr & query
         leader_address.host,
         leader_address.queries_port,
         leader_address.database,
-        user, password, "Follower replica");
+        user, true /* user specified */, password,
+        "Follower replica");
 
     std::stringstream new_query_ss;
     formatAST(*new_query, new_query_ss, false, true);

--- a/tests/integration/test_distributed_preserve_initial_user/configs/remote_servers.xml
+++ b/tests/integration/test_distributed_preserve_initial_user/configs/remote_servers.xml
@@ -1,0 +1,28 @@
+<yandex>
+    <remote_servers>
+        <c1>
+            <node>
+                <host>n1</host>
+                <port>9000</port>
+            </node>
+            <node>
+                <host>n2</host>
+                <port>9000</port>
+            </node>
+        </c1>
+
+        <c2>
+            <node>
+                <host>n1</host>
+                <port>9000</port>
+                <user>nopass</user>
+            </node>
+            <node>
+                <host>n2</host>
+                <port>9000</port>
+                <user>nopass</user>
+            </node>
+        </c2>
+    </remote_servers>
+</yandex>
+

--- a/tests/integration/test_distributed_preserve_initial_user/configs/users.xml
+++ b/tests/integration/test_distributed_preserve_initial_user/configs/users.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<yandex>
+    <profiles>
+        <default>
+        </default>
+    </profiles>
+
+    <users>
+        <default>
+            <password></password>
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </default>
+
+        <nopass>
+            <password></password>
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </nopass>
+
+        <pass>
+            <password>foo</password>
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </pass>
+    </users>
+
+    <quotas>
+        <default>
+        </default>
+    </quotas>
+</yandex>

--- a/tests/integration/test_distributed_preserve_initial_user/test.py
+++ b/tests/integration/test_distributed_preserve_initial_user/test.py
@@ -72,6 +72,32 @@ def test_user_pass():
     assert get_query_user_info(n1, 'd1-user-pass') == ['pass', 'pass']
     assert get_query_user_info(n2, 'd1-user-pass') == ['pass', 'pass']
 
+def test_cluster():
+    query_with_id(n1, 'cluster-c1', 'SELECT * FROM cluster(c1, system.one)')
+    assert get_query_user_info(n1, 'cluster-c1') == ['default', 'default']
+    assert get_query_user_info(n2, 'cluster-c1') == ['default', 'default']
+
+    query_with_id(n1, 'cluster-c2', 'SELECT * FROM cluster(c2, system.one)')
+    assert get_query_user_info(n1, 'cluster-c2') == ['default', 'default']
+    assert get_query_user_info(n2, 'cluster-c2') == ['nopass',  'default']
+
+def test_remote():
+    query_with_id(n1, 'remote-c1-no-user', "SELECT * FROM remote('n{1,2}', system.one)")
+    assert get_query_user_info(n1, 'remote-c1-no-user') == ['default', 'default']
+    assert get_query_user_info(n2, 'remote-c1-no-user') == ['default', 'default']
+
+    query_with_id(n1, 'remote-c1-user-default', "SELECT * FROM remote('n{1,2}', system.one, 'default')")
+    assert get_query_user_info(n1, 'remote-c1-user-default') == ['default', 'default']
+    assert get_query_user_info(n2, 'remote-c1-user-default') == ['default', 'default']
+
+    query_with_id(n1, 'remote-c1-user-nopass', "SELECT * FROM remote('n{1,2}', system.one, 'nopass')")
+    assert get_query_user_info(n1, 'remote-c1-user-nopass') == ['default', 'default']
+    assert get_query_user_info(n2, 'remote-c1-user-nopass') == ['nopass',  'default']
+
+    query_with_id(n1, 'remote-c1-user-pass', "SELECT * FROM remote('n{1,2}', system.one, 'pass', 'foo')")
+    assert get_query_user_info(n1, 'remote-c1-user-pass') == ['default', 'default']
+    assert get_query_user_info(n2, 'remote-c1-user-pass') == ['pass',    'default']
+
 def test_user_default_retry():
     n1.query('SELECT * FROM d1')
     # pause n2 instance to trigger connection retry on n1

--- a/tests/integration/test_distributed_preserve_initial_user/test.py
+++ b/tests/integration/test_distributed_preserve_initial_user/test.py
@@ -1,0 +1,88 @@
+# pylint: disable=unused-argument
+# pylint: disable=redefined-outer-name
+# pylint: disable=line-too-long
+# pylint: disable=redefined-builtin
+
+from time import sleep
+import threading
+import pytest
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+n1 = cluster.add_instance('n1', main_configs=['configs/remote_servers.xml'], config_dir='configs')
+n2 = cluster.add_instance('n2', main_configs=['configs/remote_servers.xml'], config_dir='configs', stay_alive=True)
+
+def create_system_tables():
+    n1.query("SYSTEM FLUSH LOGS")
+    n2.query("SYSTEM FLUSH LOGS")
+
+def create_tables():
+    n1.query("""
+    CREATE TABLE d1 AS system.one
+    Engine=Distributed(c1, system, one)
+    """)
+
+    n1.query("""
+    CREATE TABLE d2 AS system.one
+    Engine=Distributed(c2, system, one)
+    """)
+
+@pytest.fixture(scope='module', autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        create_tables()
+        create_system_tables()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+def query_with_id(node, id, query, **kwargs):
+    return node.query("WITH '{}' AS __id {}".format(id, query), **kwargs)
+
+def get_query_user_info(node, query_pattern):
+    node.query("SYSTEM FLUSH LOGS")
+    return node.query("""
+    SELECT user, initial_user
+    FROM system.query_log
+    WHERE
+        query LIKE '%{}%' AND
+        query NOT LIKE '%system.query_log%' AND
+        type = 'QueryFinish'
+    """.format(query_pattern)).strip().split('\t')
+
+def test_user_default_1():
+    query_with_id(n1, 'd1-user-default', 'SELECT * FROM d1')
+    assert get_query_user_info(n1, 'd1-user-default') == ['default', 'default']
+    assert get_query_user_info(n2, 'd1-user-default') == ['default', 'default']
+
+def test_user_default_2():
+    query_with_id(n1, 'd2-user-default', 'SELECT * FROM d2')
+    assert get_query_user_info(n1, 'd2-user-default') == ['default', 'default'] # due to local
+    assert get_query_user_info(n2, 'd2-user-default') == ['nopass',  'default']
+
+def test_user_nopass():
+    query_with_id(n1, 'd1-user-nopass', 'SELECT * FROM d1', user='nopass')
+    assert get_query_user_info(n1, 'd1-user-nopass') == ['nopass', 'nopass']
+    assert get_query_user_info(n2, 'd1-user-nopass') == ['nopass', 'nopass']
+
+def test_user_pass():
+    query_with_id(n1, 'd1-user-pass', 'SELECT * FROM d1', user='pass', password='foo')
+    assert get_query_user_info(n1, 'd1-user-pass') == ['pass', 'pass']
+    assert get_query_user_info(n2, 'd1-user-pass') == ['pass', 'pass']
+
+def test_user_default_retry():
+    n1.query('SELECT * FROM d1')
+    # pause n2 instance to trigger connection retry on n1
+    def cont():
+        sleep(5)
+        cluster.unpause_container('n2')
+    thread = threading.Thread(target=cont)
+    cluster.pause_container('n2')
+    thread.start()
+    query_with_id(n1, 'd1-retry-user-default', 'SELECT * FROM d1')
+    thread.join()
+
+    assert get_query_user_info(n1, 'd1-retry-user-default') == ['default', 'default']
+    assert get_query_user_info(n2, 'd1-retry-user-default') == ['default', 'default']


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Preserve initial_user for Distributed queries if user was not specified in remote_servers

Fixes: #6843