### PR TITLE
Allow fetching duplicate parts to detach

### DIFF
--- a/tests/integration/test_fetch_partition_with_outdated_parts/configs/zookeeper_config.xml
+++ b/tests/integration/test_fetch_partition_with_outdated_parts/configs/zookeeper_config.xml
@@ -1,0 +1,28 @@
+<yandex>
+    <zookeeper>
+        <node index="1">
+            <host>zoo1</host>
+            <port>2181</port>
+        </node>
+        <node index="2">
+            <host>zoo2</host>
+            <port>2181</port>
+        </node>
+        <node index="3">
+            <host>zoo3</host>
+            <port>2181</port>
+        </node>
+    </zookeeper>
+    <auxiliary_zookeepers>
+        <zookeeper2>
+            <node index="1">
+                <host>zoo1</host>
+                <port>2181</port>
+            </node>
+            <node index="2">
+                <host>zoo2</host>
+                <port>2181</port>
+            </node>
+        </zookeeper2>
+    </auxiliary_zookeepers>
+</yandex>

--- a/tests/integration/test_fetch_partition_with_outdated_parts/test.py
+++ b/tests/integration/test_fetch_partition_with_outdated_parts/test.py
@@ -1,0 +1,44 @@
+from __future__ import print_function
+from helpers.cluster import ClickHouseCluster
+from helpers.client import QueryRuntimeException
+import helpers
+import pytest
+
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node", main_configs=["configs/zookeeper_config.xml"], with_zookeeper=True)
+
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_fetch_partition_with_outdated_parts(start_cluster):
+    node.query(
+        "CREATE TABLE simple (date Date, id UInt32) ENGINE = ReplicatedMergeTree('/clickhouse/tables/0/simple', 'node') ORDER BY tuple() PARTITION BY date;"
+    )
+    node.query("INSERT INTO simple VALUES ('2020-08-27', 1)")
+
+    node.query(
+        "CREATE TABLE simple2 (date Date, id UInt32) ENGINE = ReplicatedMergeTree('/clickhouse/tables/1/simple', 'node') ORDER BY tuple() PARTITION BY date;"
+    )
+    node.query("INSERT INTO simple2 VALUES ('2020-08-27', 2)")
+    node.query("INSERT INTO simple2 VALUES ('2020-08-27', 3)")
+    node.query("OPTIMIZE TABLE simple2 FINAL")
+
+    # until now both tables will have the same part
+
+    node.query(
+        "ALTER TABLE simple2 FETCH PARTITION '2020-08-27' FROM 'zookeeper2:/clickhouse/tables/0/simple';"
+    )
+
+    node.query("ALTER TABLE simple2 ATTACH PARTITION '2020-08-27';")
+
+    assert node.query("SELECT id FROM simple2 order by id").strip() == "1\n2\n3"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Allow to fetch parts that are already committed or outdated in the current instance into the detached directory. It's useful when migrating tables from another cluster and having N to 1 shards mapping. It's also consistent with the current fetchPartition implementation.

Detailed description / Documentation draft:

None