### PR TITLE
Fix incorrect adaptive granularity by default

### DIFF
--- a/src/Storages/MergeTree/MergedBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/MergedBlockOutputStream.cpp
@@ -46,7 +46,7 @@ MergedBlockOutputStream::MergedBlockOutputStream(
 {
     MergeTreeWriterSettings writer_settings(
         storage.global_context.getSettings(),
-        storage.canUseAdaptiveGranularity(),
+        data_part->index_granularity_info.is_adaptive,
         aio_threshold,
         blocks_are_granules_size);
 

--- a/tests/integration/test_adaptive_granularity_different_settings/test.py
+++ b/tests/integration/test_adaptive_granularity_different_settings/test.py
@@ -6,6 +6,9 @@ cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', with_zookeeper=True)
 node2 = cluster.add_instance('node2', with_zookeeper=True)
 
+# no adaptive granularity by default
+node3 = cluster.add_instance('node3', image='yandex/clickhouse-server:19.9.5.36', with_installed_binary=True, stay_alive=True)
+
 @pytest.fixture(scope="module")
 def start_cluster():
     try:
@@ -47,3 +50,29 @@ def test_attach_detach(start_cluster):
 
     assert node1.query("SELECT COUNT() FROM  test") == "4\n"
     assert node2.query("SELECT COUNT() FROM  test") == "4\n"
+
+
+def test_mutate_with_mixed_granularity(start_cluster):
+    node3.query("""
+        CREATE TABLE test (date Date, key UInt64, value1 String, value2 String)
+        ENGINE = MergeTree
+        ORDER BY key PARTITION BY date""")
+
+    node3.query("INSERT INTO test SELECT toDate('2019-10-01') + number % 5, number, toString(number), toString(number * number) FROM numbers(500)")
+
+    assert node3.query("SELECT COUNT() FROM test") == "500\n"
+
+    node3.restart_with_latest_version()
+
+    assert node3.query("SELECT COUNT() FROM test") == "500\n"
+
+    node3.query("ALTER TABLE test MODIFY SETTING enable_mixed_granularity_parts = 1")
+
+    node3.query("INSERT INTO test SELECT toDate('2019-10-01') + number % 5, number, toString(number), toString(number * number) FROM numbers(500, 500)")
+
+    assert node3.query("SELECT COUNT() FROM test") == "1000\n"
+    assert node3.query("SELECT COUNT() FROM test WHERE key % 100 == 0") == "10\n"
+
+    node3.query("ALTER TABLE test DELETE WHERE key % 100 == 0", settings={"mutations_sync": "2"})
+
+    assert node3.query("SELECT COUNT() FROM test WHERE key % 100 == 0") == "0\n"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bug which lead to broken old parts after `ALTER DELETE` query when `enable_mixed_granularity_parts=1`. Fixes #12536.
