### PR TITLE
fix a syntax error bug while using copier

### DIFF
--- a/programs/copier/Internals.cpp
+++ b/programs/copier/Internals.cpp
@@ -208,7 +208,7 @@ Names extractPrimaryKeyColumnNames(const ASTPtr & storage_ast)
             if (!primary_key_columns_set.emplace(pk_column).second)
                 throw Exception("Primary key contains duplicate columns", ErrorCodes::BAD_ARGUMENTS);
 
-            primary_key_columns.push_back("`" + pk_column + "`");
+            primary_key_columns.push_back(backQuote(pk_column));
         }
     }
 

--- a/programs/copier/Internals.cpp
+++ b/programs/copier/Internals.cpp
@@ -208,7 +208,7 @@ Names extractPrimaryKeyColumnNames(const ASTPtr & storage_ast)
             if (!primary_key_columns_set.emplace(pk_column).second)
                 throw Exception("Primary key contains duplicate columns", ErrorCodes::BAD_ARGUMENTS);
 
-            primary_key_columns.push_back(pk_column);
+            primary_key_columns.push_back("`" + pk_column + "`");
         }
     }
 


### PR DESCRIPTION
when using copier，column name ,as sort key,with digital number as beginning,will cause a syntax error