### PR TITLE
Add merge_algorithm to system.merges

### DIFF
--- a/docs/en/operations/system-tables/merges.md
+++ b/docs/en/operations/system-tables/merges.md
@@ -10,12 +10,16 @@ Columns:
 -   `progress` (Float64) — The percentage of completed work from 0 to 1.
 -   `num_parts` (UInt64) — The number of pieces to be merged.
 -   `result_part_name` (String) — The name of the part that will be formed as the result of merging.
--   `is_mutation` (UInt8) - 1 if this process is a part mutation.
+-   `is_mutation` (UInt8) — 1 if this process is a part mutation.
 -   `total_size_bytes_compressed` (UInt64) — The total size of the compressed data in the merged chunks.
 -   `total_size_marks` (UInt64) — The total number of marks in the merged parts.
 -   `bytes_read_uncompressed` (UInt64) — Number of bytes read, uncompressed.
 -   `rows_read` (UInt64) — Number of rows read.
 -   `bytes_written_uncompressed` (UInt64) — Number of bytes written, uncompressed.
 -   `rows_written` (UInt64) — Number of rows written.
+-   `memory_usage` (UInt64) — Memory consumption of the merge process.
+-   `thread_id` (UInt64) — Thread ID of the merge process.
+-   `merge_type` — The type of current merge. Empty if it's an mutation.
+-   `merge_algorithm` — The algorithm used in current merge. Empty if it's an mutation.
 
 [Original article](https://clickhouse.tech/docs/en/operations/system_tables/merges) <!--hide-->

--- a/src/Storages/MergeTree/MergeAlgorithm.cpp
+++ b/src/Storages/MergeTree/MergeAlgorithm.cpp
@@ -1,0 +1,26 @@
+#include <Storages/MergeTree/MergeAlgorithm.h>
+#include <Common/Exception.h>
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int NOT_IMPLEMENTED;
+}
+
+String toString(MergeAlgorithm merge_algorithm)
+{
+    switch (merge_algorithm)
+    {
+        case MergeAlgorithm::Undecided:
+            return "Undecided";
+        case MergeAlgorithm::Horizontal:
+            return "Horizontal";
+        case MergeAlgorithm::Vertical:
+            return "Vertical";
+    }
+
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Unknown MergeAlgorithm {}", static_cast<UInt64>(merge_algorithm));
+}
+
+}

--- a/src/Storages/MergeTree/MergeAlgorithm.h
+++ b/src/Storages/MergeTree/MergeAlgorithm.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <Core/Types.h>
+
+namespace DB
+{
+/// Algorithm of Merge.
+enum class MergeAlgorithm
+{
+    Undecided, /// Not running yet
+    Horizontal, /// per-row merge of all columns
+    Vertical /// per-row merge of PK and secondary indices columns, per-column gather for non-PK columns
+};
+
+String toString(MergeAlgorithm merge_algorithm);
+
+}

--- a/src/Storages/MergeTree/MergeList.cpp
+++ b/src/Storages/MergeTree/MergeList.cpp
@@ -24,6 +24,7 @@ MergeListElement::MergeListElement(const std::string & database_, const std::str
     , num_parts{future_part.parts.size()}
     , thread_id{getThreadId()}
     , merge_type{future_part.merge_type}
+    , merge_algorithm{MergeAlgorithm::Undecided}
 {
     for (const auto & source_part : future_part.parts)
     {
@@ -74,6 +75,7 @@ MergeInfo MergeListElement::getInfo() const
     res.memory_usage = memory_tracker.get();
     res.thread_id = thread_id;
     res.merge_type = toString(merge_type);
+    res.merge_algorithm = toString(merge_algorithm);
 
     for (const auto & source_part_name : source_part_names)
         res.source_part_names.emplace_back(source_part_name);

--- a/src/Storages/MergeTree/MergeList.h
+++ b/src/Storages/MergeTree/MergeList.h
@@ -3,6 +3,7 @@
 #include <Common/Stopwatch.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/MemoryTracker.h>
+#include <Storages/MergeTree/MergeAlgorithm.h>
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/MergeTree/MergeType.h>
 #include <memory>
@@ -47,6 +48,7 @@ struct MergeInfo
     UInt64 memory_usage;
     UInt64 thread_id;
     std::string merge_type;
+    std::string merge_algorithm;
 };
 
 struct FutureMergedMutatedPart;
@@ -90,6 +92,7 @@ struct MergeListElement : boost::noncopyable
 
     UInt64 thread_id;
     MergeType merge_type;
+    MergeAlgorithm merge_algorithm;
 
     MergeListElement(const std::string & database, const std::string & table, const FutureMergedMutatedPart & future_part);
 

--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
@@ -62,10 +62,6 @@ namespace ErrorCodes
     extern const int ABORTED;
 }
 
-
-using MergeAlgorithm = MergeTreeDataMergerMutator::MergeAlgorithm;
-
-
 /// Do not start to merge parts, if free space is less than sum size of parts times specified coefficient.
 /// This value is chosen to not allow big merges to eat all free space. Thus allowing small merges to proceed.
 static const double DISK_USAGE_COEFFICIENT_TO_SELECT = 2;
@@ -699,6 +695,7 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataMergerMutator::mergePartsToTempor
 
     size_t sum_input_rows_upper_bound = merge_entry->total_rows_count;
     MergeAlgorithm merge_alg = chooseMergeAlgorithm(parts, sum_input_rows_upper_bound, gathering_columns, deduplicate, need_remove_expired_values);
+    merge_entry->merge_algorithm = merge_alg;
 
     LOG_DEBUG(log, "Selected MergeAlgorithm: {}", ((merge_alg == MergeAlgorithm::Vertical) ? "Vertical" : "Horizontal"));
 
@@ -1238,7 +1235,7 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataMergerMutator::mutatePartToTempor
 }
 
 
-MergeTreeDataMergerMutator::MergeAlgorithm MergeTreeDataMergerMutator::chooseMergeAlgorithm(
+MergeAlgorithm MergeTreeDataMergerMutator::chooseMergeAlgorithm(
     const MergeTreeData::DataPartsVector & parts, size_t sum_rows_upper_bound,
     const NamesAndTypesList & gathering_columns, bool deduplicate, bool need_remove_expired_values) const
 {

--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
@@ -6,6 +6,7 @@
 #include <functional>
 #include <Common/ActionBlocker.h>
 #include <Storages/MergeTree/TTLMergeSelector.h>
+#include <Storages/MergeTree/MergeAlgorithm.h>
 #include <Storages/MergeTree/MergeType.h>
 
 
@@ -225,12 +226,6 @@ public :
       */
     ActionBlocker merges_blocker;
     ActionBlocker ttl_merges_blocker;
-
-    enum class MergeAlgorithm
-    {
-        Horizontal, /// per-row merge of all columns
-        Vertical    /// per-row merge of PK and secondary indices columns, per-column gather for non-PK columns
-    };
 
 private:
 

--- a/src/Storages/System/StorageSystemMerges.cpp
+++ b/src/Storages/System/StorageSystemMerges.cpp
@@ -31,6 +31,7 @@ NamesAndTypesList StorageSystemMerges::getNamesAndTypes()
         {"memory_usage", std::make_shared<DataTypeUInt64>()},
         {"thread_id", std::make_shared<DataTypeUInt64>()},
         {"merge_type", std::make_shared<DataTypeString>()},
+        {"merge_algorithm", std::make_shared<DataTypeString>()},
     };
 }
 
@@ -67,9 +68,15 @@ void StorageSystemMerges::fillData(MutableColumns & res_columns, const Context &
         res_columns[i++]->insert(merge.memory_usage);
         res_columns[i++]->insert(merge.thread_id);
         if (!merge.is_mutation)
+        {
             res_columns[i++]->insert(merge.merge_type);
+            res_columns[i++]->insert(merge.merge_algorithm);
+        }
         else
+        {
             res_columns[i++]->insertDefault();
+            res_columns[i++]->insertDefault();
+        }
     }
 }
 

--- a/src/Storages/ya.make
+++ b/src/Storages/ya.make
@@ -36,6 +36,7 @@ SRCS(
     MergeTree/KeyCondition.cpp
     MergeTree/LevelMergeSelector.cpp
     MergeTree/localBackup.cpp
+    MergeTree/MergeAlgorithm.cpp
     MergeTree/MergedBlockOutputStream.cpp
     MergeTree/MergedColumnOnlyOutputStream.cpp
     MergeTree/MergeList.cpp


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add `merge_algorithm` to system.merges table to improve merging inspections.

Detailed description / Documentation draft:

system.merges documentation is updated.

