### PR TITLE
Fix cmake ccache search.

### DIFF
--- a/cmake/find/ccache.cmake
+++ b/cmake/find/ccache.cmake
@@ -6,6 +6,11 @@ endif()
 
 if ((ENABLE_CCACHE OR NOT DEFINED ENABLE_CCACHE) AND NOT COMPILER_MATCHES_CCACHE)
     find_program (CCACHE_FOUND ccache)
+    if (CCACHE_FOUND)
+        set(ENABLE_CCACHE_BY_DEFAULT 1)
+    else()
+        set(ENABLE_CCACHE_BY_DEFAULT 0)
+    endif()
 endif()
 
 if (NOT CCACHE_FOUND AND NOT DEFINED ENABLE_CCACHE AND NOT COMPILER_MATCHES_CCACHE)
@@ -13,7 +18,7 @@ if (NOT CCACHE_FOUND AND NOT DEFINED ENABLE_CCACHE AND NOT COMPILER_MATCHES_CCAC
             "Setting it up will significantly reduce compilation time for 2nd and consequent builds")
 endif()
 
-option(ENABLE_CCACHE "Speedup re-compilations using ccache" ${CCACHE_FOUND})
+option(ENABLE_CCACHE "Speedup re-compilations using ccache" ${ENABLE_CCACHE_BY_DEFAULT})
 
 if (NOT ENABLE_CCACHE)
     return()
@@ -24,7 +29,7 @@ if (CCACHE_FOUND AND NOT COMPILER_MATCHES_CCACHE)
    string(REGEX REPLACE "ccache version ([0-9\\.]+).*" "\\1" CCACHE_VERSION ${CCACHE_VERSION})
 
    if (CCACHE_VERSION VERSION_GREATER "3.2.0" OR NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-      #message(STATUS "Using ${CCACHE_FOUND} ${CCACHE_VERSION}")
+      message(STATUS "Using ${CCACHE_FOUND} ${CCACHE_VERSION}")
       set_property (GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_FOUND})
       set_property (GLOBAL PROPERTY RULE_LAUNCH_LINK ${CCACHE_FOUND})
    else ()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Enable ccache by default in cmake if it's found in OS.