### PR TITLE
Fix totals for delayed replica

### DIFF
--- a/src/Interpreters/ClusterProxy/SelectStreamFactory.cpp
+++ b/src/Interpreters/ClusterProxy/SelectStreamFactory.cpp
@@ -285,7 +285,7 @@ void SelectStreamFactory::createForShard(
             }
         };
 
-        res.emplace_back(createDelayedPipe(header, lazily_create_stream));
+        res.emplace_back(createDelayedPipe(header, lazily_create_stream, add_totals, add_extremes));
     }
     else
         emplace_remote_stream();

--- a/src/Processors/Sources/DelayedSource.cpp
+++ b/src/Processors/Sources/DelayedSource.cpp
@@ -127,6 +127,9 @@ Processors DelayedSource::expandPipeline()
     /// Add new inputs. They must have the same header as output.
     for (const auto & output : {main_output, totals_output, extremes_output})
     {
+        if (!output)
+            continue;
+
         inputs.emplace_back(outputs.front().getHeader(), this);
         /// Connect checks that header is same for ports.
         connect(*output, inputs.back());

--- a/src/Processors/Sources/DelayedSource.cpp
+++ b/src/Processors/Sources/DelayedSource.cpp
@@ -83,7 +83,7 @@ IProcessor::Status DelayedSource::prepare()
     return Status::Finished;
 }
 
-/// Fix port from returned pipe. Create source_port is created or drop if source_port is null.
+/// Fix port from returned pipe. Create source_port if created or drop if source_port is null.
 void synchronizePorts(OutputPort *& pipe_port, OutputPort * source_port, const Block & header, Processors & processors)
 {
     if (source_port)

--- a/src/Processors/Sources/DelayedSource.h
+++ b/src/Processors/Sources/DelayedSource.h
@@ -19,19 +19,25 @@ class DelayedSource : public IProcessor
 public:
     using Creator = std::function<Pipe()>;
 
-    DelayedSource(const Block & header, Creator processors_creator);
+    DelayedSource(const Block & header, Creator processors_creator, bool add_totals_port, bool add_extremes_port);
     String getName() const override { return "Delayed"; }
 
     Status prepare() override;
     void work() override;
     Processors expandPipeline() override;
 
-    enum PortKind { Main = 0, Totals = 1, Extremes = 2 };
-    OutputPort & getPort(PortKind kind) { return *std::next(outputs.begin(), kind); }
+    OutputPort & getPort() { return *main; }
+    OutputPort * getTotalsPort() { return totals; }
+    OutputPort * getExtremesPort() { return extremes; }
 
 private:
     Creator creator;
     Processors processors;
+
+    /// Outputs for DelayedSource.
+    OutputPort * main = nullptr;
+    OutputPort * totals = nullptr;
+    OutputPort * extremes = nullptr;
 
     /// Outputs from returned pipe.
     OutputPort * main_output = nullptr;
@@ -40,6 +46,6 @@ private:
 };
 
 /// Creates pipe from DelayedSource.
-Pipe createDelayedPipe(const Block & header, DelayedSource::Creator processors_creator);
+Pipe createDelayedPipe(const Block & header, DelayedSource::Creator processors_creator, bool add_totals_port, bool add_extremes_port);
 
 }

--- a/tests/integration/test_delayed_replica_failover/test.py
+++ b/tests/integration/test_delayed_replica_failover/test.py
@@ -69,6 +69,12 @@ SELECT sum(x) FROM distributed SETTINGS
     max_replica_delay_for_distributed_queries=1
 ''').strip() == '3'
 
+        assert instance_with_dist_table.query('''
+SELECT sum(x) FROM distributed WITH TOTALS SETTINGS
+    load_balancing='in_order',
+    max_replica_delay_for_distributed_queries=1
+''').strip() == '3\n\n3'
+
         pm.drop_instance_zk_connections(node_1_2)
         pm.drop_instance_zk_connections(node_2_2)
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible error `Totals having transform was already added to pipeline` in case of a query from delayed replica.