### PR TITLE
Avoid copying whole response stream into memory in S3 HTTP client.

### DIFF
--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -2,6 +2,8 @@
 
 #include <utility>
 #include <IO/HTTPCommon.h>
+#include <IO/S3/PocoHTTPResponseStream.h>
+#include <IO/S3/PocoHTTPResponseStream.cpp>
 #include <aws/core/http/HttpRequest.h>
 #include <aws/core/http/HttpResponse.h>
 #include <aws/core/http/standard/StandardHttpResponse.h>
@@ -149,8 +151,7 @@ void PocoHTTPClient::MakeRequestInternal(
                 response->SetClientErrorMessage(error_message);
             }
             else
-                /// TODO: Do not copy whole stream.
-                Poco::StreamCopier::copyStream(response_body_stream, response->GetResponseBody());
+                response->GetResponseStream().SetUnderlyingStream(std::make_shared<PocoHTTPResponseStream>(session, response_body_stream));
 
             break;
         }

--- a/src/IO/S3/PocoHTTPClientFactory.cpp
+++ b/src/IO/S3/PocoHTTPClientFactory.cpp
@@ -21,10 +21,12 @@ std::shared_ptr<Aws::Http::HttpRequest> PocoHTTPClientFactory::CreateHttpRequest
 }
 
 std::shared_ptr<Aws::Http::HttpRequest> PocoHTTPClientFactory::CreateHttpRequest(
-    const Aws::Http::URI & uri, Aws::Http::HttpMethod method, const Aws::IOStreamFactory & streamFactory) const
+    const Aws::Http::URI & uri, Aws::Http::HttpMethod method, const Aws::IOStreamFactory &) const
 {
     auto request = Aws::MakeShared<Aws::Http::Standard::StandardHttpRequest>("PocoHTTPClientFactory", uri, method);
-    request->SetResponseStreamFactory(streamFactory);
+
+    /// Don't create default response stream. Actual response stream will be set later in PocoHTTPClient.
+    request->SetResponseStreamFactory(null_factory);
 
     return request;
 }

--- a/src/IO/S3/PocoHTTPClientFactory.h
+++ b/src/IO/S3/PocoHTTPClientFactory.h
@@ -4,22 +4,25 @@
 
 namespace Aws::Http
 {
-    class HttpClient;
-    class HttpRequest;
+class HttpClient;
+class HttpRequest;
 }
 
 namespace DB::S3
 {
-
 class PocoHTTPClientFactory : public Aws::Http::HttpClientFactory
 {
 public:
     ~PocoHTTPClientFactory() override = default;
-    [[nodiscard]] std::shared_ptr<Aws::Http::HttpClient> CreateHttpClient(const Aws::Client::ClientConfiguration & clientConfiguration) const override;
+    [[nodiscard]] std::shared_ptr<Aws::Http::HttpClient>
+    CreateHttpClient(const Aws::Client::ClientConfiguration & clientConfiguration) const override;
     [[nodiscard]] std::shared_ptr<Aws::Http::HttpRequest>
     CreateHttpRequest(const Aws::String & uri, Aws::Http::HttpMethod method, const Aws::IOStreamFactory & streamFactory) const override;
     [[nodiscard]] std::shared_ptr<Aws::Http::HttpRequest>
     CreateHttpRequest(const Aws::Http::URI & uri, Aws::Http::HttpMethod method, const Aws::IOStreamFactory & streamFactory) const override;
+
+private:
+    const Aws::IOStreamFactory null_factory = []() { return nullptr; };
 };
 
 }

--- a/src/IO/S3/PocoHTTPResponseStream.cpp
+++ b/src/IO/S3/PocoHTTPResponseStream.cpp
@@ -1,0 +1,12 @@
+#include "PocoHTTPResponseStream.h"
+
+#include <utility>
+
+namespace DB::S3
+{
+PocoHTTPResponseStream::PocoHTTPResponseStream(std::shared_ptr<Poco::Net::HTTPClientSession> session_, std::istream & response_stream_)
+    : Aws::IStream(response_stream_.rdbuf()), session(std::move(session_))
+{
+}
+
+}

--- a/src/IO/S3/PocoHTTPResponseStream.h
+++ b/src/IO/S3/PocoHTTPResponseStream.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <aws/core/utils/stream/ResponseStream.h>
+#include <Poco/Net/HTTPClientSession.h>
+
+namespace DB::S3
+{
+/**
+ * Wrapper of IStream to store response stream and corresponding HTTP session.
+ */
+class PocoHTTPResponseStream : public Aws::IStream
+{
+public:
+    PocoHTTPResponseStream(std::shared_ptr<Poco::Net::HTTPClientSession> session_, std::istream & response_stream_);
+
+private:
+    /// Poco HTTP session is holder of response stream.
+    std::shared_ptr<Poco::Net::HTTPClientSession> session;
+};
+
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Optimize memory usage when reading a response from an S3 HTTP client.

Detailed description / Documentation draft:
AWS SDK API is modified to return IStream instead of IOStream as the response body.
Poco's response stream is passed as a response body to AWS SDK entities instead of copying the whole response into the intermediate memory buffer.
The change should help to resolve issues like #10461