### PR TITLE
Enable embedded config for aarch64

### DIFF
--- a/benchmark/hardware.sh
+++ b/benchmark/hardware.sh
@@ -36,14 +36,6 @@ if [[ ! -f clickhouse ]]; then
         $FASTER_DOWNLOAD "$AMD64_BIN_URL"
     elif [[ $CPU == aarch64 ]]; then
         $FASTER_DOWNLOAD "$AARCH64_BIN_URL"
-
-        # Download configs. ARM version has no embedded configs.
-        wget https://raw.githubusercontent.com/ClickHouse/ClickHouse/master/programs/server/config.xml
-        wget https://raw.githubusercontent.com/ClickHouse/ClickHouse/master/programs/server/users.xml
-        mkdir config.d
-        wget https://raw.githubusercontent.com/ClickHouse/ClickHouse/master/programs/server/config.d/path.xml -O config.d/path.xml
-        wget https://raw.githubusercontent.com/ClickHouse/ClickHouse/master/programs/server/config.d/access_control.xml -O config.d/access_control.xml
-        wget https://raw.githubusercontent.com/ClickHouse/ClickHouse/master/programs/server/config.d/log_to_console.xml -O config.d/log_to_console.xml
     else
         echo "Unsupported CPU type: $CPU"
         exit 1
@@ -60,7 +52,7 @@ if [[ ! -d data ]]; then
     if [[ ! -f $DATASET ]]; then
         $FASTER_DOWNLOAD "https://clickhouse-datasets.s3.yandex.net/hits/partitions/$DATASET"
     fi
-    
+
     tar $TAR_PARAMS --strip-components=1 --directory=. -x -v -f $DATASET
 fi
 

--- a/programs/server/CMakeLists.txt
+++ b/programs/server/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CLICKHOUSE_SERVER_SOURCES
     Server.cpp
 )
 
-if (OS_LINUX AND ARCH_AMD64)
+if (OS_LINUX)
     set (LINK_CONFIG_LIB INTERFACE "-Wl,${WHOLE_ARCHIVE} $<TARGET_FILE:clickhouse_server_configs> -Wl,${NO_WHOLE_ARCHIVE}")
 endif ()
 


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow to run AArch64 version of clickhouse-server without configs. This facilitates #15174 