### PR TITLE
Add current_database to system.query_log

### DIFF
--- a/src/Interpreters/QueryLog.cpp
+++ b/src/Interpreters/QueryLog.cpp
@@ -48,6 +48,7 @@ Block QueryLogElement::createBlock()
         {std::make_shared<DataTypeUInt64>(),                                  "result_bytes"},
         {std::make_shared<DataTypeUInt64>(),                                  "memory_usage"},
 
+        {std::make_shared<DataTypeString>(),                                  "current_database"},
         {std::make_shared<DataTypeString>(),                                  "query"},
         {std::make_shared<DataTypeInt32>(),                                   "exception_code"},
         {std::make_shared<DataTypeString>(),                                  "exception"},
@@ -104,6 +105,7 @@ void QueryLogElement::appendToBlock(MutableColumns & columns) const
 
     columns[i++]->insert(memory_usage);
 
+    columns[i++]->insertData(current_database.data(), current_database.size());
     columns[i++]->insertData(query.data(), query.size());
     columns[i++]->insert(exception_code);
     columns[i++]->insertData(exception.data(), exception.size());

--- a/src/Interpreters/QueryLog.h
+++ b/src/Interpreters/QueryLog.h
@@ -48,6 +48,7 @@ struct QueryLogElement
 
     UInt64 memory_usage{};
 
+    String current_database;
     String query;
 
     Int32 exception_code{}; // because ErrorCodes are int

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -195,6 +195,7 @@ static void onExceptionBeforeStart(const String & query_for_logging, Context & c
     elem.event_time = current_time;
     elem.query_start_time = current_time;
 
+    elem.current_database = context.getCurrentDatabase();
     elem.query = query_for_logging;
     elem.exception_code = getCurrentExceptionCode();
     elem.exception = getCurrentExceptionMessage(false);
@@ -462,6 +463,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
             elem.event_time = current_time;
             elem.query_start_time = current_time;
 
+            elem.current_database = context.getCurrentDatabase();
             elem.query = query_for_logging;
 
             elem.client_info = context.getClientInfo();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add `current_database` information to `system.query_log`.

Detailed description / Documentation draft:

It's useful to have the database information when analyzing query logs. NOTE, this changes the schema of `system.query_log` and the old one will be renamed to `system.query_log0` after upgrading.