### PR TITLE
Add remerge_sort_lowered_memory_bytes_ratio setting

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -255,6 +255,7 @@ class IColumn;
     M(OverflowMode, sort_overflow_mode, OverflowMode::THROW, "What to do when the limit is exceeded.", 0) \
     M(UInt64, max_bytes_before_external_sort, 0, "", 0) \
     M(UInt64, max_bytes_before_remerge_sort, 1000000000, "In case of ORDER BY with LIMIT, when memory usage is higher than specified threshold, perform additional steps of merging blocks before final merge to keep just top LIMIT rows.", 0) \
+    M(Float, remerge_sort_lowered_memory_bytes_ratio, 2., "If memory usage after remerge does not reduced by this ratio, remerge will be disabled.", 0) \
     \
     M(UInt64, max_result_rows, 0, "Limit on result size in rows. Also checked for intermediate data sent from remote servers.", 0) \
     M(UInt64, max_result_bytes, 0, "Limit on result size in bytes (uncompressed). Also checked for intermediate data sent from remote servers.", 0) \

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1782,7 +1782,7 @@ void InterpreterSelectQuery::executeOrder(QueryPlan & query_plan, InputOrderInfo
     auto merge_sorting_step = std::make_unique<MergeSortingStep>(
             query_plan.getCurrentDataStream(),
             output_order_descr, settings.max_block_size, limit,
-            settings.max_bytes_before_remerge_sort,
+            settings.max_bytes_before_remerge_sort, settings.remerge_sort_lowered_memory_bytes_ratio,
             settings.max_bytes_before_external_sort, context->getTemporaryVolume(),
             settings.min_free_disk_space_for_temporary_data);
 

--- a/src/Interpreters/MergeJoin.cpp
+++ b/src/Interpreters/MergeJoin.cpp
@@ -516,7 +516,7 @@ void MergeJoin::mergeInMemoryRightBlocks()
     pipeline.init(std::move(source));
 
     /// TODO: there should be no split keys by blocks for RIGHT|FULL JOIN
-    pipeline.addTransform(std::make_shared<MergeSortingTransform>(pipeline.getHeader(), right_sort_description, max_rows_in_right_block, 0, 0, 0, nullptr, 0));
+    pipeline.addTransform(std::make_shared<MergeSortingTransform>(pipeline.getHeader(), right_sort_description, max_rows_in_right_block, 0, 0, 0, 0, nullptr, 0));
 
     auto sorted_input = PipelineExecutingBlockInputStream(std::move(pipeline));
 

--- a/src/Processors/QueryPlan/MergeSortingStep.cpp
+++ b/src/Processors/QueryPlan/MergeSortingStep.cpp
@@ -28,6 +28,7 @@ MergeSortingStep::MergeSortingStep(
     size_t max_merged_block_size_,
     UInt64 limit_,
     size_t max_bytes_before_remerge_,
+    double remerge_lowered_memory_bytes_ratio_,
     size_t max_bytes_before_external_sort_,
     VolumePtr tmp_volume_,
     size_t min_free_disk_space_)
@@ -36,6 +37,7 @@ MergeSortingStep::MergeSortingStep(
     , max_merged_block_size(max_merged_block_size_)
     , limit(limit_)
     , max_bytes_before_remerge(max_bytes_before_remerge_)
+    , remerge_lowered_memory_bytes_ratio(remerge_lowered_memory_bytes_ratio_)
     , max_bytes_before_external_sort(max_bytes_before_external_sort_), tmp_volume(tmp_volume_)
     , min_free_disk_space(min_free_disk_space_)
 {
@@ -64,6 +66,7 @@ void MergeSortingStep::transformPipeline(QueryPipeline & pipeline)
         return std::make_shared<MergeSortingTransform>(
                 header, description, max_merged_block_size, limit,
                 max_bytes_before_remerge / pipeline.getNumStreams(),
+                remerge_lowered_memory_bytes_ratio,
                 max_bytes_before_external_sort,
                 tmp_volume,
                 min_free_disk_space);

--- a/src/Processors/QueryPlan/MergeSortingStep.h
+++ b/src/Processors/QueryPlan/MergeSortingStep.h
@@ -17,6 +17,7 @@ public:
             size_t max_merged_block_size_,
             UInt64 limit_,
             size_t max_bytes_before_remerge_,
+            double remerge_lowered_memory_bytes_ratio_,
             size_t max_bytes_before_external_sort_,
             VolumePtr tmp_volume_,
             size_t min_free_disk_space_);
@@ -36,6 +37,7 @@ private:
     UInt64 limit;
 
     size_t max_bytes_before_remerge;
+    double remerge_lowered_memory_bytes_ratio;
     size_t max_bytes_before_external_sort;
     VolumePtr tmp_volume;
     size_t min_free_disk_space;

--- a/src/Processors/Transforms/MergeSortingTransform.cpp
+++ b/src/Processors/Transforms/MergeSortingTransform.cpp
@@ -25,7 +25,6 @@ namespace ErrorCodes
 {
     extern const int NOT_ENOUGH_SPACE;
 }
-class MergeSorter;
 
 
 class BufferingToFileTransform : public IAccumulatingTransform
@@ -96,10 +95,12 @@ MergeSortingTransform::MergeSortingTransform(
     const SortDescription & description_,
     size_t max_merged_block_size_, UInt64 limit_,
     size_t max_bytes_before_remerge_,
+    double remerge_lowered_memory_bytes_ratio_,
     size_t max_bytes_before_external_sort_, VolumePtr tmp_volume_,
     size_t min_free_disk_space_)
     : SortingTransform(header, description_, max_merged_block_size_, limit_)
     , max_bytes_before_remerge(max_bytes_before_remerge_)
+    , remerge_lowered_memory_bytes_ratio(remerge_lowered_memory_bytes_ratio_)
     , max_bytes_before_external_sort(max_bytes_before_external_sort_), tmp_volume(tmp_volume_)
     , min_free_disk_space(min_free_disk_space_) {}
 
@@ -268,9 +269,12 @@ void MergeSortingTransform::remerge()
 
     LOG_DEBUG(log, "Memory usage is lowered from {} to {}", ReadableSize(sum_bytes_in_blocks), ReadableSize(new_sum_bytes_in_blocks));
 
-    /// If the memory consumption was not lowered enough - we will not perform remerge anymore. 2 is a guess.
-    if (new_sum_bytes_in_blocks * 2 > sum_bytes_in_blocks)
+    /// If the memory consumption was not lowered enough - we will not perform remerge anymore.
+    if (remerge_lowered_memory_bytes_ratio && (new_sum_bytes_in_blocks * remerge_lowered_memory_bytes_ratio > sum_bytes_in_blocks))
+    {
         remerge_is_useful = false;
+        LOG_DEBUG(log, "Re-merging is not useful (memory usage was not lowered by remerge_sort_lowered_memory_bytes_ratio={})", remerge_lowered_memory_bytes_ratio);
+    }
 
     chunks = std::move(new_chunks);
     sum_rows_in_blocks = new_sum_rows_in_blocks;

--- a/src/Processors/Transforms/MergeSortingTransform.h
+++ b/src/Processors/Transforms/MergeSortingTransform.h
@@ -22,6 +22,7 @@ public:
                           const SortDescription & description_,
                           size_t max_merged_block_size_, UInt64 limit_,
                           size_t max_bytes_before_remerge_,
+                          double remerge_lowered_memory_bytes_ratio_,
                           size_t max_bytes_before_external_sort_, VolumePtr tmp_volume_,
                           size_t min_free_disk_space_);
 
@@ -36,6 +37,7 @@ protected:
 
 private:
     size_t max_bytes_before_remerge;
+    double remerge_lowered_memory_bytes_ratio;
     size_t max_bytes_before_external_sort;
     VolumePtr tmp_volume;
     size_t min_free_disk_space;

--- a/tests/queries/0_stateless/01600_remerge_sort_lowered_memory_bytes_ratio.sql
+++ b/tests/queries/0_stateless/01600_remerge_sort_lowered_memory_bytes_ratio.sql
@@ -1,0 +1,17 @@
+-- Check remerge_sort_lowered_memory_bytes_ratio setting
+
+set max_memory_usage='4Gi';
+-- enter remerge once limit*2 is reached
+set max_bytes_before_remerge_sort='10Mi';
+-- more blocks
+set max_block_size=40960;
+
+-- default 2, slightly not enough:
+--
+--     MergeSortingTransform: Memory usage is lowered from 1.91 GiB to 980.00 MiB
+--     MergeSortingTransform: Re-merging is not useful (memory usage was not lowered by remerge_sort_lowered_memory_bytes_ratio=2.0)
+select number k, repeat(toString(number), 101) v1, repeat(toString(number), 102) v2, repeat(toString(number), 103) v3 from numbers(toUInt64(10e6)) order by k limit 400e3 format Null; -- { serverError 241 }
+select number k, repeat(toString(number), 101) v1, repeat(toString(number), 102) v2, repeat(toString(number), 103) v3 from numbers(toUInt64(10e6)) order by k limit 400e3 settings remerge_sort_lowered_memory_bytes_ratio=2. format Null; -- { serverError 241 }
+
+-- 1.91/0.98=1.94 is good
+select number k, repeat(toString(number), 101) v1, repeat(toString(number), 102) v2, repeat(toString(number), 103) v3 from numbers(toUInt64(10e6)) order by k limit 400e3 settings remerge_sort_lowered_memory_bytes_ratio=1.9 format Null;


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add `remerge_sort_lowered_memory_bytes_ratio` setting (If memory usage after remerge does not reduced by this ratio, remerge will be disabled)

Sometimes default ratio is not good enough (2), since it depends on:
- size of LIMIT
- max_memory_usage
- ...

So add a separate setting for it.

But note that it make sense to set remerge_sort_lowered_memory_bytes_ratio only in range (1, 2]
Since <= 1 will just use more CPU, and > 2 will use more RAM and will unlikely be faster.