### PR TITLE
throw exception on redirect limit in S3 request

### DIFF
--- a/tests/integration/test_storage_s3/s3_mock/mock_s3.py
+++ b/tests/integration/test_storage_s3/s3_mock/mock_s3.py
@@ -1,4 +1,11 @@
-from bottle import abort, route, run, request
+from bottle import abort, route, run, request, response
+
+
+@route('/redirected/<_path>')
+def infinite_redirect(_path):
+    response.set_header("Location", request.url)
+    response.status = 307
+    return 'Redirected'
 
 
 @route('/<_bucket>/<_path>')

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -336,3 +336,19 @@ def test_get_csv_default(cluster):
     instance = cluster.instances["dummy"]  # type: ClickHouseInstance
     result = run_query(instance, get_query)
     assert result == '1\t2\t3\n'
+
+
+def test_infinite_redirect(cluster):
+    bucket = "redirected"
+    table_format = "column1 UInt32, column2 UInt32, column3 UInt32"
+    filename = "test.csv"
+    get_query = "select * from s3('http://resolver:8080/{bucket}/{file}', 'CSV', '{table_format}')".format(
+        bucket="redirected",
+        file=filename,
+        table_format=table_format)
+    instance = cluster.instances["dummy"]  # type: ClickHouseInstance
+    try:
+        result = run_query(instance, get_query)
+    except Exception as e:
+        assert str(e).find("Too many redirects while trying to access") != -1
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixed behaviour on reaching redirect limit in request to S3 storage.


Detailed description / Documentation draft:

PocoHTTPClient didn't set any error before exiting by redirect limit. Fixed.