### PR TITLE
Added retries to test_mysql_federated

### DIFF
--- a/tests/integration/test_mysql_protocol/test.py
+++ b/tests/integration/test_mysql_protocol/test.py
@@ -139,39 +139,62 @@ def test_mysql_client(mysql_client, server_address):
 
 
 def test_mysql_federated(mysql_server, server_address):
-    node.query('''DROP DATABASE IF EXISTS mysql_federated''', settings={"password": "123"})
-    node.query('''CREATE DATABASE mysql_federated''', settings={"password": "123"})
-    node.query('''CREATE TABLE mysql_federated.test (col UInt32) ENGINE = Log''', settings={"password": "123"})
-    node.query('''INSERT INTO mysql_federated.test VALUES (0), (1), (5)''', settings={"password": "123"})
+    # For some reason it occasionally fails without retries.
+    retries = 100
+    for try_num in range(retries):
+        node.query('''DROP DATABASE IF EXISTS mysql_federated''', settings={"password": "123"})
+        node.query('''CREATE DATABASE mysql_federated''', settings={"password": "123"})
+        node.query('''CREATE TABLE mysql_federated.test (col UInt32) ENGINE = Log''', settings={"password": "123"})
+        node.query('''INSERT INTO mysql_federated.test VALUES (0), (1), (5)''', settings={"password": "123"})
 
-    code, (stdout, stderr) = mysql_server.exec_run('''
-        mysql
-        -e "DROP SERVER IF EXISTS clickhouse;"
-        -e "CREATE SERVER clickhouse FOREIGN DATA WRAPPER mysql OPTIONS (USER 'default', PASSWORD '123', HOST '{host}', PORT {port}, DATABASE 'mysql_federated');"
-        -e "DROP DATABASE IF EXISTS mysql_federated;"
-        -e "CREATE DATABASE mysql_federated;"
-    '''.format(host=server_address, port=server_port), demux=True)
+        code, (stdout, stderr) = mysql_server.exec_run('''
+            mysql
+            -e "DROP SERVER IF EXISTS clickhouse;"
+            -e "CREATE SERVER clickhouse FOREIGN DATA WRAPPER mysql
+            OPTIONS (USER 'default', PASSWORD '123', HOST '{host}', PORT {port}, DATABASE 'mysql_federated');"
+            -e "DROP DATABASE IF EXISTS mysql_federated;"
+            -e "CREATE DATABASE mysql_federated;"
+        '''.format(host=server_address, port=server_port), demux=True)
 
-    if code != 0:
-        print(stdout)
-        print(stderr)
-    assert code == 0
+        if code != 0:
+            print("stdout", stdout)
+            print("stderr", stderr)
+            if try_num + 1 < retries and "Can't connect to local MySQL server through socket" in stderr:
+                time.sleep(1)
+                continue
+        assert code == 0
 
-    code, (stdout, stderr) = mysql_server.exec_run('''
-        mysql
-        -e "CREATE TABLE mysql_federated.test(`col` int UNSIGNED) ENGINE=FEDERATED CONNECTION='clickhouse';"
-        -e "SELECT * FROM mysql_federated.test ORDER BY col;"
-    '''.format(host=server_address, port=server_port), demux=True)
+        code, (stdout, stderr) = mysql_server.exec_run('''
+            mysql
+            -e "CREATE TABLE mysql_federated.test(`col` int UNSIGNED) ENGINE=FEDERATED CONNECTION='clickhouse';"
+            -e "SELECT * FROM mysql_federated.test ORDER BY col;"
+        '''.format(host=server_address, port=server_port), demux=True)
 
-    assert stdout == '\n'.join(['col', '0', '1', '5', ''])
+        if code != 0:
+            print("stdout", stdout)
+            print("stderr", stderr)
+            if try_num + 1 < retries and "Can't connect to local MySQL server through socket" in stderr:
+                time.sleep(1)
+                continue
+        assert code == 0
 
-    code, (stdout, stderr) = mysql_server.exec_run('''
-        mysql
-        -e "INSERT INTO mysql_federated.test VALUES (0), (1), (5);"
-        -e "SELECT * FROM mysql_federated.test ORDER BY col;"
-    '''.format(host=server_address, port=server_port), demux=True)
+        assert stdout == '\n'.join(['col', '0', '1', '5', ''])
 
-    assert stdout == '\n'.join(['col', '0', '0', '1', '1', '5', '5', ''])
+        code, (stdout, stderr) = mysql_server.exec_run('''
+            mysql
+            -e "INSERT INTO mysql_federated.test VALUES (0), (1), (5);"
+            -e "SELECT * FROM mysql_federated.test ORDER BY col;"
+        '''.format(host=server_address, port=server_port), demux=True)
+
+        if code != 0:
+            print("stdout", stdout)
+            print("stderr", stderr)
+            if try_num + 1 < retries and "Can't connect to local MySQL server through socket" in stderr:
+                time.sleep(1)
+                continue
+        assert code == 0
+
+        assert stdout == '\n'.join(['col', '0', '0', '1', '1', '5', '5', ''])
 
 
 def test_python_client(server_address):


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

I'm not sure what is the reason as we already have "health check" in this test:
```
@pytest.fixture(scope='module')
def mysql_server(mysql_client):
    """Return MySQL container when it is healthy.

    :type mysql_client: Container
    :rtype: Container
    """
    retries = 30
    for i in range(retries):
        info = mysql_client.client.api.inspect_container(mysql_client.name)
        if info['State']['Health']['Status'] == 'healthy':
            break
        time.sleep(1)
    else:
        raise Exception('Mysql server has not started in %d seconds.' % retries)

    return mysql_client
```

But even after that, it sometimes cannot to connect to local mysql server within its container.
(I run the test and one time it required 53 retries.)