### PR TITLE
IP dictionary works with aliased types `IPv4` and `IPv6` (close #6804)

### DIFF
--- a/src/Dictionaries/IPAddressDictionary.cpp
+++ b/src/Dictionaries/IPAddressDictionary.cpp
@@ -112,9 +112,12 @@ static void validateKeyTypes(const DataTypes & key_types)
     if (key_types.empty() || key_types.size() > 2)
         throw Exception{"Expected a single IP address or IP with mask", ErrorCodes::TYPE_MISMATCH};
 
-    const auto & actual_type = key_types[0]->getName();
-    if (actual_type != "UInt32" && actual_type != "FixedString(16)")
-        throw Exception{"Key does not match, expected either UInt32 or FixedString(16)", ErrorCodes::TYPE_MISMATCH};
+    const auto * key_ipv4type = typeid_cast<const DataTypeUInt32 *>(key_types[0].get());
+    const auto * key_ipv6type = typeid_cast<const DataTypeFixedString *>(key_types[0].get());
+
+    if (key_ipv4type == nullptr && (key_ipv6type == nullptr || key_ipv6type->getN() != 16))
+        throw Exception{"Key does not match, expected either `IPv4` (`UInt32`) or `IPv6` (`FixedString(16)`)",
+                        ErrorCodes::TYPE_MISMATCH};
 
     if (key_types.size() > 1)
     {

--- a/tests/queries/0_stateless/01018_ip_dictionary.reference
+++ b/tests/queries/0_stateless/01018_ip_dictionary.reference
@@ -50,6 +50,8 @@
 1
 1
 1
+1
+1
 ***ipv4 trie dict mask***
 1
 1

--- a/tests/queries/0_stateless/01018_ip_dictionary.sql
+++ b/tests/queries/0_stateless/01018_ip_dictionary.sql
@@ -95,6 +95,10 @@ SELECT 11212 == dictGetUInt32('database_for_dict.dict_ipv4_trie', 'asn', tuple(I
 
 SELECT 11211 == dictGetUInt32('database_for_dict.dict_ipv4_trie', 'asn', tuple(IPv4StringToNum('202.79.32.2')));
 
+-- check that dictionary works with aliased types `IPv4` and `IPv6`
+SELECT 11211 == dictGetUInt32('database_for_dict.dict_ipv4_trie', 'asn', tuple(toIPv4('202.79.32.2')));
+SELECT 11212 == dictGetUInt32('database_for_dict.dict_ipv4_trie', 'asn', tuple(toIPv6('::ffff:101.79.55.22')));
+
 CREATE TABLE database_for_dict.table_from_ipv4_trie_dict
 (
   prefix String,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

* IP Dictionary supports `IPv4` / `IPv6` types directly.
