### PR TITLE
add query_id column to system.part_log

### DIFF
--- a/src/Interpreters/PartLog.h
+++ b/src/Interpreters/PartLog.h
@@ -18,6 +18,8 @@ struct PartLogElement
         MOVE_PART = 6,
     };
 
+    String query_id;
+
     Type event_type = NEW_PART;
 
     time_t event_time = 0;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add `query_id` column to `system.part_log` for inserted parts. closes [#10097](https://github.com/ClickHouse/ClickHouse/issues/10097)

