### PR TITLE
Revert "Documentation about ReplacingMergeTree extended with type DateTime64 for column `ver`"

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/replacingmergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/replacingmergetree.md
@@ -31,7 +31,7 @@ For a description of request parameters, see [statement description](../../../sq
 
 **ReplacingMergeTree Parameters**
 
--   `ver` — column with version. Type `UInt*`, `Date`, `DateTime` or `DateTime64`. Optional parameter.
+-   `ver` — column with version. Type `UInt*`, `Date` or `DateTime`. Optional parameter.
 
     When merging, `ReplacingMergeTree` from all the rows with the same sorting key leaves only one:
 

--- a/docs/es/engines/table-engines/mergetree-family/replacingmergetree.md
+++ b/docs/es/engines/table-engines/mergetree-family/replacingmergetree.md
@@ -33,7 +33,7 @@ Para obtener una descripción de los parámetros de solicitud, consulte [descrip
 
 **ReplacingMergeTree Parámetros**
 
--   `ver` — column with version. Type `UInt*`, `Date`, `DateTime` o `DateTime64`. Parámetro opcional.
+-   `ver` — column with version. Type `UInt*`, `Date` o `DateTime`. Parámetro opcional.
 
     Al fusionar, `ReplacingMergeTree` de todas las filas con la misma clave primaria deja solo una:
 

--- a/docs/fa/engines/table-engines/mergetree-family/replacingmergetree.md
+++ b/docs/fa/engines/table-engines/mergetree-family/replacingmergetree.md
@@ -33,7 +33,7 @@ CREATE TABLE [IF NOT EXISTS] [db.]table_name [ON CLUSTER cluster]
 
 **پارامترهای جایگزین**
 
--   `ver` — column with version. Type `UInt*`, `Date`, `DateTime` یا `DateTime64`. پارامتر اختیاری.
+-   `ver` — column with version. Type `UInt*`, `Date` یا `DateTime`. پارامتر اختیاری.
 
     هنگام ادغام, `ReplacingMergeTree` از تمام ردیف ها با همان کلید اصلی تنها یک برگ دارد:
 

--- a/docs/fr/engines/table-engines/mergetree-family/replacingmergetree.md
+++ b/docs/fr/engines/table-engines/mergetree-family/replacingmergetree.md
@@ -33,7 +33,7 @@ Pour une description des paramètres de requête, voir [demande de description](
 
 **ReplacingMergeTree Paramètres**
 
--   `ver` — column with version. Type `UInt*`, `Date`, `DateTime` ou `DateTime64`. Paramètre facultatif.
+-   `ver` — column with version. Type `UInt*`, `Date` ou `DateTime`. Paramètre facultatif.
 
     Lors de la fusion, `ReplacingMergeTree` de toutes les lignes avec la même clé primaire ne laisse qu'un:
 

--- a/docs/ja/engines/table-engines/mergetree-family/replacingmergetree.md
+++ b/docs/ja/engines/table-engines/mergetree-family/replacingmergetree.md
@@ -33,7 +33,7 @@ CREATE TABLE [IF NOT EXISTS] [db.]table_name [ON CLUSTER cluster]
 
 **ReplacingMergeTreeパラメータ**
 
--   `ver` — column with version. Type `UInt*`, `Date`, `DateTime` または `DateTime64`. 任意パラメータ。
+-   `ver` — column with version. Type `UInt*`, `Date` または `DateTime`. 任意パラメータ。
 
     マージ時, `ReplacingMergeTree` 同じ主キーを持つすべての行から、一つだけを残します:
 

--- a/docs/ru/engines/table-engines/mergetree-family/replacingmergetree.md
+++ b/docs/ru/engines/table-engines/mergetree-family/replacingmergetree.md
@@ -25,7 +25,7 @@ CREATE TABLE [IF NOT EXISTS] [db.]table_name [ON CLUSTER cluster]
 
 **Параметры ReplacingMergeTree**
 
--   `ver` — столбец с версией, тип `UInt*`, `Date`, `DateTime` или `DateTime64`. Необязательный параметр.
+-   `ver` — столбец с версией, тип `UInt*`, `Date` или `DateTime`. Необязательный параметр.
 
         При слиянии, из всех строк с одинаковым значением ключа сортировки `ReplacingMergeTree` оставляет только одну:
 

--- a/docs/tr/engines/table-engines/mergetree-family/replacingmergetree.md
+++ b/docs/tr/engines/table-engines/mergetree-family/replacingmergetree.md
@@ -33,7 +33,7 @@ CREATE TABLE [IF NOT EXISTS] [db.]table_name [ON CLUSTER cluster]
 
 **ReplacingMergeTree Parametreleri**
 
--   `ver` — column with version. Type `UInt*`, `Date`, `DateTime` veya `DateTime64`. İsteğe bağlı parametre.
+-   `ver` — column with version. Type `UInt*`, `Date` veya `DateTime`. İsteğe bağlı parametre.
 
     Birleş whenirken, `ReplacingMergeTree` aynı birincil anahtara sahip tüm satırlardan sadece bir tane bırakır:
 

--- a/docs/zh/engines/table-engines/mergetree-family/replacingmergetree.md
+++ b/docs/zh/engines/table-engines/mergetree-family/replacingmergetree.md
@@ -25,7 +25,7 @@ CREATE TABLE [IF NOT EXISTS] [db.]table_name [ON CLUSTER cluster]
 
 **参数**
 
--   `ver` — 版本列。类型为 `UInt*`, `Date`, `DateTime` 或 `DateTime64`。可选参数。
+-   `ver` — 版本列。类型为 `UInt*`, `Date` 或 `DateTime`。可选参数。
 
         合并的时候，`ReplacingMergeTree` 从所有具有相同主键的行中选择一行留下：
         - 如果 `ver` 列未指定，选择最后一条。


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#13498 (see comments)

Changelog category (leave one):
- Documentation (changelog entry is not required)