### PR TITLE
Add test for macros usage in some kafka settings.

### DIFF
--- a/tests/integration/test_storage_kafka/configs/kafka_macros.xml
+++ b/tests/integration/test_storage_kafka/configs/kafka_macros.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<yandex>
+	<macros>
+        <kafka_broker>kafka1</kafka_broker>
+        <kafka_topic_old>old</kafka_topic_old>
+        <kafka_group_name_old>old</kafka_group_name_old>
+
+        <kafka_topic_new>new</kafka_topic_new>
+        <kafka_group_name_new>new</kafka_group_name_new>
+        <kafka_client_id>instance</kafka_client_id>
+        <kafka_format_json_each_row>JSONEachRow</kafka_format_json_each_row>
+	</macros>
+</yandex>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):


Detailed description / Documentation draft:
Relates to https://github.com/ClickHouse/ClickHouse/issues/2249 and https://github.com/ClickHouse/ClickHouse/commit/918dbc29024e1d878e967085c277f58f212da0d6

We had an FR to make it work, but it seems it works properly long ago. Adding a test just in case.