### PR TITLE
Lower number of threads in binary build

### DIFF
--- a/docker/packager/binary/build.sh
+++ b/docker/packager/binary/build.sh
@@ -18,7 +18,7 @@ ccache --zero-stats ||:
 ln -s /usr/lib/x86_64-linux-gnu/libOpenCL.so.1.0.0 /usr/lib/libOpenCL.so ||:
 rm -f CMakeCache.txt
 cmake --debug-trycompile --verbose=1 -DCMAKE_VERBOSE_MAKEFILE=1 -LA -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DSANITIZE=$SANITIZER $CMAKE_FLAGS ..
-ninja $NINJA_FLAGS clickhouse-bundle
+ninja -j $(($(nproc) / 2)) $NINJA_FLAGS clickhouse-bundle
 mv ./programs/clickhouse* /output
 mv ./src/unit_tests_dbms /output
 find . -name '*.so' -print -exec mv '{}' /output \;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


