### PR TITLE
Better exception message for unknown function

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionFactory.cpp
+++ b/src/AggregateFunctions/AggregateFunctionFactory.cpp
@@ -18,6 +18,7 @@
 #include <Poco/String.h>
 #include "registerAggregateFunctions.h"
 
+#include <Functions/FunctionFactory.h>
 
 namespace DB
 {
@@ -135,12 +136,17 @@ AggregateFunctionPtr AggregateFunctionFactory::getImpl(
         return combinator->transformAggregateFunction(nested_function, out_properties, argument_types, parameters);
     }
 
+
+    String extra_info;
+    if (FunctionFactory::instance().hasNameOrAlias(name))
+        extra_info = ". There is an ordinary function with the same name, but aggregate function is expected here";
+
     auto hints = this->getHints(name);
     if (!hints.empty())
-        throw Exception(fmt::format("Unknown aggregate function {}. Maybe you meant: {}", name, toString(hints)),
-            ErrorCodes::UNKNOWN_AGGREGATE_FUNCTION);
+        throw Exception(ErrorCodes::UNKNOWN_AGGREGATE_FUNCTION,
+                        "Unknown aggregate function {}{}. Maybe you meant: {}", name, extra_info, toString(hints));
     else
-        throw Exception(fmt::format("Unknown aggregate function {}", name), ErrorCodes::UNKNOWN_AGGREGATE_FUNCTION);
+        throw Exception(ErrorCodes::UNKNOWN_AGGREGATE_FUNCTION, "Unknown aggregate function {}{}", name, extra_info);
 }
 
 

--- a/src/Common/IFactoryWithAliases.h
+++ b/src/Common/IFactoryWithAliases.h
@@ -106,6 +106,11 @@ public:
         return aliases.count(name) || case_insensitive_aliases.count(name);
     }
 
+    bool hasNameOrAlias(const String & name) const
+    {
+        return getMap().count(name) || getCaseInsensitiveMap().count(name) || isAlias(name);
+    }
+
     virtual ~IFactoryWithAliases() override {}
 
 private:

--- a/src/Functions/FunctionFactory.cpp
+++ b/src/Functions/FunctionFactory.cpp
@@ -8,6 +8,8 @@
 
 #include <IO/WriteHelpers.h>
 
+#include <AggregateFunctions/AggregateFunctionFactory.h>
+
 namespace DB
 {
 
@@ -46,12 +48,15 @@ FunctionOverloadResolverImplPtr FunctionFactory::getImpl(
     auto res = tryGetImpl(name, context);
     if (!res)
     {
+        String extra_info;
+        if (AggregateFunctionFactory::instance().hasNameOrAlias(name))
+            extra_info = ". There is an aggregate function with the same name, but ordinary function is expected here";
+
         auto hints = this->getHints(name);
         if (!hints.empty())
-            throw Exception("Unknown function " + name + ". Maybe you meant: " + toString(hints),
-                            ErrorCodes::UNKNOWN_FUNCTION);
+            throw Exception(ErrorCodes::UNKNOWN_FUNCTION, "Unknown function {}{}. Maybe you meant: {}", name, extra_info, toString(hints));
         else
-            throw Exception("Unknown function " + name, ErrorCodes::UNKNOWN_FUNCTION);
+            throw Exception(ErrorCodes::UNKNOWN_FUNCTION, "Unknown function {}{}", name, extra_info);
     }
     return res;
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Detailed description / Documentation draft:
If query is complex enough, it may be hard to understand error message like this:
```
:) SELECT a, count() AS cnt FROM (SELECT arrayJoin([1, 2, 3]) AS a) GROUP BY a, cnt

Code: 46. DB::Exception: Received from localhost:9000. DB::Exception: Unknown function count. Maybe you meant: ['round']. 
```
