### PR TITLE
Increase limit in -Resample combinator to 1M

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionResample.h
+++ b/src/AggregateFunctions/AggregateFunctionResample.h
@@ -18,6 +18,7 @@ template <typename Key>
 class AggregateFunctionResample final : public IAggregateFunctionHelper<AggregateFunctionResample<Key>>
 {
 private:
+    /// Sanity threshold to avoid creation of too large arrays. The choice of this number is arbitrary.
     const size_t MAX_ELEMENTS = 1048576;
 
     AggregateFunctionPtr nested_function;

--- a/src/AggregateFunctions/AggregateFunctionResample.h
+++ b/src/AggregateFunctions/AggregateFunctionResample.h
@@ -18,7 +18,7 @@ template <typename Key>
 class AggregateFunctionResample final : public IAggregateFunctionHelper<AggregateFunctionResample<Key>>
 {
 private:
-    const size_t MAX_ELEMENTS = 4096;
+    const size_t MAX_ELEMENTS = 1048576;
 
     AggregateFunctionPtr nested_function;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Increase limit in -Resample combinator to 1M.


Detailed description / Documentation draft:

Before this patch, it was unable to use -Resample for more than 4096 intervals. Now it's much higher, 1048576.