### PR TITLE
Support HTTP proxy and HTTPS S3 endpoint configuration

### DIFF
--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -168,12 +168,16 @@ void PocoHTTPClient::makeRequestInternal(
 
             auto request_configuration = per_request_configuration(request);
             if (!request_configuration.proxyHost.empty())
+            {
+                /// Turn on tunnel mode if proxy scheme is HTTP while endpoint scheme is HTTPS.
+                bool use_tunnel = request_configuration.proxyScheme == Aws::Http::Scheme::HTTP && poco_uri.getScheme() == "https";
                 session->setProxy(
                     request_configuration.proxyHost,
                     request_configuration.proxyPort,
                     Aws::Http::SchemeMapper::ToString(request_configuration.proxyScheme),
-                    false /// Disable proxy tunneling by default
+                    use_tunnel
                 );
+            }
 
             Poco::Net::HTTPRequest poco_request(Poco::Net::HTTPRequest::HTTP_1_1);
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support HTTP proxy and HTTPS S3 endpoint configuration


Detailed description / Documentation draft:
To work with HTTP proxy - HTTPS S3 endpoint configuration, proxy should be used in tunnel mode.

It's hard to test it because nginx (we use it as proxy) doesn't support HTTP CONNECT methods that used to work proxy in tunnel mode. We can just rely on poco library handle this mode correctly without additional tests from our side.

Related to: https://github.com/ClickHouse/ClickHouse/issues/16395