### PR TITLE
Do not override RULE_LAUNCH_COMPILE/RULE_LAUNCH_LINK in rocksdb

### DIFF
--- a/contrib/rocksdb-cmake/CMakeLists.txt
+++ b/contrib/rocksdb-cmake/CMakeLists.txt
@@ -2,12 +2,6 @@
 set(ROCKSDB_SOURCE_DIR "${ClickHouse_SOURCE_DIR}/contrib/rocksdb")
 list(APPEND CMAKE_MODULE_PATH "${ROCKSDB_SOURCE_DIR}/cmake/modules/")
 
-find_program(CCACHE_FOUND ccache)
-if(CCACHE_FOUND)
-  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
-endif(CCACHE_FOUND)
-
 if (SANITIZE STREQUAL "undefined")
     set(WITH_UBSAN ON)
 elseif (SANITIZE STREQUAL "address")


### PR DESCRIPTION
- it is already done in in find/ccache.cmake
- it does not respect disabling ccache
- it does not allow to override ccache using custom location (not in
  PATH)

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @sundy-li 
Refs: #15073