### PR TITLE
Fix another double free for shared exception message in case of dictGet from not loaded dictionary

### DIFF
--- a/src/Interpreters/ExternalLoader.cpp
+++ b/src/Interpreters/ExternalLoader.cpp
@@ -28,6 +28,7 @@ namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
     extern const int BAD_ARGUMENTS;
+    extern const int DICTIONARIES_WAS_NOT_LOADED;
 }
 
 
@@ -1404,7 +1405,24 @@ void ExternalLoader::checkLoaded(const ExternalLoader::LoadResult & result,
     if (result.status == ExternalLoader::Status::LOADING)
         throw Exception(type_name + " '" + result.name + "' is still loading", ErrorCodes::BAD_ARGUMENTS);
     if (result.exception)
-        std::rethrow_exception(result.exception);
+    {
+        // Exception is shared for multiple threads.
+        // Don't just rethrow it, because sharing the same exception object
+        // between multiple threads can lead to weird effects if they decide to
+        // modify it, for example, by adding some error context.
+        try
+        {
+            std::rethrow_exception(result.exception);
+        }
+        catch (...)
+        {
+            throw DB::Exception(ErrorCodes::DICTIONARIES_WAS_NOT_LOADED,
+                                "Failed to load dictionary '{}': {}",
+                                result.name,
+                                getCurrentExceptionMessage(true /*with stack trace*/,
+                                                           true /*check embedded stack trace*/));
+        }
+    }
     if (result.status == ExternalLoader::Status::NOT_EXIST)
         throw Exception(type_name + " '" + result.name + "' not found", ErrorCodes::BAD_ARGUMENTS);
     if (result.status == ExternalLoader::Status::NOT_LOADED)

--- a/src/Interpreters/ExternalLoader.cpp
+++ b/src/Interpreters/ExternalLoader.cpp
@@ -1414,6 +1414,11 @@ void ExternalLoader::checkLoaded(const ExternalLoader::LoadResult & result,
         {
             std::rethrow_exception(result.exception);
         }
+        catch (const Poco::Exception & e)
+        {
+            /// This will create a copy for Poco::Exception and DB::Exception
+            e.rethrow();
+        }
         catch (...)
         {
             throw DB::Exception(ErrorCodes::DICTIONARIES_WAS_NOT_LOADED,

--- a/tests/queries/0_stateless/01542_dictionary_load_exception_race.sh
+++ b/tests/queries/0_stateless/01542_dictionary_load_exception_race.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../shell_config.sh
+
+
+$CLICKHOUSE_CLIENT --query "DROP DATABASE IF EXISTS database_for_dict"
+$CLICKHOUSE_CLIENT --query "CREATE DATABASE database_for_dict"
+$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS database_for_dict.table_for_dict"
+$CLICKHOUSE_CLIENT --query "CREATE TABLE database_for_dict.table_for_dict (key_column UInt64, second_column UInt64, third_column String) ENGINE = MergeTree() ORDER BY key_column"
+$CLICKHOUSE_CLIENT --query "INSERT INTO database_for_dict.table_for_dict VALUES (100500, 10000000, 'Hello world')"
+
+$CLICKHOUSE_CLIENT --query "DROP DATABASE IF EXISTS ordinary_db"
+$CLICKHOUSE_CLIENT --query "CREATE DATABASE ordinary_db"
+$CLICKHOUSE_CLIENT --query "CREATE DICTIONARY ordinary_db.dict1 ( key_column UInt64 DEFAULT 0, second_column UInt64 DEFAULT 1, third_column String DEFAULT 'qqq' ) PRIMARY KEY key_column SOURCE(CLICKHOUSE(HOST 'localhost' PORT 9000 USER 'default' TABLE 'table_for_dict' PASSWORD '' DB 'database_for_dict')) LIFETIME(MIN 1 MAX 10) LAYOUT(FLAT()) SETTINGS(max_result_bytes=1)"
+
+function dict_get_thread()
+{
+    while true; do
+        $CLICKHOUSE_CLIENT --query "SELECT dictGetString('ordinary_db.dict1', 'third_column', toUInt64(rand() % 1000)) from numbers(2)" &>/dev/null
+    done
+}
+
+export -f dict_get_thread;
+
+TIMEOUT=10
+
+timeout $TIMEOUT bash -c dict_get_thread 2> /dev/null &
+timeout $TIMEOUT bash -c dict_get_thread 2> /dev/null &
+timeout $TIMEOUT bash -c dict_get_thread 2> /dev/null &
+timeout $TIMEOUT bash -c dict_get_thread 2> /dev/null &
+timeout $TIMEOUT bash -c dict_get_thread 2> /dev/null &
+timeout $TIMEOUT bash -c dict_get_thread 2> /dev/null &
+timeout $TIMEOUT bash -c dict_get_thread 2> /dev/null &
+timeout $TIMEOUT bash -c dict_get_thread 2> /dev/null &
+timeout $TIMEOUT bash -c dict_get_thread 2> /dev/null &
+timeout $TIMEOUT bash -c dict_get_thread 2> /dev/null &
+timeout $TIMEOUT bash -c dict_get_thread 2> /dev/null &
+timeout $TIMEOUT bash -c dict_get_thread 2> /dev/null &
+
+wait
+
+$CLICKHOUSE_CLIENT --query "DROP DATABASE IF EXISTS ordinary_db"
+$CLICKHOUSE_CLIENT --query "DROP DATABASE IF EXISTS database_for_dict"


### PR DESCRIPTION
…not loaded dictionary.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix double free in case of exception in function `dictGet`. It could have happened if dictionary was loaded with error.

https://clickhouse-test-reports.s3.yandex.net/16409/244d6183039a991b2c38ab48eabbc76d85f27cca/stress_test_(address).html#fail1