### PR TITLE
Fix estimation of the number of marks while reading from MergeTree

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -724,10 +724,15 @@ size_t roundRowsOrBytesToMarks(
     size_t rows_granularity,
     size_t bytes_granularity)
 {
+    /// Marks are placed whenever threshold on rows or bytes is met.
+    /// So we have to return the number of marks on whatever estimate is higher - by rows or by bytes.
+
+    size_t res = (rows_setting + rows_granularity - 1) / rows_granularity;
+
     if (bytes_granularity == 0)
-        return (rows_setting + rows_granularity - 1) / rows_granularity;
+        return res;
     else
-        return (bytes_setting + bytes_granularity - 1) / bytes_granularity;
+        return std::max(res, (bytes_setting + bytes_granularity - 1) / bytes_granularity);
 }
 
 }
@@ -759,7 +764,7 @@ Pipes MergeTreeDataSelectExecutor::spreadMarkRangesAmongStreams(
         sum_marks += sum_marks_in_parts[i];
 
         if (parts[i].data_part->index_granularity_info.is_adaptive)
-            adaptive_parts++;
+            ++adaptive_parts;
     }
 
     size_t index_granularity_bytes = 0;
@@ -890,7 +895,7 @@ Pipes MergeTreeDataSelectExecutor::spreadMarkRangesAmongStreamsWithOrder(
         sum_marks += sum_marks_in_parts[i];
 
         if (parts[i].data_part->index_granularity_info.is_adaptive)
-            adaptive_parts++;
+            ++adaptive_parts;
     }
 
     size_t index_granularity_bytes = 0;

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -608,6 +608,7 @@ Pipes MergeTreeDataSelectExecutor::readFromParts(
     MergeTreeReaderSettings reader_settings =
     {
         .min_bytes_to_use_direct_io = settings.min_bytes_to_use_direct_io,
+        .min_bytes_to_use_mmap_io = settings.min_bytes_to_use_mmap_io,
         .max_read_buffer_size = settings.max_read_buffer_size,
         .save_marks_in_cache = true
     };

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.h
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.h
@@ -106,7 +106,8 @@ private:
         MergeTreeIndexConditionPtr condition,
         MergeTreeData::DataPartPtr part,
         const MarkRanges & ranges,
-        const Settings & settings) const;
+        const Settings & settings,
+        const MergeTreeReaderSettings & reader_settings) const;
 };
 
 }

--- a/src/Storages/MergeTree/MergeTreeIOSettings.h
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.h
@@ -10,7 +10,7 @@ struct MergeTreeReaderSettings
     size_t min_bytes_to_use_direct_io = 0;
     size_t min_bytes_to_use_mmap_io = 0;
     size_t max_read_buffer_size = DBMS_DEFAULT_BUFFER_SIZE;
-    /// If save_marks_in_cache is false, then, if marks are not in cache, 
+    /// If save_marks_in_cache is false, then, if marks are not in cache,
     ///  we will load them but won't save in the cache, to avoid evicting other data.
     bool save_marks_in_cache = false;
 };
@@ -33,4 +33,5 @@ struct MergeTreeWriterSettings
 
     size_t estimated_size = 0;
 };
+
 }

--- a/src/Storages/MergeTree/MergeTreeIndexReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexReader.cpp
@@ -5,12 +5,13 @@ namespace DB
 {
 
 MergeTreeIndexReader::MergeTreeIndexReader(
-    MergeTreeIndexPtr index_, MergeTreeData::DataPartPtr part_, size_t marks_count_, const MarkRanges & all_mark_ranges_)
+    MergeTreeIndexPtr index_, MergeTreeData::DataPartPtr part_, size_t marks_count_, const MarkRanges & all_mark_ranges_,
+    MergeTreeReaderSettings settings)
     : index(index_), stream(
         part_->volume->getDisk(),
         part_->getFullRelativePath() + index->getFileName(), ".idx", marks_count_,
         all_mark_ranges_,
-        MergeTreeReaderSettings{}, nullptr, nullptr,
+        std::move(settings), nullptr, nullptr,
         part_->getFileSizeOrZero(index->getFileName() + ".idx"),
         &part_->index_granularity_info,
         ReadBufferFromFileBase::ProfileCallback{}, CLOCK_MONOTONIC_COARSE)

--- a/src/Storages/MergeTree/MergeTreeIndexReader.h
+++ b/src/Storages/MergeTree/MergeTreeIndexReader.h
@@ -14,7 +14,8 @@ public:
         MergeTreeIndexPtr index_,
         MergeTreeData::DataPartPtr part_,
         size_t marks_count_,
-        const MarkRanges & all_mark_ranges_);
+        const MarkRanges & all_mark_ranges_,
+        MergeTreeReaderSettings settings);
 
     void seek(size_t mark);
 

--- a/src/Storages/MergeTree/MergeTreeReaderCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderCompact.cpp
@@ -57,7 +57,7 @@ MergeTreeReaderCompact::MergeTreeReaderCompact(
                     buffer_size,
                     0,
                     settings.min_bytes_to_use_direct_io,
-                    0);
+                    settings.min_bytes_to_use_mmap_io);
             },
             uncompressed_cache);
 
@@ -71,7 +71,8 @@ MergeTreeReaderCompact::MergeTreeReaderCompact(
     {
         auto buffer =
             std::make_unique<CompressedReadBufferFromFile>(
-                data_part->volume->getDisk()->readFile(full_data_path, buffer_size, 0, settings.min_bytes_to_use_direct_io, 0));
+                data_part->volume->getDisk()->readFile(
+                    full_data_path, buffer_size, 0, settings.min_bytes_to_use_direct_io, settings.min_bytes_to_use_mmap_io));
 
         if (profile_callback_)
             buffer->setProfileCallback(profile_callback_, clock_type_);

--- a/tests/queries/0_stateless/01343_min_bytes_to_use_mmap_io.reference
+++ b/tests/queries/0_stateless/01343_min_bytes_to_use_mmap_io.reference
@@ -1,0 +1,2 @@
+Hello, world
+1

--- a/tests/queries/0_stateless/01343_min_bytes_to_use_mmap_io.sql
+++ b/tests/queries/0_stateless/01343_min_bytes_to_use_mmap_io.sql
@@ -1,11 +1,11 @@
-DROP TABLE IF EXISTS test;
-CREATE TABLE test (x String) ENGINE = MergeTree ORDER BY tuple();
-INSERT INTO test VALUES ('Hello, world');
+DROP TABLE IF EXISTS test_01343;
+CREATE TABLE test_01343 (x String) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO test_01343 VALUES ('Hello, world');
 
 SET min_bytes_to_use_mmap_io = 1;
-SELECT * FROM test;
+SELECT * FROM test_01343;
 
 SYSTEM FLUSH LOGS;
-SELECT PE.Values FROM system.query_log ARRAY JOIN ProfileEvents AS PE WHERE event_date >= yesterday() AND event_time >= now() - 300 AND query LIKE 'SELECT * FROM test%' AND PE.Names = 'CreatedReadBufferMMap' AND type = 2 ORDER BY event_time DESC LIMIT 1;
+SELECT PE.Values FROM system.query_log ARRAY JOIN ProfileEvents AS PE WHERE event_date >= yesterday() AND event_time >= now() - 300 AND query LIKE 'SELECT * FROM test_01343%' AND PE.Names = 'CreatedReadBufferMMap' AND type = 2 ORDER BY event_time DESC LIMIT 1;
 
-DROP TABLE test;
+DROP TABLE test_01343;

--- a/tests/queries/0_stateless/01343_min_bytes_to_use_mmap_io.sql
+++ b/tests/queries/0_stateless/01343_min_bytes_to_use_mmap_io.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS test;
+CREATE TABLE test (x String) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO test VALUES ('Hello, world');
+
+SET min_bytes_to_use_mmap_io = 1;
+SELECT * FROM test;
+
+SYSTEM FLUSH LOGS;
+SELECT PE.Values FROM system.query_log ARRAY JOIN ProfileEvents AS PE WHERE event_date >= yesterday() AND event_time >= now() - 300 AND query LIKE 'SELECT * FROM test%' AND PE.Names = 'CreatedReadBufferMMap' AND type = 2 ORDER BY event_time DESC LIMIT 1;
+
+DROP TABLE test;

--- a/tests/queries/0_stateless/01344_min_bytes_to_use_mmap_io_index.reference
+++ b/tests/queries/0_stateless/01344_min_bytes_to_use_mmap_io_index.reference
@@ -1,0 +1,2 @@
+Hello, world
+2

--- a/tests/queries/0_stateless/01344_min_bytes_to_use_mmap_io_index.sql
+++ b/tests/queries/0_stateless/01344_min_bytes_to_use_mmap_io_index.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS test_01344;
+CREATE TABLE test_01344 (x String, INDEX idx (x) TYPE set(10) GRANULARITY 1) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO test_01344 VALUES ('Hello, world');
+
+SET min_bytes_to_use_mmap_io = 1;
+SELECT * FROM test_01344 WHERE x = 'Hello, world';
+
+SYSTEM FLUSH LOGS;
+SELECT PE.Values FROM system.query_log ARRAY JOIN ProfileEvents AS PE WHERE event_date >= yesterday() AND event_time >= now() - 300 AND query LIKE 'SELECT * FROM test_01344 WHERE x = ''Hello, world''%' AND PE.Names = 'CreatedReadBufferMMap' AND type = 2 ORDER BY event_time DESC LIMIT 1;
+
+DROP TABLE test_01344;


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix estimation of the number of marks while reading from MergeTree. This is needed to correctly handle the settings `merge_tree_max_rows_to_use_cache`, `merge_tree_max_bytes_to_use_cache`, `merge_tree_min_rows_for_concurrent_read`, `merge_tree_min_bytes_for_concurrent_read`, `merge_tree_min_rows_for_seek`, `merge_tree_min_bytes_for_seek`. Now settings `min_bytes_to_use_mmap_io` also applied to read index and compact parts in MergeTree table engines family.
