### PR TITLE
adds some info to the exception about zookeeper path

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -3484,7 +3484,10 @@ std::optional<UInt64> StorageReplicatedMergeTree::totalBytes() const
 void StorageReplicatedMergeTree::assertNotReadonly() const
 {
     if (is_readonly)
-        throw Exception("Table is in readonly mode", ErrorCodes::TABLE_IS_READ_ONLY);
+    {
+        auto err = "Table is in readonly mode (zookeeper path: " + zookeeper_path + ")";
+        throw Exception(err, ErrorCodes::TABLE_IS_READ_ONLY);
+    }
 }
 
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -3484,10 +3484,7 @@ std::optional<UInt64> StorageReplicatedMergeTree::totalBytes() const
 void StorageReplicatedMergeTree::assertNotReadonly() const
 {
     if (is_readonly)
-    {
-        auto err = "Table is in readonly mode (zookeeper path: " + zookeeper_path + ")";
-        throw Exception(err, ErrorCodes::TABLE_IS_READ_ONLY);
-    }
+        throw Exception(ErrorCodes::TABLE_IS_READ_ONLY, "Table is in readonly mode (zookeeper path: {})", zookeeper_path);
 }
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Added extra information about table zookeeper path to debug problems 

...


Sometimes I get some exceptions with unknown source, this small debug info helps to find the tables with metadata problems.

