### PR TITLE
Add MergeTree Write-Ahead-Log(WAL) dump tool

### DIFF
--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -28,6 +28,7 @@ if (NOT DEFINED ENABLE_UTILS OR ENABLE_UTILS)
     add_subdirectory (test-data-generator)
     add_subdirectory (convert-month-partitioned-parts)
     add_subdirectory (checksum-for-compressed-block)
+    add_subdirectory (wal-dump)
 endif ()
 
 if (ENABLE_CODE_QUALITY)

--- a/utils/wal-dump/CMakeLists.txt
+++ b/utils/wal-dump/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable (wal-dump main.cpp)
+target_link_libraries(wal-dump PRIVATE dbms boost::program_options)

--- a/utils/wal-dump/main.cpp
+++ b/utils/wal-dump/main.cpp
@@ -1,0 +1,78 @@
+#include <iostream>
+
+#include <boost/program_options.hpp>
+
+#include <Compression/CompressedReadBuffer.h>
+#include <Compression/CompressedReadBufferFromFile.h>
+#include <Compression/CompressedWriteBuffer.h>
+#include <DataStreams/NativeBlockInputStream.h>
+#include <IO/Operators.h>
+#include <IO/ReadBufferFromFile.h>
+#include <IO/ReadHelpers.h>
+#include <IO/WriteBufferFromFileDescriptor.h>
+#include <Storages/MergeTree/MergeTreeWriteAheadLog.h>
+
+/*
+ * Dump the Write Ahead Log file, outputs:
+ * Part 0, Version: 0, Action : ADD_PART, Name: 4_1_1_0, Block:
+   a Int32 Int32(size = 2), b Int32 Int32(size = 2), c Int32 Int32(size = 2)
+ */
+
+static void dump(const std::string & bin_path)
+{
+    DB::ReadBufferFromFile in(bin_path);
+    DB::NativeBlockInputStream block_in(in, 0);
+    DB::Block block;
+
+    DB::WriteBufferFromFileDescriptor out(STDOUT_FILENO);
+
+    for (size_t part_num = 0; !in.eof(); ++part_num)
+    {
+        UInt8 version;
+        String part_name;
+        DB::MergeTreeWriteAheadLog::ActionType action_type;
+
+        DB::readIntBinary(version, in);
+        DB::readIntBinary(action_type, in);
+        DB::readStringBinary(part_name, in);
+        block = block_in.read();
+
+        out << "Part " << part_num << ", Version: " << version
+            << ", Action : " << (action_type == DB::MergeTreeWriteAheadLog::ActionType::ADD_PART ? "ADD_PART" : "DROP_PART")
+            << ", Name: " << part_name << ", Block:\n";
+        out << block.dumpStructure() << "\n";
+        out << "\n" << DB::flush;
+    }
+}
+
+
+int main(int argc, char ** argv)
+{
+    boost::program_options::options_description desc("Allowed options");
+    desc.add_options()("help,h", "produce help message");
+
+    boost::program_options::variables_map options;
+    boost::program_options::store(boost::program_options::parse_command_line(argc, argv, desc), options);
+
+    if (options.count("help") || argc != 2)
+    {
+        std::cout << "Usage: " << argv[0] << " wal.bin" << std::endl;
+        std::cout << desc << std::endl;
+        return 1;
+    }
+
+    try
+    {
+        dump(argv[1]);
+    }
+    catch (const DB::Exception & e)
+    {
+        std::cerr << e.what() << ", " << e.message() << std::endl
+                  << std::endl
+                  << "Stack trace:" << std::endl
+                  << e.getStackTraceString() << std::endl;
+        throw;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add MergeTree Write-Ahead-Log(WAL) dump tool


Detailed description / Documentation draft:

...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.
