### PR TITLE
Rewrite views earlier

### DIFF
--- a/src/Interpreters/InterpreterExplainQuery.cpp
+++ b/src/Interpreters/InterpreterExplainQuery.cpp
@@ -55,8 +55,7 @@ namespace
             const SelectQueryInfo & query_info = interpreter.getQueryInfo();
             if (query_info.view_query)
             {
-                ASTPtr tmp;
-                StorageView::replaceWithSubquery(select, query_info.view_query->clone(), tmp);
+                StorageView::replaceWithSubquery(select, query_info.view_query->clone());
             }
         }
     };

--- a/src/Storages/StorageView.h
+++ b/src/Storages/StorageView.h
@@ -40,13 +40,12 @@ public:
         size_t max_block_size,
         unsigned num_streams) override;
 
-    void replaceWithSubquery(ASTSelectQuery & select_query, ASTPtr & view_name, const StorageMetadataPtr & metadata_snapshot) const
+    void replaceWithSubquery(ASTSelectQuery & select_query, const StorageMetadataPtr & metadata_snapshot) const
     {
-        replaceWithSubquery(select_query, metadata_snapshot->getSelectQuery().inner_query->clone(), view_name);
+        replaceWithSubquery(select_query, metadata_snapshot->getSelectQuery().inner_query->clone());
     }
 
-    static void replaceWithSubquery(ASTSelectQuery & outer_query, ASTPtr view_query, ASTPtr & view_name);
-    static ASTPtr restoreViewName(ASTSelectQuery & select_query, const ASTPtr & view_name);
+    static void replaceWithSubquery(ASTSelectQuery & outer_query, ASTPtr view_query);
 
 protected:
     StorageView(

--- a/tests/performance/push_down_limit.xml
+++ b/tests/performance/push_down_limit.xml
@@ -5,4 +5,5 @@
     <query>select number from (select number from numbers_mt(1500000000) order by -number) limit 10</query>
 
     <query short="1">select number from numbers_view limit 100</query>
+    <query short="1">select number from view(SELECT number from numbers_mt(100000000) order by number desc) limit 100</query>
 </test>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Rewrite views earlier and make sure they're treated like subqueries. This is to fix wrong optimization of concurrency limitation: https://github.com/ClickHouse/ClickHouse/blob/084c75fa6ed6c95ff082cef27a62a4d09b1979c2/src/Interpreters/InterpreterSelectQuery.cpp#L1418-L1433   .  @KochetovNicolai 

Detailed description / Documentation draft:

none