### PR TITLE
Extend mergetree setting alter restriction

### DIFF
--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -137,7 +137,8 @@ struct MergeTreeSettings : public BaseSettings<MergeTreeSettingsTraits>
     /// We check settings after storage creation
     static bool isReadonlySetting(const String & name)
     {
-        return name == "index_granularity" || name == "index_granularity_bytes";
+        return name == "index_granularity" || name == "index_granularity_bytes" || name == "write_final_mark"
+            || name == "enable_mixed_granularity_parts" || name == "in_memory_parts_enable_wal";
     }
 
     static bool isPartFormatSetting(const String & name)

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -138,7 +138,7 @@ struct MergeTreeSettings : public BaseSettings<MergeTreeSettingsTraits>
     static bool isReadonlySetting(const String & name)
     {
         return name == "index_granularity" || name == "index_granularity_bytes" || name == "write_final_mark"
-            || name == "enable_mixed_granularity_parts" || name == "in_memory_parts_enable_wal";
+            || name == "enable_mixed_granularity_parts";
     }
 
     static bool isPartFormatSetting(const String & name)

--- a/tests/integration/test_polymorphic_parts/test.py
+++ b/tests/integration/test_polymorphic_parts/test.py
@@ -431,7 +431,7 @@ def test_in_memory_wal(start_cluster):
     node11.exec_in_container(['bash', '-c', 'test -s {}'.format(wal_file)])
     # Check file exists
     node11.exec_in_container(['bash', '-c', 'test -f {}'.format(broken_wal_file)])
-    
+
     # Data is lost without WAL
     node11.query("ALTER TABLE wal_table MODIFY SETTING in_memory_parts_enable_wal = 0")
     with PartitionManager() as pm:

--- a/tests/integration/test_polymorphic_parts/test.py
+++ b/tests/integration/test_polymorphic_parts/test.py
@@ -432,17 +432,6 @@ def test_in_memory_wal(start_cluster):
     # Check file exists
     node11.exec_in_container(['bash', '-c', 'test -f {}'.format(broken_wal_file)])
 
-    # Data is lost without WAL
-    node11.query("ALTER TABLE wal_table MODIFY SETTING in_memory_parts_enable_wal = 0")
-    with PartitionManager() as pm:
-        pm.partition_instances(node11, node12)
-
-        insert_random_data('wal_table', node11, 50)
-        check(node11, 350, 7)
-
-        node11.restart_clickhouse(kill=True)
-        check(node11, 300, 6)
-
 
 def test_in_memory_wal_rotate(start_cluster):
     # Write every part to single wal

--- a/tests/integration/test_polymorphic_parts/test.py
+++ b/tests/integration/test_polymorphic_parts/test.py
@@ -433,6 +433,7 @@ def test_in_memory_wal(start_cluster):
     node11.exec_in_container(['bash', '-c', 'test -f {}'.format(broken_wal_file)])
     # Data is lost without WAL
     node11.query("ALTER TABLE wal_table MODIFY SETTING in_memory_parts_enable_wal = 0")
+    
     with PartitionManager() as pm:
         pm.partition_instances(node11, node12)
 
@@ -441,7 +442,7 @@ def test_in_memory_wal(start_cluster):
 
         node11.restart_clickhouse(kill=True)
         check(node11, 300, 6)
-        
+
 
 def test_in_memory_wal_rotate(start_cluster):
     # Write every part to single wal

--- a/tests/integration/test_polymorphic_parts/test.py
+++ b/tests/integration/test_polymorphic_parts/test.py
@@ -431,7 +431,17 @@ def test_in_memory_wal(start_cluster):
     node11.exec_in_container(['bash', '-c', 'test -s {}'.format(wal_file)])
     # Check file exists
     node11.exec_in_container(['bash', '-c', 'test -f {}'.format(broken_wal_file)])
+    # Data is lost without WAL
+    node11.query("ALTER TABLE wal_table MODIFY SETTING in_memory_parts_enable_wal = 0")
+    with PartitionManager() as pm:
+        pm.partition_instances(node11, node12)
 
+        insert_random_data('wal_table', node11, 50)
+        check(node11, 350, 7)
+
+        node11.restart_clickhouse(kill=True)
+        check(node11, 300, 6)
+        
 
 def test_in_memory_wal_rotate(start_cluster):
     # Write every part to single wal

--- a/tests/integration/test_polymorphic_parts/test.py
+++ b/tests/integration/test_polymorphic_parts/test.py
@@ -431,9 +431,9 @@ def test_in_memory_wal(start_cluster):
     node11.exec_in_container(['bash', '-c', 'test -s {}'.format(wal_file)])
     # Check file exists
     node11.exec_in_container(['bash', '-c', 'test -f {}'.format(broken_wal_file)])
+    
     # Data is lost without WAL
     node11.query("ALTER TABLE wal_table MODIFY SETTING in_memory_parts_enable_wal = 0")
-    
     with PartitionManager() as pm:
         pm.partition_instances(node11, node12)
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Backward Incompatible Change


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Restrict `ALTER MODIFY SETTING` from changing storage settings that affects data parts (`write_final_mark` and `enable_mixed_granularity_parts`)
