### PR TITLE
Better message about build error on Mac #16072

### DIFF
--- a/cmake/tools.cmake
+++ b/cmake/tools.cmake
@@ -15,6 +15,10 @@ if (COMPILER_GCC)
 elseif (COMPILER_CLANG)
     # Require minimum version of clang/apple-clang
     if (CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
+        # If you are developer you can figure out what exact versions of AppleClang are Ok,
+        # remove the following line and commit changes below.
+        message (FATAL_ERROR "AppleClang is not supported, you should install clang from brew.")
+
         # AppleClang 10.0.1 (Xcode 10.2) corresponds to LLVM/Clang upstream version 7.0.0
         # AppleClang 11.0.0 (Xcode 11.0) corresponds to LLVM/Clang upstream version 8.0.0
         set (XCODE_MINIMUM_VERSION 10.2)


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Refuse to build with AppleClang because it's difficult to find out version correspondence. This closes #16072.
