### PR TITLE
MySQL datatypes dateTime64 and decimal

### DIFF
--- a/base/mysqlxx/ResultBase.h
+++ b/base/mysqlxx/ResultBase.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <boost/noncopyable.hpp>
 #include <mysqlxx/Types.h>
-
 
 namespace mysqlxx
 {
@@ -21,6 +19,11 @@ class ResultBase
 {
 public:
     ResultBase(MYSQL_RES * res_, Connection * conn_, const Query * query_);
+
+    ResultBase(const ResultBase &) = delete;
+    ResultBase & operator=(const ResultBase &) = delete;
+    ResultBase(ResultBase &&) = default;
+    ResultBase & operator=(ResultBase &&) = default;
 
     Connection * getConnection() { return conn; }
     MYSQL_FIELDS getFields() { return fields; }

--- a/base/mysqlxx/Value.h
+++ b/base/mysqlxx/Value.h
@@ -254,7 +254,21 @@ template <> inline std::string          Value::get<std::string          >() cons
 template <> inline LocalDate            Value::get<LocalDate            >() const { return getDate(); }
 template <> inline LocalDateTime        Value::get<LocalDateTime        >() const { return getDateTime(); }
 
-template <typename T> inline T          Value::get()                        const { return T(*this); }
+
+namespace details
+{
+// To avoid stack overflow when converting to type with no appropriate c-tor,
+// resulting in endless recursive calls from `Value::get<T>()` to `Value::operator T()` to `Value::get<T>()` to ...
+template <typename T, typename std::enable_if_t<std::is_constructible_v<T, Value>>>
+inline T contructFromValue(const Value & val)
+{
+    return T(val);
+}
+}
+
+template <typename T> inline T          Value::get()                        const {
+    return details::contructFromValue<T>(*this);
+}
 
 
 inline std::ostream & operator<< (std::ostream & ostr, const Value & x)

--- a/base/mysqlxx/Value.h
+++ b/base/mysqlxx/Value.h
@@ -266,7 +266,9 @@ inline T contructFromValue(const Value & val)
 }
 }
 
-template <typename T> inline T          Value::get()                        const {
+template <typename T>
+inline T Value::get() const
+{
     return details::contructFromValue<T>(*this);
 }
 

--- a/programs/odbc-bridge/ODBCBlockInputStream.cpp
+++ b/programs/odbc-bridge/ODBCBlockInputStream.cpp
@@ -15,6 +15,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int NUMBER_OF_COLUMNS_DOESNT_MATCH;
+    extern const int UNKNOWN_TYPE;
 }
 
 
@@ -86,6 +87,8 @@ namespace
             case ValueType::vtUUID:
                 assert_cast<ColumnUInt128 &>(column).insert(parse<UUID>(value.convert<std::string>()));
                 break;
+            default:
+                throw Exception("Unsupported value type", ErrorCodes::UNKNOWN_TYPE);
         }
     }
 

--- a/programs/odbc-bridge/ODBCBlockOutputStream.cpp
+++ b/programs/odbc-bridge/ODBCBlockOutputStream.cpp
@@ -13,6 +13,11 @@
 namespace DB
 {
 
+namespace ErrorCodes
+{
+    extern const int UNKNOWN_TYPE;
+}
+
 namespace
 {
     using ValueType = ExternalResultDescription::ValueType;
@@ -79,6 +84,9 @@ namespace
                 return Poco::Dynamic::Var(std::to_string(LocalDateTime(time_t(field.get<UInt64>())))).convert<String>();
             case ValueType::vtUUID:
                 return Poco::Dynamic::Var(UUID(field.get<UInt128>()).toUnderType().toHexString()).convert<std::string>();
+             default:
+                 throw Exception("Unsupported value type", ErrorCodes::UNKNOWN_TYPE);
+
         }
         __builtin_unreachable();
     }

--- a/src/Common/ErrorCodes.cpp
+++ b/src/Common/ErrorCodes.cpp
@@ -507,6 +507,7 @@ namespace ErrorCodes
     extern const int CANNOT_DECLARE_RABBITMQ_EXCHANGE = 540;
     extern const int CANNOT_CREATE_RABBITMQ_QUEUE_BINDING = 541;
     extern const int CANNOT_REMOVE_RABBITMQ_EXCHANGE = 542;
+    extern const int UNKNOWN_MYSQL_DATATYPES_SUPPORT_LEVEL = 543;
 
     extern const int KEEPER_EXCEPTION = 999;
     extern const int POCO_EXCEPTION = 1000;

--- a/src/Core/ExternalResultDescription.cpp
+++ b/src/Core/ExternalResultDescription.cpp
@@ -1,9 +1,11 @@
 #include "ExternalResultDescription.h"
 #include <DataTypes/DataTypeDate.h>
 #include <DataTypes/DataTypeDateTime.h>
+#include <DataTypes/DataTypeDateTime64.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeUUID.h>
+#include <DataTypes/DataTypesDecimal.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeEnum.h>
 #include <Common/typeid_cast.h>
@@ -64,6 +66,14 @@ void ExternalResultDescription::init(const Block & sample_block_)
             types.emplace_back(ValueType::vtString, is_nullable);
         else if (typeid_cast<const DataTypeEnum16 *>(type))
             types.emplace_back(ValueType::vtString, is_nullable);
+        else if (typeid_cast<const DataTypeDateTime64 *>(type))
+            types.emplace_back(ValueType::vtDateTime64, is_nullable);
+        else if (typeid_cast<const DataTypeDecimal<Decimal32> *>(type))
+            types.emplace_back(ValueType::vtDecimal32, is_nullable);
+        else if (typeid_cast<const DataTypeDecimal<Decimal64> *>(type))
+            types.emplace_back(ValueType::vtDecimal64, is_nullable);
+        else if (typeid_cast<const DataTypeDecimal<Decimal128> *>(type))
+            types.emplace_back(ValueType::vtDecimal128, is_nullable);
         else
             throw Exception{"Unsupported type " + type->getName(), ErrorCodes::UNKNOWN_TYPE};
     }

--- a/src/Core/ExternalResultDescription.h
+++ b/src/Core/ExternalResultDescription.h
@@ -26,6 +26,10 @@ struct ExternalResultDescription
         vtDate,
         vtDateTime,
         vtUUID,
+        vtDateTime64,
+        vtDecimal32,
+        vtDecimal64,
+        vtDecimal128
     };
 
     Block sample_block;

--- a/src/Core/MultiEnum.h
+++ b/src/Core/MultiEnum.h
@@ -12,9 +12,9 @@ struct MultiEnum
 
     MultiEnum() = default;
 
-    template <typename ... EnumValues, typename = std::enable_if_t<std::is_same_v<EnumTypeT, EnumValues...>>>
-    explicit MultiEnum(EnumType v0, EnumValues ... v)
-        : MultiEnum(toBitFlag(v0) | (toBitFlag(v) | ... | 0u))
+    template <typename ... EnumValues, typename = std::enable_if_t<std::conjunction_v<std::is_same<EnumTypeT, EnumValues>...>>>
+    explicit MultiEnum(EnumValues ... v)
+        : MultiEnum((toBitFlag(v) | ... | 0u))
     {}
 
     template <typename ValueType, typename = std::enable_if_t<std::is_convertible_v<ValueType, StorageType>>>

--- a/src/Core/MultiEnum.h
+++ b/src/Core/MultiEnum.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+// Wrapper around enum that can have multiple values (or none) set at once.
+template <typename EnumTypeT, typename StorageTypeT = std::uint64_t>
+struct MultiEnum
+{
+    using StorageType = StorageTypeT;
+    using EnumType = EnumTypeT;
+
+    template <typename ... EnumValues>
+    explicit MultiEnum(EnumValues ... v)
+        : MultiEnum((toBitFlag(v) | ... | 0u))
+    {}
+
+    template <typename ValueType, typename = std::enable_if_t<std::is_convertible_v<ValueType, StorageType>>>
+    explicit MultiEnum(ValueType v = 0)
+        : bitset(v)
+    {
+        static_assert(std::is_unsigned_v<ValueType>);
+        static_assert(std::is_unsigned_v<StorageType> && std::is_integral_v<StorageType>);
+    }
+
+    bool isSet(EnumType value) const
+    {
+        return bitset & toBitFlag(value);
+    }
+
+    void set(EnumType value)
+    {
+        bitset |= toBitFlag(value);
+    }
+
+    void unSet(EnumType value)
+    {
+        bitset &= ~(toBitFlag(value));
+    }
+
+    void reset()
+    {
+        bitset = 0;
+    }
+
+    StorageType getValue() const
+    {
+        return bitset;
+    }
+
+    template <typename ValueType, typename = std::enable_if_t<std::is_convertible_v<ValueType, StorageType>>>
+    void setValue(ValueType new_value)
+    {
+        // Can't set value from any enum avoid confusion
+        static_assert(!std::is_enum_v<ValueType>);
+        bitset = new_value;
+    }
+
+    bool operator==(const MultiEnum & other) const
+    {
+        return bitset == other.bitset;
+    }
+
+    template <typename ValueType, typename = std::enable_if_t<std::is_convertible_v<ValueType, StorageType>>>
+    bool operator==(ValueType other) const
+    {
+        // Shouldn't be comparable with any enum to avoid confusion
+        static_assert(!std::is_enum_v<ValueType>);
+        return bitset == other;
+    }
+
+    template <typename U>
+    bool operator!=(U && other) const
+    {
+        return !(*this == other);
+    }
+
+    template <typename ValueType, typename = std::enable_if_t<std::is_convertible_v<ValueType, StorageType>>>
+    friend bool operator==(ValueType left, MultiEnum right)
+    {
+        return right == left;
+    }
+
+    template <typename L>
+    friend bool operator!=(L left, MultiEnum right)
+    {
+        return !(right == left);
+    }
+
+private:
+    StorageType bitset;
+
+    static StorageType toBitFlag(EnumType v) { return StorageType{1} << static_cast<StorageType>(v); }
+};

--- a/src/Core/MultiEnum.h
+++ b/src/Core/MultiEnum.h
@@ -10,18 +10,23 @@ struct MultiEnum
     using StorageType = StorageTypeT;
     using EnumType = EnumTypeT;
 
-    template <typename ... EnumValues>
-    explicit MultiEnum(EnumValues ... v)
-        : MultiEnum((toBitFlag(v) | ... | 0u))
+    MultiEnum() = default;
+
+    template <typename ... EnumValues, typename = std::enable_if_t<std::is_same_v<EnumTypeT, EnumValues...>>>
+    explicit MultiEnum(EnumType v0, EnumValues ... v)
+        : MultiEnum(toBitFlag(v0) | (toBitFlag(v) | ... | 0u))
     {}
 
     template <typename ValueType, typename = std::enable_if_t<std::is_convertible_v<ValueType, StorageType>>>
-    explicit MultiEnum(ValueType v = 0)
+    explicit MultiEnum(ValueType v)
         : bitset(v)
     {
         static_assert(std::is_unsigned_v<ValueType>);
         static_assert(std::is_unsigned_v<StorageType> && std::is_integral_v<StorageType>);
     }
+
+    MultiEnum(const MultiEnum & other) = default;
+    MultiEnum & operator=(const MultiEnum & other) = default;
 
     bool isSet(EnumType value) const
     {
@@ -88,7 +93,7 @@ struct MultiEnum
     }
 
 private:
-    StorageType bitset;
+    StorageType bitset = 0;
 
     static StorageType toBitFlag(EnumType v) { return StorageType{1} << static_cast<StorageType>(v); }
 };

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -382,7 +382,7 @@ class IColumn;
     M(Bool, alter_partition_verbose_result, false, "Output information about affected parts. Currently works only for FREEZE and ATTACH commands.", 0) \
     M(Bool, allow_experimental_database_materialize_mysql, false, "Allow to create database with Engine=MaterializeMySQL(...).", 0) \
     M(Bool, system_events_show_zero_values, false, "Include all metrics, even with zero values", 0) \
-    M(MySQLDataTypesSupport, mysql_datatypes_support_level, 0, "Which MySQL types should be converted to corresponding ClickHouse types", 0) \
+    M(MySQLDataTypesSupport, mysql_datatypes_support_level, 0, "Which MySQL types should be converted to corresponding ClickHouse types (rather than being represented as String). Can be empty or any combination of 'decimal' or 'datetime64'. When empty MySQL's DECIMAL and DATETIME/TIMESTAMP with non-zero precison are seen as String on ClickHouse's side.", 0) \
     \
     /** Obsolete settings that do nothing but left for compatibility reasons. Remove each one after half a year of obsolescence. */ \
     \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -382,6 +382,7 @@ class IColumn;
     M(Bool, alter_partition_verbose_result, false, "Output information about affected parts. Currently works only for FREEZE and ATTACH commands.", 0) \
     M(Bool, allow_experimental_database_materialize_mysql, false, "Allow to create database with Engine=MaterializeMySQL(...).", 0) \
     M(Bool, system_events_show_zero_values, false, "Include all metrics, even with zero values", 0) \
+    M(MySQLDataTypesSupport, mysql_datatypes_support_level, 0, "Which MySQL types should be converted to corresponding ClickHouse types", 0) \
     \
     /** Obsolete settings that do nothing but left for compatibility reasons. Remove each one after half a year of obsolescence. */ \
     \

--- a/src/Core/SettingsEnums.cpp
+++ b/src/Core/SettingsEnums.cpp
@@ -11,6 +11,7 @@ namespace ErrorCodes
     extern const int UNKNOWN_DISTRIBUTED_PRODUCT_MODE;
     extern const int UNKNOWN_JOIN;
     extern const int BAD_ARGUMENTS;
+    extern const int UNKNOWN_MYSQL_DATATYPES_SUPPORT_LEVEL;
 }
 
 
@@ -90,5 +91,9 @@ IMPLEMENT_SETTING_ENUM_WITH_RENAME(LogQueriesType, ErrorCodes::BAD_ARGUMENTS,
 IMPLEMENT_SETTING_ENUM_WITH_RENAME(DefaultDatabaseEngine, ErrorCodes::BAD_ARGUMENTS,
     {{"Ordinary", DefaultDatabaseEngine::Ordinary},
      {"Atomic",   DefaultDatabaseEngine::Atomic}})
+
+IMPLEMENT_SETTING_MULTI_ENUM(MySQLDataTypesSupport, ErrorCodes::UNKNOWN_MYSQL_DATATYPES_SUPPORT_LEVEL,
+    {{"decimal",    MySQLDataTypesSupport::DECIMAL},
+     {"datetime64", MySQLDataTypesSupport::DATETIME64}})
 
 }

--- a/src/Core/SettingsEnums.h
+++ b/src/Core/SettingsEnums.h
@@ -126,4 +126,15 @@ enum class DefaultDatabaseEngine
 };
 
 DECLARE_SETTING_ENUM(DefaultDatabaseEngine)
+
+
+enum class MySQLDataTypesSupport
+{
+    DECIMAL, // convert MySQL's decimal and number to ClickHouse Decimal when applicable
+    DATETIME64, // convert MySQL's DATETIME and TIMESTAMP and ClickHouse DateTime64 if precision is > 0 or range is greater that for DateTime.
+    // ENUM
+};
+
+DECLARE_SETTING_MULTI_ENUM(MySQLDataTypesSupport)
+
 }

--- a/src/Core/SettingsFields.h
+++ b/src/Core/SettingsFields.h
@@ -455,6 +455,4 @@ struct SettingFieldCustom
     void readBinary(ReadBuffer & in);
 };
 
-
-
 }

--- a/src/Core/SettingsFields.h
+++ b/src/Core/SettingsFields.h
@@ -4,9 +4,11 @@
 #include <Poco/URI.h>
 #include <Core/Types.h>
 #include <Core/Field.h>
+#include <Core/MultiEnum.h>
 #include <boost/range/adaptor/map.hpp>
 #include <chrono>
 #include <unordered_map>
+#include <string_view>
 
 
 namespace DB
@@ -328,6 +330,113 @@ void SettingFieldEnum<EnumT, Traits>::readBinary(ReadBuffer & in)
         throw Exception(msg, ERROR_CODE_FOR_UNEXPECTED_NAME); \
     }
 
+// Mostly like SettingFieldEnum, but can have multiple enum values (or none) set at once.
+template <typename Enum, typename Traits>
+struct SettingFieldMultiEnum
+{
+    using EnumType = Enum;
+    using ValueType = MultiEnum<Enum>;
+    using StorageType = typename ValueType::StorageType;
+
+    ValueType value;
+    bool changed = false;
+
+    explicit SettingFieldMultiEnum(ValueType v = ValueType{}) : value{v} {}
+    explicit SettingFieldMultiEnum(EnumType e) : value{e} {}
+    explicit SettingFieldMultiEnum(StorageType s) : value(s) {}
+    explicit SettingFieldMultiEnum(const Field & f) : value(parseValueFromString(f.safeGet<const String &>())) {}
+
+    operator ValueType() const { return value; }
+    explicit operator StorageType() const { return value.getValue(); }
+    explicit operator Field() const { return toString(); }
+
+    SettingFieldMultiEnum & operator= (StorageType x) { changed = x != value.getValue(); value.setValue(x); return *this; }
+    SettingFieldMultiEnum & operator= (ValueType x) { changed = !(x == value); value = x; return *this; }
+    SettingFieldMultiEnum & operator= (const Field & x) { parseFromString(x.safeGet<const String &>()); return *this; }
+
+    String toString() const
+    {
+        static const String separator = ",";
+        String result;
+        for (StorageType i = 0; i < Traits::getEnumSize(); ++i)
+        {
+            const auto v = static_cast<Enum>(i);
+            if (value.isSet(v))
+            {
+                result += Traits::toString(v);
+                result += separator;
+            }
+        }
+
+        if (result.size() > 0)
+            result.erase(result.size() - separator.size());
+
+        return result;
+    }
+    void parseFromString(const String & str) { *this = parseValueFromString(str); }
+
+    void writeBinary(WriteBuffer & out) const;
+    void readBinary(ReadBuffer & in);
+
+private:
+    static ValueType parseValueFromString(const std::string_view str)
+    {
+        static const String separators=", ";
+
+        ValueType result;
+
+        //to avoid allocating memory on substr()
+        const std::string_view str_view{str};
+
+        auto value_start = str_view.find_first_not_of(separators);
+        while (value_start != std::string::npos)
+        {
+            auto value_end = str_view.find_first_of(separators, value_start + 1);
+            if (value_end == std::string::npos)
+                value_end = str_view.size();
+
+            result.set(Traits::fromString(str_view.substr(value_start, value_end - value_start)));
+            value_start = str_view.find_first_not_of(separators, value_end);
+        }
+
+        return result;
+    }
+};
+
+template <typename EnumT, typename Traits>
+void SettingFieldMultiEnum<EnumT, Traits>::writeBinary(WriteBuffer & out) const
+{
+    SettingFieldEnumHelpers::writeBinary(toString(), out);
+}
+
+template <typename EnumT, typename Traits>
+void SettingFieldMultiEnum<EnumT, Traits>::readBinary(ReadBuffer & in)
+{
+    parseFromString(SettingFieldEnumHelpers::readBinary(in));
+}
+
+#define DECLARE_SETTING_MULTI_ENUM(ENUM_TYPE) \
+    DECLARE_SETTING_MULTI_ENUM_WITH_RENAME(ENUM_TYPE, ENUM_TYPE)
+
+#define DECLARE_SETTING_MULTI_ENUM_WITH_RENAME(ENUM_TYPE, NEW_NAME) \
+    struct SettingField##NEW_NAME##Traits \
+    { \
+        using EnumType = ENUM_TYPE; \
+        static size_t getEnumSize(); \
+        static const String & toString(EnumType value); \
+        static EnumType fromString(const std::string_view & str); \
+    }; \
+    \
+    using SettingField##NEW_NAME = SettingFieldMultiEnum<ENUM_TYPE, SettingField##NEW_NAME##Traits>;
+
+#define IMPLEMENT_SETTING_MULTI_ENUM(ENUM_TYPE, ERROR_CODE_FOR_UNEXPECTED_NAME, ...) \
+    IMPLEMENT_SETTING_MULTI_ENUM_WITH_RENAME(ENUM_TYPE, ERROR_CODE_FOR_UNEXPECTED_NAME, __VA_ARGS__)
+
+#define IMPLEMENT_SETTING_MULTI_ENUM_WITH_RENAME(NEW_NAME, ERROR_CODE_FOR_UNEXPECTED_NAME, ...) \
+    IMPLEMENT_SETTING_ENUM_WITH_RENAME(NEW_NAME, ERROR_CODE_FOR_UNEXPECTED_NAME, __VA_ARGS__)\
+    size_t SettingField##NEW_NAME##Traits::getEnumSize() {\
+        return std::initializer_list<std::pair<const char*, NEW_NAME>> __VA_ARGS__ .size();\
+    }
 
 /// Can keep a value of any type. Used for user-defined settings.
 struct SettingFieldCustom
@@ -345,5 +454,7 @@ struct SettingFieldCustom
     void writeBinary(WriteBuffer & out) const;
     void readBinary(ReadBuffer & in);
 };
+
+
 
 }

--- a/src/Core/tests/gtest_multienum.cpp
+++ b/src/Core/tests/gtest_multienum.cpp
@@ -34,6 +34,20 @@ GTEST_TEST(MultiEnum, WithDefault)
     ASSERT_FALSE(multi_enum.isSet(TestEnum::FIVE));
 }
 
+GTEST_TEST(MultiEnum, WitheEnum)
+{
+    MultiEnum<TestEnum, UInt8> multi_enum(TestEnum::FOUR);
+    ASSERT_EQ(16, multi_enum.getValue());
+    ASSERT_EQ(16, multi_enum);
+
+    ASSERT_FALSE(multi_enum.isSet(TestEnum::ZERO));
+    ASSERT_FALSE(multi_enum.isSet(TestEnum::ONE));
+    ASSERT_FALSE(multi_enum.isSet(TestEnum::TWO));
+    ASSERT_FALSE(multi_enum.isSet(TestEnum::THREE));
+    ASSERT_TRUE(multi_enum.isSet(TestEnum::FOUR));
+    ASSERT_FALSE(multi_enum.isSet(TestEnum::FIVE));
+}
+
 GTEST_TEST(MultiEnum, WithValue)
 {
     const MultiEnum<TestEnum> multi_enum(13u); // (1 | (1 << 2 | 1 << 3)

--- a/src/Core/tests/gtest_multienum.cpp
+++ b/src/Core/tests/gtest_multienum.cpp
@@ -1,0 +1,144 @@
+#include <gtest/gtest.h>
+
+#include <Core/Types.h>
+#include <type_traits>
+#include <Core/MultiEnum.h>
+
+namespace
+{
+
+using namespace DB;
+enum class TestEnum : UInt8
+{
+    // name represents which bit is going to be set
+    ZERO,
+    ONE,
+    TWO,
+    THREE,
+    FOUR,
+    FIVE
+};
+}
+
+GTEST_TEST(MultiEnum, WithDefault)
+{
+    MultiEnum<TestEnum, UInt8> multi_enum;
+    ASSERT_EQ(0, multi_enum.getValue());
+    ASSERT_EQ(0, multi_enum);
+
+    ASSERT_FALSE(multi_enum.isSet(TestEnum::ZERO));
+    ASSERT_FALSE(multi_enum.isSet(TestEnum::ONE));
+    ASSERT_FALSE(multi_enum.isSet(TestEnum::TWO));
+    ASSERT_FALSE(multi_enum.isSet(TestEnum::THREE));
+    ASSERT_FALSE(multi_enum.isSet(TestEnum::FOUR));
+    ASSERT_FALSE(multi_enum.isSet(TestEnum::FIVE));
+}
+
+GTEST_TEST(MultiEnum, WithValue)
+{
+    const MultiEnum<TestEnum> multi_enum(13u); // (1 | (1 << 2 | 1 << 3)
+
+    ASSERT_TRUE(multi_enum.isSet(TestEnum::ZERO));
+    ASSERT_FALSE(multi_enum.isSet(TestEnum::ONE));
+    ASSERT_TRUE(multi_enum.isSet(TestEnum::TWO));
+    ASSERT_TRUE(multi_enum.isSet(TestEnum::THREE));
+    ASSERT_FALSE(multi_enum.isSet(TestEnum::FOUR));
+    ASSERT_FALSE(multi_enum.isSet(TestEnum::FIVE));
+}
+
+GTEST_TEST(MultiEnum, WithMany)
+{
+    MultiEnum<TestEnum> multi_enum{TestEnum::ONE, TestEnum::FIVE};
+    ASSERT_EQ(1 << 1 | 1 << 5, multi_enum.getValue());
+    ASSERT_EQ(1 << 1 | 1 << 5, multi_enum);
+
+    ASSERT_FALSE(multi_enum.isSet(TestEnum::ZERO));
+    ASSERT_TRUE(multi_enum.isSet(TestEnum::ONE));
+    ASSERT_FALSE(multi_enum.isSet(TestEnum::TWO));
+    ASSERT_FALSE(multi_enum.isSet(TestEnum::THREE));
+    ASSERT_FALSE(multi_enum.isSet(TestEnum::FOUR));
+    ASSERT_TRUE(multi_enum.isSet(TestEnum::FIVE));
+}
+
+GTEST_TEST(MultiEnum, WithCopyConstructor)
+{
+    const MultiEnum<TestEnum> multi_enum_source{TestEnum::ONE, TestEnum::FIVE};
+    MultiEnum<TestEnum> multi_enum{multi_enum_source};
+
+    ASSERT_EQ(1 << 1 | 1 << 5, multi_enum.getValue());
+}
+
+GTEST_TEST(MultiEnum, SetAndUnSet)
+{
+    MultiEnum<TestEnum> multi_enum;
+    multi_enum.set(TestEnum::ONE);
+    ASSERT_EQ(1 << 1, multi_enum);
+
+    multi_enum.set(TestEnum::TWO);
+    ASSERT_EQ(1 << 1| (1 << 2), multi_enum);
+
+    multi_enum.unSet(TestEnum::ONE);
+    ASSERT_EQ(1 << 2, multi_enum);
+}
+
+GTEST_TEST(MultiEnum, SetValueOnDifferentTypes)
+{
+    MultiEnum<TestEnum> multi_enum;
+
+    multi_enum.setValue(static_cast<UInt8>(1));
+    ASSERT_EQ(1, multi_enum);
+
+    multi_enum.setValue(static_cast<UInt16>(2));
+    ASSERT_EQ(2, multi_enum);
+
+    multi_enum.setValue(static_cast<UInt32>(3));
+    ASSERT_EQ(3, multi_enum);
+
+    multi_enum.setValue(static_cast<UInt64>(4));
+    ASSERT_EQ(4, multi_enum);
+}
+
+// shouldn't compile
+//GTEST_TEST(MultiEnum, WithOtherEnumType)
+//{
+//    MultiEnum<TestEnum> multi_enum;
+
+//    enum FOO {BAR, FOOBAR};
+//    MultiEnum<TestEnum> multi_enum2(BAR);
+//    MultiEnum<TestEnum> multi_enum3(BAR, FOOBAR);
+//    multi_enum.setValue(FOO::BAR);
+//    multi_enum == FOO::BAR;
+//    FOO::BAR == multi_enum;
+//}
+
+GTEST_TEST(MultiEnum, SetSameValueMultipleTimes)
+{
+    // Setting same value is idempotent.
+    MultiEnum<TestEnum> multi_enum;
+    multi_enum.set(TestEnum::ONE);
+    ASSERT_EQ(1 << 1, multi_enum);
+
+    multi_enum.set(TestEnum::ONE);
+    ASSERT_EQ(1 << 1, multi_enum);
+}
+
+GTEST_TEST(MultiEnum, UnSetValuesThatWerentSet)
+{
+    // Unsetting values that weren't set shouldn't change other flags nor aggregate value.
+    MultiEnum<TestEnum> multi_enum{TestEnum::ONE, TestEnum::THREE};
+    multi_enum.unSet(TestEnum::TWO);
+    ASSERT_EQ(1 << 1 | 1 << 3, multi_enum);
+
+    multi_enum.unSet(TestEnum::FOUR);
+    ASSERT_EQ(1 << 1 | 1 << 3, multi_enum);
+
+    multi_enum.unSet(TestEnum::FIVE);
+    ASSERT_EQ(1 << 1 | 1 << 3, multi_enum);
+}
+
+GTEST_TEST(MultiEnum, Reset)
+{
+    MultiEnum<TestEnum> multi_enum{TestEnum::ONE, TestEnum::THREE};
+    multi_enum.reset();
+    ASSERT_EQ(0, multi_enum);
+}

--- a/src/Core/tests/gtest_settings.cpp
+++ b/src/Core/tests/gtest_settings.cpp
@@ -1,0 +1,146 @@
+#include <gtest/gtest.h>
+
+#include <Core/SettingsFields.h>
+#include <Core/SettingsEnums.h>
+#include <Core/Field.h>
+
+namespace
+{
+using namespace DB;
+using SettingMySQLDataTypesSupport = SettingFieldMultiEnum<MySQLDataTypesSupport, SettingFieldMySQLDataTypesSupportTraits>;
+}
+
+namespace DB
+{
+
+template <typename Enum, typename Traits>
+bool operator== (const SettingFieldMultiEnum<Enum, Traits> & setting, const Field & f)
+{
+    return Field(setting) == f;
+}
+
+template <typename Enum, typename Traits>
+bool operator== (const Field & f, const SettingFieldMultiEnum<Enum, Traits> & setting)
+{
+    return f == Field(setting);
+}
+
+}
+
+GTEST_TEST(MySQLDataTypesSupport, WithDefault)
+{
+    // Setting can be default-initialized and that means all values are unset.
+    const SettingMySQLDataTypesSupport setting;
+    ASSERT_EQ(0, setting.value.getValue());
+    ASSERT_EQ("", setting.toString());
+    ASSERT_EQ(setting, Field(""));
+
+    ASSERT_FALSE(setting.value.isSet(MySQLDataTypesSupport::DECIMAL));
+    ASSERT_FALSE(setting.value.isSet(MySQLDataTypesSupport::DATETIME64));
+}
+
+GTEST_TEST(SettingMySQLDataTypesSupport, WithDECIMAL)
+{
+    // Setting can be initialized with MySQLDataTypesSupport::DECIMAL
+    // and this value can be obtained in varios forms with getters.
+    const SettingMySQLDataTypesSupport setting(MySQLDataTypesSupport::DECIMAL);
+    ASSERT_EQ(1, setting.value.getValue());
+
+    ASSERT_TRUE(setting.value.isSet(MySQLDataTypesSupport::DECIMAL));
+    ASSERT_FALSE(setting.value.isSet(MySQLDataTypesSupport::DATETIME64));
+
+    ASSERT_EQ("decimal", setting.toString());
+    ASSERT_EQ(Field("decimal"), setting);
+}
+
+GTEST_TEST(SettingMySQLDataTypesSupport, With1)
+{
+    // Setting can be initialized with int value corresponding to DECIMAL
+    // and rest of the test is the same as for that value.
+    const SettingMySQLDataTypesSupport setting(1u);
+    ASSERT_EQ(1, setting.value.getValue());
+
+    ASSERT_TRUE(setting.value.isSet(MySQLDataTypesSupport::DECIMAL));
+    ASSERT_FALSE(setting.value.isSet(MySQLDataTypesSupport::DATETIME64));
+
+    ASSERT_EQ("decimal", setting.toString());
+    ASSERT_EQ(Field("decimal"), setting);
+}
+
+GTEST_TEST(SettingMySQLDataTypesSupport, WithMultipleValues)
+{
+    // Setting can be initialized with int value corresponding to (DECIMAL | DATETIME64)
+    const SettingMySQLDataTypesSupport setting(3u);
+    ASSERT_EQ(3, setting.value.getValue());
+
+    ASSERT_TRUE(setting.value.isSet(MySQLDataTypesSupport::DECIMAL));
+    ASSERT_TRUE(setting.value.isSet(MySQLDataTypesSupport::DATETIME64));
+
+    ASSERT_EQ("decimal,datetime64", setting.toString());
+    ASSERT_EQ(Field("decimal,datetime64"), setting);
+}
+
+GTEST_TEST(SettingMySQLDataTypesSupport, SetString)
+{
+    SettingMySQLDataTypesSupport setting;
+    setting = String("decimal");
+    ASSERT_TRUE(setting.changed);
+    ASSERT_TRUE(setting.value.isSet(MySQLDataTypesSupport::DECIMAL));
+    ASSERT_FALSE(setting.value.isSet(MySQLDataTypesSupport::DATETIME64));
+    ASSERT_EQ("decimal", setting.toString());
+    ASSERT_EQ(Field("decimal"), setting);
+
+    setting = "datetime64,decimal";
+    ASSERT_TRUE(setting.changed);
+    ASSERT_TRUE(setting.value.isSet(MySQLDataTypesSupport::DECIMAL));
+    ASSERT_TRUE(setting.value.isSet(MySQLDataTypesSupport::DATETIME64));
+    ASSERT_EQ("decimal,datetime64", setting.toString());
+    ASSERT_EQ(Field("decimal,datetime64"), setting);
+
+    // comma with spaces
+    setting = " datetime64 ,    decimal ";
+    ASSERT_FALSE(setting.changed); // false since value is the same as previous one.
+    ASSERT_TRUE(setting.value.isSet(MySQLDataTypesSupport::DECIMAL));
+    ASSERT_TRUE(setting.value.isSet(MySQLDataTypesSupport::DATETIME64));
+    ASSERT_EQ("decimal,datetime64", setting.toString());
+    ASSERT_EQ(Field("decimal,datetime64"), setting);
+
+    setting = String(",,,,,,,, ,decimal");
+    ASSERT_TRUE(setting.changed);
+    ASSERT_TRUE(setting.value.isSet(MySQLDataTypesSupport::DECIMAL));
+    ASSERT_FALSE(setting.value.isSet(MySQLDataTypesSupport::DATETIME64));
+    ASSERT_EQ("decimal", setting.toString());
+    ASSERT_EQ(Field("decimal"), setting);
+
+    setting = String(",decimal,decimal,decimal,decimal,decimal,decimal,decimal,decimal,decimal,");
+    ASSERT_FALSE(setting.changed); //since previous value was DECIMAL
+    ASSERT_TRUE(setting.value.isSet(MySQLDataTypesSupport::DECIMAL));
+    ASSERT_FALSE(setting.value.isSet(MySQLDataTypesSupport::DATETIME64));
+    ASSERT_EQ("decimal", setting.toString());
+    ASSERT_EQ(Field("decimal"), setting);
+
+    setting = String("");
+    ASSERT_TRUE(setting.changed);
+    ASSERT_FALSE(setting.value.isSet(MySQLDataTypesSupport::DECIMAL));
+    ASSERT_FALSE(setting.value.isSet(MySQLDataTypesSupport::DATETIME64));
+    ASSERT_EQ("", setting.toString());
+    ASSERT_EQ(Field(""), setting);
+}
+
+GTEST_TEST(SettingMySQLDataTypesSupport, SetInvalidString)
+{
+    // Setting can be initialized with int value corresponding to (DECIMAL | DATETIME64)
+    SettingMySQLDataTypesSupport setting;
+    EXPECT_THROW(setting = String("FOOBAR"), Exception);
+    ASSERT_FALSE(setting.changed);
+    ASSERT_EQ(0, setting.value.getValue());
+
+    EXPECT_THROW(setting = String("decimal,datetime64,123"), Exception);
+    ASSERT_FALSE(setting.changed);
+    ASSERT_EQ(0, setting.value.getValue());
+
+    EXPECT_NO_THROW(setting = String(", "));
+    ASSERT_FALSE(setting.changed);
+    ASSERT_EQ(0, setting.value.getValue());
+}
+

--- a/src/DataStreams/MongoDBBlockInputStream.cpp
+++ b/src/DataStreams/MongoDBBlockInputStream.cpp
@@ -37,6 +37,7 @@ namespace ErrorCodes
     extern const int TYPE_MISMATCH;
     extern const int MONGODB_CANNOT_AUTHENTICATE;
     extern const int NOT_FOUND_COLUMN_IN_BLOCK;
+    extern const int UNKNOWN_TYPE;
 }
 
 
@@ -298,6 +299,8 @@ namespace
                                     ErrorCodes::TYPE_MISMATCH};
                 break;
             }
+            default:
+                throw Exception("Value of unsupported type:" + column.getName(), ErrorCodes::UNKNOWN_TYPE);
         }
     }
 

--- a/src/DataTypes/convertMySQLDataType.cpp
+++ b/src/DataTypes/convertMySQLDataType.cpp
@@ -7,6 +7,9 @@
 #include <Parsers/IAST.h>
 #include "DataTypeDate.h"
 #include "DataTypeDateTime.h"
+#include "DataTypeDateTime64.h"
+#include "DataTypeEnum.h"
+#include "DataTypesDecimal.h"
 #include "DataTypeFixedString.h"
 #include "DataTypeNullable.h"
 #include "DataTypeString.h"
@@ -25,48 +28,69 @@ ASTPtr dataTypeConvertToQuery(const DataTypePtr & data_type)
     return makeASTFunction("Nullable", dataTypeConvertToQuery(typeid_cast<const DataTypeNullable *>(data_type.get())->getNestedType()));
 }
 
-DataTypePtr convertMySQLDataType(const std::string & mysql_data_type, bool is_nullable, bool is_unsigned, size_t length)
+DataTypePtr convertMySQLDataType(const std::string & mysql_data_type, bool is_nullable, bool is_unsigned, size_t length, size_t precision, size_t scale)
 {
+    // we expect mysql_data_type to be either "basic_type" or "type_with_params(param1, param2, ...)"
+    auto data_type = std::string_view(mysql_data_type);
+    const auto param_start_pos = data_type.find("(");
+    const auto type_name = data_type.substr(0, param_start_pos);
+
     DataTypePtr res;
-    if (mysql_data_type == "tinyint")
+    if (type_name == "tinyint")
     {
         if (is_unsigned)
             res = std::make_shared<DataTypeUInt8>();
         else
             res = std::make_shared<DataTypeInt8>();
     }
-    else if (mysql_data_type == "smallint")
+    else if (type_name == "smallint")
     {
         if (is_unsigned)
             res = std::make_shared<DataTypeUInt16>();
         else
             res = std::make_shared<DataTypeInt16>();
     }
-    else if (mysql_data_type == "int" || mysql_data_type == "mediumint")
+    else if (type_name == "int" || type_name == "mediumint")
     {
         if (is_unsigned)
             res = std::make_shared<DataTypeUInt32>();
         else
             res = std::make_shared<DataTypeInt32>();
     }
-    else if (mysql_data_type == "bigint")
+    else if (type_name == "bigint")
     {
         if (is_unsigned)
             res = std::make_shared<DataTypeUInt64>();
         else
             res = std::make_shared<DataTypeInt64>();
     }
-    else if (mysql_data_type == "float")
+    else if (type_name == "float")
         res = std::make_shared<DataTypeFloat32>();
-    else if (mysql_data_type == "double")
+    else if (type_name == "double")
         res = std::make_shared<DataTypeFloat64>();
-    else if (mysql_data_type == "date")
+    else if (type_name == "date")
         res = std::make_shared<DataTypeDate>();
-    else if (mysql_data_type == "datetime" || mysql_data_type == "timestamp")
+    if (type_name == "timestamp" && scale == 0)
+    {
         res = std::make_shared<DataTypeDateTime>();
-    else if (mysql_data_type == "binary")
+    }
+    else if (type_name == "datetime" || type_name == "timestamp")
+    {
+        res = std::make_shared<DataTypeDateTime64>(scale);
+    }
+    else if (type_name == "binary")
         res = std::make_shared<DataTypeFixedString>(length);
-    else
+    else if (type_name == "numeric" || type_name == "decimal")
+    {
+        if (precision <= DecimalUtils::maxPrecision<Decimal32>())
+            res = std::make_shared<DataTypeDecimal<Decimal32>>(precision, scale);
+        else if (precision <= DecimalUtils::maxPrecision<Decimal64>())
+            res = std::make_shared<DataTypeDecimal<Decimal64>>(precision, scale);
+        else if (precision <= DecimalUtils::maxPrecision<Decimal128>())
+            res = std::make_shared<DataTypeDecimal<Decimal128>>(precision, scale);
+    }
+
+    if (!res)
         /// Also String is fallback for all unknown types.
         res = std::make_shared<DataTypeString>();
     if (is_nullable)

--- a/src/DataTypes/convertMySQLDataType.cpp
+++ b/src/DataTypes/convertMySQLDataType.cpp
@@ -2,6 +2,8 @@
 
 #include <Core/Field.h>
 #include <Core/Types.h>
+#include <Core/MultiEnum.h>
+#include <Core/SettingsEnums.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/IAST.h>
@@ -28,73 +30,88 @@ ASTPtr dataTypeConvertToQuery(const DataTypePtr & data_type)
     return makeASTFunction("Nullable", dataTypeConvertToQuery(typeid_cast<const DataTypeNullable *>(data_type.get())->getNestedType()));
 }
 
-DataTypePtr convertMySQLDataType(const std::string & mysql_data_type, bool is_nullable, bool is_unsigned, size_t length, size_t precision, size_t scale)
+DataTypePtr convertMySQLDataType(MultiEnum<MySQLDataTypesSupport> type_support,
+        const std::string & mysql_data_type,
+        bool is_nullable,
+        bool is_unsigned,
+        size_t length,
+        size_t precision,
+        size_t scale)
 {
     // we expect mysql_data_type to be either "basic_type" or "type_with_params(param1, param2, ...)"
     auto data_type = std::string_view(mysql_data_type);
     const auto param_start_pos = data_type.find("(");
     const auto type_name = data_type.substr(0, param_start_pos);
 
-    DataTypePtr res;
-    if (type_name == "tinyint")
-    {
-        if (is_unsigned)
-            res = std::make_shared<DataTypeUInt8>();
-        else
-            res = std::make_shared<DataTypeInt8>();
-    }
-    else if (type_name == "smallint")
-    {
-        if (is_unsigned)
-            res = std::make_shared<DataTypeUInt16>();
-        else
-            res = std::make_shared<DataTypeInt16>();
-    }
-    else if (type_name == "int" || type_name == "mediumint")
-    {
-        if (is_unsigned)
-            res = std::make_shared<DataTypeUInt32>();
-        else
-            res = std::make_shared<DataTypeInt32>();
-    }
-    else if (type_name == "bigint")
-    {
-        if (is_unsigned)
-            res = std::make_shared<DataTypeUInt64>();
-        else
-            res = std::make_shared<DataTypeInt64>();
-    }
-    else if (type_name == "float")
-        res = std::make_shared<DataTypeFloat32>();
-    else if (type_name == "double")
-        res = std::make_shared<DataTypeFloat64>();
-    else if (type_name == "date")
-        res = std::make_shared<DataTypeDate>();
-    if (type_name == "timestamp" && scale == 0)
-    {
-        res = std::make_shared<DataTypeDateTime>();
-    }
-    else if (type_name == "datetime" || type_name == "timestamp")
-    {
-        res = std::make_shared<DataTypeDateTime64>(scale);
-    }
-    else if (type_name == "binary")
-        res = std::make_shared<DataTypeFixedString>(length);
-    else if (type_name == "numeric" || type_name == "decimal")
-    {
-        if (precision <= DecimalUtils::maxPrecision<Decimal32>())
-            res = std::make_shared<DataTypeDecimal<Decimal32>>(precision, scale);
-        else if (precision <= DecimalUtils::maxPrecision<Decimal64>())
-            res = std::make_shared<DataTypeDecimal<Decimal64>>(precision, scale);
-        else if (precision <= DecimalUtils::maxPrecision<Decimal128>())
-            res = std::make_shared<DataTypeDecimal<Decimal128>>(precision, scale);
-    }
+    DataTypePtr res = [&]() -> DataTypePtr {
+        if (type_name == "tinyint")
+        {
+            if (is_unsigned)
+                return std::make_shared<DataTypeUInt8>();
+            else
+                return std::make_shared<DataTypeInt8>();
+        }
+        if (type_name == "smallint")
+        {
+            if (is_unsigned)
+                return std::make_shared<DataTypeUInt16>();
+            else
+                return std::make_shared<DataTypeInt16>();
+        }
+        if (type_name == "int" || type_name == "mediumint")
+        {
+            if (is_unsigned)
+                return std::make_shared<DataTypeUInt32>();
+            else
+                return std::make_shared<DataTypeInt32>();
+        }
+        if (type_name == "bigint")
+        {
+            if (is_unsigned)
+                return std::make_shared<DataTypeUInt64>();
+            else
+                return std::make_shared<DataTypeInt64>();
+        }
+        if (type_name == "float")
+            return std::make_shared<DataTypeFloat32>();
+        if (type_name == "double")
+            return std::make_shared<DataTypeFloat64>();
+        if (type_name == "date")
+            return std::make_shared<DataTypeDate>();
+        if (type_name == "binary")
+            return std::make_shared<DataTypeFixedString>(length);
+        if (type_name == "datetime" || type_name == "timestamp")
+        {
+            if (!type_support.isSet(MySQLDataTypesSupport::DATETIME64))
+                return std::make_shared<DataTypeDateTime>();
 
-    if (!res)
+            if (type_name == "timestamp" && scale == 0)
+            {
+                return std::make_shared<DataTypeDateTime>();
+            }
+            else if (type_name == "datetime" || type_name == "timestamp")
+            {
+                return std::make_shared<DataTypeDateTime64>(scale);
+            }
+        }
+
+        if (type_support.isSet(MySQLDataTypesSupport::DECIMAL) && (type_name == "numeric" || type_name == "decimal"))
+        {
+            if (precision <= DecimalUtils::maxPrecision<Decimal32>())
+                return std::make_shared<DataTypeDecimal<Decimal32>>(precision, scale);
+            else if (precision <= DecimalUtils::maxPrecision<Decimal64>())
+                return std::make_shared<DataTypeDecimal<Decimal64>>(precision, scale);
+            else if (precision <= DecimalUtils::maxPrecision<Decimal128>())
+                return std::make_shared<DataTypeDecimal<Decimal128>>(precision, scale);
+        }
+
         /// Also String is fallback for all unknown types.
-        res = std::make_shared<DataTypeString>();
+        return std::make_shared<DataTypeString>();
+    }();
+
     if (is_nullable)
         res = std::make_shared<DataTypeNullable>(res);
+
     return res;
 }
 

--- a/src/DataTypes/convertMySQLDataType.h
+++ b/src/DataTypes/convertMySQLDataType.h
@@ -1,17 +1,20 @@
 #pragma once
 
 #include <string>
+#include <Core/MultiEnum.h>
 #include <Parsers/IAST.h>
 #include "IDataType.h"
 
 namespace DB
 {
+enum class MySQLDataTypesSupport;
+
 /// Convert data type to query. for example
 /// DataTypeUInt8 -> ASTIdentifier(UInt8)
 /// DataTypeNullable(DataTypeUInt8) -> ASTFunction(ASTIdentifier(UInt8))
 ASTPtr dataTypeConvertToQuery(const DataTypePtr & data_type);
 
 /// Convert MySQL type to ClickHouse data type.
-DataTypePtr convertMySQLDataType(const std::string & mysql_data_type, bool is_nullable, bool is_unsigned, size_t length, size_t precision, size_t scale);
+DataTypePtr convertMySQLDataType(MultiEnum<MySQLDataTypesSupport> type_support, const std::string & mysql_data_type, bool is_nullable, bool is_unsigned, size_t length, size_t precision, size_t scale);
 
 }

--- a/src/DataTypes/convertMySQLDataType.h
+++ b/src/DataTypes/convertMySQLDataType.h
@@ -12,6 +12,6 @@ namespace DB
 ASTPtr dataTypeConvertToQuery(const DataTypePtr & data_type);
 
 /// Convert MySQL type to ClickHouse data type.
-DataTypePtr convertMySQLDataType(const std::string & mysql_data_type, bool is_nullable, bool is_unsigned, size_t length);
+DataTypePtr convertMySQLDataType(const std::string & mysql_data_type, bool is_nullable, bool is_unsigned, size_t length, size_t precision, size_t scale);
 
 }

--- a/src/DataTypes/tests/gtest_DataType_deserializeAsText.cpp
+++ b/src/DataTypes/tests/gtest_DataType_deserializeAsText.cpp
@@ -1,0 +1,102 @@
+#include <DataTypes/DataTypeFactory.h>
+#include <DataTypes/IDataType.h>
+#include <DataTypes/getLeastSupertype.h>
+#include <DataTypes/getMostSubtype.h>
+#include <IO/ReadBuffer.h>
+#include <Columns/IColumn.h>
+#include <Formats/FormatSettings.h>
+#include <Core/Field.h>
+#include <Columns/IColumn.h>
+
+#pragma GCC diagnostic ignored "-Wmissing-declarations"
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include <Core/iostream_debug_helpers.h>
+
+namespace std
+{
+
+template <typename T>
+inline std::ostream& operator<<(std::ostream & ostr, const std::vector<T> & v)
+{
+    ostr << "[";
+    for (const auto & i : v)
+    {
+        ostr << i << ", ";
+    }
+    return ostr << "] (" << v.size() << ") items";
+}
+
+}
+
+using namespace DB;
+
+struct ParseDataTypeTestCase
+{
+    const char * type_name;
+    std::vector<String> values;
+    FieldVector expected_values;
+};
+
+std::ostream & operator<<(std::ostream & ostr, const ParseDataTypeTestCase & test_case)
+{
+    return ostr << "ParseDataTypeTestCase{\"" << test_case.type_name << "\", " << test_case.values << "}";
+}
+
+
+class ParseDataTypeTest : public ::testing::TestWithParam<ParseDataTypeTestCase>
+{
+public:
+    void SetUp() override
+    {
+        const auto & p = GetParam();
+
+        data_type = DataTypeFactory::instance().get(p.type_name);
+    }
+
+    DataTypePtr data_type;
+};
+
+TEST_P(ParseDataTypeTest, parseStringValue)
+{
+    const auto & p = GetParam();
+
+    auto col = data_type->createColumn();
+    for (const auto & value : p.values)
+    {
+        ReadBuffer buffer(const_cast<char *>(value.data()), value.size(), 0);
+        data_type->deserializeAsWholeText(*col, buffer, FormatSettings{});
+    }
+
+    ASSERT_EQ(p.expected_values.size(), col->size()) << "Actual items: " << *col;
+    for (size_t i = 0; i < col->size(); ++i)
+    {
+        ASSERT_EQ(p.expected_values[i], (*col)[i]);
+    }
+}
+
+
+INSTANTIATE_TEST_SUITE_P(ParseDecimal,
+    ParseDataTypeTest,
+    ::testing::ValuesIn(
+        std::initializer_list<ParseDataTypeTestCase>{
+            {
+                "Decimal(8, 0)",
+                {"0", "5", "8", "-5", "-8", "12345678", "-12345678"},
+
+                std::initializer_list<Field>{
+                    DecimalField<Decimal32>(0, 0),
+                    DecimalField<Decimal32>(5, 0),
+                    DecimalField<Decimal32>(8, 0),
+                    DecimalField<Decimal32>(-5, 0),
+                    DecimalField<Decimal32>(-8, 0),
+                    DecimalField<Decimal32>(12345678, 0),
+                    DecimalField<Decimal32>(-12345678, 0)
+                }
+            }
+        }
+    )
+);

--- a/src/DataTypes/tests/gtest_DataType_deserializeAsText.cpp
+++ b/src/DataTypes/tests/gtest_DataType_deserializeAsText.cpp
@@ -1,12 +1,11 @@
+#include <Columns/IColumn.h>
+#include <Core/Field.h>
 #include <DataTypes/DataTypeFactory.h>
 #include <DataTypes/IDataType.h>
 #include <DataTypes/getLeastSupertype.h>
 #include <DataTypes/getMostSubtype.h>
-#include <IO/ReadBuffer.h>
-#include <Columns/IColumn.h>
 #include <Formats/FormatSettings.h>
-#include <Core/Field.h>
-#include <Columns/IColumn.h>
+#include <IO/ReadBuffer.h>
 
 #pragma GCC diagnostic ignored "-Wmissing-declarations"
 #include <gtest/gtest.h>

--- a/src/Databases/MySQL/DatabaseConnectionMySQL.h
+++ b/src/Databases/MySQL/DatabaseConnectionMySQL.h
@@ -4,16 +4,26 @@
 #if USE_MYSQL
 
 #include <mysqlxx/Pool.h>
-#include <Databases/DatabasesCommon.h>
-#include <memory>
-#include <Parsers/ASTCreateQuery.h>
-#include <Common/ThreadPool.h>
 
+#include <Common/ThreadPool.h>
+#include <Databases/DatabasesCommon.h>
+#include <Parsers/ASTCreateQuery.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <unordered_set>
+#include <vector>
 
 namespace DB
 {
 
 class Context;
+
+
+std::map<String, NamesAndTypesList> fetchTablesColumnsList(mysqlxx::Pool & pool, const String & database_name, const std::vector<String> & tables_name, bool external_table_functions_use_nulls);
 
 /** Real-time access to table list and table structure from remote MySQL
  *  It doesn't make any manipulations with filesystem.

--- a/src/Databases/MySQL/FetchTablesColumnsList.cpp
+++ b/src/Databases/MySQL/FetchTablesColumnsList.cpp
@@ -1,0 +1,114 @@
+#if !defined(ARCADIA_BUILD)
+#    include "config_core.h"
+#endif
+
+#if USE_MYSQL
+#include <Core/Block.h>
+#include <Databases/MySQL/FetchTablesColumnsList.h>
+#include <DataTypes/convertMySQLDataType.h>
+#include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Formats/MySQLBlockInputStream.h>
+#include <IO/WriteBufferFromString.h>
+#include <IO/WriteHelpers.h>
+#include <IO/Operators.h>
+
+#include <memory>
+
+namespace
+{
+using namespace DB;
+
+String toQueryStringWithQuote(const std::vector<String> & quote_list)
+{
+    WriteBufferFromOwnString quote_list_query;
+    quote_list_query << "(";
+
+    for (size_t index = 0; index < quote_list.size(); ++index)
+    {
+        if (index)
+            quote_list_query << ",";
+
+        quote_list_query << quote << quote_list[index];
+    }
+
+    quote_list_query << ")";
+    return quote_list_query.str();
+}
+}
+
+namespace DB
+{
+
+std::map<String, NamesAndTypesList> fetchTablesColumnsList(
+        mysqlxx::Pool & pool,
+        const String & database_name,
+        const std::vector<String> & tables_name,
+        bool external_table_functions_use_nulls,
+        MultiEnum<MySQLDataTypesSupport> type_support)
+{
+    std::map<String, NamesAndTypesList> tables_and_columns;
+
+    if (tables_name.empty())
+        return tables_and_columns;
+
+    Block tables_columns_sample_block
+    {
+        { std::make_shared<DataTypeString>(),   "table_name" },
+        { std::make_shared<DataTypeString>(),   "column_name" },
+        { std::make_shared<DataTypeString>(),   "column_type" },
+        { std::make_shared<DataTypeUInt8>(),    "is_nullable" },
+        { std::make_shared<DataTypeUInt8>(),    "is_unsigned" },
+        { std::make_shared<DataTypeUInt64>(),   "length" },
+        { std::make_shared<DataTypeUInt64>(),   "precision" },
+        { std::make_shared<DataTypeUInt64>(),   "scale" },
+    };
+
+    WriteBufferFromOwnString query;
+    query << "SELECT "
+             " TABLE_NAME AS table_name,"
+             " COLUMN_NAME AS column_name,"
+             " COLUMN_TYPE AS column_type,"
+             " IS_NULLABLE = 'YES' AS is_nullable,"
+             " COLUMN_TYPE LIKE '%unsigned' AS is_unsigned,"
+             " CHARACTER_MAXIMUM_LENGTH AS length,"
+             " NUMERIC_PRECISION as '',"
+             " IF(ISNULL(NUMERIC_SCALE), DATETIME_PRECISION, NUMERIC_SCALE) AS scale" // we know DATETIME_PRECISION as a scale in CH
+             " FROM INFORMATION_SCHEMA.COLUMNS"
+             " WHERE TABLE_SCHEMA = " << quote << database_name
+          << " AND TABLE_NAME IN " << toQueryStringWithQuote(tables_name) << " ORDER BY ORDINAL_POSITION";
+
+    MySQLBlockInputStream result(pool.get(), query.str(), tables_columns_sample_block, DEFAULT_BLOCK_SIZE);
+    while (Block block = result.read())
+    {
+        const auto & table_name_col = *block.getByPosition(0).column;
+        const auto & column_name_col = *block.getByPosition(1).column;
+        const auto & column_type_col = *block.getByPosition(2).column;
+        const auto & is_nullable_col = *block.getByPosition(3).column;
+        const auto & is_unsigned_col = *block.getByPosition(4).column;
+        const auto & char_max_length_col = *block.getByPosition(5).column;
+        const auto & precision_col = *block.getByPosition(6).column;
+        const auto & scale_col = *block.getByPosition(7).column;
+
+        size_t rows = block.rows();
+        for (size_t i = 0; i < rows; ++i)
+        {
+            String table_name = table_name_col[i].safeGet<String>();
+            tables_and_columns[table_name].emplace_back(
+                    column_name_col[i].safeGet<String>(),
+                    convertMySQLDataType(
+                            type_support,
+                            column_type_col[i].safeGet<String>(),
+                            external_table_functions_use_nulls && is_nullable_col[i].safeGet<UInt64>(),
+                            is_unsigned_col[i].safeGet<UInt64>(),
+                            char_max_length_col[i].safeGet<UInt64>(),
+                            precision_col[i].safeGet<UInt64>(),
+                            scale_col[i].safeGet<UInt64>()));
+        }
+    }
+    return tables_and_columns;
+}
+
+}
+
+#endif

--- a/src/Databases/MySQL/FetchTablesColumnsList.h
+++ b/src/Databases/MySQL/FetchTablesColumnsList.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "config_core.h"
+#if USE_MYSQL
+
+#include <mysqlxx/Pool.h>
+
+#include <common/types.h>
+#include <Core/MultiEnum.h>
+#include <Core/NamesAndTypes.h>
+#include <Core/SettingsEnums.h>
+
+#include <map>
+#include <vector>
+
+namespace DB
+{
+
+std::map<String, NamesAndTypesList> fetchTablesColumnsList(
+        mysqlxx::Pool & pool,
+        const String & database_name,
+        const std::vector<String> & tables_name,
+        bool external_table_functions_use_nulls,
+        MultiEnum<MySQLDataTypesSupport> type_support);
+
+}
+
+#endif

--- a/src/Databases/ya.make
+++ b/src/Databases/ya.make
@@ -19,6 +19,7 @@ SRCS(
     DatabaseWithDictionaries.cpp
     MySQL/DatabaseConnectionMySQL.cpp
     MySQL/DatabaseMaterializeMySQL.cpp
+    MySQL/FetchTablesColumnsList.cpp
     MySQL/MaterializeMetadata.cpp
     MySQL/MaterializeMySQLSettings.cpp
     MySQL/MaterializeMySQLSyncThread.cpp

--- a/src/Dictionaries/CassandraBlockInputStream.cpp
+++ b/src/Dictionaries/CassandraBlockInputStream.cpp
@@ -19,6 +19,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int TYPE_MISMATCH;
+    extern const int UNKNOWN_TYPE;
 }
 
 CassandraBlockInputStream::CassandraBlockInputStream(
@@ -140,6 +141,8 @@ void CassandraBlockInputStream::insertValue(IColumn & column, ValueType type, co
             assert_cast<ColumnUInt128 &>(column).insert(parse<UUID>(uuid_str.data(), uuid_str.size()));
             break;
         }
+        default:
+            throw Exception("Unknown type : " + std::to_string(static_cast<int>(type)), ErrorCodes::UNKNOWN_TYPE);
     }
 }
 
@@ -252,6 +255,8 @@ void CassandraBlockInputStream::assertTypes(const CassResultPtr & result)
                 expected = CASS_VALUE_TYPE_UUID;
                 expected_text = "uuid";
                 break;
+            default:
+                throw Exception("Unknown type : " + std::to_string(static_cast<int>(description.types[i].first)), ErrorCodes::UNKNOWN_TYPE);
         }
 
         CassValueType got = cass_result_column_type(result, i);

--- a/src/Dictionaries/RedisBlockInputStream.cpp
+++ b/src/Dictionaries/RedisBlockInputStream.cpp
@@ -26,6 +26,7 @@ namespace DB
         extern const int LOGICAL_ERROR;
         extern const int NUMBER_OF_COLUMNS_DOESNT_MATCH;
         extern const int INTERNAL_REDIS_ERROR;
+        extern const int UNKNOWN_TYPE;
     }
 
 
@@ -103,6 +104,8 @@ namespace DB
                 case ValueType::vtUUID:
                     assert_cast<ColumnUInt128 &>(column).insertValue(parse<UUID>(string_value));
                     break;
+                default:
+                    throw Exception("Value of unsupported type:" + column.getName(), ErrorCodes::UNKNOWN_TYPE);
             }
         }
     }

--- a/src/Formats/MySQLBlockInputStream.cpp
+++ b/src/Formats/MySQLBlockInputStream.cpp
@@ -7,12 +7,14 @@
 #    include <Columns/ColumnNullable.h>
 #    include <Columns/ColumnString.h>
 #    include <Columns/ColumnsNumber.h>
+#    include <Columns/ColumnDecimal.h>
+#    include <DataTypes/IDataType.h>
+#    include <DataTypes/DataTypeNullable.h>
 #    include <IO/ReadHelpers.h>
 #    include <IO/WriteHelpers.h>
 #    include <Common/assert_cast.h>
 #    include <ext/range.h>
 #    include "MySQLBlockInputStream.h"
-
 
 namespace DB
 {
@@ -39,7 +41,7 @@ namespace
 {
     using ValueType = ExternalResultDescription::ValueType;
 
-    void insertValue(IColumn & column, const ValueType type, const mysqlxx::Value & value)
+    void insertValue(const IDataType & data_type, IColumn & column, const ValueType type, const mysqlxx::Value & value)
     {
         switch (type)
         {
@@ -85,6 +87,15 @@ namespace
             case ValueType::vtUUID:
                 assert_cast<ColumnUInt128 &>(column).insert(parse<UUID>(value.data(), value.size()));
                 break;
+            case ValueType::vtDateTime64:[[fallthrough]];
+            case ValueType::vtDecimal32: [[fallthrough]];
+            case ValueType::vtDecimal64: [[fallthrough]];
+            case ValueType::vtDecimal128:
+            {
+                ReadBuffer buffer(const_cast<char *>(value.data()), value.size(), 0);
+                data_type.deserializeAsWholeText(column, buffer, FormatSettings{});
+                break;
+            }
         }
     }
 
@@ -112,19 +123,21 @@ Block MySQLBlockInputStream::readImpl()
         for (const auto idx : ext::range(0, row.size()))
         {
             const auto value = row[idx];
+            const auto & sample = description.sample_block.getByPosition(idx);
             if (!value.isNull())
             {
                 if (description.types[idx].second)
                 {
                     ColumnNullable & column_nullable = assert_cast<ColumnNullable &>(*columns[idx]);
-                    insertValue(column_nullable.getNestedColumn(), description.types[idx].first, value);
+                    const auto & data_type = assert_cast<const DataTypeNullable &>(*sample.type);
+                    insertValue(*data_type.getNestedType(), column_nullable.getNestedColumn(), description.types[idx].first, value);
                     column_nullable.getNullMapData().emplace_back(0);
                 }
                 else
-                    insertValue(*columns[idx], description.types[idx].first, value);
+                    insertValue(*sample.type, *columns[idx], description.types[idx].first, value);
             }
             else
-                insertDefaultValue(*columns[idx], *description.sample_block.getByPosition(idx).column);
+                insertDefaultValue(*columns[idx], *sample.column);
         }
 
         ++num_rows;

--- a/src/TableFunctions/TableFunctionMySQL.cpp
+++ b/src/TableFunctions/TableFunctionMySQL.cpp
@@ -21,7 +21,7 @@
 #    include <Common/quoteString.h>
 #    include "registerTableFunctions.h"
 
-#    include <Databases/DatabaseMySQL.h> // for fetchTablesColumnsList
+#    include <Databases/MySQL/DatabaseConnectionMySQL.h> // for fetchTablesColumnsList
 
 #    include <mysqlxx/Pool.h>
 
@@ -76,7 +76,8 @@ StoragePtr TableFunctionMySQL::executeImpl(const ASTPtr & ast_function, const Co
     auto parsed_host_port = parseAddress(host_port, 3306);
 
     mysqlxx::Pool pool(remote_database_name, parsed_host_port.first, user_name, password, parsed_host_port.second);
-    const auto tables_and_columns = fetchTablesColumnsList(pool, remote_database_name, {remote_table_name}, context.getSettings().external_table_functions_use_nulls);
+    const auto settings = context.getSettingsRef();
+    const auto tables_and_columns = fetchTablesColumnsList(pool, remote_database_name, {remote_table_name}, settings.external_table_functions_use_nulls, settings.mysql_datatypes_support_level);
 
     const auto columns = tables_and_columns.find(remote_table_name);
     if (columns == tables_and_columns.end())

--- a/src/TableFunctions/TableFunctionMySQL.cpp
+++ b/src/TableFunctions/TableFunctionMySQL.cpp
@@ -4,6 +4,7 @@
 
 #if USE_MYSQL
 #    include <Core/Defines.h>
+#    include <Databases/MySQL/FetchTablesColumnsList.h>
 #    include <DataTypes/DataTypeString.h>
 #    include <DataTypes/DataTypesNumber.h>
 #    include <DataTypes/convertMySQLDataType.h>
@@ -76,7 +77,7 @@ StoragePtr TableFunctionMySQL::executeImpl(const ASTPtr & ast_function, const Co
     auto parsed_host_port = parseAddress(host_port, 3306);
 
     mysqlxx::Pool pool(remote_database_name, parsed_host_port.first, user_name, password, parsed_host_port.second);
-    const auto settings = context.getSettingsRef();
+    const auto & settings = context.getSettingsRef();
     const auto tables_and_columns = fetchTablesColumnsList(pool, remote_database_name, {remote_table_name}, settings.external_table_functions_use_nulls, settings.mysql_datatypes_support_level);
 
     const auto columns = tables_and_columns.find(remote_table_name);

--- a/src/TableFunctions/TableFunctionMySQL.cpp
+++ b/src/TableFunctions/TableFunctionMySQL.cpp
@@ -21,6 +21,8 @@
 #    include <Common/quoteString.h>
 #    include "registerTableFunctions.h"
 
+#    include <Databases/DatabaseMySQL.h> // for fetchTablesColumnsList
+
 #    include <mysqlxx/Pool.h>
 
 
@@ -74,47 +76,10 @@ StoragePtr TableFunctionMySQL::executeImpl(const ASTPtr & ast_function, const Co
     auto parsed_host_port = parseAddress(host_port, 3306);
 
     mysqlxx::Pool pool(remote_database_name, parsed_host_port.first, user_name, password, parsed_host_port.second);
+    const auto tables_and_columns = fetchTablesColumnsList(pool, remote_database_name, {remote_table_name}, context.getSettings().external_table_functions_use_nulls);
 
-    /// Determine table definition by running a query to INFORMATION_SCHEMA.
-
-    Block sample_block
-    {
-        { std::make_shared<DataTypeString>(), "name" },
-        { std::make_shared<DataTypeString>(), "type" },
-        { std::make_shared<DataTypeUInt8>(), "is_nullable" },
-        { std::make_shared<DataTypeUInt8>(), "is_unsigned" },
-        { std::make_shared<DataTypeUInt64>(), "length" },
-    };
-
-    WriteBufferFromOwnString query;
-    query << "SELECT"
-            " COLUMN_NAME AS name,"
-            " DATA_TYPE AS type,"
-            " IS_NULLABLE = 'YES' AS is_nullable,"
-            " COLUMN_TYPE LIKE '%unsigned' AS is_unsigned,"
-            " CHARACTER_MAXIMUM_LENGTH AS length"
-        " FROM INFORMATION_SCHEMA.COLUMNS"
-        " WHERE TABLE_SCHEMA = " << quote << remote_database_name
-        << " AND TABLE_NAME = " << quote << remote_table_name
-        << " ORDER BY ORDINAL_POSITION";
-
-    NamesAndTypesList columns;
-    MySQLBlockInputStream result(pool.get(), query.str(), sample_block, DEFAULT_BLOCK_SIZE);
-    while (Block block = result.read())
-    {
-        size_t rows = block.rows();
-        for (size_t i = 0; i < rows; ++i)
-            columns.emplace_back(
-                (*block.getByPosition(0).column)[i].safeGet<String>(),
-                convertMySQLDataType(
-                    (*block.getByPosition(1).column)[i].safeGet<String>(),
-                    (*block.getByPosition(2).column)[i].safeGet<UInt64>() && context.getSettings().external_table_functions_use_nulls,
-                    (*block.getByPosition(3).column)[i].safeGet<UInt64>(),
-                    (*block.getByPosition(4).column)[i].safeGet<UInt64>()));
-
-    }
-
-    if (columns.empty())
+    const auto columns = tables_and_columns.find(remote_table_name);
+    if (columns == tables_and_columns.end())
         throw Exception("MySQL table " + backQuoteIfNeed(remote_database_name) + "." + backQuoteIfNeed(remote_table_name) + " doesn't exist.", ErrorCodes::UNKNOWN_TABLE);
 
     auto res = StorageMySQL::create(
@@ -124,7 +89,7 @@ StoragePtr TableFunctionMySQL::executeImpl(const ASTPtr & ast_function, const Co
         remote_table_name,
         replace_query,
         on_duplicate_clause,
-        ColumnsDescription{columns},
+        ColumnsDescription{columns->second},
         ConstraintsDescription{},
         context);
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Supporting MySQL types: `decimal` (as ClickHouse `Decimal`) and `datetime` with sub-second precision (as `DateTime64`). 
...


Detailed description / Documentation draft:

...

closes: #9320