### PR TITLE
Improve performance of quantileMerge

### DIFF
--- a/src/AggregateFunctions/ReservoirSampler.h
+++ b/src/AggregateFunctions/ReservoirSampler.h
@@ -158,12 +158,25 @@ public:
         }
         else
         {
-            randomShuffle(samples);
+            /// Replace every element in our reservoir to the b's reservoir
+            /// with the probability of b.total_values / (a.total_values + b.total_values)
+            /// Do it more roughly than true random sampling to save performance.
+
             total_values += b.total_values;
-            for (size_t i = 0; i < sample_count; ++i)
+
+            /// Will replace every frequency'th element in a to element from b.
+            double frequency = static_cast<double>(total_values) / b.total_values;
+
+            /// When frequency is too low, replace just one random element with the corresponding probability.
+            if (frequency * 2 >= sample_count)
             {
-                UInt64 rnd = genRandom(total_values);
-                if (rnd < b.total_values)
+                UInt64 rnd = genRandom(frequency);
+                if (rnd < sample_count)
+                    samples[rnd] = b.samples[rnd];
+            }
+            else
+            {
+                for (double i = 0; i < sample_count; i += frequency)
                     samples[i] = b.samples[i];
             }
         }
@@ -220,15 +233,6 @@ private:
             return static_cast<UInt32>(rng()) % static_cast<UInt32>(lim);
         else
             return (static_cast<UInt64>(rng()) * (static_cast<UInt64>(rng.max()) + 1ULL) + static_cast<UInt64>(rng())) % lim;
-    }
-
-    void randomShuffle(Array & v)
-    {
-        for (size_t i = 1; i < v.size(); ++i)
-        {
-            size_t j = genRandom(i + 1);
-            std::swap(v[i], v[j]);
-        }
     }
 
     void sortIfNeeded()

--- a/tests/performance/quantile_merge.xml
+++ b/tests/performance/quantile_merge.xml
@@ -1,0 +1,3 @@
+<test>
+    <query>SELECT quantileMerge(arrayJoin(arrayMap(x -> state, range(1000000)))) FROM (SELECT quantileState(rand()) AS state FROM numbers(10000))</query>
+</test>


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve performance of `quantileMerge`. In previous versions it was obnoxiously slow. This closes #1463.

Note: it was so slow that performance test will unlikely to finish on old version.