### PR TITLE
Adding extra xfails for some ldap tests.

### DIFF
--- a/tests/testflows/ldap/regression.py
+++ b/tests/testflows/ldap/regression.py
@@ -23,6 +23,8 @@ xfails = {
     "connection protocols/starttls with custom port":
      [(Fail, "it seems that starttls is not enabled by default on custom plain-text ports in LDAP server")],
     "connection protocols/tls cipher suite":
+     [(Fail, "can't get it to work")],
+    "connection protocols/tls minimum protocol version/:":
      [(Fail, "can't get it to work")]
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Adding extra xfails for some ldap tests.

Detailed description / Documentation draft:
Adding extra xfails for some ldap tests.
