### PR TITLE
Support new .debug location

### DIFF
--- a/src/Common/SymbolIndex.cpp
+++ b/src/Common/SymbolIndex.cpp
@@ -324,6 +324,27 @@ void collectSymbolsFromELF(dl_phdr_info * info,
         object_name = local_debug_info_path;
     else if (std::filesystem::exists(debug_info_path))
         object_name = debug_info_path;
+    else if (!build_id.empty())
+    {
+        // Check if there is a .debug file in .build-id folder. For example:
+        // /usr/lib/debug/.build-id/e4/0526a12e9a8f3819a18694f6b798f10c624d5c.debug
+        String build_id_hex;
+        build_id_hex.resize(build_id.size() * 2);
+
+        char * pos = build_id_hex.data();
+        for (auto c : build_id)
+        {
+            writeHexByteLowercase(c, pos);
+            pos += 2;
+        }
+
+        std::filesystem::path build_id_debug_info_path(
+            fmt::format("/usr/lib/debug/.build-id/{}/{}.debug", build_id_hex.substr(0, 2), build_id_hex.substr(2)));
+        if (std::filesystem::exists(build_id_debug_info_path))
+            object_name = build_id_debug_info_path;
+        else
+            object_name = canonical_path;
+    }
     else
         object_name = canonical_path;
 

--- a/src/Common/SymbolIndex.cpp
+++ b/src/Common/SymbolIndex.cpp
@@ -324,7 +324,7 @@ void collectSymbolsFromELF(dl_phdr_info * info,
         object_name = local_debug_info_path;
     else if (std::filesystem::exists(debug_info_path))
         object_name = debug_info_path;
-    else if (!build_id.empty())
+    else if (build_id.size() >= 2)
     {
         // Check if there is a .debug file in .build-id folder. For example:
         // /usr/lib/debug/.build-id/e4/0526a12e9a8f3819a18694f6b798f10c624d5c.debug


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Support using the new location of `.debug` file. This fixes https://github.com/ClickHouse/ClickHouse/issues/19348


Detailed description / Documentation draft:

.