### PR TITLE
Fix alter rename error messages

### DIFF
--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -479,11 +479,20 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, const Context & con
         if (metadata.table_ttl.definition_ast)
             rename_visitor.visit(metadata.table_ttl.definition_ast);
 
-        metadata.table_ttl = TTLTableDescription::getTTLForTableFromAST(
-            metadata.table_ttl.definition_ast, metadata.columns, context, metadata.primary_key);
-
         for (auto & constraint : metadata.constraints.constraints)
             rename_visitor.visit(constraint);
+
+        if (metadata.isSortingKeyDefined())
+            rename_visitor.visit(metadata.sorting_key.definition_ast);
+
+        if (metadata.isPrimaryKeyDefined())
+            rename_visitor.visit(metadata.primary_key.definition_ast);
+
+        if (metadata.isSamplingKeyDefined())
+            rename_visitor.visit(metadata.sampling_key.definition_ast);
+
+        if (metadata.isPartitionKeyDefined())
+            rename_visitor.visit(metadata.partition_key.definition_ast);
     }
     else
         throw Exception("Wrong parameter type in ALTER query", ErrorCodes::LOGICAL_ERROR);
@@ -722,10 +731,10 @@ void AlterCommands::apply(StorageInMemoryMetadata & metadata, const Context & co
             command.apply(metadata_copy, context);
 
     /// Changes in columns may lead to changes in keys expression.
-    metadata_copy.sorting_key.recalculateWithNewColumns(metadata_copy.columns, context);
+    metadata_copy.sorting_key.recalculateWithNewAST(metadata_copy.sorting_key.definition_ast, metadata_copy.columns, context);
     if (metadata_copy.primary_key.definition_ast != nullptr)
     {
-        metadata_copy.primary_key.recalculateWithNewColumns(metadata_copy.columns, context);
+        metadata_copy.primary_key.recalculateWithNewAST(metadata_copy.primary_key.definition_ast, metadata_copy.columns, context);
     }
     else
     {
@@ -735,11 +744,11 @@ void AlterCommands::apply(StorageInMemoryMetadata & metadata, const Context & co
 
     /// And in partition key expression
     if (metadata_copy.partition_key.definition_ast != nullptr)
-        metadata_copy.partition_key.recalculateWithNewColumns(metadata_copy.columns, context);
+        metadata_copy.partition_key.recalculateWithNewAST(metadata_copy.partition_key.definition_ast, metadata_copy.columns, context);
 
     /// Changes in columns may lead to changes in secondary indices
     for (auto & index : metadata_copy.secondary_indices)
-        index.recalculateWithNewColumns(metadata_copy.columns, context);
+        index = IndexDescription::getIndexFromAST(index.definition_ast, metadata_copy.columns, context);
 
     /// Changes in columns may lead to changes in TTL expressions.
     auto column_ttl_asts = metadata_copy.columns.getColumnTTLs();

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -493,6 +493,9 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, const Context & con
 
         if (metadata.isPartitionKeyDefined())
             rename_visitor.visit(metadata.partition_key.definition_ast);
+
+        for (auto & index : metadata.secondary_indices)
+            rename_visitor.visit(index.definition_ast);
     }
     else
         throw Exception("Wrong parameter type in ALTER query", ErrorCodes::LOGICAL_ERROR);

--- a/tests/queries/0_stateless/01213_alter_rename_primary_key_zookeeper.sql
+++ b/tests/queries/0_stateless/01213_alter_rename_primary_key_zookeeper.sql
@@ -17,11 +17,11 @@ INSERT INTO table_for_rename_pk SELECT toDate('2019-10-01') + number % 3, number
 
 SELECT key1, value1 FROM table_for_rename_pk WHERE key1 = 1 AND key2 = 1 AND key3 = 1;
 
-ALTER TABLE table_for_rename_pk RENAME COLUMN key1 TO renamed_key1; --{serverError 47}
+ALTER TABLE table_for_rename_pk RENAME COLUMN key1 TO renamed_key1; --{serverError 524}
 
-ALTER TABLE table_for_rename_pk RENAME COLUMN key3 TO renamed_key3; --{serverError 47}
+ALTER TABLE table_for_rename_pk RENAME COLUMN key3 TO renamed_key3; --{serverError 524}
 
-ALTER TABLE table_for_rename_pk RENAME COLUMN key2 TO renamed_key2; --{serverError 47}
+ALTER TABLE table_for_rename_pk RENAME COLUMN key2 TO renamed_key2; --{serverError 524}
 
 DROP TABLE IF EXISTS table_for_rename_pk NO DELAY;
 SELECT sleep(1) FORMAT Null;
@@ -45,12 +45,12 @@ PRIMARY KEY (key1, key2);
 
 INSERT INTO table_for_rename_with_primary_key SELECT toDate('2019-10-01') + number % 3, number, number, number, toString(number), toString(number) from numbers(9);
 
-ALTER TABLE table_for_rename_with_primary_key RENAME COLUMN key1 TO renamed_key1; --{serverError 47}
+ALTER TABLE table_for_rename_with_primary_key RENAME COLUMN key1 TO renamed_key1; --{serverError 524}
 
-ALTER TABLE table_for_rename_with_primary_key RENAME COLUMN key2 TO renamed_key2; --{serverError 47}
+ALTER TABLE table_for_rename_with_primary_key RENAME COLUMN key2 TO renamed_key2; --{serverError 524}
 
-ALTER TABLE table_for_rename_with_primary_key RENAME COLUMN key3 TO renamed_key3; --{serverError 47}
+ALTER TABLE table_for_rename_with_primary_key RENAME COLUMN key3 TO renamed_key3; --{serverError 524}
 
-ALTER TABLE table_for_rename_with_primary_key RENAME COLUMN value1 TO renamed_value1; --{serverError 47}
+ALTER TABLE table_for_rename_with_primary_key RENAME COLUMN value1 TO renamed_value1; --{serverError 524}
 
 DROP TABLE IF EXISTS table_for_rename_with_primary_key;

--- a/tests/queries/0_stateless/01344_alter_enum_partition_key.sql
+++ b/tests/queries/0_stateless/01344_alter_enum_partition_key.sql
@@ -28,8 +28,8 @@ ALTER TABLE test MODIFY COLUMN x UInt64; -- { serverError 524 }
 ALTER TABLE test MODIFY COLUMN x String; -- { serverError 524 }
 ALTER TABLE test MODIFY COLUMN x Nullable(Int64); -- { serverError 524 }
 
-ALTER TABLE test RENAME COLUMN x TO z; -- { serverError 47 }
-ALTER TABLE test RENAME COLUMN y TO z; -- { serverError 47 }
+ALTER TABLE test RENAME COLUMN x TO z; -- { serverError 524 }
+ALTER TABLE test RENAME COLUMN y TO z; -- { serverError 524 }
 ALTER TABLE test DROP COLUMN x; -- { serverError 47 }
 ALTER TABLE test DROP COLUMN y; -- { serverError 47 }
 

--- a/tests/queries/0_stateless/01346_alter_enum_partition_key_replicated.sql
+++ b/tests/queries/0_stateless/01346_alter_enum_partition_key_replicated.sql
@@ -40,8 +40,8 @@ ALTER TABLE test MODIFY COLUMN x UInt64; -- { serverError 524 }
 ALTER TABLE test MODIFY COLUMN x String; -- { serverError 524 }
 ALTER TABLE test MODIFY COLUMN x Nullable(Int64); -- { serverError 524 }
 
-ALTER TABLE test RENAME COLUMN x TO z; -- { serverError 47 }
-ALTER TABLE test RENAME COLUMN y TO z; -- { serverError 47 }
+ALTER TABLE test RENAME COLUMN x TO z; -- { serverError 524 }
+ALTER TABLE test RENAME COLUMN y TO z; -- { serverError 524 }
 ALTER TABLE test DROP COLUMN x; -- { serverError 47 }
 ALTER TABLE test DROP COLUMN y; -- { serverError 47 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix error message and exit codes for `ALTER RENAME COLUMN` queries, when `RENAME` is not allowed. Fixes #12301 and #12303.