### PR TITLE
Cleanup settings handling in perf tests

### DIFF
--- a/docker/test/performance-comparison/Dockerfile
+++ b/docker/test/performance-comparison/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update \
             tzdata \
             vim \
             wget \
-    && pip3 --no-cache-dir install clickhouse_driver scipy \
+    && pip3 --no-cache-dir install 'clickhouse-driver>=0.1.5' scipy \
     && apt-get purge --yes python3-dev g++ \
     && apt-get autoremove --yes \
     && apt-get clean \

--- a/docker/test/performance-comparison/perf.py
+++ b/docker/test/performance-comparison/perf.py
@@ -14,10 +14,12 @@ import string
 import sys
 import time
 import traceback
+import logging
 import xml.etree.ElementTree as et
 from threading import Thread
 from scipy import stats
 
+logging.basicConfig(format='%(asctime)s: %(levelname)s: %(module)s: %(message)s', level='WARNING')
 
 total_start_seconds = time.perf_counter()
 stage_start_seconds = total_start_seconds

--- a/docker/test/performance-comparison/perf.py
+++ b/docker/test/performance-comparison/perf.py
@@ -173,12 +173,9 @@ reportStageEnd('drop-1')
 settings = root.findall('settings/*')
 for conn_index, c in enumerate(all_connections):
     for s in settings:
-        try:
-            q = f"set {s.tag} = '{s.text}'"
-            c.execute(q)
-            print(f'set\t{conn_index}\t{c.last_query.elapsed}\t{tsv_escape(q)}')
-        except:
-            print(traceback.format_exc(), file=sys.stderr)
+        # requires clickhouse-driver >= 1.1.5 to accept arbitrary new settings
+        # (https://github.com/mymarilyn/clickhouse-driver/pull/142)
+        c.settings[s.tag] = s.text
 
 reportStageEnd('settings')
 

--- a/tests/performance/joins_in_memory_pmj.xml
+++ b/tests/performance/joins_in_memory_pmj.xml
@@ -1,6 +1,9 @@
 <test max_ignored_relative_change="0.8">
     <create_query>CREATE TABLE ints (i64 Int64, i32 Int32, i16 Int16, i8 Int8) ENGINE = Memory</create_query>
-    <create_query>SET join_algorithm = 'partial_merge'</create_query>
+
+    <settings>
+        <join_algorithm>partial_merge</join_algorithm>
+    </settings>
 
     <fill_query>INSERT INTO ints SELECT number AS i64, i64 AS i32, i64 AS i16, i64 AS i8 FROM numbers(10000)</fill_query>
     <fill_query>INSERT INTO ints SELECT 10000 + number % 1000 AS i64, i64 AS i32, i64 AS i16, i64 AS i8 FROM numbers(10000)</fill_query>

--- a/tests/performance/materialized_view_parallel_insert.xml
+++ b/tests/performance/materialized_view_parallel_insert.xml
@@ -18,13 +18,13 @@
             -- do not select anything because we only need column types
             LIMIT 0
     </create_query>
-    <fill_query>SET max_insert_threads=8</fill_query>
     <fill_query>SYSTEM STOP MERGES</fill_query>
 
     <query>
         INSERT INTO hits_mv
         SELECT CounterID, EventDate, UserID, Title
         FROM hits_10m_single
+        SETTINGS max_insert_threads=8
     </query>
 
     <drop_query>SYSTEM START MERGES</drop_query>

--- a/tests/performance/parallel_insert.xml
+++ b/tests/performance/parallel_insert.xml
@@ -19,13 +19,13 @@
             -- do not select anything because we only need column types
             LIMIT 0
     </create_query>
-    <fill_query>SET max_insert_threads=8</fill_query>
     <fill_query>SYSTEM STOP MERGES</fill_query>
 
     <query>
         INSERT INTO hits2
         SELECT CounterID, EventDate, UserID, Title
         FROM hits_10m_single
+        SETTINGS max_insert_threads=8
     </query>
 
     <drop_query>SYSTEM START MERGES</drop_query>


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

perf tests set settings via `SET` query, and in case of reconnect those settings will not be applied anymore. And clickhouse-driver (python) may implicitly do reconnects (if the ping is failed, i.e. connection has been closed).
So fix this by passing settings in the protocol instead of separate SET queries (or inplace via SETTINGS clause, refs #16619), and now clickhouse-driver will know about settings and will apply them for each query.
Also configure logging for warning+ (to see possible issues)

Cc: @akuzm 