### PR TITLE
Bitmap join optimization

### DIFF
--- a/src/Columns/ColumnAggregateFunction.cpp
+++ b/src/Columns/ColumnAggregateFunction.cpp
@@ -75,8 +75,23 @@ void ColumnAggregateFunction::set(const AggregateFunctionPtr & func_)
 ColumnAggregateFunction::~ColumnAggregateFunction()
 {
     if (!func->hasTrivialDestructor() && !src)
-        for (auto * val : data)
+        for(size_t i = 0; i < data.size(); ++i)
+        {
+            auto * val = data[i];
+            if(val==NULL)
+            {
+                continue;
+            }
+
+            for(size_t j=i;j<data.size();++j)
+            {
+                if(data[j]==val)
+                {
+                    data[j]= NULL;
+                }
+            }
             func->destroy(val);
+        }
 }
 
 void ColumnAggregateFunction::addArena(ConstArenaPtr arena_)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Performance Improvement
   improve bitmap involved join performance 


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:
  during the join , bitmap
 table1: 
dimCol                                             
       -------                                            
              1                                                   
              1
              1
              .....


table2:
      
dimCol    bitmapCol
---------------------------  
    1               large bitmap ( e.g.  contains 30million numbers)

when table1 join tabl2  on dimCol,   the large bitmap will be copied for N times,  N is table1's   same value row count.
so clickhouse will spend much time on bitmap create and destroy,the query execution will be very slow.

so I modified the code of class AddedColumns in HashJoin.cpp  like below to improve this process:  
```
template <bool has_defaults>
void appendFromBlock(const Block & block, size_t row_num)
{
       if constexpr (has_defaults)
            applyLazyDefaults();
        std::unordered_map<Block*, std::unordered_map<size_t,size_t> >::iterator iter;
        std::unordered_map<size_t,size_t>::iterator iter2;
        bool bFound = false;
        size_t pos = 0;
        for (size_t j = 0; j < right_indexes.size(); ++j){
            if (std::string(columns[j]->getFamilyName())!="AggregateFunction"){  //not aggFuncCol,copy data directly
                columns[j]->insertFrom(*block.getByPosition(right_indexes[j]).column, row_num);
            }else{ // copy pointer for same bitmap
              if(!bFound){
                    iter = copiedDataInfo.find((Block*)&block);
                    if(iter!=copiedDataInfo.end()){    //found block
                        iter2 = iter->second.find(row_num);
                        if(iter2!=iter->second.end()){  //found row
                            pos = iter2->first;
                            auto pCol = typeid_cast<ColumnAggregateFunction *>(columns[j].get());
                            pCol->getData().push_back(pCol->getData()[pos]);
                        }else{
                            pos = columns[j]->size();
                            iter->second.insert(std::pair<size_t,size_t>(row_num,pos));
                            columns[j]->insertFrom(*block.getByPosition(right_indexes[j]).column, row_num);
                        }
                    }else{
                        pos = columns[j]->size();
                        std::unordered_map<size_t,size_t> rowInfo;
                        rowInfo.insert(std::pair<size_t,size_t>(row_num,pos));
                        copiedDataInfo.insert(std::pair<Block*, std::unordered_map<size_t,size_t> >((Block*)&block,
                            rowInfo));
                        columns[j]->insertFrom(*block.getByPosition(right_indexes[j]).column, row_num);
                    }
                    bFound = true;
            }else{
                auto pCol = typeid_cast<ColumnAggregateFunction *>(columns[j].get());
                pCol->getData().push_back(pCol->getData()[pos]);
            }
          }
        }
    }
```

.......

add definition of info container in class AddedColumns:
```
private:
   ....
   std::unordered_map<Block*, std::unordered_map<size_t,size_t> > copiedDataInfo;
```

and we should modify ~ColumnAggregateFunction to destroy bitmap  data correctly :
```
ColumnAggregateFunction::~ColumnAggregateFunction()
{
    if (!func->hasTrivialDestructor() && !src){
    //    for (auto * val : data)
    //
        for(size_t i=0;i<data.size();++i){
            auto  val = data[i];
            if(val==NULL){
                continue;
            }

            for(size_t j=i;j<data.size();++j){
                if(data[j]==val){
                    data[j]= NULL;
                }
            }

            func->destroy(val);
        }
    }
}
```