### PR TITLE
Fix #15872 Enforce linker errors on any warning + fix executable stack

### DIFF
--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -99,6 +99,12 @@ if (COMPILER_CLANG)
 
         # TODO Enable conversion, sign-conversion, double-promotion warnings.
     endif ()
+    # Warn if linker have to build a binary with executable stack (security issue).
+    # add_link_options(LINKER:--warn-execstack)
+    # Unfortunately CH contains many assembler files without `.section       .note.GNU-stack,"",@progbits`
+    # That's why we just enforce non-executable stack.
+    add_link_options(LINKER:-z,noexecstack)
+    add_link_options(LINKER:--fatal-warnings)
 elseif (COMPILER_GCC)
     # Add compiler options only to c++ compiler
     function(add_cxx_compile_options option)
@@ -196,4 +202,10 @@ elseif (COMPILER_GCC)
         # For some reason (bug in gcc?) macro 'GCC diagnostic ignored "-Wstringop-overflow"' doesn't help.
         add_cxx_compile_options(-Wno-stringop-overflow)
     endif()
+    # Warn if linker have to build a binary with executable stack (security issue).
+    # add_link_options(LINKER:--warn-execstack)
+    # Unfortunately CH contains many assembler files without `.section       .note.GNU-stack,"",@progbits`
+    # That's why we just enforce non-executable stack.
+    add_link_options(LINKER:-z,noexecstack)
+    add_link_options(LINKER:--fatal-warnings)
 endif ()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry:
Prevent building binaries with executable stack even when developer was building ClickHouse manually on Fedora. It's security issue. Note that there was no such issue for official builds.
