### PR TITLE
Added `allow_merges` option for volumes in multi-disk configuration

### DIFF
--- a/src/Common/ErrorCodes.cpp
+++ b/src/Common/ErrorCodes.cpp
@@ -501,6 +501,8 @@ namespace ErrorCodes
     extern const int NO_RESERVATIONS_PROVIDED = 534;
     extern const int UNKNOWN_RAID_TYPE = 535;
 
+    extern const int INVALID_RAID_TYPE = 535;
+
     extern const int KEEPER_EXCEPTION = 999;
     extern const int POCO_EXCEPTION = 1000;
     extern const int STD_EXCEPTION = 1001;

--- a/src/Disks/IVolume.h
+++ b/src/Disks/IVolume.h
@@ -63,6 +63,10 @@ public:
     virtual DiskPtr getDisk(size_t i) const { return disks[i]; }
     const Disks & getDisks() const { return disks; }
 
+    virtual bool areMergesAllowed() const { return true; }
+
+    virtual void setAllowMergesFromQuery(bool /*allow*/) {}
+
 protected:
     Disks disks;
     const String name;

--- a/src/Disks/StoragePolicy.h
+++ b/src/Disks/StoragePolicy.h
@@ -36,6 +36,8 @@ public:
 
     StoragePolicy(String name_, Volumes volumes_, double move_factor_);
 
+    StoragePolicyPtr updateFromConfig(const Poco::Util::AbstractConfiguration & config, const String & config_prefix, DiskSelectorPtr disks) const;
+
     bool isDefaultPolicy() const;
 
     /// Returns disks ordered by volumes priority

--- a/src/Disks/VolumeJBOD.h
+++ b/src/Disks/VolumeJBOD.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include <Disks/IVolume.h>
 
 namespace DB
@@ -13,8 +15,10 @@ namespace DB
 class VolumeJBOD : public IVolume
 {
 public:
-    VolumeJBOD(String name_, Disks disks_, UInt64 max_data_part_size_)
-        : IVolume(name_, disks_, max_data_part_size_)
+    VolumeJBOD(String name_, Disks disks_, UInt64 max_data_part_size_, bool are_merges_allowed_in_config_)
+        : IVolume(name_, disks_)
+        , max_data_part_size(max_data_part_size_)
+        , are_merges_allowed_in_config(are_merges_allowed_in_config_)
     {
     }
 
@@ -24,6 +28,8 @@ public:
         const String & config_prefix,
         DiskSelectorPtr disk_selector
     );
+
+    void updateFromConfig(const Poco::Util::AbstractConfiguration & config, const String & config_prefix);
 
     VolumeType getType() const override { return VolumeType::JBOD; }
 
@@ -38,6 +44,18 @@ public:
     /// Returns valid reservation or nullptr if there is no space left on any disk.
     ReservationPtr reserve(UInt64 bytes) override;
 
+    /// Max size of reservation
+    UInt64 max_data_part_size = 0;
+
+    bool areMergesAllowed() const override;
+
+    void setAllowMergesFromQuery(bool allow) override;
+
+    /// True if parts on this volume participate in merges according to configuration.
+    bool are_merges_allowed_in_config = true;
+
+    /// True if parts on this volume participate in merges according to START/STOP MERGES ON VOLUME.
+    std::shared_ptr<bool> are_merges_allowed_from_query;
 private:
     mutable std::atomic<size_t> last_used = 0;
 };

--- a/src/Disks/VolumeRAID1.h
+++ b/src/Disks/VolumeRAID1.h
@@ -13,8 +13,8 @@ namespace DB
 class VolumeRAID1 : public VolumeJBOD
 {
 public:
-    VolumeRAID1(String name_, Disks disks_, UInt64 max_data_part_size_)
-        : VolumeJBOD(name_, disks_, max_data_part_size_)
+    VolumeRAID1(String name_, Disks disks_, UInt64 max_data_part_size_, bool are_merges_allowed_in_config_)
+        : VolumeJBOD(name_, disks_, max_data_part_size_, are_merges_allowed_in_config_)
     {
     }
 
@@ -25,6 +25,11 @@ public:
         DiskSelectorPtr disk_selector)
         : VolumeJBOD(name_, config, config_prefix, disk_selector)
     {
+    }
+
+    void updateFromConfig(const Poco::Util::AbstractConfiguration & config, const String & config_prefix)
+    {
+        VolumeJBOD::updateFromConfig(config, config_prefix);
     }
 
     VolumeType getType() const override { return VolumeType::RAID1; }

--- a/src/Disks/createVolume.cpp
+++ b/src/Disks/createVolume.cpp
@@ -12,6 +12,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int UNKNOWN_RAID_TYPE;
+    extern const int INVALID_RAID_TYPE;
 }
 
 VolumePtr createVolumeFromReservation(const ReservationPtr & reservation, VolumePtr other_volume)
@@ -25,7 +26,7 @@ VolumePtr createVolumeFromReservation(const ReservationPtr & reservation, Volume
     if (other_volume->getType() == VolumeType::RAID1)
     {
         auto volume = std::dynamic_pointer_cast<VolumeRAID1>(other_volume);
-        return std::make_shared<VolumeRAID1>(volume->getName(), reservation->getDisks(), volume->max_data_part_size);
+        return std::make_shared<VolumeRAID1>(volume->getName(), reservation->getDisks(), volume->max_data_part_size, volume->are_merges_allowed_in_config);
     }
     return nullptr;
 }
@@ -37,17 +38,37 @@ VolumePtr createVolumeFromConfig(
     DiskSelectorPtr disk_selector
 )
 {
-    auto has_raid_type = config.has(config_prefix + ".raid_type");
-    if (!has_raid_type)
-    {
-        return std::make_shared<VolumeJBOD>(name, config, config_prefix, disk_selector);
-    }
-    String raid_type = config.getString(config_prefix + ".raid_type");
+    String raid_type = config.getString(config_prefix + ".raid_type", "JBOD");
     if (raid_type == "JBOD")
     {
         return std::make_shared<VolumeJBOD>(name, config, config_prefix, disk_selector);
     }
     throw Exception("Unknown raid type '" + raid_type + "'", ErrorCodes::UNKNOWN_RAID_TYPE);
+}
+
+void updateVolumeFromConfig(
+    VolumePtr volume,
+    const Poco::Util::AbstractConfiguration & config,
+    const String & config_prefix
+)
+{
+    String raid_type = config.getString(config_prefix + ".raid_type", "JBOD");
+    if (raid_type == "RAID 1" || raid_type == "RAID-1" || raid_type == "RAID1")
+    {
+        VolumeRAID1 * volume_raid1 = dynamic_cast<VolumeRAID1 *>(volume.get());
+        if (volume_raid1 == nullptr)
+            throw Exception("Invalid raid type '" + raid_type + "', shall be RAID-1", ErrorCodes::INVALID_RAID_TYPE);
+
+        volume_raid1->updateFromConfig(config, config_prefix);
+    }
+    else if (raid_type == "JBOD")
+    {
+        VolumeJBOD * volume_jbod = dynamic_cast<VolumeJBOD *>(volume.get());
+        if (volume_jbod == nullptr)
+            throw Exception("Invalid raid type '" + raid_type + "', shall be JBOD", ErrorCodes::INVALID_RAID_TYPE);
+
+        volume_jbod->updateFromConfig(config, config_prefix);
+    }
 }
 
 }

--- a/src/Disks/createVolume.h
+++ b/src/Disks/createVolume.h
@@ -6,11 +6,18 @@ namespace DB
 {
 
 VolumePtr createVolumeFromReservation(const ReservationPtr & reservation, VolumePtr other_volume);
+
 VolumePtr createVolumeFromConfig(
     String name_,
     const Poco::Util::AbstractConfiguration & config,
     const String & config_prefix,
     DiskSelectorPtr disk_selector
+);
+
+void updateVolumeFromConfig(
+    VolumePtr volume,
+    const Poco::Util::AbstractConfiguration & config,
+    const String & config_prefix
 );
 
 }

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -163,7 +163,9 @@ void InterpreterSystemQuery::startStopAction(StorageActionBlockType action_type,
                     continue;
                 }
 
-                if (start)
+                if (volume_ptr && action_type == ActionLocks::PartsMerge)
+                    volume_ptr->setAllowMergesFromQuery(start);
+                else if (start)
                     manager->remove(table, action_type);
                 else
                     manager->add(table, action_type);
@@ -198,6 +200,10 @@ BlockIO InterpreterSystemQuery::execute()
 
     if (!query.target_dictionary.empty() && !query.database.empty())
         query.target_dictionary = query.database + "." + query.target_dictionary;
+
+    volume_ptr = {};
+    if (!query.storage_policy.empty() || !query.volume.empty())
+        volume_ptr = context.getStoragePolicy(query.storage_policy)->getVolumeByName(query.volume);
 
     switch (query.type)
     {

--- a/src/Interpreters/InterpreterSystemQuery.h
+++ b/src/Interpreters/InterpreterSystemQuery.h
@@ -5,6 +5,7 @@
 #include <Storages/IStorage_fwd.h>
 #include <Interpreters/StorageID.h>
 #include <Common/ActionLock.h>
+#include <Disks/VolumeJBOD.h>
 
 
 namespace Poco { class Logger; }
@@ -44,6 +45,7 @@ private:
     Context & context;
     Poco::Logger * log = nullptr;
     StorageID table_id = StorageID::createEmpty();      /// Will be set up if query contains table name
+    VolumePtr volume_ptr;
 
     /// Tries to get a replicated table and restart it
     /// Returns pointer to a newly created table if the restart was successful

--- a/src/Parsers/ASTSystemQuery.cpp
+++ b/src/Parsers/ASTSystemQuery.cpp
@@ -118,7 +118,8 @@ void ASTSystemQuery::formatImpl(const FormatSettings & settings, FormatState &, 
                       << (settings.hilite ? hilite_none : "");
     };
 
-    auto print_drop_replica = [&] {
+    auto print_drop_replica = [&]
+    {
         settings.ostr << " " << quoteString(replica);
         if (!table.empty())
         {
@@ -138,6 +139,16 @@ void ASTSystemQuery::formatImpl(const FormatSettings & settings, FormatState &, 
             settings.ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(database)
                           << (settings.hilite ? hilite_none : "");
         }
+    };
+
+    auto print_on_volume = [&]
+    {
+        settings.ostr << " ON VOLUME "
+                      << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(storage_policy)
+                      << (settings.hilite ? hilite_none : "")
+                      << "."
+                      << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(volume)
+                      << (settings.hilite ? hilite_none : "");
     };
 
     if (!cluster.empty())
@@ -160,6 +171,8 @@ void ASTSystemQuery::formatImpl(const FormatSettings & settings, FormatState &, 
     {
         if (!table.empty())
             print_database_table();
+        else if (!volume.empty())
+            print_on_volume();
     }
     else if (type == Type::RESTART_REPLICA || type == Type::SYNC_REPLICA || type == Type::FLUSH_DISTRIBUTED)
     {

--- a/src/Parsers/ASTSystemQuery.h
+++ b/src/Parsers/ASTSystemQuery.h
@@ -65,6 +65,8 @@ public:
     String replica;
     String replica_zk_path;
     bool is_drop_whole_replica;
+    String storage_policy;
+    String volume;
 
     String getID(char) const override { return "SYSTEM query"; }
 

--- a/src/Parsers/ParserSystemQuery.cpp
+++ b/src/Parsers/ParserSystemQuery.cpp
@@ -129,6 +129,33 @@ bool ParserSystemQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expected & 
 
         case Type::STOP_MERGES:
         case Type::START_MERGES:
+        {
+            String storage_policy_str;
+            String volume_str;
+
+            if (ParserKeyword{"ON VOLUME"}.ignore(pos, expected))
+            {
+                ASTPtr ast;
+                if (ParserStringLiteral{}.parse(pos, ast, expected))
+                    storage_policy_str = ast->as<ASTLiteral &>().value.safeGet<String>();
+                else
+                    return false;
+
+                if (!ParserToken{TokenType::Dot}.ignore(pos, expected))
+                    return false;
+
+                if (ParserStringLiteral{}.parse(pos, ast, expected))
+                    volume_str = ast->as<ASTLiteral &>().value.safeGet<String>();
+                else
+                    return false;
+            }
+            res->storage_policy = storage_policy_str;
+            res->volume = volume_str;
+            if (res->volume.empty() && res->storage_policy.empty())
+                parseDatabaseAndTableName(pos, expected, res->database, res->table);
+            break;
+        }
+
         case Type::STOP_TTL_MERGES:
         case Type::START_TTL_MERGES:
         case Type::STOP_MOVES:

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -676,6 +676,16 @@ void IMergeTreeDataPart::loadColumns(bool require)
         column_name_to_position.emplace(column.name, pos++);
 }
 
+bool IMergeTreeDataPart::areMergesAllowed() const
+{
+    auto storage_policy = storage.getStoragePolicy();
+
+    /// One need to get volume description for given volume.
+    auto volume_ptr = storage_policy->getVolume(storage_policy->getVolumeIndexByDisk(volume->getDisk()));
+
+    return volume_ptr->areMergesAllowed();
+}
+
 UInt64 IMergeTreeDataPart::calculateTotalSizeOnDisk(const DiskPtr & disk_, const String & from)
 {
     if (disk_->isFile(from))

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -324,6 +324,9 @@ public:
     /// storage and pass it to this method.
     virtual bool hasColumnFiles(const String & /* column */, const IDataType & /* type */) const{ return false; }
 
+    /// Checks if there any objections to merge this part on per-part basis.
+    bool areMergesAllowed() const;
+
     /// Calculate the total size of the entire directory with all the files
     static UInt64 calculateTotalSizeOnDisk(const DiskPtr & disk_, const String & from);
     void calculateColumnsSizesOnDisk();

--- a/src/Storages/MergeTree/SimpleMergeSelector.cpp
+++ b/src/Storages/MergeTree/SimpleMergeSelector.cpp
@@ -1,4 +1,6 @@
 #include <Storages/MergeTree/SimpleMergeSelector.h>
+
+#include <Storages/MergeTree/IMergeTreeDataPart.h>
 #include <Common/interpolate.h>
 
 #include <cmath>
@@ -152,6 +154,9 @@ void selectWithinPartition(
         if (begin > 1000)
             break;
 
+        if (!static_cast<const IMergeTreeDataPart *>(parts[begin].data)->areMergesAllowed())
+            continue;
+
         size_t sum_size = parts[begin].size;
         size_t max_size = parts[begin].size;
         size_t min_age = parts[begin].age;
@@ -159,6 +164,9 @@ void selectWithinPartition(
         for (size_t end = begin + 2; end <= parts_count; ++end)
         {
             if (settings.max_parts_to_merge_at_once && end - begin > settings.max_parts_to_merge_at_once)
+                break;
+
+            if (!static_cast<const IMergeTreeDataPart *>(parts[end - 1].data)->areMergesAllowed())
                 break;
 
             size_t cur_size = parts[end - 1].size;

--- a/src/Storages/MergeTree/TTLMergeSelector.cpp
+++ b/src/Storages/MergeTree/TTLMergeSelector.cpp
@@ -1,6 +1,9 @@
 #include <Storages/MergeTree/TTLMergeSelector.h>
 #include <Storages/MergeTree/MergeTreeData.h>
 
+#include <Storages/MergeTree/IMergeTreeDataPart.h>
+
+#include <cmath>
 #include <algorithm>
 #include <cmath>
 
@@ -24,6 +27,7 @@ IMergeSelector::PartsInPartition TTLMergeSelector::select(
     ssize_t partition_to_merge_index = -1;
     time_t partition_to_merge_min_ttl = 0;
 
+    /// Find most old TTL.
     for (size_t i = 0; i < partitions.size(); ++i)
     {
         const auto & mergeable_parts_in_partition = partitions[i];
@@ -41,9 +45,12 @@ IMergeSelector::PartsInPartition TTLMergeSelector::select(
 
             if (ttl && (partition_to_merge_index == -1 || ttl < partition_to_merge_min_ttl))
             {
-                partition_to_merge_min_ttl = ttl;
-                partition_to_merge_index = i;
-                best_begin = part_it;
+                if (only_drop_parts || static_cast<const IMergeTreeDataPart *>(part_it->data)->areMergesAllowed())
+                {
+                    partition_to_merge_min_ttl = ttl;
+                    partition_to_merge_index = i;
+                    best_begin = part_it;
+                }
             }
         }
     }
@@ -55,13 +62,16 @@ IMergeSelector::PartsInPartition TTLMergeSelector::select(
     Iterator best_end = best_begin + 1;
     size_t total_size = 0;
 
+    /// Find begin of range with most old TTL.
     while (true)
     {
         time_t ttl = only_drop_parts ? best_begin->max_ttl : best_begin->min_ttl;
 
         if (!ttl || ttl > current_time
-            || (max_total_size_to_merge && total_size > max_total_size_to_merge))
+            || (max_total_size_to_merge && total_size > max_total_size_to_merge)
+            || (!only_drop_parts && !static_cast<const IMergeTreeDataPart *>(best_begin->data)->areMergesAllowed()))
         {
+            /// This condition can not be satisfied on first iteration.
             ++best_begin;
             break;
         }
@@ -73,12 +83,14 @@ IMergeSelector::PartsInPartition TTLMergeSelector::select(
         --best_begin;
     }
 
+    /// Find end of range with most old TTL.
     while (best_end != best_partition.end())
     {
         time_t ttl = only_drop_parts ? best_end->max_ttl : best_end->min_ttl;
 
         if (!ttl || ttl > current_time
-            || (max_total_size_to_merge && total_size > max_total_size_to_merge))
+            || (max_total_size_to_merge && total_size > max_total_size_to_merge)
+            || (!only_drop_parts && !static_cast<const IMergeTreeDataPart *>(best_end->data)->areMergesAllowed()))
             break;
 
         total_size += best_end->size;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Added `allow_merges` option for volumes in multi-disk configuration.
