### PR TITLE
Disable TraceCollector if trace_log is disabled

### DIFF
--- a/src/Common/TraceCollector.cpp
+++ b/src/Common/TraceCollector.cpp
@@ -11,6 +11,7 @@
 #include <Common/Exception.h>
 #include <Common/PipeFDs.h>
 #include <Common/StackTrace.h>
+#include <Common/setThreadName.h>
 #include <common/logger_useful.h>
 
 
@@ -115,6 +116,8 @@ void TraceCollector::stop()
 
 void TraceCollector::run()
 {
+    setThreadName("TraceCollector");
+
     ReadBufferFromFileDescriptor in(pipe.fds_rw[0]);
 
     while (true)

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -451,6 +451,8 @@ struct ContextShared
 
     void initializeTraceCollector(std::shared_ptr<TraceLog> trace_log)
     {
+        if (!trace_log)
+            return;
         if (hasTraceCollector())
             return;
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @den-crane 

P.S. Also set thread name for the TraceCollector, to make the check (is it active or not) easier, simply `grep -x TraceCollector /proc/$(pgrep clickhouse-serv)/task/*/comm` over `gdb`/`system.stack_trace`