### PR TITLE
Don't allow arrayJoin inside higher order functions

### DIFF
--- a/src/Functions/array/FunctionArrayMapped.h
+++ b/src/Functions/array/FunctionArrayMapped.h
@@ -33,7 +33,8 @@ namespace ErrorCodes
   * arrayMap(x1,...,xn -> expression, array1,...,arrayn) - apply the expression to each element of the array (or set of parallel arrays).
   * arrayFilter(x -> predicate, array) - leave in the array only the elements for which the expression is true.
   *
-  * For some functions arrayCount, arrayExists, arrayAll, an overload of the form f(array) is available, which works in the same way as f(x -> x, array).
+  * For some functions arrayCount, arrayExists, arrayAll, an overload of the form f(array) is available,
+  *  which works in the same way as f(x -> x, array).
   *
   * See the example of Impl template parameter in arrayMap.cpp
   */

--- a/tests/queries/0_stateless/01330_array_join_in_higher_order_function.sql
+++ b/tests/queries/0_stateless/01330_array_join_in_higher_order_function.sql
@@ -1,0 +1,1 @@
+SELECT arrayMap(x -> arrayJoin([x, 1]), [1, 2]); -- { serverError 36 }


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Don't allow arrayJoin inside higher order functions. It was leading to broken protocol synchronization. This closes #3933.
