### PR TITLE
Revert "Abort on std::out_of_range in debug builds"

### DIFF
--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -324,13 +324,6 @@ void TCPHandler::runImpl()
             sendException(*exception, send_exception_with_stack_trace);
             std::abort();
         }
-        catch (const std::out_of_range & e)
-        {
-            state.io.onException();
-            exception.emplace(Exception::CreateFromSTDTag{}, e);
-            sendException(*exception, send_exception_with_stack_trace);
-            std::abort();
-        }
 #endif
         catch (const std::exception & e)
         {


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#12704