### PR TITLE
Drop include of the removed libbtrie in cmake rules

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -66,10 +66,6 @@ if (USE_INTERNAL_FARMHASH_LIBRARY)
     add_subdirectory (libfarmhash)
 endif ()
 
-if (USE_INTERNAL_BTRIE_LIBRARY)
-    add_subdirectory (libbtrie)
-endif ()
-
 if (USE_INTERNAL_ZLIB_LIBRARY)
     set (ZLIB_ENABLE_TESTS 0 CACHE INTERNAL "")
     set (SKIP_INSTALL_ALL 1 CACHE INTERNAL "")


### PR DESCRIPTION
Otherwise with an old cache `-DUSE_INTERNAL_BTRIE_LIBRARY=OFF` is required

Refs: #16804
Cc: @KochetovNicolai 
Cc: @vdimir

Changelog category (leave one):
- Not for changelog (changelog entry is not required)