### PR TITLE
Remove wrong assertion from SSDComplexKeyCacheDictionary

### DIFF
--- a/src/Dictionaries/SSDComplexKeyCacheDictionary.cpp
+++ b/src/Dictionaries/SSDComplexKeyCacheDictionary.cpp
@@ -1467,7 +1467,6 @@ void SSDComplexKeyCacheDictionary::getItemsNumberImpl(
 {
     assert(dict_struct.key);
     assert(key_columns.size() == key_types.size());
-    assert(key_columns.size() == dict_struct.key->size());
 
     dict_struct.validateKeyTypes(key_types);
 

--- a/tests/queries/0_stateless/01280_ssd_complex_key_dictionary.sql
+++ b/tests/queries/0_stateless/01280_ssd_complex_key_dictionary.sql
@@ -62,6 +62,8 @@ SELECT dictGetUInt64('database_for_dict.ssd_dict', 'a', tuple('10', toInt32(-20)
 SELECT dictGetInt32('database_for_dict.ssd_dict', 'b', tuple('10', toInt32(-20)));
 SELECT dictGetString('database_for_dict.ssd_dict', 'c', tuple('10', toInt32(-20)));
 
+SELECT dictGetUInt64('database_for_dict.ssd_dict', 'a', tuple(toInt32(3))); --{serverError 53}
+
 DROP DICTIONARY database_for_dict.ssd_dict;
 
 DROP TABLE IF EXISTS database_for_dict.keys_table;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes #15358.