### PR TITLE
Try enable multiple_joins_rewriter_version v2 by default

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -377,7 +377,7 @@ struct Settings : public SettingsCollection<Settings>
     \
     M(SettingBool, deduplicate_blocks_in_dependent_materialized_views, false, "Should deduplicate blocks for materialized views if the block is not a duplicate for the table. Use true to always deduplicate in dependent tables.", 0) \
     M(SettingBool, use_compact_format_in_distributed_parts_names, false, "Changes format of directories names for distributed table insert parts.", 0) \
-    M(SettingUInt64, multiple_joins_rewriter_version, 1, "1 or 2. Second rewriter version knows about table columns and keep not clashed names as is.", 0) \
+    M(SettingUInt64, multiple_joins_rewriter_version, 2, "1 or 2. Second rewriter version knows about table columns and keep not clashed names as is.", 0) \
     M(SettingBool, validate_polygons, true, "Throw exception if polygon is invalid in function pointInPolygon (e.g. self-tangent, self-intersecting). If the setting is false, the function will accept invalid polygons but may silently return wrong result.", 0) \
     M(SettingUInt64, max_parser_depth, DBMS_DEFAULT_MAX_PARSER_DEPTH, "Maximum parser depth (recursion depth of recursive descend parser).", 0) \
     M(SettingSeconds, temporary_live_view_timeout, DEFAULT_TEMPORARY_LIVE_VIEW_TIMEOUT_SEC, "Timeout after which temporary live view is deleted.", 0) \

--- a/tests/queries/0_stateless/01392_column_resolve.reference
+++ b/tests/queries/0_stateless/01392_column_resolve.reference
@@ -1,0 +1,3 @@
+Conversion 1	Click 2	15
+Conversion 1	Click 3	16
+Conversion 1	Click 1	14

--- a/tests/queries/0_stateless/01392_column_resolve.reference
+++ b/tests/queries/0_stateless/01392_column_resolve.reference
@@ -1,3 +1,3 @@
+Conversion 1	Click 1	14
 Conversion 1	Click 2	15
 Conversion 1	Click 3	16
-Conversion 1	Click 1	14

--- a/tests/queries/0_stateless/01392_column_resolve.sql
+++ b/tests/queries/0_stateless/01392_column_resolve.sql
@@ -25,7 +25,8 @@ INNER JOIN (
 ) AS click ON click.conversionId = conversion.conversionId
 LEFT JOIN (
     SELECT * FROM default.leftjoin
-) AS dummy ON (dummy.id = conversion.conversionId);
+) AS dummy ON (dummy.id = conversion.conversionId)
+ORDER BY myValue;
 
 DROP TABLE IF EXISTS tableConversion;
 DROP TABLE IF EXISTS tableClick;

--- a/tests/queries/0_stateless/01392_column_resolve.sql
+++ b/tests/queries/0_stateless/01392_column_resolve.sql
@@ -1,0 +1,34 @@
+DROP TABLE IF EXISTS tableConversion;
+DROP TABLE IF EXISTS tableClick;
+DROP TABLE IF EXISTS leftjoin;
+
+CREATE TABLE default.tableConversion (conversionId String, value Nullable(Double)) ENGINE = Log();
+CREATE TABLE default.tableClick (clickId String, conversionId String, value Nullable(Double)) ENGINE = Log();
+CREATE TABLE default.leftjoin (id String) ENGINE = Log();
+
+INSERT INTO default.tableConversion(conversionId, value) VALUES ('Conversion 1', 1);
+INSERT INTO default.tableClick(clickId, conversionId, value) VALUES ('Click 1', 'Conversion 1', 14);
+INSERT INTO default.tableClick(clickId, conversionId, value) VALUES ('Click 2', 'Conversion 1', 15);
+INSERT INTO default.tableClick(clickId, conversionId, value) VALUES ('Click 3', 'Conversion 1', 16);
+
+SET multiple_joins_rewriter_version = 2;
+
+SELECT
+    conversion.conversionId AS myConversionId,
+    click.clickId AS myClickId,
+    click.myValue AS myValue
+FROM (
+    SELECT conversionId, value as myValue
+    FROM default.tableConversion
+) AS conversion
+INNER JOIN (
+    SELECT clickId, conversionId, value as myValue
+    FROM default.tableClick
+) AS click ON click.conversionId = conversion.conversionId
+LEFT JOIN (
+    SELECT * FROM default.leftjoin
+) AS dummy ON (dummy.id = conversion.conversionId);
+
+DROP TABLE IF EXISTS tableConversion;
+DROP TABLE IF EXISTS tableClick;
+DROP TABLE IF EXISTS leftjoin;

--- a/tests/queries/0_stateless/01392_column_resolve.sql
+++ b/tests/queries/0_stateless/01392_column_resolve.sql
@@ -11,8 +11,6 @@ INSERT INTO default.tableClick(clickId, conversionId, value) VALUES ('Click 1', 
 INSERT INTO default.tableClick(clickId, conversionId, value) VALUES ('Click 2', 'Conversion 1', 15);
 INSERT INTO default.tableClick(clickId, conversionId, value) VALUES ('Click 3', 'Conversion 1', 16);
 
-SET multiple_joins_rewriter_version = 2;
-
 SELECT
     conversion.conversionId AS myConversionId,
     click.clickId AS myClickId,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Changes default value for `multiple_joins_rewriter_version` to 2. It enables new multiple joins rewriter that knows about column names.

Closes #12468 #12036 #11127 #10481 #9424 