### PR TITLE
Fixes for "Arcadia" build system

### DIFF
--- a/src/Core/TypeListNumber.h
+++ b/src/Core/TypeListNumber.h
@@ -20,7 +20,7 @@ using TypeListGeneralNumbers = typename TypeListConcat<TypeListNativeNumbers, Ty
 /// "Arcadia" build system cannot support large integers due to use of old linker version.
 
 using TypeListDecimalNumbers = TypeList<Decimal32, Decimal64, Decimal128>;
-using TypeListGeneralNumbers = typename TypeListNativeNumbers;
+using TypeListGeneralNumbers = TypeListNativeNumbers;
 
 #endif
 

--- a/src/Core/TypeListNumber.h
+++ b/src/Core/TypeListNumber.h
@@ -8,10 +8,22 @@ namespace DB
 {
 
 using TypeListNativeNumbers = TypeList<UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64, Float32, Float64>;
+
+#if !defined(ARCADIA_BUILD)
+
 using TypeListExtendedNumbers = TypeList<Int128, UInt256, Int256>;
 using TypeListDecimalNumbers = TypeList<Decimal32, Decimal64, Decimal128, Decimal256>;
-
 using TypeListGeneralNumbers = typename TypeListConcat<TypeListNativeNumbers, TypeListExtendedNumbers>::Type;
+
+#else
+
+/// "Arcadia" build system cannot support large integers due to use of old linker version.
+
+using TypeListDecimalNumbers = TypeList<Decimal32, Decimal64, Decimal128>;
+using TypeListGeneralNumbers = typename TypeListNativeNumbers;
+
+#endif
+
 using TypeListNumbers = typename TypeListConcat<TypeListGeneralNumbers, TypeListDecimalNumbers>::Type;
 
 /// Currently separate because UInt128 cannot be used in every context where other numbers can be used.

--- a/src/Functions/FunctionBinaryArithmetic.h
+++ b/src/Functions/FunctionBinaryArithmetic.h
@@ -590,13 +590,17 @@ class FunctionBinaryArithmetic : public IFunction
             DataTypeUInt16,
             DataTypeUInt32,
             DataTypeUInt64,
+#if !defined(ARCADIA_BUILD) /// "Arcadia" build system cannot support large integers due to use of old linker version.
             DataTypeUInt256,
+#endif
             DataTypeInt8,
             DataTypeInt16,
             DataTypeInt32,
             DataTypeInt64,
+#if !defined(ARCADIA_BUILD)
             DataTypeInt128,
             DataTypeInt256,
+#endif
             DataTypeFloat32,
             DataTypeFloat64,
             DataTypeDate,
@@ -604,7 +608,9 @@ class FunctionBinaryArithmetic : public IFunction
             DataTypeDecimal<Decimal32>,
             DataTypeDecimal<Decimal64>,
             DataTypeDecimal<Decimal128>,
+#if !defined(ARCADIA_BUILD)
             DataTypeDecimal<Decimal256>,
+#endif
             DataTypeFixedString
         >(type, std::forward<F>(f));
     }


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


The notorious "Arcadia" build system still using lld-7 as linker and it does not support binary size over 4 GiB.
ClickHouse is less than 4 GiB but the issue appeared when full ClickHouse engine is statically linked into another very fat binary.