### PR TITLE
Fix data race when using DatabaseMemory::getCreateTableQueryImpl(...)

### DIFF
--- a/src/Databases/DatabaseMemory.cpp
+++ b/src/Databases/DatabaseMemory.cpp
@@ -75,7 +75,7 @@ ASTPtr DatabaseMemory::getCreateTableQueryImpl(const String & table_name, const 
         else
             return {};
     }
-    return it->second;
+    return it->second->clone();
 }
 
 UUID DatabaseMemory::tryGetTableUUID(const String & table_name) const


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Not for changelog
