### PR TITLE
Destroy resources captured by lambda after `ThreadFromGlobalPool::join()`

### DIFF
--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -234,10 +234,16 @@ void ThreadPoolImpl<Thread>::worker(typename std::list<Thread>::iterator thread_
                     std::is_same_v<Thread, std::thread> ? CurrentMetrics::GlobalThreadActive : CurrentMetrics::LocalThreadActive);
 
                 job();
+                /// job should be reseted before decrementing scheduled_jobs to
+                /// ensure that the Job destroyed before wait() returns.
                 job = {};
             }
             catch (...)
             {
+                /// job should be reseted before decrementing scheduled_jobs to
+                /// ensure that the Job destroyed before wait() returns.
+                job = {};
+
                 {
                     std::unique_lock lock(mutex);
                     if (!first_exception)

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -162,14 +162,12 @@ public:
         GlobalThreadPool::instance().scheduleOrThrow([
             state = state,
             func = std::forward<Function>(func),
-            args = std::make_tuple(std::forward<Args>(args)...)]() mutable
+            args = std::make_tuple(std::forward<Args>(args)...)]() mutable /// mutable is needed to destroy capture
         {
-            SCOPE_EXIT({
-               /// Destroy function before exit.
-               /// It will guarantee that after ThreadFromGlobalPool::join all captured params are destroyed.
-               state->set();
-            });
+            SCOPE_EXIT(state->set());
 
+            /// This moves are needed to destroy function and arguments before exit.
+            /// It will guarantee that after ThreadFromGlobalPool::join all captured params are destroyed.
             auto function = std::move(func);
             auto arguments = std::move(args);
 

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -11,6 +11,7 @@
 
 #include <Poco/Event.h>
 #include <Common/ThreadStatus.h>
+#include <ext/scope_guard.h>
 
 
 /** Very simple thread pool similar to boost::threadpool.
@@ -161,21 +162,21 @@ public:
         GlobalThreadPool::instance().scheduleOrThrow([
             state = state,
             func = std::forward<Function>(func),
-            args = std::make_tuple(std::forward<Args>(args)...)]
+            args = std::make_tuple(std::forward<Args>(args)...)]() mutable
         {
             SCOPE_EXIT({
-                /// Destroy function before exit.
+               /// Destroy function before exit.
                /// It will guarantee that after ThreadFromGlobalPool::join all captured params are destroyed.
-               func = {};
                state->set();
             });
 
+            auto function = std::move(func);
             auto arguments = std::move(args);
 
             /// Thread status holds raw pointer on query context, thus it always must be destroyed
             /// before sending signal that permits to join this thread.
             DB::ThreadStatus thread_status;
-            std::apply(func, arguments);
+            std::apply(function, arguments);
         });
     }
 

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -165,10 +165,15 @@ public:
         {
             try
             {
+                /// Move capture in order to destroy it before `state->set()`.
+                /// It will guarantee that after ThreadFromGlobalPool::join all resources are destroyed.
+                auto function = std::move(func);
+                auto arguments = std::move(args);
+
                 /// Thread status holds raw pointer on query context, thus it always must be destroyed
                 /// before sending signal that permits to join this thread.
                 DB::ThreadStatus thread_status;
-                std::apply(func, args);
+                std::apply(function, arguments);
             }
             catch (...)
             {

--- a/src/Processors/Executors/PipelineExecutor.cpp
+++ b/src/Processors/Executors/PipelineExecutor.cpp
@@ -694,7 +694,9 @@ void PipelineExecutor::executeImpl(size_t num_threads)
 {
     initializeExecution(num_threads);
 
-    ThreadPool threads(num_threads);
+    using ThreadsData = std::vector<ThreadFromGlobalPool>;
+    ThreadsData threads;
+    threads.reserve(num_threads);
 
     bool finished_flag = false;
 
@@ -702,7 +704,10 @@ void PipelineExecutor::executeImpl(size_t num_threads)
         if (!finished_flag)
         {
             finish();
-            threads.wait();
+
+            for (auto & thread : threads)
+                if (thread.joinable())
+                    thread.join();
         }
     );
 
@@ -712,7 +717,7 @@ void PipelineExecutor::executeImpl(size_t num_threads)
 
         for (size_t i = 0; i < num_threads; ++i)
         {
-            threads.scheduleOrThrowOnError([this, thread_group, thread_num = i, num_threads]
+            threads.emplace_back([this, thread_group, thread_num = i, num_threads]
             {
                 /// ThreadStatus thread_status;
 
@@ -739,14 +744,9 @@ void PipelineExecutor::executeImpl(size_t num_threads)
             });
         }
 
-        /// Because ThreadPool::wait() waits until scheduled_jobs will be zero,
-        /// and this guarantee that the job was reseted, otherwise
-        /// some variables that job is referencing may be already destroyed,
-        /// while job hasn't been destoyed yet (example that pops up --
-        /// PipelineExecutor -> ThreadGroupStatusPtr -> MemoryTracker ->
-        /// ~MemoryTracker -> log, while log had been destroyed already)
-        /// (see 01505_pipeline_executor_UAF)
-        threads.wait();
+        for (auto & thread : threads)
+            if (thread.joinable())
+                thread.join();
     }
     else
         executeSingleThread(0, num_threads);

--- a/tests/queries/0_stateless/01505_pipeline_executor_UAF.sh
+++ b/tests/queries/0_stateless/01505_pipeline_executor_UAF.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../shell_config.sh
+
+# Regression for UAF in ThreadPool.
+# (Triggered under TSAN)
+for i in {1..10}; do
+    ${CLICKHOUSE_LOCAL} -q 'select * from numbers_mt(100000000) settings max_threads=100 FORMAT Null'
+    # Binding to specific CPU is not required, but this makes the test more reliable.
+    taskset --cpu-list 0 ${CLICKHOUSE_LOCAL} -q 'select * from numbers_mt(100000000) settings max_threads=100 FORMAT Null'
+done


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Continuation of #15177