### PR TITLE
Fix segfault when mutation get killed

### DIFF
--- a/src/Storages/MergeTree/MergeTreeMutationStatus.cpp
+++ b/src/Storages/MergeTree/MergeTreeMutationStatus.cpp
@@ -9,14 +9,17 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int UNFINISHED;
+    extern const int LOGICAL_ERROR;
 }
 
-void checkMutationStatus(std::optional<MergeTreeMutationStatus> & status, const Strings & mutation_ids)
+void checkMutationStatus(std::optional<MergeTreeMutationStatus> & status, const std::set<String> & mutation_ids)
 {
+    if (mutation_ids.empty())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot check mutation status because no mutation ids provided");
+
     if (!status)
     {
-        assert(mutation_ids.size() == 1);
-        throw Exception(ErrorCodes::UNFINISHED, "Mutation {} was killed", mutation_ids[0]);
+        throw Exception(ErrorCodes::UNFINISHED, "Mutation {} was killed", *mutation_ids.begin());
     }
     else if (!status->is_done && !status->latest_fail_reason.empty())
     {

--- a/src/Storages/MergeTree/MergeTreeMutationStatus.h
+++ b/src/Storages/MergeTree/MergeTreeMutationStatus.h
@@ -33,6 +33,6 @@ struct MergeTreeMutationStatus
 /// (latest_fail_reason not empty) or if mutation was killed (status empty
 /// optional). mutation_ids passed separately, because status may be empty and
 /// we can execute multiple mutations at once
-void checkMutationStatus(std::optional<MergeTreeMutationStatus> & status, const Strings & mutation_ids);
+void checkMutationStatus(std::optional<MergeTreeMutationStatus> & status, const std::set<String> & mutation_ids);
 
 }

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -1538,7 +1538,7 @@ void ReplicatedMergeTreeQueue::getInsertTimes(time_t & out_min_unprocessed_inser
 }
 
 
-std::optional<MergeTreeMutationStatus> ReplicatedMergeTreeQueue::getIncompleteMutationsStatus(const String & znode_name, Strings * mutation_ids) const
+std::optional<MergeTreeMutationStatus> ReplicatedMergeTreeQueue::getIncompleteMutationsStatus(const String & znode_name, std::set<String> * mutation_ids) const
 {
 
     std::lock_guard lock(state_mutex);
@@ -1568,7 +1568,7 @@ std::optional<MergeTreeMutationStatus> ReplicatedMergeTreeQueue::getIncompleteMu
             {
                 /// All mutations with the same failure
                 if (!it->second->is_done && it->second->latest_fail_reason == status.latest_fail_reason)
-                    mutation_ids->push_back(it->second->entry->znode_name);
+                    mutation_ids->insert(it->second->entry->znode_name);
             }
         }
     }

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
@@ -402,8 +402,10 @@ public:
 
     /// Return empty optional if mutation was killed. Otherwise return partially
     /// filled mutation status with information about error (latest_fail*) and
-    /// is_done. mutation_ids filled with all mutations with same errors, because
-    /// they may be executed simultaneously as one mutation.
+    /// is_done. mutation_ids filled with all mutations with same errors,
+    /// because they may be executed simultaneously as one mutation. Order is
+    /// important for better readability of exception message. If mutation was
+    /// killed doesn't return any ids.
     std::optional<MergeTreeMutationStatus> getIncompleteMutationsStatus(const String & znode_name, std::set<String> * mutation_ids = nullptr) const;
 
     std::vector<MergeTreeMutationStatus> getMutationsStatus() const;

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
@@ -404,7 +404,7 @@ public:
     /// filled mutation status with information about error (latest_fail*) and
     /// is_done. mutation_ids filled with all mutations with same errors, because
     /// they may be executed simultaneously as one mutation.
-    std::optional<MergeTreeMutationStatus> getIncompleteMutationsStatus(const String & znode_name, Strings * mutation_ids = nullptr) const;
+    std::optional<MergeTreeMutationStatus> getIncompleteMutationsStatus(const String & znode_name, std::set<String> * mutation_ids = nullptr) const;
 
     std::vector<MergeTreeMutationStatus> getMutationsStatus() const;
 

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -417,8 +417,10 @@ void StorageMergeTree::waitForMutation(Int64 version, const String & file_name)
         mutation_wait_event.wait(lock, check);
     }
 
+    /// At least we have our current mutation
     std::set<String> mutation_ids;
     mutation_ids.insert(file_name);
+
     auto mutation_status = getIncompleteMutationsStatus(version, &mutation_ids);
     checkMutationStatus(mutation_status, mutation_ids);
 

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -471,7 +471,8 @@ std::optional<MergeTreeMutationStatus> StorageMergeTree::getIncompleteMutationsS
             if (!mutation_entry.latest_fail_reason.empty())
             {
                 result.latest_failed_part = mutation_entry.latest_failed_part;
-                result.latest_fail_reason = mutation_entry.latest_fail_reason; result.latest_fail_time = mutation_entry.latest_fail_time;
+                result.latest_fail_reason = mutation_entry.latest_fail_reason;
+                result.latest_fail_time = mutation_entry.latest_fail_time;
 
                 /// Fill all mutations which failed with the same error
                 /// (we can execute several mutations together)

--- a/src/Storages/StorageMergeTree.h
+++ b/src/Storages/StorageMergeTree.h
@@ -161,8 +161,10 @@ private:
 
     /// Return empty optional if mutation was killed. Otherwise return partially
     /// filled mutation status with information about error (latest_fail*) and
-    /// is_done. mutation_ids filled with mutations with the same errors, because we
-    /// can execute several mutations at once
+    /// is_done. mutation_ids filled with mutations with the same errors,
+    /// because we can execute several mutations at once. Order is important for
+    /// better readability of exception message. If mutation was killed doesn't
+    /// return any ids.
     std::optional<MergeTreeMutationStatus> getIncompleteMutationsStatus(Int64 mutation_version, std::set<String> * mutation_ids = nullptr) const;
 
     void startBackgroundMovesIfNeeded() override;

--- a/src/Storages/StorageMergeTree.h
+++ b/src/Storages/StorageMergeTree.h
@@ -163,7 +163,7 @@ private:
     /// filled mutation status with information about error (latest_fail*) and
     /// is_done. mutation_ids filled with mutations with the same errors, because we
     /// can execute several mutations at once
-    std::optional<MergeTreeMutationStatus> getIncompleteMutationsStatus(Int64 mutation_version, Strings * mutation_ids = nullptr) const;
+    std::optional<MergeTreeMutationStatus> getIncompleteMutationsStatus(Int64 mutation_version, std::set<String> * mutation_ids = nullptr) const;
 
     void startBackgroundMovesIfNeeded() override;
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -398,7 +398,9 @@ void StorageReplicatedMergeTree::waitMutationToFinishOnReplicas(
             throw Exception(ErrorCodes::UNFINISHED, "Mutation {} was killed, manually removed or table was dropped", mutation_id);
         }
 
-        Strings mutation_ids;
+        std::set<String> mutation_ids;
+        mutation_ids.insert(mutation_id);
+
         auto mutation_status = queue.getIncompleteMutationsStatus(mutation_id, &mutation_ids);
         checkMutationStatus(mutation_status, mutation_ids);
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -398,6 +398,7 @@ void StorageReplicatedMergeTree::waitMutationToFinishOnReplicas(
             throw Exception(ErrorCodes::UNFINISHED, "Mutation {} was killed, manually removed or table was dropped", mutation_id);
         }
 
+        /// At least we have our current mutation
         std::set<String> mutation_ids;
         mutation_ids.insert(mutation_id);
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix segfault when mutation killed and the server tries to send the exception to the client.