### PR TITLE
Fix removing of empty parts in tables with old syntax

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -6154,7 +6154,7 @@ bool StorageReplicatedMergeTree::dropPart(
         /// DROP_RANGE with detach will move this part together with source parts to `detached/` dir.
         entry.type = LogEntry::DROP_RANGE;
         entry.source_replica = replica_name;
-        entry.new_part_name = drop_part_info.getPartName();
+        entry.new_part_name = getPartNamePossiblyFake(format_version, drop_part_info);
         entry.detach = detach;
         entry.create_time = time(nullptr);
 

--- a/tests/integration/test_merge_tree_empty_parts/configs/cleanup_thread.xml
+++ b/tests/integration/test_merge_tree_empty_parts/configs/cleanup_thread.xml
@@ -1,0 +1,6 @@
+<yandex>
+    <merge_tree>
+        <cleanup_delay_period>0</cleanup_delay_period>
+        <cleanup_delay_period_random_add>0</cleanup_delay_period_random_add>
+    </merge_tree>
+</yandex>

--- a/tests/integration/test_merge_tree_empty_parts/configs/remote_servers.xml
+++ b/tests/integration/test_merge_tree_empty_parts/configs/remote_servers.xml
@@ -1,0 +1,13 @@
+<yandex>
+    <remote_servers>
+        <test_cluster>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster>
+    </remote_servers>
+</yandex>

--- a/tests/integration/test_merge_tree_empty_parts/test.py
+++ b/tests/integration/test_merge_tree_empty_parts/test.py
@@ -1,0 +1,38 @@
+import pytest
+import helpers.client
+import helpers.cluster
+from helpers.test_tools import assert_eq_with_retry
+
+
+cluster = helpers.cluster.ClickHouseCluster(__file__)
+node1 = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml', 'configs/cleanup_thread.xml'], with_zookeeper=True)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+def test_empty_parts_alter_delete(started_cluster):
+    node1.query("CREATE TABLE empty_parts_delete (d Date, key UInt64, value String) \
+        ENGINE = ReplicatedMergeTree('/clickhouse/tables/empty_parts_delete', 'r1', d, key, 8192)")
+
+    node1.query("INSERT INTO empty_parts_delete VALUES (toDate('2020-10-10'), 1, 'a')")
+    node1.query("ALTER TABLE empty_parts_delete DELETE WHERE 1 SETTINGS mutations_sync = 2")
+
+    print(node1.query("SELECT count() FROM empty_parts_delete"))
+    assert_eq_with_retry(node1, "SELECT count() FROM system.parts WHERE table = 'empty_parts_delete' AND active", "0")
+
+def test_empty_parts_summing(started_cluster):
+    node1.query("CREATE TABLE empty_parts_summing (d Date, key UInt64, value Int64) \
+        ENGINE = ReplicatedSummingMergeTree('/clickhouse/tables/empty_parts_summing', 'r1', d, key, 8192)")
+
+    node1.query("INSERT INTO empty_parts_summing VALUES (toDate('2020-10-10'), 1, 1)")
+    node1.query("INSERT INTO empty_parts_summing VALUES (toDate('2020-10-10'), 1, -1)")
+    node1.query("OPTIMIZE TABLE empty_parts_summing FINAL")
+
+    assert_eq_with_retry(node1, "SELECT count() FROM system.parts WHERE table = 'empty_parts_summing' AND active", "0")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix removing of empty parts in `ReplicatedMergeTree` tables, created with old syntax. Fixes #18582.