### PR TITLE
testflows: increasing health-check timeouts for clickhouse nodes

### DIFF
--- a/tests/testflows/example/docker-compose/clickhouse-service.yml
+++ b/tests/testflows/example/docker-compose/clickhouse-service.yml
@@ -20,7 +20,7 @@ services:
       test: clickhouse client --query='select 1'
       interval: 3s
       timeout: 5s
-      retries: 40
+      retries: 100
       start_period: 2s
     cap_add:
       - SYS_PTRACE

--- a/tests/testflows/helpers/cluster.py
+++ b/tests/testflows/helpers/cluster.py
@@ -246,8 +246,8 @@ class Cluster(object):
                     assert os.path.exists(self.clickhouse_binary_path)
 
             os.environ["CLICKHOUSE_TESTS_SERVER_BIN_PATH"] = self.clickhouse_binary_path
-            os.environ["CLICKHOUSE_TESTS_ODBC_BRIDGE_BIN_PATH"] = os.path.join(os.path.dirname(self.clickhouse_binary_path),
-                                                                               "clickhouse-odbc-bridge")
+            os.environ["CLICKHOUSE_TESTS_ODBC_BRIDGE_BIN_PATH"] = os.path.join(
+                os.path.dirname(self.clickhouse_binary_path), "clickhouse-odbc-bridge")
             os.environ["CLICKHOUSE_TESTS_DIR"] = self.configs_dir
 
             with Given("docker-compose"):
@@ -258,7 +258,9 @@ class Cluster(object):
                 cmd = self.command(None, f'{self.docker_compose} up -d --no-recreate 2>&1 | tee')
 
         with Then("check there are no unhealthy containers"):
-            assert "is unhealthy" not in cmd.output, error()
+            if "is unhealthy" in cmd.output:
+                self.command(None, f'{self.docker_compose} logs | tee')
+                fail("found unhealthy containers")
 
         with Then("wait all nodes report healhy"):
             for name in self.nodes["clickhouse"]:

--- a/tests/testflows/ldap/docker-compose/clickhouse-service.yml
+++ b/tests/testflows/ldap/docker-compose/clickhouse-service.yml
@@ -20,7 +20,7 @@ services:
       test: clickhouse client --query='select 1'
       interval: 3s
       timeout: 10s
-      retries: 5
+      retries: 100
       start_period: 30s
     cap_add:
       - SYS_PTRACE

--- a/tests/testflows/rbac/docker-compose/clickhouse-service.yml
+++ b/tests/testflows/rbac/docker-compose/clickhouse-service.yml
@@ -20,7 +20,7 @@ services:
       test: clickhouse client --query='select 1'
       interval: 3s
       timeout: 2s
-      retries: 40
+      retries: 100
       start_period: 2s
     cap_add:
       - SYS_PTRACE


### PR DESCRIPTION
Increasing health-check timeouts for ClickHouse nodes and adding support to dump docker-compose logs if unhealthy containers found.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Increasing health-check timeouts for ClickHouse nodes and adding support to dump docker-compose logs if unhealthy containers found.

Detailed description / Documentation draft:
Increasing health-check timeouts for ClickHouse nodes and adding support to dump docker-compose logs if unhealthy containers found.
