### PR TITLE
Neutrialize thinlto's memcpy libcall gen.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -513,7 +513,12 @@ endif ()
 macro (add_executable target)
     # invoke built-in add_executable
     # explicitly acquire and interpose malloc symbols by clickhouse_malloc
-    _add_executable (${ARGV} $<TARGET_OBJECTS:clickhouse_malloc>)
+    # if GLIBC_COMPATIBILITY is ON, also provide memcpy symbol explicitly to neutrialize thinlto's libcall generation.
+    if (GLIBC_COMPATIBILITY)
+        _add_executable (${ARGV} $<TARGET_OBJECTS:clickhouse_malloc> $<TARGET_OBJECTS:clickhouse_memcpy>)
+    else (GLIBC_COMPATIBILITY)
+        _add_executable (${ARGV} $<TARGET_OBJECTS:clickhouse_malloc>)
+    endif ()
     get_target_property (type ${target} TYPE)
     if (${type} STREQUAL EXECUTABLE)
         # operator::new/delete for executables (MemoryTracker stuff)

--- a/base/glibc-compatibility/CMakeLists.txt
+++ b/base/glibc-compatibility/CMakeLists.txt
@@ -27,6 +27,10 @@ if (GLIBC_COMPATIBILITY)
         list(APPEND glibc_compatibility_sources musl/getentropy.c)
     endif()
 
+    add_library (clickhouse_memcpy OBJECT
+        ${ClickHouse_SOURCE_DIR}/contrib/FastMemcpy/memcpy_wrapper.c
+    )
+
     # Need to omit frame pointers to match the performance of glibc
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fomit-frame-pointer")
 

--- a/contrib/FastMemcpy/memcpy_wrapper.c
+++ b/contrib/FastMemcpy/memcpy_wrapper.c
@@ -1,4 +1,4 @@
-#include <FastMemcpy.h>
+#include "FastMemcpy.h"
 
 void * memcpy(void * __restrict destination, const void * __restrict source, size_t size)
 {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

This is for https://github.com/ClickHouse/ClickHouse/pull/15239 .

Detailed description / Documentation draft:

None.