### PR TITLE
RFC: ReplicatedMergeTreeLog with Protobuf

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -43,7 +43,7 @@
 	url = https://github.com/ClickHouse-Extras/UnixODBC.git
 [submodule "contrib/protobuf"]
 	path = contrib/protobuf
-	url = https://github.com/ClickHouse-Extras/protobuf.git
+	url = https://github.com/nvartolomei/protobuf.git
 [submodule "contrib/boost"]
 	path = contrib/boost
 	url = https://github.com/ClickHouse-Extras/boost.git

--- a/cmake/find/protobuf.cmake
+++ b/cmake/find/protobuf.cmake
@@ -1,12 +1,3 @@
-option(ENABLE_PROTOBUF "Enable protobuf" ${ENABLE_LIBRARIES})
-
-if(NOT ENABLE_PROTOBUF)
-  if(USE_INTERNAL_PROTOBUF_LIBRARY)
-    message(${RECONFIGURE_MESSAGE_LEVEL} "Can't use internal protobuf with ENABLE_PROTOBUF=OFF")
-  endif()
-  return()
-endif()
-
 # Normally we use the internal protobuf library.
 # You can set USE_INTERNAL_PROTOBUF_LIBRARY to OFF to force using the external protobuf library, which should be installed in the system in this case.
 # The external protobuf library can be installed in the system by running

--- a/docker/test/fasttest/run.sh
+++ b/docker/test/fasttest/run.sh
@@ -15,6 +15,8 @@ stage=${stage:-}
 # empty parameter.
 read -ra FASTTEST_CMAKE_FLAGS <<< "${FASTTEST_CMAKE_FLAGS:-}"
 
+FASTTEST_FOCUS=${FASTTEST_FOCUS:-""}
+
 FASTTEST_WORKSPACE=$(readlink -f "${FASTTEST_WORKSPACE:-.}")
 FASTTEST_SOURCE=$(readlink -f "${FASTTEST_SOURCE:-$FASTTEST_WORKSPACE/ch}")
 FASTTEST_BUILD=$(readlink -f "${FASTTEST_BUILD:-${BUILD:-$FASTTEST_WORKSPACE/build}}")
@@ -127,7 +129,7 @@ function clone_submodules
 (
 cd "$FASTTEST_SOURCE"
 
-SUBMODULES_TO_UPDATE=(contrib/boost contrib/zlib-ng contrib/libxml2 contrib/poco contrib/libunwind contrib/ryu contrib/fmtlib contrib/base64 contrib/cctz contrib/libcpuid contrib/double-conversion contrib/libcxx contrib/libcxxabi contrib/libc-headers contrib/lz4 contrib/zstd contrib/fastops contrib/rapidjson contrib/re2 contrib/sparsehash-c11 contrib/croaring)
+SUBMODULES_TO_UPDATE=(contrib/boost contrib/zlib-ng contrib/libxml2 contrib/poco contrib/libunwind contrib/ryu contrib/fmtlib contrib/base64 contrib/cctz contrib/libcpuid contrib/double-conversion contrib/libcxx contrib/libcxxabi contrib/libc-headers contrib/lz4 contrib/zstd contrib/fastops contrib/rapidjson contrib/re2 contrib/sparsehash-c11 contrib/croaring contrib/protobuf)
 
 git submodule sync
 git submodule update --init --recursive "${SUBMODULES_TO_UPDATE[@]}"
@@ -279,7 +281,7 @@ TESTS_TO_SKIP=(
     01322_ttest_scipy
 )
 
-time clickhouse-test -j 8 --order=random --no-long --testname --shard --zookeeper --skip "${TESTS_TO_SKIP[@]}" 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee "$FASTTEST_OUTPUT/test_log.txt"
+time clickhouse-test -j 8 --order=random --no-long --testname --shard --zookeeper --skip "${TESTS_TO_SKIP[@]}" -- "$FASTTEST_FOCUS" 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee "$FASTTEST_OUTPUT/test_log.txt"
 
 # substr is to remove semicolon after test name
 readarray -t FAILED_TESTS < <(awk '/FAIL|TIMEOUT|ERROR/ { print substr($3, 1, length($3)-1) }' "$FASTTEST_OUTPUT/test_log.txt" | tee "$FASTTEST_OUTPUT/failed-parallel-tests.txt")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -173,12 +173,22 @@ add_object_library(clickhouse_processors_merges Processors/Merges)
 add_object_library(clickhouse_processors_merges_algorithms Processors/Merges/Algorithms)
 add_object_library(clickhouse_processors_queryplan Processors/QueryPlan)
 
+protobuf_generate_cpp(Protobuf_Srcs Protobuf_Hdrs Storages/MergeTree/proto/ReplicationLogEntry.proto)
+list (APPEND dbms_sources ${Protobuf_Srcs})
+list (APPEND dbms_headers ${Protobuf_Hdrs})
+
+# Exists as a shortcut for developers to re-build protos.
+add_library(clickhouse_storages_mergetree_proto ${Protobuf_Srcs} ${Protobuf_Hdrs})
+target_link_libraries(clickhouse_storages_mergetree_proto ${Protobuf_LIBRARY})
+
 set (DBMS_COMMON_LIBRARIES)
 # libgcc_s does not provide an implementation of an atomics library. Instead,
 # GCC’s libatomic library can be used to supply these when using libgcc_s.
 if ((NOT USE_LIBCXX) AND COMPILER_CLANG AND OS_LINUX)
     list (APPEND DBMS_COMMON_LIBRARIES atomic)
 endif()
+
+list (APPEND DBMS_COMMON_LIBRARIES ${Protobuf_LIBRARY})
 
 if (MAKE_STATIC_LIBRARIES OR NOT SPLIT_SHARED_LIBRARIES)
     add_library (dbms STATIC ${dbms_headers} ${dbms_sources})

--- a/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.cpp
@@ -1,11 +1,13 @@
 #include <Common/ZooKeeper/Types.h>
 
 #include <Storages/MergeTree/ReplicatedMergeTreeLogEntry.h>
-#include <Storages/MergeTree/ReplicatedMergeTreeTableMetadata.h>
 #include <IO/Operators.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/WriteBufferFromString.h>
 #include <IO/ReadHelpers.h>
+
+#include <google/protobuf/text_format.h>
+#include <ReplicationLogEntry.pb.h>
 
 
 namespace DB
@@ -13,12 +15,145 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int UNKNOWN_FORMAT_VERSION;
+    extern const int UNSUPPORTED_METHOD;
     extern const int LOGICAL_ERROR;
 }
 
+MergeTreeDataPartType::Value partTypeFromProtoEnum(Protobuf::ReplicatedMergeTree::PartType t);
+Protobuf::ReplicatedMergeTree::PartType partTypeToProtoEnum(MergeTreeDataPartType t);
 
-void ReplicatedMergeTreeLogEntryData::writeText(WriteBuffer & out) const
+String ReplicatedMergeTreeLogEntryData::toString() const
 {
+    return toV5ProtoTextString();
+}
+
+String ReplicatedMergeTreeLogEntryData::toV5ProtoTextString() const
+{
+    Protobuf::ReplicatedMergeTree::LogEntry log_entry;
+    log_entry.set_create_time(create_time ? create_time : time(nullptr));
+    log_entry.set_source_replica(source_replica);
+
+    switch (type)
+    {
+
+        case GET_PART:
+        {
+            auto * get_part = log_entry.mutable_get_part();
+            get_part->set_new_part_name(new_part_name);
+            get_part->set_block_id(block_id);
+            get_part->set_quorum(quorum);
+
+            if (new_part_type == MergeTreeDataPartType::UNKNOWN)
+                get_part->set_part_type(partTypeToProtoEnum(MergeTreeDataPartType::WIDE));
+            else
+                get_part->set_part_type(partTypeToProtoEnum(new_part_type));
+        }
+            break;
+
+        case MERGE_PARTS:
+        {
+            auto * merge_parts = log_entry.mutable_merge_parts();
+
+            for (const String & s : source_parts)
+                merge_parts->add_source_parts(s);
+
+            merge_parts->set_new_part_name(new_part_name);
+            merge_parts->set_deduplicate(deduplicate);
+
+            Protobuf::ReplicatedMergeTree::LogEntry_MergeParts_Type proto_merge_type;
+            switch (merge_type) {
+                case MergeType::REGULAR:
+                    proto_merge_type = Protobuf::ReplicatedMergeTree::LogEntry_MergeParts_Type_REGULAR;
+                    break;
+                case MergeType::TTL_DELETE:
+                    proto_merge_type = Protobuf::ReplicatedMergeTree::LogEntry_MergeParts_Type_TTL_DELETE;
+                    break;
+                case MergeType::TTL_RECOMPRESS:
+                    proto_merge_type = Protobuf::ReplicatedMergeTree::LogEntry_MergeParts_Type_TTL_RECOMPRESS;
+                    break;
+            }
+            merge_parts->set_merge_type(proto_merge_type);
+
+            /// Looks like it is not always initialized, handling like in txt format.
+            if (new_part_type == MergeTreeDataPartType::UNKNOWN)
+                merge_parts->set_part_type(partTypeToProtoEnum(MergeTreeDataPartType::WIDE));
+            else
+                merge_parts->set_part_type(partTypeToProtoEnum(new_part_type));
+        }
+            break;
+
+        case DROP_RANGE:
+        {
+            auto * drop_range = log_entry.mutable_drop_range();
+            drop_range->set_part_name(new_part_name);
+            drop_range->set_detach(detach);
+        }
+            break;
+
+        case REPLACE_RANGE:
+        {
+            auto * replace_range = log_entry.mutable_replace_range();
+            replace_range->set_drop_range_part_name(replace_range_entry->drop_range_part_name);
+            replace_range->set_from_database(replace_range_entry->from_database);
+            replace_range->set_from_table(replace_range_entry->from_table);
+
+            for (const String & p : replace_range_entry->src_part_names)
+                replace_range->add_src_part_names(p);
+
+            for (const String & p : replace_range_entry->new_part_names)
+                replace_range->add_new_part_names(p);
+
+            for (const String & p : replace_range_entry->part_names_checksums)
+                replace_range->add_part_names_checksums(p);
+
+            replace_range->set_columns_version(replace_range_entry->columns_version);
+        }
+            break;
+
+        case MUTATE_PART:
+        {
+            auto * mutate_part = log_entry.mutable_mutate_part();
+            mutate_part->set_src_part_name(source_parts.at(0));
+            mutate_part->set_dst_part_name(new_part_name);
+            mutate_part->set_alter_version(alter_version);
+        }
+            break;
+
+        case ALTER_METADATA:
+        {
+            auto * alter_metadata = log_entry.mutable_alter_metadata();
+            alter_metadata->set_alter_version(alter_version);
+            alter_metadata->set_have_mutation(have_mutation);
+            alter_metadata->set_columns(columns_str);
+            alter_metadata->set_metadata(metadata_str);
+        }
+            break;
+
+
+            /// These do not exist in protobuf implementation at all.
+        case EMPTY: [[fallthrough]];
+        case CLEAR_COLUMN: [[fallthrough]];
+        case CLEAR_INDEX:
+            __builtin_unreachable();
+    }
+
+    WriteBufferFromOwnString out;
+
+    out << "format version: " << LOG_PROTOTEXT_VERSION << "\n";
+
+    String proto_txt;
+    if (!google::protobuf::TextFormat::PrintToString(log_entry, &proto_txt))
+        throw Exception("Failed to serialize proto message to text", ErrorCodes::LOGICAL_ERROR);
+    out << proto_txt;
+
+    return out.str();
+}
+
+
+String ReplicatedMergeTreeLogEntryData::toV4ManualTextString() const
+{
+    WriteBufferFromOwnString out;
+
     out << "format version: 4\n"
         << "create_time: " << LocalDateTime(create_time ? create_time : time(nullptr)) << "\n"
         << "source replica: " << source_replica << '\n'
@@ -104,17 +239,124 @@ void ReplicatedMergeTreeLogEntryData::writeText(WriteBuffer & out) const
 
     if (quorum)
         out << "quorum: " << quorum << '\n';
+
+    return out.str();
 }
 
-void ReplicatedMergeTreeLogEntryData::readText(ReadBuffer & in)
+void ReplicatedMergeTreeLogEntryData::fromV5ProtoText(ReadBuffer & in)
 {
-    UInt8 format_version = 0;
-    String type_str;
+    String proto_txt;
+    readStringUntilEOF(proto_txt, in);
 
+    Protobuf::ReplicatedMergeTree::LogEntry log_entry;
+    if (!google::protobuf::TextFormat::ParseFromString(proto_txt, &log_entry))
+        throw Exception("Failed to deserialize proto message from text: " + proto_txt, ErrorCodes::LOGICAL_ERROR);
+
+    create_time = LocalDateTime(log_entry.create_time());
+    source_replica = log_entry.source_replica();
+
+    switch (log_entry.EntryPayload_case())
+    {
+        case Protobuf::ReplicatedMergeTree::LogEntry::kGetPart:
+        {
+            const auto & get_part = log_entry.get_part();
+
+            type = GET_PART;
+            new_part_name = get_part.new_part_name();
+            block_id = get_part.block_id();
+            quorum = get_part.quorum();
+            new_part_type = partTypeFromProtoEnum(get_part.part_type());
+        }
+        break;
+
+        case Protobuf::ReplicatedMergeTree::LogEntry::kMergeParts:
+        {
+            const auto & merge_parts = log_entry.merge_parts();
+
+            type = MERGE_PARTS;
+            source_parts.assign(merge_parts.source_parts().begin(), merge_parts.source_parts().end());
+            new_part_name = merge_parts.new_part_name();
+            deduplicate = merge_parts.deduplicate();
+            switch (merge_parts.merge_type())
+            {
+                case Protobuf::ReplicatedMergeTree::LogEntry_MergeParts_Type_UNKNOWN:
+                    throw Exception("Unexpected empty merge_type", ErrorCodes::UNSUPPORTED_METHOD);
+                case Protobuf::ReplicatedMergeTree::LogEntry_MergeParts_Type_REGULAR:
+                    merge_type = MergeType::REGULAR;
+                    break;
+                case Protobuf::ReplicatedMergeTree::LogEntry_MergeParts_Type_TTL_DELETE:
+                    merge_type = MergeType::TTL_DELETE;
+                    break;
+                case Protobuf::ReplicatedMergeTree::LogEntry_MergeParts_Type_TTL_RECOMPRESS:
+                    merge_type = MergeType::TTL_RECOMPRESS;
+                    break;
+
+                case Protobuf::ReplicatedMergeTree::LogEntry_MergeParts_Type_LogEntry_MergeParts_Type_INT_MIN_SENTINEL_DO_NOT_USE_:
+                    [[fallthrough]];
+                case Protobuf::ReplicatedMergeTree::LogEntry_MergeParts_Type_LogEntry_MergeParts_Type_INT_MAX_SENTINEL_DO_NOT_USE_:
+                    __builtin_unreachable();
+            }
+            new_part_type = partTypeFromProtoEnum(merge_parts.part_type());
+        }
+        break;
+
+        case Protobuf::ReplicatedMergeTree::LogEntry::kMutatePart:
+        {
+            const auto & mutate_part = log_entry.mutate_part();
+
+            type = MUTATE_PART;
+            source_parts.emplace_back(mutate_part.src_part_name());
+            new_part_name = mutate_part.dst_part_name();
+            alter_version = mutate_part.alter_version();
+        }
+        break;
+
+        case Protobuf::ReplicatedMergeTree::LogEntry::kAlterMetadata:
+        {
+            const auto & alter_metadata = log_entry.alter_metadata();
+
+            type = ALTER_METADATA;
+            alter_version = alter_metadata.alter_version();
+            have_mutation = alter_metadata.have_mutation();
+            columns_str = alter_metadata.columns();
+            metadata_str = alter_metadata.metadata();
+        }
+        break;
+
+        case Protobuf::ReplicatedMergeTree::LogEntry::kDropRange: {
+            const auto & drop_range = log_entry.drop_range();
+
+            type = DROP_RANGE;
+            new_part_name = drop_range.part_name();
+            detach = drop_range.detach();
+        }
+        break;
+
+        case Protobuf::ReplicatedMergeTree::LogEntry::kReplaceRange:
+        {
+            const auto & replace_range = log_entry.replace_range();
+
+            type = REPLACE_RANGE;
+            replace_range_entry = std::make_shared<ReplaceRangeEntry>();
+            replace_range_entry->drop_range_part_name = replace_range.drop_range_part_name();
+            replace_range_entry->from_database = replace_range.from_database();
+            replace_range_entry->from_table = replace_range.from_table();
+            replace_range_entry->src_part_names.assign(replace_range.src_part_names().begin(), replace_range.src_part_names().end());
+            replace_range_entry->new_part_names.assign(replace_range.new_part_names().begin(), replace_range.new_part_names().end());
+            replace_range_entry->part_names_checksums.assign(
+                replace_range.part_names_checksums().begin(), replace_range.part_names_checksums().end());
+            replace_range_entry->columns_version = replace_range.columns_version();
+        }
+        break;
+
+        case Protobuf::ReplicatedMergeTree::LogEntry::ENTRYPAYLOAD_NOT_SET:
+            throw Exception("Unexpected empty EntryPayload", ErrorCodes::UNSUPPORTED_METHOD);
+    }
+}
+
+void ReplicatedMergeTreeLogEntryData::fromV4ManualText(ReadBuffer & in, UInt8 format_version)
+{
     in >> "format version: " >> format_version >> "\n";
-
-    if (format_version < 1 || format_version > 4)
-        throw Exception("Unknown ReplicatedMergeTreeLogEntry format version: " + DB::toString(format_version), ErrorCodes::UNKNOWN_FORMAT_VERSION);
 
     if (format_version >= 2)
     {
@@ -130,6 +372,7 @@ void ReplicatedMergeTreeLogEntryData::readText(ReadBuffer & in)
         in >> "block_id: " >> escape >> block_id >> "\n";
     }
 
+    String type_str;
     in >> type_str >> "\n";
 
     bool trailing_newline_found = false;
@@ -284,18 +527,21 @@ void ReplicatedMergeTreeLogEntryData::ReplaceRangeEntry::readText(ReadBuffer & i
     in >> "columns_version: " >> columns_version;
 }
 
-String ReplicatedMergeTreeLogEntryData::toString() const
-{
-    WriteBufferFromOwnString out;
-    writeText(out);
-    return out.str();
-}
-
 ReplicatedMergeTreeLogEntry::Ptr ReplicatedMergeTreeLogEntry::parse(const String & s, const Coordination::Stat & stat)
 {
     ReadBufferFromString in(s);
     Ptr res = std::make_shared<ReplicatedMergeTreeLogEntry>();
-    res->readText(in);
+
+    UInt8 format_version = 0;
+    in >> "format version: " >> format_version >> "\n";
+
+    if (format_version >= 1 && format_version < LOG_PROTOTEXT_VERSION)
+        res->fromV4ManualText(in, format_version);
+    else if (format_version == LOG_PROTOTEXT_VERSION)
+        res->fromV5ProtoText(in);
+    else
+        throw Exception("Unknown ReplicatedMergeTreeLogEntry format version: " + DB::toString(format_version), ErrorCodes::UNKNOWN_FORMAT_VERSION);
+
     assertEOF(in);
 
     if (!res->create_time)
@@ -303,5 +549,35 @@ ReplicatedMergeTreeLogEntry::Ptr ReplicatedMergeTreeLogEntry::parse(const String
 
     return res;
 }
+
+
+Protobuf::ReplicatedMergeTree::PartType partTypeToProtoEnum(MergeTreeDataPartType t)
+{
+    if (t == MergeTreeDataPartType::WIDE)
+        return Protobuf::ReplicatedMergeTree::WIDE;
+    else if (t == MergeTreeDataPartType::COMPACT)
+        return Protobuf::ReplicatedMergeTree::COMPACT;
+    else if (t == MergeTreeDataPartType::IN_MEMORY)
+        return Protobuf::ReplicatedMergeTree::IN_MEMORY;
+
+    throw Exception("Part type not handled: " + t.toString(), ErrorCodes::LOGICAL_ERROR);
+}
+
+MergeTreeDataPartType::Value partTypeFromProtoEnum(Protobuf::ReplicatedMergeTree::PartType t)
+{
+    switch (t)
+    {
+        case Protobuf::ReplicatedMergeTree::WIDE: return MergeTreeDataPartType::WIDE;
+        case Protobuf::ReplicatedMergeTree::COMPACT: return MergeTreeDataPartType::COMPACT;
+        case Protobuf::ReplicatedMergeTree::IN_MEMORY: return MergeTreeDataPartType::IN_MEMORY;
+
+        case Protobuf::ReplicatedMergeTree::UNKNOWN: throw Exception("Did not expect UNKNOWN part type", ErrorCodes::UNSUPPORTED_METHOD);
+
+        case Protobuf::ReplicatedMergeTree::PartType_INT_MIN_SENTINEL_DO_NOT_USE_: [[fallthrough]];
+        case Protobuf::ReplicatedMergeTree::PartType_INT_MAX_SENTINEL_DO_NOT_USE_:
+            __builtin_unreachable();
+    }
+}
+
 
 }

--- a/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.cpp
@@ -61,7 +61,8 @@ String ReplicatedMergeTreeLogEntryData::toV5ProtoTextString() const
             merge_parts->set_deduplicate(deduplicate);
 
             Protobuf::ReplicatedMergeTree::LogEntry_MergeParts_Type proto_merge_type;
-            switch (merge_type) {
+            switch (merge_type)
+            {
                 case MergeType::REGULAR:
                     proto_merge_type = Protobuf::ReplicatedMergeTree::LogEntry_MergeParts_Type_REGULAR;
                     break;

--- a/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.h
@@ -27,6 +27,8 @@ namespace ErrorCodes
 /// Record about what needs to be done. Only data (you can copy them).
 struct ReplicatedMergeTreeLogEntryData
 {
+    auto static constexpr LOG_PROTOTEXT_VERSION = 5;
+
     enum Type
     {
         EMPTY,          /// Not used.
@@ -62,8 +64,15 @@ struct ReplicatedMergeTreeLogEntryData
         return typeToString(type);
     }
 
-    void writeText(WriteBuffer & out) const;
-    void readText(ReadBuffer & in);
+protected:
+    void fromV5ProtoText(ReadBuffer & in);
+    void fromV4ManualText(ReadBuffer & in, UInt8 format_version);
+
+private:
+    String toV5ProtoTextString() const;
+    String toV4ManualTextString() const;
+
+public:
     String toString() const;
 
     String znode_name;

--- a/src/Storages/MergeTree/proto/ReplicationLogEntry.proto
+++ b/src/Storages/MergeTree/proto/ReplicationLogEntry.proto
@@ -1,0 +1,76 @@
+syntax = "proto3";
+
+package DB.Protobuf.ReplicatedMergeTree;
+
+message LogEntry {
+  uint64 create_time = 1;
+  string source_replica = 2;
+
+  oneof EntryPayload {
+    GetPart get_part = 100;
+    MergeParts merge_parts = 101;
+    MutatePart mutate_part = 102;
+    AlterMetadata alter_metadata = 103;
+
+    DropRange drop_range = 104;
+    ReplaceRange replace_range = 105;
+  }
+
+  message GetPart {
+    string new_part_name = 1;
+    string block_id = 2;
+    bool quorum = 3;
+    PartType part_type = 4;
+  }
+
+  message MergeParts {
+    repeated string source_parts = 1;
+    string new_part_name = 2;
+    bool deduplicate = 3;
+    Type merge_type = 4;
+    PartType part_type = 5;
+
+    enum Type {
+      UNKNOWN = 0;
+      REGULAR = 1;
+      TTL_DELETE = 2;
+      TTL_RECOMPRESS = 3;
+    }
+  }
+
+  message DropRange {
+    string part_name = 1;
+    bool detach = 2;
+  }
+
+  message ReplaceRange {
+    string drop_range_part_name = 1;
+
+    string from_database = 2;
+    string from_table = 3;
+    repeated string src_part_names = 4;
+    repeated string new_part_names = 5;
+    repeated string part_names_checksums = 6;
+    int32 columns_version = 7;
+  }
+
+  message MutatePart {
+    string src_part_name = 1;
+    string dst_part_name = 2;
+    int32 alter_version = 3;
+  }
+
+  message AlterMetadata {
+    int32 alter_version = 1;
+    bool have_mutation = 2;
+    string columns = 3;
+    string metadata = 4;
+  }
+}
+
+enum PartType {
+  UNKNOWN = 0;
+  WIDE = 1;
+  COMPACT = 2;
+  IN_MEMORY = 3;
+}


### PR DESCRIPTION
I'm trying to extend `ReplicatedMergeTreeLogEntryData` to support part UUIDs. I have tried at least 3 different ways of adding additional metadata without breaking backwards compatibility while keeping the code sane and I failed.

Here is a POC of how we could use Protobuf instead which is a format allowing easier backward and forward compatibility.
To keep log human readable (I think this is important) I have used TextProto serialization instead of default binary one
(need to explore if it provides the same guarantees re field removal addition).

This problem is not present just in `ReplicatedMergeTreeLogEntryData`, it is present also in DataPartsExchange, WriteAheadLog.

Messages look like this:

```
create_time: 1604100154
source_replica: "test"
merge_parts {
  source_parts: "20181001_0_0_0"
  source_parts: "20181001_1_1_0"
  source_parts: "20181001_2_2_0"
  source_parts: "20181001_3_3_0"
  source_parts: "20181001_4_4_0"
  new_part_name: "20181001_0_4_1"
  merge_type: REGULAR
  part_type: COMPACT
}
```

This PR switches completely to the new protocol, ideally we'd merge support for the new and enable it with a flag and making it the default one next time a bigger change is introduced. In the meantime in CI we can spin up replicas with random replication protocol for testing it thoroughly.

Here are two examples triggering eye twitching, they both have different ways to ser/de data and to handle compatibility.

```cpp
else if (type_str == "merge")
{
    type = MERGE_PARTS;
    while (true)
        // ...
    in >> new_part_name;

    if (format_version >= 4)
    {
        in >> "\ndeduplicate: " >> deduplicate;

        /// Trying to be more backward compatible
        in >> "\n";
        if (checkString("merge_type: ", in))
        {
            UInt64 value;
            in >> value;
            merge_type = checkAndGetMergeType(value);
        }
        else
            trailing_newline_found = true;
    }
}
```

---

```cpp
else if (type_str == "mutate")
{
    type = MUTATE_PART;
    String source_part;
    in >> source_part >> "\n"
        >> "to\n"
        >> new_part_name;
    source_parts.push_back(source_part);

    in >> "\n";

    if (in.eof())
        trailing_newline_found = true;
    else if (checkString("alter_version\n", in))
        in >> alter_version;
}
```

---

I think I actually had an acceptable solution by the end of the work day, something like this:

(How to solve the fact that old replicas will fail as they will get unexpected data which they don't know how to handle?)

```cpp
/// Trying to be more backward compatible
while (!trailing_newline_found)
{
    in >> "\n";

    if (checkString("merge_type: ", in))
    {
        UInt64 value;
        in >> value;
        merge_type = checkAndGetMergeType(value);
    }
    else if (checkString("into_uuid: ", in))
        in >> new_part_uuid;
    else
        trailing_newline_found = true;
}
```

But how long it will take until someone shots himself in the foot because `checkString` consumes actually characters as long as they match?
This code btw is at line 168, but a bit later (at line 250) there is `if (checkString("part_type: ", in))` so you can't introduce anything start with `p` if I read it correctly.

Now you can say that we could read up to `:` and use this as "field name", but then you have other cases where `\n` is used as delimiter instead.


---

# Is the current approach worth the time lost in this code for understanding it and trying to preserve protocol backward compatibility (and often failing)?

---

Alternatives considered: JSON but there is no code generation and no explicit schema, typing which makes it less appealing.

Big cons of protobufs would be codebase pollution with dependencies to bad autogenerated code.

---

Big todos:

- [ ] The outer log message should contain a flag wether or not an entry type could be discarded if it is not handled (ie extending the log with new events which might not be critical for correctness.
- [ ] The inner message, maybe, should also carry flags for communicating similar information. Ie `part_type` is safe to be introduced without breaking anything. `quorum` could be handled in few ways: 1. document it as "will start working correctly only after all replicas has been upgrade"; 2. tell replicas that when this field is set they should fail processing the log entry if they don't know how to read that field (no good ideas for how to do that yet).

---

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)