### PR TITLE
Fix wrong error for long queries.

### DIFF
--- a/src/Parsers/Lexer.cpp
+++ b/src/Parsers/Lexer.cpp
@@ -50,7 +50,7 @@ Token quotedString(const char *& pos, const char * const token_begin, const char
 Token Lexer::nextToken()
 {
     Token res = nextTokenImpl();
-    if (res.type != TokenType::EndOfStream && max_query_size && res.end > begin + max_query_size)
+    if (max_query_size && res.end > begin + max_query_size)
         res.type = TokenType::ErrorMaxQuerySizeExceeded;
     if (res.isSignificant())
         prev_significant_token_type = res.type;

--- a/tests/queries/0_stateless/01451_wrong_error_long_query.reference
+++ b/tests/queries/0_stateless/01451_wrong_error_long_query.reference
@@ -1,0 +1,2 @@
+Max query size exceeded
+1

--- a/tests/queries/0_stateless/01451_wrong_error_long_query.sh
+++ b/tests/queries/0_stateless/01451_wrong_error_long_query.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../shell_config.sh
+
+printf "select 1 in (1, 1, %1048554s  (-1))" | ${CLICKHOUSE_CURL} -ss 'http://localhost:8123/?max_query_size=1048576' --data-binary @- | grep -o "Max query size exceeded"
+printf "select 1 in (1, 1, %1048554s  (-1))" | ${CLICKHOUSE_CURL} -ss 'http://localhost:8123/?max_query_size=1048580' --data-binary @-


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix wrong error for long queries. It was possible to get syntax error other than `Max query size exceeded` for correct query.