### PR TITLE
Fixing options' names' links in cmake docs generator

### DIFF
--- a/docs/tools/build.py
+++ b/docs/tools/build.py
@@ -185,7 +185,7 @@ def build(args):
         test.test_templates(args.website_dir)
 
     if not args.skip_docs:
-        generate_cmake_flags_files(os.path.join(os.path.dirname(__file__), '..', '..'))
+        generate_cmake_flags_files()
 
         build_docs(args)
         from github import build_releases

--- a/docs/tools/cmake_in_clickhouse_generator.py
+++ b/docs/tools/cmake_in_clickhouse_generator.py
@@ -98,7 +98,9 @@ def process_folder(root_path:str, name: str) -> None:
             if f == "CMakeLists.txt" or ".cmake" in f:
                 process_file(root, f)
 
-def generate_cmake_flags_files(root_path: str) -> None:
+def generate_cmake_flags_files() -> None:
+    root_path: str = os.path.join(os.path.dirname(__file__), '..', '..')
+
     output_file_name: str = os.path.join(root_path, "docs/en/development/cmake-in-clickhouse.md")
     header_file_name: str = os.path.join(root_path, "docs/_includes/cmake_in_clickhouse_header.md")
     footer_file_name: str = os.path.join(root_path, "docs/_includes/cmake_in_clickhouse_footer.md")
@@ -132,14 +134,14 @@ def generate_cmake_flags_files(root_path: str) -> None:
                 f.write(entities[k][1] + "\n")
                 ignored_keys.append(k)
 
-        f.write("\n### External libraries system/bundled mode\n" + table_header)
+        f.write("\n\n### External libraries system/bundled mode\n" + table_header)
 
         for k in sorted_keys:
             if k.startswith("USE_INTERNAL_"):
                 f.write(entities[k][1] + "\n")
                 ignored_keys.append(k)
 
-        f.write("\n### Other flags\n" + table_header)
+        f.write("\n\n### Other flags\n" + table_header)
 
         for k in sorted(set(sorted_keys).difference(set(ignored_keys))):
             f.write(entities[k][1] + "\n")
@@ -149,4 +151,4 @@ def generate_cmake_flags_files(root_path: str) -> None:
 
 
 if __name__ == '__main__':
-    generate_cmake_flags_files("../../")
+    generate_cmake_flags_files()

--- a/docs/tools/cmake_in_clickhouse_generator.py
+++ b/docs/tools/cmake_in_clickhouse_generator.py
@@ -66,8 +66,8 @@ def build_entity(path: str, entity: Entity, line_comment: Tuple[int, str]) -> No
 
     entities[name] = path, formatted_entity
 
-def process_file(root_path: str, input_name: str) -> None:
-    with open(os.path.join(root_path, input_name), 'r') as cmake_file:
+def process_file(root_path: str, file_path: str, file_name: str) -> None:
+    with open(os.path.join(file_path, file_name), 'r') as cmake_file:
         contents: str = cmake_file.read()
 
         def get_line_and_comment(target: str) -> Tuple[int, str]:
@@ -88,15 +88,17 @@ def process_file(root_path: str, input_name: str) -> None:
 
         matches: Optional[List[Entity]] = re.findall(cmake_option_regex, contents, re.MULTILINE)
 
+        file_rel_path_with_name: str = os.path.join(file_path[len(root_path):], file_name)[1:]
+
         if matches:
             for entity in matches:
-                build_entity(os.path.join(root_path[6:], input_name), entity, get_line_and_comment(entity[0]))
+                build_entity(file_rel_path_with_name, entity, get_line_and_comment(entity[0]))
 
-def process_folder(root_path:str, name: str) -> None:
+def process_folder(root_path: str, name: str) -> None:
     for root, _, files in os.walk(os.path.join(root_path, name)):
         for f in files:
             if f == "CMakeLists.txt" or ".cmake" in f:
-                process_file(root, f)
+                process_file(root_path, root, f)
 
 def generate_cmake_flags_files() -> None:
     root_path: str = os.path.join(os.path.dirname(__file__), '..', '..')
@@ -105,8 +107,8 @@ def generate_cmake_flags_files() -> None:
     header_file_name: str = os.path.join(root_path, "docs/_includes/cmake_in_clickhouse_header.md")
     footer_file_name: str = os.path.join(root_path, "docs/_includes/cmake_in_clickhouse_footer.md")
 
-    process_file(root_path, "CMakeLists.txt")
-    process_file(root_path, "programs/CMakeLists.txt")
+    process_file(root_path, root_path, "CMakeLists.txt")
+    process_file(root_path, os.path.join(root_path, "programs"), "CMakeLists.txt")
 
     process_folder(root_path, "base")
     process_folder(root_path, "cmake")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixes names links introduced in https://github.com/ClickHouse/ClickHouse/pull/14711
Currently the URLs generated are invalid -- see https://clickhouse.tech/docs/en/development/cmake-in-clickhouse/#clickhouse-modes and then -- ENABLE_CLICKHOUSE_ALL option URL.
