### PR TITLE
Slightly relax the validation of ODBC connection string

### DIFF
--- a/docker/test/integration/compose/docker_compose_postgres.yml
+++ b/docker/test/integration/compose/docker_compose_postgres.yml
@@ -7,3 +7,7 @@ services:
             POSTGRES_PASSWORD: mysecretpassword
         ports:
           - 5432:5432
+        networks:
+          default:
+            aliases:
+              - postgre-sql.local

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -668,8 +668,6 @@ services:
             - {env_file}
         security_opt:
             - label:disable
-        links:
-            - postgres1:postgre-sql.local
         {networks}
             {app_net}
                 {ipv4_address}

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -668,6 +668,8 @@ services:
             - {env_file}
         security_opt:
             - label:disable
+        links:
+            - postgres1:postgre-sql.local
         {networks}
             {app_net}
                 {ipv4_address}

--- a/tests/integration/test_odbc_interaction/test.py
+++ b/tests/integration/test_odbc_interaction/test.py
@@ -223,8 +223,9 @@ def test_postgres_insert(started_cluster):
     conn = get_postgres_conn()
     conn.cursor().execute("truncate table clickhouse.test_table")
 
-    # Also test with Servername containing '.' and '-' symbols (see links in docker-compose template in helpers/cluster.py)
-    # This is needed to check parsing, validation and reconstruction of connection string.
+    # Also test with Servername containing '.' and '-' symbols (defined in
+    # postgres .yml file). This is needed to check parsing, validation and
+    # reconstruction of connection string.
 
     node1.query("create table pg_insert (column1 UInt8, column2 String) engine=ODBC('DSN=postgresql_odbc;Servername=postgre-sql.local', 'clickhouse', 'test_table')")
     node1.query("insert into pg_insert values (1, 'hello'), (2, 'world')")


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Slightly relax the validation of ODBC connection string. If the hostname or username contains only word characters along with `.` and `-`, don't put it into curly braces. It is needed, because some ODBC drivers (e.g. PostgreSQL) don't understand when hostname is enclosed in curly braces.