### PR TITLE
Speed up aggregate function sum

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionSum.h
+++ b/src/AggregateFunctions/AggregateFunctionSum.h
@@ -29,61 +29,74 @@ struct AggregateFunctionSumData
     template <typename Value>
     void NO_INLINE addMany(const Value * __restrict ptr, size_t count)
     {
-        /// Compiler cannot unroll this loop, do it manually.
-        /// (at least for floats, most likely due to the lack of -fassociative-math)
-
-        /// Something around the number of SSE registers * the number of elements fit in register.
-        constexpr size_t unroll_count = 128 / sizeof(T);
-        T partial_sums[unroll_count]{};
-
         const auto * end = ptr + count;
-        const auto * unrolled_end = ptr + (count / unroll_count * unroll_count);
 
-        while (ptr < unrolled_end)
+        if constexpr (std::is_floating_point_v<T>)
         {
+            /// Compiler cannot unroll this loop, do it manually.
+            /// (at least for floats, most likely due to the lack of -fassociative-math)
+
+            /// Something around the number of SSE registers * the number of elements fit in register.
+            constexpr size_t unroll_count = 128 / sizeof(T);
+            T partial_sums[unroll_count]{};
+
+            const auto * unrolled_end = ptr + (count / unroll_count * unroll_count);
+
+            while (ptr < unrolled_end)
+            {
+                for (size_t i = 0; i < unroll_count; ++i)
+                    partial_sums[i] += ptr[i];
+                ptr += unroll_count;
+            }
+
             for (size_t i = 0; i < unroll_count; ++i)
-                partial_sums[i] += ptr[i];
-            ptr += unroll_count;
+                sum += partial_sums[i];
         }
 
-        for (size_t i = 0; i < unroll_count; ++i)
-            sum += partial_sums[i];
-
+        /// clang cannot vectorize the loop if accumulator is class member instead of local variable.
+        T local_sum{};
         while (ptr < end)
         {
-            sum += *ptr;
+            local_sum += *ptr;
             ++ptr;
         }
+        sum += local_sum;
     }
 
     template <typename Value>
     void NO_INLINE addManyNotNull(const Value * __restrict ptr, const UInt8 * __restrict null_map, size_t count)
     {
-        constexpr size_t unroll_count = 128 / sizeof(T);
-        T partial_sums[unroll_count]{};
-
         const auto * end = ptr + count;
-        const auto * unrolled_end = ptr + (count / unroll_count * unroll_count);
 
-        while (ptr < unrolled_end)
+        if constexpr (std::is_floating_point_v<T>)
         {
+            constexpr size_t unroll_count = 128 / sizeof(T);
+            T partial_sums[unroll_count]{};
+
+            const auto * unrolled_end = ptr + (count / unroll_count * unroll_count);
+
+            while (ptr < unrolled_end)
+            {
+                for (size_t i = 0; i < unroll_count; ++i)
+                    if (!null_map[i])
+                        partial_sums[i] += ptr[i];
+                ptr += unroll_count;
+                null_map += unroll_count;
+            }
+
             for (size_t i = 0; i < unroll_count; ++i)
-                if (!null_map[i])
-                    partial_sums[i] += ptr[i];
-            ptr += unroll_count;
-            null_map += unroll_count;
+                sum += partial_sums[i];
         }
 
-        for (size_t i = 0; i < unroll_count; ++i)
-            sum += partial_sums[i];
-
+        T local_sum{};
         while (ptr < end)
         {
             if (!*null_map)
-                sum += *ptr;
+                local_sum += *ptr;
             ++ptr;
             ++null_map;
         }
+        sum += local_sum;
     }
 
     void merge(const AggregateFunctionSumData & rhs)


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Speed up aggregate function `sum`. Improvement only visible on synthetic benchmarks and not very practical.


```
SELECT sum(number) FROM system.numbers_mt
```

Was: `35.20 billion rows/s., 281.63 GB/s.`
Now: `44.68 billion rows/s., 357.43 GB/s.`

On AMD Ryzen 3950.