### PR TITLE
Fix access to redis dictionary after connection was dropped once

### DIFF
--- a/src/Dictionaries/RedisDictionarySource.cpp
+++ b/src/Dictionaries/RedisDictionarySource.cpp
@@ -179,6 +179,7 @@ namespace DB
                         primary_with_secondary.addRedisType(key);
                     }
                 }
+
                 if (primary_with_secondary.size() > 1)
                     hkeys.add(std::move(primary_with_secondary));
             }

--- a/src/Dictionaries/RedisDictionarySource.cpp
+++ b/src/Dictionaries/RedisDictionarySource.cpp
@@ -139,6 +139,9 @@ namespace DB
 
     BlockInputStreamPtr RedisDictionarySource::loadAll()
     {
+        if (!client->isConnected())
+            client->connect(host, port);
+
         RedisCommand command_for_keys("KEYS");
         command_for_keys << "*";
 
@@ -189,6 +192,9 @@ namespace DB
 
     BlockInputStreamPtr RedisDictionarySource::loadIds(const std::vector<UInt64> & ids)
     {
+        if (!client->isConnected())
+            client->connect(host, port);
+
         if (storage_type != RedisStorageType::SIMPLE)
             throw Exception{"Cannot use loadIds with \'simple\' storage type", ErrorCodes::UNSUPPORTED_METHOD};
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix access to redis dictionary after connection was dropped once. It may happen with `cache` and `direct` dictionary layouts.