### PR TITLE
Add storages from <user_directories> after ones from <users_config> and <access_control_path>.

### DIFF
--- a/tests/integration/test_user_directories/configs/local_directories.xml
+++ b/tests/integration/test_user_directories/configs/local_directories.xml
@@ -12,4 +12,6 @@
             <path>/var/lib/clickhouse/access3-ro/</path>
         </local_directory>
     </user_directories>
+    <users_config remove="remove"/>
+    <access_control_path remove="remove"/>
 </yandex>

--- a/tests/integration/test_user_directories/configs/memory.xml
+++ b/tests/integration/test_user_directories/configs/memory.xml
@@ -5,4 +5,7 @@
         </users_xml>
         <memory/>
     </user_directories>
+
+    <users_config remove="remove"/>
+    <access_control_path remove="remove"/>
 </yandex>

--- a/tests/integration/test_user_directories/configs/mixed_style.xml
+++ b/tests/integration/test_user_directories/configs/mixed_style.xml
@@ -1,0 +1,8 @@
+<yandex>
+    <user_directories replace="replace">
+        <memory/>
+    </user_directories>
+
+    <users_config>/etc/clickhouse-server/users6.xml</users_config>
+    <access_control_path>/var/lib/clickhouse/access6/</access_control_path>
+</yandex>

--- a/tests/integration/test_user_directories/configs/old_style.xml
+++ b/tests/integration/test_user_directories/configs/old_style.xml
@@ -1,5 +1,6 @@
 <yandex>
     <users_config>/etc/clickhouse-server/users2.xml</users_config>
     <access_control_path>/var/lib/clickhouse/access2/</access_control_path>
+    
     <user_directories remove="remove"/>
 </yandex>

--- a/tests/integration/test_user_directories/configs/relative_path.xml
+++ b/tests/integration/test_user_directories/configs/relative_path.xml
@@ -4,4 +4,7 @@
             <path>users4.xml</path>
         </users_xml>
     </user_directories>
+
+    <users_config remove="remove"/>
+    <access_control_path remove="remove"/>
 </yandex>

--- a/tests/integration/test_user_directories/test.py
+++ b/tests/integration/test_user_directories/test.py
@@ -16,6 +16,7 @@ def started_cluster():
         node.exec_in_container("cp /etc/clickhouse-server/users.xml /etc/clickhouse-server/users3.xml")
         node.exec_in_container("cp /etc/clickhouse-server/users.xml /etc/clickhouse-server/users4.xml")
         node.exec_in_container("cp /etc/clickhouse-server/users.xml /etc/clickhouse-server/users5.xml")
+        node.exec_in_container("cp /etc/clickhouse-server/users.xml /etc/clickhouse-server/users6.xml")
 
         yield cluster
 
@@ -49,3 +50,10 @@ def test_memory():
     node.restart_clickhouse()
     assert node.query("SELECT * FROM system.user_directories") == TSV([["users.xml", "users.xml", "/etc/clickhouse-server/users5.xml", 1, 1],
                                                                        ["memory",    "memory",    "",                                  0, 2]])
+
+def test_mixed_style():
+    node.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/mixed_style.xml"), '/etc/clickhouse-server/config.d/z.xml')
+    node.restart_clickhouse()
+    assert node.query("SELECT * FROM system.user_directories") == TSV([["users.xml",       "users.xml",       "/etc/clickhouse-server/users6.xml", 1, 1],
+                                                                       ["local directory", "local directory", "/var/lib/clickhouse/access6/",      0, 2],
+                                                                       ["memory",          "memory",          "",                                  0, 3]])


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category :
- Not for changelog

Add storages from <user_directories> after ones from <users_config> and <access_control_path>.
Follow-up to https://github.com/ClickHouse/ClickHouse/pull/13425
