### PR TITLE
Reset signal handlers just before closing signal pipe to avoid EBADF after

### DIFF
--- a/base/daemon/BaseDaemon.h
+++ b/base/daemon/BaseDaemon.h
@@ -192,6 +192,8 @@ protected:
     Poco::Util::AbstractConfiguration * last_configuration = nullptr;
 
     String build_id_info;
+
+    std::vector<int> handled_signals;
 };
 
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

stack trace in `<details>`:

<details>

```
    (gdb) bt
    0  0x00007ffff7dda355 in raise () from /usr/lib/libc.so.6
    1  0x00007ffff7dc3853 in abort () from /usr/lib/libc.so.6
    2  0x0000000013a78180 in abort_message (format=format@entry=0x5781e10 "terminate_handler unexpectedly threw an exception") at abort_message.cpp:76
    3  0x0000000013a899ff in std::__terminate (func=<optimized out>) at cxa_handlers.cpp:67
    4  0x0000000013a771a1 in __cxxabiv1::call_terminate (native_exception=native_exception@entry=true, unwind_exception=unwind_exception@entry=0x7ffff70e9060) at cxa_personality.cpp:323
    5  0x0000000013a77669 in __cxxabiv1::scan_eh_tab (results=..., actions=<optimized out>, native_exception=native_exception@entry=true, unwind_exception=0x7ffff70e9060, context=context@entry=0x7fffffffc3a0) at cxa_personality.cpp:887
    6  0x0000000013a77bde in __cxxabiv1::__gxx_personality_v0 (version=<optimized out>, actions=<optimized out>, exceptionClass=<optimized out>, unwind_exception=0x7ffff70e9060, context=0x7fffffffc3a0) at cxa_personality.cpp:969
    7  0x0000000013a962d7 in unwind_phase1 (exception_object=0x7ffff70e9060, cursor=0x7fffffffc3a0, uc=0x7fffffffc2f0) at UnwindLevel1.c:98
    8  _Unwind_RaiseException (exception_object=exception_object@entry=0x7ffff70e9060) at UnwindLevel1.c:363
    9  0x0000000013a8929b in __cxxabiv1::__cxa_rethrow () at cxa_exception.cpp:607
    10 0x000000000f170ad2 in DB::WriteBuffer::next (this=0x7fffffffc510) at WriteBuffer.h:52
    11 writeSignalIDtoSignalPipe (sig=<optimized out>) at BaseDaemon.cpp:111
    12 <signal handler called>
    13 0x00007ffff7e9895b in munmap () from /usr/lib/libc.so.6
    14 0x00007ffff7f7e255 in free_stacks () from /usr/lib/libpthread.so.0
    15 0x00007ffff7f7e6aa in __deallocate_stack () from /usr/lib/libpthread.so.0
    16 0x00007ffff7f80898 in __pthread_clockjoin_ex () from /usr/lib/libpthread.so.0
    17 0x0000000013a759f7 in std::__1::__libcpp_thread_join (__t=0x7fff0aa2b090) at __threading_support:409
    18 std::__1::thread::join (this=this@entry=0x7fff0aa2b090) at thread.cpp:56
    19 0x000000000a4c9399 in ThreadPoolImpl<std::__1::thread>::finalize (this=this@entry=0x7ffff7053900) at list:355
    20 0x000000000a4c9426 in ThreadPoolImpl<std::__1::thread>::~ThreadPoolImpl (this=0x7ffff7053900, __in_chrg=<optimized out>) at ThreadPool.cpp:172
    21 0x000000000a4c8a9c in GlobalThreadPool::~GlobalThreadPool (this=0x7ffff7053900, __in_chrg=<optimized out>) at ThreadPool.h:132
    22 std::__1::default_delete<GlobalThreadPool>::operator() (__ptr=0x7ffff7053900, this=<optimized out>) at memory:2363
    23 std::__1::unique_ptr<GlobalThreadPool, std::__1::default_delete<GlobalThreadPool> >::reset (__p=0x0, this=<optimized out>) at memory:2618
    24 std::__1::unique_ptr<GlobalThreadPool, std::__1::default_delete<GlobalThreadPool> >::~unique_ptr (this=<optimized out>, __in_chrg=<optimized out>) at memory:2572
    25 0x00007ffff7ddcc57 in __run_exit_handlers () from /usr/lib/libc.so.6
    26 0x00007ffff7ddcdfe in exit () from /usr/lib/libc.so.6
    27 0x00007ffff7dc5009 in __libc_start_main () from /usr/lib/libc.so.6
    28 0x000000000a48702e in _start () at new:340
```

</details>