### PR TITLE
Add docs about non-linux binaries

### DIFF
--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -94,13 +94,15 @@ For production environments, it’s recommended to use the latest `stable`-versi
 
 To run ClickHouse inside Docker follow the guide on [Docker Hub](https://hub.docker.com/r/yandex/clickhouse-server/). Those images use official `deb` packages inside.
 
-### From Precompiled Binaries for Non-Standard Systems {#from-binaries-non-linux}
+### From Precompiled Binaries for Non-Standard Environments {#from-binaries-non-linux}
 
 For non-Linux operating systems and for AArch64 CPU arhitecture, ClickHouse builds are provided as a cross-compiled binary from the latest commit of the `master` branch (with a few hours delay).
 
-- [macOS](https://clickhouse-builds.s3.yandex.net/master/macos/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/macos/clickhouse'`
-- [FreeBSD](https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse'`
-- [AArch64](https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse'`
+- [macOS](https://clickhouse-builds.s3.yandex.net/master/macos/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/macos/clickhouse' && chmod a+x ./clickhouse`
+- [FreeBSD](https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse' && chmod a+x ./clickhouse`
+- [AArch64](https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse' && chmod a+x ./clickhouse`
+
+After downloading, you can use the `clickhouse client` to connect to the server, or` clickhouse local` to process local data. To run `clickhouse server`, you have to additionally download [server](https://github.com/ClickHouse/ClickHouse/blob/master/programs/server/config.xml) and [users](https://github.com/ClickHouse/ClickHouse/blob/ master/Programs/server/users.xml) configuration files from GitHub.
 
 These builds are not recommended for use in production environments because they are less thoroughly tested, but you can do so on your own risk. They also have only a subset of ClickHouse features available.
 

--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -90,19 +90,19 @@ sudo clickhouse-client-$LATEST_VERSION/install/doinst.sh
 
 For production environments, it’s recommended to use the latest `stable`-version. You can find its number on GitHub page https://github.com/ClickHouse/ClickHouse/tags with postfix `-stable`.
 
-### From Precompiled Binaries for Non-Linux OS {#from-binaries-non-linux}
-
-For non-Linux operating systems, ClickHouse builds are provided as a cross-compiled binary from the latest commit of the `master` branch (with a few hours delay).
-
-- macOS — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/macos/clickhouse'`
-- AArch64 — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse'`
-- FreeBSD — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse'`
-
-These builds are not recommended for use in production environments because they are less thoroughly tested, but you can do so on your own risk. They also have only a subset of ClickHouse features available.
-
 ### From Docker Image {#from-docker-image}
 
 To run ClickHouse inside Docker follow the guide on [Docker Hub](https://hub.docker.com/r/yandex/clickhouse-server/). Those images use official `deb` packages inside.
+
+### From Precompiled Binaries for Non-Standard Systems {#from-binaries-non-linux}
+
+For non-Linux operating systems and for AArch64 CPU arhitecture, ClickHouse builds are provided as a cross-compiled binary from the latest commit of the `master` branch (with a few hours delay).
+
+- [macOS](https://clickhouse-builds.s3.yandex.net/master/macos/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/macos/clickhouse'`
+- [FreeBSD](https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse'`
+- [AArch64](https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse'`
+
+These builds are not recommended for use in production environments because they are less thoroughly tested, but you can do so on your own risk. They also have only a subset of ClickHouse features available.
 
 ### From Sources {#from-sources}
 

--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -98,9 +98,9 @@ To run ClickHouse inside Docker follow the guide on [Docker Hub](https://hub.doc
 
 For non-Linux operating systems and for AArch64 CPU arhitecture, ClickHouse builds are provided as a cross-compiled binary from the latest commit of the `master` branch (with a few hours delay).
 
-- [macOS](https://clickhouse-builds.s3.yandex.net/master/macos/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/macos/clickhouse' && chmod a+x ./clickhouse`
-- [FreeBSD](https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse' && chmod a+x ./clickhouse`
-- [AArch64](https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse' && chmod a+x ./clickhouse`
+- [macOS](https://builds.clickhouse.tech/master/macos/clickhouse) — `curl -O 'https://builds.clickhouse.tech/master/macos/clickhouse' && chmod a+x ./clickhouse`
+- [FreeBSD](https://builds.clickhouse.tech/master/freebsd/clickhouse) — `curl -O 'https://builds.clickhouse.tech/master/freebsd/clickhouse' && chmod a+x ./clickhouse`
+- [AArch64](https://builds.clickhouse.tech/master/aarch64/clickhouse) — `curl -O 'https://builds.clickhouse.tech/master/aarch64/clickhouse' && chmod a+x ./clickhouse`
 
 After downloading, you can use the `clickhouse client` to connect to the server, or `clickhouse local` to process local data. To run `clickhouse server`, you have to additionally download [server](https://github.com/ClickHouse/ClickHouse/blob/master/programs/server/config.xml) and [users](https://github.com/ClickHouse/ClickHouse/blob/master/programs/server/users.xml) configuration files from GitHub.
 

--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -98,7 +98,7 @@ For non-Linux operating systems, ClickHouse builds are provided as a cross-compi
 - AArch64 — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse'`
 - FreeBSD — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse'`
 
-These builds are not recommended for use in production environment. Not all ClickHouse features are present in them.
+These builds are not recommended for use in production environments because they are less thoroughly tested, but you can do so on your own risk. They also have only a subset of ClickHouse features available.
 
 ### From Docker Image {#from-docker-image}
 

--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -92,7 +92,7 @@ For production environments, it’s recommended to use the latest `stable`-versi
 
 ### From precompiled binaries for non-Linux OS {#from-binaries-non-linux}
 
-For non-Linux distributions, ClickHouse builds are provided as a cross-compiled binary from the latest commit of the master branch.
+For non-Linux operating systems, ClickHouse builds are provided as a cross-compiled binary from the latest commit of the master branch.
 
 - macOS — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/macos/clickhouse'`
 - AArch64 — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse'`

--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -90,7 +90,7 @@ sudo clickhouse-client-$LATEST_VERSION/install/doinst.sh
 
 For production environments, it’s recommended to use the latest `stable`-version. You can find its number on GitHub page https://github.com/ClickHouse/ClickHouse/tags with postfix `-stable`.
 
-### From precompiled binaries for non-Linux OS {#from-binaries-non-linux}
+### From Precompiled Binaries for Non-Linux OS {#from-binaries-non-linux}
 
 For non-Linux operating systems, ClickHouse builds are provided as a cross-compiled binary from the latest commit of the `master` branch (with a few hours delay).
 

--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -102,7 +102,7 @@ For non-Linux operating systems and for AArch64 CPU arhitecture, ClickHouse buil
 - [FreeBSD](https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse' && chmod a+x ./clickhouse`
 - [AArch64](https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse' && chmod a+x ./clickhouse`
 
-After downloading, you can use the `clickhouse client` to connect to the server, or` clickhouse local` to process local data. To run `clickhouse server`, you have to additionally download [server](https://github.com/ClickHouse/ClickHouse/blob/master/programs/server/config.xml) and [users](https://github.com/ClickHouse/ClickHouse/blob/ master/Programs/server/users.xml) configuration files from GitHub.
+After downloading, you can use the `clickhouse client` to connect to the server, or `clickhouse local` to process local data. To run `clickhouse server`, you have to additionally download [server](https://github.com/ClickHouse/ClickHouse/blob/master/programs/server/config.xml) and [users](https://github.com/ClickHouse/ClickHouse/blob/master/programs/server/users.xml) configuration files from GitHub.
 
 These builds are not recommended for use in production environments because they are less thoroughly tested, but you can do so on your own risk. They also have only a subset of ClickHouse features available.
 

--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -98,7 +98,7 @@ For non-Linux distributions, ClickHouse builds are provided as a cross-compiled 
 - AArch64 — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse'`
 - FreeBSD — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse'`
 
-These builds are not recommended for use in production. Not all ClickHouse features are present in them.
+These builds are not recommended for use in production environment. Not all ClickHouse features are present in them.
 
 ### From Docker Image {#from-docker-image}
 

--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -92,7 +92,7 @@ For production environments, it’s recommended to use the latest `stable`-versi
 
 ### From precompiled binaries for non-Linux OS {#from-binaries-non-linux}
 
-For non-Linux operating systems, ClickHouse builds are provided as a cross-compiled binary from the latest commit of the master branch.
+For non-Linux operating systems, ClickHouse builds are provided as a cross-compiled binary from the latest commit of the `master` branch (with a few hours delay).
 
 - macOS — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/macos/clickhouse'`
 - AArch64 — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse'`

--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -90,6 +90,16 @@ sudo clickhouse-client-$LATEST_VERSION/install/doinst.sh
 
 For production environments, it’s recommended to use the latest `stable`-version. You can find its number on GitHub page https://github.com/ClickHouse/ClickHouse/tags with postfix `-stable`.
 
+### From precompiled binaries for non-Linux OS {#from-binaries-non-linux}
+
+For non-Linux distributions, ClickHouse builds are provided as a cross-compiled binary from the latest commit of the master branch.
+
+- macOS — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/macos/clickhouse'`
+- AArch64 — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse'`
+- FreeBSD — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse'`
+
+These builds are not recommended for use in production. Not all ClickHouse features are present in them.
+
 ### From Docker Image {#from-docker-image}
 
 To run ClickHouse inside Docker follow the guide on [Docker Hub](https://hub.docker.com/r/yandex/clickhouse-server/). Those images use official `deb` packages inside.

--- a/docs/ru/getting-started/install.md
+++ b/docs/ru/getting-started/install.md
@@ -80,7 +80,7 @@ sudo clickhouse-client-$LATEST_VERSION/install/doinst.sh
 
 ### Из бинарников для других операционных систем {#from-binaries-non-linux}
 
-Для не Linux дистрибутивов сборки ClickHouse предоставляются в виде кросс-компилированного бинарника с последнего коммита ветки master.
+Для других операционных систем сборки ClickHouse предоставляются в виде кросс-компилированного бинарника с последнего коммита ветки master.
 
 - macOS — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/macos/clickhouse'`
 - AArch64 — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse'`

--- a/docs/ru/getting-started/install.md
+++ b/docs/ru/getting-started/install.md
@@ -78,19 +78,19 @@ sudo clickhouse-client-$LATEST_VERSION/install/doinst.sh
 
 Для production окружений рекомендуется использовать последнюю `stable`-версию. Её номер также можно найти на github с на вкладке https://github.com/ClickHouse/ClickHouse/tags c постфиксом `-stable`.
 
-### Из бинарников для других операционных систем {#from-binaries-non-linux}
-
-Для других операционных систем сборки ClickHouse предоставляются в виде кросс-компилированного бинарника с последнего коммита ветки master.
-
-- macOS — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/macos/clickhouse'`
-- AArch64 — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse'`
-- FreeBSD — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse'`
-
-Данные сборки не рекомендуются для использования в продакшене. В них присутствуют не все возможности ClickHouse.
-
 ### Из Docker образа {#from-docker-image}
 
 Для запуска ClickHouse в Docker нужно следовать инструкции на [Docker Hub](https://hub.docker.com/r/yandex/clickhouse-server/). Внутри образов используются официальные `deb` пакеты.
+
+### Из исполняемых файлов для нестандартных окружений {#from-binaries-non-linux}
+
+Для других операционных систем и арихитектуры AArch64, сборки ClickHouse предоставляются в виде кросс-компилированного бинарника с последнего коммита ветки master (с задержкой в несколько часов).
+
+- [macOS](https://clickhouse-builds.s3.yandex.net/master/macos/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/macos/clickhouse'`
+- [AArch64](https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse'`
+- [FreeBSD](https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse'`
+
+Данные сборки не рекомендуются для использования в продакшене, так как они недостаточно тщательно протестированны. Также, в них присутствуют не все возможности ClickHouse.
 
 ### Из исходного кода {#from-sources}
 

--- a/docs/ru/getting-started/install.md
+++ b/docs/ru/getting-started/install.md
@@ -86,9 +86,9 @@ sudo clickhouse-client-$LATEST_VERSION/install/doinst.sh
 
 Для других операционных систем и арихитектуры AArch64, сборки ClickHouse предоставляются в виде кросс-компилированного бинарника с последнего коммита ветки master (с задержкой в несколько часов).
 
-- [macOS](https://clickhouse-builds.s3.yandex.net/master/macos/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/macos/clickhouse' && chmod a+x ./clickhouse`
-- [AArch64](https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse' && chmod a+x ./clickhouse`
-- [FreeBSD](https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse' && chmod a+x ./clickhouse`
+- [macOS](https://builds.clickhouse.tech/master/macos/clickhouse) — `curl -O 'https://builds.clickhouse.tech/master/macos/clickhouse' && chmod a+x ./clickhouse`
+- [AArch64](https://builds.clickhouse.tech/master/aarch64/clickhouse) — `curl -O 'https://builds.clickhouse.tech/master/aarch64/clickhouse' && chmod a+x ./clickhouse`
+- [FreeBSD](https://builds.clickhouse.tech/master/freebsd/clickhouse) — `curl -O 'https://builds.clickhouse.tech/master/freebsd/clickhouse' && chmod a+x ./clickhouse`
 
 После скачивания, можно воспользоваться `clickhouse client` для подключения к серверу, или `clickhouse local` для обработки локальных данных. Для запуска `clickhouse server` необходимо скачать конфигурационные файлы [сервера](https://github.com/ClickHouse/ClickHouse/blob/master/programs/server/config.xml) и [пользователей](https://github.com/ClickHouse/ClickHouse/blob/master/programs/server/users.xml) с GitHub.
 

--- a/docs/ru/getting-started/install.md
+++ b/docs/ru/getting-started/install.md
@@ -90,7 +90,7 @@ sudo clickhouse-client-$LATEST_VERSION/install/doinst.sh
 - [AArch64](https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse' && chmod a+x ./clickhouse`
 - [FreeBSD](https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse' && chmod a+x ./clickhouse`
 
-После скачивания, можно воспользоваться `clickhouse client` для подключения к серверу, или `clickhouse local` для обработки локальных данных. Для запуска в режиме сервера конфигурационные файлы [сервера](https://github.com/ClickHouse/ClickHouse/blob/master/programs/server/config.xml) и [пользователей](https://github.com/ClickHouse/ClickHouse/blob/master/programs/server/users.xml) можно скачать с GitHub.
+После скачивания, можно воспользоваться `clickhouse client` для подключения к серверу, или `clickhouse local` для обработки локальных данных. Для запуска `clickhouse server` необходимо скачать конфигурационные файлы [сервера](https://github.com/ClickHouse/ClickHouse/blob/master/programs/server/config.xml) и [пользователей](https://github.com/ClickHouse/ClickHouse/blob/master/programs/server/users.xml) с GitHub.
 
 Данные сборки не рекомендуются для использования в продакшене, так как они недостаточно тщательно протестированны. Также, в них присутствуют не все возможности ClickHouse.
 

--- a/docs/ru/getting-started/install.md
+++ b/docs/ru/getting-started/install.md
@@ -78,6 +78,16 @@ sudo clickhouse-client-$LATEST_VERSION/install/doinst.sh
 
 Для production окружений рекомендуется использовать последнюю `stable`-версию. Её номер также можно найти на github с на вкладке https://github.com/ClickHouse/ClickHouse/tags c постфиксом `-stable`.
 
+### Из бинарников для других операционных систем {#from-binaries-non-linux}
+
+Для не Linux дистрибутивов сборки ClickHouse предоставляются в виде кросс-компилированного бинарника с последнего коммита ветки master.
+
+- macOS — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/macos/clickhouse'`
+- AArch64 — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse'`
+- FreeBSD — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse'`
+
+Данные сборки не рекомендуются для использования в продакшене. В них присутствуют не все возможности ClickHouse.
+
 ### Из Docker образа {#from-docker-image}
 
 Для запуска ClickHouse в Docker нужно следовать инструкции на [Docker Hub](https://hub.docker.com/r/yandex/clickhouse-server/). Внутри образов используются официальные `deb` пакеты.

--- a/docs/ru/getting-started/install.md
+++ b/docs/ru/getting-started/install.md
@@ -86,9 +86,11 @@ sudo clickhouse-client-$LATEST_VERSION/install/doinst.sh
 
 Для других операционных систем и арихитектуры AArch64, сборки ClickHouse предоставляются в виде кросс-компилированного бинарника с последнего коммита ветки master (с задержкой в несколько часов).
 
-- [macOS](https://clickhouse-builds.s3.yandex.net/master/macos/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/macos/clickhouse'`
-- [AArch64](https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse'`
-- [FreeBSD](https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse'`
+- [macOS](https://clickhouse-builds.s3.yandex.net/master/macos/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/macos/clickhouse' && chmod a+x ./clickhouse`
+- [AArch64](https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/aarch64/clickhouse' && chmod a+x ./clickhouse`
+- [FreeBSD](https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse) — `curl -O 'https://clickhouse-builds.s3.yandex.net/master/freebsd/clickhouse' && chmod a+x ./clickhouse`
+
+После скачивания, можно воспользоваться `clickhouse client` для подключения к серверу, или `clickhouse local` для обработки локальных данных. Для запуска в режиме сервера конфигурационные файлы [сервера](https://github.com/ClickHouse/ClickHouse/blob/master/programs/server/config.xml) и [пользователей](https://github.com/ClickHouse/ClickHouse/blob/master/programs/server/users.xml) можно скачать с GitHub.
 
 Данные сборки не рекомендуются для использования в продакшене, так как они недостаточно тщательно протестированны. Также, в них присутствуют не все возможности ClickHouse.
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add references to binaries for non-Linux distros.