### PR TITLE
Get rid of ViewSource

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -952,20 +952,6 @@ StoragePtr Context::executeTableFunction(const ASTPtr & table_expression)
 }
 
 
-void Context::addViewSource(const StoragePtr & storage)
-{
-    if (view_source)
-        throw Exception(
-            "Temporary view source storage " + backQuoteIfNeed(view_source->getName()) + " already exists.", ErrorCodes::TABLE_ALREADY_EXISTS);
-    view_source = storage;
-}
-
-
-StoragePtr Context::getViewSource()
-{
-    return view_source;
-}
-
 Settings Context::getSettings() const
 {
     return settings;

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -349,9 +349,6 @@ public:
 
     StoragePtr executeTableFunction(const ASTPtr & table_expression);
 
-    void addViewSource(const StoragePtr & storage);
-    StoragePtr getViewSource();
-
     String getCurrentDatabase() const;
     String getCurrentQueryId() const;
 

--- a/src/Interpreters/JoinedTables.cpp
+++ b/src/Interpreters/JoinedTables.cpp
@@ -170,17 +170,6 @@ StoragePtr JoinedTables::getLeftTableStorage()
         table_id = StorageID("system", "one");
     }
 
-    if (auto view_source = context.getViewSource())
-    {
-        const auto & storage_values = static_cast<const StorageValues &>(*view_source);
-        auto tmp_table_id = storage_values.getStorageID();
-        if (tmp_table_id.database_name == table_id.database_name && tmp_table_id.table_name == table_id.table_name)
-        {
-            /// Read from view source.
-            return context.getViewSource();
-        }
-    }
-
     /// Read from table. Even without table expression (implicit SELECT ... FROM system.one).
     return DatabaseCatalog::instance().getTable(table_id, context);
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

ViewSource in Context seems unnecessary now. Introduced in https://github.com/ClickHouse/ClickHouse/pull/3796

Detailed description / Documentation draft:

Null.