### PR TITLE
Fix formatting of overflowed DateTime values

### DIFF
--- a/base/common/DateLUTImpl.cpp
+++ b/base/common/DateLUTImpl.cpp
@@ -143,7 +143,7 @@ DateLUTImpl::DateLUTImpl(const std::string & time_zone_)
     size_t year_months_lut_index = 0;
     size_t first_day_of_last_month = 0;
 
-    for (size_t day = 0; day < DATE_LUT_SIZE; ++day)
+    for (size_t day = 0; day < DATE_LUT_MAX_DAY_NUM; ++day)
     {
         const Values & values = lut[day];
 

--- a/base/common/DateLUTImpl.cpp
+++ b/base/common/DateLUTImpl.cpp
@@ -130,12 +130,12 @@ DateLUTImpl::DateLUTImpl(const std::string & time_zone_)
         ++date;
         ++i;
     }
-    while (start_of_day <= DATE_LUT_MAX && i <= DATE_LUT_MAX_DAY_NUM);
+    while (start_of_day < DATE_LUT_MAX && i < DATE_LUT_MAX_DAY_NUM);
 
     /// Fill excessive part of lookup table. This is needed only to simplify handling of overflow cases.
     while (i < DATE_LUT_SIZE)
     {
-        lut[i] = lut[i - 1];
+        lut[i] = lut[0];
         ++i;
     }
 


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix formatting of `DateTime` values near beginning of unix epoch. In previous versions these values are formatted as values from 2106 year.


Detailed description / Documentation draft:
This may impose backwards incompatibility due to formatting of partition key of MergeTree tables.