### PR TITLE
Extend word break config to all non-alphanumeric chars

### DIFF
--- a/base/common/LineReader.h
+++ b/base/common/LineReader.h
@@ -48,7 +48,7 @@ protected:
     };
 
     const String history_file_path;
-    static constexpr char word_break_characters[] = " \t\n\r\"\\'`@$><=;|&{(.";
+    static constexpr char word_break_characters[] = " \t\v\f\a\b\r\n`~!@#$%^&*()-=+[{]}\\|;:'\",<.>/?_";
 
     String input;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Other

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Update word break characters to match readline default - all non-alphanumeric characters.
...


Detailed description / Documentation draft:

...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.
