### PR TITLE
Remove useless sleep in test

### DIFF
--- a/tests/queries/0_stateless/00933_ttl_with_default.sql
+++ b/tests/queries/0_stateless/00933_ttl_with_default.sql
@@ -5,7 +5,6 @@ insert into ttl_00933_2 values (toDateTime('2000-10-10 00:00:00'), 1);
 insert into ttl_00933_2 values (toDateTime('2000-10-10 00:00:00'), 2);
 insert into ttl_00933_2 values (toDateTime('2100-10-10 00:00:00'), 3);
 insert into ttl_00933_2 values (toDateTime('2100-10-10 00:00:00'), 4);
-select sleep(0.7) format Null; -- wait if very fast merge happen
 optimize table ttl_00933_2 final;
 select a from ttl_00933_2 order by a;
 
@@ -16,7 +15,6 @@ insert into ttl_00933_2 values (toDateTime('2000-10-10 00:00:00'), 1, 100);
 insert into ttl_00933_2 values (toDateTime('2000-10-10 00:00:00'), 2, 200);
 insert into ttl_00933_2 values (toDateTime('2100-10-10 00:00:00'), 3, 300);
 insert into ttl_00933_2 values (toDateTime('2100-10-10 00:00:00'), 4, 400);
-select sleep(0.7) format Null; -- wait if very fast merge happen
 optimize table ttl_00933_2 final;
 select a, b from ttl_00933_2 order by a;
 
@@ -27,7 +25,6 @@ insert into ttl_00933_2 values (toDateTime('2000-10-10 00:00:00'), 1, 5);
 insert into ttl_00933_2 values (toDateTime('2000-10-10 00:00:00'), 2, 10);
 insert into ttl_00933_2 values (toDateTime('2100-10-10 00:00:00'), 3, 15);
 insert into ttl_00933_2 values (toDateTime('2100-10-10 00:00:00'), 4, 20);
-select sleep(0.7) format Null; -- wait if very fast merge happen
 optimize table ttl_00933_2 final;
 select a, b from ttl_00933_2 order by a;
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


The flaky test contained sleep that was totally useless. Removing the sleep should not change anything.