### PR TITLE
Fix assertion in KeyCondition

### DIFF
--- a/tests/queries/0_stateless/01427_pk_and_expression_with_different_type.sql
+++ b/tests/queries/0_stateless/01427_pk_and_expression_with_different_type.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS pk;
+CREATE TABLE pk (x DateTime) ENGINE = MergeTree ORDER BY toStartOfMinute(x) SETTINGS index_granularity = 1;
+SELECT * FROM pk WHERE x >= toDateTime(120) AND x <= toDateTime(NULL);
+DROP TABLE pk;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix assertion in KeyCondition when primary key contains expression with monotonic function and query contains comparison with constant whose type is different. This fixes #12465.
