### PR TITLE
Increasing default timeout for live view tests from 20 sec to 120 sec

### DIFF
--- a/tests/queries/0_stateless/helpers/client.py
+++ b/tests/queries/0_stateless/helpers/client.py
@@ -19,7 +19,7 @@ class client(object):
         self.client.command = command
         self.client.eol('\r')
         self.client.logger(log, prefix=name)
-        self.client.timeout(20)
+        self.client.timeout(120)
         self.client.expect('[#\$] ', timeout=60)
         self.client.send(command)
 


### PR DESCRIPTION
Increasing default timeout for live view tests from 20 sec to 120 sec to account for slowdowns.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog.
