### PR TITLE
Add option to DiskS3 that allows it's usage if S3 unavailable

### DIFF
--- a/src/Disks/S3/registerDiskS3.cpp
+++ b/src/Disks/S3/registerDiskS3.cpp
@@ -151,7 +151,7 @@ void registerDiskS3(DiskFactory & factory)
             checkReadAccess(name, *s3disk);
             checkRemoveAccess(*s3disk);
         }
-        catch(...)
+        catch (...)
         {
             tryLogCurrentException(&Poco::Logger::get("DiskS3"), "Disk " + name + "  has no access to S3");
             if (config.getBool(config_prefix + ".fail_if_unavailable", true))

--- a/src/Disks/S3/registerDiskS3.cpp
+++ b/src/Disks/S3/registerDiskS3.cpp
@@ -145,17 +145,11 @@ void registerDiskS3(DiskFactory & factory)
             config.getUInt64(config_prefix + ".min_bytes_for_seek", 1024 * 1024));
 
         /// This code is used only to check access to the corresponding disk.
-        try
+        if (!config.getBool(config_prefix + ".skip_access_check", false))
         {
             checkWriteAccess(*s3disk);
             checkReadAccess(name, *s3disk);
             checkRemoveAccess(*s3disk);
-        }
-        catch (...)
-        {
-            tryLogCurrentException(&Poco::Logger::get("DiskS3"), "Disk " + name + "  has no access to S3");
-            if (config.getBool(config_prefix + ".fail_if_unavailable", true))
-                throw;
         }
 
         bool cache_enabled = config.getBool(config_prefix + ".cache_enabled", true);

--- a/src/Disks/S3/registerDiskS3.cpp
+++ b/src/Disks/S3/registerDiskS3.cpp
@@ -145,9 +145,18 @@ void registerDiskS3(DiskFactory & factory)
             config.getUInt64(config_prefix + ".min_bytes_for_seek", 1024 * 1024));
 
         /// This code is used only to check access to the corresponding disk.
-        checkWriteAccess(*s3disk);
-        checkReadAccess(name, *s3disk);
-        checkRemoveAccess(*s3disk);
+        try
+        {
+            checkWriteAccess(*s3disk);
+            checkReadAccess(name, *s3disk);
+            checkRemoveAccess(*s3disk);
+        }
+        catch(...)
+        {
+            tryLogCurrentException(&Poco::Logger::get("DiskS3"), "Disk " + name + "  has no access to S3");
+            if (config.getBool(config_prefix + ".fail_if_unavailable", true))
+                throw;
+        }
 
         bool cache_enabled = config.getBool(config_prefix + ".cache_enabled", true);
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add an option to skip access checks for DiskS3

Detailed description / Documentation draft:
During server startup, it reads a storage policy configuration and creates all necessary disks. However, if an S3 disk can't be created because S3 is unavailable it breaks server startup.
We can allow to startup DiskS3 without access checks for this case.
