### PR TITLE
Fix buffer overflow in DateLUT

### DIFF
--- a/base/common/DateLUTImpl.h
+++ b/base/common/DateLUTImpl.h
@@ -229,8 +229,12 @@ public:
 
     inline UInt8 daysInMonth(UInt16 year, UInt8 month) const
     {
+        UInt16 idx = year - DATE_LUT_MIN_YEAR;
+        if (unlikely(idx >= DATE_LUT_YEARS))
+            return 31;  /// Implementation specific behaviour on overflow.
+
         /// 32 makes arithmetic more simple.
-        DayNum any_day_of_month = DayNum(years_lut[year - DATE_LUT_MIN_YEAR] + 32 * (month - 1));
+        DayNum any_day_of_month = DayNum(years_lut[idx] + 32 * (month - 1));
         return lut[any_day_of_month].days_in_month;
     }
 

--- a/tests/queries/0_stateless/01666_date_lut_buffer_overflow.sql
+++ b/tests/queries/0_stateless/01666_date_lut_buffer_overflow.sql
@@ -1,0 +1,1 @@
+SELECT toDate('2105-12-31') + INTERVAL number MONTH FROM system.numbers LIMIT 25000 FORMAT Null;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Buffer overflow (on memory read) was possible if `addMonth` function was called with specifically crafted arguments. This fixes #19441. This fixes #19413.