### PR TITLE
Better version of #18167

### DIFF
--- a/src/Access/SettingsConstraints.cpp
+++ b/src/Access/SettingsConstraints.cpp
@@ -157,23 +157,7 @@ bool SettingsConstraints::checkImpl(const Settings & current_settings, SettingCh
     const String & setting_name = change.name;
 
     if (setting_name == "profile")
-    {
-        /// TODO Check profile settings in Context::setProfile(...), not here. It will be backward incompatible.
-        const String & profile_name = change.value.safeGet<String>();
-        const auto & profile_settings_changes = manager->getProfileSettings(profile_name);
-        try
-        {
-            /// NOTE We cannot use CLAMP_ON_VIOLATION here, because we cannot modify elements of profile_settings_changes
-            for (auto change_copy : *profile_settings_changes)
-                checkImpl(current_settings, change_copy, THROW_ON_VIOLATION);
-        }
-        catch (Exception & e)
-        {
-            e.addMessage(", while trying to set settings profile {}", profile_name);
-            throw;
-        }
         return true;
-    }
 
     bool cannot_cast;
     auto cast_value = [&](const Field & x) -> Field

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -849,7 +849,17 @@ std::optional<QuotaUsage> Context::getQuotaUsage() const
 
 void Context::setProfile(const String & profile_name)
 {
-    applySettingsChanges(*getAccessControlManager().getProfileSettings(profile_name));
+    SettingsChanges profile_settings_changes = *getAccessControlManager().getProfileSettings(profile_name);
+    try
+    {
+        checkSettingsConstraints(profile_settings_changes);
+    }
+    catch (Exception & e)
+    {
+        e.addMessage(", while trying to set settings profile {}", profile_name);
+        throw;
+    }
+    applySettingsChanges(profile_settings_changes);
 }
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Backward Incompatible Change


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Check settings constraints for profile settings from config. Server will fail to start if users.xml contain settings that do not meet corresponding constraints. 

Detailed description / Documentation draft:
#18167
