### PR TITLE
Fix enable_optimize_predicate_expression for finalizeAggregation

### DIFF
--- a/src/Functions/finalizeAggregation.cpp
+++ b/src/Functions/finalizeAggregation.cpp
@@ -34,11 +34,6 @@ public:
         return name;
     }
 
-    bool isStateful() const override
-    {
-        return true;
-    }
-
     size_t getNumberOfArguments() const override
     {
         return 1;

--- a/tests/queries/0_stateless/00808_not_optimize_predicate.reference
+++ b/tests/queries/0_stateless/00808_not_optimize_predicate.reference
@@ -10,3 +10,20 @@
 (1,1)
 (3,2)
 (5,2)
+-------finalizeAggregation should not be stateful (issue #14847)-------
+2	62
+3	87
+4	112
+5	137
+SELECT
+    n,
+    `finalizeAggregation(s)`
+FROM 
+(
+    SELECT
+        n,
+        finalizeAggregation(s)
+    FROM test_00808_push_down_with_finalizeAggregation
+    WHERE (n <= 5) AND (n >= 2)
+)
+WHERE (n >= 2) AND (n <= 5)

--- a/tests/queries/0_stateless/00808_not_optimize_predicate.sql
+++ b/tests/queries/0_stateless/00808_not_optimize_predicate.sql
@@ -36,3 +36,39 @@ SELECT arrayJoin(arrayMap(x -> x, arraySort(groupArray((ts, n))))) AS k FROM (
 
 
 DROP TABLE IF EXISTS test_00808;
+
+SELECT '-------finalizeAggregation should not be stateful (issue #14847)-------';
+
+DROP TABLE IF EXISTS test_00808_push_down_with_finalizeAggregation;
+
+CREATE TABLE test_00808_push_down_with_finalizeAggregation ENGINE = AggregatingMergeTree
+ORDER BY n AS
+SELECT
+    intDiv(number, 25) AS n,
+    avgState(number) AS s
+FROM numbers(2500)
+GROUP BY n;
+
+SET force_primary_key = 1, enable_debug_queries = 1, enable_optimize_predicate_expression = 1;
+
+SELECT *
+FROM
+(
+    SELECT
+        n,
+        finalizeAggregation(s)
+    FROM test_00808_push_down_with_finalizeAggregation
+)
+WHERE (n >= 2) AND (n <= 5);
+
+ANALYZE SELECT *
+FROM
+(
+    SELECT
+        n,
+        finalizeAggregation(s)
+    FROM test_00808_push_down_with_finalizeAggregation
+)
+WHERE (n >= 2) AND (n <= 5);
+
+DROP TABLE IF EXISTS test_00808_push_down_with_finalizeAggregation;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix to make predicate push down work when subquery contains finalizeAggregation function. Fixes #14847

Detailed description / Documentation draft:
