### PR TITLE
Fix unbundled build on 20.04 (libmysqlclient21)

### DIFF
--- a/base/mysqlxx/Connection.cpp
+++ b/base/mysqlxx/Connection.cpp
@@ -116,7 +116,7 @@ void Connection::connect(const char* db,
         throw ConnectionFailed(errorMessage(driver.get()), mysql_errno(driver.get()));
 
     /// Enables auto-reconnect.
-    my_bool reconnect = true;
+    bool reconnect = true;
     if (mysql_options(driver.get(), MYSQL_OPT_RECONNECT, reinterpret_cast<const char *>(&reconnect)))
         throw ConnectionFailed(errorMessage(driver.get()), mysql_errno(driver.get()));
 

--- a/cmake/find/parquet.cmake
+++ b/cmake/find/parquet.cmake
@@ -4,6 +4,10 @@ elseif(ENABLE_PARQUET OR USE_INTERNAL_PARQUET_LIBRARY)
     message (${RECONFIGURE_MESSAGE_LEVEL} "Can't use parquet without protoc executable")
 endif()
 
+if (UNBUNDLED)
+    set (ENABLE_PARQUET OFF CACHE INTERNAL "") # unbundled linkage fails with parquet
+endif()
+
 if (NOT ENABLE_PARQUET)
     if(USE_INTERNAL_PARQUET_LIBRARY)
         message (${RECONFIGURE_MESSAGE_LEVEL} "Cannot use internal parquet with ENABLE_PARQUET=OFF")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:

> The my_bool type no longer exists, and people may have been using it in their own code since some mysql.h functions have been returning that. The recommended fix is to use bool or int, which will work both in 8.0 and older versions.

https://bugs.mysql.com/bug.php?id=85131


By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
