### PR TITLE
Save history on every query in clickhouse-client

### DIFF
--- a/base/common/ReplxxLineReader.cpp
+++ b/base/common/ReplxxLineReader.cpp
@@ -70,6 +70,11 @@ ReplxxLineReader::ReplxxLineReader(
 
 ReplxxLineReader::~ReplxxLineReader()
 {
+    errno = 0;
+    if (close(history_file_fd))
+    {
+        rx.print("Close of history file failed: %s\n", strerror(errno));
+    }
 }
 
 LineReader::InputStatus ReplxxLineReader::readOneLine(const String & prompt)

--- a/base/common/ReplxxLineReader.cpp
+++ b/base/common/ReplxxLineReader.cpp
@@ -26,24 +26,26 @@ ReplxxLineReader::ReplxxLineReader(
 
     if (!history_file_path.empty())
     {
-        errno = 0;
         history_file_fd = open(history_file_path.c_str(), O_RDWR);
         if (history_file_fd < 0)
         {
             rx.print("Open of history file failed: %s\n", strerror(errno));
         }
-
-        errno = 0;
-        if (flock(history_file_fd, LOCK_SH))
+        else
         {
-            rx.print("Shared lock of history file failed: %s\n", strerror(errno));
-        }
-        rx.history_load(history_file_path);
+            if (flock(history_file_fd, LOCK_SH))
+            {
+                rx.print("Shared lock of history file failed: %s\n", strerror(errno));
+            }
+            else
+            {
+                rx.history_load(history_file_path);
 
-        errno = 0;
-        if (flock(history_file_fd, LOCK_UN))
-        {
-            rx.print("Unlock of history file failed: %s\n", strerror(errno));
+                if (flock(history_file_fd, LOCK_UN))
+                {
+                    rx.print("Unlock of history file failed: %s\n", strerror(errno));
+                }
+            }
         }
     }
 

--- a/base/common/ReplxxLineReader.h
+++ b/base/common/ReplxxLineReader.h
@@ -17,4 +17,7 @@ private:
     void addToHistory(const String & line) override;
 
     replxx::Replxx rx;
+
+    // used to call flock() to synchronize multiple clients using same history file
+    int history_file_fd = -1;
 };


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Now history file is updated after each query and there is no race condition if multiple clients use one history file. This fixes #9897.


Detailed description / Documentation draft:

Now history file is updated after each query. There is no race condition if multiple clients use one history file because before writing to file `flock()` is called.
