### PR TITLE
clickhouse-local improvements

### DIFF
--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -132,7 +132,7 @@ void LocalServer::tryInitPath()
             // This is a directory that is left by a previous run of
             // clickhouse-local that had the same pid and did not complete
             // correctly. Remove it, with an additional sanity check.
-            if (default_path.parent_path() != tmp)
+            if (!std::filesystem::equivalent(default_path.parent_path(), tmp))
             {
                 throw Exception(ErrorCodes::LOGICAL_ERROR,
                     "The temporary directory of clickhouse-local '{}' is not"
@@ -267,6 +267,7 @@ try
     context->shutdown();
     context.reset();
 
+    status.reset();
     cleanup();
 
     return Application::EXIT_OK;
@@ -433,7 +434,7 @@ void LocalServer::cleanup()
         const auto dir = *temporary_directory_to_delete;
         temporary_directory_to_delete.reset();
 
-        if (dir.parent_path() != tmp)
+        if (!std::filesystem::equivalent(dir.parent_path(), tmp))
         {
             throw Exception(ErrorCodes::LOGICAL_ERROR,
                 "The temporary directory of clickhouse-local '{}' is not inside"

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -78,10 +78,12 @@ void LocalServer::initialize(Poco::Util::Application & self)
         config().add(loaded_config.configuration.duplicate(), PRIO_DEFAULT, false);
     }
 
-    if (config().has("logger") || config().has("logger.level") || config().has("logger.log"))
+    if (config().has("logger.console") || config().has("logger.level") || config().has("logger.log"))
     {
+        // force enable logging
+        config().setString("logger", "logger");
         // sensitive data rules are not used here
-        buildLoggers(config(), logger(), self.commandName());
+        buildLoggers(config(), logger(), "clickhouse-local");
     }
     else
     {
@@ -498,6 +500,7 @@ void LocalServer::init(int argc, char ** argv)
         ("stacktrace", "print stack traces of exceptions")
         ("echo", "print query before execution")
         ("verbose", "print query and other debugging info")
+        ("logger.console", po::value<bool>()->implicit_value(true), "Log to console")
         ("logger.log", po::value<std::string>(), "Log file name")
         ("logger.level", po::value<std::string>(), "Log level")
         ("ignore-error", "do not stop processing if a query failed")
@@ -553,6 +556,8 @@ void LocalServer::init(int argc, char ** argv)
         config().setBool("echo", true);
     if (options.count("verbose"))
         config().setBool("verbose", true);
+    if (options.count("logger.console"))
+        config().setBool("logger.console", options["logger.console"].as<bool>());
     if (options.count("logger.log"))
         config().setString("logger.log", options["logger.log"].as<std::string>());
     if (options.count("logger.level"))

--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -325,6 +325,7 @@ void AsynchronousMetrics::update()
     saveAllArenasMetric<size_t>(new_values, "muzzy_purged");
 #endif
 
+#if defined(OS_LINUX)
     // Try to add processor frequencies, ignoring errors.
     try
     {
@@ -366,6 +367,7 @@ void AsynchronousMetrics::update()
     {
         tryLogCurrentException(__PRETTY_FUNCTION__);
     }
+#endif
 
     /// Add more metrics as you wish.
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Detailed description / Documentation draft:
A couple of small fixes that don't deserve separate PRs:
1. Improve logging flags for `clickhouse-local`. Previously, to enable logging, you would need to call `clickhouse-local` like this: `clickhouse-local -q "select 1" -- --logger=asd --application.baseName=qwe`.
This PR changes it to `clickhouse-local -q "select 1" --logger.console`
2. Use `std::filesystem::equivalent` (it was throwing because  `/var` is a symlink to `/private/var` on macos)
3. /proc/cpuinfo is available only on Linux.


By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.
