### PR TITLE
Fix ASTColumnsReplaceTransformer::Replacement::clone()

### DIFF
--- a/src/Parsers/ASTColumnsTransformers.h
+++ b/src/Parsers/ASTColumnsTransformers.h
@@ -53,7 +53,7 @@ public:
         ASTPtr clone() const override
         {
             auto replacement = std::make_shared<Replacement>(*this);
-            replacement->name = name;
+            replacement->children.clear();
             replacement->expr = expr->clone();
             replacement->children.push_back(replacement->expr);
             return replacement;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Not for changelog

https://clickhouse-test-reports.s3.yandex.net/15243/5ff5ca1fa6306f602aa8ba09e6884854313cc4e3/fuzzer/fuzzer.log
