### PR TITLE
Remove dryrun event to update position

### DIFF
--- a/src/Core/tests/mysql_protocol.cpp
+++ b/src/Core/tests/mysql_protocol.cpp
@@ -356,6 +356,10 @@ int main(int argc, char ** argv)
                         break;
                     }
                     default:
+                        if (event->header.type != MySQLReplication::EventType::HEARTBEAT_EVENT)
+                        {
+                            event->dump(std::cerr);
+                        }
                         break;
                 }
             }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:

For dryrun events, some [Ignored Events](https://dev.mysql.com/doc/internals/en/ignored-events.html) maybe have the same type with the normal events, here disable them to update the binlog position.

