### PR TITLE
Add perf metric for NUMA-local memory access

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -202,8 +202,8 @@
     M(PerfDataTLBMisses, "Data TLB misses") \
     M(PerfInstructionTLBReferences, "Instruction TLB references") \
     M(PerfInstructionTLBMisses, "Instruction TLB misses") \
-    M(PerfLocalMemoryReferences, "Local node memory reads") \
-    M(PerfLocalMemoryMisses, "Local node memory read misses") \
+    M(PerfLocalMemoryReferences, "Local NUMA node memory reads") \
+    M(PerfLocalMemoryMisses, "Local NUMA node memory read misses") \
     \
     M(CreatedHTTPConnections, "Total amount of created HTTP connections (closed or opened).") \
     \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -202,6 +202,8 @@
     M(PerfDataTLBMisses, "Data TLB misses") \
     M(PerfInstructionTLBReferences, "Instruction TLB references") \
     M(PerfInstructionTLBMisses, "Instruction TLB misses") \
+    M(PerfLocalMemoryReferences, "Local node memory reads") \
+    M(PerfLocalMemoryMisses, "Local node memory read misses") \
     \
     M(CreatedHTTPConnections, "Total amount of created HTTP connections (closed or opened).") \
     \

--- a/src/Common/ThreadProfileEvents.cpp
+++ b/src/Common/ThreadProfileEvents.cpp
@@ -193,12 +193,16 @@ static const PerfEventInfo raw_events_info[] = {
     // https://stackoverflow.com/questions/49933319/how-to-interpret-perf-itlb-loads-itlb-load-misses
     CACHE_EVENT(PERF_COUNT_HW_CACHE_ITLB, PerfInstructionTLBReferences, ACCESS),
     CACHE_EVENT(PERF_COUNT_HW_CACHE_ITLB, PerfInstructionTLBMisses, MISS),
+
+    CACHE_EVENT(PERF_COUNT_HW_CACHE_NODE, PerfLocalMemoryReferences, ACCESS),
+    CACHE_EVENT(PERF_COUNT_HW_CACHE_NODE, PerfLocalMemoryMisses, MISS),
 };
 
 static_assert(sizeof(raw_events_info) / sizeof(raw_events_info[0]) == NUMBER_OF_RAW_EVENTS);
 
 #undef HARDWARE_EVENT
 #undef SOFTWARE_EVENT
+#undef CACHE_EVENT
 
 // A map of event name -> event index, to parse event list in settings.
 static std::unordered_map<std::string, size_t> populateEventMap()

--- a/src/Common/ThreadProfileEvents.h
+++ b/src/Common/ThreadProfileEvents.h
@@ -59,6 +59,8 @@ namespace ProfileEvents
     extern const Event PerfDataTLBMisses;
     extern const Event PerfInstructionTLBReferences;
     extern const Event PerfInstructionTLBMisses;
+    extern const Event PerfLocalMemoryReferences;
+    extern const Event PerfLocalMemoryMisses;
 #endif
 }
 
@@ -162,7 +164,7 @@ struct PerfEventValue
     UInt64 time_running = 0;
 };
 
-static constexpr size_t NUMBER_OF_RAW_EVENTS = 20;
+static constexpr size_t NUMBER_OF_RAW_EVENTS = 22;
 
 struct PerfDescriptorsHolder : boost::noncopyable
 {


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)