### PR TITLE
Trying to implement pool suitable for background tasks on top of ThreadPool

### DIFF
--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -26,29 +26,18 @@ namespace CurrentMetrics
     extern const Metric LocalThreadActive;
 }
 
-
 template <typename Thread>
-ThreadPoolImpl<Thread>::ThreadPoolImpl()
-    : ThreadPoolImpl(getNumberOfPhysicalCPUCores())
-{
-}
-
-
-template <typename Thread>
-ThreadPoolImpl<Thread>::ThreadPoolImpl(size_t max_threads_, bool shutdown_on_exception_, bool only_log_exceptions_)
-    : ThreadPoolImpl(max_threads_, max_threads_, max_threads_, shutdown_on_exception_, only_log_exceptions_)
-{
-}
-
-template <typename Thread>
-ThreadPoolImpl<Thread>::ThreadPoolImpl(size_t max_threads_, size_t max_free_threads_, size_t queue_size_, bool shutdown_on_exception_, bool only_log_exceptions_)
+ThreadPoolImpl<Thread>::ThreadPoolImpl(size_t max_threads_, size_t max_free_threads_, size_t queue_size_, bool shutdown_on_exception_, bool only_log_exceptions_, const CurrentMetrics::Metric & custom_job_metric_)
     : max_threads(max_threads_)
     , max_free_threads(max_free_threads_)
     , queue_size(queue_size_)
     , shutdown_on_exception(shutdown_on_exception_)
     , only_log_exceptions(only_log_exceptions_)
-    , job_metric(std::is_same_v<Thread, std::thread> ? CurrentMetrics::GlobalThreadActive : CurrentMetrics::LocalThreadActive)
+    , custom_job_metric(custom_job_metric_)
 {
+    if (only_log_exceptions && shutdown_on_exception)
+        throw DB::Exception(
+            DB::ErrorCodes::LOGICAL_ERROR, "Inconsistent flags for thread pool, both only_log_exceptions and shutdown_on_exception specified");
 }
 
 template <typename Thread>
@@ -75,7 +64,7 @@ void ThreadPoolImpl<Thread>::setQueueSize(size_t value)
 
 template <typename Thread>
 template <typename ReturnType>
-ReturnType ThreadPoolImpl<Thread>::scheduleImpl(Job job, int priority, std::optional<uint64_t> wait_microseconds, const JobGroupID & job_id)
+ReturnType ThreadPoolImpl<Thread>::scheduleImpl(Job job, int priority, std::optional<uint64_t> wait_microseconds, const JobGroupID & job_group_id)
 {
     auto on_error = [&]
     {
@@ -96,7 +85,7 @@ ReturnType ThreadPoolImpl<Thread>::scheduleImpl(Job job, int priority, std::opti
     {
         std::unique_lock lock(mutex);
 
-        auto pred = [this] { return !queue_size || scheduled_jobs < queue_size || shutdown; };
+        auto pred = [this] { return !queue_size || jobCountTotal() < queue_size || shutdown; };
 
         if (wait_microseconds)  /// Check for optional. Condition is true if the optional is set and the value is zero.
         {
@@ -109,10 +98,10 @@ ReturnType ThreadPoolImpl<Thread>::scheduleImpl(Job job, int priority, std::opti
         if (shutdown)
             return on_error();
 
-        jobs.emplace(std::move(job), priority, job_id);
-        ++scheduled_jobs;
+        jobs.emplace(std::move(job), priority, job_group_id);
+        incrementJobCountInGroup(job_group_id);
 
-        if (threads.size() < std::min(max_threads, scheduled_jobs))
+        if (threads.size() < std::min(max_threads, jobCountTotal()))
         {
             threads.emplace_front();
             try
@@ -129,8 +118,18 @@ ReturnType ThreadPoolImpl<Thread>::scheduleImpl(Job job, int priority, std::opti
                 /// But this condition indicate an error nevertheless and better to refuse.
 
                 jobs.pop();
-                --scheduled_jobs;
-                return on_error();
+                decrementJobCountInGroup(job_group_id);
+
+                if (only_log_exceptions)
+                {
+                    DB::tryLogCurrentException(__PRETTY_FUNCTION__);
+                    if constexpr (std::is_same_v<ReturnType, bool>)
+                        return false;
+                }
+                else
+                {
+                    return on_error();
+                }
             }
         }
     }
@@ -138,31 +137,12 @@ ReturnType ThreadPoolImpl<Thread>::scheduleImpl(Job job, int priority, std::opti
     return ReturnType(true);
 }
 
-
-template <typename Thread>
-void ThreadPoolImpl<Thread>::scheduleOrThrowOnError(Job job, int priority, const JobGroupID & job_group_id)
-{
-    scheduleImpl<void>(std::move(job), priority, std::nullopt, job_group_id);
-}
-
-template <typename Thread>
-bool ThreadPoolImpl<Thread>::trySchedule(Job job, int priority, uint64_t wait_microseconds, const JobGroupID & job_group_id) noexcept
-{
-    return scheduleImpl<bool>(std::move(job), priority, wait_microseconds, job_group_id);
-}
-
-template <typename Thread>
-void ThreadPoolImpl<Thread>::scheduleOrThrow(Job job, int priority, uint64_t wait_microseconds, const JobGroupID & job_group_id)
-{
-    scheduleImpl<void>(std::move(job), priority, wait_microseconds, job_group_id);
-}
-
 template <typename Thread>
 void ThreadPoolImpl<Thread>::wait()
 {
     {
         std::unique_lock lock(mutex);
-        job_finished.wait(lock, [this] { return scheduled_jobs == 0; });
+        job_finished.wait(lock, [this] { return jobCountTotal() == 0; });
 
         if (first_exception)
         {
@@ -172,6 +152,23 @@ void ThreadPoolImpl<Thread>::wait()
         }
     }
 }
+
+template <typename Thread>
+void ThreadPoolImpl<Thread>::waitGroup(const JobGroupID & job_group_id)
+{
+     {
+        std::unique_lock lock(mutex);
+        job_finished.wait(lock, [this, &job_group_id] { return jobCountInGroup(job_group_id) == 0; });
+
+        if (first_exception)
+        {
+            std::exception_ptr exception;
+            std::swap(exception, first_exception);
+            std::rethrow_exception(exception);
+        }
+    }
+}
+
 
 template <typename Thread>
 ThreadPoolImpl<Thread>::~ThreadPoolImpl()
@@ -199,7 +196,14 @@ template <typename Thread>
 size_t ThreadPoolImpl<Thread>::active() const
 {
     std::unique_lock lock(mutex);
-    return scheduled_jobs;
+    return jobCountTotal();
+}
+
+template <typename Thread>
+size_t ThreadPoolImpl<Thread>::activeInGroup(const JobGroupID & job_group_id) const
+{
+    std::unique_lock lock(mutex);
+    return jobCountInGroup(job_group_id);
 }
 
 template <typename Thread>
@@ -236,12 +240,25 @@ void ThreadPoolImpl<Thread>::worker(typename std::list<Thread>::iterator thread_
         {
             try
             {
-                CurrentMetrics::Increment job_execution_threads(job_metric);
+                CurrentMetrics::Increment metric_active_threads(
+                    std::is_same_v<Thread, std::thread> ? CurrentMetrics::GlobalThreadActive : CurrentMetrics::LocalThreadActive);
 
-                job();
-                /// job should be reseted before decrementing scheduled_jobs to
-                /// ensure that the Job destroyed before wait() returns.
-                job = {};
+                /// If we have some custom metric than increment it until job done
+                if (custom_job_metric != 0)
+                {
+                    CurrentMetrics::Increment custom_job_increment(custom_job_metric);
+                    job();
+                    /// job should be reseted before decrementing scheduled_jobs to
+                    /// ensure that the Job destroyed before wait() returns.
+                    job = {};
+                }
+                else
+                {
+                    job();
+                    /// job should be reseted before decrementing scheduled_jobs to
+                    /// ensure that the Job destroyed before wait() returns.
+                    job = {};
+                }
             }
             catch (...)
             {
@@ -251,6 +268,7 @@ void ThreadPoolImpl<Thread>::worker(typename std::list<Thread>::iterator thread_
 
                 {
                     std::unique_lock lock(mutex);
+                    /// Set current exception only if we care about them
                     if (!only_log_exceptions)
                     {
                         if (!first_exception)
@@ -264,7 +282,7 @@ void ThreadPoolImpl<Thread>::worker(typename std::list<Thread>::iterator thread_
                     if (shutdown_on_exception)
                         shutdown = true;
 
-                    --scheduled_jobs;
+                    decrementJobCountInGroup(job_group_id);
                 }
 
                 job_finished.notify_all();
@@ -275,9 +293,9 @@ void ThreadPoolImpl<Thread>::worker(typename std::list<Thread>::iterator thread_
 
         {
             std::unique_lock lock(mutex);
-            --scheduled_jobs;
+            decrementJobCountInGroup(job_group_id);
 
-            if (threads.size() > scheduled_jobs + max_free_threads)
+            if (threads.size() > jobCountTotal() + max_free_threads)
             {
                 thread_it->detach();
                 threads.erase(thread_it);
@@ -291,10 +309,56 @@ void ThreadPoolImpl<Thread>::worker(typename std::list<Thread>::iterator thread_
 }
 
 
+template <typename Thread>
+void ThreadPoolImpl<Thread>::incrementJobCountInGroup(const JobGroupID & job_group_id)
+{
+    scheduled_jobs_by_group[job_group_id]++;
+}
+
+template <typename Thread>
+void ThreadPoolImpl<Thread>::decrementJobCountInGroup(const JobGroupID & job_group_id)
+{
+    if (scheduled_jobs_by_group[job_group_id] == 1)
+        scheduled_jobs_by_group.erase(job_group_id);
+    else
+        scheduled_jobs_by_group[job_group_id]--;
+}
+
+template <typename Thread>
+size_t ThreadPoolImpl<Thread>::jobCountTotal() const
+{
+    size_t result = 0;
+    for (const auto & job_to_count : scheduled_jobs_by_group)
+        result += job_to_count.second;
+    return result;
+}
+
+template <typename Thread>
+size_t ThreadPoolImpl<Thread>::jobCountInGroup(const JobGroupID & job_group_id) const
+{
+    auto elem = scheduled_jobs_by_group.find(job_group_id);
+    if (elem != scheduled_jobs_by_group.end())
+        return elem->second;
+
+    return 0;
+}
+
+
 template class ThreadPoolImpl<std::thread>;
 template class ThreadPoolImpl<ThreadFromGlobalPool>;
 
 std::unique_ptr<GlobalThreadPool> GlobalThreadPool::the_instance;
+
+void FreeThreadPool::scheduleOrThrow(Job job)
+{
+    scheduleImpl<void>(std::move(job), 0, 0, DB::UUIDHelpers::Nil);
+}
+
+void FreeThreadPool::scheduleOrThrowOnError(Job job)
+{
+    scheduleImpl<void>(std::move(job), 0, std::nullopt, DB::UUIDHelpers::Nil);
+}
+
 
 void GlobalThreadPool::initialize(size_t max_threads)
 {
@@ -319,4 +383,39 @@ GlobalThreadPool & GlobalThreadPool::instance()
     }
 
     return *the_instance;
+}
+
+ThreadPool::ThreadPool(size_t max_threads_)
+    : ThreadPoolImpl<ThreadFromGlobalPool>(max_threads_, max_threads_, max_threads_, /* shutdown_on_exception = */ true, /* only_log_exceptions = */ false, 0)
+{
+}
+
+ThreadPool::ThreadPool()
+    : ThreadPool(getNumberOfPhysicalCPUCores())
+{
+}
+
+ThreadPool::ThreadPool(size_t max_threads_, size_t max_free_threads_, size_t queue_size_, bool shutdown_on_exception_)
+    : ThreadPoolImpl<ThreadFromGlobalPool>(max_threads_, max_free_threads_, queue_size_, shutdown_on_exception_, false, 0)
+{}
+
+void ThreadPool::scheduleOrThrowOnError(Job job, int priority, const JobGroupID & job_group_id)
+{
+    scheduleImpl<void>(std::move(job), priority, std::nullopt, job_group_id);
+}
+
+bool ThreadPool::trySchedule(Job job, int priority, uint64_t wait_microseconds, const JobGroupID & job_group_id) noexcept
+{
+    return scheduleImpl<bool>(std::move(job), priority, wait_microseconds, job_group_id);
+}
+
+void ThreadPool::scheduleOrThrow(Job job, int priority, uint64_t wait_microseconds, const JobGroupID & job_group_id)
+{
+    scheduleImpl<void>(std::move(job), priority, wait_microseconds, job_group_id);
+}
+
+void BackgroundThreadPool::scheduleOrThrowOnShutdown(Job job, const JobGroupID & job_group_id, int priority)
+{
+    /// wait_microseconds is nullopt to avoid timeout exception on queue shrink wait.
+    scheduleImpl<void>(std::move(job), priority, std::nullopt, job_group_id);
 }

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -18,7 +18,8 @@
 
 /** Very simple thread pool similar to boost::threadpool.
   * Advantages:
-  * - catches exceptions and rethrows on wait.
+  * - catches exceptions and rethrows on wait or just print them to log if flag only_log_exceptions specified.
+  * - allows to run jobs with group identifier and wait until all jobs from some group finishes
   *
   * This thread pool can be used as a task queue.
   * For example, you can create a thread pool with 10 threads (and queue of size 10) and schedule 1000 tasks
@@ -31,32 +32,10 @@ class ThreadPoolImpl
 {
 public:
     using Job = std::function<void()>;
+    /// Identifier for group of jobs in thread pool. Allows to wait all jobs from one group.
     using JobGroupID = DB::UUID;
-
-    /// Maximum number of threads is based on the number of physical cores.
-    ThreadPoolImpl();
-
-    /// Size is constant. Up to num_threads are created on demand and then run until shutdown.
-    explicit ThreadPoolImpl(size_t max_threads_, bool shutdown_on_exception_ = true, bool only_log_exceptions_ = false);
-
-    /// queue_size - maximum number of running plus scheduled jobs. It can be greater than max_threads. Zero means unlimited.
-    ThreadPoolImpl(size_t max_threads_, size_t max_free_threads_, size_t queue_size_, bool shutdown_on_exception_ = true, bool only_log_exceptions_ = false);
-
-    /// Add new job. Locks until number of scheduled jobs is less than maximum or exception in one of threads was thrown.
-    /// If any thread was throw an exception, first exception will be rethrown from this method,
-    ///  and exception will be cleared.
-    /// Also throws an exception if cannot create thread.
-    /// Priority: greater is higher.
-    /// NOTE: Probably you should call wait() if exception was thrown. If some previously scheduled jobs are using some objects,
-    /// located on stack of current thread, the stack must not be unwinded until all jobs finished. However,
-    /// if ThreadPool is a local object, it will wait for all scheduled jobs in own destructor.
-    void scheduleOrThrowOnError(Job job, int priority = 0, const JobGroupID & job_group_id = DB::UUIDHelpers::Nil);
-
-    /// Similar to scheduleOrThrowOnError(...). Wait for specified amount of time and schedule a job or return false.
-    bool trySchedule(Job job, int priority = 0, uint64_t wait_microseconds = 0, const JobGroupID & job_group_id = DB::UUIDHelpers::Nil) noexcept;
-
-    /// Similar to scheduleOrThrowOnError(...). Wait for specified amount of time and schedule a job or throw an exception.
-    void scheduleOrThrow(Job job, int priority = 0, uint64_t wait_microseconds = 0, const JobGroupID & job_group_id = DB::UUIDHelpers::Nil);
+    /// Empty job group id by default.
+    inline static const auto JobIDNil = DB::UUIDHelpers::Nil;
 
     /// Wait for all currently active jobs to be done.
     /// You may call schedule and wait many times in arbitrary order.
@@ -64,16 +43,29 @@ public:
     ///  and exception will be cleared.
     void wait();
 
+    /// Same with previous, but wait only for jobs in current job_group_id can
+    /// rethrow exception from any group.
+    void waitGroup(const JobGroupID & job_group_id);
+
     /// Waits for all threads. Doesn't rethrow exceptions (use 'wait' method to rethrow exceptions).
     /// You should not destroy object while calling schedule or wait methods from another threads.
-    virtual ~ThreadPoolImpl();
+    ~ThreadPoolImpl();
 
     /// Returns number of running and scheduled jobs.
     size_t active() const;
+    /// Returns number of running and scheduled jobs with this job_group_id
+    size_t activeInGroup(const JobGroupID & job_group_id) const;
 
     void setMaxThreads(size_t value);
     void setMaxFreeThreads(size_t value);
     void setQueueSize(size_t value);
+
+protected:
+    template <typename ReturnType>
+    ReturnType scheduleImpl(Job job, int priority, std::optional<uint64_t> wait_microseconds, const JobGroupID & job_group_id);
+
+    /// queue_size - maximum number of running plus scheduled jobs. It can be greater than max_threads. Zero means unlimited.
+    ThreadPoolImpl(size_t max_threads_, size_t max_free_threads_, size_t queue_size_, bool shutdown_on_exception_, bool only_log_exceptions_, const CurrentMetrics::Metric & custom_job_metric);
 
 private:
     mutable std::mutex mutex;
@@ -84,13 +76,15 @@ private:
     size_t max_free_threads;
     size_t queue_size;
 
-    size_t scheduled_jobs = 0;
     std::unordered_map<JobGroupID, size_t> scheduled_jobs_by_group;
 
     bool shutdown = false;
     const bool shutdown_on_exception = true;
+    /// Don't rethrow exception in all cases excepti pool shutdown
     const bool only_log_exceptions = false;
-    CurrentMetrics::Metric job_metric;
+    /// Custom metric incremented on each job execution
+    /// zero means no metric
+    CurrentMetrics::Metric custom_job_metric = 0;
 
     struct JobWithPriority
     {
@@ -111,16 +105,31 @@ private:
     std::list<Thread> threads;
     std::exception_ptr first_exception;
 
-    template <typename ReturnType>
-    ReturnType scheduleImpl(Job job, int priority, std::optional<uint64_t> wait_microseconds, const JobGroupID & job_id);
-
     void worker(typename std::list<Thread>::iterator thread_it);
+
+    void incrementJobCountInGroup(const JobGroupID & job_group_id);
+    void decrementJobCountInGroup(const JobGroupID & job_group_id);
+
+    size_t jobCountTotal() const;
+    size_t jobCountInGroup(const JobGroupID & job_group_id) const;
 
     void finalize();
 };
 
 /// ThreadPool with std::thread for threads.
-using FreeThreadPool = ThreadPoolImpl<std::thread>;
+class FreeThreadPool : public ThreadPoolImpl<std::thread>
+{
+public:
+    FreeThreadPool(
+        size_t max_threads_, size_t max_free_threads_,
+        size_t queue_size_, bool shutdown_on_exception_ = true)
+        : ThreadPoolImpl<std::thread>(
+            max_threads_, max_free_threads_, queue_size_, shutdown_on_exception_, false, 0)
+    {}
+
+    void scheduleOrThrow(Job job);
+    void scheduleOrThrowOnError(Job job);
+};
 
 
 /** Global ThreadPool that can be used as a singleton.
@@ -140,11 +149,7 @@ class GlobalThreadPool : public FreeThreadPool, private boost::noncopyable
 {
     static std::unique_ptr<GlobalThreadPool> the_instance;
 
-    GlobalThreadPool(size_t max_threads_, size_t max_free_threads_,
-            size_t queue_size_, const bool shutdown_on_exception_)
-        : FreeThreadPool(max_threads_, max_free_threads_, queue_size_,
-            shutdown_on_exception_)
-    {}
+    using FreeThreadPool::FreeThreadPool;
 
 public:
     static void initialize(size_t max_threads = 10000);
@@ -229,6 +234,45 @@ private:
     std::shared_ptr<Poco::Event> state;
 };
 
-
 /// Recommended thread pool for the case when multiple thread pools are created and destroyed.
-using ThreadPool = ThreadPoolImpl<ThreadFromGlobalPool>;
+class ThreadPool : public ThreadPoolImpl<ThreadFromGlobalPool>
+{
+public:
+    ThreadPool();
+
+    ThreadPool(size_t max_threads_);
+
+    /// queue_size - maximum number of running plus scheduled jobs. It can be greater than max_threads. Zero means unlimited.
+    ThreadPool(size_t max_threads_, size_t max_free_threads_, size_t queue_size_, bool shutdown_on_exception_ = true);
+
+    /// Add new job. Locks until number of scheduled jobs is less than maximum or exception in one of threads was thrown.
+    /// If any thread was throw an exception, first exception will be rethrown from this method,
+    ///  and exception will be cleared.
+    /// Also throws an exception if cannot create thread.
+    /// Priority: greater is higher.
+    /// NOTE: Probably you should call wait() if exception was thrown. If some previously scheduled jobs are using some objects,
+    /// located on stack of current thread, the stack must not be unwinded until all jobs finished. However,
+    /// if ThreadPool is a local object, it will wait for all scheduled jobs in own destructor.
+    void scheduleOrThrowOnError(Job job, int priority = 0, const JobGroupID & job_group_id = JobIDNil);
+
+    /// Similar to scheduleOrThrowOnError(...). Wait for specified amount of time and schedule a job or return false.
+    bool trySchedule(Job job, int priority = 0, uint64_t wait_microseconds = 0, const JobGroupID & job_group_id = JobIDNil) noexcept;
+
+    /// Similar to scheduleOrThrowOnError(...). Wait for specified amount of time and schedule a job or throw an exception.
+    void scheduleOrThrow(Job job, int priority = 0, uint64_t wait_microseconds = 0, const JobGroupID & job_group_id = JobIDNil);
+};
+
+/// Thread pool for background tasks execution. Features:
+/// 1. Doesn't rethrow any exception except calls of scheduleOrThrowOnShutdown after shutdown called.
+/// 2. Print exceptions throwed from jobs to logs.
+/// 3. Allows to increment custom metric during job execution.
+class BackgroundThreadPool : public ThreadPoolImpl<ThreadFromGlobalPool>
+{
+public:
+    BackgroundThreadPool(size_t max_threads_, const CurrentMetrics::Metric & custom_job_metric_)
+        : ThreadPoolImpl<ThreadFromGlobalPool>(max_threads_, max_threads_, 10000, /* shutdown_on_exception = */ false, /* only_log_exceptions = */ true, custom_job_metric_)
+    {}
+
+    /// Throws exception only when shutdown called, otherwise print it to logs
+    void scheduleOrThrowOnShutdown(Job job, const JobGroupID & job_group_id = JobIDNil, int priority = 0);
+};

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -9,6 +9,7 @@
 #include <list>
 #include <optional>
 
+#include <Common/CurrentMetrics.h>
 #include <Poco/Event.h>
 #include <Common/ThreadStatus.h>
 #include <ext/scope_guard.h>
@@ -34,10 +35,10 @@ public:
     ThreadPoolImpl();
 
     /// Size is constant. Up to num_threads are created on demand and then run until shutdown.
-    explicit ThreadPoolImpl(size_t max_threads_);
+    explicit ThreadPoolImpl(size_t max_threads_, bool shutdown_on_exception_ = true, bool only_log_exceptions_ = false);
 
     /// queue_size - maximum number of running plus scheduled jobs. It can be greater than max_threads. Zero means unlimited.
-    ThreadPoolImpl(size_t max_threads_, size_t max_free_threads_, size_t queue_size_, bool shutdown_on_exception_ = true);
+    ThreadPoolImpl(size_t max_threads_, size_t max_free_threads_, size_t queue_size_, bool shutdown_on_exception_ = true, bool only_log_exceptions_ = false);
 
     /// Add new job. Locks until number of scheduled jobs is less than maximum or exception in one of threads was thrown.
     /// If any thread was throw an exception, first exception will be rethrown from this method,
@@ -84,6 +85,8 @@ private:
     size_t scheduled_jobs = 0;
     bool shutdown = false;
     const bool shutdown_on_exception = true;
+    const bool only_log_exceptions = false;
+    CurrentMetrics::Metric job_metric;
 
     struct JobWithPriority
     {

--- a/src/Common/tests/gtest_thread_pool_background.cpp
+++ b/src/Common/tests/gtest_thread_pool_background.cpp
@@ -34,6 +34,7 @@ TEST(BackgroundThreadPool, Exceptions)
         pool.scheduleOrThrowOnShutdown([&] { ++res; });
 
     pool.wait();
+    Poco::Logger::root().setLevel("none");
 
     EXPECT_EQ(res, 1000);
 }

--- a/src/Common/tests/gtest_thread_pool_background.cpp
+++ b/src/Common/tests/gtest_thread_pool_background.cpp
@@ -1,0 +1,80 @@
+#include <atomic>
+#include <iostream>
+#include <Common/ThreadPool.h>
+#include <Common/CurrentMetrics.h>
+#include <Core/UUID.h>
+
+#include <gtest/gtest.h>
+
+
+namespace DB::ErrorCodes
+{
+    extern const int UNSUPPORTED_METHOD;
+}
+
+namespace CurrentMetrics
+{
+    extern const Metric BackgroundPoolTask;
+}
+
+TEST(BackgroundThreadPool, Exceptions)
+{
+    BackgroundThreadPool pool(16, CurrentMetrics::BackgroundPoolTask);
+    pool.scheduleOrThrowOnShutdown([&] { throw DB::Exception(DB::ErrorCodes::UNSUPPORTED_METHOD, "Some Exception"); });
+
+    std::atomic<int> res{0};
+
+    for (size_t i = 0; i < 1000; ++i)
+        pool.scheduleOrThrowOnShutdown([&] { ++res; });
+
+    pool.wait();
+
+    EXPECT_EQ(res, 1000);
+}
+
+TEST(BackgroundThreadPool, JobGroup)
+{
+    std::atomic<int> res1{0};
+    std::atomic<int> res2{0};
+    DB::UUID first_group = DB::UUIDHelpers::generateV4();
+    DB::UUID second_group = DB::UUIDHelpers::generateV4();
+
+    BackgroundThreadPool pool(16, CurrentMetrics::BackgroundPoolTask);
+    for (size_t i = 0; i < 16; ++i)
+    {
+        if (i % 2 == 0)
+            pool.scheduleOrThrowOnShutdown([&] { sleep(1); ++res1; }, first_group);
+        else
+            pool.scheduleOrThrowOnShutdown([&] { sleep(3); ++res2; }, second_group);
+    }
+    pool.waitGroup(first_group);
+    EXPECT_EQ(res1, 8);
+    EXPECT_EQ(res2, 0);
+    pool.waitGroup(second_group);
+    EXPECT_EQ(res1, 8);
+    EXPECT_EQ(res2, 8);
+}
+
+TEST(BackgroundThreadPool, Metric)
+{
+
+    BackgroundThreadPool pool(16, CurrentMetrics::BackgroundPoolTask);
+    for (size_t i = 0; i < 16; ++i)
+        pool.scheduleOrThrowOnShutdown([&] { sleep(5); });
+
+    bool found = false;
+    /// Pool start jobs execution asynchronously, so we just trying to catch the right moment.
+    for (size_t i = 0; i < 10000; ++i)
+    {
+        if (CurrentMetrics::values[CurrentMetrics::BackgroundPoolTask].load() == 16)
+        {
+            found = true;
+            break;
+        }
+        sleep(0.1);
+    }
+
+    EXPECT_TRUE(found);
+
+    pool.wait();
+}

--- a/src/Common/tests/gtest_thread_pool_background.cpp
+++ b/src/Common/tests/gtest_thread_pool_background.cpp
@@ -1,5 +1,8 @@
 #include <atomic>
 #include <iostream>
+#include <Poco/ConsoleChannel.h>
+#include <Poco/AutoPtr.h>
+#include <Poco/Logger.h>
 #include <Common/ThreadPool.h>
 #include <Common/CurrentMetrics.h>
 #include <Core/UUID.h>
@@ -19,6 +22,9 @@ namespace CurrentMetrics
 
 TEST(BackgroundThreadPool, Exceptions)
 {
+    Poco::AutoPtr<Poco::ConsoleChannel> channel = new Poco::ConsoleChannel(std::cerr);
+    Poco::Logger::root().setChannel(channel);
+    Poco::Logger::root().setLevel("trace");
     BackgroundThreadPool pool(16, CurrentMetrics::BackgroundPoolTask);
     pool.scheduleOrThrowOnShutdown([&] { throw DB::Exception(DB::ErrorCodes::UNSUPPORTED_METHOD, "Some Exception"); });
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

My initial idea was to implement a separate class similar to `ThreadPool`, but simpler because for background tasks we don't need complicated exception's handling logic. However, I've tried to extend the current implementation and now I have several fears about it:
1) Code became more complicated.
2) I'm afraid that I've slowed down something because of job groups. Pricinciple "not pay for what you don't use” slightly broken :(
3) Interface still quite incovinient, we have to generate and store UUID somewhere if we want to wait for jobs from some group.

