### PR TITLE
Fix one more race in TestKeeper

### DIFF
--- a/src/Server/TestKeeperTCPHandler.cpp
+++ b/src/Server/TestKeeperTCPHandler.cpp
@@ -357,7 +357,7 @@ void TestKeeperTCPHandler::runImpl()
                 while (in->available());
             }
 
-            /// Process exact amout of responses from pipe
+            /// Process exact amount of responses from pipe
             /// otherwise state of responses queue and signaling pipe
             /// became inconsistent and race condition is possible.
             while (result.ready_responses_count != 0)

--- a/src/Server/TestKeeperTCPHandler.cpp
+++ b/src/Server/TestKeeperTCPHandler.cpp
@@ -28,6 +28,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int SYSTEM_ERROR;
+    extern const int LOGICAL_ERROR;
     extern const int UNEXPECTED_PACKET_FROM_CLIENT;
 }
 

--- a/src/Server/TestKeeperTCPHandler.cpp
+++ b/src/Server/TestKeeperTCPHandler.cpp
@@ -33,9 +33,9 @@ namespace ErrorCodes
 
 struct PollResult
 {
-    bool has_responses;
-    bool has_requests;
-    bool error;
+    size_t ready_responses_count{0};
+    bool has_requests{false};
+    bool error{false};
 };
 
 /// Queue with mutex. As simple as possible.
@@ -191,10 +191,17 @@ struct SocketInterruptablePollWrapper
                         result.has_requests = true;
                     else
                     {
-                        /// Skip all of them, we are not interested in exact
-                        /// amount because responses ordered in responses queue.
-                        response_in.ignore();
-                        result.has_responses = true;
+                        UInt8 dummy;
+                        do
+                        {
+                            /// All ready responses stored in responses queue,
+                            /// but we have to count amount of ready responses in pipe
+                            /// and process them only. Otherwise states of response_in
+                            /// and response queue will be inconsistent and race condition is possible.
+                            readIntBinary(dummy, response_in);
+                            result.ready_responses_count++;
+                        }
+                        while (response_in.available());
                     }
                 }
             }
@@ -349,23 +356,27 @@ void TestKeeperTCPHandler::runImpl()
                 while (in->available());
             }
 
-            if (result.has_responses)
+            /// Process exact amout of responses from pipe
+            /// otherwise state of responses queue and signaling pipe
+            /// became inconsistent and race condition is possible.
+            while (result.ready_responses_count != 0)
             {
                 Coordination::ZooKeeperResponsePtr response;
-                while (responses->tryPop(response))
-                {
-                    if (response->xid == close_xid)
-                    {
-                        LOG_DEBUG(log, "Session #{} successfully closed", session_id);
-                        return;
-                    }
+                if (!responses->tryPop(response))
+                    throw Exception(ErrorCodes::LOGICAL_ERROR, "We must have at least {} ready responses, but queue is empty. It's a bug.", result.ready_responses_count);
 
-                    if (response->error == Coordination::Error::ZOK)
-                        response->write(*out);
-                    else if (response->xid != Coordination::WATCH_XID)
-                        response->write(*out);
-                    /// skipping bad response for watch
+                if (response->xid == close_xid)
+                {
+                    LOG_DEBUG(log, "Session #{} successfully closed", session_id);
+                    return;
                 }
+
+                if (response->error == Coordination::Error::ZOK)
+                    response->write(*out);
+                else if (response->xid != Coordination::WATCH_XID)
+                    response->write(*out);
+                /// skipping bad response for watch
+                result.ready_responses_count--;
             }
 
             if (result.error)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Race example: https://clickhouse-test-reports.s3.yandex.net/0/52f570c28a2ed76742223c7fd7c081b50469b0a9/stress_test_(thread).html#fail1

The race happens during normal session close. This callback https://github.com/ClickHouse/ClickHouse/blob/master/src/Server/TestKeeperTCPHandler.cpp#L313-L318 called by `Storage` thread when a response is ready to be sent to the client. When `TestKeeperTCPHandler` sees `close` response https://github.com/ClickHouse/ClickHouse/blob/master/src/Server/TestKeeperTCPHandler.cpp#L357-L361 it just finishes (we don't need to send `close` to the client). So the race happens on callback call for `close` response. We add it to the `responses` queue and sleep for some time. At this moment `TestKeeperTCPHandler` thread pops this response from the responses queue and finishes. After that storage thread wakes up and tries to write the signaling byte into a closed descriptor: https://github.com/ClickHouse/ClickHouse/blob/master/src/Server/TestKeeperTCPHandler.cpp#L317. 
The race happened because of inconsistency between signaling pipe fd and responses queue. This fix makes them consistent (now we process only responses that were read from signaling pipe fd).