### PR TITLE
[RFC] Fix memory tracking for OPTIMIZE TABLE/merges

### DIFF
--- a/src/Storages/MergeTree/MergeList.cpp
+++ b/src/Storages/MergeTree/MergeList.cpp
@@ -40,6 +40,18 @@ MergeListElement::MergeListElement(const std::string & database_, const std::str
     background_thread_memory_tracker = CurrentThread::getMemoryTracker();
     if (background_thread_memory_tracker)
     {
+        /// From the query context it will be ("for thread") memory tracker with VariableContext::Thread level,
+        /// which does not have any limits and sampling settings configured.
+        /// And parent for this memory tracker should be ("(for query)") with VariableContext::Process level,
+        /// that has limits and sampling configured.
+        MemoryTracker * parent;
+        if (background_thread_memory_tracker->level == VariableContext::Thread &&
+            (parent = background_thread_memory_tracker->getParent()) &&
+            parent != &total_memory_tracker)
+        {
+            background_thread_memory_tracker = parent;
+        }
+
         background_thread_memory_tracker_prev_parent = background_thread_memory_tracker->getParent();
         background_thread_memory_tracker->setParent(&memory_tracker);
     }

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
@@ -180,14 +180,6 @@ void MergeTreeDataPartWriterOnDisk::calculateAndSerializePrimaryIndex(const Bloc
             index_columns[i] = primary_index_block.getByPosition(i).column->cloneEmpty();
     }
 
-    /** While filling index (index_columns), disable memory tracker.
-     * Because memory is allocated here (maybe in context of INSERT query),
-     *  but then freed in completely different place (while merging parts), where query memory_tracker is not available.
-     * And otherwise it will look like excessively growing memory consumption in context of query.
-     *  (observed in long INSERT SELECTs)
-     */
-    MemoryTracker::BlockerInThread temporarily_disable_memory_tracker;
-
     /// Write index. The index contains Primary Key value for each `index_granularity` row.
     for (const auto & granule : granules_to_write)
     {

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
@@ -180,19 +180,30 @@ void MergeTreeDataPartWriterOnDisk::calculateAndSerializePrimaryIndex(const Bloc
             index_columns[i] = primary_index_block.getByPosition(i).column->cloneEmpty();
     }
 
-    /// Write index. The index contains Primary Key value for each `index_granularity` row.
-    for (const auto & granule : granules_to_write)
     {
-        if (metadata_snapshot->hasPrimaryKey() && granule.mark_on_start)
+        /** While filling index (index_columns), disable memory tracker.
+         * Because memory is allocated here (maybe in context of INSERT query),
+         *  but then freed in completely different place (while merging parts), where query memory_tracker is not available.
+         * And otherwise it will look like excessively growing memory consumption in context of query.
+         *  (observed in long INSERT SELECTs)
+         */
+        MemoryTracker::BlockerInThread temporarily_disable_memory_tracker;
+
+        /// Write index. The index contains Primary Key value for each `index_granularity` row.
+        for (const auto & granule : granules_to_write)
         {
-            for (size_t j = 0; j < primary_columns_num; ++j)
+            if (metadata_snapshot->hasPrimaryKey() && granule.mark_on_start)
             {
-                const auto & primary_column = primary_index_block.getByPosition(j);
-                index_columns[j]->insertFrom(*primary_column.column, granule.start_row);
-                primary_column.type->serializeBinary(*primary_column.column, granule.start_row, *index_stream);
+                for (size_t j = 0; j < primary_columns_num; ++j)
+                {
+                    const auto & primary_column = primary_index_block.getByPosition(j);
+                    index_columns[j]->insertFrom(*primary_column.column, granule.start_row);
+                    primary_column.type->serializeBinary(*primary_column.column, granule.start_row, *index_stream);
+                }
             }
         }
     }
+
     /// store last index row to write final mark at the end of column
     for (size_t j = 0; j < primary_columns_num; ++j)
         last_block_index_columns[j] = primary_index_block.getByPosition(j).column;

--- a/tests/queries/0_stateless/01641_memory_tracking_insert_optimize.sql
+++ b/tests/queries/0_stateless/01641_memory_tracking_insert_optimize.sql
@@ -1,0 +1,13 @@
+drop table if exists data_01641;
+
+create table data_01641 (key Int, value String) engine=MergeTree order by (key, repeat(value, 10)) settings old_parts_lifetime=0, min_bytes_for_wide_part=0;
+
+-- peak memory usage is 170MiB
+set max_memory_usage='200Mi';
+system stop merges data_01641;
+insert into data_01641 select number, toString(number) from numbers(toUInt64(120e6));
+
+-- FIXME: this limit does not work
+set max_memory_usage='10Mi';
+system start merges data_01641;
+optimize table data_01641 final;

--- a/tests/queries/0_stateless/01641_memory_tracking_insert_optimize.sql
+++ b/tests/queries/0_stateless/01641_memory_tracking_insert_optimize.sql
@@ -7,7 +7,15 @@ set max_memory_usage='200Mi';
 system stop merges data_01641;
 insert into data_01641 select number, toString(number) from numbers(toUInt64(120e6));
 
--- FIXME: this limit does not work
-set max_memory_usage='10Mi';
+-- peak:
+-- - is 21MiB if background merges already scheduled
+-- - is ~60MiB otherwise
+set max_memory_usage='80Mi';
 system start merges data_01641;
 optimize table data_01641 final;
+
+-- definitely should fail
+set max_memory_usage='1Mi';
+optimize table data_01641 final; -- { serverError 241 }
+
+drop table data_01641;

--- a/tests/queries/skip_list.json
+++ b/tests/queries/skip_list.json
@@ -16,7 +16,8 @@
         "01474_executable_dictionary", /// informational stderr from sanitizer at start
         "functions_bad_arguments", /// Too long for TSan
         "01603_read_with_backoff_bug", /// Too long for TSan
-        "01646_system_restart_replicas_smoke" /// RESTART REPLICAS can acquire too much locks, while only 64 is possible from one thread under TSan
+        "01646_system_restart_replicas_smoke", /// RESTART REPLICAS can acquire too much locks, while only 64 is possible from one thread under TSan
+        "01641_memory_tracking_insert_optimize" /// INSERT lots of rows is too heavy for TSan
     ],
     "address-sanitizer": [
         "00877",
@@ -62,7 +63,8 @@
         "hyperscan",
         "01193_metadata_loading",
         "01473_event_time_microseconds",
-        "01396_inactive_replica_cleanup_nodes"
+        "01396_inactive_replica_cleanup_nodes",
+        "01641_memory_tracking_insert_optimize" /// INSERT lots of rows is too heavy in debug build
     ],
     "unbundled-build": [
         "00429",


### PR DESCRIPTION
Changelog category (leave one):
- Backward Incompatible Change

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix memory tracking for `OPTIMIZE TABLE`/merges
- Account query memory limits and sampling for `OPTIMIZE TABLE`/merges

Detailed description / Documentation draft:
Because of BlockerInThread in
MergeTreeDataPartWriterOnDisk::calculateAndSerializePrimaryIndex memory
was accounted incorrectly and grows constantly.

And IIUC there is no need in that blocker, since INSERT SELECT shares
the same thread group.

Plus take memory limits and sampling into account (**and because of this marked as backward incompatible since now OPTIMIZE may fail if the query has some memory limits**)