### PR TITLE
Fix AST formatting in log messages

### DIFF
--- a/base/common/logger_useful.h
+++ b/base/common/logger_useful.h
@@ -3,7 +3,6 @@
 /// Macros for convenient usage of Poco logger.
 
 #include <fmt/format.h>
-#include <fmt/ostream.h>
 #include <Poco/Logger.h>
 #include <Poco/Message.h>
 #include <Common/CurrentThread.h>

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -115,7 +115,7 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
         auto ast = DatabaseOnDisk::parseQueryFromMetadata(nullptr, context, metadata_file_path);
         create = ast->as<ASTCreateQuery &>();
         if (!create.table.empty() || !create.storage)
-            throw Exception(ErrorCodes::INCORRECT_QUERY, "Metadata file {} contains incorrect CREATE DATABASE query", metadata_file_path);
+            throw Exception(ErrorCodes::INCORRECT_QUERY, "Metadata file {} contains incorrect CREATE DATABASE query", metadata_file_path.string());
         create.attach = true;
         create.attach_short_syntax = true;
         create.database = database_name;
@@ -149,7 +149,7 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
         metadata_path = metadata_path / "store" / DatabaseCatalog::getPathForUUID(create.uuid);
 
         if (!create.attach && fs::exists(metadata_path))
-            throw Exception(ErrorCodes::DATABASE_ALREADY_EXISTS, "Metadata directory {} already exists", metadata_path);
+            throw Exception(ErrorCodes::DATABASE_ALREADY_EXISTS, "Metadata directory {} already exists", metadata_path.string());
     }
     else
     {

--- a/src/Parsers/formatAST.h
+++ b/src/Parsers/formatAST.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <ostream>
 #include <Parsers/IAST.h>
 
 
@@ -29,3 +28,20 @@ inline WriteBuffer & operator<<(WriteBuffer & buf, const ASTPtr & ast)
 }
 
 }
+
+template<>
+struct fmt::formatter<DB::ASTPtr>
+{
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext & context)
+    {
+        return context.begin();
+    }
+
+    template<typename FormatContext>
+    auto format(const DB::ASTPtr & ast, FormatContext & context)
+    {
+        return fmt::format_to(context.out(), "{}", DB::serializeAST(*ast));
+    }
+};
+

--- a/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
+++ b/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
@@ -4,6 +4,7 @@
 
 #include <cppkafka/cppkafka.h>
 #include <boost/algorithm/string/join.hpp>
+#include <fmt/ostream.h>
 #include <algorithm>
 
 namespace DB

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -695,7 +695,7 @@ void StorageDistributed::createDirectoryMonitors(const std::string & disk)
 
             if (std::filesystem::is_empty(dir_path))
             {
-                LOG_DEBUG(log, "Removing {} (used for async INSERT into Distributed)", dir_path);
+                LOG_DEBUG(log, "Removing {} (used for async INSERT into Distributed)", dir_path.string());
                 /// Will be created by DistributedBlockOutputStream on demand.
                 std::filesystem::remove(dir_path);
             }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Detailed description / Documentation draft:
Fixes log messages like the following:
```
<Debug> InterpreterSelectQuery: MergeTreeWhereOptimizer: condition "0x7f538e25cc38" moved to PREWHERE
```
Issue introduced in #16824. 
