### PR TITLE
toIPv6 function parses IPv4 addresses

### DIFF
--- a/docs/en/sql-reference/functions/ip-address-functions.md
+++ b/docs/en/sql-reference/functions/ip-address-functions.md
@@ -115,8 +115,19 @@ LIMIT 10
 
 ## IPv6StringToNum(s) {#ipv6stringtonums}
 
-The reverse function of IPv6NumToString. If the IPv6 address has an invalid format, it returns a string of null bytes.
+The reverse function of IPv6NumToString. If the IPv6 address has an invalid format, it returns a string of null bytes. 
+If the IP address is a valid IPv4 address then the IPv6 equivalent of the IPv4 address is returned.
 HEX can be uppercase or lowercase.
+
+``` sql
+SELECT cutIPv6(IPv6StringToNum('127.0.0.1'), 0, 0);
+```
+
+``` text
+┌─cutIPv6(IPv6StringToNum('127.0.0.1'), 0, 0)─┐
+│ ::ffff:127.0.0.1                            │
+└─────────────────────────────────────────────┘
+```
 
 ## IPv4ToIPv6(x) {#ipv4toipv6x}
 
@@ -214,6 +225,7 @@ SELECT
 ## toIPv6(string) {#toipv6string}
 
 An alias to `IPv6StringToNum()` that takes a string form of IPv6 address and returns value of [IPv6](../../sql-reference/data-types/domains/ipv6.md) type, which is binary equal to value returned by `IPv6StringToNum()`.
+If the IP address is a valid IPv4 address then the IPv6 equivalent of the IPv4 address is returned.
 
 ``` sql
 WITH
@@ -243,6 +255,15 @@ SELECT
 └───────────────────────────────────┴──────────────────────────────────┘
 ```
 
+``` sql
+SELECT toIPv6('127.0.0.1')
+```
+
+``` text
+┌─toIPv6('127.0.0.1')─┐
+│ ::ffff:127.0.0.1    │
+└─────────────────────┘
+```
 
 ## isIPv4String
 

--- a/src/Functions/FunctionsCoding.h
+++ b/src/Functions/FunctionsCoding.h
@@ -297,21 +297,21 @@ public:
                  out_offset < vec_res.size();
                  out_offset += IPV6_BINARY_LENGTH, ++i)
             {
+                auto src_string = std::string(reinterpret_cast<const char *>(&vec_src[src_offset]));
+                auto out = reinterpret_cast<unsigned char *>(&vec_res[out_offset]);
+                auto subnet_prefix = std::string("::ffff:");
+
+                /// If the source IP address is parsable as an IPv4 address, then transform it into a valid IPv6 address.
+                /// Keeping it simple by just prefixing `::ffff:` to the IPv4 address to represent it as a valid IPv6 address.
+                if (DB::parseIPv4(src_string.c_str(), out))
+                {
+                    src_string = subnet_prefix + src_string;
+                }
                 /// In case of failure, the function fills vec_res with zero bytes.
-                String result;
-                auto src = reinterpret_cast<const char *>(&vec_src[src_offset]);
-                auto res = reinterpret_cast<unsigned char *>(&vec_res[out_offset]);
-                if (DB::parseIPv4(reinterpret_cast<const char *>(&vec_src[src_offset]), reinterpret_cast<unsigned char *>(&result)))
-                {
-                    auto ipv4_src = std::string("::ffff:") + std::string(src);
-                    parseIPv6(ipv4_src.c_str(), res);
-                }
-                else
-                {
-                    parseIPv6(src, res);
-                }
+                parseIPv6(src_string.c_str(), out);
                 src_offset = offsets_src[i];
             }
+
             return col_res;
         }
         else

--- a/src/Functions/FunctionsCoding.h
+++ b/src/Functions/FunctionsCoding.h
@@ -298,6 +298,7 @@ public:
             const ColumnString::Chars & vec_src = col_in->getChars();
             const ColumnString::Offsets & offsets_src = col_in->getOffsets();
             size_t src_offset = 0;
+            char src_ipv4_buf[sizeof("::ffff:") + IPV4_MAX_TEXT_LENGTH + 1] = "::ffff:";
 
             for (size_t out_offset = 0, i = 0; out_offset < vec_res.size(); out_offset += IPV6_BINARY_LENGTH, ++i)
             {
@@ -307,8 +308,10 @@ public:
                 /// Keeping it simple by just prefixing `::ffff:` to the IPv4 address to represent it as a valid IPv6 address.
                 if (tryParseIPv4(reinterpret_cast<const char *>(&vec_src[src_offset])))
                 {
-                    char src_ipv4_buf[sizeof("::ffff:") + IPV4_MAX_TEXT_LENGTH + 1] = "::ffff:";
-                    std::strcat(src_ipv4_buf, reinterpret_cast<const char *>(&vec_src[src_offset]));
+                    std::memcpy(
+                        src_ipv4_buf + std::strlen("::ffff:"),
+                        reinterpret_cast<const char *>(&vec_src[src_offset]),
+                        std::strlen(reinterpret_cast<const char *>(&vec_src[src_offset])));
                     parseIPv6(src_ipv4_buf, reinterpret_cast<unsigned char *>(&vec_res[out_offset]));
                 }
                 else

--- a/src/Functions/FunctionsCoding.h
+++ b/src/Functions/FunctionsCoding.h
@@ -299,16 +299,17 @@ public:
             {
                 /// In case of failure, the function fills vec_res with zero bytes.
                 String result;
-
+                auto src = reinterpret_cast<const char *>(&vec_src[src_offset]);
+                auto res = reinterpret_cast<unsigned char *>(&vec_res[out_offset]);
                 if (DB::parseIPv4(reinterpret_cast<const char *>(&vec_src[src_offset]), reinterpret_cast<unsigned char *>(&result)))
                 {
-                    result = std::string("::ffff:") + std::string(vec_src.raw_data());
+                    auto ipv4_src = std::string("::ffff:") + std::string(src);
+                    parseIPv6(ipv4_src.c_str(), res);
                 }
                 else
                 {
-                    result = std::string(vec_res.raw_data());
+                    parseIPv6(src, res);
                 }
-                parseIPv6(reinterpret_cast<const char *>(&result), reinterpret_cast<unsigned char *>(&vec_res[out_offset]));
                 src_offset = offsets_src[i];
             }
             return col_res;

--- a/src/Functions/FunctionsCoding.h
+++ b/src/Functions/FunctionsCoding.h
@@ -298,10 +298,19 @@ public:
                  out_offset += IPV6_BINARY_LENGTH, ++i)
             {
                 /// In case of failure, the function fills vec_res with zero bytes.
-                parseIPv6(reinterpret_cast<const char *>(&vec_src[src_offset]), reinterpret_cast<unsigned char *>(&vec_res[out_offset]));
+                String result;
+
+                if (DB::parseIPv4(reinterpret_cast<const char *>(&vec_src[src_offset]), reinterpret_cast<unsigned char *>(&result)))
+                {
+                    result = std::string("::ffff:") + std::string(vec_src.raw_data());
+                }
+                else
+                {
+                    result = std::string(vec_res.raw_data());
+                }
+                parseIPv6(reinterpret_cast<const char *>(&result), reinterpret_cast<unsigned char *>(&vec_res[out_offset]));
                 src_offset = offsets_src[i];
             }
-
             return col_res;
         }
         else

--- a/src/Functions/FunctionsCoding.h
+++ b/src/Functions/FunctionsCoding.h
@@ -301,9 +301,7 @@ public:
             const ColumnString::Offsets & offsets_src = col_in->getOffsets();
             size_t src_offset = 0;
 
-            char subnet_prefix[] = "::ffff:";
-            char src_ipv4_buf[sizeof(subnet_prefix) + IPV4_MAX_TEXT_LENGTH + 1];
-            strcpy(src_ipv4_buf, subnet_prefix);
+            char src_ipv4_buf[sizeof("::ffff:") + IPV4_MAX_TEXT_LENGTH + 1] = "::ffff:";
 
             for (size_t out_offset = 0, i = 0; out_offset < vec_res.size(); out_offset += IPV6_BINARY_LENGTH, ++i)
             {

--- a/src/Functions/FunctionsCoding.h
+++ b/src/Functions/FunctionsCoding.h
@@ -311,7 +311,7 @@ public:
                     std::memcpy(
                         src_ipv4_buf + std::strlen("::ffff:"),
                         reinterpret_cast<const char *>(&vec_src[src_offset]),
-                        std::strlen(reinterpret_cast<const char *>(&vec_src[src_offset])));
+                        std::min(offsets_src[i] - src_offset, IPV4_MAX_TEXT_LENGTH + 1));
                     parseIPv6(src_ipv4_buf, reinterpret_cast<unsigned char *>(&vec_res[out_offset]));
                 }
                 else

--- a/src/Functions/FunctionsCoding.h
+++ b/src/Functions/FunctionsCoding.h
@@ -311,7 +311,7 @@ public:
                     std::memcpy(
                         src_ipv4_buf + std::strlen("::ffff:"),
                         reinterpret_cast<const char *>(&vec_src[src_offset]),
-                        std::min(offsets_src[i] - src_offset, IPV4_MAX_TEXT_LENGTH + 1));
+                        std::min<UInt64>(offsets_src[i] - src_offset, IPV4_MAX_TEXT_LENGTH + 1));
                     parseIPv6(src_ipv4_buf, reinterpret_cast<unsigned char *>(&vec_res[out_offset]));
                 }
                 else

--- a/tests/queries/0_stateless/00725_ipv4_ipv6_domains.reference
+++ b/tests/queries/0_stateless/00725_ipv4_ipv6_domains.reference
@@ -49,5 +49,16 @@ FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF is ipv6 string: 	1
 ::ffff:127.0.0.1 is ipv6 string:                        	1
 ::ffff:8.8.8.8 is ipv6 string:                          	1
 2001:0DB8:AC10:FE01:FEED:BABE:CAFE:F00D is ipv6 string: 	1
+::ffff:0.0.0.0
 ::ffff:127.0.0.1
 ::ffff:127.0.0.1
+::ffff:127.0.0.0
+::ffff:127.0.0.1
+::ffff:127.0.0.2
+::ffff:127.0.0.3
+::ffff:127.0.0.4
+::ffff:127.0.0.5
+::ffff:127.0.0.6
+::ffff:127.0.0.7
+::ffff:127.0.0.8
+::ffff:127.0.0.9

--- a/tests/queries/0_stateless/00725_ipv4_ipv6_domains.reference
+++ b/tests/queries/0_stateless/00725_ipv4_ipv6_domains.reference
@@ -49,3 +49,5 @@ FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF is ipv6 string: 	1
 ::ffff:127.0.0.1 is ipv6 string:                        	1
 ::ffff:8.8.8.8 is ipv6 string:                          	1
 2001:0DB8:AC10:FE01:FEED:BABE:CAFE:F00D is ipv6 string: 	1
+::ffff:127.0.0.1
+::ffff:127.0.0.1

--- a/tests/queries/0_stateless/00725_ipv4_ipv6_domains.reference
+++ b/tests/queries/0_stateless/00725_ipv4_ipv6_domains.reference
@@ -62,3 +62,6 @@ FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF is ipv6 string: 	1
 ::ffff:127.0.0.7
 ::ffff:127.0.0.8
 ::ffff:127.0.0.9
+::ffff:127.0.0.10
+::ffff:127.0.0.11
+::ffff:127.0.0.12

--- a/tests/queries/0_stateless/00725_ipv4_ipv6_domains.sql
+++ b/tests/queries/0_stateless/00725_ipv4_ipv6_domains.sql
@@ -84,3 +84,7 @@ SELECT '::ffff:127.0.0.1 is ipv6 string:                        ', isIPv6String(
 SELECT '::ffff:8.8.8.8 is ipv6 string:                          ', isIPv6String('::ffff:8.8.8.8');
 SELECT '2001:0DB8:AC10:FE01:FEED:BABE:CAFE:F00D is ipv6 string: ', isIPv6String('2001:0DB8:AC10:FE01:FEED:BABE:CAFE:F00D');
 
+-- IPV6 functions parse IPv4 addresses.
+
+SELECT toIPv6('127.0.0.1');
+SELECT cutIPv6(IPv6StringToNum('127.0.0.1'), 0, 0);

--- a/tests/queries/0_stateless/00725_ipv4_ipv6_domains.sql
+++ b/tests/queries/0_stateless/00725_ipv4_ipv6_domains.sql
@@ -86,5 +86,7 @@ SELECT '2001:0DB8:AC10:FE01:FEED:BABE:CAFE:F00D is ipv6 string: ', isIPv6String(
 
 -- IPV6 functions parse IPv4 addresses.
 
+SELECT toIPv6('0.0.0.0');
 SELECT toIPv6('127.0.0.1');
 SELECT cutIPv6(IPv6StringToNum('127.0.0.1'), 0, 0);
+SELECT toIPv6('127.0.0.' || toString(number)) FROM numbers(10);

--- a/tests/queries/0_stateless/00725_ipv4_ipv6_domains.sql
+++ b/tests/queries/0_stateless/00725_ipv4_ipv6_domains.sql
@@ -89,4 +89,4 @@ SELECT '2001:0DB8:AC10:FE01:FEED:BABE:CAFE:F00D is ipv6 string: ', isIPv6String(
 SELECT toIPv6('0.0.0.0');
 SELECT toIPv6('127.0.0.1');
 SELECT cutIPv6(IPv6StringToNum('127.0.0.1'), 0, 0);
-SELECT toIPv6('127.0.0.' || toString(number)) FROM numbers(10);
+SELECT toIPv6('127.0.0.' || toString(number)) FROM numbers(13);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

`toIPv6` function parses `IPv4` addresses.

Detailed description / Documentation draft:

This PR improves the `toIPv6`  function to addtitionally parse `IPv4` addresses by repesenting them as IPv6 equivalent addresses. For an example `127.0.0.1` can be represented as `::ffff:127.0.0.1`.

Before:

``` sql
SELECT toIPv6('127.0.0.1')

┌─toIPv6('127.0.0.1')─┐
│ ::                  │
└─────────────────────┘
```

After:

``` sql
SELECT toIPv6('127.0.0.1')

┌─toIPv6('127.0.0.1')─┐
│ ::ffff:127.0.0.1    │
└─────────────────────┘
```

Relates to: #18152