### PR TITLE
Restrict to use non-comparable types in primary key

### DIFF
--- a/src/Common/ErrorCodes.cpp
+++ b/src/Common/ErrorCodes.cpp
@@ -512,6 +512,7 @@ namespace ErrorCodes
     extern const int NO_ROW_DELIMITER = 546;
     extern const int INVALID_RAID_TYPE = 547;
     extern const int UNKNOWN_VOLUME = 548;
+    extern const int DATA_TYPE_CANNOT_BE_USED_IN_KEY = 549;
 
     extern const int KEEPER_EXCEPTION = 999;
     extern const int POCO_EXCEPTION = 1000;

--- a/src/Core/Field.h
+++ b/src/Core/Field.h
@@ -26,7 +26,6 @@ namespace ErrorCodes
     extern const int NOT_IMPLEMENTED;
     extern const int LOGICAL_ERROR;
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
-    extern const int LOGICAL_ERROR;
 }
 
 template <typename T, typename SFINAE = void>

--- a/src/Storages/KeyDescription.cpp
+++ b/src/Storages/KeyDescription.cpp
@@ -2,7 +2,6 @@
 
 #include <Functions/IFunction.h>
 #include <Parsers/ASTIdentifier.h>
-#include <DataTypes/DataTypeAggregateFunction.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <Interpreters/TreeRewriter.h>

--- a/src/Storages/KeyDescription.cpp
+++ b/src/Storages/KeyDescription.cpp
@@ -2,10 +2,12 @@
 
 #include <Functions/IFunction.h>
 #include <Parsers/ASTIdentifier.h>
+#include <DataTypes/DataTypeAggregateFunction.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <Interpreters/TreeRewriter.h>
 #include <Storages/extractKeyExpressionList.h>
+#include <Common/quoteString.h>
 
 
 namespace DB
@@ -14,6 +16,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
+    extern const int DATA_TYPE_CANNOT_BE_USED_IN_KEY;
 }
 
 KeyDescription::KeyDescription(const KeyDescription & other)
@@ -115,7 +118,13 @@ KeyDescription KeyDescription::getSortingKeyFromAST(
     }
 
     for (size_t i = 0; i < result.sample_block.columns(); ++i)
+    {
         result.data_types.emplace_back(result.sample_block.getByPosition(i).type);
+        if (!result.data_types.back()->isComparable())
+            throw Exception(ErrorCodes::DATA_TYPE_CANNOT_BE_USED_IN_KEY,
+                            "Column {} with type {} is not allowed in key expression, it's not comparable",
+                            backQuote(result.sample_block.getByPosition(i).name), result.data_types.back()->getName());
+    }
 
     return result;
 }

--- a/tests/queries/0_stateless/01548_uncomparable_columns_in_keys.sql
+++ b/tests/queries/0_stateless/01548_uncomparable_columns_in_keys.sql
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS uncomparable_keys;
+
+CREATE TABLE foo (id UInt64, key AggregateFunction(max, UInt64)) ENGINE MergeTree ORDER BY key; --{serverError 549}
+
+CREATE TABLE foo (id UInt64, key AggregateFunction(max, UInt64)) ENGINE MergeTree PARTITION BY key; --{serverError 549}
+
+CREATE TABLE foo (id UInt64, key AggregateFunction(max, UInt64)) ENGINE MergeTree ORDER BY (key) SAMPLE BY key; --{serverError 549}
+
+DROP TABLE IF EXISTS uncomparable_keys;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Backward Incompatible Change


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Restrict to use of non-comparable data types (like `AggregateFunction`)  in keys (Sorting key, Primary key, Partition key, and so on). 
