### PR TITLE
Fix race condition in DROP DATABASE

### DIFF
--- a/src/Databases/DatabaseAtomic.cpp
+++ b/src/Databases/DatabaseAtomic.cpp
@@ -65,6 +65,7 @@ String DatabaseAtomic::getTableDataPath(const ASTCreateQuery & query) const
 
 void DatabaseAtomic::drop(const Context &)
 {
+    assert(tables.empty());
     try
     {
         Poco::File(path_to_metadata_symlink).remove();

--- a/src/Databases/DatabaseOnDisk.cpp
+++ b/src/Databases/DatabaseOnDisk.cpp
@@ -367,6 +367,7 @@ ASTPtr DatabaseOnDisk::getCreateDatabaseQuery() const
 
 void DatabaseOnDisk::drop(const Context & context)
 {
+    assert(tables.empty());
     Poco::File(context.getPath() + getDataPath()).remove(false);
     Poco::File(getMetadataPath()).remove(false);
 }

--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -521,7 +521,21 @@ DatabaseCatalog::updateDependency(const StorageID & old_from, const StorageID & 
 std::unique_ptr<DDLGuard> DatabaseCatalog::getDDLGuard(const String & database, const String & table)
 {
     std::unique_lock lock(ddl_guards_mutex);
-    return std::make_unique<DDLGuard>(ddl_guards[database], std::move(lock), table);
+    auto db_guard_iter = ddl_guards.try_emplace(database).first;
+    DatabaseGuard & db_guard = db_guard_iter->second;
+    return std::make_unique<DDLGuard>(db_guard.first, db_guard.second, std::move(lock), table);
+}
+
+std::unique_lock<std::shared_mutex> DatabaseCatalog::getExclusiveDDLGuardForDatabase(const String & database)
+{
+    DDLGuards::iterator db_guard_iter;
+    {
+        std::unique_lock lock(ddl_guards_mutex);
+        db_guard_iter = ddl_guards.try_emplace(database).first;
+        assert(db_guard_iter->second.first.count(""));
+    }
+    DatabaseGuard & db_guard = db_guard_iter->second;
+    return std::unique_lock{db_guard.second};
 }
 
 bool DatabaseCatalog::isDictionaryExist(const StorageID & table_id) const
@@ -791,17 +805,23 @@ String DatabaseCatalog::resolveDictionaryName(const String & name) const
 }
 
 
-DDLGuard::DDLGuard(Map & map_, std::unique_lock<std::mutex> guards_lock_, const String & elem)
-        : map(map_), guards_lock(std::move(guards_lock_))
+DDLGuard::DDLGuard(Map & map_, std::shared_mutex & db_mutex_, std::unique_lock<std::mutex> guards_lock_, const String & elem)
+        : map(map_), db_mutex(db_mutex_), guards_lock(std::move(guards_lock_))
 {
     it = map.emplace(elem, Entry{std::make_unique<std::mutex>(), 0}).first;
     ++it->second.counter;
     guards_lock.unlock();
     table_lock = std::unique_lock(*it->second.mutex);
+    bool is_database = elem.empty();
+    if (!is_database)
+        db_mutex.lock_shared();
 }
 
 DDLGuard::~DDLGuard()
 {
+    bool is_database = it->first.empty();
+    if (!is_database)
+        db_mutex.unlock_shared();
     guards_lock.lock();
     --it->second.counter;
     if (!it->second.counter)

--- a/src/Interpreters/DatabaseCatalog.h
+++ b/src/Interpreters/DatabaseCatalog.h
@@ -10,6 +10,7 @@
 #include <set>
 #include <unordered_map>
 #include <mutex>
+#include <shared_mutex>
 #include <array>
 #include <list>
 
@@ -49,11 +50,12 @@ public:
     /// NOTE: using std::map here (and not std::unordered_map) to avoid iterator invalidation on insertion.
     using Map = std::map<String, Entry>;
 
-    DDLGuard(Map & map_, std::unique_lock<std::mutex> guards_lock_, const String & elem);
+    DDLGuard(Map & map_, std::shared_mutex & db_mutex_, std::unique_lock<std::mutex> guards_lock_, const String & elem);
     ~DDLGuard();
 
 private:
     Map & map;
+    std::shared_mutex & db_mutex;
     Map::iterator it;
     std::unique_lock<std::mutex> guards_lock;
     std::unique_lock<std::mutex> table_lock;
@@ -113,6 +115,8 @@ public:
 
     /// Get an object that protects the table from concurrently executing multiple DDL operations.
     std::unique_ptr<DDLGuard> getDDLGuard(const String & database, const String & table);
+    /// Get an object that protects the database from concurrent DDL queries all tables in the database
+    std::unique_lock<std::shared_mutex> getExclusiveDDLGuardForDatabase(const String & database);
 
 
     void assertDatabaseExists(const String & database_name) const;
@@ -232,11 +236,13 @@ private:
     Poco::Logger * log;
 
     /// Do not allow simultaneous execution of DDL requests on the same table.
-    /// database -> object -> (mutex, counter), counter: how many threads are running a query on the table at the same time
+    /// database name -> database guard -> (table name mutex, counter),
+    /// counter: how many threads are running a query on the table at the same time
     /// For the duration of the operation, an element is placed here, and an object is returned,
     /// which deletes the element in the destructor when counter becomes zero.
     /// In case the element already exists, waits when query will be executed in other thread. See class DDLGuard below.
-    using DDLGuards = std::unordered_map<String, DDLGuard::Map>;
+    using DatabaseGuard = std::pair<DDLGuard::Map, std::shared_mutex>;
+    using DDLGuards = std::map<String, DatabaseGuard>;
     DDLGuards ddl_guards;
     /// If you capture mutex and ddl_guards_mutex, then you need to grab them strictly in this order.
     mutable std::mutex ddl_guards_mutex;

--- a/src/Interpreters/DatabaseCatalog.h
+++ b/src/Interpreters/DatabaseCatalog.h
@@ -35,7 +35,7 @@ using Dependencies = std::vector<StorageID>;
 /// Allows executing DDL query only in one thread.
 /// Puts an element into the map, locks tables's mutex, counts how much threads run parallel query on the table,
 /// when counter is 0 erases element in the destructor.
-/// If the element already exists in the map, waits, when ddl query will be finished in other thread.
+/// If the element already exists in the map, waits when ddl query will be finished in other thread.
 class DDLGuard
 {
 public:
@@ -235,7 +235,7 @@ private:
     /// database -> object -> (mutex, counter), counter: how many threads are running a query on the table at the same time
     /// For the duration of the operation, an element is placed here, and an object is returned,
     /// which deletes the element in the destructor when counter becomes zero.
-    /// In case the element already exists, waits, when query will be executed in other thread. See class DDLGuard below.
+    /// In case the element already exists, waits when query will be executed in other thread. See class DDLGuard below.
     using DDLGuards = std::unordered_map<String, DDLGuard::Map>;
     DDLGuards ddl_guards;
     /// If you capture mutex and ddl_guards_mutex, then you need to grab them strictly in this order.

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -196,6 +196,9 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
         out.close();
     }
 
+    /// We attach database before loading it's tables, so do not allow concurrent DDL queries
+    auto db_guard = DatabaseCatalog::instance().getExclusiveDDLGuardForDatabase(database_name);
+
     bool added = false;
     bool renamed = false;
     try
@@ -691,13 +694,13 @@ bool InterpreterCreateQuery::doCreateTable(ASTCreateQuery & create,
     bool need_add_to_database = !create.temporary;
     if (need_add_to_database)
     {
-        database = DatabaseCatalog::instance().getDatabase(create.database);
-        assertOrSetUUID(create, database);
-
         /** If the request specifies IF NOT EXISTS, we allow concurrent CREATE queries (which do nothing).
           * If table doesn't exist, one thread is creating table, while others wait in DDLGuard.
           */
         guard = DatabaseCatalog::instance().getDDLGuard(create.database, table_name);
+
+        database = DatabaseCatalog::instance().getDatabase(create.database);
+        assertOrSetUUID(create, database);
 
         /// Table can be created before or it can be created concurrently in another thread, while we were waiting in DDLGuard.
         if (database->isTableExist(table_name, context))

--- a/src/Interpreters/InterpreterDropQuery.cpp
+++ b/src/Interpreters/InterpreterDropQuery.cpp
@@ -243,6 +243,9 @@ BlockIO InterpreterDropQuery::executeToDatabase(const String & database_name, AS
                 }
             }
 
+            /// Protects from concurrent CREATE TABLE queries
+            auto db_guard = DatabaseCatalog::instance().getExclusiveDDLGuardForDatabase(database_name);
+
             auto * database_atomic = typeid_cast<DatabaseAtomic *>(database.get());
             if (!drop && database_atomic)
                 database_atomic->assertCanBeDetached(true);

--- a/tests/queries/0_stateless/01444_create_table_drop_database_race.sh
+++ b/tests/queries/0_stateless/01444_create_table_drop_database_race.sh
@@ -11,8 +11,8 @@ function thread1()
 {
     while true; do
 #        ${CLICKHOUSE_CLIENT} --query="SHOW TABLES FROM test_01444"
-        ${CLICKHOUSE_CLIENT} --query="DROP DATABASE IF EXISTS test_01444"
-        ${CLICKHOUSE_CLIENT} --query="CREATE DATABASE test_01444"
+        ${CLICKHOUSE_CLIENT} --query="DROP DATABASE IF EXISTS test_01444" 2>&1| grep -F "Code: " | grep -Fv "Code: 219"
+        ${CLICKHOUSE_CLIENT} --query="CREATE DATABASE IF NOT EXISTS test_01444"
     done
 }
 
@@ -30,5 +30,8 @@ TIMEOUT=10
 
 timeout $TIMEOUT bash -c thread1 &
 timeout $TIMEOUT bash -c thread2 &
+timeout $TIMEOUT bash -c thread2 &
 
 wait
+
+${CLICKHOUSE_CLIENT} --query="DROP DATABASE IF EXISTS test_01444"

--- a/tests/queries/0_stateless/01444_create_table_drop_database_race.sh
+++ b/tests/queries/0_stateless/01444_create_table_drop_database_race.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CUR_DIR"/../shell_config.sh
+
+# This test reproduces "Directory not empty" error in DROP DATABASE query.
+
+function thread1()
+{
+    while true; do
+#        ${CLICKHOUSE_CLIENT} --query="SHOW TABLES FROM test_01444"
+        ${CLICKHOUSE_CLIENT} --query="DROP DATABASE IF EXISTS test_01444"
+        ${CLICKHOUSE_CLIENT} --query="CREATE DATABASE test_01444"
+    done
+}
+
+function thread2()
+{
+    while true; do
+        ${CLICKHOUSE_CLIENT} --query="CREATE TABLE IF NOT EXISTS test_01444.t$RANDOM (x UInt8) ENGINE = MergeTree ORDER BY tuple()" 2>/dev/null
+    done
+}
+
+export -f thread1
+export -f thread2
+
+TIMEOUT=10
+
+timeout $TIMEOUT bash -c thread1 &
+timeout $TIMEOUT bash -c thread2 &
+
+wait


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed `Directory not empty` error when concurrently executing `DROP DATABASE` and `CREATE TABLE`
