### PR TITLE
Fix compilation with gcc10 and libstdc++

### DIFF
--- a/src/Core/MySQLReplication.cpp
+++ b/src/Core/MySQLReplication.cpp
@@ -59,7 +59,7 @@ namespace MySQLReplication
         out << "Binlog Version: " << this->binlog_version << std::endl;
         out << "Server Version: " << this->server_version << std::endl;
         out << "Create Timestamp: " << this->create_timestamp << std::endl;
-        out << "Event Header Len: " << this->event_header_length << std::endl;
+        out << "Event Header Len: " << std::to_string(this->event_header_length) << std::endl;
     }
 
     /// https://dev.mysql.com/doc/internals/en/rotate-event.html
@@ -119,7 +119,7 @@ namespace MySQLReplication
         header.dump(out);
         out << "Thread ID: " << this->thread_id << std::endl;
         out << "Execution Time: " << this->exec_time << std::endl;
-        out << "Schema Len: " << this->schema_len << std::endl;
+        out << "Schema Len: " << std::to_string(this->schema_len) << std::endl;
         out << "Error Code: " << this->error_code << std::endl;
         out << "Status Len: " << this->status_len << std::endl;
         out << "Schema: " << this->schema << std::endl;
@@ -239,14 +239,14 @@ namespace MySQLReplication
         header.dump(out);
         out << "Table ID: " << this->table_id << std::endl;
         out << "Flags: " << this->flags << std::endl;
-        out << "Schema Len: " << this->schema_len << std::endl;
+        out << "Schema Len: " << std::to_string(this->schema_len) << std::endl;
         out << "Schema: " << this->schema << std::endl;
-        out << "Table Len: " << this->table_len << std::endl;
+        out << "Table Len: " << std::to_string(this->table_len) << std::endl;
         out << "Table: " << this->table << std::endl;
         out << "Column Count: " << this->column_count << std::endl;
         for (auto i = 0U; i < column_count; i++)
         {
-            out << "Column Type [" << i << "]: " << column_type[i] << ", Meta: " << column_meta[i] << std::endl;
+            out << "Column Type [" << i << "]: " << std::to_string(column_type[i]) << ", Meta: " << column_meta[i] << std::endl;
         }
         out << "Null Bitmap: " << this->null_bitmap << std::endl;
     }

--- a/src/Interpreters/MySQL/InterpretersMySQLDDLQuery.cpp
+++ b/src/Interpreters/MySQL/InterpretersMySQLDDLQuery.cpp
@@ -351,7 +351,7 @@ ASTs InterpreterCreateImpl::getRewrittenQueries(
         column_declaration->default_expression = std::make_shared<ASTLiteral>(default_value);
         column_declaration->children.emplace_back(column_declaration->type);
         column_declaration->children.emplace_back(column_declaration->default_expression);
-        return std::move(column_declaration);
+        return column_declaration;
     };
 
     /// Add _sign and _version column.

--- a/src/Interpreters/MySQL/InterpretersMySQLDDLQuery.cpp
+++ b/src/Interpreters/MySQL/InterpretersMySQLDDLQuery.cpp
@@ -344,7 +344,7 @@ ASTs InterpreterCreateImpl::getRewrittenQueries(
 
     const auto & create_materialized_column_declaration = [&](const String & name, const String & type, const auto & default_value)
     {
-        const auto column_declaration = std::make_shared<ASTColumnDeclaration>();
+        auto column_declaration = std::make_shared<ASTColumnDeclaration>();
         column_declaration->name = name;
         column_declaration->type = makeASTFunction(type);
         column_declaration->default_specifier = "MATERIALIZED";


### PR DESCRIPTION
- Fix `-Wpessimizing-move` in `InterpretersMySQLDDLQuery`
- Fix `performance-no-automatic-move` in `InterpretersMySQLDDLQuery`
- Fix compilation `MySQLReplication` with gcc10 and libstdc++ (`operator<<(char8_t)` is deleted)

Changelog category (leave one):
- Not for changelog (changelog entry is not required)