### PR TITLE
add print_query_id support for native client

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -218,6 +218,7 @@ private:
     QueryFuzzer fuzzer;
     int query_fuzzer_runs = 0;
 
+    /// We will format query_id in interactive mode in various ways, the default is just to print Query id: ...
     std::vector<std::pair<String, String>> query_id_formats;
 
     void initialize(Poco::Util::Application & self) override

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1111,9 +1111,6 @@ void Context::setCurrentDatabase(const String & name)
 
 void Context::setCurrentQueryId(const String & query_id)
 {
-    if (!client_info.current_query_id.empty())
-        throw Exception("Logical error: attempt to set query_id twice", ErrorCodes::LOGICAL_ERROR);
-
     String query_id_to_set = query_id;
 
     if (query_id_to_set.empty())    /// If the user did not submit his query_id, then we generate it ourselves.

--- a/tests/queries/0_stateless/01520_client_print_query_id.sh
+++ b/tests/queries/0_stateless/01520_client_print_query_id.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/expect -f
+
+log_user 0
+set timeout 5
+match_max 100000
+
+if ![info exists env(CLICKHOUSE_PORT_TCP)] {set env(CLICKHOUSE_PORT_TCP) 9000}
+
+spawn clickhouse-client --port "$env(CLICKHOUSE_PORT_TCP)"
+expect ":) "
+
+# Make a query
+send -- "SELECT 'print query id'\r"
+expect {
+    "Query id: *" { }
+    timeout { exit 1 }
+}
+expect "print query id"
+expect ":) "
+
+send -- "\4"
+expect eof


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add a new option `print_query_id` to clickhouse-client. It helps generate arbitrary strings with the current query id generated by the client.


Detailed description / Documentation draft:

example use case:

config-client.xml
```
<config>
  <query_id_formats>
    <speedscope>http://speedscope-host/#profileURL=qp%3Fid%3D{query_id}</speedscope>
  </query_id_formats>
</config>
```

`clickhouse-client --print_query_id --config config-client.xml`

Execute some heavy query:
```
:) insert into function file('/tmp/cd', 'Parquet', 'i int') select number from numbers(100000000)

INSERT INTO FUNCTION file('/tmp/cd', 'Parquet', 'i int') SELECT number
FROM numbers(100000000)

speedscope:
http://speedscope-host/#profileURL=qp%3Fid%3D5182b958-bbd9-4d5e-b448-a41632359554

Ok.

0 rows in set. Elapsed: 2.939 sec. Processed 100.66 million rows, 805.28 MB (34.25 million rows/s., 274.02 MB/s.)

:)
```

The query profile url is instantly available.

ClickHouse contains extraordinary capabilities to do introspecting, however, it requires `query_id` to access related metrics. With custom http handlers and this PR, it makes perf tuning much more pleasant.