### PR TITLE
Add "replicate" mode in StorageDistributed (proof-of-concept)

### DIFF
--- a/src/Storages/Distributed/DistributedBlockOutputStream.h
+++ b/src/Storages/Distributed/DistributedBlockOutputStream.h
@@ -43,6 +43,7 @@ public:
         const StorageMetadataPtr & metadata_snapshot_,
         const ASTPtr & query_ast_,
         const ClusterPtr & cluster_,
+        bool replicate_,
         bool insert_sync_,
         UInt64 insert_timeout_);
 
@@ -61,6 +62,8 @@ private:
     Blocks splitBlock(const Block & block);
 
     void writeSplitAsync(const Block & block);
+
+    void writeReplicatedAsync(const Block & block);
 
     void writeAsyncImpl(const Block & block, const size_t shard_id = 0);
 
@@ -93,6 +96,7 @@ private:
     size_t inserted_blocks = 0;
     size_t inserted_rows = 0;
 
+    bool replicate;
     bool insert_sync;
 
     /// Sync-related stuff

--- a/src/Storages/StorageDistributed.h
+++ b/src/Storages/StorageDistributed.h
@@ -144,6 +144,7 @@ public:
     const String cluster_name;
 
     bool has_sharding_key;
+    bool replicate;
     bool sharding_key_is_deterministic = false;
     ExpressionActionsPtr sharding_key_expr;
     String sharding_key_column_name;
@@ -163,6 +164,7 @@ protected:
         const String & cluster_name_,
         const Context & context_,
         const ASTPtr & sharding_key_,
+        bool replicate_,
         const String & storage_policy_name_,
         const String & relative_data_path_,
         bool attach_);
@@ -175,6 +177,7 @@ protected:
         const String & cluster_name_,
         const Context & context_,
         const ASTPtr & sharding_key_,
+        bool replicate_,
         const String & storage_policy_name_,
         const String & relative_data_path_,
         bool attach);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Proof of concept


Detailed description / Documentation draft:

Added the "replicate" mode to StorageDistributed which performs copying instead of sharding. It is a light-weight (but not reliable) method to do data replication.

```sql
create table test_local (a Int64) engine = MergeTree order by a;
create table test_distributed (a Int64) engine = Distributed(servers, default, test_local, 'replicate');
```

**This PR is not ready for merging / production use.**
