### PR TITLE
fix double slashed paths in DatabaseOrdinary by switching to std::filesystem::path

### DIFF
--- a/src/Databases/DatabaseOrdinary.cpp
+++ b/src/Databases/DatabaseOrdinary.cpp
@@ -1,5 +1,3 @@
-#include <iomanip>
-
 #include <Core/Settings.h>
 #include <Databases/DatabaseOnDisk.h>
 #include <Databases/DatabaseOrdinary.h>
@@ -12,17 +10,14 @@
 #include <Interpreters/InterpreterCreateQuery.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ParserCreateQuery.h>
-#include <Storages/StorageFactory.h>
 #include <Parsers/parseQuery.h>
 #include <Parsers/formatAST.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Dictionaries/getDictionaryConfigurationFromAST.h>
-#include <TableFunctions/TableFunctionFactory.h>
 
 #include <Parsers/queryToString.h>
 
 #include <Poco/DirectoryIterator.h>
-#include <Poco/Event.h>
 #include <Common/Stopwatch.h>
 #include <Common/quoteString.h>
 #include <Common/ThreadPool.h>

--- a/src/Databases/DatabaseOrdinary.cpp
+++ b/src/Databases/DatabaseOrdinary.cpp
@@ -116,7 +116,6 @@ void DatabaseOrdinary::loadStoredObjects(Context & context, bool has_force_resto
 
     size_t total_dictionaries = 0;
 
-    // clang-format off
     auto process_metadata = [&context, &file_names, &total_dictionaries, this](const String & file_name)
     {
         fs::path path(getMetadataPath());
@@ -139,7 +138,6 @@ void DatabaseOrdinary::loadStoredObjects(Context & context, bool has_force_resto
             throw;
         }
     };
-    // clang-format on
 
 
     iterateMetadataFiles(context, process_metadata);
@@ -159,7 +157,6 @@ void DatabaseOrdinary::loadStoredObjects(Context & context, bool has_force_resto
     {
         const auto & create_query = name_with_query.second->as<const ASTCreateQuery &>();
         if (!create_query.is_dictionary)
-            // clang-format off
             pool.scheduleOrThrowOnError([&]()
             {
                 tryAttachTable(
@@ -173,7 +170,6 @@ void DatabaseOrdinary::loadStoredObjects(Context & context, bool has_force_resto
                 /// Messages, so that it's not boring to wait for the server to load for a long time.
                 logAboutProgress(log, ++tables_processed, total_tables, watch);
             });
-        // clang-format on
     }
 
     pool.wait();
@@ -207,13 +203,11 @@ void DatabaseOrdinary::startupTables(ThreadPool & thread_pool)
     AtomicStopwatch watch;
     std::atomic<size_t> tables_processed{0};
 
-    // clang-format off
     auto startup_one_table = [&](const StoragePtr & table)
     {
         table->startup();
         logAboutProgress(log, ++tables_processed, total_tables, watch);
     };
-    // clang-format on
 
 
     try

--- a/src/Databases/DatabaseOrdinary.cpp
+++ b/src/Databases/DatabaseOrdinary.cpp
@@ -1,4 +1,4 @@
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include <Core/Settings.h>
 #include <Databases/DatabaseOnDisk.h>
@@ -25,7 +25,7 @@
 #include <Common/typeid_cast.h>
 #include <common/logger_useful.h>
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 namespace DB
 {

--- a/src/Databases/DatabaseOrdinary.cpp
+++ b/src/Databases/DatabaseOrdinary.cpp
@@ -116,7 +116,9 @@ void DatabaseOrdinary::loadStoredObjects(Context & context, bool has_force_resto
 
     size_t total_dictionaries = 0;
 
-    auto process_metadata = [&context, &file_names, &total_dictionaries, this](const String & file_name) {
+    // clang-format off
+    auto process_metadata = [&context, &file_names, &total_dictionaries, this](const String & file_name)
+    {
         fs::path path(getMetadataPath());
         fs::path file_path(file_name);
         fs::path full_path = path / file_path;
@@ -137,6 +139,8 @@ void DatabaseOrdinary::loadStoredObjects(Context & context, bool has_force_resto
             throw;
         }
     };
+    // clang-format on
+
 
     iterateMetadataFiles(context, process_metadata);
 
@@ -155,7 +159,9 @@ void DatabaseOrdinary::loadStoredObjects(Context & context, bool has_force_resto
     {
         const auto & create_query = name_with_query.second->as<const ASTCreateQuery &>();
         if (!create_query.is_dictionary)
-            pool.scheduleOrThrowOnError([&]() {
+            // clang-format off
+            pool.scheduleOrThrowOnError([&]()
+            {
                 tryAttachTable(
                     context,
                     create_query,
@@ -167,6 +173,7 @@ void DatabaseOrdinary::loadStoredObjects(Context & context, bool has_force_resto
                 /// Messages, so that it's not boring to wait for the server to load for a long time.
                 logAboutProgress(log, ++tables_processed, total_tables, watch);
             });
+        // clang-format on
     }
 
     pool.wait();
@@ -200,10 +207,14 @@ void DatabaseOrdinary::startupTables(ThreadPool & thread_pool)
     AtomicStopwatch watch;
     std::atomic<size_t> tables_processed{0};
 
-    auto startup_one_table = [&](const StoragePtr & table) {
+    // clang-format off
+    auto startup_one_table = [&](const StoragePtr & table)
+    {
         table->startup();
         logAboutProgress(log, ++tables_processed, total_tables, watch);
     };
+    // clang-format on
+
 
     try
     {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Improve path concatenation and fix double slashed paths using std::filesystem::path instead of std::string in `DatabaseOrdinary.cpp`.

Detailed description / Documentation draft:

The concatenation of path doesn't always happen reliably and can cause outputs which contain double slashed paths: (Referencing from issue #8301 and this PR relates to that)
```bash
2019.12.19 17:33:18.401719 [ 1 ] {} <Error> Application: DB::Exception: Cannot parse definition from metadata file /var/lib/clickhouse/metadata/default//aaaa.sql, error: DB::Exception: Syntax error (in file /var/lib/clickhouse/metadata/default//aaaa.sql): failed at position 21 (line 3, col 1): )
```
To fix this I have chosen `std::filesystem::path` to concatenate the file paths instead of using `std::string`.

I have also removed several imports that are not being used. Also `clang` formatted the file and it looks like that did generate several changes to formatting in `DatabaseOrdinary.cpp`.