### PR TITLE
Fix performance with Merge table over huge number of MergeTree tables

### DIFF
--- a/src/Interpreters/ExpressionAnalyzer.cpp
+++ b/src/Interpreters/ExpressionAnalyzer.cpp
@@ -139,11 +139,6 @@ ExpressionAnalyzer::ExpressionAnalyzer(
     analyzeAggregation();
 }
 
-bool ExpressionAnalyzer::isRemoteStorage() const
-{
-    return storage() && storage()->isRemote();
-}
-
 
 void ExpressionAnalyzer::analyzeAggregation()
 {

--- a/src/Interpreters/ExpressionAnalyzer.h
+++ b/src/Interpreters/ExpressionAnalyzer.h
@@ -163,7 +163,7 @@ protected:
 
     const ASTSelectQuery * getSelectQuery() const;
 
-    bool isRemoteStorage() const;
+    bool isRemoteStorage() const { return syntax->is_remote_storage; }
 };
 
 class SelectQueryExpressionAnalyzer;

--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -387,6 +387,19 @@ std::vector<const ASTFunction *> getAggregates(ASTPtr & query, const ASTSelectQu
 
 }
 
+TreeRewriterResult::TreeRewriterResult(
+    const NamesAndTypesList & source_columns_,
+    ConstStoragePtr storage_,
+    const StorageMetadataPtr & metadata_snapshot_,
+    bool add_special)
+    : storage(storage_)
+    , metadata_snapshot(metadata_snapshot_)
+    , source_columns(source_columns_)
+{
+    collectSourceColumns(add_special);
+    is_remote_storage = storage && storage->isRemote();
+}
+
 /// Add columns from storage to source_columns list. Deduplicate resulted list.
 /// Special columns are non physical columns, for example ALIAS
 void TreeRewriterResult::collectSourceColumns(bool add_special)

--- a/src/Interpreters/TreeRewriter.h
+++ b/src/Interpreters/TreeRewriter.h
@@ -53,6 +53,9 @@ struct TreeRewriterResult
 
     bool optimize_trivial_count = false;
 
+    /// Cache isRemote() call for storage, because it may be too heavy.
+    bool is_remote_storage = false;
+
     /// Results of scalar sub queries
     Scalars scalars;
 
@@ -60,13 +63,7 @@ struct TreeRewriterResult
         const NamesAndTypesList & source_columns_,
         ConstStoragePtr storage_ = {},
         const StorageMetadataPtr & metadata_snapshot_ = {},
-        bool add_special = true)
-        : storage(storage_)
-        , metadata_snapshot(metadata_snapshot_)
-        , source_columns(source_columns_)
-    {
-        collectSourceColumns(add_special);
-    }
+        bool add_special = true);
 
     void collectSourceColumns(bool add_special);
     void collectUsedColumns(const ASTPtr & query, bool is_select);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix performance of reading from `Merge` tables over huge number of `MergeTree` tables. Fixes #7748.

Detailed description / Documentation draft:
When `KeyCondition` is created, there is an invocation of `ExpressionAnalyzer::getConstActions`, which calls `IStorage::isRemote()`. But, when we read from `Merge` table, object of storage is `StorageMerge` in `query_info.syntax_analyzer_result` and `isRemote` iterates over all matched tables. So, there were O(n^2) iterations over tables, which is quite heavy operation.