### PR TITLE
Enable Poco::NetSSL support in ya.make

### DIFF
--- a/base/common/ya.make
+++ b/base/common/ya.make
@@ -11,6 +11,7 @@ CFLAGS (GLOBAL -DARCADIA_BUILD)
 CFLAGS (GLOBAL -DUSE_CPUID=1)
 CFLAGS (GLOBAL -DUSE_JEMALLOC=0)
 CFLAGS (GLOBAL -DUSE_RAPIDJSON=1)
+CFLAGS (GLOBAL -DUSE_SSL=1)
 
 IF (OS_DARWIN)
     CFLAGS (GLOBAL -DOS_DARWIN)
@@ -24,6 +25,7 @@ PEERDIR(
     contrib/libs/cctz/src
     contrib/libs/cxxsupp/libcxx-filesystem
     contrib/libs/poco/Net
+    contrib/libs/poco/NetSSL_OpenSSL
     contrib/libs/poco/Util
     contrib/libs/fmt
     contrib/restricted/boost
@@ -50,7 +52,6 @@ SRCS(
     shift10.cpp
     sleep.cpp
     terminalColors.cpp
-
 )
 
 END()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)