### PR TITLE
Handle EINTR in statvfs

### DIFF
--- a/src/Common/filesystemHelpers.cpp
+++ b/src/Common/filesystemHelpers.cpp
@@ -5,6 +5,7 @@
 #    include <cstdio>
 #    include <mntent.h>
 #endif
+#include <cerrno>
 #include <Poco/File.h>
 #include <Poco/Path.h>
 #include <Poco/Version.h>

--- a/src/Common/filesystemHelpers.cpp
+++ b/src/Common/filesystemHelpers.cpp
@@ -18,6 +18,20 @@ namespace ErrorCodes
     extern const int NOT_IMPLEMENTED;
 }
 
+
+struct statvfs getStatVFS(const String & path)
+{
+    struct statvfs fs;
+    while (statvfs(path.c_str(), &fs) != 0)
+    {
+        if (errno == EINTR)
+            continue;
+        throwFromErrnoWithPath("Could not calculate available disk space (statvfs)", path, ErrorCodes::CANNOT_STATVFS);
+    }
+    return fs;
+}
+
+
 bool enoughSpaceInDirectory(const std::string & path [[maybe_unused]], size_t data_size [[maybe_unused]])
 {
 #if POCO_VERSION >= 0x01090000

--- a/src/Common/filesystemHelpers.cpp
+++ b/src/Common/filesystemHelpers.cpp
@@ -10,13 +10,16 @@
 #include <Poco/Path.h>
 #include <Poco/Version.h>
 
+
 namespace DB
 {
+
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
     extern const int SYSTEM_ERROR;
     extern const int NOT_IMPLEMENTED;
+    extern const int CANNOT_STATVFS;
 }
 
 

--- a/src/Common/filesystemHelpers.cpp
+++ b/src/Common/filesystemHelpers.cpp
@@ -60,7 +60,7 @@ std::filesystem::path getMountPoint(std::filesystem::path absolute_path)
     const auto get_device_id = [](const std::filesystem::path & p)
     {
         struct stat st;
-        if (stat(p.c_str(), &st))
+        if (stat(p.c_str(), &st))   /// NOTE: man stat does not list EINTR as possible error
             throwFromErrnoWithPath("Cannot stat " + p.string(), p.string(), ErrorCodes::SYSTEM_ERROR);
         return st.st_dev;
     };

--- a/src/Common/filesystemHelpers.h
+++ b/src/Common/filesystemHelpers.h
@@ -12,10 +12,6 @@
 
 namespace DB
 {
-namespace ErrorCodes
-{
-    extern const int CANNOT_STATVFS;
-}
 
 using TemporaryFile = Poco::TemporaryFile;
 

--- a/src/Common/filesystemHelpers.h
+++ b/src/Common/filesystemHelpers.h
@@ -6,7 +6,6 @@
 #include <filesystem>
 #include <memory>
 #include <string>
-#include <cerrno>
 #include <sys/statvfs.h>
 #include <Poco/TemporaryFile.h>
 

--- a/src/Common/filesystemHelpers.h
+++ b/src/Common/filesystemHelpers.h
@@ -32,16 +32,6 @@ std::filesystem::path getMountPoint(std::filesystem::path absolute_path);
 #endif
 String getFilesystemName([[maybe_unused]] const String & mount_point);
 
-inline struct statvfs getStatVFS(const String & path)
-{
-    struct statvfs fs;
-    while (statvfs(path.c_str(), &fs) != 0)
-    {
-        if (errno == EINTR)
-            continue;
-        throwFromErrnoWithPath("Could not calculate available disk space (statvfs)", path, ErrorCodes::CANNOT_STATVFS);
-    }
-    return fs;
-}
+struct statvfs getStatVFS(const String & path);
 
 }


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Prevent the possibility of error message `Could not calculate available disk space (statvfs), errno: 4, strerror: Interrupted system call`. This fixes #15541.