### PR TITLE
Keep aliases for substitutions in query.

### DIFF
--- a/src/Interpreters/ReplaceQueryParameterVisitor.cpp
+++ b/src/Interpreters/ReplaceQueryParameterVisitor.cpp
@@ -49,6 +49,7 @@ void ReplaceQueryParameterVisitor::visitQueryParameter(ASTPtr & ast)
     const auto & ast_param = ast->as<ASTQueryParameter &>();
     const String & value = getParamValue(ast_param.name);
     const String & type_name = ast_param.type;
+    String alias = ast_param.alias;
 
     const auto data_type = DataTypeFactory::instance().get(type_name);
     auto temp_column_ptr = data_type->createColumn();
@@ -63,6 +64,7 @@ void ReplaceQueryParameterVisitor::visitQueryParameter(ASTPtr & ast)
             + value.substr(0, read_buffer.count()), ErrorCodes::BAD_QUERY_PARAMETER);
 
     ast = addTypeConversionToAST(std::make_shared<ASTLiteral>(temp_column[0]), type_name);
+    ast->setAlias(alias);
 }
 
 }

--- a/tests/queries/0_stateless/01342_query_parameters_alias.reference
+++ b/tests/queries/0_stateless/01342_query_parameters_alias.reference
@@ -1,0 +1,3 @@
+a
+Nullable(Nothing)
+\N

--- a/tests/queries/0_stateless/01342_query_parameters_alias.sh
+++ b/tests/queries/0_stateless/01342_query_parameters_alias.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. $CURDIR/../shell_config.sh
+
+$CLICKHOUSE_CLIENT --param_x '\N' --query 'SELECT {x:Nullable(Nothing)} as a' --format TSVWithNamesAndTypes


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Keep aliases for substitutions in query (parametrized queries). This fixes #11914.
