### PR TITLE
lifetime_rows/lifetime_bytes for Buffer engine

### DIFF
--- a/docs/en/operations/system-tables/tables.md
+++ b/docs/en/operations/system-tables/tables.md
@@ -46,4 +46,8 @@ This table contains the following columns (the column type is shown in brackets)
     -   If the table stores data on disk, returns used space on disk (i.e. compressed).
     -   If the table stores data in memory, returns approximated number of used bytes in memory.
 
+-   `lifetime_rows` (Nullable(UInt64)) - Total number of rows INSERTed since server start.
+
+-   `lifetime_bytes` (Nullable(UInt64)) - Total number of bytes INSERTed since server start.
+
 The `system.tables` table is used in `SHOW TABLES` query implementation.

--- a/docs/en/operations/system-tables/tables.md
+++ b/docs/en/operations/system-tables/tables.md
@@ -46,8 +46,8 @@ This table contains the following columns (the column type is shown in brackets)
     -   If the table stores data on disk, returns used space on disk (i.e. compressed).
     -   If the table stores data in memory, returns approximated number of used bytes in memory.
 
--   `lifetime_rows` (Nullable(UInt64)) - Total number of rows INSERTed since server start.
+-   `lifetime_rows` (Nullable(UInt64)) - Total number of rows INSERTed since server start (only for `Buffer` tables).
 
--   `lifetime_bytes` (Nullable(UInt64)) - Total number of bytes INSERTed since server start.
+-   `lifetime_bytes` (Nullable(UInt64)) - Total number of bytes INSERTed since server start (only for `Buffer` tables).
 
 The `system.tables` table is used in `SHOW TABLES` query implementation.

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -443,10 +443,7 @@ public:
     /// - For total_rows column in system.tables
     ///
     /// Does takes underlying Storage (if any) into account.
-    virtual std::optional<UInt64> totalRows() const
-    {
-        return {};
-    }
+    virtual std::optional<UInt64> totalRows() const { return {}; }
 
     /// If it is possible to quickly determine exact number of bytes for the table on storage:
     /// - memory (approximated, resident)
@@ -461,10 +458,7 @@ public:
     /// Memory part should be estimated as a resident memory size.
     /// In particular, alloctedBytes() is preferable over bytes()
     /// when considering in-memory blocks.
-    virtual std::optional<UInt64> totalBytes() const
-    {
-        return {};
-    }
+    virtual std::optional<UInt64> totalBytes() const { return {}; }
 
 private:
     /// Lock required for alter queries (lockForAlter). Always taken for write

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -460,6 +460,16 @@ public:
     /// when considering in-memory blocks.
     virtual std::optional<UInt64> totalBytes() const { return {}; }
 
+    /// Number of rows INSERTed since server start.
+    ///
+    /// Does not takes underlying Storage (if any) into account.
+    virtual std::optional<UInt64> lifetimeRows() const { return {}; }
+
+    /// Number of bytes INSERTed since server start.
+    ///
+    /// Does not takes underlying Storage (if any) into account.
+    virtual std::optional<UInt64> lifetimeBytes() const { return {}; }
+
 private:
     /// Lock required for alter queries (lockForAlter). Always taken for write
     /// (actually can be replaced with std::mutex, but for consistency we use

--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -279,7 +279,7 @@ Pipes StorageBuffer::read(
 }
 
 
-static void appendBlock(const Block & from, Block & to)
+static void appendBlock(StorageBuffer::LifeTimeWrites &writes, const Block & from, Block & to)
 {
     if (!to)
         throw Exception("Cannot append to empty block", ErrorCodes::LOGICAL_ERROR);
@@ -294,6 +294,9 @@ static void appendBlock(const Block & from, Block & to)
 
     CurrentMetrics::add(CurrentMetrics::StorageBufferRows, rows);
     CurrentMetrics::add(CurrentMetrics::StorageBufferBytes, bytes);
+
+    writes.rows += rows;
+    writes.bytes += bytes;
 
     size_t old_rows = to.rows();
 
@@ -446,7 +449,7 @@ private:
         if (!buffer.first_write_time)
             buffer.first_write_time = current_time;
 
-        appendBlock(sorted_block, buffer.data);
+        appendBlock(storage.writes, sorted_block, buffer.data);
     }
 };
 

--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -279,7 +279,7 @@ Pipes StorageBuffer::read(
 }
 
 
-static void appendBlock(StorageBuffer::LifeTimeWrites &writes, const Block & from, Block & to)
+static void appendBlock(const Block & from, Block & to)
 {
     if (!to)
         throw Exception("Cannot append to empty block", ErrorCodes::LOGICAL_ERROR);
@@ -294,9 +294,6 @@ static void appendBlock(StorageBuffer::LifeTimeWrites &writes, const Block & fro
 
     CurrentMetrics::add(CurrentMetrics::StorageBufferRows, rows);
     CurrentMetrics::add(CurrentMetrics::StorageBufferBytes, bytes);
-
-    writes.rows += rows;
-    writes.bytes += bytes;
 
     size_t old_rows = to.rows();
 
@@ -370,6 +367,9 @@ public:
         }
 
         size_t bytes = block.bytes();
+
+        storage.writes.rows += rows;
+        storage.writes.bytes += bytes;
 
         /// If the block already exceeds the maximum limit, then we skip the buffer.
         if (rows > storage.max_thresholds.rows || bytes > storage.max_thresholds.bytes)
@@ -449,7 +449,7 @@ private:
         if (!buffer.first_write_time)
             buffer.first_write_time = current_time;
 
-        appendBlock(storage.writes, sorted_block, buffer.data);
+        appendBlock(sorted_block, buffer.data);
     }
 };
 

--- a/src/Storages/StorageBuffer.h
+++ b/src/Storages/StorageBuffer.h
@@ -51,12 +51,6 @@ public:
         size_t rows;    /// The number of rows in the block.
         size_t bytes;   /// The number of (uncompressed) bytes in the block.
     };
-    /// Lifetime
-    struct LifeTimeWrites
-    {
-        std::atomic<size_t> rows = 0;
-        std::atomic<size_t> bytes = 0;
-    };
 
     std::string getName() const override { return "Buffer"; }
 
@@ -125,7 +119,12 @@ private:
     StorageID destination_id;
     bool allow_materialized;
 
-    LifeTimeWrites writes;
+    /// Lifetime
+    struct LifeTimeWrites
+    {
+        std::atomic<size_t> rows = 0;
+        std::atomic<size_t> bytes = 0;
+    } writes;
 
     Poco::Logger * log;
 

--- a/src/Storages/StorageBuffer.h
+++ b/src/Storages/StorageBuffer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mutex>
+#include <atomic>
 #include <thread>
 #include <ext/shared_ptr_helper.h>
 #include <Core/NamesAndTypes.h>
@@ -50,6 +51,12 @@ public:
         size_t rows;    /// The number of rows in the block.
         size_t bytes;   /// The number of (uncompressed) bytes in the block.
     };
+    /// Lifetime
+    struct LifeTimeWrites
+    {
+        std::atomic<size_t> rows = 0;
+        std::atomic<size_t> bytes = 0;
+    };
 
     std::string getName() const override { return "Buffer"; }
 
@@ -94,6 +101,10 @@ public:
     std::optional<UInt64> totalRows() const override;
     std::optional<UInt64> totalBytes() const override;
 
+    std::optional<UInt64> lifetimeRows() const override { return writes.rows; }
+    std::optional<UInt64> lifetimeBytes() const override { return writes.bytes; }
+
+
 private:
     Context global_context;
 
@@ -113,6 +124,8 @@ private:
 
     StorageID destination_id;
     bool allow_materialized;
+
+    LifeTimeWrites writes;
 
     Poco::Logger * log;
 

--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -55,6 +55,8 @@ StorageSystemTables::StorageSystemTables(const std::string & name_)
         {"storage_policy", std::make_shared<DataTypeString>()},
         {"total_rows", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>())},
         {"total_bytes", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>())},
+        {"lifetime_rows", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>())},
+        {"lifetime_bytes", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>())},
     }));
     setInMemoryMetadata(storage_metadata);
 }
@@ -221,6 +223,14 @@ protected:
                             res_columns[res_index++]->insertDefault();
 
                         // total_bytes
+                        if (columns_mask[src_index++])
+                            res_columns[res_index++]->insertDefault();
+
+                        // lifetime_rows
+                        if (columns_mask[src_index++])
+                            res_columns[res_index++]->insertDefault();
+
+                        // lifetime_bytes
                         if (columns_mask[src_index++])
                             res_columns[res_index++]->insertDefault();
                     }
@@ -427,6 +437,26 @@ protected:
                     auto total_bytes = table->totalBytes();
                     if (total_bytes)
                         res_columns[res_index++]->insert(*total_bytes);
+                    else
+                        res_columns[res_index++]->insertDefault();
+                }
+
+                if (columns_mask[src_index++])
+                {
+                    assert(table != nullptr);
+                    auto lifetime_rows = table->lifetimeRows();
+                    if (lifetime_rows)
+                        res_columns[res_index++]->insert(*lifetime_rows);
+                    else
+                        res_columns[res_index++]->insertDefault();
+                }
+
+                if (columns_mask[src_index++])
+                {
+                    assert(table != nullptr);
+                    auto lifetime_bytes = table->lifetimeBytes();
+                    if (lifetime_bytes)
+                        res_columns[res_index++]->insert(*lifetime_bytes);
                     else
                         res_columns[res_index++]->insertDefault();
                 }

--- a/tests/queries/0_stateless/00753_system_columns_and_system_tables.reference
+++ b/tests/queries/0_stateless/00753_system_columns_and_system_tables.reference
@@ -33,3 +33,8 @@ Check total_bytes/total_rows for Memory
 Check total_bytes/total_rows for Buffer
 0	0
 256	50
+Check lifetime_bytes/lifetime_rows for Buffer
+100	50
+100	50
+200	100
+200	100

--- a/tests/queries/0_stateless/00753_system_columns_and_system_tables.reference
+++ b/tests/queries/0_stateless/00753_system_columns_and_system_tables.reference
@@ -38,3 +38,4 @@ Check lifetime_bytes/lifetime_rows for Buffer
 100	50
 200	100
 200	100
+402	201

--- a/tests/queries/0_stateless/00753_system_columns_and_system_tables.sql
+++ b/tests/queries/0_stateless/00753_system_columns_and_system_tables.sql
@@ -84,6 +84,8 @@ SELECT total_bytes, total_rows FROM system.tables WHERE name = 'check_system_tab
 DROP TABLE check_system_tables;
 
 SELECT 'Check total_bytes/total_rows for Buffer';
+DROP TABLE IF EXISTS check_system_tables;
+DROP TABLE IF EXISTS check_system_tables_null;
 CREATE TABLE check_system_tables_null (key UInt16) ENGINE = Null();
 CREATE TABLE check_system_tables (key UInt16) ENGINE = Buffer(
     currentDatabase(),
@@ -96,5 +98,14 @@ CREATE TABLE check_system_tables (key UInt16) ENGINE = Buffer(
 SELECT total_bytes, total_rows FROM system.tables WHERE name = 'check_system_tables';
 INSERT INTO check_system_tables SELECT * FROM numbers_mt(50);
 SELECT total_bytes, total_rows FROM system.tables WHERE name = 'check_system_tables';
+
+SELECT 'Check lifetime_bytes/lifetime_rows for Buffer';
+SELECT lifetime_bytes, lifetime_rows FROM system.tables WHERE name = 'check_system_tables';
+OPTIMIZE TABLE check_system_tables; -- flush
+SELECT lifetime_bytes, lifetime_rows FROM system.tables WHERE name = 'check_system_tables';
+INSERT INTO check_system_tables SELECT * FROM numbers_mt(50);
+SELECT lifetime_bytes, lifetime_rows FROM system.tables WHERE name = 'check_system_tables';
+OPTIMIZE TABLE check_system_tables; -- flush
+SELECT lifetime_bytes, lifetime_rows FROM system.tables WHERE name = 'check_system_tables';
 DROP TABLE check_system_tables;
 DROP TABLE check_system_tables_null;

--- a/tests/queries/0_stateless/00753_system_columns_and_system_tables.sql
+++ b/tests/queries/0_stateless/00753_system_columns_and_system_tables.sql
@@ -107,5 +107,7 @@ INSERT INTO check_system_tables SELECT * FROM numbers_mt(50);
 SELECT lifetime_bytes, lifetime_rows FROM system.tables WHERE name = 'check_system_tables';
 OPTIMIZE TABLE check_system_tables; -- flush
 SELECT lifetime_bytes, lifetime_rows FROM system.tables WHERE name = 'check_system_tables';
+INSERT INTO check_system_tables SELECT * FROM numbers_mt(101); -- direct block write (due to min_rows exceeded)
+SELECT lifetime_bytes, lifetime_rows FROM system.tables WHERE name = 'check_system_tables';
 DROP TABLE check_system_tables;
 DROP TABLE check_system_tables_null;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
lifetime_rows/lifetime_bytes for Buffer engine

Detailed description / Documentation draft:
Buffer engine is usually used on INSERTs, but right now there is no way
to track number of INSERTed rows per-table, since only summary metrics
exists:
- StorageBufferRows
- StorageBufferBytes

But it can be pretty useful to track INSERTed rows rate (and it can be
exposed via http_handlers for i.e. prometheus)