### PR TITLE
Fix typo in alter/index docs

### DIFF
--- a/docs/en/sql-reference/statements/alter/index/index.md
+++ b/docs/en/sql-reference/statements/alter/index/index.md
@@ -14,7 +14,7 @@ The following operations are available:
 
 -   `ALTER TABLE [db.]table MATERIALIZE INDEX name IN PARTITION partition_name` - The query rebuilds the secondary index `name` in the partition `partition_name`. Implemented as a [mutation](../../../../sql-reference/statements/alter/index.md#mutations).
 
-The first two commands areare lightweight in a sense that they only change metadata or remove files.
+The first two commands are lightweight in a sense that they only change metadata or remove files.
 
 Also, they are replicated, syncing indices metadata via ZooKeeper.
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)

Detailed description / Documentation draft:

Fixed a one word typo in the alter/index docs.
