### PR TITLE
Kill network container with retries in integration tests

### DIFF
--- a/tests/integration/helpers/network.py
+++ b/tests/integration/helpers/network.py
@@ -173,11 +173,16 @@ class _NetworkManager:
     def _ensure_container(self):
         if self._container is None or self._container_expire_time <= time.time():
 
-            if self._container is not None:
-                try:
-                    self._container.remove(force=True)
-                except docker.errors.NotFound:
-                    pass
+            for i in range(5):
+                if self._container is not None:
+                    try:
+                        self._container.remove(force=True)
+                        break
+                    except docker.errors.NotFound:
+                        break
+                    except Exception as ex:
+                        print("Error removing network blocade container, will try again", str(ex))
+                        time.sleep(i)
 
             image = subprocess.check_output("docker images -q yandex/clickhouse-integration-helper 2>/dev/null", shell=True)
             if not image.strip():


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

