### PR TITLE
Add optimize setting to explain plan.

### DIFF
--- a/src/Interpreters/InterpreterExplainQuery.cpp
+++ b/src/Interpreters/InterpreterExplainQuery.cpp
@@ -119,13 +119,17 @@ struct QueryPlanSettings
 {
     QueryPlan::ExplainPlanOptions query_plan_options;
 
+    /// Apply query plan optimisations.
+    bool optimize = true;
+
     constexpr static char name[] = "PLAN";
 
     std::unordered_map<std::string, std::reference_wrapper<bool>> boolean_settings =
     {
             {"header", query_plan_options.header},
             {"description", query_plan_options.description},
-            {"actions", query_plan_options.actions}
+            {"actions", query_plan_options.actions},
+            {"optimize", optimize},
     };
 };
 
@@ -248,7 +252,8 @@ BlockInputStreamPtr InterpreterExplainQuery::executeImpl()
         InterpreterSelectWithUnionQuery interpreter(ast.getExplainedQuery(), context, SelectQueryOptions());
         interpreter.buildQueryPlan(plan);
 
-        plan.optimize();
+        if (settings.optimize)
+            plan.optimize();
 
         WriteBufferFromOStream buffer(ss);
         plan.explainPlan(buffer, settings.query_plan_options);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added `optimize` setting to `EXPLAIN PLAN` query. If enabled, query plan level optimisations are applied. Enabled by default.