### PR TITLE
Improve checksum checks for async INSERT into Distributed on the sender

### DIFF
--- a/src/Compression/CachedCompressedReadBuffer.cpp
+++ b/src/Compression/CachedCompressedReadBuffer.cpp
@@ -45,7 +45,7 @@ bool CachedCompressedReadBuffer::nextImpl()
 
         size_t size_decompressed;
         size_t size_compressed_without_checksum;
-        owned_cell->compressed_size = readCompressedData(size_decompressed, size_compressed_without_checksum);
+        owned_cell->compressed_size = readCompressedData(size_decompressed, size_compressed_without_checksum, false);
 
         if (owned_cell->compressed_size)
         {

--- a/src/Compression/CheckingCompressedReadBuffer.cpp
+++ b/src/Compression/CheckingCompressedReadBuffer.cpp
@@ -1,0 +1,24 @@
+#include <Compression/CheckingCompressedReadBuffer.h>
+
+namespace DB
+{
+
+bool CheckingCompressedReadBuffer::nextImpl()
+{
+    size_t size_decompressed;
+    size_t size_compressed_without_checksum;
+    size_t size_compressed = readCompressedData(size_decompressed, size_compressed_without_checksum, true);
+
+    if (!size_compressed)
+        return false;
+
+    /// own_compressed_buffer also includes getAdditionalSizeAtTheEndOfBuffer()
+    /// which should not be accounted here, so size_compressed is used.
+    ///
+    /// And BufferBase is used over ReadBuffer, since former reset the working_buffer.
+    BufferBase::set(own_compressed_buffer.data(), size_compressed, 0);
+
+    return true;
+}
+
+}

--- a/src/Compression/CheckingCompressedReadBuffer.h
+++ b/src/Compression/CheckingCompressedReadBuffer.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <Compression/CompressedReadBufferBase.h>
+#include <IO/BufferWithOwnMemory.h>
+#include <IO/ReadBuffer.h>
+
+
+namespace DB
+{
+
+/** A buffer for reading from a compressed file with just checking checksums of
+  * the compressed blocks, without any decompression.
+  */
+class CheckingCompressedReadBuffer : public CompressedReadBufferBase, public ReadBuffer
+{
+protected:
+    bool nextImpl() override;
+
+public:
+    CheckingCompressedReadBuffer(ReadBuffer & in_, bool allow_different_codecs_ = false)
+        : CompressedReadBufferBase(&in_, allow_different_codecs_)
+        , ReadBuffer(nullptr, 0)
+    {
+    }
+};
+
+}

--- a/src/Compression/CompressedReadBuffer.cpp
+++ b/src/Compression/CompressedReadBuffer.cpp
@@ -9,7 +9,7 @@ bool CompressedReadBuffer::nextImpl()
 {
     size_t size_decompressed;
     size_t size_compressed_without_checksum;
-    size_compressed = readCompressedData(size_decompressed, size_compressed_without_checksum);
+    size_compressed = readCompressedData(size_decompressed, size_compressed_without_checksum, false);
     if (!size_compressed)
         return false;
 
@@ -40,7 +40,7 @@ size_t CompressedReadBuffer::readBig(char * to, size_t n)
         size_t size_decompressed;
         size_t size_compressed_without_checksum;
 
-        if (!readCompressedData(size_decompressed, size_compressed_without_checksum))
+        if (!readCompressedData(size_decompressed, size_compressed_without_checksum, false))
             return bytes_read;
 
         auto additional_size_at_the_end_of_buffer = codec->getAdditionalSizeAtTheEndOfBuffer();

--- a/src/Compression/CompressedReadBufferBase.cpp
+++ b/src/Compression/CompressedReadBufferBase.cpp
@@ -105,19 +105,18 @@ static void validateChecksum(char * data, size_t size, const Checksum expected_c
 
 /// Read compressed data into compressed_buffer. Get size of decompressed data from block header. Checksum if need.
 /// Returns number of compressed bytes read.
-size_t CompressedReadBufferBase::readCompressedData(size_t & size_decompressed, size_t & size_compressed_without_checksum)
+size_t CompressedReadBufferBase::readCompressedData(size_t & size_decompressed, size_t & size_compressed_without_checksum, bool always_copy)
 {
     if (compressed_in->eof())
         return 0;
 
-    Checksum checksum;
-    compressed_in->readStrict(reinterpret_cast<char *>(&checksum), sizeof(Checksum));
-
     UInt8 header_size = ICompressionCodec::getHeaderSize();
-    own_compressed_buffer.resize(header_size);
-    compressed_in->readStrict(own_compressed_buffer.data(), header_size);
+    own_compressed_buffer.resize(header_size + sizeof(Checksum));
 
-    uint8_t method = ICompressionCodec::readMethod(own_compressed_buffer.data());
+    compressed_in->readStrict(own_compressed_buffer.data(), sizeof(Checksum) + header_size);
+    char * compressed_header = own_compressed_buffer.data() + sizeof(Checksum);
+
+    uint8_t method = ICompressionCodec::readMethod(compressed_header);
 
     if (!codec)
     {
@@ -139,8 +138,8 @@ size_t CompressedReadBufferBase::readCompressedData(size_t & size_decompressed, 
         }
     }
 
-    size_compressed_without_checksum = ICompressionCodec::readCompressedBlockSize(own_compressed_buffer.data());
-    size_decompressed = ICompressionCodec::readDecompressedBlockSize(own_compressed_buffer.data());
+    size_compressed_without_checksum = ICompressionCodec::readCompressedBlockSize(compressed_header);
+    size_decompressed = ICompressionCodec::readDecompressedBlockSize(compressed_header);
 
     /// This is for clang static analyzer.
     assert(size_decompressed > 0);
@@ -160,8 +159,9 @@ size_t CompressedReadBufferBase::readCompressedData(size_t & size_decompressed, 
     auto additional_size_at_the_end_of_buffer = codec->getAdditionalSizeAtTheEndOfBuffer();
 
     /// Is whole compressed block located in 'compressed_in->' buffer?
-    if (compressed_in->offset() >= header_size &&
-        compressed_in->position() + size_compressed_without_checksum + additional_size_at_the_end_of_buffer  - header_size <= compressed_in->buffer().end())
+    if (!always_copy &&
+        compressed_in->offset() >= header_size + sizeof(Checksum) &&
+        compressed_in->available() >= (size_compressed_without_checksum - header_size) + additional_size_at_the_end_of_buffer + sizeof(Checksum))
     {
         compressed_in->position() -= header_size;
         compressed_buffer = compressed_in->position();
@@ -169,13 +169,16 @@ size_t CompressedReadBufferBase::readCompressedData(size_t & size_decompressed, 
     }
     else
     {
-        own_compressed_buffer.resize(size_compressed_without_checksum + additional_size_at_the_end_of_buffer);
-        compressed_buffer = own_compressed_buffer.data();
+        own_compressed_buffer.resize(sizeof(Checksum) + size_compressed_without_checksum + additional_size_at_the_end_of_buffer);
+        compressed_buffer = own_compressed_buffer.data() + sizeof(Checksum);
         compressed_in->readStrict(compressed_buffer + header_size, size_compressed_without_checksum - header_size);
     }
 
     if (!disable_checksum)
+    {
+        Checksum & checksum = *reinterpret_cast<Checksum *>(own_compressed_buffer.data());
         validateChecksum(compressed_buffer, size_compressed_without_checksum, checksum);
+    }
 
     return size_compressed_without_checksum + sizeof(Checksum);
 }

--- a/src/Compression/CompressedReadBufferBase.h
+++ b/src/Compression/CompressedReadBufferBase.h
@@ -30,8 +30,12 @@ protected:
     bool allow_different_codecs;
 
     /// Read compressed data into compressed_buffer. Get size of decompressed data from block header. Checksum if need.
+    ///
+    /// If always_copy is true then even if the compressed block is already stored in compressed_in.buffer() it will be copied into own_compressed_buffer.
+    /// This is required for CheckingCompressedReadBuffer, since this is just a proxy.
+    ///
     /// Returns number of compressed bytes read.
-    size_t readCompressedData(size_t & size_decompressed, size_t & size_compressed_without_checksum);
+    size_t readCompressedData(size_t & size_decompressed, size_t & size_compressed_without_checksum, bool always_copy);
 
     void decompress(char * to, size_t size_decompressed, size_t size_compressed_without_checksum);
 

--- a/src/Compression/CompressedReadBufferFromFile.cpp
+++ b/src/Compression/CompressedReadBufferFromFile.cpp
@@ -19,7 +19,7 @@ bool CompressedReadBufferFromFile::nextImpl()
 {
     size_t size_decompressed = 0;
     size_t size_compressed_without_checksum;
-    size_compressed = readCompressedData(size_decompressed, size_compressed_without_checksum);
+    size_compressed = readCompressedData(size_decompressed, size_compressed_without_checksum, false);
     if (!size_compressed)
         return false;
 
@@ -98,7 +98,7 @@ size_t CompressedReadBufferFromFile::readBig(char * to, size_t n)
         size_t size_decompressed = 0;
         size_t size_compressed_without_checksum = 0;
 
-        size_t new_size_compressed = readCompressedData(size_decompressed, size_compressed_without_checksum);
+        size_t new_size_compressed = readCompressedData(size_decompressed, size_compressed_without_checksum, false);
         size_compressed = 0; /// file_in no longer points to the end of the block in working_buffer.
         if (!new_size_compressed)
             return bytes_read;

--- a/src/Compression/ya.make
+++ b/src/Compression/ya.make
@@ -17,6 +17,7 @@ PEERDIR(
 
 SRCS(
     CachedCompressedReadBuffer.cpp
+    CheckingCompressedReadBuffer.cpp
     CompressedReadBuffer.cpp
     CompressedReadBufferBase.cpp
     CompressedReadBufferFromFile.cpp

--- a/src/Storages/Distributed/DirectoryMonitor.cpp
+++ b/src/Storages/Distributed/DirectoryMonitor.cpp
@@ -90,7 +90,7 @@ namespace
         size_t bytes = 0;
     };
 
-    static DistributedHeader readDistributedHeader(ReadBuffer & in, Poco::Logger * log)
+    DistributedHeader readDistributedHeader(ReadBuffer & in, Poco::Logger * log)
     {
         DistributedHeader header;
 

--- a/src/Storages/Distributed/DirectoryMonitor.h
+++ b/src/Storages/Distributed/DirectoryMonitor.h
@@ -111,9 +111,6 @@ private:
 
     CurrentMetrics::Increment metric_pending_files;
 
-    /// Read insert query and insert settings for backward compatible.
-    static void readHeader(ReadBuffer & in, Settings & insert_settings, std::string & insert_query, ClientInfo & client_info, Poco::Logger * log);
-
     friend class DirectoryMonitorBlockInputStream;
 };
 

--- a/src/Storages/Distributed/DistributedBlockOutputStream.cpp
+++ b/src/Storages/Distributed/DistributedBlockOutputStream.cpp
@@ -653,9 +653,12 @@ void DistributedBlockOutputStream::writeToShard(const Block & block, const std::
             writeStringBinary(query_string, header_buf);
             context.getSettingsRef().write(header_buf);
             context.getClientInfo().write(header_buf, DBMS_TCP_PROTOCOL_VERSION);
+            writeVarUInt(block.rows(), header_buf);
+            writeVarUInt(block.bytes(), header_buf);
 
             /// Add new fields here, for example:
             /// writeVarUInt(my_new_data, header_buf);
+            /// And note that it is safe, because we have checksum and size for header.
 
             /// Write the header.
             const StringRef header = header_buf.stringRef();

--- a/src/Storages/Distributed/DistributedBlockOutputStream.cpp
+++ b/src/Storages/Distributed/DistributedBlockOutputStream.cpp
@@ -655,6 +655,7 @@ void DistributedBlockOutputStream::writeToShard(const Block & block, const std::
             context.getClientInfo().write(header_buf, DBMS_TCP_PROTOCOL_VERSION);
             writeVarUInt(block.rows(), header_buf);
             writeVarUInt(block.bytes(), header_buf);
+            writeStringBinary(block.cloneEmpty().dumpStructure(), header_buf);
 
             /// Add new fields here, for example:
             /// writeVarUInt(my_new_data, header_buf);

--- a/tests/integration/test_check_table/test.py
+++ b/tests/integration/test_check_table/test.py
@@ -75,10 +75,10 @@ def test_check_normal_table_corruption(started_cluster):
     corrupt_data_part_on_disk(node1, "non_replicated_mt", "201902_1_1_0")
 
     assert node1.query("CHECK TABLE non_replicated_mt", settings={
-        "check_query_single_value_result": 0}).strip() == "201902_1_1_0\t0\tCannot read all data. Bytes read: 2. Bytes expected: 16."
+        "check_query_single_value_result": 0}).strip() == "201902_1_1_0\t0\tCannot read all data. Bytes read: 2. Bytes expected: 25."
 
     assert node1.query("CHECK TABLE non_replicated_mt", settings={
-        "check_query_single_value_result": 0}).strip() == "201902_1_1_0\t0\tCannot read all data. Bytes read: 2. Bytes expected: 16."
+        "check_query_single_value_result": 0}).strip() == "201902_1_1_0\t0\tCannot read all data. Bytes read: 2. Bytes expected: 25."
 
     node1.query("INSERT INTO non_replicated_mt VALUES (toDate('2019-01-01'), 1, 10), (toDate('2019-01-01'), 2, 12)")
 
@@ -90,7 +90,7 @@ def test_check_normal_table_corruption(started_cluster):
     remove_checksums_on_disk(node1, "non_replicated_mt", "201901_2_2_0")
 
     assert node1.query("CHECK TABLE non_replicated_mt PARTITION 201901", settings={
-        "check_query_single_value_result": 0}) == "201901_2_2_0\t0\tCheck of part finished with error: \\'Cannot read all data. Bytes read: 2. Bytes expected: 16.\\'\n"
+        "check_query_single_value_result": 0}) == "201901_2_2_0\t0\tCheck of part finished with error: \\'Cannot read all data. Bytes read: 2. Bytes expected: 25.\\'\n"
 
 
 def test_check_replicated_table_simple(started_cluster):

--- a/tests/integration/test_insert_distributed_async_send/configs/remote_servers.xml
+++ b/tests/integration/test_insert_distributed_async_send/configs/remote_servers.xml
@@ -1,0 +1,18 @@
+<yandex>
+    <remote_servers>
+        <insert_distributed_async_send_cluster>
+            <shard>
+                <internal_replication>false</internal_replication>
+                <replica>
+                    <host>n1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>n2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </insert_distributed_async_send_cluster>
+    </remote_servers>
+</yandex>
+

--- a/tests/integration/test_insert_distributed_async_send/configs/users.d/batch.xml
+++ b/tests/integration/test_insert_distributed_async_send/configs/users.d/batch.xml
@@ -1,0 +1,7 @@
+<yandex>
+    <profiles>
+        <default>
+            <distributed_directory_monitor_batch_inserts>1</distributed_directory_monitor_batch_inserts>
+        </default>
+    </profiles>
+</yandex>

--- a/tests/integration/test_insert_distributed_async_send/configs/users.d/no_batch.xml
+++ b/tests/integration/test_insert_distributed_async_send/configs/users.d/no_batch.xml
@@ -1,0 +1,7 @@
+<yandex>
+    <profiles>
+        <default>
+            <distributed_directory_monitor_batch_inserts>0</distributed_directory_monitor_batch_inserts>
+        </default>
+    </profiles>
+</yandex>

--- a/tests/integration/test_insert_distributed_async_send/test.py
+++ b/tests/integration/test_insert_distributed_async_send/test.py
@@ -1,0 +1,165 @@
+# pylint: disable=unused-argument
+# pylint: disable=redefined-outer-name
+# pylint: disable=line-too-long
+
+# NOTES:
+# - timeout should not be reduced due to bit flip of the corrupted buffer
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.client import QueryRuntimeException
+
+cluster = ClickHouseCluster(__file__)
+
+# n1 -- distributed_directory_monitor_batch_inserts=1
+n1 = cluster.add_instance('n1', main_configs=['configs/remote_servers.xml'], user_configs=['configs/users.d/batch.xml'])
+# n2 -- distributed_directory_monitor_batch_inserts=0
+n2 = cluster.add_instance('n2', main_configs=['configs/remote_servers.xml'], user_configs=['configs/users.d/no_batch.xml'])
+
+batch_params = pytest.mark.parametrize('batch', [
+    (1),
+    (0),
+])
+
+@pytest.fixture(scope='module', autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def create_tables():
+    for _, instance in list(cluster.instances.items()):
+        instance.query('CREATE TABLE data (key Int, value String) Engine=Memory()')
+        instance.query("""
+        CREATE TABLE dist AS data
+        Engine=Distributed(
+            insert_distributed_async_send_cluster,
+            currentDatabase(),
+            data,
+            rand()
+        )
+        """)
+        # only via SYSTEM FLUSH DISTRIBUTED
+        instance.query('SYSTEM STOP DISTRIBUTED SENDS dist')
+
+def drop_tables():
+    for _, instance in list(cluster.instances.items()):
+        instance.query('DROP TABLE IF EXISTS data')
+        instance.query('DROP TABLE IF EXISTS dist')
+
+# return amount of bytes of the 2.bin for n2 shard
+def insert_data(node):
+    node.query('INSERT INTO dist SELECT number, randomPrintableASCII(100) FROM numbers(10000)', settings={
+        # do not do direct INSERT, always via SYSTEM FLUSH DISTRIBUTED
+        'prefer_localhost_replica': 0,
+    })
+    path = get_path_to_dist_batch()
+    size = int(node.exec_in_container(['bash', '-c', f'wc -c < {path}']))
+    assert size > 1<<16
+    return size
+
+def get_node(batch):
+    if batch:
+        return n1
+    return n2
+
+def bootstrap(batch):
+    drop_tables()
+    create_tables()
+    return insert_data(get_node(batch))
+
+def get_path_to_dist_batch(file='2.bin'):
+    # There are:
+    # - /var/lib/clickhouse/data/default/dist/shard1_replica1/1.bin
+    # - /var/lib/clickhouse/data/default/dist/shard1_replica2/2.bin
+    #
+    # @return the file for the n2 shard
+    return f'/var/lib/clickhouse/data/default/dist/shard1_replica2/{file}'
+
+def check_dist_after_corruption(truncate, batch):
+    node = get_node(batch)
+
+    if batch:
+        # In batch mode errors are ignored
+        node.query('SYSTEM FLUSH DISTRIBUTED dist')
+    else:
+        if truncate:
+            with pytest.raises(QueryRuntimeException, match="Cannot read all data. Bytes read:"):
+                node.query('SYSTEM FLUSH DISTRIBUTED dist')
+        else:
+            with pytest.raises(QueryRuntimeException, match="Checksum doesn't match: corrupted data. Reference:"):
+                node.query('SYSTEM FLUSH DISTRIBUTED dist')
+
+    # send pending files
+    # (since we have two nodes and corrupt file for only one of them)
+    node.query('SYSTEM FLUSH DISTRIBUTED dist')
+
+    # but there is broken file
+    broken = get_path_to_dist_batch('broken')
+    node.exec_in_container(['bash', '-c', f'ls {broken}/2.bin'])
+
+    assert int(n1.query('SELECT count() FROM data')) == 10000
+    assert int(n2.query('SELECT count() FROM data')) == 0
+
+
+@batch_params
+def test_insert_distributed_async_send_success(batch):
+    bootstrap(batch)
+    node = get_node(batch)
+    node.query('SYSTEM FLUSH DISTRIBUTED dist')
+    assert int(n1.query('SELECT count() FROM data')) == 10000
+    assert int(n2.query('SELECT count() FROM data')) == 10000
+
+@batch_params
+def test_insert_distributed_async_send_truncated_1(batch):
+    size = bootstrap(batch)
+    path = get_path_to_dist_batch()
+    node = get_node(batch)
+
+    new_size = size - 10
+    # we cannot use truncate, due to hardlinks
+    node.exec_in_container(['bash', '-c', f'mv {path} /tmp/bin && head -c {new_size} /tmp/bin > {path}'])
+
+    check_dist_after_corruption(True, batch)
+
+@batch_params
+def test_insert_distributed_async_send_truncated_2(batch):
+    bootstrap(batch)
+    path = get_path_to_dist_batch()
+    node = get_node(batch)
+
+    # we cannot use truncate, due to hardlinks
+    node.exec_in_container(['bash', '-c', f'mv {path} /tmp/bin && head -c 10000 /tmp/bin > {path}'])
+
+    check_dist_after_corruption(True, batch)
+
+# The difference from the test_insert_distributed_async_send_corrupted_small
+# is that small corruption will be seen only on local node
+@batch_params
+def test_insert_distributed_async_send_corrupted_big(batch):
+    size = bootstrap(batch)
+    path = get_path_to_dist_batch()
+
+    node = get_node(batch)
+
+    from_original_size = size - 8192
+    zeros_size = 8192
+    node.exec_in_container(['bash', '-c', f'mv {path} /tmp/bin && head -c {from_original_size} /tmp/bin > {path} && head -c {zeros_size} /dev/zero >> {path}'])
+
+    check_dist_after_corruption(False, batch)
+
+@batch_params
+def test_insert_distributed_async_send_corrupted_small(batch):
+    size = bootstrap(batch)
+    path = get_path_to_dist_batch()
+    node = get_node(batch)
+
+    from_original_size = size - 60
+    zeros_size = 60
+    node.exec_in_container(['bash', '-c', f'mv {path} /tmp/bin && head -c {from_original_size} /tmp/bin > {path} && head -c {zeros_size} /dev/zero >> {path}'])
+
+    check_dist_after_corruption(False, batch)


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Check per-block checksum of the distributed batch on the sender before sending (without reading the file twice, the checksums will be verified while reading), this will avoid stuck of the INSERT on the receiver (on truncated .bin file on the sender)
- Avoid reading .bin files twice for batched INSERT (it was required to calculate rows/bytes to take squashing into account, now this information included into the header, backward compatible is preserved).

Refs: #18369