### PR TITLE
S3 HTTP client  - Avoid copying response stream into memory

### DIFF
--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -3,6 +3,7 @@
 #include <utility>
 #include <IO/HTTPCommon.h>
 #include <IO/S3/PocoHTTPResponseStream.h>
+#include <IO/S3/PocoHTTPResponseStream.cpp>
 #include <aws/core/http/HttpRequest.h>
 #include <aws/core/http/HttpResponse.h>
 #include <aws/core/http/standard/StandardHttpResponse.h>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog

Was reverted in https://github.com/ClickHouse/ClickHouse/pull/11542

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Optimize memory usage when reading a response from an S3 HTTP client.

Detailed description / Documentation draft:
AWS SDK API is modified to return IStream instead of IOStream as the response body.
Poco's response stream is passed as a response body to AWS SDK entities instead of copying the whole response into the intermediate memory buffer.
The change should help to resolve issues like this https://github.com/ClickHouse/ClickHouse/issues/10461