### PR TITLE
Fix accounting for new/delete from different threads for VariableContext::Thread

### DIFF
--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -40,6 +40,8 @@ private:
     void updatePeak(Int64 will_be);
     void logMemoryUsage(Int64 current) const;
 
+    void free(Int64 size, VariableContext parent_level);
+
 public:
     MemoryTracker(VariableContext level_ = VariableContext::Thread);
     MemoryTracker(MemoryTracker * parent_, VariableContext level_ = VariableContext::Thread);


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible memory drift (due to new/delete from different threads)

Detailed description / Documentation draft:
MemoryTracker assumes that for VariableContext::Thread new/delete may be
called from different threads, hence the amount of memory can go
negative.

However the MemoryTracker is nested, so even if the negative amount is
allowed for VariableContext::Thread it does not allowed for anything
upper, and hence the MemoryTracking will not be decremented properly.

Fix this, by looking at the initial level.

Fixes: #15932 (This PR should fix memory drift for HTTP queries from that PR)

P.S. Marked as Improvement since backporting requirement is doubtful