### PR TITLE
add integration test: ClickHouse killed while insert for MaterializeMySQL ENGINE

### DIFF
--- a/tests/integration/test_materialize_mysql_database/materialize_with_ddl.py
+++ b/tests/integration/test_materialize_mysql_database/materialize_with_ddl.py
@@ -652,3 +652,28 @@ def mysql_kill_sync_thread_restore_test(clickhouse_node, mysql_node, service_nam
     mysql_node.query("DROP DATABASE test_database")
 
 
+def clickhouse_killed_while_insert(clickhouse_node, mysql_node, service_name):
+    mysql_node.query("CREATE DATABASE kill_clickhouse_while_insert")
+    mysql_node.query("CREATE TABLE kill_clickhouse_while_insert.test ( `id` int(11) NOT NULL, PRIMARY KEY (`id`) ) ENGINE=InnoDB;")
+    clickhouse_node.query("CREATE DATABASE kill_clickhouse_while_insert ENGINE = MaterializeMySQL('{}:3306', 'kill_clickhouse_while_insert', 'root', 'clickhouse')".format(service_name))
+    check_query(clickhouse_node, "SHOW TABLES FROM kill_clickhouse_while_insert FORMAT TSV", 'test\n')
+
+    def insert(num):
+        for i in range(num):
+            query = "INSERT INTO kill_clickhouse_while_insert.test VALUES({v});".format( v = i + 1 )
+            mysql_node.query(query)
+
+    t = threading.Thread(target=insert, args=(1000,))
+    t.start()
+    
+    # TODO: add clickhouse_node.restart_clickhouse(20, kill=False) test
+    clickhouse_node.restart_clickhouse(20, kill=True)
+    t.join()
+
+    result = mysql_node.query_and_get_data("SELECT COUNT(1) FROM kill_clickhouse_while_insert.test")
+    for row in result:
+        res = str(row[0]) + '\n'
+        check_query(clickhouse_node, "SELECT count() FROM kill_clickhouse_while_insert.test FORMAT TSV", res)
+
+    mysql_node.query("DROP DATABASE kill_clickhouse_while_insert")
+    clickhouse_node.query("DROP DATABASE kill_clickhouse_while_insert")

--- a/tests/integration/test_materialize_mysql_database/test.py
+++ b/tests/integration/test_materialize_mysql_database/test.py
@@ -210,3 +210,11 @@ def test_mysql_kill_sync_thread_restore_5_7(started_cluster, started_mysql_5_7):
 
 def test_mysql_kill_sync_thread_restore_8_0(started_cluster, started_mysql_8_0):
     materialize_with_ddl.mysql_kill_sync_thread_restore_test(clickhouse_node, started_mysql_8_0, "mysql8_0")
+
+
+def test_clickhouse_killed_while_insert_5_7(started_cluster, started_mysql_5_7):
+    materialize_with_ddl.clickhouse_killed_while_insert(clickhouse_node, started_mysql_5_7, "mysql1")
+
+def test_clickhouse_killed_while_insert_8_0(started_cluster, started_mysql_8_0):
+    materialize_with_ddl.clickhouse_killed_while_insert(clickhouse_node, started_mysql_8_0, "mysql8_0")
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add an integration test: ClickHouse killed while insert for MaterializeMySQL ENGINE
