### PR TITLE
Fix pipeline stuck after join

### DIFF
--- a/src/Processors/DelayedPortsProcessor.cpp
+++ b/src/Processors/DelayedPortsProcessor.cpp
@@ -11,6 +11,9 @@ DelayedPortsProcessor::DelayedPortsProcessor(
 {
     port_pairs.resize(num_ports);
 
+    for (const auto & delayed : delayed_ports)
+        port_pairs[delayed].is_delayed = true;
+
     auto input_it = inputs.begin();
     auto output_it = outputs.begin();
     for (size_t i = 0; i < num_ports; ++i)
@@ -18,15 +21,12 @@ DelayedPortsProcessor::DelayedPortsProcessor(
         port_pairs[i].input_port = &*input_it;
         ++input_it;
 
-        if (output_it != outputs.end())
+        if (!port_pairs[i].is_delayed || !assert_delayed_ports_empty)
         {
             port_pairs[i].output_port = &*output_it;
             ++output_it;
         }
     }
-
-    for (const auto & delayed : delayed_ports)
-        port_pairs[delayed].is_delayed = true;
 }
 
 bool DelayedPortsProcessor::processPair(PortsPair & pair)

--- a/src/Processors/DelayedPortsProcessor.cpp
+++ b/src/Processors/DelayedPortsProcessor.cpp
@@ -10,6 +10,7 @@ DelayedPortsProcessor::DelayedPortsProcessor(
     , num_delayed(delayed_ports.size())
 {
     port_pairs.resize(num_ports);
+    output_to_pair.reserve(outputs.size());
 
     for (const auto & delayed : delayed_ports)
         port_pairs[delayed].is_delayed = true;
@@ -24,6 +25,7 @@ DelayedPortsProcessor::DelayedPortsProcessor(
         if (!port_pairs[i].is_delayed || !assert_delayed_ports_empty)
         {
             port_pairs[i].output_port = &*output_it;
+            output_to_pair.push_back(i);
             ++output_it;
         }
     }
@@ -78,8 +80,9 @@ IProcessor::Status DelayedPortsProcessor::prepare(const PortNumbers & updated_in
 
     for (const auto & output_number : updated_outputs)
     {
-        if (!skip_delayed || !port_pairs[output_number].is_delayed)
-            need_data = processPair(port_pairs[output_number]) || need_data;
+        auto pair_num = output_to_pair[output_number];
+        if (!skip_delayed || !port_pairs[pair_num].is_delayed)
+            need_data = processPair(port_pairs[pair_num]) || need_data;
     }
 
     for (const auto & input_number : updated_inputs)

--- a/src/Processors/DelayedPortsProcessor.cpp
+++ b/src/Processors/DelayedPortsProcessor.cpp
@@ -3,6 +3,11 @@
 namespace DB
 {
 
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
 DelayedPortsProcessor::DelayedPortsProcessor(
     const Block & header, size_t num_ports, const PortNumbers & delayed_ports, bool assert_main_ports_empty)
     : IProcessor(InputPorts(num_ports, header),

--- a/src/Processors/DelayedPortsProcessor.cpp
+++ b/src/Processors/DelayedPortsProcessor.cpp
@@ -78,6 +78,11 @@ IProcessor::Status DelayedPortsProcessor::prepare(const PortNumbers & updated_in
     bool skip_delayed = (num_finished + num_delayed) < port_pairs.size();
     bool need_data = false;
 
+    if (!updated_outputs.empty())
+        for (const auto & pair : port_pairs)
+            if (!pair.output_port)
+                pair.input_port->setNeeded();
+
     for (const auto & output_number : updated_outputs)
     {
         auto pair_num = output_to_pair[output_number];

--- a/src/Processors/DelayedPortsProcessor.cpp
+++ b/src/Processors/DelayedPortsProcessor.cpp
@@ -4,9 +4,9 @@ namespace DB
 {
 
 DelayedPortsProcessor::DelayedPortsProcessor(
-    const Block & header, size_t num_ports, const PortNumbers & delayed_ports, bool assert_delayed_ports_empty)
+    const Block & header, size_t num_ports, const PortNumbers & delayed_ports, bool assert_main_ports_empty)
     : IProcessor(InputPorts(num_ports, header),
-                 OutputPorts(num_ports - (assert_delayed_ports_empty ? delayed_ports.size() : 0), header))
+                 OutputPorts((assert_main_ports_empty ? delayed_ports.size() : num_ports), header))
     , num_delayed(delayed_ports.size())
 {
     port_pairs.resize(num_ports);
@@ -22,7 +22,7 @@ DelayedPortsProcessor::DelayedPortsProcessor(
         port_pairs[i].input_port = &*input_it;
         ++input_it;
 
-        if (!port_pairs[i].is_delayed || !assert_delayed_ports_empty)
+        if (port_pairs[i].is_delayed || !assert_main_ports_empty)
         {
             port_pairs[i].output_port = &*output_it;
             output_to_pair.push_back(i);

--- a/src/Processors/DelayedPortsProcessor.cpp
+++ b/src/Processors/DelayedPortsProcessor.cpp
@@ -78,10 +78,15 @@ IProcessor::Status DelayedPortsProcessor::prepare(const PortNumbers & updated_in
     bool skip_delayed = (num_finished + num_delayed) < port_pairs.size();
     bool need_data = false;
 
-    if (!updated_outputs.empty())
+    if (!are_inputs_initialized && !updated_outputs.empty())
+    {
+        /// Activate inputs with no output.
         for (const auto & pair : port_pairs)
             if (!pair.output_port)
                 pair.input_port->setNeeded();
+
+        are_inputs_initialized = true;
+    }
 
     for (const auto & output_number : updated_outputs)
     {

--- a/src/Processors/DelayedPortsProcessor.h
+++ b/src/Processors/DelayedPortsProcessor.h
@@ -11,7 +11,7 @@ namespace DB
 class DelayedPortsProcessor : public IProcessor
 {
 public:
-    DelayedPortsProcessor(const Block & header, size_t num_ports, const PortNumbers & delayed_ports, bool assert_delayed_ports_empty = false);
+    DelayedPortsProcessor(const Block & header, size_t num_ports, const PortNumbers & delayed_ports, bool assert_main_ports_empty = false);
 
     String getName() const override { return "DelayedPorts"; }
 

--- a/src/Processors/DelayedPortsProcessor.h
+++ b/src/Processors/DelayedPortsProcessor.h
@@ -31,6 +31,8 @@ private:
     size_t num_delayed;
     size_t num_finished = 0;
 
+    std::vector<size_t> output_to_pair;
+
     bool processPair(PortsPair & pair);
 };
 

--- a/src/Processors/DelayedPortsProcessor.h
+++ b/src/Processors/DelayedPortsProcessor.h
@@ -32,6 +32,7 @@ private:
     size_t num_finished = 0;
 
     std::vector<size_t> output_to_pair;
+    bool are_inputs_initialized = false;
 
     bool processPair(PortsPair & pair);
 };

--- a/src/Processors/DelayedPortsProcessor.h
+++ b/src/Processors/DelayedPortsProcessor.h
@@ -11,7 +11,7 @@ namespace DB
 class DelayedPortsProcessor : public IProcessor
 {
 public:
-    DelayedPortsProcessor(const Block & header, size_t num_ports, const PortNumbers & delayed_ports);
+    DelayedPortsProcessor(const Block & header, size_t num_ports, const PortNumbers & delayed_ports, bool assert_delayed_ports_empty = false);
 
     String getName() const override { return "DelayedPorts"; }
 

--- a/src/Processors/QueryPipeline.cpp
+++ b/src/Processors/QueryPipeline.cpp
@@ -298,7 +298,7 @@ void QueryPipeline::addPipelineBefore(QueryPipeline pipeline)
     pipes.emplace_back(QueryPipeline::getPipe(std::move(pipeline)));
     pipe = Pipe::unitePipes(std::move(pipes), collected_processors);
 
-    auto processor = std::make_shared<DelayedPortsProcessor>(getHeader(), pipe.numOutputPorts(), delayed_streams);
+    auto processor = std::make_shared<DelayedPortsProcessor>(getHeader(), pipe.numOutputPorts(), delayed_streams, true);
     addTransform(std::move(processor));
 }
 

--- a/src/Processors/QueryPlan/AddingDelayedSourceStep.cpp
+++ b/src/Processors/QueryPlan/AddingDelayedSourceStep.cpp
@@ -32,6 +32,11 @@ void AddingDelayedSourceStep::transformPipeline(QueryPipeline & pipeline)
 {
     source->setQueryPlanStep(this);
     pipeline.addDelayedStream(source);
+
+    /// Now, after adding delayed stream, it has implicit dependency on other port.
+    /// Here we add resize processor to remove this dependency.
+    /// Otherwise, if we add MergeSorting + MergingSorted transform to pipeline, we could get `Pipeline stuck`
+    pipeline.resize(pipeline.getNumStreams(), true);
 }
 
 }

--- a/tests/queries/0_stateless/01621_sort_after_join_pipeline_stuck.sql
+++ b/tests/queries/0_stateless/01621_sort_after_join_pipeline_stuck.sql
@@ -1,0 +1,1 @@
+SELECT k FROM (SELECT NULL, nullIf(number, 3) AS k, '1048575', (65536, -9223372036854775808), toString(number) AS a FROM system.numbers LIMIT 1048577) AS js1 ANY RIGHT JOIN (SELECT 1.000100016593933, nullIf(number, NULL) AS k, toString(number) AS b FROM system.numbers LIMIT 2, 255) AS js2 USING (k) ORDER BY 257 ASC NULLS LAST FORMAT Null;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible `Pipeline stuck` error while using `ORDER BY` after subquery with `RIGHT` or `FULL` join.

https://clickhouse-test-reports.s3.yandex.net/18523/721bb60edd055c432e8606472f5e63232b1de56e/fuzzer/report.html#fail1