### PR TITLE
Run check with wide parts and release build

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -512,6 +512,15 @@ def collect_build_flags(client):
     else:
         raise Exception("Cannot get inforamtion about build from server errorcode {}, stderr {}".format(clickhouse_proc.returncode, stderr))
 
+    clickhouse_proc = Popen(shlex.split(client), stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    (stdout, stderr) = clickhouse_proc.communicate(b"SELECT value FROM system.merge_tree_settings WHERE name = 'min_bytes_for_wide_part'")
+
+    if clickhouse_proc.returncode == 0:
+        if stdout == b'0\n':
+            result.append(BuildFlags.POLYMORPHIC_PARTS)
+    else:
+        raise Exception("Cannot get inforamtion about build from server errorcode {}, stderr {}".format(clickhouse_proc.returncode, stderr))
+
     return result
 
 

--- a/tests/config/config.d/polymorphic_parts.xml
+++ b/tests/config/config.d/polymorphic_parts.xml
@@ -1,5 +1,5 @@
 <yandex>
     <merge_tree>
-        <min_bytes_for_wide_part>10485760</min_bytes_for_wide_part>
+        <min_bytes_for_wide_part>0</min_bytes_for_wide_part>
     </merge_tree>
 </yandex>

--- a/tests/queries/skip_list.json
+++ b/tests/queries/skip_list.json
@@ -98,5 +98,7 @@
         "00609_mv_index_in_in",
         "00510_materizlized_view_and_deduplication_zookeeper",
         "00738_lock_for_inner_table"
+    ],
+    "polymorphic-parts": [
     ]
 }

--- a/tests/queries/skip_list.json
+++ b/tests/queries/skip_list.json
@@ -100,5 +100,7 @@
         "00738_lock_for_inner_table"
     ],
     "polymorphic-parts": [
+        "01508_partition_pruning", /// bug, shoud be fixed
+        "01482_move_to_prewhere_and_cast" /// bug, shoud be fixed
     ]
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Until we didn't come up with a good solution how to properly check both types of part, at least run check with release build and  wide format for all parts.