### PR TITLE
Fix "no space left" extra info for Poco::Exception

### DIFF
--- a/src/Common/Exception.cpp
+++ b/src/Common/Exception.cpp
@@ -205,7 +205,19 @@ static std::string getExtraExceptionInfo(const std::exception & e)
         if (const auto * file_exception = dynamic_cast<const Poco::FileException *>(&e))
         {
             if (file_exception->code() == ENOSPC)
-                getNoSpaceLeftInfoMessage(file_exception->message(), msg);
+            {
+                /// See Poco::FileImpl::handleLastErrorImpl(...)
+                constexpr const char * expected_error_message = "no space left on device: ";
+                if (startsWith(file_exception->message(), expected_error_message))
+                {
+                    String path = file_exception->message().substr(strlen(expected_error_message));
+                    getNoSpaceLeftInfoMessage(path, msg);
+                }
+                else
+                {
+                    msg += "\nCannot print extra info for Poco::Exception";
+                }
+            }
         }
         else if (const auto * errno_exception = dynamic_cast<const DB::ErrnoException *>(&e))
         {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed wrong mount point in extra info for `Poco::Exception: no space left on device` 
