### PR TITLE
decimal field in mysql column definition packet shouldn't have size 1?

### DIFF
--- a/src/Core/MySQL/PacketsProtocolText.cpp
+++ b/src/Core/MySQL/PacketsProtocolText.cpp
@@ -77,7 +77,7 @@ ColumnDefinition::ColumnDefinition(
 
 size_t ColumnDefinition::getPayloadSize() const
 {
-    return 13 + getLengthEncodedStringSize("def") + getLengthEncodedStringSize(schema) + getLengthEncodedStringSize(table) + getLengthEncodedStringSize(org_table) + \
+    return 12 + getLengthEncodedStringSize("def") + getLengthEncodedStringSize(schema) + getLengthEncodedStringSize(table) + getLengthEncodedStringSize(org_table) + \
             getLengthEncodedStringSize(name) + getLengthEncodedStringSize(org_name) + getLengthEncodedNumberSize(next_length);
 }
 
@@ -96,7 +96,7 @@ void ColumnDefinition::readPayloadImpl(ReadBuffer & payload)
     payload.readStrict(reinterpret_cast<char *>(&column_length), 4);
     payload.readStrict(reinterpret_cast<char *>(&column_type), 1);
     payload.readStrict(reinterpret_cast<char *>(&flags), 2);
-    payload.readStrict(reinterpret_cast<char *>(&decimals), 2);
+    payload.readStrict(reinterpret_cast<char *>(&decimals), 1);
     payload.ignore(2);
 }
 
@@ -113,7 +113,7 @@ void ColumnDefinition::writePayloadImpl(WriteBuffer & buffer) const
     buffer.write(reinterpret_cast<const char *>(&column_length), 4);
     buffer.write(reinterpret_cast<const char *>(&column_type), 1);
     buffer.write(reinterpret_cast<const char *>(&flags), 2);
-    buffer.write(reinterpret_cast<const char *>(&decimals), 2);
+    buffer.write(reinterpret_cast<const char *>(&decimals), 1);
     writeChar(0x0, 2, buffer);
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Adjust decimals field size in mysql column definition packet


Detailed description / Documentation draft:

mariadb jdbc driver [assumes no padding](https://github.com/mariadb-corporation/mariadb-connector-j/blob/a5c414d35813c683fdbbb46e9d2ad6149315c88e/src/main/java/org/mariadb/jdbc/internal/com/read/resultset/ColumnDefinition.java#L149) at the end of column definition packet.
See https://mariadb.com/kb/en/resultset/#column-definition-packet

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
