### PR TITLE
Support MySQL 'KILL QUERY [connection_id]'

### DIFF
--- a/src/Server/MySQLHandler.h
+++ b/src/Server/MySQLHandler.h
@@ -73,6 +73,7 @@ protected:
 
 private:
     static const String show_table_status_replacement_query;
+    String kill_connection_id_replacement_query(const String & query);
 };
 
 #if USE_SSL

--- a/src/Server/MySQLHandler.h
+++ b/src/Server/MySQLHandler.h
@@ -72,8 +72,9 @@ protected:
     bool secure_connection = false;
 
 private:
-    static const String show_table_status_replacement_query;
-    String kill_connection_id_replacement_query(const String & query);
+    using ReplacementFn = std::function<String(const String & query)>;
+    using Replacements = std::unordered_map<std::string, ReplacementFn>;
+    Replacements replacements;
 };
 
 #if USE_SSL

--- a/tests/integration/test_mysql_protocol/test.py
+++ b/tests/integration/test_mysql_protocol/test.py
@@ -138,6 +138,34 @@ def test_mysql_client(mysql_client, server_address):
     assert stdout == '\n'.join(['column', '0', '0', '1', '1', '5', '5', 'tmp_column', '0', '1', ''])
 
 
+    # Show table status.
+    code, (stdout, stderr) = mysql_client.exec_run('''
+        mysql --protocol tcp -h {host} -P {port} default -u default
+        --password=123 -e "show table status like 'xx';"
+    '''.format(host=server_address, port=server_port), demux=True)
+    assert code == 0
+
+    # show variables.
+    code, (stdout, stderr) = mysql_client.exec_run('''
+        mysql --protocol tcp -h {host} -P {port} default -u default
+        --password=123 -e "show variables;"
+    '''.format(host=server_address, port=server_port), demux=True)
+    assert code == 0
+
+    # Kill query.
+    code, (stdout, stderr) = mysql_client.exec_run('''
+        mysql --protocol tcp -h {host} -P {port} default -u default
+        --password=123 -e "kill query 0;"
+    '''.format(host=server_address, port=server_port), demux=True)
+    assert code == 0
+
+    code, (stdout, stderr) = mysql_client.exec_run('''
+        mysql --protocol tcp -h {host} -P {port} default -u default
+        --password=123 -e "kill query where query_id='mysql:0';"
+    '''.format(host=server_address, port=server_port), demux=True)
+    assert code == 0
+
+
 def test_mysql_federated(mysql_server, server_address):
     # For some reason it occasionally fails without retries.
     retries = 100


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add `KILL QUERY [connection_id]` for the MySQL client/driver to cancel the long query, issue #12038


2. Add MySQL -> ClickHouse query replacements mapping table to clean the code.


Detailed description / Documentation draft:

...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.
