### PR TITLE
Cover distributed send with different headers

### DIFF
--- a/tests/integration/test_insert_distributed_async_send/configs/remote_servers.xml
+++ b/tests/integration/test_insert_distributed_async_send/configs/remote_servers.xml
@@ -1,6 +1,6 @@
 <yandex>
     <remote_servers>
-        <insert_distributed_async_send_cluster>
+        <insert_distributed_async_send_cluster_two_replicas>
             <shard>
                 <internal_replication>false</internal_replication>
                 <replica>
@@ -12,7 +12,21 @@
                     <port>9000</port>
                 </replica>
             </shard>
-        </insert_distributed_async_send_cluster>
+        </insert_distributed_async_send_cluster_two_replicas>
+        <insert_distributed_async_send_cluster_two_shards>
+            <shard>
+                <replica>
+                    <host>n1</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+            <shard>
+                <replica>
+                    <host>n2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </insert_distributed_async_send_cluster_two_shards>
     </remote_servers>
 </yandex>
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

*NOTE: the test can be converted to stateless once #18264 will be merged*