### PR TITLE
Fix -Wstringop-overflow in MergeTreePartition::getID() for gcc10

### DIFF
--- a/src/Storages/MergeTree/MergeTreePartition.cpp
+++ b/src/Storages/MergeTree/MergeTreePartition.cpp
@@ -81,8 +81,9 @@ String MergeTreePartition::getID(const Block & partition_key_sample) const
     char hash_data[16];
     hash.get128(hash_data);
     result.resize(32);
+    char * result_out = &result[0]; /// temporary to overcome -Wstringop-overflow
     for (size_t i = 0; i < 16; ++i)
-        writeHexByteLowercase(hash_data[i], &result[2 * i]);
+        writeHexByteLowercase(hash_data[i], &result_out[2 * i]);
 
     return result;
 }


### PR DESCRIPTION
*Submitted separately since this is a quirk (and maybe there is better way, I tried lots of variants though), plus it does not related to other build fixes*

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

By some reason gcc10 cannot understand this and reports:

    In function ‘void writeHexByteLowercase(UInt8, void*)’,
        inlined from ‘DB::String DB::MergeTreePartition::getID(const DB::Block&) const’ at ../src/Storages/MergeTree/MergeTreePartition.cpp:85:30:
    ../src/Common/hex.h:39:11: error: writing 2 bytes into a region of size 1 [-Werror=stringop-overflow=]
       39 |     memcpy(out, &hex_byte_to_char_lowercase_table[static_cast<size_t>(byte) * 2], 2);
          |     ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ../src/Storages/MergeTree/MergeTreePartition.cpp: In member function ‘DB::String DB::MergeTreePartition::getID(const DB::Block&) const’:
    ../src/Storages/MergeTree/MergeTreePartition.cpp:54:17: note: at offset 92 to object ‘result’ with size 24 declared here
       54 |     std::string result;
          |                 ^~~~~~
    In file included from ../src/Storages/MergeTree/MergeTreePartition.cpp:11:
    In function ‘void writeHexByteLowercase(UInt8, void*)’,
        inlined from ‘DB::String DB::MergeTreePartition::getID(const DB::Block&) const’ at ../src/Storages/MergeTree/MergeTreePartition.cpp:85:30:
    ../src/Common/hex.h:39:11: error: writing 2 bytes into a region of size 0 [-Werror=stringop-overflow=]
       39 |     memcpy(out, &hex_byte_to_char_lowercase_table[static_cast<size_t>(byte) * 2], 2);

