### PR TITLE
Move non-essential builds to special

### DIFF
--- a/tests/ci/ci_config.json
+++ b/tests/ci/ci_config.json
@@ -110,6 +110,18 @@
             "splitted": "unsplitted",
             "tidy": "disable",
             "with_coverage": false
+        }
+    ],
+    "special_build_config": [
+        {
+            "compiler": "clang-11",
+            "build-type": "debug",
+            "sanitizer": "",
+            "package-type": "deb",
+            "bundled": "bundled",
+            "splitted": "unsplitted",
+            "tidy": "enable",
+            "with_coverage": true
         },
         {
             "compiler": "clang-11",
@@ -150,18 +162,6 @@
             "splitted": "unsplitted",
             "tidy": "disable",
             "with_coverage": false
-        }
-    ],
-    "special_build_config": [
-        {
-            "compiler": "clang-11",
-            "build-type": "debug",
-            "sanitizer": "",
-            "package-type": "deb",
-            "bundled": "bundled",
-            "splitted": "unsplitted",
-            "tidy": "enable",
-            "with_coverage": true
         }
     ],
     "tests_config": {


### PR DESCRIPTION
Special builds have lower CI priority and start later. If some tests
fail, they won't start at all, so we'll save some CI time.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)