### PR TITLE
Avoid creating separate replxx instance

### DIFF
--- a/base/common/ReplxxLineReader.cpp
+++ b/base/common/ReplxxLineReader.cpp
@@ -45,7 +45,10 @@ ReplxxLineReader::ReplxxLineReader(
             }
             else
             {
-                rx.history_load(history_file_path);
+                if (!rx.history_load(history_file_path))
+                {
+                    rx.print("Loading history failed: %s\n", strerror(errno));
+                }
 
                 if (flock(history_file_fd, LOCK_UN))
                 {
@@ -115,7 +118,8 @@ void ReplxxLineReader::addToHistory(const String & line)
     rx.history_add(line);
 
     // flush changes to the disk
-    rx.history_save(history_file_path);
+    if (!rx.history_save(history_file_path))
+        rx.print("Saving history failed: %s\n", strerror(errno));
 
     if (locked && 0 != flock(history_file_fd, LOCK_UN))
         rx.print("Unlock of history file failed: %s\n", strerror(errno));

--- a/base/common/ReplxxLineReader.cpp
+++ b/base/common/ReplxxLineReader.cpp
@@ -16,19 +16,6 @@ void trim(String & s)
     s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) { return !std::isspace(ch); }).base(), s.end());
 }
 
-// Uses separate replxx::Replxx instance to avoid loading them again in the
-// current context (replxx::Replxx::history_load() will re-load the history
-// from the file), since then they will overlaps with history from the current
-// session (this will make behavior compatible with other interpreters, i.e.
-// bash).
-void history_save(const String & history_file_path, const String & line)
-{
-    replxx::Replxx rx_no_overlap;
-    rx_no_overlap.history_load(history_file_path);
-    rx_no_overlap.history_add(line);
-    rx_no_overlap.history_save(history_file_path);
-}
-
 }
 
 ReplxxLineReader::ReplxxLineReader(
@@ -128,7 +115,7 @@ void ReplxxLineReader::addToHistory(const String & line)
     rx.history_add(line);
 
     // flush changes to the disk
-    history_save(history_file_path, line);
+    rx.history_save(history_file_path);
 
     if (locked && 0 != flock(history_file_fd, LOCK_UN))
         rx.print("Unlock of history file failed: %s\n", strerror(errno));


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
This replxx object is pretty heavy and in debug build may slow down [1]
(although I cannot confirm 0.5s delay for each query in debug build) the
client and besides it is not required since ClickHouse-Extras/replxx#10,
which changes the behaviour of history_save(), and now it will not
update current session anymore, only save the history to the disk.

  [1]: https://github.com/ClickHouse/ClickHouse/pull/13086#issuecomment-667719026

Cc: @alexey-milovidov 