### PR TITLE
docs -  add missing examples for various system tables

### DIFF
--- a/docs/en/operations/system-tables/clusters.md
+++ b/docs/en/operations/system-tables/clusters.md
@@ -23,4 +23,44 @@ Please note that `errors_count` is updated once per query to the cluster, but `e
 -   [distributed_replica_error_cap setting](../../operations/settings/settings.md#settings-distributed_replica_error_cap)
 -   [distributed_replica_error_half_life setting](../../operations/settings/settings.md#settings-distributed_replica_error_half_life)
 
+**Example**
+
+```sql
+:) SELECT * FROM system.clusters LIMIT 2 FORMAT Vertical;
+```
+
+```text
+Row 1:
+──────
+cluster:                 test_cluster
+shard_num:               1
+shard_weight:            1
+replica_num:             1
+host_name:               clickhouse01
+host_address:            172.23.0.11
+port:                    9000
+is_local:                1
+user:                    default
+default_database:        
+errors_count:            0
+estimated_recovery_time: 0
+
+Row 2:
+──────
+cluster:                 test_cluster
+shard_num:               1
+shard_weight:            1
+replica_num:             2
+host_name:               clickhouse02
+host_address:            172.23.0.12
+port:                    9000
+is_local:                0
+user:                    default
+default_database:        
+errors_count:            0
+estimated_recovery_time: 0
+
+2 rows in set. Elapsed: 0.002 sec. 
+```
+
 [Original article](https://clickhouse.tech/docs/en/operations/system_tables/clusters) <!--hide-->

--- a/docs/en/operations/system-tables/columns.md
+++ b/docs/en/operations/system-tables/columns.md
@@ -23,4 +23,50 @@ The `system.columns` table contains the following columns (the column type is sh
 -   `is_in_sampling_key` ([UInt8](../../sql-reference/data-types/int-uint.md)) — Flag that indicates whether the column is in the sampling key expression.
 -   `compression_codec` ([String](../../sql-reference/data-types/string.md)) — Compression codec name.
 
+**Example**
+
+```sql
+:) select * from system.columns LIMIT 2 FORMAT Vertical;
+```
+
+```text
+Row 1:
+──────
+database:                system
+table:                   aggregate_function_combinators
+name:                    name
+type:                    String
+default_kind:            
+default_expression:      
+data_compressed_bytes:   0
+data_uncompressed_bytes: 0
+marks_bytes:             0
+comment:                 
+is_in_partition_key:     0
+is_in_sorting_key:       0
+is_in_primary_key:       0
+is_in_sampling_key:      0
+compression_codec:       
+
+Row 2:
+──────
+database:                system
+table:                   aggregate_function_combinators
+name:                    is_internal
+type:                    UInt8
+default_kind:            
+default_expression:      
+data_compressed_bytes:   0
+data_uncompressed_bytes: 0
+marks_bytes:             0
+comment:                 
+is_in_partition_key:     0
+is_in_sorting_key:       0
+is_in_primary_key:       0
+is_in_sampling_key:      0
+compression_codec:       
+
+2 rows in set. Elapsed: 0.002 sec. 
+```
+
 [Original article](https://clickhouse.tech/docs/en/operations/system_tables/columns) <!--hide-->

--- a/docs/en/operations/system-tables/disks.md
+++ b/docs/en/operations/system-tables/disks.md
@@ -11,3 +11,21 @@ Columns:
 -   `keep_free_space` ([UInt64](../../sql-reference/data-types/int-uint.md)) — Amount of disk space that should stay free on disk in bytes. Defined in the `keep_free_space_bytes` parameter of disk configuration.
 
 [Original article](https://clickhouse.tech/docs/en/operations/system_tables/disks) <!--hide-->
+
+
+**Example**
+
+```sql
+:) SELECT * FROM system.disks;
+```
+
+```text
+┌─name────┬─path─────────────────┬───free_space─┬──total_space─┬─keep_free_space─┐
+│ default │ /var/lib/clickhouse/ │ 276392587264 │ 490652508160 │               0 │
+└─────────┴──────────────────────┴──────────────┴──────────────┴─────────────────┘
+
+1 rows in set. Elapsed: 0.001 sec. 
+```
+
+
+

--- a/docs/en/operations/system-tables/functions.md
+++ b/docs/en/operations/system-tables/functions.md
@@ -8,3 +8,26 @@ Columns:
 -   `is_aggregate`(`UInt8`) — Whether the function is aggregate.
 
 [Original article](https://clickhouse.tech/docs/en/operations/system_tables/functions) <!--hide-->
+
+**Example**
+
+```sql
+ SELECT * FROM system.functions LIMIT 10;
+```
+
+```text
+┌─name─────────────────────┬─is_aggregate─┬─case_insensitive─┬─alias_to─┐
+│ sumburConsistentHash     │            0 │                0 │          │
+│ yandexConsistentHash     │            0 │                0 │          │
+│ demangle                 │            0 │                0 │          │
+│ addressToLine            │            0 │                0 │          │
+│ JSONExtractRaw           │            0 │                0 │          │
+│ JSONExtractKeysAndValues │            0 │                0 │          │
+│ JSONExtract              │            0 │                0 │          │
+│ JSONExtractString        │            0 │                0 │          │
+│ JSONExtractFloat         │            0 │                0 │          │
+│ JSONExtractInt           │            0 │                0 │          │
+└──────────────────────────┴──────────────┴──────────────────┴──────────┘
+
+10 rows in set. Elapsed: 0.002 sec. 
+```

--- a/docs/en/operations/system-tables/merge_tree_settings.md
+++ b/docs/en/operations/system-tables/merge_tree_settings.md
@@ -10,11 +10,6 @@ Columns:
 -   `type` (String) — Setting type (implementation specific string value).
 -   `changed` (UInt8) — Whether the setting was explicitly defined in the config or explicitly changed.
 
-[Original article](https://clickhouse.tech/docs/en/operations/system_tables/merge_tree_settings) <!--hide-->
-
- select * from system.functions LIMIT 10;
-
-
 **Example**
 ```sql
 :) SELECT * FROM system.merge_tree_settings LIMIT 4 FORMAT Vertical;
@@ -55,3 +50,5 @@ type:        SettingUInt64
 
 4 rows in set. Elapsed: 0.001 sec. 
 ```
+
+[Original article](https://clickhouse.tech/docs/en/operations/system_tables/merge_tree_settings) <!--hide-->

--- a/docs/en/operations/system-tables/merge_tree_settings.md
+++ b/docs/en/operations/system-tables/merge_tree_settings.md
@@ -11,3 +11,47 @@ Columns:
 -   `changed` (UInt8) — Whether the setting was explicitly defined in the config or explicitly changed.
 
 [Original article](https://clickhouse.tech/docs/en/operations/system_tables/merge_tree_settings) <!--hide-->
+
+ select * from system.functions LIMIT 10;
+
+
+**Example**
+```sql
+:) SELECT * FROM system.merge_tree_settings LIMIT 4 FORMAT Vertical;
+```
+
+```text
+Row 1:
+──────
+name:        index_granularity
+value:       8192
+changed:     0
+description: How many rows correspond to one primary key value.
+type:        SettingUInt64
+
+Row 2:
+──────
+name:        min_bytes_for_wide_part
+value:       0
+changed:     0
+description: Minimal uncompressed size in bytes to create part in wide format instead of compact
+type:        SettingUInt64
+
+Row 3:
+──────
+name:        min_rows_for_wide_part
+value:       0
+changed:     0
+description: Minimal number of rows to create part in wide format instead of compact
+type:        SettingUInt64
+
+Row 4:
+──────
+name:        merge_max_block_size
+value:       8192
+changed:     0
+description: How many rows in blocks should be formed for merge operations.
+type:        SettingUInt64
+
+4 rows in set. Elapsed: 0.001 sec. 
+```

--- a/docs/en/operations/system-tables/numbers.md
+++ b/docs/en/operations/system-tables/numbers.md
@@ -6,4 +6,27 @@ You can use this table for tests, or if you need to do a brute force search.
 
 Reads from this table are not parallelized.
 
+**Example**
+
+```sql
+:) SELECT * FROM system.numbers LIMIT 10;
+```
+
+```text
+┌─number─┐
+│      0 │
+│      1 │
+│      2 │
+│      3 │
+│      4 │
+│      5 │
+│      6 │
+│      7 │
+│      8 │
+│      9 │
+└────────┘
+
+10 rows in set. Elapsed: 0.001 sec. 
+```
+
 [Original article](https://clickhouse.tech/docs/en/operations/system_tables/numbers) <!--hide-->

--- a/docs/en/operations/system-tables/numbers_mt.md
+++ b/docs/en/operations/system-tables/numbers_mt.md
@@ -4,4 +4,27 @@ The same as [system.numbers](../../operations/system-tables/numbers.md) but read
 
 Used for tests.
 
+**Example**
+
+```sql
+:) SELECT * FROM system.numbers_mt LIMIT 10;
+```
+
+```text
+┌─number─┐
+│      0 │
+│      1 │
+│      2 │
+│      3 │
+│      4 │
+│      5 │
+│      6 │
+│      7 │
+│      8 │
+│      9 │
+└────────┘
+
+10 rows in set. Elapsed: 0.001 sec. 
+```
+
 [Original article](https://clickhouse.tech/docs/en/operations/system_tables/numbers_mt) <!--hide-->

--- a/docs/en/operations/system-tables/one.md
+++ b/docs/en/operations/system-tables/one.md
@@ -6,4 +6,18 @@ This table is used if a `SELECT` query doesn’t specify the `FROM` clause.
 
 This is similar to the `DUAL` table found in other DBMSs.
 
+**Example**
+
+```sql
+:) SELECT * FROM system.one LIMIT 10;
+```
+
+```text
+┌─dummy─┐
+│     0 │
+└───────┘
+
+1 rows in set. Elapsed: 0.001 sec. 
+```
+
 [Original article](https://clickhouse.tech/docs/en/operations/system_tables/one) <!--hide-->

--- a/docs/en/operations/system-tables/processes.md
+++ b/docs/en/operations/system-tables/processes.md
@@ -20,7 +20,6 @@ Columns:
 ```
 
 ```text
-
 Row 1:
 ──────
 is_initial_query:     1

--- a/docs/en/operations/system-tables/processes.md
+++ b/docs/en/operations/system-tables/processes.md
@@ -14,4 +14,52 @@ Columns:
 -   `query` (String) – The query text. For `INSERT`, it doesn’t include the data to insert.
 -   `query_id` (String) – Query ID, if defined.
 
+
+```sql
+:) SELECT * FROM system.processes LIMIT 10 FORMAT Vertical;
+```
+
+```text
+
+Row 1:
+──────
+is_initial_query:     1
+user:                 default
+query_id:             35a360fa-3743-441d-8e1f-228c938268da
+address:              ::ffff:172.23.0.1
+port:                 47588
+initial_user:         default
+initial_query_id:     35a360fa-3743-441d-8e1f-228c938268da
+initial_address:      ::ffff:172.23.0.1
+initial_port:         47588
+interface:            1
+os_user:              bharatnc
+client_hostname:      tower
+client_name:          ClickHouse 
+client_revision:      54437
+client_version_major: 20
+client_version_minor: 7
+client_version_patch: 2
+http_method:          0
+http_user_agent:      
+quota_key:            
+elapsed:              0.000582537
+is_cancelled:         0
+read_rows:            0
+read_bytes:           0
+total_rows_approx:    0
+written_rows:         0
+written_bytes:        0
+memory_usage:         0
+peak_memory_usage:    0
+query:                SELECT * from system.processes LIMIT 10 FORMAT Vertical;
+thread_ids:           [67]
+ProfileEvents.Names:  ['Query','SelectQuery','ReadCompressedBytes','CompressedReadBufferBlocks','CompressedReadBufferBytes','IOBufferAllocs','IOBufferAllocBytes','ContextLock','RWLockAcquiredReadLocks']
+ProfileEvents.Values: [1,1,36,1,10,1,89,16,1]
+Settings.Names:       ['use_uncompressed_cache','load_balancing','log_queries','max_memory_usage']
+Settings.Values:      ['0','in_order','1','10000000000']
+
+1 rows in set. Elapsed: 0.002 sec. 
+```
+
 [Original article](https://clickhouse.tech/docs/en/operations/system_tables/processes) <!--hide-->

--- a/docs/en/operations/system-tables/tables.md
+++ b/docs/en/operations/system-tables/tables.md
@@ -52,4 +52,57 @@ This table contains the following columns (the column type is shown in brackets)
 
 The `system.tables` table is used in `SHOW TABLES` query implementation.
 
+```sql
+
+```
+:) SELECT * FROM system.tables LIMIT 2 FORMAT Vertical;
+
+```text
+Row 1:
+──────
+database:                   system
+name:                       aggregate_function_combinators
+uuid:                       00000000-0000-0000-0000-000000000000
+engine:                     SystemAggregateFunctionCombinators
+is_temporary:               0
+data_paths:                 []
+metadata_path:              /var/lib/clickhouse/metadata/system/aggregate_function_combinators.sql
+metadata_modification_time: 1970-01-01 03:00:00
+dependencies_database:      []
+dependencies_table:         []
+create_table_query:         
+engine_full:                
+partition_key:              
+sorting_key:                
+primary_key:                
+sampling_key:               
+storage_policy:             
+total_rows:                 ᴺᵁᴸᴸ
+total_bytes:                ᴺᵁᴸᴸ
+
+Row 2:
+──────
+database:                   system
+name:                       asynchronous_metrics
+uuid:                       00000000-0000-0000-0000-000000000000
+engine:                     SystemAsynchronousMetrics
+is_temporary:               0
+data_paths:                 []
+metadata_path:              /var/lib/clickhouse/metadata/system/asynchronous_metrics.sql
+metadata_modification_time: 1970-01-01 03:00:00
+dependencies_database:      []
+dependencies_table:         []
+create_table_query:         
+engine_full:                
+partition_key:              
+sorting_key:                
+primary_key:                
+sampling_key:               
+storage_policy:             
+total_rows:                 ᴺᵁᴸᴸ
+total_bytes:                ᴺᵁᴸᴸ
+
+2 rows in set. Elapsed: 0.004 sec. 
+```
+
 [Original article](https://clickhouse.tech/docs/en/operations/system_tables/tables) <!--hide-->

--- a/docs/en/operations/system-tables/tables.md
+++ b/docs/en/operations/system-tables/tables.md
@@ -53,9 +53,8 @@ This table contains the following columns (the column type is shown in brackets)
 The `system.tables` table is used in `SHOW TABLES` query implementation.
 
 ```sql
-
-```
 :) SELECT * FROM system.tables LIMIT 2 FORMAT Vertical;
+```
 
 ```text
 Row 1:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):


Detailed description / Documentation draft:

This PR attempts at adding doc examples for various systems tables which are currenyly missing. It's only an initial attempt and most of the default systems tables have been covered. Examples for the optional ones will be covered in subsequent PRs.

The examples show the users a sample query with a few lines of the output.
