### PR TITLE
Fix topK test

### DIFF
--- a/tests/queries/0_stateless/00981_topK_topKWeighted_long.sql
+++ b/tests/queries/0_stateless/00981_topK_topKWeighted_long.sql
@@ -2,8 +2,7 @@ DROP TABLE IF EXISTS topk;
 
 CREATE TABLE topk (val1 String, val2 UInt32) ENGINE = MergeTree ORDER BY val1;
 
-INSERT INTO topk SELECT toString(number), number FROM numbers(3000000);
-INSERT INTO topk SELECT toString(number % 10), 999999999 FROM numbers(1000000);
+INSERT INTO topk WITH number % 7 = 0 AS frequent SELECT toString(frequent ? number % 10 : number), frequent ? 999999999 : number FROM numbers(4000000);
 
 SELECT arraySort(topK(10)(val1)) FROM topk;
 SELECT arraySort(topKWeighted(10)(val1, val2)) FROM topk;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

See https://clickhouse-test-reports.s3.yandex.net/12278/e1543c18414e566fe7cbaaa3342e061357dfbf51/functional_stateless_tests_(release,_databaseatomic).html#fail1

The test `00981_topK_topKWeighted_long.sql` fails extremely rarely (once a few months) but the reason is understandable.
It happens because the function `topK` is non-deterministic (depends on the order of data processing) and if frequent values appear early, their frequencies can be vanished by subsequent values.

Example of counter-intuitive behaviour:
```
CREATE TABLE t (x UInt64) ENGINE = TinyLog;
INSERT INTO t SELECT number AS x FROM numbers(10);
INSERT INTO t SELECT number AS x FROM numbers(1000);
SELECT topK(x) FROM t

┌─topK(x)───────────────────────────────────┐
│ [896,897,898,899,900,901,902,903,904,905] │
└───────────────────────────────────────────┘
```

Rewrite the test in a way that frequent values will be uniformly distributed across all data regardless to the order of data.