### PR TITLE
Fix missing .cfi_endproc directive g++-9

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionQuantile.cpp
+++ b/src/AggregateFunctions/AggregateFunctionQuantile.cpp
@@ -168,3 +168,4 @@ void registerAggregateFunctionsQuantile(AggregateFunctionFactory & factory)
 }
 
 }
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix very rare error `{standard input}: Error: open CFI at the end of file; missing .cfi_endproc directive
g++-9: fatal error: Killed signal terminated program cc1plus
compilation terminated.`

