### PR TITLE
Better MergeTree readFromParts debug log

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -18,6 +18,7 @@
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTSampleRatio.h>
+#include <Parsers/queryToString.h>
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <Interpreters/Context.h>
 
@@ -649,7 +650,8 @@ Pipes MergeTreeDataSelectExecutor::readFromParts(
         parts_with_ranges.resize(next_part);
     }
 
-    LOG_DEBUG(log, "Selected {} parts by date, {} parts by key, {} marks by primary key, {} marks to read from {} ranges", parts.size(), parts_with_ranges.size(), sum_marks_pk.load(std::memory_order_relaxed), sum_marks, sum_ranges);
+    const auto & partition_key = metadata_snapshot->getPartitionKeyAST();
+    LOG_DEBUG(log, "Selected {} parts by {}, {} parts by key, {} marks by primary key, {} marks to read from {} ranges", parts.size(), queryToString(partition_key), parts_with_ranges.size(), sum_marks_pk.load(std::memory_order_relaxed), sum_marks, sum_ranges);
 
     if (parts_with_ranges.empty())
         return {};

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -651,7 +651,8 @@ Pipes MergeTreeDataSelectExecutor::readFromParts(
     }
 
     const auto & partition_key = metadata_snapshot->getPartitionKeyAST();
-    LOG_DEBUG(log, "Selected {} parts by {}, {} parts by key, {} marks by primary key, {} marks to read from {} ranges", parts.size(), queryToString(partition_key), parts_with_ranges.size(), sum_marks_pk.load(std::memory_order_relaxed), sum_marks, sum_ranges);
+    const auto partition_expression_str = partition_key == nullptr ? "" : queryToString(partition_key);
+    LOG_DEBUG(log, "Selected {} parts by {}, {} parts by key, {} marks by primary key, {} marks to read from {} ranges", parts.size(), partition_expression_str, parts_with_ranges.size(), sum_marks_pk.load(std::memory_order_relaxed), sum_marks, sum_ranges);
 
     if (parts_with_ranges.empty())
         return {};


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Selected 0 parts by date --> Selected 0 parts by tuple()
Replace the date by the PARTITION BY expression


Detailed description / Documentation draft:

...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.
