### PR TITLE
[mergeTree]: fail fast if max_rows_to_read limit exceeded on parts scan

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -606,11 +606,14 @@ Pipes MergeTreeDataSelectExecutor::readFromParts(
                 if (settings.read_overflow_mode == OverflowMode::THROW && settings.max_rows_to_read)
                 {
                     /// Fail fast if estimated number of rows to read exceeds the limit
-                    size_t total_rows_estimate = total_rows.fetch_add(ranges.getRowsCount());
+                    auto current_rows_estimate = ranges.getRowsCount();
+                    size_t prev_total_rows_estimate = total_rows.fetch_add(current_rows_estimate);
+                    size_t total_rows_estimate = current_rows_estimate + prev_total_rows_estimate;
                     if (total_rows_estimate > settings.max_rows_to_read)
                         throw Exception(
-                            "Limit for rows exceeded, max rows: " + formatReadableQuantity(settings.max_rows_to_read)
-                            + ", current rows: " + formatReadableQuantity(total_rows_estimate),
+                            "Limit for rows (controlled by 'max_rows_to_read' setting) exceeded, max rows: "
+                            + formatReadableQuantity(settings.max_rows_to_read)
+                            + ", estimated rows to read (at least): " + formatReadableQuantity(total_rows_estimate),
                             ErrorCodes::TOO_MANY_ROWS);
                 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fail fast if `max_rows_to_read` limit is exceeded on parts scan. The motivation behind this change is to skip ranges scan for all selected parts if it is clear that `max_rows_to_read` is already exceeded. The change is quite noticeable for queries over big number of parts.


Detailed description / Documentation draft:

We heavily rely on `max_rows_to_read` limit in our systems and use limit exceptions from CH to decide what to do next: try different table, host, whatever. Row limit is especially important because these limits are evaluated by ClickHouse before any data is read from disk (using only the data from the indexes in-memory). But sometimes we observe significant delays for queries that expected to fail immediately (selecting big time range or too many PK entries), which is unexpected. We also noticed that "delay" before we get exception depends on number of parts query selects. Further investigation discovered that delay caused by fetching ranges for selected parts even if already fetched data is enough to throw an exception.

The change does exactly this - checks the `max_rows_to_read` during the marks and ranges fetch and fails immediately after number of rows exceeds the limit without waiting for all parts to complete.

