### PR TITLE
Fix rarely flaky test 01459_manual_write_to_replicas_quorum

### DIFF
--- a/tests/queries/0_stateless/01459_manual_write_to_replicas_quorum.sh
+++ b/tests/queries/0_stateless/01459_manual_write_to_replicas_quorum.sh
@@ -15,10 +15,12 @@ for i in $(seq 1 $NUM_REPLICAS); do
     "
 done
 
+valid_exceptions_to_retry='Quorum for previous write has not been satisfied yet|Another quorum insert has been already started|Unexpected logical error while adding block'
+
 function thread {
     for x in {0..99}; do
         while true; do
-            $CLICKHOUSE_CLIENT --insert_quorum 5 --insert_quorum_parallel 0 --query "INSERT INTO r$1 SELECT $x" 2>&1 | grep -qF 'Quorum for previous write has not been satisfied yet' || break
+            $CLICKHOUSE_CLIENT --insert_quorum 5 --insert_quorum_parallel 0 --query "INSERT INTO r$1 SELECT $x" 2>&1 | grep -qE "$valid_exceptions_to_retry" || break
         done
     done
 }
@@ -32,7 +34,9 @@ wait
 for i in $(seq 1 $NUM_REPLICAS); do
     $CLICKHOUSE_CLIENT -n -q "
         SYSTEM SYNC REPLICA r$i;
-        SELECT count(), min(x), max(x), sum(x) FROM r$i;
-        DROP TABLE IF EXISTS r$i;
-"
+        SELECT count(), min(x), max(x), sum(x) FROM r$i;"
+done
+
+for i in $(seq 1 $NUM_REPLICAS); do
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS r$i;"
 done


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Why this test was flaky:
1) We insert with a quorum to half of the replicas.
2) We don't retry all possible errors during quorum insert.
3) We drop replicas before all other replicas will sync.

Some examples from logs. Trying to insert `99` to the last replica, but give up after a non-checked error.
```
2021.01.05 23:36:14.700097 [ 21215 ] {b269ec65-0ddf-4361-b32d-7d8bcd1c39f3} <Debug> executeQuery: (from [::1]:50712, using production parser) INSERT INTO r10 SELECT 99
 (version 20.13.1.5600 (official build)) (from [::1]:50712) (in query: INSERT INTO r10 SELECT 99), Stack trace (when copying this message, always include the lines below):
2021.01.05 23:36:14.735560 [ 21213 ] {769a933d-fbbe-4a92-aba7-b87f39d6521f} <Debug> executeQuery: (from [::1]:50742, using production parser) INSERT INTO r10 SELECT 99
 (version 20.13.1.5600 (official build)) (from [::1]:50742) (in query: INSERT INTO r10 SELECT 99), Stack trace (when copying this message, always include the lines below):
2021.01.05 23:36:14.771685 [ 21213 ] {a6f7df91-5aac-4203-a15b-b5ae90931e22} <Debug> executeQuery: (from [::1]:50770, using production parser) INSERT INTO r10 SELECT 99
 (version 20.13.1.5600 (official build)) (from [::1]:50770) (in query: INSERT INTO r10 SELECT 99), Stack trace (when copying this message, always include the lines below):
2021.01.05 23:36:14.807947 [ 21193 ] {2336b122-dffb-4fe3-83f3-4040ef622c19} <Debug> executeQuery: (from [::1]:50806, using production parser) INSERT INTO r10 SELECT 99
2021.01.05 23:36:14.812494 [ 21193 ] {2336b122-dffb-4fe3-83f3-4040ef622c19} <Error> executeQuery: Code: 286, e.displayText() = DB::Exception: Another quorum insert has been already started (version 20.13.1.5600 (official build)) (from [::1]:50806) (in query: INSERT INTO r10 SELECT 99), Stack trace (when copying this message, always include the lines below):
```
All other replicas fetched this part or insert it with a quorum to some 5 replicas, but not to replica №10. After they were dropped replica 10 cannot fetch the desired part.
```
2021.01.05 23:36:15.588536 [ 21211 ] {8adbe37f-4c9e-4933-839e-0e12a66684b8} <Debug> executeQuery: (from [::1]:50892, using production parser) SYSTEM SYNC REPLICA r10; 
2021.01.05 23:36:15.590831 [ 16369 ] {} <Debug> test_t0pkrr.r10 (add9ce6b-d90a-4cba-b170-7c36ef8e1ea1): No active replica has part all_126_126_0 which needs to be written with quorum. Will try to mark that quorum as failed.
2021.01.05 23:36:15.592006 [ 187 ] {} <Warning> test_t0pkrr.r10 (ReplicatedMergeTreePartCheckThread): Checking part all_126_126_0
2021.01.05 23:36:15.592236 [ 16369 ] {} <Error> test_t0pkrr.r10 (add9ce6b-d90a-4cba-b170-7c36ef8e1ea1): auto DB::StorageReplicatedMergeTree::processQueueEntry(ReplicatedMergeTreeQueue::SelectedEntryPtr)::(anonymous class)::operator()(DB::S
torageReplicatedMergeTree::LogEntryPtr &) const: Code: 999, e.displayText() = Coordination::Exception: Can't get data for node /clickhouse/tables/01459_manual_write_ro_replicas_quorum/r/quorum/parallel/all_126_126_0: node doesn't exist (No
 node), Stack trace (when copying this message, always include the lines below):
```