### PR TITLE
Fix exception safety in ShellCommand

### DIFF
--- a/src/Common/ShellCommand.cpp
+++ b/src/Common/ShellCommand.cpp
@@ -35,12 +35,14 @@ namespace ErrorCodes
     extern const int CANNOT_CREATE_CHILD_PROCESS;
 }
 
-ShellCommand::ShellCommand(pid_t pid_, int in_fd_, int out_fd_, int err_fd_, bool terminate_in_destructor_)
+ShellCommand::ShellCommand(pid_t pid_, int & in_fd_, int & out_fd_, int & err_fd_, bool terminate_in_destructor_)
     : pid(pid_)
     , terminate_in_destructor(terminate_in_destructor_)
     , in(in_fd_)
     , out(out_fd_)
-    , err(err_fd_) {}
+    , err(err_fd_)
+{
+}
 
 Poco::Logger * ShellCommand::getLogger()
 {
@@ -144,12 +146,6 @@ std::unique_ptr<ShellCommand> ShellCommand::executeImpl(
         pid, pipe_stdin.fds_rw[1], pipe_stdout.fds_rw[0], pipe_stderr.fds_rw[0], terminate_in_destructor));
 
     LOG_TRACE(getLogger(), "Started shell command '{}' with pid {}", filename, pid);
-
-    /// Now the ownership of the file descriptors is passed to the result.
-    pipe_stdin.fds_rw[1] = -1;
-    pipe_stdout.fds_rw[0] = -1;
-    pipe_stderr.fds_rw[0] = -1;
-
     return res;
 }
 

--- a/src/Common/ShellCommand.h
+++ b/src/Common/ShellCommand.h
@@ -30,7 +30,7 @@ private:
     bool wait_called = false;
     bool terminate_in_destructor;
 
-    ShellCommand(pid_t pid_, int in_fd_, int out_fd_, int err_fd_, bool terminate_in_destructor_);
+    ShellCommand(pid_t pid_, int & in_fd_, int & out_fd_, int & err_fd_, bool terminate_in_destructor_);
 
     static Poco::Logger * getLogger();
 

--- a/src/IO/ReadBufferFromFile.cpp
+++ b/src/IO/ReadBufferFromFile.cpp
@@ -54,7 +54,7 @@ ReadBufferFromFile::ReadBufferFromFile(
 
 
 ReadBufferFromFile::ReadBufferFromFile(
-    int fd_,
+    int & fd_,
     const std::string & original_file_name,
     size_t buf_size,
     char * existing_memory,
@@ -63,6 +63,7 @@ ReadBufferFromFile::ReadBufferFromFile(
     ReadBufferFromFileDescriptor(fd_, buf_size, existing_memory, alignment),
     file_name(original_file_name.empty() ? "(fd = " + toString(fd_) + ")" : original_file_name)
 {
+    fd_ = -1;
 }
 
 

--- a/src/IO/ReadBufferFromFile.h
+++ b/src/IO/ReadBufferFromFile.h
@@ -29,7 +29,10 @@ public:
         char * existing_memory = nullptr, size_t alignment = 0);
 
     /// Use pre-opened file descriptor.
-    ReadBufferFromFile(int fd, const std::string & original_file_name = {}, size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE,
+    ReadBufferFromFile(
+        int & fd, /// Will be set to -1 if constructor didn't throw and ownership of file descriptor is passed to the object.
+        const std::string & original_file_name = {},
+        size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE,
         char * existing_memory = nullptr, size_t alignment = 0);
 
     ~ReadBufferFromFile() override;

--- a/src/IO/WriteBufferFromFile.cpp
+++ b/src/IO/WriteBufferFromFile.cpp
@@ -59,7 +59,7 @@ WriteBufferFromFile::WriteBufferFromFile(
 
 /// Use pre-opened file descriptor.
 WriteBufferFromFile::WriteBufferFromFile(
-    int fd_,
+    int & fd_,
     const std::string & original_file_name,
     size_t buf_size,
     char * existing_memory,
@@ -68,6 +68,7 @@ WriteBufferFromFile::WriteBufferFromFile(
     WriteBufferFromFileDescriptor(fd_, buf_size, existing_memory, alignment),
     file_name(original_file_name.empty() ? "(fd = " + toString(fd_) + ")" : original_file_name)
 {
+    fd_ = -1;
 }
 
 

--- a/src/IO/WriteBufferFromFile.h
+++ b/src/IO/WriteBufferFromFile.h
@@ -39,7 +39,7 @@ public:
 
     /// Use pre-opened file descriptor.
     WriteBufferFromFile(
-        int fd,
+        int & fd,   /// Will be set to -1 if constructor didn't throw and ownership of file descriptor is passed to the object.
         const std::string & original_file_name = {},
         size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE,
         char * existing_memory = nullptr,


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Suppose we are out of memory and when the second or third of Read/WriteBuffers are constructed in constructor of ShellCommand, exception is thrown. Then we will attempt to close the first file descriptor twice (it's a race condition as another file descriptor with the same number can be created in between).

PS. This was definitely an error but I'm not sure that it was reproducing.
Maybe the reason of TSan reports is different.
See also:
http://lists.llvm.org/pipermail/llvm-commits/Week-of-Mon-20140224/206389.html