### PR TITLE
Fix query parameter visitor

### DIFF
--- a/src/Interpreters/ReplaceQueryParameterVisitor.cpp
+++ b/src/Interpreters/ReplaceQueryParameterVisitor.cpp
@@ -26,13 +26,17 @@ namespace ErrorCodes
 
 void ReplaceQueryParameterVisitor::visit(ASTPtr & ast)
 {
+    if (ast->as<ASTQueryParameter>())
+        visitQueryParameter(ast);
+    else
+        visitChildren(ast);
+}
+
+
+void ReplaceQueryParameterVisitor::visitChildren(ASTPtr & ast)
+{
     for (auto & child : ast->children)
-    {
-        if (child->as<ASTQueryParameter>())
-            visitQueryParameter(child);
-        else
-            visit(child);
-    }
+        visit(child);
 }
 
 const String & ReplaceQueryParameterVisitor::getParamValue(const String & name)

--- a/src/Interpreters/ReplaceQueryParameterVisitor.h
+++ b/src/Interpreters/ReplaceQueryParameterVisitor.h
@@ -22,6 +22,7 @@ private:
     const NameToNameMap & query_parameters;
     const String & getParamValue(const String & name);
     void visitQueryParameter(ASTPtr & ast);
+    void visitChildren(ASTPtr & ast);
 };
 
 }

--- a/tests/queries/0_stateless/01015_insert_values_parametrized.reference
+++ b/tests/queries/0_stateless/01015_insert_values_parametrized.reference
@@ -3,3 +3,4 @@
 2	testparam	[0.3]
 3	paramparam	[]
 4	evaluateparam	[0.2]
+5	param	[0.2,0.3]

--- a/tests/queries/0_stateless/01015_insert_values_parametrized.sh
+++ b/tests/queries/0_stateless/01015_insert_values_parametrized.sh
@@ -15,6 +15,9 @@ $CLICKHOUSE_CLIENT --input_format_values_deduce_templates_of_expressions=1 --inp
 $CLICKHOUSE_CLIENT --input_format_values_deduce_templates_of_expressions=0 --input_format_values_interpret_expressions=1 --param_p_n="-1" --param_p_s="param" --param_p_a="[0.2,0.3]" --query="INSERT INTO insert_values_parametrized  VALUES \
 (5 + {p_n:Int8}, lower(concat('Evaluate', {p_s:String})), arrayIntersect([0, 0.2, 0.6], {p_a:Array(Nullable(Float32))}))"
 
+$CLICKHOUSE_CLIENT --param_p_n="5" --param_p_s="param" --param_p_a="[0.2,0.3]" --query="INSERT INTO insert_values_parametrized  VALUES \
+({p_n:Int8}, {p_s:String}, {p_a:Array(Nullable(Float32))})"
+
 $CLICKHOUSE_CLIENT --query="SELECT * FROM insert_values_parametrized ORDER BY n";
 
 $CLICKHOUSE_CLIENT --query="DROP TABLE insert_values_parametrized";


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed `Query parameter was not set` in `Values` format.
Fixes #11918
