### PR TITLE
Fix missed database name when altering MaterializedView

### DIFF
--- a/src/Storages/SelectQueryDescription.cpp
+++ b/src/Storages/SelectQueryDescription.cpp
@@ -105,14 +105,14 @@ SelectQueryDescription SelectQueryDescription::getSelectQueryFromASTForMatView(c
     if (new_select.list_of_selects->children.size() != 1)
         throw Exception("UNION is not supported for MATERIALIZED VIEW", ErrorCodes::QUERY_IS_NOT_SUPPORTED_IN_MATERIALIZED_VIEW);
 
-    SelectQueryDescription result;
-
-    result.inner_query = new_select.list_of_selects->children.at(0)->clone();
-
-    auto & select_query = result.inner_query->as<ASTSelectQuery &>();
+    auto & new_inner_query = new_select.list_of_selects->children.at(0);
+    auto & select_query = new_inner_query->as<ASTSelectQuery &>();
     checkAllowedQueries(select_query);
+
+    SelectQueryDescription result;
     result.select_table_id = extractDependentTableFromSelectQuery(select_query, context);
-    result.select_query = select->clone();
+    result.select_query = new_select.clone();
+    result.inner_query = new_inner_query->clone();
 
     return result;
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed missed default database name in metadata of materialized view when executing `ALTER ... MODIFY QUERY`
