### PR TITLE
passwd and group location error

### DIFF
--- a/debian/clickhouse-server.init
+++ b/debian/clickhouse-server.init
@@ -122,11 +122,11 @@ initdb()
         CLICKHOUSE_DATADIR_FROM_CONFIG=$CLICKHOUSE_DATADIR
     fi
 
-    if ! getent group ${CLICKHOUSE_USER} >/dev/null; then
+    if ! getent passwd ${CLICKHOUSE_USER} >/dev/null; then
         echo "Can't chown to non-existing user ${CLICKHOUSE_USER}"
         return
     fi
-    if ! getent passwd ${CLICKHOUSE_GROUP} >/dev/null; then
+    if ! getent group ${CLICKHOUSE_GROUP} >/dev/null; then
         echo "Can't chown to non-existing group ${CLICKHOUSE_GROUP}"
         return
     fi


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix incorrect message in `clickhouse-server.init` while checking user and group.


There is no problem when the user is the same as the group by default. When the user and group are different, there will be a bug here.
