### PR TITLE
Fix possible modification of global context in DDLWorker

### DIFF
--- a/src/Interpreters/DDLWorker.h
+++ b/src/Interpreters/DDLWorker.h
@@ -105,7 +105,7 @@ private:
 
 private:
     std::atomic<bool> is_circular_replicated = false;
-    Context & context;
+    Context context;
     Poco::Logger * log;
 
     std::string host_fqdn;      /// current host domain name


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Backward Incompatible Change



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
If some `profile` was specified in `distributed_ddl` config section, then this profile could overwrite settings of `default` profile on server startup. It's fixed, now settings of distributed DDL queries should not affect global server settings.


Detailed description / Documentation draft:
[link1](https://github.com/ClickHouse/ClickHouse/blob/11fc6fd8c93b73327ce0546c7e20267609d349d9/src/Interpreters/DDLWorker.cpp#L330)
[link2](https://github.com/ClickHouse/ClickHouse/blob/11fc6fd8c93b73327ce0546c7e20267609d349d9/programs/server/Server.cpp#L756)