### PR TITLE
Fix syntax hilite in CREATE USER query

### DIFF
--- a/src/Parsers/ASTCreateUserQuery.cpp
+++ b/src/Parsers/ASTCreateUserQuery.cpp
@@ -65,7 +65,8 @@ namespace
         settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << " IDENTIFIED WITH " << authentication_type_name
                       << (settings.hilite ? IAST::hilite_none : "");
         if (password)
-            settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << " BY " << quoteString(*password);
+            settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << " BY " << (settings.hilite ? IAST::hilite_none : "")
+                << quoteString(*password);
     }
 
 

--- a/tests/queries/0_stateless/01316_create_user_syntax_hilite.reference
+++ b/tests/queries/0_stateless/01316_create_user_syntax_hilite.reference
@@ -1,0 +1,1 @@
+[1mCREATE USER[0m user[1m IDENTIFIED WITH plaintext_password[0m[1m BY [0m'hello'

--- a/tests/queries/0_stateless/01316_create_user_syntax_hilite.sh
+++ b/tests/queries/0_stateless/01316_create_user_syntax_hilite.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. $CURDIR/../shell_config.sh
+
+set -e
+
+$CLICKHOUSE_FORMAT --hilite <<< "CREATE USER user IDENTIFIED WITH PLAINTEXT_PASSWORD BY 'hello'"


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix syntax hilite in CREATE USER query.