### PR TITLE
Fixed result order in hash set test

### DIFF
--- a/tests/queries/0_stateless/01428_hash_set_nan_key.sql
+++ b/tests/queries/0_stateless/01428_hash_set_nan_key.sql
@@ -5,6 +5,6 @@ SELECT DISTINCT number % inf FROM numbers(1000);
 
 SELECT topKWeightedMerge(1)(initializeAggregation('topKWeightedState(1)', nan, arrayJoin(range(10))));
 
-select number % inf k from numbers(256) group by k;
+select number % inf k from numbers(256) group by k order by k;
 
-SELECT uniqExact(reinterpretAsFloat64(reinterpretAsFixedString(reinterpretAsUInt64(reinterpretAsFixedString(nan)) + number))) FROM numbers(10);
+SELECT uniqExact(reinterpretAsFloat64(reinterpretAsFixedString(reinterpretAsUInt64(reinterpretAsFixedString(nan)) + number))) n FROM numbers(10) order by n;


### PR DESCRIPTION
This is needed to fix the test in 20.6, where apparently the order is
different.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)
