### PR TITLE
Fix segfault in combinator -Resample

### DIFF
--- a/tests/queries/0_stateless/01463_resample_overflow.sql
+++ b/tests/queries/0_stateless/01463_resample_overflow.sql
@@ -1,0 +1,1 @@
+select groupArrayResample(-9223372036854775808, 9223372036854775807, 9223372036854775807)(number, toInt64(number)) FROM numbers(7); -- { serverError 69 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix rare segfaults in functions with combinator -Resample, which could appear in result of overflow with very large parameters.

Fixes #14537.
