### PR TITLE
Fix transform query for external databases in presense of aliases

### DIFF
--- a/src/Interpreters/JoinToSubqueryTransformVisitor.cpp
+++ b/src/Interpreters/JoinToSubqueryTransformVisitor.cpp
@@ -257,7 +257,7 @@ struct ColumnAliasesMatcher
             if (!last_table)
             {
                 IdentifierSemantic::coverName(node, alias);
-                node.setAlias("");
+                node.setAlias({});
             }
         }
         else if (node.compound())

--- a/src/Interpreters/PredicateRewriteVisitor.cpp
+++ b/src/Interpreters/PredicateRewriteVisitor.cpp
@@ -76,7 +76,7 @@ static void cleanAliasAndCollectIdentifiers(ASTPtr & predicate, std::vector<ASTI
     }
 
     if (const auto alias = predicate->tryGetAlias(); !alias.empty())
-        predicate->setAlias("");
+        predicate->setAlias({});
 
     if (ASTIdentifier * identifier = predicate->as<ASTIdentifier>())
         identifiers.emplace_back(identifier);


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix transform of query to send to external DBMS (e.g. MySQL, ODBC) in presense of aliases. This fixes #12032.
