### PR TITLE
Docker: fix uid/gid of the clickhouse user

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -4,7 +4,14 @@ ARG repository="deb https://repo.clickhouse.tech/deb/stable/ main/"
 ARG version=21.1.0
 ARG gosu_ver=1.10
 
-# user/group precreated explicitly with fixed uid/gid on purpose (see commit)
+# user/group precreated explicitly with fixed uid/gid on purpose.
+# It is especially important for rootless containers: in that case entrypoint
+# can't do chown and owners of mounted volumes should be configured externally.
+# We do that in advance at the begining of Dockerfile before any packages will be
+# installed to prevent picking those uid / gid by some unrelated software.
+# The same uid / gid (101) is used both for alpine and ubuntu.
+# Number 101 is used by default in openshift
+
 RUN groupadd -r clickhouse --gid=101 \
     && useradd -r -g clickhouse --uid=101 --home-dir=/var/lib/clickhouse --shell=/bin/bash clickhouse \
     && apt-get update \

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -4,7 +4,10 @@ ARG repository="deb https://repo.clickhouse.tech/deb/stable/ main/"
 ARG version=21.1.0
 ARG gosu_ver=1.10
 
-RUN apt-get update \
+# user/group precreated explicitly with fixed uid/gid on purpose (see commit)
+RUN groupadd -r clickhouse --gid=101 \
+    && useradd -r -g clickhouse --uid=101 --home-dir=/var/lib/clickhouse --shell=/bin/bash clickhouse \
+    && apt-get update \
     && apt-get install --yes --no-install-recommends \
         apt-transport-https \
         ca-certificates \

--- a/docker/server/Dockerfile.alpine
+++ b/docker/server/Dockerfile.alpine
@@ -8,7 +8,14 @@ ENV LANG=en_US.UTF-8 \
 
 COPY alpine-root/ /
 
-# user/group precreated explicitly with fixed uid/gid on purpose (see commit)
+# user/group precreated explicitly with fixed uid/gid on purpose.
+# It is especially important for rootless containers: in that case entrypoint
+# can't do chown and owners of mounted volumes should be configured externally.
+# We do that in advance at the begining of Dockerfile before any packages will be
+# installed to prevent picking those uid / gid by some unrelated software.
+# The same uid / gid (101) is used both for alpine and ubuntu.
+# Number 101 is used by default in openshift
+
 RUN addgroup -S -g 101 clickhouse \
     && adduser -S -h /var/lib/clickhouse -s /bin/bash -G clickhouse -g "ClickHouse server" -u 101 clickhouse \
     && chown clickhouse:clickhouse /var/lib/clickhouse \

--- a/docker/server/Dockerfile.alpine
+++ b/docker/server/Dockerfile.alpine
@@ -8,9 +8,9 @@ ENV LANG=en_US.UTF-8 \
 
 COPY alpine-root/ /
 
-# from https://github.com/ClickHouse/ClickHouse/blob/master/debian/clickhouse-server.postinst
-RUN addgroup clickhouse \
-    && adduser -S -H -h /nonexistent -s /bin/false -G clickhouse -g "ClickHouse server" clickhouse \
+# user/group precreated explicitly with fixed uid/gid on purpose (see commit)
+RUN addgroup -S -g 101 clickhouse \
+    && adduser -S -h /var/lib/clickhouse -s /bin/bash -G clickhouse -g "ClickHouse server" -u 101 clickhouse \
     && chown clickhouse:clickhouse /var/lib/clickhouse \
     && chmod 700 /var/lib/clickhouse \
     && chown root:clickhouse /var/log/clickhouse-server \


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Explicitly set uid / gid of clickhouse user & group to the fixed values (101) in clickhouse-server images.


Detailed description / Documentation draft:

Explicitly set uid / gid of clickhouse user & group to the fixed values 101.

It is especially important for rootless containers: in that case entrypoint can't do chown and owners of mounted volumes should be configured externally.

We do that in advance at the begining of Dockerfile before any packages will be installed to prevent picking those uid / gid by some unrelated software.

The same uid / gid (101) is used both for alpine and ubuntu.

Number 101 is used by default in openshift, and was used by all clickhouse-server docker images <= 20.10. In 20.11 it was changed (by accident) to 999.

PS. IMHO should be backported to >= 20.11.