### PR TITLE
Remove excessive statement

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -139,7 +139,6 @@ BlocksWithPartition MergeTreeDataWriter::splitBlockIntoParts(const Block & block
         return result;
 
     data.check(block, true);
-    block.checkNumberOfRows();
 
     if (!data.hasPartitionKey()) /// Table is not partitioned.
     {


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Remove excessive statement. This fixes #11131