### PR TITLE
Proper exception message for wrong number of arguments of CAST

### DIFF
--- a/src/Interpreters/OptimizeIfWithConstantConditionVisitor.cpp
+++ b/src/Interpreters/OptimizeIfWithConstantConditionVisitor.cpp
@@ -33,6 +33,9 @@ static bool tryExtractConstValueFromCondition(const ASTPtr & condition, bool & v
         {
             if (const auto * expr_list = function->arguments->as<ASTExpressionList>())
             {
+                if (expr_list->children.size() != 2)
+                    throw Exception("Function CAST must have exactly two arguments", ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
+
                 const ASTPtr & type_ast = expr_list->children.at(1);
                 if (const auto * type_literal = type_ast->as<ASTLiteral>())
                 {

--- a/tests/queries/0_stateless/01503_if_const_optimization.sql
+++ b/tests/queries/0_stateless/01503_if_const_optimization.sql
@@ -1,0 +1,1 @@
+SELECT if(CAST(NULL), '2.55', NULL) AS x; -- { serverError 42 }


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Proper exception message for wrong number of arguments of CAST. This closes #13992 
