### PR TITLE
Early draft: materialize IN before sending to external databases

### DIFF
--- a/src/Storages/StorageMySQL.h
+++ b/src/Storages/StorageMySQL.h
@@ -47,6 +47,13 @@ public:
 
     BlockOutputStreamPtr write(const ASTPtr & query, const StorageMetadataPtr & /*metadata_snapshot*/, const Context & context) override;
 
+    bool supportsIndexForIn() const override { return true; }
+    bool mayBenefitFromIndexForIn(
+        const ASTPtr & /* node */, const Context & /*query_context*/, const StorageMetadataPtr & /*metadata_snapshot*/) const override
+    {
+        return true;
+    }
+
 private:
     friend class StorageMySQLBlockOutputStream;
 

--- a/src/Storages/StorageXDBC.h
+++ b/src/Storages/StorageXDBC.h
@@ -35,6 +35,12 @@ public:
     BlockOutputStreamPtr write(const ASTPtr & query, const StorageMetadataPtr & /*metadata_snapshot*/, const Context & context) override;
 
     std::string getName() const override;
+    bool supportsIndexForIn() const override { return true; }
+    bool mayBenefitFromIndexForIn(
+        const ASTPtr & /* node */, const Context & /*query_context*/, const StorageMetadataPtr & /*metadata_snapshot*/) const override
+    {
+        return true;
+    }
 private:
 
     BridgeHelperPtr bridge_helper;


### PR DESCRIPTION
This is still early but wanted to get feedback on whether you were interested in it?

The idea is to materialize a WHERE ... IN ({subquery}) or WHERE ... IN ({alias}) query before sending the query to an external database that could efficiently answer that query. It's useful for our use case but not sure if it's something you'd like to merge generally.

Open questions:

1. Currently 1 element tuples aren't sent to external databases. Is there a general format for IN ({1 element}) that works?
2. I could see large IN lists being a pessimization (e.g. query string becomes too big to handle, database doesn't have an index on the IN column). There's a workaround of just moving IN () to an enclosing query, but not sure if there's either a good way to check for this or if a config option would be appropriate.
3. This is my first CH PR - any other feedback definitely welcome!

TODO:

1. Remove extra logging
2. Ensure formatting matches CH standards
3. Properly handle multiple columns as tuple-of-tuples