### PR TITLE
Fix flaky test 00988_constraints_replication_zookeeper

### DIFF
--- a/tests/queries/0_stateless/00988_constraints_replication_zookeeper.sql
+++ b/tests/queries/0_stateless/00988_constraints_replication_zookeeper.sql
@@ -31,6 +31,11 @@ INSERT INTO replicated_constraints1 VALUES (10, 10);
 INSERT INTO replicated_constraints2 VALUES (10, 10);
 
 ALTER TABLE replicated_constraints1 ADD CONSTRAINT b_constraint CHECK b > 10;
+
+-- Otherwise "Metadata on replica is not up to date with common metadata in Zookeeper. Cannot alter." is possible.
+SYSTEM SYNC REPLICA replicated_constraints1;
+SYSTEM SYNC REPLICA replicated_constraints2;
+
 ALTER TABLE replicated_constraints2 ADD CONSTRAINT a_constraint CHECK a < 10;
 
 SYSTEM SYNC REPLICA replicated_constraints1;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://clickhouse-test-reports.s3.yandex.net/0/bb832f204c6ae49e7d8dc93ed5da9fe2c0ac2751/functional_stateless_tests_(release,_polymorphic_parts_enabled)/test_run.txt.out.log
