### PR TITLE
Fix race on DDLWorker::is_circular_replicated

### DIFF
--- a/src/Interpreters/DDLWorker.h
+++ b/src/Interpreters/DDLWorker.h
@@ -104,7 +104,6 @@ private:
     void attachToThreadGroup();
 
 private:
-    std::atomic<bool> is_circular_replicated = false;
     Context context;
     Poco::Logger * log;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
In might be determined incorrectly if cluster is circular- (cross-) replicated or not when executing `ON CLUSTER` query due to race condition when `pool_size` > 1. It's fixed.
