### PR TITLE
Increase number of threads in stress test

### DIFF
--- a/docker/test/stress/stress
+++ b/docker/test/stress/stress
@@ -62,12 +62,8 @@ if __name__ == "__main__":
     parser.add_argument("--perf-test-xml-path", default='/usr/share/clickhouse-test/performance/')
     parser.add_argument("--server-log-folder", default='/var/log/clickhouse-server')
     parser.add_argument("--output-folder")
-<<<<<<< Updated upstream
     parser.add_argument("--global-time-limit", type=int, default=3600)
-    parser.add_argument("--num-parallel", default=cpu_count() // 3);
-=======
     parser.add_argument("--num-parallel", default=cpu_count());
->>>>>>> Stashed changes
 
     args = parser.parse_args()
     func_pipes = []

--- a/docker/test/stress/stress
+++ b/docker/test/stress/stress
@@ -62,8 +62,12 @@ if __name__ == "__main__":
     parser.add_argument("--perf-test-xml-path", default='/usr/share/clickhouse-test/performance/')
     parser.add_argument("--server-log-folder", default='/var/log/clickhouse-server')
     parser.add_argument("--output-folder")
+<<<<<<< Updated upstream
     parser.add_argument("--global-time-limit", type=int, default=3600)
     parser.add_argument("--num-parallel", default=cpu_count() // 3);
+=======
+    parser.add_argument("--num-parallel", default=cpu_count());
+>>>>>>> Stashed changes
 
     args = parser.parse_args()
     func_pipes = []


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

There was no reason why it was three times less.
