### PR TITLE
Port Kerberos to BoringSSL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -183,7 +183,7 @@
 	url = https://github.com/kthohr/stats.git
 [submodule "contrib/krb5"]
 	path = contrib/krb5
-	url = https://github.com/krb5/krb5
+	url = https://github.com/ClickHouse-Extras/krb5
 [submodule "contrib/cyrus-sasl"]
 	path = contrib/cyrus-sasl
 	url = https://github.com/cyrusimap/cyrus-sasl


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Part of #16043