### PR TITLE
Extracted the debug info generation for functions into a cmake option

### DIFF
--- a/src/Functions/CMakeLists.txt
+++ b/src/Functions/CMakeLists.txt
@@ -53,14 +53,21 @@ endif()
 
 target_include_directories(clickhouse_functions SYSTEM PRIVATE ${SPARSEHASH_INCLUDE_DIR})
 
+if (CMAKE_BUILD_TYPE_UC STREQUAL "RELEASE"
+    OR CMAKE_BUILD_TYPE_UC STREQUAL "RELWITHDEBINFO"
+    OR CMAKE_BUILD_TYPE_UC STREQUAL "MINSIZEREL")
+    set (STRIP_DSF_DEFAULT ON)
+else()
+    set (STRIP_DSF_DEFAULT OFF)
+endif()
+
+
 option(STRIP_DEBUG_SYMBOLS_FUNCTIONS
     "Do not generate debugger info for ClickHouse functions.
     Provides faster linking and lower binary size.
     Tradeoff is the inability to debug some source files with e.g. gdb
     (empty stack frames and no local variables)."
-    CMAKE_BUILD_TYPE_UC STREQUAL "RELEASE"
-    OR CMAKE_BUILD_TYPE_UC STREQUAL "RELWITHDEBINFO"
-    OR CMAKE_BUILD_TYPE_UC STREQUAL "MINSIZEREL")
+    STRIP_DSF_DEFAULT)
 
 if (STRIP_DEBUG_SYMBOLS_FUNCTIONS)
     message(WARNING "Not generating debugger info for ClickHouse functions")

--- a/src/Functions/CMakeLists.txt
+++ b/src/Functions/CMakeLists.txt
@@ -53,8 +53,18 @@ endif()
 
 target_include_directories(clickhouse_functions SYSTEM PRIVATE ${SPARSEHASH_INCLUDE_DIR})
 
-# Won't generate debug info for files with heavy template instantiation to achieve faster linking and lower size.
-target_compile_options(clickhouse_functions PRIVATE "-g0")
+option(STRIP_DEBUG_SYMBOLS_FUNCTIONS
+    "Do not generate debugger info for ClickHouse functions.
+    Provides faster linking and lower binary size.
+    Tradeoff is the inability to debug some source files with e.g. gdb
+    (empty stack frames and no local variables)." OFF)
+
+if (STRIP_DEBUG_SYMBOLS_FUNCTIONS)
+    message(WARNING "Not generating debugger info for ClickHouse functions")
+    target_compile_options(clickhouse_functions PRIVATE "-g0")
+else()
+    message(STATUS "Generating debugger info for ClickHouse functions")
+endif()
 
 if (USE_ICU)
     target_link_libraries (clickhouse_functions PRIVATE ${ICU_LIBRARIES})

--- a/src/Functions/CMakeLists.txt
+++ b/src/Functions/CMakeLists.txt
@@ -67,7 +67,7 @@ option(STRIP_DEBUG_SYMBOLS_FUNCTIONS
     Provides faster linking and lower binary size.
     Tradeoff is the inability to debug some source files with e.g. gdb
     (empty stack frames and no local variables)."
-    STRIP_DSF_DEFAULT)
+    ${STRIP_DSF_DEFAULT})
 
 if (STRIP_DEBUG_SYMBOLS_FUNCTIONS)
     message(WARNING "Not generating debugger info for ClickHouse functions")

--- a/src/Functions/CMakeLists.txt
+++ b/src/Functions/CMakeLists.txt
@@ -57,7 +57,10 @@ option(STRIP_DEBUG_SYMBOLS_FUNCTIONS
     "Do not generate debugger info for ClickHouse functions.
     Provides faster linking and lower binary size.
     Tradeoff is the inability to debug some source files with e.g. gdb
-    (empty stack frames and no local variables)." OFF)
+    (empty stack frames and no local variables)."
+    CMAKE_BUILD_TYPE_UC STREQUAL "RELEASE"
+    OR CMAKE_BUILD_TYPE_UC STREQUAL "RELWITHDEBINFO"
+    OR CMAKE_BUILD_TYPE_UC STREQUAL "MINSIZEREL")
 
 if (STRIP_DEBUG_SYMBOLS_FUNCTIONS)
     message(WARNING "Not generating debugger info for ClickHouse functions")

--- a/src/Functions/GatherUtils/CMakeLists.txt
+++ b/src/Functions/GatherUtils/CMakeLists.txt
@@ -3,5 +3,6 @@ add_headers_and_sources(clickhouse_functions_gatherutils .)
 add_library(clickhouse_functions_gatherutils ${clickhouse_functions_gatherutils_sources} ${clickhouse_functions_gatherutils_headers})
 target_link_libraries(clickhouse_functions_gatherutils PRIVATE dbms)
 
-# Won't generate debug info for files with heavy template instantiation to achieve faster linking and lower size.
-target_compile_options(clickhouse_functions_gatherutils PRIVATE "-g0")
+if (STRIP_DEBUG_SYMBOLS_FUNCTIONS)
+    target_compile_options(clickhouse_functions_gatherutils PRIVATE "-g0")
+endif()

--- a/src/Functions/URL/CMakeLists.txt
+++ b/src/Functions/URL/CMakeLists.txt
@@ -3,8 +3,9 @@ add_headers_and_sources(clickhouse_functions_url .)
 add_library(clickhouse_functions_url ${clickhouse_functions_url_sources} ${clickhouse_functions_url_headers})
 target_link_libraries(clickhouse_functions_url PRIVATE dbms)
 
-# Won't generate debug info for files with heavy template instantiation to achieve faster linking and lower size.
-target_compile_options(clickhouse_functions_url PRIVATE "-g0")
+if (STRIP_DEBUG_SYMBOLS_FUNCTIONS)
+    target_compile_options(clickhouse_functions_url PRIVATE "-g0")
+endif()
 
 # TODO: move Functions/Regexps.h to some lib and use here
 target_link_libraries(clickhouse_functions_url PRIVATE hyperscan)

--- a/src/Functions/array/CMakeLists.txt
+++ b/src/Functions/array/CMakeLists.txt
@@ -3,5 +3,6 @@ add_headers_and_sources(clickhouse_functions_array .)
 add_library(clickhouse_functions_array ${clickhouse_functions_array_sources} ${clickhouse_functions_array_headers})
 target_link_libraries(clickhouse_functions_array PRIVATE dbms clickhouse_functions_gatherutils)
 
-# Won't generate debug info for files with heavy template instantiation to achieve faster linking and lower size.
-target_compile_options(clickhouse_functions_array PRIVATE "-g0")
+if (STRIP_DEBUG_SYMBOLS_FUNCTIONS)
+    target_compile_options(clickhouse_functions_array PRIVATE "-g0")
+endif()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixed the backward-incompatible change by providing the options to build without debug info for functions.
