### PR TITLE
First attempt to fix data race in ConnectionPoolWithFailover::getStatus()

### DIFF
--- a/src/Client/ConnectionPoolWithFailover.h
+++ b/src/Client/ConnectionPoolWithFailover.h
@@ -72,7 +72,7 @@ public:
 
     struct NestedPoolStatus
     {
-        const IConnectionPool * pool;
+        const Base::NestedPoolPtr pool;
         size_t error_count;
         std::chrono::seconds estimated_recovery_time;
     };

--- a/src/Common/PoolWithFailoverBase.h
+++ b/src/Common/PoolWithFailoverBase.h
@@ -124,7 +124,12 @@ protected:
 
     /// This function returns a copy of pool states to avoid race conditions when modifying shared pool states.
     PoolStates updatePoolStates(size_t max_ignored_errors);
-    PoolStates getPoolStates() const;
+
+    auto getPoolExtendedStates() const
+    {
+        std::lock_guard lock(pool_states_mutex);
+        return std::make_tuple(shared_pool_states, nested_pools, last_error_decrease_time);
+    }
 
     NestedPools nested_pools;
 
@@ -381,12 +386,4 @@ PoolWithFailoverBase<TNestedPool>::updatePoolStates(size_t max_ignored_errors)
         state.error_count = std::max<UInt64>(0, state.error_count - max_ignored_errors);
 
     return result;
-}
-
-template <typename TNestedPool>
-typename PoolWithFailoverBase<TNestedPool>::PoolStates
-PoolWithFailoverBase<TNestedPool>::getPoolStates() const
-{
-    std::lock_guard lock(pool_states_mutex);
-    return shared_pool_states;
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...
