### PR TITLE
Fix DROP TABLE hangs with Atomic engine

### DIFF
--- a/src/Storages/StorageMaterializedView.cpp
+++ b/src/Storages/StorageMaterializedView.cpp
@@ -151,6 +151,7 @@ static void executeDropQuery(ASTDropQuery::Kind kind, Context & global_context, 
         drop_query->table = target_table_id.table_name;
         drop_query->kind = kind;
         drop_query->no_delay = no_delay;
+        drop_query->if_exists = true;
         ASTPtr ast_drop_query = drop_query;
         InterpreterDropQuery drop_interpreter(ast_drop_query, global_context);
         drop_interpreter.execute();
@@ -172,7 +173,6 @@ void StorageMaterializedView::dropInnerTable(bool no_delay)
 {
     if (has_inner_table && tryGetTargetTable())
         executeDropQuery(ASTDropQuery::Kind::Drop, global_context, target_table_id, no_delay);
-    has_inner_table = false;
 }
 
 void StorageMaterializedView::truncate(const ASTPtr &, const StorageMetadataPtr &, const Context &, TableExclusiveLockHolder &)

--- a/src/Storages/StorageMaterializedView.h
+++ b/src/Storages/StorageMaterializedView.h
@@ -36,6 +36,7 @@ public:
     BlockOutputStreamPtr write(const ASTPtr & query, const StorageMetadataPtr & /*metadata_snapshot*/, const Context & context) override;
 
     void drop() override;
+    void dropInnerTable(bool no_delay);
 
     void truncate(const ASTPtr &, const StorageMetadataPtr &, const Context &, TableExclusiveLockHolder &) override;
 

--- a/tests/queries/0_stateless/01516_drop_table_stress.sh
+++ b/tests/queries/0_stateless/01516_drop_table_stress.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../shell_config.sh
+
+function drop_database()
+{
+    # redirect stderr since it is racy with DROP TABLE
+    # and tries to remove db_01516.data too.
+    ${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS db_01516" 2>/dev/null
+}
+
+function drop_table()
+{
+    ${CLICKHOUSE_CLIENT} -nm <<EOL
+DROP TABLE IF EXISTS db_01516.data3;
+DROP TABLE IF EXISTS db_01516.data1;
+DROP TABLE IF EXISTS db_01516.data2;
+EOL
+}
+
+function create()
+{
+    ${CLICKHOUSE_CLIENT} -nm <<EOL
+CREATE DATABASE IF NOT EXISTS db_01516;
+CREATE TABLE IF NOT EXISTS db_01516.data1 Engine=MergeTree() ORDER BY number AS SELECT * FROM numbers(1);
+CREATE TABLE IF NOT EXISTS db_01516.data2 Engine=MergeTree() ORDER BY number AS SELECT * FROM numbers(1);
+CREATE TABLE IF NOT EXISTS db_01516.data3 Engine=MergeTree() ORDER BY number AS SELECT * FROM numbers(1);
+EOL
+}
+
+for _ in {1..100}; do
+    create
+    drop_table &
+    drop_database &
+    wait
+done

--- a/tests/queries/0_stateless/01517_drop_mv_with_inner_table.reference
+++ b/tests/queries/0_stateless/01517_drop_mv_with_inner_table.reference
@@ -1,0 +1,2 @@
+source
+source

--- a/tests/queries/0_stateless/01517_drop_mv_with_inner_table.sql
+++ b/tests/queries/0_stateless/01517_drop_mv_with_inner_table.sql
@@ -1,0 +1,40 @@
+--
+-- Atomic no SYNC
+-- (should go first to check that thread for DROP TABLE does not hang)
+--
+drop database if exists db_01517_atomic;
+create database db_01517_atomic Engine=Atomic;
+
+create table db_01517_atomic.source (key Int) engine=Null;
+create materialized view db_01517_atomic.mv engine=Null as select * from db_01517_atomic.source;
+
+drop table db_01517_atomic.mv;
+-- ensure that the inner had been removed after sync drop
+drop table db_01517_atomic.source sync;
+show tables from db_01517_atomic;
+
+--
+-- Atomic
+--
+drop database if exists db_01517_atomic_sync;
+create database db_01517_atomic_sync Engine=Atomic;
+
+create table db_01517_atomic_sync.source (key Int) engine=Null;
+create materialized view db_01517_atomic_sync.mv engine=Null as select * from db_01517_atomic_sync.source;
+
+-- drops it and hangs with Atomic engine, due to recursive DROP
+drop table db_01517_atomic_sync.mv sync;
+show tables from db_01517_atomic_sync;
+
+--
+-- Ordinary
+---
+drop database if exists db_01517_ordinary;
+create database db_01517_ordinary Engine=Ordinary;
+
+create table db_01517_ordinary.source (key Int) engine=Null;
+create materialized view db_01517_ordinary.mv engine=Null as select * from db_01517_ordinary.source;
+
+-- drops it and hangs with Atomic engine, due to recursive DROP
+drop table db_01517_ordinary.mv sync;
+show tables from db_01517_ordinary;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix drop of materialized view with inner table in Atomic database (hangs all subsequent DROP TABLE due to hang of the worker thread, due to recursive DROP TABLE for inner table of MV)

Cc: @tavplubix 

<details>

HEAD:
- 3cfd2399296073c32e0baa1775fd6e8a576ed8bb (with scheduling regardless queue size)

</details>