### PR TITLE
Get rid of possible memory allocation in ThreadPool::worker(...)

### DIFF
--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -216,7 +216,7 @@ void ThreadPoolImpl<Thread>::worker(typename std::list<Thread>::iterator thread_
 
             if (!jobs.empty())
             {
-                job = jobs.top().job;
+                job = std::move(jobs.top().job);
                 jobs.pop();
             }
             else


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Not for changelog


Detailed description / Documentation draft:
Fix rare crashes https://gist.github.com/tavplubix/72d20b48484165529ffd903875bf1c10
