### PR TITLE
Fix race condition in clickhouse cache dictionary

### DIFF
--- a/src/Common/ProfilingScopedRWLock.h
+++ b/src/Common/ProfilingScopedRWLock.h
@@ -8,16 +8,11 @@
 namespace DB
 {
 
-class ProfilingScopedWriteUnlocker;
-
 class ProfilingScopedWriteRWLock
 {
 public:
-    friend class ProfilingScopedWriteUnlocker;
 
-    ProfilingScopedWriteRWLock(std::shared_mutex & rwl_, ProfileEvents::Event event_) :
-        watch(),
-        event(event_),
+    ProfilingScopedWriteRWLock(std::shared_mutex & rwl_, ProfileEvents::Event event) :
         scoped_write_lock(rwl_)
     {
         ProfileEvents::increment(event, watch.elapsed());
@@ -25,38 +20,14 @@ public:
 
 private:
     Stopwatch watch;
-    ProfileEvents::Event event;
     std::unique_lock<std::shared_mutex> scoped_write_lock;
 };
 
-/// Inversed RAII
-/// Used to unlock current writelock for various purposes.
-class ProfilingScopedWriteUnlocker
-{
-public:
-    ProfilingScopedWriteUnlocker() = delete;
-
-    ProfilingScopedWriteUnlocker(ProfilingScopedWriteRWLock & parent_lock_) : parent_lock(parent_lock_)
-    {
-        parent_lock.scoped_write_lock.unlock();
-    }
-
-    ~ProfilingScopedWriteUnlocker()
-    {
-        Stopwatch watch;
-        parent_lock.scoped_write_lock.lock();
-        ProfileEvents::increment(parent_lock.event, watch.elapsed());
-    }
-
-private:
-    ProfilingScopedWriteRWLock & parent_lock;
-};
 
 class ProfilingScopedReadRWLock
 {
 public:
     ProfilingScopedReadRWLock(std::shared_mutex & rwl, ProfileEvents::Event event) :
-        watch(),
         scoped_read_lock(rwl)
     {
         ProfileEvents::increment(event, watch.elapsed());

--- a/src/Dictionaries/CacheDictionary.cpp
+++ b/src/Dictionaries/CacheDictionary.cpp
@@ -885,7 +885,6 @@ void CacheDictionary::update(BunchUpdateUnit & bunch_update_unit) const
 
                 const auto & ids = id_column->getData();
 
-
                 /// cache column pointers
                 const auto column_ptrs = ext::map<std::vector>(
                         ext::range(0, attributes.size()), [&block](size_t i) { return block.safeGetByPosition(i + 1).column.get(); });

--- a/src/Dictionaries/CacheDictionary.cpp
+++ b/src/Dictionaries/CacheDictionary.cpp
@@ -865,7 +865,7 @@ void CacheDictionary::update(BunchUpdateUnit & bunch_update_unit) const
     {
         try
         {
-            auto current_source_ptr = getDictionarySourceOrUpdate();
+            auto current_source_ptr = getSourceAndUpdateIfNeeded();
 
             Stopwatch watch;
 

--- a/src/Dictionaries/CacheDictionary.h
+++ b/src/Dictionaries/CacheDictionary.h
@@ -317,6 +317,7 @@ private:
     Poco::Logger * log;
 
     mutable std::shared_mutex rw_lock;
+    mutable std::shared_mutex source_mutex;
 
     /// Actual size will be increased to match power of 2
     const size_t size;

--- a/src/Dictionaries/CacheDictionary.h
+++ b/src/Dictionaries/CacheDictionary.h
@@ -291,8 +291,10 @@ private:
 
     using SharedDictionarySourcePtr = std::shared_ptr<IDictionarySource>;
 
-    /// Update dictionary source pointer if required and return
-    /// it. Thread safe.
+    /// Update dictionary source pointer if required and return it. Thread safe.
+    /// MultiVersion is not used here because it works with constant pointers.
+    /// For some reason almost all methods in IDictionarySource interface are
+    /// not constant.
     SharedDictionarySourcePtr getDictionarySourceOrUpdate() const
     {
         std::lock_guard lock(source_mutex);

--- a/src/Dictionaries/CacheDictionary.h
+++ b/src/Dictionaries/CacheDictionary.h
@@ -316,7 +316,13 @@ private:
 
     Poco::Logger * log;
 
+    /// This lock is used for the inner cache state update function lock it for
+    /// write, when it need to update cache state all other functions just
+    /// readers. Suprisingly this lock is also used for last_exception pointer.
     mutable std::shared_mutex rw_lock;
+    /// This lock is used in update function because it is called from different
+    /// threads. If one thread deside to update source_ptr, than all other
+    /// threads should not use previous version of the ptr.
     mutable std::shared_mutex source_mutex;
 
     /// Actual size will be increased to match power of 2

--- a/src/Dictionaries/CacheDictionary.h
+++ b/src/Dictionaries/CacheDictionary.h
@@ -92,7 +92,7 @@ public:
                 database,
                 name,
                 dict_struct,
-                getDictionarySourceOrUpdate()->clone(),
+                getSourceAndUpdateIfNeeded()->clone(),
                 dict_lifetime,
                 strict_max_lifetime_seconds,
                 size,
@@ -295,7 +295,7 @@ private:
     /// MultiVersion is not used here because it works with constant pointers.
     /// For some reason almost all methods in IDictionarySource interface are
     /// not constant.
-    SharedDictionarySourcePtr getDictionarySourceOrUpdate() const
+    SharedDictionarySourcePtr getSourceAndUpdateIfNeeded() const
     {
         std::lock_guard lock(source_mutex);
         if (error_count)
@@ -326,7 +326,7 @@ private:
     const std::string full_name;
     const DictionaryStructure dict_struct;
 
-    /// Dictionary source should be used without mutex
+    /// Dictionary source should be used with mutex
     mutable std::mutex source_mutex;
     mutable SharedDictionarySourcePtr source_ptr;
 

--- a/tests/queries/0_stateless/01412_cache_dictionary_race.sh
+++ b/tests/queries/0_stateless/01412_cache_dictionary_race.sh
@@ -22,9 +22,6 @@ LIFETIME(MIN 1 MAX 3)
 LAYOUT(CACHE(SIZE_IN_CELLS 3));
 "
 
-# This alters mostly requires not only metadata change
-# but also conversion of data. Also they are all compatible
-# between each other, so can be executed concurrently.
 function dict_get_thread()
 {
     while true; do

--- a/tests/queries/0_stateless/01412_cache_dictionary_race.sh
+++ b/tests/queries/0_stateless/01412_cache_dictionary_race.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. $CURDIR/../shell_config.sh
+
+
+$CLICKHOUSE_CLIENT --query "DROP DATABASE IF EXISTS ordinary_db"
+
+$CLICKHOUSE_CLIENT --query "CREATE DATABASE ordinary_db"
+
+$CLICKHOUSE_CLIENT -n -q "
+
+CREATE DICTIONARY ordinary_db.dict1
+(
+  key_column UInt64 DEFAULT 0,
+  second_column UInt8 DEFAULT 1,
+  third_column String DEFAULT 'qqq'
+)
+PRIMARY KEY key_column
+SOURCE(CLICKHOUSE(HOST 'localhost' PORT 9000 USER 'default' TABLE 'view_for_dict' PASSWORD '' DB 'ordinary_db'))
+LIFETIME(MIN 1 MAX 3)
+LAYOUT(CACHE(SIZE_IN_CELLS 3));
+"
+
+# This alters mostly requires not only metadata change
+# but also conversion of data. Also they are all compatible
+# between each other, so can be executed concurrently.
+function dict_get_thread()
+{
+    while true; do
+        $CLICKHOUSE_CLIENT --query "SELECT dictGetString('ordinary_db.dict1', 'third_column', toUInt64(rand() % 1000)) from numbers(2)" &>/dev/null
+    done
+}
+
+
+function drop_create_table_thread()
+{
+    while true; do
+        $CLICKHOUSE_CLIENT -n --query "CREATE TABLE ordinary_db.table_for_dict_real (
+            key_column UInt64,
+            second_column UInt8,
+            third_column String
+        )
+        ENGINE MergeTree() ORDER BY tuple();
+        INSERT INTO ordinary_db.table_for_dict_real SELECT number, number, toString(number) from numbers(2);
+        CREATE VIEW ordinary_db.view_for_dict AS SELECT key_column, second_column, third_column from ordinary_db.table_for_dict_real WHERE sleepEachRow(1) == 0;
+"
+        sleep 10
+
+        $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS ordinary_db.table_for_dict_real"
+        sleep 10
+    done
+}
+
+export -f dict_get_thread;
+export -f drop_create_table_thread;
+
+TIMEOUT=30
+
+timeout $TIMEOUT bash -c dict_get_thread 2> /dev/null &
+timeout $TIMEOUT bash -c dict_get_thread 2> /dev/null &
+timeout $TIMEOUT bash -c dict_get_thread 2> /dev/null &
+timeout $TIMEOUT bash -c dict_get_thread 2> /dev/null &
+timeout $TIMEOUT bash -c dict_get_thread 2> /dev/null &
+timeout $TIMEOUT bash -c dict_get_thread 2> /dev/null &
+
+
+timeout $TIMEOUT bash -c drop_create_table_thread 2> /dev/null &
+
+wait
+
+
+
+$CLICKHOUSE_CLIENT --query "DROP DATABASE IF EXISTS ordinary_db"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix race condition in external dictionaries with cache layout which can lead server crash.