### PR TITLE
Sanitize LINK_LIBRARIES property for the directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,3 +421,5 @@ add_subdirectory (tests)
 add_subdirectory (utils)
 
 include (cmake/print_include_directories.cmake)
+
+include (cmake/sanitize_target_link_libraries.cmake)

--- a/cmake/sanitize_target_link_libraries.cmake
+++ b/cmake/sanitize_target_link_libraries.cmake
@@ -1,0 +1,56 @@
+# When you will try to link target with the directory (that exists), cmake will
+# skip this without an error, only the following warning will be reported:
+#
+#     target_link_libraries(main /tmp)
+#
+#     WARNING: Target "main" requests linking to directory "/tmp".  Targets may link only to libraries.  CMake is dropping the item.
+#
+# And there is no cmake policy that controls this.
+# (I guess the reason that it is allowed is because of FRAMEWORK for OSX).
+#
+# So to avoid error-prone cmake rules, this can be sanitized.
+# There are the following ways:
+# - overwrite target_link_libraries()/link_libraries() and check *before*
+#   calling real macro, but this requires duplicate all supported syntax
+#   -- too complex
+# - overwrite target_link_libraries() and check LINK_LIBRARIES property, this
+#   works great
+#   -- but cannot be used with link_libraries()
+# - use BUILDSYSTEM_TARGETS property to get list of all targets and sanitize
+#   -- this will work.
+
+# https://stackoverflow.com/a/62311397/328260
+function (get_all_targets var)
+    set (targets)
+    get_all_targets_recursive (targets ${CMAKE_CURRENT_SOURCE_DIR})
+    set (${var} ${targets} PARENT_SCOPE)
+endfunction()
+macro (get_all_targets_recursive targets dir)
+    get_property (subdirectories DIRECTORY ${dir} PROPERTY SUBDIRECTORIES)
+    foreach (subdir ${subdirectories})
+        get_all_targets_recursive (${targets} ${subdir})
+    endforeach ()
+    get_property (current_targets DIRECTORY ${dir} PROPERTY BUILDSYSTEM_TARGETS)
+    list (APPEND ${targets} ${current_targets})
+endmacro ()
+
+macro (sanitize_link_libraries target)
+    get_target_property(target_type ${target} TYPE)
+    if (${target_type} STREQUAL "INTERFACE_LIBRARY")
+        get_property(linked_libraries TARGET ${target} PROPERTY INTERFACE_LINK_LIBRARIES)
+    else()
+        get_property(linked_libraries TARGET ${target} PROPERTY LINK_LIBRARIES)
+    endif()
+    foreach (linked_library ${linked_libraries})
+        if (TARGET ${linked_library})
+            # just in case, skip if TARGET
+        elseif (IS_DIRECTORY ${linked_library})
+            message(FATAL_ERROR "${target} requested to link with directory: ${linked_library}")
+        endif()
+    endforeach()
+endmacro()
+
+get_all_targets (all_targets)
+foreach (target ${all_targets})
+    sanitize_link_libraries(${target})
+endforeach()


### PR DESCRIPTION
When you will try to link target with the directory (that exists), cmake will
skip this without an error, only the following warning will be reported:

    target_link_libraries(main /tmp)

    WARNING: Target "main" requests linking to directory "/tmp".  Targets may link only to libraries.  CMake is dropping the item.

And there is no cmake policy that controls this.
(I guess the reason that it is allowed is because of [FRAMEWORK for OSX](https://github.com/Kitware/CMake/blob/c68c744497c0b34db15dadb9f7a80543dd2bf9f4/Source/cmComputeLinkInformation.cxx#L1306-L1326)).

So to avoid error-prone cmake rules, this can be sanitized.
There are the following ways:
- overwrite target_link_libraries()/link_libraries() and check *before*
  calling real macro, but this requires duplicate all supported syntax
  -- too complex
- overwrite target_link_libraries() and check LINK_LIBRARIES property, this
  works great
  -- but cannot be used with link_libraries()
- use BUILDSYSTEM_TARGETS property to get list of all targets and sanitize
  -- this will work.

I also tested it with the following patch:

    $ git di
    diff --git a/base/daemon/CMakeLists.txt b/base/daemon/CMakeLists.txt
    index 26d59a57e7..35e6ff6432 100644
    --- a/base/daemon/CMakeLists.txt
    +++ b/base/daemon/CMakeLists.txt
    @@ -9,4 +9,5 @@ target_link_libraries (daemon PUBLIC loggers PRIVATE clickhouse_common_io clickh

     if (USE_SENTRY)
         target_link_libraries (daemon PRIVATE ${SENTRY_LIBRARY})
    +    target_link_libraries (daemon PRIVATE /tmp)
     endif ()

And it works:

    CMake Error at cmake/sanitize_target_link_libraries.cmake:48 (message):
       daemon requested to link with directory: /tmp
    Call Stack (most recent call first):
      cmake/sanitize_target_link_libraries.cmake:55 (sanitize_link_libraries)
      CMakeLists.txt:425 (include)

Refs: #12041

Changelog category (leave one):
- Not for changelog (changelog entry is not required)