### PR TITLE
Fix "format-changelog.py" for Python3

### DIFF
--- a/utils/simple-backport/format-changelog.py
+++ b/utils/simple-backport/format-changelog.py
@@ -18,7 +18,7 @@ args = parser.parse_args()
 def parse_one_pull_request(item):
     description = item['body']
     # Don't skip empty lines because they delimit parts of description
-    lines = [line for line in [x.strip() for x in description.split('\n') if description else []]]
+    lines = [line for line in [x.strip() for x in (description.split('\n') if description else [])]]
     lines = [re.sub(r'\s+', ' ', l) for l in lines]
 
     category = ''


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)
