### PR TITLE
Fix obvious race condition in test

### DIFF
--- a/tests/queries/0_stateless/01268_procfs_metrics.sh
+++ b/tests/queries/0_stateless/01268_procfs_metrics.sh
@@ -17,14 +17,16 @@ function read_numbers_func()
 
 function show_processes_func()
 {
-    sleep 0.1;
-    
-    # These two system metrics for the generating query above are guaranteed to be nonzero when ProcFS is mounted at /proc
-    $CLICKHOUSE_CLIENT -q "
-        SELECT count() > 0 FROM system.processes\
-        WHERE has(ProfileEvents.Names, 'OSCPUVirtualTimeMicroseconds') AND has(ProfileEvents.Names, 'OSReadChars')\
-        SETTINGS max_threads = 1
-    ";
+    while true; do
+        sleep 0.1;
+
+        # These two system metrics for the generating query above are guaranteed to be nonzero when ProcFS is mounted at /proc
+        $CLICKHOUSE_CLIENT -q "
+            SELECT count() > 0 FROM system.processes\
+            WHERE has(ProfileEvents.Names, 'OSCPUVirtualTimeMicroseconds') AND has(ProfileEvents.Names, 'OSReadChars')\
+            SETTINGS max_threads = 1
+        " | grep '1' && break;
+    done
 }
 
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

@Akazz 