### PR TITLE
Add experimental codecov.yml

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,17 @@
+codecov:
+  max_report_age: off
+  strict_yaml_branch: "master"
+
+ignore:
+  - "contrib"
+  - "docs"
+  - "benchmark"
+  - "tests"
+  - "docker"
+  - "debian"
+  - "cmake"
+
+comment: false
+
+github_checks:
+  annotations: false


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Added CodeCov config to allow push coverage results that are older than 12 hours.
Disabled comments and other notifications.
Configuration is passive - all checks and coverage reports should be pushed by us and out CI.

Detailed description / Documentation draft:

...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
