### PR TITLE
More accurate mark cache size calculation

### DIFF
--- a/src/Storages/MarkCache.h
+++ b/src/Storages/MarkCache.h
@@ -21,10 +21,12 @@ namespace DB
 /// Estimate of number of bytes in cache for marks.
 struct MarksWeightFunction
 {
+    /// We spent additional bytes on key in hashmap, linked lists, shared pointers, etc ...
+    static constexpr size_t MARK_CACHE_OVERHEAD = 128;
+
     size_t operator()(const MarksInCompressedFile & marks) const
     {
-        /// NOTE Could add extra 100 bytes for overhead of std::vector, cache structures and allocator.
-        return marks.size() * sizeof(MarkInCompressedFile);
+        return marks.size() * sizeof(MarkInCompressedFile) + MARK_CACHE_OVERHEAD;
     }
 };
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bug when mark cache size was underestimated by clickhouse. It may happen when there are a lot of tiny files with marks.