### PR TITLE
Fix note display on alter/index doc

### DIFF
--- a/docs/en/sql-reference/statements/alter/index/index.md
+++ b/docs/en/sql-reference/statements/alter/index/index.md
@@ -19,5 +19,4 @@ The first two commands are lightweight in a sense that they only change metadata
 Also, they are replicated, syncing indices metadata via ZooKeeper.
 
 !!! note "Note"
-    Index manipulation is supported only for tables with [`*MergeTree`](../../../../engines/table-engines/mergetree-family/mergetree.md) engine (including
-[replicated](../../../../engines/table-engines/mergetree-family/replication.md) variants).
+    Index manipulation is supported only for tables with [`*MergeTree`](../../../../engines/table-engines/mergetree-family/mergetree.md) engine (including [replicated](../../../../engines/table-engines/mergetree-family/replication.md) variants).


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)

Detailed description / Documentation draft:

The link to the `replicated variants` link appears on a newline outside of the note box on the [ALTER > INDEX](https://clickhouse.tech/docs/en/sql-reference/statements/alter/index/) doc page. This PR removes the newline after `including` so that the phrase will now properly appear in the note box.