### PR TITLE
construct query_start_time & query_start_time_microseconds from the same timespec

### DIFF
--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -136,6 +136,22 @@ void ThreadStatus::attachQuery(const ThreadGroupStatusPtr & thread_group_, bool 
     setupState(thread_group_);
 }
 
+inline UInt64 time_in_nanoseconds(std::chrono::time_point<std::chrono::system_clock> timepoint)
+{
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(timepoint.time_since_epoch()).count();
+}
+
+inline UInt64 time_in_microseconds(std::chrono::time_point<std::chrono::system_clock> timepoint)
+{
+    return std::chrono::duration_cast<std::chrono::microseconds>(timepoint.time_since_epoch()).count();
+}
+
+
+inline UInt64 time_in_seconds(std::chrono::time_point<std::chrono::system_clock> timepoint)
+{
+    return std::chrono::duration_cast<std::chrono::seconds>(timepoint.time_since_epoch()).count();
+}
+
 void ThreadStatus::initPerformanceCounters()
 {
     performance_counters_finalized = false;
@@ -146,14 +162,13 @@ void ThreadStatus::initPerformanceCounters()
     memory_tracker.resetCounters();
     memory_tracker.setDescription("(for thread)");
 
-    // query_start_time_{microseconds, nanoseconds} are all constructed from the same timespec
-    // to ensure that they are all atelast equal upto the precision of a second.
-    struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC, &ts);
+    // query_start_time_{microseconds, nanoseconds} are all constructed from the same time point
+    // to ensure that they are all equal upto the precision of a second.
+    const auto now = std::chrono::system_clock::now();
 
-    query_start_time_nanoseconds = UInt64(ts.tv_sec * 1000000000LL + ts.tv_nsec);
-    query_start_time = ts.tv_sec;
-    query_start_time_microseconds = UInt64((ts.tv_sec * 1000000LL) + (ts.tv_nsec / 1000));
+    query_start_time_nanoseconds = time_in_nanoseconds(now);
+    query_start_time = time_in_seconds(now);
+    query_start_time_microseconds = time_in_microseconds(now);
     ++queries_started;
 
     *last_rusage = RUsageCounters::current(query_start_time_nanoseconds);

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -196,6 +196,8 @@ static void onExceptionBeforeStart(const String & query_for_logging, Context & c
 
     elem.type = QueryLogElementType::EXCEPTION_BEFORE_START;
 
+    // the assumption here is that the callers of onExceptionBeforeStart construct both params current_time and the current_time_microseconds
+    // from the same timespec so that both of the times are equal upto the precision of a second.
     elem.event_time = current_time;
     elem.query_start_time = current_time;
     elem.query_start_time_microseconds = current_time_microseconds;
@@ -251,8 +253,13 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
     bool has_query_tail,
     ReadBuffer * istr)
 {
-    time_t current_time = time(nullptr);
-    UInt64 current_time_microseconds = getCurrentTimeMicroseconds();
+    // current_time and current_time_microseconds are both constructed from the same timespec
+    // to ensure that both the times are equal upto the precision of a second.
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+
+    time_t current_time = ts.tv_sec;
+    UInt64 current_time_microseconds = UInt64((ts.tv_sec * 1000000LL) + (ts.tv_nsec / 1000));
 
     /// If we already executing query and it requires to execute internal query, than
     /// don't replace thread context with given (it can be temporary). Otherwise, attach context to thread.

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -182,6 +182,16 @@ static void logException(Context & context, QueryLogElement & elem)
             elem.exception, context.getClientInfo().current_address.toString(), joinLines(elem.query), elem.stack_trace);
 }
 
+inline UInt64 time_in_microseconds(std::chrono::time_point<std::chrono::system_clock> timepoint)
+{
+    return std::chrono::duration_cast<std::chrono::microseconds>(timepoint.time_since_epoch()).count();
+}
+
+
+inline UInt64 time_in_seconds(std::chrono::time_point<std::chrono::system_clock> timepoint)
+{
+    return std::chrono::duration_cast<std::chrono::seconds>(timepoint.time_since_epoch()).count();
+}
 
 static void onExceptionBeforeStart(const String & query_for_logging, Context & context, time_t current_time, UInt64 current_time_microseconds, ASTPtr ast)
 {
@@ -196,8 +206,9 @@ static void onExceptionBeforeStart(const String & query_for_logging, Context & c
 
     elem.type = QueryLogElementType::EXCEPTION_BEFORE_START;
 
-    // the assumption here is that the callers of onExceptionBeforeStart construct both params current_time and the current_time_microseconds
-    // from the same timespec so that both of the times are equal upto the precision of a second.
+    // all callers to onExceptionBeforeStart upstream construct the timespec for event_time and
+    // event_time_microseconds from the same timespec. So it can be assumed that both of these
+    // times are equal upto the precision of a second.
     elem.event_time = current_time;
     elem.query_start_time = current_time;
     elem.query_start_time_microseconds = current_time_microseconds;
@@ -253,13 +264,12 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
     bool has_query_tail,
     ReadBuffer * istr)
 {
-    // current_time and current_time_microseconds are both constructed from the same timespec
+    // current_time and current_time_microseconds are both constructed from the same time point
     // to ensure that both the times are equal upto the precision of a second.
-    struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC, &ts);
+    const auto now = std::chrono::system_clock::now();
 
-    time_t current_time = ts.tv_sec;
-    UInt64 current_time_microseconds = UInt64((ts.tv_sec * 1000000LL) + (ts.tv_nsec / 1000));
+    auto current_time = time_in_seconds(now);
+    auto current_time_microseconds = time_in_microseconds(now);
 
     /// If we already executing query and it requires to execute internal query, than
     /// don't replace thread context with given (it can be temporary). Otherwise, attach context to thread.

--- a/tests/queries/0_stateless/01461_query_start_time_microseconds.sql
+++ b/tests/queries/0_stateless/01461_query_start_time_microseconds.sql
@@ -1,9 +1,36 @@
-set log_queries = 1;
+SET log_queries = 1;
+SELECT '01461_query_log_query_start_time_milliseconds_test';
+SYSTEM FLUSH LOGS;
+-- assumes that the query_start_time field is already accurate.
+WITH (
+      (
+          SELECT query_start_time_microseconds
+          FROM system.query_log
+          ORDER BY query_start_time DESC
+          LIMIT 1
+      ) AS time_with_microseconds,
+      (
+          SELECT query_start_time
+          FROM system.query_log
+          ORDER BY query_start_time DESC
+          LIMIT 1
+      ) AS t)
+SELECT if(dateDiff('second', toDateTime(time_with_microseconds), toDateTime(t)) = 0, 'ok', 'fail'); --
 
-select '01461_query_log_query_start_time_milliseconds_test';
-system flush logs;
-SELECT If((select count(query_start_time_microseconds)  from system.query_log WHERE query LIKE  '%01461_query_log_query_start_time_milliseconds_test%' AND query NOT LIKE '%system.query_log%') > 0, 'ok', 'fail');
-
-select '01461_query_thread_log_query_start_time_milliseconds_test';
-system flush logs;
-SELECT If((select count(query_start_time_microseconds)  from system.query_log WHERE query LIKE  '%01461_query_thread_log_query_start_time_milliseconds_test%' AND query NOT LIKE '%system.query_log%') > 0, 'ok', 'fail');
+SELECT '01461_query_thread_log_query_start_time_milliseconds_test';
+SYSTEM FLUSH LOGS;
+-- assumes that the query_start_time field is already accurate.
+WITH (
+      (
+          SELECT query_start_time_microseconds
+          FROM system.query_thread_log
+          ORDER BY query_start_time DESC
+          LIMIT 1
+      ) AS time_with_microseconds,
+      (
+          SELECT query_start_time
+          FROM system.query_thread_log
+          ORDER BY query_start_time DESC
+          LIMIT 1
+      ) AS t)
+SELECT if(dateDiff('second', toDateTime(time_with_microseconds), toDateTime(t)) = 0, 'ok', 'fail'); --


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Construct `query_start_time` and `query_start_time_microseconds` from the same timespec.


Detailed description / Documentation draft:

This PR ensures that the `query_start_time` and the `query_start_time_microseconds` fields are both constructed from the same timespec, such that both the times are equal upto the precision of a second.

Also improve the functional test for the `query_start_time_microseconds` field for the `system.query_log` and `system.query_thread_log tables`.

Relates to: #9800 