### PR TITLE
Fix performance test "functions logical" after move to clang

### DIFF
--- a/src/Functions/FunctionsLogical.cpp
+++ b/src/Functions/FunctionsLogical.cpp
@@ -290,10 +290,9 @@ private:
 
 
 /// Apply target function by feeding it "batches" of N columns
-/// Combining 10 columns per pass is the fastest for large columns sizes.
-/// For small columns sizes - more columns is faster.
+/// Combining 8 columns per pass is the fastest method, because it's the maximum when clang vectorizes a loop.
 template <
-    typename Op, template <typename, size_t> typename OperationApplierImpl, size_t N = 10>
+    typename Op, template <typename, size_t> typename OperationApplierImpl, size_t N = 8>
 struct OperationApplier
 {
     template <typename Columns, typename ResultData>


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
There was one case when clang produced significantly worse code, see https://gist.github.com/alexey-milovidov/84ca8bac1b15971ce5ec6012067eec88

Detailed description:

```
Alexey Milovidov, [24.10.20 11:05]
@Danlark @akazz Исследовал проблему с замедлением функции xor в 15 раз при переходе на clang, вот минимальный пример:

https://gist.github.com/alexey-milovidov/84ca8bac1b15971ce5ec6012067eec88

Не могу запостить в их баг трекер, там даже после регистрации вручную не работает вход.

Danila Kutenin, [24.10.20 11:22]
Я посмотрю сейчас

Danila Kutenin, [24.10.20 11:22]
И запосщу в трекер

Danila Kutenin, [24.10.20 11:30]
workaround нужен?

Danila Kutenin, [24.10.20 11:31]
#ifdef __clang__
    #pragma clang loop vectorize(enable) interleave(enable)
#endif
    for (size_t i = 0; i < size; ++i)
    {

Danila Kutenin, [24.10.20 11:33]
<source>:19:5: remark: loop not vectorized: cannot prove it is safe to reorder memory operations; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop. If the arrays will always be independent specify '#pragma clang loop vectorize(assume_safety)' before the loop or provide the 'restrict' qualifier with the independent array arguments. Erroneous results will occur if these options are incorrectly applied! [-Rpass-analysis=loop-vectorize]

    for (size_t i = 0; i < size; ++i)

    ^

Danila Kutenin, [24.10.20 11:43]
понятно, наткнулись на один upper bound

Danila Kutenin, [24.10.20 11:44]
https://gcc.godbolt.org/z/oYfv7K

Danila Kutenin, [24.10.20 11:44]
static cl::opt<unsigned, true> RuntimeMemoryCheckThreshold(
    "runtime-memory-check-threshold", cl::Hidden,
    cl::desc("When performing memory disambiguation checks at runtime do not "
             "generate more than this number of comparisons (default = 8)."),
    cl::location(VectorizerParams::RuntimeMemoryCheckThreshold), cl::init(8));

Danila Kutenin, [24.10.20 11:45]
10 сравнений аргументов функции просто много клангу для векторизации

Danila Kutenin, [24.10.20 11:45]
8 норм)

Danila Kutenin, [24.10.20 11:45]
думаю, что не будут фиксить)

Danila Kutenin, [24.10.20 11:47]
уменьшайте количество аргументов или форсируйте векторизацию, я думаю, что только так решится оно

Danila Kutenin, [24.10.20 11:48]
@milovidov_an FYI

Danila Kutenin, [24.10.20 11:52]
можете, кстати, попробовать поставить этот аргумент в много и посмотреть сколько ещё векторизуются, но скорее всего немного сборка замедлится

Danila Kutenin, [24.10.20 12:09]
Ну и пример очень искусственный, правда, зачем настолько делать unroll, вряд ли для 10 это лучше, чем для 8, хотя пример вроде немного сложнее..

Alexey Milovidov, [24.10.20 21:04]
[In reply to Danila Kutenin]
__restrict помогает, поставлю!

Alexey Milovidov, [24.10.20 21:05]
[In reply to Danila Kutenin]
Там сложный код, цепочки операций обрабатываются группами по 10, см. FunctionsLogical.cpp

Такое вот написали максимально оптимизировав для gcc.

Alexey Milovidov, [24.10.20 21:05]
OperationApplier

Danila Kutenin, [24.10.20 21:05]
ужас(

Alexey Milovidov, [24.10.20 21:06]
Ну а запрос в тесте уже сделали чисто как фиксацию проделанной оптимизации:

SELECT count() FROM (SELECT materialize(1) AS x1, materialize(1) AS x2, materialize(1) AS x3, materialize(1) AS x4, materialize(1) AS x5, materialize(1) AS x6, materialize(1) AS x7, materialize(1) AS x8, materialize(1) AS x9, materialize(1) AS x10 FROM zeros(500000000)) WHERE NOT ignore(xor(x1,x2,x3,x4,x5,x6,x7,x8,x9,x10))
```

It's difficult to put `__restrict`.