### PR TITLE
Mention core_dump size limit in docs

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -66,6 +66,18 @@ If no conditions met for a data part, ClickHouse uses the `lz4` compression.
 </compression>
 ```
 
+## core_dump
+
+Configures soft limit for core dump file size, one gigabyte by default.
+```xml
+<core_dump>
+    <size_limit>1073741824</size_limit>
+</core_dump> 
+```
+
+(Hard limit is configured via system tools)
+
+
 ## default\_database {#default-database}
 
 The default database.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
core_dump size limit docs.

Detailed description / Documentation draft:
