### PR TITLE
Fix currentDatabase function cannot be used in ON CLUSTER ddl query.

### DIFF
--- a/src/Interpreters/AddDefaultDatabaseVisitor.h
+++ b/src/Interpreters/AddDefaultDatabaseVisitor.h
@@ -111,7 +111,7 @@ private:
         tryVisit<ASTSelectWithUnionQuery>(subquery.children[0]);
     }
 
-    void visit(ASTFunction & function, ASTPtr & node) const
+    void visit(ASTFunction & function, ASTPtr &) const
     {
         bool is_operator_in = false;
         for (auto name : {"in", "notIn", "globalIn", "globalNotIn"})

--- a/src/Interpreters/AddDefaultDatabaseVisitor.h
+++ b/src/Interpreters/AddDefaultDatabaseVisitor.h
@@ -35,7 +35,8 @@ public:
         visitDDLChildren(ast);
 
         if (!tryVisitDynamicCast<ASTQueryWithTableAndOutput>(ast) &&
-            !tryVisitDynamicCast<ASTRenameQuery>(ast))
+            !tryVisitDynamicCast<ASTRenameQuery>(ast) &&
+            !tryVisitDynamicCast<ASTFunction>(ast))
         {}
     }
 
@@ -112,12 +113,6 @@ private:
 
     void visit(ASTFunction & function, ASTPtr & node) const
     {
-        if (function.name == "currentDatabase")
-        {
-            node = std::make_shared<ASTLiteral>(database_name);
-            return;
-        }
-
         bool is_operator_in = false;
         for (auto name : {"in", "notIn", "globalIn", "globalNotIn"})
         {
@@ -183,6 +178,15 @@ private:
                 elem.from.database = database_name;
             if (elem.to.database.empty())
                 elem.to.database = database_name;
+        }
+    }
+
+    void visitDDL(ASTFunction & function, ASTPtr & node) const
+    {
+        if (function.name == "currentDatabase")
+        {
+            node = std::make_shared<ASTLiteral>(database_name);
+            return;
         }
     }
 

--- a/src/Interpreters/AddDefaultDatabaseVisitor.h
+++ b/src/Interpreters/AddDefaultDatabaseVisitor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Common/typeid_cast.h>
+#include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTQueryWithTableAndOutput.h>
 #include <Parsers/ASTRenameQuery.h>
 #include <Parsers/ASTIdentifier.h>
@@ -109,8 +110,14 @@ private:
         tryVisit<ASTSelectWithUnionQuery>(subquery.children[0]);
     }
 
-    void visit(ASTFunction & function, ASTPtr &) const
+    void visit(ASTFunction & function, ASTPtr & node) const
     {
+        if (function.name == "currentDatabase")
+        {
+            node = std::make_shared<ASTLiteral>(database_name);
+            return;
+        }
+
         bool is_operator_in = false;
         for (auto name : {"in", "notIn", "globalIn", "globalNotIn"})
         {

--- a/src/Interpreters/AddDefaultDatabaseVisitor.h
+++ b/src/Interpreters/AddDefaultDatabaseVisitor.h
@@ -24,8 +24,9 @@ namespace DB
 class AddDefaultDatabaseVisitor
 {
 public:
-    AddDefaultDatabaseVisitor(const String & database_name_, std::ostream * ostr_ = nullptr)
+    AddDefaultDatabaseVisitor(const String & database_name_, bool only_replace_current_database_function_ = false, std::ostream * ostr_ = nullptr)
     :   database_name(database_name_),
+        only_replace_current_database_function(only_replace_current_database_function_),
         visit_depth(0),
         ostr(ostr_)
     {}
@@ -62,6 +63,7 @@ public:
 
 private:
     const String database_name;
+    bool only_replace_current_database_function = false;
     mutable size_t visit_depth;
     std::ostream * ostr;
 
@@ -166,12 +168,18 @@ private:
 
     void visitDDL(ASTQueryWithTableAndOutput & node, ASTPtr &) const
     {
+        if (only_replace_current_database_function)
+            return;
+
         if (node.database.empty())
             node.database = database_name;
     }
 
     void visitDDL(ASTRenameQuery & node, ASTPtr &) const
     {
+        if (only_replace_current_database_function)
+            return;
+
         for (ASTRenameQuery::Element & elem : node.elements)
         {
             if (elem.from.database.empty())

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -1435,6 +1435,7 @@ BlockIO executeDDLQueryOnCluster(const ASTPtr & query_ptr_, const Context & cont
            != query_requires_access.end());
 
     bool use_local_default_database = false;
+    const String & current_database = context.getCurrentDatabase();
 
     if (need_replace_current_database)
     {
@@ -1478,7 +1479,6 @@ BlockIO executeDDLQueryOnCluster(const ASTPtr & query_ptr_, const Context & cont
         }
     }
 
-    const String & current_database = context.getCurrentDatabase();
     AddDefaultDatabaseVisitor visitor(current_database, !use_local_default_database);
     visitor.visitDDL(query_ptr);
 

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -1434,9 +1434,10 @@ BlockIO executeDDLQueryOnCluster(const ASTPtr & query_ptr_, const Context & cont
                [](const AccessRightsElement & elem) { return elem.isEmptyDatabase(); })
            != query_requires_access.end());
 
+    bool use_local_default_database = false;
+
     if (need_replace_current_database)
     {
-        bool use_local_default_database = false;
         Strings shard_default_databases;
         for (const auto & shard : shards)
         {
@@ -1457,10 +1458,6 @@ BlockIO executeDDLQueryOnCluster(const ASTPtr & query_ptr_, const Context & cont
 
         if (use_local_default_database)
         {
-            const String & current_database = context.getCurrentDatabase();
-            AddDefaultDatabaseVisitor visitor(current_database);
-            visitor.visitDDL(query_ptr);
-
             query_requires_access.replaceEmptyDatabase(current_database);
         }
         else
@@ -1480,6 +1477,10 @@ BlockIO executeDDLQueryOnCluster(const ASTPtr & query_ptr_, const Context & cont
             }
         }
     }
+
+    const String & current_database = context.getCurrentDatabase();
+    AddDefaultDatabaseVisitor visitor(current_database, !use_local_default_database);
+    visitor.visitDDL(query_ptr);
 
     /// Check access rights, assume that all servers have the same users config
     if (query_requires_grant_option)

--- a/src/Storages/SelectQueryDescription.cpp
+++ b/src/Storages/SelectQueryDescription.cpp
@@ -48,7 +48,7 @@ StorageID extractDependentTableFromSelectQuery(ASTSelectQuery & query, const Con
 {
     if (add_default_db)
     {
-        AddDefaultDatabaseVisitor visitor(context.getCurrentDatabase(), nullptr);
+        AddDefaultDatabaseVisitor visitor(context.getCurrentDatabase(), false, nullptr);
         visitor.visit(query);
     }
 

--- a/tests/integration/test_default_database_on_cluster/configs/config.d/clusters.xml
+++ b/tests/integration/test_default_database_on_cluster/configs/config.d/clusters.xml
@@ -1,0 +1,28 @@
+<yandex>
+<remote_servers>
+    <cluster>
+        <shard>
+            <internal_replication>true</internal_replication>
+            <replica>
+                <host>ch1</host>
+                <port>9000</port>
+            </replica>
+            <replica>
+                <host>ch2</host>
+                <port>9000</port>
+            </replica>
+        </shard>
+        <shard>
+            <internal_replication>true</internal_replication>
+            <replica>
+                <host>ch3</host>
+                <port>9000</port>
+            </replica>
+            <replica>
+                <host>ch4</host>
+                <port>9000</port>
+            </replica>
+        </shard>
+    </cluster>
+</remote_servers>
+</yandex>

--- a/tests/integration/test_default_database_on_cluster/configs/config.d/distributed_ddl.xml
+++ b/tests/integration/test_default_database_on_cluster/configs/config.d/distributed_ddl.xml
@@ -1,0 +1,5 @@
+<yandex>
+<distributed_ddl>
+    <path>/clickhouse/task_queue/ddl</path>
+</distributed_ddl>
+</yandex>

--- a/tests/integration/test_default_database_on_cluster/test.py
+++ b/tests/integration/test_default_database_on_cluster/test.py
@@ -1,0 +1,32 @@
+import time
+import pytest
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+ch1 = cluster.add_instance('ch1', config_dir="configs", with_zookeeper=True)
+ch2 = cluster.add_instance('ch2', config_dir="configs", with_zookeeper=True)
+ch3 = cluster.add_instance('ch3', config_dir="configs", with_zookeeper=True)
+ch4 = cluster.add_instance('ch4', config_dir="configs", with_zookeeper=True)
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        ch1.query("CREATE DATABASE test_default_database ON CLUSTER 'cluster';")
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def test_default_database_on_cluster(started_cluster):
+    ch1.query(database='test_default_database', sql="CREATE TABLE test_local_table ON CLUSTER 'cluster' (column UInt8) ENGINE = Memory;")
+
+    for node in [ch1, ch2, ch3, ch4]:
+        assert node.query("SHOW TABLES FROM test_default_database FORMAT TSV") == "test_local_table\n"
+
+    ch1.query(database='test_default_database', sql="CREATE TABLE test_distributed_table ON CLUSTER 'cluster' (column UInt8) ENGINE = Distributed(cluster, currentDatabase(), 'test_local_table');")
+
+    for node in [ch1, ch2, ch3, ch4]:
+        assert node.query("SHOW TABLES FROM test_default_database FORMAT TSV") == "test_distributed_table\ntest_local_table\n"
+        assert node.query("SHOW CREATE TABLE test_default_database.test_distributed_table FORMAT TSV") == "CREATE TABLE test_default_database.test_distributed_table\\n(\\n    `column` UInt8\\n)\\nENGINE = Distributed(\\'cluster\\', \\'test_default_database\\', \\'test_local_table\\')\n"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `currentDatabase()` function cannot be used in `ON CLUSTER` ddl query.
