### PR TITLE
ISSUES-14809 fix MaterializeMySQL empty transaction unstable test case

### DIFF
--- a/tests/integration/test_materialize_mysql_database/materialize_with_ddl.py
+++ b/tests/integration/test_materialize_mysql_database/materialize_with_ddl.py
@@ -350,7 +350,7 @@ def query_event_with_empty_transaction(clickhouse_node, mysql_node, service_name
     mysql_node.query("INSERT INTO test_database.t1(a) VALUES(2)")
     mysql_node.query("/* start */ commit /* end */")
 
-    check_query(clickhouse_node, "SELECT * FROM test_database.t1 ORDER BY a FORMAT TSV",
-                "1\tBEGIN\n2\tBEGIN\n")
+    check_query(clickhouse_node, "SHOW TABLES FROM test_database FORMAT TSV", "t1\n")
+    check_query(clickhouse_node, "SELECT * FROM test_database.t1 ORDER BY a FORMAT TSV", "1\tBEGIN\n2\tBEGIN\n")
     clickhouse_node.query("DROP DATABASE test_database")
     mysql_node.query("DROP DATABASE test_database")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
#14809 
fix MaterializeMySQL empty transaction unstable test case found in CI

CC: @alexey-milovidov 
