### PR TITLE
Fix build on Mac OS

### DIFF
--- a/src/Common/tests/int_hashes_perf.cpp
+++ b/src/Common/tests/int_hashes_perf.cpp
@@ -279,7 +279,9 @@ int main(int argc, char ** argv)
 
     if (!method || method == 1) test<identity>  (n, data.data(), "0: identity");
     if (!method || method == 2) test<intHash32> (n, data.data(), "1: intHash32");
+#if !defined(__APPLE__) /// The difference in size_t: unsigned long on Linux, unsigned long long on Mac OS.
     if (!method || method == 3) test<intHash64> (n, data.data(), "2: intHash64");
+#endif
     if (!method || method == 4) test<hash3>     (n, data.data(), "3: two rounds");
     if (!method || method == 5) test<hash4>     (n, data.data(), "4: two rounds and two variables");
     if (!method || method == 6) test<hash5>     (n, data.data(), "5: two rounds with less ops");


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix build of one miscellaneous example tool on Mac OS. Note that we don't build examples on Mac OS in our CI (we build only ClickHouse binary), so there is zero chance it will not break again. This fixes #15804.