### PR TITLE
formatReadableQuantity() function

### DIFF
--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -515,6 +515,29 @@ SELECT
 └────────────────┴────────────┘
 ```
 
+## formatReadableQuantity(x) {#formatreadablequantityx}
+
+Accepts the number. Returns a rounded number with a suffix (thousand, million, billion, etc.) as a string.
+
+It is useful for reading big numbers by human.
+
+Example:
+
+``` sql
+SELECT
+    arrayJoin([1024, 1234 * 1000, (4567 * 1000) * 1000, 98765432101234]) AS number,
+    formatReadableQuantity(number) AS number_for_humans
+```
+
+``` text
+┌─────────number─┬─number_for_humans─┐
+│           1024 │ 1.02 thousand     │
+│        1234000 │ 1.23 million      │
+│     4567000000 │ 4.57 billion      │
+│ 98765432101234 │ 98.77 trillion    │
+└────────────────┴───────────────────┘
+```
+
 ## least(a, b) {#leasta-b}
 
 Returns the smallest value from a and b.

--- a/docs/ru/sql-reference/functions/other-functions.md
+++ b/docs/ru/sql-reference/functions/other-functions.md
@@ -508,6 +508,29 @@ SELECT
 └────────────────┴────────────┘
 ```
 
+## formatReadableQuantity(x) {#formatreadablequantityx}
+
+Принимает число. Возвращает округленное число с суффиксом (thousand, million, billion и т.д.) в виде строки.
+
+Облегчает визуальное восприятие больших чисел живым человеком.
+
+Пример:
+
+``` sql
+SELECT
+    arrayJoin([1024, 1234 * 1000, (4567 * 1000) * 1000, 98765432101234]) AS number,
+    formatReadableQuantity(number) AS number_for_humans
+```
+
+``` text
+┌─────────number─┬─number_for_humans─┐
+│           1024 │ 1.02 thousand     │
+│        1234000 │ 1.23 million      │
+│     4567000000 │ 4.57 billion      │
+│ 98765432101234 │ 98.77 trillion    │
+└────────────────┴───────────────────┘
+```
+
 ## least(a, b) {#leasta-b}
 
 Возвращает наименьшее значение из a и b.

--- a/src/Functions/FunctionsFormatting.cpp
+++ b/src/Functions/FunctionsFormatting.cpp
@@ -9,6 +9,7 @@ void registerFunctionsFormatting(FunctionFactory & factory)
 {
     factory.registerFunction<FunctionBitmaskToList>();
     factory.registerFunction<FunctionFormatReadableSize>();
+    factory.registerFunction<FunctionFormatReadableQuantity>();
 }
 
 }

--- a/src/Functions/FunctionsFormatting.h
+++ b/src/Functions/FunctionsFormatting.h
@@ -202,4 +202,80 @@ private:
     }
 };
 
+
+class FunctionFormatReadableQuantity : public IFunction
+{
+public:
+    static constexpr auto name = "formatReadableQuantity";
+    static FunctionPtr create(const Context &) { return std::make_shared<FunctionFormatReadableQuantity>(); }
+
+    String getName() const override
+    {
+        return name;
+    }
+
+    size_t getNumberOfArguments() const override { return 1; }
+
+    DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
+    {
+        const IDataType & type = *arguments[0];
+
+        if (!isNativeNumber(type))
+            throw Exception("Cannot format " + type.getName() + " as quantity", ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+
+        return std::make_shared<DataTypeString>();
+    }
+
+    bool useDefaultImplementationForConstants() const override { return true; }
+
+    void executeImpl(Block & block, const ColumnNumbers & arguments, size_t result, size_t /*input_rows_count*/) const override
+    {
+        if (!(executeType<UInt8>(block, arguments, result)
+            || executeType<UInt16>(block, arguments, result)
+            || executeType<UInt32>(block, arguments, result)
+            || executeType<UInt64>(block, arguments, result)
+            || executeType<Int8>(block, arguments, result)
+            || executeType<Int16>(block, arguments, result)
+            || executeType<Int32>(block, arguments, result)
+            || executeType<Int64>(block, arguments, result)
+            || executeType<Float32>(block, arguments, result)
+            || executeType<Float64>(block, arguments, result)))
+            throw Exception("Illegal column " + block.getByPosition(arguments[0]).column->getName()
+                + " of argument of function " + getName(),
+                ErrorCodes::ILLEGAL_COLUMN);
+    }
+
+private:
+    template <typename T>
+    bool executeType(Block & block, const ColumnNumbers & arguments, size_t result) const
+    {
+        if (const ColumnVector<T> * col_from = checkAndGetColumn<ColumnVector<T>>(block.getByPosition(arguments[0]).column.get()))
+        {
+            auto col_to = ColumnString::create();
+
+            const typename ColumnVector<T>::Container & vec_from = col_from->getData();
+            ColumnString::Chars & data_to = col_to->getChars();
+            ColumnString::Offsets & offsets_to = col_to->getOffsets();
+            size_t size = vec_from.size();
+            data_to.resize(size * 2);
+            offsets_to.resize(size);
+
+            WriteBufferFromVector<ColumnString::Chars> buf_to(data_to);
+
+            for (size_t i = 0; i < size; ++i)
+            {
+                formatReadableQuantity(static_cast<double>(vec_from[i]), buf_to);
+                writeChar(0, buf_to);
+                offsets_to[i] = buf_to.count();
+            }
+
+            buf_to.finalize();
+            block.getByPosition(result).column = std::move(col_to);
+            return true;
+        }
+
+        return false;
+    }
+};
+
 }

--- a/tests/queries/0_stateless/00534_filimonov.data
+++ b/tests/queries/0_stateless/00534_filimonov.data
@@ -174,6 +174,7 @@ SELECT sipHash64(NULL);
 SELECT protocol(NULL);
 SELECT toInt16OrZero(NULL);
 SELECT formatReadableSize(NULL);
+SELECT formatReadableQuantity(NULL);
 SELECT concatAssumeInjective(NULL);
 SELECT toString(NULL);
 SELECT MACStringToNum(NULL);

--- a/tests/queries/0_stateless/01492_format_readable_quantity.reference
+++ b/tests/queries/0_stateless/01492_format_readable_quantity.reference
@@ -1,0 +1,50 @@
+1.00	1.00	1.00
+2.72	2.00	2.00
+7.39	7.00	7.00
+20.09	20.00	20.00
+54.60	54.00	54.00
+148.41	148.00	148.00
+403.43	403.00	403.00
+1.10 thousand	1.10 thousand	1.10 thousand
+2.98 thousand	2.98 thousand	2.98 thousand
+8.10 thousand	8.10 thousand	8.10 thousand
+22.03 thousand	22.03 thousand	22.03 thousand
+59.87 thousand	59.87 thousand	59.87 thousand
+162.75 thousand	162.75 thousand	162.75 thousand
+442.41 thousand	442.41 thousand	442.41 thousand
+1.20 million	1.20 million	1.20 million
+3.27 million	3.27 million	3.27 million
+8.89 million	8.89 million	8.89 million
+24.15 million	24.15 million	24.15 million
+65.66 million	65.66 million	65.66 million
+178.48 million	178.48 million	178.48 million
+485.17 million	485.17 million	485.17 million
+1.32 billion	1.32 billion	1.32 billion
+3.58 billion	3.58 billion	-2.15 billion
+9.74 billion	9.74 billion	-2.15 billion
+26.49 billion	26.49 billion	-2.15 billion
+72.00 billion	72.00 billion	-2.15 billion
+195.73 billion	195.73 billion	-2.15 billion
+532.05 billion	532.05 billion	-2.15 billion
+1.45 trillion	1.45 trillion	-2.15 billion
+3.93 trillion	3.93 trillion	-2.15 billion
+10.69 trillion	10.69 trillion	-2.15 billion
+29.05 trillion	29.05 trillion	-2.15 billion
+78.96 trillion	78.96 trillion	-2.15 billion
+214.64 trillion	214.64 trillion	-2.15 billion
+583.46 trillion	583.46 trillion	-2.15 billion
+1.59 quadrillion	1.59 quadrillion	-2.15 billion
+4.31 quadrillion	4.31 quadrillion	-2.15 billion
+11.72 quadrillion	11.72 quadrillion	-2.15 billion
+31.86 quadrillion	31.86 quadrillion	-2.15 billion
+86.59 quadrillion	86.59 quadrillion	-2.15 billion
+235.39 quadrillion	235.39 quadrillion	-2.15 billion
+639.84 quadrillion	639.84 quadrillion	-2.15 billion
+1739.27 quadrillion	1739.27 quadrillion	-2.15 billion
+4727.84 quadrillion	4727.84 quadrillion	-2.15 billion
+12851.60 quadrillion	12851.60 quadrillion	-2.15 billion
+34934.27 quadrillion	0.00	-2.15 billion
+94961.19 quadrillion	0.00	-2.15 billion
+258131.29 quadrillion	0.00	-2.15 billion
+701673.59 quadrillion	0.00	-2.15 billion
+1907346.57 quadrillion	0.00	-2.15 billion

--- a/tests/queries/0_stateless/01492_format_readable_quantity.sql
+++ b/tests/queries/0_stateless/01492_format_readable_quantity.sql
@@ -1,0 +1,4 @@
+WITH round(exp(number), 6) AS x, toUInt64(x) AS y, toInt32(x) AS z
+SELECT formatReadableQuantity(x), formatReadableQuantity(y), formatReadableQuantity(z)
+FROM system.numbers
+LIMIT 50;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Added `formatReadableQuantity` function. It is useful for reading big numbers by human.


Detailed description / Documentation draft:

## formatReadableQuantity(x) {#formatreadablequantityx}

Accepts the number. Returns a rounded number with a suffix (thousand, million, billion, etc.) as a string.

It is useful for reading big numbers by human.

Example:

``` sql
SELECT
    arrayJoin([1024, 1234 * 1000, (4567 * 1000) * 1000, 98765432101234]) AS number,
    formatReadableQuantity(number) AS number_for_humans
```

``` text
┌─────────number─┬─number_for_humans─┐
│           1024 │ 1.02 thousand     │
│        1234000 │ 1.23 million      │
│     4567000000 │ 4.57 billion      │
│ 98765432101234 │ 98.77 trillion    │
└────────────────┴───────────────────┘
```
