### PR TITLE
Change error message in function if & ifNull

### DIFF
--- a/src/Functions/if.cpp
+++ b/src/Functions/if.cpp
@@ -160,7 +160,7 @@ struct NumIfImpl<A, B, NumberTraits::Error>
 private:
     [[noreturn]] static void throwError()
     {
-        throw Exception("Invalid types of arguments 2 and 3 of if", ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+        throw Exception("Incompatible types of arguments corresponding to two conditional branches", ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
     }
 public:
     template <typename... Args> static void vectorVector(Args &&...) { throwError(); }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog


Detailed description / Documentation draft:

```sql
select ifNull(defaultValueOfTypeName('Nullable(Decimal64(2))'), 123)

-- DB::Exception: Invalid types of arguments 2 and 3 of if.
```

The current error message of `ifNull()` is confusing because it is actually from `if()`.