### PR TITLE
Fix TwoLevelStringHashTable bug

### DIFF
--- a/src/Common/HashTable/TwoLevelStringHashMap.h
+++ b/src/Common/HashTable/TwoLevelStringHashMap.h
@@ -18,7 +18,7 @@ public:
     void ALWAYS_INLINE forEachMapped(Func && func)
     {
         for (auto i = 0u; i < this->NUM_BUCKETS; ++i)
-            return this->impls[i].forEachMapped(func);
+            this->impls[i].forEachMapped(func);
     }
 
     TMapped & ALWAYS_INLINE operator[](const Key & x)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix a possible memory leak during `GROUP BY` with string keys, caused by an error in `TwoLevelStringHashTable` implementation.


Fix a very wrong code in TwoLevelStringHashTable implementation, which might lead to memory leak. I'm suprised how this bug can lurk for so long....

Detailed description / Documentation draft:

None.