### PR TITLE
Replaced malloc with new in RadixSort

### DIFF
--- a/src/AggregateFunctions/QuantileTDigest.h
+++ b/src/AggregateFunctions/QuantileTDigest.h
@@ -114,7 +114,7 @@ class QuantileTDigest
         static constexpr size_t PART_SIZE_BITS = 8;
 
         using Transform = RadixSortFloatTransform<KeyBits>;
-        using Allocator = RadixSortMallocAllocator;
+        using Allocator = RadixSortAllocator;
 
         /// The function to get the key from an array element.
         static Key & extractKey(Element & elem) { return elem.mean; }

--- a/src/Common/RadixSort.h
+++ b/src/Common/RadixSort.h
@@ -42,9 +42,9 @@ struct RadixSortAllocator
         return ::operator new(size);
     }
 
-    void deallocate(void * ptr, size_t /*size*/)
+    void deallocate(void * ptr, size_t size)
     {
-        ::operator delete(ptr);
+        ::operator delete(ptr, size);
     }
 };
 

--- a/src/Common/RadixSort.h
+++ b/src/Common/RadixSort.h
@@ -39,12 +39,12 @@ struct RadixSortMallocAllocator
 {
     void * allocate(size_t size)
     {
-        return new char[size];
+        return ::operator new(size);
     }
 
     void deallocate(void * ptr, size_t /*size*/)
     {
-        return delete[](ptr);
+        ::operator delete(ptr);
     }
 };
 

--- a/src/Common/RadixSort.h
+++ b/src/Common/RadixSort.h
@@ -39,12 +39,12 @@ struct RadixSortMallocAllocator
 {
     void * allocate(size_t size)
     {
-        return malloc(size);
+        return new char[size];
     }
 
     void deallocate(void * ptr, size_t /*size*/)
     {
-        return free(ptr);
+        return delete[](ptr);
     }
 };
 

--- a/src/Common/RadixSort.h
+++ b/src/Common/RadixSort.h
@@ -35,7 +35,7 @@
 
 /** Used as a template parameter. See below.
   */
-struct RadixSortMallocAllocator
+struct RadixSortAllocator
 {
     void * allocate(size_t size)
     {
@@ -100,7 +100,7 @@ struct RadixSortFloatTraits
     /// An object with the functions allocate and deallocate.
     /// Can be used, for example, to allocate memory for a temporary array on the stack.
     /// To do this, the allocator itself is created on the stack.
-    using Allocator = RadixSortMallocAllocator;
+    using Allocator = RadixSortAllocator;
 
     /// The function to get the key from an array element.
     static Key & extractKey(Element & elem) { return elem; }
@@ -139,7 +139,7 @@ struct RadixSortUIntTraits
     static constexpr size_t PART_SIZE_BITS = 8;
 
     using Transform = RadixSortIdentityTransform<KeyBits>;
-    using Allocator = RadixSortMallocAllocator;
+    using Allocator = RadixSortAllocator;
 
     static Key & extractKey(Element & elem) { return elem; }
     static Result & extractResult(Element & elem) { return elem; }
@@ -173,7 +173,7 @@ struct RadixSortIntTraits
     static constexpr size_t PART_SIZE_BITS = 8;
 
     using Transform = RadixSortSignedTransform<KeyBits>;
-    using Allocator = RadixSortMallocAllocator;
+    using Allocator = RadixSortAllocator;
 
     static Key & extractKey(Element & elem) { return elem; }
     static Result & extractResult(Element & elem) { return elem; }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Replaced `malloc` with `new`, so that the `MemoryTracker` takes this memory into account
