### PR TITLE
Publish repo snapshot in perf test package

### DIFF
--- a/docker/packager/binary/build.sh
+++ b/docker/packager/binary/build.sh
@@ -47,7 +47,7 @@ then
     # package.
     mkdir /output/ch
     git -C /output/ch init --bare
-    git -C /output/ch remote add origin ..
+    git -C /output/ch remote add origin /build
     git -C /output/ch fetch --no-tags --depth 50 origin HEAD
     git -C /output/ch reset --soft FETCH_HEAD
     git -C /output/ch log -5

--- a/docker/packager/binary/build.sh
+++ b/docker/packager/binary/build.sh
@@ -33,6 +33,24 @@ then
     rm /output/clickhouse-odbc-bridge ||:
 
     cp -r ../docker/test/performance-comparison /output/scripts ||:
+
+    # We have to know the revision that corresponds to this binary build.
+    # It is not the nominal SHA from pull/*/head, but the pull/*/merge, which is
+    # head merged to master by github, at some point after the PR is updated.
+    # There are some quirks to consider:
+    # - apparently the real SHA is not recorded in system.build_options;
+    # - it can change at any time as github pleases, so we can't just record
+    #   the SHA and use it later, it might become inaccessible;
+    # - CI has an immutable snapshot of repository that it uses for all checks
+    #   for a given nominal SHA, but it is not accessible outside Yandex.
+    # This is why we add this repository snapshot from CI to the performance test
+    # package.
+    mkdir /output/ch
+    git -C /output/ch init --bare
+    git -C /output/ch remote add origin ..
+    git -C /output/ch fetch --no-tags --depth 50 origin HEAD
+    git -C /output/ch reset --soft FETCH_HEAD
+    git -C /output/ch log -5
 fi
 
 # May be set for split build or for performance test.


### PR DESCRIPTION
This is required to know which SHA corresponds to the binary built for perf test. Let's see how the docker check goes in this PR.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)
