### PR TITLE
Use relaxed for flag in RemoteQueryExecutorReadContext.

### DIFF
--- a/src/DataStreams/RemoteQueryExecutor.cpp
+++ b/src/DataStreams/RemoteQueryExecutor.cpp
@@ -225,7 +225,7 @@ std::variant<Block, int> RemoteQueryExecutor::read(std::unique_ptr<ReadContext> 
         if (!read_context->resumeRoutine())
             return Block();
 
-        if (read_context->is_read_in_progress)
+        if (read_context->is_read_in_progress.load(std::memory_order_relaxed))
         {
             read_context->setTimer();
             return read_context->epoll_fd;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

