### PR TITLE
Fix flappy test_log_family_s3

### DIFF
--- a/tests/integration/test_log_family_s3/configs/minio.xml
+++ b/tests/integration/test_log_family_s3/configs/minio.xml
@@ -2,13 +2,13 @@
 <yandex>
     <storage_configuration>
         <disks>
-            <default>
+            <s3>
                 <type>s3</type>
                 <endpoint>http://minio1:9001/root/data/</endpoint>
                 <access_key_id>minio</access_key_id>
                 <secret_access_key>minio123</secret_access_key>
                 <send_object_metadata>true</send_object_metadata>
-            </default>
+            </s3>
         </disks>
     </storage_configuration>
 </yandex>

--- a/tests/integration/test_log_family_s3/test.py
+++ b/tests/integration/test_log_family_s3/test.py
@@ -27,7 +27,6 @@ def cluster():
 def assert_objects_count(cluster, objects_count, path='data/'):
     minio = cluster.minio_client
     s3_objects = list(minio.list_objects(cluster.minio_bucket, path))
-    print(s3_objects, file=sys.stderr)
     if objects_count != len(s3_objects):
         for s3_object in s3_objects:
             object_meta = minio.stat_object(cluster.minio_bucket, s3_object.object_name)
@@ -41,7 +40,7 @@ def assert_objects_count(cluster, objects_count, path='data/'):
 def test_log_family_s3(cluster, log_engine, files_overhead, files_overhead_per_insert):
     node = cluster.instances["node"]
 
-    node.query("CREATE TABLE s3_test (id UInt64) Engine={}".format(log_engine))
+    node.query("CREATE TABLE s3_test (id UInt64) ENGINE={} SETTINGS disk = 's3'".format(log_engine))
 
     node.query("INSERT INTO s3_test SELECT number FROM numbers(5)")
     assert node.query("SELECT * FROM s3_test") == "0\n1\n2\n3\n4\n"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):


Detailed description / Documentation draft:
S3 disk is declared as default in the test. There is a chance that metric_log, query_log, and other system tables will start writing data to this disk. That's the cause of test flappiness.
