### PR TITLE
Consider allocatedBytes() instead of bytes() in Storage{Buffer,Memory}.

### DIFF
--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -449,7 +449,7 @@ public:
     }
 
     /// If it is possible to quickly determine exact number of bytes for the table on storage:
-    /// - memory (approximated)
+    /// - memory (approximated, resident)
     /// - disk (compressed)
     ///
     /// Used for:
@@ -457,6 +457,10 @@ public:
     //
     /// Does not takes underlying Storage (if any) into account
     /// (since for Buffer we still need to know how much bytes it uses).
+    ///
+    /// Memory part should be estimated as a resident memory size.
+    /// In particular, alloctedBytes() is preferable over bytes()
+    /// when considering in-memory blocks.
     virtual std::optional<UInt64> totalBytes() const
     {
         return {};

--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -797,7 +797,7 @@ std::optional<UInt64> StorageBuffer::totalBytes() const
     for (const auto & buffer : buffers)
     {
         std::lock_guard lock(buffer.mutex);
-        bytes += buffer.data.bytes();
+        bytes += buffer.data.allocatedBytes();
     }
     return bytes;
 }

--- a/src/Storages/StorageMemory.cpp
+++ b/src/Storages/StorageMemory.cpp
@@ -169,7 +169,7 @@ std::optional<UInt64> StorageMemory::totalBytes() const
     UInt64 bytes = 0;
     std::lock_guard lock(mutex);
     for (const auto & buffer : data)
-        bytes += buffer.bytes();
+        bytes += buffer.allocatedBytes();
     return bytes;
 }
 

--- a/tests/queries/0_stateless/00753_system_columns_and_system_tables.reference
+++ b/tests/queries/0_stateless/00753_system_columns_and_system_tables.reference
@@ -29,7 +29,7 @@ Check total_bytes/total_rows for TinyLog
 \N	\N
 Check total_bytes/total_rows for Memory
 0	0
-2	1
+64	1
 Check total_bytes/total_rows for Buffer
 0	0
-100	50
+256	50


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
`system.tables` now considers column capacities for Memory and Buffer table engines, which is better approximation for resident memory size.