### PR TITLE
Fix lgamma race.

### DIFF
--- a/src/Functions/lgamma.cpp
+++ b/src/Functions/lgamma.cpp
@@ -1,7 +1,7 @@
 #include <Functions/FunctionMathUnary.h>
 #include <Functions/FunctionFactory.h>
 
-#ifndef lgamma_r
+#if defined(OS_DARWIN)
 extern "C"
 {
     /// Is defined in libglibc-compatibility.a

--- a/src/Functions/lgamma.cpp
+++ b/src/Functions/lgamma.cpp
@@ -1,7 +1,7 @@
 #include <Functions/FunctionMathUnary.h>
 #include <Functions/FunctionFactory.h>
 
-#ifdef lgamma_r
+#ifndef lgamma_r
 extern "C"
 {
     /// Is defined in libglibc-compatibility.a

--- a/src/Functions/lgamma.cpp
+++ b/src/Functions/lgamma.cpp
@@ -1,6 +1,11 @@
 #include <Functions/FunctionMathUnary.h>
 #include <Functions/FunctionFactory.h>
-#include <cmath>
+
+extern "C"
+{
+    /// Is defined in libglibc-compatibility.a
+    double lgamma_r(double x, int * signgamp);
+}
 
 namespace DB
 {
@@ -9,7 +14,7 @@ namespace DB
 static Float64 lgamma_wrapper(Float64 arg)
 {
     int signp;
-    return ::lgamma_r(arg, &signp);
+    return lgamma_r(arg, &signp);
 }
 
 struct LGammaName { static constexpr auto name = "lgamma"; };

--- a/src/Functions/lgamma.cpp
+++ b/src/Functions/lgamma.cpp
@@ -1,11 +1,13 @@
 #include <Functions/FunctionMathUnary.h>
 #include <Functions/FunctionFactory.h>
 
+#ifdef lgamma_r
 extern "C"
 {
     /// Is defined in libglibc-compatibility.a
     double lgamma_r(double x, int * signgamp);
 }
+#endif
 
 namespace DB
 {

--- a/src/Functions/lgamma.cpp
+++ b/src/Functions/lgamma.cpp
@@ -1,11 +1,19 @@
 #include <Functions/FunctionMathUnary.h>
 #include <Functions/FunctionFactory.h>
+#include <cmath>
 
 namespace DB
 {
 
+/// Use wrapper and use lgamma_r version because std::lgamma is not threadsafe.
+static Float64 lgamma_wrapper(Float64 arg)
+{
+    int signp;
+    return ::lgamma_r(arg, &signp);
+}
+
 struct LGammaName { static constexpr auto name = "lgamma"; };
-using FunctionLGamma = FunctionMathUnary<UnaryFunctionPlain<LGammaName, std::lgamma>>;
+using FunctionLGamma = FunctionMathUnary<UnaryFunctionPlain<LGammaName, lgamma_wrapper>>;
 
 void registerFunctionLGamma(FunctionFactory & factory)
 {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix data race in `lgamma` function. This race was caught only in `tsan`, no side effects a really happened.

https://clickhouse-test-reports.s3.yandex.net/12470/78249ec989fb7461d4ad3b991ad0e88cc3707f7b/stress_test_(thread)/stderr.log

`std::lgamma` is not thread-safe.
Implementation from `musl` we use:
```c
int signgam;

double lgamma(double x)
{
	return lgamma_r(x, &signgam);
}
```

Replaced to direct `lgamma_r` call.