### PR TITLE
Remove test_keeper_server in perf tests

### DIFF
--- a/docker/test/performance-comparison/config/config.d/zzz-perf-comparison-tweaks-config.xml
+++ b/docker/test/performance-comparison/config/config.d/zzz-perf-comparison-tweaks-config.xml
@@ -3,6 +3,7 @@
     <mysql_port remove="remove"/>
     <interserver_http_port remove="remove"/>
     <tcp_with_proxy_port remove="remove"/>
+    <test_keeper_server remove="remove"/>
     <listen_host>::</listen_host>
 
     <logger>


### PR DESCRIPTION
To avoid port overlaps for right and left server (anyway it is not
used).

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Refs: #16877 
Cc: @alesapin 