### PR TITLE
DatabaseCatalog increase reschedule time to second

### DIFF
--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -833,7 +833,7 @@ void DatabaseCatalog::dropTableDataTask()
 
     /// Do not schedule a task if there is no tables to drop
     if (need_reschedule)
-        (*drop_task)->scheduleAfter(reschedule_time_ms);
+        (*drop_task)->scheduleAfter(drop_reschedule_time_ms);
 }
 
 void DatabaseCatalog::dropTableFinally(const TableMarkedAsDropped & table)

--- a/src/Interpreters/DatabaseCatalog.h
+++ b/src/Interpreters/DatabaseCatalog.h
@@ -233,8 +233,6 @@ private:
     void dropTableDataTask();
     void dropTableFinally(const TableMarkedAsDropped & table);
 
-    static constexpr size_t reschedule_time_ms = 100;
-
 private:
     using UUIDToDatabaseMap = std::unordered_map<UUID, DatabasePtr>;
 
@@ -266,6 +264,7 @@ private:
     std::unordered_set<UUID> tables_marked_dropped_ids;
     mutable std::mutex tables_marked_dropped_mutex;
 
+    static constexpr size_t drop_reschedule_time_ms = 1000;
     std::unique_ptr<BackgroundSchedulePoolTaskHolder> drop_task;
     static constexpr time_t default_drop_delay_sec = 8 * 60;
     time_t drop_delay_sec = default_drop_delay_sec;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Recently the logging code was added DatabaseCatalog::dropTableDataTask.
```
 LOG_TRACE(log, "Not found any suitable tables to drop, still have {} tables in drop queue", tables_marked_dropped.size());
```
```
 try
    {
        std::lock_guard lock(tables_marked_dropped_mutex);
        time_t current_time = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
        auto it = std::find_if(tables_marked_dropped.begin(), tables_marked_dropped.end(), [&](const auto & elem)
        {
            bool not_in_use = !elem.table || elem.table.unique();
            bool old_enough = elem.drop_time + drop_delay_sec < current_time;

            LOG_INFO(log, "Time difference sec {}", current_time - elem.drop_time);
            return not_in_use && old_enough;
        });
        if (it != tables_marked_dropped.end())
        {
            table = std::move(*it);
            LOG_INFO(log, "Will try drop {}", table.table_id.getNameForLogs());
            tables_marked_dropped.erase(it);
        }
        else
        {
            LOG_TRACE(log, "Not found any suitable tables to drop, still have {} tables in drop queue", tables_marked_dropped.size());
        }
        need_reschedule = !tables_marked_dropped.empty();
    }
```

If we perform simple create drop table on client.
CREATE TABLE test(a Int64) ENGINE=TinyLog;
DROP TABLE test;

Server will produce such log until elem.drop_time + drop_delay_sec < current_time;
```
2020.10.31 23:04:04.196415 [ 61137 ] {} <Trace> DatabaseCatalog: Not found any suitable tables to drop, still have 1 tables in drop queue
```

In check we manipulate seconds so we can use 1 second for rescheduling instead of 100 ms.

CC: @alexey-milovidov 

Changelog category (leave one):
- Improvement