### PR TITLE
Drop checkNumberOfArgumentsIfVariadic() (never called), check in getReturnType()

### DIFF
--- a/src/Functions/IFunctionAdaptors.h
+++ b/src/Functions/IFunctionAdaptors.h
@@ -221,11 +221,6 @@ class DefaultOverloadResolver : public IFunctionOverloadResolverImpl
 public:
     explicit DefaultOverloadResolver(std::shared_ptr<IFunction> function_) : function(std::move(function_)) {}
 
-    void checkNumberOfArgumentsIfVariadic(size_t number_of_arguments) const override
-    {
-        return function->checkNumberOfArgumentsIfVariadic(number_of_arguments);
-    }
-
     bool isDeterministic() const override { return function->isDeterministic(); }
     bool isDeterministicInScopeOfQuery() const override { return function->isDeterministicInScopeOfQuery(); }
     bool isInjective(const Block &block) const override { return function->isInjective(block); }

--- a/src/Functions/IFunctionImpl.h
+++ b/src/Functions/IFunctionImpl.h
@@ -156,12 +156,6 @@ public:
     virtual bool isStateful() const { return false; }
     virtual bool isVariadic() const { return false; }
 
-    /// Will be called if isVariadic returns true. You need to check if function can have specified number of arguments.
-    virtual void checkNumberOfArgumentsIfVariadic(size_t /*number_of_arguments*/) const
-    {
-        throw Exception("checkNumberOfArgumentsIfVariadic is not implemented for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
-    }
-
     virtual void getLambdaArgumentTypes(DataTypes & /*arguments*/) const
     {
         throw Exception("Function " + getName() + " can't have lambda-expressions as arguments", ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
@@ -288,11 +282,6 @@ public:
     }
 
     virtual bool isVariadic() const { return false; }
-
-    virtual void checkNumberOfArgumentsIfVariadic(size_t /*number_of_arguments*/) const
-    {
-        throw Exception("checkNumberOfArgumentsIfVariadic is not implemented for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
-    }
 
     virtual void getLambdaArgumentTypes(DataTypes & /*arguments*/) const
     {

--- a/src/Functions/randConstant.cpp
+++ b/src/Functions/randConstant.cpp
@@ -76,20 +76,20 @@ public:
     bool isVariadic() const override { return true; }
     size_t getNumberOfArguments() const override { return 0; }
 
-    void checkNumberOfArgumentsIfVariadic(size_t number_of_arguments) const override
-    {
-        if (number_of_arguments > 1)
-            throw Exception("Number of arguments for function " + getName() + " doesn't match: passed "
-                            + toString(number_of_arguments) + ", should be 0 or 1.",
-                            ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
-    }
-
     static FunctionOverloadResolverImplPtr create(const Context &)
     {
         return std::make_unique<RandomConstantOverloadResolver<ToType, Name>>();
     }
 
-    DataTypePtr getReturnType(const DataTypes &) const override { return std::make_shared<DataTypeNumber<ToType>>(); }
+    DataTypePtr getReturnType(const DataTypes & data_types) const override
+    {
+        size_t number_of_arguments = data_types.size();
+        if (number_of_arguments > 1)
+            throw Exception("Number of arguments for function " + getName() + " doesn't match: passed "
+                            + toString(number_of_arguments) + ", should be 0 or 1.",
+                            ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
+        return std::make_shared<DataTypeNumber<ToType>>();
+    }
 
     FunctionBaseImplPtr build(const ColumnsWithTypeAndName & arguments, const DataTypePtr & return_type) const override
     {


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Refs: #12418

<details>

HEADs:
- a2f6a4ebe35809eb953062629d5d81086b0849d4

</details>