### PR TITLE
Fix segfault with wrong aggregation in lambdas

### DIFF
--- a/src/Interpreters/ExpressionAnalyzer.cpp
+++ b/src/Interpreters/ExpressionAnalyzer.cpp
@@ -421,11 +421,17 @@ bool ExpressionAnalyzer::makeAggregateDescriptions(ActionsDAGPtr & actions)
         aggregate.argument_names.resize(arguments.size());
         DataTypes types(arguments.size());
 
+        const auto & index = actions->getIndex();
         for (size_t i = 0; i < arguments.size(); ++i)
         {
             getRootActionsNoMakeSet(arguments[i], true, actions);
             const std::string & name = arguments[i]->getColumnName();
-            types[i] = actions->getIndex().find(name)->second->result_type;
+
+            auto it = index.find(name);
+            if (it == index.end())
+                throw Exception(ErrorCodes::UNKNOWN_IDENTIFIER, "Unknown identifier (in aggregate function '{}'): {}", node->name, name);
+
+            types[i] = it->second->result_type;
             aggregate.argument_names[i] = name;
         }
 

--- a/tests/queries/0_stateless/01527_bad_aggregation_in_lambda.sql
+++ b/tests/queries/0_stateless/01527_bad_aggregation_in_lambda.sql
@@ -1,0 +1,1 @@
+SELECT arrayMap(x -> x * sum(x), range(10)); -- { serverError 47 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix segfault in some cases of wrong aggregation in lambdas.

Detailed description / Documentation draft:
Fixes #15981.

Looks like it's the best way to throw exception in case of expression like this `arrayMap(x -> x * sum(x), range(10))`, because it's hard to determine it in `TreeRewrirwer`.