### PR TITLE
Fix error in test 01079_parallel_alter_detach_table_zookeeper

### DIFF
--- a/tests/queries/0_stateless/01079_parallel_alter_detach_table_zookeeper.sh
+++ b/tests/queries/0_stateless/01079_parallel_alter_detach_table_zookeeper.sh
@@ -17,6 +17,7 @@ $CLICKHOUSE_CLIENT --query "INSERT INTO concurrent_alter_detach_1 SELECT number,
 $CLICKHOUSE_CLIENT --query "INSERT INTO concurrent_alter_detach_1 SELECT number, number + 10, number from numbers(10, 40)"
 
 for i in $(seq $REPLICAS); do
+    $CLICKHOUSE_CLIENT --query "SYSTEM SYNC REPLICA concurrent_alter_detach_$i"
     $CLICKHOUSE_CLIENT --query "SELECT SUM(value1) FROM concurrent_alter_detach_$i"
 done
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


It's surprising that this test has so trivial error.

All sibling tests already have correct code:
01079_parallel_alter_add_drop_column_zookeeper
01079_parallel_alter_modify_zookeeper
01076_parallel_alter_replicated_zookeeper

CC @alesapin 