### PR TITLE
Add total_rows/total_bytes support for Set/Join

### DIFF
--- a/src/Storages/StorageJoin.cpp
+++ b/src/Storages/StorageJoin.cpp
@@ -100,7 +100,10 @@ HashJoinPtr StorageJoin::getJoin(std::shared_ptr<TableJoin> analyzed_join) const
 
 
 void StorageJoin::insertBlock(const Block & block) { join->addJoinedBlock(block, true); }
+
 size_t StorageJoin::getSize() const { return join->getTotalRowCount(); }
+std::optional<UInt64> StorageJoin::totalRows() const { return join->getTotalRowCount(); }
+std::optional<UInt64> StorageJoin::totalBytes() const { return join->getTotalByteCount(); }
 
 
 void registerStorageJoin(StorageFactory & factory)

--- a/src/Storages/StorageJoin.h
+++ b/src/Storages/StorageJoin.h
@@ -46,6 +46,9 @@ public:
         size_t max_block_size,
         unsigned num_streams) override;
 
+    std::optional<UInt64> totalRows() const override;
+    std::optional<UInt64> totalBytes() const override;
+
 private:
     Block sample_block;
     const Names key_names;

--- a/src/Storages/StorageSet.cpp
+++ b/src/Storages/StorageSet.cpp
@@ -151,8 +151,10 @@ StorageSet::StorageSet(
 
 void StorageSet::insertBlock(const Block & block) { set->insertFromBlock(block); }
 void StorageSet::finishInsert() { set->finishInsert(); }
-size_t StorageSet::getSize() const { return set->getTotalRowCount(); }
 
+size_t StorageSet::getSize() const { return set->getTotalRowCount(); }
+std::optional<UInt64> StorageSet::totalRows() const { return set->getTotalRowCount(); }
+std::optional<UInt64> StorageSet::totalBytes() const { return set->getTotalByteCount(); }
 
 void StorageSet::truncate(const ASTPtr &, const StorageMetadataPtr & metadata_snapshot, const Context &, TableExclusiveLockHolder &)
 {

--- a/src/Storages/StorageSet.h
+++ b/src/Storages/StorageSet.h
@@ -72,6 +72,9 @@ public:
 
     void truncate(const ASTPtr &, const StorageMetadataPtr & metadata_snapshot, const Context &, TableExclusiveLockHolder &) override;
 
+    std::optional<UInt64> totalRows() const override;
+    std::optional<UInt64> totalBytes() const override;
+
 private:
     SetPtr set;
 

--- a/tests/queries/0_stateless/00753_system_columns_and_system_tables.reference
+++ b/tests/queries/0_stateless/00753_system_columns_and_system_tables.reference
@@ -39,3 +39,9 @@ Check lifetime_bytes/lifetime_rows for Buffer
 200	100
 200	100
 402	201
+Check total_bytes/total_rows for Set
+2048	50
+2048	100
+Check total_bytes/total_rows for Join
+10240	50
+10240	100

--- a/tests/queries/0_stateless/00753_system_columns_and_system_tables.sql
+++ b/tests/queries/0_stateless/00753_system_columns_and_system_tables.sql
@@ -112,3 +112,17 @@ INSERT INTO check_system_tables SELECT * FROM numbers_mt(101); -- direct block w
 SELECT lifetime_bytes, lifetime_rows FROM system.tables WHERE name = 'check_system_tables';
 DROP TABLE check_system_tables;
 DROP TABLE check_system_tables_null;
+
+SELECT 'Check total_bytes/total_rows for Set';
+CREATE TABLE check_system_tables Engine=Set() AS SELECT * FROM numbers(50);
+SELECT total_bytes, total_rows FROM system.tables WHERE name = 'check_system_tables';
+INSERT INTO check_system_tables SELECT number+50 FROM numbers(50);
+SELECT total_bytes, total_rows FROM system.tables WHERE name = 'check_system_tables';
+DROP TABLE check_system_tables;
+
+SELECT 'Check total_bytes/total_rows for Join';
+CREATE TABLE check_system_tables Engine=Join(ANY, LEFT, number) AS SELECT * FROM numbers(50);
+SELECT total_bytes, total_rows FROM system.tables WHERE name = 'check_system_tables';
+INSERT INTO check_system_tables SELECT number+50 FROM numbers(50);
+SELECT total_bytes, total_rows FROM system.tables WHERE name = 'check_system_tables';
+DROP TABLE check_system_tables;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add total_rows/total_bytes (from system.tables) support for Set/Join table engines

Continuation for: #9919
Refs: #7778