### PR TITLE
Do not build helper_container image inside integrational tests. Part 1: build helper_container in CI

### DIFF
--- a/docker/images.json
+++ b/docker/images.json
@@ -99,6 +99,9 @@
     "docker/test/integration/resolver": {
         "name": "yandex/clickhouse-python-bottle",
         "dependent": []
+    },
+    "docker/test/integration/helper_container": {
+        "name": "yandex/clickhouse-integration-helper",
+        "dependent": []
     }
-
 }

--- a/docker/test/integration/helper_container/Dockerfile
+++ b/docker/test/integration/helper_container/Dockerfile
@@ -1,3 +1,4 @@
+# docker build -t yandex/clickhouse-integration-helper .
 # Helper docker container to run iptables without sudo
 
 FROM alpine


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:

Push helper_container to Docker hub

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.
