### PR TITLE
Fix bad markup in docs menu

### DIFF
--- a/website/templates/docs/sidebar-item.html
+++ b/website/templates/docs/sidebar-item.html
@@ -3,7 +3,7 @@
 {% if nav_item.title.endswith('|hidden-folder') %}
 <a href="{{ base_url }}/{{ nav_item.children[0].url }}" title="{{ nav_item.title[:-14] }}" class="nav-link{% if nav_item.active%} text-white active{% else %} text-light{% endif %} text-wrap d-inline-block w-100 px-0">{{ nav_item.title[:-14] }}</a>
 {% elif nav_item.children %}
-<a href="#sidebar-{{ path }}" data-toggle="collapse" aria-expanded="{% if level < collapsed_threshold %}true{% else %}false{% endif %}" aria-controls="sidebar-{{ path }}" title="{{ nav_item.title }}" class="nav-link text-light text-wrap dropdown-toggle px-0">{{ nav_item.title }}</a>
+<a href="#sidebar-{{ path }}" data-toggle="collapse" aria-expanded="{% if level < collapsed_threshold %}true{% else %}false{% endif %}" aria-controls="sidebar-{{ path }}" title="{{ nav_item.title }}" class="nav-link text-light dropdown-toggle px-0">{{ nav_item.title }}</a>
 <div id="sidebar-{{ path }}" class="nav flex-column collapse{% if level < collapsed_threshold %} show{% endif %}">
     <nav class="nav flex-column pl-2">
     {% set base = path %}


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)


See the video:
https://drive.google.com/file/d/1GX37XKduXxjglhCxWhrImiz_NhXIG3Dj/view?usp=sharing

Normal people just can't stand it.