### PR TITLE
Mark some TestFlows as flaky

### DIFF
--- a/tests/testflows/ldap/authentication/regression.py
+++ b/tests/testflows/ldap/authentication/regression.py
@@ -25,6 +25,8 @@ xfails = {
     "connection protocols/tls cipher suite":
      [(Fail, "can't get it to work")],
     "external user directory/user authentications/valid verification cooldown value ldap unavailable":
+     [(Fail, "flaky, ask Vitaly Zakaznikov, Telegram @vzakaznikov")],
+    "user authentications/rbac=True/verification cooldown/verification cooldown performance":
      [(Fail, "flaky, ask Vitaly Zakaznikov, Telegram @vzakaznikov")]
 }
 

--- a/tests/testflows/ldap/authentication/regression.py
+++ b/tests/testflows/ldap/authentication/regression.py
@@ -23,7 +23,9 @@ xfails = {
     "connection protocols/starttls with custom port":
      [(Fail, "it seems that starttls is not enabled by default on custom plain-text ports in LDAP server")],
     "connection protocols/tls cipher suite":
-     [(Fail, "can't get it to work")]
+     [(Fail, "can't get it to work")],
+    "external user directory/user authentications/valid verification cooldown value ldap unavailable":
+     [(Fail, "flaky, ask Vitaly Zakaznikov, Telegram @vzakaznikov")]
 }
 
 @TestFeature


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

See 
https://clickhouse-test-reports.s3.yandex.net/18750/535889003987145bc366f874e486540daa24ec53/testflows_check.html#fail1
https://clickhouse-test-reports.s3.yandex.net/18688/f2ae42b857b33a3305d3d3a2a8819a402bec0fc9/testflows_check.html#fail1

96c0fff91310ad0b11282da664134430b7abfd77
486418d112b8d97eccbed1bf9317e5b5870da381
195e43de39311238e8f23bfbd7accfd37c243165

https://clickhouse-test-reports.s3.yandex.net/18753/ab6798addd9de3b26e0eb801f051b87404f4617c/testflows_check.html#fail1

#18750
#18753

"Testflows" are supported entirely by third-party: @vzakaznikov 