### PR TITLE
Use global ICU ADDINCL for Arcadia build

### DIFF
--- a/src/Columns/ya.make
+++ b/src/Columns/ya.make
@@ -2,8 +2,6 @@
 LIBRARY()
 
 ADDINCL(
-    contrib/libs/icu/common
-    contrib/libs/icu/i18n
     contrib/libs/pdqsort
 )
 

--- a/src/Functions/ya.make
+++ b/src/Functions/ya.make
@@ -10,7 +10,6 @@ ADDINCL(
     contrib/libs/farmhash
     contrib/libs/h3/h3lib/include
     contrib/libs/hyperscan/src
-    contrib/libs/icu/common
     contrib/libs/libdivide
     contrib/libs/rapidjson/include
     contrib/libs/xxhash

--- a/src/Functions/ya.make.in
+++ b/src/Functions/ya.make.in
@@ -9,7 +9,6 @@ ADDINCL(
     contrib/libs/farmhash
     contrib/libs/h3/h3lib/include
     contrib/libs/hyperscan/src
-    contrib/libs/icu/common
     contrib/libs/libdivide
     contrib/libs/rapidjson/include
     contrib/libs/xxhash


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Detailed description / Documentation draft:
ICU in Arcadia now provide ADDINCL GLOBAL with necessary headers, so PEERDIR is enough
