### PR TITLE
Fixing fails in LDAP external user directory tests.

### DIFF
--- a/tests/testflows/ldap/authentication/tests/common.py
+++ b/tests/testflows/ldap/authentication/tests/common.py
@@ -47,7 +47,7 @@ ASCII_CHARS = string.ascii_lowercase +  string.ascii_uppercase + string.digits
 def randomword(length, chars=ASCII_CHARS):
     return ''.join(random.choice(chars) for i in range(length))
 
-def restart(node=None, safe=False, timeout=20):
+def restart(node=None, safe=False, timeout=60):
     """Restart ClickHouse server and wait for config to be reloaded.
     """
     with When("I restart ClickHouse server node"):
@@ -62,7 +62,7 @@ def restart(node=None, safe=False, timeout=20):
 
             with And("getting current log size"):
                 logsize = \
-                    node.command("ls -s --block-size=1 /var/log/clickhouse-server/clickhouse-server.log").output.split(" ")[
+                    node.command("stat --format=%s /var/log/clickhouse-server/clickhouse-server.log").output.split(" ")[
                     0].strip()
 
             with And("restarting ClickHouse server"):
@@ -78,7 +78,7 @@ def restart(node=None, safe=False, timeout=20):
                     f"ConfigReloader: Loaded config '/etc/clickhouse-server/config.xml', performed update on configuration",
                     timeout=timeout)
 
-def add_config(config, timeout=20, restart=False):
+def add_config(config, timeout=60, restart=False):
     """Add dynamic configuration file to ClickHouse.
 
     :param node: node
@@ -108,7 +108,7 @@ def add_config(config, timeout=20, restart=False):
 
             with And("I get the current log size"):
                 logsize = \
-                    node.command("ls -s --block-size=1 /var/log/clickhouse-server/clickhouse-server.log").output.split(" ")[
+                    node.command("stat --format=%s /var/log/clickhouse-server/clickhouse-server.log").output.split(" ")[
                     0].strip()
 
             with And("I restart ClickHouse to apply the config changes"):
@@ -189,7 +189,7 @@ def create_ldap_servers_config_content(servers, config_d_dir="/etc/clickhouse-se
 
 @contextmanager
 def ldap_servers(servers, config_d_dir="/etc/clickhouse-server/config.d", config_file="ldap_servers.xml",
-        timeout=20, restart=False):
+        timeout=60, restart=False):
     """Add LDAP servers configuration.
     """
     config = create_ldap_servers_config_content(servers, config_d_dir, config_file)
@@ -236,7 +236,7 @@ def add_users_identified_with_ldap(*users):
 
 @contextmanager
 def ldap_authenticated_users(*users, config_d_dir="/etc/clickhouse-server/users.d",
-        config_file=None, timeout=20, restart=True, config=None, rbac=False):
+        config_file=None, timeout=60, restart=True, config=None, rbac=False):
     """Add LDAP authenticated users.
     """
     if rbac:
@@ -248,7 +248,7 @@ def ldap_authenticated_users(*users, config_d_dir="/etc/clickhouse-server/users.
             config = create_ldap_users_config_content(*users, config_d_dir=config_d_dir, config_file=config_file)
         return add_config(config, restart=restart)
 
-def invalid_server_config(servers, message=None, tail=13, timeout=20):
+def invalid_server_config(servers, message=None, tail=13, timeout=60):
     """Check that ClickHouse errors when trying to load invalid LDAP servers configuration file.
     """
     node = current().context.node
@@ -277,7 +277,7 @@ def invalid_server_config(servers, message=None, tail=13, timeout=20):
             with By("removing the config file", description=config.path):
                 node.command(f"rm -rf {config.path}", exitcode=0)
 
-def invalid_user_config(servers, config, message=None, tail=13, timeout=20):
+def invalid_user_config(servers, config, message=None, tail=13, timeout=60):
     """Check that ClickHouse errors when trying to load invalid LDAP users configuration file.
     """
     node = current().context.node

--- a/tests/testflows/ldap/external_user_directory/tests/common.py
+++ b/tests/testflows/ldap/external_user_directory/tests/common.py
@@ -129,7 +129,7 @@ def create_entries_ldap_external_user_directory_config_content(entries, config_d
 
     return Config(content, path, name, uid, "config.xml")
 
-def invalid_ldap_external_user_directory_config(server, roles, message, tail=20, timeout=20, config=None):
+def invalid_ldap_external_user_directory_config(server, roles, message, tail=20, timeout=60, config=None):
     """Check that ClickHouse errors when trying to load invalid LDAP external user directory
     configuration file.
     """
@@ -181,7 +181,7 @@ def invalid_ldap_external_user_directory_config(server, roles, message, tail=20,
 
 @contextmanager
 def ldap_external_user_directory(server, roles, config_d_dir="/etc/clickhouse-server/config.d",
-        config_file=None, timeout=20, restart=True, config=None):
+        config_file=None, timeout=60, restart=True, config=None):
     """Add LDAP external user directory.
     """
     if config_file is None:


### PR DESCRIPTION
Increasing default timeouts.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixing fails in LDAP external user directory tests.

Detailed description / Documentation draft:
Fixing fails in LDAP external user directory tests.