### PR TITLE
Move to clang-11 in CI builds

### DIFF
--- a/base/glibc-compatibility/CMakeLists.txt
+++ b/base/glibc-compatibility/CMakeLists.txt
@@ -34,9 +34,6 @@ if (GLIBC_COMPATIBILITY)
 
     if (COMPILER_CLANG)
         target_compile_options(glibc-compatibility PRIVATE -Wno-unused-command-line-argument)
-        # disable lto for this library, because for some reason clang-11 fails
-        # to link llvm with it.
-        target_compile_options(glibc-compatibility PRIVATE -fno-lto)
     elseif (COMPILER_GCC)
         target_compile_options(glibc-compatibility PRIVATE -Wno-unused-but-set-variable)
     endif ()

--- a/base/glibc-compatibility/CMakeLists.txt
+++ b/base/glibc-compatibility/CMakeLists.txt
@@ -34,6 +34,9 @@ if (GLIBC_COMPATIBILITY)
 
     if (COMPILER_CLANG)
         target_compile_options(glibc-compatibility PRIVATE -Wno-unused-command-line-argument)
+        # disable lto for this library, because for some reason clang-11 fails
+        # to link llvm with it.
+        target_compile_options(glibc-compatibility PRIVATE -fno-lto)
     elseif (COMPILER_GCC)
         target_compile_options(glibc-compatibility PRIVATE -Wno-unused-but-set-variable)
     endif ()

--- a/docker/packager/binary/Dockerfile
+++ b/docker/packager/binary/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
     && echo "${LLVM_PUBKEY_HASH} /tmp/llvm-snapshot.gpg.key" | sha384sum -c \
     && apt-key add /tmp/llvm-snapshot.gpg.key \
     && export CODENAME="$(lsb_release --codename --short | tr 'A-Z' 'a-z')" \
-    && echo "deb [trusted=yes] http://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-${LLVM_VERSION} main" >> \
+    && echo "deb [trusted=yes] http://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-11 main" >> \
         /etc/apt/sources.list
 
 # initial packages
@@ -36,12 +36,11 @@ RUN apt-get update \
         clang-${LLVM_VERSION} \
         lld-${LLVM_VERSION} \
         clang-tidy-${LLVM_VERSION} \
-        clang-9 \
-        lld-9 \
-        clang-tidy-9 \
-        clang-8 \
-        lld-8 \
-        clang-tidy-8 \
+        clang-11 \
+        clang-tidy-11 \
+        lld-11 \
+        llvm-11 \
+        llvm-11-dev \
         libicu-dev \
         libreadline-dev \
         ninja-build \

--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -35,7 +35,7 @@ function download
 #    wget -O- -nv -nd -c "https://clickhouse-builds.s3.yandex.net/$PR_TO_TEST/$SHA_TO_TEST/clickhouse_build_check/performance/performance.tgz" \
 #        | tar --strip-components=1 -zxv
 
-    wget -nv -nd -c "https://clickhouse-builds.s3.yandex.net/$PR_TO_TEST/$SHA_TO_TEST/clickhouse_build_check/clang-10_debug_none_bundled_unsplitted_disable_False_binary/clickhouse"
+    wget -nv -nd -c "https://clickhouse-builds.s3.yandex.net/$PR_TO_TEST/$SHA_TO_TEST/clickhouse_build_check/clang-11_debug_none_bundled_unsplitted_disable_False_binary/clickhouse"
     chmod +x clickhouse
     ln -s ./clickhouse ./clickhouse-server
     ln -s ./clickhouse ./clickhouse-client

--- a/tests/ci/ci_config.json
+++ b/tests/ci/ci_config.json
@@ -72,7 +72,7 @@
             "with_coverage": false
         },
         {
-            "compiler": "clang-11",
+            "compiler": "clang-10",
             "build-type": "",
             "sanitizer": "",
             "package-type": "deb",
@@ -102,7 +102,7 @@
             "with_coverage": false
         },
         {
-            "compiler": "clang-11",
+            "compiler": "clang-10",
             "build-type": "",
             "sanitizer": "",
             "package-type": "binary",

--- a/tests/ci/ci_config.json
+++ b/tests/ci/ci_config.json
@@ -12,7 +12,7 @@
             "with_coverage": false
         },
         {
-            "compiler": "gcc-10",
+            "compiler": "clang-11",
             "build-type": "",
             "sanitizer": "",
             "package-type": "performance",
@@ -32,7 +32,7 @@
             "with_coverage": false
         },
         {
-            "compiler": "clang-10",
+            "compiler": "clang-11",
             "build-type": "",
             "sanitizer": "address",
             "package-type": "deb",
@@ -42,7 +42,7 @@
             "with_coverage": false
         },
         {
-            "compiler": "clang-10",
+            "compiler": "clang-11",
             "build-type": "",
             "sanitizer": "undefined",
             "package-type": "deb",
@@ -52,7 +52,7 @@
             "with_coverage": false
         },
         {
-            "compiler": "clang-10",
+            "compiler": "clang-11",
             "build-type": "",
             "sanitizer": "thread",
             "package-type": "deb",
@@ -62,7 +62,7 @@
             "with_coverage": false
         },
         {
-            "compiler": "clang-10",
+            "compiler": "clang-11",
             "build-type": "",
             "sanitizer": "memory",
             "package-type": "deb",
@@ -72,7 +72,7 @@
             "with_coverage": false
         },
         {
-            "compiler": "clang-10",
+            "compiler": "clang-11",
             "build-type": "",
             "sanitizer": "",
             "package-type": "deb",
@@ -82,7 +82,7 @@
             "with_coverage": false
         },
         {
-            "compiler": "clang-10",
+            "compiler": "clang-11",
             "build-type": "debug",
             "sanitizer": "",
             "package-type": "deb",
@@ -102,7 +102,7 @@
             "with_coverage": false
         },
         {
-            "compiler": "clang-10",
+            "compiler": "clang-11",
             "build-type": "",
             "sanitizer": "",
             "package-type": "binary",
@@ -112,7 +112,7 @@
             "with_coverage": false
         },
         {
-            "compiler": "clang-10",
+            "compiler": "clang-11",
             "build-type": "",
             "sanitizer": "",
             "package-type": "binary",
@@ -154,7 +154,7 @@
     ],
     "special_build_config": [
         {
-            "compiler": "clang-10",
+            "compiler": "clang-11",
             "build-type": "debug",
             "sanitizer": "",
             "package-type": "deb",
@@ -167,7 +167,7 @@
     "tests_config": {
         "Functional stateful tests (address)": {
             "required_build_properties": {
-                "compiler": "clang-10",
+                "compiler": "clang-11",
                 "package_type": "deb",
                 "build_type": "relwithdebuginfo",
                 "sanitizer": "address",
@@ -179,7 +179,7 @@
         },
         "Functional stateful tests (thread)": {
             "required_build_properties": {
-                "compiler": "clang-10",
+                "compiler": "clang-11",
                 "package_type": "deb",
                 "build_type": "relwithdebuginfo",
                 "sanitizer": "thread",
@@ -191,7 +191,7 @@
         },
         "Functional stateful tests (memory)": {
             "required_build_properties": {
-                "compiler": "clang-10",
+                "compiler": "clang-11",
                 "package_type": "deb",
                 "build_type": "relwithdebuginfo",
                 "sanitizer": "memory",
@@ -203,7 +203,7 @@
         },
         "Functional stateful tests (ubsan)": {
             "required_build_properties": {
-                "compiler": "clang-10",
+                "compiler": "clang-11",
                 "package_type": "deb",
                 "build_type": "relwithdebuginfo",
                 "sanitizer": "undefined",
@@ -215,7 +215,7 @@
         },
         "Functional stateful tests (debug)": {
             "required_build_properties": {
-                "compiler": "clang-10",
+                "compiler": "clang-11",
                 "package_type": "deb",
                 "build_type": "debug",
                 "sanitizer": "none",
@@ -251,7 +251,7 @@
         },
         "Functional stateless tests (address)": {
             "required_build_properties": {
-                "compiler": "clang-10",
+                "compiler": "clang-11",
                 "package_type": "deb",
                 "build_type": "relwithdebuginfo",
                 "sanitizer": "address",
@@ -263,7 +263,7 @@
         },
         "Functional stateless tests (thread)": {
             "required_build_properties": {
-                "compiler": "clang-10",
+                "compiler": "clang-11",
                 "package_type": "deb",
                 "build_type": "relwithdebuginfo",
                 "sanitizer": "thread",
@@ -275,7 +275,7 @@
         },
         "Functional stateless tests (memory)": {
             "required_build_properties": {
-                "compiler": "clang-10",
+                "compiler": "clang-11",
                 "package_type": "deb",
                 "build_type": "relwithdebuginfo",
                 "sanitizer": "memory",
@@ -287,7 +287,7 @@
         },
         "Functional stateless tests (ubsan)": {
             "required_build_properties": {
-                "compiler": "clang-10",
+                "compiler": "clang-11",
                 "package_type": "deb",
                 "build_type": "relwithdebuginfo",
                 "sanitizer": "undefined",
@@ -299,7 +299,7 @@
         },
         "Functional stateless tests (debug)": {
             "required_build_properties": {
-                "compiler": "clang-10",
+                "compiler": "clang-11",
                 "package_type": "deb",
                 "build_type": "debug",
                 "sanitizer": "none",
@@ -359,7 +359,7 @@
         },
         "Stress test (address)": {
             "required_build_properties": {
-                "compiler": "clang-10",
+                "compiler": "clang-11",
                 "package_type": "deb",
                 "build_type": "relwithdebuginfo",
                 "sanitizer": "address",
@@ -371,7 +371,7 @@
         },
         "Stress test (thread)": {
             "required_build_properties": {
-                "compiler": "clang-10",
+                "compiler": "clang-11",
                 "package_type": "deb",
                 "build_type": "relwithdebuginfo",
                 "sanitizer": "thread",
@@ -383,7 +383,7 @@
         },
         "Stress test (undefined)": {
             "required_build_properties": {
-                "compiler": "clang-10",
+                "compiler": "clang-11",
                 "package_type": "deb",
                 "build_type": "relwithdebuginfo",
                 "sanitizer": "undefined",
@@ -395,7 +395,7 @@
         },
         "Stress test (memory)": {
             "required_build_properties": {
-                "compiler": "clang-10",
+                "compiler": "clang-11",
                 "package_type": "deb",
                 "build_type": "relwithdebuginfo",
                 "sanitizer": "memory",
@@ -407,7 +407,7 @@
         },
         "Integration tests (asan)": {
             "required_build_properties": {
-                "compiler": "clang-10",
+                "compiler": "clang-11",
                 "package_type": "deb",
                 "build_type": "relwithdebuginfo",
                 "sanitizer": "address",
@@ -419,7 +419,7 @@
         },
         "Integration tests (thread)": {
             "required_build_properties": {
-                "compiler": "clang-10",
+                "compiler": "clang-11",
                 "package_type": "deb",
                 "build_type": "relwithdebuginfo",
                 "sanitizer": "thread",
@@ -431,7 +431,7 @@
         },
         "Integration tests (release)": {
             "required_build_properties": {
-                "compiler": "clang-10",
+                "compiler": "clang-11",
                 "package_type": "deb",
                 "build_type": "relwithdebuginfo",
                 "sanitizer": "none",
@@ -455,7 +455,7 @@
         },
         "Split build smoke test": {
             "required_build_properties": {
-                "compiler": "clang-10",
+                "compiler": "clang-11",
                 "package_type": "binary",
                 "build_type": "relwithdebuginfo",
                 "sanitizer": "none",
@@ -491,7 +491,7 @@
         },
         "Unit tests release clang": {
             "required_build_properties": {
-                "compiler": "clang-10",
+                "compiler": "clang-11",
                 "package_type": "binary",
                 "build_type": "relwithdebuginfo",
                 "sanitizer": "none",
@@ -503,7 +503,7 @@
         },
         "Unit tests ASAN": {
             "required_build_properties": {
-                "compiler": "clang-10",
+                "compiler": "clang-11",
                 "package_type": "binary",
                 "build_type": "relwithdebuginfo",
                 "sanitizer": "address",
@@ -515,7 +515,7 @@
         },
         "Unit tests MSAN": {
             "required_build_properties": {
-                "compiler": "clang-10",
+                "compiler": "clang-11",
                 "package_type": "binary",
                 "build_type": "relwithdebuginfo",
                 "sanitizer": "memory",
@@ -527,7 +527,7 @@
         },
         "Unit tests TSAN": {
             "required_build_properties": {
-                "compiler": "clang-10",
+                "compiler": "clang-11",
                 "package_type": "binary",
                 "build_type": "relwithdebuginfo",
                 "sanitizer": "thread",
@@ -539,7 +539,7 @@
         },
         "Unit tests UBSAN": {
             "required_build_properties": {
-                "compiler": "clang-10",
+                "compiler": "clang-11",
                 "package_type": "binary",
                 "build_type": "relwithdebuginfo",
                 "sanitizer": "thread",
@@ -551,7 +551,7 @@
         },
         "AST fuzzer": {
             "required_build_properties": {
-                "compiler": "clang-10",
+                "compiler": "clang-11",
                 "package_type": "binary",
                 "build_type": "debug",
                 "sanitizer": "none",

--- a/tests/ci/ci_config.json
+++ b/tests/ci/ci_config.json
@@ -12,7 +12,7 @@
             "with_coverage": false
         },
         {
-            "compiler": "clang-11",
+            "compiler": "gcc-10",
             "build-type": "",
             "sanitizer": "",
             "package-type": "performance",


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now we use clang-11 to build ClickHouse in CI.