### PR TITLE
Enable Wzero-as-null-pointer-constant only for libcxx

### DIFF
--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -58,7 +58,10 @@ if (COMPILER_CLANG)
     add_warning(unused-exception-parameter)
     add_warning(unused-macros)
     add_warning(unused-member-function)
-    add_warning(zero-as-null-pointer-constant)
+    # XXX: libstdc++ has some of these for 3way compare
+    if (USE_LIBCXX)
+        add_warning(zero-as-null-pointer-constant)
+    endif()
 
     if (WEVERYTHING)
         add_warning(everything)
@@ -170,8 +173,11 @@ elseif (COMPILER_GCC)
     add_cxx_compile_options(-Wunused)
     # Warn if vector operation is not implemented via SIMD capabilities of the architecture
     add_cxx_compile_options(-Wvector-operation-performance)
-    # Warn when a literal 0 is used as null pointer constant.
-    add_cxx_compile_options(-Wzero-as-null-pointer-constant)
+    # XXX: libstdc++ has some of these for 3way compare
+    if (USE_LIBCXX)
+        # Warn when a literal 0 is used as null pointer constant.
+        add_cxx_compile_options(-Wzero-as-null-pointer-constant)
+    endif()
 
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
         # XXX: gcc10 stuck with this option while compiling GatherUtils code

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -170,6 +170,8 @@ elseif (COMPILER_GCC)
     add_cxx_compile_options(-Wunused)
     # Warn if vector operation is not implemented via SIMD capabilities of the architecture
     add_cxx_compile_options(-Wvector-operation-performance)
+    # Warn when a literal 0 is used as null pointer constant.
+    add_cxx_compile_options(-Wzero-as-null-pointer-constant)
 
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
         # XXX: gcc10 stuck with this option while compiling GatherUtils code


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Enable Wzero-as-null-pointer-constant for gcc
- Enable Wzero-as-null-pointer-constant only for libcxx

Detailed description / Documentation draft:
Since libstdc++ has some of such compares for 3way compare:

    /clickhouse/src/Common/UInt128.h:61:71: warning: zero as null pointer constant [-Wzero-as-null-pointer-constant]
        bool inline operator>= (const UInt128 rhs) const { return tuple() >= rhs.tuple(); }
                                                                          ^~
                                                                          nullptr
    /usr/include/c++/10.2.0/tuple:1426:5: note: while rewriting comparison as call to 'operator<=>' declared here
        operator<=>(const tuple<_Tps...>& __t, const tuple<_Ups...>& __u)
