### PR TITLE
Update replacingmergetree.md

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/replacingmergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/replacingmergetree.md
@@ -5,7 +5,7 @@ toc_title: ReplacingMergeTree
 
 # ReplacingMergeTree {#replacingmergetree}
 
-The engine differs from [MergeTree](../../../engines/table-engines/mergetree-family/mergetree.md#table_engines-mergetree) in that it removes duplicate entries with the same primary key value (or more accurately, with the same [sorting key](../../../engines/table-engines/mergetree-family/mergetree.md) value).
+The engine differs from [MergeTree](../../../engines/table-engines/mergetree-family/mergetree.md#table_engines-mergetree) in that it removes duplicate entries with the same [sorting key](../../../engines/table-engines/mergetree-family/mergetree.md) value.
 
 Data deduplication occurs only during a merge. Merging occurs in the background at an unknown time, so you can’t plan for it. Some of the data may remain unprocessed. Although you can run an unscheduled merge using the `OPTIMIZE` query, don’t count on using it, because the `OPTIMIZE` query will read and write a large amount of data.
 
@@ -33,7 +33,7 @@ For a description of request parameters, see [request description](../../../sql-
 
 -   `ver` — column with version. Type `UInt*`, `Date` or `DateTime`. Optional parameter.
 
-    When merging, `ReplacingMergeTree` from all the rows with the same primary key leaves only one:
+    When merging, `ReplacingMergeTree` from all the rows with the same sorting key leaves only one:
 
     -   Last in the selection, if `ver` not set.
     -   With the maximum version, if `ver` specified.


### PR DESCRIPTION
removes confusion
Changelog category:
- Documentation


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Removes confusion between Primary Key and Sorting Key in merge logic description for ReplacingMergeTree.

...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.
