### PR TITLE
Check exception message is poisoned in ExpressionActions.

### DIFF
--- a/src/Columns/ColumnConst.cpp
+++ b/src/Columns/ColumnConst.cpp
@@ -6,6 +6,8 @@
 #include <Common/WeakHash.h>
 #include <Common/HashTable/Hash.h>
 
+#include <common/defines.h>
+
 #if defined(MEMORY_SANITIZER)
     #include <sanitizer/msan_interface.h>
 #endif

--- a/src/Interpreters/ExpressionActions.cpp
+++ b/src/Interpreters/ExpressionActions.cpp
@@ -22,6 +22,15 @@
 #    include "config_core.h"
 #endif
 
+#include <common/defines.h>
+
+#if defined(MEMORY_SANITIZER)
+    #include <sanitizer/msan_interface.h>
+#endif
+
+#if defined(ADDRESS_SANITIZER)
+    #include <sanitizer/asan_interface.h>
+#endif
 
 namespace ProfileEvents
 {
@@ -623,6 +632,22 @@ void ExpressionActions::execute(Block & block, bool dry_run) const
         }
         catch (Exception & e)
         {
+#if defined(MEMORY_SANITIZER)
+            const auto & msg = e.message();
+            if (__msan_test_shadow(msg.data(), msg.size()) != -1)
+            {
+                LOG_FATAL(&Poco::Logger::get("ExpressionActions"), "Poisoned exception message (msan): {}", e.getStackTraceString());
+            }
+#endif
+
+#if defined(ADDRESS_SANITIZER)
+            const auto & msg = e.message();
+            if (__asan_region_is_poisoned(msg.data(), msg.size()))
+            {
+                LOG_FATAL(&Poco::Logger::get("ExpressionActions"), "Poisoned exception message (asan): {}", e.getStackTraceString());
+            }
+#endif
+
             e.addMessage(fmt::format("while executing '{}'", action.toString()));
             throw;
         }

--- a/src/Interpreters/ExpressionActions.cpp
+++ b/src/Interpreters/ExpressionActions.cpp
@@ -642,7 +642,7 @@ void ExpressionActions::execute(Block & block, bool dry_run) const
 
 #if defined(ADDRESS_SANITIZER)
             const auto & msg = e.message();
-            if (__asan_region_is_poisoned(msg.data(), msg.size()))
+            if (__asan_region_is_poisoned(const_cast<char *>(msg.data()), msg.size()))
             {
                 LOG_FATAL(&Poco::Logger::get("ExpressionActions"), "Poisoned exception message (asan): {}", e.getStackTraceString());
             }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


