### PR TITLE
Do not allow Fuzzer to enable LLVM

### DIFF
--- a/docker/test/fuzzer/query-fuzzer-tweaks-users.xml
+++ b/docker/test/fuzzer/query-fuzzer-tweaks-users.xml
@@ -10,6 +10,11 @@
                 <max_execution_time>
                     <max>10</max>
                 </max_execution_time>
+
+                <!-- Not ready for production -->
+                <compile_expressions>
+                    <readonly />
+                </compile_expressions>
             </constraints>
         </default>
     </profiles>


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


LLVM support is not ready for production usage.

This closes #13750.
This closes #13281.