### PR TITLE
Do not optimize any(arrayJoin()) -> arrayJoin() under optimize_move_functions_out_of_any

### DIFF
--- a/tests/queries/0_stateless/01322_any_input_optimize.reference
+++ b/tests/queries/0_stateless/01322_any_input_optimize.reference
@@ -28,3 +28,5 @@ SELECT
     x
 FROM numbers(1, 2)
 6	6
+arrayJoin
+0	[]

--- a/tests/queries/0_stateless/01322_any_input_optimize.sql
+++ b/tests/queries/0_stateless/01322_any_input_optimize.sql
@@ -30,3 +30,6 @@ ANALYZE SELECT anyLast(number * 3) AS x, x FROM numbers(1, 2);
 SELECT anyLast(number * 3) AS x, x FROM numbers(1, 2);
 
 SELECT any(anyLast(number)) FROM numbers(1); -- { serverError 184 }
+
+SELECT 'arrayJoin';
+SELECT *, any(arrayJoin([[], []])) FROM numbers(1) GROUP BY number;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not optimize any(arrayJoin()) -> arrayJoin() under optimize_move_functions_out_of_any

Detailed description / Documentation draft:
Otherwise the following query will be optimized incorrectly:

    SELECT
        *,
        any(arrayJoin([[], []]))
    FROM numbers(1)
    GROUP BY number

And the result will be:

    ┌─number─┬─arrayJoin(array(array(), array()))─┐
    │      0 │ []                                 │
    │      0 │ []                                 │
    └────────┴────────────────────────────────────┘

While should be:

    ┌─number─┬─any(arrayJoin(array(array(), array())))─┐
    │      0 │ []                                      │
    └────────┴─────────────────────────────────────────┘

Refs: #11529
Refs: #12664
Cc: @4ertus2 
Cc: @kamalov-ruslan 