### PR TITLE
Better error for wrong USING key

### DIFF
--- a/src/Interpreters/TranslateQualifiedNamesVisitor.cpp
+++ b/src/Interpreters/TranslateQualifiedNamesVisitor.cpp
@@ -26,6 +26,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int UNKNOWN_IDENTIFIER;
+    extern const int UNSUPPORTED_JOIN_KEYS;
     extern const int LOGICAL_ERROR;
 }
 
@@ -296,7 +297,8 @@ void TranslateQualifiedNamesMatcher::extractJoinUsingColumns(const ASTPtr ast, D
             {
                 String alias = key->tryGetAlias();
                 if (alias.empty())
-                    throw Exception("Logical error: expected identifier or alias, got: " + key->getID(), ErrorCodes::LOGICAL_ERROR);
+                    throw Exception("Wrong key in USING. Expected identifier or alias, got: " + key->getID(),
+                                    ErrorCodes::UNSUPPORTED_JOIN_KEYS);
                 data.join_using_columns.insert(alias);
             }
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix error code for wrong `USING` key. #11373

Closed #11373 