### PR TITLE
docker: clickhouse-server on the top of busybox

### DIFF
--- a/docker/server-busybox/.dockerignore
+++ b/docker/server-busybox/.dockerignore
@@ -1,0 +1,8 @@
+# post / preinstall scripts (not needed, we do it in Dockerfile)
+root/install/*
+
+# docs (looks useless)
+root/usr/share/doc/*
+
+# packages, etc. (used only by prepare.sh)
+ClickHouse

--- a/docker/server-busybox/.gitignore
+++ b/docker/server-busybox/.gitignore
@@ -1,0 +1,15 @@
+# folder with packages
+ClickHouse
+ClickHouse/*
+
+# weird gitexcude magic to keep committed only 2 files
+!root/
+root/*
+!root/entrypoint.sh
+!root/etc/
+root/etc/*
+!root/etc/clickhouse-server/
+root/etc/clickhouse-server/*
+!root/etc/clickhouse-server/config.d/
+root/etc/clickhouse-server/config.d/*
+!root/etc/clickhouse-server/config.d/docker_related_config.xml

--- a/docker/server-busybox/Dockerfile
+++ b/docker/server-busybox/Dockerfile
@@ -1,0 +1,25 @@
+FROM busybox
+
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8 \
+    TZ=UTC \
+    CLICKHOUSE_CONFIG=/etc/clickhouse-server/config.xml
+
+COPY root/ /
+
+# from https://github.com/ClickHouse/ClickHouse/blob/master/debian/clickhouse-server.postinst
+RUN addgroup clickhouse \
+    && adduser -S -H -h /nonexistent -s /bin/false -G clickhouse -g "ClickHouse server" clickhouse \
+    && chown clickhouse:clickhouse /var/lib/clickhouse \
+    && chmod 700 /var/lib/clickhouse \
+    && chown root:clickhouse /var/log/clickhouse-server \
+    && chmod 775 /var/log/clickhouse-server \
+    && chmod +x /entrypoint.sh
+
+EXPOSE 9000 8123 9009
+
+VOLUME /var/lib/clickhouse \
+       /var/log/clickhouse-server
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/server-busybox/README.txt
+++ b/docker/server-busybox/README.txt
@@ -1,0 +1,6 @@
+Attempt to build clickhouse-server image on the top of busybox instead of ubuntu. Non-tested.
+
+How to use:
+1) you need to get tgz packages - either by building them (see build_tgz.sh), either by downloading official build (see download_tgz.sh)
+2) run prepare.sh to unpack tgz and prepare folder structure for future image
+3) run `docker build . -t clickhouse-server:busybox`

--- a/docker/server-busybox/build_tgz.sh
+++ b/docker/server-busybox/build_tgz.sh
@@ -1,0 +1,33 @@
+# clone sources and run a build
+git clone --depth=1 --recursive -b v20.11.1.4939-testing https://github.com/ClickHouse/ClickHouse.git
+
+git clone \
+    -b v20.11.1.4939-testing \
+    --depth=1 --shallow-submodules --recurse-submodules \
+    https://github.com/ClickHouse/ClickHouse.git
+
+cd ./ClickHouse
+docker pull yandex/clickhouse-deb-builder:latest
+
+docker run --network=host --rm \
+--volume="$(realpath ./PACKAGES)":/output \
+--volume="$(realpath .)":/build \
+--volume="$(realpath ~/.ccache)":/ccache \
+-e DEB_CC=clang-11 \
+-e DEB_CXX=clang++-11 \
+-e CCACHE_DIR=/ccache \
+-e CCACHE_BASEDIR=/build \
+-e CCACHE_NOHASHDIR=true \
+-e CCACHE_COMPILERCHECK=content \
+-e CCACHE_MAXSIZE=15G \
+-e ALIEN_PKGS='--rpm --tgz' \
+-e VERSION_STRING='20.11.1.4939' \
+-e AUTHOR="$(whoami)" \
+-e CMAKE_FLAGS="$CMAKE_FLAGS -DADD_GDB_INDEX_FOR_GOLD=1 -DLINKER_NAME=lld" \
+yandex/clickhouse-deb-builder:latest
+
+# you can add into CMAKE_FLAGS some flags to exclude some libraries
+# -DENABLE_LIBRARIES=0 -DUSE_UNWIND=1 -DENABLE_JEMALLOC=1 -DENABLE_REPLXX=1 -DENABLE_TESTS=0 -DENABLE_UTILS=0 -DENABLE_EMBEDDED_COMPILER=0 -DENABLE_THINLTO=0 -DCMAKE_BUILD_TYPE=Release
+
+# clickhouse-deb-builder will write some files as root
+sudo chown -R $(id -u):$(id -g) ClickHouse

--- a/docker/server-busybox/download_tgz.sh
+++ b/docker/server-busybox/download_tgz.sh
@@ -1,0 +1,12 @@
+REPO_URL="https://repo.yandex.ru/clickhouse/tgz/stable/"
+#or https://repo.yandex.ru/clickhouse/tgz/lts/
+#or https://repo.yandex.ru/clickhouse/tgz/testing/
+VERSION="20.9.3.45"
+TGZ_PACKAGES_FOLDER="${BASH_SOURCE%/*}/ClickHouse/PACKAGES"
+
+mkdir -p ${TGZ_PACKAGES_FOLDER}
+
+cd ${TGZ_PACKAGES_FOLDER}
+wget "${REPO_URL}clickhouse-client-${VERSION}.tgz"
+wget "${REPO_URL}clickhouse-server-${VERSION}.tgz"
+wget "${REPO_URL}clickhouse-common-static-${VERSION}.tgz"

--- a/docker/server-busybox/prepare.sh
+++ b/docker/server-busybox/prepare.sh
@@ -1,0 +1,30 @@
+DOCKER_ROOT_FOLDER="${BASH_SOURCE%/*}/root"
+TGZ_PACKAGES_FOLDER="${BASH_SOURCE%/*}/ClickHouse/PACKAGES"
+
+# unpack tars
+tar xvzf ${TGZ_PACKAGES_FOLDER}/clickhouse-common-static-2*.tgz --strip-components=2 -C "$DOCKER_ROOT_FOLDER"
+tar xvzf ${TGZ_PACKAGES_FOLDER}/clickhouse-server-*.tgz --strip-components=2 -C "$DOCKER_ROOT_FOLDER"
+tar xvzf ${TGZ_PACKAGES_FOLDER}/clickhouse-client-*.tgz --strip-components=2 -C "$DOCKER_ROOT_FOLDER"
+
+# prepare few more folders
+mkdir -p "${DOCKER_ROOT_FOLDER}/etc/clickhouse-server/users.d" \
+         "${DOCKER_ROOT_FOLDER}/etc/clickhouse-server/config.d" \
+         "${DOCKER_ROOT_FOLDER}/var/log/clickhouse-server" \
+         "${DOCKER_ROOT_FOLDER}/var/lib/clickhouse" \
+         "${DOCKER_ROOT_FOLDER}/docker-entrypoint-initdb.d" \
+         "${DOCKER_ROOT_FOLDER}/lib64"
+
+# cp docker/server/docker_related_config.xml "${DOCKER_ROOT_FOLDER}/etc/clickhouse-server/config.d/"
+# cp docker/server/entrypoint.sh "${DOCKER_ROOT_FOLDER}/" <-- it differs, original one uses several bash features, non avaliable on sh
+
+## get glibc components from ubuntu 20.04 and put them to expected place
+docker pull ubuntu:20.04
+ubuntu20image=$(docker create --rm ubuntu:20.04)
+docker cp -L ${ubuntu20image}:/lib/x86_64-linux-gnu/libc.so.6       "${DOCKER_ROOT_FOLDER}/lib"
+docker cp -L ${ubuntu20image}:/lib/x86_64-linux-gnu/libdl.so.2      "${DOCKER_ROOT_FOLDER}/lib"
+docker cp -L ${ubuntu20image}:/lib/x86_64-linux-gnu/libm.so.6       "${DOCKER_ROOT_FOLDER}/lib"
+docker cp -L ${ubuntu20image}:/lib/x86_64-linux-gnu/libpthread.so.0 "${DOCKER_ROOT_FOLDER}/lib"
+docker cp -L ${ubuntu20image}:/lib/x86_64-linux-gnu/librt.so.1      "${DOCKER_ROOT_FOLDER}/lib"
+docker cp -L ${ubuntu20image}:/lib/x86_64-linux-gnu/libnss_dns.so.2 "${DOCKER_ROOT_FOLDER}/lib"
+docker cp -L ${ubuntu20image}:/lib/x86_64-linux-gnu/libresolv.so.2  "${DOCKER_ROOT_FOLDER}/lib"
+docker cp -L ${ubuntu20image}:/lib64/ld-linux-x86-64.so.2           "${DOCKER_ROOT_FOLDER}/lib64"

--- a/docker/server-busybox/root/entrypoint.sh
+++ b/docker/server-busybox/root/entrypoint.sh
@@ -1,0 +1,152 @@
+#!/bin/sh
+#set -x
+
+DO_CHOWN=1
+if [ "$CLICKHOUSE_DO_NOT_CHOWN" = 1 ]; then
+    DO_CHOWN=0
+fi
+
+CLICKHOUSE_UID="${CLICKHOUSE_UID:-"$(id -u clickhouse)"}"
+CLICKHOUSE_GID="${CLICKHOUSE_GID:-"$(id -g clickhouse)"}"
+
+# support --user
+if [ "$(id -u)" = "0" ]; then
+    USER=$CLICKHOUSE_UID
+    GROUP=$CLICKHOUSE_GID
+    # busybox has setuidgid & chpst buildin
+    gosu="setuidgid $USER:$GROUP"
+else
+    USER="$(id -u)"
+    GROUP="$(id -g)"
+    gosu=""
+    DO_CHOWN=0
+fi
+
+# set some vars
+CLICKHOUSE_CONFIG="${CLICKHOUSE_CONFIG:-/etc/clickhouse-server/config.xml}"
+
+# port is needed to check if clickhouse-server is ready for connections
+HTTP_PORT="$(clickhouse extract-from-config --config-file $CLICKHOUSE_CONFIG --key=http_port)"
+
+# get CH directories locations
+DATA_DIR="$(clickhouse extract-from-config --config-file $CLICKHOUSE_CONFIG --key=path || true)"
+TMP_DIR="$(clickhouse extract-from-config --config-file $CLICKHOUSE_CONFIG --key=tmp_path || true)"
+USER_PATH="$(clickhouse extract-from-config --config-file $CLICKHOUSE_CONFIG --key=user_files_path || true)"
+LOG_PATH="$(clickhouse extract-from-config --config-file $CLICKHOUSE_CONFIG --key=logger.log || true)"
+LOG_DIR="$(dirname $LOG_PATH || true)"
+ERROR_LOG_PATH="$(clickhouse extract-from-config --config-file $CLICKHOUSE_CONFIG --key=logger.errorlog || true)"
+ERROR_LOG_DIR="$(dirname $ERROR_LOG_PATH || true)"
+FORMAT_SCHEMA_PATH="$(clickhouse extract-from-config --config-file $CLICKHOUSE_CONFIG --key=format_schema_path || true)"
+
+CLICKHOUSE_USER="${CLICKHOUSE_USER:-default}"
+CLICKHOUSE_PASSWORD="${CLICKHOUSE_PASSWORD:-}"
+CLICKHOUSE_DB="${CLICKHOUSE_DB:-}"
+
+for dir in "$DATA_DIR" \
+  "$ERROR_LOG_DIR" \
+  "$LOG_DIR" \
+  "$TMP_DIR" \
+  "$USER_PATH" \
+  "$FORMAT_SCHEMA_PATH"
+do
+    # check if variable not empty
+    [ -z "$dir" ] && continue
+    # ensure directories exist
+    if ! mkdir -p "$dir"; then
+        echo "Couldn't create necessary directory: $dir"
+        exit 1
+    fi
+
+    if [ "$DO_CHOWN" = "1" ]; then
+        # ensure proper directories permissions
+        chown -R "$USER:$GROUP" "$dir"
+    elif [ "$(stat -c %u "$dir")" != "$USER" ]; then
+        echo "Necessary directory '$dir' isn't owned by user with id '$USER'"
+        exit 1
+    fi
+done
+
+# if clickhouse user is defined - create it (user "default" already exists out of box)
+if [ -n "$CLICKHOUSE_USER" ] && [ "$CLICKHOUSE_USER" != "default" ] || [ -n "$CLICKHOUSE_PASSWORD" ]; then
+    echo "$0: create new user '$CLICKHOUSE_USER' instead 'default'"
+    cat <<EOT > /etc/clickhouse-server/users.d/default-user.xml
+    <yandex>
+      <!-- Docs: <https://clickhouse.tech/docs/en/operations/settings/settings_users/> -->
+      <users>
+        <!-- Remove default user -->
+        <default remove="remove">
+        </default>
+
+        <${CLICKHOUSE_USER}>
+          <profile>default</profile>
+          <networks>
+            <ip>::/0</ip>
+          </networks>
+          <password>${CLICKHOUSE_PASSWORD}</password>
+          <quota>default</quota>
+        </${CLICKHOUSE_USER}>
+      </users>
+    </yandex>
+EOT
+fi
+
+if [ -n "$(ls /docker-entrypoint-initdb.d/)" ] || [ -n "$CLICKHOUSE_DB" ]; then
+    # Listen only on localhost until the initialization is done
+    $gosu /usr/bin/clickhouse-server --config-file=$CLICKHOUSE_CONFIG -- --listen_host=127.0.0.1 &
+    pid="$!"
+
+    # check if clickhouse is ready to accept connections
+    # will try to send ping clickhouse via http_port (max 6 retries, with 1 sec timeout and 1 sec delay between retries)
+    tries=6
+    while ! wget --spider -T 1 -q "http://localhost:$HTTP_PORT/ping" 2>/dev/null; do
+        if [ "$tries" -le "0" ]; then
+            echo >&2 'ClickHouse init process failed.'
+            exit 1
+        fi
+        tries=$(( tries-1 ))
+        sleep 1
+    done
+
+    if [ ! -z "$CLICKHOUSE_PASSWORD" ]; then
+        printf -v WITH_PASSWORD '%s %q' "--password" "$CLICKHOUSE_PASSWORD"
+    fi
+
+    clickhouseclient="clickhouse-client --multiquery -u $CLICKHOUSE_USER $WITH_PASSWORD "
+
+    # create default database, if defined
+    if [ -n "$CLICKHOUSE_DB" ]; then
+        echo "$0: create database '$CLICKHOUSE_DB'"
+        "$clickhouseclient" -q "CREATE DATABASE IF NOT EXISTS $CLICKHOUSE_DB";
+    fi
+
+    for f in /docker-entrypoint-initdb.d/*; do
+        case "$f" in
+            *.sh)
+                if [ -x "$f" ]; then
+                    echo "$0: running $f"
+                    "$f"
+                else
+                    echo "$0: sourcing $f"
+                    . "$f"
+                fi
+                ;;
+            *.sql)    echo "$0: running $f"; cat "$f" | "$clickhouseclient" ; echo ;;
+            *.sql.gz) echo "$0: running $f"; gunzip -c "$f" | "$clickhouseclient"; echo ;;
+            *)        echo "$0: ignoring $f" ;;
+        esac
+        echo
+    done
+
+    if ! kill -s TERM "$pid" || ! wait "$pid"; then
+        echo >&2 'Finishing of ClickHouse init process failed.'
+        exit 1
+    fi
+fi
+
+# if no args passed to `docker run` or first argument start with `--`, then the user is passing clickhouse-server arguments
+if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
+    exec $gosu /usr/bin/clickhouse-server --config-file=$CLICKHOUSE_CONFIG "$@"
+fi
+
+# Otherwise, we assume the user want to run his own process, for example a `bash` shell to explore this image
+exec "$@"

--- a/docker/server-busybox/root/etc/clickhouse-server/config.d/docker_related_config.xml
+++ b/docker/server-busybox/root/etc/clickhouse-server/config.d/docker_related_config.xml
@@ -1,0 +1,12 @@
+<yandex>
+     <!-- Listen wildcard address to allow accepting connections from other containers and host network. -->
+    <listen_host>::</listen_host>
+    <listen_host>0.0.0.0</listen_host>
+    <listen_try>1</listen_try>
+
+    <!--
+    <logger>
+        <console>1</console>
+    </logger>
+    -->
+</yandex>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Attempt to create a docker image to run clickhouse on the top of busybox instead of ubuntu. 

Detailed description / Documentation draft:
experimental / was not tested.

Uses glibc components from ubuntu 20.04.

Actually it questionable if we should now migrate to busybox (since lot of docker users already rely on ubuntu features of container, and since the final container size in only slightly smaller). 