### PR TITLE
Remove outdated suppressions, part 2

### DIFF
--- a/tests/msan_suppressions.txt
+++ b/tests/msan_suppressions.txt
@@ -9,7 +9,6 @@ fun:tolower
 # Ideally, we should report these upstream.
 src:*/contrib/zlib-ng/*
 src:*/contrib/simdjson/*
-src:*/contrib/lz4/*
 
 # Hyperscan
 fun:roseRunProgram


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)
