### PR TITLE
jemalloc: set muzzy_decay_ms = 10s

### DIFF
--- a/contrib/jemalloc-cmake/CMakeLists.txt
+++ b/contrib/jemalloc-cmake/CMakeLists.txt
@@ -29,7 +29,7 @@ if (ENABLE_JEMALLOC)
             # https://github.com/ClickHouse/ClickHouse/issues/11121 for motivation.
             set (JEMALLOC_CONFIG_MALLOC_CONF "percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:10000")
         else()
-            set (JEMALLOC_CONFIG_MALLOC_CONF "oversize_threshold:0")
+            set (JEMALLOC_CONFIG_MALLOC_CONF "oversize_threshold:0,muzzy_decay_ms:10000")
         endif()
         # CACHE variable is empty, to allow changing defaults without necessity
         # to purge cache

--- a/contrib/jemalloc-cmake/CMakeLists.txt
+++ b/contrib/jemalloc-cmake/CMakeLists.txt
@@ -22,7 +22,12 @@ if (ENABLE_JEMALLOC)
             #
             # By enabling percpu_arena number of arenas limited to number of CPUs and hence
             # this problem should go away.
-            set (JEMALLOC_CONFIG_MALLOC_CONF "percpu_arena:percpu,oversize_threshold:0")
+            #
+            # muzzy_decay_ms -- use MADV_FREE when available on newer Linuxes, to
+            # avoid spurious latencies and additional work associated with
+            # MADV_DONTNEED. See
+            # https://github.com/ClickHouse/ClickHouse/issues/11121 for motivation.
+            set (JEMALLOC_CONFIG_MALLOC_CONF "percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:10000")
         else()
             set (JEMALLOC_CONFIG_MALLOC_CONF "oversize_threshold:0")
         endif()

--- a/docker/test/performance-comparison/config/config.d/perf-comparison-tweaks-config.xml
+++ b/docker/test/performance-comparison/config/config.d/perf-comparison-tweaks-config.xml
@@ -20,4 +20,6 @@
     </metric_log>
 
     <uncompressed_cache_size>1000000000</uncompressed_cache_size>
+
+    <asynchronous_metrics_update_period_s>10</asynchronous_metrics_update_period_s>
 </yandex>


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

As a reference for other tests we've made, see https://github.com/ClickHouse/ClickHouse/pull/11401