### PR TITLE
Syntax highlight in clickhouse-client, v2

### DIFF
--- a/programs/compressor/Compressor.cpp
+++ b/programs/compressor/Compressor.cpp
@@ -125,7 +125,7 @@ int mainEntryClickHouseCompressor(int argc, char ** argv)
             ParserCodec codec_parser;
 
             std::string codecs_line = boost::algorithm::join(codecs, ",");
-            auto ast = parseQuery(codec_parser, "(" + codecs_line + ")", 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
+            auto ast = parseQuery(codec_parser, "(" + codecs_line + ")", nullptr, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
             codec = CompressionCodecFactory::instance().get(ast, nullptr, false);
         }
         else

--- a/programs/copier/ClusterCopier.cpp
+++ b/programs/copier/ClusterCopier.cpp
@@ -1188,7 +1188,7 @@ TaskStatus ClusterCopier::processPartitionPieceTaskImpl(
         ParserQuery p_query(query.data() + query.size());
 
         const auto & settings = context.getSettingsRef();
-        return parseQuery(p_query, query, settings.max_query_size, settings.max_parser_depth);
+        return parseQuery(p_query, query, nullptr, settings.max_query_size, settings.max_parser_depth);
     };
 
     /// Load balancing
@@ -1384,7 +1384,7 @@ TaskStatus ClusterCopier::processPartitionPieceTaskImpl(
 
             ParserQuery p_query(query.data() + query.size());
             const auto & settings = context.getSettingsRef();
-            query_insert_ast = parseQuery(p_query, query, settings.max_query_size, settings.max_parser_depth);
+            query_insert_ast = parseQuery(p_query, query, nullptr, settings.max_query_size, settings.max_parser_depth);
 
             LOG_DEBUG(log, "Executing INSERT query: {}", query);
         }
@@ -1602,7 +1602,7 @@ ASTPtr ClusterCopier::getCreateTableForPullShard(const ConnectionTimeouts & time
 
     ParserCreateQuery parser_create_query;
     const auto & settings = context.getSettingsRef();
-    return parseQuery(parser_create_query, create_query_pull_str, settings.max_query_size, settings.max_parser_depth);
+    return parseQuery(parser_create_query, create_query_pull_str, nullptr, settings.max_query_size, settings.max_parser_depth);
 }
 
 /// If it is implicitly asked to create split Distributed table for certain piece on current shard, we will do it.
@@ -1681,7 +1681,7 @@ std::set<String> ClusterCopier::getShardPartitions(const ConnectionTimeouts & ti
 
     ParserQuery parser_query(query.data() + query.size());
     const auto & settings = context.getSettingsRef();
-    ASTPtr query_ast = parseQuery(parser_query, query, settings.max_query_size, settings.max_parser_depth);
+    ASTPtr query_ast = parseQuery(parser_query, query, nullptr, settings.max_query_size, settings.max_parser_depth);
 
     LOG_DEBUG(log, "Computing destination partition set, executing query: {}", query);
 
@@ -1728,7 +1728,7 @@ bool ClusterCopier::checkShardHasPartition(const ConnectionTimeouts & timeouts,
 
     ParserQuery parser_query(query.data() + query.size());
 const auto & settings = context.getSettingsRef();
-    ASTPtr query_ast = parseQuery(parser_query, query, settings.max_query_size, settings.max_parser_depth);
+    ASTPtr query_ast = parseQuery(parser_query, query, nullptr, settings.max_query_size, settings.max_parser_depth);
 
     Context local_context = context;
     local_context.setSettings(task_cluster->settings_pull);
@@ -1767,7 +1767,7 @@ bool ClusterCopier::checkPresentPartitionPiecesOnCurrentShard(const ConnectionTi
 
     ParserQuery parser_query(query.data() + query.size());
     const auto & settings = context.getSettingsRef();
-    ASTPtr query_ast = parseQuery(parser_query, query, settings.max_query_size, settings.max_parser_depth);
+    ASTPtr query_ast = parseQuery(parser_query, query, nullptr, settings.max_query_size, settings.max_parser_depth);
 
     Context local_context = context;
     local_context.setSettings(task_cluster->settings_pull);
@@ -1794,7 +1794,7 @@ UInt64 ClusterCopier::executeQueryOnCluster(
     std::vector<UInt64> per_shard_num_successful_replicas(num_shards, 0);
 
     ParserQuery p_query(query.data() + query.size());
-    ASTPtr query_ast = parseQuery(p_query, query, current_settings.max_query_size, current_settings.max_parser_depth);
+    ASTPtr query_ast = parseQuery(p_query, query, nullptr, current_settings.max_query_size, current_settings.max_parser_depth);
 
     /// We will have to execute query on each replica of a shard.
     if (execution_mode == ClusterExecutionMode::ON_EACH_NODE)

--- a/programs/copier/TaskTableAndShard.h
+++ b/programs/copier/TaskTableAndShard.h
@@ -266,7 +266,7 @@ inline TaskTable::TaskTable(TaskCluster & parent, const Poco::Util::AbstractConf
 
     {
         ParserStorage parser_storage;
-        engine_push_ast = parseQuery(parser_storage, engine_push_str, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
+        engine_push_ast = parseQuery(parser_storage, engine_push_str, nullptr, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
         engine_push_partition_key_ast = extractPartitionKey(engine_push_ast);
         primary_key_comma_separated = createCommaSeparatedStringFrom(extractPrimaryKeyColumnNames(engine_push_ast));
         engine_push_zk_path = extractReplicatedTableZookeeperPath(engine_push_ast);
@@ -277,7 +277,7 @@ inline TaskTable::TaskTable(TaskCluster & parent, const Poco::Util::AbstractConf
     auxiliary_engine_split_asts.reserve(number_of_splits);
     {
         ParserExpressionWithOptionalAlias parser_expression(false);
-        sharding_key_ast = parseQuery(parser_expression, sharding_key_str, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
+        sharding_key_ast = parseQuery(parser_expression, sharding_key_str, nullptr, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
         main_engine_split_ast = createASTStorageDistributed(cluster_push_name, table_push.first, table_push.second,
                                                             sharding_key_ast);
 
@@ -295,7 +295,7 @@ inline TaskTable::TaskTable(TaskCluster & parent, const Poco::Util::AbstractConf
     if (!where_condition_str.empty())
     {
         ParserExpressionWithOptionalAlias parser_expression(false);
-        where_condition_ast = parseQuery(parser_expression, where_condition_str, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
+        where_condition_ast = parseQuery(parser_expression, where_condition_str, nullptr, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
 
         // Will use canonical expression form
         where_condition_str = queryToString(where_condition_ast);

--- a/programs/format/Format.cpp
+++ b/programs/format/Format.cpp
@@ -57,7 +57,7 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
         ParserQuery parser(end);
         do
         {
-            ASTPtr res = parseQueryAndMovePosition(parser, pos, end, "query", multiple, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
+            ASTPtr res = parseQueryAndMovePosition(parser, pos, end, nullptr, "query", multiple, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
             if (!quiet)
             {
                 formatAST(*res, std::cout, hilite, oneline);

--- a/src/Access/DiskAccessStorage.cpp
+++ b/src/Access/DiskAccessStorage.cpp
@@ -62,19 +62,19 @@ namespace
     protected:
         const char * getName() const override { return "ATTACH access entity query"; }
 
-        bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
+        bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override
         {
-            if (ParserCreateUserQuery{}.enableAttachMode(true).parse(pos, node, expected))
+            if (ParserCreateUserQuery{}.enableAttachMode(true).parse(pos, node, expected, ranges))
                 return true;
-            if (ParserCreateRoleQuery{}.enableAttachMode(true).parse(pos, node, expected))
+            if (ParserCreateRoleQuery{}.enableAttachMode(true).parse(pos, node, expected, ranges))
                 return true;
-            if (ParserCreateRowPolicyQuery{}.enableAttachMode(true).parse(pos, node, expected))
+            if (ParserCreateRowPolicyQuery{}.enableAttachMode(true).parse(pos, node, expected, ranges))
                 return true;
-            if (ParserCreateQuotaQuery{}.enableAttachMode(true).parse(pos, node, expected))
+            if (ParserCreateQuotaQuery{}.enableAttachMode(true).parse(pos, node, expected, ranges))
                 return true;
-            if (ParserCreateSettingsProfileQuery{}.enableAttachMode(true).parse(pos, node, expected))
+            if (ParserCreateSettingsProfileQuery{}.enableAttachMode(true).parse(pos, node, expected, ranges))
                 return true;
-            if (ParserGrantQuery{}.enableAttachMode(true).parse(pos, node, expected))
+            if (ParserGrantQuery{}.enableAttachMode(true).parse(pos, node, expected, ranges))
                 return true;
             return false;
         }
@@ -97,7 +97,7 @@ namespace
         const char * end = begin + file_contents.size();
         while (pos < end)
         {
-            queries.emplace_back(parseQueryAndMovePosition(parser, pos, end, "", true, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH));
+            queries.emplace_back(parseQueryAndMovePosition(parser, pos, end, nullptr, "", true, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH));
             while (isWhitespaceASCII(*pos) || *pos == ';')
                 ++pos;
         }

--- a/src/Access/RowPolicyCache.cpp
+++ b/src/Access/RowPolicyCache.cpp
@@ -79,7 +79,7 @@ void RowPolicyCache::PolicyInfo::setPolicy(const RowPolicyPtr & policy_)
         try
         {
             ParserExpression parser;
-            parsed_conditions[type] = parseQuery(parser, condition, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
+            parsed_conditions[type] = parseQuery(parser, condition, nullptr, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
         }
         catch (...)
         {

--- a/src/AggregateFunctions/parseAggregateFunctionParameters.cpp
+++ b/src/AggregateFunctions/parseAggregateFunctionParameters.cpp
@@ -69,7 +69,7 @@ void getAggregateFunctionNameAndParametersArray(
 
     ParserExpressionList params_parser(false);
     ASTPtr args_ast = parseQuery(params_parser,
-        parameters_str.data(), parameters_str.data() + parameters_str.size(),
+        parameters_str.data(), parameters_str.data() + parameters_str.size(), nullptr,
         "parameters of aggregate function in " + error_context, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
 
     if (args_ast->children.empty())

--- a/src/Common/IntervalKind.cpp
+++ b/src/Common/IntervalKind.cpp
@@ -147,7 +147,7 @@ const char * IntervalKind::toNameOfFunctionExtractTimePart() const
             return "toDayOfMonth";
         case IntervalKind::Week:
             // TODO: SELECT toRelativeWeekNum(toDate('2017-06-15')) - toRelativeWeekNum(toStartOfYear(toDate('2017-06-15')))
-            // else if (ParserKeyword("WEEK").ignore(pos, expected))
+            // else if (ParserKeyword("WEEK").ignore(pos, expected, ranges))
             //    function_name = "toRelativeWeekNum";
             throw Exception("The syntax 'EXTRACT(WEEK FROM date)' is not supported, cannot extract the number of a week", ErrorCodes::SYNTAX_ERROR);
         case IntervalKind::Month:

--- a/src/DataTypes/DataTypeFactory.cpp
+++ b/src/DataTypes/DataTypeFactory.cpp
@@ -28,7 +28,7 @@ namespace ErrorCodes
 DataTypePtr DataTypeFactory::get(const String & full_name) const
 {
     ParserIdentifierWithOptionalParameters parser;
-    ASTPtr ast = parseQuery(parser, full_name.data(), full_name.data() + full_name.size(), "data type", 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
+    ASTPtr ast = parseQuery(parser, full_name.data(), full_name.data() + full_name.size(), nullptr, "data type", 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
     return get(ast);
 }
 

--- a/src/Databases/DatabaseDictionary.cpp
+++ b/src/Databases/DatabaseDictionary.cpp
@@ -105,7 +105,7 @@ ASTPtr DatabaseDictionary::getCreateTableQueryImpl(const String & table_name, co
     ParserCreateQuery parser;
     const char * pos = query.data();
     std::string error_message;
-    auto ast = tryParseQuery(parser, pos, pos + query.size(), error_message,
+    auto ast = tryParseQuery(parser, pos, pos + query.size(), nullptr, error_message,
             /* hilite = */ false, "", /* allow_multi_statements = */ false, 0, settings.max_parser_depth);
 
     if (!ast && throw_on_error)
@@ -123,7 +123,7 @@ ASTPtr DatabaseDictionary::getCreateDatabaseQuery() const
     }
     auto settings = global_context.getSettingsRef();
     ParserCreateQuery parser;
-    return parseQuery(parser, query.data(), query.data() + query.size(), "", 0, settings.max_parser_depth);
+    return parseQuery(parser, query.data(), query.data() + query.size(), nullptr, "", 0, settings.max_parser_depth);
 }
 
 void DatabaseDictionary::shutdown()

--- a/src/Databases/DatabaseOnDisk.cpp
+++ b/src/Databases/DatabaseOnDisk.cpp
@@ -337,7 +337,7 @@ ASTPtr DatabaseOnDisk::getCreateDatabaseQuery() const
         /// If database.sql doesn't exist, then engine is Ordinary
         String query = "CREATE DATABASE " + backQuoteIfNeed(getDatabaseName()) + " ENGINE = Ordinary";
         ParserCreateQuery parser;
-        ast = parseQuery(parser, query.data(), query.data() + query.size(), "", 0, settings.max_parser_depth);
+        ast = parseQuery(parser, query.data(), query.data() + query.size(), nullptr, "", 0, settings.max_parser_depth);
     }
 
     return ast;
@@ -450,7 +450,7 @@ ASTPtr DatabaseOnDisk::parseQueryFromMetadata(Poco::Logger * loger, const Contex
     ParserCreateQuery parser;
     const char * pos = query.data();
     std::string error_message;
-    auto ast = tryParseQuery(parser, pos, pos + query.size(), error_message, /* hilite = */ false,
+    auto ast = tryParseQuery(parser, pos, pos + query.size(), nullptr, error_message, /* hilite = */ false,
                              "in file " + metadata_file_path, /* allow_multi_statements = */ false, 0, settings.max_parser_depth);
 
     if (!ast && throw_on_error)

--- a/src/Databases/DatabaseOrdinary.cpp
+++ b/src/Databases/DatabaseOrdinary.cpp
@@ -240,7 +240,7 @@ void DatabaseOrdinary::alterTable(
     }
 
     ParserCreateQuery parser;
-    ASTPtr ast = parseQuery(parser, statement.data(), statement.data() + statement.size(), "in file " + table_metadata_path,
+    ASTPtr ast = parseQuery(parser, statement.data(), statement.data() + statement.size(), nullptr, "in file " + table_metadata_path,
         0, context.getSettingsRef().max_parser_depth);
 
     auto & ast_create_query = ast->as<ASTCreateQuery &>();

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -460,7 +460,7 @@ void DDLWorker::parseQueryAndResolveHost(DDLTask & task)
 
         ParserQuery parser_query(end);
         String description;
-        task.query = parseQuery(parser_query, begin, end, description, 0, context.getSettingsRef().max_parser_depth);
+        task.query = parseQuery(parser_query, begin, end, nullptr, description, 0, context.getSettingsRef().max_parser_depth);
     }
 
     // XXX: serious design flaw since `ASTQueryWithOnCluster` is not inherited from `IAST`!

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -195,7 +195,7 @@ ASTPtr InterpreterCreateQuery::formatColumns(const NamesAndTypesList & columns)
         String type_name = column.type->getName();
         const char * pos = type_name.data();
         const char * end = pos + type_name.size();
-        column_declaration->type = parseQuery(storage_p, pos, end, "data type", 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
+        column_declaration->type = parseQuery(storage_p, pos, end, nullptr, "data type", 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
         columns_list->children.emplace_back(column_declaration);
     }
 
@@ -217,7 +217,7 @@ ASTPtr InterpreterCreateQuery::formatColumns(const ColumnsDescription & columns)
         String type_name = column.type->getName();
         const char * type_name_pos = type_name.data();
         const char * type_name_end = type_name_pos + type_name.size();
-        column_declaration->type = parseQuery(storage_p, type_name_pos, type_name_end, "data type", 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
+        column_declaration->type = parseQuery(storage_p, type_name_pos, type_name_end, nullptr, "data type", 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
 
         if (column.default_desc.expression)
         {
@@ -237,7 +237,7 @@ ASTPtr InterpreterCreateQuery::formatColumns(const ColumnsDescription & columns)
             const char * codec_desc_pos = codec_desc.data();
             const char * codec_desc_end = codec_desc_pos + codec_desc.size();
             ParserIdentifierWithParameters codec_p;
-            column_declaration->codec = parseQuery(codec_p, codec_desc_pos, codec_desc_end, "column codec", 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
+            column_declaration->codec = parseQuery(codec_p, codec_desc_pos, codec_desc_end, nullptr, "column codec", 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
         }
 
         if (column.ttl)

--- a/src/Interpreters/InterpreterKillQueryQuery.cpp
+++ b/src/Interpreters/InterpreterKillQueryQuery.cpp
@@ -267,7 +267,7 @@ BlockIO InterpreterKillQueryQuery::execute()
                 else
                 {
                     ParserAlterCommand parser;
-                    auto command_ast = parseQuery(parser, command_col.getDataAt(i).toString(), 0, context.getSettingsRef().max_parser_depth);
+                    auto command_ast = parseQuery(parser, command_col.getDataAt(i).toString(), nullptr, 0, context.getSettingsRef().max_parser_depth);
                     required_access_rights = InterpreterAlterQuery::getRequiredAccessForCommand(command_ast->as<const ASTAlterCommand &>(), table_id.database_name, table_id.table_name);
                     if (!access->isGranted(&Poco::Logger::get("InterpreterKillQueryQuery"), required_access_rights))
                     {

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -113,7 +113,7 @@ String InterpreterSelectQuery::generateFilterActions(ExpressionActionsPtr & acti
     for (const auto & column_str : prerequisite_columns)
     {
         ParserExpression expr_parser;
-        expr_list->children.push_back(parseQuery(expr_parser, column_str, 0, context->getSettingsRef().max_parser_depth));
+        expr_list->children.push_back(parseQuery(expr_parser, column_str, nullptr, 0, context->getSettingsRef().max_parser_depth));
     }
 
     select_ast->setExpression(ASTSelectQuery::Expression::TABLES, std::make_shared<ASTTablesInSelectQuery>());

--- a/src/Interpreters/InterpreterShowCreateAccessEntityQuery.cpp
+++ b/src/Interpreters/InterpreterShowCreateAccessEntityQuery.cpp
@@ -172,7 +172,7 @@ namespace
             if (!condition.empty())
             {
                 ParserExpression parser;
-                ASTPtr expr = parseQuery(parser, condition, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
+                ASTPtr expr = parseQuery(parser, condition, nullptr, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
                 query->conditions[static_cast<size_t>(type)] = expr;
             }
         }

--- a/src/Interpreters/JoinToSubqueryTransformVisitor.cpp
+++ b/src/Interpreters/JoinToSubqueryTransformVisitor.cpp
@@ -36,7 +36,7 @@ namespace
 ASTPtr makeSubqueryTemplate()
 {
     ParserTablesInSelectQueryElement parser(true);
-    ASTPtr subquery_template = parseQuery(parser, "(select * from _t) as `--.s`", 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
+    ASTPtr subquery_template = parseQuery(parser, "(select * from _t) as `--.s`", nullptr, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
     if (!subquery_template)
         throw Exception("Cannot parse subquery template", ErrorCodes::LOGICAL_ERROR);
     return subquery_template;

--- a/src/Interpreters/JoinedTables.cpp
+++ b/src/Interpreters/JoinedTables.cpp
@@ -56,7 +56,7 @@ void replaceJoinedTable(const ASTSelectQuery & select_query)
         if (table_id.alias.empty() && table_id.isShort())
         {
             ParserTableExpression parser;
-            table_expr = parseQuery(parser, expr, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH)->as<ASTTableExpression &>();
+            table_expr = parseQuery(parser, expr, nullptr, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH)->as<ASTTableExpression &>();
         }
     }
 }

--- a/src/Interpreters/QueryParameterVisitor.h
+++ b/src/Interpreters/QueryParameterVisitor.h
@@ -41,7 +41,7 @@ NameSet analyzeReceiveQueryParams(const std::string & query)
     const char * query_end = query.data() + query.size();
 
     ParserQuery parser(query_end, false);
-    ASTPtr extract_query_ast = parseQuery(parser, query_begin, query_end, "analyzeReceiveQueryParams", 0, 0);
+    ASTPtr extract_query_ast = parseQuery(parser, query_begin, query_end, nullptr, "analyzeReceiveQueryParams", 0, 0);
     QueryParameterVisitor(query_params).visit(extract_query_ast);
     return query_params;
 }

--- a/src/Interpreters/SystemLog.h
+++ b/src/Interpreters/SystemLog.h
@@ -506,7 +506,7 @@ ASTPtr SystemLog<LogElement>::getCreateTableQuery()
 
     ParserStorage storage_parser;
     ASTPtr storage_ast = parseQuery(
-        storage_parser, storage_def.data(), storage_def.data() + storage_def.size(),
+        storage_parser, storage_def.data(), storage_def.data() + storage_def.size(), nullptr,
         "Storage to create table for " + LogElement::name(), 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
     create->set(create->storage, storage_ast);
 

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -244,7 +244,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
     try
     {
         /// TODO Parser should fail early when max_query_size limit is reached.
-        ast = parseQuery(parser, begin, end, "", max_query_size, settings.max_parser_depth);
+        ast = parseQuery(parser, begin, end, nullptr, "", max_query_size, settings.max_parser_depth);
 
         auto * insert_query = ast->as<ASTInsertQuery>();
 

--- a/src/Interpreters/loadMetadata.cpp
+++ b/src/Interpreters/loadMetadata.cpp
@@ -30,7 +30,8 @@ static void executeCreateQuery(
     bool has_force_restore_data_flag)
 {
     ParserCreateQuery parser;
-    ASTPtr ast = parseQuery(parser, query.data(), query.data() + query.size(), "in file " + file_name, 0, context.getSettingsRef().max_parser_depth);
+    ASTPtr ast = parseQuery(
+        parser, query.data(), query.data() + query.size(), nullptr, "in file " + file_name, 0, context.getSettingsRef().max_parser_depth);
 
     auto & ast_create_query = ast->as<ASTCreateQuery &>();
     ast_create_query.database = database;

--- a/src/Parsers/ASTQueryWithOnCluster.cpp
+++ b/src/Parsers/ASTQueryWithOnCluster.cpp
@@ -16,12 +16,12 @@ std::string ASTQueryWithOnCluster::getRewrittenQueryWithoutOnCluster(const std::
 }
 
 
-bool ASTQueryWithOnCluster::parse(Pos & pos, std::string & cluster_str, Expected & expected)
+bool ASTQueryWithOnCluster::parse(Pos & pos, std::string & cluster_str, Expected & expected, IParser::Ranges * ranges)
 {
-    if (!ParserKeyword{"CLUSTER"}.ignore(pos, expected))
+    if (!ParserKeyword{"CLUSTER"}.ignore(pos, expected, ranges))
         return false;
 
-    return parseIdentifierOrStringLiteral(pos, expected, cluster_str);
+    return parseIdentifierOrStringLiteral(pos, expected, ranges, cluster_str);
 }
 
 

--- a/src/Parsers/ASTQueryWithOnCluster.h
+++ b/src/Parsers/ASTQueryWithOnCluster.h
@@ -25,7 +25,7 @@ public:
     void formatOnCluster(const IAST::FormatSettings & settings) const;
 
     /// Parses " CLUSTER [cluster|'cluster'] " clause
-    static bool parse(Pos & pos, std::string & cluster_str, Expected & expected);
+    static bool parse(Pos & pos, std::string & cluster_str, Expected & expected, IParser::Ranges * ranges);
 
     virtual ~ASTQueryWithOnCluster() = default;
     ASTQueryWithOnCluster() = default;

--- a/src/Parsers/CommonParsers.cpp
+++ b/src/Parsers/CommonParsers.cpp
@@ -25,7 +25,7 @@ const char * ParserKeyword::getName() const
 }
 
 
-bool ParserKeyword::parseImpl(Pos & pos, ASTPtr & /*node*/, Expected & expected)
+bool ParserKeyword::parseImpl(Pos & pos, ASTPtr & /*node*/, Expected & expected, Ranges *)
 {
     if (pos->type != TokenType::BareWord)
         return false;

--- a/src/Parsers/CommonParsers.h
+++ b/src/Parsers/CommonParsers.h
@@ -21,7 +21,9 @@ public:
 protected:
     const char * getName() const override;
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
+
+    const char * color() const override { return IAST::hilite_keyword; }
 };
 
 
@@ -34,7 +36,7 @@ public:
 protected:
     const char * getName() const override { return "token"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & /*node*/, Expected & expected) override
+    bool parseImpl(Pos & pos, ASTPtr & /*node*/, Expected & expected, Ranges *) override
     {
         if (pos->type != token_type)
         {
@@ -43,6 +45,61 @@ protected:
         }
         ++pos;
         return true;
+    }
+
+    const char * color() const override
+    {
+        switch (token_type)
+        {
+            case TokenType::Whitespace:
+            case TokenType::Comment:
+                return IAST::hilite_none;
+
+            case TokenType::Number:
+            case TokenType::StringLiteral:
+                return IAST::hilite_none;
+
+            case TokenType::QuotedIdentifier:
+
+            case TokenType::OpeningRoundBracket:
+            case TokenType::ClosingRoundBracket:
+
+            case TokenType::OpeningSquareBracket:
+            case TokenType::ClosingSquareBracket:
+
+            case TokenType::OpeningCurlyBrace:
+            case TokenType::ClosingCurlyBrace:
+
+            case TokenType::Comma:
+            case TokenType::Semicolon:
+            case TokenType::Dot:
+                return IAST::hilite_none;
+
+            case TokenType::Asterisk:
+                break;
+
+            case TokenType::Plus:
+            case TokenType::Minus:
+            case TokenType::Slash:
+            case TokenType::Percent:
+            case TokenType::Arrow:
+            case TokenType::QuestionMark:
+            case TokenType::Colon:
+            case TokenType::Equals:
+            case TokenType::NotEquals:
+            case TokenType::Less:
+            case TokenType::Greater:
+            case TokenType::LessOrEquals:
+            case TokenType::GreaterOrEquals:
+            case TokenType::Concatenation:
+            case TokenType::At:
+                return IAST::hilite_operator;
+
+            default:
+                return nullptr;
+        }
+
+        __builtin_unreachable();
     }
 };
 
@@ -53,7 +110,7 @@ class ParserNothing : public IParserBase
 public:
     const char * getName() const override { return "nothing"; }
 
-    bool parseImpl(Pos & /*pos*/, ASTPtr & /*node*/, Expected & /*expected*/) override { return true; }
+    bool parseImpl(Pos & /*pos*/, ASTPtr & /*node*/, Expected & /*expected*/, Ranges *) override { return true; }
 };
 
 }

--- a/src/Parsers/ExpressionElementParsers.h
+++ b/src/Parsers/ExpressionElementParsers.h
@@ -12,7 +12,7 @@ class ParserArray : public IParserBase
 {
 protected:
     const char * getName() const override { return "array"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -24,7 +24,7 @@ class ParserParenthesisExpression : public IParserBase
 {
 protected:
     const char * getName() const override { return "parenthesized expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -34,7 +34,7 @@ class ParserSubquery : public IParserBase
 {
 protected:
     const char * getName() const override { return "SELECT subquery"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -44,7 +44,8 @@ class ParserIdentifier : public IParserBase
 {
 protected:
     const char * getName() const override { return "identifier"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
+    const char * color() const override { return IAST::hilite_identifier; }
 };
 
 
@@ -52,7 +53,7 @@ class ParserBareWord : public IParserBase
 {
 protected:
     const char * getName() const override { return "bare word"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 /** An identifier, possibly containing a dot, for example, x_yz123 or `something special` or Hits.EventTime,
@@ -65,7 +66,7 @@ public:
     : table_name_with_optional_uuid(table_name_with_optional_uuid_) {}
 protected:
     const char * getName() const override { return "compound identifier"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
     bool table_name_with_optional_uuid;
 };
 
@@ -74,7 +75,8 @@ class ParserAsterisk : public IParserBase
 {
 protected:
     const char * getName() const override { return "asterisk"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
+    const char * color() const override { return IAST::hilite_asterisk; }
 };
 
 /** Something like t.* or db.table.*
@@ -83,7 +85,8 @@ class ParserQualifiedAsterisk : public IParserBase
 {
 protected:
     const char * getName() const override { return "qualified asterisk"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
+    const char * color() const override { return IAST::hilite_asterisk; }
 };
 
 /** COLUMNS('<regular expression>')
@@ -92,7 +95,7 @@ class ParserColumnsMatcher : public IParserBase
 {
 protected:
     const char * getName() const override { return "COLUMNS matcher"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 /** A function, for example, f(x, y + 1, g(z)).
@@ -107,7 +110,8 @@ public:
     ParserFunction(bool allow_function_parameters_ = true) : allow_function_parameters(allow_function_parameters_) {}
 protected:
     const char * getName() const override { return "function"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
+    const char * color() const override { return IAST::hilite_function; }
     bool allow_function_parameters;
 };
 
@@ -115,7 +119,7 @@ class ParserCodecDeclarationList : public IParserBase
 {
 protected:
     const char * getName() const override { return "codec declaration list"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 /** Parse compression codec
@@ -125,63 +129,63 @@ class ParserCodec : public IParserBase
 {
 protected:
     const char * getName() const override { return "codec"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 class ParserCastExpression : public IParserBase
 {
 protected:
     const char * getName() const override { return "CAST expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 class ParserSubstringExpression : public IParserBase
 {
 protected:
     const char * getName() const override { return "SUBSTRING expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 class ParserTrimExpression : public IParserBase
 {
 protected:
     const char * getName() const override { return "TRIM expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 class ParserLeftExpression : public IParserBase
 {
 protected:
     const char * getName() const override { return "LEFT expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 class ParserRightExpression : public IParserBase
 {
 protected:
     const char * getName() const override { return "RIGHT expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 class ParserExtractExpression : public IParserBase
 {
 protected:
     const char * getName() const override { return "EXTRACT expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 class ParserDateAddExpression : public IParserBase
 {
 protected:
     const char * getName() const override { return "DATE_ADD expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 class ParserDateDiffExpression : public IParserBase
 {
 protected:
     const char * getName() const override { return "DATE_DIFF expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 /** NULL literal.
@@ -190,7 +194,7 @@ class ParserNull : public IParserBase
 {
 protected:
     const char * getName() const override { return "NULL"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -200,7 +204,7 @@ class ParserNumber : public IParserBase
 {
 protected:
     const char * getName() const override { return "number"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 /** Unsigned integer, used in right hand side of tuple access operator (x.1).
@@ -209,7 +213,7 @@ class ParserUnsignedInteger : public IParserBase
 {
 protected:
     const char * getName() const override { return "unsigned integer"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -219,7 +223,7 @@ class ParserStringLiteral : public IParserBase
 {
 protected:
     const char * getName() const override { return "string literal"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -238,7 +242,7 @@ public:
         : opening_bracket(opening_bracket_), closing_bracket(closing_bracket_) {}
 protected:
     const char * getName() const override { return "collection of literals"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 private:
     TokenType opening_bracket;
     TokenType closing_bracket;
@@ -251,9 +255,9 @@ public:
     ParserCollectionOfLiterals<Tuple> tuple_parser{TokenType::OpeningRoundBracket, TokenType::ClosingRoundBracket};
 protected:
     const char * getName() const override { return "tuple"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override
     {
-        return tuple_parser.parse(pos, node, expected);
+        return tuple_parser.parse(pos, node, expected, ranges);
     }
 };
 
@@ -263,9 +267,9 @@ public:
     ParserCollectionOfLiterals<Array> array_parser{TokenType::OpeningSquareBracket, TokenType::ClosingSquareBracket};
 protected:
     const char * getName() const override { return "array"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override
     {
-        return array_parser.parse(pos, node, expected);
+        return array_parser.parse(pos, node, expected, ranges);
     }
 };
 
@@ -276,7 +280,7 @@ class ParserLiteral : public IParserBase
 {
 protected:
     const char * getName() const override { return "literal"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -293,7 +297,8 @@ private:
     bool allow_alias_without_as_keyword;
 
     const char * getName() const override { return "alias"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
+    const char * color() const override { return IAST::hilite_alias; }
 };
 
 
@@ -304,7 +309,8 @@ class ParserSubstitution : public IParserBase
 {
 protected:
     const char * getName() const override { return "substitution"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
+    const char * color() const override { return IAST::hilite_substitution; }
 };
 
 
@@ -314,7 +320,7 @@ class ParserExpressionElement : public IParserBase
 {
 protected:
     const char * getName() const override { return "element of expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -330,7 +336,7 @@ protected:
     bool allow_alias_without_as_keyword;
 
     const char * getName() const override { return "element of expression with optional alias"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -343,7 +349,7 @@ class ParserOrderByElement : public IParserBase
 {
 protected:
     const char * getName() const override { return "element of ORDER BY expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 /** Parser for function with arguments like KEY VALUE (space separated)
@@ -357,7 +363,7 @@ public:
 protected:
 
     const char * getName() const override { return "function with key-value arguments"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 
     /// brackets for function arguments can be omitted
     bool brackets_can_be_omitted;
@@ -370,7 +376,7 @@ class ParserIdentifierWithOptionalParameters : public IParserBase
 {
 protected:
     const char * getName() const  override{ return "identifier with optional parameters"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 /** Element of TTL expression - same as expression element, but in addition,
@@ -380,7 +386,7 @@ class ParserTTLElement : public IParserBase
 {
 protected:
     const char * getName() const override { return "element of TTL expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 }

--- a/src/Parsers/ExpressionListParsers.h
+++ b/src/Parsers/ExpressionListParsers.h
@@ -28,7 +28,7 @@ public:
     }
 protected:
     const char * getName() const override { return "list of elements"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 private:
     ParserPtr elem_parser;
     ParserPtr separator_parser;
@@ -65,7 +65,7 @@ public:
 protected:
     const char * getName() const override { return "list, delimited by binary operators"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -88,7 +88,7 @@ public:
 protected:
     const char * getName() const override { return "list, delimited by operator of variable arity"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -111,7 +111,7 @@ public:
 
 protected:
     const char * getName() const override { return "expression with prefix unary operator"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -123,7 +123,7 @@ private:
 protected:
     const char * getName() const  override{ return "array element expression"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -135,7 +135,7 @@ private:
 protected:
     const char * getName() const override { return "tuple element expression"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -148,7 +148,7 @@ private:
 protected:
     const char * getName() const override { return "unary minus expression"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -161,9 +161,9 @@ private:
 protected:
     const char * getName() const  override { return "multiplicative expression"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override
     {
-        return operator_parser.parse(pos, node, expected);
+        return operator_parser.parse(pos, node, expected, ranges);
     }
 };
 
@@ -174,7 +174,7 @@ protected:
     ParserMultiplicativeExpression next_parser;
 
     const char * getName() const  override { return "DATE operator expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 /// TIMESTAMP operator. "TIMESTAMP '2001-01-01 12:34:56'" would be parsed as "toDateTime('2001-01-01 12:34:56')".
@@ -184,7 +184,7 @@ protected:
     ParserDateOperatorExpression next_parser;
 
     const char * getName() const  override { return "TIMESTAMP operator expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 /// Optional conversion to INTERVAL data type. Example: "INTERVAL x SECOND" parsed as "toIntervalSecond(x)".
@@ -194,7 +194,7 @@ protected:
     ParserTimestampOperatorExpression next_parser;
 
     const char * getName() const  override { return "INTERVAL operator expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 class ParserAdditiveExpression : public IParserBase
@@ -206,9 +206,9 @@ private:
 protected:
     const char * getName() const  override { return "additive expression"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override
     {
-        return operator_parser.parse(pos, node, expected);
+        return operator_parser.parse(pos, node, expected, ranges);
     }
 };
 
@@ -220,9 +220,9 @@ class ParserConcatExpression : public IParserBase
 protected:
     const char * getName() const override { return "string concatenation expression"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override
     {
-        return operator_parser.parse(pos, node, expected);
+        return operator_parser.parse(pos, node, expected, ranges);
     }
 };
 
@@ -235,7 +235,7 @@ private:
 protected:
     const char * getName() const override { return "BETWEEN expression"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -248,9 +248,9 @@ private:
 protected:
     const char * getName() const  override{ return "comparison expression"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override
     {
-        return operator_parser.parse(pos, node, expected);
+        return operator_parser.parse(pos, node, expected, ranges);
     }
 };
 
@@ -264,7 +264,7 @@ private:
 
 protected:
     const char * getName() const override { return "nullity checking"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -277,9 +277,9 @@ private:
 protected:
     const char * getName() const  override{ return "logical-NOT expression"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override
     {
-        return operator_parser.parse(pos, node, expected);
+        return operator_parser.parse(pos, node, expected, ranges);
     }
 };
 
@@ -292,9 +292,9 @@ private:
 protected:
     const char * getName() const override { return "logical-AND expression"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override
     {
-        return operator_parser.parse(pos, node, expected);
+        return operator_parser.parse(pos, node, expected, ranges);
     }
 };
 
@@ -307,9 +307,9 @@ private:
 protected:
     const char * getName() const override { return "logical-OR expression"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override
     {
-        return operator_parser.parse(pos, node, expected);
+        return operator_parser.parse(pos, node, expected, ranges);
     }
 };
 
@@ -325,7 +325,7 @@ private:
 protected:
     const char * getName() const override { return "expression with ternary operator"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -337,7 +337,7 @@ private:
 protected:
     const char * getName() const override { return "lambda expression"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -353,9 +353,9 @@ protected:
 
     const char * getName() const override { return "expression with optional alias"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override
     {
-        return impl->parse(pos, node, expected);
+        return impl->parse(pos, node, expected, ranges);
     }
 };
 
@@ -371,7 +371,7 @@ protected:
     bool allow_alias_without_as_keyword;
 
     const char * getName() const override { return "list of expressions"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -384,7 +384,7 @@ private:
     ParserExpressionList nested_parser;
 protected:
     const char * getName() const override { return "not empty list of expressions"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -392,7 +392,7 @@ class ParserOrderByExpressionList : public IParserBase
 {
 protected:
     const char * getName() const override { return "order by expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -401,7 +401,7 @@ class ParserKeyValuePair : public IParserBase
 {
 protected:
     const char * getName() const override { return "key-value pair"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -410,7 +410,7 @@ class ParserKeyValuePairsList : public IParserBase
 {
 protected:
     const char * getName() const override { return "list of pairs"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -418,7 +418,7 @@ class ParserTTLExpressionList : public IParserBase
 {
 protected:
     const char * getName() const override { return "ttl expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 }

--- a/src/Parsers/IAST.cpp
+++ b/src/Parsers/IAST.cpp
@@ -23,6 +23,7 @@ const char * IAST::hilite_function     = "\033[0;33m";
 const char * IAST::hilite_operator     = "\033[1;33m";
 const char * IAST::hilite_alias        = "\033[0;32m";
 const char * IAST::hilite_substitution = "\033[1;36m";
+const char * IAST::hilite_asterisk     = "\033[1;35m";
 const char * IAST::hilite_none         = "\033[0m";
 
 

--- a/src/Parsers/IAST.h
+++ b/src/Parsers/IAST.h
@@ -67,7 +67,7 @@ public:
 
     ASTPtr ptr() { return shared_from_this(); }
 
-    /** Get a deep copy of the tree. Cloned object must have the same range. */
+    /** Get a deep copy of the tree. */
     virtual ASTPtr clone() const = 0;
 
     /** Get hash code, identifying this element and its subtree.
@@ -231,6 +231,7 @@ public:
     static const char * hilite_operator;
     static const char * hilite_alias;
     static const char * hilite_substitution;
+    static const char * hilite_asterisk;
     static const char * hilite_none;
 
 private:

--- a/src/Parsers/IParserBase.cpp
+++ b/src/Parsers/IParserBase.cpp
@@ -4,15 +4,36 @@
 namespace DB
 {
 
-bool IParserBase::parse(Pos & pos, ASTPtr & node, Expected & expected)
+bool IParserBase::parse(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     expected.add(pos, getName());
 
     return wrapParseImpl(pos, IncreaseDepthTag{}, [&]
     {
-        bool res = parseImpl(pos, node, expected);
-        if (!res)
+        Pos prev_pos = pos;
+        size_t prev_ranges_size = 0;
+        if (ranges)
+            prev_ranges_size = ranges->size();
+
+        bool res = parseImpl(pos, node, expected, ranges);
+
+        if (res)
+        {
+            if (ranges)
+            {
+                Range range;
+                range.begin = prev_pos;
+                range.end = pos;
+                range.color = color();
+                if (range.color)
+                    ranges->emplace_back(std::move(range));
+            }
+        }
+        else
+        {
             node = nullptr;
+        }
+
         return res;
     });
 }

--- a/src/Parsers/IParserBase.h
+++ b/src/Parsers/IParserBase.h
@@ -17,7 +17,7 @@ public:
         Pos begin = pos;
         bool res = func();
         if (!res)
-          pos = begin;
+            pos = begin;
         return res;
     }
 
@@ -31,14 +31,14 @@ public:
         bool res = func();
         pos.decreaseDepth();
         if (!res)
-          pos = begin;
+            pos = begin;
         return res;
     }
 
-    bool parse(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parse(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 
 protected:
-    virtual bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) = 0;
+    virtual bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) = 0;
 };
 
 }

--- a/src/Parsers/ParserAlterQuery.cpp
+++ b/src/Parsers/ParserAlterQuery.cpp
@@ -18,7 +18,7 @@
 namespace DB
 {
 
-bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     auto command = std::make_shared<ASTAlterCommand>();
     node = command;
@@ -98,7 +98,7 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
 
     if (is_live_view)
     {
-        if (s_refresh.ignore(pos, expected))
+        if (s_refresh.ignore(pos, expected, ranges))
         {
             command->type = ASTAlterCommand::LIVE_VIEW_REFRESH;
         }
@@ -107,165 +107,165 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
     }
     else
     {
-        if (s_add_column.ignore(pos, expected))
+        if (s_add_column.ignore(pos, expected, ranges))
         {
-            if (s_if_not_exists.ignore(pos, expected))
+            if (s_if_not_exists.ignore(pos, expected, ranges))
                 command->if_not_exists = true;
 
-            if (!parser_col_decl.parse(pos, command->col_decl, expected))
+            if (!parser_col_decl.parse(pos, command->col_decl, expected, ranges))
                 return false;
 
-            if (s_after.ignore(pos, expected))
+            if (s_after.ignore(pos, expected, ranges))
             {
-                if (!parser_name.parse(pos, command->column, expected))
+                if (!parser_name.parse(pos, command->column, expected, ranges))
                     return false;
             }
 
             command->type = ASTAlterCommand::ADD_COLUMN;
         }
-        else if (s_rename_column.ignore(pos, expected))
+        else if (s_rename_column.ignore(pos, expected, ranges))
         {
-            if (s_if_exists.ignore(pos, expected))
+            if (s_if_exists.ignore(pos, expected, ranges))
                 command->if_exists = true;
 
-            if (!parser_name.parse(pos, command->column, expected))
+            if (!parser_name.parse(pos, command->column, expected, ranges))
                 return false;
 
-            if (!s_to.ignore(pos, expected))
+            if (!s_to.ignore(pos, expected, ranges))
                 return false;
 
-            if (!parser_name.parse(pos, command->rename_to, expected))
+            if (!parser_name.parse(pos, command->rename_to, expected, ranges))
                 return false;
 
             command->type = ASTAlterCommand::RENAME_COLUMN;
         }
-        else if (s_drop_partition.ignore(pos, expected))
+        else if (s_drop_partition.ignore(pos, expected, ranges))
         {
-            if (!parser_partition.parse(pos, command->partition, expected))
+            if (!parser_partition.parse(pos, command->partition, expected, ranges))
                 return false;
 
             command->type = ASTAlterCommand::DROP_PARTITION;
         }
-        else if (s_drop_detached_partition.ignore(pos, expected))
+        else if (s_drop_detached_partition.ignore(pos, expected, ranges))
         {
-            if (!parser_partition.parse(pos, command->partition, expected))
+            if (!parser_partition.parse(pos, command->partition, expected, ranges))
                 return false;
 
             command->type = ASTAlterCommand::DROP_DETACHED_PARTITION;
         }
-        else if (s_drop_detached_part.ignore(pos, expected))
+        else if (s_drop_detached_part.ignore(pos, expected, ranges))
         {
-            if (!parser_string_literal.parse(pos, command->partition, expected))
+            if (!parser_string_literal.parse(pos, command->partition, expected, ranges))
                 return false;
 
             command->type = ASTAlterCommand::DROP_DETACHED_PARTITION;
             command->part = true;
         }
-        else if (s_drop_column.ignore(pos, expected))
+        else if (s_drop_column.ignore(pos, expected, ranges))
         {
-            if (s_if_exists.ignore(pos, expected))
+            if (s_if_exists.ignore(pos, expected, ranges))
                 command->if_exists = true;
 
-            if (!parser_name.parse(pos, command->column, expected))
+            if (!parser_name.parse(pos, command->column, expected, ranges))
                 return false;
 
             command->type = ASTAlterCommand::DROP_COLUMN;
             command->detach = false;
         }
-        else if (s_clear_column.ignore(pos, expected))
+        else if (s_clear_column.ignore(pos, expected, ranges))
         {
-            if (s_if_exists.ignore(pos, expected))
+            if (s_if_exists.ignore(pos, expected, ranges))
                 command->if_exists = true;
 
-            if (!parser_name.parse(pos, command->column, expected))
+            if (!parser_name.parse(pos, command->column, expected, ranges))
                 return false;
 
             command->type = ASTAlterCommand::DROP_COLUMN;
             command->clear_column = true;
             command->detach = false;
 
-            if (s_in_partition.ignore(pos, expected))
+            if (s_in_partition.ignore(pos, expected, ranges))
             {
-                if (!parser_partition.parse(pos, command->partition, expected))
+                if (!parser_partition.parse(pos, command->partition, expected, ranges))
                     return false;
             }
         }
-        else if (s_add_index.ignore(pos, expected))
+        else if (s_add_index.ignore(pos, expected, ranges))
         {
-            if (s_if_not_exists.ignore(pos, expected))
+            if (s_if_not_exists.ignore(pos, expected, ranges))
                 command->if_not_exists = true;
 
-            if (!parser_idx_decl.parse(pos, command->index_decl, expected))
+            if (!parser_idx_decl.parse(pos, command->index_decl, expected, ranges))
                 return false;
 
-            if (s_after.ignore(pos, expected))
+            if (s_after.ignore(pos, expected, ranges))
             {
-                if (!parser_name.parse(pos, command->index, expected))
+                if (!parser_name.parse(pos, command->index, expected, ranges))
                     return false;
             }
 
             command->type = ASTAlterCommand::ADD_INDEX;
         }
-        else if (s_drop_index.ignore(pos, expected))
+        else if (s_drop_index.ignore(pos, expected, ranges))
         {
-            if (s_if_exists.ignore(pos, expected))
+            if (s_if_exists.ignore(pos, expected, ranges))
                 command->if_exists = true;
 
-            if (!parser_name.parse(pos, command->index, expected))
+            if (!parser_name.parse(pos, command->index, expected, ranges))
                 return false;
 
             command->type = ASTAlterCommand::DROP_INDEX;
             command->detach = false;
         }
-        else if (s_clear_index.ignore(pos, expected))
+        else if (s_clear_index.ignore(pos, expected, ranges))
         {
-            if (s_if_exists.ignore(pos, expected))
+            if (s_if_exists.ignore(pos, expected, ranges))
                 command->if_exists = true;
 
-            if (!parser_name.parse(pos, command->index, expected))
+            if (!parser_name.parse(pos, command->index, expected, ranges))
                 return false;
 
             command->type = ASTAlterCommand::DROP_INDEX;
             command->clear_index = true;
             command->detach = false;
 
-            if (!s_in_partition.ignore(pos, expected))
+            if (!s_in_partition.ignore(pos, expected, ranges))
                 return false;
-            if (!parser_partition.parse(pos, command->partition, expected))
+            if (!parser_partition.parse(pos, command->partition, expected, ranges))
                 return false;
         }
-        else if (s_materialize_index.ignore(pos, expected))
+        else if (s_materialize_index.ignore(pos, expected, ranges))
         {
-            if (s_if_exists.ignore(pos, expected))
+            if (s_if_exists.ignore(pos, expected, ranges))
                 command->if_exists = true;
 
-            if (!parser_name.parse(pos, command->index, expected))
+            if (!parser_name.parse(pos, command->index, expected, ranges))
                 return false;
 
             command->type = ASTAlterCommand::MATERIALIZE_INDEX;
             command->detach = false;
 
-            if (s_in_partition.ignore(pos, expected))
+            if (s_in_partition.ignore(pos, expected, ranges))
             {
-                if (!parser_partition.parse(pos, command->partition, expected))
+                if (!parser_partition.parse(pos, command->partition, expected, ranges))
                     return false;
             }
         }
-        else if (s_move_part.ignore(pos, expected))
+        else if (s_move_part.ignore(pos, expected, ranges))
         {
-            if (!parser_string_literal.parse(pos, command->partition, expected))
+            if (!parser_string_literal.parse(pos, command->partition, expected, ranges))
                 return false;
 
             command->type = ASTAlterCommand::MOVE_PARTITION;
             command->part = true;
 
-            if (s_to_disk.ignore(pos))
+            if (s_to_disk.ignore(pos, expected, ranges))
                 command->move_destination_type = DataDestinationType::DISK;
-            else if (s_to_volume.ignore(pos))
+            else if (s_to_volume.ignore(pos, expected, ranges))
                 command->move_destination_type = DataDestinationType::VOLUME;
-            else if (s_to_table.ignore(pos))
+            else if (s_to_table.ignore(pos, expected, ranges))
             {
-                if (!parseDatabaseAndTableName(pos, expected, command->to_database, command->to_table))
+                if (!parseDatabaseAndTableName(pos, expected, ranges, command->to_database, command->to_table))
                     return false;
                 command->move_destination_type = DataDestinationType::TABLE;
             }
@@ -275,26 +275,26 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
             if (command->move_destination_type != DataDestinationType::TABLE)
             {
                 ASTPtr ast_space_name;
-                if (!parser_string_literal.parse(pos, ast_space_name, expected))
+                if (!parser_string_literal.parse(pos, ast_space_name, expected, ranges))
                     return false;
 
                 command->move_destination_name = ast_space_name->as<ASTLiteral &>().value.get<const String &>();
             }
         }
-        else if (s_move_partition.ignore(pos, expected))
+        else if (s_move_partition.ignore(pos, expected, ranges))
         {
-            if (!parser_partition.parse(pos, command->partition, expected))
+            if (!parser_partition.parse(pos, command->partition, expected, ranges))
                 return false;
 
             command->type = ASTAlterCommand::MOVE_PARTITION;
 
-            if (s_to_disk.ignore(pos))
+            if (s_to_disk.ignore(pos, expected, ranges))
                 command->move_destination_type = DataDestinationType::DISK;
-            else if (s_to_volume.ignore(pos))
+            else if (s_to_volume.ignore(pos, expected, ranges))
                 command->move_destination_type = DataDestinationType::VOLUME;
-            else if (s_to_table.ignore(pos))
+            else if (s_to_table.ignore(pos, expected, ranges))
             {
-                if (!parseDatabaseAndTableName(pos, expected, command->to_database, command->to_table))
+                if (!parseDatabaseAndTableName(pos, expected, ranges, command->to_database, command->to_table))
                     return false;
                 command->move_destination_type = DataDestinationType::TABLE;
             }
@@ -304,49 +304,49 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
             if (command->move_destination_type != DataDestinationType::TABLE)
             {
                 ASTPtr ast_space_name;
-                if (!parser_string_literal.parse(pos, ast_space_name, expected))
+                if (!parser_string_literal.parse(pos, ast_space_name, expected, ranges))
                     return false;
 
                 command->move_destination_name = ast_space_name->as<ASTLiteral &>().value.get<const String &>();
             }
         }
-        else if (s_add_constraint.ignore(pos, expected))
+        else if (s_add_constraint.ignore(pos, expected, ranges))
         {
-            if (s_if_not_exists.ignore(pos, expected))
+            if (s_if_not_exists.ignore(pos, expected, ranges))
                 command->if_not_exists = true;
 
-            if (!parser_constraint_decl.parse(pos, command->constraint_decl, expected))
+            if (!parser_constraint_decl.parse(pos, command->constraint_decl, expected, ranges))
                 return false;
 
             command->type = ASTAlterCommand::ADD_CONSTRAINT;
         }
-        else if (s_drop_constraint.ignore(pos, expected))
+        else if (s_drop_constraint.ignore(pos, expected, ranges))
         {
-            if (s_if_exists.ignore(pos, expected))
+            if (s_if_exists.ignore(pos, expected, ranges))
                 command->if_exists = true;
 
-            if (!parser_name.parse(pos, command->constraint, expected))
+            if (!parser_name.parse(pos, command->constraint, expected, ranges))
                 return false;
 
             command->type = ASTAlterCommand::DROP_CONSTRAINT;
             command->detach = false;
         }
-        else if (s_detach_partition.ignore(pos, expected))
+        else if (s_detach_partition.ignore(pos, expected, ranges))
         {
-            if (!parser_partition.parse(pos, command->partition, expected))
+            if (!parser_partition.parse(pos, command->partition, expected, ranges))
                 return false;
 
             command->type = ASTAlterCommand::DROP_PARTITION;
             command->detach = true;
         }
-        else if (s_attach_partition.ignore(pos, expected))
+        else if (s_attach_partition.ignore(pos, expected, ranges))
         {
-            if (!parser_partition.parse(pos, command->partition, expected))
+            if (!parser_partition.parse(pos, command->partition, expected, ranges))
                 return false;
 
-            if (s_from.ignore(pos))
+            if (s_from.ignore(pos, expected, ranges))
             {
-                if (!parseDatabaseAndTableName(pos, expected, command->from_database, command->from_table))
+                if (!parseDatabaseAndTableName(pos, expected, ranges, command->from_database, command->from_table))
                     return false;
 
                 command->replace = false;
@@ -357,48 +357,48 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
                 command->type = ASTAlterCommand::ATTACH_PARTITION;
             }
         }
-        else if (s_replace_partition.ignore(pos, expected))
+        else if (s_replace_partition.ignore(pos, expected, ranges))
         {
-            if (!parser_partition.parse(pos, command->partition, expected))
+            if (!parser_partition.parse(pos, command->partition, expected, ranges))
                 return false;
 
-            if (!s_from.ignore(pos, expected))
+            if (!s_from.ignore(pos, expected, ranges))
                 return false;
 
-            if (!parseDatabaseAndTableName(pos, expected, command->from_database, command->from_table))
+            if (!parseDatabaseAndTableName(pos, expected, ranges, command->from_database, command->from_table))
                 return false;
 
             command->replace = true;
             command->type = ASTAlterCommand::REPLACE_PARTITION;
         }
-        else if (s_attach_part.ignore(pos, expected))
+        else if (s_attach_part.ignore(pos, expected, ranges))
         {
-            if (!parser_string_literal.parse(pos, command->partition, expected))
+            if (!parser_string_literal.parse(pos, command->partition, expected, ranges))
                 return false;
 
             command->part = true;
             command->type = ASTAlterCommand::ATTACH_PARTITION;
         }
-        else if (s_fetch_partition.ignore(pos, expected))
+        else if (s_fetch_partition.ignore(pos, expected, ranges))
         {
-            if (!parser_partition.parse(pos, command->partition, expected))
+            if (!parser_partition.parse(pos, command->partition, expected, ranges))
                 return false;
 
-            if (!s_from.ignore(pos, expected))
+            if (!s_from.ignore(pos, expected, ranges))
                 return false;
 
             ASTPtr ast_from;
-            if (!parser_string_literal.parse(pos, ast_from, expected))
+            if (!parser_string_literal.parse(pos, ast_from, expected, ranges))
                 return false;
 
             command->from = ast_from->as<ASTLiteral &>().value.get<const String &>();
             command->type = ASTAlterCommand::FETCH_PARTITION;
         }
-        else if (s_freeze.ignore(pos, expected))
+        else if (s_freeze.ignore(pos, expected, ranges))
         {
-            if (s_partition.ignore(pos, expected))
+            if (s_partition.ignore(pos, expected, ranges))
             {
-                if (!parser_partition.parse(pos, command->partition, expected))
+                if (!parser_partition.parse(pos, command->partition, expected, ranges))
                     return false;
 
                 command->type = ASTAlterCommand::FREEZE_PARTITION;
@@ -409,93 +409,93 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
             }
 
             /// WITH NAME 'name' - place local backup to directory with specified name
-            if (s_with.ignore(pos, expected))
+            if (s_with.ignore(pos, expected, ranges))
             {
-                if (!s_name.ignore(pos, expected))
+                if (!s_name.ignore(pos, expected, ranges))
                     return false;
 
                 ASTPtr ast_with_name;
-                if (!parser_string_literal.parse(pos, ast_with_name, expected))
+                if (!parser_string_literal.parse(pos, ast_with_name, expected, ranges))
                     return false;
 
                 command->with_name = ast_with_name->as<ASTLiteral &>().value.get<const String &>();
             }
         }
-        else if (s_modify_column.ignore(pos, expected))
+        else if (s_modify_column.ignore(pos, expected, ranges))
         {
-            if (s_if_exists.ignore(pos, expected))
+            if (s_if_exists.ignore(pos, expected, ranges))
                 command->if_exists = true;
 
-            if (!parser_modify_col_decl.parse(pos, command->col_decl, expected))
+            if (!parser_modify_col_decl.parse(pos, command->col_decl, expected, ranges))
                 return false;
 
             command->type = ASTAlterCommand::MODIFY_COLUMN;
         }
-        else if (s_modify_order_by.ignore(pos, expected))
+        else if (s_modify_order_by.ignore(pos, expected, ranges))
         {
-            if (!parser_exp_elem.parse(pos, command->order_by, expected))
+            if (!parser_exp_elem.parse(pos, command->order_by, expected, ranges))
                 return false;
 
             command->type = ASTAlterCommand::MODIFY_ORDER_BY;
         }
-        else if (s_delete_where.ignore(pos, expected))
+        else if (s_delete_where.ignore(pos, expected, ranges))
         {
-            if (!parser_exp_elem.parse(pos, command->predicate, expected))
+            if (!parser_exp_elem.parse(pos, command->predicate, expected, ranges))
                 return false;
 
             command->type = ASTAlterCommand::DELETE;
         }
-        else if (s_update.ignore(pos, expected))
+        else if (s_update.ignore(pos, expected, ranges))
         {
-            if (!parser_assignment_list.parse(pos, command->update_assignments, expected))
+            if (!parser_assignment_list.parse(pos, command->update_assignments, expected, ranges))
                 return false;
 
-            if (!s_where.ignore(pos, expected))
+            if (!s_where.ignore(pos, expected, ranges))
                 return false;
 
-            if (!parser_exp_elem.parse(pos, command->predicate, expected))
+            if (!parser_exp_elem.parse(pos, command->predicate, expected, ranges))
                 return false;
 
             command->type = ASTAlterCommand::UPDATE;
         }
-        else if (s_comment_column.ignore(pos, expected))
+        else if (s_comment_column.ignore(pos, expected, ranges))
         {
-            if (s_if_exists.ignore(pos, expected))
+            if (s_if_exists.ignore(pos, expected, ranges))
                 command->if_exists = true;
 
-            if (!parser_name.parse(pos, command->column, expected))
+            if (!parser_name.parse(pos, command->column, expected, ranges))
                 return false;
 
-            if (!parser_string_literal.parse(pos, command->comment, expected))
+            if (!parser_string_literal.parse(pos, command->comment, expected, ranges))
                 return false;
 
             command->type = ASTAlterCommand::COMMENT_COLUMN;
         }
-        else if (s_modify_ttl.ignore(pos, expected))
+        else if (s_modify_ttl.ignore(pos, expected, ranges))
         {
-            if (!parser_ttl_list.parse(pos, command->ttl, expected))
+            if (!parser_ttl_list.parse(pos, command->ttl, expected, ranges))
                 return false;
             command->type = ASTAlterCommand::MODIFY_TTL;
         }
-        else if (s_materialize_ttl.ignore(pos, expected))
+        else if (s_materialize_ttl.ignore(pos, expected, ranges))
         {
             command->type = ASTAlterCommand::MATERIALIZE_TTL;
 
-            if (s_in_partition.ignore(pos, expected))
+            if (s_in_partition.ignore(pos, expected, ranges))
             {
-                if (!parser_partition.parse(pos, command->partition, expected))
+                if (!parser_partition.parse(pos, command->partition, expected, ranges))
                     return false;
             }
         }
-        else if (s_modify_setting.ignore(pos, expected))
+        else if (s_modify_setting.ignore(pos, expected, ranges))
         {
-            if (!parser_settings.parse(pos, command->settings_changes, expected))
+            if (!parser_settings.parse(pos, command->settings_changes, expected, ranges))
                 return false;
             command->type = ASTAlterCommand::MODIFY_SETTING;
         }
-        else if (s_modify_query.ignore(pos, expected))
+        else if (s_modify_query.ignore(pos, expected, ranges))
         {
-            if (!select_p.parse(pos, command->select, expected))
+            if (!select_p.parse(pos, command->select, expected, ranges))
                 return false;
             command->type = ASTAlterCommand::MODIFY_QUERY;
         }
@@ -529,7 +529,7 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
 }
 
 
-bool ParserAlterCommandList::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserAlterCommandList::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     auto command_list = std::make_shared<ASTAlterCommandList>();
     node = command_list;
@@ -540,18 +540,18 @@ bool ParserAlterCommandList::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
     do
     {
         ASTPtr command;
-        if (!p_command.parse(pos, command, expected))
+        if (!p_command.parse(pos, command, expected, ranges))
             return false;
 
         command_list->add(command);
     }
-    while (s_comma.ignore(pos, expected));
+    while (s_comma.ignore(pos, expected, ranges));
 
     return true;
 }
 
 
-bool ParserAssignment::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserAssignment::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     auto assignment = std::make_shared<ASTAssignment>();
     node = assignment;
@@ -561,13 +561,13 @@ bool ParserAssignment::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     ParserExpression p_expression;
 
     ASTPtr column;
-    if (!p_identifier.parse(pos, column, expected))
+    if (!p_identifier.parse(pos, column, expected, ranges))
         return false;
 
-    if (!s_equals.ignore(pos, expected))
+    if (!s_equals.ignore(pos, expected, ranges))
         return false;
 
-    if (!p_expression.parse(pos, assignment->expression, expected))
+    if (!p_expression.parse(pos, assignment->expression, expected, ranges))
         return false;
 
     tryGetIdentifierNameInto(column, assignment->column_name);
@@ -578,7 +578,7 @@ bool ParserAssignment::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 }
 
 
-bool ParserAlterQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserAlterQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     auto query = std::make_shared<ASTAlterQuery>();
     node = query;
@@ -588,9 +588,9 @@ bool ParserAlterQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 
     bool is_live_view = false;
 
-    if (!s_alter_table.ignore(pos, expected))
+    if (!s_alter_table.ignore(pos, expected, ranges))
     {
-        if (!s_alter_live_view.ignore(pos, expected))
+        if (!s_alter_live_view.ignore(pos, expected, ranges))
             return false;
         else
             is_live_view = true;
@@ -599,20 +599,20 @@ bool ParserAlterQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     if (is_live_view)
         query->is_live_view = true;
 
-    if (!parseDatabaseAndTableName(pos, expected, query->database, query->table))
+    if (!parseDatabaseAndTableName(pos, expected, ranges, query->database, query->table))
         return false;
 
     String cluster_str;
-    if (ParserKeyword{"ON"}.ignore(pos, expected))
+    if (ParserKeyword{"ON"}.ignore(pos, expected, ranges))
     {
-        if (!ASTQueryWithOnCluster::parse(pos, cluster_str, expected))
+        if (!ASTQueryWithOnCluster::parse(pos, cluster_str, expected, ranges))
             return false;
     }
     query->cluster = cluster_str;
 
     ParserAlterCommandList p_command_list(is_live_view);
     ASTPtr command_list;
-    if (!p_command_list.parse(pos, command_list, expected))
+    if (!p_command_list.parse(pos, command_list, expected, ranges))
         return false;
 
     query->set(query->command_list, command_list);

--- a/src/Parsers/ParserAlterQuery.h
+++ b/src/Parsers/ParserAlterQuery.h
@@ -29,7 +29,7 @@ class ParserAlterQuery : public IParserBase
 {
 protected:
     const char * getName() const  override{ return "ALTER query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -37,7 +37,7 @@ class ParserAlterCommandList : public IParserBase
 {
 protected:
     const char * getName() const  override{ return "a list of ALTER commands"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 
 public:
     bool is_live_view;
@@ -50,7 +50,7 @@ class ParserAlterCommand : public IParserBase
 {
 protected:
     const char * getName() const  override{ return "ALTER command"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 
 public:
     bool is_live_view;
@@ -64,7 +64,7 @@ class ParserAssignment : public IParserBase
 {
 protected:
     const char * getName() const  override{ return "column assignment"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 }

--- a/src/Parsers/ParserCase.cpp
+++ b/src/Parsers/ParserCase.cpp
@@ -8,7 +8,7 @@
 namespace DB
 {
 
-bool ParserCase::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserCase::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     ParserKeyword s_case{"CASE"};
     ParserKeyword s_when{"WHEN"};
@@ -17,11 +17,11 @@ bool ParserCase::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     ParserKeyword s_end{ "END"};
     ParserExpressionWithOptionalAlias p_expr{false};
 
-    if (!s_case.ignore(pos, expected))
+    if (!s_case.ignore(pos, expected, ranges))
         return false;
 
     auto old_pos = pos;
-    bool has_case_expr = !s_when.ignore(pos, expected);
+    bool has_case_expr = !s_when.ignore(pos, expected, ranges);
     pos = old_pos;
 
     ASTs args;
@@ -29,20 +29,20 @@ bool ParserCase::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     auto parse_branches = [&]()
     {
         bool has_branch = false;
-        while (s_when.ignore(pos, expected))
+        while (s_when.ignore(pos, expected, ranges))
         {
             has_branch = true;
 
             ASTPtr expr_when;
-            if (!p_expr.parse(pos, expr_when, expected))
+            if (!p_expr.parse(pos, expr_when, expected, ranges))
                 return false;
             args.push_back(expr_when);
 
-            if (!s_then.ignore(pos, expected))
+            if (!s_then.ignore(pos, expected, ranges))
                 return false;
 
             ASTPtr expr_then;
-            if (!p_expr.parse(pos, expr_then, expected))
+            if (!p_expr.parse(pos, expr_then, expected, ranges))
                 return false;
             args.push_back(expr_then);
         }
@@ -51,9 +51,9 @@ bool ParserCase::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
             return false;
 
         ASTPtr expr_else;
-        if (s_else.ignore(pos, expected))
+        if (s_else.ignore(pos, expected, ranges))
         {
-            if (!p_expr.parse(pos, expr_else, expected))
+            if (!p_expr.parse(pos, expr_else, expected, ranges))
                 return false;
         }
         else
@@ -64,13 +64,13 @@ bool ParserCase::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         }
         args.push_back(expr_else);
 
-        return s_end.ignore(pos, expected);
+        return s_end.ignore(pos, expected, ranges);
     };
 
     if (has_case_expr)
     {
         ASTPtr case_expr;
-        if (!p_expr.parse(pos, case_expr, expected))
+        if (!p_expr.parse(pos, case_expr, expected, ranges))
             return false;
         args.push_back(case_expr);
 

--- a/src/Parsers/ParserCase.h
+++ b/src/Parsers/ParserCase.h
@@ -15,7 +15,7 @@ class ParserCase final : public IParserBase
 {
 protected:
     const char * getName() const override { return "case"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 }

--- a/src/Parsers/ParserCheckQuery.cpp
+++ b/src/Parsers/ParserCheckQuery.cpp
@@ -9,7 +9,7 @@
 namespace DB
 {
 
-bool ParserCheckQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserCheckQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     ParserKeyword s_check_table("CHECK TABLE");
     ParserKeyword s_partition("PARTITION");
@@ -21,15 +21,15 @@ bool ParserCheckQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     ASTPtr table;
     ASTPtr database;
 
-    if (!s_check_table.ignore(pos, expected))
+    if (!s_check_table.ignore(pos, expected, ranges))
         return false;
-    if (!table_parser.parse(pos, database, expected))
+    if (!table_parser.parse(pos, database, expected, ranges))
         return false;
 
     auto query = std::make_shared<ASTCheckQuery>();
-    if (s_dot.ignore(pos))
+    if (s_dot.ignore(pos, expected, ranges))
     {
-        if (!table_parser.parse(pos, table, expected))
+        if (!table_parser.parse(pos, table, expected, ranges))
             return false;
 
         tryGetIdentifierNameInto(database, query->database);
@@ -41,9 +41,9 @@ bool ParserCheckQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         tryGetIdentifierNameInto(table, query->table);
     }
 
-    if (s_partition.ignore(pos, expected))
+    if (s_partition.ignore(pos, expected, ranges))
     {
-        if (!partition_parser.parse(pos, query->partition, expected))
+        if (!partition_parser.parse(pos, query->partition, expected, ranges))
             return false;
     }
 

--- a/src/Parsers/ParserCheckQuery.h
+++ b/src/Parsers/ParserCheckQuery.h
@@ -11,7 +11,7 @@ class ParserCheckQuery : public IParserBase
 {
 protected:
     const char * getName() const  override{ return "ALTER query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 }

--- a/src/Parsers/ParserCreateQuotaQuery.h
+++ b/src/Parsers/ParserCreateQuotaQuery.h
@@ -28,7 +28,7 @@ public:
 
 protected:
     const char * getName() const override { return "CREATE QUOTA or ALTER QUOTA query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 
 private:
     bool attach_mode = false;

--- a/src/Parsers/ParserCreateRoleQuery.h
+++ b/src/Parsers/ParserCreateRoleQuery.h
@@ -20,7 +20,7 @@ public:
 
 protected:
     const char * getName() const override { return "CREATE ROLE or ALTER ROLE query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 
 private:
     bool attach_mode = false;

--- a/src/Parsers/ParserCreateRowPolicyQuery.h
+++ b/src/Parsers/ParserCreateRowPolicyQuery.h
@@ -28,7 +28,7 @@ public:
 
 protected:
     const char * getName() const override { return "CREATE ROW POLICY or ALTER ROW POLICY query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 
 private:
     bool attach_mode = false;

--- a/src/Parsers/ParserCreateSettingsProfileQuery.h
+++ b/src/Parsers/ParserCreateSettingsProfileQuery.h
@@ -20,7 +20,7 @@ public:
 
 protected:
     const char * getName() const override { return "CREATE SETTINGS PROFILE or ALTER SETTINGS PROFILE query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 
 private:
     bool attach_mode = false;

--- a/src/Parsers/ParserCreateUserQuery.h
+++ b/src/Parsers/ParserCreateUserQuery.h
@@ -24,7 +24,7 @@ public:
 
 protected:
     const char * getName() const override { return "CREATE USER or ALTER USER query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 
 private:
     bool attach_mode = false;

--- a/src/Parsers/ParserDescribeTableQuery.cpp
+++ b/src/Parsers/ParserDescribeTableQuery.cpp
@@ -11,7 +11,7 @@ namespace DB
 {
 
 
-bool ParserDescribeTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserDescribeTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     ParserKeyword s_describe("DESCRIBE");
     ParserKeyword s_desc("DESC");
@@ -22,15 +22,15 @@ bool ParserDescribeTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & ex
     ASTPtr database;
     ASTPtr table;
 
-    if (!s_describe.ignore(pos, expected) && !s_desc.ignore(pos, expected))
+    if (!s_describe.ignore(pos, expected, ranges) && !s_desc.ignore(pos, expected, ranges))
         return false;
 
     auto query = std::make_shared<ASTDescribeQuery>();
 
-    s_table.ignore(pos, expected);
+    s_table.ignore(pos, expected, ranges);
 
     ASTPtr table_expression;
-    if (!ParserTableExpression().parse(pos, table_expression, expected))
+    if (!ParserTableExpression().parse(pos, table_expression, expected, ranges))
         return false;
 
     query->table_expression = table_expression;

--- a/src/Parsers/ParserDescribeTableQuery.h
+++ b/src/Parsers/ParserDescribeTableQuery.h
@@ -14,7 +14,7 @@ class ParserDescribeTableQuery : public IParserBase
 {
 protected:
     const char * getName() const override { return "DESCRIBE query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 }

--- a/src/Parsers/ParserDictionary.h
+++ b/src/Parsers/ParserDictionary.h
@@ -15,7 +15,7 @@ class ParserDictionaryLifetime : public IParserBase
 {
 protected:
     const char * getName() const override { return "lifetime definition"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 /// Parser for dictionary range part. It should contain "range" keyword opening
@@ -25,7 +25,7 @@ class ParserDictionaryRange : public IParserBase
 {
 protected:
     const char * getName() const override { return "range definition"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -36,14 +36,14 @@ class ParserDictionaryLayout : public IParserBase
 {
 protected:
     const char * getName() const override { return "layout definition"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 class ParserDictionarySettings: public IParserBase
 {
 protected:
     const char * getName() const override { return "settings definition"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -61,7 +61,7 @@ class ParserDictionary : public IParserBase
 {
 protected:
     const char * getName() const override { return "dictionary definition"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 }

--- a/src/Parsers/ParserDictionaryAttributeDeclaration.cpp
+++ b/src/Parsers/ParserDictionaryAttributeDeclaration.cpp
@@ -6,7 +6,7 @@
 namespace DB
 {
 
-bool ParserDictionaryAttributeDeclaration::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserDictionaryAttributeDeclaration::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     ParserIdentifier name_parser;
     ParserIdentifierWithOptionalParameters type_parser;
@@ -20,7 +20,7 @@ bool ParserDictionaryAttributeDeclaration::parseImpl(Pos & pos, ASTPtr & node, E
 
     /// mandatory attribute name
     ASTPtr name;
-    if (!name_parser.parse(pos, name, expected))
+    if (!name_parser.parse(pos, name, expected, ranges))
         return false;
 
     ASTPtr type;
@@ -31,40 +31,40 @@ bool ParserDictionaryAttributeDeclaration::parseImpl(Pos & pos, ASTPtr & node, E
     bool is_object_id = false;
 
     /// attribute name should be followed by type name if it
-    if (!type_parser.parse(pos, type, expected))
+    if (!type_parser.parse(pos, type, expected, ranges))
         return false;
 
     /// loop to avoid strict order of attribute properties
     while (true)
     {
-        if (!default_value && s_default.ignore(pos, expected))
+        if (!default_value && s_default.ignore(pos, expected, ranges))
         {
-            if (!default_parser.parse(pos, default_value, expected))
+            if (!default_parser.parse(pos, default_value, expected, ranges))
                 return false;
             continue;
         }
 
-        if (!expression && s_expression.ignore(pos, expected))
+        if (!expression && s_expression.ignore(pos, expected, ranges))
         {
-            if (!expression_parser.parse(pos, expression, expected))
+            if (!expression_parser.parse(pos, expression, expected, ranges))
                 return false;
             continue;
         }
 
         /// just single keyword, we don't use "true" or "1" for value
-        if (!hierarchical && s_hierarchical.ignore(pos, expected))
+        if (!hierarchical && s_hierarchical.ignore(pos, expected, ranges))
         {
             hierarchical = true;
             continue;
         }
 
-        if (!injective && s_injective.ignore(pos, expected))
+        if (!injective && s_injective.ignore(pos, expected, ranges))
         {
             injective = true;
             continue;
         }
 
-        if (!is_object_id && s_is_object_id.ignore(pos, expected))
+        if (!is_object_id && s_is_object_id.ignore(pos, expected, ranges))
         {
             is_object_id = true;
             continue;
@@ -103,11 +103,11 @@ bool ParserDictionaryAttributeDeclaration::parseImpl(Pos & pos, ASTPtr & node, E
 }
 
 
-bool ParserDictionaryAttributeDeclarationList::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserDictionaryAttributeDeclarationList::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     return ParserList(std::make_unique<ParserDictionaryAttributeDeclaration>(),
         std::make_unique<ParserToken>(TokenType::Comma), false)
-        .parse(pos, node, expected);
+        .parse(pos, node, expected, ranges);
 }
 
 }

--- a/src/Parsers/ParserDictionaryAttributeDeclaration.h
+++ b/src/Parsers/ParserDictionaryAttributeDeclaration.h
@@ -17,7 +17,7 @@ class ParserDictionaryAttributeDeclaration : public IParserBase
 protected:
     const char * getName() const override { return "attribute declaration"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -26,7 +26,7 @@ class ParserDictionaryAttributeDeclarationList : public IParserBase
 {
 protected:
     const char * getName() const  override{ return "attribute declaration list"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 }

--- a/src/Parsers/ParserDropAccessEntityQuery.h
+++ b/src/Parsers/ParserDropAccessEntityQuery.h
@@ -16,6 +16,6 @@ class ParserDropAccessEntityQuery : public IParserBase
 {
 protected:
     const char * getName() const override { return "DROP access entity query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 }

--- a/src/Parsers/ParserDropQuery.h
+++ b/src/Parsers/ParserDropQuery.h
@@ -20,7 +20,7 @@ class ParserDropQuery : public IParserBase
 {
 protected:
     const char * getName() const  override{ return "DROP query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 }

--- a/src/Parsers/ParserExtendedRoleSet.cpp
+++ b/src/Parsers/ParserExtendedRoleSet.cpp
@@ -11,22 +11,22 @@ namespace DB
 {
 namespace
 {
-    bool parseRoleNameOrID(IParserBase::Pos & pos, Expected & expected, bool parse_id, String & res)
+    bool parseRoleNameOrID(IParserBase::Pos & pos, Expected & expected, IParser::Ranges * ranges, bool parse_id, String & res)
     {
         return IParserBase::wrapParseImpl(pos, [&]
         {
             if (!parse_id)
-                return parseRoleName(pos, expected, res);
+                return parseRoleName(pos, expected, ranges, res);
 
-            if (!ParserKeyword{"ID"}.ignore(pos, expected))
+            if (!ParserKeyword{"ID"}.ignore(pos, expected, ranges))
                 return false;
-            if (!ParserToken(TokenType::OpeningRoundBracket).ignore(pos, expected))
+            if (!ParserToken(TokenType::OpeningRoundBracket).ignore(pos, expected, ranges))
                 return false;
             ASTPtr ast;
-            if (!ParserStringLiteral{}.parse(pos, ast, expected))
+            if (!ParserStringLiteral{}.parse(pos, ast, expected, ranges))
                 return false;
             String id = ast->as<ASTLiteral &>().value.safeGet<String>();
-            if (!ParserToken(TokenType::ClosingRoundBracket).ignore(pos, expected))
+            if (!ParserToken(TokenType::ClosingRoundBracket).ignore(pos, expected, ranges))
                 return false;
 
             res = std::move(id);
@@ -38,6 +38,7 @@ namespace
     bool parseBeforeExcept(
         IParserBase::Pos & pos,
         Expected & expected,
+        IParser::Ranges * ranges,
         bool id_mode,
         bool all_keyword_enabled,
         bool current_user_keyword_enabled,
@@ -52,33 +53,33 @@ namespace
             Strings res_names;
             while (true)
             {
-                if (ParserKeyword{"NONE"}.ignore(pos, expected))
+                if (ParserKeyword{"NONE"}.ignore(pos, expected, ranges))
                 {
                 }
                 else if (
                     current_user_keyword_enabled
-                    && (ParserKeyword{"CURRENT_USER"}.ignore(pos, expected) || ParserKeyword{"currentUser"}.ignore(pos, expected)))
+                    && (ParserKeyword{"CURRENT_USER"}.ignore(pos, expected, ranges) || ParserKeyword{"currentUser"}.ignore(pos, expected, ranges)))
                 {
-                    if (ParserToken{TokenType::OpeningRoundBracket}.ignore(pos, expected))
+                    if (ParserToken{TokenType::OpeningRoundBracket}.ignore(pos, expected, ranges))
                     {
-                        if (!ParserToken{TokenType::ClosingRoundBracket}.ignore(pos, expected))
+                        if (!ParserToken{TokenType::ClosingRoundBracket}.ignore(pos, expected, ranges))
                             return false;
                     }
                     res_current_user = true;
                 }
-                else if (all_keyword_enabled && ParserKeyword{"ALL"}.ignore(pos, expected))
+                else if (all_keyword_enabled && ParserKeyword{"ALL"}.ignore(pos, expected, ranges))
                 {
                     res_all = true;
                 }
                 else
                 {
                     String name;
-                    if (!parseRoleNameOrID(pos, expected, id_mode, name))
+                    if (!parseRoleNameOrID(pos, expected, ranges, id_mode, name))
                         return false;
                     res_names.push_back(name);
                 }
 
-                if (!ParserToken{TokenType::Comma}.ignore(pos, expected))
+                if (!ParserToken{TokenType::Comma}.ignore(pos, expected, ranges))
                     break;
             }
 
@@ -92,6 +93,7 @@ namespace
     bool parseExceptAndAfterExcept(
         IParserBase::Pos & pos,
         Expected & expected,
+        IParser::Ranges * ranges,
         bool id_mode,
         bool current_user_keyword_enabled,
         Strings & except_names,
@@ -99,17 +101,17 @@ namespace
     {
         return IParserBase::wrapParseImpl(pos, [&]
         {
-            if (!ParserKeyword{"EXCEPT"}.ignore(pos, expected))
+            if (!ParserKeyword{"EXCEPT"}.ignore(pos, expected, ranges))
                 return false;
 
             bool dummy;
-            return parseBeforeExcept(pos, expected, id_mode, false, current_user_keyword_enabled, except_names, dummy, except_current_user);
+            return parseBeforeExcept(pos, expected, ranges, id_mode, false, current_user_keyword_enabled, except_names, dummy, except_current_user);
         });
     }
 }
 
 
-bool ParserExtendedRoleSet::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserExtendedRoleSet::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     Strings names;
     bool current_user = false;
@@ -117,10 +119,10 @@ bool ParserExtendedRoleSet::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     Strings except_names;
     bool except_current_user = false;
 
-    if (!parseBeforeExcept(pos, expected, id_mode, all_keyword, current_user_keyword, names, all, current_user))
+    if (!parseBeforeExcept(pos, expected, ranges, id_mode, all_keyword, current_user_keyword, names, all, current_user))
         return false;
 
-    parseExceptAndAfterExcept(pos, expected, id_mode, current_user_keyword, except_names, except_current_user);
+    parseExceptAndAfterExcept(pos, expected, ranges, id_mode, current_user_keyword, except_names, except_current_user);
 
     if (all)
         names.clear();

--- a/src/Parsers/ParserExtendedRoleSet.h
+++ b/src/Parsers/ParserExtendedRoleSet.h
@@ -17,7 +17,7 @@ public:
 
 protected:
     const char * getName() const override { return "ExtendedRoleSet"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 
 private:
     bool all_keyword = true;

--- a/src/Parsers/ParserGrantQuery.h
+++ b/src/Parsers/ParserGrantQuery.h
@@ -16,7 +16,7 @@ public:
 
 protected:
     const char * getName() const override { return "GRANT or REVOKE query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 
 private:
     bool attach_mode = false;

--- a/src/Parsers/ParserInsertQuery.h
+++ b/src/Parsers/ParserInsertQuery.h
@@ -28,7 +28,7 @@ private:
     const char * end;
 
     const char * getName() const override { return "INSERT query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 public:
     ParserInsertQuery(const char * end_) : end(end_) {}
 };

--- a/src/Parsers/ParserKillQueryQuery.cpp
+++ b/src/Parsers/ParserKillQueryQuery.cpp
@@ -9,7 +9,7 @@ namespace DB
 {
 
 
-bool ParserKillQueryQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserKillQueryQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     String cluster_str;
     auto query = std::make_shared<ASTKillQueryQuery>();
@@ -24,27 +24,27 @@ bool ParserKillQueryQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expect
     ParserKeyword p_where{"WHERE"};
     ParserExpression p_where_expression;
 
-    if (!p_kill.ignore(pos, expected))
+    if (!p_kill.ignore(pos, expected, ranges))
         return false;
 
-    if (p_query.ignore(pos, expected))
+    if (p_query.ignore(pos, expected, ranges))
         query->type = ASTKillQueryQuery::Type::Query;
-    else if (p_mutation.ignore(pos, expected))
+    else if (p_mutation.ignore(pos, expected, ranges))
         query->type = ASTKillQueryQuery::Type::Mutation;
     else
         return false;
 
-    if (p_on.ignore(pos, expected) && !ASTQueryWithOnCluster::parse(pos, cluster_str, expected))
+    if (p_on.ignore(pos, expected, ranges) && !ASTQueryWithOnCluster::parse(pos, cluster_str, expected, ranges))
         return false;
 
-    if (!p_where.ignore(pos, expected) || !p_where_expression.parse(pos, query->where_expression, expected))
+    if (!p_where.ignore(pos, expected, ranges) || !p_where_expression.parse(pos, query->where_expression, expected, ranges))
         return false;
 
-    if (p_sync.ignore(pos, expected))
+    if (p_sync.ignore(pos, expected, ranges))
         query->sync = true;
-    else if (p_async.ignore(pos, expected))
+    else if (p_async.ignore(pos, expected, ranges))
         query->sync = false;
-    else if (p_test.ignore(pos, expected))
+    else if (p_test.ignore(pos, expected, ranges))
         query->test = true;
 
     query->cluster = cluster_str;

--- a/src/Parsers/ParserKillQueryQuery.h
+++ b/src/Parsers/ParserKillQueryQuery.h
@@ -12,7 +12,7 @@ class ParserKillQueryQuery : public IParserBase
 {
 protected:
     const char * getName() const override { return "KILL QUERY query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 }

--- a/src/Parsers/ParserOptimizeQuery.cpp
+++ b/src/Parsers/ParserOptimizeQuery.cpp
@@ -10,7 +10,7 @@ namespace DB
 {
 
 
-bool ParserOptimizeQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserOptimizeQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     ParserKeyword s_optimize_table("OPTIMIZE TABLE");
     ParserKeyword s_partition("PARTITION");
@@ -27,32 +27,32 @@ bool ParserOptimizeQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expecte
     bool deduplicate = false;
     String cluster_str;
 
-    if (!s_optimize_table.ignore(pos, expected))
+    if (!s_optimize_table.ignore(pos, expected, ranges))
         return false;
 
-    if (!name_p.parse(pos, table, expected))
+    if (!name_p.parse(pos, table, expected, ranges))
         return false;
 
-    if (s_dot.ignore(pos, expected))
+    if (s_dot.ignore(pos, expected, ranges))
     {
         database = table;
-        if (!name_p.parse(pos, table, expected))
+        if (!name_p.parse(pos, table, expected, ranges))
             return false;
     }
 
-    if (ParserKeyword{"ON"}.ignore(pos, expected) && !ASTQueryWithOnCluster::parse(pos, cluster_str, expected))
+    if (ParserKeyword{"ON"}.ignore(pos, expected, ranges) && !ASTQueryWithOnCluster::parse(pos, cluster_str, expected, ranges))
         return false;
 
-    if (s_partition.ignore(pos, expected))
+    if (s_partition.ignore(pos, expected, ranges))
     {
-        if (!partition_p.parse(pos, partition, expected))
+        if (!partition_p.parse(pos, partition, expected, ranges))
             return false;
     }
 
-    if (s_final.ignore(pos, expected))
+    if (s_final.ignore(pos, expected, ranges))
         final = true;
 
-    if (s_deduplicate.ignore(pos, expected))
+    if (s_deduplicate.ignore(pos, expected, ranges))
         deduplicate = true;
 
     auto query = std::make_shared<ASTOptimizeQuery>();

--- a/src/Parsers/ParserOptimizeQuery.h
+++ b/src/Parsers/ParserOptimizeQuery.h
@@ -13,7 +13,7 @@ class ParserOptimizeQuery : public IParserBase
 {
 protected:
     const char * getName() const override { return "OPTIMIZE query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 }

--- a/src/Parsers/ParserPartition.cpp
+++ b/src/Parsers/ParserPartition.cpp
@@ -10,7 +10,7 @@
 namespace DB
 {
 
-bool ParserPartition::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserPartition::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     ParserKeyword s_id("ID");
     ParserStringLiteral parser_string_literal;
@@ -20,10 +20,10 @@ bool ParserPartition::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 
     auto partition = std::make_shared<ASTPartition>();
 
-    if (s_id.ignore(pos, expected))
+    if (s_id.ignore(pos, expected, ranges))
     {
         ASTPtr partition_id;
-        if (!parser_string_literal.parse(pos, partition_id, expected))
+        if (!parser_string_literal.parse(pos, partition_id, expected, ranges))
             return false;
 
         partition->id = partition_id->as<ASTLiteral &>().value.get<String>();
@@ -31,7 +31,7 @@ bool ParserPartition::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     else
     {
         ASTPtr value;
-        if (!parser_expr.parse(pos, value, expected))
+        if (!parser_expr.parse(pos, value, expected, ranges))
             return false;
 
         size_t fields_count;

--- a/src/Parsers/ParserPartition.h
+++ b/src/Parsers/ParserPartition.h
@@ -11,7 +11,7 @@ class ParserPartition : public IParserBase
 {
 protected:
     const char * getName() const override { return "partition"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 }

--- a/src/Parsers/ParserQuery.cpp
+++ b/src/Parsers/ParserQuery.cpp
@@ -23,7 +23,7 @@ namespace DB
 {
 
 
-bool ParserQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     ParserQueryWithOutput query_with_output_p(enable_explain);
     ParserInsertQuery insert_p(end);
@@ -39,19 +39,19 @@ bool ParserQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     ParserGrantQuery grant_p;
     ParserSetRoleQuery set_role_p;
 
-    bool res = query_with_output_p.parse(pos, node, expected)
-        || insert_p.parse(pos, node, expected)
-        || use_p.parse(pos, node, expected)
-        || set_role_p.parse(pos, node, expected)
-        || set_p.parse(pos, node, expected)
-        || system_p.parse(pos, node, expected)
-        || create_user_p.parse(pos, node, expected)
-        || create_role_p.parse(pos, node, expected)
-        || create_quota_p.parse(pos, node, expected)
-        || create_row_policy_p.parse(pos, node, expected)
-        || create_settings_profile_p.parse(pos, node, expected)
-        || drop_access_entity_p.parse(pos, node, expected)
-        || grant_p.parse(pos, node, expected);
+    bool res = query_with_output_p.parse(pos, node, expected, ranges)
+        || insert_p.parse(pos, node, expected, ranges)
+        || use_p.parse(pos, node, expected, ranges)
+        || set_role_p.parse(pos, node, expected, ranges)
+        || set_p.parse(pos, node, expected, ranges)
+        || system_p.parse(pos, node, expected, ranges)
+        || create_user_p.parse(pos, node, expected, ranges)
+        || create_role_p.parse(pos, node, expected, ranges)
+        || create_quota_p.parse(pos, node, expected, ranges)
+        || create_row_policy_p.parse(pos, node, expected, ranges)
+        || create_settings_profile_p.parse(pos, node, expected, ranges)
+        || drop_access_entity_p.parse(pos, node, expected, ranges)
+        || grant_p.parse(pos, node, expected, ranges);
 
     return res;
 }

--- a/src/Parsers/ParserQuery.h
+++ b/src/Parsers/ParserQuery.h
@@ -13,7 +13,7 @@ private:
     bool enable_explain;    /// Allow queries prefixed with AST and ANALYZE for development purposes.
 
     const char * getName() const override { return "Query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 
 public:
     ParserQuery(const char * end_, bool enable_explain_ = false)

--- a/src/Parsers/ParserQueryWithOutput.cpp
+++ b/src/Parsers/ParserQueryWithOutput.cpp
@@ -23,7 +23,7 @@
 namespace DB
 {
 
-bool ParserQueryWithOutput::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserQueryWithOutput::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     ParserShowTablesQuery show_tables_p;
     ParserSelectWithUnionQuery select_p;
@@ -50,29 +50,29 @@ bool ParserQueryWithOutput::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     bool explain_ast = false;
     bool analyze_syntax = false;
 
-    if (enable_explain && s_ast.ignore(pos, expected))
+    if (enable_explain && s_ast.ignore(pos, expected, ranges))
         explain_ast = true;
 
-    if (enable_explain && s_analyze.ignore(pos, expected))
+    if (enable_explain && s_analyze.ignore(pos, expected, ranges))
         analyze_syntax = true;
 
-    bool parsed = select_p.parse(pos, query, expected)
-        || show_create_access_entity_p.parse(pos, query, expected) /// should be before `show_tables_p`
-        || show_tables_p.parse(pos, query, expected)
-        || table_p.parse(pos, query, expected)
-        || describe_table_p.parse(pos, query, expected)
-        || show_processlist_p.parse(pos, query, expected)
-        || create_p.parse(pos, query, expected)
-        || alter_p.parse(pos, query, expected)
-        || rename_p.parse(pos, query, expected)
-        || drop_p.parse(pos, query, expected)
-        || check_p.parse(pos, query, expected)
-        || kill_query_p.parse(pos, query, expected)
-        || optimize_p.parse(pos, query, expected)
-        || watch_p.parse(pos, query, expected)
-        || show_access_entities_p.parse(pos, query, expected)
-        || show_grants_p.parse(pos, query, expected)
-        || show_privileges_p.parse(pos, query, expected);
+    bool parsed = select_p.parse(pos, query, expected, ranges)
+        || show_create_access_entity_p.parse(pos, query, expected, ranges) /// should be before `show_tables_p`
+        || show_tables_p.parse(pos, query, expected, ranges)
+        || table_p.parse(pos, query, expected, ranges)
+        || describe_table_p.parse(pos, query, expected, ranges)
+        || show_processlist_p.parse(pos, query, expected, ranges)
+        || create_p.parse(pos, query, expected, ranges)
+        || alter_p.parse(pos, query, expected, ranges)
+        || rename_p.parse(pos, query, expected, ranges)
+        || drop_p.parse(pos, query, expected, ranges)
+        || check_p.parse(pos, query, expected, ranges)
+        || kill_query_p.parse(pos, query, expected, ranges)
+        || optimize_p.parse(pos, query, expected, ranges)
+        || watch_p.parse(pos, query, expected, ranges)
+        || show_access_entities_p.parse(pos, query, expected, ranges)
+        || show_grants_p.parse(pos, query, expected, ranges)
+        || show_privileges_p.parse(pos, query, expected, ranges);
 
     if (!parsed)
         return false;
@@ -81,10 +81,10 @@ bool ParserQueryWithOutput::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     auto & query_with_output = dynamic_cast<ASTQueryWithOutput &>(*query);
 
     ParserKeyword s_into_outfile("INTO OUTFILE");
-    if (s_into_outfile.ignore(pos, expected))
+    if (s_into_outfile.ignore(pos, expected, ranges))
     {
         ParserStringLiteral out_file_p;
-        if (!out_file_p.parse(pos, query_with_output.out_file, expected))
+        if (!out_file_p.parse(pos, query_with_output.out_file, expected, ranges))
             return false;
 
         query_with_output.children.push_back(query_with_output.out_file);
@@ -92,11 +92,11 @@ bool ParserQueryWithOutput::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
 
     ParserKeyword s_format("FORMAT");
 
-    if (s_format.ignore(pos, expected))
+    if (s_format.ignore(pos, expected, ranges))
     {
         ParserIdentifier format_p;
 
-        if (!format_p.parse(pos, query_with_output.format, expected))
+        if (!format_p.parse(pos, query_with_output.format, expected, ranges))
             return false;
         setIdentifierSpecial(query_with_output.format);
 
@@ -105,10 +105,10 @@ bool ParserQueryWithOutput::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
 
     // SETTINGS key1 = value1, key2 = value2, ...
     ParserKeyword s_settings("SETTINGS");
-    if (s_settings.ignore(pos, expected))
+    if (s_settings.ignore(pos, expected, ranges))
     {
         ParserSetQuery parser_settings(true);
-        if (!parser_settings.parse(pos, query_with_output.settings_ast, expected))
+        if (!parser_settings.parse(pos, query_with_output.settings_ast, expected, ranges))
             return false;
         query_with_output.children.push_back(query_with_output.settings_ast);
     }

--- a/src/Parsers/ParserQueryWithOutput.h
+++ b/src/Parsers/ParserQueryWithOutput.h
@@ -18,7 +18,7 @@ public:
 protected:
     const char * getName() const override { return "Query with output"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 
 private:
     bool enable_explain;

--- a/src/Parsers/ParserRenameQuery.cpp
+++ b/src/Parsers/ParserRenameQuery.cpp
@@ -11,7 +11,7 @@ namespace DB
 
 /// Parse database.table or table.
 static bool parseDatabaseAndTable(
-    ASTRenameQuery::Table & db_and_table, IParser::Pos & pos, Expected & expected)
+    ASTRenameQuery::Table & db_and_table, IParser::Pos & pos, Expected & expected, IParser::Ranges * ranges)
 {
     ParserIdentifier name_p;
     ParserToken s_dot(TokenType::Dot);
@@ -19,13 +19,13 @@ static bool parseDatabaseAndTable(
     ASTPtr database;
     ASTPtr table;
 
-    if (!name_p.parse(pos, table, expected))
+    if (!name_p.parse(pos, table, expected, ranges))
         return false;
 
-    if (s_dot.ignore(pos, expected))
+    if (s_dot.ignore(pos, expected, ranges))
     {
         database = table;
-        if (!name_p.parse(pos, table, expected))
+        if (!name_p.parse(pos, table, expected, ranges))
             return false;
     }
 
@@ -37,7 +37,7 @@ static bool parseDatabaseAndTable(
 }
 
 
-bool ParserRenameQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserRenameQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     ParserKeyword s_rename_table("RENAME TABLE");
     ParserKeyword s_to("TO");
@@ -47,9 +47,9 @@ bool ParserRenameQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 
     bool exchange = false;
 
-    if (!s_rename_table.ignore(pos, expected))
+    if (!s_rename_table.ignore(pos, expected, ranges))
     {
-        if (s_exchange_tables.ignore(pos, expected))
+        if (s_exchange_tables.ignore(pos, expected, ranges))
             exchange = true;
         else
             return false;
@@ -59,26 +59,26 @@ bool ParserRenameQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 
     auto ignore_delim = [&]()
     {
-        return exchange ? s_and.ignore(pos) : s_to.ignore(pos);
+        return exchange ? s_and.ignore(pos, expected, ranges) : s_to.ignore(pos, expected, ranges);
     };
 
     while (true)
     {
-        if (!elements.empty() && !s_comma.ignore(pos))
+        if (!elements.empty() && !s_comma.ignore(pos, expected, ranges))
             break;
 
         elements.push_back(ASTRenameQuery::Element());
 
-        if (!parseDatabaseAndTable(elements.back().from, pos, expected)
+        if (!parseDatabaseAndTable(elements.back().from, pos, expected, ranges)
             || !ignore_delim()
-            || !parseDatabaseAndTable(elements.back().to, pos, expected))
+            || !parseDatabaseAndTable(elements.back().to, pos, expected, ranges))
             return false;
     }
 
     String cluster_str;
-    if (ParserKeyword{"ON"}.ignore(pos, expected))
+    if (ParserKeyword{"ON"}.ignore(pos, expected, ranges))
     {
-        if (!ASTQueryWithOnCluster::parse(pos, cluster_str, expected))
+        if (!ASTQueryWithOnCluster::parse(pos, cluster_str, expected, ranges))
             return false;
     }
 

--- a/src/Parsers/ParserRenameQuery.h
+++ b/src/Parsers/ParserRenameQuery.h
@@ -15,7 +15,7 @@ class ParserRenameQuery : public IParserBase
 {
 protected:
     const char * getName() const  override{ return "RENAME query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 }

--- a/src/Parsers/ParserSampleRatio.cpp
+++ b/src/Parsers/ParserSampleRatio.cpp
@@ -81,7 +81,7 @@ static bool parseDecimal(const char * pos, const char * end, ASTSampleRatio::Rat
   * Example:
   * 123.0 / 456e0
   */
-bool ParserSampleRatio::parseImpl(Pos & pos, ASTPtr & node, Expected &)
+bool ParserSampleRatio::parseImpl(Pos & pos, ASTPtr & node, Expected &, Ranges *)
 {
     ASTSampleRatio::Rational numerator;
     ASTSampleRatio::Rational denominator;

--- a/src/Parsers/ParserSampleRatio.h
+++ b/src/Parsers/ParserSampleRatio.h
@@ -13,7 +13,7 @@ class ParserSampleRatio : public IParserBase
 {
 protected:
     const char * getName() const override { return "Sample ratio or offset"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 }

--- a/src/Parsers/ParserSelectQuery.h
+++ b/src/Parsers/ParserSelectQuery.h
@@ -11,7 +11,7 @@ class ParserSelectQuery : public IParserBase
 {
 protected:
     const char * getName() const override { return "SELECT query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 }

--- a/src/Parsers/ParserSelectWithUnionQuery.cpp
+++ b/src/Parsers/ParserSelectWithUnionQuery.cpp
@@ -23,12 +23,12 @@ static void getSelectsFromUnionListNode(ASTPtr & ast_select, ASTs & selects)
 }
 
 
-bool ParserSelectWithUnionQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserSelectWithUnionQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     ASTPtr list_node;
 
     ParserList parser(std::make_unique<ParserUnionQueryElement>(), std::make_unique<ParserKeyword>("UNION ALL"), false);
-    if (!parser.parse(pos, list_node, expected))
+    if (!parser.parse(pos, list_node, expected, ranges))
         return false;
 
     auto select_with_union_query = std::make_shared<ASTSelectWithUnionQuery>();

--- a/src/Parsers/ParserSelectWithUnionQuery.h
+++ b/src/Parsers/ParserSelectWithUnionQuery.h
@@ -10,7 +10,7 @@ class ParserSelectWithUnionQuery : public IParserBase
 {
 protected:
     const char * getName() const override { return "SELECT query, possibly with UNION"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 }

--- a/src/Parsers/ParserSetQuery.cpp
+++ b/src/Parsers/ParserSetQuery.cpp
@@ -13,7 +13,7 @@ namespace DB
 
 
 /// Parse `name = value`.
-bool ParserSetQuery::parseNameValuePair(SettingChange & change, IParser::Pos & pos, Expected & expected)
+bool ParserSetQuery::parseNameValuePair(SettingChange & change, IParser::Pos & pos, Expected & expected, Ranges * ranges)
 {
     ParserIdentifier name_p;
     ParserLiteral value_p;
@@ -22,13 +22,13 @@ bool ParserSetQuery::parseNameValuePair(SettingChange & change, IParser::Pos & p
     ASTPtr name;
     ASTPtr value;
 
-    if (!name_p.parse(pos, name, expected))
+    if (!name_p.parse(pos, name, expected, ranges))
         return false;
 
-    if (!s_eq.ignore(pos, expected))
+    if (!s_eq.ignore(pos, expected, ranges))
         return false;
 
-    if (!value_p.parse(pos, value, expected))
+    if (!value_p.parse(pos, value, expected, ranges))
         return false;
 
     tryGetIdentifierNameInto(name, change.name);
@@ -38,7 +38,7 @@ bool ParserSetQuery::parseNameValuePair(SettingChange & change, IParser::Pos & p
 }
 
 
-bool ParserSetQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserSetQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     ParserToken s_comma(TokenType::Comma);
 
@@ -46,7 +46,7 @@ bool ParserSetQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     {
         ParserKeyword s_set("SET");
 
-        if (!s_set.ignore(pos, expected))
+        if (!s_set.ignore(pos, expected, ranges))
             return false;
     }
 
@@ -54,12 +54,12 @@ bool ParserSetQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 
     while (true)
     {
-        if (!changes.empty() && !s_comma.ignore(pos))
+        if (!changes.empty() && !s_comma.ignore(pos, expected, ranges))
             break;
 
         changes.push_back(SettingChange{});
 
-        if (!parseNameValuePair(changes.back(), pos, expected))
+        if (!parseNameValuePair(changes.back(), pos, expected, ranges))
             return false;
     }
 

--- a/src/Parsers/ParserSetQuery.h
+++ b/src/Parsers/ParserSetQuery.h
@@ -14,10 +14,10 @@ class ParserSetQuery : public IParserBase
 {
 public:
     explicit ParserSetQuery(bool parse_only_internals_ = false) : parse_only_internals(parse_only_internals_) {}
-    static bool parseNameValuePair(SettingChange & change, IParser::Pos & pos, Expected & expected);
+    static bool parseNameValuePair(SettingChange & change, IParser::Pos & pos, Expected & expected, Ranges * ranges);
 protected:
     const char * getName() const override { return "SET query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
     /// Parse the list `name = value` pairs, without SET.
     bool parse_only_internals;
 };

--- a/src/Parsers/ParserSetRoleQuery.h
+++ b/src/Parsers/ParserSetRoleQuery.h
@@ -13,6 +13,6 @@ class ParserSetRoleQuery : public IParserBase
 {
 protected:
     const char * getName() const override { return "SET ROLE or SET DEFAULT ROLE query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 }

--- a/src/Parsers/ParserSettingsProfileElement.cpp
+++ b/src/Parsers/ParserSettingsProfileElement.cpp
@@ -11,22 +11,22 @@ namespace DB
 {
 namespace
 {
-    bool parseProfileNameOrID(IParserBase::Pos & pos, Expected & expected, bool parse_id, String & res)
+    bool parseProfileNameOrID(IParserBase::Pos & pos, Expected & expected, IParser::Ranges * ranges, bool parse_id, String & res)
     {
         return IParserBase::wrapParseImpl(pos, [&]
         {
             ASTPtr ast;
             if (!parse_id)
-                return parseIdentifierOrStringLiteral(pos, expected, res);
+                return parseIdentifierOrStringLiteral(pos, expected, ranges, res);
 
-            if (!ParserKeyword{"ID"}.ignore(pos, expected))
+            if (!ParserKeyword{"ID"}.ignore(pos, expected, ranges))
                 return false;
-            if (!ParserToken(TokenType::OpeningRoundBracket).ignore(pos, expected))
+            if (!ParserToken(TokenType::OpeningRoundBracket).ignore(pos, expected, ranges))
                 return false;
-            if (!ParserStringLiteral{}.parse(pos, ast, expected))
+            if (!ParserStringLiteral{}.parse(pos, ast, expected, ranges))
                 return false;
             String id = ast->as<ASTLiteral &>().value.safeGet<String>();
-            if (!ParserToken(TokenType::ClosingRoundBracket).ignore(pos, expected))
+            if (!ParserToken(TokenType::ClosingRoundBracket).ignore(pos, expected, ranges))
                 return false;
 
             res = std::move(id);
@@ -35,15 +35,15 @@ namespace
     }
 
 
-    bool parseValue(IParserBase::Pos & pos, Expected & expected, Field & res)
+    bool parseValue(IParserBase::Pos & pos, Expected & expected, IParser::Ranges * ranges, Field & res)
     {
         return IParserBase::wrapParseImpl(pos, [&]
         {
-            if (!ParserToken{TokenType::Equals}.ignore(pos, expected))
+            if (!ParserToken{TokenType::Equals}.ignore(pos, expected, ranges))
                 return false;
 
             ASTPtr ast;
-            if (!ParserLiteral{}.parse(pos, ast, expected))
+            if (!ParserLiteral{}.parse(pos, ast, expected, ranges))
                 return false;
 
             res = ast->as<ASTLiteral &>().value;
@@ -52,19 +52,19 @@ namespace
     }
 
 
-    bool parseMinMaxValue(IParserBase::Pos & pos, Expected & expected, Field & min_value, Field & max_value)
+    bool parseMinMaxValue(IParserBase::Pos & pos, Expected & expected, IParser::Ranges * ranges, Field & min_value, Field & max_value)
     {
         return IParserBase::wrapParseImpl(pos, [&]
         {
-            bool is_min_value = ParserKeyword{"MIN"}.ignore(pos, expected);
-            bool is_max_value = !is_min_value && ParserKeyword{"MAX"}.ignore(pos, expected);
+            bool is_min_value = ParserKeyword{"MIN"}.ignore(pos, expected, ranges);
+            bool is_max_value = !is_min_value && ParserKeyword{"MAX"}.ignore(pos, expected, ranges);
             if (!is_min_value && !is_max_value)
                 return false;
 
-            ParserToken{TokenType::Equals}.ignore(pos, expected);
+            ParserToken{TokenType::Equals}.ignore(pos, expected, ranges);
 
             ASTPtr ast;
-            if (!ParserLiteral{}.parse(pos, ast, expected))
+            if (!ParserLiteral{}.parse(pos, ast, expected, ranges))
                 return false;
 
             auto min_or_max_value = ast->as<ASTLiteral &>().value;
@@ -78,16 +78,16 @@ namespace
     }
 
 
-    bool parseReadonlyOrWritableKeyword(IParserBase::Pos & pos, Expected & expected, std::optional<bool> & readonly)
+    bool parseReadonlyOrWritableKeyword(IParserBase::Pos & pos, Expected & expected, IParser::Ranges * ranges, std::optional<bool> & readonly)
     {
         return IParserBase::wrapParseImpl(pos, [&]
         {
-            if (ParserKeyword{"READONLY"}.ignore(pos, expected))
+            if (ParserKeyword{"READONLY"}.ignore(pos, expected, ranges))
             {
                 readonly = true;
                 return true;
             }
-            else if (ParserKeyword{"READONLY"}.ignore(pos, expected))
+            else if (ParserKeyword{"READONLY"}.ignore(pos, expected, ranges))
             {
                 readonly = false;
                 return true;
@@ -99,7 +99,7 @@ namespace
 }
 
 
-bool ParserSettingsProfileElement::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserSettingsProfileElement::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     String parent_profile;
     String setting_name;
@@ -108,22 +108,22 @@ bool ParserSettingsProfileElement::parseImpl(Pos & pos, ASTPtr & node, Expected 
     Field max_value;
     std::optional<bool> readonly;
 
-    if (ParserKeyword{"PROFILE"}.ignore(pos, expected) ||
-        (enable_inherit_keyword && ParserKeyword{"INHERIT"}.ignore(pos, expected)))
+    if (ParserKeyword{"PROFILE"}.ignore(pos, expected, ranges) ||
+        (enable_inherit_keyword && ParserKeyword{"INHERIT"}.ignore(pos, expected, ranges)))
     {
-        if (!parseProfileNameOrID(pos, expected, id_mode, parent_profile))
+        if (!parseProfileNameOrID(pos, expected, ranges, id_mode, parent_profile))
             return false;
     }
     else
     {
         ASTPtr name_ast;
-        if (!ParserIdentifier{}.parse(pos, name_ast, expected))
+        if (!ParserIdentifier{}.parse(pos, name_ast, expected, ranges))
             return false;
         setting_name = getIdentifierName(name_ast);
 
         bool has_value_or_constraint = false;
-        while (parseValue(pos, expected, value) || parseMinMaxValue(pos, expected, min_value, max_value)
-               || parseReadonlyOrWritableKeyword(pos, expected, readonly))
+        while (parseValue(pos, expected, ranges, value) || parseMinMaxValue(pos, expected, ranges, min_value, max_value)
+               || parseReadonlyOrWritableKeyword(pos, expected, ranges, readonly))
         {
             has_value_or_constraint = true;
         }
@@ -146,11 +146,11 @@ bool ParserSettingsProfileElement::parseImpl(Pos & pos, ASTPtr & node, Expected 
 }
 
 
-bool ParserSettingsProfileElements::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserSettingsProfileElements::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     std::vector<std::shared_ptr<ASTSettingsProfileElement>> elements;
 
-    if (ParserKeyword{"NONE"}.ignore(pos, expected))
+    if (ParserKeyword{"NONE"}.ignore(pos, expected, ranges))
     {
     }
     else
@@ -158,12 +158,12 @@ bool ParserSettingsProfileElements::parseImpl(Pos & pos, ASTPtr & node, Expected
         do
         {
             ASTPtr ast;
-            if (!ParserSettingsProfileElement{}.useIDMode(id_mode).enableInheritKeyword(enable_inherit_keyword).parse(pos, ast, expected))
+            if (!ParserSettingsProfileElement{}.useIDMode(id_mode).enableInheritKeyword(enable_inherit_keyword).parse(pos, ast, expected, ranges))
                 return false;
             auto element = typeid_cast<std::shared_ptr<ASTSettingsProfileElement>>(ast);
             elements.push_back(std::move(element));
         }
-        while (ParserToken{TokenType::Comma}.ignore(pos, expected));
+        while (ParserToken{TokenType::Comma}.ignore(pos, expected, ranges));
     }
 
     auto result = std::make_shared<ASTSettingsProfileElements>();

--- a/src/Parsers/ParserSettingsProfileElement.h
+++ b/src/Parsers/ParserSettingsProfileElement.h
@@ -16,7 +16,7 @@ public:
 
 protected:
     const char * getName() const override { return "SettingsProfileElement"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 
 private:
     bool id_mode = false;
@@ -32,7 +32,7 @@ public:
 
 protected:
     const char * getName() const override { return "SettingsProfileElements"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 
 private:
     bool id_mode = false;

--- a/src/Parsers/ParserShowAccessEntitiesQuery.cpp
+++ b/src/Parsers/ParserShowAccessEntitiesQuery.cpp
@@ -10,21 +10,21 @@ namespace
 {
     using EntityType = IAccessEntity::Type;
 
-    bool parseONDatabaseAndTableName(IParserBase::Pos & pos, Expected & expected, String & database, String & table_name)
+    bool parseONDatabaseAndTableName(IParserBase::Pos & pos, Expected & expected, IParser::Ranges * ranges, String & database, String & table_name)
     {
         return IParserBase::wrapParseImpl(pos, [&]
         {
             database.clear();
             table_name.clear();
-            return ParserKeyword{"ON"}.ignore(pos, expected) && parseDatabaseAndTableName(pos, expected, database, table_name);
+            return ParserKeyword{"ON"}.ignore(pos, expected, ranges) && parseDatabaseAndTableName(pos, expected, ranges, database, table_name);
         });
     }
 }
 
 
-bool ParserShowAccessEntitiesQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserShowAccessEntitiesQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
-    if (!ParserKeyword{"SHOW"}.ignore(pos, expected))
+    if (!ParserKeyword{"SHOW"}.ignore(pos, expected, ranges))
         return false;
 
     std::optional<EntityType> type;
@@ -32,38 +32,38 @@ bool ParserShowAccessEntitiesQuery::parseImpl(Pos & pos, ASTPtr & node, Expected
     bool current_roles = false;
     bool enabled_roles = false;
 
-    if (ParserKeyword{"USERS"}.ignore(pos, expected))
+    if (ParserKeyword{"USERS"}.ignore(pos, expected, ranges))
     {
         type = EntityType::USER;
     }
-    else if (ParserKeyword{"ROLES"}.ignore(pos, expected))
+    else if (ParserKeyword{"ROLES"}.ignore(pos, expected, ranges))
     {
         type = EntityType::ROLE;
     }
-    else if (ParserKeyword{"CURRENT ROLES"}.ignore(pos, expected))
+    else if (ParserKeyword{"CURRENT ROLES"}.ignore(pos, expected, ranges))
     {
         type = EntityType::ROLE;
         current_roles = true;
     }
-    else if (ParserKeyword{"ENABLED ROLES"}.ignore(pos, expected))
+    else if (ParserKeyword{"ENABLED ROLES"}.ignore(pos, expected, ranges))
     {
         type = EntityType::ROLE;
         enabled_roles = true;
     }
-    else if (ParserKeyword{"POLICIES"}.ignore(pos, expected) || ParserKeyword{"ROW POLICIES"}.ignore(pos, expected))
+    else if (ParserKeyword{"POLICIES"}.ignore(pos, expected, ranges) || ParserKeyword{"ROW POLICIES"}.ignore(pos, expected, ranges))
     {
         type = EntityType::ROW_POLICY;
     }
-    else if (ParserKeyword{"QUOTAS"}.ignore(pos, expected))
+    else if (ParserKeyword{"QUOTAS"}.ignore(pos, expected, ranges))
     {
         type = EntityType::QUOTA;
     }
-    else if (ParserKeyword{"QUOTA"}.ignore(pos, expected) || ParserKeyword{"CURRENT QUOTA"}.ignore(pos, expected))
+    else if (ParserKeyword{"QUOTA"}.ignore(pos, expected, ranges) || ParserKeyword{"CURRENT QUOTA"}.ignore(pos, expected, ranges))
     {
         type = EntityType::QUOTA;
         current_quota = true;
     }
-    else if (ParserKeyword{"PROFILES"}.ignore(pos, expected) || ParserKeyword{"SETTINGS PROFILES"}.ignore(pos, expected))
+    else if (ParserKeyword{"PROFILES"}.ignore(pos, expected, ranges) || ParserKeyword{"SETTINGS PROFILES"}.ignore(pos, expected, ranges))
     {
         type = EntityType::SETTINGS_PROFILE;
     }
@@ -72,7 +72,7 @@ bool ParserShowAccessEntitiesQuery::parseImpl(Pos & pos, ASTPtr & node, Expected
 
     String database, table_name;
     if (type == EntityType::ROW_POLICY)
-        parseONDatabaseAndTableName(pos, expected, database, table_name);
+        parseONDatabaseAndTableName(pos, expected, ranges, database, table_name);
 
     auto query = std::make_shared<ASTShowAccessEntitiesQuery>();
     node = query;

--- a/src/Parsers/ParserShowAccessEntitiesQuery.h
+++ b/src/Parsers/ParserShowAccessEntitiesQuery.h
@@ -15,6 +15,6 @@ class ParserShowAccessEntitiesQuery : public IParserBase
 {
 protected:
     const char * getName() const override { return "ShowAccessEntitiesQuery"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 }

--- a/src/Parsers/ParserShowCreateAccessEntityQuery.cpp
+++ b/src/Parsers/ParserShowCreateAccessEntityQuery.cpp
@@ -14,17 +14,17 @@ using EntityType = IAccessEntity::Type;
 using EntityTypeInfo = IAccessEntity::TypeInfo;
 
 
-bool ParserShowCreateAccessEntityQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserShowCreateAccessEntityQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
-    if (!ParserKeyword{"SHOW CREATE"}.ignore(pos, expected))
+    if (!ParserKeyword{"SHOW CREATE"}.ignore(pos, expected, ranges))
         return false;
 
     std::optional<EntityType> type;
     for (auto type_i : ext::range(EntityType::MAX))
     {
         const auto & type_info = EntityTypeInfo::get(type_i);
-        if (ParserKeyword{type_info.name.c_str()}.ignore(pos, expected)
-            || (!type_info.alias.empty() && ParserKeyword{type_info.alias.c_str()}.ignore(pos, expected)))
+        if (ParserKeyword{type_info.name.c_str()}.ignore(pos, expected, ranges)
+            || (!type_info.alias.empty() && ParserKeyword{type_info.alias.c_str()}.ignore(pos, expected, ranges)))
         {
             type = type_i;
         }
@@ -39,12 +39,12 @@ bool ParserShowCreateAccessEntityQuery::parseImpl(Pos & pos, ASTPtr & node, Expe
 
     if (type == EntityType::USER)
     {
-        if (!parseUserNameOrCurrentUserTag(pos, expected, name, current_user))
+        if (!parseUserNameOrCurrentUserTag(pos, expected, ranges, name, current_user))
             current_user = true;
     }
     else if (type == EntityType::ROLE)
     {
-        if (!parseRoleName(pos, expected, name))
+        if (!parseRoleName(pos, expected, ranges, name))
             return false;
     }
     else if (type == EntityType::ROW_POLICY)
@@ -52,13 +52,13 @@ bool ParserShowCreateAccessEntityQuery::parseImpl(Pos & pos, ASTPtr & node, Expe
         String & database = row_policy_name_parts.database;
         String & table_name = row_policy_name_parts.table_name;
         String & short_name = row_policy_name_parts.short_name;
-        if (!parseIdentifierOrStringLiteral(pos, expected, short_name) || !ParserKeyword{"ON"}.ignore(pos, expected)
-            || !parseDatabaseAndTableName(pos, expected, database, table_name))
+        if (!parseIdentifierOrStringLiteral(pos, expected, ranges, short_name) || !ParserKeyword{"ON"}.ignore(pos, expected, ranges)
+            || !parseDatabaseAndTableName(pos, expected, ranges, database, table_name))
             return false;
     }
     else if (type == EntityType::QUOTA)
     {
-        if (!parseIdentifierOrStringLiteral(pos, expected, name))
+        if (!parseIdentifierOrStringLiteral(pos, expected, ranges, name))
         {
             /// SHOW CREATE QUOTA
             current_quota = true;
@@ -66,7 +66,7 @@ bool ParserShowCreateAccessEntityQuery::parseImpl(Pos & pos, ASTPtr & node, Expe
     }
     else if (type == EntityType::SETTINGS_PROFILE)
     {
-        if (!parseIdentifierOrStringLiteral(pos, expected, name))
+        if (!parseIdentifierOrStringLiteral(pos, expected, ranges, name))
             return false;
     }
 

--- a/src/Parsers/ParserShowCreateAccessEntityQuery.h
+++ b/src/Parsers/ParserShowCreateAccessEntityQuery.h
@@ -12,6 +12,6 @@ class ParserShowCreateAccessEntityQuery : public IParserBase
 {
 protected:
     const char * getName() const override { return "SHOW CREATE QUOTA query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 }

--- a/src/Parsers/ParserShowGrantsQuery.cpp
+++ b/src/Parsers/ParserShowGrantsQuery.cpp
@@ -6,17 +6,17 @@
 
 namespace DB
 {
-bool ParserShowGrantsQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserShowGrantsQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
-    if (!ParserKeyword{"SHOW GRANTS"}.ignore(pos, expected))
+    if (!ParserKeyword{"SHOW GRANTS"}.ignore(pos, expected, ranges))
         return false;
 
     String name;
     bool current_user = false;
 
-    if (ParserKeyword{"FOR"}.ignore(pos, expected))
+    if (ParserKeyword{"FOR"}.ignore(pos, expected, ranges))
     {
-        if (!parseUserNameOrCurrentUserTag(pos, expected, name, current_user))
+        if (!parseUserNameOrCurrentUserTag(pos, expected, ranges, name, current_user))
             return false;
     }
     else

--- a/src/Parsers/ParserShowGrantsQuery.h
+++ b/src/Parsers/ParserShowGrantsQuery.h
@@ -12,6 +12,6 @@ class ParserShowGrantsQuery : public IParserBase
 {
 protected:
     const char * getName() const override { return "SHOW GRANTS query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 }

--- a/src/Parsers/ParserShowPrivilegesQuery.cpp
+++ b/src/Parsers/ParserShowPrivilegesQuery.cpp
@@ -6,11 +6,11 @@
 namespace DB
 {
 
-bool ParserShowPrivilegesQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserShowPrivilegesQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     auto query = std::make_shared<ASTShowPrivilegesQuery>();
 
-    if (!ParserKeyword("SHOW PRIVILEGES").ignore(pos, expected))
+    if (!ParserKeyword("SHOW PRIVILEGES").ignore(pos, expected, ranges))
         return false;
 
     node = query;

--- a/src/Parsers/ParserShowPrivilegesQuery.h
+++ b/src/Parsers/ParserShowPrivilegesQuery.h
@@ -12,7 +12,7 @@ class ParserShowPrivilegesQuery : public IParserBase
 {
 protected:
     const char * getName() const override { return "SHOW PRIVILEGES query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 }

--- a/src/Parsers/ParserShowProcesslistQuery.h
+++ b/src/Parsers/ParserShowProcesslistQuery.h
@@ -16,11 +16,11 @@ class ParserShowProcesslistQuery : public IParserBase
 protected:
     const char * getName() const override { return "SHOW PROCESSLIST query"; }
 
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override
     {
         auto query = std::make_shared<ASTShowProcesslistQuery>();
 
-        if (!ParserKeyword("SHOW PROCESSLIST").ignore(pos, expected))
+        if (!ParserKeyword("SHOW PROCESSLIST").ignore(pos, expected, ranges))
             return false;
 
         node = query;

--- a/src/Parsers/ParserShowTablesQuery.cpp
+++ b/src/Parsers/ParserShowTablesQuery.cpp
@@ -14,7 +14,7 @@ namespace DB
 {
 
 
-bool ParserShowTablesQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserShowTablesQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     ParserKeyword s_show("SHOW");
     ParserKeyword s_temporary("TEMPORARY");
@@ -36,51 +36,51 @@ bool ParserShowTablesQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
 
     auto query = std::make_shared<ASTShowTablesQuery>();
 
-    if (!s_show.ignore(pos, expected))
+    if (!s_show.ignore(pos, expected, ranges))
         return false;
 
-    if (s_databases.ignore(pos))
+    if (s_databases.ignore(pos, expected, ranges))
     {
         query->databases = true;
     }
     else
     {
-        if (s_temporary.ignore(pos))
+        if (s_temporary.ignore(pos, expected, ranges))
             query->temporary = true;
 
-        if (!s_tables.ignore(pos, expected))
+        if (!s_tables.ignore(pos, expected, ranges))
         {
-            if (s_dictionaries.ignore(pos, expected))
+            if (s_dictionaries.ignore(pos, expected, ranges))
                 query->dictionaries = true;
             else
                 return false;
         }
 
-        if (s_from.ignore(pos, expected) || s_in.ignore(pos, expected))
+        if (s_from.ignore(pos, expected, ranges) || s_in.ignore(pos, expected, ranges))
         {
-            if (!name_p.parse(pos, database, expected))
+            if (!name_p.parse(pos, database, expected, ranges))
                 return false;
         }
 
-        if (s_not.ignore(pos, expected))
+        if (s_not.ignore(pos, expected, ranges))
             query->not_like = true;
 
-        if (s_like.ignore(pos, expected))
+        if (s_like.ignore(pos, expected, ranges))
         {
-            if (!like_p.parse(pos, like, expected))
+            if (!like_p.parse(pos, like, expected, ranges))
                 return false;
         }
         else if (query->not_like)
             return false;
-        else if (s_where.ignore(pos, expected))
+        else if (s_where.ignore(pos, expected, ranges))
         {
-            if (!exp_elem.parse(pos, query->where_expression, expected))
+            if (!exp_elem.parse(pos, query->where_expression, expected, ranges))
                 return false;
         }
 
-        if (s_limit.ignore(pos, expected))
+        if (s_limit.ignore(pos, expected, ranges))
         {
-            if (!exp_elem.parse(pos, query->limit_length, expected))
+            if (!exp_elem.parse(pos, query->limit_length, expected, ranges))
                 return false;
         }
     }

--- a/src/Parsers/ParserShowTablesQuery.h
+++ b/src/Parsers/ParserShowTablesQuery.h
@@ -15,7 +15,7 @@ class ParserShowTablesQuery : public IParserBase
 {
 protected:
     const char * getName() const override { return "SHOW [TEMPORARY] TABLES|DATABASES [[NOT] LIKE 'str'] [LIMIT expr]"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 }

--- a/src/Parsers/ParserSystemQuery.h
+++ b/src/Parsers/ParserSystemQuery.h
@@ -10,7 +10,7 @@ class ParserSystemQuery : public IParserBase
 {
 protected:
     const char * getName() const override { return "SYSTEM query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 }

--- a/src/Parsers/ParserTablePropertiesQuery.cpp
+++ b/src/Parsers/ParserTablePropertiesQuery.cpp
@@ -11,7 +11,7 @@ namespace DB
 {
 
 
-bool ParserTablePropertiesQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserTablePropertiesQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     ParserKeyword s_exists("EXISTS");
     ParserKeyword s_temporary("TEMPORARY");
@@ -32,29 +32,29 @@ bool ParserTablePropertiesQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & 
     bool parse_only_database_name = false;
 
     bool temporary = false;
-    if (s_exists.ignore(pos, expected))
+    if (s_exists.ignore(pos, expected, ranges))
     {
-        if (s_temporary.ignore(pos, expected))
+        if (s_temporary.ignore(pos, expected, ranges))
             temporary = true;
 
-        if (s_table.checkWithoutMoving(pos, expected))
+        if (s_table.checkWithoutMoving(pos, expected, ranges))
             query = std::make_shared<ASTExistsTableQuery>();
-        else if (s_dictionary.checkWithoutMoving(pos, expected))
+        else if (s_dictionary.checkWithoutMoving(pos, expected, ranges))
             query = std::make_shared<ASTExistsDictionaryQuery>();
         else
             query = std::make_shared<ASTExistsTableQuery>();
     }
-    else if (s_show.ignore(pos, expected))
+    else if (s_show.ignore(pos, expected, ranges))
     {
-        if (!s_create.ignore(pos, expected))
+        if (!s_create.ignore(pos, expected, ranges))
             return false;
 
-        if (s_database.ignore(pos, expected))
+        if (s_database.ignore(pos, expected, ranges))
         {
             parse_only_database_name = true;
             query = std::make_shared<ASTShowCreateDatabaseQuery>();
         }
-        else if (s_dictionary.checkWithoutMoving(pos, expected))
+        else if (s_dictionary.checkWithoutMoving(pos, expected, ranges))
             query = std::make_shared<ASTShowCreateDictionaryQuery>();
         else
             query = std::make_shared<ASTShowCreateTableQuery>();
@@ -66,24 +66,24 @@ bool ParserTablePropertiesQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & 
 
     if (parse_only_database_name)
     {
-        if (!name_p.parse(pos, database, expected))
+        if (!name_p.parse(pos, database, expected, ranges))
             return false;
     }
     else
     {
-        if (temporary || s_temporary.ignore(pos, expected))
+        if (temporary || s_temporary.ignore(pos, expected, ranges))
             query->temporary = true;
 
-        if (!s_table.ignore(pos, expected))
-            s_dictionary.ignore(pos, expected);
+        if (!s_table.ignore(pos, expected, ranges))
+            s_dictionary.ignore(pos, expected, ranges);
 
-        if (!name_p.parse(pos, table, expected))
+        if (!name_p.parse(pos, table, expected, ranges))
             return false;
 
-        if (s_dot.ignore(pos, expected))
+        if (s_dot.ignore(pos, expected, ranges))
         {
             database = table;
-            if (!name_p.parse(pos, table, expected))
+            if (!name_p.parse(pos, table, expected, ranges))
                 return false;
         }
     }

--- a/src/Parsers/ParserTablePropertiesQuery.h
+++ b/src/Parsers/ParserTablePropertiesQuery.h
@@ -13,7 +13,7 @@ class ParserTablePropertiesQuery : public IParserBase
 {
 protected:
     const char * getName() const override { return "EXISTS or SHOW CREATE query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 }

--- a/src/Parsers/ParserTablesInSelectQuery.cpp
+++ b/src/Parsers/ParserTablesInSelectQuery.cpp
@@ -17,31 +17,31 @@ namespace ErrorCodes
 }
 
 
-bool ParserTableExpression::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserTableExpression::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     auto res = std::make_shared<ASTTableExpression>();
 
-    if (!ParserWithOptionalAlias(std::make_unique<ParserSubquery>(), true).parse(pos, res->subquery, expected)
-        && !ParserWithOptionalAlias(std::make_unique<ParserFunction>(), true).parse(pos, res->table_function, expected)
-        && !ParserWithOptionalAlias(std::make_unique<ParserCompoundIdentifier>(), true).parse(pos, res->database_and_table_name, expected))
+    if (!ParserWithOptionalAlias(std::make_unique<ParserSubquery>(), true).parse(pos, res->subquery, expected, ranges)
+        && !ParserWithOptionalAlias(std::make_unique<ParserFunction>(), true).parse(pos, res->table_function, expected, ranges)
+        && !ParserWithOptionalAlias(std::make_unique<ParserCompoundIdentifier>(), true).parse(pos, res->database_and_table_name, expected, ranges))
         return false;
 
     /// FINAL
-    if (ParserKeyword("FINAL").ignore(pos, expected))
+    if (ParserKeyword("FINAL").ignore(pos, expected, ranges))
         res->final = true;
 
     /// SAMPLE number
-    if (ParserKeyword("SAMPLE").ignore(pos, expected))
+    if (ParserKeyword("SAMPLE").ignore(pos, expected, ranges))
     {
         ParserSampleRatio ratio;
 
-        if (!ratio.parse(pos, res->sample_size, expected))
+        if (!ratio.parse(pos, res->sample_size, expected, ranges))
             return false;
 
         /// OFFSET number
-        if (ParserKeyword("OFFSET").ignore(pos, expected))
+        if (ParserKeyword("OFFSET").ignore(pos, expected, ranges))
         {
-            if (!ratio.parse(pos, res->sample_offset, expected))
+            if (!ratio.parse(pos, res->sample_offset, expected, ranges))
                 return false;
         }
     }
@@ -62,7 +62,7 @@ bool ParserTableExpression::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
 }
 
 
-bool ParserArrayJoin::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserArrayJoin::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     auto res = std::make_shared<ASTArrayJoin>();
 
@@ -70,7 +70,7 @@ bool ParserArrayJoin::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     Pos saved_pos = pos;
     bool has_array_join = false;
 
-    if (ParserKeyword("LEFT ARRAY JOIN").ignore(pos, expected))
+    if (ParserKeyword("LEFT ARRAY JOIN").ignore(pos, expected, ranges))
     {
         res->kind = ASTArrayJoin::Kind::Left;
         has_array_join = true;
@@ -80,9 +80,9 @@ bool ParserArrayJoin::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         pos = saved_pos;
 
         /// INNER may be specified explicitly, otherwise it is assumed as default.
-        ParserKeyword("INNER").ignore(pos, expected);
+        ParserKeyword("INNER").ignore(pos, expected, ranges);
 
-        if (ParserKeyword("ARRAY JOIN").ignore(pos, expected))
+        if (ParserKeyword("ARRAY JOIN").ignore(pos, expected, ranges))
         {
             res->kind = ASTArrayJoin::Kind::Inner;
             has_array_join = true;
@@ -92,7 +92,7 @@ bool ParserArrayJoin::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     if (!has_array_join)
         return false;
 
-    if (!ParserExpressionList(false).parse(pos, res->expression_list, expected))
+    if (!ParserExpressionList(false).parse(pos, res->expression_list, expected, ranges))
         return false;
 
     if (res->expression_list)
@@ -103,16 +103,16 @@ bool ParserArrayJoin::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 }
 
 
-bool ParserTablesInSelectQueryElement::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserTablesInSelectQueryElement::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     auto res = std::make_shared<ASTTablesInSelectQueryElement>();
 
     if (is_first)
     {
-        if (!ParserTableExpression().parse(pos, res->table_expression, expected))
+        if (!ParserTableExpression().parse(pos, res->table_expression, expected, ranges))
             return false;
     }
-    else if (ParserArrayJoin().parse(pos, res->array_join, expected))
+    else if (ParserArrayJoin().parse(pos, res->array_join, expected, ranges))
     {
     }
     else
@@ -126,33 +126,33 @@ bool ParserTablesInSelectQueryElement::parseImpl(Pos & pos, ASTPtr & node, Expec
         }
         else
         {
-            if (ParserKeyword("GLOBAL").ignore(pos))
+            if (ParserKeyword("GLOBAL").ignore(pos, expected, ranges))
                 table_join->locality = ASTTableJoin::Locality::Global;
-            else if (ParserKeyword("LOCAL").ignore(pos))
+            else if (ParserKeyword("LOCAL").ignore(pos, expected, ranges))
                 table_join->locality = ASTTableJoin::Locality::Local;
 
-            if (ParserKeyword("ANY").ignore(pos))
+            if (ParserKeyword("ANY").ignore(pos, expected, ranges))
                 table_join->strictness = ASTTableJoin::Strictness::Any;
-            else if (ParserKeyword("ALL").ignore(pos))
+            else if (ParserKeyword("ALL").ignore(pos, expected, ranges))
                 table_join->strictness = ASTTableJoin::Strictness::All;
-            else if (ParserKeyword("ASOF").ignore(pos))
+            else if (ParserKeyword("ASOF").ignore(pos, expected, ranges))
                 table_join->strictness = ASTTableJoin::Strictness::Asof;
-            else if (ParserKeyword("SEMI").ignore(pos))
+            else if (ParserKeyword("SEMI").ignore(pos, expected, ranges))
                 table_join->strictness = ASTTableJoin::Strictness::Semi;
-            else if (ParserKeyword("ANTI").ignore(pos) || ParserKeyword("ONLY").ignore(pos))
+            else if (ParserKeyword("ANTI").ignore(pos, expected, ranges) || ParserKeyword("ONLY").ignore(pos, expected, ranges))
                 table_join->strictness = ASTTableJoin::Strictness::Anti;
             else
                 table_join->strictness = ASTTableJoin::Strictness::Unspecified;
 
-            if (ParserKeyword("INNER").ignore(pos))
+            if (ParserKeyword("INNER").ignore(pos, expected, ranges))
                 table_join->kind = ASTTableJoin::Kind::Inner;
-            else if (ParserKeyword("LEFT").ignore(pos))
+            else if (ParserKeyword("LEFT").ignore(pos, expected, ranges))
                 table_join->kind = ASTTableJoin::Kind::Left;
-            else if (ParserKeyword("RIGHT").ignore(pos))
+            else if (ParserKeyword("RIGHT").ignore(pos, expected, ranges))
                 table_join->kind = ASTTableJoin::Kind::Right;
-            else if (ParserKeyword("FULL").ignore(pos))
+            else if (ParserKeyword("FULL").ignore(pos, expected, ranges))
                 table_join->kind = ASTTableJoin::Kind::Full;
-            else if (ParserKeyword("CROSS").ignore(pos))
+            else if (ParserKeyword("CROSS").ignore(pos, expected, ranges))
                 table_join->kind = ASTTableJoin::Kind::Cross;
             else
             {
@@ -177,27 +177,27 @@ bool ParserTablesInSelectQueryElement::parseImpl(Pos & pos, ASTPtr & node, Expec
                 || table_join->kind == ASTTableJoin::Kind::Right
                 || table_join->kind == ASTTableJoin::Kind::Full)
             {
-                ParserKeyword("OUTER").ignore(pos);
+                ParserKeyword("OUTER").ignore(pos, expected, ranges);
             }
 
-            if (!ParserKeyword("JOIN").ignore(pos, expected))
+            if (!ParserKeyword("JOIN").ignore(pos, expected, ranges))
                 return false;
         }
 
-        if (!ParserTableExpression().parse(pos, res->table_expression, expected))
+        if (!ParserTableExpression().parse(pos, res->table_expression, expected, ranges))
             return false;
 
         if (table_join->kind != ASTTableJoin::Kind::Comma
             && table_join->kind != ASTTableJoin::Kind::Cross)
         {
-            if (ParserKeyword("USING").ignore(pos, expected))
+            if (ParserKeyword("USING").ignore(pos, expected, ranges))
             {
                 /// Expression for USING could be in parentheses or not.
                 bool in_parens = pos->type == TokenType::OpeningRoundBracket;
                 if (in_parens)
                     ++pos;
 
-                if (!ParserExpressionList(false).parse(pos, table_join->using_expression_list, expected))
+                if (!ParserExpressionList(false).parse(pos, table_join->using_expression_list, expected, ranges))
                     return false;
 
                 if (in_parens)
@@ -207,10 +207,10 @@ bool ParserTablesInSelectQueryElement::parseImpl(Pos & pos, ASTPtr & node, Expec
                     ++pos;
                 }
             }
-            else if (ParserKeyword("ON").ignore(pos, expected))
+            else if (ParserKeyword("ON").ignore(pos, expected, ranges))
             {
                 /// OR is operator with lowest priority, so start parsing from it.
-                if (!ParserLogicalOrExpression().parse(pos, table_join->on_expression, expected))
+                if (!ParserLogicalOrExpression().parse(pos, table_join->on_expression, expected, ranges))
                     return false;
             }
             else
@@ -239,18 +239,18 @@ bool ParserTablesInSelectQueryElement::parseImpl(Pos & pos, ASTPtr & node, Expec
 }
 
 
-bool ParserTablesInSelectQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserTablesInSelectQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     auto res = std::make_shared<ASTTablesInSelectQuery>();
 
     ASTPtr child;
 
-    if (ParserTablesInSelectQueryElement(true).parse(pos, child, expected))
+    if (ParserTablesInSelectQueryElement(true).parse(pos, child, expected, ranges))
         res->children.emplace_back(child);
     else
         return false;
 
-    while (ParserTablesInSelectQueryElement(false).parse(pos, child, expected))
+    while (ParserTablesInSelectQueryElement(false).parse(pos, child, expected, ranges))
         res->children.emplace_back(child);
 
     node = res;

--- a/src/Parsers/ParserTablesInSelectQuery.h
+++ b/src/Parsers/ParserTablesInSelectQuery.h
@@ -12,7 +12,7 @@ class ParserTablesInSelectQuery : public IParserBase
 {
 protected:
     const char * getName() const override { return "table, table function, subquery or list of joined tables"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -23,7 +23,7 @@ public:
 
 protected:
     const char * getName() const override { return "table, table function, subquery or list of joined tables"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 
 private:
     bool is_first;
@@ -34,7 +34,7 @@ class ParserTableExpression : public IParserBase
 {
 protected:
     const char * getName() const override { return "table or subquery or table function"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 
@@ -42,7 +42,7 @@ class ParserArrayJoin : public IParserBase
 {
 protected:
     const char * getName() const override { return "array join"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 

--- a/src/Parsers/ParserUnionQueryElement.cpp
+++ b/src/Parsers/ParserUnionQueryElement.cpp
@@ -8,9 +8,9 @@
 namespace DB
 {
 
-bool ParserUnionQueryElement::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserUnionQueryElement::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
-    if (!ParserSubquery().parse(pos, node, expected) && !ParserSelectQuery().parse(pos, node, expected))
+    if (!ParserSubquery().parse(pos, node, expected, ranges) && !ParserSelectQuery().parse(pos, node, expected, ranges))
         return false;
 
     if (const auto * ast_subquery = node->as<ASTSubquery>())

--- a/src/Parsers/ParserUnionQueryElement.h
+++ b/src/Parsers/ParserUnionQueryElement.h
@@ -11,7 +11,7 @@ class ParserUnionQueryElement : public IParserBase
 {
 protected:
     const char * getName() const override { return "SELECT query, subquery, possibly with UNION"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 }

--- a/src/Parsers/ParserUseQuery.cpp
+++ b/src/Parsers/ParserUseQuery.cpp
@@ -8,16 +8,16 @@
 namespace DB
 {
 
-bool ParserUseQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserUseQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     ParserKeyword s_use("USE");
     ParserIdentifier name_p;
 
-    if (!s_use.ignore(pos, expected))
+    if (!s_use.ignore(pos, expected, ranges))
         return false;
 
     ASTPtr database;
-    if (!name_p.parse(pos, database, expected))
+    if (!name_p.parse(pos, database, expected, ranges))
         return false;
 
     auto query = std::make_shared<ASTUseQuery>();

--- a/src/Parsers/ParserUseQuery.h
+++ b/src/Parsers/ParserUseQuery.h
@@ -12,7 +12,7 @@ class ParserUseQuery : public IParserBase
 {
 protected:
     const char * getName() const  override{ return "USE query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 }

--- a/src/Parsers/ParserWatchQuery.cpp
+++ b/src/Parsers/ParserWatchQuery.cpp
@@ -20,7 +20,7 @@ limitations under the License. */
 namespace DB
 {
 
-bool ParserWatchQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+bool ParserWatchQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges)
 {
     ParserKeyword s_watch("WATCH");
     ParserToken s_dot(TokenType::Dot);
@@ -32,33 +32,33 @@ bool ParserWatchQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     ASTPtr table;
     auto query = std::make_shared<ASTWatchQuery>();
 
-    if (!s_watch.ignore(pos, expected))
+    if (!s_watch.ignore(pos, expected, ranges))
     {
         return false;
     }
 
-    if (!name_p.parse(pos, table, expected))
+    if (!name_p.parse(pos, table, expected, ranges))
         return false;
 
-    if (s_dot.ignore(pos, expected))
+    if (s_dot.ignore(pos, expected, ranges))
     {
         database = table;
-        if (!name_p.parse(pos, table, expected))
+        if (!name_p.parse(pos, table, expected, ranges))
             return false;
     }
 
     /// EVENTS
-    if (s_events.ignore(pos, expected))
+    if (s_events.ignore(pos, expected, ranges))
     {
         query->is_watch_events = true;
     }
 
     /// LIMIT length
-    if (s_limit.ignore(pos, expected))
+    if (s_limit.ignore(pos, expected, ranges))
     {
         ParserNumber num;
 
-        if (!num.parse(pos, query->limit_length, expected))
+        if (!num.parse(pos, query->limit_length, expected, ranges))
             return false;
     }
 

--- a/src/Parsers/ParserWatchQuery.h
+++ b/src/Parsers/ParserWatchQuery.h
@@ -24,7 +24,7 @@ class ParserWatchQuery : public IParserBase
 {
 protected:
     const char * getName() const override { return "WATCH query"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected, Ranges * ranges) override;
 };
 
 }

--- a/src/Parsers/TokenIterator.h
+++ b/src/Parsers/TokenIterator.h
@@ -57,6 +57,7 @@ private:
     size_t index = 0;
 
 public:
+    TokenIterator() : tokens(nullptr) {}
     explicit TokenIterator(Tokens & tokens_) : tokens(&tokens_) {}
 
     const Token & get() { return (*tokens)[index]; }
@@ -68,6 +69,8 @@ public:
 
     bool operator< (const TokenIterator & rhs) const { return index < rhs.index; }
     bool operator<= (const TokenIterator & rhs) const { return index <= rhs.index; }
+    bool operator> (const TokenIterator & rhs) const { return index > rhs.index; }
+    bool operator>= (const TokenIterator & rhs) const { return index >= rhs.index; }
     bool operator== (const TokenIterator & rhs) const { return index == rhs.index; }
     bool operator!= (const TokenIterator & rhs) const { return index != rhs.index; }
 

--- a/src/Parsers/parseDatabaseAndTableName.cpp
+++ b/src/Parsers/parseDatabaseAndTableName.cpp
@@ -7,7 +7,7 @@
 namespace DB
 {
 
-bool parseDatabaseAndTableName(IParser::Pos & pos, Expected & expected, String & database_str, String & table_str)
+bool parseDatabaseAndTableName(IParser::Pos & pos, Expected & expected, IParser::Ranges * ranges, String & database_str, String & table_str)
 {
     ParserToken s_dot(TokenType::Dot);
     ParserIdentifier table_parser;
@@ -18,12 +18,12 @@ bool parseDatabaseAndTableName(IParser::Pos & pos, Expected & expected, String &
     database_str = "";
     table_str = "";
 
-    if (!table_parser.parse(pos, database, expected))
+    if (!table_parser.parse(pos, database, expected, ranges))
         return false;
 
-    if (s_dot.ignore(pos))
+    if (s_dot.ignore(pos, expected, ranges))
     {
-        if (!table_parser.parse(pos, table, expected))
+        if (!table_parser.parse(pos, table, expected, ranges))
         {
             database_str = "";
             return false;

--- a/src/Parsers/parseDatabaseAndTableName.h
+++ b/src/Parsers/parseDatabaseAndTableName.h
@@ -5,6 +5,6 @@ namespace DB
 {
 
 /// Parses [db].name
-bool parseDatabaseAndTableName(IParser::Pos & pos, Expected & expected, String & database_str, String & table_str);
+bool parseDatabaseAndTableName(IParser::Pos & pos, Expected & expected, IParser::Ranges * ranges, String & database_str, String & table_str);
 
 }

--- a/src/Parsers/parseIdentifierOrStringLiteral.cpp
+++ b/src/Parsers/parseIdentifierOrStringLiteral.cpp
@@ -8,13 +8,13 @@
 namespace DB
 {
 
-bool parseIdentifierOrStringLiteral(IParser::Pos & pos, Expected & expected, String & result)
+bool parseIdentifierOrStringLiteral(IParser::Pos & pos, Expected & expected, IParser::Ranges * ranges, String & result)
 {
     ASTPtr res;
 
-    if (!ParserIdentifier().parse(pos, res, expected))
+    if (!ParserIdentifier().parse(pos, res, expected, ranges))
     {
-        if (!ParserStringLiteral().parse(pos, res, expected))
+        if (!ParserStringLiteral().parse(pos, res, expected, ranges))
             return false;
 
         result = res->as<ASTLiteral &>().value.safeGet<String>();

--- a/src/Parsers/parseIdentifierOrStringLiteral.h
+++ b/src/Parsers/parseIdentifierOrStringLiteral.h
@@ -7,6 +7,6 @@ namespace DB
 
 /** Parses a name of an object which could be written in 3 forms:
   * name, `name` or 'name' */
-bool parseIdentifierOrStringLiteral(IParser::Pos & pos, Expected & expected, String & result);
+bool parseIdentifierOrStringLiteral(IParser::Pos & pos, Expected & expected, IParser::Ranges * ranges, String & result);
 
 }

--- a/src/Parsers/parseIntervalKind.cpp
+++ b/src/Parsers/parseIntervalKind.cpp
@@ -5,59 +5,59 @@
 
 namespace DB
 {
-bool parseIntervalKind(IParser::Pos & pos, Expected & expected, IntervalKind & result)
+bool parseIntervalKind(IParser::Pos & pos, Expected & expected, IParser::Ranges * ranges, IntervalKind & result)
 {
-    if (ParserKeyword("SECOND").ignore(pos, expected) || ParserKeyword("SQL_TSI_SECOND").ignore(pos, expected)
-        || ParserKeyword("SS").ignore(pos, expected) || ParserKeyword("S").ignore(pos, expected))
+    if (ParserKeyword("SECOND").ignore(pos, expected, ranges) || ParserKeyword("SQL_TSI_SECOND").ignore(pos, expected, ranges)
+        || ParserKeyword("SS").ignore(pos, expected, ranges) || ParserKeyword("S").ignore(pos, expected, ranges))
     {
         result = IntervalKind::Second;
         return true;
     }
 
-    if (ParserKeyword("MINUTE").ignore(pos, expected) || ParserKeyword("SQL_TSI_MINUTE").ignore(pos, expected)
-        || ParserKeyword("MI").ignore(pos, expected) || ParserKeyword("N").ignore(pos, expected))
+    if (ParserKeyword("MINUTE").ignore(pos, expected, ranges) || ParserKeyword("SQL_TSI_MINUTE").ignore(pos, expected, ranges)
+        || ParserKeyword("MI").ignore(pos, expected, ranges) || ParserKeyword("N").ignore(pos, expected, ranges))
     {
         result = IntervalKind::Minute;
         return true;
     }
 
-    if (ParserKeyword("HOUR").ignore(pos, expected) || ParserKeyword("SQL_TSI_HOUR").ignore(pos, expected)
-        || ParserKeyword("HH").ignore(pos, expected))
+    if (ParserKeyword("HOUR").ignore(pos, expected, ranges) || ParserKeyword("SQL_TSI_HOUR").ignore(pos, expected, ranges)
+        || ParserKeyword("HH").ignore(pos, expected, ranges))
     {
         result = IntervalKind::Hour;
         return true;
     }
 
-    if (ParserKeyword("DAY").ignore(pos, expected) || ParserKeyword("SQL_TSI_DAY").ignore(pos, expected)
-        || ParserKeyword("DD").ignore(pos, expected) || ParserKeyword("D").ignore(pos, expected))
+    if (ParserKeyword("DAY").ignore(pos, expected, ranges) || ParserKeyword("SQL_TSI_DAY").ignore(pos, expected, ranges)
+        || ParserKeyword("DD").ignore(pos, expected, ranges) || ParserKeyword("D").ignore(pos, expected, ranges))
     {
         result = IntervalKind::Day;
         return true;
     }
 
-    if (ParserKeyword("WEEK").ignore(pos, expected) || ParserKeyword("SQL_TSI_WEEK").ignore(pos, expected)
-        || ParserKeyword("WK").ignore(pos, expected) || ParserKeyword("WW").ignore(pos, expected))
+    if (ParserKeyword("WEEK").ignore(pos, expected, ranges) || ParserKeyword("SQL_TSI_WEEK").ignore(pos, expected, ranges)
+        || ParserKeyword("WK").ignore(pos, expected, ranges) || ParserKeyword("WW").ignore(pos, expected, ranges))
     {
         result = IntervalKind::Week;
         return true;
     }
 
-    if (ParserKeyword("MONTH").ignore(pos, expected) || ParserKeyword("SQL_TSI_MONTH").ignore(pos, expected)
-        || ParserKeyword("MM").ignore(pos, expected) || ParserKeyword("M").ignore(pos, expected))
+    if (ParserKeyword("MONTH").ignore(pos, expected, ranges) || ParserKeyword("SQL_TSI_MONTH").ignore(pos, expected, ranges)
+        || ParserKeyword("MM").ignore(pos, expected, ranges) || ParserKeyword("M").ignore(pos, expected, ranges))
     {
         result = IntervalKind::Month;
         return true;
     }
 
-    if (ParserKeyword("QUARTER").ignore(pos, expected) || ParserKeyword("SQL_TSI_QUARTER").ignore(pos, expected)
-        || ParserKeyword("QQ").ignore(pos, expected) || ParserKeyword("Q").ignore(pos, expected))
+    if (ParserKeyword("QUARTER").ignore(pos, expected, ranges) || ParserKeyword("SQL_TSI_QUARTER").ignore(pos, expected, ranges)
+        || ParserKeyword("QQ").ignore(pos, expected, ranges) || ParserKeyword("Q").ignore(pos, expected, ranges))
     {
         result = IntervalKind::Quarter;
         return true;
     }
 
-    if (ParserKeyword("YEAR").ignore(pos, expected) || ParserKeyword("SQL_TSI_YEAR").ignore(pos, expected)
-        || ParserKeyword("YYYY").ignore(pos, expected) || ParserKeyword("YY").ignore(pos, expected))
+    if (ParserKeyword("YEAR").ignore(pos, expected, ranges) || ParserKeyword("SQL_TSI_YEAR").ignore(pos, expected, ranges)
+        || ParserKeyword("YYYY").ignore(pos, expected, ranges) || ParserKeyword("YY").ignore(pos, expected, ranges))
     {
         result = IntervalKind::Year;
         return true;

--- a/src/Parsers/parseIntervalKind.h
+++ b/src/Parsers/parseIntervalKind.h
@@ -7,5 +7,5 @@
 namespace DB
 {
 /// Parses an interval kind.
-bool parseIntervalKind(IParser::Pos & pos, Expected & expected, IntervalKind & result);
+bool parseIntervalKind(IParser::Pos & pos, Expected & expected, IParser::Ranges * ranges, IntervalKind & result);
 }

--- a/src/Parsers/parseQuery.h
+++ b/src/Parsers/parseQuery.h
@@ -11,6 +11,7 @@ ASTPtr tryParseQuery(
     IParser & parser,
     const char * & pos,                /// Moved to end of parsed fragment.
     const char * end,
+    IParser::Ranges * ranges,
     std::string & out_error_message,
     bool hilite,
     const std::string & description,
@@ -25,6 +26,7 @@ ASTPtr parseQueryAndMovePosition(
     IParser & parser,
     const char * & pos,                /// Moved to end of parsed fragment.
     const char * end,
+    IParser::Ranges * ranges,
     const std::string & description,
     bool allow_multi_statements,
     size_t max_query_size,
@@ -34,6 +36,7 @@ ASTPtr parseQuery(
     IParser & parser,
     const char * begin,
     const char * end,
+    IParser::Ranges * ranges,
     const std::string & description,
     size_t max_query_size,
     size_t max_parser_depth);
@@ -41,6 +44,7 @@ ASTPtr parseQuery(
 ASTPtr parseQuery(
     IParser & parser,
     const std::string & query,
+    IParser::Ranges * ranges,
     const std::string & query_description,
     size_t max_query_size,
     size_t max_parser_depth);
@@ -48,6 +52,7 @@ ASTPtr parseQuery(
 ASTPtr parseQuery(
     IParser & parser,
     const std::string & query,
+    IParser::Ranges * ranges,
     size_t max_query_size,
     size_t max_parser_depth);
 

--- a/src/Parsers/parseUserName.cpp
+++ b/src/Parsers/parseUserName.cpp
@@ -6,18 +6,18 @@
 
 namespace DB
 {
-bool parseUserName(IParser::Pos & pos, Expected & expected, String & user_name, std::optional<String> & host_like_pattern)
+bool parseUserName(IParser::Pos & pos, Expected & expected, IParser::Ranges * ranges, String & user_name, std::optional<String> & host_like_pattern)
 {
     String name;
-    if (!parseIdentifierOrStringLiteral(pos, expected, name))
+    if (!parseIdentifierOrStringLiteral(pos, expected, ranges, name))
         return false;
 
     boost::algorithm::trim(name);
 
     std::optional<String> pattern;
-    if (ParserToken{TokenType::At}.ignore(pos, expected))
+    if (ParserToken{TokenType::At}.ignore(pos, expected, ranges))
     {
-        if (!parseIdentifierOrStringLiteral(pos, expected, pattern.emplace()))
+        if (!parseIdentifierOrStringLiteral(pos, expected, ranges, pattern.emplace()))
             return false;
 
         boost::algorithm::trim(*pattern);
@@ -32,27 +32,27 @@ bool parseUserName(IParser::Pos & pos, Expected & expected, String & user_name, 
 }
 
 
-bool parseUserName(IParser::Pos & pos, Expected & expected, String & user_name)
+bool parseUserName(IParser::Pos & pos, Expected & expected, IParser::Ranges * ranges, String & user_name)
 {
     std::optional<String> unused_pattern;
-    return parseUserName(pos, expected, user_name, unused_pattern);
+    return parseUserName(pos, expected, ranges, user_name, unused_pattern);
 }
 
 
-bool parseUserNameOrCurrentUserTag(IParser::Pos & pos, Expected & expected, String & user_name, bool & current_user)
+bool parseUserNameOrCurrentUserTag(IParser::Pos & pos, Expected & expected, IParser::Ranges * ranges, String & user_name, bool & current_user)
 {
-    if (ParserKeyword{"CURRENT_USER"}.ignore(pos, expected) || ParserKeyword{"currentUser"}.ignore(pos, expected))
+    if (ParserKeyword{"CURRENT_USER"}.ignore(pos, expected, ranges) || ParserKeyword{"currentUser"}.ignore(pos, expected, ranges))
     {
-        if (ParserToken{TokenType::OpeningRoundBracket}.ignore(pos, expected))
+        if (ParserToken{TokenType::OpeningRoundBracket}.ignore(pos, expected, ranges))
         {
-            if (!ParserToken{TokenType::ClosingRoundBracket}.ignore(pos, expected))
+            if (!ParserToken{TokenType::ClosingRoundBracket}.ignore(pos, expected, ranges))
                 return false;
         }
         current_user = true;
         return true;
     }
 
-    if (parseUserName(pos, expected, user_name))
+    if (parseUserName(pos, expected, ranges, user_name))
     {
         current_user = false;
         return true;

--- a/src/Parsers/parseUserName.h
+++ b/src/Parsers/parseUserName.h
@@ -10,16 +10,16 @@ namespace DB
 /// The `host` can be an ip address, ip subnet, or a host name.
 /// The % and _ wildcard characters are permitted in `host`.
 /// These have the same meaning as for pattern-matching operations performed with the LIKE operator.
-bool parseUserName(IParser::Pos & pos, Expected & expected, String & user_name, std::optional<String> & host_like_pattern);
-bool parseUserName(IParser::Pos & pos, Expected & expected, String & user_name);
+bool parseUserName(IParser::Pos & pos, Expected & expected, IParser::Ranges * ranges, String & user_name, std::optional<String> & host_like_pattern);
+bool parseUserName(IParser::Pos & pos, Expected & expected, IParser::Ranges * ranges, String & user_name);
 
 /// Parses either a user name or the 'CURRENT_USER' keyword (or some of the aliases).
-bool parseUserNameOrCurrentUserTag(IParser::Pos & pos, Expected & expected, String & user_name, bool & current_user);
+bool parseUserNameOrCurrentUserTag(IParser::Pos & pos, Expected & expected, IParser::Ranges * ranges, String & user_name, bool & current_user);
 
 /// Parses a role name. It follows the same rules as a user name, but allowed hosts are never checked
 /// (because roles are not used to connect to server).
-inline bool parseRoleName(IParser::Pos & pos, Expected & expected, String & role_name)
+inline bool parseRoleName(IParser::Pos & pos, Expected & expected, IParser::Ranges * ranges, String & role_name)
 {
-    return parseUserName(pos, expected, role_name);
+    return parseUserName(pos, expected, ranges, role_name);
 }
 }

--- a/src/Processors/Formats/Impl/ConstantExpressionTemplate.cpp
+++ b/src/Processors/Formats/Impl/ConstantExpressionTemplate.cpp
@@ -432,7 +432,8 @@ bool ConstantExpressionTemplate::tryParseExpression(ReadBuffer & istr, const For
     return true;
 }
 
-bool ConstantExpressionTemplate::parseLiteralAndAssertType(ReadBuffer & istr, const IDataType * complex_type, size_t column_idx, const Settings & settings)
+bool ConstantExpressionTemplate::parseLiteralAndAssertType(
+    ReadBuffer & istr, const IDataType * complex_type, size_t column_idx, const Settings & settings)
 {
     using Type = Field::Types::Which;
 
@@ -455,7 +456,7 @@ bool ConstantExpressionTemplate::parseLiteralAndAssertType(ReadBuffer & istr, co
         IParser::Pos iterator(tokens_number, settings.max_parser_depth);
         Expected expected;
         ASTPtr ast;
-        if (!parser_array.parse(iterator, ast, expected) && !parser_tuple.parse(iterator, ast, expected))
+        if (!parser_array.parse(iterator, ast, expected, nullptr) && !parser_tuple.parse(iterator, ast, expected, nullptr))
             return false;
 
         istr.position() = const_cast<char *>(iterator->begin);

--- a/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
@@ -197,7 +197,7 @@ bool ValuesBlockInputFormat::parseExpression(IColumn & column, size_t column_idx
     IParser::Pos token_iterator(tokens, settings.max_parser_depth);
     ASTPtr ast;
 
-    bool parsed = parser.parse(token_iterator, ast, expected);
+    bool parsed = parser.parse(token_iterator, ast, expected, nullptr);
 
     /// Consider delimiter after value (',' or ')') as part of expression
     if (column_idx + 1 != num_columns)

--- a/src/Storages/ColumnsDescription.cpp
+++ b/src/Storages/ColumnsDescription.cpp
@@ -104,7 +104,7 @@ void ColumnDescription::readText(ReadBuffer & buf)
     ParserColumnDeclaration column_parser(/* require type */ true);
     String column_line;
     readEscapedStringUntilEOL(column_line, buf);
-    ASTPtr ast = parseQuery(column_parser, column_line, "column parser", 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
+    ASTPtr ast = parseQuery(column_parser, column_line, nullptr, "column parser", 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
     if (const auto * col_ast = ast->as<ASTColumnDeclaration>())
     {
         name = col_ast->name;

--- a/src/Storages/ConstraintsDescription.cpp
+++ b/src/Storages/ConstraintsDescription.cpp
@@ -30,7 +30,7 @@ ConstraintsDescription ConstraintsDescription::parse(const String & str)
 
     ConstraintsDescription res;
     ParserConstraintDeclarationList parser;
-    ASTPtr list = parseQuery(parser, str, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
+    ASTPtr list = parseQuery(parser, str, nullptr, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
 
     for (const auto & constraint : list->children)
         res.constraints.push_back(constraint);

--- a/src/Storages/IndicesDescription.cpp
+++ b/src/Storages/IndicesDescription.cpp
@@ -100,7 +100,7 @@ IndicesDescription IndicesDescription::parse(const String & str, const ColumnsDe
         return result;
 
     ParserIndexDeclarationList parser;
-    ASTPtr list = parseQuery(parser, str, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
+    ASTPtr list = parseQuery(parser, str, nullptr, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
 
     for (const auto & index : list->children)
         result.emplace_back(IndexDescription::getIndexFromAST(index, columns, context));

--- a/src/Storages/MutationCommands.cpp
+++ b/src/Storages/MutationCommands.cpp
@@ -138,7 +138,7 @@ void MutationCommands::readText(ReadBuffer & in)
 
     ParserAlterCommandList p_alter_commands;
     auto commands_ast = parseQuery(
-        p_alter_commands, commands_str.data(), commands_str.data() + commands_str.length(), "mutation commands list", 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
+        p_alter_commands, commands_str.data(), commands_str.data() + commands_str.length(), nullptr, "mutation commands list", 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
     for (ASTAlterCommand * command_ast : commands_ast->as<ASTAlterCommandList &>().commands)
     {
         auto command = MutationCommand::parse(command_ast, true);

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -481,7 +481,7 @@ void StorageReplicatedMergeTree::setTableStructure(ColumnsDescription new_column
         if (metadata_diff.sorting_key_changed)
         {
             ParserNotEmptyExpressionList parser(false);
-            auto new_sorting_key_expr_list = parseQuery(parser, metadata_diff.new_sorting_key, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
+            auto new_sorting_key_expr_list = parseQuery(parser, metadata_diff.new_sorting_key, nullptr, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
 
             if (new_sorting_key_expr_list->children.size() == 1)
                 metadata.order_by_ast = new_sorting_key_expr_list->children[0];
@@ -509,7 +509,7 @@ void StorageReplicatedMergeTree::setTableStructure(ColumnsDescription new_column
         if (metadata_diff.ttl_table_changed)
         {
             ParserTTLExpressionList parser;
-            metadata.ttl_for_table_ast = parseQuery(parser, metadata_diff.new_ttl_table, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
+            metadata.ttl_for_table_ast = parseQuery(parser, metadata_diff.new_ttl_table, nullptr, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
         }
     }
 

--- a/src/Storages/getStructureOfRemoteTable.cpp
+++ b/src/Storages/getStructureOfRemoteTable.cpp
@@ -137,7 +137,7 @@ ColumnsDescription getStructureOfRemoteTableInShard(
                 column.default_desc.kind = columnDefaultKindFromString(kind_name);
                 String expr_str = (*default_expr)[i].get<const String &>();
                 column.default_desc.expression = parseQuery(
-                    expr_parser, expr_str.data(), expr_str.data() + expr_str.size(), "default expression", 0, context.getSettingsRef().max_parser_depth);
+                    expr_parser, expr_str.data(), expr_str.data() + expr_str.size(), nullptr, "default expression", 0, context.getSettingsRef().max_parser_depth);
             }
 
             res.add(column);

--- a/src/Storages/tests/gtest_transform_query_for_external_database.cpp
+++ b/src/Storages/tests/gtest_transform_query_for_external_database.cpp
@@ -57,7 +57,7 @@ static void check(const std::string & query, const std::string & expected, const
     query_info.query = ast;
     std::string transformed_query = transformQueryForExternalDatabase(query_info, columns, IdentifierQuotingStyle::DoubleQuotes, "test", "table", context);
 
-    EXPECT_EQ(transformed_query, expected);
+    EXPECT_EQ(transformed_query, expected, ranges);
 }
 
 

--- a/src/TableFunctions/parseColumnsListForTableFunction.cpp
+++ b/src/TableFunctions/parseColumnsListForTableFunction.cpp
@@ -24,7 +24,7 @@ ColumnsDescription parseColumnsListFromString(const std::string & structure, con
     ParserColumnDeclarationList parser;
     ASTPtr columns_list_raw;
 
-    if (!parser.parse(token_iterator, columns_list_raw, expected))
+    if (!parser.parse(token_iterator, columns_list_raw, expected, nullptr))
         throw Exception("Cannot parse columns declaration list.", ErrorCodes::SYNTAX_ERROR);
 
     auto * columns_list = dynamic_cast<ASTExpressionList *>(columns_list_raw.get());


### PR DESCRIPTION
Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Syntax highlight in clickhouse-client with full featured parser. It allows to see syntax error before executing query.


Detailed description / Documentation draft:
A prototype, not kind of convenient in code.