### PR TITLE
Build utils in CI, at least in split build

### DIFF
--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -148,6 +148,10 @@ def parse_env_variables(build_type, compiler, sanitizer, package_type, image_typ
 
     if split_binary:
         cmake_flags.append('-DUSE_STATIC_LIBRARIES=0 -DSPLIT_SHARED_LIBRARIES=1 -DCLICKHOUSE_SPLIT_BINARY=1')
+        # We can't always build utils because it requires too much space, but
+        # we have to build them at least in some way in CI. The split build is
+        # probably the least heavy disk-wise.
+        cmake_flags.append('-DENABLE_UTILS=1')
 
     if clang_tidy:
         cmake_flags.append('-DENABLE_CLANG_TIDY=1')

--- a/utils/convert-month-partitioned-parts/main.cpp
+++ b/utils/convert-month-partitioned-parts/main.cpp
@@ -1,4 +1,5 @@
 #include <DataTypes/DataTypeDate.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <IO/HashingWriteBuffer.h>
 #include <IO/ReadBufferFromFile.h>
 #include <IO/WriteBufferFromFile.h>


### PR DESCRIPTION
Currently we don't build them at all, so they were broken by https://github.com/ClickHouse/ClickHouse/pull/17988

Changelog category (leave one):
- Not for changelog (changelog entry is not required)