### PR TITLE
Fix nullptr dereference in defaultValueOfTypeName

### DIFF
--- a/src/Functions/defaultValueOfTypeName.cpp
+++ b/src/Functions/defaultValueOfTypeName.cpp
@@ -40,9 +40,8 @@ public:
     {
         const ColumnConst * col_type_const = typeid_cast<const ColumnConst *>(arguments.front().column.get());
         if (!col_type_const || !isString(arguments.front().type))
-            throw Exception("The argument of function " + getName() + " must be a constant string describing type. "
-                    "Instead there is a column with the following structure: " + arguments.front().column->dumpStructure(),
-                    ErrorCodes::ILLEGAL_COLUMN);
+            throw Exception("The argument of function " + getName() + " must be a constant string describing type.",
+                ErrorCodes::ILLEGAL_COLUMN);
 
         return DataTypeFactory::instance().get(col_type_const->getValue<String>());
     }

--- a/tests/queries/0_stateless/01459_default_value_of_argument_type_nullptr_dereference.sql
+++ b/tests/queries/0_stateless/01459_default_value_of_argument_type_nullptr_dereference.sql
@@ -1,0 +1,1 @@
+SELECT defaultValueOfTypeName(FQDN()); -- { serverError 44 }


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Bugfix (unreleased).