### PR TITLE
Cap max_memory_usage* limits to the process resident memory

### DIFF
--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -84,8 +84,12 @@ void MemoryTracker::alloc(Int64 size)
     /// capped to it, to avoid possible drift.
     if (unlikely(current_hard_limit && will_be > current_hard_limit))
     {
-        set(total_memory_tracker.amount);
-        will_be = size + amount.fetch_add(size, std::memory_order_relaxed);
+        Int64 total_amount = total_memory_tracker.get();
+        if (amount > total_amount)
+        {
+            set(total_amount);
+            will_be = size + total_amount;
+        }
     }
 
     std::bernoulli_distribution fault(fault_probability);

--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -77,6 +77,17 @@ void MemoryTracker::alloc(Int64 size)
     Int64 current_hard_limit = hard_limit.load(std::memory_order_relaxed);
     Int64 current_profiler_limit = profiler_limit.load(std::memory_order_relaxed);
 
+    /// Cap the limit to the total_memory_tracker, since it may include some drift.
+    ///
+    /// And since total_memory_tracker is reseted to the process resident
+    /// memory peridically (in AsynchronousMetrics::update()), any limit can be
+    /// capped to it, to avoid possible drift.
+    if (unlikely(current_hard_limit && will_be > current_hard_limit))
+    {
+        set(total_memory_tracker.amount);
+        will_be = size + amount.fetch_add(size, std::memory_order_relaxed);
+    }
+
     std::bernoulli_distribution fault(fault_probability);
     if (unlikely(fault_probability && fault(thread_local_rng)))
     {

--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -208,6 +208,7 @@ void AsynchronousMetrics::update()
         /// Otherwise it might be calculated incorrectly - it can include a "drift" of memory amount.
         /// See https://github.com/ClickHouse/ClickHouse/issues/10293
         total_memory_tracker.set(data.resident);
+        CurrentMetrics::set(CurrentMetrics::MemoryTracking, data.resident);
     }
 #endif
 

--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -208,7 +208,6 @@ void AsynchronousMetrics::update()
         /// Otherwise it might be calculated incorrectly - it can include a "drift" of memory amount.
         /// See https://github.com/ClickHouse/ClickHouse/issues/10293
         total_memory_tracker.set(data.resident);
-        CurrentMetrics::set(CurrentMetrics::MemoryTracking, data.resident);
     }
 #endif
 


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Cap max_memory_usage* limits to the process resident memory

There are still some issues with memory tracking, but now with per-user
tracking:

    executeQuery: Code: 241, e.displayText() = DB::Exception: Memory limit (for user) exceeded: would use 437.72 GiB (attempt to allocate chunk of 4200926 bytes), maximum: 437.72 GiB (version 20.6.1.1) (from 10.7.140.7:31318)

Although the server is mostly idle:

    SELECT formatReadableSize(memory_usage)
    FROM system.processes

    ┌─formatReadableSize(memory_usage)─┐
    │ 289.28 MiB                       │
    │ 155.75 MiB                       │
    │ 0.00 B                           │
    └──────────────────────────────────┘

Refs: https://github.com/ClickHouse/ClickHouse/pull/10496/files#r450206865
Cc: @alexey-milovidov

Refs: #10496 