### PR TITLE
Rename setting

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -411,7 +411,7 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingBool, enable_scalar_subquery_optimization, true, "If it is set to true, prevent scalar subqueries from (de)serializing large scalar values and possibly avoid running the same subquery more than once.", 0) \
     M(SettingBool, optimize_trivial_count_query, true, "Process trivial 'SELECT count() FROM table' query from metadata.", 0) \
     M(SettingUInt64, mutations_sync, 0, "Wait for synchronous execution of ALTER TABLE UPDATE/DELETE queries (mutations). 0 - execute asynchronously. 1 - wait current server. 2 - wait all replicas if they exist.", 0) \
-    M(SettingBool, optimize_ast_arithmetic, true, "Optimize arithmetic operations at AST layer: rewrite operations with faster ones if possible.", 0) \
+    M(SettingBool, optimize_arithmetic_operations_in_aggregate_functions, true, "Move arithmetic operations out of aggregation functions", 0) \
     M(SettingBool, optimize_if_chain_to_miltiif, false, "Replace if(cond1, then1, if(cond2, ...)) chains to multiIf. Currently it's not beneficial for numeric types.", 0) \
     M(SettingBool, allow_experimental_alter_materialized_view_structure, false, "Allow atomic alter on Materialized views. Work in progress.", 0) \
     M(SettingBool, enable_early_constant_folding, true, "Enable query optimization where we analyze function and subqueries results and rewrite query if there're constants there", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -411,7 +411,7 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingBool, enable_scalar_subquery_optimization, true, "If it is set to true, prevent scalar subqueries from (de)serializing large scalar values and possibly avoid running the same subquery more than once.", 0) \
     M(SettingBool, optimize_trivial_count_query, true, "Process trivial 'SELECT count() FROM table' query from metadata.", 0) \
     M(SettingUInt64, mutations_sync, 0, "Wait for synchronous execution of ALTER TABLE UPDATE/DELETE queries (mutations). 0 - execute asynchronously. 1 - wait current server. 2 - wait all replicas if they exist.", 0) \
-    M(SettingBool, optimize_arithmetic_operations_in_agr_func, true, "Removing arithmetic operations from aggregation functions", 0) \
+    M(SettingBool, optimize_ast_arithmetic, true, "Optimize arithmetic operations at AST layer: rewrite operations with faster ones if possible.", 0) \
     M(SettingBool, optimize_if_chain_to_miltiif, false, "Replace if(cond1, then1, if(cond2, ...)) chains to multiIf. Currently it's not beneficial for numeric types.", 0) \
     M(SettingBool, allow_experimental_alter_materialized_view_structure, false, "Allow atomic alter on Materialized views. Work in progress.", 0) \
     M(SettingBool, enable_early_constant_folding, true, "Enable query optimization where we analyze function and subqueries results and rewrite query if there're constants there", 0) \

--- a/src/Interpreters/SyntaxAnalyzer.cpp
+++ b/src/Interpreters/SyntaxAnalyzer.cpp
@@ -822,7 +822,8 @@ SyntaxAnalyzerResultPtr SyntaxAnalyzer::analyzeSelect(
     {
         optimizeIf(query, result.aliases, settings.optimize_if_chain_to_miltiif);
 
-        optimizeArithmeticOperationsInAgr(query, settings.optimize_arithmetic_operations_in_agr_func);
+        /// Move arithmetic operations out of aggregation functions
+        optimizeArithmeticOperationsInAgr(query, settings.optimize_ast_arithmetic);
 
         /// Push the predicate expression down to the subqueries.
         result.rewrite_subqueries = PredicateExpressionsOptimizer(context, tables_with_column_names, settings).optimize(*select_query);

--- a/src/Interpreters/SyntaxAnalyzer.cpp
+++ b/src/Interpreters/SyntaxAnalyzer.cpp
@@ -823,7 +823,7 @@ SyntaxAnalyzerResultPtr SyntaxAnalyzer::analyzeSelect(
         optimizeIf(query, result.aliases, settings.optimize_if_chain_to_miltiif);
 
         /// Move arithmetic operations out of aggregation functions
-        optimizeArithmeticOperationsInAgr(query, settings.optimize_ast_arithmetic);
+        optimizeArithmeticOperationsInAgr(query, settings.optimize_arithmetic_operations_in_aggregate_functions);
 
         /// Push the predicate expression down to the subqueries.
         result.rewrite_subqueries = PredicateExpressionsOptimizer(context, tables_with_column_names, settings).optimize(*select_query);

--- a/tests/queries/0_stateless/01271_optimize_arithmetic_operations_in_aggr_func.sql
+++ b/tests/queries/0_stateless/01271_optimize_arithmetic_operations_in_aggr_func.sql
@@ -1,10 +1,10 @@
-set optimize_ast_arithmetic = 1;
+set optimize_arithmetic_operations_in_aggregate_functions = 1;
 
 SELECT sum(number * -3) + min(2 * number * -3) - max(-1 * -2 * number * -3) FROM numbers(10000000);
 SELECT max(log(2) * number) FROM numbers(10000000);
 SELECT round(max(log(2) * 3 * sin(0.3) * number * 4)) FROM numbers(10000000);
 
-set optimize_ast_arithmetic = 0;
+set optimize_arithmetic_operations_in_aggregate_functions = 0;
 
 SELECT sum(number * -3) + min(2 * number * -3) - max(-1 * -2 * number * -3) FROM numbers(10000000);
 SELECT max(log(2) * number) FROM numbers(10000000);

--- a/tests/queries/0_stateless/01271_optimize_arithmetic_operations_in_aggr_func.sql
+++ b/tests/queries/0_stateless/01271_optimize_arithmetic_operations_in_aggr_func.sql
@@ -1,9 +1,11 @@
-set optimize_arithmetic_operations_in_agr_func = 1;
+set optimize_ast_arithmetic = 1;
+
 SELECT sum(number * -3) + min(2 * number * -3) - max(-1 * -2 * number * -3) FROM numbers(10000000);
 SELECT max(log(2) * number) FROM numbers(10000000);
 SELECT round(max(log(2) * 3 * sin(0.3) * number * 4)) FROM numbers(10000000);
 
-set optimize_arithmetic_operations_in_agr_func = 0;
+set optimize_ast_arithmetic = 0;
+
 SELECT sum(number * -3) + min(2 * number * -3) - max(-1 * -2 * number * -3) FROM numbers(10000000);
 SELECT max(log(2) * number) FROM numbers(10000000);
 SELECT round(max(log(2) * 3 * sin(0.3) * number * 4)) FROM numbers(10000000);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Rename `optimize_arithmetic_operations_in_agr_func`
