### PR TITLE
Merging #12548 - Correction to `merge_with_ttl_timeout` logic by @excitoon

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
@@ -222,16 +222,12 @@ bool MergeTreeDataMergerMutator::selectPartsToMerge(
     }
 
     time_t current_time = std::time(nullptr);
-    time_t next_ttl_merge_time = last_merge_with_ttl != 0 ? last_merge_with_ttl + data_settings->merge_with_ttl_timeout : current_time;
 
     IMergeSelector::Partitions partitions;
 
     const String * prev_partition_id = nullptr;
     /// Previous part only in boundaries of partition frame
     const MergeTreeData::DataPartPtr * prev_part = nullptr;
-    bool has_parts_with_expired_ttl = false;
-    size_t partition_with_expired_ttl_index = 0;
-    bool has_multiple_partitions_with_ttl_expired_parts = false;
     for (const MergeTreeData::DataPartPtr & part : data_parts)
     {
         /// Check predicate only for first part in each partition.
@@ -263,22 +259,6 @@ bool MergeTreeDataMergerMutator::selectPartsToMerge(
         part_info.min_ttl = part->ttl_infos.part_min_ttl;
         part_info.max_ttl = part->ttl_infos.part_max_ttl;
 
-        time_t ttl = data_settings->ttl_only_drop_parts ? part_info.max_ttl : part_info.min_ttl;
-
-        if (!has_multiple_partitions_with_ttl_expired_parts && ttl && ttl < next_ttl_merge_time)
-        {
-            if (has_parts_with_expired_ttl)
-            {
-                if (partition_with_expired_ttl_index != partitions.size() - 1)
-                    has_multiple_partitions_with_ttl_expired_parts = true;
-            }
-            else
-            {
-                has_parts_with_expired_ttl = true;
-                partition_with_expired_ttl_index = partitions.size() - 1;
-            }
-        }
-
         partitions.back().emplace_back(part_info);
 
         /// Check for consistency of data parts. If assertion is failed, it requires immediate investigation.
@@ -291,39 +271,38 @@ bool MergeTreeDataMergerMutator::selectPartsToMerge(
         prev_part = &part;
     }
 
-    std::unique_ptr<IMergeSelector> merge_selector;
+    IMergeSelector::PartsInPartition parts_to_merge;
 
-    bool can_merge_with_ttl = next_ttl_merge_time <= current_time;
-
-    /// NOTE Could allow selection of different merge strategy.
-    if (can_merge_with_ttl && has_parts_with_expired_ttl && !ttl_merges_blocker.isCancelled())
+    if (!ttl_merges_blocker.isCancelled())
     {
-        merge_selector = std::make_unique<TTLMergeSelector>(next_ttl_merge_time, data_settings->ttl_only_drop_parts);
-        if (!has_multiple_partitions_with_ttl_expired_parts)
-            last_merge_with_ttl = next_ttl_merge_time;
+        TTLMergeSelector merge_selector(
+                next_ttl_merge_times_by_partition,
+                current_time,
+                data_settings->merge_with_ttl_timeout,
+                data_settings->ttl_only_drop_parts);
+        parts_to_merge = merge_selector.select(partitions, max_total_size_to_merge);
     }
-    else
+
+    if (parts_to_merge.empty())
     {
         SimpleMergeSelector::Settings merge_settings;
         if (aggressive)
             merge_settings.base = 1;
-        merge_selector = std::make_unique<SimpleMergeSelector>(merge_settings);
+
+        parts_to_merge = SimpleMergeSelector(merge_settings)
+                            .select(partitions, max_total_size_to_merge);
+
+        /// Do not allow to "merge" part with itself for regular merges, unless it is a TTL-merge where it is ok to remove some values with expired ttl
+        if (parts_to_merge.size() == 1)
+            throw Exception("Logical error: merge selector returned only one part to merge", ErrorCodes::LOGICAL_ERROR);
+
+        if (parts_to_merge.empty())
+        {
+            if (out_disable_reason)
+                *out_disable_reason = "There is no need to merge parts according to merge selector algorithm";
+            return false;
+        }
     }
-
-    IMergeSelector::PartsInPartition parts_to_merge = merge_selector->select(
-        partitions,
-        max_total_size_to_merge);
-
-    if (parts_to_merge.empty())
-    {
-        if (out_disable_reason)
-            *out_disable_reason = "There is no need to merge parts according to merge selector algorithm";
-        return false;
-    }
-
-    /// Allow to "merge" part with itself if we need remove some values with expired ttl
-    if (parts_to_merge.size() == 1 && !has_parts_with_expired_ttl)
-        throw Exception("Logical error: merge selector returned only one part to merge", ErrorCodes::LOGICAL_ERROR);
 
     MergeTreeData::DataPartsVector parts;
     parts.reserve(parts_to_merge.size());

--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
@@ -265,7 +265,7 @@ bool MergeTreeDataMergerMutator::selectPartsToMerge(
 
         time_t ttl = data_settings->ttl_only_drop_parts ? part_info.max_ttl : part_info.min_ttl;
 
-        if (ttl && ttl < next_ttl_merge_time)
+        if (!has_more_parts_with_expired_ttl && ttl && ttl < next_ttl_merge_time)
         {
             if (has_part_with_expired_ttl)
             {
@@ -297,7 +297,7 @@ bool MergeTreeDataMergerMutator::selectPartsToMerge(
     if (aggressive)
         merge_settings.base = 1;
 
-    bool can_merge_with_ttl = next_ttl_merge_time >= current_time;
+    bool can_merge_with_ttl = next_ttl_merge_time <= current_time;
 
     /// NOTE Could allow selection of different merge strategy.
     if (can_merge_with_ttl && has_part_with_expired_ttl && !ttl_merges_blocker.isCancelled())

--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <functional>
 #include <Common/ActionBlocker.h>
+#include <Storages/MergeTree/TTLMergeSelector.h>
 
 
 namespace DB
@@ -242,8 +243,10 @@ private:
     /// When the last time you wrote to the log that the disk space was running out (not to write about this too often).
     time_t disk_space_warning_time = 0;
 
-    /// Last time when TTLMergeSelector has been used
-    time_t last_merge_with_ttl = 0;
+    /// Stores the next TTL merge due time for each partition (used only by TTLMergeSelector)
+    TTLMergeSelector::PartitionIdToTTLs next_ttl_merge_times_by_partition;
+    /// Performing TTL merges independently for each partition guarantees that
+    /// there is only a limited number of TTL merges and no partition stores data, that is too stale
 };
 
 

--- a/src/Storages/MergeTree/TTLMergeSelector.h
+++ b/src/Storages/MergeTree/TTLMergeSelector.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <Core/Types.h>
 #include <Storages/MergeTree/MergeSelector.h>
+
+#include <map>
 
 
 namespace DB
@@ -10,17 +13,27 @@ namespace DB
   * It selects parts to merge by greedy algorithm: 
   *  1. Finds part with the most earliest expired ttl and includes it to result.
   *  2. Tries to find the longest range of parts with expired ttl, that includes part from step 1.
+  * Finally, merge selector updates TTL merge timer for the selected partition
   */
 class TTLMergeSelector : public IMergeSelector
 {
 public:
-    explicit TTLMergeSelector(time_t current_time_, bool only_drop_parts_) : current_time(current_time_), only_drop_parts(only_drop_parts_) {}
+    using PartitionIdToTTLs = std::map<String, time_t>;
+
+    explicit TTLMergeSelector(PartitionIdToTTLs & merge_due_times_, time_t current_time_, Int64 merge_cooldown_time_, bool only_drop_parts_)
+        : merge_due_times(merge_due_times_),
+          current_time(current_time_),
+          merge_cooldown_time(merge_cooldown_time_),
+          only_drop_parts(only_drop_parts_) {}
 
     PartsInPartition select(
         const Partitions & partitions,
         const size_t max_total_size_to_merge) override;
+
 private:
+    PartitionIdToTTLs & merge_due_times;
     time_t current_time;
+    Int64 merge_cooldown_time;
     bool only_drop_parts;
 };
 

--- a/tests/integration/test_ttl_replicated/test.py
+++ b/tests/integration/test_ttl_replicated/test.py
@@ -5,9 +5,11 @@ import helpers.client as client
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
+
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', with_zookeeper=True)
 node2 = cluster.add_instance('node2', with_zookeeper=True)
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -22,10 +24,12 @@ def started_cluster():
     finally:
         cluster.shutdown()
 
+
 def drop_table(nodes, table_name):
     for node in nodes:
         node.query("DROP TABLE IF EXISTS {} NO DELAY".format(table_name))
     time.sleep(1)
+
 
 def test_ttl_columns(started_cluster):
     drop_table([node1, node2], "test_ttl")
@@ -45,6 +49,35 @@ def test_ttl_columns(started_cluster):
     expected = "1\t0\t0\n2\t0\t0\n"
     assert TSV(node1.query("SELECT id, a, b FROM test_ttl ORDER BY id")) == TSV(expected)
     assert TSV(node2.query("SELECT id, a, b FROM test_ttl ORDER BY id")) == TSV(expected)
+
+
+def test_merge_with_ttl_timeout(started_cluster):
+    table = "test_merge_with_ttl_timeout"
+    drop_table([node1, node2], table)
+    for node in [node1, node2]:
+        node.query(
+        '''
+            CREATE TABLE {table}(date DateTime, id UInt32, a Int32 TTL date + INTERVAL 1 DAY, b Int32 TTL date + INTERVAL 1 MONTH)
+            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{table}', '{replica}')
+            ORDER BY id PARTITION BY toDayOfMonth(date);
+        '''.format(replica=node.name, table=table))
+
+    node1.query("SYSTEM STOP TTL MERGES {table}".format(table=table))
+    node2.query("SYSTEM STOP TTL MERGES {table}".format(table=table))
+
+    for i in range(1, 4):
+        node1.query("INSERT INTO {table} VALUES (toDateTime('2000-10-{day:02d} 10:00:00'), 1, 2, 3)".format(day=i, table=table))
+
+    assert node1.query("SELECT countIf(a = 0) FROM {table}".format(table=table)) == "0\n"
+    assert node2.query("SELECT countIf(a = 0) FROM {table}".format(table=table)) == "0\n"
+
+    node1.query("SYSTEM START TTL MERGES {table}".format(table=table))
+    node2.query("SYSTEM START TTL MERGES {table}".format(table=table))
+
+    time.sleep(30)
+
+    assert node1.query("SELECT countIf(a = 0) FROM {table}".format(table=table)) == "3\n"
+    assert node2.query("SELECT countIf(a = 0) FROM {table}".format(table=table)) == "3\n"
 
 
 def test_ttl_many_columns(started_cluster):

--- a/tests/integration/test_ttl_replicated/test.py
+++ b/tests/integration/test_ttl_replicated/test.py
@@ -74,7 +74,12 @@ def test_merge_with_ttl_timeout(started_cluster):
     node1.query("SYSTEM START TTL MERGES {table}".format(table=table))
     node2.query("SYSTEM START TTL MERGES {table}".format(table=table))
 
-    time.sleep(30)
+    time.sleep(15) # TTL merges shall happen.
+
+    for i in range(1, 4):
+        node1.query("INSERT INTO {table} VALUES (toDateTime('2000-10-{day:02d} 10:00:00'), 1, 2, 3)".format(day=i, table=table))
+
+    time.sleep(15) # TTL merges shall not happen.
 
     assert node1.query("SELECT countIf(a = 0) FROM {table}".format(table=table)) == "3\n"
     assert node2.query("SELECT countIf(a = 0) FROM {table}".format(table=table)) == "3\n"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Corrected merge_with_ttl_timeout logic which did not work well when expiration affected more than one partition over one time interval. (Authored by @excitoon)