### PR TITLE
Parse ORDER BY in CREATE TABLE using OrderByElement parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,7 @@ website/package-lock.json
 
 # clangd cache
 /.clangd
+/.cache
 
 /compile_commands.json
 

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -241,6 +241,7 @@ bool ParserStorage::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     ParserKeyword s_settings("SETTINGS");
 
     ParserIdentifierWithOptionalParameters ident_with_optional_params_p;
+    ParserOrderByExpressionList order_list_p;
     ParserExpression expression_p;
     ParserSetQuery settings_p(/* parse_only_internals_ = */ true);
     ParserTTLExpressionList parser_ttl_list;
@@ -281,7 +282,7 @@ bool ParserStorage::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 
         if (!order_by && s_order_by.ignore(pos, expected))
         {
-            if (expression_p.parse(pos, order_by, expected))
+            if (order_list_p.parse(pos, order_by, expected))
                 continue;
             else
                 return false;

--- a/src/Storages/extractKeyExpressionList.cpp
+++ b/src/Storages/extractKeyExpressionList.cpp
@@ -1,27 +1,47 @@
 #include <Storages/extractKeyExpressionList.h>
+
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTExpressionList.h>
+#include <Parsers/ASTOrderByElement.h>
+
+#include <cassert>
+
 
 namespace DB
 {
-    ASTPtr extractKeyExpressionList(const ASTPtr & node)
+
+ASTPtr extractKeyExpressionList(const ASTPtr & node)
+{
+    if (!node)
+        return std::make_shared<ASTExpressionList>();
+
+    const auto * expr_func = node->as<ASTFunction>();
+    const auto * expr_list = node->as<ASTExpressionList>();
+
+    if (expr_func && expr_func->name == "tuple")
     {
-        if (!node)
-            return std::make_shared<ASTExpressionList>();
-
-        const auto * expr_func = node->as<ASTFunction>();
-
-        if (expr_func && expr_func->name == "tuple")
-        {
-            /// Primary key is specified in tuple, extract its arguments.
-            return expr_func->arguments->clone();
-        }
-        else
-        {
-            /// Primary key consists of one column.
-            auto res = std::make_shared<ASTExpressionList>();
-            res->children.push_back(node);
-            return res;
-        }
+        /// Primary key is specified in tuple, extract its arguments.
+        return expr_func->arguments->clone();
     }
+    else if (expr_list)
+    {
+        auto res = std::make_shared<ASTExpressionList>();
+        for (const auto & child : expr_list->children)
+        {
+            // FIXME: do we always ignore all ORDER BY options like ASC/DESC ?
+            const auto * element = child->as<ASTOrderByElement>();
+            assert(!element->children.empty());
+            res->children.push_back(element->children.front());
+        }
+        return res;
+    }
+    else
+    {
+        /// Primary key consists of one column.
+        auto res = std::make_shared<ASTExpressionList>();
+        res->children.push_back(node);
+        return res;
+    }
+}
+
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Other

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
It's useful for better compatibility with new ANTLR grammar