### PR TITLE
Fix multiline queries with comments in interactive mode

### DIFF
--- a/base/common/LineReader.cpp
+++ b/base/common/LineReader.cpp
@@ -127,7 +127,7 @@ String LineReader::readLine(const String & first_prompt, const String & second_p
         }
 #endif
 
-        line += (line.empty() ? "" : " ") + input;
+        line += (line.empty() ? "" : "\n") + input;
 
         if (!need_next_line)
             break;

--- a/tests/queries/0_stateless/01599_multiline_input_and_singleline_comments.sh
+++ b/tests/queries/0_stateless/01599_multiline_input_and_singleline_comments.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/expect -f
+
+log_user 0
+set timeout 5
+match_max 100000
+
+if ![info exists env(CLICKHOUSE_PORT_TCP)] {set env(CLICKHOUSE_PORT_TCP) 9000}
+
+spawn clickhouse-client --multiline --port "$env(CLICKHOUSE_PORT_TCP)"
+expect ":) "
+
+# Make a query
+send -- "SELECT 1\r"
+expect ":-] "
+send -- "-- xxx\r"
+expect ":-] "
+send -- ", 2\r"
+expect ":-] "
+send -- ";\r"
+
+expect "│ 1 │ 2 │"
+expect ":) "
+
+send -- "\4"
+expect eof


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
When clickhouse-client is used in interactive mode with multiline queries, single line comment was erronously extended till the end of query. This fixes #13654.
