### PR TITLE
Add max_concurrent_queries_for_all_users setting

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -153,6 +153,7 @@ class IColumn;
     \
     M(DistributedProductMode, distributed_product_mode, DistributedProductMode::DENY, "How are distributed subqueries performed inside IN or JOIN sections?", IMPORTANT) \
     \
+    M(UInt64, max_concurrent_queries_for_all_users, 0, "The maximum number of concurrent requests for all users.", 0) \
     M(UInt64, max_concurrent_queries_for_user, 0, "The maximum number of concurrent requests per user.", 0) \
     \
     M(Bool, insert_deduplicate, true, "For INSERT queries in the replicated table, specifies that deduplication of insertings blocks should be performed", 0) \

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -89,6 +89,15 @@ ProcessList::EntryPtr ProcessList::insert(const String & query_, const IAST * as
                 throw Exception("Too many simultaneous queries. Maximum: " + toString(max_size), ErrorCodes::TOO_MANY_SIMULTANEOUS_QUERIES);
         }
 
+        {
+            if (!is_unlimited_query && settings.max_concurrent_queries_for_all_users
+                && processes.size() > settings.max_concurrent_queries_for_all_users)
+                throw Exception(
+                    "Too many simultaneous queries for all users. Current: " + toString(processes.size())
+                    + ", maximum: " + settings.max_concurrent_queries_for_all_users.toString(),
+                    ErrorCodes::TOO_MANY_SIMULTANEOUS_QUERIES);
+        }
+
         /** Why we use current user?
           * Because initial one is passed by client and credentials for it is not verified,
           *  and using initial_user for limits will be insecure.

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -90,8 +90,27 @@ ProcessList::EntryPtr ProcessList::insert(const String & query_, const IAST * as
         }
 
         {
+            /**
+             * `max_size` check above is controlled by `max_concurrent_queries` server setting and is a "hard" limit for how many
+             * queries the server can process concurrently. It is configured at startup. When the server is overloaded with queries and the
+             * hard limit is reached it is impossible to connect to the server to run queries for investigation.
+             *
+             * With `max_concurrent_queries_for_all_users` it is possible to configure an additional, runtime configurable, limit for query concurrency.
+             * Usually it should be configured just once for `default_profile` which is inherited by all users. DBAs can override
+             * this setting when connecting to ClickHouse, or it can be configured for a DBA profile to have a value greater than that of
+             * the default profile (or 0 for unlimited).
+             *
+             * One example is to set `max_size=X`, `max_concurrent_queries_for_all_users=X-10` for default profile,
+             * and `max_concurrent_queries_for_all_users=0` for DBAs or accounts that are vital for ClickHouse operations (like metrics
+             * exporters).
+             *
+             * Another creative example is to configure `max_concurrent_queries_for_all_users=50` for "analyst" profiles running adhoc queries
+             * and `max_concurrent_queries_for_all_users=100` for "customer facing" services. This way "analyst" queries will be rejected
+             * once is already processing 50+ concurrent queries (including analysts or any other users).
+             */
+
             if (!is_unlimited_query && settings.max_concurrent_queries_for_all_users
-                && processes.size() > settings.max_concurrent_queries_for_all_users)
+                && processes.size() >= settings.max_concurrent_queries_for_all_users)
                 throw Exception(
                     "Too many simultaneous queries for all users. Current: " + toString(processes.size())
                     + ", maximum: " + settings.max_concurrent_queries_for_all_users.toString(),

--- a/tests/integration/test_concurrent_queries_for_all_users_restriction/configs/user_restrictions.xml
+++ b/tests/integration/test_concurrent_queries_for_all_users_restriction/configs/user_restrictions.xml
@@ -1,0 +1,38 @@
+<yandex>
+    <profiles>
+        <default>
+            <max_memory_usage>10000000000</max_memory_usage>
+            <use_uncompressed_cache>0</use_uncompressed_cache>
+            <load_balancing>random</load_balancing>
+            <max_concurrent_queries_for_all_users>2</max_concurrent_queries_for_all_users>
+        </default>
+        <someuser>
+            <max_memory_usage>10000000000</max_memory_usage>
+            <use_uncompressed_cache>0</use_uncompressed_cache>
+            <load_balancing>random</load_balancing>
+        </someuser>
+    </profiles>
+    <users>
+        <default>
+            <password></password>
+            <networks incl="networks" replace="replace">
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </default>
+        <someuser>
+            <password></password>
+            <networks incl="networks" replace="replace">
+                <ip>::/0</ip>
+            </networks>
+            <profile>someuser</profile>
+            <quota>default</quota>
+        </someuser>
+    </users>
+
+    <quotas>
+        <default>
+        </default>
+    </quotas>
+</yandex>

--- a/tests/integration/test_concurrent_queries_for_all_users_restriction/test.py
+++ b/tests/integration/test_concurrent_queries_for_all_users_restriction/test.py
@@ -1,0 +1,41 @@
+import time
+from multiprocessing.dummy import Pool
+
+import pytest
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance('node1', user_configs=['configs/user_restrictions.xml'])
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        node1.query("create table nums (number UInt64) ENGINE = MergeTree() order by tuple()")
+        node1.query("insert into nums values (0), (1)")
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_exception_message(started_cluster):
+    assert node1.query("select number from nums order by number") == "0\n1\n"
+
+    def node_busy(_):
+        for i in range(10):
+            node1.query("select sleep(2)", user='someuser', ignore_error=True)
+
+    busy_pool = Pool(3)
+    busy_pool.map_async(node_busy, range(3))
+    time.sleep(1)  # wait a little until polling starts
+
+    with pytest.raises(Exception) as exc_info:
+        for i in range(3):
+            assert node1.query("select number from remote('node1', 'default', 'nums')", user='default') == "0\n1\n"
+    exc_info.match("Too many simultaneous queries for all users")
+
+    for i in range(3):
+        assert node1.query("select number from remote('node1', 'default', 'nums')", user='default',
+                           settings={'max_concurrent_queries_for_all_users': 0}) == "0\n1\n"


### PR DESCRIPTION
Closes #6636.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add max_concurrent_queries_for_all_users setting, see #6636 for use cases.

Detailed description / Documentation draft:

...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
