### PR TITLE
Handle host/network is unreachable in integration tests

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -1041,7 +1041,7 @@ class ClickHouseInstance:
             except socket.timeout:
                 continue
             except socket.error as e:
-                if e.errno == errno.ECONNREFUSED:
+                if e.errno == errno.ECONNREFUSED or e.errno == errno.EHOSTUNREACH or e.errno == errno.ENETUNREACH:
                     time.sleep(0.1)
                 else:
                     raise


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


This error is happening from time to time due to network specifics in Docker.
See https://clickhouse-test-reports.s3.yandex.net/14471/3942cc615f03ecb8e5b9e7437fdc5c57613c245d/integration_tests_(release)/integration_run.3.txt.out.log