### PR TITLE
Avoid redundant exception while dropping part

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -6175,6 +6175,11 @@ bool StorageReplicatedMergeTree::dropPart(
             LOG_TRACE(log, "A new log entry appeared while trying to commit DROP RANGE. Retry.");
             continue;
         }
+        else if (rc == Coordination::Error::ZNONODE)
+        {
+            LOG_TRACE(log, "Other replica already removing same part {} or part deduplication node was removed by background thread. Retry.", part_name);
+            continue;
+        }
         else
             zkutil::KeeperMultiException::check(rc, ops, responses);
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes test `test_ttl_replicated/test.py::test_ttl_empty_parts`.

Previously, when the drop part did remove all parts deduplication blocks from the `/blocks/partition_` we were lucky and this race didn't happen.