### PR TITLE
Fix clang build failure when enable range-loop-analysis

### DIFF
--- a/src/Core/BaseSettings.h
+++ b/src/Core/BaseSettings.h
@@ -279,8 +279,11 @@ template <typename Traits_>
 SettingsChanges BaseSettings<Traits_>::changes() const
 {
     SettingsChanges res;
-    for (const auto & field : *this)
+    for (auto iterator = begin(); iterator != end(); ++iterator)
+    {
+        const auto & field = *iterator;
         res.emplace_back(field.getName(), field.getValue());
+    }
     return res;
 }
 
@@ -300,8 +303,11 @@ void BaseSettings<Traits_>::applyChanges(const SettingsChanges & changes)
 template <typename Traits_>
 void BaseSettings<Traits_>::applyChanges(const BaseSettings & other_settings)
 {
-    for (const auto & field : other_settings)
+    for (auto iterator = other_settings.begin(); iterator != other_settings.end(); ++iterator)
+    {
+        const auto & field = *iterator;
         set(field.getName(), field.getValue());
+    }
 }
 
 template <typename Traits_>
@@ -487,10 +493,12 @@ template <typename Traits_>
 String BaseSettings<Traits_>::toString() const
 {
     String res;
-    for (const auto & field : *this)
+    for (auto iterator = begin(); iterator != end(); ++iterator)
     {
         if (!res.empty())
             res += ", ";
+
+        const auto & field = *iterator;
         res += field.getName() + " = " + field.getValueString();
     }
     return res;
@@ -500,9 +508,9 @@ template <typename Traits_>
 bool operator==(const BaseSettings<Traits_> & left, const BaseSettings<Traits_> & right)
 {
     auto l = left.begin();
-    for (const auto & r : right)
+    for (auto iterator = right.begin(); iterator != right.end(); ++iterator)
     {
-        if ((l == left.end()) || (*l != r))
+        if ((l == left.end()) || (*l != *iterator))
             return false;
         ++l;
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix clang build failure when enable range-loop-analysis


Detailed description / Documentation draft:
CC: @vitlibar 
In Apple clang version 11.0.3 (clang-1103.0.32.62)

```
/ClickHouse/src/Core/BaseSettings.h:282:23: error: loop variable 'field' is always a copy because the range of type 'const DB::BaseSettings<DB::KafkaSettingsTraits>' does not return a reference [-Werror,-Wrange-loop-analysis]
    for (const auto & field : *this)
                      ^
/ClickHouse/src/Storages/Kafka/KafkaSettings.cpp:17:1: note: in instantiation of member function 'DB::BaseSettings<DB::KafkaSettingsTraits>::changes' requested here
IMPLEMENT_SETTINGS_TRAITS(KafkaSettingsTraits, LIST_OF_KAFKA_SETTINGS)
^
/ClickHouse/src/Core/BaseSettings.h:828:20: note: expanded from macro 'IMPLEMENT_SETTINGS_TRAITS'
    template class BaseSettings<SETTINGS_TRAITS_NAME>;
                   ^
/ClickHouse/src/Core/BaseSettings.h:282:10: note: use non-reference type 'DB::BaseSettings<DB::KafkaSettingsTraits>::SettingFieldRef'
    for (const auto & field : *this)
         ^~~~~~~~~~~~~~~~~~~~
/ClickHouse/src/Core/BaseSettings.h:303:23: error: loop variable 'field' is always a copy because the range of type 'const DB::BaseSettings<DB::KafkaSettingsTraits>' does not return a reference [-Werror,-Wrange-loop-analysis]
    for (const auto & field : other_settings)
                      ^
/ClickHouse/src/Storages/Kafka/KafkaSettings.cpp:17:1: note: in instantiation of member function 'DB::BaseSettings<DB::KafkaSettingsTraits>::applyChanges' requested here
IMPLEMENT_SETTINGS_TRAITS(KafkaSettingsTraits, LIST_OF_KAFKA_SETTINGS)
^
/ClickHouse/src/Core/BaseSettings.h:828:20: note: expanded from macro 'IMPLEMENT_SETTINGS_TRAITS'
    template class BaseSettings<SETTINGS_TRAITS_NAME>;
                   ^
/ClickHouse/src/Core/BaseSettings.h:303:10: note: use non-reference type 'DB::BaseSettings<DB::KafkaSettingsTraits>::SettingFieldRef'
    for (const auto & field : other_settings)
         ^~~~~~~~~~~~~~~~~~~~
/ClickHouse/src/Core/BaseSettings.h:490:23: error: loop variable 'field' is always a copy because the range of type 'const DB::BaseSettings<DB::KafkaSettingsTraits>' does not return a reference [-Werror,-Wrange-loop-analysis]
    for (const auto & field : *this)
                      ^
/ClickHouse/src/Storages/Kafka/KafkaSettings.cpp:17:1: note: in instantiation of member function 'DB::BaseSettings<DB::KafkaSettingsTraits>::toString' requested here
IMPLEMENT_SETTINGS_TRAITS(KafkaSettingsTraits, LIST_OF_KAFKA_SETTINGS)
^
/ClickHouse/src/Core/BaseSettings.h:828:20: note: expanded from macro 'IMPLEMENT_SETTINGS_TRAITS'
    template class BaseSettings<SETTINGS_TRAITS_NAME>;
                   ^
/ClickHouse/src/Core/BaseSettings.h:490:10: note: use non-reference type 'DB::BaseSettings<DB::KafkaSettingsTraits>::SettingFieldRef'
    for (const auto & field : *this)
         ^~~~~~~~~~~~~~~~~~~~
3 errors generated.

```