### PR TITLE
Trying to fix 00620_optimize_on_nonleader_test

### DIFF
--- a/tests/queries/0_stateless/00620_optimize_on_nonleader_replica_zookeeper.sql
+++ b/tests/queries/0_stateless/00620_optimize_on_nonleader_replica_zookeeper.sql
@@ -9,8 +9,8 @@ CREATE TABLE rename2 (p Int64, i Int64, v UInt64) ENGINE = ReplicatedReplacingMe
 INSERT INTO rename1 VALUES (0, 1, 0);
 INSERT INTO rename1 VALUES (0, 1, 1);
 
-OPTIMIZE TABLE rename1;
-OPTIMIZE TABLE rename2;
+OPTIMIZE TABLE rename1 FINAL;
+OPTIMIZE TABLE rename2 FINAL;
 SELECT * FROM rename1;
 
 RENAME TABLE rename2 TO rename3;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

All the times' test fails I see the following lines in logs:

```
2020.12.10 14:26:12.787574 [ 233954 ] {e07e7e18-49f1-4a08-986d-fd98bf9b3551} <Debug> executeQuery: (from [::1]:33482, using old parser) OPTIMIZE TABLE rename1;
2020.12.10 14:26:12.788276 [ 242036 ] {} <Trace> HTTPCommon: Failed communicating with 9b66cc94211f with error 'Received error from remote server ?endpoint=DataPartsExchange%3A%2Fclickhouse%2Ftables%2Fr%2Freplicas%2Fr1&part=all_0_0_0&client_protocol_version=5&compress=false. HTTP status code: 500 Internal Server Error, body: Code: 236, e.displayText() = DB::Exception: Transferring part to replica was cancelled (version 20.13.1.5374 (official build))' will try to reconnect session
2020.12.10 14:26:12.788324 [ 242036 ] {} <Trace> ReadWriteBufferFromHTTP: Sending request to http://9b66cc94211f:9009/?endpoint=DataPartsExchange%3A%2Fclickhouse%2Ftest%2Ftables%2Frename%2Freplicas%2F1&part=0_0_0_0&client_protocol_version=5&compress=false
2020.12.10 14:26:12.788448 [ 233946 ] {} <Trace> InterserverIOHTTPHandler-factory: HTTP Request for InterserverIOHTTPHandler-factory. Method: POST, Address: [::ffff:172.17.0.2]:60688, User-Agent: (none), Content Type: , Transfer Encoding: identity, X-Forwarded-For: (none)
2020.12.10 14:26:12.788513 [ 233946 ] {} <Trace> InterserverIOHTTPHandler: Request URI: ?endpoint=DataPartsExchange%3A%2Fclickhouse%2Ftest%2Ftables%2Frename%2Freplicas%2F1&part=0_0_0_0&client_protocol_version=5&compress=false
2020.12.10 14:26:12.788534 [ 233946 ] {} <Trace> test_3uy56s.rename1 (7cd072fd-64f8-4e9c-a544-7ad2fb61fdc1) (Replicated PartsService): Sending part 0_0_0_0
(7cd072fd-64f8-4e9c-a544-7ad2fb61fdc1): Cannot select parts for optimization: There is no need to merge parts according to merge selector algorithm
```

Examples:
https://gist.github.com/alesapin/021b6bfe0c83157ecd60752ae516bc66
https://gist.github.com/alesapin/a866d4ca29f5f16176ce0a2d58c0bf59
https://gist.github.com/alesapin/92d01cdaada57d0d27b3a18e712d0922

I don't understand how it's connected with merges assignment, just checking test flakiness.