### PR TITLE
Fix version column in replicated version collapsing merge tree

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeTableMetadata.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeTableMetadata.cpp
@@ -40,13 +40,10 @@ ReplicatedMergeTreeTableMetadata::ReplicatedMergeTreeTableMetadata(const MergeTr
     /// So rules in zookeeper metadata is following:
     /// - When we have only ORDER BY, than store it in "primary key:" row of /metadata
     /// - When we have both, than store PRIMARY KEY in "primary key:" row and ORDER BY in "sorting key:" row of /metadata
-    if (!metadata_snapshot->isPrimaryKeyDefined())
-        primary_key = formattedAST(metadata_snapshot->getSortingKey().expression_list_ast);
-    else
-    {
-        primary_key = formattedAST(metadata_snapshot->getPrimaryKey().expression_list_ast);
+
+    primary_key = formattedAST(metadata_snapshot->getPrimaryKey().expression_list_ast);
+    if (metadata_snapshot->isPrimaryKeyDefined())
         sorting_key = formattedAST(metadata_snapshot->getSortingKey().expression_list_ast);
-    }
 
     data_format_version = data.format_version;
 

--- a/tests/queries/0_stateless/01357_version_collapsing_attach_detach_zookeeper.reference
+++ b/tests/queries/0_stateless/01357_version_collapsing_attach_detach_zookeeper.reference
@@ -1,0 +1,3 @@
+metadata format version: 1\ndate column: \nsampling expression: \nindex granularity: 8192\nmode: 7\nsign column: sign\nprimary key: key1, key2\ndata format version: 1\npartition key: d\ngranularity bytes: 10485760\n
+1
+1

--- a/tests/queries/0_stateless/01357_version_collapsing_attach_detach_zookeeper.sql
+++ b/tests/queries/0_stateless/01357_version_collapsing_attach_detach_zookeeper.sql
@@ -1,0 +1,26 @@
+DROP TABLE IF EXISTS versioned_collapsing_table;
+
+CREATE TABLE versioned_collapsing_table(
+  d Date,
+  key1 UInt64,
+  key2 UInt32,
+  value String,
+  sign Int8,
+  version UInt16
+)
+ENGINE = ReplicatedVersionedCollapsingMergeTree('/clickhouse/versioned_collapsing_table', '1', sign, version)
+PARTITION BY d
+ORDER BY (key1, key2);
+
+INSERT INTO versioned_collapsing_table VALUES (toDate('2019-10-10'), 1, 1, 'Hello', -1, 1);
+
+SELECT value FROM system.zookeeper WHERE path = '/clickhouse/versioned_collapsing_table' and name = 'metadata';
+
+SELECT COUNT() FROM versioned_collapsing_table;
+
+DETACH TABLE versioned_collapsing_table;
+ATTACH TABLE versioned_collapsing_table;
+
+SELECT COUNT() FROM versioned_collapsing_table;
+
+DROP TABLE IF EXISTS versioned_collapsing_table;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bug which leads to incorrect table metadata in ZooKeepeer for ReplicatedVersionedCollapsingMergeTree tables. Fixes #12093.