### PR TITLE
Do not add -Wno-register for C module in libunwind

### DIFF
--- a/contrib/libunwind-cmake/CMakeLists.txt
+++ b/contrib/libunwind-cmake/CMakeLists.txt
@@ -54,7 +54,7 @@ endif ()
 # Example: DwarfInstructions.hpp: register unsigned long long x16 __asm("x16") = cfa;
 check_cxx_compiler_flag(-Wregister HAVE_WARNING_REGISTER)
 if (HAVE_WARNING_REGISTER)
-    target_compile_options(unwind PRIVATE -Wno-register)
+    target_compile_options(unwind PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wno-register>)
 endif ()
 
 install(


### PR DESCRIPTION
Fixes:

    cc1: warning: command-line option ‘-Wno-register’ is valid for C++/ObjC++ but not for C

Changelog category (leave one):
- Not for changelog (changelog entry is not required)