### PR TITLE
Better exception message when cannot parse columns declaration list

### DIFF
--- a/src/TableFunctions/parseColumnsListForTableFunction.cpp
+++ b/src/TableFunctions/parseColumnsListForTableFunction.cpp
@@ -1,5 +1,6 @@
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ParserCreateQuery.h>
+#include <Parsers/parseQuery.h>
 #include <Interpreters/InterpreterCreateQuery.h>
 #include <Interpreters/Context.h>
 #include <TableFunctions/parseColumnsListForTableFunction.h>
@@ -11,27 +12,20 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
-    extern const int SYNTAX_ERROR;
 }
 
 ColumnsDescription parseColumnsListFromString(const std::string & structure, const Context & context)
 {
-    Expected expected;
-
-    Tokens tokens(structure.c_str(), structure.c_str() + structure.size());
-    IParser::Pos token_iterator(tokens, context.getSettingsRef().max_parser_depth);
-
     ParserColumnDeclarationList parser;
-    ASTPtr columns_list_raw;
+    const Settings & settings = context.getSettingsRef();
 
-    if (!parser.parse(token_iterator, columns_list_raw, expected))
-        throw Exception("Cannot parse columns declaration list.", ErrorCodes::SYNTAX_ERROR);
+    ASTPtr columns_list_raw = parseQuery(parser, structure, "columns declaration list", settings.max_query_size, settings.max_parser_depth);
 
     auto * columns_list = dynamic_cast<ASTExpressionList *>(columns_list_raw.get());
     if (!columns_list)
         throw Exception("Could not cast AST to ASTExpressionList", ErrorCodes::LOGICAL_ERROR);
 
-    return InterpreterCreateQuery::getColumnsDescription(*columns_list, context, !context.getSettingsRef().allow_suspicious_codecs);
+    return InterpreterCreateQuery::getColumnsDescription(*columns_list, context, !settings.allow_suspicious_codecs);
 }
 
 }

--- a/tests/queries/0_stateless/01087_table_function_generate.sql
+++ b/tests/queries/0_stateless/01087_table_function_generate.sql
@@ -33,11 +33,11 @@ LIMIT 10;
 SELECT '-';
 SELECT
   toTypeName(i)s
-FROM generateRandom('i Nullable(Enum16(\'h\' = 1, \'w\' = 5 , \'o\' = -200)))')
+FROM generateRandom('i Nullable(Enum16(\'h\' = 1, \'w\' = 5 , \'o\' = -200))')
 LIMIT 1;
 SELECT
   i
-FROM generateRandom('i Nullable(Enum16(\'h\' = 1, \'w\' = 5 , \'o\' = -200)))', 1, 10, 10)
+FROM generateRandom('i Nullable(Enum16(\'h\' = 1, \'w\' = 5 , \'o\' = -200))', 1, 10, 10)
 LIMIT 10;
 SELECT '-';
 SELECT


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Better exception message when cannot parse columns declaration list. This closes #10403.
