### PR TITLE
Added proper authentication for S3 client

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -66,6 +66,7 @@ class IColumn;
     M(UInt64, connections_with_failover_max_tries, DBMS_CONNECTION_POOL_WITH_FAILOVER_DEFAULT_MAX_TRIES, "The maximum number of attempts to connect to replicas.", 0) \
     M(UInt64, s3_min_upload_part_size, 512*1024*1024, "The minimum size of part to upload during multipart upload to S3.", 0) \
     M(UInt64, s3_max_redirects, 10, "Max number of S3 redirects hops allowed.", 0) \
+    M(Bool, s3_use_environment_credentials, false, "Use environment credentials for S3 by default.", 0) \
     M(Bool, extremes, false, "Calculate minimums and maximums of the result columns. They can be output in JSON-formats.", IMPORTANT) \
     M(Bool, use_uncompressed_cache, true, "Whether to use the cache of uncompressed blocks.", 0) \
     M(Bool, replace_running_query, false, "Whether the running request should be canceled with the same id as the new one.", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -66,7 +66,6 @@ class IColumn;
     M(UInt64, connections_with_failover_max_tries, DBMS_CONNECTION_POOL_WITH_FAILOVER_DEFAULT_MAX_TRIES, "The maximum number of attempts to connect to replicas.", 0) \
     M(UInt64, s3_min_upload_part_size, 512*1024*1024, "The minimum size of part to upload during multipart upload to S3.", 0) \
     M(UInt64, s3_max_redirects, 10, "Max number of S3 redirects hops allowed.", 0) \
-    M(Bool, s3_use_environment_credentials, false, "Use environment credentials for S3 by default.", 0) \
     M(Bool, extremes, false, "Calculate minimums and maximums of the result columns. They can be output in JSON-formats.", IMPORTANT) \
     M(Bool, use_uncompressed_cache, true, "Whether to use the cache of uncompressed blocks.", 0) \
     M(Bool, replace_running_query, false, "Whether the running request should be canceled with the same id as the new one.", 0) \

--- a/src/Disks/S3/registerDiskS3.cpp
+++ b/src/Disks/S3/registerDiskS3.cpp
@@ -132,7 +132,7 @@ void registerDiskS3(DiskFactory & factory)
             uri.is_virtual_hosted_style,
             config.getString(config_prefix + ".access_key_id", ""),
             config.getString(config_prefix + ".secret_access_key", ""),
-            config.getBool(config_prefix + ".use_environment_credentials", context.getSettingsRef().s3_use_environment_credentials),
+            config.getBool(config_prefix + ".use_environment_credentials", config.getBool("s3.use_environment_credentials", false)),
             context.getRemoteHostFilter(),
             context.getGlobalContext().getSettingsRef().s3_max_redirects);
 

--- a/src/Disks/S3/registerDiskS3.cpp
+++ b/src/Disks/S3/registerDiskS3.cpp
@@ -132,6 +132,7 @@ void registerDiskS3(DiskFactory & factory)
             uri.is_virtual_hosted_style,
             config.getString(config_prefix + ".access_key_id", ""),
             config.getString(config_prefix + ".secret_access_key", ""),
+            config.getBool(config_prefix + ".use_environment_credentials", context.getSettingsRef().s3_use_environment_credentials),
             context.getRemoteHostFilter(),
             context.getGlobalContext().getSettingsRef().s3_max_redirects);
 

--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -92,7 +92,7 @@ private:
 class S3CredentialsProviderChain : public Aws::Auth::AWSCredentialsProviderChain
 {
 public:
-    S3CredentialsProviderChain(const DB::RemoteHostFilter & remote_host_filter)
+    explicit S3CredentialsProviderChain(const DB::RemoteHostFilter & remote_host_filter)
     {
         static const char AWS_ECS_CONTAINER_CREDENTIALS_RELATIVE_URI[] = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
         static const char AWS_ECS_CONTAINER_CREDENTIALS_FULL_URI[] = "AWS_CONTAINER_CREDENTIALS_FULL_URI";
@@ -107,7 +107,7 @@ public:
         AddProvider(std::make_shared<Aws::Auth::EnvironmentAWSCredentialsProvider>());
         AddProvider(std::make_shared<Aws::Auth::ProfileConfigFileAWSCredentialsProvider>());
         AddProvider(std::make_shared<Aws::Auth::STSAssumeRoleWebIdentityCredentialsProvider>());
-    
+
         /// ECS TaskRole Credentials only available when ENVIRONMENT VARIABLE is set.
         const auto relative_uri = Aws::Environment::GetEnv(AWS_ECS_CONTAINER_CREDENTIALS_RELATIVE_URI);
         LOG_DEBUG(logger, "The environment variable value {} is {}", AWS_ECS_CONTAINER_CREDENTIALS_RELATIVE_URI,

--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -323,8 +323,9 @@ namespace S3
 
         Aws::Auth::AWSCredentials credentials(access_key_id, secret_access_key);
 
+        auto auth_signer = std::make_shared<S3AuthSigner>(client_configuration, std::move(credentials), std::move(headers), use_environment_credentials);
         return std::make_shared<Aws::S3::S3Client>(
-            std::make_shared<S3AuthSigner>(client_configuration, std::move(credentials), std::move(headers), use_environment_credentials),
+            std::move(auth_signer),
             std::move(client_configuration), // Client configuration.
             is_virtual_hosted_style || client_configuration.endpointOverride.empty() // Use virtual addressing only if endpoint is not specified.
         );

--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -144,10 +144,10 @@ namespace S3
 {
     ClientFactory::ClientFactory()
     {
-        aws_options = Aws::SDKOptions{};
-        Aws::InitAPI(aws_options);
         Aws::Utils::Logging::InitializeAWSLogging(std::make_shared<AWSLogger>());
         Aws::Http::SetHttpClientFactory(std::make_shared<PocoHTTPClientFactory>());
+        aws_options = Aws::SDKOptions{};
+        Aws::InitAPI(aws_options);
     }
 
     ClientFactory::~ClientFactory()

--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -144,10 +144,10 @@ namespace S3
 {
     ClientFactory::ClientFactory()
     {
-        Aws::Utils::Logging::InitializeAWSLogging(std::make_shared<AWSLogger>());
-        Aws::Http::SetHttpClientFactory(std::make_shared<PocoHTTPClientFactory>());
         aws_options = Aws::SDKOptions{};
         Aws::InitAPI(aws_options);
+        Aws::Utils::Logging::InitializeAWSLogging(std::make_shared<AWSLogger>());
+        Aws::Http::SetHttpClientFactory(std::make_shared<PocoHTTPClientFactory>());
     }
 
     ClientFactory::~ClientFactory()

--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -99,7 +99,7 @@ public:
         static const char AWS_ECS_CONTAINER_AUTHORIZATION_TOKEN[] = "AWS_CONTAINER_AUTHORIZATION_TOKEN";
         static const char AWS_EC2_METADATA_DISABLED[] = "AWS_EC2_METADATA_DISABLED";
 
-        auto logger = &Poco::Logger::get("S3CredentialsProviderChain");
+        auto * logger = &Poco::Logger::get("S3CredentialsProviderChain");
 
         /// The only difference from DefaultAWSCredentialsProviderChain::DefaultAWSCredentialsProviderChain()
         /// is that this chain uses custom ClientConfiguration.

--- a/src/IO/S3Common.h
+++ b/src/IO/S3Common.h
@@ -53,6 +53,7 @@ public:
         const String & access_key_id,
         const String & secret_access_key,
         HeaderCollection headers,
+        bool use_environment_credentials,
         const RemoteHostFilter & remote_host_filter,
         unsigned int s3_max_redirects);
 

--- a/src/IO/S3Common.h
+++ b/src/IO/S3Common.h
@@ -36,6 +36,7 @@ public:
         bool is_virtual_hosted_style,
         const String & access_key_id,
         const String & secret_access_key,
+        bool use_environment_credentials,
         const RemoteHostFilter & remote_host_filter,
         unsigned int s3_max_redirects);
 
@@ -44,6 +45,7 @@ public:
         bool is_virtual_hosted_style,
         const String & access_key_id,
         const String & secret_access_key,
+        bool use_environment_credentials,
         const RemoteHostFilter & remote_host_filter,
         unsigned int s3_max_redirects);
 

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -216,8 +216,14 @@ StorageS3::StorageS3(
         credentials = Aws::Auth::AWSCredentials(std::move(settings.access_key_id), std::move(settings.secret_access_key));
 
     client = S3::ClientFactory::instance().create(
-        uri_.endpoint, uri_.is_virtual_hosted_style, access_key_id_, secret_access_key_, std::move(settings.headers),
-        context_.getRemoteHostFilter(), context_.getGlobalContext().getSettingsRef().s3_max_redirects);
+        uri_.endpoint,
+        uri_.is_virtual_hosted_style,
+        credentials.GetAWSAccessKeyId(),
+        credentials.GetAWSSecretKey(),
+        std::move(settings.headers),
+        settings.use_environment_credentials,
+        context_.getRemoteHostFilter(),
+        context_.getGlobalContext().getSettingsRef().s3_max_redirects);
 }
 
 

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -221,7 +221,7 @@ StorageS3::StorageS3(
         credentials.GetAWSAccessKeyId(),
         credentials.GetAWSSecretKey(),
         std::move(settings.headers),
-        settings.use_environment_credentials.value_or(context_.getGlobalContext().getSettingsRef().s3_use_environment_credentials),
+        settings.use_environment_credentials.value_or(global_context.getConfigRef().getBool("s3.use_environment_credentials", false)),
         context_.getRemoteHostFilter(),
         context_.getGlobalContext().getSettingsRef().s3_max_redirects);
 }

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -221,7 +221,7 @@ StorageS3::StorageS3(
         credentials.GetAWSAccessKeyId(),
         credentials.GetAWSSecretKey(),
         std::move(settings.headers),
-        settings.use_environment_credentials,
+        settings.use_environment_credentials.value_or(context_.getGlobalContext().getSettingsRef().s3_use_environment_credentials),
         context_.getRemoteHostFilter(),
         context_.getGlobalContext().getSettingsRef().s3_max_redirects);
 }

--- a/src/Storages/StorageS3Settings.cpp
+++ b/src/Storages/StorageS3Settings.cpp
@@ -26,7 +26,11 @@ void StorageS3Settings::loadFromConfig(const String & config_elem, const Poco::U
         auto endpoint = config.getString(config_elem + "." + key + ".endpoint");
         auto access_key_id = config.getString(config_elem + "." + key + ".access_key_id", "");
         auto secret_access_key = config.getString(config_elem + "." + key + ".secret_access_key", "");
-        auto use_environment_credentials = config.getBool(config_elem + "." + key + ".use_environment_credentials", false);
+        std::optional<bool> use_environment_credentials;
+        if (config.has(config_elem + "." + key + ".use_environment_credentials"))
+        {
+            use_environment_credentials = config.getBool(config_elem + "." + key + ".use_environment_credentials");
+        }
 
         HeaderCollection headers;
         Poco::Util::AbstractConfiguration::Keys subconfig_keys;

--- a/src/Storages/StorageS3Settings.cpp
+++ b/src/Storages/StorageS3Settings.cpp
@@ -26,6 +26,7 @@ void StorageS3Settings::loadFromConfig(const String & config_elem, const Poco::U
         auto endpoint = config.getString(config_elem + "." + key + ".endpoint");
         auto access_key_id = config.getString(config_elem + "." + key + ".access_key_id", "");
         auto secret_access_key = config.getString(config_elem + "." + key + ".secret_access_key", "");
+        auto use_environment_credentials = config.getBool(config_elem + "." + key + ".use_environment_credentials", false);
 
         HeaderCollection headers;
         Poco::Util::AbstractConfiguration::Keys subconfig_keys;
@@ -42,7 +43,7 @@ void StorageS3Settings::loadFromConfig(const String & config_elem, const Poco::U
             }
         }
 
-        settings.emplace(endpoint, S3AuthSettings{std::move(access_key_id), std::move(secret_access_key), std::move(headers)});
+        settings.emplace(endpoint, S3AuthSettings{std::move(access_key_id), std::move(secret_access_key), std::move(headers), use_environment_credentials});
     }
 }
 

--- a/src/Storages/StorageS3Settings.h
+++ b/src/Storages/StorageS3Settings.h
@@ -3,6 +3,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <vector>
 #include <common/types.h>
 
@@ -29,7 +30,7 @@ struct S3AuthSettings
 
     const HeaderCollection headers;
 
-    const bool use_environment_credentials;
+    std::optional<bool> use_environment_credentials;
 };
 
 /// Settings for the StorageS3.

--- a/src/Storages/StorageS3Settings.h
+++ b/src/Storages/StorageS3Settings.h
@@ -28,6 +28,8 @@ struct S3AuthSettings
     const String secret_access_key;
 
     const HeaderCollection headers;
+
+    const bool use_environment_credentials;
 };
 
 /// Settings for the StorageS3.

--- a/tests/integration/test_log_family_s3/test.py
+++ b/tests/integration/test_log_family_s3/test.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 import pytest
 from helpers.cluster import ClickHouseCluster
@@ -34,19 +35,23 @@ def test_log_family_s3(cluster, log_engine, files_overhead, files_overhead_per_i
 
     node.query("INSERT INTO s3_test SELECT number FROM numbers(5)")
     assert node.query("SELECT * FROM s3_test") == "0\n1\n2\n3\n4\n"
+    print(list(minio.list_objects(cluster.minio_bucket, 'data/')), file=sys.stderr)
     assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == files_overhead_per_insert + files_overhead
 
     node.query("INSERT INTO s3_test SELECT number + 5 FROM numbers(3)")
     assert node.query("SELECT * FROM s3_test order by id") == "0\n1\n2\n3\n4\n5\n6\n7\n"
+    print(list(minio.list_objects(cluster.minio_bucket, 'data/')), file=sys.stderr)
     assert len(
         list(minio.list_objects(cluster.minio_bucket, 'data/'))) == files_overhead_per_insert * 2 + files_overhead
 
     node.query("INSERT INTO s3_test SELECT number + 8 FROM numbers(1)")
     assert node.query("SELECT * FROM s3_test order by id") == "0\n1\n2\n3\n4\n5\n6\n7\n8\n"
+    print(list(minio.list_objects(cluster.minio_bucket, 'data/')), file=sys.stderr)
     assert len(
         list(minio.list_objects(cluster.minio_bucket, 'data/'))) == files_overhead_per_insert * 3 + files_overhead
 
     node.query("TRUNCATE TABLE s3_test")
+    print(list(minio.list_objects(cluster.minio_bucket, 'data/')), file=sys.stderr)
     assert len(list(minio.list_objects(cluster.minio_bucket, 'data/'))) == 0
 
     node.query("DROP TABLE s3_test")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Added proper authentication using environment, `~/.aws` and `AssumeRole` for S3 client.

Global configuration file setting `s3.use_environment_credentials` turns on attempt to retrieve credentials from environment, and it can be granularly overridden in endpoint/disk setting with same name: `use_environment_credentials`. If setting is on and credentials can not be retrieved from environment, credentials for given endpoint/disk are being used (possibly anonymous).

Environment credentials are retrieved by following procedure (default for AWS):
1) environment variables `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`;
2) configuration file in `$HOME/.aws`;
3) STS `AssumeRole`;
4) ECS task role credentials specified in `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` or `AWS_CONTAINER_CREDENTIALS_FULL_URI` and `AWS_ECS_CONTAINER_AUTHORIZATION_TOKEN`;
5) EC2 metadata credentials if `AWS_EC2_METADATA_DISABLED` is not set to `true` (in any case).

If credentials are retrieved but they are wrong, ClickHouse will not try another ones.