### PR TITLE
Moved useless S3 logging to TRACE level

### DIFF
--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -106,7 +106,7 @@ void PocoHTTPClient::MakeRequestInternal(
 
             if (request.GetContentBody())
             {
-                LOG_DEBUG(log, "Writing request body.");
+                LOG_TRACE(log, "Writing request body.");
                 if (attempt > 0) /// rewind content body buffer.
                 {
                     request.GetContentBody()->clear();
@@ -116,7 +116,7 @@ void PocoHTTPClient::MakeRequestInternal(
                 LOG_DEBUG(log, "Written {} bytes to request body", size);
             }
 
-            LOG_DEBUG(log, "Receiving response...");
+            LOG_TRACE(log, "Receiving response...");
             auto & response_body_stream = session->receiveResponse(poco_response);
 
             int status_code = static_cast<int>(poco_response.getStatus());

--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -31,7 +31,7 @@ const std::pair<DB::LogsLevel, Poco::Message::Priority> & convertLogLevel(Aws::U
         {Aws::Utils::Logging::LogLevel::Error, {DB::LogsLevel::error, Poco::Message::PRIO_ERROR}},
         {Aws::Utils::Logging::LogLevel::Warn, {DB::LogsLevel::warning, Poco::Message::PRIO_WARNING}},
         {Aws::Utils::Logging::LogLevel::Info, {DB::LogsLevel::information, Poco::Message::PRIO_INFORMATION}},
-        {Aws::Utils::Logging::LogLevel::Debug, {DB::LogsLevel::debug, Poco::Message::PRIO_DEBUG}},
+        {Aws::Utils::Logging::LogLevel::Debug, {DB::LogsLevel::trace, Poco::Message::PRIO_TRACE}},
         {Aws::Utils::Logging::LogLevel::Trace, {DB::LogsLevel::trace, Poco::Message::PRIO_TRACE}},
     };
     return mapping.at(log_level);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Moved useless S3 logging to TRACE level
