### PR TITLE
Fix inconsistent behaviour of rankCorr function

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionRankCorrelation.h
+++ b/src/AggregateFunctions/AggregateFunctionRankCorrelation.h
@@ -134,18 +134,18 @@ public:
         const auto & value = this->data(place).values;
         size_t size = this->data(place).size_x;
 
-        //create a copy of values not to format data
+        // create a copy of values not to format data
         PODArrayWithStackMemory<std::pair<Float64, Float64>, 32> tmp_values;
         tmp_values.resize(size);
         for (size_t j = 0; j < size; ++ j)
             tmp_values[j] = static_cast<std::pair<Float64, Float64>>(value[j]);
 
-        //sort x_values
+        // sort x_values
         std::sort(std::begin(tmp_values), std::end(tmp_values), ComparePairFirst<std::greater>{});
 
         for (size_t j = 0; j < size;)
         {
-            //replace x_values with their ranks
+            // replace x_values with their ranks
             size_t rank = j + 1;
             size_t same = 1;
             size_t cur_sum = rank;
@@ -157,9 +157,9 @@ public:
                 {
                     // rank of (j + 1)th number
                     rank += 1;
-                    same++;
+                    ++same;
                     cur_sum += rank;
-                    j++;
+                    ++j;
                 }
                 else
                     break;
@@ -169,16 +169,16 @@ public:
             Float64 insert_rank = static_cast<Float64>(cur_sum) / same;
             for (size_t i = cur_start; i <= j; ++i)
                 tmp_values[i].first = insert_rank;
-            j++;
+            ++j;
         }
 
-        //sort y_values
+        // sort y_values
         std::sort(std::begin(tmp_values), std::end(tmp_values), ComparePairSecond<std::greater>{});
 
-        //replace y_values with their ranks
+        // replace y_values with their ranks
         for (size_t j = 0; j < size;)
         {
-            //replace x_values with their ranks
+            // replace x_values with their ranks
             size_t rank = j + 1;
             size_t same = 1;
             size_t cur_sum = rank;
@@ -190,9 +190,9 @@ public:
                 {
                     // rank of (j + 1)th number
                     rank += 1;
-                    same++;
+                    ++same;
                     cur_sum += rank;
-                    j++;
+                    ++j;
                 }
                 else
                 {
@@ -204,10 +204,10 @@ public:
             Float64 insert_rank = static_cast<Float64>(cur_sum) / same;
             for (size_t i = cur_start; i <= j; ++i)
                 tmp_values[i].second = insert_rank;
-            j++;
+            ++j;
         }
 
-        //count d^2 sum
+        // count d^2 sum
         Float64 answer = static_cast<Float64>(0);
         for (size_t j = 0; j < size; ++ j)
             answer += (tmp_values[j].first - tmp_values[j].second) * (tmp_values[j].first - tmp_values[j].second);

--- a/src/AggregateFunctions/AggregateFunctionRankCorrelation.h
+++ b/src/AggregateFunctions/AggregateFunctionRankCorrelation.h
@@ -21,10 +21,6 @@
 
 #include <type_traits>
 
-namespace ErrorCodes
-{
-extern const int BAD_ARGUMENTS;
-}
 
 namespace DB
 {

--- a/src/AggregateFunctions/AggregateFunctionRankCorrelation.h
+++ b/src/AggregateFunctions/AggregateFunctionRankCorrelation.h
@@ -138,11 +138,6 @@ public:
         const auto & value = this->data(place).values;
         size_t size = this->data(place).size_x;
 
-        if (size < 2)
-        {
-            throw Exception("Aggregate function " + getName() + " requires samples to be of size > 1", ErrorCodes::BAD_ARGUMENTS);
-        }
-
         //create a copy of values not to format data
         PODArrayWithStackMemory<std::pair<Float64, Float64>, 32> tmp_values;
         tmp_values.resize(size);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Backward Incompatible Change


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make rankCorr function  return nan on insufficient data
https://github.com/ClickHouse/ClickHouse/issues/16124


Detailed description / Documentation draft:
Do not throw error while rankCorr execute on insufficient data, but return nan like other statistical algorithms (e.g. varSamp, corr) .
related issue: https://github.com/ClickHouse/ClickHouse/issues/16124
