### PR TITLE
Fix buffer overflow in "bar" function

### DIFF
--- a/src/Common/UnicodeBar.cpp
+++ b/src/Common/UnicodeBar.cpp
@@ -1,0 +1,70 @@
+#include <cstring>
+#include <cmath>
+#include <string>
+#include <common/types.h>
+#include <common/arithmeticOverflow.h>
+#include <Common/Exception.h>
+#include <Common/UnicodeBar.h>
+
+
+namespace DB
+{
+    namespace ErrorCodes
+    {
+        extern const int PARAMETER_OUT_OF_BOUND;
+    }
+}
+
+
+namespace UnicodeBar
+{
+    double getWidth(Int64 x, Int64 min, Int64 max, double max_width)
+    {
+        if (x <= min)
+            return 0;
+
+        if (x >= max)
+            return max_width;
+
+        /// The case when max - min overflows
+        Int64 max_difference;
+        if (common::subOverflow(max, min, max_difference))
+            throw DB::Exception(DB::ErrorCodes::PARAMETER_OUT_OF_BOUND, "The arguments to render unicode bar will lead to arithmetic overflow");
+
+        return (x - min) * max_width / max_difference;
+    }
+
+    size_t getWidthInBytes(double width)
+    {
+        return ceil(width - 1.0 / 8) * UNICODE_BAR_CHAR_SIZE;
+    }
+
+    void render(double width, char * dst)
+    {
+        size_t floor_width = floor(width);
+
+        for (size_t i = 0; i < floor_width; ++i)
+        {
+            memcpy(dst, "█", UNICODE_BAR_CHAR_SIZE);
+            dst += UNICODE_BAR_CHAR_SIZE;
+        }
+
+        size_t remainder = floor((width - floor_width) * 8);
+
+        if (remainder)
+        {
+            memcpy(dst, &"▏▎▍▌▋▋▊▉"[(remainder - 1) * UNICODE_BAR_CHAR_SIZE], UNICODE_BAR_CHAR_SIZE);
+            dst += UNICODE_BAR_CHAR_SIZE;
+        }
+
+        *dst = 0;
+    }
+
+    std::string render(double width)
+    {
+        std::string res(getWidthInBytes(width), '\0');
+        render(width, res.data());
+        return res;
+    }
+}
+

--- a/src/Common/UnicodeBar.h
+++ b/src/Common/UnicodeBar.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <cstring>
-#include <cmath>
 #include <string>
 #include <common/types.h>
 
@@ -10,54 +8,12 @@
 
 /** Allows you to draw a unicode-art bar whose width is displayed with a resolution of 1/8 character.
   */
-
-
 namespace UnicodeBar
 {
-    using DB::Int64;
-
-    inline double getWidth(Int64 x, Int64 min, Int64 max, double max_width)
-    {
-        if (x <= min)
-            return 0;
-
-        if (x >= max)
-            return max_width;
-
-        return (x - min) * max_width / (max - min);
-    }
-
-    inline size_t getWidthInBytes(double width)
-    {
-        return ceil(width - 1.0 / 8) * UNICODE_BAR_CHAR_SIZE;
-    }
+    double getWidth(Int64 x, Int64 min, Int64 max, double max_width);
+    size_t getWidthInBytes(double width);
 
     /// In `dst` there must be a space for barWidthInBytes(width) characters and a trailing zero.
-    inline void render(double width, char * dst)
-    {
-        size_t floor_width = floor(width);
-
-        for (size_t i = 0; i < floor_width; ++i)
-        {
-            memcpy(dst, "█", UNICODE_BAR_CHAR_SIZE);
-            dst += UNICODE_BAR_CHAR_SIZE;
-        }
-
-        size_t remainder = floor((width - floor_width) * 8);
-
-        if (remainder)
-        {
-            memcpy(dst, &"▏▎▍▌▋▋▊▉"[(remainder - 1) * UNICODE_BAR_CHAR_SIZE], UNICODE_BAR_CHAR_SIZE);
-            dst += UNICODE_BAR_CHAR_SIZE;
-        }
-
-        *dst = 0;
-    }
-
-    inline std::string render(double width)
-    {
-        std::string res(getWidthInBytes(width), '\0');
-        render(width, res.data());
-        return res;
-    }
+    void render(double width, char * dst);
+    std::string render(double width);
 }

--- a/src/Common/ya.make
+++ b/src/Common/ya.make
@@ -99,6 +99,7 @@ SRCS(
     ThreadProfileEvents.cpp
     ThreadStatus.cpp
     TraceCollector.cpp
+    UnicodeBar.cpp
     UTF8Helpers.cpp
     WeakHash.cpp
     ZooKeeper/IKeeper.cpp

--- a/tests/queries/0_stateless/01502_bar_overflow.sql
+++ b/tests/queries/0_stateless/01502_bar_overflow.sql
@@ -1,0 +1,1 @@
+SELECT bar((greatCircleAngle(100, -1, number, number) - number) * 2, -9223372036854775808, 1023, 100) FROM numbers(1048575); -- { serverError 12 }


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
If function `bar` was called with specifically crafted arguments, buffer overflow was possible. This closes #13926.