### PR TITLE
Fix remove TTL for column

### DIFF
--- a/tests/queries/0_stateless/01603_remove_column_ttl.reference
+++ b/tests/queries/0_stateless/01603_remove_column_ttl.reference
@@ -1,0 +1,6 @@
+1	32
+2	0
+CREATE TABLE default.table_with_column_ttl\n(\n    `EventTime` DateTime,\n    `UserID` UInt64,\n    `Age` UInt8\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+1	32
+2	0
+3	27

--- a/tests/queries/0_stateless/01603_remove_column_ttl.reference
+++ b/tests/queries/0_stateless/01603_remove_column_ttl.reference
@@ -1,6 +1,6 @@
 1	32
 2	0
-CREATE TABLE default.table_with_column_ttl\n(\n    `EventTime` DateTime,\n    `UserID` UInt64,\n    `Age` UInt8\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.table_with_column_ttl\n(\n    `EventTime` DateTime,\n    `UserID` UInt64,\n    `Age` UInt8\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS min_bytes_for_wide_part = 0, index_granularity = 8192
 1	32
 2	0
 3	27

--- a/tests/queries/0_stateless/01603_remove_column_ttl.sql
+++ b/tests/queries/0_stateless/01603_remove_column_ttl.sql
@@ -1,0 +1,29 @@
+DROP TABLE IF EXISTS table_with_column_ttl;
+CREATE TABLE table_with_column_ttl
+(
+    EventTime DateTime,
+    UserID UInt64,
+    Age UInt8 TTL EventTime + INTERVAL 3 MONTH
+)
+ENGINE MergeTree()
+ORDER BY tuple();
+
+INSERT INTO table_with_column_ttl VALUES (now(), 1, 32);
+
+INSERT INTO table_with_column_ttl VALUES (now() - INTERVAL 4 MONTH, 2, 45);
+
+OPTIMIZE TABLE table_with_column_ttl FINAL;
+
+SELECT UserID, Age FROM table_with_column_ttl ORDER BY UserID;
+
+ALTER TABLE table_with_column_ttl MODIFY COLUMN Age REMOVE TTL;
+
+SHOW CREATE TABLE table_with_column_ttl;
+
+INSERT INTO table_with_column_ttl VALUES (now() - INTERVAL 10 MONTH, 3, 27);
+
+OPTIMIZE TABLE table_with_column_ttl FINAL;
+
+SELECT UserID, Age FROM table_with_column_ttl ORDER BY UserID;
+
+DROP TABLE table_with_column_ttl;

--- a/tests/queries/0_stateless/01603_remove_column_ttl.sql
+++ b/tests/queries/0_stateless/01603_remove_column_ttl.sql
@@ -6,7 +6,8 @@ CREATE TABLE table_with_column_ttl
     Age UInt8 TTL EventTime + INTERVAL 3 MONTH
 )
 ENGINE MergeTree()
-ORDER BY tuple();
+ORDER BY tuple()
+SETTINGS min_bytes_for_wide_part = 0; -- column TTL doesn't work for compact parts
 
 INSERT INTO table_with_column_ttl VALUES (now(), 1, 32);
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix error when query `MODIFY COLUMN ... REMOVE TTL`  doesn't actually remove column TTL.
