### PR TITLE
Fix hardcoded timeout

### DIFF
--- a/src/Dictionaries/CacheDictionary.cpp
+++ b/src/Dictionaries/CacheDictionary.cpp
@@ -817,7 +817,7 @@ void CacheDictionary::waitForCurrentUpdateFinish(UpdateUnitPtr & update_unit_ptr
         update_unit_ptr->can_use_callback = false;
         throw DB::Exception(ErrorCodes::TIMEOUT_EXCEEDED,
                             "Dictionary {} source seems unavailable, because {}ms timeout exceeded.",
-                            getDictionaryID().getNameForLogs(), toString(timeout_for_wait));
+                            getDictionaryID().getNameForLogs(), toString(query_wait_timeout_milliseconds));
     }
 
 

--- a/src/Dictionaries/CacheDictionary.cpp
+++ b/src/Dictionaries/CacheDictionary.cpp
@@ -798,10 +798,9 @@ void CacheDictionary::waitForCurrentUpdateFinish(UpdateUnitPtr & update_unit_ptr
 {
     std::unique_lock<std::mutex> update_lock(update_mutex);
 
-    size_t timeout_for_wait = 100000;
     bool result = is_update_finished.wait_for(
             update_lock,
-            std::chrono::milliseconds(timeout_for_wait),
+            std::chrono::milliseconds(query_wait_timeout_milliseconds),
             [&] { return update_unit_ptr->is_done || update_unit_ptr->current_exception; });
 
     if (!result)
@@ -817,7 +816,7 @@ void CacheDictionary::waitForCurrentUpdateFinish(UpdateUnitPtr & update_unit_ptr
          * */
         update_unit_ptr->can_use_callback = false;
         throw DB::Exception(ErrorCodes::TIMEOUT_EXCEEDED,
-                            "Dictionary {} source seems unavailable, because {} timeout exceeded.",
+                            "Dictionary {} source seems unavailable, because {}ms timeout exceeded.",
                             getDictionaryID().getNameForLogs(), toString(timeout_for_wait));
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
When waiting for a dictionary update to complete, use the timeout specified by `query_wait_timeout_milliseconds` setting instead of a hard-coded value.
