### PR TITLE
Better min/max for Int128

### DIFF
--- a/base/common/arithmeticOverflow.h
+++ b/base/common/arithmeticOverflow.h
@@ -31,8 +31,8 @@ namespace common
     template <>
     inline bool addOverflow(__int128 x, __int128 y, __int128 & res)
     {
-        static constexpr __int128 min_int128 = __int128(0x8000000000000000ll) << 64;
-        static constexpr __int128 max_int128 = (__int128(0x7fffffffffffffffll) << 64) + 0xffffffffffffffffll;
+        static constexpr __int128 min_int128 = minInt128();
+        static constexpr __int128 max_int128 = maxInt128();
         res = x + y;
         return (y > 0 && x > max_int128 - y) || (y < 0 && x < min_int128 - y);
     }
@@ -79,8 +79,8 @@ namespace common
     template <>
     inline bool subOverflow(__int128 x, __int128 y, __int128 & res)
     {
-        static constexpr __int128 min_int128 = __int128(0x8000000000000000ll) << 64;
-        static constexpr __int128 max_int128 = (__int128(0x7fffffffffffffffll) << 64) + 0xffffffffffffffffll;
+        static constexpr __int128 min_int128 = minInt128();
+        static constexpr __int128 max_int128 = maxInt128();
         res = x - y;
         return (y < 0 && x > max_int128 + y) || (y > 0 && x < min_int128 + y);
     }

--- a/base/common/extended_types.h
+++ b/base/common/extended_types.h
@@ -13,6 +13,9 @@ using wUInt256 = wide::integer<256, unsigned>;
 static_assert(sizeof(wInt256) == 32);
 static_assert(sizeof(wUInt256) == 32);
 
+static constexpr __int128 minInt128() { return static_cast<unsigned __int128>(1) << 127; }
+static constexpr __int128 maxInt128() { return (static_cast<unsigned __int128>(1) << 127) - 1; }
+
 /// The standard library type traits, such as std::is_arithmetic, with one exception
 /// (std::common_type), are "set in stone". Attempting to specialize them causes undefined behavior.
 /// So instead of using the std type_traits, we use our own version which allows extension.

--- a/base/common/itoa.h
+++ b/base/common/itoa.h
@@ -372,7 +372,7 @@ static inline char * writeLeadingMinus(char * pos)
 
 static inline char * writeSIntText(int128_t x, char * pos)
 {
-    static const int128_t min_int128 = int128_t(0x8000000000000000ll) << 64;
+    static constexpr int128_t min_int128 = uint128_t(1) << 127;
 
     if (unlikely(x == min_int128))
     {

--- a/src/Core/AccurateComparison.h
+++ b/src/Core/AccurateComparison.h
@@ -4,6 +4,7 @@
 #include <limits>
 #include "Defines.h"
 #include "Types.h"
+#include <common/extended_types.h>
 #include <Common/NaNUtils.h>
 #include <Common/UInt128.h>
 
@@ -382,8 +383,8 @@ inline bool equalsOp<DB::Float32, DB::UInt128>(DB::Float32 f, DB::UInt128 u)
 
 inline bool NO_SANITIZE_UNDEFINED greaterOp(DB::Int128 i, DB::Float64 f)
 {
-    static constexpr Int128 min_int128 = Int128(0x8000000000000000ll) << 64;
-    static constexpr Int128 max_int128 = (Int128(0x7fffffffffffffffll) << 64) + 0xffffffffffffffffll;
+    static constexpr Int128 min_int128 = minInt128();
+    static constexpr Int128 max_int128 = maxInt128();
 
     if (-MAX_INT64_WITH_EXACT_FLOAT64_REPR <= i && i <= MAX_INT64_WITH_EXACT_FLOAT64_REPR)
         return static_cast<DB::Float64>(i) > f;
@@ -394,8 +395,8 @@ inline bool NO_SANITIZE_UNDEFINED greaterOp(DB::Int128 i, DB::Float64 f)
 
 inline bool NO_SANITIZE_UNDEFINED greaterOp(DB::Float64 f, DB::Int128 i)
 {
-    static constexpr Int128 min_int128 = Int128(0x8000000000000000ll) << 64;
-    static constexpr Int128 max_int128 = (Int128(0x7fffffffffffffffll) << 64) + 0xffffffffffffffffll;
+    static constexpr Int128 min_int128 = minInt128();
+    static constexpr Int128 max_int128 = maxInt128();
 
     if (-MAX_INT64_WITH_EXACT_FLOAT64_REPR <= i && i <= MAX_INT64_WITH_EXACT_FLOAT64_REPR)
         return f > static_cast<DB::Float64>(i);

--- a/src/DataTypes/DataTypesDecimal.h
+++ b/src/DataTypes/DataTypesDecimal.h
@@ -153,8 +153,9 @@ convertToDecimal(const typename FromDataType::FieldType & value, UInt32 scale)
         auto out = value * static_cast<FromFieldType>(DecimalUtils::scaleMultiplier<ToNativeType>(scale));
         if constexpr (std::is_same_v<ToNativeType, Int128>)
         {
-            static constexpr Int128 min_int128 = Int128(0x8000000000000000ll) << 64;
-            static constexpr Int128 max_int128 = (Int128(0x7fffffffffffffffll) << 64) + 0xffffffffffffffffll;
+            static constexpr Int128 min_int128 = minInt128();
+            static constexpr Int128 max_int128 = maxInt128();
+
             if (out <= static_cast<ToNativeType>(min_int128) || out >= static_cast<ToNativeType>(max_int128))
                 throw Exception(std::string(ToDataType::family_name) + " convert overflow. Float is out of Decimal range",
                                 ErrorCodes::DECIMAL_OVERFLOW);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
min/max for Int128 without negative int shift.