### PR TITLE
Don't hide interface symbols

### DIFF
--- a/src/Functions/GatherUtils/IArraySink.h
+++ b/src/Functions/GatherUtils/IArraySink.h
@@ -13,7 +13,6 @@ namespace ErrorCodes
 
 namespace GatherUtils
 {
-#pragma GCC visibility push(hidden)
 
 struct IArraySink
 {
@@ -24,6 +23,8 @@ struct IArraySink
         throw Exception("Accept not implemented for " + demangle(typeid(*this).name()), ErrorCodes::NOT_IMPLEMENTED);
     }
 };
+
+#pragma GCC visibility push(hidden)
 
 template <typename Derived>
 class ArraySinkImpl : public Visitable<Derived, IArraySink, ArraySinkVisitor> {};

--- a/src/Functions/GatherUtils/IArraySource.h
+++ b/src/Functions/GatherUtils/IArraySource.h
@@ -13,7 +13,6 @@ namespace ErrorCodes
 
 namespace GatherUtils
 {
-#pragma GCC visibility push(hidden)
 
 struct IArraySource
 {
@@ -30,6 +29,8 @@ struct IArraySource
         throw Exception("Accept not implemented for " + demangle(typeid(*this).name()), ErrorCodes::NOT_IMPLEMENTED);
     }
 };
+
+#pragma GCC visibility push(hidden)
 
 template <typename Derived>
 class ArraySourceImpl : public Visitable<Derived, IArraySource, ArraySourceVisitor> {};

--- a/src/Functions/GatherUtils/IValueSource.h
+++ b/src/Functions/GatherUtils/IValueSource.h
@@ -13,7 +13,6 @@ namespace ErrorCodes
 
 namespace GatherUtils
 {
-#pragma GCC visibility push(hidden)
 
 struct IValueSource
 {
@@ -26,6 +25,8 @@ struct IValueSource
 
     virtual bool isConst() const { return false; }
 };
+
+#pragma GCC visibility push(hidden)
 
 template <typename Derived>
 class ValueSourceImpl : public Visitable<Derived, IValueSource, ValueSourceVisitor> {};


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Don't hide interface symbols. Newer linkers might optimize away related functions which containing those interface types as arguments. 

cc @KochetovNicolai 


Detailed description / Documentation draft:

None.