### PR TITLE
minor fix.

### DIFF
--- a/src/Functions/FunctionsAES.h
+++ b/src/Functions/FunctionsAES.h
@@ -307,11 +307,6 @@ private:
             }
 
             const auto input_value = input_column->getDataAt(r);
-            auto aad_value = StringRef{};
-            if constexpr (mode == CipherMode::RFC5116_AEAD_AES_GCM && !std::is_same_v<std::nullptr_t, std::decay_t<AadColumnType>>)
-            {
-                aad_value = aad_column->getDataAt(r);
-            }
 
             if constexpr (mode != CipherMode::MySQLCompatibility)
             {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

redundant variable, duplicated defination of the variable aad_data
compiler error: variable ‘aad_value’ set but not used [-Werror=unused-but-set-variable]
