### PR TITLE
Fix memory tracking for input_format_parallel_parsing

### DIFF
--- a/src/DataStreams/ParallelParsingBlockInputStream.cpp
+++ b/src/DataStreams/ParallelParsingBlockInputStream.cpp
@@ -63,9 +63,9 @@ void ParallelParsingBlockInputStream::cancel(bool kill)
 
 void ParallelParsingBlockInputStream::scheduleParserThreadForUnitWithNumber(size_t ticket_number)
 {
-    pool.scheduleOrThrowOnError([this, ticket_number]()
+    pool.scheduleOrThrowOnError([this, ticket_number, group = CurrentThread::getGroup()]()
     {
-        parserThreadFunction(CurrentThread::getGroup(), ticket_number);
+        parserThreadFunction(group, ticket_number);
     });
 }
 

--- a/src/DataStreams/ParallelParsingBlockInputStream.cpp
+++ b/src/DataStreams/ParallelParsingBlockInputStream.cpp
@@ -1,11 +1,97 @@
 #include <DataStreams/ParallelParsingBlockInputStream.h>
+#include <IO/ReadBuffer.h>
+#include <Common/setThreadName.h>
 
 namespace DB
 {
 
+ParallelParsingBlockInputStream::ParallelParsingBlockInputStream(const Params & params)
+    : header(params.input_creator_params.sample),
+      row_input_format_params(params.input_creator_params.row_input_format_params),
+      format_settings(params.input_creator_params.settings),
+      input_processor_creator(params.input_processor_creator),
+      min_chunk_bytes(params.min_chunk_bytes),
+      original_buffer(params.read_buffer),
+      // Subtract one thread that we use for segmentation and one for
+      // reading. After that, must have at least two threads left for
+      // parsing. See the assertion below.
+      pool(std::max(2, params.max_threads - 2)),
+      file_segmentation_engine(params.file_segmentation_engine)
+{
+    // See comment above.
+    assert(params.max_threads >= 4);
+
+    // One unit for each thread, including segmentator and reader, plus a
+    // couple more units so that the segmentation thread doesn't spuriously
+    // bump into reader thread on wraparound.
+    processing_units.resize(params.max_threads + 2);
+
+    segmentator_thread = ThreadFromGlobalPool(
+        &ParallelParsingBlockInputStream::segmentatorThreadFunction, this);
+}
+
+ParallelParsingBlockInputStream::~ParallelParsingBlockInputStream()
+{
+    finishAndWait();
+}
+
+void ParallelParsingBlockInputStream::cancel(bool kill)
+{
+    /**
+      * Can be called multiple times, from different threads. Saturate the
+      * the kill flag with OR.
+      */
+    if (kill)
+        is_killed = true;
+    is_cancelled = true;
+
+    /*
+     * The format parsers themselves are not being cancelled here, so we'll
+     * have to wait until they process the current block. Given that the
+     * chunk size is on the order of megabytes, this should't be too long.
+     * We can't call IInputFormat->cancel here, because the parser object is
+     * local to the parser thread, and we don't want to introduce any
+     * synchronization between parser threads and the other threads to get
+     * better performance. An ideal solution would be to add a callback to
+     * IInputFormat that checks whether it was cancelled.
+     */
+
+    finishAndWait();
+}
+
+void ParallelParsingBlockInputStream::scheduleParserThreadForUnitWithNumber(size_t ticket_number)
+{
+    pool.scheduleOrThrowOnError(std::bind(
+        &ParallelParsingBlockInputStream::parserThreadFunction, this, ticket_number));
+}
+
+void ParallelParsingBlockInputStream::finishAndWait()
+{
+    finished = true;
+
+    {
+        std::unique_lock<std::mutex> lock(mutex);
+        segmentator_condvar.notify_all();
+        reader_condvar.notify_all();
+    }
+
+    if (segmentator_thread.joinable())
+        segmentator_thread.join();
+
+    try
+    {
+        pool.wait();
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+    }
+}
+
 void ParallelParsingBlockInputStream::segmentatorThreadFunction()
 {
     setThreadName("Segmentator");
+
     try
     {
         while (!finished)
@@ -51,10 +137,10 @@ void ParallelParsingBlockInputStream::segmentatorThreadFunction()
 
 void ParallelParsingBlockInputStream::parserThreadFunction(size_t current_ticket_number)
 {
+    setThreadName("ChunkParser");
+
     try
     {
-        setThreadName("ChunkParser");
-
         const auto current_unit_number = current_ticket_number % processing_units.size();
         auto & unit = processing_units[current_unit_number];
 

--- a/src/DataStreams/ParallelParsingBlockInputStream.cpp
+++ b/src/DataStreams/ParallelParsingBlockInputStream.cpp
@@ -63,8 +63,10 @@ void ParallelParsingBlockInputStream::cancel(bool kill)
 
 void ParallelParsingBlockInputStream::scheduleParserThreadForUnitWithNumber(size_t ticket_number)
 {
-    pool.scheduleOrThrowOnError(std::bind(
-        &ParallelParsingBlockInputStream::parserThreadFunction, this, CurrentThread::getGroup(), ticket_number));
+    pool.scheduleOrThrowOnError([this, ticket_number]()
+    {
+        parserThreadFunction(CurrentThread::getGroup(), ticket_number);
+    });
 }
 
 void ParallelParsingBlockInputStream::finishAndWait()

--- a/src/DataStreams/ParallelParsingBlockInputStream.h
+++ b/src/DataStreams/ParallelParsingBlockInputStream.h
@@ -3,14 +3,13 @@
 #include <DataStreams/IBlockInputStream.h>
 #include <Formats/FormatFactory.h>
 #include <Common/ThreadPool.h>
-#include <Common/setThreadName.h>
-#include <IO/BufferWithOwnMemory.h>
-#include <IO/ReadBuffer.h>
 #include <Processors/Formats/IRowInputFormat.h>
 #include <Processors/Formats/InputStreamFromInputFormat.h>
 
 namespace DB
 {
+
+class ReadBuffer;
 
 /**
  * ORDER-PRESERVING parallel parsing of data formats.
@@ -74,68 +73,16 @@ public:
         size_t min_chunk_bytes;
     };
 
-    explicit ParallelParsingBlockInputStream(const Params & params)
-            : header(params.input_creator_params.sample),
-              row_input_format_params(params.input_creator_params.row_input_format_params),
-              format_settings(params.input_creator_params.settings),
-              input_processor_creator(params.input_processor_creator),
-              min_chunk_bytes(params.min_chunk_bytes),
-              original_buffer(params.read_buffer),
-              // Subtract one thread that we use for segmentation and one for
-              // reading. After that, must have at least two threads left for
-              // parsing. See the assertion below.
-              pool(std::max(2, params.max_threads - 2)),
-              file_segmentation_engine(params.file_segmentation_engine)
-    {
-        // See comment above.
-        assert(params.max_threads >= 4);
-
-        // One unit for each thread, including segmentator and reader, plus a
-        // couple more units so that the segmentation thread doesn't spuriously
-        // bump into reader thread on wraparound.
-        processing_units.resize(params.max_threads + 2);
-
-        segmentator_thread = ThreadFromGlobalPool([this] { segmentatorThreadFunction(); });
-    }
+    explicit ParallelParsingBlockInputStream(const Params & params);
+    ~ParallelParsingBlockInputStream() override;
 
     String getName() const override { return "ParallelParsing"; }
+    Block getHeader() const override { return header; }
 
-    ~ParallelParsingBlockInputStream() override
-    {
-        finishAndWait();
-    }
-
-    void cancel(bool kill) override
-    {
-        /**
-          * Can be called multiple times, from different threads. Saturate the
-          * the kill flag with OR.
-          */
-        if (kill)
-            is_killed = true;
-        is_cancelled = true;
-
-        /*
-         * The format parsers themselves are not being cancelled here, so we'll
-         * have to wait until they process the current block. Given that the
-         * chunk size is on the order of megabytes, this should't be too long.
-         * We can't call IInputFormat->cancel here, because the parser object is
-         * local to the parser thread, and we don't want to introduce any
-         * synchronization between parser threads and the other threads to get
-         * better performance. An ideal solution would be to add a callback to
-         * IInputFormat that checks whether it was cancelled.
-         */
-
-        finishAndWait();
-    }
-
-    Block getHeader() const override
-    {
-        return header;
-    }
+    void cancel(bool kill) override;
 
 protected:
-    //Reader routine
+    // Reader routine
     Block readImpl() override;
 
     const BlockMissingValues & getMissingValues() const override
@@ -212,33 +159,8 @@ private:
     std::deque<ProcessingUnit> processing_units;
 
 
-    void scheduleParserThreadForUnitWithNumber(size_t ticket_number)
-    {
-        pool.scheduleOrThrowOnError(std::bind(&ParallelParsingBlockInputStream::parserThreadFunction, this, ticket_number));
-    }
-
-    void finishAndWait()
-    {
-        finished = true;
-
-        {
-            std::unique_lock<std::mutex> lock(mutex);
-            segmentator_condvar.notify_all();
-            reader_condvar.notify_all();
-        }
-
-        if (segmentator_thread.joinable())
-            segmentator_thread.join();
-
-        try
-        {
-            pool.wait();
-        }
-        catch (...)
-        {
-            tryLogCurrentException(__PRETTY_FUNCTION__);
-        }
-    }
+    void scheduleParserThreadForUnitWithNumber(size_t ticket_number);
+    void finishAndWait();
 
     void segmentatorThreadFunction();
     void parserThreadFunction(size_t current_ticket_number);

--- a/src/DataStreams/ParallelParsingBlockInputStream.h
+++ b/src/DataStreams/ParallelParsingBlockInputStream.h
@@ -162,8 +162,8 @@ private:
     void scheduleParserThreadForUnitWithNumber(size_t ticket_number);
     void finishAndWait();
 
-    void segmentatorThreadFunction();
-    void parserThreadFunction(size_t current_ticket_number);
+    void segmentatorThreadFunction(ThreadGroupStatusPtr thread_group);
+    void parserThreadFunction(ThreadGroupStatusPtr thread_group, size_t current_ticket_number);
 
     // Save/log a background exception, set termination flag, wake up all
     // threads. This function is used by segmentator and parsed threads.

--- a/tests/integration/test_input_format_parallel_parsing_memory_tracking/configs/conf.xml
+++ b/tests/integration/test_input_format_parallel_parsing_memory_tracking/configs/conf.xml
@@ -1,0 +1,4 @@
+<yandex>
+    <!-- make it fail earlier -->
+    <max_server_memory_usage>3000000000</max_server_memory_usage> <!-- 3GB -->
+</yandex>

--- a/tests/integration/test_input_format_parallel_parsing_memory_tracking/test.py
+++ b/tests/integration/test_input_format_parallel_parsing_memory_tracking/test.py
@@ -1,0 +1,33 @@
+# pylint: disable=unused-argument
+# pylint: disable=redefined-outer-name
+# pylint: disable=line-too-long
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+instance = cluster.add_instance('instance', main_configs=['configs/conf.xml'])
+
+@pytest.fixture(scope='module', autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+# max_memory_usage_for_user cannot be used, since the memory for user accounted
+# correctly, only total is not
+def test_memory_tracking_total():
+    instance.query('''
+        CREATE TABLE null (row String) ENGINE=Null;
+    ''')
+    instance.exec_in_container(['bash', '-c',
+        'clickhouse client -q "SELECT arrayStringConcat(arrayMap(x->toString(cityHash64(x)), range(1000)), \' \') from numbers(10000)" > data.json'])
+    for it in range(0, 20):
+        # the problem can be triggered only via HTTP,
+        # since clickhouse-client parses the data by itself.
+        assert instance.exec_in_container(['curl', '--silent', '--show-error', '--data-binary', '@data.json',
+            'http://127.1:8123/?query=INSERT%20INTO%20null%20FORMAT%20TSV']) == '', 'Failed on {} iteration'.format(it)


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix memory tracking for input_format_parallel_parsing (by attaching thread to group)

This PR includes:
- small cleanup (moves some bits into module part) - separate patch
- attach/detach thread to group - separate patch
- integration test (since this is the only test that can cover this, because it can be reproduced only with limit for total memory tracking)

Fixes: #12583
`input_format_parallel_parsing` introduced in: #6553 

<details>

HEAD:
- 65e0dab3dac1f466864e0d849d7ac1fa7fff05ba

</details>