### PR TITLE
Make symbolizers available in fuzzer Docker image

### DIFF
--- a/docker/images.json
+++ b/docker/images.json
@@ -137,7 +137,8 @@
             "docker/test/stateless",
             "docker/test/stateless_unbundled",
             "docker/test/stateless_pytest",
-            "docker/test/integration/base"
+            "docker/test/integration/base",
+            "docker/test/fuzzer"
          ]
     },
     "docker/packager/unbundled": {

--- a/docker/test/fuzzer/Dockerfile
+++ b/docker/test/fuzzer/Dockerfile
@@ -1,5 +1,5 @@
 # docker build -t yandex/clickhouse-fuzzer .
-FROM ubuntu:18.04
+FROM yandex/clickhouse-test-base
 
 ENV LANG=C.UTF-8
 ENV TZ=Europe/Moscow
@@ -7,11 +7,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
-            bash \
             ca-certificates \
-            curl \
-            gdb \
-            git \
             libc6-dbg \
             moreutils \
             ncdu \


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://clickhouse-test-reports.s3.yandex.net/19214/98a8a20b7066852ff559bd9eb660cc0d03abbe5e/fuzzer/server.log