### PR TITLE
DOCSUP-2869: Document section user_directories in the main config

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -1063,9 +1063,13 @@ Default value: `/var/lib/clickhouse/access/`.
 
 ## user_directories {#user_directories}
 
-The path to the users config files. If `user_directories` is specified, the path from `users_config` won't be used.
+Section of the configuration file that contains settings:
+-   Path to the users configuration file.
+-   Access rights.
 
-The `user_directories` section can contain any number of items, the order of the items means their precedence.
+If this section is specified, the path from [users_config](../../operations/server-configuration-parameters/settings.md#users-config) won't be used.
+
+The `user_directories` section can contain any number of items, the order of the items means their precedence (the lower the item the higher the precedence).
 
 **Example**
 

--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -1064,12 +1064,12 @@ Default value: `/var/lib/clickhouse/access/`.
 ## user_directories {#user_directories}
 
 Section of the configuration file that contains settings:
--   Path to the users configuration file.
--   Access rights.
+-   Path to configuration file with predefined users.
+-   Path to folder where users created by SQL commands are stored.
 
-If this section is specified, the path from [users_config](../../operations/server-configuration-parameters/settings.md#users-config) won't be used.
+If this section is specified, the path from [users_config](../../operations/server-configuration-parameters/settings.md#users-config) and [access_control_path](../../operations/server-configuration-parameters/settings.md#access_control_path) won't be used.
 
-The `user_directories` section can contain any number of items, the order of the items means their precedence (the lower the item the higher the precedence).
+The `user_directories` section can contain any number of items, the order of the items means their precedence (the higher the item the higher the precedence).
 
 **Example**
 
@@ -1082,6 +1082,24 @@ The `user_directories` section can contain any number of items, the order of the
         <path>/var/lib/clickhouse/access/</path>
     </local_directory>
 </user_directories>
+```
+
+You can also specify settings `memory` — means storing information only in memory, without writing to disk, and `ldap` — means storing information on an LDAP server.
+
+To add an LDAP server as a remote user directory of users that are not defined locally, define a single `ldap` section with a following parameters:
+-   `server` — one of LDAP server names defined in `ldap_servers` config section. This parameter is mandatory and cannot be empty.
+-   `roles` — section with a list of locally defined roles that will be assigned to each user retrieved from the LDAP server. If no roles are specified, user will not be able to perform any actions after authentication. If any of the listed roles is not defined locally at the time of authentication, the authenthication attept will fail as if the provided password was incorrect.
+
+**Example**
+
+``` xml
+<ldap>
+    <server>my_ldap_server</server>
+        <roles>
+            <my_local_role1 />
+            <my_local_role2 />
+        </roles>
+</ldap>
 ```
 
 [Original article](https://clickhouse.tech/docs/en/operations/server_configuration_parameters/settings/) <!--hide-->

--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -1063,7 +1063,7 @@ Default value: `/var/lib/clickhouse/access/`.
 
 ## user_directories {#user_directories}
 
-The path to the users config files. 
+The path to the users config files. If `user_directories` is specified, the path from `users_config` won't be used.
 
 The `user_directories` section can contain any number of items, the order of the items means their precedence.
 

--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -1061,4 +1061,23 @@ Default value: `/var/lib/clickhouse/access/`.
 
 -   [Access Control and Account Management](../../operations/access-rights.md#access-control)
 
+## user_directories {#user_directories}
+
+The path to the users config files. 
+
+The `user_directories` section can contain any number of items, the order of the items means their precedence.
+
+**Example**
+
+``` xml
+<user_directories>
+    <users_xml>
+        <path>/etc/clickhouse-server/users.xml</path>
+    </users_xml>
+    <local_directory>
+        <path>/var/lib/clickhouse/access/</path>
+    </local_directory>
+</user_directories>
+```
+
 [Original article](https://clickhouse.tech/docs/en/operations/server_configuration_parameters/settings/) <!--hide-->

--- a/docs/en/sql-reference/statements/system.md
+++ b/docs/en/sql-reference/statements/system.md
@@ -204,7 +204,7 @@ SYSTEM STOP MOVES [[db.]merge_tree_family_table_name]
 
 ## Managing ReplicatedMergeTree Tables {#query-language-system-replicated}
 
-ClickHouse can manage background replication related processes in [ReplicatedMergeTree](../../engines/table-engines/mergetree-family/replacingmergetree.md) tables.
+ClickHouse can manage background replication related processes in [ReplicatedMergeTree](../../engines/table-engines/mergetree-family/replication/#table_engines-replication) tables.
 
 ### STOP FETCHES {#query_language-system-stop-fetches}
 

--- a/docs/en/sql-reference/syntax.md
+++ b/docs/en/sql-reference/syntax.md
@@ -57,7 +57,7 @@ Identifiers are:
 
 Identifiers can be quoted or non-quoted. The latter is preferred.
 
-Non-quoted identifiers must match the regex `^[a-zA-Z_][0-9a-zA-Z_]*$` and can not be equal to [keywords](#syntax-keywords). Examples: `x, _1, X_y__Z123_.`
+Non-quoted identifiers must match the regex `^[0-9a-zA-Z_]*[a-zA-Z_]$` and can not be equal to [keywords](#syntax-keywords). Examples: `x, _1, X_y__Z123_.`
 
 If you want to use identifiers the same as keywords or you want to use other symbols in identifiers, quote it using double quotes or backticks, for example, `"id"`, `` `id` ``.
 

--- a/docs/ru/operations/server-configuration-parameters/settings.md
+++ b/docs/ru/operations/server-configuration-parameters/settings.md
@@ -1027,4 +1027,45 @@ ClickHouse использует ZooKeeper для хранения метадан
 
 - [Управление доступом](../access-rights.md#access-control)
 
+## user_directories {#user_directories}
+
+Секция конфигурационного файла,которая содержит настройки:
+-   Путь к конфигурационному файлу с предустановленными пользователями.
+-   Путь к файлу, в котором содержатся пользователи, созданные при помощи SQL команд. 
+
+Если эта секция определена, путь из [users_config](../../operations/server-configuration-parameters/settings.md#users-config) и [access_control_path](../../operations/server-configuration-parameters/settings.md#access_control_path) не используется.
+
+Секция `user_directories` может содержать любое количество элементов, порядок расположения элементов обозначает их приоритет (чем выше элемент, тем выше приоритет).
+
+**Пример**
+
+``` xml
+<user_directories>
+    <users_xml>
+        <path>/etc/clickhouse-server/users.xml</path>
+    </users_xml>
+    <local_directory>
+        <path>/var/lib/clickhouse/access/</path>
+    </local_directory>
+</user_directories>
+```
+
+Также вы можете указать настройку `memory` — означает хранение информации только в памяти, без записи на диск, и `ldap` — означает хранения информации на [LDAP-сервере](https://en.wikipedia.org/wiki/Lightweight_Directory_Access_Protocol).
+
+Чтобы добавить LDAP-сервер в качестве удаленного каталога пользователей, которые не определены локально, определите один раздел `ldap` со следующими параметрами:
+-   `server` — имя одного из LDAP-серверов, определенных в секции `ldap_servers` конфигурациионного файла. Этот параметр явялется необязательным и может быть пустым.
+-   `roles` — раздел со списком локально определенных ролей, которые будут назначены каждому пользователю, полученному с LDAP-сервера. Если роли не заданы, пользователь не сможет выполнять никаких действий после аутентификации. Если какая-либо из перечисленных ролей не определена локально во время проверки подлинности, попытка проверки подлинности завершится неудачей, как если бы предоставленный пароль был неверным.
+
+**Пример**
+
+``` xml
+<ldap>
+    <server>my_ldap_server</server>
+        <roles>
+            <my_local_role1 />
+            <my_local_role2 />
+        </roles>
+</ldap>
+```
+
 [Оригинальная статья](https://clickhouse.tech/docs/ru/operations/server_configuration_parameters/settings/) <!--hide-->


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:

- Documentation for #13425

