### PR TITLE
[hyperscan] Bring back -fno-omit-frame-pointer

### DIFF
--- a/contrib/hyperscan-cmake/CMakeLists.txt
+++ b/contrib/hyperscan-cmake/CMakeLists.txt
@@ -222,7 +222,7 @@ if (ENABLE_HYPERSCAN)
             PRIVATE
                 -g0 # library has too much debug information
                 -march=corei7
-                -fno-omit-frame-pointer
+                -fno-omit-frame-pointer # otherwise stack unwinding from this library leads to segfault
         )
         target_include_directories (hyperscan
             PRIVATE

--- a/contrib/hyperscan-cmake/CMakeLists.txt
+++ b/contrib/hyperscan-cmake/CMakeLists.txt
@@ -219,7 +219,10 @@ if (ENABLE_HYPERSCAN)
 
         target_compile_definitions (hyperscan PUBLIC USE_HYPERSCAN=1)
         target_compile_options (hyperscan
-            PRIVATE -g0 -march=corei7 # library has too much debug information
+            PRIVATE
+                -g0 # library has too much debug information
+                -march=corei7
+                -fno-omit-frame-pointer
         )
         target_include_directories (hyperscan
             PRIVATE


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)