### PR TITLE
Check if XCODE_IDE is true and avoid enforcing ninja in that case

### DIFF
--- a/PreLoad.cmake
+++ b/PreLoad.cmake
@@ -12,7 +12,7 @@
 # https://youtrack.jetbrains.com/issue/CPP-2659
 # https://youtrack.jetbrains.com/issue/CPP-870
 
-if (NOT DEFINED ENV{CLION_IDE})
+if (NOT DEFINED ENV{CLION_IDE} AND NOT DEFINED ENV{XCODE_IDE})
     find_program(NINJA_PATH ninja)
     if (NINJA_PATH)
         set(CMAKE_GENERATOR "Ninja" CACHE INTERNAL "" FORCE)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Not for changelog

Changelog entry:
- None

Detailed description:
- `XCODE_IDE` is not an official env var, and is not used anywhere, so this won't break anything. However, this check will help to configure `cmake` using Xcode IDE without having to edit the `PreLoad.cmake` file all the time, like this:

```sh
XCODE_IDE=1 cmake -G Xcode ..
```