### PR TITLE
Minor grammar correction in error messages

### DIFF
--- a/src/Processors/Formats/Impl/JSONCompactEachRowRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONCompactEachRowRowInputFormat.cpp
@@ -225,7 +225,7 @@ void JSONCompactEachRowRowInputFormat::readField(size_t index, MutableColumns & 
     }
     catch (Exception & e)
     {
-        e.addMessage("(while read the value of key " +  getPort().getHeader().getByPosition(index).name + ")");
+        e.addMessage("(while reading the value of key " +  getPort().getHeader().getByPosition(index).name + ")");
         throw;
     }
 }

--- a/src/Processors/Formats/Impl/JSONEachRowRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONEachRowRowInputFormat.cpp
@@ -163,7 +163,7 @@ void JSONEachRowRowInputFormat::readField(size_t index, MutableColumns & columns
     }
     catch (Exception & e)
     {
-        e.addMessage("(while read the value of key " + columnName(index) + ")");
+        e.addMessage("(while reading the value of key " + columnName(index) + ")");
         throw;
     }
 }

--- a/src/Processors/Formats/Impl/RegexpRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/RegexpRowInputFormat.cpp
@@ -102,7 +102,7 @@ bool RegexpRowInputFormat::readField(size_t index, MutableColumns & columns)
     }
     catch (Exception & e)
     {
-        e.addMessage("(while read the value of column " +  getPort().getHeader().getByPosition(index).name + ")");
+        e.addMessage("(while reading the value of column " +  getPort().getHeader().getByPosition(index).name + ")");
         throw;
     }
     return read;


### PR DESCRIPTION
Noticed this when I got an error loading some JSONEachRow data.
'while read the value of' -> 'while reading the value of'. 

Just getting in to ClickHouse and really enjoying my experience so far. Thanks!

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Correct grammar in error message in JSONEachRow, JSONCompactEachRow, and RegexpRow input formats



