### PR TITLE
Support MySQL 'SELECT DATABASE()'

### DIFF
--- a/src/Functions/currentDatabase.cpp
+++ b/src/Functions/currentDatabase.cpp
@@ -49,6 +49,7 @@ public:
 void registerFunctionCurrentDatabase(FunctionFactory & factory)
 {
     factory.registerFunction<FunctionCurrentDatabase>();
+    factory.registerFunction<FunctionCurrentDatabase>("DATABASE", FunctionFactory::CaseInsensitive);
 }
 
 }

--- a/src/Server/MySQLHandler.cpp
+++ b/src/Server/MySQLHandler.cpp
@@ -48,7 +48,6 @@ namespace ErrorCodes
 static String selectEmptyReplacementQuery(const String & query);
 static String showTableStatusReplacementQuery(const String & query);
 static String killConnectionIdReplacementQuery(const String & query);
-static String selectDatabaseReplacementQuery(const String & query);
 
 MySQLHandler::MySQLHandler(IServer & server_, const Poco::Net::StreamSocket & socket_,
     bool ssl_enabled, size_t connection_id_)
@@ -66,7 +65,6 @@ MySQLHandler::MySQLHandler(IServer & server_, const Poco::Net::StreamSocket & so
     replacements.emplace("KILL QUERY", killConnectionIdReplacementQuery);
     replacements.emplace("SHOW TABLE STATUS LIKE", showTableStatusReplacementQuery);
     replacements.emplace("SHOW VARIABLES", selectEmptyReplacementQuery);
-    replacements.emplace("SELECT DATABASE()", selectDatabaseReplacementQuery);
 }
 
 void MySQLHandler::run()
@@ -437,16 +435,6 @@ static String killConnectionIdReplacementQuery(const String & query)
         }
     }
     return query;
-}
-
-/// Replace "SELECT DATABASE()" into "SELECT currentDatabase() AS `DATABASE()`".
-static String selectDatabaseReplacementQuery(const String & query)
-{
-    const String prefix = "SELECT DATABASE()";
-    if (query.size() > prefix.size())
-        return query;
-    else
-        return ("SELECT currentDatabase() AS `DATABASE()`");
 }
 
 }

--- a/src/Server/MySQLHandler.cpp
+++ b/src/Server/MySQLHandler.cpp
@@ -48,6 +48,7 @@ namespace ErrorCodes
 static String selectEmptyReplacementQuery(const String & query);
 static String showTableStatusReplacementQuery(const String & query);
 static String killConnectionIdReplacementQuery(const String & query);
+static String selectDatabaseReplacementQuery(const String & query);
 
 MySQLHandler::MySQLHandler(IServer & server_, const Poco::Net::StreamSocket & socket_,
     bool ssl_enabled, size_t connection_id_)
@@ -65,6 +66,7 @@ MySQLHandler::MySQLHandler(IServer & server_, const Poco::Net::StreamSocket & so
     replacements.emplace("KILL QUERY", killConnectionIdReplacementQuery);
     replacements.emplace("SHOW TABLE STATUS LIKE", showTableStatusReplacementQuery);
     replacements.emplace("SHOW VARIABLES", selectEmptyReplacementQuery);
+    replacements.emplace("SELECT DATABASE()", selectDatabaseReplacementQuery);
 }
 
 void MySQLHandler::run()
@@ -437,5 +439,14 @@ static String killConnectionIdReplacementQuery(const String & query)
     return query;
 }
 
+/// Replace "SELECT DATABASE()" into "SELECT currentDatabase() AS `DATABASE()`".
+static String selectDatabaseReplacementQuery(const String & query)
+{
+    const String prefix = "SELECT DATABASE()";
+    if (query.size() > prefix.size())
+        return query;
+    else
+        return ("SELECT currentDatabase() AS `DATABASE()`");
 }
 
+}

--- a/tests/integration/test_mysql_protocol/test.py
+++ b/tests/integration/test_mysql_protocol/test.py
@@ -145,14 +145,22 @@ def test_mysql_client(mysql_client, server_address):
     '''.format(host=server_address, port=server_port), demux=True)
     assert code == 0
 
-    # show variables.
+def test_mysql_replacement_query(mysql_client, server_address):
+    # SHOW TABLE STATUS LIKE.
+    code, (stdout, stderr) = mysql_client.exec_run('''
+        mysql --protocol tcp -h {host} -P {port} default -u default
+        --password=123 -e "show table status like 'xx';"
+    '''.format(host=server_address, port=server_port), demux=True)
+    assert code == 0
+
+    # SHOW VARIABLES.
     code, (stdout, stderr) = mysql_client.exec_run('''
         mysql --protocol tcp -h {host} -P {port} default -u default
         --password=123 -e "show variables;"
     '''.format(host=server_address, port=server_port), demux=True)
     assert code == 0
 
-    # Kill query.
+    # KILL QUERY.
     code, (stdout, stderr) = mysql_client.exec_run('''
         mysql --protocol tcp -h {host} -P {port} default -u default
         --password=123 -e "kill query 0;"
@@ -164,6 +172,21 @@ def test_mysql_client(mysql_client, server_address):
         --password=123 -e "kill query where query_id='mysql:0';"
     '''.format(host=server_address, port=server_port), demux=True)
     assert code == 0
+
+    # SELECT DATABASE().
+    code, (stdout, stderr) = mysql_client.exec_run('''
+        mysql --protocol tcp -h {host} -P {port} default -u default
+        --password=123 -e "select database();"
+    '''.format(host=server_address, port=server_port), demux=True)
+    assert code == 0
+    assert stdout == 'database()\ndefault\n'
+
+    code, (stdout, stderr) = mysql_client.exec_run('''
+        mysql --protocol tcp -h {host} -P {port} default -u default
+        --password=123 -e "select DATABASE();"
+    '''.format(host=server_address, port=server_port), demux=True)
+    assert code == 0
+    assert stdout == 'DATABASE()\ndefault\n'
 
 
 def test_mysql_federated(mysql_server, server_address):


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

1. Support MySQL 'SELECT DATABASE()'  #9336 
2. Add MySQL replacement query integration test


Detailed description / Documentation draft:

...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.
