### PR TITLE
Fix branch for anchore/scan-action (master -> main)

### DIFF
--- a/.github/workflows/anchore-analysis.yml
+++ b/.github/workflows/anchore-analysis.yml
@@ -2,7 +2,7 @@
 # vulnerability and compliance scan, and integrates the results with
 # GitHub Advanced Security code scanning feature.  For more information on
 # the Anchore scan action usage and parameters, see
-# https://github.com/anchore/scan-action.  For more information on
+# https://github.com/anchore/scan-action. For more information on
 # Anchore container image scanning in general, see
 # https://docs.anchore.com.
 

--- a/.github/workflows/anchore-analysis.yml
+++ b/.github/workflows/anchore-analysis.yml
@@ -30,8 +30,8 @@ jobs:
     - name: Run the local Anchore scan action itself with GitHub Advanced Security code scanning integration enabled
       uses: anchore/scan-action@main
       with:
-        image-reference: "localbuild/testimage:latest"
-        dockerfile-path: "docker/server/Dockerfile"
+        image: "localbuild/testimage:latest"
+        path: "docker/server/Dockerfile"
         acs-report-enable: true
         fail-build: true
     - name: Upload artifact

--- a/.github/workflows/anchore-analysis.yml
+++ b/.github/workflows/anchore-analysis.yml
@@ -33,7 +33,6 @@ jobs:
       with:
         image: "localbuild/testimage:latest"
         acs-report-enable: true
-        fail-build: true
     - name: Upload Anchore Scan Report
       uses: github/codeql-action/upload-sarif@v1
       with:

--- a/.github/workflows/anchore-analysis.yml
+++ b/.github/workflows/anchore-analysis.yml
@@ -30,7 +30,6 @@ jobs:
     - name: Run the local Anchore scan action itself with GitHub Advanced Security code scanning integration enabled
       uses: anchore/scan-action@main
       with:
-        image: "localbuild/testimage:latest"
         path: "docker/server/Dockerfile"
         acs-report-enable: true
         fail-build: true

--- a/.github/workflows/anchore-analysis.yml
+++ b/.github/workflows/anchore-analysis.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Run the local Anchore scan action itself with GitHub Advanced Security code scanning integration enabled
       uses: anchore/scan-action@main
       with:
-        path: "docker/server/Dockerfile"
+        path: "docker/server"
         acs-report-enable: true
         fail-build: true
     - name: Upload artifact

--- a/.github/workflows/anchore-analysis.yml
+++ b/.github/workflows/anchore-analysis.yml
@@ -28,17 +28,13 @@ jobs:
         perl -pi -e 's|=\$version||g' Dockerfile
         docker build . --file Dockerfile --tag localbuild/testimage:latest      
     - name: Run the local Anchore scan action itself with GitHub Advanced Security code scanning integration enabled
-      uses: anchore/scan-action@main
+      uses: anchore/scan-action@v2
+      id: scan
       with:
-        path: "docker/server"
+        image: "localbuild/testimage:latest"
         acs-report-enable: true
         fail-build: true
-    - name: Upload artifact
-      uses: actions/upload-artifact@v1.0.0
-      with:
-        name: AnchoreReports
-        path: ./anchore-reports/
     - name: Upload Anchore Scan Report
       uses: github/codeql-action/upload-sarif@v1
       with:
-        sarif_file: results.sarif
+        sarif_file: ${{ steps.scan.outputs.sarif }}

--- a/.github/workflows/anchore-analysis.yml
+++ b/.github/workflows/anchore-analysis.yml
@@ -1,6 +1,6 @@
 # This workflow checks out code, performs an Anchore container image
 # vulnerability and compliance scan, and integrates the results with
-# GitHub Advanced Security code scanning feature.  For more information on
+# GitHub Advanced Security code scanning feature. For more information on
 # the Anchore scan action usage and parameters, see
 # https://github.com/anchore/scan-action. For more information on
 # Anchore container image scanning in general, see

--- a/.github/workflows/anchore-analysis.yml
+++ b/.github/workflows/anchore-analysis.yml
@@ -28,7 +28,7 @@ jobs:
         perl -pi -e 's|=\$version||g' Dockerfile
         docker build . --file Dockerfile --tag localbuild/testimage:latest      
     - name: Run the local Anchore scan action itself with GitHub Advanced Security code scanning integration enabled
-      uses: anchore/scan-action@master
+      uses: anchore/scan-action@main
       with:
         image-reference: "localbuild/testimage:latest"
         dockerfile-path: "docker/server/Dockerfile"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Update `anchore/scan-action@main` workflow action (was moved from master)
