### PR TITLE
Allow FETCH PARTITION from other zookeepers

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1455,7 +1455,12 @@ zkutil::ZooKeeperPtr Context::getAuxiliaryZooKeeper(const String & name) const
 
     auto zookeeper = shared->auxiliary_zookeepers.find(name);
     if (zookeeper == shared->auxiliary_zookeepers.end())
+    {
+        if (!getConfigRef().has("auxiliary_zookeepers." + name))
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown auxiliary ZooKeeper name '{}'. If it's required it can be added to the section <auxiliary_zookeepers> in config.xml", name);
+
         zookeeper->second = std::make_shared<zkutil::ZooKeeper>(getConfigRef(), "auxiliary_zookeepers." + name);
+    }
     else if (zookeeper->second->expired())
         zookeeper->second = zookeeper->second->startNewSession();
 

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -306,6 +306,9 @@ struct ContextShared
 
     mutable zkutil::ZooKeeperPtr zookeeper;                 /// Client for ZooKeeper.
 
+    mutable std::mutex auxiliary_zookeepers_mutex;
+    mutable std::map<String, zkutil::ZooKeeperPtr> auxiliary_zookeepers;    /// Map for auxiliary ZooKeeper clients.
+
     String interserver_io_host;                             /// The host name by which this server is available for other servers.
     UInt16 interserver_io_port = 0;                         /// and port.
     String interserver_io_user;
@@ -1444,6 +1447,19 @@ zkutil::ZooKeeperPtr Context::getZooKeeper() const
         shared->zookeeper = shared->zookeeper->startNewSession();
 
     return shared->zookeeper;
+}
+
+zkutil::ZooKeeperPtr Context::getAuxiliaryZooKeeper(const String & name) const
+{
+    std::lock_guard lock(shared->auxiliary_zookeepers_mutex);
+
+    auto zookeeper = shared->auxiliary_zookeepers.find(name);
+    if (zookeeper == shared->auxiliary_zookeepers.end())
+        zookeeper->second = std::make_shared<zkutil::ZooKeeper>(getConfigRef(), "auxiliary_zookeepers." + name);
+    else if (zookeeper->second->expired())
+        zookeeper->second = zookeeper->second->startNewSession();
+
+    return zookeeper->second;
 }
 
 void Context::resetZooKeeper() const

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -474,6 +474,8 @@ public:
     /// If the current session is expired at the time of the call, synchronously creates and returns a new session with the startNewSession() call.
     /// If no ZooKeeper configured, throws an exception.
     std::shared_ptr<zkutil::ZooKeeper> getZooKeeper() const;
+    /// Same as above but return a zookeeper connection from auxiliary_zookeepers configuration entry.
+    std::shared_ptr<zkutil::ZooKeeper> getAuxiliaryZooKeeper(const String & name) const;
     /// Has ready or expired ZooKeeper
     bool hasZooKeeper() const;
     /// Reset current zookeeper session. Do not create a new one.

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -478,7 +478,13 @@ private:
       * If quorum != 0, then the node for tracking the quorum is updated.
       * Returns false if part is already fetching right now.
       */
-    bool fetchPart(const String & part_name, const StorageMetadataPtr & metadata_snapshot, const String & replica_path, bool to_detached, size_t quorum);
+    bool fetchPart(
+        const String & part_name,
+        const StorageMetadataPtr & metadata_snapshot,
+        const String & replica_path,
+        bool to_detached,
+        size_t quorum,
+        zkutil::ZooKeeper::Ptr zookeeper_ = nullptr);
 
     /// Required only to avoid races between executeLogEntry and fetchPartition
     std::unordered_set<String> currently_fetching_parts;

--- a/tests/integration/test_fetch_partition_from_auxiliary_zookeeper/configs/zookeeper_config.xml
+++ b/tests/integration/test_fetch_partition_from_auxiliary_zookeeper/configs/zookeeper_config.xml
@@ -1,0 +1,28 @@
+<yandex>
+    <zookeeper>
+        <node index="1">
+            <host>zoo1</host>
+            <port>2181</port>
+        </node>
+        <node index="2">
+            <host>zoo2</host>
+            <port>2181</port>
+        </node>
+        <node index="3">
+            <host>zoo3</host>
+            <port>2181</port>
+        </node>
+    </zookeeper>
+    <auxiliary_zookeepers>
+        <zookeeper2>
+            <node index="1">
+                <host>zoo1</host>
+                <port>2181</port>
+            </node>
+            <node index="2">
+                <host>zoo2</host>
+                <port>2181</port>
+            </node>
+        </zookeeper2>
+    </auxiliary_zookeepers>
+</yandex>

--- a/tests/integration/test_fetch_partition_from_auxiliary_zookeeper/test.py
+++ b/tests/integration/test_fetch_partition_from_auxiliary_zookeeper/test.py
@@ -1,35 +1,42 @@
 from __future__ import print_function
 from helpers.cluster import ClickHouseCluster
+from helpers.client import QueryRuntimeException
 import helpers
 import pytest
 
-def test_chroot_with_same_root():
 
-    cluster = ClickHouseCluster(
-        __file__, zookeeper_config_path="configs/zookeeper_config.xml"
-    )
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node", main_configs=["configs/zookeeper_config.xml"], with_zookeeper=True)
 
-    node = cluster.add_instance(
-        "node", config_dir="configs", with_zookeeper=True, zookeeper_use_tmpfs=False
-    )
 
+
+@pytest.fixture(scope="module")
+def start_cluster():
     try:
         cluster.start()
 
-        node.query(
-            "CREATE TABLE simple (date Date, id UInt32) ENGINE = ReplicatedMergeTree('/clickhouse/tables/0/simple', 'node') PARTITION BY date;"
-        )
-        node.query("INSERT INTO simple VALUES ('2020-08-27', 1)")
-
-        node.query(
-            "CREATE TABLE simple2 (date Date, id UInt32) ENGINE = ReplicatedMergeTree('/clickhouse/tables/1/simple', 'node') PARTITION BY date;"
-        )
-        node.query(
-            "ALTER TABLE simple2 FETCH PARTITION '2020-08-27' FROM 'zookeeper2:/clickhouse/tables/0/simple';"
-        )
-        node.query("ALTER TABLE simple2 ATTACH PARTITION '2020-08-27';")
-
-        assert node.query("SELECT id FROM simple2").strip() == "1"
-
+        yield cluster
     finally:
         cluster.shutdown()
+
+
+def test_chroot_with_same_root(start_cluster):
+    node.query(
+        "CREATE TABLE simple (date Date, id UInt32) ENGINE = ReplicatedMergeTree('/clickhouse/tables/0/simple', 'node') ORDER BY tuple() PARTITION BY date;"
+    )
+    node.query("INSERT INTO simple VALUES ('2020-08-27', 1)")
+
+    node.query(
+        "CREATE TABLE simple2 (date Date, id UInt32) ENGINE = ReplicatedMergeTree('/clickhouse/tables/1/simple', 'node') ORDER BY tuple() PARTITION BY date;"
+    )
+    node.query(
+        "ALTER TABLE simple2 FETCH PARTITION '2020-08-27' FROM 'zookeeper2:/clickhouse/tables/0/simple';"
+    )
+    node.query("ALTER TABLE simple2 ATTACH PARTITION '2020-08-27';")
+
+    with pytest.raises(QueryRuntimeException):
+        node.query(
+            "ALTER TABLE simple2 FETCH PARTITION '2020-08-27' FROM 'zookeeper:/clickhouse/tables/0/simple';"
+        )
+
+    assert node.query("SELECT id FROM simple2").strip() == "1"

--- a/tests/integration/test_fetch_partition_from_auxiliary_zookeeper/test.py
+++ b/tests/integration/test_fetch_partition_from_auxiliary_zookeeper/test.py
@@ -20,7 +20,7 @@ def start_cluster():
         cluster.shutdown()
 
 
-def test_chroot_with_same_root(start_cluster):
+def test_fetch_part_from_allowed_zookeeper(start_cluster):
     node.query(
         "CREATE TABLE simple (date Date, id UInt32) ENGINE = ReplicatedMergeTree('/clickhouse/tables/0/simple', 'node') ORDER BY tuple() PARTITION BY date;"
     )

--- a/tests/integration/test_fetch_partition_from_auxiliary_zookeeper/test.py
+++ b/tests/integration/test_fetch_partition_from_auxiliary_zookeeper/test.py
@@ -1,0 +1,35 @@
+from __future__ import print_function
+from helpers.cluster import ClickHouseCluster
+import helpers
+import pytest
+
+def test_chroot_with_same_root():
+
+    cluster = ClickHouseCluster(
+        __file__, zookeeper_config_path="configs/zookeeper_config.xml"
+    )
+
+    node = cluster.add_instance(
+        "node", config_dir="configs", with_zookeeper=True, zookeeper_use_tmpfs=False
+    )
+
+    try:
+        cluster.start()
+
+        node.query(
+            "CREATE TABLE simple (date Date, id UInt32) ENGINE = ReplicatedMergeTree('/clickhouse/tables/0/simple', 'node') PARTITION BY date;"
+        )
+        node.query("INSERT INTO simple VALUES ('2020-08-27', 1)")
+
+        node.query(
+            "CREATE TABLE simple2 (date Date, id UInt32) ENGINE = ReplicatedMergeTree('/clickhouse/tables/1/simple', 'node') PARTITION BY date;"
+        )
+        node.query(
+            "ALTER TABLE simple2 FETCH PARTITION '2020-08-27' FROM 'zookeeper2:/clickhouse/tables/0/simple';"
+        )
+        node.query("ALTER TABLE simple2 ATTACH PARTITION '2020-08-27';")
+
+        assert node.query("SELECT id FROM simple2").strip() == "1"
+
+    finally:
+        cluster.shutdown()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Now it's possible to `ALTER TABLE table_name FETCH PARTITION partition_expr FROM 'zk://<host>:<port>/path-in-zookeeper'`. It's useful for shipping data to new clusters.

Detailed description / Documentation draft:

Documentation needs syncing.