### PR TITLE
Maybe fix max_parser_depth flaky test

### DIFF
--- a/tests/queries/0_stateless/01196_max_parser_depth.sh
+++ b/tests/queries/0_stateless/01196_max_parser_depth.sh
@@ -3,6 +3,8 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . $CURDIR/../shell_config.sh
 
-{ printf "select "; for x in {1..1000}; do printf "coalesce(null, "; done; printf "1"; for x in {1..1000}; do printf ")"; done; } | $CLICKHOUSE_CLIENT 2>&1 | grep -o -F 'Code: 306'
-{ printf "select "; for x in {1..1000}; do printf "coalesce(null, "; done; printf "1"; for x in {1..1000}; do printf ")"; done; } | $CLICKHOUSE_LOCAL 2>&1 | grep -o -F 'Code: 306'
-{ printf "select "; for x in {1..1000}; do printf "coalesce(null, "; done; printf "1"; for x in {1..1000}; do printf ")"; done; } | $CLICKHOUSE_CURL --data-binary @- -vsS "$CLICKHOUSE_URL" 2>&1 | grep -o -F 'Code: 306'
+{ printf "select "; for x in {1..1000}; do printf "coalesce(null, "; done; printf "1"; for x in {1..1000}; do printf ")"; done; } > ${CLICKHOUSE_TMP}/query
+
+cat ${CLICKHOUSE_TMP}/query | $CLICKHOUSE_CLIENT 2>&1 | grep -o -F 'Code: 306'
+cat ${CLICKHOUSE_TMP}/query | $CLICKHOUSE_LOCAL 2>&1 | grep -o -F 'Code: 306'
+cat ${CLICKHOUSE_TMP}/query | $CLICKHOUSE_CURL --data-binary @- -vsS "$CLICKHOUSE_URL" 2>&1 | grep -o -F 'Code: 306'

--- a/tests/queries/shell_config.sh
+++ b/tests/queries/shell_config.sh
@@ -71,7 +71,7 @@ mkdir -p ${CLICKHOUSE_TMP}
 
 function clickhouse_client_removed_host_parameter()
 {
-	# removing only `--host=value` and `--host value` (removing '-hvalue' feels to dangerous) with python regex.
-	# bash regex magic is arcane, but version dependant and weak; sed or awk are not really portable.
-	$(echo "$CLICKHOUSE_CLIENT"  | python -c "import sys, re; print re.sub('--host(\s+|=)[^\s]+', '', sys.stdin.read())") "$@"
+    # removing only `--host=value` and `--host value` (removing '-hvalue' feels to dangerous) with python regex.
+    # bash regex magic is arcane, but version dependant and weak; sed or awk are not really portable.
+    $(echo "$CLICKHOUSE_CLIENT"  | python -c "import sys, re; print re.sub('--host(\s+|=)[^\s]+', '', sys.stdin.read())") "$@"
 }


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

It is a very rare test failure: just a few cases for months.

See https://clickhouse-test-reports.s3.yandex.net/11684/e44e1ad0d4cb7b08e4b1de3cf863f060e4d493c0/functional_stateless_tests_(release,_databaseatomic)/test_run.txt.out.log

It's unclear how the issue appears. I was not able to reproduce it with any combinations of `printf` and `head`.