### PR TITLE
Format and cleanup imports form all *.py integration test files

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,5 +1,6 @@
 from helpers.test_tools import TSV
 
+
 def pytest_assertrepr_compare(op, left, right):
     if isinstance(left, TSV) and isinstance(right, TSV) and op == '==':
         return ['TabSeparated values differ: '] + left.diff(right)

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -1,30 +1,31 @@
 import base64
-import cassandra.cluster
-import docker
 import errno
 import httplib
 import logging
 import os
 import os.path as p
 import pprint
-import psycopg2
 import pwd
-import pymongo
-import pymysql
 import re
-import requests
 import shutil
 import socket
 import subprocess
 import time
-import urllib
 import traceback
+import urllib
+
+import cassandra.cluster
+import docker
+import psycopg2
+import pymongo
+import pymysql
+import requests
 import xml.dom.minidom
+from confluent.schemaregistry.client import CachedSchemaRegistryClient
 from dicttoxml import dicttoxml
 from kazoo.client import KazooClient
 from kazoo.exceptions import KazooException
 from minio import Minio
-from confluent.schemaregistry.client import CachedSchemaRegistryClient
 
 from .client import Client
 from .hdfs_api import HDFSApi
@@ -67,13 +68,14 @@ def get_odbc_bridge_path():
             return '/usr/bin/clickhouse-odbc-bridge'
     return path
 
+
 def get_docker_compose_path():
     compose_path = os.environ.get('DOCKER_COMPOSE_DIR')
     if compose_path is not None:
         return os.path.dirname(compose_path)
     else:
         if os.path.exists(os.path.dirname('/compose/')):
-            return os.path.dirname('/compose/') #default in docker runner container
+            return os.path.dirname('/compose/')  # default in docker runner container
         else:
             print("Fallback docker_compose_path to LOCAL_DOCKER_COMPOSE_DIR: {}".format(LOCAL_DOCKER_COMPOSE_DIR))
             return LOCAL_DOCKER_COMPOSE_DIR
@@ -91,12 +93,12 @@ class ClickHouseCluster:
     def __init__(self, base_path, name=None, base_config_dir=None, server_bin_path=None, client_bin_path=None,
                  odbc_bridge_bin_path=None, zookeeper_config_path=None, custom_dockerd_host=None):
         for param in os.environ.keys():
-            print "ENV %40s %s" % (param,os.environ[param])
+            print "ENV %40s %s" % (param, os.environ[param])
         self.base_dir = p.dirname(base_path)
         self.name = name if name is not None else ''
 
         self.base_config_dir = base_config_dir or os.environ.get('CLICKHOUSE_TESTS_BASE_CONFIG_DIR',
-                                                                   '/etc/clickhouse-server/')
+                                                                 '/etc/clickhouse-server/')
         self.server_bin_path = p.realpath(
             server_bin_path or os.environ.get('CLICKHOUSE_TESTS_SERVER_BIN_PATH', '/usr/bin/clickhouse'))
         self.odbc_bridge_bin_path = p.realpath(odbc_bridge_bin_path or get_odbc_bridge_path())
@@ -165,8 +167,10 @@ class ClickHouseCluster:
             cmd += " client"
         return cmd
 
-    def add_instance(self, name, base_config_dir=None, main_configs=None, user_configs=None, dictionaries = None, macros=None,
-                     with_zookeeper=False, with_mysql=False, with_kafka=False, with_rabbitmq=False, clickhouse_path_dir=None,
+    def add_instance(self, name, base_config_dir=None, main_configs=None, user_configs=None, dictionaries=None,
+                     macros=None,
+                     with_zookeeper=False, with_mysql=False, with_kafka=False, with_rabbitmq=False,
+                     clickhouse_path_dir=None,
                      with_odbc_drivers=False, with_postgres=False, with_hdfs=False, with_mongo=False,
                      with_redis=False, with_minio=False, with_cassandra=False,
                      hostname=None, env_variables=None, image="yandex/clickhouse-integration-test", tag=None,
@@ -247,7 +251,8 @@ class ClickHouseCluster:
             self.with_mysql = True
             self.base_cmd.extend(['--file', p.join(docker_compose_yml_dir, 'docker_compose_mysql.yml')])
             self.base_mysql_cmd = ['docker-compose', '--project-directory', self.base_dir, '--project-name',
-                                   self.project_name, '--file', p.join(docker_compose_yml_dir, 'docker_compose_mysql.yml')]
+                                   self.project_name, '--file',
+                                   p.join(docker_compose_yml_dir, 'docker_compose_mysql.yml')]
 
             cmds.append(self.base_mysql_cmd)
 
@@ -255,7 +260,8 @@ class ClickHouseCluster:
             self.with_postgres = True
             self.base_cmd.extend(['--file', p.join(docker_compose_yml_dir, 'docker_compose_postgres.yml')])
             self.base_postgres_cmd = ['docker-compose', '--project-directory', self.base_dir, '--project-name',
-                                      self.project_name, '--file', p.join(docker_compose_yml_dir, 'docker_compose_postgres.yml')]
+                                      self.project_name, '--file',
+                                      p.join(docker_compose_yml_dir, 'docker_compose_postgres.yml')]
             cmds.append(self.base_postgres_cmd)
 
         if with_odbc_drivers and not self.with_odbc_drivers:
@@ -264,7 +270,8 @@ class ClickHouseCluster:
                 self.with_mysql = True
                 self.base_cmd.extend(['--file', p.join(docker_compose_yml_dir, 'docker_compose_mysql.yml')])
                 self.base_mysql_cmd = ['docker-compose', '--project-directory', self.base_dir, '--project-name',
-                                       self.project_name, '--file', p.join(docker_compose_yml_dir, 'docker_compose_mysql.yml')]
+                                       self.project_name, '--file',
+                                       p.join(docker_compose_yml_dir, 'docker_compose_mysql.yml')]
                 cmds.append(self.base_mysql_cmd)
 
             if not self.with_postgres:
@@ -279,28 +286,32 @@ class ClickHouseCluster:
             self.with_kafka = True
             self.base_cmd.extend(['--file', p.join(docker_compose_yml_dir, 'docker_compose_kafka.yml')])
             self.base_kafka_cmd = ['docker-compose', '--project-directory', self.base_dir, '--project-name',
-                                   self.project_name, '--file', p.join(docker_compose_yml_dir, 'docker_compose_kafka.yml')]
+                                   self.project_name, '--file',
+                                   p.join(docker_compose_yml_dir, 'docker_compose_kafka.yml')]
             cmds.append(self.base_kafka_cmd)
 
         if with_rabbitmq and not self.with_rabbitmq:
             self.with_rabbitmq = True
             self.base_cmd.extend(['--file', p.join(docker_compose_yml_dir, 'docker_compose_rabbitmq.yml')])
             self.base_rabbitmq_cmd = ['docker-compose', '--project-directory', self.base_dir, '--project-name',
-                                      self.project_name, '--file', p.join(docker_compose_yml_dir, 'docker_compose_rabbitmq.yml')]
+                                      self.project_name, '--file',
+                                      p.join(docker_compose_yml_dir, 'docker_compose_rabbitmq.yml')]
             cmds.append(self.base_rabbitmq_cmd)
 
         if with_hdfs and not self.with_hdfs:
             self.with_hdfs = True
             self.base_cmd.extend(['--file', p.join(docker_compose_yml_dir, 'docker_compose_hdfs.yml')])
             self.base_hdfs_cmd = ['docker-compose', '--project-directory', self.base_dir, '--project-name',
-                                  self.project_name, '--file', p.join(docker_compose_yml_dir, 'docker_compose_hdfs.yml')]
+                                  self.project_name, '--file',
+                                  p.join(docker_compose_yml_dir, 'docker_compose_hdfs.yml')]
             cmds.append(self.base_hdfs_cmd)
 
         if with_mongo and not self.with_mongo:
             self.with_mongo = True
             self.base_cmd.extend(['--file', p.join(docker_compose_yml_dir, 'docker_compose_mongo.yml')])
             self.base_mongo_cmd = ['docker-compose', '--project-directory', self.base_dir, '--project-name',
-                                   self.project_name, '--file', p.join(docker_compose_yml_dir, 'docker_compose_mongo.yml')]
+                                   self.project_name, '--file',
+                                   p.join(docker_compose_yml_dir, 'docker_compose_mongo.yml')]
             cmds.append(self.base_mongo_cmd)
 
         if self.with_net_trics:
@@ -311,21 +322,24 @@ class ClickHouseCluster:
             self.with_redis = True
             self.base_cmd.extend(['--file', p.join(docker_compose_yml_dir, 'docker_compose_redis.yml')])
             self.base_redis_cmd = ['docker-compose', '--project-directory', self.base_dir, '--project-name',
-                                   self.project_name, '--file', p.join(docker_compose_yml_dir, 'docker_compose_redis.yml')]
+                                   self.project_name, '--file',
+                                   p.join(docker_compose_yml_dir, 'docker_compose_redis.yml')]
 
         if with_minio and not self.with_minio:
             self.with_minio = True
             self.minio_certs_dir = minio_certs_dir
             self.base_cmd.extend(['--file', p.join(docker_compose_yml_dir, 'docker_compose_minio.yml')])
             self.base_minio_cmd = ['docker-compose', '--project-directory', self.base_dir, '--project-name',
-                                   self.project_name, '--file', p.join(docker_compose_yml_dir, 'docker_compose_minio.yml')]
+                                   self.project_name, '--file',
+                                   p.join(docker_compose_yml_dir, 'docker_compose_minio.yml')]
             cmds.append(self.base_minio_cmd)
 
         if with_cassandra and not self.with_cassandra:
             self.with_cassandra = True
             self.base_cmd.extend(['--file', p.join(docker_compose_yml_dir, 'docker_compose_cassandra.yml')])
             self.base_cassandra_cmd = ['docker-compose', '--project-directory', self.base_dir, '--project-name',
-                                       self.project_name, '--file', p.join(docker_compose_yml_dir, 'docker_compose_cassandra.yml')]
+                                       self.project_name, '--file',
+                                       p.join(docker_compose_yml_dir, 'docker_compose_cassandra.yml')]
 
         return instance
 
@@ -390,7 +404,8 @@ class ClickHouseCluster:
             print("Container {} uses image {}: ".format(container_id, image_id))
             pprint.pprint(image_info)
             print("")
-            message = 'Cmd "{}" failed in container {}. Return code {}. Output: {}'.format(' '.join(cmd), container_id, exit_code, output)
+            message = 'Cmd "{}" failed in container {}. Return code {}. Output: {}'.format(' '.join(cmd), container_id,
+                                                                                           exit_code, output)
             if nothrow:
                 print(message)
             else:
@@ -401,7 +416,8 @@ class ClickHouseCluster:
         with open(local_path, 'r') as fdata:
             data = fdata.read()
             encoded_data = base64.b64encode(data)
-            self.exec_in_container(container_id, ["bash", "-c", "echo {} | base64 --decode > {}".format(encoded_data, dest_path)],
+            self.exec_in_container(container_id,
+                                   ["bash", "-c", "echo {} | base64 --decode > {}".format(encoded_data, dest_path)],
                                    user='root')
 
     def wait_mysql_to_start(self, timeout=60):
@@ -650,7 +666,6 @@ class ClickHouseCluster:
             subprocess_check_call(clickhouse_start_cmd)
             print("ClickHouse instance created")
 
-
             start_deadline = time.time() + 20.0  # seconds
             for instance in self.instances.itervalues():
                 instance.docker_client = self.docker_client
@@ -692,7 +707,7 @@ class ClickHouseCluster:
         try:
             subprocess_check_call(self.base_cmd + ['down', '--volumes', '--remove-orphans'])
         except Exception as e:
-                print "Down + remove orphans failed durung shutdown. {}".format(repr(e))
+            print "Down + remove orphans failed durung shutdown. {}".format(repr(e))
 
         self.is_up = False
 
@@ -704,23 +719,26 @@ class ClickHouseCluster:
             instance.client = None
 
         if not self.zookeeper_use_tmpfs:
-             for i in range(1, 4):
-                 zk_data_path = self.instances_dir + '/zkdata' + str(i)
-                 zk_log_data_path = self.instances_dir + '/zklog' + str(i)
-                 if os.path.exists(zk_data_path):
-                     shutil.rmtree(zk_data_path)
-                 if os.path.exists(zk_log_data_path):
-                     shutil.rmtree(zk_log_data_path)
+            for i in range(1, 4):
+                zk_data_path = self.instances_dir + '/zkdata' + str(i)
+                zk_log_data_path = self.instances_dir + '/zklog' + str(i)
+                if os.path.exists(zk_data_path):
+                    shutil.rmtree(zk_data_path)
+                if os.path.exists(zk_log_data_path):
+                    shutil.rmtree(zk_log_data_path)
 
         if sanitizer_assert_instance is not None:
-            raise Exception("Sanitizer assert found in {} for instance {}".format(self.docker_logs_path, sanitizer_assert_instance))
+            raise Exception(
+                "Sanitizer assert found in {} for instance {}".format(self.docker_logs_path, sanitizer_assert_instance))
 
     def pause_container(self, instance_name):
         subprocess_check_call(self.base_cmd + ['pause', instance_name])
+
     #    subprocess_check_call(self.base_cmd + ['kill', '-s SIGSTOP', instance_name])
 
     def unpause_container(self, instance_name):
         subprocess_check_call(self.base_cmd + ['unpause', instance_name])
+
     #    subprocess_check_call(self.base_cmd + ['kill', '-s SIGCONT', instance_name])
 
     def open_bash_shell(self, instance_name):
@@ -790,9 +808,12 @@ services:
 class ClickHouseInstance:
 
     def __init__(
-            self, cluster, base_path, name, base_config_dir, custom_main_configs, custom_user_configs, custom_dictionaries,
-            macros, with_zookeeper, zookeeper_config_path, with_mysql, with_kafka, with_rabbitmq, with_mongo, with_redis, with_minio,
-            with_cassandra, server_bin_path, odbc_bridge_bin_path, clickhouse_path_dir, with_odbc_drivers, hostname=None, env_variables=None,
+            self, cluster, base_path, name, base_config_dir, custom_main_configs, custom_user_configs,
+            custom_dictionaries,
+            macros, with_zookeeper, zookeeper_config_path, with_mysql, with_kafka, with_rabbitmq, with_mongo,
+            with_redis, with_minio,
+            with_cassandra, server_bin_path, odbc_bridge_bin_path, clickhouse_path_dir, with_odbc_drivers,
+            hostname=None, env_variables=None,
             image="yandex/clickhouse-integration-test", tag="latest",
             stay_alive=False, ipv4_address=None, ipv6_address=None, with_installed_binary=False, tmpfs=None):
 
@@ -848,15 +869,19 @@ class ClickHouseInstance:
         return "-fsanitize=thread" in build_opts
 
     # Connects to the instance via clickhouse-client, sends a query (1st argument) and returns the answer
-    def query(self, sql, stdin=None, timeout=None, settings=None, user=None, password=None, database=None, ignore_error=False):
-        return self.client.query(sql, stdin=stdin, timeout=timeout, settings=settings, user=user, password=password, database=database, ignore_error=ignore_error)
+    def query(self, sql, stdin=None, timeout=None, settings=None, user=None, password=None, database=None,
+              ignore_error=False):
+        return self.client.query(sql, stdin=stdin, timeout=timeout, settings=settings, user=user, password=password,
+                                 database=database, ignore_error=ignore_error)
 
-    def query_with_retry(self, sql, stdin=None, timeout=None, settings=None, user=None, password=None, database=None, ignore_error=False,
+    def query_with_retry(self, sql, stdin=None, timeout=None, settings=None, user=None, password=None, database=None,
+                         ignore_error=False,
                          retry_count=20, sleep_time=0.5, check_callback=lambda x: True):
         result = None
         for i in range(retry_count):
             try:
-                result = self.query(sql, stdin=stdin, timeout=timeout, settings=settings, user=user, password=password, database=database, ignore_error=ignore_error)
+                result = self.query(sql, stdin=stdin, timeout=timeout, settings=settings, user=user, password=password,
+                                    database=database, ignore_error=ignore_error)
                 if check_callback(result):
                     return result
                 time.sleep(sleep_time)
@@ -873,12 +898,16 @@ class ClickHouseInstance:
         return self.client.get_query_request(*args, **kwargs)
 
     # Connects to the instance via clickhouse-client, sends a query (1st argument), expects an error and return its code
-    def query_and_get_error(self, sql, stdin=None, timeout=None, settings=None, user=None, password=None, database=None):
-        return self.client.query_and_get_error(sql, stdin=stdin, timeout=timeout, settings=settings, user=user, password=password, database=database)
+    def query_and_get_error(self, sql, stdin=None, timeout=None, settings=None, user=None, password=None,
+                            database=None):
+        return self.client.query_and_get_error(sql, stdin=stdin, timeout=timeout, settings=settings, user=user,
+                                               password=password, database=database)
 
     # The same as query_and_get_error but ignores successful query.
-    def query_and_get_answer_with_error(self, sql, stdin=None, timeout=None, settings=None, user=None, password=None, database=None):
-        return self.client.query_and_get_answer_with_error(sql, stdin=stdin, timeout=timeout, settings=settings, user=user, password=password, database=database)
+    def query_and_get_answer_with_error(self, sql, stdin=None, timeout=None, settings=None, user=None, password=None,
+                                        database=None):
+        return self.client.query_and_get_answer_with_error(sql, stdin=stdin, timeout=timeout, settings=settings,
+                                                           user=user, password=password, database=database)
 
     # Connects to the instance via HTTP interface, sends a query and returns the answer
     def http_query(self, sql, data=None, params=None, user=None, password=None, expect_fail_and_get_error=False):
@@ -900,7 +929,8 @@ class ClickHouseInstance:
         open_result = urllib.urlopen(url, data)
 
         def http_code_and_message():
-            return str(open_result.getcode()) + " " + httplib.responses[open_result.getcode()] + ": " + open_result.read()
+            return str(open_result.getcode()) + " " + httplib.responses[
+                open_result.getcode()] + ": " + open_result.read()
 
         if expect_fail_and_get_error:
             if open_result.getcode() == 200:
@@ -913,18 +943,19 @@ class ClickHouseInstance:
 
     # Connects to the instance via HTTP interface, sends a query and returns the answer
     def http_request(self, url, method='GET', params=None, data=None, headers=None):
-        url = "http://" + self.ip_address + ":8123/"+url
+        url = "http://" + self.ip_address + ":8123/" + url
         return requests.request(method=method, url=url, params=params, data=data, headers=headers)
 
     # Connects to the instance via HTTP interface, sends a query, expects an error and return the error message
     def http_query_and_get_error(self, sql, data=None, params=None, user=None, password=None):
-        return self.http_query(sql=sql, data=data, params=params, user=user, password=password, expect_fail_and_get_error=True)
+        return self.http_query(sql=sql, data=data, params=params, user=user, password=password,
+                               expect_fail_and_get_error=True)
 
     def kill_clickhouse(self, stop_start_wait_sec=5):
         pid = self.get_process_pid("clickhouse")
         if not pid:
             raise Exception("No clickhouse found")
-        self.exec_in_container(["bash",  "-c", "kill -9 {}".format(pid)], user='root')
+        self.exec_in_container(["bash", "-c", "kill -9 {}".format(pid)], user='root')
         time.sleep(stop_start_wait_sec)
 
     def restore_clickhouse(self, retries=100):
@@ -1030,7 +1061,8 @@ class ClickHouseInstance:
             time_left = deadline - current_time
             if deadline is not None and current_time >= deadline:
                 raise Exception("Timed out while waiting for instance `{}' with ip address {} to start. "
-                                "Container status: {}, logs: {}".format(self.name, self.ip_address, status, handle.logs()))
+                                "Container status: {}, logs: {}".format(self.name, self.ip_address, status,
+                                                                        handle.logs()))
 
             # Repeatedly poll the instance address until there is something that listens there.
             # Usually it means that ClickHouse is ready to accept queries.

--- a/tests/integration/helpers/dictionary.py
+++ b/tests/integration/helpers/dictionary.py
@@ -59,7 +59,8 @@ class Row(object):
 
 
 class Field(object):
-    def __init__(self, name, field_type, is_key=False, is_range_key=False, default=None, hierarchical=False, range_hash_type=None, default_value_for_get=None):
+    def __init__(self, name, field_type, is_key=False, is_range_key=False, default=None, hierarchical=False,
+                 range_hash_type=None, default_value_for_get=None):
         self.name = name
         self.field_type = field_type
         self.is_key = is_key
@@ -123,7 +124,8 @@ class DictionaryStructure(object):
                 self.range_key = field
 
         if not self.layout.is_complex and len(self.keys) > 1:
-            raise Exception("More than one key {} field in non complex layout {}".format(len(self.keys), self.layout.name))
+            raise Exception(
+                "More than one key {} field in non complex layout {}".format(len(self.keys), self.layout.name))
 
         if self.layout.is_ranged and (not self.range_key or len(self.range_fields) != 2):
             raise Exception("Inconsistent configuration of ranged dictionary")
@@ -213,7 +215,8 @@ class DictionaryStructure(object):
         if or_default:
             or_default_expr = 'OrDefault'
             if field.default_value_for_get is None:
-                raise Exception("Can create 'dictGetOrDefault' query for field {} without default_value_for_get".format(field.name))
+                raise Exception(
+                    "Can create 'dictGetOrDefault' query for field {} without default_value_for_get".format(field.name))
 
             val = field.default_value_for_get
             if isinstance(val, str):
@@ -259,15 +262,16 @@ class DictionaryStructure(object):
     def get_get_or_default_expressions(self, dict_name, field, row):
         if not self.layout.is_ranged:
             return [
-                self._get_dict_get_common_expression(dict_name, field, row, or_default=True, with_type=False, has=False),
+                self._get_dict_get_common_expression(dict_name, field, row, or_default=True, with_type=False,
+                                                     has=False),
                 self._get_dict_get_common_expression(dict_name, field, row, or_default=True, with_type=True, has=False),
             ]
         return []
 
-
     def get_has_expressions(self, dict_name, field, row):
         if not self.layout.is_ranged:
-            return [self._get_dict_get_common_expression(dict_name, field, row, or_default=False, with_type=False, has=True)]
+            return [self._get_dict_get_common_expression(dict_name, field, row, or_default=False, with_type=False,
+                                                         has=True)]
         return []
 
     def get_hierarchical_expressions(self, dict_name, row):
@@ -290,7 +294,7 @@ class DictionaryStructure(object):
                 "dictIsIn('{dict_name}', {child_key}, {parent_key})".format(
                     dict_name=dict_name,
                     child_key=child_key_expr,
-                    parent_key=parent_key_expr,)
+                    parent_key=parent_key_expr, )
             ]
 
         return []
@@ -364,7 +368,8 @@ class Dictionary(object):
         return ['select {}'.format(expr) for expr in self.structure.get_get_expressions(self.name, field, row)]
 
     def get_select_get_or_default_queries(self, field, row):
-        return ['select {}'.format(expr) for expr in self.structure.get_get_or_default_expressions(self.name, field, row)]
+        return ['select {}'.format(expr) for expr in
+                self.structure.get_get_or_default_expressions(self.name, field, row)]
 
     def get_select_has_queries(self, field, row):
         return ['select {}'.format(expr) for expr in self.structure.get_has_expressions(self.name, field, row)]

--- a/tests/integration/helpers/http_server.py
+++ b/tests/integration/helpers/http_server.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import argparse
-from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+import csv
 import socket
 import ssl
-import csv
+from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 
 
 # Decorator used to see if authentication works for external dictionary who use a HTTP source.
@@ -15,6 +15,7 @@ def check_auth(fn):
             req.send_response(401)
         else:
             fn(req)
+
     return wrapper
 
 
@@ -37,7 +38,7 @@ def start_server(server_address, data_path, schema, cert_path, address_family):
             self.send_header('Content-type', 'text/tsv')
             self.end_headers()
 
-        def __send_data(self, only_ids = None):
+        def __send_data(self, only_ids=None):
             with open(data_path, 'r') as fl:
                 reader = csv.reader(fl, delimiter='\t')
                 for row in reader:

--- a/tests/integration/helpers/network.py
+++ b/tests/integration/helpers/network.py
@@ -1,11 +1,8 @@
-import os.path as p
+import os
 import subprocess
 import time
-import os
 
 import docker
-
-from .cluster import CLICKHOUSE_ROOT_DIR
 
 
 class PartitionManager:
@@ -23,20 +20,17 @@ class PartitionManager:
     def __init__(self):
         self._iptables_rules = []
 
-
     def drop_instance_zk_connections(self, instance, action='DROP'):
         self._check_instance(instance)
 
         self._add_rule({'source': instance.ip_address, 'destination_port': 2181, 'action': action})
         self._add_rule({'destination': instance.ip_address, 'source_port': 2181, 'action': action})
 
-
     def restore_instance_zk_connections(self, instance, action='DROP'):
         self._check_instance(instance)
 
         self._delete_rule({'source': instance.ip_address, 'destination_port': 2181, 'action': action})
         self._delete_rule({'destination': instance.ip_address, 'source_port': 2181, 'action': action})
-
 
     def partition_instances(self, left, right, port=None, action='DROP'):
         self._check_instance(left)
@@ -51,7 +45,6 @@ class PartitionManager:
         self._add_rule(create_rule(left, right))
         self._add_rule(create_rule(right, left))
 
-
     def heal_all(self):
         while self._iptables_rules:
             rule = self._iptables_rules.pop()
@@ -65,7 +58,6 @@ class PartitionManager:
     def push_rules(self, rules):
         for rule in rules:
             self._add_rule(rule)
-
 
     @staticmethod
     def _check_instance(instance):
@@ -152,7 +144,6 @@ class _NetworkManager:
             ret.extend(['-j'] + action.split())
         return ret
 
-
     def __init__(
             self,
             container_expire_timeout=50, container_exit_timeout=60):
@@ -175,7 +166,8 @@ class _NetworkManager:
                 except docker.errors.NotFound:
                     pass
 
-            self._container = self._docker_client.containers.run('yandex/clickhouse-integration-helper', auto_remove=True,
+            self._container = self._docker_client.containers.run('yandex/clickhouse-integration-helper',
+                                                                 auto_remove=True,
                                                                  command=('sleep %s' % self.container_exit_timeout),
                                                                  detach=True, network_mode='host')
             container_id = self._container.id

--- a/tests/integration/helpers/test_tools.py
+++ b/tests/integration/helpers/test_tools.py
@@ -1,6 +1,7 @@
 import difflib
 import time
 
+
 class TSV:
     """Helper to get pretty diffs between expected and actual tab-separated value files"""
 
@@ -40,17 +41,22 @@ class TSV:
     def toMat(contents):
         return [line.split("\t") for line in contents.split("\n") if line.strip()]
 
-def assert_eq_with_retry(instance, query, expectation, retry_count=20, sleep_time=0.5, stdin=None, timeout=None, settings=None, user=None, ignore_error=False):
+
+def assert_eq_with_retry(instance, query, expectation, retry_count=20, sleep_time=0.5, stdin=None, timeout=None,
+                         settings=None, user=None, ignore_error=False):
     expectation_tsv = TSV(expectation)
     for i in xrange(retry_count):
         try:
-            if TSV(instance.query(query, user=user, stdin=stdin, timeout=timeout, settings=settings, ignore_error=ignore_error)) == expectation_tsv:
+            if TSV(instance.query(query, user=user, stdin=stdin, timeout=timeout, settings=settings,
+                                  ignore_error=ignore_error)) == expectation_tsv:
                 break
             time.sleep(sleep_time)
         except Exception as ex:
             print "assert_eq_with_retry retry {} exception {}".format(i + 1, ex)
             time.sleep(sleep_time)
     else:
-        val = TSV(instance.query(query, user=user, stdin=stdin, timeout=timeout, settings=settings, ignore_error=ignore_error))
+        val = TSV(instance.query(query, user=user, stdin=stdin, timeout=timeout, settings=settings,
+                                 ignore_error=ignore_error))
         if expectation_tsv != val:
-            raise AssertionError("'{}' != '{}'\n{}".format(expectation_tsv, val, '\n'.join(expectation_tsv.diff(val, n1="expectation", n2="query"))))
+            raise AssertionError("'{}' != '{}'\n{}".format(expectation_tsv, val, '\n'.join(
+                expectation_tsv.diff(val, n1="expectation", n2="query"))))

--- a/tests/integration/helpers/uclient.py
+++ b/tests/integration/helpers/uclient.py
@@ -11,9 +11,10 @@ import uexpect
 prompt = ':\) '
 end_of_block = r'.*\r\n.*\r\n'
 
+
 class client(object):
     def __init__(self, command=None, name='', log=None):
-        self.client = uexpect.spawn(['/bin/bash','--noediting'])
+        self.client = uexpect.spawn(['/bin/bash', '--noediting'])
         if command is None:
             command = '/usr/bin/clickhouse-client'
         self.client.command = command

--- a/tests/integration/helpers/uexpect.py
+++ b/tests/integration/helpers/uexpect.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 import os
 import pty
-import time
-import sys
 import re
-
-from threading import Thread, Event
-from subprocess import Popen
+import time
 from Queue import Queue, Empty
+from subprocess import Popen
+from threading import Thread, Event
+
 
 class TimeoutError(Exception):
     def __init__(self, timeout):
@@ -27,6 +26,7 @@ class TimeoutError(Exception):
 
     def __str__(self):
         return 'Timeout %.3fs' % float(self.timeout)
+
 
 class ExpectTimeoutError(Exception):
     def __init__(self, pattern, timeout, buffer):
@@ -42,6 +42,7 @@ class ExpectTimeoutError(Exception):
             s += 'buffer %s ' % repr(self.buffer[:])
             s += 'or \'%s\'' % ','.join(['%x' % ord(c) for c in self.buffer[:]])
         return s
+
 
 class IO(object):
     class EOF(object):
@@ -59,7 +60,7 @@ class IO(object):
             self._prefix = prefix
 
         def write(self, data):
-            self._logger.write(('\n' + data).replace('\n','\n' + self._prefix))
+            self._logger.write(('\n' + data).replace('\n', '\n' + self._prefix))
 
         def flush(self):
             self._logger.flush()
@@ -165,7 +166,7 @@ class IO(object):
         data = ''
         timeleft = timeout
         try:
-            while timeleft >= 0 :
+            while timeleft >= 0:
                 start_time = time.time()
                 data += self.queue.get(timeout=timeleft)
                 if data:
@@ -182,6 +183,7 @@ class IO(object):
 
         return data
 
+
 def spawn(command):
     master, slave = pty.openpty()
     process = Popen(command, preexec_fn=os.setsid, stdout=slave, stdin=slave, stderr=slave, bufsize=1)
@@ -193,7 +195,8 @@ def spawn(command):
     thread.daemon = True
     thread.start()
 
-    return IO(process, master, queue, reader={'thread':thread, 'kill_event':reader_kill_event})
+    return IO(process, master, queue, reader={'thread': thread, 'kill_event': reader_kill_event})
+
 
 def reader(process, out, queue, kill_event):
     while True:

--- a/tests/integration/test_SYSTEM_FLUSH_LOGS/test.py
+++ b/tests/integration/test_SYSTEM_FLUSH_LOGS/test.py
@@ -24,6 +24,7 @@ system_logs = [
 # decrease timeout for the test to show possible issues.
 timeout = pytest.mark.timeout(30)
 
+
 @pytest.fixture(scope='module', autouse=True)
 def start_cluster():
     try:
@@ -32,9 +33,11 @@ def start_cluster():
     finally:
         cluster.shutdown()
 
+
 @pytest.fixture(scope='function')
 def flush_logs():
     node.query('SYSTEM FLUSH LOGS')
+
 
 @timeout
 @pytest.mark.parametrize('table,exists', system_logs)
@@ -44,6 +47,7 @@ def test_system_logs(flush_logs, table, exists):
         node.query(q)
     else:
         assert "Table {} doesn't exist".format(table) in node.query_and_get_error(q)
+
 
 # Logic is tricky, let's check that there is no hang in case of message queue
 # is not empty (this is another code path in the code).

--- a/tests/integration/test_access_control_on_cluster/test.py
+++ b/tests/integration/test_access_control_on_cluster/test.py
@@ -1,12 +1,11 @@
-import time
 import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.client import QueryRuntimeException
 
 cluster = ClickHouseCluster(__file__)
 ch1 = cluster.add_instance('ch1', main_configs=["configs/config.d/clusters.xml"], with_zookeeper=True)
 ch2 = cluster.add_instance('ch2', main_configs=["configs/config.d/clusters.xml"], with_zookeeper=True)
 ch3 = cluster.add_instance('ch3', main_configs=["configs/config.d/clusters.xml"], with_zookeeper=True)
+
 
 @pytest.fixture(scope="module", autouse=True)
 def started_cluster():

--- a/tests/integration/test_adaptive_granularity/test.py
+++ b/tests/integration/test_adaptive_granularity/test.py
@@ -1,31 +1,50 @@
 import time
+
 import pytest
-
-from helpers.cluster import ClickHouseCluster
-from multiprocessing.dummy import Pool
 from helpers.client import QueryRuntimeException, QueryTimeoutExceedException
-
+from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_eq_with_retry
 
-
 cluster = ClickHouseCluster(__file__)
-node1 = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml', 'configs/log_conf.xml'], with_zookeeper=True)
-node2 = cluster.add_instance('node2', main_configs=['configs/remote_servers.xml', 'configs/log_conf.xml'], with_zookeeper=True)
+node1 = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml', 'configs/log_conf.xml'],
+                             with_zookeeper=True)
+node2 = cluster.add_instance('node2', main_configs=['configs/remote_servers.xml', 'configs/log_conf.xml'],
+                             with_zookeeper=True)
 
-node3 = cluster.add_instance('node3', main_configs=['configs/remote_servers.xml', 'configs/log_conf.xml'], with_zookeeper=True, image='yandex/clickhouse-server', tag='19.6.3.18', with_installed_binary=True)
-node4 = cluster.add_instance('node4', main_configs=['configs/remote_servers.xml', 'configs/log_conf.xml'], with_zookeeper=True)
+node3 = cluster.add_instance('node3', main_configs=['configs/remote_servers.xml', 'configs/log_conf.xml'],
+                             with_zookeeper=True, image='yandex/clickhouse-server', tag='19.6.3.18',
+                             with_installed_binary=True)
+node4 = cluster.add_instance('node4', main_configs=['configs/remote_servers.xml', 'configs/log_conf.xml'],
+                             with_zookeeper=True)
 
-node5 = cluster.add_instance('node5', main_configs=['configs/remote_servers.xml', 'configs/log_conf.xml'], with_zookeeper=True, image='yandex/clickhouse-server', tag='19.1.15', with_installed_binary=True)
-node6 = cluster.add_instance('node6', main_configs=['configs/remote_servers.xml', 'configs/log_conf.xml'], with_zookeeper=True)
+node5 = cluster.add_instance('node5', main_configs=['configs/remote_servers.xml', 'configs/log_conf.xml'],
+                             with_zookeeper=True, image='yandex/clickhouse-server', tag='19.1.15',
+                             with_installed_binary=True)
+node6 = cluster.add_instance('node6', main_configs=['configs/remote_servers.xml', 'configs/log_conf.xml'],
+                             with_zookeeper=True)
 
-node7 = cluster.add_instance('node7', main_configs=['configs/remote_servers.xml', 'configs/log_conf.xml'], with_zookeeper=True, image='yandex/clickhouse-server', tag='19.6.3.18', stay_alive=True, with_installed_binary=True)
-node8 = cluster.add_instance('node8', main_configs=['configs/remote_servers.xml', 'configs/log_conf.xml'], with_zookeeper=True, image='yandex/clickhouse-server', tag='19.1.15', stay_alive=True, with_installed_binary=True)
+node7 = cluster.add_instance('node7', main_configs=['configs/remote_servers.xml', 'configs/log_conf.xml'],
+                             with_zookeeper=True, image='yandex/clickhouse-server', tag='19.6.3.18', stay_alive=True,
+                             with_installed_binary=True)
+node8 = cluster.add_instance('node8', main_configs=['configs/remote_servers.xml', 'configs/log_conf.xml'],
+                             with_zookeeper=True, image='yandex/clickhouse-server', tag='19.1.15', stay_alive=True,
+                             with_installed_binary=True)
 
-node9 = cluster.add_instance('node9', main_configs=['configs/remote_servers.xml', 'configs/log_conf.xml', 'configs/merge_tree_settings.xml'], with_zookeeper=True, image='yandex/clickhouse-server', tag='19.1.15', stay_alive=True, with_installed_binary=True)
-node10 = cluster.add_instance('node10', main_configs=['configs/remote_servers.xml', 'configs/log_conf.xml', 'configs/merge_tree_settings.xml'], with_zookeeper=True, image='yandex/clickhouse-server', tag='19.6.3.18', stay_alive=True, with_installed_binary=True)
+node9 = cluster.add_instance('node9', main_configs=['configs/remote_servers.xml', 'configs/log_conf.xml',
+                                                    'configs/merge_tree_settings.xml'], with_zookeeper=True,
+                             image='yandex/clickhouse-server', tag='19.1.15', stay_alive=True,
+                             with_installed_binary=True)
+node10 = cluster.add_instance('node10', main_configs=['configs/remote_servers.xml', 'configs/log_conf.xml',
+                                                      'configs/merge_tree_settings.xml'], with_zookeeper=True,
+                              image='yandex/clickhouse-server', tag='19.6.3.18', stay_alive=True,
+                              with_installed_binary=True)
 
-node11 = cluster.add_instance('node11', main_configs=['configs/remote_servers.xml', 'configs/log_conf.xml'], with_zookeeper=True, image='yandex/clickhouse-server', tag='19.1.15', stay_alive=True, with_installed_binary=True)
-node12 = cluster.add_instance('node12', main_configs=['configs/remote_servers.xml', 'configs/log_conf.xml'], with_zookeeper=True, image='yandex/clickhouse-server', tag='19.1.15', stay_alive=True, with_installed_binary=True)
+node11 = cluster.add_instance('node11', main_configs=['configs/remote_servers.xml', 'configs/log_conf.xml'],
+                              with_zookeeper=True, image='yandex/clickhouse-server', tag='19.1.15', stay_alive=True,
+                              with_installed_binary=True)
+node12 = cluster.add_instance('node12', main_configs=['configs/remote_servers.xml', 'configs/log_conf.xml'],
+                              with_zookeeper=True, image='yandex/clickhouse-server', tag='19.1.15', stay_alive=True,
+                              with_installed_binary=True)
 
 
 def prepare_single_pair_with_setting(first_node, second_node, group):
@@ -34,80 +53,80 @@ def prepare_single_pair_with_setting(first_node, second_node, group):
 
     # Two tables with adaptive granularity
     first_node.query(
-    '''
-        CREATE TABLE table_by_default(date Date, id UInt32, dummy UInt32)
-        ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{g}/table_by_default', '1')
-        PARTITION BY toYYYYMM(date)
-        ORDER BY id
-        SETTINGS index_granularity_bytes = 10485760
-    '''.format(g=group))
-
-    second_node.query(
-    '''
-        CREATE TABLE table_by_default(date Date, id UInt32, dummy UInt32)
-        ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{g}/table_by_default', '2')
-        PARTITION BY toYYYYMM(date)
-        ORDER BY id
-        SETTINGS index_granularity_bytes = 10485760
-    '''.format(g=group))
-
-    # Two tables with fixed granularity
-    first_node.query(
-    '''
-        CREATE TABLE table_with_fixed_granularity(date Date, id UInt32, dummy UInt32)
-        ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{g}/table_with_fixed_granularity', '1')
-        PARTITION BY toYYYYMM(date)
-        ORDER BY id
-        SETTINGS index_granularity_bytes = 0
-    '''.format(g=group))
-
-    second_node.query(
-    '''
-        CREATE TABLE table_with_fixed_granularity(date Date, id UInt32, dummy UInt32)
-        ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{g}/table_with_fixed_granularity', '2')
-        PARTITION BY toYYYYMM(date)
-        ORDER BY id
-        SETTINGS index_granularity_bytes = 0
-    '''.format(g=group))
-
-    # Two tables with different granularity
-    with pytest.raises(QueryRuntimeException):
-        first_node.query(
         '''
-            CREATE TABLE table_with_different_granularity(date Date, id UInt32, dummy UInt32)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{g}/table_with_different_granularity', '1')
+            CREATE TABLE table_by_default(date Date, id UInt32, dummy UInt32)
+            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{g}/table_by_default', '1')
             PARTITION BY toYYYYMM(date)
             ORDER BY id
             SETTINGS index_granularity_bytes = 10485760
         '''.format(g=group))
 
-        second_node.query(
+    second_node.query(
         '''
-            CREATE TABLE table_with_different_granularity(date Date, id UInt32, dummy UInt32)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{g}/table_with_different_granularity', '2')
+            CREATE TABLE table_by_default(date Date, id UInt32, dummy UInt32)
+            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{g}/table_by_default', '2')
+            PARTITION BY toYYYYMM(date)
+            ORDER BY id
+            SETTINGS index_granularity_bytes = 10485760
+        '''.format(g=group))
+
+    # Two tables with fixed granularity
+    first_node.query(
+        '''
+            CREATE TABLE table_with_fixed_granularity(date Date, id UInt32, dummy UInt32)
+            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{g}/table_with_fixed_granularity', '1')
             PARTITION BY toYYYYMM(date)
             ORDER BY id
             SETTINGS index_granularity_bytes = 0
         '''.format(g=group))
 
-        # Two tables with different granularity, but enabled mixed parts
-        first_node.query(
+    second_node.query(
         '''
-            CREATE TABLE table_with_mixed_granularity(date Date, id UInt32, dummy UInt32)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{g}/table_with_mixed_granularity', '1')
+            CREATE TABLE table_with_fixed_granularity(date Date, id UInt32, dummy UInt32)
+            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{g}/table_with_fixed_granularity', '2')
             PARTITION BY toYYYYMM(date)
             ORDER BY id
-            SETTINGS index_granularity_bytes = 10485760, enable_mixed_granularity_parts=1
+            SETTINGS index_granularity_bytes = 0
         '''.format(g=group))
 
+    # Two tables with different granularity
+    with pytest.raises(QueryRuntimeException):
+        first_node.query(
+            '''
+                CREATE TABLE table_with_different_granularity(date Date, id UInt32, dummy UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{g}/table_with_different_granularity', '1')
+                PARTITION BY toYYYYMM(date)
+                ORDER BY id
+                SETTINGS index_granularity_bytes = 10485760
+            '''.format(g=group))
+
         second_node.query(
-        '''
-            CREATE TABLE table_with_mixed_granularity(date Date, id UInt32, dummy UInt32)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{g}/table_with_mixed_granularity', '2')
-            PARTITION BY toYYYYMM(date)
-            ORDER BY id
-            SETTINGS index_granularity_bytes = 0, enable_mixed_granularity_parts=1
-        '''.format(g=group))
+            '''
+                CREATE TABLE table_with_different_granularity(date Date, id UInt32, dummy UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{g}/table_with_different_granularity', '2')
+                PARTITION BY toYYYYMM(date)
+                ORDER BY id
+                SETTINGS index_granularity_bytes = 0
+            '''.format(g=group))
+
+        # Two tables with different granularity, but enabled mixed parts
+        first_node.query(
+            '''
+                CREATE TABLE table_with_mixed_granularity(date Date, id UInt32, dummy UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{g}/table_with_mixed_granularity', '1')
+                PARTITION BY toYYYYMM(date)
+                ORDER BY id
+                SETTINGS index_granularity_bytes = 10485760, enable_mixed_granularity_parts=1
+            '''.format(g=group))
+
+        second_node.query(
+            '''
+                CREATE TABLE table_with_mixed_granularity(date Date, id UInt32, dummy UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{g}/table_with_mixed_granularity', '2')
+                PARTITION BY toYYYYMM(date)
+                ORDER BY id
+                SETTINGS index_granularity_bytes = 0, enable_mixed_granularity_parts=1
+            '''.format(g=group))
 
 
 def prepare_single_pair_without_setting(first_node, second_node, group):
@@ -116,21 +135,21 @@ def prepare_single_pair_without_setting(first_node, second_node, group):
 
     # Two tables with fixed granularity
     first_node.query(
-    '''
-        CREATE TABLE table_with_fixed_granularity(date Date, id UInt32, dummy UInt32)
-        ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{g}/table_with_fixed_granularity', '1')
-        PARTITION BY toYYYYMM(date)
-        ORDER BY id
-    '''.format(g=group))
+        '''
+            CREATE TABLE table_with_fixed_granularity(date Date, id UInt32, dummy UInt32)
+            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{g}/table_with_fixed_granularity', '1')
+            PARTITION BY toYYYYMM(date)
+            ORDER BY id
+        '''.format(g=group))
 
     second_node.query(
-    '''
-        CREATE TABLE table_with_fixed_granularity(date Date, id UInt32, dummy UInt32)
-        ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{g}/table_with_fixed_granularity', '2')
-        PARTITION BY toYYYYMM(date)
-        ORDER BY id
-        SETTINGS index_granularity_bytes = 0
-    '''.format(g=group))
+        '''
+            CREATE TABLE table_with_fixed_granularity(date Date, id UInt32, dummy UInt32)
+            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{g}/table_with_fixed_granularity', '2')
+            PARTITION BY toYYYYMM(date)
+            ORDER BY id
+            SETTINGS index_granularity_bytes = 0
+        '''.format(g=group))
 
 
 @pytest.fixture(scope="module")
@@ -160,7 +179,8 @@ def start_static_cluster():
 def test_different_versions_cluster(start_static_cluster, first_node, second_node, table):
     counter = 1
     for n1, n2 in ((first_node, second_node), (second_node, first_node)):
-        n1.query("INSERT INTO {tbl} VALUES (toDate('2018-10-01'), {c1}, 333), (toDate('2018-10-02'), {c2}, 444)".format(tbl=table, c1=counter * 2, c2=counter * 2 + 1))
+        n1.query("INSERT INTO {tbl} VALUES (toDate('2018-10-01'), {c1}, 333), (toDate('2018-10-02'), {c2}, 444)".format(
+            tbl=table, c1=counter * 2, c2=counter * 2 + 1))
         n2.query("SYSTEM SYNC REPLICA {tbl}".format(tbl=table))
         assert_eq_with_retry(n2, "SELECT count() from {tbl}".format(tbl=table), str(counter * 2))
         n1.query("DETACH TABLE {tbl}".format(tbl=table))
@@ -175,72 +195,73 @@ def test_different_versions_cluster(start_static_cluster, first_node, second_nod
         assert_eq_with_retry(n2, "SELECT count() from {tbl}".format(tbl=table), str(counter * 2))
         counter += 1
 
+
 @pytest.fixture(scope="module")
 def start_dynamic_cluster():
     try:
         cluster.start()
         node7.query(
-        '''
-            CREATE TABLE table_with_default_granularity(date Date, id UInt32, dummy UInt32)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/7/table_with_default_granularity', '1')
-            PARTITION BY toYYYYMM(date)
-            ORDER BY id
-        ''')
+            '''
+                CREATE TABLE table_with_default_granularity(date Date, id UInt32, dummy UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/7/table_with_default_granularity', '1')
+                PARTITION BY toYYYYMM(date)
+                ORDER BY id
+            ''')
 
         node7.query(
-        '''
-            CREATE TABLE table_with_adaptive_default_granularity(date Date, id UInt32, dummy UInt32)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/7/table_with_adaptive_default_granularity', '1')
-            PARTITION BY toYYYYMM(date)
-            ORDER BY id
-            SETTINGS index_granularity_bytes=10485760
-        ''')
+            '''
+                CREATE TABLE table_with_adaptive_default_granularity(date Date, id UInt32, dummy UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/7/table_with_adaptive_default_granularity', '1')
+                PARTITION BY toYYYYMM(date)
+                ORDER BY id
+                SETTINGS index_granularity_bytes=10485760
+            ''')
 
         node8.query(
-        '''
-            CREATE TABLE table_with_default_granularity(date Date, id UInt32, dummy UInt32)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/8/table_with_default_granularity', '1')
-            PARTITION BY toYYYYMM(date)
-            ORDER BY id
-        ''')
+            '''
+                CREATE TABLE table_with_default_granularity(date Date, id UInt32, dummy UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/8/table_with_default_granularity', '1')
+                PARTITION BY toYYYYMM(date)
+                ORDER BY id
+            ''')
 
         node9.query(
-        '''
-            CREATE TABLE table_with_default_granularity(date Date, id UInt32, dummy UInt32)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/9/table_with_default_granularity', '1')
-            PARTITION BY toYYYYMM(date)
-            ORDER BY id
-        ''')
+            '''
+                CREATE TABLE table_with_default_granularity(date Date, id UInt32, dummy UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/9/table_with_default_granularity', '1')
+                PARTITION BY toYYYYMM(date)
+                ORDER BY id
+            ''')
 
         node10.query(
-        '''
-            CREATE TABLE table_with_default_granularity(date Date, id UInt32, dummy UInt32)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/10/table_with_default_granularity', '1')
-            PARTITION BY toYYYYMM(date)
-            ORDER BY id
-        ''')
+            '''
+                CREATE TABLE table_with_default_granularity(date Date, id UInt32, dummy UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/10/table_with_default_granularity', '1')
+                PARTITION BY toYYYYMM(date)
+                ORDER BY id
+            ''')
 
         node11.query(
-        '''
-            CREATE TABLE table_with_default_granularity(date Date, id UInt32, dummy UInt32)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/shard11/table_with_default_granularity', '1')
-            PARTITION BY toYYYYMM(date)
-            ORDER BY id
-        ''')
+            '''
+                CREATE TABLE table_with_default_granularity(date Date, id UInt32, dummy UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/shard11/table_with_default_granularity', '1')
+                PARTITION BY toYYYYMM(date)
+                ORDER BY id
+            ''')
 
         node12.query(
-        '''
-            CREATE TABLE table_with_default_granularity(date Date, id UInt32, dummy UInt32)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/shard11/table_with_default_granularity', '2')
-            PARTITION BY toYYYYMM(date)
-            ORDER BY id
-        ''')
-
+            '''
+                CREATE TABLE table_with_default_granularity(date Date, id UInt32, dummy UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/shard11/table_with_default_granularity', '2')
+                PARTITION BY toYYYYMM(date)
+                ORDER BY id
+            ''')
 
         yield cluster
 
     finally:
         cluster.shutdown()
+
 
 @pytest.mark.parametrize(
     ('n', 'tables'),
@@ -251,12 +272,15 @@ def start_dynamic_cluster():
 )
 def test_version_single_node_update(start_dynamic_cluster, n, tables):
     for table in tables:
-        n.query("INSERT INTO {tbl} VALUES (toDate('2018-10-01'), 1, 333), (toDate('2018-10-02'), 2, 444)".format(tbl=table))
+        n.query(
+            "INSERT INTO {tbl} VALUES (toDate('2018-10-01'), 1, 333), (toDate('2018-10-02'), 2, 444)".format(tbl=table))
     n.restart_with_latest_version()
     for table in tables:
         assert n.query("SELECT count() from {tbl}".format(tbl=table)) == '2\n'
-        n.query("INSERT INTO {tbl} VALUES (toDate('2018-10-01'), 3, 333), (toDate('2018-10-02'), 4, 444)".format(tbl=table))
+        n.query(
+            "INSERT INTO {tbl} VALUES (toDate('2018-10-01'), 3, 333), (toDate('2018-10-02'), 4, 444)".format(tbl=table))
         assert n.query("SELECT count() from {tbl}".format(tbl=table)) == '4\n'
+
 
 @pytest.mark.parametrize(
     ('node',),
@@ -266,27 +290,38 @@ def test_version_single_node_update(start_dynamic_cluster, n, tables):
     ]
 )
 def test_mixed_granularity_single_node(start_dynamic_cluster, node):
-    node.query("INSERT INTO table_with_default_granularity VALUES (toDate('2018-10-01'), 1, 333), (toDate('2018-10-02'), 2, 444)")
-    node.query("INSERT INTO table_with_default_granularity VALUES (toDate('2018-09-01'), 1, 333), (toDate('2018-09-02'), 2, 444)")
+    node.query(
+        "INSERT INTO table_with_default_granularity VALUES (toDate('2018-10-01'), 1, 333), (toDate('2018-10-02'), 2, 444)")
+    node.query(
+        "INSERT INTO table_with_default_granularity VALUES (toDate('2018-09-01'), 1, 333), (toDate('2018-09-02'), 2, 444)")
 
     def callback(n):
-        n.replace_config("/etc/clickhouse-server/merge_tree_settings.xml", "<yandex><merge_tree><enable_mixed_granularity_parts>1</enable_mixed_granularity_parts></merge_tree></yandex>")
-        n.replace_config("/etc/clickhouse-server/config.d/merge_tree_settings.xml", "<yandex><merge_tree><enable_mixed_granularity_parts>1</enable_mixed_granularity_parts></merge_tree></yandex>")
+        n.replace_config("/etc/clickhouse-server/merge_tree_settings.xml",
+                         "<yandex><merge_tree><enable_mixed_granularity_parts>1</enable_mixed_granularity_parts></merge_tree></yandex>")
+        n.replace_config("/etc/clickhouse-server/config.d/merge_tree_settings.xml",
+                         "<yandex><merge_tree><enable_mixed_granularity_parts>1</enable_mixed_granularity_parts></merge_tree></yandex>")
 
     node.restart_with_latest_version(callback_onstop=callback)
     node.query("SYSTEM RELOAD CONFIG")
-    assert_eq_with_retry(node, "SELECT value FROM system.merge_tree_settings WHERE name='enable_mixed_granularity_parts'", '1')
+    assert_eq_with_retry(node,
+                         "SELECT value FROM system.merge_tree_settings WHERE name='enable_mixed_granularity_parts'",
+                         '1')
     assert node.query("SELECT count() from table_with_default_granularity") == '4\n'
-    node.query("INSERT INTO table_with_default_granularity VALUES (toDate('2018-10-01'), 3, 333), (toDate('2018-10-02'), 4, 444)")
+    node.query(
+        "INSERT INTO table_with_default_granularity VALUES (toDate('2018-10-01'), 3, 333), (toDate('2018-10-02'), 4, 444)")
     assert node.query("SELECT count() from table_with_default_granularity") == '6\n'
     node.query("OPTIMIZE TABLE table_with_default_granularity PARTITION 201810 FINAL")
     assert node.query("SELECT count() from table_with_default_granularity") == '6\n'
-    path_to_merged_part = node.query("SELECT path FROM system.parts WHERE table = 'table_with_default_granularity' AND active=1 ORDER BY partition DESC LIMIT 1").strip()
-    node.exec_in_container(["bash", "-c", "find {p} -name '*.mrk2' | grep '.*'".format(p=path_to_merged_part)]) # check that we have adaptive files
+    path_to_merged_part = node.query(
+        "SELECT path FROM system.parts WHERE table = 'table_with_default_granularity' AND active=1 ORDER BY partition DESC LIMIT 1").strip()
+    node.exec_in_container(["bash", "-c", "find {p} -name '*.mrk2' | grep '.*'".format(
+        p=path_to_merged_part)])  # check that we have adaptive files
 
-    path_to_old_part = node.query("SELECT path FROM system.parts WHERE table = 'table_with_default_granularity' AND active=1 ORDER BY partition ASC LIMIT 1").strip()
+    path_to_old_part = node.query(
+        "SELECT path FROM system.parts WHERE table = 'table_with_default_granularity' AND active=1 ORDER BY partition ASC LIMIT 1").strip()
 
-    node.exec_in_container(["bash", "-c", "find {p} -name '*.mrk' | grep '.*'".format(p=path_to_old_part)]) # check that we have non adaptive files
+    node.exec_in_container(["bash", "-c", "find {p} -name '*.mrk' | grep '.*'".format(
+        p=path_to_old_part)])  # check that we have non adaptive files
 
     node.query("ALTER TABLE table_with_default_granularity UPDATE dummy = dummy + 1 WHERE 1")
     # still works
@@ -295,46 +330,54 @@ def test_mixed_granularity_single_node(start_dynamic_cluster, node):
     node.query("ALTER TABLE table_with_default_granularity MODIFY COLUMN dummy String")
     node.query("ALTER TABLE table_with_default_granularity ADD COLUMN dummy2 Float64")
 
-    #still works
+    # still works
     assert node.query("SELECT count() from table_with_default_granularity") == '6\n'
+
 
 @pytest.mark.skip(reason="flaky")
 def test_version_update_two_nodes(start_dynamic_cluster):
-    node11.query("INSERT INTO table_with_default_granularity VALUES (toDate('2018-10-01'), 1, 333), (toDate('2018-10-02'), 2, 444)")
+    node11.query(
+        "INSERT INTO table_with_default_granularity VALUES (toDate('2018-10-01'), 1, 333), (toDate('2018-10-02'), 2, 444)")
     node12.query("SYSTEM SYNC REPLICA table_with_default_granularity", timeout=20)
     assert node12.query("SELECT COUNT() FROM table_with_default_granularity") == '2\n'
+
     def callback(n):
-        n.replace_config("/etc/clickhouse-server/merge_tree_settings.xml", "<yandex><merge_tree><enable_mixed_granularity_parts>0</enable_mixed_granularity_parts></merge_tree></yandex>")
-        n.replace_config("/etc/clickhouse-server/config.d/merge_tree_settings.xml", "<yandex><merge_tree><enable_mixed_granularity_parts>0</enable_mixed_granularity_parts></merge_tree></yandex>")
+        n.replace_config("/etc/clickhouse-server/merge_tree_settings.xml",
+                         "<yandex><merge_tree><enable_mixed_granularity_parts>0</enable_mixed_granularity_parts></merge_tree></yandex>")
+        n.replace_config("/etc/clickhouse-server/config.d/merge_tree_settings.xml",
+                         "<yandex><merge_tree><enable_mixed_granularity_parts>0</enable_mixed_granularity_parts></merge_tree></yandex>")
 
     node12.restart_with_latest_version(callback_onstop=callback)
 
-    node12.query("INSERT INTO table_with_default_granularity VALUES (toDate('2018-10-01'), 3, 333), (toDate('2018-10-02'), 4, 444)")
+    node12.query(
+        "INSERT INTO table_with_default_granularity VALUES (toDate('2018-10-01'), 3, 333), (toDate('2018-10-02'), 4, 444)")
     node11.query("SYSTEM SYNC REPLICA table_with_default_granularity", timeout=20)
     assert node11.query("SELECT COUNT() FROM table_with_default_granularity") == '4\n'
 
     node12.query(
-    '''
-        CREATE TABLE table_with_default_granularity_new(date Date, id UInt32, dummy UInt32)
-        ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/shard11/table_with_default_granularity_new', '2')
-        PARTITION BY toYYYYMM(date)
-        ORDER BY id
-    ''')
+        '''
+            CREATE TABLE table_with_default_granularity_new(date Date, id UInt32, dummy UInt32)
+            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/shard11/table_with_default_granularity_new', '2')
+            PARTITION BY toYYYYMM(date)
+            ORDER BY id
+        ''')
 
     node11.query(
-    '''
-        CREATE TABLE table_with_default_granularity_new(date Date, id UInt32, dummy UInt32)
-        ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/shard11/table_with_default_granularity_new', '1')
-        PARTITION BY toYYYYMM(date)
-        ORDER BY id
-    ''')
+        '''
+            CREATE TABLE table_with_default_granularity_new(date Date, id UInt32, dummy UInt32)
+            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/shard11/table_with_default_granularity_new', '1')
+            PARTITION BY toYYYYMM(date)
+            ORDER BY id
+        ''')
 
-    node12.query("INSERT INTO table_with_default_granularity_new VALUES (toDate('2018-10-01'), 1, 333), (toDate('2018-10-02'), 2, 444)")
+    node12.query(
+        "INSERT INTO table_with_default_granularity_new VALUES (toDate('2018-10-01'), 1, 333), (toDate('2018-10-02'), 2, 444)")
     with pytest.raises(QueryTimeoutExceedException):
         node11.query("SYSTEM SYNC REPLICA table_with_default_granularity_new", timeout=20)
-    node12.query("INSERT INTO table_with_default_granularity_new VALUES (toDate('2018-10-01'), 3, 333), (toDate('2018-10-02'), 4, 444)")
+    node12.query(
+        "INSERT INTO table_with_default_granularity_new VALUES (toDate('2018-10-01'), 3, 333), (toDate('2018-10-02'), 4, 444)")
 
-    node11.restart_with_latest_version(callback_onstop=callback) # just to be sure
+    node11.restart_with_latest_version(callback_onstop=callback)  # just to be sure
 
     for i in range(3):
         try:
@@ -350,7 +393,8 @@ def test_version_update_two_nodes(start_dynamic_cluster):
     assert node11.query("SELECT COUNT() FROM table_with_default_granularity_new") == "4\n"
     assert node12.query("SELECT COUNT() FROM table_with_default_granularity_new") == "4\n"
 
-    node11.query("INSERT INTO table_with_default_granularity VALUES (toDate('2018-10-01'), 5, 333), (toDate('2018-10-02'), 6, 444)")
+    node11.query(
+        "INSERT INTO table_with_default_granularity VALUES (toDate('2018-10-01'), 5, 333), (toDate('2018-10-02'), 6, 444)")
     for i in range(3):
         try:
             node12.query("SYSTEM SYNC REPLICA table_with_default_granularity", timeout=120)

--- a/tests/integration/test_adaptive_granularity_different_settings/test.py
+++ b/tests/integration/test_adaptive_granularity_different_settings/test.py
@@ -7,7 +7,9 @@ node1 = cluster.add_instance('node1', with_zookeeper=True)
 node2 = cluster.add_instance('node2', with_zookeeper=True)
 
 # no adaptive granularity by default
-node3 = cluster.add_instance('node3', image='yandex/clickhouse-server', tag='19.9.5.36', with_installed_binary=True, stay_alive=True)
+node3 = cluster.add_instance('node3', image='yandex/clickhouse-server', tag='19.9.5.36', with_installed_binary=True,
+                             stay_alive=True)
+
 
 @pytest.fixture(scope="module")
 def start_cluster():
@@ -20,7 +22,6 @@ def start_cluster():
 
 
 def test_attach_detach(start_cluster):
-
     node1.query("""
         CREATE TABLE test (key UInt64)
         ENGINE = ReplicatedMergeTree('/clickhouse/test', '1')
@@ -58,7 +59,8 @@ def test_mutate_with_mixed_granularity(start_cluster):
         ENGINE = MergeTree
         ORDER BY key PARTITION BY date""")
 
-    node3.query("INSERT INTO test SELECT toDate('2019-10-01') + number % 5, number, toString(number), toString(number * number) FROM numbers(500)")
+    node3.query(
+        "INSERT INTO test SELECT toDate('2019-10-01') + number % 5, number, toString(number), toString(number * number) FROM numbers(500)")
 
     assert node3.query("SELECT COUNT() FROM test") == "500\n"
 
@@ -68,7 +70,8 @@ def test_mutate_with_mixed_granularity(start_cluster):
 
     node3.query("ALTER TABLE test MODIFY SETTING enable_mixed_granularity_parts = 1")
 
-    node3.query("INSERT INTO test SELECT toDate('2019-10-01') + number % 5, number, toString(number), toString(number * number) FROM numbers(500, 500)")
+    node3.query(
+        "INSERT INTO test SELECT toDate('2019-10-01') + number % 5, number, toString(number), toString(number * number) FROM numbers(500, 500)")
 
     assert node3.query("SELECT COUNT() FROM test") == "1000\n"
     assert node3.query("SELECT COUNT() FROM test WHERE key % 100 == 0") == "10\n"

--- a/tests/integration/test_adaptive_granularity_replicated/test.py
+++ b/tests/integration/test_adaptive_granularity_replicated/test.py
@@ -1,17 +1,15 @@
 import time
+
 import pytest
-
 from helpers.cluster import ClickHouseCluster
-from multiprocessing.dummy import Pool
-from helpers.client import QueryRuntimeException, QueryTimeoutExceedException
-
-from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 
 node1 = cluster.add_instance('node1', with_zookeeper=True)
 node2 = cluster.add_instance('node2', with_zookeeper=True)
-node3 = cluster.add_instance('node3', with_zookeeper=True, image='yandex/clickhouse-server', tag='19.1.14', with_installed_binary=True)
+node3 = cluster.add_instance('node3', with_zookeeper=True, image='yandex/clickhouse-server', tag='19.1.14',
+                             with_installed_binary=True)
+
 
 @pytest.fixture(scope="module")
 def start_cluster():
@@ -23,11 +21,14 @@ def start_cluster():
     finally:
         cluster.shutdown()
 
+
 def test_creating_table_different_setting(start_cluster):
-    node1.query("CREATE TABLE t1 (c1 String, c2 String) ENGINE=ReplicatedMergeTree('/clickhouse/t1', '1') ORDER BY tuple(c1) SETTINGS index_granularity_bytes = 0")
+    node1.query(
+        "CREATE TABLE t1 (c1 String, c2 String) ENGINE=ReplicatedMergeTree('/clickhouse/t1', '1') ORDER BY tuple(c1) SETTINGS index_granularity_bytes = 0")
     node1.query("INSERT INTO t1 VALUES('x', 'y')")
 
-    node2.query("CREATE TABLE t1 (c1 String, c2 String) ENGINE=ReplicatedMergeTree('/clickhouse/t1', '2') ORDER BY tuple(c1) SETTINGS enable_mixed_granularity_parts = 0")
+    node2.query(
+        "CREATE TABLE t1 (c1 String, c2 String) ENGINE=ReplicatedMergeTree('/clickhouse/t1', '2') ORDER BY tuple(c1) SETTINGS enable_mixed_granularity_parts = 0")
 
     node1.query("INSERT INTO t1 VALUES('a', 'b')")
     node2.query("SYSTEM SYNC REPLICA t1", timeout=5)
@@ -49,22 +50,26 @@ def test_creating_table_different_setting(start_cluster):
     node1.query("SELECT count() FROM t1") == "3\n"
     node2.query("SELECT count() FROM t1") == "2\n"
 
-    path_part = node1.query("SELECT path FROM system.parts WHERE table = 't1' AND active=1 ORDER BY partition DESC LIMIT 1").strip()
+    path_part = node1.query(
+        "SELECT path FROM system.parts WHERE table = 't1' AND active=1 ORDER BY partition DESC LIMIT 1").strip()
 
-    with pytest.raises(Exception): # check that we have no adaptive files
+    with pytest.raises(Exception):  # check that we have no adaptive files
         node1.exec_in_container(["bash", "-c", "find {p} -name '*.mrk2' | grep '.*'".format(p=path_part)])
 
-    path_part = node2.query("SELECT path FROM system.parts WHERE table = 't1' AND active=1 ORDER BY partition DESC LIMIT 1").strip()
+    path_part = node2.query(
+        "SELECT path FROM system.parts WHERE table = 't1' AND active=1 ORDER BY partition DESC LIMIT 1").strip()
 
-    with pytest.raises(Exception): # check that we have no adaptive files
+    with pytest.raises(Exception):  # check that we have no adaptive files
         node2.exec_in_container(["bash", "-c", "find {p} -name '*.mrk2' | grep '.*'".format(p=path_part)])
 
 
 def test_old_node_with_new_node(start_cluster):
-    node3.query("CREATE TABLE t2 (c1 String, c2 String) ENGINE=ReplicatedMergeTree('/clickhouse/t2', '3') ORDER BY tuple(c1)")
+    node3.query(
+        "CREATE TABLE t2 (c1 String, c2 String) ENGINE=ReplicatedMergeTree('/clickhouse/t2', '3') ORDER BY tuple(c1)")
     node3.query("INSERT INTO t2 VALUES('x', 'y')")
 
-    node2.query("CREATE TABLE t2 (c1 String, c2 String) ENGINE=ReplicatedMergeTree('/clickhouse/t2', '2') ORDER BY tuple(c1) SETTINGS enable_mixed_granularity_parts = 0")
+    node2.query(
+        "CREATE TABLE t2 (c1 String, c2 String) ENGINE=ReplicatedMergeTree('/clickhouse/t2', '2') ORDER BY tuple(c1) SETTINGS enable_mixed_granularity_parts = 0")
 
     node3.query("INSERT INTO t2 VALUES('a', 'b')")
     node2.query("SYSTEM SYNC REPLICA t2", timeout=5)
@@ -86,12 +91,14 @@ def test_old_node_with_new_node(start_cluster):
     node3.query("SELECT count() FROM t2") == "3\n"
     node2.query("SELECT count() FROM t2") == "2\n"
 
-    path_part = node3.query("SELECT path FROM system.parts WHERE table = 't2' AND active=1 ORDER BY partition DESC LIMIT 1").strip()
+    path_part = node3.query(
+        "SELECT path FROM system.parts WHERE table = 't2' AND active=1 ORDER BY partition DESC LIMIT 1").strip()
 
-    with pytest.raises(Exception): # check that we have no adaptive files
+    with pytest.raises(Exception):  # check that we have no adaptive files
         node3.exec_in_container(["bash", "-c", "find {p} -name '*.mrk2' | grep '.*'".format(p=path_part)])
 
-    path_part = node2.query("SELECT path FROM system.parts WHERE table = 't2' AND active=1 ORDER BY partition DESC LIMIT 1").strip()
+    path_part = node2.query(
+        "SELECT path FROM system.parts WHERE table = 't2' AND active=1 ORDER BY partition DESC LIMIT 1").strip()
 
-    with pytest.raises(Exception): # check that we have no adaptive files
+    with pytest.raises(Exception):  # check that we have no adaptive files
         node2.exec_in_container(["bash", "-c", "find {p} -name '*.mrk2' | grep '.*'".format(p=path_part)])

--- a/tests/integration/test_aggregation_memory_efficient/test.py
+++ b/tests/integration/test_aggregation_memory_efficient/test.py
@@ -1,13 +1,11 @@
-import time
 import pytest
 
 from helpers.cluster import ClickHouseCluster
-from helpers.client import QueryRuntimeException, QueryTimeoutExceedException
-
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1')
 node2 = cluster.add_instance('node2')
+
 
 @pytest.fixture(scope="module")
 def start_cluster():
@@ -15,8 +13,8 @@ def start_cluster():
         cluster.start()
 
         for node in [node1, node2]:
-            node.query("create table da_memory_efficient_shard(A Int64, B Int64) Engine=MergeTree order by A partition by B % 2;")
-
+            node.query(
+                "create table da_memory_efficient_shard(A Int64, B Int64) Engine=MergeTree order by A partition by B % 2;")
 
         node1.query("insert into da_memory_efficient_shard select number, number from numbers(100000);")
         node2.query("insert into da_memory_efficient_shard select number + 100000, number from numbers(100000);")
@@ -28,19 +26,24 @@ def start_cluster():
 
 
 def test_remote(start_cluster):
-
-    node1.query("set distributed_aggregation_memory_efficient = 1, group_by_two_level_threshold = 1, group_by_two_level_threshold_bytes=1")
-    res = node1.query("select sum(a) from (SELECT B, uniqExact(A) a FROM remote('node{1,2}', default.da_memory_efficient_shard) GROUP BY B)")
+    node1.query(
+        "set distributed_aggregation_memory_efficient = 1, group_by_two_level_threshold = 1, group_by_two_level_threshold_bytes=1")
+    res = node1.query(
+        "select sum(a) from (SELECT B, uniqExact(A) a FROM remote('node{1,2}', default.da_memory_efficient_shard) GROUP BY B)")
     assert res == '200000\n'
 
     node1.query("set distributed_aggregation_memory_efficient = 0")
-    res = node1.query("select sum(a) from (SELECT B, uniqExact(A) a FROM remote('node{1,2}', default.da_memory_efficient_shard) GROUP BY B)")
+    res = node1.query(
+        "select sum(a) from (SELECT B, uniqExact(A) a FROM remote('node{1,2}', default.da_memory_efficient_shard) GROUP BY B)")
     assert res == '200000\n'
 
-    node1.query("set distributed_aggregation_memory_efficient = 1, group_by_two_level_threshold = 1, group_by_two_level_threshold_bytes=1")
-    res = node1.query("SELECT fullHostName() AS h, uniqExact(A) AS a FROM remote('node{1,2}', default.da_memory_efficient_shard) GROUP BY h ORDER BY h;")
+    node1.query(
+        "set distributed_aggregation_memory_efficient = 1, group_by_two_level_threshold = 1, group_by_two_level_threshold_bytes=1")
+    res = node1.query(
+        "SELECT fullHostName() AS h, uniqExact(A) AS a FROM remote('node{1,2}', default.da_memory_efficient_shard) GROUP BY h ORDER BY h;")
     assert res == 'node1\t100000\nnode2\t100000\n'
 
     node1.query("set distributed_aggregation_memory_efficient = 0")
-    res = node1.query("SELECT fullHostName() AS h, uniqExact(A) AS a FROM remote('node{1,2}', default.da_memory_efficient_shard) GROUP BY h ORDER BY h;")
+    res = node1.query(
+        "SELECT fullHostName() AS h, uniqExact(A) AS a FROM remote('node{1,2}', default.da_memory_efficient_shard) GROUP BY h ORDER BY h;")
     assert res == 'node1\t100000\nnode2\t100000\n'

--- a/tests/integration/test_allowed_client_hosts/test.py
+++ b/tests/integration/test_allowed_client_hosts/test.py
@@ -1,32 +1,32 @@
-import os
 import pytest
 from helpers.cluster import ClickHouseCluster
-
 
 cluster = ClickHouseCluster(__file__)
 server = cluster.add_instance('server', user_configs=["configs/users.d/network.xml"])
 
-clientA1 = cluster.add_instance('clientA1', hostname = 'clientA1.com')
-clientA2 = cluster.add_instance('clientA2', hostname = 'clientA2.com')
-clientA3 = cluster.add_instance('clientA3', hostname = 'clientA3.com')
-clientB1 = cluster.add_instance('clientB1', hostname = 'clientB001.ru')
-clientB2 = cluster.add_instance('clientB2', hostname = 'clientB002.ru')
-clientB3 = cluster.add_instance('clientB3', hostname = 'xxx.clientB003.rutracker.com')
-clientC1 = cluster.add_instance('clientC1', hostname = 'clientC01.ru')
-clientC2 = cluster.add_instance('clientC2', hostname = 'xxx.clientC02.ru')
-clientC3 = cluster.add_instance('clientC3', hostname = 'xxx.clientC03.rutracker.com')
-clientD1 = cluster.add_instance('clientD1', hostname = 'clientD0001.ru')
-clientD2 = cluster.add_instance('clientD2', hostname = 'xxx.clientD0002.ru')
-clientD3 = cluster.add_instance('clientD3', hostname = 'clientD0003.ru')
+clientA1 = cluster.add_instance('clientA1', hostname='clientA1.com')
+clientA2 = cluster.add_instance('clientA2', hostname='clientA2.com')
+clientA3 = cluster.add_instance('clientA3', hostname='clientA3.com')
+clientB1 = cluster.add_instance('clientB1', hostname='clientB001.ru')
+clientB2 = cluster.add_instance('clientB2', hostname='clientB002.ru')
+clientB3 = cluster.add_instance('clientB3', hostname='xxx.clientB003.rutracker.com')
+clientC1 = cluster.add_instance('clientC1', hostname='clientC01.ru')
+clientC2 = cluster.add_instance('clientC2', hostname='xxx.clientC02.ru')
+clientC3 = cluster.add_instance('clientC3', hostname='xxx.clientC03.rutracker.com')
+clientD1 = cluster.add_instance('clientD1', hostname='clientD0001.ru')
+clientD2 = cluster.add_instance('clientD2', hostname='xxx.clientD0002.ru')
+clientD3 = cluster.add_instance('clientD3', hostname='clientD0003.ru')
 
 
 def check_clickhouse_is_ok(client_node, server_node):
-    assert client_node.exec_in_container(["bash", "-c", "/usr/bin/curl -s {}:8123 ".format(server_node.hostname)]) == "Ok.\n"
+    assert client_node.exec_in_container(
+        ["bash", "-c", "/usr/bin/curl -s {}:8123 ".format(server_node.hostname)]) == "Ok.\n"
 
 
 def query_from_one_node_to_another(client_node, server_node, query):
     check_clickhouse_is_ok(client_node, server_node)
-    return client_node.exec_in_container(["bash", "-c", "/usr/bin/clickhouse client --host {} --query {!r}".format(server_node.hostname, query)])
+    return client_node.exec_in_container(
+        ["bash", "-c", "/usr/bin/clickhouse client --host {} --query {!r}".format(server_node.hostname, query)])
 
 
 def query(node, query):
@@ -53,8 +53,8 @@ def test_allowed_host():
     # Reverse DNS lookup currently isn't working as expected in this test.
     # For example, it gives something like "vitbartestallowedclienthosts_clientB1_1.vitbartestallowedclienthosts_default" instead of "clientB001.ru".
     # Maybe we should setup the test network better.
-    #expected_to_pass.extend([clientB1, clientB2, clientB3, clientC1, clientC2, clientD1, clientD3])
-    #expected_to_fail.extend([clientC3, clientD2])
+    # expected_to_pass.extend([clientB1, clientB2, clientB3, clientC1, clientC2, clientD1, clientD3])
+    # expected_to_fail.extend([clientC3, clientD2])
 
     for client_node in expected_to_pass:
         assert query_from_one_node_to_another(client_node, server, "SELECT * FROM test_table") == "5\n"

--- a/tests/integration/test_allowed_url_from_config/test.py
+++ b/tests/integration/test_allowed_url_from_config/test.py
@@ -1,8 +1,6 @@
-import time
 import pytest
-
-from helpers.hdfs_api import HDFSApi
 from helpers.cluster import ClickHouseCluster
+from helpers.hdfs_api import HDFSApi
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', main_configs=['configs/config_with_hosts.xml'])
@@ -21,26 +19,37 @@ def start_cluster():
     finally:
         cluster.shutdown()
 
+
 def test_config_with_hosts(start_cluster):
     assert node1.query("CREATE TABLE table_test_1_1 (word String) Engine=URL('http://host:80', HDFS)") == ""
     assert node1.query("CREATE TABLE table_test_1_2 (word String) Engine=URL('https://yandex.ru', CSV)") == ""
-    assert "not allowed" in node1.query_and_get_error("CREATE TABLE table_test_1_4 (word String) Engine=URL('https://host:123', S3)")
-    assert "not allowed" in node1.query_and_get_error("CREATE TABLE table_test_1_4 (word String) Engine=URL('https://yandex2.ru', CSV)")
+    assert "not allowed" in node1.query_and_get_error(
+        "CREATE TABLE table_test_1_4 (word String) Engine=URL('https://host:123', S3)")
+    assert "not allowed" in node1.query_and_get_error(
+        "CREATE TABLE table_test_1_4 (word String) Engine=URL('https://yandex2.ru', CSV)")
+
 
 def test_config_with_only_primary_hosts(start_cluster):
     assert node2.query("CREATE TABLE table_test_2_1 (word String) Engine=URL('https://host:80', CSV)") == ""
     assert node2.query("CREATE TABLE table_test_2_2 (word String) Engine=URL('https://host:123', S3)") == ""
     assert node2.query("CREATE TABLE table_test_2_3 (word String) Engine=URL('https://yandex.ru', CSV)") == ""
     assert node2.query("CREATE TABLE table_test_2_4 (word String) Engine=URL('https://yandex.ru:87', HDFS)") == ""
-    assert "not allowed" in node2.query_and_get_error("CREATE TABLE table_test_2_5 (word String) Engine=URL('https://host', HDFS)")
-    assert "not allowed" in node2.query_and_get_error("CREATE TABLE table_test_2_5 (word String) Engine=URL('https://host:234', CSV)")
-    assert "not allowed" in node2.query_and_get_error("CREATE TABLE table_test_2_6 (word String) Engine=URL('https://yandex2.ru', S3)")
+    assert "not allowed" in node2.query_and_get_error(
+        "CREATE TABLE table_test_2_5 (word String) Engine=URL('https://host', HDFS)")
+    assert "not allowed" in node2.query_and_get_error(
+        "CREATE TABLE table_test_2_5 (word String) Engine=URL('https://host:234', CSV)")
+    assert "not allowed" in node2.query_and_get_error(
+        "CREATE TABLE table_test_2_6 (word String) Engine=URL('https://yandex2.ru', S3)")
+
 
 def test_config_with_only_regexp_hosts(start_cluster):
     assert node3.query("CREATE TABLE table_test_3_1 (word String) Engine=URL('https://host:80', HDFS)") == ""
     assert node3.query("CREATE TABLE table_test_3_2 (word String) Engine=URL('https://yandex.ru', CSV)") == ""
-    assert "not allowed" in node3.query_and_get_error("CREATE TABLE table_test_3_3 (word String) Engine=URL('https://host', CSV)")
-    assert "not allowed" in node3.query_and_get_error("CREATE TABLE table_test_3_4 (word String) Engine=URL('https://yandex2.ru', S3)")
+    assert "not allowed" in node3.query_and_get_error(
+        "CREATE TABLE table_test_3_3 (word String) Engine=URL('https://host', CSV)")
+    assert "not allowed" in node3.query_and_get_error(
+        "CREATE TABLE table_test_3_4 (word String) Engine=URL('https://yandex2.ru', S3)")
+
 
 def test_config_without_allowed_hosts(start_cluster):
     assert node4.query("CREATE TABLE table_test_4_1 (word String) Engine=URL('https://host:80', CSV)") == ""
@@ -48,27 +57,60 @@ def test_config_without_allowed_hosts(start_cluster):
     assert node4.query("CREATE TABLE table_test_4_3 (word String) Engine=URL('https://yandex.ru', CSV)") == ""
     assert node4.query("CREATE TABLE table_test_4_4 (word String) Engine=URL('ftp://something.com', S3)") == ""
 
+
 def test_table_function_remote(start_cluster):
-    assert "not allowed in config.xml" not in node6.query_and_get_error("SELECT * FROM remoteSecure('example01-01-{1|2}', system, events)", settings={"connections_with_failover_max_tries":1, "connect_timeout_with_failover_ms": 1000, "connect_timeout_with_failover_secure_ms": 1000, "connect_timeout": 1, "send_timeout":1})
-    assert "not allowed in config.xml" not in node6.query_and_get_error("SELECT * FROM remoteSecure('example01-01-1,example01-02-1', system, events)", settings={"connections_with_failover_max_tries":1, "connect_timeout_with_failover_ms": 1000, "connect_timeout_with_failover_secure_ms": 1000, "connect_timeout": 1, "send_timeout":1})
-    assert "not allowed in config.xml" not in node6.query_and_get_error("SELECT * FROM remote('example01-0{1,2}-1', system, events", settings={"connections_with_failover_max_tries":1, "connect_timeout_with_failover_ms": 1000, "connect_timeout_with_failover_secure_ms": 1000, "connect_timeout": 1, "send_timeout":1})
-    assert "not allowed in config.xml" not in node6.query_and_get_error("SELECT * FROM remote('example01-0{1,2}-{1|2}', system, events)", settings={"connections_with_failover_max_tries":1, "connect_timeout_with_failover_ms": 1000, "connect_timeout_with_failover_secure_ms": 1000, "connect_timeout": 1, "send_timeout":1})
-    assert "not allowed in config.xml" not in node6.query_and_get_error("SELECT * FROM remoteSecure('example01-{01..02}-{1|2}', system, events)", settings={"connections_with_failover_max_tries":1, "connect_timeout_with_failover_ms": 1000, "connect_timeout_with_failover_secure_ms": 1000, "connect_timeout": 1, "send_timeout":1})
-    assert "not allowed" in node6.query_and_get_error("SELECT * FROM remoteSecure('example01-01-1,example01-03-1', system, events)", settings={"connections_with_failover_max_tries":1, "connect_timeout_with_failover_ms": 1000, "connect_timeout_with_failover_secure_ms": 1000, "connect_timeout": 1, "send_timeout":1})
-    assert "not allowed" in node6.query_and_get_error("SELECT * FROM remote('example01-01-{1|3}', system, events)", settings={"connections_with_failover_max_tries":1, "connect_timeout_with_failover_ms": 1000, "connect_timeout_with_failover_secure_ms": 1000, "connect_timeout": 1, "send_timeout":1})
-    assert "not allowed" in node6.query_and_get_error("SELECT * FROM remoteSecure('example01-0{1,3}-1', system, metrics)", settings={"connections_with_failover_max_tries":1, "connect_timeout_with_failover_ms": 1000, "connect_timeout_with_failover_secure_ms": 1000, "connect_timeout": 1, "send_timeout":1})
+    assert "not allowed in config.xml" not in node6.query_and_get_error(
+        "SELECT * FROM remoteSecure('example01-01-{1|2}', system, events)",
+        settings={"connections_with_failover_max_tries": 1, "connect_timeout_with_failover_ms": 1000,
+                  "connect_timeout_with_failover_secure_ms": 1000, "connect_timeout": 1, "send_timeout": 1})
+    assert "not allowed in config.xml" not in node6.query_and_get_error(
+        "SELECT * FROM remoteSecure('example01-01-1,example01-02-1', system, events)",
+        settings={"connections_with_failover_max_tries": 1, "connect_timeout_with_failover_ms": 1000,
+                  "connect_timeout_with_failover_secure_ms": 1000, "connect_timeout": 1, "send_timeout": 1})
+    assert "not allowed in config.xml" not in node6.query_and_get_error(
+        "SELECT * FROM remote('example01-0{1,2}-1', system, events",
+        settings={"connections_with_failover_max_tries": 1, "connect_timeout_with_failover_ms": 1000,
+                  "connect_timeout_with_failover_secure_ms": 1000, "connect_timeout": 1, "send_timeout": 1})
+    assert "not allowed in config.xml" not in node6.query_and_get_error(
+        "SELECT * FROM remote('example01-0{1,2}-{1|2}', system, events)",
+        settings={"connections_with_failover_max_tries": 1, "connect_timeout_with_failover_ms": 1000,
+                  "connect_timeout_with_failover_secure_ms": 1000, "connect_timeout": 1, "send_timeout": 1})
+    assert "not allowed in config.xml" not in node6.query_and_get_error(
+        "SELECT * FROM remoteSecure('example01-{01..02}-{1|2}', system, events)",
+        settings={"connections_with_failover_max_tries": 1, "connect_timeout_with_failover_ms": 1000,
+                  "connect_timeout_with_failover_secure_ms": 1000, "connect_timeout": 1, "send_timeout": 1})
+    assert "not allowed" in node6.query_and_get_error(
+        "SELECT * FROM remoteSecure('example01-01-1,example01-03-1', system, events)",
+        settings={"connections_with_failover_max_tries": 1, "connect_timeout_with_failover_ms": 1000,
+                  "connect_timeout_with_failover_secure_ms": 1000, "connect_timeout": 1, "send_timeout": 1})
+    assert "not allowed" in node6.query_and_get_error("SELECT * FROM remote('example01-01-{1|3}', system, events)",
+                                                      settings={"connections_with_failover_max_tries": 1,
+                                                                "connect_timeout_with_failover_ms": 1000,
+                                                                "connect_timeout_with_failover_secure_ms": 1000,
+                                                                "connect_timeout": 1, "send_timeout": 1})
+    assert "not allowed" in node6.query_and_get_error(
+        "SELECT * FROM remoteSecure('example01-0{1,3}-1', system, metrics)",
+        settings={"connections_with_failover_max_tries": 1, "connect_timeout_with_failover_ms": 1000,
+                  "connect_timeout_with_failover_secure_ms": 1000, "connect_timeout": 1, "send_timeout": 1})
     assert node6.query("SELECT * FROM remote('localhost', system, events)") != ""
     assert node6.query("SELECT * FROM remoteSecure('localhost', system, metrics)") != ""
-    assert "URL \"localhost:800\" is not allowed in config.xml" in node6.query_and_get_error("SELECT * FROM remoteSecure('localhost:800', system, events)")
-    assert "URL \"localhost:800\" is not allowed in config.xml" in node6.query_and_get_error("SELECT * FROM remote('localhost:800', system, metrics)")
+    assert "URL \"localhost:800\" is not allowed in config.xml" in node6.query_and_get_error(
+        "SELECT * FROM remoteSecure('localhost:800', system, events)")
+    assert "URL \"localhost:800\" is not allowed in config.xml" in node6.query_and_get_error(
+        "SELECT * FROM remote('localhost:800', system, metrics)")
+
 
 def test_redirect(start_cluster):
     hdfs_api = HDFSApi("root")
     hdfs_api.write_data("/simple_storage", "1\t\n")
     assert hdfs_api.read_data("/simple_storage") == "1\t\n"
-    node7.query("CREATE TABLE table_test_7_1 (word String) ENGINE=URL('http://hdfs1:50070/webhdfs/v1/simple_storage?op=OPEN&namenoderpcaddress=hdfs1:9000&offset=0', CSV)")
+    node7.query(
+        "CREATE TABLE table_test_7_1 (word String) ENGINE=URL('http://hdfs1:50070/webhdfs/v1/simple_storage?op=OPEN&namenoderpcaddress=hdfs1:9000&offset=0', CSV)")
     assert "not allowed" in node7.query_and_get_error("SET max_http_get_redirects=1; SELECT * from table_test_7_1")
 
+
 def test_HDFS(start_cluster):
-    assert "not allowed" in node7.query_and_get_error("CREATE TABLE table_test_7_2 (word String) ENGINE=HDFS('http://hdfs1:50075/webhdfs/v1/simple_storage?op=OPEN&namenoderpcaddress=hdfs1:9000&offset=0', 'CSV')")
-    assert "not allowed" in node7.query_and_get_error("SELECT * FROM hdfs('http://hdfs1:50075/webhdfs/v1/simple_storage?op=OPEN&namenoderpcaddress=hdfs1:9000&offset=0', 'TSV', 'word String')")
+    assert "not allowed" in node7.query_and_get_error(
+        "CREATE TABLE table_test_7_2 (word String) ENGINE=HDFS('http://hdfs1:50075/webhdfs/v1/simple_storage?op=OPEN&namenoderpcaddress=hdfs1:9000&offset=0', 'CSV')")
+    assert "not allowed" in node7.query_and_get_error(
+        "SELECT * FROM hdfs('http://hdfs1:50075/webhdfs/v1/simple_storage?op=OPEN&namenoderpcaddress=hdfs1:9000&offset=0', 'TSV', 'word String')")

--- a/tests/integration/test_alter_codec/test.py
+++ b/tests/integration/test_alter_codec/test.py
@@ -2,14 +2,13 @@ import pytest
 from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 
-
 cluster = ClickHouseCluster(__file__)
 
 node1 = cluster.add_instance('node1',
-            main_configs=['configs/logs_config.xml'])
+                             main_configs=['configs/logs_config.xml'])
 
 node2 = cluster.add_instance('node2',
-            main_configs=['configs/logs_config.xml'])
+                             main_configs=['configs/logs_config.xml'])
 
 
 @pytest.fixture(scope="module")
@@ -38,7 +37,6 @@ def test_alter_codec_pk(started_cluster):
 
         with pytest.raises(QueryRuntimeException):
             node1.query("ALTER TABLE {name} MODIFY COLUMN id UInt32 CODEC(Delta, LZ4)".format(name=name))
-
 
         node1.query("ALTER TABLE {name} MODIFY COLUMN id UInt64 DEFAULT 3 CODEC(Delta, LZ4)".format(name=name))
 

--- a/tests/integration/test_always_fetch_merged/test.py
+++ b/tests/integration/test_always_fetch_merged/test.py
@@ -1,13 +1,14 @@
-import pytest
 import time
+
+import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_eq_with_retry
-
 
 cluster = ClickHouseCluster(__file__)
 
 node1 = cluster.add_instance('node1', with_zookeeper=True)
 node2 = cluster.add_instance('node2', with_zookeeper=True)
+
 
 @pytest.fixture(scope="module")
 def started_cluster():

--- a/tests/integration/test_asynchronous_metric_log_table/test.py
+++ b/tests/integration/test_asynchronous_metric_log_table/test.py
@@ -39,7 +39,7 @@ def test_event_time_microseconds_field(started_cluster):
         node1.query(query_create)
         node1.query('''INSERT INTO replica.test VALUES (1, now())''')
         node1.query("SYSTEM FLUSH LOGS;")
-        #query assumes that the event_time field is accurate
+        # query assumes that the event_time field is accurate
         equals_query = '''WITH (
                             (
                                 SELECT event_time_microseconds

--- a/tests/integration/test_atomic_drop_table/test.py
+++ b/tests/integration/test_atomic_drop_table/test.py
@@ -1,12 +1,12 @@
 import time
+
 import pytest
-
-from helpers.network import PartitionManager
 from helpers.cluster import ClickHouseCluster
-
+from helpers.network import PartitionManager
 
 cluster = ClickHouseCluster(__file__)
-node1 = cluster.add_instance('node1', main_configs=["configs/config.d/zookeeper_session_timeout.xml", "configs/remote_servers.xml"], with_zookeeper=True)
+node1 = cluster.add_instance('node1', main_configs=["configs/config.d/zookeeper_session_timeout.xml",
+                                                    "configs/remote_servers.xml"], with_zookeeper=True)
 
 
 @pytest.fixture(scope="module")
@@ -25,12 +25,13 @@ def start_cluster():
     finally:
         cluster.shutdown()
 
+
 def test_atomic_delete_with_stopped_zookeeper(start_cluster):
     node1.query("insert into zktest.atomic_drop_table values (8192)")
 
     with PartitionManager() as pm:
         pm.drop_instance_zk_connections(node1)
-        error = node1.query_and_get_error("DROP TABLE zktest.atomic_drop_table") #Table won't drop
+        error = node1.query_and_get_error("DROP TABLE zktest.atomic_drop_table")  # Table won't drop
         assert error != ""
 
     time.sleep(5)

--- a/tests/integration/test_attach_without_checksums/test.py
+++ b/tests/integration/test_attach_without_checksums/test.py
@@ -17,7 +17,8 @@ def start_cluster():
 
 
 def test_attach_without_checksums(start_cluster):
-    node1.query("CREATE TABLE test (date Date, key Int32, value String) Engine=MergeTree ORDER BY key PARTITION by date")
+    node1.query(
+        "CREATE TABLE test (date Date, key Int32, value String) Engine=MergeTree ORDER BY key PARTITION by date")
 
     node1.query("INSERT INTO test SELECT toDate('2019-10-01'), number, toString(number) FROM numbers(100)")
 
@@ -29,9 +30,13 @@ def test_attach_without_checksums(start_cluster):
     assert node1.query("SELECT COUNT() FROM test") == "0\n"
 
     # to be sure output not empty
-    node1.exec_in_container(['bash', '-c', 'find /var/lib/clickhouse/data/default/test/detached -name "checksums.txt" | grep -e ".*" '], privileged=True, user='root')
+    node1.exec_in_container(
+        ['bash', '-c', 'find /var/lib/clickhouse/data/default/test/detached -name "checksums.txt" | grep -e ".*" '],
+        privileged=True, user='root')
 
-    node1.exec_in_container(['bash', '-c', 'find /var/lib/clickhouse/data/default/test/detached -name "checksums.txt" -delete'], privileged=True, user='root')
+    node1.exec_in_container(
+        ['bash', '-c', 'find /var/lib/clickhouse/data/default/test/detached -name "checksums.txt" -delete'],
+        privileged=True, user='root')
 
     node1.query("ALTER TABLE test ATTACH PARTITION '2019-10-01'")
 

--- a/tests/integration/test_authentication/test.py
+++ b/tests/integration/test_authentication/test.py
@@ -30,7 +30,8 @@ def test_authentication_pass():
 
 def test_authentication_fail():
     # User doesn't exist.
-    assert "vasya: Authentication failed" in instance.query_and_get_error("SELECT currentUser()", user = 'vasya')
-    
+    assert "vasya: Authentication failed" in instance.query_and_get_error("SELECT currentUser()", user='vasya')
+
     # Wrong password.
-    assert "masha: Authentication failed" in instance.query_and_get_error("SELECT currentUser()", user = 'masha', password = '123')
+    assert "masha: Authentication failed" in instance.query_and_get_error("SELECT currentUser()", user='masha',
+                                                                          password='123')

--- a/tests/integration/test_backup_restore/test.py
+++ b/tests/integration/test_backup_restore/test.py
@@ -1,9 +1,8 @@
 import os.path
-import pytest
 
+import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
-
 
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance('instance')
@@ -47,7 +46,7 @@ def backup_restore(started_cluster):
 
     expected = TSV('1970-01-02\t1\n1970-01-03\t2\n1970-01-04\t3\n1970-02-01\t31\n1970-02-02\t32\n1970-02-03\t33')
     res = q("SELECT * FROM test.tbl ORDER BY p")
-    assert(TSV(res) == expected)
+    assert (TSV(res) == expected)
 
     q("ALTER TABLE test.tbl FREEZE")
 
@@ -69,7 +68,7 @@ def test_restore(backup_restore):
     # Validate the attached parts are identical to the backup.
     expected = TSV('1970-01-02\t1\n1970-01-03\t2\n1970-01-04\t3\n1970-02-01\t31\n1970-02-02\t32\n1970-02-03\t33')
     res = q("SELECT * FROM test.tbl1 ORDER BY p")
-    assert(TSV(res) == expected)
+    assert (TSV(res) == expected)
 
     q("ALTER TABLE test.tbl1 UPDATE k=10 WHERE 1")
     q("SELECT sleep(2)")
@@ -77,7 +76,7 @@ def test_restore(backup_restore):
     # Validate mutation has been applied to all attached parts.
     expected = TSV('1970-01-02\t10\n1970-01-03\t10\n1970-01-04\t10\n1970-02-01\t10\n1970-02-02\t10\n1970-02-03\t10')
     res = q("SELECT * FROM test.tbl1 ORDER BY p")
-    assert(TSV(res) == expected)
+    assert (TSV(res) == expected)
 
     q("DROP TABLE IF EXISTS test.tbl1")
 
@@ -91,7 +90,7 @@ def test_attach_partition(backup_restore):
 
     expected = TSV('1970-01-04\t3\n1970-01-05\t4\n1970-02-03\t33\n1970-02-04\t34')
     res = q("SELECT * FROM test.tbl2 ORDER BY p")
-    assert(TSV(res) == expected)
+    assert (TSV(res) == expected)
 
     copy_backup_to_detached('test', 'tbl', 'tbl2')
 
@@ -102,17 +101,19 @@ def test_attach_partition(backup_restore):
     q("ALTER TABLE test.tbl2 ATTACH PARTITION 197002")
     q("SELECT sleep(2)")
 
-    expected = TSV('1970-01-02\t1\n1970-01-03\t2\n1970-01-04\t3\n1970-01-04\t3\n1970-01-05\t4\n1970-02-01\t31\n1970-02-02\t32\n1970-02-03\t33\n1970-02-03\t33\n1970-02-04\t34')
+    expected = TSV(
+        '1970-01-02\t1\n1970-01-03\t2\n1970-01-04\t3\n1970-01-04\t3\n1970-01-05\t4\n1970-02-01\t31\n1970-02-02\t32\n1970-02-03\t33\n1970-02-03\t33\n1970-02-04\t34')
     res = q("SELECT * FROM test.tbl2 ORDER BY p")
-    assert(TSV(res) == expected)
+    assert (TSV(res) == expected)
 
     q("ALTER TABLE test.tbl2 UPDATE k=10 WHERE 1")
     q("SELECT sleep(2)")
 
     # Validate mutation has been applied to all attached parts.
-    expected = TSV('1970-01-02\t10\n1970-01-03\t10\n1970-01-04\t10\n1970-01-04\t10\n1970-01-05\t10\n1970-02-01\t10\n1970-02-02\t10\n1970-02-03\t10\n1970-02-03\t10\n1970-02-04\t10')
+    expected = TSV(
+        '1970-01-02\t10\n1970-01-03\t10\n1970-01-04\t10\n1970-01-04\t10\n1970-01-05\t10\n1970-02-01\t10\n1970-02-02\t10\n1970-02-03\t10\n1970-02-03\t10\n1970-02-04\t10')
     res = q("SELECT * FROM test.tbl2 ORDER BY p")
-    assert(TSV(res) == expected)
+    assert (TSV(res) == expected)
 
     q("DROP TABLE IF EXISTS test.tbl2")
 
@@ -126,7 +127,7 @@ def test_replace_partition(backup_restore):
 
     expected = TSV('1970-01-04\t3\n1970-01-05\t4\n1970-02-03\t33\n1970-02-04\t34')
     res = q("SELECT * FROM test.tbl3 ORDER BY p")
-    assert(TSV(res) == expected)
+    assert (TSV(res) == expected)
 
     copy_backup_to_detached('test', 'tbl', 'tbl3')
 
@@ -138,7 +139,7 @@ def test_replace_partition(backup_restore):
 
     expected = TSV('1970-01-04\t3\n1970-01-05\t4\n1970-02-01\t31\n1970-02-02\t32\n1970-02-03\t33')
     res = q("SELECT * FROM test.tbl3 ORDER BY p")
-    assert(TSV(res) == expected)
+    assert (TSV(res) == expected)
 
     q("ALTER TABLE test.tbl3 UPDATE k=10 WHERE 1")
     q("SELECT sleep(2)")
@@ -146,6 +147,6 @@ def test_replace_partition(backup_restore):
     # Validate mutation has been applied to all copied parts.
     expected = TSV('1970-01-04\t10\n1970-01-05\t10\n1970-02-01\t10\n1970-02-02\t10\n1970-02-03\t10')
     res = q("SELECT * FROM test.tbl3 ORDER BY p")
-    assert(TSV(res) == expected)
+    assert (TSV(res) == expected)
 
     q("DROP TABLE IF EXISTS test.tbl3")

--- a/tests/integration/test_backup_with_other_granularity/test.py
+++ b/tests/integration/test_backup_with_other_granularity/test.py
@@ -1,13 +1,15 @@
 import pytest
 
-
 from helpers.cluster import ClickHouseCluster
+
 cluster = ClickHouseCluster(__file__)
 
-
-node1 = cluster.add_instance('node1', with_zookeeper=True, image='yandex/clickhouse-server', tag='19.4.5.35', stay_alive=True, with_installed_binary=True)
-node2 = cluster.add_instance('node2', with_zookeeper=True, image='yandex/clickhouse-server', tag='19.4.5.35', stay_alive=True, with_installed_binary=True)
-node3 = cluster.add_instance('node3', with_zookeeper=True, image='yandex/clickhouse-server', tag='19.4.5.35', stay_alive=True, with_installed_binary=True)
+node1 = cluster.add_instance('node1', with_zookeeper=True, image='yandex/clickhouse-server', tag='19.4.5.35',
+                             stay_alive=True, with_installed_binary=True)
+node2 = cluster.add_instance('node2', with_zookeeper=True, image='yandex/clickhouse-server', tag='19.4.5.35',
+                             stay_alive=True, with_installed_binary=True)
+node3 = cluster.add_instance('node3', with_zookeeper=True, image='yandex/clickhouse-server', tag='19.4.5.35',
+                             stay_alive=True, with_installed_binary=True)
 node4 = cluster.add_instance('node4')
 
 
@@ -33,13 +35,15 @@ def test_backup_from_old_version(started_cluster):
 
     node1.restart_with_latest_version()
 
-    node1.query("CREATE TABLE dest_table (A Int64,  B String,  Y String) ENGINE = ReplicatedMergeTree('/test/dest_table1', '1')  ORDER BY tuple()")
+    node1.query(
+        "CREATE TABLE dest_table (A Int64,  B String,  Y String) ENGINE = ReplicatedMergeTree('/test/dest_table1', '1')  ORDER BY tuple()")
 
     node1.query("INSERT INTO dest_table VALUES(2, '2', 'Hello')")
 
     assert node1.query("SELECT COUNT() FROM dest_table") == "1\n"
 
-    node1.exec_in_container(['bash', '-c', 'cp -r /var/lib/clickhouse/shadow/1/data/default/source_table/all_1_1_0/ /var/lib/clickhouse/data/default/dest_table/detached'])
+    node1.exec_in_container(['bash', '-c',
+                             'cp -r /var/lib/clickhouse/shadow/1/data/default/source_table/all_1_1_0/ /var/lib/clickhouse/data/default/dest_table/detached'])
 
     assert node1.query("SELECT COUNT() FROM dest_table") == "1\n"
 
@@ -69,13 +73,15 @@ def test_backup_from_old_version_setting(started_cluster):
 
     node2.restart_with_latest_version()
 
-    node2.query("CREATE TABLE dest_table (A Int64,  B String,  Y String) ENGINE = ReplicatedMergeTree('/test/dest_table2', '1')  ORDER BY tuple() SETTINGS enable_mixed_granularity_parts = 1")
+    node2.query(
+        "CREATE TABLE dest_table (A Int64,  B String,  Y String) ENGINE = ReplicatedMergeTree('/test/dest_table2', '1')  ORDER BY tuple() SETTINGS enable_mixed_granularity_parts = 1")
 
     node2.query("INSERT INTO dest_table VALUES(2, '2', 'Hello')")
 
     assert node2.query("SELECT COUNT() FROM dest_table") == "1\n"
 
-    node2.exec_in_container(['bash', '-c', 'cp -r /var/lib/clickhouse/shadow/1/data/default/source_table/all_1_1_0/ /var/lib/clickhouse/data/default/dest_table/detached'])
+    node2.exec_in_container(['bash', '-c',
+                             'cp -r /var/lib/clickhouse/shadow/1/data/default/source_table/all_1_1_0/ /var/lib/clickhouse/data/default/dest_table/detached'])
 
     assert node2.query("SELECT COUNT() FROM dest_table") == "1\n"
 
@@ -104,17 +110,20 @@ def test_backup_from_old_version_config(started_cluster):
     node3.query("ALTER TABLE source_table FREEZE PARTITION tuple();")
 
     def callback(n):
-        n.replace_config("/etc/clickhouse-server/merge_tree_settings.xml", "<yandex><merge_tree><enable_mixed_granularity_parts>1</enable_mixed_granularity_parts></merge_tree></yandex>")
+        n.replace_config("/etc/clickhouse-server/merge_tree_settings.xml",
+                         "<yandex><merge_tree><enable_mixed_granularity_parts>1</enable_mixed_granularity_parts></merge_tree></yandex>")
 
     node3.restart_with_latest_version(callback_onstop=callback)
 
-    node3.query("CREATE TABLE dest_table (A Int64,  B String,  Y String) ENGINE = ReplicatedMergeTree('/test/dest_table3', '1')  ORDER BY tuple() SETTINGS enable_mixed_granularity_parts = 1")
+    node3.query(
+        "CREATE TABLE dest_table (A Int64,  B String,  Y String) ENGINE = ReplicatedMergeTree('/test/dest_table3', '1')  ORDER BY tuple() SETTINGS enable_mixed_granularity_parts = 1")
 
     node3.query("INSERT INTO dest_table VALUES(2, '2', 'Hello')")
 
     assert node3.query("SELECT COUNT() FROM dest_table") == "1\n"
 
-    node3.exec_in_container(['bash', '-c', 'cp -r /var/lib/clickhouse/shadow/1/data/default/source_table/all_1_1_0/ /var/lib/clickhouse/data/default/dest_table/detached'])
+    node3.exec_in_container(['bash', '-c',
+                             'cp -r /var/lib/clickhouse/shadow/1/data/default/source_table/all_1_1_0/ /var/lib/clickhouse/data/default/dest_table/detached'])
 
     assert node3.query("SELECT COUNT() FROM dest_table") == "1\n"
 
@@ -144,7 +153,8 @@ def test_backup_and_alter(started_cluster):
 
     node4.query("ALTER TABLE backup_table DROP PARTITION tuple()")
 
-    node4.exec_in_container(['bash', '-c', 'cp -r /var/lib/clickhouse/shadow/1/data/default/backup_table/all_1_1_0/ /var/lib/clickhouse/data/default/backup_table/detached'])
+    node4.exec_in_container(['bash', '-c',
+                             'cp -r /var/lib/clickhouse/shadow/1/data/default/backup_table/all_1_1_0/ /var/lib/clickhouse/data/default/backup_table/detached'])
 
     node4.query("ALTER TABLE backup_table ATTACH PARTITION tuple()")
 

--- a/tests/integration/test_backward_compatibility/test.py
+++ b/tests/integration/test_backward_compatibility/test.py
@@ -1,11 +1,12 @@
 import pytest
 
-import helpers.client as client
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
-node1 = cluster.add_instance('node1', with_zookeeper=True, image='yandex/clickhouse-server', tag='19.17.8.54', stay_alive=True, with_installed_binary=True)
+node1 = cluster.add_instance('node1', with_zookeeper=True, image='yandex/clickhouse-server', tag='19.17.8.54',
+                             stay_alive=True, with_installed_binary=True)
 node2 = cluster.add_instance('node2', with_zookeeper=True)
+
 
 @pytest.fixture(scope="module")
 def start_cluster():
@@ -13,10 +14,10 @@ def start_cluster():
         cluster.start()
         for i, node in enumerate([node1, node2]):
             node.query(
-            '''CREATE TABLE t(date Date, id UInt32)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/t', '{}')
-            PARTITION BY toYYYYMM(date)
-            ORDER BY id'''.format(i))
+                '''CREATE TABLE t(date Date, id UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/t', '{}')
+                PARTITION BY toYYYYMM(date)
+                ORDER BY id'''.format(i))
 
         yield cluster
 

--- a/tests/integration/test_backward_compatibility/test_aggregate_function_state_avg.py
+++ b/tests/integration/test_backward_compatibility/test_aggregate_function_state_avg.py
@@ -1,15 +1,17 @@
 import pytest
 
-import helpers.client as client
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1',
-    with_zookeeper=False, image='yandex/clickhouse-server', tag='19.16.9.37', stay_alive=True, with_installed_binary=True)
+                             with_zookeeper=False, image='yandex/clickhouse-server', tag='19.16.9.37', stay_alive=True,
+                             with_installed_binary=True)
 node2 = cluster.add_instance('node2',
-    with_zookeeper=False, image='yandex/clickhouse-server', tag='19.16.9.37', stay_alive=True, with_installed_binary=True)
+                             with_zookeeper=False, image='yandex/clickhouse-server', tag='19.16.9.37', stay_alive=True,
+                             with_installed_binary=True)
 node3 = cluster.add_instance('node3', with_zookeeper=False)
 node4 = cluster.add_instance('node4', with_zookeeper=False)
+
 
 @pytest.fixture(scope="module")
 def start_cluster():
@@ -19,6 +21,7 @@ def start_cluster():
 
     finally:
         cluster.shutdown()
+
 
 # We will test that serialization of internal state of "avg" function is compatible between different versions.
 # TODO Implement versioning of serialization format for aggregate function states.
@@ -35,18 +38,18 @@ def test_backward_compatability(start_cluster):
     node3.query("INSERT INTO tab VALUES (3)")
     node4.query("INSERT INTO tab VALUES (4)")
 
-    assert(node1.query("SELECT avg(x) FROM remote('node{1..4}', default, tab)") == '2.5\n')
-    assert(node2.query("SELECT avg(x) FROM remote('node{1..4}', default, tab)") == '2.5\n')
-    assert(node3.query("SELECT avg(x) FROM remote('node{1..4}', default, tab)") == '2.5\n')
-    assert(node4.query("SELECT avg(x) FROM remote('node{1..4}', default, tab)") == '2.5\n')
+    assert (node1.query("SELECT avg(x) FROM remote('node{1..4}', default, tab)") == '2.5\n')
+    assert (node2.query("SELECT avg(x) FROM remote('node{1..4}', default, tab)") == '2.5\n')
+    assert (node3.query("SELECT avg(x) FROM remote('node{1..4}', default, tab)") == '2.5\n')
+    assert (node4.query("SELECT avg(x) FROM remote('node{1..4}', default, tab)") == '2.5\n')
 
     # Also check with persisted aggregate function state
 
     node1.query("create table state (x AggregateFunction(avg, UInt64)) engine = Log")
     node1.query("INSERT INTO state SELECT avgState(arrayJoin(CAST([1, 2, 3, 4] AS Array(UInt64))))")
 
-    assert(node1.query("SELECT avgMerge(x) FROM state") == '2.5\n')
+    assert (node1.query("SELECT avgMerge(x) FROM state") == '2.5\n')
 
     node1.restart_with_latest_version()
 
-    assert(node1.query("SELECT avgMerge(x) FROM state") == '2.5\n')
+    assert (node1.query("SELECT avgMerge(x) FROM state") == '2.5\n')

--- a/tests/integration/test_backward_compatibility/test_short_strings_aggregation.py
+++ b/tests/integration/test_backward_compatibility/test_short_strings_aggregation.py
@@ -1,12 +1,14 @@
 import pytest
 
-import helpers.client as client
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
-node1 = cluster.add_instance('node1', with_zookeeper=False, image='yandex/clickhouse-server', tag='19.16.9.37', stay_alive=True, with_installed_binary=True)
-node2 = cluster.add_instance('node2', with_zookeeper=False, image='yandex/clickhouse-server', tag='19.16.9.37', stay_alive=True, with_installed_binary=True)
+node1 = cluster.add_instance('node1', with_zookeeper=False, image='yandex/clickhouse-server', tag='19.16.9.37',
+                             stay_alive=True, with_installed_binary=True)
+node2 = cluster.add_instance('node2', with_zookeeper=False, image='yandex/clickhouse-server', tag='19.16.9.37',
+                             stay_alive=True, with_installed_binary=True)
 node3 = cluster.add_instance('node3', with_zookeeper=False)
+
 
 @pytest.fixture(scope="module")
 def start_cluster():
@@ -23,6 +25,7 @@ def test_backward_compatability(start_cluster):
     node2.query("create table tab (s String) engine = MergeTree order by s")
     node1.query("insert into tab select number from numbers(50)")
     node2.query("insert into tab select number from numbers(1000000)")
-    res = node3.query("select s, count() from remote('node{1,2}', default, tab) group by s order by toUInt64(s) limit 50")
+    res = node3.query(
+        "select s, count() from remote('node{1,2}', default, tab) group by s order by toUInt64(s) limit 50")
     print(res)
     assert res == ''.join('{}\t2\n'.format(i) for i in range(50))

--- a/tests/integration/test_block_structure_mismatch/test.py
+++ b/tests/integration/test_block_structure_mismatch/test.py
@@ -1,7 +1,5 @@
-import time
 import pytest
 
-from contextlib import contextmanager
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
@@ -9,7 +7,8 @@ cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml'])
 node2 = cluster.add_instance('node2', main_configs=['configs/remote_servers.xml'])
 
-#test reproducing issue https://github.com/ClickHouse/ClickHouse/issues/3162
+
+# test reproducing issue https://github.com/ClickHouse/ClickHouse/issues/3162
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
@@ -44,7 +43,9 @@ CREATE TABLE dist_test (
     finally:
         cluster.shutdown()
 
+
 def test(started_cluster):
     node1.query("INSERT INTO local_test (t, shard, col1, col2) VALUES (1000, 0, 'x', 'y')")
     node2.query("INSERT INTO local_test (t, shard, col1, col2) VALUES (1000, 1, 'foo', 'bar')")
-    assert node1.query("SELECT col1, col2 FROM dist_test WHERE (t < 3600000) AND (col1 = 'foo') ORDER BY t ASC") == "foo\tbar\n"
+    assert node1.query(
+        "SELECT col1, col2 FROM dist_test WHERE (t < 3600000) AND (col1 = 'foo') ORDER BY t ASC") == "foo\tbar\n"

--- a/tests/integration/test_check_table/test.py
+++ b/tests/integration/test_check_table/test.py
@@ -1,9 +1,6 @@
-import time
-
 import pytest
 
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 
@@ -34,15 +31,22 @@ def started_cluster():
 
 
 def corrupt_data_part_on_disk(node, table, part_name):
-    part_path = node.query("SELECT path FROM system.parts WHERE table = '{}' and name = '{}'".format(table, part_name)).strip()
-    node.exec_in_container(['bash', '-c', 'cd {p} && ls *.bin | head -n 1 | xargs -I{{}} sh -c \'echo "1" >> $1\' -- {{}}'.format(p=part_path)], privileged=True)
+    part_path = node.query(
+        "SELECT path FROM system.parts WHERE table = '{}' and name = '{}'".format(table, part_name)).strip()
+    node.exec_in_container(['bash', '-c',
+                            'cd {p} && ls *.bin | head -n 1 | xargs -I{{}} sh -c \'echo "1" >> $1\' -- {{}}'.format(
+                                p=part_path)], privileged=True)
+
 
 def remove_checksums_on_disk(node, table, part_name):
-    part_path = node.query("SELECT path FROM system.parts WHERE table = '{}' and name = '{}'".format(table, part_name)).strip()
+    part_path = node.query(
+        "SELECT path FROM system.parts WHERE table = '{}' and name = '{}'".format(table, part_name)).strip()
     node.exec_in_container(['bash', '-c', 'rm -r {p}/checksums.txt'.format(p=part_path)], privileged=True)
 
+
 def remove_part_from_disk(node, table, part_name):
-    part_path = node.query("SELECT path FROM system.parts WHERE table = '{}' and name = '{}'".format(table, part_name)).strip()
+    part_path = node.query(
+        "SELECT path FROM system.parts WHERE table = '{}' and name = '{}'".format(table, part_name)).strip()
     if not part_path:
         raise Exception("Part " + part_name + "doesn't exist")
     node.exec_in_container(['bash', '-c', 'rm -r {p}/*'.format(p=part_path)], privileged=True)
@@ -50,35 +54,42 @@ def remove_part_from_disk(node, table, part_name):
 
 def test_check_normal_table_corruption(started_cluster):
     node1.query("INSERT INTO non_replicated_mt VALUES (toDate('2019-02-01'), 1, 10), (toDate('2019-02-01'), 2, 12)")
-    assert node1.query("CHECK TABLE non_replicated_mt PARTITION 201902", settings={"check_query_single_value_result": 0}) == "201902_1_1_0\t1\t\n"
+    assert node1.query("CHECK TABLE non_replicated_mt PARTITION 201902",
+                       settings={"check_query_single_value_result": 0}) == "201902_1_1_0\t1\t\n"
 
     remove_checksums_on_disk(node1, "non_replicated_mt", "201902_1_1_0")
 
-    assert node1.query("CHECK TABLE non_replicated_mt", settings={"check_query_single_value_result": 0}).strip() == "201902_1_1_0\t1\tChecksums recounted and written to disk."
+    assert node1.query("CHECK TABLE non_replicated_mt", settings={
+        "check_query_single_value_result": 0}).strip() == "201902_1_1_0\t1\tChecksums recounted and written to disk."
 
     assert node1.query("SELECT COUNT() FROM non_replicated_mt") == "2\n"
 
     remove_checksums_on_disk(node1, "non_replicated_mt", "201902_1_1_0")
 
-    assert node1.query("CHECK TABLE non_replicated_mt PARTITION 201902", settings={"check_query_single_value_result": 0}).strip() == "201902_1_1_0\t1\tChecksums recounted and written to disk."
+    assert node1.query("CHECK TABLE non_replicated_mt PARTITION 201902", settings={
+        "check_query_single_value_result": 0}).strip() == "201902_1_1_0\t1\tChecksums recounted and written to disk."
 
     assert node1.query("SELECT COUNT() FROM non_replicated_mt") == "2\n"
 
     corrupt_data_part_on_disk(node1, "non_replicated_mt", "201902_1_1_0")
 
-    assert node1.query("CHECK TABLE non_replicated_mt", settings={"check_query_single_value_result": 0}).strip() == "201902_1_1_0\t0\tCannot read all data. Bytes read: 2. Bytes expected: 16."
+    assert node1.query("CHECK TABLE non_replicated_mt", settings={
+        "check_query_single_value_result": 0}).strip() == "201902_1_1_0\t0\tCannot read all data. Bytes read: 2. Bytes expected: 16."
 
-    assert node1.query("CHECK TABLE non_replicated_mt", settings={"check_query_single_value_result": 0}).strip() == "201902_1_1_0\t0\tCannot read all data. Bytes read: 2. Bytes expected: 16."
+    assert node1.query("CHECK TABLE non_replicated_mt", settings={
+        "check_query_single_value_result": 0}).strip() == "201902_1_1_0\t0\tCannot read all data. Bytes read: 2. Bytes expected: 16."
 
     node1.query("INSERT INTO non_replicated_mt VALUES (toDate('2019-01-01'), 1, 10), (toDate('2019-01-01'), 2, 12)")
 
-    assert node1.query("CHECK TABLE non_replicated_mt PARTITION 201901", settings={"check_query_single_value_result": 0}) == "201901_2_2_0\t1\t\n"
+    assert node1.query("CHECK TABLE non_replicated_mt PARTITION 201901",
+                       settings={"check_query_single_value_result": 0}) == "201901_2_2_0\t1\t\n"
 
     corrupt_data_part_on_disk(node1, "non_replicated_mt", "201901_2_2_0")
 
     remove_checksums_on_disk(node1, "non_replicated_mt", "201901_2_2_0")
 
-    assert node1.query("CHECK TABLE non_replicated_mt PARTITION 201901", settings={"check_query_single_value_result": 0}) == "201901_2_2_0\t0\tCheck of part finished with error: \\'Cannot read all data. Bytes read: 2. Bytes expected: 16.\\'\n"
+    assert node1.query("CHECK TABLE non_replicated_mt PARTITION 201901", settings={
+        "check_query_single_value_result": 0}) == "201901_2_2_0\t0\tCheck of part finished with error: \\'Cannot read all data. Bytes read: 2. Bytes expected: 16.\\'\n"
 
 
 def test_check_replicated_table_simple(started_cluster):
@@ -90,16 +101,20 @@ def test_check_replicated_table_simple(started_cluster):
     assert node1.query("SELECT count() from replicated_mt") == "2\n"
     assert node2.query("SELECT count() from replicated_mt") == "2\n"
 
-    assert node1.query("CHECK TABLE replicated_mt", settings={"check_query_single_value_result": 0}) == "201902_0_0_0\t1\t\n"
-    assert node2.query("CHECK TABLE replicated_mt", settings={"check_query_single_value_result": 0}) == "201902_0_0_0\t1\t\n"
+    assert node1.query("CHECK TABLE replicated_mt",
+                       settings={"check_query_single_value_result": 0}) == "201902_0_0_0\t1\t\n"
+    assert node2.query("CHECK TABLE replicated_mt",
+                       settings={"check_query_single_value_result": 0}) == "201902_0_0_0\t1\t\n"
 
     node2.query("INSERT INTO replicated_mt VALUES (toDate('2019-01-02'), 3, 10), (toDate('2019-01-02'), 4, 12)")
     node1.query("SYSTEM SYNC REPLICA replicated_mt")
     assert node1.query("SELECT count() from replicated_mt") == "4\n"
     assert node2.query("SELECT count() from replicated_mt") == "4\n"
 
-    assert node1.query("CHECK TABLE replicated_mt PARTITION 201901", settings={"check_query_single_value_result": 0}) == "201901_0_0_0\t1\t\n"
-    assert node2.query("CHECK TABLE replicated_mt PARTITION 201901", settings={"check_query_single_value_result": 0}) == "201901_0_0_0\t1\t\n"
+    assert node1.query("CHECK TABLE replicated_mt PARTITION 201901",
+                       settings={"check_query_single_value_result": 0}) == "201901_0_0_0\t1\t\n"
+    assert node2.query("CHECK TABLE replicated_mt PARTITION 201901",
+                       settings={"check_query_single_value_result": 0}) == "201901_0_0_0\t1\t\n"
 
 
 def test_check_replicated_table_corruption(started_cluster):
@@ -112,18 +127,25 @@ def test_check_replicated_table_corruption(started_cluster):
     assert node1.query("SELECT count() from replicated_mt") == "4\n"
     assert node2.query("SELECT count() from replicated_mt") == "4\n"
 
-    part_name = node1.query("SELECT name from system.parts where table = 'replicated_mt' and partition_id = '201901' and active = 1").strip()
+    part_name = node1.query(
+        "SELECT name from system.parts where table = 'replicated_mt' and partition_id = '201901' and active = 1").strip()
 
     corrupt_data_part_on_disk(node1, "replicated_mt", part_name)
-    assert node1.query("CHECK TABLE replicated_mt PARTITION 201901", settings={"check_query_single_value_result": 0}) == "{p}\t0\tPart {p} looks broken. Removing it and queueing a fetch.\n".format(p=part_name)
+    assert node1.query("CHECK TABLE replicated_mt PARTITION 201901", settings={
+        "check_query_single_value_result": 0}) == "{p}\t0\tPart {p} looks broken. Removing it and queueing a fetch.\n".format(
+        p=part_name)
 
     node1.query("SYSTEM SYNC REPLICA replicated_mt")
-    assert node1.query("CHECK TABLE replicated_mt PARTITION 201901", settings={"check_query_single_value_result": 0}) == "{}\t1\t\n".format(part_name)
+    assert node1.query("CHECK TABLE replicated_mt PARTITION 201901",
+                       settings={"check_query_single_value_result": 0}) == "{}\t1\t\n".format(part_name)
     assert node1.query("SELECT count() from replicated_mt") == "4\n"
 
     remove_part_from_disk(node2, "replicated_mt", part_name)
-    assert node2.query("CHECK TABLE replicated_mt PARTITION 201901", settings={"check_query_single_value_result": 0}) == "{p}\t0\tPart {p} looks broken. Removing it and queueing a fetch.\n".format(p=part_name)
+    assert node2.query("CHECK TABLE replicated_mt PARTITION 201901", settings={
+        "check_query_single_value_result": 0}) == "{p}\t0\tPart {p} looks broken. Removing it and queueing a fetch.\n".format(
+        p=part_name)
 
     node1.query("SYSTEM SYNC REPLICA replicated_mt")
-    assert node1.query("CHECK TABLE replicated_mt PARTITION 201901", settings={"check_query_single_value_result": 0}) == "{}\t1\t\n".format(part_name)
+    assert node1.query("CHECK TABLE replicated_mt PARTITION 201901",
+                       settings={"check_query_single_value_result": 0}) == "{}\t1\t\n".format(part_name)
     assert node1.query("SELECT count() from replicated_mt") == "4\n"

--- a/tests/integration/test_cleanup_dir_after_bad_zk_conn/test.py
+++ b/tests/integration/test_cleanup_dir_after_bad_zk_conn/test.py
@@ -1,12 +1,12 @@
 import time
-import pytest
 
+import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
 
-
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', with_zookeeper=True)
+
 
 @pytest.fixture(scope="module")
 def start_cluster():
@@ -15,6 +15,7 @@ def start_cluster():
         yield cluster
     finally:
         cluster.shutdown()
+
 
 # This tests if the data directory for a table is cleaned up if there is a Zookeeper
 # connection exception during a CreateQuery operation involving ReplicatedMergeTree tables.
@@ -48,20 +49,30 @@ def test_cleanup_dir_after_bad_zk_conn(start_cluster):
     node1.query('''INSERT INTO replica.test VALUES (1, now())''')
     assert "1\n" in node1.query('''SELECT count() from replica.test FORMAT TSV''')
 
+
 def test_cleanup_dir_after_wrong_replica_name(start_cluster):
-    node1.query("CREATE TABLE test2_r1 (n UInt64) ENGINE=ReplicatedMergeTree('/clickhouse/tables/test2/', 'r1') ORDER BY n")
-    error = node1.query_and_get_error("CREATE TABLE test2_r2 (n UInt64) ENGINE=ReplicatedMergeTree('/clickhouse/tables/test2/', 'r1') ORDER BY n")
+    node1.query(
+        "CREATE TABLE test2_r1 (n UInt64) ENGINE=ReplicatedMergeTree('/clickhouse/tables/test2/', 'r1') ORDER BY n")
+    error = node1.query_and_get_error(
+        "CREATE TABLE test2_r2 (n UInt64) ENGINE=ReplicatedMergeTree('/clickhouse/tables/test2/', 'r1') ORDER BY n")
     assert "already exists" in error
-    node1.query("CREATE TABLE test_r2 (n UInt64) ENGINE=ReplicatedMergeTree('/clickhouse/tables/test2/', 'r2') ORDER BY n")
+    node1.query(
+        "CREATE TABLE test_r2 (n UInt64) ENGINE=ReplicatedMergeTree('/clickhouse/tables/test2/', 'r2') ORDER BY n")
+
 
 def test_cleanup_dir_after_wrong_zk_path(start_cluster):
-    node1.query("CREATE TABLE test3_r1 (n UInt64) ENGINE=ReplicatedMergeTree('/clickhouse/tables/test3/', 'r1') ORDER BY n")
-    error = node1.query_and_get_error("CREATE TABLE test3_r2 (n UInt64) ENGINE=ReplicatedMergeTree('/clickhouse/tables/', 'r2') ORDER BY n")
+    node1.query(
+        "CREATE TABLE test3_r1 (n UInt64) ENGINE=ReplicatedMergeTree('/clickhouse/tables/test3/', 'r1') ORDER BY n")
+    error = node1.query_and_get_error(
+        "CREATE TABLE test3_r2 (n UInt64) ENGINE=ReplicatedMergeTree('/clickhouse/tables/', 'r2') ORDER BY n")
     assert "Cannot create" in error
-    node1.query("CREATE TABLE test3_r2 (n UInt64) ENGINE=ReplicatedMergeTree('/clickhouse/tables/test3/', 'r2') ORDER BY n")
+    node1.query(
+        "CREATE TABLE test3_r2 (n UInt64) ENGINE=ReplicatedMergeTree('/clickhouse/tables/test3/', 'r2') ORDER BY n")
+
 
 def test_attach_without_zk(start_cluster):
-    node1.query("CREATE TABLE test4_r1 (n UInt64) ENGINE=ReplicatedMergeTree('/clickhouse/tables/test4/', 'r1') ORDER BY n")
+    node1.query(
+        "CREATE TABLE test4_r1 (n UInt64) ENGINE=ReplicatedMergeTree('/clickhouse/tables/test4/', 'r1') ORDER BY n")
     node1.query("DETACH TABLE test4_r1")
     with PartitionManager() as pm:
         pm._add_rule({'probability': 0.5, 'source': node1.ip_address, 'destination_port': 2181, 'action': 'DROP'})

--- a/tests/integration/test_cluster_all_replicas/test.py
+++ b/tests/integration/test_cluster_all_replicas/test.py
@@ -7,6 +7,7 @@ cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml'], with_zookeeper=True)
 node2 = cluster.add_instance('node2', main_configs=['configs/remote_servers.xml'], with_zookeeper=True)
 
+
 @pytest.fixture(scope="module")
 def start_cluster():
     try:

--- a/tests/integration/test_cluster_copier/test.py
+++ b/tests/integration/test_cluster_copier/test.py
@@ -1,14 +1,14 @@
 import os
+import random
 import sys
 import time
+from contextlib import contextmanager
+
+import docker
 import kazoo
 import pytest
-import docker
-import random
-from contextlib import contextmanager
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
-
 
 CURRENT_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.dirname(CURRENT_TEST_DIR))
@@ -18,9 +18,10 @@ MOVING_FAIL_PROBABILITY = 0.2
 
 cluster = ClickHouseCluster(__file__)
 
+
 def check_all_hosts_sucesfully_executed(tsv_content, num_hosts):
     M = TSV.toMat(tsv_content)
-    hosts = [(l[0], l[1]) for l in M] # (host, port)
+    hosts = [(l[0], l[1]) for l in M]  # (host, port)
     codes = [l[2] for l in M]
 
     assert len(hosts) == num_hosts and len(set(hosts)) == num_hosts, "\n" + tsv_content
@@ -39,14 +40,14 @@ def started_cluster():
     global cluster
     try:
         clusters_schema = {
-         "0" : {
-            "0" : ["0", "1"],
-            "1" : ["0"]
-         },
-         "1" : {
-            "0" : ["0", "1"],
-            "1" : ["0"]
-         }
+            "0": {
+                "0": ["0", "1"],
+                "1": ["0"]
+            },
+            "1": {
+                "0": ["0", "1"],
+                "1": ["0"]
+            }
         }
 
         for cluster_name, shards in clusters_schema.iteritems():
@@ -54,10 +55,11 @@ def started_cluster():
                 for replica_name in replicas:
                     name = "s{}_{}_{}".format(cluster_name, shard_name, replica_name)
                     cluster.add_instance(name,
-                        main_configs=["configs/conf.d/query_log.xml", "configs/conf.d/ddl.xml", "configs/conf.d/clusters.xml"],
-                        user_configs=["configs/users.xml"],
-                        macros={"cluster": cluster_name, "shard": shard_name, "replica": replica_name},
-                        with_zookeeper=True)
+                                         main_configs=["configs/conf.d/query_log.xml", "configs/conf.d/ddl.xml",
+                                                       "configs/conf.d/clusters.xml"],
+                                         user_configs=["configs/users.xml"],
+                                         macros={"cluster": cluster_name, "shard": shard_name, "replica": replica_name},
+                                         with_zookeeper=True)
 
         cluster.start()
         yield cluster
@@ -70,24 +72,27 @@ class Task1:
 
     def __init__(self, cluster):
         self.cluster = cluster
-        self.zk_task_path="/clickhouse-copier/task_simple"
+        self.zk_task_path = "/clickhouse-copier/task_simple"
         self.copier_task_config = open(os.path.join(CURRENT_TEST_DIR, 'task0_description.xml'), 'r').read()
-
 
     def start(self):
         instance = cluster.instances['s0_0_0']
 
         for cluster_num in ["0", "1"]:
             ddl_check_query(instance, "DROP DATABASE IF EXISTS default ON CLUSTER cluster{}".format(cluster_num))
-            ddl_check_query(instance, "CREATE DATABASE IF NOT EXISTS default ON CLUSTER cluster{} ENGINE=Ordinary".format(cluster_num))
+            ddl_check_query(instance,
+                            "CREATE DATABASE IF NOT EXISTS default ON CLUSTER cluster{} ENGINE=Ordinary".format(
+                                cluster_num))
 
         ddl_check_query(instance, "CREATE TABLE hits ON CLUSTER cluster0 (d UInt64, d1 UInt64 MATERIALIZED d+1) " +
-                                  "ENGINE=ReplicatedMergeTree('/clickhouse/tables/cluster_{cluster}/{shard}/hits', '{replica}') " +
-                                  "PARTITION BY d % 3 ORDER BY (d, sipHash64(d)) SAMPLE BY sipHash64(d) SETTINGS index_granularity = 16")
-        ddl_check_query(instance, "CREATE TABLE hits_all ON CLUSTER cluster0 (d UInt64) ENGINE=Distributed(cluster0, default, hits, d)")
-        ddl_check_query(instance, "CREATE TABLE hits_all ON CLUSTER cluster1 (d UInt64) ENGINE=Distributed(cluster1, default, hits, d + 1)")
-        instance.query("INSERT INTO hits_all SELECT * FROM system.numbers LIMIT 1002", settings={"insert_distributed_sync": 1})
-
+                        "ENGINE=ReplicatedMergeTree('/clickhouse/tables/cluster_{cluster}/{shard}/hits', '{replica}') " +
+                        "PARTITION BY d % 3 ORDER BY (d, sipHash64(d)) SAMPLE BY sipHash64(d) SETTINGS index_granularity = 16")
+        ddl_check_query(instance,
+                        "CREATE TABLE hits_all ON CLUSTER cluster0 (d UInt64) ENGINE=Distributed(cluster0, default, hits, d)")
+        ddl_check_query(instance,
+                        "CREATE TABLE hits_all ON CLUSTER cluster1 (d UInt64) ENGINE=Distributed(cluster1, default, hits, d + 1)")
+        instance.query("INSERT INTO hits_all SELECT * FROM system.numbers LIMIT 1002",
+                       settings={"insert_distributed_sync": 1})
 
     def check(self):
         assert TSV(self.cluster.instances['s0_0_0'].query("SELECT count() FROM hits_all")) == TSV("1002\n")
@@ -107,31 +112,44 @@ class Task2:
 
     def __init__(self, cluster):
         self.cluster = cluster
-        self.zk_task_path="/clickhouse-copier/task_month_to_week_partition"
+        self.zk_task_path = "/clickhouse-copier/task_month_to_week_partition"
         self.copier_task_config = open(os.path.join(CURRENT_TEST_DIR, 'task_month_to_week_description.xml'), 'r').read()
-
 
     def start(self):
         instance = cluster.instances['s0_0_0']
 
         for cluster_num in ["0", "1"]:
             ddl_check_query(instance, "DROP DATABASE IF EXISTS default ON CLUSTER cluster{}".format(cluster_num))
-            ddl_check_query(instance, "CREATE DATABASE IF NOT EXISTS default ON CLUSTER cluster{} ENGINE=Ordinary".format(cluster_num))
+            ddl_check_query(instance,
+                            "CREATE DATABASE IF NOT EXISTS default ON CLUSTER cluster{} ENGINE=Ordinary".format(
+                                cluster_num))
 
-        ddl_check_query(instance, "CREATE TABLE a ON CLUSTER cluster0 (date Date, d UInt64, d1 UInt64 ALIAS d+1) ENGINE=ReplicatedMergeTree('/clickhouse/tables/cluster_{cluster}/{shard}/a', '{replica}', date, intHash64(d), (date, intHash64(d)), 8192)")
-        ddl_check_query(instance, "CREATE TABLE a_all ON CLUSTER cluster0 (date Date, d UInt64) ENGINE=Distributed(cluster0, default, a, d)")
+        ddl_check_query(instance,
+                        "CREATE TABLE a ON CLUSTER cluster0 (date Date, d UInt64, d1 UInt64 ALIAS d+1) ENGINE=ReplicatedMergeTree('/clickhouse/tables/cluster_{cluster}/{shard}/a', '{replica}', date, intHash64(d), (date, intHash64(d)), 8192)")
+        ddl_check_query(instance,
+                        "CREATE TABLE a_all ON CLUSTER cluster0 (date Date, d UInt64) ENGINE=Distributed(cluster0, default, a, d)")
 
-        instance.query("INSERT INTO a_all SELECT toDate(17581 + number) AS date, number AS d FROM system.numbers LIMIT 85", settings={"insert_distributed_sync": 1})
+        instance.query(
+            "INSERT INTO a_all SELECT toDate(17581 + number) AS date, number AS d FROM system.numbers LIMIT 85",
+            settings={"insert_distributed_sync": 1})
 
     def check(self):
-        assert TSV(self.cluster.instances['s0_0_0'].query("SELECT count() FROM cluster(cluster0, default, a)")) == TSV("85\n")
-        assert TSV(self.cluster.instances['s1_0_0'].query("SELECT count(), uniqExact(date) FROM cluster(cluster1, default, b)")) == TSV("85\t85\n")
+        assert TSV(self.cluster.instances['s0_0_0'].query("SELECT count() FROM cluster(cluster0, default, a)")) == TSV(
+            "85\n")
+        assert TSV(self.cluster.instances['s1_0_0'].query(
+            "SELECT count(), uniqExact(date) FROM cluster(cluster1, default, b)")) == TSV("85\t85\n")
 
-        assert TSV(self.cluster.instances['s1_0_0'].query("SELECT DISTINCT jumpConsistentHash(intHash64(d), 2) FROM b")) == TSV("0\n")
-        assert TSV(self.cluster.instances['s1_1_0'].query("SELECT DISTINCT jumpConsistentHash(intHash64(d), 2) FROM b")) == TSV("1\n")
+        assert TSV(self.cluster.instances['s1_0_0'].query(
+            "SELECT DISTINCT jumpConsistentHash(intHash64(d), 2) FROM b")) == TSV("0\n")
+        assert TSV(self.cluster.instances['s1_1_0'].query(
+            "SELECT DISTINCT jumpConsistentHash(intHash64(d), 2) FROM b")) == TSV("1\n")
 
-        assert TSV(self.cluster.instances['s1_0_0'].query("SELECT uniqExact(partition) IN (12, 13) FROM system.parts WHERE active AND database='default' AND table='b'")) == TSV("1\n")
-        assert TSV(self.cluster.instances['s1_1_0'].query("SELECT uniqExact(partition) IN (12, 13) FROM system.parts WHERE active AND database='default' AND table='b'")) == TSV("1\n")
+        assert TSV(self.cluster.instances['s1_0_0'].query(
+            "SELECT uniqExact(partition) IN (12, 13) FROM system.parts WHERE active AND database='default' AND table='b'")) == TSV(
+            "1\n")
+        assert TSV(self.cluster.instances['s1_1_0'].query(
+            "SELECT uniqExact(partition) IN (12, 13) FROM system.parts WHERE active AND database='default' AND table='b'")) == TSV(
+            "1\n")
 
         instance = cluster.instances['s0_0_0']
         ddl_check_query(instance, "DROP TABLE a ON CLUSTER cluster0")
@@ -142,10 +160,9 @@ class Task_test_block_size:
 
     def __init__(self, cluster):
         self.cluster = cluster
-        self.zk_task_path="/clickhouse-copier/task_test_block_size"
+        self.zk_task_path = "/clickhouse-copier/task_test_block_size"
         self.copier_task_config = open(os.path.join(CURRENT_TEST_DIR, 'task_test_block_size.xml'), 'r').read()
         self.rows = 1000000
-
 
     def start(self):
         instance = cluster.instances['s0_0_0']
@@ -155,11 +172,13 @@ class Task_test_block_size:
             ENGINE=ReplicatedMergeTree('/clickhouse/tables/cluster_{cluster}/{shard}/test_block_size', '{replica}')
             ORDER BY (d, sipHash64(d)) SAMPLE BY sipHash64(d)""", 2)
 
-        instance.query("INSERT INTO test_block_size SELECT toDate(0) AS partition, number as d FROM system.numbers LIMIT {}".format(self.rows))
-
+        instance.query(
+            "INSERT INTO test_block_size SELECT toDate(0) AS partition, number as d FROM system.numbers LIMIT {}".format(
+                self.rows))
 
     def check(self):
-        assert TSV(self.cluster.instances['s1_0_0'].query("SELECT count() FROM cluster(cluster1, default, test_block_size)")) == TSV("{}\n".format(self.rows))
+        assert TSV(self.cluster.instances['s1_0_0'].query(
+            "SELECT count() FROM cluster(cluster1, default, test_block_size)")) == TSV("{}\n".format(self.rows))
 
         instance = cluster.instances['s0_0_0']
         ddl_check_query(instance, "DROP TABLE test_block_size ON CLUSTER shard_0_0", 2)
@@ -170,16 +189,14 @@ class Task_no_index:
 
     def __init__(self, cluster):
         self.cluster = cluster
-        self.zk_task_path="/clickhouse-copier/task_no_index"
+        self.zk_task_path = "/clickhouse-copier/task_no_index"
         self.copier_task_config = open(os.path.join(CURRENT_TEST_DIR, 'task_no_index.xml'), 'r').read()
         self.rows = 1000000
-
 
     def start(self):
         instance = cluster.instances['s0_0_0']
         instance.query("create table ontime (Year UInt16, FlightDate String) ENGINE = Memory")
         instance.query("insert into ontime values (2016, 'test6'), (2017, 'test7'), (2018, 'test8')")
-
 
     def check(self):
         assert TSV(self.cluster.instances['s1_1_0'].query("SELECT Year FROM ontime22")) == TSV("2017\n")
@@ -193,16 +210,15 @@ class Task_no_arg:
 
     def __init__(self, cluster):
         self.cluster = cluster
-        self.zk_task_path="/clickhouse-copier/task_no_arg"
+        self.zk_task_path = "/clickhouse-copier/task_no_arg"
         self.copier_task_config = open(os.path.join(CURRENT_TEST_DIR, 'task_no_arg.xml'), 'r').read()
         self.rows = 1000000
 
-
     def start(self):
         instance = cluster.instances['s0_0_0']
-        instance.query("create table copier_test1 (date Date, id UInt32) engine = MergeTree PARTITION BY date ORDER BY date SETTINGS index_granularity = 8192")
+        instance.query(
+            "create table copier_test1 (date Date, id UInt32) engine = MergeTree PARTITION BY date ORDER BY date SETTINGS index_granularity = 8192")
         instance.query("insert into copier_test1 values ('2016-01-01', 10);")
-
 
     def check(self):
         assert TSV(self.cluster.instances['s1_1_0'].query("SELECT date FROM copier_test1_1")) == TSV("2016-01-01\n")
@@ -227,15 +243,14 @@ def execute_task(task, cmd_options):
     zk.ensure_path(zk_task_path)
     zk.create(zk_task_path + "/description", task.copier_task_config)
 
-
     # Run cluster-copier processes on each node
     docker_api = docker.from_env().api
     copiers_exec_ids = []
 
     cmd = ['/usr/bin/clickhouse', 'copier',
-        '--config', '/etc/clickhouse-server/config-copier.xml',
-        '--task-path', zk_task_path,
-        '--base-dir', '/var/log/clickhouse-server/copier']
+           '--config', '/etc/clickhouse-server/config-copier.xml',
+           '--task-path', zk_task_path,
+           '--base-dir', '/var/log/clickhouse-server/copier']
     cmd += cmd_options
 
     copiers = random.sample(cluster.instances.keys(), 3)
@@ -243,7 +258,8 @@ def execute_task(task, cmd_options):
     for instance_name in copiers:
         instance = cluster.instances[instance_name]
         container = instance.get_docker_handle()
-        instance.copy_file_to_container(os.path.join(CURRENT_TEST_DIR, "configs/config-copier.xml"), "/etc/clickhouse-server/config-copier.xml")
+        instance.copy_file_to_container(os.path.join(CURRENT_TEST_DIR, "configs/config-copier.xml"),
+                                        "/etc/clickhouse-server/config-copier.xml")
         print "Copied copier config to {}".format(instance.name)
         exec_id = docker_api.exec_create(container.id, cmd, stderr=True)
         output = docker_api.exec_start(exec_id).decode('utf8')
@@ -277,7 +293,6 @@ def execute_task(task, cmd_options):
         True
     ]
 )
-
 def test_copy_simple(started_cluster, use_sample_offset):
     if use_sample_offset:
         execute_task(Task1(started_cluster), ['--experimental-use-sample-offset', '1'])
@@ -292,13 +307,13 @@ def test_copy_simple(started_cluster, use_sample_offset):
         True
     ]
 )
-
 def test_copy_with_recovering(started_cluster, use_sample_offset):
     if use_sample_offset:
         execute_task(Task1(started_cluster), ['--copy-fault-probability', str(COPYING_FAIL_PROBABILITY),
                                               '--experimental-use-sample-offset', '1'])
     else:
         execute_task(Task1(started_cluster), ['--copy-fault-probability', str(COPYING_FAIL_PROBABILITY)])
+
 
 @pytest.mark.parametrize(
     ('use_sample_offset'),
@@ -307,7 +322,6 @@ def test_copy_with_recovering(started_cluster, use_sample_offset):
         True
     ]
 )
-
 def test_copy_with_recovering_after_move_faults(started_cluster, use_sample_offset):
     if use_sample_offset:
         execute_task(Task1(started_cluster), ['--move-fault-probability', str(MOVING_FAIL_PROBABILITY),
@@ -315,29 +329,36 @@ def test_copy_with_recovering_after_move_faults(started_cluster, use_sample_offs
     else:
         execute_task(Task1(started_cluster), ['--move-fault-probability', str(MOVING_FAIL_PROBABILITY)])
 
+
 @pytest.mark.timeout(600)
 def test_copy_month_to_week_partition(started_cluster):
     execute_task(Task2(started_cluster), [])
+
 
 @pytest.mark.timeout(600)
 def test_copy_month_to_week_partition_with_recovering(started_cluster):
     execute_task(Task2(started_cluster), ['--copy-fault-probability', str(COPYING_FAIL_PROBABILITY)])
 
+
 @pytest.mark.timeout(600)
 def test_copy_month_to_week_partition_with_recovering_after_move_faults(started_cluster):
     execute_task(Task2(started_cluster), ['--move-fault-probability', str(MOVING_FAIL_PROBABILITY)])
 
+
 def test_block_size(started_cluster):
     execute_task(Task_test_block_size(started_cluster), [])
+
 
 def test_no_index(started_cluster):
     execute_task(Task_no_index(started_cluster), [])
 
+
 def test_no_arg(started_cluster):
     execute_task(Task_no_arg(started_cluster), [])
 
+
 if __name__ == '__main__':
     with contextmanager(started_cluster)() as cluster:
-       for name, instance in cluster.instances.items():
-           print name, instance.ip_address
-       raw_input("Cluster created, press any key to destroy...")
+        for name, instance in cluster.instances.items():
+            print name, instance.ip_address
+        raw_input("Cluster created, press any key to destroy...")

--- a/tests/integration/test_cluster_copier/trivial_test.py
+++ b/tests/integration/test_cluster_copier/trivial_test.py
@@ -1,13 +1,10 @@
 import os
-import os.path as p
 import sys
 import time
-import datetime
-import pytest
 from contextlib import contextmanager
-import docker
-from kazoo.client import KazooClient
 
+import docker
+import pytest
 
 CURRENT_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.dirname(CURRENT_TEST_DIR))
@@ -18,13 +15,14 @@ COPYING_FAIL_PROBABILITY = 0.33
 MOVING_FAIL_PROBABILITY = 0.1
 cluster = None
 
+
 @pytest.fixture(scope="function")
 def started_cluster():
     global cluster
     try:
         clusters_schema = {
-            "0" : {"0" : ["0"]},
-            "1" : {"0" : ["0"]}
+            "0": {"0": ["0"]},
+            "1": {"0": ["0"]}
         }
 
         cluster = ClickHouseCluster(__file__)
@@ -50,11 +48,10 @@ class TaskTrivial:
     def __init__(self, cluster, use_sample_offset):
         self.cluster = cluster
         if use_sample_offset:
-            self.zk_task_path="/clickhouse-copier/task_trivial_use_sample_offset"
+            self.zk_task_path = "/clickhouse-copier/task_trivial_use_sample_offset"
         else:
-            self.zk_task_path="/clickhouse-copier/task_trivial"
+            self.zk_task_path = "/clickhouse-copier/task_trivial"
         self.copier_task_config = open(os.path.join(CURRENT_TEST_DIR, 'task_trivial.xml'), 'r').read()
-
 
     def start(self):
         source = cluster.instances['s0_0_0']
@@ -68,8 +65,8 @@ class TaskTrivial:
                      "ENGINE=ReplicatedMergeTree('/clickhouse/tables/source_trivial_cluster/1/trivial', '1') "
                      "PARTITION BY d % 5 ORDER BY (d, sipHash64(d)) SAMPLE BY sipHash64(d) SETTINGS index_granularity = 16")
 
-        source.query("INSERT INTO trivial SELECT * FROM system.numbers LIMIT 1002", settings={"insert_distributed_sync": 1})
-
+        source.query("INSERT INTO trivial SELECT * FROM system.numbers LIMIT 1002",
+                     settings={"insert_distributed_sync": 1})
 
     def check(self):
         source = cluster.instances['s0_0_0']
@@ -138,7 +135,6 @@ def execute_task(task, cmd_options):
         True
     ]
 )
-
 def test_trivial_copy(started_cluster, use_sample_offset):
     if use_sample_offset:
         execute_task(TaskTrivial(started_cluster, use_sample_offset), ['--experimental-use-sample-offset', '1'])
@@ -146,6 +142,7 @@ def test_trivial_copy(started_cluster, use_sample_offset):
         print("AAAAA")
         execute_task(TaskTrivial(started_cluster, use_sample_offset), [])
 
+
 @pytest.mark.parametrize(
     ('use_sample_offset'),
     [
@@ -153,7 +150,6 @@ def test_trivial_copy(started_cluster, use_sample_offset):
         True
     ]
 )
-
 def test_trivial_copy_with_copy_fault(started_cluster, use_sample_offset):
     if use_sample_offset:
         execute_task(TaskTrivial(started_cluster), ['--copy-fault-probability', str(COPYING_FAIL_PROBABILITY),
@@ -161,6 +157,7 @@ def test_trivial_copy_with_copy_fault(started_cluster, use_sample_offset):
     else:
         execute_task(TaskTrivial(started_cluster), ['--copy-fault-probability', str(COPYING_FAIL_PROBABILITY)])
 
+
 @pytest.mark.parametrize(
     ('use_sample_offset'),
     [
@@ -168,7 +165,6 @@ def test_trivial_copy_with_copy_fault(started_cluster, use_sample_offset):
         True
     ]
 )
-
 def test_trivial_copy_with_move_fault(started_cluster, use_sample_offset):
     if use_sample_offset:
         execute_task(TaskTrivial(started_cluster), ['--move-fault-probability', str(MOVING_FAIL_PROBABILITY),

--- a/tests/integration/test_concurrent_queries_for_user_restriction/test.py
+++ b/tests/integration/test_concurrent_queries_for_user_restriction/test.py
@@ -1,14 +1,14 @@
 import time
+from multiprocessing.dummy import Pool
 
 import pytest
-
-from multiprocessing.dummy import Pool
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 
 node1 = cluster.add_instance('node1', user_configs=['configs/user_restrictions.xml'])
 node2 = cluster.add_instance('node2', user_configs=['configs/user_restrictions.xml'])
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -21,6 +21,7 @@ def started_cluster():
     finally:
         cluster.shutdown()
 
+
 def test_exception_message(started_cluster):
     assert node1.query("select number from nums order by number") == "0\n1\n"
 
@@ -30,7 +31,7 @@ def test_exception_message(started_cluster):
 
     busy_pool = Pool(3)
     busy_pool.map_async(node_busy, xrange(3))
-    time.sleep(1) # wait a little until polling starts
+    time.sleep(1)  # wait a little until polling starts
     try:
         assert node2.query("select number from remote('node1', 'default', 'nums')", user='good') == "0\n1\n"
     except Exception as ex:

--- a/tests/integration/test_concurrent_ttl_merges/test.py
+++ b/tests/integration/test_concurrent_ttl_merges/test.py
@@ -1,11 +1,8 @@
 import time
+
 import pytest
-
-import helpers.client as client
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import TSV
 from helpers.test_tools import assert_eq_with_retry
-
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', main_configs=['configs/fast_background_pool.xml'], with_zookeeper=True)
@@ -24,14 +21,16 @@ def started_cluster():
 
 
 def count_ttl_merges_in_queue(node, table):
-    result = node.query("SELECT count() FROM system.replication_queue WHERE merge_type = 'TTL_DELETE' and table = '{}'".format(table))
+    result = node.query(
+        "SELECT count() FROM system.replication_queue WHERE merge_type = 'TTL_DELETE' and table = '{}'".format(table))
     if not result:
         return 0
     return int(result.strip())
 
 
 def count_ttl_merges_in_background_pool(node, table):
-    result = node.query("SELECT count() FROM system.merges WHERE merge_type = 'TTL_DELETE' and table = '{}'".format(table))
+    result = node.query(
+        "SELECT count() FROM system.merges WHERE merge_type = 'TTL_DELETE' and table = '{}'".format(table))
     if not result:
         return 0
     return int(result.strip())
@@ -55,12 +54,14 @@ def count_running_mutations(node, table):
 # but it revealed a bug when we assign different merges to the same part
 # on the borders of partitions.
 def test_no_ttl_merges_in_busy_pool(started_cluster):
-    node1.query("CREATE TABLE test_ttl (d DateTime, key UInt64, data UInt64) ENGINE = MergeTree() ORDER BY tuple() PARTITION BY key TTL d + INTERVAL 1 MONTH SETTINGS merge_with_ttl_timeout = 0, number_of_free_entries_in_pool_to_execute_mutation = 0")
+    node1.query(
+        "CREATE TABLE test_ttl (d DateTime, key UInt64, data UInt64) ENGINE = MergeTree() ORDER BY tuple() PARTITION BY key TTL d + INTERVAL 1 MONTH SETTINGS merge_with_ttl_timeout = 0, number_of_free_entries_in_pool_to_execute_mutation = 0")
 
     node1.query("SYSTEM STOP TTL MERGES")
 
     for i in range(1, 7):
-        node1.query("INSERT INTO test_ttl SELECT now() - INTERVAL 1 MONTH + number - 1, {}, number FROM numbers(5)".format(i))
+        node1.query(
+            "INSERT INTO test_ttl SELECT now() - INTERVAL 1 MONTH + number - 1, {}, number FROM numbers(5)".format(i))
 
     node1.query("ALTER TABLE test_ttl UPDATE data = data + 1 WHERE sleepEachRow(1) = 0")
 
@@ -80,7 +81,8 @@ def test_no_ttl_merges_in_busy_pool(started_cluster):
 
 
 def test_limited_ttl_merges_in_empty_pool(started_cluster):
-    node1.query("CREATE TABLE test_ttl_v2 (d DateTime, key UInt64, data UInt64) ENGINE = MergeTree() ORDER BY tuple() PARTITION BY key TTL d + INTERVAL 1 MONTH SETTINGS merge_with_ttl_timeout = 0")
+    node1.query(
+        "CREATE TABLE test_ttl_v2 (d DateTime, key UInt64, data UInt64) ENGINE = MergeTree() ORDER BY tuple() PARTITION BY key TTL d + INTERVAL 1 MONTH SETTINGS merge_with_ttl_timeout = 0")
 
     node1.query("SYSTEM STOP TTL MERGES")
 
@@ -102,7 +104,8 @@ def test_limited_ttl_merges_in_empty_pool(started_cluster):
 
 
 def test_limited_ttl_merges_in_empty_pool_replicated(started_cluster):
-    node1.query("CREATE TABLE replicated_ttl (d DateTime, key UInt64, data UInt64) ENGINE = ReplicatedMergeTree('/test/t', '1') ORDER BY tuple() PARTITION BY key TTL d + INTERVAL 1 MONTH SETTINGS merge_with_ttl_timeout = 0")
+    node1.query(
+        "CREATE TABLE replicated_ttl (d DateTime, key UInt64, data UInt64) ENGINE = ReplicatedMergeTree('/test/t', '1') ORDER BY tuple() PARTITION BY key TTL d + INTERVAL 1 MONTH SETTINGS merge_with_ttl_timeout = 0")
 
     node1.query("SYSTEM STOP TTL MERGES")
 
@@ -129,14 +132,17 @@ def test_limited_ttl_merges_in_empty_pool_replicated(started_cluster):
 def test_limited_ttl_merges_two_replicas(started_cluster):
     # Actually this test quite fast and often we cannot catch any merges.
     # To check for sure just add some sleeps in mergePartsToTemporaryPart
-    node1.query("CREATE TABLE replicated_ttl_2 (d DateTime, key UInt64, data UInt64) ENGINE = ReplicatedMergeTree('/test/t2', '1') ORDER BY tuple() PARTITION BY key TTL d + INTERVAL 1 MONTH SETTINGS merge_with_ttl_timeout = 0")
-    node2.query("CREATE TABLE replicated_ttl_2 (d DateTime, key UInt64, data UInt64) ENGINE = ReplicatedMergeTree('/test/t2', '2') ORDER BY tuple() PARTITION BY key TTL d + INTERVAL 1 MONTH SETTINGS merge_with_ttl_timeout = 0")
+    node1.query(
+        "CREATE TABLE replicated_ttl_2 (d DateTime, key UInt64, data UInt64) ENGINE = ReplicatedMergeTree('/test/t2', '1') ORDER BY tuple() PARTITION BY key TTL d + INTERVAL 1 MONTH SETTINGS merge_with_ttl_timeout = 0")
+    node2.query(
+        "CREATE TABLE replicated_ttl_2 (d DateTime, key UInt64, data UInt64) ENGINE = ReplicatedMergeTree('/test/t2', '2') ORDER BY tuple() PARTITION BY key TTL d + INTERVAL 1 MONTH SETTINGS merge_with_ttl_timeout = 0")
 
     node1.query("SYSTEM STOP TTL MERGES")
     node2.query("SYSTEM STOP TTL MERGES")
 
     for i in range(100):
-        node1.query("INSERT INTO replicated_ttl_2 SELECT now() - INTERVAL 1 MONTH, {}, number FROM numbers(10000)".format(i))
+        node1.query(
+            "INSERT INTO replicated_ttl_2 SELECT now() - INTERVAL 1 MONTH, {}, number FROM numbers(10000)".format(i))
 
     node2.query("SYSTEM SYNC REPLICA replicated_ttl_2", timeout=10)
     assert node1.query("SELECT COUNT() FROM replicated_ttl_2") == "1000000\n"
@@ -150,7 +156,8 @@ def test_limited_ttl_merges_two_replicas(started_cluster):
     while True:
         merges_with_ttl_count_node1.add(count_ttl_merges_in_background_pool(node1, "replicated_ttl_2"))
         merges_with_ttl_count_node2.add(count_ttl_merges_in_background_pool(node2, "replicated_ttl_2"))
-        if node1.query("SELECT COUNT() FROM replicated_ttl_2") == "0\n" and node2.query("SELECT COUNT() FROM replicated_ttl_2") == "0\n":
+        if node1.query("SELECT COUNT() FROM replicated_ttl_2") == "0\n" and node2.query(
+                "SELECT COUNT() FROM replicated_ttl_2") == "0\n":
             break
 
     # Both replicas can assign merges with TTL. If one will perform better than

--- a/tests/integration/test_config_corresponding_root/test.py
+++ b/tests/integration/test_config_corresponding_root/test.py
@@ -1,6 +1,6 @@
 import os
-import pytest
 
+import pytest
 from helpers.cluster import ClickHouseCluster
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -9,6 +9,7 @@ cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance('node', main_configs=["configs/config.d/bad.xml"])
 caught_exception = ""
 
+
 @pytest.fixture(scope="module")
 def start_cluster():
     global caught_exception
@@ -16,6 +17,7 @@ def start_cluster():
         cluster.start()
     except Exception as e:
         caught_exception = str(e)
+
 
 def test_work(start_cluster):
     print(caught_exception)

--- a/tests/integration/test_config_substitutions/test.py
+++ b/tests/integration/test_config_substitutions/test.py
@@ -1,21 +1,26 @@
-import time
 import pytest
 
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
-node1 = cluster.add_instance('node1', user_configs=['configs/config_no_substs.xml']) # hardcoded value 33333
-node2 = cluster.add_instance('node2', user_configs=['configs/config_env.xml'], env_variables={"MAX_QUERY_SIZE": "55555"})
+node1 = cluster.add_instance('node1', user_configs=['configs/config_no_substs.xml'])  # hardcoded value 33333
+node2 = cluster.add_instance('node2', user_configs=['configs/config_env.xml'],
+                             env_variables={"MAX_QUERY_SIZE": "55555"})
 node3 = cluster.add_instance('node3', user_configs=['configs/config_zk.xml'], with_zookeeper=True)
-node4 = cluster.add_instance('node4', user_configs=['configs/config_incl.xml'], main_configs=['configs/max_query_size.xml']) # include value 77777
+node4 = cluster.add_instance('node4', user_configs=['configs/config_incl.xml'],
+                             main_configs=['configs/max_query_size.xml'])  # include value 77777
 node5 = cluster.add_instance('node5', user_configs=['configs/config_allow_databases.xml'])
-node6 = cluster.add_instance('node6', user_configs=['configs/config_include_from_env.xml'], env_variables={"INCLUDE_FROM_ENV": "/etc/clickhouse-server/config.d/max_query_size.xml"}, main_configs=['configs/max_query_size.xml'])
+node6 = cluster.add_instance('node6', user_configs=['configs/config_include_from_env.xml'],
+                             env_variables={"INCLUDE_FROM_ENV": "/etc/clickhouse-server/config.d/max_query_size.xml"},
+                             main_configs=['configs/max_query_size.xml'])
+
 
 @pytest.fixture(scope="module")
 def start_cluster():
     try:
         def create_zk_roots(zk):
             zk.create(path="/setting/max_query_size", value="77777", makepath=True)
+
         cluster.add_zookeeper_startup_command(create_zk_roots)
 
         cluster.start()
@@ -23,25 +28,36 @@ def start_cluster():
     finally:
         cluster.shutdown()
 
+
 def test_config(start_cluster):
-   assert node1.query("select value from system.settings where name = 'max_query_size'") == "33333\n"
-   assert node2.query("select value from system.settings where name = 'max_query_size'") == "55555\n"
-   assert node3.query("select value from system.settings where name = 'max_query_size'") == "77777\n"
-   assert node4.query("select value from system.settings where name = 'max_query_size'") == "99999\n"
-   assert node6.query("select value from system.settings where name = 'max_query_size'") == "99999\n"
+    assert node1.query("select value from system.settings where name = 'max_query_size'") == "33333\n"
+    assert node2.query("select value from system.settings where name = 'max_query_size'") == "55555\n"
+    assert node3.query("select value from system.settings where name = 'max_query_size'") == "77777\n"
+    assert node4.query("select value from system.settings where name = 'max_query_size'") == "99999\n"
+    assert node6.query("select value from system.settings where name = 'max_query_size'") == "99999\n"
+
 
 def test_allow_databases(start_cluster):
     node5.query("CREATE DATABASE db1")
-    node5.query("CREATE TABLE db1.test_table(date Date, k1 String, v1 Int32) ENGINE = MergeTree(date, (k1, date), 8192)")
+    node5.query(
+        "CREATE TABLE db1.test_table(date Date, k1 String, v1 Int32) ENGINE = MergeTree(date, (k1, date), 8192)")
     node5.query("INSERT INTO db1.test_table VALUES('2000-01-01', 'test_key', 1)")
     assert node5.query("SELECT name FROM system.databases WHERE name = 'db1'") == "db1\n"
-    assert node5.query("SELECT name FROM system.tables WHERE database = 'db1' AND name = 'test_table' ") == "test_table\n"
-    assert node5.query("SELECT name FROM system.columns WHERE database = 'db1' AND table = 'test_table'") == "date\nk1\nv1\n"
-    assert node5.query("SELECT name FROM system.parts WHERE database = 'db1' AND table = 'test_table'") == "20000101_20000101_1_1_0\n"
-    assert node5.query("SELECT name FROM system.parts_columns WHERE database = 'db1' AND table = 'test_table'") == "20000101_20000101_1_1_0\n20000101_20000101_1_1_0\n20000101_20000101_1_1_0\n"
+    assert node5.query(
+        "SELECT name FROM system.tables WHERE database = 'db1' AND name = 'test_table' ") == "test_table\n"
+    assert node5.query(
+        "SELECT name FROM system.columns WHERE database = 'db1' AND table = 'test_table'") == "date\nk1\nv1\n"
+    assert node5.query(
+        "SELECT name FROM system.parts WHERE database = 'db1' AND table = 'test_table'") == "20000101_20000101_1_1_0\n"
+    assert node5.query(
+        "SELECT name FROM system.parts_columns WHERE database = 'db1' AND table = 'test_table'") == "20000101_20000101_1_1_0\n20000101_20000101_1_1_0\n20000101_20000101_1_1_0\n"
 
     assert node5.query("SELECT name FROM system.databases WHERE name = 'db1'", user="test_allow").strip() == ""
-    assert node5.query("SELECT name FROM system.tables WHERE database = 'db1' AND name = 'test_table'", user="test_allow").strip() == ""
-    assert node5.query("SELECT name FROM system.columns WHERE database = 'db1' AND table = 'test_table'", user="test_allow").strip() == ""
-    assert node5.query("SELECT name FROM system.parts WHERE database = 'db1' AND table = 'test_table'", user="test_allow").strip() == ""
-    assert node5.query("SELECT name FROM system.parts_columns WHERE database = 'db1' AND table = 'test_table'", user="test_allow").strip() == ""
+    assert node5.query("SELECT name FROM system.tables WHERE database = 'db1' AND name = 'test_table'",
+                       user="test_allow").strip() == ""
+    assert node5.query("SELECT name FROM system.columns WHERE database = 'db1' AND table = 'test_table'",
+                       user="test_allow").strip() == ""
+    assert node5.query("SELECT name FROM system.parts WHERE database = 'db1' AND table = 'test_table'",
+                       user="test_allow").strip() == ""
+    assert node5.query("SELECT name FROM system.parts_columns WHERE database = 'db1' AND table = 'test_table'",
+                       user="test_allow").strip() == ""

--- a/tests/integration/test_consistant_parts_after_move_partition/test.py
+++ b/tests/integration/test_consistant_parts_after_move_partition/test.py
@@ -1,11 +1,7 @@
-import os
-
 import pytest
 
 from helpers.cluster import ClickHouseCluster
-from helpers.network import PartitionManager
 from helpers.test_tools import assert_eq_with_retry
-
 
 CLICKHOUSE_DATABASE = 'test'
 
@@ -46,13 +42,14 @@ def test_consistent_part_after_move_partition(start_cluster):
     # insert into all replicas
     for i in range(100):
         node1.query('INSERT INTO `{database}`.src VALUES ({value} % 2, {value})'.format(database=CLICKHOUSE_DATABASE,
-                                                                                       value=i))
+                                                                                        value=i))
     query_source = 'SELECT COUNT(*) FROM `{database}`.src'.format(database=CLICKHOUSE_DATABASE)
     query_dest = 'SELECT COUNT(*) FROM `{database}`.dest'.format(database=CLICKHOUSE_DATABASE)
     assert_eq_with_retry(node2, query_source, node1.query(query_source))
     assert_eq_with_retry(node2, query_dest, node1.query(query_dest))
 
-    node1.query('ALTER TABLE `{database}`.src MOVE PARTITION 1 TO TABLE `{database}`.dest'.format(database=CLICKHOUSE_DATABASE))
+    node1.query(
+        'ALTER TABLE `{database}`.src MOVE PARTITION 1 TO TABLE `{database}`.dest'.format(database=CLICKHOUSE_DATABASE))
 
     assert_eq_with_retry(node2, query_source, node1.query(query_source))
     assert_eq_with_retry(node2, query_dest, node1.query(query_dest))

--- a/tests/integration/test_consistent_parts_after_clone_replica/test.py
+++ b/tests/integration/test_consistent_parts_after_clone_replica/test.py
@@ -8,18 +8,19 @@ from helpers.test_tools import assert_eq_with_retry
 def fill_nodes(nodes, shard):
     for node in nodes:
         node.query(
-        '''
-        CREATE DATABASE test;
-        CREATE TABLE test_table(date Date, id UInt32)
-        ENGINE = ReplicatedMergeTree('/clickhouse/tables/test{shard}/replicated', '{replica}')
-        ORDER BY id PARTITION BY toYYYYMM(date) 
-        SETTINGS min_replicated_logs_to_keep=3, max_replicated_logs_to_keep=5, cleanup_delay_period=0, cleanup_delay_period_random_add=0;
-        '''.format(shard=shard, replica=node.name))
+            '''
+            CREATE DATABASE test;
+            CREATE TABLE test_table(date Date, id UInt32)
+            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test{shard}/replicated', '{replica}')
+            ORDER BY id PARTITION BY toYYYYMM(date) 
+            SETTINGS min_replicated_logs_to_keep=3, max_replicated_logs_to_keep=5, cleanup_delay_period=0, cleanup_delay_period_random_add=0;
+            '''.format(shard=shard, replica=node.name))
 
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml'], with_zookeeper=True)
 node2 = cluster.add_instance('node2', main_configs=['configs/remote_servers.xml'], with_zookeeper=True)
+
 
 @pytest.fixture(scope="module")
 def start_cluster():
@@ -56,5 +57,3 @@ def test_inconsistent_parts_if_drop_while_replica_not_active(start_cluster):
         # the first replica will be cloned from the second
         pm.heal_all()
         assert_eq_with_retry(node1, "SELECT count(*) FROM test_table", node2.query("SELECT count(*) FROM test_table"))
-
-

--- a/tests/integration/test_cross_replication/test.py
+++ b/tests/integration/test_cross_replication/test.py
@@ -2,17 +2,16 @@ import time
 from contextlib import contextmanager
 
 import pytest
-
 from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
 from helpers.test_tools import assert_eq_with_retry
-
 
 cluster = ClickHouseCluster(__file__)
 
 node1 = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml'], with_zookeeper=True)
 node2 = cluster.add_instance('node2', main_configs=['configs/remote_servers.xml'], with_zookeeper=True)
 node3 = cluster.add_instance('node3', main_configs=['configs/remote_servers.xml'], with_zookeeper=True)
+
 
 @pytest.fixture(scope="module")
 def started_cluster():

--- a/tests/integration/test_custom_settings/test.py
+++ b/tests/integration/test_custom_settings/test.py
@@ -2,7 +2,8 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
-node = cluster.add_instance('node', main_configs=["configs/config.d/text_log.xml"], user_configs=["configs/users.d/custom_settings.xml"])
+node = cluster.add_instance('node', main_configs=["configs/config.d/text_log.xml"],
+                            user_configs=["configs/users.d/custom_settings.xml"])
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -22,9 +23,10 @@ def test():
     assert node.query("SELECT getSetting('custom_d')") == "some text\n"
 
     assert "custom_a = -5, custom_b = 10000000000, custom_c = -4.325, custom_d = \\'some text\\'" \
-        in node.query("SHOW CREATE SETTINGS PROFILE default")
+           in node.query("SHOW CREATE SETTINGS PROFILE default")
 
-    assert "no settings profile" in node.query_and_get_error("SHOW CREATE SETTINGS PROFILE profile_with_unknown_setting")
+    assert "no settings profile" in node.query_and_get_error(
+        "SHOW CREATE SETTINGS PROFILE profile_with_unknown_setting")
     assert "no settings profile" in node.query_and_get_error("SHOW CREATE SETTINGS PROFILE profile_illformed_setting")
 
 
@@ -33,9 +35,9 @@ def test_invalid_settings():
     node.query("SYSTEM FLUSH LOGS")
 
     assert node.query("SELECT COUNT() FROM system.text_log WHERE"
-        " message LIKE '%Could not parse profile `profile_illformed_setting`%'"
-        " AND message LIKE '%Couldn\\'t restore Field from dump%'") == "1\n"
+                      " message LIKE '%Could not parse profile `profile_illformed_setting`%'"
+                      " AND message LIKE '%Couldn\\'t restore Field from dump%'") == "1\n"
 
     assert node.query("SELECT COUNT() FROM system.text_log WHERE"
-        " message LIKE '%Could not parse profile `profile_with_unknown_setting`%'"
-        " AND message LIKE '%Setting x is neither a builtin setting nor started with the prefix \\'custom_\\'%'") == "1\n"
+                      " message LIKE '%Could not parse profile `profile_with_unknown_setting`%'"
+                      " AND message LIKE '%Setting x is neither a builtin setting nor started with the prefix \\'custom_\\'%'") == "1\n"

--- a/tests/integration/test_ddl_alter_query/test.py
+++ b/tests/integration/test_ddl_alter_query/test.py
@@ -10,7 +10,6 @@ node3 = cluster.add_instance('node3', main_configs=['configs/remote_servers.xml'
 node4 = cluster.add_instance('node4', main_configs=['configs/remote_servers.xml'], with_zookeeper=True)
 
 
-
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
@@ -18,10 +17,14 @@ def started_cluster():
 
         for i, node in enumerate([node1, node2]):
             node.query("CREATE DATABASE testdb")
-            node.query('''CREATE TABLE testdb.test_table(id UInt32, val String) ENGINE = ReplicatedMergeTree('/clickhouse/test/test_table1', '{}') ORDER BY id;'''.format(i))
+            node.query(
+                '''CREATE TABLE testdb.test_table(id UInt32, val String) ENGINE = ReplicatedMergeTree('/clickhouse/test/test_table1', '{}') ORDER BY id;'''.format(
+                    i))
         for i, node in enumerate([node3, node4]):
             node.query("CREATE DATABASE testdb")
-            node.query('''CREATE TABLE testdb.test_table(id UInt32, val String) ENGINE = ReplicatedMergeTree('/clickhouse/test/test_table2', '{}') ORDER BY id;'''.format(i))
+            node.query(
+                '''CREATE TABLE testdb.test_table(id UInt32, val String) ENGINE = ReplicatedMergeTree('/clickhouse/test/test_table2', '{}') ORDER BY id;'''.format(
+                    i))
         yield cluster
 
     finally:
@@ -34,7 +37,8 @@ def test_alter(started_cluster):
     node2.query("SYSTEM SYNC REPLICA testdb.test_table")
     node4.query("SYSTEM SYNC REPLICA testdb.test_table")
 
-    node1.query("ALTER TABLE testdb.test_table ON CLUSTER test_cluster ADD COLUMN somecolumn UInt8 AFTER val", settings={"replication_alter_partitions_sync": "2"})
+    node1.query("ALTER TABLE testdb.test_table ON CLUSTER test_cluster ADD COLUMN somecolumn UInt8 AFTER val",
+                settings={"replication_alter_partitions_sync": "2"})
 
     node1.query("SYSTEM SYNC REPLICA testdb.test_table")
     node2.query("SYSTEM SYNC REPLICA testdb.test_table")

--- a/tests/integration/test_default_compression_codec/test.py
+++ b/tests/integration/test_default_compression_codec/test.py
@@ -1,14 +1,17 @@
-import string
 import random
-import pytest
+import string
 
+import pytest
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 
 node1 = cluster.add_instance('node1', main_configs=['configs/default_compression.xml'], with_zookeeper=True)
 node2 = cluster.add_instance('node2', main_configs=['configs/default_compression.xml'], with_zookeeper=True)
-node3 = cluster.add_instance('node3', main_configs=['configs/default_compression.xml'], image='yandex/clickhouse-server', tag='20.3.16', stay_alive=True, with_installed_binary=True)
+node3 = cluster.add_instance('node3', main_configs=['configs/default_compression.xml'],
+                             image='yandex/clickhouse-server', tag='20.3.16', stay_alive=True,
+                             with_installed_binary=True)
+
 
 @pytest.fixture(scope="module")
 def start_cluster():
@@ -21,12 +24,14 @@ def start_cluster():
 
 
 def get_compression_codec_byte(node, table_name, part_name):
-    cmd = "tail -c +17 /var/lib/clickhouse/data/default/{}/{}/data1.bin | od -x -N 1 | head -n 1 | awk '{{print $2}}'".format(table_name, part_name)
+    cmd = "tail -c +17 /var/lib/clickhouse/data/default/{}/{}/data1.bin | od -x -N 1 | head -n 1 | awk '{{print $2}}'".format(
+        table_name, part_name)
     return node.exec_in_container(["bash", "-c", cmd]).strip()
 
 
 def get_second_multiple_codec_byte(node, table_name, part_name):
-    cmd = "tail -c +17 /var/lib/clickhouse/data/default/{}/{}/data1.bin | od -x -j 11 -N 1 | head -n 1 | awk '{{print $2}}'".format(table_name, part_name)
+    cmd = "tail -c +17 /var/lib/clickhouse/data/default/{}/{}/data1.bin | od -x -j 11 -N 1 | head -n 1 | awk '{{print $2}}'".format(
+        table_name, part_name)
     return node.exec_in_container(["bash", "-c", cmd]).strip()
 
 
@@ -74,16 +79,22 @@ def test_default_codec_single(start_cluster):
 
     # Same codec for all
     assert get_compression_codec_byte(node1, "compression_table", "1_0_0_0") == CODECS_MAPPING['ZSTD']
-    assert node1.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '1_0_0_0'") == "ZSTD(10)\n"
-    assert node2.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '1_0_0_0'") == "ZSTD(10)\n"
+    assert node1.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '1_0_0_0'") == "ZSTD(10)\n"
+    assert node2.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '1_0_0_0'") == "ZSTD(10)\n"
 
     assert get_compression_codec_byte(node1, "compression_table", "2_0_0_0") == CODECS_MAPPING['ZSTD']
-    assert node1.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '2_0_0_0'") == "ZSTD(10)\n"
-    assert node2.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '2_0_0_0'") == "ZSTD(10)\n"
+    assert node1.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '2_0_0_0'") == "ZSTD(10)\n"
+    assert node2.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '2_0_0_0'") == "ZSTD(10)\n"
 
     assert get_compression_codec_byte(node1, "compression_table", "3_0_0_0") == CODECS_MAPPING['ZSTD']
-    assert node1.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '3_0_0_0'") == "ZSTD(10)\n"
-    assert node2.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '3_0_0_0'") == "ZSTD(10)\n"
+    assert node1.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '3_0_0_0'") == "ZSTD(10)\n"
+    assert node2.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '3_0_0_0'") == "ZSTD(10)\n"
 
     # just to be sure that replication works
     node1.query("OPTIMIZE TABLE compression_table FINAL")
@@ -101,16 +112,22 @@ def test_default_codec_single(start_cluster):
     node2.query("SYSTEM FLUSH LOGS")
 
     assert get_compression_codec_byte(node1, "compression_table", "1_0_0_1") == CODECS_MAPPING['ZSTD']
-    assert node1.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '1_0_0_1'") == "ZSTD(10)\n"
-    assert node2.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '1_0_0_1'") == "ZSTD(10)\n"
+    assert node1.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '1_0_0_1'") == "ZSTD(10)\n"
+    assert node2.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '1_0_0_1'") == "ZSTD(10)\n"
 
     assert get_compression_codec_byte(node1, "compression_table", "2_0_0_1") == CODECS_MAPPING['LZ4HC']
-    assert node1.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '2_0_0_1'") == "LZ4HC(5)\n"
-    assert node2.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '2_0_0_1'") == "LZ4HC(5)\n"
+    assert node1.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '2_0_0_1'") == "LZ4HC(5)\n"
+    assert node2.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '2_0_0_1'") == "LZ4HC(5)\n"
 
     assert get_compression_codec_byte(node1, "compression_table", "3_0_0_1") == CODECS_MAPPING['LZ4']
-    assert node1.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '3_0_0_1'") == "LZ4\n"
-    assert node2.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '3_0_0_1'") == "LZ4\n"
+    assert node1.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '3_0_0_1'") == "LZ4\n"
+    assert node2.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '3_0_0_1'") == "LZ4\n"
 
     assert node1.query("SELECT COUNT() FROM compression_table") == "3\n"
     assert node2.query("SELECT COUNT() FROM compression_table") == "3\n"
@@ -137,18 +154,24 @@ def test_default_codec_multiple(start_cluster):
     # Same codec for all
     assert get_compression_codec_byte(node1, "compression_table_multiple", "1_0_0_0") == CODECS_MAPPING['Multiple']
     assert get_second_multiple_codec_byte(node1, "compression_table_multiple", "1_0_0_0") == CODECS_MAPPING['ZSTD']
-    assert node1.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table_multiple' and name = '1_0_0_0'") == "ZSTD(10)\n"
-    assert node2.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table_multiple' and name = '1_0_0_0'") == "ZSTD(10)\n"
+    assert node1.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table_multiple' and name = '1_0_0_0'") == "ZSTD(10)\n"
+    assert node2.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table_multiple' and name = '1_0_0_0'") == "ZSTD(10)\n"
 
     assert get_compression_codec_byte(node1, "compression_table_multiple", "2_0_0_0") == CODECS_MAPPING['Multiple']
     assert get_second_multiple_codec_byte(node1, "compression_table_multiple", "2_0_0_0") == CODECS_MAPPING['ZSTD']
-    assert node1.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table_multiple' and name = '2_0_0_0'") == "ZSTD(10)\n"
-    assert node2.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table_multiple' and name = '2_0_0_0'") == "ZSTD(10)\n"
+    assert node1.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table_multiple' and name = '2_0_0_0'") == "ZSTD(10)\n"
+    assert node2.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table_multiple' and name = '2_0_0_0'") == "ZSTD(10)\n"
 
     assert get_compression_codec_byte(node1, "compression_table_multiple", "3_0_0_0") == CODECS_MAPPING['Multiple']
     assert get_second_multiple_codec_byte(node1, "compression_table_multiple", "3_0_0_0") == CODECS_MAPPING['ZSTD']
-    assert node1.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table_multiple' and name = '3_0_0_0'") == "ZSTD(10)\n"
-    assert node2.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table_multiple' and name = '3_0_0_0'") == "ZSTD(10)\n"
+    assert node1.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table_multiple' and name = '3_0_0_0'") == "ZSTD(10)\n"
+    assert node2.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table_multiple' and name = '3_0_0_0'") == "ZSTD(10)\n"
 
     node2.query("SYSTEM SYNC REPLICA compression_table_multiple", timeout=15)
 
@@ -156,18 +179,24 @@ def test_default_codec_multiple(start_cluster):
 
     assert get_compression_codec_byte(node1, "compression_table_multiple", "1_0_0_1") == CODECS_MAPPING['Multiple']
     assert get_second_multiple_codec_byte(node1, "compression_table_multiple", "1_0_0_1") == CODECS_MAPPING['ZSTD']
-    assert node1.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table_multiple' and name = '1_0_0_1'") == "ZSTD(10)\n"
-    assert node2.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table_multiple' and name = '1_0_0_1'") == "ZSTD(10)\n"
+    assert node1.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table_multiple' and name = '1_0_0_1'") == "ZSTD(10)\n"
+    assert node2.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table_multiple' and name = '1_0_0_1'") == "ZSTD(10)\n"
 
     assert get_compression_codec_byte(node1, "compression_table_multiple", "2_0_0_1") == CODECS_MAPPING['Multiple']
     assert get_second_multiple_codec_byte(node1, "compression_table_multiple", "2_0_0_1") == CODECS_MAPPING['LZ4HC']
-    assert node1.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table_multiple' and name = '2_0_0_1'") == "LZ4HC(5)\n"
-    assert node2.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table_multiple' and name = '2_0_0_1'") == "LZ4HC(5)\n"
+    assert node1.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table_multiple' and name = '2_0_0_1'") == "LZ4HC(5)\n"
+    assert node2.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table_multiple' and name = '2_0_0_1'") == "LZ4HC(5)\n"
 
     assert get_compression_codec_byte(node1, "compression_table_multiple", "3_0_0_1") == CODECS_MAPPING['Multiple']
     assert get_second_multiple_codec_byte(node1, "compression_table_multiple", "3_0_0_1") == CODECS_MAPPING['LZ4']
-    assert node1.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table_multiple' and name = '3_0_0_1'") == "LZ4\n"
-    assert node2.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table_multiple' and name = '3_0_0_1'") == "LZ4\n"
+    assert node1.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table_multiple' and name = '3_0_0_1'") == "LZ4\n"
+    assert node2.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table_multiple' and name = '3_0_0_1'") == "LZ4\n"
 
     assert node1.query("SELECT COUNT() FROM compression_table_multiple") == "3\n"
     assert node2.query("SELECT COUNT() FROM compression_table_multiple") == "3\n"
@@ -187,15 +216,21 @@ def test_default_codec_version_update(start_cluster):
 
     node3.restart_with_latest_version()
 
-    assert node3.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '1_1_1_0'") == "ZSTD(1)\n"
-    assert node3.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '2_2_2_0'") == "ZSTD(1)\n"
-    assert node3.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '3_3_3_0'") == "ZSTD(1)\n"
+    assert node3.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '1_1_1_0'") == "ZSTD(1)\n"
+    assert node3.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '2_2_2_0'") == "ZSTD(1)\n"
+    assert node3.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '3_3_3_0'") == "ZSTD(1)\n"
 
     node3.query("OPTIMIZE TABLE compression_table FINAL")
 
-    assert node3.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '1_1_1_1'") == "ZSTD(10)\n"
-    assert node3.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '2_2_2_1'") == "LZ4HC(5)\n"
-    assert node3.query("SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '3_3_3_1'") == "LZ4\n"
+    assert node3.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '1_1_1_1'") == "ZSTD(10)\n"
+    assert node3.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '2_2_2_1'") == "LZ4HC(5)\n"
+    assert node3.query(
+        "SELECT default_compression_codec FROM system.parts WHERE table = 'compression_table' and name = '3_3_3_1'") == "LZ4\n"
     assert get_compression_codec_byte(node1, "compression_table_multiple", "2_0_0_1") == CODECS_MAPPING['Multiple']
     assert get_second_multiple_codec_byte(node1, "compression_table_multiple", "2_0_0_1") == CODECS_MAPPING['LZ4HC']
     assert get_compression_codec_byte(node1, "compression_table_multiple", "3_0_0_1") == CODECS_MAPPING['Multiple']

--- a/tests/integration/test_default_database_on_cluster/test.py
+++ b/tests/integration/test_default_database_on_cluster/test.py
@@ -1,12 +1,20 @@
-import time
 import pytest
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
-ch1 = cluster.add_instance('ch1', main_configs=["configs/config.d/clusters.xml", "configs/config.d/distributed_ddl.xml"], with_zookeeper=True)
-ch2 = cluster.add_instance('ch2', main_configs=["configs/config.d/clusters.xml", "configs/config.d/distributed_ddl.xml"], with_zookeeper=True)
-ch3 = cluster.add_instance('ch3', main_configs=["configs/config.d/clusters.xml", "configs/config.d/distributed_ddl.xml"], with_zookeeper=True)
-ch4 = cluster.add_instance('ch4', main_configs=["configs/config.d/clusters.xml", "configs/config.d/distributed_ddl.xml"], with_zookeeper=True)
+ch1 = cluster.add_instance('ch1',
+                           main_configs=["configs/config.d/clusters.xml", "configs/config.d/distributed_ddl.xml"],
+                           with_zookeeper=True)
+ch2 = cluster.add_instance('ch2',
+                           main_configs=["configs/config.d/clusters.xml", "configs/config.d/distributed_ddl.xml"],
+                           with_zookeeper=True)
+ch3 = cluster.add_instance('ch3',
+                           main_configs=["configs/config.d/clusters.xml", "configs/config.d/distributed_ddl.xml"],
+                           with_zookeeper=True)
+ch4 = cluster.add_instance('ch4',
+                           main_configs=["configs/config.d/clusters.xml", "configs/config.d/distributed_ddl.xml"],
+                           with_zookeeper=True)
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -20,13 +28,17 @@ def started_cluster():
 
 
 def test_default_database_on_cluster(started_cluster):
-    ch1.query(database='test_default_database', sql="CREATE TABLE test_local_table ON CLUSTER 'cluster' (column UInt8) ENGINE = Memory;")
+    ch1.query(database='test_default_database',
+              sql="CREATE TABLE test_local_table ON CLUSTER 'cluster' (column UInt8) ENGINE = Memory;")
 
     for node in [ch1, ch2, ch3, ch4]:
         assert node.query("SHOW TABLES FROM test_default_database FORMAT TSV") == "test_local_table\n"
 
-    ch1.query(database='test_default_database', sql="CREATE TABLE test_distributed_table ON CLUSTER 'cluster' (column UInt8) ENGINE = Distributed(cluster, currentDatabase(), 'test_local_table');")
+    ch1.query(database='test_default_database',
+              sql="CREATE TABLE test_distributed_table ON CLUSTER 'cluster' (column UInt8) ENGINE = Distributed(cluster, currentDatabase(), 'test_local_table');")
 
     for node in [ch1, ch2, ch3, ch4]:
-        assert node.query("SHOW TABLES FROM test_default_database FORMAT TSV") == "test_distributed_table\ntest_local_table\n"
-        assert node.query("SHOW CREATE TABLE test_default_database.test_distributed_table FORMAT TSV") == "CREATE TABLE test_default_database.test_distributed_table\\n(\\n    `column` UInt8\\n)\\nENGINE = Distributed(\\'cluster\\', \\'test_default_database\\', \\'test_local_table\\')\n"
+        assert node.query(
+            "SHOW TABLES FROM test_default_database FORMAT TSV") == "test_distributed_table\ntest_local_table\n"
+        assert node.query(
+            "SHOW CREATE TABLE test_default_database.test_distributed_table FORMAT TSV") == "CREATE TABLE test_default_database.test_distributed_table\\n(\\n    `column` UInt8\\n)\\nENGINE = Distributed(\\'cluster\\', \\'test_default_database\\', \\'test_local_table\\')\n"

--- a/tests/integration/test_default_role/test.py
+++ b/tests/integration/test_default_role/test.py
@@ -1,7 +1,6 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
-import re
 
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance('instance')
@@ -11,7 +10,7 @@ instance = cluster.add_instance('instance')
 def started_cluster():
     try:
         cluster.start()
-        
+
         instance.query("CREATE USER john")
         instance.query("CREATE ROLE rx")
         instance.query("CREATE ROLE ry")
@@ -32,41 +31,41 @@ def test_set_default_roles():
     assert instance.query("SHOW CURRENT ROLES", user="john") == ""
 
     instance.query("GRANT rx, ry TO john")
-    assert instance.query("SHOW CURRENT ROLES", user="john") == TSV( [['rx', 0, 1], ['ry', 0, 1]] )
+    assert instance.query("SHOW CURRENT ROLES", user="john") == TSV([['rx', 0, 1], ['ry', 0, 1]])
 
     instance.query("SET DEFAULT ROLE NONE TO john")
     assert instance.query("SHOW CURRENT ROLES", user="john") == ""
 
     instance.query("SET DEFAULT ROLE rx TO john")
-    assert instance.query("SHOW CURRENT ROLES", user="john") == TSV( [['rx', 0, 1]] )
+    assert instance.query("SHOW CURRENT ROLES", user="john") == TSV([['rx', 0, 1]])
 
     instance.query("SET DEFAULT ROLE ry TO john")
-    assert instance.query("SHOW CURRENT ROLES", user="john") == TSV( [['ry', 0, 1]] )
+    assert instance.query("SHOW CURRENT ROLES", user="john") == TSV([['ry', 0, 1]])
 
     instance.query("SET DEFAULT ROLE ALL TO john")
-    assert instance.query("SHOW CURRENT ROLES", user="john") == TSV( [['rx', 0, 1], ['ry', 0, 1]] )
+    assert instance.query("SHOW CURRENT ROLES", user="john") == TSV([['rx', 0, 1], ['ry', 0, 1]])
 
     instance.query("SET DEFAULT ROLE ALL EXCEPT rx TO john")
-    assert instance.query("SHOW CURRENT ROLES", user="john") == TSV( [['ry', 0, 1]] )
+    assert instance.query("SHOW CURRENT ROLES", user="john") == TSV([['ry', 0, 1]])
 
 
 def test_alter_user():
     assert instance.query("SHOW CURRENT ROLES", user="john") == ""
 
     instance.query("GRANT rx, ry TO john")
-    assert instance.query("SHOW CURRENT ROLES", user="john") == TSV( [['rx', 0, 1], ['ry', 0, 1]] )
+    assert instance.query("SHOW CURRENT ROLES", user="john") == TSV([['rx', 0, 1], ['ry', 0, 1]])
 
     instance.query("ALTER USER john DEFAULT ROLE NONE")
     assert instance.query("SHOW CURRENT ROLES", user="john") == ""
 
     instance.query("ALTER USER john DEFAULT ROLE rx")
-    assert instance.query("SHOW CURRENT ROLES", user="john") == TSV( [['rx', 0, 1]] )
+    assert instance.query("SHOW CURRENT ROLES", user="john") == TSV([['rx', 0, 1]])
 
     instance.query("ALTER USER john DEFAULT ROLE ALL")
-    assert instance.query("SHOW CURRENT ROLES", user="john") == TSV( [['rx', 0, 1], ['ry', 0, 1]] )
+    assert instance.query("SHOW CURRENT ROLES", user="john") == TSV([['rx', 0, 1], ['ry', 0, 1]])
 
     instance.query("ALTER USER john DEFAULT ROLE ALL EXCEPT rx")
-    assert instance.query("SHOW CURRENT ROLES", user="john") == TSV( [['ry', 0, 1]] )
+    assert instance.query("SHOW CURRENT ROLES", user="john") == TSV([['ry', 0, 1]])
 
 
 def test_wrong_set_default_role():

--- a/tests/integration/test_dictionaries_access/test.py
+++ b/tests/integration/test_dictionaries_access/test.py
@@ -9,7 +9,7 @@ instance = cluster.add_instance('instance')
 def started_cluster():
     try:
         cluster.start()
-        
+
         instance.query("CREATE USER mira")
         instance.query("CREATE TABLE test_table(x Int32, y Int32) ENGINE=Log")
         instance.query("INSERT INTO test_table VALUES (5,6)")

--- a/tests/integration/test_dictionaries_all_layouts_and_sources/test.py
+++ b/tests/integration/test_dictionaries_all_layouts_and_sources/test.py
@@ -1,11 +1,12 @@
-import pytest
+import math
 import os
 
+import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.dictionary import Field, Row, Dictionary, DictionaryStructure, Layout
-from helpers.external_sources import SourceMySQL, SourceClickHouse, SourceFile, SourceExecutableCache, SourceExecutableHashed
-from helpers.external_sources import SourceMongo, SourceMongoURI, SourceHTTP, SourceHTTPS, SourceRedis, SourceCassandra
-import math
+from helpers.external_sources import SourceMongo, SourceMongoURI, SourceHTTP, SourceHTTPS, SourceCassandra
+from helpers.external_sources import SourceMySQL, SourceClickHouse, SourceFile, SourceExecutableCache, \
+    SourceExecutableHashed
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 dict_configs_path = os.path.join(SCRIPT_DIR, 'configs/dictionaries')
@@ -103,8 +104,6 @@ VALUES = {
     ]
 }
 
-
-
 LAYOUTS = [
     Layout("flat"),
     Layout("hashed"),
@@ -134,6 +133,7 @@ DICTIONARIES = []
 
 cluster = None
 node = None
+
 
 def get_dict(source, layout, fields, suffix_name=''):
     global dict_configs_path
@@ -173,7 +173,8 @@ def setup_module(module):
     for fname in os.listdir(dict_configs_path):
         dictionaries.append(os.path.join(dict_configs_path, fname))
 
-    node = cluster.add_instance('node', main_configs=main_configs, dictionaries=dictionaries, with_mysql=True, with_mongo=True, with_redis=True, with_cassandra=True)
+    node = cluster.add_instance('node', main_configs=main_configs, dictionaries=dictionaries, with_mysql=True,
+                                with_mongo=True, with_redis=True, with_cassandra=True)
 
 
 @pytest.fixture(scope="module")
@@ -195,7 +196,7 @@ def get_dictionaries(fold, total_folds, all_dicts):
     chunk_len = int(math.ceil(len(all_dicts) / float(total_folds)))
     if chunk_len * fold >= len(all_dicts):
         return []
-    return all_dicts[fold * chunk_len : (fold + 1) * chunk_len]
+    return all_dicts[fold * chunk_len: (fold + 1) * chunk_len]
 
 
 def remove_mysql_dicts():
@@ -225,8 +226,8 @@ def remove_mysql_dicts():
     TODO remove this when open ssl will be fixed or thread sanitizer will be suppressed
     """
 
-    #global DICTIONARIES
-    #DICTIONARIES = [d for d in DICTIONARIES if not d.name.startswith("MySQL")]
+    # global DICTIONARIES
+    # DICTIONARIES = [d for d in DICTIONARIES if not d.name.startswith("MySQL")]
 
 
 @pytest.mark.parametrize("fold", list(range(10)))
@@ -281,7 +282,6 @@ def test_simple_dictionaries(started_cluster, fold):
 
 @pytest.mark.parametrize("fold", list(range(10)))
 def test_complex_dictionaries(started_cluster, fold):
-
     if node.is_built_with_thread_sanitizer():
         remove_mysql_dicts()
 

--- a/tests/integration/test_dictionaries_complex_key_cache_string/test.py
+++ b/tests/integration/test_dictionaries_complex_key_cache_string/test.py
@@ -1,6 +1,8 @@
-import pytest
 import os
+
+import pytest
 from helpers.cluster import ClickHouseCluster
+
 
 @pytest.fixture(scope="function")
 def cluster(request):
@@ -8,23 +10,31 @@ def cluster(request):
     cluster = ClickHouseCluster(__file__)
     try:
         if request.param == "memory":
-            node = cluster.add_instance('node', main_configs=['configs/enable_dictionaries.xml', 'configs/dictionaries/complex_key_cache_string.xml'])
+            node = cluster.add_instance('node', main_configs=['configs/enable_dictionaries.xml',
+                                                              'configs/dictionaries/complex_key_cache_string.xml'])
         if request.param == "ssd":
-            node = cluster.add_instance('node', main_configs=['configs/enable_dictionaries.xml', 'configs/dictionaries/ssd_complex_key_cache_string.xml'])
+            node = cluster.add_instance('node', main_configs=['configs/enable_dictionaries.xml',
+                                                              'configs/dictionaries/ssd_complex_key_cache_string.xml'])
         cluster.start()
-        node.query("create table radars_table (radar_id String, radar_ip String, client_id String) engine=MergeTree() order by radar_id")
+        node.query(
+            "create table radars_table (radar_id String, radar_ip String, client_id String) engine=MergeTree() order by radar_id")
 
         yield cluster
     finally:
         cluster.shutdown()
 
+
 @pytest.mark.parametrize("cluster", ["memory", "ssd"], indirect=True)
 def test_memory_consumption(cluster):
     node = cluster.instances['node']
-    node.query("insert into radars_table select toString(rand() % 5000), '{0}', '{0}' from numbers(1000)".format('w' * 8))
-    node.query("insert into radars_table select toString(rand() % 5000), '{0}', '{0}' from numbers(1000)".format('x' * 16))
-    node.query("insert into radars_table select toString(rand() % 5000), '{0}', '{0}' from numbers(1000)".format('y' * 32))
-    node.query("insert into radars_table select toString(rand() % 5000), '{0}', '{0}' from numbers(1000)".format('z' * 64))
+    node.query(
+        "insert into radars_table select toString(rand() % 5000), '{0}', '{0}' from numbers(1000)".format('w' * 8))
+    node.query(
+        "insert into radars_table select toString(rand() % 5000), '{0}', '{0}' from numbers(1000)".format('x' * 16))
+    node.query(
+        "insert into radars_table select toString(rand() % 5000), '{0}', '{0}' from numbers(1000)".format('y' * 32))
+    node.query(
+        "insert into radars_table select toString(rand() % 5000), '{0}', '{0}' from numbers(1000)".format('z' * 64))
 
     # Fill dictionary
     node.query("select dictGetString('radars', 'client_id', tuple(toString(number))) from numbers(0, 5000)")

--- a/tests/integration/test_dictionaries_ddl/test.py
+++ b/tests/integration/test_dictionaries_ddl/test.py
@@ -1,16 +1,23 @@
-import pytest
 import os
-from helpers.cluster import ClickHouseCluster
-from helpers.client import QueryRuntimeException
-import pymysql
 import warnings
+
+import pymysql
+import pytest
+from helpers.client import QueryRuntimeException
+from helpers.cluster import ClickHouseCluster
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 cluster = ClickHouseCluster(__file__)
-node1 = cluster.add_instance('node1', with_mysql=True, dictionaries=['configs/dictionaries/simple_dictionary.xml'], user_configs=['configs/user_admin.xml', 'configs/user_default.xml'])
-node2 = cluster.add_instance('node2', with_mysql=True, dictionaries=['configs/dictionaries/simple_dictionary.xml'], main_configs=['configs/dictionaries/lazy_load.xml', 'configs/allow_remote_node.xml'], user_configs=['configs/user_admin.xml', 'configs/user_default.xml'])
-node3 = cluster.add_instance('node3', main_configs=['configs/allow_remote_node.xml'], dictionaries=['configs/dictionaries/dictionary_with_conflict_name.xml', 'configs/dictionaries/conflict_name_dictionary.xml'], user_configs=['configs/user_admin.xml'])
+node1 = cluster.add_instance('node1', with_mysql=True, dictionaries=['configs/dictionaries/simple_dictionary.xml'],
+                             user_configs=['configs/user_admin.xml', 'configs/user_default.xml'])
+node2 = cluster.add_instance('node2', with_mysql=True, dictionaries=['configs/dictionaries/simple_dictionary.xml'],
+                             main_configs=['configs/dictionaries/lazy_load.xml', 'configs/allow_remote_node.xml'],
+                             user_configs=['configs/user_admin.xml', 'configs/user_default.xml'])
+node3 = cluster.add_instance('node3', main_configs=['configs/allow_remote_node.xml'],
+                             dictionaries=['configs/dictionaries/dictionary_with_conflict_name.xml',
+                                           'configs/dictionaries/conflict_name_dictionary.xml'],
+                             user_configs=['configs/user_admin.xml'])
 node4 = cluster.add_instance('node4', user_configs=['configs/user_admin.xml', 'configs/config_password.xml'])
 
 
@@ -20,6 +27,7 @@ def create_mysql_conn(user, password, hostname, port):
         password=password,
         host=hostname,
         port=port)
+
 
 def execute_mysql_query(connection, query):
     with warnings.catch_warnings():
@@ -35,13 +43,16 @@ def started_cluster():
         cluster.start()
         for clickhouse in [node1, node2, node3, node4]:
             clickhouse.query("CREATE DATABASE test", user="admin")
-            clickhouse.query("CREATE TABLE test.xml_dictionary_table (id UInt64, SomeValue1 UInt8, SomeValue2 String) ENGINE = MergeTree() ORDER BY id", user="admin")
-            clickhouse.query("INSERT INTO test.xml_dictionary_table SELECT number, number % 23, hex(number) from numbers(1000)", user="admin")
+            clickhouse.query(
+                "CREATE TABLE test.xml_dictionary_table (id UInt64, SomeValue1 UInt8, SomeValue2 String) ENGINE = MergeTree() ORDER BY id",
+                user="admin")
+            clickhouse.query(
+                "INSERT INTO test.xml_dictionary_table SELECT number, number % 23, hex(number) from numbers(1000)",
+                user="admin")
         yield cluster
 
     finally:
         cluster.shutdown()
-
 
 
 @pytest.mark.parametrize("clickhouse,name,layout", [
@@ -53,7 +64,9 @@ def started_cluster():
 def test_create_and_select_mysql(started_cluster, clickhouse, name, layout):
     mysql_conn = create_mysql_conn("root", "clickhouse", "localhost", 3308)
     execute_mysql_query(mysql_conn, "CREATE DATABASE IF NOT EXISTS clickhouse")
-    execute_mysql_query(mysql_conn, "CREATE TABLE clickhouse.{} (key_field1 int, key_field2 bigint, value1 text, value2 float, PRIMARY KEY (key_field1, key_field2))".format(name))
+    execute_mysql_query(mysql_conn,
+                        "CREATE TABLE clickhouse.{} (key_field1 int, key_field2 bigint, value1 text, value2 float, PRIMARY KEY (key_field1, key_field2))".format(
+                            name))
     values = []
     for i in range(1000):
         values.append('(' + ','.join([str(i), str(i * i), str(i) * 5, str(i * 3.14)]) + ')')
@@ -80,11 +93,15 @@ def test_create_and_select_mysql(started_cluster, clickhouse, name, layout):
     """.format(name, name, layout))
 
     for i in range(172, 200):
-        assert clickhouse.query("SELECT dictGetString('default.{}', 'value1', tuple(toInt32({}), toInt64({})))".format(name, i, i * i)) == str(i) * 5 + '\n'
-        stroka = clickhouse.query("SELECT dictGetFloat32('default.{}', 'value2', tuple(toInt32({}), toInt64({})))".format(name, i, i * i)).strip()
+        assert clickhouse.query(
+            "SELECT dictGetString('default.{}', 'value1', tuple(toInt32({}), toInt64({})))".format(name, i,
+                                                                                                   i * i)) == str(
+            i) * 5 + '\n'
+        stroka = clickhouse.query(
+            "SELECT dictGetFloat32('default.{}', 'value2', tuple(toInt32({}), toInt64({})))".format(name, i,
+                                                                                                    i * i)).strip()
         value = float(stroka)
         assert int(value) == int(i * 3.14)
-
 
     for i in range(1000):
         values.append('(' + ','.join([str(i), str(i * i), str(i) * 3, str(i * 2.718)]) + ')')
@@ -93,8 +110,13 @@ def test_create_and_select_mysql(started_cluster, clickhouse, name, layout):
     clickhouse.query("SYSTEM RELOAD DICTIONARY 'default.{}'".format(name))
 
     for i in range(172, 200):
-        assert clickhouse.query("SELECT dictGetString('default.{}', 'value1', tuple(toInt32({}), toInt64({})))".format(name, i, i * i)) == str(i) * 3 + '\n'
-        string = clickhouse.query("SELECT dictGetFloat32('default.{}', 'value2', tuple(toInt32({}), toInt64({})))".format(name, i, i * i)).strip()
+        assert clickhouse.query(
+            "SELECT dictGetString('default.{}', 'value1', tuple(toInt32({}), toInt64({})))".format(name, i,
+                                                                                                   i * i)) == str(
+            i) * 3 + '\n'
+        string = clickhouse.query(
+            "SELECT dictGetFloat32('default.{}', 'value2', tuple(toInt32({}), toInt64({})))".format(name, i,
+                                                                                                    i * i)).strip()
         value = float(string)
         assert int(value) == int(i * 2.718)
 
@@ -182,6 +204,7 @@ def test_conflicting_name(started_cluster):
     # old version still works
     node3.query("select dictGetUInt8('test.conflicting_dictionary', 'SomeValue1', toUInt64(17))") == '17\n'
 
+
 def test_http_dictionary_restrictions(started_cluster):
     try:
         node3.query("""
@@ -197,6 +220,7 @@ def test_http_dictionary_restrictions(started_cluster):
         node3.query("SELECT dictGetString('test.restricted_http_dictionary', 'value', toUInt64(1))")
     except QueryRuntimeException as ex:
         assert 'is not allowed in config.xml' in str(ex)
+
 
 def test_file_dictionary_restrictions(started_cluster):
     try:
@@ -218,7 +242,8 @@ def test_file_dictionary_restrictions(started_cluster):
 def test_dictionary_with_where(started_cluster):
     mysql_conn = create_mysql_conn("root", "clickhouse", "localhost", 3308)
     execute_mysql_query(mysql_conn, "CREATE DATABASE IF NOT EXISTS clickhouse")
-    execute_mysql_query(mysql_conn, "CREATE TABLE clickhouse.special_table (key_field1 int, value1 text, PRIMARY KEY (key_field1))")
+    execute_mysql_query(mysql_conn,
+                        "CREATE TABLE clickhouse.special_table (key_field1 int, value1 text, PRIMARY KEY (key_field1))")
     execute_mysql_query(mysql_conn, "INSERT INTO clickhouse.special_table VALUES (1, 'abcabc'), (2, 'qweqwe')")
 
     node1.query("""
@@ -242,6 +267,7 @@ def test_dictionary_with_where(started_cluster):
     node1.query("SYSTEM RELOAD DICTIONARY default.special_dict")
 
     assert node1.query("SELECT dictGetString('default.special_dict', 'value1', toUInt64(2))") == 'qweqwe\n'
+
 
 def test_clickhouse_remote(started_cluster):
     with pytest.raises(QueryRuntimeException):
@@ -272,4 +298,3 @@ def test_clickhouse_remote(started_cluster):
         """)
 
     node3.query("select dictGetUInt8('test.clickhouse_remote', 'SomeValue1', toUInt64(17))") == '17\n'
-

--- a/tests/integration/test_dictionaries_dependency/test.py
+++ b/tests/integration/test_dictionaries_dependency/test.py
@@ -17,10 +17,10 @@ def start_cluster():
             node.query("CREATE DATABASE IF NOT EXISTS ztest")
             node.query("CREATE TABLE test.source(x UInt64, y UInt64) ENGINE=Log")
             node.query("INSERT INTO test.source VALUES (5,6)")
-            
-            node.query("CREATE DICTIONARY test.dict(x UInt64, y UInt64) PRIMARY KEY x "\
-                        "SOURCE(CLICKHOUSE(HOST 'localhost' PORT 9000 USER 'default' TABLE 'source' DB 'test')) "\
-                        "LAYOUT(FLAT()) LIFETIME(0)")
+
+            node.query("CREATE DICTIONARY test.dict(x UInt64, y UInt64) PRIMARY KEY x " \
+                       "SOURCE(CLICKHOUSE(HOST 'localhost' PORT 9000 USER 'default' TABLE 'source' DB 'test')) " \
+                       "LAYOUT(FLAT()) LIFETIME(0)")
         yield cluster
 
     finally:
@@ -48,14 +48,14 @@ def cleanup_after_test():
 def test_dependency_via_implicit_table(node):
     d_names = ["test.adict", "test.zdict", "atest.dict", "ztest.dict"]
     for d_name in d_names:
-        node.query("CREATE DICTIONARY {}(x UInt64, y UInt64) PRIMARY KEY x "\
-                   "SOURCE(CLICKHOUSE(HOST 'localhost' PORT 9000 USER 'default' TABLE 'dict' DB 'test')) "\
+        node.query("CREATE DICTIONARY {}(x UInt64, y UInt64) PRIMARY KEY x " \
+                   "SOURCE(CLICKHOUSE(HOST 'localhost' PORT 9000 USER 'default' TABLE 'dict' DB 'test')) " \
                    "LAYOUT(FLAT()) LIFETIME(0)".format(d_name))
-    
+
     def check():
         for d_name in d_names:
             assert node.query("SELECT dictGet({}, 'y', toUInt64(5))".format(d_name)) == "6\n"
-    
+
     check()
 
     # Restart must not break anything.
@@ -72,14 +72,14 @@ def test_dependency_via_explicit_table(node):
         tbl_database, tbl_shortname = tbl_name.split('.')
         d_name = d_names[i]
         node.query("CREATE TABLE {}(x UInt64, y UInt64) ENGINE=Dictionary('test.dict')".format(tbl_name))
-        node.query("CREATE DICTIONARY {}(x UInt64, y UInt64) PRIMARY KEY x "\
-                   "SOURCE(CLICKHOUSE(HOST 'localhost' PORT 9000 USER 'default' TABLE '{}' DB '{}')) "\
+        node.query("CREATE DICTIONARY {}(x UInt64, y UInt64) PRIMARY KEY x " \
+                   "SOURCE(CLICKHOUSE(HOST 'localhost' PORT 9000 USER 'default' TABLE '{}' DB '{}')) " \
                    "LAYOUT(FLAT()) LIFETIME(0)".format(d_name, tbl_shortname, tbl_database))
-    
+
     def check():
         for d_name in d_names:
             assert node.query("SELECT dictGet({}, 'y', toUInt64(5))".format(d_name)) == "6\n"
-    
+
     check()
 
     # Restart must not break anything.
@@ -93,14 +93,14 @@ def test_dependency_via_dictionary_database(node):
 
     d_names = ["test.adict", "test.zdict", "atest.dict", "ztest.dict"]
     for d_name in d_names:
-        node.query("CREATE DICTIONARY {}(x UInt64, y UInt64) PRIMARY KEY x "\
-                   "SOURCE(CLICKHOUSE(HOST 'localhost' PORT 9000 USER 'default' TABLE 'test.dict' DB 'dict_db')) "\
+        node.query("CREATE DICTIONARY {}(x UInt64, y UInt64) PRIMARY KEY x " \
+                   "SOURCE(CLICKHOUSE(HOST 'localhost' PORT 9000 USER 'default' TABLE 'test.dict' DB 'dict_db')) " \
                    "LAYOUT(FLAT()) LIFETIME(0)".format(d_name))
-    
+
     def check():
         for d_name in d_names:
             assert node.query("SELECT dictGet({}, 'y', toUInt64(5))".format(d_name)) == "6\n"
-    
+
     check()
 
     # Restart must not break anything.

--- a/tests/integration/test_dictionaries_dependency_xml/test.py
+++ b/tests/integration/test_dictionaries_dependency_xml/test.py
@@ -1,13 +1,13 @@
 import pytest
-import os
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_eq_with_retry
 
 ENABLE_DICT_CONFIG = ['configs/enable_dictionaries.xml']
-DICTIONARY_FILES = ['configs/dictionaries/dep_x.xml', 'configs/dictionaries/dep_y.xml', 'configs/dictionaries/dep_z.xml']
+DICTIONARY_FILES = ['configs/dictionaries/dep_x.xml', 'configs/dictionaries/dep_y.xml',
+                    'configs/dictionaries/dep_z.xml']
 
 cluster = ClickHouseCluster(__file__)
-instance = cluster.add_instance('instance', main_configs=ENABLE_DICT_CONFIG+DICTIONARY_FILES,)
+instance = cluster.add_instance('instance', main_configs=ENABLE_DICT_CONFIG + DICTIONARY_FILES, )
 
 
 @pytest.fixture(scope="module")
@@ -60,14 +60,14 @@ def test_get_data(started_cluster):
     query("INSERT INTO test.elements VALUES (3, 'fire', 30, 8)")
 
     # Wait for dictionaries to be reloaded.
-    assert_eq_with_retry(instance, "SELECT dictHas('dep_y', toUInt64(3))", "1", sleep_time = 2, retry_count = 10)
+    assert_eq_with_retry(instance, "SELECT dictHas('dep_y', toUInt64(3))", "1", sleep_time=2, retry_count=10)
     assert query("SELECT dictGetString('dep_x', 'a', toUInt64(3))") == "XX\n"
     assert query("SELECT dictGetString('dep_y', 'a', toUInt64(3))") == "fire\n"
     assert query("SELECT dictGetString('dep_z', 'a', toUInt64(3))") == "ZZ\n"
 
     # dep_x and dep_z are updated only when there `intDiv(count(), 4)`  is changed.
     query("INSERT INTO test.elements VALUES (4, 'ether', 404, 0.001)")
-    assert_eq_with_retry(instance, "SELECT dictHas('dep_x', toUInt64(4))", "1", sleep_time = 2, retry_count = 10)
+    assert_eq_with_retry(instance, "SELECT dictHas('dep_x', toUInt64(4))", "1", sleep_time=2, retry_count=10)
     assert query("SELECT dictGetString('dep_x', 'a', toUInt64(3))") == "fire\n"
     assert query("SELECT dictGetString('dep_y', 'a', toUInt64(3))") == "fire\n"
     assert query("SELECT dictGetString('dep_z', 'a', toUInt64(3))") == "fire\n"

--- a/tests/integration/test_dictionaries_null_value/test.py
+++ b/tests/integration/test_dictionaries_null_value/test.py
@@ -1,13 +1,11 @@
 import pytest
-import os
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import TSV, assert_eq_with_retry
 
 ENABLE_DICT_CONFIG = ['configs/enable_dictionaries.xml']
 DICTIONARY_FILES = ['configs/dictionaries/cache.xml']
 
 cluster = ClickHouseCluster(__file__)
-instance = cluster.add_instance('instance', main_configs=ENABLE_DICT_CONFIG+DICTIONARY_FILES)
+instance = cluster.add_instance('instance', main_configs=ENABLE_DICT_CONFIG + DICTIONARY_FILES)
 
 
 @pytest.fixture(scope="module")
@@ -42,4 +40,5 @@ def test_null_value(started_cluster):
 
     # Check, that empty null_value interprets as default value
     assert query("select dictGetUInt64('cache', 'UInt64_', toUInt64(12121212))") == "0\n"
-    assert query("select toTimeZone(dictGetDateTime('cache', 'DateTime_', toUInt64(12121212)), 'UTC')") == "1970-01-01 00:00:00\n"
+    assert query(
+        "select toTimeZone(dictGetDateTime('cache', 'DateTime_', toUInt64(12121212)), 'UTC')") == "1970-01-01 00:00:00\n"

--- a/tests/integration/test_dictionaries_redis/test.py
+++ b/tests/integration/test_dictionaries_redis/test.py
@@ -1,7 +1,6 @@
 import os
-import pytest
-import redis
 
+import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.dictionary import Field, Row, Dictionary, DictionaryStructure, Layout
 from helpers.external_sources import SourceRedis
@@ -22,10 +21,10 @@ KEY_FIELDS = {
 }
 
 KEY_VALUES = {
-    "simple" : [
+    "simple": [
         [1], [2]
     ],
-    "complex" : [
+    "complex": [
         [1, 'world'], [2, 'qwerty2']
     ]
 }
@@ -76,6 +75,7 @@ LAYOUTS = [
 
 DICTIONARIES = []
 
+
 def get_dict(source, layout, fields, suffix_name=''):
     global dict_configs_path
 
@@ -99,8 +99,10 @@ def setup_module(module):
     for i, field in enumerate(FIELDS):
         DICTIONARIES.append([])
         sources = []
-        sources.append(SourceRedis("RedisSimple", "localhost", "6380", "redis1", "6379", "", "clickhouse", i * 2, storage_type="simple"))
-        sources.append(SourceRedis("RedisHash", "localhost", "6380", "redis1", "6379", "", "clickhouse", i * 2 + 1, storage_type="hash_map"))
+        sources.append(SourceRedis("RedisSimple", "localhost", "6380", "redis1", "6379", "", "clickhouse", i * 2,
+                                   storage_type="simple"))
+        sources.append(SourceRedis("RedisHash", "localhost", "6380", "redis1", "6379", "", "clickhouse", i * 2 + 1,
+                                   storage_type="hash_map"))
         for source in sources:
             for layout in LAYOUTS:
                 if not source.compatible_with_layout(layout):
@@ -118,6 +120,7 @@ def setup_module(module):
     cluster = ClickHouseCluster(__file__)
     node = cluster.add_instance('node', main_configs=main_configs, dictionaries=dictionaries, with_redis=True)
 
+
 @pytest.fixture(scope="module", autouse=True)
 def started_cluster():
     try:
@@ -133,6 +136,7 @@ def started_cluster():
 
     finally:
         cluster.shutdown()
+
 
 @pytest.mark.parametrize("id", range(len(FIELDS)))
 def test_redis_dictionaries(started_cluster, id):

--- a/tests/integration/test_dictionaries_select_all/generate_dictionaries.py
+++ b/tests/integration/test_dictionaries_select_all/generate_dictionaries.py
@@ -1,6 +1,5 @@
-import os
-import glob
 import difflib
+import os
 
 files = ['key_simple.tsv', 'key_complex_integers.tsv', 'key_complex_mixed.tsv']
 
@@ -11,7 +10,6 @@ types = [
     'String',
     'Date', 'DateTime'
 ]
-
 
 implicit_defaults = [
     '1', '1', '1', '',

--- a/tests/integration/test_dictionaries_select_all/test.py
+++ b/tests/integration/test_dictionaries_select_all/test.py
@@ -1,7 +1,9 @@
-import pytest
 import os
+
+import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import TSV, assert_eq_with_retry
+from helpers.test_tools import TSV
+
 from generate_dictionaries import generate_structure, generate_dictionaries, DictionaryTestTable
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -20,7 +22,7 @@ def setup_module(module):
     dictionary_files = generate_dictionaries(os.path.join(SCRIPT_DIR, 'configs/dictionaries'), structure)
 
     cluster = ClickHouseCluster(__file__)
-    instance = cluster.add_instance('instance', main_configs=dictionary_files+['configs/enable_dictionaries.xml'])
+    instance = cluster.add_instance('instance', main_configs=dictionary_files + ['configs/enable_dictionaries.xml'])
     test_table = DictionaryTestTable(os.path.join(SCRIPT_DIR, 'configs/dictionaries/source.tsv'))
 
 

--- a/tests/integration/test_dictionary_allow_read_expired_keys/test_default_reading.py
+++ b/tests/integration/test_dictionary_allow_read_expired_keys/test_default_reading.py
@@ -1,9 +1,8 @@
 from __future__ import print_function
-import pytest
-import time
-import os
-from contextlib import contextmanager
 
+import time
+
+import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.cluster import ClickHouseKiller
 from helpers.network import PartitionManager
@@ -13,6 +12,7 @@ cluster = ClickHouseCluster(__file__)
 dictionary_node = cluster.add_instance('dictionary_node', stay_alive=True)
 main_node = cluster.add_instance('main_node', main_configs=['configs/enable_dictionaries.xml',
                                                             'configs/dictionaries/cache_ints_dictionary.xml'])
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -32,6 +32,7 @@ def started_cluster():
     finally:
         cluster.shutdown()
 
+
 # @pytest.mark.skip(reason="debugging")
 def test_default_reading(started_cluster):
     assert None != dictionary_node.get_process_pid("clickhouse"), "ClickHouse must be alive"
@@ -39,14 +40,22 @@ def test_default_reading(started_cluster):
     # Key 0 is not in dictionary, so default value will be returned
 
     def test_helper():
-        assert '42' == main_node.query("select dictGetOrDefault('anime_dict', 'i8',  toUInt64(13),  toInt8(42));").rstrip()
-        assert '42' == main_node.query("select dictGetOrDefault('anime_dict', 'i16', toUInt64(13),  toInt16(42));").rstrip()
-        assert '42' == main_node.query("select dictGetOrDefault('anime_dict', 'i32', toUInt64(13),  toInt32(42));").rstrip()
-        assert '42' == main_node.query("select dictGetOrDefault('anime_dict', 'i64', toUInt64(13),  toInt64(42));").rstrip()
-        assert '42' == main_node.query("select dictGetOrDefault('anime_dict', 'u8',  toUInt64(13),  toUInt8(42));").rstrip()
-        assert '42' == main_node.query("select dictGetOrDefault('anime_dict', 'u16', toUInt64(13),  toUInt16(42));").rstrip()
-        assert '42' == main_node.query("select dictGetOrDefault('anime_dict', 'u32', toUInt64(13),  toUInt32(42));").rstrip()
-        assert '42' == main_node.query("select dictGetOrDefault('anime_dict', 'u64', toUInt64(13),  toUInt64(42));").rstrip()
+        assert '42' == main_node.query(
+            "select dictGetOrDefault('anime_dict', 'i8',  toUInt64(13),  toInt8(42));").rstrip()
+        assert '42' == main_node.query(
+            "select dictGetOrDefault('anime_dict', 'i16', toUInt64(13),  toInt16(42));").rstrip()
+        assert '42' == main_node.query(
+            "select dictGetOrDefault('anime_dict', 'i32', toUInt64(13),  toInt32(42));").rstrip()
+        assert '42' == main_node.query(
+            "select dictGetOrDefault('anime_dict', 'i64', toUInt64(13),  toInt64(42));").rstrip()
+        assert '42' == main_node.query(
+            "select dictGetOrDefault('anime_dict', 'u8',  toUInt64(13),  toUInt8(42));").rstrip()
+        assert '42' == main_node.query(
+            "select dictGetOrDefault('anime_dict', 'u16', toUInt64(13),  toUInt16(42));").rstrip()
+        assert '42' == main_node.query(
+            "select dictGetOrDefault('anime_dict', 'u32', toUInt64(13),  toUInt32(42));").rstrip()
+        assert '42' == main_node.query(
+            "select dictGetOrDefault('anime_dict', 'u64', toUInt64(13),  toUInt64(42));").rstrip()
 
     test_helper()
 
@@ -61,4 +70,3 @@ def test_default_reading(started_cluster):
         time.sleep(3)
 
         test_helper()
-

--- a/tests/integration/test_dictionary_allow_read_expired_keys/test_default_string.py
+++ b/tests/integration/test_dictionary_allow_read_expired_keys/test_default_string.py
@@ -1,10 +1,11 @@
 from __future__ import print_function
-import pytest
+
 import os
 import random
 import string
 import time
 
+import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
@@ -12,12 +13,15 @@ SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 cluster = ClickHouseCluster(__file__)
 
 dictionary_node = cluster.add_instance('dictionary_node', stay_alive=True)
-main_node = cluster.add_instance('main_node', main_configs=['configs/enable_dictionaries.xml','configs/dictionaries/cache_ints_dictionary.xml','configs/dictionaries/cache_strings_default_settings.xml'])
+main_node = cluster.add_instance('main_node', main_configs=['configs/enable_dictionaries.xml',
+                                                            'configs/dictionaries/cache_ints_dictionary.xml',
+                                                            'configs/dictionaries/cache_strings_default_settings.xml'])
 
 
 def get_random_string(string_length=8):
     alphabet = string.ascii_letters + string.digits
     return ''.join((random.choice(alphabet) for _ in range(string_length)))
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -31,12 +35,14 @@ def started_cluster():
                              ENGINE = Memory;
                              """)
 
-        values_to_insert = ", ".join(["({}, '{}')".format(1000000 + number, get_random_string()) for number in range(100)])
+        values_to_insert = ", ".join(
+            ["({}, '{}')".format(1000000 + number, get_random_string()) for number in range(100)])
         dictionary_node.query("INSERT INTO test.strings VALUES {}".format(values_to_insert))
 
         yield cluster
     finally:
         cluster.shutdown()
+
 
 # @pytest.mark.skip(reason="debugging")
 def test_return_real_values(started_cluster):

--- a/tests/integration/test_dictionary_allow_read_expired_keys/test_dict_get.py
+++ b/tests/integration/test_dictionary_allow_read_expired_keys/test_dict_get.py
@@ -1,18 +1,18 @@
 from __future__ import print_function
-import pytest
-import time
-import os
-from contextlib import contextmanager
 
+import time
+
+import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.cluster import ClickHouseKiller
 from helpers.network import PartitionManager
-from helpers.network import PartitionManagerDisabler
 
 cluster = ClickHouseCluster(__file__)
 
 dictionary_node = cluster.add_instance('dictionary_node', stay_alive=True)
-main_node = cluster.add_instance('main_node', main_configs=['configs/enable_dictionaries.xml', 'configs/dictionaries/cache_ints_dictionary.xml'])
+main_node = cluster.add_instance('main_node', main_configs=['configs/enable_dictionaries.xml',
+                                                            'configs/dictionaries/cache_ints_dictionary.xml'])
+
 
 @pytest.fixture(scope="module")
 def started_cluster():

--- a/tests/integration/test_dictionary_allow_read_expired_keys/test_dict_get_or_default.py
+++ b/tests/integration/test_dictionary_allow_read_expired_keys/test_dict_get_or_default.py
@@ -1,9 +1,8 @@
 from __future__ import print_function
-import pytest
-import time
-import os
-from contextlib import contextmanager
 
+import time
+
+import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.cluster import ClickHouseKiller
 from helpers.network import PartitionManager
@@ -11,7 +10,9 @@ from helpers.network import PartitionManager
 cluster = ClickHouseCluster(__file__)
 
 dictionary_node = cluster.add_instance('dictionary_node', stay_alive=True)
-main_node = cluster.add_instance('main_node', main_configs=['configs/enable_dictionaries.xml','configs/dictionaries/cache_ints_dictionary.xml'])
+main_node = cluster.add_instance('main_node', main_configs=['configs/enable_dictionaries.xml',
+                                                            'configs/dictionaries/cache_ints_dictionary.xml'])
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -31,19 +32,28 @@ def started_cluster():
     finally:
         cluster.shutdown()
 
+
 # @pytest.mark.skip(reason="debugging")
 def test_simple_dict_get_or_default(started_cluster):
     assert None != dictionary_node.get_process_pid("clickhouse"), "ClickHouse must be alive"
 
     def test_helper():
-        assert '5' == main_node.query("select dictGetOrDefault('anime_dict', 'i8',  toUInt64(5),  toInt8(42));").rstrip()
-        assert '5' == main_node.query("select dictGetOrDefault('anime_dict', 'i16', toUInt64(5),  toInt16(42));").rstrip()
-        assert '5' == main_node.query("select dictGetOrDefault('anime_dict', 'i32', toUInt64(5),  toInt32(42));").rstrip()
-        assert '5' == main_node.query("select dictGetOrDefault('anime_dict', 'i64', toUInt64(5),  toInt64(42));").rstrip()
-        assert '5' == main_node.query("select dictGetOrDefault('anime_dict', 'u8',  toUInt64(5),  toUInt8(42));").rstrip()
-        assert '5' == main_node.query("select dictGetOrDefault('anime_dict', 'u16', toUInt64(5),  toUInt16(42));").rstrip()
-        assert '5' == main_node.query("select dictGetOrDefault('anime_dict', 'u32', toUInt64(5),  toUInt32(42));").rstrip()
-        assert '5' == main_node.query("select dictGetOrDefault('anime_dict', 'u64', toUInt64(5),  toUInt64(42));").rstrip()
+        assert '5' == main_node.query(
+            "select dictGetOrDefault('anime_dict', 'i8',  toUInt64(5),  toInt8(42));").rstrip()
+        assert '5' == main_node.query(
+            "select dictGetOrDefault('anime_dict', 'i16', toUInt64(5),  toInt16(42));").rstrip()
+        assert '5' == main_node.query(
+            "select dictGetOrDefault('anime_dict', 'i32', toUInt64(5),  toInt32(42));").rstrip()
+        assert '5' == main_node.query(
+            "select dictGetOrDefault('anime_dict', 'i64', toUInt64(5),  toInt64(42));").rstrip()
+        assert '5' == main_node.query(
+            "select dictGetOrDefault('anime_dict', 'u8',  toUInt64(5),  toUInt8(42));").rstrip()
+        assert '5' == main_node.query(
+            "select dictGetOrDefault('anime_dict', 'u16', toUInt64(5),  toUInt16(42));").rstrip()
+        assert '5' == main_node.query(
+            "select dictGetOrDefault('anime_dict', 'u32', toUInt64(5),  toUInt32(42));").rstrip()
+        assert '5' == main_node.query(
+            "select dictGetOrDefault('anime_dict', 'u64', toUInt64(5),  toUInt64(42));").rstrip()
 
     test_helper()
 

--- a/tests/integration/test_dictionary_custom_settings/http_server.py
+++ b/tests/integration/test_dictionary_custom_settings/http_server.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import argparse
-from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+import csv
 import socket
 import ssl
-import csv
+from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 
 
 # Decorator used to see if authentication works for external dictionary who use a HTTP source.
@@ -15,6 +15,7 @@ def check_auth(fn):
             req.send_response(401)
         else:
             fn(req)
+
     return wrapper
 
 
@@ -37,7 +38,7 @@ def start_server(server_address, data_path, schema, cert_path, address_family):
             self.send_header('Content-type', 'text/csv')
             self.end_headers()
 
-        def __send_data(self, only_ids = None):
+        def __send_data(self, only_ids=None):
             with open(data_path, 'r') as fl:
                 reader = csv.reader(fl, delimiter='\t')
                 for row in reader:

--- a/tests/integration/test_dictionary_custom_settings/test.py
+++ b/tests/integration/test_dictionary_custom_settings/test.py
@@ -1,6 +1,6 @@
 import os
-import pytest
 
+import pytest
 from helpers.cluster import ClickHouseCluster
 
 ENABLE_DICT_CONFIG = ['configs/enable_dictionaries.xml']
@@ -13,7 +13,8 @@ DICTIONARY_FILES = [
 ]
 
 cluster = ClickHouseCluster(__file__)
-instance = cluster.add_instance('node', main_configs=ENABLE_DICT_CONFIG+DICTIONARY_FILES)
+instance = cluster.add_instance('node', main_configs=ENABLE_DICT_CONFIG + DICTIONARY_FILES)
+
 
 def prepare():
     node = instance
@@ -38,6 +39,7 @@ def start_cluster():
         yield cluster
     finally:
         cluster.shutdown()
+
 
 def test_work(start_cluster):
     query = instance.query

--- a/tests/integration/test_dictionary_ddl_on_cluster/test.py
+++ b/tests/integration/test_dictionary_ddl_on_cluster/test.py
@@ -1,19 +1,24 @@
-import time
 import pytest
-from helpers.cluster import ClickHouseCluster
 from helpers.client import QueryRuntimeException
+from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
-ch1 = cluster.add_instance('ch1', main_configs=["configs/config.d/clusters.xml", "configs/config.d/ddl.xml"], with_zookeeper=True)
-ch2 = cluster.add_instance('ch2', main_configs=["configs/config.d/clusters.xml", "configs/config.d/ddl.xml"], with_zookeeper=True)
-ch3 = cluster.add_instance('ch3', main_configs=["configs/config.d/clusters.xml", "configs/config.d/ddl.xml"], with_zookeeper=True)
-ch4 = cluster.add_instance('ch4', main_configs=["configs/config.d/clusters.xml", "configs/config.d/ddl.xml"], with_zookeeper=True)
+ch1 = cluster.add_instance('ch1', main_configs=["configs/config.d/clusters.xml", "configs/config.d/ddl.xml"],
+                           with_zookeeper=True)
+ch2 = cluster.add_instance('ch2', main_configs=["configs/config.d/clusters.xml", "configs/config.d/ddl.xml"],
+                           with_zookeeper=True)
+ch3 = cluster.add_instance('ch3', main_configs=["configs/config.d/clusters.xml", "configs/config.d/ddl.xml"],
+                           with_zookeeper=True)
+ch4 = cluster.add_instance('ch4', main_configs=["configs/config.d/clusters.xml", "configs/config.d/ddl.xml"],
+                           with_zookeeper=True)
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
         cluster.start()
-        ch1.query("CREATE TABLE sometbl ON CLUSTER 'cluster' (key UInt64, value String) ENGINE = MergeTree ORDER by key")
+        ch1.query(
+            "CREATE TABLE sometbl ON CLUSTER 'cluster' (key UInt64, value String) ENGINE = MergeTree ORDER by key")
         yield cluster
 
     finally:
@@ -26,7 +31,6 @@ def test_dictionary_ddl_on_cluster(started_cluster):
 
     for num, node in enumerate([ch1, ch2, ch3, ch4]):
         node.query("insert into sometbl values ({}, '{}')".format(num, node.name))
-
 
     ch1.query(
         """
@@ -42,7 +46,8 @@ def test_dictionary_ddl_on_cluster(started_cluster):
 
     for num, node in enumerate([ch1, ch2, ch3, ch4]):
         assert node.query("SELECT count() from sometbl") == "1\n"
-        assert node.query("SELECT dictGetString('default.somedict', 'value', toUInt64({}))".format(num)) == node.name + '\n'
+        assert node.query(
+            "SELECT dictGetString('default.somedict', 'value', toUInt64({}))".format(num)) == node.name + '\n'
 
     ch1.query("DETACH DICTIONARY default.somedict ON CLUSTER 'cluster'")
 
@@ -54,8 +59,8 @@ def test_dictionary_ddl_on_cluster(started_cluster):
 
     for num, node in enumerate([ch1, ch2, ch3, ch4]):
         assert node.query("SELECT count() from sometbl") == "1\n"
-        assert node.query("SELECT dictGetString('default.somedict', 'value', toUInt64({}))".format(num)) == node.name + '\n'
-
+        assert node.query(
+            "SELECT dictGetString('default.somedict', 'value', toUInt64({}))".format(num)) == node.name + '\n'
 
     for num, node in enumerate([ch1, ch2, ch3, ch4]):
         node.query("ALTER TABLE sometbl UPDATE value = 'new_key' WHERE 1")
@@ -63,7 +68,8 @@ def test_dictionary_ddl_on_cluster(started_cluster):
     ch1.query("SYSTEM RELOAD DICTIONARY ON CLUSTER 'cluster' `default.somedict`")
 
     for num, node in enumerate([ch1, ch2, ch3, ch4]):
-        assert node.query("SELECT dictGetString('default.somedict', 'value', toUInt64({}))".format(num)) == 'new_key' + '\n'
+        assert node.query(
+            "SELECT dictGetString('default.somedict', 'value', toUInt64({}))".format(num)) == 'new_key' + '\n'
 
     ch1.query("DROP DICTIONARY default.somedict ON CLUSTER 'cluster'")
 

--- a/tests/integration/test_disk_access_storage/test.py
+++ b/tests/integration/test_disk_access_storage/test.py
@@ -27,27 +27,32 @@ def create_entities():
 
 @pytest.fixture(autouse=True)
 def drop_entities():
-    instance.query("DROP USER IF EXISTS u1, u2")    
-    instance.query("DROP ROLE IF EXISTS rx, ry")    
+    instance.query("DROP USER IF EXISTS u1, u2")
+    instance.query("DROP ROLE IF EXISTS rx, ry")
     instance.query("DROP ROW POLICY IF EXISTS p ON mydb.mytable")
     instance.query("DROP QUOTA IF EXISTS q")
     instance.query("DROP SETTINGS PROFILE IF EXISTS s1, s2")
-    
+
 
 def test_create():
     create_entities()
 
     def check():
         assert instance.query("SHOW CREATE USER u1") == "CREATE USER u1 SETTINGS PROFILE s1\n"
-        assert instance.query("SHOW CREATE USER u2") == "CREATE USER u2 IDENTIFIED WITH sha256_password HOST LOCAL DEFAULT ROLE rx\n"
-        assert instance.query("SHOW CREATE ROW POLICY p ON mydb.mytable") == "CREATE ROW POLICY p ON mydb.mytable FOR SELECT USING a < 1000 TO u1, u2\n"
-        assert instance.query("SHOW CREATE QUOTA q") == "CREATE QUOTA q FOR INTERVAL 1 hour MAX queries = 100 TO ALL EXCEPT rx\n"
+        assert instance.query(
+            "SHOW CREATE USER u2") == "CREATE USER u2 IDENTIFIED WITH sha256_password HOST LOCAL DEFAULT ROLE rx\n"
+        assert instance.query(
+            "SHOW CREATE ROW POLICY p ON mydb.mytable") == "CREATE ROW POLICY p ON mydb.mytable FOR SELECT USING a < 1000 TO u1, u2\n"
+        assert instance.query(
+            "SHOW CREATE QUOTA q") == "CREATE QUOTA q FOR INTERVAL 1 hour MAX queries = 100 TO ALL EXCEPT rx\n"
         assert instance.query("SHOW GRANTS FOR u1") == ""
         assert instance.query("SHOW GRANTS FOR u2") == "GRANT rx TO u2\n"
         assert instance.query("SHOW CREATE ROLE rx") == "CREATE ROLE rx SETTINGS PROFILE s1\n"
         assert instance.query("SHOW GRANTS FOR rx") == ""
-        assert instance.query("SHOW CREATE SETTINGS PROFILE s1") == "CREATE SETTINGS PROFILE s1 SETTINGS max_memory_usage = 123456789 MIN 100000000 MAX 200000000\n"
-        assert instance.query("SHOW CREATE SETTINGS PROFILE s2") == "CREATE SETTINGS PROFILE s2 SETTINGS INHERIT s1 TO u2\n"
+        assert instance.query(
+            "SHOW CREATE SETTINGS PROFILE s1") == "CREATE SETTINGS PROFILE s1 SETTINGS max_memory_usage = 123456789 MIN 100000000 MAX 200000000\n"
+        assert instance.query(
+            "SHOW CREATE SETTINGS PROFILE s2") == "CREATE SETTINGS PROFILE s2 SETTINGS INHERIT s1 TO u2\n"
 
     check()
     instance.restart_clickhouse()  # Check persistency
@@ -69,15 +74,18 @@ def test_alter():
 
     def check():
         assert instance.query("SHOW CREATE USER u1") == "CREATE USER u1 SETTINGS PROFILE s1\n"
-        assert instance.query("SHOW CREATE USER u2") == "CREATE USER u2 IDENTIFIED WITH sha256_password HOST LOCAL DEFAULT ROLE ry\n"
+        assert instance.query(
+            "SHOW CREATE USER u2") == "CREATE USER u2 IDENTIFIED WITH sha256_password HOST LOCAL DEFAULT ROLE ry\n"
         assert instance.query("SHOW GRANTS FOR u1") == "GRANT SELECT ON mydb.mytable TO u1\n"
         assert instance.query("SHOW GRANTS FOR u2") == "GRANT rx, ry TO u2\n"
         assert instance.query("SHOW CREATE ROLE rx") == "CREATE ROLE rx SETTINGS PROFILE s2\n"
         assert instance.query("SHOW CREATE ROLE ry") == "CREATE ROLE ry\n"
         assert instance.query("SHOW GRANTS FOR rx") == "GRANT SELECT ON mydb.* TO rx WITH GRANT OPTION\n"
         assert instance.query("SHOW GRANTS FOR ry") == "GRANT rx TO ry WITH ADMIN OPTION\n"
-        assert instance.query("SHOW CREATE SETTINGS PROFILE s1") == "CREATE SETTINGS PROFILE s1 SETTINGS max_memory_usage = 987654321 READONLY\n"
-        assert instance.query("SHOW CREATE SETTINGS PROFILE s2") == "CREATE SETTINGS PROFILE s2 SETTINGS INHERIT s1 TO u2\n"
+        assert instance.query(
+            "SHOW CREATE SETTINGS PROFILE s1") == "CREATE SETTINGS PROFILE s1 SETTINGS max_memory_usage = 987654321 READONLY\n"
+        assert instance.query(
+            "SHOW CREATE SETTINGS PROFILE s2") == "CREATE SETTINGS PROFILE s2 SETTINGS INHERIT s1 TO u2\n"
 
     check()
     instance.restart_clickhouse()  # Check persistency
@@ -98,7 +106,8 @@ def test_drop():
         assert instance.query("SHOW CREATE USER u1") == "CREATE USER u1\n"
         assert instance.query("SHOW CREATE SETTINGS PROFILE s2") == "CREATE SETTINGS PROFILE s2\n"
         assert "There is no user `u2`" in instance.query_and_get_error("SHOW CREATE USER u2")
-        assert "There is no row policy `p ON mydb.mytable`" in instance.query_and_get_error("SHOW CREATE ROW POLICY p ON mydb.mytable")
+        assert "There is no row policy `p ON mydb.mytable`" in instance.query_and_get_error(
+            "SHOW CREATE ROW POLICY p ON mydb.mytable")
         assert "There is no quota `q`" in instance.query_and_get_error("SHOW CREATE QUOTA q")
 
     check()

--- a/tests/integration/test_disk_types/test.py
+++ b/tests/integration/test_disk_types/test.py
@@ -1,15 +1,14 @@
-
 import pytest
 from helpers.cluster import ClickHouseCluster
 
 disk_types = {
-    "default" : "local",
-    "disk_s3" : "s3",
-    "disk_memory" : "memory",
+    "default": "local",
+    "disk_s3": "s3",
+    "disk_memory": "memory",
 }
 
-@pytest.fixture(scope="module")
 
+@pytest.fixture(scope="module")
 def cluster():
     try:
         cluster = ClickHouseCluster(__file__)
@@ -19,19 +18,20 @@ def cluster():
     finally:
         cluster.shutdown()
 
+
 def test_different_types(cluster):
     node = cluster.instances["node"]
     responce = node.query("SELECT * FROM system.disks")
     disks = responce.split("\n")
     for disk in disks:
-        if disk == '': # skip empty line (after split at last position)
+        if disk == '':  # skip empty line (after split at last position)
             continue
         fields = disk.split("\t")
         assert len(fields) >= 6
         assert disk_types.get(fields[0], "UNKNOWN") == fields[5]
 
+
 def test_select_by_type(cluster):
     node = cluster.instances["node"]
     for name, disk_type in disk_types.items():
         assert node.query("SELECT name FROM system.disks WHERE type='" + disk_type + "'") == name + "\n"
-

--- a/tests/integration/test_distributed_backward_compatability/test.py
+++ b/tests/integration/test_distributed_backward_compatability/test.py
@@ -1,15 +1,13 @@
 import pytest
-import time
 
 from helpers.cluster import ClickHouseCluster
-from helpers.network import PartitionManager
-from helpers.test_tools import TSV
-
 
 cluster = ClickHouseCluster(__file__)
 
-node_old = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml'], image='yandex/clickhouse-server', tag='19.17.8.54', stay_alive=True, with_installed_binary=True)
+node_old = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml'], image='yandex/clickhouse-server',
+                                tag='19.17.8.54', stay_alive=True, with_installed_binary=True)
 node_new = cluster.add_instance('node2', main_configs=['configs/remote_servers.xml'])
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -22,13 +20,16 @@ def started_cluster():
         node_old.query("INSERT INTO local_table VALUES (1, 'node1')")
         node_new.query("INSERT INTO local_table VALUES (2, 'node2')")
 
-        node_old.query("CREATE TABLE distributed(id UInt32, val String) ENGINE = Distributed(test_cluster, default, local_table)")
-        node_new.query("CREATE TABLE distributed(id UInt32, val String) ENGINE = Distributed(test_cluster, default, local_table)")
+        node_old.query(
+            "CREATE TABLE distributed(id UInt32, val String) ENGINE = Distributed(test_cluster, default, local_table)")
+        node_new.query(
+            "CREATE TABLE distributed(id UInt32, val String) ENGINE = Distributed(test_cluster, default, local_table)")
 
         yield cluster
 
     finally:
         cluster.shutdown()
+
 
 def test_distributed_in_tuple(started_cluster):
     query1 = "SELECT count() FROM distributed WHERE (id, val) IN ((1, 'node1'), (2, 'a'), (3, 'b'))"

--- a/tests/integration/test_distributed_ddl/test.py
+++ b/tests/integration/test_distributed_ddl/test.py
@@ -41,7 +41,8 @@ def test_default_database(test_cluster):
 
     test_cluster.ddl_check_query(instance, "CREATE DATABASE IF NOT EXISTS test2 ON CLUSTER 'cluster' FORMAT TSV")
     test_cluster.ddl_check_query(instance, "DROP TABLE IF EXISTS null ON CLUSTER 'cluster' FORMAT TSV")
-    test_cluster.ddl_check_query(instance, "CREATE TABLE null ON CLUSTER 'cluster2' (s String DEFAULT 'escape\t\nme') ENGINE = Null")
+    test_cluster.ddl_check_query(instance,
+                                 "CREATE TABLE null ON CLUSTER 'cluster2' (s String DEFAULT 'escape\t\nme') ENGINE = Null")
 
     contents = instance.query("SELECT hostName() AS h, database FROM all_tables WHERE name = 'null' ORDER BY h")
     assert TSV(contents) == TSV("ch1\tdefault\nch2\ttest2\nch3\tdefault\nch4\ttest2\n")
@@ -52,13 +53,18 @@ def test_default_database(test_cluster):
 
 def test_create_view(test_cluster):
     instance = test_cluster.instances['ch3']
-    test_cluster.ddl_check_query(instance, "CREATE VIEW test.super_simple_view ON CLUSTER 'cluster' AS SELECT * FROM system.numbers FORMAT TSV")
-    test_cluster.ddl_check_query(instance, "CREATE MATERIALIZED VIEW test.simple_mat_view ON CLUSTER 'cluster' ENGINE = Memory AS SELECT * FROM system.numbers FORMAT TSV")
+    test_cluster.ddl_check_query(instance,
+                                 "CREATE VIEW test.super_simple_view ON CLUSTER 'cluster' AS SELECT * FROM system.numbers FORMAT TSV")
+    test_cluster.ddl_check_query(instance,
+                                 "CREATE MATERIALIZED VIEW test.simple_mat_view ON CLUSTER 'cluster' ENGINE = Memory AS SELECT * FROM system.numbers FORMAT TSV")
     test_cluster.ddl_check_query(instance, "DROP TABLE test.simple_mat_view ON CLUSTER 'cluster' FORMAT TSV")
-    test_cluster.ddl_check_query(instance, "DROP TABLE IF EXISTS test.super_simple_view2 ON CLUSTER 'cluster' FORMAT TSV")
+    test_cluster.ddl_check_query(instance,
+                                 "DROP TABLE IF EXISTS test.super_simple_view2 ON CLUSTER 'cluster' FORMAT TSV")
 
-    test_cluster.ddl_check_query(instance, "CREATE TABLE test.super_simple ON CLUSTER 'cluster' (i Int8) ENGINE = Memory")
-    test_cluster.ddl_check_query(instance, "RENAME TABLE test.super_simple TO test.super_simple2 ON CLUSTER 'cluster' FORMAT TSV")
+    test_cluster.ddl_check_query(instance,
+                                 "CREATE TABLE test.super_simple ON CLUSTER 'cluster' (i Int8) ENGINE = Memory")
+    test_cluster.ddl_check_query(instance,
+                                 "RENAME TABLE test.super_simple TO test.super_simple2 ON CLUSTER 'cluster' FORMAT TSV")
     test_cluster.ddl_check_query(instance, "DROP TABLE test.super_simple2 ON CLUSTER 'cluster'")
 
 
@@ -69,7 +75,8 @@ def test_on_server_fail(test_cluster):
     test_cluster.ddl_check_query(instance, "DROP TABLE IF EXISTS test.test_server_fail ON CLUSTER 'cluster'")
 
     kill_instance.get_docker_handle().stop()
-    request = instance.get_query_request("CREATE TABLE test.test_server_fail ON CLUSTER 'cluster' (i Int8) ENGINE=Null", timeout=30)
+    request = instance.get_query_request("CREATE TABLE test.test_server_fail ON CLUSTER 'cluster' (i Int8) ENGINE=Null",
+                                         timeout=30)
     kill_instance.get_docker_handle().start()
 
     test_cluster.ddl_check_query(instance, "DROP TABLE IF EXISTS test.__nope__ ON CLUSTER 'cluster'")
@@ -78,7 +85,8 @@ def test_on_server_fail(test_cluster):
     test_cluster.check_all_hosts_successfully_executed(request.get_answer())
 
     # And check query artefacts
-    contents = instance.query("SELECT hostName() AS h FROM all_tables WHERE database='test' AND name='test_server_fail' ORDER BY h")
+    contents = instance.query(
+        "SELECT hostName() AS h FROM all_tables WHERE database='test' AND name='test_server_fail' ORDER BY h")
     assert TSV(contents) == TSV("ch1\nch2\nch3\nch4\n")
 
     test_cluster.ddl_check_query(instance, "DROP TABLE test.test_server_fail ON CLUSTER 'cluster'")
@@ -98,11 +106,11 @@ def _test_on_connection_losses(test_cluster, zk_timeout):
 
 
 def test_on_connection_loss(test_cluster):
-    _test_on_connection_losses(test_cluster, 1.5) # connection loss will occur only (3 sec ZK timeout in config)
+    _test_on_connection_losses(test_cluster, 1.5)  # connection loss will occur only (3 sec ZK timeout in config)
 
 
 def test_on_session_expired(test_cluster):
-    _test_on_connection_losses(test_cluster, 4) # session should be expired (3 sec ZK timeout in config)
+    _test_on_connection_losses(test_cluster, 4)  # session should be expired (3 sec ZK timeout in config)
 
 
 def test_simple_alters(test_cluster):
@@ -127,28 +135,31 @@ ENGINE = Distributed('{cluster}', default, merge, i)
 
     for i in xrange(0, 4, 2):
         k = (i / 2) * 2
-        test_cluster.instances['ch{}'.format(i + 1)].query("INSERT INTO merge (i) VALUES ({})({})".format(k, k+1))
+        test_cluster.instances['ch{}'.format(i + 1)].query("INSERT INTO merge (i) VALUES ({})({})".format(k, k + 1))
 
-    assert TSV(instance.query("SELECT i FROM all_merge_32 ORDER BY i")) == TSV(''.join(['{}\n'.format(x) for x in xrange(4)]))
-
+    assert TSV(instance.query("SELECT i FROM all_merge_32 ORDER BY i")) == TSV(
+        ''.join(['{}\n'.format(x) for x in xrange(4)]))
 
     time.sleep(5)
     test_cluster.ddl_check_query(instance, "ALTER TABLE merge ON CLUSTER '{cluster}' MODIFY COLUMN i Int64")
     time.sleep(5)
-    test_cluster.ddl_check_query(instance, "ALTER TABLE merge ON CLUSTER '{cluster}' ADD COLUMN s String DEFAULT toString(i) FORMAT TSV")
+    test_cluster.ddl_check_query(instance,
+                                 "ALTER TABLE merge ON CLUSTER '{cluster}' ADD COLUMN s String DEFAULT toString(i) FORMAT TSV")
 
-    assert TSV(instance.query("SELECT i, s FROM all_merge_64 ORDER BY i")) == TSV(''.join(['{}\t{}\n'.format(x,x) for x in xrange(4)]))
-
+    assert TSV(instance.query("SELECT i, s FROM all_merge_64 ORDER BY i")) == TSV(
+        ''.join(['{}\t{}\n'.format(x, x) for x in xrange(4)]))
 
     for i in xrange(0, 4, 2):
         k = (i / 2) * 2 + 4
-        test_cluster.instances['ch{}'.format(i + 1)].query("INSERT INTO merge (p, i) VALUES (31, {})(31, {})".format(k, k+1))
+        test_cluster.instances['ch{}'.format(i + 1)].query(
+            "INSERT INTO merge (p, i) VALUES (31, {})(31, {})".format(k, k + 1))
 
-    assert TSV(instance.query("SELECT i, s FROM all_merge_64 ORDER BY i")) == TSV(''.join(['{}\t{}\n'.format(x,x) for x in xrange(8)]))
-
+    assert TSV(instance.query("SELECT i, s FROM all_merge_64 ORDER BY i")) == TSV(
+        ''.join(['{}\t{}\n'.format(x, x) for x in xrange(8)]))
 
     test_cluster.ddl_check_query(instance, "ALTER TABLE merge ON CLUSTER '{cluster}' DETACH PARTITION 197002")
-    assert TSV(instance.query("SELECT i, s FROM all_merge_64 ORDER BY i")) == TSV(''.join(['{}\t{}\n'.format(x,x) for x in xrange(4)]))
+    assert TSV(instance.query("SELECT i, s FROM all_merge_64 ORDER BY i")) == TSV(
+        ''.join(['{}\t{}\n'.format(x, x) for x in xrange(4)]))
 
     test_cluster.ddl_check_query(instance, "DROP TABLE merge ON CLUSTER '{cluster}'")
     test_cluster.ddl_check_query(instance, "DROP TABLE all_merge_32 ON CLUSTER '{cluster}'")
@@ -160,9 +171,11 @@ def test_macro(test_cluster):
     test_cluster.ddl_check_query(instance, "CREATE TABLE tab ON CLUSTER '{cluster}' (value UInt8) ENGINE = Memory")
 
     for i in xrange(4):
-        test_cluster.insert_reliable(test_cluster.instances['ch{}'.format(i + 1)], "INSERT INTO tab VALUES ({})".format(i))
+        test_cluster.insert_reliable(test_cluster.instances['ch{}'.format(i + 1)],
+                                     "INSERT INTO tab VALUES ({})".format(i))
 
-    test_cluster.ddl_check_query(instance, "CREATE TABLE distr ON CLUSTER '{cluster}' (value UInt8) ENGINE = Distributed('{cluster}', 'default', 'tab', value % 4)")
+    test_cluster.ddl_check_query(instance,
+                                 "CREATE TABLE distr ON CLUSTER '{cluster}' (value UInt8) ENGINE = Distributed('{cluster}', 'default', 'tab', value % 4)")
 
     assert TSV(instance.query("SELECT value FROM distr ORDER BY value")) == TSV('0\n1\n2\n3\n')
     assert TSV(test_cluster.instances['ch3'].query("SELECT value FROM distr ORDER BY value")) == TSV('0\n1\n2\n3\n')
@@ -197,21 +210,26 @@ def test_allowed_databases(test_cluster):
     instance.query("CREATE DATABASE IF NOT EXISTS db1 ON CLUSTER cluster")
     instance.query("CREATE DATABASE IF NOT EXISTS db2 ON CLUSTER cluster")
 
-    instance.query("CREATE TABLE db1.t1 ON CLUSTER cluster (i Int8) ENGINE = Memory", settings={"user" : "restricted_user"})
+    instance.query("CREATE TABLE db1.t1 ON CLUSTER cluster (i Int8) ENGINE = Memory",
+                   settings={"user": "restricted_user"})
 
     with pytest.raises(Exception):
-        instance.query("CREATE TABLE db2.t2 ON CLUSTER cluster (i Int8) ENGINE = Memory", settings={"user" : "restricted_user"})
+        instance.query("CREATE TABLE db2.t2 ON CLUSTER cluster (i Int8) ENGINE = Memory",
+                       settings={"user": "restricted_user"})
     with pytest.raises(Exception):
-        instance.query("CREATE TABLE t3 ON CLUSTER cluster (i Int8) ENGINE = Memory", settings={"user" : "restricted_user"})
+        instance.query("CREATE TABLE t3 ON CLUSTER cluster (i Int8) ENGINE = Memory",
+                       settings={"user": "restricted_user"})
     with pytest.raises(Exception):
-        instance.query("DROP DATABASE db2 ON CLUSTER cluster", settings={"user" : "restricted_user"})
+        instance.query("DROP DATABASE db2 ON CLUSTER cluster", settings={"user": "restricted_user"})
 
-    instance.query("DROP DATABASE db1 ON CLUSTER cluster", settings={"user" : "restricted_user"})
+    instance.query("DROP DATABASE db1 ON CLUSTER cluster", settings={"user": "restricted_user"})
+
 
 def test_kill_query(test_cluster):
     instance = test_cluster.instances['ch3']
 
     test_cluster.ddl_check_query(instance, "KILL QUERY ON CLUSTER 'cluster' WHERE NOT elapsed FORMAT TSV")
+
 
 def test_detach_query(test_cluster):
     instance = test_cluster.instances['ch3']
@@ -226,21 +244,25 @@ def test_optimize_query(test_cluster):
     instance = test_cluster.instances['ch3']
 
     test_cluster.ddl_check_query(instance, "DROP TABLE IF EXISTS test_optimize ON CLUSTER cluster FORMAT TSV")
-    test_cluster.ddl_check_query(instance, "CREATE TABLE test_optimize ON CLUSTER cluster (p Date, i Int32) ENGINE = MergeTree(p, p, 8192)")
+    test_cluster.ddl_check_query(instance,
+                                 "CREATE TABLE test_optimize ON CLUSTER cluster (p Date, i Int32) ENGINE = MergeTree(p, p, 8192)")
     test_cluster.ddl_check_query(instance, "OPTIMIZE TABLE test_optimize ON CLUSTER cluster FORMAT TSV")
 
 
 def test_create_as_select(test_cluster):
     instance = test_cluster.instances['ch2']
-    test_cluster.ddl_check_query(instance, "CREATE TABLE test_as_select ON CLUSTER cluster ENGINE = Memory AS (SELECT 1 AS x UNION ALL SELECT 2 AS x)")
+    test_cluster.ddl_check_query(instance,
+                                 "CREATE TABLE test_as_select ON CLUSTER cluster ENGINE = Memory AS (SELECT 1 AS x UNION ALL SELECT 2 AS x)")
     assert TSV(instance.query("SELECT x FROM test_as_select ORDER BY x")) == TSV("1\n2\n")
     test_cluster.ddl_check_query(instance, "DROP TABLE IF EXISTS test_as_select ON CLUSTER cluster")
 
 
 def test_create_reserved(test_cluster):
     instance = test_cluster.instances['ch2']
-    test_cluster.ddl_check_query(instance, "CREATE TABLE test_reserved ON CLUSTER cluster (`p` Date, `image` Nullable(String), `index` Nullable(Float64), `invalidate` Nullable(Int64)) ENGINE = MergeTree(`p`, `p`, 8192)")
-    test_cluster.ddl_check_query(instance, "CREATE TABLE test_as_reserved ON CLUSTER cluster ENGINE = Memory AS (SELECT * from test_reserved)")
+    test_cluster.ddl_check_query(instance,
+                                 "CREATE TABLE test_reserved ON CLUSTER cluster (`p` Date, `image` Nullable(String), `index` Nullable(Float64), `invalidate` Nullable(Int64)) ENGINE = MergeTree(`p`, `p`, 8192)")
+    test_cluster.ddl_check_query(instance,
+                                 "CREATE TABLE test_as_reserved ON CLUSTER cluster ENGINE = Memory AS (SELECT * from test_reserved)")
     test_cluster.ddl_check_query(instance, "DROP TABLE IF EXISTS test_reserved ON CLUSTER cluster")
     test_cluster.ddl_check_query(instance, "DROP TABLE IF EXISTS test_as_reserved ON CLUSTER cluster")
 
@@ -248,10 +270,11 @@ def test_create_reserved(test_cluster):
 def test_rename(test_cluster):
     instance = test_cluster.instances['ch1']
     rules = test_cluster.pm_random_drops.pop_rules()
-    test_cluster.ddl_check_query(instance, "CREATE TABLE rename_shard ON CLUSTER cluster (id Int64, sid String DEFAULT concat('old', toString(id))) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/staging/test_shard', '{replica}') ORDER BY (id)")
-    test_cluster.ddl_check_query(instance, "CREATE TABLE rename_new ON CLUSTER cluster AS rename_shard ENGINE = Distributed(cluster, default, rename_shard, id % 2)")
+    test_cluster.ddl_check_query(instance,
+                                 "CREATE TABLE rename_shard ON CLUSTER cluster (id Int64, sid String DEFAULT concat('old', toString(id))) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/staging/test_shard', '{replica}') ORDER BY (id)")
+    test_cluster.ddl_check_query(instance,
+                                 "CREATE TABLE rename_new ON CLUSTER cluster AS rename_shard ENGINE = Distributed(cluster, default, rename_shard, id % 2)")
     test_cluster.ddl_check_query(instance, "RENAME TABLE rename_new TO rename ON CLUSTER cluster;")
-
 
     for i in range(10):
         instance.query("insert into rename (id) values ({})".format(i))
@@ -261,10 +284,13 @@ def test_rename(test_cluster):
     # so ddl query will always fail on some replicas even if query was actually executed by leader
     # Also such inconsistency in cluster configuration may lead to query duplication if leader suddenly changed
     # because path of lock in zk contains shard name, which is list of host names of replicas
-    instance.query("ALTER TABLE rename_shard ON CLUSTER cluster MODIFY COLUMN sid String DEFAULT concat('new', toString(id))", ignore_error=True)
+    instance.query(
+        "ALTER TABLE rename_shard ON CLUSTER cluster MODIFY COLUMN sid String DEFAULT concat('new', toString(id))",
+        ignore_error=True)
     time.sleep(1)
 
-    test_cluster.ddl_check_query(instance, "CREATE TABLE rename_new ON CLUSTER cluster AS rename_shard ENGINE = Distributed(cluster, default, rename_shard, id % 2)")
+    test_cluster.ddl_check_query(instance,
+                                 "CREATE TABLE rename_new ON CLUSTER cluster AS rename_shard ENGINE = Distributed(cluster, default, rename_shard, id % 2)")
 
     instance.query("system stop distributed sends rename")
 
@@ -283,11 +309,12 @@ def test_rename(test_cluster):
     # system stop distributed sends does not affect inserts into local shard,
     # so some ids in range (10, 20) will be inserted into rename_shard
     assert instance.query("select count(id), sum(id) from rename").rstrip() == "25\t360"
-    #assert instance.query("select count(id), sum(id) from rename").rstrip() == "20\t290"
+    # assert instance.query("select count(id), sum(id) from rename").rstrip() == "20\t290"
     assert instance.query("select count(id), sum(id) from rename where sid like 'old%'").rstrip() == "15\t115"
-    #assert instance.query("select count(id), sum(id) from rename where sid like 'old%'").rstrip() == "10\t45"
+    # assert instance.query("select count(id), sum(id) from rename where sid like 'old%'").rstrip() == "10\t45"
     assert instance.query("select count(id), sum(id) from rename where sid like 'new%'").rstrip() == "10\t245"
     test_cluster.pm_random_drops.push_rules(rules)
+
 
 def test_socket_timeout(test_cluster):
     instance = test_cluster.instances['ch1']
@@ -295,24 +322,30 @@ def test_socket_timeout(test_cluster):
     for i in range(0, 100):
         instance.query("select hostName() as host, count() from cluster('cluster', 'system', 'settings') group by host")
 
+
 def test_replicated_without_arguments(test_cluster):
     rules = test_cluster.pm_random_drops.pop_rules()
     instance = test_cluster.instances['ch1']
     test_cluster.ddl_check_query(instance, "CREATE DATABASE test_atomic ON CLUSTER cluster ENGINE=Atomic",
                                  settings={'show_table_uuid_in_table_create_query_if_not_nil': 1})
-    test_cluster.ddl_check_query(instance, "CREATE TABLE test_atomic.rmt ON CLUSTER cluster (n UInt64, s String) ENGINE=ReplicatedMergeTree ORDER BY n",
+    test_cluster.ddl_check_query(instance,
+                                 "CREATE TABLE test_atomic.rmt ON CLUSTER cluster (n UInt64, s String) ENGINE=ReplicatedMergeTree ORDER BY n",
                                  settings={'show_table_uuid_in_table_create_query_if_not_nil': 1})
     test_cluster.ddl_check_query(instance, "DROP TABLE test_atomic.rmt ON CLUSTER cluster")
-    test_cluster.ddl_check_query(instance, "CREATE TABLE test_atomic.rmt ON CLUSTER cluster (n UInt64, s String) ENGINE=ReplicatedMergeTree ORDER BY n",
+    test_cluster.ddl_check_query(instance,
+                                 "CREATE TABLE test_atomic.rmt ON CLUSTER cluster (n UInt64, s String) ENGINE=ReplicatedMergeTree ORDER BY n",
                                  settings={'show_table_uuid_in_table_create_query_if_not_nil': 1})
     test_cluster.ddl_check_query(instance, "RENAME TABLE test_atomic.rmt TO test_atomic.rmt_renamed ON CLUSTER cluster")
-    test_cluster.ddl_check_query(instance, "CREATE TABLE test_atomic.rmt ON CLUSTER cluster (n UInt64, s String) ENGINE=ReplicatedMergeTree ORDER BY n",
+    test_cluster.ddl_check_query(instance,
+                                 "CREATE TABLE test_atomic.rmt ON CLUSTER cluster (n UInt64, s String) ENGINE=ReplicatedMergeTree ORDER BY n",
                                  settings={'show_table_uuid_in_table_create_query_if_not_nil': 1})
-    test_cluster.ddl_check_query(instance, "EXCHANGE TABLES test_atomic.rmt AND test_atomic.rmt_renamed ON CLUSTER cluster")
+    test_cluster.ddl_check_query(instance,
+                                 "EXCHANGE TABLES test_atomic.rmt AND test_atomic.rmt_renamed ON CLUSTER cluster")
     test_cluster.pm_random_drops.push_rules(rules)
+
 
 if __name__ == '__main__':
     with contextmanager(test_cluster)() as ctx_cluster:
-       for name, instance in ctx_cluster.instances.items():
-           print name, instance.ip_address
-       raw_input("Cluster created, press any key to destroy...")
+        for name, instance in ctx_cluster.instances.items():
+            print name, instance.ip_address
+        raw_input("Cluster created, press any key to destroy...")

--- a/tests/integration/test_distributed_ddl/test_replicated_alter.py
+++ b/tests/integration/test_distributed_ddl/test_replicated_alter.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import time
+
 import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -60,29 +61,34 @@ ENGINE = Distributed(cluster, default, merge_for_alter, i)
 
     for i in xrange(4):
         k = (i / 2) * 2
-        test_cluster.insert_reliable(test_cluster.instances['ch{}'.format(i + 1)], "INSERT INTO merge_for_alter (i) VALUES ({})({})".format(k, k+1))
+        test_cluster.insert_reliable(test_cluster.instances['ch{}'.format(i + 1)],
+                                     "INSERT INTO merge_for_alter (i) VALUES ({})({})".format(k, k + 1))
 
     test_cluster.sync_replicas("merge_for_alter")
 
-    assert TSV(instance.query("SELECT i FROM all_merge_32 ORDER BY i")) == TSV(''.join(['{}\n'.format(x) for x in xrange(4)]))
-
+    assert TSV(instance.query("SELECT i FROM all_merge_32 ORDER BY i")) == TSV(
+        ''.join(['{}\n'.format(x) for x in xrange(4)]))
 
     test_cluster.ddl_check_query(instance, "ALTER TABLE merge_for_alter ON CLUSTER cluster MODIFY COLUMN i Int64")
-    test_cluster.ddl_check_query(instance, "ALTER TABLE merge_for_alter ON CLUSTER cluster ADD COLUMN s String DEFAULT toString(i)")
+    test_cluster.ddl_check_query(instance,
+                                 "ALTER TABLE merge_for_alter ON CLUSTER cluster ADD COLUMN s String DEFAULT toString(i)")
 
-    assert TSV(instance.query("SELECT i, s FROM all_merge_64 ORDER BY i")) == TSV(''.join(['{}\t{}\n'.format(x,x) for x in xrange(4)]))
-
+    assert TSV(instance.query("SELECT i, s FROM all_merge_64 ORDER BY i")) == TSV(
+        ''.join(['{}\t{}\n'.format(x, x) for x in xrange(4)]))
 
     for i in xrange(4):
         k = (i / 2) * 2 + 4
-        test_cluster.insert_reliable(test_cluster.instances['ch{}'.format(i + 1)], "INSERT INTO merge_for_alter (p, i) VALUES (31, {})(31, {})".format(k, k+1))
+        test_cluster.insert_reliable(test_cluster.instances['ch{}'.format(i + 1)],
+                                     "INSERT INTO merge_for_alter (p, i) VALUES (31, {})(31, {})".format(k, k + 1))
 
     test_cluster.sync_replicas("merge_for_alter")
 
-    assert TSV(instance.query("SELECT i, s FROM all_merge_64 ORDER BY i")) == TSV(''.join(['{}\t{}\n'.format(x,x) for x in xrange(8)]))
+    assert TSV(instance.query("SELECT i, s FROM all_merge_64 ORDER BY i")) == TSV(
+        ''.join(['{}\t{}\n'.format(x, x) for x in xrange(8)]))
 
     test_cluster.ddl_check_query(instance, "ALTER TABLE merge_for_alter ON CLUSTER cluster DETACH PARTITION 197002")
-    assert TSV(instance.query("SELECT i, s FROM all_merge_64 ORDER BY i")) == TSV(''.join(['{}\t{}\n'.format(x,x) for x in xrange(4)]))
+    assert TSV(instance.query("SELECT i, s FROM all_merge_64 ORDER BY i")) == TSV(
+        ''.join(['{}\t{}\n'.format(x, x) for x in xrange(4)]))
 
     test_cluster.ddl_check_query(instance, "DROP TABLE merge_for_alter ON CLUSTER cluster")
 

--- a/tests/integration/test_distributed_ddl_password/test.py
+++ b/tests/integration/test_distributed_ddl_password/test.py
@@ -1,17 +1,21 @@
-import time
 import pytest
+from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_eq_with_retry
 
-from helpers.client import QueryRuntimeException
-
 cluster = ClickHouseCluster(__file__)
-node1 = cluster.add_instance('node1', main_configs=["configs/config.d/clusters.xml"], user_configs=["configs/users.d/default_with_password.xml"], with_zookeeper=True)
-node2 = cluster.add_instance('node2', main_configs=["configs/config.d/clusters.xml"], user_configs=["configs/users.d/default_with_password.xml"], with_zookeeper=True)
-node3 = cluster.add_instance('node3', main_configs=["configs/config.d/clusters.xml"], user_configs=["configs/users.d/default_with_password.xml"], with_zookeeper=True)
-node4 = cluster.add_instance('node4', main_configs=["configs/config.d/clusters.xml"], user_configs=["configs/users.d/default_with_password.xml"], with_zookeeper=True)
-node5 = cluster.add_instance('node5', main_configs=["configs/config.d/clusters.xml"], user_configs=["configs/users.d/default_with_password.xml"], with_zookeeper=True)
-node6 = cluster.add_instance('node6', main_configs=["configs/config.d/clusters.xml"], user_configs=["configs/users.d/default_with_password.xml"], with_zookeeper=True)
+node1 = cluster.add_instance('node1', main_configs=["configs/config.d/clusters.xml"],
+                             user_configs=["configs/users.d/default_with_password.xml"], with_zookeeper=True)
+node2 = cluster.add_instance('node2', main_configs=["configs/config.d/clusters.xml"],
+                             user_configs=["configs/users.d/default_with_password.xml"], with_zookeeper=True)
+node3 = cluster.add_instance('node3', main_configs=["configs/config.d/clusters.xml"],
+                             user_configs=["configs/users.d/default_with_password.xml"], with_zookeeper=True)
+node4 = cluster.add_instance('node4', main_configs=["configs/config.d/clusters.xml"],
+                             user_configs=["configs/users.d/default_with_password.xml"], with_zookeeper=True)
+node5 = cluster.add_instance('node5', main_configs=["configs/config.d/clusters.xml"],
+                             user_configs=["configs/users.d/default_with_password.xml"], with_zookeeper=True)
+node6 = cluster.add_instance('node6', main_configs=["configs/config.d/clusters.xml"],
+                             user_configs=["configs/users.d/default_with_password.xml"], with_zookeeper=True)
 
 
 @pytest.fixture(scope="module")
@@ -21,27 +25,29 @@ def start_cluster():
 
         for node, shard in [(node1, 1), (node2, 1), (node3, 2), (node4, 2), (node5, 3), (node6, 3)]:
             node.query(
-            '''
-                CREATE TABLE test_table(date Date, id UInt32, dummy UInt32)
-                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test{shard}/replicated', '{replica}')
-                PARTITION BY date
-                ORDER BY id
-            '''.format(shard=shard, replica=node.name), settings={"password": "clickhouse"})
+                '''
+                    CREATE TABLE test_table(date Date, id UInt32, dummy UInt32)
+                    ENGINE = ReplicatedMergeTree('/clickhouse/tables/test{shard}/replicated', '{replica}')
+                    PARTITION BY date
+                    ORDER BY id
+                '''.format(shard=shard, replica=node.name), settings={"password": "clickhouse"})
 
         yield cluster
 
     finally:
         cluster.shutdown()
 
+
 def test_truncate(start_cluster):
-    node1.query("insert into test_table values ('2019-02-15', 1, 2), ('2019-02-15', 2, 3), ('2019-02-15', 3, 4)", settings={"password": "clickhouse"})
+    node1.query("insert into test_table values ('2019-02-15', 1, 2), ('2019-02-15', 2, 3), ('2019-02-15', 3, 4)",
+                settings={"password": "clickhouse"})
 
     assert node1.query("select count(*) from test_table", settings={"password": "clickhouse"}) == "3\n"
     node2.query("system sync replica test_table", settings={"password": "clickhouse"})
     assert node2.query("select count(*) from test_table", settings={"password": "clickhouse"}) == "3\n"
 
-
-    node3.query("insert into test_table values ('2019-02-16', 1, 2), ('2019-02-16', 2, 3), ('2019-02-16', 3, 4)", settings={"password": "clickhouse"})
+    node3.query("insert into test_table values ('2019-02-16', 1, 2), ('2019-02-16', 2, 3), ('2019-02-16', 3, 4)",
+                settings={"password": "clickhouse"})
 
     assert node3.query("select count(*) from test_table", settings={"password": "clickhouse"}) == "3\n"
     node4.query("system sync replica test_table", settings={"password": "clickhouse"})
@@ -55,11 +61,15 @@ def test_truncate(start_cluster):
     node2.query("drop table test_table on cluster 'awesome_cluster'", settings={"password": "clickhouse"})
 
     for node in [node1, node2, node3, node4]:
-        assert_eq_with_retry(node, "select count(*) from system.tables where name='test_table'", "0", settings={"password": "clickhouse"})
+        assert_eq_with_retry(node, "select count(*) from system.tables where name='test_table'", "0",
+                             settings={"password": "clickhouse"})
+
 
 def test_alter(start_cluster):
-    node5.query("insert into test_table values ('2019-02-15', 1, 2), ('2019-02-15', 2, 3), ('2019-02-15', 3, 4)", settings={"password": "clickhouse"})
-    node6.query("insert into test_table values ('2019-02-15', 4, 2), ('2019-02-15', 5, 3), ('2019-02-15', 6, 4)", settings={"password": "clickhouse"})
+    node5.query("insert into test_table values ('2019-02-15', 1, 2), ('2019-02-15', 2, 3), ('2019-02-15', 3, 4)",
+                settings={"password": "clickhouse"})
+    node6.query("insert into test_table values ('2019-02-15', 4, 2), ('2019-02-15', 5, 3), ('2019-02-15', 6, 4)",
+                settings={"password": "clickhouse"})
 
     node5.query("SYSTEM SYNC REPLICA test_table", settings={"password": "clickhouse"})
     node6.query("SYSTEM SYNC REPLICA test_table", settings={"password": "clickhouse"})
@@ -75,24 +85,30 @@ def test_alter(start_cluster):
     assert_eq_with_retry(node5, "select count(*) from test_table", "6", settings={"password": "clickhouse"})
     assert_eq_with_retry(node6, "select count(*) from test_table", "6", settings={"password": "clickhouse"})
 
-    node6.query("ALTER TABLE test_table ON CLUSTER 'simple_cluster' DETACH PARTITION '2019-02-15'", settings={"password": "clickhouse"})
+    node6.query("ALTER TABLE test_table ON CLUSTER 'simple_cluster' DETACH PARTITION '2019-02-15'",
+                settings={"password": "clickhouse"})
     assert_eq_with_retry(node5, "select count(*) from test_table", "0", settings={"password": "clickhouse"})
     assert_eq_with_retry(node6, "select count(*) from test_table", "0", settings={"password": "clickhouse"})
 
     with pytest.raises(QueryRuntimeException):
-        node6.query("ALTER TABLE test_table ON CLUSTER 'simple_cluster' ATTACH PARTITION '2019-02-15'", settings={"password": "clickhouse"})
+        node6.query("ALTER TABLE test_table ON CLUSTER 'simple_cluster' ATTACH PARTITION '2019-02-15'",
+                    settings={"password": "clickhouse"})
 
     node5.query("ALTER TABLE test_table ATTACH PARTITION '2019-02-15'", settings={"password": "clickhouse"})
 
     assert_eq_with_retry(node5, "select count(*) from test_table", "6", settings={"password": "clickhouse"})
     assert_eq_with_retry(node6, "select count(*) from test_table", "6", settings={"password": "clickhouse"})
 
-    node5.query("ALTER TABLE test_table ON CLUSTER 'simple_cluster' MODIFY COLUMN dummy String", settings={"password": "clickhouse"})
+    node5.query("ALTER TABLE test_table ON CLUSTER 'simple_cluster' MODIFY COLUMN dummy String",
+                settings={"password": "clickhouse"})
 
-    assert_eq_with_retry(node5, "select length(dummy) from test_table ORDER BY dummy LIMIT 1", "1", settings={"password": "clickhouse"})
-    assert_eq_with_retry(node6, "select length(dummy) from test_table ORDER BY dummy LIMIT 1", "1", settings={"password": "clickhouse"})
+    assert_eq_with_retry(node5, "select length(dummy) from test_table ORDER BY dummy LIMIT 1", "1",
+                         settings={"password": "clickhouse"})
+    assert_eq_with_retry(node6, "select length(dummy) from test_table ORDER BY dummy LIMIT 1", "1",
+                         settings={"password": "clickhouse"})
 
-    node6.query("ALTER TABLE test_table ON CLUSTER 'simple_cluster' DROP PARTITION '2019-02-15'", settings={"password": "clickhouse"})
+    node6.query("ALTER TABLE test_table ON CLUSTER 'simple_cluster' DROP PARTITION '2019-02-15'",
+                settings={"password": "clickhouse"})
 
     assert_eq_with_retry(node5, "select count(*) from test_table", "0", settings={"password": "clickhouse"})
     assert_eq_with_retry(node6, "select count(*) from test_table", "0", settings={"password": "clickhouse"})

--- a/tests/integration/test_distributed_format/test.py
+++ b/tests/integration/test_distributed_format/test.py
@@ -1,12 +1,6 @@
-import time
 import pytest
 
 from helpers.cluster import ClickHouseCluster
-from multiprocessing.dummy import Pool
-from helpers.client import QueryRuntimeException, QueryTimeoutExceedException
-
-from helpers.test_tools import assert_eq_with_retry
-
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance('node', main_configs=['configs/remote_servers.xml'])
@@ -27,10 +21,13 @@ def started_cluster():
     finally:
         cluster.shutdown()
 
+
 @cluster_param
 def test_single_file(started_cluster, cluster):
-    node.query("create table test.distr_1 (x UInt64, s String) engine = Distributed('{}', database, table)".format(cluster))
-    node.query("insert into test.distr_1 values (1, 'a'), (2, 'bb'), (3, 'ccc')", settings={"use_compact_format_in_distributed_parts_names": "1"})
+    node.query(
+        "create table test.distr_1 (x UInt64, s String) engine = Distributed('{}', database, table)".format(cluster))
+    node.query("insert into test.distr_1 values (1, 'a'), (2, 'bb'), (3, 'ccc')",
+               settings={"use_compact_format_in_distributed_parts_names": "1"})
 
     query = "select * from file('/var/lib/clickhouse/data/test/distr_1/shard1_replica1/1.bin', 'Distributed')"
     out = node.exec_in_container(['/usr/bin/clickhouse', 'local', '--stacktrace', '-q', query])
@@ -48,9 +45,12 @@ def test_single_file(started_cluster, cluster):
 
 @cluster_param
 def test_two_files(started_cluster, cluster):
-    node.query("create table test.distr_2 (x UInt64, s String) engine = Distributed('{}', database, table)".format(cluster))
-    node.query("insert into test.distr_2 values (0, '_'), (1, 'a')", settings={"use_compact_format_in_distributed_parts_names": "1"})
-    node.query("insert into test.distr_2 values (2, 'bb'), (3, 'ccc')", settings={"use_compact_format_in_distributed_parts_names": "1"})
+    node.query(
+        "create table test.distr_2 (x UInt64, s String) engine = Distributed('{}', database, table)".format(cluster))
+    node.query("insert into test.distr_2 values (0, '_'), (1, 'a')",
+               settings={"use_compact_format_in_distributed_parts_names": "1"})
+    node.query("insert into test.distr_2 values (2, 'bb'), (3, 'ccc')",
+               settings={"use_compact_format_in_distributed_parts_names": "1"})
 
     query = "select * from file('/var/lib/clickhouse/data/test/distr_2/shard1_replica1/{1,2,3,4}.bin', 'Distributed') order by x"
     out = node.exec_in_container(['/usr/bin/clickhouse', 'local', '--stacktrace', '-q', query])
@@ -68,7 +68,8 @@ def test_two_files(started_cluster, cluster):
 
 @cluster_param
 def test_single_file_old(started_cluster, cluster):
-    node.query("create table test.distr_3 (x UInt64, s String) engine = Distributed('{}', database, table)".format(cluster))
+    node.query(
+        "create table test.distr_3 (x UInt64, s String) engine = Distributed('{}', database, table)".format(cluster))
     node.query("insert into test.distr_3 values (1, 'a'), (2, 'bb'), (3, 'ccc')")
 
     query = "select * from file('/var/lib/clickhouse/data/test/distr_3/default@not_existing:9000/1.bin', 'Distributed')"

--- a/tests/integration/test_distributed_load_balancing/test.py
+++ b/tests/integration/test_distributed_load_balancing/test.py
@@ -3,8 +3,8 @@
 # pylint: disable=line-too-long
 
 import uuid
-import pytest
 
+import pytest
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
@@ -14,7 +14,8 @@ n2 = cluster.add_instance('n2', main_configs=['configs/remote_servers.xml'])
 n3 = cluster.add_instance('n3', main_configs=['configs/remote_servers.xml'])
 
 nodes = len(cluster.instances)
-queries = nodes*5
+queries = nodes * 5
+
 
 def bootstrap():
     for n in cluster.instances.values():
@@ -58,8 +59,10 @@ def bootstrap():
             data)
         """.format())
 
+
 def make_uuid():
     return uuid.uuid4().hex
+
 
 @pytest.fixture(scope='module', autouse=True)
 def start_cluster():
@@ -69,6 +72,7 @@ def start_cluster():
         yield cluster
     finally:
         cluster.shutdown()
+
 
 def get_node(query_node, table='dist', *args, **kwargs):
     query_id = make_uuid()
@@ -106,12 +110,14 @@ def get_node(query_node, table='dist', *args, **kwargs):
     """.format(query_id=query_id))
     return rows.strip()
 
+
 # TODO: right now random distribution looks bad, but works
 def test_load_balancing_default():
     unique_nodes = set()
     for _ in range(0, queries):
         unique_nodes.add(get_node(n1, settings={'load_balancing': 'random'}))
     assert len(unique_nodes) == nodes, unique_nodes
+
 
 def test_load_balancing_nearest_hostname():
     unique_nodes = set()
@@ -120,12 +126,14 @@ def test_load_balancing_nearest_hostname():
     assert len(unique_nodes) == 1, unique_nodes
     assert unique_nodes == set(['n1'])
 
+
 def test_load_balancing_in_order():
     unique_nodes = set()
     for _ in range(0, queries):
         unique_nodes.add(get_node(n1, settings={'load_balancing': 'in_order'}))
     assert len(unique_nodes) == 1, unique_nodes
     assert unique_nodes == set(['n1'])
+
 
 def test_load_balancing_first_or_random():
     unique_nodes = set()
@@ -134,12 +142,14 @@ def test_load_balancing_first_or_random():
     assert len(unique_nodes) == 1, unique_nodes
     assert unique_nodes == set(['n1'])
 
+
 def test_load_balancing_round_robin():
     unique_nodes = set()
     for _ in range(0, nodes):
         unique_nodes.add(get_node(n1, settings={'load_balancing': 'round_robin'}))
     assert len(unique_nodes) == nodes, unique_nodes
     assert unique_nodes == set(['n1', 'n2', 'n3'])
+
 
 @pytest.mark.parametrize('dist_table', [
     ('dist_priority'),
@@ -152,6 +162,7 @@ def test_load_balancing_priority_round_robin(dist_table):
     assert len(unique_nodes) == 2, unique_nodes
     # n2 has bigger priority in config
     assert unique_nodes == set(['n1', 'n3'])
+
 
 def test_distributed_replica_max_ignored_errors():
     settings = {

--- a/tests/integration/test_distributed_over_distributed/test.py
+++ b/tests/integration/test_distributed_over_distributed/test.py
@@ -3,16 +3,8 @@
 
 from __future__ import print_function
 
-import itertools
-import timeit
-import logging
-
 import pytest
-
 from helpers.cluster import ClickHouseCluster
-from helpers.network import PartitionManager
-from helpers.test_tools import TSV
-
 
 cluster = ClickHouseCluster(__file__)
 
@@ -44,6 +36,7 @@ ENGINE = Distributed('test_cluster', default, distributed_table);
 
 INSERT_SQL_TEMPLATE = "INSERT INTO base_table VALUES ('{node_id}', {key}, {value})"
 
+
 @pytest.fixture(scope="session")
 def started_cluster():
     try:
@@ -59,11 +52,12 @@ def started_cluster():
 
 
 @pytest.mark.parametrize("node", NODES.values())
-@pytest.mark.parametrize("source", ["distributed_over_distributed_table", "cluster('test_cluster', default, distributed_table)"])
+@pytest.mark.parametrize("source",
+                         ["distributed_over_distributed_table", "cluster('test_cluster', default, distributed_table)"])
 class TestDistributedOverDistributedSuite:
     def test_select_with_order_by_node(self, started_cluster, node, source):
         assert node.query("SELECT * FROM {source} ORDER BY node, key".format(source=source)) \
-            == """node1	0	0
+               == """node1	0	0
 node1	0	0
 node1	1	1
 node1	1	1
@@ -75,7 +69,7 @@ node2	1	11
 
     def test_select_with_order_by_key(self, started_cluster, node, source):
         assert node.query("SELECT * FROM {source} ORDER BY key, node".format(source=source)) \
-            == """node1	0	0
+               == """node1	0	0
 node1	0	0
 node2	0	10
 node2	0	10
@@ -87,12 +81,12 @@ node2	1	11
 
     def test_select_with_group_by_node(self, started_cluster, node, source):
         assert node.query("SELECT node, SUM(value) FROM {source} GROUP BY node ORDER BY node".format(source=source)) \
-            == "node1	2\nnode2	42\n"
+               == "node1	2\nnode2	42\n"
 
     def test_select_with_group_by_key(self, started_cluster, node, source):
         assert node.query("SELECT key, SUM(value) FROM {source} GROUP BY key ORDER BY key".format(source=source)) \
-            == "0	20\n1	24\n"
+               == "0	20\n1	24\n"
 
     def test_select_sum(self, started_cluster, node, source):
         assert node.query("SELECT SUM(value) FROM {source}".format(source=source)) \
-            == "44\n"
+               == "44\n"

--- a/tests/integration/test_distributed_over_live_view/test.py
+++ b/tests/integration/test_distributed_over_live_view/test.py
@@ -2,16 +2,10 @@ from __future__ import print_function
 
 import sys
 import time
-import itertools
-import timeit
-import logging
 
 import pytest
-
-from helpers.uclient import client, prompt, end_of_block
 from helpers.cluster import ClickHouseCluster
-from helpers.network import PartitionManager
-from helpers.test_tools import TSV
+from helpers.uclient import client, prompt, end_of_block
 
 cluster = ClickHouseCluster(__file__)
 
@@ -46,6 +40,7 @@ ENGINE = Distributed(test_cluster, default, base_table, rand());
 
 INSERT_SQL_TEMPLATE = "INSERT INTO base_table VALUES ('{node_id}', {key}, {value})"
 
+
 @pytest.fixture(scope="function")
 def started_cluster():
     try:
@@ -77,7 +72,8 @@ class TestLiveViewOverDistributedSuite:
 
             client1.send("DROP TABLE IF EXISTS distributed_over_lv")
             client1.expect(prompt)
-            client1.send("CREATE TABLE distributed_over_lv AS lv_over_base_table ENGINE = Distributed(test_cluster, default, lv_over_base_table)")
+            client1.send(
+                "CREATE TABLE distributed_over_lv AS lv_over_base_table ENGINE = Distributed(test_cluster, default, lv_over_base_table)")
             client1.expect(prompt)
 
             client1.send(select_query)
@@ -115,7 +111,8 @@ class TestLiveViewOverDistributedSuite:
 
             client1.send("DROP TABLE IF EXISTS distributed_over_lv")
             client1.expect(prompt)
-            client1.send("CREATE TABLE distributed_over_lv AS lv_over_base_table ENGINE = Distributed(test_cluster, default, lv_over_base_table)")
+            client1.send(
+                "CREATE TABLE distributed_over_lv AS lv_over_base_table ENGINE = Distributed(test_cluster, default, lv_over_base_table)")
             client1.expect(prompt)
 
             client1.send(select_query)
@@ -153,7 +150,8 @@ class TestLiveViewOverDistributedSuite:
 
             client1.send("DROP TABLE IF EXISTS distributed_over_lv")
             client1.expect(prompt)
-            client1.send("CREATE TABLE distributed_over_lv AS lv_over_base_table ENGINE = Distributed(test_cluster, default, lv_over_base_table)")
+            client1.send(
+                "CREATE TABLE distributed_over_lv AS lv_over_base_table ENGINE = Distributed(test_cluster, default, lv_over_base_table)")
             client1.expect(prompt)
 
             client1.send(select_query)
@@ -192,7 +190,8 @@ class TestLiveViewOverDistributedSuite:
 
             client1.send("DROP TABLE IF EXISTS distributed_over_lv")
             client1.expect(prompt)
-            client1.send("CREATE TABLE distributed_over_lv AS lv_over_base_table ENGINE = Distributed(test_cluster, default, lv_over_base_table)")
+            client1.send(
+                "CREATE TABLE distributed_over_lv AS lv_over_base_table ENGINE = Distributed(test_cluster, default, lv_over_base_table)")
             client1.expect(prompt)
 
             client1.send(select_query)
@@ -230,7 +229,8 @@ class TestLiveViewOverDistributedSuite:
 
             client1.send("DROP TABLE IF EXISTS distributed_over_lv")
             client1.expect(prompt)
-            client1.send("CREATE TABLE distributed_over_lv AS lv_over_base_table ENGINE = Distributed(test_cluster, default, lv_over_base_table)")
+            client1.send(
+                "CREATE TABLE distributed_over_lv AS lv_over_base_table ENGINE = Distributed(test_cluster, default, lv_over_base_table)")
             client1.expect(prompt)
 
             client1.send("SELECT sum(value) FROM distributed_over_lv")
@@ -254,4 +254,3 @@ class TestLiveViewOverDistributedSuite:
             client1.send("SELECT sum(value) FROM distributed_over_lv")
             client1.expect(r"31" + end_of_block)
             client1.expect(prompt)
-

--- a/tests/integration/test_distributed_respect_user_timeouts/test.py
+++ b/tests/integration/test_distributed_respect_user_timeouts/test.py
@@ -1,12 +1,11 @@
 import itertools
-import timeit
 import os.path
-import pytest
+import timeit
 
+import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
 from helpers.test_tools import TSV
-
 
 cluster = ClickHouseCluster(__file__)
 
@@ -62,6 +61,7 @@ TIMEOUT_DIFF_UPPER_BOUND = {
     },
 }
 
+
 def _check_exception(exception, expected_tries=3):
     lines = exception.split('\n')
 
@@ -88,7 +88,6 @@ def _check_exception(exception, expected_tries=3):
 
 @pytest.fixture(scope="module", params=["configs", "configs_secure"])
 def started_cluster(request):
-
     cluster = ClickHouseCluster(__file__)
     cluster.__with_ssl_config = request.param == "configs_secure"
     main_configs = []

--- a/tests/integration/test_distributed_storage_configuration/test.py
+++ b/tests/integration/test_distributed_storage_configuration/test.py
@@ -9,8 +9,9 @@ from helpers.cluster import ClickHouseCluster
 cluster = ClickHouseCluster(__file__)
 
 node = cluster.add_instance('node',
-            main_configs=["configs/config.d/storage_configuration.xml"],
-            tmpfs=['/disk1:size=100M', '/disk2:size=100M'])
+                            main_configs=["configs/config.d/storage_configuration.xml"],
+                            tmpfs=['/disk1:size=100M', '/disk2:size=100M'])
+
 
 @pytest.fixture(scope='module')
 def start_cluster():
@@ -21,13 +22,16 @@ def start_cluster():
     finally:
         cluster.shutdown()
 
+
 def _files_in_dist_mon(node, root, table):
     return int(node.exec_in_container([
         'bash',
         '-c',
         # `-maxdepth 1` to avoid /tmp/ subdirectory
-        'find /{root}/data/test/{table}/default@127%2E0%2E0%2E2:9000 -maxdepth 1 -type f 2>/dev/null | wc -l'.format(root=root, table=table)
+        'find /{root}/data/test/{table}/default@127%2E0%2E0%2E2:9000 -maxdepth 1 -type f 2>/dev/null | wc -l'.format(
+            root=root, table=table)
     ]).split('\n')[0])
+
 
 def test_insert(start_cluster):
     node.query('CREATE TABLE test.foo (key Int) Engine=Memory()')

--- a/tests/integration/test_distributed_system_query/test.py
+++ b/tests/integration/test_distributed_system_query/test.py
@@ -1,5 +1,3 @@
-from contextlib import contextmanager
-
 import pytest
 
 from helpers.cluster import ClickHouseCluster
@@ -18,7 +16,8 @@ def started_cluster():
         for node in (node1, node2):
             node.query('''CREATE TABLE local_table(id UInt32, val String) ENGINE = MergeTree ORDER BY id;''')
 
-        node1.query('''CREATE TABLE distributed_table(id UInt32, val String) ENGINE = Distributed(test_cluster, default, local_table, id);''')
+        node1.query(
+            '''CREATE TABLE distributed_table(id UInt32, val String) ENGINE = Distributed(test_cluster, default, local_table, id);''')
 
         yield cluster
 
@@ -38,4 +37,3 @@ def test_start_and_stop_replica_send(started_cluster):
     node1.query("SYSTEM START DISTRIBUTED SENDS distributed_table;")
     node1.query("SYSTEM FLUSH DISTRIBUTED distributed_table;")
     assert node1.query("SELECT COUNT() FROM distributed_table").rstrip() == '2'
-

--- a/tests/integration/test_drop_replica/test.py
+++ b/tests/integration/test_drop_replica/test.py
@@ -1,53 +1,52 @@
 import time
-import pytest
 
+import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.cluster import ClickHouseKiller
-from helpers.test_tools import assert_eq_with_retry
 from helpers.network import PartitionManager
+
 
 def fill_nodes(nodes, shard):
     for node in nodes:
         node.query(
-        '''
-            CREATE DATABASE test;
-
-            CREATE TABLE test.test_table(date Date, id UInt32)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{shard}/replicated/test_table', '{replica}') ORDER BY id PARTITION BY toYYYYMM(date) SETTINGS min_replicated_logs_to_keep=3, max_replicated_logs_to_keep=5, cleanup_delay_period=0, cleanup_delay_period_random_add=0;
-        '''.format(shard=shard, replica=node.name))
-
-        node.query(
-        '''
-            CREATE DATABASE test1;
-
-            CREATE TABLE test1.test_table(date Date, id UInt32)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test1/{shard}/replicated/test_table', '{replica}') ORDER BY id PARTITION BY toYYYYMM(date) SETTINGS min_replicated_logs_to_keep=3, max_replicated_logs_to_keep=5, cleanup_delay_period=0, cleanup_delay_period_random_add=0;
-        '''.format(shard=shard, replica=node.name))
+            '''
+                CREATE DATABASE test;
+    
+                CREATE TABLE test.test_table(date Date, id UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{shard}/replicated/test_table', '{replica}') ORDER BY id PARTITION BY toYYYYMM(date) SETTINGS min_replicated_logs_to_keep=3, max_replicated_logs_to_keep=5, cleanup_delay_period=0, cleanup_delay_period_random_add=0;
+            '''.format(shard=shard, replica=node.name))
 
         node.query(
-        '''
-            CREATE DATABASE test2;
-
-            CREATE TABLE test2.test_table(date Date, id UInt32)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test2/{shard}/replicated/test_table', '{replica}') ORDER BY id PARTITION BY toYYYYMM(date) SETTINGS min_replicated_logs_to_keep=3, max_replicated_logs_to_keep=5, cleanup_delay_period=0, cleanup_delay_period_random_add=0;
-        '''.format(shard=shard, replica=node.name))
-
-
-        node.query(
-        '''
-            CREATE DATABASE test3;
-
-            CREATE TABLE test3.test_table(date Date, id UInt32)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test3/{shard}/replicated/test_table', '{replica}') ORDER BY id PARTITION BY toYYYYMM(date) SETTINGS min_replicated_logs_to_keep=3, max_replicated_logs_to_keep=5, cleanup_delay_period=0, cleanup_delay_period_random_add=0;
-        '''.format(shard=shard, replica=node.name))
+            '''
+                CREATE DATABASE test1;
+    
+                CREATE TABLE test1.test_table(date Date, id UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test1/{shard}/replicated/test_table', '{replica}') ORDER BY id PARTITION BY toYYYYMM(date) SETTINGS min_replicated_logs_to_keep=3, max_replicated_logs_to_keep=5, cleanup_delay_period=0, cleanup_delay_period_random_add=0;
+            '''.format(shard=shard, replica=node.name))
 
         node.query(
-        '''
-            CREATE DATABASE test4;
+            '''
+                CREATE DATABASE test2;
+    
+                CREATE TABLE test2.test_table(date Date, id UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test2/{shard}/replicated/test_table', '{replica}') ORDER BY id PARTITION BY toYYYYMM(date) SETTINGS min_replicated_logs_to_keep=3, max_replicated_logs_to_keep=5, cleanup_delay_period=0, cleanup_delay_period_random_add=0;
+            '''.format(shard=shard, replica=node.name))
 
-            CREATE TABLE test4.test_table(date Date, id UInt32)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test4/{shard}/replicated/test_table', '{replica}') ORDER BY id PARTITION BY toYYYYMM(date) SETTINGS min_replicated_logs_to_keep=3, max_replicated_logs_to_keep=5, cleanup_delay_period=0, cleanup_delay_period_random_add=0;
-        '''.format(shard=shard, replica=node.name))
+        node.query(
+            '''
+                CREATE DATABASE test3;
+    
+                CREATE TABLE test3.test_table(date Date, id UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test3/{shard}/replicated/test_table', '{replica}') ORDER BY id PARTITION BY toYYYYMM(date) SETTINGS min_replicated_logs_to_keep=3, max_replicated_logs_to_keep=5, cleanup_delay_period=0, cleanup_delay_period_random_add=0;
+            '''.format(shard=shard, replica=node.name))
+
+        node.query(
+            '''
+                CREATE DATABASE test4;
+    
+                CREATE TABLE test4.test_table(date Date, id UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test4/{shard}/replicated/test_table', '{replica}') ORDER BY id PARTITION BY toYYYYMM(date) SETTINGS min_replicated_logs_to_keep=3, max_replicated_logs_to_keep=5, cleanup_delay_period=0, cleanup_delay_period_random_add=0;
+            '''.format(shard=shard, replica=node.name))
+
 
 cluster = ClickHouseCluster(__file__)
 
@@ -71,6 +70,7 @@ def start_cluster():
     finally:
         cluster.shutdown()
 
+
 def test_drop_replica(start_cluster):
     for i in range(100):
         node_1_1.query("INSERT INTO test.test_table VALUES (1, {})".format(i))
@@ -81,17 +81,25 @@ def test_drop_replica(start_cluster):
 
     zk = cluster.get_kazoo_client('zoo1')
     assert "can't drop local replica" in node_1_1.query_and_get_error("SYSTEM DROP REPLICA 'node_1_1'")
-    assert "can't drop local replica" in node_1_1.query_and_get_error("SYSTEM DROP REPLICA 'node_1_1' FROM DATABASE test")
-    assert "can't drop local replica" in node_1_1.query_and_get_error("SYSTEM DROP REPLICA 'node_1_1' FROM TABLE test.test_table")
+    assert "can't drop local replica" in node_1_1.query_and_get_error(
+        "SYSTEM DROP REPLICA 'node_1_1' FROM DATABASE test")
+    assert "can't drop local replica" in node_1_1.query_and_get_error(
+        "SYSTEM DROP REPLICA 'node_1_1' FROM TABLE test.test_table")
     assert "it's active" in node_1_2.query_and_get_error("SYSTEM DROP REPLICA 'node_1_1'")
     assert "it's active" in node_1_2.query_and_get_error("SYSTEM DROP REPLICA 'node_1_1' FROM DATABASE test")
     assert "it's active" in node_1_2.query_and_get_error("SYSTEM DROP REPLICA 'node_1_1' FROM TABLE test.test_table")
     assert "it's active" in \
-        node_1_3.query_and_get_error("SYSTEM DROP REPLICA 'node_1_1' FROM ZKPATH '/clickhouse/tables/test/{shard}/replicated/test_table'".format(shard=1))
+           node_1_3.query_and_get_error(
+               "SYSTEM DROP REPLICA 'node_1_1' FROM ZKPATH '/clickhouse/tables/test/{shard}/replicated/test_table'".format(
+                   shard=1))
     assert "There is a local table" in \
-        node_1_2.query_and_get_error("SYSTEM DROP REPLICA 'node_1_1' FROM ZKPATH '/clickhouse/tables/test/{shard}/replicated/test_table'".format(shard=1))
+           node_1_2.query_and_get_error(
+               "SYSTEM DROP REPLICA 'node_1_1' FROM ZKPATH '/clickhouse/tables/test/{shard}/replicated/test_table'".format(
+                   shard=1))
     assert "There is a local table" in \
-        node_1_1.query_and_get_error("SYSTEM DROP REPLICA 'node_1_1' FROM ZKPATH '/clickhouse/tables/test/{shard}/replicated/test_table'".format(shard=1))
+           node_1_1.query_and_get_error(
+               "SYSTEM DROP REPLICA 'node_1_1' FROM ZKPATH '/clickhouse/tables/test/{shard}/replicated/test_table'".format(
+                   shard=1))
     assert "does not look like a table path" in \
            node_1_3.query_and_get_error("SYSTEM DROP REPLICA 'node_1_1' FROM ZKPATH '/clickhouse/tables/test'")
 
@@ -100,31 +108,48 @@ def test_drop_replica(start_cluster):
         pm.drop_instance_zk_connections(node_1_1)
         time.sleep(10)
 
-        assert "doesn't exist" in node_1_3.query_and_get_error("SYSTEM DROP REPLICA 'node_1_1' FROM TABLE test.test_table")
+        assert "doesn't exist" in node_1_3.query_and_get_error(
+            "SYSTEM DROP REPLICA 'node_1_1' FROM TABLE test.test_table")
 
         assert "doesn't exist" in node_1_3.query_and_get_error("SYSTEM DROP REPLICA 'node_1_1' FROM DATABASE test1")
 
         node_1_3.query("SYSTEM DROP REPLICA 'node_1_1'")
-        exists_replica_1_1 = zk.exists("/clickhouse/tables/test3/{shard}/replicated/test_table/replicas/{replica}".format(shard=1, replica='node_1_1'))
+        exists_replica_1_1 = zk.exists(
+            "/clickhouse/tables/test3/{shard}/replicated/test_table/replicas/{replica}".format(shard=1,
+                                                                                               replica='node_1_1'))
         assert (exists_replica_1_1 != None)
 
         ## If you want to drop a inactive/stale replicate table that does not have a local replica, you can following syntax(ZKPATH):
-        node_1_3.query("SYSTEM DROP REPLICA 'node_1_1' FROM ZKPATH '/clickhouse/tables/test2/{shard}/replicated/test_table'".format(shard=1))
-        exists_replica_1_1 = zk.exists("/clickhouse/tables/test2/{shard}/replicated/test_table/replicas/{replica}".format(shard=1, replica='node_1_1'))
+        node_1_3.query(
+            "SYSTEM DROP REPLICA 'node_1_1' FROM ZKPATH '/clickhouse/tables/test2/{shard}/replicated/test_table'".format(
+                shard=1))
+        exists_replica_1_1 = zk.exists(
+            "/clickhouse/tables/test2/{shard}/replicated/test_table/replicas/{replica}".format(shard=1,
+                                                                                               replica='node_1_1'))
         assert (exists_replica_1_1 == None)
 
         node_1_2.query("SYSTEM DROP REPLICA 'node_1_1' FROM TABLE test.test_table")
-        exists_replica_1_1 = zk.exists("/clickhouse/tables/test/{shard}/replicated/test_table/replicas/{replica}".format(shard=1, replica='node_1_1'))
+        exists_replica_1_1 = zk.exists(
+            "/clickhouse/tables/test/{shard}/replicated/test_table/replicas/{replica}".format(shard=1,
+                                                                                              replica='node_1_1'))
         assert (exists_replica_1_1 == None)
 
         node_1_2.query("SYSTEM DROP REPLICA 'node_1_1' FROM DATABASE test1")
-        exists_replica_1_1 = zk.exists("/clickhouse/tables/test1/{shard}/replicated/test_table/replicas/{replica}".format(shard=1, replica='node_1_1'))
+        exists_replica_1_1 = zk.exists(
+            "/clickhouse/tables/test1/{shard}/replicated/test_table/replicas/{replica}".format(shard=1,
+                                                                                               replica='node_1_1'))
         assert (exists_replica_1_1 == None)
 
-        node_1_3.query("SYSTEM DROP REPLICA 'node_1_1' FROM ZKPATH '/clickhouse/tables/test3/{shard}/replicated/test_table'".format(shard=1))
-        exists_replica_1_1 = zk.exists("/clickhouse/tables/test3/{shard}/replicated/test_table/replicas/{replica}".format(shard=1, replica='node_1_1'))
+        node_1_3.query(
+            "SYSTEM DROP REPLICA 'node_1_1' FROM ZKPATH '/clickhouse/tables/test3/{shard}/replicated/test_table'".format(
+                shard=1))
+        exists_replica_1_1 = zk.exists(
+            "/clickhouse/tables/test3/{shard}/replicated/test_table/replicas/{replica}".format(shard=1,
+                                                                                               replica='node_1_1'))
         assert (exists_replica_1_1 == None)
 
         node_1_2.query("SYSTEM DROP REPLICA 'node_1_1'")
-        exists_replica_1_1 = zk.exists("/clickhouse/tables/test4/{shard}/replicated/test_table/replicas/{replica}".format(shard=1, replica='node_1_1'))
+        exists_replica_1_1 = zk.exists(
+            "/clickhouse/tables/test4/{shard}/replicated/test_table/replicas/{replica}".format(shard=1,
+                                                                                               replica='node_1_1'))
         assert (exists_replica_1_1 == None)

--- a/tests/integration/test_enabling_access_management/test.py
+++ b/tests/integration/test_enabling_access_management/test.py
@@ -4,6 +4,7 @@ from helpers.cluster import ClickHouseCluster
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance('instance', user_configs=["configs/users.d/extra_users.xml"])
 
+
 @pytest.fixture(scope="module", autouse=True)
 def started_cluster():
     try:

--- a/tests/integration/test_extreme_deduplication/test.py
+++ b/tests/integration/test_extreme_deduplication/test.py
@@ -1,20 +1,21 @@
 import time
-from contextlib import contextmanager
 
 import pytest
-
-from helpers.cluster import ClickHouseCluster
-from helpers.network import PartitionManager
-from helpers.test_tools import TSV
 from helpers.client import CommandRequest
 from helpers.client import QueryTimeoutExceedException
-
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import TSV
 
 cluster = ClickHouseCluster(__file__)
 
-node1 = cluster.add_instance('node1', main_configs=["configs/conf.d/merge_tree.xml", "configs/conf.d/remote_servers.xml"], with_zookeeper=True, macros={"layer": 0, "shard": 0, "replica": 1})
-node2 = cluster.add_instance('node2', main_configs=["configs/conf.d/merge_tree.xml", "configs/conf.d/remote_servers.xml"], with_zookeeper=True, macros={"layer": 0, "shard": 0, "replica": 2})
+node1 = cluster.add_instance('node1',
+                             main_configs=["configs/conf.d/merge_tree.xml", "configs/conf.d/remote_servers.xml"],
+                             with_zookeeper=True, macros={"layer": 0, "shard": 0, "replica": 1})
+node2 = cluster.add_instance('node2',
+                             main_configs=["configs/conf.d/merge_tree.xml", "configs/conf.d/remote_servers.xml"],
+                             with_zookeeper=True, macros={"layer": 0, "shard": 0, "replica": 2})
 nodes = [node1, node2]
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -36,15 +37,18 @@ def test_deduplication_window_in_seconds(started_cluster):
 
     node.query("INSERT INTO simple VALUES (0, 0)")
     time.sleep(1)
-    node.query("INSERT INTO simple VALUES (0, 0)") # deduplication works here
+    node.query("INSERT INTO simple VALUES (0, 0)")  # deduplication works here
     node.query("INSERT INTO simple VALUES (0, 1)")
     assert TSV(node.query("SELECT count() FROM simple")) == TSV("2\n")
 
     # wait clean thread
     time.sleep(2)
 
-    assert TSV.toMat(node.query("SELECT count() FROM system.zookeeper WHERE path='/clickhouse/tables/0/simple/blocks'"))[0][0] == "1"
-    node.query("INSERT INTO simple VALUES (0, 0)") # deduplication doesn't works here, the first hash node was deleted
+    assert \
+        TSV.toMat(node.query("SELECT count() FROM system.zookeeper WHERE path='/clickhouse/tables/0/simple/blocks'"))[
+            0][
+            0] == "1"
+    node.query("INSERT INTO simple VALUES (0, 0)")  # deduplication doesn't works here, the first hash node was deleted
     assert TSV.toMat(node.query("SELECT count() FROM simple"))[0][0] == "3"
 
     node1.query("""DROP TABLE simple ON CLUSTER test_cluster""")

--- a/tests/integration/test_fetch_partition_from_auxiliary_zookeeper/test.py
+++ b/tests/integration/test_fetch_partition_from_auxiliary_zookeeper/test.py
@@ -1,13 +1,11 @@
 from __future__ import print_function
-from helpers.cluster import ClickHouseCluster
-from helpers.client import QueryRuntimeException
-import helpers
-import pytest
 
+import pytest
+from helpers.client import QueryRuntimeException
+from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance("node", main_configs=["configs/zookeeper_config.xml"], with_zookeeper=True)
-
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_filesystem_layout/test.py
+++ b/tests/integration/test_filesystem_layout/test.py
@@ -25,4 +25,5 @@ def test_file_path_escaping(started_cluster):
     node.query('''ALTER TABLE test.`T.a_b,l-e!` FREEZE;''')
 
     node.exec_in_container(["bash", "-c", "test -f /var/lib/clickhouse/data/test/T%2Ea_b%2Cl%2De%21/1_1_1_0/%7EId.bin"])
-    node.exec_in_container(["bash", "-c", "test -f /var/lib/clickhouse/shadow/1/data/test/T%2Ea_b%2Cl%2De%21/1_1_1_0/%7EId.bin"])
+    node.exec_in_container(
+        ["bash", "-c", "test -f /var/lib/clickhouse/shadow/1/data/test/T%2Ea_b%2Cl%2De%21/1_1_1_0/%7EId.bin"])

--- a/tests/integration/test_force_deduplication/test.py
+++ b/tests/integration/test_force_deduplication/test.py
@@ -2,13 +2,13 @@
 # pylint: disable=redefined-outer-name
 
 import pytest
-
-from helpers.cluster import ClickHouseCluster
 from helpers.client import QueryRuntimeException
+from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 
 node = cluster.add_instance('node', with_zookeeper=True)
+
 
 @pytest.fixture(scope='module')
 def start_cluster():
@@ -18,6 +18,7 @@ def start_cluster():
         yield cluster
     finally:
         cluster.shutdown()
+
 
 def get_counts():
     src = int(node.query("SELECT count() FROM test"))
@@ -69,7 +70,7 @@ def test_basic(start_cluster):
     )
     src, a, b, c = get_counts()
     assert src == 11
-    assert a == old_a + 10    # first insert could be succesfull with disabled dedup
+    assert a == old_a + 10  # first insert could be succesfull with disabled dedup
     assert b == 11
     assert c == old_c + 10
 
@@ -81,7 +82,7 @@ def test_basic(start_cluster):
             INSERT INTO test SELECT number FROM numbers(100,10);
             '''
         )
-        
+
     node.query(
         '''
         SET deduplicate_blocks_in_dependent_materialized_views = 1;
@@ -94,5 +95,3 @@ def test_basic(start_cluster):
     assert a == old_a + 20
     assert b == 21
     assert c == old_c + 20
-
-

--- a/tests/integration/test_format_avro_confluent/test.py
+++ b/tests/integration/test_format_avro_confluent/test.py
@@ -1,19 +1,14 @@
-import json
-import logging
 import io
-
-import pytest
-
-from helpers.cluster import ClickHouseCluster, ClickHouseInstance
-
-import helpers.client
+import logging
 
 import avro.schema
-from confluent.schemaregistry.client import CachedSchemaRegistryClient
+import pytest
 from confluent.schemaregistry.serializers import MessageSerializer
+from helpers.cluster import ClickHouseCluster, ClickHouseInstance
 
 logging.getLogger().setLevel(logging.INFO)
 logging.getLogger().addHandler(logging.StreamHandler())
+
 
 @pytest.fixture(scope="module")
 def cluster():
@@ -42,7 +37,6 @@ def run_query(instance, query, data=None, settings=None):
     return result
 
 
-
 def test_select(cluster):
     # type: (ClickHouseCluster) -> None
 
@@ -55,7 +49,7 @@ def test_select(cluster):
         'fields': [
             {
                 'name': 'value',
-                'type': 'long' 
+                'type': 'long'
             }
         ]
     })
@@ -73,7 +67,7 @@ def test_select(cluster):
         cluster.schema_registry_host,
         cluster.schema_registry_port
     )
-    
+
     run_query(instance, "create table avro_data(value Int64) engine = Memory()")
     settings = {'format_avro_schema_registry_url': schema_registry_url}
     run_query(instance, "insert into avro_data format AvroConfluent", data, settings)

--- a/tests/integration/test_format_schema_on_server/test.py
+++ b/tests/integration/test_format_schema_on_server/test.py
@@ -36,5 +36,6 @@ def test_protobuf_format_input(started_cluster):
 def test_protobuf_format_output(started_cluster):
     create_simple_table()
     instance.query("INSERT INTO test.simple VALUES (1, 'abc'), (2, 'def')");
-    assert instance.http_query("SELECT * FROM test.simple FORMAT Protobuf SETTINGS format_schema='simple:KeyValuePair'") == \
+    assert instance.http_query(
+        "SELECT * FROM test.simple FORMAT Protobuf SETTINGS format_schema='simple:KeyValuePair'") == \
            "\x07\x08\x01\x12\x03abc\x07\x08\x02\x12\x03def"

--- a/tests/integration/test_freeze_table/test.py
+++ b/tests/integration/test_freeze_table/test.py
@@ -39,7 +39,7 @@ def test_freeze_table(started_cluster):
         '''))
     assert 11 == len(freeze_result)
     path_col_ix = freeze_result[0].index('part_backup_path')
-    for row in freeze_result[1:]: # skip header
+    for row in freeze_result[1:]:  # skip header
         part_backup_path = row[path_col_ix]
         node.exec_in_container(
             ["bash", "-c", "test -d {}".format(part_backup_path)]
@@ -55,7 +55,7 @@ def test_freeze_table(started_cluster):
         '''))
     assert 2 == len(freeze_result)
     path_col_ix = freeze_result[0].index('part_backup_path')
-    for row in freeze_result[1:]: # skip header
+    for row in freeze_result[1:]:  # skip header
         part_backup_path = row[path_col_ix]
         assert 'test_01417_single_part' in part_backup_path
         node.exec_in_container(

--- a/tests/integration/test_grant_and_revoke/test.py
+++ b/tests/integration/test_grant_and_revoke/test.py
@@ -1,7 +1,6 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
-import re
 
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance('instance')
@@ -11,11 +10,11 @@ instance = cluster.add_instance('instance')
 def start_cluster():
     try:
         cluster.start()
-        
+
         instance.query("CREATE DATABASE test")
         instance.query("CREATE TABLE test.table(x UInt32, y UInt32) ENGINE = MergeTree ORDER BY tuple()")
         instance.query("INSERT INTO test.table VALUES (1,5), (2,10)")
-        
+
         yield cluster
 
     finally:
@@ -34,7 +33,7 @@ def cleanup_after_test():
 def test_smoke():
     instance.query("CREATE USER A")
     assert "Not enough privileges" in instance.query_and_get_error("SELECT * FROM test.table", user='A')
-    
+
     instance.query('GRANT SELECT ON test.table TO A')
     assert instance.query("SELECT * FROM test.table", user='A') == "1\t5\n2\t10\n"
 
@@ -49,7 +48,7 @@ def test_grant_option():
     instance.query('GRANT SELECT ON test.table TO A')
     assert instance.query("SELECT * FROM test.table", user='A') == "1\t5\n2\t10\n"
     assert "Not enough privileges" in instance.query_and_get_error("GRANT SELECT ON test.table TO B", user='A')
-    
+
     instance.query('GRANT SELECT ON test.table TO A WITH GRANT OPTION')
     instance.query("GRANT SELECT ON test.table TO B", user='A')
     assert instance.query("SELECT * FROM test.table", user='B') == "1\t5\n2\t10\n"
@@ -60,7 +59,7 @@ def test_grant_option():
 def test_revoke_requires_grant_option():
     instance.query("CREATE USER A")
     instance.query("CREATE USER B")
-    
+
     instance.query("GRANT SELECT ON test.table TO B")
     assert instance.query("SHOW GRANTS FOR B") == "GRANT SELECT ON test.table TO B\n"
 
@@ -111,7 +110,8 @@ def test_grant_all_on_table():
     instance.query("CREATE USER A, B")
     instance.query("GRANT ALL ON test.table TO A WITH GRANT OPTION")
     instance.query("GRANT ALL ON test.table TO B", user='A')
-    assert instance.query("SHOW GRANTS FOR B") == "GRANT SHOW TABLES, SHOW COLUMNS, SHOW DICTIONARIES, SELECT, INSERT, ALTER, CREATE TABLE, CREATE VIEW, CREATE DICTIONARY, DROP TABLE, DROP VIEW, DROP DICTIONARY, TRUNCATE, OPTIMIZE, SYSTEM MERGES, SYSTEM TTL MERGES, SYSTEM FETCHES, SYSTEM MOVES, SYSTEM SENDS, SYSTEM REPLICATION QUEUES, SYSTEM DROP REPLICA, SYSTEM SYNC REPLICA, SYSTEM RESTART REPLICA, SYSTEM FLUSH DISTRIBUTED, dictGet ON test.table TO B\n"
+    assert instance.query(
+        "SHOW GRANTS FOR B") == "GRANT SHOW TABLES, SHOW COLUMNS, SHOW DICTIONARIES, SELECT, INSERT, ALTER, CREATE TABLE, CREATE VIEW, CREATE DICTIONARY, DROP TABLE, DROP VIEW, DROP DICTIONARY, TRUNCATE, OPTIMIZE, SYSTEM MERGES, SYSTEM TTL MERGES, SYSTEM FETCHES, SYSTEM MOVES, SYSTEM SENDS, SYSTEM REPLICATION QUEUES, SYSTEM DROP REPLICA, SYSTEM SYNC REPLICA, SYSTEM RESTART REPLICA, SYSTEM FLUSH DISTRIBUTED, dictGet ON test.table TO B\n"
     instance.query("REVOKE ALL ON test.table FROM B", user='A')
     assert instance.query("SHOW GRANTS FOR B") == ""
 
@@ -120,36 +120,42 @@ def test_implicit_show_grants():
     instance.query("CREATE USER A")
     assert instance.query("select count() FROM system.databases WHERE name='test'", user="A") == "0\n"
     assert instance.query("select count() FROM system.tables WHERE database='test' AND name='table'", user="A") == "0\n"
-    assert instance.query("select count() FROM system.columns WHERE database='test' AND table='table'", user="A") == "0\n"
+    assert instance.query("select count() FROM system.columns WHERE database='test' AND table='table'",
+                          user="A") == "0\n"
 
     instance.query("GRANT SELECT(x) ON test.table TO A")
     assert instance.query("SHOW GRANTS FOR A") == "GRANT SELECT(x) ON test.table TO A\n"
     assert instance.query("select count() FROM system.databases WHERE name='test'", user="A") == "1\n"
     assert instance.query("select count() FROM system.tables WHERE database='test' AND name='table'", user="A") == "1\n"
-    assert instance.query("select count() FROM system.columns WHERE database='test' AND table='table'", user="A") == "1\n"
+    assert instance.query("select count() FROM system.columns WHERE database='test' AND table='table'",
+                          user="A") == "1\n"
 
     instance.query("GRANT SELECT ON test.table TO A")
     assert instance.query("SHOW GRANTS FOR A") == "GRANT SELECT ON test.table TO A\n"
     assert instance.query("select count() FROM system.databases WHERE name='test'", user="A") == "1\n"
     assert instance.query("select count() FROM system.tables WHERE database='test' AND name='table'", user="A") == "1\n"
-    assert instance.query("select count() FROM system.columns WHERE database='test' AND table='table'", user="A") == "2\n"
+    assert instance.query("select count() FROM system.columns WHERE database='test' AND table='table'",
+                          user="A") == "2\n"
 
     instance.query("GRANT SELECT ON test.* TO A")
     assert instance.query("SHOW GRANTS FOR A") == "GRANT SELECT ON test.* TO A\n"
     assert instance.query("select count() FROM system.databases WHERE name='test'", user="A") == "1\n"
     assert instance.query("select count() FROM system.tables WHERE database='test' AND name='table'", user="A") == "1\n"
-    assert instance.query("select count() FROM system.columns WHERE database='test' AND table='table'", user="A") == "2\n"
+    assert instance.query("select count() FROM system.columns WHERE database='test' AND table='table'",
+                          user="A") == "2\n"
 
     instance.query("GRANT SELECT ON *.* TO A")
     assert instance.query("SHOW GRANTS FOR A") == "GRANT SELECT ON *.* TO A\n"
     assert instance.query("select count() FROM system.databases WHERE name='test'", user="A") == "1\n"
     assert instance.query("select count() FROM system.tables WHERE database='test' AND name='table'", user="A") == "1\n"
-    assert instance.query("select count() FROM system.columns WHERE database='test' AND table='table'", user="A") == "2\n"
+    assert instance.query("select count() FROM system.columns WHERE database='test' AND table='table'",
+                          user="A") == "2\n"
 
     instance.query("REVOKE ALL ON *.* FROM A")
     assert instance.query("select count() FROM system.databases WHERE name='test'", user="A") == "0\n"
     assert instance.query("select count() FROM system.tables WHERE database='test' AND name='table'", user="A") == "0\n"
-    assert instance.query("select count() FROM system.columns WHERE database='test' AND table='table'", user="A") == "0\n"
+    assert instance.query("select count() FROM system.columns WHERE database='test' AND table='table'",
+                          user="A") == "0\n"
 
 
 def test_implicit_create_view_grant():
@@ -184,46 +190,53 @@ def test_introspection():
     instance.query('GRANT SELECT ON test.table TO A')
     instance.query('GRANT CREATE ON *.* TO B WITH GRANT OPTION')
 
-    assert instance.query("SHOW USERS") == TSV([ "A", "B", "default" ])
-    assert instance.query("SHOW CREATE USERS A") == TSV([ "CREATE USER A" ])
-    assert instance.query("SHOW CREATE USERS B") == TSV([ "CREATE USER B" ])
-    assert instance.query("SHOW CREATE USERS A,B") == TSV([ "CREATE USER A", "CREATE USER B" ])
-    assert instance.query("SHOW CREATE USERS") == TSV([ "CREATE USER A", "CREATE USER B", "CREATE USER default IDENTIFIED WITH plaintext_password SETTINGS PROFILE default" ])
+    assert instance.query("SHOW USERS") == TSV(["A", "B", "default"])
+    assert instance.query("SHOW CREATE USERS A") == TSV(["CREATE USER A"])
+    assert instance.query("SHOW CREATE USERS B") == TSV(["CREATE USER B"])
+    assert instance.query("SHOW CREATE USERS A,B") == TSV(["CREATE USER A", "CREATE USER B"])
+    assert instance.query("SHOW CREATE USERS") == TSV(["CREATE USER A", "CREATE USER B",
+                                                       "CREATE USER default IDENTIFIED WITH plaintext_password SETTINGS PROFILE default"])
 
-    assert instance.query("SHOW GRANTS FOR A") == TSV([ "GRANT SELECT ON test.table TO A" ])
-    assert instance.query("SHOW GRANTS FOR B") == TSV([ "GRANT CREATE ON *.* TO B WITH GRANT OPTION" ])
-    assert instance.query("SHOW GRANTS FOR A,B") == TSV([ "GRANT SELECT ON test.table TO A", "GRANT CREATE ON *.* TO B WITH GRANT OPTION" ])
-    assert instance.query("SHOW GRANTS FOR B,A") == TSV([ "GRANT SELECT ON test.table TO A", "GRANT CREATE ON *.* TO B WITH GRANT OPTION" ])
-    assert instance.query("SHOW GRANTS FOR ALL") == TSV([ "GRANT SELECT ON test.table TO A", "GRANT CREATE ON *.* TO B WITH GRANT OPTION", "GRANT ALL ON *.* TO default WITH GRANT OPTION" ])
+    assert instance.query("SHOW GRANTS FOR A") == TSV(["GRANT SELECT ON test.table TO A"])
+    assert instance.query("SHOW GRANTS FOR B") == TSV(["GRANT CREATE ON *.* TO B WITH GRANT OPTION"])
+    assert instance.query("SHOW GRANTS FOR A,B") == TSV(
+        ["GRANT SELECT ON test.table TO A", "GRANT CREATE ON *.* TO B WITH GRANT OPTION"])
+    assert instance.query("SHOW GRANTS FOR B,A") == TSV(
+        ["GRANT SELECT ON test.table TO A", "GRANT CREATE ON *.* TO B WITH GRANT OPTION"])
+    assert instance.query("SHOW GRANTS FOR ALL") == TSV(
+        ["GRANT SELECT ON test.table TO A", "GRANT CREATE ON *.* TO B WITH GRANT OPTION",
+         "GRANT ALL ON *.* TO default WITH GRANT OPTION"])
 
-    assert instance.query("SHOW GRANTS", user='A') == TSV([ "GRANT SELECT ON test.table TO A" ])
-    assert instance.query("SHOW GRANTS", user='B') == TSV([ "GRANT CREATE ON *.* TO B WITH GRANT OPTION" ])
+    assert instance.query("SHOW GRANTS", user='A') == TSV(["GRANT SELECT ON test.table TO A"])
+    assert instance.query("SHOW GRANTS", user='B') == TSV(["GRANT CREATE ON *.* TO B WITH GRANT OPTION"])
 
-    expected_access1 = "CREATE USER A\n"\
-                       "CREATE USER B\n"\
+    expected_access1 = "CREATE USER A\n" \
+                       "CREATE USER B\n" \
                        "CREATE USER default IDENTIFIED WITH plaintext_password SETTINGS PROFILE default"
-    expected_access2 = "GRANT SELECT ON test.table TO A\n"\
-                       "GRANT CREATE ON *.* TO B WITH GRANT OPTION\n"\
+    expected_access2 = "GRANT SELECT ON test.table TO A\n" \
+                       "GRANT CREATE ON *.* TO B WITH GRANT OPTION\n" \
                        "GRANT ALL ON *.* TO default WITH GRANT OPTION\n"
     assert expected_access1 in instance.query("SHOW ACCESS")
     assert expected_access2 in instance.query("SHOW ACCESS")
 
-    assert instance.query("SELECT name, storage, auth_type, auth_params, host_ip, host_names, host_names_regexp, host_names_like, default_roles_all, default_roles_list, default_roles_except from system.users WHERE name IN ('A', 'B') ORDER BY name") ==\
-           TSV([[ "A", "local directory", "no_password", "{}", "['::/0']", "[]", "[]", "[]", 1, "[]", "[]" ],
-                [ "B", "local directory", "no_password", "{}", "['::/0']", "[]", "[]", "[]", 1, "[]", "[]" ]])
-    
-    assert instance.query("SELECT * from system.grants WHERE user_name IN ('A', 'B') ORDER BY user_name, access_type, grant_option") ==\
-           TSV([[ "A",  "\N", "SELECT", "test", "table", "\N", 0, 0 ],
-                [ "B",  "\N", "CREATE", "\N",   "\N",    "\N", 0, 1 ]])
+    assert instance.query(
+        "SELECT name, storage, auth_type, auth_params, host_ip, host_names, host_names_regexp, host_names_like, default_roles_all, default_roles_list, default_roles_except from system.users WHERE name IN ('A', 'B') ORDER BY name") == \
+           TSV([["A", "local directory", "no_password", "{}", "['::/0']", "[]", "[]", "[]", 1, "[]", "[]"],
+                ["B", "local directory", "no_password", "{}", "['::/0']", "[]", "[]", "[]", 1, "[]", "[]"]])
+
+    assert instance.query(
+        "SELECT * from system.grants WHERE user_name IN ('A', 'B') ORDER BY user_name, access_type, grant_option") == \
+           TSV([["A", "\N", "SELECT", "test", "table", "\N", 0, 0],
+                ["B", "\N", "CREATE", "\N", "\N", "\N", 0, 1]])
 
 
 def test_current_database():
     instance.query("CREATE USER A")
     instance.query("GRANT SELECT ON table TO A", database="test")
-    
-    assert instance.query("SHOW GRANTS FOR A") == TSV([ "GRANT SELECT ON test.table TO A" ])
-    assert instance.query("SHOW GRANTS FOR A", database="test") == TSV([ "GRANT SELECT ON test.table TO A" ])
-    
+
+    assert instance.query("SHOW GRANTS FOR A") == TSV(["GRANT SELECT ON test.table TO A"])
+    assert instance.query("SHOW GRANTS FOR A", database="test") == TSV(["GRANT SELECT ON test.table TO A"])
+
     assert instance.query("SELECT * FROM test.table", user='A') == "1\t5\n2\t10\n"
     assert instance.query("SELECT * FROM table", user='A', database='test') == "1\t5\n2\t10\n"
 

--- a/tests/integration/test_graphite_merge_tree/test.py
+++ b/tests/integration/test_graphite_merge_tree/test.py
@@ -1,11 +1,10 @@
+import datetime
 import os.path as p
 import time
-import datetime
-import pytest
 
+import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
-
 
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance('instance',
@@ -317,20 +316,20 @@ def test_combined_rules(graphite_table):
     expected_unmerged = ''
     for i in range(384):
         to_insert += "('five_min.count', {v}, {t}, toDate({t}), 1), ".format(
-            v=1, t=1487970000+(i*300)
+            v=1, t=1487970000 + (i * 300)
         )
         to_insert += "('five_min.max', {v}, {t}, toDate({t}), 1), ".format(
-            v=i, t=1487970000+(i*300)
+            v=i, t=1487970000 + (i * 300)
         )
         expected_unmerged += ("five_min.count\t{v1}\t{t}\n"
                               "five_min.max\t{v2}\t{t}\n").format(
-                                  v1=1, v2=i,
-                                  t=1487970000+(i*300)
-                              )
+            v1=1, v2=i,
+            t=1487970000 + (i * 300)
+        )
 
     q(to_insert)
     assert TSV(q('SELECT metric, value, timestamp FROM test.graphite'
-               ' ORDER BY (timestamp, metric)')) == TSV(expected_unmerged)
+                 ' ORDER BY (timestamp, metric)')) == TSV(expected_unmerged)
 
     q('OPTIMIZE TABLE test.graphite PARTITION 201702 FINAL')
     expected_merged = '''
@@ -370,16 +369,16 @@ CREATE TABLE test.graphite
     expected_unmerged = ''
     for i in range(100):
         to_insert += "('top_level.count', {v}, {t}, toDate({t}), 1), ".format(
-            v=1, t=1487970000+(i*60)
+            v=1, t=1487970000 + (i * 60)
         )
         to_insert += "('top_level.max', {v}, {t}, toDate({t}), 1), ".format(
-            v=i, t=1487970000+(i*60)
+            v=i, t=1487970000 + (i * 60)
         )
         expected_unmerged += ("top_level.count\t{v1}\t{t}\n"
                               "top_level.max\t{v2}\t{t}\n").format(
-                                  v1=1, v2=i,
-                                  t=1487970000+(i*60)
-                              )
+            v1=1, v2=i,
+            t=1487970000 + (i * 60)
+        )
 
     q(to_insert)
     assert TSV(q('SELECT metric, value, timestamp FROM test.graphite'

--- a/tests/integration/test_host_ip_change/test.py
+++ b/tests/integration/test_host_ip_change/test.py
@@ -1,14 +1,11 @@
-import time
 import pytest
-
-import subprocess
-from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry
 from helpers.client import QueryRuntimeException
+from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
-
+from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
+
 
 def _fill_nodes(nodes, table_name):
     for node in nodes:
@@ -21,9 +18,12 @@ def _fill_nodes(nodes, table_name):
             '''.format(table_name, node.name)
         )
 
-node1 = cluster.add_instance('node1', main_configs=['configs/listen_host.xml'], with_zookeeper=True, ipv6_address='2001:3984:3989::1:1111')
+
+node1 = cluster.add_instance('node1', main_configs=['configs/listen_host.xml'], with_zookeeper=True,
+                             ipv6_address='2001:3984:3989::1:1111')
 node2 = cluster.add_instance('node2', main_configs=['configs/listen_host.xml', 'configs/dns_update_long.xml'],
-    with_zookeeper=True, ipv6_address='2001:3984:3989::1:1112')
+                             with_zookeeper=True, ipv6_address='2001:3984:3989::1:1112')
+
 
 @pytest.fixture(scope="module")
 def cluster_without_dns_cache_update():
@@ -40,6 +40,7 @@ def cluster_without_dns_cache_update():
     finally:
         cluster.shutdown()
         pass
+
 
 # node1 is a source, node2 downloads data
 # node2 has long dns_cache_update_period, so dns cache update wouldn't work
@@ -73,9 +74,11 @@ def test_ip_change_drop_dns_cache(cluster_without_dns_cache_update):
 
 
 node3 = cluster.add_instance('node3', main_configs=['configs/listen_host.xml'],
-    with_zookeeper=True, ipv6_address='2001:3984:3989::1:1113')
-node4 = cluster.add_instance('node4', main_configs=['configs/remote_servers.xml', 'configs/listen_host.xml', 'configs/dns_update_short.xml'],
-    with_zookeeper=True, ipv6_address='2001:3984:3989::1:1114')
+                             with_zookeeper=True, ipv6_address='2001:3984:3989::1:1113')
+node4 = cluster.add_instance('node4', main_configs=['configs/remote_servers.xml', 'configs/listen_host.xml',
+                                                    'configs/dns_update_short.xml'],
+                             with_zookeeper=True, ipv6_address='2001:3984:3989::1:1114')
+
 
 @pytest.fixture(scope="module")
 def cluster_with_dns_cache_update():
@@ -93,6 +96,7 @@ def cluster_with_dns_cache_update():
         cluster.shutdown()
         pass
 
+
 # node3 is a source, node4 downloads data
 # node4 has short dns_cache_update_period, so testing update of dns cache
 def test_ip_change_update_dns_cache(cluster_with_dns_cache_update):
@@ -106,7 +110,6 @@ def test_ip_change_update_dns_cache(cluster_with_dns_cache_update):
 
     # Put some data to source node3
     node3.query("INSERT INTO test_table_update VALUES ('2018-10-01', 5), ('2018-10-02', 6), ('2018-10-03', 7)")
-
 
     # Check that data is placed on node3
     assert node3.query("SELECT count(*) from test_table_update") == "6\n"
@@ -126,9 +129,12 @@ def test_ip_change_update_dns_cache(cluster_with_dns_cache_update):
     assert node3.query("SELECT count(*) from test_table_update") == "7\n"
     assert_eq_with_retry(node4, "SELECT count(*) from test_table_update", "7")
 
+
 def set_hosts(node, hosts):
     new_content = '\\n'.join(['127.0.0.1 localhost', '::1 localhost'] + hosts)
-    node.exec_in_container(['bash', '-c', 'echo -e "{}" > /etc/hosts'.format(new_content)], privileged=True, user='root')
+    node.exec_in_container(['bash', '-c', 'echo -e "{}" > /etc/hosts'.format(new_content)], privileged=True,
+                           user='root')
+
 
 def test_dns_cache_update(cluster_with_dns_cache_update):
     set_hosts(node4, ['127.255.255.255 lost_host'])
@@ -136,7 +142,8 @@ def test_dns_cache_update(cluster_with_dns_cache_update):
     with pytest.raises(QueryRuntimeException):
         node4.query("SELECT * FROM remote('lost_host', 'system', 'one')")
 
-    node4.query("CREATE TABLE distributed_lost_host (dummy UInt8) ENGINE = Distributed(lost_host_cluster, 'system', 'one')")
+    node4.query(
+        "CREATE TABLE distributed_lost_host (dummy UInt8) ENGINE = Distributed(lost_host_cluster, 'system', 'one')")
     with pytest.raises(QueryRuntimeException):
         node4.query("SELECT * FROM distributed_lost_host")
 
@@ -146,8 +153,11 @@ def test_dns_cache_update(cluster_with_dns_cache_update):
     assert_eq_with_retry(node4, "SELECT * FROM remote('lost_host', 'system', 'one')", "0")
     assert_eq_with_retry(node4, "SELECT * FROM distributed_lost_host", "0")
 
-    assert TSV(node4.query("SELECT DISTINCT host_name, host_address FROM system.clusters WHERE cluster='lost_host_cluster'")) == TSV("lost_host\t127.0.0.1\n")
+    assert TSV(node4.query(
+        "SELECT DISTINCT host_name, host_address FROM system.clusters WHERE cluster='lost_host_cluster'")) == TSV(
+        "lost_host\t127.0.0.1\n")
     assert TSV(node4.query("SELECT hostName()")) == TSV("node4")
+
 
 # Check SYSTEM DROP DNS CACHE on node5 and background cache update on node6
 node5 = cluster.add_instance('node5', main_configs=['configs/listen_host.xml', 'configs/dns_update_long.xml'],
@@ -155,12 +165,14 @@ node5 = cluster.add_instance('node5', main_configs=['configs/listen_host.xml', '
 node6 = cluster.add_instance('node6', main_configs=['configs/listen_host.xml', 'configs/dns_update_short.xml'],
                              user_configs=['configs/users_with_hostname.xml'], ipv6_address='2001:3984:3989::1:1116')
 
+
 @pytest.mark.parametrize("node", [node5, node6])
 def test_user_access_ip_change(cluster_with_dns_cache_update, node):
     node_name = node.name
     node_num = node.name[-1]
     # getaddrinfo(...) may hang for a log time without this options
-    node.exec_in_container(['bash', '-c', 'echo -e "options timeout:1\noptions attempts:2" >> /etc/resolv.conf'], privileged=True, user='root')
+    node.exec_in_container(['bash', '-c', 'echo -e "options timeout:1\noptions attempts:2" >> /etc/resolv.conf'],
+                           privileged=True, user='root')
 
     assert node3.query("SELECT * FROM remote('{}', 'system', 'one')".format(node_name)) == "0\n"
     assert node4.query("SELECT * FROM remote('{}', 'system', 'one')".format(node_name)) == "0\n"
@@ -180,8 +192,11 @@ def test_user_access_ip_change(cluster_with_dns_cache_update, node):
     retry_count = 60
     if node_name == 'node5':
         # client is not allowed to connect, so execute it directly in container to send query from localhost
-        node.exec_in_container(['bash', '-c', 'clickhouse client -q "SYSTEM DROP DNS CACHE"'], privileged=True, user='root')
+        node.exec_in_container(['bash', '-c', 'clickhouse client -q "SYSTEM DROP DNS CACHE"'], privileged=True,
+                               user='root')
         retry_count = 1
 
-    assert_eq_with_retry(node3, "SELECT * FROM remote('{}', 'system', 'one')".format(node_name), "0", retry_count=retry_count, sleep_time=1)
-    assert_eq_with_retry(node4, "SELECT * FROM remote('{}', 'system', 'one')".format(node_name), "0", retry_count=retry_count, sleep_time=1)
+    assert_eq_with_retry(node3, "SELECT * FROM remote('{}', 'system', 'one')".format(node_name), "0",
+                         retry_count=retry_count, sleep_time=1)
+    assert_eq_with_retry(node4, "SELECT * FROM remote('{}', 'system', 'one')".format(node_name), "0",
+                         retry_count=retry_count, sleep_time=1)

--- a/tests/integration/test_http_and_readonly/test.py
+++ b/tests/integration/test_http_and_readonly/test.py
@@ -16,5 +16,7 @@ def setup_nodes():
 
 
 def test_http_get_is_readonly():
-    assert "Cannot execute query in readonly mode" in instance.http_query_and_get_error("CREATE TABLE xxx (a Date) ENGINE = MergeTree(a, a, 256)")
-    assert "Cannot modify 'readonly' setting in readonly mode" in instance.http_query_and_get_error("CREATE TABLE xxx (a Date) ENGINE = MergeTree(a, a, 256)", params={"readonly": 0})
+    assert "Cannot execute query in readonly mode" in instance.http_query_and_get_error(
+        "CREATE TABLE xxx (a Date) ENGINE = MergeTree(a, a, 256)")
+    assert "Cannot modify 'readonly' setting in readonly mode" in instance.http_query_and_get_error(
+        "CREATE TABLE xxx (a Date) ENGINE = MergeTree(a, a, 256)", params={"readonly": 0})

--- a/tests/integration/test_http_handlers_config/test.py
+++ b/tests/integration/test_http_handlers_config/test.py
@@ -1,6 +1,6 @@
+import contextlib
 import os
 import urllib
-import contextlib
 
 from helpers.cluster import ClickHouseCluster
 
@@ -20,101 +20,145 @@ class SimpleCluster:
 
 
 def test_dynamic_query_handler():
-    with contextlib.closing(SimpleCluster(ClickHouseCluster(__file__), "dynamic_handler", "test_dynamic_handler")) as cluster:
+    with contextlib.closing(
+            SimpleCluster(ClickHouseCluster(__file__), "dynamic_handler", "test_dynamic_handler")) as cluster:
         test_query = urllib.quote_plus('SELECT * FROM system.settings WHERE name = \'max_threads\'')
 
         assert 404 == cluster.instance.http_request('?max_threads=1', method='GET', headers={'XXX': 'xxx'}).status_code
 
-        assert 404 == cluster.instance.http_request('test_dynamic_handler_get?max_threads=1', method='POST', headers={'XXX': 'xxx'}).status_code
+        assert 404 == cluster.instance.http_request('test_dynamic_handler_get?max_threads=1', method='POST',
+                                                    headers={'XXX': 'xxx'}).status_code
 
-        assert 404 == cluster.instance.http_request('test_dynamic_handler_get?max_threads=1', method='GET', headers={'XXX': 'bad'}).status_code
+        assert 404 == cluster.instance.http_request('test_dynamic_handler_get?max_threads=1', method='GET',
+                                                    headers={'XXX': 'bad'}).status_code
 
-        assert 400 == cluster.instance.http_request('test_dynamic_handler_get?max_threads=1', method='GET', headers={'XXX': 'xxx'}).status_code
+        assert 400 == cluster.instance.http_request('test_dynamic_handler_get?max_threads=1', method='GET',
+                                                    headers={'XXX': 'xxx'}).status_code
 
-        assert 200 == cluster.instance.http_request('test_dynamic_handler_get?max_threads=1&get_dynamic_handler_query=' + test_query,
-                method='GET', headers={'XXX': 'xxx'}).status_code
+        assert 200 == cluster.instance.http_request(
+            'test_dynamic_handler_get?max_threads=1&get_dynamic_handler_query=' + test_query,
+            method='GET', headers={'XXX': 'xxx'}).status_code
 
 
 def test_predefined_query_handler():
-    with contextlib.closing(SimpleCluster(ClickHouseCluster(__file__), "predefined_handler", "test_predefined_handler")) as cluster:
+    with contextlib.closing(
+            SimpleCluster(ClickHouseCluster(__file__), "predefined_handler", "test_predefined_handler")) as cluster:
         assert 404 == cluster.instance.http_request('?max_threads=1', method='GET', headers={'XXX': 'xxx'}).status_code
 
-        assert 404 == cluster.instance.http_request('test_predefined_handler_get?max_threads=1', method='GET', headers={'XXX': 'bad'}).status_code
+        assert 404 == cluster.instance.http_request('test_predefined_handler_get?max_threads=1', method='GET',
+                                                    headers={'XXX': 'bad'}).status_code
 
-        assert 404 == cluster.instance.http_request('test_predefined_handler_get?max_threads=1', method='POST', headers={'XXX': 'xxx'}).status_code
+        assert 404 == cluster.instance.http_request('test_predefined_handler_get?max_threads=1', method='POST',
+                                                    headers={'XXX': 'xxx'}).status_code
 
-        assert 500 == cluster.instance.http_request('test_predefined_handler_get?max_threads=1', method='GET', headers={'XXX': 'xxx'}).status_code
+        assert 500 == cluster.instance.http_request('test_predefined_handler_get?max_threads=1', method='GET',
+                                                    headers={'XXX': 'xxx'}).status_code
 
-        assert 'max_threads\t1\n' == cluster.instance.http_request('test_predefined_handler_get?max_threads=1&setting_name=max_threads', method='GET', headers={'XXX': 'xxx'}).content
+        assert 'max_threads\t1\n' == cluster.instance.http_request(
+            'test_predefined_handler_get?max_threads=1&setting_name=max_threads', method='GET',
+            headers={'XXX': 'xxx'}).content
 
         assert 'max_threads\t1\nmax_alter_threads\t1\n' == cluster.instance.http_request(
-            'query_param_with_url/max_threads?max_threads=1&max_alter_threads=1', headers={'XXX': 'max_alter_threads'}).content
+            'query_param_with_url/max_threads?max_threads=1&max_alter_threads=1',
+            headers={'XXX': 'max_alter_threads'}).content
 
 
 def test_fixed_static_handler():
-    with contextlib.closing(SimpleCluster(ClickHouseCluster(__file__), "static_handler", "test_static_handler")) as cluster:
+    with contextlib.closing(
+            SimpleCluster(ClickHouseCluster(__file__), "static_handler", "test_static_handler")) as cluster:
         assert 404 == cluster.instance.http_request('', method='GET', headers={'XXX': 'xxx'}).status_code
 
-        assert 404 == cluster.instance.http_request('test_get_fixed_static_handler', method='GET', headers={'XXX': 'bad'}).status_code
+        assert 404 == cluster.instance.http_request('test_get_fixed_static_handler', method='GET',
+                                                    headers={'XXX': 'bad'}).status_code
 
-        assert 404 == cluster.instance.http_request('test_get_fixed_static_handler', method='POST', headers={'XXX': 'xxx'}).status_code
+        assert 404 == cluster.instance.http_request('test_get_fixed_static_handler', method='POST',
+                                                    headers={'XXX': 'xxx'}).status_code
 
-        assert 402 == cluster.instance.http_request('test_get_fixed_static_handler', method='GET', headers={'XXX': 'xxx'}).status_code
-        assert 'text/html; charset=UTF-8' == cluster.instance.http_request('test_get_fixed_static_handler', method='GET', headers={'XXX': 'xxx'}).headers['Content-Type']
-        assert 'Test get static handler and fix content' == cluster.instance.http_request('test_get_fixed_static_handler', method='GET', headers={'XXX': 'xxx'}).content
+        assert 402 == cluster.instance.http_request('test_get_fixed_static_handler', method='GET',
+                                                    headers={'XXX': 'xxx'}).status_code
+        assert 'text/html; charset=UTF-8' == \
+               cluster.instance.http_request('test_get_fixed_static_handler', method='GET',
+                                             headers={'XXX': 'xxx'}).headers['Content-Type']
+        assert 'Test get static handler and fix content' == cluster.instance.http_request(
+            'test_get_fixed_static_handler', method='GET', headers={'XXX': 'xxx'}).content
 
 
 def test_config_static_handler():
-    with contextlib.closing(SimpleCluster(ClickHouseCluster(__file__), "static_handler", "test_static_handler")) as cluster:
+    with contextlib.closing(
+            SimpleCluster(ClickHouseCluster(__file__), "static_handler", "test_static_handler")) as cluster:
         assert 404 == cluster.instance.http_request('', method='GET', headers={'XXX': 'xxx'}).status_code
 
-        assert 404 == cluster.instance.http_request('test_get_config_static_handler', method='GET', headers={'XXX': 'bad'}).status_code
+        assert 404 == cluster.instance.http_request('test_get_config_static_handler', method='GET',
+                                                    headers={'XXX': 'bad'}).status_code
 
-        assert 404 == cluster.instance.http_request('test_get_config_static_handler', method='POST', headers={'XXX': 'xxx'}).status_code
+        assert 404 == cluster.instance.http_request('test_get_config_static_handler', method='POST',
+                                                    headers={'XXX': 'xxx'}).status_code
 
         # check default status code
-        assert 200 == cluster.instance.http_request('test_get_config_static_handler', method='GET', headers={'XXX': 'xxx'}).status_code
-        assert 'text/plain; charset=UTF-8' == cluster.instance.http_request('test_get_config_static_handler', method='GET', headers={'XXX': 'xxx'}).headers['Content-Type']
-        assert 'Test get static handler and config content' == cluster.instance.http_request('test_get_config_static_handler', method='GET', headers={'XXX': 'xxx'}).content
+        assert 200 == cluster.instance.http_request('test_get_config_static_handler', method='GET',
+                                                    headers={'XXX': 'xxx'}).status_code
+        assert 'text/plain; charset=UTF-8' == \
+               cluster.instance.http_request('test_get_config_static_handler', method='GET',
+                                             headers={'XXX': 'xxx'}).headers['Content-Type']
+        assert 'Test get static handler and config content' == cluster.instance.http_request(
+            'test_get_config_static_handler', method='GET', headers={'XXX': 'xxx'}).content
 
 
 def test_absolute_path_static_handler():
-    with contextlib.closing(SimpleCluster(ClickHouseCluster(__file__), "static_handler", "test_static_handler")) as cluster:
+    with contextlib.closing(
+            SimpleCluster(ClickHouseCluster(__file__), "static_handler", "test_static_handler")) as cluster:
         cluster.instance.exec_in_container(
-            ['bash', '-c', 'echo "<html><body>Absolute Path File</body></html>" > /var/lib/clickhouse/user_files/absolute_path_file.html'],
+            ['bash', '-c',
+             'echo "<html><body>Absolute Path File</body></html>" > /var/lib/clickhouse/user_files/absolute_path_file.html'],
             privileged=True, user='root')
 
         assert 404 == cluster.instance.http_request('', method='GET', headers={'XXX': 'xxx'}).status_code
 
-        assert 404 == cluster.instance.http_request('test_get_absolute_path_static_handler', method='GET', headers={'XXX': 'bad'}).status_code
+        assert 404 == cluster.instance.http_request('test_get_absolute_path_static_handler', method='GET',
+                                                    headers={'XXX': 'bad'}).status_code
 
-        assert 404 == cluster.instance.http_request('test_get_absolute_path_static_handler', method='POST', headers={'XXX': 'xxx'}).status_code
+        assert 404 == cluster.instance.http_request('test_get_absolute_path_static_handler', method='POST',
+                                                    headers={'XXX': 'xxx'}).status_code
 
         # check default status code
-        assert 200 == cluster.instance.http_request('test_get_absolute_path_static_handler', method='GET', headers={'XXX': 'xxx'}).status_code
-        assert 'text/html; charset=UTF-8' == cluster.instance.http_request('test_get_absolute_path_static_handler', method='GET', headers={'XXX': 'xxx'}).headers['Content-Type']
-        assert '<html><body>Absolute Path File</body></html>\n' == cluster.instance.http_request('test_get_absolute_path_static_handler', method='GET', headers={'XXX': 'xxx'}).content
+        assert 200 == cluster.instance.http_request('test_get_absolute_path_static_handler', method='GET',
+                                                    headers={'XXX': 'xxx'}).status_code
+        assert 'text/html; charset=UTF-8' == \
+               cluster.instance.http_request('test_get_absolute_path_static_handler', method='GET',
+                                             headers={'XXX': 'xxx'}).headers['Content-Type']
+        assert '<html><body>Absolute Path File</body></html>\n' == cluster.instance.http_request(
+            'test_get_absolute_path_static_handler', method='GET', headers={'XXX': 'xxx'}).content
 
 
 def test_relative_path_static_handler():
-    with contextlib.closing(SimpleCluster(ClickHouseCluster(__file__), "static_handler", "test_static_handler")) as cluster:
+    with contextlib.closing(
+            SimpleCluster(ClickHouseCluster(__file__), "static_handler", "test_static_handler")) as cluster:
         cluster.instance.exec_in_container(
-            ['bash', '-c', 'echo "<html><body>Relative Path File</body></html>" > /var/lib/clickhouse/user_files/relative_path_file.html'],
+            ['bash', '-c',
+             'echo "<html><body>Relative Path File</body></html>" > /var/lib/clickhouse/user_files/relative_path_file.html'],
             privileged=True, user='root')
 
         assert 404 == cluster.instance.http_request('', method='GET', headers={'XXX': 'xxx'}).status_code
 
-        assert 404 == cluster.instance.http_request('test_get_relative_path_static_handler', method='GET', headers={'XXX': 'bad'}).status_code
+        assert 404 == cluster.instance.http_request('test_get_relative_path_static_handler', method='GET',
+                                                    headers={'XXX': 'bad'}).status_code
 
-        assert 404 == cluster.instance.http_request('test_get_relative_path_static_handler', method='POST', headers={'XXX': 'xxx'}).status_code
+        assert 404 == cluster.instance.http_request('test_get_relative_path_static_handler', method='POST',
+                                                    headers={'XXX': 'xxx'}).status_code
 
         # check default status code
-        assert 200 == cluster.instance.http_request('test_get_relative_path_static_handler', method='GET', headers={'XXX': 'xxx'}).status_code
-        assert 'text/html; charset=UTF-8' == cluster.instance.http_request('test_get_relative_path_static_handler', method='GET', headers={'XXX': 'xxx'}).headers['Content-Type']
-        assert '<html><body>Relative Path File</body></html>\n' == cluster.instance.http_request('test_get_relative_path_static_handler', method='GET', headers={'XXX': 'xxx'}).content
+        assert 200 == cluster.instance.http_request('test_get_relative_path_static_handler', method='GET',
+                                                    headers={'XXX': 'xxx'}).status_code
+        assert 'text/html; charset=UTF-8' == \
+               cluster.instance.http_request('test_get_relative_path_static_handler', method='GET',
+                                             headers={'XXX': 'xxx'}).headers['Content-Type']
+        assert '<html><body>Relative Path File</body></html>\n' == cluster.instance.http_request(
+            'test_get_relative_path_static_handler', method='GET', headers={'XXX': 'xxx'}).content
+
 
 def test_defaults_http_handlers():
-    with contextlib.closing(SimpleCluster(ClickHouseCluster(__file__), "defaults_handlers", "test_defaults_handlers")) as cluster:
+    with contextlib.closing(
+            SimpleCluster(ClickHouseCluster(__file__), "defaults_handlers", "test_defaults_handlers")) as cluster:
         assert 200 == cluster.instance.http_request('', method='GET').status_code
         assert 'Default server response' == cluster.instance.http_request('', method='GET').content
 
@@ -130,24 +174,34 @@ def test_defaults_http_handlers():
         assert 200 == cluster.instance.http_request('?query=SELECT+1', method='GET').status_code
         assert '1\n' == cluster.instance.http_request('?query=SELECT+1', method='GET').content
 
+
 def test_prometheus_handler():
-    with contextlib.closing(SimpleCluster(ClickHouseCluster(__file__), "prometheus_handler", "test_prometheus_handler")) as cluster:
+    with contextlib.closing(
+            SimpleCluster(ClickHouseCluster(__file__), "prometheus_handler", "test_prometheus_handler")) as cluster:
         assert 404 == cluster.instance.http_request('', method='GET', headers={'XXX': 'xxx'}).status_code
 
         assert 404 == cluster.instance.http_request('test_prometheus', method='GET', headers={'XXX': 'bad'}).status_code
 
-        assert 404 == cluster.instance.http_request('test_prometheus', method='POST', headers={'XXX': 'xxx'}).status_code
+        assert 404 == cluster.instance.http_request('test_prometheus', method='POST',
+                                                    headers={'XXX': 'xxx'}).status_code
 
         assert 200 == cluster.instance.http_request('test_prometheus', method='GET', headers={'XXX': 'xxx'}).status_code
-        assert 'ClickHouseProfileEvents_Query' in cluster.instance.http_request('test_prometheus', method='GET', headers={'XXX': 'xxx'}).content
+        assert 'ClickHouseProfileEvents_Query' in cluster.instance.http_request('test_prometheus', method='GET',
+                                                                                headers={'XXX': 'xxx'}).content
+
 
 def test_replicas_status_handler():
-    with contextlib.closing(SimpleCluster(ClickHouseCluster(__file__), "replicas_status_handler", "test_replicas_status_handler")) as cluster:
+    with contextlib.closing(SimpleCluster(ClickHouseCluster(__file__), "replicas_status_handler",
+                                          "test_replicas_status_handler")) as cluster:
         assert 404 == cluster.instance.http_request('', method='GET', headers={'XXX': 'xxx'}).status_code
 
-        assert 404 == cluster.instance.http_request('test_replicas_status', method='GET', headers={'XXX': 'bad'}).status_code
+        assert 404 == cluster.instance.http_request('test_replicas_status', method='GET',
+                                                    headers={'XXX': 'bad'}).status_code
 
-        assert 404 == cluster.instance.http_request('test_replicas_status', method='POST', headers={'XXX': 'xxx'}).status_code
+        assert 404 == cluster.instance.http_request('test_replicas_status', method='POST',
+                                                    headers={'XXX': 'xxx'}).status_code
 
-        assert 200 == cluster.instance.http_request('test_replicas_status', method='GET', headers={'XXX': 'xxx'}).status_code
-        assert 'Ok.\n' == cluster.instance.http_request('test_replicas_status', method='GET', headers={'XXX': 'xxx'}).content
+        assert 200 == cluster.instance.http_request('test_replicas_status', method='GET',
+                                                    headers={'XXX': 'xxx'}).status_code
+        assert 'Ok.\n' == cluster.instance.http_request('test_replicas_status', method='GET',
+                                                        headers={'XXX': 'xxx'}).content

--- a/tests/integration/test_https_replication/test.py
+++ b/tests/integration/test_https_replication/test.py
@@ -1,30 +1,36 @@
-import time
-import pytest
-
-from helpers.cluster import ClickHouseCluster
-
-from helpers.test_tools import assert_eq_with_retry
-from helpers.network import PartitionManager
-from multiprocessing.dummy import Pool
 import random
+import time
+from multiprocessing.dummy import Pool
+
+import pytest
+from helpers.cluster import ClickHouseCluster
+from helpers.network import PartitionManager
+from helpers.test_tools import assert_eq_with_retry
 
 """
 Both ssl_conf.xml and no_ssl_conf.xml have the same port
 """
 
+
 def _fill_nodes(nodes, shard):
     for node in nodes:
         node.query(
-        '''
-            CREATE DATABASE test;
+            '''
+                CREATE DATABASE test;
+    
+                CREATE TABLE test_table(date Date, id UInt32, dummy UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test{shard}/replicated', '{replica}', date, id, 8192);
+            '''.format(shard=shard, replica=node.name))
 
-            CREATE TABLE test_table(date Date, id UInt32, dummy UInt32)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test{shard}/replicated', '{replica}', date, id, 8192);
-        '''.format(shard=shard, replica=node.name))
 
 cluster = ClickHouseCluster(__file__)
-node1 = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml', 'configs/ssl_conf.xml', "configs/server.crt", "configs/server.key", "configs/dhparam.pem"], with_zookeeper=True)
-node2 = cluster.add_instance('node2', main_configs=['configs/remote_servers.xml', 'configs/ssl_conf.xml', "configs/server.crt", "configs/server.key", "configs/dhparam.pem"], with_zookeeper=True)
+node1 = cluster.add_instance('node1',
+                             main_configs=['configs/remote_servers.xml', 'configs/ssl_conf.xml', "configs/server.crt",
+                                           "configs/server.key", "configs/dhparam.pem"], with_zookeeper=True)
+node2 = cluster.add_instance('node2',
+                             main_configs=['configs/remote_servers.xml', 'configs/ssl_conf.xml', "configs/server.crt",
+                                           "configs/server.key", "configs/dhparam.pem"], with_zookeeper=True)
+
 
 @pytest.fixture(scope="module")
 def both_https_cluster():
@@ -37,6 +43,7 @@ def both_https_cluster():
 
     finally:
         cluster.shutdown()
+
 
 def test_both_https(both_https_cluster):
     node1.query("insert into test_table values ('2017-06-16', 111, 0)")
@@ -77,9 +84,11 @@ def test_replication_after_partition(both_https_cluster):
     assert_eq_with_retry(node2, "SELECT count() FROM test_table", '100')
 
 
+node3 = cluster.add_instance('node3', main_configs=['configs/remote_servers.xml', 'configs/no_ssl_conf.xml'],
+                             with_zookeeper=True)
+node4 = cluster.add_instance('node4', main_configs=['configs/remote_servers.xml', 'configs/no_ssl_conf.xml'],
+                             with_zookeeper=True)
 
-node3 = cluster.add_instance('node3', main_configs=['configs/remote_servers.xml', 'configs/no_ssl_conf.xml'], with_zookeeper=True)
-node4 = cluster.add_instance('node4', main_configs=['configs/remote_servers.xml', 'configs/no_ssl_conf.xml'], with_zookeeper=True)
 
 @pytest.fixture(scope="module")
 def both_http_cluster():
@@ -93,6 +102,7 @@ def both_http_cluster():
     finally:
         cluster.shutdown()
 
+
 def test_both_http(both_http_cluster):
     node3.query("insert into test_table values ('2017-06-16', 111, 0)")
 
@@ -104,8 +114,13 @@ def test_both_http(both_http_cluster):
     assert_eq_with_retry(node3, "SELECT id FROM test_table order by id", '111\n222')
     assert_eq_with_retry(node4, "SELECT id FROM test_table order by id", '111\n222')
 
-node5 = cluster.add_instance('node5', main_configs=['configs/remote_servers.xml', 'configs/ssl_conf.xml', "configs/server.crt", "configs/server.key", "configs/dhparam.pem"], with_zookeeper=True)
-node6 = cluster.add_instance('node6', main_configs=['configs/remote_servers.xml', 'configs/no_ssl_conf.xml'], with_zookeeper=True)
+
+node5 = cluster.add_instance('node5',
+                             main_configs=['configs/remote_servers.xml', 'configs/ssl_conf.xml', "configs/server.crt",
+                                           "configs/server.key", "configs/dhparam.pem"], with_zookeeper=True)
+node6 = cluster.add_instance('node6', main_configs=['configs/remote_servers.xml', 'configs/no_ssl_conf.xml'],
+                             with_zookeeper=True)
+
 
 @pytest.fixture(scope="module")
 def mixed_protocol_cluster():
@@ -118,6 +133,7 @@ def mixed_protocol_cluster():
 
     finally:
         cluster.shutdown()
+
 
 def test_mixed_protocol(mixed_protocol_cluster):
     node5.query("insert into test_table values ('2017-06-16', 111, 0)")

--- a/tests/integration/test_inherit_multiple_profiles/test.py
+++ b/tests/integration/test_inherit_multiple_profiles/test.py
@@ -4,7 +4,6 @@ from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
-
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance('instance',
                                 user_configs=['configs/combined_profile.xml'])

--- a/tests/integration/test_input_format_parallel_parsing_memory_tracking/test.py
+++ b/tests/integration/test_input_format_parallel_parsing_memory_tracking/test.py
@@ -10,6 +10,7 @@ cluster = ClickHouseCluster(__file__)
 
 instance = cluster.add_instance('instance', main_configs=['configs/conf.xml'])
 
+
 @pytest.fixture(scope='module', autouse=True)
 def start_cluster():
     try:
@@ -18,6 +19,7 @@ def start_cluster():
     finally:
         cluster.shutdown()
 
+
 # max_memory_usage_for_user cannot be used, since the memory for user accounted
 # correctly, only total is not
 def test_memory_tracking_total():
@@ -25,9 +27,10 @@ def test_memory_tracking_total():
         CREATE TABLE null (row String) ENGINE=Null;
     ''')
     instance.exec_in_container(['bash', '-c',
-        'clickhouse client -q "SELECT arrayStringConcat(arrayMap(x->toString(cityHash64(x)), range(1000)), \' \') from numbers(10000)" > data.json'])
+                                'clickhouse client -q "SELECT arrayStringConcat(arrayMap(x->toString(cityHash64(x)), range(1000)), \' \') from numbers(10000)" > data.json'])
     for it in range(0, 20):
         # the problem can be triggered only via HTTP,
         # since clickhouse-client parses the data by itself.
         assert instance.exec_in_container(['curl', '--silent', '--show-error', '--data-binary', '@data.json',
-            'http://127.1:8123/?query=INSERT%20INTO%20null%20FORMAT%20TSV']) == '', 'Failed on {} iteration'.format(it)
+                                           'http://127.1:8123/?query=INSERT%20INTO%20null%20FORMAT%20TSV']) == '', 'Failed on {} iteration'.format(
+            it)

--- a/tests/integration/test_insert_distributed_load_balancing/test.py
+++ b/tests/integration/test_insert_distributed_load_balancing/test.py
@@ -16,6 +16,7 @@ params = pytest.mark.parametrize('cluster,q', [
     ('no_internal_replication', 1),
 ])
 
+
 @pytest.fixture(scope='module', autouse=True)
 def start_cluster():
     try:
@@ -23,6 +24,7 @@ def start_cluster():
         yield cluster
     finally:
         cluster.shutdown()
+
 
 def create_tables(cluster):
     n1.query('DROP TABLE IF EXISTS data')
@@ -41,37 +43,43 @@ def create_tables(cluster):
     )
     """.format(cluster=cluster))
 
+
 def insert_data(cluster, **settings):
     create_tables(cluster)
     n1.query('INSERT INTO dist SELECT * FROM numbers(10)', settings=settings)
     n1.query('SYSTEM FLUSH DISTRIBUTED dist')
 
+
 @params
 def test_prefer_localhost_replica_1(cluster, q):
     insert_data(cluster)
     assert int(n1.query('SELECT count() FROM data')) == 10
-    assert int(n2.query('SELECT count() FROM data')) == 10*q
+    assert int(n2.query('SELECT count() FROM data')) == 10 * q
+
 
 @params
 def test_prefer_localhost_replica_1_load_balancing_in_order(cluster, q):
     insert_data(cluster, load_balancing='in_order')
     assert int(n1.query('SELECT count() FROM data')) == 10
-    assert int(n2.query('SELECT count() FROM data')) == 10*q
+    assert int(n2.query('SELECT count() FROM data')) == 10 * q
+
 
 @params
 def test_prefer_localhost_replica_0_load_balancing_nearest_hostname(cluster, q):
     insert_data(cluster, load_balancing='nearest_hostname', prefer_localhost_replica=0)
     assert int(n1.query('SELECT count() FROM data')) == 10
-    assert int(n2.query('SELECT count() FROM data')) == 10*q
+    assert int(n2.query('SELECT count() FROM data')) == 10 * q
+
 
 @params
 def test_prefer_localhost_replica_0_load_balancing_in_order(cluster, q):
     insert_data(cluster, load_balancing='in_order', prefer_localhost_replica=0)
-    assert int(n1.query('SELECT count() FROM data')) == 10*q
+    assert int(n1.query('SELECT count() FROM data')) == 10 * q
     assert int(n2.query('SELECT count() FROM data')) == 10
+
 
 @params
 def test_prefer_localhost_replica_0_load_balancing_in_order_sync(cluster, q):
     insert_data(cluster, load_balancing='in_order', prefer_localhost_replica=0, insert_distributed_sync=1)
-    assert int(n1.query('SELECT count() FROM data')) == 10*q
+    assert int(n1.query('SELECT count() FROM data')) == 10 * q
     assert int(n2.query('SELECT count() FROM data')) == 10

--- a/tests/integration/test_insert_into_distributed/test.py
+++ b/tests/integration/test_insert_into_distributed/test.py
@@ -1,10 +1,9 @@
-import pytest
 import time
 
+import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
 from helpers.test_tools import TSV
-
 
 cluster = ClickHouseCluster(__file__)
 
@@ -24,6 +23,7 @@ node2 = cluster.add_instance('node2', main_configs=['configs/remote_servers.xml'
 shard1 = cluster.add_instance('shard1', main_configs=['configs/remote_servers.xml'], with_zookeeper=True)
 shard2 = cluster.add_instance('shard2', main_configs=['configs/remote_servers.xml'], with_zookeeper=True)
 
+
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
@@ -39,7 +39,8 @@ CREATE TABLE distributed (x UInt32) ENGINE = Distributed('test_cluster', 'defaul
 CREATE TABLE distributed (d Date, x UInt32) ENGINE = Distributed('test_cluster', 'default', 'local2')
 ''')
 
-        instance_test_inserts_local_cluster.query("CREATE TABLE local (d Date, x UInt32) ENGINE = MergeTree(d, x, 8192)")
+        instance_test_inserts_local_cluster.query(
+            "CREATE TABLE local (d Date, x UInt32) ENGINE = MergeTree(d, x, 8192)")
         instance_test_inserts_local_cluster.query('''
 CREATE TABLE distributed_on_local (d Date, x UInt32) ENGINE = Distributed('test_local_cluster', 'default', 'local')
 ''')
@@ -73,8 +74,6 @@ CREATE TABLE table_function (n UInt8, s String) ENGINE = MergeTree() ORDER BY n'
 
         node2.query('''
 CREATE TABLE table_function (n UInt8, s String) ENGINE = MergeTree() ORDER BY n''')
-
-
 
         yield cluster
 
@@ -162,6 +161,7 @@ def test_inserts_local(started_cluster):
     time.sleep(0.5)
     assert instance.query("SELECT count(*) FROM local").strip() == '1'
 
+
 def test_prefer_localhost_replica(started_cluster):
     test_query = "SELECT * FROM distributed ORDER BY id"
 
@@ -174,13 +174,13 @@ def test_prefer_localhost_replica(started_cluster):
 2017-06-17\t22
 '''
 
-    expected_from_node2 =  '''\
+    expected_from_node2 = '''\
 2017-06-17\t11
 2017-06-17\t22
 2017-06-17\t44
 '''
 
-    expected_from_node1 =  '''\
+    expected_from_node1 = '''\
 2017-06-17\t11
 2017-06-17\t22
 2017-06-17\t33
@@ -204,7 +204,9 @@ def test_prefer_localhost_replica(started_cluster):
     assert TSV(node2.query(test_query)) == TSV(expected_from_node2)
 
     # Now query is sent to node1, as it higher in order
-    assert TSV(node2.query(test_query + " SETTINGS load_balancing='in_order', prefer_localhost_replica=0")) == TSV(expected_from_node1)
+    assert TSV(node2.query(test_query + " SETTINGS load_balancing='in_order', prefer_localhost_replica=0")) == TSV(
+        expected_from_node1)
+
 
 def test_inserts_low_cardinality(started_cluster):
     instance = shard1
@@ -212,6 +214,9 @@ def test_inserts_low_cardinality(started_cluster):
     time.sleep(0.5)
     assert instance.query("SELECT count(*) FROM low_cardinality_all").strip() == '1'
 
+
 def test_table_function(started_cluster):
-    node1.query("insert into table function cluster('shard_with_local_replica', 'default', 'table_function') select number, concat('str_', toString(number)) from numbers(100000)")
-    assert node1.query("select count() from cluster('shard_with_local_replica', 'default', 'table_function')").rstrip() == '100000'
+    node1.query(
+        "insert into table function cluster('shard_with_local_replica', 'default', 'table_function') select number, concat('str_', toString(number)) from numbers(100000)")
+    assert node1.query(
+        "select count() from cluster('shard_with_local_replica', 'default', 'table_function')").rstrip() == '100000'

--- a/tests/integration/test_insert_into_distributed_sync_async/test.py
+++ b/tests/integration/test_insert_into_distributed_sync_async/test.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python2
-import sys
 import os
+import sys
 from contextlib import contextmanager
+
 import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from helpers.network import PartitionManager
 from helpers.test_tools import TSV
 from helpers.cluster import ClickHouseCluster
 from helpers.client import QueryRuntimeException, QueryTimeoutExceedException
@@ -14,6 +14,7 @@ cluster = ClickHouseCluster(__file__)
 
 node1 = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml'])
 node2 = cluster.add_instance('node2', main_configs=['configs/remote_servers.xml'])
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -24,7 +25,6 @@ def started_cluster():
             node.query('''
 CREATE TABLE local_table(date Date, val UInt64) ENGINE = MergeTree(date, (date, val), 8192);
 ''')
-
 
         node1.query('''
 CREATE TABLE distributed_table(date Date, val UInt64) ENGINE = Distributed(test_cluster, default, local_table)
@@ -37,7 +37,6 @@ CREATE TABLE distributed_table(date Date, val UInt64) ENGINE = Distributed(test_
 
 
 def test_insertion_sync(started_cluster):
-
     node1.query('''SET insert_distributed_sync = 1, insert_distributed_timeout = 0;
     INSERT INTO distributed_table SELECT today() as date, number as val FROM system.numbers LIMIT 10000''')
 
@@ -105,8 +104,9 @@ def test_insertion_sync_with_disabled_timeout(started_cluster):
 
 def test_async_inserts_into_local_shard(started_cluster):
     node1.query('''CREATE TABLE shard_local (i Int64) ENGINE = Memory''')
-    node1.query('''CREATE TABLE shard_distributed (i Int64) ENGINE = Distributed(local_shard_with_internal_replication, default, shard_local)''')
-    node1.query('''INSERT INTO shard_distributed VALUES (1)''', settings={ "insert_distributed_sync" : 0 })
+    node1.query(
+        '''CREATE TABLE shard_distributed (i Int64) ENGINE = Distributed(local_shard_with_internal_replication, default, shard_local)''')
+    node1.query('''INSERT INTO shard_distributed VALUES (1)''', settings={"insert_distributed_sync": 0})
 
     assert TSV(node1.query('''SELECT count() FROM shard_distributed''')) == TSV("1\n")
     node1.query('''DETACH TABLE shard_distributed''')

--- a/tests/integration/test_insert_into_distributed_through_materialized_view/test.py
+++ b/tests/integration/test_insert_into_distributed_through_materialized_view/test.py
@@ -1,10 +1,9 @@
-import pytest
 import time
 
+import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
 from helpers.test_tools import TSV
-
 
 cluster = ClickHouseCluster(__file__)
 
@@ -30,23 +29,25 @@ def started_cluster():
 CREATE TABLE distributed (x UInt32) ENGINE = Distributed('test_cluster', 'default', 'local1')
 ''')
         instance_test_reconnect.query("CREATE TABLE local1_source (x UInt32) ENGINE = Memory")
-        instance_test_reconnect.query("CREATE MATERIALIZED VIEW local1_view to distributed AS SELECT x FROM local1_source")
+        instance_test_reconnect.query(
+            "CREATE MATERIALIZED VIEW local1_view to distributed AS SELECT x FROM local1_source")
 
         remote.query("CREATE TABLE local2 (d Date, x UInt32, s String) ENGINE = MergeTree(d, x, 8192)")
         instance_test_inserts_batching.query('''
 CREATE TABLE distributed (d Date, x UInt32) ENGINE = Distributed('test_cluster', 'default', 'local2')
 ''')
         instance_test_inserts_batching.query("CREATE TABLE local2_source (d Date, x UInt32) ENGINE = Log")
-        instance_test_inserts_batching.query("CREATE MATERIALIZED VIEW local2_view to distributed AS SELECT d,x FROM local2_source")
-
+        instance_test_inserts_batching.query(
+            "CREATE MATERIALIZED VIEW local2_view to distributed AS SELECT d,x FROM local2_source")
 
         instance_test_inserts_local_cluster.query("CREATE TABLE local_source (d Date, x UInt32) ENGINE = Memory")
-        instance_test_inserts_local_cluster.query("CREATE MATERIALIZED VIEW local_view to distributed_on_local AS SELECT d,x FROM local_source")
-        instance_test_inserts_local_cluster.query("CREATE TABLE local (d Date, x UInt32) ENGINE = MergeTree(d, x, 8192)")
+        instance_test_inserts_local_cluster.query(
+            "CREATE MATERIALIZED VIEW local_view to distributed_on_local AS SELECT d,x FROM local_source")
+        instance_test_inserts_local_cluster.query(
+            "CREATE TABLE local (d Date, x UInt32) ENGINE = MergeTree(d, x, 8192)")
         instance_test_inserts_local_cluster.query('''
 CREATE TABLE distributed_on_local (d Date, x UInt32) ENGINE = Distributed('test_local_cluster', 'default', 'local')
 ''')
-
 
         yield cluster
 
@@ -77,6 +78,7 @@ def test_reconnect(started_cluster):
         time.sleep(1)
 
         assert remote.query("SELECT count(*) FROM local1").strip() == '3'
+
 
 @pytest.mark.skip(reason="Flapping test")
 def test_inserts_batching(started_cluster):

--- a/tests/integration/test_live_view_over_distributed/test.py
+++ b/tests/integration/test_live_view_over_distributed/test.py
@@ -1,16 +1,10 @@
 from __future__ import print_function
 
 import sys
-import itertools
-import timeit
-import logging
 
 import pytest
-
-from helpers.uclient import client, prompt, end_of_block
 from helpers.cluster import ClickHouseCluster
-from helpers.network import PartitionManager
-from helpers.test_tools import TSV
+from helpers.uclient import client, prompt, end_of_block
 
 cluster = ClickHouseCluster(__file__)
 
@@ -45,6 +39,7 @@ CREATE LIVE VIEW lv_over_distributed_table AS SELECT * FROM distributed_table;
 
 INSERT_SQL_TEMPLATE = "INSERT INTO base_table VALUES ('{node_id}', {key}, {value})"
 
+
 @pytest.fixture(scope="function")
 def started_cluster():
     try:
@@ -73,7 +68,7 @@ node2\t1\t11
 
     def test_select_with_order_by_key(self, started_cluster, node, source):
         assert node.query("SELECT * FROM {source} ORDER BY key, node".format(source=source)) \
-            == """node1\t0\t0
+               == """node1\t0\t0
 node2\t0\t10
 node1\t1\t1
 node2\t1\t11
@@ -81,15 +76,15 @@ node2\t1\t11
 
     def test_select_with_group_by_node(self, started_cluster, node, source):
         assert node.query("SELECT node, SUM(value) FROM {source} GROUP BY node ORDER BY node".format(source=source)) \
-            == "node1\t1\nnode2\t21\n"
+               == "node1\t1\nnode2\t21\n"
 
     def test_select_with_group_by_key(self, started_cluster, node, source):
         assert node.query("SELECT key, SUM(value) FROM {source} GROUP BY key ORDER BY key".format(source=source)) \
-            == "0\t10\n1\t12\n"
+               == "0\t10\n1\t12\n"
 
     def test_select_sum(self, started_cluster, node, source):
         assert node.query("SELECT SUM(value) FROM {source}".format(source=source)) \
-            == "22\n"
+               == "22\n"
 
     def test_watch_live_view_order_by_node(self, started_cluster, node, source):
         log = sys.stdout
@@ -193,7 +188,8 @@ node2\t1\t11
 
             client1.send("DROP TABLE IF EXISTS lv")
             client1.expect(prompt)
-            client1.send("CREATE LIVE VIEW lv AS SELECT node, SUM(value) FROM distributed_table GROUP BY node ORDER BY node")
+            client1.send(
+                "CREATE LIVE VIEW lv AS SELECT node, SUM(value) FROM distributed_table GROUP BY node ORDER BY node")
             client1.expect(prompt)
 
             client1.send("WATCH lv FORMAT CSV")
@@ -227,7 +223,8 @@ node2\t1\t11
 
             client1.send("DROP TABLE IF EXISTS lv")
             client1.expect(prompt)
-            client1.send("CREATE LIVE VIEW lv AS SELECT key, SUM(value) FROM distributed_table GROUP BY key ORDER BY key")
+            client1.send(
+                "CREATE LIVE VIEW lv AS SELECT key, SUM(value) FROM distributed_table GROUP BY key ORDER BY key")
             client1.expect(prompt)
 
             client1.send("WATCH lv FORMAT CSV")
@@ -246,7 +243,6 @@ node2\t1\t11
             client1.expect('1,12,3')
             client1.expect('2,2,3')
             client1.expect('3,3,3')
-
 
     def test_watch_live_view_sum(self, started_cluster, node, source):
         log = sys.stdout

--- a/tests/integration/test_log_family_s3/test.py
+++ b/tests/integration/test_log_family_s3/test.py
@@ -11,7 +11,9 @@ logging.getLogger().addHandler(logging.StreamHandler())
 def cluster():
     try:
         cluster = ClickHouseCluster(__file__)
-        cluster.add_instance("node", main_configs=["configs/minio.xml", "configs/ssl.xml", "configs/config.d/log_conf.xml"], with_minio=True)
+        cluster.add_instance("node",
+                             main_configs=["configs/minio.xml", "configs/ssl.xml", "configs/config.d/log_conf.xml"],
+                             with_minio=True)
         logging.info("Starting cluster...")
         cluster.start()
         logging.info("Cluster started")
@@ -36,11 +38,13 @@ def test_log_family_s3(cluster, log_engine, files_overhead, files_overhead_per_i
 
     node.query("INSERT INTO s3_test SELECT number + 5 FROM numbers(3)")
     assert node.query("SELECT * FROM s3_test order by id") == "0\n1\n2\n3\n4\n5\n6\n7\n"
-    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == files_overhead_per_insert * 2 + files_overhead
+    assert len(
+        list(minio.list_objects(cluster.minio_bucket, 'data/'))) == files_overhead_per_insert * 2 + files_overhead
 
     node.query("INSERT INTO s3_test SELECT number + 8 FROM numbers(1)")
     assert node.query("SELECT * FROM s3_test order by id") == "0\n1\n2\n3\n4\n5\n6\n7\n8\n"
-    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == files_overhead_per_insert * 3 + files_overhead
+    assert len(
+        list(minio.list_objects(cluster.minio_bucket, 'data/'))) == files_overhead_per_insert * 3 + files_overhead
 
     node.query("TRUNCATE TABLE s3_test")
     assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == 0

--- a/tests/integration/test_logs_level/test.py
+++ b/tests/integration/test_logs_level/test.py
@@ -5,6 +5,7 @@ from helpers.cluster import ClickHouseCluster
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance('node', main_configs=['configs/config_information.xml'])
 
+
 @pytest.fixture(scope="module")
 def start_cluster():
     try:
@@ -12,6 +13,7 @@ def start_cluster():
         yield cluster
     finally:
         cluster.shutdown()
+
 
 def test_check_client_logs_level(start_cluster):
     logs = node.query_and_get_answer_with_error("SELECT 1", settings={"send_logs_level": 'trace'})[1]

--- a/tests/integration/test_match_process_uid_against_data_owner/test.py
+++ b/tests/integration/test_match_process_uid_against_data_owner/test.py
@@ -1,9 +1,9 @@
-import docker
 import os
 import pwd
-import pytest
 import re
 
+import docker
+import pytest
 from helpers.cluster import ClickHouseCluster, CLICKHOUSE_START_COMMAND
 
 
@@ -27,11 +27,13 @@ def test_different_user():
     container.exec_run('chown {} /var/lib/clickhouse'.format(other_user_id), privileged=True)
     container.exec_run(CLICKHOUSE_START_COMMAND)
 
-    cluster.shutdown() # cleanup
+    cluster.shutdown()  # cleanup
 
     with open(os.path.join(node.path, 'logs/clickhouse-server.err.log')) as log:
         expected_message = "Effective user of the process \(.*\) does not match the owner of the data \(.*\)\. Run under 'sudo -u .*'\."
         last_message = log.readlines()[-1].strip()
 
         if re.search(expected_message, last_message) is None:
-            pytest.fail('Expected the server to fail with a message "{}", but the last message is "{}"'.format(expected_message, last_message))
+            pytest.fail(
+                'Expected the server to fail with a message "{}", but the last message is "{}"'.format(expected_message,
+                                                                                                       last_message))

--- a/tests/integration/test_materialize_mysql_database/materialize_with_ddl.py
+++ b/tests/integration/test_materialize_mysql_database/materialize_with_ddl.py
@@ -1,4 +1,5 @@
 import time
+
 import pymysql.cursors
 
 
@@ -21,73 +22,75 @@ def dml_with_materialize_mysql_database(clickhouse_node, mysql_node, service_nam
     # existed before the mapping was created
 
     mysql_node.query("CREATE TABLE test_database.test_table_1 ("
-        "`key` INT NOT NULL PRIMARY KEY, "
-        "unsigned_tiny_int TINYINT UNSIGNED, tiny_int TINYINT, "
-        "unsigned_small_int SMALLINT UNSIGNED, small_int SMALLINT, "
-        "unsigned_medium_int MEDIUMINT UNSIGNED, medium_int MEDIUMINT, "
-        "unsigned_int INT UNSIGNED, _int INT, "
-        "unsigned_integer INTEGER UNSIGNED, _integer INTEGER, "
-        "unsigned_bigint BIGINT UNSIGNED, _bigint BIGINT, "
-        "/* Need ClickHouse support read mysql decimal unsigned_decimal DECIMAL(19, 10) UNSIGNED, _decimal DECIMAL(19, 10), */"
-        "unsigned_float FLOAT UNSIGNED, _float FLOAT, "
-        "unsigned_double DOUBLE UNSIGNED, _double DOUBLE, "
-        "_varchar VARCHAR(10), _char CHAR(10), "
-        "/* Need ClickHouse support Enum('a', 'b', 'v') _enum ENUM('a', 'b', 'c'), */"
-        "_date Date, _datetime DateTime, _timestamp TIMESTAMP, _bool BOOLEAN) ENGINE = InnoDB;")
+                     "`key` INT NOT NULL PRIMARY KEY, "
+                     "unsigned_tiny_int TINYINT UNSIGNED, tiny_int TINYINT, "
+                     "unsigned_small_int SMALLINT UNSIGNED, small_int SMALLINT, "
+                     "unsigned_medium_int MEDIUMINT UNSIGNED, medium_int MEDIUMINT, "
+                     "unsigned_int INT UNSIGNED, _int INT, "
+                     "unsigned_integer INTEGER UNSIGNED, _integer INTEGER, "
+                     "unsigned_bigint BIGINT UNSIGNED, _bigint BIGINT, "
+                     "/* Need ClickHouse support read mysql decimal unsigned_decimal DECIMAL(19, 10) UNSIGNED, _decimal DECIMAL(19, 10), */"
+                     "unsigned_float FLOAT UNSIGNED, _float FLOAT, "
+                     "unsigned_double DOUBLE UNSIGNED, _double DOUBLE, "
+                     "_varchar VARCHAR(10), _char CHAR(10), "
+                     "/* Need ClickHouse support Enum('a', 'b', 'v') _enum ENUM('a', 'b', 'c'), */"
+                     "_date Date, _datetime DateTime, _timestamp TIMESTAMP, _bool BOOLEAN) ENGINE = InnoDB;")
 
     # it already has some data
     mysql_node.query(
         "INSERT INTO test_database.test_table_1 VALUES(1, 1, -1, 2, -2, 3, -3, 4, -4, 5, -5, 6, -6, 3.2, -3.2, 3.4, -3.4, 'varchar', 'char', "
         "'2020-01-01', '2020-01-01 00:00:00', '2020-01-01 00:00:00', true);")
 
-    clickhouse_node.query("CREATE DATABASE test_database ENGINE = MaterializeMySQL('{}:3306', 'test_database', 'root', 'clickhouse')".format(service_name))
+    clickhouse_node.query(
+        "CREATE DATABASE test_database ENGINE = MaterializeMySQL('{}:3306', 'test_database', 'root', 'clickhouse')".format(
+            service_name))
 
     assert "test_database" in clickhouse_node.query("SHOW DATABASES")
     check_query(clickhouse_node, "SHOW TABLES FROM test_database FORMAT TSV", "test_table_1\n")
     check_query(clickhouse_node, "SELECT * FROM test_database.test_table_1 ORDER BY key FORMAT TSV",
-        "1\t1\t-1\t2\t-2\t3\t-3\t4\t-4\t5\t-5\t6\t-6\t3.2\t-3.2\t3.4\t-3.4\tvarchar\tchar\t2020-01-01\t"
-        "2020-01-01 00:00:00\t2020-01-01 00:00:00\t1\n")
+                "1\t1\t-1\t2\t-2\t3\t-3\t4\t-4\t5\t-5\t6\t-6\t3.2\t-3.2\t3.4\t-3.4\tvarchar\tchar\t2020-01-01\t"
+                "2020-01-01 00:00:00\t2020-01-01 00:00:00\t1\n")
 
     mysql_node.query(
         "INSERT INTO test_database.test_table_1 VALUES(2, 1, -1, 2, -2, 3, -3, 4, -4, 5, -5, 6, -6, 3.2, -3.2, 3.4, -3.4, 'varchar', 'char', "
         "'2020-01-01', '2020-01-01 00:00:00', '2020-01-01 00:00:00', false);")
 
     check_query(clickhouse_node, "SELECT * FROM test_database.test_table_1 ORDER BY key FORMAT TSV",
-        "1\t1\t-1\t2\t-2\t3\t-3\t4\t-4\t5\t-5\t6\t-6\t3.2\t-3.2\t3.4\t-3.4\tvarchar\tchar\t2020-01-01\t"
-        "2020-01-01 00:00:00\t2020-01-01 00:00:00\t1\n2\t1\t-1\t2\t-2\t3\t-3\t4\t-4\t5\t-5\t6\t-6\t3.2\t-3.2\t3.4\t-3.4\t"
-        "varchar\tchar\t2020-01-01\t2020-01-01 00:00:00\t2020-01-01 00:00:00\t0\n")
+                "1\t1\t-1\t2\t-2\t3\t-3\t4\t-4\t5\t-5\t6\t-6\t3.2\t-3.2\t3.4\t-3.4\tvarchar\tchar\t2020-01-01\t"
+                "2020-01-01 00:00:00\t2020-01-01 00:00:00\t1\n2\t1\t-1\t2\t-2\t3\t-3\t4\t-4\t5\t-5\t6\t-6\t3.2\t-3.2\t3.4\t-3.4\t"
+                "varchar\tchar\t2020-01-01\t2020-01-01 00:00:00\t2020-01-01 00:00:00\t0\n")
 
     mysql_node.query("UPDATE test_database.test_table_1 SET unsigned_tiny_int = 2 WHERE `key` = 1")
 
     check_query(clickhouse_node, "SELECT key, unsigned_tiny_int, tiny_int, unsigned_small_int,"
-        " small_int, unsigned_medium_int, medium_int, unsigned_int, _int, unsigned_integer, _integer, "
-        " unsigned_bigint, _bigint, unsigned_float, _float, unsigned_double, _double, _varchar, _char, "
-        " _date, _datetime, /* exclude it, because ON UPDATE CURRENT_TIMESTAMP _timestamp, */ "
-        " _bool FROM test_database.test_table_1 ORDER BY key FORMAT TSV",
-        "1\t2\t-1\t2\t-2\t3\t-3\t4\t-4\t5\t-5\t6\t-6\t3.2\t-3.2\t3.4\t-3.4\tvarchar\tchar\t2020-01-01\t"
-        "2020-01-01 00:00:00\t1\n2\t1\t-1\t2\t-2\t3\t-3\t4\t-4\t5\t-5\t6\t-6\t3.2\t-3.2\t3.4\t-3.4\t"
-        "varchar\tchar\t2020-01-01\t2020-01-01 00:00:00\t0\n")
+                                 " small_int, unsigned_medium_int, medium_int, unsigned_int, _int, unsigned_integer, _integer, "
+                                 " unsigned_bigint, _bigint, unsigned_float, _float, unsigned_double, _double, _varchar, _char, "
+                                 " _date, _datetime, /* exclude it, because ON UPDATE CURRENT_TIMESTAMP _timestamp, */ "
+                                 " _bool FROM test_database.test_table_1 ORDER BY key FORMAT TSV",
+                "1\t2\t-1\t2\t-2\t3\t-3\t4\t-4\t5\t-5\t6\t-6\t3.2\t-3.2\t3.4\t-3.4\tvarchar\tchar\t2020-01-01\t"
+                "2020-01-01 00:00:00\t1\n2\t1\t-1\t2\t-2\t3\t-3\t4\t-4\t5\t-5\t6\t-6\t3.2\t-3.2\t3.4\t-3.4\t"
+                "varchar\tchar\t2020-01-01\t2020-01-01 00:00:00\t0\n")
 
     # update primary key
     mysql_node.query("UPDATE test_database.test_table_1 SET `key` = 3 WHERE `unsigned_tiny_int` = 2")
 
     check_query(clickhouse_node, "SELECT key, unsigned_tiny_int, tiny_int, unsigned_small_int,"
-        " small_int, unsigned_medium_int, medium_int, unsigned_int, _int, unsigned_integer, _integer, "
-        " unsigned_bigint, _bigint, unsigned_float, _float, unsigned_double, _double, _varchar, _char, "
-        " _date, _datetime, /* exclude it, because ON UPDATE CURRENT_TIMESTAMP _timestamp, */ "
-        " _bool FROM test_database.test_table_1 ORDER BY key FORMAT TSV",
-        "2\t1\t-1\t2\t-2\t3\t-3\t4\t-4\t5\t-5\t6\t-6\t3.2\t-3.2\t3.4\t-3.4\t"
-        "varchar\tchar\t2020-01-01\t2020-01-01 00:00:00\t0\n3\t2\t-1\t2\t-2\t3\t-3\t"
-        "4\t-4\t5\t-5\t6\t-6\t3.2\t-3.2\t3.4\t-3.4\tvarchar\tchar\t2020-01-01\t2020-01-01 00:00:00\t1\n")
+                                 " small_int, unsigned_medium_int, medium_int, unsigned_int, _int, unsigned_integer, _integer, "
+                                 " unsigned_bigint, _bigint, unsigned_float, _float, unsigned_double, _double, _varchar, _char, "
+                                 " _date, _datetime, /* exclude it, because ON UPDATE CURRENT_TIMESTAMP _timestamp, */ "
+                                 " _bool FROM test_database.test_table_1 ORDER BY key FORMAT TSV",
+                "2\t1\t-1\t2\t-2\t3\t-3\t4\t-4\t5\t-5\t6\t-6\t3.2\t-3.2\t3.4\t-3.4\t"
+                "varchar\tchar\t2020-01-01\t2020-01-01 00:00:00\t0\n3\t2\t-1\t2\t-2\t3\t-3\t"
+                "4\t-4\t5\t-5\t6\t-6\t3.2\t-3.2\t3.4\t-3.4\tvarchar\tchar\t2020-01-01\t2020-01-01 00:00:00\t1\n")
 
     mysql_node.query('DELETE FROM test_database.test_table_1 WHERE `key` = 2')
     check_query(clickhouse_node, "SELECT key, unsigned_tiny_int, tiny_int, unsigned_small_int,"
-        " small_int, unsigned_medium_int, medium_int, unsigned_int, _int, unsigned_integer, _integer, "
-        " unsigned_bigint, _bigint, unsigned_float, _float, unsigned_double, _double, _varchar, _char, "
-        " _date, _datetime, /* exclude it, because ON UPDATE CURRENT_TIMESTAMP _timestamp, */ "
-        " _bool FROM test_database.test_table_1 ORDER BY key FORMAT TSV",
-        "3\t2\t-1\t2\t-2\t3\t-3\t4\t-4\t5\t-5\t6\t-6\t3.2\t-3.2\t3.4\t-3.4\tvarchar\tchar\t2020-01-01\t"
-        "2020-01-01 00:00:00\t1\n")
+                                 " small_int, unsigned_medium_int, medium_int, unsigned_int, _int, unsigned_integer, _integer, "
+                                 " unsigned_bigint, _bigint, unsigned_float, _float, unsigned_double, _double, _varchar, _char, "
+                                 " _date, _datetime, /* exclude it, because ON UPDATE CURRENT_TIMESTAMP _timestamp, */ "
+                                 " _bool FROM test_database.test_table_1 ORDER BY key FORMAT TSV",
+                "3\t2\t-1\t2\t-2\t3\t-3\t4\t-4\t5\t-5\t6\t-6\t3.2\t-3.2\t3.4\t-3.4\tvarchar\tchar\t2020-01-01\t"
+                "2020-01-01 00:00:00\t1\n")
 
     mysql_node.query('DELETE FROM test_database.test_table_1 WHERE `unsigned_tiny_int` = 2')
     check_query(clickhouse_node, "SELECT * FROM test_database.test_table_1 ORDER BY key FORMAT TSV", "")
@@ -108,7 +111,8 @@ def drop_table_with_materialize_mysql_database(clickhouse_node, mysql_node, serv
 
     # create mapping
     clickhouse_node.query(
-        "CREATE DATABASE test_database ENGINE = MaterializeMySQL('{}:3306', 'test_database', 'root', 'clickhouse')".format(service_name))
+        "CREATE DATABASE test_database ENGINE = MaterializeMySQL('{}:3306', 'test_database', 'root', 'clickhouse')".format(
+            service_name))
 
     assert "test_database" in clickhouse_node.query("SHOW DATABASES")
     check_query(clickhouse_node, "SHOW TABLES FROM test_database FORMAT TSV", "test_table_2\n")
@@ -117,7 +121,8 @@ def drop_table_with_materialize_mysql_database(clickhouse_node, mysql_node, serv
     mysql_node.query("INSERT INTO test_database.test_table_2 VALUES(1), (2), (3), (4), (5), (6)")
     mysql_node.query("CREATE TABLE test_database.test_table_1 (id INT NOT NULL PRIMARY KEY) ENGINE = InnoDB;")
     check_query(clickhouse_node, "SHOW TABLES FROM test_database FORMAT TSV", "test_table_1\ntest_table_2\n")
-    check_query(clickhouse_node, "SELECT * FROM test_database.test_table_2 ORDER BY id FORMAT TSV", "1\n2\n3\n4\n5\n6\n")
+    check_query(clickhouse_node, "SELECT * FROM test_database.test_table_2 ORDER BY id FORMAT TSV",
+                "1\n2\n3\n4\n5\n6\n")
 
     mysql_node.query("DROP TABLE test_database.test_table_1;")
     mysql_node.query("TRUNCATE TABLE test_database.test_table_2;")
@@ -136,17 +141,21 @@ def create_table_with_materialize_mysql_database(clickhouse_node, mysql_node, se
     mysql_node.query("INSERT INTO test_database.test_table_1 VALUES(1), (2), (3), (5), (6), (7);")
 
     # create mapping
-    clickhouse_node.query("CREATE DATABASE test_database ENGINE = MaterializeMySQL('{}:3306', 'test_database', 'root', 'clickhouse')".format(service_name))
+    clickhouse_node.query(
+        "CREATE DATABASE test_database ENGINE = MaterializeMySQL('{}:3306', 'test_database', 'root', 'clickhouse')".format(
+            service_name))
 
     # Check for pre-existing status
     assert "test_database" in clickhouse_node.query("SHOW DATABASES")
     check_query(clickhouse_node, "SHOW TABLES FROM test_database FORMAT TSV", "test_table_1\n")
-    check_query(clickhouse_node, "SELECT * FROM test_database.test_table_1 ORDER BY id FORMAT TSV", "1\n2\n3\n5\n6\n7\n")
+    check_query(clickhouse_node, "SELECT * FROM test_database.test_table_1 ORDER BY id FORMAT TSV",
+                "1\n2\n3\n5\n6\n7\n")
 
     mysql_node.query("CREATE TABLE test_database.test_table_2 (id INT NOT NULL PRIMARY KEY) ENGINE = InnoDB;")
     mysql_node.query("INSERT INTO test_database.test_table_2 VALUES(1), (2), (3), (4), (5), (6);")
     check_query(clickhouse_node, "SHOW TABLES FROM test_database FORMAT TSV", "test_table_1\ntest_table_2\n")
-    check_query(clickhouse_node, "SELECT * FROM test_database.test_table_2 ORDER BY id FORMAT TSV", "1\n2\n3\n4\n5\n6\n")
+    check_query(clickhouse_node, "SELECT * FROM test_database.test_table_2 ORDER BY id FORMAT TSV",
+                "1\n2\n3\n4\n5\n6\n")
 
     clickhouse_node.query("DROP DATABASE test_database")
     mysql_node.query("DROP DATABASE test_database")
@@ -160,7 +169,8 @@ def rename_table_with_materialize_mysql_database(clickhouse_node, mysql_node, se
 
     # create mapping
     clickhouse_node.query(
-        "CREATE DATABASE test_database ENGINE = MaterializeMySQL('{}:3306', 'test_database', 'root', 'clickhouse')".format(service_name))
+        "CREATE DATABASE test_database ENGINE = MaterializeMySQL('{}:3306', 'test_database', 'root', 'clickhouse')".format(
+            service_name))
 
     assert "test_database" in clickhouse_node.query("SHOW DATABASES")
     check_query(clickhouse_node, "SHOW TABLES FROM test_database FORMAT TSV", "test_table_2\n")
@@ -178,30 +188,35 @@ def alter_add_column_with_materialize_mysql_database(clickhouse_node, mysql_node
     mysql_node.query("ALTER TABLE test_database.test_table_1 ADD COLUMN add_column_1 INT NOT NULL")
     mysql_node.query("ALTER TABLE test_database.test_table_1 ADD COLUMN add_column_2 INT NOT NULL FIRST")
     mysql_node.query("ALTER TABLE test_database.test_table_1 ADD COLUMN add_column_3 INT NOT NULL AFTER add_column_1")
-    mysql_node.query("ALTER TABLE test_database.test_table_1 ADD COLUMN add_column_4 INT NOT NULL DEFAULT " + ("0" if service_name == "mysql1" else "(id)"))
+    mysql_node.query("ALTER TABLE test_database.test_table_1 ADD COLUMN add_column_4 INT NOT NULL DEFAULT " + (
+        "0" if service_name == "mysql1" else "(id)"))
 
     # create mapping
     clickhouse_node.query(
-        "CREATE DATABASE test_database ENGINE = MaterializeMySQL('{}:3306', 'test_database', 'root', 'clickhouse')".format(service_name))
+        "CREATE DATABASE test_database ENGINE = MaterializeMySQL('{}:3306', 'test_database', 'root', 'clickhouse')".format(
+            service_name))
 
     assert "test_database" in clickhouse_node.query("SHOW DATABASES")
     check_query(clickhouse_node, "SHOW TABLES FROM test_database FORMAT TSV", "test_table_1\n")
     check_query(clickhouse_node, "DESC test_database.test_table_1 FORMAT TSV",
-        "add_column_2\tInt32\t\t\t\t\t\nid\tInt32\t\t\t\t\t\nadd_column_1\tInt32\t\t\t\t\t\nadd_column_3\tInt32\t\t\t\t\t\nadd_column_4\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
+                "add_column_2\tInt32\t\t\t\t\t\nid\tInt32\t\t\t\t\t\nadd_column_1\tInt32\t\t\t\t\t\nadd_column_3\tInt32\t\t\t\t\t\nadd_column_4\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
     mysql_node.query("CREATE TABLE test_database.test_table_2 (id INT NOT NULL PRIMARY KEY) ENGINE = InnoDB;")
     check_query(clickhouse_node, "SHOW TABLES FROM test_database FORMAT TSV", "test_table_1\ntest_table_2\n")
-    check_query(clickhouse_node, "DESC test_database.test_table_2 FORMAT TSV", "id\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
-    mysql_node.query("ALTER TABLE test_database.test_table_2 ADD COLUMN add_column_1 INT NOT NULL, ADD COLUMN add_column_2 INT NOT NULL FIRST")
+    check_query(clickhouse_node, "DESC test_database.test_table_2 FORMAT TSV",
+                "id\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
+    mysql_node.query(
+        "ALTER TABLE test_database.test_table_2 ADD COLUMN add_column_1 INT NOT NULL, ADD COLUMN add_column_2 INT NOT NULL FIRST")
     mysql_node.query(
         "ALTER TABLE test_database.test_table_2 ADD COLUMN add_column_3 INT NOT NULL AFTER add_column_1, ADD COLUMN add_column_4 INT NOT NULL DEFAULT " + (
             "0" if service_name == "mysql1" else "(id)"))
 
     default_expression = "DEFAULT\t0" if service_name == "mysql1" else "DEFAULT\tid"
     check_query(clickhouse_node, "DESC test_database.test_table_2 FORMAT TSV",
-        "add_column_2\tInt32\t\t\t\t\t\nid\tInt32\t\t\t\t\t\nadd_column_1\tInt32\t\t\t\t\t\nadd_column_3\tInt32\t\t\t\t\t\nadd_column_4\tInt32\t" + default_expression + "\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
+                "add_column_2\tInt32\t\t\t\t\t\nid\tInt32\t\t\t\t\t\nadd_column_1\tInt32\t\t\t\t\t\nadd_column_3\tInt32\t\t\t\t\t\nadd_column_4\tInt32\t" + default_expression + "\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
 
     mysql_node.query("INSERT INTO test_database.test_table_2 VALUES(1, 2, 3, 4, 5), (6, 7, 8, 9, 10)")
-    check_query(clickhouse_node, "SELECT * FROM test_database.test_table_2 ORDER BY id FORMAT TSV", "1\t2\t3\t4\t5\n6\t7\t8\t9\t10\n")
+    check_query(clickhouse_node, "SELECT * FROM test_database.test_table_2 ORDER BY id FORMAT TSV",
+                "1\t2\t3\t4\t5\n6\t7\t8\t9\t10\n")
 
     clickhouse_node.query("DROP DATABASE test_database")
     mysql_node.query("DROP DATABASE test_database")
@@ -209,22 +224,28 @@ def alter_add_column_with_materialize_mysql_database(clickhouse_node, mysql_node
 
 def alter_drop_column_with_materialize_mysql_database(clickhouse_node, mysql_node, service_name):
     mysql_node.query("CREATE DATABASE test_database DEFAULT CHARACTER SET 'utf8'")
-    mysql_node.query("CREATE TABLE test_database.test_table_1 (id INT NOT NULL PRIMARY KEY, drop_column INT) ENGINE = InnoDB;")
+    mysql_node.query(
+        "CREATE TABLE test_database.test_table_1 (id INT NOT NULL PRIMARY KEY, drop_column INT) ENGINE = InnoDB;")
 
     mysql_node.query("ALTER TABLE test_database.test_table_1 DROP COLUMN drop_column")
 
     # create mapping
     clickhouse_node.query(
-        "CREATE DATABASE test_database ENGINE = MaterializeMySQL('{}:3306', 'test_database', 'root', 'clickhouse')".format(service_name))
+        "CREATE DATABASE test_database ENGINE = MaterializeMySQL('{}:3306', 'test_database', 'root', 'clickhouse')".format(
+            service_name))
 
     assert "test_database" in clickhouse_node.query("SHOW DATABASES")
     check_query(clickhouse_node, "SHOW TABLES FROM test_database FORMAT TSV", "test_table_1\n")
-    check_query(clickhouse_node, "DESC test_database.test_table_1 FORMAT TSV", "id\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
-    mysql_node.query("CREATE TABLE test_database.test_table_2 (id INT NOT NULL PRIMARY KEY, drop_column INT NOT NULL) ENGINE = InnoDB;")
+    check_query(clickhouse_node, "DESC test_database.test_table_1 FORMAT TSV",
+                "id\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
+    mysql_node.query(
+        "CREATE TABLE test_database.test_table_2 (id INT NOT NULL PRIMARY KEY, drop_column INT NOT NULL) ENGINE = InnoDB;")
     check_query(clickhouse_node, "SHOW TABLES FROM test_database FORMAT TSV", "test_table_1\ntest_table_2\n")
-    check_query(clickhouse_node, "DESC test_database.test_table_2 FORMAT TSV", "id\tInt32\t\t\t\t\t\ndrop_column\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
+    check_query(clickhouse_node, "DESC test_database.test_table_2 FORMAT TSV",
+                "id\tInt32\t\t\t\t\t\ndrop_column\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
     mysql_node.query("ALTER TABLE test_database.test_table_2 DROP COLUMN drop_column")
-    check_query(clickhouse_node, "DESC test_database.test_table_2 FORMAT TSV", "id\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
+    check_query(clickhouse_node, "DESC test_database.test_table_2 FORMAT TSV",
+                "id\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
 
     mysql_node.query("INSERT INTO test_database.test_table_2 VALUES(1), (2), (3), (4), (5)")
     check_query(clickhouse_node, "SELECT * FROM test_database.test_table_2 ORDER BY id FORMAT TSV", "1\n2\n3\n4\n5\n")
@@ -237,25 +258,32 @@ def alter_rename_column_with_materialize_mysql_database(clickhouse_node, mysql_n
     mysql_node.query("CREATE DATABASE test_database DEFAULT CHARACTER SET 'utf8'")
 
     # maybe should test rename primary key?
-    mysql_node.query("CREATE TABLE test_database.test_table_1 (id INT NOT NULL PRIMARY KEY, rename_column INT NOT NULL) ENGINE = InnoDB;")
+    mysql_node.query(
+        "CREATE TABLE test_database.test_table_1 (id INT NOT NULL PRIMARY KEY, rename_column INT NOT NULL) ENGINE = InnoDB;")
 
     mysql_node.query("ALTER TABLE test_database.test_table_1 RENAME COLUMN rename_column TO new_column_name")
 
     # create mapping
     clickhouse_node.query(
-        "CREATE DATABASE test_database ENGINE = MaterializeMySQL('{}:3306', 'test_database', 'root', 'clickhouse')".format(service_name))
+        "CREATE DATABASE test_database ENGINE = MaterializeMySQL('{}:3306', 'test_database', 'root', 'clickhouse')".format(
+            service_name))
 
     assert "test_database" in clickhouse_node.query("SHOW DATABASES")
     check_query(clickhouse_node, "SHOW TABLES FROM test_database FORMAT TSV", "test_table_1\n")
-    check_query(clickhouse_node, "DESC test_database.test_table_1 FORMAT TSV", "id\tInt32\t\t\t\t\t\nnew_column_name\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
-    mysql_node.query("CREATE TABLE test_database.test_table_2 (id INT NOT NULL PRIMARY KEY, rename_column INT NOT NULL) ENGINE = InnoDB;")
+    check_query(clickhouse_node, "DESC test_database.test_table_1 FORMAT TSV",
+                "id\tInt32\t\t\t\t\t\nnew_column_name\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
+    mysql_node.query(
+        "CREATE TABLE test_database.test_table_2 (id INT NOT NULL PRIMARY KEY, rename_column INT NOT NULL) ENGINE = InnoDB;")
     check_query(clickhouse_node, "SHOW TABLES FROM test_database FORMAT TSV", "test_table_1\ntest_table_2\n")
-    check_query(clickhouse_node, "DESC test_database.test_table_2 FORMAT TSV", "id\tInt32\t\t\t\t\t\nrename_column\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
+    check_query(clickhouse_node, "DESC test_database.test_table_2 FORMAT TSV",
+                "id\tInt32\t\t\t\t\t\nrename_column\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
     mysql_node.query("ALTER TABLE test_database.test_table_2 RENAME COLUMN rename_column TO new_column_name")
-    check_query(clickhouse_node, "DESC test_database.test_table_2 FORMAT TSV", "id\tInt32\t\t\t\t\t\nnew_column_name\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
+    check_query(clickhouse_node, "DESC test_database.test_table_2 FORMAT TSV",
+                "id\tInt32\t\t\t\t\t\nnew_column_name\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
 
     mysql_node.query("INSERT INTO test_database.test_table_2 VALUES(1, 2), (3, 4), (5, 6), (7, 8), (9, 10)")
-    check_query(clickhouse_node, "SELECT * FROM test_database.test_table_2 ORDER BY id FORMAT TSV", "1\t2\n3\t4\n5\t6\n7\t8\n9\t10\n")
+    check_query(clickhouse_node, "SELECT * FROM test_database.test_table_2 ORDER BY id FORMAT TSV",
+                "1\t2\n3\t4\n5\t6\n7\t8\n9\t10\n")
 
     clickhouse_node.query("DROP DATABASE test_database")
     mysql_node.query("DROP DATABASE test_database")
@@ -265,26 +293,34 @@ def alter_modify_column_with_materialize_mysql_database(clickhouse_node, mysql_n
     mysql_node.query("CREATE DATABASE test_database DEFAULT CHARACTER SET 'utf8'")
 
     # maybe should test rename primary key?
-    mysql_node.query("CREATE TABLE test_database.test_table_1 (id INT NOT NULL PRIMARY KEY, modify_column INT NOT NULL) ENGINE = InnoDB;")
+    mysql_node.query(
+        "CREATE TABLE test_database.test_table_1 (id INT NOT NULL PRIMARY KEY, modify_column INT NOT NULL) ENGINE = InnoDB;")
 
     mysql_node.query("ALTER TABLE test_database.test_table_1 MODIFY COLUMN modify_column INT")
 
     # create mapping
     clickhouse_node.query(
-        "CREATE DATABASE test_database ENGINE = MaterializeMySQL('{}:3306', 'test_database', 'root', 'clickhouse')".format(service_name))
+        "CREATE DATABASE test_database ENGINE = MaterializeMySQL('{}:3306', 'test_database', 'root', 'clickhouse')".format(
+            service_name))
 
     assert "test_database" in clickhouse_node.query("SHOW DATABASES")
     check_query(clickhouse_node, "SHOW TABLES FROM test_database FORMAT TSV", "test_table_1\n")
-    check_query(clickhouse_node, "DESC test_database.test_table_1 FORMAT TSV", "id\tInt32\t\t\t\t\t\nmodify_column\tNullable(Int32)\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
-    mysql_node.query("CREATE TABLE test_database.test_table_2 (id INT NOT NULL PRIMARY KEY, modify_column INT NOT NULL) ENGINE = InnoDB;")
+    check_query(clickhouse_node, "DESC test_database.test_table_1 FORMAT TSV",
+                "id\tInt32\t\t\t\t\t\nmodify_column\tNullable(Int32)\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
+    mysql_node.query(
+        "CREATE TABLE test_database.test_table_2 (id INT NOT NULL PRIMARY KEY, modify_column INT NOT NULL) ENGINE = InnoDB;")
     check_query(clickhouse_node, "SHOW TABLES FROM test_database FORMAT TSV", "test_table_1\ntest_table_2\n")
-    check_query(clickhouse_node, "DESC test_database.test_table_2 FORMAT TSV", "id\tInt32\t\t\t\t\t\nmodify_column\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
+    check_query(clickhouse_node, "DESC test_database.test_table_2 FORMAT TSV",
+                "id\tInt32\t\t\t\t\t\nmodify_column\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
     mysql_node.query("ALTER TABLE test_database.test_table_2 MODIFY COLUMN modify_column INT")
-    check_query(clickhouse_node, "DESC test_database.test_table_2 FORMAT TSV", "id\tInt32\t\t\t\t\t\nmodify_column\tNullable(Int32)\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
+    check_query(clickhouse_node, "DESC test_database.test_table_2 FORMAT TSV",
+                "id\tInt32\t\t\t\t\t\nmodify_column\tNullable(Int32)\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
     mysql_node.query("ALTER TABLE test_database.test_table_2 MODIFY COLUMN modify_column INT FIRST")
-    check_query(clickhouse_node, "DESC test_database.test_table_2 FORMAT TSV", "modify_column\tNullable(Int32)\t\t\t\t\t\nid\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
+    check_query(clickhouse_node, "DESC test_database.test_table_2 FORMAT TSV",
+                "modify_column\tNullable(Int32)\t\t\t\t\t\nid\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
     mysql_node.query("ALTER TABLE test_database.test_table_2 MODIFY COLUMN modify_column INT AFTER id")
-    check_query(clickhouse_node, "DESC test_database.test_table_2 FORMAT TSV", "id\tInt32\t\t\t\t\t\nmodify_column\tNullable(Int32)\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
+    check_query(clickhouse_node, "DESC test_database.test_table_2 FORMAT TSV",
+                "id\tInt32\t\t\t\t\t\nmodify_column\tNullable(Int32)\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
 
     mysql_node.query("INSERT INTO test_database.test_table_2 VALUES(1, 2), (3, NULL)")
     check_query(clickhouse_node, "SELECT * FROM test_database.test_table_2 ORDER BY id FORMAT TSV", "1\t2\n3\t\\N\n")
@@ -299,29 +335,38 @@ def alter_modify_column_with_materialize_mysql_database(clickhouse_node, mysql_n
 
 def alter_rename_table_with_materialize_mysql_database(clickhouse_node, mysql_node, service_name):
     mysql_node.query("CREATE DATABASE test_database DEFAULT CHARACTER SET 'utf8'")
-    mysql_node.query("CREATE TABLE test_database.test_table_1 (id INT NOT NULL PRIMARY KEY, drop_column INT) ENGINE = InnoDB;")
+    mysql_node.query(
+        "CREATE TABLE test_database.test_table_1 (id INT NOT NULL PRIMARY KEY, drop_column INT) ENGINE = InnoDB;")
 
-    mysql_node.query("ALTER TABLE test_database.test_table_1 DROP COLUMN drop_column, RENAME TO test_database.test_table_2, RENAME TO test_database.test_table_3")
+    mysql_node.query(
+        "ALTER TABLE test_database.test_table_1 DROP COLUMN drop_column, RENAME TO test_database.test_table_2, RENAME TO test_database.test_table_3")
 
     # create mapping
     clickhouse_node.query(
-        "CREATE DATABASE test_database ENGINE = MaterializeMySQL('{}:3306', 'test_database', 'root', 'clickhouse')".format(service_name))
+        "CREATE DATABASE test_database ENGINE = MaterializeMySQL('{}:3306', 'test_database', 'root', 'clickhouse')".format(
+            service_name))
 
     assert "test_database" in clickhouse_node.query("SHOW DATABASES")
     check_query(clickhouse_node, "SHOW TABLES FROM test_database FORMAT TSV", "test_table_3\n")
-    check_query(clickhouse_node, "DESC test_database.test_table_3 FORMAT TSV", "id\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
-    mysql_node.query("CREATE TABLE test_database.test_table_1 (id INT NOT NULL PRIMARY KEY, drop_column INT NOT NULL) ENGINE = InnoDB;")
+    check_query(clickhouse_node, "DESC test_database.test_table_3 FORMAT TSV",
+                "id\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
+    mysql_node.query(
+        "CREATE TABLE test_database.test_table_1 (id INT NOT NULL PRIMARY KEY, drop_column INT NOT NULL) ENGINE = InnoDB;")
     check_query(clickhouse_node, "SHOW TABLES FROM test_database FORMAT TSV", "test_table_1\ntest_table_3\n")
-    check_query(clickhouse_node, "DESC test_database.test_table_1 FORMAT TSV", "id\tInt32\t\t\t\t\t\ndrop_column\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
-    mysql_node.query("ALTER TABLE test_database.test_table_1 DROP COLUMN drop_column, RENAME TO test_database.test_table_2, RENAME TO test_database.test_table_4")
+    check_query(clickhouse_node, "DESC test_database.test_table_1 FORMAT TSV",
+                "id\tInt32\t\t\t\t\t\ndrop_column\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
+    mysql_node.query(
+        "ALTER TABLE test_database.test_table_1 DROP COLUMN drop_column, RENAME TO test_database.test_table_2, RENAME TO test_database.test_table_4")
     check_query(clickhouse_node, "SHOW TABLES FROM test_database FORMAT TSV", "test_table_3\ntest_table_4\n")
-    check_query(clickhouse_node, "DESC test_database.test_table_4 FORMAT TSV", "id\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
+    check_query(clickhouse_node, "DESC test_database.test_table_4 FORMAT TSV",
+                "id\tInt32\t\t\t\t\t\n_sign\tInt8\tMATERIALIZED\t1\t\t\t\n_version\tUInt64\tMATERIALIZED\t1\t\t\t\n")
 
     mysql_node.query("INSERT INTO test_database.test_table_4 VALUES(1), (2), (3), (4), (5)")
     check_query(clickhouse_node, "SELECT * FROM test_database.test_table_4 ORDER BY id FORMAT TSV", "1\n2\n3\n4\n5\n")
 
     clickhouse_node.query("DROP DATABASE test_database")
     mysql_node.query("DROP DATABASE test_database")
+
 
 def query_event_with_empty_transaction(clickhouse_node, mysql_node, service_name):
     mysql_node.query("CREATE DATABASE test_database")

--- a/tests/integration/test_materialize_mysql_database/test.py
+++ b/tests/integration/test_materialize_mysql_database/test.py
@@ -4,9 +4,9 @@ import time
 
 import pymysql.cursors
 import pytest
+from helpers.cluster import ClickHouseCluster, get_docker_compose_path
 
 import materialize_with_ddl
-from helpers.cluster import ClickHouseCluster, get_docker_compose_path
 
 DOCKER_COMPOSE_PATH = get_docker_compose_path()
 
@@ -33,7 +33,8 @@ class MySQLNodeInstance:
 
     def alloc_connection(self):
         if self.mysql_connection is None:
-            self.mysql_connection = pymysql.connect(user=self.user, password=self.password, host=self.hostname, port=self.port, autocommit=True)
+            self.mysql_connection = pymysql.connect(user=self.user, password=self.password, host=self.hostname,
+                                                    port=self.port, autocommit=True)
         return self.mysql_connection
 
     def query(self, execution_query):
@@ -65,12 +66,14 @@ def started_mysql_5_7():
     docker_compose = os.path.join(DOCKER_COMPOSE_PATH, 'docker_compose_mysql.yml')
 
     try:
-        subprocess.check_call(['docker-compose', '-p', cluster.project_name, '-f', docker_compose, 'up', '--no-recreate', '-d'])
+        subprocess.check_call(
+            ['docker-compose', '-p', cluster.project_name, '-f', docker_compose, 'up', '--no-recreate', '-d'])
         mysql_node.wait_mysql_to_start(120)
         yield mysql_node
     finally:
         mysql_node.close()
-        subprocess.check_call(['docker-compose', '-p', cluster.project_name, '-f', docker_compose, 'down', '--volumes', '--remove-orphans'])
+        subprocess.check_call(['docker-compose', '-p', cluster.project_name, '-f', docker_compose, 'down', '--volumes',
+                               '--remove-orphans'])
 
 
 @pytest.fixture(scope="module")
@@ -79,12 +82,14 @@ def started_mysql_8_0():
     docker_compose = os.path.join(DOCKER_COMPOSE_PATH, 'docker_compose_mysql_8_0.yml')
 
     try:
-        subprocess.check_call(['docker-compose', '-p', cluster.project_name, '-f', docker_compose, 'up', '--no-recreate', '-d'])
+        subprocess.check_call(
+            ['docker-compose', '-p', cluster.project_name, '-f', docker_compose, 'up', '--no-recreate', '-d'])
         mysql_node.wait_mysql_to_start(120)
         yield mysql_node
     finally:
         mysql_node.close()
-        subprocess.check_call(['docker-compose', '-p', cluster.project_name, '-f', docker_compose, 'down', '--volumes', '--remove-orphans'])
+        subprocess.check_call(['docker-compose', '-p', cluster.project_name, '-f', docker_compose, 'down', '--volumes',
+                               '--remove-orphans'])
 
 
 def test_materialize_database_dml_with_mysql_5_7(started_cluster, started_mysql_5_7):
@@ -94,19 +99,25 @@ def test_materialize_database_dml_with_mysql_5_7(started_cluster, started_mysql_
 def test_materialize_database_dml_with_mysql_8_0(started_cluster, started_mysql_8_0):
     materialize_with_ddl.dml_with_materialize_mysql_database(clickhouse_node, started_mysql_8_0, "mysql8_0")
 
+
 def test_materialize_database_ddl_with_mysql_5_7(started_cluster, started_mysql_5_7):
     try:
         materialize_with_ddl.drop_table_with_materialize_mysql_database(clickhouse_node, started_mysql_5_7, "mysql1")
         materialize_with_ddl.create_table_with_materialize_mysql_database(clickhouse_node, started_mysql_5_7, "mysql1")
         materialize_with_ddl.rename_table_with_materialize_mysql_database(clickhouse_node, started_mysql_5_7, "mysql1")
-        materialize_with_ddl.alter_add_column_with_materialize_mysql_database(clickhouse_node, started_mysql_5_7, "mysql1")
-        materialize_with_ddl.alter_drop_column_with_materialize_mysql_database(clickhouse_node, started_mysql_5_7, "mysql1")
+        materialize_with_ddl.alter_add_column_with_materialize_mysql_database(clickhouse_node, started_mysql_5_7,
+                                                                              "mysql1")
+        materialize_with_ddl.alter_drop_column_with_materialize_mysql_database(clickhouse_node, started_mysql_5_7,
+                                                                               "mysql1")
         # mysql 5.7 cannot support alter rename column
         # materialize_with_ddl.alter_rename_column_with_materialize_mysql_database(clickhouse_node, started_mysql_5_7, "mysql1")
-        materialize_with_ddl.alter_rename_table_with_materialize_mysql_database(clickhouse_node, started_mysql_5_7, "mysql1")
-        materialize_with_ddl.alter_modify_column_with_materialize_mysql_database(clickhouse_node, started_mysql_5_7, "mysql1")
+        materialize_with_ddl.alter_rename_table_with_materialize_mysql_database(clickhouse_node, started_mysql_5_7,
+                                                                                "mysql1")
+        materialize_with_ddl.alter_modify_column_with_materialize_mysql_database(clickhouse_node, started_mysql_5_7,
+                                                                                 "mysql1")
     except:
-        print(clickhouse_node.query("select '\n', thread_id, query_id, arrayStringConcat(arrayMap(x -> concat(demangle(addressToSymbol(x)), '\n    ', addressToLine(x)), trace), '\n') AS sym from system.stack_trace format TSVRaw"))
+        print(clickhouse_node.query(
+            "select '\n', thread_id, query_id, arrayStringConcat(arrayMap(x -> concat(demangle(addressToSymbol(x)), '\n    ', addressToLine(x)), trace), '\n') AS sym from system.stack_trace format TSVRaw"))
         raise
 
 
@@ -114,14 +125,21 @@ def test_materialize_database_ddl_with_mysql_8_0(started_cluster, started_mysql_
     materialize_with_ddl.drop_table_with_materialize_mysql_database(clickhouse_node, started_mysql_8_0, "mysql8_0")
     materialize_with_ddl.create_table_with_materialize_mysql_database(clickhouse_node, started_mysql_8_0, "mysql8_0")
     materialize_with_ddl.rename_table_with_materialize_mysql_database(clickhouse_node, started_mysql_8_0, "mysql8_0")
-    materialize_with_ddl.alter_add_column_with_materialize_mysql_database(clickhouse_node, started_mysql_8_0, "mysql8_0")
-    materialize_with_ddl.alter_drop_column_with_materialize_mysql_database(clickhouse_node, started_mysql_8_0, "mysql8_0")
-    materialize_with_ddl.alter_rename_table_with_materialize_mysql_database(clickhouse_node, started_mysql_8_0, "mysql8_0")
-    materialize_with_ddl.alter_rename_column_with_materialize_mysql_database(clickhouse_node, started_mysql_8_0, "mysql8_0")
-    materialize_with_ddl.alter_modify_column_with_materialize_mysql_database(clickhouse_node, started_mysql_8_0, "mysql8_0")
+    materialize_with_ddl.alter_add_column_with_materialize_mysql_database(clickhouse_node, started_mysql_8_0,
+                                                                          "mysql8_0")
+    materialize_with_ddl.alter_drop_column_with_materialize_mysql_database(clickhouse_node, started_mysql_8_0,
+                                                                           "mysql8_0")
+    materialize_with_ddl.alter_rename_table_with_materialize_mysql_database(clickhouse_node, started_mysql_8_0,
+                                                                            "mysql8_0")
+    materialize_with_ddl.alter_rename_column_with_materialize_mysql_database(clickhouse_node, started_mysql_8_0,
+                                                                             "mysql8_0")
+    materialize_with_ddl.alter_modify_column_with_materialize_mysql_database(clickhouse_node, started_mysql_8_0,
+                                                                             "mysql8_0")
+
 
 def test_materialize_database_ddl_with_empty_transaction_5_7(started_cluster, started_mysql_5_7):
     materialize_with_ddl.query_event_with_empty_transaction(clickhouse_node, started_mysql_5_7, "mysql1")
+
 
 def test_materialize_database_ddl_with_empty_transaction_8_0(started_cluster, started_mysql_8_0):
     materialize_with_ddl.query_event_with_empty_transaction(clickhouse_node, started_mysql_8_0, "mysql8_0")

--- a/tests/integration/test_merge_table_over_distributed/test.py
+++ b/tests/integration/test_merge_table_over_distributed/test.py
@@ -1,13 +1,13 @@
 from contextlib import contextmanager
 
 import pytest
-
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 
 node1 = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml'])
 node2 = cluster.add_instance('node2', main_configs=['configs/remote_servers.xml'])
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -36,28 +36,29 @@ CREATE TABLE merge_table(id UInt32, val String) ENGINE = Merge(default, '^distri
 
 
 def test_global_in(started_cluster):
-    assert node1.query("SELECT val FROM distributed_table WHERE id GLOBAL IN (SELECT toUInt32(3 - id) FROM local_table)").rstrip() \
-        == 'node2'
+    assert node1.query(
+        "SELECT val FROM distributed_table WHERE id GLOBAL IN (SELECT toUInt32(3 - id) FROM local_table)").rstrip() \
+           == 'node2'
 
-    assert node1.query("SELECT val FROM merge_table WHERE id GLOBAL IN (SELECT toUInt32(3 - id) FROM local_table)").rstrip() \
-        == 'node2'
+    assert node1.query(
+        "SELECT val FROM merge_table WHERE id GLOBAL IN (SELECT toUInt32(3 - id) FROM local_table)").rstrip() \
+           == 'node2'
 
 
 def test_filtering(started_cluster):
-
     assert node1.query("SELECT id, val FROM merge_table WHERE id = 1").rstrip() == '1\tnode1'
 
     assert node1.query("SELECT id + 1, val FROM merge_table WHERE id = 1").rstrip() == '2\tnode1'
 
     assert node1.query("SELECT id + 1 FROM merge_table WHERE val = 'node1'").rstrip() == '2'
 
-    assert node1.query("SELECT id + 1, val FROM merge_table PREWHERE id = 1 WHERE _table != '_dummy'").rstrip() == '2\tnode1'
+    assert node1.query(
+        "SELECT id + 1, val FROM merge_table PREWHERE id = 1 WHERE _table != '_dummy'").rstrip() == '2\tnode1'
 
     assert node1.query("SELECT count() FROM merge_table PREWHERE id = 1").rstrip() == '1'
 
 
 def test_select_table_name_from_merge_over_distributed(started_cluster):
-
     node1.query("INSERT INTO local_table_2 VALUES (1, 'node1')")
     node2.query("INSERT INTO local_table_2 VALUES (2, 'node2')")
 

--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -14,7 +14,9 @@ logging.getLogger().addHandler(logging.StreamHandler())
 def cluster():
     try:
         cluster = ClickHouseCluster(__file__)
-        cluster.add_instance("node", main_configs=["configs/config.d/storage_conf.xml", "configs/config.d/bg_processing_pool_conf.xml", "configs/config.d/log_conf.xml"], user_configs=[], with_minio=True)
+        cluster.add_instance("node", main_configs=["configs/config.d/storage_conf.xml",
+                                                   "configs/config.d/bg_processing_pool_conf.xml",
+                                                   "configs/config.d/log_conf.xml"], user_configs=[], with_minio=True)
         logging.info("Starting cluster...")
         cluster.start()
         logging.info("Cluster started")
@@ -36,7 +38,7 @@ def random_string(length):
 
 
 def generate_values(date_str, count, sign=1):
-    data = [[date_str, sign*(i + 1), random_string(10)] for i in range(count)]
+    data = [[date_str, sign * (i + 1), random_string(10)] for i in range(count)]
     data.sort(key=lambda tup: tup[1])
     return ",".join(["('{}',{},'{}')".format(x, y, z) for x, y, z in data])
 
@@ -103,7 +105,7 @@ def test_simple_insert_select(cluster, min_rows_for_wide_part, files_per_part):
     values2 = generate_values('2020-01-04', 4096)
     node.query("INSERT INTO s3_test VALUES {}".format(values2))
     assert node.query("SELECT * FROM s3_test ORDER BY dt, id FORMAT Values") == values1 + "," + values2
-    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + files_per_part*2
+    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + files_per_part * 2
 
     assert node.query("SELECT count(*) FROM s3_test where id = 1 FORMAT Values") == "(2)"
 
@@ -132,7 +134,8 @@ def test_insert_same_partition_and_merge(cluster, merge_vertical):
     node.query("INSERT INTO s3_test VALUES {}".format(generate_values('2020-01-03', 4096, -1)))
     assert node.query("SELECT sum(id) FROM s3_test FORMAT Values") == "(0)"
     assert node.query("SELECT count(distinct(id)) FROM s3_test FORMAT Values") == "(8192)"
-    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD_PER_PART_WIDE*6 + FILES_OVERHEAD
+    assert len(
+        list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD_PER_PART_WIDE * 6 + FILES_OVERHEAD
 
     node.query("SYSTEM START MERGES s3_test")
     # Wait for merges and old parts deletion
@@ -161,7 +164,8 @@ def test_alter_table_columns(cluster):
 
     assert node.query("SELECT sum(col1) FROM s3_test FORMAT Values") == "(8192)"
     assert node.query("SELECT sum(col1) FROM s3_test WHERE id > 0 FORMAT Values") == "(4096)"
-    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE + FILES_OVERHEAD_PER_COLUMN
+    assert len(list(minio.list_objects(cluster.minio_bucket,
+                                       'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE + FILES_OVERHEAD_PER_COLUMN
 
     node.query("ALTER TABLE s3_test MODIFY COLUMN col1 String", settings={"mutations_sync": 2})
 
@@ -170,7 +174,8 @@ def test_alter_table_columns(cluster):
 
     assert node.query("SELECT distinct(col1) FROM s3_test FORMAT Values") == "('1')"
     # and file with mutation
-    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == (FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE + FILES_OVERHEAD_PER_COLUMN + 1)
+    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == (
+            FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE + FILES_OVERHEAD_PER_COLUMN + 1)
 
     node.query("ALTER TABLE s3_test DROP COLUMN col1", settings={"mutations_sync": 2})
 
@@ -178,7 +183,8 @@ def test_alter_table_columns(cluster):
     time.sleep(3)
 
     # and 2 files with mutations
-    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE + 2
+    assert len(
+        list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE + 2
 
 
 def test_attach_detach_partition(cluster):
@@ -190,15 +196,18 @@ def test_attach_detach_partition(cluster):
     node.query("INSERT INTO s3_test VALUES {}".format(generate_values('2020-01-03', 4096)))
     node.query("INSERT INTO s3_test VALUES {}".format(generate_values('2020-01-04', 4096)))
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(8192)"
-    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE*2
+    assert len(
+        list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2
 
     node.query("ALTER TABLE s3_test DETACH PARTITION '2020-01-03'")
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(4096)"
-    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE*2
+    assert len(
+        list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2
 
     node.query("ALTER TABLE s3_test ATTACH PARTITION '2020-01-03'")
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(8192)"
-    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE*2
+    assert len(
+        list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2
 
     node.query("ALTER TABLE s3_test DROP PARTITION '2020-01-03'")
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(4096)"
@@ -219,7 +228,8 @@ def test_move_partition_to_another_disk(cluster):
     node.query("INSERT INTO s3_test VALUES {}".format(generate_values('2020-01-03', 4096)))
     node.query("INSERT INTO s3_test VALUES {}".format(generate_values('2020-01-04', 4096)))
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(8192)"
-    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE*2
+    assert len(
+        list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2
 
     node.query("ALTER TABLE s3_test MOVE PARTITION '2020-01-04' TO DISK 'hdd'")
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(8192)"
@@ -227,7 +237,8 @@ def test_move_partition_to_another_disk(cluster):
 
     node.query("ALTER TABLE s3_test MOVE PARTITION '2020-01-04' TO DISK 's3'")
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(8192)"
-    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE*2
+    assert len(
+        list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2
 
 
 def test_table_manipulations(cluster):
@@ -241,7 +252,8 @@ def test_table_manipulations(cluster):
 
     node.query("RENAME TABLE s3_test TO s3_renamed")
     assert node.query("SELECT count(*) FROM s3_renamed FORMAT Values") == "(8192)"
-    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE*2
+    assert len(
+        list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2
     node.query("RENAME TABLE s3_renamed TO s3_test")
 
     assert node.query("CHECK TABLE s3_test FORMAT Values") == "(1)"
@@ -249,7 +261,8 @@ def test_table_manipulations(cluster):
     node.query("DETACH TABLE s3_test")
     node.query("ATTACH TABLE s3_test")
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(8192)"
-    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE*2
+    assert len(
+        list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2
 
     node.query("TRUNCATE TABLE s3_test")
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(0)"
@@ -268,7 +281,8 @@ def test_move_replace_partition_to_another_table(cluster):
     node.query("INSERT INTO s3_test VALUES {}".format(generate_values('2020-01-06', 4096, -1)))
     assert node.query("SELECT sum(id) FROM s3_test FORMAT Values") == "(0)"
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(16384)"
-    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE*4
+    assert len(
+        list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 4
 
     create_table(cluster, "s3_clone")
 
@@ -279,14 +293,16 @@ def test_move_replace_partition_to_another_table(cluster):
     assert node.query("SELECT sum(id) FROM s3_clone FORMAT Values") == "(0)"
     assert node.query("SELECT count(*) FROM s3_clone FORMAT Values") == "(8192)"
     # Number of objects in S3 should be unchanged.
-    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD*2 + FILES_OVERHEAD_PER_PART_WIDE*4
+    assert len(list(
+        minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD * 2 + FILES_OVERHEAD_PER_PART_WIDE * 4
 
     # Add new partitions to source table, but with different values and replace them from copied table.
     node.query("INSERT INTO s3_test VALUES {}".format(generate_values('2020-01-03', 4096, -1)))
     node.query("INSERT INTO s3_test VALUES {}".format(generate_values('2020-01-05', 4096)))
     assert node.query("SELECT sum(id) FROM s3_test FORMAT Values") == "(0)"
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(16384)"
-    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD*2 + FILES_OVERHEAD_PER_PART_WIDE*6
+    assert len(list(
+        minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD * 2 + FILES_OVERHEAD_PER_PART_WIDE * 6
 
     node.query("ALTER TABLE s3_test REPLACE PARTITION '2020-01-03' FROM s3_clone")
     node.query("ALTER TABLE s3_test REPLACE PARTITION '2020-01-05' FROM s3_clone")
@@ -297,23 +313,26 @@ def test_move_replace_partition_to_another_table(cluster):
 
     # Wait for outdated partitions deletion.
     time.sleep(3)
-    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD*2 + FILES_OVERHEAD_PER_PART_WIDE*4
+    assert len(list(
+        minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD * 2 + FILES_OVERHEAD_PER_PART_WIDE * 4
 
     node.query("DROP TABLE s3_clone NO DELAY")
     time.sleep(1)
     assert node.query("SELECT sum(id) FROM s3_test FORMAT Values") == "(0)"
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(16384)"
     # Data should remain in S3
-    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE*4
+    assert len(
+        list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 4
 
     node.query("ALTER TABLE s3_test FREEZE")
     # Number S3 objects should be unchanged.
-    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE*4
+    assert len(
+        list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 4
 
     node.query("DROP TABLE s3_test NO DELAY")
     time.sleep(1)
     # Backup data should remain in S3.
-    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD_PER_PART_WIDE*4
+    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == FILES_OVERHEAD_PER_PART_WIDE * 4
 
     for obj in list(minio.list_objects(cluster.minio_bucket, 'data/')):
         minio.remove_object(cluster.minio_bucket, obj.object_name)

--- a/tests/integration/test_mutations_hardlinks/test.py
+++ b/tests/integration/test_mutations_hardlinks/test.py
@@ -1,15 +1,15 @@
-import pytest
-
 import os
 import time
-from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry
 from multiprocessing.dummy import Pool
 
+import pytest
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 
 node1 = cluster.add_instance('node1')
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -38,20 +38,23 @@ def check_exists(table, part_path, column_file):
 
 
 def test_update_mutation(started_cluster):
-    node1.query("CREATE TABLE table_for_update(key UInt64, value1 UInt64, value2 String) ENGINE MergeTree() ORDER BY tuple()")
+    node1.query(
+        "CREATE TABLE table_for_update(key UInt64, value1 UInt64, value2 String) ENGINE MergeTree() ORDER BY tuple()")
 
     node1.query("INSERT INTO table_for_update SELECT number, number, toString(number) from numbers(100)")
 
     assert int(node1.query("SELECT sum(value1) FROM table_for_update").strip()) == sum(range(100))
 
-    node1.query("ALTER TABLE table_for_update UPDATE value1 = value1 * value1 WHERE 1", settings={"mutations_sync" : "2"})
+    node1.query("ALTER TABLE table_for_update UPDATE value1 = value1 * value1 WHERE 1",
+                settings={"mutations_sync": "2"})
     assert int(node1.query("SELECT sum(value1) FROM table_for_update").strip()) == sum(i * i for i in range(100))
 
     check_hardlinks("table_for_update", "all_1_1_0_2", "key.bin", 2)
     check_hardlinks("table_for_update", "all_1_1_0_2", "value2.bin", 2)
     check_hardlinks("table_for_update", "all_1_1_0_2", "value1.bin", 1)
 
-    node1.query("ALTER TABLE table_for_update UPDATE key=key, value1=value1, value2=value2 WHERE 1", settings={"mutations_sync": "2"})
+    node1.query("ALTER TABLE table_for_update UPDATE key=key, value1=value1, value2=value2 WHERE 1",
+                settings={"mutations_sync": "2"})
 
     assert int(node1.query("SELECT sum(value1) FROM table_for_update").strip()) == sum(i * i for i in range(100))
 
@@ -61,13 +64,14 @@ def test_update_mutation(started_cluster):
 
 
 def test_modify_mutation(started_cluster):
-    node1.query("CREATE TABLE table_for_modify(key UInt64, value1 UInt64, value2 String) ENGINE MergeTree() ORDER BY tuple()")
+    node1.query(
+        "CREATE TABLE table_for_modify(key UInt64, value1 UInt64, value2 String) ENGINE MergeTree() ORDER BY tuple()")
 
     node1.query("INSERT INTO table_for_modify SELECT number, number, toString(number) from numbers(100)")
 
     assert int(node1.query("SELECT sum(value1) FROM table_for_modify").strip()) == sum(range(100))
 
-    node1.query("ALTER TABLE table_for_modify MODIFY COLUMN value2 UInt64", settings={"mutations_sync" : "2"})
+    node1.query("ALTER TABLE table_for_modify MODIFY COLUMN value2 UInt64", settings={"mutations_sync": "2"})
 
     assert int(node1.query("SELECT sum(value2) FROM table_for_modify").strip()) == sum(range(100))
 
@@ -77,7 +81,8 @@ def test_modify_mutation(started_cluster):
 
 
 def test_drop_mutation(started_cluster):
-    node1.query("CREATE TABLE table_for_drop(key UInt64, value1 UInt64, value2 String) ENGINE MergeTree() ORDER BY tuple()")
+    node1.query(
+        "CREATE TABLE table_for_drop(key UInt64, value1 UInt64, value2 String) ENGINE MergeTree() ORDER BY tuple()")
 
     node1.query("INSERT INTO table_for_drop SELECT number, number, toString(number) from numbers(100)")
 
@@ -95,7 +100,8 @@ def test_drop_mutation(started_cluster):
 
 
 def test_delete_and_drop_mutation(started_cluster):
-    node1.query("CREATE TABLE table_for_delete_and_drop(key UInt64, value1 UInt64, value2 String) ENGINE MergeTree() ORDER BY tuple()")
+    node1.query(
+        "CREATE TABLE table_for_delete_and_drop(key UInt64, value1 UInt64, value2 String) ENGINE MergeTree() ORDER BY tuple()")
 
     node1.query("INSERT INTO table_for_delete_and_drop SELECT number, number, toString(number) from numbers(100)")
 
@@ -110,7 +116,8 @@ def test_delete_and_drop_mutation(started_cluster):
     p.apply_async(mutate)
 
     for _ in range(1, 100):
-        result = node1.query("SELECT COUNT() FROM system.mutations WHERE table = 'table_for_delete_and_drop' and is_done=0")
+        result = node1.query(
+            "SELECT COUNT() FROM system.mutations WHERE table = 'table_for_delete_and_drop' and is_done=0")
         try:
             if int(result.strip()) == 2:
                 break
@@ -122,7 +129,8 @@ def test_delete_and_drop_mutation(started_cluster):
 
     node1.query("SYSTEM START MERGES")
 
-    assert_eq_with_retry(node1, "SELECT COUNT() FROM table_for_delete_and_drop", str(sum(1 for i in range(100) if i % 2 != 0)))
+    assert_eq_with_retry(node1, "SELECT COUNT() FROM table_for_delete_and_drop",
+                         str(sum(1 for i in range(100) if i % 2 != 0)))
 
     check_hardlinks("table_for_delete_and_drop", "all_1_1_0_3", "key.bin", 1)
     check_hardlinks("table_for_delete_and_drop", "all_1_1_0_3", "value1.bin", 1)

--- a/tests/integration/test_mutations_with_merge_tree/test.py
+++ b/tests/integration/test_mutations_with_merge_tree/test.py
@@ -1,21 +1,22 @@
-from contextlib import contextmanager
-
 import time
-import pytest
 
+import pytest
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 
-instance_test_mutations = cluster.add_instance('test_mutations_with_merge_tree', main_configs=['configs/config.xml'], user_configs=['configs/users.xml'])
+instance_test_mutations = cluster.add_instance('test_mutations_with_merge_tree', main_configs=['configs/config.xml'],
+                                               user_configs=['configs/users.xml'])
 
 
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
         cluster.start()
-        instance_test_mutations.query('''CREATE TABLE test_mutations_with_ast_elements(date Date, a UInt64, b String) ENGINE = MergeTree(date, (a, date), 8192)''')
-        instance_test_mutations.query('''INSERT INTO test_mutations_with_ast_elements SELECT '2019-07-29' AS date, 1, toString(number) FROM numbers(1)''')
+        instance_test_mutations.query(
+            '''CREATE TABLE test_mutations_with_ast_elements(date Date, a UInt64, b String) ENGINE = MergeTree(date, (a, date), 8192)''')
+        instance_test_mutations.query(
+            '''INSERT INTO test_mutations_with_ast_elements SELECT '2019-07-29' AS date, 1, toString(number) FROM numbers(1)''')
         yield cluster
     finally:
         cluster.shutdown()
@@ -26,31 +27,36 @@ def test_mutations_with_merge_background_task(started_cluster):
 
     ## The number of asts per query is 15
     for execution_times_for_mutation in range(100):
-        instance_test_mutations.query('''ALTER TABLE test_mutations_with_ast_elements DELETE WHERE 1 = 1 AND toUInt32(b) IN (1)''')
+        instance_test_mutations.query(
+            '''ALTER TABLE test_mutations_with_ast_elements DELETE WHERE 1 = 1 AND toUInt32(b) IN (1)''')
 
     all_done = False
-    for wait_times_for_mutation in range(100): # wait for replication 80 seconds max
+    for wait_times_for_mutation in range(100):  # wait for replication 80 seconds max
         time.sleep(0.8)
 
         def get_done_mutations(instance):
             instance_test_mutations.query('''DETACH TABLE test_mutations_with_ast_elements''')
             instance_test_mutations.query('''ATTACH TABLE test_mutations_with_ast_elements''')
-            return int(instance.query("SELECT sum(is_done) FROM system.mutations WHERE table = 'test_mutations_with_ast_elements'").rstrip())
+            return int(instance.query(
+                "SELECT sum(is_done) FROM system.mutations WHERE table = 'test_mutations_with_ast_elements'").rstrip())
 
         if get_done_mutations(instance_test_mutations) == 100:
             all_done = True
             break
 
-    print instance_test_mutations.query("SELECT mutation_id, command, parts_to_do, is_done FROM system.mutations WHERE table = 'test_mutations_with_ast_elements' FORMAT TSVWithNames")
+    print instance_test_mutations.query(
+        "SELECT mutation_id, command, parts_to_do, is_done FROM system.mutations WHERE table = 'test_mutations_with_ast_elements' FORMAT TSVWithNames")
     assert all_done
+
 
 def test_mutations_with_truncate_table(started_cluster):
     instance_test_mutations.query('''SYSTEM STOP MERGES test_mutations_with_ast_elements''')
 
     ## The number of asts per query is 15
     for execute_number in range(100):
-        instance_test_mutations.query('''ALTER TABLE test_mutations_with_ast_elements DELETE WHERE 1 = 1 AND toUInt32(b) IN (1)''')
+        instance_test_mutations.query(
+            '''ALTER TABLE test_mutations_with_ast_elements DELETE WHERE 1 = 1 AND toUInt32(b) IN (1)''')
 
     instance_test_mutations.query("TRUNCATE TABLE test_mutations_with_ast_elements")
-    assert instance_test_mutations.query("SELECT COUNT() FROM system.mutations WHERE table = 'test_mutations_with_ast_elements'").rstrip() == '0'
-
+    assert instance_test_mutations.query(
+        "SELECT COUNT() FROM system.mutations WHERE table = 'test_mutations_with_ast_elements'").rstrip() == '0'

--- a/tests/integration/test_mysql_database_engine/test.py
+++ b/tests/integration/test_mysql_database_engine/test.py
@@ -1,13 +1,11 @@
-import time
 import contextlib
+import time
+from string import Template
 
 import pymysql.cursors
 import pytest
-
-from helpers.cluster import ClickHouseCluster
 from helpers.client import QueryRuntimeException
-
-from string import Template
+from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 clickhouse_node = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml'], with_mysql=True)
@@ -32,7 +30,8 @@ class MySQLNodeInstance:
 
     def query(self, execution_query):
         if self.mysql_connection is None:
-            self.mysql_connection = pymysql.connect(user=self.user, password=self.password, host=self.hostname, port=self.port)
+            self.mysql_connection = pymysql.connect(user=self.user, password=self.password, host=self.hostname,
+                                                    port=self.port)
         with self.mysql_connection.cursor() as cursor:
             def execute(query):
                 res = cursor.execute(query)
@@ -59,19 +58,25 @@ def test_mysql_ddl_for_mysql_database(started_cluster):
     with contextlib.closing(MySQLNodeInstance('root', 'clickhouse', '127.0.0.1', port=3308)) as mysql_node:
         mysql_node.query("CREATE DATABASE test_database DEFAULT CHARACTER SET 'utf8'")
 
-        clickhouse_node.query("CREATE DATABASE test_database ENGINE = MySQL('mysql1:3306', 'test_database', 'root', 'clickhouse')")
+        clickhouse_node.query(
+            "CREATE DATABASE test_database ENGINE = MySQL('mysql1:3306', 'test_database', 'root', 'clickhouse')")
         assert 'test_database' in clickhouse_node.query('SHOW DATABASES')
 
-        mysql_node.query('CREATE TABLE `test_database`.`test_table` ( `id` int(11) NOT NULL, PRIMARY KEY (`id`) ) ENGINE=InnoDB;')
+        mysql_node.query(
+            'CREATE TABLE `test_database`.`test_table` ( `id` int(11) NOT NULL, PRIMARY KEY (`id`) ) ENGINE=InnoDB;')
         assert 'test_table' in clickhouse_node.query('SHOW TABLES FROM test_database')
 
-        time.sleep(3)  # Because the unit of MySQL modification time is seconds, modifications made in the same second cannot be obtained
+        time.sleep(
+            3)  # Because the unit of MySQL modification time is seconds, modifications made in the same second cannot be obtained
         mysql_node.query('ALTER TABLE `test_database`.`test_table` ADD COLUMN `add_column` int(11)')
-        assert 'add_column' in clickhouse_node.query("SELECT name FROM system.columns WHERE table = 'test_table' AND database = 'test_database'")
+        assert 'add_column' in clickhouse_node.query(
+            "SELECT name FROM system.columns WHERE table = 'test_table' AND database = 'test_database'")
 
-        time.sleep(3)  # Because the unit of MySQL modification time is seconds, modifications made in the same second cannot be obtained
+        time.sleep(
+            3)  # Because the unit of MySQL modification time is seconds, modifications made in the same second cannot be obtained
         mysql_node.query('ALTER TABLE `test_database`.`test_table` DROP COLUMN `add_column`')
-        assert 'add_column' not in clickhouse_node.query("SELECT name FROM system.columns WHERE table = 'test_table' AND database = 'test_database'")
+        assert 'add_column' not in clickhouse_node.query(
+            "SELECT name FROM system.columns WHERE table = 'test_table' AND database = 'test_database'")
 
         mysql_node.query('DROP TABLE `test_database`.`test_table`;')
         assert 'test_table' not in clickhouse_node.query('SHOW TABLES FROM test_database')
@@ -85,9 +90,11 @@ def test_mysql_ddl_for_mysql_database(started_cluster):
 def test_clickhouse_ddl_for_mysql_database(started_cluster):
     with contextlib.closing(MySQLNodeInstance('root', 'clickhouse', '127.0.0.1', port=3308)) as mysql_node:
         mysql_node.query("CREATE DATABASE test_database DEFAULT CHARACTER SET 'utf8'")
-        mysql_node.query('CREATE TABLE `test_database`.`test_table` ( `id` int(11) NOT NULL, PRIMARY KEY (`id`) ) ENGINE=InnoDB;')
+        mysql_node.query(
+            'CREATE TABLE `test_database`.`test_table` ( `id` int(11) NOT NULL, PRIMARY KEY (`id`) ) ENGINE=InnoDB;')
 
-        clickhouse_node.query("CREATE DATABASE test_database ENGINE = MySQL('mysql1:3306', 'test_database', 'root', 'clickhouse')")
+        clickhouse_node.query(
+            "CREATE DATABASE test_database ENGINE = MySQL('mysql1:3306', 'test_database', 'root', 'clickhouse')")
 
         assert 'test_table' in clickhouse_node.query('SHOW TABLES FROM test_database')
         clickhouse_node.query("DROP TABLE test_database.test_table")
@@ -108,8 +115,10 @@ def test_clickhouse_ddl_for_mysql_database(started_cluster):
 def test_clickhouse_dml_for_mysql_database(started_cluster):
     with contextlib.closing(MySQLNodeInstance('root', 'clickhouse', '127.0.0.1', port=3308)) as mysql_node:
         mysql_node.query("CREATE DATABASE test_database DEFAULT CHARACTER SET 'utf8'")
-        mysql_node.query('CREATE TABLE `test_database`.`test_table` ( `i``d` int(11) NOT NULL, PRIMARY KEY (`i``d`)) ENGINE=InnoDB;')
-        clickhouse_node.query("CREATE DATABASE test_database ENGINE = MySQL('mysql1:3306', test_database, 'root', 'clickhouse')")
+        mysql_node.query(
+            'CREATE TABLE `test_database`.`test_table` ( `i``d` int(11) NOT NULL, PRIMARY KEY (`i``d`)) ENGINE=InnoDB;')
+        clickhouse_node.query(
+            "CREATE DATABASE test_database ENGINE = MySQL('mysql1:3306', test_database, 'root', 'clickhouse')")
 
         assert clickhouse_node.query("SELECT count() FROM `test_database`.`test_table`").rstrip() == '0'
         clickhouse_node.query("INSERT INTO `test_database`.`test_table`(`i``d`) select number from numbers(10000)")
@@ -130,8 +139,10 @@ def test_clickhouse_join_for_mysql_database(started_cluster):
                          "service VARCHAR(5) DEFAULT '' NOT NULL,"
                          "opco    VARCHAR(5) DEFAULT ''"
                          ")")
-        clickhouse_node.query("CREATE TABLE default.t1_remote_mysql AS mysql('mysql1:3306','test','t1_mysql_local','root','clickhouse')")
-        clickhouse_node.query("CREATE TABLE default.t2_remote_mysql AS mysql('mysql1:3306','test','t2_mysql_local','root','clickhouse')")
+        clickhouse_node.query(
+            "CREATE TABLE default.t1_remote_mysql AS mysql('mysql1:3306','test','t1_mysql_local','root','clickhouse')")
+        clickhouse_node.query(
+            "CREATE TABLE default.t2_remote_mysql AS mysql('mysql1:3306','test','t2_mysql_local','root','clickhouse')")
         assert clickhouse_node.query("SELECT s.pays "
                                      "FROM default.t1_remote_mysql AS s "
                                      "LEFT JOIN default.t1_remote_mysql AS s_ref "
@@ -143,7 +154,8 @@ def test_bad_arguments_for_mysql_database_engine(started_cluster):
     with contextlib.closing(MySQLNodeInstance('root', 'clickhouse', '127.0.0.1', port=3308)) as mysql_node:
         with pytest.raises(QueryRuntimeException) as exception:
             mysql_node.query("CREATE DATABASE IF NOT EXISTS test_bad_arguments DEFAULT CHARACTER SET 'utf8'")
-            clickhouse_node.query("CREATE DATABASE test_database_bad_arguments ENGINE = MySQL('mysql1:3306', test_bad_arguments, root, 'clickhouse')")
+            clickhouse_node.query(
+                "CREATE DATABASE test_database_bad_arguments ENGINE = MySQL('mysql1:3306', test_bad_arguments, root, 'clickhouse')")
         assert 'Database engine MySQL requested literal argument.' in str(exception.value)
         mysql_node.query("DROP DATABASE test_bad_arguments")
 
@@ -152,46 +164,57 @@ decimal_values = [0.123, 0.4, 5.67, 8.91011, 123456789.123, -0.123, -0.4, -5.67,
 timestamp_values = ['2015-05-18 07:40:01.123', '2019-09-16 19:20:11.123']
 timestamp_values_no_subsecond = ['2015-05-18 07:40:01', '2019-09-16 19:20:11']
 
+
 @pytest.mark.parametrize("case_name, mysql_type, expected_ch_type, mysql_values, setting_mysql_datatypes_support_level",
-[
-    ("decimal_default", "decimal NOT NULL", "Decimal(10, 0)", decimal_values, "decimal,datetime64"),
-    ("decimal_default_nullable", "decimal", "Nullable(Decimal(10, 0))", decimal_values, "decimal,datetime64"),
-    ("decimal_18_6", "decimal(18, 6) NOT NULL", "Decimal(18, 6)", decimal_values, "decimal,datetime64"),
-    ("decimal_38_6", "decimal(38, 6) NOT NULL", "Decimal(38, 6)", decimal_values, "decimal,datetime64"),
+                         [
+                             ("decimal_default", "decimal NOT NULL", "Decimal(10, 0)", decimal_values,
+                              "decimal,datetime64"),
+                             ("decimal_default_nullable", "decimal", "Nullable(Decimal(10, 0))", decimal_values,
+                              "decimal,datetime64"),
+                             ("decimal_18_6", "decimal(18, 6) NOT NULL", "Decimal(18, 6)", decimal_values,
+                              "decimal,datetime64"),
+                             ("decimal_38_6", "decimal(38, 6) NOT NULL", "Decimal(38, 6)", decimal_values,
+                              "decimal,datetime64"),
 
-    # Due to python DB driver roundtrip MySQL timestamp and datetime values
-    # are printed with 6 digits after decimal point, so to simplify tests a bit,
-    # we only validate precision of 0 and 6.
-    ("timestamp_default", "timestamp", "DateTime", timestamp_values, "decimal,datetime64"),
-    ("timestamp_6", "timestamp(6)", "DateTime64(6)", timestamp_values, "decimal,datetime64"),
-    ("datetime_default", "DATETIME NOT NULL", "DateTime64(0)", timestamp_values, "decimal,datetime64"),
-    ("datetime_6", "DATETIME(6) NOT NULL", "DateTime64(6)", timestamp_values, "decimal,datetime64"),
+                             # Due to python DB driver roundtrip MySQL timestamp and datetime values
+                             # are printed with 6 digits after decimal point, so to simplify tests a bit,
+                             # we only validate precision of 0 and 6.
+                             ("timestamp_default", "timestamp", "DateTime", timestamp_values, "decimal,datetime64"),
+                             ("timestamp_6", "timestamp(6)", "DateTime64(6)", timestamp_values, "decimal,datetime64"),
+                             ("datetime_default", "DATETIME NOT NULL", "DateTime64(0)", timestamp_values,
+                              "decimal,datetime64"),
+                             ("datetime_6", "DATETIME(6) NOT NULL", "DateTime64(6)", timestamp_values,
+                              "decimal,datetime64"),
 
-    # right now precision bigger than 39 is not supported by ClickHouse's Decimal, hence fall back to String
-    ("decimal_40_6", "decimal(40, 6) NOT NULL", "String", decimal_values, "decimal,datetime64"),
-    ("decimal_18_6", "decimal(18, 6) NOT NULL", "String", decimal_values, "datetime64"),
-    ("decimal_18_6", "decimal(18, 6) NOT NULL", "String", decimal_values, ""),
-    ("datetime_6", "DATETIME(6) NOT NULL", "DateTime", timestamp_values_no_subsecond, "decimal"),
-    ("datetime_6", "DATETIME(6) NOT NULL", "DateTime", timestamp_values_no_subsecond, ""),
-])
-def test_mysql_types(started_cluster, case_name, mysql_type, expected_ch_type, mysql_values, setting_mysql_datatypes_support_level):
+                             # right now precision bigger than 39 is not supported by ClickHouse's Decimal, hence fall back to String
+                             (
+                                     "decimal_40_6", "decimal(40, 6) NOT NULL", "String", decimal_values,
+                                     "decimal,datetime64"),
+                             ("decimal_18_6", "decimal(18, 6) NOT NULL", "String", decimal_values, "datetime64"),
+                             ("decimal_18_6", "decimal(18, 6) NOT NULL", "String", decimal_values, ""),
+                             ("datetime_6", "DATETIME(6) NOT NULL", "DateTime", timestamp_values_no_subsecond,
+                              "decimal"),
+                             ("datetime_6", "DATETIME(6) NOT NULL", "DateTime", timestamp_values_no_subsecond, ""),
+                         ])
+def test_mysql_types(started_cluster, case_name, mysql_type, expected_ch_type, mysql_values,
+                     setting_mysql_datatypes_support_level):
     """ Verify that values written to MySQL can be read on ClickHouse side via DB engine MySQL,
     or Table engine MySQL, or mysql() table function.
     Make sure that type is converted properly and values match exactly.
     """
 
     substitutes = dict(
-        mysql_db = 'decimal_support',
-        table_name = case_name,
-        mysql_type = mysql_type,
-        mysql_values = ', '.join('({})'.format(repr(x)) for x in mysql_values),
-        ch_mysql_db = 'mysql_db',
-        ch_mysql_table = 'mysql_table_engine_' + case_name,
-        expected_ch_type = expected_ch_type,
+        mysql_db='decimal_support',
+        table_name=case_name,
+        mysql_type=mysql_type,
+        mysql_values=', '.join('({})'.format(repr(x)) for x in mysql_values),
+        ch_mysql_db='mysql_db',
+        ch_mysql_table='mysql_table_engine_' + case_name,
+        expected_ch_type=expected_ch_type,
     )
 
     clickhouse_query_settings = dict(
-        mysql_datatypes_support_level = setting_mysql_datatypes_support_level
+        mysql_datatypes_support_level=setting_mysql_datatypes_support_level
     )
 
     def execute_query(node, query, **kwargs):
@@ -216,9 +239,8 @@ def test_mysql_types(started_cluster, case_name, mysql_type, expected_ch_type, m
         ])
 
         assert execute_query(mysql_node, "SELECT COUNT(*) FROM ${mysql_db}.${table_name}") \
-            == \
-            "{}".format(len(mysql_values))
-
+               == \
+               "{}".format(len(mysql_values))
 
         # MySQL TABLE ENGINE
         execute_query(clickhouse_node, [
@@ -229,17 +251,16 @@ def test_mysql_types(started_cluster, case_name, mysql_type, expected_ch_type, m
         # Validate type
         assert \
             execute_query(clickhouse_node, "SELECT toTypeName(value) FROM ${ch_mysql_table} LIMIT 1",
-                    settings=clickhouse_query_settings) \
+                          settings=clickhouse_query_settings) \
             == \
             expected_ch_type
 
         # Validate values
         assert \
             execute_query(clickhouse_node, "SELECT value FROM ${ch_mysql_table}",
-                    settings=clickhouse_query_settings) \
+                          settings=clickhouse_query_settings) \
             == \
             execute_query(mysql_node, "SELECT value FROM ${mysql_db}.${table_name}")
-
 
         # MySQL DATABASE ENGINE
         execute_query(clickhouse_node, [
@@ -250,22 +271,23 @@ def test_mysql_types(started_cluster, case_name, mysql_type, expected_ch_type, m
         # Validate type
         assert \
             execute_query(clickhouse_node, "SELECT toTypeName(value) FROM ${ch_mysql_db}.${table_name} LIMIT 1",
-                    settings=clickhouse_query_settings) \
+                          settings=clickhouse_query_settings) \
             == \
             expected_ch_type
 
         # Validate values
         assert \
             execute_query(clickhouse_node, "SELECT value FROM ${ch_mysql_db}.${table_name}",
-                    settings=clickhouse_query_settings) \
+                          settings=clickhouse_query_settings) \
             == \
             execute_query(mysql_node, "SELECT value FROM ${mysql_db}.${table_name}")
 
         # MySQL TABLE FUNCTION
         # Validate type
         assert \
-            execute_query(clickhouse_node, "SELECT toTypeName(value) FROM mysql('mysql1:3306', '${mysql_db}', '${table_name}', 'root', 'clickhouse') LIMIT 1",
-                    settings=clickhouse_query_settings) \
+            execute_query(clickhouse_node,
+                          "SELECT toTypeName(value) FROM mysql('mysql1:3306', '${mysql_db}', '${table_name}', 'root', 'clickhouse') LIMIT 1",
+                          settings=clickhouse_query_settings) \
             == \
             expected_ch_type
 
@@ -273,5 +295,6 @@ def test_mysql_types(started_cluster, case_name, mysql_type, expected_ch_type, m
         assert \
             execute_query(mysql_node, "SELECT value FROM ${mysql_db}.${table_name}") \
             == \
-            execute_query(clickhouse_node, "SELECT value FROM mysql('mysql1:3306', '${mysql_db}', '${table_name}', 'root', 'clickhouse')",
-                    settings=clickhouse_query_settings)
+            execute_query(clickhouse_node,
+                          "SELECT value FROM mysql('mysql1:3306', '${mysql_db}', '${table_name}', 'root', 'clickhouse')",
+                          settings=clickhouse_query_settings)

--- a/tests/integration/test_no_local_metadata_node/test.py
+++ b/tests/integration/test_no_local_metadata_node/test.py
@@ -1,10 +1,10 @@
-import time
 import pytest
 
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', with_zookeeper=True)
+
 
 @pytest.fixture(scope="module")
 def start_cluster():

--- a/tests/integration/test_non_default_compression/test.py
+++ b/tests/integration/test_non_default_compression/test.py
@@ -1,17 +1,23 @@
-import time
-import pytest
-import string
 import random
+import string
 
+import pytest
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 
-node1 = cluster.add_instance('node1', main_configs=['configs/zstd_compression_by_default.xml'], user_configs=['configs/allow_suspicious_codecs.xml'])
-node2 = cluster.add_instance('node2', main_configs=['configs/lz4hc_compression_by_default.xml'], user_configs=['configs/allow_suspicious_codecs.xml'])
-node3 = cluster.add_instance('node3', main_configs=['configs/custom_compression_by_default.xml'], user_configs=['configs/allow_suspicious_codecs.xml'])
-node4 = cluster.add_instance('node4', user_configs=['configs/enable_uncompressed_cache.xml', 'configs/allow_suspicious_codecs.xml'])
-node5 = cluster.add_instance('node5', main_configs=['configs/zstd_compression_by_default.xml'], user_configs=['configs/enable_uncompressed_cache.xml', 'configs/allow_suspicious_codecs.xml'])
+node1 = cluster.add_instance('node1', main_configs=['configs/zstd_compression_by_default.xml'],
+                             user_configs=['configs/allow_suspicious_codecs.xml'])
+node2 = cluster.add_instance('node2', main_configs=['configs/lz4hc_compression_by_default.xml'],
+                             user_configs=['configs/allow_suspicious_codecs.xml'])
+node3 = cluster.add_instance('node3', main_configs=['configs/custom_compression_by_default.xml'],
+                             user_configs=['configs/allow_suspicious_codecs.xml'])
+node4 = cluster.add_instance('node4', user_configs=['configs/enable_uncompressed_cache.xml',
+                                                    'configs/allow_suspicious_codecs.xml'])
+node5 = cluster.add_instance('node5', main_configs=['configs/zstd_compression_by_default.xml'],
+                             user_configs=['configs/enable_uncompressed_cache.xml',
+                                           'configs/allow_suspicious_codecs.xml'])
+
 
 @pytest.fixture(scope="module")
 def start_cluster():
@@ -33,16 +39,22 @@ def test_preconfigured_default_codec(start_cluster):
             somecolumn Float64
         ) ENGINE = MergeTree() PARTITION BY somedate ORDER BY id SETTINGS index_granularity = 2;
         """)
-        node.query("INSERT INTO compression_codec_multiple_with_key VALUES(toDate('2018-10-12'), 100000, 'hello', 88.88), (toDate('2018-10-12'), 100002, 'world', 99.99), (toDate('2018-10-12'), 1111, '!', 777.777)")
+        node.query(
+            "INSERT INTO compression_codec_multiple_with_key VALUES(toDate('2018-10-12'), 100000, 'hello', 88.88), (toDate('2018-10-12'), 100002, 'world', 99.99), (toDate('2018-10-12'), 1111, '!', 777.777)")
         assert node.query("SELECT COUNT(*) FROM compression_codec_multiple_with_key WHERE id % 2 == 0") == "2\n"
-        assert node.query("SELECT DISTINCT somecolumn FROM compression_codec_multiple_with_key ORDER BY id") == "777.777\n88.88\n99.99\n"
-        assert node.query("SELECT data FROM compression_codec_multiple_with_key WHERE id >= 1112 AND somedate = toDate('2018-10-12') AND somecolumn <= 100") == "hello\nworld\n"
+        assert node.query(
+            "SELECT DISTINCT somecolumn FROM compression_codec_multiple_with_key ORDER BY id") == "777.777\n88.88\n99.99\n"
+        assert node.query(
+            "SELECT data FROM compression_codec_multiple_with_key WHERE id >= 1112 AND somedate = toDate('2018-10-12') AND somecolumn <= 100") == "hello\nworld\n"
 
-        node.query("INSERT INTO compression_codec_multiple_with_key SELECT toDate('2018-10-12'), number, toString(number), 1.0 FROM system.numbers LIMIT 10000")
+        node.query(
+            "INSERT INTO compression_codec_multiple_with_key SELECT toDate('2018-10-12'), number, toString(number), 1.0 FROM system.numbers LIMIT 10000")
 
         assert node.query("SELECT COUNT(id) FROM compression_codec_multiple_with_key WHERE id % 10 == 0") == "1001\n"
-        assert node.query("SELECT SUM(somecolumn) FROM compression_codec_multiple_with_key") == str(777.777 + 88.88 + 99.99 + 1.0 * 10000) + "\n"
+        assert node.query("SELECT SUM(somecolumn) FROM compression_codec_multiple_with_key") == str(
+            777.777 + 88.88 + 99.99 + 1.0 * 10000) + "\n"
         assert node.query("SELECT count(*) FROM compression_codec_multiple_with_key GROUP BY somedate") == "10003\n"
+
 
 def test_preconfigured_custom_codec(start_cluster):
     node3.query("""
@@ -54,22 +66,38 @@ def test_preconfigured_custom_codec(start_cluster):
     ) ENGINE = MergeTree() PARTITION BY somedate ORDER BY id SETTINGS index_granularity = 2;
     """)
 
-    node3.query("INSERT INTO compression_codec_multiple_with_key VALUES(toDate('2018-10-12'), 100000, 'hello', 88.88), (toDate('2018-10-12'), 100002, 'world', 99.99), (toDate('2018-10-12'), 1111, '!', 777.777)")
+    node3.query(
+        "INSERT INTO compression_codec_multiple_with_key VALUES(toDate('2018-10-12'), 100000, 'hello', 88.88), (toDate('2018-10-12'), 100002, 'world', 99.99), (toDate('2018-10-12'), 1111, '!', 777.777)")
     assert node3.query("SELECT COUNT(*) FROM compression_codec_multiple_with_key WHERE id % 2 == 0") == "2\n"
-    assert node3.query("SELECT DISTINCT somecolumn FROM compression_codec_multiple_with_key ORDER BY id") == "777.777\n88.88\n99.99\n"
-    assert node3.query("SELECT data FROM compression_codec_multiple_with_key WHERE id >= 1112 AND somedate = toDate('2018-10-12') AND somecolumn <= 100") == "hello\nworld\n"
+    assert node3.query(
+        "SELECT DISTINCT somecolumn FROM compression_codec_multiple_with_key ORDER BY id") == "777.777\n88.88\n99.99\n"
+    assert node3.query(
+        "SELECT data FROM compression_codec_multiple_with_key WHERE id >= 1112 AND somedate = toDate('2018-10-12') AND somecolumn <= 100") == "hello\nworld\n"
 
-    node3.query("INSERT INTO compression_codec_multiple_with_key VALUES(toDate('2018-10-12'), 100000, '{}', 88.88)".format(''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10000))))
+    node3.query(
+        "INSERT INTO compression_codec_multiple_with_key VALUES(toDate('2018-10-12'), 100000, '{}', 88.88)".format(
+            ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10000))))
 
     node3.query("OPTIMIZE TABLE compression_codec_multiple_with_key FINAL")
-    assert node3.query("SELECT max(length(data)) from compression_codec_multiple_with_key GROUP BY data ORDER BY max(length(data)) DESC LIMIT 1") == "10000\n"
+    assert node3.query(
+        "SELECT max(length(data)) from compression_codec_multiple_with_key GROUP BY data ORDER BY max(length(data)) DESC LIMIT 1") == "10000\n"
 
     for i in xrange(10):
-        node3.query("INSERT INTO compression_codec_multiple_with_key VALUES(toDate('2018-10-12'), {}, '{}', 88.88)".format(i, ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10000))))
+        node3.query(
+            "INSERT INTO compression_codec_multiple_with_key VALUES(toDate('2018-10-12'), {}, '{}', 88.88)".format(i,
+                                                                                                                   ''.join(
+                                                                                                                       random.choice(
+                                                                                                                           string.ascii_uppercase + string.digits)
+                                                                                                                       for
+                                                                                                                       _
+                                                                                                                       in
+                                                                                                                       range(
+                                                                                                                           10000))))
 
     node3.query("OPTIMIZE TABLE compression_codec_multiple_with_key FINAL")
 
     assert node3.query("SELECT COUNT(*) from compression_codec_multiple_with_key WHERE length(data) = 10000") == "11\n"
+
 
 def test_uncompressed_cache_custom_codec(start_cluster):
     node4.query("""
@@ -81,12 +109,17 @@ def test_uncompressed_cache_custom_codec(start_cluster):
     ) ENGINE = MergeTree() PARTITION BY somedate ORDER BY id SETTINGS index_granularity = 2;
     """)
 
-    node4.query("INSERT INTO compression_codec_multiple_with_key VALUES(toDate('2018-10-12'), 100000, '{}', 88.88)".format(''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10000))))
+    node4.query(
+        "INSERT INTO compression_codec_multiple_with_key VALUES(toDate('2018-10-12'), 100000, '{}', 88.88)".format(
+            ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10000))))
 
     # two equal requests one by one, to get into UncompressedCache for the first block
-    assert node4.query("SELECT max(length(data)) from compression_codec_multiple_with_key GROUP BY data ORDER BY max(length(data)) DESC LIMIT 1") == "10000\n"
+    assert node4.query(
+        "SELECT max(length(data)) from compression_codec_multiple_with_key GROUP BY data ORDER BY max(length(data)) DESC LIMIT 1") == "10000\n"
 
-    assert node4.query("SELECT max(length(data)) from compression_codec_multiple_with_key GROUP BY data ORDER BY max(length(data)) DESC LIMIT 1") == "10000\n"
+    assert node4.query(
+        "SELECT max(length(data)) from compression_codec_multiple_with_key GROUP BY data ORDER BY max(length(data)) DESC LIMIT 1") == "10000\n"
+
 
 def test_uncompressed_cache_plus_zstd_codec(start_cluster):
     node5.query("""
@@ -98,6 +131,9 @@ def test_uncompressed_cache_plus_zstd_codec(start_cluster):
     ) ENGINE = MergeTree() PARTITION BY somedate ORDER BY id SETTINGS index_granularity = 2;
     """)
 
-    node5.query("INSERT INTO compression_codec_multiple_with_key VALUES(toDate('2018-10-12'), 100000, '{}', 88.88)".format('a' * 10000))
+    node5.query(
+        "INSERT INTO compression_codec_multiple_with_key VALUES(toDate('2018-10-12'), 100000, '{}', 88.88)".format(
+            'a' * 10000))
 
-    assert node5.query("SELECT max(length(data)) from compression_codec_multiple_with_key GROUP BY data ORDER BY max(length(data)) DESC LIMIT 1") == "10000\n"
+    assert node5.query(
+        "SELECT max(length(data)) from compression_codec_multiple_with_key GROUP BY data ORDER BY max(length(data)) DESC LIMIT 1") == "10000\n"

--- a/tests/integration/test_odbc_interaction/test.py
+++ b/tests/integration/test_odbc_interaction/test.py
@@ -1,17 +1,20 @@
 import time
-import pytest
 
-import os
-import pymysql.cursors
 import psycopg2
-from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+import pymysql.cursors
+import pytest
 from helpers.cluster import ClickHouseCluster
-
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
 cluster = ClickHouseCluster(__file__)
-node1 = cluster.add_instance('node1', with_odbc_drivers=True, with_mysql=True, main_configs=['configs/openssl.xml','configs/odbc_logging.xml','configs/enable_dictionaries.xml','configs/dictionaries/sqlite3_odbc_hashed_dictionary.xml','configs/dictionaries/sqlite3_odbc_cached_dictionary.xml','configs/dictionaries/postgres_odbc_hashed_dictionary.xml'], stay_alive=True)
+node1 = cluster.add_instance('node1', with_odbc_drivers=True, with_mysql=True,
+                             main_configs=['configs/openssl.xml', 'configs/odbc_logging.xml',
+                                           'configs/enable_dictionaries.xml',
+                                           'configs/dictionaries/sqlite3_odbc_hashed_dictionary.xml',
+                                           'configs/dictionaries/sqlite3_odbc_cached_dictionary.xml',
+                                           'configs/dictionaries/postgres_odbc_hashed_dictionary.xml'], stay_alive=True)
 
-create_table_sql_template =   """
+create_table_sql_template = """
     CREATE TABLE `clickhouse`.`{}` (
     `id` int(11) NOT NULL,
     `name` varchar(50) NOT NULL,
@@ -20,18 +23,23 @@ create_table_sql_template =   """
     `column_x` int default NULL,
     PRIMARY KEY (`id`)) ENGINE=InnoDB;
     """
+
+
 def get_mysql_conn():
     conn = pymysql.connect(user='root', password='clickhouse', host='127.0.0.1', port=3308)
     return conn
+
 
 def create_mysql_db(conn, name):
     with conn.cursor() as cursor:
         cursor.execute(
             "CREATE DATABASE {} DEFAULT CHARACTER SET 'utf8'".format(name))
 
+
 def create_mysql_table(conn, table_name):
     with conn.cursor() as cursor:
         cursor.execute(create_table_sql_template.format(table_name))
+
 
 def get_postgres_conn():
     conn_string = "host='localhost' user='postgres' password='mysecretpassword'"
@@ -40,9 +48,11 @@ def get_postgres_conn():
     conn.autocommit = True
     return conn
 
+
 def create_postgres_db(conn, name):
     cursor = conn.cursor()
     cursor.execute("CREATE SCHEMA {}".format(name))
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -51,10 +61,18 @@ def started_cluster():
         sqlite_db = node1.odbc_drivers["SQLite3"]["Database"]
 
         print "sqlite data received"
-        node1.exec_in_container(["bash", "-c", "echo 'CREATE TABLE t1(x INTEGER PRIMARY KEY ASC, y, z);' | sqlite3 {}".format(sqlite_db)], privileged=True, user='root')
-        node1.exec_in_container(["bash", "-c", "echo 'CREATE TABLE t2(X INTEGER PRIMARY KEY ASC, Y, Z);' | sqlite3 {}".format(sqlite_db)], privileged=True, user='root')
-        node1.exec_in_container(["bash", "-c", "echo 'CREATE TABLE t3(X INTEGER PRIMARY KEY ASC, Y, Z);' | sqlite3 {}".format(sqlite_db)], privileged=True, user='root')
-        node1.exec_in_container(["bash", "-c", "echo 'CREATE TABLE t4(X INTEGER PRIMARY KEY ASC, Y, Z);' | sqlite3 {}".format(sqlite_db)], privileged=True, user='root')
+        node1.exec_in_container(
+            ["bash", "-c", "echo 'CREATE TABLE t1(x INTEGER PRIMARY KEY ASC, y, z);' | sqlite3 {}".format(sqlite_db)],
+            privileged=True, user='root')
+        node1.exec_in_container(
+            ["bash", "-c", "echo 'CREATE TABLE t2(X INTEGER PRIMARY KEY ASC, Y, Z);' | sqlite3 {}".format(sqlite_db)],
+            privileged=True, user='root')
+        node1.exec_in_container(
+            ["bash", "-c", "echo 'CREATE TABLE t3(X INTEGER PRIMARY KEY ASC, Y, Z);' | sqlite3 {}".format(sqlite_db)],
+            privileged=True, user='root')
+        node1.exec_in_container(
+            ["bash", "-c", "echo 'CREATE TABLE t4(X INTEGER PRIMARY KEY ASC, Y, Z);' | sqlite3 {}".format(sqlite_db)],
+            privileged=True, user='root')
         print "sqlite tables created"
         mysql_conn = get_mysql_conn()
         print "mysql connection received"
@@ -69,7 +87,8 @@ def started_cluster():
         print "postgres db created"
 
         cursor = postgres_conn.cursor()
-        cursor.execute("create table if not exists clickhouse.test_table (column1 int primary key, column2 varchar(40) not null)")
+        cursor.execute(
+            "create table if not exists clickhouse.test_table (column1 int primary key, column2 varchar(40) not null)")
 
         yield cluster
 
@@ -78,6 +97,7 @@ def started_cluster():
         raise ex
     finally:
         cluster.shutdown()
+
 
 def test_mysql_simple_select_works(started_cluster):
     mysql_setup = node1.odbc_drivers["MySQL"]
@@ -88,17 +108,25 @@ def test_mysql_simple_select_works(started_cluster):
 
     # Check that NULL-values are handled correctly by the ODBC-bridge
     with conn.cursor() as cursor:
-        cursor.execute("INSERT INTO clickhouse.{} VALUES(50, 'null-guy', 127, 255, NULL), (100, 'non-null-guy', 127, 255, 511);".format(table_name))
+        cursor.execute(
+            "INSERT INTO clickhouse.{} VALUES(50, 'null-guy', 127, 255, NULL), (100, 'non-null-guy', 127, 255, 511);".format(
+                table_name))
         conn.commit()
-    assert node1.query("SELECT column_x FROM odbc('DSN={}', '{}')".format(mysql_setup["DSN"], table_name), settings={"external_table_functions_use_nulls": "1"}) == '\\N\n511\n'
-    assert node1.query("SELECT column_x FROM odbc('DSN={}', '{}')".format(mysql_setup["DSN"], table_name), settings={"external_table_functions_use_nulls": "0"}) == '0\n511\n'
+    assert node1.query("SELECT column_x FROM odbc('DSN={}', '{}')".format(mysql_setup["DSN"], table_name),
+                       settings={"external_table_functions_use_nulls": "1"}) == '\\N\n511\n'
+    assert node1.query("SELECT column_x FROM odbc('DSN={}', '{}')".format(mysql_setup["DSN"], table_name),
+                       settings={"external_table_functions_use_nulls": "0"}) == '0\n511\n'
 
     node1.query('''
 CREATE TABLE {}(id UInt32, name String, age UInt32, money UInt32, column_x Nullable(UInt32)) ENGINE = MySQL('mysql1:3306', 'clickhouse', '{}', 'root', 'clickhouse');
 '''.format(table_name, table_name))
 
-    node1.query("INSERT INTO {}(id, name, money, column_x) select number, concat('name_', toString(number)), 3, NULL from numbers(49) ".format(table_name))
-    node1.query("INSERT INTO {}(id, name, money, column_x) select number, concat('name_', toString(number)), 3, 42 from numbers(51, 49) ".format(table_name))
+    node1.query(
+        "INSERT INTO {}(id, name, money, column_x) select number, concat('name_', toString(number)), 3, NULL from numbers(49) ".format(
+            table_name))
+    node1.query(
+        "INSERT INTO {}(id, name, money, column_x) select number, concat('name_', toString(number)), 3, 42 from numbers(51, 49) ".format(
+            table_name))
 
     assert node1.query("SELECT COUNT () FROM {} WHERE column_x IS NOT NULL".format(table_name)) == '50\n'
     assert node1.query("SELECT COUNT () FROM {} WHERE column_x IS NULL".format(table_name)) == '50\n'
@@ -110,6 +138,7 @@ CREATE TABLE {}(id UInt32, name String, age UInt32, money UInt32, column_x Nulla
 
     conn.close()
 
+
 def test_mysql_insert(started_cluster):
     mysql_setup = node1.odbc_drivers["MySQL"]
     table_name = 'test_insert'
@@ -117,20 +146,26 @@ def test_mysql_insert(started_cluster):
     create_mysql_table(conn, table_name)
     odbc_args = "'DSN={}', '{}', '{}'".format(mysql_setup["DSN"], mysql_setup["Database"], table_name)
 
-    node1.query("create table mysql_insert (id Int64, name String, age UInt8, money Float, column_x Nullable(Int16)) Engine=ODBC({})".format(odbc_args))
+    node1.query(
+        "create table mysql_insert (id Int64, name String, age UInt8, money Float, column_x Nullable(Int16)) Engine=ODBC({})".format(
+            odbc_args))
     node1.query("insert into mysql_insert values (1, 'test', 11, 111, 1111), (2, 'odbc', 22, 222, NULL)")
     assert node1.query("select * from mysql_insert") == "1\ttest\t11\t111\t1111\n2\todbc\t22\t222\t\\N\n"
 
     node1.query("insert into table function odbc({}) values (3, 'insert', 33, 333, 3333)".format(odbc_args))
-    node1.query("insert into table function odbc({}) (id, name, age, money) select id*4, upper(name), age*4, money*4 from odbc({}) where id=1".format(odbc_args, odbc_args))
-    assert node1.query("select * from mysql_insert where id in (3, 4)") == "3\tinsert\t33\t333\t3333\n4\tTEST\t44\t444\t\\N\n"
+    node1.query(
+        "insert into table function odbc({}) (id, name, age, money) select id*4, upper(name), age*4, money*4 from odbc({}) where id=1".format(
+            odbc_args, odbc_args))
+    assert node1.query(
+        "select * from mysql_insert where id in (3, 4)") == "3\tinsert\t33\t333\t3333\n4\tTEST\t44\t444\t\\N\n"
 
 
 def test_sqlite_simple_select_function_works(started_cluster):
     sqlite_setup = node1.odbc_drivers["SQLite3"]
     sqlite_db = sqlite_setup["Database"]
 
-    node1.exec_in_container(["bash", "-c", "echo 'INSERT INTO t1 values(1, 2, 3);' | sqlite3 {}".format(sqlite_db)], privileged=True, user='root')
+    node1.exec_in_container(["bash", "-c", "echo 'INSERT INTO t1 values(1, 2, 3);' | sqlite3 {}".format(sqlite_db)],
+                            privileged=True, user='root')
     assert node1.query("select * from odbc('DSN={}', '{}')".format(sqlite_setup["DSN"], 't1')) == "1\t2\t3\n"
 
     assert node1.query("select y from odbc('DSN={}', '{}')".format(sqlite_setup["DSN"], 't1')) == "2\n"
@@ -138,14 +173,18 @@ def test_sqlite_simple_select_function_works(started_cluster):
     assert node1.query("select x from odbc('DSN={}', '{}')".format(sqlite_setup["DSN"], 't1')) == "1\n"
     assert node1.query("select x, y from odbc('DSN={}', '{}')".format(sqlite_setup["DSN"], 't1')) == "1\t2\n"
     assert node1.query("select z, x, y from odbc('DSN={}', '{}')".format(sqlite_setup["DSN"], 't1')) == "3\t1\t2\n"
-    assert node1.query("select count(), sum(x) from odbc('DSN={}', '{}') group by x".format(sqlite_setup["DSN"], 't1')) == "1\t1\n"
+    assert node1.query(
+        "select count(), sum(x) from odbc('DSN={}', '{}') group by x".format(sqlite_setup["DSN"], 't1')) == "1\t1\n"
+
 
 def test_sqlite_simple_select_storage_works(started_cluster):
     sqlite_setup = node1.odbc_drivers["SQLite3"]
     sqlite_db = sqlite_setup["Database"]
 
-    node1.exec_in_container(["bash", "-c", "echo 'INSERT INTO t4 values(1, 2, 3);' | sqlite3 {}".format(sqlite_db)], privileged=True, user='root')
-    node1.query("create table SqliteODBC (x Int32, y String, z String) engine = ODBC('DSN={}', '', 't4')".format(sqlite_setup["DSN"]))
+    node1.exec_in_container(["bash", "-c", "echo 'INSERT INTO t4 values(1, 2, 3);' | sqlite3 {}".format(sqlite_db)],
+                            privileged=True, user='root')
+    node1.query("create table SqliteODBC (x Int32, y String, z String) engine = ODBC('DSN={}', '', 't4')".format(
+        sqlite_setup["DSN"]))
 
     assert node1.query("select * from SqliteODBC") == "1\t2\t3\n"
     assert node1.query("select y from SqliteODBC") == "2\n"
@@ -155,32 +194,38 @@ def test_sqlite_simple_select_storage_works(started_cluster):
     assert node1.query("select z, x, y from SqliteODBC") == "3\t1\t2\n"
     assert node1.query("select count(), sum(x) from SqliteODBC group by x") == "1\t1\n"
 
+
 def test_sqlite_odbc_hashed_dictionary(started_cluster):
-    sqlite_db =  node1.odbc_drivers["SQLite3"]["Database"]
-    node1.exec_in_container(["bash", "-c", "echo 'INSERT INTO t2 values(1, 2, 3);' | sqlite3 {}".format(sqlite_db)], privileged=True, user='root')
+    sqlite_db = node1.odbc_drivers["SQLite3"]["Database"]
+    node1.exec_in_container(["bash", "-c", "echo 'INSERT INTO t2 values(1, 2, 3);' | sqlite3 {}".format(sqlite_db)],
+                            privileged=True, user='root')
 
     assert node1.query("select dictGetUInt8('sqlite3_odbc_hashed', 'Z', toUInt64(1))") == "3\n"
-    assert node1.query("select dictGetUInt8('sqlite3_odbc_hashed', 'Z', toUInt64(200))") == "1\n" # default
+    assert node1.query("select dictGetUInt8('sqlite3_odbc_hashed', 'Z', toUInt64(200))") == "1\n"  # default
 
-    time.sleep(5) # first reload
-    node1.exec_in_container(["bash", "-c", "echo 'INSERT INTO t2 values(200, 2, 7);' | sqlite3 {}".format(sqlite_db)], privileged=True, user='root')
+    time.sleep(5)  # first reload
+    node1.exec_in_container(["bash", "-c", "echo 'INSERT INTO t2 values(200, 2, 7);' | sqlite3 {}".format(sqlite_db)],
+                            privileged=True, user='root')
 
     # No reload because of invalidate query
     time.sleep(5)
     assert node1.query("select dictGetUInt8('sqlite3_odbc_hashed', 'Z', toUInt64(1))") == "3\n"
-    assert node1.query("select dictGetUInt8('sqlite3_odbc_hashed', 'Z', toUInt64(200))") == "1\n" # still default
+    assert node1.query("select dictGetUInt8('sqlite3_odbc_hashed', 'Z', toUInt64(200))") == "1\n"  # still default
 
-    node1.exec_in_container(["bash", "-c", "echo 'REPLACE INTO t2 values(1, 2, 5);' | sqlite3 {}".format(sqlite_db)], privileged=True, user='root')
+    node1.exec_in_container(["bash", "-c", "echo 'REPLACE INTO t2 values(1, 2, 5);' | sqlite3 {}".format(sqlite_db)],
+                            privileged=True, user='root')
 
     # waiting for reload
     time.sleep(5)
 
     assert node1.query("select dictGetUInt8('sqlite3_odbc_hashed', 'Z', toUInt64(1))") == "5\n"
-    assert node1.query("select dictGetUInt8('sqlite3_odbc_hashed', 'Z', toUInt64(200))") == "7\n" # new value
+    assert node1.query("select dictGetUInt8('sqlite3_odbc_hashed', 'Z', toUInt64(200))") == "7\n"  # new value
+
 
 def test_sqlite_odbc_cached_dictionary(started_cluster):
-    sqlite_db =  node1.odbc_drivers["SQLite3"]["Database"]
-    node1.exec_in_container(["bash", "-c", "echo 'INSERT INTO t3 values(1, 2, 3);' | sqlite3 {}".format(sqlite_db)], privileged=True, user='root')
+    sqlite_db = node1.odbc_drivers["SQLite3"]["Database"]
+    node1.exec_in_container(["bash", "-c", "echo 'INSERT INTO t3 values(1, 2, 3);' | sqlite3 {}".format(sqlite_db)],
+                            privileged=True, user='root')
 
     assert node1.query("select dictGetUInt8('sqlite3_odbc_cached', 'Z', toUInt64(1))") == "3\n"
 
@@ -188,15 +233,18 @@ def test_sqlite_odbc_cached_dictionary(started_cluster):
     node1.exec_in_container(["bash", "-c", "chmod a+rw /tmp"], privileged=True, user='root')
     node1.exec_in_container(["bash", "-c", "chmod a+rw {}".format(sqlite_db)], privileged=True, user='root')
 
-    node1.query("insert into table function odbc('DSN={};', '', 't3') values (200, 2, 7)".format(node1.odbc_drivers["SQLite3"]["DSN"]))
+    node1.query("insert into table function odbc('DSN={};', '', 't3') values (200, 2, 7)".format(
+        node1.odbc_drivers["SQLite3"]["DSN"]))
 
-    assert node1.query("select dictGetUInt8('sqlite3_odbc_cached', 'Z', toUInt64(200))") == "7\n" # new value
+    assert node1.query("select dictGetUInt8('sqlite3_odbc_cached', 'Z', toUInt64(200))") == "7\n"  # new value
 
-    node1.exec_in_container(["bash", "-c", "echo 'REPLACE INTO t3 values(1, 2, 12);' | sqlite3 {}".format(sqlite_db)], privileged=True, user='root')
+    node1.exec_in_container(["bash", "-c", "echo 'REPLACE INTO t3 values(1, 2, 12);' | sqlite3 {}".format(sqlite_db)],
+                            privileged=True, user='root')
 
     time.sleep(5)
 
     assert node1.query("select dictGetUInt8('sqlite3_odbc_cached', 'Z', toUInt64(1))") == "12\n"
+
 
 def test_postgres_odbc_hached_dictionary_with_schema(started_cluster):
     conn = get_postgres_conn()
@@ -205,6 +253,7 @@ def test_postgres_odbc_hached_dictionary_with_schema(started_cluster):
     time.sleep(5)
     assert node1.query("select dictGetString('postgres_odbc_hashed', 'column2', toUInt64(1))") == "hello\n"
     assert node1.query("select dictGetString('postgres_odbc_hashed', 'column2', toUInt64(2))") == "world\n"
+
 
 def test_postgres_odbc_hached_dictionary_no_tty_pipe_overflow(started_cluster):
     conn = get_postgres_conn()
@@ -218,6 +267,7 @@ def test_postgres_odbc_hached_dictionary_no_tty_pipe_overflow(started_cluster):
 
     assert node1.query("select dictGetString('postgres_odbc_hashed', 'column2', toUInt64(3))") == "xxx\n"
 
+
 def test_postgres_insert(started_cluster):
     conn = get_postgres_conn()
     conn.cursor().execute("truncate table clickhouse.test_table")
@@ -226,13 +276,17 @@ def test_postgres_insert(started_cluster):
     # postgres .yml file). This is needed to check parsing, validation and
     # reconstruction of connection string.
 
-    node1.query("create table pg_insert (column1 UInt8, column2 String) engine=ODBC('DSN=postgresql_odbc;Servername=postgre-sql.local', 'clickhouse', 'test_table')")
+    node1.query(
+        "create table pg_insert (column1 UInt8, column2 String) engine=ODBC('DSN=postgresql_odbc;Servername=postgre-sql.local', 'clickhouse', 'test_table')")
     node1.query("insert into pg_insert values (1, 'hello'), (2, 'world')")
     assert node1.query("select * from pg_insert") == '1\thello\n2\tworld\n'
     node1.query("insert into table function odbc('DSN=postgresql_odbc;', 'clickhouse', 'test_table') format CSV 3,test")
-    node1.query("insert into table function odbc('DSN=postgresql_odbc;Servername=postgre-sql.local', 'clickhouse', 'test_table') select number, 's' || toString(number) from numbers (4, 7)")
+    node1.query(
+        "insert into table function odbc('DSN=postgresql_odbc;Servername=postgre-sql.local', 'clickhouse', 'test_table') select number, 's' || toString(number) from numbers (4, 7)")
     assert node1.query("select sum(column1), count(column1) from pg_insert") == "55\t10\n"
-    assert node1.query("select sum(n), count(n) from (select (*,).1 as n from (select * from odbc('DSN=postgresql_odbc;', 'clickhouse', 'test_table')))") == "55\t10\n"
+    assert node1.query(
+        "select sum(n), count(n) from (select (*,).1 as n from (select * from odbc('DSN=postgresql_odbc;', 'clickhouse', 'test_table')))") == "55\t10\n"
+
 
 def test_bridge_dies_with_parent(started_cluster):
     node1.query("select dictGetString('postgres_odbc_hashed', 'column2', toUInt64(1))")
@@ -251,13 +305,14 @@ def test_bridge_dies_with_parent(started_cluster):
         time.sleep(1)
 
     for i in range(5):
-        time.sleep(1) # just for sure, that odbc-bridge caught signal
+        time.sleep(1)  # just for sure, that odbc-bridge caught signal
         bridge_pid = node1.get_process_pid("odbc-bridge")
         if bridge_pid is None:
             break
 
     if bridge_pid:
-        out = node1.exec_in_container(["gdb", "-p", str(bridge_pid), "--ex", "thread apply all bt", "--ex", "q"], privileged=True, user='root')
+        out = node1.exec_in_container(["gdb", "-p", str(bridge_pid), "--ex", "thread apply all bt", "--ex", "q"],
+                                      privileged=True, user='root')
         print("Bridge is running, gdb output:")
         print(out)
 

--- a/tests/integration/test_old_versions/test.py
+++ b/tests/integration/test_old_versions/test.py
@@ -1,28 +1,30 @@
-
-import time
-import os
 import pytest
 
 from helpers.cluster import ClickHouseCluster
-from multiprocessing.dummy import Pool
-from helpers.client import QueryRuntimeException, QueryTimeoutExceedException
 from helpers.test_tools import assert_eq_with_retry
 
-
 cluster = ClickHouseCluster(__file__)
-node18_14 = cluster.add_instance('node18_14', image='yandex/clickhouse-server', tag='18.14.19', with_installed_binary=True, main_configs=["configs/config.d/test_cluster.xml"])
-node19_1 = cluster.add_instance('node19_1', image='yandex/clickhouse-server', tag='19.1.16', with_installed_binary=True, main_configs=["configs/config.d/test_cluster.xml"])
-node19_4 = cluster.add_instance('node19_4', image='yandex/clickhouse-server', tag='19.4.5.35', with_installed_binary=True, main_configs=["configs/config.d/test_cluster.xml"])
-node19_8 = cluster.add_instance('node19_8', image='yandex/clickhouse-server', tag='19.8.3.8', with_installed_binary=True, main_configs=["configs/config.d/test_cluster.xml"])
-node19_11 = cluster.add_instance('node19_11', image='yandex/clickhouse-server', tag='19.11.13.74', with_installed_binary=True, main_configs=["configs/config.d/test_cluster.xml"])
-node19_13 = cluster.add_instance('node19_13', image='yandex/clickhouse-server', tag='19.13.7.57', with_installed_binary=True, main_configs=["configs/config.d/test_cluster.xml"])
-node19_16 = cluster.add_instance('node19_16', image='yandex/clickhouse-server', tag='19.16.2.2', with_installed_binary=True, main_configs=["configs/config.d/test_cluster.xml"])
+node18_14 = cluster.add_instance('node18_14', image='yandex/clickhouse-server', tag='18.14.19',
+                                 with_installed_binary=True, main_configs=["configs/config.d/test_cluster.xml"])
+node19_1 = cluster.add_instance('node19_1', image='yandex/clickhouse-server', tag='19.1.16', with_installed_binary=True,
+                                main_configs=["configs/config.d/test_cluster.xml"])
+node19_4 = cluster.add_instance('node19_4', image='yandex/clickhouse-server', tag='19.4.5.35',
+                                with_installed_binary=True, main_configs=["configs/config.d/test_cluster.xml"])
+node19_8 = cluster.add_instance('node19_8', image='yandex/clickhouse-server', tag='19.8.3.8',
+                                with_installed_binary=True, main_configs=["configs/config.d/test_cluster.xml"])
+node19_11 = cluster.add_instance('node19_11', image='yandex/clickhouse-server', tag='19.11.13.74',
+                                 with_installed_binary=True, main_configs=["configs/config.d/test_cluster.xml"])
+node19_13 = cluster.add_instance('node19_13', image='yandex/clickhouse-server', tag='19.13.7.57',
+                                 with_installed_binary=True, main_configs=["configs/config.d/test_cluster.xml"])
+node19_16 = cluster.add_instance('node19_16', image='yandex/clickhouse-server', tag='19.16.2.2',
+                                 with_installed_binary=True, main_configs=["configs/config.d/test_cluster.xml"])
 old_nodes = [node18_14, node19_1, node19_4, node19_8, node19_11, node19_13, node19_16]
 new_node = cluster.add_instance('node_new')
 
 
 def query_from_one_node_to_another(client_node, server_node, query):
-    client_node.exec_in_container(["bash", "-c", "/usr/bin/clickhouse client --host {} --query {!r}".format(server_node.name, query)])
+    client_node.exec_in_container(
+        ["bash", "-c", "/usr/bin/clickhouse client --host {} --query {!r}".format(server_node.name, query)])
 
 
 @pytest.fixture(scope="module")
@@ -34,7 +36,8 @@ def setup_nodes():
             n.query('''CREATE TABLE test_table (id UInt32, value UInt64) ENGINE = MergeTree() ORDER BY tuple()''')
 
         for n in old_nodes:
-            n.query('''CREATE TABLE dist_table AS test_table ENGINE = Distributed('test_cluster', 'default', 'test_table')''')
+            n.query(
+                '''CREATE TABLE dist_table AS test_table ENGINE = Distributed('test_cluster', 'default', 'test_table')''')
 
         yield cluster
     finally:
@@ -70,5 +73,7 @@ def test_distributed_query_initiator_is_older_than_shard(setup_nodes):
     for i, initiator in enumerate(distributed_query_initiator_old_nodes):
         initiator.query("INSERT INTO dist_table VALUES (3, {})".format(i))
 
-    assert_eq_with_retry(shard, "SELECT COUNT() FROM test_table WHERE id=3", str(len(distributed_query_initiator_old_nodes)))
-    assert_eq_with_retry(initiator, "SELECT COUNT() FROM dist_table WHERE id=3", str(len(distributed_query_initiator_old_nodes)))
+    assert_eq_with_retry(shard, "SELECT COUNT() FROM test_table WHERE id=3",
+                         str(len(distributed_query_initiator_old_nodes)))
+    assert_eq_with_retry(initiator, "SELECT COUNT() FROM dist_table WHERE id=3",
+                         str(len(distributed_query_initiator_old_nodes)))

--- a/tests/integration/test_on_cluster_timeouts/test.py
+++ b/tests/integration/test_on_cluster_timeouts/test.py
@@ -1,14 +1,17 @@
 import pytest
 
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 
-node1 = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml'], user_configs=['configs/users_config.xml'], with_zookeeper=True)
-node2 = cluster.add_instance('node2', main_configs=['configs/remote_servers.xml'], user_configs=['configs/users_config.xml'], with_zookeeper=True)
-node3 = cluster.add_instance('node3', main_configs=['configs/remote_servers.xml'], user_configs=['configs/users_config.xml'], with_zookeeper=True)
-node4 = cluster.add_instance('node4', main_configs=['configs/remote_servers.xml'], user_configs=['configs/users_config.xml'], with_zookeeper=True)
+node1 = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml'],
+                             user_configs=['configs/users_config.xml'], with_zookeeper=True)
+node2 = cluster.add_instance('node2', main_configs=['configs/remote_servers.xml'],
+                             user_configs=['configs/users_config.xml'], with_zookeeper=True)
+node3 = cluster.add_instance('node3', main_configs=['configs/remote_servers.xml'],
+                             user_configs=['configs/users_config.xml'], with_zookeeper=True)
+node4 = cluster.add_instance('node4', main_configs=['configs/remote_servers.xml'],
+                             user_configs=['configs/users_config.xml'], with_zookeeper=True)
 
 
 @pytest.fixture(scope="module")
@@ -22,19 +25,24 @@ def started_cluster():
 
 
 def test_long_query(started_cluster):
-    node1.query("CREATE TABLE cluster_table (key UInt64, value String) ENGINE = ReplicatedMergeTree('/test/1/cluster_table', '1') ORDER BY tuple()")
-    node2.query("CREATE TABLE cluster_table (key UInt64, value String) ENGINE = ReplicatedMergeTree('/test/1/cluster_table', '2') ORDER BY tuple()")
+    node1.query(
+        "CREATE TABLE cluster_table (key UInt64, value String) ENGINE = ReplicatedMergeTree('/test/1/cluster_table', '1') ORDER BY tuple()")
+    node2.query(
+        "CREATE TABLE cluster_table (key UInt64, value String) ENGINE = ReplicatedMergeTree('/test/1/cluster_table', '2') ORDER BY tuple()")
 
     node1.query("INSERT INTO cluster_table SELECT number, toString(number) FROM numbers(20)")
     node2.query("SYSTEM SYNC REPLICA cluster_table")
 
-    node3.query("CREATE TABLE cluster_table (key UInt64, value String) ENGINE = ReplicatedMergeTree('/test/2/cluster_table', '1') ORDER BY tuple()")
+    node3.query(
+        "CREATE TABLE cluster_table (key UInt64, value String) ENGINE = ReplicatedMergeTree('/test/2/cluster_table', '1') ORDER BY tuple()")
 
-    node4.query("CREATE TABLE cluster_table (key UInt64, value String) ENGINE = ReplicatedMergeTree('/test/2/cluster_table', '2') ORDER BY tuple()")
+    node4.query(
+        "CREATE TABLE cluster_table (key UInt64, value String) ENGINE = ReplicatedMergeTree('/test/2/cluster_table', '2') ORDER BY tuple()")
     node3.query("INSERT INTO cluster_table SELECT number, toString(number) FROM numbers(20)")
     node4.query("SYSTEM SYNC REPLICA cluster_table")
 
-    node1.query("ALTER TABLE cluster_table ON CLUSTER 'test_cluster' UPDATE key = 1 WHERE sleepEachRow(1) == 0", settings={"mutations_sync": "2"})
+    node1.query("ALTER TABLE cluster_table ON CLUSTER 'test_cluster' UPDATE key = 1 WHERE sleepEachRow(1) == 0",
+                settings={"mutations_sync": "2"})
 
     assert node1.query("SELECT SUM(key) FROM cluster_table") == "20\n"
     assert node2.query("SELECT SUM(key) FROM cluster_table") == "20\n"

--- a/tests/integration/test_part_log_table/test.py
+++ b/tests/integration/test_part_log_table/test.py
@@ -1,4 +1,3 @@
-import time
 import pytest
 
 from helpers.cluster import ClickHouseCluster
@@ -8,6 +7,7 @@ node1 = cluster.add_instance("node1")
 node2 = cluster.add_instance("node2", main_configs=["configs/config_with_standard_part_log.xml"])
 node3 = cluster.add_instance("node3", main_configs=["configs/config_with_non_standard_part_log.xml"])
 
+
 @pytest.fixture(scope="module")
 def start_cluster():
     try:
@@ -15,6 +15,7 @@ def start_cluster():
         yield cluster
     finally:
         cluster.shutdown()
+
 
 def test_config_without_part_log(start_cluster):
     assert "Table system.part_log doesn't exist" in node1.query_and_get_error("SELECT * FROM system.part_log")
@@ -24,6 +25,7 @@ def test_config_without_part_log(start_cluster):
     node1.query("SYSTEM FLUSH LOGS")
     assert "Table system.part_log doesn't exist" in node1.query_and_get_error("SELECT * FROM system.part_log")
 
+
 # Note: if part_log is defined, we cannot say when the table will be created - because of metric_log, trace_log, text_log, query_log...
 
 def test_config_with_standard_part_log(start_cluster):
@@ -31,6 +33,7 @@ def test_config_with_standard_part_log(start_cluster):
     node2.query("INSERT INTO test_table VALUES ('name', 1)")
     node2.query("SYSTEM FLUSH LOGS")
     assert node2.query("SELECT * FROM system.part_log") != ""
+
 
 def test_config_with_non_standard_part_log(start_cluster):
     node3.query("CREATE TABLE test_table(word String, value UInt64) ENGINE=MergeTree() Order by value")

--- a/tests/integration/test_partition/test.py
+++ b/tests/integration/test_partition/test.py
@@ -3,7 +3,6 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
-
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance('instance')
 q = instance.query
@@ -109,7 +108,6 @@ def partition_table_complex(started_cluster):
 
 
 def test_partition_complex(partition_table_complex):
-
     partition_complex_assert_columns_txt()
 
     q("ALTER TABLE test.partition FREEZE")
@@ -131,7 +129,7 @@ def test_partition_complex(partition_table_complex):
     expected = TSV('31\t1\t2\n'
                    '1\t2\t3')
     res = q("SELECT toUInt16(p), k, v1 FROM test.partition ORDER BY k")
-    assert(TSV(res) == expected)
+    assert (TSV(res) == expected)
 
 
 @pytest.fixture
@@ -175,7 +173,7 @@ def test_attach_check_all_parts(attach_check_all_parts_table):
     path_to_detached = path_to_data + 'data/test/attach_partition/detached/'
     exec_bash('mkdir {}'.format(path_to_detached + '0_5_5_0'))
     exec_bash('cp -pr {} {}'.format(path_to_detached + '0_1_1_0', path_to_detached + 'attaching_0_6_6_0'))
-    exec_bash('cp -pr {} {}'.format(path_to_detached + '0_3_3_0', path_to_detached +  'deleting_0_7_7_0'))
+    exec_bash('cp -pr {} {}'.format(path_to_detached + '0_3_3_0', path_to_detached + 'deleting_0_7_7_0'))
 
     error = instance.client.query_and_get_error("ALTER TABLE test.attach_partition ATTACH PARTITION 0")
     assert 0 <= error.find('No columns in part 0_5_5_0')
@@ -224,15 +222,18 @@ def test_drop_detached_parts(drop_detached_parts_table):
     exec_bash('mkdir {}'.format(path_to_detached + 'any_other_name'))
     exec_bash('mkdir {}'.format(path_to_detached + 'prefix_1_2_2_0_0'))
 
-    error = instance.client.query_and_get_error("ALTER TABLE test.drop_detached DROP DETACHED PART '../1_2_2_0'", settings=s)
+    error = instance.client.query_and_get_error("ALTER TABLE test.drop_detached DROP DETACHED PART '../1_2_2_0'",
+                                                settings=s)
     assert 0 <= error.find('Invalid part name')
 
     q("ALTER TABLE test.drop_detached DROP DETACHED PART '0_1_1_0'", settings=s)
 
-    error = instance.client.query_and_get_error("ALTER TABLE test.drop_detached DROP DETACHED PART 'attaching_0_6_6_0'", settings=s)
+    error = instance.client.query_and_get_error("ALTER TABLE test.drop_detached DROP DETACHED PART 'attaching_0_6_6_0'",
+                                                settings=s)
     assert 0 <= error.find('Cannot drop part')
 
-    error = instance.client.query_and_get_error("ALTER TABLE test.drop_detached DROP DETACHED PART 'deleting_0_7_7_0'", settings=s)
+    error = instance.client.query_and_get_error("ALTER TABLE test.drop_detached DROP DETACHED PART 'deleting_0_7_7_0'",
+                                                settings=s)
     assert 0 <= error.find('Cannot drop part')
 
     q("ALTER TABLE test.drop_detached DROP DETACHED PART 'any_other_name'", settings=s)

--- a/tests/integration/test_parts_delete_zookeeper/test.py
+++ b/tests/integration/test_parts_delete_zookeeper/test.py
@@ -1,10 +1,9 @@
 import time
+
 import pytest
-
-from helpers.network import PartitionManager
 from helpers.cluster import ClickHouseCluster
+from helpers.network import PartitionManager
 from helpers.test_tools import assert_eq_with_retry
-
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml'], with_zookeeper=True)
@@ -55,7 +54,7 @@ def test_merge_doesnt_work_without_zookeeper(start_cluster):
     with PartitionManager() as pm:
         node1.query("OPTIMIZE TABLE test_table FINAL")
         pm.drop_instance_zk_connections(node1)
-        time.sleep(10) # > old_parts_lifetime
+        time.sleep(10)  # > old_parts_lifetime
         assert node1.query("SELECT count(*) from system.parts where table = 'test_table'") == "3\n"
 
     assert_eq_with_retry(node1, "SELECT count(*) from system.parts where table = 'test_table' and active = 1", "1")

--- a/tests/integration/test_polymorphic_parts/test.py
+++ b/tests/integration/test_polymorphic_parts/test.py
@@ -1,81 +1,92 @@
-import time
-import pytest
+import os
 import random
 import string
-import os
 import struct
 
-from helpers.test_tools import TSV
-from helpers.test_tools import assert_eq_with_retry
+import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
-from multiprocessing.dummy import Pool
+from helpers.test_tools import TSV
+from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 
+
 def get_random_array():
     return [random.randint(0, 1000) % 1000 for _ in range(random.randint(0, 1000))]
+
 
 def get_random_string():
     length = random.randint(0, 1000)
     return ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(length))
 
+
 def insert_random_data(table, node, size):
     data = [
-    '(' + ','.join((
-        "'2019-10-11'",
-        str(i),
-        "'" + get_random_string() + "'",
-        str(get_random_array()))) +
-    ')' for i in range(size)
+        '(' + ','.join((
+            "'2019-10-11'",
+            str(i),
+            "'" + get_random_string() + "'",
+            str(get_random_array()))) +
+        ')' for i in range(size)
     ]
 
     node.query("INSERT INTO {} VALUES {}".format(table, ','.join(data)))
 
+
 def create_tables(name, nodes, node_settings, shard):
     for i, (node, settings) in enumerate(zip(nodes, node_settings)):
         node.query(
-        '''
-        CREATE TABLE {name}(date Date, id UInt32, s String, arr Array(Int32))
-        ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{shard}/{name}', '{repl}')
-        PARTITION BY toYYYYMM(date)
-        ORDER BY id
-        SETTINGS index_granularity = 64, index_granularity_bytes = {index_granularity_bytes},
-        min_rows_for_wide_part = {min_rows_for_wide_part}, min_rows_for_compact_part = {min_rows_for_compact_part},
-        in_memory_parts_enable_wal = 1
-        '''.format(name=name, shard=shard, repl=i, **settings))
+            '''
+            CREATE TABLE {name}(date Date, id UInt32, s String, arr Array(Int32))
+            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{shard}/{name}', '{repl}')
+            PARTITION BY toYYYYMM(date)
+            ORDER BY id
+            SETTINGS index_granularity = 64, index_granularity_bytes = {index_granularity_bytes},
+            min_rows_for_wide_part = {min_rows_for_wide_part}, min_rows_for_compact_part = {min_rows_for_compact_part},
+            in_memory_parts_enable_wal = 1
+            '''.format(name=name, shard=shard, repl=i, **settings))
+
 
 def create_tables_old_format(name, nodes, shard):
     for i, node in enumerate(nodes):
         node.query(
-        '''
-        CREATE TABLE {name}(date Date, id UInt32, s String, arr Array(Int32))
-        ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{shard}/{name}', '{repl}', date, id, 64)
-        '''.format(name=name, shard=shard, repl=i))
+            '''
+            CREATE TABLE {name}(date Date, id UInt32, s String, arr Array(Int32))
+            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{shard}/{name}', '{repl}', date, id, 64)
+            '''.format(name=name, shard=shard, repl=i))
 
-node1 = cluster.add_instance('node1', main_configs=[], user_configs=["configs/users.d/not_optimize_count.xml"], with_zookeeper=True)
-node2 = cluster.add_instance('node2', main_configs=[], user_configs=["configs/users.d/not_optimize_count.xml"], with_zookeeper=True)
 
-settings_default = {'index_granularity_bytes' : 10485760, 'min_rows_for_wide_part' : 512, 'min_rows_for_compact_part' : 0}
-settings_compact_only = {'index_granularity_bytes' : 10485760, 'min_rows_for_wide_part' : 1000000, 'min_rows_for_compact_part' : 0}
-settings_not_adaptive = {'index_granularity_bytes' : 0, 'min_rows_for_wide_part' : 512, 'min_rows_for_compact_part' : 0}
+node1 = cluster.add_instance('node1', main_configs=[], user_configs=["configs/users.d/not_optimize_count.xml"],
+                             with_zookeeper=True)
+node2 = cluster.add_instance('node2', main_configs=[], user_configs=["configs/users.d/not_optimize_count.xml"],
+                             with_zookeeper=True)
 
-node3 = cluster.add_instance('node3', main_configs=[], user_configs=["configs/users.d/not_optimize_count.xml"], with_zookeeper=True)
-node4 = cluster.add_instance('node4', user_configs=["configs/users.d/not_optimize_count.xml"], main_configs=['configs/no_leader.xml'], with_zookeeper=True)
+settings_default = {'index_granularity_bytes': 10485760, 'min_rows_for_wide_part': 512, 'min_rows_for_compact_part': 0}
+settings_compact_only = {'index_granularity_bytes': 10485760, 'min_rows_for_wide_part': 1000000,
+                         'min_rows_for_compact_part': 0}
+settings_not_adaptive = {'index_granularity_bytes': 0, 'min_rows_for_wide_part': 512, 'min_rows_for_compact_part': 0}
 
-settings_compact = {'index_granularity_bytes' : 10485760, 'min_rows_for_wide_part' : 512, 'min_rows_for_compact_part' : 0}
-settings_wide = {'index_granularity_bytes' : 10485760, 'min_rows_for_wide_part' : 0, 'min_rows_for_compact_part' : 0}
+node3 = cluster.add_instance('node3', main_configs=[], user_configs=["configs/users.d/not_optimize_count.xml"],
+                             with_zookeeper=True)
+node4 = cluster.add_instance('node4', user_configs=["configs/users.d/not_optimize_count.xml"],
+                             main_configs=['configs/no_leader.xml'], with_zookeeper=True)
+
+settings_compact = {'index_granularity_bytes': 10485760, 'min_rows_for_wide_part': 512, 'min_rows_for_compact_part': 0}
+settings_wide = {'index_granularity_bytes': 10485760, 'min_rows_for_wide_part': 0, 'min_rows_for_compact_part': 0}
 
 node5 = cluster.add_instance('node5', main_configs=['configs/compact_parts.xml'], with_zookeeper=True)
 node6 = cluster.add_instance('node6', main_configs=['configs/compact_parts.xml'], with_zookeeper=True)
 
-settings_in_memory = {'index_granularity_bytes' : 10485760, 'min_rows_for_wide_part' : 512, 'min_rows_for_compact_part' : 256}
+settings_in_memory = {'index_granularity_bytes': 10485760, 'min_rows_for_wide_part': 512,
+                      'min_rows_for_compact_part': 256}
 
 node9 = cluster.add_instance('node9', with_zookeeper=True, stay_alive=True)
 node10 = cluster.add_instance('node10', with_zookeeper=True)
 
 node11 = cluster.add_instance('node11', main_configs=['configs/do_not_merge.xml'], with_zookeeper=True, stay_alive=True)
 node12 = cluster.add_instance('node12', main_configs=['configs/do_not_merge.xml'], with_zookeeper=True, stay_alive=True)
+
 
 @pytest.fixture(scope="module")
 def start_cluster():
@@ -100,11 +111,12 @@ def start_cluster():
     finally:
         cluster.shutdown()
 
+
 @pytest.mark.parametrize(
     ('first_node', 'second_node'),
     [
-        (node1, node2), # compact parts
-        (node5, node6), # compact parts, old-format
+        (node1, node2),  # compact parts
+        (node5, node6),  # compact parts, old-format
     ]
 )
 def test_polymorphic_parts_basics(start_cluster, first_node, second_node):
@@ -121,9 +133,11 @@ def test_polymorphic_parts_basics(start_cluster, first_node, second_node):
     expected = "Compact\t2\nWide\t1\n"
 
     assert TSV(first_node.query("SELECT part_type, count() FROM system.parts " \
-        "WHERE table = 'polymorphic_table' AND active GROUP BY part_type ORDER BY part_type")) == TSV(expected)
+                                "WHERE table = 'polymorphic_table' AND active GROUP BY part_type ORDER BY part_type")) == TSV(
+        expected)
     assert TSV(second_node.query("SELECT part_type, count() FROM system.parts " \
-        "WHERE table = 'polymorphic_table' AND active GROUP BY part_type ORDER BY part_type")) == TSV(expected)
+                                 "WHERE table = 'polymorphic_table' AND active GROUP BY part_type ORDER BY part_type")) == TSV(
+        expected)
 
     first_node.query("SYSTEM START MERGES")
     second_node.query("SYSTEM START MERGES")
@@ -144,8 +158,10 @@ def test_polymorphic_parts_basics(start_cluster, first_node, second_node):
     assert first_node.query("SELECT count() FROM polymorphic_table") == "2000\n"
     assert second_node.query("SELECT count() FROM polymorphic_table") == "2000\n"
 
-    assert first_node.query("SELECT DISTINCT part_type FROM system.parts WHERE table = 'polymorphic_table' AND active") == "Wide\n"
-    assert second_node.query("SELECT DISTINCT part_type FROM system.parts WHERE table = 'polymorphic_table' AND active") == "Wide\n"
+    assert first_node.query(
+        "SELECT DISTINCT part_type FROM system.parts WHERE table = 'polymorphic_table' AND active") == "Wide\n"
+    assert second_node.query(
+        "SELECT DISTINCT part_type FROM system.parts WHERE table = 'polymorphic_table' AND active") == "Wide\n"
 
     # Check alters and mutations also work
     first_node.query("ALTER TABLE polymorphic_table ADD COLUMN ss String")
@@ -159,6 +175,7 @@ def test_polymorphic_parts_basics(start_cluster, first_node, second_node):
     second_node.query("SELECT count(ss) FROM polymorphic_table") == "2000\n"
     second_node.query("SELECT uniqExact(ss) FROM polymorphic_table") == "600\n"
 
+
 # Checks mostly that merge from compact part to compact part works.
 def test_compact_parts_only(start_cluster):
     for i in range(20):
@@ -171,8 +188,10 @@ def test_compact_parts_only(start_cluster):
     assert node1.query("SELECT count() FROM compact_parts_only") == "4000\n"
     assert node2.query("SELECT count() FROM compact_parts_only") == "4000\n"
 
-    assert node1.query("SELECT DISTINCT part_type FROM system.parts WHERE table = 'compact_parts_only' AND active") == "Compact\n"
-    assert node2.query("SELECT DISTINCT part_type FROM system.parts WHERE table = 'compact_parts_only' AND active") == "Compact\n"
+    assert node1.query(
+        "SELECT DISTINCT part_type FROM system.parts WHERE table = 'compact_parts_only' AND active") == "Compact\n"
+    assert node2.query(
+        "SELECT DISTINCT part_type FROM system.parts WHERE table = 'compact_parts_only' AND active") == "Compact\n"
 
     node1.query("OPTIMIZE TABLE compact_parts_only FINAL")
     node2.query("SYSTEM SYNC REPLICA compact_parts_only", timeout=20)
@@ -180,9 +199,12 @@ def test_compact_parts_only(start_cluster):
 
     expected = "Compact\t1\n"
     assert TSV(node1.query("SELECT part_type, count() FROM system.parts " \
-        "WHERE table = 'compact_parts_only' AND active GROUP BY part_type ORDER BY part_type")) == TSV(expected)
+                           "WHERE table = 'compact_parts_only' AND active GROUP BY part_type ORDER BY part_type")) == TSV(
+        expected)
     assert TSV(node2.query("SELECT part_type, count() FROM system.parts " \
-        "WHERE table = 'compact_parts_only' AND active GROUP BY part_type ORDER BY part_type")) == TSV(expected)
+                           "WHERE table = 'compact_parts_only' AND active GROUP BY part_type ORDER BY part_type")) == TSV(
+        expected)
+
 
 # Check that follower replicas create parts of the same type, which leader has chosen at merge.
 @pytest.mark.parametrize(
@@ -208,16 +230,21 @@ def test_different_part_types_on_replicas(start_cluster, table, part_type):
     expected = "{}\t1\n".format(part_type)
 
     assert TSV(leader.query("SELECT part_type, count() FROM system.parts " \
-        "WHERE table = '{}' AND active GROUP BY part_type ORDER BY part_type".format(table))) == TSV(expected)
+                            "WHERE table = '{}' AND active GROUP BY part_type ORDER BY part_type".format(
+        table))) == TSV(expected)
     assert TSV(follower.query("SELECT part_type, count() FROM system.parts " \
-        "WHERE table = '{}' AND active GROUP BY part_type ORDER BY part_type".format(table))) == TSV(expected)
+                              "WHERE table = '{}' AND active GROUP BY part_type ORDER BY part_type".format(
+        table))) == TSV(expected)
 
 
-node7 = cluster.add_instance('node7', user_configs=["configs_old/users.d/not_optimize_count.xml"], with_zookeeper=True, image='yandex/clickhouse-server', tag='19.17.8.54', stay_alive=True, with_installed_binary=True)
+node7 = cluster.add_instance('node7', user_configs=["configs_old/users.d/not_optimize_count.xml"], with_zookeeper=True,
+                             image='yandex/clickhouse-server', tag='19.17.8.54', stay_alive=True,
+                             with_installed_binary=True)
 node8 = cluster.add_instance('node8', user_configs=["configs/users.d/not_optimize_count.xml"], with_zookeeper=True)
 
-settings7 = {'index_granularity_bytes' : 10485760}
-settings8 = {'index_granularity_bytes' : 10485760, 'min_rows_for_wide_part' : 512, 'min_rows_for_compact_part' : 0}
+settings7 = {'index_granularity_bytes': 10485760}
+settings8 = {'index_granularity_bytes': 10485760, 'min_rows_for_wide_part': 512, 'min_rows_for_compact_part': 0}
+
 
 @pytest.fixture(scope="module")
 def start_cluster_diff_versions():
@@ -225,24 +252,24 @@ def start_cluster_diff_versions():
         for name in ['polymorphic_table', 'polymorphic_table_2']:
             cluster.start()
             node7.query(
-            '''
-            CREATE TABLE {name}(date Date, id UInt32, s String, arr Array(Int32))
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/shard5/{name}', '1')
-            PARTITION BY toYYYYMM(date)
-            ORDER BY id
-            SETTINGS index_granularity = 64, index_granularity_bytes = {index_granularity_bytes}
-            '''.format(name=name, **settings7)
+                '''
+                CREATE TABLE {name}(date Date, id UInt32, s String, arr Array(Int32))
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/shard5/{name}', '1')
+                PARTITION BY toYYYYMM(date)
+                ORDER BY id
+                SETTINGS index_granularity = 64, index_granularity_bytes = {index_granularity_bytes}
+                '''.format(name=name, **settings7)
             )
 
             node8.query(
-            '''
-            CREATE TABLE {name}(date Date, id UInt32, s String, arr Array(Int32))
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/shard5/{name}', '2')
-            PARTITION BY toYYYYMM(date)
-            ORDER BY id
-            SETTINGS index_granularity = 64, index_granularity_bytes = {index_granularity_bytes},
-            min_rows_for_wide_part = {min_rows_for_wide_part}, min_bytes_for_wide_part = {min_bytes_for_wide_part}
-            '''.format(name=name, **settings8)
+                '''
+                CREATE TABLE {name}(date Date, id UInt32, s String, arr Array(Int32))
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/shard5/{name}', '2')
+                PARTITION BY toYYYYMM(date)
+                ORDER BY id
+                SETTINGS index_granularity = 64, index_granularity_bytes = {index_granularity_bytes},
+                min_rows_for_wide_part = {min_rows_for_wide_part}, min_bytes_for_wide_part = {min_bytes_for_wide_part}
+                '''.format(name=name, **settings8)
             )
 
         yield cluster
@@ -262,7 +289,8 @@ def test_polymorphic_parts_diff_versions(start_cluster_diff_versions):
     node8.query("SYSTEM SYNC REPLICA polymorphic_table", timeout=20)
 
     assert node8.query("SELECT count() FROM polymorphic_table") == "100\n"
-    assert node8.query("SELECT DISTINCT part_type FROM system.parts WHERE table = 'polymorphic_table' and active") == "Wide\n"
+    assert node8.query(
+        "SELECT DISTINCT part_type FROM system.parts WHERE table = 'polymorphic_table' and active") == "Wide\n"
 
 
 @pytest.mark.skip(reason="compatability is temporary broken")
@@ -286,7 +314,8 @@ def test_polymorphic_parts_diff_versions_2(start_cluster_diff_versions):
 
     # Works after update
     assert node_old.query("SELECT count() FROM polymorphic_table_2") == "100\n"
-    assert node_old.query("SELECT DISTINCT part_type FROM system.parts WHERE table = 'polymorphic_table_2' and active") == "Compact\n"
+    assert node_old.query(
+        "SELECT DISTINCT part_type FROM system.parts WHERE table = 'polymorphic_table_2' and active") == "Compact\n"
 
 
 def test_polymorphic_parts_non_adaptive(start_cluster):
@@ -300,11 +329,15 @@ def test_polymorphic_parts_non_adaptive(start_cluster):
     node1.query("SYSTEM SYNC REPLICA non_adaptive_table", timeout=20)
 
     assert TSV(node1.query("SELECT part_type, count() FROM system.parts " \
-        "WHERE table = 'non_adaptive_table' AND active GROUP BY part_type ORDER BY part_type")) == TSV("Wide\t2\n")
+                           "WHERE table = 'non_adaptive_table' AND active GROUP BY part_type ORDER BY part_type")) == TSV(
+        "Wide\t2\n")
     assert TSV(node2.query("SELECT part_type, count() FROM system.parts " \
-        "WHERE table = 'non_adaptive_table' AND active GROUP BY part_type ORDER BY part_type")) == TSV("Wide\t2\n")
+                           "WHERE table = 'non_adaptive_table' AND active GROUP BY part_type ORDER BY part_type")) == TSV(
+        "Wide\t2\n")
 
-    assert node1.contains_in_log("<Warning> default.non_adaptive_table: Table can't create parts with adaptive granularity")
+    assert node1.contains_in_log(
+        "<Warning> default.non_adaptive_table: Table can't create parts with adaptive granularity")
+
 
 def test_in_memory(start_cluster):
     node9.query("SYSTEM STOP MERGES")
@@ -320,9 +353,11 @@ def test_in_memory(start_cluster):
     expected = "Compact\t1\nInMemory\t2\nWide\t1\n"
 
     assert TSV(node9.query("SELECT part_type, count() FROM system.parts " \
-        "WHERE table = 'in_memory_table' AND active GROUP BY part_type ORDER BY part_type")) == TSV(expected)
+                           "WHERE table = 'in_memory_table' AND active GROUP BY part_type ORDER BY part_type")) == TSV(
+        expected)
     assert TSV(node10.query("SELECT part_type, count() FROM system.parts " \
-        "WHERE table = 'in_memory_table' AND active GROUP BY part_type ORDER BY part_type")) == TSV(expected)
+                            "WHERE table = 'in_memory_table' AND active GROUP BY part_type ORDER BY part_type")) == TSV(
+        expected)
 
     node9.query("SYSTEM START MERGES")
     node10.query("SYSTEM START MERGES")
@@ -334,9 +369,12 @@ def test_in_memory(start_cluster):
     assert node10.query("SELECT count() FROM in_memory_table") == "1300\n"
 
     assert TSV(node9.query("SELECT part_type, count() FROM system.parts " \
-        "WHERE table = 'in_memory_table' AND active GROUP BY part_type ORDER BY part_type")) == TSV("Wide\t1\n")
+                           "WHERE table = 'in_memory_table' AND active GROUP BY part_type ORDER BY part_type")) == TSV(
+        "Wide\t1\n")
     assert TSV(node10.query("SELECT part_type, count() FROM system.parts " \
-        "WHERE table = 'in_memory_table' AND active GROUP BY part_type ORDER BY part_type")) == TSV("Wide\t1\n")
+                            "WHERE table = 'in_memory_table' AND active GROUP BY part_type ORDER BY part_type")) == TSV(
+        "Wide\t1\n")
+
 
 def test_in_memory_wal(start_cluster):
     # Merges are disabled in config
@@ -347,7 +385,9 @@ def test_in_memory_wal(start_cluster):
 
     def check(node, rows, parts):
         node.query("SELECT count() FROM wal_table") == "{}\n".format(rows)
-        node.query("SELECT count() FROM system.parts WHERE table = 'wal_table' AND part_type = 'InMemory'") == "{}\n".format(parts)
+        node.query(
+            "SELECT count() FROM system.parts WHERE table = 'wal_table' AND part_type = 'InMemory'") == "{}\n".format(
+            parts)
 
     check(node11, 250, 5)
     check(node12, 250, 5)
@@ -383,7 +423,7 @@ def test_in_memory_wal(start_cluster):
     node11.query("SYSTEM SYNC REPLICA wal_table", timeout=20)
     check(node11, 300, 6)
 
-    #Check that new data is written to new wal, but old is still exists for restoring
+    # Check that new data is written to new wal, but old is still exists for restoring
     assert os.path.getsize(wal_file) > 0
     assert os.path.exists(broken_wal_file)
 
@@ -398,6 +438,7 @@ def test_in_memory_wal(start_cluster):
         node11.restart_clickhouse(kill=True)
         check(node11, 300, 6)
 
+
 def test_in_memory_wal_rotate(start_cluster):
     # Write every part to single wal
     node11.query("ALTER TABLE restore_table MODIFY SETTING write_ahead_log_max_bytes = 10")
@@ -409,7 +450,8 @@ def test_in_memory_wal_rotate(start_cluster):
         assert os.path.exists(wal_file)
 
     for node in [node11, node12]:
-        node.query("ALTER TABLE restore_table MODIFY SETTING number_of_free_entries_in_pool_to_lower_max_size_of_merge = 0")
+        node.query(
+            "ALTER TABLE restore_table MODIFY SETTING number_of_free_entries_in_pool_to_lower_max_size_of_merge = 0")
         node.query("ALTER TABLE restore_table MODIFY SETTING max_bytes_to_merge_at_max_space_in_pool = 10000000")
 
     assert_eq_with_retry(node11, "OPTIMIZE TABLE restore_table FINAL SETTINGS optimize_throw_if_noop = 1", "")
@@ -425,6 +467,7 @@ def test_in_memory_wal_rotate(start_cluster):
     assert os.path.exists(wal_file)
     assert os.path.getsize(wal_file) == 0
 
+
 def test_in_memory_deduplication(start_cluster):
     for i in range(3):
         node9.query("INSERT INTO deduplication_table (date, id, s) VALUES (toDate('2020-03-03'), 1, 'foo')")
@@ -436,13 +479,15 @@ def test_in_memory_deduplication(start_cluster):
     assert node9.query("SELECT date, id, s FROM deduplication_table") == "2020-03-03\t1\tfoo\n"
     assert node10.query("SELECT date, id, s FROM deduplication_table") == "2020-03-03\t1\tfoo\n"
 
+
 # Checks that restoring from WAL works after table schema changed
 def test_in_memory_alters(start_cluster):
     def check_parts_type(parts_num):
         assert node9.query("SELECT part_type, count() FROM system.parts WHERE table = 'alters_table' \
              AND active GROUP BY part_type") == "InMemory\t{}\n".format(parts_num)
 
-    node9.query("INSERT INTO alters_table (date, id, s) VALUES (toDate('2020-10-10'), 1, 'ab'), (toDate('2020-10-10'), 2, 'cd')")
+    node9.query(
+        "INSERT INTO alters_table (date, id, s) VALUES (toDate('2020-10-10'), 1, 'ab'), (toDate('2020-10-10'), 2, 'cd')")
     node9.query("ALTER TABLE alters_table ADD COLUMN col1 UInt32")
     node9.restart_clickhouse(kill=True)
 
@@ -461,6 +506,7 @@ def test_in_memory_alters(start_cluster):
 
     expected = expected = "1\t0_foo\n2\t0_foo\n3\t100_foo\n"
     assert node9.query("SELECT id, col1 || '_foo' FROM alters_table")
+
 
 def test_polymorphic_parts_index(start_cluster):
     node1.query('''

--- a/tests/integration/test_profile_events_s3/test.py
+++ b/tests/integration/test_profile_events_s3/test.py
@@ -1,11 +1,8 @@
 import logging
-import random
-import string
-import time
 import re
-import requests
 
 import pytest
+import requests
 from helpers.cluster import ClickHouseCluster
 
 logging.getLogger().setLevel(logging.INFO)
@@ -17,7 +14,8 @@ def cluster():
     try:
         cluster = ClickHouseCluster(__file__)
 
-        cluster.add_instance("node", main_configs=["configs/config.d/storage_conf.xml", "configs/log.xml",  "configs/query_log.xml",  "configs/ssl_conf.xml"], with_minio=True)
+        cluster.add_instance("node", main_configs=["configs/config.d/storage_conf.xml", "configs/log.xml",
+                                                   "configs/query_log.xml", "configs/ssl_conf.xml"], with_minio=True)
 
         logging.info("Starting cluster...")
         cluster.start()
@@ -29,19 +27,20 @@ def cluster():
 
 
 init_list = {
-    "S3ReadMicroseconds" : 0,
-    "S3ReadBytes" : 0,
-    "S3ReadRequestsCount" : 0,
-    "S3ReadRequestsErrorsTotal" : 0,
-    "S3ReadRequestsErrors503" : 0,
-    "S3ReadRequestsRedirects" : 0,
-    "S3WriteMicroseconds" : 0,
-    "S3WriteBytes" : 0,
-    "S3WriteRequestsCount" : 0,
-    "S3WriteRequestsErrorsTotal" : 0,
-    "S3WriteRequestsErrors503" : 0,
-    "S3WriteRequestsRedirects" : 0,
+    "S3ReadMicroseconds": 0,
+    "S3ReadBytes": 0,
+    "S3ReadRequestsCount": 0,
+    "S3ReadRequestsErrorsTotal": 0,
+    "S3ReadRequestsErrors503": 0,
+    "S3ReadRequestsRedirects": 0,
+    "S3WriteMicroseconds": 0,
+    "S3WriteBytes": 0,
+    "S3WriteRequestsCount": 0,
+    "S3WriteRequestsErrorsTotal": 0,
+    "S3WriteRequestsErrors503": 0,
+    "S3WriteRequestsRedirects": 0,
 }
+
 
 def get_s3_events(instance):
     result = init_list.copy()
@@ -55,13 +54,14 @@ def get_s3_events(instance):
 
 def get_minio_stat(cluster):
     result = {
-        "get_requests" : 0,
-        "set_requests" : 0,
-        "errors" : 0,
-        "rx_bytes" : 0,
-        "tx_bytes" : 0,
+        "get_requests": 0,
+        "set_requests": 0,
+        "errors": 0,
+        "rx_bytes": 0,
+        "tx_bytes": 0,
     }
-    stat = requests.get(url="http://{}:{}/minio/prometheus/metrics".format("localhost", cluster.minio_port)).text.split("\n")
+    stat = requests.get(url="http://{}:{}/minio/prometheus/metrics".format("localhost", cluster.minio_port)).text.split(
+        "\n")
     for line in stat:
         x = re.search("s3_requests_total(\{.*\})?\s(\d+)(\s.*)?", line)
         if x != None:
@@ -126,8 +126,10 @@ def test_profile_events(cluster):
     metrics1 = get_s3_events(instance)
     minio1 = get_minio_stat(cluster)
 
-    assert metrics1["S3ReadRequestsCount"] - metrics0["S3ReadRequestsCount"] == minio1["get_requests"] - minio0["get_requests"] - 1 # 1 from get_minio_size
-    assert metrics1["S3WriteRequestsCount"] - metrics0["S3WriteRequestsCount"] == minio1["set_requests"] - minio0["set_requests"]
+    assert metrics1["S3ReadRequestsCount"] - metrics0["S3ReadRequestsCount"] == minio1["get_requests"] - minio0[
+        "get_requests"] - 1  # 1 from get_minio_size
+    assert metrics1["S3WriteRequestsCount"] - metrics0["S3WriteRequestsCount"] == minio1["set_requests"] - minio0[
+        "set_requests"]
     stat1 = get_query_stat(instance, query1)
     for metric in stat1:
         assert stat1[metric] == metrics1[metric] - metrics0[metric]
@@ -140,8 +142,10 @@ def test_profile_events(cluster):
     metrics2 = get_s3_events(instance)
     minio2 = get_minio_stat(cluster)
 
-    assert metrics2["S3ReadRequestsCount"] - metrics1["S3ReadRequestsCount"] == minio2["get_requests"] - minio1["get_requests"] - 1 # 1 from get_minio_size
-    assert metrics2["S3WriteRequestsCount"] - metrics1["S3WriteRequestsCount"] == minio2["set_requests"] - minio1["set_requests"]
+    assert metrics2["S3ReadRequestsCount"] - metrics1["S3ReadRequestsCount"] == minio2["get_requests"] - minio1[
+        "get_requests"] - 1  # 1 from get_minio_size
+    assert metrics2["S3WriteRequestsCount"] - metrics1["S3WriteRequestsCount"] == minio2["set_requests"] - minio1[
+        "set_requests"]
     stat2 = get_query_stat(instance, query2)
     for metric in stat2:
         assert stat2[metric] == metrics2[metric] - metrics1[metric]
@@ -153,8 +157,10 @@ def test_profile_events(cluster):
     metrics3 = get_s3_events(instance)
     minio3 = get_minio_stat(cluster)
 
-    assert metrics3["S3ReadRequestsCount"] - metrics2["S3ReadRequestsCount"] == minio3["get_requests"] - minio2["get_requests"]
-    assert metrics3["S3WriteRequestsCount"] - metrics2["S3WriteRequestsCount"] == minio3["set_requests"] - minio2["set_requests"]
+    assert metrics3["S3ReadRequestsCount"] - metrics2["S3ReadRequestsCount"] == minio3["get_requests"] - minio2[
+        "get_requests"]
+    assert metrics3["S3WriteRequestsCount"] - metrics2["S3WriteRequestsCount"] == minio3["set_requests"] - minio2[
+        "set_requests"]
     stat3 = get_query_stat(instance, query3)
     for metric in stat3:
         assert stat3[metric] == metrics3[metric] - metrics2[metric]

--- a/tests/integration/test_prometheus_endpoint/test.py
+++ b/tests/integration/test_prometheus_endpoint/test.py
@@ -1,14 +1,15 @@
 from __future__ import print_function
-import pytest
 
 import re
-import requests
 import time
 
+import pytest
+import requests
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance('node', main_configs=['configs/prom_conf.xml'])
+
 
 @pytest.fixture(scope="module")
 def start_cluster():
@@ -66,7 +67,6 @@ def get_and_check_metrics(retries):
 
 
 def test_prometheus_endpoint(start_cluster):
-
     metrics_dict = get_and_check_metrics(10)
     assert metrics_dict['ClickHouseProfileEvents_Query'] >= 0
     prev_query_count = metrics_dict['ClickHouseProfileEvents_Query']

--- a/tests/integration/test_quorum_inserts/test.py
+++ b/tests/integration/test_quorum_inserts/test.py
@@ -1,9 +1,8 @@
 import time
 
 import pytest
-
-from helpers.test_tools import TSV
 from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import TSV
 
 cluster = ClickHouseCluster(__file__)
 
@@ -19,9 +18,11 @@ second = cluster.add_instance("second", user_configs=["configs/users.d/settings.
                               macros={"cluster": "anime", "shard": "0", "replica": "second"},
                               with_zookeeper=True)
 
+
 def execute_on_all_cluster(query_):
     for node in [zero, first, second]:
         node.query(query_)
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -47,7 +48,7 @@ def test_simple_add_replica(started_cluster):
 
     first.query("SYSTEM STOP FETCHES test_simple")
 
-    zero.query("INSERT INTO test_simple VALUES (1, '2011-01-01')", settings={'insert_quorum' : 1})
+    zero.query("INSERT INTO test_simple VALUES (1, '2011-01-01')", settings={'insert_quorum': 1})
 
     assert '1\t2011-01-01\n' == zero.query("SELECT * from test_simple")
     assert '' == first.query("SELECT * from test_simple")
@@ -69,7 +70,6 @@ def test_simple_add_replica(started_cluster):
     execute_on_all_cluster("DROP TABLE IF EXISTS test_simple")
 
 
-
 def test_drop_replica_and_achieve_quorum(started_cluster):
     execute_on_all_cluster("DROP TABLE IF EXISTS test_drop_replica_and_achieve_quorum")
 
@@ -86,23 +86,24 @@ def test_drop_replica_and_achieve_quorum(started_cluster):
     first.query("SYSTEM STOP FETCHES test_drop_replica_and_achieve_quorum")
 
     print("Insert to other replica. This query will fail.")
-    quorum_timeout = zero.query_and_get_error("INSERT INTO test_drop_replica_and_achieve_quorum(a,d) VALUES (1, '2011-01-01')",
-                                              settings={'insert_quorum_timeout' : 5000})
+    quorum_timeout = zero.query_and_get_error(
+        "INSERT INTO test_drop_replica_and_achieve_quorum(a,d) VALUES (1, '2011-01-01')",
+        settings={'insert_quorum_timeout': 5000})
     assert "Timeout while waiting for quorum" in quorum_timeout, "Query must fail."
 
     assert TSV("1\t2011-01-01\n") == TSV(zero.query("SELECT * FROM test_drop_replica_and_achieve_quorum",
-                                          settings={'select_sequential_consistency' : 0}))
+                                                    settings={'select_sequential_consistency': 0}))
 
     assert TSV("") == TSV(zero.query("SELECT * FROM test_drop_replica_and_achieve_quorum",
-                                           settings={'select_sequential_consistency' : 1}))
+                                     settings={'select_sequential_consistency': 1}))
 
-    #TODO:(Mikhaylov) begin; maybe delete this lines. I want clickhouse to fetch parts and update quorum.
+    # TODO:(Mikhaylov) begin; maybe delete this lines. I want clickhouse to fetch parts and update quorum.
     print("START FETCHES first replica")
     first.query("SYSTEM START FETCHES test_drop_replica_and_achieve_quorum")
 
     print("SYNC first replica")
     first.query("SYSTEM SYNC REPLICA test_drop_replica_and_achieve_quorum", timeout=20)
-    #TODO:(Mikhaylov) end
+    # TODO:(Mikhaylov) end
 
     print("Add second replica")
     second.query(create_query)
@@ -112,14 +113,17 @@ def test_drop_replica_and_achieve_quorum(started_cluster):
 
     print("Quorum for previous insert achieved.")
     assert TSV("1\t2011-01-01\n") == TSV(second.query("SELECT * FROM test_drop_replica_and_achieve_quorum",
-                                            settings={'select_sequential_consistency' : 1}))
+                                                      settings={'select_sequential_consistency': 1}))
 
     print("Now we can insert some other data.")
     zero.query("INSERT INTO test_drop_replica_and_achieve_quorum(a,d) VALUES (2, '2012-02-02')")
 
-    assert TSV("1\t2011-01-01\n2\t2012-02-02\n") == TSV(zero.query("SELECT * FROM test_drop_replica_and_achieve_quorum ORDER BY a"))
-    assert TSV("1\t2011-01-01\n2\t2012-02-02\n") == TSV(first.query("SELECT * FROM test_drop_replica_and_achieve_quorum ORDER BY a"))
-    assert TSV("1\t2011-01-01\n2\t2012-02-02\n") == TSV(second.query("SELECT * FROM test_drop_replica_and_achieve_quorum ORDER BY a"))
+    assert TSV("1\t2011-01-01\n2\t2012-02-02\n") == TSV(
+        zero.query("SELECT * FROM test_drop_replica_and_achieve_quorum ORDER BY a"))
+    assert TSV("1\t2011-01-01\n2\t2012-02-02\n") == TSV(
+        first.query("SELECT * FROM test_drop_replica_and_achieve_quorum ORDER BY a"))
+    assert TSV("1\t2011-01-01\n2\t2012-02-02\n") == TSV(
+        second.query("SELECT * FROM test_drop_replica_and_achieve_quorum ORDER BY a"))
 
     execute_on_all_cluster("DROP TABLE IF EXISTS test_drop_replica_and_achieve_quorum")
 
@@ -131,7 +135,6 @@ def test_drop_replica_and_achieve_quorum(started_cluster):
         True
     ]
 )
-
 def test_insert_quorum_with_drop_partition(started_cluster, add_new_data):
     execute_on_all_cluster("DROP TABLE IF EXISTS test_quorum_insert_with_drop_partition")
 
@@ -186,20 +189,19 @@ def test_insert_quorum_with_drop_partition(started_cluster, add_new_data):
         True
     ]
 )
-
 def test_insert_quorum_with_move_partition(started_cluster, add_new_data):
     execute_on_all_cluster("DROP TABLE IF EXISTS test_insert_quorum_with_move_partition_source")
     execute_on_all_cluster("DROP TABLE IF EXISTS test_insert_quorum_with_move_partition_destination")
 
     create_source = "CREATE TABLE test_insert_quorum_with_move_partition_source " \
-                   "(a Int8, d Date) " \
-                   "Engine = ReplicatedMergeTree('/clickhouse/tables/{shard}/{table}', '{replica}') " \
-                   "PARTITION BY d ORDER BY a "
-
-    create_destination = "CREATE TABLE test_insert_quorum_with_move_partition_destination " \
                     "(a Int8, d Date) " \
                     "Engine = ReplicatedMergeTree('/clickhouse/tables/{shard}/{table}', '{replica}') " \
                     "PARTITION BY d ORDER BY a "
+
+    create_destination = "CREATE TABLE test_insert_quorum_with_move_partition_destination " \
+                         "(a Int8, d Date) " \
+                         "Engine = ReplicatedMergeTree('/clickhouse/tables/{shard}/{table}', '{replica}') " \
+                         "PARTITION BY d ORDER BY a "
 
     print("Create source Replicated table with three replicas")
     zero.query(create_source)
@@ -218,7 +220,8 @@ def test_insert_quorum_with_move_partition(started_cluster, add_new_data):
     zero.query("INSERT INTO test_insert_quorum_with_move_partition_source(a,d) VALUES(1, '2011-01-01')")
 
     print("Drop partition.")
-    zero.query("ALTER TABLE test_insert_quorum_with_move_partition_source MOVE PARTITION '2011-01-01' TO TABLE test_insert_quorum_with_move_partition_destination")
+    zero.query(
+        "ALTER TABLE test_insert_quorum_with_move_partition_source MOVE PARTITION '2011-01-01' TO TABLE test_insert_quorum_with_move_partition_destination")
 
     if (add_new_data):
         print("Insert to deleted partition")
@@ -237,7 +240,8 @@ def test_insert_quorum_with_move_partition(started_cluster, add_new_data):
     print("Select from updated partition.")
     if (add_new_data):
         assert TSV("2\t2011-01-01\n") == TSV(zero.query("SELECT * FROM test_insert_quorum_with_move_partition_source"))
-        assert TSV("2\t2011-01-01\n") == TSV(second.query("SELECT * FROM test_insert_quorum_with_move_partition_source"))
+        assert TSV("2\t2011-01-01\n") == TSV(
+            second.query("SELECT * FROM test_insert_quorum_with_move_partition_source"))
     else:
         assert TSV("") == TSV(zero.query("SELECT * FROM test_insert_quorum_with_move_partition_source"))
         assert TSV("") == TSV(second.query("SELECT * FROM test_insert_quorum_with_move_partition_source"))
@@ -265,12 +269,13 @@ def test_insert_quorum_with_ttl(started_cluster):
 
     print("Insert should fail since it can not reach the quorum.")
     quorum_timeout = zero.query_and_get_error("INSERT INTO test_insert_quorum_with_ttl(a,d) VALUES(1, '2011-01-01')",
-                                              settings={'insert_quorum_timeout' : 5000})
+                                              settings={'insert_quorum_timeout': 5000})
     assert "Timeout while waiting for quorum" in quorum_timeout, "Query must fail."
 
     print("Wait 10 seconds and TTL merge have to be executed. But it won't delete data.")
     time.sleep(10)
-    assert TSV("1\t2011-01-01\n") == TSV(zero.query("SELECT * FROM test_insert_quorum_with_ttl", settings={'select_sequential_consistency' : 0}))
+    assert TSV("1\t2011-01-01\n") == TSV(
+        zero.query("SELECT * FROM test_insert_quorum_with_ttl", settings={'select_sequential_consistency': 0}))
 
     print("Resume fetches for test_insert_quorum_with_ttl at first replica.")
     first.query("SYSTEM START FETCHES test_insert_quorum_with_ttl")
@@ -279,7 +284,7 @@ def test_insert_quorum_with_ttl(started_cluster):
     first.query("SYSTEM SYNC REPLICA test_insert_quorum_with_ttl")
 
     zero.query("INSERT INTO test_insert_quorum_with_ttl(a,d) VALUES(1, '2011-01-01')",
-                                              settings={'insert_quorum_timeout' : 5000})
+               settings={'insert_quorum_timeout': 5000})
 
     print("Inserts should resume.")
     zero.query("INSERT INTO test_insert_quorum_with_ttl(a, d) VALUES(2, '2012-02-02')")
@@ -288,7 +293,9 @@ def test_insert_quorum_with_ttl(started_cluster):
     first.query("SYSTEM SYNC REPLICA test_insert_quorum_with_ttl")
     zero.query("SYSTEM SYNC REPLICA test_insert_quorum_with_ttl")
 
-    assert TSV("2\t2012-02-02\n") == TSV(first.query("SELECT * FROM test_insert_quorum_with_ttl", settings={'select_sequential_consistency' : 0}))
-    assert TSV("2\t2012-02-02\n") == TSV(first.query("SELECT * FROM test_insert_quorum_with_ttl", settings={'select_sequential_consistency' : 1}))
+    assert TSV("2\t2012-02-02\n") == TSV(
+        first.query("SELECT * FROM test_insert_quorum_with_ttl", settings={'select_sequential_consistency': 0}))
+    assert TSV("2\t2012-02-02\n") == TSV(
+        first.query("SELECT * FROM test_insert_quorum_with_ttl", settings={'select_sequential_consistency': 1}))
 
     execute_on_all_cluster("DROP TABLE IF EXISTS test_insert_quorum_with_ttl")

--- a/tests/integration/test_quota/test.py
+++ b/tests/integration/test_quota/test.py
@@ -1,12 +1,15 @@
-import pytest
-from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry, TSV
 import os
 import re
 import time
 
+import pytest
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry, TSV
+
 cluster = ClickHouseCluster(__file__)
-instance = cluster.add_instance('instance', user_configs=["configs/users.d/assign_myquota.xml", "configs/users.d/drop_default_quota.xml", "configs/users.d/quota.xml"])
+instance = cluster.add_instance('instance', user_configs=["configs/users.d/assign_myquota.xml",
+                                                          "configs/users.d/drop_default_quota.xml",
+                                                          "configs/users.d/quota.xml"])
 
 
 def check_system_quotas(canonical):
@@ -15,35 +18,40 @@ def check_system_quotas(canonical):
     print("system_quotas: {},\ncanonical: {}".format(r, TSV(canonical_tsv)))
     assert r == canonical_tsv
 
+
 def system_quota_limits(canonical):
     canonical_tsv = TSV(canonical)
     r = TSV(instance.query("SELECT * FROM system.quota_limits ORDER BY quota_name, duration"))
     print("system_quota_limits: {},\ncanonical: {}".format(r, TSV(canonical_tsv)))
     assert r == canonical_tsv
 
+
 def system_quota_usage(canonical):
     canonical_tsv = TSV(canonical)
-    query = "SELECT quota_name, quota_key, duration, queries, max_queries, errors, max_errors, result_rows, max_result_rows,"\
-            "result_bytes, max_result_bytes, read_rows, max_read_rows, read_bytes, max_read_bytes, max_execution_time "\
+    query = "SELECT quota_name, quota_key, duration, queries, max_queries, errors, max_errors, result_rows, max_result_rows," \
+            "result_bytes, max_result_bytes, read_rows, max_read_rows, read_bytes, max_read_bytes, max_execution_time " \
             "FROM system.quota_usage ORDER BY duration"
     r = TSV(instance.query(query))
     print("system_quota_usage: {},\ncanonical: {}".format(r, TSV(canonical_tsv)))
     assert r == canonical_tsv
 
+
 def system_quotas_usage(canonical):
     canonical_tsv = TSV(canonical)
-    query = "SELECT quota_name, quota_key, is_current, duration, queries, max_queries, errors, max_errors, result_rows, max_result_rows, "\
-            "result_bytes, max_result_bytes, read_rows, max_read_rows, read_bytes, max_read_bytes, max_execution_time "\
+    query = "SELECT quota_name, quota_key, is_current, duration, queries, max_queries, errors, max_errors, result_rows, max_result_rows, " \
+            "result_bytes, max_result_bytes, read_rows, max_read_rows, read_bytes, max_read_bytes, max_execution_time " \
             "FROM system.quotas_usage ORDER BY quota_name, quota_key, duration"
     r = TSV(instance.query(query))
     print("system_quotas_usage: {},\ncanonical: {}".format(r, TSV(canonical_tsv)))
     assert r == canonical_tsv
 
-def copy_quota_xml(local_file_name, reload_immediately = True):
+
+def copy_quota_xml(local_file_name, reload_immediately=True):
     script_dir = os.path.dirname(os.path.realpath(__file__))
-    instance.copy_file_to_container(os.path.join(script_dir, local_file_name), '/etc/clickhouse-server/users.d/quota.xml')
+    instance.copy_file_to_container(os.path.join(script_dir, local_file_name),
+                                    '/etc/clickhouse-server/users.d/quota.xml')
     if reload_immediately:
-       instance.query("SYSTEM RELOAD CONFIG")
+        instance.query("SYSTEM RELOAD CONFIG")
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -66,52 +74,63 @@ def reset_quotas_and_usage_info():
         yield
     finally:
         instance.query("DROP QUOTA IF EXISTS qA, qB")
-        copy_quota_xml('simpliest.xml') # To reset usage info.
+        copy_quota_xml('simpliest.xml')  # To reset usage info.
         copy_quota_xml('normal_limits.xml')
 
 
 def test_quota_from_users_xml():
-    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", [31556952], 0, "['default']", "[]"]])
+    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", [31556952],
+                          0, "['default']", "[]"]])
     system_quota_limits([["myQuota", 31556952, 0, 1000, "\N", "\N", "\N", 1000, "\N", "\N"]])
     system_quota_usage([["myQuota", "default", 31556952, 0, 1000, 0, "\N", 0, "\N", 0, "\N", 0, 1000, 0, "\N", "\N"]])
-    system_quotas_usage([["myQuota", "default", 1, 31556952, 0, 1000, 0, "\N", 0, "\N", 0, "\N", 0, 1000, 0, "\N", "\N"]])
+    system_quotas_usage(
+        [["myQuota", "default", 1, 31556952, 0, 1000, 0, "\N", 0, "\N", 0, "\N", 0, 1000, 0, "\N", "\N"]])
 
     instance.query("SELECT * from test_table")
-    system_quota_usage([["myQuota", "default", 31556952, 1, 1000, 0, "\N", 50, "\N", 200, "\N", 50, 1000, 200, "\N", "\N"]])
+    system_quota_usage(
+        [["myQuota", "default", 31556952, 1, 1000, 0, "\N", 50, "\N", 200, "\N", 50, 1000, 200, "\N", "\N"]])
 
     instance.query("SELECT COUNT() from test_table")
-    system_quota_usage([["myQuota", "default", 31556952, 2, 1000, 0, "\N", 51, "\N", 208, "\N", 50, 1000, 200, "\N", "\N"]])
+    system_quota_usage(
+        [["myQuota", "default", 31556952, 2, 1000, 0, "\N", 51, "\N", 208, "\N", 50, 1000, 200, "\N", "\N"]])
 
 
 def test_simpliest_quota():
     # Simpliest quota doesn't even track usage.
     copy_quota_xml('simpliest.xml')
-    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", "[]", 0, "['default']", "[]"]])
+    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", "[]", 0,
+                          "['default']", "[]"]])
     system_quota_limits("")
-    system_quota_usage([["myQuota", "default", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N"]])
+    system_quota_usage(
+        [["myQuota", "default", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N"]])
 
     instance.query("SELECT * from test_table")
-    system_quota_usage([["myQuota", "default", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N"]])
+    system_quota_usage(
+        [["myQuota", "default", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N"]])
 
 
 def test_tracking_quota():
     # Now we're tracking usage.
     copy_quota_xml('tracking.xml')
-    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", "[31556952]", 0, "['default']", "[]"]])
+    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", "[31556952]",
+                          0, "['default']", "[]"]])
     system_quota_limits([["myQuota", 31556952, 0, "\N", "\N", "\N", "\N", "\N", "\N", "\N"]])
     system_quota_usage([["myQuota", "default", 31556952, 0, "\N", 0, "\N", 0, "\N", 0, "\N", 0, "\N", 0, "\N", "\N"]])
 
     instance.query("SELECT * from test_table")
-    system_quota_usage([["myQuota", "default", 31556952, 1, "\N", 0, "\N", 50, "\N", 200, "\N", 50, "\N", 200, "\N", "\N"]])
+    system_quota_usage(
+        [["myQuota", "default", 31556952, 1, "\N", 0, "\N", 50, "\N", 200, "\N", 50, "\N", 200, "\N", "\N"]])
 
     instance.query("SELECT COUNT() from test_table")
-    system_quota_usage([["myQuota", "default", 31556952, 2, "\N", 0, "\N", 51, "\N", 208, "\N", 50, "\N", 200, "\N", "\N"]])
+    system_quota_usage(
+        [["myQuota", "default", 31556952, 2, "\N", 0, "\N", 51, "\N", 208, "\N", 50, "\N", 200, "\N", "\N"]])
 
 
 def test_exceed_quota():
     # Change quota, now the limits are tiny so we will exceed the quota.
     copy_quota_xml('tiny_limits.xml')
-    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", "[31556952]", 0, "['default']", "[]"]])
+    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", "[31556952]",
+                          0, "['default']", "[]"]])
     system_quota_limits([["myQuota", 31556952, 0, 1, 1, 1, "\N", 1, "\N", "\N"]])
     system_quota_usage([["myQuota", "default", 31556952, 0, 1, 0, 1, 0, 1, 0, "\N", 0, 1, 0, "\N", "\N"]])
 
@@ -120,75 +139,94 @@ def test_exceed_quota():
 
     # Change quota, now the limits are enough to execute queries.
     copy_quota_xml('normal_limits.xml')
-    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", "[31556952]", 0, "['default']", "[]"]])
+    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", "[31556952]",
+                          0, "['default']", "[]"]])
     system_quota_limits([["myQuota", 31556952, 0, 1000, "\N", "\N", "\N", 1000, "\N", "\N"]])
     system_quota_usage([["myQuota", "default", 31556952, 1, 1000, 1, "\N", 0, "\N", 0, "\N", 50, 1000, 0, "\N", "\N"]])
 
     instance.query("SELECT * from test_table")
-    system_quota_usage([["myQuota", "default", 31556952, 2, 1000, 1, "\N", 50, "\N", 200, "\N", 100, 1000, 200, "\N", "\N"]])
+    system_quota_usage(
+        [["myQuota", "default", 31556952, 2, 1000, 1, "\N", 50, "\N", 200, "\N", 100, 1000, 200, "\N", "\N"]])
 
 
 def test_add_remove_interval():
-    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", [31556952], 0, "['default']", "[]"]])
+    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", [31556952],
+                          0, "['default']", "[]"]])
     system_quota_limits([["myQuota", 31556952, 0, 1000, "\N", "\N", "\N", 1000, "\N", "\N"]])
     system_quota_usage([["myQuota", "default", 31556952, 0, 1000, 0, "\N", 0, "\N", 0, "\N", 0, 1000, 0, "\N", "\N"]])
 
     # Add interval.
     copy_quota_xml('two_intervals.xml')
-    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", "[31556952,63113904]", 0, "['default']", "[]"]])
-    system_quota_limits([["myQuota", 31556952, 0, 1000, "\N", "\N", "\N",  1000, "\N",  "\N"],
-                                     ["myQuota", 63113904, 1, "\N", "\N", "\N", 30000, "\N", 20000, 120]])
-    system_quota_usage([["myQuota", "default", 31556952, 0, 1000, 0, "\N", 0, "\N", 0, "\N",  0, 1000, 0, "\N",  "\N"],
-                                    ["myQuota", "default", 63113904, 0, "\N", 0, "\N", 0, "\N", 0, 30000, 0, "\N", 0, 20000, 120]])
+    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']",
+                          "[31556952,63113904]", 0, "['default']", "[]"]])
+    system_quota_limits([["myQuota", 31556952, 0, 1000, "\N", "\N", "\N", 1000, "\N", "\N"],
+                         ["myQuota", 63113904, 1, "\N", "\N", "\N", 30000, "\N", 20000, 120]])
+    system_quota_usage([["myQuota", "default", 31556952, 0, 1000, 0, "\N", 0, "\N", 0, "\N", 0, 1000, 0, "\N", "\N"],
+                        ["myQuota", "default", 63113904, 0, "\N", 0, "\N", 0, "\N", 0, 30000, 0, "\N", 0, 20000, 120]])
 
     instance.query("SELECT * from test_table")
-    system_quota_usage([["myQuota", "default", 31556952, 1, 1000, 0, "\N", 50, "\N", 200, "\N",  50, 1000, 200, "\N",  "\N"],
-                                    ["myQuota", "default", 63113904, 1, "\N", 0, "\N", 50, "\N", 200, 30000, 50, "\N", 200, 20000, 120]])
+    system_quota_usage(
+        [["myQuota", "default", 31556952, 1, 1000, 0, "\N", 50, "\N", 200, "\N", 50, 1000, 200, "\N", "\N"],
+         ["myQuota", "default", 63113904, 1, "\N", 0, "\N", 50, "\N", 200, 30000, 50, "\N", 200, 20000, 120]])
 
     # Remove interval.
     copy_quota_xml('normal_limits.xml')
-    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", [31556952], 0, "['default']", "[]"]])
+    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", [31556952],
+                          0, "['default']", "[]"]])
     system_quota_limits([["myQuota", 31556952, 0, 1000, "\N", "\N", "\N", 1000, "\N", "\N"]])
-    system_quota_usage([["myQuota", "default", 31556952, 1, 1000, 0, "\N", 50, "\N", 200, "\N",  50, 1000, 200,  "\N", "\N"]])
+    system_quota_usage(
+        [["myQuota", "default", 31556952, 1, 1000, 0, "\N", 50, "\N", 200, "\N", 50, 1000, 200, "\N", "\N"]])
 
     instance.query("SELECT * from test_table")
-    system_quota_usage([["myQuota", "default", 31556952, 2, 1000, 0, "\N", 100, "\N", 400, "\N",  100, 1000, 400,  "\N", "\N"]])
+    system_quota_usage(
+        [["myQuota", "default", 31556952, 2, 1000, 0, "\N", 100, "\N", 400, "\N", 100, 1000, 400, "\N", "\N"]])
 
     # Remove all intervals.
     copy_quota_xml('simpliest.xml')
-    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", "[]", 0, "['default']", "[]"]])
+    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", "[]", 0,
+                          "['default']", "[]"]])
     system_quota_limits("")
-    system_quota_usage([["myQuota", "default", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N"]])
+    system_quota_usage(
+        [["myQuota", "default", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N"]])
 
     instance.query("SELECT * from test_table")
-    system_quota_usage([["myQuota", "default", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N"]])
+    system_quota_usage(
+        [["myQuota", "default", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N", "\N"]])
 
     # Add one interval back.
     copy_quota_xml('normal_limits.xml')
-    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", [31556952], 0, "['default']", "[]"]])
+    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", [31556952],
+                          0, "['default']", "[]"]])
     system_quota_limits([["myQuota", 31556952, 0, 1000, "\N", "\N", "\N", 1000, "\N", "\N"]])
     system_quota_usage([["myQuota", "default", 31556952, 0, 1000, 0, "\N", 0, "\N", 0, "\N", 0, 1000, 0, "\N", "\N"]])
 
 
 def test_add_remove_quota():
-    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", [31556952], 0, "['default']", "[]"]])
+    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", [31556952],
+                          0, "['default']", "[]"]])
     system_quota_limits([["myQuota", 31556952, 0, 1000, "\N", "\N", "\N", 1000, "\N", "\N"]])
-    system_quotas_usage([["myQuota", "default", 1, 31556952, 0, 1000, 0, "\N", 0, "\N", 0, "\N", 0, 1000, 0, "\N", "\N"]])
+    system_quotas_usage(
+        [["myQuota", "default", 1, 31556952, 0, 1000, 0, "\N", 0, "\N", 0, "\N", 0, 1000, 0, "\N", "\N"]])
 
     # Add quota.
     copy_quota_xml('two_quotas.xml')
-    check_system_quotas([["myQuota",  "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']",              "[31556952]",     0, "['default']", "[]"],
-                         ["myQuota2", "4590510c-4d13-bf21-ec8a-c2187b092e73", "users.xml", "['client_key','user_name']", "[3600,2629746]", 0, "[]",          "[]"]])
-    system_quota_limits([["myQuota",  31556952, 0, 1000, "\N", "\N", "\N",   1000, "\N",   "\N"],
-                                     ["myQuota2", 3600,     1, "\N", "\N", 4000, 400000, 4000, 400000, 60],
-                                     ["myQuota2", 2629746,  0, "\N", "\N", "\N", "\N",   "\N", "\N",   1800]])
-    system_quotas_usage([["myQuota", "default", 1, 31556952, 0, 1000, 0, "\N", 0, "\N", 0, "\N", 0, 1000, 0, "\N", "\N"]])
+    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", "[31556952]",
+                          0, "['default']", "[]"],
+                         ["myQuota2", "4590510c-4d13-bf21-ec8a-c2187b092e73", "users.xml", "['client_key','user_name']",
+                          "[3600,2629746]", 0, "[]", "[]"]])
+    system_quota_limits([["myQuota", 31556952, 0, 1000, "\N", "\N", "\N", 1000, "\N", "\N"],
+                         ["myQuota2", 3600, 1, "\N", "\N", 4000, 400000, 4000, 400000, 60],
+                         ["myQuota2", 2629746, 0, "\N", "\N", "\N", "\N", "\N", "\N", 1800]])
+    system_quotas_usage(
+        [["myQuota", "default", 1, 31556952, 0, 1000, 0, "\N", 0, "\N", 0, "\N", 0, 1000, 0, "\N", "\N"]])
 
     # Drop quota.
     copy_quota_xml('normal_limits.xml')
-    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", "[31556952]", 0, "['default']", "[]"]])
+    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", "[31556952]",
+                          0, "['default']", "[]"]])
     system_quota_limits([["myQuota", 31556952, 0, 1000, "\N", "\N", "\N", 1000, "\N", "\N"]])
-    system_quotas_usage([["myQuota", "default", 1, 31556952, 0, 1000, 0, "\N", 0, "\N", 0, "\N", 0, 1000, 0, "\N", "\N"]])
+    system_quotas_usage(
+        [["myQuota", "default", 1, 31556952, 0, 1000, 0, "\N", 0, "\N", 0, "\N", 0, 1000, 0, "\N", "\N"]])
 
     # Drop all quotas.
     copy_quota_xml('no_quotas.xml')
@@ -198,32 +236,42 @@ def test_add_remove_quota():
 
     # Add one quota back.
     copy_quota_xml('normal_limits.xml')
-    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", "[31556952]", 0, "['default']", "[]"]])
+    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", "[31556952]",
+                          0, "['default']", "[]"]])
     system_quota_limits([["myQuota", 31556952, 0, 1000, "\N", "\N", "\N", 1000, "\N", "\N"]])
-    system_quotas_usage([["myQuota", "default", 1, 31556952, 0, 1000, 0, "\N", 0, "\N", 0, "\N", 0, 1000, 0, "\N", "\N"]])
+    system_quotas_usage(
+        [["myQuota", "default", 1, 31556952, 0, 1000, 0, "\N", 0, "\N", 0, "\N", 0, 1000, 0, "\N", "\N"]])
 
 
 def test_reload_users_xml_by_timer():
-    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", "[31556952]", 0, "['default']", "[]"]])
+    check_system_quotas([["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", "['user_name']", "[31556952]",
+                          0, "['default']", "[]"]])
     system_quota_limits([["myQuota", 31556952, 0, 1000, "\N", "\N", "\N", 1000, "\N", "\N"]])
 
-    time.sleep(1) # The modification time of the 'quota.xml' file should be different,
-                  # because config files are reload by timer only when the modification time is changed.
+    time.sleep(1)  # The modification time of the 'quota.xml' file should be different,
+    # because config files are reload by timer only when the modification time is changed.
     copy_quota_xml('tiny_limits.xml', reload_immediately=False)
-    assert_eq_with_retry(instance, "SELECT * FROM system.quotas", [["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", ['user_name'], "[31556952]", 0, "['default']", "[]"]])
-    assert_eq_with_retry(instance, "SELECT * FROM system.quota_limits", [["myQuota", 31556952, 0, 1, 1, 1, "\N", 1, "\N", "\N"]])
+    assert_eq_with_retry(instance, "SELECT * FROM system.quotas", [
+        ["myQuota", "e651da9c-a748-8703-061a-7e5e5096dae7", "users.xml", ['user_name'], "[31556952]", 0, "['default']",
+         "[]"]])
+    assert_eq_with_retry(instance, "SELECT * FROM system.quota_limits",
+                         [["myQuota", 31556952, 0, 1, 1, 1, "\N", 1, "\N", "\N"]])
 
 
 def test_dcl_introspection():
     assert instance.query("SHOW QUOTAS") == "myQuota\n"
-    assert instance.query("SHOW CREATE QUOTA") == "CREATE QUOTA myQuota KEYED BY user_name FOR INTERVAL 1 year MAX queries = 1000, read_rows = 1000 TO default\n"
-    assert instance.query("SHOW CREATE QUOTAS") == "CREATE QUOTA myQuota KEYED BY user_name FOR INTERVAL 1 year MAX queries = 1000, read_rows = 1000 TO default\n"
-    assert re.match("myQuota\\tdefault\\t.*\\t31556952\\t0\\t1000\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t1000\\t0\\t\\\\N\\t.*\\t\\\\N\n",
-                    instance.query("SHOW QUOTA"))
+    assert instance.query(
+        "SHOW CREATE QUOTA") == "CREATE QUOTA myQuota KEYED BY user_name FOR INTERVAL 1 year MAX queries = 1000, read_rows = 1000 TO default\n"
+    assert instance.query(
+        "SHOW CREATE QUOTAS") == "CREATE QUOTA myQuota KEYED BY user_name FOR INTERVAL 1 year MAX queries = 1000, read_rows = 1000 TO default\n"
+    assert re.match(
+        "myQuota\\tdefault\\t.*\\t31556952\\t0\\t1000\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t1000\\t0\\t\\\\N\\t.*\\t\\\\N\n",
+        instance.query("SHOW QUOTA"))
 
     instance.query("SELECT * from test_table")
-    assert re.match("myQuota\\tdefault\\t.*\\t31556952\\t1\\t1000\\t0\\t\\\\N\\t50\\t\\\\N\\t200\\t\\\\N\\t50\\t1000\\t200\\t\\\\N\\t.*\\t\\\\N\n",
-                    instance.query("SHOW QUOTA"))
+    assert re.match(
+        "myQuota\\tdefault\\t.*\\t31556952\\t1\\t1000\\t0\\t\\\\N\\t50\\t\\\\N\\t200\\t\\\\N\\t50\\t1000\\t200\\t\\\\N\\t.*\\t\\\\N\n",
+        instance.query("SHOW QUOTA"))
 
     expected_access = "CREATE QUOTA myQuota KEYED BY user_name FOR INTERVAL 1 year MAX queries = 1000, read_rows = 1000 TO default\n"
     assert expected_access in instance.query("SHOW ACCESS")
@@ -231,20 +279,26 @@ def test_dcl_introspection():
     # Add interval.
     copy_quota_xml('two_intervals.xml')
     assert instance.query("SHOW QUOTAS") == "myQuota\n"
-    assert instance.query("SHOW CREATE QUOTA") == "CREATE QUOTA myQuota KEYED BY user_name FOR INTERVAL 1 year MAX queries = 1000, read_rows = 1000, FOR RANDOMIZED INTERVAL 2 year MAX result_bytes = 30000, read_bytes = 20000, execution_time = 120 TO default\n"
-    assert re.match("myQuota\\tdefault\\t.*\\t31556952\\t1\\t1000\\t0\\t\\\\N\\t50\\t\\\\N\\t200\\t\\\\N\\t50\\t1000\\t200\\t\\\\N\\t.*\\t\\\\N\n"
-                    "myQuota\\tdefault\\t.*\\t63113904\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t30000\\t0\\t\\\\N\\t0\\t20000\\t.*\\t120",
-                    instance.query("SHOW QUOTA"))
+    assert instance.query(
+        "SHOW CREATE QUOTA") == "CREATE QUOTA myQuota KEYED BY user_name FOR INTERVAL 1 year MAX queries = 1000, read_rows = 1000, FOR RANDOMIZED INTERVAL 2 year MAX result_bytes = 30000, read_bytes = 20000, execution_time = 120 TO default\n"
+    assert re.match(
+        "myQuota\\tdefault\\t.*\\t31556952\\t1\\t1000\\t0\\t\\\\N\\t50\\t\\\\N\\t200\\t\\\\N\\t50\\t1000\\t200\\t\\\\N\\t.*\\t\\\\N\n"
+        "myQuota\\tdefault\\t.*\\t63113904\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t30000\\t0\\t\\\\N\\t0\\t20000\\t.*\\t120",
+        instance.query("SHOW QUOTA"))
 
     # Drop interval, add quota.
     copy_quota_xml('two_quotas.xml')
     assert instance.query("SHOW QUOTAS") == "myQuota\nmyQuota2\n"
-    assert instance.query("SHOW CREATE QUOTA myQuota") == "CREATE QUOTA myQuota KEYED BY user_name FOR INTERVAL 1 year MAX queries = 1000, read_rows = 1000 TO default\n"
-    assert instance.query("SHOW CREATE QUOTA myQuota2") == "CREATE QUOTA myQuota2 KEYED BY client_key, user_name FOR RANDOMIZED INTERVAL 1 hour MAX result_rows = 4000, result_bytes = 400000, read_rows = 4000, read_bytes = 400000, execution_time = 60, FOR INTERVAL 1 month MAX execution_time = 1800\n"
-    assert instance.query("SHOW CREATE QUOTAS") == "CREATE QUOTA myQuota KEYED BY user_name FOR INTERVAL 1 year MAX queries = 1000, read_rows = 1000 TO default\n"\
-                                                   "CREATE QUOTA myQuota2 KEYED BY client_key, user_name FOR RANDOMIZED INTERVAL 1 hour MAX result_rows = 4000, result_bytes = 400000, read_rows = 4000, read_bytes = 400000, execution_time = 60, FOR INTERVAL 1 month MAX execution_time = 1800\n"
-    assert re.match("myQuota\\tdefault\\t.*\\t31556952\\t1\\t1000\\t0\\t\\\\N\\t50\\t\\\\N\\t200\\t\\\\N\\t50\\t1000\\t200\\t\\\\N\\t.*\\t\\\\N\n",
-                    instance.query("SHOW QUOTA"))
+    assert instance.query(
+        "SHOW CREATE QUOTA myQuota") == "CREATE QUOTA myQuota KEYED BY user_name FOR INTERVAL 1 year MAX queries = 1000, read_rows = 1000 TO default\n"
+    assert instance.query(
+        "SHOW CREATE QUOTA myQuota2") == "CREATE QUOTA myQuota2 KEYED BY client_key, user_name FOR RANDOMIZED INTERVAL 1 hour MAX result_rows = 4000, result_bytes = 400000, read_rows = 4000, read_bytes = 400000, execution_time = 60, FOR INTERVAL 1 month MAX execution_time = 1800\n"
+    assert instance.query(
+        "SHOW CREATE QUOTAS") == "CREATE QUOTA myQuota KEYED BY user_name FOR INTERVAL 1 year MAX queries = 1000, read_rows = 1000 TO default\n" \
+                                 "CREATE QUOTA myQuota2 KEYED BY client_key, user_name FOR RANDOMIZED INTERVAL 1 hour MAX result_rows = 4000, result_bytes = 400000, read_rows = 4000, read_bytes = 400000, execution_time = 60, FOR INTERVAL 1 month MAX execution_time = 1800\n"
+    assert re.match(
+        "myQuota\\tdefault\\t.*\\t31556952\\t1\\t1000\\t0\\t\\\\N\\t50\\t\\\\N\\t200\\t\\\\N\\t50\\t1000\\t200\\t\\\\N\\t.*\\t\\\\N\n",
+        instance.query("SHOW QUOTA"))
 
     # Drop all quotas.
     copy_quota_xml('no_quotas.xml')
@@ -258,41 +312,54 @@ def test_dcl_management():
     assert instance.query("SHOW QUOTA") == ""
 
     instance.query("CREATE QUOTA qA FOR INTERVAL 15 MONTH MAX QUERIES 123 TO CURRENT_USER")
-    assert instance.query("SHOW CREATE QUOTA qA") == "CREATE QUOTA qA FOR INTERVAL 5 quarter MAX queries = 123 TO default\n"
-    assert re.match("qA\\t\\t.*\\t39446190\\t0\\t123\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t.*\\t\\\\N\n",
-                    instance.query("SHOW QUOTA"))
+    assert instance.query(
+        "SHOW CREATE QUOTA qA") == "CREATE QUOTA qA FOR INTERVAL 5 quarter MAX queries = 123 TO default\n"
+    assert re.match(
+        "qA\\t\\t.*\\t39446190\\t0\\t123\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t.*\\t\\\\N\n",
+        instance.query("SHOW QUOTA"))
 
     instance.query("SELECT * from test_table")
-    assert re.match("qA\\t\\t.*\\t39446190\\t1\\t123\\t0\\t\\\\N\\t50\\t\\\\N\\t200\\t\\\\N\\t50\\t\\\\N\\t200\\t\\\\N\\t.*\\t\\\\N\n",
-                    instance.query("SHOW QUOTA"))
+    assert re.match(
+        "qA\\t\\t.*\\t39446190\\t1\\t123\\t0\\t\\\\N\\t50\\t\\\\N\\t200\\t\\\\N\\t50\\t\\\\N\\t200\\t\\\\N\\t.*\\t\\\\N\n",
+        instance.query("SHOW QUOTA"))
 
-    instance.query("ALTER QUOTA qA FOR INTERVAL 15 MONTH MAX QUERIES 321, MAX ERRORS 10, FOR INTERVAL 0.5 HOUR MAX EXECUTION TIME 0.5")
-    assert instance.query("SHOW CREATE QUOTA qA") == "CREATE QUOTA qA FOR INTERVAL 30 minute MAX execution_time = 0.5, FOR INTERVAL 5 quarter MAX queries = 321, errors = 10 TO default\n"
-    assert re.match("qA\\t\\t.*\\t1800\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t.*\\t0.5\n"
-                    "qA\\t\\t.*\\t39446190\\t1\\t321\\t0\\t10\\t50\\t\\\\N\\t200\\t\\\\N\\t50\\t\\\\N\\t200\\t\\\\N\\t.*\\t\\\\N\n",
-                    instance.query("SHOW QUOTA"))
-
-    instance.query("SELECT * from test_table")
-    assert re.match("qA\\t\\t.*\\t1800\\t1\\t\\\\N\\t0\\t\\\\N\\t50\\t\\\\N\\t200\\t\\\\N\\t50\\t\\\\N\\t200\\t\\\\N\\t.*\\t0.5\n"
-                    "qA\\t\\t.*\\t39446190\\t2\\t321\\t0\\t10\\t100\\t\\\\N\\t400\\t\\\\N\\t100\\t\\\\N\\t400\\t\\\\N\\t.*\\t\\\\N\n",
-                    instance.query("SHOW QUOTA"))
-
-    instance.query("ALTER QUOTA qA FOR INTERVAL 15 MONTH NO LIMITS, FOR RANDOMIZED INTERVAL 16 MONTH TRACKING ONLY, FOR INTERVAL 1800 SECOND NO LIMITS")
-    assert re.match("qA\\t\\t.*\\t42075936\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t.*\\t\\\\N\n",
-                    instance.query("SHOW QUOTA"))
+    instance.query(
+        "ALTER QUOTA qA FOR INTERVAL 15 MONTH MAX QUERIES 321, MAX ERRORS 10, FOR INTERVAL 0.5 HOUR MAX EXECUTION TIME 0.5")
+    assert instance.query(
+        "SHOW CREATE QUOTA qA") == "CREATE QUOTA qA FOR INTERVAL 30 minute MAX execution_time = 0.5, FOR INTERVAL 5 quarter MAX queries = 321, errors = 10 TO default\n"
+    assert re.match(
+        "qA\\t\\t.*\\t1800\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t.*\\t0.5\n"
+        "qA\\t\\t.*\\t39446190\\t1\\t321\\t0\\t10\\t50\\t\\\\N\\t200\\t\\\\N\\t50\\t\\\\N\\t200\\t\\\\N\\t.*\\t\\\\N\n",
+        instance.query("SHOW QUOTA"))
 
     instance.query("SELECT * from test_table")
-    assert re.match("qA\\t\\t.*\\t42075936\\t1\\t\\\\N\\t0\\t\\\\N\\t50\\t\\\\N\\t200\\t\\\\N\\t50\\t\\\\N\\t200\\t\\\\N\\t.*\\t\\\\N\n",
-                    instance.query("SHOW QUOTA"))
+    assert re.match(
+        "qA\\t\\t.*\\t1800\\t1\\t\\\\N\\t0\\t\\\\N\\t50\\t\\\\N\\t200\\t\\\\N\\t50\\t\\\\N\\t200\\t\\\\N\\t.*\\t0.5\n"
+        "qA\\t\\t.*\\t39446190\\t2\\t321\\t0\\t10\\t100\\t\\\\N\\t400\\t\\\\N\\t100\\t\\\\N\\t400\\t\\\\N\\t.*\\t\\\\N\n",
+        instance.query("SHOW QUOTA"))
+
+    instance.query(
+        "ALTER QUOTA qA FOR INTERVAL 15 MONTH NO LIMITS, FOR RANDOMIZED INTERVAL 16 MONTH TRACKING ONLY, FOR INTERVAL 1800 SECOND NO LIMITS")
+    assert re.match(
+        "qA\\t\\t.*\\t42075936\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t0\\t\\\\N\\t.*\\t\\\\N\n",
+        instance.query("SHOW QUOTA"))
+
+    instance.query("SELECT * from test_table")
+    assert re.match(
+        "qA\\t\\t.*\\t42075936\\t1\\t\\\\N\\t0\\t\\\\N\\t50\\t\\\\N\\t200\\t\\\\N\\t50\\t\\\\N\\t200\\t\\\\N\\t.*\\t\\\\N\n",
+        instance.query("SHOW QUOTA"))
 
     instance.query("ALTER QUOTA qA RENAME TO qB")
-    assert instance.query("SHOW CREATE QUOTA qB") == "CREATE QUOTA qB FOR RANDOMIZED INTERVAL 16 month TRACKING ONLY TO default\n"
-    assert re.match("qB\\t\\t.*\\t42075936\\t1\\t\\\\N\\t0\\t\\\\N\\t50\\t\\\\N\\t200\\t\\\\N\\t50\\t\\\\N\\t200\\t\\\\N\\t.*\\t\\\\N\n",
-                    instance.query("SHOW QUOTA"))
+    assert instance.query(
+        "SHOW CREATE QUOTA qB") == "CREATE QUOTA qB FOR RANDOMIZED INTERVAL 16 month TRACKING ONLY TO default\n"
+    assert re.match(
+        "qB\\t\\t.*\\t42075936\\t1\\t\\\\N\\t0\\t\\\\N\\t50\\t\\\\N\\t200\\t\\\\N\\t50\\t\\\\N\\t200\\t\\\\N\\t.*\\t\\\\N\n",
+        instance.query("SHOW QUOTA"))
 
     instance.query("SELECT * from test_table")
-    assert re.match("qB\\t\\t.*\\t42075936\\t2\\t\\\\N\\t0\\t\\\\N\\t100\\t\\\\N\\t400\\t\\\\N\\t100\\t\\\\N\\t400\\t\\\\N\\t.*\\t\\\\N\n",
-                    instance.query("SHOW QUOTA"))
+    assert re.match(
+        "qB\\t\\t.*\\t42075936\\t2\\t\\\\N\\t0\\t\\\\N\\t100\\t\\\\N\\t400\\t\\\\N\\t100\\t\\\\N\\t400\\t\\\\N\\t.*\\t\\\\N\n",
+        instance.query("SHOW QUOTA"))
 
     instance.query("DROP QUOTA qB")
     assert instance.query("SHOW QUOTA") == ""

--- a/tests/integration/test_random_inserts/test.py
+++ b/tests/integration/test_random_inserts/test.py
@@ -1,22 +1,24 @@
-import time
 import os
-import threading
 import random
-from contextlib import contextmanager
+import threading
+import time
 
 import pytest
-
+from helpers.client import CommandRequest
 from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
 from helpers.test_tools import TSV
-from helpers.client import CommandRequest
-
 
 cluster = ClickHouseCluster(__file__)
 
-node1 = cluster.add_instance('node1', main_configs=["configs/conf.d/merge_tree.xml", "configs/conf.d/remote_servers.xml" ], with_zookeeper=True, macros={"layer": 0, "shard": 0, "replica": 1})
-node2 = cluster.add_instance('node2', main_configs=["configs/conf.d/merge_tree.xml", "configs/conf.d/remote_servers.xml" ], with_zookeeper=True, macros={"layer": 0, "shard": 0, "replica": 2})
+node1 = cluster.add_instance('node1',
+                             main_configs=["configs/conf.d/merge_tree.xml", "configs/conf.d/remote_servers.xml"],
+                             with_zookeeper=True, macros={"layer": 0, "shard": 0, "replica": 1})
+node2 = cluster.add_instance('node2',
+                             main_configs=["configs/conf.d/merge_tree.xml", "configs/conf.d/remote_servers.xml"],
+                             with_zookeeper=True, macros={"layer": 0, "shard": 0, "replica": 2})
 nodes = [node1, node2]
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -31,7 +33,7 @@ def started_cluster():
 
 def test_random_inserts(started_cluster):
     # Duration of the test, reduce it if don't want to wait
-    DURATION_SECONDS = 10# * 60
+    DURATION_SECONDS = 10  # * 60
 
     node1.query("""
         CREATE TABLE simple ON CLUSTER test_cluster (date Date, i UInt32, s String)
@@ -39,9 +41,9 @@ def test_random_inserts(started_cluster):
 
     with PartitionManager() as pm_random_drops:
         for sacrifice in nodes:
-            pass # This test doesn't work with partition problems still
-            #pm_random_drops._add_rule({'probability': 0.01, 'destination': sacrifice.ip_address, 'source_port': 2181, 'action': 'REJECT --reject-with tcp-reset'})
-            #pm_random_drops._add_rule({'probability': 0.01, 'source': sacrifice.ip_address, 'destination_port': 2181, 'action': 'REJECT --reject-with tcp-reset'})
+            pass  # This test doesn't work with partition problems still
+            # pm_random_drops._add_rule({'probability': 0.01, 'destination': sacrifice.ip_address, 'source_port': 2181, 'action': 'REJECT --reject-with tcp-reset'})
+            # pm_random_drops._add_rule({'probability': 0.01, 'source': sacrifice.ip_address, 'destination_port': 2181, 'action': 'REJECT --reject-with tcp-reset'})
 
         min_timestamp = int(time.time())
         max_timestamp = min_timestamp + DURATION_SECONDS
@@ -50,18 +52,21 @@ def test_random_inserts(started_cluster):
         bash_script = os.path.join(os.path.dirname(__file__), "test.sh")
         inserters = []
         for node in nodes:
-            cmd = ['/bin/bash', bash_script, node.ip_address, str(min_timestamp), str(max_timestamp), str(cluster.get_client_cmd())]
+            cmd = ['/bin/bash', bash_script, node.ip_address, str(min_timestamp), str(max_timestamp),
+                   str(cluster.get_client_cmd())]
             inserters.append(CommandRequest(cmd, timeout=DURATION_SECONDS * 2, stdin=''))
             print node.name, node.ip_address
 
         for inserter in inserters:
             inserter.get_answer()
 
-    answer="{}\t{}\t{}\t{}\n".format(num_timestamps, num_timestamps, min_timestamp, max_timestamp)
+    answer = "{}\t{}\t{}\t{}\n".format(num_timestamps, num_timestamps, min_timestamp, max_timestamp)
 
     for node in nodes:
-        res = node.query_with_retry("SELECT count(), uniqExact(i), min(i), max(i) FROM simple", check_callback=lambda res: TSV(res) == TSV(answer))
-        assert TSV(res) == TSV(answer), node.name + " : " + node.query("SELECT groupArray(_part), i, count() AS c FROM simple GROUP BY i ORDER BY c DESC LIMIT 1")
+        res = node.query_with_retry("SELECT count(), uniqExact(i), min(i), max(i) FROM simple",
+                                    check_callback=lambda res: TSV(res) == TSV(answer))
+        assert TSV(res) == TSV(answer), node.name + " : " + node.query(
+            "SELECT groupArray(_part), i, count() AS c FROM simple GROUP BY i ORDER BY c DESC LIMIT 1")
 
     node1.query("""DROP TABLE simple ON CLUSTER test_cluster""")
 
@@ -114,13 +119,14 @@ def test_insert_multithreaded(started_cluster):
         node.query("DROP TABLE IF EXISTS repl_test")
 
     for node in nodes:
-        node.query("CREATE TABLE repl_test(d Date, x UInt32) ENGINE ReplicatedMergeTree('/clickhouse/tables/test/repl_test', '{replica}') ORDER BY x PARTITION BY toYYYYMM(d)")
+        node.query(
+            "CREATE TABLE repl_test(d Date, x UInt32) ENGINE ReplicatedMergeTree('/clickhouse/tables/test/repl_test', '{replica}') ORDER BY x PARTITION BY toYYYYMM(d)")
 
     runner = Runner()
 
     threads = []
     for thread_num in range(5):
-        threads.append(threading.Thread(target=runner.do_insert, args=(thread_num, )))
+        threads.append(threading.Thread(target=runner.do_insert, args=(thread_num,)))
 
     for t in threads:
         t.start()
@@ -135,7 +141,7 @@ def test_insert_multithreaded(started_cluster):
     assert runner.total_inserted > 0
 
     all_replicated = False
-    for i in range(100): # wait for replication 50 seconds max
+    for i in range(100):  # wait for replication 50 seconds max
         time.sleep(0.5)
 
         def get_delay(node):

--- a/tests/integration/test_range_hashed_dictionary_types/test.py
+++ b/tests/integration/test_range_hashed_dictionary_types/test.py
@@ -1,7 +1,7 @@
 import pytest
 
-
 from helpers.cluster import ClickHouseCluster
+
 cluster = ClickHouseCluster(__file__)
 
 node1 = cluster.add_instance('node1')
@@ -39,4 +39,5 @@ def test_range_hashed_dict(started_cluster):
     """)
     node1.query("SYSTEM RELOAD DICTIONARY default.rates")
 
-    assert node1.query("SELECT dictGetString('default.rates', 'currency', toUInt64(4990954156238030839), toDateTime('2019-10-01 00:00:00'))") == "RU\n"
+    assert node1.query(
+        "SELECT dictGetString('default.rates', 'currency', toUInt64(4990954156238030839), toDateTime('2019-10-01 00:00:00'))") == "RU\n"

--- a/tests/integration/test_read_temporary_tables_on_failure/test.py
+++ b/tests/integration/test_read_temporary_tables_on_failure/test.py
@@ -1,12 +1,11 @@
 import pytest
-import time
-
-from helpers.cluster import ClickHouseCluster
 from helpers.client import QueryTimeoutExceedException, QueryRuntimeException
+from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 
 node = cluster.add_instance('node')
+
 
 @pytest.fixture(scope="module")
 def start_cluster():
@@ -16,6 +15,7 @@ def start_cluster():
         yield cluster
     finally:
         cluster.shutdown()
+
 
 def test_different_versions(start_cluster):
     with pytest.raises(QueryTimeoutExceedException):

--- a/tests/integration/test_recovery_replica/test.py
+++ b/tests/integration/test_recovery_replica/test.py
@@ -1,22 +1,25 @@
 import time
-import pytest
 
+import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_eq_with_retry
+
 
 def fill_nodes(nodes, shard):
     for node in nodes:
         node.query(
-        '''
-            CREATE DATABASE test;
+            '''
+                CREATE DATABASE test;
+    
+                CREATE TABLE test_table(date Date, id UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test{shard}/replicated', '{replica}') ORDER BY id PARTITION BY toYYYYMM(date) SETTINGS min_replicated_logs_to_keep=3, max_replicated_logs_to_keep=5, cleanup_delay_period=0, cleanup_delay_period_random_add=0;
+            '''.format(shard=shard, replica=node.name))
 
-            CREATE TABLE test_table(date Date, id UInt32)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test{shard}/replicated', '{replica}') ORDER BY id PARTITION BY toYYYYMM(date) SETTINGS min_replicated_logs_to_keep=3, max_replicated_logs_to_keep=5, cleanup_delay_period=0, cleanup_delay_period_random_add=0;
-        '''.format(shard=shard, replica=node.name))
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml'], with_zookeeper=True)
 node2 = cluster.add_instance('node2', main_configs=['configs/remote_servers.xml'], with_zookeeper=True)
+
 
 @pytest.fixture(scope="module")
 def start_cluster():
@@ -33,6 +36,7 @@ def start_cluster():
     finally:
         cluster.shutdown()
 
+
 def test_recovery(start_cluster):
     node1.query("INSERT INTO test_table VALUES (1, 1)")
     time.sleep(1)
@@ -41,6 +45,7 @@ def test_recovery(start_cluster):
     for i in range(100):
         node1.query("INSERT INTO test_table VALUES (1, {})".format(i))
 
-    node2.query_with_retry("ATTACH TABLE test_table", check_callback=lambda x: len(node2.query("select * from test_table")) > 0)
+    node2.query_with_retry("ATTACH TABLE test_table",
+                           check_callback=lambda x: len(node2.query("select * from test_table")) > 0)
 
     assert_eq_with_retry(node2, "SELECT count(*) FROM test_table", node1.query("SELECT count(*) FROM test_table"))

--- a/tests/integration/test_redirect_url_storage/test.py
+++ b/tests/integration/test_redirect_url_storage/test.py
@@ -1,10 +1,10 @@
 import pytest
-from helpers.hdfs_api import HDFSApi
-
 from helpers.cluster import ClickHouseCluster
+from helpers.hdfs_api import HDFSApi
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', with_zookeeper=False, with_hdfs=True)
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -15,14 +15,17 @@ def started_cluster():
     finally:
         cluster.shutdown()
 
+
 def test_url_without_redirect(started_cluster):
     hdfs_api = HDFSApi("root")
     hdfs_api.write_data("/simple_storage", "1\tMark\t72.53\n")
     assert hdfs_api.read_data("/simple_storage") == "1\tMark\t72.53\n"
 
     # access datanode port directly
-    node1.query("create table WebHDFSStorage (id UInt32, name String, weight Float64) ENGINE = URL('http://hdfs1:50075/webhdfs/v1/simple_storage?op=OPEN&namenoderpcaddress=hdfs1:9000&offset=0', 'TSV')")
+    node1.query(
+        "create table WebHDFSStorage (id UInt32, name String, weight Float64) ENGINE = URL('http://hdfs1:50075/webhdfs/v1/simple_storage?op=OPEN&namenoderpcaddress=hdfs1:9000&offset=0', 'TSV')")
     assert node1.query("select * from WebHDFSStorage") == "1\tMark\t72.53\n"
+
 
 def test_url_with_redirect_not_allowed(started_cluster):
     hdfs_api = HDFSApi("root")
@@ -30,9 +33,11 @@ def test_url_with_redirect_not_allowed(started_cluster):
     assert hdfs_api.read_data("/simple_storage") == "1\tMark\t72.53\n"
 
     # access proxy port without allowing redirects
-    node1.query("create table WebHDFSStorageWithoutRedirect (id UInt32, name String, weight Float64) ENGINE = URL('http://hdfs1:50070/webhdfs/v1/simple_storage?op=OPEN&namenoderpcaddress=hdfs1:9000&offset=0', 'TSV')")
+    node1.query(
+        "create table WebHDFSStorageWithoutRedirect (id UInt32, name String, weight Float64) ENGINE = URL('http://hdfs1:50070/webhdfs/v1/simple_storage?op=OPEN&namenoderpcaddress=hdfs1:9000&offset=0', 'TSV')")
     with pytest.raises(Exception):
         assert node1.query("select * from WebHDFSStorageWithoutRedirect") == "1\tMark\t72.53\n"
+
 
 def test_url_with_redirect_allowed(started_cluster):
     hdfs_api = HDFSApi("root")
@@ -41,5 +46,6 @@ def test_url_with_redirect_allowed(started_cluster):
 
     # access proxy port with allowing redirects
     # http://localhost:50070/webhdfs/v1/b?op=OPEN&namenoderpcaddress=hdfs1:9000&offset=0
-    node1.query("create table WebHDFSStorageWithRedirect (id UInt32, name String, weight Float64) ENGINE = URL('http://hdfs1:50070/webhdfs/v1/simple_storage?op=OPEN&namenoderpcaddress=hdfs1:9000&offset=0', 'TSV')")
+    node1.query(
+        "create table WebHDFSStorageWithRedirect (id UInt32, name String, weight Float64) ENGINE = URL('http://hdfs1:50070/webhdfs/v1/simple_storage?op=OPEN&namenoderpcaddress=hdfs1:9000&offset=0', 'TSV')")
     assert node1.query("SET max_http_get_redirects=1; select * from WebHDFSStorageWithRedirect") == "1\tMark\t72.53\n"

--- a/tests/integration/test_relative_filepath/test.py
+++ b/tests/integration/test_relative_filepath/test.py
@@ -6,6 +6,7 @@ cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance('node', main_configs=['configs/config.xml'])
 path_to_userfiles_from_defaut_config = "user_files"
 
+
 @pytest.fixture(scope="module")
 def start_cluster():
     try:
@@ -13,6 +14,7 @@ def start_cluster():
         yield cluster
     finally:
         cluster.shutdown()
+
 
 def test_filepath(start_cluster):
     # 2 rows data

--- a/tests/integration/test_reload_max_table_size_to_drop/test.py
+++ b/tests/integration/test_reload_max_table_size_to_drop/test.py
@@ -1,10 +1,8 @@
-
-import time
-import pytest
 import os
+import time
 
+import pytest
 from helpers.cluster import ClickHouseCluster
-
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance('node', main_configs=["configs/max_table_size_to_drop.xml"])

--- a/tests/integration/test_reloading_storage_configuration/test.py
+++ b/tests/integration/test_reloading_storage_configuration/test.py
@@ -5,27 +5,27 @@ import shutil
 import time
 import xml.etree.ElementTree as ET
 
-import pytest
-
 import helpers.client
 import helpers.cluster
-
+import pytest
 
 cluster = helpers.cluster.ClickHouseCluster(__file__)
 
 node1 = cluster.add_instance('node1',
-            main_configs=['configs/logs_config.xml'],
-            with_zookeeper=True,
-            stay_alive=True,
-            tmpfs=['/jbod1:size=40M', '/jbod2:size=40M', '/jbod3:size=40M', '/jbod4:size=40M', '/external:size=200M'],
-            macros={"shard": 0, "replica": 1} )
+                             main_configs=['configs/logs_config.xml'],
+                             with_zookeeper=True,
+                             stay_alive=True,
+                             tmpfs=['/jbod1:size=40M', '/jbod2:size=40M', '/jbod3:size=40M', '/jbod4:size=40M',
+                                    '/external:size=200M'],
+                             macros={"shard": 0, "replica": 1})
 
 node2 = cluster.add_instance('node2',
-            main_configs=['configs/logs_config.xml'],
-            with_zookeeper=True,
-            stay_alive=True,
-            tmpfs=['/jbod1:size=40M', '/jbod2:size=40M', '/jbod3:size=40M', '/jbod4:size=40M', '/external:size=200M'],
-            macros={"shard": 0, "replica": 2} )
+                             main_configs=['configs/logs_config.xml'],
+                             with_zookeeper=True,
+                             stay_alive=True,
+                             tmpfs=['/jbod1:size=40M', '/jbod2:size=40M', '/jbod3:size=40M', '/jbod4:size=40M',
+                                    '/external:size=200M'],
+                             macros={"shard": 0, "replica": 2})
 
 
 def get_log(node):
@@ -43,7 +43,8 @@ def started_cluster():
 
 
 def start_over():
-    shutil.copy(os.path.join(os.path.dirname(__file__), "configs/config.d/storage_configuration.xml"), os.path.join(node1.config_d_dir, "storage_configuration.xml"))
+    shutil.copy(os.path.join(os.path.dirname(__file__), "configs/config.d/storage_configuration.xml"),
+                os.path.join(node1.config_d_dir, "storage_configuration.xml"))
 
     for node in (node1, node2):
         separate_configuration_path = os.path.join(node.config_d_dir, "separate_configuration.xml")
@@ -62,7 +63,8 @@ def add_disk(node, name, path, separate_file=False):
         else:
             tree = ET.parse(os.path.join(node.config_d_dir, "storage_configuration.xml"))
     except:
-        tree = ET.ElementTree(ET.fromstring('<yandex><storage_configuration><disks/><policies/></storage_configuration></yandex>'))
+        tree = ET.ElementTree(
+            ET.fromstring('<yandex><storage_configuration><disks/><policies/></storage_configuration></yandex>'))
     root = tree.getroot()
     new_disk = ET.Element(name)
     new_path = ET.Element("path")
@@ -178,8 +180,10 @@ def test_add_policy(started_cluster):
 
         disks = set(node1.query("SELECT name FROM system.disks").splitlines())
         assert "cool_policy" in set(node1.query("SELECT policy_name FROM system.storage_policies").splitlines())
-        assert {"volume1"} == set(node1.query("SELECT volume_name FROM system.storage_policies WHERE policy_name = 'cool_policy'").splitlines())
-        assert {"['jbod3','jbod4']"} == set(node1.query("SELECT disks FROM system.storage_policies WHERE policy_name = 'cool_policy'").splitlines())
+        assert {"volume1"} == set(node1.query(
+            "SELECT volume_name FROM system.storage_policies WHERE policy_name = 'cool_policy'").splitlines())
+        assert {"['jbod3','jbod4']"} == set(
+            node1.query("SELECT disks FROM system.storage_policies WHERE policy_name = 'cool_policy'").splitlines())
 
     finally:
         try:
@@ -218,7 +222,8 @@ def test_new_policy_works(started_cluster):
         start_over()
         add_disk(node1, "jbod3", "/jbod3/")
         add_disk(node1, "jbod4", "/jbod4/")
-        add_policy(node1, "cool_policy", collections.OrderedDict([("volume1", ["jbod3"]), ("main", ["jbod1", "jbod2"]), ("external", ["external"])]))
+        add_policy(node1, "cool_policy", collections.OrderedDict(
+            [("volume1", ["jbod3"]), ("main", ["jbod1", "jbod2"]), ("external", ["external"])]))
         node1.query("SYSTEM RELOAD CONFIG")
 
         node1.query("""
@@ -228,7 +233,8 @@ def test_new_policy_works(started_cluster):
         node1.query("""
             INSERT INTO TABLE {name} VALUES (1)
         """.format(name=name))
-        assert {"jbod3"} == set(node1.query("SELECT disk_name FROM system.parts WHERE active = 1 AND table = '{name}'".format(name=name)).splitlines())
+        assert {"jbod3"} == set(node1.query(
+            "SELECT disk_name FROM system.parts WHERE active = 1 AND table = '{name}'".format(name=name)).splitlines())
 
     finally:
         try:
@@ -263,8 +269,10 @@ def test_add_volume_to_policy(started_cluster):
         add_policy(node1, "cool_policy", collections.OrderedDict([("volume1", ["jbod3"]), ("volume2", ["jbod4"])]))
         node1.query("SYSTEM RELOAD CONFIG")
 
-        volumes = set(node1.query("SELECT volume_name FROM system.storage_policies WHERE policy_name = 'cool_policy'").splitlines())
-        disks_sets = set(node1.query("SELECT disks FROM system.storage_policies WHERE policy_name = 'cool_policy'").splitlines())
+        volumes = set(node1.query(
+            "SELECT volume_name FROM system.storage_policies WHERE policy_name = 'cool_policy'").splitlines())
+        disks_sets = set(
+            node1.query("SELECT disks FROM system.storage_policies WHERE policy_name = 'cool_policy'").splitlines())
         assert {"volume1", "volume2"} == volumes
         assert {"['jbod3']", "['jbod4']"} == disks_sets
 
@@ -298,11 +306,13 @@ def test_add_disk_to_policy(started_cluster):
         start_over()
         add_disk(node1, "jbod3", "/jbod3/")
         add_disk(node1, "jbod4", "/jbod4/")
-        add_policy(node1, "cool_policy", {"volume1": ["jbod3","jbod4"]})
+        add_policy(node1, "cool_policy", {"volume1": ["jbod3", "jbod4"]})
         node1.query("SYSTEM RELOAD CONFIG")
 
-        volumes = set(node1.query("SELECT volume_name FROM system.storage_policies WHERE policy_name = 'cool_policy'").splitlines())
-        disks_sets = set(node1.query("SELECT disks FROM system.storage_policies WHERE policy_name = 'cool_policy'").splitlines())
+        volumes = set(node1.query(
+            "SELECT volume_name FROM system.storage_policies WHERE policy_name = 'cool_policy'").splitlines())
+        disks_sets = set(
+            node1.query("SELECT disks FROM system.storage_policies WHERE policy_name = 'cool_policy'").splitlines())
         assert {"volume1"} == volumes
         assert {"['jbod3','jbod4']"} == disks_sets
 
@@ -365,14 +375,16 @@ def test_remove_policy(started_cluster):
             SETTINGS storage_policy='jbods_with_external'
         """.format(name=name, engine=engine))
 
-        assert "remove_policy_cool_policy" in set(node1.query("SELECT policy_name FROM system.storage_policies").splitlines())
+        assert "remove_policy_cool_policy" in set(
+            node1.query("SELECT policy_name FROM system.storage_policies").splitlines())
 
         start_over()
         add_disk(node1, "jbod3", "/jbod3/")
         add_disk(node1, "jbod4", "/jbod4/")
         node1.query("SYSTEM RELOAD CONFIG")
 
-        assert "remove_policy_cool_policy" in set(node1.query("SELECT policy_name FROM system.storage_policies").splitlines())
+        assert "remove_policy_cool_policy" in set(
+            node1.query("SELECT policy_name FROM system.storage_policies").splitlines())
         assert re.search("Error.*remove_policy_cool_policy", get_log(node1))
 
     finally:
@@ -390,7 +402,8 @@ def test_remove_volume_from_policy(started_cluster):
         start_over()
         add_disk(node1, "jbod3", "/jbod3/")
         add_disk(node1, "jbod4", "/jbod4/")
-        add_policy(node1, "test_remove_volume_from_policy_cool_policy", collections.OrderedDict([("volume1", ["jbod3"]), ("volume2", ["jbod4"])]))
+        add_policy(node1, "test_remove_volume_from_policy_cool_policy",
+                   collections.OrderedDict([("volume1", ["jbod3"]), ("volume2", ["jbod4"])]))
         node1.restart_clickhouse(kill=True)
         time.sleep(2)
 
@@ -402,8 +415,10 @@ def test_remove_volume_from_policy(started_cluster):
             SETTINGS storage_policy='jbods_with_external'
         """.format(name=name, engine=engine))
 
-        volumes = set(node1.query("SELECT volume_name FROM system.storage_policies WHERE policy_name = 'test_remove_volume_from_policy_cool_policy'").splitlines())
-        disks_sets = set(node1.query("SELECT disks FROM system.storage_policies WHERE policy_name = 'test_remove_volume_from_policy_cool_policy'").splitlines())
+        volumes = set(node1.query(
+            "SELECT volume_name FROM system.storage_policies WHERE policy_name = 'test_remove_volume_from_policy_cool_policy'").splitlines())
+        disks_sets = set(node1.query(
+            "SELECT disks FROM system.storage_policies WHERE policy_name = 'test_remove_volume_from_policy_cool_policy'").splitlines())
         assert {"volume1", "volume2"} == volumes
         assert {"['jbod3']", "['jbod4']"} == disks_sets
 
@@ -413,8 +428,10 @@ def test_remove_volume_from_policy(started_cluster):
         add_policy(node1, "cool_policy", {"volume1": ["jbod3"]})
         node1.query("SYSTEM RELOAD CONFIG")
 
-        volumes = set(node1.query("SELECT volume_name FROM system.storage_policies WHERE policy_name = 'test_remove_volume_from_policy_cool_policy'").splitlines())
-        disks_sets = set(node1.query("SELECT disks FROM system.storage_policies WHERE policy_name = 'test_remove_volume_from_policy_cool_policy'").splitlines())
+        volumes = set(node1.query(
+            "SELECT volume_name FROM system.storage_policies WHERE policy_name = 'test_remove_volume_from_policy_cool_policy'").splitlines())
+        disks_sets = set(node1.query(
+            "SELECT disks FROM system.storage_policies WHERE policy_name = 'test_remove_volume_from_policy_cool_policy'").splitlines())
         assert {"volume1", "volume2"} == volumes
         assert {"['jbod3']", "['jbod4']"} == disks_sets
         assert re.search("Error.*test_remove_volume_from_policy_cool_policy", get_log(node1))
@@ -434,7 +451,7 @@ def test_remove_disk_from_policy(started_cluster):
         start_over()
         add_disk(node1, "jbod3", "/jbod3/")
         add_disk(node1, "jbod4", "/jbod4/")
-        add_policy(node1, "test_remove_disk_from_policy_cool_policy", {"volume1": ["jbod3","jbod4"]})
+        add_policy(node1, "test_remove_disk_from_policy_cool_policy", {"volume1": ["jbod3", "jbod4"]})
         node1.restart_clickhouse(kill=True)
         time.sleep(2)
 
@@ -446,8 +463,10 @@ def test_remove_disk_from_policy(started_cluster):
             SETTINGS storage_policy='jbods_with_external'
         """.format(name=name, engine=engine))
 
-        volumes = set(node1.query("SELECT volume_name FROM system.storage_policies WHERE policy_name = 'test_remove_disk_from_policy_cool_policy'").splitlines())
-        disks_sets = set(node1.query("SELECT disks FROM system.storage_policies WHERE policy_name = 'test_remove_disk_from_policy_cool_policy'").splitlines())
+        volumes = set(node1.query(
+            "SELECT volume_name FROM system.storage_policies WHERE policy_name = 'test_remove_disk_from_policy_cool_policy'").splitlines())
+        disks_sets = set(node1.query(
+            "SELECT disks FROM system.storage_policies WHERE policy_name = 'test_remove_disk_from_policy_cool_policy'").splitlines())
         assert {"volume1"} == volumes
         assert {"['jbod3','jbod4']"} == disks_sets
 
@@ -457,8 +476,10 @@ def test_remove_disk_from_policy(started_cluster):
         add_policy(node1, "cool_policy", {"volume1": ["jbod3"]})
         node1.query("SYSTEM RELOAD CONFIG")
 
-        volumes = set(node1.query("SELECT volume_name FROM system.storage_policies WHERE policy_name = 'test_remove_disk_from_policy_cool_policy'").splitlines())
-        disks_sets = set(node1.query("SELECT disks FROM system.storage_policies WHERE policy_name = 'test_remove_disk_from_policy_cool_policy'").splitlines())
+        volumes = set(node1.query(
+            "SELECT volume_name FROM system.storage_policies WHERE policy_name = 'test_remove_disk_from_policy_cool_policy'").splitlines())
+        disks_sets = set(node1.query(
+            "SELECT disks FROM system.storage_policies WHERE policy_name = 'test_remove_disk_from_policy_cool_policy'").splitlines())
         assert {"volume1"} == volumes
         assert {"['jbod3','jbod4']"} == disks_sets
         assert re.search("Error.*test_remove_disk_from_policy_cool_policy", get_log(node1))

--- a/tests/integration/test_remote_prewhere/test.py
+++ b/tests/integration/test_remote_prewhere/test.py
@@ -1,13 +1,11 @@
-import time
 import pytest
 
 from helpers.cluster import ClickHouseCluster
-from helpers.client import QueryRuntimeException, QueryTimeoutExceedException
-
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', main_configs=['configs/log_conf.xml'])
 node2 = cluster.add_instance('node2', main_configs=['configs/log_conf.xml'])
+
 
 @pytest.fixture(scope="module")
 def start_cluster():
@@ -32,4 +30,5 @@ def start_cluster():
 
 
 def test_remote(start_cluster):
-    assert node1.query("SELECT 1 FROM remote('node{1,2}', default.test_table) WHERE (APIKey = 137715) AND (CustomAttributeId IN (45, 66)) AND (ProfileIDHash != 0) LIMIT 1") == ""
+    assert node1.query(
+        "SELECT 1 FROM remote('node{1,2}', default.test_table) WHERE (APIKey = 137715) AND (CustomAttributeId IN (45, 66)) AND (ProfileIDHash != 0) LIMIT 1") == ""

--- a/tests/integration/test_replica_can_become_leader/test.py
+++ b/tests/integration/test_replica_can_become_leader/test.py
@@ -1,12 +1,12 @@
 import pytest
-
-from helpers.cluster import ClickHouseCluster
 from helpers.client import QueryRuntimeException
+from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', main_configs=['configs/notleader.xml'], with_zookeeper=True)
 node2 = cluster.add_instance('node2', main_configs=['configs/notleaderignorecase.xml'], with_zookeeper=True)
 node3 = cluster.add_instance('node3', with_zookeeper=True)
+
 
 @pytest.fixture(scope="module")
 def start_cluster():

--- a/tests/integration/test_replicated_merge_tree_s3/test.py
+++ b/tests/integration/test_replicated_merge_tree_s3/test.py
@@ -1,7 +1,6 @@
 import logging
 import random
 import string
-import time
 
 import pytest
 from helpers.cluster import ClickHouseCluster
@@ -15,9 +14,12 @@ def cluster():
     try:
         cluster = ClickHouseCluster(__file__)
 
-        cluster.add_instance("node1", main_configs=["configs/config.d/storage_conf.xml"], macros={'cluster': 'test1'}, with_minio=True, with_zookeeper=True)
-        cluster.add_instance("node2", main_configs=["configs/config.d/storage_conf.xml"], macros={'cluster': 'test1'}, with_zookeeper=True)
-        cluster.add_instance("node3", main_configs=["configs/config.d/storage_conf.xml"], macros={'cluster': 'test1'}, with_zookeeper=True)
+        cluster.add_instance("node1", main_configs=["configs/config.d/storage_conf.xml"], macros={'cluster': 'test1'},
+                             with_minio=True, with_zookeeper=True)
+        cluster.add_instance("node2", main_configs=["configs/config.d/storage_conf.xml"], macros={'cluster': 'test1'},
+                             with_zookeeper=True)
+        cluster.add_instance("node3", main_configs=["configs/config.d/storage_conf.xml"], macros={'cluster': 'test1'},
+                             with_zookeeper=True)
 
         logging.info("Starting cluster...")
         cluster.start()
@@ -39,7 +41,7 @@ def random_string(length):
 
 
 def generate_values(date_str, count, sign=1):
-    data = [[date_str, sign*(i + 1), random_string(10)] for i in range(count)]
+    data = [[date_str, sign * (i + 1), random_string(10)] for i in range(count)]
     data.sort(key=lambda tup: tup[1])
     return ",".join(["('{}',{},'{}')".format(x, y, z) for x, y, z in data])
 
@@ -87,7 +89,9 @@ def test_insert_select_replicated(cluster):
 
     for node_idx in range(1, 4):
         node = cluster.instances["node" + str(node_idx)]
-        assert node.query("SELECT * FROM s3_test order by dt, id FORMAT Values", settings={"select_sequential_consistency": 1}) == all_values
+        assert node.query("SELECT * FROM s3_test order by dt, id FORMAT Values",
+                          settings={"select_sequential_consistency": 1}) == all_values
 
     minio = cluster.minio_client
-    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == 3 * (FILES_OVERHEAD + FILES_OVERHEAD_PER_PART * 3)
+    assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == 3 * (
+            FILES_OVERHEAD + FILES_OVERHEAD_PER_PART * 3)

--- a/tests/integration/test_replicated_mutations/test.py
+++ b/tests/integration/test_replicated_mutations/test.py
@@ -1,25 +1,27 @@
-import time
-import threading
 import random
+import threading
+import time
 from collections import Counter
 
 import pytest
-
 from helpers.cluster import ClickHouseCluster
-
 
 cluster = ClickHouseCluster(__file__)
 
 node1 = cluster.add_instance('node1', macros={'cluster': 'test1'}, with_zookeeper=True)
 # Check, that limits on max part size for merges doesn`t affect mutations
-node2 = cluster.add_instance('node2', macros={'cluster': 'test1'}, main_configs=["configs/merge_tree.xml"], with_zookeeper=True)
+node2 = cluster.add_instance('node2', macros={'cluster': 'test1'}, main_configs=["configs/merge_tree.xml"],
+                             with_zookeeper=True)
 
-node3 = cluster.add_instance('node3', macros={'cluster': 'test2'}, main_configs=["configs/merge_tree_max_parts.xml"], with_zookeeper=True)
-node4 = cluster.add_instance('node4', macros={'cluster': 'test2'}, main_configs=["configs/merge_tree_max_parts.xml"], with_zookeeper=True)
+node3 = cluster.add_instance('node3', macros={'cluster': 'test2'}, main_configs=["configs/merge_tree_max_parts.xml"],
+                             with_zookeeper=True)
+node4 = cluster.add_instance('node4', macros={'cluster': 'test2'}, main_configs=["configs/merge_tree_max_parts.xml"],
+                             with_zookeeper=True)
 
 node5 = cluster.add_instance('node5', macros={'cluster': 'test3'}, main_configs=["configs/merge_tree_max_parts.xml"])
 
 all_nodes = [node1, node2, node3, node4, node5]
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -30,9 +32,11 @@ def started_cluster():
             node.query("DROP TABLE IF EXISTS test_mutations")
 
         for node in [node1, node2, node3, node4]:
-            node.query("CREATE TABLE test_mutations(d Date, x UInt32, i UInt32) ENGINE ReplicatedMergeTree('/clickhouse/{cluster}/tables/test/test_mutations', '{instance}') ORDER BY x PARTITION BY toYYYYMM(d)")
+            node.query(
+                "CREATE TABLE test_mutations(d Date, x UInt32, i UInt32) ENGINE ReplicatedMergeTree('/clickhouse/{cluster}/tables/test/test_mutations', '{instance}') ORDER BY x PARTITION BY toYYYYMM(d)")
 
-        node5.query("CREATE TABLE test_mutations(d Date, x UInt32, i UInt32) ENGINE MergeTree() ORDER BY x PARTITION BY toYYYYMM(d)")
+        node5.query(
+            "CREATE TABLE test_mutations(d Date, x UInt32, i UInt32) ENGINE MergeTree() ORDER BY x PARTITION BY toYYYYMM(d)")
 
         yield cluster
 
@@ -184,7 +188,8 @@ def test_mutations(started_cluster):
 
     print "Total mutations: ", runner.total_mutations
     for node in nodes:
-        print node.query("SELECT mutation_id, command, parts_to_do, is_done FROM system.mutations WHERE table = 'test_mutations' FORMAT TSVWithNames")
+        print node.query(
+            "SELECT mutation_id, command, parts_to_do, is_done FROM system.mutations WHERE table = 'test_mutations' FORMAT TSVWithNames")
     assert all_done
 
     expected_sum = runner.total_inserted_xs - runner.total_deleted_xs
@@ -195,10 +200,10 @@ def test_mutations(started_cluster):
 
 
 @pytest.mark.parametrize(
-    ('nodes', ),
+    ('nodes',),
     [
-        ([node5, ], ),          # MergeTree
-        ([node3, node4], ),     # ReplicatedMergeTree
+        ([node5, ],),  # MergeTree
+        ([node3, node4],),  # ReplicatedMergeTree
     ]
 )
 def test_mutations_dont_prevent_merges(started_cluster, nodes):
@@ -228,8 +233,10 @@ def test_mutations_dont_prevent_merges(started_cluster, nodes):
         t.join()
 
     for node in nodes:
-        print node.query("SELECT mutation_id, command, parts_to_do, is_done FROM system.mutations WHERE table = 'test_mutations' FORMAT TSVWithNames")
-        print node.query("SELECT partition, count(name), sum(active), sum(active*rows) FROM system.parts WHERE table ='test_mutations' GROUP BY partition FORMAT TSVWithNames")
+        print node.query(
+            "SELECT mutation_id, command, parts_to_do, is_done FROM system.mutations WHERE table = 'test_mutations' FORMAT TSVWithNames")
+        print node.query(
+            "SELECT partition, count(name), sum(active), sum(active*rows) FROM system.parts WHERE table ='test_mutations' GROUP BY partition FORMAT TSVWithNames")
 
     assert all_done
     assert all([str(e).find("Too many parts") < 0 for e in runner.exceptions])

--- a/tests/integration/test_replicated_parse_zk_metadata/test.py
+++ b/tests/integration/test_replicated_parse_zk_metadata/test.py
@@ -5,6 +5,7 @@ from helpers.cluster import ClickHouseCluster
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance('node', with_zookeeper=True)
 
+
 @pytest.fixture(scope='module', autouse=True)
 def started_cluster():
     try:
@@ -13,17 +14,18 @@ def started_cluster():
     finally:
         cluster.shutdown()
 
+
 def test_replicated_engine_parse_metadata_on_attach():
     node.query(
-    '''
-    CREATE TABLE data (
-        key Int,
-        INDEX key_idx0 key+0 TYPE minmax GRANULARITY 1,
-        INDEX key_idx1 key+1 TYPE minmax GRANULARITY 1
-    )
-    ENGINE = ReplicatedMergeTree('/ch/tables/default/data', 'node')
-    ORDER BY key;
-    ''')
+        '''
+        CREATE TABLE data (
+            key Int,
+            INDEX key_idx0 key+0 TYPE minmax GRANULARITY 1,
+            INDEX key_idx1 key+1 TYPE minmax GRANULARITY 1
+        )
+        ENGINE = ReplicatedMergeTree('/ch/tables/default/data', 'node')
+        ORDER BY key;
+        ''')
     node.query('DETACH TABLE data')
 
     zk = cluster.get_kazoo_client('zoo1')

--- a/tests/integration/test_replicating_constants/test.py
+++ b/tests/integration/test_replicating_constants/test.py
@@ -5,7 +5,9 @@ from helpers.cluster import ClickHouseCluster
 cluster = ClickHouseCluster(__file__)
 
 node1 = cluster.add_instance('node1', with_zookeeper=True)
-node2 = cluster.add_instance('node2', with_zookeeper=True, image='yandex/clickhouse-server', tag='19.1.14', with_installed_binary=True)
+node2 = cluster.add_instance('node2', with_zookeeper=True, image='yandex/clickhouse-server', tag='19.1.14',
+                             with_installed_binary=True)
+
 
 @pytest.fixture(scope="module")
 def start_cluster():
@@ -16,6 +18,6 @@ def start_cluster():
     finally:
         cluster.shutdown()
 
-def test_different_versions(start_cluster):
 
+def test_different_versions(start_cluster):
     assert node1.query("SELECT uniqExact(x) FROM (SELECT version() as x from remote('node{1,2}', system.one))") == "2\n"

--- a/tests/integration/test_replication_credentials/test.py
+++ b/tests/integration/test_replication_credentials/test.py
@@ -1,22 +1,25 @@
 import time
-import pytest
 
+import pytest
 from helpers.cluster import ClickHouseCluster
 
 
 def _fill_nodes(nodes, shard):
     for node in nodes:
         node.query(
-        '''
-            CREATE DATABASE test;
+            '''
+                CREATE DATABASE test;
+    
+                CREATE TABLE test_table(date Date, id UInt32, dummy UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test{shard}/replicated', '{replica}', date, id, 8192);
+            '''.format(shard=shard, replica=node.name))
 
-            CREATE TABLE test_table(date Date, id UInt32, dummy UInt32)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test{shard}/replicated', '{replica}', date, id, 8192);
-        '''.format(shard=shard, replica=node.name))
 
 cluster = ClickHouseCluster(__file__)
-node1 = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml', 'configs/credentials1.xml'], with_zookeeper=True)
-node2 = cluster.add_instance('node2', main_configs=['configs/remote_servers.xml', 'configs/credentials1.xml'], with_zookeeper=True)
+node1 = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml', 'configs/credentials1.xml'],
+                             with_zookeeper=True)
+node2 = cluster.add_instance('node2', main_configs=['configs/remote_servers.xml', 'configs/credentials1.xml'],
+                             with_zookeeper=True)
 
 
 @pytest.fixture(scope="module")
@@ -30,6 +33,7 @@ def same_credentials_cluster():
 
     finally:
         cluster.shutdown()
+
 
 def test_same_credentials(same_credentials_cluster):
     node1.query("insert into test_table values ('2017-06-16', 111, 0)")
@@ -45,8 +49,11 @@ def test_same_credentials(same_credentials_cluster):
     assert node2.query("SELECT id FROM test_table order by id") == '111\n222\n'
 
 
-node3 = cluster.add_instance('node3', main_configs=['configs/remote_servers.xml', 'configs/no_credentials.xml'], with_zookeeper=True)
-node4 = cluster.add_instance('node4', main_configs=['configs/remote_servers.xml', 'configs/no_credentials.xml'], with_zookeeper=True)
+node3 = cluster.add_instance('node3', main_configs=['configs/remote_servers.xml', 'configs/no_credentials.xml'],
+                             with_zookeeper=True)
+node4 = cluster.add_instance('node4', main_configs=['configs/remote_servers.xml', 'configs/no_credentials.xml'],
+                             with_zookeeper=True)
+
 
 @pytest.fixture(scope="module")
 def no_credentials_cluster():
@@ -74,8 +81,12 @@ def test_no_credentials(no_credentials_cluster):
     assert node3.query("SELECT id FROM test_table order by id") == '111\n222\n'
     assert node4.query("SELECT id FROM test_table order by id") == '111\n222\n'
 
-node5 = cluster.add_instance('node5', main_configs=['configs/remote_servers.xml', 'configs/credentials1.xml'], with_zookeeper=True)
-node6 = cluster.add_instance('node6', main_configs=['configs/remote_servers.xml', 'configs/credentials2.xml'], with_zookeeper=True)
+
+node5 = cluster.add_instance('node5', main_configs=['configs/remote_servers.xml', 'configs/credentials1.xml'],
+                             with_zookeeper=True)
+node6 = cluster.add_instance('node6', main_configs=['configs/remote_servers.xml', 'configs/credentials2.xml'],
+                             with_zookeeper=True)
+
 
 @pytest.fixture(scope="module")
 def different_credentials_cluster():
@@ -88,6 +99,7 @@ def different_credentials_cluster():
 
     finally:
         cluster.shutdown()
+
 
 def test_different_credentials(different_credentials_cluster):
     node5.query("insert into test_table values ('2017-06-20', 111, 0)")
@@ -102,8 +114,12 @@ def test_different_credentials(different_credentials_cluster):
     assert node5.query("SELECT id FROM test_table order by id") == '111\n'
     assert node6.query("SELECT id FROM test_table order by id") == '222\n'
 
-node7 = cluster.add_instance('node7', main_configs=['configs/remote_servers.xml', 'configs/credentials1.xml'], with_zookeeper=True)
-node8 = cluster.add_instance('node8', main_configs=['configs/remote_servers.xml', 'configs/no_credentials.xml'], with_zookeeper=True)
+
+node7 = cluster.add_instance('node7', main_configs=['configs/remote_servers.xml', 'configs/credentials1.xml'],
+                             with_zookeeper=True)
+node8 = cluster.add_instance('node8', main_configs=['configs/remote_servers.xml', 'configs/no_credentials.xml'],
+                             with_zookeeper=True)
+
 
 @pytest.fixture(scope="module")
 def credentials_and_no_credentials_cluster():
@@ -117,6 +133,7 @@ def credentials_and_no_credentials_cluster():
     finally:
         cluster.shutdown()
 
+
 def test_credentials_and_no_credentials(credentials_and_no_credentials_cluster):
     node7.query("insert into test_table values ('2017-06-21', 111, 0)")
     time.sleep(1)
@@ -129,4 +146,3 @@ def test_credentials_and_no_credentials(credentials_and_no_credentials_cluster):
 
     assert node7.query("SELECT id FROM test_table order by id") == '111\n'
     assert node8.query("SELECT id FROM test_table order by id") == '222\n'
-

--- a/tests/integration/test_replication_without_zookeeper/test.py
+++ b/tests/integration/test_replication_without_zookeeper/test.py
@@ -1,8 +1,7 @@
 import time
-import pytest
 
+import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml'], with_zookeeper=True, stay_alive=True)
@@ -50,4 +49,3 @@ def test_startup_without_zookeeper(start_cluster):
 
     assert node1.query("SELECT COUNT(*) from test_table") == "3\n"
     assert node1.query("SELECT is_readonly from system.replicas where table='test_table'") == "1\n"
-

--- a/tests/integration/test_role/test.py
+++ b/tests/integration/test_role/test.py
@@ -1,7 +1,6 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
-import re
 
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance('instance')
@@ -11,7 +10,7 @@ instance = cluster.add_instance('instance')
 def started_cluster():
     try:
         cluster.start()
-        
+
         instance.query("CREATE TABLE test_table(x UInt32, y UInt32) ENGINE = MergeTree ORDER BY tuple()")
         instance.query("INSERT INTO test_table VALUES (1,5), (2,10)")
 
@@ -35,7 +34,7 @@ def test_create_role():
     instance.query('CREATE ROLE R1')
 
     assert "Not enough privileges" in instance.query_and_get_error("SELECT * FROM test_table", user='A')
-    
+
     instance.query('GRANT SELECT ON test_table TO R1')
     assert "Not enough privileges" in instance.query_and_get_error("SELECT * FROM test_table", user='A')
 
@@ -52,13 +51,13 @@ def test_grant_role_to_role():
     instance.query('CREATE ROLE R2')
 
     assert "Not enough privileges" in instance.query_and_get_error("SELECT * FROM test_table", user='A')
-    
+
     instance.query('GRANT R1 TO A')
     assert "Not enough privileges" in instance.query_and_get_error("SELECT * FROM test_table", user='A')
-    
+
     instance.query('GRANT R2 TO R1')
     assert "Not enough privileges" in instance.query_and_get_error("SELECT * FROM test_table", user='A')
-    
+
     instance.query('GRANT SELECT ON test_table TO R2')
     assert instance.query("SELECT * FROM test_table", user='A') == "1\t5\n2\t10\n"
 
@@ -69,12 +68,12 @@ def test_combine_privileges():
     instance.query('CREATE ROLE R2')
 
     assert "Not enough privileges" in instance.query_and_get_error("SELECT * FROM test_table", user='A')
-    
+
     instance.query('GRANT R1 TO A')
     instance.query('GRANT SELECT(x) ON test_table TO R1')
     assert "Not enough privileges" in instance.query_and_get_error("SELECT * FROM test_table", user='A')
     assert instance.query("SELECT x FROM test_table", user='A') == "1\n2\n"
-    
+
     instance.query('GRANT SELECT(y) ON test_table TO R2')
     instance.query('GRANT R2 TO A')
     assert instance.query("SELECT * FROM test_table", user='A') == "1\t5\n2\t10\n"
@@ -100,7 +99,7 @@ def test_admin_option():
 def test_revoke_requires_admin_option():
     instance.query("CREATE USER A, B")
     instance.query("CREATE ROLE R1, R2")
-    
+
     instance.query("GRANT R1 TO B")
     assert instance.query("SHOW GRANTS FOR B") == "GRANT R1 TO B\n"
 
@@ -150,25 +149,28 @@ def test_introspection():
     instance.query('GRANT CREATE ON *.* TO B WITH GRANT OPTION')
     instance.query('REVOKE SELECT(x) ON test.table FROM R2')
 
-    assert instance.query("SHOW ROLES") == TSV([ "R1", "R2" ])
-    assert instance.query("SHOW CREATE ROLE R1") == TSV([ "CREATE ROLE R1" ])
-    assert instance.query("SHOW CREATE ROLE R2") == TSV([ "CREATE ROLE R2" ])
-    assert instance.query("SHOW CREATE ROLES R1, R2") == TSV([ "CREATE ROLE R1", "CREATE ROLE R2" ])
-    assert instance.query("SHOW CREATE ROLES") == TSV([ "CREATE ROLE R1", "CREATE ROLE R2" ])
+    assert instance.query("SHOW ROLES") == TSV(["R1", "R2"])
+    assert instance.query("SHOW CREATE ROLE R1") == TSV(["CREATE ROLE R1"])
+    assert instance.query("SHOW CREATE ROLE R2") == TSV(["CREATE ROLE R2"])
+    assert instance.query("SHOW CREATE ROLES R1, R2") == TSV(["CREATE ROLE R1", "CREATE ROLE R2"])
+    assert instance.query("SHOW CREATE ROLES") == TSV(["CREATE ROLE R1", "CREATE ROLE R2"])
 
-    assert instance.query("SHOW GRANTS FOR A") == TSV([ "GRANT SELECT ON test.table TO A", "GRANT R1 TO A" ])
-    assert instance.query("SHOW GRANTS FOR B") == TSV([ "GRANT CREATE ON *.* TO B WITH GRANT OPTION", "GRANT R2 TO B WITH ADMIN OPTION" ])
+    assert instance.query("SHOW GRANTS FOR A") == TSV(["GRANT SELECT ON test.table TO A", "GRANT R1 TO A"])
+    assert instance.query("SHOW GRANTS FOR B") == TSV(
+        ["GRANT CREATE ON *.* TO B WITH GRANT OPTION", "GRANT R2 TO B WITH ADMIN OPTION"])
     assert instance.query("SHOW GRANTS FOR R1") == ""
-    assert instance.query("SHOW GRANTS FOR R2") == TSV([ "GRANT SELECT ON test.table TO R2", "REVOKE SELECT(x) ON test.table FROM R2" ])
+    assert instance.query("SHOW GRANTS FOR R2") == TSV(
+        ["GRANT SELECT ON test.table TO R2", "REVOKE SELECT(x) ON test.table FROM R2"])
 
-    assert instance.query("SHOW GRANTS", user='A') == TSV([ "GRANT SELECT ON test.table TO A", "GRANT R1 TO A" ])
-    assert instance.query("SHOW GRANTS", user='B') == TSV([ "GRANT CREATE ON *.* TO B WITH GRANT OPTION", "GRANT R2 TO B WITH ADMIN OPTION" ])
-    assert instance.query("SHOW CURRENT ROLES", user='A') == TSV([[ "R1", 0, 1 ]])
-    assert instance.query("SHOW CURRENT ROLES", user='B') == TSV([[ "R2", 1, 1 ]])
-    assert instance.query("SHOW ENABLED ROLES", user='A') == TSV([[ "R1", 0, 1, 1 ]])
-    assert instance.query("SHOW ENABLED ROLES", user='B') == TSV([[ "R2", 1, 1, 1 ]])
+    assert instance.query("SHOW GRANTS", user='A') == TSV(["GRANT SELECT ON test.table TO A", "GRANT R1 TO A"])
+    assert instance.query("SHOW GRANTS", user='B') == TSV(
+        ["GRANT CREATE ON *.* TO B WITH GRANT OPTION", "GRANT R2 TO B WITH ADMIN OPTION"])
+    assert instance.query("SHOW CURRENT ROLES", user='A') == TSV([["R1", 0, 1]])
+    assert instance.query("SHOW CURRENT ROLES", user='B') == TSV([["R2", 1, 1]])
+    assert instance.query("SHOW ENABLED ROLES", user='A') == TSV([["R1", 0, 1, 1]])
+    assert instance.query("SHOW ENABLED ROLES", user='B') == TSV([["R2", 1, 1, 1]])
 
-    expected_access1 = "CREATE ROLE R1\n"\
+    expected_access1 = "CREATE ROLE R1\n" \
                        "CREATE ROLE R2\n"
     expected_access2 = "GRANT R1 TO A\n"
     expected_access3 = "GRANT R2 TO B WITH ADMIN OPTION"
@@ -176,21 +178,23 @@ def test_introspection():
     assert expected_access2 in instance.query("SHOW ACCESS")
     assert expected_access3 in instance.query("SHOW ACCESS")
 
-    assert instance.query("SELECT name, storage from system.roles WHERE name IN ('R1', 'R2') ORDER BY name") ==\
-           TSV([[ "R1", "local directory" ],
-                [ "R2", "local directory" ]])
+    assert instance.query("SELECT name, storage from system.roles WHERE name IN ('R1', 'R2') ORDER BY name") == \
+           TSV([["R1", "local directory"],
+                ["R2", "local directory"]])
 
-    assert instance.query("SELECT * from system.grants WHERE user_name IN ('A', 'B') OR role_name IN ('R1', 'R2') ORDER BY user_name, role_name, access_type, grant_option") ==\
-           TSV([[ "A",  "\N", "SELECT", "test", "table", "\N", 0, 0 ],
-                [ "B",  "\N", "CREATE", "\N",   "\N",    "\N", 0, 1 ],
-                [ "\N", "R2", "SELECT", "test", "table", "\N", 0, 0 ],
-                [ "\N", "R2", "SELECT", "test", "table", "x",  1, 0 ]])
+    assert instance.query(
+        "SELECT * from system.grants WHERE user_name IN ('A', 'B') OR role_name IN ('R1', 'R2') ORDER BY user_name, role_name, access_type, grant_option") == \
+           TSV([["A", "\N", "SELECT", "test", "table", "\N", 0, 0],
+                ["B", "\N", "CREATE", "\N", "\N", "\N", 0, 1],
+                ["\N", "R2", "SELECT", "test", "table", "\N", 0, 0],
+                ["\N", "R2", "SELECT", "test", "table", "x", 1, 0]])
 
-    assert instance.query("SELECT * from system.role_grants WHERE user_name IN ('A', 'B') OR role_name IN ('R1', 'R2') ORDER BY user_name, role_name, granted_role_name") ==\
-           TSV([[ "A", "\N", "R1", 1, 0 ],
-                [ "B", "\N", "R2", 1, 1 ]])
+    assert instance.query(
+        "SELECT * from system.role_grants WHERE user_name IN ('A', 'B') OR role_name IN ('R1', 'R2') ORDER BY user_name, role_name, granted_role_name") == \
+           TSV([["A", "\N", "R1", 1, 0],
+                ["B", "\N", "R2", 1, 1]])
 
-    assert instance.query("SELECT * from system.current_roles ORDER BY role_name", user='A') == TSV([[ "R1", 0, 1 ]])
-    assert instance.query("SELECT * from system.current_roles ORDER BY role_name", user='B') == TSV([[ "R2", 1, 1 ]])
-    assert instance.query("SELECT * from system.enabled_roles ORDER BY role_name", user='A') == TSV([[ "R1", 0, 1, 1 ]])
-    assert instance.query("SELECT * from system.enabled_roles ORDER BY role_name", user='B') == TSV([[ "R2", 1, 1, 1 ]])
+    assert instance.query("SELECT * from system.current_roles ORDER BY role_name", user='A') == TSV([["R1", 0, 1]])
+    assert instance.query("SELECT * from system.current_roles ORDER BY role_name", user='B') == TSV([["R2", 1, 1]])
+    assert instance.query("SELECT * from system.enabled_roles ORDER BY role_name", user='A') == TSV([["R1", 0, 1, 1]])
+    assert instance.query("SELECT * from system.enabled_roles ORDER BY role_name", user='B') == TSV([["R2", 1, 1, 1]])

--- a/tests/integration/test_row_policy/test.py
+++ b/tests/integration/test_row_policy/test.py
@@ -1,20 +1,28 @@
-import pytest
-from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry, TSV
 import os
 import re
 import time
 
+import pytest
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry, TSV
+
 cluster = ClickHouseCluster(__file__)
-node = cluster.add_instance('node', main_configs=["configs/config.d/remote_servers.xml"], user_configs=["configs/users.d/row_policy.xml", "configs/users.d/another_user.xml", "configs/users.d/any_join_distinct_right_table_keys.xml"], with_zookeeper=True)
-node2 = cluster.add_instance('node2', main_configs=["configs/config.d/remote_servers.xml"], user_configs=["configs/users.d/row_policy.xml", "configs/users.d/another_user.xml", "configs/users.d/any_join_distinct_right_table_keys.xml"], with_zookeeper=True)
+node = cluster.add_instance('node', main_configs=["configs/config.d/remote_servers.xml"],
+                            user_configs=["configs/users.d/row_policy.xml", "configs/users.d/another_user.xml",
+                                          "configs/users.d/any_join_distinct_right_table_keys.xml"],
+                            with_zookeeper=True)
+node2 = cluster.add_instance('node2', main_configs=["configs/config.d/remote_servers.xml"],
+                             user_configs=["configs/users.d/row_policy.xml", "configs/users.d/another_user.xml",
+                                           "configs/users.d/any_join_distinct_right_table_keys.xml"],
+                             with_zookeeper=True)
 nodes = [node, node2]
 
 
-def copy_policy_xml(local_file_name, reload_immediately = True):
+def copy_policy_xml(local_file_name, reload_immediately=True):
     script_dir = os.path.dirname(os.path.realpath(__file__))
     for current_node in nodes:
-        current_node.copy_file_to_container(os.path.join(script_dir, local_file_name), '/etc/clickhouse-server/users.d/row_policy.xml')
+        current_node.copy_file_to_container(os.path.join(script_dir, local_file_name),
+                                            '/etc/clickhouse-server/users.d/row_policy.xml')
         if reload_immediately:
             current_node.query("SYSTEM RELOAD CONFIG")
 
@@ -66,7 +74,7 @@ def reset_policies():
 
 
 def test_smoke():
-    assert node.query("SELECT * FROM mydb.filtered_table1") == TSV([[1,0], [1, 1]])
+    assert node.query("SELECT * FROM mydb.filtered_table1") == TSV([[1, 0], [1, 1]])
     assert node.query("SELECT * FROM mydb.filtered_table2") == TSV([[0, 0, 0, 0], [0, 0, 6, 0]])
     assert node.query("SELECT * FROM mydb.filtered_table3") == TSV([[0, 1], [1, 0]])
 
@@ -86,8 +94,12 @@ def test_smoke():
 
 
 def test_join():
-    assert node.query("SELECT * FROM mydb.filtered_table1 as t1 ANY LEFT JOIN mydb.filtered_table1 as t2 ON t1.a = t2.b") == TSV([[1, 0, 1, 1], [1, 1, 1, 1]])
-    assert node.query("SELECT * FROM mydb.filtered_table1 as t2 ANY RIGHT JOIN mydb.filtered_table1 as t1 ON t2.b = t1.a") == TSV([[1, 1, 1, 0]])
+    assert node.query(
+        "SELECT * FROM mydb.filtered_table1 as t1 ANY LEFT JOIN mydb.filtered_table1 as t2 ON t1.a = t2.b") == TSV(
+        [[1, 0, 1, 1], [1, 1, 1, 1]])
+    assert node.query(
+        "SELECT * FROM mydb.filtered_table1 as t2 ANY RIGHT JOIN mydb.filtered_table1 as t1 ON t2.b = t1.a") == TSV(
+        [[1, 1, 1, 0]])
 
 
 def test_cannot_trick_row_policy_with_keyword_with():
@@ -104,17 +116,19 @@ def test_prewhere_not_supported():
     assert expected_error in node.query_and_get_error("SELECT * FROM mydb.filtered_table3 PREWHERE 1")
 
     # However PREWHERE should still work for user without filtering.
-    assert node.query("SELECT * FROM mydb.filtered_table1 PREWHERE 1", user="another") == TSV([[0, 0], [0, 1], [1, 0], [1, 1]])
+    assert node.query("SELECT * FROM mydb.filtered_table1 PREWHERE 1", user="another") == TSV(
+        [[0, 0], [0, 1], [1, 0], [1, 1]])
 
 
 def test_policy_from_users_xml_affects_only_user_assigned():
-    assert node.query("SELECT * FROM mydb.filtered_table1") == TSV([[1,0], [1, 1]])
+    assert node.query("SELECT * FROM mydb.filtered_table1") == TSV([[1, 0], [1, 1]])
     assert node.query("SELECT * FROM mydb.filtered_table1", user="another") == TSV([[0, 0], [0, 1], [1, 0], [1, 1]])
 
     assert node.query("SELECT * FROM mydb.filtered_table2") == TSV([[0, 0, 0, 0], [0, 0, 6, 0]])
-    assert node.query("SELECT * FROM mydb.filtered_table2", user="another") == TSV([[0, 0, 0, 0], [0, 0, 6, 0], [1, 2, 3, 4], [4, 3, 2, 1]])
+    assert node.query("SELECT * FROM mydb.filtered_table2", user="another") == TSV(
+        [[0, 0, 0, 0], [0, 0, 6, 0], [1, 2, 3, 4], [4, 3, 2, 1]])
 
-    assert node.query("SELECT * FROM mydb.local") == TSV([[1,0], [1, 1], [2, 0], [2, 1]])
+    assert node.query("SELECT * FROM mydb.local") == TSV([[1, 0], [1, 1], [2, 0], [2, 1]])
     assert node.query("SELECT * FROM mydb.local", user="another") == TSV([[1, 0], [1, 1]])
 
 
@@ -126,7 +140,8 @@ def test_change_of_users_xml_changes_row_policies():
 
     copy_policy_xml('all_rows.xml')
     assert node.query("SELECT * FROM mydb.filtered_table1") == TSV([[0, 0], [0, 1], [1, 0], [1, 1]])
-    assert node.query("SELECT * FROM mydb.filtered_table2") == TSV([[0, 0, 0, 0], [0, 0, 6, 0], [1, 2, 3, 4], [4, 3, 2, 1]])
+    assert node.query("SELECT * FROM mydb.filtered_table2") == TSV(
+        [[0, 0, 0, 0], [0, 0, 6, 0], [1, 2, 3, 4], [4, 3, 2, 1]])
     assert node.query("SELECT * FROM mydb.filtered_table3") == TSV([[0, 0], [0, 1], [1, 0], [1, 1]])
 
     copy_policy_xml('no_rows.xml')
@@ -141,7 +156,8 @@ def test_change_of_users_xml_changes_row_policies():
 
     copy_policy_xml('no_filters.xml')
     assert node.query("SELECT * FROM mydb.filtered_table1") == TSV([[0, 0], [0, 1], [1, 0], [1, 1]])
-    assert node.query("SELECT * FROM mydb.filtered_table2") == TSV([[0, 0, 0, 0], [0, 0, 6, 0], [1, 2, 3, 4], [4, 3, 2, 1]])
+    assert node.query("SELECT * FROM mydb.filtered_table2") == TSV(
+        [[0, 0, 0, 0], [0, 0, 6, 0], [1, 2, 3, 4], [4, 3, 2, 1]])
     assert node.query("SELECT * FROM mydb.filtered_table3") == TSV([[0, 0], [0, 1], [1, 0], [1, 1]])
 
     copy_policy_xml('normal_filters.xml')
@@ -156,13 +172,14 @@ def test_reload_users_xml_by_timer():
     assert node.query("SELECT * FROM mydb.filtered_table2") == TSV([[0, 0, 0, 0], [0, 0, 6, 0]])
     assert node.query("SELECT * FROM mydb.filtered_table3") == TSV([[0, 1], [1, 0]])
 
-    time.sleep(1) # The modification time of the 'row_policy.xml' file should be different.
+    time.sleep(1)  # The modification time of the 'row_policy.xml' file should be different.
     copy_policy_xml('all_rows.xml', False)
     assert_eq_with_retry(node, "SELECT * FROM mydb.filtered_table1", [[0, 0], [0, 1], [1, 0], [1, 1]])
-    assert_eq_with_retry(node, "SELECT * FROM mydb.filtered_table2", [[0, 0, 0, 0], [0, 0, 6, 0], [1, 2, 3, 4], [4, 3, 2, 1]])
+    assert_eq_with_retry(node, "SELECT * FROM mydb.filtered_table2",
+                         [[0, 0, 0, 0], [0, 0, 6, 0], [1, 2, 3, 4], [4, 3, 2, 1]])
     assert_eq_with_retry(node, "SELECT * FROM mydb.filtered_table3", [[0, 0], [0, 1], [1, 0], [1, 1]])
 
-    time.sleep(1) # The modification time of the 'row_policy.xml' file should be different.
+    time.sleep(1)  # The modification time of the 'row_policy.xml' file should be different.
     copy_policy_xml('normal_filters.xml', False)
     assert_eq_with_retry(node, "SELECT * FROM mydb.filtered_table1", [[1, 0], [1, 1]])
     assert_eq_with_retry(node, "SELECT * FROM mydb.filtered_table2", [[0, 0, 0, 0], [0, 0, 6, 0]])
@@ -171,57 +188,109 @@ def test_reload_users_xml_by_timer():
 
 def test_introspection():
     policies = [
-        ["another ON mydb.filtered_table1", "another", "mydb", "filtered_table1", "6068883a-0e9d-f802-7e22-0144f8e66d3c", "users.xml", "1",                      0, 0, "['another']", "[]"],
-        ["another ON mydb.filtered_table2", "another", "mydb", "filtered_table2", "c019e957-c60b-d54e-cc52-7c90dac5fb01", "users.xml", "1",                      0, 0, "['another']", "[]"],
-        ["another ON mydb.filtered_table3", "another", "mydb", "filtered_table3", "4cb080d0-44e8-dbef-6026-346655143628", "users.xml", "1",                      0, 0, "['another']", "[]"],
-        ["another ON mydb.local",           "another", "mydb", "local",           "5b23c389-7e18-06bf-a6bc-dd1afbbc0a97", "users.xml", "a = 1",                  0, 0, "['another']", "[]"],
-        ["default ON mydb.filtered_table1", "default", "mydb", "filtered_table1", "9e8a8f62-4965-2b5e-8599-57c7b99b3549", "users.xml", "a = 1",                  0, 0, "['default']", "[]"],
-        ["default ON mydb.filtered_table2", "default", "mydb", "filtered_table2", "cffae79d-b9bf-a2ef-b798-019c18470b25", "users.xml", "a + b < 1 or c - d > 5", 0, 0, "['default']", "[]"],
-        ["default ON mydb.filtered_table3", "default", "mydb", "filtered_table3", "12fc5cef-e3da-3940-ec79-d8be3911f42b", "users.xml", "c = 1",                  0, 0, "['default']", "[]"],
-        ["default ON mydb.local",           "default", "mydb", "local",           "cdacaeb5-1d97-f99d-2bb0-4574f290629c", "users.xml", "1",                      0, 0, "['default']", "[]"]
+        ["another ON mydb.filtered_table1", "another", "mydb", "filtered_table1",
+         "6068883a-0e9d-f802-7e22-0144f8e66d3c", "users.xml", "1", 0, 0, "['another']", "[]"],
+        ["another ON mydb.filtered_table2", "another", "mydb", "filtered_table2",
+         "c019e957-c60b-d54e-cc52-7c90dac5fb01", "users.xml", "1", 0, 0, "['another']", "[]"],
+        ["another ON mydb.filtered_table3", "another", "mydb", "filtered_table3",
+         "4cb080d0-44e8-dbef-6026-346655143628", "users.xml", "1", 0, 0, "['another']", "[]"],
+        ["another ON mydb.local", "another", "mydb", "local", "5b23c389-7e18-06bf-a6bc-dd1afbbc0a97", "users.xml",
+         "a = 1", 0, 0, "['another']", "[]"],
+        ["default ON mydb.filtered_table1", "default", "mydb", "filtered_table1",
+         "9e8a8f62-4965-2b5e-8599-57c7b99b3549", "users.xml", "a = 1", 0, 0, "['default']", "[]"],
+        ["default ON mydb.filtered_table2", "default", "mydb", "filtered_table2",
+         "cffae79d-b9bf-a2ef-b798-019c18470b25", "users.xml", "a + b < 1 or c - d > 5", 0, 0, "['default']", "[]"],
+        ["default ON mydb.filtered_table3", "default", "mydb", "filtered_table3",
+         "12fc5cef-e3da-3940-ec79-d8be3911f42b", "users.xml", "c = 1", 0, 0, "['default']", "[]"],
+        ["default ON mydb.local", "default", "mydb", "local", "cdacaeb5-1d97-f99d-2bb0-4574f290629c", "users.xml", "1",
+         0, 0, "['default']", "[]"]
     ]
     assert node.query("SELECT * from system.row_policies ORDER BY short_name, database, table") == TSV(policies)
 
 
 def test_dcl_introspection():
-    assert node.query("SHOW POLICIES") == TSV(["another ON mydb.filtered_table1", "another ON mydb.filtered_table2", "another ON mydb.filtered_table3", "another ON mydb.local", "default ON mydb.filtered_table1", "default ON mydb.filtered_table2", "default ON mydb.filtered_table3", "default ON mydb.local"])
+    assert node.query("SHOW POLICIES") == TSV(
+        ["another ON mydb.filtered_table1", "another ON mydb.filtered_table2", "another ON mydb.filtered_table3",
+         "another ON mydb.local", "default ON mydb.filtered_table1", "default ON mydb.filtered_table2",
+         "default ON mydb.filtered_table3", "default ON mydb.local"])
 
-    assert node.query("SHOW POLICIES ON mydb.filtered_table1") == TSV([ "another", "default" ])
-    assert node.query("SHOW POLICIES ON mydb.local") == TSV([ "another", "default" ])
-    assert node.query("SHOW POLICIES ON mydb.*") == TSV([ "another ON mydb.filtered_table1", "another ON mydb.filtered_table2", "another ON mydb.filtered_table3", "another ON mydb.local", "default ON mydb.filtered_table1", "default ON mydb.filtered_table2", "default ON mydb.filtered_table3", "default ON mydb.local" ])
-    assert node.query("SHOW POLICIES default") == TSV([ "default ON mydb.filtered_table1", "default ON mydb.filtered_table2", "default ON mydb.filtered_table3", "default ON mydb.local" ])
+    assert node.query("SHOW POLICIES ON mydb.filtered_table1") == TSV(["another", "default"])
+    assert node.query("SHOW POLICIES ON mydb.local") == TSV(["another", "default"])
+    assert node.query("SHOW POLICIES ON mydb.*") == TSV(
+        ["another ON mydb.filtered_table1", "another ON mydb.filtered_table2", "another ON mydb.filtered_table3",
+         "another ON mydb.local", "default ON mydb.filtered_table1", "default ON mydb.filtered_table2",
+         "default ON mydb.filtered_table3", "default ON mydb.local"])
+    assert node.query("SHOW POLICIES default") == TSV(
+        ["default ON mydb.filtered_table1", "default ON mydb.filtered_table2", "default ON mydb.filtered_table3",
+         "default ON mydb.local"])
 
-    assert node.query("SHOW CREATE POLICY default ON mydb.filtered_table1") == "CREATE ROW POLICY default ON mydb.filtered_table1 FOR SELECT USING a = 1 TO default\n"
-    assert node.query("SHOW CREATE POLICY default ON mydb.filtered_table2") == "CREATE ROW POLICY default ON mydb.filtered_table2 FOR SELECT USING ((a + b) < 1) OR ((c - d) > 5) TO default\n"
-    assert node.query("SHOW CREATE POLICY default ON mydb.filtered_table3") == "CREATE ROW POLICY default ON mydb.filtered_table3 FOR SELECT USING c = 1 TO default\n"
-    assert node.query("SHOW CREATE POLICY default ON mydb.local") == "CREATE ROW POLICY default ON mydb.local FOR SELECT USING 1 TO default\n"
+    assert node.query(
+        "SHOW CREATE POLICY default ON mydb.filtered_table1") == "CREATE ROW POLICY default ON mydb.filtered_table1 FOR SELECT USING a = 1 TO default\n"
+    assert node.query(
+        "SHOW CREATE POLICY default ON mydb.filtered_table2") == "CREATE ROW POLICY default ON mydb.filtered_table2 FOR SELECT USING ((a + b) < 1) OR ((c - d) > 5) TO default\n"
+    assert node.query(
+        "SHOW CREATE POLICY default ON mydb.filtered_table3") == "CREATE ROW POLICY default ON mydb.filtered_table3 FOR SELECT USING c = 1 TO default\n"
+    assert node.query(
+        "SHOW CREATE POLICY default ON mydb.local") == "CREATE ROW POLICY default ON mydb.local FOR SELECT USING 1 TO default\n"
 
-    assert node.query("SHOW CREATE POLICY default") == TSV([ "CREATE ROW POLICY default ON mydb.filtered_table1 FOR SELECT USING a = 1 TO default", "CREATE ROW POLICY default ON mydb.filtered_table2 FOR SELECT USING ((a + b) < 1) OR ((c - d) > 5) TO default", "CREATE ROW POLICY default ON mydb.filtered_table3 FOR SELECT USING c = 1 TO default", "CREATE ROW POLICY default ON mydb.local FOR SELECT USING 1 TO default" ])
-    assert node.query("SHOW CREATE POLICIES ON mydb.filtered_table1") == TSV([ "CREATE ROW POLICY another ON mydb.filtered_table1 FOR SELECT USING 1 TO another", "CREATE ROW POLICY default ON mydb.filtered_table1 FOR SELECT USING a = 1 TO default" ])
-    assert node.query("SHOW CREATE POLICIES ON mydb.*") == TSV([ "CREATE ROW POLICY another ON mydb.filtered_table1 FOR SELECT USING 1 TO another", "CREATE ROW POLICY another ON mydb.filtered_table2 FOR SELECT USING 1 TO another", "CREATE ROW POLICY another ON mydb.filtered_table3 FOR SELECT USING 1 TO another", "CREATE ROW POLICY another ON mydb.local FOR SELECT USING a = 1 TO another", "CREATE ROW POLICY default ON mydb.filtered_table1 FOR SELECT USING a = 1 TO default", "CREATE ROW POLICY default ON mydb.filtered_table2 FOR SELECT USING ((a + b) < 1) OR ((c - d) > 5) TO default", "CREATE ROW POLICY default ON mydb.filtered_table3 FOR SELECT USING c = 1 TO default", "CREATE ROW POLICY default ON mydb.local FOR SELECT USING 1 TO default" ])
-    assert node.query("SHOW CREATE POLICIES") == TSV([ "CREATE ROW POLICY another ON mydb.filtered_table1 FOR SELECT USING 1 TO another", "CREATE ROW POLICY another ON mydb.filtered_table2 FOR SELECT USING 1 TO another", "CREATE ROW POLICY another ON mydb.filtered_table3 FOR SELECT USING 1 TO another", "CREATE ROW POLICY another ON mydb.local FOR SELECT USING a = 1 TO another", "CREATE ROW POLICY default ON mydb.filtered_table1 FOR SELECT USING a = 1 TO default", "CREATE ROW POLICY default ON mydb.filtered_table2 FOR SELECT USING ((a + b) < 1) OR ((c - d) > 5) TO default", "CREATE ROW POLICY default ON mydb.filtered_table3 FOR SELECT USING c = 1 TO default", "CREATE ROW POLICY default ON mydb.local FOR SELECT USING 1 TO default" ])
+    assert node.query("SHOW CREATE POLICY default") == TSV(
+        ["CREATE ROW POLICY default ON mydb.filtered_table1 FOR SELECT USING a = 1 TO default",
+         "CREATE ROW POLICY default ON mydb.filtered_table2 FOR SELECT USING ((a + b) < 1) OR ((c - d) > 5) TO default",
+         "CREATE ROW POLICY default ON mydb.filtered_table3 FOR SELECT USING c = 1 TO default",
+         "CREATE ROW POLICY default ON mydb.local FOR SELECT USING 1 TO default"])
+    assert node.query("SHOW CREATE POLICIES ON mydb.filtered_table1") == TSV(
+        ["CREATE ROW POLICY another ON mydb.filtered_table1 FOR SELECT USING 1 TO another",
+         "CREATE ROW POLICY default ON mydb.filtered_table1 FOR SELECT USING a = 1 TO default"])
+    assert node.query("SHOW CREATE POLICIES ON mydb.*") == TSV(
+        ["CREATE ROW POLICY another ON mydb.filtered_table1 FOR SELECT USING 1 TO another",
+         "CREATE ROW POLICY another ON mydb.filtered_table2 FOR SELECT USING 1 TO another",
+         "CREATE ROW POLICY another ON mydb.filtered_table3 FOR SELECT USING 1 TO another",
+         "CREATE ROW POLICY another ON mydb.local FOR SELECT USING a = 1 TO another",
+         "CREATE ROW POLICY default ON mydb.filtered_table1 FOR SELECT USING a = 1 TO default",
+         "CREATE ROW POLICY default ON mydb.filtered_table2 FOR SELECT USING ((a + b) < 1) OR ((c - d) > 5) TO default",
+         "CREATE ROW POLICY default ON mydb.filtered_table3 FOR SELECT USING c = 1 TO default",
+         "CREATE ROW POLICY default ON mydb.local FOR SELECT USING 1 TO default"])
+    assert node.query("SHOW CREATE POLICIES") == TSV(
+        ["CREATE ROW POLICY another ON mydb.filtered_table1 FOR SELECT USING 1 TO another",
+         "CREATE ROW POLICY another ON mydb.filtered_table2 FOR SELECT USING 1 TO another",
+         "CREATE ROW POLICY another ON mydb.filtered_table3 FOR SELECT USING 1 TO another",
+         "CREATE ROW POLICY another ON mydb.local FOR SELECT USING a = 1 TO another",
+         "CREATE ROW POLICY default ON mydb.filtered_table1 FOR SELECT USING a = 1 TO default",
+         "CREATE ROW POLICY default ON mydb.filtered_table2 FOR SELECT USING ((a + b) < 1) OR ((c - d) > 5) TO default",
+         "CREATE ROW POLICY default ON mydb.filtered_table3 FOR SELECT USING c = 1 TO default",
+         "CREATE ROW POLICY default ON mydb.local FOR SELECT USING 1 TO default"])
 
-    expected_access = "CREATE ROW POLICY another ON mydb.filtered_table1 FOR SELECT USING 1 TO another\n"\
-                      "CREATE ROW POLICY another ON mydb.filtered_table2 FOR SELECT USING 1 TO another\n"\
-                      "CREATE ROW POLICY another ON mydb.filtered_table3 FOR SELECT USING 1 TO another\n"\
-                      "CREATE ROW POLICY another ON mydb.local FOR SELECT USING a = 1 TO another\n"\
-                      "CREATE ROW POLICY default ON mydb.filtered_table1 FOR SELECT USING a = 1 TO default\n"\
-                      "CREATE ROW POLICY default ON mydb.filtered_table2 FOR SELECT USING ((a + b) < 1) OR ((c - d) > 5) TO default\n"\
-                      "CREATE ROW POLICY default ON mydb.filtered_table3 FOR SELECT USING c = 1 TO default\n"\
+    expected_access = "CREATE ROW POLICY another ON mydb.filtered_table1 FOR SELECT USING 1 TO another\n" \
+                      "CREATE ROW POLICY another ON mydb.filtered_table2 FOR SELECT USING 1 TO another\n" \
+                      "CREATE ROW POLICY another ON mydb.filtered_table3 FOR SELECT USING 1 TO another\n" \
+                      "CREATE ROW POLICY another ON mydb.local FOR SELECT USING a = 1 TO another\n" \
+                      "CREATE ROW POLICY default ON mydb.filtered_table1 FOR SELECT USING a = 1 TO default\n" \
+                      "CREATE ROW POLICY default ON mydb.filtered_table2 FOR SELECT USING ((a + b) < 1) OR ((c - d) > 5) TO default\n" \
+                      "CREATE ROW POLICY default ON mydb.filtered_table3 FOR SELECT USING c = 1 TO default\n" \
                       "CREATE ROW POLICY default ON mydb.local FOR SELECT USING 1 TO default\n"
     assert expected_access in node.query("SHOW ACCESS")
 
     copy_policy_xml('all_rows.xml')
-    assert node.query("SHOW POLICIES") == TSV(["another ON mydb.filtered_table1", "another ON mydb.filtered_table2", "another ON mydb.filtered_table3", "default ON mydb.filtered_table1", "default ON mydb.filtered_table2", "default ON mydb.filtered_table3"])
-    assert node.query("SHOW CREATE POLICY default ON mydb.filtered_table1") == "CREATE ROW POLICY default ON mydb.filtered_table1 FOR SELECT USING 1 TO default\n"
-    assert node.query("SHOW CREATE POLICY default ON mydb.filtered_table2") == "CREATE ROW POLICY default ON mydb.filtered_table2 FOR SELECT USING 1 TO default\n"
-    assert node.query("SHOW CREATE POLICY default ON mydb.filtered_table3") == "CREATE ROW POLICY default ON mydb.filtered_table3 FOR SELECT USING 1 TO default\n"
+    assert node.query("SHOW POLICIES") == TSV(
+        ["another ON mydb.filtered_table1", "another ON mydb.filtered_table2", "another ON mydb.filtered_table3",
+         "default ON mydb.filtered_table1", "default ON mydb.filtered_table2", "default ON mydb.filtered_table3"])
+    assert node.query(
+        "SHOW CREATE POLICY default ON mydb.filtered_table1") == "CREATE ROW POLICY default ON mydb.filtered_table1 FOR SELECT USING 1 TO default\n"
+    assert node.query(
+        "SHOW CREATE POLICY default ON mydb.filtered_table2") == "CREATE ROW POLICY default ON mydb.filtered_table2 FOR SELECT USING 1 TO default\n"
+    assert node.query(
+        "SHOW CREATE POLICY default ON mydb.filtered_table3") == "CREATE ROW POLICY default ON mydb.filtered_table3 FOR SELECT USING 1 TO default\n"
 
     copy_policy_xml('no_rows.xml')
-    assert node.query("SHOW POLICIES") == TSV(["another ON mydb.filtered_table1", "another ON mydb.filtered_table2", "another ON mydb.filtered_table3", "default ON mydb.filtered_table1", "default ON mydb.filtered_table2", "default ON mydb.filtered_table3"])
-    assert node.query("SHOW CREATE POLICY default ON mydb.filtered_table1") == "CREATE ROW POLICY default ON mydb.filtered_table1 FOR SELECT USING NULL TO default\n"
-    assert node.query("SHOW CREATE POLICY default ON mydb.filtered_table2") == "CREATE ROW POLICY default ON mydb.filtered_table2 FOR SELECT USING NULL TO default\n"
-    assert node.query("SHOW CREATE POLICY default ON mydb.filtered_table3") == "CREATE ROW POLICY default ON mydb.filtered_table3 FOR SELECT USING NULL TO default\n"
+    assert node.query("SHOW POLICIES") == TSV(
+        ["another ON mydb.filtered_table1", "another ON mydb.filtered_table2", "another ON mydb.filtered_table3",
+         "default ON mydb.filtered_table1", "default ON mydb.filtered_table2", "default ON mydb.filtered_table3"])
+    assert node.query(
+        "SHOW CREATE POLICY default ON mydb.filtered_table1") == "CREATE ROW POLICY default ON mydb.filtered_table1 FOR SELECT USING NULL TO default\n"
+    assert node.query(
+        "SHOW CREATE POLICY default ON mydb.filtered_table2") == "CREATE ROW POLICY default ON mydb.filtered_table2 FOR SELECT USING NULL TO default\n"
+    assert node.query(
+        "SHOW CREATE POLICY default ON mydb.filtered_table3") == "CREATE ROW POLICY default ON mydb.filtered_table3 FOR SELECT USING NULL TO default\n"
 
     copy_policy_xml('no_filters.xml')
     assert node.query("SHOW POLICIES") == ""
@@ -245,7 +314,8 @@ def test_dcl_management():
     node.query("ALTER POLICY pA ON mydb.filtered_table1 RENAME TO pB")
     assert node.query("SELECT * FROM mydb.filtered_table1") == TSV([[1, 0]])
     assert node.query("SHOW POLICIES ON mydb.filtered_table1") == "pB\n"
-    assert node.query("SHOW CREATE POLICY pB ON mydb.filtered_table1") == "CREATE ROW POLICY pB ON mydb.filtered_table1 FOR SELECT USING a > b TO default\n"
+    assert node.query(
+        "SHOW CREATE POLICY pB ON mydb.filtered_table1") == "CREATE ROW POLICY pB ON mydb.filtered_table1 FOR SELECT USING a > b TO default\n"
 
     node.query("DROP POLICY pB ON mydb.filtered_table1")
     assert node.query("SELECT * FROM mydb.filtered_table1") == TSV([[0, 0], [0, 1], [1, 0], [1, 1]])
@@ -258,16 +328,17 @@ def test_users_xml_is_readonly():
 
 def test_tags_with_db_and_table_names():
     copy_policy_xml('tags_with_db_and_table_names.xml')
-    
+
     assert node.query("SELECT * FROM mydb.table") == TSV([[0, 0], [0, 1]])
     assert node.query("SELECT * FROM mydb.filtered_table2") == TSV([[0, 0, 6, 0]])
     assert node.query("SELECT * FROM mydb.filtered_table3") == TSV([[0, 0]])
     assert node.query("SELECT * FROM mydb.`.filtered_table4`") == TSV([[1, 1]])
 
-    assert node.query("SHOW CREATE POLICIES default") == TSV(["CREATE ROW POLICY default ON mydb.`.filtered_table4` FOR SELECT USING c = 2 TO default",
-                                                              "CREATE ROW POLICY default ON mydb.filtered_table2 FOR SELECT USING c > (d + 5) TO default",
-                                                              "CREATE ROW POLICY default ON mydb.filtered_table3 FOR SELECT USING c = 0 TO default",
-                                                              "CREATE ROW POLICY default ON mydb.table FOR SELECT USING a = 0 TO default"])
+    assert node.query("SHOW CREATE POLICIES default") == TSV(
+        ["CREATE ROW POLICY default ON mydb.`.filtered_table4` FOR SELECT USING c = 2 TO default",
+         "CREATE ROW POLICY default ON mydb.filtered_table2 FOR SELECT USING c > (d + 5) TO default",
+         "CREATE ROW POLICY default ON mydb.filtered_table3 FOR SELECT USING c = 0 TO default",
+         "CREATE ROW POLICY default ON mydb.table FOR SELECT USING a = 0 TO default"])
 
 
 def test_miscellaneous_engines():
@@ -275,7 +346,8 @@ def test_miscellaneous_engines():
 
     # ReplicatedMergeTree
     node.query("DROP TABLE mydb.filtered_table1")
-    node.query("CREATE TABLE mydb.filtered_table1 (a UInt8, b UInt8) ENGINE ReplicatedMergeTree('/clickhouse/tables/00-00/filtered_table1', 'replica1') ORDER BY a")
+    node.query(
+        "CREATE TABLE mydb.filtered_table1 (a UInt8, b UInt8) ENGINE ReplicatedMergeTree('/clickhouse/tables/00-00/filtered_table1', 'replica1') ORDER BY a")
     node.query("INSERT INTO mydb.filtered_table1 values (0, 0), (0, 1), (1, 0), (1, 1)")
     assert node.query("SELECT * FROM mydb.filtered_table1") == TSV([[1, 0], [1, 1]])
 
@@ -287,12 +359,15 @@ def test_miscellaneous_engines():
 
     # ReplicatedCollapsingMergeTree
     node.query("DROP TABLE mydb.filtered_table1")
-    node.query("CREATE TABLE mydb.filtered_table1 (a UInt8, b Int8) ENGINE ReplicatedCollapsingMergeTree('/clickhouse/tables/00-00/filtered_table1', 'replica1', b) ORDER BY a")
+    node.query(
+        "CREATE TABLE mydb.filtered_table1 (a UInt8, b Int8) ENGINE ReplicatedCollapsingMergeTree('/clickhouse/tables/00-00/filtered_table1', 'replica1', b) ORDER BY a")
     node.query("INSERT INTO mydb.filtered_table1 values (0, 1), (0, 1), (1, 1), (1, 1)")
     assert node.query("SELECT * FROM mydb.filtered_table1") == TSV([[1, 1], [1, 1]])
 
     # DistributedMergeTree
     node.query("DROP TABLE IF EXISTS mydb.not_filtered_table")
-    node.query("CREATE TABLE mydb.not_filtered_table (a UInt8, b UInt8) ENGINE Distributed('test_local_cluster', mydb, local)")
+    node.query(
+        "CREATE TABLE mydb.not_filtered_table (a UInt8, b UInt8) ENGINE Distributed('test_local_cluster', mydb, local)")
     assert node.query("SELECT * FROM mydb.not_filtered_table", user="another") == TSV([[1, 0], [1, 1], [1, 0], [1, 1]])
-    assert node.query("SELECT sum(a), b FROM mydb.not_filtered_table GROUP BY b ORDER BY b", user="another") == TSV([[2, 0], [2, 1]])
+    assert node.query("SELECT sum(a), b FROM mydb.not_filtered_table GROUP BY b ORDER BY b", user="another") == TSV(
+        [[2, 0], [2, 1]])

--- a/tests/integration/test_s3_with_https/test.py
+++ b/tests/integration/test_s3_with_https/test.py
@@ -18,7 +18,9 @@ def check_proxy_logs(cluster, proxy_instance):
 def cluster():
     try:
         cluster = ClickHouseCluster(__file__)
-        cluster.add_instance("node", main_configs=["configs/config.d/storage_conf.xml", "configs/config.d/log_conf.xml", "configs/config.d/ssl.xml"], with_minio=True, minio_certs_dir='minio_certs')
+        cluster.add_instance("node", main_configs=["configs/config.d/storage_conf.xml", "configs/config.d/log_conf.xml",
+                                                   "configs/config.d/ssl.xml"], with_minio=True,
+                             minio_certs_dir='minio_certs')
         logging.info("Starting cluster...")
         cluster.start()
         logging.info("Cluster started")
@@ -43,7 +45,7 @@ def test_s3_with_https(cluster, policy):
         ORDER BY id
         SETTINGS storage_policy='{}'
         """
-        .format(policy)
+            .format(policy)
     )
 
     node.query("INSERT INTO s3_test VALUES (0,'data'),(1,'data')")

--- a/tests/integration/test_s3_with_proxy/proxy-resolver/resolver.py
+++ b/tests/integration/test_s3_with_proxy/proxy-resolver/resolver.py
@@ -1,5 +1,6 @@
-import bottle
 import random
+
+import bottle
 
 
 @bottle.route('/hostname')

--- a/tests/integration/test_s3_with_proxy/test.py
+++ b/tests/integration/test_s3_with_proxy/test.py
@@ -21,7 +21,9 @@ def run_resolver(cluster):
 def cluster():
     try:
         cluster = ClickHouseCluster(__file__)
-        cluster.add_instance("node", main_configs=["configs/config.d/log_conf.xml", "configs/config.d/storage_conf.xml"], with_minio=True)
+        cluster.add_instance("node",
+                             main_configs=["configs/config.d/log_conf.xml", "configs/config.d/storage_conf.xml"],
+                             with_minio=True)
         logging.info("Starting cluster...")
         cluster.start()
         logging.info("Cluster started")
@@ -56,7 +58,7 @@ def test_s3_with_proxy_list(cluster, policy):
         ORDER BY id
         SETTINGS storage_policy='{}'
         """
-        .format(policy)
+            .format(policy)
     )
 
     node.query("INSERT INTO s3_test VALUES (0,'data'),(1,'data')")

--- a/tests/integration/test_send_crash_reports/fake_sentry_server.py
+++ b/tests/integration/test_send_crash_reports/fake_sentry_server.py
@@ -2,6 +2,7 @@ import BaseHTTPServer
 
 RESULT_PATH = '/result.txt'
 
+
 class SentryHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     def do_POST(self):
         post_data = self.__read_and_decode_post_data()

--- a/tests/integration/test_send_crash_reports/test.py
+++ b/tests/integration/test_send_crash_reports/test.py
@@ -1,12 +1,11 @@
 import os
 import time
 
-import pytest
-
 import helpers.cluster
 import helpers.test_tools
-import fake_sentry_server
+import pytest
 
+import fake_sentry_server
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -24,7 +23,7 @@ def started_node():
         cluster.shutdown()
 
 
-def test_send_segfault(started_node,):
+def test_send_segfault(started_node, ):
     started_node.copy_file_to_container(os.path.join(SCRIPT_DIR, "fake_sentry_server.py"), "/fake_sentry_server.py")
     started_node.exec_in_container(["bash", "-c", "python2 /fake_sentry_server.py"], detach=True, user="root")
     time.sleep(0.5)

--- a/tests/integration/test_send_request_to_leader_replica/test.py
+++ b/tests/integration/test_send_request_to_leader_replica/test.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 
 from helpers.cluster import ClickHouseCluster
@@ -7,16 +5,20 @@ from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 
-node1 = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml'], user_configs=['configs/user_good_restricted.xml'], with_zookeeper=True)
-node2 = cluster.add_instance('node2', main_configs=['configs/remote_servers.xml'], user_configs=['configs/user_good_restricted.xml'], with_zookeeper=True)
-node3 = cluster.add_instance('node3', main_configs=['configs/remote_servers.xml'], user_configs=['configs/user_good_allowed.xml'], with_zookeeper=True)
-node4 = cluster.add_instance('node4', main_configs=['configs/remote_servers.xml'], user_configs=['configs/user_good_allowed.xml'], with_zookeeper=True)
+node1 = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml'],
+                             user_configs=['configs/user_good_restricted.xml'], with_zookeeper=True)
+node2 = cluster.add_instance('node2', main_configs=['configs/remote_servers.xml'],
+                             user_configs=['configs/user_good_restricted.xml'], with_zookeeper=True)
+node3 = cluster.add_instance('node3', main_configs=['configs/remote_servers.xml'],
+                             user_configs=['configs/user_good_allowed.xml'], with_zookeeper=True)
+node4 = cluster.add_instance('node4', main_configs=['configs/remote_servers.xml'],
+                             user_configs=['configs/user_good_allowed.xml'], with_zookeeper=True)
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
         cluster.start()
-
 
         for node in [node1, node2]:
             node.query('''
@@ -30,18 +32,18 @@ def started_cluster():
     ENGINE = ReplicatedMergeTree('/clickhouse/tables/0/someothertable', '{replica}', date, id, 8192);
                 '''.format(replica=node.name), user='good')
 
-
         yield cluster
 
     finally:
         cluster.shutdown()
 
+
 @pytest.mark.parametrize("table,query,expected,n1,n2", [
-    ("sometable","ALTER TABLE sometable DROP PARTITION 201706", '1', node1, node2),
-    ("sometable","TRUNCATE TABLE sometable", '0', node1, node2),
+    ("sometable", "ALTER TABLE sometable DROP PARTITION 201706", '1', node1, node2),
+    ("sometable", "TRUNCATE TABLE sometable", '0', node1, node2),
     ("sometable", "OPTIMIZE TABLE sometable", '4', node1, node2),
-    ("someothertable","ALTER TABLE someothertable DROP PARTITION 201706", '1', node3, node4),
-    ("someothertable","TRUNCATE TABLE someothertable", '0', node3, node4),
+    ("someothertable", "ALTER TABLE someothertable DROP PARTITION 201706", '1', node3, node4),
+    ("someothertable", "TRUNCATE TABLE someothertable", '0', node3, node4),
     ("someothertable", "OPTIMIZE TABLE someothertable", '4', node3, node4),
 ])
 def test_alter_table_drop_partition(started_cluster, table, query, expected, n1, n2):

--- a/tests/integration/test_server_initialization/test.py
+++ b/tests/integration/test_server_initialization/test.py
@@ -1,7 +1,7 @@
-import time
 import pytest
 
 from helpers.cluster import ClickHouseCluster
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -14,7 +14,7 @@ def started_cluster():
         instance_fail = cluster_fail.add_instance('dummy_fail', clickhouse_path_dir='clickhouse_path_fail')
         with pytest.raises(Exception):
             cluster_fail.start()
-        cluster_fail.shutdown() # cleanup
+        cluster_fail.shutdown()  # cleanup
 
         yield cluster
 
@@ -30,9 +30,10 @@ def test_sophisticated_default(started_cluster):
 
 def test_partially_dropped_tables(started_cluster):
     instance = started_cluster.instances['dummy']
-    assert instance.exec_in_container(['bash', '-c', 'find /var/lib/clickhouse/*/default -name *.sql* | sort'], privileged=True, user='root') \
-          == "/var/lib/clickhouse/metadata/default/should_be_restored.sql\n" \
-             "/var/lib/clickhouse/metadata/default/sophisticated_default.sql\n"
+    assert instance.exec_in_container(['bash', '-c', 'find /var/lib/clickhouse/*/default -name *.sql* | sort'],
+                                      privileged=True, user='root') \
+           == "/var/lib/clickhouse/metadata/default/should_be_restored.sql\n" \
+              "/var/lib/clickhouse/metadata/default/sophisticated_default.sql\n"
     assert instance.query("SELECT n FROM should_be_restored") == "1\n2\n3\n"
     assert instance.query("SELECT count() FROM system.tables WHERE name='should_be_dropped'") == "0\n"
 
@@ -42,5 +43,6 @@ def test_live_view_dependency(started_cluster):
     instance.query("CREATE DATABASE a_load_first")
     instance.query("CREATE DATABASE b_load_second")
     instance.query("CREATE TABLE b_load_second.mt (a Int32) Engine=MergeTree order by tuple()")
-    instance.query("CREATE LIVE VIEW a_load_first.lv AS SELECT sum(a) FROM b_load_second.mt", settings={'allow_experimental_live_view': 1})
+    instance.query("CREATE LIVE VIEW a_load_first.lv AS SELECT sum(a) FROM b_load_second.mt",
+                   settings={'allow_experimental_live_view': 1})
     instance.restart_clickhouse()

--- a/tests/integration/test_settings_constraints/test.py
+++ b/tests/integration/test_settings_constraints/test.py
@@ -5,8 +5,6 @@ cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance('instance', user_configs=["configs/users.xml"])
 
 
-
-
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
@@ -18,13 +16,15 @@ def started_cluster():
 
 
 def test_system_settings(started_cluster):
-    assert instance.query("SELECT name, value, min, max, readonly from system.settings WHERE name = 'force_index_by_date'") ==\
+    assert instance.query(
+        "SELECT name, value, min, max, readonly from system.settings WHERE name = 'force_index_by_date'") == \
            "force_index_by_date\t0\t\\N\t\\N\t1\n"
 
-    assert instance.query("SELECT name, value, min, max, readonly from system.settings WHERE name = 'max_memory_usage'") ==\
+    assert instance.query(
+        "SELECT name, value, min, max, readonly from system.settings WHERE name = 'max_memory_usage'") == \
            "max_memory_usage\t10000000000\t5000000000\t20000000000\t0\n"
 
-    assert instance.query("SELECT name, value, min, max, readonly from system.settings WHERE name = 'readonly'") ==\
+    assert instance.query("SELECT name, value, min, max, readonly from system.settings WHERE name = 'readonly'") == \
            "readonly\t0\t\\N\t\\N\t0\n"
 
 

--- a/tests/integration/test_settings_constraints_distributed/test.py
+++ b/tests/integration/test_settings_constraints_distributed/test.py
@@ -1,16 +1,16 @@
-import time
-
 import pytest
 
-from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 
-node1 = cluster.add_instance('node1', main_configs=["configs/config.d/remote_servers.xml"], user_configs=["configs/users.d/allow_introspection_functions.xml"])
-node2 = cluster.add_instance('node2', main_configs=["configs/config.d/remote_servers.xml"], user_configs=["configs/users.d/allow_introspection_functions.xml"])
-distributed = cluster.add_instance('distributed', main_configs=["configs/config.d/remote_servers.xml"], user_configs=["configs/users.d/allow_introspection_functions.xml"], stay_alive=True)
+node1 = cluster.add_instance('node1', main_configs=["configs/config.d/remote_servers.xml"],
+                             user_configs=["configs/users.d/allow_introspection_functions.xml"])
+node2 = cluster.add_instance('node2', main_configs=["configs/config.d/remote_servers.xml"],
+                             user_configs=["configs/users.d/allow_introspection_functions.xml"])
+distributed = cluster.add_instance('distributed', main_configs=["configs/config.d/remote_servers.xml"],
+                                   user_configs=["configs/users.d/allow_introspection_functions.xml"], stay_alive=True)
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -24,8 +24,10 @@ def started_cluster():
             node.query("CREATE USER shard")
             node.query("GRANT ALL ON *.* TO shard")
 
-        distributed.query("CREATE TABLE proxy (date Date, id UInt32, value Int32) ENGINE = Distributed(test_cluster, default, sometable, toUInt64(date));")
-        distributed.query("CREATE TABLE shard_settings (name String, value String) ENGINE = Distributed(test_cluster, system, settings);")
+        distributed.query(
+            "CREATE TABLE proxy (date Date, id UInt32, value Int32) ENGINE = Distributed(test_cluster, default, sometable, toUInt64(date));")
+        distributed.query(
+            "CREATE TABLE shard_settings (name String, value String) ENGINE = Distributed(test_cluster, system, settings);")
         distributed.query("CREATE ROLE admin")
         distributed.query("GRANT ALL ON *.* TO admin")
 
@@ -53,49 +55,52 @@ def test_select_clamps_settings():
     # Check that shards doesn't throw exceptions on constraints violation
     query = "SELECT COUNT() FROM proxy"
     assert distributed.query(query) == '2\n'
-    assert distributed.query(query, user = 'normal') == '2\n'
-    assert distributed.query(query, user = 'wasteful') == '2\n'
-    assert distributed.query(query, user = 'readonly') == '2\n'
+    assert distributed.query(query, user='normal') == '2\n'
+    assert distributed.query(query, user='wasteful') == '2\n'
+    assert distributed.query(query, user='readonly') == '2\n'
 
     assert distributed.query(query, settings={"max_memory_usage": 40000000, "readonly": 2}) == '2\n'
     assert distributed.query(query, settings={"max_memory_usage": 3000000000, "readonly": 2}) == '2\n'
 
     query = "SELECT COUNT() FROM remote('node{1,2}', 'default', 'sometable')"
     assert distributed.query(query) == '2\n'
-    assert distributed.query(query, user = 'normal') == '2\n'
-    assert distributed.query(query, user = 'wasteful') == '2\n'
+    assert distributed.query(query, user='normal') == '2\n'
+    assert distributed.query(query, user='wasteful') == '2\n'
 
     # Check that shards clamp passed settings.
     query = "SELECT hostName() as host, name, value FROM shard_settings WHERE name = 'max_memory_usage' OR name = 'readonly' ORDER BY host, name, value"
-    assert distributed.query(query) == 'node1\tmax_memory_usage\t99999999\n'\
-                                       'node1\treadonly\t0\n'\
-                                       'node2\tmax_memory_usage\t10000000000\n'\
+    assert distributed.query(query) == 'node1\tmax_memory_usage\t99999999\n' \
+                                       'node1\treadonly\t0\n' \
+                                       'node2\tmax_memory_usage\t10000000000\n' \
                                        'node2\treadonly\t1\n'
-    assert distributed.query(query, user = 'normal') == 'node1\tmax_memory_usage\t80000000\n'\
-                                                        'node1\treadonly\t0\n'\
-                                                        'node2\tmax_memory_usage\t10000000000\n'\
+    assert distributed.query(query, user='normal') == 'node1\tmax_memory_usage\t80000000\n' \
+                                                      'node1\treadonly\t0\n' \
+                                                      'node2\tmax_memory_usage\t10000000000\n' \
+                                                      'node2\treadonly\t1\n'
+    assert distributed.query(query, user='wasteful') == 'node1\tmax_memory_usage\t99999999\n' \
+                                                        'node1\treadonly\t0\n' \
+                                                        'node2\tmax_memory_usage\t10000000000\n' \
                                                         'node2\treadonly\t1\n'
-    assert distributed.query(query, user = 'wasteful') == 'node1\tmax_memory_usage\t99999999\n'\
-                                                          'node1\treadonly\t0\n'\
-                                                          'node2\tmax_memory_usage\t10000000000\n'\
-                                                          'node2\treadonly\t1\n'
-    assert distributed.query(query, user = 'readonly') == 'node1\tmax_memory_usage\t99999999\n'\
-                                                          'node1\treadonly\t1\n'\
-                                                          'node2\tmax_memory_usage\t10000000000\n'\
-                                                          'node2\treadonly\t1\n'
+    assert distributed.query(query, user='readonly') == 'node1\tmax_memory_usage\t99999999\n' \
+                                                        'node1\treadonly\t1\n' \
+                                                        'node2\tmax_memory_usage\t10000000000\n' \
+                                                        'node2\treadonly\t1\n'
 
-    assert distributed.query(query, settings={"max_memory_usage": 1}) == 'node1\tmax_memory_usage\t11111111\n'\
-                                                                         'node1\treadonly\t0\n'\
-                                                                         'node2\tmax_memory_usage\t10000000000\n'\
+    assert distributed.query(query, settings={"max_memory_usage": 1}) == 'node1\tmax_memory_usage\t11111111\n' \
+                                                                         'node1\treadonly\t0\n' \
+                                                                         'node2\tmax_memory_usage\t10000000000\n' \
                                                                          'node2\treadonly\t1\n'
-    assert distributed.query(query, settings={"max_memory_usage": 40000000, "readonly": 2}) == 'node1\tmax_memory_usage\t40000000\n'\
-                                                                                               'node1\treadonly\t2\n'\
-                                                                                               'node2\tmax_memory_usage\t10000000000\n'\
-                                                                                               'node2\treadonly\t1\n'
-    assert distributed.query(query, settings={"max_memory_usage": 3000000000, "readonly": 2}) == 'node1\tmax_memory_usage\t99999999\n'\
-                                                                                                 'node1\treadonly\t2\n'\
-                                                                                                 'node2\tmax_memory_usage\t10000000000\n'\
-                                                                                                 'node2\treadonly\t1\n'
+    assert distributed.query(query, settings={"max_memory_usage": 40000000,
+                                              "readonly": 2}) == 'node1\tmax_memory_usage\t40000000\n' \
+                                                                 'node1\treadonly\t2\n' \
+                                                                 'node2\tmax_memory_usage\t10000000000\n' \
+                                                                 'node2\treadonly\t1\n'
+    assert distributed.query(query, settings={"max_memory_usage": 3000000000,
+                                              "readonly": 2}) == 'node1\tmax_memory_usage\t99999999\n' \
+                                                                 'node1\treadonly\t2\n' \
+                                                                 'node2\tmax_memory_usage\t10000000000\n' \
+                                                                 'node2\treadonly\t1\n'
+
 
 def test_insert_clamps_settings():
     node1.query("ALTER USER shard SETTINGS max_memory_usage = 50000000 MIN 11111111 MAX 99999999")

--- a/tests/integration/test_settings_profile/test.py
+++ b/tests/integration/test_settings_profile/test.py
@@ -7,7 +7,9 @@ instance = cluster.add_instance('instance')
 
 
 def system_settings_profile(profile_name):
-    return TSV(instance.query("SELECT name, storage, num_elements, apply_to_all, apply_to_list, apply_to_except FROM system.settings_profiles WHERE name='" + profile_name + "'"))
+    return TSV(instance.query(
+        "SELECT name, storage, num_elements, apply_to_all, apply_to_list, apply_to_except FROM system.settings_profiles WHERE name='" + profile_name + "'"))
+
 
 def system_settings_profile_elements(profile_name=None, user_name=None, role_name=None):
     where = ""
@@ -45,33 +47,46 @@ def reset_after_test():
 
 def test_smoke():
     # Set settings and constraints via CREATE SETTINGS PROFILE ... TO user 
-    instance.query("CREATE SETTINGS PROFILE xyz SETTINGS max_memory_usage = 100000001 MIN 90000000 MAX 110000000 TO robin")
-    assert instance.query("SHOW CREATE SETTINGS PROFILE xyz") == "CREATE SETTINGS PROFILE xyz SETTINGS max_memory_usage = 100000001 MIN 90000000 MAX 110000000 TO robin\n"
-    assert instance.query("SELECT value FROM system.settings WHERE name = 'max_memory_usage'", user="robin") == "100000001\n"
-    assert "Setting max_memory_usage shouldn't be less than 90000000" in instance.query_and_get_error("SET max_memory_usage = 80000000", user="robin")
-    assert "Setting max_memory_usage shouldn't be greater than 110000000" in instance.query_and_get_error("SET max_memory_usage = 120000000", user="robin")
-    assert system_settings_profile("xyz") == [[ "xyz", "local directory", 1, 0, "['robin']", "[]" ]]
-    assert system_settings_profile_elements(profile_name="xyz") == [[ "xyz", "\N", "\N", 0, "max_memory_usage", 100000001, 90000000, 110000000, "\N", "\N" ]]
+    instance.query(
+        "CREATE SETTINGS PROFILE xyz SETTINGS max_memory_usage = 100000001 MIN 90000000 MAX 110000000 TO robin")
+    assert instance.query(
+        "SHOW CREATE SETTINGS PROFILE xyz") == "CREATE SETTINGS PROFILE xyz SETTINGS max_memory_usage = 100000001 MIN 90000000 MAX 110000000 TO robin\n"
+    assert instance.query("SELECT value FROM system.settings WHERE name = 'max_memory_usage'",
+                          user="robin") == "100000001\n"
+    assert "Setting max_memory_usage shouldn't be less than 90000000" in instance.query_and_get_error(
+        "SET max_memory_usage = 80000000", user="robin")
+    assert "Setting max_memory_usage shouldn't be greater than 110000000" in instance.query_and_get_error(
+        "SET max_memory_usage = 120000000", user="robin")
+    assert system_settings_profile("xyz") == [["xyz", "local directory", 1, 0, "['robin']", "[]"]]
+    assert system_settings_profile_elements(profile_name="xyz") == [
+        ["xyz", "\N", "\N", 0, "max_memory_usage", 100000001, 90000000, 110000000, "\N", "\N"]]
 
     instance.query("ALTER SETTINGS PROFILE xyz TO NONE")
-    assert instance.query("SHOW CREATE SETTINGS PROFILE xyz") == "CREATE SETTINGS PROFILE xyz SETTINGS max_memory_usage = 100000001 MIN 90000000 MAX 110000000\n"
-    assert instance.query("SELECT value FROM system.settings WHERE name = 'max_memory_usage'", user="robin") == "10000000000\n"
+    assert instance.query(
+        "SHOW CREATE SETTINGS PROFILE xyz") == "CREATE SETTINGS PROFILE xyz SETTINGS max_memory_usage = 100000001 MIN 90000000 MAX 110000000\n"
+    assert instance.query("SELECT value FROM system.settings WHERE name = 'max_memory_usage'",
+                          user="robin") == "10000000000\n"
     instance.query("SET max_memory_usage = 80000000", user="robin")
     instance.query("SET max_memory_usage = 120000000", user="robin")
-    assert system_settings_profile("xyz") == [[ "xyz", "local directory", 1, 0, "[]", "[]" ]]
+    assert system_settings_profile("xyz") == [["xyz", "local directory", 1, 0, "[]", "[]"]]
     assert system_settings_profile_elements(user_name="robin") == []
 
     # Set settings and constraints via CREATE USER ... SETTINGS PROFILE
     instance.query("ALTER USER robin SETTINGS PROFILE xyz")
     assert instance.query("SHOW CREATE USER robin") == "CREATE USER robin SETTINGS PROFILE xyz\n"
-    assert instance.query("SELECT value FROM system.settings WHERE name = 'max_memory_usage'", user="robin") == "100000001\n"
-    assert "Setting max_memory_usage shouldn't be less than 90000000" in instance.query_and_get_error("SET max_memory_usage = 80000000", user="robin")
-    assert "Setting max_memory_usage shouldn't be greater than 110000000" in instance.query_and_get_error("SET max_memory_usage = 120000000", user="robin")
-    assert system_settings_profile_elements(user_name="robin") == [[ "\N", "robin", "\N", 0, "\N", "\N", "\N", "\N", "\N", "xyz" ]]
+    assert instance.query("SELECT value FROM system.settings WHERE name = 'max_memory_usage'",
+                          user="robin") == "100000001\n"
+    assert "Setting max_memory_usage shouldn't be less than 90000000" in instance.query_and_get_error(
+        "SET max_memory_usage = 80000000", user="robin")
+    assert "Setting max_memory_usage shouldn't be greater than 110000000" in instance.query_and_get_error(
+        "SET max_memory_usage = 120000000", user="robin")
+    assert system_settings_profile_elements(user_name="robin") == [
+        ["\N", "robin", "\N", 0, "\N", "\N", "\N", "\N", "\N", "xyz"]]
 
     instance.query("ALTER USER robin SETTINGS NONE")
     assert instance.query("SHOW CREATE USER robin") == "CREATE USER robin\n"
-    assert instance.query("SELECT value FROM system.settings WHERE name = 'max_memory_usage'", user="robin") == "10000000000\n"
+    assert instance.query("SELECT value FROM system.settings WHERE name = 'max_memory_usage'",
+                          user="robin") == "10000000000\n"
     instance.query("SET max_memory_usage = 80000000", user="robin")
     instance.query("SET max_memory_usage = 120000000", user="robin")
     assert system_settings_profile_elements(user_name="robin") == []
@@ -79,70 +94,95 @@ def test_smoke():
 
 def test_settings_from_granted_role():
     # Set settings and constraints via granted role
-    instance.query("CREATE SETTINGS PROFILE xyz SETTINGS max_memory_usage = 100000001 MAX 110000000, max_ast_depth = 2000")
+    instance.query(
+        "CREATE SETTINGS PROFILE xyz SETTINGS max_memory_usage = 100000001 MAX 110000000, max_ast_depth = 2000")
     instance.query("CREATE ROLE worker SETTINGS PROFILE xyz")
     instance.query("GRANT worker TO robin")
-    assert instance.query("SHOW CREATE SETTINGS PROFILE xyz") == "CREATE SETTINGS PROFILE xyz SETTINGS max_memory_usage = 100000001 MAX 110000000, max_ast_depth = 2000\n"
+    assert instance.query(
+        "SHOW CREATE SETTINGS PROFILE xyz") == "CREATE SETTINGS PROFILE xyz SETTINGS max_memory_usage = 100000001 MAX 110000000, max_ast_depth = 2000\n"
     assert instance.query("SHOW CREATE ROLE worker") == "CREATE ROLE worker SETTINGS PROFILE xyz\n"
-    assert instance.query("SELECT value FROM system.settings WHERE name = 'max_memory_usage'", user="robin") == "100000001\n"
+    assert instance.query("SELECT value FROM system.settings WHERE name = 'max_memory_usage'",
+                          user="robin") == "100000001\n"
     assert instance.query("SELECT value FROM system.settings WHERE name = 'max_ast_depth'", user="robin") == "2000\n"
-    assert "Setting max_memory_usage shouldn't be greater than 110000000" in instance.query_and_get_error("SET max_memory_usage = 120000000", user="robin")
-    assert system_settings_profile("xyz") == [[ "xyz", "local directory", 2, 0, "[]", "[]" ]]
-    assert system_settings_profile_elements(profile_name="xyz") == [[ "xyz", "\N", "\N", 0, "max_memory_usage", 100000001, "\N", 110000000, "\N", "\N" ],
-                                                                    [ "xyz", "\N", "\N", 1, "max_ast_depth",    2000,      "\N", "\N",      "\N", "\N" ]]
-    assert system_settings_profile_elements(role_name="worker") == [[ "\N", "\N", "worker", 0, "\N", "\N", "\N", "\N", "\N", "xyz" ]]
+    assert "Setting max_memory_usage shouldn't be greater than 110000000" in instance.query_and_get_error(
+        "SET max_memory_usage = 120000000", user="robin")
+    assert system_settings_profile("xyz") == [["xyz", "local directory", 2, 0, "[]", "[]"]]
+    assert system_settings_profile_elements(profile_name="xyz") == [
+        ["xyz", "\N", "\N", 0, "max_memory_usage", 100000001, "\N", 110000000, "\N", "\N"],
+        ["xyz", "\N", "\N", 1, "max_ast_depth", 2000, "\N", "\N", "\N", "\N"]]
+    assert system_settings_profile_elements(role_name="worker") == [
+        ["\N", "\N", "worker", 0, "\N", "\N", "\N", "\N", "\N", "xyz"]]
 
     instance.query("REVOKE worker FROM robin")
-    assert instance.query("SELECT value FROM system.settings WHERE name = 'max_memory_usage'", user="robin") == "10000000000\n"
+    assert instance.query("SELECT value FROM system.settings WHERE name = 'max_memory_usage'",
+                          user="robin") == "10000000000\n"
     instance.query("SET max_memory_usage = 120000000", user="robin")
 
     instance.query("ALTER ROLE worker SETTINGS NONE")
     instance.query("GRANT worker TO robin")
     assert instance.query("SHOW CREATE ROLE worker") == "CREATE ROLE worker\n"
-    assert instance.query("SELECT value FROM system.settings WHERE name = 'max_memory_usage'", user="robin") == "10000000000\n"
+    assert instance.query("SELECT value FROM system.settings WHERE name = 'max_memory_usage'",
+                          user="robin") == "10000000000\n"
     instance.query("SET max_memory_usage = 120000000", user="robin")
     assert system_settings_profile_elements(role_name="worker") == []
 
     # Set settings and constraints via CREATE SETTINGS PROFILE ... TO granted role
     instance.query("ALTER SETTINGS PROFILE xyz TO worker")
-    assert instance.query("SHOW CREATE SETTINGS PROFILE xyz") == "CREATE SETTINGS PROFILE xyz SETTINGS max_memory_usage = 100000001 MAX 110000000, max_ast_depth = 2000 TO worker\n"
-    assert instance.query("SELECT value FROM system.settings WHERE name = 'max_memory_usage'", user="robin") == "100000001\n"
-    assert "Setting max_memory_usage shouldn't be greater than 110000000" in instance.query_and_get_error("SET max_memory_usage = 120000000", user="robin")
-    assert system_settings_profile("xyz") == [[ "xyz", "local directory", 2, 0, "['worker']", "[]" ]]
+    assert instance.query(
+        "SHOW CREATE SETTINGS PROFILE xyz") == "CREATE SETTINGS PROFILE xyz SETTINGS max_memory_usage = 100000001 MAX 110000000, max_ast_depth = 2000 TO worker\n"
+    assert instance.query("SELECT value FROM system.settings WHERE name = 'max_memory_usage'",
+                          user="robin") == "100000001\n"
+    assert "Setting max_memory_usage shouldn't be greater than 110000000" in instance.query_and_get_error(
+        "SET max_memory_usage = 120000000", user="robin")
+    assert system_settings_profile("xyz") == [["xyz", "local directory", 2, 0, "['worker']", "[]"]]
 
     instance.query("ALTER SETTINGS PROFILE xyz TO NONE")
-    assert instance.query("SHOW CREATE SETTINGS PROFILE xyz") == "CREATE SETTINGS PROFILE xyz SETTINGS max_memory_usage = 100000001 MAX 110000000, max_ast_depth = 2000\n"
-    assert instance.query("SELECT value FROM system.settings WHERE name = 'max_memory_usage'", user="robin") == "10000000000\n"
+    assert instance.query(
+        "SHOW CREATE SETTINGS PROFILE xyz") == "CREATE SETTINGS PROFILE xyz SETTINGS max_memory_usage = 100000001 MAX 110000000, max_ast_depth = 2000\n"
+    assert instance.query("SELECT value FROM system.settings WHERE name = 'max_memory_usage'",
+                          user="robin") == "10000000000\n"
     instance.query("SET max_memory_usage = 120000000", user="robin")
-    assert system_settings_profile("xyz") == [[ "xyz", "local directory", 2, 0, "[]", "[]" ]]
+    assert system_settings_profile("xyz") == [["xyz", "local directory", 2, 0, "[]", "[]"]]
 
 
 def test_inheritance():
     instance.query("CREATE SETTINGS PROFILE xyz SETTINGS max_memory_usage = 100000002 READONLY")
     instance.query("CREATE SETTINGS PROFILE alpha SETTINGS PROFILE xyz TO robin")
-    assert instance.query("SHOW CREATE SETTINGS PROFILE xyz") == "CREATE SETTINGS PROFILE xyz SETTINGS max_memory_usage = 100000002 READONLY\n"
-    assert instance.query("SHOW CREATE SETTINGS PROFILE alpha") == "CREATE SETTINGS PROFILE alpha SETTINGS INHERIT xyz TO robin\n"
-    assert instance.query("SELECT value FROM system.settings WHERE name = 'max_memory_usage'", user="robin") == "100000002\n"
-    assert "Setting max_memory_usage should not be changed" in instance.query_and_get_error("SET max_memory_usage = 80000000", user="robin")
+    assert instance.query(
+        "SHOW CREATE SETTINGS PROFILE xyz") == "CREATE SETTINGS PROFILE xyz SETTINGS max_memory_usage = 100000002 READONLY\n"
+    assert instance.query(
+        "SHOW CREATE SETTINGS PROFILE alpha") == "CREATE SETTINGS PROFILE alpha SETTINGS INHERIT xyz TO robin\n"
+    assert instance.query("SELECT value FROM system.settings WHERE name = 'max_memory_usage'",
+                          user="robin") == "100000002\n"
+    assert "Setting max_memory_usage should not be changed" in instance.query_and_get_error(
+        "SET max_memory_usage = 80000000", user="robin")
 
-    assert system_settings_profile("xyz") == [[ "xyz", "local directory", 1, 0, "[]", "[]" ]]
-    assert system_settings_profile_elements(profile_name="xyz") == [[ "xyz", "\N", "\N", 0, "max_memory_usage", 100000002, "\N", "\N", 1, "\N" ]]
-    assert system_settings_profile("alpha") == [[ "alpha", "local directory", 1, 0, "['robin']", "[]" ]]
-    assert system_settings_profile_elements(profile_name="alpha") == [[ "alpha", "\N", "\N", 0, "\N", "\N", "\N", "\N", "\N", "xyz" ]]
+    assert system_settings_profile("xyz") == [["xyz", "local directory", 1, 0, "[]", "[]"]]
+    assert system_settings_profile_elements(profile_name="xyz") == [
+        ["xyz", "\N", "\N", 0, "max_memory_usage", 100000002, "\N", "\N", 1, "\N"]]
+    assert system_settings_profile("alpha") == [["alpha", "local directory", 1, 0, "['robin']", "[]"]]
+    assert system_settings_profile_elements(profile_name="alpha") == [
+        ["alpha", "\N", "\N", 0, "\N", "\N", "\N", "\N", "\N", "xyz"]]
     assert system_settings_profile_elements(user_name="robin") == []
 
 
 def test_alter_and_drop():
-    instance.query("CREATE SETTINGS PROFILE xyz SETTINGS max_memory_usage = 100000003 MIN 90000000 MAX 110000000 TO robin")
-    assert instance.query("SELECT value FROM system.settings WHERE name = 'max_memory_usage'", user="robin") == "100000003\n"
-    assert "Setting max_memory_usage shouldn't be less than 90000000" in instance.query_and_get_error("SET max_memory_usage = 80000000", user="robin")
-    assert "Setting max_memory_usage shouldn't be greater than 110000000" in instance.query_and_get_error("SET max_memory_usage = 120000000", user="robin")
+    instance.query(
+        "CREATE SETTINGS PROFILE xyz SETTINGS max_memory_usage = 100000003 MIN 90000000 MAX 110000000 TO robin")
+    assert instance.query("SELECT value FROM system.settings WHERE name = 'max_memory_usage'",
+                          user="robin") == "100000003\n"
+    assert "Setting max_memory_usage shouldn't be less than 90000000" in instance.query_and_get_error(
+        "SET max_memory_usage = 80000000", user="robin")
+    assert "Setting max_memory_usage shouldn't be greater than 110000000" in instance.query_and_get_error(
+        "SET max_memory_usage = 120000000", user="robin")
 
     instance.query("ALTER SETTINGS PROFILE xyz SETTINGS readonly=1")
-    assert "Cannot modify 'max_memory_usage' setting in readonly mode" in instance.query_and_get_error("SET max_memory_usage = 80000000", user="robin")
+    assert "Cannot modify 'max_memory_usage' setting in readonly mode" in instance.query_and_get_error(
+        "SET max_memory_usage = 80000000", user="robin")
 
     instance.query("DROP SETTINGS PROFILE xyz")
-    assert instance.query("SELECT value FROM system.settings WHERE name = 'max_memory_usage'", user="robin") == "10000000000\n"
+    assert instance.query("SELECT value FROM system.settings WHERE name = 'max_memory_usage'",
+                          user="robin") == "10000000000\n"
     instance.query("SET max_memory_usage = 80000000", user="robin")
     instance.query("SET max_memory_usage = 120000000", user="robin")
 
@@ -151,25 +191,29 @@ def test_show_profiles():
     instance.query("CREATE SETTINGS PROFILE xyz")
     assert instance.query("SHOW SETTINGS PROFILES") == "default\nreadonly\nxyz\n"
     assert instance.query("SHOW PROFILES") == "default\nreadonly\nxyz\n"
-    
+
     assert instance.query("SHOW CREATE PROFILE xyz") == "CREATE SETTINGS PROFILE xyz\n"
-    assert instance.query("SHOW CREATE SETTINGS PROFILE default") == "CREATE SETTINGS PROFILE default SETTINGS max_memory_usage = 10000000000, use_uncompressed_cache = 0, load_balancing = \\'random\\'\n"
-    assert instance.query("SHOW CREATE PROFILES") == "CREATE SETTINGS PROFILE default SETTINGS max_memory_usage = 10000000000, use_uncompressed_cache = 0, load_balancing = \\'random\\'\n"\
-                                                     "CREATE SETTINGS PROFILE readonly SETTINGS readonly = 1\n"\
-                                                     "CREATE SETTINGS PROFILE xyz\n"
-    
-    expected_access = "CREATE SETTINGS PROFILE default SETTINGS max_memory_usage = 10000000000, use_uncompressed_cache = 0, load_balancing = \\'random\\'\n"\
-                      "CREATE SETTINGS PROFILE readonly SETTINGS readonly = 1\n"\
+    assert instance.query(
+        "SHOW CREATE SETTINGS PROFILE default") == "CREATE SETTINGS PROFILE default SETTINGS max_memory_usage = 10000000000, use_uncompressed_cache = 0, load_balancing = \\'random\\'\n"
+    assert instance.query(
+        "SHOW CREATE PROFILES") == "CREATE SETTINGS PROFILE default SETTINGS max_memory_usage = 10000000000, use_uncompressed_cache = 0, load_balancing = \\'random\\'\n" \
+                                   "CREATE SETTINGS PROFILE readonly SETTINGS readonly = 1\n" \
+                                   "CREATE SETTINGS PROFILE xyz\n"
+
+    expected_access = "CREATE SETTINGS PROFILE default SETTINGS max_memory_usage = 10000000000, use_uncompressed_cache = 0, load_balancing = \\'random\\'\n" \
+                      "CREATE SETTINGS PROFILE readonly SETTINGS readonly = 1\n" \
                       "CREATE SETTINGS PROFILE xyz\n"
     assert expected_access in instance.query("SHOW ACCESS")
 
 
 def test_allow_ddl():
     assert "Not enough privileges" in instance.query_and_get_error("CREATE TABLE tbl(a Int32) ENGINE=Log", user="robin")
-    assert "DDL queries are prohibited" in instance.query_and_get_error("CREATE TABLE tbl(a Int32) ENGINE=Log", settings={"allow_ddl":0})
+    assert "DDL queries are prohibited" in instance.query_and_get_error("CREATE TABLE tbl(a Int32) ENGINE=Log",
+                                                                        settings={"allow_ddl": 0})
 
     assert "Not enough privileges" in instance.query_and_get_error("GRANT CREATE ON tbl TO robin", user="robin")
-    assert "DDL queries are prohibited" in instance.query_and_get_error("GRANT CREATE ON tbl TO robin", settings={"allow_ddl":0})
+    assert "DDL queries are prohibited" in instance.query_and_get_error("GRANT CREATE ON tbl TO robin",
+                                                                        settings={"allow_ddl": 0})
 
     instance.query("GRANT CREATE ON tbl TO robin")
     instance.query("CREATE TABLE tbl(a Int32) ENGINE=Log", user="robin")
@@ -179,14 +223,16 @@ def test_allow_ddl():
 def test_allow_introspection():
     assert "Introspection functions are disabled" in instance.query_and_get_error("SELECT demangle('a')")
     assert "Not enough privileges" in instance.query_and_get_error("SELECT demangle('a')", user="robin")
-    assert "Not enough privileges" in instance.query_and_get_error("SELECT demangle('a')", user="robin", settings={"allow_introspection_functions":1})
+    assert "Not enough privileges" in instance.query_and_get_error("SELECT demangle('a')", user="robin",
+                                                                   settings={"allow_introspection_functions": 1})
 
     assert "Introspection functions are disabled" in instance.query_and_get_error("GRANT demangle ON *.* TO robin")
     assert "Not enough privileges" in instance.query_and_get_error("GRANT demangle ON *.* TO robin", user="robin")
-    assert "Not enough privileges" in instance.query_and_get_error("GRANT demangle ON *.* TO robin", user="robin", settings={"allow_introspection_functions":1})
+    assert "Not enough privileges" in instance.query_and_get_error("GRANT demangle ON *.* TO robin", user="robin",
+                                                                   settings={"allow_introspection_functions": 1})
 
-    assert instance.query("SELECT demangle('a')", settings={"allow_introspection_functions":1}) == "signed char\n"
-    instance.query("GRANT demangle ON *.* TO robin", settings={"allow_introspection_functions":1})
+    assert instance.query("SELECT demangle('a')", settings={"allow_introspection_functions": 1}) == "signed char\n"
+    instance.query("GRANT demangle ON *.* TO robin", settings={"allow_introspection_functions": 1})
 
     assert "Introspection functions are disabled" in instance.query_and_get_error("SELECT demangle('a')", user="robin")
     instance.query("ALTER USER robin SETTINGS allow_introspection_functions=1")
@@ -201,5 +247,5 @@ def test_allow_introspection():
     instance.query("DROP SETTINGS PROFILE xyz")
     assert "Introspection functions are disabled" in instance.query_and_get_error("SELECT demangle('a')", user="robin")
 
-    instance.query("REVOKE demangle ON *.* FROM robin", settings={"allow_introspection_functions":1})
+    instance.query("REVOKE demangle ON *.* FROM robin", settings={"allow_introspection_functions": 1})
     assert "Not enough privileges" in instance.query_and_get_error("SELECT demangle('a')", user="robin")

--- a/tests/integration/test_storage_hdfs/test.py
+++ b/tests/integration/test_storage_hdfs/test.py
@@ -1,18 +1,13 @@
-import time
-import pytest
-import requests
-from tempfile import NamedTemporaryFile
-from helpers.hdfs_api import HDFSApi
-
 import os
 
+import pytest
 from helpers.cluster import ClickHouseCluster
-import subprocess
-
+from helpers.hdfs_api import HDFSApi
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', with_hdfs=True, user_configs=[], main_configs=['configs/log_conf.xml'])
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -27,21 +22,28 @@ def started_cluster():
     finally:
         cluster.shutdown()
 
+
 def test_read_write_storage(started_cluster):
     hdfs_api = HDFSApi("root")
 
-    node1.query("create table SimpleHDFSStorage (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs1:9000/simple_storage', 'TSV')")
+    node1.query(
+        "create table SimpleHDFSStorage (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs1:9000/simple_storage', 'TSV')")
     node1.query("insert into SimpleHDFSStorage values (1, 'Mark', 72.53)")
     assert hdfs_api.read_data("/simple_storage") == "1\tMark\t72.53\n"
     assert node1.query("select * from SimpleHDFSStorage") == "1\tMark\t72.53\n"
 
+
 def test_read_write_storage_with_globs(started_cluster):
     hdfs_api = HDFSApi("root")
 
-    node1.query("create table HDFSStorageWithRange (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs1:9000/storage{1..5}', 'TSV')")
-    node1.query("create table HDFSStorageWithEnum (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs1:9000/storage{1,2,3,4,5}', 'TSV')")
-    node1.query("create table HDFSStorageWithQuestionMark (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs1:9000/storage?', 'TSV')")
-    node1.query("create table HDFSStorageWithAsterisk (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs1:9000/storage*', 'TSV')")
+    node1.query(
+        "create table HDFSStorageWithRange (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs1:9000/storage{1..5}', 'TSV')")
+    node1.query(
+        "create table HDFSStorageWithEnum (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs1:9000/storage{1,2,3,4,5}', 'TSV')")
+    node1.query(
+        "create table HDFSStorageWithQuestionMark (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs1:9000/storage?', 'TSV')")
+    node1.query(
+        "create table HDFSStorageWithAsterisk (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs1:9000/storage*', 'TSV')")
 
     for i in ["1", "2", "3"]:
         hdfs_api.write_data("/storage" + i, i + "\tMark\t72.53\n")
@@ -73,6 +75,7 @@ def test_read_write_storage_with_globs(started_cluster):
         print ex
         assert "in readonly mode" in str(ex)
 
+
 def test_read_write_table(started_cluster):
     hdfs_api = HDFSApi("root")
     data = "1\tSerialize\t555.222\n2\tData\t777.333\n"
@@ -80,42 +83,50 @@ def test_read_write_table(started_cluster):
 
     assert hdfs_api.read_data("/simple_table_function") == data
 
-    assert node1.query("select * from hdfs('hdfs://hdfs1:9000/simple_table_function', 'TSV', 'id UInt64, text String, number Float64')") == data
+    assert node1.query(
+        "select * from hdfs('hdfs://hdfs1:9000/simple_table_function', 'TSV', 'id UInt64, text String, number Float64')") == data
 
 
 def test_write_table(started_cluster):
     hdfs_api = HDFSApi("root")
 
-    node1.query("create table OtherHDFSStorage (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs1:9000/other_storage', 'TSV')")
+    node1.query(
+        "create table OtherHDFSStorage (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs1:9000/other_storage', 'TSV')")
     node1.query("insert into OtherHDFSStorage values (10, 'tomas', 55.55), (11, 'jack', 32.54)")
 
     result = "10\ttomas\t55.55\n11\tjack\t32.54\n"
     assert hdfs_api.read_data("/other_storage") == result
     assert node1.query("select * from OtherHDFSStorage order by id") == result
 
+
 def test_bad_hdfs_uri(started_cluster):
     try:
-        node1.query("create table BadStorage1 (id UInt32, name String, weight Float64) ENGINE = HDFS('hads:hgsdfs100500:9000/other_storage', 'TSV')")
+        node1.query(
+            "create table BadStorage1 (id UInt32, name String, weight Float64) ENGINE = HDFS('hads:hgsdfs100500:9000/other_storage', 'TSV')")
     except Exception as ex:
         print ex
         assert "Illegal HDFS URI" in str(ex)
     try:
-        node1.query("create table BadStorage2 (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs100500:9000/other_storage', 'TSV')")
+        node1.query(
+            "create table BadStorage2 (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs100500:9000/other_storage', 'TSV')")
     except Exception as ex:
         print ex
         assert "Unable to create builder to connect to HDFS" in str(ex)
 
     try:
-        node1.query("create table BadStorage3 (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs1:9000/<>', 'TSV')")
+        node1.query(
+            "create table BadStorage3 (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs1:9000/<>', 'TSV')")
     except Exception as ex:
         print ex
         assert "Unable to open HDFS file" in str(ex)
+
 
 def test_globs_in_read_table(started_cluster):
     hdfs_api = HDFSApi("root")
     some_data = "1\tSerialize\t555.222\n2\tData\t777.333\n"
     globs_dir = "/dir_for_test_with_globs/"
-    files = ["dir1/dir_dir/file1", "dir2/file2", "simple_table_function", "dir/file", "some_dir/dir1/file", "some_dir/dir2/file", "some_dir/file", "table1_function", "table2_function", "table3_function"]
+    files = ["dir1/dir_dir/file1", "dir2/file2", "simple_table_function", "dir/file", "some_dir/dir1/file",
+             "some_dir/dir2/file", "some_dir/file", "table1_function", "table2_function", "table3_function"]
     for filename in files:
         hdfs_api.write_data(globs_dir + filename, some_data)
 
@@ -135,8 +146,11 @@ def test_globs_in_read_table(started_cluster):
     for pattern, paths_amount, files_amount in test_requests:
         inside_table_func = "'hdfs://hdfs1:9000" + globs_dir + pattern + "', 'TSV', 'id UInt64, text String, number Float64'"
         assert node1.query("select * from hdfs(" + inside_table_func + ")") == paths_amount * some_data
-        assert node1.query("select count(distinct _path) from hdfs(" + inside_table_func + ")").rstrip() == str(paths_amount)
-        assert node1.query("select count(distinct _file) from hdfs(" + inside_table_func + ")").rstrip() == str(files_amount)
+        assert node1.query("select count(distinct _path) from hdfs(" + inside_table_func + ")").rstrip() == str(
+            paths_amount)
+        assert node1.query("select count(distinct _file) from hdfs(" + inside_table_func + ")").rstrip() == str(
+            files_amount)
+
 
 def test_read_write_gzip_table(started_cluster):
     hdfs_api = HDFSApi("root")
@@ -145,7 +159,9 @@ def test_read_write_gzip_table(started_cluster):
 
     assert hdfs_api.read_gzip_data("/simple_table_function.gz") == data
 
-    assert node1.query("select * from hdfs('hdfs://hdfs1:9000/simple_table_function.gz', 'TSV', 'id UInt64, text String, number Float64')") == data
+    assert node1.query(
+        "select * from hdfs('hdfs://hdfs1:9000/simple_table_function.gz', 'TSV', 'id UInt64, text String, number Float64')") == data
+
 
 def test_read_write_gzip_table_with_parameter_gzip(started_cluster):
     hdfs_api = HDFSApi("root")
@@ -154,7 +170,9 @@ def test_read_write_gzip_table_with_parameter_gzip(started_cluster):
 
     assert hdfs_api.read_gzip_data("/simple_table_function") == data
 
-    assert node1.query("select * from hdfs('hdfs://hdfs1:9000/simple_table_function', 'TSV', 'id UInt64, text String, number Float64', 'gzip')") == data
+    assert node1.query(
+        "select * from hdfs('hdfs://hdfs1:9000/simple_table_function', 'TSV', 'id UInt64, text String, number Float64', 'gzip')") == data
+
 
 def test_read_write_table_with_parameter_none(started_cluster):
     hdfs_api = HDFSApi("root")
@@ -163,7 +181,9 @@ def test_read_write_table_with_parameter_none(started_cluster):
 
     assert hdfs_api.read_data("/simple_table_function.gz") == data
 
-    assert node1.query("select * from hdfs('hdfs://hdfs1:9000/simple_table_function.gz', 'TSV', 'id UInt64, text String, number Float64', 'none')") == data
+    assert node1.query(
+        "select * from hdfs('hdfs://hdfs1:9000/simple_table_function.gz', 'TSV', 'id UInt64, text String, number Float64', 'none')") == data
+
 
 def test_read_write_gzip_table_with_parameter_auto_gz(started_cluster):
     hdfs_api = HDFSApi("root")
@@ -172,20 +192,25 @@ def test_read_write_gzip_table_with_parameter_auto_gz(started_cluster):
 
     assert hdfs_api.read_gzip_data("/simple_table_function.gz") == data
 
-    assert node1.query("select * from hdfs('hdfs://hdfs1:9000/simple_table_function.gz', 'TSV', 'id UInt64, text String, number Float64', 'auto')") == data
+    assert node1.query(
+        "select * from hdfs('hdfs://hdfs1:9000/simple_table_function.gz', 'TSV', 'id UInt64, text String, number Float64', 'auto')") == data
+
 
 def test_write_gz_storage(started_cluster):
     hdfs_api = HDFSApi("root")
 
-    node1.query("create table GZHDFSStorage (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs1:9000/storage.gz', 'TSV')")
+    node1.query(
+        "create table GZHDFSStorage (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs1:9000/storage.gz', 'TSV')")
     node1.query("insert into GZHDFSStorage values (1, 'Mark', 72.53)")
     assert hdfs_api.read_gzip_data("/storage.gz") == "1\tMark\t72.53\n"
     assert node1.query("select * from GZHDFSStorage") == "1\tMark\t72.53\n"
 
+
 def test_write_gzip_storage(started_cluster):
     hdfs_api = HDFSApi("root")
 
-    node1.query("create table GZIPHDFSStorage (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs1:9000/gzip_storage', 'TSV', 'gzip')")
+    node1.query(
+        "create table GZIPHDFSStorage (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs1:9000/gzip_storage', 'TSV', 'gzip')")
     node1.query("insert into GZIPHDFSStorage values (1, 'Mark', 72.53)")
     assert hdfs_api.read_gzip_data("/gzip_storage") == "1\tMark\t72.53\n"
     assert node1.query("select * from GZIPHDFSStorage") == "1\tMark\t72.53\n"

--- a/tests/integration/test_storage_kafka/kafka_pb2.py
+++ b/tests/integration/test_storage_kafka/kafka_pb2.py
@@ -2,75 +2,70 @@
 # source: clickhouse_path/format_schemas/kafka.proto
 
 import sys
-_b=sys.version_info[0]<3 and (lambda x:x) or (lambda x:x.encode('latin1'))
+
+_b = sys.version_info[0] < 3 and (lambda x: x) or (lambda x: x.encode('latin1'))
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
-from google.protobuf import descriptor_pb2
+
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
 
-
-
-
 DESCRIPTOR = _descriptor.FileDescriptor(
-  name='clickhouse_path/format_schemas/kafka.proto',
-  package='',
-  syntax='proto3',
-  serialized_pb=_b('\n*clickhouse_path/format_schemas/kafka.proto\"*\n\x0cKeyValuePair\x12\x0b\n\x03key\x18\x01 \x01(\x04\x12\r\n\x05value\x18\x02 \x01(\tb\x06proto3')
+    name='clickhouse_path/format_schemas/kafka.proto',
+    package='',
+    syntax='proto3',
+    serialized_pb=_b(
+        '\n*clickhouse_path/format_schemas/kafka.proto\"*\n\x0cKeyValuePair\x12\x0b\n\x03key\x18\x01 \x01(\x04\x12\r\n\x05value\x18\x02 \x01(\tb\x06proto3')
 )
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
-
-
-
 _KEYVALUEPAIR = _descriptor.Descriptor(
-  name='KeyValuePair',
-  full_name='KeyValuePair',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='key', full_name='KeyValuePair.key', index=0,
-      number=1, type=4, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='value', full_name='KeyValuePair.value', index=1,
-      number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=46,
-  serialized_end=88,
+    name='KeyValuePair',
+    full_name='KeyValuePair',
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name='key', full_name='KeyValuePair.key', index=0,
+            number=1, type=4, cpp_type=4, label=1,
+            has_default_value=False, default_value=0,
+            message_type=None, enum_type=None, containing_type=None,
+            is_extension=False, extension_scope=None,
+            options=None),
+        _descriptor.FieldDescriptor(
+            name='value', full_name='KeyValuePair.value', index=1,
+            number=2, type=9, cpp_type=9, label=1,
+            has_default_value=False, default_value=_b("").decode('utf-8'),
+            message_type=None, enum_type=None, containing_type=None,
+            is_extension=False, extension_scope=None,
+            options=None),
+    ],
+    extensions=[
+    ],
+    nested_types=[],
+    enum_types=[
+    ],
+    options=None,
+    is_extendable=False,
+    syntax='proto3',
+    extension_ranges=[],
+    oneofs=[
+    ],
+    serialized_start=46,
+    serialized_end=88,
 )
 
 DESCRIPTOR.message_types_by_name['KeyValuePair'] = _KEYVALUEPAIR
 
 KeyValuePair = _reflection.GeneratedProtocolMessageType('KeyValuePair', (_message.Message,), dict(
-  DESCRIPTOR = _KEYVALUEPAIR,
-  __module__ = 'clickhouse_path.format_schemas.kafka_pb2'
-  # @@protoc_insertion_point(class_scope:KeyValuePair)
-  ))
+    DESCRIPTOR=_KEYVALUEPAIR,
+    __module__='clickhouse_path.format_schemas.kafka_pb2'
+    # @@protoc_insertion_point(class_scope:KeyValuePair)
+))
 _sym_db.RegisterMessage(KeyValuePair)
-
 
 # @@protoc_insertion_point(module_scope)

--- a/tests/integration/test_storage_mongodb/test.py
+++ b/tests/integration/test_storage_mongodb/test.py
@@ -3,7 +3,6 @@ import pymongo
 import pytest
 from helpers.client import QueryRuntimeException
 
-
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
@@ -36,7 +35,8 @@ def test_simple_select(started_cluster):
         data.append({'key': i, 'data': hex(i * i)})
     simple_mongo_table.insert_many(data)
 
-    node.query("CREATE TABLE simple_mongo_table(key UInt64, data String) ENGINE = MongoDB('mongo1:27017', 'test', 'simple_table', 'root', 'clickhouse')")
+    node.query(
+        "CREATE TABLE simple_mongo_table(key UInt64, data String) ENGINE = MongoDB('mongo1:27017', 'test', 'simple_table', 'root', 'clickhouse')")
 
     assert node.query("SELECT COUNT() FROM simple_mongo_table") == '100\n'
     assert node.query("SELECT sum(key) FROM simple_mongo_table") == str(sum(range(0, 100))) + '\n'
@@ -51,10 +51,11 @@ def test_complex_data_type(started_cluster):
     incomplete_mongo_table = db['complex_table']
     data = []
     for i in range(0, 100):
-        data.append({'key': i, 'data': hex(i * i), 'dict': {'a' : i, 'b': str(i)}})
+        data.append({'key': i, 'data': hex(i * i), 'dict': {'a': i, 'b': str(i)}})
     incomplete_mongo_table.insert_many(data)
 
-    node.query("CREATE TABLE incomplete_mongo_table(key UInt64, data String) ENGINE = MongoDB('mongo1:27017', 'test', 'complex_table', 'root', 'clickhouse')")
+    node.query(
+        "CREATE TABLE incomplete_mongo_table(key UInt64, data String) ENGINE = MongoDB('mongo1:27017', 'test', 'complex_table', 'root', 'clickhouse')")
 
     assert node.query("SELECT COUNT() FROM incomplete_mongo_table") == '100\n'
     assert node.query("SELECT sum(key) FROM incomplete_mongo_table") == str(sum(range(0, 100))) + '\n'
@@ -72,7 +73,8 @@ def test_incorrect_data_type(started_cluster):
         data.append({'key': i, 'data': hex(i * i), 'aaaa': 'Hello'})
     strange_mongo_table.insert_many(data)
 
-    node.query("CREATE TABLE strange_mongo_table(key String, data String) ENGINE = MongoDB('mongo1:27017', 'test', 'strange_table', 'root', 'clickhouse')")
+    node.query(
+        "CREATE TABLE strange_mongo_table(key String, data String) ENGINE = MongoDB('mongo1:27017', 'test', 'strange_table', 'root', 'clickhouse')")
 
     with pytest.raises(QueryRuntimeException):
         node.query("SELECT COUNT() FROM strange_mongo_table")
@@ -80,7 +82,8 @@ def test_incorrect_data_type(started_cluster):
     with pytest.raises(QueryRuntimeException):
         node.query("SELECT uniq(key) FROM strange_mongo_table")
 
-    node.query("CREATE TABLE strange_mongo_table2(key UInt64, data String, bbbb String) ENGINE = MongoDB('mongo1:27017', 'test', 'strange_table', 'root', 'clickhouse')")
+    node.query(
+        "CREATE TABLE strange_mongo_table2(key UInt64, data String, bbbb String) ENGINE = MongoDB('mongo1:27017', 'test', 'strange_table', 'root', 'clickhouse')")
 
     with pytest.raises(QueryRuntimeException):
         node.query("SELECT bbbb FROM strange_mongo_table2")

--- a/tests/integration/test_storage_rabbitmq/rabbitmq_pb2.py
+++ b/tests/integration/test_storage_rabbitmq/rabbitmq_pb2.py
@@ -6,72 +6,66 @@ from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
+
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
 
-
-
-
 DESCRIPTOR = _descriptor.FileDescriptor(
-  name='clickhouse_path/format_schemas/rabbitmq.proto',
-  package='',
-  syntax='proto3',
-  serialized_options=None,
-  create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n-clickhouse_path/format_schemas/rabbitmq.proto\"+\n\rKeyValueProto\x12\x0b\n\x03key\x18\x01 \x01(\x04\x12\r\n\x05value\x18\x02 \x01(\tb\x06proto3'
+    name='clickhouse_path/format_schemas/rabbitmq.proto',
+    package='',
+    syntax='proto3',
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+    serialized_pb=b'\n-clickhouse_path/format_schemas/rabbitmq.proto\"+\n\rKeyValueProto\x12\x0b\n\x03key\x18\x01 \x01(\x04\x12\r\n\x05value\x18\x02 \x01(\tb\x06proto3'
 )
 
-
-
-
 _KEYVALUEPROTO = _descriptor.Descriptor(
-  name='KeyValueProto',
-  full_name='KeyValueProto',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='key', full_name='KeyValueProto.key', index=0,
-      number=1, type=4, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='value', full_name='KeyValueProto.value', index=1,
-      number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=49,
-  serialized_end=92,
+    name='KeyValueProto',
+    full_name='KeyValueProto',
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name='key', full_name='KeyValueProto.key', index=0,
+            number=1, type=4, cpp_type=4, label=1,
+            has_default_value=False, default_value=0,
+            message_type=None, enum_type=None, containing_type=None,
+            is_extension=False, extension_scope=None,
+            serialized_options=None, file=DESCRIPTOR, create_key=_descriptor._internal_create_key),
+        _descriptor.FieldDescriptor(
+            name='value', full_name='KeyValueProto.value', index=1,
+            number=2, type=9, cpp_type=9, label=1,
+            has_default_value=False, default_value=b"".decode('utf-8'),
+            message_type=None, enum_type=None, containing_type=None,
+            is_extension=False, extension_scope=None,
+            serialized_options=None, file=DESCRIPTOR, create_key=_descriptor._internal_create_key),
+    ],
+    extensions=[
+    ],
+    nested_types=[],
+    enum_types=[
+    ],
+    serialized_options=None,
+    is_extendable=False,
+    syntax='proto3',
+    extension_ranges=[],
+    oneofs=[
+    ],
+    serialized_start=49,
+    serialized_end=92,
 )
 
 DESCRIPTOR.message_types_by_name['KeyValueProto'] = _KEYVALUEPROTO
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 KeyValueProto = _reflection.GeneratedProtocolMessageType('KeyValueProto', (_message.Message,), {
-  'DESCRIPTOR' : _KEYVALUEPROTO,
-  '__module__' : 'clickhouse_path.format_schemas.rabbitmq_pb2'
-  # @@protoc_insertion_point(class_scope:KeyValueProto)
-  })
+    'DESCRIPTOR': _KEYVALUEPROTO,
+    '__module__': 'clickhouse_path.format_schemas.rabbitmq_pb2'
+    # @@protoc_insertion_point(class_scope:KeyValueProto)
+})
 _sym_db.RegisterMessage(KeyValueProto)
-
 
 # @@protoc_insertion_point(module_scope)

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -1,29 +1,23 @@
+import json
 import os.path as p
 import random
+import subprocess
 import threading
 import time
-import pytest
-
 from random import randrange
-import pika
-from sys import getdefaultencoding
 
+import pika
+import pytest
+from google.protobuf.internal.encoder import _VarintBytes
+from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
-from helpers.client import QueryRuntimeException
-from helpers.network import PartitionManager
-
-import json
-import subprocess
-
-from confluent.schemaregistry.serializers.MessageSerializer import MessageSerializer
-from google.protobuf.internal.encoder import _VarintBytes
 
 import rabbitmq_pb2
 
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance('instance',
-                                main_configs=['configs/rabbitmq.xml','configs/log_conf.xml'],
+                                main_configs=['configs/rabbitmq.xml', 'configs/log_conf.xml'],
                                 with_rabbitmq=True)
 #                                clickhouse_path_dir='clickhouse_path')
 rabbitmq_id = ''
@@ -542,7 +536,6 @@ def test_rabbitmq_big_message(rabbitmq_cluster):
 
 @pytest.mark.timeout(420)
 def test_rabbitmq_sharding_between_queues_publish(rabbitmq_cluster):
-
     NUM_CONSUMERS = 10
     NUM_QUEUES = 2
 
@@ -570,6 +563,7 @@ def test_rabbitmq_sharding_between_queues_publish(rabbitmq_cluster):
 
     credentials = pika.PlainCredentials('root', 'clickhouse')
     parameters = pika.ConnectionParameters('localhost', 5672, '/', credentials)
+
     def produce():
         connection = pika.BlockingConnection(parameters)
         channel = connection.channel()
@@ -582,7 +576,8 @@ def test_rabbitmq_sharding_between_queues_publish(rabbitmq_cluster):
         for message in messages:
             current += 1
             mes_id = str(current)
-            channel.basic_publish(exchange='test_sharding', routing_key='', properties=pika.BasicProperties(message_id=mes_id), body=message)
+            channel.basic_publish(exchange='test_sharding', routing_key='',
+                                  properties=pika.BasicProperties(message_id=mes_id), body=message)
         connection.close()
 
     threads = []
@@ -612,7 +607,6 @@ def test_rabbitmq_sharding_between_queues_publish(rabbitmq_cluster):
 
 @pytest.mark.timeout(420)
 def test_rabbitmq_mv_combo(rabbitmq_cluster):
-
     NUM_MV = 5
     NUM_CONSUMERS = 4
 
@@ -646,6 +640,7 @@ def test_rabbitmq_mv_combo(rabbitmq_cluster):
 
     credentials = pika.PlainCredentials('root', 'clickhouse')
     parameters = pika.ConnectionParameters('localhost', 5672, '/', credentials)
+
     def produce():
         connection = pika.BlockingConnection(parameters)
         channel = connection.channel()
@@ -656,7 +651,7 @@ def test_rabbitmq_mv_combo(rabbitmq_cluster):
             i[0] += 1
         for msg_id in range(messages_num):
             channel.basic_publish(exchange='combo', routing_key='',
-                properties=pika.BasicProperties(message_id=str(msg_id)), body=messages[msg_id])
+                                  properties=pika.BasicProperties(message_id=str(msg_id)), body=messages[msg_id])
         connection.close()
 
     threads = []
@@ -684,7 +679,6 @@ def test_rabbitmq_mv_combo(rabbitmq_cluster):
             DROP TABLE test.combo_{0}_mv;
             DROP TABLE test.combo_{0};
         '''.format(mv_id))
-
 
     assert int(result) == messages_num * threads_num * NUM_MV, 'ClickHouse lost some messages: {}'.format(result)
 
@@ -727,6 +721,7 @@ def test_rabbitmq_insert(rabbitmq_cluster):
                 raise
 
     insert_messages = []
+
     def onReceived(channel, method, properties, body):
         i = 0
         insert_messages.append(body.decode())
@@ -762,7 +757,7 @@ def test_rabbitmq_insert_headers_exchange(rabbitmq_cluster):
     result = consumer.queue_declare(queue='')
     queue_name = result.method.queue
     consumer.queue_bind(exchange='insert_headers', queue=queue_name, routing_key="",
-            arguments={'x-match':'all', 'test':'insert', 'topic':'headers'})
+                        arguments={'x-match': 'all', 'test': 'insert', 'topic': 'headers'})
 
     values = []
     for i in range(50):
@@ -780,6 +775,7 @@ def test_rabbitmq_insert_headers_exchange(rabbitmq_cluster):
                 raise
 
     insert_messages = []
+
     def onReceived(channel, method, properties, body):
         i = 0
         insert_messages.append(body.decode())
@@ -826,6 +822,7 @@ def test_rabbitmq_many_inserts(rabbitmq_cluster):
     ''')
 
     messages_num = 1000
+
     def insert():
         values = []
         for i in range(messages_num):
@@ -904,6 +901,7 @@ def test_rabbitmq_overloaded_insert(rabbitmq_cluster):
     ''')
 
     messages_num = 100000
+
     def insert():
         values = []
         for i in range(messages_num):
@@ -997,8 +995,8 @@ def test_rabbitmq_direct_exchange(rabbitmq_cluster):
         for message in messages:
             mes_id = str(randrange(10))
             channel.basic_publish(
-                    exchange='direct_exchange_testing', routing_key=key,
-                    properties=pika.BasicProperties(message_id=mes_id), body=message)
+                exchange='direct_exchange_testing', routing_key=key,
+                properties=pika.BasicProperties(message_id=mes_id), body=message)
 
     connection.close()
 
@@ -1065,7 +1063,7 @@ def test_rabbitmq_fanout_exchange(rabbitmq_cluster):
 
     for msg_id in range(messages_num):
         channel.basic_publish(exchange='fanout_exchange_testing', routing_key='',
-                properties=pika.BasicProperties(message_id=str(msg_id)), body=messages[msg_id])
+                              properties=pika.BasicProperties(message_id=str(msg_id)), body=messages[msg_id])
 
     connection.close()
 
@@ -1160,7 +1158,7 @@ def test_rabbitmq_topic_exchange(rabbitmq_cluster):
     current = 0
     for msg_id in range(messages_num):
         channel.basic_publish(exchange='topic_exchange_testing', routing_key=key,
-                properties=pika.BasicProperties(message_id=str(msg_id)), body=messages[msg_id])
+                              properties=pika.BasicProperties(message_id=str(msg_id)), body=messages[msg_id])
 
     connection.close()
 
@@ -1180,7 +1178,9 @@ def test_rabbitmq_topic_exchange(rabbitmq_cluster):
         DROP TABLE test.destination;
     ''')
 
-    assert int(result) == messages_num * num_tables + messages_num * num_tables, 'ClickHouse lost some messages: {}'.format(result)
+    assert int(
+        result) == messages_num * num_tables + messages_num * num_tables, 'ClickHouse lost some messages: {}'.format(
+        result)
 
 
 @pytest.mark.timeout(420)
@@ -1228,7 +1228,7 @@ def test_rabbitmq_hash_exchange(rabbitmq_cluster):
             i[0] += 1
         for msg_id in range(messages_num):
             channel.basic_publish(exchange='hash_exchange_testing', routing_key=str(msg_id),
-                properties=pika.BasicProperties(message_id=str(msg_id)), body=messages[msg_id])
+                                  properties=pika.BasicProperties(message_id=str(msg_id)), body=messages[msg_id])
         connection.close()
 
     threads = []
@@ -1265,7 +1265,6 @@ def test_rabbitmq_hash_exchange(rabbitmq_cluster):
 
     assert int(result1) == messages_num * threads_num, 'ClickHouse lost some messages: {}'.format(result)
     assert int(result2) == 4 * num_tables
-
 
 
 @pytest.mark.timeout(420)
@@ -1402,14 +1401,15 @@ def test_rabbitmq_headers_exchange(rabbitmq_cluster):
         messages.append(json.dumps({'key': i[0], 'value': i[0]}))
         i[0] += 1
 
-    fields={}
-    fields['format']='logs'
-    fields['type']='report'
-    fields['year']='2020'
+    fields = {}
+    fields['format'] = 'logs'
+    fields['type'] = 'report'
+    fields['year'] = '2020'
 
     for msg_id in range(messages_num):
         channel.basic_publish(exchange='headers_exchange_testing', routing_key='',
-                properties=pika.BasicProperties(headers=fields, message_id=str(msg_id)), body=messages[msg_id])
+                              properties=pika.BasicProperties(headers=fields, message_id=str(msg_id)),
+                              body=messages[msg_id])
 
     connection.close()
 
@@ -1535,7 +1535,8 @@ def test_rabbitmq_virtual_columns_with_materialized_view(rabbitmq_cluster):
 
     connection.close()
 
-    result = instance.query("SELECT key, value, exchange_name, SUBSTRING(channel_id, 1, 3), delivery_tag, redelivered FROM test.view ORDER BY delivery_tag")
+    result = instance.query(
+        "SELECT key, value, exchange_name, SUBSTRING(channel_id, 1, 3), delivery_tag, redelivered FROM test.view ORDER BY delivery_tag")
     expected = '''\
 0	0	virtuals_mv	1_0	1	0
 1	1	virtuals_mv	1_0	2	0
@@ -1591,6 +1592,7 @@ def test_rabbitmq_many_consumers_to_each_queue(rabbitmq_cluster):
 
     credentials = pika.PlainCredentials('root', 'clickhouse')
     parameters = pika.ConnectionParameters('localhost', 5672, '/', credentials)
+
     def produce():
         connection = pika.BlockingConnection(parameters)
         channel = connection.channel()
@@ -1601,7 +1603,7 @@ def test_rabbitmq_many_consumers_to_each_queue(rabbitmq_cluster):
             i[0] += 1
         for msg_id in range(messages_num):
             channel.basic_publish(exchange='many_consumers', routing_key='',
-                    properties=pika.BasicProperties(message_id=str(msg_id)), body=messages[msg_id])
+                                  properties=pika.BasicProperties(message_id=str(msg_id)), body=messages[msg_id])
         connection.close()
 
     threads = []
@@ -1739,7 +1741,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster):
         i += 1
     for msg_id in range(messages_num):
         channel.basic_publish(exchange='consumer_reconnect', routing_key='', body=messages[msg_id],
-                properties=pika.BasicProperties(delivery_mode = 2, message_id=str(msg_id)))
+                              properties=pika.BasicProperties(delivery_mode=2, message_id=str(msg_id)))
     connection.close()
 
     instance.query('''
@@ -1759,12 +1761,12 @@ def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster):
     time.sleep(8)
     revive_rabbitmq()
 
-    #while int(instance.query('SELECT count() FROM test.view')) == 0:
+    # while int(instance.query('SELECT count() FROM test.view')) == 0:
     #    time.sleep(0.1)
 
-    #kill_rabbitmq()
-    #time.sleep(2)
-    #revive_rabbitmq()
+    # kill_rabbitmq()
+    # time.sleep(2)
+    # revive_rabbitmq()
 
     while True:
         result = instance.query('SELECT count(DISTINCT key) FROM test.view')
@@ -1808,6 +1810,7 @@ def test_rabbitmq_commit_on_block_write(rabbitmq_cluster):
     cancel = threading.Event()
 
     i = [0]
+
     def produce():
         while not cancel.is_set():
             messages = []

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -1,14 +1,12 @@
 import json
 import logging
+import os
 import random
 import threading
-import os
-
-import pytest
-
-from helpers.cluster import ClickHouseCluster, ClickHouseInstance
 
 import helpers.client
+import pytest
+from helpers.cluster import ClickHouseCluster, ClickHouseInstance
 
 logging.getLogger().setLevel(logging.INFO)
 logging.getLogger().addHandler(logging.StreamHandler())
@@ -292,7 +290,7 @@ def test_s3_glob_scheherazade(cluster):
                     cluster.minio_host, cluster.minio_port, bucket, path, table_format, values)
                 run_query(instance, query)
 
-        jobs.append(threading.Thread(target=add_tales, args=(night, min(night+nights_per_job, 1001))))
+        jobs.append(threading.Thread(target=add_tales, args=(night, min(night + nights_per_job, 1001))))
         jobs[-1].start()
 
     for job in jobs:
@@ -313,9 +311,10 @@ def run_s3_mock(cluster):
 
 
 def test_custom_auth_headers(cluster):
-    ping_response = cluster.exec_in_container(cluster.get_container_id('resolver'), ["curl", "-s", "http://resolver:8080"])
+    ping_response = cluster.exec_in_container(cluster.get_container_id('resolver'),
+                                              ["curl", "-s", "http://resolver:8080"])
     assert ping_response == 'OK', 'Expected "OK", but got "{}"'.format(ping_response)
-    
+
     table_format = "column1 UInt32, column2 UInt32, column3 UInt32"
     filename = "test.csv"
     get_query = "select * from s3('http://resolver:8080/{bucket}/{file}', 'CSV', '{table_format}')".format(
@@ -345,4 +344,3 @@ def test_infinite_redirect(cluster):
         exception_raised = True
     finally:
         assert exception_raised
-

--- a/tests/integration/test_system_merges/test.py
+++ b/tests/integration/test_system_merges/test.py
@@ -1,19 +1,20 @@
-import pytest
 import threading
 import time
+
+import pytest
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 
 node1 = cluster.add_instance('node1',
-            main_configs=['configs/logs_config.xml'],
-            with_zookeeper=True,
-            macros={"shard": 0, "replica": 1} )
+                             main_configs=['configs/logs_config.xml'],
+                             with_zookeeper=True,
+                             macros={"shard": 0, "replica": 1})
 
 node2 = cluster.add_instance('node2',
-            main_configs=['configs/logs_config.xml'],
-            with_zookeeper=True,
-            macros={"shard": 0, "replica": 2} )
+                             main_configs=['configs/logs_config.xml'],
+                             with_zookeeper=True,
+                             macros={"shard": 0, "replica": 2})
 
 
 @pytest.fixture(scope="module")
@@ -29,7 +30,7 @@ def started_cluster():
 
 
 def split_tsv(data):
-    return [ x.split("\t") for x in data.splitlines() ]
+    return [x.split("\t") for x in data.splitlines()]
 
 
 @pytest.mark.parametrize("replicated", [
@@ -62,8 +63,8 @@ def test_merge_simple(started_cluster, replicated):
         node1.query("INSERT INTO {name} VALUES (2)".format(name=name))
         node1.query("INSERT INTO {name} VALUES (3)".format(name=name))
 
-        parts = ["all_{}_{}_0".format(x, x) for x in range(starting_block, starting_block+3)]
-        result_part = "all_{}_{}_1".format(starting_block, starting_block+2)
+        parts = ["all_{}_{}_0".format(x, x) for x in range(starting_block, starting_block + 3)]
+        result_part = "all_{}_{}_1".format(starting_block, starting_block + 2)
 
         def optimize():
             node1.query("OPTIMIZE TABLE {name}".format(name=name))
@@ -84,7 +85,8 @@ def test_merge_simple(started_cluster, replicated):
                 table_name,
                 "3",
                 "['{}','{}','{}']".format(*parts),
-                "['{clickhouse}/{table_path}/{}/','{clickhouse}/{table_path}/{}/','{clickhouse}/{table_path}/{}/']".format(*parts, clickhouse=clickhouse_path, table_path=table_path),
+                "['{clickhouse}/{table_path}/{}/','{clickhouse}/{table_path}/{}/','{clickhouse}/{table_path}/{}/']".format(
+                    *parts, clickhouse=clickhouse_path, table_path=table_path),
                 result_part,
                 "{clickhouse}/{table_path}/{}/".format(result_part, clickhouse=clickhouse_path, table_path=table_path),
                 "all",
@@ -129,7 +131,7 @@ def test_mutation_simple(started_cluster, replicated):
 
         node1.query("INSERT INTO {name} VALUES (1)".format(name=name))
         part = "all_{}_{}_0".format(starting_block, starting_block)
-        result_part = "all_{}_{}_0_{}".format(starting_block, starting_block, starting_block+1)
+        result_part = "all_{}_{}_0_{}".format(starting_block, starting_block, starting_block + 1)
 
         def alter():
             node1.query("ALTER TABLE {name} UPDATE a = 42 WHERE sleep(2) OR 1".format(name=name))

--- a/tests/integration/test_system_queries/test.py
+++ b/tests/integration/test_system_queries/test.py
@@ -1,10 +1,9 @@
 import os
-import os.path as p
 import sys
 import time
-import datetime
-import pytest
 from contextlib import contextmanager
+
+import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from helpers.cluster import ClickHouseCluster
@@ -18,8 +17,10 @@ def started_cluster():
     global instance
     try:
         cluster = ClickHouseCluster(__file__)
-        cluster.add_instance('ch1', main_configs=["configs/config.d/clusters_config.xml", "configs/config.d/query_log.xml"],
-            dictionaries=["configs/dictionaries/dictionary_clickhouse_cache.xml", "configs/dictionaries/dictionary_clickhouse_flat.xml"])
+        cluster.add_instance('ch1',
+                             main_configs=["configs/config.d/clusters_config.xml", "configs/config.d/query_log.xml"],
+                             dictionaries=["configs/dictionaries/dictionary_clickhouse_cache.xml",
+                                           "configs/dictionaries/dictionary_clickhouse_flat.xml"])
         cluster.start()
 
         instance = cluster.instances['ch1']
@@ -39,20 +40,32 @@ def test_SYSTEM_RELOAD_DICTIONARY(started_cluster):
     instance = cluster.instances['ch1']
 
     instance.query("SYSTEM RELOAD DICTIONARIES")
-    assert TSV(instance.query("SELECT dictHas('clickhouse_flat', toUInt64(0)), dictHas('clickhouse_flat', toUInt64(1))")) == TSV("0\t0\n")
+    assert TSV(instance.query(
+        "SELECT dictHas('clickhouse_flat', toUInt64(0)), dictHas('clickhouse_flat', toUInt64(1))")) == TSV("0\t0\n")
 
     instance.query("INSERT INTO dictionary_source VALUES (0, 0)")
-    assert TSV(instance.query("SELECT dictGetUInt8('clickhouse_cache', 'value', toUInt64(0)), dictHas('clickhouse_cache', toUInt64(1))")) == TSV("0\t0\n")
+    assert TSV(instance.query(
+        "SELECT dictGetUInt8('clickhouse_cache', 'value', toUInt64(0)), dictHas('clickhouse_cache', toUInt64(1))")) == TSV(
+        "0\t0\n")
     instance.query("INSERT INTO dictionary_source VALUES (1, 1)")
-    assert TSV(instance.query("SELECT dictGetUInt8('clickhouse_cache', 'value', toUInt64(0)), dictHas('clickhouse_cache', toUInt64(1))")) == TSV("0\t0\n")
+    assert TSV(instance.query(
+        "SELECT dictGetUInt8('clickhouse_cache', 'value', toUInt64(0)), dictHas('clickhouse_cache', toUInt64(1))")) == TSV(
+        "0\t0\n")
 
     instance.query("SYSTEM RELOAD DICTIONARY clickhouse_cache")
-    assert TSV(instance.query("SELECT dictGetUInt8('clickhouse_cache', 'value', toUInt64(0)), dictGetUInt8('clickhouse_cache', 'value', toUInt64(1))")) == TSV("0\t1\n")
-    assert TSV(instance.query("SELECT dictHas('clickhouse_flat', toUInt64(0)), dictHas('clickhouse_flat', toUInt64(1))")) == TSV("0\t0\n")
+    assert TSV(instance.query(
+        "SELECT dictGetUInt8('clickhouse_cache', 'value', toUInt64(0)), dictGetUInt8('clickhouse_cache', 'value', toUInt64(1))")) == TSV(
+        "0\t1\n")
+    assert TSV(instance.query(
+        "SELECT dictHas('clickhouse_flat', toUInt64(0)), dictHas('clickhouse_flat', toUInt64(1))")) == TSV("0\t0\n")
 
     instance.query("SYSTEM RELOAD DICTIONARIES")
-    assert TSV(instance.query("SELECT dictGetUInt8('clickhouse_cache', 'value', toUInt64(0)), dictGetUInt8('clickhouse_cache', 'value', toUInt64(1))")) == TSV("0\t1\n")
-    assert TSV(instance.query("SELECT dictGetUInt8('clickhouse_flat', 'value', toUInt64(0)), dictGetUInt8('clickhouse_flat', 'value', toUInt64(1))")) == TSV("0\t1\n")
+    assert TSV(instance.query(
+        "SELECT dictGetUInt8('clickhouse_cache', 'value', toUInt64(0)), dictGetUInt8('clickhouse_cache', 'value', toUInt64(1))")) == TSV(
+        "0\t1\n")
+    assert TSV(instance.query(
+        "SELECT dictGetUInt8('clickhouse_flat', 'value', toUInt64(0)), dictGetUInt8('clickhouse_flat', 'value', toUInt64(1))")) == TSV(
+        "0\t1\n")
 
 
 def test_DROP_DNS_CACHE(started_cluster):
@@ -61,13 +74,15 @@ def test_DROP_DNS_CACHE(started_cluster):
     instance.exec_in_container(['bash', '-c', 'echo 127.0.0.1 localhost > /etc/hosts'], privileged=True, user='root')
     instance.exec_in_container(['bash', '-c', 'echo ::1 localhost >> /etc/hosts'], privileged=True, user='root')
 
-    instance.exec_in_container(['bash', '-c', 'echo 127.255.255.255 lost_host >> /etc/hosts'], privileged=True, user='root')
+    instance.exec_in_container(['bash', '-c', 'echo 127.255.255.255 lost_host >> /etc/hosts'], privileged=True,
+                               user='root')
     instance.query("SYSTEM DROP DNS CACHE")
 
     with pytest.raises(QueryRuntimeException):
         instance.query("SELECT * FROM remote('lost_host', 'system', 'one')")
 
-    instance.query("CREATE TABLE distributed_lost_host (dummy UInt8) ENGINE = Distributed(lost_host_cluster, 'system', 'one')")
+    instance.query(
+        "CREATE TABLE distributed_lost_host (dummy UInt8) ENGINE = Distributed(lost_host_cluster, 'system', 'one')")
     with pytest.raises(QueryRuntimeException):
         instance.query("SELECT * FROM distributed_lost_host")
 
@@ -79,11 +94,12 @@ def test_DROP_DNS_CACHE(started_cluster):
 
     instance.query("SELECT * FROM remote('lost_host', 'system', 'one')")
     instance.query("SELECT * FROM distributed_lost_host")
-    assert TSV(instance.query("SELECT DISTINCT host_name, host_address FROM system.clusters WHERE cluster='lost_host_cluster'")) == TSV("lost_host\t127.0.0.1\n")
+    assert TSV(instance.query(
+        "SELECT DISTINCT host_name, host_address FROM system.clusters WHERE cluster='lost_host_cluster'")) == TSV(
+        "lost_host\t127.0.0.1\n")
 
 
 def test_RELOAD_CONFIG_AND_MACROS(started_cluster):
-
     macros = "<yandex><macros><mac>ro</mac></macros></yandex>"
     create_macros = 'echo "{}" > /etc/clickhouse-server/config.d/macros.xml'.format(macros)
 
@@ -120,6 +136,6 @@ def test_SYSTEM_FLUSH_LOGS(started_cluster):
 
 if __name__ == '__main__':
     with contextmanager(started_cluster)() as cluster:
-       for name, instance in cluster.instances.items():
-           print name, instance.ip_address
-       raw_input("Cluster created, press any key to destroy...")
+        for name, instance in cluster.instances.items():
+            print name, instance.ip_address
+        raw_input("Cluster created, press any key to destroy...")

--- a/tests/integration/test_text_log_level/test.py
+++ b/tests/integration/test_text_log_level/test.py
@@ -2,13 +2,13 @@
 # pylint: disable=redefined-outer-name
 
 import pytest
-
-from helpers.cluster import ClickHouseCluster
 from helpers.client import QueryRuntimeException
+from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 
 node = cluster.add_instance('node', main_configs=["configs/config.d/text_log.xml"])
+
 
 @pytest.fixture(scope='module')
 def start_cluster():
@@ -18,6 +18,7 @@ def start_cluster():
         yield cluster
     finally:
         cluster.shutdown()
+
 
 def test_basic(start_cluster):
     with pytest.raises(QueryRuntimeException):

--- a/tests/integration/test_timezone_config/test.py
+++ b/tests/integration/test_timezone_config/test.py
@@ -5,6 +5,7 @@ from helpers.cluster import ClickHouseCluster
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance('node', main_configs=['configs/config.xml'])
 
+
 @pytest.fixture(scope="module")
 def start_cluster():
     try:
@@ -12,6 +13,7 @@ def start_cluster():
         yield cluster
     finally:
         cluster.shutdown()
+
 
 def test_check_timezone_config(start_cluster):
     assert node.query("SELECT toDateTime(1111111111)") == "2005-03-17 17:58:31\n"

--- a/tests/integration/test_tmp_policy/test.py
+++ b/tests/integration/test_tmp_policy/test.py
@@ -8,8 +8,9 @@ from helpers.cluster import ClickHouseCluster
 cluster = ClickHouseCluster(__file__)
 
 node = cluster.add_instance('node',
-            main_configs=["configs/config.d/storage_configuration.xml"],
-            tmpfs=['/disk1:size=100M', '/disk2:size=100M'])
+                            main_configs=["configs/config.d/storage_configuration.xml"],
+                            tmpfs=['/disk1:size=100M', '/disk2:size=100M'])
+
 
 @pytest.fixture(scope='module')
 def start_cluster():
@@ -19,11 +20,12 @@ def start_cluster():
     finally:
         cluster.shutdown()
 
+
 def test_different_versions(start_cluster):
     query = 'SELECT count(ignore(*)) FROM (SELECT * FROM system.numbers LIMIT 1e7) GROUP BY number'
     settings = {
-        'max_bytes_before_external_group_by': 1<<20,
-        'max_bytes_before_external_sort':     1<<20,
+        'max_bytes_before_external_group_by': 1 << 20,
+        'max_bytes_before_external_sort': 1 << 20,
     }
 
     assert node.contains_in_log('Setting up /disk1/ to store temporary data in it')

--- a/tests/integration/test_ttl_replicated/test.py
+++ b/tests/integration/test_ttl_replicated/test.py
@@ -1,10 +1,9 @@
 import time
-import pytest
 
 import helpers.client as client
+import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
-
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', with_zookeeper=True)
@@ -35,15 +34,15 @@ def test_ttl_columns(started_cluster):
     drop_table([node1, node2], "test_ttl")
     for node in [node1, node2]:
         node.query(
-        '''
-            CREATE TABLE test_ttl(date DateTime, id UInt32, a Int32 TTL date + INTERVAL 1 DAY, b Int32 TTL date + INTERVAL 1 MONTH)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/test_ttl', '{replica}')
-            ORDER BY id PARTITION BY toDayOfMonth(date) SETTINGS merge_with_ttl_timeout=0;
-        '''.format(replica=node.name))
+            '''
+                CREATE TABLE test_ttl(date DateTime, id UInt32, a Int32 TTL date + INTERVAL 1 DAY, b Int32 TTL date + INTERVAL 1 MONTH)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/test_ttl', '{replica}')
+                ORDER BY id PARTITION BY toDayOfMonth(date) SETTINGS merge_with_ttl_timeout=0;
+            '''.format(replica=node.name))
 
     node1.query("INSERT INTO test_ttl VALUES (toDateTime('2000-10-10 00:00:00'), 1, 1, 3)")
     node1.query("INSERT INTO test_ttl VALUES (toDateTime('2000-10-11 10:00:00'), 2, 2, 4)")
-    time.sleep(1) # sleep to allow use ttl merge selector for second time
+    time.sleep(1)  # sleep to allow use ttl merge selector for second time
     node1.query("OPTIMIZE TABLE test_ttl FINAL")
 
     expected = "1\t0\t0\n2\t0\t0\n"
@@ -56,17 +55,18 @@ def test_merge_with_ttl_timeout(started_cluster):
     drop_table([node1, node2], table)
     for node in [node1, node2]:
         node.query(
-        '''
-            CREATE TABLE {table}(date DateTime, id UInt32, a Int32 TTL date + INTERVAL 1 DAY, b Int32 TTL date + INTERVAL 1 MONTH)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{table}', '{replica}')
-            ORDER BY id PARTITION BY toDayOfMonth(date);
-        '''.format(replica=node.name, table=table))
+            '''
+                CREATE TABLE {table}(date DateTime, id UInt32, a Int32 TTL date + INTERVAL 1 DAY, b Int32 TTL date + INTERVAL 1 MONTH)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/{table}', '{replica}')
+                ORDER BY id PARTITION BY toDayOfMonth(date);
+            '''.format(replica=node.name, table=table))
 
     node1.query("SYSTEM STOP TTL MERGES {table}".format(table=table))
     node2.query("SYSTEM STOP TTL MERGES {table}".format(table=table))
 
     for i in range(1, 4):
-        node1.query("INSERT INTO {table} VALUES (toDateTime('2000-10-{day:02d} 10:00:00'), 1, 2, 3)".format(day=i, table=table))
+        node1.query(
+            "INSERT INTO {table} VALUES (toDateTime('2000-10-{day:02d} 10:00:00'), 1, 2, 3)".format(day=i, table=table))
 
     assert node1.query("SELECT countIf(a = 0) FROM {table}".format(table=table)) == "0\n"
     assert node2.query("SELECT countIf(a = 0) FROM {table}".format(table=table)) == "0\n"
@@ -74,12 +74,13 @@ def test_merge_with_ttl_timeout(started_cluster):
     node1.query("SYSTEM START TTL MERGES {table}".format(table=table))
     node2.query("SYSTEM START TTL MERGES {table}".format(table=table))
 
-    time.sleep(15) # TTL merges shall happen.
+    time.sleep(15)  # TTL merges shall happen.
 
     for i in range(1, 4):
-        node1.query("INSERT INTO {table} VALUES (toDateTime('2000-10-{day:02d} 10:00:00'), 1, 2, 3)".format(day=i, table=table))
+        node1.query(
+            "INSERT INTO {table} VALUES (toDateTime('2000-10-{day:02d} 10:00:00'), 1, 2, 3)".format(day=i, table=table))
 
-    time.sleep(15) # TTL merges shall not happen.
+    time.sleep(15)  # TTL merges shall not happen.
 
     assert node1.query("SELECT countIf(a = 0) FROM {table}".format(table=table)) == "3\n"
     assert node2.query("SELECT countIf(a = 0) FROM {table}".format(table=table)) == "3\n"
@@ -89,15 +90,15 @@ def test_ttl_many_columns(started_cluster):
     drop_table([node1, node2], "test_ttl_2")
     for node in [node1, node2]:
         node.query(
-        '''
-            CREATE TABLE test_ttl_2(date DateTime, id UInt32,
-                a Int32 TTL date,
-                _idx Int32 TTL date,
-                _offset Int32 TTL date,
-                _partition Int32 TTL date)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/test_ttl_2', '{replica}')
-            ORDER BY id PARTITION BY toDayOfMonth(date) SETTINGS merge_with_ttl_timeout=0;
-        '''.format(replica=node.name))
+            '''
+                CREATE TABLE test_ttl_2(date DateTime, id UInt32,
+                    a Int32 TTL date,
+                    _idx Int32 TTL date,
+                    _offset Int32 TTL date,
+                    _partition Int32 TTL date)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/test_ttl_2', '{replica}')
+                ORDER BY id PARTITION BY toDayOfMonth(date) SETTINGS merge_with_ttl_timeout=0;
+            '''.format(replica=node.name))
 
     node1.query("SYSTEM STOP TTL MERGES test_ttl_2")
     node2.query("SYSTEM STOP TTL MERGES test_ttl_2")
@@ -114,7 +115,7 @@ def test_ttl_many_columns(started_cluster):
     node1.query("SYSTEM START TTL MERGES test_ttl_2")
     node2.query("SYSTEM START TTL MERGES test_ttl_2")
 
-    time.sleep(1) # sleep to allow use ttl merge selector for second time
+    time.sleep(1)  # sleep to allow use ttl merge selector for second time
     node1.query("OPTIMIZE TABLE test_ttl_2 FINAL", timeout=5)
 
     node2.query("SYSTEM SYNC REPLICA test_ttl_2", timeout=5)
@@ -132,32 +133,34 @@ def test_ttl_table(started_cluster, delete_suffix):
     drop_table([node1, node2], "test_ttl")
     for node in [node1, node2]:
         node.query(
-        '''
-            CREATE TABLE test_ttl(date DateTime, id UInt32)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/test_ttl', '{replica}')
-            ORDER BY id PARTITION BY toDayOfMonth(date)
-            TTL date + INTERVAL 1 DAY {delete_suffix} SETTINGS merge_with_ttl_timeout=0;
-        '''.format(replica=node.name, delete_suffix=delete_suffix))
+            '''
+                CREATE TABLE test_ttl(date DateTime, id UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/test_ttl', '{replica}')
+                ORDER BY id PARTITION BY toDayOfMonth(date)
+                TTL date + INTERVAL 1 DAY {delete_suffix} SETTINGS merge_with_ttl_timeout=0;
+            '''.format(replica=node.name, delete_suffix=delete_suffix))
 
     node1.query("INSERT INTO test_ttl VALUES (toDateTime('2000-10-10 00:00:00'), 1)")
     node1.query("INSERT INTO test_ttl VALUES (toDateTime('2000-10-11 10:00:00'), 2)")
-    time.sleep(1) # sleep to allow use ttl merge selector for second time
+    time.sleep(1)  # sleep to allow use ttl merge selector for second time
     node1.query("OPTIMIZE TABLE test_ttl FINAL")
 
     assert TSV(node1.query("SELECT * FROM test_ttl")) == TSV("")
     assert TSV(node2.query("SELECT * FROM test_ttl")) == TSV("")
 
+
 def test_modify_ttl(started_cluster):
     drop_table([node1, node2], "test_ttl")
     for node in [node1, node2]:
         node.query(
-        '''
-            CREATE TABLE test_ttl(d DateTime, id UInt32)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/test_ttl', '{replica}')
-            ORDER BY id
-        '''.format(replica=node.name))
+            '''
+                CREATE TABLE test_ttl(d DateTime, id UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/test_ttl', '{replica}')
+                ORDER BY id
+            '''.format(replica=node.name))
 
-    node1.query("INSERT INTO test_ttl VALUES (now() - INTERVAL 5 HOUR, 1), (now() - INTERVAL 3 HOUR, 2), (now() - INTERVAL 1 HOUR, 3)")
+    node1.query(
+        "INSERT INTO test_ttl VALUES (now() - INTERVAL 5 HOUR, 1), (now() - INTERVAL 3 HOUR, 2), (now() - INTERVAL 1 HOUR, 3)")
     node2.query("SYSTEM SYNC REPLICA test_ttl", timeout=20)
 
     node1.query("ALTER TABLE test_ttl MODIFY TTL d + INTERVAL 4 HOUR SETTINGS mutations_sync = 2")
@@ -169,17 +172,19 @@ def test_modify_ttl(started_cluster):
     node1.query("ALTER TABLE test_ttl MODIFY TTL d + INTERVAL 30 MINUTE SETTINGS mutations_sync = 2")
     assert node2.query("SELECT id FROM test_ttl") == ""
 
+
 def test_modify_column_ttl(started_cluster):
     drop_table([node1, node2], "test_ttl")
     for node in [node1, node2]:
         node.query(
-        '''
-            CREATE TABLE test_ttl(d DateTime, id UInt32 DEFAULT 42)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/test_ttl', '{replica}')
-            ORDER BY d
-        '''.format(replica=node.name))
+            '''
+                CREATE TABLE test_ttl(d DateTime, id UInt32 DEFAULT 42)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/test_ttl', '{replica}')
+                ORDER BY d
+            '''.format(replica=node.name))
 
-    node1.query("INSERT INTO test_ttl VALUES (now() - INTERVAL 5 HOUR, 1), (now() - INTERVAL 3 HOUR, 2), (now() - INTERVAL 1 HOUR, 3)")
+    node1.query(
+        "INSERT INTO test_ttl VALUES (now() - INTERVAL 5 HOUR, 1), (now() - INTERVAL 3 HOUR, 2), (now() - INTERVAL 1 HOUR, 3)")
     node2.query("SYSTEM SYNC REPLICA test_ttl", timeout=20)
 
     node1.query("ALTER TABLE test_ttl MODIFY COLUMN id UInt32 TTL d + INTERVAL 4 HOUR SETTINGS mutations_sync = 2")
@@ -190,6 +195,7 @@ def test_modify_column_ttl(started_cluster):
 
     node1.query("ALTER TABLE test_ttl MODIFY COLUMN id UInt32 TTL d + INTERVAL 30 MINUTE SETTINGS mutations_sync = 2")
     assert node2.query("SELECT id FROM test_ttl") == "42\n42\n42\n"
+
 
 def test_ttl_double_delete_rule_returns_error(started_cluster):
     drop_table([node1, node2], "test_ttl")
@@ -205,6 +211,7 @@ def test_ttl_double_delete_rule_returns_error(started_cluster):
         pass
     except:
         assert False
+
 
 @pytest.mark.parametrize("name,engine", [
     ("test_ttl_alter_delete", "MergeTree()"),
@@ -238,21 +245,24 @@ limitations under the License."""
                 break
             except:
                 time.sleep(0.5)
+
     node1.query(
-    """
-        CREATE TABLE {name} (
-            s1 String,
-            d1 DateTime
-        ) ENGINE = {engine}
-        ORDER BY tuple()
-        TTL d1 + INTERVAL 1 DAY DELETE
-    """.format(name=name, engine=engine))
+        """
+            CREATE TABLE {name} (
+                s1 String,
+                d1 DateTime
+            ) ENGINE = {engine}
+            ORDER BY tuple()
+            TTL d1 + INTERVAL 1 DAY DELETE
+        """.format(name=name, engine=engine))
 
     node1.query("""ALTER TABLE {name} MODIFY COLUMN s1 String TTL d1 + INTERVAL 1 SECOND""".format(name=name))
     node1.query("""ALTER TABLE {name} ADD COLUMN b1 Int32""".format(name=name))
 
-    node1.query("""INSERT INTO {name} (s1, b1, d1) VALUES ('hello1', 1, toDateTime({time}))""".format(name=name, time=time.time()))
-    node1.query("""INSERT INTO {name} (s1, b1, d1) VALUES ('hello2', 2, toDateTime({time}))""".format(name=name, time=time.time() + 360))
+    node1.query("""INSERT INTO {name} (s1, b1, d1) VALUES ('hello1', 1, toDateTime({time}))""".format(name=name,
+                                                                                                      time=time.time()))
+    node1.query("""INSERT INTO {name} (s1, b1, d1) VALUES ('hello2', 2, toDateTime({time}))""".format(name=name,
+                                                                                                      time=time.time() + 360))
 
     time.sleep(1)
 
@@ -261,7 +271,8 @@ limitations under the License."""
     assert r == ["\t1", "hello2\t2"]
 
     node1.query("""ALTER TABLE {name} MODIFY COLUMN b1 Int32 TTL d1""".format(name=name))
-    node1.query("""INSERT INTO {name} (s1, b1, d1) VALUES ('hello3', 3, toDateTime({time}))""".format(name=name, time=time.time()))
+    node1.query("""INSERT INTO {name} (s1, b1, d1) VALUES ('hello3', 3, toDateTime({time}))""".format(name=name,
+                                                                                                      time=time.time()))
 
     time.sleep(1)
 

--- a/tests/integration/test_union_header/test.py
+++ b/tests/integration/test_union_header/test.py
@@ -14,7 +14,6 @@ def started_cluster():
         cluster.start()
 
         for node in (node1, node2):
-
             node.query('''
             CREATE TABLE default.t1_local
             (

--- a/tests/integration/test_user_directories/test.py
+++ b/tests/integration/test_user_directories/test.py
@@ -1,11 +1,13 @@
-import pytest
 import os
+
+import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance('node', stay_alive=True)
+
 
 @pytest.fixture(scope="module", autouse=True)
 def started_cluster():
@@ -22,42 +24,56 @@ def started_cluster():
 
 
 def test_old_style():
-    node.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/old_style.xml"), '/etc/clickhouse-server/config.d/z.xml')
+    node.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/old_style.xml"),
+                                '/etc/clickhouse-server/config.d/z.xml')
     node.restart_clickhouse()
-    assert node.query("SELECT * FROM system.user_directories") == TSV([["users.xml",       "users.xml",       '{"path":"\\\\/etc\\\\/clickhouse-server\\\\/users2.xml"}',    1],
-                                                                       ["local directory", "local directory", '{"path":"\\\\/var\\\\/lib\\\\/clickhouse\\\\/access2\\\\/"}', 2]])
+    assert node.query("SELECT * FROM system.user_directories") == TSV(
+        [["users.xml", "users.xml", '{"path":"\\\\/etc\\\\/clickhouse-server\\\\/users2.xml"}', 1],
+         ["local directory", "local directory", '{"path":"\\\\/var\\\\/lib\\\\/clickhouse\\\\/access2\\\\/"}', 2]])
 
 
 def test_local_directories():
-    node.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/local_directories.xml"), '/etc/clickhouse-server/config.d/z.xml')
+    node.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/local_directories.xml"),
+                                '/etc/clickhouse-server/config.d/z.xml')
     node.restart_clickhouse()
-    assert node.query("SELECT * FROM system.user_directories") == TSV([["users.xml",            "users.xml",       '{"path":"\\\\/etc\\\\/clickhouse-server\\\\/users3.xml"}',                       1],
-                                                                       ["local directory",      "local directory", '{"path":"\\\\/var\\\\/lib\\\\/clickhouse\\\\/access3\\\\/"}',                    2],
-                                                                       ["local directory (ro)", "local directory", '{"path":"\\\\/var\\\\/lib\\\\/clickhouse\\\\/access3-ro\\\\/","readonly":true}', 3]])
+    assert node.query("SELECT * FROM system.user_directories") == TSV(
+        [["users.xml", "users.xml", '{"path":"\\\\/etc\\\\/clickhouse-server\\\\/users3.xml"}', 1],
+         ["local directory", "local directory", '{"path":"\\\\/var\\\\/lib\\\\/clickhouse\\\\/access3\\\\/"}', 2],
+         ["local directory (ro)", "local directory",
+          '{"path":"\\\\/var\\\\/lib\\\\/clickhouse\\\\/access3-ro\\\\/","readonly":true}', 3]])
 
 
 def test_relative_path():
-    node.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/relative_path.xml"), '/etc/clickhouse-server/config.d/z.xml')
+    node.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/relative_path.xml"),
+                                '/etc/clickhouse-server/config.d/z.xml')
     node.restart_clickhouse()
-    assert node.query("SELECT * FROM system.user_directories") == TSV([["users.xml", "users.xml", '{"path":"\\\\/etc\\\\/clickhouse-server\\\\/users4.xml"}', 1]])
+    assert node.query("SELECT * FROM system.user_directories") == TSV(
+        [["users.xml", "users.xml", '{"path":"\\\\/etc\\\\/clickhouse-server\\\\/users4.xml"}', 1]])
 
 
 def test_memory():
     node.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/memory.xml"), '/etc/clickhouse-server/config.d/z.xml')
     node.restart_clickhouse()
-    assert node.query("SELECT * FROM system.user_directories") == TSV([["users.xml", "users.xml", '{"path":"\\\\/etc\\\\/clickhouse-server\\\\/users5.xml"}', 1],
-                                                                       ["memory",    "memory",    '{}',                                                       2]])
+    assert node.query("SELECT * FROM system.user_directories") == TSV(
+        [["users.xml", "users.xml", '{"path":"\\\\/etc\\\\/clickhouse-server\\\\/users5.xml"}', 1],
+         ["memory", "memory", '{}', 2]])
+
 
 def test_mixed_style():
-    node.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/mixed_style.xml"), '/etc/clickhouse-server/config.d/z.xml')
+    node.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/mixed_style.xml"),
+                                '/etc/clickhouse-server/config.d/z.xml')
     node.restart_clickhouse()
-    assert node.query("SELECT * FROM system.user_directories") == TSV([["users.xml",       "users.xml",       '{"path":"\\\\/etc\\\\/clickhouse-server\\\\/users6.xml"}',     1],
-                                                                       ["local directory", "local directory", '{"path":"\\\\/var\\\\/lib\\\\/clickhouse\\\\/access6\\\\/"}',  2],
-                                                                       ["local directory", "local directory", '{"path":"\\\\/var\\\\/lib\\\\/clickhouse\\\\/access6a\\\\/"}', 3],
-                                                                       ["memory",          "memory",          '{}',                                                           4]])
+    assert node.query("SELECT * FROM system.user_directories") == TSV(
+        [["users.xml", "users.xml", '{"path":"\\\\/etc\\\\/clickhouse-server\\\\/users6.xml"}', 1],
+         ["local directory", "local directory", '{"path":"\\\\/var\\\\/lib\\\\/clickhouse\\\\/access6\\\\/"}', 2],
+         ["local directory", "local directory", '{"path":"\\\\/var\\\\/lib\\\\/clickhouse\\\\/access6a\\\\/"}', 3],
+         ["memory", "memory", '{}', 4]])
+
 
 def test_duplicates():
-    node.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/duplicates.xml"), '/etc/clickhouse-server/config.d/z.xml')
+    node.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/duplicates.xml"),
+                                '/etc/clickhouse-server/config.d/z.xml')
     node.restart_clickhouse()
-    assert node.query("SELECT * FROM system.user_directories") == TSV([["users.xml",       "users.xml",       '{"path":"\\\\/etc\\\\/clickhouse-server\\\\/users7.xml"}',    1],
-                                                                       ["local directory", "local directory", '{"path":"\\\\/var\\\\/lib\\\\/clickhouse\\\\/access7\\\\/"}', 2]])
+    assert node.query("SELECT * FROM system.user_directories") == TSV(
+        [["users.xml", "users.xml", '{"path":"\\\\/etc\\\\/clickhouse-server\\\\/users7.xml"}', 1],
+         ["local directory", "local directory", '{"path":"\\\\/var\\\\/lib\\\\/clickhouse\\\\/access7\\\\/"}', 2]])

--- a/tests/integration/test_user_ip_restrictions/test.py
+++ b/tests/integration/test_user_ip_restrictions/test.py
@@ -1,22 +1,26 @@
-import time
 import pytest
 
 from helpers.cluster import ClickHouseCluster
 
-from helpers.test_tools import assert_eq_with_retry
-
 cluster = ClickHouseCluster(__file__)
 
-node_ipv4 = cluster.add_instance('node_ipv4', main_configs=[], user_configs=['configs/users_ipv4.xml'], ipv4_address='10.5.172.77')
+node_ipv4 = cluster.add_instance('node_ipv4', main_configs=[], user_configs=['configs/users_ipv4.xml'],
+                                 ipv4_address='10.5.172.77')
 client_ipv4_ok = cluster.add_instance('client_ipv4_ok', main_configs=[], user_configs=[], ipv4_address='10.5.172.10')
-client_ipv4_ok_direct = cluster.add_instance('client_ipv4_ok_direct', main_configs=[], user_configs=[], ipv4_address='10.5.173.1')
-client_ipv4_ok_full_mask = cluster.add_instance('client_ipv4_ok_full_mask', main_configs=[], user_configs=[], ipv4_address='10.5.175.77')
+client_ipv4_ok_direct = cluster.add_instance('client_ipv4_ok_direct', main_configs=[], user_configs=[],
+                                             ipv4_address='10.5.173.1')
+client_ipv4_ok_full_mask = cluster.add_instance('client_ipv4_ok_full_mask', main_configs=[], user_configs=[],
+                                                ipv4_address='10.5.175.77')
 client_ipv4_bad = cluster.add_instance('client_ipv4_bad', main_configs=[], user_configs=[], ipv4_address='10.5.173.10')
 
-node_ipv6 = cluster.add_instance('node_ipv6', main_configs=["configs/config_ipv6.xml"], user_configs=['configs/users_ipv6.xml'], ipv6_address='2001:3984:3989::1:1000')
-client_ipv6_ok = cluster.add_instance('client_ipv6_ok', main_configs=[], user_configs=[], ipv6_address='2001:3984:3989::5555')
-client_ipv6_ok_direct = cluster.add_instance('client_ipv6_ok_direct', main_configs=[], user_configs=[], ipv6_address='2001:3984:3989::1:1111')
-client_ipv6_bad = cluster.add_instance('client_ipv6_bad', main_configs=[], user_configs=[], ipv6_address='2001:3984:3989::1:1112')
+node_ipv6 = cluster.add_instance('node_ipv6', main_configs=["configs/config_ipv6.xml"],
+                                 user_configs=['configs/users_ipv6.xml'], ipv6_address='2001:3984:3989::1:1000')
+client_ipv6_ok = cluster.add_instance('client_ipv6_ok', main_configs=[], user_configs=[],
+                                      ipv6_address='2001:3984:3989::5555')
+client_ipv6_ok_direct = cluster.add_instance('client_ipv6_ok_direct', main_configs=[], user_configs=[],
+                                             ipv6_address='2001:3984:3989::1:1111')
+client_ipv6_bad = cluster.add_instance('client_ipv6_bad', main_configs=[], user_configs=[],
+                                       ipv6_address='2001:3984:3989::1:1112')
 
 
 @pytest.fixture(scope="module")
@@ -31,42 +35,57 @@ def setup_cluster():
 
 def test_ipv4(setup_cluster):
     try:
-        client_ipv4_ok.exec_in_container(["bash", "-c", "/usr/bin/clickhouse client --host 10.5.172.77 --query 'select 1'"], privileged=True, user='root')
+        client_ipv4_ok.exec_in_container(
+            ["bash", "-c", "/usr/bin/clickhouse client --host 10.5.172.77 --query 'select 1'"], privileged=True,
+            user='root')
     except Exception as ex:
         assert False, "allowed client with 10.5.172.10 cannot connect to server with allowed mask '10.5.172.0/24'"
 
     try:
-        client_ipv4_ok_direct.exec_in_container(["bash", "-c", "/usr/bin/clickhouse client --host 10.5.172.77 --query 'select 1'"], privileged=True, user='root')
+        client_ipv4_ok_direct.exec_in_container(
+            ["bash", "-c", "/usr/bin/clickhouse client --host 10.5.172.77 --query 'select 1'"], privileged=True,
+            user='root')
     except Exception as ex:
         assert False, "allowed client with 10.5.173.1 cannot connect to server with allowed ip '10.5.173.1'"
 
     try:
-        client_ipv4_ok_full_mask.exec_in_container(["bash", "-c", "/usr/bin/clickhouse client --host 10.5.172.77 --query 'select 1'"], privileged=True, user='root')
+        client_ipv4_ok_full_mask.exec_in_container(
+            ["bash", "-c", "/usr/bin/clickhouse client --host 10.5.172.77 --query 'select 1'"], privileged=True,
+            user='root')
     except Exception as ex:
         assert False, "allowed client with 10.5.175.77 cannot connect to server with allowed ip '10.5.175.0/255.255.255.0'"
 
     try:
-        client_ipv4_bad.exec_in_container(["bash", "-c", "/usr/bin/clickhouse client --host 10.5.172.77 --query 'select 1'"], privileged=True, user='root')
+        client_ipv4_bad.exec_in_container(
+            ["bash", "-c", "/usr/bin/clickhouse client --host 10.5.172.77 --query 'select 1'"], privileged=True,
+            user='root')
         assert False, "restricted client with 10.5.173.10 can connect to server with allowed mask '10.5.172.0/24'"
     except AssertionError:
         raise
     except Exception as ex:
         print ex
 
+
 def test_ipv6(setup_cluster):
     try:
-        client_ipv6_ok.exec_in_container(["bash", "-c", "/usr/bin/clickhouse client --host 2001:3984:3989::1:1000 --query 'select 1'"], privileged=True, user='root')
+        client_ipv6_ok.exec_in_container(
+            ["bash", "-c", "/usr/bin/clickhouse client --host 2001:3984:3989::1:1000 --query 'select 1'"],
+            privileged=True, user='root')
     except Exception as ex:
         print ex
         assert False, "allowed client with 2001:3984:3989:0:0:0:1:1111 cannot connect to server with allowed mask '2001:3984:3989:0:0:0:0:0/112'"
 
     try:
-        client_ipv6_ok_direct.exec_in_container(["bash", "-c", "/usr/bin/clickhouse client --host 2001:3984:3989:0:0:0:1:1000 --query 'select 1'"], privileged=True, user='root')
+        client_ipv6_ok_direct.exec_in_container(
+            ["bash", "-c", "/usr/bin/clickhouse client --host 2001:3984:3989:0:0:0:1:1000 --query 'select 1'"],
+            privileged=True, user='root')
     except Exception as ex:
         assert False, "allowed client with 2001:3984:3989:0:0:0:1:1111 cannot connect to server with allowed ip '2001:3984:3989:0:0:0:1:1111'"
 
     try:
-        client_ipv6_bad.exec_in_container(["bash", "-c", "/usr/bin/clickhouse client --host 2001:3984:3989:0:0:0:1:1000 --query 'select 1'"], privileged=True, user='root')
+        client_ipv6_bad.exec_in_container(
+            ["bash", "-c", "/usr/bin/clickhouse client --host 2001:3984:3989:0:0:0:1:1000 --query 'select 1'"],
+            privileged=True, user='root')
         assert False, "restricted client with 2001:3984:3989:0:0:0:1:1112 can connect to server with allowed mask '2001:3984:3989:0:0:0:0:0/112'"
     except AssertionError:
         raise

--- a/tests/integration/test_user_zero_database_access/test_user_zero_database_access.py
+++ b/tests/integration/test_user_zero_database_access/test_user_zero_database_access.py
@@ -1,8 +1,6 @@
-import time
 import pytest
 
 from helpers.cluster import ClickHouseCluster
-
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance('node', user_configs=["configs/users.xml"])
@@ -20,7 +18,8 @@ def start_cluster():
 
 def test_user_zero_database_access(start_cluster):
     try:
-        node.exec_in_container(["bash", "-c", "/usr/bin/clickhouse client --user 'no_access' --query 'DROP DATABASE test'"], user='root')
+        node.exec_in_container(
+            ["bash", "-c", "/usr/bin/clickhouse client --user 'no_access' --query 'DROP DATABASE test'"], user='root')
         assert False, "user with no access rights dropped database test"
     except AssertionError:
         raise
@@ -28,17 +27,22 @@ def test_user_zero_database_access(start_cluster):
         print ex
 
     try:
-        node.exec_in_container(["bash", "-c", "/usr/bin/clickhouse client --user 'has_access' --query 'DROP DATABASE test'"], user='root')
+        node.exec_in_container(
+            ["bash", "-c", "/usr/bin/clickhouse client --user 'has_access' --query 'DROP DATABASE test'"], user='root')
     except Exception as ex:
         assert False, "user with access rights can't drop database test"
 
     try:
-        node.exec_in_container(["bash", "-c", "/usr/bin/clickhouse client --user 'has_access' --query 'CREATE DATABASE test'"], user='root')
+        node.exec_in_container(
+            ["bash", "-c", "/usr/bin/clickhouse client --user 'has_access' --query 'CREATE DATABASE test'"],
+            user='root')
     except Exception as ex:
         assert False, "user with access rights can't create database test"
 
     try:
-        node.exec_in_container(["bash", "-c", "/usr/bin/clickhouse client --user 'no_access' --query 'CREATE DATABASE test2'"], user='root')
+        node.exec_in_container(
+            ["bash", "-c", "/usr/bin/clickhouse client --user 'no_access' --query 'CREATE DATABASE test2'"],
+            user='root')
         assert False, "user with no access rights created database test2"
     except AssertionError:
         raise
@@ -46,7 +50,9 @@ def test_user_zero_database_access(start_cluster):
         print ex
 
     try:
-        node.exec_in_container(["bash", "-c", "/usr/bin/clickhouse client --user 'has_access' --query 'CREATE DATABASE test2'"], user='root')
+        node.exec_in_container(
+            ["bash", "-c", "/usr/bin/clickhouse client --user 'has_access' --query 'CREATE DATABASE test2'"],
+            user='root')
         assert False, "user with limited access rights created database test2 which is outside of his scope of rights"
     except AssertionError:
         raise
@@ -54,11 +60,13 @@ def test_user_zero_database_access(start_cluster):
         print ex
 
     try:
-        node.exec_in_container(["bash", "-c", "/usr/bin/clickhouse client --user 'default' --query 'CREATE DATABASE test2'"], user='root')
+        node.exec_in_container(
+            ["bash", "-c", "/usr/bin/clickhouse client --user 'default' --query 'CREATE DATABASE test2'"], user='root')
     except Exception as ex:
         assert False, "user with full access rights can't create database test2"
 
     try:
-        node.exec_in_container(["bash", "-c", "/usr/bin/clickhouse client --user 'default' --query 'DROP DATABASE test2'"], user='root')
+        node.exec_in_container(
+            ["bash", "-c", "/usr/bin/clickhouse client --user 'default' --query 'DROP DATABASE test2'"], user='root')
     except Exception as ex:
         assert False, "user with full access rights can't drop database test2"

--- a/tests/integration/test_version_update_after_mutation/test.py
+++ b/tests/integration/test_version_update_after_mutation/test.py
@@ -5,9 +5,13 @@ from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 
-node1 = cluster.add_instance('node1', with_zookeeper=True, image='yandex/clickhouse-server', tag='20.1.10.70', with_installed_binary=True, stay_alive=True)
-node2 = cluster.add_instance('node2', with_zookeeper=True, image='yandex/clickhouse-server', tag='20.1.10.70', with_installed_binary=True, stay_alive=True)
-node3 = cluster.add_instance('node3', with_zookeeper=True, image='yandex/clickhouse-server', tag='20.1.10.70', with_installed_binary=True, stay_alive=True)
+node1 = cluster.add_instance('node1', with_zookeeper=True, image='yandex/clickhouse-server', tag='20.1.10.70',
+                             with_installed_binary=True, stay_alive=True)
+node2 = cluster.add_instance('node2', with_zookeeper=True, image='yandex/clickhouse-server', tag='20.1.10.70',
+                             with_installed_binary=True, stay_alive=True)
+node3 = cluster.add_instance('node3', with_zookeeper=True, image='yandex/clickhouse-server', tag='20.1.10.70',
+                             with_installed_binary=True, stay_alive=True)
+
 
 @pytest.fixture(scope="module")
 def start_cluster():
@@ -21,7 +25,9 @@ def start_cluster():
 
 def test_mutate_and_upgrade(start_cluster):
     for node in [node1, node2]:
-        node.query("CREATE TABLE mt (EventDate Date, id UInt64) ENGINE ReplicatedMergeTree('/clickhouse/tables/t', '{}') ORDER BY tuple()".format(node.name))
+        node.query(
+            "CREATE TABLE mt (EventDate Date, id UInt64) ENGINE ReplicatedMergeTree('/clickhouse/tables/t', '{}') ORDER BY tuple()".format(
+                node.name))
 
     node1.query("INSERT INTO mt VALUES ('2020-02-13', 1), ('2020-02-13', 2);")
 
@@ -52,7 +58,8 @@ def test_mutate_and_upgrade(start_cluster):
     assert node1.query("SELECT COUNT() FROM mt") == "2\n"
     assert node2.query("SELECT COUNT() FROM mt") == "2\n"
 
-    node1.query("ALTER TABLE mt MODIFY COLUMN id String DEFAULT '0'", settings={"replication_alter_partitions_sync": "2"})
+    node1.query("ALTER TABLE mt MODIFY COLUMN id String DEFAULT '0'",
+                settings={"replication_alter_partitions_sync": "2"})
 
     node2.query("OPTIMIZE TABLE mt FINAL")
 
@@ -61,7 +68,8 @@ def test_mutate_and_upgrade(start_cluster):
 
 
 def test_upgrade_while_mutation(start_cluster):
-    node3.query("CREATE TABLE mt1 (EventDate Date, id UInt64) ENGINE ReplicatedMergeTree('/clickhouse/tables/t1', 'node3') ORDER BY tuple()")
+    node3.query(
+        "CREATE TABLE mt1 (EventDate Date, id UInt64) ENGINE ReplicatedMergeTree('/clickhouse/tables/t1', 'node3') ORDER BY tuple()")
 
     node3.query("INSERT INTO mt1 select '2020-02-13', number from numbers(100000)")
 

--- a/tests/integration/test_zookeeper_config/test.py
+++ b/tests/integration/test_zookeeper_config/test.py
@@ -1,24 +1,30 @@
 from __future__ import print_function
-from helpers.cluster import ClickHouseCluster
+
+import time
+from os import path as p, unlink
+from tempfile import NamedTemporaryFile
+
 import helpers
 import pytest
-import time
-from tempfile import NamedTemporaryFile
-from os import path as p, unlink
+from helpers.cluster import ClickHouseCluster
 
 
 def test_chroot_with_same_root():
-
     cluster_1 = ClickHouseCluster(__file__, zookeeper_config_path='configs/zookeeper_config_root_a.xml')
     cluster_2 = ClickHouseCluster(__file__, zookeeper_config_path='configs/zookeeper_config_root_a.xml')
 
-    node1 = cluster_1.add_instance('node1', main_configs=["configs/remote_servers.xml", "configs/zookeeper_config_root_a.xml"], with_zookeeper=True, zookeeper_use_tmpfs=False)
-    node2 = cluster_2.add_instance('node2', main_configs=["configs/remote_servers.xml", "configs/zookeeper_config_root_a.xml"], with_zookeeper=True, zookeeper_use_tmpfs=False)
+    node1 = cluster_1.add_instance('node1',
+                                   main_configs=["configs/remote_servers.xml", "configs/zookeeper_config_root_a.xml"],
+                                   with_zookeeper=True, zookeeper_use_tmpfs=False)
+    node2 = cluster_2.add_instance('node2',
+                                   main_configs=["configs/remote_servers.xml", "configs/zookeeper_config_root_a.xml"],
+                                   with_zookeeper=True, zookeeper_use_tmpfs=False)
     nodes = [node1, node2]
 
     def create_zk_root(zk):
         zk.ensure_path('/root_a')
         print(zk.get_children('/'))
+
     cluster_1.add_zookeeper_startup_command(create_zk_root)
 
     try:
@@ -31,7 +37,7 @@ def test_chroot_with_same_root():
                 CREATE TABLE simple (date Date, id UInt32)
                 ENGINE = ReplicatedMergeTree('/clickhouse/tables/0/simple', '{replica}', date, id, 8192);
                 '''.format(replica=node.name))
-                for j in range(2): # Second insert to test deduplication
+                for j in range(2):  # Second insert to test deduplication
                     node.query("INSERT INTO simple VALUES ({0}, {0})".format(i))
 
             time.sleep(1)
@@ -47,18 +53,22 @@ def test_chroot_with_same_root():
 
 
 def test_chroot_with_different_root():
-
     cluster_1 = ClickHouseCluster(__file__, zookeeper_config_path='configs/zookeeper_config_root_a.xml')
     cluster_2 = ClickHouseCluster(__file__, zookeeper_config_path='configs/zookeeper_config_root_b.xml')
 
-    node1 = cluster_1.add_instance('node1', main_configs=["configs/remote_servers.xml", "configs/zookeeper_config_root_a.xml"], with_zookeeper=True, zookeeper_use_tmpfs=False)
-    node2 = cluster_2.add_instance('node2', main_configs=["configs/remote_servers.xml", "configs/zookeeper_config_root_b.xml"], with_zookeeper=True, zookeeper_use_tmpfs=False)
+    node1 = cluster_1.add_instance('node1',
+                                   main_configs=["configs/remote_servers.xml", "configs/zookeeper_config_root_a.xml"],
+                                   with_zookeeper=True, zookeeper_use_tmpfs=False)
+    node2 = cluster_2.add_instance('node2',
+                                   main_configs=["configs/remote_servers.xml", "configs/zookeeper_config_root_b.xml"],
+                                   with_zookeeper=True, zookeeper_use_tmpfs=False)
     nodes = [node1, node2]
 
     def create_zk_roots(zk):
         zk.ensure_path('/root_a')
         zk.ensure_path('/root_b')
         print(zk.get_children('/'))
+
     cluster_1.add_zookeeper_startup_command(create_zk_roots)
 
     try:
@@ -72,7 +82,7 @@ def test_chroot_with_different_root():
                 CREATE TABLE simple (date Date, id UInt32)
                 ENGINE = ReplicatedMergeTree('/clickhouse/tables/0/simple', '{replica}', date, id, 8192);
                 '''.format(replica=node.name))
-                for j in range(2): # Second insert to test deduplication
+                for j in range(2):  # Second insert to test deduplication
                     node.query("INSERT INTO simple VALUES ({0}, {0})".format(i))
 
             assert node1.query('select count() from simple').strip() == '1'
@@ -86,12 +96,14 @@ def test_chroot_with_different_root():
 
 
 def test_identity():
-
     cluster_1 = ClickHouseCluster(__file__, zookeeper_config_path='configs/zookeeper_config_with_password.xml')
     cluster_2 = ClickHouseCluster(__file__)
 
-    node1 = cluster_1.add_instance('node1', main_configs=["configs/remote_servers.xml", "configs/zookeeper_config_with_password.xml"], with_zookeeper=True, zookeeper_use_tmpfs=False)
-    node2 = cluster_2.add_instance('node2', main_configs=["configs/remote_servers.xml"], with_zookeeper=True, zookeeper_use_tmpfs=False)
+    node1 = cluster_1.add_instance('node1', main_configs=["configs/remote_servers.xml",
+                                                          "configs/zookeeper_config_with_password.xml"],
+                                   with_zookeeper=True, zookeeper_use_tmpfs=False)
+    node2 = cluster_2.add_instance('node2', main_configs=["configs/remote_servers.xml"], with_zookeeper=True,
+                                   zookeeper_use_tmpfs=False)
 
     try:
         cluster_1.start()
@@ -146,11 +158,15 @@ def test_secure_connection():
     docker_compose.close()
 
     node1 = cluster.add_instance('node1', main_configs=["configs_secure/client.crt", "configs_secure/client.key",
-                                                        "configs_secure/conf.d/remote_servers.xml", "configs_secure/conf.d/ssl_conf.xml"],
-                                 with_zookeeper=True, zookeeper_docker_compose_path=docker_compose.name, zookeeper_use_tmpfs=False)
+                                                        "configs_secure/conf.d/remote_servers.xml",
+                                                        "configs_secure/conf.d/ssl_conf.xml"],
+                                 with_zookeeper=True, zookeeper_docker_compose_path=docker_compose.name,
+                                 zookeeper_use_tmpfs=False)
     node2 = cluster.add_instance('node2', main_configs=["configs_secure/client.crt", "configs_secure/client.key",
-                                                        "configs_secure/conf.d/remote_servers.xml", "configs_secure/conf.d/ssl_conf.xml"],
-                                 with_zookeeper=True, zookeeper_docker_compose_path=docker_compose.name, zookeeper_use_tmpfs=False)
+                                                        "configs_secure/conf.d/remote_servers.xml",
+                                                        "configs_secure/conf.d/ssl_conf.xml"],
+                                 with_zookeeper=True, zookeeper_docker_compose_path=docker_compose.name,
+                                 zookeeper_use_tmpfs=False)
 
     try:
         cluster.start()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Reformat and cleanup code in all integration test *.py files.

Detailed description / Documentation draft:

.This PR formats all the `*.py` files found under the `tests/integration`
folder. It also reorders the imports and cleans up a bunch of unused
imports.

The formatting also takes care of other things like wrapping lines and
fixing spaces and indents such that the tests look more readable.
