### PR TITLE
Fix LDAP tests by grabbing log size after container is stopped

### DIFF
--- a/docker/test/testflows/runner/Dockerfile
+++ b/docker/test/testflows/runner/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update \
 ENV TZ=Europe/Moscow
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN pip3 install urllib3 testflows==1.6.57 docker-compose docker dicttoxml kazoo tzlocal
+RUN pip3 install urllib3 testflows==1.6.59 docker-compose docker dicttoxml kazoo tzlocal
 
 ENV DOCKER_CHANNEL stable
 ENV DOCKER_VERSION 17.09.1-ce

--- a/tests/testflows/aes_encryption/regression.py
+++ b/tests/testflows/aes_encryption/regression.py
@@ -48,6 +48,7 @@ xfails = {
 @TestFeature
 @Name("aes encryption")
 @ArgumentParser(argparser)
+@Specifications(SRS_008_ClickHouse_AES_Encryption_Functions)
 @Requirements(
     RQ_SRS008_AES_Functions("1.0"),
     RQ_SRS008_AES_Functions_DifferentModes("1.0")

--- a/tests/testflows/aes_encryption/requirements/requirements.py
+++ b/tests/testflows/aes_encryption/requirements/requirements.py
@@ -1,9 +1,1955 @@
 # These requirements were auto generated
 # from software requirements specification (SRS)
-# document by TestFlows v1.6.200731.1222107.
+# document by TestFlows v1.6.201026.1232822.
 # Do not edit by hand but re-generate instead
 # using 'tfs requirements generate' command.
+from testflows.core import Specification
 from testflows.core import Requirement
+
+SRS_008_ClickHouse_AES_Encryption_Functions = Specification(
+        name='SRS-008 ClickHouse AES Encryption Functions', 
+        description=None,
+        author=None,
+        date=None, 
+        status=None, 
+        approved_by=None,
+        approved_date=None,
+        approved_version=None,
+        version=None,
+        group=None,
+        type=None,
+        link=None,
+        uid=None,
+        parent=None,
+        children=None,
+        content='''
+# SRS-008 ClickHouse AES Encryption Functions
+# Software Requirements Specification
+
+## Table of Contents
+* 1 [Revision History](#revision-history)
+* 2 [Introduction](#introduction)
+* 3 [Terminology](#terminology)
+* 4 [Requirements](#requirements)
+  * 4.1 [Generic](#generic)
+    * 4.1.1 [RQ.SRS008.AES.Functions](#rqsrs008aesfunctions)
+    * 4.1.2 [RQ.SRS008.AES.Functions.Compatability.MySQL](#rqsrs008aesfunctionscompatabilitymysql)
+    * 4.1.3 [RQ.SRS008.AES.Functions.Compatability.Dictionaries](#rqsrs008aesfunctionscompatabilitydictionaries)
+    * 4.1.4 [RQ.SRS008.AES.Functions.Compatability.Engine.Database.MySQL](#rqsrs008aesfunctionscompatabilityenginedatabasemysql)
+    * 4.1.5 [RQ.SRS008.AES.Functions.Compatability.Engine.Table.MySQL](#rqsrs008aesfunctionscompatabilityenginetablemysql)
+    * 4.1.6 [RQ.SRS008.AES.Functions.Compatability.TableFunction.MySQL](#rqsrs008aesfunctionscompatabilitytablefunctionmysql)
+    * 4.1.7 [RQ.SRS008.AES.Functions.DifferentModes](#rqsrs008aesfunctionsdifferentmodes)
+    * 4.1.8 [RQ.SRS008.AES.Functions.DataFromMultipleSources](#rqsrs008aesfunctionsdatafrommultiplesources)
+    * 4.1.9 [RQ.SRS008.AES.Functions.SuppressOutputOfSensitiveValues](#rqsrs008aesfunctionssuppressoutputofsensitivevalues)
+    * 4.1.10 [RQ.SRS008.AES.Functions.InvalidParameters](#rqsrs008aesfunctionsinvalidparameters)
+    * 4.1.11 [RQ.SRS008.AES.Functions.MismatchedKey](#rqsrs008aesfunctionsmismatchedkey)
+    * 4.1.12 [RQ.SRS008.AES.Functions.Check.Performance](#rqsrs008aesfunctionscheckperformance)
+    * 4.1.13 [RQ.SRS008.AES.Function.Check.Performance.BestCase](#rqsrs008aesfunctioncheckperformancebestcase)
+    * 4.1.14 [RQ.SRS008.AES.Function.Check.Performance.WorstCase](#rqsrs008aesfunctioncheckperformanceworstcase)
+    * 4.1.15 [RQ.SRS008.AES.Functions.Check.Compression](#rqsrs008aesfunctionscheckcompression)
+    * 4.1.16 [RQ.SRS008.AES.Functions.Check.Compression.LowCardinality](#rqsrs008aesfunctionscheckcompressionlowcardinality)
+  * 4.2 [Specific](#specific)
+    * 4.2.1 [RQ.SRS008.AES.Encrypt.Function](#rqsrs008aesencryptfunction)
+    * 4.2.2 [RQ.SRS008.AES.Encrypt.Function.Syntax](#rqsrs008aesencryptfunctionsyntax)
+    * 4.2.3 [RQ.SRS008.AES.Encrypt.Function.NIST.TestVectors](#rqsrs008aesencryptfunctionnisttestvectors)
+    * 4.2.4 [RQ.SRS008.AES.Encrypt.Function.Parameters.PlainText](#rqsrs008aesencryptfunctionparametersplaintext)
+    * 4.2.5 [RQ.SRS008.AES.Encrypt.Function.Parameters.Key](#rqsrs008aesencryptfunctionparameterskey)
+    * 4.2.6 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode](#rqsrs008aesencryptfunctionparametersmode)
+    * 4.2.7 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.ValuesFormat](#rqsrs008aesencryptfunctionparametersmodevaluesformat)
+    * 4.2.8 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.Invalid](#rqsrs008aesencryptfunctionparametersmodevalueinvalid)
+    * 4.2.9 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-128-ECB](#rqsrs008aesencryptfunctionparametersmodevalueaes-128-ecb)
+    * 4.2.10 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-192-ECB](#rqsrs008aesencryptfunctionparametersmodevalueaes-192-ecb)
+    * 4.2.11 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-256-ECB](#rqsrs008aesencryptfunctionparametersmodevalueaes-256-ecb)
+    * 4.2.12 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-128-CBC](#rqsrs008aesencryptfunctionparametersmodevalueaes-128-cbc)
+    * 4.2.13 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-192-CBC](#rqsrs008aesencryptfunctionparametersmodevalueaes-192-cbc)
+    * 4.2.14 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-256-CBC](#rqsrs008aesencryptfunctionparametersmodevalueaes-256-cbc)
+    * 4.2.15 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-128-CFB1](#rqsrs008aesencryptfunctionparametersmodevalueaes-128-cfb1)
+    * 4.2.16 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-192-CFB1](#rqsrs008aesencryptfunctionparametersmodevalueaes-192-cfb1)
+    * 4.2.17 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-256-CFB1](#rqsrs008aesencryptfunctionparametersmodevalueaes-256-cfb1)
+    * 4.2.18 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-128-CFB8](#rqsrs008aesencryptfunctionparametersmodevalueaes-128-cfb8)
+    * 4.2.19 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-192-CFB8](#rqsrs008aesencryptfunctionparametersmodevalueaes-192-cfb8)
+    * 4.2.20 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-256-CFB8](#rqsrs008aesencryptfunctionparametersmodevalueaes-256-cfb8)
+    * 4.2.21 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-128-CFB128](#rqsrs008aesencryptfunctionparametersmodevalueaes-128-cfb128)
+    * 4.2.22 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-192-CFB128](#rqsrs008aesencryptfunctionparametersmodevalueaes-192-cfb128)
+    * 4.2.23 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-256-CFB128](#rqsrs008aesencryptfunctionparametersmodevalueaes-256-cfb128)
+    * 4.2.24 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-128-OFB](#rqsrs008aesencryptfunctionparametersmodevalueaes-128-ofb)
+    * 4.2.25 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-192-OFB](#rqsrs008aesencryptfunctionparametersmodevalueaes-192-ofb)
+    * 4.2.26 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-256-OFB](#rqsrs008aesencryptfunctionparametersmodevalueaes-256-ofb)
+    * 4.2.27 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-128-GCM](#rqsrs008aesencryptfunctionparametersmodevalueaes-128-gcm)
+    * 4.2.28 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-192-GCM](#rqsrs008aesencryptfunctionparametersmodevalueaes-192-gcm)
+    * 4.2.29 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-256-GCM](#rqsrs008aesencryptfunctionparametersmodevalueaes-256-gcm)
+    * 4.2.30 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-128-CTR](#rqsrs008aesencryptfunctionparametersmodevalueaes-128-ctr)
+    * 4.2.31 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-192-CTR](#rqsrs008aesencryptfunctionparametersmodevalueaes-192-ctr)
+    * 4.2.32 [RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-256-CTR](#rqsrs008aesencryptfunctionparametersmodevalueaes-256-ctr)
+    * 4.2.33 [RQ.SRS008.AES.Encrypt.Function.Parameters.InitializationVector](#rqsrs008aesencryptfunctionparametersinitializationvector)
+    * 4.2.34 [RQ.SRS008.AES.Encrypt.Function.Parameters.AdditionalAuthenticatedData](#rqsrs008aesencryptfunctionparametersadditionalauthenticateddata)
+    * 4.2.35 [RQ.SRS008.AES.Encrypt.Function.Parameters.ReturnValue](#rqsrs008aesencryptfunctionparametersreturnvalue)
+    * 4.2.36 [RQ.SRS008.AES.Encrypt.Function.Key.Length.InvalidLengthError](#rqsrs008aesencryptfunctionkeylengthinvalidlengtherror)
+    * 4.2.37 [RQ.SRS008.AES.Encrypt.Function.InitializationVector.Length.InvalidLengthError](#rqsrs008aesencryptfunctioninitializationvectorlengthinvalidlengtherror)
+    * 4.2.38 [RQ.SRS008.AES.Encrypt.Function.InitializationVector.NotValidForMode](#rqsrs008aesencryptfunctioninitializationvectornotvalidformode)
+    * 4.2.39 [RQ.SRS008.AES.Encrypt.Function.AdditionalAuthenticationData.NotValidForMode](#rqsrs008aesencryptfunctionadditionalauthenticationdatanotvalidformode)
+    * 4.2.40 [RQ.SRS008.AES.Encrypt.Function.AdditionalAuthenticationData.Length](#rqsrs008aesencryptfunctionadditionalauthenticationdatalength)
+    * 4.2.41 [RQ.SRS008.AES.Encrypt.Function.AES-128-ECB.KeyAndInitializationVector.Length](#rqsrs008aesencryptfunctionaes-128-ecbkeyandinitializationvectorlength)
+    * 4.2.42 [RQ.SRS008.AES.Encrypt.Function.AES-192-ECB.KeyAndInitializationVector.Length](#rqsrs008aesencryptfunctionaes-192-ecbkeyandinitializationvectorlength)
+    * 4.2.43 [RQ.SRS008.AES.Encrypt.Function.AES-256-ECB.KeyAndInitializationVector.Length](#rqsrs008aesencryptfunctionaes-256-ecbkeyandinitializationvectorlength)
+    * 4.2.44 [RQ.SRS008.AES.Encrypt.Function.AES-128-CBC.KeyAndInitializationVector.Length](#rqsrs008aesencryptfunctionaes-128-cbckeyandinitializationvectorlength)
+    * 4.2.45 [RQ.SRS008.AES.Encrypt.Function.AES-192-CBC.KeyAndInitializationVector.Length](#rqsrs008aesencryptfunctionaes-192-cbckeyandinitializationvectorlength)
+    * 4.2.46 [RQ.SRS008.AES.Encrypt.Function.AES-256-CBC.KeyAndInitializationVector.Length](#rqsrs008aesencryptfunctionaes-256-cbckeyandinitializationvectorlength)
+    * 4.2.47 [RQ.SRS008.AES.Encrypt.Function.AES-128-CFB1.KeyAndInitializationVector.Length](#rqsrs008aesencryptfunctionaes-128-cfb1keyandinitializationvectorlength)
+    * 4.2.48 [RQ.SRS008.AES.Encrypt.Function.AES-192-CFB1.KeyAndInitializationVector.Length](#rqsrs008aesencryptfunctionaes-192-cfb1keyandinitializationvectorlength)
+    * 4.2.49 [RQ.SRS008.AES.Encrypt.Function.AES-256-CFB1.KeyAndInitializationVector.Length](#rqsrs008aesencryptfunctionaes-256-cfb1keyandinitializationvectorlength)
+    * 4.2.50 [RQ.SRS008.AES.Encrypt.Function.AES-128-CFB8.KeyAndInitializationVector.Length](#rqsrs008aesencryptfunctionaes-128-cfb8keyandinitializationvectorlength)
+    * 4.2.51 [RQ.SRS008.AES.Encrypt.Function.AES-192-CFB8.KeyAndInitializationVector.Length](#rqsrs008aesencryptfunctionaes-192-cfb8keyandinitializationvectorlength)
+    * 4.2.52 [RQ.SRS008.AES.Encrypt.Function.AES-256-CFB8.KeyAndInitializationVector.Length](#rqsrs008aesencryptfunctionaes-256-cfb8keyandinitializationvectorlength)
+    * 4.2.53 [RQ.SRS008.AES.Encrypt.Function.AES-128-CFB128.KeyAndInitializationVector.Length](#rqsrs008aesencryptfunctionaes-128-cfb128keyandinitializationvectorlength)
+    * 4.2.54 [RQ.SRS008.AES.Encrypt.Function.AES-192-CFB128.KeyAndInitializationVector.Length](#rqsrs008aesencryptfunctionaes-192-cfb128keyandinitializationvectorlength)
+    * 4.2.55 [RQ.SRS008.AES.Encrypt.Function.AES-256-CFB128.KeyAndInitializationVector.Length](#rqsrs008aesencryptfunctionaes-256-cfb128keyandinitializationvectorlength)
+    * 4.2.56 [RQ.SRS008.AES.Encrypt.Function.AES-128-OFB.KeyAndInitializationVector.Length](#rqsrs008aesencryptfunctionaes-128-ofbkeyandinitializationvectorlength)
+    * 4.2.57 [RQ.SRS008.AES.Encrypt.Function.AES-192-OFB.KeyAndInitializationVector.Length](#rqsrs008aesencryptfunctionaes-192-ofbkeyandinitializationvectorlength)
+    * 4.2.58 [RQ.SRS008.AES.Encrypt.Function.AES-256-OFB.KeyAndInitializationVector.Length](#rqsrs008aesencryptfunctionaes-256-ofbkeyandinitializationvectorlength)
+    * 4.2.59 [RQ.SRS008.AES.Encrypt.Function.AES-128-GCM.KeyAndInitializationVector.Length](#rqsrs008aesencryptfunctionaes-128-gcmkeyandinitializationvectorlength)
+    * 4.2.60 [RQ.SRS008.AES.Encrypt.Function.AES-192-GCM.KeyAndInitializationVector.Length](#rqsrs008aesencryptfunctionaes-192-gcmkeyandinitializationvectorlength)
+    * 4.2.61 [RQ.SRS008.AES.Encrypt.Function.AES-256-GCM.KeyAndInitializationVector.Length](#rqsrs008aesencryptfunctionaes-256-gcmkeyandinitializationvectorlength)
+    * 4.2.62 [RQ.SRS008.AES.Encrypt.Function.AES-128-CTR.KeyAndInitializationVector.Length](#rqsrs008aesencryptfunctionaes-128-ctrkeyandinitializationvectorlength)
+    * 4.2.63 [RQ.SRS008.AES.Encrypt.Function.AES-192-CTR.KeyAndInitializationVector.Length](#rqsrs008aesencryptfunctionaes-192-ctrkeyandinitializationvectorlength)
+    * 4.2.64 [RQ.SRS008.AES.Encrypt.Function.AES-256-CTR.KeyAndInitializationVector.Length](#rqsrs008aesencryptfunctionaes-256-ctrkeyandinitializationvectorlength)
+    * 4.2.65 [RQ.SRS008.AES.Decrypt.Function](#rqsrs008aesdecryptfunction)
+    * 4.2.66 [RQ.SRS008.AES.Decrypt.Function.Syntax](#rqsrs008aesdecryptfunctionsyntax)
+    * 4.2.67 [RQ.SRS008.AES.Decrypt.Function.Parameters.CipherText](#rqsrs008aesdecryptfunctionparametersciphertext)
+    * 4.2.68 [RQ.SRS008.AES.Decrypt.Function.Parameters.Key](#rqsrs008aesdecryptfunctionparameterskey)
+    * 4.2.69 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode](#rqsrs008aesdecryptfunctionparametersmode)
+    * 4.2.70 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.ValuesFormat](#rqsrs008aesdecryptfunctionparametersmodevaluesformat)
+    * 4.2.71 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.Invalid](#rqsrs008aesdecryptfunctionparametersmodevalueinvalid)
+    * 4.2.72 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-128-ECB](#rqsrs008aesdecryptfunctionparametersmodevalueaes-128-ecb)
+    * 4.2.73 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-192-ECB](#rqsrs008aesdecryptfunctionparametersmodevalueaes-192-ecb)
+    * 4.2.74 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-256-ECB](#rqsrs008aesdecryptfunctionparametersmodevalueaes-256-ecb)
+    * 4.2.75 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-128-CBC](#rqsrs008aesdecryptfunctionparametersmodevalueaes-128-cbc)
+    * 4.2.76 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-192-CBC](#rqsrs008aesdecryptfunctionparametersmodevalueaes-192-cbc)
+    * 4.2.77 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-256-CBC](#rqsrs008aesdecryptfunctionparametersmodevalueaes-256-cbc)
+    * 4.2.78 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-128-CFB1](#rqsrs008aesdecryptfunctionparametersmodevalueaes-128-cfb1)
+    * 4.2.79 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-192-CFB1](#rqsrs008aesdecryptfunctionparametersmodevalueaes-192-cfb1)
+    * 4.2.80 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-256-CFB1](#rqsrs008aesdecryptfunctionparametersmodevalueaes-256-cfb1)
+    * 4.2.81 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-128-CFB8](#rqsrs008aesdecryptfunctionparametersmodevalueaes-128-cfb8)
+    * 4.2.82 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-192-CFB8](#rqsrs008aesdecryptfunctionparametersmodevalueaes-192-cfb8)
+    * 4.2.83 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-256-CFB8](#rqsrs008aesdecryptfunctionparametersmodevalueaes-256-cfb8)
+    * 4.2.84 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-128-CFB128](#rqsrs008aesdecryptfunctionparametersmodevalueaes-128-cfb128)
+    * 4.2.85 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-192-CFB128](#rqsrs008aesdecryptfunctionparametersmodevalueaes-192-cfb128)
+    * 4.2.86 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-256-CFB128](#rqsrs008aesdecryptfunctionparametersmodevalueaes-256-cfb128)
+    * 4.2.87 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-128-OFB](#rqsrs008aesdecryptfunctionparametersmodevalueaes-128-ofb)
+    * 4.2.88 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-192-OFB](#rqsrs008aesdecryptfunctionparametersmodevalueaes-192-ofb)
+    * 4.2.89 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-256-OFB](#rqsrs008aesdecryptfunctionparametersmodevalueaes-256-ofb)
+    * 4.2.90 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-128-GCM](#rqsrs008aesdecryptfunctionparametersmodevalueaes-128-gcm)
+    * 4.2.91 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-192-GCM](#rqsrs008aesdecryptfunctionparametersmodevalueaes-192-gcm)
+    * 4.2.92 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-256-GCM](#rqsrs008aesdecryptfunctionparametersmodevalueaes-256-gcm)
+    * 4.2.93 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-128-CTR](#rqsrs008aesdecryptfunctionparametersmodevalueaes-128-ctr)
+    * 4.2.94 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-192-CTR](#rqsrs008aesdecryptfunctionparametersmodevalueaes-192-ctr)
+    * 4.2.95 [RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-256-CTR](#rqsrs008aesdecryptfunctionparametersmodevalueaes-256-ctr)
+    * 4.2.96 [RQ.SRS008.AES.Decrypt.Function.Parameters.InitializationVector](#rqsrs008aesdecryptfunctionparametersinitializationvector)
+    * 4.2.97 [RQ.SRS008.AES.Decrypt.Function.Parameters.AdditionalAuthenticatedData](#rqsrs008aesdecryptfunctionparametersadditionalauthenticateddata)
+    * 4.2.98 [RQ.SRS008.AES.Decrypt.Function.Parameters.ReturnValue](#rqsrs008aesdecryptfunctionparametersreturnvalue)
+    * 4.2.99 [RQ.SRS008.AES.Decrypt.Function.Key.Length.InvalidLengthError](#rqsrs008aesdecryptfunctionkeylengthinvalidlengtherror)
+    * 4.2.100 [RQ.SRS008.AES.Decrypt.Function.InitializationVector.Length.InvalidLengthError](#rqsrs008aesdecryptfunctioninitializationvectorlengthinvalidlengtherror)
+    * 4.2.101 [RQ.SRS008.AES.Decrypt.Function.InitializationVector.NotValidForMode](#rqsrs008aesdecryptfunctioninitializationvectornotvalidformode)
+    * 4.2.102 [RQ.SRS008.AES.Decrypt.Function.AdditionalAuthenticationData.NotValidForMode](#rqsrs008aesdecryptfunctionadditionalauthenticationdatanotvalidformode)
+    * 4.2.103 [RQ.SRS008.AES.Decrypt.Function.AdditionalAuthenticationData.Length](#rqsrs008aesdecryptfunctionadditionalauthenticationdatalength)
+    * 4.2.104 [RQ.SRS008.AES.Decrypt.Function.AES-128-ECB.KeyAndInitializationVector.Length](#rqsrs008aesdecryptfunctionaes-128-ecbkeyandinitializationvectorlength)
+    * 4.2.105 [RQ.SRS008.AES.Decrypt.Function.AES-192-ECB.KeyAndInitializationVector.Length](#rqsrs008aesdecryptfunctionaes-192-ecbkeyandinitializationvectorlength)
+    * 4.2.106 [RQ.SRS008.AES.Decrypt.Function.AES-256-ECB.KeyAndInitializationVector.Length](#rqsrs008aesdecryptfunctionaes-256-ecbkeyandinitializationvectorlength)
+    * 4.2.107 [RQ.SRS008.AES.Decrypt.Function.AES-128-CBC.KeyAndInitializationVector.Length](#rqsrs008aesdecryptfunctionaes-128-cbckeyandinitializationvectorlength)
+    * 4.2.108 [RQ.SRS008.AES.Decrypt.Function.AES-192-CBC.KeyAndInitializationVector.Length](#rqsrs008aesdecryptfunctionaes-192-cbckeyandinitializationvectorlength)
+    * 4.2.109 [RQ.SRS008.AES.Decrypt.Function.AES-256-CBC.KeyAndInitializationVector.Length](#rqsrs008aesdecryptfunctionaes-256-cbckeyandinitializationvectorlength)
+    * 4.2.110 [RQ.SRS008.AES.Decrypt.Function.AES-128-CFB1.KeyAndInitializationVector.Length](#rqsrs008aesdecryptfunctionaes-128-cfb1keyandinitializationvectorlength)
+    * 4.2.111 [RQ.SRS008.AES.Decrypt.Function.AES-192-CFB1.KeyAndInitializationVector.Length](#rqsrs008aesdecryptfunctionaes-192-cfb1keyandinitializationvectorlength)
+    * 4.2.112 [RQ.SRS008.AES.Decrypt.Function.AES-256-CFB1.KeyAndInitializationVector.Length](#rqsrs008aesdecryptfunctionaes-256-cfb1keyandinitializationvectorlength)
+    * 4.2.113 [RQ.SRS008.AES.Decrypt.Function.AES-128-CFB8.KeyAndInitializationVector.Length](#rqsrs008aesdecryptfunctionaes-128-cfb8keyandinitializationvectorlength)
+    * 4.2.114 [RQ.SRS008.AES.Decrypt.Function.AES-192-CFB8.KeyAndInitializationVector.Length](#rqsrs008aesdecryptfunctionaes-192-cfb8keyandinitializationvectorlength)
+    * 4.2.115 [RQ.SRS008.AES.Decrypt.Function.AES-256-CFB8.KeyAndInitializationVector.Length](#rqsrs008aesdecryptfunctionaes-256-cfb8keyandinitializationvectorlength)
+    * 4.2.116 [RQ.SRS008.AES.Decrypt.Function.AES-128-CFB128.KeyAndInitializationVector.Length](#rqsrs008aesdecryptfunctionaes-128-cfb128keyandinitializationvectorlength)
+    * 4.2.117 [RQ.SRS008.AES.Decrypt.Function.AES-192-CFB128.KeyAndInitializationVector.Length](#rqsrs008aesdecryptfunctionaes-192-cfb128keyandinitializationvectorlength)
+    * 4.2.118 [RQ.SRS008.AES.Decrypt.Function.AES-256-CFB128.KeyAndInitializationVector.Length](#rqsrs008aesdecryptfunctionaes-256-cfb128keyandinitializationvectorlength)
+    * 4.2.119 [RQ.SRS008.AES.Decrypt.Function.AES-128-OFB.KeyAndInitializationVector.Length](#rqsrs008aesdecryptfunctionaes-128-ofbkeyandinitializationvectorlength)
+    * 4.2.120 [RQ.SRS008.AES.Decrypt.Function.AES-192-OFB.KeyAndInitializationVector.Length](#rqsrs008aesdecryptfunctionaes-192-ofbkeyandinitializationvectorlength)
+    * 4.2.121 [RQ.SRS008.AES.Decrypt.Function.AES-256-OFB.KeyAndInitializationVector.Length](#rqsrs008aesdecryptfunctionaes-256-ofbkeyandinitializationvectorlength)
+    * 4.2.122 [RQ.SRS008.AES.Decrypt.Function.AES-128-GCM.KeyAndInitializationVector.Length](#rqsrs008aesdecryptfunctionaes-128-gcmkeyandinitializationvectorlength)
+    * 4.2.123 [RQ.SRS008.AES.Decrypt.Function.AES-192-GCM.KeyAndInitializationVector.Length](#rqsrs008aesdecryptfunctionaes-192-gcmkeyandinitializationvectorlength)
+    * 4.2.124 [RQ.SRS008.AES.Decrypt.Function.AES-256-GCM.KeyAndInitializationVector.Length](#rqsrs008aesdecryptfunctionaes-256-gcmkeyandinitializationvectorlength)
+    * 4.2.125 [RQ.SRS008.AES.Decrypt.Function.AES-128-CTR.KeyAndInitializationVector.Length](#rqsrs008aesdecryptfunctionaes-128-ctrkeyandinitializationvectorlength)
+    * 4.2.126 [RQ.SRS008.AES.Decrypt.Function.AES-192-CTR.KeyAndInitializationVector.Length](#rqsrs008aesdecryptfunctionaes-192-ctrkeyandinitializationvectorlength)
+    * 4.2.127 [RQ.SRS008.AES.Decrypt.Function.AES-256-CTR.KeyAndInitializationVector.Length](#rqsrs008aesdecryptfunctionaes-256-ctrkeyandinitializationvectorlength)
+  * 4.3 [MySQL Specific Functions](#mysql-specific-functions)
+    * 4.3.1 [RQ.SRS008.AES.MySQL.Encrypt.Function](#rqsrs008aesmysqlencryptfunction)
+    * 4.3.2 [RQ.SRS008.AES.MySQL.Encrypt.Function.Syntax](#rqsrs008aesmysqlencryptfunctionsyntax)
+    * 4.3.3 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.PlainText](#rqsrs008aesmysqlencryptfunctionparametersplaintext)
+    * 4.3.4 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Key](#rqsrs008aesmysqlencryptfunctionparameterskey)
+    * 4.3.5 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode](#rqsrs008aesmysqlencryptfunctionparametersmode)
+    * 4.3.6 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.ValuesFormat](#rqsrs008aesmysqlencryptfunctionparametersmodevaluesformat)
+    * 4.3.7 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.Invalid](#rqsrs008aesmysqlencryptfunctionparametersmodevalueinvalid)
+    * 4.3.8 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-128-ECB](#rqsrs008aesmysqlencryptfunctionparametersmodevalueaes-128-ecb)
+    * 4.3.9 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-192-ECB](#rqsrs008aesmysqlencryptfunctionparametersmodevalueaes-192-ecb)
+    * 4.3.10 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-256-ECB](#rqsrs008aesmysqlencryptfunctionparametersmodevalueaes-256-ecb)
+    * 4.3.11 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-128-CBC](#rqsrs008aesmysqlencryptfunctionparametersmodevalueaes-128-cbc)
+    * 4.3.12 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-192-CBC](#rqsrs008aesmysqlencryptfunctionparametersmodevalueaes-192-cbc)
+    * 4.3.13 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-256-CBC](#rqsrs008aesmysqlencryptfunctionparametersmodevalueaes-256-cbc)
+    * 4.3.14 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-128-CFB1](#rqsrs008aesmysqlencryptfunctionparametersmodevalueaes-128-cfb1)
+    * 4.3.15 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-192-CFB1](#rqsrs008aesmysqlencryptfunctionparametersmodevalueaes-192-cfb1)
+    * 4.3.16 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-256-CFB1](#rqsrs008aesmysqlencryptfunctionparametersmodevalueaes-256-cfb1)
+    * 4.3.17 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-128-CFB8](#rqsrs008aesmysqlencryptfunctionparametersmodevalueaes-128-cfb8)
+    * 4.3.18 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-192-CFB8](#rqsrs008aesmysqlencryptfunctionparametersmodevalueaes-192-cfb8)
+    * 4.3.19 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-256-CFB8](#rqsrs008aesmysqlencryptfunctionparametersmodevalueaes-256-cfb8)
+    * 4.3.20 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-128-CFB128](#rqsrs008aesmysqlencryptfunctionparametersmodevalueaes-128-cfb128)
+    * 4.3.21 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-192-CFB128](#rqsrs008aesmysqlencryptfunctionparametersmodevalueaes-192-cfb128)
+    * 4.3.22 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-256-CFB128](#rqsrs008aesmysqlencryptfunctionparametersmodevalueaes-256-cfb128)
+    * 4.3.23 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-128-OFB](#rqsrs008aesmysqlencryptfunctionparametersmodevalueaes-128-ofb)
+    * 4.3.24 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-192-OFB](#rqsrs008aesmysqlencryptfunctionparametersmodevalueaes-192-ofb)
+    * 4.3.25 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-256-OFB](#rqsrs008aesmysqlencryptfunctionparametersmodevalueaes-256-ofb)
+    * 4.3.26 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-128-GCM.Error](#rqsrs008aesmysqlencryptfunctionparametersmodevalueaes-128-gcmerror)
+    * 4.3.27 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-192-GCM.Error](#rqsrs008aesmysqlencryptfunctionparametersmodevalueaes-192-gcmerror)
+    * 4.3.28 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-256-GCM.Error](#rqsrs008aesmysqlencryptfunctionparametersmodevalueaes-256-gcmerror)
+    * 4.3.29 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-128-CTR.Error](#rqsrs008aesmysqlencryptfunctionparametersmodevalueaes-128-ctrerror)
+    * 4.3.30 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-192-CTR.Error](#rqsrs008aesmysqlencryptfunctionparametersmodevalueaes-192-ctrerror)
+    * 4.3.31 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-256-CTR.Error](#rqsrs008aesmysqlencryptfunctionparametersmodevalueaes-256-ctrerror)
+    * 4.3.32 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.InitializationVector](#rqsrs008aesmysqlencryptfunctionparametersinitializationvector)
+    * 4.3.33 [RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.ReturnValue](#rqsrs008aesmysqlencryptfunctionparametersreturnvalue)
+    * 4.3.34 [RQ.SRS008.AES.MySQL.Encrypt.Function.Key.Length.TooShortError](#rqsrs008aesmysqlencryptfunctionkeylengthtooshorterror)
+    * 4.3.35 [RQ.SRS008.AES.MySQL.Encrypt.Function.Key.Length.TooLong](#rqsrs008aesmysqlencryptfunctionkeylengthtoolong)
+    * 4.3.36 [RQ.SRS008.AES.MySQL.Encrypt.Function.InitializationVector.Length.TooShortError](#rqsrs008aesmysqlencryptfunctioninitializationvectorlengthtooshorterror)
+    * 4.3.37 [RQ.SRS008.AES.MySQL.Encrypt.Function.InitializationVector.Length.TooLong](#rqsrs008aesmysqlencryptfunctioninitializationvectorlengthtoolong)
+    * 4.3.38 [RQ.SRS008.AES.MySQL.Encrypt.Function.InitializationVector.NotValidForMode](#rqsrs008aesmysqlencryptfunctioninitializationvectornotvalidformode)
+    * 4.3.39 [RQ.SRS008.AES.MySQL.Encrypt.Function.AES-128-ECB.KeyAndInitializationVector.Length](#rqsrs008aesmysqlencryptfunctionaes-128-ecbkeyandinitializationvectorlength)
+    * 4.3.40 [RQ.SRS008.AES.MySQL.Encrypt.Function.AES-192-ECB.KeyAndInitializationVector.Length](#rqsrs008aesmysqlencryptfunctionaes-192-ecbkeyandinitializationvectorlength)
+    * 4.3.41 [RQ.SRS008.AES.MySQL.Encrypt.Function.AES-256-ECB.KeyAndInitializationVector.Length](#rqsrs008aesmysqlencryptfunctionaes-256-ecbkeyandinitializationvectorlength)
+    * 4.3.42 [RQ.SRS008.AES.MySQL.Encrypt.Function.AES-128-CBC.KeyAndInitializationVector.Length](#rqsrs008aesmysqlencryptfunctionaes-128-cbckeyandinitializationvectorlength)
+    * 4.3.43 [RQ.SRS008.AES.MySQL.Encrypt.Function.AES-192-CBC.KeyAndInitializationVector.Length](#rqsrs008aesmysqlencryptfunctionaes-192-cbckeyandinitializationvectorlength)
+    * 4.3.44 [RQ.SRS008.AES.MySQL.Encrypt.Function.AES-256-CBC.KeyAndInitializationVector.Length](#rqsrs008aesmysqlencryptfunctionaes-256-cbckeyandinitializationvectorlength)
+    * 4.3.45 [RQ.SRS008.AES.MySQL.Encrypt.Function.AES-128-CFB1.KeyAndInitializationVector.Length](#rqsrs008aesmysqlencryptfunctionaes-128-cfb1keyandinitializationvectorlength)
+    * 4.3.46 [RQ.SRS008.AES.MySQL.Encrypt.Function.AES-192-CFB1.KeyAndInitializationVector.Length](#rqsrs008aesmysqlencryptfunctionaes-192-cfb1keyandinitializationvectorlength)
+    * 4.3.47 [RQ.SRS008.AES.MySQL.Encrypt.Function.AES-256-CFB1.KeyAndInitializationVector.Length](#rqsrs008aesmysqlencryptfunctionaes-256-cfb1keyandinitializationvectorlength)
+    * 4.3.48 [RQ.SRS008.AES.MySQL.Encrypt.Function.AES-128-CFB8.KeyAndInitializationVector.Length](#rqsrs008aesmysqlencryptfunctionaes-128-cfb8keyandinitializationvectorlength)
+    * 4.3.49 [RQ.SRS008.AES.MySQL.Encrypt.Function.AES-192-CFB8.KeyAndInitializationVector.Length](#rqsrs008aesmysqlencryptfunctionaes-192-cfb8keyandinitializationvectorlength)
+    * 4.3.50 [RQ.SRS008.AES.MySQL.Encrypt.Function.AES-256-CFB8.KeyAndInitializationVector.Length](#rqsrs008aesmysqlencryptfunctionaes-256-cfb8keyandinitializationvectorlength)
+    * 4.3.51 [RQ.SRS008.AES.MySQL.Encrypt.Function.AES-128-CFB128.KeyAndInitializationVector.Length](#rqsrs008aesmysqlencryptfunctionaes-128-cfb128keyandinitializationvectorlength)
+    * 4.3.52 [RQ.SRS008.AES.MySQL.Encrypt.Function.AES-192-CFB128.KeyAndInitializationVector.Length](#rqsrs008aesmysqlencryptfunctionaes-192-cfb128keyandinitializationvectorlength)
+    * 4.3.53 [RQ.SRS008.AES.MySQL.Encrypt.Function.AES-256-CFB128.KeyAndInitializationVector.Length](#rqsrs008aesmysqlencryptfunctionaes-256-cfb128keyandinitializationvectorlength)
+    * 4.3.54 [RQ.SRS008.AES.MySQL.Encrypt.Function.AES-128-OFB.KeyAndInitializationVector.Length](#rqsrs008aesmysqlencryptfunctionaes-128-ofbkeyandinitializationvectorlength)
+    * 4.3.55 [RQ.SRS008.AES.MySQL.Encrypt.Function.AES-192-OFB.KeyAndInitializationVector.Length](#rqsrs008aesmysqlencryptfunctionaes-192-ofbkeyandinitializationvectorlength)
+    * 4.3.56 [RQ.SRS008.AES.MySQL.Encrypt.Function.AES-256-OFB.KeyAndInitializationVector.Length](#rqsrs008aesmysqlencryptfunctionaes-256-ofbkeyandinitializationvectorlength)
+    * 4.3.57 [RQ.SRS008.AES.MySQL.Decrypt.Function](#rqsrs008aesmysqldecryptfunction)
+    * 4.3.58 [RQ.SRS008.AES.MySQL.Decrypt.Function.Syntax](#rqsrs008aesmysqldecryptfunctionsyntax)
+    * 4.3.59 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.CipherText](#rqsrs008aesmysqldecryptfunctionparametersciphertext)
+    * 4.3.60 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Key](#rqsrs008aesmysqldecryptfunctionparameterskey)
+    * 4.3.61 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode](#rqsrs008aesmysqldecryptfunctionparametersmode)
+    * 4.3.62 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.ValuesFormat](#rqsrs008aesmysqldecryptfunctionparametersmodevaluesformat)
+    * 4.3.63 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.Invalid](#rqsrs008aesmysqldecryptfunctionparametersmodevalueinvalid)
+    * 4.3.64 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-128-ECB](#rqsrs008aesmysqldecryptfunctionparametersmodevalueaes-128-ecb)
+    * 4.3.65 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-192-ECB](#rqsrs008aesmysqldecryptfunctionparametersmodevalueaes-192-ecb)
+    * 4.3.66 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-256-ECB](#rqsrs008aesmysqldecryptfunctionparametersmodevalueaes-256-ecb)
+    * 4.3.67 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-128-CBC](#rqsrs008aesmysqldecryptfunctionparametersmodevalueaes-128-cbc)
+    * 4.3.68 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-192-CBC](#rqsrs008aesmysqldecryptfunctionparametersmodevalueaes-192-cbc)
+    * 4.3.69 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-256-CBC](#rqsrs008aesmysqldecryptfunctionparametersmodevalueaes-256-cbc)
+    * 4.3.70 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-128-CFB1](#rqsrs008aesmysqldecryptfunctionparametersmodevalueaes-128-cfb1)
+    * 4.3.71 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-192-CFB1](#rqsrs008aesmysqldecryptfunctionparametersmodevalueaes-192-cfb1)
+    * 4.3.72 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-256-CFB1](#rqsrs008aesmysqldecryptfunctionparametersmodevalueaes-256-cfb1)
+    * 4.3.73 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-128-CFB8](#rqsrs008aesmysqldecryptfunctionparametersmodevalueaes-128-cfb8)
+    * 4.3.74 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-192-CFB8](#rqsrs008aesmysqldecryptfunctionparametersmodevalueaes-192-cfb8)
+    * 4.3.75 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-256-CFB8](#rqsrs008aesmysqldecryptfunctionparametersmodevalueaes-256-cfb8)
+    * 4.3.76 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-128-CFB128](#rqsrs008aesmysqldecryptfunctionparametersmodevalueaes-128-cfb128)
+    * 4.3.77 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-192-CFB128](#rqsrs008aesmysqldecryptfunctionparametersmodevalueaes-192-cfb128)
+    * 4.3.78 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-256-CFB128](#rqsrs008aesmysqldecryptfunctionparametersmodevalueaes-256-cfb128)
+    * 4.3.79 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-128-OFB](#rqsrs008aesmysqldecryptfunctionparametersmodevalueaes-128-ofb)
+    * 4.3.80 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-192-OFB](#rqsrs008aesmysqldecryptfunctionparametersmodevalueaes-192-ofb)
+    * 4.3.81 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-256-OFB](#rqsrs008aesmysqldecryptfunctionparametersmodevalueaes-256-ofb)
+    * 4.3.82 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-128-GCM.Error](#rqsrs008aesmysqldecryptfunctionparametersmodevalueaes-128-gcmerror)
+    * 4.3.83 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-192-GCM.Error](#rqsrs008aesmysqldecryptfunctionparametersmodevalueaes-192-gcmerror)
+    * 4.3.84 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-256-GCM.Error](#rqsrs008aesmysqldecryptfunctionparametersmodevalueaes-256-gcmerror)
+    * 4.3.85 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-128-CTR.Error](#rqsrs008aesmysqldecryptfunctionparametersmodevalueaes-128-ctrerror)
+    * 4.3.86 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-192-CTR.Error](#rqsrs008aesmysqldecryptfunctionparametersmodevalueaes-192-ctrerror)
+    * 4.3.87 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-256-CTR.Error](#rqsrs008aesmysqldecryptfunctionparametersmodevalueaes-256-ctrerror)
+    * 4.3.88 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.InitializationVector](#rqsrs008aesmysqldecryptfunctionparametersinitializationvector)
+    * 4.3.89 [RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.ReturnValue](#rqsrs008aesmysqldecryptfunctionparametersreturnvalue)
+    * 4.3.90 [RQ.SRS008.AES.MySQL.Decrypt.Function.Key.Length.TooShortError](#rqsrs008aesmysqldecryptfunctionkeylengthtooshorterror)
+    * 4.3.91 [RQ.SRS008.AES.MySQL.Decrypt.Function.Key.Length.TooLong](#rqsrs008aesmysqldecryptfunctionkeylengthtoolong)
+    * 4.3.92 [RQ.SRS008.AES.MySQL.Decrypt.Function.InitializationVector.Length.TooShortError](#rqsrs008aesmysqldecryptfunctioninitializationvectorlengthtooshorterror)
+    * 4.3.93 [RQ.SRS008.AES.MySQL.Decrypt.Function.InitializationVector.Length.TooLong](#rqsrs008aesmysqldecryptfunctioninitializationvectorlengthtoolong)
+    * 4.3.94 [RQ.SRS008.AES.MySQL.Decrypt.Function.InitializationVector.NotValidForMode](#rqsrs008aesmysqldecryptfunctioninitializationvectornotvalidformode)
+    * 4.3.95 [RQ.SRS008.AES.MySQL.Decrypt.Function.AES-128-ECB.KeyAndInitializationVector.Length](#rqsrs008aesmysqldecryptfunctionaes-128-ecbkeyandinitializationvectorlength)
+    * 4.3.96 [RQ.SRS008.AES.MySQL.Decrypt.Function.AES-192-ECB.KeyAndInitializationVector.Length](#rqsrs008aesmysqldecryptfunctionaes-192-ecbkeyandinitializationvectorlength)
+    * 4.3.97 [RQ.SRS008.AES.MySQL.Decrypt.Function.AES-256-ECB.KeyAndInitializationVector.Length](#rqsrs008aesmysqldecryptfunctionaes-256-ecbkeyandinitializationvectorlength)
+    * 4.3.98 [RQ.SRS008.AES.MySQL.Decrypt.Function.AES-128-CBC.KeyAndInitializationVector.Length](#rqsrs008aesmysqldecryptfunctionaes-128-cbckeyandinitializationvectorlength)
+    * 4.3.99 [RQ.SRS008.AES.MySQL.Decrypt.Function.AES-192-CBC.KeyAndInitializationVector.Length](#rqsrs008aesmysqldecryptfunctionaes-192-cbckeyandinitializationvectorlength)
+    * 4.3.100 [RQ.SRS008.AES.MySQL.Decrypt.Function.AES-256-CBC.KeyAndInitializationVector.Length](#rqsrs008aesmysqldecryptfunctionaes-256-cbckeyandinitializationvectorlength)
+    * 4.3.101 [RQ.SRS008.AES.MySQL.Decrypt.Function.AES-128-CFB1.KeyAndInitializationVector.Length](#rqsrs008aesmysqldecryptfunctionaes-128-cfb1keyandinitializationvectorlength)
+    * 4.3.102 [RQ.SRS008.AES.MySQL.Decrypt.Function.AES-192-CFB1.KeyAndInitializationVector.Length](#rqsrs008aesmysqldecryptfunctionaes-192-cfb1keyandinitializationvectorlength)
+    * 4.3.103 [RQ.SRS008.AES.MySQL.Decrypt.Function.AES-256-CFB1.KeyAndInitializationVector.Length](#rqsrs008aesmysqldecryptfunctionaes-256-cfb1keyandinitializationvectorlength)
+    * 4.3.104 [RQ.SRS008.AES.MySQL.Decrypt.Function.AES-128-CFB8.KeyAndInitializationVector.Length](#rqsrs008aesmysqldecryptfunctionaes-128-cfb8keyandinitializationvectorlength)
+    * 4.3.105 [RQ.SRS008.AES.MySQL.Decrypt.Function.AES-192-CFB8.KeyAndInitializationVector.Length](#rqsrs008aesmysqldecryptfunctionaes-192-cfb8keyandinitializationvectorlength)
+    * 4.3.106 [RQ.SRS008.AES.MySQL.Decrypt.Function.AES-256-CFB8.KeyAndInitializationVector.Length](#rqsrs008aesmysqldecryptfunctionaes-256-cfb8keyandinitializationvectorlength)
+    * 4.3.107 [RQ.SRS008.AES.MySQL.Decrypt.Function.AES-128-CFB128.KeyAndInitializationVector.Length](#rqsrs008aesmysqldecryptfunctionaes-128-cfb128keyandinitializationvectorlength)
+    * 4.3.108 [RQ.SRS008.AES.MySQL.Decrypt.Function.AES-192-CFB128.KeyAndInitializationVector.Length](#rqsrs008aesmysqldecryptfunctionaes-192-cfb128keyandinitializationvectorlength)
+    * 4.3.109 [RQ.SRS008.AES.MySQL.Decrypt.Function.AES-256-CFB128.KeyAndInitializationVector.Length](#rqsrs008aesmysqldecryptfunctionaes-256-cfb128keyandinitializationvectorlength)
+    * 4.3.110 [RQ.SRS008.AES.MySQL.Decrypt.Function.AES-128-OFB.KeyAndInitializationVector.Length](#rqsrs008aesmysqldecryptfunctionaes-128-ofbkeyandinitializationvectorlength)
+    * 4.3.111 [RQ.SRS008.AES.MySQL.Decrypt.Function.AES-192-OFB.KeyAndInitializationVector.Length](#rqsrs008aesmysqldecryptfunctionaes-192-ofbkeyandinitializationvectorlength)
+    * 4.3.112 [RQ.SRS008.AES.MySQL.Decrypt.Function.AES-256-OFB.KeyAndInitializationVector.Length](#rqsrs008aesmysqldecryptfunctionaes-256-ofbkeyandinitializationvectorlength)
+* 5 [References](#references)
+
+## Revision History
+
+This document is stored in an electronic form using [Git] source control management software
+hosted in a [GitHub Repository].
+All the updates are tracked using the [Revision History].
+
+## Introduction
+
+Users need an ability to encrypt and decrypt column data with tenant specific keys.
+Use cases include protection of sensitive column values and [GDPR] right to forget policies.
+The implementation will support capabilities of the [MySQL aes_encrypt] and [MySQL aes_decrypt]
+functions which encrypt and decrypt values using the [AES] (Advanced Encryption Standard)
+algorithm. This functionality will enable encryption and decryption of data
+accessed on remote [MySQL] servers via [MySQL Dictionary] or [MySQL Database Engine],
+[MySQL Table Engine], or [MySQL Table Function].
+
+## Terminology
+
+* **AES** -
+  Advanced Encryption Standard ([AES])
+
+## Requirements
+
+### Generic
+
+#### RQ.SRS008.AES.Functions
+version: 1.0
+
+[ClickHouse] SHALL support [AES] encryption functions to encrypt and decrypt data.
+
+#### RQ.SRS008.AES.Functions.Compatability.MySQL
+version: 1.0
+
+[ClickHouse] SHALL support [AES] encryption functions compatible with [MySQL 5.7].
+
+#### RQ.SRS008.AES.Functions.Compatability.Dictionaries
+version: 1.0
+
+[ClickHouse] SHALL support encryption and decryption of data accessed on remote
+[MySQL] servers using [MySQL Dictionary].
+
+#### RQ.SRS008.AES.Functions.Compatability.Engine.Database.MySQL
+version: 1.0
+
+[ClickHouse] SHALL support encryption and decryption of data accessed using [MySQL Database Engine],
+
+#### RQ.SRS008.AES.Functions.Compatability.Engine.Table.MySQL
+version: 1.0
+
+[ClickHouse] SHALL support encryption and decryption of data accessed using [MySQL Table Engine].
+
+#### RQ.SRS008.AES.Functions.Compatability.TableFunction.MySQL
+version: 1.0
+
+[ClickHouse] SHALL support encryption and decryption of data accessed using [MySQL Table Function].
+
+#### RQ.SRS008.AES.Functions.DifferentModes
+version: 1.0
+
+[ClickHouse] SHALL allow different modes to be supported in a single SQL statement
+using explicit function parameters.
+
+#### RQ.SRS008.AES.Functions.DataFromMultipleSources
+version: 1.0
+
+[ClickHouse] SHALL support handling encryption and decryption of data from multiple sources
+in the `SELECT` statement, including [ClickHouse] [MergeTree] table as well as [MySQL Dictionary],
+[MySQL Database Engine], [MySQL Table Engine], and [MySQL Table Function]
+with possibly different encryption schemes.
+
+#### RQ.SRS008.AES.Functions.SuppressOutputOfSensitiveValues
+version: 1.0
+
+[ClickHouse] SHALL suppress output of [AES] `string` and `key` parameters to the system log,
+error log, and `query_log` table to prevent leakage of sensitive values.
+
+#### RQ.SRS008.AES.Functions.InvalidParameters
+version: 1.0
+
+[ClickHouse] SHALL return an error when parameters are invalid.
+
+#### RQ.SRS008.AES.Functions.Mismatched.Key
+version: 1.0
+
+[ClickHouse] SHALL return garbage for mismatched keys.
+
+#### RQ.SRS008.AES.Functions.Mismatched.IV
+version: 1.0
+
+[ClickHouse] SHALL return garbage for mismatched initialization vector for the modes that use it.
+
+#### RQ.SRS008.AES.Functions.Mismatched.AAD
+version: 1.0
+
+[ClickHouse] SHALL return garbage for mismatched additional authentication data for the modes that use it.
+
+#### RQ.SRS008.AES.Functions.Mismatched.Mode
+version: 1.0
+
+[ClickHouse] SHALL return an error or garbage for mismatched mode.
+
+#### RQ.SRS008.AES.Functions.Check.Performance
+version: 1.0
+
+Performance of [AES] encryption functions SHALL be measured.
+
+#### RQ.SRS008.AES.Function.Check.Performance.BestCase
+version: 1.0
+
+Performance of [AES] encryption functions SHALL be checked for the best case
+scenario where there is one key, one initialization vector, and one large stream of data.
+
+#### RQ.SRS008.AES.Function.Check.Performance.WorstCase
+version: 1.0
+
+Performance of [AES] encryption functions SHALL be checked for the worst case
+where there are `N` keys, `N` initialization vectors and `N` very small streams of data.
+
+#### RQ.SRS008.AES.Functions.Check.Compression
+version: 1.0
+
+Effect of [AES] encryption on column compression SHALL be measured.
+
+#### RQ.SRS008.AES.Functions.Check.Compression.LowCardinality
+version: 1.0
+
+Effect of [AES] encryption on the compression of a column with [LowCardinality] data type
+SHALL be measured.
+
+### Specific
+
+#### RQ.SRS008.AES.Encrypt.Function
+version: 1.0
+
+[ClickHouse] SHALL support `aes_encrypt` function to encrypt data using [AES].
+
+#### RQ.SRS008.AES.Encrypt.Function.Syntax
+version: 1.0
+
+[ClickHouse] SHALL support the following syntax for the `aes_encrypt` function
+
+```sql
+aes_encrypt(plaintext, key, mode, [iv, aad])
+```
+
+#### RQ.SRS008.AES.Encrypt.Function.NIST.TestVectors
+version: 1.0
+
+[ClickHouse] `aes_encrypt` function output SHALL produce output that matches [NIST test vectors].
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.PlainText
+version: 1.0
+
+[ClickHouse] SHALL support `plaintext` accepting any data type as
+the first parameter to the `aes_encrypt` function that SHALL specify the data to be encrypted.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Key
+version: 1.0
+
+[ClickHouse] SHALL support `key` with `String` or `FixedString` data types
+as the second parameter to the `aes_encrypt` function that SHALL specify the encryption key.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode
+version: 1.0
+
+[ClickHouse] SHALL support `mode` with `String` or `FixedString` data types as the third parameter
+to the `aes_encrypt` function that SHALL specify encryption key length and block encryption mode.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.ValuesFormat
+version: 1.0
+
+[ClickHouse] SHALL support values of the form `aes-[key length]-[mode]` for the `mode` parameter
+of the `aes_encrypt` function where
+the `key_length` SHALL specifies the length of the key and SHALL accept
+`128`, `192`, or `256` as the values and the `mode` SHALL specify the block encryption
+mode and SHALL accept [ECB], [CBC], [CFB1], [CFB8], [CFB128], or [OFB] as well as
+[CTR] and [GCM] as the values. For example, `aes-256-ofb`.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.Invalid
+version: 1.0
+
+[ClickHouse] SHALL return an error if the specified value for the `mode` parameter of the `aes_encrypt`
+function is not valid with the exception where such a mode is supported by the underlying
+[OpenSSL] implementation.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-128-ECB
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-ecb` as the value for the `mode` parameter of the `aes_encrypt` function
+and [AES] algorithm SHALL use the [ECB] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-192-ECB
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-ecb` as the value for the `mode` parameter of the `aes_encrypt` function
+and [AES] algorithm SHALL use the [ECB] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-256-ECB
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-ecb` as the value for the `mode` parameter of the `aes_encrypt` function
+and [AES] algorithm SHALL use the [ECB] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-128-CBC
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-cbc` as the value for the `mode` parameter of the `aes_encrypt` function
+and [AES] algorithm SHALL use the [CBC] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-192-CBC
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-cbc` as the value for the `mode` parameter of the `aes_encrypt` function
+and [AES] algorithm SHALL use the [CBC] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-256-CBC
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-cbc` as the value for the `mode` parameter of the `aes_encrypt` function
+and [AES] algorithm SHALL use the [CBC] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-128-CFB1
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-cfb1` as the value for the `mode` parameter of the `aes_encrypt` function
+and [AES] algorithm SHALL use the [CFB1] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-192-CFB1
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-cfb1` as the value for the `mode` parameter of the `aes_encrypt` function
+and [AES] algorithm SHALL use the [CFB1] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-256-CFB1
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-cfb1` as the value for the `mode` parameter of the `aes_encrypt` function
+and [AES] algorithm SHALL use the [CFB1] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-128-CFB8
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-cfb8` as the value for the `mode` parameter of the `aes_encrypt` function
+and [AES] algorithm SHALL use the [CFB8] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-192-CFB8
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-cfb8` as the value for the `mode` parameter of the `aes_encrypt` function
+and [AES] algorithm SHALL use the [CFB8] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-256-CFB8
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-cfb8` as the value for the `mode` parameter of the `aes_encrypt` function
+and [AES] algorithm SHALL use the [CFB8] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-128-CFB128
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-cfb128` as the value for the `mode` parameter of the `aes_encrypt` function
+and [AES] algorithm SHALL use the [CFB128] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-192-CFB128
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-cfb128` as the value for the `mode` parameter of the `aes_encrypt` function
+and [AES] algorithm SHALL use the [CFB128] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-256-CFB128
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-cfb128` as the value for the `mode` parameter of the `aes_encrypt` function
+and [AES] algorithm SHALL use the [CFB128] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-128-OFB
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-ofb` as the value for the `mode` parameter of the `aes_encrypt` function
+and [AES] algorithm SHALL use the [OFB] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-192-OFB
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-ofb` as the value for the `mode` parameter of the `aes_encrypt` function
+and [AES] algorithm SHALL use the [OFB] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-256-OFB
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-ofb` as the value for the `mode` parameter of the `aes_encrypt` function
+and [AES] algorithm SHALL use the [OFB] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-128-GCM
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-gcm` as the value for the `mode` parameter of the `aes_encrypt` function
+and [AES] algorithm SHALL use the [GCM] block mode encryption with a 128 bit key.
+An `AEAD` 16-byte tag is appended to the resulting ciphertext according to
+the [RFC5116].
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-192-GCM
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-gcm` as the value for the `mode` parameter of the `aes_encrypt` function
+and [AES] algorithm SHALL use the [GCM] block mode encryption with a 192 bit key.
+An `AEAD` 16-byte tag is appended to the resulting ciphertext according to
+the [RFC5116].
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-256-GCM
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-gcm` as the value for the `mode` parameter of the `aes_encrypt` function
+and [AES] algorithm SHALL use the [GCM] block mode encryption with a 256 bit key.
+An `AEAD` 16-byte tag is appended to the resulting ciphertext according to
+the [RFC5116].
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-128-CTR
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-ctr` as the value for the `mode` parameter of the `aes_encrypt` function
+and [AES] algorithm SHALL use the [CTR] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-192-CTR
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-ctr` as the value for the `mode` parameter of the `aes_encrypt` function
+and [AES] algorithm SHALL use the [CTR] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-256-CTR
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-ctr` as the value for the `mode` parameter of the `aes_encrypt` function
+and [AES] algorithm SHALL use the [CTR] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.InitializationVector
+version: 1.0
+
+[ClickHouse] SHALL support `iv` with `String` or `FixedString` data types as the optional fourth
+parameter to the `aes_encrypt` function that SHALL specify the initialization vector for block modes that require
+it.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.AdditionalAuthenticatedData
+version: 1.0
+
+[ClickHouse] SHALL support `aad` with `String` or `FixedString` data types as the optional fifth
+parameter to the `aes_encrypt` function that SHALL specify the additional authenticated data
+for block modes that require it.
+
+#### RQ.SRS008.AES.Encrypt.Function.Parameters.ReturnValue
+version: 1.0
+
+[ClickHouse] SHALL return the encrypted value of the data
+using `String` data type as the result of `aes_encrypt` function.
+
+#### RQ.SRS008.AES.Encrypt.Function.Key.Length.InvalidLengthError
+version: 1.0
+
+[ClickHouse] SHALL return an error if the `key` length is not exact for the `aes_encrypt` function for a given block mode.
+
+#### RQ.SRS008.AES.Encrypt.Function.InitializationVector.Length.InvalidLengthError
+version: 1.0
+
+[ClickHouse] SHALL return an error if the `iv` length is specified and not of the exact size for the `aes_encrypt` function for a given block mode.
+
+#### RQ.SRS008.AES.Encrypt.Function.InitializationVector.NotValidForMode
+version: 1.0
+
+[ClickHouse] SHALL return an error if the `iv` is specified for the `aes_encrypt` function for a mode that does not need it.
+
+#### RQ.SRS008.AES.Encrypt.Function.AdditionalAuthenticationData.NotValidForMode
+version: 1.0
+
+[ClickHouse] SHALL return an error if the `aad` is specified for the `aes_encrypt` function for a mode that does not need it.
+
+#### RQ.SRS008.AES.Encrypt.Function.AdditionalAuthenticationData.Length
+version: 1.0
+
+[ClickHouse] SHALL not limit the size of the `aad` parameter passed to the `aes_encrypt` function.
+
+#### RQ.SRS008.AES.Encrypt.Function.AES-128-ECB.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-128-ecb` and `key` is not 16 bytes
+or `iv` or `aad` is specified.
+
+#### RQ.SRS008.AES.Encrypt.Function.AES-192-ECB.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-192-ecb` and `key` is not 24 bytes
+or `iv` or `aad` is specified.
+
+#### RQ.SRS008.AES.Encrypt.Function.AES-256-ECB.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-256-ecb` and `key` is not 32 bytes
+or `iv` or `aad` is specified.
+
+#### RQ.SRS008.AES.Encrypt.Function.AES-128-CBC.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-128-cbc` and `key` is not 16 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Encrypt.Function.AES-192-CBC.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-192-cbc` and `key` is not 24 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Encrypt.Function.AES-256-CBC.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-256-cbc` and `key` is not 32 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Encrypt.Function.AES-128-CFB1.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-128-cfb1` and `key` is not 16 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Encrypt.Function.AES-192-CFB1.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-192-cfb1` and `key` is not 24 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Encrypt.Function.AES-256-CFB1.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-256-cfb1` and `key` is not 32 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Encrypt.Function.AES-128-CFB8.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-128-cfb8` and `key` is not 16 bytes
+and if specified `iv` is not 16 bytes.
+
+#### RQ.SRS008.AES.Encrypt.Function.AES-192-CFB8.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-192-cfb8` and `key` is not 24 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Encrypt.Function.AES-256-CFB8.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-256-cfb8` and `key` is not 32 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Encrypt.Function.AES-128-CFB128.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-128-cfb128` and `key` is not 16 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Encrypt.Function.AES-192-CFB128.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-192-cfb128` and `key` is not 24 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Encrypt.Function.AES-256-CFB128.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-256-cfb128` and `key` is not 32 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Encrypt.Function.AES-128-OFB.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-128-ofb` and `key` is not 16 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Encrypt.Function.AES-192-OFB.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-192-ofb` and `key` is not 24 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Encrypt.Function.AES-256-OFB.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-256-ofb` and `key` is not 32 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Encrypt.Function.AES-128-GCM.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-128-gcm` and `key` is not 16 bytes
+or `iv` is not specified or is less than 8 bytes.
+
+#### RQ.SRS008.AES.Encrypt.Function.AES-192-GCM.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-192-gcm` and `key` is not 24 bytes
+or `iv` is not specified or is less than 8 bytes.
+
+#### RQ.SRS008.AES.Encrypt.Function.AES-256-GCM.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-256-gcm` and `key` is not 32 bytes
+or `iv` is not specified or is less than 8 bytes.
+
+#### RQ.SRS008.AES.Encrypt.Function.AES-128-CTR.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-128-ctr` and `key` is not 16 bytes
+or if specified `iv` is not 16 bytes.
+
+#### RQ.SRS008.AES.Encrypt.Function.AES-192-CTR.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-192-ctr` and `key` is not 24 bytes
+or if specified `iv` is not 16 bytes.
+
+#### RQ.SRS008.AES.Encrypt.Function.AES-256-CTR.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-256-ctr` and `key` is not 32 bytes
+or if specified `iv` is not 16 bytes.
+
+#### RQ.SRS008.AES.Decrypt.Function
+version: 1.0
+
+[ClickHouse] SHALL support `aes_decrypt` function to decrypt data using [AES].
+
+#### RQ.SRS008.AES.Decrypt.Function.Syntax
+version: 1.0
+
+[ClickHouse] SHALL support the following syntax for the `aes_decrypt` function
+
+```sql
+aes_decrypt(ciphertext, key, mode, [iv, aad])
+```
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.CipherText
+version: 1.0
+
+[ClickHouse] SHALL support `ciphertext` accepting `FixedString` or `String` data types as
+the first parameter to the `aes_decrypt` function that SHALL specify the data to be decrypted.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Key
+version: 1.0
+
+[ClickHouse] SHALL support `key` with `String` or `FixedString` data types
+as the second parameter to the `aes_decrypt` function that SHALL specify the encryption key.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode
+version: 1.0
+
+[ClickHouse] SHALL support `mode` with `String` or `FixedString` data types as the third parameter
+to the `aes_decrypt` function that SHALL specify encryption key length and block encryption mode.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.ValuesFormat
+version: 1.0
+
+[ClickHouse] SHALL support values of the form `aes-[key length]-[mode]` for the `mode` parameter
+of the `aes_decrypt` function where
+the `key_length` SHALL specifies the length of the key and SHALL accept
+`128`, `192`, or `256` as the values and the `mode` SHALL specify the block encryption
+mode and SHALL accept [ECB], [CBC], [CFB1], [CFB8], [CFB128], or [OFB] as well as
+[CTR] and [GCM] as the values. For example, `aes-256-ofb`.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.Invalid
+version: 1.0
+
+[ClickHouse] SHALL return an error if the specified value for the `mode` parameter of the `aes_decrypt`
+function is not valid with the exception where such a mode is supported by the underlying
+[OpenSSL] implementation.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-128-ECB
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-ecb` as the value for the `mode` parameter of the `aes_decrypt` function
+and [AES] algorithm SHALL use the [ECB] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-192-ECB
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-ecb` as the value for the `mode` parameter of the `aes_decrypt` function
+and [AES] algorithm SHALL use the [ECB] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-256-ECB
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-ecb` as the value for the `mode` parameter of the `aes_decrypt` function
+and [AES] algorithm SHALL use the [ECB] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-128-CBC
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-cbc` as the value for the `mode` parameter of the `aes_decrypt` function
+and [AES] algorithm SHALL use the [CBC] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-192-CBC
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-cbc` as the value for the `mode` parameter of the `aes_decrypt` function
+and [AES] algorithm SHALL use the [CBC] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-256-CBC
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-cbc` as the value for the `mode` parameter of the `aes_decrypt` function
+and [AES] algorithm SHALL use the [CBC] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-128-CFB1
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-cfb1` as the value for the `mode` parameter of the `aes_decrypt` function
+and [AES] algorithm SHALL use the [CFB1] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-192-CFB1
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-cfb1` as the value for the `mode` parameter of the `aes_decrypt` function
+and [AES] algorithm SHALL use the [CFB1] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-256-CFB1
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-cfb1` as the value for the `mode` parameter of the `aes_decrypt` function
+and [AES] algorithm SHALL use the [CFB1] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-128-CFB8
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-cfb8` as the value for the `mode` parameter of the `aes_decrypt` function
+and [AES] algorithm SHALL use the [CFB8] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-192-CFB8
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-cfb8` as the value for the `mode` parameter of the `aes_decrypt` function
+and [AES] algorithm SHALL use the [CFB8] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-256-CFB8
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-cfb8` as the value for the `mode` parameter of the `aes_decrypt` function
+and [AES] algorithm SHALL use the [CFB8] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-128-CFB128
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-cfb128` as the value for the `mode` parameter of the `aes_decrypt` function
+and [AES] algorithm SHALL use the [CFB128] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-192-CFB128
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-cfb128` as the value for the `mode` parameter of the `aes_decrypt` function
+and [AES] algorithm SHALL use the [CFB128] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-256-CFB128
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-cfb128` as the value for the `mode` parameter of the `aes_decrypt` function
+and [AES] algorithm SHALL use the [CFB128] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-128-OFB
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-ofb` as the value for the `mode` parameter of the `aes_decrypt` function
+and [AES] algorithm SHALL use the [OFB] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-192-OFB
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-ofb` as the value for the `mode` parameter of the `aes_decrypt` function
+and [AES] algorithm SHALL use the [OFB] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-256-OFB
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-ofb` as the value for the `mode` parameter of the `aes_decrypt` function
+and [AES] algorithm SHALL use the [OFB] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-128-GCM
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-gcm` as the value for the `mode` parameter of the `aes_decrypt` function
+and [AES] algorithm SHALL use the [GCM] block mode encryption with a 128 bit key.
+An [AEAD] 16-byte tag is expected present at the end of the ciphertext according to
+the [RFC5116].
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-192-GCM
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-gcm` as the value for the `mode` parameter of the `aes_decrypt` function
+and [AES] algorithm SHALL use the [GCM] block mode encryption with a 192 bit key.
+An [AEAD] 16-byte tag is expected present at the end of the ciphertext according to
+the [RFC5116].
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-256-GCM
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-gcm` as the value for the `mode` parameter of the `aes_decrypt` function
+and [AES] algorithm SHALL use the [GCM] block mode encryption with a 256 bit key.
+An [AEAD] 16-byte tag is expected present at the end of the ciphertext according to
+the [RFC5116].
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-128-CTR
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-ctr` as the value for the `mode` parameter of the `aes_decrypt` function
+and [AES] algorithm SHALL use the [CTR] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-192-CTR
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-ctr` as the value for the `mode` parameter of the `aes_decrypt` function
+and [AES] algorithm SHALL use the [CTR] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-256-CTR
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-ctr` as the value for the `mode` parameter of the `aes_decrypt` function
+and [AES] algorithm SHALL use the [CTR] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.InitializationVector
+version: 1.0
+
+[ClickHouse] SHALL support `iv` with `String` or `FixedString` data types as the optional fourth
+parameter to the `aes_decrypt` function that SHALL specify the initialization vector for block modes that require
+it.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.AdditionalAuthenticatedData
+version: 1.0
+
+[ClickHouse] SHALL support `aad` with `String` or `FixedString` data types as the optional fifth
+parameter to the `aes_decrypt` function that SHALL specify the additional authenticated data
+for block modes that require it.
+
+#### RQ.SRS008.AES.Decrypt.Function.Parameters.ReturnValue
+version: 1.0
+
+[ClickHouse] SHALL return the decrypted value of the data
+using `String` data type as the result of `aes_decrypt` function.
+
+#### RQ.SRS008.AES.Decrypt.Function.Key.Length.InvalidLengthError
+version: 1.0
+
+[ClickHouse] SHALL return an error if the `key` length is not exact for the `aes_decrypt` function for a given block mode.
+
+#### RQ.SRS008.AES.Decrypt.Function.InitializationVector.Length.InvalidLengthError
+version: 1.0
+
+[ClickHouse] SHALL return an error if the `iv` is speficified and the length is not exact for the `aes_decrypt` function for a given block mode.
+
+#### RQ.SRS008.AES.Decrypt.Function.InitializationVector.NotValidForMode
+version: 1.0
+
+[ClickHouse] SHALL return an error if the `iv` is specified for the `aes_decrypt` function
+for a mode that does not need it.
+
+#### RQ.SRS008.AES.Decrypt.Function.AdditionalAuthenticationData.NotValidForMode
+version: 1.0
+
+[ClickHouse] SHALL return an error if the `aad` is specified for the `aes_decrypt` function
+for a mode that does not need it.
+
+#### RQ.SRS008.AES.Decrypt.Function.AdditionalAuthenticationData.Length
+version: 1.0
+
+[ClickHouse] SHALL not limit the size of the `aad` parameter passed to the `aes_decrypt` function.
+
+#### RQ.SRS008.AES.Decrypt.Function.AES-128-ECB.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-128-ecb` and `key` is not 16 bytes
+or `iv` or `aad` is specified.
+
+#### RQ.SRS008.AES.Decrypt.Function.AES-192-ECB.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-192-ecb` and `key` is not 24 bytes
+or `iv` or `aad` is specified.
+
+#### RQ.SRS008.AES.Decrypt.Function.AES-256-ECB.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-256-ecb` and `key` is not 32 bytes
+or `iv` or `aad` is specified.
+
+#### RQ.SRS008.AES.Decrypt.Function.AES-128-CBC.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-128-cbc` and `key` is not 16 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Decrypt.Function.AES-192-CBC.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-192-cbc` and `key` is not 24 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Decrypt.Function.AES-256-CBC.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-256-cbc` and `key` is not 32 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Decrypt.Function.AES-128-CFB1.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-128-cfb1` and `key` is not 16 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Decrypt.Function.AES-192-CFB1.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-192-cfb1` and `key` is not 24 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Decrypt.Function.AES-256-CFB1.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-256-cfb1` and `key` is not 32 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Decrypt.Function.AES-128-CFB8.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-128-cfb8` and `key` is not 16 bytes
+and if specified `iv` is not 16 bytes.
+
+#### RQ.SRS008.AES.Decrypt.Function.AES-192-CFB8.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-192-cfb8` and `key` is not 24 bytes
+or `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Decrypt.Function.AES-256-CFB8.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-256-cfb8` and `key` is not 32 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Decrypt.Function.AES-128-CFB128.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-128-cfb128` and `key` is not 16 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Decrypt.Function.AES-192-CFB128.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-192-cfb128` and `key` is not 24 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Decrypt.Function.AES-256-CFB128.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-256-cfb128` and `key` is not 32 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Decrypt.Function.AES-128-OFB.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-128-ofb` and `key` is not 16 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Decrypt.Function.AES-192-OFB.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-192-ofb` and `key` is not 24 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Decrypt.Function.AES-256-OFB.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-256-ofb` and `key` is not 32 bytes
+or if specified `iv` is not 16 bytes or `aad` is specified.
+
+#### RQ.SRS008.AES.Decrypt.Function.AES-128-GCM.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-128-gcm` and `key` is not 16 bytes
+or `iv` is not specified or is less than 8 bytes.
+
+#### RQ.SRS008.AES.Decrypt.Function.AES-192-GCM.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-192-gcm` and `key` is not 24 bytes
+or `iv` is not specified or is less than 8 bytes.
+
+#### RQ.SRS008.AES.Decrypt.Function.AES-256-GCM.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-256-gcm` and `key` is not 32 bytes
+or `iv` is not specified or is less than 8 bytes.
+
+#### RQ.SRS008.AES.Decrypt.Function.AES-128-CTR.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-128-ctr` and `key` is not 16 bytes
+or if specified `iv` is not 16 bytes.
+
+#### RQ.SRS008.AES.Decrypt.Function.AES-192-CTR.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-192-ctr` and `key` is not 24 bytes
+or if specified `iv` is not 16 bytes.
+
+#### RQ.SRS008.AES.Decrypt.Function.AES-256-CTR.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-256-ctr` and `key` is not 32 bytes
+or if specified `iv` is not 16 bytes.
+
+### MySQL Specific Functions
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function
+version: 1.0
+
+[ClickHouse] SHALL support `aes_encrypt_mysql` function to encrypt data using [AES].
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Syntax
+version: 1.0
+
+[ClickHouse] SHALL support the following syntax for the `aes_encrypt_mysql` function
+
+```sql
+aes_encrypt_mysql(plaintext, key, mode, [iv])
+```
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.PlainText
+version: 1.0
+
+[ClickHouse] SHALL support `plaintext` accepting any data type as
+the first parameter to the `aes_encrypt_mysql` function that SHALL specify the data to be encrypted.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Key
+version: 1.0
+
+[ClickHouse] SHALL support `key` with `String` or `FixedString` data types
+as the second parameter to the `aes_encrypt_mysql` function that SHALL specify the encryption key.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode
+version: 1.0
+
+[ClickHouse] SHALL support `mode` with `String` or `FixedString` data types as the third parameter
+to the `aes_encrypt_mysql` function that SHALL specify encryption key length and block encryption mode.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.ValuesFormat
+version: 1.0
+
+[ClickHouse] SHALL support values of the form `aes-[key length]-[mode]` for the `mode` parameter
+of the `aes_encrypt_mysql` function where
+the `key_length` SHALL specifies the length of the key and SHALL accept
+`128`, `192`, or `256` as the values and the `mode` SHALL specify the block encryption
+mode and SHALL accept [ECB], [CBC], [CFB1], [CFB8], [CFB128], or [OFB]. For example, `aes-256-ofb`.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.Invalid
+version: 1.0
+
+[ClickHouse] SHALL return an error if the specified value for the `mode` parameter of the `aes_encrypt_mysql`
+function is not valid with the exception where such a mode is supported by the underlying
+[OpenSSL] implementation.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-128-ECB
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-ecb` as the value for the `mode` parameter of the `aes_encrypt_mysql` function
+and [AES] algorithm SHALL use the [ECB] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-192-ECB
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-ecb` as the value for the `mode` parameter of the `aes_encrypt_mysql` function
+and [AES] algorithm SHALL use the [ECB] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-256-ECB
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-ecb` as the value for the `mode` parameter of the `aes_encrypt_mysql` function
+and [AES] algorithm SHALL use the [ECB] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-128-CBC
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-cbc` as the value for the `mode` parameter of the `aes_encrypt_mysql` function
+and [AES] algorithm SHALL use the [CBC] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-192-CBC
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-cbc` as the value for the `mode` parameter of the `aes_encrypt_mysql` function
+and [AES] algorithm SHALL use the [CBC] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-256-CBC
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-cbc` as the value for the `mode` parameter of the `aes_encrypt_mysql` function
+and [AES] algorithm SHALL use the [CBC] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-128-CFB1
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-cfb1` as the value for the `mode` parameter of the `aes_encrypt_mysql` function
+and [AES] algorithm SHALL use the [CFB1] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-192-CFB1
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-cfb1` as the value for the `mode` parameter of the `aes_encrypt_mysql` function
+and [AES] algorithm SHALL use the [CFB1] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-256-CFB1
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-cfb1` as the value for the `mode` parameter of the `aes_encrypt_mysql` function
+and [AES] algorithm SHALL use the [CFB1] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-128-CFB8
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-cfb8` as the value for the `mode` parameter of the `aes_encrypt_mysql` function
+and [AES] algorithm SHALL use the [CFB8] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-192-CFB8
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-cfb8` as the value for the `mode` parameter of the `aes_encrypt_mysql` function
+and [AES] algorithm SHALL use the [CFB8] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-256-CFB8
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-cfb8` as the value for the `mode` parameter of the `aes_encrypt_mysql` function
+and [AES] algorithm SHALL use the [CFB8] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-128-CFB128
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-cfb128` as the value for the `mode` parameter of the `aes_encrypt_mysql` function
+and [AES] algorithm SHALL use the [CFB128] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-192-CFB128
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-cfb128` as the value for the `mode` parameter of the `aes_encrypt_mysql` function
+and [AES] algorithm SHALL use the [CFB128] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-256-CFB128
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-cfb128` as the value for the `mode` parameter of the `aes_encrypt_mysql` function
+and [AES] algorithm SHALL use the [CFB128] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-128-OFB
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-ofb` as the value for the `mode` parameter of the `aes_encrypt_mysql` function
+and [AES] algorithm SHALL use the [OFB] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-192-OFB
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-ofb` as the value for the `mode` parameter of the `aes_encrypt_mysql` function
+and [AES] algorithm SHALL use the [OFB] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-256-OFB
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-ofb` as the value for the `mode` parameter of the `aes_encrypt_mysql` function
+and [AES] algorithm SHALL use the [OFB] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-128-GCM.Error
+version: 1.0
+
+[ClickHouse] SHALL return an error if `aes-128-gcm` is specified as the value for the `mode` parameter of the
+`aes_encrypt_mysql` function.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-192-GCM.Error
+version: 1.0
+
+[ClickHouse] SHALL return an error if `aes-192-gcm` is specified as the value for the `mode` parameter of the
+`aes_encrypt_mysql` function.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-256-GCM.Error
+version: 1.0
+
+[ClickHouse] SHALL return an error if `aes-256-gcm` is specified as the value for the `mode` parameter of the
+`aes_encrypt_mysql` function.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-128-CTR.Error
+version: 1.0
+
+[ClickHouse] SHALL return an error if `aes-128-ctr` is specified as the value for the `mode` parameter of the
+`aes_encrypt_mysql` function.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-192-CTR.Error
+version: 1.0
+
+[ClickHouse] SHALL return an error if `aes-192-ctr` is specified as the value for the `mode` parameter of the
+`aes_encrypt_mysql` function.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-256-CTR.Error
+version: 1.0
+
+[ClickHouse] SHALL return an error if `aes-256-ctr` is specified as the value for the `mode` parameter of the
+`aes_encrypt_mysql` function.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.InitializationVector
+version: 1.0
+
+[ClickHouse] SHALL support `iv` with `String` or `FixedString` data types as the optional fourth
+parameter to the `aes_encrypt_mysql` function that SHALL specify the initialization vector for block modes that require
+it.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.ReturnValue
+version: 1.0
+
+[ClickHouse] SHALL return the encrypted value of the data
+using `String` data type as the result of `aes_encrypt_mysql` function.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Key.Length.TooShortError
+version: 1.0
+
+[ClickHouse] SHALL return an error if the `key` length is less than the minimum for the `aes_encrypt_mysql`
+function for a given block mode.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.Key.Length.TooLong
+version: 1.0
+
+[ClickHouse] SHALL use folding algorithm specified below if the `key` length is longer than required
+for the `aes_encrypt_mysql` function for a given block mode.
+
+```python
+def fold_key(key, cipher_key_size):
+    key = list(key) if not isinstance(key, (list, tuple)) else key
+	  folded_key = key[:cipher_key_size]
+	  for i in range(cipher_key_size, len(key)):
+		    print(i % cipher_key_size, i)
+		    folded_key[i % cipher_key_size] ^= key[i]
+	  return folded_key
+```
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.InitializationVector.Length.TooShortError
+version: 1.0
+
+[ClickHouse] SHALL return an error if the `iv` length is specified and is less than the minimum
+that is required for the `aes_encrypt_mysql` function for a given block mode.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.InitializationVector.Length.TooLong
+version: 1.0
+
+[ClickHouse] SHALL use the first `N` bytes that are required if the `iv` is specified and
+its length is longer than required for the `aes_encrypt_mysql` function for a given block mode.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.InitializationVector.NotValidForMode
+version: 1.0
+
+[ClickHouse] SHALL return an error if the `iv` is specified for the `aes_encrypt_mysql`
+function for a mode that does not need it.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.AES-128-ECB.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-128-ecb` and `key` is less than 16 bytes
+or `iv` is specified.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.AES-192-ECB.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-192-ecb` and `key` is less than 24 bytes
+or `iv` is specified.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.AES-256-ECB.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-256-ecb` and `key` is less than 32 bytes
+or `iv` is specified.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.AES-128-CBC.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-128-cbc` and `key` is less than 16 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.AES-192-CBC.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-192-cbc` and `key` is less than 24 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.AES-256-CBC.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-256-cbc` and `key` is less than 32 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.AES-128-CFB1.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-128-cfb1` and `key` is less than 16 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.AES-192-CFB1.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-192-cfb1` and `key` is less than 24 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.AES-256-CFB1.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-256-cfb1` and `key` is less than 32 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.AES-128-CFB8.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-128-cfb8` and `key` is less than 16 bytes
+and if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.AES-192-CFB8.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-192-cfb8` and `key` is less than 24 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.AES-256-CFB8.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-256-cfb8` and `key` is less than 32 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.AES-128-CFB128.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-128-cfb128` and `key` is less than 16 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.AES-192-CFB128.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-192-cfb128` and `key` is less than 24 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.AES-256-CFB128.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-256-cfb128` and `key` is less than 32 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.AES-128-OFB.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-128-ofb` and `key` is less than 16 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.AES-192-OFB.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-192-ofb` and `key` is less than 24 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Encrypt.Function.AES-256-OFB.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-256-ofb` and `key` is less than 32 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function
+version: 1.0
+
+[ClickHouse] SHALL support `aes_decrypt_mysql` function to decrypt data using [AES].
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Syntax
+version: 1.0
+
+[ClickHouse] SHALL support the following syntax for the `aes_decrypt_mysql` function
+
+```sql
+aes_decrypt_mysql(ciphertext, key, mode, [iv])
+```
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.CipherText
+version: 1.0
+
+[ClickHouse] SHALL support `ciphertext` accepting any data type as
+the first parameter to the `aes_decrypt_mysql` function that SHALL specify the data to be decrypted.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Key
+version: 1.0
+
+[ClickHouse] SHALL support `key` with `String` or `FixedString` data types
+as the second parameter to the `aes_decrypt_mysql` function that SHALL specify the encryption key.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode
+version: 1.0
+
+[ClickHouse] SHALL support `mode` with `String` or `FixedString` data types as the third parameter
+to the `aes_decrypt_mysql` function that SHALL specify encryption key length and block encryption mode.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.ValuesFormat
+version: 1.0
+
+[ClickHouse] SHALL support values of the form `aes-[key length]-[mode]` for the `mode` parameter
+of the `aes_decrypt_mysql` function where
+the `key_length` SHALL specifies the length of the key and SHALL accept
+`128`, `192`, or `256` as the values and the `mode` SHALL specify the block encryption
+mode and SHALL accept [ECB], [CBC], [CFB1], [CFB8], [CFB128], or [OFB]. For example, `aes-256-ofb`.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.Invalid
+version: 1.0
+
+[ClickHouse] SHALL return an error if the specified value for the `mode` parameter of the `aes_decrypt_mysql`
+function is not valid with the exception where such a mode is supported by the underlying
+[OpenSSL] implementation.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-128-ECB
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-ecb` as the value for the `mode` parameter of the `aes_decrypt_mysql` function
+and [AES] algorithm SHALL use the [ECB] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-192-ECB
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-ecb` as the value for the `mode` parameter of the `aes_decrypt_mysql` function
+and [AES] algorithm SHALL use the [ECB] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-256-ECB
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-ecb` as the value for the `mode` parameter of the `aes_decrypt_mysql` function
+and [AES] algorithm SHALL use the [ECB] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-128-CBC
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-cbc` as the value for the `mode` parameter of the `aes_decrypt_mysql` function
+and [AES] algorithm SHALL use the [CBC] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-192-CBC
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-cbc` as the value for the `mode` parameter of the `aes_decrypt_mysql` function
+and [AES] algorithm SHALL use the [CBC] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-256-CBC
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-cbc` as the value for the `mode` parameter of the `aes_decrypt_mysql` function
+and [AES] algorithm SHALL use the [CBC] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-128-CFB1
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-cfb1` as the value for the `mode` parameter of the `aes_decrypt_mysql` function
+and [AES] algorithm SHALL use the [CFB1] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-192-CFB1
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-cfb1` as the value for the `mode` parameter of the `aes_decrypt_mysql` function
+and [AES] algorithm SHALL use the [CFB1] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-256-CFB1
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-cfb1` as the value for the `mode` parameter of the `aes_decrypt_mysql` function
+and [AES] algorithm SHALL use the [CFB1] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-128-CFB8
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-cfb8` as the value for the `mode` parameter of the `aes_decrypt_mysql` function
+and [AES] algorithm SHALL use the [CFB8] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-192-CFB8
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-cfb8` as the value for the `mode` parameter of the `aes_decrypt_mysql` function
+and [AES] algorithm SHALL use the [CFB8] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-256-CFB8
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-cfb8` as the value for the `mode` parameter of the `aes_decrypt_mysql` function
+and [AES] algorithm SHALL use the [CFB8] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-128-CFB128
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-cfb128` as the value for the `mode` parameter of the `aes_decrypt_mysql` function
+and [AES] algorithm SHALL use the [CFB128] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-192-CFB128
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-cfb128` as the value for the `mode` parameter of the `aes_decrypt_mysql` function
+and [AES] algorithm SHALL use the [CFB128] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-256-CFB128
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-cfb128` as the value for the `mode` parameter of the `aes_decrypt_mysql` function
+and [AES] algorithm SHALL use the [CFB128] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-128-OFB
+version: 1.0
+
+[ClickHouse] SHALL support `aes-128-ofb` as the value for the `mode` parameter of the `aes_decrypt_mysql` function
+and [AES] algorithm SHALL use the [OFB] block mode encryption with a 128 bit key.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-192-OFB
+version: 1.0
+
+[ClickHouse] SHALL support `aes-192-ofb` as the value for the `mode` parameter of the `aes_decrypt_mysql` function
+and [AES] algorithm SHALL use the [OFB] block mode encryption with a 192 bit key.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-256-OFB
+version: 1.0
+
+[ClickHouse] SHALL support `aes-256-ofb` as the value for the `mode` parameter of the `aes_decrypt_mysql` function
+and [AES] algorithm SHALL use the [OFB] block mode encryption with a 256 bit key.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-128-GCM.Error
+version: 1.0
+
+[ClickHouse] SHALL return an error if `aes-128-gcm` is specified as the value for the `mode` parameter of the
+`aes_decrypt_mysql` function.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-192-GCM.Error
+version: 1.0
+
+[ClickHouse] SHALL return an error if `aes-192-gcm` is specified as the value for the `mode` parameter of the
+`aes_decrypt_mysql` function.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-256-GCM.Error
+version: 1.0
+
+[ClickHouse] SHALL return an error if `aes-256-gcm` is specified as the value for the `mode` parameter of the
+`aes_decrypt_mysql` function.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-128-CTR.Error
+version: 1.0
+
+[ClickHouse] SHALL return an error if `aes-128-ctr` is specified as the value for the `mode` parameter of the
+`aes_decrypt_mysql` function.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-192-CTR.Error
+version: 1.0
+
+[ClickHouse] SHALL return an error if `aes-192-ctr` is specified as the value for the `mode` parameter of the
+`aes_decrypt_mysql` function.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-256-CTR.Error
+version: 1.0
+
+[ClickHouse] SHALL return an error if `aes-256-ctr` is specified as the value for the `mode` parameter of the
+`aes_decrypt_mysql` function.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.InitializationVector
+version: 1.0
+
+[ClickHouse] SHALL support `iv` with `String` or `FixedString` data types as the optional fourth
+parameter to the `aes_decrypt_mysql` function that SHALL specify the initialization vector for block modes that require
+it.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.ReturnValue
+version: 1.0
+
+[ClickHouse] SHALL return the decrypted value of the data
+using `String` data type as the result of `aes_decrypt_mysql` function.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Key.Length.TooShortError
+version: 1.0
+
+[ClickHouse] SHALL return an error if the `key` length is less than the minimum for the `aes_decrypt_mysql`
+function for a given block mode.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.Key.Length.TooLong
+version: 1.0
+
+[ClickHouse] SHALL use folding algorithm specified below if the `key` length is longer than required
+for the `aes_decrypt_mysql` function for a given block mode.
+
+```python
+def fold_key(key, cipher_key_size):
+    key = list(key) if not isinstance(key, (list, tuple)) else key
+	  folded_key = key[:cipher_key_size]
+	  for i in range(cipher_key_size, len(key)):
+		    print(i % cipher_key_size, i)
+		    folded_key[i % cipher_key_size] ^= key[i]
+	  return folded_key
+```
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.InitializationVector.Length.TooShortError
+version: 1.0
+
+[ClickHouse] SHALL return an error if the `iv` length is specified and is less than the minimum
+that is required for the `aes_decrypt_mysql` function for a given block mode.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.InitializationVector.Length.TooLong
+version: 1.0
+
+[ClickHouse] SHALL use the first `N` bytes that are required if the `iv` is specified and
+its length is longer than required for the `aes_decrypt_mysql` function for a given block mode.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.InitializationVector.NotValidForMode
+version: 1.0
+
+[ClickHouse] SHALL return an error if the `iv` is specified for the `aes_decrypt_mysql`
+function for a mode that does not need it.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.AES-128-ECB.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-128-ecb` and `key` is less than 16 bytes
+or `iv` is specified.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.AES-192-ECB.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-192-ecb` and `key` is less than 24 bytes
+or `iv` is specified.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.AES-256-ECB.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-256-ecb` and `key` is less than 32 bytes
+or `iv` is specified.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.AES-128-CBC.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-128-cbc` and `key` is less than 16 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.AES-192-CBC.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-192-cbc` and `key` is less than 24 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.AES-256-CBC.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-256-cbc` and `key` is less than 32 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.AES-128-CFB1.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-128-cfb1` and `key` is less than 16 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.AES-192-CFB1.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-192-cfb1` and `key` is less than 24 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.AES-256-CFB1.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-256-cfb1` and `key` is less than 32 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.AES-128-CFB8.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-128-cfb8` and `key` is less than 16 bytes
+and if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.AES-192-CFB8.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-192-cfb8` and `key` is less than 24 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.AES-256-CFB8.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-256-cfb8` and `key` is less than 32 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.AES-128-CFB128.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-128-cfb128` and `key` is less than 16 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.AES-192-CFB128.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-192-cfb128` and `key` is less than 24 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.AES-256-CFB128.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-256-cfb128` and `key` is less than 32 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.AES-128-OFB.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-128-ofb` and `key` is less than 16 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.AES-192-OFB.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-192-ofb` and `key` is less than 24 bytes
+or if specified `iv` is less than 16 bytes.
+
+#### RQ.SRS008.AES.MySQL.Decrypt.Function.AES-256-OFB.KeyAndInitializationVector.Length
+version: 1.0
+
+[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-256-ofb` and `key` is less than 32 bytes
+or if specified `iv` is less than 16 bytes.
+
+## References
+
+* **GDPR:** https://en.wikipedia.org/wiki/General_Data_Protection_Regulation
+* **MySQL:** https://www.mysql.com/
+* **AES:** https://en.wikipedia.org/wiki/Advanced_Encryption_Standard
+* **ClickHouse:** https://clickhouse.tech
+* **Git:** https://git-scm.com/
+
+[OpenSSL]: https://www.openssl.org/
+[LowCardinality]: https://clickhouse.tech/docs/en/sql-reference/data-types/lowcardinality/
+[MergeTree]: https://clickhouse.tech/docs/en/engines/table-engines/mergetree-family/mergetree/
+[MySQL Database Engine]: https://clickhouse.tech/docs/en/engines/database-engines/mysql/
+[MySQL Table Engine]: https://clickhouse.tech/docs/en/engines/table-engines/integrations/mysql/
+[MySQL Table Function]: https://clickhouse.tech/docs/en/sql-reference/table-functions/mysql/
+[MySQL Dictionary]: https://clickhouse.tech/docs/en/sql-reference/dictionaries/external-dictionaries/external-dicts-dict-sources/#dicts-external_dicts_dict_sources-mysql
+[GCM]: https://en.wikipedia.org/wiki/Galois/Counter_Mode
+[CTR]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Counter_(CTR)
+[CBC]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Cipher_block_chaining_(CBC)
+[ECB]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Electronic_codebook_(ECB)
+[CFB]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Cipher_feedback_(CFB)
+[CFB1]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Cipher_feedback_(CFB)
+[CFB8]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Cipher_feedback_(CFB)
+[CFB128]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Cipher_feedback_(CFB)
+[OFB]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Output_feedback_(OFB)
+[GDPR]: https://en.wikipedia.org/wiki/General_Data_Protection_Regulation
+[RFC5116]: https://tools.ietf.org/html/rfc5116#section-5.1
+[MySQL]: https://www.mysql.com/
+[MySQL 5.7]: https://dev.mysql.com/doc/refman/5.7/en/
+[MySQL aes_encrypt]: https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_aes-encrypt
+[MySQL aes_decrypt]: https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_aes-decrypt
+[AES]: https://en.wikipedia.org/wiki/Advanced_Encryption_Standard
+[ClickHouse]: https://clickhouse.tech
+[GitHub repository]: https://github.com/ClickHouse/ClickHouse/blob/master/tests/testflows/aes_encryption/requirements/requirements.md
+[Revision history]: https://github.com/ClickHouse/ClickHouse/commits/master/tests/testflows/aes_encryption/requirements/requirements.md
+[Git]: https://git-scm.com/
+[NIST test vectors]: https://csrc.nist.gov/Projects/Cryptographic-Algorithm-Validation-Program
+''')
 
 RQ_SRS008_AES_Functions = Requirement(
         name='RQ.SRS008.AES.Functions',
@@ -14,9 +1960,9 @@ RQ_SRS008_AES_Functions = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL support [AES] encryption functions to encrypt and decrypt data.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Functions_Compatability_MySQL = Requirement(
         name='RQ.SRS008.AES.Functions.Compatability.MySQL',
@@ -27,9 +1973,9 @@ RQ_SRS008_AES_Functions_Compatability_MySQL = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL support [AES] encryption functions compatible with [MySQL 5.7].\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Functions_Compatability_Dictionaries = Requirement(
         name='RQ.SRS008.AES.Functions.Compatability.Dictionaries',
@@ -41,9 +1987,9 @@ RQ_SRS008_AES_Functions_Compatability_Dictionaries = Requirement(
         description=(
         '[ClickHouse] SHALL support encryption and decryption of data accessed on remote\n'
         '[MySQL] servers using [MySQL Dictionary].\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Functions_Compatability_Engine_Database_MySQL = Requirement(
         name='RQ.SRS008.AES.Functions.Compatability.Engine.Database.MySQL',
@@ -54,9 +2000,9 @@ RQ_SRS008_AES_Functions_Compatability_Engine_Database_MySQL = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL support encryption and decryption of data accessed using [MySQL Database Engine],\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Functions_Compatability_Engine_Table_MySQL = Requirement(
         name='RQ.SRS008.AES.Functions.Compatability.Engine.Table.MySQL',
@@ -67,9 +2013,9 @@ RQ_SRS008_AES_Functions_Compatability_Engine_Table_MySQL = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL support encryption and decryption of data accessed using [MySQL Table Engine].\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Functions_Compatability_TableFunction_MySQL = Requirement(
         name='RQ.SRS008.AES.Functions.Compatability.TableFunction.MySQL',
@@ -80,9 +2026,9 @@ RQ_SRS008_AES_Functions_Compatability_TableFunction_MySQL = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL support encryption and decryption of data accessed using [MySQL Table Function].\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Functions_DifferentModes = Requirement(
         name='RQ.SRS008.AES.Functions.DifferentModes',
@@ -94,9 +2040,9 @@ RQ_SRS008_AES_Functions_DifferentModes = Requirement(
         description=(
         '[ClickHouse] SHALL allow different modes to be supported in a single SQL statement\n'
         'using explicit function parameters.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Functions_DataFromMultipleSources = Requirement(
         name='RQ.SRS008.AES.Functions.DataFromMultipleSources',
@@ -110,9 +2056,9 @@ RQ_SRS008_AES_Functions_DataFromMultipleSources = Requirement(
         'in the `SELECT` statement, including [ClickHouse] [MergeTree] table as well as [MySQL Dictionary],\n'
         '[MySQL Database Engine], [MySQL Table Engine], and [MySQL Table Function]\n'
         'with possibly different encryption schemes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Functions_SuppressOutputOfSensitiveValues = Requirement(
         name='RQ.SRS008.AES.Functions.SuppressOutputOfSensitiveValues',
@@ -124,9 +2070,9 @@ RQ_SRS008_AES_Functions_SuppressOutputOfSensitiveValues = Requirement(
         description=(
         '[ClickHouse] SHALL suppress output of [AES] `string` and `key` parameters to the system log,\n'
         'error log, and `query_log` table to prevent leakage of sensitive values.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Functions_InvalidParameters = Requirement(
         name='RQ.SRS008.AES.Functions.InvalidParameters',
@@ -137,9 +2083,9 @@ RQ_SRS008_AES_Functions_InvalidParameters = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL return an error when parameters are invalid.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Functions_Mismatched_Key = Requirement(
         name='RQ.SRS008.AES.Functions.Mismatched.Key',
@@ -150,9 +2096,9 @@ RQ_SRS008_AES_Functions_Mismatched_Key = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL return garbage for mismatched keys.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Functions_Mismatched_IV = Requirement(
         name='RQ.SRS008.AES.Functions.Mismatched.IV',
@@ -163,9 +2109,9 @@ RQ_SRS008_AES_Functions_Mismatched_IV = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL return garbage for mismatched initialization vector for the modes that use it.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Functions_Mismatched_AAD = Requirement(
         name='RQ.SRS008.AES.Functions.Mismatched.AAD',
@@ -176,9 +2122,9 @@ RQ_SRS008_AES_Functions_Mismatched_AAD = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL return garbage for mismatched additional authentication data for the modes that use it.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Functions_Mismatched_Mode = Requirement(
         name='RQ.SRS008.AES.Functions.Mismatched.Mode',
@@ -189,9 +2135,9 @@ RQ_SRS008_AES_Functions_Mismatched_Mode = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL return an error or garbage for mismatched mode.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Functions_Check_Performance = Requirement(
         name='RQ.SRS008.AES.Functions.Check.Performance',
@@ -202,9 +2148,9 @@ RQ_SRS008_AES_Functions_Check_Performance = Requirement(
         uid=None,
         description=(
         'Performance of [AES] encryption functions SHALL be measured.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Function_Check_Performance_BestCase = Requirement(
         name='RQ.SRS008.AES.Function.Check.Performance.BestCase',
@@ -216,9 +2162,9 @@ RQ_SRS008_AES_Function_Check_Performance_BestCase = Requirement(
         description=(
         'Performance of [AES] encryption functions SHALL be checked for the best case\n'
         'scenario where there is one key, one initialization vector, and one large stream of data.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Function_Check_Performance_WorstCase = Requirement(
         name='RQ.SRS008.AES.Function.Check.Performance.WorstCase',
@@ -230,9 +2176,9 @@ RQ_SRS008_AES_Function_Check_Performance_WorstCase = Requirement(
         description=(
         'Performance of [AES] encryption functions SHALL be checked for the worst case\n'
         'where there are `N` keys, `N` initialization vectors and `N` very small streams of data.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Functions_Check_Compression = Requirement(
         name='RQ.SRS008.AES.Functions.Check.Compression',
@@ -243,9 +2189,9 @@ RQ_SRS008_AES_Functions_Check_Compression = Requirement(
         uid=None,
         description=(
         'Effect of [AES] encryption on column compression SHALL be measured.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Functions_Check_Compression_LowCardinality = Requirement(
         name='RQ.SRS008.AES.Functions.Check.Compression.LowCardinality',
@@ -257,9 +2203,9 @@ RQ_SRS008_AES_Functions_Check_Compression_LowCardinality = Requirement(
         description=(
         'Effect of [AES] encryption on the compression of a column with [LowCardinality] data type\n'
         'SHALL be measured.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function',
@@ -270,9 +2216,9 @@ RQ_SRS008_AES_Encrypt_Function = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL support `aes_encrypt` function to encrypt data using [AES].\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Syntax = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Syntax',
@@ -287,9 +2233,9 @@ RQ_SRS008_AES_Encrypt_Function_Syntax = Requirement(
         '```sql\n'
         'aes_encrypt(plaintext, key, mode, [iv, aad])\n'
         '```\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_NIST_TestVectors = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.NIST.TestVectors',
@@ -300,9 +2246,9 @@ RQ_SRS008_AES_Encrypt_Function_NIST_TestVectors = Requirement(
         uid=None,
         description=(
         '[ClickHouse] `aes_encrypt` function output SHALL produce output that matches [NIST test vectors].\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_PlainText = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.PlainText',
@@ -314,9 +2260,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_PlainText = Requirement(
         description=(
         '[ClickHouse] SHALL support `plaintext` accepting any data type as\n'
         'the first parameter to the `aes_encrypt` function that SHALL specify the data to be encrypted.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Key = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Key',
@@ -328,9 +2274,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Key = Requirement(
         description=(
         '[ClickHouse] SHALL support `key` with `String` or `FixedString` data types\n'
         'as the second parameter to the `aes_encrypt` function that SHALL specify the encryption key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode',
@@ -342,9 +2288,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode = Requirement(
         description=(
         '[ClickHouse] SHALL support `mode` with `String` or `FixedString` data types as the third parameter\n'
         'to the `aes_encrypt` function that SHALL specify encryption key length and block encryption mode.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_ValuesFormat = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.ValuesFormat',
@@ -360,9 +2306,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_ValuesFormat = Requirement(
         '`128`, `192`, or `256` as the values and the `mode` SHALL specify the block encryption\n'
         'mode and SHALL accept [ECB], [CBC], [CFB1], [CFB8], [CFB128], or [OFB] as well as\n'
         '[CTR] and [GCM] as the values. For example, `aes-256-ofb`.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_Invalid = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.Invalid',
@@ -375,9 +2321,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_Invalid = Requirement(
         '[ClickHouse] SHALL return an error if the specified value for the `mode` parameter of the `aes_encrypt`\n'
         'function is not valid with the exception where such a mode is supported by the underlying\n'
         '[OpenSSL] implementation.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_128_ECB = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-128-ECB',
@@ -389,9 +2335,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_128_ECB = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-128-ecb` as the value for the `mode` parameter of the `aes_encrypt` function\n'
         'and [AES] algorithm SHALL use the [ECB] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_192_ECB = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-192-ECB',
@@ -403,9 +2349,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_192_ECB = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-192-ecb` as the value for the `mode` parameter of the `aes_encrypt` function\n'
         'and [AES] algorithm SHALL use the [ECB] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_256_ECB = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-256-ECB',
@@ -417,9 +2363,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_256_ECB = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-256-ecb` as the value for the `mode` parameter of the `aes_encrypt` function\n'
         'and [AES] algorithm SHALL use the [ECB] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_128_CBC = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-128-CBC',
@@ -431,9 +2377,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_128_CBC = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-128-cbc` as the value for the `mode` parameter of the `aes_encrypt` function\n'
         'and [AES] algorithm SHALL use the [CBC] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_192_CBC = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-192-CBC',
@@ -445,9 +2391,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_192_CBC = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-192-cbc` as the value for the `mode` parameter of the `aes_encrypt` function\n'
         'and [AES] algorithm SHALL use the [CBC] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_256_CBC = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-256-CBC',
@@ -459,9 +2405,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_256_CBC = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-256-cbc` as the value for the `mode` parameter of the `aes_encrypt` function\n'
         'and [AES] algorithm SHALL use the [CBC] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_128_CFB1 = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-128-CFB1',
@@ -473,9 +2419,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_128_CFB1 = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-128-cfb1` as the value for the `mode` parameter of the `aes_encrypt` function\n'
         'and [AES] algorithm SHALL use the [CFB1] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_192_CFB1 = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-192-CFB1',
@@ -487,9 +2433,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_192_CFB1 = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-192-cfb1` as the value for the `mode` parameter of the `aes_encrypt` function\n'
         'and [AES] algorithm SHALL use the [CFB1] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_256_CFB1 = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-256-CFB1',
@@ -501,9 +2447,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_256_CFB1 = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-256-cfb1` as the value for the `mode` parameter of the `aes_encrypt` function\n'
         'and [AES] algorithm SHALL use the [CFB1] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_128_CFB8 = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-128-CFB8',
@@ -515,9 +2461,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_128_CFB8 = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-128-cfb8` as the value for the `mode` parameter of the `aes_encrypt` function\n'
         'and [AES] algorithm SHALL use the [CFB8] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_192_CFB8 = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-192-CFB8',
@@ -529,9 +2475,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_192_CFB8 = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-192-cfb8` as the value for the `mode` parameter of the `aes_encrypt` function\n'
         'and [AES] algorithm SHALL use the [CFB8] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_256_CFB8 = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-256-CFB8',
@@ -543,9 +2489,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_256_CFB8 = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-256-cfb8` as the value for the `mode` parameter of the `aes_encrypt` function\n'
         'and [AES] algorithm SHALL use the [CFB8] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_128_CFB128 = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-128-CFB128',
@@ -557,9 +2503,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_128_CFB128 = Requiremen
         description=(
         '[ClickHouse] SHALL support `aes-128-cfb128` as the value for the `mode` parameter of the `aes_encrypt` function\n'
         'and [AES] algorithm SHALL use the [CFB128] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_192_CFB128 = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-192-CFB128',
@@ -571,9 +2517,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_192_CFB128 = Requiremen
         description=(
         '[ClickHouse] SHALL support `aes-192-cfb128` as the value for the `mode` parameter of the `aes_encrypt` function\n'
         'and [AES] algorithm SHALL use the [CFB128] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_256_CFB128 = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-256-CFB128',
@@ -585,9 +2531,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_256_CFB128 = Requiremen
         description=(
         '[ClickHouse] SHALL support `aes-256-cfb128` as the value for the `mode` parameter of the `aes_encrypt` function\n'
         'and [AES] algorithm SHALL use the [CFB128] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_128_OFB = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-128-OFB',
@@ -599,9 +2545,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_128_OFB = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-128-ofb` as the value for the `mode` parameter of the `aes_encrypt` function\n'
         'and [AES] algorithm SHALL use the [OFB] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_192_OFB = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-192-OFB',
@@ -613,9 +2559,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_192_OFB = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-192-ofb` as the value for the `mode` parameter of the `aes_encrypt` function\n'
         'and [AES] algorithm SHALL use the [OFB] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_256_OFB = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-256-OFB',
@@ -627,9 +2573,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_256_OFB = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-256-ofb` as the value for the `mode` parameter of the `aes_encrypt` function\n'
         'and [AES] algorithm SHALL use the [OFB] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_128_GCM = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-128-GCM',
@@ -643,9 +2589,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_128_GCM = Requirement(
         'and [AES] algorithm SHALL use the [GCM] block mode encryption with a 128 bit key.\n'
         'An `AEAD` 16-byte tag is appended to the resulting ciphertext according to\n'
         'the [RFC5116].\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_192_GCM = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-192-GCM',
@@ -659,9 +2605,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_192_GCM = Requirement(
         'and [AES] algorithm SHALL use the [GCM] block mode encryption with a 192 bit key.\n'
         'An `AEAD` 16-byte tag is appended to the resulting ciphertext according to\n'
         'the [RFC5116].\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_256_GCM = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-256-GCM',
@@ -675,9 +2621,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_256_GCM = Requirement(
         'and [AES] algorithm SHALL use the [GCM] block mode encryption with a 256 bit key.\n'
         'An `AEAD` 16-byte tag is appended to the resulting ciphertext according to\n'
         'the [RFC5116].\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_128_CTR = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-128-CTR',
@@ -689,9 +2635,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_128_CTR = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-128-ctr` as the value for the `mode` parameter of the `aes_encrypt` function\n'
         'and [AES] algorithm SHALL use the [CTR] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_192_CTR = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-192-CTR',
@@ -703,9 +2649,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_192_CTR = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-192-ctr` as the value for the `mode` parameter of the `aes_encrypt` function\n'
         'and [AES] algorithm SHALL use the [CTR] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_256_CTR = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.Mode.Value.AES-256-CTR',
@@ -717,9 +2663,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_Mode_Value_AES_256_CTR = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-256-ctr` as the value for the `mode` parameter of the `aes_encrypt` function\n'
         'and [AES] algorithm SHALL use the [CTR] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_InitializationVector = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.InitializationVector',
@@ -732,9 +2678,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_InitializationVector = Requirement(
         '[ClickHouse] SHALL support `iv` with `String` or `FixedString` data types as the optional fourth\n'
         'parameter to the `aes_encrypt` function that SHALL specify the initialization vector for block modes that require\n'
         'it.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_AdditionalAuthenticatedData = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.AdditionalAuthenticatedData',
@@ -747,9 +2693,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_AdditionalAuthenticatedData = Requirem
         '[ClickHouse] SHALL support `aad` with `String` or `FixedString` data types as the optional fifth\n'
         'parameter to the `aes_encrypt` function that SHALL specify the additional authenticated data\n'
         'for block modes that require it.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Parameters_ReturnValue = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Parameters.ReturnValue',
@@ -761,9 +2707,9 @@ RQ_SRS008_AES_Encrypt_Function_Parameters_ReturnValue = Requirement(
         description=(
         '[ClickHouse] SHALL return the encrypted value of the data\n'
         'using `String` data type as the result of `aes_encrypt` function.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_Key_Length_InvalidLengthError = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.Key.Length.InvalidLengthError',
@@ -774,9 +2720,9 @@ RQ_SRS008_AES_Encrypt_Function_Key_Length_InvalidLengthError = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL return an error if the `key` length is not exact for the `aes_encrypt` function for a given block mode.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_InitializationVector_Length_InvalidLengthError = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.InitializationVector.Length.InvalidLengthError',
@@ -787,9 +2733,9 @@ RQ_SRS008_AES_Encrypt_Function_InitializationVector_Length_InvalidLengthError = 
         uid=None,
         description=(
         '[ClickHouse] SHALL return an error if the `iv` length is specified and not of the exact size for the `aes_encrypt` function for a given block mode.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_InitializationVector_NotValidForMode = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.InitializationVector.NotValidForMode',
@@ -800,9 +2746,9 @@ RQ_SRS008_AES_Encrypt_Function_InitializationVector_NotValidForMode = Requiremen
         uid=None,
         description=(
         '[ClickHouse] SHALL return an error if the `iv` is specified for the `aes_encrypt` function for a mode that does not need it.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AdditionalAuthenticationData_NotValidForMode = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AdditionalAuthenticationData.NotValidForMode',
@@ -813,9 +2759,9 @@ RQ_SRS008_AES_Encrypt_Function_AdditionalAuthenticationData_NotValidForMode = Re
         uid=None,
         description=(
         '[ClickHouse] SHALL return an error if the `aad` is specified for the `aes_encrypt` function for a mode that does not need it.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AdditionalAuthenticationData_Length = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AdditionalAuthenticationData.Length',
@@ -826,9 +2772,9 @@ RQ_SRS008_AES_Encrypt_Function_AdditionalAuthenticationData_Length = Requirement
         uid=None,
         description=(
         '[ClickHouse] SHALL not limit the size of the `aad` parameter passed to the `aes_encrypt` function.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AES_128_ECB_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AES-128-ECB.KeyAndInitializationVector.Length',
@@ -840,9 +2786,9 @@ RQ_SRS008_AES_Encrypt_Function_AES_128_ECB_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-128-ecb` and `key` is not 16 bytes\n'
         'or `iv` or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AES_192_ECB_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AES-192-ECB.KeyAndInitializationVector.Length',
@@ -854,9 +2800,9 @@ RQ_SRS008_AES_Encrypt_Function_AES_192_ECB_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-192-ecb` and `key` is not 24 bytes\n'
         'or `iv` or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AES_256_ECB_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AES-256-ECB.KeyAndInitializationVector.Length',
@@ -868,9 +2814,9 @@ RQ_SRS008_AES_Encrypt_Function_AES_256_ECB_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-256-ecb` and `key` is not 32 bytes\n'
         'or `iv` or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AES_128_CBC_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AES-128-CBC.KeyAndInitializationVector.Length',
@@ -882,9 +2828,9 @@ RQ_SRS008_AES_Encrypt_Function_AES_128_CBC_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-128-cbc` and `key` is not 16 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AES_192_CBC_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AES-192-CBC.KeyAndInitializationVector.Length',
@@ -896,9 +2842,9 @@ RQ_SRS008_AES_Encrypt_Function_AES_192_CBC_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-192-cbc` and `key` is not 24 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AES_256_CBC_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AES-256-CBC.KeyAndInitializationVector.Length',
@@ -910,9 +2856,9 @@ RQ_SRS008_AES_Encrypt_Function_AES_256_CBC_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-256-cbc` and `key` is not 32 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AES_128_CFB1_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AES-128-CFB1.KeyAndInitializationVector.Length',
@@ -924,9 +2870,9 @@ RQ_SRS008_AES_Encrypt_Function_AES_128_CFB1_KeyAndInitializationVector_Length = 
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-128-cfb1` and `key` is not 16 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AES_192_CFB1_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AES-192-CFB1.KeyAndInitializationVector.Length',
@@ -938,9 +2884,9 @@ RQ_SRS008_AES_Encrypt_Function_AES_192_CFB1_KeyAndInitializationVector_Length = 
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-192-cfb1` and `key` is not 24 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AES_256_CFB1_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AES-256-CFB1.KeyAndInitializationVector.Length',
@@ -952,9 +2898,9 @@ RQ_SRS008_AES_Encrypt_Function_AES_256_CFB1_KeyAndInitializationVector_Length = 
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-256-cfb1` and `key` is not 32 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AES_128_CFB8_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AES-128-CFB8.KeyAndInitializationVector.Length',
@@ -966,9 +2912,9 @@ RQ_SRS008_AES_Encrypt_Function_AES_128_CFB8_KeyAndInitializationVector_Length = 
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-128-cfb8` and `key` is not 16 bytes\n'
         'and if specified `iv` is not 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AES_192_CFB8_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AES-192-CFB8.KeyAndInitializationVector.Length',
@@ -980,9 +2926,9 @@ RQ_SRS008_AES_Encrypt_Function_AES_192_CFB8_KeyAndInitializationVector_Length = 
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-192-cfb8` and `key` is not 24 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AES_256_CFB8_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AES-256-CFB8.KeyAndInitializationVector.Length',
@@ -994,9 +2940,9 @@ RQ_SRS008_AES_Encrypt_Function_AES_256_CFB8_KeyAndInitializationVector_Length = 
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-256-cfb8` and `key` is not 32 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AES_128_CFB128_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AES-128-CFB128.KeyAndInitializationVector.Length',
@@ -1008,9 +2954,9 @@ RQ_SRS008_AES_Encrypt_Function_AES_128_CFB128_KeyAndInitializationVector_Length 
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-128-cfb128` and `key` is not 16 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AES_192_CFB128_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AES-192-CFB128.KeyAndInitializationVector.Length',
@@ -1022,9 +2968,9 @@ RQ_SRS008_AES_Encrypt_Function_AES_192_CFB128_KeyAndInitializationVector_Length 
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-192-cfb128` and `key` is not 24 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AES_256_CFB128_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AES-256-CFB128.KeyAndInitializationVector.Length',
@@ -1036,9 +2982,9 @@ RQ_SRS008_AES_Encrypt_Function_AES_256_CFB128_KeyAndInitializationVector_Length 
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-256-cfb128` and `key` is not 32 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AES_128_OFB_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AES-128-OFB.KeyAndInitializationVector.Length',
@@ -1050,9 +2996,9 @@ RQ_SRS008_AES_Encrypt_Function_AES_128_OFB_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-128-ofb` and `key` is not 16 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AES_192_OFB_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AES-192-OFB.KeyAndInitializationVector.Length',
@@ -1064,9 +3010,9 @@ RQ_SRS008_AES_Encrypt_Function_AES_192_OFB_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-192-ofb` and `key` is not 24 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AES_256_OFB_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AES-256-OFB.KeyAndInitializationVector.Length',
@@ -1078,9 +3024,9 @@ RQ_SRS008_AES_Encrypt_Function_AES_256_OFB_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-256-ofb` and `key` is not 32 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AES_128_GCM_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AES-128-GCM.KeyAndInitializationVector.Length',
@@ -1092,9 +3038,9 @@ RQ_SRS008_AES_Encrypt_Function_AES_128_GCM_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-128-gcm` and `key` is not 16 bytes\n'
         'or `iv` is not specified or is less than 8 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AES_192_GCM_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AES-192-GCM.KeyAndInitializationVector.Length',
@@ -1106,9 +3052,9 @@ RQ_SRS008_AES_Encrypt_Function_AES_192_GCM_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-192-gcm` and `key` is not 24 bytes\n'
         'or `iv` is not specified or is less than 8 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AES_256_GCM_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AES-256-GCM.KeyAndInitializationVector.Length',
@@ -1120,9 +3066,9 @@ RQ_SRS008_AES_Encrypt_Function_AES_256_GCM_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-256-gcm` and `key` is not 32 bytes\n'
         'or `iv` is not specified or is less than 8 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AES_128_CTR_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AES-128-CTR.KeyAndInitializationVector.Length',
@@ -1134,9 +3080,9 @@ RQ_SRS008_AES_Encrypt_Function_AES_128_CTR_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-128-ctr` and `key` is not 16 bytes\n'
         'or if specified `iv` is not 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AES_192_CTR_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AES-192-CTR.KeyAndInitializationVector.Length',
@@ -1148,9 +3094,9 @@ RQ_SRS008_AES_Encrypt_Function_AES_192_CTR_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-192-ctr` and `key` is not 24 bytes\n'
         'or if specified `iv` is not 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Encrypt_Function_AES_256_CTR_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Encrypt.Function.AES-256-CTR.KeyAndInitializationVector.Length',
@@ -1162,9 +3108,9 @@ RQ_SRS008_AES_Encrypt_Function_AES_256_CTR_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt` function is set to `aes-256-ctr` and `key` is not 32 bytes\n'
         'or if specified `iv` is not 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function',
@@ -1175,9 +3121,9 @@ RQ_SRS008_AES_Decrypt_Function = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL support `aes_decrypt` function to decrypt data using [AES].\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Syntax = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Syntax',
@@ -1192,9 +3138,9 @@ RQ_SRS008_AES_Decrypt_Function_Syntax = Requirement(
         '```sql\n'
         'aes_decrypt(ciphertext, key, mode, [iv, aad])\n'
         '```\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_CipherText = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.CipherText',
@@ -1206,9 +3152,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_CipherText = Requirement(
         description=(
         '[ClickHouse] SHALL support `ciphertext` accepting `FixedString` or `String` data types as\n'
         'the first parameter to the `aes_decrypt` function that SHALL specify the data to be decrypted.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Key = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Key',
@@ -1220,9 +3166,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Key = Requirement(
         description=(
         '[ClickHouse] SHALL support `key` with `String` or `FixedString` data types\n'
         'as the second parameter to the `aes_decrypt` function that SHALL specify the encryption key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode',
@@ -1234,9 +3180,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode = Requirement(
         description=(
         '[ClickHouse] SHALL support `mode` with `String` or `FixedString` data types as the third parameter\n'
         'to the `aes_decrypt` function that SHALL specify encryption key length and block encryption mode.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_ValuesFormat = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.ValuesFormat',
@@ -1252,9 +3198,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_ValuesFormat = Requirement(
         '`128`, `192`, or `256` as the values and the `mode` SHALL specify the block encryption\n'
         'mode and SHALL accept [ECB], [CBC], [CFB1], [CFB8], [CFB128], or [OFB] as well as\n'
         '[CTR] and [GCM] as the values. For example, `aes-256-ofb`.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_Invalid = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.Invalid',
@@ -1267,9 +3213,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_Invalid = Requirement(
         '[ClickHouse] SHALL return an error if the specified value for the `mode` parameter of the `aes_decrypt`\n'
         'function is not valid with the exception where such a mode is supported by the underlying\n'
         '[OpenSSL] implementation.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_128_ECB = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-128-ECB',
@@ -1281,9 +3227,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_128_ECB = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-128-ecb` as the value for the `mode` parameter of the `aes_decrypt` function\n'
         'and [AES] algorithm SHALL use the [ECB] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_192_ECB = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-192-ECB',
@@ -1295,9 +3241,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_192_ECB = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-192-ecb` as the value for the `mode` parameter of the `aes_decrypt` function\n'
         'and [AES] algorithm SHALL use the [ECB] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_256_ECB = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-256-ECB',
@@ -1309,9 +3255,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_256_ECB = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-256-ecb` as the value for the `mode` parameter of the `aes_decrypt` function\n'
         'and [AES] algorithm SHALL use the [ECB] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_128_CBC = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-128-CBC',
@@ -1323,9 +3269,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_128_CBC = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-128-cbc` as the value for the `mode` parameter of the `aes_decrypt` function\n'
         'and [AES] algorithm SHALL use the [CBC] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_192_CBC = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-192-CBC',
@@ -1337,9 +3283,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_192_CBC = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-192-cbc` as the value for the `mode` parameter of the `aes_decrypt` function\n'
         'and [AES] algorithm SHALL use the [CBC] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_256_CBC = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-256-CBC',
@@ -1351,9 +3297,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_256_CBC = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-256-cbc` as the value for the `mode` parameter of the `aes_decrypt` function\n'
         'and [AES] algorithm SHALL use the [CBC] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_128_CFB1 = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-128-CFB1',
@@ -1365,9 +3311,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_128_CFB1 = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-128-cfb1` as the value for the `mode` parameter of the `aes_decrypt` function\n'
         'and [AES] algorithm SHALL use the [CFB1] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_192_CFB1 = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-192-CFB1',
@@ -1379,9 +3325,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_192_CFB1 = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-192-cfb1` as the value for the `mode` parameter of the `aes_decrypt` function\n'
         'and [AES] algorithm SHALL use the [CFB1] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_256_CFB1 = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-256-CFB1',
@@ -1393,9 +3339,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_256_CFB1 = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-256-cfb1` as the value for the `mode` parameter of the `aes_decrypt` function\n'
         'and [AES] algorithm SHALL use the [CFB1] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_128_CFB8 = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-128-CFB8',
@@ -1407,9 +3353,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_128_CFB8 = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-128-cfb8` as the value for the `mode` parameter of the `aes_decrypt` function\n'
         'and [AES] algorithm SHALL use the [CFB8] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_192_CFB8 = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-192-CFB8',
@@ -1421,9 +3367,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_192_CFB8 = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-192-cfb8` as the value for the `mode` parameter of the `aes_decrypt` function\n'
         'and [AES] algorithm SHALL use the [CFB8] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_256_CFB8 = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-256-CFB8',
@@ -1435,9 +3381,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_256_CFB8 = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-256-cfb8` as the value for the `mode` parameter of the `aes_decrypt` function\n'
         'and [AES] algorithm SHALL use the [CFB8] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_128_CFB128 = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-128-CFB128',
@@ -1449,9 +3395,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_128_CFB128 = Requiremen
         description=(
         '[ClickHouse] SHALL support `aes-128-cfb128` as the value for the `mode` parameter of the `aes_decrypt` function\n'
         'and [AES] algorithm SHALL use the [CFB128] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_192_CFB128 = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-192-CFB128',
@@ -1463,9 +3409,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_192_CFB128 = Requiremen
         description=(
         '[ClickHouse] SHALL support `aes-192-cfb128` as the value for the `mode` parameter of the `aes_decrypt` function\n'
         'and [AES] algorithm SHALL use the [CFB128] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_256_CFB128 = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-256-CFB128',
@@ -1477,9 +3423,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_256_CFB128 = Requiremen
         description=(
         '[ClickHouse] SHALL support `aes-256-cfb128` as the value for the `mode` parameter of the `aes_decrypt` function\n'
         'and [AES] algorithm SHALL use the [CFB128] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_128_OFB = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-128-OFB',
@@ -1491,9 +3437,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_128_OFB = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-128-ofb` as the value for the `mode` parameter of the `aes_decrypt` function\n'
         'and [AES] algorithm SHALL use the [OFB] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_192_OFB = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-192-OFB',
@@ -1505,9 +3451,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_192_OFB = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-192-ofb` as the value for the `mode` parameter of the `aes_decrypt` function\n'
         'and [AES] algorithm SHALL use the [OFB] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_256_OFB = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-256-OFB',
@@ -1519,9 +3465,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_256_OFB = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-256-ofb` as the value for the `mode` parameter of the `aes_decrypt` function\n'
         'and [AES] algorithm SHALL use the [OFB] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_128_GCM = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-128-GCM',
@@ -1535,9 +3481,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_128_GCM = Requirement(
         'and [AES] algorithm SHALL use the [GCM] block mode encryption with a 128 bit key.\n'
         'An [AEAD] 16-byte tag is expected present at the end of the ciphertext according to\n'
         'the [RFC5116].\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_192_GCM = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-192-GCM',
@@ -1551,9 +3497,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_192_GCM = Requirement(
         'and [AES] algorithm SHALL use the [GCM] block mode encryption with a 192 bit key.\n'
         'An [AEAD] 16-byte tag is expected present at the end of the ciphertext according to\n'
         'the [RFC5116].\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_256_GCM = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-256-GCM',
@@ -1567,9 +3513,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_256_GCM = Requirement(
         'and [AES] algorithm SHALL use the [GCM] block mode encryption with a 256 bit key.\n'
         'An [AEAD] 16-byte tag is expected present at the end of the ciphertext according to\n'
         'the [RFC5116].\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_128_CTR = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-128-CTR',
@@ -1581,9 +3527,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_128_CTR = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-128-ctr` as the value for the `mode` parameter of the `aes_decrypt` function\n'
         'and [AES] algorithm SHALL use the [CTR] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_192_CTR = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-192-CTR',
@@ -1595,9 +3541,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_192_CTR = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-192-ctr` as the value for the `mode` parameter of the `aes_decrypt` function\n'
         'and [AES] algorithm SHALL use the [CTR] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_256_CTR = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.Mode.Value.AES-256-CTR',
@@ -1609,9 +3555,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_Mode_Value_AES_256_CTR = Requirement(
         description=(
         '[ClickHouse] SHALL support `aes-256-ctr` as the value for the `mode` parameter of the `aes_decrypt` function\n'
         'and [AES] algorithm SHALL use the [CTR] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_InitializationVector = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.InitializationVector',
@@ -1624,9 +3570,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_InitializationVector = Requirement(
         '[ClickHouse] SHALL support `iv` with `String` or `FixedString` data types as the optional fourth\n'
         'parameter to the `aes_decrypt` function that SHALL specify the initialization vector for block modes that require\n'
         'it.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_AdditionalAuthenticatedData = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.AdditionalAuthenticatedData',
@@ -1639,9 +3585,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_AdditionalAuthenticatedData = Requirem
         '[ClickHouse] SHALL support `aad` with `String` or `FixedString` data types as the optional fifth\n'
         'parameter to the `aes_decrypt` function that SHALL specify the additional authenticated data\n'
         'for block modes that require it.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Parameters_ReturnValue = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Parameters.ReturnValue',
@@ -1653,9 +3599,9 @@ RQ_SRS008_AES_Decrypt_Function_Parameters_ReturnValue = Requirement(
         description=(
         '[ClickHouse] SHALL return the decrypted value of the data\n'
         'using `String` data type as the result of `aes_decrypt` function.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_Key_Length_InvalidLengthError = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.Key.Length.InvalidLengthError',
@@ -1666,9 +3612,9 @@ RQ_SRS008_AES_Decrypt_Function_Key_Length_InvalidLengthError = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL return an error if the `key` length is not exact for the `aes_decrypt` function for a given block mode.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_InitializationVector_Length_InvalidLengthError = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.InitializationVector.Length.InvalidLengthError',
@@ -1679,9 +3625,9 @@ RQ_SRS008_AES_Decrypt_Function_InitializationVector_Length_InvalidLengthError = 
         uid=None,
         description=(
         '[ClickHouse] SHALL return an error if the `iv` is speficified and the length is not exact for the `aes_decrypt` function for a given block mode.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_InitializationVector_NotValidForMode = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.InitializationVector.NotValidForMode',
@@ -1693,9 +3639,9 @@ RQ_SRS008_AES_Decrypt_Function_InitializationVector_NotValidForMode = Requiremen
         description=(
         '[ClickHouse] SHALL return an error if the `iv` is specified for the `aes_decrypt` function\n'
         'for a mode that does not need it.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AdditionalAuthenticationData_NotValidForMode = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AdditionalAuthenticationData.NotValidForMode',
@@ -1707,9 +3653,9 @@ RQ_SRS008_AES_Decrypt_Function_AdditionalAuthenticationData_NotValidForMode = Re
         description=(
         '[ClickHouse] SHALL return an error if the `aad` is specified for the `aes_decrypt` function\n'
         'for a mode that does not need it.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AdditionalAuthenticationData_Length = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AdditionalAuthenticationData.Length',
@@ -1720,9 +3666,9 @@ RQ_SRS008_AES_Decrypt_Function_AdditionalAuthenticationData_Length = Requirement
         uid=None,
         description=(
         '[ClickHouse] SHALL not limit the size of the `aad` parameter passed to the `aes_decrypt` function.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AES_128_ECB_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AES-128-ECB.KeyAndInitializationVector.Length',
@@ -1734,9 +3680,9 @@ RQ_SRS008_AES_Decrypt_Function_AES_128_ECB_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-128-ecb` and `key` is not 16 bytes\n'
         'or `iv` or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AES_192_ECB_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AES-192-ECB.KeyAndInitializationVector.Length',
@@ -1748,9 +3694,9 @@ RQ_SRS008_AES_Decrypt_Function_AES_192_ECB_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-192-ecb` and `key` is not 24 bytes\n'
         'or `iv` or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AES_256_ECB_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AES-256-ECB.KeyAndInitializationVector.Length',
@@ -1762,9 +3708,9 @@ RQ_SRS008_AES_Decrypt_Function_AES_256_ECB_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-256-ecb` and `key` is not 32 bytes\n'
         'or `iv` or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AES_128_CBC_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AES-128-CBC.KeyAndInitializationVector.Length',
@@ -1776,9 +3722,9 @@ RQ_SRS008_AES_Decrypt_Function_AES_128_CBC_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-128-cbc` and `key` is not 16 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AES_192_CBC_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AES-192-CBC.KeyAndInitializationVector.Length',
@@ -1790,9 +3736,9 @@ RQ_SRS008_AES_Decrypt_Function_AES_192_CBC_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-192-cbc` and `key` is not 24 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AES_256_CBC_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AES-256-CBC.KeyAndInitializationVector.Length',
@@ -1804,9 +3750,9 @@ RQ_SRS008_AES_Decrypt_Function_AES_256_CBC_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-256-cbc` and `key` is not 32 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AES_128_CFB1_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AES-128-CFB1.KeyAndInitializationVector.Length',
@@ -1818,9 +3764,9 @@ RQ_SRS008_AES_Decrypt_Function_AES_128_CFB1_KeyAndInitializationVector_Length = 
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-128-cfb1` and `key` is not 16 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AES_192_CFB1_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AES-192-CFB1.KeyAndInitializationVector.Length',
@@ -1832,9 +3778,9 @@ RQ_SRS008_AES_Decrypt_Function_AES_192_CFB1_KeyAndInitializationVector_Length = 
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-192-cfb1` and `key` is not 24 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AES_256_CFB1_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AES-256-CFB1.KeyAndInitializationVector.Length',
@@ -1846,9 +3792,9 @@ RQ_SRS008_AES_Decrypt_Function_AES_256_CFB1_KeyAndInitializationVector_Length = 
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-256-cfb1` and `key` is not 32 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AES_128_CFB8_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AES-128-CFB8.KeyAndInitializationVector.Length',
@@ -1860,9 +3806,9 @@ RQ_SRS008_AES_Decrypt_Function_AES_128_CFB8_KeyAndInitializationVector_Length = 
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-128-cfb8` and `key` is not 16 bytes\n'
         'and if specified `iv` is not 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AES_192_CFB8_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AES-192-CFB8.KeyAndInitializationVector.Length',
@@ -1874,9 +3820,9 @@ RQ_SRS008_AES_Decrypt_Function_AES_192_CFB8_KeyAndInitializationVector_Length = 
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-192-cfb8` and `key` is not 24 bytes\n'
         'or `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AES_256_CFB8_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AES-256-CFB8.KeyAndInitializationVector.Length',
@@ -1888,9 +3834,9 @@ RQ_SRS008_AES_Decrypt_Function_AES_256_CFB8_KeyAndInitializationVector_Length = 
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-256-cfb8` and `key` is not 32 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AES_128_CFB128_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AES-128-CFB128.KeyAndInitializationVector.Length',
@@ -1902,9 +3848,9 @@ RQ_SRS008_AES_Decrypt_Function_AES_128_CFB128_KeyAndInitializationVector_Length 
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-128-cfb128` and `key` is not 16 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AES_192_CFB128_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AES-192-CFB128.KeyAndInitializationVector.Length',
@@ -1916,9 +3862,9 @@ RQ_SRS008_AES_Decrypt_Function_AES_192_CFB128_KeyAndInitializationVector_Length 
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-192-cfb128` and `key` is not 24 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AES_256_CFB128_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AES-256-CFB128.KeyAndInitializationVector.Length',
@@ -1930,9 +3876,9 @@ RQ_SRS008_AES_Decrypt_Function_AES_256_CFB128_KeyAndInitializationVector_Length 
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-256-cfb128` and `key` is not 32 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AES_128_OFB_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AES-128-OFB.KeyAndInitializationVector.Length',
@@ -1944,9 +3890,9 @@ RQ_SRS008_AES_Decrypt_Function_AES_128_OFB_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-128-ofb` and `key` is not 16 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AES_192_OFB_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AES-192-OFB.KeyAndInitializationVector.Length',
@@ -1958,9 +3904,9 @@ RQ_SRS008_AES_Decrypt_Function_AES_192_OFB_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-192-ofb` and `key` is not 24 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AES_256_OFB_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AES-256-OFB.KeyAndInitializationVector.Length',
@@ -1972,9 +3918,9 @@ RQ_SRS008_AES_Decrypt_Function_AES_256_OFB_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-256-ofb` and `key` is not 32 bytes\n'
         'or if specified `iv` is not 16 bytes or `aad` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AES_128_GCM_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AES-128-GCM.KeyAndInitializationVector.Length',
@@ -1986,9 +3932,9 @@ RQ_SRS008_AES_Decrypt_Function_AES_128_GCM_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-128-gcm` and `key` is not 16 bytes\n'
         'or `iv` is not specified or is less than 8 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AES_192_GCM_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AES-192-GCM.KeyAndInitializationVector.Length',
@@ -2000,9 +3946,9 @@ RQ_SRS008_AES_Decrypt_Function_AES_192_GCM_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-192-gcm` and `key` is not 24 bytes\n'
         'or `iv` is not specified or is less than 8 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AES_256_GCM_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AES-256-GCM.KeyAndInitializationVector.Length',
@@ -2014,9 +3960,9 @@ RQ_SRS008_AES_Decrypt_Function_AES_256_GCM_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-256-gcm` and `key` is not 32 bytes\n'
         'or `iv` is not specified or is less than 8 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AES_128_CTR_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AES-128-CTR.KeyAndInitializationVector.Length',
@@ -2028,9 +3974,9 @@ RQ_SRS008_AES_Decrypt_Function_AES_128_CTR_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-128-ctr` and `key` is not 16 bytes\n'
         'or if specified `iv` is not 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AES_192_CTR_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AES-192-CTR.KeyAndInitializationVector.Length',
@@ -2042,9 +3988,9 @@ RQ_SRS008_AES_Decrypt_Function_AES_192_CTR_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-192-ctr` and `key` is not 24 bytes\n'
         'or if specified `iv` is not 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_Decrypt_Function_AES_256_CTR_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.Decrypt.Function.AES-256-CTR.KeyAndInitializationVector.Length',
@@ -2056,9 +4002,9 @@ RQ_SRS008_AES_Decrypt_Function_AES_256_CTR_KeyAndInitializationVector_Length = R
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt` function is set to `aes-256-ctr` and `key` is not 32 bytes\n'
         'or if specified `iv` is not 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function',
@@ -2069,9 +4015,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL support `aes_encrypt_mysql` function to encrypt data using [AES].\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Syntax = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Syntax',
@@ -2086,9 +4032,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Syntax = Requirement(
         '```sql\n'
         'aes_encrypt_mysql(plaintext, key, mode, [iv])\n'
         '```\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_PlainText = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.PlainText',
@@ -2100,9 +4046,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_PlainText = Requirement(
         description=(
         '[ClickHouse] SHALL support `plaintext` accepting any data type as\n'
         'the first parameter to the `aes_encrypt_mysql` function that SHALL specify the data to be encrypted.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Key = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Key',
@@ -2114,9 +4060,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Key = Requirement(
         description=(
         '[ClickHouse] SHALL support `key` with `String` or `FixedString` data types\n'
         'as the second parameter to the `aes_encrypt_mysql` function that SHALL specify the encryption key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode',
@@ -2128,9 +4074,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode = Requirement(
         description=(
         '[ClickHouse] SHALL support `mode` with `String` or `FixedString` data types as the third parameter\n'
         'to the `aes_encrypt_mysql` function that SHALL specify encryption key length and block encryption mode.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_ValuesFormat = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.ValuesFormat',
@@ -2145,9 +4091,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_ValuesFormat = Requirement(
         'the `key_length` SHALL specifies the length of the key and SHALL accept\n'
         '`128`, `192`, or `256` as the values and the `mode` SHALL specify the block encryption\n'
         'mode and SHALL accept [ECB], [CBC], [CFB1], [CFB8], [CFB128], or [OFB]. For example, `aes-256-ofb`.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_Invalid = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.Invalid',
@@ -2160,9 +4106,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_Invalid = Requirement
         '[ClickHouse] SHALL return an error if the specified value for the `mode` parameter of the `aes_encrypt_mysql`\n'
         'function is not valid with the exception where such a mode is supported by the underlying\n'
         '[OpenSSL] implementation.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_128_ECB = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-128-ECB',
@@ -2174,9 +4120,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_128_ECB = Require
         description=(
         '[ClickHouse] SHALL support `aes-128-ecb` as the value for the `mode` parameter of the `aes_encrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [ECB] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_192_ECB = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-192-ECB',
@@ -2188,9 +4134,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_192_ECB = Require
         description=(
         '[ClickHouse] SHALL support `aes-192-ecb` as the value for the `mode` parameter of the `aes_encrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [ECB] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_256_ECB = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-256-ECB',
@@ -2202,9 +4148,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_256_ECB = Require
         description=(
         '[ClickHouse] SHALL support `aes-256-ecb` as the value for the `mode` parameter of the `aes_encrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [ECB] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_128_CBC = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-128-CBC',
@@ -2216,9 +4162,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_128_CBC = Require
         description=(
         '[ClickHouse] SHALL support `aes-128-cbc` as the value for the `mode` parameter of the `aes_encrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [CBC] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_192_CBC = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-192-CBC',
@@ -2230,9 +4176,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_192_CBC = Require
         description=(
         '[ClickHouse] SHALL support `aes-192-cbc` as the value for the `mode` parameter of the `aes_encrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [CBC] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_256_CBC = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-256-CBC',
@@ -2244,9 +4190,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_256_CBC = Require
         description=(
         '[ClickHouse] SHALL support `aes-256-cbc` as the value for the `mode` parameter of the `aes_encrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [CBC] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_128_CFB1 = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-128-CFB1',
@@ -2258,9 +4204,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_128_CFB1 = Requir
         description=(
         '[ClickHouse] SHALL support `aes-128-cfb1` as the value for the `mode` parameter of the `aes_encrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [CFB1] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_192_CFB1 = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-192-CFB1',
@@ -2272,9 +4218,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_192_CFB1 = Requir
         description=(
         '[ClickHouse] SHALL support `aes-192-cfb1` as the value for the `mode` parameter of the `aes_encrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [CFB1] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_256_CFB1 = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-256-CFB1',
@@ -2286,9 +4232,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_256_CFB1 = Requir
         description=(
         '[ClickHouse] SHALL support `aes-256-cfb1` as the value for the `mode` parameter of the `aes_encrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [CFB1] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_128_CFB8 = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-128-CFB8',
@@ -2300,9 +4246,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_128_CFB8 = Requir
         description=(
         '[ClickHouse] SHALL support `aes-128-cfb8` as the value for the `mode` parameter of the `aes_encrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [CFB8] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_192_CFB8 = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-192-CFB8',
@@ -2314,9 +4260,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_192_CFB8 = Requir
         description=(
         '[ClickHouse] SHALL support `aes-192-cfb8` as the value for the `mode` parameter of the `aes_encrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [CFB8] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_256_CFB8 = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-256-CFB8',
@@ -2328,9 +4274,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_256_CFB8 = Requir
         description=(
         '[ClickHouse] SHALL support `aes-256-cfb8` as the value for the `mode` parameter of the `aes_encrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [CFB8] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_128_CFB128 = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-128-CFB128',
@@ -2342,9 +4288,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_128_CFB128 = Requ
         description=(
         '[ClickHouse] SHALL support `aes-128-cfb128` as the value for the `mode` parameter of the `aes_encrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [CFB128] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_192_CFB128 = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-192-CFB128',
@@ -2356,9 +4302,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_192_CFB128 = Requ
         description=(
         '[ClickHouse] SHALL support `aes-192-cfb128` as the value for the `mode` parameter of the `aes_encrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [CFB128] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_256_CFB128 = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-256-CFB128',
@@ -2370,9 +4316,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_256_CFB128 = Requ
         description=(
         '[ClickHouse] SHALL support `aes-256-cfb128` as the value for the `mode` parameter of the `aes_encrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [CFB128] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_128_OFB = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-128-OFB',
@@ -2384,9 +4330,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_128_OFB = Require
         description=(
         '[ClickHouse] SHALL support `aes-128-ofb` as the value for the `mode` parameter of the `aes_encrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [OFB] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_192_OFB = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-192-OFB',
@@ -2398,9 +4344,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_192_OFB = Require
         description=(
         '[ClickHouse] SHALL support `aes-192-ofb` as the value for the `mode` parameter of the `aes_encrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [OFB] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_256_OFB = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-256-OFB',
@@ -2412,9 +4358,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_256_OFB = Require
         description=(
         '[ClickHouse] SHALL support `aes-256-ofb` as the value for the `mode` parameter of the `aes_encrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [OFB] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_128_GCM_Error = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-128-GCM.Error',
@@ -2426,9 +4372,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_128_GCM_Error = R
         description=(
         '[ClickHouse] SHALL return an error if `aes-128-gcm` is specified as the value for the `mode` parameter of the\n'
         '`aes_encrypt_mysql` function.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_192_GCM_Error = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-192-GCM.Error',
@@ -2440,9 +4386,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_192_GCM_Error = R
         description=(
         '[ClickHouse] SHALL return an error if `aes-192-gcm` is specified as the value for the `mode` parameter of the\n'
         '`aes_encrypt_mysql` function.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_256_GCM_Error = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-256-GCM.Error',
@@ -2454,9 +4400,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_256_GCM_Error = R
         description=(
         '[ClickHouse] SHALL return an error if `aes-256-gcm` is specified as the value for the `mode` parameter of the\n'
         '`aes_encrypt_mysql` function.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_128_CTR_Error = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-128-CTR.Error',
@@ -2468,9 +4414,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_128_CTR_Error = R
         description=(
         '[ClickHouse] SHALL return an error if `aes-128-ctr` is specified as the value for the `mode` parameter of the\n'
         '`aes_encrypt_mysql` function.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_192_CTR_Error = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-192-CTR.Error',
@@ -2482,9 +4428,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_192_CTR_Error = R
         description=(
         '[ClickHouse] SHALL return an error if `aes-192-ctr` is specified as the value for the `mode` parameter of the\n'
         '`aes_encrypt_mysql` function.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_256_CTR_Error = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.Mode.Value.AES-256-CTR.Error',
@@ -2496,9 +4442,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_Mode_Value_AES_256_CTR_Error = R
         description=(
         '[ClickHouse] SHALL return an error if `aes-256-ctr` is specified as the value for the `mode` parameter of the\n'
         '`aes_encrypt_mysql` function.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_InitializationVector = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.InitializationVector',
@@ -2511,9 +4457,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_InitializationVector = Requireme
         '[ClickHouse] SHALL support `iv` with `String` or `FixedString` data types as the optional fourth\n'
         'parameter to the `aes_encrypt_mysql` function that SHALL specify the initialization vector for block modes that require\n'
         'it.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_ReturnValue = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Parameters.ReturnValue',
@@ -2525,9 +4471,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Parameters_ReturnValue = Requirement(
         description=(
         '[ClickHouse] SHALL return the encrypted value of the data\n'
         'using `String` data type as the result of `aes_encrypt_mysql` function.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Key_Length_TooShortError = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Key.Length.TooShortError',
@@ -2539,9 +4485,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Key_Length_TooShortError = Requirement(
         description=(
         '[ClickHouse] SHALL return an error if the `key` length is less than the minimum for the `aes_encrypt_mysql`\n'
         'function for a given block mode.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_Key_Length_TooLong = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.Key.Length.TooLong',
@@ -2563,9 +4509,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_Key_Length_TooLong = Requirement(
         '\t\t    folded_key[i % cipher_key_size] ^= key[i]\n'
         '\t  return folded_key\n'
         '```\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_InitializationVector_Length_TooShortError = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.InitializationVector.Length.TooShortError',
@@ -2577,9 +4523,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_InitializationVector_Length_TooShortError =
         description=(
         '[ClickHouse] SHALL return an error if the `iv` length is specified and is less than the minimum\n'
         'that is required for the `aes_encrypt_mysql` function for a given block mode.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_InitializationVector_Length_TooLong = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.InitializationVector.Length.TooLong',
@@ -2591,9 +4537,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_InitializationVector_Length_TooLong = Requi
         description=(
         '[ClickHouse] SHALL use the first `N` bytes that are required if the `iv` is specified and\n'
         'its length is longer than required for the `aes_encrypt_mysql` function for a given block mode.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_InitializationVector_NotValidForMode = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.InitializationVector.NotValidForMode',
@@ -2605,9 +4551,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_InitializationVector_NotValidForMode = Requ
         description=(
         '[ClickHouse] SHALL return an error if the `iv` is specified for the `aes_encrypt_mysql`\n'
         'function for a mode that does not need it.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_AES_128_ECB_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.AES-128-ECB.KeyAndInitializationVector.Length',
@@ -2619,9 +4565,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_AES_128_ECB_KeyAndInitializationVector_Leng
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-128-ecb` and `key` is less than 16 bytes\n'
         'or `iv` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_AES_192_ECB_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.AES-192-ECB.KeyAndInitializationVector.Length',
@@ -2633,9 +4579,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_AES_192_ECB_KeyAndInitializationVector_Leng
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-192-ecb` and `key` is less than 24 bytes\n'
         'or `iv` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_AES_256_ECB_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.AES-256-ECB.KeyAndInitializationVector.Length',
@@ -2647,9 +4593,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_AES_256_ECB_KeyAndInitializationVector_Leng
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-256-ecb` and `key` is less than 32 bytes\n'
         'or `iv` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_AES_128_CBC_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.AES-128-CBC.KeyAndInitializationVector.Length',
@@ -2661,9 +4607,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_AES_128_CBC_KeyAndInitializationVector_Leng
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-128-cbc` and `key` is less than 16 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_AES_192_CBC_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.AES-192-CBC.KeyAndInitializationVector.Length',
@@ -2675,9 +4621,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_AES_192_CBC_KeyAndInitializationVector_Leng
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-192-cbc` and `key` is less than 24 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_AES_256_CBC_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.AES-256-CBC.KeyAndInitializationVector.Length',
@@ -2689,9 +4635,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_AES_256_CBC_KeyAndInitializationVector_Leng
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-256-cbc` and `key` is less than 32 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_AES_128_CFB1_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.AES-128-CFB1.KeyAndInitializationVector.Length',
@@ -2703,9 +4649,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_AES_128_CFB1_KeyAndInitializationVector_Len
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-128-cfb1` and `key` is less than 16 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_AES_192_CFB1_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.AES-192-CFB1.KeyAndInitializationVector.Length',
@@ -2717,9 +4663,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_AES_192_CFB1_KeyAndInitializationVector_Len
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-192-cfb1` and `key` is less than 24 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_AES_256_CFB1_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.AES-256-CFB1.KeyAndInitializationVector.Length',
@@ -2731,9 +4677,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_AES_256_CFB1_KeyAndInitializationVector_Len
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-256-cfb1` and `key` is less than 32 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_AES_128_CFB8_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.AES-128-CFB8.KeyAndInitializationVector.Length',
@@ -2745,9 +4691,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_AES_128_CFB8_KeyAndInitializationVector_Len
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-128-cfb8` and `key` is less than 16 bytes\n'
         'and if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_AES_192_CFB8_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.AES-192-CFB8.KeyAndInitializationVector.Length',
@@ -2759,9 +4705,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_AES_192_CFB8_KeyAndInitializationVector_Len
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-192-cfb8` and `key` is less than 24 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_AES_256_CFB8_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.AES-256-CFB8.KeyAndInitializationVector.Length',
@@ -2773,9 +4719,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_AES_256_CFB8_KeyAndInitializationVector_Len
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-256-cfb8` and `key` is less than 32 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_AES_128_CFB128_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.AES-128-CFB128.KeyAndInitializationVector.Length',
@@ -2787,9 +4733,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_AES_128_CFB128_KeyAndInitializationVector_L
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-128-cfb128` and `key` is less than 16 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_AES_192_CFB128_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.AES-192-CFB128.KeyAndInitializationVector.Length',
@@ -2801,9 +4747,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_AES_192_CFB128_KeyAndInitializationVector_L
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-192-cfb128` and `key` is less than 24 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_AES_256_CFB128_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.AES-256-CFB128.KeyAndInitializationVector.Length',
@@ -2815,9 +4761,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_AES_256_CFB128_KeyAndInitializationVector_L
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-256-cfb128` and `key` is less than 32 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_AES_128_OFB_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.AES-128-OFB.KeyAndInitializationVector.Length',
@@ -2829,9 +4775,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_AES_128_OFB_KeyAndInitializationVector_Leng
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-128-ofb` and `key` is less than 16 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_AES_192_OFB_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.AES-192-OFB.KeyAndInitializationVector.Length',
@@ -2843,9 +4789,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_AES_192_OFB_KeyAndInitializationVector_Leng
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-192-ofb` and `key` is less than 24 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Encrypt_Function_AES_256_OFB_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Encrypt.Function.AES-256-OFB.KeyAndInitializationVector.Length',
@@ -2857,9 +4803,9 @@ RQ_SRS008_AES_MySQL_Encrypt_Function_AES_256_OFB_KeyAndInitializationVector_Leng
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_encrypt_mysql` function is set to `aes-256-ofb` and `key` is less than 32 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function',
@@ -2870,9 +4816,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL support `aes_decrypt_mysql` function to decrypt data using [AES].\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Syntax = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Syntax',
@@ -2887,9 +4833,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Syntax = Requirement(
         '```sql\n'
         'aes_decrypt_mysql(ciphertext, key, mode, [iv])\n'
         '```\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_CipherText = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.CipherText',
@@ -2901,9 +4847,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_CipherText = Requirement(
         description=(
         '[ClickHouse] SHALL support `ciphertext` accepting any data type as\n'
         'the first parameter to the `aes_decrypt_mysql` function that SHALL specify the data to be decrypted.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Key = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Key',
@@ -2915,9 +4861,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Key = Requirement(
         description=(
         '[ClickHouse] SHALL support `key` with `String` or `FixedString` data types\n'
         'as the second parameter to the `aes_decrypt_mysql` function that SHALL specify the encryption key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode',
@@ -2929,9 +4875,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode = Requirement(
         description=(
         '[ClickHouse] SHALL support `mode` with `String` or `FixedString` data types as the third parameter\n'
         'to the `aes_decrypt_mysql` function that SHALL specify encryption key length and block encryption mode.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_ValuesFormat = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.ValuesFormat',
@@ -2946,9 +4892,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_ValuesFormat = Requirement(
         'the `key_length` SHALL specifies the length of the key and SHALL accept\n'
         '`128`, `192`, or `256` as the values and the `mode` SHALL specify the block encryption\n'
         'mode and SHALL accept [ECB], [CBC], [CFB1], [CFB8], [CFB128], or [OFB]. For example, `aes-256-ofb`.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_Invalid = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.Invalid',
@@ -2961,9 +4907,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_Invalid = Requirement
         '[ClickHouse] SHALL return an error if the specified value for the `mode` parameter of the `aes_decrypt_mysql`\n'
         'function is not valid with the exception where such a mode is supported by the underlying\n'
         '[OpenSSL] implementation.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_128_ECB = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-128-ECB',
@@ -2975,9 +4921,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_128_ECB = Require
         description=(
         '[ClickHouse] SHALL support `aes-128-ecb` as the value for the `mode` parameter of the `aes_decrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [ECB] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_192_ECB = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-192-ECB',
@@ -2989,9 +4935,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_192_ECB = Require
         description=(
         '[ClickHouse] SHALL support `aes-192-ecb` as the value for the `mode` parameter of the `aes_decrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [ECB] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_256_ECB = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-256-ECB',
@@ -3003,9 +4949,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_256_ECB = Require
         description=(
         '[ClickHouse] SHALL support `aes-256-ecb` as the value for the `mode` parameter of the `aes_decrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [ECB] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_128_CBC = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-128-CBC',
@@ -3017,9 +4963,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_128_CBC = Require
         description=(
         '[ClickHouse] SHALL support `aes-128-cbc` as the value for the `mode` parameter of the `aes_decrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [CBC] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_192_CBC = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-192-CBC',
@@ -3031,9 +4977,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_192_CBC = Require
         description=(
         '[ClickHouse] SHALL support `aes-192-cbc` as the value for the `mode` parameter of the `aes_decrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [CBC] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_256_CBC = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-256-CBC',
@@ -3045,9 +4991,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_256_CBC = Require
         description=(
         '[ClickHouse] SHALL support `aes-256-cbc` as the value for the `mode` parameter of the `aes_decrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [CBC] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_128_CFB1 = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-128-CFB1',
@@ -3059,9 +5005,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_128_CFB1 = Requir
         description=(
         '[ClickHouse] SHALL support `aes-128-cfb1` as the value for the `mode` parameter of the `aes_decrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [CFB1] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_192_CFB1 = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-192-CFB1',
@@ -3073,9 +5019,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_192_CFB1 = Requir
         description=(
         '[ClickHouse] SHALL support `aes-192-cfb1` as the value for the `mode` parameter of the `aes_decrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [CFB1] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_256_CFB1 = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-256-CFB1',
@@ -3087,9 +5033,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_256_CFB1 = Requir
         description=(
         '[ClickHouse] SHALL support `aes-256-cfb1` as the value for the `mode` parameter of the `aes_decrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [CFB1] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_128_CFB8 = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-128-CFB8',
@@ -3101,9 +5047,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_128_CFB8 = Requir
         description=(
         '[ClickHouse] SHALL support `aes-128-cfb8` as the value for the `mode` parameter of the `aes_decrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [CFB8] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_192_CFB8 = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-192-CFB8',
@@ -3115,9 +5061,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_192_CFB8 = Requir
         description=(
         '[ClickHouse] SHALL support `aes-192-cfb8` as the value for the `mode` parameter of the `aes_decrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [CFB8] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_256_CFB8 = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-256-CFB8',
@@ -3129,9 +5075,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_256_CFB8 = Requir
         description=(
         '[ClickHouse] SHALL support `aes-256-cfb8` as the value for the `mode` parameter of the `aes_decrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [CFB8] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_128_CFB128 = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-128-CFB128',
@@ -3143,9 +5089,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_128_CFB128 = Requ
         description=(
         '[ClickHouse] SHALL support `aes-128-cfb128` as the value for the `mode` parameter of the `aes_decrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [CFB128] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_192_CFB128 = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-192-CFB128',
@@ -3157,9 +5103,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_192_CFB128 = Requ
         description=(
         '[ClickHouse] SHALL support `aes-192-cfb128` as the value for the `mode` parameter of the `aes_decrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [CFB128] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_256_CFB128 = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-256-CFB128',
@@ -3171,9 +5117,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_256_CFB128 = Requ
         description=(
         '[ClickHouse] SHALL support `aes-256-cfb128` as the value for the `mode` parameter of the `aes_decrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [CFB128] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_128_OFB = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-128-OFB',
@@ -3185,9 +5131,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_128_OFB = Require
         description=(
         '[ClickHouse] SHALL support `aes-128-ofb` as the value for the `mode` parameter of the `aes_decrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [OFB] block mode encryption with a 128 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_192_OFB = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-192-OFB',
@@ -3199,9 +5145,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_192_OFB = Require
         description=(
         '[ClickHouse] SHALL support `aes-192-ofb` as the value for the `mode` parameter of the `aes_decrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [OFB] block mode encryption with a 192 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_256_OFB = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-256-OFB',
@@ -3213,9 +5159,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_256_OFB = Require
         description=(
         '[ClickHouse] SHALL support `aes-256-ofb` as the value for the `mode` parameter of the `aes_decrypt_mysql` function\n'
         'and [AES] algorithm SHALL use the [OFB] block mode encryption with a 256 bit key.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_128_GCM_Error = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-128-GCM.Error',
@@ -3227,9 +5173,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_128_GCM_Error = R
         description=(
         '[ClickHouse] SHALL return an error if `aes-128-gcm` is specified as the value for the `mode` parameter of the\n'
         '`aes_decrypt_mysql` function.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_192_GCM_Error = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-192-GCM.Error',
@@ -3241,9 +5187,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_192_GCM_Error = R
         description=(
         '[ClickHouse] SHALL return an error if `aes-192-gcm` is specified as the value for the `mode` parameter of the\n'
         '`aes_decrypt_mysql` function.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_256_GCM_Error = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-256-GCM.Error',
@@ -3255,9 +5201,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_256_GCM_Error = R
         description=(
         '[ClickHouse] SHALL return an error if `aes-256-gcm` is specified as the value for the `mode` parameter of the\n'
         '`aes_decrypt_mysql` function.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_128_CTR_Error = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-128-CTR.Error',
@@ -3269,9 +5215,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_128_CTR_Error = R
         description=(
         '[ClickHouse] SHALL return an error if `aes-128-ctr` is specified as the value for the `mode` parameter of the\n'
         '`aes_decrypt_mysql` function.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_192_CTR_Error = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-192-CTR.Error',
@@ -3283,9 +5229,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_192_CTR_Error = R
         description=(
         '[ClickHouse] SHALL return an error if `aes-192-ctr` is specified as the value for the `mode` parameter of the\n'
         '`aes_decrypt_mysql` function.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_256_CTR_Error = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.Mode.Value.AES-256-CTR.Error',
@@ -3297,9 +5243,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_Mode_Value_AES_256_CTR_Error = R
         description=(
         '[ClickHouse] SHALL return an error if `aes-256-ctr` is specified as the value for the `mode` parameter of the\n'
         '`aes_decrypt_mysql` function.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_InitializationVector = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.InitializationVector',
@@ -3312,9 +5258,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_InitializationVector = Requireme
         '[ClickHouse] SHALL support `iv` with `String` or `FixedString` data types as the optional fourth\n'
         'parameter to the `aes_decrypt_mysql` function that SHALL specify the initialization vector for block modes that require\n'
         'it.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_ReturnValue = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Parameters.ReturnValue',
@@ -3326,9 +5272,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Parameters_ReturnValue = Requirement(
         description=(
         '[ClickHouse] SHALL return the decrypted value of the data\n'
         'using `String` data type as the result of `aes_decrypt_mysql` function.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Key_Length_TooShortError = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Key.Length.TooShortError',
@@ -3340,9 +5286,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Key_Length_TooShortError = Requirement(
         description=(
         '[ClickHouse] SHALL return an error if the `key` length is less than the minimum for the `aes_decrypt_mysql`\n'
         'function for a given block mode.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_Key_Length_TooLong = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.Key.Length.TooLong',
@@ -3364,9 +5310,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_Key_Length_TooLong = Requirement(
         '\t\t    folded_key[i % cipher_key_size] ^= key[i]\n'
         '\t  return folded_key\n'
         '```\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_InitializationVector_Length_TooShortError = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.InitializationVector.Length.TooShortError',
@@ -3378,9 +5324,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_InitializationVector_Length_TooShortError =
         description=(
         '[ClickHouse] SHALL return an error if the `iv` length is specified and is less than the minimum\n'
         'that is required for the `aes_decrypt_mysql` function for a given block mode.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_InitializationVector_Length_TooLong = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.InitializationVector.Length.TooLong',
@@ -3392,9 +5338,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_InitializationVector_Length_TooLong = Requi
         description=(
         '[ClickHouse] SHALL use the first `N` bytes that are required if the `iv` is specified and\n'
         'its length is longer than required for the `aes_decrypt_mysql` function for a given block mode.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_InitializationVector_NotValidForMode = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.InitializationVector.NotValidForMode',
@@ -3406,9 +5352,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_InitializationVector_NotValidForMode = Requ
         description=(
         '[ClickHouse] SHALL return an error if the `iv` is specified for the `aes_decrypt_mysql`\n'
         'function for a mode that does not need it.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_AES_128_ECB_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.AES-128-ECB.KeyAndInitializationVector.Length',
@@ -3420,9 +5366,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_AES_128_ECB_KeyAndInitializationVector_Leng
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-128-ecb` and `key` is less than 16 bytes\n'
         'or `iv` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_AES_192_ECB_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.AES-192-ECB.KeyAndInitializationVector.Length',
@@ -3434,9 +5380,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_AES_192_ECB_KeyAndInitializationVector_Leng
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-192-ecb` and `key` is less than 24 bytes\n'
         'or `iv` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_AES_256_ECB_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.AES-256-ECB.KeyAndInitializationVector.Length',
@@ -3448,9 +5394,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_AES_256_ECB_KeyAndInitializationVector_Leng
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-256-ecb` and `key` is less than 32 bytes\n'
         'or `iv` is specified.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_AES_128_CBC_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.AES-128-CBC.KeyAndInitializationVector.Length',
@@ -3462,9 +5408,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_AES_128_CBC_KeyAndInitializationVector_Leng
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-128-cbc` and `key` is less than 16 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_AES_192_CBC_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.AES-192-CBC.KeyAndInitializationVector.Length',
@@ -3476,9 +5422,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_AES_192_CBC_KeyAndInitializationVector_Leng
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-192-cbc` and `key` is less than 24 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_AES_256_CBC_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.AES-256-CBC.KeyAndInitializationVector.Length',
@@ -3490,9 +5436,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_AES_256_CBC_KeyAndInitializationVector_Leng
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-256-cbc` and `key` is less than 32 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_AES_128_CFB1_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.AES-128-CFB1.KeyAndInitializationVector.Length',
@@ -3504,9 +5450,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_AES_128_CFB1_KeyAndInitializationVector_Len
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-128-cfb1` and `key` is less than 16 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_AES_192_CFB1_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.AES-192-CFB1.KeyAndInitializationVector.Length',
@@ -3518,9 +5464,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_AES_192_CFB1_KeyAndInitializationVector_Len
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-192-cfb1` and `key` is less than 24 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_AES_256_CFB1_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.AES-256-CFB1.KeyAndInitializationVector.Length',
@@ -3532,9 +5478,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_AES_256_CFB1_KeyAndInitializationVector_Len
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-256-cfb1` and `key` is less than 32 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_AES_128_CFB8_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.AES-128-CFB8.KeyAndInitializationVector.Length',
@@ -3546,9 +5492,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_AES_128_CFB8_KeyAndInitializationVector_Len
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-128-cfb8` and `key` is less than 16 bytes\n'
         'and if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_AES_192_CFB8_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.AES-192-CFB8.KeyAndInitializationVector.Length',
@@ -3560,9 +5506,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_AES_192_CFB8_KeyAndInitializationVector_Len
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-192-cfb8` and `key` is less than 24 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_AES_256_CFB8_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.AES-256-CFB8.KeyAndInitializationVector.Length',
@@ -3574,9 +5520,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_AES_256_CFB8_KeyAndInitializationVector_Len
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-256-cfb8` and `key` is less than 32 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_AES_128_CFB128_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.AES-128-CFB128.KeyAndInitializationVector.Length',
@@ -3588,9 +5534,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_AES_128_CFB128_KeyAndInitializationVector_L
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-128-cfb128` and `key` is less than 16 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_AES_192_CFB128_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.AES-192-CFB128.KeyAndInitializationVector.Length',
@@ -3602,9 +5548,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_AES_192_CFB128_KeyAndInitializationVector_L
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-192-cfb128` and `key` is less than 24 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_AES_256_CFB128_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.AES-256-CFB128.KeyAndInitializationVector.Length',
@@ -3616,9 +5562,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_AES_256_CFB128_KeyAndInitializationVector_L
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-256-cfb128` and `key` is less than 32 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_AES_128_OFB_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.AES-128-OFB.KeyAndInitializationVector.Length',
@@ -3630,9 +5576,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_AES_128_OFB_KeyAndInitializationVector_Leng
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-128-ofb` and `key` is less than 16 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_AES_192_OFB_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.AES-192-OFB.KeyAndInitializationVector.Length',
@@ -3644,9 +5590,9 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_AES_192_OFB_KeyAndInitializationVector_Leng
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-192-ofb` and `key` is less than 24 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS008_AES_MySQL_Decrypt_Function_AES_256_OFB_KeyAndInitializationVector_Length = Requirement(
         name='RQ.SRS008.AES.MySQL.Decrypt.Function.AES-256-OFB.KeyAndInitializationVector.Length',
@@ -3658,6 +5604,6 @@ RQ_SRS008_AES_MySQL_Decrypt_Function_AES_256_OFB_KeyAndInitializationVector_Leng
         description=(
         '[ClickHouse] SHALL return an error when `mode` for the `aes_decrypt_mysql` function is set to `aes-256-ofb` and `key` is less than 32 bytes\n'
         'or if specified `iv` is less than 16 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)

--- a/tests/testflows/ldap/authentication/regression.py
+++ b/tests/testflows/ldap/authentication/regression.py
@@ -33,7 +33,7 @@ xfails = {
     RQ_SRS_007_LDAP_Authentication("1.0")
 )
 @XFails(xfails)
-def regression(self, local, clickhouse_binary_path):
+def regression(self, local, clickhouse_binary_path, stress=None, parallel=None):
     """ClickHouse integration with LDAP regression module.
     """
     nodes = {
@@ -42,6 +42,11 @@ def regression(self, local, clickhouse_binary_path):
 
     with Cluster(local, clickhouse_binary_path, nodes=nodes) as cluster:
         self.context.cluster = cluster
+
+        if stress is not None or not hasattr(self.context, "stress"):
+            self.context.stress = stress
+        if parallel is not None or not hasattr(self.context, "parallel"):
+            self.context.parallel = parallel
 
         Scenario(run=load("ldap.authentication.tests.sanity", "scenario"))
         Scenario(run=load("ldap.authentication.tests.multiple_servers", "scenario"))

--- a/tests/testflows/ldap/authentication/requirements/requirements.md
+++ b/tests/testflows/ldap/authentication/requirements/requirements.md
@@ -460,14 +460,14 @@ time user configuration contains any of the `<password*>` entries.
 #### RQ.SRS-007.LDAP.Configuration.User.LDAP.InvalidServerName.NotDefined
 version: 1.0
 
-[ClickHouse] SHALL throw an error during any authentification attempt
+[ClickHouse] SHALL throw an error during any authentication attempt
 if the name of the [LDAP] server used inside the `<ldap>` entry
 is not defined in the `<ldap_servers>` section.
 
 #### RQ.SRS-007.LDAP.Configuration.User.LDAP.InvalidServerName.Empty
 version: 1.0
 
-[ClickHouse] SHALL throw an error during any authentification attempt
+[ClickHouse] SHALL throw an error during any authentication attempt
 if the name of the [LDAP] server used inside the `<ldap>` entry
 is empty.
 

--- a/tests/testflows/ldap/authentication/requirements/requirements.py
+++ b/tests/testflows/ldap/authentication/requirements/requirements.py
@@ -1,9 +1,570 @@
 # These requirements were auto generated
 # from software requirements specification (SRS)
-# document by TestFlows v1.6.200811.1124123.
+# document by TestFlows v1.6.201026.1232822.
 # Do not edit by hand but re-generate instead
 # using 'tfs requirements generate' command.
+from testflows.core import Specification
 from testflows.core import Requirement
+
+SRS_007_ClickHouse_Authentication_of_Users_via_LDAP = Specification(
+        name='SRS-007 ClickHouse Authentication of Users via LDAP', 
+        description=None,
+        author=None,
+        date=None, 
+        status=None, 
+        approved_by=None,
+        approved_date=None,
+        approved_version=None,
+        version=None,
+        group=None,
+        type=None,
+        link=None,
+        uid=None,
+        parent=None,
+        children=None,
+        content='''
+# SRS-007 ClickHouse Authentication of Users via LDAP
+
+## Table of Contents
+
+* 1 [Revision History](#revision-history)
+* 2 [Introduction](#introduction)
+* 3 [Terminology](#terminology)
+* 4 [Requirements](#requirements)
+  * 4.1 [Generic](#generic)
+    * 4.1.1 [RQ.SRS-007.LDAP.Authentication](#rqsrs-007ldapauthentication)
+    * 4.1.2 [RQ.SRS-007.LDAP.Authentication.MultipleServers](#rqsrs-007ldapauthenticationmultipleservers)
+    * 4.1.3 [RQ.SRS-007.LDAP.Authentication.Protocol.PlainText](#rqsrs-007ldapauthenticationprotocolplaintext)
+    * 4.1.4 [RQ.SRS-007.LDAP.Authentication.Protocol.TLS](#rqsrs-007ldapauthenticationprotocoltls)
+    * 4.1.5 [RQ.SRS-007.LDAP.Authentication.Protocol.StartTLS](#rqsrs-007ldapauthenticationprotocolstarttls)
+    * 4.1.6 [RQ.SRS-007.LDAP.Authentication.TLS.Certificate.Validation](#rqsrs-007ldapauthenticationtlscertificatevalidation)
+    * 4.1.7 [RQ.SRS-007.LDAP.Authentication.TLS.Certificate.SelfSigned](#rqsrs-007ldapauthenticationtlscertificateselfsigned)
+    * 4.1.8 [RQ.SRS-007.LDAP.Authentication.TLS.Certificate.SpecificCertificationAuthority](#rqsrs-007ldapauthenticationtlscertificatespecificcertificationauthority)
+    * 4.1.9 [RQ.SRS-007.LDAP.Server.Configuration.Invalid](#rqsrs-007ldapserverconfigurationinvalid)
+    * 4.1.10 [RQ.SRS-007.LDAP.User.Configuration.Invalid](#rqsrs-007ldapuserconfigurationinvalid)
+    * 4.1.11 [RQ.SRS-007.LDAP.Authentication.Mechanism.Anonymous](#rqsrs-007ldapauthenticationmechanismanonymous)
+    * 4.1.12 [RQ.SRS-007.LDAP.Authentication.Mechanism.Unauthenticated](#rqsrs-007ldapauthenticationmechanismunauthenticated)
+    * 4.1.13 [RQ.SRS-007.LDAP.Authentication.Mechanism.NamePassword](#rqsrs-007ldapauthenticationmechanismnamepassword)
+    * 4.1.14 [RQ.SRS-007.LDAP.Authentication.Valid](#rqsrs-007ldapauthenticationvalid)
+    * 4.1.15 [RQ.SRS-007.LDAP.Authentication.Invalid](#rqsrs-007ldapauthenticationinvalid)
+    * 4.1.16 [RQ.SRS-007.LDAP.Authentication.Invalid.DeletedUser](#rqsrs-007ldapauthenticationinvaliddeleteduser)
+    * 4.1.17 [RQ.SRS-007.LDAP.Authentication.UsernameChanged](#rqsrs-007ldapauthenticationusernamechanged)
+    * 4.1.18 [RQ.SRS-007.LDAP.Authentication.PasswordChanged](#rqsrs-007ldapauthenticationpasswordchanged)
+    * 4.1.19 [RQ.SRS-007.LDAP.Authentication.LDAPServerRestart](#rqsrs-007ldapauthenticationldapserverrestart)
+    * 4.1.20 [RQ.SRS-007.LDAP.Authentication.ClickHouseServerRestart](#rqsrs-007ldapauthenticationclickhouseserverrestart)
+    * 4.1.21 [RQ.SRS-007.LDAP.Authentication.Parallel](#rqsrs-007ldapauthenticationparallel)
+    * 4.1.22 [RQ.SRS-007.LDAP.Authentication.Parallel.ValidAndInvalid](#rqsrs-007ldapauthenticationparallelvalidandinvalid)
+  * 4.2 [Specific](#specific)
+    * 4.2.1 [RQ.SRS-007.LDAP.UnreachableServer](#rqsrs-007ldapunreachableserver)
+    * 4.2.2 [RQ.SRS-007.LDAP.Configuration.Server.Name](#rqsrs-007ldapconfigurationservername)
+    * 4.2.3 [RQ.SRS-007.LDAP.Configuration.Server.Host](#rqsrs-007ldapconfigurationserverhost)
+    * 4.2.4 [RQ.SRS-007.LDAP.Configuration.Server.Port](#rqsrs-007ldapconfigurationserverport)
+    * 4.2.5 [RQ.SRS-007.LDAP.Configuration.Server.Port.Default](#rqsrs-007ldapconfigurationserverportdefault)
+    * 4.2.6 [RQ.SRS-007.LDAP.Configuration.Server.AuthDN.Prefix](#rqsrs-007ldapconfigurationserverauthdnprefix)
+    * 4.2.7 [RQ.SRS-007.LDAP.Configuration.Server.AuthDN.Suffix](#rqsrs-007ldapconfigurationserverauthdnsuffix)
+    * 4.2.8 [RQ.SRS-007.LDAP.Configuration.Server.AuthDN.Value](#rqsrs-007ldapconfigurationserverauthdnvalue)
+    * 4.2.9 [RQ.SRS-007.LDAP.Configuration.Server.EnableTLS](#rqsrs-007ldapconfigurationserverenabletls)
+    * 4.2.10 [RQ.SRS-007.LDAP.Configuration.Server.EnableTLS.Options.Default](#rqsrs-007ldapconfigurationserverenabletlsoptionsdefault)
+    * 4.2.11 [RQ.SRS-007.LDAP.Configuration.Server.EnableTLS.Options.No](#rqsrs-007ldapconfigurationserverenabletlsoptionsno)
+    * 4.2.12 [RQ.SRS-007.LDAP.Configuration.Server.EnableTLS.Options.Yes](#rqsrs-007ldapconfigurationserverenabletlsoptionsyes)
+    * 4.2.13 [RQ.SRS-007.LDAP.Configuration.Server.EnableTLS.Options.StartTLS](#rqsrs-007ldapconfigurationserverenabletlsoptionsstarttls)
+    * 4.2.14 [RQ.SRS-007.LDAP.Configuration.Server.TLSMinimumProtocolVersion](#rqsrs-007ldapconfigurationservertlsminimumprotocolversion)
+    * 4.2.15 [RQ.SRS-007.LDAP.Configuration.Server.TLSMinimumProtocolVersion.Values](#rqsrs-007ldapconfigurationservertlsminimumprotocolversionvalues)
+    * 4.2.16 [RQ.SRS-007.LDAP.Configuration.Server.TLSMinimumProtocolVersion.Default](#rqsrs-007ldapconfigurationservertlsminimumprotocolversiondefault)
+    * 4.2.17 [RQ.SRS-007.LDAP.Configuration.Server.TLSRequireCert](#rqsrs-007ldapconfigurationservertlsrequirecert)
+    * 4.2.18 [RQ.SRS-007.LDAP.Configuration.Server.TLSRequireCert.Options.Default](#rqsrs-007ldapconfigurationservertlsrequirecertoptionsdefault)
+    * 4.2.19 [RQ.SRS-007.LDAP.Configuration.Server.TLSRequireCert.Options.Demand](#rqsrs-007ldapconfigurationservertlsrequirecertoptionsdemand)
+    * 4.2.20 [RQ.SRS-007.LDAP.Configuration.Server.TLSRequireCert.Options.Allow](#rqsrs-007ldapconfigurationservertlsrequirecertoptionsallow)
+    * 4.2.21 [RQ.SRS-007.LDAP.Configuration.Server.TLSRequireCert.Options.Try](#rqsrs-007ldapconfigurationservertlsrequirecertoptionstry)
+    * 4.2.22 [RQ.SRS-007.LDAP.Configuration.Server.TLSRequireCert.Options.Never](#rqsrs-007ldapconfigurationservertlsrequirecertoptionsnever)
+    * 4.2.23 [RQ.SRS-007.LDAP.Configuration.Server.TLSCertFile](#rqsrs-007ldapconfigurationservertlscertfile)
+    * 4.2.24 [RQ.SRS-007.LDAP.Configuration.Server.TLSKeyFile](#rqsrs-007ldapconfigurationservertlskeyfile)
+    * 4.2.25 [RQ.SRS-007.LDAP.Configuration.Server.TLSCACertDir](#rqsrs-007ldapconfigurationservertlscacertdir)
+    * 4.2.26 [RQ.SRS-007.LDAP.Configuration.Server.TLSCACertFile](#rqsrs-007ldapconfigurationservertlscacertfile)
+    * 4.2.27 [RQ.SRS-007.LDAP.Configuration.Server.TLSCipherSuite](#rqsrs-007ldapconfigurationservertlsciphersuite)
+    * 4.2.28 [RQ.SRS-007.LDAP.Configuration.Server.Syntax](#rqsrs-007ldapconfigurationserversyntax)
+    * 4.2.29 [RQ.SRS-007.LDAP.Configuration.User.RBAC](#rqsrs-007ldapconfigurationuserrbac)
+    * 4.2.30 [RQ.SRS-007.LDAP.Configuration.User.Syntax](#rqsrs-007ldapconfigurationusersyntax)
+    * 4.2.31 [RQ.SRS-007.LDAP.Configuration.User.Name.Empty](#rqsrs-007ldapconfigurationusernameempty)
+    * 4.2.32 [RQ.SRS-007.LDAP.Configuration.User.BothPasswordAndLDAP](#rqsrs-007ldapconfigurationuserbothpasswordandldap)
+    * 4.2.33 [RQ.SRS-007.LDAP.Configuration.User.LDAP.InvalidServerName.NotDefined](#rqsrs-007ldapconfigurationuserldapinvalidservernamenotdefined)
+    * 4.2.34 [RQ.SRS-007.LDAP.Configuration.User.LDAP.InvalidServerName.Empty](#rqsrs-007ldapconfigurationuserldapinvalidservernameempty)
+    * 4.2.35 [RQ.SRS-007.LDAP.Configuration.User.OnlyOneServer](#rqsrs-007ldapconfigurationuseronlyoneserver)
+    * 4.2.36 [RQ.SRS-007.LDAP.Configuration.User.Name.Long](#rqsrs-007ldapconfigurationusernamelong)
+    * 4.2.37 [RQ.SRS-007.LDAP.Configuration.User.Name.UTF8](#rqsrs-007ldapconfigurationusernameutf8)
+    * 4.2.38 [RQ.SRS-007.LDAP.Authentication.Username.Empty](#rqsrs-007ldapauthenticationusernameempty)
+    * 4.2.39 [RQ.SRS-007.LDAP.Authentication.Username.Long](#rqsrs-007ldapauthenticationusernamelong)
+    * 4.2.40 [RQ.SRS-007.LDAP.Authentication.Username.UTF8](#rqsrs-007ldapauthenticationusernameutf8)
+    * 4.2.41 [RQ.SRS-007.LDAP.Authentication.Password.Empty](#rqsrs-007ldapauthenticationpasswordempty)
+    * 4.2.42 [RQ.SRS-007.LDAP.Authentication.Password.Long](#rqsrs-007ldapauthenticationpasswordlong)
+    * 4.2.43 [RQ.SRS-007.LDAP.Authentication.Password.UTF8](#rqsrs-007ldapauthenticationpasswordutf8)
+* 5 [References](#references)
+
+## Revision History
+
+This document is stored in an electronic form using [Git] source control management software
+hosted in a [GitHub Repository].
+All the updates are tracked using the [Git]'s [Revision History].
+
+## Introduction
+
+[ClickHouse] currently does not have any integration with [LDAP].
+As the initial step in integrating with [LDAP] this software requirements specification covers
+only the requirements to enable authentication of users using an [LDAP] server.
+
+## Terminology
+
+* **CA** -
+  Certificate Authority ([CA])
+
+* **LDAP** -
+  Lightweight Directory Access Protocol ([LDAP])
+
+## Requirements
+
+### Generic
+
+#### RQ.SRS-007.LDAP.Authentication
+version: 1.0
+
+[ClickHouse] SHALL support user authentication via an [LDAP] server.
+
+#### RQ.SRS-007.LDAP.Authentication.MultipleServers
+version: 1.0
+
+[ClickHouse] SHALL support specifying multiple [LDAP] servers that can be used to authenticate
+users.
+
+#### RQ.SRS-007.LDAP.Authentication.Protocol.PlainText
+version: 1.0
+
+[ClickHouse] SHALL support user authentication using plain text `ldap://` non secure protocol.
+
+#### RQ.SRS-007.LDAP.Authentication.Protocol.TLS
+version: 1.0
+
+[ClickHouse] SHALL support user authentication using `SSL/TLS` `ldaps://` secure protocol.
+
+#### RQ.SRS-007.LDAP.Authentication.Protocol.StartTLS
+version: 1.0
+
+[ClickHouse] SHALL support user authentication using legacy `StartTLS` protocol which is a
+plain text `ldap://` protocol that is upgraded to [TLS].
+
+#### RQ.SRS-007.LDAP.Authentication.TLS.Certificate.Validation
+version: 1.0
+
+[ClickHouse] SHALL support certificate validation used for [TLS] connections.
+
+#### RQ.SRS-007.LDAP.Authentication.TLS.Certificate.SelfSigned
+version: 1.0
+
+[ClickHouse] SHALL support self-signed certificates for [TLS] connections.
+
+#### RQ.SRS-007.LDAP.Authentication.TLS.Certificate.SpecificCertificationAuthority
+version: 1.0
+
+[ClickHouse] SHALL support certificates signed by specific Certification Authority for [TLS] connections.
+
+#### RQ.SRS-007.LDAP.Server.Configuration.Invalid
+version: 1.0
+
+[ClickHouse] SHALL return an error and prohibit user login if [LDAP] server configuration is not valid.
+
+#### RQ.SRS-007.LDAP.User.Configuration.Invalid
+version: 1.0
+
+[ClickHouse] SHALL return an error and prohibit user login if user configuration is not valid.
+
+#### RQ.SRS-007.LDAP.Authentication.Mechanism.Anonymous
+version: 1.0
+
+[ClickHouse] SHALL return an error and prohibit authentication using [Anonymous Authentication Mechanism of Simple Bind]
+authentication mechanism.
+
+#### RQ.SRS-007.LDAP.Authentication.Mechanism.Unauthenticated
+version: 1.0
+
+[ClickHouse] SHALL return an error and prohibit authentication using [Unauthenticated Authentication Mechanism of Simple Bind]
+authentication mechanism.
+
+#### RQ.SRS-007.LDAP.Authentication.Mechanism.NamePassword
+version: 1.0
+
+[ClickHouse] SHALL allow authentication using only [Name/Password Authentication Mechanism of Simple Bind]
+authentication mechanism.
+
+#### RQ.SRS-007.LDAP.Authentication.Valid
+version: 1.0
+
+[ClickHouse] SHALL only allow user authentication using [LDAP] server if and only if
+user name and password match [LDAP] server records for the user.
+
+#### RQ.SRS-007.LDAP.Authentication.Invalid
+version: 1.0
+
+[ClickHouse] SHALL return an error and prohibit authentication if either user name or password
+do not match [LDAP] server records for the user.
+
+#### RQ.SRS-007.LDAP.Authentication.Invalid.DeletedUser
+version: 1.0
+
+[ClickHouse] SHALL return an error and prohibit authentication if the user
+has been deleted from the [LDAP] server.
+
+#### RQ.SRS-007.LDAP.Authentication.UsernameChanged
+version: 1.0
+
+[ClickHouse] SHALL return an error and prohibit authentication if the username is changed
+on the [LDAP] server.
+
+#### RQ.SRS-007.LDAP.Authentication.PasswordChanged
+version: 1.0
+
+[ClickHouse] SHALL return an error and prohibit authentication if the password
+for the user is changed on the [LDAP] server.
+
+#### RQ.SRS-007.LDAP.Authentication.LDAPServerRestart
+version: 1.0
+
+[ClickHouse] SHALL support authenticating users after [LDAP] server is restarted.
+
+#### RQ.SRS-007.LDAP.Authentication.ClickHouseServerRestart
+version: 1.0
+
+[ClickHouse] SHALL support authenticating users after server is restarted.
+
+#### RQ.SRS-007.LDAP.Authentication.Parallel
+version: 1.0
+
+[ClickHouse] SHALL support parallel authentication of users using [LDAP] server.
+
+#### RQ.SRS-007.LDAP.Authentication.Parallel.ValidAndInvalid
+version: 1.0
+
+[ClickHouse] SHALL support authentication of valid users and
+prohibit authentication of invalid users using [LDAP] server
+in parallel without having invalid attempts affecting valid authentications.
+
+### Specific
+
+#### RQ.SRS-007.LDAP.UnreachableServer
+version: 1.0
+
+[ClickHouse] SHALL return an error and prohibit user login if [LDAP] server is unreachable.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.Name
+version: 1.0
+
+[ClickHouse] SHALL not support empty string as a server name.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.Host
+version: 1.0
+
+[ClickHouse] SHALL support `<host>` parameter to specify [LDAP]
+server hostname or IP, this parameter SHALL be mandatory and SHALL not be empty.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.Port
+version: 1.0
+
+[ClickHouse] SHALL support `<port>` parameter to specify [LDAP] server port.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.Port.Default
+version: 1.0
+
+[ClickHouse] SHALL use default port number `636` if `enable_tls` is set to `yes` or `389` otherwise.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.AuthDN.Prefix
+version: 1.0
+
+[ClickHouse] SHALL support `<auth_dn_prefix>` parameter to specify the prefix
+of value used to construct the DN to bound to during authentication via [LDAP] server.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.AuthDN.Suffix
+version: 1.0
+
+[ClickHouse] SHALL support `<auth_dn_suffix>` parameter to specify the suffix
+of value used to construct the DN to bound to during authentication via [LDAP] server.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.AuthDN.Value
+version: 1.0
+
+[ClickHouse] SHALL construct DN as  `auth_dn_prefix + escape(user_name) + auth_dn_suffix` string.
+
+> This implies that auth_dn_suffix should usually have comma ',' as its first non-space character.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.EnableTLS
+version: 1.0
+
+[ClickHouse] SHALL support `<enable_tls>` parameter to trigger the use of secure connection to the [LDAP] server.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.EnableTLS.Options.Default
+version: 1.0
+
+[ClickHouse] SHALL use `yes` value as the default for `<enable_tls>` parameter
+to enable SSL/TLS `ldaps://` protocol.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.EnableTLS.Options.No
+version: 1.0
+
+[ClickHouse] SHALL support specifying `no` as the value of `<enable_tls>` parameter to enable
+plain text `ldap://` protocol.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.EnableTLS.Options.Yes
+version: 1.0
+
+[ClickHouse] SHALL support specifying `yes` as the value of `<enable_tls>` parameter to enable
+SSL/TLS `ldaps://` protocol.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.EnableTLS.Options.StartTLS
+version: 1.0
+
+[ClickHouse] SHALL support specifying `starttls` as the value of `<enable_tls>` parameter to enable
+legacy `StartTLS` protocol that used plain text `ldap://` protocol, upgraded to [TLS].
+
+#### RQ.SRS-007.LDAP.Configuration.Server.TLSMinimumProtocolVersion
+version: 1.0
+
+[ClickHouse] SHALL support `<tls_minimum_protocol_version>` parameter to specify
+the minimum protocol version of SSL/TLS.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.TLSMinimumProtocolVersion.Values
+version: 1.0
+
+[ClickHouse] SHALL support specifying `ssl2`, `ssl3`, `tls1.0`, `tls1.1`, and `tls1.2`
+as a value of the `<tls_minimum_protocol_version>` parameter.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.TLSMinimumProtocolVersion.Default
+version: 1.0
+
+[ClickHouse] SHALL set `tls1.2` as the default value of the `<tls_minimum_protocol_version>` parameter.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.TLSRequireCert
+version: 1.0
+
+[ClickHouse] SHALL support `<tls_require_cert>` parameter to specify [TLS] peer
+certificate verification behavior.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.TLSRequireCert.Options.Default
+version: 1.0
+
+[ClickHouse] SHALL use `demand` value as the default for the `<tls_require_cert>` parameter.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.TLSRequireCert.Options.Demand
+version: 1.0
+
+[ClickHouse] SHALL support specifying `demand` as the value of `<tls_require_cert>` parameter to
+enable requesting of client certificate.  If no certificate  is  provided,  or  a  bad   certificate   is
+provided, the session SHALL be immediately terminated.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.TLSRequireCert.Options.Allow
+version: 1.0
+
+[ClickHouse] SHALL support specifying `allow` as the value of `<tls_require_cert>` parameter to
+enable requesting of client certificate. If no
+certificate is provided, the session SHALL proceed normally.
+If a bad certificate is provided, it SHALL be ignored and the session SHALL proceed normally.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.TLSRequireCert.Options.Try
+version: 1.0
+
+[ClickHouse] SHALL support specifying `try` as the value of `<tls_require_cert>` parameter to
+enable requesting of client certificate. If no certificate is provided, the session
+SHALL proceed  normally.  If a bad certificate is provided, the session SHALL be
+immediately terminated.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.TLSRequireCert.Options.Never
+version: 1.0
+
+[ClickHouse] SHALL support specifying `never` as the value of `<tls_require_cert>` parameter to
+disable requesting of client certificate.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.TLSCertFile
+version: 1.0
+
+[ClickHouse] SHALL support `<tls_cert_file>` to specify the path to certificate file used by
+[ClickHouse] to establish connection with the [LDAP] server.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.TLSKeyFile
+version: 1.0
+
+[ClickHouse] SHALL support `<tls_key_file>` to specify the path to key file for the certificate
+specified by the `<tls_cert_file>` parameter.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.TLSCACertDir
+version: 1.0
+
+[ClickHouse] SHALL support `<tls_ca_cert_dir>` parameter to specify to a path to
+the directory containing [CA] certificates used to verify certificates provided by the [LDAP] server.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.TLSCACertFile
+version: 1.0
+
+[ClickHouse] SHALL support `<tls_ca_cert_file>` parameter to specify a path to a specific
+[CA] certificate file used to verify certificates provided by the [LDAP] server.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.TLSCipherSuite
+version: 1.0
+
+[ClickHouse] SHALL support `tls_cipher_suite` parameter to specify allowed cipher suites.
+The value SHALL use the same format as the `ciphersuites` in the [OpenSSL Ciphers].
+
+For example,
+
+```xml
+<tls_cipher_suite>ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:AES256-GCM-SHA384</tls_cipher_suite>
+```
+
+The available suites SHALL depend on the [OpenSSL] library version and variant used to build
+[ClickHouse] and therefore might change.
+
+#### RQ.SRS-007.LDAP.Configuration.Server.Syntax
+version: 1.0
+
+[ClickHouse] SHALL support the following example syntax to create an entry for an [LDAP] server inside the `config.xml`
+configuration file or of any configuration file inside the `config.d` directory.
+
+```xml
+<yandex>
+    <my_ldap_server>
+        <host>localhost</host>
+        <port>636</port>
+        <auth_dn_prefix>cn=</auth_dn_prefix>
+        <auth_dn_suffix>, ou=users, dc=example, dc=com</auth_dn_suffix>
+        <enable_tls>yes</enable_tls>
+        <tls_minimum_protocol_version>tls1.2</tls_minimum_protocol_version>
+        <tls_require_cert>demand</tls_require_cert>
+        <tls_cert_file>/path/to/tls_cert_file</tls_cert_file>
+        <tls_key_file>/path/to/tls_key_file</tls_key_file>
+        <tls_ca_cert_file>/path/to/tls_ca_cert_file</tls_ca_cert_file>
+        <tls_ca_cert_dir>/path/to/tls_ca_cert_dir</tls_ca_cert_dir>
+        <tls_cipher_suite>ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:AES256-GCM-SHA384</tls_cipher_suite>
+    </my_ldap_server>
+</yandex>
+```
+
+#### RQ.SRS-007.LDAP.Configuration.User.RBAC
+version: 1.0
+
+[ClickHouse] SHALL support creating users identified using an [LDAP] server using
+the following RBAC command
+
+```sql
+CREATE USER name IDENTIFIED WITH ldap_server BY 'server_name'
+```
+
+#### RQ.SRS-007.LDAP.Configuration.User.Syntax
+version: 1.0
+
+[ClickHouse] SHALL support the following example syntax to create a user that is authenticated using
+an [LDAP] server inside the `users.xml` file or any configuration file inside the `users.d` directory.
+
+```xml
+<yandex>
+    <users>
+        <user_name>
+            <ldap>
+                <server>my_ldap_server</server>
+            </ldap>
+        </user_name>
+    </users>
+</yandex>
+```
+
+#### RQ.SRS-007.LDAP.Configuration.User.Name.Empty
+version: 1.0
+
+[ClickHouse] SHALL not support empty string as a user name.
+
+#### RQ.SRS-007.LDAP.Configuration.User.BothPasswordAndLDAP
+version: 1.0
+
+[ClickHouse] SHALL throw an error if `<ldap>` is specified for the user and at the same
+time user configuration contains any of the `<password*>` entries.
+
+#### RQ.SRS-007.LDAP.Configuration.User.LDAP.InvalidServerName.NotDefined
+version: 1.0
+
+[ClickHouse] SHALL throw an error during any authentication attempt
+if the name of the [LDAP] server used inside the `<ldap>` entry
+is not defined in the `<ldap_servers>` section.
+
+#### RQ.SRS-007.LDAP.Configuration.User.LDAP.InvalidServerName.Empty
+version: 1.0
+
+[ClickHouse] SHALL throw an error during any authentication attempt
+if the name of the [LDAP] server used inside the `<ldap>` entry
+is empty.
+
+#### RQ.SRS-007.LDAP.Configuration.User.OnlyOneServer
+version: 1.0
+
+[ClickHouse] SHALL support specifying only one [LDAP] server for a given user.
+
+#### RQ.SRS-007.LDAP.Configuration.User.Name.Long
+version: 1.0
+
+[ClickHouse] SHALL support long user names of at least 256 bytes
+to specify users that can be authenticated using an [LDAP] server.
+
+#### RQ.SRS-007.LDAP.Configuration.User.Name.UTF8
+version: 1.0
+
+[ClickHouse] SHALL support user names that contain [UTF-8] characters.
+
+#### RQ.SRS-007.LDAP.Authentication.Username.Empty
+version: 1.0
+
+[ClickHouse] SHALL not support authenticating users with empty username.
+
+#### RQ.SRS-007.LDAP.Authentication.Username.Long
+version: 1.0
+
+[ClickHouse] SHALL support authenticating users with a long username of at least 256 bytes.
+
+#### RQ.SRS-007.LDAP.Authentication.Username.UTF8
+version: 1.0
+
+[ClickHouse] SHALL support authentication users with a username that contains [UTF-8] characters.
+
+#### RQ.SRS-007.LDAP.Authentication.Password.Empty
+version: 1.0
+
+[ClickHouse] SHALL not support authenticating users with empty passwords
+even if an empty password is valid for the user and
+is allowed by the [LDAP] server.
+
+#### RQ.SRS-007.LDAP.Authentication.Password.Long
+version: 1.0
+
+[ClickHouse] SHALL support long password of at least 256 bytes
+that can be used to authenticate users using an [LDAP] server.
+
+#### RQ.SRS-007.LDAP.Authentication.Password.UTF8
+version: 1.0
+
+[ClickHouse] SHALL support [UTF-8] characters in passwords
+used to authenticate users using an [LDAP] server.
+
+## References
+
+* **ClickHouse:** https://clickhouse.tech
+
+[Anonymous Authentication Mechanism of Simple Bind]: https://ldapwiki.com/wiki/Simple%20Authentication#section-Simple+Authentication-AnonymousAuthenticationMechanismOfSimpleBind
+[Unauthenticated Authentication Mechanism of Simple Bind]: https://ldapwiki.com/wiki/Simple%20Authentication#section-Simple+Authentication-UnauthenticatedAuthenticationMechanismOfSimpleBind
+[Name/Password Authentication Mechanism of Simple Bind]: https://ldapwiki.com/wiki/Simple%20Authentication#section-Simple+Authentication-NamePasswordAuthenticationMechanismOfSimpleBind
+[UTF-8]: https://en.wikipedia.org/wiki/UTF-8
+[OpenSSL]: https://www.openssl.org/
+[OpenSSL Ciphers]: https://www.openssl.org/docs/manmaster/man1/openssl-ciphers.html
+[CA]: https://en.wikipedia.org/wiki/Certificate_authority
+[TLS]: https://en.wikipedia.org/wiki/Transport_Layer_Security
+[LDAP]: https://en.wikipedia.org/wiki/Lightweight_Directory_Access_Protocol
+[ClickHouse]: https://clickhouse.tech
+[GitHub]: https://github.com
+[GitHub Repository]: https://github.com/ClickHouse/ClickHouse/blob/master/tests/testflows/ldap/authentication/requirements/requirements.md
+[Revision History]: https://github.com/ClickHouse/ClickHouse/commits/master/tests/testflows/ldap/authentication/requirements/requirements.md
+[Git]: https://git-scm.com/
+''')
 
 RQ_SRS_007_LDAP_Authentication = Requirement(
         name='RQ.SRS-007.LDAP.Authentication',
@@ -14,9 +575,9 @@ RQ_SRS_007_LDAP_Authentication = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL support user authentication via an [LDAP] server.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Authentication_MultipleServers = Requirement(
         name='RQ.SRS-007.LDAP.Authentication.MultipleServers',
@@ -28,9 +589,9 @@ RQ_SRS_007_LDAP_Authentication_MultipleServers = Requirement(
         description=(
         '[ClickHouse] SHALL support specifying multiple [LDAP] servers that can be used to authenticate\n'
         'users.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Authentication_Protocol_PlainText = Requirement(
         name='RQ.SRS-007.LDAP.Authentication.Protocol.PlainText',
@@ -41,9 +602,9 @@ RQ_SRS_007_LDAP_Authentication_Protocol_PlainText = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL support user authentication using plain text `ldap://` non secure protocol.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Authentication_Protocol_TLS = Requirement(
         name='RQ.SRS-007.LDAP.Authentication.Protocol.TLS',
@@ -54,9 +615,9 @@ RQ_SRS_007_LDAP_Authentication_Protocol_TLS = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL support user authentication using `SSL/TLS` `ldaps://` secure protocol.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Authentication_Protocol_StartTLS = Requirement(
         name='RQ.SRS-007.LDAP.Authentication.Protocol.StartTLS',
@@ -68,9 +629,9 @@ RQ_SRS_007_LDAP_Authentication_Protocol_StartTLS = Requirement(
         description=(
         '[ClickHouse] SHALL support user authentication using legacy `StartTLS` protocol which is a\n'
         'plain text `ldap://` protocol that is upgraded to [TLS].\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Authentication_TLS_Certificate_Validation = Requirement(
         name='RQ.SRS-007.LDAP.Authentication.TLS.Certificate.Validation',
@@ -81,9 +642,9 @@ RQ_SRS_007_LDAP_Authentication_TLS_Certificate_Validation = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL support certificate validation used for [TLS] connections.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Authentication_TLS_Certificate_SelfSigned = Requirement(
         name='RQ.SRS-007.LDAP.Authentication.TLS.Certificate.SelfSigned',
@@ -94,9 +655,9 @@ RQ_SRS_007_LDAP_Authentication_TLS_Certificate_SelfSigned = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL support self-signed certificates for [TLS] connections.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Authentication_TLS_Certificate_SpecificCertificationAuthority = Requirement(
         name='RQ.SRS-007.LDAP.Authentication.TLS.Certificate.SpecificCertificationAuthority',
@@ -107,9 +668,9 @@ RQ_SRS_007_LDAP_Authentication_TLS_Certificate_SpecificCertificationAuthority = 
         uid=None,
         description=(
         '[ClickHouse] SHALL support certificates signed by specific Certification Authority for [TLS] connections.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Server_Configuration_Invalid = Requirement(
         name='RQ.SRS-007.LDAP.Server.Configuration.Invalid',
@@ -120,9 +681,9 @@ RQ_SRS_007_LDAP_Server_Configuration_Invalid = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL return an error and prohibit user login if [LDAP] server configuration is not valid.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_User_Configuration_Invalid = Requirement(
         name='RQ.SRS-007.LDAP.User.Configuration.Invalid',
@@ -133,9 +694,9 @@ RQ_SRS_007_LDAP_User_Configuration_Invalid = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL return an error and prohibit user login if user configuration is not valid.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Authentication_Mechanism_Anonymous = Requirement(
         name='RQ.SRS-007.LDAP.Authentication.Mechanism.Anonymous',
@@ -147,9 +708,9 @@ RQ_SRS_007_LDAP_Authentication_Mechanism_Anonymous = Requirement(
         description=(
         '[ClickHouse] SHALL return an error and prohibit authentication using [Anonymous Authentication Mechanism of Simple Bind]\n'
         'authentication mechanism.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Authentication_Mechanism_Unauthenticated = Requirement(
         name='RQ.SRS-007.LDAP.Authentication.Mechanism.Unauthenticated',
@@ -161,9 +722,9 @@ RQ_SRS_007_LDAP_Authentication_Mechanism_Unauthenticated = Requirement(
         description=(
         '[ClickHouse] SHALL return an error and prohibit authentication using [Unauthenticated Authentication Mechanism of Simple Bind]\n'
         'authentication mechanism.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Authentication_Mechanism_NamePassword = Requirement(
         name='RQ.SRS-007.LDAP.Authentication.Mechanism.NamePassword',
@@ -175,9 +736,9 @@ RQ_SRS_007_LDAP_Authentication_Mechanism_NamePassword = Requirement(
         description=(
         '[ClickHouse] SHALL allow authentication using only [Name/Password Authentication Mechanism of Simple Bind]\n'
         'authentication mechanism.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Authentication_Valid = Requirement(
         name='RQ.SRS-007.LDAP.Authentication.Valid',
@@ -189,9 +750,9 @@ RQ_SRS_007_LDAP_Authentication_Valid = Requirement(
         description=(
         '[ClickHouse] SHALL only allow user authentication using [LDAP] server if and only if\n'
         'user name and password match [LDAP] server records for the user.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Authentication_Invalid = Requirement(
         name='RQ.SRS-007.LDAP.Authentication.Invalid',
@@ -203,9 +764,9 @@ RQ_SRS_007_LDAP_Authentication_Invalid = Requirement(
         description=(
         '[ClickHouse] SHALL return an error and prohibit authentication if either user name or password\n'
         'do not match [LDAP] server records for the user.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Authentication_Invalid_DeletedUser = Requirement(
         name='RQ.SRS-007.LDAP.Authentication.Invalid.DeletedUser',
@@ -217,9 +778,9 @@ RQ_SRS_007_LDAP_Authentication_Invalid_DeletedUser = Requirement(
         description=(
         '[ClickHouse] SHALL return an error and prohibit authentication if the user\n'
         'has been deleted from the [LDAP] server.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Authentication_UsernameChanged = Requirement(
         name='RQ.SRS-007.LDAP.Authentication.UsernameChanged',
@@ -231,9 +792,9 @@ RQ_SRS_007_LDAP_Authentication_UsernameChanged = Requirement(
         description=(
         '[ClickHouse] SHALL return an error and prohibit authentication if the username is changed\n'
         'on the [LDAP] server.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Authentication_PasswordChanged = Requirement(
         name='RQ.SRS-007.LDAP.Authentication.PasswordChanged',
@@ -245,9 +806,9 @@ RQ_SRS_007_LDAP_Authentication_PasswordChanged = Requirement(
         description=(
         '[ClickHouse] SHALL return an error and prohibit authentication if the password\n'
         'for the user is changed on the [LDAP] server.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Authentication_LDAPServerRestart = Requirement(
         name='RQ.SRS-007.LDAP.Authentication.LDAPServerRestart',
@@ -258,9 +819,9 @@ RQ_SRS_007_LDAP_Authentication_LDAPServerRestart = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL support authenticating users after [LDAP] server is restarted.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Authentication_ClickHouseServerRestart = Requirement(
         name='RQ.SRS-007.LDAP.Authentication.ClickHouseServerRestart',
@@ -271,9 +832,9 @@ RQ_SRS_007_LDAP_Authentication_ClickHouseServerRestart = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL support authenticating users after server is restarted.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Authentication_Parallel = Requirement(
         name='RQ.SRS-007.LDAP.Authentication.Parallel',
@@ -284,9 +845,9 @@ RQ_SRS_007_LDAP_Authentication_Parallel = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL support parallel authentication of users using [LDAP] server.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Authentication_Parallel_ValidAndInvalid = Requirement(
         name='RQ.SRS-007.LDAP.Authentication.Parallel.ValidAndInvalid',
@@ -299,9 +860,9 @@ RQ_SRS_007_LDAP_Authentication_Parallel_ValidAndInvalid = Requirement(
         '[ClickHouse] SHALL support authentication of valid users and\n'
         'prohibit authentication of invalid users using [LDAP] server\n'
         'in parallel without having invalid attempts affecting valid authentications.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_UnreachableServer = Requirement(
         name='RQ.SRS-007.LDAP.UnreachableServer',
@@ -312,9 +873,9 @@ RQ_SRS_007_LDAP_UnreachableServer = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL return an error and prohibit user login if [LDAP] server is unreachable.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_Name = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.Name',
@@ -325,9 +886,9 @@ RQ_SRS_007_LDAP_Configuration_Server_Name = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL not support empty string as a server name.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_Host = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.Host',
@@ -339,9 +900,9 @@ RQ_SRS_007_LDAP_Configuration_Server_Host = Requirement(
         description=(
         '[ClickHouse] SHALL support `<host>` parameter to specify [LDAP]\n'
         'server hostname or IP, this parameter SHALL be mandatory and SHALL not be empty.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_Port = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.Port',
@@ -352,9 +913,9 @@ RQ_SRS_007_LDAP_Configuration_Server_Port = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL support `<port>` parameter to specify [LDAP] server port.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_Port_Default = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.Port.Default',
@@ -365,9 +926,9 @@ RQ_SRS_007_LDAP_Configuration_Server_Port_Default = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL use default port number `636` if `enable_tls` is set to `yes` or `389` otherwise.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_AuthDN_Prefix = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.AuthDN.Prefix',
@@ -379,9 +940,9 @@ RQ_SRS_007_LDAP_Configuration_Server_AuthDN_Prefix = Requirement(
         description=(
         '[ClickHouse] SHALL support `<auth_dn_prefix>` parameter to specify the prefix\n'
         'of value used to construct the DN to bound to during authentication via [LDAP] server.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_AuthDN_Suffix = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.AuthDN.Suffix',
@@ -393,9 +954,9 @@ RQ_SRS_007_LDAP_Configuration_Server_AuthDN_Suffix = Requirement(
         description=(
         '[ClickHouse] SHALL support `<auth_dn_suffix>` parameter to specify the suffix\n'
         'of value used to construct the DN to bound to during authentication via [LDAP] server.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_AuthDN_Value = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.AuthDN.Value',
@@ -408,9 +969,9 @@ RQ_SRS_007_LDAP_Configuration_Server_AuthDN_Value = Requirement(
         '[ClickHouse] SHALL construct DN as  `auth_dn_prefix + escape(user_name) + auth_dn_suffix` string.\n'
         '\n'
         "> This implies that auth_dn_suffix should usually have comma ',' as its first non-space character.\n"
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_EnableTLS = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.EnableTLS',
@@ -421,9 +982,9 @@ RQ_SRS_007_LDAP_Configuration_Server_EnableTLS = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL support `<enable_tls>` parameter to trigger the use of secure connection to the [LDAP] server.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_EnableTLS_Options_Default = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.EnableTLS.Options.Default',
@@ -435,9 +996,9 @@ RQ_SRS_007_LDAP_Configuration_Server_EnableTLS_Options_Default = Requirement(
         description=(
         '[ClickHouse] SHALL use `yes` value as the default for `<enable_tls>` parameter\n'
         'to enable SSL/TLS `ldaps://` protocol.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_EnableTLS_Options_No = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.EnableTLS.Options.No',
@@ -449,9 +1010,9 @@ RQ_SRS_007_LDAP_Configuration_Server_EnableTLS_Options_No = Requirement(
         description=(
         '[ClickHouse] SHALL support specifying `no` as the value of `<enable_tls>` parameter to enable\n'
         'plain text `ldap://` protocol.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_EnableTLS_Options_Yes = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.EnableTLS.Options.Yes',
@@ -463,9 +1024,9 @@ RQ_SRS_007_LDAP_Configuration_Server_EnableTLS_Options_Yes = Requirement(
         description=(
         '[ClickHouse] SHALL support specifying `yes` as the value of `<enable_tls>` parameter to enable\n'
         'SSL/TLS `ldaps://` protocol.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_EnableTLS_Options_StartTLS = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.EnableTLS.Options.StartTLS',
@@ -477,9 +1038,9 @@ RQ_SRS_007_LDAP_Configuration_Server_EnableTLS_Options_StartTLS = Requirement(
         description=(
         '[ClickHouse] SHALL support specifying `starttls` as the value of `<enable_tls>` parameter to enable\n'
         'legacy `StartTLS` protocol that used plain text `ldap://` protocol, upgraded to [TLS].\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_TLSMinimumProtocolVersion = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.TLSMinimumProtocolVersion',
@@ -491,9 +1052,9 @@ RQ_SRS_007_LDAP_Configuration_Server_TLSMinimumProtocolVersion = Requirement(
         description=(
         '[ClickHouse] SHALL support `<tls_minimum_protocol_version>` parameter to specify\n'
         'the minimum protocol version of SSL/TLS.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_TLSMinimumProtocolVersion_Values = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.TLSMinimumProtocolVersion.Values',
@@ -505,9 +1066,9 @@ RQ_SRS_007_LDAP_Configuration_Server_TLSMinimumProtocolVersion_Values = Requirem
         description=(
         '[ClickHouse] SHALL support specifying `ssl2`, `ssl3`, `tls1.0`, `tls1.1`, and `tls1.2`\n'
         'as a value of the `<tls_minimum_protocol_version>` parameter.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_TLSMinimumProtocolVersion_Default = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.TLSMinimumProtocolVersion.Default',
@@ -518,9 +1079,9 @@ RQ_SRS_007_LDAP_Configuration_Server_TLSMinimumProtocolVersion_Default = Require
         uid=None,
         description=(
         '[ClickHouse] SHALL set `tls1.2` as the default value of the `<tls_minimum_protocol_version>` parameter.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_TLSRequireCert = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.TLSRequireCert',
@@ -532,9 +1093,9 @@ RQ_SRS_007_LDAP_Configuration_Server_TLSRequireCert = Requirement(
         description=(
         '[ClickHouse] SHALL support `<tls_require_cert>` parameter to specify [TLS] peer\n'
         'certificate verification behavior.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_TLSRequireCert_Options_Default = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.TLSRequireCert.Options.Default',
@@ -545,9 +1106,9 @@ RQ_SRS_007_LDAP_Configuration_Server_TLSRequireCert_Options_Default = Requiremen
         uid=None,
         description=(
         '[ClickHouse] SHALL use `demand` value as the default for the `<tls_require_cert>` parameter.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_TLSRequireCert_Options_Demand = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.TLSRequireCert.Options.Demand',
@@ -560,9 +1121,9 @@ RQ_SRS_007_LDAP_Configuration_Server_TLSRequireCert_Options_Demand = Requirement
         '[ClickHouse] SHALL support specifying `demand` as the value of `<tls_require_cert>` parameter to\n'
         'enable requesting of client certificate.  If no certificate  is  provided,  or  a  bad   certificate   is\n'
         'provided, the session SHALL be immediately terminated.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_TLSRequireCert_Options_Allow = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.TLSRequireCert.Options.Allow',
@@ -576,9 +1137,9 @@ RQ_SRS_007_LDAP_Configuration_Server_TLSRequireCert_Options_Allow = Requirement(
         'enable requesting of client certificate. If no\n'
         'certificate is provided, the session SHALL proceed normally.\n'
         'If a bad certificate is provided, it SHALL be ignored and the session SHALL proceed normally.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_TLSRequireCert_Options_Try = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.TLSRequireCert.Options.Try',
@@ -592,9 +1153,9 @@ RQ_SRS_007_LDAP_Configuration_Server_TLSRequireCert_Options_Try = Requirement(
         'enable requesting of client certificate. If no certificate is provided, the session\n'
         'SHALL proceed  normally.  If a bad certificate is provided, the session SHALL be\n'
         'immediately terminated.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_TLSRequireCert_Options_Never = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.TLSRequireCert.Options.Never',
@@ -606,9 +1167,9 @@ RQ_SRS_007_LDAP_Configuration_Server_TLSRequireCert_Options_Never = Requirement(
         description=(
         '[ClickHouse] SHALL support specifying `never` as the value of `<tls_require_cert>` parameter to\n'
         'disable requesting of client certificate.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_TLSCertFile = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.TLSCertFile',
@@ -620,9 +1181,9 @@ RQ_SRS_007_LDAP_Configuration_Server_TLSCertFile = Requirement(
         description=(
         '[ClickHouse] SHALL support `<tls_cert_file>` to specify the path to certificate file used by\n'
         '[ClickHouse] to establish connection with the [LDAP] server.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_TLSKeyFile = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.TLSKeyFile',
@@ -634,9 +1195,9 @@ RQ_SRS_007_LDAP_Configuration_Server_TLSKeyFile = Requirement(
         description=(
         '[ClickHouse] SHALL support `<tls_key_file>` to specify the path to key file for the certificate\n'
         'specified by the `<tls_cert_file>` parameter.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_TLSCACertDir = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.TLSCACertDir',
@@ -648,9 +1209,9 @@ RQ_SRS_007_LDAP_Configuration_Server_TLSCACertDir = Requirement(
         description=(
         '[ClickHouse] SHALL support `<tls_ca_cert_dir>` parameter to specify to a path to\n'
         'the directory containing [CA] certificates used to verify certificates provided by the [LDAP] server.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_TLSCACertFile = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.TLSCACertFile',
@@ -662,9 +1223,9 @@ RQ_SRS_007_LDAP_Configuration_Server_TLSCACertFile = Requirement(
         description=(
         '[ClickHouse] SHALL support `<tls_ca_cert_file>` parameter to specify a path to a specific\n'
         '[CA] certificate file used to verify certificates provided by the [LDAP] server.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_TLSCipherSuite = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.TLSCipherSuite',
@@ -685,9 +1246,9 @@ RQ_SRS_007_LDAP_Configuration_Server_TLSCipherSuite = Requirement(
         '\n'
         'The available suites SHALL depend on the [OpenSSL] library version and variant used to build\n'
         '[ClickHouse] and therefore might change.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_Server_Syntax = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.Server.Syntax',
@@ -718,9 +1279,9 @@ RQ_SRS_007_LDAP_Configuration_Server_Syntax = Requirement(
         '    </my_ldap_server>\n'
         '</yandex>\n'
         '```\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_User_RBAC = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.User.RBAC',
@@ -736,9 +1297,9 @@ RQ_SRS_007_LDAP_Configuration_User_RBAC = Requirement(
         '```sql\n'
         "CREATE USER name IDENTIFIED WITH ldap_server BY 'server_name'\n"
         '```\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_User_Syntax = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.User.Syntax',
@@ -762,9 +1323,9 @@ RQ_SRS_007_LDAP_Configuration_User_Syntax = Requirement(
         '    </users>\n'
         '</yandex>\n'
         '```\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_User_Name_Empty = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.User.Name.Empty',
@@ -775,9 +1336,9 @@ RQ_SRS_007_LDAP_Configuration_User_Name_Empty = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL not support empty string as a user name.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_User_BothPasswordAndLDAP = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.User.BothPasswordAndLDAP',
@@ -789,9 +1350,9 @@ RQ_SRS_007_LDAP_Configuration_User_BothPasswordAndLDAP = Requirement(
         description=(
         '[ClickHouse] SHALL throw an error if `<ldap>` is specified for the user and at the same\n'
         'time user configuration contains any of the `<password*>` entries.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_User_LDAP_InvalidServerName_NotDefined = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.User.LDAP.InvalidServerName.NotDefined',
@@ -801,12 +1362,12 @@ RQ_SRS_007_LDAP_Configuration_User_LDAP_InvalidServerName_NotDefined = Requireme
         type=None,
         uid=None,
         description=(
-        '[ClickHouse] SHALL throw an error during any authentification attempt\n'
+        '[ClickHouse] SHALL throw an error during any authentication attempt\n'
         'if the name of the [LDAP] server used inside the `<ldap>` entry\n'
         'is not defined in the `<ldap_servers>` section.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_User_LDAP_InvalidServerName_Empty = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.User.LDAP.InvalidServerName.Empty',
@@ -816,12 +1377,12 @@ RQ_SRS_007_LDAP_Configuration_User_LDAP_InvalidServerName_Empty = Requirement(
         type=None,
         uid=None,
         description=(
-        '[ClickHouse] SHALL throw an error during any authentification attempt\n'
+        '[ClickHouse] SHALL throw an error during any authentication attempt\n'
         'if the name of the [LDAP] server used inside the `<ldap>` entry\n'
         'is empty.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_User_OnlyOneServer = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.User.OnlyOneServer',
@@ -832,9 +1393,9 @@ RQ_SRS_007_LDAP_Configuration_User_OnlyOneServer = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL support specifying only one [LDAP] server for a given user.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_User_Name_Long = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.User.Name.Long',
@@ -846,9 +1407,9 @@ RQ_SRS_007_LDAP_Configuration_User_Name_Long = Requirement(
         description=(
         '[ClickHouse] SHALL support long user names of at least 256 bytes\n'
         'to specify users that can be authenticated using an [LDAP] server.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Configuration_User_Name_UTF8 = Requirement(
         name='RQ.SRS-007.LDAP.Configuration.User.Name.UTF8',
@@ -859,9 +1420,9 @@ RQ_SRS_007_LDAP_Configuration_User_Name_UTF8 = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL support user names that contain [UTF-8] characters.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Authentication_Username_Empty = Requirement(
         name='RQ.SRS-007.LDAP.Authentication.Username.Empty',
@@ -872,9 +1433,9 @@ RQ_SRS_007_LDAP_Authentication_Username_Empty = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL not support authenticating users with empty username.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Authentication_Username_Long = Requirement(
         name='RQ.SRS-007.LDAP.Authentication.Username.Long',
@@ -885,9 +1446,9 @@ RQ_SRS_007_LDAP_Authentication_Username_Long = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL support authenticating users with a long username of at least 256 bytes.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Authentication_Username_UTF8 = Requirement(
         name='RQ.SRS-007.LDAP.Authentication.Username.UTF8',
@@ -898,9 +1459,9 @@ RQ_SRS_007_LDAP_Authentication_Username_UTF8 = Requirement(
         uid=None,
         description=(
         '[ClickHouse] SHALL support authentication users with a username that contains [UTF-8] characters.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Authentication_Password_Empty = Requirement(
         name='RQ.SRS-007.LDAP.Authentication.Password.Empty',
@@ -913,9 +1474,9 @@ RQ_SRS_007_LDAP_Authentication_Password_Empty = Requirement(
         '[ClickHouse] SHALL not support authenticating users with empty passwords\n'
         'even if an empty password is valid for the user and\n'
         'is allowed by the [LDAP] server.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Authentication_Password_Long = Requirement(
         name='RQ.SRS-007.LDAP.Authentication.Password.Long',
@@ -927,9 +1488,9 @@ RQ_SRS_007_LDAP_Authentication_Password_Long = Requirement(
         description=(
         '[ClickHouse] SHALL support long password of at least 256 bytes\n'
         'that can be used to authenticate users using an [LDAP] server.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)
 
 RQ_SRS_007_LDAP_Authentication_Password_UTF8 = Requirement(
         name='RQ.SRS-007.LDAP.Authentication.Password.UTF8',
@@ -941,6 +1502,6 @@ RQ_SRS_007_LDAP_Authentication_Password_UTF8 = Requirement(
         description=(
         '[ClickHouse] SHALL support [UTF-8] characters in passwords\n'
         'used to authenticate users using an [LDAP] server.\n'
+        '\n'
         ),
-        link=None
-    )
+        link=None)

--- a/tests/testflows/ldap/external_user_directory/regression.py
+++ b/tests/testflows/ldap/external_user_directory/regression.py
@@ -33,7 +33,7 @@ xfails = {
     RQ_SRS_009_LDAP_ExternalUserDirectory_Authentication("1.0")
 )
 @XFails(xfails)
-def regression(self, local, clickhouse_binary_path):
+def regression(self, local, clickhouse_binary_path, stress=None, parallel=None):
     """ClickHouse LDAP external user directory regression module.
     """
     nodes = {
@@ -42,6 +42,11 @@ def regression(self, local, clickhouse_binary_path):
 
     with Cluster(local, clickhouse_binary_path, nodes=nodes) as cluster:
         self.context.cluster = cluster
+        
+        if stress is not None or not hasattr(self.context, "stress"):
+            self.context.stress = stress
+        if parallel is not None or not hasattr(self.context, "parallel"):
+            self.context.parallel = parallel
 
         Scenario(run=load("ldap.authentication.tests.sanity", "scenario"))
         Scenario(run=load("ldap.external_user_directory.tests.simple", "scenario"))

--- a/tests/testflows/ldap/external_user_directory/tests/authentications.py
+++ b/tests/testflows/ldap/external_user_directory/tests/authentications.py
@@ -92,25 +92,23 @@ def parallel_login(self, server, user_count=10, timeout=200):
     with Given("a group of LDAP users"):
         users = [{"cn": f"parallel_user{i}", "userpassword": randomword(20)} for i in range(user_count)]
 
-    with rbac_roles("ldap_role") as roles:
-        with ldap_external_user_directory(server=server, roles=roles, restart=True):
-            with ldap_users(*users):
-                tasks = []
-                try:
-                    with When("users try to login in parallel", description="""
-                        * with valid username and password
-                        * with invalid username and valid password
-                        * with valid username and invalid password
-                        """):
-                        p = Pool(15)
-                        for i in range(25):
-                            tasks.append(p.apply_async(login_with_valid_username_and_password, (users, i, 50,)))
-                            tasks.append(p.apply_async(login_with_valid_username_and_invalid_password, (users, i, 50,)))
-                            tasks.append(p.apply_async(login_with_invalid_username_and_valid_password, (users, i, 50,)))
+    with ldap_users(*users):
+        tasks = []
+        try:
+            with When("users try to login in parallel", description="""
+                * with valid username and password
+                * with invalid username and valid password
+                * with valid username and invalid password
+                """):
+                p = Pool(15)
+                for i in range(25):
+                    tasks.append(p.apply_async(login_with_valid_username_and_password, (users, i, 50,)))
+                    tasks.append(p.apply_async(login_with_valid_username_and_invalid_password, (users, i, 50,)))
+                    tasks.append(p.apply_async(login_with_invalid_username_and_valid_password, (users, i, 50,)))
 
-                finally:
-                    with Then("it should work"):
-                        join(tasks, timeout)
+        finally:
+            with Then("it should work"):
+                join(tasks, timeout)
 
 @TestScenario
 @Requirements(
@@ -127,25 +125,23 @@ def parallel_login_with_the_same_user(self, server, timeout=200):
     with Given("only one LDAP user"):
         users = [{"cn": f"parallel_user1", "userpassword": randomword(20)}]
 
-    with rbac_roles("ldap_role") as roles:
-        with ldap_external_user_directory(server=server, roles=roles, restart=True):
-            with ldap_users(*users):
-                tasks = []
-                try:
-                    with When("the same user tries to login in parallel", description="""
-                        * with valid username and password
-                        * with invalid username and valid password
-                        * with valid username and invalid password
-                        """):
-                        p = Pool(15)
-                        for i in range(25):
-                            tasks.append(p.apply_async(login_with_valid_username_and_password, (users, i, 50,)))
-                            tasks.append(p.apply_async(login_with_valid_username_and_invalid_password, (users, i, 50,)))
-                            tasks.append(p.apply_async(login_with_invalid_username_and_valid_password, (users, i, 50,)))
+    with ldap_users(*users):
+        tasks = []
+        try:
+            with When("the same user tries to login in parallel", description="""
+                * with valid username and password
+                * with invalid username and valid password
+                * with valid username and invalid password
+                """):
+                p = Pool(15)
+                for i in range(25):
+                    tasks.append(p.apply_async(login_with_valid_username_and_password, (users, i, 50,)))
+                    tasks.append(p.apply_async(login_with_valid_username_and_invalid_password, (users, i, 50,)))
+                    tasks.append(p.apply_async(login_with_invalid_username_and_valid_password, (users, i, 50,)))
 
-                finally:
-                    with Then("it should work"):
-                        join(tasks, timeout)
+        finally:
+            with Then("it should work"):
+                join(tasks, timeout)
 
 @TestScenario
 def login_after_ldap_external_user_directory_is_removed(self, server):
@@ -162,6 +158,7 @@ def login_after_ldap_external_user_directory_is_removed(self, server):
         login_and_execute_query(username="user2", password="user2", exitcode=exitcode, message=message)
 
 @TestScenario
+@Tags("custom config")
 @Requirements(
     RQ_SRS_009_LDAP_ExternalUserDirectory_Authentication_Parallel_SameUser("1.0"),
     RQ_SRS_009_LDAP_ExternalUserDirectory_Authentication_Parallel_ValidAndInvalid("1.0")
@@ -204,6 +201,7 @@ def parallel_login_with_the_same_user_multiple_servers(self, server, timeout=200
                         join(tasks, timeout)
 
 @TestScenario
+@Tags("custom config")
 @Requirements(
     RQ_SRS_009_LDAP_ExternalUserDirectory_Authentication_Parallel_MultipleServers("1.0"),
     RQ_SRS_009_LDAP_ExternalUserDirectory_Authentication_Parallel_ValidAndInvalid("1.0")
@@ -256,6 +254,7 @@ def parallel_login_with_multiple_servers(self, server, user_count=10, timeout=20
                         join(tasks, timeout)
 
 @TestScenario
+@Tags("custom config")
 @Requirements(
     RQ_SRS_009_LDAP_ExternalUserDirectory_Authentication_Parallel_LocalAndMultipleLDAP("1.0"),
     RQ_SRS_009_LDAP_ExternalUserDirectory_Authentication_Parallel_ValidAndInvalid("1.0")
@@ -323,20 +322,18 @@ def parallel_login_with_rbac_users(self, server, user_count=10, timeout=200):
 
     users = [{"cn": f"parallel_user{i}", "userpassword": randomword(20)} for i in range(user_count)]
 
-    with rbac_roles("ldap_role") as roles:
-        with ldap_external_user_directory(server=server, roles=roles, restart=True):
-            with rbac_users(*users):
-                tasks = []
-                try:
-                    with When("I login in parallel"):
-                        p = Pool(15)
-                        for i in range(25):
-                            tasks.append(p.apply_async(login_with_valid_username_and_password, (users, i, 50,)))
-                            tasks.append(p.apply_async(login_with_valid_username_and_invalid_password, (users, i, 50,)))
-                            tasks.append(p.apply_async(login_with_invalid_username_and_valid_password, (users, i, 50,)))
-                finally:
-                    with Then("it should work"):
-                        join(tasks, timeout)
+    with rbac_users(*users):
+        tasks = []
+        try:
+            with When("I login in parallel"):
+                p = Pool(15)
+                for i in range(25):
+                    tasks.append(p.apply_async(login_with_valid_username_and_password, (users, i, 50,)))
+                    tasks.append(p.apply_async(login_with_valid_username_and_invalid_password, (users, i, 50,)))
+                    tasks.append(p.apply_async(login_with_invalid_username_and_valid_password, (users, i, 50,)))
+        finally:
+            with Then("it should work"):
+                join(tasks, timeout)
 
 @TestScenario
 @Requirements(
@@ -347,10 +344,8 @@ def login_after_user_is_added_to_ldap(self, server):
     """
     user = {"cn": "myuser", "userpassword": "myuser"}
 
-    with rbac_roles("ldap_role") as roles:
-        with ldap_external_user_directory(server=server, roles=roles, restart=True):
-            with When(f"I add user to LDAP and try to login"):
-                add_user_to_ldap_and_login(user=user, server=server)
+    with When(f"I add user to LDAP and try to login"):
+        add_user_to_ldap_and_login(user=user, server=server)
 
 @TestScenario
 @Requirements(
@@ -363,27 +358,25 @@ def login_after_user_is_deleted_from_ldap(self, server):
     self.context.ldap_node = self.context.cluster.node(server)
     user = None
 
-    with rbac_roles("ldap_role") as roles:
-        with ldap_external_user_directory(server=server, roles=roles, restart=True):
-            try:
-                with Given(f"I add user to LDAP"):
-                    user = {"cn": "myuser", "userpassword": "myuser"}
-                    user = add_user_to_ldap(**user)
+    try:
+        with Given(f"I add user to LDAP"):
+            user = {"cn": "myuser", "userpassword": "myuser"}
+            user = add_user_to_ldap(**user)
 
-                login_and_execute_query(username=user["cn"], password=user["userpassword"])
+        login_and_execute_query(username=user["cn"], password=user["userpassword"])
 
-                with When("I delete this user from LDAP"):
-                    delete_user_from_ldap(user)
+        with When("I delete this user from LDAP"):
+            delete_user_from_ldap(user)
 
-                with Then("when I try to login again it should fail"):
-                    login_and_execute_query(username=user["cn"], password=user["userpassword"],
-                        exitcode=4,
-                        message=f"DB::Exception: {user['cn']}: Authentication failed: password is incorrect or there is no user with such name"
-                    )
-            finally:
-                with Finally("I make sure LDAP user is deleted"):
-                    if user is not None:
-                        delete_user_from_ldap(user, exitcode=None)
+        with Then("when I try to login again it should fail"):
+            login_and_execute_query(username=user["cn"], password=user["userpassword"],
+                exitcode=4,
+                message=f"DB::Exception: {user['cn']}: Authentication failed: password is incorrect or there is no user with such name"
+            )
+    finally:
+        with Finally("I make sure LDAP user is deleted"):
+            if user is not None:
+                delete_user_from_ldap(user, exitcode=None)
 
 @TestScenario
 @Requirements(
@@ -396,31 +389,29 @@ def login_after_user_password_changed_in_ldap(self, server):
     self.context.ldap_node = self.context.cluster.node(server)
     user = None
 
-    with rbac_roles("ldap_role") as roles:
-        with ldap_external_user_directory(server=server, roles=roles, restart=True):
-            try:
-                with Given(f"I add user to LDAP"):
-                    user = {"cn": "myuser", "userpassword": "myuser"}
-                    user = add_user_to_ldap(**user)
+    try:
+        with Given(f"I add user to LDAP"):
+            user = {"cn": "myuser", "userpassword": "myuser"}
+            user = add_user_to_ldap(**user)
 
-                login_and_execute_query(username=user["cn"], password=user["userpassword"])
+        login_and_execute_query(username=user["cn"], password=user["userpassword"])
 
-                with When("I change user password in LDAP"):
-                    change_user_password_in_ldap(user, "newpassword")
+        with When("I change user password in LDAP"):
+            change_user_password_in_ldap(user, "newpassword")
 
-                with Then("when I try to login again it should fail"):
-                    login_and_execute_query(username=user["cn"], password=user["userpassword"],
-                        exitcode=4,
-                        message=f"DB::Exception: {user['cn']}: Authentication failed: password is incorrect or there is no user with such name"
-                    )
+        with Then("when I try to login again it should fail"):
+            login_and_execute_query(username=user["cn"], password=user["userpassword"],
+                exitcode=4,
+                message=f"DB::Exception: {user['cn']}: Authentication failed: password is incorrect or there is no user with such name"
+            )
 
-                with And("when I try to login with the new password it should work"):
-                    login_and_execute_query(username=user["cn"], password="newpassword")
+        with And("when I try to login with the new password it should work"):
+            login_and_execute_query(username=user["cn"], password="newpassword")
 
-            finally:
-                with Finally("I make sure LDAP user is deleted"):
-                    if user is not None:
-                        delete_user_from_ldap(user, exitcode=None)
+    finally:
+        with Finally("I make sure LDAP user is deleted"):
+            if user is not None:
+                delete_user_from_ldap(user, exitcode=None)
 
 @TestScenario
 @Requirements(
@@ -434,27 +425,25 @@ def login_after_user_cn_changed_in_ldap(self, server):
     user = None
     new_user = None
 
-    with rbac_roles("ldap_role") as roles:
-        with ldap_external_user_directory(server=server, roles=roles, restart=True):
-            try:
-                with Given(f"I add user to LDAP"):
-                    user = {"cn": "myuser", "userpassword": "myuser"}
-                    user = add_user_to_ldap(**user)
+    try:
+        with Given(f"I add user to LDAP"):
+            user = {"cn": "myuser", "userpassword": "myuser"}
+            user = add_user_to_ldap(**user)
 
-                login_and_execute_query(username=user["cn"], password=user["userpassword"])
+        login_and_execute_query(username=user["cn"], password=user["userpassword"])
 
-                with When("I change user password in LDAP"):
-                    new_user = change_user_cn_in_ldap(user, "myuser2")
+        with When("I change user password in LDAP"):
+            new_user = change_user_cn_in_ldap(user, "myuser2")
 
-                with Then("when I try to login again it should fail"):
-                    login_and_execute_query(username=user["cn"], password=user["userpassword"],
-                        exitcode=4,
-                        message=f"DB::Exception: {user['cn']}: Authentication failed: password is incorrect or there is no user with such name"
-                    )
-            finally:
-                with Finally("I make sure LDAP user is deleted"):
-                    if new_user is not None:
-                        delete_user_from_ldap(new_user, exitcode=None)
+        with Then("when I try to login again it should fail"):
+            login_and_execute_query(username=user["cn"], password=user["userpassword"],
+                exitcode=4,
+                message=f"DB::Exception: {user['cn']}: Authentication failed: password is incorrect or there is no user with such name"
+            )
+    finally:
+        with Finally("I make sure LDAP user is deleted"):
+            if new_user is not None:
+                delete_user_from_ldap(new_user, exitcode=None)
 
 @TestScenario
 @Requirements(
@@ -467,31 +456,29 @@ def login_after_ldap_server_is_restarted(self, server, timeout=60):
     self.context.ldap_node = self.context.cluster.node(server)
     user = None
 
-    with rbac_roles("ldap_role") as roles:
-        with ldap_external_user_directory(server=server, roles=roles, restart=True):
-            try:
-                with Given(f"I add user to LDAP"):
-                    user = {"cn": "myuser", "userpassword": getuid()}
-                    user = add_user_to_ldap(**user)
+    try:
+        with Given(f"I add user to LDAP"):
+            user = {"cn": "myuser", "userpassword": getuid()}
+            user = add_user_to_ldap(**user)
 
-                login_and_execute_query(username=user["cn"], password=user["userpassword"])
+        login_and_execute_query(username=user["cn"], password=user["userpassword"])
 
-                with When("I restart LDAP server"):
-                    self.context.ldap_node.restart()
+        with When("I restart LDAP server"):
+            self.context.ldap_node.restart()
 
-                with Then("I try to login until it works", description=f"timeout {timeout} sec"):
-                    started = time.time()
-                    while True:
-                        r = self.context.node.query("SELECT 1",
-                            settings=[("user", user["cn"]), ("password", user["userpassword"])],
-                            no_checks=True)
-                        if r.exitcode == 0:
-                            break
-                        assert time.time() - started < timeout, error(r.output)
-            finally:
-                with Finally("I make sure LDAP user is deleted"):
-                    if user is not None:
-                        delete_user_from_ldap(user, exitcode=None)
+        with Then("I try to login until it works", description=f"timeout {timeout} sec"):
+            started = time.time()
+            while True:
+                r = self.context.node.query("SELECT 1",
+                    settings=[("user", user["cn"]), ("password", user["userpassword"])],
+                    no_checks=True)
+                if r.exitcode == 0:
+                    break
+                assert time.time() - started < timeout, error(r.output)
+    finally:
+        with Finally("I make sure LDAP user is deleted"):
+            if user is not None:
+                delete_user_from_ldap(user, exitcode=None)
 
 @TestScenario
 @Requirements(
@@ -504,31 +491,29 @@ def login_after_clickhouse_server_is_restarted(self, server, timeout=60):
     self.context.ldap_node = self.context.cluster.node(server)
     user = None
 
-    with rbac_roles("ldap_role") as roles:
-        with ldap_external_user_directory(server=server, roles=roles, restart=True):
-            try:
-                with Given(f"I add user to LDAP"):
-                    user = {"cn": "myuser", "userpassword": getuid()}
-                    user = add_user_to_ldap(**user)
+    try:
+        with Given(f"I add user to LDAP"):
+            user = {"cn": "myuser", "userpassword": getuid()}
+            user = add_user_to_ldap(**user)
 
-                login_and_execute_query(username=user["cn"], password=user["userpassword"])
+        login_and_execute_query(username=user["cn"], password=user["userpassword"])
 
-                with When("I restart ClickHouse server"):
-                    self.context.node.restart()
+        with When("I restart ClickHouse server"):
+            self.context.node.restart()
 
-                with Then("I try to login until it works", description=f"timeout {timeout} sec"):
-                    started = time.time()
-                    while True:
-                        r = self.context.node.query("SELECT 1",
-                            settings=[("user", user["cn"]), ("password", user["userpassword"])],
-                            no_checks=True)
-                        if r.exitcode == 0:
-                            break
-                        assert time.time() - started < timeout, error(r.output)
-            finally:
-                with Finally("I make sure LDAP user is deleted"):
-                    if user is not None:
-                        delete_user_from_ldap(user, exitcode=None)
+        with Then("I try to login until it works", description=f"timeout {timeout} sec"):
+            started = time.time()
+            while True:
+                r = self.context.node.query("SELECT 1",
+                    settings=[("user", user["cn"]), ("password", user["userpassword"])],
+                    no_checks=True)
+                if r.exitcode == 0:
+                    break
+                assert time.time() - started < timeout, error(r.output)
+    finally:
+        with Finally("I make sure LDAP user is deleted"):
+            if user is not None:
+                delete_user_from_ldap(user, exitcode=None)
 
 @TestScenario
 @Requirements(
@@ -542,9 +527,7 @@ def valid_username_with_valid_empty_password(self, server):
     exitcode = 4
     message = f"DB::Exception: {user['cn']}: Authentication failed: password is incorrect or there is no user with such name"
 
-    with rbac_roles("ldap_role") as roles:
-        with ldap_external_user_directory(server=server, roles=roles, restart=True):
-            add_user_to_ldap_and_login(user=user, exitcode=exitcode, message=message, server=server)
+    add_user_to_ldap_and_login(user=user, exitcode=exitcode, message=message, server=server)
 
 @TestScenario
 @Requirements(
@@ -561,9 +544,7 @@ def valid_username_and_invalid_empty_password(self, server):
     exitcode = 4
     message = f"DB::Exception: {username}: Authentication failed: password is incorrect or there is no user with such name"
 
-    with rbac_roles("ldap_role") as roles:
-        with ldap_external_user_directory(server=server, roles=roles, restart=True):
-            add_user_to_ldap_and_login(user=user, login=login, exitcode=exitcode, message=message, server=server)
+    add_user_to_ldap_and_login(user=user, login=login, exitcode=exitcode, message=message, server=server)
 
 @TestScenario
 @Requirements(
@@ -575,10 +556,8 @@ def valid_username_and_password(self, server):
     username = "valid_username_and_password"
     user = {"cn": username, "userpassword": username}
 
-    with rbac_roles("ldap_role") as roles:
-        with ldap_external_user_directory(server=server, roles=roles, restart=True):
-            with When(f"I add user {username} to LDAP and try to login"):
-                add_user_to_ldap_and_login(user=user, server=server)
+    with When(f"I add user {username} to LDAP and try to login"):
+        add_user_to_ldap_and_login(user=user, server=server)
 
 @TestScenario
 @Requirements(
@@ -593,9 +572,7 @@ def valid_username_and_password_invalid_server(self, server=None):
     exitcode = 4
     message = f"DB::Exception: user2: Authentication failed: password is incorrect or there is no user with such name"
 
-    with rbac_roles("ldap_role") as roles:
-        with ldap_external_user_directory(server=server, roles=roles, restart=True):
-            login_and_execute_query(username="user2", password="user2", exitcode=exitcode, message=message)
+    login_and_execute_query(username="user2", password="user2", exitcode=exitcode, message=message)
 
 @TestScenario
 @Requirements(
@@ -608,9 +585,7 @@ def valid_long_username_and_short_password(self, server):
     username = "long_username_12345678901234567890123456789012345678901234567890123456789012345678901234567890"
     user = {"cn": username, "userpassword": "long_username"}
 
-    with rbac_roles("ldap_role") as roles:
-        with ldap_external_user_directory(server=server, roles=roles, restart=True):
-            add_user_to_ldap_and_login(user=user, server=server)
+    add_user_to_ldap_and_login(user=user, server=server)
 
 @TestScenario
 @Requirements(
@@ -626,9 +601,7 @@ def invalid_long_username_and_valid_short_password(self, server):
     exitcode = 4
     message=f"DB::Exception: {login['username']}: Authentication failed: password is incorrect or there is no user with such name"
 
-    with rbac_roles("ldap_role") as roles:
-        with ldap_external_user_directory(server=server, roles=roles, restart=True):
-            add_user_to_ldap_and_login(user=user, login=login, exitcode=exitcode, message=message, server=server)
+    add_user_to_ldap_and_login(user=user, login=login, exitcode=exitcode, message=message, server=server)
 
 @TestScenario
 @Requirements(
@@ -641,9 +614,7 @@ def valid_short_username_and_long_password(self, server):
     username = "long_password"
     user = {"cn": username, "userpassword": "long_password_12345678901234567890123456789012345678901234567890123456789012345678901234567890"}
 
-    with rbac_roles("ldap_role") as roles:
-        with ldap_external_user_directory(server=server, roles=roles, restart=True):
-            add_user_to_ldap_and_login(user=user, server=server)
+    add_user_to_ldap_and_login(user=user, server=server)
 
 @TestScenario
 @Requirements(
@@ -659,9 +630,7 @@ def valid_short_username_and_invalid_long_password(self, server):
     exitcode = 4
     message=f"DB::Exception: {username}: Authentication failed: password is incorrect or there is no user with such name"
 
-    with rbac_roles("ldap_role") as roles:
-        with ldap_external_user_directory(server=server, roles=roles, restart=True):
-            add_user_to_ldap_and_login(user=user, login=login, exitcode=exitcode, message=message, server=server)
+    add_user_to_ldap_and_login(user=user, login=login, exitcode=exitcode, message=message, server=server)
 
 @TestScenario
 @Requirements(
@@ -677,9 +646,7 @@ def valid_username_and_invalid_password(self, server):
     exitcode = 4
     message=f"DB::Exception: {username}: Authentication failed: password is incorrect or there is no user with such name"
 
-    with rbac_roles("ldap_role") as roles:
-        with ldap_external_user_directory(server=server, roles=roles, restart=True):
-            add_user_to_ldap_and_login(user=user, login=login, exitcode=exitcode, message=message, server=server)
+    add_user_to_ldap_and_login(user=user, login=login, exitcode=exitcode, message=message, server=server)
 
 @TestScenario
 @Requirements(
@@ -695,9 +662,7 @@ def invalid_username_and_valid_password(self, server):
     exitcode = 4
     message=f"DB::Exception: {login['username']}: Authentication failed: password is incorrect or there is no user with such name"
 
-    with rbac_roles("ldap_role") as roles:
-        with ldap_external_user_directory(server=server, roles=roles, restart=True):
-            add_user_to_ldap_and_login(user=user, login=login, exitcode=exitcode, message=message, server=server)
+    add_user_to_ldap_and_login(user=user, login=login, exitcode=exitcode, message=message, server=server)
 
 @TestScenario
 @Requirements(
@@ -710,9 +675,7 @@ def valid_utf8_username_and_ascii_password(self, server):
     username = "utf8_username_Gãńdåłf_Thê_Gręât"
     user = {"cn": username, "userpassword": "utf8_username"}
 
-    with rbac_roles("ldap_role") as roles:
-        with ldap_external_user_directory(server=server, roles=roles, restart=True):
-            add_user_to_ldap_and_login(user=user, server=server)
+    add_user_to_ldap_and_login(user=user, server=server)
 
 @TestScenario
 @Requirements(
@@ -725,18 +688,14 @@ def valid_ascii_username_and_utf8_password(self, server):
     username = "utf8_password"
     user = {"cn": username, "userpassword": "utf8_password_Gãńdåłf_Thê_Gręât"}
 
-    with rbac_roles("ldap_role") as roles:
-        with ldap_external_user_directory(server=server, roles=roles, restart=True):
-            add_user_to_ldap_and_login(user=user, server=server)
+    add_user_to_ldap_and_login(user=user, server=server)
 
 @TestScenario
 def empty_username_and_empty_password(self, server=None):
     """Check that we can login using empty username and empty password as
     it will use the default user and that has an empty password.
     """
-    with rbac_roles("ldap_role") as roles:
-        with ldap_external_user_directory(server=server, roles=roles, restart=True):
-            login_and_execute_query(username="", password="")
+    login_and_execute_query(username="", password="")
 
 @TestScenario
 @Requirements(
@@ -763,18 +722,16 @@ def user_lookup_priority(self, server):
         "ldap": {"username": "ldap", "password": "userldap"}
     }
 
-    with rbac_roles("ldap_role") as roles:
-        with ldap_external_user_directory(server=server, roles=roles, restart=True):
-            with ldap_users(*[{"cn": user["username"], "userpassword": user["password"]} for user in users.values()]):
-                with rbac_users({"cn": "local", "userpassword": "local"}):
-                    with When("I try to login as 'default' user which is also defined in users.xml it should fail"):
-                        login_and_execute_query(**users["default"], exitcode=exitcode, message=message.format(username="default"))
+    with ldap_users(*[{"cn": user["username"], "userpassword": user["password"]} for user in users.values()]):
+        with rbac_users({"cn": "local", "userpassword": "local"}):
+            with When("I try to login as 'default' user which is also defined in users.xml it should fail"):
+                login_and_execute_query(**users["default"], exitcode=exitcode, message=message.format(username="default"))
 
-                    with When("I try to login as 'local' user which is also defined in local storage it should fail"):
-                        login_and_execute_query(**users["local"], exitcode=exitcode, message=message.format(username="local"))
+            with When("I try to login as 'local' user which is also defined in local storage it should fail"):
+                login_and_execute_query(**users["local"], exitcode=exitcode, message=message.format(username="local"))
 
-                    with When("I try to login as 'ldap' user defined only in LDAP it should work"):
-                        login_and_execute_query(**users["ldap"])
+            with When("I try to login as 'ldap' user defined only in LDAP it should work"):
+                login_and_execute_query(**users["ldap"])
 
 
 @TestOutline(Feature)
@@ -795,5 +752,10 @@ def feature(self, servers=None, server=None, node="clickhouse1"):
         server = "openldap1"
 
     with ldap_servers(servers):
-        for scenario in loads(current_module(), Scenario):
+        with rbac_roles("ldap_role") as roles:
+            with ldap_external_user_directory(server=server, roles=roles, restart=True):
+                for scenario in loads(current_module(), Scenario, filter=~has.tag("custom config")):
+                    Scenario(test=scenario, flags=TE)(server=server)
+
+        for scenario in loads(current_module(), Scenario, filter=has.tag("custom config")):
             Scenario(test=scenario, flags=TE)(server=server)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix LDAP tests by grabbing log size after container is stopped

Detailed description / Documentation draft:
Fix LDAP tests by grabbing log size after container is stopped
