### PR TITLE
Disable network blocades in integration tests

### DIFF
--- a/docker/test/integration/runner/Dockerfile
+++ b/docker/test/integration/runner/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update \
     libssl-dev \
     libcurl4-openssl-dev \
     gdb \
+    moreutils \
     && rm -rf \
         /var/lib/apt/lists/* \
         /var/cache/debconf \
@@ -96,4 +97,4 @@ RUN set -x \
 VOLUME /var/lib/docker
 EXPOSE 2375
 ENTRYPOINT ["dockerd-entrypoint.sh"]
-CMD ["sh", "-c", "pytest $PYTEST_OPTS"]
+CMD ["sh", "-c", "pytest $PYTEST_OPTS 2>&1 | ts '%Y-%m-%d %H:%M:%S'"]

--- a/tests/integration/helpers/network.py
+++ b/tests/integration/helpers/network.py
@@ -129,12 +129,12 @@ class _NetworkManager:
     def add_iptables_rule(self, **kwargs):
         cmd = ['iptables', '-I', 'DOCKER-USER', '1']
         cmd.extend(self._iptables_cmd_suffix(**kwargs))
-        self._exec_run(cmd, privileged=True)
+        # self._exec_run(cmd, privileged=True)
 
     def delete_iptables_rule(self, **kwargs):
         cmd = ['iptables', '-D', 'DOCKER-USER']
         cmd.extend(self._iptables_cmd_suffix(**kwargs))
-        self._exec_run(cmd, privileged=True)
+        # self._exec_run(cmd, privileged=True)
 
     @staticmethod
     def _iptables_cmd_suffix(
@@ -168,7 +168,7 @@ class _NetworkManager:
 
         self._container = None
 
-        self._ensure_container()
+        # self._ensure_container()
 
     def _ensure_container(self):
         if self._container is None or self._container_expire_time <= time.time():


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)