### PR TITLE
Fix segfault in prewhere with bad types

### DIFF
--- a/tests/queries/0_stateless/01355_prewhere_bad_type.sql
+++ b/tests/queries/0_stateless/01355_prewhere_bad_type.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS prewhere_bad_type;
+CREATE TABLE prewhere_bad_type (id UInt32, s String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO prewhere_bad_type (id) VALUES (1);
+SELECT id, s FROM prewhere_bad_type PREWHERE s; -- { serverError 59 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix segfault in `PREWHERE` with non-UInt8 types.


Fixes #12053.

