### PR TITLE
Readline fix

### DIFF
--- a/base/common/ReadlineLineReader.cpp
+++ b/base/common/ReadlineLineReader.cpp
@@ -6,6 +6,8 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <iostream>
+
 namespace
 {
 
@@ -107,6 +109,8 @@ ReadlineLineReader::ReadlineLineReader(
         throw std::runtime_error(std::string("Cannot set signal handler for readline: ") + strerror(errno));
 
     rl_variable_bind("completion-ignore-case", "on");
+    // TODO: it doesn't work
+    // history_write_timestamps = 1;
 }
 
 ReadlineLineReader::~ReadlineLineReader()
@@ -129,6 +133,11 @@ LineReader::InputStatus ReadlineLineReader::readOneLine(const String & prompt)
 void ReadlineLineReader::addToHistory(const String & line)
 {
     add_history(line.c_str());
+
+    // Flush changes to the disk
+    // NOTE readline builds a buffer of all the lines to write, and write them in one syscall.
+    // Thus there is no need to lock the history file here.
+    write_history(history_file_path.c_str());
 }
 
 #if RL_VERSION_MAJOR >= 7


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Other

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix readline so it dumps history to file now.

Detailed description / Documentation draft:

No need.