### PR TITLE
Fixed `std::out_of_range: basic_string` in S3 URL parsing

### DIFF
--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -368,7 +368,7 @@ namespace S3
                 throw Exception(
                     "Bucket name length is out of bounds in virtual hosted style S3 URI: " + bucket + " (" + uri.toString() + ")", ErrorCodes::BAD_ARGUMENTS);
 
-            if (uri.getPath().size() > 0)
+            if (!uri.getPath().empty())
             {
                 /// Remove leading '/' from path to extract key.
                 key = uri.getPath().substr(1);

--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -368,8 +368,12 @@ namespace S3
                 throw Exception(
                     "Bucket name length is out of bounds in virtual hosted style S3 URI: " + bucket + " (" + uri.toString() + ")", ErrorCodes::BAD_ARGUMENTS);
 
-            /// Remove leading '/' from path to extract key.
-            key = uri.getPath().substr(1);
+            if (uri.getPath().size() > 0)
+            {
+                /// Remove leading '/' from path to extract key.
+                key = uri.getPath().substr(1);
+            }
+
             if (key.empty() || key == "/")
                 throw Exception("Key name is empty in virtual hosted style S3 URI: " + key + " (" + uri.toString() + ")", ErrorCodes::BAD_ARGUMENTS);
             boost::to_upper(name);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixed `std::out_of_range: basic_string` in S3 URL parsing.

Detailed description / Documentation draft:

Fixed bug with unclear error message when specifying root path in S3 URL without trailing `/`:

```
SELECT *
FROM s3('https://altinity-qa-test.s3-us-west-2.amazonaws.com', '---', '---', 'TSV', 'row String')
LIMIT 1

Query id: 11dd399e-d913-4a27-984d-ca0afee9d5d2


Received exception from server (version 20.8.2):
Code: 1001. DB::Exception: Received from localhost:9000. DB::Exception: std::out_of_range: basic_string. 

0 rows in set. Elapsed: 0.016 sec. 
```