### PR TITLE
Suppress race in OpenSSL

### DIFF
--- a/tests/tsan_suppressions.txt
+++ b/tests/tsan_suppressions.txt
@@ -1,2 +1,4 @@
 # looks like a bug in clang-11 thread sanitizer, detects normal data race with random FD in this method
 race:DB::LazyPipeFDs::close
+# races in openSSL https://github.com/openssl/openssl/issues/11974
+race:evp_cipher_cache_constants


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Known race condition: https://github.com/openssl/openssl/issues/11974
