### PR TITLE
Decrease log verbosity of disconnecting clients

### DIFF
--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -83,7 +83,7 @@ void TCPHandler::runImpl()
 
     if (in->eof())
     {
-        LOG_WARNING(log, "Client has not sent any data.");
+        LOG_INFO(log, "Client has not sent any data.");
         return;
     }
 
@@ -102,7 +102,7 @@ void TCPHandler::runImpl()
 
         if (e.code() == ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF)
         {
-            LOG_WARNING(log, "Client has gone away.");
+            LOG_INFO(log, "Client has gone away.");
             return;
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Decrease log verbosity of the events when the client drops the connection from WARNING to INFORMATION.

Detailed description / Documentation draft:
Right now they go to the error log. In most of the cases, it's nothing important that requires DBA attention (typically it's just health checks or smth similar).  Fixes #2332.