### PR TITLE
Change exception code from LOGICAL_ERROR to BAD_ARGUMENTS when the name of remote table is empty.

### DIFF
--- a/src/TableFunctions/TableFunctionRemote.cpp
+++ b/src/TableFunctions/TableFunctionRemote.cpp
@@ -186,7 +186,7 @@ StoragePtr TableFunctionRemote::executeImpl(const ASTPtr & ast_function, const C
             secure);
     }
 
-    if (remote_table.empty())
+    if (!remote_table_function_ptr && remote_table.empty())
         throw Exception("The name of remote table cannot be empty", ErrorCodes::BAD_ARGUMENTS);
 
     auto remote_table_id = StorageID::createEmpty();

--- a/src/TableFunctions/TableFunctionRemote.cpp
+++ b/src/TableFunctions/TableFunctionRemote.cpp
@@ -186,6 +186,9 @@ StoragePtr TableFunctionRemote::executeImpl(const ASTPtr & ast_function, const C
             secure);
     }
 
+    if (remote_table.empty())
+        throw Exception("The name of remote table cannot be empty", ErrorCodes::BAD_ARGUMENTS);
+
     auto remote_table_id = StorageID::createEmpty();
     remote_table_id.database_name = remote_database;
     remote_table_id.table_name = remote_table;

--- a/tests/queries/0_stateless/01372_remote_table_function_empty_table.sql
+++ b/tests/queries/0_stateless/01372_remote_table_function_empty_table.sql
@@ -1,0 +1,1 @@
+SELECT * FROM remote('127..2', 'a.'); -- { serverError 36 }


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Not a bug. We ensure that logical errors should never happen.
This fixes #12146.