### PR TITLE
Skip abnormaly small messages in AvroConfluent format

### DIFF
--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -72,7 +72,6 @@ namespace ErrorCodes
     extern const int ILLEGAL_COLUMN;
     extern const int TYPE_MISMATCH;
     extern const int CANNOT_PARSE_UUID;
-    extern const int ATTEMPT_TO_READ_AFTER_EOF;
     extern const int CANNOT_READ_ALL_DATA;
 }
 
@@ -706,8 +705,7 @@ static uint32_t readConfluentSchemaId(ReadBuffer & in)
     }
     catch (const Exception & e)
     {
-        if (e.code() == CANNOT_READ_ALL_DATA
-           || e.code() == ATTEMPT_TO_READ_AFTER_EOF)
+        if (e.code() == ErrorCodes::CANNOT_READ_ALL_DATA)
         {
             /* empty or incomplete message without Avro Confluent magic number or schema id */
             throw Exception("Missing AvroConfluent magic byte or schema identifier.", ErrorCodes::INCORRECT_DATA);

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -697,7 +697,7 @@ static uint32_t readConfluentSchemaId(ReadBuffer & in)
     uint8_t magic;
     uint32_t schema_id;
 
-    try 
+    try
     {
         readBinaryBigEndian(magic, in);
         readBinaryBigEndian(schema_id, in);

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -697,8 +697,15 @@ static uint32_t readConfluentSchemaId(ReadBuffer & in)
     uint8_t magic;
     uint32_t schema_id;
 
-    readBinaryBigEndian(magic, in);
-    readBinaryBigEndian(schema_id, in);
+    try 
+    {
+        readBinaryBigEndian(magic, in);
+        readBinaryBigEndian(schema_id, in);
+    }
+    catch(Exception & e) {
+        /* empty or incomplete message without Avro Confluent magic number or schema id */
+        throw Exception("Missing AvroConfluent magic byte or schema identifier.", ErrorCodes::INCORRECT_DATA);
+    }
 
     if (magic != 0x00)
     {

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -702,7 +702,8 @@ static uint32_t readConfluentSchemaId(ReadBuffer & in)
         readBinaryBigEndian(magic, in);
         readBinaryBigEndian(schema_id, in);
     }
-    catch(Exception & e) {
+    catch (const Exception & e)
+    {
         /* empty or incomplete message without Avro Confluent magic number or schema id */
         throw Exception("Missing AvroConfluent magic byte or schema identifier.", ErrorCodes::INCORRECT_DATA);
     }


### PR DESCRIPTION
This PR fixes the issue #13710 

When using Kafka table engine and AvroConfluent input format, gracefully skip malformed message that do not comply with the minumum requirements of AvroConfluent format and thus, do not include at least the 'magic byte' number and the 'schema identifier'.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Corrected an error in AvroConfluent format that caused the Kafka table engine to stop processing messages when an abnormally small, malformed, message was received.

Detailed description / Documentation draft:

When using Kafka table engine and AvroConfluent input format, gracefully skip malformed message that do not comply with the minumum requirements of AvroConfluent format and thus, do not include at least the 'magic byte' number and the 'schema identifier'.
