### PR TITLE
Check wrong type for filter.

### DIFF
--- a/src/DataTypes/DataTypeNullable.h
+++ b/src/DataTypes/DataTypeNullable.h
@@ -90,7 +90,7 @@ public:
     bool canBeComparedWithCollation() const override { return nested_data_type->canBeComparedWithCollation(); }
     bool canBeUsedAsVersion() const override { return false; }
     bool isSummable() const override { return nested_data_type->isSummable(); }
-    bool canBeUsedInBooleanContext() const override { return nested_data_type->canBeUsedInBooleanContext(); }
+    bool canBeUsedInBooleanContext() const override { return nested_data_type->canBeUsedInBooleanContext() || onlyNull(); }
     bool haveMaximumSizeOfValue() const override { return nested_data_type->haveMaximumSizeOfValue(); }
     size_t getMaximumSizeOfValueInMemory() const override { return 1 + nested_data_type->getMaximumSizeOfValueInMemory(); }
     bool isNullable() const override { return true; }

--- a/src/Interpreters/ExpressionAnalyzer.cpp
+++ b/src/Interpreters/ExpressionAnalyzer.cpp
@@ -78,6 +78,7 @@ namespace ErrorCodes
     extern const int ILLEGAL_PREWHERE;
     extern const int LOGICAL_ERROR;
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+    extern const int ILLEGAL_TYPE_OF_COLUMN_FOR_FILTER;
 }
 
 namespace
@@ -637,9 +638,9 @@ bool SelectQueryExpressionAnalyzer::appendPrewhere(
     step.can_remove_required_output.push_back(true);
 
     auto filter_type = step.actions->getSampleBlock().getByName(prewhere_column_name).type;
-    if (!isInteger(removeNullable(filter_type)))
+    if (!filter_type->canBeUsedInBooleanContext())
         throw Exception("Invalid type for filter in PREWHERE: " + filter_type->getName(),
-                        ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+                        ErrorCodes::ILLEGAL_TYPE_OF_COLUMN_FOR_FILTER);
 
     {
         /// Remove unused source_columns from prewhere actions.
@@ -728,9 +729,9 @@ bool SelectQueryExpressionAnalyzer::appendWhere(ExpressionActionsChain & chain, 
     getRootActions(select_query->where(), only_types, step.actions);
 
     auto filter_type = step.actions->getSampleBlock().getByName(where_column_name).type;
-    if (!isInteger(removeNullable(filter_type)))
+    if (!filter_type->canBeUsedInBooleanContext())
         throw Exception("Invalid type for filter in WHERE: " + filter_type->getName(),
-                        ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+                        ErrorCodes::ILLEGAL_TYPE_OF_COLUMN_FOR_FILTER);
 
     return true;
 }

--- a/src/Interpreters/ExpressionAnalyzer.cpp
+++ b/src/Interpreters/ExpressionAnalyzer.cpp
@@ -637,7 +637,7 @@ bool SelectQueryExpressionAnalyzer::appendPrewhere(
     step.can_remove_required_output.push_back(true);
 
     auto filter_type = step.actions->getSampleBlock().getByName(prewhere_column_name).type;
-    if (!isInteger(filter_type))
+    if (!isInteger(removeNullable(filter_type)))
         throw Exception("Invalid type for filter in PREWHERE: " + filter_type->getName(),
                         ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
 
@@ -728,7 +728,7 @@ bool SelectQueryExpressionAnalyzer::appendWhere(ExpressionActionsChain & chain, 
     getRootActions(select_query->where(), only_types, step.actions);
 
     auto filter_type = step.actions->getSampleBlock().getByName(where_column_name).type;
-    if (!isInteger(filter_type))
+    if (!isInteger(removeNullable(filter_type)))
         throw Exception("Invalid type for filter in WHERE: " + filter_type->getName(),
                         ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
 

--- a/src/Interpreters/ExpressionAnalyzer.cpp
+++ b/src/Interpreters/ExpressionAnalyzer.cpp
@@ -639,7 +639,7 @@ bool SelectQueryExpressionAnalyzer::appendPrewhere(
     auto filter_type = step.actions->getSampleBlock().getByName(prewhere_column_name).type;
     if (!isInteger(filter_type))
         throw Exception("Invalid type for filter in PREWHERE: " + filter_type->getName(),
-                        ErrorCodes::LOGICAL_ERROR);
+                        ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
 
     {
         /// Remove unused source_columns from prewhere actions.
@@ -730,7 +730,7 @@ bool SelectQueryExpressionAnalyzer::appendWhere(ExpressionActionsChain & chain, 
     auto filter_type = step.actions->getSampleBlock().getByName(where_column_name).type;
     if (!isInteger(filter_type))
         throw Exception("Invalid type for filter in WHERE: " + filter_type->getName(),
-                        ErrorCodes::LOGICAL_ERROR);
+                        ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
 
     return true;
 }

--- a/src/Interpreters/ExpressionAnalyzer.cpp
+++ b/src/Interpreters/ExpressionAnalyzer.cpp
@@ -636,6 +636,11 @@ bool SelectQueryExpressionAnalyzer::appendPrewhere(
     step.required_output.push_back(prewhere_column_name);
     step.can_remove_required_output.push_back(true);
 
+    auto filter_type = step.actions->getSampleBlock().getByName(prewhere_column_name).type;
+    if (!isInteger(filter_type))
+        throw Exception("Invalid type for filter in PREWHERE: " + filter_type->getName(),
+                        ErrorCodes::LOGICAL_ERROR);
+
     {
         /// Remove unused source_columns from prewhere actions.
         auto tmp_actions = std::make_shared<ExpressionActions>(sourceColumns(), context);
@@ -716,10 +721,16 @@ bool SelectQueryExpressionAnalyzer::appendWhere(ExpressionActionsChain & chain, 
 
     ExpressionActionsChain::Step & step = chain.lastStep(sourceColumns());
 
-    step.required_output.push_back(select_query->where()->getColumnName());
+    auto where_column_name = select_query->where()->getColumnName();
+    step.required_output.push_back(where_column_name);
     step.can_remove_required_output = {true};
 
     getRootActions(select_query->where(), only_types, step.actions);
+
+    auto filter_type = step.actions->getSampleBlock().getByName(where_column_name).type;
+    if (!isInteger(filter_type))
+        throw Exception("Invalid type for filter in PREWHERE: " + filter_type->getName(),
+                        ErrorCodes::LOGICAL_ERROR);
 
     return true;
 }

--- a/src/Interpreters/ExpressionAnalyzer.cpp
+++ b/src/Interpreters/ExpressionAnalyzer.cpp
@@ -729,7 +729,7 @@ bool SelectQueryExpressionAnalyzer::appendWhere(ExpressionActionsChain & chain, 
 
     auto filter_type = step.actions->getSampleBlock().getByName(where_column_name).type;
     if (!isInteger(filter_type))
-        throw Exception("Invalid type for filter in PREWHERE: " + filter_type->getName(),
+        throw Exception("Invalid type for filter in WHERE: " + filter_type->getName(),
                         ErrorCodes::LOGICAL_ERROR);
 
     return true;

--- a/src/Storages/MergeTree/MergeTreeBaseSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeBaseSelectProcessor.cpp
@@ -6,6 +6,7 @@
 #include <Columns/FilterDescription.h>
 #include <Common/typeid_cast.h>
 #include <DataTypes/DataTypeNothing.h>
+#include <DataTypes/DataTypeNullable.h>
 
 
 namespace DB
@@ -318,7 +319,7 @@ void MergeTreeBaseSelectProcessor::executePrewhereActions(Block & block, const P
         prewhere_info->prewhere_actions->execute(block);
         auto & prewhere_column = block.getByName(prewhere_info->prewhere_column_name);
 
-        if (!isInteger(prewhere_column.type))
+        if (!isInteger(removeNullable(prewhere_column.type)))
             throw Exception("Invalid type for filter in PREWHERE: " + prewhere_column.type->getName(),
                             ErrorCodes::LOGICAL_ERROR);
 

--- a/src/Storages/MergeTree/MergeTreeBaseSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeBaseSelectProcessor.cpp
@@ -316,6 +316,12 @@ void MergeTreeBaseSelectProcessor::executePrewhereActions(Block & block, const P
             prewhere_info->alias_actions->execute(block);
 
         prewhere_info->prewhere_actions->execute(block);
+        auto & prewhere_column = block.getByName(prewhere_info->prewhere_column_name);
+
+        if (!isInteger(prewhere_column.type))
+            throw Exception("Invalid type for filter in PREWHERE: " + prewhere_column.type->getName(),
+                            ErrorCodes::LOGICAL_ERROR);
+
         if (prewhere_info->remove_prewhere_column)
             block.erase(prewhere_info->prewhere_column_name);
         else

--- a/src/Storages/MergeTree/MergeTreeBaseSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeBaseSelectProcessor.cpp
@@ -319,7 +319,7 @@ void MergeTreeBaseSelectProcessor::executePrewhereActions(Block & block, const P
         prewhere_info->prewhere_actions->execute(block);
         auto & prewhere_column = block.getByName(prewhere_info->prewhere_column_name);
 
-        if (!isInteger(removeNullable(prewhere_column.type)))
+        if (!prewhere_column.type->canBeUsedInBooleanContext())
             throw Exception("Invalid type for filter in PREWHERE: " + prewhere_column.type->getName(),
                             ErrorCodes::LOGICAL_ERROR);
 

--- a/tests/queries/0_stateless/01356_wrong_filter-type_bug.sql
+++ b/tests/queries/0_stateless/01356_wrong_filter-type_bug.sql
@@ -3,7 +3,7 @@ drop table if exists t0;
 CREATE TABLE t0 (`c0` String, `c1` Int32 CODEC(NONE), `c2` Int32) ENGINE = MergeTree() ORDER BY tuple();
 insert into t0 values ('a', 1, 2);
 
-SELECT t0.c2, t0.c1, t0.c0 FROM t0 PREWHERE t0.c0 ORDER BY ((t0.c2)>=(t0.c1)), (((- (((t0.c0)>(t0.c0))))) IS NULL) FORMAT TabSeparatedWithNamesAndTypes; -- {serverError 43}
-SELECT t0.c2, t0.c1, t0.c0 FROM t0 WHERE t0.c0 ORDER BY ((t0.c2)>=(t0.c1)), (((- (((t0.c0)>(t0.c0))))) IS NULL) FORMAT TabSeparatedWithNamesAndTypes settings optimize_move_to_prewhere=0; -- {serverError 43}
+SELECT t0.c2, t0.c1, t0.c0 FROM t0 PREWHERE t0.c0 ORDER BY ((t0.c2)>=(t0.c1)), (((- (((t0.c0)>(t0.c0))))) IS NULL) FORMAT TabSeparatedWithNamesAndTypes; -- {serverError 59}
+SELECT t0.c2, t0.c1, t0.c0 FROM t0 WHERE t0.c0 ORDER BY ((t0.c2)>=(t0.c1)), (((- (((t0.c0)>(t0.c0))))) IS NULL) FORMAT TabSeparatedWithNamesAndTypes settings optimize_move_to_prewhere=0; -- {serverError 59}
 
 drop table if exists t0;

--- a/tests/queries/0_stateless/01356_wrong_filter-type_bug.sql
+++ b/tests/queries/0_stateless/01356_wrong_filter-type_bug.sql
@@ -1,0 +1,9 @@
+drop table if exists t0;
+
+CREATE TABLE t0 (`c0` String, `c1` Int32 CODEC(NONE), `c2` Int32) ENGINE = MergeTree() ORDER BY tuple();
+insert into t0 values ('a', 1, 2);
+
+SELECT t0.c2, t0.c1, t0.c0 FROM t0 PREWHERE t0.c0 ORDER BY ((t0.c2)>=(t0.c1)), (((- (((t0.c0)>(t0.c0))))) IS NULL) FORMAT TabSeparatedWithNamesAndTypes; -- {serverError 43}
+SELECT t0.c2, t0.c1, t0.c0 FROM t0 WHERE t0.c0 ORDER BY ((t0.c2)>=(t0.c1)), (((- (((t0.c0)>(t0.c0))))) IS NULL) FORMAT TabSeparatedWithNamesAndTypes settings optimize_move_to_prewhere=0; -- {serverError 43}
+
+drop table if exists t0;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible crash while using wrong type for `PREWHERE`. Fixes #12053, #12060