### PR TITLE
Add docker to run SQLancer in CI

### DIFF
--- a/docker/images.json
+++ b/docker/images.json
@@ -151,5 +151,9 @@
     "docker/test/integration/kerberized_hadoop": {
         "name": "yandex/clickhouse-kerberized-hadoop",
         "dependent": []
+    },
+    "docker/test/sqlancer": {
+        "name": "yandex/clickhouse-sqlancer-test",
+        "dependent": []
     }
 }

--- a/docker/test/sqlancer/Dockerfile
+++ b/docker/test/sqlancer/Dockerfile
@@ -1,0 +1,13 @@
+# docker build -t yandex/clickhouse-sqlancer-test .
+FROM ubuntu:20.04
+
+RUN apt-get update --yes && env DEBIAN_FRONTEND=noninteractive apt-get install wget unzip git openjdk-14-jdk maven --yes --no-install-recommends
+
+RUN wget https://github.com/sqlancer/sqlancer/archive/master.zip -O /sqlancer.zip
+RUN mkdir /sqlancer && \
+	cd /sqlancer && \
+	unzip /sqlancer.zip
+RUN cd /sqlancer/sqlancer-master && mvn package -DskipTests
+
+COPY run.sh /
+CMD ["/bin/bash", "/run.sh"]

--- a/docker/test/sqlancer/run.sh
+++ b/docker/test/sqlancer/run.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e -x
+
+dpkg -i package_folder/clickhouse-common-static_*.deb
+dpkg -i package_folder/clickhouse-common-static-dbg_*.deb
+dpkg -i package_folder/clickhouse-server_*.deb
+dpkg -i package_folder/clickhouse-client_*.deb
+
+service clickhouse-server start && sleep 5
+
+cd /sqlancer/sqlancer-master
+CLICKHOUSE_AVAILABLE=true mvn -Dtest=TestClickHouse test
+
+cp /sqlancer/sqlancer-master/target/surefire-reports/TEST-sqlancer.dbms.TestClickHouse.xml /test_output/result.xml


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add SQLancer test docker image to run check in CI.

Detailed description / Documentation draft:

...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
