### PR TITLE
Don't throw exception if Distributed storage has multi-volume storage policy configuration

### DIFF
--- a/src/Storages/StorageDistributed.h
+++ b/src/Storages/StorageDistributed.h
@@ -183,6 +183,11 @@ protected:
 
     /// Can be empty if relative_data_path is empty. In this case, a directory for the data to be sent is not created.
     StoragePolicyPtr storage_policy;
+    /// The main volume to store data.
+    /// Storage policy may have several configured volumes, but second and other volumes are used for parts movement in MergeTree engine.
+    /// For Distributed engine such configuration doesn't make sense and only the first (main) volume will be used to store data.
+    /// Other volumes will be ignored. It's needed to allow using the same multi-volume policy both for Distributed and other engines.
+    VolumePtr data_volume;
 
     struct ClusterNodeData
     {


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow using multi-volume storage configuration in storage Distributed.

Detailed description / Documentation draft:
If a user has a default storage policy with multi-volume configuration he can create MergeTree storages, but can't create Distributed storage. Such behavior worsens UX, and even more multi-volume configuration doesn't make practical sense. Second and other volumes in such configuration will be ignored for storage Distributed.
