### PR TITLE
curl dependency tiny fixes

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -119,11 +119,6 @@ if (USE_INTERNAL_LDAP_LIBRARY)
     add_subdirectory (openldap-cmake)
 endif ()
 
-# Should go before:
-# - aws-s3-cmake
-# - sentry-native
-add_subdirectory (curl-cmake)
-
 function(mysql_support)
     set(CLIENT_PLUGIN_CACHING_SHA2_PASSWORD STATIC)
     set(CLIENT_PLUGIN_SHA256_PASSWORD STATIC)
@@ -287,6 +282,10 @@ endif()
 if (USE_CASSANDRA)
     add_subdirectory (cassandra)
 endif()
+
+# Should go before:
+# - sentry-native
+add_subdirectory (curl-cmake)
 
 if (USE_SENTRY)
     add_subdirectory (sentry-native)

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -120,7 +120,6 @@ if (USE_INTERNAL_LDAP_LIBRARY)
 endif ()
 
 # Should go before:
-# - mariadb-connector-c
 # - aws-s3-cmake
 # - sentry-native
 add_subdirectory (curl-cmake)
@@ -142,6 +141,7 @@ function(mysql_support)
         set(ZLIB_LIBRARY ${ZLIB_LIBRARIES})
         set(WITH_EXTERNAL_ZLIB ON)
     endif()
+    set(WITH_CURL OFF)
     add_subdirectory (mariadb-connector-c)
 endfunction()
 if (ENABLE_MYSQL AND USE_INTERNAL_MYSQL_LIBRARY)


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Update comment for curl dependency for aws
- Disable curl for mariadb-connector-c (it is not required)