### PR TITLE
Disable write with AIO even for big merges

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
@@ -682,7 +682,6 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataMergerMutator::mergePartsToTempor
     if (disk->exists(new_part_tmp_path))
         throw Exception("Directory " + fullPath(disk, new_part_tmp_path) + " already exists", ErrorCodes::DIRECTORY_ALREADY_EXISTS);
 
-    MergeTreeData::DataPart::ColumnToSize merged_column_to_size;
 
     Names all_column_names = metadata_snapshot->getColumns().getNamesOfPhysical();
     NamesAndTypesList storage_columns = metadata_snapshot->getColumns().getAllPhysical();
@@ -764,6 +763,7 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataMergerMutator::mergePartsToTempor
         rows_sources_uncompressed_write_buf = tmp_disk->writeFile(rows_sources_file_path);
         rows_sources_write_buf = std::make_unique<CompressedWriteBuffer>(*rows_sources_uncompressed_write_buf);
 
+        MergeTreeData::DataPart::ColumnToSize merged_column_to_size;
         for (const MergeTreeData::DataPartPtr & part : parts)
             part->accumulateColumnSizes(merged_column_to_size);
 
@@ -918,7 +918,6 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataMergerMutator::mergePartsToTempor
         merging_columns,
         index_factory.getMany(metadata_snapshot->getSecondaryIndices()),
         compression_codec,
-        merged_column_to_size,
         data_settings->min_merge_bytes_to_use_direct_io,
         blocks_are_granules_size};
 

--- a/src/Storages/MergeTree/MergeTreeIOSettings.h
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.h
@@ -46,7 +46,8 @@ struct MergeTreeWriterSettings
     bool rewrite_primary_key;
     bool blocks_are_granules_size;
 
-    /// true if we write temporary files during alter.
+    /// Used for AIO threshold comparsion
+    /// FIXME currently doesn't work because WriteBufferAIO contain obscure bug(s)
     size_t estimated_size = 0;
 };
 

--- a/src/Storages/MergeTree/MergedBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/MergedBlockOutputStream.cpp
@@ -27,7 +27,6 @@ MergedBlockOutputStream::MergedBlockOutputStream(
         columns_list_,
         skip_indices,
         default_codec_,
-        {},
         data_part->storage.global_context.getSettings().min_bytes_to_use_direct_io,
         blocks_are_granules_size)
 {
@@ -39,7 +38,6 @@ MergedBlockOutputStream::MergedBlockOutputStream(
     const NamesAndTypesList & columns_list_,
     const MergeTreeIndices & skip_indices,
     CompressionCodecPtr default_codec_,
-    const MergeTreeData::DataPart::ColumnToSize & merged_column_to_size,
     size_t aio_threshold,
     bool blocks_are_granules_size)
     : IMergedBlockOutputStream(data_part, metadata_snapshot_)
@@ -53,16 +51,6 @@ MergedBlockOutputStream::MergedBlockOutputStream(
         aio_threshold,
         /* rewrite_primary_key = */ true,
         blocks_are_granules_size);
-
-    if (aio_threshold > 0 && !merged_column_to_size.empty())
-    {
-        for (const auto & column : columns_list)
-        {
-            auto size_it = merged_column_to_size.find(column.name);
-            if (size_it != merged_column_to_size.end())
-                writer_settings.estimated_size += size_it->second;
-        }
-    }
 
     if (!part_path.empty())
         volume->getDisk()->createDirectories(part_path);

--- a/src/Storages/MergeTree/MergedBlockOutputStream.h
+++ b/src/Storages/MergeTree/MergedBlockOutputStream.h
@@ -27,7 +27,6 @@ public:
         const NamesAndTypesList & columns_list_,
         const MergeTreeIndices & skip_indices,
         CompressionCodecPtr default_codec_,
-        const MergeTreeData::DataPart::ColumnToSize & merged_column_to_size,
         size_t aio_threshold,
         bool blocks_are_granules_size = false);
 

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -195,6 +195,12 @@ class ClickHouseCluster:
 
         if tag is None:
             tag = self.docker_base_tag
+        if not env_variables:
+            env_variables = {}
+
+        # Code coverage files will be placed in database directory
+        # (affect only WITH_COVERAGE=1 build)
+        env_variables['LLVM_PROFILE_FILE'] = '/var/lib/clickhouse/server_%h_%p_%m.profraw'
 
         instance = ClickHouseInstance(
             cluster=self,
@@ -221,7 +227,7 @@ class ClickHouseCluster:
             clickhouse_path_dir=clickhouse_path_dir,
             with_odbc_drivers=with_odbc_drivers,
             hostname=hostname,
-            env_variables=env_variables or {},
+            env_variables=env_variables,
             image=image,
             tag=tag,
             stay_alive=stay_alive,
@@ -759,9 +765,11 @@ class ClickHouseCluster:
 
         if kill:
             try:
-                subprocess_check_call(self.base_cmd + ['kill'])
+                subprocess_check_call(self.base_cmd + ['stop', '--timeout', '20'])
             except Exception as e:
-                print("Kill command failed durung shutdown. {}".format(repr(e)))
+                print("Kill command failed during shutdown. {}".format(repr(e)))
+                print("Trying to kill forcefully")
+                subprocess_check_call(self.base_cmd + ['kill'])
 
         try:
             subprocess_check_call(self.base_cmd + ['down', '--volumes', '--remove-orphans'])

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -195,12 +195,6 @@ class ClickHouseCluster:
 
         if tag is None:
             tag = self.docker_base_tag
-        if not env_variables:
-            env_variables = {}
-
-        # Code coverage files will be placed in database directory
-        # (affect only WITH_COVERAGE=1 build)
-        env_variables['LLVM_PROFILE_FILE'] = '/var/lib/clickhouse/server_%h_%p_%m.profraw'
 
         instance = ClickHouseInstance(
             cluster=self,
@@ -227,7 +221,7 @@ class ClickHouseCluster:
             clickhouse_path_dir=clickhouse_path_dir,
             with_odbc_drivers=with_odbc_drivers,
             hostname=hostname,
-            env_variables=env_variables,
+            env_variables=env_variables or {},
             image=image,
             tag=tag,
             stay_alive=stay_alive,
@@ -765,11 +759,9 @@ class ClickHouseCluster:
 
         if kill:
             try:
-                subprocess_check_call(self.base_cmd + ['stop', '--timeout', '20'])
-            except Exception as e:
-                print("Kill command failed during shutdown. {}".format(repr(e)))
-                print("Trying to kill forcefully")
                 subprocess_check_call(self.base_cmd + ['kill'])
+            except Exception as e:
+                print("Kill command failed durung shutdown. {}".format(repr(e)))
 
         try:
             subprocess_check_call(self.base_cmd + ['down', '--volumes', '--remove-orphans'])


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Disable write with AIO during merges because it can lead to extremely rare data corruption of primary key columns during merge.