### PR TITLE
Support parallel INSERT for more table engines

### DIFF
--- a/src/Storages/StorageBuffer.h
+++ b/src/Storages/StorageBuffer.h
@@ -65,6 +65,8 @@ public:
         size_t max_block_size,
         unsigned num_streams) override;
 
+    bool supportsParallelInsert() const override { return true; }
+
     BlockOutputStreamPtr write(const ASTPtr & query, const StorageMetadataPtr & /*metadata_snapshot*/, const Context & context) override;
 
     void startup() override;

--- a/src/Storages/StorageDistributed.h
+++ b/src/Storages/StorageDistributed.h
@@ -79,6 +79,8 @@ public:
         size_t max_block_size,
         unsigned num_streams) override;
 
+    bool supportsParallelInsert() const override { return true; }
+
     BlockOutputStreamPtr write(const ASTPtr & query, const StorageMetadataPtr & /*metadata_snapshot*/, const Context & context) override;
 
     /// Removes temporary data in local filesystem.

--- a/src/Storages/StorageMemory.h
+++ b/src/Storages/StorageMemory.h
@@ -37,6 +37,8 @@ public:
         size_t max_block_size,
         unsigned num_streams) override;
 
+    bool supportsParallelInsert() const override { return true; }
+
     BlockOutputStreamPtr write(const ASTPtr & query, const StorageMetadataPtr & metadata_snapshot, const Context & context) override;
 
     void drop() override;

--- a/src/Storages/StorageNull.h
+++ b/src/Storages/StorageNull.h
@@ -35,6 +35,8 @@ public:
             std::make_shared<NullSource>(metadata_snapshot->getSampleBlockForColumns(column_names, getVirtuals(), getStorageID())));
     }
 
+    bool supportsParallelInsert() const override { return true; }
+
     BlockOutputStreamPtr write(const ASTPtr &, const StorageMetadataPtr & metadata_snapshot, const Context &) override
     {
         return std::make_shared<NullBlockOutputStream>(metadata_snapshot->getSampleBlock());

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -17,3 +17,10 @@ If your test continued more than 10 minutes, please, add tag `long` to have an o
 ### How to run performance test
 
 TODO @akuzm
+
+### How to validate single test
+
+```
+pip3 install clickhouse_driver
+../../docker/test/performance-comparison/perf.py --runs 1 insert_parallel.xml
+```

--- a/tests/performance/insert_parallel.xml
+++ b/tests/performance/insert_parallel.xml
@@ -1,0 +1,5 @@
+<test>
+    <create_query>CREATE TABLE t (x UInt64) ENGINE = Null</create_query>
+    <query>INSERT INTO t SELECT * FROM numbers_mt(1000000000)</query>
+    <drop_query>DROP TABLE IF EXISTS t</drop_query>
+</test>


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Enable parallel INSERTs for table engines `Null`, `Memory`, `Distributed` and `Buffer`.