### PR TITLE
bugfix:aggregate:fix boundingratio args check

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionBoundingRatio.h
+++ b/src/AggregateFunctions/AggregateFunctionBoundingRatio.h
@@ -115,7 +115,7 @@ public:
         : IAggregateFunctionDataHelper<AggregateFunctionBoundingRatioData, AggregateFunctionBoundingRatio>(arguments, {})
     {
         const auto x_arg = arguments.at(0).get();
-        const auto y_arg = arguments.at(0).get();
+        const auto y_arg = arguments.at(1).get();
 
         if (!x_arg->isValueRepresentedByNumber() || !y_arg->isValueRepresentedByNumber())
             throw Exception("Illegal types of arguments of aggregate function " + getName() + ", must have number representation.",


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Report proper error when the second argument of `boundingRatio` aggregate function has a wrong type.