### PR TITLE
Fix the unexpected behaviour of show tables when antlr parser enabled

### DIFF
--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -351,7 +351,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
 #if !defined(ARCADIA_BUILD)
         if (settings.use_antlr_parser)
         {
-            ast = parseQuery(begin, end, max_query_size, settings.max_parser_depth, &context);
+            ast = parseQuery(begin, end, max_query_size, settings.max_parser_depth, context.getCurrentDatabase());
         }
         else
         {

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -351,7 +351,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
 #if !defined(ARCADIA_BUILD)
         if (settings.use_antlr_parser)
         {
-            ast = parseQuery(begin, end, max_query_size, settings.max_parser_depth);
+            ast = parseQuery(begin, end, max_query_size, settings.max_parser_depth, &context);
         }
         else
         {

--- a/src/Parsers/New/ParseTreeVisitor.cpp
+++ b/src/Parsers/New/ParseTreeVisitor.cpp
@@ -33,15 +33,9 @@
 
 // Include last, because antlr-runtime undefines EOF macros, which is required in boost multiprecision numbers.
 #include <Parsers/New/ParseTreeVisitor.h>
-#include <Interpreters/Context.h>
 
 namespace DB
 {
-
-namespace ErrorCodes
-{
-    extern const int LOGICAL_ERROR;
-}
 
 using namespace AST;
 
@@ -119,11 +113,7 @@ antlrcpp::Any ParseTreeVisitor::visitShowTablesStmt(ClickHouseParser::ShowTables
 
     auto and_args = PtrTo<ColumnExprList>(new ColumnExprList{ColumnExpr::createLiteral(Literal::createNumber("1"))});
 
-    if (context == nullptr)
-    {
-        throw Exception("Context should be provided", ErrorCodes::LOGICAL_ERROR);
-    }
-    auto current_database = ColumnExpr::createLiteral(Literal::createString(context->getCurrentDatabase()));
+    auto current_database = ColumnExpr::createLiteral(Literal::createString(current_database_name));
     if (ctx->databaseIdentifier())
     {
         current_database = ColumnExpr::createLiteral(Literal::createString(visit(ctx->databaseIdentifier()).as<PtrTo<DatabaseIdentifier>>()->getName()));

--- a/src/Parsers/New/ParseTreeVisitor.cpp
+++ b/src/Parsers/New/ParseTreeVisitor.cpp
@@ -33,10 +33,15 @@
 
 // Include last, because antlr-runtime undefines EOF macros, which is required in boost multiprecision numbers.
 #include <Parsers/New/ParseTreeVisitor.h>
-
+#include <Interpreters/Context.h>
 
 namespace DB
 {
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
 
 using namespace AST;
 
@@ -114,15 +119,21 @@ antlrcpp::Any ParseTreeVisitor::visitShowTablesStmt(ClickHouseParser::ShowTables
 
     auto and_args = PtrTo<ColumnExprList>(new ColumnExprList{ColumnExpr::createLiteral(Literal::createNumber("1"))});
 
+    if (context == nullptr)
+    {
+        throw Exception("Context should be provided", ErrorCodes::LOGICAL_ERROR);
+    }
+    auto current_database = ColumnExpr::createLiteral(Literal::createString(context->getCurrentDatabase()));
     if (ctx->databaseIdentifier())
     {
-        auto database = std::make_shared<ColumnIdentifier>(nullptr, std::make_shared<Identifier>("database"));
-        auto args = PtrTo<ColumnExprList>(new ColumnExprList{
-            ColumnExpr::createIdentifier(database),
-            ColumnExpr::createLiteral(Literal::createString(visit(ctx->databaseIdentifier()).as<PtrTo<DatabaseIdentifier>>()->getName()))
-        });
-        and_args->push(ColumnExpr::createFunction(std::make_shared<Identifier>("equals"), nullptr, args));
+        current_database = ColumnExpr::createLiteral(Literal::createString(visit(ctx->databaseIdentifier()).as<PtrTo<DatabaseIdentifier>>()->getName()));
     }
+    auto database = std::make_shared<ColumnIdentifier>(nullptr, std::make_shared<Identifier>("database"));
+    auto equals_args = PtrTo<ColumnExprList>(new ColumnExprList{
+        ColumnExpr::createIdentifier(database),
+        current_database
+    });
+    and_args->push(ColumnExpr::createFunction(std::make_shared<Identifier>("equals"), nullptr, equals_args));
 
     if (ctx->LIKE())
     {

--- a/src/Parsers/New/ParseTreeVisitor.h
+++ b/src/Parsers/New/ParseTreeVisitor.h
@@ -5,9 +5,13 @@
 
 namespace DB {
 
+class Context;
+
 class ParseTreeVisitor : public ClickHouseParserVisitor
 {
+    const Context* context;
 public:
+    explicit ParseTreeVisitor(const Context* context_) : ClickHouseParserVisitor(), context(context_) {}
     virtual ~ParseTreeVisitor() override = default;
 
     // Top-level statements

--- a/src/Parsers/New/ParseTreeVisitor.h
+++ b/src/Parsers/New/ParseTreeVisitor.h
@@ -5,13 +5,11 @@
 
 namespace DB {
 
-class Context;
-
 class ParseTreeVisitor : public ClickHouseParserVisitor
 {
-    const Context* context;
+    const String & current_database_name;
 public:
-    explicit ParseTreeVisitor(const Context* context_) : ClickHouseParserVisitor(), context(context_) {}
+    explicit ParseTreeVisitor(const String & database_name) : ClickHouseParserVisitor(), current_database_name(database_name) {}
     virtual ~ParseTreeVisitor() override = default;
 
     // Top-level statements

--- a/src/Parsers/New/parseQuery.cpp
+++ b/src/Parsers/New/parseQuery.cpp
@@ -11,7 +11,7 @@
 #include <Parsers/New/ParserErrorListener.h>
 
 #include <CommonTokenStream.h>
-
+#include <Interpreters/Context.h>
 
 namespace DB
 {
@@ -20,7 +20,7 @@ using namespace antlr4;
 using namespace AST;
 
 // For testing only
-PtrTo<Query> parseQuery(const String & query)
+PtrTo<Query> parseQuery(const String & query, const Context * context)
 {
     ANTLRInputStream input(query);
     ClickHouseLexer lexer(&input);
@@ -34,12 +34,12 @@ PtrTo<Query> parseQuery(const String & query)
     lexer.addErrorListener(&lexer_error_listener);
     parser.addErrorListener(&parser_error_listener);
 
-    ParseTreeVisitor visitor;
+    ParseTreeVisitor visitor { context };
 
     return visitor.visit(parser.queryStmt());
 }
 
-ASTPtr parseQuery(const char * begin, const char * end, size_t, size_t)
+ASTPtr parseQuery(const char * begin, const char * end, size_t, size_t, const Context * context)
 {
     // TODO: do not ignore |max_parser_depth|.
 
@@ -60,7 +60,7 @@ ASTPtr parseQuery(const char * begin, const char * end, size_t, size_t)
     lexer.addErrorListener(&lexer_error_listener);
     parser.addErrorListener(&parser_error_listener);
 
-    ParseTreeVisitor visitor;
+    ParseTreeVisitor visitor { context };
 
     PtrTo<Query> new_ast = visitor.visit(parser.queryStmt());
     auto old_ast = new_ast->convertToOld();

--- a/src/Parsers/New/parseQuery.cpp
+++ b/src/Parsers/New/parseQuery.cpp
@@ -11,7 +11,6 @@
 #include <Parsers/New/ParserErrorListener.h>
 
 #include <CommonTokenStream.h>
-#include <Interpreters/Context.h>
 
 namespace DB
 {
@@ -20,7 +19,7 @@ using namespace antlr4;
 using namespace AST;
 
 // For testing only
-PtrTo<Query> parseQuery(const String & query, const Context * context)
+PtrTo<Query> parseQuery(const String & query, const String & current_database)
 {
     ANTLRInputStream input(query);
     ClickHouseLexer lexer(&input);
@@ -34,12 +33,12 @@ PtrTo<Query> parseQuery(const String & query, const Context * context)
     lexer.addErrorListener(&lexer_error_listener);
     parser.addErrorListener(&parser_error_listener);
 
-    ParseTreeVisitor visitor { context };
+    ParseTreeVisitor visitor { current_database };
 
     return visitor.visit(parser.queryStmt());
 }
 
-ASTPtr parseQuery(const char * begin, const char * end, size_t, size_t, const Context * context)
+ASTPtr parseQuery(const char * begin, const char * end, size_t, size_t, const String & current_database)
 {
     // TODO: do not ignore |max_parser_depth|.
 
@@ -60,7 +59,7 @@ ASTPtr parseQuery(const char * begin, const char * end, size_t, size_t, const Co
     lexer.addErrorListener(&lexer_error_listener);
     parser.addErrorListener(&parser_error_listener);
 
-    ParseTreeVisitor visitor { context };
+    ParseTreeVisitor visitor { current_database };
 
     PtrTo<Query> new_ast = visitor.visit(parser.queryStmt());
     auto old_ast = new_ast->convertToOld();

--- a/src/Parsers/New/parseQuery.h
+++ b/src/Parsers/New/parseQuery.h
@@ -8,8 +8,8 @@ namespace DB
 {
 
 // Compatibility interface
-
-AST::PtrTo<AST::Query> parseQuery(const std::string & query);
-ASTPtr parseQuery(const char * begin, const char * end, size_t max_query_size, size_t max_parser_depth);
+class Context;
+AST::PtrTo<AST::Query> parseQuery(const std::string & query, const Context * context);
+ASTPtr parseQuery(const char * begin, const char * end, size_t max_query_size, size_t max_parser_depth, const Context * context);
 
 }

--- a/src/Parsers/New/parseQuery.h
+++ b/src/Parsers/New/parseQuery.h
@@ -2,14 +2,13 @@
 
 #include <Parsers/IAST_fwd.h>
 #include <Parsers/New/AST/fwd_decl.h>
-
+#include <common/types.h>
 
 namespace DB
 {
 
 // Compatibility interface
-class Context;
-AST::PtrTo<AST::Query> parseQuery(const std::string & query, const Context * context);
-ASTPtr parseQuery(const char * begin, const char * end, size_t max_query_size, size_t max_parser_depth, const Context * context);
+AST::PtrTo<AST::Query> parseQuery(const std::string & query, const String & current_database);
+ASTPtr parseQuery(const char * begin, const char * end, size_t max_query_size, size_t max_parser_depth, const String & current_database);
 
 }

--- a/utils/syntax-analyzer/main.cpp
+++ b/utils/syntax-analyzer/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, const char **)
             ASTPtr orig_ast = parseQuery(parser, q, 10000000, 10000);
 
             std::cout << std::endl << "New AST:" << std::endl;
-            auto new_ast = parseQuery(q, /* const Context * context */ nullptr);
+            auto new_ast = parseQuery(q, "");
             new_ast->dump();
 
             auto old_ast = new_ast->convertToOld();

--- a/utils/syntax-analyzer/main.cpp
+++ b/utils/syntax-analyzer/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, const char **)
             ASTPtr orig_ast = parseQuery(parser, q, 10000000, 10000);
 
             std::cout << std::endl << "New AST:" << std::endl;
-            auto new_ast = parseQuery(q);
+            auto new_ast = parseQuery(q, /* const Context * context */ nullptr);
             new_ast->dump();
 
             auto old_ast = new_ast->convertToOld();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix the unexpected behaviour of `SHOW TABLES`

#18139 
