### PR TITLE
Some provisions for Android build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,7 +287,7 @@ endif ()
 
 include(cmake/dbms_glob_sources.cmake)
 
-if (OS_LINUX)
+if (OS_LINUX OR OS_ANDROID)
     include(cmake/linux/default_libs.cmake)
 elseif (OS_DARWIN)
     include(cmake/darwin/default_libs.cmake)

--- a/base/common/getThreadId.cpp
+++ b/base/common/getThreadId.cpp
@@ -1,6 +1,9 @@
 #include <common/getThreadId.h>
 
-#if defined(OS_LINUX)
+#if defined(OS_ANDROID)
+    #include <sys/types.h>
+    #include <unistd.h>
+#elif defined(OS_LINUX)
     #include <unistd.h>
     #include <syscall.h>
 #elif defined(OS_FREEBSD)
@@ -16,7 +19,9 @@ uint64_t getThreadId()
 {
     if (!current_tid)
     {
-#if defined(OS_LINUX)
+#if defined(OS_ANDROID)
+        current_tid = gettid();
+#elif defined(OS_LINUX)
         current_tid = syscall(SYS_gettid); /// This call is always successful. - man gettid
 #elif defined(OS_FREEBSD)
         current_tid = pthread_getthreadid_np();

--- a/base/daemon/BaseDaemon.cpp
+++ b/base/daemon/BaseDaemon.cpp
@@ -9,7 +9,6 @@
 #include <string.h>
 #include <signal.h>
 #include <cxxabi.h>
-#include <execinfo.h>
 #include <unistd.h>
 
 #include <typeinfo>

--- a/cmake/find/amqpcpp.cmake
+++ b/cmake/find/amqpcpp.cmake
@@ -1,4 +1,4 @@
-SET(ENABLE_AMQPCPP ${ENABLE_LIBRARIES})
+option(ENABLE_AMQPCPP "Enalbe AMQP-CPP" ${ENABLE_LIBRARIES})
 if (NOT EXISTS "${ClickHouse_SOURCE_DIR}/contrib/AMQP-CPP/CMakeLists.txt")
     message (WARNING "submodule contrib/AMQP-CPP is missing. to fix try run: \n git submodule update --init --recursive")
     set (ENABLE_AMQPCPP 0)

--- a/cmake/linux/default_libs.cmake
+++ b/cmake/linux/default_libs.cmake
@@ -11,7 +11,12 @@ else ()
     set (BUILTINS_LIBRARY "-lgcc")
 endif ()
 
+if (OS_ANDROID)
+# pthread and rt are included in libc
+set (DEFAULT_LIBS "${DEFAULT_LIBS} ${BUILTINS_LIBRARY} ${COVERAGE_OPTION} -lc -lm -ldl")
+else ()
 set (DEFAULT_LIBS "${DEFAULT_LIBS} ${BUILTINS_LIBRARY} ${COVERAGE_OPTION} -lc -lm -lrt -lpthread -ldl")
+endif ()
 
 message(STATUS "Default libraries: ${DEFAULT_LIBS}")
 
@@ -35,7 +40,11 @@ add_library(global-libs INTERFACE)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
-add_subdirectory(base/glibc-compatibility)
+if (NOT OS_ANDROID)
+    # Our compatibility layer doesn't build under Android, many errors in musl.
+    add_subdirectory(base/glibc-compatibility)
+endif ()
+
 include (cmake/find/unwind.cmake)
 include (cmake/find/cxx.cmake)
 

--- a/cmake/target.cmake
+++ b/cmake/target.cmake
@@ -1,6 +1,11 @@
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")
     set (OS_LINUX 1)
     add_definitions(-D OS_LINUX)
+elseif (CMAKE_SYSTEM_NAME MATCHES "Android")
+    # This is a toy configuration and not in CI, so expect it to be broken.
+    # Use cmake flags such as: -DCMAKE_TOOLCHAIN_FILE=~/ch2/android-ndk-r21d/build/cmake/android.toolchain.cmake -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=28
+    set (OS_ANDROID 1)
+    add_definitions(-D OS_ANDROID)
 elseif (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
     set (OS_FREEBSD 1)
     add_definitions(-D OS_FREEBSD)
@@ -17,7 +22,7 @@ if (CMAKE_CROSSCOMPILING)
         set (ENABLE_PARQUET OFF CACHE INTERNAL "")
         set (ENABLE_ICU OFF CACHE INTERNAL "")
         set (ENABLE_FASTOPS OFF CACHE INTERNAL "")
-    elseif (OS_LINUX)
+    elseif (OS_LINUX OR OS_ANDROID)
         if (ARCH_AARCH64)
             # FIXME: broken dependencies
             set (ENABLE_PROTOBUF OFF CACHE INTERNAL "")

--- a/src/Common/MemoryStatisticsOS.cpp
+++ b/src/Common/MemoryStatisticsOS.cpp
@@ -1,3 +1,5 @@
+#if defined(OS_LINUX)
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -101,3 +103,5 @@ MemoryStatisticsOS::Data MemoryStatisticsOS::get() const
 }
 
 }
+
+#endif

--- a/src/Common/MemoryStatisticsOS.h
+++ b/src/Common/MemoryStatisticsOS.h
@@ -1,4 +1,5 @@
 #pragma once
+#if defined(OS_LINUX)
 #include <cstdint>
 
 
@@ -38,3 +39,5 @@ private:
 };
 
 }
+
+#endif

--- a/src/Dictionaries/SSDCacheDictionary.cpp
+++ b/src/Dictionaries/SSDCacheDictionary.cpp
@@ -1,4 +1,4 @@
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
 
 #include "SSDCacheDictionary.h"
 

--- a/src/Dictionaries/SSDComplexKeyCacheDictionary.cpp
+++ b/src/Dictionaries/SSDComplexKeyCacheDictionary.cpp
@@ -1,4 +1,4 @@
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
 
 #include "SSDComplexKeyCacheDictionary.h"
 

--- a/src/Dictionaries/SSDComplexKeyCacheDictionary.h
+++ b/src/Dictionaries/SSDComplexKeyCacheDictionary.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
 
 #include "DictionaryStructure.h"
 #include "IDictionary.h"

--- a/src/Dictionaries/registerDictionaries.cpp
+++ b/src/Dictionaries/registerDictionaries.cpp
@@ -33,7 +33,7 @@ void registerDictionaries()
         registerDictionaryFlat(factory);
         registerDictionaryHashed(factory);
         registerDictionaryCache(factory);
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
         registerDictionarySSDCache(factory);
         registerDictionarySSDComplexKeyCache(factory);
 #endif

--- a/src/Functions/FunctionsExternalDictionaries.h
+++ b/src/Functions/FunctionsExternalDictionaries.h
@@ -29,7 +29,7 @@
 #include <Dictionaries/FlatDictionary.h>
 #include <Dictionaries/HashedDictionary.h>
 #include <Dictionaries/CacheDictionary.h>
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
 #include <Dictionaries/SSDCacheDictionary.h>
 #include <Dictionaries/SSDComplexKeyCacheDictionary.h>
 #endif
@@ -182,13 +182,13 @@ private:
             !executeDispatchSimple<DirectDictionary>(block, arguments, result, dict) &&
             !executeDispatchSimple<HashedDictionary>(block, arguments, result, dict) &&
             !executeDispatchSimple<CacheDictionary>(block, arguments, result, dict) &&
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
             !executeDispatchSimple<SSDCacheDictionary>(block, arguments, result, dict) &&
 #endif
             !executeDispatchComplex<ComplexKeyHashedDictionary>(block, arguments, result, dict) &&
             !executeDispatchComplex<ComplexKeyDirectDictionary>(block, arguments, result, dict) &&
             !executeDispatchComplex<ComplexKeyCacheDictionary>(block, arguments, result, dict) &&
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
             !executeDispatchComplex<SSDComplexKeyCacheDictionary>(block, arguments, result, dict) &&
 #endif
 #if !defined(ARCADIA_BUILD)
@@ -338,13 +338,13 @@ private:
             !executeDispatch<HashedDictionary>(block, arguments, result, dict) &&
             !executeDispatch<DirectDictionary>(block, arguments, result, dict) &&
             !executeDispatch<CacheDictionary>(block, arguments, result, dict) &&
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
             !executeDispatch<SSDCacheDictionary>(block, arguments, result, dict) &&
 #endif
             !executeDispatchComplex<ComplexKeyHashedDictionary>(block, arguments, result, dict) &&
             !executeDispatchComplex<ComplexKeyDirectDictionary>(block, arguments, result, dict) &&
             !executeDispatchComplex<ComplexKeyCacheDictionary>(block, arguments, result, dict) &&
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
             !executeDispatchComplex<SSDComplexKeyCacheDictionary>(block, arguments, result, dict) &&
 #endif
 #if !defined(ARCADIA_BUILD)
@@ -522,13 +522,13 @@ private:
             !executeDispatch<HashedDictionary>(block, arguments, result, dict) &&
             !executeDispatch<DirectDictionary>(block, arguments, result, dict) &&
             !executeDispatch<CacheDictionary>(block, arguments, result, dict) &&
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
             !executeDispatch<SSDCacheDictionary>(block, arguments, result, dict) &&
 #endif
             !executeDispatchComplex<ComplexKeyHashedDictionary>(block, arguments, result, dict) &&
             !executeDispatchComplex<ComplexKeyDirectDictionary>(block, arguments, result, dict) &&
             !executeDispatchComplex<ComplexKeyCacheDictionary>(block, arguments, result, dict) &&
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
             !executeDispatchComplex<SSDComplexKeyCacheDictionary>(block, arguments, result, dict) &&
 #endif
 #if !defined(ARCADIA_BUILD)
@@ -862,13 +862,13 @@ private:
             !executeDispatch<HashedDictionary>(block, arguments, result, dict) &&
             !executeDispatch<DirectDictionary>(block, arguments, result, dict) &&
             !executeDispatch<CacheDictionary>(block, arguments, result, dict) &&
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
             !executeDispatch<SSDCacheDictionary>(block, arguments, result, dict) &&
 #endif
             !executeDispatchComplex<ComplexKeyHashedDictionary>(block, arguments, result, dict) &&
             !executeDispatchComplex<ComplexKeyDirectDictionary>(block, arguments, result, dict) &&
             !executeDispatchComplex<ComplexKeyCacheDictionary>(block, arguments, result, dict) &&
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
             !executeDispatchComplex<SSDComplexKeyCacheDictionary>(block, arguments, result, dict) &&
 #endif
 #if !defined(ARCADIA_BUILD)
@@ -1123,13 +1123,13 @@ private:
             !executeDispatch<HashedDictionary>(block, arguments, result, dict) &&
             !executeDispatch<DirectDictionary>(block, arguments, result, dict) &&
             !executeDispatch<CacheDictionary>(block, arguments, result, dict) &&
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
             !executeDispatch<SSDCacheDictionary>(block, arguments, result, dict) &&
 #endif
             !executeDispatchComplex<ComplexKeyHashedDictionary>(block, arguments, result, dict) &&
             !executeDispatchComplex<ComplexKeyDirectDictionary>(block, arguments, result, dict) &&
             !executeDispatchComplex<ComplexKeyCacheDictionary>(block, arguments, result, dict) &&
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
             !executeDispatchComplex<SSDComplexKeyCacheDictionary>(block, arguments, result, dict) &&
 #endif
 #if !defined(ARCADIA_BUILD)

--- a/src/IO/AIOContextPool.cpp
+++ b/src/IO/AIOContextPool.cpp
@@ -1,4 +1,4 @@
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
 
 #include <Common/Exception.h>
 #include <common/logger_useful.h>

--- a/src/IO/AIOContextPool.h
+++ b/src/IO/AIOContextPool.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
 
 #include <condition_variable>
 #include <future>

--- a/src/IO/BitHelpers.h
+++ b/src/IO/BitHelpers.h
@@ -7,7 +7,7 @@
 #include <cstring>
 #include <cassert>
 
-#if defined(__OpenBSD__) || defined(__FreeBSD__)
+#if defined(__OpenBSD__) || defined(__FreeBSD__) || defined (__ANDROID__)
 #   include <sys/endian.h>
 #elif defined(__APPLE__)
 #   include <libkern/OSByteOrder.h>

--- a/src/IO/ReadBufferAIO.cpp
+++ b/src/IO/ReadBufferAIO.cpp
@@ -1,4 +1,4 @@
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
 
 #include <IO/ReadBufferAIO.h>
 #include <IO/AIOContextPool.h>

--- a/src/IO/ReadBufferAIO.h
+++ b/src/IO/ReadBufferAIO.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
 
 #include <IO/ReadBufferFromFileBase.h>
 #include <IO/ReadBuffer.h>

--- a/src/IO/WriteBufferAIO.cpp
+++ b/src/IO/WriteBufferAIO.cpp
@@ -1,4 +1,4 @@
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
 
 #include <IO/WriteBufferAIO.h>
 #include <Common/MemorySanitizer.h>

--- a/src/IO/WriteBufferAIO.h
+++ b/src/IO/WriteBufferAIO.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
 
 #include <IO/WriteBufferFromFileBase.h>
 #include <IO/WriteBuffer.h>

--- a/src/IO/createReadBufferFromFileBase.cpp
+++ b/src/IO/createReadBufferFromFileBase.cpp
@@ -1,6 +1,6 @@
 #include <IO/createReadBufferFromFileBase.h>
 #include <IO/ReadBufferFromFile.h>
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
 #include <IO/ReadBufferAIO.h>
 #endif
 #include <IO/MMapReadBufferFromFile.h>
@@ -24,7 +24,7 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBufferFromFileBase(
     size_t estimated_size, size_t aio_threshold, size_t mmap_threshold,
     size_t buffer_size_, int flags_, char * existing_memory_, size_t alignment)
 {
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
     if (aio_threshold && estimated_size >= aio_threshold)
     {
         /// Attempt to open a file with O_DIRECT

--- a/src/IO/createWriteBufferFromFileBase.cpp
+++ b/src/IO/createWriteBufferFromFileBase.cpp
@@ -1,6 +1,6 @@
 #include <IO/createWriteBufferFromFileBase.h>
 #include <IO/WriteBufferFromFile.h>
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
 #include <IO/WriteBufferAIO.h>
 #endif
 #include <Common/ProfileEvents.h>
@@ -20,7 +20,7 @@ std::unique_ptr<WriteBufferFromFileBase> createWriteBufferFromFileBase(const std
         size_t aio_threshold, size_t buffer_size_, int flags_, mode_t mode, char * existing_memory_,
         size_t alignment)
 {
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
     if (aio_threshold && estimated_size >= aio_threshold)
     {
         /// Attempt to open a file with O_DIRECT


### PR DESCRIPTION
It doesn't really work anyway, but someday we will have a highly performant mobile OLAP cluster...
This PR mostly replaces `__linux__` with `OS_LINUX`, because the former also applies to Android.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)