### PR TITLE
remove unused imports from HTTPHandlerFactory

### DIFF
--- a/src/Server/HTTPHandlerFactory.cpp
+++ b/src/Server/HTTPHandlerFactory.cpp
@@ -1,9 +1,6 @@
 #include "HTTPHandlerFactory.h"
 
-#include <re2/re2.h>
 #include <re2/stringpiece.h>
-#include <common/find_symbols.h>
-#include <Poco/StringTokenizer.h>
 #include <Poco/Util/LayeredConfiguration.h>
 
 #include "HTTPHandler.h"


### PR DESCRIPTION
This removes unused imports from `src/Server/HTTPHandlerFactory.cpp`:

```bash
- #include <re2/re2.h>
- #include <common/find_symbols.h>
- #include <Poco/StringTokenizer.h>
```

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Removes unused imports from HTTPHandlerFactory.