### PR TITLE
add check for systemlog tables' engine definition

### DIFF
--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -74,6 +74,7 @@ std::shared_ptr<TSystemLog> createSystemLog(
             engine += " TTL " + ttl;
         engine += " ORDER BY (event_date, event_time)";
     }
+    // Validate engine definition grammatically to prevent some configuration errors
     ParserStorage storage_parser;
     parseQuery(storage_parser, engine.data(), engine.data() + engine.size(),
             "Storage to create table for " + config_prefix, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);

--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -74,6 +74,9 @@ std::shared_ptr<TSystemLog> createSystemLog(
             engine += " TTL " + ttl;
         engine += " ORDER BY (event_date, event_time)";
     }
+    ParserStorage storage_parser;
+    parseQuery(storage_parser, engine.data(), engine.data() + engine.size(),
+            "Storage to create table for " + config_prefix, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
 
     size_t flush_interval_milliseconds = config.getUInt64(config_prefix + ".flush_interval_milliseconds",
                                                           DEFAULT_SYSTEM_LOG_FLUSH_INTERVAL_MILLISECONDS);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Check system log tables' engine definition grammatically to prevent some configuration errors.
Notes that this grammar check is not semantical, that means  such mistakes as non-existent columns / expression functions  would be not found out util the table is created  