### PR TITLE
Fix missing include in util

### DIFF
--- a/utils/convert-month-partitioned-parts/main.cpp
+++ b/utils/convert-month-partitioned-parts/main.cpp
@@ -1,4 +1,5 @@
 #include <DataTypes/DataTypeDate.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <IO/HashingWriteBuffer.h>
 #include <IO/ReadBufferFromFile.h>
 #include <IO/WriteBufferFromFile.h>


### PR DESCRIPTION
Given that this error seems extremely easy to reproduce and seems like it should be compiler independent--I can reproduce it just by running the `ninja` command--it comes off as bizarre to me that others haven't reported similar. I'm thinking that perhaps I've missed something, though I'm not entirely sure what. If I _did_ miss something, please let me know.



I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one): Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md): Added a missing include to a util.


Detailed description / Documentation draft:

A util was missing the DataTypesNumber include. As a result, builds failed locally under Clang 11 (though I would expect builds to fail under any compiler) because DataTypeUInt32 was undefined.
This patch includes DataTypesNumber, resolving the build failure.

This was the error that was fixed:
```
../utils/convert-month-partitioned-parts/main.cpp:90:59: error: ‘DataTypeUInt32’ was not declared in this scope; did you mean ‘DataTypeDate’?
```