### PR TITLE
Fix possibly dangling reference to target table of MV

### DIFF
--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -414,6 +414,11 @@ BlockIO InterpreterInsertQuery::execute()
         res.out = std::move(out_streams.at(0));
 
     res.pipeline.addStorageHolder(table);
+    if (const auto * mv = dynamic_cast<const StorageMaterializedView *>(table.get()))
+    {
+        if (auto inner_table = mv->tryGetTargetTable())
+            res.pipeline.addStorageHolder(inner_table);
+    }
 
     return res;
 }

--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -239,6 +239,7 @@ Pipe StorageBuffer::read(
         }
 
         pipe_from_dst.addTableLock(destination_lock);
+        pipe_from_dst.addStorageHolder(destination);
     }
 
     Pipe pipe_from_buffers;

--- a/src/Storages/StorageMaterializeMySQL.cpp
+++ b/src/Storages/StorageMaterializeMySQL.cpp
@@ -82,6 +82,7 @@ Pipe StorageMaterializeMySQL::read(
     }
 
     Pipe pipe = nested_storage->read(require_columns_name, nested_metadata, query_info, context, processed_stage, max_block_size, num_streams);
+    pipe.addTableLock(lock);
 
     if (!expressions->children.empty() && !pipe.empty())
     {

--- a/src/Storages/StorageMaterializedView.cpp
+++ b/src/Storages/StorageMaterializedView.cpp
@@ -125,7 +125,6 @@ Pipe StorageMaterializedView::read(
     Pipe pipe = storage->read(column_names, metadata_snapshot, query_info, context, processed_stage, max_block_size, num_streams);
     pipe.addTableLock(lock);
     pipe.addStorageHolder(storage);
-    
 
     return pipe;
 }

--- a/src/Storages/StorageMaterializedView.cpp
+++ b/src/Storages/StorageMaterializedView.cpp
@@ -124,6 +124,8 @@ Pipe StorageMaterializedView::read(
 
     Pipe pipe = storage->read(column_names, metadata_snapshot, query_info, context, processed_stage, max_block_size, num_streams);
     pipe.addTableLock(lock);
+    pipe.addStorageHolder(storage);
+    
 
     return pipe;
 }

--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -357,6 +357,7 @@ Pipe StorageMerge::createSources(
         convertingSourceStream(header, metadata_snapshot, *modified_context, modified_query_info.query, pipe, processed_stage);
 
         pipe.addTableLock(struct_lock);
+        pipe.addStorageHolder(storage);
         pipe.addInterpreterContext(modified_context);
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix rare segfaults when inserting into or selecting from MaterializedView and concurrently dropping target table (for Atomic database engine).

Fixes https://clickhouse-test-reports.s3.yandex.net/0/13896cf4c92d6cf0962a2e9bb181dfe42045d39c/stress_test_(thread)/stderr.log and https://clickhouse-test-reports.s3.yandex.net/0/57575a5a12721682f07ff813460c6edb4b85b2c7/stress_test_(thread)/stderr.log