### PR TITLE
Add client library for Swift: ClickHouseNIO and ClickHouseVapor

### DIFF
--- a/docs/en/interfaces/third-party/client-libraries.md
+++ b/docs/en/interfaces/third-party/client-libraries.md
@@ -26,6 +26,9 @@ toc_title: Client Libraries
     -   [go-clickhouse](https://github.com/roistat/go-clickhouse)
     -   [mailrugo-clickhouse](https://github.com/mailru/go-clickhouse)
     -   [golang-clickhouse](https://github.com/leprosus/golang-clickhouse)
+-   Swift
+    -   [ClickHouseNIO](https://github.com/patrick-zippenfenig/ClickHouseNIO)
+    -   [ClickHouseVapor ORM](https://github.com/patrick-zippenfenig/ClickHouseVapor)
 -   NodeJs
     -   [clickhouse (NodeJs)](https://github.com/TimonKK/clickhouse)
     -   [node-clickhouse](https://github.com/apla/node-clickhouse)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)

Hi,

I would like to add 2 Swift Client Libraries for ClickHouse. The underlying adapter is utilising Swift NIO, which is a well  established standard in the Swift ecosystem. Fully asynchronous IO and native data type conversion, make it easy to implement concurrent APIs.

The second ORM library on-top of this client, offers connection pooling and seamless integration into [Vapor](https://vapor.codes), the most popular server side framework for Swift.

Both libraries are a great opportunity for the Swift ecosystem to pick up more analytical workload using ClickHouse. I am happy to further advocate on the use and implementation for those libraries!

Best regards,
Patrick
