### PR TITLE
In mysqlxx::Pool: fix for reconnection problem

### DIFF
--- a/base/mysqlxx/Connection.cpp
+++ b/base/mysqlxx/Connection.cpp
@@ -104,6 +104,11 @@ void Connection::connect(const char* db,
     if (mysql_options(driver.get(), MYSQL_OPT_LOCAL_INFILE, &enable_local_infile_arg))
         throw ConnectionFailed(errorMessage(driver.get()), mysql_errno(driver.get()));
 
+    /// Enables auto-reconnect.
+    bool reconnect = true;
+    if (mysql_options(driver.get(), MYSQL_OPT_RECONNECT, reinterpret_cast<const char *>(&reconnect)))
+        throw ConnectionFailed(errorMessage(driver.get()), mysql_errno(driver.get()));
+
     /// Specifies particular ssl key and certificate if it needs
     if (mysql_ssl_set(driver.get(), ifNotEmpty(ssl_key), ifNotEmpty(ssl_cert), ifNotEmpty(ssl_ca), nullptr, nullptr))
         throw ConnectionFailed(errorMessage(driver.get()), mysql_errno(driver.get()));
@@ -113,11 +118,6 @@ void Connection::connect(const char* db,
 
     /// Sets UTF-8 as default encoding.
     if (mysql_set_character_set(driver.get(), "UTF8"))
-        throw ConnectionFailed(errorMessage(driver.get()), mysql_errno(driver.get()));
-
-    /// Enables auto-reconnect.
-    bool reconnect = true;
-    if (mysql_options(driver.get(), MYSQL_OPT_RECONNECT, reinterpret_cast<const char *>(&reconnect)))
         throw ConnectionFailed(errorMessage(driver.get()), mysql_errno(driver.get()));
 
     is_connected = true;

--- a/base/mysqlxx/Pool.cpp
+++ b/base/mysqlxx/Pool.cpp
@@ -211,7 +211,7 @@ void Pool::Entry::forceConnected() const
     Poco::Util::Application & app = Poco::Util::Application::instance();
 
     bool first = true;
-    while (!tryForceConnected());
+    while (!tryForceConnected())
     {
         if (first)
             first = false;

--- a/base/mysqlxx/Pool.cpp
+++ b/base/mysqlxx/Pool.cpp
@@ -240,7 +240,7 @@ void Pool::Entry::forceConnected() const
 
 bool Pool::Entry::tryForceConnected() const
 {
-    const auto mysql_driver = data->conn.getDriver();
+    auto * const mysql_driver = data->conn.getDriver();
     const auto prev_connection_id = mysql_thread_id(mysql_driver);
     if (data->conn.ping())  /// Attempts to reestablish lost connection
     {

--- a/base/mysqlxx/Pool.h
+++ b/base/mysqlxx/Pool.h
@@ -127,10 +127,7 @@ public:
         void forceConnected() const;
 
         /// Connects to database. If connection is failed then returns false.
-        bool tryForceConnected() const
-        {
-            return data->conn.ping();
-        }
+        bool tryForceConnected() const;
 
         void incrementRefCount();
         void decrementRefCount();

--- a/base/mysqlxx/tests/CMakeLists.txt
+++ b/base/mysqlxx/tests/CMakeLists.txt
@@ -1,2 +1,5 @@
 add_executable (mysqlxx_test mysqlxx_test.cpp)
 target_link_libraries (mysqlxx_test PRIVATE mysqlxx)
+
+add_executable (mysqlxx_pool_test mysqlxx_pool_test.cpp)
+target_link_libraries (mysqlxx_pool_test PRIVATE mysqlxx)

--- a/base/mysqlxx/tests/mysqlxx_pool_test.cpp
+++ b/base/mysqlxx/tests/mysqlxx_pool_test.cpp
@@ -12,11 +12,11 @@ mysqlxx::Pool::Entry getWithFailover(mysqlxx::Pool & connections_pool)
 {
     using namespace std::chrono;
 
-    constexpr size_t MAX_TRIES = 3;
+    constexpr size_t max_tries = 3;
 
     mysqlxx::Pool::Entry worker_connection;
 
-    for (size_t try_no = 1; try_no <= MAX_TRIES; ++try_no)
+    for (size_t try_no = 1; try_no <= max_tries; ++try_no)
     {
         try
         {

--- a/base/mysqlxx/tests/mysqlxx_pool_test.cpp
+++ b/base/mysqlxx/tests/mysqlxx_pool_test.cpp
@@ -1,0 +1,98 @@
+#include <mysqlxx/mysqlxx.h>
+
+#include <chrono>
+#include <iostream>
+#include <sstream>
+#include <thread>
+
+
+namespace
+{
+mysqlxx::Pool::Entry getWithFailover(mysqlxx::Pool & connections_pool)
+{
+    using namespace std::chrono;
+
+    constexpr size_t MAX_TRIES = 3;
+
+    mysqlxx::Pool::Entry worker_connection;
+
+    for (size_t try_no = 1; try_no <= MAX_TRIES; ++try_no)
+    {
+        try
+        {
+            worker_connection = connections_pool.tryGet();
+
+            if (!worker_connection.isNull())
+            {
+                return worker_connection;
+            }
+        }
+        catch (const Poco::Exception & e)
+        {
+            if (e.displayText().find("mysqlxx::Pool is full") != std::string::npos) /// NOTE: String comparison is trashy code.
+            {
+                std::cerr << e.displayText() << std::endl;
+            }
+
+            std::cerr << "Connection to " << connections_pool.getDescription() << " failed: " << e.displayText() << std::endl;
+        }
+
+        std::clog << "Connection to all replicas failed " << try_no << " times" << std::endl;
+        std::this_thread::sleep_for(1s);
+    }
+
+    std::stringstream message;
+    message << "Connections to all replicas failed: " << connections_pool.getDescription();
+
+    throw Poco::Exception(message.str());
+}
+}
+
+int main(int, char **)
+{
+    using namespace std::chrono;
+
+    const char * remote_mysql = "localhost";
+    const std::string test_query = "SHOW DATABASES";
+
+    mysqlxx::Pool mysql_conn_pool("", remote_mysql, "default", "10203040", 3306);
+
+    size_t iteration = 0;
+    while (++iteration)
+    {
+        std::clog << "Iteration: " << iteration << std::endl;
+        try
+        {
+            std::clog << "Acquiring DB connection ...";
+            mysqlxx::Pool::Entry worker = getWithFailover(mysql_conn_pool);
+            std::clog << "ok" << std::endl;
+
+            std::clog << "Preparing query (5s sleep) ...";
+            std::this_thread::sleep_for(5s);
+            mysqlxx::Query query = worker->query();
+            query << test_query;
+            std::clog << "ok" << std::endl;
+
+            std::clog << "Querying result (5s sleep) ...";
+            std::this_thread::sleep_for(5s);
+            mysqlxx::UseQueryResult result = query.use();
+            std::clog << "ok" << std::endl;
+
+            std::clog << "Fetching result data (5s sleep) ...";
+            std::this_thread::sleep_for(5s);
+            size_t rows_count = 0;
+            while (result.fetch())
+                ++rows_count;
+            std::clog << "ok" << std::endl;
+
+            std::clog << "Read " << rows_count << " rows." << std::endl;
+        }
+        catch (const Poco::Exception & e)
+        {
+            std::cerr << "Iteration FAILED:\n" << e.displayText() << std::endl;
+        }
+
+        std::clog << "====================" << std::endl;
+        std::this_thread::sleep_for(3s);
+    }
+}

--- a/base/mysqlxx/tests/mysqlxx_pool_test.cpp
+++ b/base/mysqlxx/tests/mysqlxx_pool_test.cpp
@@ -29,7 +29,7 @@ mysqlxx::Pool::Entry getWithFailover(mysqlxx::Pool & connections_pool)
         }
         catch (const Poco::Exception & e)
         {
-            if (e.displayText().find("mysqlxx::Pool is full") != std::string::npos) /// NOTE: String comparison is trashy code.
+            if (e.displayText().find("mysqlxx::Pool is full") != std::string::npos)
             {
                 std::cerr << e.displayText() << std::endl;
             }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed problem when ClickHouse fails to resume connection to MySQL servers.


Detailed description / Documentation draft:
Under certain conditions CH may become unable to resume its connections to mysql when mysql server is used as a data source (external dictionaries, tables, etc.)