### PR TITLE
Update ActionsVisitor.cpp

### DIFF
--- a/src/Interpreters/ActionsVisitor.cpp
+++ b/src/Interpreters/ActionsVisitor.cpp
@@ -510,13 +510,14 @@ void ActionsMatcher::visit(const ASTIdentifier & identifier, const ASTPtr & ast,
         /// The requested column is not in the block.
         /// If such a column exists in the table, then the user probably forgot to surround it with an aggregate function or add it to GROUP BY.
  
-        for (const auto & column_name_type : data.source_columns) {
-            if (column_name_type.name == column_name.get(ast)) {
+        for (const auto & column_name_type : data.source_columns) 
+        {
+            if (column_name_type.name == column_name.get(ast)) 
+            {
                 throw Exception("Column " + backQuote(column_name.get(ast)) + " is not under aggregate function and not in GROUP BY",
                 ErrorCodes::NOT_AN_AGGREGATE);
             }
         }
-
 
         /// Special check for WITH statement alias. Add alias action to be able to use this alias.
         if (identifier.prefer_alias_to_column_name && !identifier.alias.empty())

--- a/src/Interpreters/ActionsVisitor.cpp
+++ b/src/Interpreters/ActionsVisitor.cpp
@@ -509,10 +509,10 @@ void ActionsMatcher::visit(const ASTIdentifier & identifier, const ASTPtr & ast,
     {
         /// The requested column is not in the block.
         /// If such a column exists in the table, then the user probably forgot to surround it with an aggregate function or add it to GROUP BY.
- 
-        for (const auto & column_name_type : data.source_columns) 
+
+        for (const auto & column_name_type : data.source_columns)
         {
-            if (column_name_type.name == column_name.get(ast)) 
+            if (column_name_type.name == column_name.get(ast))
             {
                 throw Exception("Column " + backQuote(column_name.get(ast)) + " is not under aggregate function and not in GROUP BY",
                 ErrorCodes::NOT_AN_AGGREGATE);

--- a/src/Interpreters/ActionsVisitor.cpp
+++ b/src/Interpreters/ActionsVisitor.cpp
@@ -509,15 +509,14 @@ void ActionsMatcher::visit(const ASTIdentifier & identifier, const ASTPtr & ast,
     {
         /// The requested column is not in the block.
         /// If such a column exists in the table, then the user probably forgot to surround it with an aggregate function or add it to GROUP BY.
-
-        bool found = false;
-        for (const auto & column_name_type : data.source_columns)
-            if (column_name_type.name == column_name.get(ast))
-                found = true;
-
-        if (found)
-            throw Exception("Column " + backQuote(column_name.get(ast)) + " is not under aggregate function and not in GROUP BY",
+ 
+        for (const auto & column_name_type : data.source_columns) {
+            if (column_name_type.name == column_name.get(ast)) {
+                throw Exception("Column " + backQuote(column_name.get(ast)) + " is not under aggregate function and not in GROUP BY",
                 ErrorCodes::NOT_AN_AGGREGATE);
+            }
+        }
+
 
         /// Special check for WITH statement alias. Add alias action to be able to use this alias.
         if (identifier.prefer_alias_to_column_name && !identifier.alias.empty())


### PR DESCRIPTION
Refactoring: eliminated a local, throws if it matches the column name as opposed to iterating to the end of the container.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog