### PR TITLE
Improve performance of grouping by single LowCardinality(FixedString)

### DIFF
--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -367,6 +367,14 @@ AggregatedDataVariants::Type Aggregator::chooseAggregationMethod()
         throw Exception("Logical error: numeric column has sizeOfField not in 1, 2, 4, 8, 16, 32.", ErrorCodes::LOGICAL_ERROR);
     }
 
+    if (params.keys_size == 1 && isFixedString(types_removed_nullable[0]))
+    {
+        if (has_low_cardinality)
+            return AggregatedDataVariants::Type::low_cardinality_key_fixed_string;
+        else
+            return AggregatedDataVariants::Type::key_fixed_string;
+    }
+
     /// If all keys fits in N bits, will use hash table with all keys packed (placed contiguously) to single N-bit key.
     if (params.keys_size == num_fixed_contiguous_keys)
     {
@@ -397,14 +405,6 @@ AggregatedDataVariants::Type Aggregator::chooseAggregationMethod()
             return AggregatedDataVariants::Type::low_cardinality_key_string;
         else
             return AggregatedDataVariants::Type::key_string;
-    }
-
-    if (params.keys_size == 1 && isFixedString(types_removed_nullable[0]))
-    {
-        if (has_low_cardinality)
-            return AggregatedDataVariants::Type::low_cardinality_key_fixed_string;
-        else
-            return AggregatedDataVariants::Type::key_fixed_string;
     }
 
     return AggregatedDataVariants::Type::serialized;

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -228,7 +228,7 @@ struct AggregationMethodString
 
     static void insertKeyIntoColumns(const StringRef & key, MutableColumns & key_columns, const Sizes &)
     {
-        key_columns[0]->insertData(key.data, key.size);
+        static_cast<ColumnString *>(key_columns[0].get())->insertData(key.data, key.size);
     }
 };
 
@@ -254,7 +254,7 @@ struct AggregationMethodStringNoCache
 
     static void insertKeyIntoColumns(const StringRef & key, MutableColumns & key_columns, const Sizes &)
     {
-        key_columns[0]->insertData(key.data, key.size);
+        static_cast<ColumnString *>(key_columns[0].get())->insertData(key.data, key.size);
     }
 };
 
@@ -280,7 +280,7 @@ struct AggregationMethodFixedString
 
     static void insertKeyIntoColumns(const StringRef & key, MutableColumns & key_columns, const Sizes &)
     {
-        key_columns[0]->insertData(key.data, key.size);
+        static_cast<ColumnFixedString *>(key_columns[0].get())->insertData(key.data, key.size);
     }
 };
 
@@ -305,7 +305,7 @@ struct AggregationMethodFixedStringNoCache
 
     static void insertKeyIntoColumns(const StringRef & key, MutableColumns & key_columns, const Sizes &)
     {
-        key_columns[0]->insertData(key.data, key.size);
+        static_cast<ColumnFixedString *>(key_columns[0].get())->insertData(key.data, key.size);
     }
 };
 

--- a/tests/performance/single_fixed_string_groupby.xml
+++ b/tests/performance/single_fixed_string_groupby.xml
@@ -10,8 +10,8 @@
         INSERT INTO perf_lc_fixed_str_groupby SELECT ('number key ' || toString(number % 400)) AS a, ('number key ' || toString(number % 20)) AS b FROM numbers(30000000)
     </fill_query>
 
-    <query>SELECT count() FROM perf_lc_fixed_str_groupby GROUP BY a</query>
-    <query>SELECT count() FROM perf_lc_fixed_str_groupby GROUP BY b</query>
+    <query short="1">SELECT count() FROM perf_lc_fixed_str_groupby GROUP BY a</query>
+    <query short="1">SELECT count() FROM perf_lc_fixed_str_groupby GROUP BY b</query>
 
     <drop_query>DROP TABLE IF EXISTS perf_lc_fixed_str_groupby</drop_query>
 </test>

--- a/tests/performance/single_fixed_string_groupby.xml
+++ b/tests/performance/single_fixed_string_groupby.xml
@@ -1,0 +1,17 @@
+<test max_ignored_relative_change="0.2">
+    <create_query>DROP TABLE IF EXISTS perf_lc_fixed_str_groupby</create_query>
+    <create_query>CREATE TABLE perf_lc_fixed_str_groupby(
+            a LowCardinality(FixedString(14)),
+            b LowCardinality(FixedString(14))
+        ) ENGINE MergeTree ORDER BY tuple()
+    </create_query>
+
+    <fill_query>
+        INSERT INTO perf_lc_fixed_str_groupby SELECT ('number key ' || toString(number % 400)) AS a, ('number key ' || toString(number % 20)) AS b FROM numbers(30000000)
+    </fill_query>
+
+    <query>SELECT count() FROM perf_lc_fixed_str_groupby GROUP BY a</query>
+    <query>SELECT count() FROM perf_lc_fixed_str_groupby GROUP BY b</query>
+
+    <drop_query>DROP TABLE IF EXISTS perf_lc_fixed_str_groupby</drop_query>
+</test>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

We used to choose fixed key method to group by one fixed string. It's unnecessary since we have StringHashTable which do the similar packedFix optimization for FixedString columns. And we should use low_cardinality_key_fixed_string if possible.



Detailed description / Documentation draft:

This issue is raised by https://github.com/ClickHouse/ClickHouse/issues/15005 (a valid test case via SSB). 

A similar benchmark is setup just like the author did in the above issue. There is significant improvement over LowCardinality(FixedString) column.

![image](https://user-images.githubusercontent.com/5085485/93706072-58dea680-fb55-11ea-82ee-d04523e62482.png)
