### PR TITLE
Fix 'optimize_redundant_functions_in_order_by'

### DIFF
--- a/src/Interpreters/RedundantFunctionsInOrderByVisitor.h
+++ b/src/Interpreters/RedundantFunctionsInOrderByVisitor.h
@@ -5,6 +5,7 @@
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTOrderByElement.h>
 #include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ASTExpressionList.h>
 
 namespace DB
 {
@@ -75,7 +76,8 @@ public:
 
     static bool needChildVisit(const ASTPtr & node, const ASTPtr &)
     {
-        return node->as<ASTFunction>();
+        /// Visit functions and their arguments, that are stored in ASTExpressionList.
+        return node->as<ASTFunction>() || node->as<ASTExpressionList>();
     }
 };
 

--- a/tests/queries/0_stateless/01323_redundant_functions_in_order_by.reference
+++ b/tests/queries/0_stateless/01323_redundant_functions_in_order_by.reference
@@ -63,7 +63,9 @@ SELECT
     key,
     a
 FROM test
-ORDER BY key ASC
+ORDER BY
+    key ASC,
+    exp(key + a) ASC
 [0,1,2]
 [0,1,2]
 [0,1,2]

--- a/tests/queries/0_stateless/01593_functions_in_order_by.reference
+++ b/tests/queries/0_stateless/01593_functions_in_order_by.reference
@@ -1,0 +1,14 @@
+SELECT
+    msg,
+    toDateTime(intDiv(ms, 1000)) AS time
+FROM 
+(
+    SELECT
+        \'hello\' AS msg,
+        toUInt64(t) * 1000 AS ms
+    FROM generateRandom(\'t DateTime\')
+    LIMIT 10
+)
+ORDER BY
+    msg ASC,
+    time ASC

--- a/tests/queries/0_stateless/01593_functions_in_order_by.sql
+++ b/tests/queries/0_stateless/01593_functions_in_order_by.sql
@@ -1,0 +1,11 @@
+EXPLAIN SYNTAX
+SELECT msg, toDateTime(intDiv(ms, 1000)) AS time
+FROM 
+(
+    SELECT
+        'hello' AS msg,
+        toUInt64(t) * 1000 AS ms
+    FROM generateRandom('t DateTime')
+    LIMIT 10
+)
+ORDER BY msg, time;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `ORDER BY` with enabled setting `optimize_redundant_functions_in_order_by`.

Fixes #17392.