### PR TITLE
Fix the bug when NOTHING_TO_DO events wrongly increment count_no_work_done

### DIFF
--- a/src/Storages/MergeTree/BackgroundProcessingPool.cpp
+++ b/src/Storages/MergeTree/BackgroundProcessingPool.cpp
@@ -217,8 +217,11 @@ void BackgroundProcessingPool::workLoopFunc()
 
             if (task_result == TaskResult::SUCCESS)
                 task->count_no_work_done = 0;
-            else
+            else if (task_result == TaskResult::ERROR)
                 ++task->count_no_work_done;
+            /// NOTHING_TO_DO should not increment count_no_work_done
+            /// otherwise error after period of inactivity (lot of NOTHING_TO_DO)
+            /// leads to 5-10 min replication hang
 
             /// If task has done work, it could be executed again immediately.
             /// If not, add delay before next run.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Prevent replica hang for 5-10 mins when replication error happens after a period of inactivity.

Detailed description / Documentation draft:
Fixes https://github.com/ClickHouse/ClickHouse/issues/15955