### PR TITLE
Fix MaterializeMySQL empty GTID transaction issue #14235

### DIFF
--- a/src/Core/MySQL/MySQLReplication.h
+++ b/src/Core/MySQL/MySQLReplication.h
@@ -345,9 +345,9 @@ namespace MySQLReplication
 
     enum QueryType
     {
-        DDL = 0,
-        BEGIN = 1,
-        XA = 2
+        QUERY_EVENT_DDL = 0,
+        QUERY_EVENT_MULTI_TXN_FLAG = 1,
+        QUERY_EVENT_XA = 2
     };
 
     class QueryEvent : public EventBase
@@ -361,7 +361,7 @@ namespace MySQLReplication
         String status;
         String schema;
         String query;
-        QueryType typ = DDL;
+        QueryType typ = QUERY_EVENT_DDL;
 
         QueryEvent() : thread_id(0), exec_time(0), schema_len(0), error_code(0), status_len(0) { }
         void dump(std::ostream & out) const override;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix handling of empty transactions in `MaterializeMySQL` database engine. This fixes #14235


Detailed description / Documentation draft:

issue #14235
...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
