### PR TITLE
Unfinished attempt to remove implicit bool conversions

### DIFF
--- a/base/common/LineReader.cpp
+++ b/base/common/LineReader.cpp
@@ -22,7 +22,7 @@ namespace
 /// Trim ending whitespace inplace
 void trim(String & s)
 {
-    s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) { return !std::isspace(ch); }).base(), s.end());
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) { return 0 == std::isspace(ch); }).base(), s.end());
 }
 
 /// Check if multi-line query is inserted from the paste buffer.
@@ -116,7 +116,7 @@ String LineReader::readLine(const String & first_prompt, const String & second_p
             }
         }
 
-        need_next_line = has_extender || (multiline && !has_delimiter) || hasInputData();
+        need_next_line = (has_extender != nullptr) || (multiline && has_delimiter != nullptr) || hasInputData();
 
         if (has_extender)
         {

--- a/base/common/ReplxxLineReader.cpp
+++ b/base/common/ReplxxLineReader.cpp
@@ -13,7 +13,7 @@ namespace
 /// Trim ending whitespace inplace
 void trim(String & s)
 {
-    s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) { return !std::isspace(ch); }).base(), s.end());
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) { return 0 == std::isspace(ch); }).base(), s.end());
 }
 
 }
@@ -39,7 +39,7 @@ ReplxxLineReader::ReplxxLineReader(
         }
         else
         {
-            if (flock(history_file_fd, LOCK_SH))
+            if (0 != flock(history_file_fd, LOCK_SH))
             {
                 rx.print("Shared lock of history file failed: %s\n", errnoToString(errno).c_str());
             }
@@ -47,7 +47,7 @@ ReplxxLineReader::ReplxxLineReader(
             {
                 rx.history_load(history_file_path);
 
-                if (flock(history_file_fd, LOCK_UN))
+                if (0 != flock(history_file_fd, LOCK_UN))
                 {
                     rx.print("Unlock of history file failed: %s\n", errnoToString(errno).c_str());
                 }

--- a/base/common/getMemoryAmount.cpp
+++ b/base/common/getMemoryAmount.cpp
@@ -101,7 +101,7 @@ uint64_t getMemoryAmountOrZero()
 uint64_t getMemoryAmount()
 {
     auto res = getMemoryAmountOrZero();
-    if (!res)
+    if (0 == res)
         throw std::runtime_error("Cannot determine memory amount");
     return res;
 }

--- a/base/common/getThreadId.cpp
+++ b/base/common/getThreadId.cpp
@@ -14,7 +14,7 @@
 static thread_local uint64_t current_tid = 0;
 uint64_t getThreadId()
 {
-    if (!current_tid)
+    if (0 == current_tid)
     {
 #if defined(OS_LINUX)
         current_tid = syscall(SYS_gettid); /// This call is always successful. - man gettid

--- a/base/common/mremap.cpp
+++ b/base/common/mremap.cpp
@@ -13,7 +13,7 @@ void * mremap_fallback(
     if (new_size < old_size)
         return old_address;
 
-    if (!(flags & MREMAP_MAYMOVE))
+    if (0 == (flags & MREMAP_MAYMOVE))
     {
         errno = ENOMEM;
         return MAP_FAILED;
@@ -32,7 +32,7 @@ void * mremap_fallback(
 #if defined(_MSC_VER)
     delete old_address;
 #else
-    if (munmap(old_address, old_size))
+    if (0 != munmap(old_address, old_size))
         abort();
 #endif
 

--- a/base/common/phdr_cache.cpp
+++ b/base/common/phdr_cache.cpp
@@ -42,7 +42,7 @@ using DLIterateFunction = int (*) (int (*callback) (dl_phdr_info * info, size_t 
 DLIterateFunction getOriginalDLIteratePHDR()
 {
     void * func = dlsym(RTLD_NEXT, "dl_iterate_phdr");
-    if (!func)
+    if (nullptr == func)
         throw std::runtime_error("Cannot find dl_iterate_phdr function with dlsym");
     return reinterpret_cast<DLIterateFunction>(func);
 }
@@ -62,7 +62,7 @@ extern "C"
 int dl_iterate_phdr(int (*callback) (dl_phdr_info * info, size_t size, void * data), void * data)
 {
     auto * current_phdr_cache = phdr_cache.load();
-    if (!current_phdr_cache)
+    if (nullptr == current_phdr_cache)
     {
         // Cache is not yet populated, pass through to the original function.
         return getOriginalDLIteratePHDR()(callback, data);

--- a/base/common/setTerminalEcho.cpp
+++ b/base/common/setTerminalEcho.cpp
@@ -30,7 +30,7 @@ void setTerminalEcho(bool enable)
         throw std::runtime_error(std::string("setTerminalEcho failed set: ") + std::to_string(GetLastError()));
 #else
     struct termios tty;
-    if (tcgetattr(STDIN_FILENO, &tty))
+    if (0 != tcgetattr(STDIN_FILENO, &tty))
         throw std::runtime_error(std::string("setTerminalEcho failed get: ") + strerror(errno));
     if (!enable)
         tty.c_lflag &= ~ECHO;
@@ -38,7 +38,7 @@ void setTerminalEcho(bool enable)
         tty.c_lflag |= ECHO;
 
     auto ret = tcsetattr(STDIN_FILENO, TCSANOW, &tty);
-    if (ret)
+    if (0 != ret)
         throw std::runtime_error(std::string("setTerminalEcho failed set: ") + strerror(errno));
 #endif
 }

--- a/base/mysqlxx/Connection.cpp
+++ b/base/mysqlxx/Connection.cpp
@@ -116,7 +116,7 @@ void Connection::connect(const char* db,
         throw ConnectionFailed(errorMessage(driver.get()), mysql_errno(driver.get()));
 
     /// Enables auto-reconnect.
-    my_bool reconnect = true;
+    my_bool reconnect = 1;
     if (mysql_options(driver.get(), MYSQL_OPT_RECONNECT, reinterpret_cast<const char *>(&reconnect)))
         throw ConnectionFailed(errorMessage(driver.get()), mysql_errno(driver.get()));
 
@@ -142,7 +142,7 @@ void Connection::disconnect()
 
 bool Connection::ping()
 {
-    return is_connected && !mysql_ping(driver.get());
+    return is_connected && 0 == mysql_ping(driver.get());
 }
 
 Query Connection::query(const std::string & str)

--- a/base/mysqlxx/Row.cpp
+++ b/base/mysqlxx/Row.cpp
@@ -15,7 +15,7 @@ Value Row::operator[] (const char * name) const
     MYSQL_FIELDS fields = res->getFields();
 
     for (unsigned i = 0; i < n; ++i)
-        if (!strcmp(name, fields[i].name))
+        if (0 == strcmp(name, fields[i].name))
             return operator[](i);
 
     throw Exception(std::string("Unknown column ") + name);

--- a/src/Storages/tests/transform_part_zk_nodes.cpp
+++ b/src/Storages/tests/transform_part_zk_nodes.cpp
@@ -27,7 +27,7 @@ try
     boost::program_options::variables_map options;
     boost::program_options::store(boost::program_options::parse_command_line(argc, argv, desc), options);
 
-    if (options.count("help"))
+    if (0 != options.count("help"))
     {
         std::cout << "Transform contents of part nodes in ZooKeeper to more compact storage scheme." << std::endl;
         std::cout << "Usage: " << argv[0] << " [options]" << std::endl;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


This is an attempt to add
```
diff --git a/.clang-tidy b/.clang-tidy
index b0971418e0..25161b2d91 100644
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -58,6 +58,7 @@ Checks: '-*,
     readability-simplify-boolean-expr,
     readability-inconsistent-declaration-parameter-name,
     readability-identifier-naming,
+    readability-implicit-bool-conversion,
 
     bugprone-undelegated-constructor,
     bugprone-argument-comment,
@@ -203,3 +204,7 @@ CheckOptions:
     value: CamelCase
   - key: readability-identifier-naming.UsingCase
     value: CamelCase
+  - key: readability-implicit-bool-conversion.AllowIntegerConditions
+    value: 1
+  - key: readability-implicit-bool-conversion.AllowPointerConditions
+    value: 1
```

but I decided to cancel it.