### PR TITLE
Fix bug in "Quick Start" markup on the website

### DIFF
--- a/website/templates/index/quickstart.html
+++ b/website/templates/index/quickstart.html
@@ -21,13 +21,13 @@
 
     <div class="tab-content" id="install-tab-content">
         <div class="tab-pane show active" id="deb" role="tabpanel" aria-labelledby="deb-tab">
-            {% highlight "bash" %}{% include "install/deb.sh" %}{% endhighlight %}
+            {% include "install/deb.sh" %}
         </div>
         <div class="tab-pane" id="rpm" role="tabpanel" aria-labelledby="rpm-tab">
-            {% highlight "bash" %}{% include "install/rpm.sh" %}{% endhighlight %}
+            {% include "install/rpm.sh" %}
         </div>
-        <div class="tab-pane" id="tgz" role="tabpanel" aria-labelledby="thz-tab">
-            {% highlight "bash" %}{% include "install/tgz.sh" %}{% endhighlight %}
+        <div class="tab-pane" id="tgz" role="tabpanel" aria-labelledby="tgz-tab">
+            {% include "install/tgz.sh" %}
         </div>
     </div>
 


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)

There is a complaint that it does not display correctly:
https://yadi.sk/i/y83ge-3bkcp_nA
https://yadi.sk/i/RJMQ2Nbs-6VdJA