### PR TITLE
Fix http session releasing

### DIFF
--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -596,8 +596,15 @@ void HTTPHandler::processQuery(
     customizeContext(request, context);
 
     executeQuery(*in, *used_output.out_maybe_delayed_and_compressed, /* allow_into_outfile = */ false, context,
-        [&response] (const String & current_query_id, const String & content_type, const String & format, const String & timezone)
+        [&session, &response] (const String & current_query_id, const String & content_type, const String & format, const String & timezone)
         {
+            /// Release the session when the query is done.
+            if (session)
+            {
+                session->release();
+                session = nullptr;
+            }
+
             response.setContentType(content_type);
             response.add("X-ClickHouse-Query-Id", current_query_id);
             response.add("X-ClickHouse-Format", format);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix "session is locked" error in consecutive http requests


Detailed description / Documentation draft:

We found this problem in stress testing. Our http client send several requests sequentially and ClickHouse reports "session is locked by a concurrent client."
Occasionally, `session->release();` will be called later than the moment that the http response finishes and the client moves on to the next request.