### PR TITLE
Fix test_input_format_parallel_parsing_memory_tracking flackiness

### DIFF
--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -207,8 +207,22 @@ void AsynchronousMetrics::update()
         /// We must update the value of total_memory_tracker periodically.
         /// Otherwise it might be calculated incorrectly - it can include a "drift" of memory amount.
         /// See https://github.com/ClickHouse/ClickHouse/issues/10293
-        total_memory_tracker.set(data.resident);
-        CurrentMetrics::set(CurrentMetrics::MemoryTracking, data.resident);
+        {
+            Int64 amount = total_memory_tracker.get();
+            Int64 peak = total_memory_tracker.getPeak();
+            Int64 new_peak = data.resident;
+
+            LOG_DEBUG(&Poco::Logger::get("AsynchronousMetrics"),
+                "MemoryTracking: was {}, peak {}, will set to {} (RSS), difference: {}",
+                ReadableSize(amount),
+                ReadableSize(peak),
+                ReadableSize(new_peak),
+                ReadableSize(new_peak - peak)
+            );
+
+            total_memory_tracker.set(new_peak);
+            CurrentMetrics::set(CurrentMetrics::MemoryTracking, new_peak);
+        }
     }
 #endif
 

--- a/tests/integration/test_input_format_parallel_parsing_memory_tracking/configs/asynchronous_metrics_update_period_s.xml
+++ b/tests/integration/test_input_format_parallel_parsing_memory_tracking/configs/asynchronous_metrics_update_period_s.xml
@@ -1,0 +1,4 @@
+<yandex>
+    <!-- this update period also syncs MemoryTracking with RSS, disable this, by using period = 1 day -->
+    <asynchronous_metrics_update_period_s>86400</asynchronous_metrics_update_period_s>
+</yandex>

--- a/tests/integration/test_input_format_parallel_parsing_memory_tracking/test.py
+++ b/tests/integration/test_input_format_parallel_parsing_memory_tracking/test.py
@@ -8,7 +8,10 @@ from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 
-instance = cluster.add_instance('instance', main_configs=['configs/conf.xml'])
+instance = cluster.add_instance('instance', main_configs=[
+    'configs/conf.xml',
+    'configs/asynchronous_metrics_update_period_s.xml',
+])
 
 
 @pytest.fixture(scope='module', autouse=True)


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- disable syncing MemoryTracking with RSS for the test
- add log message when MemoryTracking is adjusted to RSS

Here are some thoughts about this test:
- I guess the problem can be if different threads will be used to serve the query
- And sometimes process RSS can be higher due to memory reservations in jemalloc
Anyway the test is about checking MemoryTracking not the memory consumption, so syncing with RSS should be disabled.