### PR TITLE
Allow parameterized functions in APPLY

### DIFF
--- a/src/Parsers/ASTColumnsTransformers.cpp
+++ b/src/Parsers/ASTColumnsTransformers.cpp
@@ -30,16 +30,21 @@ void IASTColumnsTransformer::transform(const ASTPtr & transformer, ASTs & nodes)
     }
 }
 
-void ASTColumnsApplyTransformer::formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const
+void ASTColumnsApplyTransformer::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << "APPLY" << (settings.hilite ? hilite_none : "") << "(" << func_name << ")";
+    settings.ostr << (settings.hilite ? hilite_keyword : "") << "APPLY" << (settings.hilite ? hilite_none : "") << "(" << func_name;
+    if (parameters)
+        parameters->formatImpl(settings, state, frame);
+    settings.ostr << ")";
 }
 
 void ASTColumnsApplyTransformer::transform(ASTs & nodes) const
 {
     for (auto & column : nodes)
     {
-        column = makeASTFunction(func_name, column);
+        auto function = makeASTFunction(func_name, column);
+        function->parameters = parameters;
+        column = function;
     }
 }
 

--- a/src/Parsers/ASTColumnsTransformers.h
+++ b/src/Parsers/ASTColumnsTransformers.h
@@ -18,10 +18,13 @@ public:
     ASTPtr clone() const override
     {
         auto res = std::make_shared<ASTColumnsApplyTransformer>(*this);
+        if (parameters)
+            res->parameters = parameters->clone();
         return res;
     }
     void transform(ASTs & nodes) const override;
     String func_name;
+    ASTPtr parameters;
 
 protected:
     void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;

--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -1229,16 +1229,29 @@ bool ParserColumnsTransformers::parseImpl(Pos & pos, ASTPtr & node, Expected & e
             return false;
         ++pos;
 
-        String func_name;
-        if (!parseIdentifierOrStringLiteral(pos, expected, func_name))
+        ASTPtr func_name;
+        if (!ParserIdentifier().parse(pos, func_name, expected))
             return false;
+
+        ASTPtr expr_list_args;
+        if (pos->type == TokenType::OpeningRoundBracket)
+        {
+            ++pos;
+            if (!ParserExpressionList(false).parse(pos, expr_list_args, expected))
+                return false;
+
+            if (pos->type != TokenType::ClosingRoundBracket)
+                return false;
+            ++pos;
+        }
 
         if (pos->type != TokenType::ClosingRoundBracket)
             return false;
         ++pos;
 
         auto res = std::make_shared<ASTColumnsApplyTransformer>();
-        res->func_name = func_name;
+        res->func_name = getIdentifierName(func_name);
+        res->parameters = expr_list_args;
         node = std::move(res);
         return true;
     }

--- a/tests/queries/0_stateless/01470_columns_transformers.reference
+++ b/tests/queries/0_stateless/01470_columns_transformers.reference
@@ -77,3 +77,9 @@ SELECT
     toFloat64(k),
     j
 FROM columns_transformers
+[110]	[9]	[173.5]
+SELECT
+    quantiles(0.5)(i),
+    quantiles(0.5)(j),
+    quantiles(0.5)(k)
+FROM columns_transformers

--- a/tests/queries/0_stateless/01470_columns_transformers.sql
+++ b/tests/queries/0_stateless/01470_columns_transformers.sql
@@ -41,4 +41,8 @@ EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) APPLY(sum) from columns_transformers;
 SELECT i, j, COLUMNS(i, j, k) APPLY(toFloat64), COLUMNS(i, j) EXCEPT (i) from columns_transformers;
 EXPLAIN SYNTAX SELECT i, j, COLUMNS(i, j, k) APPLY(toFloat64), COLUMNS(i, j) EXCEPT (i) from columns_transformers;
 
+-- APPLY with parameterized function
+SELECT COLUMNS(i, j, k) APPLY(quantiles(0.5)) from columns_transformers;
+EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) APPLY(quantiles(0.5)) from columns_transformers;
+
 DROP TABLE columns_transformers;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Now paratmeterized functions can be used in APPLY column transformer.

Detailed description / Documentation draft:

No need for now. Perhaps one day we can support function currying.