### PR TITLE
Fix performance comparison

### DIFF
--- a/docker/packager/binary/build.sh
+++ b/docker/packager/binary/build.sh
@@ -31,7 +31,7 @@ find . -name '*.so.*' -print -exec mv '{}' /output \;
 if [ "performance" == "$COMBINED_OUTPUT" ]
 then
     cp -r ../tests/performance /output
-    cp -r ../tests/config/top_level_domains  /
+    cp -r ../tests/config/top_level_domains  /output
     cp -r ../docker/test/performance-comparison/config /output ||:
     rm /output/unit_tests_dbms ||:
     rm /output/clickhouse-odbc-bridge ||:

--- a/docker/test/performance-comparison/compare.sh
+++ b/docker/test/performance-comparison/compare.sh
@@ -36,6 +36,22 @@ function wait_for_server # port, pid
     fi
 }
 
+function left_or_right()
+{
+    local from=$1 && shift
+    local basename=$1 && shift
+
+    if [ -e "$from/$basename" ]; then
+        echo "$from/$basename"
+        return
+    fi
+
+    case "$from" in
+        left) echo "right/$basename" ;;
+        right) echo "left/$basename" ;;
+    esac
+}
+
 function configure
 {
     # Use the new config for both servers, so that we can change it in a PR.
@@ -55,7 +71,7 @@ function configure
         # server *config* directives overrides
         --path db0
         --user_files_path db0/user_files
-        --top_level_domains_path right/top_level_domains
+        --top_level_domains_path "$(left_or_right right top_level_domains)"
         --tcp_port $LEFT_SERVER_PORT
     )
     left/clickhouse-server "${setup_left_server_opts[@]}" &> setup-server-log.log &
@@ -103,7 +119,7 @@ function restart
         # server *config* directives overrides
         --path left/db
         --user_files_path left/db/user_files
-        --top_level_domains_path left/top_level_domains
+        --top_level_domains_path "$(left_or_right left top_level_domains)"
         --tcp_port $LEFT_SERVER_PORT
     )
     left/clickhouse-server "${left_server_opts[@]}" &>> left-server-log.log &
@@ -118,7 +134,7 @@ function restart
         # server *config* directives overrides
         --path right/db
         --user_files_path right/db/user_files
-        --top_level_domains_path right/top_level_domains
+        --top_level_domains_path "$(left_or_right right top_level_domains)"
         --tcp_port $RIGHT_SERVER_PORT
     )
     right/clickhouse-server "${right_server_opts[@]}" &>> right-server-log.log &

--- a/docker/test/performance-comparison/compare.sh
+++ b/docker/test/performance-comparison/compare.sh
@@ -55,7 +55,7 @@ function configure
         # server *config* directives overrides
         --path db0
         --user_files_path db0/user_files
-        --top_level_domains_path /top_level_domains
+        --top_level_domains_path right/top_level_domains
         --tcp_port $LEFT_SERVER_PORT
     )
     left/clickhouse-server "${setup_left_server_opts[@]}" &> setup-server-log.log &
@@ -103,7 +103,7 @@ function restart
         # server *config* directives overrides
         --path left/db
         --user_files_path left/db/user_files
-        --top_level_domains_path /top_level_domains
+        --top_level_domains_path left/top_level_domains
         --tcp_port $LEFT_SERVER_PORT
     )
     left/clickhouse-server "${left_server_opts[@]}" &>> left-server-log.log &
@@ -118,7 +118,7 @@ function restart
         # server *config* directives overrides
         --path right/db
         --user_files_path right/db/user_files
-        --top_level_domains_path /top_level_domains
+        --top_level_domains_path right/top_level_domains
         --tcp_port $RIGHT_SERVER_PORT
     )
     right/clickhouse-server "${right_server_opts[@]}" &>> right-server-log.log &


### PR DESCRIPTION
In #18113 the top_level_domains list copying was moved into
docker/packager/binary/build.sh, this was done to avoid symlinks (since
Dockerfile cannot dereference them).

But the patch was wrong, since it copied into the root (/), which is not
included into performance.tgz and also compare.sh was not modified.

This wasn't showed up with CI checks since the docker image wasn't
updated and it still included that top_level_domains, once it was
modified the image was updated and it became broken.

Cc: @akuzm

Changelog category (leave one):
- Not for changelog (changelog entry is not required)