### PR TITLE
Fix timeout in sql_fuzzy test

### DIFF
--- a/tests/queries/0_stateless/00746_sql_fuzzy.sh
+++ b/tests/queries/0_stateless/00746_sql_fuzzy.sh
@@ -13,7 +13,7 @@ $CLICKHOUSE_CLIENT -q "select name from system.table_functions format TSV;" > $S
 # if you want long run use: env SQL_FUZZY_RUNS=100000 clickhouse-test sql_fuzzy
 
 for SQL_FUZZY_RUN in $(seq ${SQL_FUZZY_RUNS:=10}); do
-    env SQL_FUZZY_RUN=$SQL_FUZZY_RUN $CURDIR/00746_sql_fuzzy.pl | $CLICKHOUSE_CLIENT --max_execution_time 10 -n --ignore-error >/dev/null 2>&1
+    env SQL_FUZZY_RUN=$SQL_FUZZY_RUN $CURDIR/00746_sql_fuzzy.pl | $CLICKHOUSE_CLIENT --format Null --max_execution_time 10 -n --ignore-error >/dev/null 2>&1
     if [[ `$CLICKHOUSE_CLIENT -q "SELECT 'Still alive'"` != 'Still alive' ]]; then
         break
     fi


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://clickhouse-test-reports.s3.yandex.net/11655/59d4df19f03ab10588f043efa4f24e3292c2698d/functional_stateless_tests_(debug).html#fail1

The test sql_fuzzy can timeout despite the `--max_execution_time 10` setting.
It happens after executing a query like `SELECT * FROM zeros(sipHash64('\0', []))`.
This query takes a few minutes and finishes successfully. But it is more than 10 seconds.
The hypothesis is that it takes too much time to read output and we should change format to Null.
