### PR TITLE
Use previous users.xml if failed to reload

### DIFF
--- a/docker/test/testflows/runner/Dockerfile
+++ b/docker/test/testflows/runner/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update \
 ENV TZ=Europe/Moscow
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN pip3 install urllib3 testflows==1.6.42 docker-compose docker dicttoxml kazoo tzlocal
+RUN pip3 install urllib3 testflows==1.6.48 docker-compose docker dicttoxml kazoo tzlocal
 
 ENV DOCKER_CHANNEL stable
 ENV DOCKER_VERSION 17.09.1-ce

--- a/src/Common/Config/ConfigReloader.cpp
+++ b/src/Common/Config/ConfigReloader.cpp
@@ -138,6 +138,7 @@ void ConfigReloader::reloadIfNewer(bool force, bool throw_on_error, bool fallbac
             if (throw_on_error)
                 throw;
             tryLogCurrentException(log, "Error updating configuration from '" + path + "' config.");
+            return;
         }
 
         LOG_DEBUG(log, "Loaded config '{}', performed update on configuration", path);

--- a/tests/integration/helpers/test_tools.py
+++ b/tests/integration/helpers/test_tools.py
@@ -60,3 +60,19 @@ def assert_eq_with_retry(instance, query, expectation, retry_count=20, sleep_tim
         if expectation_tsv != val:
             raise AssertionError("'{}' != '{}'\n{}".format(expectation_tsv, val, '\n'.join(
                 expectation_tsv.diff(val, n1="expectation", n2="query"))))
+
+def assert_logs_contain(instance, substring):
+    if not instance.contains_in_log(substring):
+        raise AssertionError("'{}' not found in logs".format(substring))
+
+def assert_logs_contain_with_retry(instance, substring, retry_count=20, sleep_time=0.5):
+    for i in xrange(retry_count):
+        try:
+            if instance.contains_in_log(substring):
+                break
+            time.sleep(sleep_time)
+        except Exception as ex:
+            print "contains_in_log_with_retry retry {} exception {}".format(i + 1, ex)
+            time.sleep(sleep_time)
+    else:
+        raise AssertionError("'{}' not found in logs".format(substring))

--- a/tests/integration/test_custom_settings/configs/config.d/text_log.xml
+++ b/tests/integration/test_custom_settings/configs/config.d/text_log.xml
@@ -1,3 +1,0 @@
-<yandex>
-    <text_log/>
-</yandex>

--- a/tests/integration/test_custom_settings/configs/custom_settings.xml
+++ b/tests/integration/test_custom_settings/configs/custom_settings.xml
@@ -6,13 +6,5 @@
             <custom_c>Float64_-43.25e-1</custom_c>
             <custom_d>'some text'</custom_d>
         </default>
-
-        <profile_with_unknown_setting>
-            <x>1</x>
-        </profile_with_unknown_setting>
-
-        <profile_illformed_setting>
-            <custom_f>1</custom_f>
-        </profile_illformed_setting>
     </profiles>
 </yandex>

--- a/tests/integration/test_custom_settings/configs/illformed_setting.xml
+++ b/tests/integration/test_custom_settings/configs/illformed_setting.xml
@@ -1,0 +1,7 @@
+<yandex>
+    <profiles>
+        <default>
+            <custom_f>1</custom_f>
+        </default>
+    </profiles>
+</yandex>

--- a/tests/integration/test_custom_settings/test.py
+++ b/tests/integration/test_custom_settings/test.py
@@ -1,9 +1,10 @@
 import pytest
+import os
 from helpers.cluster import ClickHouseCluster
 
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 cluster = ClickHouseCluster(__file__)
-node = cluster.add_instance('node', main_configs=["configs/config.d/text_log.xml"],
-                            user_configs=["configs/users.d/custom_settings.xml"])
+node = cluster.add_instance('node')
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -16,28 +17,17 @@ def started_cluster():
         cluster.shutdown()
 
 
-def test():
+def test_custom_settings():
+    node.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/custom_settings.xml"), '/etc/clickhouse-server/users.d/z.xml')
+    node.query("SYSTEM RELOAD CONFIG")
+
     assert node.query("SELECT getSetting('custom_a')") == "-5\n"
     assert node.query("SELECT getSetting('custom_b')") == "10000000000\n"
     assert node.query("SELECT getSetting('custom_c')") == "-4.325\n"
     assert node.query("SELECT getSetting('custom_d')") == "some text\n"
 
-    assert "custom_a = -5, custom_b = 10000000000, custom_c = -4.325, custom_d = \\'some text\\'" \
-           in node.query("SHOW CREATE SETTINGS PROFILE default")
 
-    assert "no settings profile" in node.query_and_get_error(
-        "SHOW CREATE SETTINGS PROFILE profile_with_unknown_setting")
-    assert "no settings profile" in node.query_and_get_error("SHOW CREATE SETTINGS PROFILE profile_illformed_setting")
-
-
-def test_invalid_settings():
-    node.query("SYSTEM RELOAD CONFIG")
-    node.query("SYSTEM FLUSH LOGS")
-
-    assert node.query("SELECT COUNT() FROM system.text_log WHERE"
-                      " message LIKE '%Could not parse profile `profile_illformed_setting`%'"
-                      " AND message LIKE '%Couldn\\'t restore Field from dump%'") == "1\n"
-
-    assert node.query("SELECT COUNT() FROM system.text_log WHERE"
-                      " message LIKE '%Could not parse profile `profile_with_unknown_setting`%'"
-                      " AND message LIKE '%Setting x is neither a builtin setting nor started with the prefix \\'custom_\\'%'") == "1\n"
+def test_illformed_setting():
+    node.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/illformed_setting.xml"), '/etc/clickhouse-server/users.d/z.xml')
+    error_message = "Couldn't restore Field from dump: 1"
+    assert error_message in node.query_and_get_error("SYSTEM RELOAD CONFIG")

--- a/tests/integration/test_reloading_settings_from_users_xml/configs/changed_settings.xml
+++ b/tests/integration/test_reloading_settings_from_users_xml/configs/changed_settings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<yandex>
+    <profiles replace="replace">
+        <default>
+            <max_memory_usage>20000000000</max_memory_usage>
+            <load_balancing>nearest_hostname</load_balancing>
+        </default>
+    </profiles>
+</yandex>

--- a/tests/integration/test_reloading_settings_from_users_xml/configs/normal_settings.xml
+++ b/tests/integration/test_reloading_settings_from_users_xml/configs/normal_settings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<yandex>
+    <profiles replace="replace">
+        <default>
+            <max_memory_usage>10000000000</max_memory_usage>
+            <load_balancing>first_or_random</load_balancing>
+        </default>
+    </profiles>
+</yandex>

--- a/tests/integration/test_reloading_settings_from_users_xml/configs/unexpected_setting_enum.xml
+++ b/tests/integration/test_reloading_settings_from_users_xml/configs/unexpected_setting_enum.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<yandex>
+    <profiles replace="replace">
+        <default>
+            <max_memory_usage>20000000000</max_memory_usage>
+            <load_balancing>a</load_balancing>
+        </default>
+    </profiles>
+</yandex>

--- a/tests/integration/test_reloading_settings_from_users_xml/configs/unexpected_setting_int.xml
+++ b/tests/integration/test_reloading_settings_from_users_xml/configs/unexpected_setting_int.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<yandex>
+    <profiles replace="replace">
+        <default>
+            <max_memory_usage>a</max_memory_usage>
+            <load_balancing>nearest_hostname</load_balancing>
+        </default>
+    </profiles>
+</yandex>

--- a/tests/integration/test_reloading_settings_from_users_xml/configs/unknown_setting.xml
+++ b/tests/integration/test_reloading_settings_from_users_xml/configs/unknown_setting.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<yandex>
+    <profiles replace="replace">
+        <default>
+            <xyz>8</xyz>
+        </default>
+    </profiles>
+</yandex>

--- a/tests/integration/test_reloading_settings_from_users_xml/test.py
+++ b/tests/integration/test_reloading_settings_from_users_xml/test.py
@@ -1,0 +1,90 @@
+import pytest
+import os
+import time
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry, assert_logs_contain_with_retry
+
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance('node', user_configs=["configs/normal_settings.xml"])
+
+@pytest.fixture(scope="module", autouse=True)
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def reset_to_normal_settings_after_test():
+    try:
+        node.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/normal_settings.xml"), '/etc/clickhouse-server/users.d/z.xml')
+        node.query("SYSTEM RELOAD CONFIG")
+        yield
+    finally:
+        pass
+
+
+def test_force_reload():
+    assert node.query("SELECT getSetting('max_memory_usage')") == "10000000000\n"
+    assert node.query("SELECT getSetting('load_balancing')") == "first_or_random\n"
+    
+    node.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/changed_settings.xml"), '/etc/clickhouse-server/users.d/z.xml')
+    node.query("SYSTEM RELOAD CONFIG")
+
+    assert node.query("SELECT getSetting('max_memory_usage')") == "20000000000\n"
+    assert node.query("SELECT getSetting('load_balancing')") == "nearest_hostname\n"
+
+
+def test_reload_on_timeout():
+    assert node.query("SELECT getSetting('max_memory_usage')") == "10000000000\n"
+    assert node.query("SELECT getSetting('load_balancing')") == "first_or_random\n"
+
+    time.sleep(1) # The modification time of the 'z.xml' file should be different,
+                  # because config files are reload by timer only when the modification time is changed.
+    node.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/changed_settings.xml"), '/etc/clickhouse-server/users.d/z.xml')
+
+    assert_eq_with_retry(node, "SELECT getSetting('max_memory_usage')", "20000000000")
+    assert_eq_with_retry(node, "SELECT getSetting('load_balancing')", "nearest_hostname")
+
+
+def test_unknown_setting_force_reload():
+    node.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/unknown_setting.xml"), '/etc/clickhouse-server/users.d/z.xml')
+
+    error_message = "Setting xyz is neither a builtin setting nor started with the prefix 'custom_' registered for user-defined settings"
+    assert error_message in node.query_and_get_error("SYSTEM RELOAD CONFIG")
+
+    assert node.query("SELECT getSetting('max_memory_usage')") == "10000000000\n"
+    assert node.query("SELECT getSetting('load_balancing')") == "first_or_random\n"
+
+
+def test_unknown_setting_reload_on_timeout():
+    time.sleep(1) # The modification time of the 'z.xml' file should be different,
+                  # because config files are reload by timer only when the modification time is changed.
+    node.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/unknown_setting.xml"), '/etc/clickhouse-server/users.d/z.xml')
+
+    error_message = "Setting xyz is neither a builtin setting nor started with the prefix 'custom_' registered for user-defined settings"
+    assert_logs_contain_with_retry(node, error_message)
+
+    assert node.query("SELECT getSetting('max_memory_usage')") == "10000000000\n"
+    assert node.query("SELECT getSetting('load_balancing')") == "first_or_random\n"
+
+
+def test_unexpected_setting_int():
+    node.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/unexpected_setting_int.xml"), '/etc/clickhouse-server/users.d/z.xml')
+    error_message = "Cannot parse"
+    assert error_message in node.query_and_get_error("SYSTEM RELOAD CONFIG")
+
+    assert node.query("SELECT getSetting('max_memory_usage')") == "10000000000\n"
+    assert node.query("SELECT getSetting('load_balancing')") == "first_or_random\n"
+
+
+def test_unexpected_setting_enum():
+    node.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/unexpected_setting_int.xml"), '/etc/clickhouse-server/users.d/z.xml')
+    error_message = "Cannot parse"
+    assert error_message in node.query_and_get_error("SYSTEM RELOAD CONFIG")
+
+    assert node.query("SELECT getSetting('max_memory_usage')") == "10000000000\n"
+    assert node.query("SELECT getSetting('load_balancing')") == "first_or_random\n"

--- a/tests/testflows/ldap/tests/user_config.py
+++ b/tests/testflows/ldap/tests/user_config.py
@@ -29,6 +29,7 @@ def empty_user_name(self, timeout=20):
 def empty_server_name(self, timeout=20):
     """Check that if server name is an empty string then login is not allowed.
     """
+    message = "Exception: LDAP server name cannot be empty for user"
     servers = {"openldap1": {
         "host": "openldap1", "port": "389", "enable_tls": "no",
         "auth_dn_prefix": "cn=", "auth_dn_suffix": ",ou=users,dc=company,dc=com"
@@ -37,7 +38,8 @@ def empty_server_name(self, timeout=20):
         "errorcode": 4,
         "message": "DB::Exception: user1: Authentication failed: password is incorrect or there is no user with such name"
     }]
-    login(servers, *users)
+    config = create_ldap_users_config_content(*users)
+    invalid_user_config(servers, config, message=message, tail=15, timeout=timeout)
 
 @TestScenario
 @Requirements(
@@ -146,9 +148,6 @@ def ldap_and_password(self):
 
     with Then("I expect an error when I try to load the configuration file", description=error_message):
         invalid_user_config(servers, new_config, message=error_message, tail=16)
-
-    with And("I expect the authentication to fail when I try to login"):
-        login(servers, user, config=new_config)
 
 @TestFeature
 @Name("user config")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Improvement

Changelog entry:
SYSTEM RELOAD CONFIG now throws an exception if failed to reload and continues using the previous users.xml.
The background periodic reloading also continues using the previous users.xml if failed to reload.
