### PR TITLE
Query plan for creating sets

### DIFF
--- a/src/Interpreters/ActionsVisitor.cpp
+++ b/src/Interpreters/ActionsVisitor.cpp
@@ -900,10 +900,11 @@ SetPtr ActionsMatcher::makeSet(const ASTFunction & node, Data & data, bool no_su
           *   in the subquery_for_set object, this subquery is set as source and the temporary table _data1 as the table.
           * - this function shows the expression IN_data1.
           */
-        if (subquery_for_set.source.empty() && data.no_storage_or_local)
+        if (!subquery_for_set.source && data.no_storage_or_local)
         {
             auto interpreter = interpretSubquery(right_in_operand, data.context, data.subquery_depth, {});
-            subquery_for_set.source = QueryPipeline::getPipe(interpreter->execute().pipeline);
+            subquery_for_set.source = std::make_unique<QueryPlan>();
+            interpreter->buildQueryPlan(*subquery_for_set.source);
         }
 
         subquery_for_set.set = set;

--- a/src/Interpreters/ExpressionAnalyzer.cpp
+++ b/src/Interpreters/ExpressionAnalyzer.cpp
@@ -582,7 +582,7 @@ JoinPtr SelectQueryExpressionAnalyzer::makeTableJoin(const ASTTablesInSelectQuer
         ExpressionActionsPtr joined_block_actions = createJoinedBlockActions(context, analyzedJoin());
 
         Names original_right_columns;
-        if (subquery_for_join.source.empty())
+        if (!subquery_for_join.source)
         {
             NamesWithAliases required_columns_with_aliases = analyzedJoin().getRequiredColumns(
                 joined_block_actions->getSampleBlock(), joined_block_actions->getRequiredColumns());

--- a/src/Interpreters/GlobalSubqueriesVisitor.h
+++ b/src/Interpreters/GlobalSubqueriesVisitor.h
@@ -135,7 +135,8 @@ public:
                 ast = database_and_table_name;
 
             external_tables[external_table_name] = external_storage_holder;
-            subqueries_for_sets[external_table_name].source = QueryPipeline::getPipe(interpreter->execute().pipeline);
+            subqueries_for_sets[external_table_name].source = std::make_unique<QueryPlan>();
+            interpreter->buildQueryPlan(*subqueries_for_sets[external_table_name].source);
             subqueries_for_sets[external_table_name].table = external_storage;
 
             /** NOTE If it was written IN tmp_table - the existing temporary (but not external) table,

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1866,34 +1866,7 @@ void InterpreterSelectQuery::executeSubqueriesInSetsAndJoins(QueryPlan & query_p
         return;
 
     SizeLimits limits(settings.max_rows_to_transfer, settings.max_bytes_to_transfer, settings.transfer_overflow_mode);
-
-    std::vector<QueryPlan> plans;
-    DataStreams input_streams;
-    input_streams.emplace_back(query_plan.getCurrentDataStream());
-
-    for (auto & [description, set] : subqueries_for_sets)
-    {
-        auto plan = std::move(set.source);
-        std::string type = (set.join != nullptr) ? "JOIN"
-                                                 : "subquery";
-
-        auto creating_set = std::make_unique<CreatingSetStep>(
-                plan->getCurrentDataStream(),
-                query_plan.getCurrentDataStream().header,
-                std::move(description),
-                std::move(set),
-                limits,
-                *context);
-        creating_set->setStepDescription("Create set for " + type);
-        plan->addStep(std::move(creating_set));
-
-        input_streams.emplace_back(plan->getCurrentDataStream());
-        plans.emplace_back(std::move(*plan));
-    }
-
-    auto creating_sets = std::make_unique<CreatingSetsStep>(std::move(input_streams));
-    creating_sets->setStepDescription("Create sets before main query execution");
-    query_plan.unitePlans(std::move(creating_sets), std::move(plans));
+    addCreatingSetsStep(query_plan, std::move(subqueries_for_sets), limits, *context);
 }
 
 

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1899,9 +1899,6 @@ void InterpreterSelectQuery::executeSubqueriesInSetsAndJoins(QueryPlan & query_p
 
     const Settings & settings = context->getSettingsRef();
 
-    if (subqueries_for_sets.empty())
-        return;
-
     SizeLimits limits(settings.max_rows_to_transfer, settings.max_bytes_to_transfer, settings.transfer_overflow_mode);
     addCreatingSetsStep(query_plan, std::move(subqueries_for_sets), limits, *context);
 }

--- a/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
+++ b/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
@@ -183,13 +183,14 @@ void InterpreterSelectWithUnionQuery::buildQueryPlan(QueryPlan & query_plan)
         return;
     }
 
-    std::vector<QueryPlan> plans(num_plans);
+    std::vector<std::unique_ptr<QueryPlan>> plans(num_plans);
     DataStreams data_streams(num_plans);
 
     for (size_t i = 0; i < num_plans; ++i)
     {
-        nested_interpreters[i]->buildQueryPlan(plans[i]);
-        data_streams[i] = plans[i].getCurrentDataStream();
+        plans[i] = std::make_unique<QueryPlan>();
+        nested_interpreters[i]->buildQueryPlan(*plans[i]);
+        data_streams[i] = plans[i]->getCurrentDataStream();
     }
 
     auto max_threads = context->getSettingsRef().max_threads;

--- a/src/Interpreters/MutationsInterpreter.cpp
+++ b/src/Interpreters/MutationsInterpreter.cpp
@@ -11,6 +11,11 @@
 #include <Processors/Transforms/MaterializingTransform.h>
 #include <Processors/Sources/NullSource.h>
 #include <Processors/QueryPipeline.h>
+#include <Processors/QueryPlan/QueryPlan.h>
+#include <Processors/QueryPlan/ExpressionStep.h>
+#include <Processors/QueryPlan/FilterStep.h>
+#include <Processors/QueryPlan/ReadFromPreparedSource.h>
+#include <Processors/Executors/PipelineExecutingBlockInputStream.h>
 #include <DataStreams/CheckSortedBlockInputStream.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTFunction.h>
@@ -19,6 +24,7 @@
 #include <Parsers/ASTSelectQuery.h>
 #include <Parsers/formatAST.h>
 #include <IO/WriteHelpers.h>
+#include <Processors/QueryPlan/CreatingSetsStep.h>
 
 
 namespace DB
@@ -524,10 +530,11 @@ ASTPtr MutationsInterpreter::prepare(bool dry_run)
                     SelectQueryOptions().analyze(/* dry_run = */ false).ignoreLimits()};
 
                 auto first_stage_header = interpreter.getSampleBlock();
-                QueryPipeline pipeline;
-                pipeline.init(Pipe(std::make_shared<NullSource>(first_stage_header)));
-                addStreamsForLaterStages(stages_copy, pipeline);
-                updated_header = std::make_unique<Block>(pipeline.getHeader());
+                QueryPlan plan;
+                auto source = std::make_shared<NullSource>(first_stage_header);
+                plan.addStep(std::make_unique<ReadFromPreparedSource>(Pipe(std::move(source))));
+                auto pipeline = addStreamsForLaterStages(stages_copy, plan);
+                updated_header = std::make_unique<Block>(pipeline->getHeader());
             }
 
             /// Special step to recalculate affected indices and TTL expressions.
@@ -656,7 +663,7 @@ ASTPtr MutationsInterpreter::prepareInterpreterSelectQuery(std::vector<Stage> & 
     return select;
 }
 
-void MutationsInterpreter::addStreamsForLaterStages(const std::vector<Stage> & prepared_stages, QueryPipeline & pipeline) const
+QueryPipelinePtr MutationsInterpreter::addStreamsForLaterStages(const std::vector<Stage> & prepared_stages, QueryPlan & plan) const
 {
     for (size_t i_stage = 1; i_stage < prepared_stages.size(); ++i_stage)
     {
@@ -668,18 +675,12 @@ void MutationsInterpreter::addStreamsForLaterStages(const std::vector<Stage> & p
             if (i < stage.filter_column_names.size())
             {
                 /// Execute DELETEs.
-                pipeline.addSimpleTransform([&](const Block & header)
-                {
-                    return std::make_shared<FilterTransform>(header, step->actions(), stage.filter_column_names[i], false);
-                });
+                plan.addStep(std::make_unique<FilterStep>(plan.getCurrentDataStream(), step->actions(), stage.filter_column_names[i], false));
             }
             else
             {
                 /// Execute UPDATE or final projection.
-                pipeline.addSimpleTransform([&](const Block & header)
-                {
-                    return std::make_shared<ExpressionTransform>(header, step->actions());
-                });
+                plan.addStep(std::make_unique<ExpressionStep>(plan.getCurrentDataStream(), step->actions()));
             }
         }
 
@@ -689,14 +690,17 @@ void MutationsInterpreter::addStreamsForLaterStages(const std::vector<Stage> & p
             const Settings & settings = context.getSettingsRef();
             SizeLimits network_transfer_limits(
                     settings.max_rows_to_transfer, settings.max_bytes_to_transfer, settings.transfer_overflow_mode);
-            pipeline.addCreatingSetsTransform(std::move(subqueries_for_sets), network_transfer_limits, context);
+            addCreatingSetsStep(plan, std::move(subqueries_for_sets), network_transfer_limits, context);
         }
     }
 
-    pipeline.addSimpleTransform([&](const Block & header)
+    auto pipeline = plan.buildQueryPipeline();
+    pipeline->addSimpleTransform([&](const Block & header)
     {
         return std::make_shared<MaterializingTransform>(header);
     });
+
+    return pipeline;
 }
 
 void MutationsInterpreter::validate()
@@ -718,8 +722,11 @@ void MutationsInterpreter::validate()
         }
     }
 
-    auto block_io = select_interpreter->execute();
-    addStreamsForLaterStages(stages, block_io.pipeline);
+    QueryPlan plan;
+    select_interpreter->buildQueryPlan(plan);
+    addStreamsForLaterStages(stages, plan);
+
+    auto pipeline = plan.buildQueryPipeline();
 }
 
 BlockInputStreamPtr MutationsInterpreter::execute()
@@ -727,10 +734,13 @@ BlockInputStreamPtr MutationsInterpreter::execute()
     if (!can_execute)
         throw Exception("Cannot execute mutations interpreter because can_execute flag set to false", ErrorCodes::LOGICAL_ERROR);
 
-    auto block_io = select_interpreter->execute();
-    addStreamsForLaterStages(stages, block_io.pipeline);
+    QueryPlan plan;
+    select_interpreter->buildQueryPlan(plan);
 
-    auto result_stream = block_io.getInputStream();
+    addStreamsForLaterStages(stages, plan);
+
+    auto pipeline = plan.buildQueryPipeline();
+    BlockInputStreamPtr result_stream = std::make_shared<PipelineExecutingBlockInputStream>(std::move(*pipeline));
 
     /// Sometimes we update just part of columns (for example UPDATE mutation)
     /// in this case we don't read sorting key, so just we don't check anything.

--- a/src/Interpreters/MutationsInterpreter.cpp
+++ b/src/Interpreters/MutationsInterpreter.cpp
@@ -724,9 +724,7 @@ void MutationsInterpreter::validate()
 
     QueryPlan plan;
     select_interpreter->buildQueryPlan(plan);
-    addStreamsForLaterStages(stages, plan);
-
-    auto pipeline = plan.buildQueryPipeline();
+    auto pipeline = addStreamsForLaterStages(stages, plan);
 }
 
 BlockInputStreamPtr MutationsInterpreter::execute()
@@ -737,9 +735,7 @@ BlockInputStreamPtr MutationsInterpreter::execute()
     QueryPlan plan;
     select_interpreter->buildQueryPlan(plan);
 
-    addStreamsForLaterStages(stages, plan);
-
-    auto pipeline = plan.buildQueryPipeline();
+    auto pipeline = addStreamsForLaterStages(stages, plan);
     BlockInputStreamPtr result_stream = std::make_shared<PipelineExecutingBlockInputStream>(std::move(*pipeline));
 
     /// Sometimes we update just part of columns (for example UPDATE mutation)

--- a/src/Interpreters/MutationsInterpreter.h
+++ b/src/Interpreters/MutationsInterpreter.h
@@ -13,7 +13,10 @@ namespace DB
 {
 
 class Context;
+class QueryPlan;
+
 class QueryPipeline;
+using QueryPipelinePtr = std::unique_ptr<QueryPipeline>;
 
 /// Return false if the data isn't going to be changed by mutations.
 bool isStorageTouchedByMutations(
@@ -52,7 +55,7 @@ private:
     struct Stage;
 
     ASTPtr prepareInterpreterSelectQuery(std::vector<Stage> &prepared_stages, bool dry_run);
-    void addStreamsForLaterStages(const std::vector<Stage> & prepared_stages, QueryPipeline & pipeline) const;
+    QueryPipelinePtr addStreamsForLaterStages(const std::vector<Stage> & prepared_stages, QueryPlan & plan) const;
 
     std::optional<SortDescription> getStorageSortDescriptionIfPossible(const Block & header) const;
 

--- a/src/Interpreters/SubqueryForSet.cpp
+++ b/src/Interpreters/SubqueryForSet.cpp
@@ -8,6 +8,11 @@
 namespace DB
 {
 
+SubqueryForSet::SubqueryForSet() = default;
+SubqueryForSet::~SubqueryForSet() = default;
+SubqueryForSet::SubqueryForSet(SubqueryForSet &&) = default;
+SubqueryForSet & SubqueryForSet::operator= (SubqueryForSet &&) = default;
+
 void SubqueryForSet::makeSource(std::shared_ptr<InterpreterSelectWithUnionQuery> & interpreter,
                                 NamesWithAliases && joined_block_aliases_)
 {

--- a/src/Interpreters/SubqueryForSet.cpp
+++ b/src/Interpreters/SubqueryForSet.cpp
@@ -12,9 +12,10 @@ void SubqueryForSet::makeSource(std::shared_ptr<InterpreterSelectWithUnionQuery>
                                 NamesWithAliases && joined_block_aliases_)
 {
     joined_block_aliases = std::move(joined_block_aliases_);
-    source = QueryPipeline::getPipe(interpreter->execute().pipeline);
+    source = std::make_unique<QueryPlan>();
+    interpreter->buildQueryPlan(*source);
 
-    sample_block = source.getHeader();
+    sample_block = interpreter->getSampleBlock();
     renameColumns(sample_block);
 }
 

--- a/src/Interpreters/SubqueryForSet.h
+++ b/src/Interpreters/SubqueryForSet.h
@@ -18,6 +18,11 @@ class QueryPlan;
 /// Information on what to do when executing a subquery in the [GLOBAL] IN/JOIN section.
 struct SubqueryForSet
 {
+    SubqueryForSet();
+    ~SubqueryForSet();
+    SubqueryForSet(SubqueryForSet &&);
+    SubqueryForSet & operator= (SubqueryForSet &&);
+
     /// The source is obtained using the InterpreterSelectQuery subquery.
     std::unique_ptr<QueryPlan> source;
 

--- a/src/Interpreters/SubqueryForSet.h
+++ b/src/Interpreters/SubqueryForSet.h
@@ -5,7 +5,6 @@
 #include <Parsers/IAST.h>
 #include <Interpreters/IJoin.h>
 #include <Interpreters/PreparedSets.h>
-#include <Processors/Pipe.h>
 
 
 namespace DB
@@ -14,12 +13,13 @@ namespace DB
 class InterpreterSelectWithUnionQuery;
 class ExpressionActions;
 using ExpressionActionsPtr = std::shared_ptr<ExpressionActions>;
+class QueryPlan;
 
 /// Information on what to do when executing a subquery in the [GLOBAL] IN/JOIN section.
 struct SubqueryForSet
 {
     /// The source is obtained using the InterpreterSelectQuery subquery.
-    Pipe source;
+    std::unique_ptr<QueryPlan> source;
 
     /// If set, build it from result.
     SetPtr set;

--- a/src/Processors/QueryPipeline.cpp
+++ b/src/Processors/QueryPipeline.cpp
@@ -268,11 +268,11 @@ void QueryPipeline::addCreatingSetsTransform(const Block & res_header, SubqueryF
     resize(1);
 
     auto transform = std::make_shared<CreatingSetsTransform>(
-            pipeline.getHeader(),
+            getHeader(),
             res_header,
             std::move(subquery_for_set),
             limits,
-            context));
+            context);
 
     InputPort * totals_port = nullptr;
 

--- a/src/Processors/QueryPipeline.cpp
+++ b/src/Processors/QueryPipeline.cpp
@@ -263,15 +263,15 @@ QueryPipeline QueryPipeline::unitePipelines(
 }
 
 
-void QueryPipeline::addCreatingSetsTransform()
+void QueryPipeline::addCreatingSetsTransform(SubqueryForSet subquery_for_set, const SizeLimits & limits, const Context & context)
 {
-    pipeline.resize(1);
+    resize(1);
 
     auto transform = std::make_shared<CreatingSetsTransform>(
             pipeline.getHeader(),
             getOutputStream().header,
             std::move(subquery_for_set),
-            network_transfer_limits,
+            limits,
             context));
 
     InputPort * totals_port = nullptr;

--- a/src/Processors/QueryPipeline.cpp
+++ b/src/Processors/QueryPipeline.cpp
@@ -263,13 +263,13 @@ QueryPipeline QueryPipeline::unitePipelines(
 }
 
 
-void QueryPipeline::addCreatingSetsTransform(SubqueryForSet subquery_for_set, const SizeLimits & limits, const Context & context)
+void QueryPipeline::addCreatingSetsTransform(const Block & res_header, SubqueryForSet subquery_for_set, const SizeLimits & limits, const Context & context)
 {
     resize(1);
 
     auto transform = std::make_shared<CreatingSetsTransform>(
             pipeline.getHeader(),
-            getOutputStream().header,
+            res_header,
             std::move(subquery_for_set),
             limits,
             context));

--- a/src/Processors/QueryPipeline.cpp
+++ b/src/Processors/QueryPipeline.cpp
@@ -196,59 +196,6 @@ void QueryPipeline::addExtremesTransform()
     pipe.addTransform(std::move(transform), nullptr, port);
 }
 
-void QueryPipeline::addCreatingSetsTransform(SubqueriesForSets subqueries_for_sets, const SizeLimits & network_transfer_limits, const Context & context)
-{
-    checkInitializedAndNotCompleted();
-
-    Pipes sources;
-
-    for (auto & subquery : subqueries_for_sets)
-    {
-        if (subquery.second.source)
-        {
-            auto & source = sources.emplace_back(std::move(subquery.second.source));
-            if (source.numOutputPorts() > 1)
-                source.addTransform(std::make_shared<ResizeProcessor>(source.getHeader(), source.numOutputPorts(), 1));
-
-            source.dropExtremes();
-
-            auto creating_sets = std::make_shared<CreatingSetsTransform>(
-                    source.getHeader(),
-                    getHeader(),
-                    std::move(subquery.second),
-                    network_transfer_limits,
-                    context);
-
-            InputPort * totals = nullptr;
-            if (source.getTotalsPort())
-                totals = creating_sets->addTotalsPort();
-
-            source.addTransform(std::move(creating_sets), totals, nullptr);
-        }
-    }
-
-    if (sources.empty())
-        return;
-
-    auto * collected_processors = pipe.collected_processors;
-
-    /// We unite all sources together.
-    /// Set collected_processors to attach all newly-added processors to current query plan step.
-    auto source = Pipe::unitePipes(std::move(sources), collected_processors);
-    if (source.numOutputPorts() > 1)
-        source.addTransform(std::make_shared<ResizeProcessor>(source.getHeader(), source.numOutputPorts(), 1));
-    source.collected_processors = nullptr;
-
-    resize(1);
-
-    Pipes pipes;
-    pipes.emplace_back(std::move(source));
-    pipes.emplace_back(std::move(pipe));
-    pipe = Pipe::unitePipes(std::move(pipes), collected_processors);
-
-    pipe.addTransform(std::make_shared<ConcatProcessor>(getHeader(), 2));
-}
-
 void QueryPipeline::setOutputFormat(ProcessorPtr output)
 {
     checkInitializedAndNotCompleted();
@@ -315,7 +262,7 @@ QueryPipeline QueryPipeline::unitePipelines(
     return pipeline;
 }
 
-void QueryPipeline::addDelayedPipeline(QueryPipeline pipeline)
+void QueryPipeline::addDelayingPipeline(QueryPipeline pipeline)
 {
     pipeline.resize(1);
 

--- a/src/Processors/QueryPipeline.cpp
+++ b/src/Processors/QueryPipeline.cpp
@@ -262,6 +262,26 @@ QueryPipeline QueryPipeline::unitePipelines(
     return pipeline;
 }
 
+
+void QueryPipeline::addCreatingSetsTransform()
+{
+    pipeline.resize(1);
+
+    auto transform = std::make_shared<CreatingSetsTransform>(
+            pipeline.getHeader(),
+            getOutputStream().header,
+            std::move(subquery_for_set),
+            network_transfer_limits,
+            context));
+
+    InputPort * totals_port = nullptr;
+
+    if (pipe.getTotalsPort())
+        totals_port = transform->addTotalsPort();
+
+    pipe.addTransform(std::move(transform), totals_port, nullptr);
+}
+
 void QueryPipeline::addDelayingPipeline(QueryPipeline pipeline)
 {
     checkInitializedAndNotCompleted();

--- a/src/Processors/QueryPipeline.cpp
+++ b/src/Processors/QueryPipeline.cpp
@@ -282,7 +282,7 @@ void QueryPipeline::addCreatingSetsTransform(const Block & res_header, SubqueryF
     pipe.addTransform(std::move(transform), totals_port, nullptr);
 }
 
-void QueryPipeline::addDelayingPipeline(QueryPipeline pipeline)
+void QueryPipeline::addPipelineBefore(QueryPipeline pipeline)
 {
     checkInitializedAndNotCompleted();
     assertBlocksHaveEqualStructure(getHeader(), pipeline.getHeader(), "QueryPipeline");

--- a/src/Processors/QueryPipeline.h
+++ b/src/Processors/QueryPipeline.h
@@ -26,6 +26,8 @@ class QueryPlan;
 struct SubqueryForSet;
 using SubqueriesForSets = std::unordered_map<String, SubqueryForSet>;
 
+struct SizeLimits;
+
 class QueryPipeline
 {
 public:
@@ -89,7 +91,7 @@ public:
     /// Pipeline must have same header.
     void addDelayingPipeline(QueryPipeline pipeline);
 
-    void addCreatingSetsTransform();
+    void addCreatingSetsTransform(SubqueryForSet subquery_for_set, const SizeLimits & limits, const Context & context);
 
     PipelineExecutorPtr execute();
 

--- a/src/Processors/QueryPipeline.h
+++ b/src/Processors/QueryPipeline.h
@@ -87,6 +87,8 @@ public:
             size_t max_threads_limit = 0,
             Processors * collected_processors = nullptr);
 
+    void addDelayedPipeline(QueryPipeline);
+
     PipelineExecutorPtr execute();
 
     size_t getNumStreams() const { return pipe.numOutputPorts(); }

--- a/src/Processors/QueryPipeline.h
+++ b/src/Processors/QueryPipeline.h
@@ -55,8 +55,6 @@ public:
     void addTotalsHavingTransform(ProcessorPtr transform);
     /// Add transform which calculates extremes. This transform adds extremes port and doesn't change inputs number.
     void addExtremesTransform();
-    /// Adds transform which creates sets. It will be executed before reading any data from input ports.
-    void addCreatingSetsTransform(SubqueriesForSets subqueries_for_sets, const SizeLimits & network_transfer_limits, const Context & context);
     /// Resize pipeline to single output and add IOutputFormat. Pipeline will be completed after this transformation.
     void setOutputFormat(ProcessorPtr output);
     /// Get current OutputFormat.
@@ -87,7 +85,9 @@ public:
             size_t max_threads_limit = 0,
             Processors * collected_processors = nullptr);
 
-    void addDelayedPipeline(QueryPipeline);
+    /// Add other pipeline and execute it before current one.
+    /// Pipeline must have same header.
+    void addDelayingPipeline(QueryPipeline pipeline);
 
     PipelineExecutorPtr execute();
 

--- a/src/Processors/QueryPipeline.h
+++ b/src/Processors/QueryPipeline.h
@@ -91,7 +91,7 @@ public:
     /// Pipeline must have same header.
     void addDelayingPipeline(QueryPipeline pipeline);
 
-    void addCreatingSetsTransform(SubqueryForSet subquery_for_set, const SizeLimits & limits, const Context & context);
+    void addCreatingSetsTransform(const Block & res_header, SubqueryForSet subquery_for_set, const SizeLimits & limits, const Context & context);
 
     PipelineExecutorPtr execute();
 

--- a/src/Processors/QueryPipeline.h
+++ b/src/Processors/QueryPipeline.h
@@ -89,6 +89,8 @@ public:
     /// Pipeline must have same header.
     void addDelayingPipeline(QueryPipeline pipeline);
 
+    void addCreatingSetsTransform();
+
     PipelineExecutorPtr execute();
 
     size_t getNumStreams() const { return pipe.numOutputPorts(); }

--- a/src/Processors/QueryPipeline.h
+++ b/src/Processors/QueryPipeline.h
@@ -89,7 +89,7 @@ public:
 
     /// Add other pipeline and execute it before current one.
     /// Pipeline must have same header.
-    void addDelayingPipeline(QueryPipeline pipeline);
+    void addPipelineBefore(QueryPipeline pipeline);
 
     void addCreatingSetsTransform(const Block & res_header, SubqueryForSet subquery_for_set, const SizeLimits & limits, const Context & context);
 

--- a/src/Processors/QueryPlan/CreatingSetsStep.cpp
+++ b/src/Processors/QueryPlan/CreatingSetsStep.cpp
@@ -6,6 +6,11 @@
 namespace DB
 {
 
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
 static ITransformingStep::Traits getTraits()
 {
     return ITransformingStep::Traits

--- a/src/Processors/QueryPlan/CreatingSetsStep.cpp
+++ b/src/Processors/QueryPlan/CreatingSetsStep.cpp
@@ -39,7 +39,7 @@ CreatingSetStep::CreatingSetStep(
 
 void CreatingSetStep::transformPipeline(QueryPipeline & pipeline)
 {
-    pipeline.addCreatingSetsTransform(std::move(subquery_for_set), network_transfer_limits, context);
+    pipeline.addCreatingSetsTransform(getOutputStream().header, std::move(subquery_for_set), network_transfer_limits, context);
 }
 
 void CreatingSetStep::describeActions(FormatSettings & settings) const

--- a/src/Processors/QueryPlan/CreatingSetsStep.cpp
+++ b/src/Processors/QueryPlan/CreatingSetsStep.cpp
@@ -39,14 +39,7 @@ CreatingSetStep::CreatingSetStep(
 
 void CreatingSetStep::transformPipeline(QueryPipeline & pipeline)
 {
-    pipeline.resize(1);
-    pipeline.addTransform(
-        std::make_shared<CreatingSetsTransform>(
-            pipeline.getHeader(),
-            getOutputStream().header,
-            std::move(subquery_for_set),
-            network_transfer_limits,
-            context));
+    pipeline.addCreatingSetsTransform();
 }
 
 void CreatingSetStep::describeActions(FormatSettings & settings) const

--- a/src/Processors/QueryPlan/CreatingSetsStep.cpp
+++ b/src/Processors/QueryPlan/CreatingSetsStep.cpp
@@ -39,7 +39,7 @@ CreatingSetStep::CreatingSetStep(
 
 void CreatingSetStep::transformPipeline(QueryPipeline & pipeline)
 {
-    pipeline.addCreatingSetsTransform();
+    pipeline.addCreatingSetsTransform(std::move(subquery_for_set), network_transfer_limits, context);
 }
 
 void CreatingSetStep::describeActions(FormatSettings & settings) const

--- a/src/Processors/QueryPlan/CreatingSetsStep.cpp
+++ b/src/Processors/QueryPlan/CreatingSetsStep.cpp
@@ -22,37 +22,91 @@ static ITransformingStep::Traits getTraits()
     };
 }
 
-CreatingSetsStep::CreatingSetsStep(
+CreatingSetStep::CreatingSetStep(
     const DataStream & input_stream_,
-    SubqueriesForSets subqueries_for_sets_,
+    Block header,
+    String description_,
+    SubqueryForSet subquery_for_set_,
     SizeLimits network_transfer_limits_,
     const Context & context_)
-    : ITransformingStep(input_stream_, input_stream_.header, getTraits())
-    , subqueries_for_sets(std::move(subqueries_for_sets_))
+    : ITransformingStep(input_stream_, header, getTraits())
+    , description(std::move(description_))
+    , subquery_for_set(std::move(subquery_for_set_))
     , network_transfer_limits(std::move(network_transfer_limits_))
     , context(context_)
 {
 }
 
-void CreatingSetsStep::transformPipeline(QueryPipeline & pipeline)
+void CreatingSetStep::transformPipeline(QueryPipeline & pipeline)
 {
-    pipeline.addCreatingSetsTransform(std::move(subqueries_for_sets), network_transfer_limits, context);
+    pipeline.resize(1);
+    pipeline.addTransform(
+        std::make_shared<CreatingSetsTransform>(
+            pipeline.getHeader(),
+            getOutputStream().header,
+            std::move(subquery_for_set),
+            network_transfer_limits,
+            context));
 }
 
-void CreatingSetsStep::describeActions(FormatSettings & settings) const
+void CreatingSetStep::describeActions(FormatSettings & settings) const
 {
     String prefix(settings.offset, ' ');
 
-    for (const auto & set : subqueries_for_sets)
-    {
-        settings.out << prefix;
-        if (set.second.set)
-            settings.out << "Set: ";
-        else if (set.second.join)
-            settings.out << "Join: ";
+    settings.out << prefix;
+    if (subquery_for_set.set)
+        settings.out << "Set: ";
+    else if (subquery_for_set.join)
+        settings.out << "Join: ";
 
-        settings.out << set.first << '\n';
+    settings.out << description << '\n';
+}
+
+CreatingSetsStep::CreatingSetsStep(DataStreams input_streams_)
+{
+    if (input_streams_.empty())
+        throw Exception("CreatingSetsStep cannot be created with no inputs", ErrorCodes::LOGICAL_ERROR);
+
+    input_streams = std::move(input_streams_);
+    output_stream = input_streams.front();
+
+    for (size_t i = 1; i < input_streams.size(); ++i)
+        assertBlocksHaveEqualStructure(output_stream->header, input_streams[i].header, "CreatingSets");
+}
+
+QueryPipelinePtr CreatingSetsStep::updatePipeline(QueryPipelines pipelines)
+{
+    if (pipelines.empty())
+        throw Exception("CreatingSetsStep cannot be created with no inputs", ErrorCodes::LOGICAL_ERROR);
+
+    auto main_pipeline = std::move(pipelines.front());
+    if (pipelines.size() == 1)
+        return main_pipeline;
+
+    std::swap(pipelines.front(), pipelines.back());
+    pipelines.pop_back();
+
+    QueryPipeline delayed_pipeline;
+    if (pipelines.size() > 1)
+    {
+        QueryPipelineProcessorsCollector collector(delayed_pipeline, this);
+        delayed_pipeline = QueryPipeline::unitePipelines(std::move(pipelines), output_stream->header);
+        processors = collector.detachProcessors();
     }
+    else
+        delayed_pipeline = std::move(*pipelines.front());
+
+    QueryPipelineProcessorsCollector collector(*main_pipeline, this);
+    main_pipeline->addDelayedPipeline(std::move(delayed_pipeline));
+    auto added_processors = collector.detachProcessors();
+    processors.insert(processors.end(), added_processors.begin(), added_processors.end());
+
+    return main_pipeline;
+}
+
+void CreatingSetsStep::describePipeline(FormatSettings & settings) const
+{
+    IQueryPlanStep::describePipeline(processors, settings);
 }
 
 }

--- a/src/Processors/QueryPlan/CreatingSetsStep.cpp
+++ b/src/Processors/QueryPlan/CreatingSetsStep.cpp
@@ -121,6 +121,9 @@ void addCreatingSetsStep(
 
     for (auto & [description, set] : subqueries_for_sets)
     {
+        if (!set.source)
+            continue;
+
         auto plan = std::move(set.source);
         std::string type = (set.join != nullptr) ? "JOIN"
                                                  : "subquery";
@@ -137,6 +140,12 @@ void addCreatingSetsStep(
 
         input_streams.emplace_back(plan->getCurrentDataStream());
         plans.emplace_back(std::move(plan));
+    }
+
+    if (plans.size() == 1)
+    {
+        query_plan = std::move(*plans.front());
+        return;
     }
 
     auto creating_sets = std::make_unique<CreatingSetsStep>(std::move(input_streams));

--- a/src/Processors/QueryPlan/CreatingSetsStep.cpp
+++ b/src/Processors/QueryPlan/CreatingSetsStep.cpp
@@ -95,7 +95,7 @@ QueryPipelinePtr CreatingSetsStep::updatePipeline(QueryPipelines pipelines)
         delayed_pipeline = std::move(*pipelines.front());
 
     QueryPipelineProcessorsCollector collector(*main_pipeline, this);
-    main_pipeline->addDelayingPipeline(std::move(delayed_pipeline));
+    main_pipeline->addPipelineBefore(std::move(delayed_pipeline));
     auto added_processors = collector.detachProcessors();
     processors.insert(processors.end(), added_processors.begin(), added_processors.end());
 

--- a/src/Processors/QueryPlan/CreatingSetsStep.h
+++ b/src/Processors/QueryPlan/CreatingSetsStep.h
@@ -7,12 +7,14 @@ namespace DB
 {
 
 /// Creates sets for subqueries and JOIN. See CreatingSetsTransform.
-class CreatingSetsStep : public ITransformingStep
+class CreatingSetStep : public ITransformingStep
 {
 public:
-    CreatingSetsStep(
+    CreatingSetStep(
             const DataStream & input_stream_,
-            SubqueriesForSets subqueries_for_sets_,
+            Block header,
+            String description_,
+            SubqueryForSet subquery_for_set_,
             SizeLimits network_transfer_limits_,
             const Context & context_);
 
@@ -23,9 +25,25 @@ public:
     void describeActions(FormatSettings & settings) const override;
 
 private:
-    SubqueriesForSets subqueries_for_sets;
+    String description;
+    SubqueryForSet subquery_for_set;
     SizeLimits network_transfer_limits;
     const Context & context;
+};
+
+class CreatingSetsStep : public IQueryPlanStep
+{
+public:
+    CreatingSetsStep(DataStreams input_streams_);
+
+    String getName() const override { return "CreatingSets"; }
+
+    QueryPipelinePtr updatePipeline(QueryPipelines pipelines) override;
+
+    void describePipeline(FormatSettings & settings) const override;
+
+private:
+    Processors processors;
 };
 
 }

--- a/src/Processors/QueryPlan/CreatingSetsStep.h
+++ b/src/Processors/QueryPlan/CreatingSetsStep.h
@@ -18,7 +18,7 @@ public:
             SizeLimits network_transfer_limits_,
             const Context & context_);
 
-    String getName() const override { return "CreatingSets"; }
+    String getName() const override { return "CreatingSet"; }
 
     void transformPipeline(QueryPipeline & pipeline) override;
 
@@ -45,5 +45,11 @@ public:
 private:
     Processors processors;
 };
+
+void addCreatingSetsStep(
+    QueryPlan & query_plan,
+    SubqueriesForSets subqueries_for_sets,
+    const SizeLimits & limits,
+    const Context & context);
 
 }

--- a/src/Processors/QueryPlan/QueryPlan.cpp
+++ b/src/Processors/QueryPlan/QueryPlan.cpp
@@ -26,6 +26,8 @@ namespace ErrorCodes
 
 QueryPlan::QueryPlan() = default;
 QueryPlan::~QueryPlan() = default;
+QueryPlan::QueryPlan(QueryPlan &&) = default;
+QueryPlan & QueryPlan::operator=(QueryPlan &&) = default;
 
 void QueryPlan::checkInitialized() const
 {
@@ -51,7 +53,7 @@ const DataStream & QueryPlan::getCurrentDataStream() const
     return root->step->getOutputStream();
 }
 
-void QueryPlan::unitePlans(QueryPlanStepPtr step, std::vector<QueryPlan> plans)
+void QueryPlan::unitePlans(QueryPlanStepPtr step, std::vector<std::unique_ptr<QueryPlan>> plans)
 {
     if (isInitialized())
         throw Exception("Cannot unite plans because current QueryPlan is already initialized",
@@ -70,7 +72,7 @@ void QueryPlan::unitePlans(QueryPlanStepPtr step, std::vector<QueryPlan> plans)
     for (size_t i = 0; i < num_inputs; ++i)
     {
         const auto & step_header = inputs[i].header;
-        const auto & plan_header = plans[i].getCurrentDataStream().header;
+        const auto & plan_header = plans[i]->getCurrentDataStream().header;
         if (!blocksHaveEqualStructure(step_header, plan_header))
             throw Exception("Cannot unite QueryPlans using " + step->getName() + " because "
                             "it has incompatible header with plan " + root->step->getName() + " "
@@ -79,19 +81,19 @@ void QueryPlan::unitePlans(QueryPlanStepPtr step, std::vector<QueryPlan> plans)
     }
 
     for (auto & plan : plans)
-        nodes.splice(nodes.end(), std::move(plan.nodes));
+        nodes.splice(nodes.end(), std::move(plan->nodes));
 
     nodes.emplace_back(Node{.step = std::move(step)});
     root = &nodes.back();
 
     for (auto & plan : plans)
-        root->children.emplace_back(plan.root);
+        root->children.emplace_back(plan->root);
 
     for (auto & plan : plans)
     {
-        max_threads = std::max(max_threads, plan.max_threads);
+        max_threads = std::max(max_threads, plan->max_threads);
         interpreter_context.insert(interpreter_context.end(),
-                                   plan.interpreter_context.begin(), plan.interpreter_context.end());
+                                   plan->interpreter_context.begin(), plan->interpreter_context.end());
     }
 }
 

--- a/src/Processors/QueryPlan/QueryPlan.h
+++ b/src/Processors/QueryPlan/QueryPlan.h
@@ -25,8 +25,10 @@ class QueryPlan
 public:
     QueryPlan();
     ~QueryPlan();
+    QueryPlan(QueryPlan &&);
+    QueryPlan & operator=(QueryPlan &&);
 
-    void unitePlans(QueryPlanStepPtr step, std::vector<QueryPlan> plans);
+    void unitePlans(QueryPlanStepPtr step, std::vector<std::unique_ptr<QueryPlan>> plans);
     void addStep(QueryPlanStepPtr step);
 
     bool isInitialized() const { return root != nullptr; } /// Tree is not empty

--- a/src/Processors/QueryPlan/ReadFromPreparedSource.cpp
+++ b/src/Processors/QueryPlan/ReadFromPreparedSource.cpp
@@ -14,7 +14,8 @@ ReadFromPreparedSource::ReadFromPreparedSource(Pipe pipe_, std::shared_ptr<Conte
 void ReadFromPreparedSource::initializePipeline(QueryPipeline & pipeline)
 {
     pipeline.init(std::move(pipe));
-    pipeline.addInterpreterContext(std::move(context));
+    if (context)
+        pipeline.addInterpreterContext(std::move(context));
 }
 
 }

--- a/src/Processors/QueryPlan/ReadFromPreparedSource.h
+++ b/src/Processors/QueryPlan/ReadFromPreparedSource.h
@@ -9,7 +9,7 @@ namespace DB
 class ReadFromPreparedSource : public ISourceStep
 {
 public:
-    explicit ReadFromPreparedSource(Pipe pipe_, std::shared_ptr<Context> context_);
+    explicit ReadFromPreparedSource(Pipe pipe_, std::shared_ptr<Context> context_ = nullptr);
 
     String getName() const override { return "ReadNothing"; }
 

--- a/src/Processors/Transforms/JoiningTransform.h
+++ b/src/Processors/Transforms/JoiningTransform.h
@@ -14,7 +14,7 @@ public:
     JoiningTransform(Block input_header, JoinPtr join_,
                      bool on_totals_ = false, bool default_totals_ = false);
 
-    String getName() const override { return "InflatingExpressionTransform"; }
+    String getName() const override { return "JoiningTransform"; }
 
     static Block transformHeader(Block header, const JoinPtr & join);
 

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -53,6 +53,9 @@ class QueryPlan;
 class StoragePolicy;
 using StoragePolicyPtr = std::shared_ptr<const StoragePolicy>;
 
+struct StreamLocalLimits;
+class EnabledQuota;
+
 struct ColumnSize
 {
     size_t marks = 0;

--- a/tests/queries/0_stateless/00853_join_with_nulls_crash.sql
+++ b/tests/queries/0_stateless/00853_join_with_nulls_crash.sql
@@ -21,14 +21,14 @@ SELECT s1.other, s2.other, count_a, count_b, toTypeName(s1.other), toTypeName(s2
 ALL FULL JOIN
     ( SELECT other, count() AS count_b FROM table_b GROUP BY other ) s2
 ON s1.other = s2.other
-ORDER BY s2.other DESC;
+ORDER BY s2.other DESC, count_a;
 
 SELECT s1.other, s2.other, count_a, count_b, toTypeName(s1.other), toTypeName(s2.other) FROM
     ( SELECT other, count() AS count_a FROM table_a GROUP BY other ) s1
 ALL FULL JOIN
     ( SELECT other, count() AS count_b FROM table_b GROUP BY other ) s2
 USING other
-ORDER BY s2.other DESC;
+ORDER BY s2.other DESC, count_a;
 
 SELECT s1.something, s2.something, count_a, count_b, toTypeName(s1.something), toTypeName(s2.something) FROM
     ( SELECT something, count() AS count_a FROM table_a GROUP BY something ) s1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Show subqueries for `SET` and `JOIN` in `EXPLAIN` result.

Subqueries for set and join now use `QueryPlan` step as source. It also may be helpful for query optimisations.