### PR TITLE
Add a check to avoid exception when long alias equals to column

### DIFF
--- a/src/Interpreters/JoinToSubqueryTransformVisitor.cpp
+++ b/src/Interpreters/JoinToSubqueryTransformVisitor.cpp
@@ -475,8 +475,10 @@ std::vector<TableNeededColumns> normalizeColumnNamesExtractNeeded(
             if (!ident->isShort())
             {
                 if (got_alias)
-                    throw Exception("Alias clashes with qualified column '" + ident->name() + "'", ErrorCodes::AMBIGUOUS_COLUMN_NAME);
-
+                {
+                    if (aliases.find(ident->name())->second->ptr().get() != ident)
+                        throw Exception("Alias clashes with qualified column '" + ident->name() + "'", ErrorCodes::AMBIGUOUS_COLUMN_NAME);
+                }
                 String short_name = ident->shortName();
                 String original_long_name;
                 if (public_identifiers.count(ident))

--- a/src/Interpreters/JoinToSubqueryTransformVisitor.cpp
+++ b/src/Interpreters/JoinToSubqueryTransformVisitor.cpp
@@ -467,6 +467,7 @@ std::vector<TableNeededColumns> normalizeColumnNamesExtractNeeded(
 
     for (ASTIdentifier * ident : identifiers)
     {
+
         bool got_alias = aliases.count(ident->name());
         bool allow_ambiguous = got_alias; /// allow ambiguous column overridden by an alias
 
@@ -476,7 +477,16 @@ std::vector<TableNeededColumns> normalizeColumnNamesExtractNeeded(
             {
                 if (got_alias)
                 {
-                    if (aliases.find(ident->name())->second->ptr().get() != ident)
+                    auto alias = aliases.find(ident->name())->second;
+                    auto alias_table = IdentifierSemantic::getTableName(alias->ptr());
+                    bool alias_equals_column_name = false;
+                    if (alias->ptr()->getColumnNameWithoutAlias()==ident->getColumnNameWithoutAlias()){
+                        alias_equals_column_name = true;
+                    } else if (alias_table == IdentifierSemantic::getTableName(ident->ptr()) && ident->shortName() == alias->as<ASTIdentifier>()->shortName())
+                    {
+                        alias_equals_column_name = true;
+                    }
+                    if (!alias_equals_column_name)
                         throw Exception("Alias clashes with qualified column '" + ident->name() + "'", ErrorCodes::AMBIGUOUS_COLUMN_NAME);
                 }
                 String short_name = ident->shortName();

--- a/src/Interpreters/JoinToSubqueryTransformVisitor.cpp
+++ b/src/Interpreters/JoinToSubqueryTransformVisitor.cpp
@@ -480,9 +480,9 @@ std::vector<TableNeededColumns> normalizeColumnNamesExtractNeeded(
                     auto alias = aliases.find(ident->name())->second;
                     auto alias_table = IdentifierSemantic::getTableName(alias->ptr());
                     bool alias_equals_column_name = false;
-                    if (alias->ptr()->getColumnNameWithoutAlias()==ident->getColumnNameWithoutAlias()){
-                        alias_equals_column_name = true;
-                    } else if (alias_table == IdentifierSemantic::getTableName(ident->ptr()) && ident->shortName() == alias->as<ASTIdentifier>()->shortName())
+                    if ((!ident->isShort() && alias->ptr()->getColumnNameWithoutAlias() == ident->getColumnNameWithoutAlias())
+                        || (alias_table == IdentifierSemantic::getTableName(ident->ptr())
+                            && ident->shortName() == alias->as<ASTIdentifier>()->shortName()))
                     {
                         alias_equals_column_name = true;
                     }

--- a/src/Parsers/ASTIdentifier.cpp
+++ b/src/Parsers/ASTIdentifier.cpp
@@ -80,8 +80,12 @@ void ASTIdentifier::setShortName(const String & new_name)
     name_parts = {new_name};
 
     bool special = semantic->special;
+    //how about keep the semantic info here, such as table
+    auto table = semantic->table;
+
     *semantic = IdentifierSemanticImpl();
     semantic->special = special;
+    semantic->table = table;
 }
 
 const String & ASTIdentifier::name() const

--- a/tests/queries/0_stateless/01600_multiple_left_join_with_aliases.sql
+++ b/tests/queries/0_stateless/01600_multiple_left_join_with_aliases.sql
@@ -1,0 +1,52 @@
+drop database if exists test_01600;
+create database test_01600;
+
+CREATE TABLE test_01600.base
+(
+`id` UInt64,
+`id2` UInt64,
+`d` UInt64,
+`value` UInt64
+)
+ENGINE=MergeTree()
+PARTITION BY d
+ORDER BY (id,id2,d);
+
+CREATE TABLE test_01600.derived1
+(
+    `id1` UInt64,
+    `d1` UInt64,
+    `value1` UInt64
+)
+ENGINE = MergeTree()
+PARTITION BY d1
+ORDER BY (id1, d1)
+;
+
+CREATE TABLE test_01600.derived2
+(
+    `id2` UInt64,
+    `d2` UInt64,
+    `value2` UInt64
+)
+ENGINE = MergeTree()
+PARTITION BY d2
+ORDER BY (id2, d2)
+;
+
+select 
+base.id as `base.id`,
+derived2.value2 as `derived2.value2`,
+derived1.value1 as `derived1.value1`
+from test_01600.base as base 
+left join test_01600.derived2 as derived2 on base.id2 = derived2.id2
+left join test_01600.derived1 as derived1 on base.id = derived1.id1;
+
+
+SELECT
+    base.id AS `base.id`,
+    derived1.value1 AS `derived1.value1`
+FROM test_01600.base AS base
+LEFT JOIN test_01600.derived1 AS derived1 ON base.id = derived1.id1;
+
+drop database test_01600;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
to fix https://github.com/ClickHouse/ClickHouse/issues/18894
Add a check to avoid exception when long column alias('table.column' style, usually auto-generated by BI tools like Looker) equals to long table name.


Detailed description / Documentation draft:

TODO:

- [x] Add a function test.
- [x] Regression testing