### PR TITLE
Return query plan from storage.

### DIFF
--- a/src/DataStreams/IBlockInputStream.h
+++ b/src/DataStreams/IBlockInputStream.h
@@ -5,6 +5,7 @@
 #include <DataStreams/IBlockStream_fwd.h>
 #include <DataStreams/SizeLimits.h>
 #include <DataStreams/ExecutionSpeedLimits.h>
+#include <DataStreams/LocalLimits.h>
 #include <IO/Progress.h>
 #include <Storages/TableLockHolder.h>
 #include <Common/TypePromotion.h>
@@ -172,31 +173,6 @@ public:
 
     bool isCancelled() const;
     bool isCancelledOrThrowIfKilled() const;
-
-    /** What limitations and quotas should be checked.
-      * LIMITS_CURRENT - checks amount of data returned by current stream only (BlockStreamProfileInfo is used for check).
-      *  Currently it is used in root streams to check max_result_{rows,bytes} limits.
-      * LIMITS_TOTAL - checks total amount of read data from leaf streams (i.e. data read from disk and remote servers).
-      *  It is checks max_{rows,bytes}_to_read in progress handler and use info from ProcessListElement::progress_in for this.
-      *  Currently this check is performed only in leaf streams.
-      */
-    enum LimitsMode
-    {
-        LIMITS_CURRENT,
-        LIMITS_TOTAL,
-    };
-
-    /// It is a subset of limitations from Limits.
-    struct LocalLimits
-    {
-        LimitsMode mode = LIMITS_CURRENT;
-
-        SizeLimits size_limits;
-
-        ExecutionSpeedLimits speed_limits;
-
-        OverflowMode timeout_overflow_mode = OverflowMode::THROW;
-    };
 
     /** Set limitations that checked on each block. */
     virtual void setLimits(const LocalLimits & limits_)

--- a/src/DataStreams/IBlockInputStream.h
+++ b/src/DataStreams/IBlockInputStream.h
@@ -5,7 +5,7 @@
 #include <DataStreams/IBlockStream_fwd.h>
 #include <DataStreams/SizeLimits.h>
 #include <DataStreams/ExecutionSpeedLimits.h>
-#include <DataStreams/LocalLimits.h>
+#include <DataStreams/StreamLocalLimits.h>
 #include <IO/Progress.h>
 #include <Storages/TableLockHolder.h>
 #include <Common/TypePromotion.h>
@@ -175,12 +175,12 @@ public:
     bool isCancelledOrThrowIfKilled() const;
 
     /** Set limitations that checked on each block. */
-    virtual void setLimits(const LocalLimits & limits_)
+    virtual void setLimits(const StreamLocalLimits & limits_)
     {
         limits = limits_;
     }
 
-    const LocalLimits & getLimits() const
+    const StreamLocalLimits & getLimits() const
     {
         return limits;
     }
@@ -244,7 +244,7 @@ private:
 
     /// Limitations and quotas.
 
-    LocalLimits limits;
+    StreamLocalLimits limits;
 
     std::shared_ptr<const EnabledQuota> quota;    /// If nullptr - the quota is not used.
     UInt64 prev_elapsed = 0;

--- a/src/DataStreams/LocalLimits.h
+++ b/src/DataStreams/LocalLimits.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <DataStreams/SizeLimits.h>
 #include <DataStreams/ExecutionSpeedLimits.h>
 

--- a/src/DataStreams/LocalLimits.h
+++ b/src/DataStreams/LocalLimits.h
@@ -1,0 +1,32 @@
+#include <DataStreams/SizeLimits.h>
+#include <DataStreams/ExecutionSpeedLimits.h>
+
+namespace DB
+{
+
+/** What limitations and quotas should be checked.
+  * LIMITS_CURRENT - checks amount of data returned by current stream only (BlockStreamProfileInfo is used for check).
+  *  Currently it is used in root streams to check max_result_{rows,bytes} limits.
+  * LIMITS_TOTAL - checks total amount of read data from leaf streams (i.e. data read from disk and remote servers).
+  *  It is checks max_{rows,bytes}_to_read in progress handler and use info from ProcessListElement::progress_in for this.
+  *  Currently this check is performed only in leaf streams.
+  */
+enum class LimitsMode
+{
+    LIMITS_CURRENT,
+    LIMITS_TOTAL,
+};
+
+/// It is a subset of limitations from Limits.
+struct LocalLimits
+{
+    LimitsMode mode = LimitsMode::LIMITS_CURRENT;
+
+    SizeLimits size_limits;
+
+    ExecutionSpeedLimits speed_limits;
+
+    OverflowMode timeout_overflow_mode = OverflowMode::THROW;
+};
+
+}

--- a/src/DataStreams/StreamLocalLimits.h
+++ b/src/DataStreams/StreamLocalLimits.h
@@ -19,7 +19,7 @@ enum class LimitsMode
 };
 
 /// It is a subset of limitations from Limits.
-struct LocalLimits
+struct StreamLocalLimits
 {
     LimitsMode mode = LimitsMode::LIMITS_CURRENT;
 

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1409,12 +1409,43 @@ void InterpreterSelectQuery::executeFetchColumns(
             query_info.input_order_info = query_info.order_optimizer->getInputOrder(storage, metadata_snapshot);
         }
 
-        auto read_step = std::make_unique<ReadFromStorageStep>(
-            table_lock, metadata_snapshot, options, storage,
-                required_columns, query_info, context, processing_stage, max_block_size, max_streams);
+        LocalLimits limits;
+        std::shared_ptr<const EnabledQuota> quota;
 
-        read_step->setStepDescription("Read from " + storage->getName());
-        query_plan.addStep(std::move(read_step));
+        /// Set the limits and quota for reading data, the speed and time of the query.
+        if (!options.ignore_limits)
+        {
+            limits.mode = LimitsMode::LIMITS_TOTAL;
+            limits.size_limits = SizeLimits(settings.max_rows_to_read, settings.max_bytes_to_read,
+                                            settings.read_overflow_mode);
+            limits.speed_limits.max_execution_time = settings.max_execution_time;
+            limits.timeout_overflow_mode = settings.timeout_overflow_mode;
+
+            /** Quota and minimal speed restrictions are checked on the initiating server of the request, and not on remote servers,
+              *  because the initiating server has a summary of the execution of the request on all servers.
+              *
+              * But limits on data size to read and maximum execution time are reasonable to check both on initiator and
+              *  additionally on each remote server, because these limits are checked per block of data processed,
+              *  and remote servers may process way more blocks of data than are received by initiator.
+              *
+              * The limits to throttle maximum execution speed is also checked on all servers.
+              */
+            if (options.to_stage == QueryProcessingStage::Complete)
+            {
+                limits.speed_limits.min_execution_rps = settings.min_execution_speed;
+                limits.speed_limits.min_execution_bps = settings.min_execution_speed_bytes;
+            }
+
+            limits.speed_limits.max_execution_rps = settings.max_execution_speed;
+            limits.speed_limits.max_execution_bps = settings.max_execution_speed_bytes;
+            limits.speed_limits.timeout_before_checking_execution_speed = settings.timeout_before_checking_execution_speed;
+        }
+
+        if (!options.ignore_quota && (options.to_stage == QueryProcessingStage::Complete))
+            quota = context->getQuota();
+
+        storage->read(query_plan, table_lock, metadata_snapshot, limits, std::move(quota),
+                      required_columns, query_info, context, processing_stage, max_block_size, max_streams);
     }
     else
         throw Exception("Logical error in InterpreterSelectQuery: nowhere to read", ErrorCodes::LOGICAL_ERROR);

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1071,6 +1071,37 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, const BlockInpu
         executeSubqueriesInSetsAndJoins(query_plan, subqueries_for_sets);
 }
 
+static StreamLocalLimits getLimitsForStorage(const Settings & settings, const SelectQueryOptions & options)
+{
+    StreamLocalLimits limits;
+    limits.mode = LimitsMode::LIMITS_TOTAL;
+    limits.size_limits = SizeLimits(settings.max_rows_to_read, settings.max_bytes_to_read,
+                                    settings.read_overflow_mode);
+    limits.speed_limits.max_execution_time = settings.max_execution_time;
+    limits.timeout_overflow_mode = settings.timeout_overflow_mode;
+
+    /** Quota and minimal speed restrictions are checked on the initiating server of the request, and not on remote servers,
+      *  because the initiating server has a summary of the execution of the request on all servers.
+      *
+      * But limits on data size to read and maximum execution time are reasonable to check both on initiator and
+      *  additionally on each remote server, because these limits are checked per block of data processed,
+      *  and remote servers may process way more blocks of data than are received by initiator.
+      *
+      * The limits to throttle maximum execution speed is also checked on all servers.
+      */
+    if (options.to_stage == QueryProcessingStage::Complete)
+    {
+        limits.speed_limits.min_execution_rps = settings.min_execution_speed;
+        limits.speed_limits.min_execution_bps = settings.min_execution_speed_bytes;
+    }
+
+    limits.speed_limits.max_execution_rps = settings.max_execution_speed;
+    limits.speed_limits.max_execution_bps = settings.max_execution_speed_bytes;
+    limits.speed_limits.timeout_before_checking_execution_speed = settings.timeout_before_checking_execution_speed;
+
+    return limits;
+}
+
 void InterpreterSelectQuery::executeFetchColumns(
     QueryProcessingStage::Enum processing_stage, QueryPlan & query_plan,
     const PrewhereInfoPtr & prewhere_info, const Names & columns_to_remove_after_prewhere)
@@ -1409,37 +1440,12 @@ void InterpreterSelectQuery::executeFetchColumns(
             query_info.input_order_info = query_info.order_optimizer->getInputOrder(storage, metadata_snapshot);
         }
 
-        LocalLimits limits;
+        StreamLocalLimits limits;
         std::shared_ptr<const EnabledQuota> quota;
 
         /// Set the limits and quota for reading data, the speed and time of the query.
         if (!options.ignore_limits)
-        {
-            limits.mode = LimitsMode::LIMITS_TOTAL;
-            limits.size_limits = SizeLimits(settings.max_rows_to_read, settings.max_bytes_to_read,
-                                            settings.read_overflow_mode);
-            limits.speed_limits.max_execution_time = settings.max_execution_time;
-            limits.timeout_overflow_mode = settings.timeout_overflow_mode;
-
-            /** Quota and minimal speed restrictions are checked on the initiating server of the request, and not on remote servers,
-              *  because the initiating server has a summary of the execution of the request on all servers.
-              *
-              * But limits on data size to read and maximum execution time are reasonable to check both on initiator and
-              *  additionally on each remote server, because these limits are checked per block of data processed,
-              *  and remote servers may process way more blocks of data than are received by initiator.
-              *
-              * The limits to throttle maximum execution speed is also checked on all servers.
-              */
-            if (options.to_stage == QueryProcessingStage::Complete)
-            {
-                limits.speed_limits.min_execution_rps = settings.min_execution_speed;
-                limits.speed_limits.min_execution_bps = settings.min_execution_speed_bytes;
-            }
-
-            limits.speed_limits.max_execution_rps = settings.max_execution_speed;
-            limits.speed_limits.max_execution_bps = settings.max_execution_speed_bytes;
-            limits.speed_limits.timeout_before_checking_execution_speed = settings.timeout_before_checking_execution_speed;
-        }
+            limits = getLimitsForStorage(settings, options);
 
         if (!options.ignore_quota && (options.to_stage == QueryProcessingStage::Complete))
             quota = context->getQuota();

--- a/src/Interpreters/InterpreterWatchQuery.cpp
+++ b/src/Interpreters/InterpreterWatchQuery.cpp
@@ -17,7 +17,7 @@ limitations under the License. */
 #include <Access/AccessFlags.h>
 #include <DataStreams/IBlockInputStream.h>
 #include <DataStreams/OneBlockInputStream.h>
-#include <DataStreams/LocalLimits.h>
+#include <DataStreams/StreamLocalLimits.h>
 
 
 namespace DB
@@ -77,7 +77,7 @@ BlockIO InterpreterWatchQuery::execute()
     /// Constraints on the result, the quota on the result, and also callback for progress.
     if (IBlockInputStream * stream = dynamic_cast<IBlockInputStream *>(streams[0].get()))
     {
-        LocalLimits limits;
+        StreamLocalLimits limits;
         limits.mode = LimitsMode::LIMITS_CURRENT;
         limits.size_limits.max_rows = settings.max_result_rows;
         limits.size_limits.max_bytes = settings.max_result_bytes;

--- a/src/Interpreters/InterpreterWatchQuery.cpp
+++ b/src/Interpreters/InterpreterWatchQuery.cpp
@@ -17,6 +17,7 @@ limitations under the License. */
 #include <Access/AccessFlags.h>
 #include <DataStreams/IBlockInputStream.h>
 #include <DataStreams/OneBlockInputStream.h>
+#include <DataStreams/LocalLimits.h>
 
 
 namespace DB
@@ -76,8 +77,8 @@ BlockIO InterpreterWatchQuery::execute()
     /// Constraints on the result, the quota on the result, and also callback for progress.
     if (IBlockInputStream * stream = dynamic_cast<IBlockInputStream *>(streams[0].get()))
     {
-        IBlockInputStream::LocalLimits limits;
-        limits.mode = IBlockInputStream::LIMITS_CURRENT;
+        LocalLimits limits;
+        limits.mode = LimitsMode::LIMITS_CURRENT;
         limits.size_limits.max_rows = settings.max_result_rows;
         limits.size_limits.max_bytes = settings.max_result_bytes;
         limits.size_limits.overflow_mode = settings.result_overflow_mode;

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -382,10 +382,10 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
             }
         }
 
-        IBlockInputStream::LocalLimits limits;
+        LocalLimits limits;
         if (!interpreter->ignoreLimits())
         {
-            limits.mode = IBlockInputStream::LIMITS_CURRENT;
+            limits.mode = LimitsMode::LIMITS_CURRENT;
             limits.size_limits = SizeLimits(settings.max_result_rows, settings.max_result_bytes, settings.result_overflow_mode);
         }
 

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -382,7 +382,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
             }
         }
 
-        LocalLimits limits;
+        StreamLocalLimits limits;
         if (!interpreter->ignoreLimits())
         {
             limits.mode = LimitsMode::LIMITS_CURRENT;

--- a/src/Processors/Executors/PipelineExecutingBlockInputStream.cpp
+++ b/src/Processors/Executors/PipelineExecutingBlockInputStream.cpp
@@ -103,7 +103,7 @@ void PipelineExecutingBlockInputStream::setProcessListElement(QueryStatus * elem
     pipeline->setProcessListElement(elem);
 }
 
-void PipelineExecutingBlockInputStream::setLimits(const IBlockInputStream::LocalLimits & limits_)
+void PipelineExecutingBlockInputStream::setLimits(const LocalLimits & limits_)
 {
     throwIfExecutionStarted(is_execution_started, "setLimits");
 

--- a/src/Processors/Executors/PipelineExecutingBlockInputStream.cpp
+++ b/src/Processors/Executors/PipelineExecutingBlockInputStream.cpp
@@ -103,7 +103,7 @@ void PipelineExecutingBlockInputStream::setProcessListElement(QueryStatus * elem
     pipeline->setProcessListElement(elem);
 }
 
-void PipelineExecutingBlockInputStream::setLimits(const LocalLimits & limits_)
+void PipelineExecutingBlockInputStream::setLimits(const StreamLocalLimits & limits_)
 {
     throwIfExecutionStarted(is_execution_started, "setLimits");
 

--- a/src/Processors/Executors/PipelineExecutingBlockInputStream.h
+++ b/src/Processors/Executors/PipelineExecutingBlockInputStream.h
@@ -24,7 +24,7 @@ public:
     /// Implement IBlockInputStream methods via QueryPipeline.
     void setProgressCallback(const ProgressCallback & callback) final;
     void setProcessListElement(QueryStatus * elem) final;
-    void setLimits(const LocalLimits & limits_) final;
+    void setLimits(const StreamLocalLimits & limits_) final;
     void setQuota(const std::shared_ptr<const EnabledQuota> & quota_) final;
     void addTotalRowsApprox(size_t value) final;
 

--- a/src/Processors/Pipe.cpp
+++ b/src/Processors/Pipe.cpp
@@ -779,7 +779,7 @@ void Pipe::transform(const Transformer & transformer)
     max_parallel_streams = std::max<size_t>(max_parallel_streams, output_ports.size());
 }
 
-void Pipe::setLimits(const LocalLimits & limits)
+void Pipe::setLimits(const StreamLocalLimits & limits)
 {
     for (auto & processor : processors)
     {

--- a/src/Processors/Pipe.cpp
+++ b/src/Processors/Pipe.cpp
@@ -779,7 +779,7 @@ void Pipe::transform(const Transformer & transformer)
     max_parallel_streams = std::max<size_t>(max_parallel_streams, output_ports.size());
 }
 
-void Pipe::setLimits(const ISourceWithProgress::LocalLimits & limits)
+void Pipe::setLimits(const LocalLimits & limits)
 {
     for (auto & processor : processors)
     {

--- a/src/Processors/Pipe.h
+++ b/src/Processors/Pipe.h
@@ -6,6 +6,8 @@
 namespace DB
 {
 
+struct LocalLimits;
+
 class Pipe;
 using Pipes = std::vector<Pipe>;
 
@@ -94,7 +96,7 @@ public:
     const Processors & getProcessors() const { return processors; }
 
     /// Specify quotas and limits for every ISourceWithProgress.
-    void setLimits(const SourceWithProgress::LocalLimits & limits);
+    void setLimits(const LocalLimits & limits);
     void setQuota(const std::shared_ptr<const EnabledQuota> & quota);
 
     /// Do not allow to change the table while the processors of pipe are alive.

--- a/src/Processors/Pipe.h
+++ b/src/Processors/Pipe.h
@@ -6,7 +6,7 @@
 namespace DB
 {
 
-struct LocalLimits;
+struct StreamLocalLimits;
 
 class Pipe;
 using Pipes = std::vector<Pipe>;
@@ -96,7 +96,7 @@ public:
     const Processors & getProcessors() const { return processors; }
 
     /// Specify quotas and limits for every ISourceWithProgress.
-    void setLimits(const LocalLimits & limits);
+    void setLimits(const StreamLocalLimits & limits);
     void setQuota(const std::shared_ptr<const EnabledQuota> & quota);
 
     /// Do not allow to change the table while the processors of pipe are alive.

--- a/src/Processors/QueryPlan/PartialSortingStep.cpp
+++ b/src/Processors/QueryPlan/PartialSortingStep.cpp
@@ -56,7 +56,7 @@ void PartialSortingStep::transformPipeline(QueryPipeline & pipeline)
         return std::make_shared<PartialSortingTransform>(header, sort_description, limit);
     });
 
-    LocalLimits limits;
+    StreamLocalLimits limits;
     limits.mode = LimitsMode::LIMITS_CURRENT;
     limits.size_limits = size_limits;
 

--- a/src/Processors/QueryPlan/PartialSortingStep.cpp
+++ b/src/Processors/QueryPlan/PartialSortingStep.cpp
@@ -56,7 +56,7 @@ void PartialSortingStep::transformPipeline(QueryPipeline & pipeline)
         return std::make_shared<PartialSortingTransform>(header, sort_description, limit);
     });
 
-    IBlockInputStream::LocalLimits limits;
+    LocalLimits limits;
     limits.mode = IBlockInputStream::LIMITS_CURRENT;
     limits.size_limits = size_limits;
 

--- a/src/Processors/QueryPlan/PartialSortingStep.cpp
+++ b/src/Processors/QueryPlan/PartialSortingStep.cpp
@@ -57,7 +57,7 @@ void PartialSortingStep::transformPipeline(QueryPipeline & pipeline)
     });
 
     LocalLimits limits;
-    limits.mode = IBlockInputStream::LIMITS_CURRENT;
+    limits.mode = LimitsMode::LIMITS_CURRENT;
     limits.size_limits = size_limits;
 
     pipeline.addSimpleTransform([&](const Block & header, QueryPipeline::StreamType stream_type) -> ProcessorPtr

--- a/src/Processors/QueryPlan/ReadFromStorageStep.cpp
+++ b/src/Processors/QueryPlan/ReadFromStorageStep.cpp
@@ -14,7 +14,7 @@ namespace DB
 ReadFromStorageStep::ReadFromStorageStep(
     TableLockHolder table_lock_,
     StorageMetadataPtr metadata_snapshot_,
-    LocalLimits & limits_,
+    StreamLocalLimits & limits_,
     std::shared_ptr<const EnabledQuota> quota_,
     StoragePtr storage_,
     const Names & required_columns_,

--- a/src/Processors/QueryPlan/ReadFromStorageStep.cpp
+++ b/src/Processors/QueryPlan/ReadFromStorageStep.cpp
@@ -13,8 +13,9 @@ namespace DB
 
 ReadFromStorageStep::ReadFromStorageStep(
     TableLockHolder table_lock_,
-    StorageMetadataPtr & metadata_snapshot_,
-    SelectQueryOptions options_,
+    StorageMetadataPtr metadata_snapshot_,
+    LocalLimits & limits_,
+    std::shared_ptr<const EnabledQuota> quota_,
     StoragePtr storage_,
     const Names & required_columns_,
     const SelectQueryInfo & query_info_,
@@ -23,8 +24,9 @@ ReadFromStorageStep::ReadFromStorageStep(
     size_t max_block_size_,
     size_t max_streams_)
     : table_lock(std::move(table_lock_))
-    , metadata_snapshot(metadata_snapshot_)
-    , options(std::move(options_))
+    , metadata_snapshot(std::move(metadata_snapshot_))
+    , limits(limits_)
+    , quota(std::move(quota_))
     , storage(std::move(storage_))
     , required_columns(required_columns_)
     , query_info(query_info_)
@@ -82,43 +84,10 @@ ReadFromStorageStep::ReadFromStorageStep(
     /// Table lock is stored inside pipeline here.
     pipeline->addTableLock(table_lock);
 
-    /// Set the limits and quota for reading data, the speed and time of the query.
-    {
-        const Settings & settings = context->getSettingsRef();
+    pipe.setLimits(limits);
 
-        IBlockInputStream::LocalLimits limits;
-        limits.mode = IBlockInputStream::LIMITS_TOTAL;
-        limits.size_limits = SizeLimits(settings.max_rows_to_read, settings.max_bytes_to_read, settings.read_overflow_mode);
-        limits.speed_limits.max_execution_time = settings.max_execution_time;
-        limits.timeout_overflow_mode = settings.timeout_overflow_mode;
-
-        /** Quota and minimal speed restrictions are checked on the initiating server of the request, and not on remote servers,
-          *  because the initiating server has a summary of the execution of the request on all servers.
-          *
-          * But limits on data size to read and maximum execution time are reasonable to check both on initiator and
-          *  additionally on each remote server, because these limits are checked per block of data processed,
-          *  and remote servers may process way more blocks of data than are received by initiator.
-          *
-          * The limits to throttle maximum execution speed is also checked on all servers.
-          */
-        if (options.to_stage == QueryProcessingStage::Complete)
-        {
-            limits.speed_limits.min_execution_rps = settings.min_execution_speed;
-            limits.speed_limits.min_execution_bps = settings.min_execution_speed_bytes;
-        }
-
-        limits.speed_limits.max_execution_rps = settings.max_execution_speed;
-        limits.speed_limits.max_execution_bps = settings.max_execution_speed_bytes;
-        limits.speed_limits.timeout_before_checking_execution_speed = settings.timeout_before_checking_execution_speed;
-
-        auto quota = context->getQuota();
-
-        if (!options.ignore_limits)
-            pipe.setLimits(limits);
-
-        if (!options.ignore_quota && (options.to_stage == QueryProcessingStage::Complete))
-            pipe.setQuota(quota);
-    }
+    if (quota)
+        pipe.setQuota(quota);
 
     pipeline->init(std::move(pipe));
 

--- a/src/Processors/QueryPlan/ReadFromStorageStep.h
+++ b/src/Processors/QueryPlan/ReadFromStorageStep.h
@@ -1,7 +1,7 @@
 #include <Processors/QueryPlan/IQueryPlanStep.h>
 #include <Core/QueryProcessingStage.h>
 #include <Storages/TableLockHolder.h>
-#include <Interpreters/SelectQueryOptions.h>
+#include <DataStreams/LocalLimits.h>
 
 namespace DB
 {
@@ -16,14 +16,17 @@ struct SelectQueryInfo;
 
 struct PrewhereInfo;
 
+class EnabledQuota;
+
 /// Reads from storage.
 class ReadFromStorageStep : public IQueryPlanStep
 {
 public:
     ReadFromStorageStep(
         TableLockHolder table_lock,
-        StorageMetadataPtr & metadata_snapshot,
-        SelectQueryOptions options,
+        StorageMetadataPtr metadata_snapshot,
+        LocalLimits & limits,
+        std::shared_ptr<const EnabledQuota> quota,
         StoragePtr storage,
         const Names & required_columns,
         const SelectQueryInfo & query_info,
@@ -43,7 +46,8 @@ public:
 private:
     TableLockHolder table_lock;
     StorageMetadataPtr metadata_snapshot;
-    SelectQueryOptions options;
+    LocalLimits limits;
+    std::shared_ptr<const EnabledQuota> quota;
 
     StoragePtr storage;
     const Names & required_columns;

--- a/src/Processors/QueryPlan/ReadFromStorageStep.h
+++ b/src/Processors/QueryPlan/ReadFromStorageStep.h
@@ -1,7 +1,7 @@
 #include <Processors/QueryPlan/IQueryPlanStep.h>
 #include <Core/QueryProcessingStage.h>
 #include <Storages/TableLockHolder.h>
-#include <DataStreams/LocalLimits.h>
+#include <DataStreams/StreamLocalLimits.h>
 
 namespace DB
 {
@@ -25,7 +25,7 @@ public:
     ReadFromStorageStep(
         TableLockHolder table_lock,
         StorageMetadataPtr metadata_snapshot,
-        LocalLimits & limits,
+        StreamLocalLimits & limits,
         std::shared_ptr<const EnabledQuota> quota,
         StoragePtr storage,
         const Names & required_columns,
@@ -46,7 +46,7 @@ public:
 private:
     TableLockHolder table_lock;
     StorageMetadataPtr metadata_snapshot;
-    LocalLimits limits;
+    StreamLocalLimits limits;
     std::shared_ptr<const EnabledQuota> quota;
 
     StoragePtr storage;

--- a/src/Processors/Sources/SourceFromInputStream.h
+++ b/src/Processors/Sources/SourceFromInputStream.h
@@ -32,7 +32,7 @@ public:
     void setRowsBeforeLimitCounter(RowsBeforeLimitCounterPtr counter) { rows_before_limit.swap(counter); }
 
     /// Implementation for methods from ISourceWithProgress.
-    void setLimits(const LocalLimits & limits_) final { stream->setLimits(limits_); }
+    void setLimits(const StreamLocalLimits & limits_) final { stream->setLimits(limits_); }
     void setQuota(const std::shared_ptr<const EnabledQuota> & quota_) final { stream->setQuota(quota_); }
     void setProcessListElement(QueryStatus * elem) final { stream->setProcessListElement(elem); }
     void setProgressCallback(const ProgressCallback & callback) final { stream->setProgressCallback(callback); }

--- a/src/Processors/Sources/SourceWithProgress.h
+++ b/src/Processors/Sources/SourceWithProgress.h
@@ -2,6 +2,7 @@
 #include <Processors/ISource.h>
 #include <DataStreams/IBlockInputStream.h>
 #include <Common/Stopwatch.h>
+#include <DataStreams/LocalLimits.h>
 
 namespace DB
 {
@@ -12,9 +13,6 @@ class ISourceWithProgress : public ISource
 {
 public:
     using ISource::ISource;
-
-    using LocalLimits = IBlockInputStream::LocalLimits;
-    using LimitsMode = IBlockInputStream::LimitsMode;
 
     /// Set limitations that checked on each chunk.
     virtual void setLimits(const LocalLimits & limits_) = 0;
@@ -46,9 +44,6 @@ public:
     using ISourceWithProgress::ISourceWithProgress;
     /// If enable_auto_progress flag is set, progress() will be automatically called on each generated chunk.
     SourceWithProgress(Block header, bool enable_auto_progress);
-
-    using LocalLimits = IBlockInputStream::LocalLimits;
-    using LimitsMode = IBlockInputStream::LimitsMode;
 
     void setLimits(const LocalLimits & limits_) final { limits = limits_; }
     void setQuota(const std::shared_ptr<const EnabledQuota> & quota_) final { quota = quota_; }

--- a/src/Processors/Sources/SourceWithProgress.h
+++ b/src/Processors/Sources/SourceWithProgress.h
@@ -2,7 +2,7 @@
 #include <Processors/ISource.h>
 #include <DataStreams/IBlockInputStream.h>
 #include <Common/Stopwatch.h>
-#include <DataStreams/LocalLimits.h>
+#include <DataStreams/StreamLocalLimits.h>
 
 namespace DB
 {
@@ -15,7 +15,7 @@ public:
     using ISource::ISource;
 
     /// Set limitations that checked on each chunk.
-    virtual void setLimits(const LocalLimits & limits_) = 0;
+    virtual void setLimits(const StreamLocalLimits & limits_) = 0;
 
     /// Set the quota. If you set a quota on the amount of raw data,
     /// then you should also set mode = LIMITS_TOTAL to LocalLimits with setLimits.
@@ -45,7 +45,7 @@ public:
     /// If enable_auto_progress flag is set, progress() will be automatically called on each generated chunk.
     SourceWithProgress(Block header, bool enable_auto_progress);
 
-    void setLimits(const LocalLimits & limits_) final { limits = limits_; }
+    void setLimits(const StreamLocalLimits & limits_) final { limits = limits_; }
     void setQuota(const std::shared_ptr<const EnabledQuota> & quota_) final { quota = quota_; }
     void setProcessListElement(QueryStatus * elem) final { process_list_elem = elem; }
     void setProgressCallback(const ProgressCallback & callback) final { progress_callback = callback; }
@@ -58,7 +58,7 @@ protected:
     void work() override;
 
 private:
-    LocalLimits limits;
+    StreamLocalLimits limits;
     std::shared_ptr<const EnabledQuota> quota;
     ProgressCallback progress_callback;
     QueryStatus * process_list_elem = nullptr;

--- a/src/Processors/Transforms/LimitsCheckingTransform.cpp
+++ b/src/Processors/Transforms/LimitsCheckingTransform.cpp
@@ -18,7 +18,7 @@ void ProcessorProfileInfo::update(const Chunk & block)
     bytes += block.bytes();
 }
 
-LimitsCheckingTransform::LimitsCheckingTransform(const Block & header_, LocalLimits limits_)
+LimitsCheckingTransform::LimitsCheckingTransform(const Block & header_, StreamLocalLimits limits_)
     : ISimpleTransform(header_, header_, false)
     , limits(std::move(limits_))
 {

--- a/src/Processors/Transforms/LimitsCheckingTransform.h
+++ b/src/Processors/Transforms/LimitsCheckingTransform.h
@@ -4,7 +4,7 @@
 #include <Poco/Timespan.h>
 #include <Interpreters/ProcessList.h>
 
-#include <DataStreams/LocalLimits.h>
+#include <DataStreams/StreamLocalLimits.h>
 
 namespace DB
 {
@@ -26,7 +26,7 @@ class LimitsCheckingTransform : public ISimpleTransform
 {
 public:
 
-    LimitsCheckingTransform(const Block & header_, LocalLimits limits_);
+    LimitsCheckingTransform(const Block & header_, StreamLocalLimits limits_);
 
     String getName() const override { return "LimitsCheckingTransform"; }
 
@@ -36,7 +36,7 @@ protected:
     void transform(Chunk & chunk) override;
 
 private:
-    LocalLimits limits;
+    StreamLocalLimits limits;
 
     std::shared_ptr<const EnabledQuota> quota;
     UInt64 prev_elapsed = 0;

--- a/src/Processors/Transforms/LimitsCheckingTransform.h
+++ b/src/Processors/Transforms/LimitsCheckingTransform.h
@@ -4,7 +4,7 @@
 #include <Poco/Timespan.h>
 #include <Interpreters/ProcessList.h>
 
-#include <DataStreams/IBlockOutputStream.h>
+#include <DataStreams/LocalLimits.h>
 
 namespace DB
 {
@@ -25,9 +25,6 @@ struct ProcessorProfileInfo
 class LimitsCheckingTransform : public ISimpleTransform
 {
 public:
-
-    using LocalLimits = IBlockInputStream::LocalLimits;
-    using LimitsMode = IBlockInputStream::LimitsMode;
 
     LimitsCheckingTransform(const Block & header_, LocalLimits limits_);
 

--- a/src/Storages/IStorage.cpp
+++ b/src/Storages/IStorage.cpp
@@ -7,6 +7,7 @@
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Processors/Pipe.h>
+#include <Processors/QueryPlan/ReadFromStorageStep.h>
 #include <Interpreters/Context.h>
 #include <Common/StringUtils/StringUtils.h>
 #include <Common/quoteString.h>
@@ -89,6 +90,27 @@ Pipe IStorage::read(
         unsigned /*num_streams*/)
 {
     throw Exception("Method read is not supported by storage " + getName(), ErrorCodes::NOT_IMPLEMENTED);
+}
+
+void IStorage::read(
+        QueryPlan & query_plan,
+        TableLockHolder table_lock,
+        StorageMetadataPtr metadata_snapshot,
+        LocalLimits & limits,
+        std::shared_ptr<const EnabledQuota> quota,
+        const Names & column_names,
+        const SelectQueryInfo & query_info,
+        std::shared_ptr<Context> context,
+        QueryProcessingStage::Enum processed_stage,
+        size_t max_block_size,
+        unsigned num_streams)
+{
+    auto read_step = std::make_unique<ReadFromStorageStep>(
+            std::move(table_lock), std::move(metadata_snapshot), limits, std::move(quota), shared_from_this(),
+            column_names, query_info, std::move(context), processed_stage, max_block_size, num_streams);
+
+    read_step->setStepDescription("Read from " + getName());
+    query_plan.addStep(std::move(read_step));
 }
 
 Pipe IStorage::alterPartition(

--- a/src/Storages/IStorage.cpp
+++ b/src/Storages/IStorage.cpp
@@ -96,7 +96,7 @@ void IStorage::read(
         QueryPlan & query_plan,
         TableLockHolder table_lock,
         StorageMetadataPtr metadata_snapshot,
-        LocalLimits & limits,
+        StreamLocalLimits & limits,
         std::shared_ptr<const EnabledQuota> quota,
         const Names & column_names,
         const SelectQueryInfo & query_info,

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -287,7 +287,7 @@ public:
         QueryPlan & query_plan,
         TableLockHolder table_lock,
         StorageMetadataPtr metadata_snapshot,
-        LocalLimits & limits,
+        StreamLocalLimits & limits,
         std::shared_ptr<const EnabledQuota> quota,
         const Names & column_names,
         const SelectQueryInfo & query_info,

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -48,6 +48,7 @@ using ProcessorPtr = std::shared_ptr<IProcessor>;
 using Processors = std::vector<ProcessorPtr>;
 
 class Pipe;
+class QueryPlan;
 
 class StoragePolicy;
 using StoragePolicyPtr = std::shared_ptr<const StoragePolicy>;
@@ -279,6 +280,19 @@ public:
         QueryProcessingStage::Enum /*processed_stage*/,
         size_t /*max_block_size*/,
         unsigned /*num_streams*/);
+
+    virtual void read(
+        QueryPlan & query_plan,
+        TableLockHolder table_lock,
+        StorageMetadataPtr metadata_snapshot,
+        LocalLimits & limits,
+        std::shared_ptr<const EnabledQuota> quota,
+        const Names & column_names,
+        const SelectQueryInfo & query_info,
+        std::shared_ptr<Context> context,
+        QueryProcessingStage::Enum processed_stage,
+        size_t max_block_size,
+        unsigned num_streams);
 
     /** Writes the data to a table.
       * Receives a description of the query, which can contain information about the data write method.

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -281,6 +281,8 @@ public:
         size_t /*max_block_size*/,
         unsigned /*num_streams*/);
 
+    /// Other version of read which adds reading step to query plan.
+    /// Default implementation creates ReadFromStorageStep and uses usual read.
     virtual void read(
         QueryPlan & query_plan,
         TableLockHolder table_lock,

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -565,7 +565,7 @@ bool StorageKafka::streamToViews()
         streams.emplace_back(stream);
 
         // Limit read batch to maximum block size to allow DDL
-        IBlockInputStream::LocalLimits limits;
+        LocalLimits limits;
 
         limits.speed_limits.max_execution_time = kafka_settings->kafka_flush_interval_ms.changed
                                                  ? kafka_settings->kafka_flush_interval_ms

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -565,7 +565,7 @@ bool StorageKafka::streamToViews()
         streams.emplace_back(stream);
 
         // Limit read batch to maximum block size to allow DDL
-        LocalLimits limits;
+        StreamLocalLimits limits;
 
         limits.speed_limits.max_execution_time = kafka_settings->kafka_flush_interval_ms.changed
                                                  ? kafka_settings->kafka_flush_interval_ms

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
@@ -752,7 +752,7 @@ bool StorageRabbitMQ::streamToViews()
         streams.emplace_back(stream);
 
         // Limit read batch to maximum block size to allow DDL
-        LocalLimits limits;
+        StreamLocalLimits limits;
 
         limits.speed_limits.max_execution_time = rabbitmq_settings->rabbitmq_flush_interval_ms.changed
                                                   ? rabbitmq_settings->rabbitmq_flush_interval_ms

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
@@ -752,7 +752,7 @@ bool StorageRabbitMQ::streamToViews()
         streams.emplace_back(stream);
 
         // Limit read batch to maximum block size to allow DDL
-        IBlockInputStream::LocalLimits limits;
+        LocalLimits limits;
 
         limits.speed_limits.max_execution_time = rabbitmq_settings->rabbitmq_flush_interval_ms.changed
                                                   ? rabbitmq_settings->rabbitmq_flush_interval_ms


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add `IStorage::read` with query plan support.