### PR TITLE
Add function runningConcurrency()

### DIFF
--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -820,6 +820,66 @@ WHERE diff != 1
 
 Same as for [runningDifference](../../sql-reference/functions/other-functions.md#other_functions-runningdifference), the difference is the value of the first row, returned the value of the first row, and each subsequent row returns the difference from the previous row.
 
+## runningConcurrency {#runningconcurrency}
+
+Given a series of beginning time and ending time of events, this function calculates concurrency of the events at each of the data point, that is, the beginning time.
+
+!!! warning "Warning"
+    Events spanning multiple data blocks will not be processed correctly. The function resets its state for each new data block.
+
+The result of the function depends on the order of data in the block. It assumes the beginning time is sorted in ascending order.
+
+**Syntax**
+
+``` sql
+runningConcurrency(begin, end)
+```
+
+**Parameters**
+
+-   `begin` — A column for the beginning time of events (inclusive). [Date](../../sql-reference/data-types/date.md), [DateTime](../../sql-reference/data-types/datetime.md), or [DateTime64](../../sql-reference/data-types/datetime64.md).
+-   `end` — A column for the ending time of events (exclusive).  [Date](../../sql-reference/data-types/date.md), [DateTime](../../sql-reference/data-types/datetime.md), or [DateTime64](../../sql-reference/data-types/datetime64.md).
+
+Note that two columns `begin` and `end` must have the same type.
+
+**Returned values**
+
+-   The concurrency of events at the data point.
+
+Type: [UInt32](../../sql-reference/data-types/int-uint.md)
+
+**Example**
+
+Input table:
+
+``` text
+┌───────────────begin─┬─────────────────end─┐
+│ 2020-12-01 00:00:00 │ 2020-12-01 00:59:59 │
+│ 2020-12-01 00:30:00 │ 2020-12-01 00:59:59 │
+│ 2020-12-01 00:40:00 │ 2020-12-01 01:30:30 │
+│ 2020-12-01 01:10:00 │ 2020-12-01 01:30:30 │
+│ 2020-12-01 01:50:00 │ 2020-12-01 01:59:59 │
+└─────────────────────┴─────────────────────┘
+```
+
+Query:
+
+``` sql
+SELECT runningConcurrency(begin, end) FROM example
+```
+
+Result:
+
+``` text
+┌─runningConcurrency(begin, end)─┐
+│                              1 │
+│                              2 │
+│                              3 │
+│                              2 │
+│                              1 │
+└────────────────────────────────┘
+```
+
 ## MACNumToString(num) {#macnumtostringnum}
 
 Accepts a UInt64 number. Interprets it as a MAC address in big endian. Returns a string containing the corresponding MAC address in the format AA:BB:CC:DD:EE:FF (colon-separated numbers in hexadecimal form).

--- a/src/Functions/registerFunctionsMiscellaneous.cpp
+++ b/src/Functions/registerFunctionsMiscellaneous.cpp
@@ -45,6 +45,7 @@ void registerFunctionTimeZone(FunctionFactory &);
 void registerFunctionRunningAccumulate(FunctionFactory &);
 void registerFunctionRunningDifference(FunctionFactory &);
 void registerFunctionRunningDifferenceStartingWithFirstValue(FunctionFactory &);
+void registerFunctionRunningConcurrency(FunctionFactory &);
 void registerFunctionFinalizeAggregation(FunctionFactory &);
 void registerFunctionToLowCardinality(FunctionFactory &);
 void registerFunctionLowCardinalityIndices(FunctionFactory &);
@@ -112,6 +113,7 @@ void registerFunctionsMiscellaneous(FunctionFactory & factory)
     registerFunctionRunningAccumulate(factory);
     registerFunctionRunningDifference(factory);
     registerFunctionRunningDifferenceStartingWithFirstValue(factory);
+    registerFunctionRunningConcurrency(factory);
     registerFunctionFinalizeAggregation(factory);
     registerFunctionToLowCardinality(factory);
     registerFunctionLowCardinalityIndices(factory);

--- a/src/Functions/runningConcurrency.cpp
+++ b/src/Functions/runningConcurrency.cpp
@@ -1,0 +1,223 @@
+#include <Columns/ColumnVector.h>
+#include <Core/callOnTypeIndex.h>
+#include <DataTypes/IDataType.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <DataTypes/DataTypeDate.h>
+#include <DataTypes/DataTypeDateTime.h>
+#include <DataTypes/DataTypeDateTime64.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <Formats/FormatSettings.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/IFunctionImpl.h>
+#include <IO/WriteBufferFromString.h>
+#include <common/defines.h>
+#include <set>
+
+namespace DB
+{
+    namespace ErrorCodes
+    {
+        extern const int ILLEGAL_COLUMN;
+        extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+        extern const int INCORRECT_DATA;
+    }
+
+    template <typename Name, typename ArgDataType, typename ConcurrencyDataType>
+    class ExecutableFunctionRunningConcurrency : public IExecutableFunctionImpl
+    {
+    public:
+        String getName() const override
+        {
+            return Name::name;
+        }
+
+        ColumnPtr execute(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
+        {
+            using ColVecArg = typename ArgDataType::ColumnType;
+            const ColVecArg * col_begin = checkAndGetColumn<ColVecArg>(arguments[0].column.get());
+            const ColVecArg * col_end   = checkAndGetColumn<ColVecArg>(arguments[1].column.get());
+            if (!col_begin || !col_end)
+                throw Exception("Constant columns are not supported at the moment",
+                                ErrorCodes::ILLEGAL_COLUMN);
+            const typename ColVecArg::Container & vec_begin = col_begin->getData();
+            const typename ColVecArg::Container & vec_end   = col_end->getData();
+
+            using ColVecConc = typename ConcurrencyDataType::ColumnType;
+            typename ColVecConc::MutablePtr col_concurrency = ColVecConc::create(input_rows_count);
+            typename ColVecConc::Container & vec_concurrency = col_concurrency->getData();
+
+            std::multiset<typename ArgDataType::FieldType> ongoing_until;
+            for (size_t i = 0; i < input_rows_count; ++i)
+            {
+                const auto begin = vec_begin[i];
+                const auto end   = vec_end[i];
+
+                if (unlikely(begin > end))
+                {
+                    const FormatSettings default_format;
+                    WriteBufferFromOwnString buf_begin, buf_end;
+                    arguments[0].type->serializeAsTextQuoted(*(arguments[0].column), i, buf_begin, default_format);
+                    arguments[1].type->serializeAsTextQuoted(*(arguments[1].column), i, buf_end, default_format);
+                    throw Exception(
+                        "Incorrect order of events: " + buf_begin.str() + " > " + buf_end.str(),
+                        ErrorCodes::INCORRECT_DATA);
+                }
+
+                ongoing_until.insert(end);
+
+                // Erase all the elements from "ongoing_until" which
+                // are less than or equal to "begin", i.e. durations
+                // that have already ended. We consider "begin" to be
+                // inclusive, and "end" to be exclusive.
+                ongoing_until.erase(
+                    ongoing_until.begin(), ongoing_until.upper_bound(begin));
+
+                vec_concurrency[i] = ongoing_until.size();
+            }
+
+            return col_concurrency;
+        }
+
+        bool useDefaultImplementationForConstants() const override
+        {
+            return true;
+        }
+    };
+
+    template <typename Name, typename ArgDataType, typename ConcurrencyDataType>
+    class FunctionBaseRunningConcurrency : public IFunctionBaseImpl
+    {
+    public:
+        explicit FunctionBaseRunningConcurrency(DataTypes argument_types_, DataTypePtr return_type_)
+            : argument_types(std::move(argument_types_))
+            , return_type(std::move(return_type_)) {}
+
+        String getName() const override
+        {
+            return Name::name;
+        }
+
+        const DataTypes & getArgumentTypes() const override
+        {
+            return argument_types;
+        }
+
+        const DataTypePtr & getResultType() const override
+        {
+            return return_type;
+        }
+
+        ExecutableFunctionImplPtr prepare(const ColumnsWithTypeAndName &) const override
+        {
+            return std::make_unique<ExecutableFunctionRunningConcurrency<Name, ArgDataType, ConcurrencyDataType>>();
+        }
+
+        bool isStateful() const override
+        {
+            return true;
+        }
+
+    private:
+        DataTypes argument_types;
+        DataTypePtr return_type;
+    };
+
+    template <typename Name, typename ConcurrencyDataType>
+    class RunningConcurrencyOverloadResolver : public IFunctionOverloadResolverImpl
+    {
+        template <typename T>
+        struct TypeTag
+        {
+            using Type = T;
+        };
+
+        /// Call a polymorphic lambda with a type tag of src_type.
+        template <typename F>
+        void dispatchForSourceType(const IDataType & src_type, F && f) const
+        {
+            WhichDataType which(src_type);
+
+            switch (which.idx)
+            {
+            case TypeIndex::Date:       f(TypeTag<DataTypeDate>());       break;
+            case TypeIndex::DateTime:   f(TypeTag<DataTypeDateTime>());   break;
+            case TypeIndex::DateTime64: f(TypeTag<DataTypeDateTime64>()); break;
+            default:
+                throw Exception(
+                    "Arguments for function " + getName() + " must be Date, DateTime, or DateTime64.",
+                    ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+            }
+        }
+
+    public:
+        static constexpr auto name = Name::name;
+
+        static FunctionOverloadResolverImplPtr create(const Context &)
+        {
+            return std::make_unique<RunningConcurrencyOverloadResolver<Name, ConcurrencyDataType>>();
+        }
+
+        String getName() const override
+        {
+            return Name::name;
+        }
+
+        FunctionBaseImplPtr build(const ColumnsWithTypeAndName & arguments, const DataTypePtr & return_type) const override
+        {
+            // The type of the second argument must match with that of the first one.
+            if (unlikely(!arguments[1].type->equals(*(arguments[0].type))))
+            {
+                throw Exception(
+                    "Function " + getName() + " must be called with two arguments having the same type.",
+                    ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+            }
+
+            DataTypes argument_types = { arguments[0].type, arguments[1].type };
+            FunctionBaseImplPtr base;
+            dispatchForSourceType(*(arguments[0].type), [&](auto arg_type_tag) // Throws when the type is inappropriate.
+            {
+                using Tag = decltype(arg_type_tag);
+                using ArgDataType = typename Tag::Type;
+
+                base = std::make_unique<FunctionBaseRunningConcurrency<Name, ArgDataType, ConcurrencyDataType>>(argument_types, return_type);
+            });
+
+            return base;
+        }
+
+        DataTypePtr getReturnType(const DataTypes &) const override
+        {
+            return std::make_shared<ConcurrencyDataType>();
+        }
+
+        size_t getNumberOfArguments() const override
+        {
+            return 2;
+        }
+
+        bool isInjective(const ColumnsWithTypeAndName &) const override
+        {
+            return false;
+        }
+
+        bool isStateful() const override
+        {
+            return true;
+        }
+
+        bool useDefaultImplementationForNulls() const override
+        {
+            return false;
+        }
+    };
+
+    struct NameRunningConcurrency
+    {
+        static constexpr auto name = "runningConcurrency";
+    };
+
+    void registerFunctionRunningConcurrency(FunctionFactory & factory)
+    {
+        factory.registerFunction<RunningConcurrencyOverloadResolver<NameRunningConcurrency, DataTypeUInt32>>();
+    }
+}

--- a/src/Functions/ya.make
+++ b/src/Functions/ya.make
@@ -425,6 +425,7 @@ SRCS(
     rowNumberInAllBlocks.cpp
     rowNumberInBlock.cpp
     runningAccumulate.cpp
+    runningConcurrency.cpp
     runningDifference.cpp
     runningDifferenceStartingWithFirstValue.cpp
     sigmoid.cpp

--- a/tests/queries/0_stateless/01602_runningConcurrency.reference
+++ b/tests/queries/0_stateless/01602_runningConcurrency.reference
@@ -1,0 +1,19 @@
+Invocation with Date columns
+1
+2
+3
+2
+1
+Invocation with DateTime
+1
+2
+3
+2
+1
+Invocation with DateTime64
+1
+2
+3
+2
+1
+Erroneous cases

--- a/tests/queries/0_stateless/01602_runningConcurrency.sql
+++ b/tests/queries/0_stateless/01602_runningConcurrency.sql
@@ -1,0 +1,49 @@
+--
+SELECT 'Invocation with Date columns';
+
+DROP TABLE IF EXISTS runningConcurrency_test;
+CREATE TABLE runningConcurrency_test(begin Date, end Date) ENGINE = Memory;
+
+INSERT INTO runningConcurrency_test VALUES ('2020-12-01', '2020-12-10'), ('2020-12-02', '2020-12-10'), ('2020-12-03', '2020-12-12'), ('2020-12-10', '2020-12-12'), ('2020-12-13', '2020-12-20');
+SELECT runningConcurrency(begin, end) FROM runningConcurrency_test;
+
+DROP TABLE runningConcurrency_test;
+
+--
+SELECT 'Invocation with DateTime';
+
+DROP TABLE IF EXISTS runningConcurrency_test;
+CREATE TABLE runningConcurrency_test(begin DateTime, end DateTime) ENGINE = Memory;
+
+INSERT INTO runningConcurrency_test VALUES ('2020-12-01 00:00:00', '2020-12-01 00:59:59'), ('2020-12-01 00:30:00', '2020-12-01 00:59:59'), ('2020-12-01 00:40:00', '2020-12-01 01:30:30'), ('2020-12-01 01:10:00', '2020-12-01 01:30:30'), ('2020-12-01 01:50:00', '2020-12-01 01:59:59');
+SELECT runningConcurrency(begin, end) FROM runningConcurrency_test;
+
+DROP TABLE runningConcurrency_test;
+
+--
+SELECT 'Invocation with DateTime64';
+
+DROP TABLE IF EXISTS runningConcurrency_test;
+CREATE TABLE runningConcurrency_test(begin DateTime64(3), end DateTime64(3)) ENGINE = Memory;
+
+INSERT INTO runningConcurrency_test VALUES ('2020-12-01 00:00:00.000', '2020-12-01 00:00:00.100'), ('2020-12-01 00:00:00.010', '2020-12-01 00:00:00.100'), ('2020-12-01 00:00:00.020', '2020-12-01 00:00:00.200'), ('2020-12-01 00:00:00.150', '2020-12-01 00:00:00.200'), ('2020-12-01 00:00:00.250', '2020-12-01 00:00:00.300');
+SELECT runningConcurrency(begin, end) FROM runningConcurrency_test;
+
+DROP TABLE runningConcurrency_test;
+
+--
+SELECT 'Erroneous cases';
+
+-- Constant columns are currently not supported.
+SELECT runningConcurrency(toDate(arrayJoin([1, 2])), toDate('2000-01-01')); -- { serverError 44 }
+
+-- Unsupported data types
+SELECT runningConcurrency('strings are', 'not supported'); -- { serverError 43 }
+SELECT runningConcurrency(NULL, NULL); -- { serverError 43 }
+SELECT runningConcurrency(CAST(NULL, 'Nullable(DateTime)'), CAST(NULL, 'Nullable(DateTime)')); -- { serverError 43 }
+
+-- Mismatching data types
+SELECT runningConcurrency(toDate('2000-01-01'), toDateTime('2000-01-01 00:00:00')); -- { serverError 43 }
+
+-- begin > end
+SELECT runningConcurrency(toDate('2000-01-02'), toDate('2000-01-01')); -- { serverError 117 }

--- a/tests/queries/0_stateless/01602_runningConcurrency.sql
+++ b/tests/queries/0_stateless/01602_runningConcurrency.sql
@@ -47,3 +47,5 @@ SELECT runningConcurrency(toDate('2000-01-01'), toDateTime('2000-01-01 00:00:00'
 
 -- begin > end
 SELECT runningConcurrency(toDate('2000-01-02'), toDate('2000-01-01')); -- { serverError 117 }
+
+                                                       


### PR DESCRIPTION
Given a series of beginning time and ending time of events, this function calculates concurrency of the events at each of the data point, that is, the beginning time.

Changelog category:
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Included in the pull request

Detailed description / Documentation draft:
- Included in the pull request

```text
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
