### PR TITLE
Add more debuginfo for test_concurrent_ttl_merges test

### DIFF
--- a/tests/integration/helpers/test_tools.py
+++ b/tests/integration/helpers/test_tools.py
@@ -38,6 +38,9 @@ class TSV:
     def __str__(self):
         return '\n'.join(self.lines)
 
+    def __len__(self):
+        return len(self.lines)
+
     @staticmethod
     def toMat(contents):
         return [line.split("\t") for line in contents.split("\n") if line.strip()]

--- a/tests/integration/test_concurrent_ttl_merges/test.py
+++ b/tests/integration/test_concurrent_ttl_merges/test.py
@@ -2,7 +2,7 @@ import time
 
 import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry
+from helpers.test_tools import assert_eq_with_retry, TSV
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', main_configs=['configs/fast_background_pool.xml', 'configs/log_conf.xml'], with_zookeeper=True)
@@ -28,12 +28,13 @@ def count_ttl_merges_in_queue(node, table):
     return int(result.strip())
 
 
-def count_ttl_merges_in_background_pool(node, table):
-    result = node.query(
-        "SELECT count() FROM system.merges WHERE merge_type = 'TTL_DELETE' and table = '{}'".format(table))
-    if not result:
-        return 0
-    return int(result.strip())
+def count_ttl_merges_in_background_pool(node, table, level):
+    result = TSV(node.query(
+        "SELECT * FROM system.merges WHERE merge_type = 'TTL_DELETE' and table = '{}'".format(table)))
+    count = len(result)
+    if count >= level:
+        print("count_ttl_merges_in_background_pool: merges more than warn level:\n{}".format(result))
+    return count
 
 
 def count_regular_merges_in_background_pool(node, table):
@@ -67,7 +68,7 @@ def test_no_ttl_merges_in_busy_pool(started_cluster):
 
     while count_running_mutations(node1, "test_ttl") < 6:
         print("Mutations count", count_running_mutations(node1, "test_ttl"))
-        assert count_ttl_merges_in_background_pool(node1, "test_ttl") == 0
+        assert count_ttl_merges_in_background_pool(node1, "test_ttl", 1) == 0
         time.sleep(0.5)
 
     node1.query("SYSTEM START TTL MERGES")
@@ -100,7 +101,7 @@ def test_limited_ttl_merges_in_empty_pool(started_cluster):
 
     merges_with_ttl_count = set({})
     while True:
-        merges_with_ttl_count.add(count_ttl_merges_in_background_pool(node1, "test_ttl_v2"))
+        merges_with_ttl_count.add(count_ttl_merges_in_background_pool(node1, "test_ttl_v2", 3))
         time.sleep(0.01)
         if node1.query("SELECT COUNT() FROM test_ttl_v2") == "0\n":
             break
@@ -124,7 +125,7 @@ def test_limited_ttl_merges_in_empty_pool_replicated(started_cluster):
     merges_with_ttl_count = set({})
     entries_with_ttl_count = set({})
     while True:
-        merges_with_ttl_count.add(count_ttl_merges_in_background_pool(node1, "replicated_ttl"))
+        merges_with_ttl_count.add(count_ttl_merges_in_background_pool(node1, "replicated_ttl", 3))
         entries_with_ttl_count.add(count_ttl_merges_in_queue(node1, "replicated_ttl"))
         time.sleep(0.01)
         if node1.query("SELECT COUNT() FROM replicated_ttl") == "0\n":
@@ -159,8 +160,8 @@ def test_limited_ttl_merges_two_replicas(started_cluster):
     merges_with_ttl_count_node1 = set({})
     merges_with_ttl_count_node2 = set({})
     while True:
-        merges_with_ttl_count_node1.add(count_ttl_merges_in_background_pool(node1, "replicated_ttl_2"))
-        merges_with_ttl_count_node2.add(count_ttl_merges_in_background_pool(node2, "replicated_ttl_2"))
+        merges_with_ttl_count_node1.add(count_ttl_merges_in_background_pool(node1, "replicated_ttl_2"), 3)
+        merges_with_ttl_count_node2.add(count_ttl_merges_in_background_pool(node2, "replicated_ttl_2"), 3)
         if node1.query("SELECT COUNT() FROM replicated_ttl_2") == "0\n" and node2.query(
                 "SELECT COUNT() FROM replicated_ttl_2") == "0\n":
             break

--- a/tests/integration/test_concurrent_ttl_merges/test.py
+++ b/tests/integration/test_concurrent_ttl_merges/test.py
@@ -160,8 +160,8 @@ def test_limited_ttl_merges_two_replicas(started_cluster):
     merges_with_ttl_count_node1 = set({})
     merges_with_ttl_count_node2 = set({})
     while True:
-        merges_with_ttl_count_node1.add(count_ttl_merges_in_background_pool(node1, "replicated_ttl_2"), 3)
-        merges_with_ttl_count_node2.add(count_ttl_merges_in_background_pool(node2, "replicated_ttl_2"), 3)
+        merges_with_ttl_count_node1.add(count_ttl_merges_in_background_pool(node1, "replicated_ttl_2", 3))
+        merges_with_ttl_count_node2.add(count_ttl_merges_in_background_pool(node2, "replicated_ttl_2", 3))
         if node1.query("SELECT COUNT() FROM replicated_ttl_2") == "0\n" and node2.query(
                 "SELECT COUNT() FROM replicated_ttl_2") == "0\n":
             break


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Added more logging in test_concurrent_ttl_merges test. Add __len__ for TSV helper object


Detailed description / Documentation draft:

Test is incorrect or there is a bug.

```
test_concurrent_ttl_merges/test.py .F

================================================================================================= FAILURES =================================================================================================
__________________________________________________________________________________ test_limited_ttl_merges_in_empty_pool ___________________________________________________________________________________

started_cluster = <helpers.cluster.ClickHouseCluster object at 0x7fd76853efd0>

    def test_limited_ttl_merges_in_empty_pool(started_cluster):
        node1.query(
            "CREATE TABLE test_ttl_v2 (d DateTime, key UInt64, data UInt64) ENGINE = MergeTree() ORDER BY tuple() PARTITION BY key TTL d + INTERVAL 1 MONTH SETTINGS merge_with_ttl_timeout = 0")

        node1.query("SYSTEM STOP TTL MERGES")

        for i in range(100):
            node1.query("INSERT INTO test_ttl_v2 SELECT now() - INTERVAL 1 MONTH, {}, number FROM numbers(1)".format(i))

        assert node1.query("SELECT COUNT() FROM test_ttl_v2") == "100\n"

        node1.query("SYSTEM START TTL MERGES")

        merges_with_ttl_count = set({})
        while True:
            merges_with_ttl_count.add(count_ttl_merges_in_background_pool(node1, "test_ttl_v2", 3))
            time.sleep(0.01)
            if node1.query("SELECT COUNT() FROM test_ttl_v2") == "0\n":
                break

>       assert max(merges_with_ttl_count) <= 2
E       assert 3 <= 2
E        +  where 3 = max({1, 3})

test_concurrent_ttl_merges/test.py:109: AssertionError
------------------------------------------------------------------------------------------- Captured stdout call -------------------------------------------------------------------------------------------
count_ttl_merges_in_background_pool: merges more than warn level:
default	test_ttl_v2	0.007884232	0	1	['28_29_29_0']	28_29_29_1	['/var/lib/clickhouse/store/1c0/1c0dc3d4-6bc5-41d0-8f2a-46b6d2e07aef/28_29_29_0/']	/var/lib/clickhouse/store/1c0/1c0dc3d4-6bc5-41d0-8f2a-46b6d2e07aef/28_29_29_1/	28	0	302	2	0	0	0	0	0	0	55	TTL_DELETE	Horizontal
default	test_ttl_v2	0.007368731	0	1	['29_30_30_0']	29_30_30_1	['/var/lib/clickhouse/store/1c0/1c0dc3d4-6bc5-41d0-8f2a-46b6d2e07aef/29_30_30_0/']	/var/lib/clickhouse/store/1c0/1c0dc3d4-6bc5-41d0-8f2a-46b6d2e07aef/29_30_30_1/	29	0	302	2	0	0	0	0	0	0	52	TTL_DELETE	Horizontal
default	test_ttl_v2	0.006917526	0	1	['30_31_31_0']	30_31_31_1	['/var/lib/clickhouse/store/1c0/1c0dc3d4-6bc5-41d0-8f2a-46b6d2e07aef/30_31_31_0/']	/var/lib/clickhouse/store/1c0/1c0dc3d4-6bc5-41d0-8f2a-46b6d2e07aef/30_31_31_1/	30	0	302	2	0	0	0	0	0	0	56	TTL_DELETE	Horizontal
----------------------------------------------------------------------- generated xml file: /ClickHouse/tests/integration/result.xml -----------------------------------------------------------------------
========================================================================================= short test summary info ==========================================================================================
FAILED test_concurrent_ttl_merges/test.py::test_limited_ttl_merges_in_empty_pool - assert 3 <= 2
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
======================================================================================= 1 failed, 1 passed in 41.72s =======================================================================================
```

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
