### PR TITLE
Do not overallocate when creating PODArray with given size

### DIFF
--- a/src/Common/PODArray.h
+++ b/src/Common/PODArray.h
@@ -111,7 +111,7 @@ protected:
 
     void alloc_for_num_elements(size_t num_elements)
     {
-        alloc(roundUpToPowerOfTwoOrZero(minimum_memory_for_elements(num_elements)));
+        alloc(minimum_memory_for_elements(num_elements));
     }
 
     template <typename ... TAllocatorParams>


### PR DESCRIPTION
Another part of #12278

Changelog category (leave one):
- Not for changelog (changelog entry is not required)