### PR TITLE
Add noop runner parameter to prepare actual changes

### DIFF
--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -124,6 +124,10 @@ if __name__ == "__main__":
         default="latest",
         help="Version of docker image which runner will use to run tests")
 
+    parser.add_argument(
+        "--docker-compose-images-tags",
+        action="append",
+        help="Set non-default tags for images used in docker compose recipes(yandex/my_container:my_tag)")
 
     parser.add_argument('pytest_args', nargs='*', help="args for pytest command")
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:

Added new argument to allow changes in Sandbox Task.
Next changes:

- Pass changed image that is used in integration tests (Sandbox)
- Actual changes in runner script and docker_compose files to allow #13448

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.
