### PR TITLE
Allow Replicated tables in Arcadia

### DIFF
--- a/src/Storages/MergeTree/LeaderElection.h
+++ b/src/Storages/MergeTree/LeaderElection.h
@@ -112,13 +112,12 @@ private:
 
             String value = zookeeper.get(path + "/" + children.front());
 
-#if !defined(ARCADIA_BUILD) /// C++20; Replicated tables are unused in Arcadia.
             if (value.ends_with(suffix))
             {
                 handler();
                 return;
             }
-#endif
+
             if (my_node_it == children.begin())
                 throw Poco::Exception("Assertion failed in LeaderElection");
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


ClickHouse build from Arcadia is not used by itself - this change is only to avoid confustion with testing.