### PR TITLE
Fixes in ODBC dictionary reload and ODBC bridge reachability

### DIFF
--- a/programs/odbc-bridge/ODBCBridge.cpp
+++ b/programs/odbc-bridge/ODBCBridge.cpp
@@ -89,7 +89,7 @@ void ODBCBridge::defineOptions(Poco::Util::OptionSet & options)
 {
     options.addOption(Poco::Util::Option("http-port", "", "port to listen").argument("http-port", true).binding("http-port"));
     options.addOption(
-        Poco::Util::Option("listen-host", "", "hostname to listen, default localhost").argument("listen-host").binding("listen-host"));
+        Poco::Util::Option("listen-host", "", "hostname or address to listen, default 127.0.0.1").argument("listen-host").binding("listen-host"));
     options.addOption(
         Poco::Util::Option("http-timeout", "", "http timeout for socket, default 1800").argument("http-timeout").binding("http-timeout"));
 
@@ -161,7 +161,7 @@ void ODBCBridge::initialize(Application & self)
     BaseDaemon::logRevision();
 
     log = &logger();
-    hostname = config().getString("listen-host", "localhost");
+    hostname = config().getString("listen-host", "127.0.0.1");
     port = config().getUInt("http-port");
     if (port > 0xFFFF)
         throw Exception("Out of range 'http-port': " + std::to_string(port), ErrorCodes::ARGUMENT_OUT_OF_BOUND);

--- a/src/Common/XDBCBridgeHelper.h
+++ b/src/Common/XDBCBridgeHelper.h
@@ -76,7 +76,7 @@ public:
     const Context & context;
     const Configuration & config;
 
-    static constexpr inline auto DEFAULT_HOST = "localhost";
+    static constexpr inline auto DEFAULT_HOST = "127.0.0.1";
     static constexpr inline auto DEFAULT_PORT = BridgeHelperMixin::DEFAULT_PORT;
     static constexpr inline auto PING_HANDLER = "/ping";
     static constexpr inline auto MAIN_HANDLER = "/";

--- a/src/Dictionaries/ExternalQueryBuilder.h
+++ b/src/Dictionaries/ExternalQueryBuilder.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <Columns/IColumn.h>
+#include <Dictionaries/DictionaryStructure.h>
 #include <Formats/FormatSettings.h>
 #include <Parsers/IdentifierQuotingStyle.h>
 
@@ -16,11 +17,11 @@ class WriteBuffer;
   */
 struct ExternalQueryBuilder
 {
-    const DictionaryStructure & dict_struct;
-    std::string db;
-    std::string schema;
-    std::string table;
-    const std::string & where;
+    const DictionaryStructure dict_struct;
+    const std::string db;
+    const std::string schema;
+    const std::string table;
+    const std::string where;
 
     IdentifierQuotingStyle quoting_style;
 

--- a/src/IO/ReadWriteBufferFromHTTP.h
+++ b/src/IO/ReadWriteBufferFromHTTP.h
@@ -105,11 +105,11 @@ namespace detail
         RemoteHostFilter remote_host_filter;
         std::function<void(size_t)> next_callback;
 
-        std::istream * call(const Poco::URI uri_, Poco::Net::HTTPResponse & response)
+        std::istream * call(Poco::URI uri_, Poco::Net::HTTPResponse & response)
         {
             // With empty path poco will send "POST  HTTP/1.1" its bug.
-            if (uri.getPath().empty())
-                uri.setPath("/");
+            if (uri_.getPath().empty())
+                uri_.setPath("/");
 
             Poco::Net::HTTPRequest request(method, uri_.getPathAndQuery(), Poco::Net::HTTPRequest::HTTP_1_1);
             request.setHost(uri_.getHost()); // use original, not resolved host name in header
@@ -125,7 +125,7 @@ namespace detail
             if (!credentials.getUsername().empty())
                 credentials.authenticate(request);
 
-            LOG_TRACE((&Poco::Logger::get("ReadWriteBufferFromHTTP")), "Sending request to {}", uri.toString());
+            LOG_TRACE((&Poco::Logger::get("ReadWriteBufferFromHTTP")), "Sending request to {}", uri_.toString());
 
             auto sess = session->getSession();
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Bug Fix

Changelog entry:
- Fixed issue when `clickhouse-odbc-bridge` process is unreachable by server on machines with dual IPv4/IPv6 stack; - Fixed issue when ODBC dictionary updates are performed using malformed queries and/or cause crashes; Possibly closes #14489.

Detailed description:
- `clickhouse-odbc-bridge` now binds to `127.0.0.1` by default instead of `localhost`, this solves a problem when server tries to connect to `::1` while the bridge is listening to `127.0.0.1` when `localhost` resolves to those addresses.
- `ExternalQueryBuilder` instance stores const-refs to members of enclosing object, and when that object is `clone()`'ed and the original object is destroyed, the instance of `ExternalQueryBuilder`, that is stored in the new enclosing object, now refers to the destroyed members and builds queries with garbage in them, accessing the destroyed objects. Fixes now closed #17215.
- Seemingly a typo in `ReadWriteBufferFromHTTPBase::call()`. Fixed.