### PR TITLE
disable embedded compiler in 20.3

### DIFF
--- a/cmake/find/llvm.cmake
+++ b/cmake/find/llvm.cmake
@@ -1,7 +1,7 @@
 # Broken in macos. TODO: update clang, re-test, enable
 if (NOT APPLE)
     option (ENABLE_EMBEDDED_COMPILER "Set to TRUE to enable support for 'compile_expressions' option for query execution" 0)
-    option (USE_INTERNAL_LLVM_LIBRARY "Use bundled or system LLVM library." ${NOT_UNBUNDLED})
+    option (USE_INTERNAL_LLVM_LIBRARY "Use bundled or system LLVM library." 0)
 endif ()
 
 if (ENABLE_EMBEDDED_COMPILER)

--- a/cmake/find/llvm.cmake
+++ b/cmake/find/llvm.cmake
@@ -1,6 +1,6 @@
 # Broken in macos. TODO: update clang, re-test, enable
 if (NOT APPLE)
-    option (ENABLE_EMBEDDED_COMPILER "Set to TRUE to enable support for 'compile_expressions' option for query execution" ${ENABLE_LIBRARIES})
+    option (ENABLE_EMBEDDED_COMPILER "Set to TRUE to enable support for 'compile_expressions' option for query execution" 0)
     option (USE_INTERNAL_LLVM_LIBRARY "Use bundled or system LLVM library." ${NOT_UNBUNDLED})
 endif ()
 


### PR DESCRIPTION
should fix the libz3.so.4 problem in tests

Changelog category (leave one):
- Not for changelog (changelog entry is not required)