### PR TITLE
Fix possible corruption in librdkafka snappy decompression

### DIFF
--- a/src/Storages/Kafka/KafkaSettings.h
+++ b/src/Storages/Kafka/KafkaSettings.h
@@ -20,7 +20,7 @@ class ASTStorage;
     M(Milliseconds, kafka_poll_timeout_ms, 0, "Timeout for single poll from Kafka.", 0) \
     /* default is min(max_block_size, kafka_max_block_size)*/ \
     M(UInt64, kafka_poll_max_batch_size, 0, "Maximum amount of messages to be polled in a single Kafka poll.", 0) \
-    /* default is = min_insert_block_size / kafka_num_consumers  */ \
+    /* default is = max_insert_block_size / kafka_num_consumers  */ \
     M(UInt64, kafka_max_block_size, 0, "Number of row collected by poll(s) for flushing data from Kafka.", 0) \
     /* default is stream_flush_interval_ms */ \
     M(Milliseconds, kafka_flush_interval_ms, 0, "Timeout for flushing data from Kafka.", 0) \


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix corruption in librdkafka snappy decompression (was a problem only for gcc10 builds, but official builds uses clang already, so at least recent official releases are not affected)

Details:
- Bump librdkafka to fix UB in snappy decompression.
- Add a test for kafka with snappy compression method (regression for UB in snappy), I've checked it manually and it works with clang build and does not with gcc (there are NULL bytes in the middle of value).

Related RR's:
- https://github.com/ClickHouse-Extras/librdkafka/pull/3
- https://github.com/andikleen/snappy-c/pull/22
- https://github.com/edenhill/librdkafka/pull/3179