### PR TITLE
explict column list in columns matcher

### DIFF
--- a/src/Interpreters/TranslateQualifiedNamesVisitor.cpp
+++ b/src/Interpreters/TranslateQualifiedNamesVisitor.cpp
@@ -250,18 +250,26 @@ void TranslateQualifiedNamesMatcher::visit(ASTExpressionList & node, const ASTPt
         }
         else if (const auto * asterisk_pattern = child->as<ASTColumnsMatcher>())
         {
-            bool first_table = true;
-            for (const auto & table : tables_with_columns)
+            if (asterisk_pattern->column_list)
             {
-                for (const auto & column : table.columns)
+                for (const auto & ident : asterisk_pattern->column_list->children)
+                    node.children.emplace_back(ident->clone());
+            }
+            else
+            {
+                bool first_table = true;
+                for (const auto & table : tables_with_columns)
                 {
-                    if (asterisk_pattern->isColumnMatching(column.name) && (first_table || !data.join_using_columns.count(column.name)))
+                    for (const auto & column : table.columns)
                     {
-                        addIdentifier(node.children, table.table, column.name, AsteriskSemantic::getAliases(*asterisk_pattern));
+                        if (asterisk_pattern->isColumnMatching(column.name) && (first_table || !data.join_using_columns.count(column.name)))
+                        {
+                            addIdentifier(node.children, table.table, column.name, AsteriskSemantic::getAliases(*asterisk_pattern));
+                        }
                     }
-                }
 
-                first_table = false;
+                    first_table = false;
+                }
             }
             // ColumnsMatcher's transformers start to appear at child 1
             for (auto it = asterisk_pattern->children.begin() + 1; it != asterisk_pattern->children.end(); ++it)

--- a/src/Parsers/ASTColumnsMatcher.cpp
+++ b/src/Parsers/ASTColumnsMatcher.cpp
@@ -30,8 +30,12 @@ void ASTColumnsMatcher::updateTreeHashImpl(SipHash & hash_state) const
 
 void ASTColumnsMatcher::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << "COLUMNS" << (settings.hilite ? hilite_none : "") << "("
-                  << quoteString(original_pattern) << ")";
+    settings.ostr << (settings.hilite ? hilite_keyword : "") << "COLUMNS" << (settings.hilite ? hilite_none : "") << "(";
+    if (column_list)
+        column_list->formatImpl(settings, state, frame);
+    else
+        settings.ostr << quoteString(original_pattern);
+    settings.ostr << ")";
     for (ASTs::const_iterator it = children.begin() + 1; it != children.end(); ++it)
     {
         settings.ostr << ' ';

--- a/src/Parsers/ASTColumnsMatcher.h
+++ b/src/Parsers/ASTColumnsMatcher.h
@@ -36,6 +36,8 @@ public:
     bool isColumnMatching(const String & column_name) const;
     void updateTreeHashImpl(SipHash & hash_state) const override;
 
+    ASTPtr column_list;
+
 protected:
     void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 

--- a/tests/queries/0_stateless/01470_columns_transformers.reference
+++ b/tests/queries/0_stateless/01470_columns_transformers.reference
@@ -61,3 +61,9 @@ SELECT
     j,
     k
 FROM columns_transformers
+220	18	347
+SELECT
+    sum(i),
+    sum(j),
+    sum(k)
+FROM columns_transformers

--- a/tests/queries/0_stateless/01470_columns_transformers.sql
+++ b/tests/queries/0_stateless/01470_columns_transformers.sql
@@ -33,4 +33,8 @@ EXPLAIN SYNTAX SELECT a.* APPLY(toDate) REPLACE(i + 1 AS i) APPLY(any) from colu
 -- Multiple REPLACE in a row
 EXPLAIN SYNTAX SELECT * REPLACE(i + 1 AS i) REPLACE(i + 1 AS i) from columns_transformers;
 
+-- Explicit column list
+SELECT COLUMNS(i, j, k) APPLY(sum) from columns_transformers;
+EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) APPLY(sum) from columns_transformers;
+
 DROP TABLE columns_transformers;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Now columns can be used to wrap over a list of columns and apply column transformers afterwards.

Detailed description / Documentation draft:

Null.