### PR TITLE
Better update of ZooKeeper configuration in runtime.

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -363,7 +363,7 @@ struct ContextShared
     /// Initialized on demand (on distributed storages initialization) since Settings should be initialized
     std::unique_ptr<Clusters> clusters;
     ConfigurationPtr clusters_config;                        /// Stores updated configs
-    ConfigurationPtr zookeeper_config;                        /// Stores zookeeperd configs
+    ConfigurationPtr zookeeper_config;                        /// Stores zookeeper configs
     mutable std::mutex clusters_mutex;                        /// Guards clusters and clusters_config
 
 #if USE_EMBEDDED_COMPILER

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -363,6 +363,7 @@ struct ContextShared
     /// Initialized on demand (on distributed storages initialization) since Settings should be initialized
     std::unique_ptr<Clusters> clusters;
     ConfigurationPtr clusters_config;                        /// Stores updated configs
+    ConfigurationPtr zookeeper_config;                        /// Stores zookeeperd configs
     mutable std::mutex clusters_mutex;                        /// Guards clusters and clusters_config
 
 #if USE_EMBEDDED_COMPILER
@@ -1472,8 +1473,9 @@ zkutil::ZooKeeperPtr Context::getZooKeeper() const
 {
     std::lock_guard lock(shared->zookeeper_mutex);
 
+    const auto & config = shared->zookeeper_config ? *shared->zookeeper_config : getConfigRef();
     if (!shared->zookeeper)
-        shared->zookeeper = std::make_shared<zkutil::ZooKeeper>(getConfigRef(), "zookeeper");
+        shared->zookeeper = std::make_shared<zkutil::ZooKeeper>(config, "zookeeper");
     else if (shared->zookeeper->expired())
         shared->zookeeper = shared->zookeeper->startNewSession();
 
@@ -1507,6 +1509,8 @@ void Context::resetZooKeeper() const
 void Context::reloadZooKeeperIfChanged(const ConfigurationPtr & config) const
 {
     std::lock_guard lock(shared->zookeeper_mutex);
+    shared->zookeeper_config = config;
+
     if (!shared->zookeeper || shared->zookeeper->configChanged(*config, "zookeeper"))
     {
         shared->zookeeper = std::make_shared<zkutil::ZooKeeper>(*config, "zookeeper");

--- a/tests/integration/test_reload_zookeeper/test.py
+++ b/tests/integration/test_reload_zookeeper/test.py
@@ -10,9 +10,6 @@ from helpers.test_tools import assert_eq_with_retry
 cluster = ClickHouseCluster(__file__, zookeeper_config_path='configs/zookeeper.xml')
 node = cluster.add_instance('node', with_zookeeper=True)
 
-SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
-ZK_CONFIG_PATH = os.path.join(SCRIPT_DIR, 'configs/zookeeper.xml')
-
 
 @pytest.fixture(scope="module")
 def start_cluster():
@@ -28,7 +25,6 @@ def start_cluster():
 
         yield cluster
     finally:
-        config.close()
         cluster.shutdown()
 
 def test_reload_zookeeper(start_cluster):

--- a/tests/integration/test_reload_zookeeper/test.py
+++ b/tests/integration/test_reload_zookeeper/test.py
@@ -28,28 +28,6 @@ def start_cluster():
 
         yield cluster
     finally:
-        ## write back the configs
-        config = open(ZK_CONFIG_PATH, 'w')
-        config.write(
-"""
-<yandex>
-    <zookeeper>
-        <node index="1">
-            <host>zoo1</host>
-            <port>2181</port>
-        </node>
-        <node index="2">
-            <host>zoo2</host>
-            <port>2181</port>
-        </node>
-            <node index="3">
-            <host>zoo3</host>
-            <port>2181</port>
-        </node>
-        <session_timeout_ms>2000</session_timeout_ms>
-    </zookeeper>
-</yandex>
-    """)
         config.close()
         cluster.shutdown()
 
@@ -71,8 +49,7 @@ def test_reload_zookeeper(start_cluster):
     node.query("INSERT INTO test_table(date, id) select today(), number FROM numbers(1000)")
 
     ## remove zoo2, zoo3 from configs
-    config = open(ZK_CONFIG_PATH, 'w')
-    config.write(
+    new_config =
 """
 <yandex>
     <zookeeper>
@@ -84,8 +61,7 @@ def test_reload_zookeeper(start_cluster):
     </zookeeper>
 </yandex >
 """
-    )
-    config.close()
+    node.replace_config("/etc/clickhouse-server/conf.d/zookeeper.xml", new_config)
     ## config reloads, but can still work
     assert_eq_with_retry(node, "SELECT COUNT() FROM test_table", '1000', retry_count=120, sleep_time=0.5)
 
@@ -101,8 +77,7 @@ def test_reload_zookeeper(start_cluster):
         node.query("SELECT COUNT() FROM test_table")
 
     ## set config to zoo2, server will be normal
-    config = open(ZK_CONFIG_PATH, 'w')
-    config.write(
+    new_config =
 """
 <yandex>
     <zookeeper>
@@ -114,7 +89,7 @@ def test_reload_zookeeper(start_cluster):
     </zookeeper>
 </yandex>
 """
-    )
-    config.close()
+    node.replace_config("/etc/clickhouse-server/conf.d/zookeeper.xml", new_config)
+
     assert_eq_with_retry(node, "SELECT COUNT() FROM test_table", '1000', retry_count=120, sleep_time=0.5)
 

--- a/tests/integration/test_reload_zookeeper/test.py
+++ b/tests/integration/test_reload_zookeeper/test.py
@@ -45,8 +45,7 @@ def test_reload_zookeeper(start_cluster):
     node.query("INSERT INTO test_table(date, id) select today(), number FROM numbers(1000)")
 
     ## remove zoo2, zoo3 from configs
-    new_config =
-"""
+    new_config = """
 <yandex>
     <zookeeper>
         <node index="1">
@@ -73,8 +72,7 @@ def test_reload_zookeeper(start_cluster):
         node.query("SELECT COUNT() FROM test_table")
 
     ## set config to zoo2, server will be normal
-    new_config =
-"""
+    new_config = """
 <yandex>
     <zookeeper>
         <node index="1">


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
 
- Improvement
 

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Better update of ZooKeeper configuration in runtime.


Detailed description / Documentation draft:

Better change the config as PR #16627  did after discussing with @amosbird 

Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
