### PR TITLE
RFC: Add metadata section to MergeTreeWriteAheadLog

### DIFF
--- a/src/Storages/CMakeLists.txt
+++ b/src/Storages/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(MergeTree)
 add_subdirectory(System)
 
 if(ENABLE_TESTS)

--- a/src/Storages/MergeTree/CMakeLists.txt
+++ b/src/Storages/MergeTree/CMakeLists.txt
@@ -1,0 +1,3 @@
+if(ENABLE_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/src/Storages/MergeTree/MergeTreeWriteAheadLog.h
+++ b/src/Storages/MergeTree/MergeTreeWriteAheadLog.h
@@ -28,6 +28,19 @@ public:
         DROP_PART = 1,
     };
 
+    struct ActionMetadata
+    {
+        /// The minimum version of WAL reader that can understand metadata written by current ClickHouse version.
+        /// This field must be increased when making backwards incompatible changes.
+        ///
+        /// The same approach can be used recursively inside metadata.
+        UInt8 min_compatible_version = 0;
+
+        void write(WriteBuffer & meta_out) const;
+        void read(ReadBuffer & meta_in);
+    };
+
+    constexpr static UInt8 WAL_VERSION = 0;
     constexpr static auto WAL_FILE_NAME = "wal";
     constexpr static auto WAL_FILE_EXTENSION = ".bin";
     constexpr static auto DEFAULT_WAL_FILE_NAME = "wal.bin";

--- a/src/Storages/MergeTree/tests/CMakeLists.txt
+++ b/src/Storages/MergeTree/tests/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable (wal_action_metadata wal_action_metadata.cpp)
+target_link_libraries (wal_action_metadata PRIVATE dbms)

--- a/src/Storages/MergeTree/tests/wal_action_metadata.cpp
+++ b/src/Storages/MergeTree/tests/wal_action_metadata.cpp
@@ -1,0 +1,61 @@
+#include <iostream>
+
+#include <IO/MemoryReadWriteBuffer.h>
+#include <Storages/MergeTree/MergeTreeWriteAheadLog.h>
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int UNKNOWN_FORMAT_VERSION;
+}
+}
+
+int main(int, char **)
+{
+    try
+    {
+        {
+            std::cout << "test: dummy test" << std::endl;
+
+            DB::MergeTreeWriteAheadLog::ActionMetadata metadata_out;
+            DB::MemoryWriteBuffer buf{};
+
+            metadata_out.write(buf);
+            buf.finalize();
+
+            metadata_out.read(*buf.tryGetReadBuffer());
+        }
+
+        {
+            std::cout << "test: min compatibility" << std::endl;
+
+            DB::MergeTreeWriteAheadLog::ActionMetadata metadata_out;
+            metadata_out.min_compatible_version = DB::MergeTreeWriteAheadLog::WAL_VERSION + 1;
+            DB::MemoryWriteBuffer buf{};
+
+            metadata_out.write(buf);
+            buf.finalize();
+
+            try
+            {
+                metadata_out.read(*buf.tryGetReadBuffer());
+            }
+            catch (const DB::Exception & e)
+            {
+                if (e.code() != DB::ErrorCodes::UNKNOWN_FORMAT_VERSION)
+                {
+                    std::cerr << "Expected UNKNOWN_FORMAT_VERSION exception but got: "
+                        << e.what() << ", " << e.displayText() << std::endl;
+                }
+            }
+        }
+    }
+    catch (const DB::Exception & e)
+    {
+        std::cerr << e.what() << ", " << e.displayText() << std::endl;
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Current WAL format doesn't seem to be extendable without breaking
reverse compatibility.

This PR proposes to introduces a metadata section
for each action in the WAL to which optional fields can be added.

Adding new fields is trivial and doesn't have to break backwards
compatibility if these are not critical for correctness.

Metadata contains the minimum version of the reader allowed
to interpret it.

Removing fields is not supported.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

- Other

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Try to make MergeTreeWriteAheadLog forward compatible.