### PR TITLE
Introduce columns transformers.

### DIFF
--- a/src/Parsers/ASTAsterisk.cpp
+++ b/src/Parsers/ASTAsterisk.cpp
@@ -13,9 +13,14 @@ ASTPtr ASTAsterisk::clone() const
 
 void ASTAsterisk::appendColumnName(WriteBuffer & ostr) const { ostr.write('*'); }
 
-void ASTAsterisk::formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTAsterisk::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     settings.ostr << "*";
+    for (const auto & child : children)
+    {
+        settings.ostr << ' ';
+        child->formatImpl(settings, state, frame);
+    }
 }
 
 }

--- a/src/Parsers/ASTAsterisk.h
+++ b/src/Parsers/ASTAsterisk.h
@@ -9,6 +9,9 @@ namespace DB
 struct AsteriskSemantic;
 struct AsteriskSemanticImpl;
 
+/** SELECT * is expanded to all visible columns of the source table.
+  * Optional transformers can be attached to further manipulate these expanded columns.
+  */
 class ASTAsterisk : public IAST
 {
 public:

--- a/src/Parsers/ASTColumnsMatcher.cpp
+++ b/src/Parsers/ASTColumnsMatcher.cpp
@@ -28,10 +28,15 @@ void ASTColumnsMatcher::updateTreeHashImpl(SipHash & hash_state) const
     IAST::updateTreeHashImpl(hash_state);
 }
 
-void ASTColumnsMatcher::formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTColumnsMatcher::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     settings.ostr << (settings.hilite ? hilite_keyword : "") << "COLUMNS" << (settings.hilite ? hilite_none : "") << "("
                   << quoteString(original_pattern) << ")";
+    for (ASTs::const_iterator it = children.begin() + 1; it != children.end(); ++it)
+    {
+        settings.ostr << ' ';
+        (*it)->formatImpl(settings, state, frame);
+    }
 }
 
 void ASTColumnsMatcher::setPattern(String pattern)

--- a/src/Parsers/ASTColumnsMatcher.h
+++ b/src/Parsers/ASTColumnsMatcher.h
@@ -23,6 +23,7 @@ struct AsteriskSemanticImpl;
 
 
 /** SELECT COLUMNS('regexp') is expanded to multiple columns like * (asterisk).
+  * Optional transformers can be attached to further manipulate these expanded columns.
   */
 class ASTColumnsMatcher : public IAST
 {

--- a/src/Parsers/ASTColumnsTransformers.cpp
+++ b/src/Parsers/ASTColumnsTransformers.cpp
@@ -1,0 +1,158 @@
+#include "ASTColumnsTransformers.h"
+#include <IO/WriteHelpers.h>
+#include <Parsers/ASTFunction.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Common/SipHash.h>
+#include <Common/quoteString.h>
+
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+}
+
+void IASTColumnsTransformer::transform(const ASTPtr & transformer, ASTs & nodes)
+{
+    if (const auto * apply = transformer->as<ASTColumnsApplyTransformer>())
+    {
+        apply->transform(nodes);
+    }
+    else if (const auto * except = transformer->as<ASTColumnsExceptTransformer>())
+    {
+        except->transform(nodes);
+    }
+    else if (const auto * replace = transformer->as<ASTColumnsReplaceTransformer>())
+    {
+        replace->transform(nodes);
+    }
+}
+
+void ASTColumnsApplyTransformer::formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+{
+    settings.ostr << (settings.hilite ? hilite_keyword : "") << "APPLY" << (settings.hilite ? hilite_none : "") << "(" << func_name << ")";
+}
+
+void ASTColumnsApplyTransformer::transform(ASTs & nodes) const
+{
+    for (auto & column : nodes)
+    {
+        column = makeASTFunction(func_name, column);
+    }
+}
+
+void ASTColumnsExceptTransformer::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+{
+    settings.ostr << (settings.hilite ? hilite_keyword : "") << "EXCEPT" << (settings.hilite ? hilite_none : "") << "(";
+
+    for (ASTs::const_iterator it = children.begin(); it != children.end(); ++it)
+    {
+        if (it != children.begin())
+        {
+            settings.ostr << ", ";
+        }
+        (*it)->formatImpl(settings, state, frame);
+    }
+
+    settings.ostr << ")";
+}
+
+void ASTColumnsExceptTransformer::transform(ASTs & nodes) const
+{
+    nodes.erase(
+        std::remove_if(
+            nodes.begin(),
+            nodes.end(),
+            [this](const ASTPtr & node_child)
+            {
+                if (const auto * id = node_child->as<ASTIdentifier>())
+                {
+                    for (const auto & except_child : children)
+                    {
+                        if (except_child->as<const ASTIdentifier &>().name == id->shortName())
+                            return true;
+                    }
+                }
+                return false;
+            }),
+        nodes.end());
+}
+
+void ASTColumnsReplaceTransformer::Replacement::formatImpl(
+    const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+{
+    expr->formatImpl(settings, state, frame);
+    settings.ostr << (settings.hilite ? hilite_keyword : "") << " AS " << (settings.hilite ? hilite_none : "") << name;
+}
+
+void ASTColumnsReplaceTransformer::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+{
+    settings.ostr << (settings.hilite ? hilite_keyword : "") << "REPLACE" << (settings.hilite ? hilite_none : "") << "(";
+
+    for (ASTs::const_iterator it = children.begin(); it != children.end(); ++it)
+    {
+        if (it != children.begin())
+        {
+            settings.ostr << ", ";
+        }
+        (*it)->formatImpl(settings, state, frame);
+    }
+
+    settings.ostr << ")";
+}
+
+void ASTColumnsReplaceTransformer::replaceChildren(ASTPtr & node, const ASTPtr & replacement, const String & name)
+{
+    for (auto & child : node->children)
+    {
+        if (const auto * id = child->as<ASTIdentifier>())
+        {
+            if (id->shortName() == name)
+                child = replacement;
+        }
+        else
+            replaceChildren(child, replacement, name);
+    }
+}
+
+void ASTColumnsReplaceTransformer::transform(ASTs & nodes) const
+{
+    std::map<String, ASTPtr> replace_map;
+    for (const auto & replace_child : children)
+    {
+        auto & replacement = replace_child->as<Replacement &>();
+        if (replace_map.find(replacement.name) != replace_map.end())
+            throw Exception(
+                "Expressions in columns transformer REPLACE should not contain the same replacement more than once",
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+        replace_map.emplace(replacement.name, replacement.expr);
+    }
+
+    for (auto & column : nodes)
+    {
+        if (const auto * id = column->as<ASTIdentifier>())
+        {
+            auto replace_it = replace_map.find(id->shortName());
+            if (replace_it != replace_map.end())
+            {
+                column = replace_it->second;
+                column->setAlias(replace_it->first);
+            }
+        }
+        else if (auto * ast_with_alias = dynamic_cast<ASTWithAlias *>(column.get()))
+        {
+            auto replace_it = replace_map.find(ast_with_alias->alias);
+            if (replace_it != replace_map.end())
+            {
+                auto new_ast = replace_it->second->clone();
+                ast_with_alias->alias = ""; // remove the old alias as it's useless after replace transformation
+                replaceChildren(new_ast, column, replace_it->first);
+                column = new_ast;
+                column->setAlias(replace_it->first);
+            }
+        }
+    }
+}
+
+}

--- a/src/Parsers/ASTColumnsTransformers.cpp
+++ b/src/Parsers/ASTColumnsTransformers.cpp
@@ -1,3 +1,4 @@
+#include <map>
 #include "ASTColumnsTransformers.h"
 #include <IO/WriteHelpers.h>
 #include <Parsers/ASTFunction.h>

--- a/src/Parsers/ASTColumnsTransformers.h
+++ b/src/Parsers/ASTColumnsTransformers.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <Parsers/IAST.h>
+
+namespace DB
+{
+class IASTColumnsTransformer : public IAST
+{
+public:
+    virtual void transform(ASTs & nodes) const = 0;
+    static void transform(const ASTPtr & transformer, ASTs & nodes);
+};
+
+class ASTColumnsApplyTransformer : public IASTColumnsTransformer
+{
+public:
+    String getID(char) const override { return "ColumnsApplyTransformer"; }
+    ASTPtr clone() const override
+    {
+        auto res = std::make_shared<ASTColumnsApplyTransformer>(*this);
+        return res;
+    }
+    void transform(ASTs & nodes) const override;
+    String func_name;
+
+protected:
+    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+};
+
+class ASTColumnsExceptTransformer : public IASTColumnsTransformer
+{
+public:
+    String getID(char) const override { return "ColumnsExceptTransformer"; }
+    ASTPtr clone() const override
+    {
+        auto clone = std::make_shared<ASTColumnsExceptTransformer>(*this);
+        clone->cloneChildren();
+        return clone;
+    }
+    void transform(ASTs & nodes) const override;
+
+protected:
+    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+};
+
+class ASTColumnsReplaceTransformer : public IASTColumnsTransformer
+{
+public:
+    class Replacement : public IAST
+    {
+    public:
+        String getID(char) const override { return "ColumnsReplaceTransformer::Replacement"; }
+        ASTPtr clone() const override
+        {
+            auto replacement = std::make_shared<Replacement>(*this);
+            replacement->name = name;
+            replacement->expr = expr->clone();
+            replacement->children.push_back(replacement->expr);
+            return replacement;
+        }
+
+        String name;
+        ASTPtr expr;
+
+    protected:
+        void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+    };
+
+    String getID(char) const override { return "ColumnsReplaceTransformer"; }
+    ASTPtr clone() const override
+    {
+        auto clone = std::make_shared<ASTColumnsReplaceTransformer>(*this);
+        clone->cloneChildren();
+        return clone;
+    }
+    void transform(ASTs & nodes) const override;
+
+protected:
+    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
+
+private:
+    static void replaceChildren(ASTPtr & node, const ASTPtr & replacement, const String & name);
+};
+
+}

--- a/src/Parsers/ASTQualifiedAsterisk.cpp
+++ b/src/Parsers/ASTQualifiedAsterisk.cpp
@@ -16,6 +16,11 @@ void ASTQualifiedAsterisk::formatImpl(const FormatSettings & settings, FormatSta
     const auto & qualifier = children.at(0);
     qualifier->formatImpl(settings, state, frame);
     settings.ostr << ".*";
+    for (ASTs::const_iterator it = children.begin() + 1; it != children.end(); ++it)
+    {
+        settings.ostr << ' ';
+        (*it)->formatImpl(settings, state, frame);
+    }
 }
 
 }

--- a/src/Parsers/ASTQualifiedAsterisk.h
+++ b/src/Parsers/ASTQualifiedAsterisk.h
@@ -11,6 +11,7 @@ struct AsteriskSemanticImpl;
 
 /** Something like t.*
   * It will have qualifier as its child ASTIdentifier.
+  * Optional transformers can be attached to further manipulate these expanded columns.
   */
 class ASTQualifiedAsterisk : public IAST
 {

--- a/src/Parsers/ExpressionElementParsers.h
+++ b/src/Parsers/ExpressionElementParsers.h
@@ -88,6 +88,15 @@ protected:
     bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
+/** *, t.*, db.table.*, COLUMNS('<regular expression>') APPLY(...) or EXCEPT(...) or REPLACE(...)
+  */
+class ParserColumnsTransformers : public IParserBase
+{
+protected:
+    const char * getName() const override { return "COLUMNS transformers"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+};
+
 /** A function, for example, f(x, y + 1, g(z)).
   * Or an aggregate function: sum(x + f(y)), corr(x, y). The syntax is the same as the usual function.
   * Or a parametric aggregate function: quantile(0.9)(x + y).

--- a/src/Parsers/ya.make
+++ b/src/Parsers/ya.make
@@ -10,6 +10,7 @@ SRCS(
     ASTAsterisk.cpp
     ASTColumnDeclaration.cpp
     ASTColumnsMatcher.cpp
+    ASTColumnsTransformers.cpp
     ASTConstraintDeclaration.cpp
     ASTCreateQuery.cpp
     ASTCreateQuotaQuery.cpp

--- a/tests/queries/0_stateless/01470_columns_transformers.reference
+++ b/tests/queries/0_stateless/01470_columns_transformers.reference
@@ -1,0 +1,63 @@
+220	18	347
+110	9	173.5
+1970-04-11	1970-01-11	1970-11-21
+2	3
+1	2
+18	347
+110	173.5
+1970-04-11	1970-01-11	1970-11-21
+222	18	347
+111	11	173.5
+1970-04-11	1970-01-11	1970-11-21
+SELECT 
+    sum(i),
+    sum(j),
+    sum(k)
+FROM columns_transformers
+SELECT 
+    avg(i),
+    avg(j),
+    avg(k)
+FROM columns_transformers
+SELECT 
+    toDate(any(i)),
+    toDate(any(j)),
+    toDate(any(k))
+FROM columns_transformers AS a
+SELECT 
+    length(toString(j)),
+    length(toString(k))
+FROM columns_transformers
+SELECT 
+    sum(j),
+    sum(k)
+FROM columns_transformers
+SELECT 
+    avg(i),
+    avg(k)
+FROM columns_transformers
+SELECT 
+    toDate(any(i)),
+    toDate(any(j)),
+    toDate(any(k))
+FROM columns_transformers AS a
+SELECT 
+    sum(i + 1 AS i),
+    sum(j),
+    sum(k)
+FROM columns_transformers
+SELECT 
+    avg(i + 1 AS i),
+    avg(j + 2 AS j),
+    avg(k)
+FROM columns_transformers
+SELECT 
+    toDate(any(i)),
+    toDate(any(j)),
+    toDate(any(k))
+FROM columns_transformers AS a
+SELECT 
+    (i + 1) + 1 AS i,
+    j,
+    k
+FROM columns_transformers

--- a/tests/queries/0_stateless/01470_columns_transformers.sql
+++ b/tests/queries/0_stateless/01470_columns_transformers.sql
@@ -1,0 +1,36 @@
+DROP TABLE IF EXISTS columns_transformers;
+
+CREATE TABLE columns_transformers (i Int64, j Int16, k Int64) Engine=TinyLog;
+INSERT INTO columns_transformers VALUES (100, 10, 324), (120, 8, 23);
+
+SELECT * APPLY(sum) from columns_transformers;
+SELECT columns_transformers.* APPLY(avg) from columns_transformers;
+SELECT a.* APPLY(toDate) APPLY(any) from columns_transformers a;
+SELECT COLUMNS('[jk]') APPLY(toString) APPLY(length) from columns_transformers;
+
+SELECT * EXCEPT(i) APPLY(sum) from columns_transformers;
+SELECT columns_transformers.* EXCEPT(j) APPLY(avg) from columns_transformers;
+-- EXCEPT after APPLY will not match anything
+SELECT a.* APPLY(toDate) EXCEPT(i, j) APPLY(any) from columns_transformers a;
+
+SELECT * REPLACE(i + 1 AS i) APPLY(sum) from columns_transformers;
+SELECT columns_transformers.* REPLACE(j + 2 AS j, i + 1 AS i) APPLY(avg) from columns_transformers;
+SELECT columns_transformers.* REPLACE(j + 1 AS j, j + 2 AS j) APPLY(avg) from columns_transformers; -- { serverError 43 }
+-- REPLACE after APPLY will not match anything
+SELECT a.* APPLY(toDate) REPLACE(i + 1 AS i) APPLY(any) from columns_transformers a;
+
+EXPLAIN SYNTAX SELECT * APPLY(sum) from columns_transformers;
+EXPLAIN SYNTAX SELECT columns_transformers.* APPLY(avg) from columns_transformers;
+EXPLAIN SYNTAX SELECT a.* APPLY(toDate) APPLY(any) from columns_transformers a;
+EXPLAIN SYNTAX SELECT COLUMNS('[jk]') APPLY(toString) APPLY(length) from columns_transformers;
+EXPLAIN SYNTAX SELECT * EXCEPT(i) APPLY(sum) from columns_transformers;
+EXPLAIN SYNTAX SELECT columns_transformers.* EXCEPT(j) APPLY(avg) from columns_transformers;
+EXPLAIN SYNTAX SELECT a.* APPLY(toDate) EXCEPT(i, j) APPLY(any) from columns_transformers a;
+EXPLAIN SYNTAX SELECT * REPLACE(i + 1 AS i) APPLY(sum) from columns_transformers;
+EXPLAIN SYNTAX SELECT columns_transformers.* REPLACE(j + 2 AS j, i + 1 AS i) APPLY(avg) from columns_transformers;
+EXPLAIN SYNTAX SELECT a.* APPLY(toDate) REPLACE(i + 1 AS i) APPLY(any) from columns_transformers a;
+
+-- Multiple REPLACE in a row
+EXPLAIN SYNTAX SELECT * REPLACE(i + 1 AS i) REPLACE(i + 1 AS i) from columns_transformers;
+
+DROP TABLE columns_transformers;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Now we can write `select * apply(length) apply(max) from wide_string_table` to find out the maxium length of all string columns. And the follow two variants are provided too:

https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select_except
https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select_replace

Detailed description / Documentation draft:

TBD.