### PR TITLE
Lower binary size in "Arcadia" build

### DIFF
--- a/base/common/ya.make
+++ b/base/common/ya.make
@@ -32,6 +32,8 @@ PEERDIR(
     contrib/restricted/cityhash-1.0.2
 )
 
+CFLAGS(-g0)
+
 SRCS(
     argsToConfig.cpp
     coverage.cpp

--- a/base/common/ya.make.in
+++ b/base/common/ya.make.in
@@ -31,6 +31,8 @@ PEERDIR(
     contrib/restricted/cityhash-1.0.2
 )
 
+CFLAGS(-g0)
+
 SRCS(
 <? find . -name '*.cpp' | grep -v -F tests/ | grep -v -F Replxx | grep -v -F Readline | sed 's/^\.\//    /' | sort ?>
 )

--- a/base/daemon/ya.make
+++ b/base/daemon/ya.make
@@ -6,6 +6,8 @@ PEERDIR(
     clickhouse/src/Common
 )
 
+CFLAGS(-g0)
+
 SRCS(
     BaseDaemon.cpp
     GraphiteWriter.cpp

--- a/base/loggers/ya.make
+++ b/base/loggers/ya.make
@@ -4,6 +4,8 @@ PEERDIR(
     clickhouse/src/Common
 )
 
+CFLAGS(-g0)
+
 SRCS(
     ExtendedLogChannel.cpp
     Loggers.cpp

--- a/base/readpassphrase/ya.make
+++ b/base/readpassphrase/ya.make
@@ -1,5 +1,7 @@
 LIBRARY()
 
+CFLAGS(-g0)
+
 SRCS(
     readpassphrase.c
 )

--- a/base/widechar_width/ya.make
+++ b/base/widechar_width/ya.make
@@ -2,6 +2,8 @@ LIBRARY()
 
 ADDINCL(GLOBAL clickhouse/base/widechar_width)
 
+CFLAGS(-g0)
+
 SRCS(
     widechar_width.cpp
 )

--- a/programs/server/ya.make
+++ b/programs/server/ya.make
@@ -8,6 +8,8 @@ PEERDIR(
     contrib/libs/poco/NetSSL_OpenSSL
 )
 
+CFLAGS(-g0)
+
 SRCS(
     clickhouse-server.cpp
 

--- a/programs/ya.make
+++ b/programs/ya.make
@@ -12,6 +12,8 @@ PEERDIR(
     clickhouse/src
 )
 
+CFLAGS(-g0)
+
 SRCS(
     main.cpp
 

--- a/src/Access/ya.make
+++ b/src/Access/ya.make
@@ -5,6 +5,8 @@ PEERDIR(
     clickhouse/src/Common
 )
 
+CFLAGS(-g0)
+
 SRCS(
     AccessControlManager.cpp
     AccessRights.cpp

--- a/src/Access/ya.make.in
+++ b/src/Access/ya.make.in
@@ -4,6 +4,8 @@ PEERDIR(
     clickhouse/src/Common
 )
 
+CFLAGS(-g0)
+
 SRCS(
 <? find . -name '*.cpp' | sed 's/^\.\//    /' | sort ?>
 )

--- a/src/AggregateFunctions/ya.make
+++ b/src/AggregateFunctions/ya.make
@@ -5,6 +5,8 @@ PEERDIR(
     clickhouse/src/Common
 )
 
+CFLAGS(-g0)
+
 SRCS(
     AggregateFunctionAggThrow.cpp
     AggregateFunctionArray.cpp

--- a/src/AggregateFunctions/ya.make.in
+++ b/src/AggregateFunctions/ya.make.in
@@ -4,6 +4,8 @@ PEERDIR(
     clickhouse/src/Common
 )
 
+CFLAGS(-g0)
+
 SRCS(
 <? find . -name '*.cpp' | grep -v -F tests | grep -v -F GroupBitmap | sed 's/^\.\//    /' | sort ?>
 )

--- a/src/Client/ya.make
+++ b/src/Client/ya.make
@@ -6,6 +6,8 @@ PEERDIR(
     contrib/libs/poco/NetSSL_OpenSSL
 )
 
+CFLAGS(-g0)
+
 SRCS(
     Connection.cpp
     ConnectionPoolWithFailover.cpp

--- a/src/Client/ya.make.in
+++ b/src/Client/ya.make.in
@@ -5,6 +5,8 @@ PEERDIR(
     contrib/libs/poco/NetSSL_OpenSSL
 )
 
+CFLAGS(-g0)
+
 SRCS(
 <? find . -name '*.cpp' | grep -v -F tests | sed 's/^\.\//    /' | sort ?>
 )

--- a/src/Columns/ya.make
+++ b/src/Columns/ya.make
@@ -13,6 +13,8 @@ PEERDIR(
     contrib/libs/pdqsort
 )
 
+CFLAGS(-g0)
+
 SRCS(
     Collator.cpp
     ColumnAggregateFunction.cpp

--- a/src/Common/ya.make
+++ b/src/Common/ya.make
@@ -21,6 +21,8 @@ PEERDIR(
 
 INCLUDE(${ARCADIA_ROOT}/clickhouse/cmake/yandex/ya.make.versions.inc)
 
+CFLAGS(-g0)
+
 SRCS(
     ActionLock.cpp
     AlignedBuffer.cpp

--- a/src/Common/ya.make.in
+++ b/src/Common/ya.make.in
@@ -20,6 +20,8 @@ PEERDIR(
 
 INCLUDE(${ARCADIA_ROOT}/clickhouse/cmake/yandex/ya.make.versions.inc)
 
+CFLAGS(-g0)
+
 SRCS(
 <? find . -name '*.cpp' | grep -v -F tests | sed 's/^\.\//    /' | sort ?>
 )

--- a/src/Compression/ya.make
+++ b/src/Compression/ya.make
@@ -12,6 +12,8 @@ PEERDIR(
     contrib/libs/zstd
 )
 
+CFLAGS(-g0)
+
 SRCS(
     CachedCompressedReadBuffer.cpp
     CompressedReadBufferBase.cpp

--- a/src/Compression/ya.make.in
+++ b/src/Compression/ya.make.in
@@ -11,6 +11,8 @@ PEERDIR(
     contrib/libs/zstd
 )
 
+CFLAGS(-g0)
+
 SRCS(
 <? find . -name '*.cpp' | grep -v -F tests | sed 's/^\.\//    /' | sort ?>
 )

--- a/src/Core/ya.make
+++ b/src/Core/ya.make
@@ -7,6 +7,8 @@ PEERDIR(
     contrib/restricted/boost/libs
 )
 
+CFLAGS(-g0)
+
 SRCS(
     BackgroundSchedulePool.cpp
     BaseSettings.cpp

--- a/src/Core/ya.make.in
+++ b/src/Core/ya.make.in
@@ -6,6 +6,8 @@ PEERDIR(
     contrib/restricted/boost/libs
 )
 
+CFLAGS(-g0)
+
 SRCS(
 <? find . -name '*.cpp' | grep -v -F tests | sed 's/^\.\//    /' | sort ?>
 )

--- a/src/DataStreams/ya.make
+++ b/src/DataStreams/ya.make
@@ -8,6 +8,8 @@ PEERDIR(
 
 NO_COMPILER_WARNINGS()
 
+CFLAGS(-g0)
+
 SRCS(
     AddingDefaultBlockOutputStream.cpp
     AddingDefaultsBlockInputStream.cpp

--- a/src/DataStreams/ya.make.in
+++ b/src/DataStreams/ya.make.in
@@ -7,6 +7,8 @@ PEERDIR(
 
 NO_COMPILER_WARNINGS()
 
+CFLAGS(-g0)
+
 SRCS(
 <? find . -name '*.cpp' | grep -v -F tests | sed 's/^\.\//    /' | sort ?>
 )

--- a/src/DataTypes/ya.make
+++ b/src/DataTypes/ya.make
@@ -6,6 +6,8 @@ PEERDIR(
     clickhouse/src/Formats
 )
 
+CFLAGS(-g0)
+
 SRCS(
     convertMySQLDataType.cpp
     DataTypeAggregateFunction.cpp

--- a/src/DataTypes/ya.make.in
+++ b/src/DataTypes/ya.make.in
@@ -5,6 +5,8 @@ PEERDIR(
     clickhouse/src/Formats
 )
 
+CFLAGS(-g0)
+
 SRCS(
 <? find . -name '*.cpp' | grep -v -F tests | sed 's/^\.\//    /' | sort ?>
 )

--- a/src/Databases/ya.make
+++ b/src/Databases/ya.make
@@ -5,6 +5,8 @@ PEERDIR(
     clickhouse/src/Common
 )
 
+CFLAGS(-g0)
+
 SRCS(
     DatabaseAtomic.cpp
     DatabaseDictionary.cpp

--- a/src/Databases/ya.make.in
+++ b/src/Databases/ya.make.in
@@ -4,6 +4,8 @@ PEERDIR(
     clickhouse/src/Common
 )
 
+CFLAGS(-g0)
+
 SRCS(
 <? find . -name '*.cpp' | sed 's/^\.\//    /' | sort ?>
 )

--- a/src/Dictionaries/ya.make
+++ b/src/Dictionaries/ya.make
@@ -12,6 +12,8 @@ PEERDIR(
 
 NO_COMPILER_WARNINGS()
 
+CFLAGS(-g0)
+
 SRCS(
     CacheDictionary.cpp
     CacheDictionary_generate1.cpp

--- a/src/Dictionaries/ya.make.in
+++ b/src/Dictionaries/ya.make.in
@@ -11,6 +11,8 @@ PEERDIR(
 
 NO_COMPILER_WARNINGS()
 
+CFLAGS(-g0)
+
 SRCS(
 <? find . -name '*.cpp' | grep -v -F tests | grep -v -F Trie | sed 's/^\.\//    /' | sort ?>
 )

--- a/src/Disks/S3/ya.make
+++ b/src/Disks/S3/ya.make
@@ -4,6 +4,8 @@ PEERDIR(
     clickhouse/src/Common
 )
 
+CFLAGS(-g0)
+
 SRCS(
     DiskS3.cpp
     registerDiskS3.cpp

--- a/src/Disks/ya.make
+++ b/src/Disks/ya.make
@@ -5,6 +5,8 @@ PEERDIR(
     clickhouse/src/Common
 )
 
+CFLAGS(-g0)
+
 SRCS(
     createVolume.cpp
     DiskCacheWrapper.cpp

--- a/src/Disks/ya.make.in
+++ b/src/Disks/ya.make.in
@@ -4,6 +4,8 @@ PEERDIR(
     clickhouse/src/Common
 )
 
+CFLAGS(-g0)
+
 SRCS(
 <? find . -name '*.cpp' | grep -v -F tests | grep -v -F S3 | sed 's/^\.\//    /' | sort ?>
 )

--- a/src/Formats/ya.make
+++ b/src/Formats/ya.make
@@ -7,6 +7,8 @@ PEERDIR(
     contrib/libs/protoc
 )
 
+CFLAGS(-g0)
+
 SRCS(
     FormatFactory.cpp
     FormatSchemaInfo.cpp

--- a/src/Formats/ya.make.in
+++ b/src/Formats/ya.make.in
@@ -6,6 +6,8 @@ PEERDIR(
     contrib/libs/protoc
 )
 
+CFLAGS(-g0)
+
 SRCS(
 <? find . -name '*.cpp' | grep -v -F tests | sed 's/^\.\//    /' | sort ?>
 )

--- a/src/Functions/ya.make
+++ b/src/Functions/ya.make
@@ -33,6 +33,8 @@ PEERDIR(
 )
 
 # "Arcadia" build is slightly deficient. It lacks many libraries that we need.
+CFLAGS(-g0)
+
 SRCS(
     abs.cpp
     acos.cpp

--- a/src/Functions/ya.make.in
+++ b/src/Functions/ya.make.in
@@ -32,6 +32,8 @@ PEERDIR(
 )
 
 # "Arcadia" build is slightly deficient. It lacks many libraries that we need.
+CFLAGS(-g0)
+
 SRCS(
 <? find . -name '*.cpp' | grep -i -v -P 'tests|Bitmap|sumbur|abtesting' | sed 's/^\.\//    /' | sort ?>
 )

--- a/src/IO/ya.make
+++ b/src/IO/ya.make
@@ -8,6 +8,8 @@ PEERDIR(
     contrib/libs/poco/NetSSL_OpenSSL
 )
 
+CFLAGS(-g0)
+
 SRCS(
     AIOContextPool.cpp
     AIO.cpp

--- a/src/IO/ya.make.in
+++ b/src/IO/ya.make.in
@@ -7,6 +7,8 @@ PEERDIR(
     contrib/libs/poco/NetSSL_OpenSSL
 )
 
+CFLAGS(-g0)
+
 SRCS(
 <? find . -name '*.cpp' | grep -v -F tests | grep -v -P 'S3|HDFS' | sed 's/^\.\//    /' | sort ?>
 )

--- a/src/Interpreters/ya.make
+++ b/src/Interpreters/ya.make
@@ -14,6 +14,8 @@ PEERDIR(
 
 NO_COMPILER_WARNINGS()
 
+CFLAGS(-g0)
+
 SRCS(
     ActionLocksManager.cpp
     ActionsVisitor.cpp

--- a/src/Interpreters/ya.make.in
+++ b/src/Interpreters/ya.make.in
@@ -13,6 +13,8 @@ PEERDIR(
 
 NO_COMPILER_WARNINGS()
 
+CFLAGS(-g0)
+
 SRCS(
 <? find . -name '*.cpp' | grep -v -F tests | grep -v -F JIT | sed 's/^\.\//    /' | sort ?>
 )

--- a/src/Parsers/ya.make
+++ b/src/Parsers/ya.make
@@ -5,6 +5,8 @@ PEERDIR(
     clickhouse/src/Common
 )
 
+CFLAGS(-g0)
+
 SRCS(
     ASTAlterQuery.cpp
     ASTAsterisk.cpp

--- a/src/Parsers/ya.make.in
+++ b/src/Parsers/ya.make.in
@@ -4,6 +4,8 @@ PEERDIR(
     clickhouse/src/Common
 )
 
+CFLAGS(-g0)
+
 SRCS(
 <? find . -name '*.cpp' | grep -v -F tests | sed 's/^\.\//    /' | sort ?>
 )

--- a/src/Processors/ya.make
+++ b/src/Processors/ya.make
@@ -7,6 +7,8 @@ PEERDIR(
     contrib/libs/protobuf
 )
 
+CFLAGS(-g0)
+
 SRCS(
     Chunk.cpp
     ConcatProcessor.cpp

--- a/src/Processors/ya.make.in
+++ b/src/Processors/ya.make.in
@@ -6,6 +6,8 @@ PEERDIR(
     contrib/libs/protobuf
 )
 
+CFLAGS(-g0)
+
 SRCS(
 <? find . -name '*.cpp' | grep -v -F tests | grep -v -P 'Arrow|Avro|ORC|Parquet|CapnProto' | sed 's/^\.\//    /' | sort ?>
 )

--- a/src/Server/ya.make
+++ b/src/Server/ya.make
@@ -6,6 +6,8 @@ PEERDIR(
     contrib/libs/poco/Util
 )
 
+CFLAGS(-g0)
+
 SRCS(
     HTTPHandler.cpp
     HTTPHandlerFactory.cpp

--- a/src/Server/ya.make.in
+++ b/src/Server/ya.make.in
@@ -5,6 +5,8 @@ PEERDIR(
     contrib/libs/poco/Util
 )
 
+CFLAGS(-g0)
+
 SRCS(
 <? find . -name '*.cpp' | sed 's/^\.\//    /' | sort ?>
 )

--- a/src/Storages/ya.make
+++ b/src/Storages/ya.make
@@ -7,6 +7,8 @@ PEERDIR(
     contrib/libs/poco/MongoDB
 )
 
+CFLAGS(-g0)
+
 SRCS(
     AlterCommands.cpp
     ColumnDefault.cpp

--- a/src/Storages/ya.make.in
+++ b/src/Storages/ya.make.in
@@ -6,6 +6,8 @@ PEERDIR(
     contrib/libs/poco/MongoDB
 )
 
+CFLAGS(-g0)
+
 SRCS(
 <? find . -name '*.cpp' | grep -v -F tests | grep -v -P 'Kafka|RabbitMQ|S3|HDFS|Licenses|TimeZones' | sed 's/^\.\//    /' | sort ?>
 )

--- a/src/TableFunctions/ya.make
+++ b/src/TableFunctions/ya.make
@@ -5,6 +5,8 @@ PEERDIR(
     clickhouse/src/Common
 )
 
+CFLAGS(-g0)
+
 SRCS(
     ITableFunction.cpp
     ITableFunctionFileLike.cpp

--- a/src/TableFunctions/ya.make.in
+++ b/src/TableFunctions/ya.make.in
@@ -4,6 +4,8 @@ PEERDIR(
     clickhouse/src/Common
 )
 
+CFLAGS(-g0)
+
 SRCS(
 <? find . -name '*.cpp' | grep -v -P 'S3|HDFS' | sed 's/^\.\//    /' | sort ?>
 )

--- a/ya.make
+++ b/ya.make
@@ -5,8 +5,6 @@
 
 OWNER(g:clickhouse)
 
-CFLAGS(-g0)
-
 RECURSE(
     base
     programs

--- a/ya.make
+++ b/ya.make
@@ -5,6 +5,8 @@
 
 OWNER(g:clickhouse)
 
+CFLAGS(-g0)
+
 RECURSE(
     base
     programs


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

The notorious "Arcadia" build system still using lld-7 as linker and it does not support binary size over 4 GiB.
ClickHouse is less than 4 GiB but the issue appeared when full ClickHouse engine is statically linked into another very fat binary.
