### PR TITLE
Fix printing of stacktraces in clickhouse-test

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -180,7 +180,7 @@ def need_retry(stderr):
 
 def get_processlist(client_cmd):
     try:
-        return subprocess.check_output("{} --query 'SHOW PROCESSLIST FORMAT Vertical'".format(client_cmd), shell=True)
+        return subprocess.check_output("{} --query 'SHOW PROCESSLIST FORMAT Vertical'".format(client_cmd), shell=True).decode('utf-8')
     except:
         return "" #  server seems dead
 
@@ -189,7 +189,7 @@ def get_processlist(client_cmd):
 def get_stacktraces_from_gdb(server_pid):
     cmd = "gdb -batch -ex 'thread apply all backtrace' -p {}".format(server_pid)
     try:
-        return subprocess.check_output(cmd, shell=True)
+        return subprocess.check_output(cmd, shell=True).decode('utf-8')
     except Exception as ex:
         return "Error occured while receiving stack traces from gdb: {}".format(str(ex))
 
@@ -198,7 +198,10 @@ def get_stacktraces_from_gdb(server_pid):
 # it does not work in Sandbox
 def get_stacktraces_from_clickhouse(client):
     try:
-        return subprocess.check_output("{} --allow_introspection_functions=1 --query \"SELECT arrayStringConcat(arrayMap(x, y -> concat(x, ': ', y), arrayMap(x -> addressToLine(x), trace), arrayMap(x -> demangle(addressToSymbol(x)), trace)), '\n') as trace FROM system.stack_trace format Vertical\"".format(client), shell=True)
+        return subprocess.check_output("{} --allow_introspection_functions=1 --query "
+               "\"SELECT arrayStringConcat(arrayMap(x, y -> concat(x, ': ', y), arrayMap(x -> addressToLine(x), trace), "
+               "arrayMap(x -> demangle(addressToSymbol(x)), trace)), '\n') as trace "
+               "FROM system.stack_trace format Vertical\"".format(client), shell=True).decode('utf-8')
     except Exception as ex:
         return "Error occured while receiving stack traces from client: {}".format(str(ex))
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Detailed description / Documentation draft:
`subprocess.check_output(...)` returns `bytes`, not `str` (see https://clickhouse-test-reports.s3.yandex.net/0/cc5f15da291d96cafb4f5d47beff424e73d51839/functional_stateless_tests_(debug)/test_run.txt.out.log)
