### PR TITLE
Fix constant folding when the result is unknown

### DIFF
--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -1468,7 +1468,7 @@ Code: 395. DB::Exception: Received from localhost:9000. DB::Exception: Too many.
 
 ## identity {#identity}
 
-Returns the same value that was used as its argument. Used for debugging and testing, allows to cancel using index, and get the query performance of a full scan. When query is analyzed for possible use of index, the analyzer doesn’t look inside `identity` functions.
+Returns the same value that was used as its argument. Used for debugging and testing, allows to cancel using index, and get the query performance of a full scan. When query is analyzed for possible use of index, the analyzer doesn’t look inside `identity` functions. Also constant folding is not applied too.
 
 **Syntax**
 

--- a/src/Functions/identity.cpp
+++ b/src/Functions/identity.cpp
@@ -16,15 +16,8 @@ public:
         return std::make_shared<FunctionIdentity>();
     }
 
-    String getName() const override
-    {
-        return name;
-    }
-
-    size_t getNumberOfArguments() const override
-    {
-        return 1;
-    }
+    String getName() const override { return name; }
+    size_t getNumberOfArguments() const override { return 1; }
 
     DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
     {

--- a/src/Functions/identity.cpp
+++ b/src/Functions/identity.cpp
@@ -18,6 +18,7 @@ public:
 
     String getName() const override { return name; }
     size_t getNumberOfArguments() const override { return 1; }
+    bool isSuitableForConstantFolding() const override { return false; }
 
     DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
     {

--- a/src/Interpreters/ExecuteScalarSubqueriesVisitor.cpp
+++ b/src/Interpreters/ExecuteScalarSubqueriesVisitor.cpp
@@ -168,6 +168,16 @@ void ExecuteScalarSubqueriesMatcher::visit(const ASTSubquery & subquery, ASTPtr 
         lit->alias = subquery.alias;
         lit->prefer_alias_to_column_name = subquery.prefer_alias_to_column_name;
         ast = addTypeConversionToAST(std::move(lit), scalar.safeGetByPosition(0).type->getName());
+
+        /// If only analyze was requested the expression is not suitable for constant folding, disable it.
+        if (data.only_analyze)
+        {
+            ast->as<ASTFunction>()->alias.clear();
+            auto func = makeASTFunction("identity", std::move(ast));
+            func->alias = subquery.alias;
+            func->prefer_alias_to_column_name = subquery.prefer_alias_to_column_name;
+            ast = std::move(func);
+        }
     }
     else
     {

--- a/tests/queries/0_stateless/00597_push_down_predicate.reference
+++ b/tests/queries/0_stateless/00597_push_down_predicate.reference
@@ -114,8 +114,9 @@ FROM
 (
     SELECT
         1 AS id,
-        cast(1, \'UInt8\') AS subquery
+        identity(cast(1, \'UInt8\')) AS subquery
 )
+WHERE subquery = 1
 1	1
 SELECT
     a,

--- a/tests/queries/0_stateless/01268_mv_scalars.sql
+++ b/tests/queries/0_stateless/01268_mv_scalars.sql
@@ -1,4 +1,9 @@
+DROP TABLE IF EXISTS dest_table_mv;
+DROP TABLE IF EXISTS left_table;
+DROP TABLE IF EXISTS right_table;
+DROP TABLE IF EXISTS dest_table;
 DROP TABLE IF EXISTS src_table;
+DROP VIEW IF EXISTS dst_mv;
 
 create table src_table Engine=Memory as system.numbers;
 CREATE MATERIALIZED VIEW dst_mv Engine=Memory as select *, (SELECT count() FROM src_table) AS cnt FROM src_table;

--- a/tests/queries/0_stateless/01611_constant_folding_subqueries.reference
+++ b/tests/queries/0_stateless/01611_constant_folding_subqueries.reference
@@ -1,0 +1,9 @@
+-- { echo }
+SELECT * FROM (SELECT (SELECT * FROM system.numbers LIMIT 1 OFFSET 1) AS n, toUInt64(10 / n)) FORMAT CSV;
+1,10
+SELECT (SELECT * FROM system.numbers LIMIT 1 OFFSET 1) AS n, toUInt64(10 / n) FORMAT CSV;
+1,10
+EXPLAIN SYNTAX SELECT (SELECT * FROM system.numbers LIMIT 1 OFFSET 1) AS n, toUInt64(10 / n);
+SELECT
+    identity(cast(0, \'UInt64\')) AS n,
+    toUInt64(10 / n)

--- a/tests/queries/0_stateless/01611_constant_folding_subqueries.sql
+++ b/tests/queries/0_stateless/01611_constant_folding_subqueries.sql
@@ -1,0 +1,4 @@
+-- { echo }
+SELECT * FROM (SELECT (SELECT * FROM system.numbers LIMIT 1 OFFSET 1) AS n, toUInt64(10 / n)) FORMAT CSV;
+SELECT (SELECT * FROM system.numbers LIMIT 1 OFFSET 1) AS n, toUInt64(10 / n) FORMAT CSV;
+EXPLAIN SYNTAX SELECT (SELECT * FROM system.numbers LIMIT 1 OFFSET 1) AS n, toUInt64(10 / n);


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Disable constant folding for subqueries on the analysis stage, when the result cannot be calculated.