### PR TITLE
Add missed <atomic> include in ProxyListConfiguration

### DIFF
--- a/src/Disks/S3/ProxyListConfiguration.h
+++ b/src/Disks/S3/ProxyListConfiguration.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic> // for std::atomic<size_t>
+
 #include "ProxyConfiguration.h"
 
 namespace DB::S3


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Missed `<atomic>` is required for `std::atomic<>`.

