### PR TITLE
Use default implemetation for constants in JSON* functions

### DIFF
--- a/src/Functions/FunctionsJSON.h
+++ b/src/Functions/FunctionsJSON.h
@@ -279,7 +279,7 @@ public:
     String getName() const override { return Name::name; }
     bool isVariadic() const override { return true; }
     size_t getNumberOfArguments() const override { return 0; }
-    bool useDefaultImplementationForConstants() const override { return false; }
+    bool useDefaultImplementationForConstants() const override { return true; }
 
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
     {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed `Element ... is not a constant expression` error when using `JSON*` function result in `VALUES`, `LIMIT` or right side of `IN` operator.

Detailed description / Documentation draft:
JSON* functions return non-constant result for constant arguments:
```
select JSONExtract('{"a":[1, 2]}', 'a', 'Array(UInt32)') as a,  1 in a

Code: 36, e.displayText() = DB::Exception: Element of set in IN, VALUES or LIMIT is not a constant expression (result column is not const): JSONExtract('{a:[1, 2]}', 'a', 'Array(UInt32)') (version 20.9.1.4543 (official build))
```

Seems like these functions should work fine with default implementation for constant columns.
