### PR TITLE
Move check of MADV_DONTNEED into runtime (fixes clickhouse under qemu)

### DIFF
--- a/base/glibc-compatibility/glibc-compatibility.c
+++ b/base/glibc-compatibility/glibc-compatibility.c
@@ -4,10 +4,6 @@
   * Also look at http://www.lightofdawn.org/wiki/wiki.cgi/NewAppsOnOldGlibc
   */
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 #include <pthread.h>
 
 size_t __pthread_get_minstack(const pthread_attr_t * attr)
@@ -179,8 +175,3 @@ void __explicit_bzero_chk(void * buf, size_t len, size_t unused)
 {
     return explicit_bzero(buf, len);
 }
-
-
-#if defined (__cplusplus)
-}
-#endif

--- a/base/glibc-compatibility/madvise.c
+++ b/base/glibc-compatibility/madvise.c
@@ -11,10 +11,6 @@
 
 static int MADV_DONTNEED_works = -1;
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 static int __madvise(void * addr, size_t len, int advice)
 {
     return syscall(SYS_madvise, addr, len, advice);
@@ -94,7 +90,3 @@ int madvise(void * addr, size_t len, int advice)
 {
     return __madvise_safe(addr, len, advice);
 }
-
-#if defined (__cplusplus)
-}
-#endif

--- a/base/glibc-compatibility/madvise.c
+++ b/base/glibc-compatibility/madvise.c
@@ -1,0 +1,100 @@
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/syscall.h>
+#include <sys/mman.h>
+
+#if !defined(unlikely)
+#define unlikely(x) (__builtin_expect(!!(x), 0))
+#endif
+
+static int MADV_DONTNEED_works = -1;
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+static int __madvise(void * addr, size_t len, int advice)
+{
+    return syscall(SYS_madvise, addr, len, advice);
+}
+
+/**
+ * Check for working MADV_DONTNEED at runtime.
+ * If MADV_DONTNEED will not work propertly, madvise will be "patched" to return ENOSYS.
+ *
+ * TL;DR;
+ *
+ * jemalloc relies on working MADV_DONTNEED (that fact that after
+ * madvise(MADV_DONTNEED) returns success, after subsequent access to those
+ * pages they will be zeroed).
+ *
+ * However qemu does not support this, yet [1], and you can get very tricky
+ * assert if you will run clickhouse-server under qemu:
+ *
+ *     <jemalloc>: ../contrib/jemalloc/src/extent.c:1195: Failed assertion: "p[i] == 0"
+ *
+ *   [1]: https://patchwork.kernel.org/patch/10576637/
+ *
+ * And "not supports this" means that it returns 0, not ENOSYS or some other
+ * error.
+ *
+ * Refs: https://gist.github.com/azat/12ba2c825b710653ece34dba7f926ece
+ * Refs: https://github.com/ClickHouse/ClickHouse/pull/15590
+ */
+static int madvise_MADV_DONTNEED_works()
+{
+    int works = -1;
+    size_t size = 1 << 16;
+
+    void * addr1 = mmap(NULL, size, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+    void * addr2 = mmap(NULL, size, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+
+    if (addr1 == MAP_FAILED || addr2 == MAP_FAILED)
+    {
+        abort();
+    }
+
+    memset(addr1, 'A', size);
+    if (__madvise(addr1, size, MADV_DONTNEED) == 0)
+    {
+        works = memcmp(addr1, addr2, size) == 0;
+    }
+    else
+    {
+        /* Avoid checking one more time in case of MADV_DONTNEED does not actually supported. */
+        works = -2;
+    }
+
+    if (munmap(addr1, size) != 0 || munmap(addr2, size) != 0)
+    {
+        abort();
+    }
+
+    return works;
+}
+
+static int __madvise_safe(void * addr, size_t len, int advice)
+{
+    if (unlikely(MADV_DONTNEED_works == -1))
+    {
+        MADV_DONTNEED_works = madvise_MADV_DONTNEED_works();
+    }
+    /* "Patch" to return ENOSYS */
+    if (advice == MADV_DONTNEED && !MADV_DONTNEED_works)
+    {
+        errno = ENOSYS;
+        return -1;
+    }
+    return __madvise(addr, len, advice);
+}
+
+int madvise(void * addr, size_t len, int advice)
+{
+    return __madvise_safe(addr, len, advice);
+}
+
+#if defined (__cplusplus)
+}
+#endif

--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -2,10 +2,6 @@
 #include <setjmp.h>
 #include <unistd.h>
 
-#ifdef __linux__
-#include <sys/mman.h>
-#endif
-
 #include <new>
 #include <iostream>
 #include <vector>
@@ -308,53 +304,11 @@ void checkRequiredInstructions()
     }
 }
 
-#ifdef __linux__
-/// clickhouse uses jemalloc as a production allocator
-/// and jemalloc relies on working MADV_DONTNEED,
-/// which doesn't work under qemu
-///
-/// but do this only under for linux, since only it return zeroed pages after MADV_DONTNEED
-/// (and jemalloc assumes this too, see contrib/jemalloc-cmake/include_linux_x86_64/jemalloc/internal/jemalloc_internal_defs.h.in)
-void checkRequiredMadviseFlags()
-{
-    size_t size = 1 << 16;
-    void * addr = mmap(nullptr, size, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
-    if (addr == MAP_FAILED)
-    {
-        writeError("Can not mmap pages for MADV_DONTNEED check\n");
-        _Exit(1);
-    }
-    memset(addr, 'A', size);
-
-    if (!madvise(addr, size, MADV_DONTNEED))
-    {
-        /// Suboptimal, but should be simple.
-        for (size_t i = 0; i < size; ++i)
-        {
-            if (reinterpret_cast<unsigned char *>(addr)[i] != 0)
-            {
-                writeError("MADV_DONTNEED does not zeroed page. jemalloc will be broken\n");
-                _Exit(1);
-            }
-        }
-    }
-
-    if (munmap(addr, size))
-    {
-        writeError("Can not munmap pages for MADV_DONTNEED check\n");
-        _Exit(1);
-    }
-}
-#endif
-
 struct Checker
 {
     Checker()
     {
         checkRequiredInstructions();
-#ifdef __linux__
-        checkRequiredMadviseFlags();
-#endif
     }
 } checker;
 

--- a/tests/queries/0_stateless/01103_check_cpu_instructions_at_startup.reference
+++ b/tests/queries/0_stateless/01103_check_cpu_instructions_at_startup.reference
@@ -2,4 +2,4 @@ Instruction check fail. The CPU does not support SSSE3 instruction set.
 Instruction check fail. The CPU does not support SSE4.1 instruction set.
 Instruction check fail. The CPU does not support SSE4.2 instruction set.
 Instruction check fail. The CPU does not support POPCNT instruction set.
-MADV_DONTNEED does not zeroed page. jemalloc will be broken
+1


### PR DESCRIPTION
Move check of MADV_DONTNEED (that is required by jemalloc) into runtime (fixes clickhouse under qemu)

Refs: #15174
Refs: #15590
Сс: @alexey-milovidov 

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

*P.S. I've checked it manually*