### PR TITLE
Support sumWithOverflow as SimpleAggregateFunction

### DIFF
--- a/docs/en/sql-reference/data-types/simpleaggregatefunction.md
+++ b/docs/en/sql-reference/data-types/simpleaggregatefunction.md
@@ -9,6 +9,7 @@ The following aggregate functions are supported:
 -   [`min`](../../sql-reference/aggregate-functions/reference/min.md#agg_function-min)
 -   [`max`](../../sql-reference/aggregate-functions/reference/max.md#agg_function-max)
 -   [`sum`](../../sql-reference/aggregate-functions/reference/sum.md#agg_function-sum)
+-   [`sumWithOverflow`](../../sql-reference/aggregate-functions/reference/sumwithoverflow.md#sumwithoverflowx)
 -   [`groupBitAnd`](../../sql-reference/aggregate-functions/reference/groupbitand.md#groupbitand)
 -   [`groupBitOr`](../../sql-reference/aggregate-functions/reference/groupbitor.md#groupbitor)
 -   [`groupBitXor`](../../sql-reference/aggregate-functions/reference/groupbitxor.md#groupbitxor)

--- a/src/DataTypes/DataTypeCustomSimpleAggregateFunction.cpp
+++ b/src/DataTypes/DataTypeCustomSimpleAggregateFunction.cpp
@@ -30,7 +30,9 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-static const std::vector<String> supported_functions{"any", "anyLast", "min", "max", "sum", "groupBitAnd", "groupBitOr", "groupBitXor", "sumMap", "groupArrayArray", "groupUniqArrayArray"};
+static const std::vector<String> supported_functions{"any", "anyLast", "min",
+    "max", "sum", "sumWithOverflow", "groupBitAnd", "groupBitOr", "groupBitXor",
+    "sumMap", "groupArrayArray", "groupUniqArrayArray"};
 
 
 String DataTypeCustomSimpleAggregateFunction::getName() const

--- a/tests/queries/0_stateless/00915_simple_aggregate_function.reference
+++ b/tests/queries/0_stateless/00915_simple_aggregate_function.reference
@@ -42,3 +42,4 @@ SimpleAggregateFunction(sum, Float64)
 1	1	2	2.2.2.2	3	([1,2,3],[2,1,1])	[1,2,2,3,4]	[4,2,1,3]
 10	2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222	20	20.20.20.20	5	([2,3,4],[2,1,1])	[]	[]
 SimpleAggregateFunction(anyLast, Nullable(String))	SimpleAggregateFunction(anyLast, LowCardinality(Nullable(String)))	SimpleAggregateFunction(anyLast, IPv4)	SimpleAggregateFunction(groupBitOr, UInt32)	SimpleAggregateFunction(sumMap, Tuple(Array(Int32), Array(Int64)))	SimpleAggregateFunction(groupArrayArray, Array(Int32))	SimpleAggregateFunction(groupUniqArrayArray, Array(Int32))
+with_overflow	1	0

--- a/tests/queries/0_stateless/00915_simple_aggregate_function.sql
+++ b/tests/queries/0_stateless/00915_simple_aggregate_function.sql
@@ -1,3 +1,5 @@
+set optimize_throw_if_noop = 1;
+
 -- basic test
 drop table if exists simple;
 
@@ -41,3 +43,15 @@ select toTypeName(nullable_str),toTypeName(low_str),toTypeName(ip),toTypeName(st
 optimize table simple final;
 
 drop table simple;
+
+create table with_overflow (
+    id UInt64,
+    s SimpleAggregateFunction(sumWithOverflow, UInt8)
+) engine AggregatingMergeTree order by id;
+
+insert into with_overflow select 1, 1 from numbers(256);
+
+optimize table with_overflow final;
+
+select 'with_overflow', * from with_overflow;
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow to use `sumWithOverflow` as `SimpleAggregateFunction`. Closes https://github.com/ClickHouse/ClickHouse/issues/8053
