### PR TITLE
Fixed race between copy-constructor and addQueryAccessInfo

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -946,7 +946,7 @@ bool Context::hasScalar(const String & name) const
 void Context::addQueryAccessInfo(const String & quoted_database_name, const String & full_quoted_table_name, const Names & column_names)
 {
     assert(global_context != this || getApplicationType() == ApplicationType::LOCAL);
-    auto lock = getLock();
+    std::lock_guard<std::mutex> lock(query_access_info.mutex);
     query_access_info.databases.emplace(quoted_database_name);
     query_access_info.tables.emplace(full_quoted_table_name);
     for (const auto & column_name : column_names)

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -212,7 +212,7 @@ private:
             return *this;
         }
 
-        void swap(QueryAccessInfo & rhs) 
+        void swap(QueryAccessInfo & rhs)
         {
             std::swap(databases, rhs.databases);
             std::swap(tables, rhs.tables);

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -194,9 +194,36 @@ private:
     /// Record entities accessed by current query, and store this information in system.query_log.
     struct QueryAccessInfo
     {
-        std::set<std::string> databases;
-        std::set<std::string> tables;
-        std::set<std::string> columns;
+        QueryAccessInfo() = default;
+
+        QueryAccessInfo(const QueryAccessInfo & rhs)
+        {
+            std::lock_guard<std::mutex> lock(rhs.mutex);
+            databases = rhs.databases;
+            tables = rhs.tables;
+            columns = rhs.columns;
+        }
+
+        QueryAccessInfo(QueryAccessInfo && rhs) = delete;
+
+        QueryAccessInfo & operator=(QueryAccessInfo rhs)
+        {
+            swap(rhs);
+            return *this;
+        }
+
+        void swap(QueryAccessInfo & rhs) 
+        {
+            std::swap(databases, rhs.databases);
+            std::swap(tables, rhs.tables);
+            std::swap(columns, rhs.columns);
+        }
+
+        /// To prevent a race between copy-constructor and other uses of this structure.
+        mutable std::mutex mutex{};
+        std::set<std::string> databases{};
+        std::set<std::string> tables{};
+        std::set<std::string> columns{};
     };
 
     QueryAccessInfo query_access_info;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed CI found race https://clickhouse-test-reports.s3.yandex.net/19284/374cee47e040e977e67b255d1685186cd285ef19/functional_stateless_tests_(thread)/stderr.log


