### PR TITLE
Minor usability improvement in parser

### DIFF
--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -169,6 +169,10 @@ bool ParserIdentifier::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     }
     else if (pos->type == TokenType::BareWord)
     {
+        /// Reserved keyword.
+        if (pos->size() == strlen("FROM") && 0 == strncasecmp(pos->begin, "FROM", strlen("FROM")))
+            return false;
+
         node = std::make_shared<ASTIdentifier>(String(pos->begin, pos->end));
         ++pos;
         return true;

--- a/tests/queries/0_stateless/00829_bitmap_function.sql
+++ b/tests/queries/0_stateless/00829_bitmap_function.sql
@@ -139,8 +139,8 @@ CREATE TABLE bitmap_column_expr_test3
     tag_id String,
     z AggregateFunction(groupBitmap, UInt64),
     replace Nested (
-        from UInt16,
-        to UInt64
+        `from` UInt16,
+        `to` UInt64
     )
 )
 ENGINE = MergeTree
@@ -149,12 +149,12 @@ ORDER BY tag_id;
 DROP TABLE IF EXISTS numbers10;
 CREATE VIEW numbers10 AS SELECT number FROM system.numbers LIMIT 10;
 
-INSERT INTO bitmap_column_expr_test3(tag_id, z, replace.from, replace.to) SELECT 'tag1', groupBitmapState(toUInt64(number)), cast([] as Array(UInt16)), cast([] as Array(UInt64)) FROM numbers10;
-INSERT INTO bitmap_column_expr_test3(tag_id, z, replace.from, replace.to) SELECT 'tag2', groupBitmapState(toUInt64(number)), cast([0] as Array(UInt16)), cast([2] as Array(UInt64)) FROM numbers10;
-INSERT INTO bitmap_column_expr_test3(tag_id, z, replace.from, replace.to) SELECT 'tag3', groupBitmapState(toUInt64(number)), cast([0,7] as Array(UInt16)), cast([3,101] as Array(UInt64)) FROM numbers10;
-INSERT INTO bitmap_column_expr_test3(tag_id, z, replace.from, replace.to) SELECT 'tag4', groupBitmapState(toUInt64(number)), cast([5,999,2] as Array(UInt16)), cast([2,888,20] as Array(UInt64)) FROM numbers10;
+INSERT INTO bitmap_column_expr_test3(tag_id, z, replace.`from`, replace.`to`) SELECT 'tag1', groupBitmapState(toUInt64(number)), cast([] as Array(UInt16)), cast([] as Array(UInt64)) FROM numbers10;
+INSERT INTO bitmap_column_expr_test3(tag_id, z, replace.`from`, replace.`to`) SELECT 'tag2', groupBitmapState(toUInt64(number)), cast([0] as Array(UInt16)), cast([2] as Array(UInt64)) FROM numbers10;
+INSERT INTO bitmap_column_expr_test3(tag_id, z, replace.`from`, replace.`to`) SELECT 'tag3', groupBitmapState(toUInt64(number)), cast([0,7] as Array(UInt16)), cast([3,101] as Array(UInt64)) FROM numbers10;
+INSERT INTO bitmap_column_expr_test3(tag_id, z, replace.`from`, replace.`to`) SELECT 'tag4', groupBitmapState(toUInt64(number)), cast([5,999,2] as Array(UInt16)), cast([2,888,20] as Array(UInt64)) FROM numbers10;
 
-SELECT tag_id, bitmapToArray(z), replace.from, replace.to, bitmapToArray(bitmapTransform(z, replace.from, replace.to)) FROM bitmap_column_expr_test3 ORDER BY tag_id;
+SELECT tag_id, bitmapToArray(z), replace.`from`, replace.`to`, bitmapToArray(bitmapTransform(z, replace.`from`, replace.`to`)) FROM bitmap_column_expr_test3 ORDER BY tag_id;
 
 
 DROP TABLE IF EXISTS bitmap_test;

--- a/tests/queries/0_stateless/01670_from_is_not_a_function.reference
+++ b/tests/queries/0_stateless/01670_from_is_not_a_function.reference
@@ -1,0 +1,2 @@
+Syntax error
+Code: 36.

--- a/tests/queries/0_stateless/01670_from_is_not_a_function.sh
+++ b/tests/queries/0_stateless/01670_from_is_not_a_function.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -e
+
+CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=fatal
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+
+$CLICKHOUSE_CLIENT --multiquery --query "
+DROP TABLE IF EXISTS items;
+
+CREATE TABLE items (
+  time DateTime,
+  group_id UInt16,
+  value UInt32()
+) ENGINE = MergeTree()
+PARTITION BY toYYYYMM(time)
+ORDER BY (group_id, time);
+"
+
+$CLICKHOUSE_CLIENT --multiquery --query "
+SELECT
+  group_id,
+  groupArray(time)[1] as time,
+  groupArray(value)                       ,
+FROM (
+  SELECT * FROM items ORDER BY time desc LIMIT 100 BY group_id
+)
+GROUP BY group_id;
+" 2>&1 | grep -oF 'Syntax error'
+
+$CLICKHOUSE_CLIENT --multiquery --query "
+SELECT
+  group_id,
+  groupArray(time)[1] as time,
+  groupArray(value)                       ,
+FRO (
+  SELECT * FROM items ORDER BY time desc LIMIT 100 BY group_id
+)
+GROUP BY group_id;
+" 2>&1 | grep -oF 'Code: 36.'
+
+$CLICKHOUSE_CLIENT --multiquery --query "
+DROP TABLE IF EXISTS items;
+"


### PR DESCRIPTION
Changelog category (leave one):
- Backward Incompatible Change


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Minor usability improvement in parser of `FROM`. This closes #19477.