### PR TITLE
do not expose ClickHouse server until initialization is complete

### DIFF
--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -89,7 +89,8 @@ EOT
 fi
 
 if [ -n "$(ls /docker-entrypoint-initdb.d/)" ] || [ -n "$CLICKHOUSE_DB" ]; then
-    $gosu /usr/bin/clickhouse-server --config-file=$CLICKHOUSE_CONFIG &
+    # Listen only on localhost until the initialization is done
+    $gosu /usr/bin/clickhouse-server --config-file=$CLICKHOUSE_CONFIG -- --listen_host=127.0.0.1 &
     pid="$!"
 
     # check if clickhouse is ready to accept connections


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Do not allow connections to ClickHouse server until all scripts in `/docker-entrypoint-initdb.d/` are executed.


Detailed description / Documentation draft:

As mentioned in #10963, docker container is expected to start accepting connections only after all init scripts are finished. Currently, the first startup of the server (which is done only for scripts execution) permits connections, thus making healthcheck scripts (like [wait-for-it.sh](https://github.com/vishnubob/wait-for-it)) trigger. This may result in incorrect behaviour of the latter.

Closes #10963
