### PR TITLE
Fix dangling references

### DIFF
--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -564,7 +564,7 @@ void HTTPHandler::processQuery(
     context.checkSettingsConstraints(settings_changes);
     context.applySettingsChanges(settings_changes);
 
-    const auto & query = getQuery(request, params, context);
+    const auto query = getQuery(request, params, context);
     std::unique_ptr<ReadBuffer> in_param = std::make_unique<ReadBufferFromString>(query);
     in = has_external_data ? std::move(in_param) : std::make_unique<ConcatReadBuffer>(*in_param, *in_post_maybe_compressed);
 

--- a/src/Storages/Distributed/DirectoryMonitor.cpp
+++ b/src/Storages/Distributed/DirectoryMonitor.cpp
@@ -126,7 +126,7 @@ void StorageDistributedDirectoryMonitor::flushAllData()
 
     std::unique_lock lock{mutex};
 
-    const auto & files = getFiles();
+    const auto files = getFiles();
     if (!files.empty())
     {
         processFiles(files);
@@ -161,7 +161,7 @@ void StorageDistributedDirectoryMonitor::run()
     {
         do_sleep = true;
 
-        const auto & files = getFiles();
+        const auto files = getFiles();
         if (files.empty())
             break;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:

...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/

---

Dangling references to objects in stack