### PR TITLE
Use RLIMIT_DATA/RLIMIT_AS over RLIMIT_RSS for ENABLE_CHECK_HEAVY_BUILDS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,9 +68,9 @@ include (cmake/find/ccache.cmake)
 
 option(ENABLE_CHECK_HEAVY_BUILDS "Don't allow C++ translation units to compile too long or to take too much memory while compiling" OFF)
 if (ENABLE_CHECK_HEAVY_BUILDS)
-    # set DATA (since RSS does not work since 2.6.x+) to 1G
+    # set DATA (since RSS does not work since 2.6.x+) to 2G
     # set VIRT (RLIMIT_AS) to 10G (DATA*10)
-    set (CMAKE_CXX_COMPILER_LAUNCHER prlimit --as=10000000000 --data=1000000000 --cpu=600)
+    set (CMAKE_CXX_COMPILER_LAUNCHER prlimit --as=10000000000 --data=2000000000 --cpu=600)
 endif ()
 
 if (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "None")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,9 @@ include (cmake/find/ccache.cmake)
 
 option(ENABLE_CHECK_HEAVY_BUILDS "Don't allow C++ translation units to compile too long or to take too much memory while compiling" OFF)
 if (ENABLE_CHECK_HEAVY_BUILDS)
-    set (CMAKE_CXX_COMPILER_LAUNCHER prlimit --rss=10000000 --cpu=600)
+    # set DATA (since RSS does not work since 2.6.x+) to 1G
+    # set VIRT (RLIMIT_AS) to 10G (DATA*10)
+    set (CMAKE_CXX_COMPILER_LAUNCHER prlimit --as=10000000000 --data=1000000000 --cpu=600)
 endif ()
 
 if (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "None")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ if (ENABLE_CHECK_HEAVY_BUILDS)
     if (SANITIZE STREQUAL "memory" OR COMPILER_GCC)
        set (RLIMIT_DATA 10000000000)
     endif()
-    set (CMAKE_CXX_COMPILER_LAUNCHER prlimit --as=${RLIMIT_AS}--data=${RLIMIT_DATA}--cpu=600)
+    set (CMAKE_CXX_COMPILER_LAUNCHER prlimit --as=${RLIMIT_AS} --data=${RLIMIT_DATA} --cpu=600)
 endif ()
 
 if (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "None")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ option(ENABLE_CHECK_HEAVY_BUILDS "Don't allow C++ translation units to compile t
 if (ENABLE_CHECK_HEAVY_BUILDS)
     # set DATA (since RSS does not work since 2.6.x+) to 2G
     # set VIRT (RLIMIT_AS) to 10G (DATA*10)
-    set (CMAKE_CXX_COMPILER_LAUNCHER prlimit --as=10000000000 --data=2000000000 --cpu=600)
+    set (CMAKE_CXX_COMPILER_LAUNCHER prlimit --as=10000000000 --data=5000000000 --cpu=600)
 endif ()
 
 if (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "None")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,8 +69,14 @@ include (cmake/find/ccache.cmake)
 option(ENABLE_CHECK_HEAVY_BUILDS "Don't allow C++ translation units to compile too long or to take too much memory while compiling" OFF)
 if (ENABLE_CHECK_HEAVY_BUILDS)
     # set DATA (since RSS does not work since 2.6.x+) to 2G
+    set (RLIMIT_DATA 5000000000)
     # set VIRT (RLIMIT_AS) to 10G (DATA*10)
-    set (CMAKE_CXX_COMPILER_LAUNCHER prlimit --as=10000000000 --data=5000000000 --cpu=600)
+    set (RLIMIT_AS 10000000000)
+    # gcc10/gcc10/clang -fsanitize=memory is too heavy
+    if (SANITIZE STREQUAL "memory" OR COMPILER_GCC)
+       set (RLIMIT_DATA 10000000000)
+    endif()
+    set (CMAKE_CXX_COMPILER_LAUNCHER prlimit --as=${RLIMIT_AS}--data=${RLIMIT_DATA}--cpu=600)
 endif ()
 
 if (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "None")


### PR DESCRIPTION
RLIMIT_RSS does not work since 2.6.x+, from getrlimit(2):

       RLIMIT_RSS
              This  is  a  limit (in bytes) on the process's resident set (the number of virtual pages resident in RAM).  This limit has effect only in Linux 2.4.x, x < 30, and there af‐
              fects only calls to madvise(2) specifying MADV_WILLNEED.

Note that before this patch RSS was to 10MB but I doubt that it is
enough for C++ compiler, this patch uses 1G limit for DATA and 10G for
AS/VIRT (but it seems that even 1G may be too small).

And see also https://code.woboq.org/linux/linux/mm/mmap.c.html#may_expand_vm

Changelog category (leave one):
- Not for changelog (changelog entry is not required)