### PR TITLE
Add log message with elapsed time while pushing to view

### DIFF
--- a/src/DataStreams/PushingToViewsBlockOutputStream.h
+++ b/src/DataStreams/PushingToViewsBlockOutputStream.h
@@ -4,6 +4,10 @@
 #include <Parsers/IAST_fwd.h>
 #include <Storages/IStorage.h>
 
+namespace Poco
+{
+class Logger;
+};
 
 namespace DB
 {
@@ -36,6 +40,7 @@ private:
     StorageMetadataPtr metadata_snapshot;
     BlockOutputStreamPtr output;
     ReplicatedMergeTreeBlockOutputStream * replicated_output = nullptr;
+    Poco::Logger * log;
 
     const Context & context;
     ASTPtr query_ptr;


### PR DESCRIPTION
Since right now these queries are not logged and there is no way to
determine the time that it takes.

*Proper fix will be to account them in system.processes (and all other places), but this is not that easy.*

Changelog category (leave one):
- Not for changelog (changelog entry is not required)