### PR TITLE
Remove stateless_pytest container from 20.3

### DIFF
--- a/docker/images.json
+++ b/docker/images.json
@@ -4,7 +4,6 @@
         "dependent": [
             "docker/test/stateless",
             "docker/test/stateless_with_coverage",
-            "docker/test/stateless_pytest",
             "docker/test/coverage"
         ]
     },
@@ -51,10 +50,6 @@
             "docker/test/stateful",
             "docker/test/stateful_with_coverage"
         ]
-    },
-    "docker/test/stateless_pytest": {
-        "name": "yandex/clickhouse-stateless-pytest",
-        "dependent": []
     },
     "docker/test/stateless_with_coverage": {
         "name": "yandex/clickhouse-stateless-test-with-coverage",


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:

FIX 20.3 docker build

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.
