### PR TITLE
Add connection thread metrics

### DIFF
--- a/base/common/defines.h
+++ b/base/common/defines.h
@@ -76,6 +76,8 @@
 #    define NO_SANITIZE_THREAD
 #endif
 
-/// A macro for suppressing warnings about unused variables or function results.
-/// Useful for structured bindings which have no standard way to declare this.
-#define UNUSED(...) (void)(__VA_ARGS__)
+/// A template function for suppressing warnings about unused variables or function results.
+template <typename... Args>
+constexpr void UNUSED(Args &&... args [[maybe_unused]])
+{
+}

--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -7,6 +7,7 @@
 #include <Common/setThreadName.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/typeid_cast.h>
+#include <Server/ProtocolServerAdapter.h>
 #include <Storages/MarkCache.h>
 #include <Storages/StorageMergeTree.h>
 #include <Storages/StorageReplicatedMergeTree.h>
@@ -43,7 +44,8 @@ AsynchronousMetrics::~AsynchronousMetrics()
         }
 
         wait_cond.notify_one();
-        thread.join();
+        if (thread)
+            thread->join();
     }
     catch (...)
     {
@@ -169,7 +171,7 @@ void AsynchronousMetrics::update()
     AsynchronousMetricValues new_values;
 
     {
-        if (auto mark_cache = context.getMarkCache())
+        if (auto mark_cache = global_context.getMarkCache())
         {
             new_values["MarkCacheBytes"] = mark_cache->weight();
             new_values["MarkCacheFiles"] = mark_cache->count();
@@ -177,7 +179,7 @@ void AsynchronousMetrics::update()
     }
 
     {
-        if (auto uncompressed_cache = context.getUncompressedCache())
+        if (auto uncompressed_cache = global_context.getUncompressedCache())
         {
             new_values["UncompressedCacheBytes"] = uncompressed_cache->weight();
             new_values["UncompressedCacheCells"] = uncompressed_cache->count();
@@ -186,12 +188,12 @@ void AsynchronousMetrics::update()
 
 #if USE_EMBEDDED_COMPILER
     {
-        if (auto compiled_expression_cache = context.getCompiledExpressionCache())
+        if (auto compiled_expression_cache = global_context.getCompiledExpressionCache())
             new_values["CompiledExpressionCacheCount"]  = compiled_expression_cache->count();
     }
 #endif
 
-    new_values["Uptime"] = context.getUptimeSeconds();
+    new_values["Uptime"] = global_context.getUptimeSeconds();
 
     /// Process memory usage according to OS
 #if defined(OS_LINUX)
@@ -250,7 +252,7 @@ void AsynchronousMetrics::update()
             /// Check if database can contain MergeTree tables
             if (!db.second->canContainMergeTreeTables())
                 continue;
-            for (auto iterator = db.second->getTablesIterator(context); iterator->isValid(); iterator->next())
+            for (auto iterator = db.second->getTablesIterator(global_context); iterator->isValid(); iterator->next())
             {
                 ++total_number_of_tables;
                 const auto & table = iterator->table();
@@ -312,6 +314,39 @@ void AsynchronousMetrics::update()
 
         new_values["NumberOfDatabases"] = number_of_databases;
         new_values["NumberOfTables"] = total_number_of_tables;
+
+        auto get_metric_name = [](const String & name) -> const char *
+        {
+            static std::map<String, const char *> metric_map = {
+                {"tcp_port", "TCPThreads"},
+                {"tcp_port_secure", "TCPSecureThreads"},
+                {"http_port", "HTTPThreads"},
+                {"https_port", "HTTPSecureThreads"},
+                {"interserver_http_port", "InterserverThreads"},
+                {"interserver_https_port", "InterserverSecureThreads"},
+                {"mysql_port", "MySQLThreads"},
+                {"postgresql_port", "PostgreSQLThreads"},
+                {"grpc_port", "GRPCThreads"},
+                {"prometheus.port", "PrometheusThreads"}
+            };
+            auto it = metric_map.find(name);
+            if (it == metric_map.end())
+                return nullptr;
+            else
+                return it->second;
+        };
+
+        for (const auto & server : servers_to_start_before_tables)
+        {
+            if (const auto * name = get_metric_name(server.getPortName()))
+                new_values[name] = server.currentThreads();
+        }
+
+        for (const auto & server : servers)
+        {
+            if (const auto * name = get_metric_name(server.getPortName()))
+                new_values[name] = server.currentThreads();
+        }
     }
 
 #if USE_JEMALLOC && JEMALLOC_VERSION_MAJOR >= 4
@@ -386,7 +421,7 @@ void AsynchronousMetrics::update()
     /// Add more metrics as you wish.
 
     // Log the new metrics.
-    if (auto log = context.getAsynchronousMetricLog())
+    if (auto log = global_context.getAsynchronousMetricLog())
     {
         log->addValues(new_values);
     }

--- a/src/Interpreters/AsynchronousMetrics.h
+++ b/src/Interpreters/AsynchronousMetrics.h
@@ -13,9 +13,10 @@ namespace DB
 {
 
 class Context;
+class ProtocolServerAdapter;
 
-typedef double AsynchronousMetricValue;
-typedef std::unordered_map<std::string, AsynchronousMetricValue> AsynchronousMetricValues;
+using AsynchronousMetricValue = double;
+using AsynchronousMetricValues = std::unordered_map<std::string, AsynchronousMetricValue>;
 
 
 /** Periodically (by default, each minute, starting at 30 seconds offset)
@@ -28,22 +29,34 @@ public:
     // The default value of update_period_seconds is for ClickHouse-over-YT
     // in Arcadia -- it uses its own server implementation that also uses these
     // metrics.
-    AsynchronousMetrics(Context & context_, int update_period_seconds = 60)
-        : context(context_),
-          update_period(update_period_seconds),
-          thread([this] { run(); })
+    AsynchronousMetrics(
+        Context & global_context_,
+        int update_period_seconds,
+        const std::vector<ProtocolServerAdapter> & servers_to_start_before_tables_,
+        const std::vector<ProtocolServerAdapter> & servers_)
+        : global_context(global_context_)
+        , update_period(update_period_seconds)
+        , servers_to_start_before_tables(servers_to_start_before_tables_)
+        , servers(servers_)
     {
     }
 
     ~AsynchronousMetrics();
 
+    /// Separate method allows to initialize the `servers` variable beforehand.
+    void start()
+    {
+        thread = std::make_unique<ThreadFromGlobalPool>([this] { run(); });
+    }
 
     /// Returns copy of all values.
     AsynchronousMetricValues getValues() const;
 
 private:
-    Context & context;
+    Context & global_context;
     const std::chrono::seconds update_period;
+    const std::vector<ProtocolServerAdapter> & servers_to_start_before_tables;
+    const std::vector<ProtocolServerAdapter> & servers;
 
     mutable std::mutex mutex;
     std::condition_variable wait_cond;
@@ -54,7 +67,7 @@ private:
     MemoryStatisticsOS memory_stat;
 #endif
 
-    ThreadFromGlobalPool thread;
+    std::unique_ptr<ThreadFromGlobalPool> thread;
 
     void run();
     void update();

--- a/src/Server/GRPCServer.h
+++ b/src/Server/GRPCServer.h
@@ -35,6 +35,9 @@ public:
     /// Returns the number of currently handled connections.
     size_t currentConnections() const;
 
+    /// Returns the number of current threads.
+    size_t currentThreads() const { return currentConnections(); }
+
 private:
     using GRPCService = clickhouse::grpc::ClickHouse::AsyncService;
     class Runner;

--- a/src/Server/ProtocolServerAdapter.cpp
+++ b/src/Server/ProtocolServerAdapter.cpp
@@ -17,14 +17,15 @@ public:
     void start() override { tcp_server->start(); }
     void stop() override { tcp_server->stop(); }
     size_t currentConnections() const override { return tcp_server->currentConnections(); }
+    size_t currentThreads() const override { return tcp_server->currentThreads(); }
 
 private:
     std::unique_ptr<Poco::Net::TCPServer> tcp_server;
 };
 
-ProtocolServerAdapter::ProtocolServerAdapter(std::unique_ptr<Poco::Net::TCPServer> tcp_server_)
+ProtocolServerAdapter::ProtocolServerAdapter(const char * port_name_, std::unique_ptr<Poco::Net::TCPServer> tcp_server_)
+    : port_name(port_name_), impl(std::make_unique<TCPServerAdapterImpl>(std::move(tcp_server_)))
 {
-    impl = std::make_unique<TCPServerAdapterImpl>(std::move(tcp_server_));
 }
 
 #if USE_GRPC
@@ -37,14 +38,15 @@ public:
     void start() override { grpc_server->start(); }
     void stop() override { grpc_server->stop(); }
     size_t currentConnections() const override { return grpc_server->currentConnections(); }
+    size_t currentThreads() const override { return grpc_server->currentThreads(); }
 
 private:
     std::unique_ptr<GRPCServer> grpc_server;
 };
 
-ProtocolServerAdapter::ProtocolServerAdapter(std::unique_ptr<GRPCServer> grpc_server_)
+ProtocolServerAdapter::ProtocolServerAdapter(const char * port_name_, std::unique_ptr<GRPCServer> grpc_server_)
+    : port_name(port_name_), impl(std::make_unique<GRPCServerAdapterImpl>(std::move(grpc_server_)))
 {
-    impl = std::make_unique<GRPCServerAdapterImpl>(std::move(grpc_server_));
 }
 #endif
 }

--- a/src/Server/ProtocolServerAdapter.h
+++ b/src/Server/ProtocolServerAdapter.h
@@ -5,6 +5,7 @@
 #endif
 
 #include <memory>
+#include <string>
 
 namespace Poco::Net { class TCPServer; }
 
@@ -16,16 +17,14 @@ class GRPCServer;
 /// no matter what type it has (HTTPServer, TCPServer, MySQLServer, GRPCServer, ...).
 class ProtocolServerAdapter
 {
+    friend class ProtocolServers;
 public:
-    ProtocolServerAdapter() {}
     ProtocolServerAdapter(ProtocolServerAdapter && src) = default;
     ProtocolServerAdapter & operator =(ProtocolServerAdapter && src) = default;
-    ~ProtocolServerAdapter() {}
-
-    ProtocolServerAdapter(std::unique_ptr<Poco::Net::TCPServer> tcp_server_);
+    ProtocolServerAdapter(const char * port_name_, std::unique_ptr<Poco::Net::TCPServer> tcp_server_);
 
 #if USE_GRPC
-    ProtocolServerAdapter(std::unique_ptr<GRPCServer> grpc_server_);
+    ProtocolServerAdapter(const char * port_name_, std::unique_ptr<GRPCServer> grpc_server_);
 #endif
 
     /// Starts the server. A new thread will be created that waits for and accepts incoming connections.
@@ -37,6 +36,11 @@ public:
     /// Returns the number of currently handled connections.
     size_t currentConnections() const { return impl->currentConnections(); }
 
+    /// Returns the number of current threads.
+    size_t currentThreads() const { return impl->currentThreads(); }
+
+    const std::string & getPortName() const { return port_name; }
+
 private:
     class Impl
     {
@@ -45,10 +49,12 @@ private:
         virtual void start() = 0;
         virtual void stop() = 0;
         virtual size_t currentConnections() const = 0;
+        virtual size_t currentThreads() const = 0;
     };
     class TCPServerAdapterImpl;
     class GRPCServerAdapterImpl;
 
+    std::string port_name;
     std::unique_ptr<Impl> impl;
 };
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Export asynchronous metrics of all servers current threads. It's useful to track down issues like https://github.com/ClickHouse-Extras/poco/pull/28

Detailed description / Documentation draft:

None.