### PR TITLE
Documentation: fix box drawing characters

### DIFF
--- a/website/css/docs.css
+++ b/website/css/docs.css
@@ -76,6 +76,7 @@ body[data-spy] #content {
 #content pre {
     background: #efefef;
     padding: 1rem;
+    line-height: 1.25;
 }
 
 #docsearch-input:focus, #docsearch-input:active {


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)


In previous versions, the box drawing characters were too far from each other.

See the screenshot:
![Screenshot_20200807_011139](https://user-images.githubusercontent.com/18581488/89587786-fbafbf80-d84a-11ea-9d9c-87b903307334.png)

GitHub does it better:
```
┌─1─┐
│ 1 │
└───┘
```