### PR TITLE
Fix access rights for SELECT count()

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -234,7 +234,7 @@ static void checkAccessRightsForSelect(
             if (access->isGranted(AccessType::SELECT, table_id.database_name, table_id.table_name, column.name))
                 return;
         }
-        throw Exception(context.getUserName() + " : Not enough privileges. "
+        throw Exception(context.getUserName() + ": Not enough privileges. "
                         "To execute this query it's necessary to have grant SELECT for at least one column on " + table_id.getFullTableName(),
                         ErrorCodes::ACCESS_DENIED);
     }

--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -588,11 +588,13 @@ void TreeRewriterResult::collectUsedColumns(const ASTPtr & query, bool is_select
                 required.insert(column_name_type.name);
     }
 
-    /// You need to read at least one column to find the number of rows.
-    if (is_select && required.empty())
+    /// Figure out if we're able to use the trivial count optimization.
+    has_explicit_columns = !required.empty();
+    if (is_select && !has_explicit_columns)
     {
         optimize_trivial_count = true;
 
+        /// You need to read at least one column to find the number of rows.
         /// We will find a column with minimum <compressed_size, type_size, uncompressed_size>.
         /// Because it is the column that is cheapest to read.
         struct ColumnSizeTuple

--- a/src/Interpreters/TreeRewriter.h
+++ b/src/Interpreters/TreeRewriter.h
@@ -53,6 +53,13 @@ struct TreeRewriterResult
     /// Predicate optimizer overrides the sub queries
     bool rewrite_subqueries = false;
 
+    /// Whether the query contains explicit columns like "SELECT column1 + column2 FROM table1".
+    /// Queries like "SELECT count() FROM table1", "SELECT 1" don't contain explicit columns.
+    bool has_explicit_columns = false;
+
+    /// Whether it's possible to use the trivial count optimization,
+    /// i.e. use a fast call of IStorage::totalRows() (or IStorage::totalRowsByPartitionPredicate())
+    /// instead of actual retrieving columns and counting rows.
     bool optimize_trivial_count = false;
 
     /// Cache isRemote() call for storage, because it may be too heavy.

--- a/tests/integration/test_select_access_rights/test.py
+++ b/tests/integration/test_select_access_rights/test.py
@@ -155,3 +155,25 @@ def test_select_union():
 
     instance.query("REVOKE SELECT ON default.table1 FROM A")
     assert "it's necessary to have grant SELECT(a, b) ON default.table1" in instance.query_and_get_error(select_query, user = 'A')
+
+
+def test_select_count():
+    instance.query("CREATE TABLE table1(x String, y UInt8) ENGINE = MergeTree ORDER BY tuple()")
+
+    select_query = "SELECT count() FROM table1"
+    assert "it's necessary to have grant SELECT for at least one column on default.table1" in instance.query_and_get_error(select_query, user = 'A')
+
+    instance.query("GRANT SELECT(x) ON default.table1 TO A")
+    assert instance.query(select_query, user = 'A') == "0\n"
+
+    instance.query("REVOKE SELECT(x) ON default.table1 FROM A")
+    assert "it's necessary to have grant SELECT for at least one column on default.table1" in instance.query_and_get_error(select_query, user = 'A')
+
+    instance.query("GRANT SELECT(y) ON default.table1 TO A")
+    assert instance.query(select_query, user = 'A') == "0\n"
+
+    instance.query("REVOKE SELECT(y) ON default.table1 FROM A")
+    assert "it's necessary to have grant SELECT for at least one column on default.table1" in instance.query_and_get_error(select_query, user = 'A')
+
+    instance.query("GRANT SELECT ON default.table1 TO A")
+    assert instance.query(select_query, user = 'A') == "0\n"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Bug Fix

Changelog entry:
`SELECT count() FROM table` now can be executed if only one any column can be selected from the `table`.
This PR fixes https://github.com/ClickHouse/ClickHouse/issues/10639