### PR TITLE
[experiment] os_thread_io_priority_class and os_thread_io_priority_level (ionice for threads)

### DIFF
--- a/src/Common/ErrorCodes.cpp
+++ b/src/Common/ErrorCodes.cpp
@@ -496,6 +496,7 @@ namespace ErrorCodes
     extern const int NO_SUITABLE_FUNCTION_IMPLEMENTATION = 527;
     extern const int CASSANDRA_INTERNAL_ERROR = 528;
     extern const int NOT_A_LEADER = 529;
+    extern const int UNKNOWN_THREAD_IO_PRIORITY_CLASS = 530;
 
     extern const int KEEPER_EXCEPTION = 999;
     extern const int POCO_EXCEPTION = 1000;

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -92,6 +92,7 @@ public:
     const UInt64 thread_id = 0;
     /// Also called "nice" value. If it was changed to non-zero (when attaching query) - will be reset to zero when query is detached.
     Int32 os_thread_priority = 0;
+    ThreadIOPriorityClass io_priority_class = ThreadIOPriorityClass::none;
 
     /// TODO: merge them into common entity
     ProfileEvents::Counters performance_counters{VariableContext::Thread};
@@ -208,6 +209,10 @@ protected:
     std::function<void()> fatal_error_callback;
 
 private:
+    // set I/O scheduling class and priority (wrapper for ioprio_set),
+    // has meaning only on linux & CFQ scheduler
+    inline void setThreadIOPriority(ThreadIOPriorityClass io_priority_class, int io_priority_level);
+
     void setupState(const ThreadGroupStatusPtr & thread_group_);
 };
 

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -157,6 +157,8 @@ struct Settings : public SettingsCollection<Settings>
     \
     M(SettingUInt64, priority, 0, "Priority of the query. 1 - the highest, higher value - lower priority; 0 - do not use priorities.", 0) \
     M(SettingInt64, os_thread_priority, 0, "If non zero - set corresponding 'nice' value for query processing threads. Can be used to adjust query priority for OS scheduler.", 0) \
+    M(SettingThreadIOPriorityClass, os_thread_io_priority_class, ThreadIOPriorityClass::none, "IO priority class for the thread. Possible values are: none, realtime, best_effort, idle. See also: ioprio_set(2)", 0) \
+    M(SettingInt64, os_thread_io_priority_level, 0, "Have meaning only together with os_thread_io_priority_class. The IO priority level determines a priority relative to other processes of the same IO priority class. Priority levels range from 0 (highest) to 7 (lowest). See also: ioprio_set(2)", 0) \
     \
     M(SettingBool, log_queries, 1, "Log requests and write the log to the system table.", 0) \
     M(SettingLogQueriesType, log_queries_min_type, QueryLogElementType::QUERY_START, "Minimal type in query_log to log, possible values (from low to high): QUERY_START, QUERY_FINISH, EXCEPTION_BEFORE_START, EXCEPTION_WHILE_PROCESSING.", 0) \

--- a/src/Core/SettingsCollection.cpp
+++ b/src/Core/SettingsCollection.cpp
@@ -18,6 +18,7 @@ namespace ErrorCodes
     extern const int UNKNOWN_OVERFLOW_MODE;
     extern const int UNKNOWN_TOTALS_MODE;
     extern const int UNKNOWN_DISTRIBUTED_PRODUCT_MODE;
+    extern const int UNKNOWN_THREAD_IO_PRIORITY_CLASS;
     extern const int UNKNOWN_JOIN;
     extern const int SIZE_OF_FIXED_STRING_DOESNT_MATCH;
     extern const int BAD_ARGUMENTS;
@@ -525,6 +526,12 @@ IMPLEMENT_SETTING_ENUM(OverflowMode, OVERFLOW_MODE_LIST_OF_NAMES, ErrorCodes::UN
     M(ANY, "any")
 IMPLEMENT_SETTING_ENUM_WITH_TAG(OverflowMode, SettingOverflowModeGroupByTag, OVERFLOW_MODE_LIST_OF_NAMES_WITH_ANY, ErrorCodes::UNKNOWN_OVERFLOW_MODE)
 
+#define THREAD_IO_PRIORITY_CLASS_OF_NAMES(M) \
+    M(none, "none") \
+    M(realtime, "realtime") \
+    M(best_effort, "best_effort") \
+    M(idle, "idle")
+IMPLEMENT_SETTING_ENUM(ThreadIOPriorityClass, THREAD_IO_PRIORITY_CLASS_OF_NAMES, ErrorCodes::UNKNOWN_THREAD_IO_PRIORITY_CLASS)
 
 #define DISTRIBUTED_PRODUCT_MODE_LIST_OF_NAMES(M) \
     M(DENY, "deny") \

--- a/src/Core/SettingsCollection.h
+++ b/src/Core/SettingsCollection.h
@@ -295,6 +295,16 @@ enum class DistributedProductMode
 };
 using SettingDistributedProductMode = SettingEnum<DistributedProductMode>;
 
+/// The setting for executing distributed subqueries inside IN or JOIN sections.
+enum class ThreadIOPriorityClass
+{
+    none = 0,
+    realtime,
+    best_effort,
+    idle
+};
+using SettingThreadIOPriorityClass = SettingEnum<ThreadIOPriorityClass>;
+
 
 using SettingDateTimeInputFormat = SettingEnum<FormatSettings::DateTimeInputFormat>;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
per-thread ionice (same way as os_thread_priority)

Detailed description / Documentation draft:
See
https://man7.org/linux/man-pages/man2/ioprio_set.2.html 
https://www.kernel.org/doc/Documentation/block/ioprio.txt