### PR TITLE
Fix EINVAL in renameat2 on MacOS

### DIFF
--- a/src/Common/renameat2.cpp
+++ b/src/Common/renameat2.cpp
@@ -48,8 +48,10 @@ static bool supportsRenameat2Impl()
 
 #if defined(__NR_renameat2)
 
-static void renameat2(const std::string & old_path, const std::string & new_path, int flags)
+static bool renameat2(const std::string & old_path, const std::string & new_path, int flags)
 {
+    if(!supportsRenameat2())
+        return false;
     if (old_path.empty() || new_path.empty())
         throw Exception("Cannot rename " + old_path + " to " + new_path + ": path is empty", ErrorCodes::LOGICAL_ERROR);
 
@@ -57,7 +59,14 @@ static void renameat2(const std::string & old_path, const std::string & new_path
     /// int newdirfd (ignored for absolute newpath), const char *newpath,
     /// unsigned int flags
     if (0 == syscall(__NR_renameat2, AT_FDCWD, old_path.c_str(), AT_FDCWD, new_path.c_str(), flags))
-        return;
+        return true;
+
+    /// EINVAL means that filesystem does not support one of the flags.
+    /// It also may happen when running clickhouse in docker with Mac OS as a host OS.
+    /// supportsRenameat2() with uname is not enough in this case, because virtualized Linux kernel is used.
+    /// Other cases when EINVAL can be returned should never happen.
+    if (errno == EINVAL)
+        return false;
 
     if (errno == EEXIST)
         throwFromErrno("Cannot rename " + old_path + " to " + new_path + " because the second path already exists", ErrorCodes::ATOMIC_RENAME_FAIL);
@@ -104,18 +113,19 @@ bool supportsRenameat2()
 
 void renameNoReplace(const std::string & old_path, const std::string & new_path)
 {
-    if (supportsRenameat2())
-        renameat2(old_path, new_path, RENAME_NOREPLACE);
-    else
+    if (!renameat2(old_path, new_path, RENAME_NOREPLACE))
         renameNoReplaceFallback(old_path, new_path);
 }
 
 void renameExchange(const std::string & old_path, const std::string & new_path)
 {
-    if (supportsRenameat2())
-        renameat2(old_path, new_path, RENAME_EXCHANGE);
-    else
+    if (!renameat2(old_path, new_path, RENAME_EXCHANGE))
         renameExchangeFallback(old_path, new_path);
+}
+
+bool renameExchangeIfSupported(const std::string & old_path, const std::string & new_path)
+{
+    return renameat2(old_path, new_path, RENAME_EXCHANGE);
 }
 
 }

--- a/src/Common/renameat2.cpp
+++ b/src/Common/renameat2.cpp
@@ -50,7 +50,7 @@ static bool supportsRenameat2Impl()
 
 static bool renameat2(const std::string & old_path, const std::string & new_path, int flags)
 {
-    if(!supportsRenameat2())
+    if (!supportsRenameat2())
         return false;
     if (old_path.empty() || new_path.empty())
         throw Exception("Cannot rename " + old_path + " to " + new_path + ": path is empty", ErrorCodes::LOGICAL_ERROR);

--- a/src/Common/renameat2.cpp
+++ b/src/Common/renameat2.cpp
@@ -79,10 +79,9 @@ static bool renameat2(const std::string & old_path, const std::string & new_path
 #define RENAME_NOREPLACE -1
 #define RENAME_EXCHANGE -1
 
-[[noreturn]]
-static void renameat2(const std::string &, const std::string &, int)
+static bool renameat2(const std::string &, const std::string &, int)
 {
-    throw Exception("Compiled without renameat2() support", ErrorCodes::UNSUPPORTED_METHOD);
+    return false
 }
 
 #endif

--- a/src/Common/renameat2.cpp
+++ b/src/Common/renameat2.cpp
@@ -81,7 +81,7 @@ static bool renameat2(const std::string & old_path, const std::string & new_path
 
 static bool renameat2(const std::string &, const std::string &, int)
 {
-    return false
+    return false;
 }
 
 #endif

--- a/src/Common/renameat2.h
+++ b/src/Common/renameat2.h
@@ -14,4 +14,7 @@ void renameNoReplace(const std::string & old_path, const std::string & new_path)
 /// Atomically exchange oldpath and newpath. Throw exception if some of them does not exist
 void renameExchange(const std::string & old_path, const std::string & new_path);
 
+/// Returns false instead of throwing exception if renameat2 is not supported
+bool renameExchangeIfSupported(const std::string & old_path, const std::string & new_path);
+
 }

--- a/src/Databases/DatabaseAtomic.cpp
+++ b/src/Databases/DatabaseAtomic.cpp
@@ -277,7 +277,7 @@ void DatabaseAtomic::commitCreateTable(const ASTCreateQuery & query, const Stora
 
 void DatabaseAtomic::commitAlterTable(const StorageID & table_id, const String & table_metadata_tmp_path, const String & table_metadata_path)
 {
-    bool check_file_exists = supportsRenameat2();
+    bool check_file_exists = true;
     SCOPE_EXIT({ std::error_code code; if (check_file_exists) std::filesystem::remove(table_metadata_tmp_path, code); });
 
     std::unique_lock lock{mutex};
@@ -286,9 +286,8 @@ void DatabaseAtomic::commitAlterTable(const StorageID & table_id, const String &
     if (table_id.uuid != actual_table_id.uuid)
         throw Exception("Cannot alter table because it was renamed", ErrorCodes::CANNOT_ASSIGN_ALTER);
 
-    if (check_file_exists)
-        renameExchange(table_metadata_tmp_path, table_metadata_path);
-    else
+    check_file_exists = renameExchangeIfSupported(table_metadata_tmp_path, table_metadata_path);
+    if (!check_file_exists)
         std::filesystem::rename(table_metadata_tmp_path, table_metadata_path);
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed `Cannot rename ... errno: 22, strerror: Invalid argument` error on DDL query execution in Atomic database when running clickhouse-server in docker on Mac OS

Fixes #14865
