### PR TITLE
Don't let the fuzzer change max_execution_time

### DIFF
--- a/docker/test/fuzzer/query-fuzzer-tweaks-users.xml
+++ b/docker/test/fuzzer/query-fuzzer-tweaks-users.xml
@@ -2,6 +2,15 @@
     <profiles>
         <default>
             <max_execution_time>10</max_execution_time>
+            <!--
+                Don't let the fuzzer change this setting (I've actually seen it
+                do this before).
+            -->
+            <constraints>
+                <max_execution_time>
+                    <max>10</max>
+                </max_execution_time>
+            </constraints>
         </default>
     </profiles>
 </yandex>


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)