### PR TITLE
Fix mutation may hang after REPLACE/DROP PARTITION

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -4053,6 +4053,7 @@ Pipe StorageReplicatedMergeTree::alterPartition(
 
 
 /// If new version returns ordinary name, else returns part name containing the first and last month of the month
+/// NOTE: use it in pair with getFakePartCoveringAllPartsInPartition(...)
 static String getPartNamePossiblyFake(MergeTreeDataFormatVersion format_version, const MergeTreePartInfo & part_info)
 {
     if (format_version < MERGE_TREE_DATA_MIN_FORMAT_VERSION_WITH_CUSTOM_PARTITIONING)
@@ -4068,7 +4069,7 @@ static String getPartNamePossiblyFake(MergeTreeDataFormatVersion format_version,
     return part_info.getPartName();
 }
 
-bool StorageReplicatedMergeTree::getFakePartCoveringAllPartsInPartition(const String & partition_id, MergeTreePartInfo & part_info)
+bool StorageReplicatedMergeTree::getFakePartCoveringAllPartsInPartition(const String & partition_id, MergeTreePartInfo & part_info, bool for_replace_partition)
 {
     /// Even if there is no data in the partition, you still need to mark the range for deletion.
     /// - Because before executing DETACH, tasks for downloading parts to this partition can be executed.
@@ -4091,11 +4092,15 @@ bool StorageReplicatedMergeTree::getFakePartCoveringAllPartsInPartition(const St
         mutation_version = queue.getCurrentMutationVersion(partition_id, right);
     }
 
-    /// Empty partition.
-    if (right == 0)
-        return false;
+    /// REPLACE PARTITION does not decrement max_block of DROP_RANGE for unknown (probably historical) reason.
+    if (!for_replace_partition)
+    {
+        /// Empty partition.
+        if (right == 0)
+            return false;
 
-    --right;
+        --right;
+    }
 
     /// Artificial high level is chosen, to make this part "covering" all parts inside.
     part_info = MergeTreePartInfo(partition_id, left, right, MergeTreePartInfo::MAX_LEVEL, mutation_version);
@@ -5305,11 +5310,11 @@ void StorageReplicatedMergeTree::replacePartitionFrom(
     /// Firstly, generate last block number and compute drop_range
     /// NOTE: Even if we make ATTACH PARTITION instead of REPLACE PARTITION drop_range will not be empty, it will contain a block.
     /// So, such case has special meaning, if drop_range contains only one block it means that nothing to drop.
+    /// TODO why not to add normal DROP_RANGE entry to replication queue if `replace` is true?
     MergeTreePartInfo drop_range;
-    drop_range.partition_id = partition_id;
-    drop_range.max_block = allocateBlockNumber(partition_id, zookeeper)->getNumber();
-    drop_range.min_block = replace ? 0 : drop_range.max_block;
-    drop_range.level = std::numeric_limits<decltype(drop_range.level)>::max();
+    getFakePartCoveringAllPartsInPartition(partition_id, drop_range, true);
+    if (!replace)
+        drop_range.min_block = drop_range.max_block;
 
     String drop_range_fake_part_name = getPartNamePossiblyFake(format_version, drop_range);
 
@@ -5502,11 +5507,7 @@ void StorageReplicatedMergeTree::movePartitionToTable(const StoragePtr & dest_ta
     /// A range for log entry to remove parts from the source table (myself).
 
     MergeTreePartInfo drop_range;
-    drop_range.partition_id = partition_id;
-    drop_range.max_block = allocateBlockNumber(partition_id, zookeeper)->getNumber();
-    drop_range.min_block = 0;
-    drop_range.level = std::numeric_limits<decltype(drop_range.level)>::max();
-
+    getFakePartCoveringAllPartsInPartition(partition_id, drop_range, true);
     String drop_range_fake_part_name = getPartNamePossiblyFake(format_version, drop_range);
 
     if (drop_range.getBlocksCount() > 1)
@@ -5561,6 +5562,7 @@ void StorageReplicatedMergeTree::movePartitionToTable(const StoragePtr & dest_ta
         drop_range_dest.max_block = drop_range.max_block;
         drop_range_dest.min_block = drop_range.max_block;
         drop_range_dest.level = drop_range.level;
+        drop_range_dest.mutation = drop_range.mutation;
 
         entry.type = ReplicatedMergeTreeLogEntryData::REPLACE_RANGE;
         entry.source_replica = dest_table_storage->replica_name;

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -526,7 +526,7 @@ private:
 
     /// Produce an imaginary part info covering all parts in the specified partition (at the call moment).
     /// Returns false if the partition doesn't exist yet.
-    bool getFakePartCoveringAllPartsInPartition(const String & partition_id, MergeTreePartInfo & part_info);
+    bool getFakePartCoveringAllPartsInPartition(const String & partition_id, MergeTreePartInfo & part_info, bool for_replace_partition = false);
 
     /// Check for a node in ZK. If it is, remember this information, and then immediately answer true.
     std::unordered_set<std::string> existing_nodes_cache;

--- a/tests/queries/0_stateless/01149_zookeeper_mutation_stuck_after_replace_partition.reference
+++ b/tests/queries/0_stateless/01149_zookeeper_mutation_stuck_after_replace_partition.reference
@@ -1,0 +1,29 @@
+1
+2
+44
+33
+3
+4
+default	mt	0	0_1_1_0	2
+default	mt	3	3_2_2_0	1
+default	mt	4	4_3_3_0	1
+default	rmt	0	0_0_0_0	2
+3
+4
+default	mt	0	0_1_1_0	2
+default	mt	3	3_2_2_0	1
+default	mt	4	4_3_3_0	1
+default	rmt	0	0_2_2_0	2
+3
+4
+1	1
+2	2
+3
+4
+default	mt	0	0_1_1_0	2
+default	mt	3	3_2_2_0	1
+default	mt	4	4_3_3_0	1
+default	rmt	0	0_6_6_0	2
+default	rmt	0000000000	DROP COLUMN s	2020-10-02 17:46:31	['0']	[3]	['0_0_5_4294967295']	1	1		1970-01-01 03:00:00
+3
+4

--- a/tests/queries/0_stateless/01149_zookeeper_mutation_stuck_after_replace_partition.reference
+++ b/tests/queries/0_stateless/01149_zookeeper_mutation_stuck_after_replace_partition.reference
@@ -1,29 +1,14 @@
-1
-2
-44
-33
-3
-4
-default	mt	0	0_1_1_0	2
-default	mt	3	3_2_2_0	1
-default	mt	4	4_3_3_0	1
-default	rmt	0	0_0_0_0	2
-3
-4
-default	mt	0	0_1_1_0	2
-default	mt	3	3_2_2_0	1
-default	mt	4	4_3_3_0	1
-default	rmt	0	0_2_2_0	2
-3
-4
 1	1
 2	2
-3
-4
-default	mt	0	0_1_1_0	2
-default	mt	3	3_2_2_0	1
-default	mt	4	4_3_3_0	1
-default	rmt	0	0_6_6_0	2
-default	rmt	0000000000	DROP COLUMN s	2020-10-02 17:46:31	['0']	[3]	['0_0_5_4294967295']	1	1		1970-01-01 03:00:00
+3	3
+4	4
+mt	0	0_1_1_0	2
+rmt	0	0_0_0_0	2
+1	1
+2	2
+mt	0	0_1_1_0	2
+rmt	0	0_3_3_0	2
+0000000000	UPDATE s = concat(\'s\', toString(n)) WHERE 1	[]	0	1
+0000000001	DROP COLUMN s	[]	0	1
 3
 4

--- a/tests/queries/0_stateless/01149_zookeeper_mutation_stuck_after_replace_partition.sql
+++ b/tests/queries/0_stateless/01149_zookeeper_mutation_stuck_after_replace_partition.sql
@@ -1,39 +1,28 @@
 drop table if exists mt;
 drop table if exists rmt;
 
+create table mt (n UInt64, s String) engine = MergeTree partition by intDiv(n, 10) order by n;
+insert into mt values (3, '3'), (4, '4');
 
-create table mt (`n` UInt64) engine = MergeTree partition by intDiv(n, 10) order by n;
+create table rmt (n UInt64, s String) engine = ReplicatedMergeTree('/clickhouse/test_01149/rmt', 'r1') partition by intDiv(n, 10) order by n;
+insert into rmt values (1,'1'), (2, '2');
 
-insert into mt values (3), (4), (33), (44);
-
-create table rmt (`n` UInt64) engine = ReplicatedMergeTree('/clickhouse/test_01149/rmt1', 'r1') partition by intDiv(n, 10) order by n;
-
-insert into rmt values (1), (2);
 select * from rmt;
 select * from mt;
+select table, partition_id, name, rows from system.parts where database=currentDatabase() and table in ('mt', 'rmt') order by table, name;
 
-select database, table, partition_id, name, rows from system.parts where database=currentDatabase() and table in ('mt', 'rmt') order by table, name;
-
-alter table rmt replace partition '0' from mt;
-select * from rmt;
-select database, table, partition_id, name, rows from system.parts where database=currentDatabase() and table in ('mt', 'rmt') order by table, name;
-
-alter table rmt add column s String;
-alter table rmt drop column s;
-select * from rmt;
-alter table rmt add column s String;
-insert into rmt values (1, '1'), (2, '2');
-alter table mt add column s String;
+alter table rmt update s = 's'||toString(n) where 1;    -- increment mutation version
 select * from rmt;
 alter table rmt replace partition '0' from mt;      -- (probably) removes parts incorrectly
 
-select database, table, partition_id, name, rows from system.parts where database=currentDatabase() and table in ('mt', 'rmt') order by table, name;
+--system restart replica rmt;  -- workaround
+
+select table, partition_id, name, rows from system.parts where database=currentDatabase() and table in ('mt', 'rmt') order by table, name;
 
 alter table rmt drop column s;  -- hangs waiting for mutation of removed parts
 
 -- see parts_to_do
-select * from system.mutations where database=currentDatabase() and table='rmt';
-
+select mutation_id, command, parts_to_do_names, parts_to_do, is_done from system.mutations where database=currentDatabase() and table='rmt';
 select * from rmt;
 
 drop table mt;

--- a/tests/queries/0_stateless/01149_zookeeper_mutation_stuck_after_replace_partition.sql
+++ b/tests/queries/0_stateless/01149_zookeeper_mutation_stuck_after_replace_partition.sql
@@ -22,5 +22,17 @@ alter table rmt drop column s;
 select mutation_id, command, parts_to_do_names, parts_to_do, is_done from system.mutations where database=currentDatabase() and table='rmt';
 select * from rmt;
 
+drop table rmt sync;
+
+set replication_alter_partitions_sync=0;
+create table rmt (n UInt64, s String) engine = ReplicatedMergeTree('/clickhouse/test_01149/rmt', 'r1') partition by intDiv(n, 10) order by n;
+insert into rmt values (1,'1'), (2, '2');
+
+alter table rmt update s = 's'||toString(n) where 1;
+alter table rmt drop partition '0';
+
+set replication_alter_partitions_sync=1;
+alter table rmt drop column s;
+
 drop table mt;
 drop table rmt sync;

--- a/tests/queries/0_stateless/01149_zookeeper_mutation_stuck_after_replace_partition.sql
+++ b/tests/queries/0_stateless/01149_zookeeper_mutation_stuck_after_replace_partition.sql
@@ -12,6 +12,7 @@ select * from mt;
 select table, partition_id, name, rows from system.parts where database=currentDatabase() and table in ('mt', 'rmt') and active=1 order by table, name;
 
 alter table rmt update s = 's'||toString(n) where 1;
+
 select * from rmt;
 alter table rmt replace partition '0' from mt;
 

--- a/tests/queries/0_stateless/01149_zookeeper_mutation_stuck_after_replace_partition.sql
+++ b/tests/queries/0_stateless/01149_zookeeper_mutation_stuck_after_replace_partition.sql
@@ -1,0 +1,40 @@
+drop table if exists mt;
+drop table if exists rmt;
+
+
+create table mt (`n` UInt64) engine = MergeTree partition by intDiv(n, 10) order by n;
+
+insert into mt values (3), (4), (33), (44);
+
+create table rmt (`n` UInt64) engine = ReplicatedMergeTree('/clickhouse/test_01149/rmt1', 'r1') partition by intDiv(n, 10) order by n;
+
+insert into rmt values (1), (2);
+select * from rmt;
+select * from mt;
+
+select database, table, partition_id, name, rows from system.parts where database=currentDatabase() and table in ('mt', 'rmt') order by table, name;
+
+alter table rmt replace partition '0' from mt;
+select * from rmt;
+select database, table, partition_id, name, rows from system.parts where database=currentDatabase() and table in ('mt', 'rmt') order by table, name;
+
+alter table rmt add column s String;
+alter table rmt drop column s;
+select * from rmt;
+alter table rmt add column s String;
+insert into rmt values (1, '1'), (2, '2');
+alter table mt add column s String;
+select * from rmt;
+alter table rmt replace partition '0' from mt;      -- (probably) removes parts incorrectly
+
+select database, table, partition_id, name, rows from system.parts where database=currentDatabase() and table in ('mt', 'rmt') order by table, name;
+
+alter table rmt drop column s;  -- hangs waiting for mutation of removed parts
+
+-- see parts_to_do
+select * from system.mutations where database=currentDatabase() and table='rmt';
+
+select * from rmt;
+
+drop table mt;
+drop table rmt;

--- a/tests/queries/0_stateless/01149_zookeeper_mutation_stuck_after_replace_partition.sql
+++ b/tests/queries/0_stateless/01149_zookeeper_mutation_stuck_after_replace_partition.sql
@@ -1,5 +1,5 @@
 drop table if exists mt;
-drop table if exists rmt;
+drop table if exists rmt sync;
 
 create table mt (n UInt64, s String) engine = MergeTree partition by intDiv(n, 10) order by n;
 insert into mt values (3, '3'), (4, '4');
@@ -9,21 +9,18 @@ insert into rmt values (1,'1'), (2, '2');
 
 select * from rmt;
 select * from mt;
-select table, partition_id, name, rows from system.parts where database=currentDatabase() and table in ('mt', 'rmt') order by table, name;
+select table, partition_id, name, rows from system.parts where database=currentDatabase() and table in ('mt', 'rmt') and active=1 order by table, name;
 
-alter table rmt update s = 's'||toString(n) where 1;    -- increment mutation version
+alter table rmt update s = 's'||toString(n) where 1;
 select * from rmt;
-alter table rmt replace partition '0' from mt;      -- (probably) removes parts incorrectly
+alter table rmt replace partition '0' from mt;
 
---system restart replica rmt;  -- workaround
+select table, partition_id, name, rows from system.parts where database=currentDatabase() and table in ('mt', 'rmt') and active=1 order by table, name;
 
-select table, partition_id, name, rows from system.parts where database=currentDatabase() and table in ('mt', 'rmt') order by table, name;
+alter table rmt drop column s;
 
-alter table rmt drop column s;  -- hangs waiting for mutation of removed parts
-
--- see parts_to_do
 select mutation_id, command, parts_to_do_names, parts_to_do, is_done from system.mutations where database=currentDatabase() and table='rmt';
 select * from rmt;
 
 drop table mt;
-drop table rmt;
+drop table rmt sync;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Mutation might hang waiting for some non-existent part after `MOVE` or `REPLACE PARTITION` or, in rare cases, after `DETACH` or `DROP PARTITION`. It's fixed.


Detailed description / Documentation draft:
Actually fixes two independent bugs: wrong covering part for partition in `REPLACE_RANGE` and excess virtual parts in `parts_to_do`

