### PR TITLE
Control alter sequential execution more correctly

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeAltersSequence.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeAltersSequence.cpp
@@ -23,11 +23,13 @@ void ReplicatedMergeTreeAltersSequence::addMutationForAlter(int alter_version, s
 }
 
 void ReplicatedMergeTreeAltersSequence::addMetadataAlter(
-    int alter_version, bool have_mutation, std::lock_guard<std::mutex> & /*state_lock*/)
+    int alter_version, std::lock_guard<std::mutex> & /*state_lock*/)
 {
+    /// Data alter (mutation) always added before. See ReplicatedMergeTreeQueue::pullLogsToQueue.
+    /// So mutation alredy added to this sequence or doesn't exist.
     if (!queue_state.count(alter_version))
-        queue_state.emplace(alter_version, AlterState{.metadata_finished=false, .data_finished=!have_mutation});
-    else /// Data alter can be added before.
+        queue_state.emplace(alter_version, AlterState{.metadata_finished=false, .data_finished=true});
+    else
         queue_state[alter_version].metadata_finished = false;
 }
 
@@ -43,6 +45,7 @@ void ReplicatedMergeTreeAltersSequence::finishMetadataAlter(int alter_version, s
         queue_state.erase(alter_version);
     else
         queue_state[alter_version].metadata_finished = true;
+
 }
 
 void ReplicatedMergeTreeAltersSequence::finishDataAlter(int alter_version, std::lock_guard<std::mutex> & /*state_lock*/)

--- a/src/Storages/MergeTree/ReplicatedMergeTreeAltersSequence.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeAltersSequence.cpp
@@ -45,7 +45,6 @@ void ReplicatedMergeTreeAltersSequence::finishMetadataAlter(int alter_version, s
         queue_state.erase(alter_version);
     else
         queue_state[alter_version].metadata_finished = true;
-
 }
 
 void ReplicatedMergeTreeAltersSequence::finishDataAlter(int alter_version, std::lock_guard<std::mutex> & /*state_lock*/)

--- a/src/Storages/MergeTree/ReplicatedMergeTreeAltersSequence.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeAltersSequence.h
@@ -38,9 +38,8 @@ public:
     /// Add mutation for alter (alter data stage).
     void addMutationForAlter(int alter_version, std::lock_guard<std::mutex> & /*state_lock*/);
 
-    /// Add metadata for alter (alter metadata stage). If have_mutation=true, than we expect, that
-    /// corresponding mutation will be added.
-    void addMetadataAlter(int alter_version, bool have_mutation, std::lock_guard<std::mutex> & /*state_lock*/);
+    /// Add metadata for alter (alter metadata stage).
+    void addMetadataAlter(int alter_version, std::lock_guard<std::mutex> & /*state_lock*/);
 
     /// Finish metadata alter. If corresponding data alter finished, than we can remove
     /// alter from sequence.

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -158,7 +158,7 @@ void ReplicatedMergeTreeQueue::insertUnlocked(
     if (entry->type == LogEntry::ALTER_METADATA)
     {
         LOG_TRACE(log, "Adding alter metadata version {} to the queue", entry->alter_version);
-        alter_sequence.addMetadataAlter(entry->alter_version, entry->have_mutation, state_lock);
+        alter_sequence.addMetadataAlter(entry->alter_version, state_lock);
     }
 }
 

--- a/tests/queries/0_stateless/01593_concurrent_alter_mutations_kill.sh
+++ b/tests/queries/0_stateless/01593_concurrent_alter_mutations_kill.sh
@@ -24,6 +24,7 @@ function alter_thread
 function kill_mutation_thread
 {
     while true; do
+        # find any mutation and kill it
         mutation_id=$($CLICKHOUSE_CLIENT --query "SELECT mutation_id FROM system.mutations WHERE is_done=0 and database='${CLICKHOUSE_DATABASE}' and table='concurrent_mutate_kill' LIMIT 1")
         if [ ! -z "$mutation_id" ]; then
             $CLICKHOUSE_CLIENT --query "KILL MUTATION WHERE mutation_id='$mutation_id'" 1> /dev/null

--- a/tests/queries/0_stateless/01593_concurrent_alter_mutations_kill_many_replicas.sh
+++ b/tests/queries/0_stateless/01593_concurrent_alter_mutations_kill_many_replicas.sh
@@ -36,6 +36,7 @@ function alter_thread
 function kill_mutation_thread
 {
     while true; do
+        # find any mutation and kill it
         mutation_id=$($CLICKHOUSE_CLIENT --query "SELECT mutation_id FROM system.mutations WHERE is_done = 0 and table like 'concurrent_kill_%' and database='${CLICKHOUSE_DATABASE}' LIMIT 1")
         if [ ! -z "$mutation_id" ]; then
             $CLICKHOUSE_CLIENT --query "KILL MUTATION WHERE mutation_id='$mutation_id'" 1> /dev/null


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bug which may lead to `ALTER` queries hung after corresponding mutation kill. Found by thread fuzzer. 
