### PR TITLE
Docker cli example

### DIFF
--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -43,7 +43,7 @@ $ docker run -d -p 8123:8123 --name some-clickhouse-server --ulimit nofile=26214
 ### Start server as custom user
 ```
 # $(pwd)/data/clickhouse should exist and be owned by current user
-$ docker run --rm --user ${UID}:${GID} --name some-clickhouse-server --ulimit nofile=262144:262144 p 8123:8123 -v "$(pwd)/logs/clickhouse:/var/log/clickhouse-server" -v "$(pwd)/data/clickhouse:/var/lib/clickhouse" yandex/clickhouse-server
+$ docker run --rm --user ${UID}:${GID} --name some-clickhouse-server --ulimit nofile=262144:262144 -v "$(pwd)/logs/clickhouse:/var/log/clickhouse-server" -v "$(pwd)/data/clickhouse:/var/lib/clickhouse" yandex/clickhouse-server
 ```
 When you use the image with mounting local directories inside you probably would like to not mess your directory tree with files owner and permissions. Then you could use `--user` argument. In this case, you should mount every necessary directory (`/var/lib/clickhouse` and `/var/log/clickhouse-server`) inside the container. Otherwise, image will complain and not start.
 

--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -31,7 +31,7 @@ echo "SELECT 'Hello, ClickHouse!'" | docker run -i --rm --link some-clickhouse-s
 ```
 More information about [ClickHouse HTTP Interface](https://clickhouse.tech/docs/en/interfaces/http/).
 
-### stopping the containter
+### stopping / removing the containter
 
 ```bash
 $ docker stop some-clickhouse-server

--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -12,8 +12,10 @@ For more information and documentation see https://clickhouse.yandex/.
 
 ### start server instance
 ```bash
-$ docker run -d -p 8123:8123 --name some-clickhouse-server --ulimit nofile=262144:262144 yandex/clickhouse-server
+$ docker run -d --name some-clickhouse-server --ulimit nofile=262144:262144 yandex/clickhouse-server
 ```
+
+By default ClickHouse will be accessible only via docker network. See the [networking section below](#networking).
 
 ### connect to it from a native client
 ```bash
@@ -25,9 +27,66 @@ More information about [ClickHouse client](https://clickhouse.yandex/docs/en/int
 ### connect to it using curl
 
 ```bash
-$ echo 'SELECT 1' | curl 'http://localhost:8123/?query=' --data-binary @-
+echo "SELECT 'Hello, ClickHouse!'" | docker run -i --rm --link some-clickhouse-server:clickhouse-server curlimages/curl 'http://clickhouse-server:8123/?query=' -s --data-binary @-
 ```
 More information about [ClickHouse HTTP Interface](https://clickhouse.tech/docs/en/interfaces/http/).
+
+### stopping the containter
+
+```bash
+$ docker stop some-clickhouse-server
+$ docker rm some-clickhouse-server
+```
+
+### networking
+
+You can expose you ClickHouse running in docker by [mapping particular port](https://docs.docker.com/config/containers/container-networking/) from inside container to a host ports:
+
+```bash
+$ docker run -d -p 18123:8123 -p19000:9000 --name some-clickhouse-server --ulimit nofile=262144:262144 yandex/clickhouse-server
+$ echo 'SELECT version()' | curl 'http://localhost:18123/' --data-binary @-
+20.12.3.3
+```
+
+or by allowing container to use [host ports directly](https://docs.docker.com/network/host/) using `--network=host` (also allow to archive better network performance):
+
+```bash
+$ docker run -d --network=host --name some-clickhouse-server --ulimit nofile=262144:262144 yandex/clickhouse-server
+$ echo 'SELECT version()' | curl 'http://localhost:8123/' --data-binary @-
+20.12.3.3
+```
+
+### Volumes 
+
+Typically you may want to mount the following folders inside your container to archieve persistency:
+
+* `/var/lib/clickhouse/` - main folder where ClickHouse stores the data
+* `/val/log/clickhouse-server/` - logs
+
+```bash
+$ docker run -d \
+	-v $(realpath ./ch_data):/var/lib/clickhouse/ \
+	-v $(realpath ./ch_logs):/var/log/clickhouse-server/ \
+	--name some-clickhouse-server --ulimit nofile=262144:262144 yandex/clickhouse-server
+```
+
+You may also want to mount:
+
+* `/etc/clickhouse-server/config.d/*.xml` - files with server configuration adjustmenets
+* `/etc/clickhouse-server/usert.d/*.xml` - files with use settings adjustmenets
+* `/docker-entrypoint-initdb.d/` - folder with database initialization scripts (see below).
+
+### Linux capabilities 
+
+ClickHouse has some anvanced functionality which requite enabling several [linux capabilities](https://man7.org/linux/man-pages/man7/capabilities.7.html).
+
+It is optional and can be enabled using the following [docker command line agruments](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities):
+
+```bash
+$ docker run -d \
+	--cap-add=SYS_NICE --cap-add=NET_ADMIN --cap-add=IPC_LOCK \
+	--name some-clickhouse-server --ulimit nofile=262144:262144 yandex/clickhouse-server
+```
 
 ## Configuration
 

--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -43,13 +43,13 @@ $ docker run -d -p 8123:8123 --name some-clickhouse-server --ulimit nofile=26214
 ### Start server as custom user
 ```
 # $(pwd)/data/clickhouse should exist and be owned by current user
-$ docker run --rm --user ${UID}:${GID} --name some-clickhouse-server --ulimit nofile=262144:262144 -v "$(pwd)/logs/clickhouse:/var/log/clickhouse-server" -v "$(pwd)/data/clickhouse:/var/lib/clickhouse" yandex/clickhouse-server
+$ docker run --rm --user ${UID}:${GID} --name some-clickhouse-server --ulimit nofile=262144:262144 p 8123:8123 -v "$(pwd)/logs/clickhouse:/var/log/clickhouse-server" -v "$(pwd)/data/clickhouse:/var/lib/clickhouse" yandex/clickhouse-server
 ```
 When you use the image with mounting local directories inside you probably would like to not mess your directory tree with files owner and permissions. Then you could use `--user` argument. In this case, you should mount every necessary directory (`/var/lib/clickhouse` and `/var/log/clickhouse-server`) inside the container. Otherwise, image will complain and not start.
 
 ### Start server from root (useful in case of userns enabled)
 ```
-$ docker run --rm -e CLICKHOUSE_UID=0 -e CLICKHOUSE_GID=0 --name clickhouse-server-userns -v "$(pwd)/logs/clickhouse:/var/log/clickhouse-server" -v "$(pwd)/data/clickhouse:/var/lib/clickhouse" yandex/clickhouse-server 
+$ docker run --rm -e CLICKHOUSE_UID=0 -e CLICKHOUSE_GID=0 --name clickhouse-server-userns -v "$(pwd)/logs/clickhouse:/var/log/clickhouse-server" -v "$(pwd)/data/clickhouse:/var/lib/clickhouse" yandex/clickhouse-server
 ```
 
 ### How to create default database and user on starting

--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -48,7 +48,7 @@ $ echo 'SELECT version()' | curl 'http://localhost:18123/' --data-binary @-
 20.12.3.3
 ```
 
-or by allowing container to use [host ports directly](https://docs.docker.com/network/host/) using `--network=host` (also allow to archive better network performance):
+or by allowing container to use [host ports directly](https://docs.docker.com/network/host/) using `--network=host` (also allows archiving better network performance):
 
 ```bash
 $ docker run -d --network=host --name some-clickhouse-server --ulimit nofile=262144:262144 yandex/clickhouse-server
@@ -78,7 +78,7 @@ You may also want to mount:
 
 ### Linux capabilities 
 
-ClickHouse has some anvanced functionality which requite enabling several [linux capabilities](https://man7.org/linux/man-pages/man7/capabilities.7.html).
+ClickHouse has some advanced functionality which requite enabling several [linux capabilities](https://man7.org/linux/man-pages/man7/capabilities.7.html).
 
 It is optional and can be enabled using the following [docker command line agruments](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities):
 
@@ -96,7 +96,7 @@ ClickHouse configuration represented with a file "config.xml" ([documentation](h
 
 ### Start server instance with custom configuration
 ```bash
-$ docker run -d -p 8123:8123 --name some-clickhouse-server --ulimit nofile=262144:262144 -v /path/to/your/config.xml:/etc/clickhouse-server/config.xml yandex/clickhouse-server
+$ docker run -d --name some-clickhouse-server --ulimit nofile=262144:262144 -v /path/to/your/config.xml:/etc/clickhouse-server/config.xml yandex/clickhouse-server
 ```
 
 ### Start server as custom user

--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -12,7 +12,7 @@ For more information and documentation see https://clickhouse.yandex/.
 
 ### start server instance
 ```bash
-$ docker run -d --name some-clickhouse-server --ulimit nofile=262144:262144 yandex/clickhouse-server
+$ docker run -d -p 8123:8123 --name some-clickhouse-server --ulimit nofile=262144:262144 yandex/clickhouse-server
 ```
 
 ### connect to it from a native client
@@ -22,6 +22,13 @@ $ docker run -it --rm --link some-clickhouse-server:clickhouse-server yandex/cli
 
 More information about [ClickHouse client](https://clickhouse.yandex/docs/en/interfaces/cli/).
 
+### connect to it using curl
+
+```bash
+$ echo 'SELECT 1' | curl 'http://localhost:8123/?query=' --data-binary @-
+```
+More information about [ClickHouse HTTP Interface](https://clickhouse.tech/docs/en/interfaces/http/).
+
 ## Configuration
 
 Container exposes 8123 port for [HTTP interface](https://clickhouse.yandex/docs/en/interfaces/http_interface/) and 9000 port for [native client](https://clickhouse.yandex/docs/en/interfaces/tcp/).
@@ -30,7 +37,7 @@ ClickHouse configuration represented with a file "config.xml" ([documentation](h
 
 ### Start server instance with custom configuration
 ```bash
-$ docker run -d --name some-clickhouse-server --ulimit nofile=262144:262144 -v /path/to/your/config.xml:/etc/clickhouse-server/config.xml yandex/clickhouse-server
+$ docker run -d -p 8123:8123 --name some-clickhouse-server --ulimit nofile=262144:262144 -v /path/to/your/config.xml:/etc/clickhouse-server/config.xml yandex/clickhouse-server
 ```
 
 ### Start server as custom user
@@ -42,7 +49,7 @@ When you use the image with mounting local directories inside you probably would
 
 ### Start server from root (useful in case of userns enabled)
 ```
-$ docker run --rm -e CLICKHOUSE_UID=0 -e CLICKHOUSE_GID=0 --name clickhouse-server-userns -v "$(pwd)/logs/clickhouse:/var/log/clickhouse-server" -v "$(pwd)/data/clickhouse:/var/lib/clickhouse" yandex/clickhouse-server
+$ docker run --rm -e CLICKHOUSE_UID=0 -e CLICKHOUSE_GID=0 --name clickhouse-server-userns -v "$(pwd)/logs/clickhouse:/var/log/clickhouse-server" -v "$(pwd)/data/clickhouse:/var/lib/clickhouse" yandex/clickhouse-server 
 ```
 
 ### How to create default database and user on starting


### PR DESCRIPTION
Exposing the 8123 (HTTP) interface in basic example and giving CLI connection instruction makes it easier to start. For a lot of developers, curl is a native and very familiar tool

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Documentation (changelog entry is not required)