### PR TITLE
Fix DROP TABLE ON CLUSTER SYNC hang with Atomic database

### DIFF
--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -727,9 +727,15 @@ void DDLWorker::processTask(DDLTask & task)
                 }
 
                 if (storage && taskShouldBeExecutedOnLeader(rewritten_ast, storage)  && !task.is_circular_replicated)
+                {
                     tryExecuteQueryOnLeaderReplica(task, storage, rewritten_query, task.entry_path, zookeeper);
+                }
                 else
+                {
+                    /// StoragePtr may cause DROP TABLE to hang
+                    storage.reset();
                     tryExecuteQuery(rewritten_query, task, task.execution_status);
+                }
             }
             else
                 tryExecuteQuery(rewritten_query, task, task.execution_status);

--- a/tests/queries/0_stateless/01181_db_atomic_drop_on_cluster.reference
+++ b/tests/queries/0_stateless/01181_db_atomic_drop_on_cluster.reference
@@ -1,0 +1,5 @@
+localhost	9000	0		0	0
+localhost	9000	0		0	0
+localhost	9000	0		0	0
+localhost	9000	0		0	0
+localhost	9000	0		0	0

--- a/tests/queries/0_stateless/01181_db_atomic_drop_on_cluster.sql
+++ b/tests/queries/0_stateless/01181_db_atomic_drop_on_cluster.sql
@@ -1,0 +1,6 @@
+DROP TABLE IF EXISTS test_repl ON CLUSTER test_shard_localhost SYNC;
+
+CREATE TABLE test_repl ON CLUSTER test_shard_localhost (n UInt64) ENGINE ReplicatedMergeTree('/clickhouse/test_01181/{database}/test_repl','r1') ORDER BY tuple();
+DETACH TABLE test_repl ON CLUSTER test_shard_localhost SYNC;
+ATTACH TABLE test_repl ON CLUSTER test_shard_localhost;
+DROP TABLE test_repl ON CLUSTER test_shard_localhost SYNC;

--- a/tests/queries/0_stateless/arcadia_skip_list.txt
+++ b/tests/queries/0_stateless/arcadia_skip_list.txt
@@ -193,3 +193,4 @@
 01660_sum_ubsan
 01669_columns_declaration_serde
 01666_blns
+01181_db_atomic_drop_on_cluster


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
`DROP/DETACH TABLE table ON CLUSTER cluster SYNC` query might hang, it's fixed.
Fixes #19568.
