### PR TITLE
Keep "metadata_loading" test only for release build

### DIFF
--- a/tests/queries/skip_list.json
+++ b/tests/queries/skip_list.json
@@ -12,7 +12,8 @@
         "01103_check_cpu_instructions_at_startup",
         "01098_temporary_and_external_tables",
         "00152_insert_different_granularity",
-        "00151_replace_partition_with_different_granularity"
+        "00151_replace_partition_with_different_granularity",
+        "01193_metadata_loading"
     ],
     "address-sanitizer": [
         "00281",
@@ -21,7 +22,8 @@
         "query_profiler",
         "memory_profiler",
         "odbc_roundtrip",
-        "01103_check_cpu_instructions_at_startup"
+        "01103_check_cpu_instructions_at_startup",
+        "01193_metadata_loading"
     ],
     "ub-sanitizer": [
         "00281",
@@ -30,7 +32,8 @@
         "query_profiler",
         "memory_profiler",
         "01103_check_cpu_instructions_at_startup",
-        "00900_orc_load"
+        "00900_orc_load",
+        "01193_metadata_loading"
     ],
     "memory-sanitizer": [
         "00281",
@@ -41,7 +44,8 @@
         "01103_check_cpu_instructions_at_startup",
         "01086_odbc_roundtrip",
         "00877_memory_limit_for_new_delete",
-        "01114_mysql_database_engine_segfault"
+        "01114_mysql_database_engine_segfault",
+        "01193_metadata_loading"
     ],
     "debug-build": [
         "00281",
@@ -55,7 +59,8 @@
         "01200_mutations_memory_consumption",
         "01103_check_cpu_instructions_at_startup",
         "01037_polygon_dicts_",
-        "hyperscan"
+        "hyperscan",
+        "01193_metadata_loading"
     ],
     "unbundled-build": [
         "00429",
@@ -82,7 +87,8 @@
         "01099_parallel_distributed_insert_select",
         "01300_client_save_history_when_terminated",
         "orc_output",
-        "01370_client_autocomplete_word_break_characters"
+        "01370_client_autocomplete_word_break_characters",
+        "01193_metadata_loading"
     ],
     "release-build": [
         "avx2"


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


It depends on timings with scale of about one second (race condition).
The design of this test makes race condition inevitable.
Assumption that it will work on this scale is too bold.

See https://clickhouse-test-reports.s3.yandex.net/12052/cf306c5be13e6cf128e656086f8e0319e84c4de3/functional_stateless_tests_(thread)/test_run.txt.out.log

CC @tavplubix 
