### PR TITLE
Attempt to fix stress test

### DIFF
--- a/debian/clickhouse-server.init
+++ b/debian/clickhouse-server.init
@@ -76,7 +76,7 @@ is_supported_command()
 
 is_running()
 {
-    pgrep --pidfile "$CLICKHOUSE_PIDFILE" 1> /dev/null 2> /dev/null
+    pgrep --pidfile "$CLICKHOUSE_PIDFILE" $(echo \"${PROGRAM}\" | cut -c1-15) 1> /dev/null 2> /dev/null
 }
 
 

--- a/debian/clickhouse-server.init
+++ b/debian/clickhouse-server.init
@@ -76,7 +76,7 @@ is_supported_command()
 
 is_running()
 {
-    pgrep --pidfile "$CLICKHOUSE_PIDFILE" $(echo \"${PROGRAM}\" | cut -c1-15) 1> /dev/null 2> /dev/null
+    pgrep --pidfile "$CLICKHOUSE_PIDFILE" $(echo "${PROGRAM}" | cut -c1-15) 1> /dev/null 2> /dev/null
 }
 
 

--- a/debian/clickhouse-server.init
+++ b/debian/clickhouse-server.init
@@ -76,7 +76,7 @@ is_supported_command()
 
 is_running()
 {
-    [ -r "$CLICKHOUSE_PIDFILE" ] && pgrep -s $(cat "$CLICKHOUSE_PIDFILE") 1> /dev/null 2> /dev/null
+    pgrep --pidfile "$CLICKHOUSE_PIDFILE" 1> /dev/null 2> /dev/null
 }
 
 

--- a/tests/performance/linear_regression.xml
+++ b/tests/performance/linear_regression.xml
@@ -1,11 +1,8 @@
 <test>
-
-
     <preconditions>
         <table_exists>test.hits</table_exists>
         <table_exists>hits_100m_single</table_exists>
     </preconditions>
-
 
     <create_query>DROP TABLE IF EXISTS test_model</create_query>
     <create_query>CREATE TABLE test_model engine = Memory as select stochasticLinearRegressionState(0.0001)(Age, Income, ParamPrice, Robotness, RefererHash) as state from test.hits</create_query>


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Possible reason 1:
`clickhouse-server` may not stop in 120 seconds because OS takes a long time to finish the process and it remains in process table after `_Exit`. Then we cannot start it and get `Already running` message.

Possible reason 2:
Our SysV init script is deficient - it checks for running processes with specified pid. But if server was killed, pid can be reused by another process. Need to check that the running process is clickhouse-server and nothing else.