### PR TITLE
Move MMAP_THRESHOLD definition to .cpp file.

### DIFF
--- a/src/Common/Allocator.cpp
+++ b/src/Common/Allocator.cpp
@@ -5,12 +5,12 @@
   * in third-party code.
   */
 #ifdef NDEBUG
-    __attribute__((__weak__)) extern const size_t MMAP_THRESHOLD = 64 * (1ULL << 20);
+    __attribute__((__weak__)) const size_t MMAP_THRESHOLD = 64 * (1ULL << 20);
 #else
     /**
       * In debug build, use small mmap threshold to reproduce more memory
       * stomping bugs. Along with ASLR it will hopefully detect more issues than
       * ASan. The program may fail due to the limit on number of memory mappings.
       */
-    __attribute__((__weak__)) extern const size_t MMAP_THRESHOLD = 4096;
+    __attribute__((__weak__)) const size_t MMAP_THRESHOLD = 4096;
 #endif

--- a/src/Common/Allocator.cpp
+++ b/src/Common/Allocator.cpp
@@ -3,14 +3,17 @@
 /** Keep definition of this constant in cpp file; otherwise its value
   * is inlined into allocator code making it impossible to override it
   * in third-party code.
+  *
+  * Note: extern may seem redundant, but is actually needed due to bug in GCC.
+  * See also: https://gcc.gnu.org/legacy-ml/gcc-help/2017-12/msg00021.html
   */
 #ifdef NDEBUG
-    __attribute__((__weak__)) const size_t MMAP_THRESHOLD = 64 * (1ULL << 20);
+    __attribute__((__weak__)) extern const size_t MMAP_THRESHOLD = 64 * (1ULL << 20);
 #else
     /**
       * In debug build, use small mmap threshold to reproduce more memory
       * stomping bugs. Along with ASLR it will hopefully detect more issues than
       * ASan. The program may fail due to the limit on number of memory mappings.
       */
-    __attribute__((__weak__)) const size_t MMAP_THRESHOLD = 4096;
+    __attribute__((__weak__)) extern const size_t MMAP_THRESHOLD = 4096;
 #endif

--- a/src/Common/Allocator.cpp
+++ b/src/Common/Allocator.cpp
@@ -1,0 +1,16 @@
+#include "Allocator.h"
+
+/** Keep definition of this constant in cpp file; otherwise its value
+  * is inlined into allocator code making it impossible to override it
+  * in third-party code.
+  */
+#ifdef NDEBUG
+    __attribute__((__weak__)) extern const size_t MMAP_THRESHOLD = 64 * (1ULL << 20);
+#else
+    /**
+      * In debug build, use small mmap threshold to reproduce more memory
+      * stomping bugs. Along with ASLR it will hopefully detect more issues than
+      * ASan. The program may fail due to the limit on number of memory mappings.
+      */
+    __attribute__((__weak__)) extern const size_t MMAP_THRESHOLD = 4096;
+#endif

--- a/src/Common/Allocator.h
+++ b/src/Common/Allocator.h
@@ -57,16 +57,7 @@
   * third-party applications which may already use own allocator doing mmaps
   * in the implementation of alloc/realloc.
   */
-#ifdef NDEBUG
-    __attribute__((__weak__)) extern const size_t MMAP_THRESHOLD = 64 * (1ULL << 20);
-#else
-    /**
-      * In debug build, use small mmap threshold to reproduce more memory
-      * stomping bugs. Along with ASLR it will hopefully detect more issues than
-      * ASan. The program may fail due to the limit on number of memory mappings.
-      */
-    __attribute__((__weak__)) extern const size_t MMAP_THRESHOLD = 4096;
-#endif
+__attribute__((__weak__)) extern const size_t MMAP_THRESHOLD;
 
 static constexpr size_t MMAP_MIN_ALIGNMENT = 4096;
 static constexpr size_t MALLOC_MIN_ALIGNMENT = 8;

--- a/src/Common/Allocator.h
+++ b/src/Common/Allocator.h
@@ -57,7 +57,7 @@
   * third-party applications which may already use own allocator doing mmaps
   * in the implementation of alloc/realloc.
   */
-__attribute__((__weak__)) extern const size_t MMAP_THRESHOLD;
+extern const size_t MMAP_THRESHOLD;
 
 static constexpr size_t MMAP_MIN_ALIGNMENT = 4096;
 static constexpr size_t MALLOC_MIN_ALIGNMENT = 8;

--- a/src/Common/ya.make
+++ b/src/Common/ya.make
@@ -23,6 +23,7 @@ INCLUDE(${ARCADIA_ROOT}/clickhouse/cmake/yandex/ya.make.versions.inc)
 SRCS(
     ActionLock.cpp
     AlignedBuffer.cpp
+    Allocator.cpp
     checkStackSize.cpp
     ClickHouseRevision.cpp
     Config/AbstractConfigurationComparison.cpp


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Without this fix MMAP_THRESHOLD may be inlined in Allocator::allocNoTrack resulting in using the original ClickHouse value instead of provided by third-party code.