### PR TITLE
Make some perf tests faster on slower machines

### DIFF
--- a/tests/performance/constant_column_search.xml
+++ b/tests/performance/constant_column_search.xml
@@ -43,7 +43,7 @@
 
     <query><![CDATA[SELECT DISTINCT Title, multiFuzzyMatchAny(Title, 2, ['^metrika\\.ry$']) AS distance FROM hits_100m_single WHERE distance = 1]]></query>
     <query><![CDATA[SELECT DISTINCT Title, multiFuzzyMatchAny(Title, 5, ['^metrika\\.ry$']) AS distance FROM hits_100m_single WHERE distance = 1]]></query>
-    <query><![CDATA[SELECT sum(multiFuzzyMatchAny(Title, 3, ['hello$', 'world$', '^hello'])) FROM hits_100m_single]]></query>
+    <query><![CDATA[SELECT sum(multiFuzzyMatchAny(Title, 3, ['hello$', 'world$', '^hello'])) FROM (SELECT * FROM hits_100m_single LIMIT 50000000) FORMAT Null]]></query>
     <query><![CDATA[SELECT count() FROM hits_10m_single WHERE multiFuzzyMatchAny(URL, 2, ['about/address', 'for_woman', '^https?://lm-company.ruy/$', 'ultimateguitar.com'])]]></query>
 
 

--- a/tests/performance/countMatches.xml
+++ b/tests/performance/countMatches.xml
@@ -9,14 +9,14 @@
 
     <query>SELECT count() FROM test.hits WHERE NOT ignore(countMatches(URL, 'yandex')) SETTINGS max_threads=2</query>
     <query>SELECT count() FROM test.hits WHERE NOT ignore(countMatches(URL, 'yandex|google')) SETTINGS max_threads=2</query>
-    <query>SELECT count() FROM test.hits WHERE NOT ignore(countMatches(URL, '(\\w+=\\w+)')) SETTINGS max_threads=2</query>
+    <query>SELECT count() FROM test.hits WHERE NOT ignore(countMatches(URL, '(\\w+=\\w+)')) SETTINGS max_threads=4</query>
 
     <query>SELECT count() FROM test.hits WHERE NOT ignore(countMatchesCaseInsensitive(URL, 'yandex')) SETTINGS max_threads=2</query>
     <query>SELECT count() FROM test.hits WHERE NOT ignore(countMatchesCaseInsensitive(URL, 'yandex|google')) SETTINGS max_threads=2</query>
-    <query>SELECT count() FROM test.hits WHERE NOT ignore(countMatchesCaseInsensitive(URL, '(\\w+=\\w+)')) SETTINGS max_threads=2</query>
+    <query>SELECT count() FROM test.hits WHERE NOT ignore(countMatchesCaseInsensitive(URL, '(\\w+=\\w+)')) SETTINGS max_threads=4</query>
 
     <!-- Another variant of case-insensitivity -->
     <query>SELECT count() FROM test.hits WHERE NOT ignore(countMatches(URL, '(?i)yandex')) SETTINGS max_threads=2</query>
     <query>SELECT count() FROM test.hits WHERE NOT ignore(countMatches(URL, '(?i)yandex|google')) SETTINGS max_threads=2</query>
-    <query>SELECT count() FROM test.hits WHERE NOT ignore(countMatches(URL, '(?i)(\\w+=\\w+)')) SETTINGS max_threads=2</query>
+    <query>SELECT count() FROM test.hits WHERE NOT ignore(countMatches(URL, '(?i)(\\w+=\\w+)')) SETTINGS max_threads=4</query>
 </test>

--- a/tests/performance/general_purpose_hashes.xml
+++ b/tests/performance/general_purpose_hashes.xml
@@ -35,14 +35,14 @@
            <name>table_slow</name>
            <values>
                <value>zeros(1000000)</value>
-               <value>zeros_mt(10000000)</value>
+               <value>zeros_mt(5000000)</value>
            </values>
         </substitution>
         <substitution>
            <name>table</name>
            <values>
                <value>numbers(100000000)</value>
-               <value>numbers_mt(1000000000)</value>
+               <value>numbers_mt(500000000)</value>
            </values>
         </substitution>
     </substitutions>

--- a/tests/performance/generate_table_function.xml
+++ b/tests/performance/generate_table_function.xml
@@ -11,7 +11,7 @@
     <query>SELECT sum(NOT ignore(*)) FROM (SELECT * FROM generateRandom('i Tuple(Int32, Int64)', 0, 10, 10) LIMIT 1000000000);</query>
     <query>SELECT sum(NOT ignore(*)) FROM (SELECT * FROM generateRandom('i Array(Int8)', 0, 10, 10) LIMIT 100000000);</query>
     <query>SELECT sum(NOT ignore(*)) FROM (SELECT * FROM generateRandom('i Array(Nullable(Int32))', 0, 10, 10) LIMIT 100000000);</query>
-    <query>SELECT sum(NOT ignore(*)) FROM (SELECT * FROM generateRandom('i Tuple(Int32, Array(Int64))', 0, 10, 10) LIMIT 1000000000);</query>
+    <query>SELECT sum(NOT ignore(*)) FROM (SELECT * FROM generateRandom('i Tuple(Int32, Array(Int64))', 0, 10, 10) LIMIT 500000000);</query>
     <query>SELECT sum(NOT ignore(*)) FROM (SELECT * FROM generateRandom('i Nullable(String)', 0, 10, 10) LIMIT 100000000);</query>
     <query>SELECT sum(NOT ignore(*)) FROM (SELECT * FROM generateRandom('i Array(String)', 0, 10, 10) LIMIT 100000000);</query>
     <query>SELECT sum(NOT ignore(*)) FROM (SELECT * FROM generateRandom('i UUID', 0, 10, 10) LIMIT 1000000000);</query>

--- a/tests/performance/push_down_limit.xml
+++ b/tests/performance/push_down_limit.xml
@@ -1,7 +1,8 @@
 <test>
     <create_query>CREATE VIEW numbers_view AS SELECT number from numbers_mt(100000000) order by number desc</create_query>
 
-    <query>select number from (select number from numbers(1500000000) order by -number) limit 10</query>
+    <!-- This must have been an EXPLAIN test. -->
+    <query>select number from (select number from numbers(500000000) order by -number) limit 10</query>
     <query>select number from (select number from numbers_mt(1500000000) order by -number) limit 10</query>
 
     <query short="1">select number from numbers_view limit 100</query>

--- a/tests/performance/string_sort.xml
+++ b/tests/performance/string_sort.xml
@@ -35,7 +35,7 @@
     <query><![CDATA[SELECT {str1} FROM hits_100m_single ORDER BY {str1} LIMIT 2000 format Null]]></query>
     <query><![CDATA[SELECT {str1} FROM hits_100m_single ORDER BY {str1} LIMIT 5000 format Null]]></query>
     <query><![CDATA[SELECT {str1} FROM hits_100m_single ORDER BY {str1} LIMIT 10000 format Null]]></query>
-    <query><![CDATA[SELECT {str1} FROM hits_100m_single ORDER BY {str1} LIMIT 65535 format Null]]></query>
+    <query><![CDATA[SELECT {str1} FROM hits_10m_single ORDER BY {str1} LIMIT 65535 format Null]]></query>
 
     <query><![CDATA[SELECT {str1} FROM hits_100m_single ORDER BY {str1}, CounterID LIMIT 10 format Null]]></query>
     <query><![CDATA[SELECT {str1} FROM hits_100m_single ORDER BY {str1}, CounterID LIMIT 300 format Null]]></query>

--- a/tests/performance/url_hits.xml
+++ b/tests/performance/url_hits.xml
@@ -1,13 +1,22 @@
 <test>
     <preconditions>
         <table_exists>hits_100m_single</table_exists>
+        <table_exists>hits_10m_single</table_exists>
         <table_exists>test.hits</table_exists>
     </preconditions>
 
 
     <substitutions>
         <substitution>
-           <name>func</name>
+           <name>func_slow</name>
+           <values>
+               <value>URLHierarchy</value>
+               <value>URLPathHierarchy</value>
+           </values>
+       </substitution>
+
+        <substitution>
+           <name>func_fast</name>
            <values>
                <value>protocol</value>
                <value>domain</value>
@@ -22,8 +31,6 @@
                <value>queryStringAndFragment</value>
                <value>extractURLParameters</value>
                <value>extractURLParameterNames</value>
-               <value>URLHierarchy</value>
-               <value>URLPathHierarchy</value>
                <value>decodeURLComponent</value>
                <value>cutWWW</value>
                <value>cutQueryString</value>
@@ -31,7 +38,9 @@
            </values>
        </substitution>
     </substitutions>
-    <query>SELECT count() FROM hits_100m_single WHERE NOT ignore({func}(URL))</query>
+
+    <query>SELECT count() FROM hits_100m_single WHERE NOT ignore({func_fast}(URL))</query>
+    <query>SELECT count() FROM hits_10m_single  WHERE NOT ignore({func_slow}(URL))</query>
 
     <!-- firstSignificantSubdomain/firstSignificantSubdomainCustom -->
     <query>SELECT count() FROM test.hits WHERE NOT ignore(firstSignificantSubdomain(URL)) SETTINGS max_threads=1</query>

--- a/tests/performance/website.xml
+++ b/tests/performance/website.xml
@@ -36,7 +36,7 @@
 <query>SELECT SearchEngineID, SearchPhrase, count() AS c FROM {table} WHERE SearchPhrase != '' GROUP BY SearchEngineID, SearchPhrase ORDER BY c DESC LIMIT 10</query>
 <query>SELECT UserID, count() FROM {table} GROUP BY UserID ORDER BY count() DESC LIMIT 10</query>
 <query>SELECT UserID, SearchPhrase, count() FROM {table} GROUP BY UserID, SearchPhrase ORDER BY count() DESC LIMIT 10</query>
-<query>SELECT UserID, SearchPhrase, count() FROM {table} GROUP BY UserID, SearchPhrase LIMIT 10</query>
+<query>SELECT UserID, SearchPhrase, count() FROM hits_10m_single GROUP BY UserID, SearchPhrase LIMIT 10</query>
 <query>SELECT UserID, toMinute(EventTime) AS m, SearchPhrase, count() FROM hits_10m_single GROUP BY UserID, m, SearchPhrase ORDER BY count() DESC LIMIT 10</query>
 <query short="1">SELECT count() FROM hits_100m_single WHERE UserID = 12345678901234567890</query>
 <query>SELECT count() FROM hits_100m_single WHERE URL LIKE '%metrika%'</query>


### PR DESCRIPTION
This is a part of the effort to run them on smaller machines in CI. It doesn't really help the quota utilization though...

Changelog category (leave one):
- Not for changelog (changelog entry is not required)