### PR TITLE
Addition to #11214

### DIFF
--- a/src/DataTypes/DataTypesNumber.cpp
+++ b/src/DataTypes/DataTypesNumber.cpp
@@ -65,6 +65,21 @@ void registerDataTypeNumbers(DataTypeFactory & factory)
     factory.registerAlias("DOUBLE", "Float64", DataTypeFactory::CaseInsensitive);
 
     factory.registerAlias("DOUBLE PRECISION", "Float64", DataTypeFactory::CaseInsensitive);
+
+    /// MySQL
+    factory.registerAlias("TINYINT SIGNED", "Int8", DataTypeFactory::CaseInsensitive);
+    factory.registerAlias("INT1 SIGNED", "Int8", DataTypeFactory::CaseInsensitive);
+    factory.registerAlias("SMALLINT SIGNED", "Int16", DataTypeFactory::CaseInsensitive);
+    factory.registerAlias("INT SIGNED", "Int32", DataTypeFactory::CaseInsensitive);
+    factory.registerAlias("INTEGER SIGNED", "Int32", DataTypeFactory::CaseInsensitive);
+    factory.registerAlias("BIGINT SIGNED", "Int64", DataTypeFactory::CaseInsensitive);
+    factory.registerAlias("TINYINT UNSIGNED", "UInt8", DataTypeFactory::CaseInsensitive);
+    factory.registerAlias("INT1 UNSIGNED", "UInt8", DataTypeFactory::CaseInsensitive);
+    factory.registerAlias("SMALLINT UNSIGNED", "UInt16", DataTypeFactory::CaseInsensitive);
+    factory.registerAlias("INT UNSIGNED", "UInt32", DataTypeFactory::CaseInsensitive);
+    factory.registerAlias("INTEGER UNSIGNED", "UInt32", DataTypeFactory::CaseInsensitive);
+    factory.registerAlias("BIGINT UNSIGNED", "UInt64", DataTypeFactory::CaseInsensitive);
+
 }
 
 }

--- a/src/Parsers/ParserDataType.cpp
+++ b/src/Parsers/ParserDataType.cpp
@@ -55,6 +55,14 @@ bool ParserDataType::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         if (ParserKeyword("PRECISION").ignore(pos))
             type_name_suffix = "PRECISION";
     }
+    else if (type_name_upper.find("INT") != std::string::npos)
+    {
+        /// Support SIGNED and UNSIGNED integer type modifiers for compatibility with MySQL
+        if (ParserKeyword("SIGNED").ignore(pos))
+            type_name_suffix = "SIGNED";
+        else if (ParserKeyword("UNSIGNED").ignore(pos))
+            type_name_suffix = "UNSIGNED";
+    }
 
     if (!type_name_suffix.empty())
         type_name = type_name_upper + " " + type_name_suffix;

--- a/tests/queries/0_stateless/01144_multiword_data_types.reference
+++ b/tests/queries/0_stateless/01144_multiword_data_types.reference
@@ -1,3 +1,5 @@
 CREATE TABLE default.multiword_types\n(\n    `a` Float64,\n    `b` Float64,\n    `c` String DEFAULT \'str\',\n    `d` String,\n    `e` String COMMENT \'comment\',\n    `f` String,\n    `g` String,\n    `h` String DEFAULT toString(a) COMMENT \'comment\',\n    `i` String,\n    `j` String,\n    `k` String,\n    `l` String,\n    `m` String,\n    `n` String,\n    `o` String,\n    `p` String\n)\nENGINE = Memory
 Tuple(Float64, Float64, String, String, String, String, String, String, String, String, String, String, String, String, String, String)
-42	42
+CREATE TABLE default.unsigned_types\n(\n    `a` Int8,\n    `b` Int8,\n    `c` Int16,\n    `d` Int32,\n    `e` Int32,\n    `f` Int64,\n    `g` UInt8,\n    `h` UInt8,\n    `i` UInt16,\n    `j` UInt32,\n    `k` UInt32,\n    `l` UInt64\n)\nENGINE = Memory
+Tuple(Int8, Int8, Int16, Int32, Int32, Int64, UInt8, UInt8, UInt16, UInt32, UInt32, UInt64)
+42	42	255	-1

--- a/tests/queries/0_stateless/01144_multiword_data_types.sql
+++ b/tests/queries/0_stateless/01144_multiword_data_types.sql
@@ -1,4 +1,5 @@
 DROP TABLE IF EXISTS multiword_types;
+DROP TABLE IF EXISTS unsigned_types;
 
 CREATE TABLE multiword_types (
     a DOUBLE,
@@ -24,6 +25,27 @@ SHOW CREATE TABLE multiword_types;
 INSERT INTO multiword_types(a) VALUES (1);
 SELECT toTypeName((*,)) FROM multiword_types;
 
-SELECT CAST('42' AS DOUBLE PRECISION), CAST(42, 'NATIONAL CHARACTER VARYING');
+CREATE TABLE unsigned_types (
+    a TINYINT  SIGNED,
+    b INT1     SIGNED,
+    c SMALLINT SIGNED,
+    d INT      SIGNED,
+    e INTEGER  SIGNED,
+    f BIGINT   SIGNED,
+    g TINYINT  UNSIGNED,
+    h INT1     UNSIGNED,
+    i SMALLINT UNSIGNED,
+    j INT      UNSIGNED,
+    k INTEGER  UNSIGNED,
+    l BIGINT   UNSIGNED
+) ENGINE=Memory;
+
+SHOW CREATE TABLE unsigned_types;
+
+INSERT INTO unsigned_types(a) VALUES (1);
+SELECT toTypeName((*,)) FROM unsigned_types;
+
+SELECT CAST('42' AS DOUBLE PRECISION), CAST(42, 'NATIONAL CHARACTER VARYING'), CAST(-1 AS tinyint  UnSiGnEd), CAST(65535, ' sMaLlInT  signed ');
 
 DROP TABLE multiword_types;
+DROP TABLE unsigned_types;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support `SIGNED` and `UNSIGNED` modifiers of standard integer types (`BIGINT`, `INT`, ...) for compatibility with MySQL.

Related to #11214
