### PR TITLE
Fix error in clickhouse-benchmark test

### DIFF
--- a/tests/queries/0_stateless/01393_benchmark_secure_port.sh
+++ b/tests/queries/0_stateless/01393_benchmark_secure_port.sh
@@ -3,4 +3,4 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../shell_config.sh
 
-$CLICKHOUSE_BENCHMARK --secure -i 100 <<< 'SELECT 1' 2>&1 | grep -F 'Queries executed'
+$CLICKHOUSE_BENCHMARK --secure -i 100 <<< 'SELECT 1' 2>&1 | grep -F 'Queries executed' | tail -n1


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://clickhouse-test-reports.s3.yandex.net/14048/f95acff93cb17afda047f6fe2d40ebb59e3fb2f8/functional_stateless_tests_(debug)/test_run.txt.out.log

https://github.com/ClickHouse/ClickHouse/pull/14048