### PR TITLE
Make MMAP_THRESHOLD volatile to prevent inlining

### DIFF
--- a/src/Common/Allocator.h
+++ b/src/Common/Allocator.h
@@ -58,14 +58,14 @@
   * in the implementation of alloc/realloc.
   */
 #ifdef NDEBUG
-    __attribute__((__weak__)) extern const size_t MMAP_THRESHOLD = 64 * (1ULL << 20);
+    __attribute__((__weak__)) extern const volatile size_t MMAP_THRESHOLD = 64 * (1ULL << 20);
 #else
     /**
       * In debug build, use small mmap threshold to reproduce more memory
       * stomping bugs. Along with ASLR it will hopefully detect more issues than
       * ASan. The program may fail due to the limit on number of memory mappings.
       */
-    __attribute__((__weak__)) extern const size_t MMAP_THRESHOLD = 4096;
+    __attribute__((__weak__)) extern const volatile size_t MMAP_THRESHOLD = 4096;
 #endif
 
 static constexpr size_t MMAP_MIN_ALIGNMENT = 4096;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Without this fix MMAP_THRESHOLD may be inlined in Allocator::allocNoTrack resulting in using the original ClickHouse value instead of provided by third-party code.