### PR TITLE
Remove bad code in HashJoin

### DIFF
--- a/src/Interpreters/HashJoin.cpp
+++ b/src/Interpreters/HashJoin.cpp
@@ -357,16 +357,32 @@ void HashJoin::init(Type type_)
     joinDispatch(kind, strictness, data->maps, [&](auto, auto, auto & map) { map.create(data->type); });
 }
 
-size_t HashJoin::getTotalRowCount() const
+bool HashJoin::overDictionary() const
 {
-    std::shared_lock lock(data->rwlock);
-    return getTotalRowCountLocked();
+    return data->type == Type::DICT;
+}
+
+bool HashJoin::empty() const
+{
+    return data->type == Type::EMPTY;
 }
 
 size_t HashJoin::getTotalByteCount() const
 {
     std::shared_lock lock(data->rwlock);
     return getTotalByteCountLocked();
+}
+
+size_t HashJoin::getTotalRowCount() const
+{
+    std::shared_lock lock(data->rwlock);
+    return getTotalRowCountLocked();
+}
+
+bool HashJoin::alwaysReturnsEmptySet() const
+{
+    std::shared_lock lock(data->rwlock);
+    return isInnerOrRight(getKind()) && data->empty && !overDictionary();
 }
 
 size_t HashJoin::getTotalRowCountLocked() const

--- a/src/Interpreters/HashJoin.h
+++ b/src/Interpreters/HashJoin.h
@@ -150,9 +150,6 @@ class HashJoin : public IJoin
 public:
     HashJoin(std::shared_ptr<TableJoin> table_join_, const Block & right_sample_block, bool any_take_last_row_ = false);
 
-    bool empty() const { return data->type == Type::EMPTY; }
-    bool overDictionary() const { return data->type == Type::DICT; }
-
     /** Add block of data from right hand of JOIN to the map.
       * Returns false, if some limit was exceeded and you should not insert more data.
       */
@@ -188,7 +185,7 @@ public:
     /// Sum size in bytes of all buffers, used for JOIN maps and for all memory pools.
     size_t getTotalByteCount() const final;
 
-    bool alwaysReturnsEmptySet() const final { return isInnerOrRight(getKind()) && data->empty && !overDictionary(); }
+    bool alwaysReturnsEmptySet() const final;
 
     ASTTableJoin::Kind getKind() const { return kind; }
     ASTTableJoin::Strictness getStrictness() const { return strictness; }
@@ -397,6 +394,9 @@ private:
     /// Call with already locked rwlock.
     size_t getTotalRowCountLocked() const;
     size_t getTotalByteCountLocked() const;
+
+    bool empty() const;
+    bool overDictionary() const;
 };
 
 }


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


The code was obnoxiously bad: unused public methods + wrong locking.
https://clickhouse-test-reports.s3.yandex.net/18748/a15eb69f049fe0ab78f21236468fc64248a1afa1/stress_test_(thread)/stderr.log Discovered here: #18748