### PR TITLE
Improve error message for Decimal CAST

### DIFF
--- a/src/DataTypes/DataTypeDecimalBase.cpp
+++ b/src/DataTypes/DataTypeDecimalBase.cpp
@@ -8,7 +8,6 @@
 #include <Formats/ProtobufWriter.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
-#include <IO/readDecimalText.h>
 #include <Interpreters/Context.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/IAST.h>

--- a/src/IO/readDecimalText.h
+++ b/src/IO/readDecimalText.h
@@ -15,13 +15,13 @@ namespace ErrorCodes
 /// Use 'digits' input as max allowed meaning decimal digits in result. Place actual number of meaning digits in 'digits' output.
 /// Do not care about decimal scale, only about meaning digits in decimal text representation.
 template <bool _throw_on_error, typename T>
-inline bool readDigits(ReadBuffer & buf, T & x, unsigned int & digits, int & exponent, bool digits_only = false)
+inline bool readDigits(ReadBuffer & buf, T & x, uint32_t & digits, int32_t & exponent, bool digits_only = false)
 {
     x = 0;
     exponent = 0;
-    unsigned int max_digits = digits;
+    uint32_t max_digits = digits;
     digits = 0;
-    unsigned int places = 0;
+    uint32_t places = 0;
     typename T::NativeType sign = 1;
     bool leading_zeroes = true;
     bool after_point = false;
@@ -131,19 +131,19 @@ inline bool readDigits(ReadBuffer & buf, T & x, unsigned int & digits, int & exp
 }
 
 template <typename T>
-inline void readDecimalText(ReadBuffer & buf, T & x, unsigned int precision, unsigned int & scale, bool digits_only = false)
+inline void readDecimalText(ReadBuffer & buf, T & x, uint32_t precision, uint32_t & scale, bool digits_only = false)
 {
-    unsigned int digits = precision;
-    int exponent;
+    uint32_t digits = precision;
+    int32_t exponent;
     readDigits<true>(buf, x, digits, exponent, digits_only);
 
-    if (static_cast<int>(digits) + exponent > static_cast<int>(precision - scale))
+    if (static_cast<int32_t>(digits) + exponent > static_cast<int32_t>(precision - scale))
         throw Exception(fmt::format(
             "Decimal value is too big: {} digits were read: {}e{}."
             " Expected to read decimal with scale {} and precision {}",
             digits, x, exponent, scale, precision), ErrorCodes::ARGUMENT_OUT_OF_BOUND);
 
-    if (static_cast<int>(scale) + exponent < 0)
+    if (static_cast<int32_t>(scale) + exponent < 0)
         throw Exception(fmt::format(
             "Decimal value has too large number of digits after point: {} digits were read: {}e{}."
             " Expected to read decimal with scale {} and precision {}",
@@ -153,14 +153,14 @@ inline void readDecimalText(ReadBuffer & buf, T & x, unsigned int precision, uns
 }
 
 template <typename T>
-inline bool tryReadDecimalText(ReadBuffer & buf, T & x, unsigned int precision, unsigned int & scale)
+inline bool tryReadDecimalText(ReadBuffer & buf, T & x, uint32_t precision, uint32_t & scale)
 {
-    unsigned int digits = precision;
-    int exponent;
+    uint32_t digits = precision;
+    int32_t exponent;
 
     if (!readDigits<false>(buf, x, digits, exponent, true) ||
-        static_cast<int>(digits) + exponent > static_cast<int>(precision - scale) ||
-        static_cast<int>(scale) + exponent < 0)
+        static_cast<int32_t>(digits) + exponent > static_cast<int32_t>(precision - scale) ||
+        static_cast<int32_t>(scale) + exponent < 0)
         return false;
 
     scale += exponent;
@@ -168,7 +168,7 @@ inline bool tryReadDecimalText(ReadBuffer & buf, T & x, unsigned int precision, 
 }
 
 template <typename T>
-inline void readCSVDecimalText(ReadBuffer & buf, T & x, unsigned int precision, unsigned int & scale)
+inline void readCSVDecimalText(ReadBuffer & buf, T & x, uint32_t precision, uint32_t & scale)
 {
     if (buf.eof())
         throwReadAfterEOF();


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Slightly improve diagnostic of reading decimal from string. This closes #10202.


Detailed description / Documentation draft:

But the issue remain.
Consider the following query:
`SELECT CAST('1.1111111111111' AS Decimal(10, 5))`

PostgreSQL:
1.11111

MySQL:
1.11111

ClickHouse:
Decimal value has too large number of digits after point: 14 digits were read: 11111111111111e-13. Expected to read decimal with scale 5 and precision 18.

`SELECT CAST('1.1111111111111' AS Decimal(10, 10))`

PostgreSQL:
ERROR: numeric field overflow Detail: A field with precision 10, scale 10 must round to an absolute value less than 1.

MySQL:
0.9999999999

ClickHouse:
Decimal value has too large number of digits after point: 14 digits were read: 11111111111111e-13. Expected to read decimal with scale 10 and precision 18.