### PR TITLE
Fix flaky tests after "max_memory_usage_for_user"

### DIFF
--- a/tests/queries/0_stateless/01541_max_memory_usage_for_user.sh
+++ b/tests/queries/0_stateless/01541_max_memory_usage_for_user.sh
@@ -10,7 +10,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # - one users' query in background (to avoid reseting max_memory_usage_for_user)
 
 # We have to create a separate user to run this tests isolated from other tests.
-${CLICKHOUSE_CLIENT} -n --query "DROP USER IF EXISTS test_01541; CREATE USER test_01541; GRANT ALL ON *.* TO test_01541;";
+${CLICKHOUSE_CLIENT} -n --allow_introspection_functions 1 --query "DROP USER IF EXISTS test_01541; CREATE USER test_01541; GRANT ALL ON *.* TO test_01541;";
 
 
 query="SELECT groupArray(repeat('a', 1000)) FROM numbers(10000) GROUP BY number % 10 FORMAT JSON"


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

See also #16486