### PR TITLE
Normalize "pid" file handling #3501

### DIFF
--- a/base/daemon/BaseDaemon.h
+++ b/base/daemon/BaseDaemon.h
@@ -22,6 +22,7 @@
 #include <common/getThreadId.h>
 #include <daemon/GraphiteWriter.h>
 #include <Common/Config/ConfigProcessor.h>
+#include <Common/StatusFile.h>
 #include <loggers/Loggers.h>
 
 
@@ -163,16 +164,7 @@ protected:
 
     std::unique_ptr<Poco::TaskManager> task_manager;
 
-    /// RAII wrapper for pid file.
-    struct PID
-    {
-        std::string file;
-
-        PID(const std::string & file_);
-        ~PID();
-    };
-
-    std::optional<PID> pid;
+    std::optional<DB::StatusFile> pid;
 
     std::atomic_bool is_cancelled{false};
 

--- a/programs/copier/ClusterCopierApp.cpp
+++ b/programs/copier/ClusterCopierApp.cpp
@@ -1,4 +1,6 @@
 #include "ClusterCopierApp.h"
+#include <Common/StatusFile.h>
+
 
 namespace DB
 {
@@ -91,7 +93,7 @@ void ClusterCopierApp::defineOptions(Poco::Util::OptionSet & options)
 
 void ClusterCopierApp::mainImpl()
 {
-    StatusFile status_file(process_path + "/status");
+    StatusFile status_file(process_path + "/status", StatusFile::write_full_info);
     ThreadStatus thread_status;
 
     auto * log = &logger();

--- a/programs/copier/Internals.h
+++ b/programs/copier/Internals.h
@@ -66,7 +66,6 @@
 #include <Dictionaries/registerDictionaries.h>
 #include <Disks/registerDisks.h>
 #include <Databases/DatabaseMemory.h>
-#include <Common/StatusFile.h>
 
 #include "Aliases.h"
 

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -248,7 +248,7 @@ try
     if (!context->getPath().empty())
     {
         /// Lock path directory before read
-        status.emplace(context->getPath() + "status");
+        status.emplace(context->getPath() + "status", StatusFile::write_full_info);
 
         LOG_DEBUG(log, "Loading metadata from {}", context->getPath());
         loadMetadataSystem(*context);

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -378,7 +378,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
 
     global_context->setPath(path);
 
-    StatusFile status{path + "status"};
+    StatusFile status{path + "status", StatusFile::write_full_info};
 
     SCOPE_EXIT({
         /** Ask to cancel background jobs all table engines,

--- a/src/Common/StatusFile.cpp
+++ b/src/Common/StatusFile.cpp
@@ -32,7 +32,7 @@ namespace ErrorCodes
 
 StatusFile::FillFunction StatusFile::write_pid = [](WriteBuffer & out)
 {
-    out << getpid() << "\n";
+    out << getpid();
 };
 
 StatusFile::FillFunction StatusFile::write_full_info = [](WriteBuffer & out)

--- a/src/Common/StatusFile.cpp
+++ b/src/Common/StatusFile.cpp
@@ -30,8 +30,21 @@ namespace ErrorCodes
 }
 
 
-StatusFile::StatusFile(const std::string & path_)
-    : path(path_)
+StatusFile::FillFunction StatusFile::write_pid = [](WriteBuffer & out)
+{
+    out << getpid() << "\n";
+};
+
+StatusFile::FillFunction StatusFile::write_full_info = [](WriteBuffer & out)
+{
+    out << "PID: " << getpid() << "\n"
+        << "Started at: " << LocalDateTime(time(nullptr)) << "\n"
+        << "Revision: " << ClickHouseRevision::get() << "\n";
+};
+
+
+StatusFile::StatusFile(std::string path_, FillFunction fill_)
+    : path(std::move(path_)), fill(std::move(fill_))
 {
     /// If file already exists. NOTE Minor race condition.
     if (Poco::File(path).exists())
@@ -72,13 +85,8 @@ StatusFile::StatusFile(const std::string & path_)
             throwFromErrnoWithPath("Cannot lseek " + path, path, ErrorCodes::CANNOT_SEEK_THROUGH_FILE);
 
         /// Write information about current server instance to the file.
-        {
-            WriteBufferFromFileDescriptor out(fd, 1024);
-            out
-                << "PID: " << getpid() << "\n"
-                << "Started at: " << LocalDateTime(time(nullptr)) << "\n"
-                << "Revision: " << ClickHouseRevision::get() << "\n";
-        }
+        WriteBufferFromFileDescriptor out(fd, 1024);
+        fill(out);
     }
     catch (...)
     {

--- a/src/Common/StatusFile.h
+++ b/src/Common/StatusFile.h
@@ -1,11 +1,14 @@
 #pragma once
 
 #include <string>
+#include <functional>
 #include <boost/noncopyable.hpp>
 
 
 namespace DB
 {
+
+class WriteBuffer;
 
 
 /** Provides that no more than one server works with one data directory.
@@ -13,11 +16,18 @@ namespace DB
 class StatusFile : private boost::noncopyable
 {
 public:
-    explicit StatusFile(const std::string & path_);
+    using FillFunction = std::function<void(WriteBuffer&)>;
+
+    StatusFile(std::string path_, FillFunction fill_);
     ~StatusFile();
+
+    /// You can use one of these functions to fill the file or provide your own.
+    static FillFunction write_pid;
+    static FillFunction write_full_info;
 
 private:
     const std::string path;
+    FillFunction fill;
     int fd = -1;
 };
 


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Normalize "pid" file handling. In previous versions the server may refuse to start if it was killed without proper shutdown and if there is another process that has the same pid as previously runned server. Also pid file may be removed in unsuccessful server startup even if there is another server running. This fixes #3501.


Detailed description / Documentation draft:
No tests will be provided for this fix.