### PR TITLE
Allow docker to be executed with arbitrary uid

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -10,7 +10,6 @@ ARG gosu_ver=1.10
 # We do that in advance at the begining of Dockerfile before any packages will be
 # installed to prevent picking those uid / gid by some unrelated software.
 # The same uid / gid (101) is used both for alpine and ubuntu.
-# Number 101 is used by default in openshift
 
 RUN groupadd -r clickhouse --gid=101 \
     && useradd -r -g clickhouse --uid=101 --home-dir=/var/lib/clickhouse --shell=/bin/bash clickhouse \
@@ -37,7 +36,12 @@ RUN groupadd -r clickhouse --gid=101 \
         /var/lib/apt/lists/* \
         /var/cache/debconf \
         /tmp/* \
-    && apt-get clean
+    && apt-get clean \
+    && mkdir -p /var/lib/clickhouse /var/log/clickhouse-server /etc/clickhouse-server /etc/clickhouse-client \
+    && chmod ugo+Xrw -R /var/lib/clickhouse /var/log/clickhouse-server /etc/clickhouse-server /etc/clickhouse-client
+
+# we need to allow to allow "others" access to clickhouse folder, because docker container
+# can be started with arbitrary uid (openshift usecase)
 
 ADD https://github.com/tianon/gosu/releases/download/$gosu_ver/gosu-amd64 /bin/gosu
 

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -40,7 +40,7 @@ RUN groupadd -r clickhouse --gid=101 \
     && mkdir -p /var/lib/clickhouse /var/log/clickhouse-server /etc/clickhouse-server /etc/clickhouse-client \
     && chmod ugo+Xrw -R /var/lib/clickhouse /var/log/clickhouse-server /etc/clickhouse-server /etc/clickhouse-client
 
-# we need to allow to allow "others" access to clickhouse folder, because docker container
+# we need to allow "others" access to clickhouse folder, because docker container
 # can be started with arbitrary uid (openshift usecase)
 
 ADD https://github.com/tianon/gosu/releases/download/$gosu_ver/gosu-amd64 /bin/gosu

--- a/docker/server/Dockerfile.alpine
+++ b/docker/server/Dockerfile.alpine
@@ -24,7 +24,7 @@ RUN addgroup -S -g 101 clickhouse \
     && apk add --no-cache su-exec bash \
     && chmod ugo+Xrw -R /var/lib/clickhouse /var/log/clickhouse-server /etc/clickhouse-server /etc/clickhouse-client
 
-# we need to allow to allow "others" access to clickhouse folder, because docker container
+# we need to allow "others" access to clickhouse folder, because docker container
 # can be started with arbitrary uid (openshift usecase)
 
 EXPOSE 9000 8123 9009

--- a/docker/server/Dockerfile.alpine
+++ b/docker/server/Dockerfile.alpine
@@ -14,16 +14,18 @@ COPY alpine-root/ /
 # We do that in advance at the begining of Dockerfile before any packages will be
 # installed to prevent picking those uid / gid by some unrelated software.
 # The same uid / gid (101) is used both for alpine and ubuntu.
-# Number 101 is used by default in openshift
 
 RUN addgroup -S -g 101 clickhouse \
     && adduser -S -h /var/lib/clickhouse -s /bin/bash -G clickhouse -g "ClickHouse server" -u 101 clickhouse \
+    && mkdir -p /var/lib/clickhouse /var/log/clickhouse-server /etc/clickhouse-server /etc/clickhouse-client \
     && chown clickhouse:clickhouse /var/lib/clickhouse \
-    && chmod 700 /var/lib/clickhouse \
     && chown root:clickhouse /var/log/clickhouse-server \
-    && chmod 775 /var/log/clickhouse-server \
     && chmod +x /entrypoint.sh \
-    && apk add --no-cache su-exec bash
+    && apk add --no-cache su-exec bash \
+    && chmod ugo+Xrw -R /var/lib/clickhouse /var/log/clickhouse-server /etc/clickhouse-server /etc/clickhouse-client
+
+# we need to allow to allow "others" access to clickhouse folder, because docker container
+# can be started with arbitrary uid (openshift usecase)
 
 EXPOSE 9000 8123 9009
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow docker to be executed with arbitrary uid. 

Detailed description / Documentation draft:
Allow "others" access clickhouse folders in the docker to make it possible to start the container with arbitrary uid.

Together with #18954 #19096 allows to run clickhouse rootless with arbitrary uid, for example in OpenShift, resolving #11003

Resolves (the docker part) of #18927.

Containers can be tested from:
filimonovq/clickhouse-server:21.1.2.15-alpine
filimonovq/clickhouse-server:21.1.2.15
