### PR TITLE
Preserve column alias with optimize_aggregators_of_group_by_keys

### DIFF
--- a/src/Interpreters/AggregateFunctionOfGroupByKeysVisitor.h
+++ b/src/Interpreters/AggregateFunctionOfGroupByKeysVisitor.h
@@ -14,7 +14,7 @@
 namespace DB
 {
 
-///recursive traversal and check for optimizeAggregateFunctionsOfGroupByKeys
+/// Recursive traversal and check for optimizeAggregateFunctionsOfGroupByKeys
 struct KeepAggregateFunctionMatcher
 {
     struct Data
@@ -91,7 +91,7 @@ public:
 
     static void visit(ASTPtr & ast, Data & data)
     {
-        ///check if function is min/max/any
+        /// Check if function is min/max/any
         auto * function_node = ast->as<ASTFunction>();
         if (function_node && (function_node->name == "min" || function_node->name == "max" ||
                               function_node->name == "any" || function_node->name == "anyLast"))
@@ -100,10 +100,12 @@ public:
             KeepAggregateFunctionVisitor::Data keep_data{data.group_by_keys, keep_aggregator};
             KeepAggregateFunctionVisitor(keep_data).visit(function_node->arguments);
 
+            /// Place argument of an aggregate function instead of function
             if (!keep_aggregator)
             {
-                ///place argument of an aggregate function instead of function
+                String alias = function_node->alias;
                 ast = (function_node->arguments->children[0])->clone();
+                ast->setAlias(alias);
             }
         }
     }

--- a/tests/queries/0_stateless/01321_aggregate_functions_of_group_by_keys.reference
+++ b/tests/queries/0_stateless/01321_aggregate_functions_of_group_by_keys.reference
@@ -45,9 +45,12 @@
 18
 20
 24
-SELECT \n    number % 2,\n    number % 3\nFROM numbers(10000000)\nGROUP BY \n    number % 2,\n    number % 3\nORDER BY \n    min(number % 2) AS a ASC,\n    max(number % 3) AS b ASC
-SELECT \n    number % 2,\n    number % 3\nFROM numbers(10000000)\nGROUP BY \n    number % 2,\n    number % 3\nORDER BY \n    any(number % 2) AS a ASC,\n    anyLast(number % 3) AS b ASC
-SELECT (number % 5) * (number % 7)\nFROM numbers(10000000)\nGROUP BY \n    number % 7,\n    number % 5\nORDER BY max((number % 5) * (number % 7)) AS a ASC
+0
+0
+SELECT \n    number % 2 AS a,\n    number % 3 AS b\nFROM numbers(10000000)\nGROUP BY \n    number % 2,\n    number % 3\nORDER BY \n    min(number % 2) AS a ASC,\n    max(number % 3) AS b ASC
+SELECT \n    number % 2 AS a,\n    number % 3 AS b\nFROM numbers(10000000)\nGROUP BY \n    number % 2,\n    number % 3\nORDER BY \n    any(number % 2) AS a ASC,\n    anyLast(number % 3) AS b ASC
+SELECT (number % 5) * (number % 7) AS a\nFROM numbers(10000000)\nGROUP BY \n    number % 7,\n    number % 5\nORDER BY max((number % 5) * (number % 7)) AS a ASC
+SELECT foo\nFROM \n(\n    SELECT number AS foo\n    FROM numbers(1)\n    GROUP BY number\n)
 0	0
 0	1
 0	2
@@ -95,6 +98,8 @@ SELECT (number % 5) * (number % 7)\nFROM numbers(10000000)\nGROUP BY \n    numbe
 18
 20
 24
+0
 SELECT \n    min(number % 2) AS a,\n    max(number % 3) AS b\nFROM numbers(10000000)\nGROUP BY \n    number % 2,\n    number % 3\nORDER BY \n    a ASC,\n    b ASC
 SELECT \n    any(number % 2) AS a,\n    anyLast(number % 3) AS b\nFROM numbers(10000000)\nGROUP BY \n    number % 2,\n    number % 3\nORDER BY \n    a ASC,\n    b ASC
 SELECT max((number % 5) * (number % 7)) AS a\nFROM numbers(10000000)\nGROUP BY \n    number % 7,\n    number % 5\nORDER BY a ASC
+SELECT foo\nFROM \n(\n    SELECT anyLast(number) AS foo\n    FROM numbers(1)\n    GROUP BY number\n)

--- a/tests/queries/0_stateless/01321_aggregate_functions_of_group_by_keys.sql
+++ b/tests/queries/0_stateless/01321_aggregate_functions_of_group_by_keys.sql
@@ -5,17 +5,22 @@ set optimize_any_input = 0;
 SELECT min(number % 2) AS a, max(number % 3) AS b FROM numbers(10000000) GROUP BY number % 2, number % 3 ORDER BY a, b;
 SELECT any(number % 2) AS a, anyLast(number % 3) AS b FROM numbers(10000000) GROUP BY number % 2, number % 3 ORDER BY a, b;
 SELECT max((number % 5) * (number % 7)) AS a FROM numbers(10000000) GROUP BY number % 7, number % 5 ORDER BY a;
+SELECT foo FROM (SELECT anyLast(number) AS foo FROM numbers(1) GROUP BY number);
+SELECT anyLast(number) FROM numbers(1) GROUP BY number;
 
 analyze SELECT min(number % 2) AS a, max(number % 3) AS b FROM numbers(10000000) GROUP BY number % 2, number % 3 ORDER BY a, b;
 analyze SELECT any(number % 2) AS a, anyLast(number % 3) AS b FROM numbers(10000000) GROUP BY number % 2, number % 3 ORDER BY a, b;
 analyze SELECT max((number % 5) * (number % 7)) AS a FROM numbers(10000000) GROUP BY number % 7, number % 5 ORDER BY a;
+analyze SELECT foo FROM (SELECT anyLast(number) AS foo FROM numbers(1) GROUP BY number);
 
 set optimize_aggregators_of_group_by_keys = 0;
 
 SELECT min(number % 2) AS a, max(number % 3) AS b FROM numbers(10000000) GROUP BY number % 2, number % 3 ORDER BY a, b;
 SELECT any(number % 2) AS a, anyLast(number % 3) AS b FROM numbers(10000000) GROUP BY number % 2, number % 3 ORDER BY a, b;
 SELECT max((number % 5) * (number % 7)) AS a FROM numbers(10000000) GROUP BY number % 7, number % 5 ORDER BY a;
+SELECT foo FROM (SELECT anyLast(number) AS foo FROM numbers(1) GROUP BY number);
 
 analyze SELECT min(number % 2) AS a, max(number % 3) AS b FROM numbers(10000000) GROUP BY number % 2, number % 3 ORDER BY a, b;
 analyze SELECT any(number % 2) AS a, anyLast(number % 3) AS b FROM numbers(10000000) GROUP BY number % 2, number % 3 ORDER BY a, b;
 analyze SELECT max((number % 5) * (number % 7)) AS a FROM numbers(10000000) GROUP BY number % 7, number % 5 ORDER BY a;
+analyze SELECT foo FROM (SELECT anyLast(number) AS foo FROM numbers(1) GROUP BY number);


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Preserve column alias with optimize_aggregators_of_group_by_keys (`optimize_aggregators_of_group_by_keys` has been introduced in #11667)

Cc: @xPoSx 

<details>

HEAD:
- 3010b47489edba694a517a0b408a3a136cb880b7

</details>