### PR TITLE
Remove dependency on tzdata

### DIFF
--- a/base/common/DateLUT.cpp
+++ b/base/common/DateLUT.cpp
@@ -75,7 +75,7 @@ std::string determineDefaultTimeZone()
 
     try
     {
-        tz_database_path = fs::canonical(tz_database_path);
+        tz_database_path = fs::weakly_canonical(tz_database_path);
 
         /// The tzdata file exists. If it is inside the tz_database_dir,
         /// then the relative path is the time zone id.
@@ -91,7 +91,7 @@ std::string determineDefaultTimeZone()
             if (!tz_file_path.is_absolute())
                 tz_file_path = tz_database_path / tz_file_path;
 
-            tz_file_path = fs::canonical(tz_file_path);
+            tz_file_path = fs::weakly_canonical(tz_file_path);
 
             fs::path relative_path = tz_file_path.lexically_relative(tz_database_path);
             if (!relative_path.empty() && *relative_path.begin() != ".." && *relative_path.begin() != ".")

--- a/debian/control
+++ b/debian/control
@@ -28,7 +28,7 @@ Description: Client binary for ClickHouse
 
 Package: clickhouse-common-static
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, tzdata
+Depends: ${shlibs:Depends}, ${misc:Depends}
 Suggests: clickhouse-common-static-dbg
 Replaces: clickhouse-common, clickhouse-server-base
 Provides: clickhouse-common, clickhouse-server-base

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get update \
             clickhouse-client=$version \
             clickhouse-common-static=$version \
             locales \
-            tzdata \
     && rm -rf /var/lib/apt/lists/* /var/cache/debconf \
     && apt-get clean
 

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -21,7 +21,6 @@ RUN apt-get update \
             locales \
             ca-certificates \
             wget \
-            tzdata \
     && rm -rf \
         /var/lib/apt/lists/* \
         /var/cache/debconf \

--- a/docker/test/integration/base/Dockerfile
+++ b/docker/test/integration/base/Dockerfile
@@ -17,8 +17,7 @@ RUN apt-get update \
         odbc-postgresql \
         sqlite3 \
         curl \
-        tar \
-        tzdata
+        tar
 RUN rm -rf \
         /var/lib/apt/lists/* \
         /var/cache/debconf \


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove dependency on `tzdata`: do not fail if `/usr/share/zoneinfo` directory does not exist. Note that all timezones work in ClickHouse even without tzdata installed in system.


Notes:

```
docker run --rm --volume /home/milovidov/work/ClickHouse:/ClickHouse -it ubuntu:bionic /bin/bash
/ClickHouse/build/programs/clickhouse server -C /ClickHouse/programs/server/config.xml
TZ=Asia/Shanghai /ClickHouse/build/programs/clickhouse server -C /ClickHouse/programs/server/config.xml
```