### PR TITLE
experiment: disable profiler in perf tests

### DIFF
--- a/docker/test/performance-comparison/config/users.d/perf-comparison-tweaks-users.xml
+++ b/docker/test/performance-comparison/config/users.d/perf-comparison-tweaks-users.xml
@@ -1,7 +1,7 @@
 <yandex>
     <profiles>
         <default>
-            <query_profiler_real_time_period_ns>10000000</query_profiler_real_time_period_ns>
+            <query_profiler_real_time_period_ns>0</query_profiler_real_time_period_ns>
             <query_profiler_cpu_time_period_ns>0</query_profiler_cpu_time_period_ns>
             <allow_introspection_functions>1</allow_introspection_functions>
             <log_queries>1</log_queries>


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

just an experiment for now, let's look how it influences the query instability