### PR TITLE
Use Port::Data instead of Chunk in LazyOutputFormat.

### DIFF
--- a/src/Processors/Formats/IOutputFormat.h
+++ b/src/Processors/Formats/IOutputFormat.h
@@ -82,8 +82,19 @@ public:
     virtual void doWritePrefix() {}
     virtual void doWriteSuffix() { finalize(); }
 
-    void setTotals(const Block & totals) { consumeTotals(Port::Data{.chunk = Chunk(totals.getColumns(), totals.rows())}); }
-    void setExtremes(const Block & extremes) { consumeExtremes(Port::Data{.chunk = Chunk(extremes.getColumns(), extremes.rows())}); }
+    void setTotals(const Block & totals)
+    {
+        Port::Data data;
+        data.chunk = Chunk(totals.getColumns(), totals.rows());
+        consumeTotals(std::move(data));
+    }
+
+    void setExtremes(const Block & extremes)
+    {
+        Port::Data data;
+        data.chunk = Chunk(extremes.getColumns(), extremes.rows());
+        consumeExtremes(std::move(data));
+    }
 
     size_t getResultRows() const { return result_rows; }
     size_t getResultBytes() const { return result_bytes; }

--- a/src/Processors/Formats/IOutputFormat.h
+++ b/src/Processors/Formats/IOutputFormat.h
@@ -28,7 +28,7 @@ public:
 protected:
     WriteBuffer & out;
 
-    Chunk current_chunk;
+    Port::Data current_chunk;
     PortKind current_block_kind = PortKind::Main;
     bool has_input = false;
     bool finished = false;
@@ -39,9 +39,14 @@ protected:
 
     RowsBeforeLimitCounterPtr rows_before_limit_counter;
 
-    virtual void consume(Chunk) = 0;
+    virtual void consume(Chunk);
     virtual void consumeTotals(Chunk) {}
     virtual void consumeExtremes(Chunk) {}
+
+    virtual void consume(Port::Data data) { consume(data.getChunkOrTrow()); }
+    virtual void consumeTotals(Port::Data data) { consumeTotals(data.getChunkOrTrow()); }
+    virtual void consumeExtremes(Port::Data data) { consumeExtremes(data.getChunkOrTrow()); }
+
     virtual void finalize() {}
 
 public:
@@ -77,8 +82,8 @@ public:
     virtual void doWritePrefix() {}
     virtual void doWriteSuffix() { finalize(); }
 
-    void setTotals(const Block & totals) { consumeTotals(Chunk(totals.getColumns(), totals.rows())); }
-    void setExtremes(const Block & extremes) { consumeExtremes(Chunk(extremes.getColumns(), extremes.rows())); }
+    void setTotals(const Block & totals) { consumeTotals(Port::Data{.chunk = Chunk(totals.getColumns(), totals.rows())}); }
+    void setExtremes(const Block & extremes) { consumeExtremes(Port::Data{.chunk = Chunk(extremes.getColumns(), extremes.rows())}); }
 
     size_t getResultRows() const { return result_rows; }
     size_t getResultBytes() const { return result_bytes; }

--- a/src/Processors/Formats/LazyOutputFormat.cpp
+++ b/src/Processors/Formats/LazyOutputFormat.cpp
@@ -15,24 +15,24 @@ Chunk LazyOutputFormat::getChunk(UInt64 milliseconds)
             return {};
     }
 
-    Chunk chunk;
-    if (!queue.tryPop(chunk, milliseconds))
+    Port::Data data;
+    if (!queue.tryPop(data, milliseconds))
         return {};
 
-    if (chunk)
-        info.update(chunk.getNumRows(), chunk.allocatedBytes());
+    if (!data.exception)
+        info.update(data.chunk.getNumRows(), data.chunk.allocatedBytes());
 
-    return chunk;
+    return data.getChunkOrTrow();
 }
 
 Chunk LazyOutputFormat::getTotals()
 {
-    return std::move(totals);
+    return totals.getChunkOrTrow();
 }
 
 Chunk LazyOutputFormat::getExtremes()
 {
-    return std::move(extremes);
+    return extremes.getChunkOrTrow();
 }
 
 void LazyOutputFormat::setRowsBeforeLimit(size_t rows_before_limit)

--- a/src/Processors/Formats/LazyOutputFormat.h
+++ b/src/Processors/Formats/LazyOutputFormat.h
@@ -37,28 +37,28 @@ public:
     }
 
 protected:
-    void consume(Chunk chunk) override
+    void consume(Port::Data data) override
     {
         if (!finished_processing)
-            queue.emplace(std::move(chunk));
+            queue.emplace(std::move(data));
     }
 
-    void consumeTotals(Chunk chunk) override { totals = std::move(chunk); }
-    void consumeExtremes(Chunk chunk) override { extremes = std::move(chunk); }
+    void consumeTotals(Port::Data data) override { totals = std::move(data); }
+    void consumeExtremes(Port::Data data) override { extremes = std::move(data); }
 
     void finalize() override
     {
         finished_processing = true;
 
         /// In case we are waiting for result.
-        queue.emplace(Chunk());
+        queue.emplace(Port::Data{});
     }
 
 private:
 
-    ConcurrentBoundedQueue<Chunk> queue;
-    Chunk totals;
-    Chunk extremes;
+    ConcurrentBoundedQueue<Port::Data> queue;
+    Port::Data totals;
+    Port::Data extremes;
 
     /// Is not used.
     static WriteBuffer out;

--- a/src/Processors/Port.h
+++ b/src/Processors/Port.h
@@ -60,6 +60,14 @@ protected:
             /// Note: std::variant can be used. But move constructor for it can't be inlined.
             Chunk chunk;
             std::exception_ptr exception;
+
+            Chunk getChunkOrTrow()
+            {
+                if (exception)
+                    std::rethrow_exception(std::move(exception));
+
+                return std::move(chunk);
+            }
         };
 
     private:
@@ -303,12 +311,7 @@ public:
 
     Chunk ALWAYS_INLINE pull(bool set_not_needed = false)
     {
-        auto data_ = pullData(set_not_needed);
-
-        if (data_.exception)
-            std::rethrow_exception(data_.exception);
-
-        return std::move(data_.chunk);
+        return pullData(set_not_needed).getChunkOrTrow();
     }
 
     bool ALWAYS_INLINE isFinished() const

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -12,7 +12,7 @@ You must install latest Docker from
 https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/#set-up-the-repository
 Don't use Docker from your system repository.
 
-* [pip](https://pypi.python.org/pypi/pip) and `libpq-dev`. To install: `sudo apt-get install python3-pip libpq-dev zlib1g-dev libcrypto++-dev libssl-dev`
+* [pip](https://pypi.python.org/pypi/pip) and `libpq-dev`. To install: `sudo apt-get install python3-pip libpq-dev zlib1g-dev libcrypto++-dev libssl-dev libkrb5-dev`
 * [py.test](https://docs.pytest.org/) testing framework. To install: `sudo -H pip install pytest`
 * [docker-compose](https://docs.docker.com/compose/) and additional python libraries. To install:
 

--- a/tests/integration/test_grpc_protocol/test.py
+++ b/tests/integration/test_grpc_protocol/test.py
@@ -239,7 +239,7 @@ def test_progress():
 , output: "6\\t0\\n7\\t0\\n"
 , stats {
   rows: 8
-  blocks: 4
+  blocks: 5
   allocated_bytes: 324
   applied_limit: true
   rows_before_limit: 8


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Trying to fix `01133_max_result_rows`: [example](https://clickhouse-test-reports.s3.yandex.net/9814/fd35c9bb61a57bb4cab5150244262f8d68bb7b5b/functional_stateless_tests_(release)/test_run.txt.out.log)
Assuming exception `Limit for result exceeded` might have happened before one packet with data was sent to client.  