### PR TITLE
Simplify init script (part 2)

### DIFF
--- a/debian/clickhouse-server.init
+++ b/debian/clickhouse-server.init
@@ -67,26 +67,6 @@ if uname -mpi | grep -q 'x86_64'; then
 fi
 
 
-is_running()
-{
-    pgrep --pidfile "$CLICKHOUSE_PIDFILE" $(echo "${PROGRAM}" | cut -c1-15) 1> /dev/null 2> /dev/null
-}
-
-
-wait_for_done()
-{
-    timeout=$1
-    attempts=0
-    while is_running; do
-        attempts=$(($attempts + 1))
-        if [ -n "$timeout" ] && [ $attempts -gt $timeout ]; then
-            return 1
-        fi
-        sleep 1
-    done
-}
-
-
 die()
 {
     echo $1 >&2
@@ -171,17 +151,7 @@ restart()
 
 forcestop()
 {
-    local EXIT_STATUS
-    EXIT_STATUS=0
-
-    echo -n "Stop forcefully $PROGRAM service: "
-
-    kill -KILL $(cat "$CLICKHOUSE_PIDFILE")
-
-    wait_for_done
-
-    echo "DONE"
-    return $EXIT_STATUS
+    ${CLICKHOUSE_GENERIC_PROGRAM} stop --force --pid-path "${CLICKHOUSE_PIDDIR}"
 }
 
 
@@ -261,16 +231,16 @@ main()
         service_or_func restart
         ;;
     condstart)
-        is_running || service_or_func start
+        service_or_func start
         ;;
     condstop)
-        is_running && service_or_func stop
+        service_or_func stop
         ;;
     condrestart)
-        is_running && service_or_func restart
+        service_or_func restart
         ;;
     condreload)
-        is_running && service_or_func restart
+        service_or_func restart
         ;;
     initdb)
         initdb
@@ -293,17 +263,7 @@ main()
 
 status()
 {
-    if is_running; then
-        echo "$PROGRAM service is running"
-        exit 0
-    else
-        if is_cron_disabled; then
-            echo "$PROGRAM service is stopped";
-        else
-            echo "$PROGRAM: process unexpectedly terminated"
-        fi
-        exit 3
-    fi
+    ${CLICKHOUSE_GENERIC_PROGRAM} status --pid-path "${CLICKHOUSE_PIDDIR}"
 }
 
 

--- a/debian/clickhouse-server.init
+++ b/debian/clickhouse-server.init
@@ -85,49 +85,7 @@ check_config()
 
 initdb()
 {
-    if [ -x "$CLICKHOUSE_BINDIR/$EXTRACT_FROM_CONFIG" ]; then
-        CLICKHOUSE_DATADIR_FROM_CONFIG=$(su -s $SHELL ${CLICKHOUSE_USER} -c "$CLICKHOUSE_BINDIR/$EXTRACT_FROM_CONFIG --config-file=\"$CLICKHOUSE_CONFIG\" --key=path")
-        if [ "(" "$?" -ne "0" ")" -o "(" -z "${CLICKHOUSE_DATADIR_FROM_CONFIG}" ")" ]; then
-            die "Cannot obtain value of path from config file: ${CLICKHOUSE_CONFIG}";
-        fi
-        echo "Path to data directory in ${CLICKHOUSE_CONFIG}: ${CLICKHOUSE_DATADIR_FROM_CONFIG}"
-    else
-        CLICKHOUSE_DATADIR_FROM_CONFIG=$CLICKHOUSE_DATADIR
-    fi
-
-    if ! getent passwd ${CLICKHOUSE_USER} >/dev/null; then
-        echo "Can't chown to non-existing user ${CLICKHOUSE_USER}"
-        return
-    fi
-    if ! getent group ${CLICKHOUSE_GROUP} >/dev/null; then
-        echo "Can't chown to non-existing group ${CLICKHOUSE_GROUP}"
-        return
-    fi
-
-    if ! $(su -s $SHELL ${CLICKHOUSE_USER} -c "test -r ${CLICKHOUSE_CONFIG}"); then
-        echo "Warning! clickhouse config [${CLICKHOUSE_CONFIG}] not readable by user [${CLICKHOUSE_USER}]"
-    fi
-
-    if ! $(su -s $SHELL ${CLICKHOUSE_USER} -c "test -O \"${CLICKHOUSE_DATADIR_FROM_CONFIG}\" && test -G \"${CLICKHOUSE_DATADIR_FROM_CONFIG}\""); then
-        if [ $(dirname "${CLICKHOUSE_DATADIR_FROM_CONFIG}") = "/" ]; then
-            echo "Directory ${CLICKHOUSE_DATADIR_FROM_CONFIG} seems too dangerous to chown."
-        else
-            if [ ! -e "${CLICKHOUSE_DATADIR_FROM_CONFIG}" ]; then
-                echo "Creating directory ${CLICKHOUSE_DATADIR_FROM_CONFIG}"
-                mkdir -p "${CLICKHOUSE_DATADIR_FROM_CONFIG}"
-            fi
-
-            echo "Changing owner of [${CLICKHOUSE_DATADIR_FROM_CONFIG}] to [${CLICKHOUSE_USER}:${CLICKHOUSE_GROUP}]"
-            chown -R ${CLICKHOUSE_USER}:${CLICKHOUSE_GROUP} "${CLICKHOUSE_DATADIR_FROM_CONFIG}"
-        fi
-    fi
-
-    if ! $(su -s $SHELL ${CLICKHOUSE_USER} -c "test -w ${CLICKHOUSE_LOGDIR}"); then
-        echo "Changing owner of [${CLICKHOUSE_LOGDIR}/*] to [${CLICKHOUSE_USER}:${CLICKHOUSE_GROUP}]"
-        chown -R ${CLICKHOUSE_USER}:${CLICKHOUSE_GROUP} ${CLICKHOUSE_LOGDIR}/*
-        echo "Changing owner of [${CLICKHOUSE_LOGDIR}] to [${CLICKHOUSE_LOGDIR_USER}:${CLICKHOUSE_GROUP}]"
-        chown ${CLICKHOUSE_LOGDIR_USER}:${CLICKHOUSE_GROUP} ${CLICKHOUSE_LOGDIR}
-    fi
+    ${CLICKHOUSE_GENERIC_PROGRAM} install --user "${CLICKHOUSE_USER}" --pid-path "${CLICKHOUSE_PIDDIR}" --config-path "${CLICKHOUSE_CONFDIR}" --binary-path "${CLICKHOUSE_BINDIR}"
 }
 
 


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Simplify Sys/V init script. It was not working on Ubuntu 12.04.

Details:
`pgrep` on Ubuntu 12.04 has not argument `--pidfile`.