### PR TITLE
Fix getting settings specified in query.

### DIFF
--- a/src/Functions/getScalar.cpp
+++ b/src/Functions/getScalar.cpp
@@ -44,7 +44,8 @@ public:
         if (arguments.size() != 1 || !isString(arguments[0].type) || !arguments[0].column || !isColumnConst(*arguments[0].column))
             throw Exception("Function " + getName() + " accepts one const string argument", ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
         auto scalar_name = assert_cast<const ColumnConst &>(*arguments[0].column).getValue<String>();
-        scalar = context.getScalar(scalar_name).getByPosition(0);
+        const Context & query_context = context.hasQueryContext() ? context.getQueryContext() : context;
+        scalar = query_context.getScalar(scalar_name).getByPosition(0);
         return scalar.type;
     }
 

--- a/src/Interpreters/ActionsVisitor.cpp
+++ b/src/Interpreters/ActionsVisitor.cpp
@@ -586,15 +586,10 @@ void ActionsMatcher::visit(const ASTFunction & node, const ASTPtr & ast, Data & 
     if (AggregateFunctionFactory::instance().isAggregateFunctionName(node.name))
         return;
 
-    /// Context object that we pass to function should live during query.
-    const Context & function_context = data.context.hasQueryContext()
-        ? data.context.getQueryContext()
-        : data.context;
-
     FunctionOverloadResolverPtr function_builder;
     try
     {
-        function_builder = FunctionFactory::instance().get(node.name, function_context);
+        function_builder = FunctionFactory::instance().get(node.name, data.context);
     }
     catch (DB::Exception & e)
     {

--- a/tests/queries/0_stateless/01418_custom_settings.reference
+++ b/tests/queries/0_stateless/01418_custom_settings.reference
@@ -6,6 +6,7 @@ custom_a	UInt64_5
 custom_b	Int64_-177
 custom_c	Float64_98.11
 custom_d	\'abc def\'
+
 changed	String
 \N	Nullable(Nothing)
 50000	UInt16
@@ -14,7 +15,16 @@ custom_a	\'changed\'
 custom_b	NULL
 custom_c	UInt64_50000
 custom_d	Float64_1.11
-0	UInt8
+
+404	UInt16
+
+-0.333	Float64
+custom_e	Float64_-0.333
+404	UInt16
+custom_e	UInt64_404
+word	String
+custom_f	\'word\'
+0
 
 test	String
 custom_compound.identifier.v1	\'test\'

--- a/tests/queries/0_stateless/01418_custom_settings.sql
+++ b/tests/queries/0_stateless/01418_custom_settings.sql
@@ -8,6 +8,7 @@ SELECT getSetting('custom_c') as v, toTypeName(v);
 SELECT getSetting('custom_d') as v, toTypeName(v);
 SELECT name, value FROM system.settings WHERE name LIKE 'custom_%' ORDER BY name;
 
+SELECT '';
 SET custom_a = 'changed';
 SET custom_b = NULL;
 SET custom_c = 50000;
@@ -18,11 +19,23 @@ SELECT getSetting('custom_c') as v, toTypeName(v);
 SELECT getSetting('custom_d') as v, toTypeName(v);
 SELECT name, value FROM system.settings WHERE name LIKE 'custom_%' ORDER BY name;
 
+SELECT '';
 SELECT getSetting('custom_e') as v, toTypeName(v); -- { serverError 115 } -- Setting not found.
-SET custom_e = 0;
+SET custom_e = 404;
 SELECT getSetting('custom_e') as v, toTypeName(v);
 
 SET invalid_custom = 8; -- { serverError 115 } -- Setting is neither a builtin nor started with one of the registered prefixes for user-defined settings.
+
+SELECT '';
+SELECT getSetting('custom_e') as v, toTypeName(v) SETTINGS custom_e = -0.333;
+SELECT name, value FROM system.settings WHERE name = 'custom_e' SETTINGS custom_e = -0.333;
+SELECT getSetting('custom_e') as v, toTypeName(v);
+SELECT name, value FROM system.settings WHERE name = 'custom_e';
+
+SELECT getSetting('custom_f') as v, toTypeName(v) SETTINGS custom_f = 'word';
+SELECT name, value FROM system.settings WHERE name = 'custom_f' SETTINGS custom_f = 'word';
+SELECT getSetting('custom_f') as v, toTypeName(v); -- { serverError 115 } -- Setting not found.
+SELECT COUNT() FROM system.settings WHERE name = 'custom_f';
 
 SELECT '';
 SET custom_compound.identifier.v1 = 'test';


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Not for changelog

The following query didn't work properly without this PR:
```
SELECT getSetting('custom_f') as v, toTypeName(v) SETTINGS custom_f = 'word';
```
That query should output ```word``` but it showed error `Unknown setting custom_f` instead.