### PR TITLE
Stop query execution if exception happened in PipelineExecutor itself.

### DIFF
--- a/src/Processors/Executors/PipelineExecutor.cpp
+++ b/src/Processors/Executors/PipelineExecutor.cpp
@@ -469,7 +469,16 @@ void PipelineExecutor::wakeUpExecutor(size_t thread_num)
 
 void PipelineExecutor::executeSingleThread(size_t thread_num, size_t num_threads)
 {
-    executeStepImpl(thread_num, num_threads);
+    try
+    {
+        executeStepImpl(thread_num, num_threads);
+    }
+    catch (...)
+    {
+        /// In case of exception from executor itself, stop other threads.
+        finish();
+        throw;
+    }
 
 #ifndef NDEBUG
     auto & context = executor_contexts[thread_num];


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Stop query execution if exception happened in `PipelineExecutor` itself. This could prevent rare possible query hung.