### PR TITLE
Fix build for AppleClang

### DIFF
--- a/contrib/capnproto-cmake/CMakeLists.txt
+++ b/contrib/capnproto-cmake/CMakeLists.txt
@@ -29,10 +29,6 @@ set (KJ_SRCS
     ${CAPNPROTO_SOURCE_DIR}/kj/parse/char.c++
 )
 
-if (CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-char8_t")
-endif ()
-
 add_library(kj ${KJ_SRCS})
 target_include_directories(kj SYSTEM PUBLIC ${CAPNPROTO_SOURCE_DIR})
 
@@ -82,8 +78,9 @@ if (COMPILER_GCC)
         -Wno-deprecated-declarations -Wno-class-memaccess)
 elseif (COMPILER_CLANG)
     set (SUPPRESS_WARNINGS -Wno-non-virtual-dtor -Wno-sign-compare -Wno-strict-aliasing -Wno-deprecated-declarations)
+    set (CAPNP_PRIVATE_CXX_FLAGS -fno-char8_t)
 endif ()
 
-target_compile_options(kj PRIVATE ${SUPPRESS_WARNINGS})
-target_compile_options(capnp PRIVATE ${SUPPRESS_WARNINGS})
-target_compile_options(capnpc PRIVATE ${SUPPRESS_WARNINGS})
+target_compile_options(kj PRIVATE ${SUPPRESS_WARNINGS} ${CAPNP_PRIVATE_CXX_FLAGS})
+target_compile_options(capnp PRIVATE ${SUPPRESS_WARNINGS} ${CAPNP_PRIVATE_CXX_FLAGS})
+target_compile_options(capnpc PRIVATE ${SUPPRESS_WARNINGS} ${CAPNP_PRIVATE_CXX_FLAGS})

--- a/contrib/capnproto-cmake/CMakeLists.txt
+++ b/contrib/capnproto-cmake/CMakeLists.txt
@@ -29,6 +29,10 @@ set (KJ_SRCS
     ${CAPNPROTO_SOURCE_DIR}/kj/parse/char.c++
 )
 
+if (CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-char8_t")
+endif ()
+
 add_library(kj ${KJ_SRCS})
 target_include_directories(kj SYSTEM PUBLIC ${CAPNPROTO_SOURCE_DIR})
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Not for changelog (changelog entry is not required)

Detailed description:
Fix build on master branch for internal **capnproto** library when build with Clang.  This issue have been discussed in here https://github.com/capnproto/capnproto/issues/815. The problem is that lib **capnproto** unable to build with flag **fchar8_t** on .So to fix it, I disable this flag when build this library with clang. 
 

