### PR TITLE
Fix EXPLAIN format for MySQL client

### DIFF
--- a/src/Parsers/ParserQueryWithOutput.cpp
+++ b/src/Parsers/ParserQueryWithOutput.cpp
@@ -109,16 +109,6 @@ bool ParserQueryWithOutput::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
         query_with_output.children.push_back(query_with_output.settings_ast);
     }
 
-    if (auto * ast = query->as<ASTExplainQuery>())
-    {
-        /// Set default format TSV, because output is a single string column.
-        if (!ast->format)
-        {
-            ast->format = std::make_shared<ASTIdentifier>("TSV");
-            ast->children.push_back(ast->format);
-        }
-    }
-
     node = std::move(query);
     return true;
 }

--- a/tests/integration/test_mysql_protocol/test.py
+++ b/tests/integration/test_mysql_protocol/test.py
@@ -192,6 +192,36 @@ def test_mysql_replacement_query(mysql_client, server_address):
     assert stdout == 'DATABASE()\ndefault\n'
 
 
+def test_mysql_explain(mysql_client, server_address):
+    # EXPLAIN SELECT 1
+    code, (stdout, stderr) = mysql_client.exec_run('''
+        mysql --protocol tcp -h {host} -P {port} default -u default --password=123
+        -e "EXPLAIN SELECT 1;"
+    '''.format(host=server_address, port=server_port), demux=True)
+    assert code == 0
+
+    # EXPLAIN AST SELECT 1
+    code, (stdout, stderr) = mysql_client.exec_run('''
+        mysql --protocol tcp -h {host} -P {port} default -u default --password=123
+        -e "EXPLAIN AST SELECT 1;"
+    '''.format(host=server_address, port=server_port), demux=True)
+    assert code == 0
+
+    # EXPLAIN PLAN SELECT 1
+    code, (stdout, stderr) = mysql_client.exec_run('''
+        mysql --protocol tcp -h {host} -P {port} default -u default --password=123
+        -e "EXPLAIN PLAN SELECT 1;"
+    '''.format(host=server_address, port=server_port), demux=True)
+    assert code == 0
+    
+    # EXPLAIN PIPELINE graph=1 SELECT 1
+    code, (stdout, stderr) = mysql_client.exec_run('''
+        mysql --protocol tcp -h {host} -P {port} default -u default --password=123
+        -e "EXPLAIN PIPELINE graph=1 SELECT 1;"
+    '''.format(host=server_address, port=server_port), demux=True)
+    assert code == 0
+    
+    
 def test_mysql_federated(mysql_server, server_address):
     # For some reason it occasionally fails without retries.
     retries = 100


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix explain query format overwrite by default, issue https://github.com/ClickHouse/ClickHouse/issues/12432


Detailed description / Documentation draft:

...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.
