### PR TITLE
More consistent metadata usage in TTL moves

### DIFF
--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -276,7 +276,7 @@ MergeTreeData::MutableDataPartPtr Fetcher::fetchPart(
             ReadBufferFromString ttl_infos_buffer(ttl_infos_string);
             assertString("ttl format version: 1\n", ttl_infos_buffer);
             ttl_infos.read(ttl_infos_buffer);
-            reservation = data.reserveSpacePreferringTTLRules(sum_files_size, ttl_infos, std::time(nullptr), 0, true);
+            reservation = data.reserveSpacePreferringTTLRules(metadata_snapshot, sum_files_size, ttl_infos, std::time(nullptr), 0, true);
         }
         else
             reservation = data.reserveSpace(sum_files_size);

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3037,28 +3037,31 @@ ReservationPtr MergeTreeData::tryReserveSpace(UInt64 expected_size, SpacePtr spa
     return space->reserve(expected_size);
 }
 
-ReservationPtr MergeTreeData::reserveSpacePreferringTTLRules(UInt64 expected_size,
-        const IMergeTreeDataPart::TTLInfos & ttl_infos,
-        time_t time_of_move,
-        size_t min_volume_index,
-        bool is_insert) const
+ReservationPtr MergeTreeData::reserveSpacePreferringTTLRules(
+    const StorageMetadataPtr & metadata_snapshot,
+    UInt64 expected_size,
+    const IMergeTreeDataPart::TTLInfos & ttl_infos,
+    time_t time_of_move,
+    size_t min_volume_index,
+    bool is_insert) const
 {
     expected_size = std::max(RESERVATION_MIN_ESTIMATION_SIZE, expected_size);
 
-    ReservationPtr reservation = tryReserveSpacePreferringTTLRules(expected_size, ttl_infos, time_of_move, min_volume_index, is_insert);
+    ReservationPtr reservation = tryReserveSpacePreferringTTLRules(metadata_snapshot, expected_size, ttl_infos, time_of_move, min_volume_index, is_insert);
 
     return checkAndReturnReservation(expected_size, std::move(reservation));
 }
 
-ReservationPtr MergeTreeData::tryReserveSpacePreferringTTLRules(UInt64 expected_size,
-        const IMergeTreeDataPart::TTLInfos & ttl_infos,
-        time_t time_of_move,
-        size_t min_volume_index,
-        bool is_insert) const
+ReservationPtr MergeTreeData::tryReserveSpacePreferringTTLRules(
+    const StorageMetadataPtr & metadata_snapshot,
+    UInt64 expected_size,
+    const IMergeTreeDataPart::TTLInfos & ttl_infos,
+    time_t time_of_move,
+    size_t min_volume_index,
+    bool is_insert) const
 {
     expected_size = std::max(RESERVATION_MIN_ESTIMATION_SIZE, expected_size);
 
-    auto metadata_snapshot = getInMemoryMetadataPtr();
     ReservationPtr reservation;
 
     auto move_ttl_entry = selectTTLDescriptionForTTLInfos(metadata_snapshot->getMoveTTLs(), ttl_infos.moves_ttl, time_of_move, true);

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -632,6 +632,7 @@ public:
 
     /// Reserves space at least 1MB preferring best destination according to `ttl_infos`.
     ReservationPtr reserveSpacePreferringTTLRules(
+        const StorageMetadataPtr & metadata_snapshot,
         UInt64 expected_size,
         const IMergeTreeDataPart::TTLInfos & ttl_infos,
         time_t time_of_move,
@@ -639,6 +640,7 @@ public:
         bool is_insert = false) const;
 
     ReservationPtr tryReserveSpacePreferringTTLRules(
+        const StorageMetadataPtr & metadata_snapshot,
         UInt64 expected_size,
         const IMergeTreeDataPart::TTLInfos & ttl_infos,
         time_t time_of_move,

--- a/src/Storages/MergeTree/MergeTreeDataPartTTLInfo.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartTTLInfo.cpp
@@ -182,6 +182,10 @@ std::optional<TTLDescription> selectTTLDescriptionForTTLInfos(const TTLDescripti
     for (auto ttl_entry_it = descriptions.begin(); ttl_entry_it != descriptions.end(); ++ttl_entry_it)
     {
         auto ttl_info_it = ttl_info_map.find(ttl_entry_it->result_column);
+
+        if (ttl_info_it == ttl_info_map.end())
+            continue;
+
         time_t ttl_time;
 
         if (use_max)
@@ -190,8 +194,7 @@ std::optional<TTLDescription> selectTTLDescriptionForTTLInfos(const TTLDescripti
             ttl_time = ttl_info_it->second.min;
 
         /// Prefer TTL rule which went into action last.
-        if (ttl_info_it != ttl_info_map.end()
-                && ttl_time <= current_time
+        if (ttl_time <= current_time
                 && best_ttl_time <= ttl_time)
         {
             best_entry_it = ttl_entry_it;

--- a/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -237,7 +237,7 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataWriter::writeTempPart(BlockWithPa
         updateTTL(ttl_entry, move_ttl_infos, move_ttl_infos.moves_ttl[ttl_entry.result_column], block, false);
 
     NamesAndTypesList columns = metadata_snapshot->getColumns().getAllPhysical().filter(block.getNames());
-    ReservationPtr reservation = data.reserveSpacePreferringTTLRules(expected_size, move_ttl_infos, time(nullptr), 0, true);
+    ReservationPtr reservation = data.reserveSpacePreferringTTLRules(metadata_snapshot, expected_size, move_ttl_infos, time(nullptr), 0, true);
     VolumePtr volume = data.getStoragePolicy()->getVolume(0);
 
     auto new_data_part = data.createPart(

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -286,7 +286,12 @@ struct CurrentlyMergingPartsTagger
     StorageMergeTree & storage;
 
 public:
-    CurrentlyMergingPartsTagger(FutureMergedMutatedPart & future_part_, size_t total_size, StorageMergeTree & storage_, bool is_mutation)
+    CurrentlyMergingPartsTagger(
+        FutureMergedMutatedPart & future_part_,
+        size_t total_size,
+        StorageMergeTree & storage_,
+        const StorageMetadataPtr & metadata_snapshot,
+        bool is_mutation)
         : future_part(future_part_), storage(storage_)
     {
         /// Assume mutex is already locked, because this method is called from mergeTask.
@@ -304,7 +309,7 @@ public:
                 max_volume_index = std::max(max_volume_index, storage.getStoragePolicy()->getVolumeIndexByDisk(part_ptr->volume->getDisk()));
             }
 
-            reserved_space = storage.tryReserveSpacePreferringTTLRules(total_size, ttl_infos, time(nullptr), max_volume_index);
+            reserved_space = storage.tryReserveSpacePreferringTTLRules(metadata_snapshot, total_size, ttl_infos, time(nullptr), max_volume_index);
         }
         if (!reserved_space)
         {
@@ -715,7 +720,7 @@ bool StorageMergeTree::merge(
             return false;
         }
 
-        merging_tagger.emplace(future_part, MergeTreeDataMergerMutator::estimateNeededDiskSpace(future_part.parts), *this, false);
+        merging_tagger.emplace(future_part, MergeTreeDataMergerMutator::estimateNeededDiskSpace(future_part.parts), *this, metadata_snapshot, false);
         auto table_id = getStorageID();
         merge_entry = global_context.getMergeList().insert(table_id.database_name, table_id.table_name, future_part);
     }
@@ -856,7 +861,7 @@ bool StorageMergeTree::tryMutatePart()
             future_part.name = part->getNewName(new_part_info);
             future_part.type = part->getType();
 
-            tagger.emplace(future_part, MergeTreeDataMergerMutator::estimateNeededDiskSpace({part}), *this, true);
+            tagger.emplace(future_part, MergeTreeDataMergerMutator::estimateNeededDiskSpace({part}), *this, metadata_snapshot, true);
             break;
         }
     }

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1416,11 +1416,11 @@ bool StorageReplicatedMergeTree::tryExecuteMerge(const LogEntry & entry)
         ttl_infos.update(part_ptr->ttl_infos);
         max_volume_index = std::max(max_volume_index, getStoragePolicy()->getVolumeIndexByDisk(part_ptr->volume->getDisk()));
     }
-    ReservationPtr reserved_space = reserveSpacePreferringTTLRules(estimated_space_for_merge,
-            ttl_infos, time(nullptr), max_volume_index);
-
     auto table_lock = lockForShare(RWLockImpl::NO_QUERY, storage_settings_ptr->lock_acquire_timeout_for_background_operations);
+
     StorageMetadataPtr metadata_snapshot = getInMemoryMetadataPtr();
+    ReservationPtr reserved_space = reserveSpacePreferringTTLRules(
+        metadata_snapshot, estimated_space_for_merge, ttl_infos, time(nullptr), max_volume_index);
 
     FutureMergedMutatedPart future_merged_part(parts, entry.new_part_type);
     if (future_merged_part.name != entry.new_part_name)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Probably the reason of failures https://clickhouse-test-reports.s3.yandex.net/15608/a3d27962a78d0da7e524755ea63fa1d427f3fb30/integration_tests_(asan).html#fail1:
```
2020.10.05 16:26:26.849808 [ 89 ] {} <Fatal> BaseDaemon: ########################################
2020.10.05 16:26:26.850257 [ 89 ] {} <Fatal> BaseDaemon: (version 20.10.1.4839, build id: 2F3DD07EC5ADBE2E) (from thread 38) (query_id: b411132b-6566-4c90-b75e-6fbb9e53c654) Received signal Unknown signal -3 (-3)
2020.10.05 16:26:26.850433 [ 89 ] {} <Fatal> BaseDaemon: Sanitizer trap.
2020.10.05 16:26:26.850639 [ 89 ] {} <Fatal> BaseDaemon: Stack trace: 0x9d33e37 0xa0bf76d 0x9c6f6d6 0x9c57104 0x9c58bbe 0x9c59488 0x1d77c599 0x1d68de4a 0x1d68d8e6 0x1d80a37b 0x1d61225d 0x1c2f29b7 0x1c395b96 0x1c2e9d17 0x1c2e9f7e 0x1dc05a1d 0x1dbf8d6f 0x1dc15a1b 0x23efd2cf 0x23efde21 0x241b0385 0x241aaec7 0x7f5942d7f669 0x7f5942c962b3
2020.10.05 16:26:26.851390 [ 89 ] {} <Fatal> BaseDaemon: 0. /build/obj-x86_64-linux-gnu/../src/Common/StackTrace.cpp:291: StackTrace::StackTrace() @ 0x9d33e37 in /usr/bin/clickhouse
2020.10.05 16:26:26.852591 [ 89 ] {} <Fatal> BaseDaemon: 1. /build/obj-x86_64-linux-gnu/../src/Common/CurrentThread.h:81: sanitizerDeathCallback() @ 0xa0bf76d in /usr/bin/clickhouse
2020.10.05 16:26:26.854435 [ 89 ] {} <Fatal> BaseDaemon: 2. __sanitizer::Die() @ 0x9c6f6d6 in /usr/bin/clickhouse
2020.10.05 16:26:26.856197 [ 89 ] {} <Fatal> BaseDaemon: 3. ? @ 0x9c57104 in /usr/bin/clickhouse
2020.10.05 16:26:26.857971 [ 89 ] {} <Fatal> BaseDaemon: 4. __asan::ReportGenericError(unsigned long, unsigned long, unsigned long, unsigned long, bool, unsigned long, unsigned int, bool) @ 0x9c58bbe in /usr/bin/clickhouse
2020.10.05 16:26:26.859753 [ 89 ] {} <Fatal> BaseDaemon: 5. __asan_report_load8 @ 0x9c59488 in /usr/bin/clickhouse
2020.10.05 16:26:26.861534 [ 89 ] {} <Fatal> BaseDaemon: 6. /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/vector:1540: DB::selectTTLDescriptionForTTLInfos(std::__1::vector<DB::TTLDescription, std::__1::allocator<DB::TTLDescription> > const&, std::__1::map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, DB::MergeTreeDataPartTTLInfo, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, DB::MergeTreeDataPartTTLInfo> > > const&, long, bool) @ 0x1d77c599 in /usr/bin/clickhouse
2020.10.05 16:26:26.870049 [ 89 ] {} <Fatal> BaseDaemon: 7. /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/vector:698: DB::MergeTreeData::tryReserveSpacePreferringTTLRules(unsigned long, DB::MergeTreeDataPartTTLInfos const&, long, unsigned long, bool) const @ 0x1d68de4a in /usr/bin/clickhouse
2020.10.05 16:26:26.878284 [ 89 ] {} <Fatal> BaseDaemon: 8. /build/obj-x86_64-linux-gnu/../src/Storages/MergeTree/MergeTreeData.cpp:3048: DB::MergeTreeData::reserveSpacePreferringTTLRules(unsigned long, DB::MergeTreeDataPartTTLInfos const&, long, unsigned long, bool) const @ 0x1d68d8e6 in /usr/bin/clickhouse
2020.10.05 16:26:26.879726 [ 89 ] {} <Fatal> BaseDaemon: 9. /build/obj-x86_64-linux-gnu/../src/Storages/MergeTree/MergeTreeDataWriter.cpp:240: DB::MergeTreeDataWriter::writeTempPart(DB::BlockWithPartition&, std::__1::shared_ptr<DB::StorageInMemoryMetadata const> const&) @ 0x1d80a37b in /usr/bin/clickhouse
2020.10.05 16:26:26.880837 [ 89 ] {} <Fatal> BaseDaemon: 10. /build/obj-x86_64-linux-gnu/../src/Storages/MergeTree/MergeTreeBlockOutputStream.cpp:26: DB::MergeTreeBlockOutputStream::write(DB::Block const&) @ 0x1d61225d in /usr/bin/clickhouse
2020.10.05 16:26:26.882130 [ 89 ] {} <Fatal> BaseDaemon: 11. /build/obj-x86_64-linux-gnu/../src/DataStreams/PushingToViewsBlockOutputStream.cpp:0: DB::PushingToViewsBlockOutputStream::write(DB::Block const&) @ 0x1c2f29b7 in /usr/bin/clickhouse
2020.10.05 16:26:26.883287 [ 89 ] {} <Fatal> BaseDaemon: 12. /build/obj-x86_64-linux-gnu/../src/DataStreams/AddingDefaultBlockOutputStream.cpp:10: DB::AddingDefaultBlockOutputStream::write(DB::Block const&) @ 0x1c395b96 in /usr/bin/clickhouse
2020.10.05 16:26:26.884640 [ 89 ] {} <Fatal> BaseDaemon: 13. /build/obj-x86_64-linux-gnu/../src/DataStreams/SquashingBlockOutputStream.cpp:31: DB::SquashingBlockOutputStream::finalize() @ 0x1c2e9d17 in /usr/bin/clickhouse
2020.10.05 16:26:26.885709 [ 89 ] {} <Fatal> BaseDaemon: 14. /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/memory:3826: DB::SquashingBlockOutputStream::writeSuffix() @ 0x1c2e9f7e in /usr/bin/clickhouse
2020.10.05 16:26:26.887901 [ 89 ] {} <Fatal> BaseDaemon: 15. /build/obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:1909: DB::TCPHandler::processInsertQuery(DB::Settings const&) @ 0x1dc05a1d in /usr/bin/clickhouse
2020.10.05 16:26:26.889652 [ 89 ] {} <Fatal> BaseDaemon: 16. /build/obj-x86_64-linux-gnu/../src/Server/TCPHandler.cpp:264: DB::TCPHandler::runImpl() @ 0x1dbf8d6f in /usr/bin/clickhouse
2020.10.05 16:26:26.892910 [ 89 ] {} <Fatal> BaseDaemon: 17. /build/obj-x86_64-linux-gnu/../src/Server/TCPHandler.cpp:0: DB::TCPHandler::run() @ 0x1dc15a1b in /usr/bin/clickhouse
2020.10.05 16:26:26.895452 [ 89 ] {} <Fatal> BaseDaemon: 18. /build/obj-x86_64-linux-gnu/../contrib/poco/Net/src/TCPServerConnection.cpp:57: Poco::Net::TCPServerConnection::start() @ 0x23efd2cf in /usr/bin/clickhouse
2020.10.05 16:26:26.897062 [ 89 ] {} <Fatal> BaseDaemon: 19. /build/obj-x86_64-linux-gnu/../contrib/poco/Net/src/TCPServerDispatcher.cpp:0: Poco::Net::TCPServerDispatcher::run() @ 0x23efde21 in /usr/bin/clickhouse
2020.10.05 16:26:26.898800 [ 89 ] {} <Fatal> BaseDaemon: 20. /build/obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/ThreadPool.cpp:0: Poco::PooledThread::run() @ 0x241b0385 in /usr/bin/clickhouse
2020.10.05 16:26:26.900634 [ 89 ] {} <Fatal> BaseDaemon: 21. /build/obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Thread_POSIX.cpp:0: Poco::ThreadImpl::runnableEntry(void*) @ 0x241aaec7 in /usr/bin/clickhouse
2020.10.05 16:26:26.900949 [ 89 ] {} <Fatal> BaseDaemon: 22. start_thread @ 0x9669 in /usr/lib/x86_64-linux-gnu/libpthread-2.30.so
2020.10.05 16:26:26.901172 [ 89 ] {} <Fatal> BaseDaemon: 23. __clone @ 0x1222b3 in /usr/lib/x86_64-linux-gnu/libc-2.30.so


=================================================================                                                                                                                                                                              
==1==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7f587975cb90 at pc 0x00001d77c599 bp 0x7f587975bcf0 sp 0x7f587975bce8                                                                                                         
READ of size 8 at 0x7f587975cb90 thread T32 (TCPHandler)                                                                                                                                                                                       
    #0 0x1d77c598 in DB::selectTTLDescriptionForTTLInfos(std::__1::vector<DB::TTLDescription, std::__1::allocator<DB::TTLDescription> > const&, std::__1::map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, DB::MergeTreeDataPartTTLInfo, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, DB::MergeTreeDataPartTTLInfo> > > const&, long, bool) /build/obj-x86_64-linux-gnu/../src/Storages/MergeTree/MergeTreeDataPartTTLInfo.cpp                                                                          
    #1 0x1d68de49 in DB::MergeTreeData::tryReserveSpacePreferringTTLRules(unsigned long, DB::MergeTreeDataPartTTLInfos const&, long, unsigned long, bool) const /build/obj-x86_64-linux-gnu/../src/Storages/MergeTree/MergeTreeData.cpp:3064:27
    #2 0x1d68d8e5 in DB::MergeTreeData::reserveSpacePreferringTTLRules(unsigned long, DB::MergeTreeDataPartTTLInfos const&, long, unsigned long, bool) const /build/obj-x86_64-linux-gnu/../src/Storages/MergeTree/MergeTreeData.cpp:3048:34   
    #3 0x1d80a37a in DB::MergeTreeDataWriter::writeTempPart(DB::BlockWithPartition&, std::__1::shared_ptr<DB::StorageInMemoryMetadata const> const&) /build/obj-x86_64-linux-gnu/../src/Storages/MergeTree/MergeTreeDataWriter.cpp:240:39      
    #4 0x1d61225c in DB::MergeTreeBlockOutputStream::write(DB::Block const&) /build/obj-x86_64-linux-gnu/../src/Storages/MergeTree/MergeTreeBlockOutputStream.cpp:25:65                                                                        
    #5 0x1c2f29b6 in DB::PushingToViewsBlockOutputStream::write(DB::Block const&) /build/obj-x86_64-linux-gnu/../src/DataStreams/PushingToViewsBlockOutputStream.cpp:156:21                                                                    
    #6 0x1c395b95 in DB::AddingDefaultBlockOutputStream::write(DB::Block const&) /build/obj-x86_64-linux-gnu/../src/DataStreams/AddingDefaultBlockOutputStream.cpp:10:13                                                                       
    #7 0x1c2e9d16 in DB::SquashingBlockOutputStream::finalize() /build/obj-x86_64-linux-gnu/../src/DataStreams/SquashingBlockOutputStream.cpp:30:17                                                                                            
    #8 0x1c2e9f7d in DB::SquashingBlockOutputStream::writeSuffix() /build/obj-x86_64-linux-gnu/../src/DataStreams/SquashingBlockOutputStream.cpp:50:5                                                                                          
    #9 0x1dc05a1c in DB::TCPHandler::processInsertQuery(DB::Settings const&) /build/obj-x86_64-linux-gnu/../src/Server/TCPHandler.cpp:511:19                                                                                                   
    #10 0x1dbf8d6e in DB::TCPHandler::runImpl() /build/obj-x86_64-linux-gnu/../src/Server/TCPHandler.cpp:264:17                                                                                                                                
    #11 0x1dc15a1a in DB::TCPHandler::run() /build/obj-x86_64-linux-gnu/../src/Server/TCPHandler.cpp:1311:9                                                                                                                                    
    #12 0x23efd2ce in Poco::Net::TCPServerConnection::start() /build/obj-x86_64-linux-gnu/../contrib/poco/Net/src/TCPServerConnection.cpp:43:3                                                                                                 
    #13 0x23efde20 in Poco::Net::TCPServerDispatcher::run() /build/obj-x86_64-linux-gnu/../contrib/poco/Net/src/TCPServerDispatcher.cpp:114:20                                                                                                 
    #14 0x241b0384 in Poco::PooledThread::run() /build/obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/ThreadPool.cpp:199:14                                                                                                               
    #15 0x241aaec6 in Poco::ThreadImpl::runnableEntry(void*) /build/obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Thread_POSIX.cpp:345:27                                                                                                
    #16 0x7f5942d7f668 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x9668)                                                                                                                                                          
    #17 0x7f5942c962b2 in clone (/lib/x86_64-linux-gnu/libc.so.6+0x1222b2)                                                                                                                                                                     
                                                                                                                                                                                                                                               
Address 0x7f587975cb90 is located in stack of thread T32 (TCPHandler) at offset 848 in frame                                                                                                                                                   
    #0 0x1d80978f in DB::MergeTreeDataWriter::writeTempPart(DB::BlockWithPartition&, std::__1::shared_ptr<DB::StorageInMemoryMetadata const> const&) /build/obj-x86_64-linux-gnu/../src/Storages/MergeTree/MergeTreeDataWriter.cpp:198         
```