### PR TITLE
Improve performace of reading in order of sorting key.

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -333,7 +333,7 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingBool, enable_unaligned_array_join, false, "Allow ARRAY JOIN with multiple arrays that have different sizes. When this settings is enabled, arrays will be resized to the longest one.", 0) \
     M(SettingBool, optimize_read_in_order, true, "Enable ORDER BY optimization for reading data in corresponding order in MergeTree tables.", 0) \
     M(SettingBool, optimize_aggregation_in_order, false, "Enable GROUP BY optimization for aggregating data in corresponding order in MergeTree tables.", 0) \
-    M(SettingUInt64, read_in_order_two_level_merge_threshold, 30, "Minimal number of parts for one thread to run preliminary merge step during multithread reading in order of primary key.", 0) \
+    M(SettingUInt64, read_in_order_two_level_merge_threshold, 100, "Minimal number of parts to read to run preliminary merge step during multithread reading in order of primary key.", 0) \
     M(SettingBool, low_cardinality_allow_in_native_format, true, "Use LowCardinality type in Native format. Otherwise, convert LowCardinality columns to ordinary for select query, and convert ordinary columns to required LowCardinality for insert query.", 0) \
     M(SettingBool, cancel_http_readonly_queries_on_client_close, false, "Cancel HTTP readonly queries when a client closes the connection without waiting for response.", 0) \
     M(SettingBool, external_table_functions_use_nulls, true, "If it is set to true, external table functions will implicitly use Nullable type if needed. Otherwise NULLs will be substituted with default values. Currently supported only by 'mysql' and 'odbc' table functions.", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -333,6 +333,7 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingBool, enable_unaligned_array_join, false, "Allow ARRAY JOIN with multiple arrays that have different sizes. When this settings is enabled, arrays will be resized to the longest one.", 0) \
     M(SettingBool, optimize_read_in_order, true, "Enable ORDER BY optimization for reading data in corresponding order in MergeTree tables.", 0) \
     M(SettingBool, optimize_aggregation_in_order, false, "Enable GROUP BY optimization for aggregating data in corresponding order in MergeTree tables.", 0) \
+    M(SettingUInt64, read_in_order_two_level_merge_threshold, 30, "Minimal number of parts for one thread to run preliminary merge step during multithread reading in order of primary key.", 0) \
     M(SettingBool, low_cardinality_allow_in_native_format, true, "Use LowCardinality type in Native format. Otherwise, convert LowCardinality columns to ordinary for select query, and convert ordinary columns to required LowCardinality for insert query.", 0) \
     M(SettingBool, cancel_http_readonly_queries_on_client_close, false, "Cancel HTTP readonly queries when a client closes the connection without waiting for response.", 0) \
     M(SettingBool, external_table_functions_use_nulls, true, "If it is set to true, external table functions will implicitly use Nullable type if needed. Otherwise NULLs will be substituted with default values. Currently supported only by 'mysql' and 'odbc' table functions.", 0) \

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -940,6 +940,7 @@ Pipes MergeTreeDataSelectExecutor::spreadMarkRangesAmongStreamsWithOrder(
     };
 
     const size_t min_marks_per_stream = (sum_marks - 1) / num_streams + 1;
+    bool need_preliminary_merge = (parts.size() > settings.read_in_order_two_level_merge_threshold);
 
     for (size_t i = 0; i < num_streams && !parts.empty(); ++i)
     {
@@ -1021,7 +1022,7 @@ Pipes MergeTreeDataSelectExecutor::spreadMarkRangesAmongStreamsWithOrder(
             }
         }
 
-        if (pipes.size() >= settings.read_in_order_two_level_merge_threshold)
+        if (pipes.size() > 1 && need_preliminary_merge)
         {
             SortDescription sort_description;
             for (size_t j = 0; j < input_order_info->order_key_prefix_descr.size(); ++j)

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -1021,7 +1021,7 @@ Pipes MergeTreeDataSelectExecutor::spreadMarkRangesAmongStreamsWithOrder(
             }
         }
 
-        if (pipes.size() > 1)
+        if (pipes.size() >= settings.read_in_order_two_level_merge_threshold)
         {
             SortDescription sort_description;
             for (size_t j = 0; j < input_order_info->order_key_prefix_descr.size(); ++j)
@@ -1039,7 +1039,10 @@ Pipes MergeTreeDataSelectExecutor::spreadMarkRangesAmongStreamsWithOrder(
             res.emplace_back(std::move(pipes), std::move(merging_sorted));
         }
         else
-            res.emplace_back(std::move(pipes.front()));
+        {
+            for (auto && pipe : pipes)
+                res.emplace_back(std::move(pipe));
+        }
     }
 
     return res;

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -639,13 +639,6 @@ Pipes MergeTreeDataSelectExecutor::readFromParts(
     }
     else if ((settings.optimize_read_in_order || settings.optimize_aggregation_in_order) && query_info.input_order_info)
     {
-        size_t prefix_size = query_info.input_order_info->order_key_prefix_descr.size();
-        auto order_key_prefix_ast = data.getSortingKey().expression_list_ast->clone();
-        order_key_prefix_ast->children.resize(prefix_size);
-
-        auto syntax_result = SyntaxAnalyzer(context).analyze(order_key_prefix_ast, data.getColumns().getAllPhysical());
-        auto sorting_key_prefix_expr = ExpressionAnalyzer(order_key_prefix_ast, syntax_result, context).getActions(false);
-
         res = spreadMarkRangesAmongStreamsWithOrder(
             std::move(parts_with_ranges),
             num_streams,
@@ -653,11 +646,9 @@ Pipes MergeTreeDataSelectExecutor::readFromParts(
             max_block_size,
             settings.use_uncompressed_cache,
             query_info,
-            sorting_key_prefix_expr,
             virt_column_names,
             settings,
-            reader_settings,
-            result_projection);
+            reader_settings);
     }
     else
     {
@@ -848,11 +839,9 @@ Pipes MergeTreeDataSelectExecutor::spreadMarkRangesAmongStreamsWithOrder(
     UInt64 max_block_size,
     bool use_uncompressed_cache,
     const SelectQueryInfo & query_info,
-    const ExpressionActionsPtr & sorting_key_prefix_expr,
     const Names & virt_columns,
     const Settings & settings,
-    const MergeTreeReaderSettings & reader_settings,
-    ExpressionActionsPtr & out_projection) const
+    const MergeTreeReaderSettings & reader_settings) const
 {
     size_t sum_marks = 0;
     const InputOrderInfoPtr & input_order_info = query_info.input_order_info;
@@ -945,8 +934,6 @@ Pipes MergeTreeDataSelectExecutor::spreadMarkRangesAmongStreamsWithOrder(
     {
         size_t need_marks = min_marks_per_stream;
 
-        Pipes pipes;
-
         /// Loop over parts.
         /// We will iteratively take part or some subrange of a part from the back
         ///  and assign a stream to read from it.
@@ -1003,7 +990,7 @@ Pipes MergeTreeDataSelectExecutor::spreadMarkRangesAmongStreamsWithOrder(
 
             if (input_order_info->direction == 1)
             {
-                pipes.emplace_back(std::make_shared<MergeTreeSelectProcessor>(
+                res.emplace_back(std::make_shared<MergeTreeSelectProcessor>(
                     data, part.data_part, max_block_size, settings.preferred_block_size_bytes,
                     settings.preferred_max_column_in_block_size_bytes, column_names, ranges_to_get_from_part,
                     use_uncompressed_cache, query_info.prewhere_info, true, reader_settings,
@@ -1011,35 +998,15 @@ Pipes MergeTreeDataSelectExecutor::spreadMarkRangesAmongStreamsWithOrder(
             }
             else
             {
-                pipes.emplace_back(std::make_shared<MergeTreeReverseSelectProcessor>(
+                res.emplace_back(std::make_shared<MergeTreeReverseSelectProcessor>(
                     data, part.data_part, max_block_size, settings.preferred_block_size_bytes,
                     settings.preferred_max_column_in_block_size_bytes, column_names, ranges_to_get_from_part,
                     use_uncompressed_cache, query_info.prewhere_info, true, reader_settings,
                     virt_columns, part.part_index_in_query));
 
-                pipes.back().addSimpleTransform(std::make_shared<ReverseTransform>(pipes.back().getHeader()));
+                res.back().addSimpleTransform(std::make_shared<ReverseTransform>(res.back().getHeader()));
             }
         }
-
-        if (pipes.size() > 1)
-        {
-            SortDescription sort_description;
-            for (size_t j = 0; j < input_order_info->order_key_prefix_descr.size(); ++j)
-                sort_description.emplace_back(data.getSortingKey().column_names[j],
-                      input_order_info->direction, 1);
-
-            /// Drop temporary columns, added by 'sorting_key_prefix_expr'
-            out_projection = createProjection(pipes.back(), data);
-            for (auto & pipe : pipes)
-                pipe.addSimpleTransform(std::make_shared<ExpressionTransform>(pipe.getHeader(), sorting_key_prefix_expr));
-
-            auto merging_sorted = std::make_shared<MergingSortedTransform>(
-                pipes.back().getHeader(), pipes.size(), sort_description, max_block_size);
-
-            res.emplace_back(std::move(pipes), std::move(merging_sorted));
-        }
-        else
-            res.emplace_back(std::move(pipes.front()));
     }
 
     return res;

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.h
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.h
@@ -65,9 +65,11 @@ private:
         UInt64 max_block_size,
         bool use_uncompressed_cache,
         const SelectQueryInfo & query_info,
+        const ExpressionActionsPtr & sorting_key_prefix_expr,
         const Names & virt_columns,
         const Settings & settings,
-        const MergeTreeReaderSettings & reader_settings) const;
+        const MergeTreeReaderSettings & reader_settings,
+        ExpressionActionsPtr & out_projection) const;
 
     Pipes spreadMarkRangesAmongStreamsFinal(
         RangesInDataParts && parts,

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.h
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.h
@@ -65,11 +65,9 @@ private:
         UInt64 max_block_size,
         bool use_uncompressed_cache,
         const SelectQueryInfo & query_info,
-        const ExpressionActionsPtr & sorting_key_prefix_expr,
         const Names & virt_columns,
         const Settings & settings,
-        const MergeTreeReaderSettings & reader_settings,
-        ExpressionActionsPtr & out_projection) const;
+        const MergeTreeReaderSettings & reader_settings) const;
 
     Pipes spreadMarkRangesAmongStreamsFinal(
         RangesInDataParts && parts,

--- a/tests/performance/read_in_order_many_parts.xml
+++ b/tests/performance/read_in_order_many_parts.xml
@@ -3,6 +3,7 @@
         <optimize_aggregation_in_order>1</optimize_aggregation_in_order>
         <optimize_read_in_order>1</optimize_read_in_order>
         <max_partitions_per_insert_block>200</max_partitions_per_insert_block>
+        <max_threads>8</max_threads>
     </settings>
 
     <substitutions>

--- a/tests/performance/read_in_order_many_parts.xml
+++ b/tests/performance/read_in_order_many_parts.xml
@@ -1,0 +1,31 @@
+<test>
+    <settings>
+        <optimize_aggregation_in_order>1</optimize_aggregation_in_order>
+        <optimize_read_in_order>1</optimize_read_in_order>
+        <max_partitions_per_insert_block>200</max_partitions_per_insert_block>
+    </settings>
+
+    <substitutions>
+        <substitution>
+            <name>table</name>
+            <values>
+                <value>mt_20_parts</value>
+                <value>mt_200_parts</value>
+            </values>
+        </substitution>
+    </substitutions>
+
+    <create_query>CREATE TABLE mt_20_parts(id UInt32, val1 UInt32, val2 UInt32) ENGINE = MergeTree ORDER BY val1 PARTITION BY id % 20</create_query>
+    <create_query>CREATE TABLE mt_200_parts(id UInt32, val1 UInt32, val2 UInt32) ENGINE = MergeTree ORDER BY val1 PARTITION BY id % 200</create_query>
+
+    <fill_query>INSERT INTO mt_20_parts SELECT number, rand() % 10000, rand() FROM numbers_mt(100000000)</fill_query>
+    <fill_query>INSERT INTO mt_200_parts SELECT number, rand() % 10000, rand() FROM numbers_mt(100000000)</fill_query>
+    <fill_query>OPTIMIZE TABLE mt_20_parts FINAL</fill_query>
+    <fill_query>OPTIMIZE TABLE mt_200_parts FINAL</fill_query>
+
+    <query>SELECT val2 FROM {table} ORDER BY val1 LIMIT 100 FORMAT Null</query>
+    <query>SELECT val2 FROM {table} ORDER BY val1 LIMIT 100000 FORMAT Null</query>
+    <query>SELECT sum(val2) FROM {table} GROUP BY val1 FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS {table}</drop_query>
+</test>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improved performace of 'ORDER BY' and 'GROUP BY' by prefix of sorting key.
