### PR TITLE
Fix bug: no newline after exception message in some tools

### DIFF
--- a/programs/compressor/Compressor.cpp
+++ b/programs/compressor/Compressor.cpp
@@ -155,7 +155,7 @@ int mainEntryClickHouseCompressor(int argc, char ** argv)
     }
     catch (...)
     {
-        std::cerr << getCurrentExceptionMessage(true);
+        std::cerr << getCurrentExceptionMessage(true) << '\n';
         return getCurrentExceptionCode();
     }
 

--- a/programs/format/Format.cpp
+++ b/programs/format/Format.cpp
@@ -142,7 +142,7 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
     }
     catch (...)
     {
-        std::cerr << getCurrentExceptionMessage(true);
+        std::cerr << getCurrentExceptionMessage(true) << '\n';
         return getCurrentExceptionCode();
     }
 


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bug: no newline after exception message in some tools.