### PR TITLE
Remove outdated suppressions

### DIFF
--- a/tests/msan_suppressions.txt
+++ b/tests/msan_suppressions.txt
@@ -5,19 +5,9 @@ fun:__gxx_personality_*
 # it is OK. Reproduce with "select ngramDistanceCaseInsensitive(materialize(''), '')"
 fun:tolower
 
-# May be it's not OK, but suppress it to run other tests
-# Some functions in OpenSSL:
-fun:probable_prime
-fun:BN_bin2bn
-fun:BN_add_word
-fun:bn_div_fixed_top
-fun:bn_mul_words
-fun:BN_cmp
-
 # Suppress some failures in contrib so that we can enable MSan in CI.
 # Ideally, we should report these upstream.
 src:*/contrib/zlib-ng/*
-src:*/contrib/openssl/*
 src:*/contrib/simdjson/*
 src:*/contrib/lz4/*
 

--- a/tests/ubsan_suppressions.txt
+++ b/tests/ubsan_suppressions.txt
@@ -1,3 +1,1 @@
-# Suppress some failures in contrib so that we can enable UBSan in CI.
-# Ideally, we should report these upstream.
-src:*/contrib/openssl/*
+# We have no suppressions!


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Also I don't believe there is anything in `lz4`, we need to remove suppressions for it too.