### PR TITLE
Fix backport script; read the code

### DIFF
--- a/utils/github/backport.py
+++ b/utils/github/backport.py
@@ -20,7 +20,7 @@ class Backport:
     def getPullRequests(self, from_commit):
         return self._gh.get_pull_requests(from_commit)
 
-    def execute(self, repo, til, number, run_cherrypick):
+    def execute(self, repo, until_commit, number, run_cherrypick):
         repo = LocalRepo(repo, 'origin', self.default_branch_name)
         branches = repo.get_release_branches()[-number:]  # [(branch_name, base_commit)]
 
@@ -31,9 +31,9 @@ class Backport:
         for branch in branches:
             logging.info('Found release branch: %s', branch[0])
 
-        if not til:
-            til = branches[0][1]
-        prs = self.getPullRequests(til)
+        if not until_commit:
+            until_commit = branches[0][1]
+        pull_requests = self.getPullRequests(until_commit)
 
         backport_map = {}
 
@@ -42,7 +42,7 @@ class Backport:
         RE_BACKPORTED = re.compile(r'^v(\d+\.\d+)-backported$')
 
         # pull-requests are sorted by ancestry from the least recent.
-        for pr in prs:
+        for pr in pull_requests:
             while repo.comparator(branches[-1][1]) >= repo.comparator(pr['mergeCommit']['oid']):
                 logging.info("PR #{} is already inside {}. Dropping this branch for further PRs".format(pr['number'], branches[-1][0]))
                 branches.pop()
@@ -55,28 +55,28 @@ class Backport:
 
             # First pass. Find all must-backports
             for label in pr['labels']['nodes']:
-                if label['name'].startswith('pr-') and label['color'] == 'ff0000':
+                if label['name'] == 'pr-bugfix':
                     backport_map[pr['number']] = branch_set.copy()
                     continue
-                m = RE_MUST_BACKPORT.match(label['name'])
-                if m:
+                matched = RE_MUST_BACKPORT.match(label['name'])
+                if matched:
                     if pr['number'] not in backport_map:
                         backport_map[pr['number']] = set()
-                    backport_map[pr['number']].add(m.group(1))
+                    backport_map[pr['number']].add(matched.group(1))
 
             # Second pass. Find all no-backports
             for label in pr['labels']['nodes']:
                 if label['name'] == 'pr-no-backport' and pr['number'] in backport_map:
                     del backport_map[pr['number']]
                     break
-                m1 = RE_NO_BACKPORT.match(label['name'])
-                m2 = RE_BACKPORTED.match(label['name'])
-                if m1 and pr['number'] in backport_map and m1.group(1) in backport_map[pr['number']]:
-                    backport_map[pr['number']].remove(m1.group(1))
-                    logging.info('\tskipping %s because of forced no-backport', m1.group(1))
-                elif m2 and pr['number'] in backport_map and m2.group(1) in backport_map[pr['number']]:
-                    backport_map[pr['number']].remove(m2.group(1))
-                    logging.info('\tskipping %s because it\'s already backported manually', m2.group(1))
+                matched_no_backport = RE_NO_BACKPORT.match(label['name'])
+                matched_backported = RE_BACKPORTED.match(label['name'])
+                if matched_no_backport and pr['number'] in backport_map and matched_no_backport.group(1) in backport_map[pr['number']]:
+                    backport_map[pr['number']].remove(matched_no_backport.group(1))
+                    logging.info('\tskipping %s because of forced no-backport', matched_no_backport.group(1))
+                elif matched_backported and pr['number'] in backport_map and matched_backported.group(1) in backport_map[pr['number']]:
+                    backport_map[pr['number']].remove(matched_backported.group(1))
+                    logging.info('\tskipping %s because it\'s already backported manually', matched_backported.group(1))
 
         for pr, branches in backport_map.items():
             logging.info('PR #%s needs to be backported to:', pr)


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix the logic in backport script. In previous versions it was triggered for any labels of 100% red color. It was strange.


Detailed description / Documentation draft:
See #14393 #14392 #14391 #14390.

```
Artem Zuikov, [21.06.19 20:35]
а зачем мы хотим бэкпортировать pr-doc-fix? у нас что-то в старых ветках по ним строится?

Alexey Milovidov, [30.07.20 17:26]
А почему черри-пикалка реагирует ещё на pr-doc-fix?

Ivan Lezhankin (Work), [30.07.20 17:28]
[In reply to Alexey Milovidov]
Она работает, как и старый алгоритм, по цвету метки. Черрипикается всё красное.

Alexey Milovidov, [30.07.20 17:29]
Ок, давай тогда поменяем на имя метки, пусть останется только pr-bugfix.

Ivan Lezhankin (Work), [30.07.20 17:29]
[In reply to Alexey Milovidov]
Хорошо, сделаю тогда вместе с добавлением Changelog Description.
```

@abyss7 forgot to change it.