### PR TITLE
Fix rare deadlock at shutdown of BackgroundSchedulePool

### DIFF
--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -273,10 +273,9 @@ try
     global_context->setCurrentDatabase(default_database);
     applyCmdOptions(*global_context);
 
-    if (config().has("path"))
+    String path = global_context->getPath();
+    if (!path.empty())
     {
-        String path = global_context->getPath();
-
         /// Lock path directory before read
         status.emplace(path + "status", StatusFile::write_full_info);
 

--- a/src/Core/BackgroundSchedulePool.cpp
+++ b/src/Core/BackgroundSchedulePool.cpp
@@ -250,7 +250,16 @@ void BackgroundSchedulePool::threadFunction()
 
     while (!shutdown)
     {
-        if (Poco::AutoPtr<Poco::Notification> notification = queue.waitDequeueNotification())
+        /// We have to wait with timeout to prevent very rare deadlock, caused by the following race condition:
+        /// 1. Background thread N: threadFunction(): checks for shutdown (it's false)
+        /// 2. Main thread: ~BackgroundSchedulePool(): sets shutdown to true, calls queue.wakeUpAll(), it triggers
+        ///    all existing Poco::Events inside Poco::NotificationQueue which background threads are waiting on.
+        /// 3. Background thread N: threadFunction(): calls queue.waitDequeueNotification(), it creates
+        ///    new Poco::Event inside Poco::NotificationQueue and starts to wait on it
+        /// Background thread N will never be woken up.
+        /// TODO Do we really need Poco::NotificationQueue? Why not to use std::queue + mutex + condvar or maybe even DB::ThreadPool?
+        constexpr size_t wait_timeout_ms = 500;
+        if (Poco::AutoPtr<Poco::Notification> notification = queue.waitDequeueNotification(wait_timeout_ms))
         {
             TaskNotification & task_notification = static_cast<TaskNotification &>(*notification);
             task_notification.execute();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed very rare deadlock at shutdown

Detailed description / Documentation draft:
Fixes #18891.
