### PR TITLE
Fixing the inability to deserialize AVRO into table if it contains LowCardinality columns

### DIFF
--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -175,9 +175,7 @@ static std::string nodeName(avro::NodePtr node)
 
 AvroDeserializer::DeserializeFn AvroDeserializer::createDeserializeFn(avro::NodePtr root_node, DataTypePtr target_type)
 {
-    const WhichDataType target = target_type->getTypeId() == TypeIndex::LowCardinality
-        ? removeLowCardinality(target_type)
-        : target_type;
+    const WhichDataType target = removeLowCardinality(target_type);
 
     switch (root_node->type())
     {

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -1,4 +1,5 @@
 #include "AvroRowInputFormat.h"
+#include "DataTypes/DataTypeLowCardinality.h"
 #if USE_AVRO
 
 #include <numeric>
@@ -174,7 +175,10 @@ static std::string nodeName(avro::NodePtr node)
 
 AvroDeserializer::DeserializeFn AvroDeserializer::createDeserializeFn(avro::NodePtr root_node, DataTypePtr target_type)
 {
-    WhichDataType target(target_type);
+    const WhichDataType target = target_type->getTypeId() == TypeIndex::LowCardinality
+        ? removeLowCardinality(target_type)
+        : target_type;
+
     switch (root_node->type())
     {
         case avro::AVRO_STRING: [[fallthrough]];
@@ -384,7 +388,8 @@ AvroDeserializer::DeserializeFn AvroDeserializer::createDeserializeFn(avro::Node
     }
 
     throw Exception(
-        "Type " + target_type->getName() + " is not compatible with Avro " + avro::toString(root_node->type()) + ":\n" + nodeToJson(root_node),
+        "Type " + target_type->getName() + " is not compatible with Avro " + avro::toString(root_node->type()) + ":\n"
+        + nodeToJson(root_node),
         ErrorCodes::ILLEGAL_COLUMN);
 }
 

--- a/tests/queries/0_stateless/01543_avro_deserialization_with_lc.sh
+++ b/tests/queries/0_stateless/01543_avro_deserialization_with_lc.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT --query "CREATE TABLE IF NOT EXISTS test_01543 (value LowCardinality(String)) ENGINE=Memory()"
+$CLICKHOUSE_CLIENT --query "INSERT INTO test_01543 SELECT toString(number) FROM numbers(1000)"
+
+$CLICKHOUSE_CLIENT -q "SELECT * FROM test_01543 FORMAT Avro" |
+    $CLICKHOUSE_CLIENT -q "INSERT INTO test_01543 FORMAT Avro";
+
+$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS test_01543"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now when parsing AVRO from input the LowCardinality is removed from type.
Fixes https://github.com/ClickHouse/ClickHouse/issues/16188
