### PR TITLE
Fix a 'Week'-interval formatting for ATTACH/ALTER/CREATE QUOTA-statements

### DIFF
--- a/src/Common/IntervalKind.cpp
+++ b/src/Common/IntervalKind.cpp
@@ -51,10 +51,10 @@ IntervalKind IntervalKind::fromAvgSeconds(Int64 num_seconds)
             return IntervalKind::Year;
         if (!(num_seconds % 7889238))
             return IntervalKind::Quarter;
-        if (!(num_seconds % 604800))
-            return IntervalKind::Week;
         if (!(num_seconds % 2629746))
             return IntervalKind::Month;
+        if (!(num_seconds % 604800))
+            return IntervalKind::Week;
         if (!(num_seconds % 86400))
             return IntervalKind::Day;
         if (!(num_seconds % 3600))


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


**Changelog entry** (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix a 'Week'-interval formatting for ATTACH/ALTER/CREATE QUOTA-statements.


**Detailed description**:

Some interval values in second/minute/hour/day which multiple of the month is formatted as week-based not month-based as expected.

Current output:

```sql
:) create quota quota_01 for interval 4207593600 second max queries = 1000;

CREATE QUOTA quota_01 FOR INTERVAL 6957 week MAX queries = 1000

Ok.
```

Expected output:
```sql
:) create quota quota_01 for interval 4207593600 second max queries = 1000;

CREATE QUOTA quota_01 FOR INTERVAL 1600 month MAX queries = 1000

Ok.
```