### PR TITLE
Remove obsolete code from JOIN

### DIFF
--- a/src/Interpreters/TableJoin.cpp
+++ b/src/Interpreters/TableJoin.cpp
@@ -28,8 +28,6 @@ TableJoin::TableJoin(const Settings & settings, VolumePtr tmp_volume_)
     , temporary_files_codec(settings.temporary_files_codec)
     , tmp_volume(tmp_volume_)
 {
-    if (settings.partial_merge_join)
-        join_algorithm = JoinAlgorithm::PREFER_PARTIAL_MERGE;
 }
 
 void TableJoin::resetCollected()


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)
