### PR TITLE
Fix clickhouse-test

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -688,7 +688,7 @@ def main(args):
                 prefix, suffix = item.split('_', 1)
 
                 try:
-                    return reverse * int(prefix), suffix
+                    return reverse * int(prefix)
                 except ValueError:
                     return 99997
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Python gives an error: `TypeError: '<' not supported between instances of 'int' and 'tuple'`