### PR TITLE
Allow "register" variables in libunwind

### DIFF
--- a/contrib/libunwind-cmake/CMakeLists.txt
+++ b/contrib/libunwind-cmake/CMakeLists.txt
@@ -53,7 +53,7 @@ endif ()
 # The library is using register variables that are bound to specific registers
 # Example: DwarfInstructions.hpp: register unsigned long long x16 __asm("x16") = cfa;
 check_cxx_compiler_flag(-Wregister HAVE_WARNING_REGISTER)
-if (HAVE_WARNING_MAYBE_UNINITIALIZED)
+if (HAVE_WARNING_REGISTER)
     target_compile_options(unwind PRIVATE -Wno-register)
 endif ()
 

--- a/contrib/libunwind-cmake/CMakeLists.txt
+++ b/contrib/libunwind-cmake/CMakeLists.txt
@@ -50,6 +50,13 @@ if (HAVE_WARNING_MAYBE_UNINITIALIZED)
     target_compile_options(unwind PRIVATE -Wno-maybe-uninitialized)
 endif ()
 
+# The library is using register variables that are bound to specific registers
+# Example: DwarfInstructions.hpp: register unsigned long long x16 __asm("x16") = cfa;
+check_cxx_compiler_flag(-Wregister HAVE_WARNING_REGISTER)
+if (HAVE_WARNING_MAYBE_UNINITIALIZED)
+    target_compile_options(unwind PRIVATE -Wno-register)
+endif ()
+
 install(
     TARGETS unwind
     EXPORT global


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix libunwind build in AArch64. This fixes #13204.


Detailed description / Documentation draft:
Without this PR we have compiler warning.