### PR TITLE
add diagnostic information when two merge tables try to read each oth…

### DIFF
--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -430,7 +430,15 @@ StorageMerge::StorageListWithLocks StorageMerge::getSelectedTables(
 
 DatabaseTablesIteratorPtr StorageMerge::getDatabaseIterator(const Context & context) const
 {
-    checkStackSize();
+    try
+    {
+        checkStackSize();
+    }
+    catch (Exception & e)
+    {
+        e.addMessage("while getting table iterator of Merge table. Maybe caused by two Merge tables that will endlessly try to read each other's data");
+        throw;
+    }
     auto database = DatabaseCatalog::instance().getDatabase(source_database);
     auto table_name_match = [this](const String & table_name_) { return table_name_regexp.match(table_name_); };
     return database->getTablesIterator(context, table_name_match);


### PR DESCRIPTION
…er's data

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add diagnostic information when two merge tables try to read each other's data.

Detailed description / Documentation draft:

We can do circle detection when create `Merge` table, but calculation is relatively large（O(n^2)). 
So here we simply add diagnostic information to help locate the problem.

