### PR TITLE
Fix arrayAUC function header in documentation

### DIFF
--- a/docs/ru/sql-reference/functions/array-functions.md
+++ b/docs/ru/sql-reference/functions/array-functions.md
@@ -1157,6 +1157,7 @@ SELECT arrayCumSum([1, 1, 1, 1]) AS res
 ┌─res──────────┐
 │ [1, 2, 3, 4] │
 └──────────────┘
+```
 
 ## arrayAUC {#arrayauc}
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)

Detailed description / Documentation draft:

Fixed a header in block about `arrayAUC` function in documentation.
