### PR TITLE
NaN argument in function 'bar'

### DIFF
--- a/src/Functions/bar.cpp
+++ b/src/Functions/bar.cpp
@@ -7,8 +7,6 @@
 #include <Common/FieldVisitors.h>
 #include <IO/WriteHelpers.h>
 
-#include <iostream>
-
 
 namespace DB
 {

--- a/src/Functions/bar.cpp
+++ b/src/Functions/bar.cpp
@@ -7,6 +7,8 @@
 #include <Common/FieldVisitors.h>
 #include <IO/WriteHelpers.h>
 
+#include <iostream>
+
 
 namespace DB
 {
@@ -75,11 +77,14 @@ public:
         /// The maximum width of the bar in characters, by default.
         Float64 max_width = arguments.size() == 4 ? extractConstant<Float64>(arguments, 3, "Fourth") : 80;
 
+        if (isNaN(max_width))
+            throw Exception("Argument 'max_width' must not be NaN", ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+
         if (max_width < 1)
-            throw Exception("Max_width argument must be >= 1.", ErrorCodes::ARGUMENT_OUT_OF_BOUND);
+            throw Exception("Argument 'max_width' must be >= 1", ErrorCodes::ARGUMENT_OUT_OF_BOUND);
 
         if (max_width > 1000)
-            throw Exception("Too large max_width.", ErrorCodes::ARGUMENT_OUT_OF_BOUND);
+            throw Exception("Argument 'max_width' must be <= 1000", ErrorCodes::ARGUMENT_OUT_OF_BOUND);
 
         const auto & src = *arguments[0].column;
 

--- a/tests/queries/0_stateless/01621_bar_nan_arguments.sql
+++ b/tests/queries/0_stateless/01621_bar_nan_arguments.sql
@@ -1,0 +1,2 @@
+SELECT bar((greatCircleAngle(65537, 2, 1, 1) - 1) * 65535, 1048576, 1048577, nan); -- { serverError 43 }
+select bar(1,1,1,nan); -- { serverError 43 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed assertion error inside allocator in case when last argument of function bar is NaN. Now simple ClickHouse's exception is being thrown. This fixes #17876

