### PR TITLE
Fix showing temporary tables in system tables

### DIFF
--- a/src/Storages/System/StorageSystemColumns.cpp
+++ b/src/Storages/System/StorageSystemColumns.cpp
@@ -288,6 +288,14 @@ Pipe StorageSystemColumns::read(
                 database_column_mut->insert(database_name);
         }
 
+        Tables external_tables;
+        if (context.hasSessionContext())
+        {
+            external_tables = context.getSessionContext().getExternalTables();
+            if (!external_tables.empty())
+                database_column_mut->insertDefault(); /// Empty database for external tables.
+        }
+
         block_to_filter.insert(ColumnWithTypeAndName(std::move(database_column_mut), std::make_shared<DataTypeString>(), "database"));
 
         /// Filter block with `database` column.
@@ -300,29 +308,36 @@ Pipe StorageSystemColumns::read(
         }
 
         ColumnPtr & database_column = block_to_filter.getByName("database").column;
-        size_t rows = database_column->size();
 
         /// Add `table` column.
         MutableColumnPtr table_column_mut = ColumnString::create();
-        IColumn::Offsets offsets(rows);
-        for (size_t i = 0; i < rows; ++i)
+        IColumn::Offsets offsets(database_column->size());
+
+        for (size_t i = 0; i < database_column->size(); ++i)
         {
             const std::string database_name = (*database_column)[i].get<std::string>();
-            const DatabasePtr & database = databases.at(database_name);
-            offsets[i] = i ? offsets[i - 1] : 0;
-
-            for (auto iterator = database->getTablesIterator(context); iterator->isValid(); iterator->next())
+            if (database_name.empty())
             {
-                if (const auto & table = iterator->table())
+                for (auto & [table_name, table] : external_tables)
                 {
-                    const String & table_name = iterator->name();
-                    storages.emplace(std::piecewise_construct,
-                        std::forward_as_tuple(database_name, table_name),
-                        std::forward_as_tuple(table));
+                    storages[{"", table_name}] = table;
                     table_column_mut->insert(table_name);
-                    ++offsets[i];
                 }
             }
+            else
+            {
+                const DatabasePtr & database = databases.at(database_name);
+                for (auto iterator = database->getTablesIterator(context); iterator->isValid(); iterator->next())
+                {
+                    if (const auto & table = iterator->table())
+                    {
+                        const String & table_name = iterator->name();
+                        storages[{database_name, table_name}] = table;
+                        table_column_mut->insert(table_name);
+                    }
+                }
+            }
+            offsets[i] = table_column_mut->size();
         }
 
         database_column = database_column->replicate(offsets);

--- a/src/Storages/System/StorageSystemDatabases.cpp
+++ b/src/Storages/System/StorageSystemDatabases.cpp
@@ -25,17 +25,20 @@ void StorageSystemDatabases::fillData(MutableColumns & res_columns, const Contex
     const auto access = context.getAccess();
     const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_DATABASES);
 
-    auto databases = DatabaseCatalog::instance().getDatabases();
-    for (const auto & database : databases)
+    const auto databases = DatabaseCatalog::instance().getDatabases();
+    for (const auto & [database_name, database] : databases)
     {
-        if (check_access_for_databases && !access->isGranted(AccessType::SHOW_DATABASES, database.first))
+        if (check_access_for_databases && !access->isGranted(AccessType::SHOW_DATABASES, database_name))
             continue;
 
-        res_columns[0]->insert(database.first);
-        res_columns[1]->insert(database.second->getEngineName());
-        res_columns[2]->insert(context.getPath() + database.second->getDataPath());
-        res_columns[3]->insert(database.second->getMetadataPath());
-        res_columns[4]->insert(database.second->getUUID());
+        if (database_name == DatabaseCatalog::TEMPORARY_DATABASE)
+            continue; /// We don't want to show the internal database for temporary tables in system.databases
+
+        res_columns[0]->insert(database_name);
+        res_columns[1]->insert(database->getEngineName());
+        res_columns[2]->insert(context.getPath() + database->getDataPath());
+        res_columns[3]->insert(database->getMetadataPath());
+        res_columns[4]->insert(database->getUUID());
    }
 }
 

--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -199,7 +199,11 @@ protected:
 
                         // create_table_query
                         if (columns_mask[src_index++])
-                            res_columns[res_index++]->insertDefault();
+                        {
+                            auto temp_db = DatabaseCatalog::instance().getDatabaseForTemporaryTables();
+                            ASTPtr ast = temp_db ? temp_db->tryGetCreateTableQuery(table.second->getStorageID().getTableName(), context) : nullptr;
+                            res_columns[res_index++]->insert(ast ? queryToString(ast) : "");
+                        }
 
                         // engine_full
                         if (columns_mask[src_index++])

--- a/tests/queries/0_stateless/00693_max_block_size_system_tables_columns.reference
+++ b/tests/queries/0_stateless/00693_max_block_size_system_tables_columns.reference
@@ -2,7 +2,7 @@
 1
 1
 1
-	t_00693	Memory	1	[]		1970-01-01 00:00:00	[]	[]		Memory						\N	\N
+	t_00693	Memory	1	[]		1970-01-01 00:00:00	[]	[]	CREATE TEMPORARY TABLE t_00693 (`x` UInt8) ENGINE = Memory	Memory						\N	\N
 1
 1
 1

--- a/tests/queries/0_stateless/01098_temporary_and_external_tables.reference
+++ b/tests/queries/0_stateless/01098_temporary_and_external_tables.reference
@@ -1,2 +1,9 @@
+CREATE TEMPORARY TABLE tmp_table\n(\n    `n` UInt64\n)\nENGINE = Memory AS\nSELECT number AS n\nFROM numbers(42)
+CREATE TEMPORARY TABLE tmp_table\n(\n    `n` UInt64\n)\nENGINE = Memory AS\nSELECT number AS n\nFROM numbers(42)
+CREATE TEMPORARY TABLE tmp_table\n(\n    `n` UInt64\n)\nENGINE = Memory AS\nSELECT number AS n\nFROM numbers(42)
+42
+OK
 OK
 3	9
+0
+1

--- a/tests/queries/0_stateless/01098_temporary_and_external_tables.sh
+++ b/tests/queries/0_stateless/01098_temporary_and_external_tables.sh
@@ -6,20 +6,23 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 url_without_session="https://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_HTTPS}/?"
 url="${url_without_session}session_id=test_01098"
 
-${CLICKHOUSE_CURL} -m 30 -sSk "$url" --data "CREATE TEMPORARY TABLE tmp_table AS SELECT number AS n FROM numbers(42)" > /dev/null;
+${CLICKHOUSE_CURL} -m 30 -sSk "$url" --data "DROP TEMPORARY TABLE IF EXISTS tmp_table"
+${CLICKHOUSE_CURL} -m 30 -sSk "$url" --data "CREATE TEMPORARY TABLE tmp_table AS SELECT number AS n FROM numbers(42)"
 
-name_expr="'\`' || database || '\`.\`' || name || '\`'"
-full_tmp_name=$(echo "SELECT $name_expr FROM system.tables WHERE database='_temporary_and_external_tables' AND create_table_query LIKE '%tmp_table%'" | ${CLICKHOUSE_CURL} -m 30 -sSgk "$url" -d @-)
+id=$(echo "SELECT uuid FROM system.tables WHERE name='tmp_table' AND is_temporary" | ${CLICKHOUSE_CURL} -m 31 -sSgk "$url" -d @-)
+internal_table_name="_temporary_and_external_tables.\`_tmp_$id\`"
 
-echo "SELECT * FROM $full_tmp_name" | ${CLICKHOUSE_CURL} -m 60 -sSgk "$url" -d @- | grep -F "Code: 291" > /dev/null && echo "OK"
+${CLICKHOUSE_CURL} -m 30 -sSk "$url" --data "SHOW CREATE TEMPORARY TABLE tmp_table"
+${CLICKHOUSE_CURL} -m 30 -sSk "$url" --data "SHOW CREATE TABLE $internal_table_name"
+${CLICKHOUSE_CURL} -m 30 -sSk "$url_without_session" --data "SHOW CREATE TABLE $internal_table_name"
 
-echo -ne '0\n1\n' | ${CLICKHOUSE_CURL} -m 30 -sSkF 'file=@-' "$url&file_format=CSV&file_types=UInt64&query=SELECT+sum((number+GLOBAL+IN+(SELECT+number+AS+n+FROM+remote('127.0.0.2',+numbers(5))+WHERE+n+GLOBAL+IN+(SELECT+*+FROM+tmp_table)+AND+n+GLOBAL+NOT+IN+(SELECT+*+FROM+file)+))+AS+res),+sum(number*res)+FROM+remote('127.0.0.2',+numbers(10))";
+echo "SELECT COUNT() FROM tmp_table" | ${CLICKHOUSE_CURL} -m 60 -sSgk "$url" -d @-
+echo "SELECT COUNT() FROM $internal_table_name" | ${CLICKHOUSE_CURL} -m 60 -sSgk "$url" -d @- | grep -F "Code: 291" > /dev/null && echo "OK"
+echo "SELECT COUNT() FROM $internal_table_name" | ${CLICKHOUSE_CURL} -m 60 -sSgk "$url_without_session" -d @- | grep -F "Code: 291" > /dev/null && echo "OK"
 
-echo -ne '0\n1\n' | ${CLICKHOUSE_CURL} -m 30 -sSkF 'file=@-' "$url&file_format=CSV&file_types=UInt64&query=SELECT+sleepEachRow(3)+FROM+file" > /dev/null &
-sleep 1
-full_tmp_names=$(echo "SELECT $name_expr FROM system.tables WHERE database='_temporary_and_external_tables' FORMAT TSV" | ${CLICKHOUSE_CURL} -m 30 -sSgk "$url_without_session" -d @-)
-for name in $full_tmp_names
-do
-  ${CLICKHOUSE_CURL} -m 30 -sSk "${url_without_session}query=SHOW+CREATE+TABLE+$name" 1>/dev/null 2>/dev/null
-done;
+echo -ne '0\n1\n' | ${CLICKHOUSE_CURL} -m 30 -sSkF 'file=@-' "$url&file_format=CSV&file_types=UInt64&query=SELECT+sum((number+GLOBAL+IN+(SELECT+number+AS+n+FROM+remote('127.0.0.2',+numbers(5))+WHERE+n+GLOBAL+IN+(SELECT+*+FROM+tmp_table)+AND+n+GLOBAL+NOT+IN+(SELECT+*+FROM+file)+))+AS+res),+sum(number*res)+FROM+remote('127.0.0.2',+numbers(10))"
+
+echo -ne '0\n1\n' | ${CLICKHOUSE_CURL} -m 30 -sSkF 'file=@-' "$url&file_format=CSV&file_types=UInt64&query=SELECT+_1%2BsleepEachRow(3)+FROM+file" &
+
 wait
+${CLICKHOUSE_CURL} -m 30 -sSk "$url" --data "DROP TEMPORARY TABLE tmp_table"

--- a/tests/queries/0_stateless/01601_temporary_table_session_scope.reference
+++ b/tests/queries/0_stateless/01601_temporary_table_session_scope.reference
@@ -1,0 +1,5 @@
+CREATE TEMPORARY TABLE tmptable (`x` UInt32) ENGINE = Memory
+CREATE TEMPORARY TABLE tmptable (`y` Float64, `z` String) ENGINE = Memory
+x	UInt32	1
+y	Float64	1
+z	String	2

--- a/tests/queries/0_stateless/01601_temporary_table_session_scope.sh
+++ b/tests/queries/0_stateless/01601_temporary_table_session_scope.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../shell_config.sh
+
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&query=DROP+TEMPORARY+TABLE+IF+EXISTS+tmptable&session_id=session_1601a"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&query=DROP+TEMPORARY+TABLE+IF+EXISTS+tmptable&session_id=session_1601b"
+
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&query=CREATE+TEMPORARY+TABLE+tmptable(x+UInt32)&session_id=session_1601a"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&query=CREATE+TEMPORARY+TABLE+tmptable(y+Float64,+z+String)&session_id=session_1601b"
+
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&query=SELECT+create_table_query+FROM+system.tables+WHERE+database=''+AND+name='tmptable'&session_id=session_1601a"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&query=SELECT+create_table_query+FROM+system.tables+WHERE+database=''+AND+name='tmptable'&session_id=session_1601b"
+
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&query=SELECT+name,type,position+FROM+system.columns+WHERE+database=''+AND+table='tmptable'&session_id=session_1601a"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&query=SELECT+name,type,position+FROM+system.columns+WHERE+database=''+AND+table='tmptable'&session_id=session_1601b"
+
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&query=DROP+TEMPORARY+TABLE+tmptable&session_id=session_1601a"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&query=DROP+TEMPORARY+TABLE+tmptable&session_id=session_1601b"

--- a/tests/queries/0_stateless/01602_temporary_table_in_system_tables.reference
+++ b/tests/queries/0_stateless/01602_temporary_table_in_system_tables.reference
@@ -1,0 +1,10 @@
+	test_01602a	CREATE TEMPORARY TABLE test_01602a (`x` UInt32) ENGINE = Memory	Memory	Memory	1
+	test_01602b	CREATE TEMPORARY TABLE test_01602b (`y` Float64, `z` String) ENGINE = Memory	Memory	Memory	1
+	test_01602a	x	UInt32	1			0	0	0		0	0	0	0	
+	test_01602b	y	Float64	1			0	0	0		0	0	0	0	
+	test_01602b	z	String	2			0	0	0		0	0	0	0	
+CREATE TEMPORARY TABLE test_01602a\n(\n    `x` UInt32\n)\nENGINE = Memory
+CREATE TEMPORARY TABLE test_01602b\n(\n    `y` Float64,\n    `z` String\n)\nENGINE = Memory
+0
+0
+0

--- a/tests/queries/0_stateless/01602_temporary_table_in_system_tables.sql
+++ b/tests/queries/0_stateless/01602_temporary_table_in_system_tables.sql
@@ -1,0 +1,18 @@
+DROP TEMPORARY TABLE IF EXISTS test_01602a;
+DROP TEMPORARY TABLE IF EXISTS test_01602b;
+
+CREATE TEMPORARY TABLE test_01602a(x UInt32);
+CREATE TEMPORARY TABLE test_01602b(y Float64, z String);
+
+SELECT database, name, create_table_query, engine, engine_full, is_temporary FROM system.tables WHERE name LIKE 'test_01602%' ORDER BY name;
+SELECT * FROM system.columns WHERE table LIKE 'test_01602%' ORDER BY table, name;
+
+SHOW CREATE TEMPORARY TABLE test_01602a;
+SHOW CREATE TEMPORARY TABLE test_01602b;
+
+SELECT COUNT() FROM system.databases WHERE name='_temporary_and_external_tables';
+SELECT COUNT() FROM system.tables WHERE database='_temporary_and_external_tables';
+SELECT COUNT() FROM system.columns WHERE database='_temporary_and_external_tables';
+
+DROP TEMPORARY TABLE test_01602a;
+DROP TEMPORARY TABLE test_01602b;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Improvement

Changelog entry:
Temporary tables are visible in the system tables `system.tables` and `system.columns` now only in those session where they have been created. The internal database `_temporary_and_external_tables` is now hidden in those system tables; temporary tables are shown as tables with empty database with the `is_temporary` flag set instead.
