### PR TITLE
Query deduplication based on parts fingerprints

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -1679,6 +1679,9 @@ private:
 
         switch (packet.type)
         {
+            case Protocol::Server::Fingerprints:
+                return true;
+
             case Protocol::Server::Data:
                 if (!cancelled)
                     onData(packet.block);

--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -522,6 +522,13 @@ void Connection::sendScalarsData(Scalars & data)
             ReadableSize(maybe_compressed_out_bytes / watch.elapsedSeconds()));
 }
 
+void Connection::sendFingerprints(const Strings & fps)
+{
+    writeVarUInt(Protocol::Client::Fingerprints, *out);
+    writeVectorBinary<>(fps, *out);
+    out->next();
+}
+
 namespace
 {
 /// Sink which sends data for external table.
@@ -712,6 +719,11 @@ Packet Connection::receivePacket()
                 return res;
 
             case Protocol::Server::EndOfStream:
+                return res;
+
+            case Protocol::Server::Fingerprints:
+                LOG_DEBUG(log_wrapper.get(), "got fingerprints packet");
+                readVectorBinary(res.fingerprints, *in);
                 return res;
 
             default:

--- a/src/Client/Connection.h
+++ b/src/Client/Connection.h
@@ -63,6 +63,7 @@ struct Packet
     std::vector<String> multistring_message;
     Progress progress;
     BlockStreamProfileInfo profile_info;
+    Strings fingerprints;
 
     Packet() : type(Protocol::Server::Hello) {}
 };
@@ -154,6 +155,9 @@ public:
     /// Send prepared block of data (serialized and, if need, compressed), that will be read from 'input'.
     /// You could pass size of serialized/compressed block.
     void sendPreparedData(ReadBuffer & input, size_t size, const String & name = "");
+
+    /// Send parts' fingerprints
+    void sendFingerprints(const Strings & fps);
 
     /// Check, if has data to read.
     bool poll(size_t timeout_microseconds = 0);

--- a/src/Client/MultiplexedConnections.h
+++ b/src/Client/MultiplexedConnections.h
@@ -50,6 +50,9 @@ public:
     /// Send a request to the replica to cancel the request
     void sendCancel();
 
+    /// Send parts' fingerprints to replicas before the query itself
+    void sendFingerprints(const Strings & fps);
+
     /** On each replica, read and skip all packets to EndOfStream or Exception.
       * Returns EndOfStream if no exception has been received. Otherwise
       * returns the last received packet of type Exception.

--- a/src/Common/ErrorCodes.cpp
+++ b/src/Common/ErrorCodes.cpp
@@ -508,6 +508,7 @@ namespace ErrorCodes
     extern const int CANNOT_CREATE_RABBITMQ_QUEUE_BINDING = 541;
     extern const int CANNOT_REMOVE_RABBITMQ_EXCHANGE = 542;
     extern const int UNKNOWN_MYSQL_DATATYPES_SUPPORT_LEVEL = 543;
+    extern const int DUPLICATED_FINGERPRINTS = 544;
 
     extern const int KEEPER_EXCEPTION = 999;
     extern const int POCO_EXCEPTION = 1000;

--- a/src/Core/Protocol.h
+++ b/src/Core/Protocol.h
@@ -71,6 +71,7 @@ namespace Protocol
             TablesStatusResponse = 9, /// A response to TablesStatus request.
             Log = 10,                 /// System logs of the query execution
             TableColumns = 11,        /// Columns' description for default values calculation
+            Fingerprints = 12,        /// List of uniq parts ids.
         };
 
         /// NOTE: If the type of packet argument would be Enum, the comparison packet >= 0 && packet < 10
@@ -80,8 +81,8 @@ namespace Protocol
         inline const char * toString(UInt64 packet)
         {
             static const char * data[] = { "Hello", "Data", "Exception", "Progress", "Pong", "EndOfStream", "ProfileInfo", "Totals",
-                "Extremes", "TablesStatusResponse", "Log", "TableColumns" };
-            return packet < 12
+                "Extremes", "TablesStatusResponse", "Log", "TableColumns", "Fingerprints" };
+            return packet < 13
                 ? data[packet]
                 : "Unknown packet";
         }
@@ -113,13 +114,14 @@ namespace Protocol
             Ping = 4,                /// Check that connection to the server is alive.
             TablesStatusRequest = 5, /// Check status of tables on the server.
             KeepAlive = 6,           /// Keep the connection alive
-            Scalar = 7               /// A block of data (compressed or not).
+            Scalar = 7,               /// A block of data (compressed or not).
+            Fingerprints = 8          /// List of uniq parts ids to exclude from being processed
         };
 
         inline const char * toString(UInt64 packet)
         {
-            static const char * data[] = { "Hello", "Query", "Data", "Cancel", "Ping", "TablesStatusRequest", "KeepAlive" };
-            return packet < 7
+            static const char * data[] = { "Hello", "Query", "Data", "Cancel", "Ping", "TablesStatusRequest", "KeepAlive", "Scalar", "Fingerprints" };
+            return packet < 9
                 ? data[packet]
                 : "Unknown packet";
         }

--- a/src/Interpreters/ClusterProxy/SelectStreamFactory.cpp
+++ b/src/Interpreters/ClusterProxy/SelectStreamFactory.cpp
@@ -131,6 +131,7 @@ void SelectStreamFactory::createForShard(
     }
 
     auto modified_query_ast = query_ast->clone();
+    /// TODO(xjewer) return earlier if there is a filter by _shard_num, don't need to send remote query
     if (has_virtual_shard_num_column)
         VirtualColumnUtils::rewriteEntityInAst(modified_query_ast, "_shard_num", shard_info.shard_num, "toUInt32");
 

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -154,6 +154,19 @@ private:
     std::unique_ptr<ContextShared> shared;
 };
 
+struct Fingerprints
+{
+    using StringsMap = std::unordered_map<String, std::nullptr_t>;
+    Strings add(const Strings & fps);
+    Strings getList();
+    StringsMap getMap();
+    ~Fingerprints();
+    Fingerprints();
+private:
+    std::mutex mutex;
+    StringsMap map;
+};
+
 /** A set of known objects that can be used in the query.
   * Consists of a shared part (always common to all sessions and queries)
   *  and copied part (which can be its own for each session or query).
@@ -200,6 +213,9 @@ private:
 
     using SampleBlockCache = std::unordered_map<std::string, Block>;
     mutable SampleBlockCache sample_block_cache;
+
+    std::shared_ptr<Fingerprints> fingerprints; /// set of parts' fingerprints, is used for query parts deduplication
+    std::shared_ptr<Fingerprints> excluded_fingerprints; /// set of parts' fingerprints, is used for exluding parts being processed
 
     NameToNameMap query_parameters;   /// Dictionary with query parameters for prepared statements.
                                                      /// (key=name, value)
@@ -618,6 +634,9 @@ public:
     };
 
     MySQLWireContext mysql;
+
+    std::shared_ptr<Fingerprints> getFingerprints();
+    std::shared_ptr<Fingerprints> getExcludedFingerprints();
 private:
     std::unique_lock<std::recursive_mutex> getLock() const;
 

--- a/src/Processors/Transforms/FilterTransform.cpp
+++ b/src/Processors/Transforms/FilterTransform.cpp
@@ -33,6 +33,7 @@ Block FilterTransform::transformHeader(
     const String & filter_column_name,
     bool remove_filter_column)
 {
+
     expression->execute(header);
 
     if (remove_filter_column)

--- a/src/Server/TCPHandler.h
+++ b/src/Server/TCPHandler.h
@@ -65,6 +65,8 @@ struct QueryState
     bool need_receive_data_for_insert = false;
     /// Temporary tables read
     bool temporary_tables_read = false;
+    /// A state got fingerprints to exclude from a query
+    bool fingerprints = false;
 
     /// Request requires data from client for function input()
     bool need_receive_data_for_input = false;
@@ -155,6 +157,7 @@ private:
     void receiveHello();
     bool receivePacket();
     void receiveQuery();
+    void receiveFingerprints();
     bool receiveData(bool scalar);
     bool readDataNext(const size_t & poll_interval, const int & receive_timeout);
     void readData(const Settings & connection_settings);
@@ -183,6 +186,7 @@ private:
     void sendProgress();
     void sendLogs();
     void sendEndOfStream();
+    void sendFingerprints();
     void sendProfileInfo(const BlockStreamProfileInfo & info);
     void sendTotals(const Block & totals);
     void sendExtremes(const Block & extremes);

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -417,6 +417,8 @@ void IMergeTreeDataPart::loadColumnsChecksumsIndexes(bool require_columns_checks
     loadRowsCount(); /// Must be called after loadIndexGranularity() as it uses the value of `index_granularity`.
     loadPartitionAndMinMaxIndex();
     loadTTLInfos();
+    loadFingerprint();
+
     if (check_consistency)
         checkConsistency(require_columns_checksums);
     loadDefaultCompressionCodec();
@@ -722,6 +724,21 @@ void IMergeTreeDataPart::loadTTLInfos()
         }
         else
             throw Exception("Unknown ttl format version: " + toString(format_version), ErrorCodes::BAD_TTL_FILE);
+    }
+}
+
+void IMergeTreeDataPart::loadFingerprint()
+{
+
+
+    String path = getFullRelativePath() + "fingerprint.txt";
+    if (volume->getDisk()->exists(path))
+    {
+        auto in = openForReading(volume->getDisk(), path);
+
+        readText(fingerprint, *in);
+        if (fingerprint.empty())
+            throw Exception("Found fingerprint.txt but it is empty in part: " + name, ErrorCodes::LOGICAL_ERROR);
     }
 }
 

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -729,8 +729,6 @@ void IMergeTreeDataPart::loadTTLInfos()
 
 void IMergeTreeDataPart::loadFingerprint()
 {
-
-
     String path = getFullRelativePath() + "fingerprint.txt";
     if (volume->getDisk()->exists(path))
     {

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -187,6 +187,10 @@ public:
     /// Frozen by ALTER TABLE ... FREEZE ... It is used for information purposes in system.parts table.
     mutable std::atomic<bool> is_frozen {false};
 
+    /// Cluster level partition fingerprint.
+    /// Used for resolving conflicts during cross-shard data movement.
+    String fingerprint;
+
     /**
      * Part state is a stage of its lifetime. States are ordered and state of a part could be increased only.
      * Part state should be modified under data_parts mutex.
@@ -398,6 +402,9 @@ private:
 
     /// Loads ttl infos in json format from file ttl.txt. If file doesn't exists assigns ttl infos with all zeros
     void loadTTLInfos();
+
+    /// TODO(nv) This is just for POC. Should probably live in another place and for Replicated* should be in ZK.
+    void loadFingerprint();
 
     void loadPartitionAndMinMaxIndex();
 

--- a/src/Storages/MergeTree/MergeTreeBaseSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeBaseSelectProcessor.cpp
@@ -241,6 +241,16 @@ static void injectVirtualColumnsImpl(size_t rows, VirtualColumnsInserter & inser
 
                 inserter.insertUInt64Column(column, virtual_column_name);
             }
+            else if (virtual_column_name == "_part_fingerprint")
+            {
+                ColumnPtr column;
+                if (rows)
+                    column = DataTypeString().createColumnConst(rows, task->data_part->fingerprint)->convertToFullColumnIfConst();
+                else
+                    column = DataTypeString().createColumn();
+
+                inserter.insertStringColumn(column, virtual_column_name);
+            }
             else if (virtual_column_name == "_partition_id")
             {
                 ColumnPtr column;

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3658,6 +3658,7 @@ NamesAndTypesList MergeTreeData::getVirtuals() const
     return NamesAndTypesList{
         NameAndTypePair("_part", std::make_shared<DataTypeString>()),
         NameAndTypePair("_part_index", std::make_shared<DataTypeUInt64>()),
+        NameAndTypePair("_part_fingerprint", std::make_shared<DataTypeString>()),
         NameAndTypePair("_partition_id", std::make_shared<DataTypeString>()),
         NameAndTypePair("_sample_factor", std::make_shared<DataTypeFloat64>()),
     };

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -338,6 +338,7 @@ NamesAndTypesList StorageDistributed::getVirtuals() const
             NameAndTypePair("_table", std::make_shared<DataTypeString>()),
             NameAndTypePair("_part", std::make_shared<DataTypeString>()),
             NameAndTypePair("_part_index", std::make_shared<DataTypeUInt64>()),
+            NameAndTypePair("_part_fingerprint", std::make_shared<DataTypeString>()),
             NameAndTypePair("_partition_id", std::make_shared<DataTypeString>()),
             NameAndTypePair("_sample_factor", std::make_shared<DataTypeFloat64>()),
             NameAndTypePair("_shard_num", std::make_shared<DataTypeUInt32>()),

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -640,6 +640,12 @@ bool StorageMergeTree::merge(
 
         auto can_merge = [this, &lock] (const DataPartPtr & left, const DataPartPtr & right, String *) -> bool
         {
+            /// Ignore fingerprinted parts.
+            if ((left && !left->fingerprint.empty()) || !right->fingerprint.empty())
+            {
+                return false;
+            }
+
             /// This predicate is checked for the first part of each partition.
             /// (left = nullptr, right = "first part of partition")
             if (!left)

--- a/src/Storages/System/StorageSystemParts.cpp
+++ b/src/Storages/System/StorageSystemParts.cpp
@@ -67,6 +67,8 @@ StorageSystemParts::StorageSystemParts(const StorageID & table_id_)
         {"recompression_ttl_info.expression",           std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>())},
         {"recompression_ttl_info.min",                  std::make_shared<DataTypeArray>(std::make_shared<DataTypeDateTime>())},
         {"recompression_ttl_info.max",                  std::make_shared<DataTypeArray>(std::make_shared<DataTypeDateTime>())},
+
+        {"fingerprint",                                 std::make_shared<DataTypeString>()},
     }
     )
 {
@@ -182,6 +184,8 @@ void StorageSystemParts::processNextStorage(MutableColumns & columns_, const Sto
         columns_[i++]->insert(queryToString(part->default_codec->getCodecDesc()));
 
         add_ttl_info_map(part->ttl_infos.recompression_ttl);
+
+        columns_[i++]->insert(part->fingerprint);
     }
 }
 

--- a/tests/integration/test_part_fingerprints/configs/remote_servers.xml
+++ b/tests/integration/test_part_fingerprints/configs/remote_servers.xml
@@ -1,0 +1,18 @@
+<yandex>
+    <remote_servers>
+        <test_cluster>
+            <shard>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+            <shard>
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster>
+    </remote_servers>
+</yandex>

--- a/tests/integration/test_part_fingerprints/test.py
+++ b/tests/integration/test_part_fingerprints/test.py
@@ -1,0 +1,94 @@
+"""
+This is a basic test for de-duplication during data movement between shards.
+
+The focus is on finding a way to propagate fingerprints to root executor and
+use them for either de-duplicating or re-executing query by excluding parts
+for which we have duplicate fingerprints.
+
+1. We configure 2 nodes which have some sample data in a MergeTree table with
+some parts containing a fingerprint.
+
+2. Query the distributed table covering both nodes and check that data with
+matching fingerprints is present just once in the end result.
+
+Run test:
+
+    $ ./runner --disable-net-host --binary /home/nv/play-clickhouse-data/build/clickhouse-master/programs/clickhouse \
+        -- -k test_part_fingerprints -s
+
+"""
+
+import logging
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import TSV
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml'])
+node2 = cluster.add_instance('node2', main_configs=['configs/remote_servers.xml'])
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+def prepare_node(node, fingerprints=None):
+    node.query("""
+    CREATE TABLE t(key UInt64, value UInt64)
+    ENGINE MergeTree()
+    ORDER BY tuple()
+    SETTINGS index_granularity = 1
+    """)
+
+    node.query("""
+    CREATE TABLE d AS t ENGINE=Distributed(test_cluster, default, t)
+    """)
+
+    # Stop merges while populating test data
+    node.query("SYSTEM STOP MERGES")
+
+    # Create 5 parts
+    for i in range(1, 6):
+        node.query("INSERT INTO t VALUES ({}, {})".format(i, i))
+
+    node.query("DETACH TABLE t")
+
+    for part, fingerprint in fingerprints:
+        script = """
+        echo '{}' > /var/lib/clickhouse/data/default/t/{}/fingerprint.txt
+        """.format(fingerprint, part)
+        node.exec_in_container(["bash", "-c", script])
+
+    # Attach table back
+    node.query("ATTACH TABLE t")
+
+    node.query("SYSTEM START MERGES")
+    node.query("OPTIMIZE TABLE t FINAL")
+
+    print(node.name)
+    print(node.query("SELECT name, fingerprint FROM system.parts WHERE table = 't' AND active ORDER BY name"))
+
+    # Presence of fingerprints prevents all merges in a partition
+    assert '5' == node.query("SELECT count() FROM system.parts WHERE table = 't' AND active").strip()
+    assert str(len(fingerprints)) == node.query("SELECT count() FROM system.parts WHERE table = 't' AND length(fingerprint) > 0").strip()
+
+
+def test_basic(started_cluster):
+    prepare_node(node1, fingerprints=[("all_3_3_0", "my_uniq_fp_1")])
+    prepare_node(node2, fingerprints=[("all_3_3_0", "my_uniq_fp_1"), ("all_4_4_0", "my_uniq_fp2")])
+
+    # Part containing `key=3` has the same fingerprint on both nodes,
+    #   we expect it to be included only once in the end result.;
+    expected = """
+1	2
+2	2
+3	1
+4	2
+5	2
+"""
+    assert TSV(expected) == TSV(node1.query("SELECT key, count() c FROM d GROUP BY key ORDER BY c, key"))


### PR DESCRIPTION
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

Changelog category (leave one):
- New Feature


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Distributed query deduplication is a followup to #14860 and partially resolves the proposal #13574  

Data parts’ fingerprints is a mechanism of giving a data part a unique identifier (UUID).

Adding the UUID to a data part allows moving it between shards preserving data consistency on a read path:
duplicated fingerprints (parts with fingerprints) will cause root executor to retry query against on of the replica explicitly
asking to exclude encountered duplicated fingerprints during a distributed query execution.

cc @alexey-milovidov @nvartolomei 
