### PR TITLE
Fix crash in CREATE TABLE AS

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -75,6 +75,7 @@ namespace ErrorCodes
     extern const int DICTIONARY_ALREADY_EXISTS;
     extern const int ILLEGAL_SYNTAX_FOR_DATA_TYPE;
     extern const int ILLEGAL_COLUMN;
+    extern const int LOGICAL_ERROR;
 }
 
 namespace fs = std::filesystem;

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -630,7 +630,12 @@ void InterpreterCreateQuery::setEngine(ASTCreateQuery & create) const
                 "Cannot CREATE a table AS " + qualified_name + ", it is a Dictionary",
                 ErrorCodes::INCORRECT_QUERY);
 
-        create.set(create.storage, as_create.storage->ptr());
+        if (as_create.storage)
+            create.set(create.storage, as_create.storage->ptr());
+        else if (as_create.as_table_function)
+            create.as_table_function = as_create.as_table_function->clone();
+        else
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot set engine, it's a bug.");
     }
 }
 

--- a/tests/queries/0_stateless/01189_create_as_table_as_table_function.reference
+++ b/tests/queries/0_stateless/01189_create_as_table_as_table_function.reference
@@ -1,0 +1,4 @@
+CREATE TABLE default.table2\n(\n    `number` UInt64\n) AS numbers(5)
+CREATE TABLE default.table3\n(\n    `number` UInt64\n) AS numbers(5)
+5	10
+5	10

--- a/tests/queries/0_stateless/01189_create_as_table_as_table_function.sql
+++ b/tests/queries/0_stateless/01189_create_as_table_as_table_function.sql
@@ -1,0 +1,14 @@
+DROP TABLE IF EXISTS table2;
+DROP TABLE IF EXISTS table3;
+
+CREATE TABLE table2 AS numbers(5);
+CREATE TABLE table3 AS table2;
+
+SHOW CREATE table2;
+SHOW CREATE table3;
+
+SELECT count(), sum(number) FROM table2;
+SELECT count(), sum(number) FROM table3;
+
+DROP TABLE table2;
+DROP TABLE table3;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed crash on `CREATE TABLE ... AS some_table` query when `some_table` was created `AS table_function()`
Fixes #16944