### PR TITLE
Replace useless multiset with unordered_set

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -223,7 +223,7 @@ Pipe MergeTreeDataSelectExecutor::readFromParts(
     if (part_column_queried)
         VirtualColumnUtils::filterBlockWithQuery(query_info.query, virtual_columns_block, context);
 
-    std::multiset<String> part_values = VirtualColumnUtils::extractSingleValueFromBlock<String>(virtual_columns_block, "_part");
+    auto part_values = VirtualColumnUtils::extractSingleValueFromBlock<String>(virtual_columns_block, "_part");
 
     metadata_snapshot->check(real_column_names, data.getVirtuals(), data.getStorageID());
 

--- a/src/Storages/VirtualColumnUtils.h
+++ b/src/Storages/VirtualColumnUtils.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <set>
+#include <unordered_set>
 
 #include <Core/Block.h>
 #include <Parsers/IAST_fwd.h>
@@ -30,9 +30,9 @@ void filterBlockWithQuery(const ASTPtr & query, Block & block, const Context & c
 
 /// Extract from the input stream a set of `name` column values
 template <typename T>
-std::multiset<T> extractSingleValueFromBlock(const Block & block, const String & name)
+auto extractSingleValueFromBlock(const Block & block, const String & name)
 {
-    std::multiset<T> res;
+    std::unordered_set<T> res;
     const ColumnWithTypeAndName & data = block.getByName(name);
     size_t rows = block.rows();
     for (size_t i = 0; i < rows; ++i)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

I couldn't figure out a reason why multiset is used.

Detailed description / Documentation draft:

Null.