### PR TITLE
Fix test `01056_prepared_statements_null_and_escaping.sh`

### DIFF
--- a/tests/queries/0_stateless/01056_prepared_statements_null_and_escaping.sh
+++ b/tests/queries/0_stateless/01056_prepared_statements_null_and_escaping.sh
@@ -22,7 +22,7 @@ ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&param_x=%5CN" \
     -d "SELECT {x:Nullable(String)}";
 
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&param_x=Hello,%09World" \
-    -d "SELECT {x:Nullable(String)}" 2>&1 | grep -oF '457';
+    -d "SELECT {x:Nullable(String)}" 2>&1 | grep -oF '457' | head -n1;
 
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&param_x=Hello,%0AWorld" \
-    -d "SELECT {x:Nullable(String)}" 2>&1 | grep -oF '457';
+    -d "SELECT {x:Nullable(String)}" 2>&1 | grep -oF '457' | head -n1;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)
