### PR TITLE
Add missed <stdexcept>

### DIFF
--- a/base/common/StringRef.h
+++ b/base/common/StringRef.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cassert>
+#include <stdexcept> // for std::logic_error
 #include <string>
 #include <vector>
 #include <functional>


### PR DESCRIPTION
std::logic_error is used at line 294, so the appropriate header is required.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

`std::logic_error` is used at line 294 of `base/common/StringRef.h`, so the appropriate `<stdexcept>` header is required.


