### PR TITLE
Add MindsDB to 3rd party interfaces

### DIFF
--- a/docs/en/interfaces/third-party/gui.md
+++ b/docs/en/interfaces/third-party/gui.md
@@ -107,6 +107,10 @@ Features:
 
 [xeus-clickhouse](https://github.com/wangfenjin/xeus-clickhouse) is a Jupyter kernal for ClickHouse, which supports query CH data using SQL in Jupyter.
 
+### MindsDB Studio {#mindsdb}
+
+[MindsDB](https://mindsdb.com/) is an open-source AI layer for databases including ClickHouse that allows you to effortlessly develop, train and deploy state-of-the-art machine learning models. MindsDB Studio(GUI) allows you to train new models from database, interpret predictions made by the model, identify potential data biases, and evaluate and visualize model accuracy using the Explainable AI function to adapt and tune your Machine Learning models faster.
+
 ## Commercial {#commercial}
 
 ### DataGrip {#datagrip}
@@ -162,9 +166,5 @@ Features:
 -   Powerful workflow integration via Looker’s [Data Actions](https://looker.com/platform/actions).
 
 [How to configure ClickHouse in Looker.](https://docs.looker.com/setup-and-management/database-config/clickhouse)
-
-### MindsDB Studio {#mindsdb}
-
-[MindsDB](https://mindsdb.com/) is an open-source AI layer for databases including ClickHouse that allows you to effortlessly develop, train and deploy state-of-the-art machine learning models. MindsDB Studio(GUI) allows you to train new models from database, interpret predictions made by the model, identify potential data biases, and evaluate and visualize model accuracy using the Explainable AI function to adapt and tune your Machine Learning models faster.
 
 [Original article](https://clickhouse.tech/docs/en/interfaces/third-party/gui/) <!--hide-->

--- a/docs/en/interfaces/third-party/gui.md
+++ b/docs/en/interfaces/third-party/gui.md
@@ -163,4 +163,8 @@ Features:
 
 [How to configure ClickHouse in Looker.](https://docs.looker.com/setup-and-management/database-config/clickhouse)
 
+### MindsDB Studio {#mindsdb}
+
+[MindsDB](https://mindsdb.com/) is an open-source AI layer for databases including ClickHouse that allows you to effortlessly develop, train and deploy state-of-the-art machine learning models. MindsDB Studio(GUI) allows you to train new models from database, interpret predictions made by the model, identify potential data biases, and evaluate and visualize model accuracy using the Explainable AI function to adapt and tune your Machine Learning models faster.
+
 [Original article](https://clickhouse.tech/docs/en/interfaces/third-party/gui/) <!--hide-->

--- a/docs/en/interfaces/third-party/integrations.md
+++ b/docs/en/interfaces/third-party/integrations.md
@@ -69,6 +69,9 @@ toc_title: Integrations
 -   Geo
     -   [MaxMind](https://dev.maxmind.com/geoip/)
         -   [clickhouse-maxmind-geoip](https://github.com/AlexeyKupershtokh/clickhouse-maxmind-geoip)
+-   AutoML
+    -   [MindsDB](https://mindsdb.com/)
+        -   [MindsDB](https://github.com/mindsdb/mindsdb) - Predictive AI layer for ClickHouse database.
 
 ## Programming Language Ecosystems {#programming-language-ecosystems}
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation 

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Add MindsDB to 3rd party docs 

Detailed description / Documentation draft:
- Add MindsDB to docs  as a 3rd party software that enables AutoML in ClickHouse

