### PR TITLE
DOCSUP-5917: CREATE QUOTA and ALTER QUOTA syntax updated

### DIFF
--- a/docs/en/operations/system-tables/quotas.md
+++ b/docs/en/operations/system-tables/quotas.md
@@ -7,16 +7,16 @@ Columns:
 - `id` ([UUID](../../sql-reference/data-types/uuid.md)) — Quota ID.
 - `storage`([String](../../sql-reference/data-types/string.md)) — Storage of quotas. Possible value: “users.xml” if a quota configured in the users.xml file, “disk” if a quota configured by an SQL-query.
 - `keys` ([Array](../../sql-reference/data-types/array.md)([Enum8](../../sql-reference/data-types/enum.md))) — Key specifies how the quota should be shared. If two connections use the same quota and key, they share the same amounts of resources. Values:
-- `[]` — All users share the same quota.
-- `['user_name']` — Connections with the same user name share the same quota.
-- `['ip_address']` — Connections from the same IP share the same quota.
-- `['client_key']` — Connections with the same key share the same quota. A key must be explicitly provided by a client. When using [clickhouse-client](../../interfaces/cli.md), pass a key value in the `--quota-key` parameter, or use the `quota_key` parameter in the client configuration file. When using HTTP interface, use the `X-ClickHouse-Quota` header.
-- `['user_name', 'client_key']` — Connections with the same `client_key` share the same quota. If a key isn’t provided by a client, the qouta is tracked for `user_name`.
-- `['client_key', 'ip_address']` — Connections with the same `client_key` share the same quota. If a key isn’t provided by a client, the qouta is tracked for `ip_address`.
+    - `[]` — All users share the same quota.
+    - `['user_name']` — Connections with the same user name share the same quota.
+    - `['ip_address']` — Connections from the same IP share the same quota.
+    - `['client_key']` — Connections with the same key share the same quota. A key must be explicitly provided by a client. When using [clickhouse-client](../../interfaces/cli.md), pass a key value in the `--quota-key` parameter, or use the `quota_key` parameter in the client configuration file. When using HTTP interface, use the `X-ClickHouse-Quota` header.
+    - `['user_name', 'client_key']` — Connections with the same `client_key` share the same quota. If a key isn’t provided by a client, the qouta is tracked for `user_name`.
+    - `['client_key', 'ip_address']` — Connections with the same `client_key` share the same quota. If a key isn’t provided by a client, the qouta is tracked for `ip_address`.
 - `durations` ([Array](../../sql-reference/data-types/array.md)([UInt64](../../sql-reference/data-types/int-uint.md))) — Time interval lengths in seconds.
 - `apply_to_all` ([UInt8](../../sql-reference/data-types/int-uint.md#uint-ranges)) — Logical value. It shows which users the quota is applied to. Values:
-- `0` — The quota applies to users specify in the `apply_to_list`.
-- `1` — The quota applies to all users except those listed in `apply_to_except`.
+    - `0` — The quota applies to users specify in the `apply_to_list`.
+    - `1` — The quota applies to all users except those listed in `apply_to_except`.
 - `apply_to_list` ([Array](../../sql-reference/data-types/array.md)([String](../../sql-reference/data-types/string.md))) — List of user names/[roles](../../operations/access-rights.md#role-management) that the quota should be applied to.
 - `apply_to_except` ([Array](../../sql-reference/data-types/array.md)([String](../../sql-reference/data-types/string.md))) — List of user names/roles that the quota should not apply to.
 

--- a/docs/en/sql-reference/statements/alter/quota.md
+++ b/docs/en/sql-reference/statements/alter/quota.md
@@ -5,16 +5,33 @@ toc_title: QUOTA
 
 # ALTER QUOTA {#alter-quota-statement}
 
-Changes quotas.
+Changes [quotas](../../../operations/access-rights.md#quotas-management).
 
 Syntax:
 
 ``` sql
 ALTER QUOTA [IF EXISTS] name [ON CLUSTER cluster_name]
     [RENAME TO new_name]
-    [KEYED BY {'none' | 'user name' | 'ip address' | 'client key' | 'client key or user name' | 'client key or ip address'}]
+    [KEYED BY {NONE | USER_NAME | IP_ADDRESS | CLIENT_KEY | CLIENT_KEY, USER_NAME | CLIENT_KEY, IP_ADDRESS} | NOT KEYED]
     [FOR [RANDOMIZED] INTERVAL number {SECOND | MINUTE | HOUR | DAY | WEEK | MONTH | QUARTER | YEAR}
-        {MAX { {QUERIES | ERRORS | RESULT ROWS | RESULT BYTES | READ ROWS | READ BYTES | EXECUTION TIME} = number } [,...] |
+        {MAX { {QUERIES | ERRORS | RESULT_ROWS | RESULT_BYTES | READ_ROWS | READ_BYTES | EXECUTION_TIME} = number } [,...] |
         NO LIMITS | TRACKING ONLY} [,...]]
     [TO {role [,...] | ALL | ALL EXCEPT role [,...]}]
+```
+Multiword key types may be written either with underscores (`CLIENT_KEY`), or with spaces and in simple quotes (`'client key'`). You may also use `'client key or user name'` instead of `CLIENT_KEY, USER_NAME`, and `'client key or ip address'` instead of `CLIENT_KEY, IP_ADDRESS`.
+
+Multiword resource types may be written either with underscores (`RESULT_ROWS`) or without them (`RESULT ROWS`). 
+
+**Examples**
+
+Limit the maximum number of queries for the current user with 123 queries in 15 months constraint:
+
+``` sql
+ALTER QUOTA IF EXISTS qA FOR INTERVAL 15 MONTH MAX QUERIES 123 TO CURRENT_USER;
+```
+
+For the default user limit the maximum execution time with half a second in 30 minutes, and limit the maximum number of queries with 321 and the maximum number of errors with 10 in 5 quaters:
+
+``` sql
+ALTER QUOTA IF EXISTS qB FOR INTERVAL 30 MINUTE MAX EXECUTION_TIME = 0.5, FOR INTERVAL 5 QUATER MAX QUERIES = 321, ERRORS = 10 TO default;
 ```

--- a/docs/en/sql-reference/statements/alter/quota.md
+++ b/docs/en/sql-reference/statements/alter/quota.md
@@ -12,15 +12,12 @@ Syntax:
 ``` sql
 ALTER QUOTA [IF EXISTS] name [ON CLUSTER cluster_name]
     [RENAME TO new_name]
-    [KEYED BY {NONE | USER_NAME | IP_ADDRESS | CLIENT_KEY | CLIENT_KEY, USER_NAME | CLIENT_KEY, IP_ADDRESS} | NOT KEYED]
+    [KEYED BY {USER_NAME | IP_ADDRESS | CLIENT_KEY | CLIENT_KEY, USER_NAME | CLIENT_KEY, IP_ADDRESS} | NOT KEYED]
     [FOR [RANDOMIZED] INTERVAL number {SECOND | MINUTE | HOUR | DAY | WEEK | MONTH | QUARTER | YEAR}
         {MAX { {QUERIES | ERRORS | RESULT_ROWS | RESULT_BYTES | READ_ROWS | READ_BYTES | EXECUTION_TIME} = number } [,...] |
         NO LIMITS | TRACKING ONLY} [,...]]
     [TO {role [,...] | ALL | ALL EXCEPT role [,...]}]
 ```
-Multiword key types may be written either with underscores (`CLIENT_KEY`), or with spaces and in simple quotes (`'client key'`). You may also use `'client key or user name'` instead of `CLIENT_KEY, USER_NAME`, and `'client key or ip address'` instead of `CLIENT_KEY, IP_ADDRESS`.
-
-Multiword resource types may be written either with underscores (`RESULT_ROWS`) or without them (`RESULT ROWS`). 
 
 **Examples**
 

--- a/docs/en/sql-reference/statements/alter/quota.md
+++ b/docs/en/sql-reference/statements/alter/quota.md
@@ -12,23 +12,28 @@ Syntax:
 ``` sql
 ALTER QUOTA [IF EXISTS] name [ON CLUSTER cluster_name]
     [RENAME TO new_name]
-    [KEYED BY {USER_NAME | IP_ADDRESS | CLIENT_KEY | CLIENT_KEY, USER_NAME | CLIENT_KEY, IP_ADDRESS} | NOT KEYED]
-    [FOR [RANDOMIZED] INTERVAL number {SECOND | MINUTE | HOUR | DAY | WEEK | MONTH | QUARTER | YEAR}
-        {MAX { {QUERIES | ERRORS | RESULT_ROWS | RESULT_BYTES | READ_ROWS | READ_BYTES | EXECUTION_TIME} = number } [,...] |
+    [KEYED BY {user_name | ip_address | client_key | client_key,user_name | client_key,ip_address} | NOT KEYED]
+    [FOR [RANDOMIZED] INTERVAL number {second | minute | hour | day | week | month | quarter | year}
+        {MAX { {queries | errors | result_rows | result_bytes | read_rows | read_bytes | execution_time} = number } [,...] |
         NO LIMITS | TRACKING ONLY} [,...]]
     [TO {role [,...] | ALL | ALL EXCEPT role [,...]}]
 ```
+Keys `user_name`, `ip_address`, `client_key`, `client_key, user_name` and `client_key, ip_address` correspond to the fields in the [system.quotas](../../../operations/system-tables/quotas.md) table.
+
+Parameters `queries`, `errors`, `result_rows`, `result_bytes`, `read_rows`, `read_bytes`, `execution_time` correspond to the fields in the [system.quotas_usage](../../../operations/system-tables/quotas_usage.md) table.
+
+`ON CLUSTER` clause allows creating quotas on a cluster, see [Distributed DDL](../../../sql-reference/distributed-ddl.md).
 
 **Examples**
 
 Limit the maximum number of queries for the current user with 123 queries in 15 months constraint:
 
 ``` sql
-ALTER QUOTA IF EXISTS qA FOR INTERVAL 15 MONTH MAX QUERIES 123 TO CURRENT_USER;
+ALTER QUOTA IF EXISTS qA FOR INTERVAL 15 month MAX queries = 123 TO CURRENT_USER;
 ```
 
 For the default user limit the maximum execution time with half a second in 30 minutes, and limit the maximum number of queries with 321 and the maximum number of errors with 10 in 5 quaters:
 
 ``` sql
-ALTER QUOTA IF EXISTS qB FOR INTERVAL 30 MINUTE MAX EXECUTION_TIME = 0.5, FOR INTERVAL 5 QUATER MAX QUERIES = 321, ERRORS = 10 TO default;
+ALTER QUOTA IF EXISTS qB FOR INTERVAL 30 minute MAX execution_time = 0.5, FOR INTERVAL 5 quarter MAX queries = 321, errors = 10 TO default;
 ```

--- a/docs/en/sql-reference/statements/create/quota.md
+++ b/docs/en/sql-reference/statements/create/quota.md
@@ -11,12 +11,16 @@ Syntax:
 
 ``` sql
 CREATE QUOTA [IF NOT EXISTS | OR REPLACE] name [ON CLUSTER cluster_name]
-    [KEYED BY {USER_NAME | IP_ADDRESS | CLIENT_KEY | CLIENT_KEY, USER_NAME | CLIENT_KEY, IP_ADDRESS} | NOT KEYED]
-    [FOR [RANDOMIZED] INTERVAL number {SECOND | MINUTE | HOUR | DAY | WEEK | MONTH | QUARTER | YEAR}
-        {MAX { {QUERIES | ERRORS | RESULT_ROWS | RESULT_BYTES | READ_ROWS | READ_BYTES | EXECUTION_TIME} = number } [,...] |
+    [KEYED BY {user_name | ip_address | client_key | client_key,user_name | client_key,ip_address} | NOT KEYED]
+    [FOR [RANDOMIZED] INTERVAL number {second | minute | hour | day | week | month | quarter | year}
+        {MAX { {queries | errors | result_rows | result_bytes | read_rows | read_bytes | execution_time} = number } [,...] |
          NO LIMITS | TRACKING ONLY} [,...]]
     [TO {role [,...] | ALL | ALL EXCEPT role [,...]}]
 ```
+
+Keys `user_name`, `ip_address`, `client_key`, `client_key, user_name` and `client_key, ip_address` correspond to the fields in the [system.quotas](../../../operations/system-tables/quotas.md) table.
+
+Parameters `queries`, `errors`, `result_rows`, `result_bytes`, `read_rows`, `read_bytes`, `execution_time` correspond to the fields in the [system.quotas_usage](../../../operations/system-tables/quotas_usage.md) table.
 
 `ON CLUSTER` clause allows creating quotas on a cluster, see [Distributed DDL](../../../sql-reference/distributed-ddl.md).
 
@@ -25,11 +29,11 @@ CREATE QUOTA [IF NOT EXISTS | OR REPLACE] name [ON CLUSTER cluster_name]
 Limit the maximum number of queries for the current user with 123 queries in 15 months constraint:
 
 ``` sql
-CREATE QUOTA qA FOR INTERVAL 15 MONTH MAX QUERIES 123 TO CURRENT_USER;
+CREATE QUOTA qA FOR INTERVAL 15 month MAX queries = 123 TO CURRENT_USER;
 ```
 
 For the default user limit the maximum execution time with half a second in 30 minutes, and limit the maximum number of queries with 321 and the maximum number of errors with 10 in 5 quaters:
 
 ``` sql
-CREATE QUOTA qB FOR INTERVAL 30 MINUTE MAX EXECUTION_TIME = 0.5, FOR INTERVAL 5 QUATER MAX QUERIES = 321, ERRORS = 10 TO default;
+CREATE QUOTA qB FOR INTERVAL 30 minute MAX execution_time = 0.5, FOR INTERVAL 5 quarter MAX queries = 321, errors = 10 TO default;
 ```

--- a/docs/en/sql-reference/statements/create/quota.md
+++ b/docs/en/sql-reference/statements/create/quota.md
@@ -19,7 +19,8 @@ CREATE QUOTA [IF NOT EXISTS | OR REPLACE] name [ON CLUSTER cluster_name]
 ```
 
 `ON CLUSTER` clause allows creating quotas on a cluster, see [Distributed DDL](../../../sql-reference/distributed-ddl.md).
-## Examples {#create-quota-example}
+
+**Examples** 
 
 Limit the maximum number of queries for the current user with 123 queries in 15 months constraint:
 

--- a/docs/en/sql-reference/statements/create/quota.md
+++ b/docs/en/sql-reference/statements/create/quota.md
@@ -11,7 +11,7 @@ Syntax:
 
 ``` sql
 CREATE QUOTA [IF NOT EXISTS | OR REPLACE] name [ON CLUSTER cluster_name]
-    [KEYED BY {NONE | USER_NAME | IP_ADDRESS | CLIENT_KEY | CLIENT_KEY, USER_NAME | CLIENT_KEY, IP_ADDRESS} | NOT KEYED]
+    [KEYED BY {USER_NAME | IP_ADDRESS | CLIENT_KEY | CLIENT_KEY, USER_NAME | CLIENT_KEY, IP_ADDRESS} | NOT KEYED]
     [FOR [RANDOMIZED] INTERVAL number {SECOND | MINUTE | HOUR | DAY | WEEK | MONTH | QUARTER | YEAR}
         {MAX { {QUERIES | ERRORS | RESULT_ROWS | RESULT_BYTES | READ_ROWS | READ_BYTES | EXECUTION_TIME} = number } [,...] |
          NO LIMITS | TRACKING ONLY} [,...]]
@@ -19,21 +19,6 @@ CREATE QUOTA [IF NOT EXISTS | OR REPLACE] name [ON CLUSTER cluster_name]
 ```
 
 `ON CLUSTER` clause allows creating quotas on a cluster, see [Distributed DDL](../../../sql-reference/distributed-ddl.md).
-
-Multiword key types may be written either with underscores (`CLIENT_KEY`), or with spaces and in simple quotes (`'client key'`). You may also use `'client key or user name'` instead of `CLIENT_KEY, USER_NAME`, and `'client key or ip address'` instead of `CLIENT_KEY, IP_ADDRESS`.
-
-Multiword resource types may be written either with underscores (`RESULT_ROWS`) or without them (`RESULT ROWS`). 
-## Example {#create-quota-example}
-
-Limit the maximum number of queries for the current user with 123 queries in 15 months constraint:
-
-``` sql
-CREATE QUOTA qA FOR INTERVAL 15 MONTH MAX QUERIES 123 TO CURRENT_USER
-```
-Multiword key types may be written either with underscores (`CLIENT_KEY`), or with spaces and in simple quotes (`'client key'`). You can also use `'client key or user name'` instead of `CLIENT_KEY, USER_NAME`, and `'client key or ip address'` instead of `CLIENT_KEY, IP_ADDRESS`.
-
-Multiword resource types may be written either with underscores (`RESULT_ROWS`) or without them (`RESULT ROWS`). 
-
 ## Examples {#create-quota-example}
 
 Limit the maximum number of queries for the current user with 123 queries in 15 months constraint:

--- a/docs/en/sql-reference/statements/create/quota.md
+++ b/docs/en/sql-reference/statements/create/quota.md
@@ -11,19 +11,39 @@ Syntax:
 
 ``` sql
 CREATE QUOTA [IF NOT EXISTS | OR REPLACE] name [ON CLUSTER cluster_name]
-    [KEYED BY {'none' | 'user name' | 'ip address' | 'forwarded ip address' | 'client key' | 'client key or user name' | 'client key or ip address'}]
+    [KEYED BY {NONE | USER_NAME | IP_ADDRESS | CLIENT_KEY | CLIENT_KEY, USER_NAME | CLIENT_KEY, IP_ADDRESS} | NOT KEYED]
     [FOR [RANDOMIZED] INTERVAL number {SECOND | MINUTE | HOUR | DAY | WEEK | MONTH | QUARTER | YEAR}
-        {MAX { {QUERIES | ERRORS | RESULT ROWS | RESULT BYTES | READ ROWS | READ BYTES | EXECUTION TIME} = number } [,...] |
+        {MAX { {QUERIES | ERRORS | RESULT_ROWS | RESULT_BYTES | READ_ROWS | READ_BYTES | EXECUTION_TIME} = number } [,...] |
          NO LIMITS | TRACKING ONLY} [,...]]
     [TO {role [,...] | ALL | ALL EXCEPT role [,...]}]
 ```
 
 `ON CLUSTER` clause allows creating quotas on a cluster, see [Distributed DDL](../../../sql-reference/distributed-ddl.md).
 
+Multiword key types may be written either with underscores (`CLIENT_KEY`), or with spaces and in simple quotes (`'client key'`). You may also use `'client key or user name'` instead of `CLIENT_KEY, USER_NAME`, and `'client key or ip address'` instead of `CLIENT_KEY, IP_ADDRESS`.
+
+Multiword resource types may be written either with underscores (`RESULT_ROWS`) or without them (`RESULT ROWS`). 
 ## Example {#create-quota-example}
 
 Limit the maximum number of queries for the current user with 123 queries in 15 months constraint:
 
 ``` sql
 CREATE QUOTA qA FOR INTERVAL 15 MONTH MAX QUERIES 123 TO CURRENT_USER
+```
+Multiword key types may be written either with underscores (`CLIENT_KEY`), or with spaces and in simple quotes (`'client key'`). You can also use `'client key or user name'` instead of `CLIENT_KEY, USER_NAME`, and `'client key or ip address'` instead of `CLIENT_KEY, IP_ADDRESS`.
+
+Multiword resource types may be written either with underscores (`RESULT_ROWS`) or without them (`RESULT ROWS`). 
+
+## Examples {#create-quota-example}
+
+Limit the maximum number of queries for the current user with 123 queries in 15 months constraint:
+
+``` sql
+CREATE QUOTA qA FOR INTERVAL 15 MONTH MAX QUERIES 123 TO CURRENT_USER;
+```
+
+For the default user limit the maximum execution time with half a second in 30 minutes, and limit the maximum number of queries with 321 and the maximum number of errors with 10 in 5 quaters:
+
+``` sql
+CREATE QUOTA qB FOR INTERVAL 30 MINUTE MAX EXECUTION_TIME = 0.5, FOR INTERVAL 5 QUATER MAX QUERIES = 321, ERRORS = 10 TO default;
 ```

--- a/docs/ru/sql-reference/statements/alter/quota.md
+++ b/docs/ru/sql-reference/statements/alter/quota.md
@@ -12,25 +12,31 @@ toc_title: QUOTA
 ``` sql
 ALTER QUOTA [IF EXISTS] name [ON CLUSTER cluster_name]
     [RENAME TO new_name]
-    [KEYED BY {USER_NAME | IP_ADDRESS | CLIENT_KEY | CLIENT_KEY, USER_NAME | CLIENT_KEY, IP_ADDRESS} | NOT KEYED]
-    [FOR [RANDOMIZED] INTERVAL number {SECOND | MINUTE | HOUR | DAY | WEEK | MONTH | QUARTER | YEAR}
-        {MAX { {QUERIES | ERRORS | RESULT_ROWS | RESULT_BYTES | READ_ROWS | READ_BYTES | EXECUTION_TIME} = number } [,...] |
+    [KEYED BY {user_name | ip_address | client_key | client_key,user_name | client_key,ip_address} | NOT KEYED]
+    [FOR [RANDOMIZED] INTERVAL number {second | minute | hour | day | week | month | quarter | year}
+        {MAX { {queries | errors | result_rows | result_bytes | read_rows | read_bytes | execution_time} = number } [,...] |
         NO LIMITS | TRACKING ONLY} [,...]]
     [TO {role [,...] | ALL | ALL EXCEPT role [,...]}]
 ```
+
+Ключи `user_name`, `ip_address`, `client_key`, `client_key, user_name` и `client_key, ip_address` соответствуют полям таблицы [system.quotas](../../../operations/system-tables/quotas.md).
+
+Параметры `queries`, `errors`, `result_rows`, `result_bytes`, `read_rows`, `read_bytes`, `execution_time` соответствуют полям таблицы [system.quotas_usage](../../../operations/system-tables/quotas_usage.md).
+
+В секции `ON CLUSTER` можно указать кластеры, на которых создается квота, см. [Распределенные DDL запросы](../../../sql-reference/distributed-ddl.md).
 
 **Примеры**
 
 Ограничить для текущего пользователя максимальное число запросов — не более 123 запросов за каждые 15 месяцев:
 
 ``` sql
-ALTER QUOTA IF EXISTS qA FOR INTERVAL 15 MONTH MAX QUERIES 123 TO CURRENT_USER;
+ALTER QUOTA IF EXISTS qA FOR INTERVAL 15 month MAX queries = 123 TO CURRENT_USER;
 ```
 
 Ограничить по умолчанию максимальное время выполнения запроса — не более полсекунды за каждые 30 минут, а также максимальное число запросов — не более 321 и максимальное число ошибок — не более 10 за каждые 5 кварталов:
 
 ``` sql
-ALTER QUOTA IF EXISTS qB FOR INTERVAL 30 MINUTE MAX EXECUTION_TIME = 0.5, FOR INTERVAL 5 QUATER MAX QUERIES = 321, ERRORS = 10 TO default;
+ALTER QUOTA IF EXISTS qB FOR INTERVAL 30 minute MAX execution_time = 0.5, FOR INTERVAL 5 quarter MAX queries = 321, errors = 10 TO default;
 ```
 
 [Оригинальная статья](https://clickhouse.tech/docs/ru/sql-reference/alter/quota/) <!--hide-->

--- a/docs/ru/sql-reference/statements/alter/quota.md
+++ b/docs/ru/sql-reference/statements/alter/quota.md
@@ -12,15 +12,12 @@ toc_title: QUOTA
 ``` sql
 ALTER QUOTA [IF EXISTS] name [ON CLUSTER cluster_name]
     [RENAME TO new_name]
-    [KEYED BY {NONE | USER_NAME | IP_ADDRESS | CLIENT_KEY | CLIENT_KEY, USER_NAME | CLIENT_KEY, IP_ADDRESS} | NOT KEYED]
+    [KEYED BY {USER_NAME | IP_ADDRESS | CLIENT_KEY | CLIENT_KEY, USER_NAME | CLIENT_KEY, IP_ADDRESS} | NOT KEYED]
     [FOR [RANDOMIZED] INTERVAL number {SECOND | MINUTE | HOUR | DAY | WEEK | MONTH | QUARTER | YEAR}
         {MAX { {QUERIES | ERRORS | RESULT_ROWS | RESULT_BYTES | READ_ROWS | READ_BYTES | EXECUTION_TIME} = number } [,...] |
         NO LIMITS | TRACKING ONLY} [,...]]
     [TO {role [,...] | ALL | ALL EXCEPT role [,...]}]
 ```
-Поддерживаются два варианта написания составных типов ключей: с подчеркиванием (`CLIENT_KEY`) или через пробел и в одинарных кавычках (`'client key'`). Также можно использовать ключ `'client key or user name'` вместо `CLIENT_KEY, USER_NAME`, и ключ `'client key or ip address'` вместо `CLIENT_KEY, IP_ADDRESS`.
-
-Поддерживаются также два варианта написания составных типов ресурсов: с подчеркиванием (`RESULT_ROWS`) или без подчеркивания, через пробел (`RESULT ROWS`). 
 
 **Примеры**
 

--- a/docs/ru/sql-reference/statements/alter/quota.md
+++ b/docs/ru/sql-reference/statements/alter/quota.md
@@ -5,18 +5,35 @@ toc_title: QUOTA
 
 # ALTER QUOTA {#alter-quota-statement}
 
-Изменяет квоту.
+Изменяет [квоту](../../../operations/access-rights.md#quotas-management).
 
-## Синтаксис {#alter-quota-syntax}
+Синтаксис:
 
 ``` sql
 ALTER QUOTA [IF EXISTS] name [ON CLUSTER cluster_name]
     [RENAME TO new_name]
-    [KEYED BY {'none' | 'user name' | 'ip address' | 'client key' | 'client key or user name' | 'client key or ip address'}]
+    [KEYED BY {NONE | USER_NAME | IP_ADDRESS | CLIENT_KEY | CLIENT_KEY, USER_NAME | CLIENT_KEY, IP_ADDRESS} | NOT KEYED]
     [FOR [RANDOMIZED] INTERVAL number {SECOND | MINUTE | HOUR | DAY | WEEK | MONTH | QUARTER | YEAR}
-        {MAX { {QUERIES | ERRORS | RESULT ROWS | RESULT BYTES | READ ROWS | READ BYTES | EXECUTION TIME} = number } [,...] |
+        {MAX { {QUERIES | ERRORS | RESULT_ROWS | RESULT_BYTES | READ_ROWS | READ_BYTES | EXECUTION_TIME} = number } [,...] |
         NO LIMITS | TRACKING ONLY} [,...]]
     [TO {role [,...] | ALL | ALL EXCEPT role [,...]}]
 ```
+Поддерживаются два варианта написания составных типов ключей: с подчеркиванием (`CLIENT_KEY`) или через пробел и в одинарных кавычках (`'client key'`). Также можно использовать ключ `'client key or user name'` вместо `CLIENT_KEY, USER_NAME`, и ключ `'client key or ip address'` вместо `CLIENT_KEY, IP_ADDRESS`.
 
-[Оригинальная статья](https://clickhouse.tech/docs/ru/query_language/alter/quota/) <!--hide-->
+Поддерживаются также два варианта написания составных типов ресурсов: с подчеркиванием (`RESULT_ROWS`) или без подчеркивания, через пробел (`RESULT ROWS`). 
+
+**Примеры**
+
+Ограничить для текущего пользователя максимальное число запросов — не более 123 запросов за каждые 15 месяцев:
+
+``` sql
+ALTER QUOTA IF EXISTS qA FOR INTERVAL 15 MONTH MAX QUERIES 123 TO CURRENT_USER;
+```
+
+Ограничить по умолчанию максимальное время выполнения запроса — не более полсекунды за каждые 30 минут, а также максимальное число запросов — не более 321 и максимальное число ошибок — не более 10 за каждые 5 кварталов:
+
+``` sql
+ALTER QUOTA IF EXISTS qB FOR INTERVAL 30 MINUTE MAX EXECUTION_TIME = 0.5, FOR INTERVAL 5 QUATER MAX QUERIES = 321, ERRORS = 10 TO default;
+```
+
+[Оригинальная статья](https://clickhouse.tech/docs/ru/sql-reference/alter/quota/) <!--hide-->

--- a/docs/ru/sql-reference/statements/create/quota.md
+++ b/docs/ru/sql-reference/statements/create/quota.md
@@ -11,7 +11,7 @@ toc_title: "\u041a\u0432\u043e\u0442\u0430"
 
 ``` sql
 CREATE QUOTA [IF NOT EXISTS | OR REPLACE] name [ON CLUSTER cluster_name]
-    [KEYED BY {NONE | USER_NAME | IP_ADDRESS | CLIENT_KEY | CLIENT_KEY, USER_NAME | CLIENT_KEY, IP_ADDRESS} | NOT KEYED]
+    [KEYED BY {USER_NAME | IP_ADDRESS | CLIENT_KEY | CLIENT_KEY, USER_NAME | CLIENT_KEY, IP_ADDRESS} | NOT KEYED]
     [FOR [RANDOMIZED] INTERVAL number {SECOND | MINUTE | HOUR | DAY | WEEK | MONTH | QUARTER | YEAR}
         {MAX { {QUERIES | ERRORS | RESULT_ROWS | RESULT_BYTES | READ_ROWS | READ_BYTES | EXECUTION_TIME} = number } [,...] |
          NO LIMITS | TRACKING ONLY} [,...]]
@@ -19,10 +19,6 @@ CREATE QUOTA [IF NOT EXISTS | OR REPLACE] name [ON CLUSTER cluster_name]
 ```
 
 В секции `ON CLUSTER` можно указать кластеры, на которых создается квота, см. [Распределенные DDL запросы](../../../sql-reference/distributed-ddl.md).
-
-Поддерживаются два варианта написания составных типов ключей: с подчеркиванием (`CLIENT_KEY`) или через пробел и в одинарных кавычках (`'client key'`). Также можно использовать ключ `'client key or user name'` вместо `CLIENT_KEY, USER_NAME`, и ключ `'client key or ip address'` вместо `CLIENT_KEY, IP_ADDRESS`.
-
-Поддерживаются также два варианта написания составных типов ресурсов: с подчеркиванием (`RESULT_ROWS`) или без подчеркивания, через пробел (`RESULT ROWS`). 
 
 **Примеры**
 

--- a/docs/ru/sql-reference/statements/create/quota.md
+++ b/docs/ru/sql-reference/statements/create/quota.md
@@ -7,23 +7,35 @@ toc_title: "\u041a\u0432\u043e\u0442\u0430"
 
 Создает [квоту](../../../operations/access-rights.md#quotas-management), которая может быть присвоена пользователю или роли.
 
-### Синтаксис {#create-quota-syntax}
+Синтаксис:
 
 ``` sql
 CREATE QUOTA [IF NOT EXISTS | OR REPLACE] name [ON CLUSTER cluster_name]
-    [KEYED BY {'none' | 'user name' | 'ip address' | 'client key' | 'client key or user name' | 'client key or ip address'}]
+    [KEYED BY {NONE | USER_NAME | IP_ADDRESS | CLIENT_KEY | CLIENT_KEY, USER_NAME | CLIENT_KEY, IP_ADDRESS} | NOT KEYED]
     [FOR [RANDOMIZED] INTERVAL number {SECOND | MINUTE | HOUR | DAY | WEEK | MONTH | QUARTER | YEAR}
-        {MAX { {QUERIES | ERRORS | RESULT ROWS | RESULT BYTES | READ ROWS | READ BYTES | EXECUTION TIME} = number } [,...] |
+        {MAX { {QUERIES | ERRORS | RESULT_ROWS | RESULT_BYTES | READ_ROWS | READ_BYTES | EXECUTION_TIME} = number } [,...] |
          NO LIMITS | TRACKING ONLY} [,...]]
     [TO {role [,...] | ALL | ALL EXCEPT role [,...]}]
 ```
 
-### Пример {#create-quota-example}
+В секции `ON CLUSTER` можно указать кластеры, на которых создается квота, см. [Распределенные DDL запросы](../../../sql-reference/distributed-ddl.md).
 
-Ограничить максимальное количество запросов для текущего пользователя до 123 запросов каждые 15 месяцев:
+Поддерживаются два варианта написания составных типов ключей: с подчеркиванием (`CLIENT_KEY`) или через пробел и в одинарных кавычках (`'client key'`). Также можно использовать ключ `'client key or user name'` вместо `CLIENT_KEY, USER_NAME`, и ключ `'client key or ip address'` вместо `CLIENT_KEY, IP_ADDRESS`.
+
+Поддерживаются также два варианта написания составных типов ресурсов: с подчеркиванием (`RESULT_ROWS`) или без подчеркивания, через пробел (`RESULT ROWS`). 
+
+**Примеры**
+
+Ограничить максимальное количество запросов для текущего пользователя — не более 123 запросов за каждые 15 месяцев:
 
 ``` sql
-CREATE QUOTA qA FOR INTERVAL 15 MONTH MAX QUERIES 123 TO CURRENT_USER
+CREATE QUOTA qA FOR INTERVAL 15 MONTH MAX QUERIES 123 TO CURRENT_USER;
+```
+
+Ограничить по умолчанию максимальное время выполнения запроса — не более полсекунды за каждые 30 минут, а также максимальное число запросов — не более 321 и максимальное число ошибок — не более 10 за каждые 5 кварталов:
+
+``` sql
+CREATE QUOTA qB FOR INTERVAL 30 MINUTE MAX EXECUTION_TIME = 0.5, FOR INTERVAL 5 QUATER MAX QUERIES = 321, ERRORS = 10 TO default;
 ```
 
 [Оригинальная статья](https://clickhouse.tech/docs/ru/sql-reference/statements/create/quota) 

--- a/docs/ru/sql-reference/statements/create/quota.md
+++ b/docs/ru/sql-reference/statements/create/quota.md
@@ -11,12 +11,15 @@ toc_title: "\u041a\u0432\u043e\u0442\u0430"
 
 ``` sql
 CREATE QUOTA [IF NOT EXISTS | OR REPLACE] name [ON CLUSTER cluster_name]
-    [KEYED BY {USER_NAME | IP_ADDRESS | CLIENT_KEY | CLIENT_KEY, USER_NAME | CLIENT_KEY, IP_ADDRESS} | NOT KEYED]
-    [FOR [RANDOMIZED] INTERVAL number {SECOND | MINUTE | HOUR | DAY | WEEK | MONTH | QUARTER | YEAR}
-        {MAX { {QUERIES | ERRORS | RESULT_ROWS | RESULT_BYTES | READ_ROWS | READ_BYTES | EXECUTION_TIME} = number } [,...] |
+    [KEYED BY {user_name | ip_address | client_key | client_key, user_name | client_key, ip_address} | NOT KEYED]
+    [FOR [RANDOMIZED] INTERVAL number {second | minute | hour | day | week | month | quarter | year}
+        {MAX { {queries | errors | result_rows | result_bytes | read_rows | read_bytes | execution_time} = number } [,...] |
          NO LIMITS | TRACKING ONLY} [,...]]
     [TO {role [,...] | ALL | ALL EXCEPT role [,...]}]
 ```
+Ключи `user_name`, `ip_address`, `client_key`, `client_key, user_name` и `client_key, ip_address` соответствуют полям таблицы [system.quotas](../../../operations/system-tables/quotas.md).
+
+Параметры `queries`, `errors`, `result_rows`, `result_bytes`, `read_rows`, `read_bytes`, `execution_time` соответствуют полям таблицы [system.quotas_usage](../../../operations/system-tables/quotas_usage.md).
 
 В секции `ON CLUSTER` можно указать кластеры, на которых создается квота, см. [Распределенные DDL запросы](../../../sql-reference/distributed-ddl.md).
 
@@ -25,13 +28,13 @@ CREATE QUOTA [IF NOT EXISTS | OR REPLACE] name [ON CLUSTER cluster_name]
 Ограничить максимальное количество запросов для текущего пользователя — не более 123 запросов за каждые 15 месяцев:
 
 ``` sql
-CREATE QUOTA qA FOR INTERVAL 15 MONTH MAX QUERIES 123 TO CURRENT_USER;
+CREATE QUOTA qA FOR INTERVAL 15 month MAX queries = 123 TO CURRENT_USER;
 ```
 
 Ограничить по умолчанию максимальное время выполнения запроса — не более полсекунды за каждые 30 минут, а также максимальное число запросов — не более 321 и максимальное число ошибок — не более 10 за каждые 5 кварталов:
 
 ``` sql
-CREATE QUOTA qB FOR INTERVAL 30 MINUTE MAX EXECUTION_TIME = 0.5, FOR INTERVAL 5 QUATER MAX QUERIES = 321, ERRORS = 10 TO default;
+CREATE QUOTA qB FOR INTERVAL 30 minute MAX execution_time = 0.5, FOR INTERVAL 5 quarter MAX queries = 321, errors = 10 TO default;
 ```
 
 [Оригинальная статья](https://clickhouse.tech/docs/ru/sql-reference/statements/create/quota) 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Documentation for #11670 (part 3 CREATE|ALTER QUOTA)