### PR TITLE
Trial: Add merge_max_parts to MergeTreeSettings

### DIFF
--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -34,6 +34,7 @@ struct MergeTreeSettings : public SettingsCollection<MergeTreeSettings>
     \
     /** Merge settings. */ \
     M(SettingUInt64, merge_max_block_size, DEFAULT_MERGE_BLOCK_SIZE, "How many rows in blocks should be formed for merge operations.", 0) \
+    M(SettingUInt64, merge_max_parts, 1000, "How many parts should be merged per merge operation.", 0) \
     M(SettingUInt64, max_bytes_to_merge_at_max_space_in_pool, 150ULL * 1024 * 1024 * 1024, "Maximum in total size of parts to merge, when there are maximum free threads in background pool (or entries in replication queue).", 0) \
     M(SettingUInt64, max_bytes_to_merge_at_min_space_in_pool, 1024 * 1024, "Maximum in total size of parts to merge, when there are minimum free threads in background pool (or entries in replication queue).", 0) \
     M(SettingUInt64, max_replicated_merges_in_queue, 16, "How many tasks of merging and mutating parts are allowed simultaneously in ReplicatedMergeTree queue.", 0) \

--- a/src/Storages/MergeTree/SimpleMergeSelector.cpp
+++ b/src/Storages/MergeTree/SimpleMergeSelector.cpp
@@ -146,10 +146,12 @@ void selectWithinPartition(
     if (parts_count <= 1)
         return;
 
+    const auto data_settings = data.getSettings();
+
     for (size_t begin = 0; begin < parts_count; ++begin)
     {
         /// If too many parts, select only from first, to avoid complexity.
-        if (begin > 1000)
+        if (begin > data_settings->merge_max_parts)
             break;
 
         size_t sum_size = parts[begin].size;

--- a/src/Storages/MergeTree/SimpleMergeSelector.h
+++ b/src/Storages/MergeTree/SimpleMergeSelector.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Storages/MergeTree/MergeSelector.h>
+#include <Storages/MergeTree/MergeTreeData.h>
 
 
 namespace DB
@@ -79,6 +80,7 @@ public:
 
 private:
     const Settings settings;
+    MergeTreeData & data;
 };
 
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Category (leave one):
Improvement

Short description (up to few sentences):

Adds `merge_max_parts` to `MergeTreeSettings`. Currently this
is fixed to 1000 in `SimpleMergeSelector.cpp.`