### PR TITLE
sub ReadonlyReplica metric when detach readonly tables

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -355,7 +355,7 @@ void ReplicatedMergeTreeRestartingThread::shutdown()
     task->deactivate();
     LOG_TRACE(log, "Restarting thread finished");
 
-    // For detach table query, we should reset the ReadonlyReplica metric.
+    /// For detach table query, we should reset the ReadonlyReplica metric.
     if (incr_readonly)
     {
         CurrentMetrics::sub(CurrentMetrics::ReadonlyReplica);

--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.h
@@ -36,6 +36,9 @@ private:
     Poco::Logger * log;
     std::atomic<bool> need_stop {false};
 
+    // We need it besides `storage.is_readonly`, bacause `shutdown()` may be called many times, that way `storage.is_readonly` will not change.
+    bool incr_readonly = false;
+
     /// The random data we wrote into `/replicas/me/is_active`.
     String active_node_identifier;
 

--- a/tests/integration/test_system_metrics/configs/remote_servers.xml
+++ b/tests/integration/test_system_metrics/configs/remote_servers.xml
@@ -1,0 +1,19 @@
+<yandex>
+    <remote_servers>
+        <test_cluster>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <default_database>shard_0</default_database>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <default_database>shard_0</default_database>
+                    <host>node2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster>
+    </remote_servers>
+</yandex>

--- a/tests/integration/test_system_metrics/test.py
+++ b/tests/integration/test_system_metrics/test.py
@@ -1,0 +1,62 @@
+import time
+
+import pytest
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
+from helpers.network import PartitionManager
+
+
+def fill_nodes(nodes, shard):
+    for node in nodes:
+        node.query(
+            '''
+                CREATE DATABASE test;
+
+                CREATE TABLE test.test_table(date Date, id UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test{shard}/replicated', '{replica}') ORDER BY id PARTITION BY toYYYYMM(date) SETTINGS min_replicated_logs_to_keep=3, max_replicated_logs_to_keep=5, cleanup_delay_period=0, cleanup_delay_period_random_add=0;
+            '''.format(shard=shard, replica=node.name))
+
+
+cluster = ClickHouseCluster(__file__)
+node1 = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml'], with_zookeeper=True)
+node2 = cluster.add_instance('node2', main_configs=['configs/remote_servers.xml'], with_zookeeper=True)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+
+        fill_nodes([node1, node2], 1)
+
+        yield cluster
+
+    except Exception as ex:
+        print(ex)
+
+    finally:
+        cluster.shutdown()
+
+def test_readonly_metrics(start_cluster):
+    assert node1.query("SELECT value FROM system.metrics WHERE metric = 'ReadonlyReplica'") == "0\n"
+
+    with PartitionManager() as pm:
+        ## make node1 readonly -> heal -> readonly -> heal -> detach table -> heal -> attach table
+        pm.drop_instance_zk_connections(node1)
+        time.sleep(3)
+        assert "1\n" == node1.query("SELECT value FROM system.metrics WHERE metric = 'ReadonlyReplica'")
+
+        pm.heal_all()
+        time.sleep(3)
+        assert "0\n" == node1.query("SELECT value FROM system.metrics WHERE metric = 'ReadonlyReplica'")
+
+        pm.drop_instance_zk_connections(node1)
+        time.sleep(3)
+        assert "1\n" == node1.query("SELECT value FROM system.metrics WHERE metric = 'ReadonlyReplica'")
+        node1.query("DETACH TABLE test.test_table")
+        assert "0\n" == node1.query("SELECT value FROM system.metrics WHERE metric = 'ReadonlyReplica'")
+
+        pm.heal_all()
+        node1.query("ATTACH TABLE test.test_table")
+        time.sleep(5)
+        assert "0\n" == node1.query("SELECT value FROM system.metrics WHERE metric = 'ReadonlyReplica'")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Decrement the `ReadonlyReplica` metric when detaching read-only tables. This fixes https://github.com/ClickHouse/ClickHouse/issues/15598

Detailed description / Documentation draft:

In our production env, `clickhouse` 20.3.8.53,  `Readonly` will not be decreased when we detach the readonly tables,  since we can't mutate `system.metrics`, the only way to handle it is to restart the whole  CH server or stop the metric alert rules.
```
ubuntu :) select * from system.replicas where is_readonly = 1\G

SELECT *
FROM system.replicas
WHERE is_readonly = 1

Ok.

0 rows in set. Elapsed: 5.119 sec. Processed 2.14 thousand rows, 938.52 KB (417.87 rows/s., 183.35 KB/s.)

ubuntu :) select * from system.metrics where metric like '%Readonly%';

SELECT *
FROM system.metrics
WHERE metric LIKE '%Readonly%'

┌─metric──────────┬─value─┬─description────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ ReadonlyReplica │     6 │ Number of Replicated tables that are currently in readonly state due to re-initialization after ZooKeeper session loss or due to startup without ZooKeeper configured. │
└─────────────────┴───────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

```

Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/

#15598