### PR TITLE
Improve zookeeper path concatenation inside DDLWorker

### DIFF
--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -1,3 +1,5 @@
+#include <filesystem>
+
 #include <Interpreters/DDLWorker.h>
 #include <Parsers/ASTAlterQuery.h>
 #include <Parsers/ASTDropQuery.h>

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -11,7 +11,6 @@
 #include <IO/ReadHelpers.h>
 #include <IO/Operators.h>
 #include <IO/ReadBufferFromString.h>
-#include <Storages/IStorage.h>
 #include <Storages/StorageDistributed.h>
 #include <DataStreams/IBlockInputStream.h>
 #include <Interpreters/executeQuery.h>
@@ -31,16 +30,11 @@
 #include <Common/quoteString.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeString.h>
-#include <DataTypes/DataTypeArray.h>
-#include <Columns/ColumnsNumber.h>
-#include <Columns/ColumnString.h>
-#include <Columns/ColumnArray.h>
 #include <Storages/StorageReplicatedMergeTree.h>
 #include <Poco/Timestamp.h>
 #include <Poco/Net/NetException.h>
 #include <common/sleep.h>
 #include <common/getFQDNOrHostName.h>
-#include <random>
 #include <pcg_random.hpp>
 
 
@@ -862,6 +856,8 @@ bool DDLWorker::tryExecuteQueryOnLeaderReplica(
     };
 
     String shard_node_name = get_shard_name(task.cluster->getShardsAddresses().at(task.host_shard_num));
+
+
     String shard_path = node_path + "/shards/" + shard_node_name;
     String is_executed_path = shard_path + "/executed";
     String tries_to_execute_path = shard_path + "/tries_to_execute";


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Improves the path concatenation of zookeeper paths inside DDLWorker.

Detailed description / Documentation draft:

This PR uses `std::filesystem::path`  for doing zookeeper path concatenation inside the DDLWorker instead of joining the paths adhoc using the `+` operator. 

The `std::filesystem::path` has been used to replace other similar adhoc concatenations in other parts of the code base as well, so leveraging it for uniformity.
