### PR TITLE
fix PostgreSQL protocol build failure

### DIFF
--- a/src/Core/PostgreSQLProtocol.h
+++ b/src/Core/PostgreSQLProtocol.h
@@ -233,6 +233,10 @@ public:
     /** Size of the message in bytes including message length part (4 bytes) */
     virtual Int32 size() const = 0;
 
+    ISerializable() = default;
+
+    ISerializable(const ISerializable &) = default;
+
     virtual ~ISerializable() = default;
 };
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
```
error: definition of implicit copy constructor for 'ISerializable' is deprecated because it has a user-declared destructor [-Werror,-Wdeprecated]
```