### PR TITLE
Fix error Extremes transform was already added to pipeline

### DIFF
--- a/src/Processors/QueryPipeline.cpp
+++ b/src/Processors/QueryPipeline.cpp
@@ -182,8 +182,11 @@ void QueryPipeline::addExtremesTransform()
 {
     checkInitializedAndNotCompleted();
 
+    /// It is possible that pipeline already have extremes.
+    /// For example, it may be added from VIEW subquery.
+    /// In this case, recalculate extremes again - they should be calculated for different rows.
     if (pipe.getExtremesPort())
-        throw Exception("Extremes transform was already added to pipeline.", ErrorCodes::LOGICAL_ERROR);
+        pipe.dropExtremes();
 
     resize(1);
     auto transform = std::make_shared<ExtremesTransform>(getHeader());

--- a/tests/queries/0_stateless/01660_second_extremes_bug.reference
+++ b/tests/queries/0_stateless/01660_second_extremes_bug.reference
@@ -1,0 +1,16 @@
+{
+	"meta":
+	[
+		{
+			"name": "a",
+			"type": "String"
+		}
+	],
+
+	"data":
+	[
+
+	],
+
+	"rows": 0
+}

--- a/tests/queries/0_stateless/01660_second_extremes_bug.sql
+++ b/tests/queries/0_stateless/01660_second_extremes_bug.sql
@@ -1,0 +1,10 @@
+DROP TABLE IF EXISTS t;
+DROP TABLE IF EXISTS t_v;
+
+CREATE TABLE t ( a String ) ENGINE = Memory();
+CREATE VIEW t_v AS SELECT * FROM t;
+SET output_format_write_statistics = 0;
+SELECT * FROM t_v FORMAT JSON SETTINGS extremes = 1;
+
+DROP TABLE IF EXISTS t;
+DROP TABLE IF EXISTS t_v;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible error `Extremes transform was already added to pipeline`. Fixes #14100