### PR TITLE
Update json-import.md

### DIFF
--- a/docs/en/faq/integration/json-import.md
+++ b/docs/en/faq/integration/json-import.md
@@ -19,7 +19,7 @@ $ echo '{"foo":"bar"}' | curl 'http://localhost:8123/?query=INSERT%20INTO%20test
 Using [CLI interface](../../interfaces/cli.md):
 
 ``` bash
-$ echo '{"foo":"bar"}'  | clickhouse-client ---query="INSERT INTO test FORMAT 20JSONEachRow"
+$ echo '{"foo":"bar"}'  | clickhouse-client ---query="INSERT INTO test FORMAT JSONEachRow"
 ```
 
 Instead of inserting data manually, you might consider to use one of [client libraries](../../interfaces/index.md) instead.


### PR DESCRIPTION
Correct a (possible) typo at Using CLI interface part of the documentation. 

The insert/input format specified shall be `JSONEachRow` rather than `20JSONEachRow`.

[the Patch file](https://patch-diff.githubusercontent.com/raw/ClickHouse/ClickHouse/pull/14038.patch)

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Detailed description / Documentation draft:

Correct a (possible) typo at Using CLI interface part of the documentation. 

The insert/input format specified shall be `JSONEachRow` rather than `20JSONEachRow`.

https://patch-diff.githubusercontent.com/raw/ClickHouse/ClickHouse/pull/14038.patch


