### PR TITLE
Fix flackiness of LIVE VIEW tests by increasing timeout for HTTPConnection

### DIFF
--- a/tests/queries/0_stateless/helpers/httpclient.py
+++ b/tests/queries/0_stateless/helpers/httpclient.py
@@ -8,7 +8,7 @@ sys.path.insert(0, os.path.join(CURDIR))
 import httpexpect
 
 def client(request, name='', log=None):
-    client = httpexpect.spawn({'host':'localhost','port':8123,'timeout':1}, request)
+    client = httpexpect.spawn({'host':'localhost','port':8123,'timeout':30}, request)
     client.logger(log, prefix=name)
     client.timeout(20)
     return client


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Trace:

<details>

Trace from [1]:

    2020-10-13 01:37:06 00966_live_view_watch_events_http:                                      [ FAIL ] - return code 1
    2020-10-13 01:37:06 Exception in thread Thread-2:
    2020-10-13 01:37:06 Traceback (most recent call last):
    2020-10-13 01:37:06   File "/usr/lib/python3.7/threading.py", line 926, in _bootstrap_inner
    2020-10-13 01:37:06     self.run()
    2020-10-13 01:37:06   File "/usr/lib/python3.7/threading.py", line 870, in run
    2020-10-13 01:37:06     self._target(*self._args, **self._kwargs)
    2020-10-13 01:37:06   File "/usr/share/clickhouse-test/queries/0_stateless/helpers/httpexpect.py", line 48, in reader
    2020-10-13 01:37:06     data = response.read(1).decode()
    2020-10-13 01:37:06   File "/usr/lib/python3.7/http/client.py", line 457, in read
    2020-10-13 01:37:06     n = self.readinto(b)
    2020-10-13 01:37:06   File "/usr/lib/python3.7/http/client.py", line 491, in readinto
    2020-10-13 01:37:06     return self._readinto_chunked(b)
    2020-10-13 01:37:06   File "/usr/lib/python3.7/http/client.py", line 586, in _readinto_chunked
    2020-10-13 01:37:06     chunk_left = self._get_chunk_left()
    2020-10-13 01:37:06   File "/usr/lib/python3.7/http/client.py", line 554, in _get_chunk_left
    2020-10-13 01:37:06     chunk_left = self._read_next_chunk_size()
    2020-10-13 01:37:06   File "/usr/lib/python3.7/http/client.py", line 514, in _read_next_chunk_size
    2020-10-13 01:37:06     line = self.fp.readline(_MAXLINE + 1)
    2020-10-13 01:37:06   File "/usr/lib/python3.7/socket.py", line 589, in readinto
    2020-10-13 01:37:06     return self._sock.recv_into(b)
    2020-10-13 01:37:06 socket.timeout: timed out

  [1]: https://clickhouse-test-reports.s3.yandex.net/15879/f7bf94b5d361d0a54e85673c14e630cfdf8dbe01/functional_stateless_tests_(release,_polymorphic_parts_enabled)/test_run.txt.out.log

</details>

Cc: @vzakaznikov 
Introduced-in: #15007 