### PR TITLE
[RFC] Disallow low values of max_untracked_memory (which may lead to server crash)

### DIFF
--- a/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
+++ b/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
@@ -64,18 +64,18 @@ const Block & PullingAsyncPipelineExecutor::getHeader() const
 
 static void threadFunction(PullingAsyncPipelineExecutor::Data & data, ThreadGroupStatusPtr thread_group, size_t num_threads)
 {
-    if (thread_group)
-        CurrentThread::attachTo(thread_group);
-
-    SCOPE_EXIT(
-        if (thread_group)
-            CurrentThread::detachQueryIfNotDetached();
-    );
-
     setThreadName("QueryPipelineEx");
 
     try
     {
+        if (thread_group)
+            CurrentThread::attachTo(thread_group);
+
+        SCOPE_EXIT(
+            if (thread_group)
+                CurrentThread::detachQueryIfNotDetached();
+        );
+
         data.executor->execute(num_threads);
     }
     catch (...)

--- a/tests/integration/test_distributed_inter_server_secret/test.py
+++ b/tests/integration/test_distributed_inter_server_secret/test.py
@@ -171,7 +171,7 @@ def test_per_user_inline_settings_insecure_cluster(user, password):
     SETTINGS
         prefer_localhost_replica=0,
         max_memory_usage_for_user=1e9,
-        max_untracked_memory=0
+        max_untracked_memory=4096
     """, user=user, password=password)
     assert get_query_setting_on_shard(n1, id_, 'max_memory_usage_for_user') == ''
 @users
@@ -182,7 +182,7 @@ def test_per_user_inline_settings_secure_cluster(user, password):
     SETTINGS
         prefer_localhost_replica=0,
         max_memory_usage_for_user=1e9,
-        max_untracked_memory=0
+        max_untracked_memory=4096
     """, user=user, password=password)
     assert int(get_query_setting_on_shard(n1, id_, 'max_memory_usage_for_user')) == int(1e9)
 @users
@@ -191,7 +191,7 @@ def test_per_user_protocol_settings_insecure_cluster(user, password):
     query_with_id(n1, id_, 'SELECT * FROM dist_insecure', user=user, password=password, settings={
         'prefer_localhost_replica': 0,
         'max_memory_usage_for_user': int(1e9),
-        'max_untracked_memory': 0,
+        'max_untracked_memory': 4096,
     })
     assert get_query_setting_on_shard(n1, id_, 'max_memory_usage_for_user') == ''
 @users
@@ -200,7 +200,7 @@ def test_per_user_protocol_settings_secure_cluster(user, password):
     query_with_id(n1, id_, 'SELECT * FROM dist_secure', user=user, password=password, settings={
         'prefer_localhost_replica': 0,
         'max_memory_usage_for_user': int(1e9),
-        'max_untracked_memory': 0,
+        'max_untracked_memory': 4096,
     })
     assert int(get_query_setting_on_shard(n1, id_, 'max_memory_usage_for_user')) == int(1e9)
 

--- a/tests/queries/0_stateless/01526_max_untracked_memory.sh
+++ b/tests/queries/0_stateless/01526_max_untracked_memory.sh
@@ -12,7 +12,7 @@ min_trace_entries=2
 
 # do not use _, they should be escaped for LIKE
 query_id_tcp_prefix="01526-tcp-memory-tracking-$RANDOM-$$"
-${CLICKHOUSE_CLIENT} --log_queries=1 --max_threads=1 --max_untracked_memory=0 --memory_profiler_sample_probability=1 -q "with '$query_id_tcp_prefix' as __id $query FORMAT Null"
+${CLICKHOUSE_CLIENT} --log_queries=1 --max_threads=1 --max_untracked_memory=4096 --memory_profiler_sample_probability=1 -q "with '$query_id_tcp_prefix' as __id $query FORMAT Null"
 ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS"
 query_id_tcp="$(${CLICKHOUSE_CLIENT} -q "SELECT DISTINCT query_id FROM system.query_log WHERE query LIKE '%$query_id_tcp_prefix%'")"
 ${CLICKHOUSE_CLIENT} -q "SELECT count()>=$min_trace_entries FROM system.trace_log WHERE query_id = '$query_id_tcp' AND abs(size) < 4e6 AND event_time >= now() - interval 1 hour"
@@ -21,7 +21,7 @@ ${CLICKHOUSE_CLIENT} -q "SELECT count()>=$min_trace_entries FROM system.trace_lo
 
 # query_id cannot be longer then 28 bytes
 query_id_http="01526_http_${RANDOM}_$$"
-echo "$query" | ${CLICKHOUSE_CURL} -sSg -o /dev/null "${CLICKHOUSE_URL}&query_id=$query_id_http&max_untracked_memory=0&memory_profiler_sample_probability=1&max_threads=1" -d @-
+echo "$query" | ${CLICKHOUSE_CURL} -sSg -o /dev/null "${CLICKHOUSE_URL}&query_id=$query_id_http&max_untracked_memory=4096&memory_profiler_sample_probability=1&max_threads=1" -d @-
 ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS"
 # at least 2, one allocation, one deallocation
 # (but actually even more)

--- a/tests/queries/0_stateless/01594_too_low_memory_limits.sql
+++ b/tests/queries/0_stateless/01594_too_low_memory_limits.sql
@@ -1,0 +1,9 @@
+-- it is not mandatory to use existing table since it fails earlier, hence just a placeholder.
+
+-- this format of INSERT SELECT pass settings attach settings to the SELECT query only
+-- expecting UNKNOWN_TABLE, not the server unexpected termination
+insert into placeholder_table_name select * from numbers_mt(65535) settings max_memory_usage=1, max_untracked_memory=1 ; -- { serverError 60 }
+
+-- this is another format of INSERT SELECT, that pass these settings exactly for INSERT query not the SELECT
+-- expecting SETTING_CONSTRAINT_VIOLATION, not the server unexpected termination
+insert into placeholder_table_name select * from numbers_mt(65535) format Null settings max_memory_usage=1, max_untracked_memory=1 ; -- { serverError 452 }


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Disallow too low values of `max_untracked_memory`, since this may lead to server crash

Detailed description / Documentation draft:
Due to failed allocation from the destructor, example of the stacktrace:

<details>

```
2020.11.25 22:51:36.377873 [ 1853495 ] {edae87ee-05b3-4bfa-be51-3f81d25bca2e} <Debug> executeQuery: (from [::1]:48852) insert into placeholder_table_name select * from numbers_mt(65535) format Null settings max_memory_usage=1, max_untracked_memory=1 
2020.11.25 22:51:36.390607 [ 1853446 ] {} <Trace> BaseDaemon: Received signal -1
2020.11.25 22:51:36.390644 [ 1853446 ] {} <Fatal> BaseDaemon: (version 20.12.1.5205 (official build), build id: B23CB64BD60D7F4C) (from thread 1853495) Terminate called for uncaught exception:
Code: 241, e.displayText() = DB::Exception: Memory limit (for query) exceeded: would use 2.01 MiB (attempt to allocate chunk of 48 bytes), maximum: 1.00 B, Stack trace (when copying this message, always include the lines below):

0. /build/build_docker/../contrib/poco/Foundation/src/Exception.cpp:27: Poco::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) @ 0x107323d0 in /src/ch/tmp/upstream/clickhouse
1. /build/build_docker/../src/Common/Exception.cpp:39: DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) @ 0x74f5085 in /src/ch/tmp/upstream/clickhouse
2. /build/build_docker/../contrib/libcxx/include/string:2134: DB::Exception::Exception<char const*, char const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long&, std::__1::basic_string<char, std::__1::char_traits<char>, 
2020.11.25 22:51:36.390667 [ 1853446 ] {} <Trace> BaseDaemon: Received signal 6
2020.11.25 22:51:36.390801 [ 1854585 ] {} <Fatal> BaseDaemon: ########################################
2020.11.25 22:51:36.390827 [ 1854585 ] {} <Fatal> BaseDaemon: (version 20.12.1.5205 (official build), build id: B23CB64BD60D7F4C) (from thread 1853495) (query_id: edae87ee-05b3-4bfa-be51-3f81d25bca2e) Received signal Aborted (6)
2020.11.25 22:51:36.390842 [ 1854585 ] {} <Fatal> BaseDaemon: 
2020.11.25 22:51:36.390859 [ 1854585 ] {} <Fatal> BaseDaemon: Stack trace: 0x7ffff7dde615 0x7ffff7dc7862 0x768a37d 0x11aea23c 0x11ad6df1 0x11ad72bc 0x11ad7806 0x11af6657 0x11ae99ea 0x74df512 0x74de86c 0x74dd02c 0x11acf19c 0xd692953 0xd7bf172 0xd7bc031 0xd7b8c11 0xdf37cf9 0xdf38e9e 0x1067a1cb 0x1067a660 0x107bec66 0x107ba3d0 0x7ffff7f843e9 0x7ffff7ea1293
2020.11.25 22:51:36.390888 [ 1854585 ] {} <Fatal> BaseDaemon: 3. raise @ 0x3d615 in /usr/lib/libc-2.32.so
2020.11.25 22:51:36.390900 [ 1854585 ] {} <Fatal> BaseDaemon: 4. __GI_abort @ 0x26862 in /usr/lib/libc-2.32.so
2020.11.25 22:51:36.391618 [ 1854585 ] {} <Fatal> BaseDaemon: 5. /build/build_docker/../src/IO/WriteBuffer.h:46: terminate_handler() (.cold) @ 0x768a37d in /src/ch/tmp/upstream/clickhouse
2020.11.25 22:51:36.392363 [ 1854585 ] {} <Fatal> BaseDaemon: 6. /build/build_docker/../contrib/libcxxabi/src/cxa_handlers.cpp:61: std::__terminate(void (*)()) @ 0x11aea23c in /src/ch/tmp/upstream/clickhouse
2020.11.25 22:51:36.393103 [ 1854585 ] {} <Fatal> BaseDaemon: 7. /build/build_docker/../contrib/libcxxabi/src/cxa_personality.cpp:325: call_terminate @ 0x11ad6df1 in /src/ch/tmp/upstream/clickhouse
2020.11.25 22:51:36.393812 [ 1854585 ] {} <Fatal> BaseDaemon: 8. /build/build_docker/../contrib/libcxxabi/src/cxa_personality.cpp:887: scan_eh_tab @ 0x11ad72bc in /src/ch/tmp/upstream/clickhouse
2020.11.25 22:51:36.394541 [ 1854585 ] {} <Fatal> BaseDaemon: 9. /build/build_docker/../contrib/libcxxabi/src/cxa_personality.cpp:970: __gxx_personality_v0 @ 0x11ad7806 in /src/ch/tmp/upstream/clickhouse
2020.11.25 22:51:36.395265 [ 1854585 ] {} <Fatal> BaseDaemon: 10. /build/obj-x86_64-linux-gnu/../contrib/libunwind/src/UnwindLevel1.c:101: _Unwind_RaiseException @ 0x11af6657 in /src/ch/tmp/upstream/clickhouse
2020.11.25 22:51:36.395979 [ 1854585 ] {} <Fatal> BaseDaemon: 11. /build/build_docker/../contrib/libcxxabi/src/cxa_exception.cpp:151: __cxa_throw @ 0x11ae99ea in /src/ch/tmp/upstream/clickhouse
2020.11.25 22:51:36.396038 [ 1854585 ] {} <Fatal> BaseDaemon: 12. /build/build_docker/../src/Common/MemoryTracker.cpp:171: MemoryTracker::alloc(long) (.cold) @ 0x74df512 in /src/ch/tmp/upstream/clickhouse
2020.11.25 22:51:36.396212 [ 1854585 ] {} <Fatal> BaseDaemon: 13. /build/build_docker/../src/Common/MemoryTracker.cpp:177: MemoryTracker::alloc(long) @ 0x74de86c in /src/ch/tmp/upstream/clickhouse
2020.11.25 22:51:36.396225 [ 1854585 ] {} <Fatal> BaseDaemon: 14. /build/build_docker/../base/common/../common/memory.h:20: operator new(unsigned long) @ 0x74dd02c in /src/ch/tmp/upstream/clickhouse
2020.11.25 22:51:36.396948 [ 1854585 ] {} <Fatal> BaseDaemon: 15. /build/build_docker/../contrib/libcxx/include/string:1495: std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::basic_string(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) @ 0x11acf19c in /src/ch/tmp/upstream/clickhouse
2020.11.25 22:51:36.397683 [ 1854585 ] {} <Fatal> BaseDaemon: 16. /build/build_docker/../contrib/libcxx/include/list:361: DB::ProcessListEntry::~ProcessListEntry() @ 0xd692953 in /src/ch/tmp/upstream/clickhouse
2020.11.25 22:51:36.399234 [ 1854585 ] {} <Fatal> BaseDaemon: 17. /build/build_docker/../contrib/libcxx/include/memory:3483: std::__1::shared_ptr<DB::ProcessListEntry>::~shared_ptr() @ 0xd7bf172 in /src/ch/tmp/upstream/clickhouse
2020.11.25 22:51:36.400472 [ 1854585 ] {} <Fatal> BaseDaemon: 18. /build/build_docker/../src/Interpreters/executeQuery.cpp:428: DB::executeQueryImpl(char const*, char const*, DB::Context&, bool, DB::QueryProcessingStage::Enum, bool, DB::ReadBuffer*) (.cold) @ 0xd7bc031 in /src/ch/tmp/upstream/clickhouse
2020.11.25 22:51:36.401525 [ 1854585 ] {} <Fatal> BaseDaemon: 19. /build/build_docker/../src/Interpreters/executeQuery.cpp:814: DB::executeQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::Context&, bool, DB::QueryProcessingStage::Enum, bool) @ 0xd7b8c11 in /src/ch/tmp/upstream/clickhouse
2020.11.25 22:51:36.402887 [ 1854585 ] {} <Fatal> BaseDaemon: 20. /build/build_docker/../src/Server/TCPHandler.cpp:254: DB::TCPHandler::runImpl() @ 0xdf37cf9 in /src/ch/tmp/upstream/clickhouse
2020.11.25 22:51:36.404453 [ 1854585 ] {} <Fatal> BaseDaemon: 21. /build/build_docker/../src/Server/TCPHandler.cpp:1336: DB::TCPHandler::run() @ 0xdf38e9e in /src/ch/tmp/upstream/clickhouse
2020.11.25 22:51:36.405158 [ 1854585 ] {} <Fatal> BaseDaemon: 22. /build/build_docker/../contrib/poco/Net/src/TCPServerConnection.cpp:57: Poco::Net::TCPServerConnection::start() @ 0x1067a1cb in /src/ch/tmp/upstream/clickhouse
2020.11.25 22:51:36.405918 [ 1854585 ] {} <Fatal> BaseDaemon: 23. /build/build_docker/../contrib/libcxx/include/atomic:856: Poco::Net::TCPServerDispatcher::run() @ 0x1067a660 in /src/ch/tmp/upstream/clickhouse
2020.11.25 22:51:36.406690 [ 1854585 ] {} <Fatal> BaseDaemon: 24. /build/build_docker/../contrib/poco/Foundation/include/Poco/Mutex_POSIX.h:59: Poco::PooledThread::run() @ 0x107bec66 in /src/ch/tmp/upstream/clickhouse
2020.11.25 22:51:36.407413 [ 1854585 ] {} <Fatal> BaseDaemon: 25. /build/build_docker/../contrib/poco/Foundation/include/Poco/AutoPtr.h:215: Poco::ThreadImpl::runnableEntry(void*) @ 0x107ba3d0 in /src/ch/tmp/upstream/clickhouse
2020.11.25 22:51:36.407428 [ 1854585 ] {} <Fatal> BaseDaemon: 26. start_thread @ 0x93e9 in /usr/lib/libpthread-2.32.so
2020.11.25 22:51:36.407436 [ 1854585 ] {} <Fatal> BaseDaemon: 27. clone @ 0x100293 in /usr/lib/libc-2.32.so
```

</details>