### PR TITLE
Add dumb "fuzzer" (that adds random delays) for Processors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ if (ENABLE_FUZZING)
     set (FUZZER "libfuzzer")
 endif()
 
-option (ENABLE_PROCESSORS_FUZZING "Enables random delays for Processors (to trigger possible Pipeline stuck errors)" OFF)
+option (ENABLE_PROCESSORS_FUZZING "Enables random delays for Processors (to trigger possible Pipeline stuck errors)" ON)
 # XXX: rework this
 if (ENABLE_PROCESSORS_FUZZING)
     message (STATUS "Processors fuzzing enabled")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,13 @@ if (ENABLE_FUZZING)
     set (FUZZER "libfuzzer")
 endif()
 
+option (ENABLE_PROCESSORS_FUZZING "Enables random delays for Processors (to trigger possible Pipeline stuck errors)" OFF)
+# XXX: rework this
+if (ENABLE_PROCESSORS_FUZZING)
+    message (STATUS "Processors fuzzing enabled")
+    add_definitions(-DENABLE_PROCESSORS_FUZZING)
+endif()
+
 include (cmake/fuzzer.cmake)
 include (cmake/sanitize.cmake)
 

--- a/src/Processors/Port.h
+++ b/src/Processors/Port.h
@@ -263,8 +263,8 @@ protected:
 #ifdef ENABLE_PROCESSORS_FUZZING
     void yieldIfNeed()
     {
-        static const float yield_probability = .4;
-        static const int   sleep_time_us     = 10'000;
+        static const float yield_probability = .1;
+        static const int   sleep_time_us     = 1'000;
         if (std::bernoulli_distribution(yield_probability)(thread_local_rng))
         {
             sleepForNanoseconds(sleep_time_us * 1000);

--- a/src/Processors/Port.h
+++ b/src/Processors/Port.h
@@ -264,7 +264,7 @@ protected:
     void yieldIfNeed()
     {
         static const float yield_probability = .1;
-        static const int   sleep_time_us     = 1'000;
+        static const int   sleep_time_us     = 10'000;
         if (std::bernoulli_distribution(yield_probability)(thread_local_rng))
         {
             sleepForNanoseconds(sleep_time_us * 1000);


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

"Pipeline stuck" is still possible from time to time, let's try random delays for Port interaction in attempt to make it visible.

Cc: @KochetovNicolai 