### PR TITLE
Fix logging in MergeTreeDataSelectExecutor for multiple threads (attach to thread group)

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -1343,7 +1343,7 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
     /// If index is not used.
     if (key_condition.alwaysUnknownOrTrue())
     {
-        LOG_TRACE(log, "Not using index on part {}", part->name);
+        LOG_TRACE(log, "Not using primary index on part {}", part->name);
 
         if (has_final_mark)
             res.push_back(MarkRange(0, marks_count - 1));

--- a/tests/queries/0_stateless/01323_too_many_threads_bug.sql
+++ b/tests/queries/0_stateless/01323_too_many_threads_bug.sql
@@ -14,6 +14,6 @@ select arrayUniq(thread_ids) <= 4 from system.query_log where event_date >= toda
 select x from table_01323_many_parts order by x limit 10 format Null;
 
 system flush logs;
-select arrayUniq(thread_ids) <= 20 from system.query_log where event_date >= today() - 1 and query ilike '%select x from table_01323_many_parts order by x%' and query not like '%system.query_log%' and type = 'QueryFinish' order by query_start_time desc limit 1;
+select arrayUniq(thread_ids) <= 36 from system.query_log where event_date >= today() - 1 and query ilike '%select x from table_01323_many_parts order by x%' and query not like '%system.query_log%' and type = 'QueryFinish' order by query_start_time desc limit 1;
 
 drop table if exists table_01323_many_parts;

--- a/tests/queries/0_stateless/01323_too_many_threads_bug.sql
+++ b/tests/queries/0_stateless/01323_too_many_threads_bug.sql
@@ -9,11 +9,11 @@ set log_queries = 1;
 select x from table_01323_many_parts limit 10 format Null;
 
 system flush logs;
-select arrayUniq(thread_ids) <= 4 from system.query_log where event_date >= today() - 1 and lower(query) like '%select x from table_01323_many_parts%' and type = 'QueryFinish' order by query_start_time desc limit 1;
+select arrayUniq(thread_ids) <= 4 from system.query_log where event_date >= today() - 1 and query ilike '%select x from table_01323_many_parts%' and type = 'QueryFinish' order by query_start_time desc limit 1;
 
 select x from table_01323_many_parts order by x limit 10 format Null;
 
 system flush logs;
-select arrayUniq(thread_ids) <= 20 from system.query_log where event_date >= today() - 1 and lower(query) like '%select x from table_01323_many_parts order by x%' and type = 'QueryFinish' order by query_start_time desc limit 1;
+select arrayUniq(thread_ids) <= 20 from system.query_log where event_date >= today() - 1 and query ilike '%select x from table_01323_many_parts order by x%' and type = 'QueryFinish' order by query_start_time desc limit 1;
 
 drop table if exists table_01323_many_parts;

--- a/tests/queries/0_stateless/01323_too_many_threads_bug.sql
+++ b/tests/queries/0_stateless/01323_too_many_threads_bug.sql
@@ -9,11 +9,11 @@ set log_queries = 1;
 select x from table_01323_many_parts limit 10 format Null;
 
 system flush logs;
-select length(thread_ids) <= 4 from system.query_log where event_date >= today() - 1 and lower(query) like '%select x from table_01323_many_parts%' and type = 'QueryFinish' order by query_start_time desc limit 1;
+select arrayUniq(thread_ids) <= 4 from system.query_log where event_date >= today() - 1 and lower(query) like '%select x from table_01323_many_parts%' and type = 'QueryFinish' order by query_start_time desc limit 1;
 
 select x from table_01323_many_parts order by x limit 10 format Null;
 
 system flush logs;
-select length(thread_ids) <= 20 from system.query_log where event_date >= today() - 1 and lower(query) like '%select x from table_01323_many_parts order by x%' and type = 'QueryFinish' order by query_start_time desc limit 1;
+select arrayUniq(thread_ids) <= 20 from system.query_log where event_date >= today() - 1 and lower(query) like '%select x from table_01323_many_parts order by x%' and type = 'QueryFinish' order by query_start_time desc limit 1;
 
 drop table if exists table_01323_many_parts;

--- a/tests/queries/0_stateless/01323_too_many_threads_bug.sql
+++ b/tests/queries/0_stateless/01323_too_many_threads_bug.sql
@@ -9,11 +9,11 @@ set log_queries = 1;
 select x from table_01323_many_parts limit 10 format Null;
 
 system flush logs;
-select arrayUniq(thread_ids) <= 4 from system.query_log where event_date >= today() - 1 and query ilike '%select x from table_01323_many_parts%' and type = 'QueryFinish' order by query_start_time desc limit 1;
+select arrayUniq(thread_ids) <= 4 from system.query_log where event_date >= today() - 1 and query ilike '%select x from table_01323_many_parts%' and query not like '%system.query_log%' and type = 'QueryFinish' order by query_start_time desc limit 1;
 
 select x from table_01323_many_parts order by x limit 10 format Null;
 
 system flush logs;
-select arrayUniq(thread_ids) <= 20 from system.query_log where event_date >= today() - 1 and query ilike '%select x from table_01323_many_parts order by x%' and type = 'QueryFinish' order by query_start_time desc limit 1;
+select arrayUniq(thread_ids) <= 20 from system.query_log where event_date >= today() - 1 and query ilike '%select x from table_01323_many_parts order by x%' and query not like '%system.query_log%' and type = 'QueryFinish' order by query_start_time desc limit 1;
 
 drop table if exists table_01323_many_parts;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: #12589
Cc: @KochetovNicolai 
Cc: @bobrik 

<details>

HEAD:
- bad09ac00d1c2676a89effd3b9f51907f57b234d - v0
- a47814b2c20fd3a170d17a6d8ee615a5b719e19a - test fix
- eba14eb527c7bae3c84584e813d29077324eb0ff - merge with master
- 5eaf39d3faf0abdd425cca9b7ee5778b06aad716 - rebase against master
- 43af55b9a109279fea3147a95f9fef26824fdca0 - rebased against master after https://github.com/ClickHouse/ClickHouse/pull/13201#issuecomment-667646956

</details>