### PR TITLE
Add MySQL 5.6 support for MaterializeMySQL

### DIFF
--- a/docker/test/integration/runner/compose/docker_compose_mysql_5_6.yml
+++ b/docker/test/integration/runner/compose/docker_compose_mysql_5_6.yml
@@ -1,0 +1,10 @@
+version: '2.3'
+services:
+    mysql5_6:
+        image: mysql:5.6
+        restart: always
+        environment:
+            MYSQL_ROOT_PASSWORD: clickhouse
+        ports:
+          - 33306:3306
+        command: --server_id=100 --log-bin='mysql-bin-1.log' --default-time-zone='+3:00' --gtid-mode="ON" --enforce-gtid-consistency

--- a/src/Databases/MySQL/MaterializeMySQLSyncThread.cpp
+++ b/src/Databases/MySQL/MaterializeMySQLSyncThread.cpp
@@ -101,19 +101,17 @@ static String checkVariableAndGetVersion(const mysqlxx::Pool::Entry & connection
     const String & check_query = "SHOW VARIABLES WHERE "
          "(Variable_name = 'log_bin' AND upper(Value) = 'ON') "
          "OR (Variable_name = 'binlog_format' AND upper(Value) = 'ROW') "
-         "OR (Variable_name = 'binlog_row_image' AND upper(Value) = 'FULL') "
-         "OR (Variable_name = 'default_authentication_plugin' AND upper(Value) = 'MYSQL_NATIVE_PASSWORD');";
+         "OR (Variable_name = 'binlog_row_image' AND upper(Value) = 'FULL');";
 
     MySQLBlockInputStream variables_input(connection, check_query, variables_header, DEFAULT_BLOCK_SIZE);
 
     Block variables_block = variables_input.read();
-    if (!variables_block || variables_block.rows() != 4)
+    if (!variables_block || variables_block.rows() != 3)
     {
         std::unordered_map<String, String> variables_error_message{
             {"log_bin", "log_bin = 'ON'"},
             {"binlog_format", "binlog_format='ROW'"},
-            {"binlog_row_image", "binlog_row_image='FULL'"},
-            {"default_authentication_plugin", "default_authentication_plugin='mysql_native_password'"}
+            {"binlog_row_image", "binlog_row_image='FULL'"}
         };
         ColumnPtr variable_name_column = variables_block.getByName("Variable_name").column;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:
Support MySQL 5.6 for MaterializeMySQL
...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
