### PR TITLE
Fix gcc10 build by reducing storage of the lambdas in executeQuery

### DIFF
--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -487,15 +487,15 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
             }
 
             /// Common code for finish and exception callbacks
-            auto status_info_to_query_log = [ast](QueryLogElement &element, const QueryStatusInfo &info) mutable
+            auto status_info_to_query_log = [](QueryLogElement &element, const QueryStatusInfo &info, const ASTPtr query_ast) mutable
             {
                 DB::UInt64 query_time = info.elapsed_seconds * 1000000;
                 ProfileEvents::increment(ProfileEvents::QueryTimeMicroseconds, query_time);
-                if (ast->as<ASTSelectQuery>() || ast->as<ASTSelectWithUnionQuery>())
+                if (query_ast->as<ASTSelectQuery>() || query_ast->as<ASTSelectWithUnionQuery>())
                 {
                     ProfileEvents::increment(ProfileEvents::SelectQueryTimeMicroseconds, query_time);
                 }
-                else if (ast->as<ASTInsertQuery>())
+                else if (query_ast->as<ASTInsertQuery>())
                 {
                     ProfileEvents::increment(ProfileEvents::InsertQueryTimeMicroseconds, query_time);
                 }
@@ -535,7 +535,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
 
                 elem.event_time = time(nullptr);
 
-                status_info_to_query_log(elem, info);
+                status_info_to_query_log(elem, info, ast);
 
                 auto progress_callback = context.getProgressCallback();
 
@@ -608,7 +608,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
                 if (process_list_elem)
                 {
                     QueryStatusInfo info = process_list_elem->getInfo(true, current_settings.log_profile_events, false);
-                    status_info_to_query_log(elem, info);
+                    status_info_to_query_log(elem, info, ast);
                 }
 
                 if (current_settings.calculate_text_stack_trace)


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

There is no need to capture query AST for the status_info_to_query_log,
since callers already captured it anyway.

gcc10 reports:
```
    ../src/Interpreters/executeQuery.cpp: In member function ‘void std::__1::function<_Rp(_ArgTypes ...)>::swap(std::__1::function<_Rp(_ArgTypes ...)>&) [with _Rp = void; _ArgTypes = {DB::IBlockInputStream*, DB::IBlockOutputStream*, DB::QueryPipeline*}]’:
    ../src/Interpreters/executeQuery.cpp:490:49: error: array subscript 35 is outside array bounds of ‘std::__1::aligned_storage<32, 16>::type [1]’ [-Werror=array-bounds]
      490 |             auto status_info_to_query_log = [ast](QueryLogElement &element, const QueryStatusInfo &info) mutable
          |                                                 ^
    In file included from ../contrib/libcxx/include/algorithm:644,
                     from ../contrib/libcxx/include/__string:57,
                     from ../contrib/libcxx/include/string_view:175,
                     from ../contrib/libcxx/include/string:504,
                     from ../src/Common/formatReadable.h:3,                                                                                                  from ../src/Interpreters/executeQuery.cpp:1:
    ../contrib/libcxx/include/functional:1877:60: note: while referencing ‘__tempbuf’
     1877 |             typename aligned_storage<sizeof(__buf_)>::type __tempbuf;
          |                                                            ^~~~~~~~~
```

Fixes: #13336