### PR TITLE
Optimize redundant functions in ORDER BY

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -363,6 +363,7 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingBool, optimize_any_input, true, "removal of any operations from Any", 0) \
     M(SettingBool, optimize_arithmetic_operations_in_aggregate_functions, true, "Move arithmetic operations out of aggregation functions", 0) \
     M(SettingBool, optimize_duplicate_order_by_and_distinct, true, "Remove duplicate ORDER BY and DISTINCT if it's possible", 0) \
+    M(SettingBool, optimize_redundant_functions_in_order_by, true, "Remove functions from ORDER BY if its argument is also in ORDER BY", 0) \
     M(SettingBool, optimize_if_chain_to_miltiif, false, "Replace if(cond1, then1, if(cond2, ...)) chains to multiIf. Currently it's not beneficial for numeric types.", 0) \
     M(SettingBool, allow_experimental_alter_materialized_view_structure, false, "Allow atomic alter on Materialized views. Work in progress.", 0) \
     M(SettingBool, enable_early_constant_folding, true, "Enable query optimization where we analyze function and subqueries results and rewrite query if there're constants there", 0) \

--- a/src/Interpreters/RedundantFunctionsInOrderByVisitor.h
+++ b/src/Interpreters/RedundantFunctionsInOrderByVisitor.h
@@ -45,7 +45,7 @@ public:
         if (!identifier)
             return;
 
-        if (data.keys.count(identifier->shortName()))
+        if (data.keys.count(getIdentifierName(identifier)))
             data.should_be_erased = true;
     }
 

--- a/src/Interpreters/RedundantFunctionsInOrderByVisitor.h
+++ b/src/Interpreters/RedundantFunctionsInOrderByVisitor.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <Interpreters/InDepthNodeVisitor.h>
+#include <Parsers/ASTFunction.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTOrderByElement.h>
+#include <Parsers/ASTSelectQuery.h>
+
+namespace DB
+{
+
+class RedundantFunctionsInOrderByMatcher
+{
+public:
+    struct Data
+    {
+        std::unordered_set<String> & keys;
+        bool should_be_erased = false;
+        bool done = false;
+    };
+
+    static void visit(const ASTPtr & ast, Data & data)
+    {
+        auto * ast_function = ast->as<ASTFunction>();
+        if (ast_function)
+        {
+            visit(*ast_function, data);
+        }
+    }
+
+    static void visit(ASTFunction & ast_function, Data & data)
+    {
+        if (data.done)
+            return;
+
+        auto arguments = ast_function.arguments;
+
+        if (arguments->children.size() != 1)
+        {
+            data.done = true;
+            return;
+        }
+
+        auto * identifier = arguments->children[0]->as<ASTIdentifier>();
+        if (!identifier)
+            return;
+
+        if (data.keys.count(identifier->shortName()))
+            data.should_be_erased = true;
+    }
+
+    static bool needChildVisit(const ASTPtr &, const ASTPtr &)
+    {
+        return true;
+    }
+
+};
+
+using RedundantFunctionsInOrderByVisitor = InDepthNodeVisitor<RedundantFunctionsInOrderByMatcher, true>;
+
+}

--- a/src/Interpreters/SyntaxAnalyzer.cpp
+++ b/src/Interpreters/SyntaxAnalyzer.cpp
@@ -537,8 +537,8 @@ void optimizeRedundantFunctionsInOrderBy(ASTSelectQuery * select_query, bool opt
 
             if (auto * identifier = child->children[0]->as<ASTIdentifier>())
             {
-                if (!keys.count(identifier->shortName()))
-                    keys.insert(identifier->shortName());
+                if (!keys.count(getIdentifierName(identifier)))
+                    keys.insert(getIdentifierName(identifier));
                 else
                     continue;
             }

--- a/tests/performance/redundant_functions_in_order_by.xml
+++ b/tests/performance/redundant_functions_in_order_by.xml
@@ -4,6 +4,7 @@
     </preconditions>
 
     <query>SELECT CounterID, EventDate FROM hits_10m_single ORDER BY CounterID, exp(CounterID), sqrt(CounterID) FORMAT Null</query>
-    <query>SELECT CounterID, EventDate FROM hits_10m_single ORDER BY CounterID, EventDate, exp(CounterID), exp(EventDate) FORMAT Null</query>
+    <query>SELECT CounterID, EventDate FROM hits_10m_single ORDER BY CounterID, EventDate, exp(CounterID), toDateTime(EventDate) FORMAT Null</query>
+    <query>SELECT CounterID, EventDate FROM hits_10m_single ORDER BY CounterID DESC, EventDate DESC, exp(CounterID), toDateTime(EventDate) FORMAT Null</query>
 
 </test>

--- a/tests/performance/redundant_functions_in_order_by.xml
+++ b/tests/performance/redundant_functions_in_order_by.xml
@@ -1,0 +1,9 @@
+<test>
+    <preconditions>
+        <table_exists>hits_10m_single</table_exists>
+    </preconditions>
+
+    <query>SELECT CounterID, EventDate FROM hits_10m_single ORDER BY CounterID, exp(CounterID), sqrt(CounterID) FORMAT Null</query>
+    <query>SELECT CounterID, EventDate FROM hits_10m_single ORDER BY CounterID, EventDate, exp(CounterID), exp(EventDate) FORMAT Null</query>
+
+</test>

--- a/tests/queries/0_stateless/01323_redundant_functions_in_order_by.reference
+++ b/tests/queries/0_stateless/01323_redundant_functions_in_order_by.reference
@@ -1,0 +1,16 @@
+0
+1
+2
+0
+1
+2
+SELECT number AS x\nFROM numbers(3)\nORDER BY x ASC
+SELECT number AS x\nFROM numbers(3)\nORDER BY \n    exp(x) ASC,\n    x ASC
+0
+1
+2
+0
+1
+2
+SELECT number AS x\nFROM numbers(3)\nORDER BY \n    x ASC,\n    exp(x) ASC
+SELECT number AS x\nFROM numbers(3)\nORDER BY \n    exp(x) ASC,\n    x ASC

--- a/tests/queries/0_stateless/01323_redundant_functions_in_order_by.reference
+++ b/tests/queries/0_stateless/01323_redundant_functions_in_order_by.reference
@@ -1,14 +1,27 @@
 [0,1,2]
 [0,1,2]
+[0,1,2]
 0	0	0	0
 0	1	1	1
 2	2	2	2
 3	3	3	3
 4	0		0
 5	0		0
+0	0
+1	1
+2	2
+3	3
+0	0
+1	1
+2	2
+3	3
+SELECT groupArray(x)\nFROM \n(\n    SELECT number AS x\n    FROM numbers(3)\n    ORDER BY x ASC\n)
 SELECT groupArray(x)\nFROM \n(\n    SELECT number AS x\n    FROM numbers(3)\n    ORDER BY x ASC\n)
 SELECT groupArray(x)\nFROM \n(\n    SELECT number AS x\n    FROM numbers(3)\n    ORDER BY \n        exp(x) ASC,\n        x ASC\n)
-SELECT \n    key,\n    a,\n    b,\n    c\nFROM \n(\n    SELECT number + 2 AS key\n    FROM numbers(4)\n) AS s\nALL FULL OUTER JOIN dict_flat AS d USING (key)\nORDER BY \n    key ASC,\n    d.key ASC
+SELECT \n    key,\n    a,\n    b,\n    c\nFROM \n(\n    SELECT number + 2 AS key\n    FROM numbers(4)\n) AS s\nALL FULL OUTER JOIN test AS t USING (key)\nORDER BY \n    key ASC,\n    t.key ASC
+SELECT \n    key,\n    a\nFROM test\nORDER BY \n    key ASC,\n    a ASC
+SELECT \n    key,\n    a\nFROM test\nORDER BY \n    key ASC,\n    exp(key + a) ASC
+[0,1,2]
 [0,1,2]
 [0,1,2]
 0	0	0	0
@@ -17,6 +30,17 @@ SELECT \n    key,\n    a,\n    b,\n    c\nFROM \n(\n    SELECT number + 2 AS key
 3	3	3	3
 4	0		0
 5	0		0
+0	0
+1	1
+2	2
+3	3
+0	0
+1	1
+2	2
+3	3
 SELECT groupArray(x)\nFROM \n(\n    SELECT number AS x\n    FROM numbers(3)\n    ORDER BY \n        x ASC,\n        exp(x) ASC\n)
+SELECT groupArray(x)\nFROM \n(\n    SELECT number AS x\n    FROM numbers(3)\n    ORDER BY \n        x ASC,\n        exp(exp(x)) ASC\n)
 SELECT groupArray(x)\nFROM \n(\n    SELECT number AS x\n    FROM numbers(3)\n    ORDER BY \n        exp(x) ASC,\n        x ASC\n)
-SELECT \n    key,\n    a,\n    b,\n    c\nFROM \n(\n    SELECT number + 2 AS key\n    FROM numbers(4)\n) AS s\nALL FULL OUTER JOIN dict_flat AS d USING (key)\nORDER BY \n    key ASC,\n    d.key ASC
+SELECT \n    key,\n    a,\n    b,\n    c\nFROM \n(\n    SELECT number + 2 AS key\n    FROM numbers(4)\n) AS s\nALL FULL OUTER JOIN test AS t USING (key)\nORDER BY \n    key ASC,\n    t.key ASC
+SELECT \n    key,\n    a\nFROM test\nORDER BY \n    key ASC,\n    a ASC,\n    exp(key + a) ASC
+SELECT \n    key,\n    a\nFROM test\nORDER BY \n    key ASC,\n    exp(key + a) ASC

--- a/tests/queries/0_stateless/01323_redundant_functions_in_order_by.reference
+++ b/tests/queries/0_stateless/01323_redundant_functions_in_order_by.reference
@@ -1,16 +1,22 @@
-0
-1
-2
-0
-1
-2
-SELECT number AS x\nFROM numbers(3)\nORDER BY x ASC
-SELECT number AS x\nFROM numbers(3)\nORDER BY \n    exp(x) ASC,\n    x ASC
-0
-1
-2
-0
-1
-2
-SELECT number AS x\nFROM numbers(3)\nORDER BY \n    x ASC,\n    exp(x) ASC
-SELECT number AS x\nFROM numbers(3)\nORDER BY \n    exp(x) ASC,\n    x ASC
+[0,1,2]
+[0,1,2]
+0	0	0	0
+0	1	1	1
+2	2	2	2
+3	3	3	3
+4	0		0
+5	0		0
+SELECT groupArray(x)\nFROM \n(\n    SELECT number AS x\n    FROM numbers(3)\n    ORDER BY x ASC\n)
+SELECT groupArray(x)\nFROM \n(\n    SELECT number AS x\n    FROM numbers(3)\n    ORDER BY \n        exp(x) ASC,\n        x ASC\n)
+SELECT \n    key,\n    a,\n    b,\n    c\nFROM \n(\n    SELECT number + 2 AS key\n    FROM numbers(4)\n) AS s\nALL FULL OUTER JOIN dict_flat AS d USING (key)\nORDER BY \n    key ASC,\n    d.key ASC
+[0,1,2]
+[0,1,2]
+0	0	0	0
+0	1	1	1
+2	2	2	2
+3	3	3	3
+4	0		0
+5	0		0
+SELECT groupArray(x)\nFROM \n(\n    SELECT number AS x\n    FROM numbers(3)\n    ORDER BY \n        x ASC,\n        exp(x) ASC\n)
+SELECT groupArray(x)\nFROM \n(\n    SELECT number AS x\n    FROM numbers(3)\n    ORDER BY \n        exp(x) ASC,\n        x ASC\n)
+SELECT \n    key,\n    a,\n    b,\n    c\nFROM \n(\n    SELECT number + 2 AS key\n    FROM numbers(4)\n) AS s\nALL FULL OUTER JOIN dict_flat AS d USING (key)\nORDER BY \n    key ASC,\n    d.key ASC

--- a/tests/queries/0_stateless/01323_redundant_functions_in_order_by.sql
+++ b/tests/queries/0_stateless/01323_redundant_functions_in_order_by.sql
@@ -1,14 +1,39 @@
+DROP DATABASE IF EXISTS db_01115;
+CREATE DATABASE db_01115 Engine = Ordinary;
+
+USE db_01115;
+
+DROP DICTIONARY IF EXISTS dict_flat;
+
+CREATE TABLE t1 (key UInt64, a UInt8, b String, c Float64) ENGINE = MergeTree() ORDER BY key;
+INSERT INTO t1 SELECT number, number, toString(number), number from numbers(4);
+
+CREATE DICTIONARY dict_flat (key UInt64 DEFAULT 0, a UInt8 DEFAULT 42, b String DEFAULT 'x', c Float64 DEFAULT 42.0)
+PRIMARY KEY key
+SOURCE(CLICKHOUSE(HOST 'localhost' PORT 9000 USER 'default' TABLE 't1' PASSWORD '' DB 'db_01115'))
+LIFETIME(MIN 1 MAX 10)
+LAYOUT(FLAT());
+
 set enable_debug_queries = 1;
 set optimize_redundant_functions_in_order_by = 1;
 
-SELECT number as x FROM numbers(3) ORDER BY x, exp(x);
-SELECT number as x FROM numbers(3) ORDER BY exp(x), x;
-analyze SELECT number as x FROM numbers(3) ORDER BY x, exp(x);
-analyze SELECT number as x FROM numbers(3) ORDER BY exp(x), x;
+SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY x, exp(x));
+SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY exp(x), x);
+SELECT * FROM (SELECT number + 2 AS key FROM numbers(4)) s FULL JOIN dict_flat d USING(key) ORDER BY s.key, d.key;
+analyze SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY x, exp(x));
+analyze SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY exp(x), x);
+analyze SELECT * FROM (SELECT number + 2 AS key FROM numbers(4)) s FULL JOIN dict_flat d USING(key) ORDER BY s.key, d.key;
 
 set optimize_redundant_functions_in_order_by = 0;
 
-SELECT number as x FROM numbers(3) ORDER BY x, exp(x);
-SELECT number as x FROM numbers(3) ORDER BY exp(x), x;
-analyze SELECT number as x FROM numbers(3) ORDER BY x, exp(x);
-analyze SELECT number as x FROM numbers(3) ORDER BY exp(x), x;
+SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY x, exp(x));
+SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY exp(x), x);
+SELECT * FROM (SELECT number + 2 AS key FROM numbers(4)) s FULL JOIN dict_flat d USING(key) ORDER BY s.key, d.key;
+analyze SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY x, exp(x));
+analyze SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY exp(x), x);
+analyze SELECT * FROM (SELECT number + 2 AS key FROM numbers(4)) s FULL JOIN dict_flat d USING(key) ORDER BY s.key, d.key;
+
+DROP DICTIONARY dict_flat;
+
+DROP TABLE t1;
+DROP DATABASE IF EXISTS db_01115;

--- a/tests/queries/0_stateless/01323_redundant_functions_in_order_by.sql
+++ b/tests/queries/0_stateless/01323_redundant_functions_in_order_by.sql
@@ -1,39 +1,37 @@
-DROP DATABASE IF EXISTS db_01115;
-CREATE DATABASE db_01115 Engine = Ordinary;
+DROP TABLE IF EXISTS test;
 
-USE db_01115;
-
-DROP DICTIONARY IF EXISTS dict_flat;
-
-CREATE TABLE t1 (key UInt64, a UInt8, b String, c Float64) ENGINE = MergeTree() ORDER BY key;
-INSERT INTO t1 SELECT number, number, toString(number), number from numbers(4);
-
-CREATE DICTIONARY dict_flat (key UInt64 DEFAULT 0, a UInt8 DEFAULT 42, b String DEFAULT 'x', c Float64 DEFAULT 42.0)
-PRIMARY KEY key
-SOURCE(CLICKHOUSE(HOST 'localhost' PORT 9000 USER 'default' TABLE 't1' PASSWORD '' DB 'db_01115'))
-LIFETIME(MIN 1 MAX 10)
-LAYOUT(FLAT());
+CREATE TABLE test (key UInt64, a UInt8, b String, c Float64) ENGINE = MergeTree() ORDER BY key;
+INSERT INTO test SELECT number, number, toString(number), number from numbers(4);
 
 set enable_debug_queries = 1;
 set optimize_redundant_functions_in_order_by = 1;
 
 SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY x, exp(x));
+SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY x, exp(exp(x)));
 SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY exp(x), x);
-SELECT * FROM (SELECT number + 2 AS key FROM numbers(4)) s FULL JOIN dict_flat d USING(key) ORDER BY s.key, d.key;
+SELECT * FROM (SELECT number + 2 AS key FROM numbers(4)) s FULL JOIN test t USING(key) ORDER BY s.key, t.key;
+SELECT key, a FROM test ORDER BY key, a, exp(key + a);
+SELECT key, a FROM test ORDER BY key, exp(key + a);
 analyze SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY x, exp(x));
+analyze SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY x, exp(exp(x)));
 analyze SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY exp(x), x);
-analyze SELECT * FROM (SELECT number + 2 AS key FROM numbers(4)) s FULL JOIN dict_flat d USING(key) ORDER BY s.key, d.key;
+analyze SELECT * FROM (SELECT number + 2 AS key FROM numbers(4)) s FULL JOIN test t USING(key) ORDER BY s.key, t.key;
+analyze SELECT key, a FROM test ORDER BY key, a, exp(key + a);
+analyze SELECT key, a FROM test ORDER BY key, exp(key + a);
 
 set optimize_redundant_functions_in_order_by = 0;
 
 SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY x, exp(x));
+SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY x, exp(exp(x)));
 SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY exp(x), x);
-SELECT * FROM (SELECT number + 2 AS key FROM numbers(4)) s FULL JOIN dict_flat d USING(key) ORDER BY s.key, d.key;
+SELECT * FROM (SELECT number + 2 AS key FROM numbers(4)) s FULL JOIN test t USING(key) ORDER BY s.key, t.key;
+SELECT key, a FROM test ORDER BY key, a, exp(key + a);
+SELECT key, a FROM test ORDER BY key, exp(key + a);
 analyze SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY x, exp(x));
+analyze SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY x, exp(exp(x)));
 analyze SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY exp(x), x);
-analyze SELECT * FROM (SELECT number + 2 AS key FROM numbers(4)) s FULL JOIN dict_flat d USING(key) ORDER BY s.key, d.key;
+analyze SELECT * FROM (SELECT number + 2 AS key FROM numbers(4)) s FULL JOIN test t USING(key) ORDER BY s.key, t.key;
+analyze SELECT key, a FROM test ORDER BY key, a, exp(key + a);
+analyze SELECT key, a FROM test ORDER BY key, exp(key + a);
 
-DROP DICTIONARY dict_flat;
-
-DROP TABLE t1;
-DROP DATABASE IF EXISTS db_01115;
+DROP TABLE test;

--- a/tests/queries/0_stateless/01323_redundant_functions_in_order_by.sql
+++ b/tests/queries/0_stateless/01323_redundant_functions_in_order_by.sql
@@ -1,0 +1,14 @@
+set enable_debug_queries = 1;
+set optimize_redundant_functions_in_order_by = 1;
+
+SELECT number as x FROM numbers(3) ORDER BY x, exp(x);
+SELECT number as x FROM numbers(3) ORDER BY exp(x), x;
+analyze SELECT number as x FROM numbers(3) ORDER BY x, exp(x);
+analyze SELECT number as x FROM numbers(3) ORDER BY exp(x), x;
+
+set optimize_redundant_functions_in_order_by = 0;
+
+SELECT number as x FROM numbers(3) ORDER BY x, exp(x);
+SELECT number as x FROM numbers(3) ORDER BY exp(x), x;
+analyze SELECT number as x FROM numbers(3) ORDER BY x, exp(x);
+analyze SELECT number as x FROM numbers(3) ORDER BY exp(x), x;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Optimize ORDER BY x, f(x) to ORDER by x

Detailed description / Documentation draft:

Optimize ORDER BY if it has x followed by f(x)