### PR TITLE
Fuzzer: reset default database before reconnect

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -866,6 +866,8 @@ private:
             // will exit. The ping() would be the best match here, but it's
             // private, probably for a good reason that the protocol doesn't allow
             // pings at any possible moment.
+            // Don't forget to reset the default database which might have changed.
+            connection->setDefaultDatabase("");
             connection->forceConnected(connection_parameters.timeouts);
 
             if (text.size() > 4 * 1024)
@@ -1103,7 +1105,9 @@ private:
                 {
                     last_exception_received_from_server = std::make_unique<Exception>(getCurrentExceptionMessage(true), getCurrentExceptionCode());
                     received_exception_from_server = true;
-                    std::cerr << "Error on processing query: " << ast_to_process->formatForErrorMessage() << std::endl << last_exception_received_from_server->message();
+                    fmt::print(stderr, "Error on processing query '{}': {}\n",
+                        ast_to_process->formatForErrorMessage(),
+                        last_exception_received_from_server->message());
                 }
 
                 if (!connection->isConnected())


### PR DESCRIPTION
During fuzzing it may be changed to a nonexistent db and we won't be able to reconnect.

https://clickhouse-test-reports.s3.yandex.net/14494/485b1048985e55fd6fb9e20d883056b98ad2a9d2/fuzzer/fuzzer.log

Changelog category (leave one):
- Not for changelog (changelog entry is not required)