### PR TITLE
Fix range checks in h3 functions

### DIFF
--- a/src/Functions/h3ToChildren.cpp
+++ b/src/Functions/h3ToChildren.cpp
@@ -5,6 +5,7 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/IFunction.h>
 #include <Common/typeid_cast.h>
+#include <IO/WriteHelpers.h>
 #include <ext/range.h>
 
 #include <constants.h>

--- a/src/Functions/h3ToChildren.cpp
+++ b/src/Functions/h3ToChildren.cpp
@@ -7,15 +7,19 @@
 #include <Common/typeid_cast.h>
 #include <ext/range.h>
 
+#include <constants.h>
 #include <h3api.h>
 
 
 namespace DB
 {
+
 namespace ErrorCodes
 {
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+    extern const int ARGUMENT_OUT_OF_BOUND;
 }
+
 class FunctionH3ToChildren : public IFunction
 {
 public:
@@ -62,6 +66,10 @@ public:
         {
             const UInt64 parent_hindex = col_hindex->getUInt(row);
             const UInt8 child_resolution = col_resolution->getUInt(row);
+
+            if (child_resolution > MAX_H3_RES)
+                throw Exception("The argument 'resolution' (" + toString(child_resolution) + ") of function " + getName()
+                    + " is out of bounds because the maximum resolution in H3 library is " + toString(MAX_H3_RES), ErrorCodes::ARGUMENT_OUT_OF_BOUND);
 
             const auto vec_size = maxH3ToChildrenSize(parent_hindex, child_resolution);
             hindex_vec.resize(vec_size);

--- a/src/Functions/h3ToParent.cpp
+++ b/src/Functions/h3ToParent.cpp
@@ -5,15 +5,19 @@
 #include <Common/typeid_cast.h>
 #include <ext/range.h>
 
+#include <constants.h>
 #include <h3api.h>
 
 
 namespace DB
 {
+
 namespace ErrorCodes
 {
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+    extern const int ARGUMENT_OUT_OF_BOUND;
 }
+
 class FunctionH3ToParent : public IFunction
 {
 public:
@@ -56,6 +60,10 @@ public:
         {
             const UInt64 hindex = col_hindex->getUInt(row);
             const UInt8 resolution = col_resolution->getUInt(row);
+
+            if (resolution > MAX_H3_RES)
+                throw Exception("The argument 'resolution' (" + toString(resolution) + ") of function " + getName()
+                    + " is out of bounds because the maximum resolution in H3 library is " + toString(MAX_H3_RES), ErrorCodes::ARGUMENT_OUT_OF_BOUND);
 
             UInt64 res = h3ToParent(hindex, resolution);
 

--- a/src/Functions/h3ToParent.cpp
+++ b/src/Functions/h3ToParent.cpp
@@ -3,6 +3,7 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/IFunction.h>
 #include <Common/typeid_cast.h>
+#include <IO/WriteHelpers.h>
 #include <ext/range.h>
 
 #include <constants.h>

--- a/tests/queries/0_stateless/01428_h3_range_check.sql
+++ b/tests/queries/0_stateless/01428_h3_range_check.sql
@@ -1,0 +1,2 @@
+SELECT h3ToChildren(599405990164561919, 100); -- { serverError 69 }
+SELECT h3ToParent(599405990164561919, 100); -- { serverError 69 }


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The server may crash if user passed specifically crafted arguments to the function `h3ToChildren`. This fixes #13275.
