### PR TITLE
Redis dictionary support for simple Redis requirepass authorization

### DIFF
--- a/docker/test/integration/runner/compose/docker_compose_redis.yml
+++ b/docker/test/integration/runner/compose/docker_compose_redis.yml
@@ -5,3 +5,4 @@ services:
         restart: always
         ports:
           - 6380:6379
+        command: redis-server --requirepass "clickhouse"

--- a/src/Dictionaries/RedisDictionarySource.cpp
+++ b/src/Dictionaries/RedisDictionarySource.cpp
@@ -51,12 +51,14 @@ namespace DB
             const String & host_,
             UInt16 port_,
             UInt8 db_index_,
+            const String & password_,
             RedisStorageType storage_type_,
             const Block & sample_block_)
             : dict_struct{dict_struct_}
             , host{host_}
             , port{port_}
             , db_index{db_index_}
+            , password{password_}
             , storage_type{storage_type_}
             , sample_block{sample_block_}
             , client{std::make_shared<Poco::Redis::Client>(host, port)}
@@ -77,16 +79,22 @@ namespace DB
                                 ErrorCodes::INVALID_CONFIG_PARAMETER};
             // suppose key[0] is primary key, key[1] is secondary key
         }
+        if (!password.empty())
+        {
+            RedisCommand command("AUTH");
+            command << password;
+            String reply = client->execute<String>(command);
+            if (reply != "OK")
+                throw Exception{"Authentication failed with reason "
+                     + reply, ErrorCodes::INTERNAL_REDIS_ERROR};
+        }
 
         if (db_index != 0)
         {
             RedisCommand command("SELECT");
-            // Use poco's Int64, because it is defined as long long, and on
-            // MacOS, for the purposes of template instantiation, this type is
-            // distinct from int64_t, which is our Int64.
-            command << static_cast<Poco::Int64>(db_index);
+            command << std::to_string(db_index);
             String reply = client->execute<String>(command);
-            if (reply != "+OK\r\n")
+            if (reply != "OK")
                 throw Exception{"Selecting database with index " + DB::toString(db_index)
                     + " failed with reason " + reply, ErrorCodes::INTERNAL_REDIS_ERROR};
         }
@@ -103,6 +111,7 @@ namespace DB
             config_.getString(config_prefix_ + ".host"),
             config_.getUInt(config_prefix_ + ".port"),
             config_.getUInt(config_prefix_ + ".db_index", 0),
+            config_.getString(config_prefix_ + ".password",""),
             parseStorageType(config_.getString(config_prefix_ + ".storage_type", "")),
             sample_block_)
     {
@@ -114,6 +123,7 @@ namespace DB
                                     other.host,
                                     other.port,
                                     other.db_index,
+                                    other.password,
                                     other.storage_type,
                                     other.sample_block}
     {

--- a/src/Dictionaries/RedisDictionarySource.h
+++ b/src/Dictionaries/RedisDictionarySource.h
@@ -41,6 +41,7 @@ namespace ErrorCodes
                 const std::string & host,
                 UInt16 port,
                 UInt8 db_index,
+                const std::string & password,
                 RedisStorageType storage_type,
                 const Block & sample_block);
 
@@ -91,6 +92,7 @@ namespace ErrorCodes
         const std::string host;
         const UInt16 port;
         const UInt8 db_index;
+        const std::string password;
         const RedisStorageType storage_type;
         Block sample_block;
 

--- a/tests/integration/test_dictionaries_all_layouts_and_sources/external_sources.py
+++ b/tests/integration/test_dictionaries_all_layouts_and_sources/external_sources.py
@@ -483,23 +483,27 @@ class SourceRedis(ExternalSource):
             name, internal_hostname, internal_port, docker_hostname, docker_port, user, password
         )
         self.storage_type = storage_type
+        self.db_index = 1
 
     def get_source_str(self, table_name):
         return '''
             <redis>
                 <host>{host}</host>
                 <port>{port}</port>
-                <db_index>0</db_index>
+                <password>{password}</password>
+                <db_index>{db_index}</db_index>
                 <storage_type>{storage_type}</storage_type>
             </redis>
         '''.format(
             host=self.docker_hostname,
             port=self.docker_port,
+            password=self.password,
             storage_type=self.storage_type,  # simple or hash_map
+            db_index=self.db_index,
         )
 
     def prepare(self, structure, table_name, cluster):
-        self.client = redis.StrictRedis(host=self.internal_hostname, port=self.internal_port)
+        self.client = redis.StrictRedis(host=self.internal_hostname, port=self.internal_port, db=self.db_index, password=self.password or None)
         self.prepared = True
         self.ordered_names = structure.get_ordered_names()
 
@@ -524,7 +528,6 @@ class SourceRedis(ExternalSource):
         ):
             return True
         return False
-
 
 class SourceAerospike(ExternalSource):
     def __init__(self, name, internal_hostname, internal_port,

--- a/tests/integration/test_dictionaries_all_layouts_and_sources/test.py
+++ b/tests/integration/test_dictionaries_all_layouts_and_sources/test.py
@@ -134,8 +134,8 @@ DICTIONARIES = []
 
 # Key-value dictionaries with only one possible field for key
 SOURCES_KV = [
-    SourceRedis("RedisSimple", "localhost", "6380", "redis1", "6379", "", "", storage_type="simple"),
-    SourceRedis("RedisHash", "localhost", "6380", "redis1", "6379", "", "", storage_type="hash_map"),
+    SourceRedis("RedisSimple", "localhost", "6380", "redis1", "6379", "", "clickhouse", storage_type="simple"),
+    SourceRedis("RedisHash", "localhost", "6380", "redis1", "6379", "", "clickhouse", storage_type="hash_map"),
 ]
 
 DICTIONARIES_KV = []


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
-  Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added Redis requirepass authorization

Detailed description / Documentation draft: 

Adds support for simple Redis requirepass authorization (but does not include support for Redis 6 ACL) and fixes select a non-default db index. This error causes the redis ERR Protocol error: expected '$', got ':', as well as the return value is not checked correctly (checked +OK\r\n instead of the returned value by poco library OK)

