### PR TITLE
Check MADV_DONTNEED (for jemalloc), maybe broken under qemu

### DIFF
--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -262,9 +262,9 @@ void writeErrorLen(const char * data, size_t size)
     }
 }
 /// Macros to avoid using strlen(), since it may fail if SSE is not supported.
-#define writeError(data) \
+#define writeError(data) do { \
     static_assert(__builtin_constant_p(data)); \
-    writeErrorLen(data, ARRAY_SIZE(data) - 1)
+    writeErrorLen(data, ARRAY_SIZE(data) - 1) } while (false)
 
 /// Check SSE and others instructions availability. Calls exit on fail.
 /// This function must be called as early as possible, even before main, because static initializers may use unavailable instructions.

--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -2,6 +2,10 @@
 #include <setjmp.h>
 #include <unistd.h>
 
+#ifdef __linux__
+#include <sys/mman.h>
+#endif
+
 #include <new>
 #include <iostream>
 #include <vector>
@@ -296,10 +300,52 @@ void checkRequiredInstructions()
     }
 }
 
+#ifdef __linux__
+/// clickhouse uses jemalloc as a production allocator
+/// and jemalloc relies on working MADV_DONTNEED,
+/// which doesn't work under qemu
+///
+/// but do this only under for linux, since only it return zeroed pages after MADV_DONTNEED
+/// (and jemalloc assumes this too, see contrib/jemalloc-cmake/include_linux_x86_64/jemalloc/internal/jemalloc_internal_defs.h.in)
+void checkRequiredMadviseFlags()
+{
+    size_t size = 1 << 16;
+    void * addr = mmap(nullptr, size, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+    if (addr == MAP_FAILED)
+    {
+        writeError("Can not mmap pages for MADV_DONTNEED check\n");
+        _Exit(1);
+    }
+    memset(addr, 'A', size);
+
+    if (!madvise(addr, size, MADV_DONTNEED))
+    {
+        /// Suboptimal, but should be simple.
+        for (size_t i = 0; i < size; ++i)
+        {
+            if (reinterpret_cast<unsigned char *>(addr)[i] != 0)
+            {
+                writeError("MADV_DONTNEED does not zeroed page. jemalloc will be broken\n");
+                _Exit(1);
+            }
+        }
+    }
+
+    if (munmap(addr, size))
+    {
+        writeError("Can not munmap pages for MADV_DONTNEED check\n");
+        _Exit(1);
+    }
+}
+#endif
+
 struct Checker
 {
     Checker()
     {
+#ifdef __linux__
+        checkRequiredMadviseFlags();
+#endif
         checkRequiredInstructions();
     }
 } checker;

--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -343,10 +343,10 @@ struct Checker
 {
     Checker()
     {
+        checkRequiredInstructions();
 #ifdef __linux__
         checkRequiredMadviseFlags();
 #endif
-        checkRequiredInstructions();
     }
 } checker;
 

--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -238,8 +238,9 @@ void checkRequiredInstructionsImpl(volatile InstructionFail & fail)
 }
 
 /// This function is safe to use in static initializers.
-void writeError(const char * data, size_t size)
+void writeError(const char * data)
 {
+    size_t size = strlen(data);
     while (size != 0)
     {
         ssize_t res = ::write(STDERR_FILENO, data, size);
@@ -272,8 +273,7 @@ void checkRequiredInstructions()
         /// Typical implementation of strlen is using SSE4.2 or AVX2.
         /// But this is not the case because it's compiler builtin and is executed at compile time.
 
-        const char * msg = "Can not set signal handler\n";
-        writeError(msg, strlen(msg));
+        writeError("Can not set signal handler\n");
         _Exit(1);
     }
 
@@ -281,12 +281,9 @@ void checkRequiredInstructions()
 
     if (sigsetjmp(jmpbuf, 1))
     {
-        const char * msg1 = "Instruction check fail. The CPU does not support ";
-        writeError(msg1, strlen(msg1));
-        const char * msg2 = instructionFailToString(fail);
-        writeError(msg2, strlen(msg2));
-        const char * msg3 = " instruction set.\n";
-        writeError(msg3, strlen(msg3));
+        writeError("Instruction check fail. The CPU does not support ");
+        writeError(instructionFailToString(fail));
+        writeError(" instruction set.\n");
         _Exit(1);
     }
 
@@ -294,13 +291,18 @@ void checkRequiredInstructions()
 
     if (sigaction(signal, &sa_old, nullptr))
     {
-        const char * msg = "Can not set signal handler\n";
-        writeError(msg, strlen(msg));
+        writeError("Can not set signal handler\n");
         _Exit(1);
     }
 }
 
-struct Checker { Checker() { checkRequiredInstructions(); } } checker;
+struct Checker
+{
+    Checker()
+    {
+        checkRequiredInstructions();
+    }
+} checker;
 
 }
 

--- a/tests/queries/0_stateless/01103_check_cpu_instructions_at_startup.reference
+++ b/tests/queries/0_stateless/01103_check_cpu_instructions_at_startup.reference
@@ -2,4 +2,4 @@ Instruction check fail. The CPU does not support SSSE3 instruction set.
 Instruction check fail. The CPU does not support SSE4.1 instruction set.
 Instruction check fail. The CPU does not support SSE4.2 instruction set.
 Instruction check fail. The CPU does not support POPCNT instruction set.
-1
+MADV_DONTNEED does not zeroed page. jemalloc will be broken


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Check MADV_DONTNEED (for jemalloc), maybe broken under qemu

Detailed description / Documentation draft:
jemalloc relies on working MADV_DONTNEED (that fact that after
madvise(MADV_DONTNEED) returns success, after subsequent access to those
pages they will be zeroed).
However qemu does not support this, yet [1], and you can get very tricky
assert if you will run clickhouse-server under qemu:

    <jemalloc>: ../contrib/jemalloc/src/extent.c:1195: Failed assertion: "p[i] == 0"

  [1]: https://patchwork.kernel.org/patch/10576637/

But after this patch you will get pretty error:

    $ qemu-x86_64-static programs/clickhouse
    MADV_DONTNEED does not zeroed page. jemalloc will be broken

P.S. I also checked clickhouse with patched qemu, that returns ENOSYS in the [linux-user layer](https://github.com/qemu/qemu/blob/469e72ab7dbbd7ff4ee601e5ea7c29545d46593b/linux-user/syscall.c#L11773-L11778), and jemalloc assert no more triggered.

Refs: https://gist.github.com/azat/12ba2c825b710653ece34dba7f926ece

<details>

HEAD:
- a139a594bfc6b7709c8640aec0e68c0673fcdcaa (before strlen fix)
- 152922998bc80cde5a44dd84d70a001cd5feb05a (after strlen fix)
- 0a9268cb20673e774355d7d200374aa6c41ef339 (w/ `bugprone-macro-parentheses`)

</details>