### PR TITLE
Mark distributed batch as broken in case of empty data block in one of files

### DIFF
--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -54,6 +54,7 @@ namespace ErrorCodes
     extern const int UNKNOWN_PACKET_FROM_SERVER;
     extern const int SUPPORT_IS_DISABLED;
     extern const int BAD_ARGUMENTS;
+    extern const int EMPTY_DATA_PASSED;
 }
 
 
@@ -544,6 +545,9 @@ void Connection::sendData(const Block & block, const String & name, bool scalar)
 void Connection::sendPreparedData(ReadBuffer & input, size_t size, const String & name)
 {
     /// NOTE 'Throttler' is not used in this method (could use, but it's not important right now).
+
+    if (input.eof())
+        throw Exception("Buffer is empty (some kind of corruption)", ErrorCodes::EMPTY_DATA_PASSED);
 
     writeVarUInt(Protocol::Client::Data, *out);
     writeStringBinary(name, *out);

--- a/src/Storages/Distributed/DirectoryMonitor.cpp
+++ b/src/Storages/Distributed/DirectoryMonitor.cpp
@@ -46,6 +46,7 @@ namespace ErrorCodes
     extern const int CHECKSUM_DOESNT_MATCH;
     extern const int TOO_LARGE_SIZE_COMPRESSED;
     extern const int ATTEMPT_TO_READ_AFTER_EOF;
+    extern const int EMPTY_DATA_PASSED;
 }
 
 
@@ -170,6 +171,7 @@ namespace
     bool isFileBrokenErrorCode(int code, bool remote_error)
     {
         return code == ErrorCodes::CHECKSUM_DOESNT_MATCH
+            || code == ErrorCodes::EMPTY_DATA_PASSED
             || code == ErrorCodes::TOO_LARGE_SIZE_COMPRESSED
             || code == ErrorCodes::CANNOT_READ_ALL_DATA
             || code == ErrorCodes::UNKNOWN_CODEC


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Mark distributed batch as broken in case of empty data block in one of files

Detailed description / Documentation draft:
It is possible to get corruption (even though it is very unlikely, and
initially it wasn't corruption, but ignored exception - #19451) just before the data block goes in the
file on disk, and in case of batching, it will break the packets, since
it will write the packet type but will not write any data after.