### PR TITLE
Add fsync support for Distributed engine.

### DIFF
--- a/docs/en/engines/table-engines/special/distributed.md
+++ b/docs/en/engines/table-engines/special/distributed.md
@@ -29,7 +29,7 @@ Also it accept the following settings:
 
 - `fsync_after_insert` - do the `fsync` for the file data after asynchronous insert to Distributed. Guarantees that the OS flushed the whole inserted data to a file **on the initiator node** disk.
 
-- `fsync_tmp_directory` - do the `fsync` for directories. Guarantees that the OS refreshed directory metadata after operations related to asynchronous inserts on Distributed table (after insert, after sending the data to shard, etc).
+- `fsync_directories` - do the `fsync` for directories. Guarantees that the OS refreshed directory metadata after operations related to asynchronous inserts on Distributed table (after insert, after sending the data to shard, etc).
 
 !!! note "Note"
 
@@ -45,7 +45,7 @@ Example:
 Distributed(logs, default, hits[, sharding_key[, policy_name]])
 SETTINGS
     fsync_after_insert=0,
-    fsync_tmp_directory=0;
+    fsync_directories=0;
 ```
 
 Data will be read from all servers in the `logs` cluster, from the default.hits table located on every server in the cluster.

--- a/docs/en/engines/table-engines/special/distributed.md
+++ b/docs/en/engines/table-engines/special/distributed.md
@@ -27,9 +27,17 @@ The Distributed engine accepts parameters:
 
 Also it accept the following settings:
 
-- `fsync_after_insert` - Do fsync for every inserted. Will decreases performance of inserts (only for async INSERT, i.e. `insert_distributed_sync=false`),
+- `fsync_after_insert` - do the `fsync` for the file data after asynchronous insert to Distributed. Guarantees that the OS flushed the whole inserted data to a file **on the initiator node** disk.
 
-- `fsync_tmp_directory` - Do fsync for temporary directory (that is used for async INSERT only) after all part operations (writes, renames, etc.).
+- `fsync_tmp_directory` - do the `fsync` for directories. Guarantees that the OS refreshed directory metadata after operations related to asynchronous inserts on Distributed table (after insert, after sending the data to shard, etc).
+
+!!! note "Note"
+
+    **Durability settings** (`fsync_...`):
+
+    - Affect only asynchronous INSERTs (i.e. `insert_distributed_sync=false`) when data first stored on the initiator node disk and later asynchronously send to shards.
+    - May significantly decrease the inserts' performance
+    - Affect writing the data stored inside Distributed table folder into the **node which accepted your insert**. If you need to have guarantees of writing data to underlying MergeTree tables - see durability settings (`...fsync...`) in `system.merge_tree_settings`
 
 Example:
 

--- a/docs/en/engines/table-engines/special/distributed.md
+++ b/docs/en/engines/table-engines/special/distributed.md
@@ -25,10 +25,19 @@ The Distributed engine accepts parameters:
     -   [insert_distributed_sync](../../../operations/settings/settings.md#insert_distributed_sync) setting
     -   [MergeTree](../../../engines/table-engines/mergetree-family/mergetree.md#table_engine-mergetree-multiple-volumes) for the examples
 
+Also it accept the following settings:
+
+- `fsync_after_insert` - Do fsync for every inserted. Will decreases performance of inserts (only for async INSERT, i.e. `insert_distributed_sync=false`),
+
+- `fsync_tmp_directory` - Do fsync for temporary directory (that is used for async INSERT only) after all part operations (writes, renames, etc.).
+
 Example:
 
 ``` sql
 Distributed(logs, default, hits[, sharding_key[, policy_name]])
+SETTINGS
+    fsync_after_insert=0,
+    fsync_tmp_directory=0;
 ```
 
 Data will be read from all servers in the `logs` cluster, from the default.hits table located on every server in the cluster.

--- a/src/Storages/Distributed/DirectoryMonitor.cpp
+++ b/src/Storages/Distributed/DirectoryMonitor.cpp
@@ -94,7 +94,7 @@ StorageDistributedDirectoryMonitor::StorageDistributedDirectoryMonitor(
     , relative_path(relative_path_)
     , path(disk->getPath() + relative_path + '/')
     , should_batch_inserts(storage.global_context.getSettingsRef().distributed_directory_monitor_batch_inserts)
-    , dir_fsync(storage.getDistributedSettingsRef().fsync_tmp_directory)
+    , dir_fsync(storage.getDistributedSettingsRef().fsync_directories)
     , min_batched_block_size_rows(storage.global_context.getSettingsRef().min_insert_block_size_rows)
     , min_batched_block_size_bytes(storage.global_context.getSettingsRef().min_insert_block_size_bytes)
     , current_batch_file_path(path + "current_batch.txt")

--- a/src/Storages/Distributed/DirectoryMonitor.h
+++ b/src/Storages/Distributed/DirectoryMonitor.h
@@ -14,6 +14,9 @@ namespace CurrentMetrics { class Increment; }
 namespace DB
 {
 
+class IDisk;
+using DiskPtr = std::shared_ptr<IDisk>;
+
 class StorageDistributed;
 class ActionBlocker;
 class BackgroundSchedulePool;
@@ -25,13 +28,18 @@ class StorageDistributedDirectoryMonitor
 {
 public:
     StorageDistributedDirectoryMonitor(
-        StorageDistributed & storage_, std::string path_, ConnectionPoolPtr pool_, ActionBlocker & monitor_blocker_, BackgroundSchedulePool & bg_pool);
+        StorageDistributed & storage_,
+        const DiskPtr & disk_,
+        const std::string & relative_path_,
+        ConnectionPoolPtr pool_,
+        ActionBlocker & monitor_blocker_,
+        BackgroundSchedulePool & bg_pool);
 
     ~StorageDistributedDirectoryMonitor();
 
     static ConnectionPoolPtr createPool(const std::string & name, const StorageDistributed & storage);
 
-    void updatePath(const std::string & new_path);
+    void updatePath(const std::string & new_relative_path);
 
     void flushAllData();
 
@@ -70,6 +78,9 @@ private:
 
     StorageDistributed & storage;
     const ConnectionPoolPtr pool;
+
+    DiskPtr disk;
+    std::string relative_path;
     std::string path;
 
     const bool should_batch_inserts = false;

--- a/src/Storages/Distributed/DirectoryMonitor.h
+++ b/src/Storages/Distributed/DirectoryMonitor.h
@@ -84,6 +84,7 @@ private:
     std::string path;
 
     const bool should_batch_inserts = false;
+    const bool dir_fsync = false;
     const size_t min_batched_block_size_rows = 0;
     const size_t min_batched_block_size_bytes = 0;
     String current_batch_file_path;

--- a/src/Storages/Distributed/DistributedBlockOutputStream.cpp
+++ b/src/Storages/Distributed/DistributedBlockOutputStream.cpp
@@ -698,7 +698,7 @@ void DistributedBlockOutputStream::writeToShard(const Block & block, const std::
     auto sleep_ms = context.getSettingsRef().distributed_directory_monitor_sleep_time_ms;
     for (const auto & dir_name : dir_names)
     {
-        auto & directory_monitor = storage.requireDirectoryMonitor(disk_path, dir_name);
+        auto & directory_monitor = storage.requireDirectoryMonitor(disk, dir_name);
         directory_monitor.scheduleAfter(sleep_ms.totalMilliseconds());
     }
 }

--- a/src/Storages/Distributed/DistributedBlockOutputStream.cpp
+++ b/src/Storages/Distributed/DistributedBlockOutputStream.cpp
@@ -592,7 +592,7 @@ void DistributedBlockOutputStream::writeToShard(const Block & block, const std::
     const auto & distributed_settings = storage.getDistributedSettingsRef();
 
     bool fsync = distributed_settings.fsync_after_insert;
-    bool dir_fsync = distributed_settings.fsync_tmp_directory;
+    bool dir_fsync = distributed_settings.fsync_directories;
 
     std::string compression_method = Poco::toUpper(settings.network_compression_method.toString());
     std::optional<int> compression_level;

--- a/src/Storages/Distributed/DistributedSettings.cpp
+++ b/src/Storages/Distributed/DistributedSettings.cpp
@@ -1,0 +1,42 @@
+#include <Storages/Distributed/DistributedSettings.h>
+#include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTSetQuery.h>
+#include <Parsers/ASTFunction.h>
+#include <Common/Exception.h>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int UNKNOWN_SETTING;
+}
+
+IMPLEMENT_SETTINGS_TRAITS(DistributedSettingsTraits, LIST_OF_DISTRIBUTED_SETTINGS)
+
+void DistributedSettings::loadFromQuery(ASTStorage & storage_def)
+{
+    if (storage_def.settings)
+    {
+        try
+        {
+            applyChanges(storage_def.settings->changes);
+        }
+        catch (Exception & e)
+        {
+            if (e.code() == ErrorCodes::UNKNOWN_SETTING)
+                e.addMessage("for storage " + storage_def.engine->name);
+            throw;
+        }
+    }
+    else
+    {
+        auto settings_ast = std::make_shared<ASTSetQuery>();
+        settings_ast->is_standalone = false;
+        storage_def.set(storage_def.settings, settings_ast);
+    }
+}
+
+}
+

--- a/src/Storages/Distributed/DistributedSettings.h
+++ b/src/Storages/Distributed/DistributedSettings.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <Core/Defines.h>
+#include <Core/BaseSettings.h>
+
+
+namespace Poco::Util
+{
+    class AbstractConfiguration;
+}
+
+
+namespace DB
+{
+class ASTStorage;
+
+#define LIST_OF_DISTRIBUTED_SETTINGS(M) \
+    M(Bool, fsync_after_insert, false, "Do fsync for every inserted. Will decreases performance of inserts (only for async INSERT, i.e. insert_distributed_sync=false)", 0) \
+    M(Bool, fsync_tmp_directory, false, "Do fsync for temporary directory (that is used for async INSERT only) after all part operations (writes, renames, etc.).", 0) \
+
+DECLARE_SETTINGS_TRAITS(DistributedSettingsTraits, LIST_OF_DISTRIBUTED_SETTINGS)
+
+
+/** Settings for the Distributed family of engines.
+  */
+struct DistributedSettings : public BaseSettings<DistributedSettingsTraits>
+{
+    void loadFromQuery(ASTStorage & storage_def);
+};
+
+}

--- a/src/Storages/Distributed/DistributedSettings.h
+++ b/src/Storages/Distributed/DistributedSettings.h
@@ -16,7 +16,7 @@ class ASTStorage;
 
 #define LIST_OF_DISTRIBUTED_SETTINGS(M) \
     M(Bool, fsync_after_insert, false, "Do fsync for every inserted. Will decreases performance of inserts (only for async INSERT, i.e. insert_distributed_sync=false)", 0) \
-    M(Bool, fsync_tmp_directory, false, "Do fsync for temporary directory (that is used for async INSERT only) after all part operations (writes, renames, etc.).", 0) \
+    M(Bool, fsync_directories, false, "Do fsync for temporary directory (that is used for async INSERT only) after all part operations (writes, renames, etc.).", 0) \
 
 DECLARE_SETTINGS_TRAITS(DistributedSettingsTraits, LIST_OF_DISTRIBUTED_SETTINGS)
 

--- a/src/Storages/StorageDistributed.h
+++ b/src/Storages/StorageDistributed.h
@@ -24,6 +24,9 @@ class Context;
 class IVolume;
 using VolumePtr = std::shared_ptr<IVolume>;
 
+class IDisk;
+using DiskPtr = std::shared_ptr<IDisk>;
+
 class ExpressionActions;
 using ExpressionActionsPtr = std::shared_ptr<ExpressionActions>;
 
@@ -104,9 +107,9 @@ public:
     std::string getClusterName() const { return cluster_name; } /// Returns empty string if tables is used by TableFunctionRemote
 
     /// create directory monitors for each existing subdirectory
-    void createDirectoryMonitors(const std::string & disk);
+    void createDirectoryMonitors(const DiskPtr & disk);
     /// ensure directory monitor thread and connectoin pool creation by disk and subdirectory name
-    StorageDistributedDirectoryMonitor & requireDirectoryMonitor(const std::string & disk, const std::string & name);
+    StorageDistributedDirectoryMonitor & requireDirectoryMonitor(const DiskPtr & disk, const std::string & name);
     /// Return list of metrics for all created monitors
     /// (note that monitors are created lazily, i.e. until at least one INSERT executed)
     std::vector<StorageDistributedDirectoryMonitor::Status> getDirectoryMonitorsStatuses() const;

--- a/src/Storages/StorageDistributed.h
+++ b/src/Storages/StorageDistributed.h
@@ -4,6 +4,7 @@
 
 #include <Storages/IStorage.h>
 #include <Storages/Distributed/DirectoryMonitor.h>
+#include <Storages/Distributed/DistributedSettings.h>
 #include <Common/SimpleIncrement.h>
 #include <Client/ConnectionPool.h>
 #include <Client/ConnectionPoolWithFailover.h>
@@ -127,6 +128,8 @@ public:
 
     size_t getRandomShardIndex(const Cluster::ShardsInfo & shards);
 
+    const DistributedSettings & getDistributedSettingsRef() const { return distributed_settings; }
+
     String remote_database;
     String remote_table;
     ASTPtr remote_table_function_ptr;
@@ -162,6 +165,7 @@ protected:
         const ASTPtr & sharding_key_,
         const String & storage_policy_name_,
         const String & relative_data_path_,
+        const DistributedSettings & distributed_settings_,
         bool attach_,
         ClusterPtr owned_cluster_ = {});
 
@@ -175,6 +179,7 @@ protected:
         const ASTPtr & sharding_key_,
         const String & storage_policy_name_,
         const String & relative_data_path_,
+        const DistributedSettings & distributed_settings_,
         bool attach,
         ClusterPtr owned_cluster_ = {});
 
@@ -187,6 +192,8 @@ protected:
     /// For Distributed engine such configuration doesn't make sense and only the first (main) volume will be used to store data.
     /// Other volumes will be ignored. It's needed to allow using the same multi-volume policy both for Distributed and other engines.
     VolumePtr data_volume;
+
+    DistributedSettings distributed_settings;
 
     struct ClusterNodeData
     {

--- a/src/Storages/ya.make
+++ b/src/Storages/ya.make
@@ -17,6 +17,7 @@ SRCS(
     ConstraintsDescription.cpp
     Distributed/DirectoryMonitor.cpp
     Distributed/DistributedBlockOutputStream.cpp
+    Distributed/DistributedSettings.cpp
     IStorage.cpp
     IndicesDescription.cpp
     JoinSettings.cpp

--- a/src/TableFunctions/TableFunctionRemote.cpp
+++ b/src/TableFunctions/TableFunctionRemote.cpp
@@ -211,6 +211,7 @@ StoragePtr TableFunctionRemote::executeImpl(const ASTPtr & /*ast_function*/, con
             ASTPtr{},
             String{},
             String{},
+            DistributedSettings{},
             false,
             cluster)
         : StorageDistributed::create(
@@ -224,6 +225,7 @@ StoragePtr TableFunctionRemote::executeImpl(const ASTPtr & /*ast_function*/, con
             ASTPtr{},
             String{},
             String{},
+            DistributedSettings{},
             false,
             cluster);
 

--- a/tests/integration/test_insert_into_distributed/test.py
+++ b/tests/integration/test_insert_into_distributed/test.py
@@ -36,7 +36,7 @@ CREATE TABLE distributed (x UInt32) ENGINE = Distributed('test_cluster', 'defaul
 
         remote.query("CREATE TABLE local2 (d Date, x UInt32, s String) ENGINE = MergeTree(d, x, 8192)")
         instance_test_inserts_batching.query('''
-CREATE TABLE distributed (d Date, x UInt32) ENGINE = Distributed('test_cluster', 'default', 'local2')
+CREATE TABLE distributed (d Date, x UInt32) ENGINE = Distributed('test_cluster', 'default', 'local2') SETTINGS fsync_after_insert=1, fsync_tmp_directory=1
 ''')
 
         instance_test_inserts_local_cluster.query(

--- a/tests/integration/test_insert_into_distributed/test.py
+++ b/tests/integration/test_insert_into_distributed/test.py
@@ -36,7 +36,7 @@ CREATE TABLE distributed (x UInt32) ENGINE = Distributed('test_cluster', 'defaul
 
         remote.query("CREATE TABLE local2 (d Date, x UInt32, s String) ENGINE = MergeTree(d, x, 8192)")
         instance_test_inserts_batching.query('''
-CREATE TABLE distributed (d Date, x UInt32) ENGINE = Distributed('test_cluster', 'default', 'local2') SETTINGS fsync_after_insert=1, fsync_tmp_directory=1
+CREATE TABLE distributed (d Date, x UInt32) ENGINE = Distributed('test_cluster', 'default', 'local2') SETTINGS fsync_after_insert=1, fsync_directories=1
 ''')
 
         instance_test_inserts_local_cluster.query(

--- a/tests/queries/0_stateless/01644_distributed_async_insert_fsync_smoke.reference
+++ b/tests/queries/0_stateless/01644_distributed_async_insert_fsync_smoke.reference
@@ -1,0 +1,6 @@
+no fsync
+0
+90
+fsync
+90
+180

--- a/tests/queries/0_stateless/01644_distributed_async_insert_fsync_smoke.sql
+++ b/tests/queries/0_stateless/01644_distributed_async_insert_fsync_smoke.sql
@@ -13,7 +13,7 @@ select sum(*) from dist_01643;
 drop table dist_01643;
 
 select 'fsync';
-create table dist_01643 as data_01643 engine=Distributed(test_cluster_two_shards, currentDatabase(), data_01643, key) settings fsync_after_insert=1, fsync_tmp_directory=1;
+create table dist_01643 as data_01643 engine=Distributed(test_cluster_two_shards, currentDatabase(), data_01643, key) settings fsync_after_insert=1, fsync_directories=1;
 system stop distributed sends dist_01643;
 insert into dist_01643 select * from numbers(10) settings prefer_localhost_replica=0;
 select sum(*) from dist_01643;

--- a/tests/queries/0_stateless/01644_distributed_async_insert_fsync_smoke.sql
+++ b/tests/queries/0_stateless/01644_distributed_async_insert_fsync_smoke.sql
@@ -1,0 +1,24 @@
+drop table if exists dist_01643;
+drop table if exists data_01643;
+
+create table data_01643 (key Int) engine=Memory();
+
+select 'no fsync';
+create table dist_01643 as data_01643 engine=Distributed(test_cluster_two_shards, currentDatabase(), data_01643, key);
+system stop distributed sends dist_01643;
+insert into dist_01643 select * from numbers(10) settings prefer_localhost_replica=0;
+select sum(*) from dist_01643;
+system flush distributed dist_01643;
+select sum(*) from dist_01643;
+drop table dist_01643;
+
+select 'fsync';
+create table dist_01643 as data_01643 engine=Distributed(test_cluster_two_shards, currentDatabase(), data_01643, key) settings fsync_after_insert=1, fsync_tmp_directory=1;
+system stop distributed sends dist_01643;
+insert into dist_01643 select * from numbers(10) settings prefer_localhost_replica=0;
+select sum(*) from dist_01643;
+system flush distributed dist_01643;
+select sum(*) from dist_01643;
+drop table dist_01643;
+
+drop table if exists data_01643;

--- a/tests/queries/0_stateless/arcadia_skip_list.txt
+++ b/tests/queries/0_stateless/arcadia_skip_list.txt
@@ -182,3 +182,4 @@
 01601_custom_tld
 01636_nullable_fuzz2
 01639_distributed_sync_insert_zero_rows
+01644_distributed_async_insert_fsync_smoke


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Two new settings (by analogy with MergeTree family) has been added:
- `fsync_after_insert` - Do fsync for every inserted. Will decreases performance of inserts.
- `fsync_directories` - Do fsync for temporary directory (that is used for async INSERT only) after all operations (writes, renames, etc.).

Detailed description / Documentation draft:
Now Distributed engine support the SETTINGS clause (since there are too much arguments already, and some of them will be converted to the SETTINGS Later), and two new settings, that listed above, added.

Refs: #17380 (p1)