### PR TITLE
replace PODArray with PODArrayWithStackMemory in AggregateFunctionWindowFunnelData

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionWindowFunnel.h
+++ b/src/AggregateFunctions/AggregateFunctionWindowFunnel.h
@@ -33,7 +33,7 @@ template <typename T>
 struct AggregateFunctionWindowFunnelData
 {
     using TimestampEvent = std::pair<T, UInt8>;
-    using TimestampEvents = PODArray<TimestampEvent, 64>;
+    using TimestampEvents = PODArrayWithStackMemory<TimestampEvent, 64>;
     using Comparator = ComparePairFirst;
 
     bool sorted = true;

--- a/tests/performance/optimize_window_funnel.xml
+++ b/tests/performance/optimize_window_funnel.xml
@@ -1,0 +1,12 @@
+<test>
+    <create_query>CREATE TABLE action(uid UInt64, event String, time DateTime) ENGINE = MergeTree ORDER BY uid</create_query>
+
+    <fill_query>INSERT INTO action SELECT arrayJoin(groupArray(number)), 'a', now() from numbers(10000000)</fill_query>
+    <fill_query>INSERT INTO action SELECT arrayJoin(groupArray(number)), 'b', now() + INTERVAL 6 hour from numbers(10000000)</fill_query>
+    <fill_query>INSERT INTO action SELECT arrayJoin(groupArray(number)), 'c', now() + INTERVAL 12 hour from numbers(10000000)</fill_query>
+    <fill_query>INSERT INTO action SELECT arrayJoin(groupArray(number)), 'd', now() + INTERVAL 18 hour from numbers(10000000)</fill_query>
+
+    <query>SELECT level, count() from (select windowFunnel(86400)(time, event='a', event='b', event='c', event='d') level from action group by uid) group by level FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS action</drop_query>
+</test>

--- a/tests/performance/optimize_window_funnel.xml
+++ b/tests/performance/optimize_window_funnel.xml
@@ -1,10 +1,10 @@
 <test>
     <create_query>CREATE TABLE action(uid UInt64, event String, time DateTime) ENGINE = MergeTree ORDER BY uid</create_query>
 
-    <fill_query>INSERT INTO action SELECT arrayJoin(groupArray(number)), 'a', now() from numbers(10000000)</fill_query>
-    <fill_query>INSERT INTO action SELECT arrayJoin(groupArray(number)), 'b', now() + INTERVAL 6 hour from numbers(10000000)</fill_query>
-    <fill_query>INSERT INTO action SELECT arrayJoin(groupArray(number)), 'c', now() + INTERVAL 12 hour from numbers(10000000)</fill_query>
-    <fill_query>INSERT INTO action SELECT arrayJoin(groupArray(number)), 'd', now() + INTERVAL 18 hour from numbers(10000000)</fill_query>
+    <fill_query>INSERT INTO action SELECT arrayJoin(groupArray(number)), 'a', now() from numbers(1000000)</fill_query>
+    <fill_query>INSERT INTO action SELECT arrayJoin(groupArray(number)), 'b', now() + INTERVAL 6 hour from numbers(1000000)</fill_query>
+    <fill_query>INSERT INTO action SELECT arrayJoin(groupArray(number)), 'c', now() + INTERVAL 12 hour from numbers(1000000)</fill_query>
+    <fill_query>INSERT INTO action SELECT arrayJoin(groupArray(number)), 'd', now() + INTERVAL 18 hour from numbers(1000000)</fill_query>
 
     <query>SELECT level, count() from (select windowFunnel(86400)(time, event='a', event='b', event='c', event='d') level from action group by uid) group by level FORMAT Null</query>
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Replace `PODArray` with `PODArrayWithStackMemory` in `AggregateFunctionWindowFunnelData`  to improvement `windowFunnel` function performance.



Detailed description / Documentation draft:

Funnel analysis is very useful in many scenarios. 

In Tencent, we use `windowFunnel` aggregate function to analyze user events, and it's slow. we profile with perf and found that lots of time is used in memory allocation, CPU utilization is not very high. 

We consider the implementation of this function, and analyze it with specific sql,  then we found that usually, we always caculate `windowFunnel` with group by `userid` and lots of fileter condition, for example:
```sql
SELECT
    level,
    count()
FROM
(
    SELECT
        uid,
        windowFunnel(86400)(time, event = '浏览', event = '点击', event = '下单', event = '支付') AS level
    FROM action where ...// lots of filter condition
    GROUP BY uid
)
GROUP BY level
```
After filter, each user's event list is not very big, so we replace `PODArray` with `PODArrayWithStackMemory` in `AggregateFunctionWindowFunnelData` and gain a lot of performance improvement, maybe we should consider about the implementation here?