### PR TITLE
Fix std::bad_typeid when JSON functions called with argument of wrong type

### DIFF
--- a/src/Common/typeid_cast.h
+++ b/src/Common/typeid_cast.h
@@ -47,7 +47,7 @@ std::enable_if_t<std::is_pointer_v<To>, To> typeid_cast(From * from)
 {
     try
     {
-        if ((typeid(From) == typeid(std::remove_pointer_t<To>)) || (typeid(*from) == typeid(std::remove_pointer_t<To>)))
+        if ((typeid(From) == typeid(std::remove_pointer_t<To>)) || (from && typeid(*from) == typeid(std::remove_pointer_t<To>)))
             return static_cast<To>(from);
         else
             return nullptr;
@@ -64,7 +64,7 @@ std::enable_if_t<ext::is_shared_ptr_v<To>, To> typeid_cast(const std::shared_ptr
 {
     try
     {
-        if ((typeid(From) == typeid(typename To::element_type)) || (typeid(*from) == typeid(typename To::element_type)))
+        if ((typeid(From) == typeid(typename To::element_type)) || (from && typeid(*from) == typeid(typename To::element_type)))
             return std::static_pointer_cast<typename To::element_type>(from);
         else
             return nullptr;

--- a/src/Functions/FunctionsJSON.h
+++ b/src/Functions/FunctionsJSON.h
@@ -892,7 +892,7 @@ public:
         auto col_type_const = typeid_cast<const ColumnConst *>(col.column.get());
         if (!col_type_const || !isString(col.type))
             throw Exception{"The last argument of function " + String(function_name)
-                                + " should be a constant string specifying the return data type, illegal value: " + col.column->getName(),
+                                + " should be a constant string specifying the return data type, illegal value: " + col.name,
                             ErrorCodes::ILLEGAL_COLUMN};
 
         return DataTypeFactory::instance().get(col_type_const->getValue<String>());
@@ -929,7 +929,7 @@ public:
         auto col_type_const = typeid_cast<const ColumnConst *>(col.column.get());
         if (!col_type_const || !isString(col.type))
             throw Exception{"The last argument of function " + String(function_name)
-                                + " should be a constant string specifying the values' data type, illegal value: " + col.column->getName(),
+                                + " should be a constant string specifying the values' data type, illegal value: " + col.name,
                             ErrorCodes::ILLEGAL_COLUMN};
 
         DataTypePtr key_type = std::make_unique<DataTypeString>();

--- a/tests/queries/0_stateless/00918_json_functions.reference
+++ b/tests/queries/0_stateless/00918_json_functions.reference
@@ -99,6 +99,7 @@ d
 e
 u
 v
+--show error: type should be const string
 --allow_simdjson=0--
 --JSONLength--
 2
@@ -200,3 +201,4 @@ d
 e
 u
 v
+--show error: type should be const string

--- a/tests/queries/0_stateless/00918_json_functions.sql
+++ b/tests/queries/0_stateless/00918_json_functions.sql
@@ -108,6 +108,9 @@ SELECT '--const/non-const mixed--';
 SELECT JSONExtractString('["a", "b", "c", "d", "e"]', idx) FROM (SELECT arrayJoin([1,2,3,4,5]) AS idx);
 SELECT JSONExtractString(json, 's') FROM (SELECT arrayJoin(['{"s":"u"}', '{"s":"v"}']) AS json);
 
+SELECT '--show error: type should be const string';
+SELECT JSONExtractKeysAndValues([], JSONLength('^?V{LSwp')); -- { serverError 44 }
+WITH '{"i": 1, "f": 1.2}' AS json SELECT JSONExtract(json, 'i', JSONType(json, 'i')); -- { serverError 44 }
 
 
 SELECT '--allow_simdjson=0--';
@@ -219,3 +222,7 @@ SELECT JSONExtractKeysAndValuesRaw('{"a": "hello", "b": [-100, 200.0, 300], "c":
 SELECT '--const/non-const mixed--';
 SELECT JSONExtractString('["a", "b", "c", "d", "e"]', idx) FROM (SELECT arrayJoin([1,2,3,4,5]) AS idx);
 SELECT JSONExtractString(json, 's') FROM (SELECT arrayJoin(['{"s":"u"}', '{"s":"v"}']) AS json);
+
+SELECT '--show error: type should be const string';
+SELECT JSONExtractKeysAndValues([], JSONLength('^?V{LSwp')); -- { serverError 44 }
+WITH '{"i": 1, "f": 1.2}' AS json SELECT JSONExtract(json, 'i', JSONType(json, 'i')); -- { serverError 44 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Not for changelog

Fix std::bad_typeid when JSON functions called with argument of wrong type.
This fixes https://github.com/ClickHouse/ClickHouse/issues/11885 and related to https://github.com/ClickHouse/ClickHouse/issues/8327