### PR TITLE
Fix sequential number in TestKeeper

### DIFF
--- a/src/Common/ZooKeeper/TestKeeper.cpp
+++ b/src/Common/ZooKeeper/TestKeeper.cpp
@@ -216,7 +216,6 @@ std::pair<ResponsePtr, Undo> TestKeeperCreateRequest::process(TestKeeper::Contai
             if (is_sequential)
             {
                 auto seq_num = it->second.seq_num;
-                ++it->second.seq_num;
 
                 std::stringstream seq_num_str;      // STYLE_CHECK_ALLOW_STD_STRING_STREAM
                 seq_num_str.exceptions(std::ios::failbit);
@@ -225,18 +224,19 @@ std::pair<ResponsePtr, Undo> TestKeeperCreateRequest::process(TestKeeper::Contai
                 path_created += seq_num_str.str();
             }
 
+            /// Increment sequential number even if node is not sequential
+            ++it->second.seq_num;
+
             response.path_created = path_created;
             container.emplace(path_created, std::move(created_node));
 
-            undo = [&container, path_created, is_sequential = is_sequential, parent_path = it->first]
+            undo = [&container, path_created, parent_path = it->first]
             {
                 container.erase(path_created);
                 auto & undo_parent = container.at(parent_path);
                 --undo_parent.stat.cversion;
                 --undo_parent.stat.numChildren;
-
-                if (is_sequential)
-                    --undo_parent.seq_num;
+                --undo_parent.seq_num;
             };
 
             ++it->second.stat.cversion;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Detailed description / Documentation draft:
ZooKeeper increments sequential number on every child creation:

```
[zk: localhost:2181(CONNECTED) 13] create /test q
Created /test
[zk: localhost:2181(CONNECTED) 14] create /test/a q
Created /test/a
[zk: localhost:2181(CONNECTED) 15] create /test/b q
Created /test/b
[zk: localhost:2181(CONNECTED) 16] create -s /test/c- q
Created /test/c-0000000002
[zk: localhost:2181(CONNECTED) 17] create /test/d q
Created /test/d
[zk: localhost:2181(CONNECTED) 18] create -s /test/e- q
Created /test/e-0000000004
```
