### PR TITLE
Fix: precision of readFloatTextFastImpl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 #### Bug Fix
 
+* Fix floating-point precision issues when inserting numbers such as 2.236
+
 * Fix rare silent crashes when query profiler is on and ClickHouse is installed on OS with glibc version that has (supposedly) broken asynchronous unwind tables for some functions. This fixes [#15301](https://github.com/ClickHouse/ClickHouse/issues/15301). This fixes [#13098](https://github.com/ClickHouse/ClickHouse/issues/13098). [#16846](https://github.com/ClickHouse/ClickHouse/pull/16846) ([alexey-milovidov](https://github.com/alexey-milovidov)).
 
 


### PR DESCRIPTION
Reproduce the bug: clickhouse local -S 'a Float64' -q 'select 2.236-a from table' <<<2.236

Expected result: 0

Actual result: 4.440892098500626e-16

Root Cause: The precision of readFloatTextFastImpl is inconsistent with strtod

Solution: use strtod