### PR TITLE
Fix Pipeline stuck for INSERT SELECT FINAL

### DIFF
--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -209,10 +209,7 @@ BlockIO InterpreterInsertQuery::execute()
             if (table->supportsParallelInsert() && settings.max_insert_threads > 1)
                 out_streams_size = std::min(size_t(settings.max_insert_threads), res.pipeline.getNumStreams());
 
-            if (out_streams_size == 1)
-                res.pipeline.addPipe({std::make_shared<ConcatProcessor>(res.pipeline.getHeader(), res.pipeline.getNumStreams())});
-            else
-                res.pipeline.resize(out_streams_size);
+            res.pipeline.resize(out_streams_size);
         }
         else if (query.watch)
         {

--- a/src/Processors/ConcatProcessor.cpp
+++ b/src/Processors/ConcatProcessor.cpp
@@ -9,12 +9,6 @@ ConcatProcessor::ConcatProcessor(const Block & header, size_t num_inputs)
 {
 }
 
-void ConcatProcessor::prepareInitializeInputs()
-{
-    for (auto & input : inputs)
-        input.setNeeded();
-}
-
 ConcatProcessor::Status ConcatProcessor::prepare()
 {
     auto & output = outputs.front();
@@ -52,12 +46,6 @@ ConcatProcessor::Status ConcatProcessor::prepare()
     }
 
     auto & input = *current_input;
-
-    if (!is_initialized)
-    {
-        prepareInitializeInputs();
-        is_initialized = true;
-    }
 
     input.setNeeded();
 

--- a/src/Processors/ConcatProcessor.cpp
+++ b/src/Processors/ConcatProcessor.cpp
@@ -4,6 +4,17 @@
 namespace DB
 {
 
+ConcatProcessor::ConcatProcessor(const Block & header, size_t num_inputs)
+    : IProcessor(InputPorts(num_inputs, header), OutputPorts{header}), current_input(inputs.begin())
+{
+}
+
+void ConcatProcessor::prepareInitializeInputs()
+{
+    for (auto & input : inputs)
+        input.setNeeded();
+}
+
 ConcatProcessor::Status ConcatProcessor::prepare()
 {
     auto & output = outputs.front();
@@ -41,6 +52,12 @@ ConcatProcessor::Status ConcatProcessor::prepare()
     }
 
     auto & input = *current_input;
+
+    if (!is_initialized)
+    {
+        prepareInitializeInputs();
+        is_initialized = true;
+    }
 
     input.setNeeded();
 

--- a/src/Processors/ConcatProcessor.h
+++ b/src/Processors/ConcatProcessor.h
@@ -26,9 +26,6 @@ public:
 
 private:
     InputPorts::iterator current_input;
-
-    bool is_initialized = false;
-    void prepareInitializeInputs();
 };
 
 }

--- a/src/Processors/ConcatProcessor.h
+++ b/src/Processors/ConcatProcessor.h
@@ -16,10 +16,7 @@ namespace DB
 class ConcatProcessor : public IProcessor
 {
 public:
-    ConcatProcessor(const Block & header, size_t num_inputs)
-        : IProcessor(InputPorts(num_inputs, header), OutputPorts{header}), current_input(inputs.begin())
-    {
-    }
+    ConcatProcessor(const Block & header, size_t num_inputs);
 
     String getName() const override { return "Concat"; }
 
@@ -29,6 +26,9 @@ public:
 
 private:
     InputPorts::iterator current_input;
+
+    bool is_initialized = false;
+    void prepareInitializeInputs();
 };
 
 }

--- a/tests/queries/0_stateless/01296_pipeline_stuck.reference
+++ b/tests/queries/0_stateless/01296_pipeline_stuck.reference
@@ -1,0 +1,13 @@
+1
+INSERT SELECT
+1
+1
+INSERT SELECT max_threads
+1
+1
+1
+INSERT SELECT max_insert_threads max_threads
+1
+1
+1
+1

--- a/tests/queries/0_stateless/01296_pipeline_stuck.sql
+++ b/tests/queries/0_stateless/01296_pipeline_stuck.sql
@@ -1,0 +1,18 @@
+drop table if exists data_01295;
+create table data_01295 (key Int) Engine=AggregatingMergeTree() order by key;
+
+insert into data_01295 values (1);
+select * from data_01295;
+
+select 'INSERT SELECT';
+insert into data_01295 select * from data_01295; -- no stuck for now
+select * from data_01295;
+
+select 'INSERT SELECT max_threads';
+insert into data_01295 select * from data_01295 final settings max_threads=2; -- stuck with multiple threads
+select * from data_01295;
+
+select 'INSERT SELECT max_insert_threads max_threads';
+set max_insert_threads=2;
+insert into data_01295 select * from data_01295 final settings max_threads=2; -- no stuck for now
+select * from data_01295;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `Pipeline stuck` exception for `INSERT SELECT FINAL` where `SELECT` (`max_threads`>1) has multiple streams but `INSERT` has only one (`max_insert_threads`==0)

Cc: @KochetovNicolai (please take a look)