### PR TITLE
Return lost comments and default values

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -103,6 +103,7 @@ public:
     virtual ~IMergeTreeDataPart();
 
     using ColumnToSize = std::map<std::string, UInt64>;
+    /// Populates columns_to_size map (compressed size).
     void accumulateColumnSizes(ColumnToSize & /* column_to_size */) const;
 
     Type getType() const { return part_type; }
@@ -113,6 +114,7 @@ public:
 
     const NamesAndTypesList & getColumns() const { return columns; }
 
+    /// Throws an exception if part is not stored in on-disk format.
     void assertOnDisk() const;
 
     void remove() const;
@@ -153,6 +155,8 @@ public:
 
     DiskPtr disk;
 
+    /// A directory path (relative to storage's path) where part data is actually stored
+    /// Examples: 'detached/tmp_fetch_<name>', 'tmp_<name>', '<name>'
     mutable String relative_path;
     MergeTreeIndexGranularityInfo index_granularity_info;
 
@@ -282,10 +286,21 @@ public:
     void setBytesOnDisk(UInt64 bytes_on_disk_) { bytes_on_disk = bytes_on_disk_; }
 
     size_t getFileSizeOrZero(const String & file_name) const;
+
+    /// Returns path to part dir relatively to disk mount point
     String getFullRelativePath() const;
+
+    /// Returns full path to part dir
     String getFullPath() const;
-    void renameTo(const String & new_relative_path, bool remove_new_dir_if_exists = false) const;
+
+    /// Makes checks and move part to new directory
+    /// Changes only relative_dir_name, you need to update other metadata (name, is_temp) explicitly
+    void renameTo(const String & new_relative_path, bool remove_new_dir_if_exists = true) const;
+
+    /// Moves a part to detached/ directory and adds prefix to its name
     void renameToDetached(const String & prefix) const;
+
+    /// Makes clone of a part in detached/ directory via hard links
     void makeCloneInDetached(const String & prefix) const;
 
     /// Makes full clone of part in detached/ on another disk
@@ -294,6 +309,7 @@ public:
     /// Checks that .bin and .mrk files exist
     virtual bool hasColumnFiles(const String & /* column */, const IDataType & /* type */) const{ return false; }
 
+    /// Calculate the total size of the entire directory with all the files
     static UInt64 calculateTotalSizeOnDisk(const DiskPtr & disk_, const String & from);
     void calculateColumnsSizesOnDisk();
 
@@ -346,6 +362,7 @@ private:
 
     void loadPartitionAndMinMaxIndex();
 
+    /// Generate unique path to detach part
     String getRelativePathForDetachedPart(const String & prefix) const;
 };
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

They were accidantly lost by refactoring in b433add.