### PR TITLE
Fix assertion for carriage return in TSV format header

### DIFF
--- a/src/Processors/Formats/Impl/TabSeparatedRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/TabSeparatedRowInputFormat.cpp
@@ -38,7 +38,7 @@ static void checkForCarriageReturn(ReadBuffer & in)
         throw Exception("\nYou have carriage return (\\r, 0x0D, ASCII 13) at end of first row."
             "\nIt's like your input data has DOS/Windows style line separators, that are illegal in TabSeparated format."
             " You must transform your file to Unix format."
-            "\nBut if you really need carriage return at end of string value of last column, you need to escape it as \\\\r.",
+            "\nBut if you really need carriage return at end of string value of last column, you need to escape it as \\r.",
             ErrorCodes::INCORRECT_DATA);
 }
 

--- a/tests/queries/0_stateless/01406_carriage_return_in_tsv_csv.reference
+++ b/tests/queries/0_stateless/01406_carriage_return_in_tsv_csv.reference
@@ -1,0 +1,9 @@
+CSVWithNames
+bar
+TSVWithNames
+117
+
+TSV
+117
+key\r
+bar

--- a/tests/queries/0_stateless/01406_carriage_return_in_tsv_csv.sh
+++ b/tests/queries/0_stateless/01406_carriage_return_in_tsv_csv.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../shell_config.sh
+
+echo 'CSVWithNames'
+echo -n $'key\r\nbar\r\n' | ${CLICKHOUSE_LOCAL} --input-format CSVWithNames -S 'key String' -q 'select * from table'
+
+echo 'TSVWithNames'
+echo -n $'key\r\nbar\r\n' | ${CLICKHOUSE_LOCAL} --input-format TSVWithNames -S 'key String' -q 'select * from table' >& /dev/null
+echo $?
+echo -n $'key\\r\nbar\n' | ${CLICKHOUSE_LOCAL} --input_format_skip_unknown_fields=1 --input-format TSVWithNames -S 'key String' -q 'select * from table'
+
+echo 'TSV'
+echo -n $'key\r\nbar\r\n' | ${CLICKHOUSE_LOCAL} --input-format TSV -S 'key String' -q 'select * from table' >& /dev/null
+echo $?
+echo -n $'key\\r\nbar\n' | ${CLICKHOUSE_LOCAL} --input-format TSV -S 'key String' -q 'select * from table'


### PR DESCRIPTION
TabSeparatedRowInputFormat::readPrefix() tries to check for carriage
return (via checkForCarriageReturn()), however it does the check after
checking the column is exists, reorder the codepath a little bit to
run checkForCarriageReturn() before.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<details>

HEAD:
- 39365cce5025f4bc4ffbb7124458e185809166e3

</details>