### PR TITLE
Fix rare hanging in DNSResolver

### DIFF
--- a/src/Common/DNSResolver.cpp
+++ b/src/Common/DNSResolver.cpp
@@ -269,6 +269,8 @@ bool DNSResolver::updateCache()
     LOG_DEBUG(log, "Updating DNS cache");
 
     {
+        String updated_host_name = Poco::Net::DNS::hostName();
+
         std::lock_guard lock(impl->drop_mutex);
 
         for (const auto & host : impl->new_hosts)
@@ -279,7 +281,7 @@ bool DNSResolver::updateCache()
             impl->known_addresses.insert(address);
         impl->new_addresses.clear();
 
-        impl->host_name.emplace(Poco::Net::DNS::hostName());
+        impl->host_name.emplace(updated_host_name);
     }
 
     /// FIXME Updating may take a long time becouse we cannot manage timeouts of getaddrinfo(...) and getnameinfo(...).


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Some threads might randomly hang for a few seconds during DNS cache updating. It's fixed.


Detailed description / Documentation draft:
`OwnSplitChannel::logSplit(...)` calls `DNSResolver::getHostName()` and may wait on `DNSResolver::Impl::drop_mutex`, while `DNSResolver::updateCache()` calls `gethostname(...)` holding the mutex.