### PR TITLE
Do not use non thread-safe function `strerror`

### DIFF
--- a/base/common/ReadlineLineReader.cpp
+++ b/base/common/ReadlineLineReader.cpp
@@ -1,4 +1,5 @@
 #include <common/ReadlineLineReader.h>
+#include <common/errnoToString.h>
 #include <ext/scope_guard.h>
 
 #include <errno.h>
@@ -69,7 +70,7 @@ ReadlineLineReader::ReadlineLineReader(
     {
         int res = read_history(history_file_path.c_str());
         if (res)
-            std::cerr << "Cannot read history from file " + history_file_path + ": "+ strerror(errno) << std::endl;
+            std::cerr << "Cannot read history from file " + history_file_path + ": "+ errnoToString(errno) << std::endl;
     }
 
     /// Added '.' to the default list. Because it is used to separate database and table.
@@ -107,7 +108,7 @@ ReadlineLineReader::ReadlineLineReader(
     };
 
     if (signal(SIGINT, clear_prompt_or_exit) == SIG_ERR)
-        throw std::runtime_error(std::string("Cannot set signal handler for readline: ") + strerror(errno));
+        throw std::runtime_error(std::string("Cannot set signal handler for readline: ") + errnoToString(errno));
 
     rl_variable_bind("completion-ignore-case", "on");
     // TODO: it doesn't work

--- a/base/common/ReplxxLineReader.cpp
+++ b/base/common/ReplxxLineReader.cpp
@@ -47,7 +47,7 @@ ReplxxLineReader::ReplxxLineReader(
             {
                 if (!rx.history_load(history_file_path))
                 {
-                    rx.print("Loading history failed: %s\n", strerror(errno));
+                    rx.print("Loading history failed: %s\n", errnoToString(errno).c_str());
                 }
 
                 if (flock(history_file_fd, LOCK_UN))
@@ -88,7 +88,7 @@ ReplxxLineReader::ReplxxLineReader(
 ReplxxLineReader::~ReplxxLineReader()
 {
     if (close(history_file_fd))
-        rx.print("Close of history file failed: %s\n", strerror(errno));
+        rx.print("Close of history file failed: %s\n", errnoToString(errno).c_str());
 }
 
 LineReader::InputStatus ReplxxLineReader::readOneLine(const String & prompt)
@@ -113,7 +113,7 @@ void ReplxxLineReader::addToHistory(const String & line)
     // and that is why flock() is added here.
     bool locked = false;
     if (flock(history_file_fd, LOCK_EX))
-        rx.print("Lock of history file failed: %s\n", strerror(errno));
+        rx.print("Lock of history file failed: %s\n", errnoToString(errno).c_str());
     else
         locked = true;
 
@@ -121,10 +121,10 @@ void ReplxxLineReader::addToHistory(const String & line)
 
     // flush changes to the disk
     if (!rx.history_save(history_file_path))
-        rx.print("Saving history failed: %s\n", strerror(errno));
+        rx.print("Saving history failed: %s\n", errnoToString(errno).c_str());
 
     if (locked && 0 != flock(history_file_fd, LOCK_UN))
-        rx.print("Unlock of history file failed: %s\n", strerror(errno));
+        rx.print("Unlock of history file failed: %s\n", errnoToString(errno).c_str());
 }
 
 void ReplxxLineReader::enableBracketedPaste()

--- a/base/common/setTerminalEcho.cpp
+++ b/base/common/setTerminalEcho.cpp
@@ -1,6 +1,7 @@
 // https://stackoverflow.com/questions/1413445/reading-a-password-from-stdcin
 
 #include <common/setTerminalEcho.h>
+#include <common/errnoToString.h>
 #include <stdexcept>
 #include <cstring>
 #include <string>
@@ -31,7 +32,7 @@ void setTerminalEcho(bool enable)
 #else
     struct termios tty;
     if (tcgetattr(STDIN_FILENO, &tty))
-        throw std::runtime_error(std::string("setTerminalEcho failed get: ") + strerror(errno));
+        throw std::runtime_error(std::string("setTerminalEcho failed get: ") + errnoToString(errno));
     if (!enable)
         tty.c_lflag &= ~ECHO;
     else
@@ -39,6 +40,6 @@ void setTerminalEcho(bool enable)
 
     auto ret = tcsetattr(STDIN_FILENO, TCSANOW, &tty);
     if (ret)
-        throw std::runtime_error(std::string("setTerminalEcho failed set: ") + strerror(errno));
+        throw std::runtime_error(std::string("setTerminalEcho failed set: ") + errnoToString(errno));
 #endif
 }

--- a/src/Common/Config/ConfigProcessor.cpp
+++ b/src/Common/Config/ConfigProcessor.cpp
@@ -16,8 +16,10 @@
 #include <Common/StringUtils/StringUtils.h>
 #include <Common/Exception.h>
 #include <common/getResource.h>
+#include <common/errnoToString.h>
 #include <IO/WriteBufferFromString.h>
 #include <IO/Operators.h>
+
 
 #define PREPROCESSED_SUFFIX "-preprocessed"
 
@@ -234,7 +236,7 @@ static std::string layerFromHost()
 {
     utsname buf;
     if (uname(&buf))
-        throw Poco::Exception(std::string("uname failed: ") + std::strerror(errno));
+        throw Poco::Exception(std::string("uname failed: ") + errnoToString(errno));
 
     std::string layer = numberFromHost(buf.nodename);
     if (layer.empty())

--- a/src/Common/ThreadProfileEvents.cpp
+++ b/src/Common/ThreadProfileEvents.cpp
@@ -21,6 +21,9 @@
 #include <sys/types.h>
 #include <dirent.h>
 
+#include <common/errnoToString.h>
+
+
 namespace DB
 {
 
@@ -246,7 +249,7 @@ static void enablePerfEvent(int event_fd)
     {
         LOG_WARNING(&Poco::Logger::get("PerfEvents"),
             "Can't enable perf event with file descriptor {}: '{}' ({})",
-            event_fd, strerror(errno), errno);
+            event_fd, errnoToString(errno), errno);
     }
 }
 
@@ -256,7 +259,7 @@ static void disablePerfEvent(int event_fd)
     {
         LOG_WARNING(&Poco::Logger::get("PerfEvents"),
             "Can't disable perf event with file descriptor {}: '{}' ({})",
-            event_fd, strerror(errno), errno);
+            event_fd, errnoToString(errno), errno);
     }
 }
 
@@ -266,7 +269,7 @@ static void releasePerfEvent(int event_fd)
     {
         LOG_WARNING(&Poco::Logger::get("PerfEvents"),
             "Can't close perf event file descriptor {}: {} ({})",
-            event_fd, strerror(errno), errno);
+            event_fd, errnoToString(errno), errno);
     }
 }
 
@@ -284,7 +287,7 @@ static bool validatePerfEventDescriptor(int & fd)
     {
         LOG_WARNING(&Poco::Logger::get("PerfEvents"),
             "Error while checking availability of event descriptor {}: {} ({})",
-            fd, strerror(errno), errno);
+            fd, errnoToString(errno), errno);
 
         disablePerfEvent(fd);
         releasePerfEvent(fd);
@@ -391,7 +394,7 @@ bool PerfEventsCounters::processThreadLocalChanges(const std::string & needed_ev
             LOG_WARNING(&Poco::Logger::get("PerfEvents"),
                 "Failed to open perf event {} (event_type={}, event_config={}): "
                 "'{}' ({})", event_info.settings_name, event_info.event_type,
-                event_info.event_config, strerror(errno), errno);
+                event_info.event_config, errnoToString(errno), errno);
         }
     }
 
@@ -477,7 +480,7 @@ void PerfEventsCounters::finalizeProfileEvents(ProfileEvents::Counters & profile
         {
             LOG_WARNING(&Poco::Logger::get("PerfEvents"),
                 "Can't read event value from file descriptor {}: '{}' ({})",
-                fd, strerror(errno), errno);
+                fd, errnoToString(errno), errno);
             current_values[i] = {};
         }
     }


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not use non thread-safe function `strerror`.