### PR TITLE
Allow building librdkafka without ssl

### DIFF
--- a/cmake/find/rdkafka.cmake
+++ b/cmake/find/rdkafka.cmake
@@ -1,9 +1,7 @@
-if (NOT ARCH_ARM AND OPENSSL_FOUND)
+if (NOT ARCH_ARM)
     option (ENABLE_RDKAFKA "Enable kafka" ${ENABLE_LIBRARIES})
-elseif(ENABLE_RDKAFKA AND NOT OPENSSL_FOUND)
-    message (${RECONFIGURE_MESSAGE_LEVEL} "Can't use librdkafka without SSL")
 elseif(ENABLE_RDKAFKA)
-    message (${RECONFIGURE_MESSAGE_LEVEL} "librdafka is not supported on ARM and on FreeBSD")
+    message (${RECONFIGURE_MESSAGE_LEVEL} "librdafka is not supported on ARM")
 endif ()
 
 if (NOT ENABLE_RDKAFKA)

--- a/contrib/librdkafka-cmake/CMakeLists.txt
+++ b/contrib/librdkafka-cmake/CMakeLists.txt
@@ -50,12 +50,12 @@ set(SRCS
   ${RDKAFKA_SOURCE_DIR}/rdkafka_request.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_roundrobin_assignor.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_sasl.c
-#  ${RDKAFKA_SOURCE_DIR}/rdkafka_sasl_cyrus.c # optionally included below
-  ${RDKAFKA_SOURCE_DIR}/rdkafka_sasl_oauthbearer.c
+#  ${RDKAFKA_SOURCE_DIR}/rdkafka_sasl_cyrus.c        # optionally included below
+#  ${RDKAFKA_SOURCE_DIR}/rdkafka_sasl_oauthbearer.c  # optionally included below
   ${RDKAFKA_SOURCE_DIR}/rdkafka_sasl_plain.c
-  ${RDKAFKA_SOURCE_DIR}/rdkafka_sasl_scram.c
+#  ${RDKAFKA_SOURCE_DIR}/rdkafka_sasl_scram.c        # optionally included below
 #  ${RDKAFKA_SOURCE_DIR}/rdkafka_sasl_win32.c
-  ${RDKAFKA_SOURCE_DIR}/rdkafka_ssl.c
+#  ${RDKAFKA_SOURCE_DIR}/rdkafka_ssl.c               # optionally included below
   ${RDKAFKA_SOURCE_DIR}/rdkafka_sticky_assignor.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_subscription.c
   ${RDKAFKA_SOURCE_DIR}/rdkafka_timer.c
@@ -82,10 +82,33 @@ set(SRCS
 
 if(${ENABLE_CYRUS_SASL})
     message (STATUS "librdkafka with SASL support")
-    set(SRCS
-        ${SRCS}
-        ${RDKAFKA_SOURCE_DIR}/rdkafka_sasl_cyrus.c # needed to support Kerberos, requires cyrus-sasl
-    )
+    set(WITH_SASL_CYRUS 1)
+endif()
+
+if(OPENSSL_FOUND)
+    message (STATUS "librdkafka with SSL support")
+    set(WITH_SSL 1)
+
+    if(${ENABLE_CYRUS_SASL})
+       set(WITH_SASL_SCRAM 1)
+       set(WITH_SASL_OAUTHBEARER 1)
+    endif()
+endif()
+
+if(WITH_SSL)
+  list(APPEND SRCS ${RDKAFKA_SOURCE_DIR}/rdkafka_ssl.c)
+endif()
+
+if(WITH_SASL_CYRUS)
+  list(APPEND SRCS ${RDKAFKA_SOURCE_DIR}/rdkafka_sasl_cyrus.c) # needed to support Kerberos, requires cyrus-sasl
+endif()
+
+if(WITH_SASL_SCRAM)
+  list(APPEND SRCS ${RDKAFKA_SOURCE_DIR}/rdkafka_sasl_scram.c)
+endif()
+
+if(WITH_SASL_OAUTHBEARER)
+  list(APPEND SRCS ${RDKAFKA_SOURCE_DIR}/rdkafka_sasl_oauthbearer.c)
 endif()
 
 add_library(rdkafka ${SRCS})
@@ -101,7 +124,6 @@ if(OPENSSL_SSL_LIBRARY AND OPENSSL_CRYPTO_LIBRARY)
 endif()
 if(${ENABLE_CYRUS_SASL})
     target_link_libraries(rdkafka PRIVATE ${CYRUS_SASL_LIBRARY})
-    set(WITH_SASL_CYRUS 1)
 endif()
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/auxdir)

--- a/contrib/librdkafka-cmake/config.h.in
+++ b/contrib/librdkafka-cmake/config.h.in
@@ -60,11 +60,11 @@
 // WITH_SOCKEM
 #define WITH_SOCKEM 1
 // libssl
-#define WITH_SSL 1
+#cmakedefine WITH_SSL 1
 // WITH_SASL_SCRAM
-#define WITH_SASL_SCRAM 1
+#cmakedefine WITH_SASL_SCRAM 1
 // WITH_SASL_OAUTHBEARER
-#define WITH_SASL_OAUTHBEARER 1
+#cmakedefine WITH_SASL_OAUTHBEARER 1
 #cmakedefine WITH_SASL_CYRUS 1
 // crc32chw
 #if !defined(__PPC__)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow building librdkafka without ssl.

Detailed description / Documentation draft:
mostly fof dev. checked locally
```
cmake .. -DCMAKE_C_FLAGS="-fuse-ld=lld" -DCMAKE_CXX_FLAGS="-fuse-ld=lld" -DCMAKE_CXX_COMPILER=clang++-11 -DCMAKE_C_COMPILER=clang-11 -DENABLE_LIBRARIES=0 -DUSE_UNWIND=1 -DENABLE_REPLXX=1 -DENABLE_JEMALLOC=1 -DENABLE_TESTS=0 -DENABLE_UTILS=0 -DENABLE_EMBEDDED_COMPILER=0 -DENABLE_THINLTO=0  -DENABLE_RDKAFKA=1 -DCMAKE_BUILD_TYPE=Debug
```