### PR TITLE
Fix missed includes

### DIFF
--- a/base/common/strong_typedef.h
+++ b/base/common/strong_typedef.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <type_traits>
 #include <utility>
 

--- a/base/common/strong_typedef.h
+++ b/base/common/strong_typedef.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <type_traits>
+#include <utility>
 
 template <class T, class Tag>
 struct StrongTypedef


### PR DESCRIPTION
`<utility>` is required for `std::move`

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix missed include for `std::move` used at line 17.
