### PR TITLE
Added a test for query parameter of type UUID

### DIFF
--- a/tests/queries/0_stateless/01526_param_uuid.reference
+++ b/tests/queries/0_stateless/01526_param_uuid.reference
@@ -1,0 +1,1 @@
+ffffffff-ffff-ffff-ffff-ffffffffffff

--- a/tests/queries/0_stateless/01526_param_uuid.sh
+++ b/tests/queries/0_stateless/01526_param_uuid.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} --param_p1='ffffffff-ffff-ffff-ffff-ffffffffffff' --query "SELECT {p1:UUID}"


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

A test for #7463.