### PR TITLE
Fix lack of aliases with function 'any'

### DIFF
--- a/src/Interpreters/AnyInputOptimize.cpp
+++ b/src/Interpreters/AnyInputOptimize.cpp
@@ -71,10 +71,13 @@ void AnyInputMatcher::visit(ASTPtr & current_ast, Data data)
         && function_argument && function_argument->as<ASTFunction>())
     {
         auto name = function_node->name;
+        auto alias = function_node->alias;
+
         ///cut any or anyLast
         if (!function_argument->as<ASTFunction>()->arguments->children.empty())
         {
             current_ast = function_argument->clone();
+            current_ast->setAlias(alias);
             for (size_t i = 0; i < current_ast->as<ASTFunction>()->arguments->children.size(); ++i)
                 changeAllIdentifiers(current_ast, i, name);
         }

--- a/tests/queries/0_stateless/01398_any_with_alias.reference
+++ b/tests/queries/0_stateless/01398_any_with_alias.reference
@@ -1,0 +1,8 @@
+"n"
+0
+SELECT any(number) * any(number) AS n
+FROM numbers(100)
+"n"
+0,0
+SELECT (any(number), any(number) * 2) AS n
+FROM numbers(100)

--- a/tests/queries/0_stateless/01398_any_with_alias.sql
+++ b/tests/queries/0_stateless/01398_any_with_alias.sql
@@ -1,0 +1,5 @@
+SELECT any(number * number) AS n FROM numbers(100) FORMAT CSVWithNames;
+EXPLAIN SYNTAX SELECT any(number * number) AS n FROM numbers(100);
+
+SELECT any((number, number * 2)) as n FROM numbers(100) FORMAT CSVWithNames;
+EXPLAIN SYNTAX SELECT any((number, number * 2)) as n FROM numbers(100);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix lack of aliases with function `any`.


Fixes #12592.