### PR TITLE
Drop python from build dependencies (fixes building deb package on debian:testing)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,6 @@ Build-Depends: debhelper (>= 9),
                libicu-dev,
                libreadline-dev,
                gperf,
-               python,
                tzdata
 Standards-Version: 3.9.8
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Drop python from build dependencies (fixes building deb package on debian:testing)

Detailed description / Documentation draft:
I don't see where it can be required.
And plus there is no python package in debian:testing anymore, only:
- python2
- python3
So that said that you cannot build debian package on debian:testing
anymore (but debian:stable don't have gcc9 for example).

Everything would be great, if there will be packages for python2, i.e.
python2-lxml, but there isn't, I guess because python2 had been
deprecated long time ago...
So it looks like converting to python3 is coming.

Just for the history, now it is:
- debian:stable -> buster
- debian:testing -> bullseye

Added in: #5368
Cc: @proller (hm, but looks like he is inactive right now)