### PR TITLE
Minor change in query profiler

### DIFF
--- a/src/Common/QueryProfiler.cpp
+++ b/src/Common/QueryProfiler.cpp
@@ -176,7 +176,7 @@ template class QueryProfilerBase<QueryProfilerReal>;
 template class QueryProfilerBase<QueryProfilerCpu>;
 
 QueryProfilerReal::QueryProfilerReal(const UInt64 thread_id, const UInt32 period)
-    : QueryProfilerBase(thread_id, CLOCK_REALTIME, period, SIGUSR1)
+    : QueryProfilerBase(thread_id, CLOCK_MONOTONIC, period, SIGUSR1)
 {}
 
 void QueryProfilerReal::signalHandler(int sig, siginfo_t * info, void * context)


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


This is more correct (and probably has less overhead).

PS. I'm not sure, if it still distributes events across all threads...