### PR TITLE
Do not mark file for distributed send as broken on EOF

### DIFF
--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -803,6 +803,9 @@ Packet Connection::receivePacket(std::function<void(Poco::Net::Socket &)> async_
     }
     catch (Exception & e)
     {
+        /// This is to consider ATTEMPT_TO_READ_AFTER_EOF as a remote exception.
+        e.setRemoteException();
+
         /// Add server address to exception message, if need.
         if (e.code() != ErrorCodes::UNKNOWN_PACKET_FROM_SERVER)
             e.addMessage("while receiving packet from " + getDescription());
@@ -892,7 +895,7 @@ void Connection::setDescription()
 
 std::unique_ptr<Exception> Connection::receiveException()
 {
-    return std::make_unique<Exception>(readException(*in, "Received from " + getDescription()));
+    return std::make_unique<Exception>(readException(*in, "Received from " + getDescription(), true /* remote */));
 }
 
 

--- a/src/Common/Exception.cpp
+++ b/src/Common/Exception.cpp
@@ -50,8 +50,9 @@ void handle_error_code([[maybe_unused]] const std::string & msg, int code)
     ErrorCodes::increment(code);
 }
 
-Exception::Exception(const std::string & msg, int code)
+Exception::Exception(const std::string & msg, int code, bool remote_)
     : Poco::Exception(msg, code)
+    , remote(remote_)
 {
     handle_error_code(msg, code);
 }

--- a/src/Common/Exception.h
+++ b/src/Common/Exception.h
@@ -25,7 +25,7 @@ class Exception : public Poco::Exception
 {
 public:
     Exception() = default;
-    Exception(const std::string & msg, int code);
+    Exception(const std::string & msg, int code, bool remote_ = false);
     Exception(const std::string & msg, const Exception & nested, int code);
 
     Exception(int code, const std::string & message)
@@ -61,12 +61,17 @@ public:
         extendedMessage(message);
     }
 
+    /// Used to distinguish local exceptions from the one that was received from remote node.
+    void setRemoteException(bool remote_ = true) { remote = remote_; }
+    bool isRemoteException() const { return remote; }
+
     std::string getStackTraceString() const;
 
 private:
 #ifndef STD_EXCEPTION_HAS_STACK_TRACE
     StackTrace trace;
 #endif
+    bool remote = false;
 
     const char * className() const throw() override { return "DB::Exception"; }
 };

--- a/src/IO/ReadHelpers.cpp
+++ b/src/IO/ReadHelpers.cpp
@@ -1014,7 +1014,7 @@ void skipJSONField(ReadBuffer & buf, const StringRef & name_of_field)
 }
 
 
-Exception readException(ReadBuffer & buf, const String & additional_message)
+Exception readException(ReadBuffer & buf, const String & additional_message, bool remote_exception)
 {
     int code = 0;
     String name;
@@ -1041,7 +1041,7 @@ Exception readException(ReadBuffer & buf, const String & additional_message)
     if (!stack_trace.empty())
         out << " Stack trace:\n\n" << stack_trace;
 
-    return Exception(out.str(), code);
+    return Exception(out.str(), code, remote_exception);
 }
 
 void readAndThrowException(ReadBuffer & buf, const String & additional_message)

--- a/src/IO/ReadHelpers.h
+++ b/src/IO/ReadHelpers.h
@@ -1073,7 +1073,7 @@ void skipJSONField(ReadBuffer & buf, const StringRef & name_of_field);
   * (type is cut to base class, 'message' replaced by 'displayText', and stack trace is appended to 'message')
   * Some additional message could be appended to exception (example: you could add information about from where it was received).
   */
-Exception readException(ReadBuffer & buf, const String & additional_message = "");
+Exception readException(ReadBuffer & buf, const String & additional_message = "", bool remote_exception = false);
 void readAndThrowException(ReadBuffer & buf, const String & additional_message = "");
 
 

--- a/src/Storages/Distributed/DirectoryMonitor.h
+++ b/src/Storages/Distributed/DirectoryMonitor.h
@@ -70,7 +70,6 @@ private:
     void processFile(const std::string & file_path);
     void processFilesWithBatching(const std::map<UInt64, std::string> & files);
 
-    static bool isFileBrokenErrorCode(int code);
     void markAsBroken(const std::string & file_path) const;
     bool maybeMarkAsBroken(const std::string & file_path, const Exception & e) const;
 


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not mark file for distributed send as broken on EOF

Detailed description / Documentation draft:
ATTEMPT_TO_READ_AFTER_EOF should not be ignored if we receive it from remote (receiver), since:
- the sender will got ATTEMPT_TO_READ_AFTER_EOF when the client just go away,
  i.e. server had been restarted
- since #18853 the file will be checked on the sender locally, and
  if there is something wrong with the file itself, we will receive
  ATTEMPT_TO_READ_AFTER_EOF not from the remote at first
  and mark batch as broken.

<details>

```
2021.01.15 08:59:57.379143 [ 8271 ] {} <Error> default.dist.DirectoryMonitor: Failed to send batch due to: Code: 32, e.displayText() = DB::Exception: Attempt to read after eof: while receiving packet from ch2.net:9000, Stack trace (when copying this message, always include the lines below): 
0. DB::throwReadAfterEOF() @ 0x86e5020 in /usr/bin/clickhouse
1. ? @ 0x870934d in /usr/bin/clickhouse
2. DB::Connection::receivePacket(std::__1::function<void (Poco::Net::Socket&)>) @ 0xf965556 in /usr/bin/clickhouse
3. DB::RemoteBlockOutputStream::RemoteBlockOutputStream(DB::Connection&, DB::ConnectionTimeouts const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::Settings const&, DB::ClientInfo const&) @ 0xf6ecdbc in /usr/bin/clickhou
se
4. DB::StorageDistributedDirectoryMonitor::Batch::send() @ 0xf6e7775 in /usr/bin/clickhouse
5. DB::StorageDistributedDirectoryMonitor::processFilesWithBatching(std::__1::map<unsigned long, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::less<unsigned long>, std::__1::allocator<std::__1::pair<unsigned long const, std 
::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > > const&) @ 0xf6e2e04 in /usr/bin/clickhouse
6. DB::StorageDistributedDirectoryMonitor::run() @ 0xf6e0fd6 in /usr/bin/clickhouse
7. DB::BackgroundSchedulePoolTaskInfo::execute() @ 0xecc31e0 in /usr/bin/clickhouse
8. DB::BackgroundSchedulePool::threadFunction() @ 0xecc51d2 in /usr/bin/clickhouse
9. ? @ 0xecc5f92 in /usr/bin/clickhouse
10. ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) @ 0x870df5e in /usr/bin/clickhouse
11. ? @ 0x87119d3 in /usr/bin/clickhouse
12. start_thread @ 0x8ea7 in /lib/x86_64-linux-gnu/libpthread-2.31.so
13. clone @ 0xfdeaf in /lib/x86_64-linux-gnu/libc-2.31.so
 (version 21.1.1.5646)
2021.01.15 08:59:57.379211 [ 8271 ] {} <Error> default.dist.DirectoryMonitor: Marking a batch of 28 files as broken.
```

</details>

Cc: @alexey-milovidov (maybe you have some details on why `ATTEMPT_TO_READ_AFTER_EOF` has been added?)