### PR TITLE
return 200 when replicas status is ok and verbose = 1

### DIFF
--- a/src/Server/ReplicasStatusHandler.cpp
+++ b/src/Server/ReplicasStatusHandler.cpp
@@ -75,14 +75,16 @@ void ReplicasStatusHandler::handleRequest(Poco::Net::HTTPServerRequest & request
         const auto & config = context.getConfigRef();
         setResponseDefaultHeaders(response, config.getUInt("keep_alive_timeout", 10));
 
-        if (!ok) {
+        if (!ok)
+        {
             response.setStatusAndReason(Poco::Net::HTTPResponse::HTTP_SERVICE_UNAVAILABLE);
             verbose = true;
         }
 
         if (verbose)
             response.send() << message.rdbuf();
-        else {
+        else
+        {
             const char * data = "Ok.\n";
             response.sendBuffer(data, strlen(data));
         }

--- a/src/Server/ReplicasStatusHandler.cpp
+++ b/src/Server/ReplicasStatusHandler.cpp
@@ -75,15 +75,16 @@ void ReplicasStatusHandler::handleRequest(Poco::Net::HTTPServerRequest & request
         const auto & config = context.getConfigRef();
         setResponseDefaultHeaders(response, config.getUInt("keep_alive_timeout", 10));
 
-        if (ok && !verbose)
-        {
+        if (!ok) {
+            response.setStatusAndReason(Poco::Net::HTTPResponse::HTTP_SERVICE_UNAVAILABLE);
+            verbose = true;
+        }
+
+        if (verbose)
+            response.send() << message.rdbuf();
+        else {
             const char * data = "Ok.\n";
             response.sendBuffer(data, strlen(data));
-        }
-        else
-        {
-            response.setStatusAndReason(Poco::Net::HTTPResponse::HTTP_SERVICE_UNAVAILABLE);
-            response.send() << message.rdbuf();
         }
     }
     catch (...)

--- a/tests/integration/test_http_handlers_config/test.py
+++ b/tests/integration/test_http_handlers_config/test.py
@@ -125,7 +125,7 @@ def test_defaults_http_handlers():
         assert 'Ok.\n' == cluster.instance.http_request('replicas_status', method='get').content
 
         assert 200 == cluster.instance.http_request('replicas_status?verbose=1', method='get').status_code
-        assert '\n' == cluster.instance.http_request('replicas_status?verbose=1', method='get').content
+        assert '' == cluster.instance.http_request('replicas_status?verbose=1', method='get').content
 
         assert 200 == cluster.instance.http_request('?query=SELECT+1', method='GET').status_code
         assert '1\n' == cluster.instance.http_request('?query=SELECT+1', method='GET').content

--- a/tests/integration/test_http_handlers_config/test.py
+++ b/tests/integration/test_http_handlers_config/test.py
@@ -122,7 +122,7 @@ def test_defaults_http_handlers():
         assert 'Ok.\n' == cluster.instance.http_request('ping', method='GET').content
 
         assert 200 == cluster.instance.http_request('replicas_status', method='get').status_code
-        assert 'ok.\n' == cluster.instance.http_request('replicas_status', method='get').content
+        assert 'Ok.\n' == cluster.instance.http_request('replicas_status', method='get').content
 
         assert 200 == cluster.instance.http_request('replicas_status?verbose=1', method='get').status_code
         assert '\n' == cluster.instance.http_request('replicas_status?verbose=1', method='get').content

--- a/tests/integration/test_http_handlers_config/test.py
+++ b/tests/integration/test_http_handlers_config/test.py
@@ -121,8 +121,11 @@ def test_defaults_http_handlers():
         assert 200 == cluster.instance.http_request('ping', method='GET').status_code
         assert 'Ok.\n' == cluster.instance.http_request('ping', method='GET').content
 
-        assert 200 == cluster.instance.http_request('replicas_status', method='GET').status_code
-        assert 'Ok.\n' == cluster.instance.http_request('replicas_status', method='GET').content
+        assert 200 == cluster.instance.http_request('replicas_status', method='get').status_code
+        assert 'ok.\n' == cluster.instance.http_request('replicas_status', method='get').content
+
+        assert 200 == cluster.instance.http_request('replicas_status?verbose=1', method='get').status_code
+        assert 'ok.\n' == cluster.instance.http_request('replicas_status?verbose=1', method='get').content
 
         assert 200 == cluster.instance.http_request('?query=SELECT+1', method='GET').status_code
         assert '1\n' == cluster.instance.http_request('?query=SELECT+1', method='GET').content

--- a/tests/integration/test_http_handlers_config/test.py
+++ b/tests/integration/test_http_handlers_config/test.py
@@ -125,7 +125,7 @@ def test_defaults_http_handlers():
         assert 'ok.\n' == cluster.instance.http_request('replicas_status', method='get').content
 
         assert 200 == cluster.instance.http_request('replicas_status?verbose=1', method='get').status_code
-        assert 'ok.\n' == cluster.instance.http_request('replicas_status?verbose=1', method='get').content
+        assert '\n' == cluster.instance.http_request('replicas_status?verbose=1', method='get').content
 
         assert 200 == cluster.instance.http_request('?query=SELECT+1', method='GET').status_code
         assert '1\n' == cluster.instance.http_request('?query=SELECT+1', method='GET').content


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

A previous change made /replicas_status endpoint return 500 when verbose=1 even when the replication lag is 0

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes /replicas_status endpoint response status code when verbose=1
