### PR TITLE
Fix error Task was not found in task queue

### DIFF
--- a/src/Processors/Executors/PollingQueue.cpp
+++ b/src/Processors/Executors/PollingQueue.cpp
@@ -60,8 +60,6 @@ void PollingQueue::addTask(size_t thread_number, void * data, int fd)
 
     if (-1 == epoll_ctl(epoll_fd, EPOLL_CTL_ADD, fd, &socket_event))
         throwFromErrno("Cannot add socket descriptor to epoll", ErrorCodes::CANNOT_OPEN_FILE);
-
-    log.emplace_back(Log{.add = true, .key = key, .ptr = data, .thread_id = getThreadId()});
 }
 
 static std::string dumpTasks(const std::unordered_map<std::uintptr_t, PollingQueue::TaskData> & tasks)
@@ -77,19 +75,6 @@ static std::string dumpTasks(const std::unordered_map<std::uintptr_t, PollingQue
     }
 
     res << "]";
-    return res.str();
-}
-
-static std::string dumpLog(const std::vector<PollingQueue::Log> & log)
-{
-    WriteBufferFromOwnString res;
-    for (const auto & item : log)
-    {
-        res << (item.add ? '+' : '-') << ' ' << item.key << ' ';
-        writePointerHex(item.ptr, res);
-        res << " [" << item.thread_id << "]\n";
-    }
-
     return res.str();
 }
 
@@ -121,8 +106,8 @@ PollingQueue::TaskData PollingQueue::wait(std::unique_lock<std::mutex> & lock)
     auto it = tasks.find(key);
     if (it == tasks.end())
     {
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Task {} ({}) was not found in task queue: {}\n {}",
-                        key, ptr, dumpTasks(tasks), dumpLog(log));
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Task {} ({}) was not found in task queue: {}",
+                        key, ptr, dumpTasks(tasks));
     }
 
     auto res = it->second;
@@ -130,8 +115,6 @@ PollingQueue::TaskData PollingQueue::wait(std::unique_lock<std::mutex> & lock)
 
     if (-1 == epoll_ctl(epoll_fd, EPOLL_CTL_DEL, res.fd, &event))
         throwFromErrno("Cannot remove socket descriptor to epoll", ErrorCodes::CANNOT_OPEN_FILE);
-
-    log.emplace_back(Log{.add = false, .key = key, .ptr = ptr, .thread_id = getThreadId()});
 
     return res;
 }

--- a/src/Processors/Executors/PollingQueue.cpp
+++ b/src/Processors/Executors/PollingQueue.cpp
@@ -9,7 +9,6 @@
 
 #include <IO/WriteBufferFromString.h>
 #include <IO/Operators.h>
-#include <common/getThreadId.h>
 
 namespace DB
 {

--- a/src/Processors/Executors/PollingQueue.cpp
+++ b/src/Processors/Executors/PollingQueue.cpp
@@ -130,7 +130,7 @@ PollingQueue::TaskData PollingQueue::wait(std::unique_lock<std::mutex> & lock)
     if (-1 == epoll_ctl(epoll_fd, EPOLL_CTL_DEL, res.fd, &event))
         throwFromErrno("Cannot remove socket descriptor to epoll", ErrorCodes::CANNOT_OPEN_FILE);
 
-    log.emplace_back(Log{.add = true, .key = key, .ptr = ptr});
+    log.emplace_back(Log{.add = false, .key = key, .ptr = ptr});
 
     return res;
 }

--- a/src/Processors/Executors/PollingQueue.cpp
+++ b/src/Processors/Executors/PollingQueue.cpp
@@ -139,7 +139,6 @@ PollingQueue::TaskData PollingQueue::wait(std::unique_lock<std::mutex> & lock)
 void PollingQueue::finish()
 {
     is_finished = true;
-    tasks.clear();
 
     uint64_t buf = 0;
     while (-1 == write(pipe_fd[1], &buf, sizeof(buf)))

--- a/src/Processors/Executors/PollingQueue.h
+++ b/src/Processors/Executors/PollingQueue.h
@@ -25,20 +25,11 @@ public:
         explicit operator bool() const { return data; }
     };
 
-    struct Log
-    {
-        bool add;
-        std::uintptr_t key;
-        const void * ptr;
-        uint64_t thread_id;
-    };
-
 private:
     int epoll_fd;
     int pipe_fd[2];
     std::atomic_bool is_finished = false;
     std::unordered_map<std::uintptr_t, TaskData> tasks;
-    std::vector<Log> log;
 
 public:
     PollingQueue();

--- a/src/Processors/Executors/PollingQueue.h
+++ b/src/Processors/Executors/PollingQueue.h
@@ -30,6 +30,7 @@ public:
         bool add;
         std::uintptr_t key;
         const void * ptr;
+        uint64_t thread_id;
     };
 
 private:

--- a/src/Processors/Executors/PollingQueue.h
+++ b/src/Processors/Executors/PollingQueue.h
@@ -4,7 +4,6 @@
 #include <mutex>
 #include <atomic>
 #include <unordered_map>
-#include <vector>
 
 namespace DB
 {

--- a/src/Processors/Executors/PollingQueue.h
+++ b/src/Processors/Executors/PollingQueue.h
@@ -4,6 +4,7 @@
 #include <mutex>
 #include <atomic>
 #include <unordered_map>
+#include <vector>
 
 namespace DB
 {
@@ -24,11 +25,19 @@ public:
         explicit operator bool() const { return data; }
     };
 
+    struct Log
+    {
+        bool add;
+        std::uintptr_t key;
+        const void * ptr;
+    };
+
 private:
     int epoll_fd;
     int pipe_fd[2];
     std::atomic_bool is_finished = false;
     std::unordered_map<std::uintptr_t, TaskData> tasks;
+    std::vector<Log> log;
 
 public:
     PollingQueue();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix error `Task was not found in task queue` (possible only for remote queries, with `async_socket_for_remote = 1`).