### PR TITLE
External queries: fix the case of expr IN table #9756

### DIFF
--- a/src/Storages/tests/gtest_transform_query_for_external_database.cpp
+++ b/src/Storages/tests/gtest_transform_query_for_external_database.cpp
@@ -80,6 +80,24 @@ TEST(TransformQueryForExternalDatabase, InWithSingleElement)
           state.context, state.columns);
 }
 
+TEST(TransformQueryForExternalDatabase, InWithTable)
+{
+    const State & state = State::instance();
+
+    check("SELECT column FROM test.table WHERE 1 IN external_table",
+          R"(SELECT "column" FROM "test"."table")",
+          state.context, state.columns);
+    check("SELECT column FROM test.table WHERE 1 IN (x)",
+          R"(SELECT "column" FROM "test"."table")",
+          state.context, state.columns);
+    check("SELECT column, field, value FROM test.table WHERE column IN (field, value)",
+          R"(SELECT "column", "field", "value" FROM "test"."table" WHERE "column" IN ("field", "value"))",
+          state.context, state.columns);
+    check("SELECT column FROM test.table WHERE column NOT IN hello AND column = 123",
+          R"(SELECT "column" FROM "test"."table" WHERE ("column" = 123))",
+          state.context, state.columns);
+}
+
 TEST(TransformQueryForExternalDatabase, Like)
 {
     const State & state = State::instance();

--- a/src/Storages/transformQueryForExternalDatabase.cpp
+++ b/src/Storages/transformQueryForExternalDatabase.cpp
@@ -138,6 +138,12 @@ bool isCompatible(const IAST & node)
         if (name == "tuple" && function->arguments->children.size() <= 1)
             return false;
 
+        /// If the right hand side of IN is an identifier (example: x IN table), then it's not compatible.
+        if ((name == "in" || name == "notIn")
+            && (function->arguments->children.size() != 2
+                || function->arguments->children[1]->as<ASTIdentifier>()))
+            return false;
+
         for (const auto & expr : function->arguments->children)
             if (!isCompatible(*expr))
                 return false;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Queries for external databases (MySQL, ODBC, JDBC) were incorrectly rewritten if there was an expression in form of `x IN table`. This fixes #9756.
