### PR TITLE
Support multiple ZooKeeper clusters

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/replication.md
+++ b/docs/en/engines/table-engines/mergetree-family/replication.md
@@ -53,6 +53,42 @@ Example of setting the addresses of the ZooKeeper cluster:
 </zookeeper>
 ```
 
+ClickHouse also supports to store replicas meta information in the auxiliary ZooKeeper cluster by providing ZooKeeper cluster name and path as engine arguments.
+In other word, it supports to store the metadata of differnt tables in different ZooKeeper clusters.
+
+Example of setting the addresses of the auxiliary ZooKeeper cluster:
+
+``` xml
+<auxiliary_zookeepers>
+    <zookeeper2>
+        <node index="1">
+            <host>example_2_1</host>
+            <port>2181</port>
+        </node>
+        <node index="2">
+            <host>example_2_2</host>
+            <port>2181</port>
+        </node>
+        <node index="3">
+            <host>example_2_3</host>
+            <port>2181</port>
+        </node>
+    </zookeeper2>
+    <zookeeper3>
+        <node index="1">
+            <host>example_3_1</host>
+            <port>2181</port>
+        </node>
+    </zookeeper3>
+</auxiliary_zookeepers>
+```
+
+To store table datameta in a auxiliary ZooKeeper cluster instead of default ZooKeeper cluster, we can use the SQL to create table with
+ReplicatedMergeTree engine as follow:
+
+```
+CREATE TABLE table_name ( ... ) ENGINE = ReplicatedMergeTree('zookeeper_name_configurated_in_auxiliary_zookeepers:path', 'replica_name') ...
+```
 You can specify any existing ZooKeeper cluster and the system will use a directory on it for its own data (the directory is specified when creating a replicatable table).
 
 If ZooKeeper isn’t set in the config file, you can’t create replicated tables, and any existing replicated tables will be read-only.

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1574,6 +1574,10 @@ bool Context::hasZooKeeper() const
     return getConfigRef().has("zookeeper");
 }
 
+bool Context::hasAuxiliaryZooKeeper(const String & name) const
+{
+    return getConfigRef().has("auxiliary_zookeepers." + name);
+}
 
 void Context::setInterserverIOAddress(const String & host, UInt16 port)
 {

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -492,6 +492,8 @@ public:
     void reloadAuxiliaryZooKeepersConfigIfChanged(const ConfigurationPtr & config);
     /// Has ready or expired ZooKeeper
     bool hasZooKeeper() const;
+    /// Has ready or expired auxiliary ZooKeeper
+    bool hasAuxiliaryZooKeeper(const String & name) const;
     /// Reset current zookeeper session. Do not create a new one.
     void resetZooKeeper() const;
     // Reload Zookeeper

--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -83,7 +83,7 @@ void ReplicatedMergeTreeRestartingThread::run()
             {
                 try
                 {
-                    storage.setZooKeeper(storage.global_context.getZooKeeper());
+                    storage.setZooKeeper();
                 }
                 catch (const Coordination::Exception &)
                 {

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -184,10 +184,10 @@ static String extractZooKeeperName(const String & path)
     auto pos = path.find(':');
     if (pos != String::npos)
     {
-        auto zookeeper_name_ = path.substr(0, pos);
-        if (zookeeper_name_.empty())
+        auto zookeeper_name = path.substr(0, pos);
+        if (zookeeper_name.empty())
             throw Exception("Zookeeper path should start with '/' or '<auxiliary_zookeeper_name>:/'", ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
-        return zookeeper_name_; 
+        return zookeeper_name;
     }
     static constexpr auto default_zookeeper_name = "default";
     return default_zookeeper_name;
@@ -228,8 +228,8 @@ StorageReplicatedMergeTree::StorageReplicatedMergeTree(
                     true,                   /// require_part_metadata
                     attach,
                     [this] (const std::string & name) { enqueuePartForCheck(name); })
-    , zookeeper_name(extractZooKeeperName(zookeeper_path_)) 
-    , zookeeper_path(extractZooKeeperPath(zookeeper_path_)) 
+    , zookeeper_name(extractZooKeeperName(zookeeper_path_))
+    , zookeeper_path(extractZooKeeperPath(zookeeper_path_))
     , replica_name(replica_name_)
     , replica_path(zookeeper_path + "/replicas/" + replica_name_)
     , reader(*this)

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -176,7 +176,7 @@ static std::string normalizeZooKeeperPath(std::string zookeeper_path)
     return zookeeper_path;
 }
 
-void StorageReplicatedMergeTree::extractZooKeeperNameAndPath(const String & path, String & zookeeper_name_, String & zookeeper_path_) const
+void StorageReplicatedMergeTree::extractZooKeeperNameAndPath(const String & path, String & zookeeper_name_, String & zookeeper_path_)
 {
     if (path.empty())
         throw Exception("ZooKeeper path should not be empty", ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -238,6 +238,7 @@ private:
     zkutil::ZooKeeperPtr tryGetZooKeeper() const;
     zkutil::ZooKeeperPtr getZooKeeper() const;
     void setZooKeeper();
+    void extractZooKeeperNameAndPath(const String & path, String & zookeeper_name_, String & zookeeper_path_) const;
 
     /// If true, the table is offline and can not be written to it.
     std::atomic_bool is_readonly {false};

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -238,7 +238,7 @@ private:
     zkutil::ZooKeeperPtr tryGetZooKeeper() const;
     zkutil::ZooKeeperPtr getZooKeeper() const;
     void setZooKeeper();
-    void extractZooKeeperNameAndPath(const String & path, String & zookeeper_name_, String & zookeeper_path_) const;
+    static void extractZooKeeperNameAndPath(const String & path, String & zookeeper_name_, String & zookeeper_path_);
 
     /// If true, the table is offline and can not be written to it.
     std::atomic_bool is_readonly {false};

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -237,13 +237,15 @@ private:
 
     zkutil::ZooKeeperPtr tryGetZooKeeper() const;
     zkutil::ZooKeeperPtr getZooKeeper() const;
-    void setZooKeeper(zkutil::ZooKeeperPtr zookeeper);
+    void setZooKeeper();
 
     /// If true, the table is offline and can not be written to it.
     std::atomic_bool is_readonly {false};
     /// If false - ZooKeeper is available, but there is no table metadata. It's safe to drop table in this case.
     bool has_metadata_in_zookeeper = true;
 
+    static constexpr auto default_zookeeper_name = "default";
+    String zookeeper_name;
     String zookeeper_path;
     String replica_name;
     String replica_path;

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -238,7 +238,6 @@ private:
     zkutil::ZooKeeperPtr tryGetZooKeeper() const;
     zkutil::ZooKeeperPtr getZooKeeper() const;
     void setZooKeeper();
-    static void extractZooKeeperNameAndPath(const String & path, String & zookeeper_name_, String & zookeeper_path_);
 
     /// If true, the table is offline and can not be written to it.
     std::atomic_bool is_readonly {false};

--- a/tests/integration/test_replicated_merge_tree_with_auxiliary_zookeepers/configs/config.xml
+++ b/tests/integration/test_replicated_merge_tree_with_auxiliary_zookeepers/configs/config.xml
@@ -1,0 +1,42 @@
+<yandex>
+    <zookeeper>
+        <node index="1">
+            <host>zoo1</host>
+            <port>2181</port>
+        </node>
+        <node index="2">
+            <host>zoo2</host>
+            <port>2181</port>
+        </node>
+        <node index="3">
+            <host>zoo3</host>
+            <port>2181</port>
+        </node>
+    </zookeeper>
+    <auxiliary_zookeepers>
+        <zookeeper2>
+            <node index="1">
+                <host>zoo1</host>
+                <port>2181</port>
+            </node>
+            <node index="2">
+                <host>zoo2</host>
+                <port>2181</port>
+            </node>
+        </zookeeper2>
+    </auxiliary_zookeepers>
+    <remote_servers>
+        <test_cluster>
+            <shard>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster>
+    </remote_servers>
+</yandex>

--- a/tests/integration/test_replicated_merge_tree_with_auxiliary_zookeepers/configs/remote_servers.xml
+++ b/tests/integration/test_replicated_merge_tree_with_auxiliary_zookeepers/configs/remote_servers.xml
@@ -1,0 +1,16 @@
+<yandex>
+    <remote_servers>
+        <test_cluster>
+            <shard>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster>
+    </remote_servers>
+</yandex>

--- a/tests/integration/test_replicated_merge_tree_with_auxiliary_zookeepers/configs/zookeeper_config.xml
+++ b/tests/integration/test_replicated_merge_tree_with_auxiliary_zookeepers/configs/zookeeper_config.xml
@@ -25,18 +25,4 @@
             </node>
         </zookeeper2>
     </auxiliary_zookeepers>
-    <remote_servers>
-        <test_cluster>
-            <shard>
-                <replica>
-                    <host>node1</host>
-                    <port>9000</port>
-                </replica>
-                <replica>
-                    <host>node2</host>
-                    <port>9000</port>
-                </replica>
-            </shard>
-        </test_cluster>
-    </remote_servers>
 </yandex>

--- a/tests/integration/test_replicated_merge_tree_with_auxiliary_zookeepers/test.py
+++ b/tests/integration/test_replicated_merge_tree_with_auxiliary_zookeepers/test.py
@@ -1,0 +1,68 @@
+import time
+
+import helpers.client as client
+import pytest
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import TSV
+
+cluster = ClickHouseCluster(__file__)
+cluster = ClickHouseCluster(__file__)
+node1 = cluster.add_instance("node1", main_configs=["configs/config.xml"], with_zookeeper=True)
+node2 = cluster.add_instance("node2", main_configs=["configs/config.xml"], with_zookeeper=True)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+
+        yield cluster
+
+    except Exception as ex:
+        print(ex)
+
+    finally:
+        cluster.shutdown()
+
+
+def drop_table(nodes, table_name):
+    for node in nodes:
+        node.query("DROP TABLE IF EXISTS {} NO DELAY".format(table_name))
+
+# Create table with default zookeeper.
+def test_create_replicated_merge_tree_with_default_zookeeper(started_cluster):
+    drop_table([node1, node2], "test_default_zookeeper")
+    for node in [node1, node2]:
+        node.query(
+            '''
+                CREATE TABLE test_default_zookeeper(a Int32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/test_default_zookeeper', '{replica}')
+                ORDER BY a;
+            '''.format(replica=node.name))
+
+    # Insert data into node1, and query it from node2.
+    node1.query("INSERT INTO test_default_zookeeper VALUES (1)")
+    time.sleep(5)
+
+    expected = "1\n"
+    assert TSV(node1.query("SELECT a FROM test_default_zookeeper")) == TSV(expected)
+    assert TSV(node2.query("SELECT a FROM test_default_zookeeper")) == TSV(expected)
+
+# Create table with auxiliary zookeeper.
+def test_create_replicated_merge_tree_with_auxiliary_zookeeper(started_cluster):
+    drop_table([node1, node2], "test_auxiliary_zookeeper")
+    for node in [node1, node2]:
+        node.query(
+            '''
+                CREATE TABLE test_auxiliary_zookeeper(a Int32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/test_auxiliary_zookeeper', '{replica}')
+                ORDER BY a;
+            '''.format(replica=node.name))
+
+    # Insert data into node1, and query it from node2.
+    node1.query("INSERT INTO test_auxiliary_zookeeper VALUES (1)")
+    time.sleep(5)
+
+    expected = "1\n"
+    assert TSV(node1.query("SELECT a FROM test_auxiliary_zookeeper")) == TSV(expected)
+    assert TSV(node2.query("SELECT a FROM test_auxiliary_zookeeper")) == TSV(expected)

--- a/tests/integration/test_replicated_merge_tree_with_auxiliary_zookeepers/test.py
+++ b/tests/integration/test_replicated_merge_tree_with_auxiliary_zookeepers/test.py
@@ -3,12 +3,13 @@ import time
 import helpers.client as client
 import pytest
 from helpers.cluster import ClickHouseCluster
+from helpers.client import QueryRuntimeException
 from helpers.test_tools import TSV
 
 cluster = ClickHouseCluster(__file__)
 cluster = ClickHouseCluster(__file__)
-node1 = cluster.add_instance("node1", main_configs=["configs/config.xml"], with_zookeeper=True)
-node2 = cluster.add_instance("node2", main_configs=["configs/config.xml"], with_zookeeper=True)
+node1 = cluster.add_instance("node1", main_configs=["configs/zookeeper_config.xml", "configs/remote_servers.xml"], with_zookeeper=True)
+node2 = cluster.add_instance("node2", main_configs=["configs/zookeeper_config.xml", "configs/remote_servers.xml"], with_zookeeper=True)
 
 
 @pytest.fixture(scope="module")
@@ -55,7 +56,7 @@ def test_create_replicated_merge_tree_with_auxiliary_zookeeper(started_cluster):
         node.query(
             '''
                 CREATE TABLE test_auxiliary_zookeeper(a Int32)
-                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/test_auxiliary_zookeeper', '{replica}')
+                ENGINE = ReplicatedMergeTree('zookeeper2:/clickhouse/tables/test/test_auxiliary_zookeeper', '{replica}')
                 ORDER BY a;
             '''.format(replica=node.name))
 
@@ -66,3 +67,14 @@ def test_create_replicated_merge_tree_with_auxiliary_zookeeper(started_cluster):
     expected = "1\n"
     assert TSV(node1.query("SELECT a FROM test_auxiliary_zookeeper")) == TSV(expected)
     assert TSV(node2.query("SELECT a FROM test_auxiliary_zookeeper")) == TSV(expected)
+
+# Create table with auxiliary zookeeper.
+def test_create_replicated_merge_tree_with_not_exists_auxiliary_zookeeper(started_cluster):
+    drop_table([node1], "test_auxiliary_zookeeper")
+    with pytest.raises(QueryRuntimeException):
+        node1.query(
+            '''
+                CREATE TABLE test_auxiliary_zookeeper(a Int32)
+                ENGINE = ReplicatedMergeTree('zookeeper_not_exits:/clickhouse/tables/test/test_auxiliary_zookeeper', '{replica}')
+                ORDER BY a;
+            '''.format(replica=node1.name))


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

- Add configuration for multi zookeeper clusters.

Now it's possible to make different ReplicatedMergeTree engine with different ZooKeeper clusters.
The auxiliary zookeepers configuration (#14155 ) is reused to support this feature.
We can create table like follow:

CREATE TABLE t1 (a String) ENGINE= ReplicatedMergeTree('test:/tables/t1','{replica}') ORDER BY a;

It means that the metadata of the table named t1 is saved in zookeeper cluster named test, which configurated in
auxiliary_zookeepers.

CREATE TABLE t2 (a String) ENGINE= ReplicatedMergeTree('/tables/t2','{replica}') ORDER BY a;
It means that the metadata of the table named t2 is saved in the default zookeeper cluster, which configurated in
zookeeper.

<auxiliary_zookeepers>
        <test>
            <node index = "1">
                <host>172.19.0.11</host>
                <port>2181</port>
            </node>
        </test>
    </auxiliary_zookeepers>
In fact, the implementation compatibles with the old configuration.

Detailed description / Documentation draft: