### PR TITLE
Fix MSan error in rocksdb #19213

### DIFF
--- a/base/glibc-compatibility/musl/sched_getcpu.c
+++ b/base/glibc-compatibility/musl/sched_getcpu.c
@@ -4,6 +4,12 @@
 #include "syscall.h"
 #include "atomic.h"
 
+#if defined(__has_feature)
+#if __has_feature(memory_sanitizer)
+#include <sanitizer/msan_interface.h>
+#endif
+#endif
+
 #ifdef VDSO_GETCPU_SYM
 
 static void *volatile vdso_func;
@@ -37,6 +43,13 @@ int sched_getcpu(void)
 #endif
 
 	r = __syscall(SYS_getcpu, &cpu, 0, 0);
-	if (!r) return cpu;
+	if (!r) {
+#if defined(__has_feature)
+#if __has_feature(memory_sanitizer)
+        __msan_unpoison(&cpu, sizeof(cpu));
+#endif
+#endif
+        return cpu;
+    }
 	return __syscall_ret(r);
 }


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

This closes #19213.