### PR TITLE
Explain ast support nonselect querys

### DIFF
--- a/programs/odbc-bridge/ColumnInfoHandler.cpp
+++ b/programs/odbc-bridge/ColumnInfoHandler.cpp
@@ -115,7 +115,7 @@ void ODBCColumnsInfoHandler::handleRequest(Poco::Net::HTTPServerRequest & reques
         std::string name = schema_name.empty() ? backQuoteIfNeed(table_name) : backQuoteIfNeed(schema_name) + "." + backQuoteIfNeed(table_name);
         WriteBufferFromOwnString buf;
         std::string input = "SELECT * FROM " + name + " WHERE 1 = 0";
-        ParserQueryWithOutput parser;
+        ParserQueryWithOutput parser(input.data() + input.size());
         ASTPtr select = parseQuery(parser, input.data(), input.data() + input.size(), "", context_settings.max_query_size, context_settings.max_parser_depth);
 
         IAST::FormatSettings settings(buf, true);

--- a/src/Parsers/ParserExplainQuery.cpp
+++ b/src/Parsers/ParserExplainQuery.cpp
@@ -5,6 +5,7 @@
 #include <Parsers/ParserCreateQuery.h>
 #include <Parsers/ParserSelectWithUnionQuery.h>
 #include <Parsers/ParserSetQuery.h>
+#include <Parsers/ParserQuery.h>
 
 namespace DB
 {
@@ -51,7 +52,13 @@ bool ParserExplainQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
     ParserCreateTableQuery create_p;
     ParserSelectWithUnionQuery select_p;
     ASTPtr query;
-    if (select_p.parse(pos, query, expected) ||
+    if (kind == ASTExplainQuery::ExplainKind::ParsedAST)
+    {
+        ParserQuery p(end);
+        if (p.parse(pos, query, expected))
+            explain_query->setExplainedQuery(std::move(query));
+    }
+    else if (select_p.parse(pos, query, expected) ||
         create_p.parse(pos, query, expected))
         explain_query->setExplainedQuery(std::move(query));
     else

--- a/src/Parsers/ParserExplainQuery.h
+++ b/src/Parsers/ParserExplainQuery.h
@@ -9,8 +9,12 @@ namespace DB
 class ParserExplainQuery : public IParserBase
 {
 protected:
+    const char * end;
+
     const char * getName() const override { return "EXPLAIN"; }
     bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+public:
+    ParserExplainQuery(const char* end_) : end(end_) {}
 };
 
 }

--- a/src/Parsers/ParserQuery.cpp
+++ b/src/Parsers/ParserQuery.cpp
@@ -26,7 +26,7 @@ namespace DB
 
 bool ParserQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
-    ParserQueryWithOutput query_with_output_p;
+    ParserQueryWithOutput query_with_output_p(end);
     ParserInsertQuery insert_p(end);
     ParserUseQuery use_p;
     ParserSetQuery set_p;

--- a/src/Parsers/ParserQueryWithOutput.cpp
+++ b/src/Parsers/ParserQueryWithOutput.cpp
@@ -48,7 +48,7 @@ bool ParserQueryWithOutput::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     ParserShowCreateAccessEntityQuery show_create_access_entity_p;
     ParserShowGrantsQuery show_grants_p;
     ParserShowPrivilegesQuery show_privileges_p;
-    ParserExplainQuery explain_p;
+    ParserExplainQuery explain_p(end);
 
     ASTPtr query;
 

--- a/src/Parsers/ParserQueryWithOutput.h
+++ b/src/Parsers/ParserQueryWithOutput.h
@@ -11,8 +11,11 @@ namespace DB
 class ParserQueryWithOutput : public IParserBase
 {
 protected:
+    const char * end;
     const char * getName() const override { return "Query with output"; }
     bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+public:
+    ParserQueryWithOutput(const char * end_) : end(end_) {}
 };
 
 }

--- a/src/Parsers/tests/select_parser.cpp
+++ b/src/Parsers/tests/select_parser.cpp
@@ -22,7 +22,7 @@ try
         " INTO OUTFILE 'test.out'"
         " FORMAT TabSeparated";
 
-    ParserQueryWithOutput parser;
+    ParserQueryWithOutput parser(input.data() + input.size());
     ASTPtr ast = parseQuery(parser, input.data(), input.data() + input.size(), "", 0, 0);
 
     std::cout << "Success." << std::endl;

--- a/src/Parsers/tests/select_parser_fuzzer.cpp
+++ b/src/Parsers/tests/select_parser_fuzzer.cpp
@@ -11,7 +11,7 @@ try
 {
     std::string input = std::string(reinterpret_cast<const char*>(data), size);
 
-    DB::ParserQueryWithOutput parser;
+    DB::ParserQueryWithOutput parser(input.data() + input.size());
     DB::ASTPtr ast = parseQuery(parser, input.data(), input.data() + input.size(), "", 0, 0);
 
     DB::formatAST(*ast, std::cerr);

--- a/tests/queries/0_stateless/01604_explain_ast_of_nonselect_query.reference
+++ b/tests/queries/0_stateless/01604_explain_ast_of_nonselect_query.reference
@@ -1,0 +1,8 @@
+AlterQuery  t1 (children 1)
+ ExpressionList (children 1)
+  AlterCommand 25 (children 1)
+   Function equals (children 1)
+    ExpressionList (children 2)
+     Identifier date
+     Function today (children 1)
+      ExpressionList

--- a/tests/queries/0_stateless/01604_explain_ast_of_nonselect_query.sql
+++ b/tests/queries/0_stateless/01604_explain_ast_of_nonselect_query.sql
@@ -1,0 +1,1 @@
+explain ast alter table t1 delete where date = today();

--- a/tests/queries/0_stateless/01604_explain_ast_of_nonselect_query.sql
+++ b/tests/queries/0_stateless/01604_explain_ast_of_nonselect_query.sql
@@ -1,1 +1,1 @@
-explain ast alter table t1 delete where date = today();
+explain ast alter table t1 delete where date = today()

--- a/utils/db-generator/query_db_generator.cpp
+++ b/utils/db-generator/query_db_generator.cpp
@@ -1255,10 +1255,10 @@ void parseSelectQuery(DB::ASTPtr ast, TableList & all_tables)
 
 TableList getTablesFromSelect(std::vector<std::string> queries)
 {
-    DB::ParserQueryWithOutput parser;
     TableList result;
     for (std::string & query : queries)
     {
+        DB::ParserQueryWithOutput parser(query.data() + query.size());
         DB::ASTPtr ast = parseQuery(parser, query.data(), query.data() + query.size(), "", 0, 0);
         for (auto & select : getSelect(ast))
         {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
`EXPLAIN AST` now support queries other then `SELECT`. 

