### PR TITLE
Renaming setting `allow_merges` ⟶ `disable_merges` for volumes in storage policy

### DIFF
--- a/src/Disks/VolumeJBOD.cpp
+++ b/src/Disks/VolumeJBOD.cpp
@@ -54,7 +54,7 @@ VolumeJBOD::VolumeJBOD(
     if (max_data_part_size != 0 && max_data_part_size < MIN_PART_SIZE)
         LOG_WARNING(logger, "Volume {} max_data_part_size is too low ({} < {})", backQuote(name), ReadableSize(max_data_part_size), ReadableSize(MIN_PART_SIZE));
 
-    are_merges_allowed = config.getBool(config_prefix + ".allow_merges", true);
+    are_merges_allowed = config.getBool(config_prefix + ".disable_merges", false);
 }
 
 VolumeJBOD::VolumeJBOD(const VolumeJBOD & volume_jbod,

--- a/src/Storages/System/StorageSystemStoragePolicies.cpp
+++ b/src/Storages/System/StorageSystemStoragePolicies.cpp
@@ -30,7 +30,7 @@ StorageSystemStoragePolicies::StorageSystemStoragePolicies(const StorageID & tab
              {"volume_type", std::make_shared<DataTypeString>()},
              {"max_data_part_size", std::make_shared<DataTypeUInt64>()},
              {"move_factor", std::make_shared<DataTypeFloat32>()},
-             {"allow_merges", std::make_shared<DataTypeUInt8>()}
+             {"disable_merges", std::make_shared<DataTypeUInt8>()}
     }));
     // TODO: Add string column with custom volume-type-specific options
     setInMemoryMetadata(storage_metadata);
@@ -54,7 +54,7 @@ Pipe StorageSystemStoragePolicies::read(
     MutableColumnPtr col_volume_type = ColumnString::create();
     MutableColumnPtr col_max_part_size = ColumnUInt64::create();
     MutableColumnPtr col_move_factor = ColumnFloat32::create();
-    MutableColumnPtr col_allow_merges = ColumnUInt8::create();
+    MutableColumnPtr col_disable_merges = ColumnUInt8::create();
 
     for (const auto & [policy_name, policy_ptr] : context.getPoliciesMap())
     {
@@ -72,7 +72,7 @@ Pipe StorageSystemStoragePolicies::read(
             col_volume_type->insert(volumeTypeToString(volumes[i]->getType()));
             col_max_part_size->insert(volumes[i]->max_data_part_size);
             col_move_factor->insert(policy_ptr->getMoveFactor());
-            col_allow_merges->insert(volumes[i]->areMergesAllowed() ? 1 : 0);
+            col_disable_merges->insert(volumes[i]->areMergesAllowed() ? 0 : 1);
         }
     }
 
@@ -84,7 +84,7 @@ Pipe StorageSystemStoragePolicies::read(
     res_columns.emplace_back(std::move(col_volume_type));
     res_columns.emplace_back(std::move(col_max_part_size));
     res_columns.emplace_back(std::move(col_move_factor));
-    res_columns.emplace_back(std::move(col_allow_merges));
+    res_columns.emplace_back(std::move(col_disable_merges));
 
     UInt64 num_rows = res_columns.at(0)->size();
     Chunk chunk(std::move(res_columns), num_rows);

--- a/tests/integration/test_multiple_disks/configs/config.d/storage_configuration.xml
+++ b/tests/integration/test_multiple_disks/configs/config.d/storage_configuration.xml
@@ -37,7 +37,7 @@
                 </main>
                 <external>
                     <disk>external</disk>
-                    <allow_merges>false</allow_merges>
+                    <disable_merges>true</disable_merges>
                 </external>
             </volumes>
         </small_jbod_with_external_no_merges>

--- a/tests/integration/test_multiple_disks/test.py
+++ b/tests/integration/test_multiple_disks/test.py
@@ -76,7 +76,7 @@ def test_system_tables(start_cluster):
             "volume_type": "JBOD",
             "max_data_part_size": "0",
             "move_factor": 0.1,
-            "allow_merges": 1,
+            "disable_merges": 0,
         },
         {
             "policy_name": "small_jbod_with_external",
@@ -86,7 +86,7 @@ def test_system_tables(start_cluster):
             "volume_type": "JBOD",
             "max_data_part_size": "0",
             "move_factor": 0.1,
-            "allow_merges": 1,
+            "disable_merges": 0,
         },
         {
             "policy_name": "small_jbod_with_external_no_merges",
@@ -96,7 +96,7 @@ def test_system_tables(start_cluster):
             "volume_type": "JBOD",
             "max_data_part_size": "0",
             "move_factor": 0.1,
-            "allow_merges": 1,
+            "disable_merges": 0,
         },
         {
             "policy_name": "small_jbod_with_external_no_merges",
@@ -106,7 +106,7 @@ def test_system_tables(start_cluster):
             "volume_type": "JBOD",
             "max_data_part_size": "0",
             "move_factor": 0.1,
-            "allow_merges": 0,
+            "disable_merges": 1,
         },
         {
             "policy_name": "one_more_small_jbod_with_external",
@@ -116,7 +116,7 @@ def test_system_tables(start_cluster):
             "volume_type": "JBOD",
             "max_data_part_size": "0",
             "move_factor": 0.1,
-            "allow_merges": 1,
+            "disable_merges": 0,
         },
         {
             "policy_name": "one_more_small_jbod_with_external",
@@ -126,7 +126,7 @@ def test_system_tables(start_cluster):
             "volume_type": "JBOD",
             "max_data_part_size": "0",
             "move_factor": 0.1,
-            "allow_merges": 1,
+            "disable_merges": 0,
         },
         {
             "policy_name": "jbods_with_external",
@@ -136,7 +136,7 @@ def test_system_tables(start_cluster):
             "volume_type": "JBOD",
             "max_data_part_size": "10485760",
             "move_factor": 0.1,
-            "allow_merges": 1,
+            "disable_merges": 0,
         },
         {
             "policy_name": "jbods_with_external",
@@ -146,7 +146,7 @@ def test_system_tables(start_cluster):
             "volume_type": "JBOD",
             "max_data_part_size": "0",
             "move_factor": 0.1,
-            "allow_merges": 1,
+            "disable_merges": 0,
         },
         {
             "policy_name": "moving_jbod_with_external",
@@ -156,7 +156,7 @@ def test_system_tables(start_cluster):
             "volume_type": "JBOD",
             "max_data_part_size": "0",
             "move_factor": 0.7,
-            "allow_merges": 1,
+            "disable_merges": 0,
         },
         {
             "policy_name": "moving_jbod_with_external",
@@ -166,7 +166,7 @@ def test_system_tables(start_cluster):
             "volume_type": "JBOD",
             "max_data_part_size": "0",
             "move_factor": 0.7,
-            "allow_merges": 1,
+            "disable_merges": 0,
         },
         {
             "policy_name": "default_disk_with_external",
@@ -176,7 +176,7 @@ def test_system_tables(start_cluster):
             "volume_type": "JBOD",
             "max_data_part_size": "2097152",
             "move_factor": 0.1,
-            "allow_merges": 1,
+            "disable_merges": 0,
         },
         {
             "policy_name": "default_disk_with_external",
@@ -186,7 +186,7 @@ def test_system_tables(start_cluster):
             "volume_type": "JBOD",
             "max_data_part_size": "20971520",
             "move_factor": 0.1,
-            "allow_merges": 1,
+            "disable_merges": 0,
         },
         {
             "policy_name": "special_warning_policy",
@@ -196,7 +196,7 @@ def test_system_tables(start_cluster):
             "volume_type": "JBOD",
             "max_data_part_size": "0",
             "move_factor": 0.1,
-            "allow_merges": 1,
+            "disable_merges": 0,
         },
         {
             "policy_name": "special_warning_policy",
@@ -206,7 +206,7 @@ def test_system_tables(start_cluster):
             "volume_type": "JBOD",
             "max_data_part_size": "0",
             "move_factor": 0.1,
-            "allow_merges": 1,
+            "disable_merges": 0,
         },
         {
             "policy_name": "special_warning_policy",
@@ -216,7 +216,7 @@ def test_system_tables(start_cluster):
             "volume_type": "JBOD",
             "max_data_part_size": "1024",
             "move_factor": 0.1,
-            "allow_merges": 1,
+            "disable_merges": 0,
         },
         {
             "policy_name": "special_warning_policy",
@@ -226,7 +226,7 @@ def test_system_tables(start_cluster):
             "volume_type": "JBOD",
             "max_data_part_size": "1024000000",
             "move_factor": 0.1,
-            "allow_merges": 1,
+            "disable_merges": 0,
         },
     ]
 
@@ -1357,19 +1357,19 @@ def _insert_merge_execute(name, policy, parts, cmds, parts_before_cmds, parts_af
         node1.query("DROP TABLE IF EXISTS {name}".format(name=name))
 
 
-def _get_allow_merges_for_storage_policy(node, storage_policy):
-    return list(map(int, node.query("SELECT allow_merges FROM system.storage_policies WHERE policy_name = '{}' ORDER BY volume_priority".format(storage_policy)).splitlines()))
+def _get_disable_merges_for_storage_policy(node, storage_policy):
+    return list(map(int, node.query("SELECT disable_merges FROM system.storage_policies WHERE policy_name = '{}' ORDER BY volume_priority".format(storage_policy)).splitlines()))
 
 
 def test_no_merges_in_configuration_allow_from_query_without_reload(start_cluster):
     try:
         name = "test_no_merges_in_configuration_allow_from_query_without_reload"
         node1.restart_clickhouse(kill=True)
-        assert _get_allow_merges_for_storage_policy(node1, "small_jbod_with_external_no_merges") == [1, 0]
+        assert _get_disable_merges_for_storage_policy(node1, "small_jbod_with_external_no_merges") == [0, 1]
         _insert_merge_execute(name, "small_jbod_with_external_no_merges", 2, [
                 "SYSTEM START MERGES ON VOLUME small_jbod_with_external_no_merges.external"
             ], 2, 1)
-        assert _get_allow_merges_for_storage_policy(node1, "small_jbod_with_external_no_merges") == [1, 1]
+        assert _get_disable_merges_for_storage_policy(node1, "small_jbod_with_external_no_merges") == [0, 0]
 
     finally:
         node1.query("SYSTEM STOP MERGES ON VOLUME small_jbod_with_external_no_merges.external")
@@ -1379,12 +1379,12 @@ def test_no_merges_in_configuration_allow_from_query_with_reload(start_cluster):
     try:
         name = "test_no_merges_in_configuration_allow_from_query_with_reload"
         node1.restart_clickhouse(kill=True)
-        assert _get_allow_merges_for_storage_policy(node1, "small_jbod_with_external_no_merges") == [1, 0]
+        assert _get_disable_merges_for_storage_policy(node1, "small_jbod_with_external_no_merges") == [0, 1]
         _insert_merge_execute(name, "small_jbod_with_external_no_merges", 2, [
                 "SYSTEM START MERGES ON VOLUME small_jbod_with_external_no_merges.external",
                 "SYSTEM RELOAD CONFIG"
             ], 2, 1)
-        assert _get_allow_merges_for_storage_policy(node1, "small_jbod_with_external_no_merges") == [1, 1]
+        assert _get_disable_merges_for_storage_policy(node1, "small_jbod_with_external_no_merges") == [0, 0]
 
     finally:
         node1.query("SYSTEM STOP MERGES ON VOLUME small_jbod_with_external_no_merges.external")
@@ -1394,12 +1394,12 @@ def test_yes_merges_in_configuration_disallow_from_query_without_reload(start_cl
     try:
         name = "test_yes_merges_in_configuration_allow_from_query_without_reload"
         node1.restart_clickhouse(kill=True)
-        assert _get_allow_merges_for_storage_policy(node1, "small_jbod_with_external") == [1, 1]
+        assert _get_disable_merges_for_storage_policy(node1, "small_jbod_with_external") == [0, 0]
         _insert_merge_execute(name, "small_jbod_with_external", 2, [
                 "SYSTEM STOP MERGES ON VOLUME small_jbod_with_external.external",
                 "INSERT INTO {name} VALUES (2)".format(name=name)
             ], 1, 2)
-        assert _get_allow_merges_for_storage_policy(node1, "small_jbod_with_external") == [1, 0]
+        assert _get_disable_merges_for_storage_policy(node1, "small_jbod_with_external") == [0, 1]
 
     finally:
         node1.query("SYSTEM START MERGES ON VOLUME small_jbod_with_external.external")
@@ -1409,13 +1409,13 @@ def test_yes_merges_in_configuration_disallow_from_query_with_reload(start_clust
     try:
         name = "test_yes_merges_in_configuration_allow_from_query_with_reload"
         node1.restart_clickhouse(kill=True)
-        assert _get_allow_merges_for_storage_policy(node1, "small_jbod_with_external") == [1, 1]
+        assert _get_disable_merges_for_storage_policy(node1, "small_jbod_with_external") == [0, 0]
         _insert_merge_execute(name, "small_jbod_with_external", 2, [
                 "SYSTEM STOP MERGES ON VOLUME small_jbod_with_external.external",
                 "INSERT INTO {name} VALUES (2)".format(name=name),
                 "SYSTEM RELOAD CONFIG"
             ], 1, 2)
-        assert _get_allow_merges_for_storage_policy(node1, "small_jbod_with_external") == [1, 0]
+        assert _get_disable_merges_for_storage_policy(node1, "small_jbod_with_external") == [0, 1]
 
     finally:
         node1.query("SYSTEM START MERGES ON VOLUME small_jbod_with_external.external")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

- Renaming setting`allow_merges` ⟶ `disable_merges` for volumes in storage policy
