### PR TITLE
specific ReplicatedMergeTree settings

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -521,6 +521,22 @@ For more information, see the MergeTreeSettings.h header file.
 </merge_tree>
 ```
 
+## replicated\_merge\_tree {#server_configuration_parameters-replicated_merge_tree}
+
+Fine tuning for tables in the [ReplicatedMergeTree](../../engines/table-engines/mergetree-family/mergetree.md).
+
+This setting has higher priority.
+
+For more information, see the MergeTreeSettings.h header file.
+
+**Example**
+
+``` xml
+<replicated_merge_tree>
+    <max_suspicious_broken_parts>5</max_suspicious_broken_parts>
+</replicated_merge_tree>
+```
+
 ## openSSL {#server_configuration_parameters-openssl}
 
 SSL client/server configuration.

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -596,6 +596,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
 
     /// Check sanity of MergeTreeSettings on server startup
     global_context->getMergeTreeSettings().sanityCheck(settings);
+    global_context->getReplicatedMergeTreeSettings().sanityCheck(settings);
 
     /// Limit on total memory usage
     size_t max_server_memory_usage = config().getUInt64("max_server_memory_usage", 0);

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -348,6 +348,7 @@ struct ContextShared
     mutable std::shared_ptr<const StoragePolicySelector> merge_tree_storage_policy_selector;
 
     std::optional<MergeTreeSettings> merge_tree_settings;   /// Settings of MergeTree* engines.
+    std::optional<MergeTreeSettings> replicated_merge_tree_settings;   /// Settings of ReplicatedMergeTree* engines.
     std::atomic_size_t max_table_size_to_drop = 50000000000lu; /// Protects MergeTree tables from accidental DROP (50GB by default)
     std::atomic_size_t max_partition_size_to_drop = 50000000000lu; /// Protects MergeTree partitions from accidental DROP (50GB by default)
     String format_schema_path;                              /// Path to a directory that contains schema files used by input formats.
@@ -1821,6 +1822,22 @@ const MergeTreeSettings & Context::getMergeTreeSettings() const
     }
 
     return *shared->merge_tree_settings;
+}
+
+const MergeTreeSettings & Context::getReplicatedMergeTreeSettings() const
+{
+    auto lock = getLock();
+
+    if (!shared->replicated_merge_tree_settings)
+    {
+        const auto & config = getConfigRef();
+        MergeTreeSettings mt_settings;
+        mt_settings.loadFromConfig("merge_tree", config);
+        mt_settings.loadFromConfig("replicated_merge_tree", config);
+        shared->replicated_merge_tree_settings.emplace(mt_settings);
+    }
+
+    return *shared->replicated_merge_tree_settings;
 }
 
 const StorageS3Settings & Context::getStorageS3Settings() const

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -537,6 +537,7 @@ public:
     std::shared_ptr<PartLog> getPartLog(const String & part_database);
 
     const MergeTreeSettings & getMergeTreeSettings() const;
+    const MergeTreeSettings & getReplicatedMergeTreeSettings() const;
     const StorageS3Settings & getStorageS3Settings() const;
 
     /// Prevents DROP TABLE if its size is greater than max_size (50GB by default, max_size=0 turn off this check)

--- a/src/Server/ReplicasStatusHandler.cpp
+++ b/src/Server/ReplicasStatusHandler.cpp
@@ -33,7 +33,7 @@ void ReplicasStatusHandler::handleRequest(Poco::Net::HTTPServerRequest & request
         /// Even if lag is small, output detailed information about the lag.
         bool verbose = params.get("verbose", "") == "1";
 
-        const MergeTreeSettings & settings = context.getMergeTreeSettings();
+        const MergeTreeSettings & settings = context.getReplicatedMergeTreeSettings();
 
         bool ok = true;
         std::stringstream message;

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -514,7 +514,11 @@ static StoragePtr create(const StorageFactory::Arguments & args)
     StorageInMemoryMetadata metadata;
     metadata.columns = args.columns;
 
-    std::unique_ptr<MergeTreeSettings> storage_settings = std::make_unique<MergeTreeSettings>(args.context.getMergeTreeSettings());
+    std::unique_ptr<MergeTreeSettings> storage_settings;
+    if (replicated)
+        storage_settings = std::make_unique<MergeTreeSettings>(args.context.getReplicatedMergeTreeSettings());
+    else
+        storage_settings = std::make_unique<MergeTreeSettings>(args.context.getMergeTreeSettings());
 
     if (is_extended_storage_def)
     {

--- a/src/Storages/System/StorageSystemMergeTreeSettings.cpp
+++ b/src/Storages/System/StorageSystemMergeTreeSettings.cpp
@@ -7,7 +7,8 @@
 namespace DB
 {
 
-NamesAndTypesList SystemMergeTreeSettings::getNamesAndTypes()
+template <bool replicated>
+NamesAndTypesList SystemMergeTreeSettings<replicated>::getNamesAndTypes()
 {
     return {
         {"name",        std::make_shared<DataTypeString>()},
@@ -18,9 +19,11 @@ NamesAndTypesList SystemMergeTreeSettings::getNamesAndTypes()
     };
 }
 
-void SystemMergeTreeSettings::fillData(MutableColumns & res_columns, const Context & context, const SelectQueryInfo &) const
+template <bool replicated>
+void SystemMergeTreeSettings<replicated>::fillData(MutableColumns & res_columns, const Context & context, const SelectQueryInfo &) const
 {
-    for (const auto & setting : context.getMergeTreeSettings().all())
+    const auto & settings = replicated ? context.getReplicatedMergeTreeSettings().all() : context.getMergeTreeSettings().all();
+    for (const auto & setting : settings)
     {
         res_columns[0]->insert(setting.getName());
         res_columns[1]->insert(setting.getValueString());
@@ -30,4 +33,6 @@ void SystemMergeTreeSettings::fillData(MutableColumns & res_columns, const Conte
     }
 }
 
+template class SystemMergeTreeSettings<false>;
+template class SystemMergeTreeSettings<true>;
 }

--- a/src/Storages/System/StorageSystemMergeTreeSettings.h
+++ b/src/Storages/System/StorageSystemMergeTreeSettings.h
@@ -11,18 +11,22 @@ namespace DB
 class Context;
 
 
-/** implements system table "merge_tree_settings", which allows to get information about the current MergeTree settings.
+/** implements system table "merge_tree_settings" and "replicated_merge_tree_settings",
+  *  which allows to get information about the current MergeTree settings.
   */
-class SystemMergeTreeSettings final : public ext::shared_ptr_helper<SystemMergeTreeSettings>, public IStorageSystemOneBlock<SystemMergeTreeSettings>
+template <bool replicated>
+class SystemMergeTreeSettings final : public ext::shared_ptr_helper<SystemMergeTreeSettings<replicated>>,
+                                      public IStorageSystemOneBlock<SystemMergeTreeSettings<replicated>>
 {
-    friend struct ext::shared_ptr_helper<SystemMergeTreeSettings>;
+    friend struct ext::shared_ptr_helper<SystemMergeTreeSettings<replicated>>;
+
 public:
-    std::string getName() const override { return "SystemMergeTreeSettings"; }
+    std::string getName() const override { return replicated ? "SystemReplicatedMergeTreeSettings" : "SystemMergeTreeSettings"; }
 
     static NamesAndTypesList getNamesAndTypes();
 
 protected:
-    using IStorageSystemOneBlock::IStorageSystemOneBlock;
+    using IStorageSystemOneBlock<SystemMergeTreeSettings<replicated>>::IStorageSystemOneBlock;
 
     void fillData(MutableColumns & res_columns, const Context & context, const SelectQueryInfo & query_info) const override;
 };

--- a/src/Storages/System/attachSystemTables.cpp
+++ b/src/Storages/System/attachSystemTables.cpp
@@ -82,7 +82,8 @@ void attachSystemTablesLocal(IDatabase & system_database)
     attach<StorageSystemFunctions>(system_database, "functions");
     attach<StorageSystemEvents>(system_database, "events");
     attach<StorageSystemSettings>(system_database, "settings");
-    attach<SystemMergeTreeSettings>(system_database, "merge_tree_settings");
+    attach<SystemMergeTreeSettings<false>>(system_database, "merge_tree_settings");
+    attach<SystemMergeTreeSettings<true>>(system_database, "replicated_merge_tree_settings");
     attach<StorageSystemBuildOptions>(system_database, "build_options");
     attach<StorageSystemFormats>(system_database, "formats");
     attach<StorageSystemTableFunctions>(system_database, "table_functions");

--- a/tests/integration/test_replicated_merge_tree_config/configs/config.xml
+++ b/tests/integration/test_replicated_merge_tree_config/configs/config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<yandex>
+    <merge_tree>
+        <index_granularity>100</index_granularity>
+    </merge_tree>
+    <replicated_merge_tree>
+        <index_granularity>200</index_granularity>
+    </replicated_merge_tree>
+</yandex>

--- a/tests/integration/test_replicated_merge_tree_config/test.py
+++ b/tests/integration/test_replicated_merge_tree_config/test.py
@@ -1,14 +1,14 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
+import logging
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node", main_configs=["configs/config.xml"], with_zookeeper=True)
 
 
 @pytest.fixture(scope="module")
-def cluster():
+def start_cluster():
     try:
-        cluster = ClickHouseCluster(__file__)
-        cluster.add_instance(
-            "node", config_dir="configs", with_zookeeper=True,
-        )
         logging.info("Starting cluster...")
         cluster.start()
         logging.info("Cluster started")
@@ -19,19 +19,18 @@ def cluster():
 
 
 @pytest.fixture(autouse=True)
-def drop_table(cluster):
+def drop_table(start_cluster):
     yield
     for node in cluster.instances.values():
         node.query("DROP TABLE IF EXISTS test1")
         node.query("DROP TABLE IF EXISTS test2")
 
 
-def test_replicated_merge_tree_settings(cluster):
-    node = cluster.instances["node"]
+def test_replicated_merge_tree_settings(start_cluster):
     node.query("CREATE TABLE test1 (id Int64) ENGINE MergeTree ORDER BY id")
     node.query(
         "CREATE TABLE test2 (id Int64) ENGINE ReplicatedMergeTree('/clickhouse/test', 'test') ORDER BY id"
     )
 
-    assert node.query("SHOW CREATE test1").endswith("100")
-    assert node.query("SHOW CREATE test2").endswith("200")
+    assert node.query("SHOW CREATE test1").strip().endswith("100")
+    assert node.query("SHOW CREATE test2").strip().endswith("200")

--- a/tests/integration/test_replicated_merge_tree_config/test.py
+++ b/tests/integration/test_replicated_merge_tree_config/test.py
@@ -1,0 +1,37 @@
+import pytest
+from helpers.cluster import ClickHouseCluster
+
+
+@pytest.fixture(scope="module")
+def cluster():
+    try:
+        cluster = ClickHouseCluster(__file__)
+        cluster.add_instance(
+            "node", config_dir="configs", with_zookeeper=True,
+        )
+        logging.info("Starting cluster...")
+        cluster.start()
+        logging.info("Cluster started")
+
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def drop_table(cluster):
+    yield
+    for node in cluster.instances.values():
+        node.query("DROP TABLE IF EXISTS test1")
+        node.query("DROP TABLE IF EXISTS test2")
+
+
+def test_replicated_merge_tree_settings(cluster):
+    node = cluster.instances["node"]
+    node.query("CREATE TABLE test1 (id Int64) ENGINE MergeTree ORDER BY id")
+    node.query(
+        "CREATE TABLE test2 (id Int64) ENGINE ReplicatedMergeTree('/clickhouse/test', 'test') ORDER BY id"
+    )
+
+    assert node.query("SHOW CREATE test1").endswith("100")
+    assert node.query("SHOW CREATE test2").endswith("200")

--- a/tests/integration/test_replicated_merge_tree_config/test.py
+++ b/tests/integration/test_replicated_merge_tree_config/test.py
@@ -32,5 +32,5 @@ def test_replicated_merge_tree_settings(start_cluster):
         "CREATE TABLE test2 (id Int64) ENGINE ReplicatedMergeTree('/clickhouse/test', 'test') ORDER BY id"
     )
 
-    assert node.query("SHOW CREATE test1").strip().endswith("100")
-    assert node.query("SHOW CREATE test2").strip().endswith("200")
+    assert "index_granularity = 100" in node.query("SHOW CREATE test1")
+    assert "index_granularity = 200" in node.query("SHOW CREATE test2")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Allow user to specify settings for `ReplicatedMergeTree*` storage in  `<replicated_merge_tree>` section of config file. It works similarly to `<merge_tree>` section. For `ReplicatedMergeTree*` storages settings from `<merge_tree>` and `<replicated_merge_tree>` are applied together, but settings from `<replicated_merge_tree>` has higher priority. Added `system.replicated_merge_tree_settings` table.


There are some settings which are useful defaults for replicated tables but don't make sense for normal tables, and using `merge_tree` settings will complicate system tables.

Detailed description / Documentation draft:

Document has been updated.
