### PR TITLE
Restore kafka on freebsd

### DIFF
--- a/cmake/find/rdkafka.cmake
+++ b/cmake/find/rdkafka.cmake
@@ -1,5 +1,4 @@
-# Freebsd: contrib/cppkafka/include/cppkafka/detail/endianness.h:53:23: error: 'betoh16' was not declared in this scope
-if (NOT ARCH_ARM AND NOT OS_FREEBSD AND OPENSSL_FOUND)
+if (NOT ARCH_ARM AND OPENSSL_FOUND)
     option (ENABLE_RDKAFKA "Enable kafka" ${ENABLE_LIBRARIES})
 elseif(ENABLE_RDKAFKA AND NOT OPENSSL_FOUND)
     message (${RECONFIGURE_MESSAGE_LEVEL} "Can't use librdkafka without SSL")

--- a/contrib/librdkafka-cmake/config.h.in
+++ b/contrib/librdkafka-cmake/config.h.in
@@ -83,7 +83,8 @@
 #if (__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ <= 101400)
 #define _TTHREAD_EMULATE_TIMESPEC_GET_
 #endif
-
+#elif defined(__FreeBSD__)
+#define HAVE_PTHREAD_SETNAME_FREEBSD 1
 #else
 // pthread_setname_gnu
 #define HAVE_PTHREAD_SETNAME_GNU 1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Restore Kafka input in FreeBSD builds

Detailed description:

When migrating from rdkafka to cppkafka, FreeBSD build was disabled due to bug
in cppkafka. Since then, cppkafka is fixed (https://github.com/mfontanini/cppkafka/pull/172),
so this is not an issue anymore.
Second change fixes incorrect assumption that everything that is not Apple is Linux
and have pthread_setname_np function: FreeBSD have it's specific variant 
(pthread_set_name_np), so this assumption went to broken build. 
