### PR TITLE
Adjust ignore thresholds for unstable perf tests

### DIFF
--- a/tests/performance/array_index_low_cardinality_strings.xml
+++ b/tests/performance/array_index_low_cardinality_strings.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.2">
     <create_query>DROP TABLE IF EXISTS perf_lc_str</create_query>
     <create_query>CREATE TABLE perf_lc_str(
         str LowCardinality(String),

--- a/tests/performance/codecs_int_insert.xml
+++ b/tests/performance/codecs_int_insert.xml
@@ -1,4 +1,4 @@
-<test max_ignored_relative_change="0.2">
+<test max_ignored_relative_change="0.5">
     <settings>
         <allow_suspicious_codecs>1</allow_suspicious_codecs>
     </settings>

--- a/tests/performance/codecs_int_insert.xml
+++ b/tests/performance/codecs_int_insert.xml
@@ -1,4 +1,4 @@
-<test max_ignored_relative_change="0.5">
+<test max_ignored_relative_change="0.2">
     <settings>
         <allow_suspicious_codecs>1</allow_suspicious_codecs>
     </settings>

--- a/tests/performance/collations.xml
+++ b/tests/performance/collations.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.8">
 
 
 

--- a/tests/performance/column_column_comparison.xml
+++ b/tests/performance/column_column_comparison.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.5">
     <tags>
         <tag>comparison</tag>
     </tags>

--- a/tests/performance/columns_hashing.xml
+++ b/tests/performance/columns_hashing.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.3">
     <tags>
         <tag>columns_hashing</tag>
     </tags>

--- a/tests/performance/count.xml
+++ b/tests/performance/count.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.5">
     <create_query>CREATE TABLE data(k UInt64, v UInt64) ENGINE = MergeTree ORDER BY k</create_query>
 
     <fill_query>INSERT INTO data SELECT number, 1 from numbers(10000000)</fill_query>

--- a/tests/performance/cryptographic_hashes.xml
+++ b/tests/performance/cryptographic_hashes.xml
@@ -1,4 +1,4 @@
-<test max_ignored_relative_change="1.3">
+<test max_ignored_relative_change="1.0">
     <substitutions>
         <substitution>
            <name>hash_slow</name>

--- a/tests/performance/cryptographic_hashes.xml
+++ b/tests/performance/cryptographic_hashes.xml
@@ -1,4 +1,4 @@
-<test max_ignored_relative_change="1.0">
+<test max_ignored_relative_change="1.3">
     <substitutions>
         <substitution>
            <name>hash_slow</name>

--- a/tests/performance/date_parsing.xml
+++ b/tests/performance/date_parsing.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.3">
     <preconditions>
         <table_exists>hits_100m_single</table_exists>
     </preconditions>

--- a/tests/performance/decimal_aggregates.xml
+++ b/tests/performance/decimal_aggregates.xml
@@ -1,4 +1,4 @@
-<test max_ignored_relative_change="0.4">
+<test max_ignored_relative_change="0.5">
     <settings>
         <max_memory_usage>35G</max_memory_usage>
     </settings>

--- a/tests/performance/empty_string_serialization.xml
+++ b/tests/performance/empty_string_serialization.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.2">
 
 
     <!-- gcc-8 generates 20% faster code than gcc-9

--- a/tests/performance/entropy.xml
+++ b/tests/performance/entropy.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.3">
     <preconditions>
         <table_exists>hits_100m_single</table_exists>
         <table_exists>hits_10m_single</table_exists>

--- a/tests/performance/extract.xml
+++ b/tests/performance/extract.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.4">
     <preconditions>
         <table_exists>test.hits</table_exists>
     </preconditions>

--- a/tests/performance/general_purpose_hashes.xml
+++ b/tests/performance/general_purpose_hashes.xml
@@ -1,4 +1,4 @@
-<test max_ignored_relative_change="0.2">
+<test max_ignored_relative_change="0.3">
     <substitutions>
         <substitution>
            <name>gp_hash_func</name>

--- a/tests/performance/if_array_string.xml
+++ b/tests/performance/if_array_string.xml
@@ -1,4 +1,4 @@
-<test max_ignored_relative_change="0.2">
+<test max_ignored_relative_change="0.3">
     <query>SELECT count() FROM zeros(10000000) WHERE NOT ignore(rand() % 2 ? ['Hello', 'World'] : ['a', 'b', 'c'])</query>
     <query>SELECT count() FROM zeros(10000000) WHERE NOT ignore(rand() % 2 ? materialize(['Hello', 'World']) : ['a', 'b', 'c'])</query>
     <query>SELECT count() FROM zeros(10000000) WHERE NOT ignore(rand() % 2 ? ['Hello', 'World'] : materialize(['a', 'b', 'c']))</query>

--- a/tests/performance/insert_parallel.xml
+++ b/tests/performance/insert_parallel.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.4">
     <settings>
         <max_insert_threads>4</max_insert_threads>
     </settings>

--- a/tests/performance/jit_large_requests.xml
+++ b/tests/performance/jit_large_requests.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.3">
     <create_query>
         CREATE TABLE jit_test (
             a UInt64,

--- a/tests/performance/joins_in_memory.xml
+++ b/tests/performance/joins_in_memory.xml
@@ -1,4 +1,4 @@
-<test max_ignored_relative_change="0.2">
+<test max_ignored_relative_change="0.7">
     <create_query>CREATE TABLE ints (i64 Int64, i32 Int32, i16 Int16, i8 Int8) ENGINE = Memory</create_query>
 
     <fill_query>INSERT INTO ints SELECT number AS i64, i64 AS i32, i64 AS i16, i64 AS i8 FROM numbers(10000)</fill_query>

--- a/tests/performance/local_replica.xml
+++ b/tests/performance/local_replica.xml
@@ -1,3 +1,3 @@
-<test>
+<test max_ignored_relative_change="0.3">
     <query>select sum(number) from remote('127.0.0.{{1|2}}', numbers_mt(1000000000)) group by bitAnd(number, 1)</query>
 </test>

--- a/tests/performance/logical_functions_medium.xml
+++ b/tests/performance/logical_functions_medium.xml
@@ -1,4 +1,4 @@
-<test max_ignored_relative_change="0.4">
+<test max_ignored_relative_change="0.5">
     <settings>
         <max_threads>1</max_threads>
     </settings>

--- a/tests/performance/materialized_view_parallel_insert.xml
+++ b/tests/performance/materialized_view_parallel_insert.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.3">
     <preconditions>
         <table_exists>hits_10m_single</table_exists>
     </preconditions>

--- a/tests/performance/merge_tree_huge_pk.xml
+++ b/tests/performance/merge_tree_huge_pk.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.3">
     <create_query>
         CREATE TABLE huge_pk ENGINE = MergeTree ORDER BY (
         c001, c002, c003, c004, c005, c006, c007, c008, c009, c010, c011, c012, c013, c014, c015, c016, c017, c018, c019, c020, 

--- a/tests/performance/merge_tree_many_partitions.xml
+++ b/tests/performance/merge_tree_many_partitions.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.5">
     <create_query>CREATE TABLE bad_partitions (x UInt64) ENGINE = MergeTree PARTITION BY x ORDER BY x</create_query>
     <fill_query>INSERT INTO bad_partitions SELECT * FROM numbers(10000)</fill_query>
 

--- a/tests/performance/merge_tree_simple_select.xml
+++ b/tests/performance/merge_tree_simple_select.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.7">
     <create_query>CREATE TABLE simple_mergetree (EventDate Date, x UInt64) ENGINE = MergeTree ORDER BY x</create_query>
     <fill_query>INSERT INTO simple_mergetree SELECT number, today() + intDiv(number, 10000000) FROM numbers_mt(100000000)</fill_query>
     <fill_query>OPTIMIZE TABLE simple_mergetree FINAL</fill_query>

--- a/tests/performance/order_by_single_column.xml
+++ b/tests/performance/order_by_single_column.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.5">
     <tags>
         <tag>sorting</tag>
         <tag>comparison</tag>

--- a/tests/performance/parallel_index.xml
+++ b/tests/performance/parallel_index.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.3">
     <create_query>create table test_parallel_index (x UInt64, y UInt64, z UInt64, INDEX a (y) TYPE minmax GRANULARITY 2,
         INDEX b (z) TYPE set(8) GRANULARITY 2) engine = MergeTree order by x partition by bitAnd(x, 63 * 64) settings index_granularity = 4;</create_query>
 

--- a/tests/performance/parallel_index.xml
+++ b/tests/performance/parallel_index.xml
@@ -1,4 +1,4 @@
-<test max_ignored_relative_change="0.3">
+<test max_ignored_relative_change="0.2">
     <create_query>create table test_parallel_index (x UInt64, y UInt64, z UInt64, INDEX a (y) TYPE minmax GRANULARITY 2,
         INDEX b (z) TYPE set(8) GRANULARITY 2) engine = MergeTree order by x partition by bitAnd(x, 63 * 64) settings index_granularity = 4;</create_query>
 

--- a/tests/performance/parallel_insert.xml
+++ b/tests/performance/parallel_insert.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.3">
 
     <preconditions>
         <table_exists>hits_10m_single</table_exists>

--- a/tests/performance/parse_engine_file.xml
+++ b/tests/performance/parse_engine_file.xml
@@ -1,4 +1,4 @@
-<test max_ignored_relative_change="0.2">
+<test max_ignored_relative_change="0.4">
     
     <create_query>CREATE TABLE IF NOT EXISTS table_{format} ENGINE = File({format}) AS test.hits</create_query>
 

--- a/tests/performance/push_down_limit.xml
+++ b/tests/performance/push_down_limit.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.3">
     <query>select number from (select number from numbers(10000000) order by -number) limit 10</query>
     <query>select number from (select number from numbers_mt(100000000) order by -number) limit 10</query>
 </test>

--- a/tests/performance/random_printable_ascii.xml
+++ b/tests/performance/random_printable_ascii.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.2">
     <query>SELECT count() FROM zeros(10000000) WHERE NOT ignore(randomPrintableASCII(10))</query>
     <query>SELECT count() FROM zeros(10000000) WHERE NOT ignore(randomPrintableASCII(100))</query>
     <query>SELECT count() FROM zeros(100000) WHERE NOT ignore(randomPrintableASCII(1000))</query>

--- a/tests/performance/random_string.xml
+++ b/tests/performance/random_string.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.2">
     <query>SELECT count() FROM zeros(10000000) WHERE NOT ignore(randomString(10))</query>
     <query>SELECT count() FROM zeros(10000000) WHERE NOT ignore(randomString(100))</query>
     <query>SELECT count() FROM zeros(100000) WHERE NOT ignore(randomString(1000))</query>

--- a/tests/performance/read_in_order_many_parts.xml
+++ b/tests/performance/read_in_order_many_parts.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.4">
     <settings>
         <optimize_aggregation_in_order>1</optimize_aggregation_in_order>
         <optimize_read_in_order>1</optimize_read_in_order>

--- a/tests/performance/select_format.xml
+++ b/tests/performance/select_format.xml
@@ -1,4 +1,4 @@
-<test max_ignored_relative_change="0.2">
+<test max_ignored_relative_change="0.3">
     <settings>
         <output_format_pretty_max_rows>1000000</output_format_pretty_max_rows>
         <max_threads>1</max_threads>

--- a/tests/performance/set.xml
+++ b/tests/performance/set.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.2">
     <substitutions>
        <substitution>
            <name>table_small</name>

--- a/tests/performance/set_index.xml
+++ b/tests/performance/set_index.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.7">
     <create_query>CREATE TABLE test_in (`a` UInt32) ENGINE = MergeTree() ORDER BY a</create_query>
     <fill_query>INSERT INTO test_in SELECT number FROM numbers(500000000)</fill_query>
 

--- a/tests/performance/string_sort.xml
+++ b/tests/performance/string_sort.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.4">
     <preconditions>
         <table_exists>hits_10m_single</table_exists>
         <table_exists>hits_100m_single</table_exists>

--- a/tests/performance/uniq.xml
+++ b/tests/performance/uniq.xml
@@ -1,4 +1,4 @@
-<test>
+<test max_ignored_relative_change="0.9">
 
     <preconditions>
         <table_exists>hits_100m_single</table_exists>

--- a/tests/performance/website.xml
+++ b/tests/performance/website.xml
@@ -1,4 +1,4 @@
-<test max_ignored_relative_change="0.6">
+<test max_ignored_relative_change="0.4">
 
     <preconditions>
         <table_exists>hits_10m_single</table_exists>

--- a/tests/performance/website.xml
+++ b/tests/performance/website.xml
@@ -1,4 +1,4 @@
-<test max_ignored_relative_change="0.2">
+<test max_ignored_relative_change="0.6">
 
     <preconditions>
         <table_exists>hits_10m_single</table_exists>


### PR DESCRIPTION
Based on historical data.

```
SELECT
    test,
    ceil(max(q[3]), 1) AS h
FROM
(
    SELECT
        test,
        query_index,
        count(*),
        min(event_time),
        max(event_time) AS t,
        arrayMap(x -> floor(x, 3), quantiles(0, 0.5, 0.95, 1)(stat_threshold)) AS q,
        median(stat_threshold) AS m
    FROM perftest.query_metrics
    WHERE (metric = 'client_time') AND (abs(diff) < 0.05)
    GROUP BY
        test,
        query_index,
        query_display_name
    HAVING (t > '2020-09-01 00:00:00') AND (m > 0.1)
    ORDER BY m DESC
)
GROUP BY test
ORDER BY h DESC
FORMAT TSV

cryptographic_hashes	1.3
collations	0.8
joins_in_memory_pmj	0.8
joins_in_memory	0.7
merge_tree_simple_select	0.7
set_index	0.7
decimal_casts	0.7
website	0.6
logical_functions_medium	0.5
count	0.5
merge_tree_many_partitions	0.5
decimal_aggregates	0.5
codecs_int_insert	0.5
column_column_comparison	0.5
insert_parallel	0.4
parse_engine_file	0.4
read_in_order_many_parts	0.4
logical_functions_small	0.4
parallel_insert	0.3
parallel_index	0.3
push_down_limit	0.3
jit_large_requests	0.3
select_format	0.3
arithmetic	0.3
merge_tree_huge_pk	0.3
materialized_view_parallel_insert	0.3
columns_hashing	0.3
if_array_string	0.3
random_string	0.2
random_printable_ascii	0.2
set	0.2
empty_string_serialization	0.2
```

To apply:
```
sed 's/^\(.*\)        \(.*\)$/sed -i "s\/^<test.*$\/<test max_ignored_relative_change="'"'"\2">\/g" tests\/performance\/\1.xml/g' ../bad.tsv | bash
```

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

