### PR TITLE
Fix alter default validation

### DIFF
--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1109,24 +1109,21 @@ void AlterCommands::validate(const StorageInMemoryMetadata & metadata, const Con
         {
             if (command.default_expression)
             {
-                /// If we modify default, but not type
-                if (!command.data_type)
-                {
-                    default_expr_list->children.emplace_back(setAlias(command.default_expression->clone(), column_name));
-                }
+                DataTypePtr data_type_ptr;
+                /// If we modify default, but not type.
+                if (!command.data_type) /// it's not ADD COLUMN, because we cannot add column without type
+                    data_type_ptr = all_columns.get(column_name).type;
                 else
-                {
-                    const auto & final_column_name = column_name;
-                    const auto tmp_column_name = final_column_name + "_tmp";
-                    const auto data_type_ptr = command.data_type;
+                    data_type_ptr = command.data_type;
 
+                const auto & final_column_name = column_name;
+                const auto tmp_column_name = final_column_name + "_tmp";
 
-                    default_expr_list->children.emplace_back(setAlias(
-                        addTypeConversionToAST(std::make_shared<ASTIdentifier>(tmp_column_name), data_type_ptr->getName()),
-                        final_column_name));
+                default_expr_list->children.emplace_back(setAlias(
+                    addTypeConversionToAST(std::make_shared<ASTIdentifier>(tmp_column_name), data_type_ptr->getName()),
+                    final_column_name));
 
-                    default_expr_list->children.emplace_back(setAlias(command.default_expression->clone(), tmp_column_name));
-                }
+                default_expr_list->children.emplace_back(setAlias(command.default_expression->clone(), tmp_column_name));
             } /// if we change data type for column with default
             else if (all_columns.has(column_name) && command.data_type)
             {
@@ -1138,7 +1135,6 @@ void AlterCommands::validate(const StorageInMemoryMetadata & metadata, const Con
                 const auto & final_column_name = column_name;
                 const auto tmp_column_name = final_column_name + "_tmp";
                 const auto data_type_ptr = command.data_type;
-
 
                 default_expr_list->children.emplace_back(setAlias(
                     addTypeConversionToAST(std::make_shared<ASTIdentifier>(tmp_column_name), data_type_ptr->getName()), final_column_name));

--- a/tests/queries/0_stateless/01522_validate_alter_default.sql
+++ b/tests/queries/0_stateless/01522_validate_alter_default.sql
@@ -1,0 +1,16 @@
+DROP TABLE IF EXISTS table2;
+CREATE TABLE table2
+(
+        EventDate Date,
+        Id Int32,
+        Value Int32
+)
+Engine = MergeTree()
+PARTITION BY toYYYYMM(EventDate)
+ORDER BY Id;
+
+ALTER TABLE table2 MODIFY COLUMN `Value` DEFAULT 'some_string'; --{serverError 6}
+
+ALTER TABLE table2 ADD COLUMN `Value2` DEFAULT 'some_string'; --{serverError 36}
+
+DROP TABLE IF EXISTS table2;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now exception will be thrown when `ALTER MODIFY COLUMN ... DEFAULT ...` has incompatible default with column type. Fixes #15854.
