### PR TITLE
Alternative implementation of #14043

### DIFF
--- a/src/Storages/StorageMemory.cpp
+++ b/src/Storages/StorageMemory.cpp
@@ -126,20 +126,27 @@ Pipe StorageMemory::read(
 
     Pipes pipes;
 
+    BlocksList::iterator first = data.begin();
+
+    size_t offset = 0;
     for (size_t stream = 0; stream < num_streams; ++stream)
     {
-        BlocksList::iterator first = data.begin();
-        BlocksList::iterator last = data.begin();
+        auto next = first;
+        while (offset < stream * size / num_streams)
+        {
+            ++next;
+            ++offset;
+        }
 
-        std::advance(first, stream * size / num_streams);
-        std::advance(last, (stream + 1) * size / num_streams);
-
-        if (first == last)
+        if (first == next)
             continue;
-        else
-            --last;
+
+        auto last = next;
+        --last;
 
         pipes.emplace_back(std::make_shared<MemorySource>(column_names, first, last, *this, metadata_snapshot));
+
+        first = next;
     }
 
     return Pipe::unitePipes(std::move(pipes));

--- a/src/Storages/StorageMemory.cpp
+++ b/src/Storages/StorageMemory.cpp
@@ -57,11 +57,12 @@ protected:
             for (const auto & name : column_names)
                 columns.emplace_back(src.getByName(name).column);
 
-            ++current_it;
             ++current_block_idx;
 
             if (current_block_idx == num_blocks)
                 is_finished = true;
+            else
+                ++current_it;
 
             return Chunk(std::move(columns), src.rows());
         }

--- a/src/Storages/StorageMemory.cpp
+++ b/src/Storages/StorageMemory.cpp
@@ -57,15 +57,12 @@ protected:
             for (const auto & name : column_names)
                 columns.emplace_back(src.getByName(name).column);
 
+            ++current_it;
+            ++current_block_idx;
+
             if (current_block_idx == num_blocks)
-            {
                 is_finished = true;
-            }
-            else
-            {
-                ++current_it;
-                ++current_block_idx;
-            }
+
             return Chunk(std::move(columns), src.rows());
         }
     }
@@ -137,7 +134,7 @@ Pipe StorageMemory::read(
     size_t offset = 0;
     for (size_t stream = 0; stream < num_streams; ++stream)
     {
-        size_t next_offset = stream * size / num_streams;
+        size_t next_offset = (stream + 1) * size / num_streams;
         size_t num_blocks = next_offset - offset;
 
         assert(num_blocks > 0);


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Slightly better performance of Memory table if it was constructed from a huge number of very small blocks (that's unlikely). Author of the idea: [Mark Papadakis](https://github.com/markpapadakis). Closes #14043.
