### PR TITLE
ensure user config dir exists

### DIFF
--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -40,6 +40,11 @@ CLICKHOUSE_USER="${CLICKHOUSE_USER:-default}"
 CLICKHOUSE_PASSWORD="${CLICKHOUSE_PASSWORD:-}"
 CLICKHOUSE_DB="${CLICKHOUSE_DB:-}"
 
+# ensure user config dir exists
+if [[ ! -e /etc/clickhouse-server/users.d ]]; then
+  mkdir /etc/clickhouse-server/users.d
+fi
+
 for dir in "$DATA_DIR" \
   "$ERROR_LOG_DIR" \
   "$LOG_DIR" \


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Detailed description / Documentation draft:
I found some simple issue while yandex/clickhouse-server image starting with `CLICKHOUSE_USER` env and fixed it out
```
/entrypoint.sh: create new user 'root' instead 'default'
/entrypoint.sh: line 70: /etc/clickhouse-server/users.d/default-user.xml: No such file or directory
```