### PR TITLE
Add ability to alter version column in VersionedCollapsingMergeTree.

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1330,6 +1330,44 @@ bool isSafeForPartitionKeyConversion(const IDataType * from, const IDataType * t
     return false;
 }
 
+/// Special check for alters of VersionedCollapsingMergeTree version column
+void checkVersionColumnTypesConversion(const IDataType * old_type, const IDataType * new_type, const String column_name)
+{
+    /// Check new type can be used as version
+    if (!new_type->canBeUsedAsVersion())
+        throw Exception("Cannot alter version column " + backQuoteIfNeed(column_name) +
+            " to type " + new_type->getName() +
+            " because version column must be of an integer type or of type Date or DateTime"
+            , ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN);
+
+    auto which_new_type = WhichDataType(new_type);
+    auto which_old_type = WhichDataType(old_type);
+
+    /// Check alter to different sign or float -> int and so on
+    if ((which_old_type.isInt() && !which_new_type.isInt())
+        || (which_old_type.isUInt() && !which_new_type.isUInt())
+        || (which_old_type.isDate() && !which_new_type.isDate())
+        || (which_old_type.isDateTime() && !which_new_type.isDateTime())
+        || (which_old_type.isFloat() && !which_new_type.isFloat()))
+    {
+        throw Exception("Cannot alter version column " + backQuoteIfNeed(column_name) +
+            " from type " + old_type->getName() +
+            " to type " + new_type->getName() + " because new type will change sort order of version column." +
+            " The only possible conversion is expansion of the number of bytes of the current type."
+            , ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN);
+    }
+
+    /// Check alter to smaller size: UInt64 -> UInt32 and so on
+    if (new_type->getSizeOfValueInMemory() < old_type->getSizeOfValueInMemory())
+    {
+        throw Exception("Cannot alter version column " + backQuoteIfNeed(column_name) +
+            " from type " + old_type->getName() +
+            " to type " + new_type->getName() + " because new type is smaller than current in the number of bytes." +
+            " The only possible conversion is expansion of the number of bytes of the current type."
+            , ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN);
+    }
+}
+
 }
 
 void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, const Settings & settings) const
@@ -1421,41 +1459,10 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, const S
         {
             auto new_type = command.data_type;
             auto old_type = old_types[command.column_name];
-            /// Check new type can be used as version
-            if (!new_type->canBeUsedAsVersion())
-                throw Exception("Cannot alter version column " + backQuoteIfNeed(command.column_name) +
-                    " to type " + new_type->getName() +
-                    " because version column must be of an integer type or of type Date or DateTime"
-                    , ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN);
 
-            auto which_new_type = WhichDataType(new_type);
-            auto which_old_type = WhichDataType(old_type);
+            checkVersionColumnTypesConversion(old_type, new_type.get(), command.column_name);
 
-            /// Check alter to different sign or float -> int and so on
-            if ((which_old_type.isInt() && !which_new_type.isInt())
-                || (which_old_type.isUInt() && !which_new_type.isUInt())
-                || (which_old_type.isDate() && !which_new_type.isDate())
-                || (which_old_type.isDateTime() && !which_new_type.isDateTime())
-                || (which_old_type.isFloat() && !which_new_type.isFloat()))
-            {
-                throw Exception("Cannot alter version column " + backQuoteIfNeed(command.column_name) +
-                    " from type " + old_type->getName() +
-                    " to type " + new_type->getName() + " because new type will change sort order of version column." +
-                    " The only possible conversion is expansion of the number of bytes of the current type."
-                    , ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN);
-            }
-
-            /// Check alter to smaller size: UInt64 -> UInt32 and so on
-            if (new_type->getSizeOfValueInMemory() < old_type->getSizeOfValueInMemory())
-            {
-                throw Exception("Cannot alter version column " + backQuoteIfNeed(command.column_name) +
-                    " from type " + old_type->getName() +
-                    " to type " + new_type->getName() + " because new type is smaller than current in the number of bytes." +
-                    " The only possible conversion is expansion of the number of bytes of the current type."
-                    , ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN);
-            }
-
-            /// Positive case, alter allowed
+            /// No other checks required
             continue;
         }
 

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1457,10 +1457,10 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, const S
         /// Some type changes for version column is allowed despite it's a part of sorting key
         if (command.type == AlterCommand::MODIFY_COLUMN && command.column_name == merging_params.version_column)
         {
-            auto new_type = command.data_type;
-            auto old_type = old_types[command.column_name];
+            const IDataType * new_type = command.data_type.get();
+            const IDataType * old_type = old_types[command.column_name];
 
-            checkVersionColumnTypesConversion(old_type, new_type.get(), command.column_name);
+            checkVersionColumnTypesConversion(old_type, new_type, command.column_name);
 
             /// No other checks required
             continue;

--- a/tests/queries/0_stateless/01511_alter_version_versioned_collapsing_merge_tree.reference
+++ b/tests/queries/0_stateless/01511_alter_version_versioned_collapsing_merge_tree.reference
@@ -1,0 +1,13 @@
+1	1	1	-1
+2	2	2	-1
+CREATE TABLE default.table_with_version\n(\n    `key` UInt64,\n    `value` String,\n    `version` UInt8,\n    `sign` Int8\n)\nENGINE = VersionedCollapsingMergeTree(sign, version)\nORDER BY key\nSETTINGS index_granularity = 8192
+1	1	1	-1
+2	2	2	-1
+CREATE TABLE default.table_with_version\n(\n    `key` UInt64,\n    `value` String,\n    `version` UInt32,\n    `sign` Int8\n)\nENGINE = VersionedCollapsingMergeTree(sign, version)\nORDER BY key\nSETTINGS index_granularity = 8192
+1	1	2	1
+2	2	2	-1
+1	1	2	1
+2	2	2	-1
+3	3	65555	1
+1	1	2	1
+2	2	2	-1

--- a/tests/queries/0_stateless/01511_alter_version_versioned_collapsing_merge_tree.sql
+++ b/tests/queries/0_stateless/01511_alter_version_versioned_collapsing_merge_tree.sql
@@ -37,5 +37,10 @@ INSERT INTO TABLE table_with_version VALUES(3, '3', 65555, -1);
 SELECT * FROM table_with_version FINAL ORDER BY key;
 
 ALTER TABLE table_with_version MODIFY COLUMN version String; --{serverError 524}
+ALTER TABLE table_with_version MODIFY COLUMN version Int64; --{serverError 524}
+ALTER TABLE table_with_version MODIFY COLUMN version UInt16; --{serverError 524}
+ALTER TABLE table_with_version MODIFY COLUMN version Float64; --{serverError 524}
+ALTER TABLE table_with_version MODIFY COLUMN version Date; --{serverError 524}
+ALTER TABLE table_with_version MODIFY COLUMN version DateTime; --{serverError 524}
 
 DROP TABLE IF EXISTS table_with_version;

--- a/tests/queries/0_stateless/01511_alter_version_versioned_collapsing_merge_tree.sql
+++ b/tests/queries/0_stateless/01511_alter_version_versioned_collapsing_merge_tree.sql
@@ -1,0 +1,41 @@
+DROP TABLE IF EXISTS table_with_version;
+
+CREATE TABLE table_with_version
+(
+    key UInt64,
+    value String,
+    version UInt8,
+    sign Int8
+)
+ENGINE VersionedCollapsingMergeTree(sign, version)
+ORDER BY key;
+
+INSERT INTO table_with_version VALUES (1, '1', 1, -1);
+INSERT INTO table_with_version VALUES (2, '2', 2, -1);
+
+SELECT * FROM table_with_version ORDER BY key;
+
+SHOW CREATE TABLE table_with_version;
+
+ALTER TABLE table_with_version MODIFY COLUMN version UInt32;
+
+SELECT * FROM table_with_version ORDER BY key;
+
+SHOW CREATE TABLE table_with_version;
+
+INSERT INTO TABLE table_with_version VALUES(1, '1', 1, 1);
+INSERT INTO TABLE table_with_version VALUES(1, '1', 2, 1);
+
+SELECT * FROM table_with_version FINAL ORDER BY key;
+
+INSERT INTO TABLE table_with_version VALUES(3, '3', 65555, 1);
+
+SELECT * FROM table_with_version FINAL ORDER BY key;
+
+INSERT INTO TABLE table_with_version VALUES(3, '3', 65555, -1);
+
+SELECT * FROM table_with_version FINAL ORDER BY key;
+
+ALTER TABLE table_with_version MODIFY COLUMN version String; --{serverError 524}
+
+DROP TABLE IF EXISTS table_with_version;

--- a/tests/queries/0_stateless/01511_alter_version_versioned_collapsing_merge_tree_zookeeper.reference
+++ b/tests/queries/0_stateless/01511_alter_version_versioned_collapsing_merge_tree_zookeeper.reference
@@ -1,0 +1,16 @@
+1	1	1	-1
+2	2	2	-1
+CREATE TABLE default.table_with_version_replicated_1\n(\n    `key` UInt64,\n    `value` String,\n    `version` UInt8,\n    `sign` Int8\n)\nENGINE = ReplicatedVersionedCollapsingMergeTree(\'/clickhouse/test_01511/t\', \'1\', sign, version)\nORDER BY key\nSETTINGS index_granularity = 8192
+1	1	1	-1
+2	2	2	-1
+CREATE TABLE default.table_with_version_replicated_1\n(\n    `key` UInt64,\n    `value` String,\n    `version` UInt32,\n    `sign` Int8\n)\nENGINE = ReplicatedVersionedCollapsingMergeTree(\'/clickhouse/test_01511/t\', \'1\', sign, version)\nORDER BY key\nSETTINGS index_granularity = 8192
+1	1	2	1
+2	2	2	-1
+1	1	2	1
+2	2	2	-1
+3	3	65555	1
+1	1	2	1
+2	2	2	-1
+CREATE TABLE default.table_with_version_replicated_2\n(\n    `key` UInt64,\n    `value` String,\n    `version` UInt32,\n    `sign` Int8\n)\nENGINE = ReplicatedVersionedCollapsingMergeTree(\'/clickhouse/test_01511/t\', \'2\', sign, version)\nORDER BY key\nSETTINGS index_granularity = 8192
+1	1	2	1
+2	2	2	-1

--- a/tests/queries/0_stateless/01511_alter_version_versioned_collapsing_merge_tree_zookeeper.sql
+++ b/tests/queries/0_stateless/01511_alter_version_versioned_collapsing_merge_tree_zookeeper.sql
@@ -1,0 +1,64 @@
+DROP TABLE IF EXISTS table_with_version_replicated_1;
+DROP TABLE IF EXISTS table_with_version_replicated_2;
+
+CREATE TABLE table_with_version_replicated_1
+(
+    key UInt64,
+    value String,
+    version UInt8,
+    sign Int8
+)
+ENGINE ReplicatedVersionedCollapsingMergeTree('/clickhouse/test_01511/t', '1', sign, version)
+ORDER BY key;
+
+CREATE TABLE table_with_version_replicated_2
+(
+    key UInt64,
+    value String,
+    version UInt8,
+    sign Int8
+)
+ENGINE ReplicatedVersionedCollapsingMergeTree('/clickhouse/test_01511/t', '2', sign, version)
+ORDER BY key;
+
+INSERT INTO table_with_version_replicated_1 VALUES (1, '1', 1, -1);
+INSERT INTO table_with_version_replicated_1 VALUES (2, '2', 2, -1);
+
+SELECT * FROM table_with_version_replicated_1 ORDER BY key;
+
+SHOW CREATE TABLE table_with_version_replicated_1;
+
+ALTER TABLE table_with_version_replicated_1 MODIFY COLUMN version UInt32 SETTINGS replication_alter_partitions_sync=2;
+
+SELECT * FROM table_with_version_replicated_1 ORDER BY key;
+
+SHOW CREATE TABLE table_with_version_replicated_1;
+
+INSERT INTO TABLE table_with_version_replicated_1 VALUES(1, '1', 1, 1);
+INSERT INTO TABLE table_with_version_replicated_1 VALUES(1, '1', 2, 1);
+
+SELECT * FROM table_with_version_replicated_1 FINAL ORDER BY key;
+
+INSERT INTO TABLE table_with_version_replicated_1 VALUES(3, '3', 65555, 1);
+
+SELECT * FROM table_with_version_replicated_1 FINAL ORDER BY key;
+
+INSERT INTO TABLE table_with_version_replicated_1 VALUES(3, '3', 65555, -1);
+
+SYSTEM SYNC REPLICA table_with_version_replicated_2;
+
+DETACH TABLE table_with_version_replicated_1;
+DETACH TABLE table_with_version_replicated_2;
+ATTACH TABLE table_with_version_replicated_2;
+ATTACH TABLE table_with_version_replicated_1;
+
+SELECT * FROM table_with_version_replicated_1 FINAL ORDER BY key;
+
+SYSTEM SYNC REPLICA table_with_version_replicated_2;
+
+SHOW CREATE TABLE table_with_version_replicated_2;
+
+SELECT * FROM table_with_version_replicated_2 FINAL ORDER BY key;
+
+DROP TABLE IF EXISTS table_with_version_replicated_1;
+DROP TABLE IF EXISTS table_with_version_replicated_2;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now it's possible to change the type of version column for `VersionedCollapsingMergeTree` with `ALTER` query.