### PR TITLE
Fix direct IO with PREWHERE

### DIFF
--- a/src/IO/ReadBufferAIO.cpp
+++ b/src/IO/ReadBufferAIO.cpp
@@ -4,6 +4,7 @@
 #include <IO/AIOContextPool.h>
 #include <Common/ProfileEvents.h>
 #include <Common/Stopwatch.h>
+#include <Common/MemorySanitizer.h>
 #include <Core/Defines.h>
 
 #include <sys/types.h>
@@ -271,6 +272,9 @@ void ReadBufferAIO::prepare()
     region_aligned_size = region_aligned_end - region_aligned_begin;
 
     buffer_begin = fill_buffer.internalBuffer().begin();
+
+    /// Unpoison because msan doesn't instrument linux AIO
+    __msan_unpoison(buffer_begin, fill_buffer.internalBuffer().size());
 }
 
 void ReadBufferAIO::finalize()

--- a/src/IO/ReadBufferAIO.h
+++ b/src/IO/ReadBufferAIO.h
@@ -100,8 +100,6 @@ private:
     bool is_eof = false;
     /// At least one read request was sent.
     bool is_started = false;
-    /// Is the operation asynchronous?
-    bool is_aio = false;
     /// Did the asynchronous operation fail?
     bool aio_failed = false;
 

--- a/tests/queries/0_stateless/01304_direct_io.reference
+++ b/tests/queries/0_stateless/01304_direct_io.reference
@@ -1,0 +1,1 @@
+Loaded 1 queries.

--- a/tests/queries/0_stateless/01304_direct_io.sh
+++ b/tests/queries/0_stateless/01304_direct_io.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. $CURDIR/../shell_config.sh
+
+$CLICKHOUSE_CLIENT --multiquery --query "
+    DROP TABLE IF EXISTS bug;
+    CREATE TABLE bug (UserID UInt64, Date Date) ENGINE = MergeTree ORDER BY Date;
+    INSERT INTO bug SELECT rand64(), '2020-06-07' FROM numbers(50000000);
+    OPTIMIZE TABLE bug FINAL;"
+
+$CLICKHOUSE_BENCHMARK --database $CLICKHOUSE_DATABASE --iterations 10 --max_threads 100 --min_bytes_to_use_direct_io 1 <<< "SELECT sum(UserID) FROM bug PREWHERE NOT ignore(Date)" >/dev/null 2>$CLICKHOUSE_TMP/err
+cat $CLICKHOUSE_TMP/err
+
+$CLICKHOUSE_CLIENT --multiquery --query "
+    DROP TABLE bug;"

--- a/tests/queries/0_stateless/01304_direct_io.sh
+++ b/tests/queries/0_stateless/01304_direct_io.sh
@@ -9,8 +9,9 @@ $CLICKHOUSE_CLIENT --multiquery --query "
     INSERT INTO bug SELECT rand64(), '2020-06-07' FROM numbers(50000000);
     OPTIMIZE TABLE bug FINAL;"
 
-$CLICKHOUSE_BENCHMARK --database $CLICKHOUSE_DATABASE --iterations 10 --max_threads 100 --min_bytes_to_use_direct_io 1 <<< "SELECT sum(UserID) FROM bug PREWHERE NOT ignore(Date)" >/dev/null 2>$CLICKHOUSE_TMP/err
-cat $CLICKHOUSE_TMP/err
+$CLICKHOUSE_BENCHMARK --database $CLICKHOUSE_DATABASE --iterations 10 --max_threads 100 --min_bytes_to_use_direct_io 1 <<< "SELECT sum(UserID) FROM bug PREWHERE NOT ignore(Date)" 1>/dev/null 2>$CLICKHOUSE_TMP/err
+cat $CLICKHOUSE_TMP/err | grep Exception
+cat $CLICKHOUSE_TMP/err | grep Loaded
 
 $CLICKHOUSE_CLIENT --multiquery --query "
     DROP TABLE bug;"


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix the error `Data compressed with different methods` that can happen if `min_bytes_to_use_direct_io` is enabled and PREWHERE is active and using SAMPLE or high number of threads. This fixes #11539