### PR TITLE
Fixed bug in git-import tool

### DIFF
--- a/programs/git-import/git-import.cpp
+++ b/programs/git-import/git-import.cpp
@@ -680,7 +680,7 @@ void updateSnapshot(Snapshot & snapshot, const Commit & commit, CommitDiff & fil
     for (auto & elem : file_changes)
     {
         auto & file = elem.second.file_change;
-        if (file.path != file.old_path)
+        if (!file.old_path.empty() && file.path != file.old_path)
             snapshot[file.path] = snapshot[file.old_path];
     }
 


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Blame info was not calculated correctly in `clickhouse-git-import`.