### PR TITLE
Avoid re-loading completion from the history file after each query

### DIFF
--- a/base/common/ReplxxLineReader.cpp
+++ b/base/common/ReplxxLineReader.cpp
@@ -114,6 +114,10 @@ LineReader::InputStatus ReplxxLineReader::readOneLine(const String & prompt)
 void ReplxxLineReader::addToHistory(const String & line)
 {
     // locking history file to prevent from inconsistent concurrent changes
+    //
+    // replxx::Replxx::history_save() already has lockf(),
+    // but replxx::Replxx::history_load() does not
+    // and that is why flock() is added here.
     bool locked = false;
     if (flock(history_file_fd, LOCK_EX))
         rx.print("Lock of history file failed: %s\n", strerror(errno));

--- a/base/common/ReplxxLineReader.cpp
+++ b/base/common/ReplxxLineReader.cpp
@@ -16,6 +16,19 @@ void trim(String & s)
     s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) { return !std::isspace(ch); }).base(), s.end());
 }
 
+// Uses separate replxx::Replxx instance to avoid loading them again in the
+// current context (replxx::Replxx::history_load() will re-load the history
+// from the file), since then they will overlaps with history from the current
+// session (this will make behavior compatible with other interpreters, i.e.
+// bash).
+void history_save(const String & history_file_path, const String & line)
+{
+    replxx::Replxx rx_no_overlap;
+    rx_no_overlap.history_load(history_file_path);
+    rx_no_overlap.history_add(line);
+    rx_no_overlap.history_save(history_file_path);
+}
+
 }
 
 ReplxxLineReader::ReplxxLineReader(
@@ -110,7 +123,7 @@ void ReplxxLineReader::addToHistory(const String & line)
     rx.history_add(line);
 
     // flush changes to the disk
-    rx.history_save(history_file_path);
+    history_save(history_file_path, line);
 
     if (locked && 0 != flock(history_file_fd, LOCK_UN))
         rx.print("Unlock of history file failed: %s\n", strerror(errno));


### PR DESCRIPTION
Changelog category (leave one):
- Other

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Avoid re-loading completion from the history file after each query (to avoid history overlaps with other client sessions)

By default replxx reload history from the file in
replxx::Replxx::history_save(), and this will overlaps current session
history with the history from other sessions, and this does not looks a
great idea (bash and other interpreters don't do this).

So to avoid this, use separate replxx::Replxx instance.

Refs: #11453 