### PR TITLE
Auto-balance big parts in JBOD array

### DIFF
--- a/src/Storages/MergeTree/DataPartsExchange.h
+++ b/src/Storages/MergeTree/DataPartsExchange.h
@@ -58,7 +58,8 @@ public:
         const String & password,
         const String & interserver_scheme,
         bool to_detached = false,
-        const String & tmp_prefix_ = "");
+        const String & tmp_prefix_ = "",
+        std::optional<CurrentlySubmergingEmergingTagger> * tagger_ptr = nullptr);
 
     /// You need to stop the data transfer.
     ActionBlocker blocker;

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -4145,17 +4145,17 @@ ReservationPtr MergeTreeData::balancedReservation(
     if (tagger_ptr && min_bytes_to_rebalance_partition_over_jbod > 0 && part_size >= min_bytes_to_rebalance_partition_over_jbod)
     try
     {
-        auto & disks = getStoragePolicy()->getVolume(max_volume_index)->getDisks();
+        const auto & disks = getStoragePolicy()->getVolume(max_volume_index)->getDisks();
         std::map<String, size_t> disk_occupation;
         std::map<String, std::vector<String>> disk_parts;
-        for (auto & disk : disks)
+        for (const auto & disk : disks)
             disk_occupation.emplace(disk->getName(), 0);
 
         std::set<String> big_parts;
         std::set<String> merging_parts;
         std::lock_guard lock(currently_submerging_emerging_mutex);
 
-        for (auto & part : currently_submerging_parts)
+        for (const auto & part : currently_submerging_parts)
         {
             if (part->isStoredOnDisk() && part->getBytesOnDisk() >= min_bytes_to_rebalance_partition_over_jbod
                 && part_info.partition_id == part->info.partition_id)
@@ -4174,7 +4174,7 @@ ReservationPtr MergeTreeData::balancedReservation(
             }
 
             // Also include current submerging parts
-            for (auto & part : covered_parts)
+            for (const auto & part : covered_parts)
                 merging_parts.insert(part->name);
 
             for (const auto & part : getDataPartsStateRange(MergeTreeData::DataPartState::Committed))
@@ -4201,7 +4201,7 @@ ReservationPtr MergeTreeData::balancedReservation(
             }
         }
 
-        for (auto & [name, emerging_part] : currently_emerging_parts)
+        for (const auto & [name, emerging_part] : currently_emerging_parts)
         {
             // It's possible that the emerging parts are committed and get added twice. Thus a set is used to deduplicate.
             if (big_parts.find(name) == big_parts.end())
@@ -4218,7 +4218,7 @@ ReservationPtr MergeTreeData::balancedReservation(
 
         size_t min_occupation_size = std::numeric_limits<size_t>::max();
         std::vector<String> candidates;
-        for (auto & [disk_name, size] : disk_occupation)
+        for (const auto & [disk_name, size] : disk_occupation)
         {
             if (size < min_occupation_size)
             {
@@ -4238,7 +4238,7 @@ ReservationPtr MergeTreeData::balancedReservation(
             String selected_disk_name = candidates.front();
             WriteBufferFromOwnString log_str;
             writeCString("\nbalancer: \n", log_str);
-            for (auto & [disk_name, per_disk_parts] : disk_parts)
+            for (const auto & [disk_name, per_disk_parts] : disk_parts)
                 writeString(fmt::format("  {}: [{}]\n", disk_name, boost::algorithm::join(per_disk_parts, ", ")), log_str);
             LOG_DEBUG(log, log_str.str());
 

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -4256,7 +4256,7 @@ ReservationPtr MergeTreeData::balancedReservation(
             WriteBufferFromOwnString log_str;
             writeCString("\nbalancer: \n", log_str);
             for (const auto & [disk_name, per_disk_parts] : disk_parts_for_logging)
-                writeString(fmt::format("  {}: [{}]\n", disk_name, boost::algorithm::join(per_disk_parts, ", ")), log_str);
+                writeString(fmt::format("  {}: [{}]\n", disk_name, fmt::join(per_disk_parts, ", ")), log_str);
             LOG_DEBUG(log, log_str.str());
 
             if (ttl_infos)

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -768,10 +768,10 @@ public:
     bool areBackgroundMovesNeeded() const;
 
     /// Parts that currently submerging (merging to bigger parts) or emerging
-    /// (to be appeared after merging finished). This set have to be used
+    /// (to be appeared after merging finished). These two variables have to be used
     /// with `currently_submerging_emerging_mutex`.
-    DataParts currently_submerging_parts;
-    std::map<String, EmergingPartInfo> currently_emerging_parts;
+    DataParts currently_submerging_big_parts;
+    std::map<String, EmergingPartInfo> currently_emerging_big_parts;
     /// Mutex for currently_submerging_parts and currently_emerging_parts
     mutable std::mutex currently_submerging_emerging_mutex;
 
@@ -1014,13 +1014,13 @@ private:
 struct CurrentlySubmergingEmergingTagger
 {
     MergeTreeData & storage;
-    String name;
-    MergeTreeData::DataPartsVector parts;
+    String emerging_part_name;
+    MergeTreeData::DataPartsVector submerging_parts;
     Poco::Logger * log;
 
     CurrentlySubmergingEmergingTagger(
         MergeTreeData & storage_, const String & name_, MergeTreeData::DataPartsVector && parts_, Poco::Logger * log_)
-        : storage(storage_), name(name_), parts(std::move(parts_)), log(log_)
+        : storage(storage_), emerging_part_name(name_), submerging_parts(std::move(parts_)), log(log_)
     {
     }
 

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -41,6 +41,16 @@ class MutationCommands;
 class Context;
 struct JobAndPool;
 
+/// Auxiliary struct holding information about the future merged or mutated part.
+struct EmergingPartInfo
+{
+    String disk_name;
+    String partition_id;
+    size_t estimate_bytes;
+};
+
+struct CurrentlySubmergingEmergingTagger;
+
 class ExpressionActions;
 using ExpressionActionsPtr = std::shared_ptr<ExpressionActions>;
 using ManyExpressionActions = std::vector<ExpressionActionsPtr>;
@@ -651,7 +661,8 @@ public:
         const IMergeTreeDataPart::TTLInfos & ttl_infos,
         time_t time_of_move,
         size_t min_volume_index = 0,
-        bool is_insert = false) const;
+        bool is_insert = false,
+        DiskPtr selected_disk = nullptr) const;
 
     ReservationPtr tryReserveSpacePreferringTTLRules(
         const StorageMetadataPtr & metadata_snapshot,
@@ -659,7 +670,22 @@ public:
         const IMergeTreeDataPart::TTLInfos & ttl_infos,
         time_t time_of_move,
         size_t min_volume_index = 0,
-        bool is_insert = false) const;
+        bool is_insert = false,
+        DiskPtr selected_disk = nullptr) const;
+
+    /// Reserves space for the part based on the distribution of "big parts" in the same partition.
+    /// Parts with estimated size larger than `min_bytes_to_rebalance_partition_over_jbod` are
+    /// considered as big. The priority is lower than TTL. If reservation fails, return nullptr.
+    ReservationPtr balancedReservation(
+        const StorageMetadataPtr & metadata_snapshot,
+        size_t part_size,
+        size_t max_volume_index,
+        const String & part_name,
+        const MergeTreePartInfo & part_info,
+        MergeTreeData::DataPartsVector covered_parts,
+        std::optional<CurrentlySubmergingEmergingTagger> * tagger_ptr,
+        const IMergeTreeDataPart::TTLInfos * ttl_infos,
+        bool is_insert = false);
 
     /// Choose disk with max available free space
     /// Reserves 0 bytes
@@ -740,6 +766,14 @@ public:
     /// Return job to move parts between disks/volumes and so on.
     std::optional<JobAndPool> getDataMovingJob();
     bool areBackgroundMovesNeeded() const;
+
+    /// Parts that currently submerging (merging to bigger parts) or emerging
+    /// (to be appeared after merging finished). This set have to be used
+    /// with `currently_submerging_emerging_mutex`.
+    DataParts currently_submerging_parts;
+    std::map<String, EmergingPartInfo> currently_emerging_parts;
+    /// Mutex for currently_submerging_parts and currently_emerging_parts
+    mutable std::mutex currently_submerging_emerging_mutex;
 
 protected:
 
@@ -973,6 +1007,24 @@ private:
     // Record all query ids which access the table. It's guarded by `query_id_set_mutex` and is always mutable.
     mutable std::set<String> query_id_set;
     mutable std::mutex query_id_set_mutex;
+};
+
+/// RAII struct to record big parts that are submerging or emerging.
+/// It's used to calculate the balanced statistics of JBOD array.
+struct CurrentlySubmergingEmergingTagger
+{
+    MergeTreeData & storage;
+    String name;
+    MergeTreeData::DataPartsVector parts;
+    Poco::Logger * log;
+
+    CurrentlySubmergingEmergingTagger(
+        MergeTreeData & storage_, const String & name_, MergeTreeData::DataPartsVector && parts_, Poco::Logger * log_)
+        : storage(storage_), name(name_), parts(std::move(parts_)), log(log_)
+    {
+    }
+
+    ~CurrentlySubmergingEmergingTagger();
 };
 
 }

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -119,6 +119,7 @@ struct Settings;
     M(Int64, max_partitions_to_read, -1, "Limit the max number of partitions that can be accessed in one query. <= 0 means unlimited. This setting is the default that can be overridden by the query-level setting with the same name.", 0) \
     M(UInt64, max_concurrent_queries, 0, "Max number of concurrently executed queries related to the MergeTree table (0 - disabled). Queries will still be limited by other max_concurrent_queries settings.", 0) \
     M(UInt64, min_marks_to_honor_max_concurrent_queries, 0, "Minimal number of marks to honor the MergeTree-level's max_concurrent_queries (0 - disabled). Queries will still be limited by other max_concurrent_queries settings.", 0) \
+    M(UInt64, min_bytes_to_rebalance_partition_over_jbod, 512 * 1024 * 1024, "Minimal amount of bytes to enable part rebalance over JBOD array (0 - disabled).", 0) \
     \
     /** Obsolete settings. Kept for backward compatibility only. */ \
     M(UInt64, min_relative_delay_to_yield_leadership, 120, "Obsolete setting, does nothing.", 0) \

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -119,7 +119,7 @@ struct Settings;
     M(Int64, max_partitions_to_read, -1, "Limit the max number of partitions that can be accessed in one query. <= 0 means unlimited. This setting is the default that can be overridden by the query-level setting with the same name.", 0) \
     M(UInt64, max_concurrent_queries, 0, "Max number of concurrently executed queries related to the MergeTree table (0 - disabled). Queries will still be limited by other max_concurrent_queries settings.", 0) \
     M(UInt64, min_marks_to_honor_max_concurrent_queries, 0, "Minimal number of marks to honor the MergeTree-level's max_concurrent_queries (0 - disabled). Queries will still be limited by other max_concurrent_queries settings.", 0) \
-    M(UInt64, min_bytes_to_rebalance_partition_over_jbod, 512 * 1024 * 1024, "Minimal amount of bytes to enable part rebalance over JBOD array (0 - disabled).", 0) \
+    M(UInt64, min_bytes_to_rebalance_partition_over_jbod, 0, "Minimal amount of bytes to enable part rebalance over JBOD array (0 - disabled).", 0) \
     \
     /** Obsolete settings. Kept for backward compatibility only. */ \
     M(UInt64, min_relative_delay_to_yield_leadership, 120, "Obsolete setting, does nothing.", 0) \

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -654,37 +654,6 @@ static StoragePtr create(const StorageFactory::Arguments & args)
         // updates the default storage_settings with settings specified via SETTINGS arg in a query
         if (args.storage_def->settings)
             metadata.settings_changes = args.storage_def->settings->ptr();
-
-        size_t index_granularity_bytes = 0;
-        size_t min_index_granularity_bytes = 0;
-
-        index_granularity_bytes = storage_settings->index_granularity_bytes;
-        min_index_granularity_bytes = storage_settings->min_index_granularity_bytes;
-
-        /* the min_index_granularity_bytes value is 1024 b and index_granularity_bytes is 10 mb by default
-         * if index_granularity_bytes is not disabled i.e > 0 b, then always ensure that it's greater than
-         * min_index_granularity_bytes. This is mainly a safeguard against accidents whereby a really low
-         * index_granularity_bytes SETTING of 1b can create really large parts with large marks.
-        */
-        if (index_granularity_bytes > 0 && index_granularity_bytes < min_index_granularity_bytes)
-        {
-            throw Exception(
-                "index_granularity_bytes: " + std::to_string(index_granularity_bytes)
-                    + " is lesser than specified min_index_granularity_bytes: " + std::to_string(min_index_granularity_bytes),
-                ErrorCodes::BAD_ARGUMENTS);
-        }
-
-        // Pre-define a reasonable minimum size for the JBOD rebalancer
-        static constexpr size_t MIN_BYTES_TO_REBALANCE_OVER_JBOD = 100 * 1024 * 1024;
-        if (storage_settings->min_bytes_to_rebalance_partition_over_jbod > 0
-            && storage_settings->min_bytes_to_rebalance_partition_over_jbod < MIN_BYTES_TO_REBALANCE_OVER_JBOD)
-        {
-            throw Exception(
-                "min_bytes_to_rebalance_partition_over_jbod: "
-                    + std::to_string(storage_settings->min_bytes_to_rebalance_partition_over_jbod) + " is lesser than "
-                    + std::to_string(MIN_BYTES_TO_REBALANCE_OVER_JBOD),
-                ErrorCodes::BAD_ARGUMENTS);
-        }
     }
     else
     {

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -673,6 +673,18 @@ static StoragePtr create(const StorageFactory::Arguments & args)
                     + " is lesser than specified min_index_granularity_bytes: " + std::to_string(min_index_granularity_bytes),
                 ErrorCodes::BAD_ARGUMENTS);
         }
+
+        // Pre-define a reasonable minimum size for the JBOD rebalancer
+        static constexpr size_t MIN_BYTES_TO_REBALANCE_OVER_JBOD = 100 * 1024 * 1024;
+        if (storage_settings->min_bytes_to_rebalance_partition_over_jbod > 0
+            && storage_settings->min_bytes_to_rebalance_partition_over_jbod < MIN_BYTES_TO_REBALANCE_OVER_JBOD)
+        {
+            throw Exception(
+                "min_bytes_to_rebalance_partition_over_jbod: "
+                    + std::to_string(storage_settings->min_bytes_to_rebalance_partition_over_jbod) + " is lesser than "
+                    + std::to_string(MIN_BYTES_TO_REBALANCE_OVER_JBOD),
+                ErrorCodes::BAD_ARGUMENTS);
+        }
     }
     else
     {

--- a/src/Storages/StorageMergeTree.h
+++ b/src/Storages/StorageMergeTree.h
@@ -150,8 +150,8 @@ private:
     {
         FutureMergedMutatedPart future_part;
         ReservationPtr reserved_space;
-
         StorageMergeTree & storage;
+        std::optional<CurrentlySubmergingEmergingTagger> tagger;
 
         CurrentlyMergingPartsTagger(
             FutureMergedMutatedPart & future_part_,

--- a/src/Storages/StorageMergeTree.h
+++ b/src/Storages/StorageMergeTree.h
@@ -151,6 +151,7 @@ private:
         FutureMergedMutatedPart future_part;
         ReservationPtr reserved_space;
         StorageMergeTree & storage;
+        // Optional tagger to maintain volatile parts for the JBOD balancer
         std::optional<CurrentlySubmergingEmergingTagger> tagger;
 
         CurrentlyMergingPartsTagger(

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -3562,6 +3562,7 @@ bool StorageReplicatedMergeTree::fetchPart(const String & part_name, const Stora
 
     }
 
+    std::optional<CurrentlySubmergingEmergingTagger> tagger_ptr;
     std::function<MutableDataPartPtr()> get_part;
     if (part_to_clone)
     {
@@ -3585,9 +3586,18 @@ bool StorageReplicatedMergeTree::fetchPart(const String & part_name, const Stora
                     ErrorCodes::INTERSERVER_SCHEME_DOESNT_MATCH);
 
             return fetcher.fetchPart(
-                metadata_snapshot, part_name, source_replica_path,
-                address.host, address.replication_port,
-                timeouts, user_password.first, user_password.second, interserver_scheme, to_detached);
+                metadata_snapshot,
+                part_name,
+                source_replica_path,
+                address.host,
+                address.replication_port,
+                timeouts,
+                user_password.first,
+                user_password.second,
+                interserver_scheme,
+                to_detached,
+                "",
+                &tagger_ptr);
         };
     }
 

--- a/tests/integration/test_jbod_balancer/configs/config.d/storage_configuration.xml
+++ b/tests/integration/test_jbod_balancer/configs/config.d/storage_configuration.xml
@@ -1,0 +1,29 @@
+<yandex>
+    <storage_configuration>
+        <disks>
+            <default>
+                <keep_free_space_bytes>1024</keep_free_space_bytes>
+            </default>
+            <jbod1>
+                <path>/jbod1/</path>
+            </jbod1>
+            <jbod2>
+                <path>/jbod2/</path>
+            </jbod2>
+            <jbod3>
+                <path>/jbod3/</path>
+            </jbod3>
+        </disks>
+        <policies>
+            <jbod>
+                <volumes>
+                    <jbod_volume>
+                        <disk>jbod1</disk>
+                        <disk>jbod2</disk>
+                        <disk>jbod3</disk>
+                    </jbod_volume>
+                </volumes>
+            </jbod>
+        </policies>
+    </storage_configuration>
+</yandex>

--- a/tests/integration/test_jbod_balancer/test.py
+++ b/tests/integration/test_jbod_balancer/test.py
@@ -170,15 +170,7 @@ def test_replicated_balanced_merge_fetch(start_cluster):
                 "insert into tmp2 select randConstant() % 2, randomPrintableASCII(16) from numbers(50)"
             )
 
-        time.sleep(2)
-
-        for _ in range(10):
-            try:
-                print("Syncing replica")
-                node2.query("SYSTEM SYNC REPLICA tbl")
-                break
-            except:
-                time.sleep(0.5)
+        node2.query("SYSTEM SYNC REPLICA tbl", timeout=10)
 
         check_balance(node1, "tbl")
         check_balance(node2, "tbl")

--- a/tests/integration/test_jbod_balancer/test.py
+++ b/tests/integration/test_jbod_balancer/test.py
@@ -1,0 +1,190 @@
+import json
+import random
+import re
+import string
+import threading
+import time
+from multiprocessing.dummy import Pool
+
+import pytest
+from helpers.client import QueryRuntimeException
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=["configs/config.d/storage_configuration.xml",],
+    with_zookeeper=True,
+    stay_alive=True,
+    tmpfs=["/jbod1:size=100M", "/jbod2:size=100M", "/jbod3:size=100M"],
+    macros={"shard": 0, "replica": 1},
+)
+
+
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=["configs/config.d/storage_configuration.xml"],
+    with_zookeeper=True,
+    stay_alive=True,
+    tmpfs=["/jbod1:size=100M", "/jbod2:size=100M", "/jbod3:size=100M"],
+    macros={"shard": 0, "replica": 2},
+)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def check_balance(node, table):
+
+    partitions = node.query(
+        """
+        WITH
+            arraySort(groupArray(c)) AS array_c,
+            arrayEnumerate(array_c) AS array_i,
+            sum(c) AS sum_c,
+            count() AS n,
+            if(sum_c = 0, 0, (((2. * arraySum(arrayMap((c, i) -> (c * i), array_c, array_i))) / n) / sum_c) - (((n + 1) * 1.) / n)) AS gini
+        SELECT
+            partition
+        FROM
+        (
+            SELECT
+                partition,
+                disk_name,
+                sum(bytes_on_disk) AS c
+            FROM system.parts
+            WHERE active AND level > 0 AND disk_name like 'jbod%' AND table = '{}'
+            GROUP BY
+                partition, disk_name
+        )
+        GROUP BY partition
+        HAVING gini < 0.1
+        """.format(
+            table
+        )
+    ).splitlines()
+
+    assert set(partitions) == set(["0", "1"])
+
+
+def test_jbod_balanced_merge(start_cluster):
+    try:
+        node1.query(
+            """
+            CREATE TABLE tbl (p UInt8, d String)
+            ENGINE = MergeTree
+            PARTITION BY p
+            ORDER BY tuple()
+            SETTINGS
+                storage_policy = 'jbod',
+                min_bytes_to_rebalance_partition_over_jbod = 1024,
+                max_bytes_to_merge_at_max_space_in_pool = 4096
+        """
+        )
+        node1.query("create table tmp1 as tbl")
+        node1.query("create table tmp2 as tbl")
+
+        for i in range(200):
+            # around 1k per block
+            node1.query(
+                "insert into tbl select randConstant() % 2, randomPrintableASCII(16) from numbers(50)"
+            )
+            node1.query(
+                "insert into tmp1 select randConstant() % 2, randomPrintableASCII(16) from numbers(50)"
+            )
+            node1.query(
+                "insert into tmp2 select randConstant() % 2, randomPrintableASCII(16) from numbers(50)"
+            )
+
+        time.sleep(1)
+
+        check_balance(node1, "tbl")
+
+    finally:
+        node1.query(f"DROP TABLE IF EXISTS tbl SYNC")
+        node1.query(f"DROP TABLE IF EXISTS tmp1 SYNC")
+        node1.query(f"DROP TABLE IF EXISTS tmp2 SYNC")
+
+
+def test_replicated_balanced_merge_fetch(start_cluster):
+    try:
+        for i, node in enumerate([node1, node2]):
+            node.query(
+                """
+                CREATE TABLE tbl (p UInt8, d String)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tbl', '{}')
+                PARTITION BY p
+                ORDER BY tuple()
+                SETTINGS
+                    storage_policy = 'jbod',
+                    old_parts_lifetime = 1,
+                    cleanup_delay_period = 1,
+                    cleanup_delay_period_random_add = 2,
+                    min_bytes_to_rebalance_partition_over_jbod = 1024,
+                    max_bytes_to_merge_at_max_space_in_pool = 4096
+            """.format(
+                    i
+                )
+            )
+
+            node.query(
+                """
+                CREATE TABLE tmp1 (p UInt8, d String)
+                ENGINE = MergeTree
+                PARTITION BY p
+                ORDER BY tuple()
+                SETTINGS
+                    storage_policy = 'jbod',
+                    min_bytes_to_rebalance_partition_over_jbod = 1024,
+                    max_bytes_to_merge_at_max_space_in_pool = 4096
+            """
+            )
+
+            node.query("create table tmp2 as tmp1")
+
+        node2.query("alter table tbl modify setting always_fetch_merged_part = 1")
+
+        for i in range(200):
+            # around 1k per block
+            node1.query(
+                "insert into tbl select randConstant() % 2, randomPrintableASCII(16) from numbers(50)"
+            )
+            node1.query(
+                "insert into tmp1 select randConstant() % 2, randomPrintableASCII(16) from numbers(50)"
+            )
+            node1.query(
+                "insert into tmp2 select randConstant() % 2, randomPrintableASCII(16) from numbers(50)"
+            )
+            node2.query(
+                "insert into tmp1 select randConstant() % 2, randomPrintableASCII(16) from numbers(50)"
+            )
+            node2.query(
+                "insert into tmp2 select randConstant() % 2, randomPrintableASCII(16) from numbers(50)"
+            )
+
+        time.sleep(2)
+
+        for _ in range(10):
+            try:
+                print("Syncing replica")
+                node2.query("SYSTEM SYNC REPLICA tbl")
+                break
+            except:
+                time.sleep(0.5)
+
+        check_balance(node1, "tbl")
+        check_balance(node2, "tbl")
+
+    finally:
+        for node in [node1, node2]:
+            node.query("DROP TABLE IF EXISTS tbl SYNC")
+            node.query("DROP TABLE IF EXISTS tmp1 SYNC")
+            node.query("DROP TABLE IF EXISTS tmp2 SYNC")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Introduce a new merge tree setting `min_bytes_to_rebalance_partition_over_jbod` which allows assigning new parts to different disks of a JBOD volume in a balanced way.


Detailed description / Documentation draft:

JBOD volume is notorious in that only a small subset of disks can be fully utilized for a given query. This PR focuses on a particular common scenario: partition-wise queries. Now big new parts are assigned to different disks of a JBOD volume in a balanced way.  
It might be useful for https://github.com/ClickHouse/ClickHouse/issues/16300.

