### PR TITLE
Allow to drop table if there is no metadata in ZooKeeper; allow to rename.

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -244,6 +244,7 @@ StorageReplicatedMergeTree::StorageReplicatedMergeTree(
     {
         LOG_WARNING(log, "No metadata in ZooKeeper: table will be in readonly mode.");
         is_readonly = true;
+        has_metadata_in_zookeeper = false;
         return;
     }
 
@@ -620,9 +621,14 @@ void StorageReplicatedMergeTree::createReplica()
 
 void StorageReplicatedMergeTree::drop()
 {
+    /// There is also the case when user has configured ClickHouse to wrong ZooKeeper cluster,
+    /// in this case, has_metadata_in_zookeeper = false, and we also permit to drop the table.
+
+    if (has_metadata_in_zookeeper)
     {
         auto zookeeper = tryGetZooKeeper();
 
+        /// If probably there is metadata in ZooKeeper, we don't allow to drop the table.
         if (is_readonly || !zookeeper)
             throw Exception("Can't drop readonly replicated table (need to drop data in ZooKeeper as well)", ErrorCodes::TABLE_IS_READ_ONLY);
 
@@ -4032,8 +4038,20 @@ void StorageReplicatedMergeTree::rename(const String & new_path_to_table_data, c
     MergeTreeData::rename(new_path_to_table_data, new_table_id);
 
     /// Update table name in zookeeper
-    auto zookeeper = getZooKeeper();
-    zookeeper->set(replica_path + "/host", getReplicatedMergeTreeAddress().toString());
+    if (!is_readonly)
+    {
+        /// We don't do it for readonly tables, because it will be updated on next table startup.
+        /// It is also Ok to skip ZK error for the same reason.
+        try
+        {
+            auto zookeeper = getZooKeeper();
+            zookeeper->set(replica_path + "/host", getReplicatedMergeTreeAddress().toString());
+        }
+        catch (Coordination::Exception & e)
+        {
+            LOG_WARNING(log, "Cannot update the value of 'host' node (replica address) in ZooKeeper: {}", e.displayText());
+        }
+    }
 
     /// TODO: You can update names of loggers.
 }

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -210,6 +210,8 @@ private:
 
     /// If true, the table is offline and can not be written to it.
     std::atomic_bool is_readonly {false};
+    /// If false - ZooKeeper is available, but there is no table metadata. It's safe to drop table in this case.
+    bool has_metadata_in_zookeeper = true;
 
     String zookeeper_path;
     String replica_name;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow to DROP replicated table if the metadata in ZooKeeper was already removed and does not exist (this is also the case when using TestKeeper for testing and the server was restarted). Allow to RENAME replicated table even if there is an error communicating with ZooKeeper. This fixes #10720.


Detailed description / Documentation draft:
Tests will not be provided for this modification.