### PR TITLE
Update build-osx.md

### DIFF
--- a/docs/zh/development/build-osx.md
+++ b/docs/zh/development/build-osx.md
@@ -43,7 +43,7 @@ $ cd ..
 
 为此，请创建以下文件：
 
-/图书馆/LaunchDaemons/限制.maxfilesplist:
+/资源库/LaunchDaemons/limit.maxfiles.plist:
 
 ``` xml
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Correct the filename and the path translated in Chinese for "limit.maxfiles.plist"

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Correct the filename and the path translated in Chinese in "How to Build ClickHouse on Mac OS X".


Detailed description / Documentation draft:
The filename "limit.maxfiles.plist" should not be translated, and the correct file path should be "资源库" instead of "图书馆"
