### PR TITLE
Improve quantileTDigest performance

### DIFF
--- a/src/AggregateFunctions/QuantileTDigest.h
+++ b/src/AggregateFunctions/QuantileTDigest.h
@@ -243,7 +243,8 @@ public:
 };
 
 template <typename T>
-class QuantileTDigest {
+class QuantileTDigest
+{
     using Value = Float32;
     using Count = Float32;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Performance Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve `quantileTDigest` performance. This fixes #2668.

Detailed description / Documentation draft:
Improve quantileTDigest performance by using the next method:
We store two t-digests instead of one. When an amount of elements in first t-digest becomes more than some threshold (10'000'000 in this case) we merge first t-digest in the second, reset first and start filling first t-digest. This method is needed to decrease an amount of centroids in first t-digest (experiments show that after this threshold the size of t-digest significantly grows, but merging two big t-digest decreases it).

Previously, applying this function (quantileTDigest) to the data with large size (more then 1 billion rows) took almost forever  (https://github.com/ClickHouse/ClickHouse/issues/2668). So now it's ok:
```
:) SELECT count(*) FROM test.quantilesTDigest

SELECT count(*)
FROM test.quantilesTDigest

┌────count()─┐
│ 1400000000 │
└────────────┘

1 rows in set. Elapsed: 0.009 sec. 

:) SELECT quantilesTDigest(0.01, 0.05, 0.25, 0.5, 0.75, 0.95, 0.99)(x) FROM test.quantilesTDigest;

SELECT quantilesTDigest(0.01, 0.05, 0.25, 0.5, 0.75, 0.95, 0.99)(x)
FROM test.quantilesTDigest

┌─quantilesTDigest(0.01, 0.05, 0.25, 0.5, 0.75, 0.95, 0.99)(x)─────────────┐
│ [14104604,70187840,350080540,699598600,1049228600,1329492000,1385572900] │
└──────────────────────────────────────────────────────────────────────────┘

1 rows in set. Elapsed: 29.936 sec. Processed 1.40 billion rows, 5.60 GB (46.77 million rows/s., 187.07 MB/s.)

```

