### PR TITLE
Improve REVOKE command

### DIFF
--- a/src/Access/AccessRights.h
+++ b/src/Access/AccessRights.h
@@ -93,7 +93,9 @@ public:
 
     /// Merges two sets of access rights together.
     /// It's used to combine access rights from multiple roles.
-    void merge(const AccessRights & other);
+    void makeUnion(const AccessRights & other);
+
+    void makeIntersection(const AccessRights & other);
 
     friend bool operator ==(const AccessRights & left, const AccessRights & right);
     friend bool operator !=(const AccessRights & left, const AccessRights & right) { return !(left == right); }

--- a/src/Access/ContextAccess.h
+++ b/src/Access/ContextAccess.h
@@ -135,6 +135,11 @@ public:
 
     /// Checks if a specified role is granted with admin option, and throws an exception if not.
     void checkAdminOption(const UUID & role_id) const;
+    void checkAdminOption(const UUID & role_id, const String & role_name) const;
+    void checkAdminOption(const UUID & role_id, const std::unordered_map<UUID, String> & names_of_roles) const;
+    void checkAdminOption(const std::vector<UUID> & role_ids) const;
+    void checkAdminOption(const std::vector<UUID> & role_ids, const Strings & names_of_roles) const;
+    void checkAdminOption(const std::vector<UUID> & role_ids, const std::unordered_map<UUID, String> & names_of_roles) const;
 
     /// Makes an instance of ContextAccess which provides full access to everything
     /// without any limitations. This is used for the global context.
@@ -148,7 +153,7 @@ private:
     void setUser(const UserPtr & user_) const;
     void setRolesInfo(const std::shared_ptr<const EnabledRolesInfo> & roles_info_) const;
     void setSettingsAndConstraints() const;
-    void setFinalAccess() const;
+    void calculateAccessRights() const;
 
     template <bool grant_option>
     bool isGrantedImpl(const AccessFlags & flags) const;
@@ -180,6 +185,9 @@ private:
     template <bool grant_option, typename... Args>
     void checkAccessImpl2(const AccessFlags & flags, const Args &... args) const;
 
+    template <typename Container, typename GetNameFunction>
+    void checkAdminOptionImpl(const Container & role_ids, const GetNameFunction & get_name_function) const;
+
     const AccessControlManager * manager = nullptr;
     const Params params;
     mutable Poco::Logger * trace_log = nullptr;
@@ -193,9 +201,10 @@ private:
     mutable std::shared_ptr<const EnabledRowPolicies> enabled_row_policies;
     mutable std::shared_ptr<const EnabledQuota> enabled_quota;
     mutable std::shared_ptr<const EnabledSettings> enabled_settings;
-    mutable std::shared_ptr<const ContextAccess> access_without_readonly;
-    mutable std::shared_ptr<const ContextAccess> access_with_allow_ddl;
-    mutable std::shared_ptr<const ContextAccess> access_with_allow_introspection;
+    mutable std::shared_ptr<const AccessRights> access_without_readonly;
+    mutable std::shared_ptr<const AccessRights> access_with_allow_ddl;
+    mutable std::shared_ptr<const AccessRights> access_with_allow_introspection;
+    mutable std::shared_ptr<const AccessRights> access_from_user_and_roles;
     mutable std::mutex mutex;
 };
 

--- a/src/Access/RoleCache.cpp
+++ b/src/Access/RoleCache.cpp
@@ -43,7 +43,7 @@ namespace
             roles_info.enabled_roles_with_admin_option.emplace(role_id);
 
         roles_info.names_of_roles[role_id] = role->getName();
-        roles_info.access.merge(role->access);
+        roles_info.access.makeUnion(role->access);
         roles_info.settings_from_enabled_roles.merge(role->settings);
 
         for (const auto & granted_role : role->granted_roles.roles)

--- a/src/Interpreters/InterpreterGrantQuery.cpp
+++ b/src/Interpreters/InterpreterGrantQuery.cpp
@@ -9,57 +9,196 @@
 #include <Access/User.h>
 #include <Access/Role.h>
 #include <boost/range/algorithm/copy.hpp>
+#include <boost/range/algorithm/set_algorithm.hpp>
 
 
 namespace DB
 {
 namespace
 {
-    template <typename T>
-    void updateFromQueryImpl(T & grantee, const ASTGrantQuery & query, const std::vector<UUID> & roles_from_query)
+    using Kind = ASTGrantQuery::Kind;
+
+    void doGrantAccess(
+        AccessRights & current_access,
+        const AccessRightsElements & access_to_grant,
+        bool with_grant_option)
     {
-        using Kind = ASTGrantQuery::Kind;
+        if (with_grant_option)
+            current_access.grantWithGrantOption(access_to_grant);
+        else
+            current_access.grant(access_to_grant);
+    }
+
+
+    AccessRightsElements getFilteredAccessRightsElementsToRevoke(
+        const AccessRights & current_access, const AccessRightsElements & access_to_revoke, bool grant_option)
+    {
+        AccessRights intersection;
+        if (grant_option)
+            intersection.grantWithGrantOption(access_to_revoke);
+        else
+            intersection.grant(access_to_revoke);
+        intersection.makeIntersection(current_access);
+
+        AccessRightsElements res;
+        for (auto & element : intersection.getElements())
+        {
+            if ((element.kind == Kind::GRANT) && (element.grant_option || !grant_option))
+                res.emplace_back(std::move(element));
+        }
+
+        return res;
+    }
+
+    void doRevokeAccess(
+        AccessRights & current_access,
+        const AccessRightsElements & access_to_revoke,
+        bool grant_option,
+        const std::shared_ptr<const ContextAccess> & context)
+    {
+        if (context && !context->hasGrantOption(access_to_revoke))
+            context->checkGrantOption(getFilteredAccessRightsElementsToRevoke(current_access, access_to_revoke, grant_option));
+
+        if (grant_option)
+            current_access.revokeGrantOption(access_to_revoke);
+        else
+            current_access.revoke(access_to_revoke);
+    }
+
+
+    void doGrantRoles(GrantedRoles & granted_roles,
+                      const RolesOrUsersSet & roles_to_grant,
+                      bool with_admin_option)
+    {
+        auto ids = roles_to_grant.getMatchingIDs();
+
+        if (with_admin_option)
+            granted_roles.grantWithAdminOption(ids);
+        else
+            granted_roles.grant(ids);
+    }
+
+
+    std::vector<UUID>
+    getFilteredListOfRolesToRevoke(const GrantedRoles & granted_roles, const RolesOrUsersSet & roles_to_revoke, bool admin_option)
+    {
+        std::vector<UUID> ids;
+        if (roles_to_revoke.all)
+        {
+            boost::range::set_difference(
+                admin_option ? granted_roles.roles_with_admin_option : granted_roles.roles,
+                roles_to_revoke.except_ids,
+                std::back_inserter(ids));
+        }
+        else
+        {
+            boost::range::set_intersection(
+                        admin_option ? granted_roles.roles_with_admin_option : granted_roles.roles,
+                        roles_to_revoke.getMatchingIDs(),
+                        std::back_inserter(ids));
+        }
+        return ids;
+    }
+
+    void doRevokeRoles(GrantedRoles & granted_roles,
+                       RolesOrUsersSet * default_roles,
+                       const RolesOrUsersSet & roles_to_revoke,
+                       bool admin_option,
+                       const std::unordered_map<UUID, String> & names_of_roles,
+                       const std::shared_ptr<const ContextAccess> & context)
+    {
+        auto ids = getFilteredListOfRolesToRevoke(granted_roles, roles_to_revoke, admin_option);
+
+        if (context)
+            context->checkAdminOption(ids, names_of_roles);
+
+        if (admin_option)
+            granted_roles.revokeAdminOption(ids);
+        else
+        {
+            granted_roles.revoke(ids);
+            if (default_roles)
+            {
+                for (const UUID & id : ids)
+                    default_roles->ids.erase(id);
+                for (const UUID & id : ids)
+                    default_roles->except_ids.erase(id);
+            }
+        }
+    }
+
+
+    template <typename T>
+    void collectRoleNamesTemplate(
+        std::unordered_map<UUID, String> & names_of_roles,
+        const T & grantee,
+        const ASTGrantQuery & query,
+        const RolesOrUsersSet & roles_from_query,
+        const AccessControlManager & access_control)
+    {
+        for (const auto & id : getFilteredListOfRolesToRevoke(grantee.granted_roles, roles_from_query, query.admin_option))
+        {
+            auto name = access_control.tryReadName(id);
+            if (name)
+                names_of_roles.emplace(id, std::move(*name));
+        }
+    }
+
+    void collectRoleNames(
+        std::unordered_map<UUID, String> & names_of_roles,
+        const IAccessEntity & grantee,
+        const ASTGrantQuery & query,
+        const RolesOrUsersSet & roles_from_query,
+        const AccessControlManager & access_control)
+    {
+        if (const auto * user = typeid_cast<const User *>(&grantee))
+            collectRoleNamesTemplate(names_of_roles, *user, query, roles_from_query, access_control);
+        else if (const auto * role = typeid_cast<const Role *>(&grantee))
+            collectRoleNamesTemplate(names_of_roles, *role, query, roles_from_query, access_control);
+    }
+
+
+    template <typename T>
+    void updateFromQueryTemplate(
+        T & grantee,
+        const ASTGrantQuery & query,
+        const RolesOrUsersSet & roles_from_query,
+        const std::unordered_map<UUID, String> & names_of_roles,
+        const std::shared_ptr<const ContextAccess> & context)
+    {
         if (!query.access_rights_elements.empty())
         {
             if (query.kind == Kind::GRANT)
-            {
-                if (query.grant_option)
-                    grantee.access.grantWithGrantOption(query.access_rights_elements);
-                else
-                    grantee.access.grant(query.access_rights_elements);
-            }
+                doGrantAccess(grantee.access, query.access_rights_elements, query.grant_option);
             else
-            {
-                if (query.grant_option)
-                    grantee.access.revokeGrantOption(query.access_rights_elements);
-                else
-                    grantee.access.revoke(query.access_rights_elements);
-            }
+                doRevokeAccess(grantee.access, query.access_rights_elements, query.grant_option, context);
         }
 
         if (!roles_from_query.empty())
         {
             if (query.kind == Kind::GRANT)
-            {
-                if (query.admin_option)
-                    grantee.granted_roles.grantWithAdminOption(roles_from_query);
-                else
-                    grantee.granted_roles.grant(roles_from_query);
-            }
+                doGrantRoles(grantee.granted_roles, roles_from_query, query.admin_option);
             else
             {
-                if (query.admin_option)
-                    grantee.granted_roles.revokeAdminOption(roles_from_query);
-                else
-                    grantee.granted_roles.revoke(roles_from_query);
-
+                RolesOrUsersSet * grantee_default_roles = nullptr;
                 if constexpr (std::is_same_v<T, User>)
-                {
-                    for (const UUID & role_from_query : roles_from_query)
-                        grantee.default_roles.ids.erase(role_from_query);
-                }
+                    grantee_default_roles = &grantee.default_roles;
+                doRevokeRoles(grantee.granted_roles, grantee_default_roles, roles_from_query, query.admin_option, names_of_roles, context);
             }
         }
+    }
+
+    void updateFromQueryImpl(
+        IAccessEntity & grantee,
+        const ASTGrantQuery & query,
+        const RolesOrUsersSet & roles_from_query,
+        const std::unordered_map<UUID, String> & names_or_roles,
+        const std::shared_ptr<const ContextAccess> & context)
+    {
+        if (auto * user = typeid_cast<User *>(&grantee))
+            updateFromQueryTemplate(*user, query, roles_from_query, names_or_roles, context);
+        else if (auto * role = typeid_cast<Role *>(&grantee))
+            updateFromQueryTemplate(*role, query, roles_from_query, names_or_roles, context);
     }
 }
 
@@ -68,40 +207,45 @@ BlockIO InterpreterGrantQuery::execute()
 {
     auto & query = query_ptr->as<ASTGrantQuery &>();
     query.replaceCurrentUserTagWithName(context.getUserName());
-    auto access = context.getAccess();
-    auto & access_control = context.getAccessControlManager();
-
-    std::vector<UUID> roles_from_query;
-    if (query.roles)
-    {
-        roles_from_query = RolesOrUsersSet{*query.roles, access_control}.getMatchingIDs(access_control);
-        for (const UUID & role_from_query : roles_from_query)
-            access->checkAdminOption(role_from_query);
-    }
 
     if (!query.cluster.empty())
         return executeDDLQueryOnCluster(query_ptr, context, query.access_rights_elements, true);
 
+    auto access = context.getAccess();
+    auto & access_control = context.getAccessControlManager();
     query.replaceEmptyDatabaseWithCurrent(context.getCurrentDatabase());
-    access->checkGrantOption(query.access_rights_elements);
+
+    RolesOrUsersSet roles_from_query;
+    if (query.roles)
+        roles_from_query = RolesOrUsersSet{*query.roles, access_control};
 
     std::vector<UUID> to_roles = RolesOrUsersSet{*query.to_roles, access_control, context.getUserID()}.getMatchingIDs(access_control);
+
+    std::unordered_map<UUID, String> names_of_roles;
+    if (!roles_from_query.empty() && (query.kind == Kind::REVOKE))
+    {
+        for (const auto & id : to_roles)
+        {
+            auto entity = access_control.tryRead(id);
+            if (entity)
+                collectRoleNames(names_of_roles, *entity, query, roles_from_query, access_control);
+        }
+    }
+
+    if (query.kind == Kind::GRANT) /// For Kind::REVOKE the grant/admin option is checked inside updateFromQueryImpl().
+    {
+        if (!query.access_rights_elements.empty())
+            access->checkGrantOption(query.access_rights_elements);
+
+        if (!roles_from_query.empty())
+            access->checkAdminOption(roles_from_query.getMatchingIDs());
+    }
 
     auto update_func = [&](const AccessEntityPtr & entity) -> AccessEntityPtr
     {
         auto clone = entity->clone();
-        if (auto user = typeid_cast<std::shared_ptr<User>>(clone))
-        {
-            updateFromQueryImpl(*user, query, roles_from_query);
-            return user;
-        }
-        else if (auto role = typeid_cast<std::shared_ptr<Role>>(clone))
-        {
-            updateFromQueryImpl(*role, query, roles_from_query);
-            return role;
-        }
-        else
-            return entity;
+        updateFromQueryImpl(*clone, query, roles_from_query, names_of_roles, access);
+        return clone;
     };
 
     access_control.update(to_roles, update_func);
@@ -112,19 +256,19 @@ BlockIO InterpreterGrantQuery::execute()
 
 void InterpreterGrantQuery::updateUserFromQuery(User & user, const ASTGrantQuery & query)
 {
-    std::vector<UUID> roles_from_query;
+    RolesOrUsersSet roles_from_query;
     if (query.roles)
-        roles_from_query = RolesOrUsersSet{*query.roles}.getMatchingIDs();
-    updateFromQueryImpl(user, query, roles_from_query);
+        roles_from_query = RolesOrUsersSet{*query.roles};
+    updateFromQueryImpl(user, query, roles_from_query, {}, nullptr);
 }
 
 
 void InterpreterGrantQuery::updateRoleFromQuery(Role & role, const ASTGrantQuery & query)
 {
-    std::vector<UUID> roles_from_query;
+    RolesOrUsersSet roles_from_query;
     if (query.roles)
-        roles_from_query = RolesOrUsersSet{*query.roles}.getMatchingIDs();
-    updateFromQueryImpl(role, query, roles_from_query);
+        roles_from_query = RolesOrUsersSet{*query.roles};
+    updateFromQueryImpl(role, query, roles_from_query, {}, nullptr);
 }
 
 }

--- a/tests/integration/test_create_user_and_login/test.py
+++ b/tests/integration/test_create_user_and_login/test.py
@@ -64,6 +64,56 @@ def test_grant_option():
     instance.query('REVOKE SELECT ON test.table FROM A, B')
 
 
+def test_revoke_requires_grant_option():
+    instance.query("CREATE USER A")
+    instance.query("CREATE USER B")
+    
+    instance.query("GRANT SELECT ON test.table TO B")
+    assert instance.query("SHOW GRANTS FOR B") == "GRANT SELECT ON test.table TO B\n"
+
+    expected_error = "Not enough privileges"
+    assert expected_error in instance.query_and_get_error("REVOKE SELECT ON test.table FROM B", user='A')
+    assert instance.query("SHOW GRANTS FOR B") == "GRANT SELECT ON test.table TO B\n"
+
+    instance.query("GRANT SELECT ON test.table TO A")
+    expected_error = "privileges have been granted, but without grant option"
+    assert expected_error in instance.query_and_get_error("REVOKE SELECT ON test.table FROM B", user='A')
+    assert instance.query("SHOW GRANTS FOR B") == "GRANT SELECT ON test.table TO B\n"
+
+    instance.query("GRANT SELECT ON test.table TO A WITH GRANT OPTION")
+    assert instance.query("SHOW GRANTS FOR B") == "GRANT SELECT ON test.table TO B\n"
+    instance.query("REVOKE SELECT ON test.table FROM B", user='A')
+    assert instance.query("SHOW GRANTS FOR B") == ""
+
+    instance.query("GRANT SELECT ON test.table TO B")
+    assert instance.query("SHOW GRANTS FOR B") == "GRANT SELECT ON test.table TO B\n"
+    instance.query("REVOKE SELECT ON test.* FROM B", user='A')
+    assert instance.query("SHOW GRANTS FOR B") == ""
+
+    instance.query("GRANT SELECT ON test.table TO B")
+    assert instance.query("SHOW GRANTS FOR B") == "GRANT SELECT ON test.table TO B\n"
+    instance.query("REVOKE ALL ON test.* FROM B", user='A')
+    assert instance.query("SHOW GRANTS FOR B") == ""
+
+    instance.query("GRANT SELECT ON test.table TO B")
+    assert instance.query("SHOW GRANTS FOR B") == "GRANT SELECT ON test.table TO B\n"
+    instance.query("REVOKE ALL ON *.* FROM B", user='A')
+    assert instance.query("SHOW GRANTS FOR B") == ""
+
+    instance.query("REVOKE GRANT OPTION FOR ALL ON *.* FROM A")
+    instance.query("GRANT SELECT ON test.table TO B")
+    assert instance.query("SHOW GRANTS FOR B") == "GRANT SELECT ON test.table TO B\n"
+    expected_error = "privileges have been granted, but without grant option"
+    assert expected_error in instance.query_and_get_error("REVOKE SELECT ON test.table FROM B", user='A')
+    assert instance.query("SHOW GRANTS FOR B") == "GRANT SELECT ON test.table TO B\n"
+
+    instance.query("GRANT SELECT ON test.* TO A WITH GRANT OPTION")
+    instance.query("GRANT SELECT ON test.table TO B")
+    assert instance.query("SHOW GRANTS FOR B") == "GRANT SELECT ON test.table TO B\n"
+    instance.query("REVOKE SELECT ON test.table FROM B", user='A')
+    assert instance.query("SHOW GRANTS FOR B") == ""
+
+
 def test_introspection():
     instance.query("CREATE USER A")
     instance.query("CREATE USER B")

--- a/tests/integration/test_role/test.py
+++ b/tests/integration/test_role/test.py
@@ -97,6 +97,48 @@ def test_admin_option():
     assert instance.query("SELECT * FROM test_table", user='B') == "1\t5\n2\t10\n"
 
 
+def test_revoke_requires_admin_option():
+    instance.query("CREATE USER A, B")
+    instance.query("CREATE ROLE R1, R2")
+    
+    instance.query("GRANT R1 TO B")
+    assert instance.query("SHOW GRANTS FOR B") == "GRANT R1 TO B\n"
+
+    expected_error = "necessary to have the role R1 granted"
+    assert expected_error in instance.query_and_get_error("REVOKE R1 FROM B", user='A')
+    assert instance.query("SHOW GRANTS FOR B") == "GRANT R1 TO B\n"
+
+    instance.query("GRANT R1 TO A")
+    expected_error = "granted, but without ADMIN option"
+    assert expected_error in instance.query_and_get_error("REVOKE R1 FROM B", user='A')
+    assert instance.query("SHOW GRANTS FOR B") == "GRANT R1 TO B\n"
+
+    instance.query("GRANT R1 TO A WITH ADMIN OPTION")
+    instance.query("REVOKE R1 FROM B", user='A')
+    assert instance.query("SHOW GRANTS FOR B") == ""
+
+    instance.query("GRANT R1 TO B")
+    assert instance.query("SHOW GRANTS FOR B") == "GRANT R1 TO B\n"
+    instance.query("REVOKE ALL FROM B", user='A')
+    assert instance.query("SHOW GRANTS FOR B") == ""
+
+    instance.query("GRANT R1, R2 TO B")
+    assert instance.query("SHOW GRANTS FOR B") == "GRANT R1, R2 TO B\n"
+    expected_error = "necessary to have the role R2 granted"
+    assert expected_error in instance.query_and_get_error("REVOKE ALL FROM B", user='A')
+    assert instance.query("SHOW GRANTS FOR B") == "GRANT R1, R2 TO B\n"
+    instance.query("REVOKE ALL EXCEPT R2 FROM B", user='A')
+    assert instance.query("SHOW GRANTS FOR B") == "GRANT R2 TO B\n"
+    instance.query("GRANT R2 TO A WITH ADMIN OPTION")
+    instance.query("REVOKE ALL FROM B", user='A')
+    assert instance.query("SHOW GRANTS FOR B") == ""
+
+    instance.query("GRANT R1, R2 TO B")
+    assert instance.query("SHOW GRANTS FOR B") == "GRANT R1, R2 TO B\n"
+    instance.query("REVOKE ALL FROM B", user='A')
+    assert instance.query("SHOW GRANTS FOR B") == ""
+
+
 def test_introspection():
     instance.query("CREATE USER A")
     instance.query("CREATE USER B")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Improvement

Changelog entry:
Improves `REVOKE` command: now it requires grant/admin option for only access which will be revoked. For example, to execute `REVOKE ALL ON *.* FROM user1` now it doesn't require to have full access rights granted with grant option.
Added command `REVOKE ALL FROM user1` - it revokes all granted roles from `user1`.
