### PR TITLE
Disable rotation of the logs in tests (on CI)

### DIFF
--- a/programs/server/config.d/logging_no_rotate.xml
+++ b/programs/server/config.d/logging_no_rotate.xml
@@ -1,0 +1,1 @@
+../../../tests/config/config.d/logging_no_rotate.xml

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -11,6 +11,9 @@
         <level>trace</level>
         <log>/var/log/clickhouse-server/clickhouse-server.log</log>
         <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
+        <!-- Rotation policy
+             See https://github.com/pocoproject/poco/blob/poco-1.9.4-release/Foundation/include/Poco/FileChannel.h#L54-L85
+          -->
         <size>1000M</size>
         <count>10</count>
         <!-- <console>1</console> --> <!-- Default behavior is autodetection (log to console if not daemon mode and is tty) -->

--- a/tests/config/config.d/logging_no_rotate.xml
+++ b/tests/config/config.d/logging_no_rotate.xml
@@ -1,0 +1,8 @@
+<yandex>
+    <logger>
+        <!-- Disable rotation
+             https://pocoproject.org/docs/Poco.FileChannel.html
+        -->
+        <size>never</size>
+    </logger>
+</yandex>

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -28,6 +28,7 @@ ln -sf $SRC_PATH/config.d/clusters.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/graphite.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/database_atomic.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/test_cluster_with_incorrect_pw.xml $DEST_SERVER_PATH/config.d/
+ln -sf $SRC_PATH/config.d/logging_no_rotate.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/users.d/log_queries.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/readonly.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/access_management.xml $DEST_SERVER_PATH/users.d/


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Right now due to rotation the archive with the clickhouse-server.log maybe not full, for example:
- not full - https://clickhouse-test-reports.s3.yandex.net/16947/caf5f98db2ae39dd911f7d1fc0a7c2cc382b1c53/functional_stateless_tests_(ubsan)/clickhouse-server.log (no messages about server start)
- full     - https://clickhouse-test-reports.s3.yandex.net/16993/d1f52dc72d417580c4088cf3880593176416bea2/functional_stateless_tests_(thread).html

And sometimes rotated part may include relative part of the log, so it is better to disable it.


Cc: @alesapin 