### PR TITLE
Complete dictionary names (declared via configuration files) in clickhouse-client

### DIFF
--- a/programs/client/Suggest.cpp
+++ b/programs/client/Suggest.cpp
@@ -114,6 +114,8 @@ void Suggest::loadImpl(Connection & connection, const ConnectionTimeouts & timeo
             << " UNION ALL "
             "SELECT DISTINCT name FROM system.tables LIMIT " << limit_str
             << " UNION ALL "
+            "SELECT DISTINCT name FROM system.dictionaries LIMIT " << limit_str
+            << " UNION ALL "
             "SELECT DISTINCT name FROM system.columns LIMIT " << limit_str;
     }
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Detailed description / Documentation draft:
Since system.tables does not includes all dictionaries (dictionaries
declared via configuration files -- *.xml), and since this are those
dictionaries we should use regular system.dictionaries.name over
system.dictionaries.origin.
