### PR TITLE
Add missed #include <atomic>

### DIFF
--- a/src/Processors/Port.h
+++ b/src/Processors/Port.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <vector>
 #include <variant>


### PR DESCRIPTION
`std::atomic<Data*>` at line 199 requires including `<atomic>`

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix missed `#include <atomic>`


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
