### PR TITLE
Remove redundant conditions

### DIFF
--- a/src/Common/StringSearcher.h
+++ b/src/Common/StringSearcher.h
@@ -254,7 +254,7 @@ public:
                 const auto offset = __builtin_ctz(mask);
                 haystack += offset;
 
-                if (haystack < haystack_end && haystack + n <= haystack_end && pageSafe(haystack))
+                if (haystack + n <= haystack_end && pageSafe(haystack))
                 {
                     const auto v_haystack_offset = _mm_loadu_si128(reinterpret_cast<const __m128i *>(haystack));
                     const auto v_against_l_offset = _mm_cmpeq_epi8(v_haystack_offset, cachel);
@@ -463,7 +463,7 @@ public:
                 const auto offset = __builtin_ctz(mask);
                 haystack += offset;
 
-                if (haystack < haystack_end && haystack + n <= haystack_end && pageSafe(haystack))
+                if (haystack + n <= haystack_end && pageSafe(haystack))
                 {
                     const auto v_haystack_offset = _mm_loadu_si128(reinterpret_cast<const __m128i *>(haystack));
                     const auto v_against_l_offset = _mm_cmpeq_epi8(v_haystack_offset, cachel);
@@ -652,7 +652,7 @@ public:
                 const auto offset = __builtin_ctz(mask);
                 haystack += offset;
 
-                if (haystack < haystack_end && haystack + n <= haystack_end && pageSafe(haystack))
+                if (haystack + n <= haystack_end && pageSafe(haystack))
                 {
                     /// check for first 16 octets
                     const auto v_haystack_offset = _mm_loadu_si128(reinterpret_cast<const __m128i *>(haystack));


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

```
Amos Bird, [04.09.20 01:51]
btw, it seems the first condition is redundant here 

Alexey Milovidov, [04.09.20 01:56]
Yes it is (only because pointer overflow is undefined behaviour in C++).
Let's remove it.
```