### PR TITLE
Allow -march=native with clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,10 +176,7 @@ if(NOT DISABLE_CPU_OPTIMIZE)
     include(cmake/cpu_features.cmake)
 endif()
 
-if(NOT COMPILER_CLANG) # clang: error: the clang compiler does not support '-march=native'
-    option(ARCH_NATIVE "Enable -march=native compiler flag" ${ARCH_ARM})
-endif()
-
+option(ARCH_NATIVE "Enable -march=native compiler flag" ${ARCH_ARM})
 if (ARCH_NATIVE)
     set (COMPILER_FLAGS "${COMPILER_FLAGS} -march=native")
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,7 +176,7 @@ if(NOT DISABLE_CPU_OPTIMIZE)
     include(cmake/cpu_features.cmake)
 endif()
 
-option(ARCH_NATIVE "Enable -march=native compiler flag" ${ARCH_ARM})
+option(ARCH_NATIVE "Enable -march=native compiler flag" 0)
 if (ARCH_NATIVE)
     set (COMPILER_FLAGS "${COMPILER_FLAGS} -march=native")
 endif ()


### PR DESCRIPTION
Qrator Labs s.r.o. contributes this under the terms of the Apache-2.0 license 

Changelog category (leave one):

- Not for changelog (changelog entry is not required)