### PR TITLE
Higher mmap threshold in debug build

### DIFF
--- a/src/Common/Allocator.cpp
+++ b/src/Common/Allocator.cpp
@@ -14,6 +14,8 @@
       * In debug build, use small mmap threshold to reproduce more memory
       * stomping bugs. Along with ASLR it will hopefully detect more issues than
       * ASan. The program may fail due to the limit on number of memory mappings.
+      *
+      * Not too small to avoid too quick exhaust of memory mappings.
       */
-    __attribute__((__weak__)) extern const size_t MMAP_THRESHOLD = 4096;
+    __attribute__((__weak__)) extern const size_t MMAP_THRESHOLD = 16384;
 #endif


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

See https://github.com/ClickHouse/ClickHouse/issues/15718#issuecomment-724908432