### PR TITLE
Fix access denied on opening file /var/lib/clickhouse/status in integration tests.

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -1165,11 +1165,12 @@ class ClickHouseInstance:
 
         db_dir = p.abspath(p.join(self.path, 'database'))
         print "Setup database dir {}".format(db_dir)
-        os.mkdir(db_dir)
         if self.clickhouse_path_dir is not None:
             print "Database files taken from {}".format(self.clickhouse_path_dir)
             shutil.copytree(self.clickhouse_path_dir, db_dir)
             print "Database copied from {} to {}".format(self.clickhouse_path_dir, db_dir)
+        else:
+            os.mkdir(db_dir)
 
         logs_dir = p.abspath(p.join(self.path, 'logs'))
         print "Setup logs dir {}".format(logs_dir)

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -1165,6 +1165,7 @@ class ClickHouseInstance:
 
         db_dir = p.abspath(p.join(self.path, 'database'))
         print "Setup database dir {}".format(db_dir)
+        os.mkdir(db_dir)
         if self.clickhouse_path_dir is not None:
             print "Database files taken from {}".format(self.clickhouse_path_dir)
             shutil.copytree(self.clickhouse_path_dir, db_dir)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Not for changelog

I was unable to run the integration tests using pytest without this change because the database directory for running a test (e.g. `/home/vitbar/work/ClickHouse/tests/integration/test_user_directories/_instances/node/database`) was created with wrong permissions. It was broken in https://github.com/ClickHouse/ClickHouse/pull/14619