### PR TITLE
Abort on std::out_of_range in debug builds

### DIFF
--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -324,6 +324,13 @@ void TCPHandler::runImpl()
             sendException(*exception, send_exception_with_stack_trace);
             std::abort();
         }
+        catch (const std::out_of_range & e)
+        {
+            state.io.onException();
+            exception.emplace(Exception::CreateFromSTDTag{}, e);
+            sendException(*exception, send_exception_with_stack_trace);
+            std::abort();
+        }
 #endif
         catch (const std::exception & e)
         {


### PR DESCRIPTION
This helps notice them in tests, same as:
- std::logic_error
- LOGICAL_ERROR

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @akuzm 
Refs: #12522
Refs: #12418