### PR TITLE
Prepend slash for path while querying system.zookeeper

### DIFF
--- a/src/Storages/System/StorageSystemZooKeeper.cpp
+++ b/src/Storages/System/StorageSystemZooKeeper.cpp
@@ -112,8 +112,13 @@ void StorageSystemZooKeeper::fillData(MutableColumns & res_columns, const Contex
 
     zkutil::ZooKeeperPtr zookeeper = context.getZooKeeper();
 
+    String path_corrected;
+    /// path should starts with '/', otherwise ZBADARGUMENTS will be thrown in
+    /// ZooKeeper::sendThread and the session will fail.
+    if (path[0] != '/')
+        path_corrected = '/';
+    path_corrected += path;
     /// In all cases except the root, path must not end with a slash.
-    String path_corrected = path;
     if (path_corrected != "/" && path_corrected.back() == '/')
         path_corrected.resize(path_corrected.size() - 1);
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)