### PR TITLE
Retrieve logs from grpc

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -137,29 +137,29 @@
     <!-- gRPC protocol (see src/Server/grpc_protos/clickhouse_grpc.proto for the API) -->
     <!-- <grpc_port>9100</grpc_port> -->
     <grpc>
-        <enable_ssl>true</enable_ssl>
+        <enable_ssl>false</enable_ssl>
 
-        <!-- The following two files are used only if enable_ssl=1
+        <!-- The following two files are used only if enable_ssl=1 -->
         <ssl_cert_file>/path/to/ssl_cert_file</ssl_cert_file>
-        <ssl_key_file>/path/to/ssl_key_file</ssl_key_file> -->
+        <ssl_key_file>/path/to/ssl_key_file</ssl_key_file>
 
-        <!-- Whether server will request client for a certificate
-        <ssl_require_client_auth>true</ssl_require_client_auth> -->
+        <!-- Whether server will request client for a certificate -->
+        <ssl_require_client_auth>false</ssl_require_client_auth>
 
-        <!-- The following file is used only if ssl_require_client_auth=1
-        <ssl_ca_cert_file>/path/to/ssl_ca_cert_file</ssl_ca_cert_file> -->
+        <!-- The following file is used only if ssl_require_client_auth=1 -->
+        <ssl_ca_cert_file>/path/to/ssl_ca_cert_file</ssl_ca_cert_file>
 
         <!-- Default compression algorithm (applied if client doesn't specify another algorithm).
-             Supported algorithms: none, deflate, gzip, stream_gzip
-        <compression>gzip</compression> -->
+             Supported algorithms: none, deflate, gzip, stream_gzip -->
+        <compression>deflate</compression>
 
         <!-- Default compression level (applied if client doesn't specify another level).
-             Supported levels: none, low, medium, high
-        <compression_level>high</compression_level> -->
+             Supported levels: none, low, medium, high -->
+        <compression_level>medium</compression_level>
 
-        <!-- Send/receive message size limits in bytes. -1 means unlimited
+        <!-- Send/receive message size limits in bytes. -1 means unlimited -->
         <max_send_message_size>-1</max_send_message_size>
-        <max_receive_message_size>4194304</max_receive_message_size> -->
+        <max_receive_message_size>-1</max_receive_message_size>
     </grpc>
 
     <!-- Maximum number of concurrent queries. -->

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -160,6 +160,9 @@
         <!-- Send/receive message size limits in bytes. -1 means unlimited -->
         <max_send_message_size>-1</max_send_message_size>
         <max_receive_message_size>-1</max_receive_message_size>
+
+        <!-- Enable if you want very detailed logs -->
+        <verbose_logs>false</verbose_logs>
     </grpc>
 
     <!-- Maximum number of concurrent queries. -->

--- a/tests/integration/test_grpc_protocol/configs/grpc_config.xml
+++ b/tests/integration/test_grpc_protocol/configs/grpc_config.xml
@@ -1,0 +1,4 @@
+<yandex>
+    <grpc_port>9100</grpc_port>
+    <grpc replace="replace"/>
+</yandex>

--- a/tests/integration/test_grpc_protocol/configs/grpc_config.xml
+++ b/tests/integration/test_grpc_protocol/configs/grpc_config.xml
@@ -1,4 +1,7 @@
 <yandex>
     <grpc_port>9100</grpc_port>
-    <grpc replace="replace"/>
+    <grpc replace="replace">
+        <!-- Enable if you want very detailed logs -->
+        <verbose_logs>false</verbose_logs>
+    </grpc>
 </yandex>

--- a/tests/integration/test_grpc_protocol/configs/grpc_port.xml
+++ b/tests/integration/test_grpc_protocol/configs/grpc_port.xml
@@ -1,3 +1,0 @@
-<yandex>
-    <grpc_port replace="replace">9100</grpc_port>
-</yandex>

--- a/tests/integration/test_grpc_protocol/test.py
+++ b/tests/integration/test_grpc_protocol/test.py
@@ -28,7 +28,7 @@ import clickhouse_grpc_pb2_grpc
 
 config_dir = os.path.join(SCRIPT_DIR, './configs')
 cluster = ClickHouseCluster(__file__)
-node = cluster.add_instance('node', main_configs=['configs/grpc_port.xml'])
+node = cluster.add_instance('node', main_configs=['configs/grpc_config.xml'])
 grpc_port = 9100
 main_channel = None
 

--- a/tests/integration/test_grpc_protocol/test.py
+++ b/tests/integration/test_grpc_protocol/test.py
@@ -138,15 +138,12 @@ def reset_after_test():
 
 # Actual tests
 
-@pytest.mark.skip(reason="Flaky")
 def test_select_one():
     assert query("SELECT 1") == "1\n"
 
-@pytest.mark.skip(reason="Flaky")
 def test_ordinary_query():
     assert query("SELECT count() FROM numbers(100)") == "100\n"
 
-@pytest.mark.skip(reason="Flaky")
 def test_insert_query():
     query("CREATE TABLE t (a UInt8) ENGINE = Memory")
     query("INSERT INTO t VALUES (1),(2),(3)")
@@ -155,13 +152,11 @@ def test_insert_query():
     query("INSERT INTO t FORMAT TabSeparated", input_data="9\n10\n")
     assert query("SELECT a FROM t ORDER BY a") == "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n"
 
-@pytest.mark.skip(reason="Flaky")
 def test_insert_query_streaming():
     query("CREATE TABLE t (a UInt8) ENGINE = Memory")
     query("INSERT INTO t VALUES", input_data=["(1),(2),(3),", "(5),(4),(6),", "(7),(8),(9)"])
     assert query("SELECT a FROM t ORDER BY a") == "1\n2\n3\n4\n5\n6\n7\n8\n9\n"
 
-@pytest.mark.skip(reason="Flaky")
 def test_insert_query_delimiter():
     query("CREATE TABLE t (a UInt8) ENGINE = Memory")
     query("INSERT INTO t FORMAT CSV 1\n2", input_data=["3", "4\n5"], input_data_delimiter='\n')
@@ -171,7 +166,6 @@ def test_insert_query_delimiter():
     query("INSERT INTO t FORMAT CSV 1\n2", input_data=["3", "4\n5"])
     assert query("SELECT a FROM t ORDER BY a") == "1\n5\n234\n"
 
-@pytest.mark.skip(reason="Flaky")
 def test_insert_default_column():
     query("CREATE TABLE t (a UInt8, b Int32 DEFAULT 100, c String DEFAULT 'c') ENGINE = Memory")
     query("INSERT INTO t (c, a) VALUES ('x',1),('y',2)")
@@ -181,20 +175,17 @@ def test_insert_default_column():
                                                   "3\t100\tc\n" \
                                                   "4\t100\tc\n"
 
-@pytest.mark.skip(reason="Flaky")
 def test_insert_splitted_row():
     query("CREATE TABLE t (a UInt8) ENGINE = Memory")
     query("INSERT INTO t VALUES", input_data=["(1),(2),(", "3),(5),(4),(6)"])
     assert query("SELECT a FROM t ORDER BY a") == "1\n2\n3\n4\n5\n6\n"
 
-@pytest.mark.skip(reason="Flaky")
 def test_output_format():
     query("CREATE TABLE t (a UInt8) ENGINE = Memory")
     query("INSERT INTO t VALUES (1),(2),(3)")
     assert query("SELECT a FROM t ORDER BY a FORMAT JSONEachRow") == '{"a":1}\n{"a":2}\n{"a":3}\n'
     assert query("SELECT a FROM t ORDER BY a", output_format="JSONEachRow") == '{"a":1}\n{"a":2}\n{"a":3}\n'
 
-@pytest.mark.skip(reason="Flaky")
 def test_totals_and_extremes():
     query("CREATE TABLE t (x UInt8, y UInt8) ENGINE = Memory")
     query("INSERT INTO t VALUES (1, 2), (2, 4), (3, 2), (3, 3), (3, 4)")
@@ -203,7 +194,6 @@ def test_totals_and_extremes():
     assert query("SELECT x, y FROM t") == "1\t2\n2\t4\n3\t2\n3\t3\n3\t4\n"
     assert query_and_get_extremes("SELECT x, y FROM t", settings={"extremes": "1"}) == "1\t2\n3\t4\n"
 
-@pytest.mark.skip(reason="Flaky")
 def test_errors_handling():
     e = query_and_get_error("")
     #print(e)
@@ -212,19 +202,16 @@ def test_errors_handling():
     e = query_and_get_error("CREATE TABLE t (a UInt8) ENGINE = Memory")
     assert "Table default.t already exists" in e.display_text
 
-@pytest.mark.skip(reason="Flaky")
 def test_authentication():
     query("CREATE USER john IDENTIFIED BY 'qwe123'")
     assert query("SELECT currentUser()", user_name="john", password="qwe123") == "john\n"
 
-@pytest.mark.skip(reason="Flaky")
 def test_logs():
     logs = query_and_get_logs("SELECT 1", settings={'send_logs_level':'debug'})
     assert "SELECT 1" in logs
     assert "Read 1 rows" in logs
     assert "Peak memory usage" in logs
 
-@pytest.mark.skip(reason="Flaky")
 def test_progress():
     results = query_no_errors("SELECT number, sleep(0.31) FROM numbers(8) SETTINGS max_block_size=2, interactive_delay=100000", stream_output=True)
     #print(results)
@@ -259,7 +246,6 @@ def test_progress():
 }
 ]"""
 
-@pytest.mark.skip(reason="Flaky")
 def test_session():
     session_a = "session A"
     session_b = "session B"
@@ -270,12 +256,10 @@ def test_session():
     assert query("SELECT getSetting('custom_x'), getSetting('custom_y')", session_id=session_a) == "1\t2\n"
     assert query("SELECT getSetting('custom_x'), getSetting('custom_y')", session_id=session_b) == "3\t4\n"
 
-@pytest.mark.skip(reason="Flaky")
 def test_no_session():
     e = query_and_get_error("SET custom_x=1")
     assert "There is no session" in e.display_text
 
-@pytest.mark.skip(reason="Flaky")
 def test_input_function():
     query("CREATE TABLE t (a UInt8) ENGINE = Memory")
     query("INSERT INTO t SELECT col1 * col2 FROM input('col1 UInt8, col2 UInt8') FORMAT CSV", input_data=["5,4\n", "8,11\n", "10,12\n"])
@@ -285,7 +269,6 @@ def test_input_function():
     query("INSERT INTO t SELECT col1 * col2 FROM input('col1 UInt8, col2 UInt8') FORMAT CSV 20,10\n", input_data="15,15\n")
     assert query("SELECT a FROM t ORDER BY a") == "20\n88\n120\n143\n200\n225\n"
 
-@pytest.mark.skip(reason="Flaky")
 def test_external_table():
     columns = [clickhouse_grpc_pb2.NameAndType(name='UserID', type='UInt64'), clickhouse_grpc_pb2.NameAndType(name='UserName', type='String')]
     ext1 = clickhouse_grpc_pb2.ExternalTable(name='ext1', columns=columns, data='1\tAlex\n2\tBen\n3\tCarl\n', format='TabSeparated')
@@ -303,7 +286,6 @@ def test_external_table():
     assert query("SELECT * FROM _data ORDER BY _2", external_tables=[unnamed_table]) == "7\tFred\n"\
                                                                                         "6\tGeorge\n"
 
-@pytest.mark.skip(reason="Flaky")
 def test_external_table_streaming():
     columns = [clickhouse_grpc_pb2.NameAndType(name='UserID', type='UInt64'), clickhouse_grpc_pb2.NameAndType(name='UserName', type='String')]
     def send_query_info():
@@ -319,7 +301,6 @@ def test_external_table_streaming():
                             "4\tDaniel\n"\
                             "5\tEthan\n"
 
-@pytest.mark.skip(reason="Flaky")
 def test_simultaneous_queries_same_channel():
     threads=[]
     try:
@@ -331,7 +312,6 @@ def test_simultaneous_queries_same_channel():
         for thread in threads:
             thread.join()
 
-@pytest.mark.skip(reason="Flaky")
 def test_simultaneous_queries_multiple_channels():
     threads=[]
     try:
@@ -343,7 +323,6 @@ def test_simultaneous_queries_multiple_channels():
         for thread in threads:
             thread.join()
 
-@pytest.mark.skip(reason="Flaky")
 def test_cancel_while_processing_input():
     query("CREATE TABLE t (a UInt8) ENGINE = Memory")
     def send_query_info():
@@ -356,7 +335,6 @@ def test_cancel_while_processing_input():
     assert result.progress.written_rows == 6
     assert query("SELECT a FROM t ORDER BY a") == "1\n2\n3\n4\n5\n6\n"
 
-@pytest.mark.skip(reason="Flaky")
 def test_cancel_while_generating_output():
     def send_query_info():
         yield clickhouse_grpc_pb2.QueryInfo(query="SELECT number, sleep(0.2) FROM numbers(10) SETTINGS max_block_size=2")

--- a/tests/integration/test_grpc_protocol_ssl/configs/grpc_config.xml
+++ b/tests/integration/test_grpc_protocol_ssl/configs/grpc_config.xml
@@ -20,5 +20,8 @@
         <!-- Default compression level (applied if client doesn't specify another level).
              Supported levels: none, low, medium, high -->
         <compression_level>high</compression_level>
+
+        <!-- Enable if you want very detailed logs -->
+        <verbose_logs>false</verbose_logs>
     </grpc>
 </yandex>

--- a/tests/integration/test_grpc_protocol_ssl/configs/grpc_config.xml
+++ b/tests/integration/test_grpc_protocol_ssl/configs/grpc_config.xml
@@ -1,5 +1,5 @@
 <yandex>
-    <grpc_port replace="replace">9100</grpc_port>
+    <grpc_port>9100</grpc_port>
     <grpc replace="replace">
         <enable_ssl>true</enable_ssl>
 

--- a/tests/integration/test_grpc_protocol_ssl/test.py
+++ b/tests/integration/test_grpc_protocol_ssl/test.py
@@ -73,18 +73,15 @@ def start_cluster():
 
 # Actual tests
 
-@pytest.mark.skip(reason="Flaky")
 def test_secure_channel():
     with create_secure_channel() as channel:
         assert query("SELECT 'ok'", channel) == "ok\n"
 
-@pytest.mark.skip(reason="Flaky")
 def test_insecure_channel():
     with pytest.raises(grpc.FutureTimeoutError):
         with create_insecure_channel() as channel:
             query("SELECT 'ok'", channel)
 
-@pytest.mark.skip(reason="Flaky")
 def test_wrong_client_certificate():
     with pytest.raises(grpc.FutureTimeoutError):
         with create_insecure_channel() as channel:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog

This PR makes grpc library to pass its logs to our logging system. This PR also enables `test_grpc_protocol*` integration tests back.