### PR TITLE
Force table creation on SYSTEM FLUSH LOGS (v2)

### DIFF
--- a/docs/en/sql-reference/statements/system.md
+++ b/docs/en/sql-reference/statements/system.md
@@ -79,6 +79,7 @@ Complied expression cache used when query/user/profile enable option [compile](.
 ## FLUSH LOGS {#query_language-system-flush_logs}
 
 Flushes buffers of log messages to system tables (e.g. system.query\_log). Allows you to not wait 7.5 seconds when debugging.
+This will also create system tables even if message queue is empty.
 
 ## RELOAD CONFIG {#query_language-system-reload-config}
 

--- a/docs/ru/sql-reference/statements/system.md
+++ b/docs/ru/sql-reference/statements/system.md
@@ -74,6 +74,7 @@ SELECT name, status FROM system.dictionaries;
 ## FLUSH LOGS {#query_language-system-flush_logs}
 
 Записывает буферы логов в системные таблицы (например system.query\_log). Позволяет не ждать 7.5 секунд при отладке.
+Если буфер логов пустой, то этот запрос просто создаст системные таблицы.
 
 ## RELOAD CONFIG {#query_language-system-reload-config}
 

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -302,13 +302,13 @@ BlockIO InterpreterSystemQuery::execute()
         case Type::FLUSH_LOGS:
             context.checkAccess(AccessType::SYSTEM_FLUSH_LOGS);
             executeCommandsAndThrowIfError(
-                    [&] () { if (auto query_log = context.getQueryLog()) query_log->flush(); },
-                    [&] () { if (auto part_log = context.getPartLog("")) part_log->flush(); },
-                    [&] () { if (auto query_thread_log = context.getQueryThreadLog()) query_thread_log->flush(); },
-                    [&] () { if (auto trace_log = context.getTraceLog()) trace_log->flush(); },
-                    [&] () { if (auto text_log = context.getTextLog()) text_log->flush(); },
-                    [&] () { if (auto metric_log = context.getMetricLog()) metric_log->flush(); },
-                    [&] () { if (auto asynchronous_metric_log = context.getAsynchronousMetricLog()) asynchronous_metric_log->flush(); }
+                    [&] () { if (auto query_log = context.getQueryLog()) query_log->flush(true); },
+                    [&] () { if (auto part_log = context.getPartLog("")) part_log->flush(true); },
+                    [&] () { if (auto query_thread_log = context.getQueryThreadLog()) query_thread_log->flush(true); },
+                    [&] () { if (auto trace_log = context.getTraceLog()) trace_log->flush(true); },
+                    [&] () { if (auto text_log = context.getTextLog()) text_log->flush(true); },
+                    [&] () { if (auto metric_log = context.getMetricLog()) metric_log->flush(true); },
+                    [&] () { if (auto asynchronous_metric_log = context.getAsynchronousMetricLog()) asynchronous_metric_log->flush(true); }
             );
             break;
         case Type::STOP_LISTEN_QUERIES:

--- a/src/Interpreters/SystemLog.h
+++ b/src/Interpreters/SystemLog.h
@@ -369,7 +369,13 @@ void SystemLog<LogElement>::savingThreadFunction()
 
             if (to_flush.empty())
             {
-                if (is_force_prepare_tables)
+                bool force;
+                {
+                    std::lock_guard lock(mutex);
+                    force = is_force_prepare_tables;
+                }
+
+                if (force)
                 {
                     prepareTable();
                     LOG_TRACE(log, "Table created (force)");

--- a/src/Interpreters/SystemLog.h
+++ b/src/Interpreters/SystemLog.h
@@ -217,7 +217,7 @@ SystemLog<LogElement>::SystemLog(Context & context_,
 template <typename LogElement>
 void SystemLog<LogElement>::startup()
 {
-    std::unique_lock lock(mutex);
+    std::lock_guard lock(mutex);
     saving_thread = ThreadFromGlobalPool([this] { savingThreadFunction(); });
 }
 
@@ -231,7 +231,7 @@ void SystemLog<LogElement>::add(const LogElement & element)
     /// Otherwise the tests like 01017_uniqCombined_memory_usage.sql will be flacky.
     auto temporarily_disable_memory_tracker = getCurrentMemoryTrackerActionLock();
 
-    std::unique_lock lock(mutex);
+    std::lock_guard lock(mutex);
 
     if (is_shutdown)
         return;
@@ -307,7 +307,7 @@ template <typename LogElement>
 void SystemLog<LogElement>::stopFlushThread()
 {
     {
-        std::unique_lock lock(mutex);
+        std::lock_guard lock(mutex);
 
         if (!saving_thread.joinable())
         {
@@ -420,7 +420,7 @@ void SystemLog<LogElement>::flushImpl(const std::vector<LogElement> & to_flush, 
     }
 
     {
-        std::unique_lock lock(mutex);
+        std::lock_guard lock(mutex);
         flushed_before = to_flush_end;
         flush_event.notify_all();
     }

--- a/tests/integration/test_SYSTEM_FLUSH_LOGS/test.py
+++ b/tests/integration/test_SYSTEM_FLUSH_LOGS/test.py
@@ -1,0 +1,58 @@
+# pylint: disable=line-too-long
+# pylint: disable=unused-argument
+# pylint: disable=redefined-outer-name
+
+import pytest
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance('node_default')
+
+system_logs = [
+    # disabled by default
+    ('system.part_log', 0),
+    ('system.text_log', 0),
+
+    # enabled by default
+    ('system.query_log', 1),
+    ('system.query_thread_log', 1),
+    ('system.trace_log', 1),
+    ('system.metric_log', 1),
+]
+
+# Default timeout for flush is 60
+# decrease timeout for the test to show possible issues.
+timeout = pytest.mark.timeout(30)
+
+@pytest.fixture(scope='module', autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+@pytest.fixture(scope='function')
+def flush_logs():
+    node.query('SYSTEM FLUSH LOGS')
+
+@timeout
+@pytest.mark.parametrize('table,exists', system_logs)
+def test_system_logs(flush_logs, table, exists):
+    q = 'SELECT * FROM {}'.format(table)
+    if exists:
+        node.query(q)
+    else:
+        assert "Table {} doesn't exist".format(table) in node.query_and_get_error(q)
+
+# Logic is tricky, let's check that there is no hang in case of message queue
+# is not empty (this is another code path in the code).
+@timeout
+def test_system_logs_non_empty_queue():
+    node.query('SELECT 1', settings={
+        # right now defaults are the same,
+        # this set explicitly to avoid depends from defaults.
+        'log_queries': 1,
+        'log_queries_min_type': 'QUERY_START',
+    })
+    node.query('SYSTEM FLUSH LOGS')


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Force table creation on SYSTEM FLUSH LOGS (at least some way to guarantee system.*_log creation, without quirks, until deadlock will be fixed)

After this patch SYSTEM FLUSH LOGS will force system.*_log table
creations (only for enabled tables of course).

This will avoid such hacks like:
```sql
   set log_queries=1;
   select 1;
   system flush logs;
```

This is the second version of the patch, since first has a deadlock [1]
(reported by @alesapin). This version does not use separate lock and do
not issue CREATE TABLE from the query execution thread, instead it
activate flushing thread to do so, hence this should be the same as if
the table will be created during flush.

  [1]: https://gist.github.com/alesapin/d915d1deaa27d49aa31223daded02be2

Fixes: #11563
Refs: #11293
Cc: @alesapin
Cc: @nikitamikhaylov

<details>

HEAD's:
- 103eb17107e24704e6100eab4760a38eb3a21286
- 08cdeb21ebd732584c05b15a8f989106e321fa26

</details>