### PR TITLE
Support MySQL handler 'set @@xx' settting

### DIFF
--- a/src/Server/MySQLHandler.cpp
+++ b/src/Server/MySQLHandler.cpp
@@ -394,6 +394,7 @@ static bool isFederatedServerSetupSetCommand(const String & query)
         "|(^(SET FOREIGN_KEY_CHECKS(.*)))"
         "|(^(SET AUTOCOMMIT(.*)))"
         "|(^(SET sql_mode(.*)))"
+        "|(^(SET @@(.*)))"
         "|(^(SET SESSION TRANSACTION ISOLATION LEVEL(.*)))"
         , std::regex::icase};
     return 1 == std::regex_match(query, expr);

--- a/tests/integration/test_mysql_protocol/test.py
+++ b/tests/integration/test_mysql_protocol/test.py
@@ -282,6 +282,23 @@ def test_mysql_federated(mysql_server, server_address):
         assert stdout == '\n'.join(['col', '0', '0', '1', '1', '5', '5', ''])
 
 
+def test_mysql_set_variables(mysql_client, server_address):
+    code, (stdout, stderr) = mysql_client.exec_run('''
+        mysql --protocol tcp -h {host} -P {port} default -u default --password=123
+        -e 
+        "
+        SET NAMES=default;
+        SET character_set_results=default;
+        SET FOREIGN_KEY_CHECKS=false;
+        SET AUTOCOMMIT=1;
+        SET sql_mode='strict';
+        SET @@wait_timeout = 2147483;
+        SET SESSION TRANSACTION ISOLATION LEVEL READ;
+        "
+    '''.format(host=server_address, port=server_port), demux=True)
+    assert code == 0
+
+
 def test_python_client(server_address):
     client = pymysql.connections.Connection(host=server_address, user='user_with_double_sha1', password='abacaba', database='default', port=server_port)
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
MySQL handler returns `OK` for queries like `SET @@var = value`. Such statement is ignored. It is needed because some MySQL drivers send `SET @@` query for setup after handshake  https://github.com/ClickHouse/ClickHouse/issues/9336#issuecomment-686222422 .
