### PR TITLE
Fix fast test failure due to "Memory limit (for user) exceeded"

### DIFF
--- a/docker/test/fasttest/run.sh
+++ b/docker/test/fasttest/run.sh
@@ -158,6 +158,8 @@ TESTS_TO_SKIP=(
     01280_ssd_complex_key_dictionary
     00652_replicated_mutations_zookeeper
     01411_bayesian_ab_testing
+    01238_http_memory_tracking              # max_memory_usage_for_user can interfere another queries running concurrently
+    01281_group_by_limit_memory_tracking    # max_memory_usage_for_user can interfere another queries running concurrently
 )
 
 clickhouse-test -j 4 --no-long --testname --shard --zookeeper --skip ${TESTS_TO_SKIP[*]} 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee /test_output/test_log.txt


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

See 
https://clickhouse-test-reports.s3.yandex.net/0/360f4d93efeaf58be7bb1b832358055d05a639a5/fast_test/runlog.out.log
https://clickhouse-test-reports.s3.yandex.net/0/57eb912fa626de543851fb223552a7d1d3e9c520/fast_test/runlog.out.log
https://clickhouse-test-reports.s3.yandex.net/0/4af4d25db4aacb939f70f4af5c0967f6cd25f1c0/fast_test/runlog.out.log
https://clickhouse-test-reports.s3.yandex.net/0/ba5988dcf6f0bcdaff6cd86cc51e0f1566adea8c/fast_test/runlog.out.log

We faced this issue about four times in two weeks, that's really annoying.