### PR TITLE
Attempt to fix Stress test (MSan)

### DIFF
--- a/src/Functions/FunctionBase64Conversion.h
+++ b/src/Functions/FunctionBase64Conversion.h
@@ -106,8 +106,8 @@ public:
         auto & dst_offsets = dst_column->getOffsets();
 
         size_t reserve = Func::getBufferSize(input->getChars().size(), input->size());
-        dst_data.resize(reserve);
-        dst_offsets.resize(input_rows_count);
+        dst_data.resize_fill(reserve);
+        dst_offsets.resize_fill(input_rows_count);
 
         const ColumnString::Offsets & src_offsets = input->getOffsets();
 
@@ -164,7 +164,7 @@ public:
             src_offset_prev = src_offsets[row];
         }
 
-        dst_data.resize(dst_pos - dst);
+        dst_data.resize_fill(dst_pos - dst);
 
         return dst_column;
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
`PODArray` does not initialize "new" elements when resizing, unlike `std::vector`. This probably fixes [this failure](https://clickhouse-test-reports.s3.yandex.net/17309/065cd002578f2e8228f12a2744bd40c970065e0c/stress_test_(memory)/stderr.log) from #17309. 


