### PR TITLE
ON CLUSTER support for SYSTEM {FLUSH DISTRIBUTED,STOP/START DISTRIBUTED SENDS}

### DIFF
--- a/src/Parsers/ParserSystemQuery.cpp
+++ b/src/Parsers/ParserSystemQuery.cpp
@@ -59,10 +59,25 @@ bool ParserSystemQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expected & 
 
         case Type::RESTART_REPLICA:
         case Type::SYNC_REPLICA:
-        case Type::FLUSH_DISTRIBUTED:
             if (!parseDatabaseAndTableName(pos, expected, res->database, res->table))
                 return false;
             break;
+
+        case Type::STOP_DISTRIBUTED_SENDS:
+        case Type::START_DISTRIBUTED_SENDS:
+        case Type::FLUSH_DISTRIBUTED:
+        {
+            String cluster_str;
+            if (ParserKeyword{"ON"}.ignore(pos, expected))
+            {
+                if (!ASTQueryWithOnCluster::parse(pos, cluster_str, expected))
+                    return false;
+            }
+            res->cluster = cluster_str;
+            if (!parseDatabaseAndTableName(pos, expected, res->database, res->table))
+                return false;
+            break;
+        }
 
         case Type::STOP_MERGES:
         case Type::START_MERGES:
@@ -76,8 +91,6 @@ bool ParserSystemQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expected & 
         case Type::START_REPLICATED_SENDS:
         case Type::STOP_REPLICATION_QUEUES:
         case Type::START_REPLICATION_QUEUES:
-        case Type::STOP_DISTRIBUTED_SENDS:
-        case Type::START_DISTRIBUTED_SENDS:
             parseDatabaseAndTableName(pos, expected, res->database, res->table);
             break;
 

--- a/src/Parsers/ParserSystemQuery.cpp
+++ b/src/Parsers/ParserSystemQuery.cpp
@@ -75,7 +75,12 @@ bool ParserSystemQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expected & 
             }
             res->cluster = cluster_str;
             if (!parseDatabaseAndTableName(pos, expected, res->database, res->table))
-                return false;
+            {
+                /// FLUSH DISTRIBUTED requires table
+                /// START/STOP DISTRIBUTED SENDS does not requires table
+                if (res->type == Type::FLUSH_DISTRIBUTED)
+                    return false;
+            }
             break;
         }
 

--- a/tests/queries/0_stateless/01294_system_distributed_on_cluster.reference
+++ b/tests/queries/0_stateless/01294_system_distributed_on_cluster.reference
@@ -1,0 +1,3 @@
+localhost	9000	0		0	0
+localhost	9000	0		0	0
+localhost	9000	0		0	0

--- a/tests/queries/0_stateless/01294_system_distributed_on_cluster.sql
+++ b/tests/queries/0_stateless/01294_system_distributed_on_cluster.sql
@@ -10,9 +10,11 @@ create table db_01294.dist_01294 as system.one engine=Distributed(test_shard_loc
 system flush distributed db_01294.dist_01294;
 system flush distributed on cluster test_shard_localhost db_01294.dist_01294;
 -- stop
+system stop distributed sends;
 system stop distributed sends db_01294.dist_01294;
 system stop distributed sends on cluster test_shard_localhost db_01294.dist_01294;
 -- start
+system start distributed sends;
 system start distributed sends db_01294.dist_01294;
 system start distributed sends on cluster test_shard_localhost db_01294.dist_01294;
 

--- a/tests/queries/0_stateless/01294_system_distributed_on_cluster.sql
+++ b/tests/queries/0_stateless/01294_system_distributed_on_cluster.sql
@@ -1,15 +1,19 @@
 -- just a smoke test
 
-drop table if exists dist_01294;
-create table dist_01294 as system.one engine=Distributed(test_shard_localhost, system, one);
--- flush
-system flush distributed dist_01294;
-system flush distributed on cluster test_shard_localhost dist_01294;
--- stop
-system stop distributed sends dist_01294;
-system stop distributed sends on cluster test_shard_localhost dist_01294;
--- start
-system start distributed sends dist_01294;
-system start distributed sends on cluster test_shard_localhost dist_01294;
+-- quirk for ON CLUSTER does not uses currentDatabase()
+drop database if exists db_01294;
+create database db_01294;
 
-drop table dist_01294;
+drop table if exists db_01294.dist_01294;
+create table db_01294.dist_01294 as system.one engine=Distributed(test_shard_localhost, system, one);
+-- flush
+system flush distributed db_01294.dist_01294;
+system flush distributed on cluster test_shard_localhost db_01294.dist_01294;
+-- stop
+system stop distributed sends db_01294.dist_01294;
+system stop distributed sends on cluster test_shard_localhost db_01294.dist_01294;
+-- start
+system start distributed sends db_01294.dist_01294;
+system start distributed sends on cluster test_shard_localhost db_01294.dist_01294;
+
+drop database db_01294;

--- a/tests/queries/0_stateless/01294_system_distributed_on_cluster.sql
+++ b/tests/queries/0_stateless/01294_system_distributed_on_cluster.sql
@@ -1,0 +1,15 @@
+-- just a smoke test
+
+drop table if exists dist_01294;
+create table dist_01294 as system.one engine=Distributed(test_shard_localhost, system, one);
+-- flush
+system flush distributed dist_01294;
+system flush distributed on cluster test_shard_localhost dist_01294;
+-- stop
+system stop distributed sends dist_01294;
+system stop distributed sends on cluster test_shard_localhost dist_01294;
+-- start
+system start distributed sends dist_01294;
+system start distributed sends on cluster test_shard_localhost dist_01294;
+
+drop table dist_01294;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
ON CLUSTER support for SYSTEM {FLUSH DISTRIBUTED,STOP/START DISTRIBUTED SEND}

Detailed description / Documentation draft:
It is pretty logical to have ON CLUSTER for managing Distributed tables.
