### PR TITLE
Maybe fix MSan report in base64

### DIFF
--- a/src/Functions/FunctionBase64Conversion.h
+++ b/src/Functions/FunctionBase64Conversion.h
@@ -4,6 +4,7 @@
 
 #if USE_BASE64
 #    include <Columns/ColumnConst.h>
+#    include <Common/MemorySanitizer.h>
 #    include <Columns/ColumnString.h>
 #    include <DataTypes/DataTypeString.h>
 #    include <Functions/FunctionFactory.h>
@@ -150,6 +151,10 @@ public:
                     }
                 }
             }
+
+            /// Base64 library is using AVX-512 with some shuffle operations.
+            /// Memory sanitizer don't understand if there was uninitialized memory in SIMD register but it was not used in the result of shuffle.
+            __msan_unpoison(dst_pos, outlen);
 
             source += srclen + 1;
             dst_pos += outlen + 1;


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Maybe fix MSan report in base64 (on servers with AVX-512). This fixes #14006