### PR TITLE
Fix `Block structure mismatch` error for queries with  UNION and JOIN

### DIFF
--- a/src/Processors/QueryPipeline.cpp
+++ b/src/Processors/QueryPipeline.cpp
@@ -654,7 +654,7 @@ void QueryPipeline::unitePipelines(
         if (extremes.size() == 1)
             extremes_port = extremes.back();
         else
-            extremes_port = uniteExtremes(extremes, current_header, processors);
+            extremes_port = uniteExtremes(extremes, common_header, processors);
     }
 
     if (!totals.empty())
@@ -662,7 +662,7 @@ void QueryPipeline::unitePipelines(
         if (totals.size() == 1)
             totals_having_port = totals.back();
         else
-            totals_having_port = uniteTotals(totals, current_header, processors);
+            totals_having_port = uniteTotals(totals, common_header, processors);
     }
 
     current_header = common_header;

--- a/tests/queries/0_stateless/01416_join_totals_header_bug.sql
+++ b/tests/queries/0_stateless/01416_join_totals_header_bug.sql
@@ -1,0 +1,63 @@
+DROP TABLE IF EXISTS tableCommon;
+DROP TABLE IF EXISTS tableTrees;
+DROP TABLE IF EXISTS tableFlowers;
+
+CREATE TABLE tableCommon (`key` FixedString(15), `value` Nullable(Int8)) ENGINE = Log();
+CREATE TABLE tableTrees (`key` FixedString(15), `name` Nullable(Int8), `name2` Nullable(Int8)) ENGINE = Log();
+CREATE TABLE tableFlowers (`key` FixedString(15), `name` Nullable(Int8)) ENGINE = Log();
+
+SELECT * FROM (
+    SELECT common.key, common.value, trees.name, trees.name2
+    FROM (
+	SELECT *
+	FROM tableCommon
+    ) as common
+    INNER JOIN (
+	SELECT *
+	FROM tableTrees
+    ) trees ON (common.key = trees.key)
+)
+UNION ALL
+(
+    SELECT common.key, common.value, 
+    null as name, null as name2 
+    
+    FROM (
+	SELECT *
+	FROM tableCommon
+    ) as common
+    INNER JOIN (
+	SELECT *
+	FROM tableFlowers
+    ) flowers ON (common.key = flowers.key)
+);
+
+SELECT * FROM (
+    SELECT common.key, common.value, trees.name, trees.name2
+    FROM (
+	SELECT *
+	FROM tableCommon
+    ) as common
+    INNER JOIN (
+	SELECT *
+	FROM tableTrees
+    ) trees ON (common.key = trees.key)
+)
+UNION ALL
+(
+    SELECT common.key, common.value, 
+    flowers.name, null as name2
+
+    FROM (
+	SELECT *
+	FROM tableCommon
+    ) as common
+    INNER JOIN (
+	SELECT *
+	FROM tableFlowers
+    ) flowers ON (common.key = flowers.key)
+);
+
+DROP TABLE IF EXISTS tableCommon;
+DROP TABLE IF EXISTS tableTrees;
+DROP TABLE IF EXISTS tableFlowers;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `Block structure mismatch` error for queries with `UNION` and `JOIN`. Fixes #12602
