### PR TITLE
Do not allow to throw MEMORY_LIMIT_EXCEEDED if there is uncaught exception

### DIFF
--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -33,6 +33,8 @@ MemoryTracker * getMemoryTracker()
 /// MemoryTracker cannot throw MEMORY_LIMIT_EXCEEDED (either configured memory
 /// limit reached or fault injected), in the following cases:
 ///
+/// - when it is explicitly blocked with LockExceptionInThread
+///
 /// - to avoid std::terminate(), when stack unwinding is current in progress in
 ///   this thread.
 ///
@@ -41,7 +43,7 @@ MemoryTracker * getMemoryTracker()
 ///   noexcept(false)) will cause std::terminate()
 bool inline memoryTrackerCanThrow()
 {
-    return !std::uncaught_exceptions();
+    return !MemoryTracker::LockExceptionInThread::isBlocked() && !std::uncaught_exceptions();
 }
 
 }
@@ -63,6 +65,7 @@ namespace ProfileEvents
 static constexpr size_t log_peak_memory_usage_every = 1ULL << 30;
 
 thread_local bool MemoryTracker::BlockerInThread::is_blocked = false;
+thread_local bool MemoryTracker::LockExceptionInThread::is_blocked = false;
 
 MemoryTracker total_memory_tracker(nullptr, VariableContext::Global);
 

--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -142,6 +142,30 @@ public:
         ~BlockerInThread() { is_blocked = false; }
         static bool isBlocked() { return is_blocked; }
     };
+
+    /// To be able to avoid MEMORY_LIMIT_EXCEEDED Exception in destructors:
+    /// - either configured memory limit reached
+    /// - or fault injected
+    ///
+    /// So this will simply ignore the configured memory limit (and avoid fault injection).
+    ///
+    /// NOTE: exception will be silently ignored, no message in log
+    /// (since logging from MemoryTracker::alloc() is tricky)
+    ///
+    /// NOTE: MEMORY_LIMIT_EXCEEDED Exception implicitly blocked if
+    /// stack unwinding is currently in progress in this thread (to avoid
+    /// std::terminate()), so you don't need to use it in this case explicitly.
+    struct LockExceptionInThread
+    {
+    private:
+        LockExceptionInThread(const LockExceptionInThread &) = delete;
+        LockExceptionInThread & operator=(const LockExceptionInThread &) = delete;
+        static thread_local bool is_blocked;
+    public:
+        LockExceptionInThread() { is_blocked = true; }
+        ~LockExceptionInThread() { is_blocked = false; }
+        static bool isBlocked() { return is_blocked; }
+    };
 };
 
 extern MemoryTracker total_memory_tracker;

--- a/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
+++ b/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
@@ -64,18 +64,18 @@ const Block & PullingAsyncPipelineExecutor::getHeader() const
 
 static void threadFunction(PullingAsyncPipelineExecutor::Data & data, ThreadGroupStatusPtr thread_group, size_t num_threads)
 {
-    if (thread_group)
-        CurrentThread::attachTo(thread_group);
-
-    SCOPE_EXIT(
-        if (thread_group)
-            CurrentThread::detachQueryIfNotDetached();
-    );
-
     setThreadName("QueryPipelineEx");
 
     try
     {
+        if (thread_group)
+            CurrentThread::attachTo(thread_group);
+
+        SCOPE_EXIT(
+            if (thread_group)
+                CurrentThread::detachQueryIfNotDetached();
+        );
+
         data.executor->execute(num_threads);
     }
     catch (...)

--- a/tests/queries/0_stateless/01594_too_low_memory_limits.sh
+++ b/tests/queries/0_stateless/01594_too_low_memory_limits.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../shell_config.sh
+
+# it is not mandatory to use existing table since it fails earlier, hence just a placeholder.
+# this is format of INSERT SELECT, that pass these settings exactly for INSERT query not the SELECT
+${CLICKHOUSE_CLIENT} --format Null -q 'insert into placeholder_table_name select * from numbers_mt(65535) format Null settings max_memory_usage=1, max_untracked_memory=1' >& /dev/null
+exit_code=$?
+
+# expecting ATTEMPT_TO_READ_AFTER_EOF, 32
+test $exit_code -eq 32 || exit 1
+
+# check that server is still alive
+${CLICKHOUSE_CLIENT} --format Null -q 'SELECT 1'


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Avoid server abnormal termination in case of too low memory limits (`max_memory_usage=1`/`max_untracked_memory=1`)

This PR also adds ability to explicitly disable throwing `MEMORY_LIMT_EXCEEDED` from the `MemoryTracking`, with `LockExceptionInThread`, but it is not used for now.

Supersedes: #17415
Cc: @alexey-milovidov 