### PR TITLE
[RFC] Significantly reduce memory usage in AggregatingInOrderTransform

### DIFF
--- a/src/Processors/Transforms/AggregatingTransform.h
+++ b/src/Processors/Transforms/AggregatingTransform.h
@@ -8,6 +8,15 @@
 namespace DB
 {
 
+class AggregatedArenasChunkInfo : public ChunkInfo
+{
+public:
+    Arenas arenas;
+    AggregatedArenasChunkInfo(Arenas arenas_)
+        : arenas(std::move(arenas_))
+    {}
+};
+
 class AggregatedChunkInfo : public ChunkInfo
 {
 public:

--- a/tests/queries/0_stateless/01513_optimize_aggregation_in_order_memory.sql
+++ b/tests/queries/0_stateless/01513_optimize_aggregation_in_order_memory.sql
@@ -1,0 +1,16 @@
+drop table if exists data_01513;
+create table data_01513 (key String) engine=MergeTree() order by key;
+-- 10e3 groups, 1e3 keys each
+insert into data_01513 select number%10e3 from numbers(toUInt64(2e6));
+-- reduce number of parts to 1
+optimize table data_01513 final;
+
+-- this is enough to trigger non-reusable Chunk in Arena.
+set max_memory_usage='500M';
+set max_threads=1;
+set max_block_size=500;
+
+select key, groupArray(repeat('a', 200)), count() from data_01513 group by key format Null; -- { serverError 241; }
+select key, groupArray(repeat('a', 200)), count() from data_01513 group by key format Null settings optimize_aggregation_in_order=1;
+-- for WITH TOTALS previous groups should be kept.
+select key, groupArray(repeat('a', 200)), count() from data_01513 group by key with totals format Null settings optimize_aggregation_in_order=1; -- { serverError 241; }


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Significantly reduce memory usage in AggregatingInOrderTransform/optimize_aggregation_in_order

Detailed description / Documentation draft:
Clean the aggregates pools (Arena's objects) between flushes, this will
reduce memory usage significantly (since Arena is not intended for
memory reuse in the already full Chunk's)

Before this patch you cannot run SELECT FROM huge_table GROUP BY
primary_key SETTINGS optimize_aggregation_in_order=1 (and the whole
point of optimize_aggregation_in_order got lost), while after, this
should be possible.

P.S. marked as bug fix, since it seems that this change should be backported (but personally I don't need this, so feel free to adjust this as you wish).

Refs: #9113

<details>

HEAD:
- 8195a309dfd4db2f9c906c322cb9a001008d6c6c w/ log message
- 2a2f858365168f0bf74ef4da52d67c62eda6eefd w/o log message

</details>