### PR TITLE
Update ya.make

### DIFF
--- a/src/Formats/ya.make
+++ b/src/Formats/ya.make
@@ -3,6 +3,7 @@ LIBRARY()
 PEERDIR(
     clickhouse/src/Common
     contrib/libs/protobuf
+    contrib/libs/protoc
 )
 
 SRCS(


### PR DESCRIPTION
Works around https://github.com/protocolbuffers/protobuf/issues/7681

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add PEERDIR(protoc) as protobuf format parses .proto file in runtime.


Detailed description / Documentation draft:

The fact of <google/protobuf/compiler/{imporer,parser}.{h,cc}> is being linked to libprotobuf looks like a bug in original protobuf build script. See protobuf issue referenced above.
