### PR TITLE
Fixing unstable test in tests/testflows/ldap/external_user_directory/tests/authentications.py

### DIFF
--- a/docker/test/testflows/runner/Dockerfile
+++ b/docker/test/testflows/runner/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update \
 ENV TZ=Europe/Moscow
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN pip3 install urllib3 testflows==1.6.62 docker-compose docker dicttoxml kazoo tzlocal
+RUN pip3 install urllib3 testflows==1.6.65 docker-compose docker dicttoxml kazoo tzlocal
 
 ENV DOCKER_CHANNEL stable
 ENV DOCKER_VERSION 17.09.1-ce

--- a/tests/testflows/ldap/external_user_directory/tests/authentications.py
+++ b/tests/testflows/ldap/external_user_directory/tests/authentications.py
@@ -144,6 +144,7 @@ def parallel_login_with_the_same_user(self, server, timeout=200):
                 join(tasks, timeout)
 
 @TestScenario
+@Tags("custom config")
 def login_after_ldap_external_user_directory_is_removed(self, server):
     """Check that ClickHouse stops authenticating LDAP users
     after LDAP external user directory is removed.


### PR DESCRIPTION
Fixing unstable test in tests/testflows/ldap/external_user_directory/tests/authentications.py

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixing unstable test in tests/testflows/ldap/external_user_directory/tests/authentications.py

Detailed description / Documentation draft:
Fixing unstable test in tests/testflows/ldap/external_user_directory/tests/authentications.py
