### PR TITLE
fix gcc-9 build-check fail - /base/mysqlxx/Connection.cpp

### DIFF
--- a/base/mysqlxx/Connection.cpp
+++ b/base/mysqlxx/Connection.cpp
@@ -115,8 +115,6 @@ void Connection::connect(const char* db,
     if (mysql_set_character_set(driver.get(), "UTF8"))
         throw ConnectionFailed(errorMessage(driver.get()), mysql_errno(driver.get()));
 
-    /// Enables auto-reconnect.
-    my_bool reconnect = true;
     if (mysql_options(driver.get(), MYSQL_OPT_RECONNECT, reinterpret_cast<const char *>(&reconnect)))
         throw ConnectionFailed(errorMessage(driver.get()), mysql_errno(driver.get()));
 

--- a/base/mysqlxx/Connection.h
+++ b/base/mysqlxx/Connection.h
@@ -158,6 +158,9 @@ private:
     std::unique_ptr<MYSQL> driver;
     bool is_initialized = false;
     bool is_connected = false;
+    /// Enables auto-reconnect.
+    bool reconnect = true;
+
 };
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Build/Testing/Packaging Improvement



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixes gcc-9 unbundled (with debug info) failing build-check.

Detailed description / Documentation draft:

This PR attempts to fix the build-check failure for `gcc-9` builds.

```bash
gcc-9 -- relwithdebuginfo -- none --unbundled -- unsplitted

```

Currently the builds fail with:

```bash

2020-08-30 17:45:13 ../base/mysqlxx/Connection.cpp:119:5: error: 'my_bool' was not declared in this scope; did you mean 'bool'?
2020-08-30 17:45:13   119 |     my_bool reconnect = true;
2020-08-30 17:45:13       |     ^~~~~~~
2020-08-30 17:45:13       |     bool
2020-08-30 17:45:13 ../base/mysqlxx/Connection.cpp:120:90: error: 'reconnect' was not declared in this scope; did you mean 'connect'?
2020-08-30 17:45:13   120 |     if (mysql_options(driver.get(), MYSQL_OPT_RECONNECT, reinterpret_cast<const char *>(&reconnect)))
2020-08-30 17:45:13       |                                                                                          ^~~~~~~~~
2020-08-30 17:45:13       |                                                                                          connect
```

Example (failing at head, at the time of this PR): https://clickhouse-builds.s3.yandex.net/0/b1efc5df016af083948f4d74118a634197b6be1f/clickhouse_build_check/build_log_759745247_1598751588.txt

If my estimate is correct, this build started failed from the commit
hash: d9f24b23a63a8c844b2506e8f59e069f1316cfc2 and the related PR is
 #14168.

The fix in this PR is to move the `my_bool reconnect = true;` to the
Connection.h headerfile. I think this should fix this error, and also
this is how the other variables like `is_connected`,  `is_initialized`,
etc are initialized.

 Related to #14257
