### PR TITLE
Remove assorted synonyms of LOGICAL_ERROR

### DIFF
--- a/src/Access/IAccessStorage.cpp
+++ b/src/Access/IAccessStorage.cpp
@@ -15,6 +15,7 @@ namespace ErrorCodes
     extern const int ACCESS_ENTITY_ALREADY_EXISTS;
     extern const int ACCESS_ENTITY_NOT_FOUND;
     extern const int ACCESS_STORAGE_READONLY;
+    extern const int LOGICAL_ERROR;
 }
 
 

--- a/src/Access/IAccessStorage.cpp
+++ b/src/Access/IAccessStorage.cpp
@@ -12,7 +12,6 @@ namespace DB
 {
 namespace ErrorCodes
 {
-    extern const int BAD_CAST;
     extern const int ACCESS_ENTITY_ALREADY_EXISTS;
     extern const int ACCESS_ENTITY_NOT_FOUND;
     extern const int ACCESS_STORAGE_READONLY;
@@ -403,7 +402,7 @@ void IAccessStorage::throwBadCast(const UUID & id, EntityType type, const String
 {
     throw Exception(
         "ID {" + toString(id) + "}: " + outputEntityTypeAndName(type, name) + " expected to be of type " + toString(required_type),
-        ErrorCodes::BAD_CAST);
+        ErrorCodes::LOGICAL_ERROR);
 }
 
 

--- a/src/AggregateFunctions/AggregateFunctionMLMethod.h
+++ b/src/AggregateFunctions/AggregateFunctionMLMethod.h
@@ -15,7 +15,6 @@ namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
     extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
-    extern const int BAD_CAST;
 }
 
 /**
@@ -381,7 +380,7 @@ public:
         auto * column = typeid_cast<ColumnFloat64 *>(&to);
         if (!column)
             throw Exception("Cast of column of predictions is incorrect. getReturnTypeToPredict must return same value as it is casted to",
-                            ErrorCodes::BAD_CAST);
+                            ErrorCodes::LOGICAL_ERROR);
 
         this->data(place).predict(column->getData(), block, offset, limit, arguments, context);
     }

--- a/src/Common/ErrorCodes.cpp
+++ b/src/Common/ErrorCodes.cpp
@@ -341,7 +341,6 @@ namespace ErrorCodes
     extern const int OUTPUT_IS_NOT_SORTED = 365;
     extern const int SIZES_OF_NESTED_COLUMNS_ARE_INCONSISTENT = 366;
     extern const int TOO_MANY_FETCHES = 367;
-    extern const int BAD_CAST = 368;
     extern const int ALL_REPLICAS_ARE_STALE = 369;
     extern const int DATA_TYPE_CANNOT_BE_USED_IN_TABLES = 370;
     extern const int INCONSISTENT_CLUSTER_DEFINITION = 371;
@@ -398,7 +397,6 @@ namespace ErrorCodes
     extern const int CANNOT_GETTIMEOFDAY = 423;
     extern const int CANNOT_LINK = 424;
     extern const int SYSTEM_ERROR = 425;
-    extern const int NULL_POINTER_DEREFERENCE = 426;
     extern const int CANNOT_COMPILE_REGEXP = 427;
     extern const int UNKNOWN_LOG_LEVEL = 428;
     extern const int FAILED_TO_GETPWUID = 429;
@@ -458,7 +456,6 @@ namespace ErrorCodes
     extern const int TOO_MANY_REDIRECTS = 483;
     extern const int INTERNAL_REDIS_ERROR = 484;
     extern const int SCALAR_ALREADY_EXISTS = 485;
-    extern const int UNKNOWN_SCALAR = 486;
     extern const int CANNOT_GET_CREATE_DICTIONARY_QUERY = 487;
     extern const int UNKNOWN_DICTIONARY = 488;
     extern const int INCORRECT_DICTIONARY_DEFINITION = 489;

--- a/src/Common/ZooKeeper/ZooKeeperHolder.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperHolder.cpp
@@ -5,7 +5,7 @@ namespace DB
 {
     namespace ErrorCodes
     {
-        extern const int NULL_POINTER_DEREFERENCE;
+        extern const int LOGICAL_ERROR;
     }
 }
 
@@ -57,7 +57,7 @@ ZooKeeperHolder::UnstorableZookeeperHandler::UnstorableZookeeperHandler(ZooKeepe
 ZooKeeper * ZooKeeperHolder::UnstorableZookeeperHandler::operator->()
 {
     if (zk_ptr == nullptr)
-        throw DB::Exception(nullptr_exception_message, DB::ErrorCodes::NULL_POINTER_DEREFERENCE);
+        throw DB::Exception(nullptr_exception_message, DB::ErrorCodes::LOGICAL_ERROR);
 
     return zk_ptr.get();
 }
@@ -65,20 +65,20 @@ ZooKeeper * ZooKeeperHolder::UnstorableZookeeperHandler::operator->()
 const ZooKeeper * ZooKeeperHolder::UnstorableZookeeperHandler::operator->() const
 {
     if (zk_ptr == nullptr)
-        throw DB::Exception(nullptr_exception_message, DB::ErrorCodes::NULL_POINTER_DEREFERENCE);
+        throw DB::Exception(nullptr_exception_message, DB::ErrorCodes::LOGICAL_ERROR);
     return zk_ptr.get();
 }
 
 ZooKeeper & ZooKeeperHolder::UnstorableZookeeperHandler::operator*()
 {
     if (zk_ptr == nullptr)
-        throw DB::Exception(nullptr_exception_message, DB::ErrorCodes::NULL_POINTER_DEREFERENCE);
+        throw DB::Exception(nullptr_exception_message, DB::ErrorCodes::LOGICAL_ERROR);
     return *zk_ptr;
 }
 
 const ZooKeeper & ZooKeeperHolder::UnstorableZookeeperHandler::operator*() const
 {
     if (zk_ptr == nullptr)
-        throw DB::Exception(nullptr_exception_message, DB::ErrorCodes::NULL_POINTER_DEREFERENCE);
+        throw DB::Exception(nullptr_exception_message, DB::ErrorCodes::LOGICAL_ERROR);
     return *zk_ptr;
 }

--- a/src/Common/assert_cast.h
+++ b/src/Common/assert_cast.h
@@ -13,7 +13,7 @@ namespace DB
 {
     namespace ErrorCodes
     {
-        extern const int BAD_CAST;
+        extern const int LOGICAL_ERROR;
     }
 }
 
@@ -41,11 +41,11 @@ To assert_cast(From && from)
     }
     catch (const std::exception & e)
     {
-        throw DB::Exception(e.what(), DB::ErrorCodes::BAD_CAST);
+        throw DB::Exception(e.what(), DB::ErrorCodes::LOGICAL_ERROR);
     }
 
     throw DB::Exception("Bad cast from type " + demangle(typeid(from).name()) + " to " + demangle(typeid(To).name()),
-                        DB::ErrorCodes::BAD_CAST);
+                        DB::ErrorCodes::LOGICAL_ERROR);
 #else
     return static_cast<To>(from);
 #endif

--- a/src/Common/typeid_cast.h
+++ b/src/Common/typeid_cast.h
@@ -15,7 +15,7 @@ namespace DB
 {
     namespace ErrorCodes
     {
-        extern const int BAD_CAST;
+        extern const int LOGICAL_ERROR;
     }
 }
 
@@ -34,11 +34,11 @@ std::enable_if_t<std::is_reference_v<To>, To> typeid_cast(From & from)
     }
     catch (const std::exception & e)
     {
-        throw DB::Exception(e.what(), DB::ErrorCodes::BAD_CAST);
+        throw DB::Exception(e.what(), DB::ErrorCodes::LOGICAL_ERROR);
     }
 
     throw DB::Exception("Bad cast from type " + demangle(typeid(from).name()) + " to " + demangle(typeid(To).name()),
-                        DB::ErrorCodes::BAD_CAST);
+                        DB::ErrorCodes::LOGICAL_ERROR);
 }
 
 
@@ -54,7 +54,7 @@ std::enable_if_t<std::is_pointer_v<To>, To> typeid_cast(From * from)
     }
     catch (const std::exception & e)
     {
-        throw DB::Exception(e.what(), DB::ErrorCodes::BAD_CAST);
+        throw DB::Exception(e.what(), DB::ErrorCodes::LOGICAL_ERROR);
     }
 }
 
@@ -71,6 +71,6 @@ std::enable_if_t<ext::is_shared_ptr_v<To>, To> typeid_cast(const std::shared_ptr
     }
     catch (const std::exception & e)
     {
-        throw DB::Exception(e.what(), DB::ErrorCodes::BAD_CAST);
+        throw DB::Exception(e.what(), DB::ErrorCodes::LOGICAL_ERROR);
     }
 }

--- a/src/Functions/bitBoolMaskAnd.cpp
+++ b/src/Functions/bitBoolMaskAnd.cpp
@@ -7,7 +7,7 @@ namespace DB
 {
     namespace ErrorCodes
     {
-        extern const int BAD_CAST;
+        extern const int LOGICAL_ERROR;
     }
 
     /// Working with UInt8: last bit = can be true, previous = can be false (Like src/Storages/MergeTree/BoolMask.h).
@@ -24,7 +24,7 @@ namespace DB
         static inline Result apply(A left, B right)
         {
             if constexpr (!std::is_same_v<A, ResultType> || !std::is_same_v<B, ResultType>)
-                throw DB::Exception("It's a bug! Only UInt8 type is supported by __bitBoolMaskAnd.", ErrorCodes::BAD_CAST);
+                throw DB::Exception("It's a bug! Only UInt8 type is supported by __bitBoolMaskAnd.", ErrorCodes::LOGICAL_ERROR);
             return static_cast<ResultType>(
                     ((static_cast<ResultType>(left) & static_cast<ResultType>(right)) & 1)
                     | ((((static_cast<ResultType>(left) >> 1) | (static_cast<ResultType>(right) >> 1)) & 1) << 1));

--- a/src/Functions/bitBoolMaskOr.cpp
+++ b/src/Functions/bitBoolMaskOr.cpp
@@ -7,7 +7,7 @@ namespace DB
 {
     namespace ErrorCodes
     {
-        extern const int BAD_CAST;
+        extern const int LOGICAL_ERROR;
     }
 
     /// Working with UInt8: last bit = can be true, previous = can be false (Like src/Storages/MergeTree/BoolMask.h).
@@ -24,7 +24,7 @@ namespace DB
         static inline Result apply(A left, B right)
         {
             if constexpr (!std::is_same_v<A, ResultType> || !std::is_same_v<B, ResultType>)
-                throw DB::Exception("It's a bug! Only UInt8 type is supported by __bitBoolMaskOr.", ErrorCodes::BAD_CAST);
+                throw DB::Exception("It's a bug! Only UInt8 type is supported by __bitBoolMaskOr.", ErrorCodes::LOGICAL_ERROR);
             return static_cast<ResultType>(
                     ((static_cast<ResultType>(left) | static_cast<ResultType>(right)) & 1)
                     | ((((static_cast<ResultType>(left) >> 1) & (static_cast<ResultType>(right) >> 1)) & 1) << 1));

--- a/src/Functions/bitSwapLastTwo.cpp
+++ b/src/Functions/bitSwapLastTwo.cpp
@@ -7,7 +7,6 @@ namespace DB
     namespace ErrorCodes
     {
         extern const int LOGICAL_ERROR;
-        extern const int BAD_CAST;
     }
 
     /// Working with UInt8: last bit = can be true, previous = can be false (Like src/Storages/MergeTree/BoolMask.h).
@@ -21,7 +20,7 @@ namespace DB
         static inline ResultType NO_SANITIZE_UNDEFINED apply(A a)
         {
             if constexpr (!std::is_same_v<A, ResultType>)
-                throw DB::Exception("It's a bug! Only UInt8 type is supported by __bitSwapLastTwo.", ErrorCodes::BAD_CAST);
+                throw DB::Exception("It's a bug! Only UInt8 type is supported by __bitSwapLastTwo.", ErrorCodes::LOGICAL_ERROR);
             return static_cast<ResultType>(
                     ((static_cast<ResultType>(a) & 1) << 1) | ((static_cast<ResultType>(a) >> 1) & 1));
         }

--- a/src/Functions/bitWrapperFunc.cpp
+++ b/src/Functions/bitWrapperFunc.cpp
@@ -6,7 +6,7 @@ namespace DB
 {
     namespace ErrorCodes
     {
-        extern const int BAD_CAST;
+        extern const int LOGICAL_ERROR;
     }
 
     /// Working with UInt8: last bit = can be true, previous = can be false (Like src/Storages/MergeTree/BoolMask.h).
@@ -21,7 +21,7 @@ namespace DB
         static inline ResultType NO_SANITIZE_UNDEFINED apply(A a)
         {
             if constexpr (!is_integral_v<A>)
-                throw DB::Exception("It's a bug! Only integer types are supported by __bitWrapperFunc.", ErrorCodes::BAD_CAST);
+                throw DB::Exception("It's a bug! Only integer types are supported by __bitWrapperFunc.", ErrorCodes::LOGICAL_ERROR);
             return a == 0 ? static_cast<ResultType>(0b10) : static_cast<ResultType >(0b1);
         }
 

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -101,7 +101,6 @@ namespace ErrorCodes
     extern const int SESSION_NOT_FOUND;
     extern const int SESSION_IS_LOCKED;
     extern const int LOGICAL_ERROR;
-    extern const int UNKNOWN_SCALAR;
     extern const int AUTHENTICATION_FAILED;
     extern const int NOT_IMPLEMENTED;
 }
@@ -821,7 +820,7 @@ const Block & Context::getScalar(const String & name) const
 {
     auto it = scalars.find(name);
     if (scalars.end() == it)
-        throw Exception("Scalar " + backQuoteIfNeed(name) + " doesn't exist (internal bug)", ErrorCodes::UNKNOWN_SCALAR);
+        throw Exception("Scalar " + backQuoteIfNeed(name) + " doesn't exist (internal bug)", ErrorCodes::LOGICAL_ERROR);
     return it->second;
 }
 

--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -25,7 +25,6 @@ namespace ErrorCodes
     extern const int DATABASE_NOT_EMPTY;
     extern const int DATABASE_ACCESS_DENIED;
     extern const int LOGICAL_ERROR;
-    extern const int NULL_POINTER_DEREFERENCE;
 }
 
 TemporaryTableHolder::TemporaryTableHolder(const Context & context_,
@@ -389,34 +388,40 @@ DatabaseCatalog::DatabaseCatalog(Context * global_context_)
     : global_context(global_context_), log(&Poco::Logger::get("DatabaseCatalog"))
 {
     if (!global_context)
-        throw Exception("DatabaseCatalog is not initialized. It's a bug.", ErrorCodes::NULL_POINTER_DEREFERENCE);
+        throw Exception("DatabaseCatalog is not initialized. It's a bug.", ErrorCodes::LOGICAL_ERROR);
 }
 
 DatabaseCatalog & DatabaseCatalog::init(Context * global_context_)
 {
-    static DatabaseCatalog database_catalog(global_context_);
-    return database_catalog;
+    if (database_catalog)
+    {
+        throw Exception("Database catalog is initialized twice. This is a bug.\n",
+            ErrorCodes::LOGICAL_ERROR);
+    }
+
+    database_catalog.reset(new DatabaseCatalog(global_context_));
+
+    return *database_catalog;
 }
 
 DatabaseCatalog & DatabaseCatalog::instance()
 {
-    return init(nullptr);
+    if (!database_catalog)
+    {
+        throw Exception("Database catalog is not initialized. This is a bug.\n",
+            ErrorCodes::LOGICAL_ERROR);
+    }
+
+    return *database_catalog;
 }
 
 void DatabaseCatalog::shutdown()
 {
-    try
+    // The catalog might not be initialized yet by init(global_context). It can
+    // happen if some exception was thrown on first steps of startup.
+    if (database_catalog)
     {
-        instance().shutdownImpl();
-    }
-    catch (const Exception & e)
-    {
-        /// If catalog was not initialized yet by init(global_context), instance() throws NULL_POINTER_DEREFERENCE.
-        /// It can happen if some exception was thrown on first steps of startup (e.g. command line arguments parsing).
-        /// Ignore it.
-        if (e.code() == ErrorCodes::NULL_POINTER_DEREFERENCE)
-            return;
-        throw;
+        database_catalog->shutdownImpl();
     }
 }
 

--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -384,6 +384,8 @@ void DatabaseCatalog::updateUUIDMapping(const UUID & uuid, DatabasePtr database,
     it->second = std::make_pair(std::move(database), std::move(table));
 }
 
+std::unique_ptr<DatabaseCatalog> DatabaseCatalog::database_catalog;
+
 DatabaseCatalog::DatabaseCatalog(Context * global_context_)
     : global_context(global_context_), log(&Poco::Logger::get("DatabaseCatalog"))
 {

--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -410,7 +410,7 @@ DatabaseCatalog & DatabaseCatalog::instance()
 {
     if (!database_catalog)
     {
-        throw Exception("Database catalog is not initialized. This is a bug.\n",
+        throw Exception("Database catalog is not initialized. This is a bug.",
             ErrorCodes::LOGICAL_ERROR);
     }
 
@@ -731,4 +731,3 @@ DDLGuard::~DDLGuard()
 }
 
 }
-

--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -397,7 +397,7 @@ DatabaseCatalog & DatabaseCatalog::init(Context * global_context_)
 {
     if (database_catalog)
     {
-        throw Exception("Database catalog is initialized twice. This is a bug.\n",
+        throw Exception("Database catalog is initialized twice. This is a bug.",
             ErrorCodes::LOGICAL_ERROR);
     }
 
@@ -731,5 +731,4 @@ DDLGuard::~DDLGuard()
 }
 
 }
-
 

--- a/src/Interpreters/DatabaseCatalog.h
+++ b/src/Interpreters/DatabaseCatalog.h
@@ -169,6 +169,11 @@ public:
     void enqueueDroppedTableCleanup(StorageID table_id, StoragePtr table, String dropped_metadata_path, bool ignore_delay = false);
 
 private:
+    // The global instance of database catalog. unique_ptr is to allow
+    // deferred initialization. Thought I'd use std::optional, but I can't
+    // make emplace(global_context_) compile with private constructor ¯\_(ツ)_/¯.
+    static std::unique_ptr<DatabaseCatalog> database_catalog;
+
     DatabaseCatalog(Context * global_context_);
     void assertDatabaseExistsUnlocked(const String & database_name) const;
     void assertDatabaseDoesntExistUnlocked(const String & database_name) const;

--- a/src/Storages/tests/gtest_transform_query_for_external_database.cpp
+++ b/src/Storages/tests/gtest_transform_query_for_external_database.cpp
@@ -27,23 +27,26 @@ struct State
         {"create_time", std::make_shared<DataTypeDateTime>()},
     };
 
+    static const State & instance()
+    {
+        static State state;
+        return state;
+    }
+
+private:
     explicit State()
         : context(getContext().context)
     {
         registerFunctions();
         DatabasePtr database = std::make_shared<DatabaseMemory>("test", context);
         database->attachTable("table", StorageMemory::create(StorageID("test", "table"), ColumnsDescription{columns}, ConstraintsDescription{}));
-        context.makeGlobalContext();
         DatabaseCatalog::instance().attachDatabase("test", database);
         context.setCurrentDatabase("test");
     }
+
+    State(const State&) = delete;
 };
 
-State getState()
-{
-    static State state;
-    return state;
-}
 
 static void check(const std::string & query, const std::string & expected, const Context & context, const NamesAndTypesList & columns)
 {
@@ -60,7 +63,7 @@ static void check(const std::string & query, const std::string & expected, const
 
 TEST(TransformQueryForExternalDatabase, InWithSingleElement)
 {
-    const State & state = getState();
+    const State & state = State::instance();
 
     check("SELECT column FROM test.table WHERE 1 IN (1)",
           R"(SELECT "column" FROM "test"."table" WHERE 1)",
@@ -75,7 +78,7 @@ TEST(TransformQueryForExternalDatabase, InWithSingleElement)
 
 TEST(TransformQueryForExternalDatabase, Like)
 {
-    const State & state = getState();
+    const State & state = State::instance();
 
     check("SELECT column FROM test.table WHERE column LIKE '%hello%'",
           R"(SELECT "column" FROM "test"."table" WHERE "column" LIKE '%hello%')",
@@ -87,7 +90,7 @@ TEST(TransformQueryForExternalDatabase, Like)
 
 TEST(TransformQueryForExternalDatabase, Substring)
 {
-    const State & state = getState();
+    const State & state = State::instance();
 
     check("SELECT column FROM test.table WHERE left(column, 10) = RIGHT(column, 10) AND SUBSTRING(column FROM 1 FOR 2) = 'Hello'",
           R"(SELECT "column" FROM "test"."table")",
@@ -96,7 +99,7 @@ TEST(TransformQueryForExternalDatabase, Substring)
 
 TEST(TransformQueryForExternalDatabase, MultipleAndSubqueries)
 {
-    const State & state = getState();
+    const State & state = State::instance();
 
     check("SELECT column FROM test.table WHERE 1 = 1 AND toString(column) = '42' AND column = 42 AND left(column, 10) = RIGHT(column, 10) AND column IN (1, 42) AND SUBSTRING(column FROM 1 FOR 2) = 'Hello' AND column != 4",
           R"(SELECT "column" FROM "test"."table" WHERE 1 AND ("column" = 42) AND ("column" IN (1, 42)) AND ("column" != 4))",
@@ -108,7 +111,7 @@ TEST(TransformQueryForExternalDatabase, MultipleAndSubqueries)
 
 TEST(TransformQueryForExternalDatabase, Issue7245)
 {
-    const State & state = getState();
+    const State & state = State::instance();
 
     check("select apply_id from test.table where apply_type = 2 and create_time > addDays(toDateTime('2019-01-01 01:02:03'),-7) and apply_status in (3,4)",
           R"(SELECT "apply_id", "apply_type", "apply_status", "create_time" FROM "test"."table" WHERE ("apply_type" = 2) AND ("create_time" > '2018-12-25 01:02:03') AND ("apply_status" IN (3, 4)))",

--- a/src/Storages/tests/gtest_transform_query_for_external_database.cpp
+++ b/src/Storages/tests/gtest_transform_query_for_external_database.cpp
@@ -18,6 +18,8 @@ using namespace DB;
 /// NOTE How to do better?
 struct State
 {
+    State(const State&) = delete;
+
     Context context;
     NamesAndTypesList columns{
         {"column", std::make_shared<DataTypeUInt8>()},
@@ -43,8 +45,6 @@ private:
         DatabaseCatalog::instance().attachDatabase("test", database);
         context.setCurrentDatabase("test");
     }
-
-    State(const State&) = delete;
 };
 
 


### PR DESCRIPTION
We don't need any special handling for them on the client, and, on the
contrary, have to handle them as logical errors in tests.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


@tavplubix please take a look at the DatabaseCatalog part. When some state (in this case, a non-initialized catalog) is valid and expected to occur, it's better to represent this state explicitly, instead of using some trick to detect it indirectly.