### PR TITLE
[RFC] Parse metadata stored in zookeeper before checking for equality

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeTableMetadata.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeTableMetadata.cpp
@@ -210,7 +210,7 @@ void ReplicatedMergeTreeTableMetadata::checkImmutableFieldsEquals(const Replicat
 
 }
 
-void ReplicatedMergeTreeTableMetadata::checkEquals(const ReplicatedMergeTreeTableMetadata & from_zk) const
+void ReplicatedMergeTreeTableMetadata::checkEquals(const ReplicatedMergeTreeTableMetadata & from_zk, const ColumnsDescription & columns, const Context & context) const
 {
 
     checkImmutableFieldsEquals(from_zk);
@@ -232,20 +232,24 @@ void ReplicatedMergeTreeTableMetadata::checkEquals(const ReplicatedMergeTreeTabl
                 ErrorCodes::METADATA_MISMATCH);
     }
 
-    if (skip_indices != from_zk.skip_indices)
+    String parsed_zk_skip_indices = IndicesDescription::parse(from_zk.skip_indices, columns, context).toString();
+    if (skip_indices != parsed_zk_skip_indices)
     {
         throw Exception(
                 "Existing table metadata in ZooKeeper differs in skip indexes."
                 " Stored in ZooKeeper: " + from_zk.skip_indices +
+                ", parsed from ZooKeeper: " + parsed_zk_skip_indices +
                 ", local: " + skip_indices,
                 ErrorCodes::METADATA_MISMATCH);
     }
 
-    if (constraints != from_zk.constraints)
+    String parsed_zk_constraints = ConstraintsDescription::parse(from_zk.constraints).toString();
+    if (constraints != parsed_zk_constraints)
     {
         throw Exception(
                 "Existing table metadata in ZooKeeper differs in constraints."
                 " Stored in ZooKeeper: " + from_zk.constraints +
+                ", parsed from ZooKeeper: " + parsed_zk_constraints +
                 ", local: " + constraints,
                        ErrorCodes::METADATA_MISMATCH);
     }

--- a/src/Storages/MergeTree/ReplicatedMergeTreeTableMetadata.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeTableMetadata.h
@@ -60,7 +60,7 @@ struct ReplicatedMergeTreeTableMetadata
         }
     };
 
-    void checkEquals(const ReplicatedMergeTreeTableMetadata & from_zk) const;
+    void checkEquals(const ReplicatedMergeTreeTableMetadata & from_zk, const ColumnsDescription & columns, const Context & context) const;
 
     Diff checkAndFindDiff(const ReplicatedMergeTreeTableMetadata & from_zk) const;
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -741,7 +741,7 @@ void StorageReplicatedMergeTree::checkTableStructure(const String & zookeeper_pr
     Coordination::Stat metadata_stat;
     String metadata_str = zookeeper->get(zookeeper_prefix + "/metadata", &metadata_stat);
     auto metadata_from_zk = ReplicatedMergeTreeTableMetadata::parse(metadata_str);
-    old_metadata.checkEquals(metadata_from_zk);
+    old_metadata.checkEquals(metadata_from_zk, getColumns(), global_context);
 
     Coordination::Stat columns_stat;
     auto columns_from_zk = ColumnsDescription::parse(zookeeper->get(zookeeper_prefix + "/columns", &columns_stat));

--- a/tests/integration/test_replicated_parse_zk_metadata/test.py
+++ b/tests/integration/test_replicated_parse_zk_metadata/test.py
@@ -1,0 +1,48 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance('node', with_zookeeper=True)
+
+@pytest.fixture(scope='module', autouse=True)
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+def test_replicated_engine_parse_metadata_on_attach():
+    node.query(
+    '''
+    CREATE TABLE data (
+        key Int,
+        INDEX key_idx0 key+0 TYPE minmax GRANULARITY 1,
+        INDEX key_idx1 key+1 TYPE minmax GRANULARITY 1
+    )
+    ENGINE = ReplicatedMergeTree('/ch/tables/default/data', 'node')
+    ORDER BY key;
+    ''')
+    node.query('DETACH TABLE data')
+
+    zk = cluster.get_kazoo_client('zoo1')
+    # Add **extra space between indices**, to check that it will be re-parsed
+    # and successfully accepted by the server.
+    #
+    # This metadata was obtain from the server without #11325
+    zk.set('/ch/tables/default/data/replicas/node/metadata', """
+metadata format version: 1
+date column: 
+sampling expression: 
+index granularity: 8192
+mode: 0
+sign column: 
+primary key: key
+data format version: 1
+partition key: 
+indices:  key_idx0 key + 0 TYPE minmax GRANULARITY 1,  key_idx1 key + 1 TYPE minmax GRANULARITY 1
+granularity bytes: 10485760
+
+""".lstrip())
+    node.query('ATTACH TABLE data')


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Parse metadata stored in zookeeper before checking for equality

After #11325 trailing whitespaces has been removed for data skipping
indices, and it may be different, if you have multiple skip indices,
and in this case new server will not load such tables, because metadata
will be different.

Fix this by re-parse metadata in zookeeper.

Cc: @alexey-milovidov 