### PR TITLE
Fix wrong serde of ColumnsDescription

### DIFF
--- a/tests/queries/0_stateless/01669_columns_declaration_serde.reference
+++ b/tests/queries/0_stateless/01669_columns_declaration_serde.reference
@@ -1,0 +1,3 @@
+Hello, world!
+Hello, world!
+1	\r\n\t\\\n

--- a/tests/queries/0_stateless/01669_columns_declaration_serde.reference
+++ b/tests/queries/0_stateless/01669_columns_declaration_serde.reference
@@ -1,3 +1,7 @@
 Hello, world!
 Hello, world!
 1	\r\n\t\\\n
+---
+0	\\
+---
+0	\\

--- a/tests/queries/0_stateless/01669_columns_declaration_serde.sql
+++ b/tests/queries/0_stateless/01669_columns_declaration_serde.sql
@@ -17,3 +17,24 @@ INSERT INTO test (x) VALUES (1);
 SELECT * FROM test;
 
 DROP TABLE test;
+
+DROP TABLE IF EXISTS test_r1;
+DROP TABLE IF EXISTS test_r2;
+
+CREATE TABLE test_r1 (x UInt64, "\\" String DEFAULT '\r\n\t\\' || '
+') ENGINE = ReplicatedMergeTree('/clickhouse/test', 'r1') ORDER BY "\\";
+
+INSERT INTO test_r1 ("\\") VALUES ('\\');
+
+CREATE TABLE test_r2 (x UInt64, "\\" String DEFAULT '\r\n\t\\' || '
+') ENGINE = ReplicatedMergeTree('/clickhouse/test', 'r2') ORDER BY "\\";
+
+SYSTEM SYNC REPLICA test_r2;
+
+SELECT '---';
+SELECT * FROM test_r1;
+SELECT '---';
+SELECT * FROM test_r2;
+
+DROP TABLE test_r1;
+DROP TABLE test_r2;

--- a/tests/queries/0_stateless/01669_columns_declaration_serde.sql
+++ b/tests/queries/0_stateless/01669_columns_declaration_serde.sql
@@ -1,0 +1,19 @@
+CREATE TEMPORARY TABLE test ("\\" String DEFAULT '\r\n\t\\' || '
+');
+
+INSERT INTO test VALUES ('Hello, world!');
+INSERT INTO test ("\\") VALUES ('Hello, world!');
+
+SELECT * FROM test;
+
+DROP TEMPORARY TABLE test;
+DROP TABLE IF EXISTS test;
+
+CREATE TABLE test (x UInt64, "\\" String DEFAULT '\r\n\t\\' || '
+') ENGINE = MergeTree ORDER BY x;
+
+INSERT INTO test (x) VALUES (1);
+
+SELECT * FROM test;
+
+DROP TABLE test;

--- a/tests/queries/0_stateless/arcadia_skip_list.txt
+++ b/tests/queries/0_stateless/arcadia_skip_list.txt
@@ -191,3 +191,4 @@
 01655_agg_if_nullable
 01182_materialized_view_different_structure
 01660_sum_ubsan
+01669_columns_declaration_serde


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix wrong deserialization of columns description. It makes INSERT into a table with a column named `\` impossible.


CC @alesapin 