### PR TITLE
remove warnings in integration tests

### DIFF
--- a/docker/test/integration/runner/Dockerfile
+++ b/docker/test/integration/runner/Dockerfile
@@ -37,7 +37,28 @@ RUN apt-get update \
 ENV TZ=Europe/Moscow
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN python3 -m pip install urllib3==1.23 pytest docker-compose==1.22.0 docker dicttoxml kazoo PyMySQL psycopg2==2.7.5 pymongo tzlocal kafka-python protobuf redis aerospike pytest-timeout minio grpcio grpcio-tools cassandra-driver confluent-kafka avro
+RUN python3 -m pip install \
+    PyMySQL \
+    aerospike \
+    avro \
+    cassandra-driver \
+    confluent-kafka \
+    dicttoxml \
+    docker \
+    docker-compose==1.22.0 \
+    grpcio \
+    grpcio-tools \
+    kafka-python \
+    kazoo \
+    minio \
+    protobuf \
+    psycopg2-binary==2.7.5 \
+    pymongo \
+    pytest \
+    pytest-timeout \
+    redis \
+    tzlocal \
+    urllib3
 
 ENV DOCKER_CHANNEL stable
 ENV DOCKER_VERSION 17.09.1-ce


### PR DESCRIPTION
```
============================================================================= warnings summary ==============================================================================
../../../usr/local/lib/python3.6/dist-packages/requests/__init__.py:80
  /usr/local/lib/python3.6/dist-packages/requests/__init__.py:80: RequestsDependencyWarning: urllib3 (1.23) or chardet (3.0.4) doesn't match a supported version!
    RequestsDependencyWarning)

../../../usr/local/lib/python3.6/dist-packages/psycopg2/__init__.py:144
  /usr/local/lib/python3.6/dist-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
    """)

```

Changelog category (leave one):
- Not for changelog (changelog entry is not required)
