### PR TITLE
Fix calculation of access rights when allow_introspection_functions = 0

### DIFF
--- a/src/Access/ContextAccess.cpp
+++ b/src/Access/ContextAccess.cpp
@@ -431,8 +431,8 @@ boost::shared_ptr<const AccessRights> ContextAccess::calculateResultAccess(bool 
     if (!allow_ddl_ && !grant_option)
         merged_access->revoke(table_and_dictionary_ddl);
 
-    if (!allow_introspection_ && !grant_option)
-        merged_access->revoke(AccessType::INTROSPECTION);
+    if (allow_introspection_)
+        merged_access->grant(AccessType::INTROSPECTION);
 
     /// Anyone has access to the "system" database.
     merged_access->grant(AccessType::SELECT, DatabaseCatalog::SYSTEM_DATABASE);

--- a/src/Access/UsersConfigAccessStorage.cpp
+++ b/src/Access/UsersConfigAccessStorage.cpp
@@ -162,6 +162,10 @@ namespace
                 user->access.grantWithGrantOption(AccessFlags::allDictionaryFlags(), IDictionary::NO_DATABASE_TAG, dictionary);
         }
 
+        /// For users from users.xml access to the introspection functions can be enabled by the setting
+        /// 'allow_introspection_functions'.
+        user->access.revoke(AccessType::INTROSPECTION);
+
         bool access_management = config.getBool(user_config + ".access_management", false);
         if (!access_management)
         {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Bug Fix

Changelog entry:
Fix calculation of access rights when allow_introspection_functions = 0.
