### PR TITLE
Remove useless metrics to avoid confusion

### DIFF
--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -34,13 +34,6 @@
     M(QueryThread, "Number of query processing threads") \
     M(ReadonlyReplica, "Number of Replicated tables that are currently in readonly state due to re-initialization after ZooKeeper session loss or due to startup without ZooKeeper configured.") \
     M(MemoryTracking, "Total amount of memory (bytes) allocated by the server.") \
-    M(MemoryTrackingInBackgroundProcessingPool, "Total amount of memory (bytes) allocated in background processing pool (that is dedicated for background merges, mutations and fetches). Note that this value may include a drift when the memory was allocated in a context of background processing pool and freed in other context or vice-versa. This happens naturally due to caches for tables indexes and doesn't indicate memory leaks.") \
-    M(MemoryTrackingInBackgroundMoveProcessingPool, "Total amount of memory (bytes) allocated in background processing pool (that is dedicated for background moves). Note that this value may include a drift when the memory was allocated in a context of background processing pool and freed in other context or vice-versa. This happens naturally due to caches for tables indexes and doesn't indicate memory leaks.") \
-    M(MemoryTrackingInBackgroundSchedulePool, "Total amount of memory (bytes) allocated in background schedule pool (that is dedicated for bookkeeping tasks of Replicated tables).") \
-    M(MemoryTrackingInBackgroundBufferFlushSchedulePool, "Total amount of memory (bytes) allocated in background buffer flushes pool (that is dedicated for background buffer flushes).") \
-    M(MemoryTrackingInBackgroundDistributedSchedulePool, "Total amount of memory (bytes) allocated in background distributed schedule pool (that is dedicated for distributed sends).") \
-    M(MemoryTrackingInBackgroundMessageBrokerSchedulePool, "Total amount of memory (bytes) allocated in background message broker pool (that is dedicated for background message streaming).") \
-    M(MemoryTrackingForMerges, "Total amount of memory (bytes) allocated for background merges. Included in MemoryTrackingInBackgroundProcessingPool. Note that this value may include a drift when the memory was allocated in a context of background processing pool and freed in other context or vice-versa. This happens naturally due to caches for tables indexes and doesn't indicate memory leaks.") \
     M(EphemeralNode, "Number of ephemeral nodes hold in ZooKeeper.") \
     M(ZooKeeperSession, "Number of sessions (connections) to ZooKeeper. Should be no more than one, because using more than one connection to ZooKeeper may lead to bugs due to lack of linearizability (stale reads) that ZooKeeper consistency model allows.") \
     M(ZooKeeperWatch, "Number of watches (event subscriptions) in ZooKeeper.") \

--- a/src/Core/BackgroundSchedulePool.cpp
+++ b/src/Core/BackgroundSchedulePool.cpp
@@ -150,10 +150,9 @@ Coordination::WatchCallback BackgroundSchedulePoolTaskInfo::getWatchCallback()
 }
 
 
-BackgroundSchedulePool::BackgroundSchedulePool(size_t size_, CurrentMetrics::Metric tasks_metric_, CurrentMetrics::Metric memory_metric_, const char *thread_name_)
+BackgroundSchedulePool::BackgroundSchedulePool(size_t size_, CurrentMetrics::Metric tasks_metric_, const char *thread_name_)
     : size(size_)
     , tasks_metric(tasks_metric_)
-    , memory_metric(memory_metric_)
     , thread_name(thread_name_)
 {
     LOG_INFO(&Poco::Logger::get("BackgroundSchedulePool/" + thread_name), "Create BackgroundSchedulePool with {} threads", size);
@@ -249,8 +248,6 @@ void BackgroundSchedulePool::threadFunction()
 
     attachToThreadGroup();
     SCOPE_EXIT({ CurrentThread::detachQueryIfNotDetached(); });
-    if (auto * memory_tracker = CurrentThread::getMemoryTracker())
-        memory_tracker->setMetric(memory_metric);
 
     while (!shutdown)
     {

--- a/src/Core/BackgroundSchedulePool.h
+++ b/src/Core/BackgroundSchedulePool.h
@@ -51,7 +51,7 @@ public:
     size_t getNumberOfThreads() const { return size; }
 
     /// thread_name_ cannot be longer then 13 bytes (2 bytes is reserved for "/D" suffix for delayExecutionThreadFunction())
-    BackgroundSchedulePool(size_t size_, CurrentMetrics::Metric tasks_metric_, CurrentMetrics::Metric memory_metric_, const char *thread_name_);
+    BackgroundSchedulePool(size_t size_, CurrentMetrics::Metric tasks_metric_, const char *thread_name_);
     ~BackgroundSchedulePool();
 
 private:
@@ -85,7 +85,6 @@ private:
     ThreadGroupStatusPtr thread_group;
 
     CurrentMetrics::Metric tasks_metric;
-    CurrentMetrics::Metric memory_metric;
     std::string thread_name;
 
     void attachToThreadGroup();

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -73,19 +73,10 @@ namespace CurrentMetrics
 {
     extern const Metric ContextLockWait;
     extern const Metric BackgroundMovePoolTask;
-    extern const Metric MemoryTrackingInBackgroundMoveProcessingPool;
-
     extern const Metric BackgroundSchedulePoolTask;
-    extern const Metric MemoryTrackingInBackgroundSchedulePool;
-
     extern const Metric BackgroundBufferFlushSchedulePoolTask;
-    extern const Metric MemoryTrackingInBackgroundBufferFlushSchedulePool;
-
     extern const Metric BackgroundDistributedSchedulePoolTask;
-    extern const Metric MemoryTrackingInBackgroundDistributedSchedulePool;
-
     extern const Metric BackgroundMessageBrokerSchedulePoolTask;
-    extern const Metric MemoryTrackingInBackgroundMessageBrokerSchedulePool;
 }
 
 
@@ -1415,7 +1406,6 @@ BackgroundProcessingPool & Context::getBackgroundMovePool()
         pool_settings.task_sleep_seconds_when_no_work_multiplier = config.getDouble("background_move_processing_pool_task_sleep_seconds_when_no_work_multiplier", 1.1);
         pool_settings.task_sleep_seconds_when_no_work_random_part = config.getDouble("background_move_processing_pool_task_sleep_seconds_when_no_work_random_part", 1.0);
         pool_settings.tasks_metric = CurrentMetrics::BackgroundMovePoolTask;
-        pool_settings.memory_metric = CurrentMetrics::MemoryTrackingInBackgroundMoveProcessingPool;
         shared->background_move_pool.emplace(settings.background_move_pool_size, pool_settings, "BackgroundMovePool", "BgMoveProcPool");
     }
     return *shared->background_move_pool;
@@ -1428,7 +1418,6 @@ BackgroundSchedulePool & Context::getBufferFlushSchedulePool()
         shared->buffer_flush_schedule_pool.emplace(
             settings.background_buffer_flush_schedule_pool_size,
             CurrentMetrics::BackgroundBufferFlushSchedulePoolTask,
-            CurrentMetrics::MemoryTrackingInBackgroundBufferFlushSchedulePool,
             "BgBufSchPool");
     return *shared->buffer_flush_schedule_pool;
 }
@@ -1440,7 +1429,6 @@ BackgroundSchedulePool & Context::getSchedulePool()
         shared->schedule_pool.emplace(
             settings.background_schedule_pool_size,
             CurrentMetrics::BackgroundSchedulePoolTask,
-            CurrentMetrics::MemoryTrackingInBackgroundSchedulePool,
             "BgSchPool");
     return *shared->schedule_pool;
 }
@@ -1452,7 +1440,6 @@ BackgroundSchedulePool & Context::getDistributedSchedulePool()
         shared->distributed_schedule_pool.emplace(
             settings.background_distributed_schedule_pool_size,
             CurrentMetrics::BackgroundDistributedSchedulePoolTask,
-            CurrentMetrics::MemoryTrackingInBackgroundDistributedSchedulePool,
             "BgDistSchPool");
     return *shared->distributed_schedule_pool;
 }
@@ -1464,7 +1451,6 @@ BackgroundSchedulePool & Context::getMessageBrokerSchedulePool()
         shared->message_broker_schedule_pool.emplace(
             settings.background_message_broker_schedule_pool_size,
             CurrentMetrics::BackgroundMessageBrokerSchedulePoolTask,
-            CurrentMetrics::MemoryTrackingInBackgroundMessageBrokerSchedulePool,
             "BgMBSchPool");
     return *shared->message_broker_schedule_pool;
 }

--- a/src/Storages/MergeTree/BackgroundProcessingPool.cpp
+++ b/src/Storages/MergeTree/BackgroundProcessingPool.cpp
@@ -138,8 +138,6 @@ void BackgroundProcessingPool::workLoopFunc()
     }
 
     SCOPE_EXIT({ CurrentThread::detachQueryIfNotDetached(); });
-    if (auto * const memory_tracker = CurrentThread::getMemoryTracker())
-        memory_tracker->setMetric(settings.memory_metric);
 
     pcg64 rng(randomSeed());
     std::this_thread::sleep_for(std::chrono::duration<double>(std::uniform_real_distribution<double>(0, settings.thread_sleep_seconds_random_part)(rng)));

--- a/src/Storages/MergeTree/BackgroundProcessingPool.h
+++ b/src/Storages/MergeTree/BackgroundProcessingPool.h
@@ -21,7 +21,6 @@
 namespace CurrentMetrics
 {
     extern const Metric BackgroundPoolTask;
-    extern const Metric MemoryTrackingInBackgroundProcessingPool;
 }
 
 namespace DB
@@ -67,7 +66,6 @@ public:
         double task_sleep_seconds_when_no_work_random_part = 1.0;
 
         CurrentMetrics::Metric tasks_metric = CurrentMetrics::BackgroundPoolTask;
-        CurrentMetrics::Metric memory_metric = CurrentMetrics::MemoryTrackingInBackgroundProcessingPool;
 
         PoolSettings() noexcept {}
     };

--- a/src/Storages/MergeTree/MergeList.cpp
+++ b/src/Storages/MergeTree/MergeList.cpp
@@ -5,12 +5,6 @@
 #include <Common/CurrentThread.h>
 
 
-namespace CurrentMetrics
-{
-    extern const Metric MemoryTrackingForMerges;
-}
-
-
 namespace DB
 {
 
@@ -46,7 +40,6 @@ MergeListElement::MergeListElement(const std::string & database_, const std::str
     background_thread_memory_tracker = CurrentThread::getMemoryTracker();
     if (background_thread_memory_tracker)
     {
-        memory_tracker.setMetric(CurrentMetrics::MemoryTrackingForMerges);
         background_thread_memory_tracker_prev_parent = background_thread_memory_tracker->getParent();
         background_thread_memory_tracker->setParent(&memory_tracker);
     }


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove `MemoryTrackingInBackground*` metrics to avoid potentially misleading results. This fixes #15684.