### PR TITLE
Fix bug for orderby withfill with limit clause

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1026,10 +1026,23 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, const BlockInpu
             /** Optimization - if there are several sources and there is LIMIT, then first apply the preliminary LIMIT,
               * limiting the number of rows in each up to `offset + limit`.
               */
+            bool has_withfill = false;
+            if (query.orderBy())
+            {
+                SortDescription order_descr = getSortDescription(query, *context);
+                for (auto & desc : order_descr)
+                    if (desc.with_fill)
+                    {
+                        has_withfill = true;
+                        break;
+                    }
+            }
+
             bool has_prelimit = false;
             if (!to_aggregation_stage &&
                 query.limitLength() && !query.limit_with_ties && !hasWithTotalsInAnySubqueryInFromClause(query) &&
-                !query.arrayJoinExpressionList() && !query.distinct && !expressions.hasLimitBy() && !settings.extremes)
+                !query.arrayJoinExpressionList() && !query.distinct && !expressions.hasLimitBy() && !settings.extremes &&
+                !has_withfill)
             {
                 executePreLimit(query_plan, false);
                 has_prelimit = true;

--- a/tests/queries/0_stateless/01614_with_fill_with_limit.reference
+++ b/tests/queries/0_stateless/01614_with_fill_with_limit.reference
@@ -1,0 +1,4 @@
+1	original
+2	
+1	original
+2	

--- a/tests/queries/0_stateless/01614_with_fill_with_limit.sql
+++ b/tests/queries/0_stateless/01614_with_fill_with_limit.sql
@@ -1,0 +1,15 @@
+SELECT
+    toFloat32(number % 10) AS n,
+    'original' AS source
+FROM numbers(10)
+WHERE (number % 3) = 1
+ORDER BY n ASC WITH FILL STEP 1
+LIMIT 2;
+
+SELECT
+    toFloat32(number % 10) AS n,
+    'original' AS source
+FROM numbers(10)
+WHERE (number % 3) = 1
+ORDER BY n ASC WITH FILL STEP 1
+LIMIT 2 WITH TIES;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Related to https://github.com/ClickHouse/ClickHouse/issues/17466


Detailed description / Documentation draft:
There are inconsistency between below two queries:
select xxx from table order by with fill limit xxx
select xxx from table order by with fill limit xxx with ties
```
EXPLAIN
SELECT
    toFloat32(number % 10) AS n,
    'original' AS source
FROM numbers(10)
WHERE (number % 3) = 1
ORDER BY n ASC WITH FILL STEP 1
LIMIT 2

Query id: a76cc4a4-88f5-449f-a7b8-599de961fb5d

┌─explain─────────────────────────────────────────────────────────────────────────────────┐
│ Expression (Projection)                                                                 │
│   Filling                                                                               │
│     Limit (preliminary LIMIT)                                                           │
│       MergingSorted (Merge sorted streams for ORDER BY)                                 │
│         MergeSorting (Merge sorted blocks for ORDER BY)                                 │
│           PartialSorting (Sort each block for ORDER BY)                                 │
│             Expression (Before ORDER BY and SELECT)                                     │
│               Filter (WHERE)                                                            │
│                 SettingQuotaAndLimits (Set limits and quota after reading from storage) │
│                   ReadFromStorage (SystemNumbers)                  │
└─────────────────────────────────────────────────────────────────────────────────────────┘

EXPLAIN
SELECT
    toFloat32(number % 10) AS n,
    'original' AS source
FROM numbers(10)
WHERE (number % 3) = 1
ORDER BY n ASC WITH FILL STEP 1
LIMIT 2
 WITH TIES

Query id: 95fcb085-cc0d-4abc-aea4-562ff3a1c39b

┌─explain─────────────────────────────────────────────────────────────────────────────────┐
│ Expression (Projection)                                                                 │
│   Limit (LIMIT WITH TIES)                                                               │
│     Filling                                                                             │
│       MergingSorted (Merge sorted streams for ORDER BY)                                 │
│         MergeSorting (Merge sorted blocks for ORDER BY)                                 │
│           PartialSorting (Sort each block for ORDER BY)                                 │
│             Expression (Before ORDER BY and SELECT)                                     │
│               Filter (WHERE)                                                            │
│                 SettingQuotaAndLimits (Set limits and quota after reading from storage) │
│                   ReadFromStorage (SystemNumbers)                                       │
└─────────────────────────────────────────────────────────────────────────────────────────┘
```

So delay the limit after withfill.