### PR TITLE
Allow to enable or disable watchdog via env var

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -109,8 +109,20 @@ int mainEntryClickHouseServer(int argc, char ** argv)
 
     /// Do not fork separate process from watchdog if we attached to terminal.
     /// Otherwise it breaks gdb usage.
-    if (argc > 0 && !isatty(STDIN_FILENO) && !isatty(STDOUT_FILENO) && !isatty(STDERR_FILENO))
-        app.shouldSetupWatchdog(argv[0]);
+    /// Can be overridden by environment variable (cannot use server config at this moment).
+    if (argc > 0)
+    {
+        const char * env_watchdog = getenv("CLICKHOUSE_WATCHDOG_ENABLE");
+        if (env_watchdog)
+        {
+            if (0 == strcmp(env_watchdog, "1"))
+                app.shouldSetupWatchdog(argv[0]);
+
+            /// Other values disable watchdog explicitly.
+        }
+        else if (!isatty(STDIN_FILENO) && !isatty(STDOUT_FILENO) && !isatty(STDERR_FILENO))
+            app.shouldSetupWatchdog(argv[0]);
+    }
 
     try
     {


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow to explicitly enable or disable watchdog via environment variable `CLICKHOUSE_WATCHDOG_ENABLE`. By default it is enabled if server is not attached to terminal.



Detailed description / Documentation draft:
I also tried to use ptrace to debug #19108. But it appeared to be quite difficult. The name of the variable is `CLICKHOUSE_WATCHDOG_ENABLE`, not `CLICKHOUSE_ENABLE_WATCHDOG` to allow more variables starting with `CLICKHOUSE_WATCHDOG_` like `CLICKHOUSE_WATCHDOG_AUTORESTART`.