### PR TITLE
Fixed error in DDL query doc for MongoDB dict

### DIFF
--- a/docs/en/sql-reference/dictionaries/external-dictionaries/external-dicts-dict-sources.md
+++ b/docs/en/sql-reference/dictionaries/external-dictionaries/external-dicts-dict-sources.md
@@ -583,7 +583,7 @@ Example of settings:
 or
 
 ``` sql
-SOURCE(MONGO(
+SOURCE(MONGODB(
     host 'localhost'
     port 27017
     user ''


### PR DESCRIPTION
According to the documentation, DDL query for MongoDB dictionaries require

```sql
SOURCE(MONGO(
    host 'localhost'
    port 27017
    user ''
    password ''
    db 'test'
    collection 'dictionary_source'
))
```
However, the source type `MONGO` is not recognized.
It is, however, the source type `MONGODB`.

My change fixes this mistake in documentation.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)

