### PR TITLE
Fix arrayJoin with GROUP BY

### DIFF
--- a/src/Processors/Formats/Impl/JSONCompactEachRowRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONCompactEachRowRowOutputFormat.cpp
@@ -44,9 +44,12 @@ void JSONCompactEachRowRowOutputFormat::writeRowEndDelimiter()
     writeCString("]\n", out);
 }
 
-void JSONCompactEachRowRowOutputFormat::writeTotals(const Columns & columns, size_t row_num)
+void JSONCompactEachRowRowOutputFormat::writeBeforeTotals()
 {
     writeChar('\n', out);
+}
+void JSONCompactEachRowRowOutputFormat::writeTotals(const Columns & columns, size_t row_num)
+{
     size_t num_columns = columns.size();
     writeChar('[', out);
     for (size_t i = 0; i < num_columns; ++i)

--- a/src/Processors/Formats/Impl/JSONCompactEachRowRowOutputFormat.h
+++ b/src/Processors/Formats/Impl/JSONCompactEachRowRowOutputFormat.h
@@ -21,7 +21,7 @@ public:
 
     void writePrefix() override;
 
-    void writeBeforeTotals() override {}
+    void writeBeforeTotals() override;
     void writeTotals(const Columns & columns, size_t row_num) override;
     void writeAfterTotals() override {}
 

--- a/tests/queries/0_stateless/01405_with_totals_arrayJoin.reference
+++ b/tests/queries/0_stateless/01405_with_totals_arrayJoin.reference
@@ -1,0 +1,11 @@
+ARRAY JOIN
+0
+
+0
+0	[]
+
+0	[]
+arrayJoin
+0
+
+0

--- a/tests/queries/0_stateless/01405_with_totals_arrayJoin.sql
+++ b/tests/queries/0_stateless/01405_with_totals_arrayJoin.sql
@@ -1,0 +1,11 @@
+SELECT 'ARRAY JOIN';
+SELECT * FROM numbers(1) ARRAY JOIN [[], []] AS a_ GROUP BY number WITH TOTALS;
+-- before there was:
+--     Code: 10. DB::Exception: Received from localhost:9000. DB::Exception: Not found column a_ in block. There are only columns: number.
+SELECT *, a_ FROM numbers(1) ARRAY JOIN [[], []] AS a_ GROUP BY number WITH TOTALS; -- { serverError 215; }
+SELECT *, any(a_) FROM numbers(1) ARRAY JOIN [[], []] AS a_ GROUP BY number WITH TOTALS;
+SELECT 'arrayJoin';
+SELECT arrayJoin([[], []]), * FROM numbers(1) GROUP BY number WITH TOTALS; -- { serverError 215; }
+-- after https://github.com/ClickHouse/ClickHouse/pull/13681
+-- (do not forget to update .reference)
+-- SELECT any(arrayJoin([[], []])), * FROM numbers(1) GROUP BY number WITH TOTALS;


### PR DESCRIPTION
**TODO: update Changelog category to Bugfix**

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix arrayJoin with GROUP BY

Found with: [AST query fuzzer](https://clickhouse-test-reports.s3.yandex.net/13156/4e196fb55b85db05243f3d9024f27f07a53412b6/fuzzer/fuzzer.log#fail1)
Blocked by: #13611