### PR TITLE
Store read-only flag into metadata file for DiskS3

### DIFF
--- a/src/Disks/S3/DiskS3.cpp
+++ b/src/Disks/S3/DiskS3.cpp
@@ -112,7 +112,7 @@ namespace
         /// Number of references (hardlinks) to this metadata file.
         UInt32 ref_count;
         /// Flag indicates that file is read only.
-        bool read_only;
+        bool read_only = false;
 
         /// Load metadata by path or create empty if `create` flag is set.
         explicit Metadata(const String & s3_root_path_, const String & disk_path_, const String & metadata_file_path_, bool create = false)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed possible not-working mutations for parts stored on S3 disk.


Detailed description / Documentation draft:
When we perform local backup of a data part (e.g. doing mutations, cloning) it does the following things with each file of the part:
1. Mark file as read-only
2. Create hard-link from that file to destination path

Marking file as read-only in DiskS3 just sets FS read-only flag for metadata file.
When we create hard-link from that file it modifies metadata file incrementing number of references. This is actually file modification operation and it breaks, because metadata file was marked as read-only right before:
https://gist.github.com/Jokser/d282052507b4592dca78b9c61d1295ca

We shouldn't mark file as read-only on FS in that case, instead we should store read-only inside metadata file and check it if we trying to re-write this file.
