### PR TITLE
Fix system.parts _state column

### DIFF
--- a/src/Storages/System/StorageSystemParts.cpp
+++ b/src/Storages/System/StorageSystemParts.cpp
@@ -139,9 +139,6 @@ void StorageSystemParts::processNextStorage(MutableColumns & columns_, const Sto
             columns_[i++]->insertDefault();
         }
 
-        if (has_state_column)
-            columns_[i++]->insert(part->stateString());
-
         MinimalisticDataPartChecksums helper;
         helper.computeTotalChecksums(part->checksums);
 
@@ -184,6 +181,10 @@ void StorageSystemParts::processNextStorage(MutableColumns & columns_, const Sto
         columns_[i++]->insert(queryToString(part->default_codec->getCodecDesc()));
 
         add_ttl_info_map(part->ttl_infos.recompression_ttl);
+
+        /// _state column should be the latest.
+        if (has_state_column)
+            columns_[i++]->insert(part->stateString());
     }
 }
 

--- a/tests/queries/0_stateless/01660_system_parts_smoke.reference
+++ b/tests/queries/0_stateless/01660_system_parts_smoke.reference
@@ -1,0 +1,14 @@
+# two parts
+Committed
+Committed
+all_1_1_0	Committed
+all_2_2_0	Committed
+all_1_1_0	1
+all_2_2_0	1
+# optimize
+2	Outdated
+1	Committed
+# truncate
+Outdated
+Outdated
+# drop

--- a/tests/queries/0_stateless/01660_system_parts_smoke.sql
+++ b/tests/queries/0_stateless/01660_system_parts_smoke.sql
@@ -1,0 +1,41 @@
+-- There is different code path when:
+-- - _state is not requested
+-- - _state is requested
+-- - only _state is requested
+SELECT * FROM system.parts FORMAT Null;
+SELECT *, _state FROM system.parts FORMAT Null;
+SELECT _state FROM system.parts FORMAT Null;
+
+-- Create one table and see some columns in system.parts
+DROP TABLE IF EXISTS data_01660;
+CREATE TABLE data_01660 (key Int) Engine=MergeTree() ORDER BY key;
+SYSTEM STOP MERGES data_01660;
+
+-- Empty
+SELECT _state FROM system.parts WHERE database = currentDatabase() AND table = 'data_01660';
+SELECT name, _state FROM system.parts WHERE database = currentDatabase() AND table = 'data_01660';
+SELECT name, active FROM system.parts WHERE database = currentDatabase() AND table = 'data_01660';
+
+-- Add part and check again
+SELECT '# two parts';
+INSERT INTO data_01660 VALUES (0);
+INSERT INTO data_01660 VALUES (1);
+SELECT _state FROM system.parts WHERE database = currentDatabase() AND table = 'data_01660';
+SELECT name, _state FROM system.parts WHERE database = currentDatabase() AND table = 'data_01660';
+SELECT name, active FROM system.parts WHERE database = currentDatabase() AND table = 'data_01660';
+
+-- OPTIMIZE to create Outdated parts
+SELECT '# optimize';
+SYSTEM START MERGES data_01660;
+OPTIMIZE TABLE data_01660 FINAL;
+SELECT count(), _state FROM system.parts WHERE database = currentDatabase() AND table = 'data_01660' GROUP BY _state;
+
+-- TRUNCATE does not remove parts instantly
+SELECT '# truncate';
+TRUNCATE data_01660;
+SELECT _state FROM system.parts WHERE database = currentDatabase() AND table = 'data_01660';
+
+-- But DROP does
+SELECT '# drop';
+DROP TABLE data_01660;
+SELECT * FROM system.parts WHERE database = currentDatabase() AND table = 'data_01660';


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix system.parts _state column (LOGICAL_ERROR when querying this column, due to incorrect order)