### PR TITLE
Backport #16865 to 20.3.

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionTimeSeriesGroupSum.h
+++ b/src/AggregateFunctions/AggregateFunctionTimeSeriesGroupSum.h
@@ -189,7 +189,10 @@ struct AggregateFunctionTimeSeriesGroupSumData
     {
         size_t size = result.size();
         writeVarUInt(size, buf);
-        buf.write(reinterpret_cast<const char *>(result.data()), sizeof(result[0]));
+        if (size > 0)
+        {
+            buf.write(reinterpret_cast<const char *>(result.data()), size * sizeof(result[0]));
+        }
     }
 
     void deserialize(ReadBuffer & buf)
@@ -197,7 +200,10 @@ struct AggregateFunctionTimeSeriesGroupSumData
         size_t size = 0;
         readVarUInt(size, buf);
         result.resize(size);
-        buf.read(reinterpret_cast<char *>(result.data()), size * sizeof(result[0]));
+        if (size > 0)
+        {
+            buf.read(reinterpret_cast<char *>(result.data()), size * sizeof(result[0]));
+        }
     }
 };
 template <bool rate>

--- a/tests/queries/0_stateless/01560_timeseriesgroupsum_segfault.reference
+++ b/tests/queries/0_stateless/01560_timeseriesgroupsum_segfault.reference
@@ -1,0 +1,3 @@
+[]
+1
+server is still alive

--- a/tests/queries/0_stateless/01560_timeseriesgroupsum_segfault.sql
+++ b/tests/queries/0_stateless/01560_timeseriesgroupsum_segfault.sql
@@ -1,0 +1,23 @@
+DROP TABLE IF EXISTS tsgs_local;
+DROP TABLE IF EXISTS tsgs;
+
+CREATE TABLE tsgs_local ENGINE = MergeTree ORDER BY tuple() AS
+SELECT
+    toUInt64(13820745146630357293) AS a,
+    toInt64(1604422500000000000) AS b,
+    toFloat64(0) AS c
+FROM numbers(100);
+
+-- the issue (https://github.com/ClickHouse/ClickHouse/issues/16862) happens during serialization of the state
+-- so happens only when Distributed tables are used or with -State modifier.
+
+CREATE TABLE tsgs AS tsgs_local ENGINE = Distributed(test_cluster_two_shards, currentDatabase(), tsgs_local);
+
+SELECT timeSeriesGroupSum(a, b, c) FROM tsgs;
+
+SELECT count() FROM ( SELECT timeSeriesGroupSumState(a, b, c) as x FROM tsgs_local) WHERE NOT ignore(*);
+
+SELECT 'server is still alive';
+
+DROP TABLE tsgs_local;
+DROP TABLE tsgs;


### PR DESCRIPTION
Test and fix for segfault in TimeSeriesGroupSum. Issue #16862.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:

Merge #16865 first... 