### PR TITLE
CMake moved power pc check in tools

### DIFF
--- a/cmake/arch.cmake
+++ b/cmake/arch.cmake
@@ -16,8 +16,4 @@ endif ()
 
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(ppc64le.*|PPC64LE.*)")
     set (ARCH_PPC64LE 1)
-    # FIXME: move this check into tools.cmake
-    if (COMPILER_CLANG OR (COMPILER_GCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8))
-        message(FATAL_ERROR "Only gcc-8 or higher is supported for powerpc architecture")
-    endif ()
 endif ()

--- a/cmake/tools.cmake
+++ b/cmake/tools.cmake
@@ -80,3 +80,9 @@ if (LINKER_NAME)
 
     message(STATUS "Using custom linker by name: ${LINKER_NAME}")
 endif ()
+
+if (ARCH_PPC64LE)
+    if (COMPILER_CLANG OR (COMPILER_GCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8))
+        message(FATAL_ERROR "Only gcc-8 or higher is supported for powerpc architecture")
+    endif ()
+endif ()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

CMake moved power pc architecture and compiler check in tools.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)