### PR TITLE
Enable CodeQL security scanner

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,33 @@
+name: "CodeQL Scanning"
+
+on:
+  schedule:
+    - cron: '0 19 * * *'
+jobs:
+  CodeQL-Build:
+
+    runs-on: self-hosted
+    timeout-minutes: 1440
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
+        submodules: 'recursive'
+
+    - run: git checkout HEAD^2
+      if: ${{ github.event_name == 'pull_request' }}
+      
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+
+      with:
+        languages: cpp
+
+    - run: sudo apt-get update && sudo apt-get install -y git cmake python ninja-build gcc-9 g++-9 && mkdir build
+    - run: cd build && CC=gcc-9 CXX=g++-9 cmake ..
+    - run: cd build && ninja
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Daily check by [GitHub CodeQL](https://securitylab.github.com/tools/codeql) security analysis tool that looks for [CWE](https://cwe.mitre.org/). 

Detailed description / Documentation draft:
On ClickHouse fork found 175 instances of 7 different [CWE](https://cwe.mitre.org/) (including `contrib`). Takes 10+ hours, so can't be run frequently.
