### PR TITLE
ISSUES-16605 fix without returning affected rows when insert select query in MySQL handler

### DIFF
--- a/src/Server/MySQLHandler.cpp
+++ b/src/Server/MySQLHandler.cpp
@@ -328,6 +328,9 @@ void MySQLHandler::comQuery(ReadBuffer & payload)
 
         Context query_context = connection_context;
 
+        size_t affected_rows = 0;
+        query_context.setProgressCallback([&](const Progress & progress) { affected_rows += progress.written_rows; });
+
         executeQuery(should_replace ? replacement : payload, *out, true, query_context,
             [&with_output](const String &, const String &, const String &, const String &)
             {
@@ -336,7 +339,7 @@ void MySQLHandler::comQuery(ReadBuffer & payload)
         );
 
         if (!with_output)
-            packet_endpoint->sendPacket(OKPacket(0x00, client_capability_flags, 0, 0, 0), true);
+            packet_endpoint->sendPacket(OKPacket(0x00, client_capability_flags, affected_rows, 0, 0), true);
     }
 }
 

--- a/tests/integration/test_mysql_protocol/test.py
+++ b/tests/integration/test_mysql_protocol/test.py
@@ -167,7 +167,7 @@ def test_mysql_affected_rows(mysql_client, server_address):
     '''.format(host=server_address, port=server_port), demux=True)
 
     assert code == 0
-    assert "1 rows affected" in stdout.decode()
+    assert "1 row affected" in stdout.decode()
 
     code, (stdout, stderr) = mysql_client.exec_run('''
         mysql -vvv --protocol tcp -h {host} -P {port} default -u default --password=123

--- a/tests/integration/test_mysql_protocol/test.py
+++ b/tests/integration/test_mysql_protocol/test.py
@@ -154,6 +154,36 @@ def test_mysql_client_exception(mysql_client, server_address):
                             "ERROR 1000 (00000) at line 1: Poco::Exception. Code: 1000, e.code() = 2002, e.displayText() = mysqlxx::ConnectionFailed: Can't connect to MySQL server on '127.0.0.1' (115) ((nullptr):0)"
 
 
+def test_mysql_affected_rows(mysql_client, server_address):
+    code, (stdout, stderr) = mysql_client.exec_run('''
+        mysql --protocol tcp -h {host} -P {port} default -u default --password=123
+        -e "CREATE TABLE IF NOT EXISTS default.t1 (n UInt64) ENGINE MergeTree() ORDER BY tuple();"
+    '''.format(host=server_address, port=server_port), demux=True)
+    assert code == 0
+
+    code, (stdout, stderr) = mysql_client.exec_run('''
+        mysql -vvv --protocol tcp -h {host} -P {port} default -u default --password=123
+        -e "INSERT INTO default.t1(n) VALUES(1);"
+    '''.format(host=server_address, port=server_port), demux=True)
+
+    assert code == 0
+    assert "1 rows affected" in stdout
+
+    code, (stdout, stderr) = mysql_client.exec_run('''
+        mysql -vvv --protocol tcp -h {host} -P {port} default -u default --password=123
+        -e "INSERT INTO default.t1(n) SELECT * FROM numbers(1000)"
+    '''.format(host=server_address, port=server_port), demux=True)
+
+    assert code == 0
+    assert "1000 rows affected" in stdout
+
+    code, (stdout, stderr) = mysql_client.exec_run('''
+        mysql --protocol tcp -h {host} -P {port} default -u default --password=123
+        -e "DROP TABLE default.t1;"
+    '''.format(host=server_address, port=server_port), demux=True)
+    assert code == 0
+
+
 def test_mysql_replacement_query(mysql_client, server_address):
     # SHOW TABLE STATUS LIKE.
     code, (stdout, stderr) = mysql_client.exec_run('''

--- a/tests/integration/test_mysql_protocol/test.py
+++ b/tests/integration/test_mysql_protocol/test.py
@@ -167,7 +167,7 @@ def test_mysql_affected_rows(mysql_client, server_address):
     '''.format(host=server_address, port=server_port), demux=True)
 
     assert code == 0
-    assert "1 rows affected" in stdout
+    assert "1 rows affected" in stdout.decode()
 
     code, (stdout, stderr) = mysql_client.exec_run('''
         mysql -vvv --protocol tcp -h {host} -P {port} default -u default --password=123
@@ -175,7 +175,7 @@ def test_mysql_affected_rows(mysql_client, server_address):
     '''.format(host=server_address, port=server_port), demux=True)
 
     assert code == 0
-    assert "1000 rows affected" in stdout
+    assert "1000 rows affected" in stdout.decode()
 
     code, (stdout, stderr) = mysql_client.exec_run('''
         mysql --protocol tcp -h {host} -P {port} default -u default --password=123


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Return number of affected rows for INSERT queries via MySQL protocol. Previously ClickHouse used to always return 0, it's fixed.
Fixes #16605 