### PR TITLE
Removed an incorrect check from Field::get().

### DIFF
--- a/src/Core/Field.h
+++ b/src/Core/Field.h
@@ -768,8 +768,7 @@ T & Field::get()
     // Disregard signedness when converting between int64 types.
     constexpr Field::Types::Which target = TypeToEnum<NearestFieldType<ValueType>>::value;
     if (target != which
-           && (!isInt64FieldType(target) || !isInt64FieldType(which))
-        && target != Field::Types::Decimal64 /* DateTime64 fields */)
+           && (!isInt64FieldType(target) || !isInt64FieldType(which)))
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Invalid Field get from type {} to type {}", Types::toString(which), Types::toString(target));
 #endif
 

--- a/src/Interpreters/AsynchronousMetricLog.h
+++ b/src/Interpreters/AsynchronousMetricLog.h
@@ -22,7 +22,7 @@ struct AsynchronousMetricLogElement
 {
     UInt16 event_date;
     time_t event_time;
-    UInt64 event_time_microseconds;
+    Decimal64 event_time_microseconds;
     std::string metric_name;
     double value;
 

--- a/src/Interpreters/MetricLog.h
+++ b/src/Interpreters/MetricLog.h
@@ -18,7 +18,7 @@ namespace DB
 struct MetricLogElement
 {
     time_t event_time{};
-    UInt64 event_time_microseconds{};
+    Decimal64 event_time_microseconds{};
     UInt64 milliseconds{};
 
     std::vector<ProfileEvents::Count> profile_events;

--- a/src/Interpreters/OpenTelemetrySpanLog.h
+++ b/src/Interpreters/OpenTelemetrySpanLog.h
@@ -11,8 +11,8 @@ struct OpenTelemetrySpan
     UInt64 span_id;
     UInt64 parent_span_id;
     std::string operation_name;
-    UInt64 start_time_us;
-    UInt64 finish_time_us;
+    Decimal64 start_time_us;
+    Decimal64 finish_time_us;
     UInt64 duration_ns;
     Array attribute_names;
     Array attribute_values;

--- a/src/Interpreters/QueryLog.h
+++ b/src/Interpreters/QueryLog.h
@@ -30,9 +30,9 @@ struct QueryLogElement
     /// Depending on the type of query and type of stage, not all the fields may be filled.
 
     time_t event_time{};
-    UInt64 event_time_microseconds{};
+    Decimal64 event_time_microseconds{};
     time_t query_start_time{};
-    UInt64 query_start_time_microseconds{};
+    Decimal64 query_start_time_microseconds{};
     UInt64 query_duration_ms{};
 
     /// The data fetched from DB to execute the query

--- a/src/Interpreters/QueryThreadLog.h
+++ b/src/Interpreters/QueryThreadLog.h
@@ -16,11 +16,11 @@ namespace DB
 struct QueryThreadLogElement
 {
     time_t event_time{};
-    UInt64 event_time_microseconds{};
+    Decimal64 event_time_microseconds{};
     /// When query was attached to current thread
     time_t query_start_time{};
     /// same as above but adds microsecond precision
-    UInt64 query_start_time_microseconds{};
+    Decimal64 query_start_time_microseconds{};
     /// Real time spent by the thread to execute the query
     UInt64 query_duration_ms{};
 

--- a/src/Interpreters/TextLog.h
+++ b/src/Interpreters/TextLog.h
@@ -9,7 +9,7 @@ using Poco::Message;
 struct TextLogElement
 {
     time_t event_time{};
-    UInt64 event_time_microseconds{};
+    Decimal64 event_time_microseconds{};
     UInt32 microseconds;
 
     String thread_name;

--- a/src/Interpreters/TraceLog.h
+++ b/src/Interpreters/TraceLog.h
@@ -18,7 +18,7 @@ struct TraceLogElement
     static const TraceDataType::Values trace_values;
 
     time_t event_time{};
-    UInt64 event_time_microseconds{};
+    Decimal64 event_time_microseconds{};
     UInt64 timestamp_ns{};
     TraceType trace_type{};
     UInt64 thread_id{};


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
 
- Improvement
 

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now `event_time_microseconds` field stores in Decimal64, not UInt64. Removed an incorrect check from Field::get().
