### PR TITLE
Fix Distributed queries finishing (avoid connection resets)

### DIFF
--- a/docker/test/fasttest/run.sh
+++ b/docker/test/fasttest/run.sh
@@ -287,6 +287,8 @@ TESTS_TO_SKIP=(
     01322_ttest_scipy
 
     01545_system_errors
+    # Checks system.errors
+    01563_distributed_query_finish
 )
 
 time clickhouse-test -j 8 --order=random --no-long --testname --shard --zookeeper --skip "${TESTS_TO_SKIP[@]}" 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee "$FASTTEST_OUTPUT/test_log.txt"

--- a/src/Processors/Sources/RemoteSource.cpp
+++ b/src/Processors/Sources/RemoteSource.cpp
@@ -21,6 +21,10 @@ RemoteSource::~RemoteSource() = default;
 
 Chunk RemoteSource::generate()
 {
+    /// onCancel() will do the cancel if the query was sent.
+    if (was_query_canceled)
+        return {};
+
     if (!was_query_sent)
     {
         /// Progress method will be called on Progress packet.
@@ -62,6 +66,7 @@ Chunk RemoteSource::generate()
 
 void RemoteSource::onCancel()
 {
+    was_query_canceled = true;
     query_executor->cancel();
 }
 

--- a/src/Processors/Sources/RemoteSource.cpp
+++ b/src/Processors/Sources/RemoteSource.cpp
@@ -19,6 +19,16 @@ RemoteSource::RemoteSource(RemoteQueryExecutorPtr executor, bool add_aggregation
 
 RemoteSource::~RemoteSource() = default;
 
+ISource::Status RemoteSource::prepare()
+{
+    Status status = SourceWithProgress::prepare();
+    /// To avoid resetting the connection (because of "unfinished" query) in the
+    /// RemoteQueryExecutor it should be finished explicitly.
+    if (status == Status::Finished)
+        query_executor->finish();
+    return status;
+}
+
 Chunk RemoteSource::generate()
 {
     /// onCancel() will do the cancel if the query was sent.

--- a/src/Processors/Sources/RemoteSource.h
+++ b/src/Processors/Sources/RemoteSource.h
@@ -36,6 +36,7 @@ protected:
     void onCancel() override;
 
 private:
+    bool was_query_canceled = false;
     bool was_query_sent = false;
     bool add_aggregation_info = false;
     RemoteQueryExecutorPtr query_executor;

--- a/src/Processors/Sources/RemoteSource.h
+++ b/src/Processors/Sources/RemoteSource.h
@@ -20,6 +20,7 @@ public:
     RemoteSource(RemoteQueryExecutorPtr executor, bool add_aggregation_info_);
     ~RemoteSource() override;
 
+    Status prepare() override;
     String getName() const override { return "Remote"; }
 
     void setRowsBeforeLimitCounter(RowsBeforeLimitCounterPtr counter) { rows_before_limit.swap(counter); }

--- a/src/Processors/Sources/RemoteSource.h
+++ b/src/Processors/Sources/RemoteSource.h
@@ -3,6 +3,7 @@
 #include <Processors/Sources/SourceWithProgress.h>
 #include <Processors/RowsBeforeLimitCounter.h>
 #include <Processors/Pipe.h>
+#include <atomic>
 
 namespace DB
 {
@@ -37,7 +38,7 @@ protected:
     void onCancel() override;
 
 private:
-    bool was_query_canceled = false;
+    std::atomic<bool> was_query_canceled = false;
     bool was_query_sent = false;
     bool add_aggregation_info = false;
     RemoteQueryExecutorPtr query_executor;

--- a/tests/queries/0_stateless/01563_distributed_query_finish.reference
+++ b/tests/queries/0_stateless/01563_distributed_query_finish.reference
@@ -1,0 +1,2 @@
+1,0
+NETWORK_ERROR=0

--- a/tests/queries/0_stateless/01563_distributed_query_finish.sh
+++ b/tests/queries/0_stateless/01563_distributed_query_finish.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# query finish should not produce any NETWORK_ERROR
+# (NETWORK_ERROR will be in case of connection reset)
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -nm <<EOL
+drop table if exists dist_01247;
+drop table if exists data_01247;
+
+create table data_01247 engine=Memory() as select * from numbers(2);
+create table dist_01247 as data_01247 engine=Distributed(test_cluster_two_shards, currentDatabase(), data_01247, number);
+
+select * from dist_01247 format Null;
+EOL
+
+network_errors_before=$($CLICKHOUSE_CLIENT -q "SELECT value FROM system.errors WHERE name = 'NETWORK_ERROR'")
+
+opts=(
+    "--max_distributed_connections=1"
+    "--optimize_skip_unused_shards=1"
+    "--optimize_distributed_group_by_sharding_key=1"
+    "--prefer_localhost_replica=0"
+)
+$CLICKHOUSE_CLIENT "${opts[@]}" --format CSV -nm <<EOL
+select count(), * from dist_01247 group by number limit 1;
+EOL
+
+# expect zero new network errors
+network_errors_after=$($CLICKHOUSE_CLIENT -q "SELECT value FROM system.errors WHERE name = 'NETWORK_ERROR'")
+echo NETWORK_ERROR=$(( network_errors_after-network_errors_before ))


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Avoid unnecessary network errors for remote queries which may be cancelled while execution, like queries with `LIMIT`.

- Do not try to send query if it was already canceled
- Explicitly finish the remote query (in case of not all data was read, i.e. in case of LIMIT) to avoid connection resets
- Add a test that checks lack of NETWORK_ERROR in this case (since you will not get error for the query, because the state will be reseted too late, and it you can see it only in server logs)

Related failures of the 01247_optimize_distributed_group_by_sharding_key should be fixed by this patches:
- https://clickhouse-test-reports.s3.yandex.net/16996/0dfc18249d08ddea5bb1c9dd214b7101efdd181f/functional_stateless_tests_flaky_check_(address).html#fail1
- https://clickhouse-test-reports.s3.yandex.net/16993/d1f52dc72d417580c4088cf3880593176416bea2/functional_stateless_tests_(ubsan).html#fail1
- https://clickhouse-test-reports.s3.yandex.net/16853/185f886812639ea70f15529b096aafdc92e3efad/functional_stateless_tests_(thread).html#fail1