### PR TITLE
Fix flaky unit test

### DIFF
--- a/src/Common/tests/gtest_thread_pool_schedule_exception.cpp
+++ b/src/Common/tests/gtest_thread_pool_schedule_exception.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <Common/ThreadPool.h>
+#include <Poco/Event.h>
 
 #include <gtest/gtest.h>
 
@@ -9,21 +10,34 @@ static bool check()
 {
     ThreadPool pool(10);
 
+    /// The throwing thread.
     pool.scheduleOrThrowOnError([] { throw std::runtime_error("Hello, world!"); });
 
     try
     {
-        for (size_t i = 0; i < 500; ++i)
-            pool.scheduleOrThrowOnError([] {});    /// An exception will be rethrown from this method.
+        while (true)
+        {
+            /// An exception from the throwing thread will be rethrown from this method
+            /// as soon as the throwing thread executed.
+
+            /// This innocent thread may or may not be executed, the following possibilities exist:
+            /// 1. The throwing thread has already throwed exception and the attempt to schedule the innocent thread will rethrow it.
+            /// 2. The throwing thread has not executed, the innocent thread will be scheduled and executed.
+            /// 3. The throwing thread has not executed, the innocent thread will be scheduled but before it will be executed,
+            ///    the throwing thread will be executed and throw exception and it will prevent starting of execution of the innocent thread
+            ///    the method will return and the exception will be rethrown only on call to "wait" or on next call on next loop iteration as (1).
+            pool.scheduleOrThrowOnError([]{});
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
     }
     catch (const std::runtime_error &)
     {
+        pool.wait();
         return true;
     }
 
-    pool.wait();
-
-    return false;
+    __builtin_unreachable();
 }
 
 

--- a/src/Common/tests/gtest_thread_pool_schedule_exception.cpp
+++ b/src/Common/tests/gtest_thread_pool_schedule_exception.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <stdexcept>
 #include <Common/ThreadPool.h>
-#include <Poco/Event.h>
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://clickhouse-test-reports.s3.yandex.net/11718/03f39fe1f434d7541ab7f2cd4e9149304fda7b19/unit_tests_relwithdebuginfo_gcc-9/test_run.txt.out.log

This unit tests fails in extemely rare conditions (only once a few months).
It is not a bug - everything is working as expected but the test contained a race condition.

Obviously, TSan is not able to catch this race condition (we are running all tests under TSan as well).