### PR TITLE
[RFC] Purge insert_distributed_timeout/DistributedSyncInsertionTimeoutExceeded

### DIFF
--- a/programs/copier/TaskCluster.h
+++ b/programs/copier/TaskCluster.h
@@ -94,7 +94,6 @@ inline void DB::TaskCluster::reloadSettings(const Poco::Util::AbstractConfigurat
     set_default_value(settings_pull.max_threads, 1);
     set_default_value(settings_pull.max_block_size, 8192UL);
     set_default_value(settings_pull.preferred_block_size_bytes, 0);
-    set_default_value(settings_push.insert_distributed_timeout, 0);
 }
 
 }

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -157,7 +157,6 @@
     M(DictCacheLockWriteNs, "") \
     M(DictCacheLockReadNs, "") \
     \
-    M(DistributedSyncInsertionTimeoutExceeded, "") \
     M(DataAfterMergeDiffersFromReplica, "") \
     M(DataAfterMutationDiffersFromReplica, "") \
     M(PolygonsAddedToPool, "") \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -198,7 +198,6 @@ class IColumn;
     M(UInt64, preferred_max_column_in_block_size_bytes, 0, "Limit on max column size in block while reading. Helps to decrease cache misses count. Should be close to L2 cache size.", 0) \
     \
     M(Bool, insert_distributed_sync, false, "If setting is enabled, insert query into distributed waits until data will be sent to all nodes in cluster.", 0) \
-    M(UInt64, insert_distributed_timeout, 0, "Timeout for insert query into distributed. Setting is used only with insert_distributed_sync enabled. Zero value means no timeout.", 0) \
     M(Int64, distributed_ddl_task_timeout, 180, "Timeout for DDL query responses from all hosts in cluster. If a ddl request has not been performed on all hosts, a response will contain a timeout error and a request will be executed in an async mode. Negative value means infinite.", 0) \
     M(Milliseconds, stream_flush_interval_ms, 7500, "Timeout for flushing data from streaming storages.", 0) \
     M(Milliseconds, stream_poll_timeout_ms, 500, "Timeout for polling data from/to streaming storages.", 0) \

--- a/src/Storages/Distributed/DistributedBlockOutputStream.h
+++ b/src/Storages/Distributed/DistributedBlockOutputStream.h
@@ -25,7 +25,7 @@ namespace DB
 class Context;
 class StorageDistributed;
 
-/** If insert_sync_ is true, the write is synchronous. Uses insert_timeout_ if it is not zero.
+/** If insert_sync_ is true, the write is synchronous.
  *  Otherwise, the write is asynchronous - the data is first written to the local filesystem, and then sent to the remote servers.
  *  If the Distributed table uses more than one shard, then in order to support the write,
  *  when creating the table, an additional parameter must be specified for ENGINE - the sharding key.
@@ -43,8 +43,7 @@ public:
         const StorageMetadataPtr & metadata_snapshot_,
         const ASTPtr & query_ast_,
         const ClusterPtr & cluster_,
-        bool insert_sync_,
-        UInt64 insert_timeout_);
+        bool insert_sync_);
 
     Block getHeader() const override;
     void write(const Block & block) override;
@@ -70,7 +69,7 @@ private:
     void writeToShard(const Block & block, const std::vector<std::string> & dir_names);
 
 
-    /// Performs synchronous insertion to remote nodes. If timeout_exceeded flag was set, throws.
+    /// Performs synchronous insertion to remote nodes.
     void writeSync(const Block & block);
 
     void initWritingJobs(const Block & first_block);
@@ -96,7 +95,6 @@ private:
     bool insert_sync;
 
     /// Sync-related stuff
-    UInt64 insert_timeout; // in seconds
     Stopwatch watch;
     Stopwatch watch_current_block;
     std::optional<ThreadPool> pool;

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -537,12 +537,15 @@ BlockOutputStreamPtr StorageDistributed::write(const ASTPtr &, const StorageMeta
 
     /// Force sync insertion if it is remote() table function
     bool insert_sync = settings.insert_distributed_sync || owned_cluster;
-    auto timeout = settings.insert_distributed_timeout;
 
     /// DistributedBlockOutputStream will not own cluster, but will own ConnectionPools of the cluster
     return std::make_shared<DistributedBlockOutputStream>(
-        context, *this, metadata_snapshot, createInsertToRemoteTableQuery(remote_database, remote_table, metadata_snapshot->getSampleBlockNonMaterialized()), cluster,
-        insert_sync, timeout);
+        context,
+        *this,
+        metadata_snapshot,
+        createInsertToRemoteTableQuery(remote_database, remote_table, metadata_snapshot->getSampleBlockNonMaterialized()),
+        cluster,
+        insert_sync);
 }
 
 

--- a/tests/integration/test_insert_into_distributed_sync_async/test.py
+++ b/tests/integration/test_insert_into_distributed_sync_async/test.py
@@ -38,30 +38,30 @@ CREATE TABLE distributed_table(date Date, val UInt64) ENGINE = Distributed(test_
 
 def test_insertion_sync(started_cluster):
 
-    node1.query('''SET insert_distributed_sync = 1, insert_distributed_timeout = 0;
+    node1.query('''SET insert_distributed_sync = 1;
     INSERT INTO distributed_table SELECT today() as date, number as val FROM system.numbers LIMIT 10000''')
 
     assert node2.query("SELECT count() FROM local_table").rstrip() == '10000'
 
     node1.query('''
-    SET insert_distributed_sync = 1, insert_distributed_timeout = 1;
+    SET insert_distributed_sync = 1;
     INSERT INTO distributed_table SELECT today() - 1 as date, number as val FROM system.numbers LIMIT 10000''')
 
     assert node2.query("SELECT count() FROM local_table").rstrip() == '20000'
 
     # Insert with explicitly specified columns.
     node1.query('''
-    SET insert_distributed_sync = 1, insert_distributed_timeout = 1;
+    SET insert_distributed_sync = 1;
     INSERT INTO distributed_table(date, val) VALUES ('2000-01-01', 100500)''')
 
     # Insert with columns specified in different order.
     node1.query('''
-    SET insert_distributed_sync = 1, insert_distributed_timeout = 1;
+    SET insert_distributed_sync = 1;
     INSERT INTO distributed_table(val, date) VALUES (100500, '2000-01-01')''')
 
     # Insert with an incomplete list of columns.
     node1.query('''
-    SET insert_distributed_sync = 1, insert_distributed_timeout = 1;
+    SET insert_distributed_sync = 1;
     INSERT INTO distributed_table(val) VALUES (100500)''')
 
     expected = TSV('''
@@ -77,7 +77,7 @@ def test_insertion_sync_fails_on_error(started_cluster):
         pm.partition_instances(node2, node1, action='REJECT --reject-with tcp-reset')
         with pytest.raises(QueryRuntimeException):
             node1.query('''
-            SET insert_distributed_sync = 1, insert_distributed_timeout = 0;
+            SET insert_distributed_sync = 1;
             INSERT INTO distributed_table SELECT today() as date, number as val FROM system.numbers''', timeout=2)
 """
 
@@ -85,21 +85,21 @@ def test_insertion_sync_fails_on_error(started_cluster):
 def test_insertion_sync_fails_with_timeout(started_cluster):
     with pytest.raises(QueryRuntimeException):
         node1.query('''
-        SET insert_distributed_sync = 1, insert_distributed_timeout = 1;
+        SET insert_distributed_sync = 1;
         INSERT INTO distributed_table SELECT today() as date, number as val FROM system.numbers''')
 
 
 def test_insertion_without_sync_ignores_timeout(started_cluster):
     with pytest.raises(QueryTimeoutExceedException):
         node1.query('''
-        SET insert_distributed_sync = 0, insert_distributed_timeout = 1;
+        SET insert_distributed_sync = 0;
         INSERT INTO distributed_table SELECT today() as date, number as val FROM system.numbers''', timeout=1.5)
 
 
 def test_insertion_sync_with_disabled_timeout(started_cluster):
     with pytest.raises(QueryTimeoutExceedException):
         node1.query('''
-        SET insert_distributed_sync = 1, insert_distributed_timeout = 0;
+        SET insert_distributed_sync = 1;
         INSERT INTO distributed_table SELECT today() as date, number as val FROM system.numbers''', timeout=1)
 
 


### PR DESCRIPTION
Changelog category (leave one):
- Backward Incompatible Change

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Purge insert_distributed_timeout/DistributedSyncInsertionTimeoutExceeded (has been broken a long time ago)

Detailed description / Documentation draft:
For insert_distributed_sync (had been added in [1]) there was two things:
- DistributedSyncInsertionTimeoutExceeded (had been added in [2])
- insert_distributed_timeout

But insert_distributed_timeout never was a generic timeout, when it was
added it could cancel INSERTs into other shards if it takes longer.

But after DistributedBlockOutputStream was converted to ThreadPool (in
[3]) and insert_distributed_timeout lost it's sense, since INSERT into
multiple shards performed in parallel (and in [4] things became even
more broken).

  [1]: b3157aebb21f5ae6e44ec12d415b2abba76f2b88 (cc: @KochetovNicolai)
  [2]: 2f8f199d08c14402bee6e0403749d3edac51dfd2 (cc: @KochetovNicolai)
  [3]: 369f88f65d3fdeb00f3ef55ad91eab5e51d388df (cc: @ludv1x)
  [4]: 96d4e59dabaf2bd29b4172a29bf08bf531dd5b4a (cc: @ludv1x)

Looks like nobody uses it anyway (since it hadn't been working for a
long time, and nobody reports anything), and it had been removed to
simplify logic.

Plus insert_distributed_sync is not the default option.

And w/o insert_distributed_timeout there is sense in
DistributedSyncInsertionTimeoutExceeded.

Reported-by: @Slach

P.S. There were several push --force, and I guess github sends multiple notifications to all the people in `Cc`, sorry for the noise.