### PR TITLE
Fix corner case (only) for exit code overflow

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -1920,7 +1920,11 @@ public:
                 std::string text = e.displayText();
                 std::cerr << "Code: " << e.code() << ". " << text << std::endl;
                 std::cerr << "Table №" << i << std::endl << std::endl;
-                exit(e.code());
+                auto exit_code = e.code() % 256;
+                if (exit_code == 0)
+                    exit_code = 255;
+                exit(exit_code);
+
             }
         }
 

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -1920,6 +1920,7 @@ public:
                 std::string text = e.displayText();
                 std::cerr << "Code: " << e.code() << ". " << text << std::endl;
                 std::cerr << "Table №" << i << std::endl << std::endl;
+                /// Avoid the case when error exit code can possibly overflow to normal (zero).
                 auto exit_code = e.code() % 256;
                 if (exit_code == 0)
                     exit_code = 255;

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -1925,7 +1925,6 @@ public:
                 if (exit_code == 0)
                     exit_code = 255;
                 exit(exit_code);
-
             }
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix wrong exit code of the clickhouse-client, when exception.code() % 256 = 0.

Detailed description / Documentation draft:
Fixes #11581. Other status codes should stay as is now (so @vzakaznikov's tests will not blow up). 