### PR TITLE
[security docs] actually only admins can create advisories

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,5 +18,4 @@ currently being supported with security updates:
 
 ## Reporting a Vulnerability
 
-To report a potential vulnerability in ClickHouse please use the security advisory feature of GitHub:
-https://github.com/ClickHouse/ClickHouse/security/advisories
+To report a potential vulnerability in ClickHouse please send the details about it to [clickhouse-feedback@yandex-team.com](mailto:clickhouse-feedback@yandex-team.com).


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)
