### PR TITLE
Docs - isIPv4String, isIPv6String functions

### DIFF
--- a/docs/en/sql-reference/functions/ip-address-functions.md
+++ b/docs/en/sql-reference/functions/ip-address-functions.md
@@ -251,13 +251,9 @@ Determines if the input string is an IPv4 address or not. Returns `1` if true `0
 ``` sql
 SELECT isIPv4String('127.0.0.1')
 
-Query id: 031fdb77-fa98-456e-9323-c68c7788fdde
-
 ┌─isIPv4String('127.0.0.1')─┐
 │                         1 │
 └───────────────────────────┘
-
-1 rows in set. Elapsed: 0.009 sec. 
 ```
 
 ## isIPv6String
@@ -267,13 +263,9 @@ Determines if the input string is an IPv6 address or not. Returns `1` if true `0
 ``` sql
 SELECT isIPv6String('2001:438:ffff::407d:1bc1')
 
-Query id: f8e3cd94-b1f6-4f3b-bfd6-955b6e3d278d
-
 ┌─isIPv6String('2001:438:ffff::407d:1bc1')─┐
 │                                        1 │
 └──────────────────────────────────────────┘
-
-1 rows in set. Elapsed: 0.009 sec. 
 ```
 
 [Original article](https://clickhouse.tech/docs/en/query_language/functions/ip_address_functions/) <!--hide-->

--- a/docs/en/sql-reference/functions/ip-address-functions.md
+++ b/docs/en/sql-reference/functions/ip-address-functions.md
@@ -243,4 +243,37 @@ SELECT
 └───────────────────────────────────┴──────────────────────────────────┘
 ```
 
+
+## isIPv4String
+
+Determines if the input string is an IPv4 address or not. Returns `1` if true `0` otherwise.
+
+``` sql
+SELECT isIPv4String('127.0.0.1')
+
+Query id: 031fdb77-fa98-456e-9323-c68c7788fdde
+
+┌─isIPv4String('127.0.0.1')─┐
+│                         1 │
+└───────────────────────────┘
+
+1 rows in set. Elapsed: 0.009 sec. 
+```
+
+## isIPv6String
+
+Determines if the input string is an IPv6 address or not. Returns `1` if true `0` otherwise.
+
+``` sql
+SELECT isIPv6String('2001:438:ffff::407d:1bc1')
+
+Query id: f8e3cd94-b1f6-4f3b-bfd6-955b6e3d278d
+
+┌─isIPv6String('2001:438:ffff::407d:1bc1')─┐
+│                                        1 │
+└──────────────────────────────────────────┘
+
+1 rows in set. Elapsed: 0.009 sec. 
+```
+
 [Original article](https://clickhouse.tech/docs/en/query_language/functions/ip_address_functions/) <!--hide-->

--- a/docs/en/sql-reference/functions/ip-address-functions.md
+++ b/docs/en/sql-reference/functions/ip-address-functions.md
@@ -250,7 +250,9 @@ Determines if the input string is an IPv4 address or not. Returns `1` if true `0
 
 ``` sql
 SELECT isIPv4String('127.0.0.1')
+```
 
+``` text
 ┌─isIPv4String('127.0.0.1')─┐
 │                         1 │
 └───────────────────────────┘
@@ -262,7 +264,9 @@ Determines if the input string is an IPv6 address or not. Returns `1` if true `0
 
 ``` sql
 SELECT isIPv6String('2001:438:ffff::407d:1bc1')
+```
 
+``` text
 ┌─isIPv6String('2001:438:ffff::407d:1bc1')─┐
 │                                        1 │
 └──────────────────────────────────────────┘


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):



Detailed description / Documentation draft:

This PR documents and explains the use of the functions `isIPv4String`
and `isIPv6String`.

Related to: #18349