### PR TITLE
Limit max memory usage in fuzz testing

### DIFF
--- a/docker/test/fuzzer/query-fuzzer-tweaks-users.xml
+++ b/docker/test/fuzzer/query-fuzzer-tweaks-users.xml
@@ -12,7 +12,7 @@
                 </max_execution_time>
 
                 <max_memory_usage>
-                    <max>10737418240</max>
+                    <max>10G</max>
                 </max_memory_usage>
 
                 <!-- Not ready for production -->

--- a/docker/test/fuzzer/query-fuzzer-tweaks-users.xml
+++ b/docker/test/fuzzer/query-fuzzer-tweaks-users.xml
@@ -11,6 +11,10 @@
                     <max>10</max>
                 </max_execution_time>
 
+                <max_memory_usage>
+                    <max>10GB</max>
+                </max_memory_usage>
+
                 <!-- Not ready for production -->
                 <compile_expressions>
                     <readonly />

--- a/docker/test/fuzzer/query-fuzzer-tweaks-users.xml
+++ b/docker/test/fuzzer/query-fuzzer-tweaks-users.xml
@@ -12,7 +12,7 @@
                 </max_execution_time>
 
                 <max_memory_usage>
-                    <max>10GB</max>
+                    <max>10737418240</max>
                 </max_memory_usage>
 
                 <!-- Not ready for production -->


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Don't allow Query Fuzzer to raise maximum memory usage too much.
This may fix #19395.
