### PR TITLE
Fix bug in queries like SELECT toStartOfDay(today())

### DIFF
--- a/src/Functions/FunctionDateOrDateTimeToSomething.h
+++ b/src/Functions/FunctionDateOrDateTimeToSomething.h
@@ -71,7 +71,9 @@ public:
         if constexpr (std::is_same_v<ToDataType, DataTypeDateTime>)
         {
             std::string time_zone = extractTimeZoneNameFromFunctionArguments(arguments, 1, 0);
-            if (time_zone.empty())
+            /// only validate the time_zone part if the number of arguments is 2. This is mainly
+            /// to accommodate functions like toStartOfDay(today()), toStartOfDay(yesterday()) etc.
+            if (arguments.size() == 2 && time_zone.empty())
                 throw Exception(
                     "Function " + getName() + " supports a 2nd argument (optional) that must be non-empty and be a valid time zone",
                     ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);

--- a/tests/queries/0_stateless/00921_datetime64_compatibility.reference
+++ b/tests/queries/0_stateless/00921_datetime64_compatibility.reference
@@ -88,38 +88,37 @@ SELECT toStartOfWeek(N)
 "Date","2019-09-15"
 ------------------------------------------
 SELECT toStartOfDay(N)
-
-Code: 43: Function toStartOfDay supports a 2nd argument (optional) that must be non-empty and be a valid time zone.
+"DateTime","2019-09-16 00:00:00"
 "DateTime('Europe/Minsk')","2019-09-16 00:00:00"
 "DateTime('Europe/Minsk')","2019-09-16 00:00:00"
 ------------------------------------------
 SELECT toStartOfHour(N)
 
-Code: 43: Function toStartOfHour supports a 2nd argument (optional) that must be non-empty and be a valid time zone.
+Code: 43: Illegal type Date of argument for function toStartOfHour.
 "DateTime('Europe/Minsk')","2019-09-16 19:00:00"
 "DateTime('Europe/Minsk')","2019-09-16 19:00:00"
 ------------------------------------------
 SELECT toStartOfMinute(N)
 
-Code: 43: Function toStartOfMinute supports a 2nd argument (optional) that must be non-empty and be a valid time zone.
+Code: 43: Illegal type Date of argument for function toStartOfMinute.
 "DateTime('Europe/Minsk')","2019-09-16 19:20:00"
 "DateTime('Europe/Minsk')","2019-09-16 19:20:00"
 ------------------------------------------
 SELECT toStartOfFiveMinute(N)
 
-Code: 43: Function toStartOfFiveMinute supports a 2nd argument (optional) that must be non-empty and be a valid time zone.
+Code: 43: Illegal type Date of argument for function toStartOfFiveMinute.
 "DateTime('Europe/Minsk')","2019-09-16 19:20:00"
 "DateTime('Europe/Minsk')","2019-09-16 19:20:00"
 ------------------------------------------
 SELECT toStartOfTenMinutes(N)
 
-Code: 43: Function toStartOfTenMinutes supports a 2nd argument (optional) that must be non-empty and be a valid time zone.
+Code: 43: Illegal type Date of argument for function toStartOfTenMinutes.
 "DateTime('Europe/Minsk')","2019-09-16 19:20:00"
 "DateTime('Europe/Minsk')","2019-09-16 19:20:00"
 ------------------------------------------
 SELECT toStartOfFifteenMinutes(N)
 
-Code: 43: Function toStartOfFifteenMinutes supports a 2nd argument (optional) that must be non-empty and be a valid time zone.
+Code: 43: Illegal type Date of argument for function toStartOfFifteenMinutes.
 "DateTime('Europe/Minsk')","2019-09-16 19:15:00"
 "DateTime('Europe/Minsk')","2019-09-16 19:15:00"
 ------------------------------------------
@@ -167,7 +166,7 @@ Code: 43: Illegal type Date of argument for function date_trunc.
 ------------------------------------------
 SELECT toTime(N)
 
-Code: 43: Function toTime supports a 2nd argument (optional) that must be non-empty and be a valid time zone.
+Code: 43: Illegal type Date of argument for function toTime.
 "DateTime('Europe/Minsk')","1970-01-02 19:20:11"
 "DateTime('Europe/Minsk')","1970-01-02 19:20:11"
 ------------------------------------------
@@ -233,7 +232,7 @@ SELECT toYearWeek(N)
 ------------------------------------------
 SELECT timeSlot(N)
 
-Code: 43: Function timeSlot supports a 2nd argument (optional) that must be non-empty and be a valid time zone.
+Code: 43: Illegal type Date of argument for function timeSlot.
 "DateTime('Europe/Minsk')","2019-09-16 19:00:00"
 "DateTime('Europe/Minsk')","2019-09-16 19:00:00"
 ------------------------------------------

--- a/tests/queries/0_stateless/01472_toStartOfInterval_disallow_empty_tz_field.sql
+++ b/tests/queries/0_stateless/01472_toStartOfInterval_disallow_empty_tz_field.sql
@@ -21,3 +21,7 @@ SELECT toStartOfHour(toDateTime('2017-12-31 01:59:00', 'UTC'), 'UTC'); -- succes
 
 SELECT toStartOfMinute(toDateTime('2017-12-31 00:00:00', 'UTC'), ''); -- {serverError 43}
 SELECT toStartOfMinute(toDateTime('2017-12-31 00:01:30', 'UTC'), 'UTC'); -- success
+
+-- special case - allow empty time_zone when using functions like today(), yesterday() etc.
+SELECT toStartOfDay(today()) FORMAT Null; -- success
+SELECT toStartOfDay(yesterday()) FORMAT Null; -- success


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix bug where queries like SELECT toStartOfDay(today()) fail complaining about empty time_zone argument.

Detailed description / Documentation draft:

This PR fixes the bug where function like `SELECT toStartOfDay(today());` failed as the time_zone argument is empty. These special cases should be supported without the need to validate the time_zone argument. Solution is to only check for a valid time_zone if the number of arguments = 2.

Before:

```sql
tower :) SELECT toStartOfDay(today());

SELECT toStartOfDay(today())


Received exception from server (version 20.10.1):
Code: 43. DB::Exception: Received from localhost:9000. DB::Exception: Function toStartOfDay supports a 2nd argument (optional) that must be non-empty and be a valid time zone. 

0 rows in set. Elapsed: 0.653 sec. 

```
After:
```sql
tower :) SELECT toStartOfDay(today());

SELECT toStartOfDay(today())

┌─toStartOfDay(today())─┐
│   2020-09-25 00:00:00 │
└───────────────────────┘

1 rows in set. Elapsed: 0.014 sec. 

tower :) SELECT toStartOfDay(yesterday());

SELECT toStartOfDay(yesterday())

┌─toStartOfDay(yesterday())─┐
│       2020-09-24 00:00:00 │
└───────────────────────────┘
```

Fixes: #15313
