### PR TITLE
Fix shard_num/replica_num for <node> (breaks use_compact_format_in_distributed_parts_names)

### DIFF
--- a/tests/integration/test_distributed_format/configs/remote_servers.xml
+++ b/tests/integration/test_distributed_format/configs/remote_servers.xml
@@ -8,5 +8,12 @@
                 </replica>
             </shard>
         </test_cluster>
+
+        <test_cluster_2>
+            <node>
+                <host>not_existing</host>
+                <port>9000</port>
+            </node>
+        </test_cluster_2>
     </remote_servers>
 </yandex>


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix shard_num/replica_num for `<node>` (breaks use_compact_format_in_distributed_parts_names)

Refs: #9653
Cc: @alesapin 