### PR TITLE
Attempt to fix flaky test 00721_force_by_identical_result_after_merge

### DIFF
--- a/tests/queries/0_stateless/00721_force_by_identical_result_after_merge_zookeeper.sql
+++ b/tests/queries/0_stateless/00721_force_by_identical_result_after_merge_zookeeper.sql
@@ -10,6 +10,8 @@ SYSTEM SYNC REPLICA byte_identical_r2;
 -- Add a column with a default expression that will yield different values on different replicas.
 -- Call optimize to materialize it. Replicas should compare checksums and restore consistency.
 ALTER TABLE byte_identical_r1 ADD COLUMN y UInt64 DEFAULT rand();
+SYSTEM SYNC REPLICA byte_identical_r1;
+SYSTEM SYNC REPLICA byte_identical_r2;
 OPTIMIZE TABLE byte_identical_r1 PARTITION tuple() FINAL;
 
 SELECT x, t1.y - t2.y FROM byte_identical_r1 t1 SEMI LEFT JOIN byte_identical_r2 t2 USING x ORDER BY x;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

See https://clickhouse-test-reports.s3.yandex.net/12153/5a055142c3f7124cf299d3c84a970f8259c41d5e/functional_stateless_tests_(debug).html#fail1