### PR TITLE
Should fail ddl query as soon as possible if table is shutdown

### DIFF
--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -868,7 +868,8 @@ bool DDLWorker::tryExecuteQueryOnLeaderReplica(
         replicated_storage->getStatus(status);
 
         // Should return as soon as possible if the table is shutdown by drop or other command.
-        if (status.is_partial_shutdown) {
+        if (status.is_partial_shutdown)
+        {
             LOG_WARNING(log, "Table is shutdown, task {} will not be executed.", task.entry_name);
             task.execution_status = ExecutionStatus(ErrorCodes::UNFINISHED, "Cannot execute replicated DDL query, table is shutdown");
             return false;

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -865,13 +865,16 @@ bool DDLWorker::tryExecuteQueryOnLeaderReplica(
     while (stopwatch.elapsedSeconds() <= MAX_EXECUTION_TIMEOUT_SEC)
     {
         StorageReplicatedMergeTree::Status status;
-        replicated_storage->getStatus(status);
+        // Has to get with zk fields to get active replicas field
+        replicated_storage->getStatus(status, true);
 
-        // Should return as soon as possible if the table is shutdown by drop or other command.
-        if (status.is_partial_shutdown)
+        // Should return as soon as possible if the table is dropped.
+        bool replica_dropped = replicated_storage->is_dropped;
+        bool all_replicas_likely_detached = status.active_replicas == 0 && !DatabaseCatalog::instance().isTableExist(replicated_storage->getStorageID(), context);
+        if (replica_dropped || all_replicas_likely_detached) 
         {
-            LOG_WARNING(log, "Table is shutdown, task {} will not be executed.", task.entry_name);
-            task.execution_status = ExecutionStatus(ErrorCodes::UNFINISHED, "Cannot execute replicated DDL query, table is shutdown");
+            LOG_WARNING(log, "Table is dropped or detached permantly, task {} will not be executed.", task.entry_name);
+            task.execution_status = ExecutionStatus(ErrorCodes::UNFINISHED, "Cannot execute replicated DDL query, table is dropped or detached permantly");
             return false;
         }
 

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -871,10 +871,10 @@ bool DDLWorker::tryExecuteQueryOnLeaderReplica(
         // Should return as soon as possible if the table is dropped.
         bool replica_dropped = replicated_storage->is_dropped;
         bool all_replicas_likely_detached = status.active_replicas == 0 && !DatabaseCatalog::instance().isTableExist(replicated_storage->getStorageID(), context);
-        if (replica_dropped || all_replicas_likely_detached) 
+        if (replica_dropped || all_replicas_likely_detached)
         {
-            LOG_WARNING(log, "Table is dropped or detached permantly, task {} will not be executed.", task.entry_name);
-            task.execution_status = ExecutionStatus(ErrorCodes::UNFINISHED, "Cannot execute replicated DDL query, table is dropped or detached permantly");
+            LOG_WARNING(log, ", task {} will not be executed.", task.entry_name);
+            task.execution_status = ExecutionStatus(ErrorCodes::UNFINISHED, "Cannot execute replicated DDL query, table is dropped or detached permanently");
             return false;
         }
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -4791,6 +4791,7 @@ void StorageReplicatedMergeTree::getStatus(Status & res, bool with_zk_fields)
     res.can_become_leader = storage_settings_ptr->replicated_can_become_leader;
     res.is_readonly = is_readonly;
     res.is_session_expired = !zookeeper || zookeeper->expired();
+    res.is_partial_shutdown = partial_shutdown_called;
 
     res.queue = queue.getStatus();
     res.absolute_delay = getAbsoluteDelay(); /// NOTE: may be slightly inconsistent with queue status.

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -4791,7 +4791,6 @@ void StorageReplicatedMergeTree::getStatus(Status & res, bool with_zk_fields)
     res.can_become_leader = storage_settings_ptr->replicated_can_become_leader;
     res.is_readonly = is_readonly;
     res.is_session_expired = !zookeeper || zookeeper->expired();
-    res.is_partial_shutdown = partial_shutdown_called;
 
     res.queue = queue.getStatus();
     res.absolute_delay = getAbsoluteDelay(); /// NOTE: may be slightly inconsistent with queue status.

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -159,6 +159,7 @@ public:
         bool can_become_leader;
         bool is_readonly;
         bool is_session_expired;
+        bool is_partial_shutdown;
         ReplicatedMergeTreeQueue::Status queue;
         UInt32 parts_to_check;
         String zookeeper_path;

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -159,7 +159,6 @@ public:
         bool can_become_leader;
         bool is_readonly;
         bool is_session_expired;
-        bool is_partial_shutdown;
         ReplicatedMergeTreeQueue::Status queue;
         UInt32 parts_to_check;
         String zookeeper_path;

--- a/tests/queries/0_stateless/01671_ddl_hang_timeout.sh
+++ b/tests/queries/0_stateless/01671_ddl_hang_timeout.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=fatal
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 $CLICKHOUSE_CLIENT --query "DROP DATABASE IF EXISTS test_01671"
 $CLICKHOUSE_CLIENT --query "CREATE DATABASE test_01671"

--- a/tests/queries/0_stateless/01671_ddl_hang_timeout.sh
+++ b/tests/queries/0_stateless/01671_ddl_hang_timeout.sh
@@ -7,14 +7,14 @@ $CLICKHOUSE_CLIENT --query "CREATE DATABASE test_01671"
 function thread_create_drop_table {
     while true; do
         REPLICA=$(($RANDOM % 10))
-        $CLICKHOUSE_CLIENT --query "CREATE TABLE test_01671.t1 (x UInt64, s Array(Nullable(String))) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test_01671/test_01671', 'r_$REPLICA') order by x"
+        $CLICKHOUSE_CLIENT --query "CREATE TABLE IF NOT EXISTS test_01671.t1 (x UInt64, s Array(Nullable(String))) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test_01671/test_01671', 'r_$REPLICA') order by x" 2>/dev/null
         sleep 0.0$RANDOM
-        $CLICKHOUSE_CLIENT --query "DROP TABLE test_01671.t1"
+        $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS test_01671.t1"
     done
 }
 function thread_alter_table {
     while true; do
-        $CLICKHOUSE_CLIENT --query "ALTER TABLE test_01671.t1 on cluster test_shard_localhost ADD COLUMN newcol UInt32"
+        $CLICKHOUSE_CLIENT --query "ALTER TABLE test_01671.t1 on cluster test_shard_localhost ADD COLUMN newcol UInt32" >/dev/null 2>&1
         sleep 0.0$RANDOM
     done
 }

--- a/tests/queries/0_stateless/01671_ddl_hang_timeout.sh
+++ b/tests/queries/0_stateless/01671_ddl_hang_timeout.sh
@@ -2,22 +2,23 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
-$CLICKHOUSE_CLIENT --query "DROP DATABASE IF EXISTS test_01671"
-$CLICKHOUSE_CLIENT --query "CREATE DATABASE test_01671"
+
 function thread_create_drop_table {
     while true; do
         REPLICA=$(($RANDOM % 10))
-        $CLICKHOUSE_CLIENT --query "CREATE TABLE IF NOT EXISTS test_01671.t1 (x UInt64, s Array(Nullable(String))) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test_01671/test_01671', 'r_$REPLICA') order by x" 2>/dev/null
+        $CLICKHOUSE_CLIENT --query "CREATE TABLE IF NOT EXISTS t1 (x UInt64, s Array(Nullable(String))) ENGINE = ReplicatedMergeTree('/clickhouse/tables/test_01671/test_01671', 'r_$REPLICA') order by x" 2>/dev/null
         sleep 0.0$RANDOM
-        $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS test_01671.t1"
+        $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS t1"
     done
 }
+
 function thread_alter_table {
     while true; do
-        $CLICKHOUSE_CLIENT --query "ALTER TABLE test_01671.t1 on cluster test_shard_localhost ADD COLUMN newcol UInt32" >/dev/null 2>&1
+        $CLICKHOUSE_CLIENT --query "ALTER TABLE $CLICKHOUSE_DATABASE.t1 on cluster test_shard_localhost ADD COLUMN newcol UInt32" >/dev/null 2>&1
         sleep 0.0$RANDOM
     done
 }
+
 export -f thread_create_drop_table
 export -f thread_alter_table
 timeout 20 bash -c "thread_create_drop_table" &
@@ -25,4 +26,4 @@ timeout 20 bash -c 'thread_alter_table' &
 wait
 sleep 1
 
-$CLICKHOUSE_CLIENT --query "DROP DATABASE test_01671";
+$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS t1";


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Background thread which executes `ON CLUSTER` queries might hang waiting for dropped replicated table to do something. It's fixed.

Detailed description / Documentation draft:

Check table status during ddl execution. Set task status to exception if the table is shutdown by drop command or others.
