### PR TITLE
Fix lock order inversion when renaming Distributed table

### DIFF
--- a/src/Storages/Distributed/DirectoryMonitor.cpp
+++ b/src/Storages/Distributed/DirectoryMonitor.cpp
@@ -782,9 +782,8 @@ std::string StorageDistributedDirectoryMonitor::getLoggerName() const
 
 void StorageDistributedDirectoryMonitor::updatePath(const std::string & new_path)
 {
-    std::lock_guard lock{mutex};
-
     task_handle->deactivate();
+    std::lock_guard lock{mutex};
 
     {
         std::unique_lock metrics_lock(metrics_mutex);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed potential deadlock when renaming `Distributed` table

Detailed description / Documentation draft:
Integration test: test_distributed_ddl/test.py::test_rename[configs_secure] https://clickhouse-test-reports.s3.yandex.net/0/5d2013f2240f450e25323a482e3a02312dc92849/integration_tests_(thread).html#fail1
tsan report: https://gist.github.com/tavplubix/ee5c2859ae67101296b2056a22629bd4
