### PR TITLE
fix flap in no_holes_when_write_suffix_failed

### DIFF
--- a/tests/integration/helpers/network.py
+++ b/tests/integration/helpers/network.py
@@ -166,6 +166,17 @@ class _NetworkManager:
                 except docker.errors.NotFound:
                     pass
 
+            # for some reason docker api may hang if image doesn't exist, so we download it
+            # before running
+            for i in range(5):
+                try:
+                    subprocess.check_call("docker pull yandex/clickhouse-integration-helper", shell=True)
+                    break
+                except:
+                    time.sleep(i)
+            else:
+                raise Exception("Cannot pull yandex/clickhouse-integration-helper image")
+
             self._container = self._docker_client.containers.run('yandex/clickhouse-integration-helper',
                                                                  auto_remove=True,
                                                                  command=('sleep %s' % self.container_exit_timeout),

--- a/tests/integration/helpers/network.py
+++ b/tests/integration/helpers/network.py
@@ -19,6 +19,7 @@ class PartitionManager:
 
     def __init__(self):
         self._iptables_rules = []
+        _NetworkManager.get()
 
     def drop_instance_zk_connections(self, instance, action='DROP'):
         self._check_instance(instance)

--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -1454,8 +1454,15 @@ def test_kafka_virtual_columns2(kafka_cluster):
     assert TSV(result) == TSV(expected)
 
 
-@pytest.mark.timeout(240)
+@pytest.mark.timeout(120)
 def test_kafka_produce_key_timestamp(kafka_cluster):
+
+    admin_client = KafkaAdminClient(bootstrap_servers="localhost:9092")
+
+    topic_list = []
+    topic_list.append(NewTopic(name="insert3", num_partitions=1, replication_factor=1))
+    admin_client.create_topics(new_topics=topic_list, validate_only=False)
+
     instance.query('''
         DROP TABLE IF EXISTS test.view;
         DROP TABLE IF EXISTS test.consumer;

--- a/tests/queries/0_stateless/01360_materialized_view_with_join_on_query_log.sql
+++ b/tests/queries/0_stateless/01360_materialized_view_with_join_on_query_log.sql
@@ -2,7 +2,7 @@ DROP TABLE IF EXISTS slow_log;
 DROP TABLE IF EXISTS expected_times;
 
 CREATE TABLE expected_times (QUERY_GROUP_ID String, max_query_duration_ms UInt64) Engine=Memory;
-INSERT INTO expected_times VALUES('main_dashboard_top_query', 100), ('main_dashboard_bottom_query', 100);
+INSERT INTO expected_times VALUES('main_dashboard_top_query', 500), ('main_dashboard_bottom_query', 500);
 
 SET log_queries=1;
 SELECT 1;
@@ -25,8 +25,8 @@ CREATE MATERIALIZED VIEW slow_log Engine=Memory AS
 SELECT 1 /* QUERY_GROUP_ID:main_dashboard_top_query */;
 SELECT 1 /* QUERY_GROUP_ID:main_dashboard_bottom_query */;
 
-SELECT 1 WHERE not ignore(sleep(0.105)) /* QUERY_GROUP_ID:main_dashboard_top_query */;
-SELECT 1 WHERE not ignore(sleep(0.105)) /* QUERY_GROUP_ID:main_dashboard_bottom_query */;
+SELECT 1 WHERE not ignore(sleep(0.520)) /* QUERY_GROUP_ID:main_dashboard_top_query */;
+SELECT 1 WHERE not ignore(sleep(0.520)) /* QUERY_GROUP_ID:main_dashboard_bottom_query */;
 
 SET log_queries=0;
 SYSTEM FLUSH LOGS;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix flap in test_storage_kafka/test.py::test_kafka_no_holes_when_write_suffix_failed (✕1)

Detailed description / Documentation draft:
https://clickhouse-test-reports.s3.yandex.net/15199/5b8630e11894266bc9d8a8841c712158a0866123/integration_tests_flaky_check_(asan).html#fail1 

It seems assignment took longer than 12 sec:
```
2020.10.07 23:32:39.485454 [ 20 ] {} <Debug> StorageKafka (kafka): Started streaming to 1 attached views
2020.10.07 23:32:39.487831 [ 20 ] {} <Trace> StorageKafka (kafka): Already subscribed to topics: []
2020.10.07 23:32:39.487946 [ 20 ] {} <Trace> StorageKafka (kafka): Already assigned to: [  ]
2020.10.07 23:32:42.500536 [ 20 ] {} <Trace> StorageKafka (kafka): Topics/partitions assigned: [ no_holes_when_write_suffix_failed[0:#] ]
2020.10.07 23:32:42.604607 [ 20 ] {} <Trace> StorageKafka (kafka): Polled batch of 20 messages. Offsets position: [ no_holes_when_write_suffix_failed[0:20] ]

2020.10.07 23:33:02.610366 [ 20 ] {} <Debug> test.view (bde3a7fe-983b-4ae7-86e2-2bd1f124a3f8) (Replicated OutputStream): Wrote block with ID 'all_13234067450316952167_1031822982405810513', 20 rows
2020.10.07 23:33:02.616476 [ 20 ] {} <Trace> test.view (bde3a7fe-983b-4ae7-86e2-2bd1f124a3f8): Renaming temporary part tmp_insert_all_1_1_0 to all_0_0_0.
2020.10.07 23:33:02.620250 [ 24 ] {} <Debug> test.view (ReplicatedMergeTreeQueue): Pulling 1 entries to queue: log-0000000000 - log-0000000000

2020.10.07 23:33:02.619621 [ 20 ] {} <Trace> StorageKafka (kafka): Polled offset 20 (topic: no_holes_when_write_suffix_failed, partition: 0)
2020.10.07 23:33:02.621509 [ 20 ] {} <Trace> StorageKafka (kafka): Committed offset 20 (topic: no_holes_when_write_suffix_failed, partition: 0)

2020.10.07 23:33:02.621744 [ 20 ] {} <Debug> StorageKafka (kafka): Started streaming to 1 attached views
2020.10.07 23:33:02.624161 [ 20 ] {} <Trace> StorageKafka (kafka): Already subscribed to topics: [no_holes_when_write_suffix_failed]
2020.10.07 23:33:02.624224 [ 20 ] {} <Trace> StorageKafka (kafka): Already assigned to: [ no_holes_when_write_suffix_failed[0:#] ]
2020.10.07 23:33:03.125022 [ 20 ] {} <Trace> StorageKafka (kafka): Polled batch of 2 messages. Offsets position: [ no_holes_when_write_suffix_failed[0:22] ]
2020.10.07 23:33:03.625300 [ 20 ] {} <Trace> StorageKafka (kafka): Stalled
2020.10.07 23:33:04.125436 [ 20 ] {} <Trace> StorageKafka (kafka): Stalled
2020.10.07 23:33:04.625579 [ 20 ] {} <Trace> StorageKafka (kafka): Stalled
```

