### PR TITLE
Fix strange code in InterpreterShowAccessQuery

### DIFF
--- a/src/Interpreters/InterpreterShowAccessQuery.cpp
+++ b/src/Interpreters/InterpreterShowAccessQuery.cpp
@@ -78,7 +78,7 @@ ASTs InterpreterShowAccessQuery::getCreateAndGrantQueries() const
     for (const auto & entity : entities)
     {
         create_queries.push_back(InterpreterShowCreateAccessEntityQuery::getCreateQuery(*entity, access_control));
-        if (entity->isTypeOf(EntityType::USER) || entity->isTypeOf(EntityType::USER))
+        if (entity->isTypeOf(EntityType::USER) || entity->isTypeOf(EntityType::ROLE))
             boost::range::push_back(grant_queries, InterpreterShowGrantsQuery::getGrantQueries(*entity, access_control));
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
TODO

Detailed description:
I'm not familiar with RBAC code, but it seems like the condition should be `(... USER || ... ROLE)`, because the first argument of `getGrantQueries(...)` named `user_or_role`