### PR TITLE
Don't use debug info from ELF file if it doesn't correspond to the running binary.

### DIFF
--- a/src/Common/Elf.cpp
+++ b/src/Common/Elf.cpp
@@ -54,6 +54,18 @@ Elf::Elf(const std::string & path)
         throw Exception("The ELF is truncated (section names string table points after end of file)", ErrorCodes::CANNOT_PARSE_ELF);
 
     section_names = reinterpret_cast<const char *>(mapped + section_names_offset);
+
+    /// Get program headers
+
+    ElfOff program_header_offset = header->e_phoff;
+    uint16_t program_header_num_entries = header->e_phnum;
+
+    if (!program_header_offset
+        || !program_header_num_entries
+        || program_header_offset + program_header_num_entries * sizeof(ElfPhdr) > elf_size)
+        throw Exception("The ELF is truncated (program header points after end of file)", ErrorCodes::CANNOT_PARSE_ELF);
+
+    program_headers = reinterpret_cast<const ElfPhdr *>(mapped + program_header_offset);
 }
 
 
@@ -101,6 +113,40 @@ std::optional<Elf::Section> Elf::findSection(std::function<bool(const Section & 
 std::optional<Elf::Section> Elf::findSectionByName(const char * name) const
 {
     return findSection([&](const Section & section, size_t) { return 0 == strcmp(name, section.name()); });
+}
+
+
+String Elf::getBuildID() const
+{
+    for (size_t idx = 0; idx < header->e_phnum; ++idx)
+    {
+        const ElfPhdr & phdr = program_headers[idx];
+
+        if (phdr.p_type == PT_NOTE)
+            return getBuildID(mapped + phdr.p_offset, phdr.p_filesz);
+    }
+    return {};
+}
+
+
+String Elf::getBuildID(const char * nhdr_pos, size_t size)
+{
+    const char * nhdr_end = nhdr_pos + size;
+
+    while (nhdr_pos < nhdr_end)
+    {
+        const ElfNhdr & nhdr = *reinterpret_cast<const ElfNhdr *>(nhdr_pos);
+
+        nhdr_pos += sizeof(ElfNhdr) + nhdr.n_namesz;
+        if (nhdr.n_type == NT_GNU_BUILD_ID)
+        {
+            const char * build_id = nhdr_pos;
+            return {build_id, nhdr.n_descsz};
+        }
+        nhdr_pos += nhdr.n_descsz;
+    }
+
+    return {};
 }
 
 

--- a/src/Common/Elf.h
+++ b/src/Common/Elf.h
@@ -17,6 +17,7 @@ using ElfEhdr = ElfW(Ehdr);
 using ElfOff = ElfW(Off);
 using ElfPhdr = ElfW(Phdr);
 using ElfShdr = ElfW(Shdr);
+using ElfNhdr = ElfW(Nhdr);
 using ElfSym = ElfW(Sym);
 
 
@@ -53,12 +54,18 @@ public:
     const char * end() const { return mapped + elf_size; }
     size_t size() const { return elf_size; }
 
+    /// Obtain build id from PT_NOTES section of program headers. Return empty string if does not exist.
+    /// The string is returned in binary. Note that "readelf -n ./clickhouse-server" prints it in hex.
+    String getBuildID() const;
+    static String getBuildID(const char * nhdr_pos, size_t size);
+
 private:
     MMapReadBufferFromFile in;
     size_t elf_size;
     const char * mapped;
     const ElfEhdr * header;
     const ElfShdr * section_headers;
+    const ElfPhdr * program_headers;
     const char * section_names = nullptr;
 };
 


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Don't use debug info from ELF file if it doesn't correspond to the running binary. It is needed to avoid printing wrong function names and source locations in stack traces. This fixes #7514