### PR TITLE
Fix buffer sample

### DIFF
--- a/tests/queries/0_stateless/01305_buffer_final_bug.sql
+++ b/tests/queries/0_stateless/01305_buffer_final_bug.sql
@@ -1,0 +1,11 @@
+drop table if exists t;
+drop table if exists t_buf;
+
+create table t (x UInt64) engine = MergeTree order by (x, intHash64(x)) sample by intHash64(x);
+insert into t select number from numbers(10000);
+create table t_buf as t engine = Buffer(currentDatabase(), 't', 16, 20, 100, 100000, 10000000, 50000000, 250000000);
+insert into t_buf values (1);
+select count() from t_buf sample 1/2 format Null;
+
+drop table if exists t_buf;
+drop table if exists t;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix error `Block structure mismatch` for queries with sampling reading from `Buffer` table.