### PR TITLE
Add minMap and maxMap support to SimpleAggregateFunction

### DIFF
--- a/docs/en/sql-reference/data-types/simpleaggregatefunction.md
+++ b/docs/en/sql-reference/data-types/simpleaggregatefunction.md
@@ -15,6 +15,9 @@ The following aggregate functions are supported:
 -   [`groupBitXor`](../../sql-reference/aggregate-functions/reference/groupbitxor.md#groupbitxor)
 -   [`groupArrayArray`](../../sql-reference/aggregate-functions/reference/grouparray.md#agg_function-grouparray)
 -   [`groupUniqArrayArray`](../../sql-reference/aggregate-functions/reference/groupuniqarray.md)
+-   [`sumMap`](../../sql-reference/aggregate-functions/reference/summap.md#agg_functions-summap)
+-   [`minMap`](../../sql-reference/aggregate-functions/reference/minmap.md#agg_functions-minmap)
+-   [`maxMap`](../../sql-reference/aggregate-functions/reference/maxmap.md#agg_functions-maxmap)
 
 Values of the `SimpleAggregateFunction(func, Type)` look and stored the same way as `Type`, so you do not need to apply functions with `-Merge`/`-State` suffixes. `SimpleAggregateFunction` has better performance than `AggregateFunction` with same aggregation function.
 

--- a/src/DataTypes/DataTypeCustomSimpleAggregateFunction.cpp
+++ b/src/DataTypes/DataTypeCustomSimpleAggregateFunction.cpp
@@ -32,7 +32,7 @@ namespace ErrorCodes
 
 static const std::vector<String> supported_functions{"any", "anyLast", "min",
     "max", "sum", "sumWithOverflow", "groupBitAnd", "groupBitOr", "groupBitXor",
-    "sumMap", "groupArrayArray", "groupUniqArrayArray"};
+    "sumMap", "minMap", "maxMap", "groupArrayArray", "groupUniqArrayArray"};
 
 
 String DataTypeCustomSimpleAggregateFunction::getName() const

--- a/tests/queries/0_stateless/00915_simple_aggregate_function.reference
+++ b/tests/queries/0_stateless/00915_simple_aggregate_function.reference
@@ -39,7 +39,7 @@ SimpleAggregateFunction(sum, Float64)
 7	14
 8	16
 9	18
-1	1	2	2.2.2.2	3	([1,2,3],[2,1,1])	[1,2,2,3,4]	[4,2,1,3]
-10	2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222	20	20.20.20.20	5	([2,3,4],[2,1,1])	[]	[]
-SimpleAggregateFunction(anyLast, Nullable(String))	SimpleAggregateFunction(anyLast, LowCardinality(Nullable(String)))	SimpleAggregateFunction(anyLast, IPv4)	SimpleAggregateFunction(groupBitOr, UInt32)	SimpleAggregateFunction(sumMap, Tuple(Array(Int32), Array(Int64)))	SimpleAggregateFunction(groupArrayArray, Array(Int32))	SimpleAggregateFunction(groupUniqArrayArray, Array(Int32))
+1	1	2	2.2.2.2	3	([1,2,3],[2,1,1])	([1,2,3],[1,1,2])	([1,2,3],[2,1,2])	[1,2,2,3,4]	[4,2,1,3]
+10	2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222	20	20.20.20.20	5	([2,3,4],[2,1,1])	([2,3,4],[3,3,4])	([2,3,4],[4,3,4])	[]	[]
+SimpleAggregateFunction(anyLast, Nullable(String))	SimpleAggregateFunction(anyLast, LowCardinality(Nullable(String)))	SimpleAggregateFunction(anyLast, IPv4)	SimpleAggregateFunction(groupBitOr, UInt32)	SimpleAggregateFunction(sumMap, Tuple(Array(Int32), Array(Int64)))	SimpleAggregateFunction(minMap, Tuple(Array(Int32), Array(Int64)))	SimpleAggregateFunction(maxMap, Tuple(Array(Int32), Array(Int64)))	SimpleAggregateFunction(groupArrayArray, Array(Int32))	SimpleAggregateFunction(groupUniqArrayArray, Array(Int32))
 with_overflow	1	0

--- a/tests/queries/0_stateless/00915_simple_aggregate_function.sql
+++ b/tests/queries/0_stateless/00915_simple_aggregate_function.sql
@@ -28,22 +28,25 @@ create table simple (
     ip SimpleAggregateFunction(anyLast,IPv4),
     status SimpleAggregateFunction(groupBitOr, UInt32),
     tup SimpleAggregateFunction(sumMap, Tuple(Array(Int32), Array(Int64))),
+    tup_min SimpleAggregateFunction(minMap, Tuple(Array(Int32), Array(Int64))),
+    tup_max SimpleAggregateFunction(maxMap, Tuple(Array(Int32), Array(Int64))),
     arr SimpleAggregateFunction(groupArrayArray, Array(Int32)),
     uniq_arr SimpleAggregateFunction(groupUniqArrayArray, Array(Int32))
 ) engine=AggregatingMergeTree order by id;
-insert into simple values(1,'1','1','1.1.1.1', 1, ([1,2], [1,1]), [1,2], [1,2]);
-insert into simple values(1,null,'2','2.2.2.2', 2, ([1,3], [1,1]), [2,3,4], [2,3,4]);
+insert into simple values(1,'1','1','1.1.1.1', 1, ([1,2], [1,1]), ([1,2], [1,1]), ([1,2], [1,1]), [1,2], [1,2]);
+insert into simple values(1,null,'2','2.2.2.2', 2, ([1,3], [1,1]), ([1,3], [2,2]), ([1,3], [2,2]), [2,3,4], [2,3,4]);
 -- String longer then MAX_SMALL_STRING_SIZE (actual string length is 100)
-insert into simple values(10,'10','10','10.10.10.10', 4, ([2,3], [1,1]), [], []);
-insert into simple values(10,'2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222','20','20.20.20.20', 1, ([2, 4], [1,1]), [], []);
+insert into simple values(10,'10','10','10.10.10.10', 4, ([2,3], [1,1]), ([2,3], [3,3]), ([2,3], [3,3]), [], []);
+insert into simple values(10,'2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222','20','20.20.20.20', 1, ([2, 4], [1,1]), ([2, 4], [4,4]), ([2, 4], [4,4]), [], []);
 
 select * from simple final order by id;
-select toTypeName(nullable_str),toTypeName(low_str),toTypeName(ip),toTypeName(status), toTypeName(tup), toTypeName(arr), toTypeName(uniq_arr) from simple limit 1;
+select toTypeName(nullable_str),toTypeName(low_str),toTypeName(ip),toTypeName(status), toTypeName(tup), toTypeName(tup_min), toTypeName(tup_max), toTypeName(arr), toTypeName(uniq_arr) from simple limit 1;
 
 optimize table simple final;
 
 drop table simple;
 
+drop table if exists with_overflow;
 create table with_overflow (
     id UInt64,
     s SimpleAggregateFunction(sumWithOverflow, UInt8)
@@ -54,4 +57,4 @@ insert into with_overflow select 1, 1 from numbers(256);
 optimize table with_overflow final;
 
 select 'with_overflow', * from with_overflow;
-
+drop table with_overflow;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add `minMap` and `maxMap` functions support to `SimpleAggregateFunction`
