### PR TITLE
Add Sanitizer report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/95_sanitizer-report.md
+++ b/.github/ISSUE_TEMPLATE/95_sanitizer-report.md
@@ -1,0 +1,19 @@
+---
+name: Sanitizer alert
+about: Potential issue has been found by special code instrumentation
+title: ''
+labels: testing
+assignees: ''
+
+---
+
+(you don't have to strictly follow this form)
+
+**Describe the bug**
+A link to the report
+
+**How to reproduce**
+Try to reproduce the report and copy the tables and queries involved.
+
+**Error message and/or stacktrace**
+You can find additional information in server logs.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:

Add separate issue type for sanitizer reports.

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
