### PR TITLE
Less number of threads in builder

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -18,7 +18,7 @@ ifeq ($(CCACHE_PREFIX),distcc)
     THREADS_COUNT=$(shell distcc -j)
 endif
 ifeq ($(THREADS_COUNT),)
-    THREADS_COUNT=$(shell nproc || grep -c ^processor /proc/cpuinfo || sysctl -n hw.ncpu || echo 4)
+    THREADS_COUNT=$(shell $$(( $$(nproc || grep -c ^processor /proc/cpuinfo || sysctl -n hw.ncpu || echo 8) / 2 )) )
 endif
 DEB_BUILD_OPTIONS+=parallel=$(THREADS_COUNT)
 

--- a/src/Dictionaries/BucketCache.h
+++ b/src/Dictionaries/BucketCache.h
@@ -30,12 +30,13 @@ struct Int64Hasher
 };
 
 
-/*
-    Class for storing cache index.
-    It consists of two arrays.
-    The first one is split into buckets (each stores 8 elements (cells)) determined by hash of the element key.
-    The second one is split into 4bit numbers, which are positions in bucket for next element write (So cache uses FIFO eviction algorithm inside each bucket).
-*/
+/**
+  * Class for storing cache index.
+  * It consists of two arrays.
+  * The first one is split into buckets (each stores 8 elements (cells)) determined by hash of the element key.
+  * The second one is split into 4bit numbers, which are positions in bucket for next element write
+  * (So cache uses FIFO eviction algorithm inside each bucket).
+  */
 template <typename K, typename V, typename Hasher, typename Deleter = EmptyDeleter>
 class BucketCacheIndex
 {


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Don't use all hyperthreading cores.
See https://clickhouse-builds.s3.yandex.net/14333/ac5877e601714450a369062abbf80f84485bc6f5/clickhouse_build_check/build_log_761737419_1598985376.txt