### PR TITLE
Fix race condition in extractAllGroups

### DIFF
--- a/src/Functions/MatchImpl.h
+++ b/src/Functions/MatchImpl.h
@@ -126,7 +126,7 @@ struct MatchImpl
         {
             size_t size = offsets.size();
 
-            const auto & regexp = Regexps::get<like, true>(pattern);
+            auto regexp = Regexps::get<like, true>(pattern);
 
             std::string required_substring;
             bool is_trivial;
@@ -281,7 +281,7 @@ struct MatchImpl
         {
             size_t size = data.size() / n;
 
-            const auto & regexp = Regexps::get<like, true>(pattern);
+            auto regexp = Regexps::get<like, true>(pattern);
 
             std::string required_substring;
             bool is_trivial;

--- a/src/Functions/extractAllGroups.h
+++ b/src/Functions/extractAllGroups.h
@@ -82,7 +82,8 @@ public:
             throw Exception("Length of 'needle' argument must be greater than 0.", ErrorCodes::BAD_ARGUMENTS);
 
         using StringPiece = typename Regexps::Regexp::StringPieceType;
-        const auto & regexp = Regexps::get<false, false>(needle)->getRE2();
+        auto holder = Regexps::get<false, false>(needle);
+        const auto & regexp = holder->getRE2();
 
         if (!regexp)
             throw Exception("There are no groups in regexp: " + needle, ErrorCodes::BAD_ARGUMENTS);

--- a/src/Functions/extractGroups.cpp
+++ b/src/Functions/extractGroups.cpp
@@ -61,7 +61,7 @@ public:
         if (needle.empty())
             throw Exception(getName() + " length of 'needle' argument must be greater than 0.", ErrorCodes::BAD_ARGUMENTS);
 
-        const auto regexp = Regexps::get<false, false>(needle);
+        auto regexp = Regexps::get<false, false>(needle);
         const auto & re2 = regexp->getRE2();
 
         if (!re2)


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix race condition in extractAllGroups* functions.


See https://clickhouse-test-reports.s3.yandex.net/11920/29a9d4187f569cc781cffbc712c1a3ddb3fcfb82/stress_test_(thread)/stderr.log

PS. We use `re2_st` instead of `re2` for reason.