### PR TITLE
Update test containers

### DIFF
--- a/docker/images.json
+++ b/docker/images.json
@@ -45,7 +45,8 @@
         "name": "yandex/clickhouse-stateless-test",
         "dependent": [
             "docker/test/stateful",
-            "docker/test/coverage"
+            "docker/test/coverage",
+            "docker/test/unit"
         ]
     },
     "docker/test/stateless_pytest": {
@@ -134,7 +135,9 @@
          "name": "yandex/clickhouse-test-base",
          "dependent": [
             "docker/test/stateless",
-            "docker/test/stateless_pytest"
+            "docker/test/stateless_unbundled",
+            "docker/test/stateless_pytest",
+            "docker/test/integration/base"
          ]
     },
     "docker/packager/unbundled": {

--- a/docker/test/integration/base/Dockerfile
+++ b/docker/test/integration/base/Dockerfile
@@ -30,3 +30,4 @@ RUN curl 'https://cdn.mysql.com//Downloads/Connector-ODBC/8.0/mysql-connector-od
 
 ENV TZ=Europe/Moscow
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+

--- a/docker/test/stateless_unbundled/Dockerfile
+++ b/docker/test/stateless_unbundled/Dockerfile
@@ -86,3 +86,4 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 COPY run.sh /
 CMD ["/bin/bash", "/run.sh"]
+

--- a/docker/test/unit/Dockerfile
+++ b/docker/test/unit/Dockerfile
@@ -7,3 +7,4 @@ RUN apt-get install gdb
 
 CMD service zookeeper start && sleep 7 && /usr/share/zookeeper/bin/zkCli.sh -server localhost:2181 -create create /clickhouse_test ''; \
     gdb -q  -ex 'set print inferior-events off' -ex 'set confirm off' -ex 'set print thread-events off' -ex run -ex bt -ex quit --args ./unit_tests_dbms | tee test_output/test_result.txt
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:
yandex/clickhouse-test-base was updated to 20.04 in https://github.com/ClickHouse/ClickHouse/pull/18105/files 
But one of dependant images was not updated:
```
docker run -it yandex/clickhouse-test-base lsb_release -a 
No LSB modules are available.
Distributor ID:  Ubuntu
Description:  Ubuntu 20.04.1 LTS
Release:  20.04
Codename:  focal

docker run --pull=always -it yandex/clickhouse-integration-test lsb_release -a 
latest: Pulling from yandex/clickhouse-integration-test
Digest: sha256:5f5d188998647677b63e46f36f9715044ff2e4f96ebdcfb9d9a2793bf511ac53
Status: Image is up to date for yandex/clickhouse-integration-test:latest
No LSB modules are available.
Distributor ID:  Ubuntu
Description:  Ubuntu 19.10
Release:  19.10
Codename:  eoan
```

19.10 reached it's EOL and you can not do any apt operations in that image.

That PR fixes the deps, and touch the images which should be updated.