### PR TITLE
Proper initialize wide_integer

### DIFF
--- a/base/common/wide_integer.h
+++ b/base/common/wide_integer.h
@@ -127,7 +127,7 @@ private:
     friend class std::numeric_limits<integer<Bits, signed>>;
     friend class std::numeric_limits<integer<Bits, unsigned>>;
 
-    base_type items[_impl::item_count];
+    base_type items[_impl::item_count]{};
 };
 
 template <typename T>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Or else compiler (gcc 9.3.0) complains with
```
wide_integer.h:54:7: note: 'class wide::integer<256, unsigned int>' has no user-provided default constructor
   54 | class integer
      |       ^~~~~~~
wide_integer.h:61:5: note: constructor is not user-provided because it is explicitly defaulted in the class body
   61 |     integer() = default;
      |     ^~~~~~~
wide_integer.h:130:15: note: and the implicitly-defined constructor does not initialize 'wide::integer<256, unsigned int>::base_type wide::integer<256, unsigned int>::items [4]'
  130 |     base_type items[_impl::item_count];
      |               ^~~~~
```

Detailed description / Documentation draft:
Null
