### PR TITLE
Disable S3 requests processing during context shutdown to speed up termination process

### DIFF
--- a/src/Disks/IDisk.h
+++ b/src/Disks/IDisk.h
@@ -183,6 +183,9 @@ public:
     /// Return disk type - "local", "s3", etc.
     virtual const String getType() const = 0;
 
+    /// Invoked when Global Context is shutdown.
+    virtual void shutdown() { }
+
 private:
     /// Returns executor to perform asynchronous operations.
     Executor & getExecutor() { return *executor; }

--- a/src/Disks/S3/DiskS3.cpp
+++ b/src/Disks/S3/DiskS3.cpp
@@ -746,4 +746,9 @@ void DiskS3::setReadOnly(const String & path)
     Poco::File(metadata_path + path).setReadOnly(true);
 }
 
+void DiskS3::shutdown()
+{
+    client->DisableRequestProcessing();
+}
+
 }

--- a/src/Disks/S3/DiskS3.cpp
+++ b/src/Disks/S3/DiskS3.cpp
@@ -748,6 +748,10 @@ void DiskS3::setReadOnly(const String & path)
 
 void DiskS3::shutdown()
 {
+    /// This call stops any next retry attempts for ongoing S3 requests.
+    /// If S3 request is failed and the method below is executed S3 client immediately returns the last failed S3 request outcome.
+    /// If S3 is healthy nothing wrong will be happened and S3 requests will be processed in a regular way without errors.
+    /// This should significantly speed up shutdown process if S3 is unhealthy.
     client->DisableRequestProcessing();
 }
 

--- a/src/Disks/S3/DiskS3.h
+++ b/src/Disks/S3/DiskS3.h
@@ -102,6 +102,8 @@ public:
 
     const String getType() const override { return "s3"; }
 
+    void shutdown() override;
+
 private:
     bool tryReserve(UInt64 bytes);
 

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1973,6 +1973,13 @@ void Context::reloadConfig() const
 
 void Context::shutdown()
 {
+    auto disks = getDisksMap();
+    for (auto & [disk_name, disk] : disks)
+    {
+        LOG_INFO(shared->log, "Shutdown disk {}", disk_name);
+        disk->shutdown();
+    }
+
     shared->shutdown();
 }
 

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1973,8 +1973,7 @@ void Context::reloadConfig() const
 
 void Context::shutdown()
 {
-    auto disks = getDisksMap();
-    for (auto & [disk_name, disk] : disks)
+    for (auto & [disk_name, disk] : getDisksMap())
     {
         LOG_INFO(shared->log, "Shutdown disk {}", disk_name);
         disk->shutdown();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Speed up server shutdown process if there are ongoing S3 requests

Detailed description / Documentation draft:
The shutdown process can be delayed if there are ongoing S3 requests, especially when S3 is unavailable (request is repeated again and again due to retry strategy).
When shutdown is called we can forcibly break all S3 connections and speed up the shutdown process.
