### PR TITLE
[ClickHouse][Core][MySql] fix use database err

### DIFF
--- a/src/Core/MySQL/PacketsProtocolText.cpp
+++ b/src/Core/MySQL/PacketsProtocolText.cpp
@@ -52,6 +52,7 @@ void ComFieldList::readPayloadImpl(ReadBuffer & payload)
 {
     // Command byte has been already read from payload.
     readNullTerminated(table, payload);
+    payload.ignore();
     readStringUntilEOF(field_wildcard, payload);
 }
 


### PR DESCRIPTION
Fixes https://github.com/ClickHouse/ClickHouse/issues/18926

```
2021.01.18 14:47:08.459253 [ 71229 ] {} <Trace> MySQLHandlerFactory: MySQL connection. Id: 56. Address: [::ffff:xxx]:30292
2021.01.18 14:47:08.459464 [ 71229 ] {} <Trace> MySQLHandler: Sent handshake
2021.01.18 14:47:08.462727 [ 71229 ] {} <Trace> MySQLHandler: payload size: 83
2021.01.18 14:47:08.462746 [ 71229 ] {} <Trace> MySQLHandler: Capabilities: 537896581, max_packet_size: 16777216, character_set: 33, user: default, auth_response length: 20, database: , auth_plugin_name: mysql_native_password
2021.01.18 14:47:08.462770 [ 71229 ] {} <Debug> MySQLHandler: Authentication for user default succeeded.
2021.01.18 14:47:08.464621 [ 71229 ] {} <Debug> MySQLHandler: Received command: 3. Connection id: 56.
2021.01.18 14:47:08.464732 [ 71229 ] {} <Debug> executeQuery: (from [::ffff:xxx]:30292) select @@version_comment limit 1
2021.01.18 14:47:08.465108 [ 71229 ] {} <Information> executeQuery: Read 1 rows, 1.00 B in 0.000349832 sec., 2858 rows/sec., 2.79 KiB/sec.
2021.01.18 14:47:10.928604 [ 71229 ] {} <Debug> MySQLHandler: Received command: 3. Connection id: 56.
2021.01.18 14:47:10.928722 [ 71229 ] {} <Debug> executeQuery: (from [::ffff:xxx]:30292) SELECT DATABASE()
2021.01.18 14:47:10.929063 [ 71229 ] {} <Information> executeQuery: Read 1 rows, 1.00 B in 0.000326059 sec., 3066 rows/sec., 3.00 KiB/sec.
2021.01.18 14:47:10.930624 [ 71229 ] {} <Debug> MySQLHandler: Received command: 2. Connection id: 56.
2021.01.18 14:47:10.930654 [ 71229 ] {} <Debug> MySQLHandler: Setting current database to jason
2021.01.18 14:47:10.933269 [ 71229 ] {} <Debug> MySQLHandler: Received command: 3. Connection id: 56.
2021.01.18 14:47:10.933307 [ 71229 ] {} <Debug> executeQuery: (from [::ffff:xxx]:30292) show databases
2021.01.18 14:47:10.933366 [ 71229 ] {} <Debug> executeQuery: (internal) SELECT name FROM system.databases
2021.01.18 14:47:10.933700 [ 71229 ] {} <Information> executeQuery: Read 13 rows, 2.09 KiB in 0.000382505 sec., 33986 rows/sec., 5.33 MiB/sec.
2021.01.18 14:47:10.935325 [ 71229 ] {} <Debug> MySQLHandler: Received command: 3. Connection id: 56.
2021.01.18 14:47:10.935362 [ 71229 ] {} <Debug> executeQuery: (from [::ffff:xxx]:30292) show tables
2021.01.18 14:47:10.935442 [ 71229 ] {} <Debug> executeQuery: (internal) SELECT name FROM system.tables WHERE database = 'jason'
2021.01.18 14:47:10.935989 [ 71229 ] {} <Information> executeQuery: Read 4 rows, 140.00 B in 0.000614729 sec., 6506 rows/sec., 222.40 KiB/sec.
2021.01.18 14:47:10.937526 [ 71229 ] {} <Debug> MySQLHandler: Received command: 4. Connection id: 56.
2021.01.18 14:47:10.939108 [ 71229 ] {} <Debug> MySQLHandler: Received command: 4. Connection id: 56.
2021.01.18 14:47:10.939263 [ 71229 ] {} <Error> MySQLHandler: DB::Exception: Cannot read all data. Bytes read: 0. Bytes expected: 3.
```