### PR TITLE
Fix flaky mutations test

### DIFF
--- a/tests/queries/0_stateless/01414_mutations_and_errors_zookeeper.sh
+++ b/tests/queries/0_stateless/01414_mutations_and_errors_zookeeper.sh
@@ -29,7 +29,7 @@ query_result=$($CLICKHOUSE_CLIENT --query="$check_query" 2>&1)
 while [ "$query_result" != "1" ]
 do
     query_result=$($CLICKHOUSE_CLIENT --query="$check_query" 2>&1)
-    sleep 0.5
+    sleep 0.1
 done
 
 $CLICKHOUSE_CLIENT --query "KILL MUTATION WHERE table='replicated_mutation_table' and database='$CLICKHOUSE_DATABASE' and mutation_id='0000000000'" &> /dev/null
@@ -42,9 +42,10 @@ done
 
 wait
 
+
 $CLICKHOUSE_CLIENT --query "ALTER TABLE replicated_mutation_table MODIFY COLUMN value UInt64 SETTINGS replication_alter_partitions_sync = 2" 2>&1 | grep -o "Cannot parse string 'Hello' as UInt64" | head -n 1 &
 
-check_query="SELECT count() FROM system.mutations WHERE table='replicated_mutation_table' and database='$CLICKHOUSE_DATABASE' and mutation_id='0000000001'"
+check_query="SELECT type = 'UInt64' FROM system.columns WHERE table='replicated_mutation_table' and database='$CLICKHOUSE_DATABASE' and name='value'"
 
 query_result=$($CLICKHOUSE_CLIENT --query="$check_query" 2>&1)
 
@@ -55,6 +56,9 @@ do
 done
 
 wait
+
+
+check_query="SELECT count() FROM system.mutations WHERE table='replicated_mutation_table' and database='$CLICKHOUSE_DATABASE' and mutation_id='0000000001'"
 
 $CLICKHOUSE_CLIENT --query "KILL MUTATION WHERE table='replicated_mutation_table' and database='$CLICKHOUSE_DATABASE' AND mutation_id='0000000001'" &> /dev/null
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Look at: https://clickhouse-test-reports.s3.yandex.net/13753/57b8d3f89b4eb6c4ce723d68cfc72786407eed8b/fast_test/runlog.out.log

If my hypothesis is correct, mutation for MODIFY COLUMN can appear in `system.mutations` before column is modified.
@alesapin Am I right?