### PR TITLE
Fixed a problem with the translation of get-started

### DIFF
--- a/docs/zh/getting-started/example-datasets/index.md
+++ b/docs/zh/getting-started/example-datasets/index.md
@@ -6,15 +6,16 @@ toc_title: "\u5BFC\u8A00"
 
 # 示例数据集 {#example-datasets}
 
-本节介绍如何获取示例数据集并将其导入ClickHouse。
+本节介绍如何获取示例数据集并将其导入ClickHouse。对于某些数据集，还可以使用示例查询。
+
 对于某些数据集示例查询也可用。
 
--   [脱敏的Yandex.Metrica数据集](metrica.md)
--   [星型基准测试](star-schema.md)
--   [维基访问数据](wikistat.md)
--   [Criteo TB级别点击日志](criteo.md)
--   [AMPLab大数据基准测试](amplab-benchmark.md)
--   [纽约出租车数据](nyc-taxi.md)
--   [航班飞行数据](ontime.md)
+-   [Anonymized Yandex.Metrica Dataset](../../getting-started/example-datasets/metrica.md)
+-   [Star Schema Benchmark](../../getting-started/example-datasets/star-schema.md)
+-   [WikiStat](../../getting-started/example-datasets/wikistat.md)
+-   [Terabyte of Click Logs from Criteo](../../getting-started/example-datasets/criteo.md)
+-   [AMPLab Big Data Benchmark](../../getting-started/example-datasets/amplab-benchmark.md)
+-   [New York Taxi Data](../../getting-started/example-datasets/nyc-taxi.md)
+-   [OnTime](../../getting-started/example-datasets/ontime.md)
 
 [原始文章](https://clickhouse.tech/docs/en/getting_started/example_datasets) <!--hide-->

--- a/docs/zh/getting-started/example-datasets/metrica.md
+++ b/docs/zh/getting-started/example-datasets/metrica.md
@@ -1,17 +1,17 @@
 ---
-toc_priority: 21
-toc_title: "Yandex\u6885\u7279\u91CC\u5361\u6570\u636E"
+toc_priority: 15
+toc_title: Yandex.Metrica Data
 ---
 
-# 脱敏的Yandex.Metrica数据集 {#anonymized-yandex-metrica-data}
+# Anonymized Yandex.Metrica Data {#anonymized-yandex-metrica-data}
 
-Dataset由两个表组成，其中包含有关命中的匿名数据 (`hits_v1`）和访问 (`visits_v1`）的Yandex的。梅特里卡 你可以阅读更多关于Yandex的。梅特里卡 [ClickHouse历史](../../introduction/history.md) 科。
+数据集由两个表组成，包含关于Yandex.Metrica的hits(`hits_v1`)和visit(`visits_v1`)的匿名数据。你可以阅读更多关于Yandex的信息。在[ClickHouse历史](../../introduction/history.md)的Metrica部分。
 
-数据集由两个表组成，其中任何一个都可以作为压缩表下载 `tsv.xz` 文件或作为准备的分区。 除此之外，该扩展版本 `hits` 包含1亿行的表可作为TSV在https://clickhouse-datasets.s3.yandex.net/hits/tsv/hits_100m_obfuscated_v1.tsv.xz 并作为准备的分区在https://clickhouse-datasets.s3.yandex.net/hits/partitions/hits_100m_obfuscated_v1.tar.xz.
+数据集由两个表组成，他们中的任何一个都可以下载作为一个压缩`tsv.xz`的文件或准备的分区。除此之外,一个扩展版的`hits`表包含1亿行TSV在https://clickhouse-datasets.s3.yandex.net/hits/tsv/hits_100m_obfuscated_v1.tsv.xz，准备分区在https://clickhouse-datasets.s3.yandex.net/hits/partitions/hits_100m_obfuscated_v1.tar.xz。
 
 ## 从准备好的分区获取表 {#obtaining-tables-from-prepared-partitions}
 
-下载和导入点击表:
+下载和导入`hits`表:
 
 ``` bash
 curl -O https://clickhouse-datasets.s3.yandex.net/hits/partitions/hits_v1.tar
@@ -21,7 +21,7 @@ sudo service clickhouse-server restart
 clickhouse-client --query "SELECT COUNT(*) FROM datasets.hits_v1"
 ```
 
-下载和导入访问:
+下载和导入`visits`表:
 
 ``` bash
 curl -O https://clickhouse-datasets.s3.yandex.net/visits/partitions/visits_v1.tar
@@ -31,9 +31,9 @@ sudo service clickhouse-server restart
 clickhouse-client --query "SELECT COUNT(*) FROM datasets.visits_v1"
 ```
 
-## 从压缩TSV文件获取表 {#obtaining-tables-from-compressed-tsv-file}
+## 从TSV压缩文件获取表 {#obtaining-tables-from-compressed-tsv-file}
 
-从压缩的TSV文件下载并导入命中:
+从TSV压缩文件下载并导入`hits`:
 
 ``` bash
 curl https://clickhouse-datasets.s3.yandex.net/hits/tsv/hits_v1.tsv.xz | unxz --threads=`nproc` > hits_v1.tsv
@@ -47,7 +47,7 @@ clickhouse-client --query "OPTIMIZE TABLE datasets.hits_v1 FINAL"
 clickhouse-client --query "SELECT COUNT(*) FROM datasets.hits_v1"
 ```
 
-从压缩tsv文件下载和导入访问:
+从压缩tsv文件下载和导入`visits`:
 
 ``` bash
 curl https://clickhouse-datasets.s3.yandex.net/visits/tsv/visits_v1.tsv.xz | unxz --threads=`nproc` > visits_v1.tsv
@@ -63,6 +63,6 @@ clickhouse-client --query "SELECT COUNT(*) FROM datasets.visits_v1"
 
 ## 查询示例 {#example-queries}
 
-[点击教程](../../getting-started/tutorial.md) 是基于Yandex的。Metrica数据集和开始使用此数据集的推荐方式是通过教程。
+[使用教程](../../getting-started/tutorial.md)是以Yandex.Metrica数据集开始教程。
 
-查询这些表的其他示例可以在 [有状态测试](https://github.com/ClickHouse/ClickHouse/tree/master/tests/queries/1_stateful) ClickHouse的（它们被命名为 `test.hists` 和 `test.visits` 那里）。
+可以在ClickHouse的[stateful tests](https://github.com/ClickHouse/ClickHouse/tree/master/tests/queries/1_stateful) 中找到对这些表的查询的其他示例(它们被命名为`test.hists`和`test.visits`)。

--- a/docs/zh/getting-started/index.md
+++ b/docs/zh/getting-started/index.md
@@ -1,3 +1,10 @@
+---
+machine_translated: true
+machine_translated_rev: 72537a2d527c63c07aa5d2361a8829f3895cf2bd
+toc_folder_title: "\u5BFC\u8A00"
+toc_priority: 2
+---
+
 # 入门 {#ru-men}
 
 如果您是ClickHouse的新手，并希望亲身体验它的性能，首先您需要通过 [安装过程](install.md).

--- a/docs/zh/getting-started/install.md
+++ b/docs/zh/getting-started/install.md
@@ -1,5 +1,5 @@
 ---
-toc_priority: 1
+toc_priority: 11
 toc_title: 安装部署
 ---
 

--- a/docs/zh/getting-started/install.md
+++ b/docs/zh/getting-started/install.md
@@ -1,34 +1,46 @@
+---
+toc_priority: 1
+toc_title: 安装部署
+---
+
 # 安装 {#clickhouse-an-zhuang}
 
 ## 系统要求 {#xi-tong-yao-qiu}
 
 ClickHouse可以在任何具有x86_64，AArch64或PowerPC64LE CPU架构的Linux，FreeBSD或Mac OS X上运行。
 
-虽然预构建的二进制文件通常是为x86  _64编译并利用SSE 4.2指令集，但除非另有说明，否则使用支持它的CPU将成为额外的系统要求。这是检查当前CPU是否支持SSE 4.2的命令：
+官方预构建的二进制文件通常针对x86_64进行编译，并利用`SSE 4.2`指令集，因此，除非另有说明，支持它的CPU使用将成为额外的系统需求。下面是检查当前CPU是否支持SSE 4.2的命令:
 
 ``` bash
 $ grep -q sse4_2 /proc/cpuinfo && echo "SSE 4.2 supported" || echo "SSE 4.2 not supported"
 ```
 
-要在不支持SSE 4.2或具有AArch64或PowerPC64LE体系结构的处理器上运行ClickHouse，您应该[通过源构建ClickHouse](#from-sources)进行适当的配置调整。
+要在不支持`SSE 4.2`或`AArch64`，`PowerPC64LE`架构的处理器上运行ClickHouse，您应该通过适当的配置调整从[源代码构建ClickHouse](#from-sources)。
 
-## 可用的安装选项 {#install-from-deb-packages}
+## 可用安装包 {#install-from-deb-packages}
 
-建议为Debian或Ubuntu使用官方的预编译`deb`软件包。 运行以下命令以安装软件包：
+### `DEB`安装包
 
-然后运行：
+建议使用Debian或Ubuntu的官方预编译`deb`软件包。运行以下命令来安装包:
 
 ``` bash
 {% include 'install/deb.sh' %}
 ```
 
-你也可以从这里手动下载安装包：https://repo.clickhouse.tech/deb/stable/main/。
+如果您想使用最新的版本，请用`testing`替代`stable`(我们只推荐您用于测试环境)。
 
-如果你想使用最新的测试版本，请使用`testing`替换`stable`。
+你也可以从这里手动下载安装包：[下载](https://repo.clickhouse.tech/deb/stable/main/)。
 
-### 来自RPM包 {#from-rpm-packages}
+安装包列表：
 
-Yandex ClickHouse团队建议使用官方预编译的`rpm`软件包，用于CentOS，RedHat和所有其他基于rpm的Linux发行版。
+- `clickhouse-common-static` — ClickHouse编译的二进制文件。
+- `clickhouse-server` — 创建`clickhouse-server`软连接，并安装默认配置服务
+- `clickhouse-client` — 创建`clickhouse-client`客户端工具软连接，并安装客户端配置文件。
+- `clickhouse-common-static-dbg` — 带有调试信息的ClickHouse二进制文件。
+
+### `RPM`安装包 {#from-rpm-packages}
+
+推荐使用CentOS、RedHat和所有其他基于rpm的Linux发行版的官方预编译`rpm`包。
 
 首先，您需要添加官方存储库：
 
@@ -38,84 +50,120 @@ sudo rpm --import https://repo.clickhouse.tech/CLICKHOUSE-KEY.GPG
 sudo yum-config-manager --add-repo https://repo.clickhouse.tech/rpm/stable/x86_64
 ```
 
-如果您想使用最新版本，请将`stable`替换为`testing`（建议您在测试环境中使用）。
+如果您想使用最新的版本，请用`testing`替代`stable`(我们只推荐您用于测试环境)。`prestable`有时也可用。
 
-然后运行这些命令以实际安装包：
+然后运行命令安装：
 
 ``` bash
 sudo yum install clickhouse-server clickhouse-client
 ```
 
-您也可以从此处手动下载和安装软件包：https://repo.clickhouse.tech/rpm/stable/x86_64。
+你也可以从这里手动下载安装包：[下载](https://repo.clickhouse.tech/rpm/stable/x86_64)。
 
-### 来自Docker {#from-docker-image}
+### `Tgz`安装包 {#from-tgz-archives}
 
-要在Docker中运行ClickHouse，请遵循[码头工人中心](https://hub.docker.com/r/yandex/clickhouse-server/)上的指南。那些图像使用官方的`deb`包。
+如果您的操作系统不支持安装`deb`或`rpm`包，建议使用官方预编译的`tgz`软件包。
+
+所需的版本可以通过`curl`或`wget`从存储库`https://repo.clickhouse.tech/tgz/`下载。
+
+下载后解压缩下载资源文件并使用安装脚本进行安装。以下是一个最新版本的安装示例:
+
+``` bash
+export LATEST_VERSION=`curl https://api.github.com/repos/ClickHouse/ClickHouse/tags 2>/dev/null | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -n 1`
+curl -O https://repo.clickhouse.tech/tgz/clickhouse-common-static-$LATEST_VERSION.tgz
+curl -O https://repo.clickhouse.tech/tgz/clickhouse-common-static-dbg-$LATEST_VERSION.tgz
+curl -O https://repo.clickhouse.tech/tgz/clickhouse-server-$LATEST_VERSION.tgz
+curl -O https://repo.clickhouse.tech/tgz/clickhouse-client-$LATEST_VERSION.tgz
+
+tar -xzvf clickhouse-common-static-$LATEST_VERSION.tgz
+sudo clickhouse-common-static-$LATEST_VERSION/install/doinst.sh
+
+tar -xzvf clickhouse-common-static-dbg-$LATEST_VERSION.tgz
+sudo clickhouse-common-static-dbg-$LATEST_VERSION/install/doinst.sh
+
+tar -xzvf clickhouse-server-$LATEST_VERSION.tgz
+sudo clickhouse-server-$LATEST_VERSION/install/doinst.sh
+sudo /etc/init.d/clickhouse-server start
+
+tar -xzvf clickhouse-client-$LATEST_VERSION.tgz
+sudo clickhouse-client-$LATEST_VERSION/install/doinst.sh
+```
+
+对于生产环境，建议使用最新的`stable`版本。你可以在GitHub页面https://github.com/ClickHouse/ClickHouse/tags找到它，它以后缀`-stable`标志。
+
+### `Docker`安装包 {#from-docker-image}
+
+要在Docker中运行ClickHouse，请遵循[Docker Hub](https://hub.docker.com/r/yandex/clickhouse-server/)上的指南。它是官方的`deb`安装包。
+
+### 其他环境安装包 {#from-other}
+
+对于非linux操作系统和Arch64 CPU架构，ClickHouse将会以`master`分支的最新提交的进行编译提供(它将会有几小时的延迟)。
+
+-   [macOS](https://builds.clickhouse.tech/master/macos/clickhouse) — `curl -O 'https://builds.clickhouse.tech/master/macos/clickhouse' && chmod a+x ./clickhouse`
+-   [FreeBSD](https://builds.clickhouse.tech/master/freebsd/clickhouse) — `curl -O 'https://builds.clickhouse.tech/master/freebsd/clickhouse' && chmod a+x ./clickhouse`
+-   [AArch64](https://builds.clickhouse.tech/master/aarch64/clickhouse) — `curl -O 'https://builds.clickhouse.tech/master/aarch64/clickhouse' && chmod a+x ./clickhouse`
+
+下载后，您可以使用`clickhouse client`连接服务，或者使用`clickhouse local`模式处理数据，不过您必须要额外在GitHub下载[server](https://github.com/ClickHouse/ClickHouse/blob/master/programs/server/config.xml)和[users](https://github.com/ClickHouse/ClickHouse/blob/master/programs/server/users.xml)配置文件。
+
+不建议在生产环境中使用这些构建版本，因为它们没有经过充分的测试，但是您可以自行承担这样做的风险。它们只是ClickHouse功能的一个部分。
 
 ### 使用源码安装 {#from-sources}
 
-具体编译方式可以参考build.md。
+要手动编译ClickHouse, 请遵循[Linux](../development/build.md)或[Mac OS X](../development/build-osx.md)说明。
 
-你可以编译并安装它们。
-你也可以直接使用而不进行安装。
+您可以编译并安装它们，也可以使用不安装包的程序。通过手动构建，您可以禁用`SSE 4.2`或`AArch64 cpu`。
 
-``` text
-Client: programs/clickhouse-client
-Server: programs/clickhouse-server
-```
+      Client: programs/clickhouse-client
+      Server: programs/clickhouse-server
 
-在服务器中为数据创建如下目录：
+您需要创建一个数据和元数据文件夹，并为所需的用户`chown`授权。它们的路径可以在服务器配置(`src/programs/server/config.xml`)中改变，默认情况下它们是:
 
-``` text
-/opt/clickhouse/data/default/
-/opt/clickhouse/metadata/default/
-```
+      /opt/clickhouse/data/default/
+      /opt/clickhouse/metadata/default/
 
-(它们可以在server config中配置。)
-为需要的用户运行’chown’
-
-日志的路径可以在server config (src/programs/server/config.xml)中配置。
+在Gentoo上，你可以使用`emerge clickhouse`从源代码安装ClickHouse。
 
 ## 启动 {#qi-dong}
 
-可以运行如下命令在后台启动服务：
+如果没有`service`，可以运行如下命令在后台启动服务：
 
 ``` bash
-sudo service clickhouse-server start
+$ sudo /etc/init.d/clickhouse-server start
 ```
 
-可以在`/var/log/clickhouse-server/`目录中查看日志。
+日志文件将输出在`/var/log/clickhouse-server/`文件夹。
 
-如果服务没有启动，请检查配置文件 `/etc/clickhouse-server/config.xml`。
+如果服务器没有启动，检查`/etc/clickhouse-server/config.xml`中的配置。
 
-你也可以在控制台中直接启动服务：
+您也可以手动从控制台启动服务器:
 
-``` bash
-clickhouse-server --config-file=/etc/clickhouse-server/config.xml
+```bash
+$ clickhouse-server --config-file=/etc/clickhouse-server/config.xml
 ```
 
-在这种情况下，日志将被打印到控制台中，这在开发过程中很方便。
-如果配置文件在当前目录中，你可以不指定’–config-file’参数。它默认使用’./config.xml’。
+在这种情况下，日志将被打印到控制台，这在开发过程中很方便。
 
-你可以使用命令行客户端连接到服务：
+如果配置文件在当前目录中，则不需要指定`——config-file`参数。默认情况下，它的路径为`./config.xml`。
+
+ClickHouse支持访问限制设置。它们位于`users.xml`文件(与`config.xml`同级目录)。
+默认情况下，允许`default`用户从任何地方访问，不需要密码。可查看`user/default/networks`。
+更多信息，请参见[Configuration Files](../operations/configuration-files.md)。
+
+启动服务后，您可以使用命令行客户端连接到它:
 
 ``` bash
-clickhouse-client
+$ clickhouse-client
 ```
 
-默认情况下它使用’default’用户无密码的与localhost:9000服务建立连接。
-客户端也可以用于连接远程服务，例如：
+默认情况下，使用`default`用户并不携带密码连接到`localhost:9000`。还可以使用`--host`参数连接到指定服务器。
 
-``` bash
-clickhouse-client --host=example.com
+终端必须使用UTF-8编码。
+更多信息，请参阅[Command-line client](../interfaces/cli.md)。
+
+示例：
+
 ```
-
-有关更多信息，请参考«Command-line client»部分。
-
-检查系统是否工作：
-
-``` bash
-milovidov@hostname:~/work/metrica/src/src/Client$ ./clickhouse-client
+$ ./clickhouse-client
 ClickHouse client version 0.0.18749.
 Connecting to localhost:9000.
 Connected to ClickHouse server version 0.0.18749.
@@ -135,6 +183,6 @@ SELECT 1
 
 **恭喜，系统已经工作了!**
 
-为了继续进行实验，你可以尝试下载测试数据集。
+为了继续进行实验，你可以尝试下载测试数据集或查看[教程](https://clickhouse.tech/tutorial.html)。
 
 [原始文章](https://clickhouse.tech/docs/en/getting_started/install/) <!--hide-->

--- a/docs/zh/getting-started/tutorial.md
+++ b/docs/zh/getting-started/tutorial.md
@@ -1,19 +1,19 @@
 ---
 toc_priority: 12
-toc_title: "\u6559\u7A0B"
+toc_title: 使用教程
 ---
 
-# 点击教程 {#clickhouse-tutorial}
+# ClickHouse教程 {#clickhouse-tutorial}
 
-## 从本教程中可以期待什么？ {#what-to-expect-from-this-tutorial}
+## 从本教程中可以获得什么？ {#what-to-expect-from-this-tutorial}
 
-通过本教程，您将学习如何设置一个简单的ClickHouse集群。 它会很小，但却是容错和可扩展的。 然后，我们将使用其中一个示例数据集来填充数据并执行一些演示查询。
+通过学习本教程，您将了解如何设置一个简单的ClickHouse集群。它会很小，但是可以容错和扩展。然后，我们将使用其中一个示例数据集来填充数据并执行一些演示查询。
 
 ## 单节点设置 {#single-node-setup}
 
-为了推迟分布式环境的复杂性，我们将首先在单个服务器或虚拟机上部署ClickHouse。 ClickHouse通常是从[deb](install.md#install-from-deb-packages) 或 [rpm](install.md#from-rpm-packages) 包安装，但对于不支持它们的操作系统也有 [替代方法](install.md#from-docker-image) 。
+为了延迟演示分布式环境的复杂性，我们将首先在单个服务器或虚拟机上部署ClickHouse。ClickHouse通常是从[deb](install.md#install-from-deb-packages)或[rpm](install.md#from-rpm-packages)包安装，但对于不支持它们的操作系统也有[其他方法](install.md#from-docker-image)。
 
-例如，您选择了从 `deb` 包安装，执行:
+例如，您选择`deb`安装包，执行:
 
 ``` bash
 {% include 'install/deb.sh' %}
@@ -21,13 +21,13 @@ toc_title: "\u6559\u7A0B"
 
 在我们安装的软件中包含这些包:
 
--   `clickhouse-client` 包，包含 [clickhouse-client](../interfaces/cli.md) 应用程序，它是交互式ClickHouse控制台客户端。
+-   `clickhouse-client` 包，包含[clickhouse-client](../interfaces/cli.md)客户端，它是交互式ClickHouse控制台客户端。
 -   `clickhouse-common` 包，包含一个ClickHouse可执行文件。
 -   `clickhouse-server` 包，包含要作为服务端运行的ClickHouse配置文件。
 
-服务端配置文件位于 `/etc/clickhouse-server/`。 在进一步讨论之前，请注意 `config.xml`文件中的`<path>` 元素. Path决定了数据存储的位置，因此该位置应该位于磁盘容量较大的卷上；默认值为 `/var/lib/clickhouse/`。 如果你想调整配置，考虑到它可能会在未来的软件包更新中被重写，直接编辑`config.xml` 文件并不方便。 推荐的方法是在[配置文件](../operations/configuration-files.md)目录创建文件，作为config.xml文件的“补丁”，用以复写配置元素。
+服务器配置文件位于`/etc/clickhouse-server/`。在继续之前，请注意`config.xml`中的`<path>`元素。它决定了数据存储的位置，因此它应该位于磁盘容量的卷上;默认值是`/var/lib/clickhouse/`。如果你想调整配置，直接编辑config是不方便的。考虑到它可能会在将来的包更新中被重写。建议重写配置元素的方法是在配置中创建[config.d文件夹](../operations/configuration-files.md)，作为config.xml的重写方式。
 
-你可能已经注意到了, `clickhouse-server` 安装后不会自动启动。 它也不会在更新后自动重新启动。 您启动服务端的方式取决于您的初始系统，通常情况下是这样:
+你可能已经注意到了,`clickhouse-server`安装后不会自动启动。 它也不会在更新后自动重新启动。 您启动服务端的方式取决于您的初始系统，通常情况下是这样:
 
 ``` bash
 sudo service clickhouse-server start
@@ -39,9 +39,9 @@ sudo service clickhouse-server start
 sudo /etc/init.d/clickhouse-server start
 ```
 
-服务端日志的默认位置是 `/var/log/clickhouse-server/`。当服务端在日志中记录 `Ready for connections` 消息，即表示服务端已准备好处理客户端连接。
+服务端日志的默认位置是`/var/log/clickhouse-server/`。当服务端在日志中记录`Ready for connections`消息，即表示服务端已准备好处理客户端连接。
 
-一旦 `clickhouse-server` 启动并运行，我们可以利用 `clickhouse-client` 连接到服务端，并运行一些测试查询，如 `SELECT "Hello, world!";`.
+一旦`clickhouse-server`启动并运行，我们可以利用`clickhouse-client`连接到服务端，并运行一些测试查询，如`SELECT "Hello, world!";`.
 
 <details markdown="1">
 
@@ -80,7 +80,7 @@ clickhouse-client --query='INSERT INTO table FORMAT TabSeparated' < data.tsv
 
 ## 导入示例数据集 {#import-sample-dataset}
 
-现在是时候用一些示例数据填充我们的ClickHouse服务端。 在本教程中，我们将使用Yandex.Metrica的匿名数据，它是在ClickHouse成为开源之前作为生产环境运行的第一个服务（关于这一点的更多内容请参阅[ClickHouse历史](../introduction/history.md))。有 [多种导入Yandex.Metrica数据集的的方法](example-datasets/metrica.md)，为了本教程，我们将使用最现实的一个。
+现在是时候用一些示例数据填充我们的ClickHouse服务端。 在本教程中，我们将使用Yandex.Metrica的匿名数据，它是在ClickHouse成为开源之前作为生产环境运行的第一个服务（关于这一点的更多内容请参阅[ClickHouse历史](../introduction/history.md))。[多种导入Yandex.Metrica数据集方法](example-datasets/metrica.md)，为了本教程，我们将使用最现实的一个。
 
 ### 下载并提取表数据 {#download-and-extract-table-data}
 
@@ -93,17 +93,17 @@ curl https://clickhouse-datasets.s3.yandex.net/visits/tsv/visits_v1.tsv.xz | unx
 
 ### 创建表 {#create-tables}
 
-与大多数数据库管理系统一样，ClickHouse在逻辑上将表分组为数据库。包含一个 `default` 数据库，但我们将创建一个新的数据库 `tutorial`:
+与大多数数据库管理系统一样，ClickHouse在逻辑上将表分组为数据库。包含一个`default`数据库，但我们将创建一个新的数据库`tutorial`:
 
 ``` bash
 clickhouse-client --query "CREATE DATABASE IF NOT EXISTS tutorial"
 ```
 
-与创建数据库相比，创建表的语法要复杂得多（请参阅 [参考资料](../sql-reference/statements/create.md). 一般 `CREATE TABLE` 声明必须指定三个关键的事情:
+与创建数据库相比，创建表的语法要复杂得多（请参阅[参考资料](../sql-reference/statements/create.md). 一般`CREATE TABLE`声明必须指定三个关键的事情:
 
 1.  要创建的表的名称。
 2.  表结构，例如：列名和对应的[数据类型](../sql-reference/data-types/index.md)。
-3.  [表引擎](../engines/table-engines/index.md) 及其设置，这决定了对此表的查询操作是如何在物理层面执行的所有细节。
+3.  [表引擎](../engines/table-engines/index.md)及其设置，这决定了对此表的查询操作是如何在物理层面执行的所有细节。
 
 Yandex.Metrica是一个网络分析服务，样本数据集不包括其全部功能，因此只有两个表可以创建:
 
@@ -455,11 +455,11 @@ SETTINGS index_granularity = 8192
 
 您可以使用`clickhouse-client`的交互模式执行这些查询（只需在终端中启动它，而不需要提前指定查询）。或者如果你愿意，可以尝试一些[替代接口](../interfaces/index.md)。
 
-正如我们所看到的, `hits_v1` 使用 [基本的MergeTree引擎](../engines/table-engines/mergetree-family/mergetree.md)，而 `visits_v1` 使用 [折叠树](../engines/table-engines/mergetree-family/collapsingmergetree.md) 变体。
+正如我们所看到的, `hits_v1`使用 [MergeTree引擎](../engines/table-engines/mergetree-family/mergetree.md)，而`visits_v1`使用 [Collapsing](../engines/table-engines/mergetree-family/collapsingmergetree.md)引擎。
 
 ### 导入数据 {#import-data}
 
-数据导入到ClickHouse是通过以下方式完成的 [INSERT INTO](../sql-reference/statements/insert-into.md) 查询像许多其他SQL数据库。 然而，数据通常是在一个提供 [支持的序列化格式](../interfaces/formats.md) 而不是 `VALUES` 子句（也支持）。
+数据导入到ClickHouse是通过[INSERT INTO](../sql-reference/statements/insert-into.md)方式完成的，查询类似许多SQL数据库。然而，数据通常是在一个提供[支持序列化格式](../interfaces/formats.md)而不是`VALUES`子句（也支持）。
 
 我们之前下载的文件是以制表符分隔的格式，所以这里是如何通过控制台客户端导入它们:
 
@@ -468,7 +468,7 @@ clickhouse-client --query "INSERT INTO tutorial.hits_v1 FORMAT TSV" --max_insert
 clickhouse-client --query "INSERT INTO tutorial.visits_v1 FORMAT TSV" --max_insert_block_size=100000 < visits_v1.tsv
 ```
 
-ClickHouse有很多 [要调整的设置](../operations/settings/index.md) 在控制台客户端中指定它们的一种方法是通过参数，就像我们看到上面语句中的 `--max_insert_block_size`。找出可用的设置、含义及其默认值的最简单方法是查询 `system.settings` 表:
+ClickHouse有很多[要调整的设置](../operations/settings/index.md)在控制台客户端中指定它们的一种方法是通过参数，就像我们看到上面语句中的`--max_insert_block_size`。找出可用的设置、含义及其默认值的最简单方法是查询`system.settings` 表:
 
 ``` sql
 SELECT name, value, changed, description
@@ -479,14 +479,14 @@ FORMAT TSV
 max_insert_block_size    1048576    0    "The maximum block size for insertion, if we control the creation of blocks for insertion."
 ```
 
-您也可以 [OPTIMIZE](../sql-reference/statements/misc.md#misc_operations-optimize) 导入后的表。 使用MergeTree-family引擎配置的表总是在后台合并数据部分以优化数据存储（或至少检查是否有意义）。 这些查询强制表引擎立即进行存储优化，而不是稍后一段时间执行:
+您也可以[OPTIMIZE](../sql-reference/statements/misc.md#misc_operations-optimize)导入后的表。使用MergeTree-family引擎配置的表总是在后台合并数据部分以优化数据存储（或至少检查是否有意义）。 这些查询强制表引擎立即进行存储优化，而不是稍后一段时间执行:
 
 ``` bash
 clickhouse-client --query "OPTIMIZE TABLE tutorial.hits_v1 FINAL"
 clickhouse-client --query "OPTIMIZE TABLE tutorial.visits_v1 FINAL"
 ```
 
-这些查询开始一个I/O和CPU密集型操作，所以如果表一直接收到新数据，最好不要管它，让合并在后台运行。
+这些查询开始I/O和CPU密集型操作，所以如果表一直接收到新数据，最好不要管它，让合并在后台运行。
 
 现在我们可以检查表导入是否成功:
 
@@ -524,9 +524,9 @@ ClickHouse集群是一个同质集群。 设置步骤:
 1.  在群集的所有机器上安装ClickHouse服务端
 2.  在配置文件中设置群集配置
 3.  在每个实例上创建本地表
-4.  创建一个 [分布式表](../engines/table-engines/special/distributed.md)
+4.  创建一个[分布式表](../engines/table-engines/special/distributed.md)
 
-[分布式表](../engines/table-engines/special/distributed.md) 实际上是一种 “视图”，映射到ClickHouse集群的本地表。 从分布式表中执行 **SELECT** 查询会使用集群所有分片的资源。 您可以为多个集群指定configs，并创建多个分布式表，为不同的集群提供视图。
+[分布式表](../engines/table-engines/special/distributed.md)实际上是一种`view`，映射到ClickHouse集群的本地表。 从分布式表中执行**SELECT**查询会使用集群所有分片的资源。 您可以为多个集群指定configs，并创建多个分布式表，为不同的集群提供视图。
 
 具有三个分片，每个分片一个副本的集群的示例配置:
 
@@ -555,7 +555,7 @@ ClickHouse集群是一个同质集群。 设置步骤:
 </remote_servers>
 ```
 
-为了进一步演示，让我们使用和创建 `hits_v1` 表相同的 `CREATE TABLE` 语句创建一个新的本地表，但表名不同:
+为了进一步演示，让我们使用和创建`hits_v1`表相同的`CREATE TABLE`语句创建一个新的本地表，但表名不同:
 
 ``` sql
 CREATE TABLE tutorial.hits_local (...) ENGINE = MergeTree() ...
@@ -568,9 +568,9 @@ CREATE TABLE tutorial.hits_all AS tutorial.hits_local
 ENGINE = Distributed(perftest_3shards_1replicas, tutorial, hits_local, rand());
 ```
 
-常见的做法是在集群的所有计算机上创建类似的分布式表。 它允许在群集的任何计算机上运行分布式查询。 还有一个替代选项可以使用以下方法为给定的SELECT查询创建临时分布式表 [远程](../sql-reference/table-functions/remote.md) 表功能。
+常见的做法是在集群的所有计算机上创建类似的分布式表。 它允许在群集的任何计算机上运行分布式查询。 还有一个替代选项可以使用以下方法为给定的SELECT查询创建临时分布式表[远程](../sql-reference/table-functions/remote.md)表功能。
 
-让我们运行 [INSERT SELECT](../sql-reference/statements/insert-into.md) 将该表传播到多个服务器。
+让我们运行[INSERT SELECT](../sql-reference/statements/insert-into.md)将该表传播到多个服务器。
 
 ``` sql
 INSERT INTO tutorial.hits_all SELECT * FROM tutorial.hits_v1;
@@ -609,10 +609,10 @@ INSERT INTO tutorial.hits_all SELECT * FROM tutorial.hits_v1;
 </remote_servers>
 ```
 
-启用本机复制 [Zookeeper](http://zookeeper.apache.org/) 是必需的。 ClickHouse负责所有副本的数据一致性，并在失败后自动运行恢复过程。 建议将ZooKeeper集群部署在单独的服务器上（其中没有其他进程，包括运行的ClickHouse）。
+启用本机复制[Zookeeper](http://zookeeper.apache.org/)是必需的。 ClickHouse负责所有副本的数据一致性，并在失败后自动运行恢复过程。建议将ZooKeeper集群部署在单独的服务器上（其中没有其他进程，包括运行的ClickHouse）。
 
-!!! note "注"
-    ZooKeeper不是一个严格的要求：在某些简单的情况下，您可以通过将数据写入应用程序代码中的所有副本来复制数据。 这种方法是 **不** 建议的，在这种情况下，ClickHouse将无法保证所有副本上的数据一致性。 因此需要由您的应用来保证这一点。
+!!! note "注意"
+    ZooKeeper不是一个严格的要求：在某些简单的情况下，您可以通过将数据写入应用程序代码中的所有副本来复制数据。 这种方法是**不**建议的，在这种情况下，ClickHouse将无法保证所有副本上的数据一致性。 因此需要由您的应用来保证这一点。
 
 ZooKeeper位置在配置文件中指定:
 
@@ -653,12 +653,12 @@ ENGINE = ReplcatedMergeTree(
 ...
 ```
 
-在这里，我们使用 [ReplicatedMergeTree](../engines/table-engines/mergetree-family/replication.md) 表引擎。 在参数中，我们指定包含分片和副本标识符的ZooKeeper路径。
+在这里，我们使用[ReplicatedMergeTree](../engines/table-engines/mergetree-family/replication.md)表引擎。 在参数中，我们指定包含分片和副本标识符的ZooKeeper路径。
 
 ``` sql
 INSERT INTO tutorial.hits_replica SELECT * FROM tutorial.hits_local;
 ```
 
-复制在多主机模式下运行。 数据可以加载到任何副本中，然后系统会自动将其与其他实例同步。 复制是异步的，因此在给定时刻，并非所有副本都可能包含最近插入的数据。 至少应有一个副本允许数据摄取。 其他人将同步数据和修复一致性，一旦他们将再次变得活跃。 请注意，这种方法允许最近插入的数据丢失的可能性很低。
+复制在多主机模式下运行。数据可以加载到任何副本中，然后系统自动将其与其他实例同步。复制是异步的，因此在给定时刻，并非所有副本都可能包含最近插入的数据。至少应该有一个副本允许数据摄入。另一些则会在重新激活后同步数据并修复一致性。请注意，这种方法允许最近插入的数据丢失的可能性很低。
 
 [原始文章](https://clickhouse.tech/docs/en/getting_started/tutorial/) <!--hide-->


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation

...

- translate tutorial documentation
- translate example for metrica documentation
- translate and improve the installation and deployment documentation

...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
