### PR TITLE
Don't wait forever for log update after table was dropped

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -4652,7 +4652,9 @@ bool StorageReplicatedMergeTree::waitForTableReplicaToProcessLogEntry(
         bool stop_waiting_non_active = !wait_for_non_active && !getZooKeeper()->exists(table_zookeeper_path + "/replicas/" + replica + "/is_active");
         return stop_waiting_itself || stop_waiting_non_active;
     };
-    constexpr auto event_wait_timeout_ms = 1000;
+
+    /// Don't recheck ZooKeeper too often
+    constexpr auto event_wait_timeout_ms = 3000;
 
     if (startsWith(entry.znode_name, "log-"))
     {
@@ -4673,10 +4675,11 @@ bool StorageReplicatedMergeTree::waitForTableReplicaToProcessLogEntry(
             if (!log_pointer.empty() && parse<UInt64>(log_pointer) > log_index)
                 break;
 
-            if (wait_for_non_active)
-                event->wait();
-            else
-                event->tryWait(event_wait_timeout_ms);
+            /// Wait with timeout because we can be already shut down, but not dropped.
+            /// So log_pointer node will exist, but we will never update it because all background threads already stopped.
+            /// It can lead to query hung because table drop query can wait for some query (alter, optimize, etc) which called this method,
+            /// but the query will never finish because the drop already shut down the table.
+            event->tryWait(event_wait_timeout_ms);
         }
     }
     else if (startsWith(entry.znode_name, "queue-"))
@@ -4721,10 +4724,11 @@ bool StorageReplicatedMergeTree::waitForTableReplicaToProcessLogEntry(
                 if (!log_pointer_new.empty() && parse<UInt64>(log_pointer_new) > log_index)
                     break;
 
-                if (wait_for_non_active)
-                    event->wait();
-                else
-                    event->tryWait(event_wait_timeout_ms);
+                /// Wait with timeout because we can be already shut down, but not dropped.
+                /// So log_pointer node will exist, but we will never update it because all background threads already stopped.
+                /// It can lead to query hung because table drop query can wait for some query (alter, optimize, etc) which called this method,
+                /// but the query will never finish because the drop already shut down the table.
+                event->tryWait(event_wait_timeout_ms);
             }
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bug when concurrent `ALTER` and `DROP` queries may hang while processing ReplicatedMergeTree table.


No tests, but an example of the bug. Drop shut down table, but cannot remove it from zk. Alter waiting for the update of `log_pointer`, but processing threads were shut down. https://clickhouse-test-reports.s3.yandex.net/18919/2edef43b9876ec7205a7806d31c73e7c64d0ce5d/functional_stateless_tests_(release).html#fail1


```
2021-01-17 21:47:30 
2021-01-17 21:47:30 Thread 255 (Thread 0x7f658dd8e000 (LWP 138076)):
2021-01-17 21:47:30 #0  0x00007f688c8f1376 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib/x86_64-linux-gnu/libpthread.so.0
2021-01-17 21:47:30 #1  0x000000000eb79194 in std::__1::__libcpp_condvar_wait (__cv=0x7f688b835b48, __m=0x7f688b835b10) at ../contrib/libcxx/include/__threading_support:353
2021-01-17 21:47:30 #2  std::__1::condition_variable::wait (this=0x7f688b835b48, lk=...) at ../contrib/libcxx/src/condition_variable.cpp:44
2021-01-17 21:47:30 #3  std::__1::condition_variable::wait<DB::DatabaseCatalog::waitTableFinallyDropped(StrongTypedef<DB::UInt128, DB::UUIDTag> const&)::$_4>(std::__1::unique_lock<std::__1::mutex>&, DB::DatabaseCatalog::waitTableFinallyDropped(StrongTypedef<DB::UInt128, DB::UUIDTag> const&)::$_4) (this=0x7f688b835b48, __lk=..., __pred=...) at ../contrib/libcxx/include/__mutex_base:409
2021-01-17 21:47:30 #4  DB::DatabaseCatalog::waitTableFinallyDropped (this=0x7f688b835500, uuid=...) at ../src/Interpreters/DatabaseCatalog.cpp:937
2021-01-17 21:47:30 #5  0x000000000ee011dd in DB::InterpreterDropQuery::waitForTableToBeActuallyDroppedOrDetached (query=..., db=..., uuid_to_wait=...) at ../src/Interpreters/InterpreterDropQuery.cpp:78
2021-01-17 21:47:30 #6  DB::InterpreterDropQuery::executeToTable (this=<optimized out>, query=...) at ../src/Interpreters/InterpreterDropQuery.cpp:89
2021-01-17 21:47:30 #7  0x000000000ee00c81 in DB::InterpreterDropQuery::execute (this=0x7f680d183220) at ../src/Interpreters/InterpreterDropQuery.cpp:59
2021-01-17 21:47:30 #8  0x000000000f17d029 in DB::executeQueryImpl (begin=<optimized out>, end=<optimized out>, context=..., internal=<optimized out>, stage=DB::QueryProcessingStage::Complete, has_query_tail=<optimized out>, istr=<optimized out>) at ../src/Interpreters/executeQuery.cpp:525
2021-01-17 21:47:30 #9  0x000000000f17b99d in DB::executeQuery (query=..., context=..., internal=false, stage=DB::QueryProcessingStage::MAX, may_have_embedded_data=<optimized out>) at ../src/Interpreters/executeQuery.cpp:868
2021-01-17 21:47:30 #10 0x000000000f8844d6 in DB::TCPHandler::runImpl (this=0x7f680de71000) at ../src/Server/TCPHandler.cpp:260
2021-01-17 21:47:30 #11 0x000000000f8932e7 in DB::TCPHandler::run (this=0x7f680de71000) at ../src/Server/TCPHandler.cpp:1417
2021-01-17 21:47:30 #12 0x0000000011dd646f in Poco::Net::TCPServerConnection::start (this=0x7f688b835b74) at ../contrib/poco/Net/src/TCPServerConnection.cpp:43
2021-01-17 21:47:30 #13 0x0000000011dd7e81 in Poco::Net::TCPServerDispatcher::run (this=0x7f686bfc7800) at ../contrib/poco/Net/src/TCPServerDispatcher.cpp:112
2021-01-17 21:47:30 #14 0x0000000011f03809 in Poco::PooledThread::run (this=0x7f67e1996480) at ../contrib/poco/Foundation/src/ThreadPool.cpp:199
2021-01-17 21:47:30 #15 0x0000000011eff79a in Poco::ThreadImpl::runnableEntry (pThread=<optimized out>) at ../contrib/poco/Foundation/src/Thread_POSIX.cpp:345
2021-01-17 21:47:30 #16 0x00007f688c8ea609 in start_thread () from /lib/x86_64-linux-gnu/libpthread.so.0
2021-01-17 21:47:30 #17 0x00007f688c80b293 in clone () from /lib/x86_64-linux-gnu/libc.so.6
2021-01-17 21:47:30 
2021-01-17 21:47:30 Thread 254 (Thread 0x7f65d9d9d000 (LWP 138060)):
2021-01-17 21:47:30 #0  0x00007f688c8f1376 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib/x86_64-linux-gnu/libpthread.so.0
2021-01-17 21:47:30 #1  0x0000000011e87ab1 in Poco::EventImpl::waitImpl (this=0x7f66eeb4b098) at ../contrib/poco/Foundation/src/Event_POSIX.cpp:106
2021-01-17 21:47:30 #2  0x000000000f44aeb3 in Poco::Event::wait (this=0x7f66eeb4b0f0) at ../contrib/poco/Foundation/include/Poco/Event.h:97
2021-01-17 21:47:30 #3  DB::StorageReplicatedMergeTree::waitForTableReplicaToProcessLogEntry (this=<optimized out>, table_zookeeper_path=..., replica=..., entry=..., wait_for_non_active=<optimized out>) at ../src/Storages/StorageReplicatedMergeTree.cpp:4677
2021-01-17 21:47:30 #4  0x000000000f441636 in DB::StorageReplicatedMergeTree::waitForReplicaToProcessLogEntry (this=0x7f684fc61000, replica=..., entry=..., wait_for_non_active=true) at ../src/Storages/StorageReplicatedMergeTree.cpp:4777
2021-01-17 21:47:30 #5  DB::StorageReplicatedMergeTree::alter (this=<optimized out>, commands=..., query_context=..., table_lock_holder=...) at ../src/Storages/StorageReplicatedMergeTree.cpp:4313
2021-01-17 21:47:30 #6  0x000000000ee07872 in DB::InterpreterAlterQuery::execute (this=<optimized out>) at ../src/Interpreters/InterpreterAlterQuery.cpp:118
2021-01-17 21:47:30 #7  0x000000000f17d029 in DB::executeQueryImpl (begin=<optimized out>, end=<optimized out>, context=..., internal=<optimized out>, stage=DB::QueryProcessingStage::Complete, has_query_tail=<optimized out>, istr=<optimized out>) at ../src/Interpreters/executeQuery.cpp:525
2021-01-17 21:47:30 #8  0x000000000f17b99d in DB::executeQuery (query=..., context=..., internal=false, stage=DB::QueryProcessingStage::FetchColumns, may_have_embedded_data=<optimized out>) at ../src/Interpreters/executeQuery.cpp:868
2021-01-17 21:47:30 #9  0x000000000f8844d6 in DB::TCPHandler::runImpl (this=0x7f67fae7e800) at ../src/Server/TCPHandler.cpp:260
2021-01-17 21:47:30 #10 0x000000000f8932e7 in DB::TCPHandler::run (this=0x7f67fae7e800) at ../src/Server/TCPHandler.cpp:1417
2021-01-17 21:47:30 #11 0x0000000011dd646f in Poco::Net::TCPServerConnection::start (this=0x7f66eeb4b0f0) at ../contrib/poco/Net/src/TCPServerConnection.cpp:43
2021-01-17 21:47:30 #12 0x0000000011dd7e81 in Poco::Net::TCPServerDispatcher::run (this=0x7f686bfc7800) at ../contrib/poco/Net/src/TCPServerDispatcher.cpp:112
2021-01-17 21:47:30 #13 0x0000000011f03809 in Poco::PooledThread::run (this=0x7f681a619680) at ../contrib/poco/Foundation/src/ThreadPool.cpp:199
2021-01-17 21:47:30 #14 0x0000000011eff79a in Poco::ThreadImpl::runnableEntry (pThread=<optimized out>) at ../contrib/poco/Foundation/src/Thread_POSIX.cpp:345
2021-01-17 21:47:30 #15 0x00007f688c8ea609 in start_thread () from /lib/x86_64-linux-gnu/libpthread.so.0
2021-01-17 21:47:30 #16 0x00007f688c80b293 in clone () from /lib/x86_64-linux-gnu/libc.so.6
```