### PR TITLE
Add missing <unique_ptr> for RadixSort.h

### DIFF
--- a/src/Common/RadixSort.h
+++ b/src/Common/RadixSort.h
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <cassert>
 #include <type_traits>
+#include <memory>
 
 #include <ext/bit_cast.h>
 #include <common/extended_types.h>


### PR DESCRIPTION
Fails compiling quantile-t-digest.cpp test on:
- clang 11
- libstdc++

Changelog category (leave one):
- Not for changelog (changelog entry is not required)