### PR TITLE
Fix defaultValueOfArgumentType

### DIFF
--- a/src/Functions/defaultValueOfArgumentType.cpp
+++ b/src/Functions/defaultValueOfArgumentType.cpp
@@ -22,6 +22,7 @@ public:
     }
 
     bool useDefaultImplementationForNulls() const override { return false; }
+    bool useDefaultImplementationForLowCardinalityColumns() const override { return false; }
 
     size_t getNumberOfArguments() const override
     {

--- a/tests/queries/0_stateless/01355_defaultValueOfArgumentType_bug.reference
+++ b/tests/queries/0_stateless/01355_defaultValueOfArgumentType_bug.reference
@@ -1,0 +1,1 @@
+	LowCardinality(String)

--- a/tests/queries/0_stateless/01355_defaultValueOfArgumentType_bug.sql
+++ b/tests/queries/0_stateless/01355_defaultValueOfArgumentType_bug.sql
@@ -1,0 +1,4 @@
+SELECT 
+    materialize(toLowCardinality('')) AS lc,
+    toTypeName(lc)
+WHERE lc = defaultValueOfArgumentType(lc)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix=


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix error `Expected single dictionary argument for function` for function `defaultValueOfArgumentType` with `LowCardinality` type. Fixes #11808