### PR TITLE
Fix libunwind warning

### DIFF
--- a/contrib/libunwind-cmake/CMakeLists.txt
+++ b/contrib/libunwind-cmake/CMakeLists.txt
@@ -54,7 +54,7 @@ endif ()
 # Example: DwarfInstructions.hpp: register unsigned long long x16 __asm("x16") = cfa;
 check_cxx_compiler_flag(-Wregister HAVE_WARNING_REGISTER)
 if (HAVE_WARNING_REGISTER)
-    target_compile_options(unwind PRIVATE -Wno-register)
+    target_compile_options(unwind PRIVATE "$<$<STREQUAL:$<TARGET_PROPERTY:LINKER_LANGUAGE>,CXX>:-Wno-register>")
 endif ()
 
 install(

--- a/contrib/libunwind-cmake/CMakeLists.txt
+++ b/contrib/libunwind-cmake/CMakeLists.txt
@@ -54,7 +54,7 @@ endif ()
 # Example: DwarfInstructions.hpp: register unsigned long long x16 __asm("x16") = cfa;
 check_cxx_compiler_flag(-Wregister HAVE_WARNING_REGISTER)
 if (HAVE_WARNING_REGISTER)
-    target_compile_options(unwind PRIVATE "$<$<STREQUAL:$<TARGET_PROPERTY:LINKER_LANGUAGE>,CXX>:-Wno-register>")
+    target_compile_options(unwind PRIVATE "$<$<STREQUAL:$<TARGET_PROPERTY:LANGUAGE>,CXX>:-Wno-register>")
 endif ()
 
 install(


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


It does not build with gcc 9.3 on our "perftest" server
despite all green CI checks in https://github.com/ClickHouse/ClickHouse/pull/13208