### PR TITLE
Add support for "Raw" column format for Regexp format

### DIFF
--- a/src/DataTypes/DataTypeLowCardinality.cpp
+++ b/src/DataTypes/DataTypeLowCardinality.cpp
@@ -774,7 +774,7 @@ void DataTypeLowCardinality::deserializeTextQuoted(IColumn & column, ReadBuffer 
 
 void DataTypeLowCardinality::deserializeWholeText(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const
 {
-    deserializeImpl(column, &IDataType::deserializeAsTextEscaped, istr, settings);
+    deserializeImpl(column, &IDataType::deserializeAsWholeText, istr, settings);
 }
 
 void DataTypeLowCardinality::serializeTextCSV(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const

--- a/src/Processors/Formats/Impl/RegexpRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/RegexpRowInputFormat.cpp
@@ -51,6 +51,8 @@ RegexpRowInputFormat::ColumnFormat RegexpRowInputFormat::stringToFormat(const St
         return ColumnFormat::Csv;
     if (format == "JSON")
         return ColumnFormat::Json;
+    if (format == "Raw")
+        return ColumnFormat::Raw;
     throw Exception("Unsupported column format \"" + format + "\".", ErrorCodes::BAD_ARGUMENTS);
 }
 
@@ -87,6 +89,12 @@ bool RegexpRowInputFormat::readField(size_t index, MutableColumns & columns)
                     read = DataTypeNullable::deserializeTextJSON(*columns[index], field_buf, format_settings, type);
                 else
                     type->deserializeAsTextJSON(*columns[index], field_buf, format_settings);
+                break;
+            case ColumnFormat::Raw:
+                if (parse_as_nullable)
+                    read = DataTypeNullable::deserializeWholeText(*columns[index], field_buf, format_settings, type);
+                else
+                    type->deserializeAsWholeText(*columns[index], field_buf, format_settings);
                 break;
             default:
                 break;

--- a/tests/queries/0_stateless/01508_format_regexp_raw.reference
+++ b/tests/queries/0_stateless/01508_format_regexp_raw.reference
@@ -1,0 +1,1 @@
+abc\\	Hello, world!

--- a/tests/queries/0_stateless/01508_format_regexp_raw.sh
+++ b/tests/queries/0_stateless/01508_format_regexp_raw.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} -n --query "
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (a String, b String) ENGINE = Memory;
+"
+
+${CLICKHOUSE_CLIENT} --format_regexp_escaping_rule 'Raw' --format_regexp '^(.+?) separator (.+?)$' --query '
+INSERT INTO t FORMAT Regexp abc\ separator Hello, world!'
+
+${CLICKHOUSE_CLIENT} -n --query "
+SELECT * FROM t;
+DROP TABLE t;
+"

--- a/tests/queries/0_stateless/01510_format_regexp_raw_low_cardinality.reference
+++ b/tests/queries/0_stateless/01510_format_regexp_raw_low_cardinality.reference
@@ -1,0 +1,1 @@
+abc\\	Hello, world!

--- a/tests/queries/0_stateless/01510_format_regexp_raw_low_cardinality.sh
+++ b/tests/queries/0_stateless/01510_format_regexp_raw_low_cardinality.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} -n --query "
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (a String, b LowCardinality(Nullable(String))) ENGINE = Memory;
+"
+
+${CLICKHOUSE_CLIENT} --format_regexp_escaping_rule 'Raw' --format_regexp '^(.+?) separator (.+?)$' --query '
+INSERT INTO t FORMAT Regexp abc\ separator Hello, world!'
+
+${CLICKHOUSE_CLIENT} -n --query "
+SELECT * FROM t;
+DROP TABLE t;
+"


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add support for "Raw" column format for `Regexp` format. It allows to simply extract subpatterns as a whole without any escaping rules.