### PR TITLE
fix incorrect initialize MergeTreeWriterSettings

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIOSettings.h
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.h
@@ -22,7 +22,7 @@ struct MergeTreeWriterSettings
     MergeTreeWriterSettings(const Settings & global_settings, bool can_use_adaptive_granularity_,
         size_t aio_threshold_, bool blocks_are_granules_size_ = false)
         : min_compress_block_size(global_settings.min_compress_block_size)
-        , max_compress_block_size(global_settings.min_compress_block_size)
+        , max_compress_block_size(global_settings.max_compress_block_size)
         , aio_threshold(aio_threshold_)
         , can_use_adaptive_granularity(can_use_adaptive_granularity_)
         , blocks_are_granules_size(blocks_are_granules_size_) {}


### PR DESCRIPTION
Original pull-request #17833

For some reason it wasn't backported automatically to 20.8
https://github.com/ClickHouse/ClickHouse/pull/17833#issuecomment-739827311

cc @alexey-milovidov 