### PR TITLE
Return back some configs, that are used in Arcadia

### DIFF
--- a/tests/client-test.xml
+++ b/tests/client-test.xml
@@ -1,0 +1,17 @@
+<!-- Config for connecting to test server in Arcadia -->
+<yandex>
+    <tcp_port>59000</tcp_port>
+    <tcp_port_secure>59440</tcp_port_secure>
+    <openSSL>
+        <client>
+            <loadDefaultCAFile>true</loadDefaultCAFile>
+            <cacheSessions>true</cacheSessions>
+            <disableProtocols>sslv2,sslv3</disableProtocols>
+            <preferServerCiphers>true</preferServerCiphers>
+            <verificationMode>none</verificationMode>
+            <invalidCertificateHandler>
+                <name>AcceptCertificateHandler</name>
+            </invalidCertificateHandler>
+        </client>
+    </openSSL>
+</yandex>

--- a/tests/server-test.xml
+++ b/tests/server-test.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0"?>
+<!-- Config for test server in Arcadia -->
+<yandex>
+    <logger>
+        <level>trace</level>
+        <log>/tmp/clickhouse/log/clickhouse-server.log</log>
+        <errorlog>/tmp/clickhouse/log/clickhouse-server.err.log</errorlog>
+        <size>10M</size>
+        <count>1</count>
+        <compress>0</compress>
+    </logger>
+    <listen_host>::</listen_host>
+    <listen_host>0.0.0.0</listen_host>
+    <listen_try>1</listen_try>
+    <http_port>58123</http_port>
+    <tcp_port>59000</tcp_port>
+    <https_port>58443</https_port>
+    <tcp_port_secure>59440</tcp_port_secure>
+    <interserver_http_port>59009</interserver_http_port>
+    <max_thread_pool_size>10000</max_thread_pool_size>
+    <openSSL>
+        <server> <!-- Used for https server AND secure tcp port -->
+            <!-- openssl req -subj "/CN=localhost" -new -newkey rsa:2048 -days 365 -nodes -x509 -keyout /etc/clickhouse-server/server.key -out /etc/clickhouse-server/server.crt -->
+            <certificateFile>/tmp/clickhouse/etc/server.crt</certificateFile>
+            <privateKeyFile>/tmp/clickhouse/etc/server.key</privateKeyFile>
+            <!-- openssl dhparam -out /etc/clickhouse-server/dhparam.pem 4096 -->
+            <dhParamsFile>/tmp/clickhouse/etc/dhparam.pem</dhParamsFile>
+            <verificationMode>none</verificationMode>
+            <loadDefaultCAFile>true</loadDefaultCAFile>
+            <cacheSessions>true</cacheSessions>
+            <disableProtocols>sslv2,sslv3</disableProtocols>
+            <preferServerCiphers>true</preferServerCiphers>
+        </server>
+
+        <client> <!-- Used for connecting to https dictionary source and secured Zookeeper communication -->
+            <loadDefaultCAFile>true</loadDefaultCAFile>
+            <cacheSessions>true</cacheSessions>
+            <disableProtocols>sslv2,sslv3</disableProtocols>
+            <preferServerCiphers>true</preferServerCiphers>
+            <verificationMode>none</verificationMode>
+            <invalidCertificateHandler>
+                <name>AcceptCertificateHandler</name>
+            </invalidCertificateHandler>
+        </client>
+    </openSSL>
+
+    <keep_alive_timeout>3</keep_alive_timeout>
+    <path>/tmp/clickhouse/data/</path>
+    <tmp_path>/tmp/clickhouse/tmp/</tmp_path>
+    <users_config>users.xml</users_config>
+    <access_control_path>/tmp/clickhouse/data/access/</access_control_path>
+    <custom_settings_prefixes>custom_</custom_settings_prefixes>
+    <mark_cache_size>5368709120</mark_cache_size>
+    <default_profile>default</default_profile>
+    <default_database>default</default_database>
+    <timezone>Europe/Moscow</timezone>
+    <remote_servers incl="clickhouse_remote_servers" >
+        <!-- Test only shard config for testing distributed storage -->
+        <test_unavailable_shard>
+            <shard>
+                <replica>
+                    <host>localhost</host>
+                    <port>59000</port>
+                </replica>
+            </shard>
+            <shard>
+                <replica>
+                    <host>localhost</host>
+                    <port>1</port>
+                </replica>
+            </shard>
+        </test_unavailable_shard>
+        <test_shard_localhost>
+            <shard>
+                <replica>
+                    <host>localhost</host>
+                    <port>59000</port>
+                </replica>
+            </shard>
+        </test_shard_localhost>
+        <test_cluster_two_shards>
+            <shard>
+                <replica>
+                    <host>127.0.0.1</host>
+                    <port>59000</port>
+                </replica>
+            </shard>
+            <shard>
+                <replica>
+                    <host>127.0.0.2</host>
+                    <port>59000</port>
+                </replica>
+            </shard>
+        </test_cluster_two_shards>
+        <test_cluster_two_shards_localhost>
+            <shard>
+                <replica>
+                    <host>localhost</host>
+                    <port>59000</port>
+                </replica>
+            </shard>
+            <shard>
+                <replica>
+                    <host>localhost</host>
+                    <port>59000</port>
+                </replica>
+            </shard>
+        </test_cluster_two_shards_localhost>
+        <test_shard_localhost_secure>
+            <shard>
+                <replica>
+                    <host>localhost</host>
+                    <port>59440</port>
+                    <secure>1</secure>
+                </replica>
+            </shard>
+        </test_shard_localhost_secure>
+    </remote_servers>
+    <include_from/>
+    <zookeeper incl="zookeeper-servers" optional="true" />
+    <macros incl="macros" optional="true" />
+    <builtin_dictionaries_reload_interval>3600</builtin_dictionaries_reload_interval>
+    <max_session_timeout>3600</max_session_timeout>
+    <default_session_timeout>60</default_session_timeout>
+    <query_log>
+        <database>system</database>
+        <table>query_log</table>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    </query_log>
+    <dictionaries_config>*_dictionary.xml</dictionaries_config>
+    <compression incl="clickhouse_compression">
+    </compression>
+    <distributed_ddl>
+        <path>/clickhouse/task_queue/ddl</path>
+    </distributed_ddl>
+    <format_schema_path>/tmp/clickhouse/data/format_schemas/</format_schema_path>
+    <query_masking_rules>
+        <rule>
+            <regexp>TOPSECRET.TOPSECRET</regexp>
+            <replace>[hidden]</replace>
+        </rule>
+    </query_masking_rules>
+</yandex>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
