### PR TITLE
testflows: adding retry logic when bringing up docker-compose cluster

### DIFF
--- a/docker/test/testflows/runner/Dockerfile
+++ b/docker/test/testflows/runner/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update \
 ENV TZ=Europe/Moscow
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN pip3 install urllib3 testflows==1.6.39 docker-compose docker dicttoxml kazoo tzlocal
+RUN pip3 install urllib3 testflows==1.6.42 docker-compose docker dicttoxml kazoo tzlocal
 
 ENV DOCKER_CHANNEL stable
 ENV DOCKER_VERSION 17.09.1-ce

--- a/tests/testflows/helpers/cluster.py
+++ b/tests/testflows/helpers/cluster.py
@@ -258,22 +258,22 @@ class Cluster(object):
         with Given("docker-compose"):
             max_attempts = 5
             for attempt in range(max_attempts):
-                with When("attempt {attempt}/{max_attempts}"):
+                with When(f"attempt {attempt}/{max_attempts}"):
                     with By("pulling images for all the services"):
-                        cmd = self.command(None, f'{self.docker_compose} pull 2>&1 | tee', exitcode=None, timeout=timeout)
+                        cmd = self.command(None, f"{self.docker_compose} pull 2>&1 | tee", exitcode=None, timeout=timeout)
                         if cmd.exitcode != 0:
                             continue
                     with And("executing docker-compose down just in case it is up"):
-                        cmd = self.command(None, f'{self.docker_compose} down 2>&1 | tee', exitcode=None, timeout=timeout)
+                        cmd = self.command(None, f"{self.docker_compose} down 2>&1 | tee", exitcode=None, timeout=timeout)
                         if cmd.exitcode != 0:
                             continue
                     with And("executing docker-compose up"):
-                        cmd = self.command(None, f'{self.docker_compose} up -d 2>&1 | tee', timeout=timeout)
+                        cmd = self.command(None, f"{self.docker_compose} up -d 2>&1 | tee", timeout=timeout)
 
                     with Then("check there are no unhealthy containers"):
                         if "is unhealthy" in cmd.output:
-                            self.command(None, f'{self.docker_compose} ps | tee')
-                            self.command(None, f'{self.docker_compose} logs | tee')
+                            self.command(None, f"{self.docker_compose} ps | tee")
+                            self.command(None, f"{self.docker_compose} logs | tee")
 
                     if cmd.exitcode == 0:
                         break

--- a/tests/testflows/helpers/cluster.py
+++ b/tests/testflows/helpers/cluster.py
@@ -246,7 +246,7 @@ class Cluster(object):
                     assert os.path.exists(self.clickhouse_binary_path)
 
             with And("I set all the necessary environment variables"):
-                os.environ["COMPOSE_HTTP_TIMEOUT"] = 300
+                os.environ["COMPOSE_HTTP_TIMEOUT"] = "300"
                 os.environ["CLICKHOUSE_TESTS_SERVER_BIN_PATH"] = self.clickhouse_binary_path
                 os.environ["CLICKHOUSE_TESTS_ODBC_BRIDGE_BIN_PATH"] = os.path.join(
                     os.path.dirname(self.clickhouse_binary_path), "clickhouse-odbc-bridge")

--- a/tests/testflows/helpers/cluster.py
+++ b/tests/testflows/helpers/cluster.py
@@ -246,6 +246,7 @@ class Cluster(object):
                     assert os.path.exists(self.clickhouse_binary_path)
 
             with And("I set all the necessary environment variables"):
+                os.environ["COMPOSE_HTTP_TIMEOUT"] = 300
                 os.environ["CLICKHOUSE_TESTS_SERVER_BIN_PATH"] = self.clickhouse_binary_path
                 os.environ["CLICKHOUSE_TESTS_ODBC_BRIDGE_BIN_PATH"] = os.path.join(
                     os.path.dirname(self.clickhouse_binary_path), "clickhouse-odbc-bridge")
@@ -255,18 +256,30 @@ class Cluster(object):
                 self.command(None, "env | grep CLICKHOUSE")
 
         with Given("docker-compose"):
-            with By("pulling images for all the services"):
-                self.command(None, f'{self.docker_compose} pull 2>&1 | tee', exitcode=0, timeout=timeout)
-            with And("executing docker-compose down just in case it is up"):
-                self.command(None, f'{self.docker_compose} down 2>&1 | tee', exitcode=0, timeout=timeout)
-            with And("executing docker-compose up"):
-                cmd = self.command(None, f'{self.docker_compose} up -d 2>&1 | tee', timeout=timeout)
+            max_attempts = 5
+            for attempt in range(max_attempts):
+                with When("attempt {attempt}/{max_attempts}"):
+                    with By("pulling images for all the services"):
+                        cmd = self.command(None, f'{self.docker_compose} pull 2>&1 | tee', exitcode=None, timeout=timeout)
+                        if cmd.exitcode != 0:
+                            continue
+                    with And("executing docker-compose down just in case it is up"):
+                        cmd = self.command(None, f'{self.docker_compose} down 2>&1 | tee', exitcode=None, timeout=timeout)
+                        if cmd.exitcode != 0:
+                            continue
+                    with And("executing docker-compose up"):
+                        cmd = self.command(None, f'{self.docker_compose} up -d 2>&1 | tee', timeout=timeout)
 
-        with Then("check there are no unhealthy containers"):
-            if "is unhealthy" in cmd.output:
-                self.command(None, f'{self.docker_compose} ps | tee')
-                self.command(None, f'{self.docker_compose} logs | tee')
-                fail("found unhealthy containers")
+                    with Then("check there are no unhealthy containers"):
+                        if "is unhealthy" in cmd.output:
+                            self.command(None, f'{self.docker_compose} ps | tee')
+                            self.command(None, f'{self.docker_compose} logs | tee')
+
+                    if cmd.exitcode == 0:
+                        break
+
+            if cmd.exitcode != 0:
+                fail("could not bring up docker-compose cluster")
 
         with Then("wait all nodes report healhy"):
             for name in self.nodes["clickhouse"]:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

These changes are to address fail in https://clickhouse-test-reports.s3.yandex.net/0/5a8bd865eed9c6e860e8d1e7ff3eefa9b7016a63/testflows_check.html.

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* Adding retry logic when bringing up docker-compose cluster
* Increasing COMPOSE_HTTP_TIMEOUT

Detailed description / Documentation draft:
* Adding retry logic when bringing up docker-compose cluster
* Increasing COMPOSE_HTTP_TIMEOUT
