### PR TITLE
Remove TestFlows due to timeouts

### DIFF
--- a/tests/testflows/regression.py
+++ b/tests/testflows/regression.py
@@ -14,10 +14,10 @@ def regression(self, local, clickhouse_binary_path, stress=None, parallel=None):
     """
     args = {"local": local, "clickhouse_binary_path": clickhouse_binary_path, "stress": stress, "parallel": parallel}
 
-    Feature(test=load("example.regression", "regression"))(**args)
-    Feature(test=load("ldap.regression", "regression"))(**args)
-    Feature(test=load("rbac.regression", "regression"))(**args)
-    Feature(test=load("aes_encryption.regression", "regression"))(**args)
+#    Feature(test=load("example.regression", "regression"))(**args)
+#    Feature(test=load("ldap.regression", "regression"))(**args)
+#    Feature(test=load("rbac.regression", "regression"))(**args)
+#    Feature(test=load("aes_encryption.regression", "regression"))(**args)
 
 if main():
     regression()


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

[TestFlows](https://testflows.com/) - enterprise quality open-source test framework that makes testing flow.

Remove TestFlows because they cannot finish in three hours in half of the runs.
And they are flaky in the remaining runs.

CC @vzakaznikov 
Need to turn them on again when fixed.
