### PR TITLE
Fix race condition in TestKeeperHandler on session finish

### DIFF
--- a/src/Common/ZooKeeper/TestKeeperStorageDispatcher.cpp
+++ b/src/Common/ZooKeeper/TestKeeperStorageDispatcher.cpp
@@ -49,7 +49,7 @@ void TestKeeperStorageDispatcher::setResponse(int64_t session_id, const Coordina
     std::lock_guard lock(session_to_response_callback_mutex);
     auto session_writer = session_to_response_callback.find(session_id);
     if (session_writer == session_to_response_callback.end())
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown session id {}", session_id);
+        return;
 
     session_writer->second(response);
     /// Session closed, no more writes
@@ -126,6 +126,14 @@ void TestKeeperStorageDispatcher::registerSession(int64_t session_id, ZooKeeperR
     std::lock_guard lock(session_to_response_callback_mutex);
     if (!session_to_response_callback.try_emplace(session_id, callback).second)
         throw Exception(DB::ErrorCodes::LOGICAL_ERROR, "Session with id {} already registered in dispatcher", session_id);
+}
+
+void TestKeeperStorageDispatcher::finishSession(int64_t session_id)
+{
+    std::lock_guard lock(session_to_response_callback_mutex);
+    auto session_it = session_to_response_callback.find(session_id);
+    if (session_it != session_to_response_callback.end())
+        session_to_response_callback.erase(session_it);
 }
 
 }

--- a/src/Common/ZooKeeper/TestKeeperStorageDispatcher.h
+++ b/src/Common/ZooKeeper/TestKeeperStorageDispatcher.h
@@ -53,6 +53,8 @@ public:
         return storage.getSessionID();
     }
     void registerSession(int64_t session_id, ZooKeeperResponseCallback callback);
+    /// Call if we don't need any responses for this session no more (session was expired)
+    void finishSession(int64_t session_id);
 };
 
 }

--- a/src/Server/TestKeeperTCPHandler.cpp
+++ b/src/Server/TestKeeperTCPHandler.cpp
@@ -390,7 +390,11 @@ void TestKeeperTCPHandler::finish()
 {
     Coordination::ZooKeeperRequestPtr request = Coordination::ZooKeeperRequestFactory::instance().get(Coordination::OpNum::Close);
     request->xid = close_xid;
+    /// Put close request (so storage will remove all info about session)
     test_keeper_storage_dispatcher->putRequest(request, session_id);
+    /// We don't need any callbacks because session can be already dead and
+    /// nobody wait for response
+    test_keeper_storage_dispatcher->finishSession(session_id);
 }
 
 std::pair<Coordination::OpNum, Coordination::XID> TestKeeperTCPHandler::receiveRequest()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Found be stress test https://clickhouse-test-reports.s3.yandex.net/19346/5f3059555a039181cdb9b558fb073fc7998ad496/stress_test_(thread).html#fail1
