### PR TITLE
Added a check for incorrect settings

### DIFF
--- a/docker/test/performance-comparison/config/config.d/perf-comparison-tweaks-config.xml
+++ b/docker/test/performance-comparison/config/config.d/perf-comparison-tweaks-config.xml
@@ -19,6 +19,5 @@
         <collect_interval_milliseconds>1000</collect_interval_milliseconds>
     </metric_log>
 
-    <use_uncompressed_cache>0</use_uncompressed_cache>
     <uncompressed_cache_size>1000000000</uncompressed_cache_size>
 </yandex>

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -246,9 +246,14 @@ void checkForUsersNotInMainConfig(
         return;
 
     if (config.has("users") || config.has("profiles") || config.has("quotas"))
+    {
+        /// We cannot throw exception here, because we have support for obsolete 'conf.d' directory
+        /// (that does not correspond to config.d or users.d) but substitute configuration to both of them.
+
         LOG_ERROR(log, "The <users>, <profiles> and <quotas> elements should be located in users config file: {} not in main config {}."
             " Also note that you should place configuration changes to the appropriate *.d directory like 'users.d'.",
             users_config_path, config_path);
+    }
 }
 
 

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <!--
   NOTE: User and query level settings are set up in "users.xml" file.
+  If you have accidentially specified user-level settings here, server won't start.
+  You can either move the settings to the right place inside "users.xml" file
+   or add <skip_check_for_incorrect_settings>1</skip_check_for_incorrect_settings> here.
 -->
 <yandex>
     <logger>


### PR DESCRIPTION
Changelog category (leave one):
- Backward incompatible change


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added a check for the case when user-level setting is specified in a wrong place. User-level settings should be specified in `users.xml` inside `<profile>` section for specific user profile (or in `<default>` for default settings). The server won't start with exception message in log. This fixes #9051. If you want to skip the check, you can either move settings to the appropriate place or add `<skip_check_for_incorrect_settings>1</skip_check_for_incorrect_settings>` to config.xml.