### PR TITLE
Fix overflow in function "neighbor"

### DIFF
--- a/tests/queries/0_stateless/01353_neighbor_overflow.sql
+++ b/tests/queries/0_stateless/01353_neighbor_overflow.sql
@@ -1,0 +1,2 @@
+SELECT neighbor(toString(number), -9223372036854775808) FROM numbers(100); -- { serverError 69 }
+WITH neighbor(toString(number), toInt64(rand64())) AS x SELECT * FROM system.numbers WHERE NOT ignore(x); -- { serverError 69 }


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
A query with function `neighbor` as the only returned expression may return empty result if the function is called with offset `-9223372036854775808`. This fixes #11367.
