### PR TITLE
Fix hash table with NaN keys

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionUniq.h
+++ b/src/AggregateFunctions/AggregateFunctionUniq.h
@@ -276,7 +276,8 @@ public:
 
     void add(AggregateDataPtr place, const IColumn ** columns, size_t row_num, Arena *) const override
     {
-        this->data(place).set.insert(typename Data::Set::value_type(UniqVariadicHash<is_exact, argument_is_tuple>::apply(num_args, columns, row_num)));
+        this->data(place).set.insert(typename Data::Set::value_type(
+            UniqVariadicHash<is_exact, argument_is_tuple>::apply(num_args, columns, row_num)));
     }
 
     void merge(AggregateDataPtr place, ConstAggregateDataPtr rhs, Arena *) const override

--- a/src/Common/HashTable/HashMap.h
+++ b/src/Common/HashTable/HashMap.h
@@ -61,9 +61,9 @@ struct HashMapCell
     /// Get the key (internally).
     static const Key & getKey(const value_type & value) { return value.first; }
 
-    bool keyEquals(const Key & key_) const { return value.first == key_; }
-    bool keyEquals(const Key & key_, size_t /*hash_*/) const { return value.first == key_; }
-    bool keyEquals(const Key & key_, size_t /*hash_*/, const State & /*state*/) const { return value.first == key_; }
+    bool keyEquals(const Key & key_) const { return bitEquals(value.first, key_); }
+    bool keyEquals(const Key & key_, size_t /*hash_*/) const { return bitEquals(value.first, key_); }
+    bool keyEquals(const Key & key_, size_t /*hash_*/, const State & /*state*/) const { return bitEquals(value.first, key_); }
 
     void setHash(size_t /*hash_value*/) {}
     size_t getHash(const Hash & hash) const { return hash(value.first); }
@@ -120,8 +120,8 @@ struct HashMapCellWithSavedHash : public HashMapCell<Key, TMapped, Hash, TState>
 
     using Base::Base;
 
-    bool keyEquals(const Key & key_) const { return this->value.first == key_; }
-    bool keyEquals(const Key & key_, size_t hash_) const { return saved_hash == hash_ && this->value.first == key_; }
+    bool keyEquals(const Key & key_) const { return bitEquals(this->value.first, key_); }
+    bool keyEquals(const Key & key_, size_t hash_) const { return saved_hash == hash_ && bitEquals(this->value.first, key_); }
     bool keyEquals(const Key & key_, size_t hash_, const typename Base::State &) const { return keyEquals(key_, hash_); }
 
     void setHash(size_t hash_value) { saved_hash = hash_value; }

--- a/src/Common/HashTable/HashSet.h
+++ b/src/Common/HashTable/HashSet.h
@@ -76,8 +76,8 @@ struct HashSetCellWithSavedHash : public HashTableCell<Key, Hash, TState>
     HashSetCellWithSavedHash() : Base() {}
     HashSetCellWithSavedHash(const Key & key_, const typename Base::State & state) : Base(key_, state) {}
 
-    bool keyEquals(const Key & key_) const { return this->key == key_; }
-    bool keyEquals(const Key & key_, size_t hash_) const { return saved_hash == hash_ && this->key == key_; }
+    bool keyEquals(const Key & key_) const { return bitEquals(this->key, key_); }
+    bool keyEquals(const Key & key_, size_t hash_) const { return saved_hash == hash_ && bitEquals(this->key, key_); }
     bool keyEquals(const Key & key_, size_t hash_, const typename Base::State &) const { return keyEquals(key_, hash_); }
 
     void setHash(size_t hash_value) { saved_hash = hash_value; }

--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -75,6 +75,23 @@ void set(T & x) { x = 0; }
 
 }
 
+
+/** Numbers are compared bitwise.
+  * Complex types are compared by operator== as usual (this is important if there are gaps).
+  *
+  * This is needed if you use floats as keys. They are compared by bit equality.
+  * Otherwise the invariants in hash table probing do not met.
+  */
+template <typename T>
+inline bool bitEquals(T && a, T && b)
+{
+    if constexpr (std::is_floating_point_v<T>)
+        return 0 == memcmp(&a, &b, sizeof(T));
+    else
+        return a == b;
+}
+
+
 /**
   * getKey/Mapped -- methods to get key/"mapped" values from the LookupResult returned by find() and
   * emplace() methods of HashTable. Must not be called for a null LookupResult.
@@ -150,9 +167,9 @@ struct HashTableCell
     static const Key & getKey(const value_type & value) { return value; }
 
     /// Are the keys at the cells equal?
-    bool keyEquals(const Key & key_) const { return key == key_; }
-    bool keyEquals(const Key & key_, size_t /*hash_*/) const { return key == key_; }
-    bool keyEquals(const Key & key_, size_t /*hash_*/, const State & /*state*/) const { return key == key_; }
+    bool keyEquals(const Key & key_) const { return bitEquals(key, key_); }
+    bool keyEquals(const Key & key_, size_t /*hash_*/) const { return bitEquals(key, key_); }
+    bool keyEquals(const Key & key_, size_t /*hash_*/, const State & /*state*/) const { return bitEquals(key, key_); }
 
     /// If the cell can remember the value of the hash function, then remember it.
     void setHash(size_t /*hash_value*/) {}

--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -68,7 +68,7 @@ namespace ZeroTraits
 {
 
 template <typename T>
-bool check(T && x) { return x == 0; }
+bool check(const T x) { return x == 0; }
 
 template <typename T>
 void set(T & x) { x = 0; }

--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -68,7 +68,7 @@ namespace ZeroTraits
 {
 
 template <typename T>
-bool check(const T x) { return x == 0; }
+bool check(T && x) { return x == 0; }
 
 template <typename T>
 void set(T & x) { x = 0; }
@@ -80,13 +80,15 @@ void set(T & x) { x = 0; }
   * Complex types are compared by operator== as usual (this is important if there are gaps).
   *
   * This is needed if you use floats as keys. They are compared by bit equality.
-  * Otherwise the invariants in hash table probing do not met.
+  * Otherwise the invariants in hash table probing do not met when NaNs are present.
   */
 template <typename T>
 inline bool bitEquals(T && a, T && b)
 {
-    if constexpr (std::is_floating_point_v<T>)
-        return 0 == memcmp(&a, &b, sizeof(T));
+    using RealT = std::decay_t<T>;
+
+    if constexpr (std::is_floating_point_v<RealT>)
+        return 0 == memcmp(&a, &b, sizeof(RealT));  /// Note that memcmp with constant size is compiler builtin.
     else
         return a == b;
 }

--- a/tests/queries/0_stateless/01428_hash_set_nan_key.reference
+++ b/tests/queries/0_stateless/01428_hash_set_nan_key.reference
@@ -1,0 +1,7 @@
+1
+1
+nan
+nan
+[nan]
+nan
+10

--- a/tests/queries/0_stateless/01428_hash_set_nan_key.sql
+++ b/tests/queries/0_stateless/01428_hash_set_nan_key.sql
@@ -1,0 +1,10 @@
+SELECT uniqExact(nan) FROM numbers(1000);
+SELECT uniqExact(number % inf) FROM numbers(1000);
+SELECT sumDistinct(number % inf) FROM numbers(1000);
+SELECT DISTINCT number % inf FROM numbers(1000);
+
+SELECT topKWeightedMerge(1)(initializeAggregation('topKWeightedState(1)', nan, arrayJoin(range(10))));
+
+select number % inf k from numbers(256) group by k;
+
+SELECT uniqExact(reinterpretAsFloat64(reinterpretAsFixedString(reinterpretAsUInt64(reinterpretAsFixedString(nan)) + number))) FROM numbers(10);


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix potentially low performance and slightly incorrect result for `uniqExact`, `topK`, `sumDistinct` and similar aggregate functions called on Float types with NaN values. It also triggered assert in debug build. This fixes #12491.
