### PR TITLE
Allow locahost optimization for clusters with non default_database

### DIFF
--- a/src/Interpreters/Cluster.cpp
+++ b/src/Interpreters/Cluster.cpp
@@ -31,7 +31,7 @@ namespace
 /// Default shard weight.
 constexpr UInt32 default_weight = 1;
 
-inline bool isLocalImpl(const Cluster::Address & address, const Poco::Net::SocketAddress & resolved_address, UInt16 clickhouse_port)
+inline bool isLocalImpl(const Poco::Net::SocketAddress & resolved_address, UInt16 clickhouse_port)
 {
     /// If there is replica, for which:
     /// - its port is the same that the server is listening;
@@ -39,11 +39,8 @@ inline bool isLocalImpl(const Cluster::Address & address, const Poco::Net::Socke
     /// then we must go to this shard without any inter-process communication.
     ///
     /// * - this criteria is somewhat approximate.
-    ///
-    /// Also, replica is considered non-local, if it has default database set
-    ///  (only reason is to avoid query rewrite).
 
-    return address.default_database.empty() && isLocalAddress(resolved_address, clickhouse_port);
+    return isLocalAddress(resolved_address, clickhouse_port);
 }
 
 void concatInsertPath(std::string & insert_path, const std::string & dir_name)
@@ -76,7 +73,7 @@ std::optional<Poco::Net::SocketAddress> Cluster::Address::getResolvedAddress() c
 bool Cluster::Address::isLocal(UInt16 clickhouse_port) const
 {
     if (auto resolved = getResolvedAddress())
-        return isLocalImpl(*this, *resolved, clickhouse_port);
+        return isLocalImpl(*resolved, clickhouse_port);
     return false;
 }
 


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow locahost optimization for clusters with non default_database

Detailed description / Documentation draft:
Localhost optimization is an optimization that allows to avoid sending
query over network, if the address is local (i.e. when the query will be
sent to the same clichouse-server as the initiator).

This localhost optimization allows to significantly increase QPS, ~3x
times (490 vs 167).

In e0f3cbb432d313b2d32bd572b2bb92fff12b3168 ("Added optional
'default_database' parameter for Cluster (allow Distributed tables to
connect to different databases on different shards/replicas)
[#METR-22462]") the default_database was added, and also that patch
disables localhost optimization in case of non default default_database.

While there is no reason for this, since even in case of
"cross-replication" (when multiple servers may run on the same host)
they will have different port, and port was always checked in
isLocalAddress() (the first commit that contains it, that I found, is
1c86e582c11a37cd3df1fb83d8696a772e5cf0b9 ("Decreased warning threshold
[#MOBMET-3248]"), although the subject is not reflect the change, but
anyway this is enough, since this commit is older then the commit that
introduces default_database - e0f3cbb432d313b2d32bd572b2bb92fff12b3168).

As for the comment about:

    Also, replica is considered non-local, if it has default database set
     (only reason is to avoid query rewrite).

This does not seems related, since you cannot run query w/o specifying
database for Distributed queries, and only there query rewrite is
performed.

And AFAIR there are enough tests for distributed SELECT and INSERT to
show possible issues, so let's check this on CI.

Fixes: #14099