### PR TITLE
Throw exception on alter for storages created from table functions

### DIFF
--- a/src/Databases/DatabaseOrdinary.cpp
+++ b/src/Databases/DatabaseOrdinary.cpp
@@ -33,6 +33,11 @@ static constexpr size_t PRINT_MESSAGE_EACH_N_OBJECTS = 256;
 static constexpr size_t PRINT_MESSAGE_EACH_N_SECONDS = 5;
 static constexpr size_t METADATA_FILE_BUFFER_SIZE = 32768;
 
+namespace ErrorCodes
+{
+    extern const int NOT_IMPLEMENTED;
+}
+
 namespace
 {
     void tryAttachTable(
@@ -248,6 +253,9 @@ void DatabaseOrdinary::alterTable(const Context & context, const StorageID & tab
         context.getSettingsRef().max_parser_depth);
 
     auto & ast_create_query = ast->as<ASTCreateQuery &>();
+
+    if (ast_create_query.as_table_function)
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Cannot alter table {} because it was created AS table function", backQuote(table_name));
 
     ASTPtr new_columns = InterpreterCreateQuery::formatColumns(metadata.columns);
     ASTPtr new_indices = InterpreterCreateQuery::formatIndices(metadata.secondary_indices);

--- a/tests/queries/0_stateless/01461_alter_table_function.reference
+++ b/tests/queries/0_stateless/01461_alter_table_function.reference
@@ -1,0 +1,7 @@
+CREATE TABLE default.table_from_remote AS remote(\'localhost\', \'system\', \'numbers\')
+CREATE TABLE default.table_from_remote AS remote(\'localhost\', \'system\', \'numbers\')
+CREATE TABLE default.table_from_numbers AS numbers(1000)
+CREATE TABLE default.table_from_numbers AS numbers(1000)
+CREATE TABLE default.table_from_select\n(\n    `number` UInt64\n)\nENGINE = MergeTree()\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.table_from_select\n(\n    `number` UInt64,\n    `col` UInt8\n)\nENGINE = MergeTree()\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+1

--- a/tests/queries/0_stateless/01461_alter_table_function.sql
+++ b/tests/queries/0_stateless/01461_alter_table_function.sql
@@ -1,0 +1,33 @@
+DROP TABLE IF EXISTS table_from_remote;
+DROP TABLE IF EXISTS table_from_select;
+DROP TABLE IF EXISTS table_from_numbers;
+
+CREATE TABLE table_from_remote AS remote('localhost', 'system', 'numbers');
+
+SHOW CREATE TABLE table_from_remote;
+
+ALTER TABLE table_from_remote ADD COLUMN col UInt8; --{serverError 48}
+
+SHOW CREATE TABLE table_from_remote;
+
+CREATE TABLE table_from_numbers AS numbers(1000);
+
+SHOW CREATE TABLE table_from_numbers;
+
+ALTER TABLE table_from_numbers ADD COLUMN col UInt8; --{serverError 48}
+
+SHOW CREATE TABLE table_from_numbers;
+
+CREATE TABLE table_from_select ENGINE = MergeTree() ORDER BY tuple() AS SELECT number from system.numbers LIMIT 1;
+
+SHOW CREATE TABLE table_from_select;
+
+ALTER TABLE table_from_select ADD COLUMN col UInt8;
+
+SHOW CREATE TABLE table_from_select;
+
+SELECT 1;
+
+DROP TABLE IF EXISTS table_from_remote;
+DROP TABLE IF EXISTS table_from_select;
+DROP TABLE IF EXISTS table_from_numbers;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix crash during `ALTER` query for table which was created `AS table_function`. Fixes #14212.
