### PR TITLE
Refactor now64

### DIFF
--- a/src/Functions/now64.cpp
+++ b/src/Functions/now64.cpp
@@ -3,6 +3,7 @@
 #include <Core/DecimalFunctions.h>
 #include <Functions/IFunction.h>
 #include <Functions/FunctionFactory.h>
+#include <DataTypes/DataTypeNullable.h>
 
 #include <Common/assert_cast.h>
 
@@ -134,7 +135,8 @@ public:
     FunctionBaseImplPtr build(const ColumnsWithTypeAndName &, const DataTypePtr & result_type) const override
     {
         UInt32 scale = DataTypeDateTime64::default_scale;
-        if (const auto * type = typeid_cast<const DataTypeDateTime64 *>(result_type.get()))
+        auto res_type = removeNullable(result_type);
+        if (const auto * type = typeid_cast<const DataTypeDateTime64 *>(res_type.get()))
             scale = type->getScale();
 
         return std::make_unique<FunctionBaseNow64>(nowSubsecond(scale), result_type);

--- a/src/Functions/now64.cpp
+++ b/src/Functions/now64.cpp
@@ -133,7 +133,10 @@ public:
 
     FunctionBaseImplPtr build(const ColumnsWithTypeAndName &, const DataTypePtr & result_type) const override
     {
-        const UInt32 scale = assert_cast<const DataTypeDateTime64 *>(result_type.get())->getScale();
+        UInt32 scale = DataTypeDateTime64::default_scale;
+        if (const auto * type = typeid_cast<const DataTypeDateTime64 *>(result_type.get()))
+            scale = type->getScale();
+
         return std::make_unique<FunctionBaseNow64>(nowSubsecond(scale), result_type);
     }
 };


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix error `Cannot convert column now64() because it is constant but values of constants are different in source and result`. Continuation of #7156