### PR TITLE
Update column info for system.database docs

### DIFF
--- a/docs/en/operations/system-tables/databases.md
+++ b/docs/en/operations/system-tables/databases.md
@@ -1,6 +1,6 @@
 # system.databases {#system-databases}
 
-Contains information about database. Each database that the server knows about has a corresponding entry in the table.
+Contains information about the databases that are available to the current user.
 
 Columns:
 
@@ -20,7 +20,7 @@ Create a database.
 CREATE DATABASE test
 ```
 
-Check all of the available databases.
+Check all of the available databases to the user.
 
 ``` sql
 SELECT * FROM system.databases

--- a/docs/en/operations/system-tables/databases.md
+++ b/docs/en/operations/system-tables/databases.md
@@ -5,7 +5,7 @@ Contains information about the databases that are available to the current user.
 Columns:
 
 -   `name` ([String](../../sql-reference/data-types/string.md)) — Database name.
--   `engine` ([String](../../sql-reference/data-types/string.md)) — [Database engine](../..//engines/database-engines/index.md).
+-   `engine` ([String](../../sql-reference/data-types/string.md)) — [Database engine](../../engines/database-engines/index.md).
 -   `data_path` ([String](../../sql-reference/data-types/string.md)) — Data path.
 -   `metadata_path` ([String](../../sql-reference/data-types/enum.md)) — Metadata path.
 -   `uuid` ([UUID](../../sql-reference/data-types/uuid.md)) — Database UUID.

--- a/docs/en/operations/system-tables/databases.md
+++ b/docs/en/operations/system-tables/databases.md
@@ -1,9 +1,38 @@
 # system.databases {#system-databases}
 
-This table contains a single String column called ‘name’ – the name of a database.
+Contains information about database. Each database that the server knows about has a corresponding entry in the table.
 
-Each database that the server knows about has a corresponding entry in the table.
+Columns:
 
-This system table is used for implementing the `SHOW DATABASES` query.
+-   `name` ([String](../../sql-reference/data-types/string.md)) — Database name.
+-   `engine` ([String](../../sql-reference/data-types/string.md)) — [Database engine](../..//engines/database-engines/index.md).
+-   `data_path` ([String](../../sql-reference/data-types/string.md)) — Data path.
+-   `metadata_path` ([String](../../sql-reference/data-types/enum.md)) — Metadata path.
+-   `uuid` ([UUID](../../sql-reference/data-types/uuid.md)) — Database UUID.
+
+The `name` column from this system table is used for implementing the `SHOW DATABASES` query.
+
+**Example**
+
+Create a database.
+
+``` sql
+CREATE DATABASE test
+```
+
+Check all of the available databases.
+
+``` sql
+SELECT * FROM system.databases
+```
+
+``` text
+┌─name───────────────────────────┬─engine─┬─data_path──────────────────┬─metadata_path───────────────────────────────────────────────────────┬─────────────────────────────────uuid─┐
+│ _temporary_and_external_tables │ Memory │ /var/lib/clickhouse/       │                                                                     │ 00000000-0000-0000-0000-000000000000 │
+│ default                        │ Atomic │ /var/lib/clickhouse/store/ │ /var/lib/clickhouse/store/d31/d317b4bd-3595-4386-81ee-c2334694128a/ │ d317b4bd-3595-4386-81ee-c2334694128a │
+│ test                           │ Atomic │ /var/lib/clickhouse/store/ │ /var/lib/clickhouse/store/39b/39bf0cc5-4c06-4717-87fe-c75ff3bd8ebb/ │ 39bf0cc5-4c06-4717-87fe-c75ff3bd8ebb │
+│ system                         │ Atomic │ /var/lib/clickhouse/store/ │ /var/lib/clickhouse/store/1d1/1d1c869d-e465-4b1b-a51f-be033436ebf9/ │ 1d1c869d-e465-4b1b-a51f-be033436ebf9 │
+└────────────────────────────────┴────────┴────────────────────────────┴─────────────────────────────────────────────────────────────────────┴──────────────────────────────────────┘
+```
 
 [Original article](https://clickhouse.tech/docs/en/operations/system_tables/databases) <!--hide-->


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)

Detailed description / Documentation draft:

Added information about columns of the `system.database` table to the docs as the docs seemed to indicate that only the `name` column would be returned. I wrote the docs against the `latest` docker hub tag, but did test against the `18` tag which had all columns except `uuid`.