### PR TITLE
Try to make clickhouse-install work on mac

### DIFF
--- a/programs/install/Install.cpp
+++ b/programs/install/Install.cpp
@@ -165,11 +165,10 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
             Exception(ErrorCodes::FILE_DOESNT_EXIST, "Cannot obtain path to the binary");
 
         fs::path binary_self_path(path);
-#endif
-
-#if defined(OS_LINUX)
+#else
         fs::path binary_self_path = "/proc/self/exe";
 #endif
+
         if (!fs::exists(binary_self_path))
             throw Exception(ErrorCodes::FILE_DOESNT_EXIST, "Cannot obtain path to the binary from {}, file doesn't exist",
                             binary_self_path.string());

--- a/programs/install/Install.cpp
+++ b/programs/install/Install.cpp
@@ -151,17 +151,17 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
     try
     {
         /// We need to copy binary to the binary directory.
-        /// The binary is currently run. We need to obtain its path from procfs.
+        /// The binary is currently run. We need to obtain its path from procfs (on Linux).
 
 #if defined(OS_DARWIN)
-        uint32_t lenght = 0;
-        _NSGetExecutablePath(nullptr, &length);
-        if (length <= 1) 
+        uint32_t path_length = 0;
+        _NSGetExecutablePath(nullptr, &path_length);
+        if (path_length <= 1) 
             Exception(ErrorCodes::FILE_DOESNT_EXIST, "Cannot obtain path to the binary");
 
-        std::string path(length, std::string::value_type());
-        auto result = _NSGetExecutablePath(&path[0], &length);
-        if (result != 0)
+        std::string path(path_length, std::string::value_type());
+        auto res = _NSGetExecutablePath(&path[0], &path_length);
+        if (res != 0)
             Exception(ErrorCodes::FILE_DOESNT_EXIST, "Cannot obtain path to the binary");
 
         fs::path binary_self_path(path);

--- a/programs/install/Install.cpp
+++ b/programs/install/Install.cpp
@@ -156,7 +156,7 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
 #if defined(OS_DARWIN)
         uint32_t path_length = 0;
         _NSGetExecutablePath(nullptr, &path_length);
-        if (path_length <= 1) 
+        if (path_length <= 1)
             Exception(ErrorCodes::FILE_DOESNT_EXIST, "Cannot obtain path to the binary");
 
         std::string path(path_length, std::string::value_type());
@@ -179,6 +179,8 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
         /// Copy binary to the destination directory.
 
         /// TODO An option to link instead of copy - useful for developers.
+
+        std::cout << options["prefix"].as<std::string>() << std::endl;
 
         fs::path prefix = fs::path(options["prefix"].as<std::string>());
         fs::path bin_dir = prefix / fs::path(options["binary-path"].as<std::string>());

--- a/programs/install/Install.cpp
+++ b/programs/install/Install.cpp
@@ -156,7 +156,7 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
 #if defined(OS_DARWIN)
         uint32_t path_length = 0;
         _NSGetExecutablePath(nullptr, &path_length);
-        if (path_length <= 1) 
+        if (path_length <= 1)
             Exception(ErrorCodes::FILE_DOESNT_EXIST, "Cannot obtain path to the binary");
 
         std::string path(path_length, std::string::value_type());

--- a/programs/install/Install.cpp
+++ b/programs/install/Install.cpp
@@ -156,7 +156,7 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
 #if defined(OS_DARWIN)
         uint32_t path_length = 0;
         _NSGetExecutablePath(nullptr, &path_length);
-        if (path_length <= 1)
+        if (path_length <= 1) 
             Exception(ErrorCodes::FILE_DOESNT_EXIST, "Cannot obtain path to the binary");
 
         std::string path(path_length, std::string::value_type());
@@ -179,8 +179,6 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
         /// Copy binary to the destination directory.
 
         /// TODO An option to link instead of copy - useful for developers.
-
-        std::cout << options["prefix"].as<std::string>() << std::endl;
 
         fs::path prefix = fs::path(options["prefix"].as<std::string>());
         fs::path bin_dir = prefix / fs::path(options["binary-path"].as<std::string>());


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now clickhouse-install could work on Mac. The problem was that there is no procfs on this platform.

