### PR TITLE
Fix race condition in SYSTEM SYNC REPLICA

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -646,7 +646,7 @@ void ReplicatedMergeTreeQueue::updateMutations(zkutil::ZooKeeperPtr zookeeper, C
         }
     }
 
-    if (some_active_mutations_were_killed)
+    if (some_active_mutations_were_killed && storage.queue_task_handle)
         storage.queue_task_handle->signalReadyToRun();
 
     if (!entries_to_load.empty())
@@ -759,7 +759,7 @@ ReplicatedMergeTreeMutationEntryPtr ReplicatedMergeTreeQueue::removeMutation(
         LOG_DEBUG(log, "Removed mutation {} from local state.", entry->znode_name);
     }
 
-    if (mutation_was_active)
+    if (mutation_was_active && storage.queue_task_handle)
         storage.queue_task_handle->signalReadyToRun();
 
     return entry;

--- a/tests/queries/0_stateless/01320_create_sync_race_condition.sh
+++ b/tests/queries/0_stateless/01320_create_sync_race_condition.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. $CURDIR/../shell_config.sh
+
+set -e
+
+$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS r;"
+
+function thread1()
+{
+    while true; do $CLICKHOUSE_CLIENT -n --query "CREATE TABLE r (x UInt64) ENGINE = ReplicatedMergeTree('/test/table', 'r') ORDER BY x; DROP TABLE r;"; done
+}
+
+function thread2()
+{
+    while true; do $CLICKHOUSE_CLIENT --query "SYSTEM SYNC REPLICA r" 2>/dev/null; done
+}
+
+export -f thread1
+export -f thread2
+
+timeout 10 bash -c thread1 &
+timeout 10 bash -c thread2 &
+
+wait
+
+$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS r;"


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix very rare race condition in SYSTEM SYNC REPLICA. If the replicated table is created and at the same time from the separate connection another client is issuing `SYSTEM SYNC REPLICA` command on that table (this is unlikely, because another client should be aware that the table is created), it's possible to get nullptr dereference.


Detailed description / Documentation draft:
Found by Thread Fuzzer: https://github.com/ClickHouse/ClickHouse/pull/9813
