### PR TITLE
Alias column on alias column

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.h
+++ b/src/Interpreters/InterpreterSelectQuery.h
@@ -153,6 +153,8 @@ private:
       */
     void initSettings();
 
+    void getDependentAliasColumns(const std::string & column, std::map<std::string, ASTPtr> & required_alias_columns);
+
     TreeRewriterResultPtr syntax_analyzer_result;
     std::unique_ptr<SelectQueryExpressionAnalyzer> query_analyzer;
     SelectQueryInfo query_info;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Query alias column without specifying all dependent alias columns.


Detailed description / Documentation draft:
When users create alias column (derived alias column) on alias column (base alias column), users can't query the derived alias column alone for now. Users instead need specify all of the dependent alias columns explicitly in the query. 
For instance, `SELECT alias_derived FROM alias_columns` in the following example will report error in the current code base: `DB::Exception: Missing columns: 'alias_base' while processing query: ...`. With the enhancement, users will be able to run this query.

```
CREATE TABLE alias_columns (s String) ENGINE=MergeTree() ORDER BY s;
INSERT INTO alias_columns (s) VALUES('k=v,k1=v1');
ALTER TABLE alias_columns ADD COLUMN alias_base Array(Array(String)) ALIAS extractAllGroups(s, '("[^"]+"|\\w)=("[^"]+"|\\w+)');
ALTER TABLE alias_columns ADD COLUMN alias_derived String ALIAS alias_base[1][1];
SELECT alias_derived FROM alias_columns;
```

Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
