### PR TITLE
Ignore key constraints when doing mutations.

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
@@ -1080,8 +1080,8 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataMergerMutator::mutatePartToTempor
     context_for_reading.setSetting("max_streams_to_max_threads_ratio", 1);
     context_for_reading.setSetting("max_threads", 1);
     /// Allow mutations to work when force_index_by_date or force_primary_key is on.
-    context_for_reading.setSetting("force_index_by_date", 0);
-    context_for_reading.setSetting("force_primary_key", 0);
+    context_for_reading.setSetting("force_index_by_date", Field(0));
+    context_for_reading.setSetting("force_primary_key", Field(0));
 
     MutationCommands commands_for_part;
     for (const auto & command : commands)

--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
@@ -1079,6 +1079,9 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataMergerMutator::mutatePartToTempor
     auto context_for_reading = context;
     context_for_reading.setSetting("max_streams_to_max_threads_ratio", 1);
     context_for_reading.setSetting("max_threads", 1);
+    /// Allow mutations to work when force_index_by_date or force_primary_key is on.
+    context_for_reading.setSetting("force_index_by_date", 0);
+    context_for_reading.setSetting("force_primary_key", 0);
 
     MutationCommands commands_for_part;
     for (const auto & command : commands)

--- a/tests/integration/test_mutations_with_merge_tree/configs/users.xml
+++ b/tests/integration/test_mutations_with_merge_tree/configs/users.xml
@@ -3,6 +3,8 @@
     <profiles>
         <default>
             <max_expanded_ast_elements>500</max_expanded_ast_elements>
+            <force_index_by_date>1</force_index_by_date>
+            <force_primary_key>1</force_primary_key>
         </default>
     </profiles>
 </yandex>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Ignore key constraints when doing mutations. Without this pr, it's not possible to do mutations when `force_index_by_date = 1` or `force_primary_key = 1`.


Detailed description / Documentation draft:

Null

