### PR TITLE
Fix cassandra build on macos

### DIFF
--- a/cmake/find/cassandra.cmake
+++ b/cmake/find/cassandra.cmake
@@ -1,6 +1,10 @@
 option(ENABLE_CASSANDRA "Enable Cassandra" ${ENABLE_LIBRARIES})
 
 if (ENABLE_CASSANDRA)
+    if (APPLE)
+        SET(CMAKE_MACOSX_RPATH ON)
+    endif()
+
     if (NOT EXISTS "${ClickHouse_SOURCE_DIR}/contrib/libuv")
         message (ERROR "submodule contrib/libuv is missing. to fix try run: \n git submodule update --init --recursive")
     elseif (NOT EXISTS "${ClickHouse_SOURCE_DIR}/contrib/cassandra")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

FIx cassandra build on Mac OS

Detailed description / Documentation draft:

```
CMake Warning (dev):
  Policy CMP0042 is not set: MACOSX_RPATH is enabled by default.  Run "cmake
  --help-policy CMP0042" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  MACOSX_RPATH is not specified for the following targets:

   cassandra


```
By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.
