### PR TITLE
Make a test slightly more reliable

### DIFF
--- a/tests/queries/0_stateless/01249_flush_interactive.sh
+++ b/tests/queries/0_stateless/01249_flush_interactive.sh
@@ -10,7 +10,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 #  unless the my-program will try to output a thousand more lines overflowing pipe buffer and terminating with Broken Pipe.
 # But if my program just output 5 (or slightly more) lines and hang up, the pipeline is not terminated.
 
-timeout 1 ${CLICKHOUSE_LOCAL} --max_execution_time 10 --query "SELECT DISTINCT number % 5 FROM system.numbers" ||:
+timeout 5 ${CLICKHOUSE_LOCAL} --max_execution_time 10 --query "SELECT DISTINCT number % 5 FROM system.numbers" ||:
 echo '---'
-timeout 1 ${CLICKHOUSE_CURL} -sS --no-buffer "${CLICKHOUSE_URL}&max_execution_time=10" --data-binary "SELECT DISTINCT number % 5 FROM system.numbers" ||:
+timeout 5 ${CLICKHOUSE_CURL} -sS --no-buffer "${CLICKHOUSE_URL}&max_execution_time=10" --data-binary "SELECT DISTINCT number % 5 FROM system.numbers" ||:
 echo '---'


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://clickhouse-test-reports.s3.yandex.net/13747/9e6d4802ac48639da327bdae8ae8c6759e59fd4d/functional_stateless_tests_(release,_databaseatomic)/test_run.txt.out.log