### PR TITLE
Support multi zookeeper clusters

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1485,7 +1485,7 @@ DDLWorker & Context::getDDLWorker() const
 zkutil::ZooKeeperPtr Context::getZooKeeper() const
 {
     std::lock_guard lock(shared->zookeeper_mutex);
- 
+
     const auto & config = shared->zookeeper_config ? *shared->zookeeper_config : getConfigRef();
     if (!shared->zookeeper)
         shared->zookeeper = std::make_shared<zkutil::ZooKeeper>(config, "zookeeper");

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1485,7 +1485,7 @@ DDLWorker & Context::getDDLWorker() const
 zkutil::ZooKeeperPtr Context::getZooKeeper() const
 {
     std::lock_guard lock(shared->zookeeper_mutex);
-
+ 
     const auto & config = shared->zookeeper_config ? *shared->zookeeper_config : getConfigRef();
     if (!shared->zookeeper)
         shared->zookeeper = std::make_shared<zkutil::ZooKeeper>(config, "zookeeper");
@@ -1519,15 +1519,10 @@ zkutil::ZooKeeperPtr Context::getAuxiliaryZooKeeper(const String & name) const
     return zookeeper->second;
 }
 
-void Context::resetZooKeeper(const std::string & name) const
+void Context::resetZooKeeper() const
 {
     std::lock_guard lock(shared->zookeeper_mutex);
-    auto zookeeper = shared->zookeepers.find(name);
-    if (zookeeper == shared->zookeepers.end())
-    {
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown ZooKeeper name '{}'.", name);
-    }
-    zookeeper->second.reset();
+    shared->zookeeper.reset();
 }
 
 static void reloadZooKeeperIfChangedImpl(const ConfigurationPtr & config, const std::string & config_name, zkutil::ZooKeeperPtr & zk)
@@ -1563,23 +1558,8 @@ void Context::reloadAuxiliaryZooKeepersConfigIfChanged(const ConfigurationPtr & 
 
 
 bool Context::hasZooKeeper() const
-=======
-    if (config->has("zookeeper"))
-    {
-        auto zookeeper = shared->zookeepers.find("default");
-        if (zookeeper != shared->zookeepers.end())
-            zookeeper->second->configChanged(*config, "zookeeper");
-    }
-    for (auto & zookeeper : shared->zookeepers)
-    {
-         zookeeper.second->configChanged(*config, "zookeepers.");
-    }
-}
-
-bool Context::hasZooKeeper(const std::string & name) const
->>>>>>> Support multi zookeeper clusters
 {
-    return getConfigRef().has("zookeepers." + name) || (name == "default" && getConfigRef().has("zookeeper"));
+    return getConfigRef().has("zookeeper");
 }
 
 

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -484,16 +484,16 @@ public:
 
     /// If the current session is expired at the time of the call, synchronously creates and returns a new session with the startNewSession() call.
     /// If no ZooKeeper configured, throws an exception.
-    std::shared_ptr<zkutil::ZooKeeper> getZooKeeper() const;
+    std::shared_ptr<zkutil::ZooKeeper> getZooKeeper(const std::string & name = "default") const;
     /// Same as above but return a zookeeper connection from auxiliary_zookeepers configuration entry.
     std::shared_ptr<zkutil::ZooKeeper> getAuxiliaryZooKeeper(const String & name) const;
 
     /// Set auxiliary zookeepers configuration at server starting or configuration reloading.
     void reloadAuxiliaryZooKeepersConfigIfChanged(const ConfigurationPtr & config);
     /// Has ready or expired ZooKeeper
-    bool hasZooKeeper() const;
+    bool hasZooKeeper(const std::string & name = "default") const;
     /// Reset current zookeeper session. Do not create a new one.
-    void resetZooKeeper() const;
+    void resetZooKeeper(const std::string & name = "default") const;
     // Reload Zookeeper
     void reloadZooKeeperIfChanged(const ConfigurationPtr & config) const;
 

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -484,16 +484,16 @@ public:
 
     /// If the current session is expired at the time of the call, synchronously creates and returns a new session with the startNewSession() call.
     /// If no ZooKeeper configured, throws an exception.
-    std::shared_ptr<zkutil::ZooKeeper> getZooKeeper(const std::string & name = "default") const;
+    std::shared_ptr<zkutil::ZooKeeper> getZooKeeper() const;
     /// Same as above but return a zookeeper connection from auxiliary_zookeepers configuration entry.
     std::shared_ptr<zkutil::ZooKeeper> getAuxiliaryZooKeeper(const String & name) const;
 
     /// Set auxiliary zookeepers configuration at server starting or configuration reloading.
     void reloadAuxiliaryZooKeepersConfigIfChanged(const ConfigurationPtr & config);
     /// Has ready or expired ZooKeeper
-    bool hasZooKeeper(const std::string & name = "default") const;
+    bool hasZooKeeper() const;
     /// Reset current zookeeper session. Do not create a new one.
-    void resetZooKeeper(const std::string & name = "default") const;
+    void resetZooKeeper() const;
     // Reload Zookeeper
     void reloadZooKeeperIfChanged(const ConfigurationPtr & config) const;
 

--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -83,7 +83,8 @@ void ReplicatedMergeTreeRestartingThread::run()
             {
                 try
                 {
-                    storage.setZooKeeper(storage.global_context.getZooKeeper());
+                    auto zookeeper_cluster_name = storage.getZooKeeperClusterName();
+                    storage.setZooKeeper(storage.global_context.getZooKeeper(zookeeper_cluster_name));
                 }
                 catch (const Coordination::Exception &)
                 {

--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -83,8 +83,7 @@ void ReplicatedMergeTreeRestartingThread::run()
             {
                 try
                 {
-                    auto zookeeper_cluster_name = storage.getZooKeeperClusterName();
-                    storage.setZooKeeper(storage.global_context.getZooKeeper(zookeeper_cluster_name));
+                    storage.setZooKeeper();
                 }
                 catch (const Coordination::Exception &)
                 {

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -756,9 +756,7 @@ static StoragePtr create(const StorageFactory::Arguments & args)
 
     if (replicated)
     {
-        auto zookeeper_cluster = storage_settings->zookeeper_cluster;
         return StorageReplicatedMergeTree::create(
-            zookeeper_cluster,
             zookeeper_path,
             replica_name,
             args.attach,

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -769,7 +769,8 @@ static StoragePtr create(const StorageFactory::Arguments & args)
             date_column_name,
             merging_params,
             std::move(storage_settings),
-            args.has_force_restore_data_flag);
+            args.has_force_restore_data_flag,
+            allow_renaming);
     }
     else
         return StorageMergeTree::create(

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -755,7 +755,10 @@ static StoragePtr create(const StorageFactory::Arguments & args)
         throw Exception("Wrong number of engine arguments.", ErrorCodes::BAD_ARGUMENTS);
 
     if (replicated)
+    {
+        auto zookeeper_cluster = storage_settings->zookeeper_cluster;
         return StorageReplicatedMergeTree::create(
+            zookeeper_cluster,
             zookeeper_path,
             replica_name,
             args.attach,
@@ -766,8 +769,8 @@ static StoragePtr create(const StorageFactory::Arguments & args)
             date_column_name,
             merging_params,
             std::move(storage_settings),
-            args.has_force_restore_data_flag,
-            allow_renaming);
+            args.has_force_restore_data_flag);
+    }
     else
         return StorageMergeTree::create(
             args.table_id,

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -260,7 +260,7 @@ StorageReplicatedMergeTree::StorageReplicatedMergeTree(
     {
         /// It's possible for getZooKeeper()/getAuxiliaryZookeeper() to timeout
         /// if  zookeeper host(s) can't be reached. In such cases Poco::Exception
-        /// is thrown after a connection timeout 
+        /// is thrown after a connection timeout
         /// - refer to src/Common/ZooKeeper/ZooKeeperImpl.cpp:866 for more info.
         ///
         /// Side effect of this is that the CreateQuery gets interrupted and it exits.

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -158,6 +158,7 @@ public:
         bool is_session_expired;
         ReplicatedMergeTreeQueue::Status queue;
         UInt32 parts_to_check;
+        String zookeeper_cluster;
         String zookeeper_path;
         String replica_name;
         String replica_path;
@@ -208,7 +209,6 @@ public:
     /// Checks that fetches are not disabled with action blocker and pool for fetches
     /// is not overloaded
     bool canExecuteFetch(const ReplicatedMergeTreeLogEntry & entry, String & disable_reason) const;
-
 private:
 
     /// Get a sequential consistent view of current parts.
@@ -242,6 +242,7 @@ private:
     /// If false - ZooKeeper is available, but there is no table metadata. It's safe to drop table in this case.
     bool has_metadata_in_zookeeper = true;
 
+    String zookeeper_cluster;
     String zookeeper_path;
     String replica_name;
     String replica_path;
@@ -586,6 +587,7 @@ protected:
     /** If not 'attach', either creates a new table in ZK, or adds a replica to an existing table.
       */
     StorageReplicatedMergeTree(
+        const String & zookeeper_cluster_,
         const String & zookeeper_path_,
         const String & replica_name_,
         bool attach,

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -158,7 +158,7 @@ public:
         bool is_session_expired;
         ReplicatedMergeTreeQueue::Status queue;
         UInt32 parts_to_check;
-        String zookeeper_cluster;
+        String zookeeper_name;
         String zookeeper_path;
         String replica_name;
         String replica_path;
@@ -235,14 +235,17 @@ private:
 
     zkutil::ZooKeeperPtr tryGetZooKeeper() const;
     zkutil::ZooKeeperPtr getZooKeeper() const;
-    void setZooKeeper(zkutil::ZooKeeperPtr zookeeper);
+    void setZooKeeper();
+    zkutil::ZooKeeperPtr obtainZooKeeperImpl(Context & global_context_,
+        const String & cluster_name_, bool use_auxiliary_zookeeper_);
 
     /// If true, the table is offline and can not be written to it.
     std::atomic_bool is_readonly {false};
     /// If false - ZooKeeper is available, but there is no table metadata. It's safe to drop table in this case.
     bool has_metadata_in_zookeeper = true;
 
-    String zookeeper_cluster;
+    bool use_auxiliary_zookeeper = false; 
+    String zookeeper_name;
     String zookeeper_path;
     String replica_name;
     String replica_path;
@@ -587,7 +590,6 @@ protected:
     /** If not 'attach', either creates a new table in ZK, or adds a replica to an existing table.
       */
     StorageReplicatedMergeTree(
-        const String & zookeeper_cluster_,
         const String & zookeeper_path_,
         const String & replica_name_,
         bool attach,

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -244,7 +244,7 @@ private:
     /// If false - ZooKeeper is available, but there is no table metadata. It's safe to drop table in this case.
     bool has_metadata_in_zookeeper = true;
 
-    bool use_auxiliary_zookeeper = false; 
+    bool use_auxiliary_zookeeper = false;
     String zookeeper_name;
     String zookeeper_path;
     String replica_name;

--- a/src/Storages/System/StorageSystemReplicas.cpp
+++ b/src/Storages/System/StorageSystemReplicas.cpp
@@ -29,6 +29,7 @@ StorageSystemReplicas::StorageSystemReplicas(const StorageID & table_id_)
         { "is_session_expired",                   std::make_shared<DataTypeUInt8>()    },
         { "future_parts",                         std::make_shared<DataTypeUInt32>()   },
         { "parts_to_check",                       std::make_shared<DataTypeUInt32>()   },
+        { "zookeeper_cluster",                    std::make_shared<DataTypeString>()   },
         { "zookeeper_path",                       std::make_shared<DataTypeString>()   },
         { "replica_name",                         std::make_shared<DataTypeString>()   },
         { "replica_path",                         std::make_shared<DataTypeString>()   },
@@ -162,6 +163,7 @@ Pipe StorageSystemReplicas::read(
         res_columns[col_num++]->insert(status.is_session_expired);
         res_columns[col_num++]->insert(status.queue.future_parts);
         res_columns[col_num++]->insert(status.parts_to_check);
+        res_columns[col_num++]->insert(status.zookeeper_cluster);
         res_columns[col_num++]->insert(status.zookeeper_path);
         res_columns[col_num++]->insert(status.replica_name);
         res_columns[col_num++]->insert(status.replica_path);

--- a/src/Storages/System/StorageSystemReplicas.cpp
+++ b/src/Storages/System/StorageSystemReplicas.cpp
@@ -29,7 +29,7 @@ StorageSystemReplicas::StorageSystemReplicas(const StorageID & table_id_)
         { "is_session_expired",                   std::make_shared<DataTypeUInt8>()    },
         { "future_parts",                         std::make_shared<DataTypeUInt32>()   },
         { "parts_to_check",                       std::make_shared<DataTypeUInt32>()   },
-        { "zookeeper_cluster",                    std::make_shared<DataTypeString>()   },
+        { "zookeeper_name",                       std::make_shared<DataTypeString>()   },
         { "zookeeper_path",                       std::make_shared<DataTypeString>()   },
         { "replica_name",                         std::make_shared<DataTypeString>()   },
         { "replica_path",                         std::make_shared<DataTypeString>()   },
@@ -163,7 +163,7 @@ Pipe StorageSystemReplicas::read(
         res_columns[col_num++]->insert(status.is_session_expired);
         res_columns[col_num++]->insert(status.queue.future_parts);
         res_columns[col_num++]->insert(status.parts_to_check);
-        res_columns[col_num++]->insert(status.zookeeper_cluster);
+        res_columns[col_num++]->insert(status.zookeeper_name);
         res_columns[col_num++]->insert(status.zookeeper_path);
         res_columns[col_num++]->insert(status.replica_name);
         res_columns[col_num++]->insert(status.replica_path);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

* 1. Add configuration for multi zookeeper clusters.

Now it's possible to make different ReplicatedMergeTree engine with different ZooKeeper clusters.
The auxiliary zookeepers configuration (#14155 ) is reused to support this feature.
We can create table like follow:

```CREATE TABLE t1 (a String) ENGINE= ReplicatedMergeTree('test:/tables/t1','{replica}') ORDER BY a;```

It means that the metadata of the table named t1 is saved in zookeeper cluster named test, which configurated in 
auxiliary_zookeepers.

```CREATE TABLE t2 (a String) ENGINE= ReplicatedMergeTree('/tables/t2','{replica}') ORDER BY a;```
It means that the metadata of the table named t2 is saved in the default zookeeper cluster, which configurated in
zookeeper.


```
<auxiliary_zookeepers>
        <test>
            <node index = "1">
                <host>172.19.0.11</host>
                <port>2181</port>
            </node>
        </test>
    </auxiliary_zookeepers>
```
In fact, the implementation compatibles with the old configuration.


Detailed description / Documentation draft:


