### PR TITLE
Fail fast in incorrect usage of extractAllGroups

### DIFF
--- a/src/Functions/extractAllGroups.h
+++ b/src/Functions/extractAllGroups.h
@@ -14,12 +14,14 @@
 
 #include <Core/iostream_debug_helpers.h>
 
+
 namespace DB
 {
 
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
+    extern const int TOO_LARGE_ARRAY_SIZE;
 }
 
 
@@ -145,11 +147,11 @@ public:
         }
         else
         {
-            std::vector<StringPiece> all_matches;
-            // number of times RE matched on each row of haystack column.
-            std::vector<size_t> number_of_matches_per_row;
+            PODArray<StringPiece, 0> all_matches;
+            /// Number of times RE matched on each row of haystack column.
+            PODArray<size_t, 0> number_of_matches_per_row;
 
-            // we expect RE to match multiple times on each row, `* 8` is arbitrary to reduce number of re-allocations.
+            /// We expect RE to match multiple times on each row, `* 8` is arbitrary to reduce number of re-allocations.
             all_matches.reserve(input_rows_count * groups_count * 8);
             number_of_matches_per_row.reserve(input_rows_count);
 
@@ -169,6 +171,12 @@ public:
                     // 1 is to exclude group #0 which is whole re match.
                     for (size_t group = 1; group <= groups_count; ++group)
                         all_matches.push_back(matched_groups[group]);
+
+                    /// Additional limit to fail fast on supposedly incorrect usage.
+                    static constexpr size_t MAX_GROUPS_PER_ROW = 1000000;
+
+                    if (all_matches.size() > MAX_GROUPS_PER_ROW)
+                        throw Exception(ErrorCodes::TOO_LARGE_ARRAY_SIZE, "Too large array size in the result of function {}", getName());
 
                     pos = matched_groups[0].data() + std::max<size_t>(1, matched_groups[0].size());
 

--- a/tests/queries/0_stateless/01661_extract_all_groups_fail_fast.sql
+++ b/tests/queries/0_stateless/01661_extract_all_groups_fail_fast.sql
@@ -1,0 +1,1 @@
+SELECT repeat('abcdefghijklmnopqrstuvwxyz', number * 100) AS haystack, extractAllGroupsHorizontal(haystack, '(\\w)') AS matches FROM numbers(1023); -- { serverError 128 }


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


MemorySanitizer can argue about trying to allocate more than 16 GiB of memory in single allocation.
This is normal and we have MemoryTracker to prevent excessive memory usage.

This change is needed to avoid the report from MSan. Also it allows incorrect queries to fail more quickly. Also minor improvements have been made.