### PR TITLE
Fix libunwind build for cmake 3.19+

### DIFF
--- a/contrib/libunwind-cmake/CMakeLists.txt
+++ b/contrib/libunwind-cmake/CMakeLists.txt
@@ -22,7 +22,16 @@ set_source_files_properties(${LIBUNWIND_C_SOURCES} PROPERTIES COMPILE_FLAGS "-st
 set(LIBUNWIND_ASM_SOURCES
     ${LIBUNWIND_SOURCE_DIR}/src/UnwindRegistersRestore.S
     ${LIBUNWIND_SOURCE_DIR}/src/UnwindRegistersSave.S)
-set_source_files_properties(${LIBUNWIND_ASM_SOURCES} PROPERTIES LANGUAGE C)
+
+# CMake doesn't pass the correct architecture for Apple prior to CMake 3.19 [1]
+# Workaround these two issues by compiling as C.
+#
+#   [1]: https://gitlab.kitware.com/cmake/cmake/-/issues/20771
+if (APPLE AND CMAKE_VERSION VERSION_LESS 3.19)
+    set_source_files_properties(${LIBUNWIND_ASM_SOURCES} PROPERTIES LANGUAGE C)
+else()
+    enable_language(ASM)
+endif()
 
 set(LIBUNWIND_SOURCES
     ${LIBUNWIND_CXX_SOURCES}


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

cmake 3.19 (prior 3.19 it didn't) will add `-x c` for those `*.S` files and clang will fail (since you cannot pass this flag for the asm files).