### PR TITLE
Fix SIGSEGV in StorageKafka when broker is unavailable

### DIFF
--- a/src/Storages/Kafka/KafkaBlockInputStream.h
+++ b/src/Storages/Kafka/KafkaBlockInputStream.h
@@ -35,7 +35,7 @@ public:
     void readSuffixImpl() override;
 
     void commit();
-    bool isStalled() const { return buffer->isStalled(); }
+    bool isStalled() const { return !buffer || buffer->isStalled(); }
 
 private:
     StorageKafka & storage;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix SIGSEGV in StorageKafka when broker is unavailable (and not only)

Includes: #12487
Fixes: #12488 
Cc: @CurtizJ 
Cc: @filimonov 