### PR TITLE
Switch cppkafka to upstream and bump to upstream/master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -76,7 +76,7 @@
 	url = https://github.com/google/snappy
 [submodule "contrib/cppkafka"]
 	path = contrib/cppkafka
-	url = https://github.com/ClickHouse-Extras/cppkafka.git
+	url = https://github.com/mfontanini/cppkafka.git
 [submodule "contrib/brotli"]
 	path = contrib/brotli
 	url = https://github.com/google/brotli.git


### PR DESCRIPTION
All changes in ClickHouse-Extra has been merged into upstream no need in
using the fork.

There are not a lot of changes for now, and cppkafka does not looks like
in the active development stage, but just in case better to sync with
upstream.

FWIW cppkafka usage is pretty minimal and it's usage is questionable,
since librdkafka is under active development while cppkafka is not, and
later still does not support some features that is used in clickhouse:
- interceptors (for logging proxying)

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @filimonov 
