### PR TITLE
[docker] install ca-certificates before the first apt-get update

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -6,6 +6,7 @@ ARG version=20.6.1.*
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
         apt-transport-https \
+        ca-certificates \
         dirmngr \
         gnupg \
     && mkdir -p /etc/apt/sources.list.d \

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -7,6 +7,7 @@ ARG gosu_ver=1.10
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
         apt-transport-https \
+        ca-certificates \
         dirmngr \
         gnupg \
     && mkdir -p /etc/apt/sources.list.d \
@@ -19,7 +20,6 @@ RUN apt-get update \
             clickhouse-client=$version \
             clickhouse-server=$version \
             locales \
-            ca-certificates \
             wget \
     && rm -rf \
         /var/lib/apt/lists/* \


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Install `ca-certificates` before the first `apt-get update` in Dockerfile.

