### PR TITLE
Fix a build for old some OS with old find

### DIFF
--- a/contrib/cctz-cmake/CMakeLists.txt
+++ b/contrib/cctz-cmake/CMakeLists.txt
@@ -82,7 +82,7 @@ if (NOT EXTERNAL_CCTZ_LIBRARY_FOUND OR NOT EXTERNAL_CCTZ_LIBRARY_WORKS)
 
         # each file/symlink in that dir (except of tab and localtime) store the info about timezone
         execute_process(COMMAND
-            bash -c "cd ${TZDIR} && find * -type f,l -and ! -name '*.tab' -and ! -name 'localtime' | sort | paste -sd ';'"
+            bash -c "cd ${TZDIR} && find * -type f -and ! -name '*.tab' -and ! -name 'localtime' | sort | paste -sd ';'"
             OUTPUT_STRIP_TRAILING_WHITESPACE
             OUTPUT_VARIABLE TIMEZONES)
 

--- a/contrib/cctz-cmake/CMakeLists.txt
+++ b/contrib/cctz-cmake/CMakeLists.txt
@@ -80,7 +80,7 @@ if (NOT EXTERNAL_CCTZ_LIBRARY_FOUND OR NOT EXTERNAL_CCTZ_LIBRARY_WORKS)
 
         set(TZ_OBJS)
 
-        # each file/symlink in that dir (except of tab and localtime) store the info about timezone
+        # each file in that dir (except of tab and localtime) store the info about timezone
         execute_process(COMMAND
             bash -c "cd ${TZDIR} && find * -type f -and ! -name '*.tab' -and ! -name 'localtime' | sort | paste -sd ';'"
             OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Actually there are no symlinks there, so `-type f` is enough
```
~/workspace/ClickHouse/contrib/cctz/testdata/zoneinfo$
find . -type l -ls | wc -l 
0
```
Closes #14209

Detailed description / Documentation draft:
