### PR TITLE
Remove pink screen with confusing questions about Kerberos

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -40,7 +40,7 @@ Description: Common files for ClickHouse
 Package: clickhouse-server
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, clickhouse-common-static (= ${binary:Version}), adduser
-Recommends: libcap2-bin, krb5-user
+Recommends: libcap2-bin
 Replaces: clickhouse-server-common, clickhouse-server-base
 Provides: clickhouse-server-common
 Description: Server binary for ClickHouse


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


This closes #18734