### PR TITLE
Add missing type check in dictHas for COMPLEX_KEY_SSD_CACHE layout

### DIFF
--- a/src/Dictionaries/SSDComplexKeyCacheDictionary.cpp
+++ b/src/Dictionaries/SSDComplexKeyCacheDictionary.cpp
@@ -1644,6 +1644,8 @@ void SSDComplexKeyCacheDictionary::has(
     const DataTypes & key_types,
     PaddedPODArray<UInt8> & out) const
 {
+    dict_struct.validateKeyTypes(key_types);
+
     const auto now = std::chrono::system_clock::now();
 
     std::unordered_map<KeyRef, std::vector<size_t>> not_found_keys;

--- a/tests/queries/0_stateless/01280_ssd_complex_key_dictionary.sql
+++ b/tests/queries/0_stateless/01280_ssd_complex_key_dictionary.sql
@@ -42,6 +42,9 @@ LAYOUT(COMPLEX_KEY_SSD_CACHE(FILE_SIZE 8192 PATH '/var/lib/clickhouse/clickhouse
 SELECT 'TEST_SMALL';
 SELECT 'VALUE FROM RAM BUFFER';
 
+-- NUMBER_OF_ARGUMENTS_DOESNT_MATCH
+SELECT dictHas('database_for_dict.ssd_dict', 'a', tuple('1')); -- { serverError 42 }
+
 SELECT dictGetUInt64('database_for_dict.ssd_dict', 'a', tuple('1', toInt32(3)));
 SELECT dictGetInt32('database_for_dict.ssd_dict', 'b', tuple('1', toInt32(3)));
 SELECT dictGetString('database_for_dict.ssd_dict', 'c', tuple('1', toInt32(3)));


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add missing type check in dictHas for COMPLEX_KEY_SSD_CACHE layout

P.S. marked as "Not for changelog" since release builds do not fail on LOGICAL_ERROR

Cc: @nikitamikhaylov 
Cc: @nikvas0 