### PR TITLE
Fix IDisk::open parameters to match posix open

### DIFF
--- a/src/Disks/DiskDecorator.cpp
+++ b/src/Disks/DiskDecorator.cpp
@@ -175,9 +175,9 @@ void DiskDecorator::truncateFile(const String & path, size_t size)
     delegate->truncateFile(path, size);
 }
 
-int DiskDecorator::open(const String & path, mode_t mode) const
+int DiskDecorator::open(const String & path, int flags) const
 {
-    return delegate->open(path, mode);
+    return delegate->open(path, flags);
 }
 
 void DiskDecorator::close(int fd) const

--- a/src/Disks/DiskDecorator.h
+++ b/src/Disks/DiskDecorator.h
@@ -48,7 +48,7 @@ public:
     void setReadOnly(const String & path) override;
     void createHardLink(const String & src_path, const String & dst_path) override;
     void truncateFile(const String & path, size_t size) override;
-    int open(const String & path, mode_t mode) const override;
+    int open(const String & path, int flags) const override;
     void close(int fd) const override;
     void sync(int fd) const override;
     const String getType() const override { return delegate->getType(); }

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -315,10 +315,10 @@ void DiskLocal::copy(const String & from_path, const std::shared_ptr<IDisk> & to
         IDisk::copy(from_path, to_disk, to_path); /// Copy files through buffers.
 }
 
-int DiskLocal::open(const String & path, mode_t mode) const
+int DiskLocal::open(const String & path, int flags) const
 {
     String full_path = disk_path + path;
-    int fd = ::open(full_path.c_str(), mode);
+    int fd = ::open(full_path.c_str(), flags);
     if (-1 == fd)
         throwFromErrnoWithPath("Cannot open file " + full_path, full_path,
                         errno == ENOENT ? ErrorCodes::FILE_DOESNT_EXIST : ErrorCodes::CANNOT_OPEN_FILE);

--- a/src/Disks/DiskLocal.h
+++ b/src/Disks/DiskLocal.h
@@ -98,7 +98,7 @@ public:
 
     void createHardLink(const String & src_path, const String & dst_path) override;
 
-    int open(const String & path, mode_t mode) const override;
+    int open(const String & path, int flags) const override;
     void close(int fd) const override;
     void sync(int fd) const override;
 

--- a/src/Disks/DiskMemory.cpp
+++ b/src/Disks/DiskMemory.cpp
@@ -436,7 +436,7 @@ void DiskMemory::setReadOnly(const String &)
     throw Exception("Method setReadOnly is not implemented for memory disks", ErrorCodes::NOT_IMPLEMENTED);
 }
 
-int DiskMemory::open(const String & /*path*/, mode_t /*mode*/) const
+int DiskMemory::open(const String & /*path*/, int /*flags*/) const
 {
     throw Exception("Method open is not implemented for memory disks", ErrorCodes::NOT_IMPLEMENTED);
 }

--- a/src/Disks/DiskMemory.h
+++ b/src/Disks/DiskMemory.h
@@ -89,7 +89,7 @@ public:
 
     void createHardLink(const String & src_path, const String & dst_path) override;
 
-    int open(const String & path, mode_t mode) const override;
+    int open(const String & path, int flags) const override;
     void close(int fd) const override;
     void sync(int fd) const override;
 

--- a/src/Disks/IDisk.h
+++ b/src/Disks/IDisk.h
@@ -175,7 +175,7 @@ public:
     virtual void createHardLink(const String & src_path, const String & dst_path) = 0;
 
     /// Wrapper for POSIX open
-    virtual int open(const String & path, mode_t mode) const = 0;
+    virtual int open(const String & path, int flags) const = 0;
 
     /// Wrapper for POSIX close
     virtual void close(int fd) const = 0;

--- a/src/Disks/S3/DiskS3.cpp
+++ b/src/Disks/S3/DiskS3.cpp
@@ -878,7 +878,7 @@ void DiskS3::setReadOnly(const String & path)
     metadata.save();
 }
 
-int DiskS3::open(const String & /*path*/, mode_t /*mode*/) const
+int DiskS3::open(const String & /*path*/, int /*flags*/) const
 {
     throw Exception("Method open is not implemented for S3 disks", ErrorCodes::NOT_IMPLEMENTED);
 }

--- a/src/Disks/S3/DiskS3.h
+++ b/src/Disks/S3/DiskS3.h
@@ -105,7 +105,7 @@ public:
 
     void setReadOnly(const String & path) override;
 
-    int open(const String & path, mode_t mode) const override;
+    int open(const String & path, int flags) const override;
     void close(int fd) const override;
     void sync(int fd) const override;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for Changelog

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Changed IDisk::open parameters to match posix "int open(const char *pathname, int flags);"

Detailed description / Documentation draft:

Previously "mode_t mode" was used to path O_DIRECTORY flag which was failing on some Darwin builds:

```
$(SOURCE_ROOT)/clickhouse/src/Common/DirectorySyncGuard.cpp:21:28: error: implicit conversion from 'int' to 'mode_t' (aka 'unsigned short') changes value from 1048576 to 0 [-Werror,-Wconstant-conversion]
    , fd(disk_->open(path, O_DIRECTORY))
                ~~~~       ^~~~~~~~~~~
$(TOOL_ROOT)/sbr1137285108/usr/include/sys/fcntl.h:157:25: note: expanded from macro 'O_DIRECTORY'
#define O_DIRECTORY     0x100000
                        ^~~~~~~~
1 error generated.  
```


By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
