### PR TITLE
[docs] add redirect from an introduction index page

### DIFF
--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -161,6 +161,7 @@ interfaces/third-party/client_libraries.md interfaces/third-party/client-librari
 interfaces/third-party_client_libraries.md interfaces/third-party/client-libraries.md
 interfaces/third-party_gui.md interfaces/third-party/gui.md
 interfaces/third_party/index.md interfaces/third-party/index.md
+introduction/index.md 
 introduction/distinctive_features.md introduction/distinctive-features.md
 introduction/features_considered_disadvantages.md introduction/distinctive-features.md
 introduction/possible_silly_questions.md faq/general.md


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)