### PR TITLE
Use IDisk in Set and Join storages

### DIFF
--- a/src/Storages/SetSettings.h
+++ b/src/Storages/SetSettings.h
@@ -10,7 +10,8 @@ class ASTStorage;
 
 
 #define SET_RELATED_SETTINGS(M) \
-    M(Bool, persistent, true, "Disable setting to avoid the overhead of writing to disk for StorageSet", 0)
+    M(Bool, persistent, true, "Disable setting to avoid the overhead of writing to disk for StorageSet", 0) \
+    M(String, disk, "default", "Name of the disk used to persist set data", 0)
 
 #define LIST_OF_SET_SETTINGS(M) \
     SET_RELATED_SETTINGS(M) \

--- a/src/Storages/StorageJoin.cpp
+++ b/src/Storages/StorageJoin.cpp
@@ -8,6 +8,7 @@
 #include <Core/ColumnNumbers.h>
 #include <DataStreams/IBlockInputStream.h>
 #include <DataTypes/NestedUtils.h>
+#include <Disks/IDisk.h>
 #include <Interpreters/joinDispatch.h>
 #include <Interpreters/TableJoin.h>
 #include <Interpreters/castColumn.h>
@@ -35,6 +36,7 @@ namespace ErrorCodes
 }
 
 StorageJoin::StorageJoin(
+    DiskPtr disk_,
     const String & relative_path_,
     const StorageID & table_id_,
     const Names & key_names_,
@@ -45,9 +47,8 @@ StorageJoin::StorageJoin(
     const ColumnsDescription & columns_,
     const ConstraintsDescription & constraints_,
     bool overwrite_,
-    const Context & context_,
     bool persistent_)
-    : StorageSetOrJoinBase{relative_path_, table_id_, columns_, constraints_, context_, persistent_}
+    : StorageSetOrJoinBase{disk_, relative_path_, table_id_, columns_, constraints_, persistent_}
     , key_names(key_names_)
     , use_nulls(use_nulls_)
     , limits(limits_)
@@ -69,9 +70,9 @@ StorageJoin::StorageJoin(
 void StorageJoin::truncate(
     const ASTPtr &, const StorageMetadataPtr & metadata_snapshot, const Context &, TableExclusiveLockHolder&)
 {
-    Poco::File(path).remove(true);
-    Poco::File(path).createDirectories();
-    Poco::File(path + "tmp/").createDirectories();
+    disk->removeRecursive(path);
+    disk->createDirectories(path);
+    disk->createDirectories(path + "tmp/");
 
     increment = 0;
     join = std::make_shared<HashJoin>(table_join, metadata_snapshot->getSampleBlock().sortColumns(), overwrite);
@@ -124,6 +125,7 @@ void registerStorageJoin(StorageFactory & factory)
         auto join_any_take_last_row = settings.join_any_take_last_row;
         auto old_any_join = settings.any_join_distinct_right_table_keys;
         bool persistent = true;
+        String disk_name = "default";
 
         if (args.storage_def && args.storage_def->settings)
         {
@@ -141,6 +143,8 @@ void registerStorageJoin(StorageFactory & factory)
                     join_any_take_last_row = setting.value;
                 else if (setting.name == "any_join_distinct_right_table_keys")
                     old_any_join = setting.value;
+                else if (setting.name == "disk")
+                    disk_name = setting.value.get<String>();
                 else if (setting.name == "persistent")
                 {
                     auto join_settings = std::make_unique<JoinSettings>();
@@ -148,11 +152,11 @@ void registerStorageJoin(StorageFactory & factory)
                     persistent = join_settings->persistent;
                 }
                 else
-                    throw Exception(
-                        "Unknown setting " + setting.name + " for storage " + args.engine_name,
-                        ErrorCodes::BAD_ARGUMENTS);
+                    throw Exception("Unknown setting " + setting.name + " for storage " + args.engine_name, ErrorCodes::BAD_ARGUMENTS);
             }
         }
+
+        DiskPtr disk = args.context.getDisk(disk_name);
 
         if (engine_args.size() < 3)
             throw Exception(
@@ -219,6 +223,7 @@ void registerStorageJoin(StorageFactory & factory)
         }
 
         return StorageJoin::create(
+            disk,
             args.relative_data_path,
             args.table_id,
             key_names,
@@ -229,7 +234,6 @@ void registerStorageJoin(StorageFactory & factory)
             args.columns,
             args.constraints,
             join_any_take_last_row,
-            args.context,
             persistent);
     };
 

--- a/src/Storages/StorageJoin.h
+++ b/src/Storages/StorageJoin.h
@@ -67,6 +67,7 @@ private:
 
 protected:
     StorageJoin(
+        DiskPtr disk_,
         const String & relative_path_,
         const StorageID & table_id_,
         const Names & key_names_,
@@ -76,7 +77,6 @@ protected:
         const ColumnsDescription & columns_,
         const ConstraintsDescription & constraints_,
         bool overwrite,
-        const Context & context_,
         bool persistent_);
 };
 

--- a/src/Storages/StorageSet.h
+++ b/src/Storages/StorageSet.h
@@ -2,6 +2,7 @@
 
 #include <ext/shared_ptr_helper.h>
 
+#include <Interpreters/Context.h>
 #include <Storages/IStorage.h>
 #include <Storages/SetSettings.h>
 
@@ -29,14 +30,14 @@ public:
 
 protected:
     StorageSetOrJoinBase(
+        DiskPtr disk_,
         const String & relative_path_,
         const StorageID & table_id_,
         const ColumnsDescription & columns_,
         const ConstraintsDescription & constraints_,
-        const Context & context_,
         bool persistent_);
 
-    String base_path;
+    DiskPtr disk;
     String path;
     bool persistent;
 
@@ -85,11 +86,11 @@ private:
 
 protected:
     StorageSet(
+        DiskPtr disk_,
         const String & relative_path_,
         const StorageID & table_id_,
         const ColumnsDescription & columns_,
         const ConstraintsDescription & constraints_,
-        const Context & context_,
         bool persistent_);
 };
 

--- a/tests/integration/test_join_set_family_s3/configs/config.d/log_conf.xml
+++ b/tests/integration/test_join_set_family_s3/configs/config.d/log_conf.xml
@@ -1,0 +1,12 @@
+<yandex>
+    <shutdown_wait_unfinished>3</shutdown_wait_unfinished>
+    <logger>
+        <level>trace</level>
+        <log>/var/log/clickhouse-server/log.log</log>
+        <errorlog>/var/log/clickhouse-server/log.err.log</errorlog>
+        <size>1000M</size>
+        <count>10</count>
+        <stderr>/var/log/clickhouse-server/stderr.log</stderr>
+        <stdout>/var/log/clickhouse-server/stdout.log</stdout>
+    </logger>
+</yandex>

--- a/tests/integration/test_join_set_family_s3/configs/config.xml
+++ b/tests/integration/test_join_set_family_s3/configs/config.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<yandex>
+    <logger>
+        <level>trace</level>
+        <log>/var/log/clickhouse-server/clickhouse-server.log</log>
+        <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
+        <size>1000M</size>
+        <count>10</count>
+    </logger>
+
+    <tcp_port>9000</tcp_port>
+    <listen_host>127.0.0.1</listen_host>
+
+    <openSSL>
+        <client>
+            <cacheSessions>true</cacheSessions>
+            <verificationMode>none</verificationMode>
+            <invalidCertificateHandler>
+                <name>AcceptCertificateHandler</name>
+            </invalidCertificateHandler>
+        </client>
+    </openSSL>
+
+    <max_concurrent_queries>500</max_concurrent_queries>
+    <mark_cache_size>5368709120</mark_cache_size>
+    <path>./clickhouse/</path>
+    <users_config>users.xml</users_config>
+</yandex>

--- a/tests/integration/test_join_set_family_s3/configs/minio.xml
+++ b/tests/integration/test_join_set_family_s3/configs/minio.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<yandex>
+    <storage_configuration>
+        <disks>
+            <s3>
+                <type>s3</type>
+                <endpoint>http://minio1:9001/root/data/</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>minio123</secret_access_key>
+                <send_object_metadata>true</send_object_metadata>
+            </s3>
+        </disks>
+    </storage_configuration>
+</yandex>

--- a/tests/integration/test_join_set_family_s3/configs/ssl.xml
+++ b/tests/integration/test_join_set_family_s3/configs/ssl.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<yandex>
+    <openSSL>
+        <client>
+            <cacheSessions>true</cacheSessions>
+            <verificationMode>none</verificationMode>
+            <invalidCertificateHandler>
+                <name>AcceptCertificateHandler</name>
+            </invalidCertificateHandler>
+        </client>
+    </openSSL>
+</yandex>

--- a/tests/integration/test_join_set_family_s3/configs/users.xml
+++ b/tests/integration/test_join_set_family_s3/configs/users.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<yandex>
+    <profiles>
+        <default>
+        </default>
+    </profiles>
+
+    <users>
+        <default>
+            <password></password>
+            <networks incl="networks" replace="replace">
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </default>
+    </users>
+
+    <quotas>
+        <default>
+        </default>
+    </quotas>
+</yandex>

--- a/tests/integration/test_join_set_family_s3/test.py
+++ b/tests/integration/test_join_set_family_s3/test.py
@@ -1,0 +1,97 @@
+import logging
+import sys
+
+import pytest
+from helpers.cluster import ClickHouseCluster
+
+logging.getLogger().setLevel(logging.INFO)
+logging.getLogger().addHandler(logging.StreamHandler())
+
+
+@pytest.fixture(scope="module")
+def cluster():
+    try:
+        cluster = ClickHouseCluster(__file__)
+        cluster.add_instance("node",
+                             main_configs=["configs/minio.xml", "configs/ssl.xml", "configs/config.d/log_conf.xml"],
+                             with_minio=True, stay_alive=True)
+        logging.info("Starting cluster...")
+        cluster.start()
+
+        logging.info("Cluster started")
+
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def assert_objects_count(cluster, objects_count, path='data/'):
+    minio = cluster.minio_client
+    s3_objects = list(minio.list_objects(cluster.minio_bucket, path))
+    if objects_count != len(s3_objects):
+        for s3_object in s3_objects:
+            object_meta = minio.stat_object(cluster.minio_bucket, s3_object.object_name)
+            logging.info("Existing S3 object: %s", str(object_meta))
+        assert objects_count == len(s3_objects)
+
+
+def test_set_s3(cluster):
+    node = cluster.instances["node"]
+
+    node.query("CREATE TABLE testLocalSet (n UInt64) Engine = Set")
+    node.query("CREATE TABLE testS3Set (n UInt64) Engine = Set SETTINGS disk='s3'")
+
+    node.query("INSERT INTO TABLE testLocalSet VALUES (1)")
+    node.query("INSERT INTO TABLE testS3Set VALUES (1)")
+
+    assert node.query("SELECT number in testLocalSet, number in testS3Set FROM system.numbers LIMIT 3") == "0\t0\n1\t1\n0\t0\n"
+    assert_objects_count(cluster, 1)
+
+    node.query("INSERT INTO TABLE testLocalSet VALUES (2)")
+    node.query("INSERT INTO TABLE testS3Set VALUES (2)")
+
+    assert node.query("SELECT number in testLocalSet, number in testS3Set FROM system.numbers LIMIT 3") == "0\t0\n1\t1\n1\t1\n"
+    assert_objects_count(cluster, 2)
+
+    node.restart_clickhouse()
+    assert node.query("SELECT number in testLocalSet, number in testS3Set FROM system.numbers LIMIT 3") == "0\t0\n1\t1\n1\t1\n"
+
+    node.query("TRUNCATE TABLE testLocalSet")
+    node.query("TRUNCATE TABLE testS3Set")
+
+    assert node.query("SELECT number in testLocalSet, number in testS3Set FROM system.numbers LIMIT 3") == "0\t0\n0\t0\n0\t0\n"
+    assert_objects_count(cluster, 0)
+
+    node.query("DROP TABLE testLocalSet")
+    node.query("DROP TABLE testS3Set")
+
+
+def test_join_s3(cluster):
+    node = cluster.instances["node"]
+
+    node.query("CREATE TABLE testLocalJoin(`id` UInt64, `val` String) ENGINE = Join(ANY, LEFT, id)")
+    node.query("CREATE TABLE testS3Join(`id` UInt64, `val` String) ENGINE = Join(ANY, LEFT, id) SETTINGS disk='s3'")
+
+    node.query("INSERT INTO testLocalJoin VALUES (1, 'a')")
+    node.query("INSERT INTO testS3Join VALUES (1, 'a')")
+
+    assert node.query("SELECT joinGet('testLocalJoin', 'val', number) as local, joinGet('testS3Join', 'val', number) as s3 FROM system.numbers LIMIT 3") == "\t\na\ta\n\t\n"
+    assert_objects_count(cluster, 1)
+
+    node.query("INSERT INTO testLocalJoin VALUES (2, 'b')")
+    node.query("INSERT INTO testS3Join VALUES (2, 'b')")
+
+    assert node.query("SELECT joinGet('testLocalJoin', 'val', number) as local, joinGet('testS3Join', 'val', number) as s3 FROM system.numbers LIMIT 3") == "\t\na\ta\nb\tb\n"
+    assert_objects_count(cluster, 2)
+
+    node.restart_clickhouse()
+    assert node.query("SELECT joinGet('testLocalJoin', 'val', number) as local, joinGet('testS3Join', 'val', number) as s3 FROM system.numbers LIMIT 3") == "\t\na\ta\nb\tb\n"
+
+    node.query("TRUNCATE TABLE testLocalJoin")
+    node.query("TRUNCATE TABLE testS3Join")
+
+    assert node.query("SELECT joinGet('testLocalJoin', 'val', number) as local, joinGet('testS3Join', 'val', number) as s3 FROM system.numbers LIMIT 3") == "\t\n\t\n\t\n"
+    assert_objects_count(cluster, 0)
+
+    node.query("DROP TABLE testLocalJoin")
+    node.query("DROP TABLE testS3Join")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add `disk` to Set and Join storage settings. 


Detailed description / Documentation draft:
Support custom disk for Set and Join storages `CREATE TABLE testS3Set (n UInt64) Engine = Set SETTINGS disk='s3'` and `CREATE TABLE testS3Join(`id` UInt64, `val` String) ENGINE = Join(ANY, LEFT, id) SETTINGS disk='s3'`
By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
