### PR TITLE
Clickhouse client added history file parameter

### DIFF
--- a/docs/en/interfaces/cli.md
+++ b/docs/en/interfaces/cli.md
@@ -123,6 +123,7 @@ You can pass parameters to `clickhouse-client` (all parameters have a default va
 -   `--stacktrace` – If specified, also print the stack trace if an exception occurs.
 -   `--config-file` – The name of the configuration file.
 -   `--secure` – If specified, will connect to server over secure connection.
+-   `--history_file` — Path to a file containing command history.
 -   `--param_<name>` — Value for a [query with parameters](#cli-queries-with-parameters).
 
 ### Configuration Files {#configuration_files}

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -2329,6 +2329,7 @@ public:
             ("query-fuzzer-runs", po::value<int>()->default_value(0), "query fuzzer runs")
             ("opentelemetry-traceparent", po::value<std::string>(), "OpenTelemetry traceparent header as described by W3C Trace Context recommendation")
             ("opentelemetry-tracestate", po::value<std::string>(), "OpenTelemetry tracestate header as described by W3C Trace Context recommendation")
+            ("history_file", po::value<std::string>(), "path to history file")
         ;
 
         Settings cmd_settings;
@@ -2485,6 +2486,8 @@ public:
             config().setInt("suggestion_limit", options["suggestion_limit"].as<int>());
         if (options.count("highlight"))
             config().setBool("highlight", options["highlight"].as<bool>());
+        if (options.count("history_file"))
+            config().setString("history_file", options["history_file"].as<std::string>());
 
         if ((query_fuzzer_runs = options["query-fuzzer-runs"].as<int>()))
         {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make it possible to change the path to history file in `clickhouse-client` using the `--history_file` parameter.
