### PR TITLE
[RFC] Do not pass StoragePtr to ReadInOrderOptimizer::getInputOrder()

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1453,7 +1453,7 @@ void InterpreterSelectQuery::executeFetchColumns(
                     getSortDescriptionFromGroupBy(query),
                     query_info.syntax_analyzer_result);
 
-            query_info.input_order_info = query_info.order_optimizer->getInputOrder(storage, metadata_snapshot);
+            query_info.input_order_info = query_info.order_optimizer->getInputOrder(metadata_snapshot);
         }
 
         StreamLocalLimits limits;

--- a/src/Storages/ReadInOrderOptimizer.cpp
+++ b/src/Storages/ReadInOrderOptimizer.cpp
@@ -30,26 +30,11 @@ ReadInOrderOptimizer::ReadInOrderOptimizer(
         forbidden_columns.insert(elem.first);
 }
 
-InputOrderInfoPtr ReadInOrderOptimizer::getInputOrder(const StoragePtr & storage, const StorageMetadataPtr & metadata_snapshot) const
+InputOrderInfoPtr ReadInOrderOptimizer::getInputOrder(const StorageMetadataPtr & metadata_snapshot) const
 {
-    Names sorting_key_columns;
-    if (dynamic_cast<const MergeTreeData *>(storage.get()))
-    {
-        if (!metadata_snapshot->hasSortingKey())
-            return {};
-        sorting_key_columns = metadata_snapshot->getSortingKeyColumns();
-    }
-    else if (dynamic_cast<const StorageFromMergeTreeDataPart *>(storage.get()))
-    {
-        if (!metadata_snapshot->hasSortingKey())
-            return {};
-        sorting_key_columns = metadata_snapshot->getSortingKeyColumns();
-    }
-    else /// Inapplicable storage type
-    {
+    Names sorting_key_columns = metadata_snapshot->getSortingKeyColumns();
+    if (!metadata_snapshot->hasSortingKey())
         return {};
-    }
-
 
     SortDescription order_key_prefix_descr;
     int read_direction = required_sort_description.at(0).direction;

--- a/src/Storages/ReadInOrderOptimizer.h
+++ b/src/Storages/ReadInOrderOptimizer.h
@@ -20,7 +20,7 @@ public:
         const SortDescription & required_sort_description,
         const TreeRewriterResultPtr & syntax_result);
 
-    InputOrderInfoPtr getInputOrder(const StoragePtr & storage, const StorageMetadataPtr & metadata_snapshot) const;
+    InputOrderInfoPtr getInputOrder(const StorageMetadataPtr & metadata_snapshot) const;
 
 private:
     /// Actions for every element of order expression to analyze functions for monotonicity

--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -179,7 +179,7 @@ Pipe StorageBuffer::read(
         if (dst_has_same_structure)
         {
             if (query_info.order_optimizer)
-                query_info.input_order_info = query_info.order_optimizer->getInputOrder(destination, destination_metadata_snapshot);
+                query_info.input_order_info = query_info.order_optimizer->getInputOrder(destination_metadata_snapshot);
 
             /// The destination table has the same structure of the requested columns and we can simply read blocks from there.
             pipe_from_dst = destination->read(

--- a/src/Storages/StorageMaterializedView.cpp
+++ b/src/Storages/StorageMaterializedView.cpp
@@ -120,7 +120,7 @@ Pipe StorageMaterializedView::read(
     auto metadata_snapshot = storage->getInMemoryMetadataPtr();
 
     if (query_info.order_optimizer)
-        query_info.input_order_info = query_info.order_optimizer->getInputOrder(storage, metadata_snapshot);
+        query_info.input_order_info = query_info.order_optimizer->getInputOrder(metadata_snapshot);
 
     Pipe pipe = storage->read(column_names, metadata_snapshot, query_info, context, processed_stage, max_block_size, num_streams);
     pipe.addTableLock(lock);

--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -211,7 +211,7 @@ Pipe StorageMerge::read(
         {
             auto storage_ptr = std::get<0>(*it);
             auto storage_metadata_snapshot = storage_ptr->getInMemoryMetadataPtr();
-            auto current_info = query_info.order_optimizer->getInputOrder(storage_ptr, storage_metadata_snapshot);
+            auto current_info = query_info.order_optimizer->getInputOrder(storage_metadata_snapshot);
             if (it == selected_tables.begin())
                 input_sorting_info = current_info;
             else if (!current_info || (input_sorting_info && *current_info != *input_sorting_info))


### PR DESCRIPTION
Looks like this is not required anymore, since #11745

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @alesapin 