### PR TITLE
Functions for converting between Proleptic Gregorian calendar date and Modified Julian Day number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,8 +223,8 @@ if (ARCH_NATIVE)
     set (COMPILER_FLAGS "${COMPILER_FLAGS} -march=native")
 endif ()
 
-if (UNBUNDLED AND (COMPILER_GCC OR COMPILER_CLANG))
-    # to make numeric_limits<__int128> works for unbundled build
+if (COMPILER_GCC OR COMPILER_CLANG)
+    # to make numeric_limits<__int128> works with GCC
     set (_CXX_STANDARD "-std=gnu++2a")
 else()
     set (_CXX_STANDARD "-std=c++2a")

--- a/base/common/wide_integer.h
+++ b/base/common/wide_integer.h
@@ -58,8 +58,7 @@ public:
     using signed_base_type = int64_t;
 
     // ctors
-    integer() = default;
-
+    constexpr integer() noexcept;
     template <typename T>
     constexpr integer(T rhs) noexcept;
     template <typename T>

--- a/base/common/wide_integer_impl.h
+++ b/base/common/wide_integer_impl.h
@@ -917,6 +917,11 @@ public:
 // Members
 
 template <size_t Bits, typename Signed>
+constexpr integer<Bits, Signed>::integer() noexcept
+    : items{}
+{}
+
+template <size_t Bits, typename Signed>
 template <typename T>
 constexpr integer<Bits, Signed>::integer(T rhs) noexcept
     : items{}

--- a/docs/en/sql-reference/functions/date-time-functions.md
+++ b/docs/en/sql-reference/functions/date-time-functions.md
@@ -692,3 +692,147 @@ SELECT FROM_UNIXTIME(1234334543, '%Y-%m-%d %R:%S') AS DateTime
 │ 2009-02-11 14:42:23 │
 └─────────────────────┘
 ```
+
+## toMJD {#tomjd}
+
+Converts a [Proleptic Gregorian calendar](https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar) date in text form `YYYY-MM-DD` to a [Modified Julian Day](https://en.wikipedia.org/wiki/Julian_day#Variants) number in Int32. This function supports date from `0000-01-01` to `9999-12-31`. It raises an exception if the argument cannot be parsed as a date, or the date is invalid.
+
+**Syntax**
+
+``` sql
+toMJD(date)
+```
+
+**Parameters**
+
+-   `date` — Date in text form. [String](../../sql-reference/data-types/string.md) or [FixedString](../../sql-reference/data-types/fixedstring.md).
+
+**Returned value**
+
+-   Modified Julian Day number.
+
+Type: [Int32](../../sql-reference/data-types/int-uint.md).
+
+**Example**
+
+Query:
+
+``` sql
+SELECT toMJD('2020-01-01');
+```
+
+Result:
+
+``` text
+┌─toMJD('2020-01-01')─┐
+│               58849 │
+└─────────────────────┘
+```
+
+## toMJDOrNull {#tomjdornull}
+
+Similar to [toMJD()](#tomjd), but instead of raising exceptions it returns `NULL`.
+
+**Syntax**
+
+``` sql
+toMJDOrNull(date)
+```
+
+**Parameters**
+
+-   `date` — Date in text form. [String](../../sql-reference/data-types/string.md) or [FixedString](../../sql-reference/data-types/fixedstring.md).
+
+**Returned value**
+
+-   Modified Julian Day number.
+
+Type: [Nullable(Int32)](../../sql-reference/data-types/int-uint.md).
+
+**Example**
+
+Query:
+
+``` sql
+SELECT toMJDOrNull('2020-01-01');
+```
+
+Result:
+
+``` text
+┌─toMJDOrNull('2020-01-01')─┐
+│                     58849 │
+└───────────────────────────┘
+```
+
+## fromMJD {#frommjd}
+
+Converts a [Modified Julian Day](https://en.wikipedia.org/wiki/Julian_day#Variants) number to a [Proleptic Gregorian calendar](https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar) date in text form `YYYY-MM-DD`. This function supports day number from `-678941` to `2973119` (which represent 0000-01-01 and 9999-12-31 respectively). It raises an exception if the day number is outside of the supported range.
+
+**Syntax**
+
+``` sql
+fromMJD(day)
+```
+
+**Parameters**
+
+-   `day` — Modified Julian Day number. [Any integral types](../../sql-reference/data-types/int-uint.md).
+
+**Returned value**
+
+-   Date in text form.
+
+Type: [String](../../sql-reference/data-types/string.md)
+
+**Example**
+
+Query:
+
+``` sql
+SELECT fromMJD(58849);
+```
+
+Result:
+
+``` text
+┌─fromMJD(58849)─┐
+│ 2020-01-01     │
+└────────────────┘
+```
+
+## fromMJDOrNull {#frommjdornull}
+
+Similar to [fromMJD()](#frommjd), but instead of raising exceptions it returns `NULL`.
+
+**Syntax**
+
+``` sql
+fromMJDOrNull(day)
+```
+
+**Parameters**
+
+-   `day` — Modified Julian Day number. [Any integral types](../../sql-reference/data-types/int-uint.md).
+
+**Returned value**
+
+-   Date in text form.
+
+Type: [Nullable(String)](../../sql-reference/data-types/string.md)
+
+**Example**
+
+Query:
+
+``` sql
+SELECT fromMJDOrNull(58849);
+```
+
+Result:
+
+``` text
+┌─fromMJDOrNull(58849)─┐
+│ 2020-01-01           │
+└──────────────────────┘
+```

--- a/src/Common/RadixSort.h
+++ b/src/Common/RadixSort.h
@@ -10,6 +10,7 @@
 #include <cstdlib>
 #include <cstdint>
 #include <cassert>
+#include <memory>
 #include <type_traits>
 #include <memory>
 

--- a/src/Functions/GregorianDate.h
+++ b/src/Functions/GregorianDate.h
@@ -1,0 +1,431 @@
+#pragma once
+
+#include <Common/Exception.h>
+#include <Core/Types.h>
+#include <IO/ReadBuffer.h>
+#include <IO/ReadHelpers.h>
+#include <IO/WriteBufferFromString.h>
+#include <IO/WriteHelpers.h>
+
+#include <cstdint>
+
+namespace DB
+{
+    namespace ErrorCodes
+    {
+        extern const int CANNOT_PARSE_INPUT_ASSERTION_FAILED;
+        extern const int CANNOT_PARSE_DATE;
+        extern const int CANNOT_FORMAT_DATETIME;
+        extern const int LOGICAL_ERROR;
+    }
+
+    /** Proleptic Gregorian calendar date. YearT is an integral type
+      * which should be at least 32 bits wide, and should preferably
+      * be signed.
+     */
+    template <typename YearT = int32_t>
+    class GregorianDate
+    {
+    public:
+        GregorianDate() = delete;
+
+        /** Construct from date in text form 'YYYY-MM-DD' by reading from
+          * ReadBuffer.
+          */
+        GregorianDate(ReadBuffer & in);
+
+        /** Construct from Modified Julian Day. The type T is an
+          * integral type which should be at least 32 bits wide, and
+          * should preferably signed.
+          */
+        template <typename T, std::enable_if_t<wide::IntegralConcept<T>()> * = nullptr>
+        GregorianDate(T mjd);
+
+        /** Convert to Modified Julian Day. The type T is an integral type
+          * which should be at least 32 bits wide, and should preferably
+          * signed.
+          */
+        template <typename T, std::enable_if_t<wide::IntegralConcept<T>()> * = nullptr>
+        T toMJD() const;
+
+        /** Write the date in text form 'YYYY-MM-DD' to a buffer.
+          */
+        void write(WriteBuffer & buf) const;
+
+        /** Convert to a string in text form 'YYYY-MM-DD'.
+          */
+        std::string toString() const;
+
+        YearT year() const noexcept
+        {
+            return year_;
+        }
+
+        uint8_t month() const noexcept
+        {
+            return month_;
+        }
+
+        uint8_t dayOfMonth() const noexcept
+        {
+            return dayOfMonth_;
+        }
+
+    private:
+        YearT year_;
+        uint8_t month_;
+        uint8_t dayOfMonth_;
+    };
+
+    /** ISO 8601 Ordinal Date. YearT is an integral type which should
+      * be at least 32 bits wide, and should preferably signed.
+     */
+    template <typename YearT = int32_t>
+    class OrdinalDate
+    {
+    public:
+        OrdinalDate(YearT year, uint16_t dayOfYear);
+
+        /** Construct from Modified Julian Day. The type T is an
+          * integral type which should be at least 32 bits wide, and
+          * should preferably signed.
+          */
+        template <typename T, std::enable_if_t<wide::IntegralConcept<T>()> * = nullptr>
+        OrdinalDate(T mjd);
+
+        /** Convert to Modified Julian Day. The type T is an integral
+          * type which should be at least 32 bits wide, and should
+          * preferably be signed.
+          */
+        template <typename T, std::enable_if_t<wide::IntegralConcept<T>()> * = nullptr>
+        T toMJD() const noexcept;
+
+        YearT year() const noexcept
+        {
+            return year_;
+        }
+
+        uint16_t dayOfYear() const noexcept
+        {
+            return dayOfYear_;
+        }
+
+    private:
+        YearT year_;
+        uint16_t dayOfYear_;
+    };
+
+    class MonthDay
+    {
+    public:
+        /** Construct from month and day. */
+        MonthDay(uint8_t month, uint8_t dayOfMonth);
+
+        /** Construct from day of year in Gregorian or Julian
+          * calendars to month and day.
+          */
+        MonthDay(bool isLeapYear, uint16_t dayOfYear);
+
+        /** Convert month and day in Gregorian or Julian calendars to
+          * day of year.
+          */
+        uint16_t dayOfYear(bool isLeapYear) const;
+
+        uint8_t month() const noexcept
+        {
+            return month_;
+        }
+
+        uint8_t dayOfMonth() const noexcept
+        {
+            return dayOfMonth_;
+        }
+
+    private:
+        uint8_t month_;
+        uint8_t dayOfMonth_;
+    };
+}
+
+/* Implementation */
+
+namespace gd {
+    using namespace DB;
+
+    template <typename YearT>
+    static inline constexpr bool isLeapYear(YearT year)
+    {
+        return ( (year % 4 == 0)
+                 &&
+                 ( (year % 400 == 0)
+                   ||
+                   (! (year % 100 == 0)) ) );
+    }
+
+    static inline constexpr uint8_t monthLength(bool isLeapYear, uint8_t month)
+    {
+        switch (month)
+        {
+        case  1: return 31;
+        case  2: return isLeapYear ? 29 : 28;
+        case  3: return 31;
+        case  4: return 30;
+        case  5: return 31;
+        case  6: return 30;
+        case  7: return 31;
+        case  8: return 31;
+        case  9: return 30;
+        case 10: return 31;
+        case 11: return 30;
+        case 12: return 31;
+        default:
+            std::terminate();
+        }
+    }
+
+    /** Integer division truncated toward negative infinity.
+      */
+    template <typename I, typename J>
+    static inline constexpr I div(I x, J y)
+    {
+        const auto y_ = static_cast<I>(y);
+        if (x > 0 && y_ < 0) {
+            return ((x - 1) / y_) - 1;
+        }
+        else if (x < 0 && y_ > 0) {
+            return ((x + 1) / y_) - 1;
+        }
+        else {
+            return x / y_;
+        }
+    }
+
+    /** Integer modulus, satisfying div(x, y)*y + mod(x, y) == x.
+      */
+    template <typename I, typename J>
+    static inline constexpr I mod(I x, J y)
+    {
+        const auto y_ = static_cast<I>(y);
+        const auto r = x % y_;
+        if ((x > 0 && y_ < 0) || (x < 0 && y_ > 0)) {
+            return r == 0 ? static_cast<I>(0) : r + y_;
+        }
+        else {
+            return r;
+        }
+    }
+
+    /** Like std::min(), but the type of operands may differ.
+      */
+    template <typename I, typename J>
+    static inline constexpr I min(I x, J y)
+    {
+        const auto y_ = static_cast<I>(y);
+        return x < y_ ? x : y_;
+    }
+
+    static inline char readDigit(ReadBuffer & in)
+    {
+        char c;
+        if (!in.read(c)) {
+            throw Exception(
+                "Cannot parse input: expected a digit at the end of stream",
+                ErrorCodes::CANNOT_PARSE_INPUT_ASSERTION_FAILED);
+        }
+        else if (c < '0' || c > '9') {
+            throw Exception(
+                "Cannot read input: expected a digit but got something else",
+                ErrorCodes::CANNOT_PARSE_INPUT_ASSERTION_FAILED);
+        }
+        else {
+            return c - '0';
+        }
+    }
+}
+
+namespace DB
+{
+    template <typename YearT>
+    GregorianDate<YearT>::GregorianDate(ReadBuffer & in)
+    {
+        year_ = gd::readDigit(in) * 1000
+              + gd::readDigit(in) *  100
+              + gd::readDigit(in) *   10
+              + gd::readDigit(in);
+
+        assertChar('-', in);
+
+        month_ = gd::readDigit(in) * 10
+               + gd::readDigit(in);
+
+        assertChar('-', in);
+
+        dayOfMonth_ = gd::readDigit(in) * 10
+                    + gd::readDigit(in);
+
+        assertEOF(in);
+
+        if (month_      < 1 || month_      > 12 ||
+            dayOfMonth_ < 1 || dayOfMonth_ > gd::monthLength(gd::isLeapYear(year_), month_))
+        {
+            throw Exception(
+                "Invalid date: " + toString(), ErrorCodes::CANNOT_PARSE_DATE);
+        }
+    }
+
+    template <typename YearT>
+    template <typename T, std::enable_if_t<wide::IntegralConcept<T>()> *>
+    GregorianDate<YearT>::GregorianDate(T mjd)
+    {
+        const OrdinalDate<YearT> ord(mjd);
+        const MonthDay md(gd::isLeapYear(ord.year()), ord.dayOfYear());
+        year_       = ord.year();
+        month_      = md.month();
+        dayOfMonth_ = md.dayOfMonth();
+    }
+
+    template <typename YearT>
+    template <typename T, std::enable_if_t<wide::IntegralConcept<T>()> *>
+    T GregorianDate<YearT>::toMJD() const
+    {
+        const MonthDay md(month_, dayOfMonth_);
+        const auto dayOfYear = md.dayOfYear(gd::isLeapYear(year_));
+        const OrdinalDate<YearT> ord(year_, dayOfYear);
+        return ord.template toMJD<T>();
+    }
+
+    template <typename YearT>
+    void GregorianDate<YearT>::write(WriteBuffer & buf) const
+    {
+        if (year_ < 0 || year_ > 9999)
+        {
+            throw Exception(
+                "Impossible to stringify: year too big or small: " + DB::toString(year_),
+                ErrorCodes::CANNOT_FORMAT_DATETIME);
+        }
+        else {
+            auto y = year_;
+            writeChar('0' + y / 1000, buf); y %= 1000;
+            writeChar('0' + y /  100, buf); y %=  100;
+            writeChar('0' + y /   10, buf); y %=   10;
+            writeChar('0' + y       , buf);;
+
+            writeChar('-', buf);
+
+            auto m = month_;
+            writeChar('0' + m / 10, buf); m %= 10;
+            writeChar('0' + m     , buf);
+
+            writeChar('-', buf);
+
+            auto d = dayOfMonth_;
+            writeChar('0' + d / 10, buf); d %= 10;
+            writeChar('0' + d     , buf);
+        }
+    }
+
+    template <typename YearT>
+    std::string GregorianDate<YearT>::toString() const
+    {
+        WriteBufferFromOwnString buf;
+        write(buf);
+        return buf.str();
+    }
+
+    template <typename YearT>
+    OrdinalDate<YearT>::OrdinalDate(YearT year, uint16_t dayOfYear)
+        : year_(year)
+        , dayOfYear_(dayOfYear)
+    {
+        if (dayOfYear < 1 || dayOfYear > (gd::isLeapYear(year) ? 366 : 365))
+        {
+            throw Exception(
+                "Invalid ordinal date: " + toString(year) + "-" + toString(dayOfYear),
+                ErrorCodes::LOGICAL_ERROR);
+        }
+    }
+
+    template <typename YearT>
+    template <typename T, std::enable_if_t<wide::IntegralConcept<T>()> *>
+    OrdinalDate<YearT>::OrdinalDate(T mjd)
+    {
+        const auto a         = mjd + 678575;
+        const auto quad_cent = gd::div(a, 146097);
+        const auto b         = gd::mod(a, 146097);
+        const auto cent      = gd::min(gd::div(b, 36524), 3);
+        const auto c         = b - cent * 36524;
+        const auto quad      = gd::div(c, 1461);
+        const auto d         = gd::mod(c, 1461);
+        const auto y         = gd::min(gd::div(d, 365), 3);
+        dayOfYear_ = d - y * 365 + 1;
+        year_      = quad_cent * 400 + cent * 100 + quad * 4 + y + 1;
+    }
+
+    template <typename YearT>
+    template <typename T, std::enable_if_t<wide::IntegralConcept<T>()> *>
+    T OrdinalDate<YearT>::toMJD() const noexcept
+    {
+        const auto y = year_ - 1;
+        return dayOfYear_
+            +  365 * y
+            +  gd::div(y,   4)
+            -  gd::div(y, 100)
+            +  gd::div(y, 400)
+            -  678576;
+    }
+
+    inline MonthDay::MonthDay(uint8_t month, uint8_t dayOfMonth)
+        : month_(month)
+        , dayOfMonth_(dayOfMonth)
+    {
+        if (month < 1 || month > 12) {
+            throw Exception(
+                "Invalid month: " + DB::toString(month),
+                ErrorCodes::LOGICAL_ERROR);
+        }
+        /* We can't validate dayOfMonth here, because we don't know if
+         * it's a leap year. */
+    }
+
+    inline MonthDay::MonthDay(bool isLeapYear, uint16_t dayOfYear)
+    {
+        if (dayOfYear < 1 || dayOfYear > (isLeapYear ? 366 : 365))
+        {
+            throw Exception(
+                std::string("Invalid day of year: ") +
+                (isLeapYear ? "leap, " : "non-leap, ") + DB::toString(dayOfYear),
+                ErrorCodes::LOGICAL_ERROR);
+        }
+
+        month_ = 1;
+        uint16_t d = dayOfYear;
+        while (true) {
+            const auto len = gd::monthLength(isLeapYear, month_);
+            if (d > len)
+            {
+                month_++;
+                d -= len;
+            }
+            else {
+                break;
+            }
+        }
+        dayOfMonth_ = d;
+    }
+
+    inline uint16_t MonthDay::dayOfYear(bool isLeapYear) const
+    {
+        if (dayOfMonth_ < 1 || dayOfMonth_ > gd::monthLength(isLeapYear, month_))
+        {
+            throw Exception(
+                std::string("Invalid day of month: ") +
+                (isLeapYear ? "leap, " : "non-leap, ") + DB::toString(month_) +
+                "-" + DB::toString(dayOfMonth_),
+                ErrorCodes::LOGICAL_ERROR);
+        }
+        const auto k = month_ <= 2 ?  0
+                     : isLeapYear  ? -1
+                     :               -2;
+        return (367 * month_ - 362) / 12 + k + dayOfMonth_;
+    }
+}

--- a/src/Functions/fromMJD.cpp
+++ b/src/Functions/fromMJD.cpp
@@ -1,0 +1,248 @@
+#include <Columns/ColumnNullable.h>
+#include <Columns/ColumnString.h>
+#include <Columns/ColumnVector.h>
+#include <Columns/ColumnsNumber.h>
+#include <Core/callOnTypeIndex.h>
+#include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <DataTypes/IDataType.h>
+#include <Functions/IFunctionImpl.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/GregorianDate.h>
+#include <IO/WriteBufferFromVector.h>
+#include <IO/WriteHelpers.h>
+
+namespace DB
+{
+    template <typename Name, typename FromDataType, bool nullOnErrors>
+    class ExecutableFunctionFromMJD : public IExecutableFunctionImpl
+    {
+    public:
+        String getName() const override
+        {
+            return Name::name;
+        }
+
+        ColumnPtr execute(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
+        {
+            using ColVecType = typename FromDataType::ColumnType;
+            const ColVecType * col_from = checkAndGetColumn<ColVecType>(arguments[0].column.get());
+            const typename ColVecType::Container & vec_from = col_from->getData();
+
+            auto col_to = ColumnString::create();
+            ColumnString::Chars & data_to = col_to->getChars();
+            ColumnString::Offsets & offsets_to = col_to->getOffsets();
+            data_to.resize(input_rows_count * strlen("YYYY-MM-DD") + 1);
+            offsets_to.resize(input_rows_count);
+
+            ColumnUInt8::MutablePtr col_null_map_to;
+            ColumnUInt8::Container * vec_null_map_to [[maybe_unused]] = nullptr;
+            if constexpr (nullOnErrors)
+            {
+                col_null_map_to = ColumnUInt8::create(input_rows_count);
+                vec_null_map_to = &col_null_map_to->getData();
+            }
+
+            WriteBufferFromVector<ColumnString::Chars> write_buffer(data_to);
+            for (size_t i = 0; i < input_rows_count; ++i)
+            {
+                if constexpr (nullOnErrors)
+                {
+                    try
+                    {
+                        const GregorianDate<> gd(vec_from[i]);
+                        gd.write(write_buffer);
+                        (*vec_null_map_to)[i] = false;
+                    }
+                    catch (const Exception & e)
+                    {
+                        if (e.code() == ErrorCodes::CANNOT_FORMAT_DATETIME)
+                        {
+                            (*vec_null_map_to)[i] = true;
+                        }
+                        else
+                        {
+                            throw;
+                        }
+                    }
+                    writeChar(0, write_buffer);
+                    offsets_to[i] = write_buffer.count();
+                }
+                else {
+                    const GregorianDate<> gd(vec_from[i]);
+                    gd.write(write_buffer);
+                    writeChar(0, write_buffer);
+                    offsets_to[i] = write_buffer.count();
+                }
+            }
+            write_buffer.finalize();
+
+            if constexpr (nullOnErrors)
+            {
+                return ColumnNullable::create(std::move(col_to), std::move(col_null_map_to));
+            }
+            else
+            {
+                return col_to;
+            }
+        }
+
+        bool useDefaultImplementationForConstants() const override
+        {
+            return true;
+        }
+    };
+
+    template <typename Name, typename FromDataType, bool nullOnErrors>
+    class FunctionBaseFromMJD : public IFunctionBaseImpl
+    {
+    public:
+        explicit FunctionBaseFromMJD(DataTypes argument_types_, DataTypePtr return_type_)
+            : argument_types(std::move(argument_types_))
+            , return_type(std::move(return_type_)) {}
+
+        String getName() const override
+        {
+            return Name::name;
+        }
+
+        const DataTypes & getArgumentTypes() const override
+        {
+            return argument_types;
+        }
+
+        const DataTypePtr & getResultType() const override
+        {
+            return return_type;
+        }
+
+        ExecutableFunctionImplPtr prepare(const ColumnsWithTypeAndName &) const override
+        {
+            return std::make_unique<ExecutableFunctionFromMJD<Name, FromDataType, nullOnErrors>>();
+        }
+
+        bool isInjective(const ColumnsWithTypeAndName &) const override
+        {
+            return true;
+        }
+
+        bool hasInformationAboutMonotonicity() const override
+        {
+            return true;
+        }
+
+        Monotonicity getMonotonicityForRange(const IDataType &, const Field &, const Field &) const override
+        {
+            return Monotonicity(
+                true,  // is_monotonic
+                true,  // is_positive
+                true); // is_always_monotonic
+        }
+
+    private:
+        DataTypes argument_types;
+        DataTypePtr return_type;
+    };
+
+    template <typename Name, bool nullOnErrors>
+    class FromMJDOverloadResolver : public IFunctionOverloadResolverImpl
+    {
+    public:
+        static constexpr auto name = Name::name;
+
+        static FunctionOverloadResolverImplPtr create(const Context &)
+        {
+            return std::make_unique<FromMJDOverloadResolver<Name, nullOnErrors>>();
+        }
+
+        String getName() const override
+        {
+            return Name::name;
+        }
+
+        FunctionBaseImplPtr build(const ColumnsWithTypeAndName & arguments, const DataTypePtr & return_type) const override
+        {
+            const DataTypePtr & from_type = arguments[0].type;
+            DataTypes argument_types = { from_type };
+            FunctionBaseImplPtr base;
+            auto call = [&](const auto & types) -> bool
+            {
+                using Types = std::decay_t<decltype(types)>;
+                using FromIntType = typename Types::RightType;
+                using FromDataType = DataTypeNumber<FromIntType>;
+
+                base = std::make_unique<FunctionBaseFromMJD<Name, FromDataType, nullOnErrors>>(argument_types, return_type);
+                return true;
+            };
+            bool built = callOnBasicType<void, true, false, false, false>(from_type->getTypeId(), call);
+            if (built)
+            {
+                return base;
+            }
+            else
+            {
+                /* When the argument is a NULL constant, the resulting
+                 * function base will not be actually called but it
+                 * will still be inspected. Returning a NULL pointer
+                 * here causes a SEGV. So we must somehow create a
+                 * dummy implementation and return it.
+                 */
+                if (WhichDataType(from_type).isNullable()) // Nullable(Nothing)
+                {
+                    return std::make_unique<FunctionBaseFromMJD<Name, DataTypeInt32, nullOnErrors>>(argument_types, return_type);
+                }
+                else {
+                    // Should not happen.
+                    throw Exception(
+                        "The argument of function " + getName() + " must be integral", ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+                }
+            }
+        }
+
+        DataTypePtr getReturnType(const DataTypes & arguments) const override
+        {
+            if (!isInteger(arguments[0]))
+            {
+                throw Exception(
+                    "The argument of function " + getName() + " must be integral", ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+            }
+
+            DataTypePtr baseType = std::make_shared<DataTypeString>();
+            if constexpr (nullOnErrors)
+            {
+                return std::make_shared<DataTypeNullable>(baseType);
+            }
+            else
+            {
+                return baseType;
+            }
+        }
+
+        size_t getNumberOfArguments() const override
+        {
+            return 1;
+        }
+
+        bool isInjective(const ColumnsWithTypeAndName &) const override
+        {
+            return true;
+        }
+    };
+
+    struct NameFromMJD
+    {
+        static constexpr auto name = "fromMJD";
+    };
+
+    struct NameFromMJDOrNull
+    {
+        static constexpr auto name = "fromMJDOrNull";
+    };
+
+    void registerFunctionFromMJD(FunctionFactory & factory)
+    {
+        factory.registerFunction<FromMJDOverloadResolver<NameFromMJD, false>>();
+        factory.registerFunction<FromMJDOverloadResolver<NameFromMJDOrNull, true>>();
+    }
+}

--- a/src/Functions/registerFunctionsDateTime.cpp
+++ b/src/Functions/registerFunctionsDateTime.cpp
@@ -18,6 +18,7 @@ void registerFunctionToMonday(FunctionFactory &);
 void registerFunctionToISOWeek(FunctionFactory &);
 void registerFunctionToISOYear(FunctionFactory &);
 void registerFunctionToCustomWeek(FunctionFactory &);
+void registerFunctionToMJD(FunctionFactory &);
 void registerFunctionToStartOfMonth(FunctionFactory &);
 void registerFunctionToStartOfQuarter(FunctionFactory &);
 void registerFunctionToStartOfYear(FunctionFactory &);
@@ -65,6 +66,7 @@ void registerFunctionSubtractYears(FunctionFactory &);
 void registerFunctionDateDiff(FunctionFactory &);
 void registerFunctionToTimeZone(FunctionFactory &);
 void registerFunctionFormatDateTime(FunctionFactory &);
+void registerFunctionFromMJD(FunctionFactory &);
 void registerFunctionDateTrunc(FunctionFactory &);
 
 void registerFunctionsDateTime(FunctionFactory & factory)
@@ -83,6 +85,7 @@ void registerFunctionsDateTime(FunctionFactory & factory)
     registerFunctionToISOWeek(factory);
     registerFunctionToISOYear(factory);
     registerFunctionToCustomWeek(factory);
+    registerFunctionToMJD(factory);
     registerFunctionToStartOfMonth(factory);
     registerFunctionToStartOfQuarter(factory);
     registerFunctionToStartOfYear(factory);
@@ -131,6 +134,7 @@ void registerFunctionsDateTime(FunctionFactory & factory)
     registerFunctionDateDiff(factory);
     registerFunctionToTimeZone(factory);
     registerFunctionFormatDateTime(factory);
+    registerFunctionFromMJD(factory);
     registerFunctionDateTrunc(factory);
 }
 

--- a/src/Functions/toMJD.cpp
+++ b/src/Functions/toMJD.cpp
@@ -1,0 +1,241 @@
+#include <Columns/ColumnNullable.h>
+#include <Columns/ColumnString.h>
+#include <Columns/ColumnFixedString.h>
+#include <Columns/ColumnVector.h>
+#include <Columns/ColumnsNumber.h>
+#include <DataTypes/IDataType.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <Functions/IFunctionImpl.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/GregorianDate.h>
+#include <IO/ReadBufferFromMemory.h>
+
+namespace DB
+{
+    namespace ErrorCodes
+    {
+        extern const int ILLEGAL_COLUMN;
+        extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+    }
+
+    template <typename Name, typename ToDataType, bool nullOnErrors>
+    class ExecutableFunctionToMJD : public IExecutableFunctionImpl
+    {
+    public:
+        String getName() const override
+        {
+            return Name::name;
+        }
+
+        ColumnPtr execute(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
+        {
+            const IColumn * col_from = arguments[0].column.get();
+            const ColumnString * col_from_string = checkAndGetColumn<ColumnString>(col_from);
+            const ColumnFixedString * col_from_fixed_string = checkAndGetColumn<ColumnFixedString>(col_from);
+
+            const ColumnString::Chars * chars = nullptr;
+            const IColumn::Offsets * offsets = nullptr;
+            size_t fixed_string_size = 0;
+
+            if (col_from_string)
+            {
+                chars = &col_from_string->getChars();
+                offsets = &col_from_string->getOffsets();
+            }
+            else if (col_from_fixed_string)
+            {
+                chars = &col_from_fixed_string->getChars();
+                fixed_string_size = col_from_fixed_string->getN();
+            }
+            else
+            {
+                 throw Exception("Illegal column " + col_from->getName()
+                                 + " of first argument of function " + Name::name,
+                                 ErrorCodes::ILLEGAL_COLUMN);
+            }
+
+            using ColVecTo = typename ToDataType::ColumnType;
+            typename ColVecTo::MutablePtr col_to = ColVecTo::create(input_rows_count);
+            typename ColVecTo::Container & vec_to = col_to->getData();
+
+            ColumnUInt8::MutablePtr col_null_map_to;
+            ColumnUInt8::Container * vec_null_map_to [[maybe_unused]] = nullptr;
+            if constexpr (nullOnErrors)
+            {
+                col_null_map_to = ColumnUInt8::create(input_rows_count);
+                vec_null_map_to = &col_null_map_to->getData();
+            }
+
+            size_t current_offset = 0;
+            for (size_t i = 0; i < input_rows_count; ++i)
+            {
+                 const size_t next_offset = offsets ? (*offsets)[i] : current_offset + fixed_string_size;
+                 const size_t string_size = offsets ? next_offset - current_offset - 1 : fixed_string_size;
+                 ReadBufferFromMemory read_buffer(&(*chars)[current_offset], string_size);
+                 current_offset = next_offset;
+
+                 if constexpr (nullOnErrors)
+                 {
+                     try
+                     {
+                         const GregorianDate<> date(read_buffer);
+                         vec_to[i] = date.toMJD<typename ToDataType::FieldType>();
+                         (*vec_null_map_to)[i] = false;
+                     }
+                     catch (const Exception & e)
+                     {
+                         if (e.code() == ErrorCodes::CANNOT_PARSE_INPUT_ASSERTION_FAILED ||
+                             e.code() == ErrorCodes::CANNOT_PARSE_DATE)
+                         {
+                             (*vec_null_map_to)[i] = true;
+                         }
+                         else
+                         {
+                             throw;
+                         }
+                     }
+                 }
+                 else
+                 {
+                     const GregorianDate<> date(read_buffer);
+                     vec_to[i] = date.toMJD<typename ToDataType::FieldType>();
+                 }
+            }
+
+            if constexpr (nullOnErrors)
+            {
+                return ColumnNullable::create(std::move(col_to), std::move(col_null_map_to));
+            }
+            else
+            {
+                return col_to;
+            }
+        }
+
+        bool useDefaultImplementationForConstants() const override
+        {
+            return true;
+        }
+    };
+
+    template <typename Name, typename ToDataType, bool nullOnErrors>
+    class FunctionBaseToMJD : public IFunctionBaseImpl
+    {
+    public:
+        explicit FunctionBaseToMJD(DataTypes argument_types_, DataTypePtr return_type_)
+            : argument_types(std::move(argument_types_))
+            , return_type(std::move(return_type_)) {}
+
+        String getName() const override
+        {
+            return Name::name;
+        }
+
+        const DataTypes & getArgumentTypes() const override
+        {
+            return argument_types;
+        }
+
+        const DataTypePtr & getResultType() const override
+        {
+            return return_type;
+        }
+
+        ExecutableFunctionImplPtr prepare(const ColumnsWithTypeAndName &) const override
+        {
+            return std::make_unique<ExecutableFunctionToMJD<Name, ToDataType, nullOnErrors>>();
+        }
+
+        bool isInjective(const ColumnsWithTypeAndName &) const override
+        {
+            return true;
+        }
+
+        bool hasInformationAboutMonotonicity() const override
+        {
+            return true;
+        }
+
+        Monotonicity getMonotonicityForRange(const IDataType &, const Field &, const Field &) const override
+        {
+            return Monotonicity(
+                true,  // is_monotonic
+                true,  // is_positive
+                true); // is_always_monotonic
+        }
+
+    private:
+        DataTypes argument_types;
+        DataTypePtr return_type;
+    };
+
+    template <typename Name, typename ToDataType, bool nullOnErrors>
+    class ToMJDOverloadResolver : public IFunctionOverloadResolverImpl
+    {
+    public:
+        static constexpr auto name = Name::name;
+
+        static FunctionOverloadResolverImplPtr create(const Context &)
+        {
+            return std::make_unique<ToMJDOverloadResolver<Name, ToDataType, nullOnErrors>>();
+        }
+
+        String getName() const override
+        {
+            return Name::name;
+        }
+
+        FunctionBaseImplPtr build(const ColumnsWithTypeAndName & arguments, const DataTypePtr & return_type) const override
+        {
+            DataTypes argument_types = { arguments[0].type };
+
+            return std::make_unique<FunctionBaseToMJD<Name, ToDataType, nullOnErrors>>(argument_types, return_type);
+        }
+
+        DataTypePtr getReturnType(const DataTypes & arguments) const override
+        {
+            if (!isStringOrFixedString(arguments[0]))
+            {
+                throw Exception(
+                    "The argument of function " + getName() + " must be String or FixedString", ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+            }
+
+            DataTypePtr baseType = std::make_shared<ToDataType>();
+            if constexpr (nullOnErrors)
+            {
+                return std::make_shared<DataTypeNullable>(baseType);
+            }
+            else
+            {
+                return baseType;
+            }
+        }
+
+        size_t getNumberOfArguments() const override
+        {
+            return 1;
+        }
+
+        bool isInjective(const ColumnsWithTypeAndName &) const override
+        {
+            return true;
+        }
+    };
+
+    struct NameToMJD
+    {
+        static constexpr auto name = "toMJD";
+    };
+
+    struct NameToMJDOrNull
+    {
+        static constexpr auto name = "toMJDOrNull";
+    };
+
+    void registerFunctionToMJD(FunctionFactory & factory)
+    {
+        factory.registerFunction<ToMJDOverloadResolver<NameToMJD, DataTypeInt32, false>>();
+        factory.registerFunction<ToMJDOverloadResolver<NameToMJDOrNull, DataTypeInt32, true>>();
+    }
+}

--- a/tests/queries/0_stateless/01543_toMJD.reference
+++ b/tests/queries/0_stateless/01543_toMJD.reference
@@ -1,0 +1,18 @@
+Invocation with constant
+-1
+0
+59154
+\N
+or null
+59154
+\N
+\N
+\N
+Invocation with String column
+-1
+0
+59154
+Invocation with FixedString column
+-1
+0
+59154

--- a/tests/queries/0_stateless/01543_toMJD.sql
+++ b/tests/queries/0_stateless/01543_toMJD.sql
@@ -1,0 +1,38 @@
+--
+SELECT 'Invocation with constant';
+
+SELECT toMJD('1858-11-16');
+SELECT toMJD('1858-11-17');
+SELECT toMJD('2020-11-01');
+SELECT toMJD(NULL);
+SELECT toMJD('unparsable'); -- { serverError 27 }
+SELECT toMJD('1999-02-29'); -- { serverError 38 }
+SELECT toMJD('1999-13-32'); -- { serverError 38 }
+
+SELECT 'or null';
+SELECT toMJDOrNull('2020-11-01');
+SELECT toMJDOrNull('unparsable');
+SELECT toMJDOrNull('1999-02-29');
+SELECT toMJDOrNull('1999-13-32');
+
+--
+SELECT 'Invocation with String column';
+
+DROP TABLE IF EXISTS toMJD_test;
+CREATE TABLE toMJD_test (d String) ENGINE = Memory;
+
+INSERT INTO toMJD_test VALUES ('1858-11-16'), ('1858-11-17'), ('2020-11-01');
+SELECT toMJD(d) FROM toMJD_test;
+
+DROP TABLE toMJD_test;
+
+--
+SELECT 'Invocation with FixedString column';
+
+DROP TABLE IF EXISTS toMJD_test;
+CREATE TABLE toMJD_test (d FixedString(10)) ENGINE = Memory;
+
+INSERT INTO toMJD_test VALUES ('1858-11-16'), ('1858-11-17'), ('2020-11-01');
+SELECT toMJD(d) FROM toMJD_test;
+
+DROP TABLE toMJD_test;

--- a/tests/queries/0_stateless/01544_fromMJD.reference
+++ b/tests/queries/0_stateless/01544_fromMJD.reference
@@ -1,0 +1,14 @@
+Invocation with constant
+1858-11-16
+1858-11-17
+2020-11-01
+\N
+or null
+2020-11-01
+\N
+\N
+\N
+Invocation with Int32 column
+1858-11-16
+1858-11-17
+2020-11-01

--- a/tests/queries/0_stateless/01544_fromMJD.sql
+++ b/tests/queries/0_stateless/01544_fromMJD.sql
@@ -1,0 +1,26 @@
+--
+SELECT 'Invocation with constant';
+
+SELECT fromMJD(-1);
+SELECT fromMJD(0);
+SELECT fromMJD(59154);
+SELECT fromMJD(NULL);
+SELECT fromMJD(-678942); -- { serverError 490 }
+SELECT fromMJD(2973484); -- { serverError 490 }
+
+SELECT 'or null';
+SELECT fromMJDOrNull(59154);
+SELECT fromMJDOrNull(NULL);
+SELECT fromMJDOrNull(-678942);
+SELECT fromMJDOrNull(2973484);
+
+--
+SELECT 'Invocation with Int32 column';
+
+DROP TABLE IF EXISTS fromMJD_test;
+CREATE TABLE fromMJD_test (d Int32) ENGINE = Memory;
+
+INSERT INTO fromMJD_test VALUES (-1), (0), (59154);
+SELECT fromMJD(d) FROM fromMJD_test;
+
+DROP TABLE fromMJD_test;


### PR DESCRIPTION
Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Added functions `toMJD`, `fromMJD`, `toMJDOrNull`, and `fromMJDOrNull`. These functions convert between Proleptic Gregorian calendar date and Modified Julian Day number.

Detailed description / Documentation draft:

Included in the pull request.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
