### PR TITLE
Trying to make read_in_order_many_parts more stable

### DIFF
--- a/tests/performance/read_in_order_many_parts.xml
+++ b/tests/performance/read_in_order_many_parts.xml
@@ -3,6 +3,7 @@
         <optimize_aggregation_in_order>1</optimize_aggregation_in_order>
         <optimize_read_in_order>1</optimize_read_in_order>
         <max_partitions_per_insert_block>2000</max_partitions_per_insert_block>
+        <max_insert_block_size>10000000</max_insert_block_size>
         <max_threads>8</max_threads>
     </settings>
 
@@ -16,8 +17,10 @@
         </substitution>
     </substitutions>
 
-    <create_query>CREATE TABLE mt_{parts}_parts(id UInt32, val1 UInt32, val2 UInt32) ENGINE = MergeTree ORDER BY val1 PARTITION BY id % {parts}</create_query>
-    <fill_query>INSERT INTO mt_{parts}_parts SELECT number, rand() % 10000, rand() FROM numbers_mt(100000000)</fill_query>
+    <create_query>CREATE TABLE mt_{parts}_parts(id UInt32, val1 UInt32, val2 UInt32) ENGINE = MergeTree ORDER BY val1 PARTITION BY id % {parts} SETTINGS parts_to_throw_insert=10000, parts_to_delay_insert=10000</create_query>
+    <fill_query>SYSTEM STOP MERGES mt_{parts}_parts</fill_query>
+    <fill_query>INSERT INTO mt_{parts}_parts SELECT number, rand() % 10000, rand() FROM numbers_mt(100000000) SETTINGS max_block_size=10000000</fill_query>
+    <fill_query>SYSTEM START MERGES mt_{parts}_parts</fill_query>
     <fill_query>OPTIMIZE TABLE mt_{parts}_parts FINAL</fill_query>
 
     <query>SELECT val2 FROM mt_{parts}_parts ORDER BY val1 LIMIT 1000000 FORMAT Null</query>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)
