### PR TITLE
optimize error msg for null value of TabSeparatedRow format 

### DIFF
--- a/src/Processors/Formats/Impl/TabSeparatedRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/TabSeparatedRowInputFormat.cpp
@@ -331,22 +331,22 @@ void TabSeparatedRowInputFormat::tryDeserializeField(const DataTypePtr & type, I
 {
     if (column_indexes_for_input_fields[file_column])
     {
-        // check null value for type is not nullable. don't cross buffer bound for simplicity, so maybe missing some case 
-        if(!type->isNullable() && !in.eof()) 
-        { 
-            if(*in.position() == '\\' && in.available() >= 2) 
-            { 
-                ++in.position(); 
-                if(*in.position() == 'N') 
-                { 
-                    ++in.position(); 
-                    throw Exception("unexpected Null value of not Nullable type", ErrorCodes::INCORRECT_DATA); 
-                } 
-                else 
-                { 
-                    --in.position(); 
-                } 
-            } 
+        // check null value for type is not nullable. don't cross buffer bound for simplicity, so maybe missing some case
+        if(!type->isNullable() && !in.eof())
+        {
+            if(*in.position() == '\\' && in.available() >= 2)
+            {
+                ++in.position();
+                if(*in.position() == 'N')
+                {
+                    ++in.position();
+                    throw Exception("unexpected Null value of not Nullable type", ErrorCodes::INCORRECT_DATA);
+                }
+                else
+                {
+                    --in.position();
+                }
+            }
         }
         const bool is_last_file_column = file_column + 1 == column_indexes_for_input_fields.size();
         readField(column, type, is_last_file_column);

--- a/src/Processors/Formats/Impl/TabSeparatedRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/TabSeparatedRowInputFormat.cpp
@@ -331,6 +331,23 @@ void TabSeparatedRowInputFormat::tryDeserializeField(const DataTypePtr & type, I
 {
     if (column_indexes_for_input_fields[file_column])
     {
+        // check null value for type is not nullable. don't cross buffer bound for simplicity, so maybe missing some case 
+        if(!type->isNullable() && !in.eof()) 
+        { 
+            if(*in.position() == '\\' && in.available() >= 2) 
+            { 
+                ++in.position(); 
+                if(*in.position() == 'N') 
+                { 
+                    ++in.position(); 
+                    throw Exception("unexpected Null value of not Nullable type", ErrorCodes::INCORRECT_DATA); 
+                } 
+                else 
+                { 
+                    --in.position(); 
+                } 
+            } 
+        }
         const bool is_last_file_column = file_column + 1 == column_indexes_for_input_fields.size();
         readField(column, type, is_last_file_column);
     }

--- a/src/Processors/Formats/Impl/TabSeparatedRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/TabSeparatedRowInputFormat.cpp
@@ -332,12 +332,12 @@ void TabSeparatedRowInputFormat::tryDeserializeField(const DataTypePtr & type, I
     if (column_indexes_for_input_fields[file_column])
     {
         // check null value for type is not nullable. don't cross buffer bound for simplicity, so maybe missing some case
-        if(!type->isNullable() && !in.eof())
+        if (!type->isNullable() && !in.eof())
         {
-            if(*in.position() == '\\' && in.available() >= 2)
+            if (*in.position() == '\\' && in.available() >= 2)
             {
                 ++in.position();
-                if(*in.position() == 'N')
+                if (*in.position() == 'N')
                 {
                     ++in.position();
                     throw Exception("unexpected Null value of not Nullable type", ErrorCodes::INCORRECT_DATA);

--- a/src/Processors/Formats/Impl/TabSeparatedRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/TabSeparatedRowInputFormat.cpp
@@ -340,7 +340,7 @@ void TabSeparatedRowInputFormat::tryDeserializeField(const DataTypePtr & type, I
                 if (*in.position() == 'N')
                 {
                     ++in.position();
-                    throw Exception("unexpected Null value of not Nullable type", ErrorCodes::INCORRECT_DATA);
+                    throw Exception(ErrorCodes::INCORRECT_DATA, "Unexpected NULL value of not Nullable type {}", type->getName());
                 }
                 else
                 {

--- a/src/Processors/Formats/RowInputFormatWithDiagnosticInfo.cpp
+++ b/src/Processors/Formats/RowInputFormatWithDiagnosticInfo.cpp
@@ -140,6 +140,16 @@ bool RowInputFormatWithDiagnosticInfo::deserializeFieldAndPrintDiagnosticInfo(co
             out << "ERROR: Date must be in YYYY-MM-DD format.\n";
         else
             out << "ERROR\n";
+        
+        //print exception msg 
+        try 
+        { 
+            std::rethrow_exception(exception); 
+        } 
+        catch (DB::Exception e) 
+        { 
+            out << e.what(); 
+        }
         return false;
     }
 

--- a/src/Processors/Formats/RowInputFormatWithDiagnosticInfo.cpp
+++ b/src/Processors/Formats/RowInputFormatWithDiagnosticInfo.cpp
@@ -140,15 +140,8 @@ bool RowInputFormatWithDiagnosticInfo::deserializeFieldAndPrintDiagnosticInfo(co
             out << "ERROR: Date must be in YYYY-MM-DD format.\n";
         else
             out << "ERROR\n";
-        //print exception msg
-        try
-        {
-            std::rethrow_exception(exception);
-        }
-        catch (const DB::Exception & e)
-        {
-            out << e.what();
-        }
+        // Print exception message
+        out << getExceptionMessage(e, false) << '\n';
         return false;
     }
 

--- a/src/Processors/Formats/RowInputFormatWithDiagnosticInfo.cpp
+++ b/src/Processors/Formats/RowInputFormatWithDiagnosticInfo.cpp
@@ -141,7 +141,7 @@ bool RowInputFormatWithDiagnosticInfo::deserializeFieldAndPrintDiagnosticInfo(co
         else
             out << "ERROR\n";
         // Print exception message
-        out << getExceptionMessage(e, false) << '\n';
+        out << getExceptionMessage(exception, false) << '\n';
         return false;
     }
 

--- a/src/Processors/Formats/RowInputFormatWithDiagnosticInfo.cpp
+++ b/src/Processors/Formats/RowInputFormatWithDiagnosticInfo.cpp
@@ -145,7 +145,7 @@ bool RowInputFormatWithDiagnosticInfo::deserializeFieldAndPrintDiagnosticInfo(co
         {
             std::rethrow_exception(exception);
         }
-        catch (DB::Exception e)
+        catch (const DB::Exception & e)
         {
             out << e.what();
         }

--- a/src/Processors/Formats/RowInputFormatWithDiagnosticInfo.cpp
+++ b/src/Processors/Formats/RowInputFormatWithDiagnosticInfo.cpp
@@ -140,15 +140,14 @@ bool RowInputFormatWithDiagnosticInfo::deserializeFieldAndPrintDiagnosticInfo(co
             out << "ERROR: Date must be in YYYY-MM-DD format.\n";
         else
             out << "ERROR\n";
-        
-        //print exception msg 
-        try 
-        { 
-            std::rethrow_exception(exception); 
-        } 
-        catch (DB::Exception e) 
-        { 
-            out << e.what(); 
+        //print exception msg
+        try
+        {
+            std::rethrow_exception(exception);
+        }
+        catch (DB::Exception e)
+        {
+            out << e.what();
         }
         return false;
     }

--- a/tests/queries/0_stateless/01195_formats_diagnostic_info.reference
+++ b/tests/queries/0_stateless/01195_formats_diagnostic_info.reference
@@ -20,6 +20,7 @@ ERROR: DateTime must be in YYYY-MM-DD hh:mm:ss or NNNNNNNNNN (unix timestamp, ex
 ERROR: Tab found where line feed is expected. It's like your file has more columns than expected.
 ERROR: garbage after Decimal(18, 10): "Hello<LINE FEED>"
 Column 0,   name: t, type: DateTime,        ERROR: text "<LINE FEED>" is not like DateTime
+Unexpected NULL value
 
 CustomSeparated
 Column 2,   name: d, type: Decimal(18, 10), parsed text: "123456789"ERROR

--- a/tests/queries/0_stateless/01195_formats_diagnostic_info.sh
+++ b/tests/queries/0_stateless/01195_formats_diagnostic_info.sh
@@ -28,6 +28,7 @@ echo -e '2020-04-21 12:34:567\tHello\t123456789' | "${PARSER[@]}" 2>&1| grep "ER
 echo -e '2020-04-21 12:34:56\tHello\t12345678\t1' | "${PARSER[@]}" 2>&1| grep "ERROR"
 echo -e '2020-04-21 12:34:56\t\t123Hello' | "${PARSER[@]}" 2>&1| grep "ERROR"
 echo -e '2020-04-21 12:34:56\tHello\t12345678\n' | "${PARSER[@]}" 2>&1| grep "ERROR"
+echo -e '\N\tHello\t12345678' | "${PARSER[@]}" 2>&1| grep -o "Unexpected NULL value"
 
 PARSER=(${CLICKHOUSE_LOCAL} --query 'SELECT t, s, d FROM table' --structure 't DateTime, s String, d Decimal64(10)' --input-format CustomSeparated)
 echo -e '2020-04-21 12:34:56\tHello\t12345678' | "${PARSER[@]}"  2>&1| grep "ERROR" || echo -e "\nCustomSeparated"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Better error message for null value of TabSeparatedRow format.

Detailed description / Documentation draft:
when using TabSeparatedRow format import data liking JDBC, if the column definition is not Nullable but the insert value is Null,clickhouse will give exception:

_DB::Exception: Cannot parse input: expected
Column 0,   name: number,     type: Int32,    ERROR: text "<BACKSLASH>N<TAB>VN<TAB>1590" is not like Int32_

this error msg is very misleading and looks like dirty data problem, but actual is Null value problem.
after optimize the error msg like this:

_DB::Exception: Cannot parse input: expected '\t' before: '\\N\t\\N\t10000\n': (at row 1)
Row 1:
Column 0,   name: number,     type: Int32,    parsed text: "<BACKSLASH>N"ERROR
unexpected Null value of not Nullable type_
