### PR TITLE
Fixed typo in log message format

### DIFF
--- a/base/mysqlxx/Pool.cpp
+++ b/base/mysqlxx/Pool.cpp
@@ -248,7 +248,7 @@ bool Pool::Entry::tryForceConnected() const
         if (prev_connection_id != current_connection_id)
         {
             auto & logger = Poco::Util::Application::instance().logger();
-            logger.information("Connection to mysql server has been reestablished. Connection id changed: %d -> %d",
+            logger.information("Connection to mysql server has been reestablished. Connection id changed: %lu -> %lu",
                                 prev_connection_id, current_connection_id);
         }
         return true;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes a minor glitch in log message of mysqlxx::Pool (where Poco logger would print [ERRFMT] instead of correct value)