### PR TITLE
Use terminal width for the formatted help text of the clickhouse-copier

### DIFF
--- a/programs/copier/ClusterCopierApp.cpp
+++ b/programs/copier/ClusterCopierApp.cpp
@@ -1,5 +1,7 @@
 #include "ClusterCopierApp.h"
 #include <Common/StatusFile.h>
+#include <Common/TerminalSize.h>
+#include <unistd.h>
 
 
 namespace DB
@@ -52,7 +54,13 @@ void ClusterCopierApp::initialize(Poco::Util::Application & self)
 
 void ClusterCopierApp::handleHelp(const std::string &, const std::string &)
 {
+    uint16_t terminal_width = 0;
+    if (isatty(STDIN_FILENO))
+        terminal_width = getTerminalWidth();
+
     Poco::Util::HelpFormatter help_formatter(options());
+    if (terminal_width)
+        help_formatter.setWidth(terminal_width);
     help_formatter.setCommand(commandName());
     help_formatter.setHeader("Copies tables from one cluster to another");
     help_formatter.setUsage("--config-file <config-file> --task-path <task-path>");


### PR DESCRIPTION
Like other utils, clickhouse-client and so on (since copier uses Poco,
while other uses boost).
Otherwise clickhouse-copier --help is unreadable.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @nikitamikhaylov 