### PR TITLE
ISSUES-4006 try fix test failure after merge

### DIFF
--- a/src/Storages/StorageMaterializeMySQL.cpp
+++ b/src/Storages/StorageMaterializeMySQL.cpp
@@ -85,7 +85,10 @@ Pipe StorageMaterializeMySQL::read(
         auto syntax = TreeRewriter(context).analyze(expressions, pipe_header.getNamesAndTypesList());
         ExpressionActionsPtr expression_actions = ExpressionAnalyzer(expressions, syntax, context).getActions(true);
 
-        pipe.addTransform(std::make_shared<FilterTransform>(pipe.getHeader(), expression_actions, filter_column_name, false));
+        pipe.addSimpleTransform([&](const Block & header)
+        {
+            return std::make_shared<FilterTransform>(header, expression_actions, filter_column_name, false);
+        });
     }
 
     return pipe;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)



Detailed description / Documentation draft:
cc: @alexey-milovidov @KochetovNicolai 

https://github.com/ClickHouse/ClickHouse/pull/13337/files
https://github.com/ClickHouse/ClickHouse/commit/7a6e0deea5cf2d4077a3074a1a643e44d27de943

Integration test failure in master
```
          raise QueryRuntimeException('Client failed! Return code: {}, stderr: {}'.format(self.process.returncode, stderr))
E           QueryRuntimeException: Client failed! Return code: 49, stderr: Received exception from server (version 20.8.1):
E           Code: 49. DB::Exception: Received from 172.19.0.2:9000. DB::Exception: Cannot add transform FilterTransform to Pipes because Processor has 1 input ports, but 16 expected. Stack trace:
E           
E           0. Poco::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) @ 0x12a77bf0 in /usr/bin/clickhouse
E           1. DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) @ 0xa4a4d8d in /usr/bin/clickhouse
E           2. ? @ 0x102609fb in /usr/bin/clickhouse
E           3. DB::Pipe::addTransform(std::__1::shared_ptr<DB::IProcessor>) @ 0x1025a544 in /usr/bin/clickhouse
E           4. DB::StorageMaterializeMySQL::read(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, std::__1::shared_ptr<DB::StorageInMemoryMetadata const> const&, DB::SelectQueryInfo const&, DB::Context const&, DB::QueryProcessingStage::Enum, unsigned long, unsigned int) @ 0xfd4faa4 in /usr/bin/clickhouse
E           5. DB::ReadFromStorageStep::ReadFromStorageStep(std::__1::shared_ptr<DB::RWLockImpl::LockHolderImpl>, std::__1::shared_ptr<DB::StorageInMemoryMetadata const>&, DB::SelectQueryOptions, std::__1::shared_ptr<DB::IStorage>, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, DB::SelectQueryInfo const&, std::__1::shared_ptr<DB::Context>, DB::QueryProcessingStage::Enum, unsigned long, unsigned long) @ 0x1052adfa in /usr/bin/clickhouse
E           6. DB::InterpreterSelectQuery::executeFetchColumns(DB::QueryProcessingStage::Enum, DB::QueryPlan&, std::__1::shared_ptr<DB::PrewhereInfo> const&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) @ 0xf88cf41 in /usr/bin/clickhouse
E           7. DB::InterpreterSelectQuery::executeImpl(DB::QueryPlan&, std::__1::shared_ptr<DB::IBlockInputStream> const&, std::__1::optional<DB::Pipe>) @ 0xf890e7a in /usr/bin/clickhouse
E           8. DB::InterpreterSelectQuery::buildQueryPlan(DB::QueryPlan&) @ 0xf892404 in /usr/bin/clickhouse
E           9. DB::InterpreterSelectWithUnionQuery::buildQueryPlan(DB::QueryPlan&) @ 0xfa05e98 in /usr/bin/clickhouse
E           10. DB::InterpreterSelectWithUnionQuery::execute() @ 0xfa06067 in /usr/bin/clickhouse
E           11. ? @ 0xfb8b323 in /usr/bin/clickhouse
E           12. DB::executeQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::Context&, bool, DB::QueryProcessingStage::Enum, bool) @ 0xfb8cd5f in /usr/bin/clickhouse
E           13. DB::TCPHandler::runImpl() @ 0x1020a3d5 in /usr/bin/clickhouse
E           14. DB::TCPHandler::run() @ 0x1020b140 in /usr/bin/clickhouse
E           15. Poco::Net::TCPServerConnection::start() @ 0x12995a1b in /usr/bin/clickhouse
E           16. Poco::Net::TCPServerDispatcher::run() @ 0x12995eab in /usr/bin/clickhouse
E           17. Poco::PooledThread::run() @ 0x12b149d6 in /usr/bin/clickhouse
E           18. Poco::ThreadImpl::runnableEntry(void*) @ 0x12b0fdd0 in /usr/bin/clickhouse
E           19. start_thread @ 0x9669 in /usr/lib/x86_64-linux-gnu/libpthread-2.30.so
E           20. clone @ 0x1222b3 in /usr/lib/x86_64-linux-gnu/libc-2.30.so
```