### PR TITLE
fix bug for building query_db_generator.cpp

### DIFF
--- a/utils/db-generator/query_db_generator.cpp
+++ b/utils/db-generator/query_db_generator.cpp
@@ -1,3 +1,4 @@
+#include <map>
 #include <boost/algorithm/string.hpp>
 #include <cstdlib>
 #include <iostream>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
fix bug for building query_db_generator.cpp


Detailed description / Documentation draft:
My environment for building lastest-Clickhouse failed:
```
guojiantao@comput131 ~/Clickhouse $ gcc --version
gcc (Gentoo 10.2.0-r1 p2) 10.2.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
guojiantao@comput131 ~ $ cmake --version
cmake version 3.18.2

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```
And Clickhouse version:
```
git log shows:
commit bbbe51033dfd5b8c3d54e168475ca707ac7ec0b4
Merge: df6221f da8a938
Author: alexey-milovidov <milovidov@yandex-team.ru>
Date:   Sat Sep 26 19:43:36 2020 +0300

    Merge pull request #15321 from ClickHouse/query-obfuscator

    Query obfuscator
```
fix bug for building query_db_generator.cpp
