### PR TITLE
Fail more quickly in clickhouse-test if server does not respond

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -303,6 +303,14 @@ def run_tests_array(all_tests_with_params):
                         clickhouse_proc = Popen(shlex.split(args.client), stdin=PIPE, stdout=PIPE, stderr=PIPE)
                         clickhouse_proc.communicate("SELECT 'Running test {suite}/{case} from pid={pid}';".format(pid = os.getpid(), case = case, suite = suite))
 
+                        if clickhouse_proc.returncode != 0:
+                            failures += 1
+                            print(MSG_FAIL, end='')
+                            print_test_time(0)
+                            print(" - server does not respond to health check")
+                            SERVER_DIED = True
+                            break
+
                     reference_file = os.path.join(suite_dir, name) + '.reference'
                     stdout_file = os.path.join(suite_tmp_dir, name) + '.stdout'
                     stderr_file = os.path.join(suite_tmp_dir, name) + '.stderr'

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -305,9 +305,7 @@ def run_tests_array(all_tests_with_params):
 
                         if clickhouse_proc.returncode != 0:
                             failures += 1
-                            print(MSG_FAIL, end='')
-                            print_test_time(0)
-                            print(" - server does not respond to health check")
+                            print("Server does not respond to health check")
                             SERVER_DIED = True
                             break
 


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fail early in functional tests if server failed to respond. This closes #15262.


Example:

```
$ ./clickhouse-test --order asc --testname
Using queries from 'queries' directory
Connecting to ClickHouse server... OK

Running 2301 stateless tests.

00001_select_1:                                                         [ OK ]
00002_system_numbers:                                                   [ OK ]
00003_reinterpret_as_string:                                            [ OK ]
00004_shard_format_ast_and_remote_table:                                [ OK ]
00005_shard_format_ast_and_remote_table_lambda:                         [ FAIL ] - server does not respond to health check
```