### PR TITLE
Lock structure exclusively only if settings changed

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -3359,6 +3359,7 @@ void StorageReplicatedMergeTree::alter(
             changed_nodes.emplace_back(zookeeper_path, "metadata", new_metadata_str);
 
         /// Perform settings update locally
+        if (ast_to_str(metadata.settings_ast) != ast_to_str(settings_ast))
         {
             lockStructureExclusively(table_lock_holder, query_context.getCurrentQueryId());
             auto old_metadata = getInMemoryMetadata();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix excess lock for structure during alter.
