### PR TITLE
Option to disable TTL move on data part insert

### DIFF
--- a/src/Disks/IVolume.h
+++ b/src/Disks/IVolume.h
@@ -73,7 +73,7 @@ public:
     UInt64 max_data_part_size = 0;
     /// Should a new data part be synchronously moved to a volume according to ttl on insert
     /// or move this part in background task asynchronously after insert.
-    bool perform_ttl_move_on_insert;
+    bool perform_ttl_move_on_insert = true;
 };
 
 /// Reservation for multiple disks at once. Can be used in RAID1 implementation.

--- a/src/Disks/IVolume.h
+++ b/src/Disks/IVolume.h
@@ -36,10 +36,11 @@ using Volumes = std::vector<VolumePtr>;
 class IVolume : public Space
 {
 public:
-    IVolume(String name_, Disks disks_, size_t max_data_part_size_ = 0)
+    IVolume(String name_, Disks disks_, size_t max_data_part_size_ = 0, bool perform_ttl_move_on_insert_ = true)
         : disks(std::move(disks_))
         , name(name_)
         , max_data_part_size(max_data_part_size_)
+        , perform_ttl_move_on_insert(perform_ttl_move_on_insert_)
     {
     }
 
@@ -70,6 +71,9 @@ protected:
 public:
     /// Max size of reservation, zero means unlimited size
     UInt64 max_data_part_size = 0;
+    /// Should a new data part be synchronously moved to a volume according to ttl on insert
+    /// or move this part in background task asynchronously after insert.
+    bool perform_ttl_move_on_insert;
 };
 
 /// Reservation for multiple disks at once. Can be used in RAID1 implementation.

--- a/src/Disks/VolumeJBOD.cpp
+++ b/src/Disks/VolumeJBOD.cpp
@@ -53,6 +53,9 @@ VolumeJBOD::VolumeJBOD(
     static constexpr UInt64 MIN_PART_SIZE = 8u * 1024u * 1024u;
     if (max_data_part_size != 0 && max_data_part_size < MIN_PART_SIZE)
         LOG_WARNING(logger, "Volume {} max_data_part_size is too low ({} < {})", backQuote(name), ReadableSize(max_data_part_size), ReadableSize(MIN_PART_SIZE));
+
+    /// Default value is 'true' due to backward compatibility.
+    perform_ttl_move_on_insert = config.getBool(config_prefix + ".perform_ttl_move_on_insert", true);
 }
 
 DiskPtr VolumeJBOD::getDisk(size_t /* index */) const

--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -276,7 +276,7 @@ MergeTreeData::MutableDataPartPtr Fetcher::fetchPart(
             ReadBufferFromString ttl_infos_buffer(ttl_infos_string);
             assertString("ttl format version: 1\n", ttl_infos_buffer);
             ttl_infos.read(ttl_infos_buffer);
-            reservation = data.reserveSpacePreferringTTLRules(sum_files_size, ttl_infos, std::time(nullptr));
+            reservation = data.reserveSpacePreferringTTLRules(sum_files_size, ttl_infos, std::time(nullptr), 0, true);
         }
         else
             reservation = data.reserveSpace(sum_files_size);

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -624,13 +624,15 @@ public:
         UInt64 expected_size,
         const IMergeTreeDataPart::TTLInfos & ttl_infos,
         time_t time_of_move,
-        size_t min_volume_index = 0) const;
+        size_t min_volume_index = 0,
+        bool is_insert = false) const;
 
     ReservationPtr tryReserveSpacePreferringTTLRules(
         UInt64 expected_size,
         const IMergeTreeDataPart::TTLInfos & ttl_infos,
         time_t time_of_move,
-        size_t min_volume_index = 0) const;
+        size_t min_volume_index = 0,
+        bool is_insert = false) const;
 
     /// Choose disk with max available free space
     /// Reserves 0 bytes
@@ -638,9 +640,9 @@ public:
 
     /// Return alter conversions for part which must be applied on fly.
     AlterConversions getAlterConversionsForPart(const MergeTreeDataPartPtr part) const;
-    /// Returns destination disk or volume for the TTL rule according to current
-    /// storage policy
-    SpacePtr getDestinationForTTL(const TTLDescription & ttl) const;
+    /// Returns destination disk or volume for the TTL rule according to current storage policy
+    /// 'is_insert' - is TTL move performed on new data part insert.
+    SpacePtr getDestinationForTTL(const TTLDescription & ttl, bool is_insert = false) const;
 
     /// Checks if given part already belongs destination disk or volume for the
     /// TTL rule.

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -642,7 +642,7 @@ public:
     AlterConversions getAlterConversionsForPart(const MergeTreeDataPartPtr part) const;
     /// Returns destination disk or volume for the TTL rule according to current storage policy
     /// 'is_insert' - is TTL move performed on new data part insert.
-    SpacePtr getDestinationForTTL(const TTLDescription & ttl, bool is_insert = false) const;
+    SpacePtr getDestinationForMoveTTL(const TTLDescription & move_ttl, bool is_insert = false) const;
 
     /// Checks if given part already belongs destination disk or volume for the
     /// TTL rule.

--- a/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -237,7 +237,7 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataWriter::writeTempPart(BlockWithPa
         updateTTL(ttl_entry, move_ttl_infos, move_ttl_infos.moves_ttl[ttl_entry.result_column], block, false);
 
     NamesAndTypesList columns = metadata_snapshot->getColumns().getAllPhysical().filter(block.getNames());
-    ReservationPtr reservation = data.reserveSpacePreferringTTLRules(expected_size, move_ttl_infos, time(nullptr));
+    ReservationPtr reservation = data.reserveSpacePreferringTTLRules(expected_size, move_ttl_infos, time(nullptr), true);
     VolumePtr volume = data.getStoragePolicy()->getVolume(0);
 
     auto new_data_part = data.createPart(

--- a/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -237,7 +237,7 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataWriter::writeTempPart(BlockWithPa
         updateTTL(ttl_entry, move_ttl_infos, move_ttl_infos.moves_ttl[ttl_entry.result_column], block, false);
 
     NamesAndTypesList columns = metadata_snapshot->getColumns().getAllPhysical().filter(block.getNames());
-    ReservationPtr reservation = data.reserveSpacePreferringTTLRules(expected_size, move_ttl_infos, time(nullptr), true);
+    ReservationPtr reservation = data.reserveSpacePreferringTTLRules(expected_size, move_ttl_infos, time(nullptr), 0, true);
     VolumePtr volume = data.getStoragePolicy()->getVolume(0);
 
     auto new_data_part = data.createPart(

--- a/src/Storages/MergeTree/MergeTreePartsMover.cpp
+++ b/src/Storages/MergeTree/MergeTreePartsMover.cpp
@@ -136,9 +136,9 @@ bool MergeTreePartsMover::selectPartsForMove(
         ReservationPtr reservation;
         if (ttl_entry)
         {
-            auto destination = data->getDestinationForTTL(*ttl_entry);
+            auto destination = data->getDestinationForMoveTTL(*ttl_entry);
             if (destination && !data->isPartInTTLDestination(*ttl_entry, *part))
-                reservation = data->tryReserveSpace(part->getBytesOnDisk(), data->getDestinationForTTL(*ttl_entry));
+                reservation = data->tryReserveSpace(part->getBytesOnDisk(), data->getDestinationForMoveTTL(*ttl_entry));
         }
 
         if (reservation) /// Found reservation by TTL rule.

--- a/tests/integration/test_ttl_move/configs/config.d/storage_configuration.xml
+++ b/tests/integration/test_ttl_move/configs/config.d/storage_configuration.xml
@@ -83,6 +83,18 @@
                 </main>
             </volumes>
         </only_jbod2>
+
+        <jbod_without_instant_ttl_move>
+            <volumes>
+                <main>
+                    <disk>jbod1</disk>
+                </main>
+                <external>
+                    <disk>external</disk>
+                    <perform_ttl_move_on_insert>false</perform_ttl_move_on_insert>
+                </external>
+            </volumes>
+        </jbod_without_instant_ttl_move>
     </policies>
 
 </storage_configuration>

--- a/tests/integration/test_ttl_move/configs/config.d/storage_configuration.xml
+++ b/tests/integration/test_ttl_move/configs/config.d/storage_configuration.xml
@@ -88,6 +88,7 @@
             <volumes>
                 <main>
                     <disk>jbod1</disk>
+                    <disk>jbod2</disk>
                 </main>
                 <external>
                     <disk>external</disk>

--- a/tests/integration/test_ttl_move/configs/config.d/storage_configuration.xml
+++ b/tests/integration/test_ttl_move/configs/config.d/storage_configuration.xml
@@ -88,7 +88,6 @@
             <volumes>
                 <main>
                     <disk>jbod1</disk>
-                    <disk>jbod2</disk>
                 </main>
                 <external>
                     <disk>external</disk>

--- a/tests/integration/test_ttl_move/test.py
+++ b/tests/integration/test_ttl_move/test.py
@@ -1113,6 +1113,7 @@ limitations under the License."""
 def test_disabled_ttl_move_on_insert(started_cluster, name, dest_type, engine):
     try:
         node1.query("SYSTEM STOP MOVES")
+        node2.query("SYSTEM STOP MOVES")
 
         node1.query("""
             CREATE TABLE {name} (
@@ -1132,14 +1133,15 @@ def test_disabled_ttl_move_on_insert(started_cluster, name, dest_type, engine):
         node1.query("INSERT INTO {} (s1, d1) VALUES {}".format(name, ",".join(["(" + ",".join(x) + ")" for x in data])))
 
         used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == "jbod1"
+        assert set(used_disks) == {"jbod1"}
         assert node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "10"
 
         node1.query("SYSTEM START MOVES")
+        node2.query("SYSTEM START MOVES")
         time.sleep(3)
 
         used_disks = get_used_disks_for_table(node1, name)
-        assert set(used_disks) == "external"
+        assert set(used_disks) == {"external"}
         assert node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "10"
 
     finally:

--- a/tests/integration/test_ttl_move/test.py
+++ b/tests/integration/test_ttl_move/test.py
@@ -1135,7 +1135,7 @@ def test_disabled_ttl_move_on_insert(started_cluster, name, dest_type, engine):
         assert set(used_disks) == {"jbod1"}
         assert node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "10"
 
-        node1.query("SYSTEM START MOVES {}").format(name)
+        node1.query("SYSTEM START MOVES {}".format(name))
         time.sleep(3)
 
         used_disks = get_used_disks_for_table(node1, name)

--- a/tests/integration/test_ttl_move/test.py
+++ b/tests/integration/test_ttl_move/test.py
@@ -1102,3 +1102,48 @@ limitations under the License."""
 
     finally:
         node1.query("DROP TABLE IF EXISTS {name} NO DELAY".format(name=name))
+
+
+@pytest.mark.parametrize("name,dest_type,engine", [
+    ("mt_test_disabled_ttl_move_on_insert_work", "DISK", "MergeTree()"),
+    ("mt_test_disabled_ttl_move_on_insert_work", "VOLUME", "MergeTree()"),
+    ("replicated_mt_test_disabled_ttl_move_on_insert_work", "DISK", "ReplicatedMergeTree('/clickhouse/replicated_test_disabled_ttl_move_on_insert_work', '1')"),
+    ("replicated_mt_test_disabled_ttl_move_on_insert_work", "VOLUME", "ReplicatedMergeTree('/clickhouse/replicated_test_disabled_ttl_move_on_insert_work', '1')"),
+])
+def test_disabled_ttl_move_on_insert(started_cluster, name, dest_type, engine):
+    try:
+        node1.query("SYSTEM STOP MOVES")
+
+        node1.query("""
+            CREATE TABLE {name} (
+                s1 String,
+                d1 DateTime
+            ) ENGINE = {engine}
+            ORDER BY tuple()
+            TTL d1 TO {dest_type} 'external'
+            SETTINGS storage_policy='jbod_without_instant_ttl_move'
+        """.format(name=name, dest_type=dest_type, engine=engine))
+
+        data = []  # 10MB in total
+        for i in range(10):
+            data.append(("'{}'".format(get_random_string(1024 * 1024)), "toDateTime({})".format(
+                time.time() - 1)))  # 1MB row
+
+        node1.query("INSERT INTO {} (s1, d1) VALUES {}".format(name, ",".join(["(" + ",".join(x) + ")" for x in data])))
+
+        used_disks = get_used_disks_for_table(node1, name)
+        assert set(used_disks) == "jbod1"
+        assert node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "10"
+
+        node1.query("SYSTEM START MOVES")
+        time.sleep(3)
+
+        used_disks = get_used_disks_for_table(node1, name)
+        assert set(used_disks) == "external"
+        assert node1.query("SELECT count() FROM {name}".format(name=name)).strip() == "10"
+
+    finally:
+        try:
+            node1.query("DROP TABLE IF EXISTS {} NO DELAY".format(name))
+        except:
+            pass


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add option to disable TTL move on data part insert

Detailed description / Documentation draft:
At the moment if we insert a data part that already expired by the TTL move rule it immediately goes to a volume/disk declared in move rule. This can significantly slowdown insert in case if destination volume/disk is slow (e.g. S3). This behaviour should be controlled by a special option declared at destination volume section.