### PR TITLE
Fix toUnixTimestamp(Date()) error (use type name not column type name)

### DIFF
--- a/src/Functions/FunctionsConversion.h
+++ b/src/Functions/FunctionsConversion.h
@@ -117,7 +117,7 @@ struct ConvertImpl
         if (std::is_same_v<Name, NameToUnixTimestamp>)
         {
             if (isDate(named_from.type))
-                throw Exception("Illegal column " + named_from.column->getName() + " of first argument of function " + Name::name,
+                throw Exception("Illegal type " + named_from.type->getName() + " of first argument of function " + Name::name,
                     ErrorCodes::ILLEGAL_COLUMN);
         }
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Was:

    Code: 44. DB::Exception: Received from localhost:9000. DB::Exception: Illegal column UInt16 of first argument of function toUnixTimestamp: While processing toUnixTimestamp(today()).

Now:

    Code: 44. DB::Exception: Received from localhost:9000. DB::Exception: Illegal type Date of first argument of function toUnixTimestamp: While processing toUnixTimestamp(today()).

Fixes: #17376
Cc: @den-crane 
Cc: @alexey-milovidov 

P.S. since original PR marked as backward incompatible and there was no release since then, mark this as "Not for changelog"