### PR TITLE
Fix data race on global BlockStreamProfileInfo in PullingAsyncPipelineExecutor

### DIFF
--- a/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
+++ b/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
@@ -220,9 +220,15 @@ Block PullingAsyncPipelineExecutor::getExtremesBlock()
 
 BlockStreamProfileInfo & PullingAsyncPipelineExecutor::getProfileInfo()
 {
+    if (lazy_format)
+        return lazy_format->getProfileInfo();
+
     static BlockStreamProfileInfo profile_info;
-    return lazy_format ? lazy_format->getProfileInfo()
-                       : profile_info;
+    static std::once_flag flag;
+    /// Calculate rows before limit here to avoid race.
+    std::call_once(flag, []() { profile_info.getRowsBeforeLimit(); });
+
+    return profile_info;
 }
 
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

