### PR TITLE
Add CPU frequencies to system.asynchronous_metrics

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -861,7 +861,8 @@ int Server::main(const std::vector<std::string> & /*args*/)
         };
 
         /// This object will periodically calculate some metrics.
-        AsynchronousMetrics async_metrics(*global_context);
+        AsynchronousMetrics async_metrics(*global_context,
+            config().getUInt("asynchronous_metrics_update_period_s", 60));
         attachSystemTablesAsync(*DatabaseCatalog::instance().getSystemDatabase(), async_metrics);
 
         for (const auto & listen_host : listen_hosts)

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -230,7 +230,6 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingUInt64, query_profiler_cpu_time_period_ns, 1000000000, "Period for CPU clock timer of query profiler (in nanoseconds). Set 0 value to turn off the CPU clock query profiler. Recommended value is at least 10000000 (100 times a second) for single queries or 1000000000 (once a second) for cluster-wide profiling.", 0) \
     M(SettingBool, metrics_perf_events_enabled, false, "If enabled, some of the perf events will be measured throughout queries' execution.", 0) \
     M(SettingString, metrics_perf_events_list, "", "Comma separated list of perf metrics that will be measured throughout queries' execution. Empty means all events. See PerfEventInfo in sources for the available events.", 0) \
-    M(SettingUInt64, asynchronous_metrics_update_period_s, 60, "Period for updating asynchronous metrics, in seconds.", 0) \
     \
     \
     /** Limits during query execution are part of the settings. \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -230,6 +230,7 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingUInt64, query_profiler_cpu_time_period_ns, 1000000000, "Period for CPU clock timer of query profiler (in nanoseconds). Set 0 value to turn off the CPU clock query profiler. Recommended value is at least 10000000 (100 times a second) for single queries or 1000000000 (once a second) for cluster-wide profiling.", 0) \
     M(SettingBool, metrics_perf_events_enabled, false, "If enabled, some of the perf events will be measured throughout queries' execution.", 0) \
     M(SettingString, metrics_perf_events_list, "", "Comma separated list of perf metrics that will be measured throughout queries' execution. Empty means all events. See PerfEventInfo in sources for the available events.", 0) \
+    M(SettingUInt64, asynchronous_metrics_update_period_s, 60, "Period for updating asynchronous metrics, in seconds.", 0) \
     \
     \
     /** Limits during query execution are part of the settings. \

--- a/src/IO/ReadHelpers.h
+++ b/src/IO/ReadHelpers.h
@@ -454,6 +454,8 @@ void readBackQuotedString(String & s, ReadBuffer & buf);
 void readBackQuotedStringWithSQLStyle(String & s, ReadBuffer & buf);
 
 void readStringUntilEOF(String & s, ReadBuffer & buf);
+
+// Doesn't read the EOL itself.
 void readEscapedStringUntilEOL(String & s, ReadBuffer & buf);
 
 

--- a/src/IO/ReadHelpers.h
+++ b/src/IO/ReadHelpers.h
@@ -455,7 +455,8 @@ void readBackQuotedStringWithSQLStyle(String & s, ReadBuffer & buf);
 
 void readStringUntilEOF(String & s, ReadBuffer & buf);
 
-// Doesn't read the EOL itself.
+// Reads the line until EOL, unescaping backslash escape sequences.
+// Buffer pointer is left at EOL, don't forget to advance it.
 void readEscapedStringUntilEOL(String & s, ReadBuffer & buf);
 
 

--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -332,8 +332,8 @@ void AsynchronousMetrics::update()
         ReadBufferFromFile buf("/proc/cpuinfo");
 
         // We need the following lines:
-        // core id  	: 4
-        // cpu MHz	 	: 4052.941
+        // core id : 4
+        // cpu MHz : 4052.941
         // They contain tabs and are interspersed with other info.
         int core_id = 0;
         while (!buf.eof())

--- a/src/Interpreters/AsynchronousMetrics.h
+++ b/src/Interpreters/AsynchronousMetrics.h
@@ -25,7 +25,10 @@ typedef std::unordered_map<std::string, AsynchronousMetricValue> AsynchronousMet
 class AsynchronousMetrics
 {
 public:
-    AsynchronousMetrics(Context & context_, int update_period_seconds)
+    // The default value of update_period_seconds is for ClickHouse-over-YT
+    // in Arcadia -- it uses its own server implementation that also uses these
+    // metrics.
+    AsynchronousMetrics(Context & context_, int update_period_seconds = 60)
         : context(context_),
           update_period(update_period_seconds),
           thread([this] { run(); })

--- a/src/Interpreters/AsynchronousMetrics.h
+++ b/src/Interpreters/AsynchronousMetrics.h
@@ -18,15 +18,17 @@ typedef double AsynchronousMetricValue;
 typedef std::unordered_map<std::string, AsynchronousMetricValue> AsynchronousMetricValues;
 
 
-/** Periodically (each minute, starting at 30 seconds offset)
+/** Periodically (by default, each minute, starting at 30 seconds offset)
   *  calculates and updates some metrics,
   *  that are not updated automatically (so, need to be asynchronously calculated).
   */
 class AsynchronousMetrics
 {
 public:
-    AsynchronousMetrics(Context & context_)
-        : context(context_), thread([this] { run(); })
+    AsynchronousMetrics(Context & context_, int update_period_seconds)
+        : context(context_),
+          update_period(update_period_seconds),
+          thread([this] { run(); })
     {
     }
 
@@ -38,6 +40,7 @@ public:
 
 private:
     Context & context;
+    const std::chrono::seconds update_period;
 
     mutable std::mutex mutex;
     std::condition_variable wait_cond;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add CPU frequencies to system.asynchronous_metrics. Make the metric collection period configurable.