### PR TITLE
Fix step overflow in range()

### DIFF
--- a/src/Functions/array/range.cpp
+++ b/src/Functions/array/range.cpp
@@ -145,7 +145,13 @@ private:
         for (size_t row_idx = 0; row_idx < input_rows_count; ++row_idx)
         {
             for (size_t st = start, ed = end_data[row_idx]; st < ed; st += step)
+            {
                 out_data[offset++] = st;
+
+                if (st > st + step)
+                    throw Exception{"A call to function " + getName() + " overflows, investigate the values of arguments you are passing",
+                                ErrorCodes::ARGUMENT_OUT_OF_BOUND};
+            }
 
             out_offsets[row_idx] = offset;
         }
@@ -200,7 +206,13 @@ private:
         for (size_t row_idx = 0; row_idx < input_rows_count; ++row_idx)
         {
             for (size_t st = start_data[row_idx], ed = end_data[row_idx]; st < ed; st += step)
+            {
                 out_data[offset++] = st;
+
+                if (st > st + step)
+                    throw Exception{"A call to function " + getName() + " overflows, investigate the values of arguments you are passing",
+                                ErrorCodes::ARGUMENT_OUT_OF_BOUND};
+            }
 
             out_offsets[row_idx] = offset;
         }
@@ -255,7 +267,13 @@ private:
         for (size_t row_idx = 0; row_idx < input_rows_count; ++row_idx)
         {
             for (size_t st = start, ed = end_data[row_idx]; st < ed; st += step_data[row_idx])
+            {
                 out_data[offset++] = st;
+
+                if (st > st + step_data[row_idx])
+                    throw Exception{"A call to function " + getName() + " overflows, investigate the values of arguments you are passing",
+                                ErrorCodes::ARGUMENT_OUT_OF_BOUND};
+            }
 
             out_offsets[row_idx] = offset;
         }
@@ -313,7 +331,13 @@ private:
         for (size_t row_idx = 0; row_idx < input_rows_count; ++row_idx)
         {
             for (size_t st = start_data[row_idx], ed = end_start[row_idx]; st < ed; st += step_data[row_idx])
+            {
                 out_data[offset++] = st;
+
+                if (st > st + step_data[row_idx])
+                    throw Exception{"A call to function " + getName() + " overflows, investigate the values of arguments you are passing",
+                                ErrorCodes::ARGUMENT_OUT_OF_BOUND};
+            }
 
             out_offsets[row_idx] = offset;
         }

--- a/tests/queries/0_stateless/01408_range_overflow.sql
+++ b/tests/queries/0_stateless/01408_range_overflow.sql
@@ -1,0 +1,12 @@
+-- executeGeneric()
+SELECT range(1025, 1048576 + 9223372036854775807, 9223372036854775807); -- { serverError 69; }
+SELECT range(1025, 1048576 + (9223372036854775807 AS i), i); -- { serverError 69; }
+
+-- executeConstStep()
+SELECT range(number, 1048576 + 9223372036854775807, 9223372036854775807) FROM system.numbers LIMIT 1 OFFSET 1025; -- { serverError 69; }
+
+-- executeConstStartStep()
+SELECT range(1025, number + 9223372036854775807, 9223372036854775807) FROM system.numbers LIMIT 1 OFFSET 1048576; -- { serverError 69; }
+
+-- executeConstStart()
+SELECT range(1025, 1048576 + 9223372036854775807, number + 9223372036854775807) FROM system.numbers LIMIT 1; -- { serverError 69; }


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix step overflow in range()

Found with: [AST fuzzer](https://clickhouse-test-reports.s3.yandex.net/10373/a2467f205f4ab120443afbb426cec3d5a506478d/fuzzer/fuzzer.log#fail1)