### PR TITLE
Add config for integration tests msan

### DIFF
--- a/tests/ci/ci_config.json
+++ b/tests/ci/ci_config.json
@@ -477,6 +477,18 @@
                 "with_coverage": false
             }
         },
+        "Integration tests (memory)": {
+            "required_build_properties": {
+                "compiler": "clang-11",
+                "package_type": "deb",
+                "build_type": "relwithdebuginfo",
+                "sanitizer": "memory",
+                "bundled": "bundled",
+                "splitted": "unsplitted",
+                "clang-tidy": "disable",
+                "with_coverage": false
+            }
+        },
         "Integration tests flaky check (asan)": {
             "required_build_properties": {
                 "compiler": "clang-11",


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add integration tests run with memory sanitizer.