### PR TITLE
Demangle exception classname for std::exception

### DIFF
--- a/src/Common/Exception.cpp
+++ b/src/Common/Exception.cpp
@@ -56,7 +56,7 @@ Exception::Exception(CreateFromPocoTag, const Poco::Exception & exc)
 }
 
 Exception::Exception(CreateFromSTDTag, const std::exception & exc)
-    : Poco::Exception(String(typeid(exc).name()) + ": " + String(exc.what()), ErrorCodes::STD_EXCEPTION)
+    : Poco::Exception(demangle(typeid(exc).name()) + ": " + String(exc.what()), ErrorCodes::STD_EXCEPTION)
 {
 #ifdef STD_EXCEPTION_HAS_STACK_TRACE
     set_stack_trace(exc.get_stack_trace_frames(), exc.get_stack_trace_size());


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Exception classname is demangled in getCurrentExceptionMessage, but (I believe, mistakenly) not demangled when explcitly constructing from std::exception. As a consequence, when an std::exception occurs on a remote replica, it appears mangled:

```
Code: 1001, e.displayText() = DB::Exception: Received from max42-dev.sas.yp-c.yandex.net:4244. DB::Exception: N3NYT15TErrorExceptionE: Testing exception in subquery
```

This patch fixes that behaviour.