### PR TITLE
Fix loading parts without checksums

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -2453,19 +2453,6 @@ static void loadPartAndFixMetadataImpl(MergeTreeData::MutableDataPartPtr part)
 
     part->loadColumnsChecksumsIndexes(false, true);
     part->modification_time = disk->getLastModified(full_part_path).epochTime();
-
-    /// If the checksums file is not present, calculate the checksums and write them to disk.
-    /// Check the data while we are at it.
-    if (part->checksums.empty())
-    {
-        part->checksums = checkDataPart(part, false);
-        {
-            auto out = disk->writeFile(full_part_path + "checksums.txt.tmp", 4096);
-            part->checksums.write(*out);
-        }
-
-        disk->moveFile(full_part_path + "checksums.txt.tmp", full_part_path + "checksums.txt");
-    }
 }
 
 MergeTreeData::MutableDataPartPtr MergeTreeData::loadPartAndFixMetadata(const VolumePtr & volume, const String & relative_path) const

--- a/tests/integration/test_attach_without_checksums/test.py
+++ b/tests/integration/test_attach_without_checksums/test.py
@@ -1,0 +1,39 @@
+import pytest
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance('node1')
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_attach_without_checksums(start_cluster):
+    node1.query("CREATE TABLE test (date Date, key Int32, value String) Engine=MergeTree ORDER BY key PARTITION by date")
+
+    node1.query("INSERT INTO test SELECT toDate('2019-10-01'), number, toString(number) FROM numbers(100)")
+
+    assert node1.query("SELECT COUNT() FROM test WHERE key % 10 == 0") == "10\n"
+
+    node1.query("ALTER TABLE test DETACH PARTITION '2019-10-01'")
+
+    assert node1.query("SELECT COUNT() FROM test WHERE key % 10 == 0") == "0\n"
+    assert node1.query("SELECT COUNT() FROM test") == "0\n"
+
+    # to be sure output not empty
+    node1.exec_in_container(['bash', '-c', 'find /var/lib/clickhouse/data/default/test/detached -name "checksums.txt" | grep -e ".*" '], privileged=True, user='root')
+
+    node1.exec_in_container(['bash', '-c', 'find /var/lib/clickhouse/data/default/test/detached -name "checksums.txt" -delete'], privileged=True, user='root')
+
+    node1.query("ALTER TABLE test ATTACH PARTITION '2019-10-01'")
+
+    assert node1.query("SELECT COUNT() FROM test WHERE key % 10 == 0") == "10\n"
+    assert node1.query("SELECT COUNT() FROM test") == "100\n"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now ClickHouse will recalculate checksums for parts when file `checksums.txt` is absent. Broken since #9827.
