### PR TITLE
Poco build fixes

### DIFF
--- a/cmake/find/poco.cmake
+++ b/cmake/find/poco.cmake
@@ -1,8 +1,6 @@
 option (USE_INTERNAL_POCO_LIBRARY "Use internal Poco library" ON)
 
-if (USE_INTERNAL_POCO_LIBRARY)
-    set (LIBRARY_DIR ${ClickHouse_SOURCE_DIR}/contrib/poco)
-else ()
+if (NOT USE_INTERNAL_POCO_LIBRARY)
     find_path (ROOT_DIR NAMES Foundation/include/Poco/Poco.h include/Poco/Poco.h)
     if (NOT ROOT_DIR)
         message (${RECONFIGURE_MESSAGE_LEVEL} "Can't find system poco")

--- a/contrib/poco-cmake/CMakeLists.txt
+++ b/contrib/poco-cmake/CMakeLists.txt
@@ -1,3 +1,5 @@
+set (LIBRARY_DIR ${ClickHouse_SOURCE_DIR}/contrib/poco)
+
 add_subdirectory (Crypto)
 add_subdirectory (Data)
 add_subdirectory (Data/ODBC)

--- a/contrib/poco-cmake/Crypto/CMakeLists.txt
+++ b/contrib/poco-cmake/Crypto/CMakeLists.txt
@@ -30,7 +30,7 @@ if (ENABLE_SSL)
 
         target_compile_options (_poco_crypto PRIVATE -Wno-newline-eof)
         target_include_directories (_poco_crypto SYSTEM PUBLIC ${LIBRARY_DIR}/Crypto/include)
-        target_link_libraries (_poco_crypto PUBLIC Poco::Foundation ssl)
+        target_link_libraries (_poco_crypto PUBLIC Poco::Foundation ssl crypto)
     else ()
         add_library (Poco::Crypto UNKNOWN IMPORTED GLOBAL)
 

--- a/src/Common/Exception.h
+++ b/src/Common/Exception.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <memory>
 
+#include <Poco/Version.h>
 #include <Poco/Exception.h>
 
 #include <Common/StackTrace.h>
@@ -114,7 +115,11 @@ public:
     }
 
 
-    std::string displayText() const override;
+    std::string displayText() const
+#if defined(POCO_CLICKHOUSE_PATCH)
+    override
+#endif
+    ;
 
     int getLineNumber() { return line_number_; }
     void setLineNumber(int line_number) { line_number_ = line_number;}


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix Poco::Crypto library (missing linking with crypto)
- Fix ParsingException::displayText override (guard with POCO_CLICKHOUSE_PATCH) (#17641, due to `virtual` qualifier for `displayText` - https://github.com/ClickHouse-Extras/poco/pull/31)
- Make poco library path variable scope less global

Cc: @nikitamikhaylov 