### PR TITLE
Separated `AWSAuthV4Signer` into different logger, removed "AWSClient: AWSClient"

### DIFF
--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -23,7 +23,7 @@
 namespace
 {
 
-static const char * S3_LOGGER_TAG_NAMES[][2] = {
+const char * S3_LOGGER_TAG_NAMES[][2] = {
     {"AWSClient", "AWSClient"},
     {"AWSAuthV4Signer", "AWSClient (AWSAuthV4Signer)"},
 };

--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -22,6 +22,12 @@
 
 namespace
 {
+
+static const char * S3_LOGGER_TAG_NAMES[][2] = {
+    {"AWSClient", "AWSClient"},
+    {"AWSAuthV4Signer", "AWSClient (AWSAuthV4Signer)"},
+};
+
 const std::pair<DB::LogsLevel, Poco::Message::Priority> & convertLogLevel(Aws::Utils::Logging::LogLevel log_level)
 {
     static const std::unordered_map<Aws::Utils::Logging::LogLevel, std::pair<DB::LogsLevel, Poco::Message::Priority>> mapping =
@@ -42,9 +48,10 @@ class AWSLogger final : public Aws::Utils::Logging::LogSystemInterface
 public:
     AWSLogger()
     {
-        default_logger = &Poco::Logger::get("AWSClient");
-        tag_loggers["AWSAuthV4Signer"] = &Poco::Logger::get("AWSClient (AWSAuthV4Signer)");
-        tag_loggers["AWSClient"] = default_logger;
+        for (auto [tag, name] : S3_LOGGER_TAG_NAMES)
+            tag_loggers[tag] = &Poco::Logger::get(name);
+
+        default_logger = tag_loggers[S3_LOGGER_TAG_NAMES[0][0]];
     }
 
     ~AWSLogger() final = default;
@@ -121,7 +128,9 @@ public:
 private:
     const DB::HeaderCollection headers;
 };
+
 }
+
 
 namespace DB
 {

--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -42,9 +42,9 @@ class AWSLogger final : public Aws::Utils::Logging::LogSystemInterface
 public:
     AWSLogger()
     {
-        log = &Poco::Logger::get("AWSClient");
+        default_logger = &Poco::Logger::get("AWSClient");
         tag_loggers["AWSAuthV4Signer"] = &Poco::Logger::get("AWSClient (AWSAuthV4Signer)");
-        tag_loggers["AWSClient"] = log;
+        tag_loggers["AWSClient"] = default_logger;
     }
 
     ~AWSLogger() final = default;
@@ -70,14 +70,14 @@ public:
         }
         else
         {
-            LOG_IMPL(log, level, prio, "{}: {}", tag, message);
+            LOG_IMPL(default_logger, level, prio, "{}: {}", tag, message);
         }
     }
 
     void Flush() final {}
 
 private:
-    Poco::Logger * log;
+    Poco::Logger * default_logger;
     std::unordered_map<String, Poco::Logger *> tag_loggers;
 };
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Separated `AWSAuthV4Signer` into different logger, removed "AWSClient: AWSClient".
