### PR TITLE
Disable ATTACH/DETACH TABLE <DICTIONARY>

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -684,6 +684,10 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
         // Table SQL definition is available even if the table is detached
         auto query = database->getCreateTableQuery(create.table, context);
         create = query->as<ASTCreateQuery &>(); // Copy the saved create query, but use ATTACH instead of CREATE
+        if (create.is_dictionary)
+            throw Exception(
+                "Cannot ATTACH TABLE " + backQuoteIfNeed(database_name) + "." + backQuoteIfNeed(create.table) + ", it is a Dictionary",
+                ErrorCodes::INCORRECT_QUERY);
         create.attach = true;
         create.attach_short_syntax = true;
         create.if_not_exists = if_not_exists;

--- a/src/Interpreters/InterpreterDropQuery.cpp
+++ b/src/Interpreters/InterpreterDropQuery.cpp
@@ -119,6 +119,7 @@ BlockIO InterpreterDropQuery::executeToTableImpl(const ASTDropQuery & query, Dat
         if (query.kind == ASTDropQuery::Kind::Detach)
         {
             context.checkAccess(table->isView() ? AccessType::DROP_VIEW : AccessType::DROP_TABLE, table_id);
+            table->checkTableCanBeDetached();
             table->shutdown();
             TableExclusiveLockHolder table_lock;
             if (database->getEngineName() != "Atomic")

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -443,6 +443,8 @@ public:
     /// Otherwise - throws an exception with detailed information.
     /// We do not use mutex because it is not very important that the size could change during the operation.
     virtual void checkTableCanBeDropped() const {}
+    /// Similar to above but checks for DETACH. It's only used for DICTIONARIES.
+    virtual void checkTableCanBeDetached() const {}
 
     /// Checks that Partition could be dropped right now
     /// Otherwise - throws an exception with detailed information.

--- a/src/Storages/StorageDictionary.cpp
+++ b/src/Storages/StorageDictionary.cpp
@@ -130,6 +130,11 @@ void StorageDictionary::checkTableCanBeDropped() const
         throw Exception("Cannot detach table " + getStorageID().getFullTableName() + " from a database with DICTIONARY engine", ErrorCodes::CANNOT_DETACH_DICTIONARY_AS_TABLE);
 }
 
+void StorageDictionary::checkTableCanBeDetached() const
+{
+    checkTableCanBeDropped();
+}
+
 Pipe StorageDictionary::read(
     const Names & column_names,
     const StorageMetadataPtr & /*metadata_snapshot*/,

--- a/src/Storages/StorageDictionary.h
+++ b/src/Storages/StorageDictionary.h
@@ -15,6 +15,7 @@ public:
     std::string getName() const override { return "Dictionary"; }
 
     void checkTableCanBeDropped() const override;
+    void checkTableCanBeDetached() const override;
 
     Pipe read(
         const Names & column_names,

--- a/tests/queries/0_stateless/01575_disable_detach_table_of_dictionary.sql
+++ b/tests/queries/0_stateless/01575_disable_detach_table_of_dictionary.sql
@@ -1,0 +1,26 @@
+DROP DATABASE IF EXISTS database_for_dict;
+
+CREATE DATABASE database_for_dict;
+
+CREATE TABLE database_for_dict.table_for_dict (k UInt64, v UInt8) ENGINE = MergeTree ORDER BY k;
+
+DROP DICTIONARY IF EXISTS database_for_dict.dict1;
+
+CREATE DICTIONARY database_for_dict.dict1 (k UInt64 DEFAULT 0, v UInt8 DEFAULT 1) PRIMARY KEY k
+SOURCE(CLICKHOUSE(HOST 'localhost' PORT 9000 USER 'default' TABLE 'table_for_dict' PASSWORD '' DB 'database_for_dict'))
+LIFETIME(MIN 1 MAX 10)
+LAYOUT(FLAT());
+
+DETACH TABLE database_for_dict.dict1; -- { serverError 520 }
+
+DETACH DICTIONARY database_for_dict.dict1;
+
+ATTACH TABLE database_for_dict.dict1; -- { serverError 80 }
+
+ATTACH DICTIONARY database_for_dict.dict1;
+
+DROP DICTIONARY database_for_dict.dict1;
+
+DROP TABLE database_for_dict.table_for_dict;
+
+DROP DATABASE IF EXISTS database_for_dict;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Throw an informative error message when doing ATTACH/DETACH TABLE <DICTIONARY>. Before this PR, `detach table <dict>` works but leads to an ill-formed in-memory metadata.

Detailed description / Documentation draft:

None.