### PR TITLE
Bugfix: attach partition should reset the mutation

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeBlockOutputStream.cpp
@@ -254,6 +254,7 @@ void ReplicatedMergeTreeBlockOutputStream::commitPart(
             part->info.min_block = block_number;
             part->info.max_block = block_number;
             part->info.level = 0;
+            part->info.mutation = 0;
 
             part->name = part->getNewName(part->info);
 

--- a/tests/integration/test_fetch_partition_should_reset_mutation/configs/zookeeper_config.xml
+++ b/tests/integration/test_fetch_partition_should_reset_mutation/configs/zookeeper_config.xml
@@ -1,0 +1,8 @@
+<yandex>
+    <zookeeper>
+        <node index="1">
+            <host>zoo1</host>
+            <port>2181</port>
+        </node>
+    </zookeeper>
+</yandex>

--- a/tests/integration/test_fetch_partition_should_reset_mutation/test.py
+++ b/tests/integration/test_fetch_partition_should_reset_mutation/test.py
@@ -1,0 +1,60 @@
+import pytest
+from helpers.client import QueryRuntimeException
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import TSV
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node", main_configs=["configs/zookeeper_config.xml"], with_zookeeper=True)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_part_should_reset_mutation(start_cluster):
+    node.query(
+        "CREATE TABLE test (i Int64, s String) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test', 'node') ORDER BY i;"
+    )
+    node.query("INSERT INTO test SELECT 1, 'a'")
+    node.query("optimize table test final")
+    node.query("optimize table test final")
+
+
+    expected = TSV('''all_0_0_2\t1\ta''')
+    assert TSV(node.query('SELECT _part, * FROM test')) == expected
+
+    node.query("ALTER TABLE test UPDATE s='xxx' WHERE 1")
+    node.query("ALTER TABLE test UPDATE s='xxx' WHERE 1")
+    node.query("ALTER TABLE test UPDATE s='xxx' WHERE 1")
+    node.query("ALTER TABLE test UPDATE s='xxx' WHERE 1")
+
+    expected = TSV('''all_0_0_2_4\t1\txxx''')
+    assert TSV(node.query('SELECT _part, * FROM test')) == expected
+
+    node.query(
+        "CREATE TABLE restore (i Int64, s String) ENGINE = ReplicatedMergeTree('/clickhouse/tables/restore', 'node') ORDER BY i;"
+    )
+    node.query("ALTER TABLE restore FETCH PARTITION tuple() FROM '/clickhouse/tables/test/'")
+    node.query("ALTER TABLE restore ATTACH PART 'all_0_0_2_4'")
+    node.query("INSERT INTO restore select 2, 'a'")
+
+    print(TSV(node.query('SELECT _part, * FROM restore')))
+    expected = TSV('''all_0_0_0\t1\txxx\nall_1_1_0\t2\ta''')
+    assert TSV(node.query('SELECT _part, * FROM restore ORDER BY i')) == expected
+
+    node.query("ALTER TABLE restore UPDATE s='yyy' WHERE 1")
+
+
+    expected = TSV('''all_0_0_0_2\t1\tyyy\nall_1_1_0_2\t2\tyyy''')
+    assert TSV(node.query('SELECT _part, * FROM restore ORDER BY i')) == expected
+
+    node.query("ALTER TABLE restore DELETE WHERE 1")
+
+
+    assert node.query("SELECT count() FROM restore").strip() == "0"

--- a/tests/integration/test_fetch_partition_should_reset_mutation/test.py
+++ b/tests/integration/test_fetch_partition_should_reset_mutation/test.py
@@ -29,10 +29,10 @@ def test_part_should_reset_mutation(start_cluster):
     expected = TSV('''all_0_0_2\t1\ta''')
     assert TSV(node.query('SELECT _part, * FROM test')) == expected
 
-    node.query("ALTER TABLE test UPDATE s='xxx' WHERE 1")
-    node.query("ALTER TABLE test UPDATE s='xxx' WHERE 1")
-    node.query("ALTER TABLE test UPDATE s='xxx' WHERE 1")
-    node.query("ALTER TABLE test UPDATE s='xxx' WHERE 1")
+    node.query("ALTER TABLE test UPDATE s='xxx' WHERE 1", settings={"mutations_sync": "2"})
+    node.query("ALTER TABLE test UPDATE s='xxx' WHERE 1", settings={"mutations_sync": "2"})
+    node.query("ALTER TABLE test UPDATE s='xxx' WHERE 1", settings={"mutations_sync": "2"})
+    node.query("ALTER TABLE test UPDATE s='xxx' WHERE 1", settings={"mutations_sync": "2"})
 
     expected = TSV('''all_0_0_2_4\t1\txxx''')
     assert TSV(node.query('SELECT _part, * FROM test')) == expected
@@ -48,13 +48,13 @@ def test_part_should_reset_mutation(start_cluster):
     expected = TSV('''all_0_0_0\t1\txxx\nall_1_1_0\t2\ta''')
     assert TSV(node.query('SELECT _part, * FROM restore ORDER BY i')) == expected
 
-    node.query("ALTER TABLE restore UPDATE s='yyy' WHERE 1")
+    node.query("ALTER TABLE restore UPDATE s='yyy' WHERE 1", settings={"mutations_sync": "2"})
 
 
     expected = TSV('''all_0_0_0_2\t1\tyyy\nall_1_1_0_2\t2\tyyy''')
     assert TSV(node.query('SELECT _part, * FROM restore ORDER BY i')) == expected
 
-    node.query("ALTER TABLE restore DELETE WHERE 1")
+    node.query("ALTER TABLE restore DELETE WHERE 1", settings={"mutations_sync": "2"})
 
 
     assert node.query("SELECT count() FROM restore").strip() == "0"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Attach partition should reset the mutation.  #18804 


Detailed description / Documentation draft:

Reset the mutation when processing the attach partition command.
