### PR TITLE
Add missing entry to client packet stringify

### DIFF
--- a/src/Core/Protocol.h
+++ b/src/Core/Protocol.h
@@ -146,6 +146,7 @@ namespace Protocol
                 "Ping",
                 "TablesStatusRequest",
                 "KeepAlive",
+                "Scalar",
             };
             return packet <= MAX
                 ? data[packet]


### PR DESCRIPTION
(noticed while reading the code)

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:

...

