### PR TITLE
delete injective functions inside uniq

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -361,7 +361,7 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingBool, optimize_trivial_count_query, true, "Process trivial 'SELECT count() FROM table' query from metadata.", 0) \
     M(SettingUInt64, mutations_sync, 0, "Wait for synchronous execution of ALTER TABLE UPDATE/DELETE queries (mutations). 0 - execute asynchronously. 1 - wait current server. 2 - wait all replicas if they exist.", 0) \
     M(SettingBool, optimize_any_input, true, "removal of any operations from Any", 0) \
-    M(SettingBool, injective_functions_inside_uniq, true, "deleting all injective functions inside uniq", 0) \
+    M(SettingBool, optimize_injective_functions_inside_uniq, true, "deleting all injective functions inside uniq", 0) \
     M(SettingBool, optimize_arithmetic_operations_in_aggregate_functions, true, "Move arithmetic operations out of aggregation functions", 0) \
     M(SettingBool, optimize_duplicate_order_by_and_distinct, true, "Remove duplicate ORDER BY and DISTINCT if it's possible", 0) \
     M(SettingBool, optimize_if_chain_to_miltiif, false, "Replace if(cond1, then1, if(cond2, ...)) chains to multiIf. Currently it's not beneficial for numeric types.", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -361,6 +361,7 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingBool, optimize_trivial_count_query, true, "Process trivial 'SELECT count() FROM table' query from metadata.", 0) \
     M(SettingUInt64, mutations_sync, 0, "Wait for synchronous execution of ALTER TABLE UPDATE/DELETE queries (mutations). 0 - execute asynchronously. 1 - wait current server. 2 - wait all replicas if they exist.", 0) \
     M(SettingBool, optimize_any_input, true, "removal of any operations from Any", 0) \
+    M(SettingBool, injective_functions_inside_uniq, true, "deleting all injective functions inside uniq", 0) \
     M(SettingBool, optimize_arithmetic_operations_in_aggregate_functions, true, "Move arithmetic operations out of aggregation functions", 0) \
     M(SettingBool, optimize_duplicate_order_by_and_distinct, true, "Remove duplicate ORDER BY and DISTINCT if it's possible", 0) \
     M(SettingBool, optimize_if_chain_to_miltiif, false, "Replace if(cond1, then1, if(cond2, ...)) chains to multiIf. Currently it's not beneficial for numeric types.", 0) \

--- a/src/Interpreters/InjectiveFunctionsInsideUniq.cpp
+++ b/src/Interpreters/InjectiveFunctionsInsideUniq.cpp
@@ -26,7 +26,7 @@ static void removeInjectiveFuctions(ASTPtr & ast, size_t child_number, Injective
         if (exact_child->as<ASTFunction>()->arguments->children.size() == 1)
             ast->as<ASTFunction>()->arguments->children[child_number] = (exact_child->as<ASTFunction>()->arguments->children[0])->clone();
         if (ast->as<ASTFunction>() && exact_child->as<ASTFunction>()->arguments->children.size() == 1)
-            killInjectiveFuctions(ast, child_number, data);
+            removeInjectiveFuctions(ast, child_number, data);
     }
 }
 

--- a/src/Interpreters/InjectiveFunctionsInsideUniq.h
+++ b/src/Interpreters/InjectiveFunctionsInsideUniq.h
@@ -9,7 +9,8 @@ namespace DB
 class InjectiveFunctionsInsideUniqMatcher
 {
 public:
-    struct Data {
+    struct Data
+    {
         const Context & context;
     };
 

--- a/src/Interpreters/InjectiveFunctionsInsideUniq.h
+++ b/src/Interpreters/InjectiveFunctionsInsideUniq.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <Parsers/IAST.h>
+#include <Interpreters/InDepthNodeVisitor.h>
+
+namespace DB
+{
+
+class InjectiveFunctionsInsideUniqMatcher
+{
+public:
+    struct Data {
+        const Context & context;
+    };
+
+    static void visit(ASTPtr & ast, Data data);
+    static bool needChildVisit(const ASTPtr & node, const ASTPtr & child);
+};
+using InjectiveFunctionsInsideUniqVisitor = InDepthNodeVisitor<InjectiveFunctionsInsideUniqMatcher, true>;
+}

--- a/src/Interpreters/SyntaxAnalyzer.cpp
+++ b/src/Interpreters/SyntaxAnalyzer.cpp
@@ -990,7 +990,7 @@ SyntaxAnalyzerResultPtr SyntaxAnalyzer::analyzeSelect(
         optimizeAnyInput(query, settings.optimize_any_input);
 
         ///remove injective functions inside uniq
-        optimizeInjectiveFunctionsInsideUniq(query, context, settings.injective_functions_inside_uniq);
+        optimizeInjectiveFunctionsInsideUniq(query, context, settings.optimize_injective_functions_inside_uniq);
 
         /// Eliminate min/max/any aggregators of functions of GROUP BY keys
         optimizeAggregateFunctionsOfGroupByKeys(select_query, settings.optimize_aggregators_of_group_by_keys);

--- a/src/Interpreters/SyntaxAnalyzer.cpp
+++ b/src/Interpreters/SyntaxAnalyzer.cpp
@@ -585,14 +585,11 @@ void optimizeAnyInput(ASTPtr & query, bool optimize_any_input)
     }
 }
 
-void optimizeInjectiveFunctionsInsideUniq(ASTPtr & query, const Context & context, bool optimize_injective_functions_inside_uniq)
+void optimizeInjectiveFunctionsInsideUniq(ASTPtr & query, const Context & context)
 {
-    if (optimize_injective_functions_inside_uniq)
-    {
-        /// Removing arithmetic operations from functions
-        InjectiveFunctionsInsideUniqVisitor::Data data = {context};
-        InjectiveFunctionsInsideUniqVisitor(data).visit(query);
-    }
+    /// Removing arithmetic operations from functions
+    InjectiveFunctionsInsideUniqVisitor::Data data = {context};
+    InjectiveFunctionsInsideUniqVisitor(data).visit(query);
 }
 
 void getArrayJoinedColumns(ASTPtr & query, SyntaxAnalyzerResult & result, const ASTSelectQuery * select_query,
@@ -990,7 +987,8 @@ SyntaxAnalyzerResultPtr SyntaxAnalyzer::analyzeSelect(
         optimizeAnyInput(query, settings.optimize_any_input);
 
         ///remove injective functions inside uniq
-        optimizeInjectiveFunctionsInsideUniq(query, context, settings.optimize_injective_functions_inside_uniq);
+        if (settings.optimize_injective_functions_inside_uniq)
+            optimizeInjectiveFunctionsInsideUniq(query, context);
 
         /// Eliminate min/max/any aggregators of functions of GROUP BY keys
         optimizeAggregateFunctionsOfGroupByKeys(select_query, settings.optimize_aggregators_of_group_by_keys);

--- a/src/Interpreters/ya.make
+++ b/src/Interpreters/ya.make
@@ -60,6 +60,7 @@ SRCS(
     HashJoin.cpp
     IdentifierSemantic.cpp
     IExternalLoadable.cpp
+    InjectiveFunctionsInsideUniq.cpp
     InJoinSubqueriesPreprocessor.cpp
     inplaceBlockConversions.cpp
     InternalTextLogsQueue.cpp

--- a/tests/performance/injective_functions_inside_uniq.xml
+++ b/tests/performance/injective_functions_inside_uniq.xml
@@ -1,0 +1,7 @@
+<test>
+
+    <query>SELECT uniq(negate(negate(negate(number)))) FROM numbers(500000000)</query>
+
+    <query>SELECT uniq(hex(hex(number))) FROM numbers(500000000)</query>
+
+</test>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
removal of injective functions from `uniq()`

Detailed description / Documentation draft:
recursive search for uniq function and try to delete injective functions inside it
