### PR TITLE
Check server able to restart after stress

### DIFF
--- a/docker/test/stress/Dockerfile
+++ b/docker/test/stress/Dockerfile
@@ -23,28 +23,7 @@ RUN apt-get update -y \
             brotli
 
 COPY ./stress /stress
+COPY run.sh /
 
 ENV DATASETS="hits visits"
-
-CMD dpkg -i package_folder/clickhouse-common-static_*.deb; \
-    dpkg -i package_folder/clickhouse-common-static-dbg_*.deb; \
-    dpkg -i package_folder/clickhouse-server_*.deb;  \
-    dpkg -i package_folder/clickhouse-client_*.deb; \
-    dpkg -i package_folder/clickhouse-test_*.deb; \
-    ln -s /usr/share/clickhouse-test/config/log_queries.xml /etc/clickhouse-server/users.d/; \
-    ln -s /usr/share/clickhouse-test/config/part_log.xml /etc/clickhouse-server/config.d/; \
-    echo "TSAN_OPTIONS='halt_on_error=1 history_size=7 ignore_noninstrumented_modules=1 verbosity=1'" >> /etc/environment; \
-    echo "UBSAN_OPTIONS='print_stacktrace=1'" >> /etc/environment; \
-    echo "ASAN_OPTIONS='malloc_context_size=10 verbosity=1 allocator_release_to_os_interval_ms=10000'" >> /etc/environment; \
-    service clickhouse-server start && sleep 5 \
-    && /s3downloader --dataset-names $DATASETS \
-    && chmod 777 -R /var/lib/clickhouse \
-    && clickhouse-client --query "ATTACH DATABASE IF NOT EXISTS datasets ENGINE = Ordinary" \
-    && clickhouse-client --query "CREATE DATABASE IF NOT EXISTS test" \
-    && service clickhouse-server restart && sleep 5 \
-    && clickhouse-client --query "SHOW TABLES FROM datasets" \
-    && clickhouse-client --query "SHOW TABLES FROM test" \
-    && clickhouse-client --query "RENAME TABLE datasets.hits_v1 TO test.hits" \
-    && clickhouse-client --query "RENAME TABLE datasets.visits_v1 TO test.visits" \
-    && clickhouse-client --query "SHOW TABLES FROM test" \
-    && ./stress --output-folder test_output --skip-func-tests "$SKIP_TESTS_OPTION"
+CMD ["/bin/bash", "/run.sh"]

--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -51,6 +51,6 @@ service clickhouse-server restart
 
 wait_server
 
-clickhouse-client --query "SELECT 'Server successfuly started'" || echo 'Server failed to start'
+clickhouse-client --query "SELECT 'Server successfuly started'" > /test_output/alive_check.txt || echo 'Server failed to start' > /test_output/alive_check.txt
 
 mv /var/log/clickhouse-server/* /test_output

--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+dpkg -i package_folder/clickhouse-common-static_*.deb
+dpkg -i package_folder/clickhouse-common-static-dbg_*.deb
+dpkg -i package_folder/clickhouse-server_*.deb
+dpkg -i package_folder/clickhouse-client_*.deb
+dpkg -i package_folder/clickhouse-test_*.deb
+
+function wait_server()
+{
+    counter=0
+    until clickhouse-client --query "SELECT 1"
+    do
+        if [ "$counter" -gt 120 ]
+        then
+            break
+        fi
+        sleep 0.5
+        counter=$(($counter + 1))
+    done
+}
+
+ln -s /usr/share/clickhouse-test/config/log_queries.xml /etc/clickhouse-server/users.d/
+ln -s /usr/share/clickhouse-test/config/part_log.xml /etc/clickhouse-server/config.d/
+
+echo "TSAN_OPTIONS='halt_on_error=1 history_size=7 ignore_noninstrumented_modules=1 verbosity=1'" >> /etc/environment
+echo "UBSAN_OPTIONS='print_stacktrace=1'" >> /etc/environment
+echo "ASAN_OPTIONS='malloc_context_size=10 verbosity=1 allocator_release_to_os_interval_ms=10000'" >> /etc/environment
+
+service clickhouse-server start
+
+wait_server
+
+/s3downloader --dataset-names $DATASETS
+chmod 777 -R /var/lib/clickhouse
+clickhouse-client --query "ATTACH DATABASE IF NOT EXISTS datasets ENGINE = Ordinary"
+clickhouse-client --query "CREATE DATABASE IF NOT EXISTS test"
+service clickhouse-server restart
+
+wait_server
+
+clickhouse-client --query "SHOW TABLES FROM datasets"
+clickhouse-client --query "SHOW TABLES FROM test"
+clickhouse-client --query "RENAME TABLE datasets.hits_v1 TO test.hits"
+clickhouse-client --query "RENAME TABLE datasets.visits_v1 TO test.visits"
+clickhouse-client --query "SHOW TABLES FROM test"
+
+./stress --output-folder test_output --skip-func-tests "$SKIP_TESTS_OPTION"
+
+service clickhouse-server restart
+
+wait_server
+
+clickhouse-client --query "SELECT 'Server successfuly started'" || echo 'Server failed to start'
+
+mv /var/log/clickhouse-server/* /test_output

--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 dpkg -i package_folder/clickhouse-common-static_*.deb
 dpkg -i package_folder/clickhouse-common-static-dbg_*.deb
 dpkg -i package_folder/clickhouse-server_*.deb
@@ -52,5 +54,3 @@ service clickhouse-server restart
 wait_server
 
 clickhouse-client --query "SELECT 'Server successfuly started'" > /test_output/alive_check.txt || echo 'Server failed to start' > /test_output/alive_check.txt
-
-mv /var/log/clickhouse-server/* /test_output

--- a/docker/test/stress/stress
+++ b/docker/test/stress/stress
@@ -41,15 +41,6 @@ def run_func_test(cmd, output_prefix, num_processes, skip_tests_option):
     return pipes
 
 
-def check_clickhouse_alive(cmd):
-    try:
-        logging.info("Checking ClickHouse still alive")
-        check_call("{} --query \"select 'Still alive'\"".format(cmd), shell=True)
-        return True
-    except:
-        return False
-
-
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')
     parser = argparse.ArgumentParser(description="ClickHouse script for running stresstest")
@@ -65,29 +56,18 @@ if __name__ == "__main__":
     args = parser.parse_args()
     func_pipes = []
     perf_process = None
-    try:
-        perf_process = run_perf_test(args.perf_test_cmd, args.perf_test_xml_path, args.output_folder)
-        func_pipes = run_func_test(args.test_cmd, args.output_folder, args.num_parallel, args.skip_func_tests)
+    perf_process = run_perf_test(args.perf_test_cmd, args.perf_test_xml_path, args.output_folder)
+    func_pipes = run_func_test(args.test_cmd, args.output_folder, args.num_parallel, args.skip_func_tests)
 
-        logging.info("Will wait functests to finish")
-        while True:
-            retcodes = []
-            for p in func_pipes:
-                if p.poll() is not None:
-                    retcodes.append(p.returncode)
-            if len(retcodes) == len(func_pipes):
-                break
-            logging.info("Finished %s from %s processes", len(retcodes), len(func_pipes))
-            time.sleep(5)
+    logging.info("Will wait functests to finish")
+    while True:
+        retcodes = []
+        for p in func_pipes:
+            if p.poll() is not None:
+                retcodes.append(p.returncode)
+        if len(retcodes) == len(func_pipes):
+            break
+        logging.info("Finished %s from %s processes", len(retcodes), len(func_pipes))
+        time.sleep(5)
 
-        if not check_clickhouse_alive(args.client_cmd):
-            raise Exception("Stress failed, results in logs")
-        else:
-            logging.info("Stress is ok")
-    except Exception as ex:
-        raise ex
-    finally:
-        if os.path.exists(args.server_log_folder):
-            logging.info("Copying server log files")
-            for log_file in os.listdir(args.server_log_folder):
-                shutil.copy(os.path.join(args.server_log_folder, log_file), os.path.join(args.output_folder, log_file))
+    logging.info("Stress test finished")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now we check that server is able to start after stress tests run. This fixes #12473.