### PR TITLE
Fixed wrong result in big integers (128, 256 bit) when casting from double to int64_t.

### DIFF
--- a/base/common/wide_integer_impl.h
+++ b/base/common/wide_integer_impl.h
@@ -5,6 +5,9 @@
 /// (See at http://www.boost.org/LICENSE_1_0.txt)
 
 #include "throwError.h"
+#include <cfloat>
+#include <limits>
+#include <cassert>
 
 namespace wide
 {
@@ -192,7 +195,7 @@ struct integer<Bits, Signed>::_impl
     }
 
     template <typename T>
-    constexpr static auto to_Integral(T f) noexcept
+    __attribute__((no_sanitize("undefined"))) constexpr static auto to_Integral(T f) noexcept
     {
         if constexpr (std::is_same_v<T, __int128>)
             return f;
@@ -225,25 +228,54 @@ struct integer<Bits, Signed>::_impl
             self.items[i] = 0;
     }
 
-    constexpr static void wide_integer_from_bultin(integer<Bits, Signed> & self, double rhs) noexcept
-    {
-        if ((rhs > 0 && rhs < std::numeric_limits<uint64_t>::max()) || (rhs < 0 && rhs > std::numeric_limits<int64_t>::min()))
+    /**
+     * N.B. t is constructed from double, so max(t) = max(double) ~ 2^310
+     * the recursive call happens when t / 2^64 > 2^64, so there won't be more than 5 of them.
+     *
+     * t = a1 * max_int + b1,   a1 > max_int, b1 < max_int
+     * a1 = a2 * max_int + b2,  a2 > max_int, b2 < max_int
+     * a_(n - 1) = a_n * max_int + b2, a_n <= max_int <- base case.
+     */
+    template <class T>
+    constexpr static void set_multiplier(integer<Bits, Signed> & self, T t) noexcept {
+        constexpr uint64_t max_int = std::numeric_limits<uint64_t>::max();
+        const T alpha = t / max_int;
+
+        if (alpha <= max_int)
+            self = static_cast<uint64_t>(alpha);
+        else // max(double) / 2^64 will surely contain less than 52 precision bits, so speed up computations.
+            set_multiplier<double>(self, alpha);
+
+        self *= max_int;
+        self += static_cast<uint64_t>(t - alpha * max_int); // += b_i
+    }
+
+    constexpr static void wide_integer_from_bultin(integer<Bits, Signed>& self, double rhs) noexcept {
+        constexpr int64_t max_int = std::numeric_limits<int64_t>::max();
+        constexpr int64_t min_int = std::numeric_limits<int64_t>::min();
+
+        /// There are values in int64 that have more than 53 significant bits (in terms of double
+        /// representation). Such values, being promoted to double, are rounded up or down. If they are rounded up,
+        /// the result may not fit in 64 bits.
+        /// The example of such a number is 9.22337e+18.
+        /// As to_Integral does a static_cast to int64_t, it may result in UB.
+        /// The necessary check here is that long double has enough significant (mantissa) bits to store the
+        /// int64_t max value precisely.
+        static_assert(LDBL_MANT_DIG >= 64,
+            "On your system long double has less than 64 precision bits,"
+            "which may result in UB when initializing double from int64_t");
+
+        if ((rhs > 0 && rhs < max_int) || (rhs < 0 && rhs > min_int))
         {
-            self = to_Integral(rhs);
+            self = static_cast<int64_t>(rhs);
             return;
         }
 
-        long double r = rhs;
-        if (r < 0)
-            r = -r;
+        const long double rhs_long_double = (static_cast<long double>(rhs) < 0)
+            ? -static_cast<long double>(rhs)
+            : rhs;
 
-        size_t count = r / std::numeric_limits<uint64_t>::max();
-        self = count;
-        self *= std::numeric_limits<uint64_t>::max();
-        long double to_diff = count;
-        to_diff *= std::numeric_limits<uint64_t>::max();
-
-        self += to_Integral(r - to_diff);
+        set_multiplier(self, rhs_long_double);
 
         if (rhs < 0)
             self = -self;

--- a/src/Columns/ColumnDecimal.cpp
+++ b/src/Columns/ColumnDecimal.cpp
@@ -7,8 +7,10 @@
 #include <Core/BigInt.h>
 
 #include <common/unaligned.h>
-#include <common/sort.h>
 #include <ext/scope_guard.h>
+#if !defined(ARCADIA_BUILD)
+    #include <miniselect/floyd_rivest_select.h> // Y_IGNORE
+#endif
 
 
 #include <IO/WriteHelpers.h>
@@ -55,32 +57,16 @@ void ColumnDecimal<T>::compareColumn(const IColumn & rhs, size_t rhs_row_num,
 template <typename T>
 StringRef ColumnDecimal<T>::serializeValueIntoArena(size_t n, Arena & arena, char const *& begin) const
 {
-    if constexpr (is_POD)
-    {
-        auto * pos = arena.allocContinue(sizeof(T), begin);
-        memcpy(pos, &data[n], sizeof(T));
-        return StringRef(pos, sizeof(T));
-    }
-    else
-    {
-        char * pos = arena.allocContinue(BigInt<T>::size, begin);
-        return BigInt<Int256>::serialize(data[n], pos);
-    }
+    auto * pos = arena.allocContinue(sizeof(T), begin);
+    memcpy(pos, &data[n], sizeof(T));
+    return StringRef(pos, sizeof(T));
 }
 
 template <typename T>
 const char * ColumnDecimal<T>::deserializeAndInsertFromArena(const char * pos)
 {
-    if constexpr (is_POD)
-    {
-        data.push_back(unalignedLoad<T>(pos));
-        return pos + sizeof(T);
-    }
-    else
-    {
-        data.push_back(BigInt<Int256>::deserialize(pos));
-        return pos + BigInt<Int256>::size;
-    }
+    data.push_back(unalignedLoad<T>(pos));
+    return pos + sizeof(T);
 }
 
 template <typename T>
@@ -195,11 +181,21 @@ void ColumnDecimal<T>::updatePermutation(bool reverse, size_t limit, int, IColum
         /// Since then we are working inside the interval.
 
         if (reverse)
-            partial_sort(res.begin() + first, res.begin() + limit, res.begin() + last,
+#if !defined(ARCADIA_BUILD)
+            miniselect::floyd_rivest_partial_sort(res.begin() + first, res.begin() + limit, res.begin() + last,
                 [this](size_t a, size_t b) { return data[a] > data[b]; });
+#else
+            std::partial_sort(res.begin() + first, res.begin() + limit, res.begin() + last,
+                [this](size_t a, size_t b) { return data[a] > data[b]; });
+#endif
         else
-            partial_sort(res.begin() + first, res.begin() + limit, res.begin() + last,
+#if !defined(ARCADIA_BUILD)
+            miniselect::floyd_rivest_partial_sort(res.begin() + first, res.begin() + limit, res.begin() + last,
                 [this](size_t a, size_t b) { return data[a] < data[b]; });
+#else
+            std::partial_sort(res.begin() + first, res.begin() + limit, res.begin() + last,
+                [this](size_t a, size_t b) { return data[a] > data[b]; });
+#endif
         auto new_first = first;
         for (auto j = first + 1; j < limit; ++j)
         {
@@ -252,24 +248,13 @@ MutableColumnPtr ColumnDecimal<T>::cloneResized(size_t size) const
         new_col.data.resize(size);
 
         size_t count = std::min(this->size(), size);
-        if constexpr (is_POD)
-        {
-            memcpy(new_col.data.data(), data.data(), count * sizeof(data[0]));
 
-            if (size > count)
-            {
-                void * tail = &new_col.data[count];
-                memset(tail, 0, (size - count) * sizeof(T));
-            }
-        }
-        else
-        {
-            for (size_t i = 0; i < count; i++)
-                new_col.data[i] = data[i];
+        memcpy(new_col.data.data(), data.data(), count * sizeof(data[0]));
 
-            if (size > count)
-                for (size_t i = count; i < size; i++)
-                    new_col.data[i] = T{};
+        if (size > count)
+        {
+            void * tail = &new_col.data[count];
+            memset(tail, 0, (size - count) * sizeof(T));
         }
     }
 
@@ -279,16 +264,9 @@ MutableColumnPtr ColumnDecimal<T>::cloneResized(size_t size) const
 template <typename T>
 void ColumnDecimal<T>::insertData(const char * src, size_t /*length*/)
 {
-    if constexpr (is_POD)
-    {
-        T tmp;
-        memcpy(&tmp, src, sizeof(T));
-        data.emplace_back(tmp);
-    }
-    else
-    {
-        data.push_back(BigInt<Int256>::deserialize(src));
-    }
+    T tmp;
+    memcpy(&tmp, src, sizeof(T));
+    data.emplace_back(tmp);
 }
 
 template <typename T>
@@ -303,13 +281,8 @@ void ColumnDecimal<T>::insertRangeFrom(const IColumn & src, size_t start, size_t
 
     size_t old_size = data.size();
     data.resize(old_size + length);
-    if constexpr (is_POD)
-        memcpy(data.data() + old_size, &src_vec.data[start], length * sizeof(data[0]));
-    else
-    {
-        for (size_t i = 0; i < length; i++)
-            data[old_size + i] = src_vec.data[start + i];
-    }
+
+    memcpy(data.data() + old_size, &src_vec.data[start], length * sizeof(data[0]));
 }
 
 template <typename T>

--- a/src/Columns/ColumnDecimal.cpp
+++ b/src/Columns/ColumnDecimal.cpp
@@ -7,10 +7,8 @@
 #include <Core/BigInt.h>
 
 #include <common/unaligned.h>
+#include <common/sort.h>
 #include <ext/scope_guard.h>
-#if !defined(ARCADIA_BUILD)
-    #include <miniselect/floyd_rivest_select.h> // Y_IGNORE
-#endif
 
 
 #include <IO/WriteHelpers.h>
@@ -181,21 +179,11 @@ void ColumnDecimal<T>::updatePermutation(bool reverse, size_t limit, int, IColum
         /// Since then we are working inside the interval.
 
         if (reverse)
-#if !defined(ARCADIA_BUILD)
-            miniselect::floyd_rivest_partial_sort(res.begin() + first, res.begin() + limit, res.begin() + last,
+            partial_sort(res.begin() + first, res.begin() + limit, res.begin() + last,
                 [this](size_t a, size_t b) { return data[a] > data[b]; });
-#else
-            std::partial_sort(res.begin() + first, res.begin() + limit, res.begin() + last,
-                [this](size_t a, size_t b) { return data[a] > data[b]; });
-#endif
         else
-#if !defined(ARCADIA_BUILD)
-            miniselect::floyd_rivest_partial_sort(res.begin() + first, res.begin() + limit, res.begin() + last,
+            partial_sort(res.begin() + first, res.begin() + limit, res.begin() + last,
                 [this](size_t a, size_t b) { return data[a] < data[b]; });
-#else
-            std::partial_sort(res.begin() + first, res.begin() + limit, res.begin() + last,
-                [this](size_t a, size_t b) { return data[a] > data[b]; });
-#endif
         auto new_first = first;
         for (auto j = first + 1; j < limit; ++j)
         {

--- a/src/Columns/ColumnDecimal.h
+++ b/src/Columns/ColumnDecimal.h
@@ -82,7 +82,7 @@ public:
 
     bool isNumeric() const override { return false; }
     bool canBeInsideNullable() const override { return true; }
-    bool isFixedAndContiguous() const final { return true; }
+    bool isFixedAndContiguous() const override { return true; }
     size_t sizeOfValueIfFixed() const override { return sizeof(T); }
 
     size_t size() const override { return data.size(); }

--- a/src/Columns/ColumnDecimal.h
+++ b/src/Columns/ColumnDecimal.h
@@ -1,16 +1,14 @@
 #pragma once
 
-#include <cmath>
-
-#include <Common/typeid_cast.h>
-#include "Core/DecimalFunctions.h"
+#include <Columns/ColumnVectorHelper.h>
 #include <Columns/IColumn.h>
 #include <Columns/IColumnImpl.h>
-#include <Columns/ColumnVectorHelper.h>
 #include <Core/Field.h>
-#if !defined(ARCADIA_BUILD)
-    #include <miniselect/floyd_rivest_select.h> // Y_IGNORE
-#endif
+#include <Core/DecimalFunctions.h>
+#include <Common/typeid_cast.h>
+#include <common/sort.h>
+
+#include <cmath>
 
 
 namespace DB
@@ -191,17 +189,9 @@ protected:
             sort_end = res.begin() + limit;
 
         if (reverse)
-#if !defined(ARCADIA_BUILD)
-            miniselect::floyd_rivest_partial_sort(res.begin(), sort_end, res.end(), [this](size_t a, size_t b) { return data[a] > data[b]; });
-#else
-            std::partial_sort(res.begin(), sort_end, res.end(), [this](size_t a, size_t b) { return data[a] > data[b]; });
-#endif
+            partial_sort(res.begin(), sort_end, res.end(), [this](size_t a, size_t b) { return data[a] > data[b]; });
         else
-#if !defined(ARCADIA_BUILD)
-            miniselect::floyd_rivest_partial_sort(res.begin(), sort_end, res.end(), [this](size_t a, size_t b) { return data[a] < data[b]; });
-#else
-            std::partial_sort(res.begin(), sort_end, res.end(), [this](size_t a, size_t b) { return data[a] < data[b]; });
-#endif
+            partial_sort(res.begin(), sort_end, res.end(), [this](size_t a, size_t b) { return data[a] < data[b]; });
     }
 };
 

--- a/src/Columns/ColumnDecimal.h
+++ b/src/Columns/ColumnDecimal.h
@@ -1,23 +1,20 @@
 #pragma once
 
-#include <Columns/ColumnVectorHelper.h>
+#include <cmath>
+
+#include <Common/typeid_cast.h>
+#include "Core/DecimalFunctions.h"
 #include <Columns/IColumn.h>
 #include <Columns/IColumnImpl.h>
+#include <Columns/ColumnVectorHelper.h>
 #include <Core/Field.h>
-#include <Common/typeid_cast.h>
-#include <common/sort.h>
-
-#include <cmath>
+#if !defined(ARCADIA_BUILD)
+    #include <miniselect/floyd_rivest_select.h> // Y_IGNORE
+#endif
 
 
 namespace DB
 {
-
-namespace ErrorCodes
-{
-    extern const int NOT_IMPLEMENTED;
-}
-
 /// PaddedPODArray extended by Decimal scale
 template <typename T>
 class DecimalPaddedPODArray : public PaddedPODArray<T>
@@ -55,43 +52,6 @@ private:
     UInt32 scale;
 };
 
-/// std::vector extended by Decimal scale
-template <typename T>
-class DecimalVector : public std::vector<T>
-{
-public:
-    using Base = std::vector<T>;
-    using Base::operator[];
-
-    DecimalVector(size_t size, UInt32 scale_)
-    :   Base(size),
-        scale(scale_)
-    {}
-
-    DecimalVector(const DecimalVector & other)
-    :   Base(other.begin(), other.end()),
-        scale(other.scale)
-    {}
-
-    DecimalVector(DecimalVector && other)
-    {
-        this->swap(other);
-        std::swap(scale, other.scale);
-    }
-
-    DecimalVector & operator=(DecimalVector && other)
-    {
-        this->swap(other);
-        std::swap(scale, other.scale);
-        return *this;
-    }
-
-    UInt32 getScale() const { return scale; }
-
-private:
-    UInt32 scale;
-};
-
 /// A ColumnVector for Decimals
 template <typename T>
 class ColumnDecimal final : public COWHelper<ColumnVectorHelper, ColumnDecimal<T>>
@@ -105,10 +65,7 @@ private:
 public:
     using ValueType = T;
     using NativeT = typename T::NativeType;
-    static constexpr bool is_POD = !is_big_int_v<NativeT>;
-    using Container = std::conditional_t<is_POD,
-                                         DecimalPaddedPODArray<T>,
-                                         DecimalVector<T>>;
+    using Container = DecimalPaddedPODArray<T>;
 
 private:
     ColumnDecimal(const size_t n, UInt32 scale_)
@@ -127,23 +84,13 @@ public:
 
     bool isNumeric() const override { return false; }
     bool canBeInsideNullable() const override { return true; }
-    bool isFixedAndContiguous() const override { return true; }
+    bool isFixedAndContiguous() const final { return true; }
     size_t sizeOfValueIfFixed() const override { return sizeof(T); }
 
     size_t size() const override { return data.size(); }
     size_t byteSize() const override { return data.size() * sizeof(data[0]); }
-    size_t allocatedBytes() const override
-    {
-        if constexpr (is_POD)
-            return data.allocated_bytes();
-        else
-            return data.capacity() * sizeof(data[0]);
-    }
-    void protect() override
-    {
-        if constexpr (is_POD)
-            data.protect();
-    }
+    size_t allocatedBytes() const override { return data.allocated_bytes(); }
+    void protect() override { data.protect(); }
     void reserve(size_t n) override { data.reserve(n); }
 
     void insertFrom(const IColumn & src, size_t n) override { data.push_back(static_cast<const Self &>(src).getData()[n]); }
@@ -151,37 +98,27 @@ public:
     void insertDefault() override { data.push_back(T()); }
     virtual void insertManyDefaults(size_t length) override
     {
-        if constexpr (is_POD)
-            data.resize_fill(data.size() + length);
-        else
-            data.resize(data.size() + length);
+        data.resize_fill(data.size() + length);
     }
     void insert(const Field & x) override { data.push_back(DB::get<NearestFieldType<T>>(x)); }
     void insertRangeFrom(const IColumn & src, size_t start, size_t length) override;
 
     void popBack(size_t n) override
     {
-        if constexpr (is_POD)
-            data.resize_assume_reserved(data.size() - n);
-        else
-            data.resize(data.size() - n);
+        data.resize_assume_reserved(data.size() - n);
     }
 
     StringRef getRawData() const override
     {
-        if constexpr (is_POD)
-            return StringRef(reinterpret_cast<const char*>(data.data()), byteSize());
-        else
-            throw Exception("getRawData() is not implemented for big integers", ErrorCodes::NOT_IMPLEMENTED);
+        return StringRef(reinterpret_cast<const char*>(data.data()), byteSize());
     }
 
     StringRef getDataAt(size_t n) const override
     {
-        if constexpr (is_POD)
-            return StringRef(reinterpret_cast<const char *>(&data[n]), sizeof(data[n]));
-        else
-            throw Exception("getDataAt() is not implemented for big integers", ErrorCodes::NOT_IMPLEMENTED);
+        return StringRef(reinterpret_cast<const char *>(&data[n]), sizeof(data[n]));
     }
+
+    Float64 getFloat64(size_t n) const final { return DecimalUtils::convertTo<Float64>(data[n], scale); }
 
     StringRef serializeValueIntoArena(size_t n, Arena & arena, char const *& begin) const override;
     const char * deserializeAndInsertFromArena(const char * pos) override;
@@ -254,9 +191,17 @@ protected:
             sort_end = res.begin() + limit;
 
         if (reverse)
-            partial_sort(res.begin(), sort_end, res.end(), [this](size_t a, size_t b) { return data[a] > data[b]; });
+#if !defined(ARCADIA_BUILD)
+            miniselect::floyd_rivest_partial_sort(res.begin(), sort_end, res.end(), [this](size_t a, size_t b) { return data[a] > data[b]; });
+#else
+            std::partial_sort(res.begin(), sort_end, res.end(), [this](size_t a, size_t b) { return data[a] > data[b]; });
+#endif
         else
-            partial_sort(res.begin(), sort_end, res.end(), [this](size_t a, size_t b) { return data[a] < data[b]; });
+#if !defined(ARCADIA_BUILD)
+            miniselect::floyd_rivest_partial_sort(res.begin(), sort_end, res.end(), [this](size_t a, size_t b) { return data[a] < data[b]; });
+#else
+            std::partial_sort(res.begin(), sort_end, res.end(), [this](size_t a, size_t b) { return data[a] < data[b]; });
+#endif
     }
 };
 

--- a/src/Core/DecimalComparison.h
+++ b/src/Core/DecimalComparison.h
@@ -57,6 +57,7 @@ public:
     using Op = Operation<CompareInt, CompareInt>;
     using ColVecA = std::conditional_t<IsDecimalNumber<A>, ColumnDecimal<A>, ColumnVector<A>>;
     using ColVecB = std::conditional_t<IsDecimalNumber<B>, ColumnDecimal<B>, ColumnVector<B>>;
+
     using ArrayA = typename ColVecA::Container;
     using ArrayB = typename ColVecB::Container;
 

--- a/src/Core/Types.h
+++ b/src/Core/Types.h
@@ -145,7 +145,7 @@ struct Decimal
     operator T () const { return value; }
 
     template <typename U>
-    U convertTo()
+    U convertTo() const
     {
         /// no IsDecimalNumber defined yet
         if constexpr (std::is_same_v<U, Decimal<Int32>> ||

--- a/src/DataTypes/IDataType.h
+++ b/src/DataTypes/IDataType.h
@@ -466,75 +466,66 @@ struct WhichDataType
 {
     TypeIndex idx;
 
-    WhichDataType(TypeIndex idx_ = TypeIndex::Nothing)
-        : idx(idx_)
-    {}
+    constexpr WhichDataType(TypeIndex idx_ = TypeIndex::Nothing) : idx(idx_) {}
+    constexpr WhichDataType(const IDataType & data_type) : idx(data_type.getTypeId()) {}
+    constexpr WhichDataType(const IDataType * data_type) : idx(data_type->getTypeId()) {}
 
-    WhichDataType(const IDataType & data_type)
-        : idx(data_type.getTypeId())
-    {}
+    // shared ptr -> is non-constexpr in gcc
+    WhichDataType(const DataTypePtr & data_type) : idx(data_type->getTypeId()) {}
 
-    WhichDataType(const IDataType * data_type)
-        : idx(data_type->getTypeId())
-    {}
+    constexpr bool isUInt8() const { return idx == TypeIndex::UInt8; }
+    constexpr bool isUInt16() const { return idx == TypeIndex::UInt16; }
+    constexpr bool isUInt32() const { return idx == TypeIndex::UInt32; }
+    constexpr bool isUInt64() const { return idx == TypeIndex::UInt64; }
+    constexpr bool isUInt128() const { return idx == TypeIndex::UInt128; }
+    constexpr bool isUInt256() const { return idx == TypeIndex::UInt256; }
+    constexpr bool isUInt() const { return isUInt8() || isUInt16() || isUInt32() || isUInt64() || isUInt128() || isUInt256(); }
+    constexpr bool isNativeUInt() const { return isUInt8() || isUInt16() || isUInt32() || isUInt64(); }
 
-    WhichDataType(const DataTypePtr & data_type)
-        : idx(data_type->getTypeId())
-    {}
+    constexpr bool isInt8() const { return idx == TypeIndex::Int8; }
+    constexpr bool isInt16() const { return idx == TypeIndex::Int16; }
+    constexpr bool isInt32() const { return idx == TypeIndex::Int32; }
+    constexpr bool isInt64() const { return idx == TypeIndex::Int64; }
+    constexpr bool isInt128() const { return idx == TypeIndex::Int128; }
+    constexpr bool isInt256() const { return idx == TypeIndex::Int256; }
+    constexpr bool isInt() const { return isInt8() || isInt16() || isInt32() || isInt64() || isInt128() || isInt256(); }
+    constexpr bool isNativeInt() const { return isInt8() || isInt16() || isInt32() || isInt64(); }
 
-    bool isUInt8() const { return idx == TypeIndex::UInt8; }
-    bool isUInt16() const { return idx == TypeIndex::UInt16; }
-    bool isUInt32() const { return idx == TypeIndex::UInt32; }
-    bool isUInt64() const { return idx == TypeIndex::UInt64; }
-    bool isUInt128() const { return idx == TypeIndex::UInt128; }
-    bool isUInt256() const { return idx == TypeIndex::UInt256; }
-    bool isUInt() const { return isUInt8() || isUInt16() || isUInt32() || isUInt64() || isUInt128() || isUInt256(); }
-    bool isNativeUInt() const { return isUInt8() || isUInt16() || isUInt32() || isUInt64(); }
+    constexpr bool isDecimal32() const { return idx == TypeIndex::Decimal32; }
+    constexpr bool isDecimal64() const { return idx == TypeIndex::Decimal64; }
+    constexpr bool isDecimal128() const { return idx == TypeIndex::Decimal128; }
+    constexpr bool isDecimal256() const { return idx == TypeIndex::Decimal256; }
+    constexpr bool isDecimal() const { return isDecimal32() || isDecimal64() || isDecimal128() || isDecimal256(); }
 
-    bool isInt8() const { return idx == TypeIndex::Int8; }
-    bool isInt16() const { return idx == TypeIndex::Int16; }
-    bool isInt32() const { return idx == TypeIndex::Int32; }
-    bool isInt64() const { return idx == TypeIndex::Int64; }
-    bool isInt128() const { return idx == TypeIndex::Int128; }
-    bool isInt256() const { return idx == TypeIndex::Int256; }
-    bool isInt() const { return isInt8() || isInt16() || isInt32() || isInt64() || isInt128() || isInt256(); }
-    bool isNativeInt() const { return isInt8() || isInt16() || isInt32() || isInt64(); }
+    constexpr bool isFloat32() const { return idx == TypeIndex::Float32; }
+    constexpr bool isFloat64() const { return idx == TypeIndex::Float64; }
+    constexpr bool isFloat() const { return isFloat32() || isFloat64(); }
 
-    bool isDecimal32() const { return idx == TypeIndex::Decimal32; }
-    bool isDecimal64() const { return idx == TypeIndex::Decimal64; }
-    bool isDecimal128() const { return idx == TypeIndex::Decimal128; }
-    bool isDecimal256() const { return idx == TypeIndex::Decimal256; }
-    bool isDecimal() const { return isDecimal32() || isDecimal64() || isDecimal128() || isDecimal256(); }
+    constexpr bool isEnum8() const { return idx == TypeIndex::Enum8; }
+    constexpr bool isEnum16() const { return idx == TypeIndex::Enum16; }
+    constexpr bool isEnum() const { return isEnum8() || isEnum16(); }
 
-    bool isFloat32() const { return idx == TypeIndex::Float32; }
-    bool isFloat64() const { return idx == TypeIndex::Float64; }
-    bool isFloat() const { return isFloat32() || isFloat64(); }
+    constexpr bool isDate() const { return idx == TypeIndex::Date; }
+    constexpr bool isDateTime() const { return idx == TypeIndex::DateTime; }
+    constexpr bool isDateTime64() const { return idx == TypeIndex::DateTime64; }
+    constexpr bool isDateOrDateTime() const { return isDate() || isDateTime() || isDateTime64(); }
 
-    bool isEnum8() const { return idx == TypeIndex::Enum8; }
-    bool isEnum16() const { return idx == TypeIndex::Enum16; }
-    bool isEnum() const { return isEnum8() || isEnum16(); }
+    constexpr bool isString() const { return idx == TypeIndex::String; }
+    constexpr bool isFixedString() const { return idx == TypeIndex::FixedString; }
+    constexpr bool isStringOrFixedString() const { return isString() || isFixedString(); }
 
-    bool isDate() const { return idx == TypeIndex::Date; }
-    bool isDateTime() const { return idx == TypeIndex::DateTime; }
-    bool isDateTime64() const { return idx == TypeIndex::DateTime64; }
-    bool isDateOrDateTime() const { return isDate() || isDateTime() || isDateTime64(); }
+    constexpr bool isUUID() const { return idx == TypeIndex::UUID; }
+    constexpr bool isArray() const { return idx == TypeIndex::Array; }
+    constexpr bool isTuple() const { return idx == TypeIndex::Tuple; }
+    constexpr bool isSet() const { return idx == TypeIndex::Set; }
+    constexpr bool isInterval() const { return idx == TypeIndex::Interval; }
 
-    bool isString() const { return idx == TypeIndex::String; }
-    bool isFixedString() const { return idx == TypeIndex::FixedString; }
-    bool isStringOrFixedString() const { return isString() || isFixedString(); }
+    constexpr bool isNothing() const { return idx == TypeIndex::Nothing; }
+    constexpr bool isNullable() const { return idx == TypeIndex::Nullable; }
+    constexpr bool isFunction() const { return idx == TypeIndex::Function; }
+    constexpr bool isAggregateFunction() const { return idx == TypeIndex::AggregateFunction; }
 
-    bool isUUID() const { return idx == TypeIndex::UUID; }
-    bool isArray() const { return idx == TypeIndex::Array; }
-    bool isTuple() const { return idx == TypeIndex::Tuple; }
-    bool isSet() const { return idx == TypeIndex::Set; }
-    bool isInterval() const { return idx == TypeIndex::Interval; }
-
-    bool isNothing() const { return idx == TypeIndex::Nothing; }
-    bool isNullable() const { return idx == TypeIndex::Nullable; }
-    bool isFunction() const { return idx == TypeIndex::Function; }
-    bool isAggregateFunction() const { return idx == TypeIndex::AggregateFunction; }
-
-    bool IsBigIntOrDeimal() const { return isInt128() || isInt256() || isUInt256() || isDecimal256(); }
+    constexpr bool IsBigIntOrDeimal() const { return isInt128() || isInt256() || isUInt256() || isDecimal256(); }
 };
 
 /// IDataType helpers (alternative for IDataType virtual methods with single point of truth)


### PR DESCRIPTION
Corresponding upstream fix: https://github.com/cerevra/int/pull/24

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed wrong result in big integers (128, 256 bit) when casting from double.


Detailed description:
Fixed the UB in the wide_int library  when casting from double to int64_t.
Replaced ColumnDecimal is_POD as it's useless now.
