### PR TITLE
More robust stateful test

### DIFF
--- a/docker/test/stateful/run.sh
+++ b/docker/test/stateful/run.sh
@@ -37,7 +37,15 @@ chmod 777 -R /var/lib/clickhouse
 clickhouse-client --query "SHOW DATABASES"
 clickhouse-client --query "ATTACH DATABASE datasets ENGINE = Ordinary"
 clickhouse-client --query "CREATE DATABASE test"
-service clickhouse-server restart && sleep 5
+
+service clickhouse-server restart
+
+# Wait for server to start accepting connections
+for _ in {1..120}; do
+    clickhouse-client --query "SELECT 1" && break
+    sleep 1
+done
+
 clickhouse-client --query "SHOW TABLES FROM datasets"
 clickhouse-client --query "SHOW TABLES FROM test"
 clickhouse-client --query "RENAME TABLE datasets.hits_v1 TO test.hits"


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Server may take time to start.
Discovered here: https://clickhouse-test-reports.s3.yandex.net/18745/3bbdacc66b7d86669f278a8f036e2edd19879565/functional_stateful_tests_(release)/test_run.txt.out.log
#18745