### PR TITLE
Fix flaky test 01584_distributed_buffer_cannot_find_column

### DIFF
--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -580,7 +580,7 @@ void StorageBuffer::startup()
         LOG_WARNING(log, "Storage {} is run with readonly settings, it will not be able to insert data. Set appropriate system_profile to fix this.", getName());
     }
 
-    flush_handle = bg_pool.createTask(log->name() + "/Bg", [this]{ flushBack(); });
+    flush_handle = bg_pool.createTask(log->name() + "/Bg", [this]{ backgroundFlush(); });
     flush_handle->activateAndSchedule();
 }
 
@@ -829,7 +829,7 @@ void StorageBuffer::writeBlockToDestination(const Block & block, StoragePtr tabl
 }
 
 
-void StorageBuffer::flushBack()
+void StorageBuffer::backgroundFlush()
 {
     try
     {

--- a/src/Storages/StorageBuffer.h
+++ b/src/Storages/StorageBuffer.h
@@ -157,7 +157,7 @@ private:
     /// `table` argument is passed, as it is sometimes evaluated beforehand. It must match the `destination`.
     void writeBlockToDestination(const Block & block, StoragePtr table);
 
-    void flushBack();
+    void backgroundFlush();
     void reschedule();
 
     BackgroundSchedulePool & bg_pool;

--- a/tests/queries/0_stateless/01584_distributed_buffer_cannot_find_column.sql
+++ b/tests/queries/0_stateless/01584_distributed_buffer_cannot_find_column.sql
@@ -8,11 +8,15 @@ CREATE TABLE realtimebuff(amount Int64,transID String,userID String,appID String
 
 insert into realtimebuff (amount,transID,userID,appID,appName,transType,orderSource,nau,fau,transactionType,supplier,fMerchant,bankConnCode,reqDate) values (100, '200312000295032','200223000028708','14', 'Data','1', '20','1', '0','123','abc', '1234a','ZPVBIDV', 1598256583);
 
+-- Data is written to the buffer table but has not been written to the Distributed table
 select sum(amount) = 100 from realtimebuff;
 
 OPTIMIZE TABLE realtimebuff;
-select sum(amount) IN (100, 200) from realtimebuff;
+-- Data has been flushed from Buffer table to the Distributed table and can possibly being sent to 0, 1 or 2 shards.
+-- Both shards reside on localhost in the same table.
+select sum(amount) IN (0, 100, 200) from realtimebuff;
 
+-- Data has been sent to all shards.
 SYSTEM FLUSH DISTRIBUTED realtimedistributed;
 select sum(amount) = 200 from realtimebuff;
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

It failed 8 times in past 100 days,

first seen: db3918d88d47cdf88024e3fb81581c7c5ea92df8
last seen: e169b39fa78f4edca0983faf705118c977e35203

```
SELECT test_name, count() AS c, max(check_start_time) AS last_time, argMin(commit_sha, check_start_time) AS first_seen, argMax(commit_sha, check_start_time) AS last_seen FROM `gh-data`.checks
WHERE
    test_status = 'FAIL'
    AND check_name LIKE 'Functional%'
    AND pull_request_number = 0
    AND check_start_time >= now() - INTERVAL 100 DAY
GROUP BY test_name
HAVING last_time >= now() - INTERVAL 3 DAY
ORDER BY c DESC
LIMIT 100
```