### PR TITLE
Better diagnostics in clickhouse-test

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -282,6 +282,10 @@ def run_tests_array(all_tests_with_params):
                             if args.stop and ('Connection refused' in stderr or 'Attempt to read after eof' in stderr) and not 'Received exception from server' in stderr:
                                 SERVER_DIED = True
 
+                            if os.path.isfile(stdout_file):
+                                print(", result:\n")
+                                print(open(stdout_file).read())
+
                         elif stderr:
                             failures += 1
                             failures_chain += 1


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://clickhouse-test-reports.s3.yandex.net/0/321d4ed64348f74a352827c8aac42fd596dac612/functional_stateless_tests_(release,_databaseatomic)/test_run.txt.out.log

```
2020-08-08 08:13:13 00463_long_sessions_in_http_interface:                                  [ FAIL ] 17.97 sec. - return code 1
```