### PR TITLE
Publish list-versions.tsv on the website

### DIFF
--- a/docs/tools/build.py
+++ b/docs/tools/build.py
@@ -202,7 +202,11 @@ def build(args):
 
 if __name__ == '__main__':
     os.chdir(os.path.join(os.path.dirname(__file__), '..'))
-    website_dir = os.path.join('..', 'website')
+
+    # A root path to ClickHouse source code.
+    src_dir = '..'
+
+    website_dir = os.path.join(src_dir, 'website')
 
     arg_parser = argparse.ArgumentParser()
     arg_parser.add_argument('--lang', default='en,es,fr,ru,zh,ja,tr,fa')
@@ -210,6 +214,7 @@ if __name__ == '__main__':
     arg_parser.add_argument('--docs-dir', default='.')
     arg_parser.add_argument('--theme-dir', default=website_dir)
     arg_parser.add_argument('--website-dir', default=website_dir)
+    arg_parser.add_argument('--src-dir', default=src_dir)
     arg_parser.add_argument('--blog-dir', default=os.path.join(website_dir, 'blog'))
     arg_parser.add_argument('--output-dir', default='build')
     arg_parser.add_argument('--enable-stable-releases', action='store_true')

--- a/docs/tools/website.py
+++ b/docs/tools/website.py
@@ -145,13 +145,19 @@ def build_website(args):
             'public',
             'node_modules',
             'templates',
-            'locale'
+            'locale',
+            '.gitkeep'
         )
     )
+
+    # This file can be requested to check for available ClickHouse releases.
+    shutil.copy2(
+        os.path.join(args.src_dir, 'utils', 'list-versions', 'version_date.tsv'),
+        os.path.join(args.output_dir, 'data', 'version_date.tsv'))
+
     shutil.copy2(
         os.path.join(args.website_dir, 'js', 'embedd.min.js'),
-        os.path.join(args.output_dir, 'js', 'embedd.min.js')
-    )
+        os.path.join(args.output_dir, 'js', 'embedd.min.js'))
 
     for root, _, filenames in os.walk(args.output_dir):
         for filename in filenames:

--- a/website/data/.gitkeep
+++ b/website/data/.gitkeep
@@ -1,0 +1,1 @@
+# This directory will contain miscellaneous data files on ClickHouse website


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add machine readable file `https://clickhouse.tech/data/version_date.tsv` on the website. It can be queried directly with table function `url`. In contrast to [raw.githubusercontent.com](https://raw.githubusercontent.com/ClickHouse/ClickHouse/master/utils/list-versions/version_date.tsv), IPv6 is supported as well (it is important for querying from IPv6-only datacenter infrastructure when DNS64/NAT64 is unavailable).
