### PR TITLE
Fix type duduction in Values format

### DIFF
--- a/src/Processors/Formats/Impl/ConstantExpressionTemplate.cpp
+++ b/src/Processors/Formats/Impl/ConstantExpressionTemplate.cpp
@@ -74,7 +74,7 @@ static void fillLiteralInfo(DataTypes & nested_types, LiteralInfo & info)
     size_t elements_num = nested_types.size();
     info.special_parser.nested_types.reserve(elements_num);
 
-    for (auto nested_type : nested_types)
+    for (auto & nested_type : nested_types)
     {
         /// It can be Array(Nullable(nested_type)) or Tuple(..., Nullable(nested_type), ...)
         bool is_nullable = false;
@@ -201,7 +201,10 @@ private:
 
     static void setDataType(LiteralInfo & info)
     {
-        /// Type (Field::Types:Which) of literal in AST can be: String, UInt64, Int64, Float64, Null or Array of simple literals (not of Arrays).
+        /// Type (Field::Types:Which) of literal in AST can be:
+        /// 1. simple literal type: String, UInt64, Int64, Float64, Null
+        /// 2. complex literal type: Array or Tuple of simple literals
+        /// 3. Array or Tuple of complex literals
         /// Null and empty Array literals are considered as tokens, because template with Nullable(Nothing) or Array(Nothing) is useless.
 
         Field::Types::Which field_type = info.literal->value.getType();

--- a/tests/queries/0_stateless/00948_values_interpreter_template.reference
+++ b/tests/queries/0_stateless/00948_values_interpreter_template.reference
@@ -1,3 +1,7 @@
+1	Array(UInt64)	Tuple(Nullable(UInt64), Nullable(Int64), Nullable(Float64), Nullable(String), Array(Int64))	Array(Tuple(Nullable(UInt64), Array(UInt64)))
+2	Array(Int64)	Tuple(Nullable(UInt64), Nullable(Int64), Nullable(UInt64), Nullable(String), Array(UInt64))	Array(Tuple(Nullable(UInt64), Array(Nothing)))
+3	Array(UInt64)	Tuple(Nullable(UInt64), Nullable(Int64), Nullable(Float64), Nullable(String), Array(Int64))	Array(Tuple(Nullable(UInt64), Array(UInt64)))
+4	Array(Int64)	Tuple(Nullable(UInt64), Nullable(Int64), Nullable(Float64), Nullable(String), Array(Int64))	Array(Tuple(Nullable(UInt64), Array(UInt64)))
 1970-01-02	hello	6	-20	nan	[3,2,1]
 1970-01-03	world	7	2	inf	[]
 1970-01-04	test	6	-9223372036854775807	3.14	[5,4]

--- a/tests/queries/0_stateless/00948_values_interpreter_template.sql
+++ b/tests/queries/0_stateless/00948_values_interpreter_template.sql
@@ -1,12 +1,17 @@
+DROP TABLE IF EXISTS type_names;
 DROP TABLE IF EXISTS values_template;
 DROP TABLE IF EXISTS values_template_nullable;
 DROP TABLE IF EXISTS values_template_fallback;
 
+CREATE TABLE type_names (n UInt8, s1 String, s2 String, s3 String) ENGINE=Memory;
 CREATE TABLE values_template (d Date, s String, u UInt8, i Int64, f Float64, a Array(UInt8)) ENGINE = Memory;
 CREATE TABLE values_template_nullable (d Date, s Nullable(String), u Nullable(UInt8), a Array(Nullable(Float32))) ENGINE = Memory;
 CREATE TABLE values_template_fallback (n UInt8) ENGINE = Memory;
 
 SET input_format_values_interpret_expressions = 0;
+
+-- checks type deduction
+INSERT INTO type_names VALUES (1, toTypeName([1, 2]), toTypeName((256, -1, 3.14, 'str', [1, -1])), toTypeName([(1, [256]), (256, [1, 2])])), (2, toTypeName([1, -1]), toTypeName((256, -1, 3, 'str', [1, 2])), toTypeName([(256, []), (1, [])]));
 
 --(1, lower(replaceAll(_STR_1, 'o', 'a')), _NUM_1 + _NUM_2 + _NUM_3, round(_NUM_4 / _NUM_5), _NUM_6 * CAST(_STR_7, 'Int8'), _ARR_8);
 -- _NUM_1: UInt64 -> Int64 -> UInt64
@@ -22,13 +27,17 @@ INSERT INTO values_template_fallback VALUES ([1]); -- { clientError 43 }
 
 INSERT INTO values_template_fallback VALUES (CAST(1, 'UInt8')), (CAST('2', 'UInt8'));
 SET input_format_values_accurate_types_of_literals = 0;
+
+INSERT INTO type_names VALUES (3, toTypeName([1, 2]), toTypeName((256, -1, 3.14, 'str', [1, -1])), toTypeName([(1, [256]), (256, [1, 2])])), (4, toTypeName([1, -1]), toTypeName((256, -1, 3, 'str', [1, 2])), toTypeName([(256, []), (1, [])]));
 SET input_format_values_interpret_expressions = 1;
 INSERT INTO values_template_fallback VALUES (1 + 2), (3 + +04), (5 + 6);
 INSERT INTO values_template_fallback VALUES (+020), (+030), (+040);
 
+SELECT * FROM type_names ORDER BY n;
 SELECT * FROM values_template ORDER BY d;
 SELECT * FROM values_template_nullable ORDER BY d;
 SELECT * FROM values_template_fallback ORDER BY n;
+DROP TABLE type_names;
 DROP TABLE values_template;
 DROP TABLE values_template_nullable;
 DROP TABLE values_template_fallback;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed LOGICAL_ERROR caused by wrong type deduction of complex literals in Values input format.
