### PR TITLE
Stop query execution if exception happened in PipelineExecutor itself.

### DIFF
--- a/src/Processors/Executors/PipelineExecutor.cpp
+++ b/src/Processors/Executors/PipelineExecutor.cpp
@@ -402,6 +402,11 @@ void PipelineExecutor::execute(size_t num_threads)
         for (auto & node : graph->nodes)
             if (node->exception)
                 std::rethrow_exception(node->exception);
+
+        /// Exception which happened in executing thread, but not at processor.
+        for (auto & executor_context : executor_contexts)
+            if (executor_context->exception)
+                std::rethrow_exception(executor_context->exception);
     }
     catch (...)
     {
@@ -431,11 +436,6 @@ bool PipelineExecutor::executeStep(std::atomic_bool * yield_flag)
     for (auto & node : graph->nodes)
         if (node->exception)
             std::rethrow_exception(node->exception);
-
-    /// Exception which happened in executing thread, but not at processor.
-    for (auto & executor_context : executor_contexts)
-        if (executor_context->exception)
-            std::rethrow_exception(executor_context->exception);
 
     finalizeExecution();
 

--- a/src/Processors/Executors/PipelineExecutor.cpp
+++ b/src/Processors/Executors/PipelineExecutor.cpp
@@ -432,6 +432,11 @@ bool PipelineExecutor::executeStep(std::atomic_bool * yield_flag)
         if (node->exception)
             std::rethrow_exception(node->exception);
 
+    /// Exception which happened in executing thread, but not at processor.
+    for (auto & executor_context : executor_contexts)
+        if (executor_context->exception)
+            std::rethrow_exception(executor_context->exception);
+
     finalizeExecution();
 
     return false;
@@ -469,16 +474,7 @@ void PipelineExecutor::wakeUpExecutor(size_t thread_num)
 
 void PipelineExecutor::executeSingleThread(size_t thread_num, size_t num_threads)
 {
-    try
-    {
-        executeStepImpl(thread_num, num_threads);
-    }
-    catch (...)
-    {
-        /// In case of exception from executor itself, stop other threads.
-        finish();
-        throw;
-    }
+    executeStepImpl(thread_num, num_threads);
 
 #ifndef NDEBUG
     auto & context = executor_contexts[thread_num];
@@ -735,7 +731,16 @@ void PipelineExecutor::executeImpl(size_t num_threads)
                             CurrentThread::detachQueryIfNotDetached();
                 );
 
-                executeSingleThread(thread_num, num_threads);
+                try
+                {
+                    executeSingleThread(thread_num, num_threads);
+                }
+                catch (...)
+                {
+                    /// In case of exception from executor itself, stop other threads.
+                    finish();
+                    executor_contexts[thread_num]->exception = std::current_exception();
+                }
             });
         }
 

--- a/src/Processors/Executors/PipelineExecutor.h
+++ b/src/Processors/Executors/PipelineExecutor.h
@@ -97,6 +97,9 @@ private:
         /// Currently processing node.
         ExecutingGraph::Node * node = nullptr;
 
+        /// Exception from executing thread itself.
+        std::exception_ptr exception;
+
 #ifndef NDEBUG
         /// Time for different processing stages.
         UInt64 total_time_ns = 0;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Stop query execution if exception happened in `PipelineExecutor` itself. This could prevent rare possible query hung. Continuation of #14334