### PR TITLE
Fix flaky test 

### DIFF
--- a/tests/queries/0_stateless/00834_cancel_http_readonly_queries_on_client_close.sh
+++ b/tests/queries/0_stateless/00834_cancel_http_readonly_queries_on_client_close.sh
@@ -5,7 +5,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 ${CLICKHOUSE_CURL} --max-time 1 -sS "${CLICKHOUSE_URL}&query_id=cancel_http_readonly_queries_on_client_close&cancel_http_readonly_queries_on_client_close=1&query=SELECT+count()+FROM+system.numbers" 2>&1 | grep -cF 'curl: (28)'
 
-for _ in {1..20}
+while true
 do
     ${CLICKHOUSE_CURL} -sS --data "SELECT count() FROM system.processes WHERE query_id = 'cancel_http_readonly_queries_on_client_close'" "${CLICKHOUSE_URL}" | grep '0' && break
     sleep 0.2


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

See https://clickhouse-test-reports.s3.yandex.net/0/67f16d5ae8e5ecfdb989c689134c279f8a9c2fa4/functional_stateless_tests_(debug)/test_run.txt.out.log

It only gives the query one second to finish. It may be not enough.
I have changed that it will wait for query to finish until global test timeout (600 seconds).

If the logic of "cancel on connection close" does not work the query won't finish before arbitrary large timeout,
so the test is still correct.