### PR TITLE
Restart server in stress test with timeout

### DIFF
--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -29,7 +29,7 @@ echo "TSAN_OPTIONS='halt_on_error=1 history_size=7 ignore_noninstrumented_module
 echo "UBSAN_OPTIONS='print_stacktrace=1'" >> /etc/environment
 echo "ASAN_OPTIONS='malloc_context_size=10 verbosity=1 allocator_release_to_os_interval_ms=10000'" >> /etc/environment
 
-service clickhouse-server start
+timeout 120 service clickhouse-server start
 
 wait_server
 
@@ -37,7 +37,8 @@ wait_server
 chmod 777 -R /var/lib/clickhouse
 clickhouse-client --query "ATTACH DATABASE IF NOT EXISTS datasets ENGINE = Ordinary"
 clickhouse-client --query "CREATE DATABASE IF NOT EXISTS test"
-service clickhouse-server restart
+
+timeout 120 service clickhouse-server restart
 
 wait_server
 

--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -49,7 +49,7 @@ clickhouse-client --query "SHOW TABLES FROM test"
 
 ./stress --output-folder test_output --skip-func-tests "$SKIP_TESTS_OPTION"
 
-service clickhouse-server restart
+timeout 120 service clickhouse-server restart
 
 wait_server
 

--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -38,7 +38,8 @@ chmod 777 -R /var/lib/clickhouse
 clickhouse-client --query "ATTACH DATABASE IF NOT EXISTS datasets ENGINE = Ordinary"
 clickhouse-client --query "CREATE DATABASE IF NOT EXISTS test"
 
-timeout 120 service clickhouse-server restart
+timeout 120 service clickhouse-server stop
+timeout 120 service clickhouse-server start
 
 wait_server
 
@@ -50,7 +51,8 @@ clickhouse-client --query "SHOW TABLES FROM test"
 
 ./stress --output-folder test_output --skip-func-tests "$SKIP_TESTS_OPTION"
 
-timeout 120 service clickhouse-server restart
+timeout 120 service clickhouse-server stop
+timeout 120 service clickhouse-server start
 
 wait_server
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix timeout error during server restart in the stress test.