### PR TITLE
Apply all SETTINGS clauses as early as possible.

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -226,7 +226,6 @@ InterpreterSelectQuery::InterpreterSelectQuery(
 {
     checkStackSize();
 
-    initSettings();
     const Settings & settings = context->getSettingsRef();
 
     if (settings.max_subquery_depth && options.subquery_depth > settings.max_subquery_depth)
@@ -2041,14 +2040,6 @@ void InterpreterSelectQuery::executeSubqueriesInSetsAndJoins(QueryPipeline & pip
 void InterpreterSelectQuery::ignoreWithTotals()
 {
     getSelectQuery().group_by_with_totals = false;
-}
-
-
-void InterpreterSelectQuery::initSettings()
-{
-    auto & query = getSelectQuery();
-    if (query.settings())
-        InterpreterSetQuery(query.settings(), *context).executeForCurrentContext();
 }
 
 }

--- a/src/Interpreters/InterpreterSelectQuery.h
+++ b/src/Interpreters/InterpreterSelectQuery.h
@@ -145,14 +145,6 @@ private:
 
     void executeRollupOrCube(QueryPipeline & pipeline, Modificator modificator);
 
-    /** If there is a SETTINGS section in the SELECT query, then apply settings from it.
-      *
-      * Section SETTINGS - settings for a specific query.
-      * Normally, the settings can be passed in other ways, not inside the query.
-      * But the use of this section is justified if you need to set the settings for one subquery.
-      */
-    void initSettings();
-
     SelectQueryOptions options;
     ASTPtr query_ptr;
     std::shared_ptr<Context> context;

--- a/tests/queries/1_stateful/00157_settings_memory_usage.sql
+++ b/tests/queries/1_stateful/00157_settings_memory_usage.sql
@@ -1,0 +1,1 @@
+select max(CounterID + UserID) from test.hits settings max_memory_usage = 1; -- { serverError 241 }

--- a/tests/queries/1_stateful/00157_settings_memory_usage.sql
+++ b/tests/queries/1_stateful/00157_settings_memory_usage.sql
@@ -1,1 +1,1 @@
-select max(CounterID + UserID) from test.hits settings max_memory_usage = 1; -- { serverError 241 }
+select max(CounterID - UserID) from test.hits settings max_memory_usage = 1; -- { serverError 241 }


### PR DESCRIPTION
Among other things, this fixes max_memory_usage in settings clause --
didn't work before, because the memory limit is set when the query is
added to the process list, and the settings were applied after that,
when an individual select query interpreter is initialized.

Do not backport, because it's not important and I'm somewhat uneasy about something breaking -- the situation with settings is far from clear.

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Apply `max_memory_usage` from `SETTINGS` clause, where it didn't have any effect before. Fixes https://github.com/ClickHouse/ClickHouse/issues/11763