### PR TITLE
Remove data for Distributed tables (blocks from async INSERTs) on DROP TABLE

### DIFF
--- a/src/Storages/StorageDistributed.h
+++ b/src/Storages/StorageDistributed.h
@@ -95,6 +95,7 @@ public:
 
     void startup() override;
     void shutdown() override;
+    void drop() override;
 
     Strings getDataPaths() const override;
 

--- a/tests/integration/test_distributed_storage_configuration/test.py
+++ b/tests/integration/test_distributed_storage_configuration/test.py
@@ -29,7 +29,7 @@ def _files_in_dist_mon(node, root, table):
         'find /{root}/data/test/{table}/default@127%2E0%2E0%2E2:9000 -maxdepth 1 -type f 2>/dev/null | wc -l'.format(root=root, table=table)
     ]).split('\n')[0])
 
-def test_different_versions(start_cluster):
+def test_insert(start_cluster):
     node.query('CREATE TABLE test.foo (key Int) Engine=Memory()')
     node.query("""
     CREATE TABLE test.dist_foo (key Int)
@@ -64,3 +64,13 @@ def test_different_versions(start_cluster):
     assert node.query('SELECT count() FROM test.dist2_foo') == '300\n'
     node.query('SYSTEM FLUSH DISTRIBUTED test.dist2_foo')
     assert node.query('SELECT count() FROM test.dist2_foo') == '400\n'
+
+    #
+    # DROP
+    #
+    node.query('DROP TABLE test.dist2_foo')
+    for disk in ['disk1', 'disk2']:
+        node.exec_in_container([
+            'bash', '-c',
+            'test ! -e /{}/data/test/dist2_foo'.format(disk)
+        ])


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove data for Distributed tables (blocks from async INSERTs) on DROP TABLE

P.S. hope that nobody relies on this behavior

<details>

HEAD:
- 1e0622fc3cb86856d84970765d38faf7c8d7f3fe

</details