### PR TITLE
Prettify clickhouse-client's query_id output

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -255,7 +255,7 @@ private:
                 query_id_formats.emplace_back(name + ":", config().getString("query_id_formats." + name));
         }
         if (query_id_formats.empty())
-            query_id_formats.emplace_back("Query id:", " {query_id}");
+            query_id_formats.emplace_back("Query id:", " {query_id}\n");
     }
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Print a newline after query id.

Detailed description / Documentation draft:

null.