### PR TITLE
Fix calculation of access rights when allow_ddl = 0

### DIFF
--- a/src/Access/ContextAccess.cpp
+++ b/src/Access/ContextAccess.cpp
@@ -428,7 +428,7 @@ boost::shared_ptr<const AccessRights> ContextAccess::calculateResultAccess(bool 
         merged_access->revoke(AccessType::CREATE_TEMPORARY_TABLE);
     }
 
-    if (!allow_ddl_ && !grant_option)
+    if (!allow_ddl_)
         merged_access->revoke(table_and_dictionary_ddl);
 
     if (!allow_introspection_ && !grant_option)

--- a/tests/integration/test_settings_profile/test.py
+++ b/tests/integration/test_settings_profile/test.py
@@ -164,6 +164,18 @@ def test_show_profiles():
     assert expected_access in instance.query("SHOW ACCESS")
 
 
+def test_allow_ddl():
+    assert "Not enough privileges" in instance.query_and_get_error("CREATE TABLE tbl(a Int32) ENGINE=Log", user="robin")
+    assert "DDL queries are prohibited" in instance.query_and_get_error("CREATE TABLE tbl(a Int32) ENGINE=Log", settings={"allow_ddl":0})
+
+    assert "Not enough privileges" in instance.query_and_get_error("GRANT CREATE ON tbl TO robin", user="robin")
+    assert "DDL queries are prohibited" in instance.query_and_get_error("GRANT CREATE ON tbl TO robin", settings={"allow_ddl":0})
+
+    instance.query("GRANT CREATE ON tbl TO robin")
+    instance.query("CREATE TABLE tbl(a Int32) ENGINE=Log", user="robin")
+    instance.query("DROP TABLE tbl")
+
+
 def test_allow_introspection():
     assert "Not enough privileges" in instance.query_and_get_error("SELECT demangle('a')", user="robin")
     


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Bug Fix

Changelog entry:
Fix calculation of access rights when allow_ddl=0. 
