### PR TITLE
Fix logging Settings.Names/Values when log_queries_min_type > QUERY_START

### DIFF
--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -474,13 +474,16 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
             bool log_queries = settings.log_queries && !internal;
 
             /// Log into system table start of query execution, if need.
-            if (log_queries && elem.type >= settings.log_queries_min_type)
+            if (log_queries)
             {
                 if (settings.log_query_settings)
                     elem.query_settings = std::make_shared<Settings>(context.getSettingsRef());
 
-                if (auto query_log = context.getQueryLog())
-                    query_log->add(elem);
+                if (elem.type >= settings.log_queries_min_type)
+                {
+                    if (auto query_log = context.getQueryLog())
+                        query_log->add(elem);
+                }
             }
 
             /// Common code for finish and exception callbacks

--- a/tests/queries/0_stateless/01231_log_queries_min_type.reference
+++ b/tests/queries/0_stateless/01231_log_queries_min_type.reference
@@ -1,5 +1,5 @@
 01231_log_queries_min_type/QUERY_START
 2
 01231_log_queries_min_type/EXCEPTION_BEFORE_START
-2
-3
+0
+1

--- a/tests/queries/0_stateless/01231_log_queries_min_type.reference
+++ b/tests/queries/0_stateless/01231_log_queries_min_type.reference
@@ -3,3 +3,4 @@
 01231_log_queries_min_type/EXCEPTION_BEFORE_START
 0
 1
+1

--- a/tests/queries/0_stateless/01231_log_queries_min_type.sql
+++ b/tests/queries/0_stateless/01231_log_queries_min_type.sql
@@ -2,14 +2,14 @@ set log_queries=1;
 
 select '01231_log_queries_min_type/QUERY_START';
 system flush logs;
-select count() from system.query_log where query like '%01231_log_queries_min_type/%' and query not like '%system.query_log%' and event_date = today() and event_time >= now() - interval 1 minute;
+select count() from system.query_log where query like '%01231_log_queries_min_type/QUERY_START%' and query not like '%system.query_log%' and event_date = today() and event_time >= now() - interval 1 minute;
 
 set log_queries_min_type='EXCEPTION_BEFORE_START';
 select '01231_log_queries_min_type/EXCEPTION_BEFORE_START';
 system flush logs;
-select count() from system.query_log where query like '%01231_log_queries_min_type/%' and query not like '%system.query_log%' and event_date = today() and event_time >= now() - interval 1 minute;
+select count() from system.query_log where query like '%01231_log_queries_min_type/EXCEPTION_BEFORE_START%' and query not like '%system.query_log%' and event_date = today() and event_time >= now() - interval 1 minute;
 
 set log_queries_min_type='EXCEPTION_WHILE_PROCESSING';
-select '01231_log_queries_min_type/', max(number) from system.numbers limit 1e6 settings max_rows_to_read='100K'; -- { serverError 158; }
+select '01231_log_queries_min_type/EXCEPTION_WHILE_PROCESSING', max(number) from system.numbers limit 1e6 settings max_rows_to_read='100K'; -- { serverError 158; }
 system flush logs;
-select count() from system.query_log where query like '%01231_log_queries_min_type/%' and query not like '%system.query_log%' and event_date = today() and event_time >= now() - interval 1 minute;
+select count() from system.query_log where query like '%01231_log_queries_min_type/EXCEPTION_WHILE_PROCESSING%' and query not like '%system.query_log%' and event_date = today() and event_time >= now() - interval 1 minute and type = 'ExceptionWhileProcessing';

--- a/tests/queries/0_stateless/01231_log_queries_min_type.sql
+++ b/tests/queries/0_stateless/01231_log_queries_min_type.sql
@@ -9,7 +9,18 @@ select '01231_log_queries_min_type/EXCEPTION_BEFORE_START';
 system flush logs;
 select count() from system.query_log where query like '%01231_log_queries_min_type/EXCEPTION_BEFORE_START%' and query not like '%system.query_log%' and event_date = today() and event_time >= now() - interval 1 minute;
 
+set max_rows_to_read='100K';
 set log_queries_min_type='EXCEPTION_WHILE_PROCESSING';
-select '01231_log_queries_min_type/EXCEPTION_WHILE_PROCESSING', max(number) from system.numbers limit 1e6 settings max_rows_to_read='100K'; -- { serverError 158; }
+select '01231_log_queries_min_type/EXCEPTION_WHILE_PROCESSING', max(number) from system.numbers limit 1e6; -- { serverError 158; }
 system flush logs;
 select count() from system.query_log where query like '%01231_log_queries_min_type/EXCEPTION_WHILE_PROCESSING%' and query not like '%system.query_log%' and event_date = today() and event_time >= now() - interval 1 minute and type = 'ExceptionWhileProcessing';
+
+select '01231_log_queries_min_type w/ Settings/EXCEPTION_WHILE_PROCESSING', max(number) from system.numbers limit 1e6; -- { serverError 158; }
+system flush logs;
+select count() from system.query_log where
+    query like '%01231_log_queries_min_type w/ Settings/EXCEPTION_WHILE_PROCESSING%' and
+    query not like '%system.query_log%' and
+    event_date = today() and
+    event_time >= now() - interval 1 minute and
+    type = 'ExceptionWhileProcessing' and
+    has(Settings.Names, 'max_rows_to_read');


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix logging Settings.Names/Values when log_queries_min_type > QUERY_START

Refs: #10053