### PR TITLE
Fix mutations premature "finish"

### DIFF
--- a/src/Storages/MergeTree/ActiveDataPartSet.h
+++ b/src/Storages/MergeTree/ActiveDataPartSet.h
@@ -67,6 +67,17 @@ public:
         return result;
     }
 
+    /// Remove only covered parts from active set
+    bool removePartsCoveredBy(const String & part_name)
+    {
+        Strings parts_covered_by = getPartsCoveredBy(MergeTreePartInfo::fromPartName(part_name, format_version));
+        bool result = true;
+        for (const auto & part : parts_covered_by)
+            result &= remove(part);
+
+        return result;
+    }
+
     /// If not found, return an empty string.
     String getContainingPart(const MergeTreePartInfo & part_info) const;
     String getContainingPart(const String & name) const;

--- a/src/Storages/MergeTree/ActiveDataPartSet.h
+++ b/src/Storages/MergeTree/ActiveDataPartSet.h
@@ -73,7 +73,8 @@ public:
         Strings parts_covered_by = getPartsCoveredBy(MergeTreePartInfo::fromPartName(part_name, format_version));
         bool result = true;
         for (const auto & part : parts_covered_by)
-            result &= remove(part);
+            if (part != part_name)
+                result &= remove(part);
 
         return result;
     }

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
@@ -210,13 +210,15 @@ private:
     void addPartToMutations(const String & part_name);
 
     /// Remove covered parts from mutations (parts_to_do) which were assigned
-    /// for mutation. If remove_part == true, than also remove part itself.
+    /// for mutation. If remove_covered_parts = true, than remove parts covered
+    /// by first argument. If remove_part == true, than also remove part itself.
+    /// Both negative flags will throw exception.
     ///
     /// Part removed from mutations which satisfy contitions:
     /// block_number > part.getDataVersion()
     /// or block_number == part.getDataVersion()
     ///    ^ (this may happen if we downloaded mutated part from other replica)
-    void removeCoveredPartsFromMutations(const String & part_name, bool remove_part);
+    void removeCoveredPartsFromMutations(const String & part_name, bool remove_part, bool remove_covered_parts);
 
     /// Update the insertion times in ZooKeeper.
     void updateTimesInZooKeeper(zkutil::ZooKeeperPtr zookeeper,

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
@@ -107,8 +107,13 @@ private:
 
         ReplicatedMergeTreeMutationEntryPtr entry;
 
-        /// Parts we have to mutate to complete mutation. We use ActiveDataPartSet structure
-        /// to be able to manage covering and covered parts.
+        /// Current parts we have to mutate to complete mutation.
+        ///
+        /// current_part_name =mutation> result_part_name
+        /// ^~~parts_to_do~~^            ^~virtual_parts~^
+        ///
+        /// We use ActiveDataPartSet structure to be able to manage covering and
+        /// covered parts.
         ActiveDataPartSet parts_to_do;
 
         /// Note that is_done is not equivalent to parts_to_do.size() == 0
@@ -204,7 +209,7 @@ private:
     /// Add part for mutations with block_number > part.getDataVersion()
     void addPartToMutations(const String & part_name);
 
-    /// Remove part from mutations which were assigned to mutate it
+    /// Remove part from mutations (parts_to_do) which were assigned to mutate it
     /// with block_number > part.getDataVersion()
     /// and block_number == part.getDataVersion()
     ///     ^ (this may happen if we downloaded mutated part from other replica)

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
@@ -209,11 +209,14 @@ private:
     /// Add part for mutations with block_number > part.getDataVersion()
     void addPartToMutations(const String & part_name);
 
-    /// Remove part from mutations (parts_to_do) which were assigned to mutate it
-    /// with block_number > part.getDataVersion()
-    /// and block_number == part.getDataVersion()
-    ///     ^ (this may happen if we downloaded mutated part from other replica)
-    void removePartFromMutations(const String & part_name);
+    /// Remove covered parts from mutations (parts_to_do) which were assigned
+    /// for mutation. If remove_part == true, than also remove part itself.
+    ///
+    /// Part removed from mutations which satisfy contitions:
+    /// block_number > part.getDataVersion()
+    /// or block_number == part.getDataVersion()
+    ///    ^ (this may happen if we downloaded mutated part from other replica)
+    void removeCoveredPartsFromMutations(const String & part_name, bool remove_part);
 
     /// Update the insertion times in ZooKeeper.
     void updateTimesInZooKeeper(zkutil::ZooKeeperPtr zookeeper,

--- a/tests/queries/0_stateless/01076_parallel_alter_replicated_zookeeper.sh
+++ b/tests/queries/0_stateless/01076_parallel_alter_replicated_zookeeper.sh
@@ -110,6 +110,9 @@ while [[ $($CLICKHOUSE_CLIENT --query "select * from system.mutations where tabl
         break
     fi
     sleep 1
+    for i in `seq $REPLICAS`; do
+        $CLICKHOUSE_CLIENT --query "ATTACH TABLE concurrent_mutate_mt_$i" 2> /dev/null
+    done
     counter=$(($counter + 1))
 done
 

--- a/tests/queries/0_stateless/01076_parallel_alter_replicated_zookeeper.sh
+++ b/tests/queries/0_stateless/01076_parallel_alter_replicated_zookeeper.sh
@@ -105,7 +105,7 @@ sleep 1
 counter=0
 
 while [[ $($CLICKHOUSE_CLIENT --query "select * from system.mutations where table like 'concurrent_mutate_mt_%' and is_done=0" 2>&1) ]]; do
-    if [ "$counter" -gt 40 ]
+    if [ "$counter" -gt 120 ]
     then
         break
     fi

--- a/tests/queries/0_stateless/01318_long_failing_mutation_zookeeper.reference
+++ b/tests/queries/0_stateless/01318_long_failing_mutation_zookeeper.reference
@@ -1,0 +1,6 @@
+90001
+2
+waiting	default	mutation_table	0000000000	MODIFY COLUMN `value` UInt64
+is_done	parts_to_do
+0	1
+MUTATE_PART	0_0_0_0_2

--- a/tests/queries/0_stateless/01318_long_failing_mutation_zookeeper.sh
+++ b/tests/queries/0_stateless/01318_long_failing_mutation_zookeeper.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. $CURDIR/../shell_config.sh
+
+$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS mutation_table"
+
+$CLICKHOUSE_CLIENT --query "
+    CREATE TABLE mutation_table(
+        key UInt64,
+        value String
+    )
+    ENGINE = ReplicatedMergeTree('/clickhouse/tables/mutation_table', '1')
+    ORDER BY key
+    PARTITION BY key % 10
+"
+
+$CLICKHOUSE_CLIENT --query "INSERT INTO mutation_table select number, toString(number) from numbers(100000) where number % 10 != 0"
+
+$CLICKHOUSE_CLIENT --query "INSERT INTO mutation_table VALUES(0, 'hello')"
+
+$CLICKHOUSE_CLIENT --query "SELECT COUNT() FROM mutation_table"
+
+$CLICKHOUSE_CLIENT --query "ALTER TABLE mutation_table MODIFY COLUMN value UInt64 SETTINGS replication_alter_partitions_sync=0"
+
+first_mutation_id=$($CLICKHOUSE_CLIENT --query "SELECT mutation_id FROM system.mutations where table='mutation_table' and database='$CLICKHOUSE_DATABASE'")
+
+# Here we have long sleeps, but they shouldn't lead to flaps. We just check that
+# background mutation finalization function will be triggered at least once. In
+# rare cases this test doesn't check anything, but will report OK.
+sleep 7
+
+$CLICKHOUSE_CLIENT --query "ALTER TABLE mutation_table MODIFY COLUMN value UInt32 SETTINGS replication_alter_partitions_sync=0"
+
+
+#### just check that both mutations started
+check_query="SELECT count() FROM system.mutations WHERE table='mutation_table' and database='$CLICKHOUSE_DATABASE'"
+
+query_result=`$CLICKHOUSE_CLIENT --query="$check_query" 2>&1`
+
+while [ "$query_result" != "2" ]
+do
+    query_result=`$CLICKHOUSE_CLIENT --query="$check_query" 2>&1`
+    sleep 0.5
+done
+
+echo $query_result
+
+$CLICKHOUSE_CLIENT --query "KILL MUTATION WHERE mutation_id='$first_mutation_id'"
+
+sleep 7
+
+$CLICKHOUSE_CLIENT --query "SELECT is_done, parts_to_do FROM system.mutations where table='mutation_table' and database='$CLICKHOUSE_DATABASE' FORMAT TSVWithNames"
+
+$CLICKHOUSE_CLIENT --query "SELECT type, new_part_name FROM system.replication_queue WHERE table='mutation_table' and database='$CLICKHOUSE_DATABASE'"
+
+$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS mutation_table"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix error which leads to an incorrect state of `system.mutations`. It may show that whole mutation is already done but the server still has `MUTATE_PART` tasks in the replication queue and tries to execute them. This fixes #11611.