### PR TITLE
Fix performance issue when doing datetime comparison

### DIFF
--- a/src/Functions/FunctionsComparison.h
+++ b/src/Functions/FunctionsComparison.h
@@ -1213,7 +1213,7 @@ public:
         const bool left_is_string = isStringOrFixedString(which_left);
         const bool right_is_string = isStringOrFixedString(which_right);
 
-        bool date_and_datetime = (left_type != right_type) &&
+        bool date_and_datetime = (which_left.idx != which_right.idx) &&
             which_left.isDateOrDateTime() && which_right.isDateOrDateTime();
 
         if (left_is_num && right_is_num && !date_and_datetime)

--- a/tests/performance/datetime_comparison.xml
+++ b/tests/performance/datetime_comparison.xml
@@ -1,0 +1,5 @@
+<test>
+    <query>SELECT count() FROM numbers(1000000000) WHERE materialize(now()) > toString(toDateTime('2020-09-30 00:00:00'))</query>
+    <query>SELECT count() FROM numbers(1000000000) WHERE materialize(now()) > toUInt32(toDateTime('2020-09-30 00:00:00'))</query>
+    <query>SELECT count() FROM numbers(1000000000) WHERE materialize(now()) > toDateTime('2020-09-30 00:00:00')</query>
+</test>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix `DateTime <op> DateTime` mistakenly choosing the slow generic implementation. This fixes https://github.com/ClickHouse/ClickHouse/issues/15153 .

Detailed description / Documentation draft:

none.