### PR TITLE
Support default arguments for Replicated engine

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -156,6 +156,8 @@ class IColumn;
     M(UInt64, max_concurrent_queries_for_user, 0, "The maximum number of concurrent requests per user.", 0) \
     \
     M(Bool, insert_deduplicate, true, "For INSERT queries in the replicated table, specifies that deduplication of insertings blocks should be performed", 0) \
+    M(String, default_replica_path, "", "Default replica path for ReplicatedMergeTree. Allow to omit arguments for Replicated table engine if default_replica_path and default_replica_name are specified.", 0) \
+    M(String, default_replica_name, "", "Default replica name for ReplicatedMergeTree. Allow to omit arguments for Replicated table engine if default_replica_path and default_replica_name are specified.", 0) \
     \
     M(UInt64, insert_quorum, 0, "For INSERT queries in the replicated table, wait writing for the specified number of replicas and linearize the addition of the data. 0 - disabled.", 0) \
     M(Milliseconds, insert_quorum_timeout, 600000, "", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -156,8 +156,6 @@ class IColumn;
     M(UInt64, max_concurrent_queries_for_user, 0, "The maximum number of concurrent requests per user.", 0) \
     \
     M(Bool, insert_deduplicate, true, "For INSERT queries in the replicated table, specifies that deduplication of insertings blocks should be performed", 0) \
-    M(String, default_replica_path, "", "Default replica path for ReplicatedMergeTree. Allow to omit arguments for Replicated table engine if default_replica_path and default_replica_name are specified.", 0) \
-    M(String, default_replica_name, "", "Default replica name for ReplicatedMergeTree. Allow to omit arguments for Replicated table engine if default_replica_path and default_replica_name are specified.", 0) \
     \
     M(UInt64, insert_quorum, 0, "For INSERT queries in the replicated table, wait writing for the specified number of replicas and linearize the addition of the data. 0 - disabled.", 0) \
     M(Milliseconds, insert_quorum_timeout, 600000, "", 0) \

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -273,8 +273,13 @@ static StoragePtr create(const StorageFactory::Arguments & args)
     String name_part = args.engine_name.substr(0, args.engine_name.size() - strlen("MergeTree"));
 
     bool replicated = startsWith(name_part, "Replicated");
+    bool has_replicated_default_args = false;
     if (replicated)
+    {
         name_part = name_part.substr(strlen("Replicated"));
+        has_replicated_default_args = args.context.getSettingsRef().default_replica_path.value != ""
+            && args.context.getSettingsRef().default_replica_name.value != "";
+    }
 
     MergeTreeData::MergingParams merging_params;
     merging_params.mode = MergeTreeData::MergingParams::Ordinary;
@@ -318,7 +323,7 @@ static StoragePtr create(const StorageFactory::Arguments & args)
 
     if (replicated)
     {
-        if (is_extended_storage_def)
+        if (is_extended_storage_def || has_replicated_default_args)
         {
             add_optional_param("path in ZooKeeper");
             add_optional_param("replica name");
@@ -420,6 +425,12 @@ static StoragePtr create(const StorageFactory::Arguments & args)
                 throw Exception(
                     "No replica name in config" + getMergeTreeVerboseHelp(is_extended_storage_def), ErrorCodes::NO_REPLICA_NAME_GIVEN);
             ++arg_num;
+        }
+        else if (has_replicated_default_args && !has_arguments)
+        {
+            zookeeper_path
+                = args.context.getSettingsRef().default_replica_path.value + "/" + args.table_id.database_name + "." + args.table_id.table_name;
+            replica_name = args.context.getSettingsRef().default_replica_name;
         }
         else if (is_extended_storage_def && !has_arguments)
         {

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -273,13 +273,8 @@ static StoragePtr create(const StorageFactory::Arguments & args)
     String name_part = args.engine_name.substr(0, args.engine_name.size() - strlen("MergeTree"));
 
     bool replicated = startsWith(name_part, "Replicated");
-    bool has_replicated_default_args = false;
     if (replicated)
-    {
         name_part = name_part.substr(strlen("Replicated"));
-        has_replicated_default_args = args.context.getSettingsRef().default_replica_path.value != ""
-            && args.context.getSettingsRef().default_replica_name.value != "";
-    }
 
     MergeTreeData::MergingParams merging_params;
     merging_params.mode = MergeTreeData::MergingParams::Ordinary;
@@ -323,7 +318,7 @@ static StoragePtr create(const StorageFactory::Arguments & args)
 
     if (replicated)
     {
-        if (is_extended_storage_def || has_replicated_default_args)
+        if (is_extended_storage_def)
         {
             add_optional_param("path in ZooKeeper");
             add_optional_param("replica name");
@@ -426,18 +421,13 @@ static StoragePtr create(const StorageFactory::Arguments & args)
                     "No replica name in config" + getMergeTreeVerboseHelp(is_extended_storage_def), ErrorCodes::NO_REPLICA_NAME_GIVEN);
             ++arg_num;
         }
-        else if (has_replicated_default_args && !has_arguments)
-        {
-            zookeeper_path
-                = args.context.getSettingsRef().default_replica_path.value + "/" + args.table_id.database_name + "." + args.table_id.table_name;
-            replica_name = args.context.getSettingsRef().default_replica_name;
-        }
         else if (is_extended_storage_def && !has_arguments)
         {
             /// Try use default values if arguments are not specified.
-            /// It works for ON CLUSTER queries when database engine is Atomic and there are {shard} and {replica} in config.
-            zookeeper_path = "/clickhouse/tables/{uuid}/{shard}";
-            replica_name = "{replica}"; /// TODO maybe use hostname if {replica} is not defined?
+            /// Note: {uuid} macro works for ON CLUSTER queries when database engine is Atomic.
+            zookeeper_path = args.context.getConfigRef().getString("default_replica_path", "/clickhouse/tables/{uuid}/{shard}");
+            /// TODO maybe use hostname if {replica} is not defined?
+            replica_name = args.context.getConfigRef().getString("default_replica_name", "{replica}");
         }
         else
             throw Exception("Expected two string literal arguments: zookeper_path and replica_name", ErrorCodes::BAD_ARGUMENTS);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Allow to omit arguments for Replicated table engine if defaults are specified in config.

Detailed description / Documentation draft:

This PR solved issue #8675.

For example, if in config.xml we have

```
<default_replica_path>/clickhouse/tables/{shard}</default_replica_path>
<default_replica_name>{replica}</default_replica_path>
```

then query

```SQL
CREATE TABLE db.table_name (x UInt32) engine = ReplicatedMergeTree ORDER BY x
```

will be equivalent to query

```SQL
CREATE TABLE db.table_name (x UInt32) engine = ReplicatedMergeTree('/clickhouse/tables/{shard}/db.table_name',
```