### PR TITLE
Don't touch MySQL database if it's unnecessary

### DIFF
--- a/src/Databases/DatabaseLazy.h
+++ b/src/Databases/DatabaseLazy.h
@@ -22,6 +22,10 @@ public:
 
     String getEngineName() const override { return "Lazy"; }
 
+    bool canContainMergeTreeTables() const override { return false; }
+
+    bool canContainDistributedTables() const override { return false; }
+
     void loadStoredObjects(
         Context & context,
         bool has_force_restore_data_flag, bool force_attach) override;

--- a/src/Databases/IDatabase.h
+++ b/src/Databases/IDatabase.h
@@ -147,6 +147,10 @@ public:
     /// Get name of database engine.
     virtual String getEngineName() const = 0;
 
+    virtual bool canContainMergeTreeTables() const { return true; }
+
+    virtual bool canContainDistributedTables() const { return true; }
+
     /// Load a set of existing tables.
     /// You can call only once, right after the object is created.
     virtual void loadStoredObjects(Context & /*context*/, bool /*has_force_restore_data_flag*/, bool /*force_attach*/ = false) {}

--- a/src/Databases/MySQL/DatabaseConnectionMySQL.h
+++ b/src/Databases/MySQL/DatabaseConnectionMySQL.h
@@ -42,6 +42,12 @@ public:
 
     String getEngineName() const override { return "MySQL"; }
 
+    bool canContainMergeTreeTables() const override { return false; }
+
+    bool canContainDistributedTables() const override { return false; }
+
+    bool shouldBeEmptyOnDetach() const override { return false; }
+
     bool empty() const override;
 
     DatabaseTablesIteratorPtr getTablesIterator(const Context & context, const FilterByNameFunction & filter_by_table_name) override;

--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -233,8 +233,8 @@ void AsynchronousMetrics::update()
 
         for (const auto & db : databases)
         {
-            /// Lazy database can not contain MergeTree tables
-            if (db.second->getEngineName() == "Lazy")
+            /// Check if database can contain MergeTree tables
+            if (!db.second->canContainMergeTreeTables())
                 continue;
             for (auto iterator = db.second->getTablesIterator(context); iterator->isValid(); iterator->next())
             {

--- a/src/Server/ReplicasStatusHandler.cpp
+++ b/src/Server/ReplicasStatusHandler.cpp
@@ -43,8 +43,8 @@ void ReplicasStatusHandler::handleRequest(Poco::Net::HTTPServerRequest & request
         /// Iterate through all the replicated tables.
         for (const auto & db : databases)
         {
-            /// Lazy database can not contain replicated tables
-            if (db.second->getEngineName() == "Lazy")
+            /// Check if database can contain replicated tables
+            if (!db.second->canContainMergeTreeTables())
                 continue;
 
             for (auto iterator = db.second->getTablesIterator(context); iterator->isValid(); iterator->next())

--- a/src/Storages/System/StorageSystemDistributionQueue.cpp
+++ b/src/Storages/System/StorageSystemDistributionQueue.cpp
@@ -38,8 +38,8 @@ void StorageSystemDistributionQueue::fillData(MutableColumns & res_columns, cons
     std::map<String, std::map<String, StoragePtr>> tables;
     for (const auto & db : DatabaseCatalog::instance().getDatabases())
     {
-        /// Lazy database can not contain distributed tables
-        if (db.second->getEngineName() == "Lazy")
+        /// Check if database can contain distributed tables
+        if (!db.second->canContainDistributedTables())
             continue;
 
         const bool check_access_for_tables = check_access_for_databases && !access->isGranted(AccessType::SHOW_TABLES, db.first);

--- a/src/Storages/System/StorageSystemGraphite.cpp
+++ b/src/Storages/System/StorageSystemGraphite.cpp
@@ -32,8 +32,8 @@ static StorageSystemGraphite::Configs getConfigs(const Context & context)
 
     for (const auto & db : databases)
     {
-        /// Lazy database can not contain MergeTree tables
-        if (db.second->getEngineName() == "Lazy")
+        /// Check if database can contain MergeTree tables
+        if (!db.second->canContainMergeTreeTables())
             continue;
 
         for (auto iterator = db.second->getTablesIterator(context); iterator->isValid(); iterator->next())

--- a/src/Storages/System/StorageSystemMutations.cpp
+++ b/src/Storages/System/StorageSystemMutations.cpp
@@ -44,8 +44,8 @@ void StorageSystemMutations::fillData(MutableColumns & res_columns, const Contex
     std::map<String, std::map<String, StoragePtr>> merge_tree_tables;
     for (const auto & db : DatabaseCatalog::instance().getDatabases())
     {
-        /// Lazy database can not contain MergeTree tables
-        if (db.second->getEngineName() == "Lazy")
+        /// Check if database can contain MergeTree tables
+        if (!db.second->canContainMergeTreeTables())
             continue;
 
         const bool check_access_for_tables = check_access_for_databases && !access->isGranted(AccessType::SHOW_TABLES, db.first);

--- a/src/Storages/System/StorageSystemPartsBase.cpp
+++ b/src/Storages/System/StorageSystemPartsBase.cpp
@@ -83,9 +83,9 @@ StoragesInfoStream::StoragesInfoStream(const SelectQueryInfo & query_info, const
         MutableColumnPtr database_column_mut = ColumnString::create();
         for (const auto & database : databases)
         {
-            /// Lazy database can not contain MergeTree tables
-            /// and it's unnecessary to load all tables of Lazy database just to filter all of them.
-            if (database.second->getEngineName() != "Lazy")
+            /// Checck if database can contain MergeTree tables,
+            /// if not it's unnecessary to load all tables of database just to filter all of them.
+            if (database.second->canContainMergeTreeTables())
                 database_column_mut->insert(database.first);
         }
         block_to_filter.insert(ColumnWithTypeAndName(

--- a/src/Storages/System/StorageSystemReplicas.cpp
+++ b/src/Storages/System/StorageSystemReplicas.cpp
@@ -75,7 +75,7 @@ Pipe StorageSystemReplicas::read(
     for (const auto & db : DatabaseCatalog::instance().getDatabases())
     {
         /// Check if database can contain replicated tables
-        if (db.second->canContainMergeTreeTables())
+        if (!db.second->canContainMergeTreeTables())
             continue;
         const bool check_access_for_tables = check_access_for_databases && !access->isGranted(AccessType::SHOW_TABLES, db.first);
         for (auto iterator = db.second->getTablesIterator(context); iterator->isValid(); iterator->next())

--- a/src/Storages/System/StorageSystemReplicas.cpp
+++ b/src/Storages/System/StorageSystemReplicas.cpp
@@ -74,8 +74,8 @@ Pipe StorageSystemReplicas::read(
     std::map<String, std::map<String, StoragePtr>> replicated_tables;
     for (const auto & db : DatabaseCatalog::instance().getDatabases())
     {
-        /// Lazy database can not contain replicated tables
-        if (db.second->getEngineName() == "Lazy")
+        /// Check if database can contain replicated tables
+        if (db.second->canContainMergeTreeTables())
             continue;
         const bool check_access_for_tables = check_access_for_databases && !access->isGranted(AccessType::SHOW_TABLES, db.first);
         for (auto iterator = db.second->getTablesIterator(context); iterator->isValid(); iterator->next())

--- a/src/Storages/System/StorageSystemReplicationQueue.cpp
+++ b/src/Storages/System/StorageSystemReplicationQueue.cpp
@@ -55,8 +55,8 @@ void StorageSystemReplicationQueue::fillData(MutableColumns & res_columns, const
     std::map<String, std::map<String, StoragePtr>> replicated_tables;
     for (const auto & db : DatabaseCatalog::instance().getDatabases())
     {
-        /// Lazy database can not contain replicated tables
-        if (db.second->getEngineName() == "Lazy")
+        /// Check if database can contain replicated tables
+        if (!db.second->canContainMergeTreeTables())
             continue;
 
         const bool check_access_for_tables = check_access_for_databases && !access->isGranted(AccessType::SHOW_TABLES, db.first);

--- a/tests/integration/test_disabled_mysql_server/configs/remote_servers.xml
+++ b/tests/integration/test_disabled_mysql_server/configs/remote_servers.xml
@@ -1,0 +1,12 @@
+<yandex>
+    <remote_servers>
+        <test_cluster>
+            <shard>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster>
+    </remote_servers>
+</yandex>

--- a/tests/integration/test_disabled_mysql_server/test.py
+++ b/tests/integration/test_disabled_mysql_server/test.py
@@ -27,7 +27,7 @@ class MySQLNodeInstance:
         self.port = port
         self.hostname = hostname
         self.password = password
-        self.mysql_connection = None  # lazy init
+        self.mysql_connection = None   # lazy init
 
     def alloc_connection(self):
         if self.mysql_connection is None:

--- a/tests/integration/test_disabled_mysql_server/test.py
+++ b/tests/integration/test_disabled_mysql_server/test.py
@@ -51,7 +51,6 @@ def test_disabled_mysql_server(started_cluster):
 
     with PartitionManager() as pm:
         clickhouse_node.query("CREATE DATABASE test_db ENGINE = MySQL('mysql1:3306', 'test_db', 'root', 'clickhouse')")
-
             
         pm._add_rule({'source': clickhouse_node.ip_address, 'destination_port': 3306, 'action': 'DROP'})
         clickhouse_node.query("SELECT * FROM system.parts")

--- a/tests/integration/test_disabled_mysql_server/test.py
+++ b/tests/integration/test_disabled_mysql_server/test.py
@@ -1,0 +1,61 @@
+import time
+import contextlib
+import pymysql.cursors
+import pytest
+import os
+import subprocess
+
+from helpers.client import QueryRuntimeException
+from helpers.cluster import ClickHouseCluster, get_docker_compose_path
+from helpers.network import PartitionManager
+
+cluster = ClickHouseCluster(__file__)
+clickhouse_node = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml'], with_mysql=True)
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+class MySQLNodeInstance:
+    def __init__(self, user='root', password='clickhouse', hostname='127.0.0.1', port=3308):
+        self.user = user
+        self.port = port
+        self.hostname = hostname
+        self.password = password
+        self.mysql_connection = None  # lazy init
+
+    def alloc_connection(self):
+        if self.mysql_connection is None:
+            self.mysql_connection = pymysql.connect(user=self.user, password=self.password, host=self.hostname,
+                                                    port=self.port, autocommit=True)
+        return self.mysql_connection
+
+    def query(self, execution_query):
+        with self.alloc_connection().cursor() as cursor:
+            cursor.execute(execution_query)
+
+    def close(self):
+        if self.mysql_connection is not None:
+            self.mysql_connection.close()
+
+
+def test_disabled_mysql_server(started_cluster):
+    with contextlib.closing(MySQLNodeInstance()) as mysql_node:
+        mysql_node.query("CREATE DATABASE test_db;")
+        mysql_node.query("CREATE TABLE test_db.test_table ( `id` int(11) NOT NULL, PRIMARY KEY (`id`) ) ENGINE=InnoDB;")
+
+    with PartitionManager() as pm:
+        clickhouse_node.query("CREATE DATABASE test_db ENGINE = MySQL('mysql1:3306', 'test_db', 'root', 'clickhouse')")
+
+            
+        pm._add_rule({'source': clickhouse_node.ip_address, 'destination_port': 3306, 'action': 'DROP'})
+        clickhouse_node.query("SELECT * FROM system.parts")
+        clickhouse_node.query("SELECT * FROM system.mutations")
+        clickhouse_node.query("SELECT * FROM system.graphite_retentions")
+
+        clickhouse_node.query("DROP DATABASE test_db")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bug with MySQL database. When MySQL server used as database engine is down some queries raise Exception, because they try to get tables from disabled server, while it's unnecessary. For example, query `SELECT ... FROM system.parts` should work only with MergeTree tables and don't touch MySQL database at all. 

This closes #15706
