### PR TITLE
Add eof check in receiveHello

### DIFF
--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -207,6 +207,12 @@ void Connection::receiveHello()
     /// Receive hello packet.
     UInt64 packet_type = 0;
 
+    /// Prevent read after eof in readVarUInt in case of reset connection
+    /// (Poco should throw such exception while reading from socket but
+    /// sometimes it doesn't for unknown reason)
+    if (in->eof())
+        throw Poco::Net::NetException("Connection reset by peer");
+
     readVarUInt(packet_type, *in);
     if (packet_type == Protocol::Server::Hello)
     {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add eof check in receiveHello to prevent getting `Attempt to read after eof` exception.

Detailed description / Documentation draft:
If we have a ssh server `host` with a ClickHouse server and we use ssh port forwarding:
`ssh -L local_port:localhost:9440 host`
And if we try such request (without `--secure` parameter):
`clickhouse-client --query="select 1" --port local_port`
We get an uninformative exception:
`Code: 32. DB::Exception: Attempt to read after eof`

If we do this request locally on the host we get a normal exception:
`Code: 210. DB::NetException: Connection reset by peer, while reading from socket ([::1]:9440)`

So, we need to check this situation and throw an appropriate exception. 

Closes https://github.com/ClickHouse/ClickHouse/issues/14878.