### PR TITLE
Deadlock in textlog

### DIFF
--- a/base/loggers/OwnSplitChannel.cpp
+++ b/base/loggers/OwnSplitChannel.cpp
@@ -91,10 +91,14 @@ void OwnSplitChannel::logSplit(const Poco::Message & msg)
             elem.source_file = msg.getSourceFile();
 
         elem.source_line = msg.getSourceLine();
-
-        std::lock_guard<std::mutex> lock(text_log_mutex);
-        if (auto log = text_log.lock())
-            log->add(elem);
+        
+        shared_ptr<TextLog> text_log_locked;
+        {
+            std::lock_guard<std::mutex> lock(text_log_mutex);
+            text_log_locked = text_log.lock();
+        }
+        if (text_log_locked)
+               text_log_locked->add(elem);
     }
 }
 

--- a/base/loggers/OwnSplitChannel.cpp
+++ b/base/loggers/OwnSplitChannel.cpp
@@ -92,7 +92,7 @@ void OwnSplitChannel::logSplit(const Poco::Message & msg)
 
         elem.source_line = msg.getSourceLine();
         
-        shared_ptr<TextLog> text_log_locked;
+        std::shared_ptr<TextLog> text_log_locked;
         {
             std::lock_guard<std::mutex> lock(text_log_mutex);
             text_log_locked = text_log.lock();

--- a/base/loggers/OwnSplitChannel.cpp
+++ b/base/loggers/OwnSplitChannel.cpp
@@ -98,7 +98,7 @@ void OwnSplitChannel::logSplit(const Poco::Message & msg)
             text_log_locked = text_log.lock();
         }
         if (text_log_locked)
-               text_log_locked->add(elem);
+            text_log_locked->add(elem);
     }
 }
 

--- a/base/loggers/OwnSplitChannel.cpp
+++ b/base/loggers/OwnSplitChannel.cpp
@@ -91,8 +91,7 @@ void OwnSplitChannel::logSplit(const Poco::Message & msg)
             elem.source_file = msg.getSourceFile();
 
         elem.source_line = msg.getSourceLine();
-        
-        std::shared_ptr<TextLog> text_log_locked;
+        std::shared_ptr<TextLog> text_log_locked{};
         {
             std::lock_guard<std::mutex> lock(text_log_mutex);
             text_log_locked = text_log.lock();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed the deadlock in textlog. It is a part of #12339. This fixes #12325

Detailed description / Documentation draft:
Mutex is needed only to get a shared_ptr from weak_ptr concurrently.
