### PR TITLE
Wait with retries in fast test

### DIFF
--- a/docker/test/fasttest/run.sh
+++ b/docker/test/fasttest/run.sh
@@ -86,9 +86,17 @@ ln -sf /usr/share/clickhouse-test/config/client_config.xml /etc/clickhouse-clien
 
 clickhouse-server --config /etc/clickhouse-server/config.xml --daemon
 
+counter=0
+
 until clickhouse-client --query "SELECT 1"
 do
     sleep 0.1
+    if [ "$counter" -gt 1200 ]
+    then
+        break
+    fi
+
+    counter=$(($counter + 1))
 done
 
 TESTS_TO_SKIP=(
@@ -178,9 +186,16 @@ if [[ ! -z "$FAILED_TESTS" ]]; then
 
     clickhouse-server --config /etc/clickhouse-server/config.xml --daemon
 
+    counter=0
     until clickhouse-client --query "SELECT 1"
     do
         sleep 0.1
+        if [ "$counter" -gt 1200 ]
+        then
+            break
+        fi
+
+        counter=$(($counter + 1))
     done
 
     echo "Going to run again: $FAILED_TESTS"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now fast test will wait server with retries.