### PR TITLE
Switch docker tests to use test-base

### DIFF
--- a/docker/images.json
+++ b/docker/images.json
@@ -2,10 +2,6 @@
     "docker/packager/deb": {
         "name": "yandex/clickhouse-deb-builder",
         "dependent": [
-            "docker/test/stateless",
-            "docker/test/stateless_with_coverage",
-            "docker/test/stateless_pytest",
-            "docker/test/coverage",
             "docker/packager/unbundled"
         ]
     },
@@ -136,6 +132,10 @@
     "docker/test/base": {
          "name": "yandex/clickhouse-test-base",
          "dependent": [
+            "docker/test/stateless",
+            "docker/test/stateless_with_coverage",
+            "docker/test/stateless_pytest",
+            "docker/test/coverage"
          ]
     },
     "docker/packager/unbundled": {

--- a/docker/test/coverage/Dockerfile
+++ b/docker/test/coverage/Dockerfile
@@ -1,32 +1,11 @@
 # docker build -t yandex/clickhouse-coverage .
-FROM yandex/clickhouse-deb-builder
-
-RUN apt-get --allow-unauthenticated update -y \
-    && env DEBIAN_FRONTEND=noninteractive \
-    apt-get --allow-unauthenticated install --yes --no-install-recommends \
-    bash \
-    fakeroot \
-    cmake \
-    ccache \
-    curl \
-    software-properties-common
-
-
-RUN apt-get --allow-unauthenticated update -y \
-    && env DEBIAN_FRONTEND=noninteractive \
-        apt-get --allow-unauthenticated install --yes --no-install-recommends \
-            perl \
-            lcov \
-            clang-10 \
-            llvm-10 \
-            tzdata
-
+ARG PARENT_TAG=latest
+FROM yandex/clickhouse-test-base:${PARENT_TAG}
 
 ENV COVERAGE_DIR=/coverage_reports
 ENV SOURCE_DIR=/build
 ENV OUTPUT_DIR=/output
 ENV IGNORE='.*contrib.*'
-
 
 CMD mkdir -p /build/obj-x86_64-linux-gnu && cd /build/obj-x86_64-linux-gnu && CC=clang-10 CXX=clang++-10 cmake .. && cd /; \
     dpkg -i /package_folder/clickhouse-common-static_*.deb; \

--- a/docker/test/stateless/Dockerfile
+++ b/docker/test/stateless/Dockerfile
@@ -1,37 +1,29 @@
 # docker build -t yandex/clickhouse-stateless-test .
-FROM yandex/clickhouse-deb-builder
+FROM yandex/clickhouse-test-base
 
 ARG odbc_driver_url="https://github.com/ClickHouse/clickhouse-odbc/releases/download/v1.1.4.20200302/clickhouse-odbc-1.1.4-Linux.tar.gz"
 
 RUN apt-get update -y \
     && env DEBIAN_FRONTEND=noninteractive \
         apt-get install --yes --no-install-recommends \
-            bash \
-            tzdata \
-            fakeroot \
-            debhelper \
-            zookeeper \
-            zookeeperd \
+            brotli \
             expect \
-            python \
-            python-lxml \
-            python-termcolor \
-            python-requests \
-            curl \
-            sudo \
-            openssl \
+            lsof \
             ncdu \
             netcat-openbsd \
+            openssl \
+            python \
+            python-lxml \
+            python-requests \
+            python-termcolor \
+            qemu-user-static \
+            sudo \
             telnet \
             tree \
-            moreutils \
-            brotli \
-            gdb \
-            lsof \
-            llvm-9 \
             unixodbc \
             wget \
-            qemu-user-static
+            zookeeper \
+            zookeeperd
 
 RUN mkdir -p /tmp/clickhouse-odbc-tmp \
    && wget --quiet -O - ${odbc_driver_url} | tar --strip-components=1 -xz -C /tmp/clickhouse-odbc-tmp \
@@ -42,12 +34,6 @@ RUN mkdir -p /tmp/clickhouse-odbc-tmp \
 
 ENV TZ=Europe/Moscow
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-
-# Sanitizer options
-RUN echo "TSAN_OPTIONS='verbosity=1000 halt_on_error=1 history_size=7'" >> /etc/environment; \
-    echo "UBSAN_OPTIONS='print_stacktrace=1'" >> /etc/environment; \
-    echo "MSAN_OPTIONS='abort_on_error=1'" >> /etc/environment; \
-    ln -s /usr/lib/llvm-10/bin/llvm-symbolizer /usr/bin/llvm-symbolizer;
 
 COPY run.sh /
 CMD ["/bin/bash", "/run.sh"]

--- a/docker/test/stateless_pytest/Dockerfile
+++ b/docker/test/stateless_pytest/Dockerfile
@@ -1,5 +1,5 @@
 # docker build -t yandex/clickhouse-stateless-pytest .
-FROM yandex/clickhouse-deb-builder
+FROM yandex/clickhouse-test-base
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \

--- a/docker/test/stateless_with_coverage/Dockerfile
+++ b/docker/test/stateless_with_coverage/Dockerfile
@@ -1,6 +1,6 @@
 # docker build -t yandex/clickhouse-stateless-with-coverage-test .
 # TODO: that can be based on yandex/clickhouse-stateless-test (llvm version and CMD differs)
-FROM yandex/clickhouse-deb-builder
+FROM yandex/clickhouse-test-base
 
 ARG odbc_driver_url="https://github.com/ClickHouse/clickhouse-odbc/releases/download/v1.1.4.20200302/clickhouse-odbc-1.1.4-Linux.tar.gz"
 
@@ -18,7 +18,6 @@ RUN apt-get update -y \
             python-lxml \
             python-termcolor \
             python-requests \
-            curl \
             sudo \
             openssl \
             ncdu \
@@ -43,12 +42,5 @@ RUN mkdir -p /tmp/clickhouse-odbc-tmp \
 ENV TZ=Europe/Moscow
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 COPY run.sh /run.sh
-
-# Sanitizer options
-RUN echo "TSAN_OPTIONS='verbosity=1000 halt_on_error=1 history_size=7'" >> /etc/environment; \
-  echo "UBSAN_OPTIONS='print_stacktrace=1'" >> /etc/environment; \
-  echo "MSAN_OPTIONS='abort_on_error=1'" >> /etc/environment; \
-  ln -s /usr/lib/llvm-10/bin/llvm-symbolizer /usr/bin/llvm-symbolizer;
-
 
 CMD ["/bin/bash", "/run.sh"]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Switch tests docker images to use test-base parent.

Detailed description / Documentation draft:

...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
