### PR TITLE
Fix for Lazy database

### DIFF
--- a/src/Databases/DatabaseOnDisk.cpp
+++ b/src/Databases/DatabaseOnDisk.cpp
@@ -221,6 +221,11 @@ void DatabaseOnDisk::dropTable(const Context & context, const String & table_nam
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Path is empty");
 
     StoragePtr table = detachTable(table_name);
+
+    /// This is possible for Lazy database.
+    if (!table)
+        return;
+
     bool renamed = false;
     try
     {


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://clickhouse-test-reports.s3.yandex.net/0/5a529f171ce44c21f2039b05135b40813f2ab0d1/stress_test_(undefined)/stderr.log

`Lazy` database has poor design that make these kind of errors difficult to avoid.
No additional tests will be provided for this change.
CC @nikvas0 