### PR TITLE
Avro: allow_missing_fields setting

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -421,6 +421,7 @@ struct Settings : public SettingsCollection<Settings>
     M(SettingBool, input_format_values_interpret_expressions, true, "For Values format: if the field could not be parsed by streaming parser, run SQL parser and try to interpret it as SQL expression.", 0) \
     M(SettingBool, input_format_values_deduce_templates_of_expressions, true, "For Values format: if the field could not be parsed by streaming parser, run SQL parser, deduce template of the SQL expression, try to parse all rows using template and then interpret expression for all rows.", 0) \
     M(SettingBool, input_format_values_accurate_types_of_literals, true, "For Values format: when parsing and interpreting expressions using template, check actual type of literal to avoid possible overflow and precision issues.", 0) \
+    M(SettingBool, input_format_avro_allow_missing_fields, false, "For Avro/AvroConfluent format: when field is not found in schema use default value instead of error", 0) \
     M(SettingURI, format_avro_schema_registry_url, {}, "For AvroConfluent format: Confluent Schema Registry URL.", 0) \
     \
     M(SettingBool, output_format_json_quote_64bit_integers, true, "Controls quoting of 64-bit integers in JSON output format.", 0) \

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -85,6 +85,7 @@ static FormatSettings getInputFormatSetting(const Settings & settings, const Con
             context.getRemoteHostFilter().checkURL(avro_schema_registry_url);
     }
     format_settings.avro.schema_registry_url = settings.format_avro_schema_registry_url.toString();
+    format_settings.avro.allow_missing_fields = settings.input_format_avro_allow_missing_fields;
 
     return format_settings;
 }

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -128,6 +128,7 @@ struct FormatSettings
         String schema_registry_url;
         String output_codec;
         UInt64 output_sync_interval = 16 * 1024;
+        bool allow_missing_fields = false;
     };
 
     Avro avro;

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.h
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include <Core/Block.h>
+#include <Formats/FormatSettings.h>
 #include <Formats/FormatSchemaInfo.h>
 #include <Processors/Formats/IRowInputFormat.h>
 
@@ -24,7 +25,7 @@ namespace DB
 class AvroDeserializer
 {
 public:
-    AvroDeserializer(const Block & header, avro::ValidSchema schema);
+    AvroDeserializer(const Block & header, avro::ValidSchema schema, const FormatSettings & format_settings);
     void deserializeRow(MutableColumns & columns, avro::Decoder & decoder, RowReadExtension & ext) const;
 
 private:
@@ -105,7 +106,7 @@ private:
 class AvroRowInputFormat : public IRowInputFormat
 {
 public:
-    AvroRowInputFormat(const Block & header_, ReadBuffer & in_, Params params_);
+    AvroRowInputFormat(const Block & header_, ReadBuffer & in_, Params params_, const FormatSettings & format_settings_);
     virtual bool readRow(MutableColumns & columns, RowReadExtension & ext) override;
     String getName() const override { return "AvroRowInputFormat"; }
 
@@ -136,6 +137,7 @@ private:
 
     avro::InputStreamPtr input_stream;
     avro::DecoderPtr decoder;
+    FormatSettings format_settings;
 };
 
 }

--- a/tests/queries/0_stateless/01060_avro.reference
+++ b/tests/queries/0_stateless/01060_avro.reference
@@ -46,6 +46,7 @@ not compatible
 0
 1000
 not found
+1000
 === output
 = primitive
 1,1,2,3.4,5.6,"b1","s1"

--- a/tests/queries/0_stateless/01060_avro.sh
+++ b/tests/queries/0_stateless/01060_avro.sh
@@ -58,6 +58,8 @@ cat $DATA_DIR/empty.avro | ${CLICKHOUSE_LOCAL} --input-format Avro --output-form
 cat $DATA_DIR/simple.null.avro | ${CLICKHOUSE_LOCAL} --input-format Avro --output-format CSV -S 'a Int32' -q 'select count() from table'
 # field not found
 cat $DATA_DIR/simple.null.avro | ${CLICKHOUSE_LOCAL} --input-format Avro --output-format CSV -S 'b Int64' -q 'select count() from table' 2>&1 | grep -i 'not found' -o
+# allow_missing_fields
+cat $DATA_DIR/simple.null.avro | ${CLICKHOUSE_LOCAL} --input-format Avro --output-format CSV --input_format_avro_allow_missing_fields 1 -S 'b Int64' -q 'select count() from table'
 
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add setting to fields not found in Avro schema

Detailed description / Documentation draft:
Add setting `input_format_avro_allow_missing_fields` to allow reading fields not found in Avro schema (using default value instead).
Useful for  Kafka + schema evolution when old messages  are missing newly added field in their schema and preventing ClickHouse from making progress.
Related to https://github.com/ClickHouse/ClickHouse/issues/11986

Not using `input_format_defaults_for_omitted_fields` because it defaults to `true`. 

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.
