### PR TITLE
Run perf tests with memory sampling (for allocations >1M)

### DIFF
--- a/docker/test/performance-comparison/config/users.d/perf-comparison-tweaks-users.xml
+++ b/docker/test/performance-comparison/config/users.d/perf-comparison-tweaks-users.xml
@@ -6,6 +6,8 @@
             <allow_introspection_functions>1</allow_introspection_functions>
             <log_queries>1</log_queries>
             <metrics_perf_events_enabled>1</metrics_perf_events_enabled>
+            <memory_profiler_sample_probability>1</memory_profiler_sample_probability>
+            <max_untracked_memory>1048576</max_untracked_memory> <!-- 1MB -->
         </default>
     </profiles>
 </yandex>


### PR DESCRIPTION
This is to know the memory allocation size distribution, that can be
obtained later from left-trace-log.tsv.

This is an attempt to tune tcmalloc (new CPP version by google) to use
lock-free part of the allocator for typical allocations (and it is a bad
idea just to increase kMaxSize there, since number of allocation for
each size class is also important).

P.S. hope that this file will be applied, if no, then the same effect
can be reached by tunning defaults in Settings.h

Refs: #11590
Cc: @akuzm

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<details>

HEAD's:
- 307c3c92a586e0cde9f5522607bb5d951df32103

</details>