### PR TITLE
Fix ClickHouseDictionarySource wrong access check

### DIFF
--- a/src/Dictionaries/ClickHouseDictionarySource.cpp
+++ b/src/Dictionaries/ClickHouseDictionarySource.cpp
@@ -77,8 +77,8 @@ ClickHouseDictionarySource::ClickHouseDictionarySource(
     if (is_local)
     {
         context.setUser(user, password, Poco::Net::SocketAddress("127.0.0.1", 0));
+        context = copyContextAndApplySettings(path_to_settings, context, config);
     }
-    context = copyContextAndApplySettings(path_to_settings, context, config);
 
     /// Query context is needed because some code in executeQuery function may assume it exists.
     /// Current example is Context::getSampleBlockCache from InterpreterSelectWithUnionQuery::getSampleBlock.

--- a/src/Dictionaries/ClickHouseDictionarySource.cpp
+++ b/src/Dictionaries/ClickHouseDictionarySource.cpp
@@ -74,7 +74,10 @@ ClickHouseDictionarySource::ClickHouseDictionarySource(
     , load_all_query{query_builder.composeLoadAllQuery()}
 {
     /// We should set user info even for the case when the dictionary is loaded in-process (without TCP communication).
-    context.setUser(user, password, Poco::Net::SocketAddress("127.0.0.1", 0));
+    if (is_local)
+    {
+        context.setUser(user, password, Poco::Net::SocketAddress("127.0.0.1", 0));
+    }
     context = copyContextAndApplySettings(path_to_settings, context, config);
 
     /// Query context is needed because some code in executeQuery function may assume it exists.

--- a/tests/integration/test_dictionaries_ddl/configs/config_password.xml
+++ b/tests/integration/test_dictionaries_ddl/configs/config_password.xml
@@ -1,0 +1,23 @@
+<yandex>
+  <profiles>
+    <default>
+    </default>
+  </profiles>
+
+  <users>
+      <default>
+          <password>default</password>
+          <profile>default</profile>
+          <quota>default</quota>
+      </default>
+
+      <admin>
+            <password></password>
+            <networks incl="networks" replace="replace">
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+      </admin>
+  </users>
+</yandex>

--- a/tests/integration/test_dictionaries_ddl/test.py
+++ b/tests/integration/test_dictionaries_ddl/test.py
@@ -11,6 +11,7 @@ cluster = ClickHouseCluster(__file__, base_configs_dir=os.path.join(SCRIPT_DIR, 
 node1 = cluster.add_instance('node1', with_mysql=True, main_configs=['configs/dictionaries/simple_dictionary.xml'])
 node2 = cluster.add_instance('node2', with_mysql=True, main_configs=['configs/dictionaries/simple_dictionary.xml', 'configs/dictionaries/lazy_load.xml'])
 node3 = cluster.add_instance('node3', main_configs=['configs/dictionaries/dictionary_with_conflict_name.xml'])
+node4 = cluster.add_instance('node4', user_configs=['configs/config_password.xml']) # hardcoded value 33333
 
 
 def create_mysql_conn(user, password, hostname, port):
@@ -32,7 +33,7 @@ def execute_mysql_query(connection, query):
 def started_cluster():
     try:
         cluster.start()
-        for clickhouse in [node1, node2, node3]:
+        for clickhouse in [node1, node2, node3, node4]:
             clickhouse.query("CREATE DATABASE test", user="admin")
             clickhouse.query("CREATE TABLE test.xml_dictionary_table (id UInt64, SomeValue1 UInt8, SomeValue2 String) ENGINE = MergeTree() ORDER BY id", user="admin")
             clickhouse.query("INSERT INTO test.xml_dictionary_table SELECT number, number % 23, hex(number) from numbers(1000)", user="admin")
@@ -241,3 +242,33 @@ def test_dictionary_with_where(started_cluster):
     node1.query("SYSTEM RELOAD DICTIONARY default.special_dict")
 
     assert node1.query("SELECT dictGetString('default.special_dict', 'value1', toUInt64(2))") == 'qweqwe\n'
+
+def test_clickhouse_remote(started_cluster):
+    with pytest.raises(QueryRuntimeException):
+        node3.query("""
+        CREATE DICTIONARY test.clickhouse_remote(
+            id UInt64,
+            SomeValue1 UInt8,
+            SomeValue2 String
+        )
+        PRIMARY KEY id
+        LAYOUT(FLAT())
+        SOURCE(CLICKHOUSE(HOST 'node4' PORT 9000 USER 'default' TABLE 'xml_dictionary_table' DB 'test'))
+        LIFETIME(MIN 1 MAX 10)
+        """)
+        node3.query("system reload dictionaries")
+
+    node3.query("detach dictionary if exists test.clickhouse_remote")
+    node3.query("""
+        CREATE DICTIONARY test.clickhouse_remote(
+            id UInt64,
+            SomeValue1 UInt8,
+            SomeValue2 String
+        )
+        PRIMARY KEY id
+        LAYOUT(FLAT())
+        SOURCE(CLICKHOUSE(HOST 'node4' PORT 9000 USER 'default' PASSWORD 'default' TABLE 'xml_dictionary_table' DB 'test'))
+        LIFETIME(MIN 1 MAX 10)
+        """)
+
+    node3.query("select dictGetUInt8('test.clickhouse_remote', 'SomeValue1', toUInt64(17))") == '17\n'

--- a/tests/integration/test_dictionaries_ddl/test.py
+++ b/tests/integration/test_dictionaries_ddl/test.py
@@ -272,3 +272,4 @@ def test_clickhouse_remote(started_cluster):
         """)
 
     node3.query("select dictGetUInt8('test.clickhouse_remote', 'SomeValue1', toUInt64(17))") == '17\n'
+    


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Removed wrong auth access check when using ClickHouseDictionarySource to query remote tables.
