### PR TITLE
Use std::nullptr_t over nullptr_t (build fix)

### DIFF
--- a/src/Functions/FunctionsAES.h
+++ b/src/Functions/FunctionsAES.h
@@ -301,14 +301,14 @@ private:
         {
             const auto key_value = key_holder.setKey(key_size, key_column->getDataAt(r));
             auto iv_value = StringRef{};
-            if constexpr (!std::is_same_v<nullptr_t, std::decay_t<IvColumnType>>)
+            if constexpr (!std::is_same_v<std::nullptr_t, std::decay_t<IvColumnType>>)
             {
                 iv_value = iv_column->getDataAt(r);
             }
 
             const auto input_value = input_column->getDataAt(r);
             auto aad_value = StringRef{};
-            if constexpr (mode == CipherMode::RFC5116_AEAD_AES_GCM && !std::is_same_v<nullptr_t, std::decay_t<AadColumnType>>)
+            if constexpr (mode == CipherMode::RFC5116_AEAD_AES_GCM && !std::is_same_v<std::nullptr_t, std::decay_t<AadColumnType>>)
             {
                 aad_value = aad_column->getDataAt(r);
             }
@@ -348,7 +348,7 @@ private:
                         onError("Failed to set key and IV");
 
                     // 1.a.2 Set AAD
-                    if constexpr (!std::is_same_v<nullptr_t, std::decay_t<AadColumnType>>)
+                    if constexpr (!std::is_same_v<std::nullptr_t, std::decay_t<AadColumnType>>)
                     {
                         const auto aad_data = aad_column->getDataAt(r);
                         int tmp_len = 0;
@@ -574,7 +574,7 @@ private:
             // 0: prepare key if required
             auto key_value = key_holder.setKey(key_size, key_column->getDataAt(r));
             auto iv_value = StringRef{};
-            if constexpr (!std::is_same_v<nullptr_t, std::decay_t<IvColumnType>>)
+            if constexpr (!std::is_same_v<std::nullptr_t, std::decay_t<IvColumnType>>)
             {
                 iv_value = iv_column->getDataAt(r);
             }
@@ -626,7 +626,7 @@ private:
                         onError("Failed to set key and IV");
 
                     // 1.a.2: Set AAD if present
-                    if constexpr (!std::is_same_v<nullptr_t, std::decay_t<AadColumnType>>)
+                    if constexpr (!std::is_same_v<std::nullptr_t, std::decay_t<AadColumnType>>)
                     {
                         const auto aad_data = aad_column->getDataAt(r);
                         int tmp_len = 0;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Refs: #11844