### PR TITLE
Fix MSan report in QueryLog

### DIFF
--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -401,7 +401,7 @@ void ProcessList::killAllQueries()
 
 QueryStatusInfo QueryStatus::getInfo(bool get_thread_list, bool get_profile_events, bool get_settings) const
 {
-    QueryStatusInfo res;
+    QueryStatusInfo res{};
 
     res.query             = query;
     res.client_info       = client_info;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix MSan report in QueryLog. Uninitialized memory can be used for the field `memory_usage`.

Details: https://clickhouse-test-reports.s3.yandex.net/15240/dce6a436f37713224c242092446e1a9fcf8b4a4a/stress_test_(memory)/stderr.log

Remaining questions:
- why a query may not heave a thread group at this moment?
- why did not reproduce earlier?