### PR TITLE
gcc10 build fixes

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionTimeSeriesGroupSum.h
+++ b/src/AggregateFunctions/AggregateFunctionTimeSeriesGroupSum.h
@@ -108,13 +108,13 @@ struct AggregateFunctionTimeSeriesGroupSumData
             else
                 result.emplace_back(std::make_pair(t, v));
         }
-        size_t i = result.size() - 1;
+        ssize_t i = result.size() - 1;
         //reverse find out the index of timestamp that more than previous timestamp of t
         while (result[i].first > it_ss->second.dps.front().first && i >= 0)
             i--;
 
         i++;
-        while (i < result.size() - 1)
+        while (i < ssize_t(result.size()) - 1)
         {
             result[i].second += it_ss->second.getval(result[i].first);
             i++;

--- a/src/Common/UInt128.h
+++ b/src/Common/UInt128.h
@@ -89,8 +89,8 @@ struct UInt128
     UInt128 & operator= (const UInt64 rhs) { low = rhs; high = 0; return *this; }
 };
 
-template <typename T> bool inline operator == (T a, const UInt128 b) { return b == a; }
-template <typename T> bool inline operator != (T a, const UInt128 b) { return b != a; }
+template <typename T> bool inline operator == (T a, const UInt128 b) { return b.operator==(a); }
+template <typename T> bool inline operator != (T a, const UInt128 b) { return b.operator!=(a); }
 template <typename T> bool inline operator >= (T a, const UInt128 b) { return b <= a; }
 template <typename T> bool inline operator >  (T a, const UInt128 b) { return b < a; }
 template <typename T> bool inline operator <= (T a, const UInt128 b) { return b >= a; }


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

gcc10 build fixes:
- Fix C++20 comparison calls recursively with reversed arguments in `UInt128.h` ([over.match.oper#3.4.4](http://eel.is/c++draft/over.match.oper#3.4.4))
- Fix `-Werror=type-limits` in `AggregateFunctionTimeSeriesGroupSum.h` (`size_t() >= 0`)

P.S. there are still few issues left:
- some issues with APInt.h compilation (llvm)
- `-Werror=vector-operation-performance` in `negate`
- #13901 (regression in gcc10 for `-Wstringop-overflow`)