### PR TITLE
Fix flaky test test_concurrent_ttl_merges

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3955,7 +3955,7 @@ NamesAndTypesList MergeTreeData::getVirtuals() const
 
 size_t MergeTreeData::getTotalMergesWithTTLInMergeList() const
 {
-    return global_context.getMergeList().getExecutingMergesWithTTLCount();
+    return global_context.getMergeList().getMergesWithTTLCount();
 }
 
 void MergeTreeData::addPartContributionToDataVolume(const DataPartPtr & part)

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -732,6 +732,10 @@ std::shared_ptr<StorageMergeTree::MergeMutateSelectedEntry> StorageMergeTree::se
         return {};
     }
 
+    /// Account TTL merge here to avoid exceeding the max_number_of_merges_with_ttl_in_pool limit
+    if (isTTLMergeType(future_part.merge_type))
+        global_context.getMergeList().bookMergeWithTTL();
+
     merging_tagger = std::make_unique<CurrentlyMergingPartsTagger>(future_part, MergeTreeDataMergerMutator::estimateNeededDiskSpace(future_part.parts), *this, metadata_snapshot, false);
     return std::make_shared<MergeMutateSelectedEntry>(future_part, std::move(merging_tagger), MutationCommands{});
 }

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1490,7 +1490,12 @@ bool StorageReplicatedMergeTree::tryExecuteMerge(const LogEntry & entry)
     future_merged_part.updatePath(*this, reserved_space);
     future_merged_part.merge_type = entry.merge_type;
 
+    /// Account TTL merge
+    if (isTTLMergeType(future_merged_part.merge_type))
+        global_context.getMergeList().bookMergeWithTTL();
+
     auto table_id = getStorageID();
+    /// Add merge to list
     MergeList::EntryPtr merge_entry = global_context.getMergeList().insert(table_id.database_name, table_id.table_name, future_merged_part);
 
     Transaction transaction(*this);

--- a/tests/integration/helpers/test_tools.py
+++ b/tests/integration/helpers/test_tools.py
@@ -38,6 +38,9 @@ class TSV:
     def __str__(self):
         return '\n'.join(self.lines)
 
+    def __len__(self):
+        return len(self.lines)
+
     @staticmethod
     def toMat(contents):
         return [line.split("\t") for line in contents.split("\n") if line.strip()]

--- a/tests/integration/test_concurrent_ttl_merges/test.py
+++ b/tests/integration/test_concurrent_ttl_merges/test.py
@@ -2,7 +2,7 @@ import time
 
 import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry
+from helpers.test_tools import assert_eq_with_retry, TSV
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', main_configs=['configs/fast_background_pool.xml', 'configs/log_conf.xml'], with_zookeeper=True)
@@ -28,12 +28,13 @@ def count_ttl_merges_in_queue(node, table):
     return int(result.strip())
 
 
-def count_ttl_merges_in_background_pool(node, table):
-    result = node.query(
-        "SELECT count() FROM system.merges WHERE merge_type = 'TTL_DELETE' and table = '{}'".format(table))
-    if not result:
-        return 0
-    return int(result.strip())
+def count_ttl_merges_in_background_pool(node, table, level):
+    result = TSV(node.query(
+        "SELECT * FROM system.merges WHERE merge_type = 'TTL_DELETE' and table = '{}'".format(table)))
+    count = len(result)
+    if count >= level:
+        print("count_ttl_merges_in_background_pool: merges more than warn level:\n{}".format(result))
+    return count
 
 
 def count_regular_merges_in_background_pool(node, table):
@@ -67,7 +68,7 @@ def test_no_ttl_merges_in_busy_pool(started_cluster):
 
     while count_running_mutations(node1, "test_ttl") < 6:
         print("Mutations count", count_running_mutations(node1, "test_ttl"))
-        assert count_ttl_merges_in_background_pool(node1, "test_ttl") == 0
+        assert count_ttl_merges_in_background_pool(node1, "test_ttl", 1) == 0
         time.sleep(0.5)
 
     node1.query("SYSTEM START TTL MERGES")
@@ -100,7 +101,7 @@ def test_limited_ttl_merges_in_empty_pool(started_cluster):
 
     merges_with_ttl_count = set({})
     while True:
-        merges_with_ttl_count.add(count_ttl_merges_in_background_pool(node1, "test_ttl_v2"))
+        merges_with_ttl_count.add(count_ttl_merges_in_background_pool(node1, "test_ttl_v2", 3))
         time.sleep(0.01)
         if node1.query("SELECT COUNT() FROM test_ttl_v2") == "0\n":
             break
@@ -124,7 +125,7 @@ def test_limited_ttl_merges_in_empty_pool_replicated(started_cluster):
     merges_with_ttl_count = set({})
     entries_with_ttl_count = set({})
     while True:
-        merges_with_ttl_count.add(count_ttl_merges_in_background_pool(node1, "replicated_ttl"))
+        merges_with_ttl_count.add(count_ttl_merges_in_background_pool(node1, "replicated_ttl", 3))
         entries_with_ttl_count.add(count_ttl_merges_in_queue(node1, "replicated_ttl"))
         time.sleep(0.01)
         if node1.query("SELECT COUNT() FROM replicated_ttl") == "0\n":
@@ -159,8 +160,8 @@ def test_limited_ttl_merges_two_replicas(started_cluster):
     merges_with_ttl_count_node1 = set({})
     merges_with_ttl_count_node2 = set({})
     while True:
-        merges_with_ttl_count_node1.add(count_ttl_merges_in_background_pool(node1, "replicated_ttl_2"))
-        merges_with_ttl_count_node2.add(count_ttl_merges_in_background_pool(node2, "replicated_ttl_2"))
+        merges_with_ttl_count_node1.add(count_ttl_merges_in_background_pool(node1, "replicated_ttl_2"), 3)
+        merges_with_ttl_count_node2.add(count_ttl_merges_in_background_pool(node2, "replicated_ttl_2"), 3)
         if node1.query("SELECT COUNT() FROM replicated_ttl_2") == "0\n" and node2.query(
                 "SELECT COUNT() FROM replicated_ttl_2") == "0\n":
             break

--- a/tests/integration/test_concurrent_ttl_merges/test.py
+++ b/tests/integration/test_concurrent_ttl_merges/test.py
@@ -160,8 +160,8 @@ def test_limited_ttl_merges_two_replicas(started_cluster):
     merges_with_ttl_count_node1 = set({})
     merges_with_ttl_count_node2 = set({})
     while True:
-        merges_with_ttl_count_node1.add(count_ttl_merges_in_background_pool(node1, "replicated_ttl_2"), 3)
-        merges_with_ttl_count_node2.add(count_ttl_merges_in_background_pool(node2, "replicated_ttl_2"), 3)
+        merges_with_ttl_count_node1.add(count_ttl_merges_in_background_pool(node1, "replicated_ttl_2", 3))
+        merges_with_ttl_count_node2.add(count_ttl_merges_in_background_pool(node2, "replicated_ttl_2", 3))
         if node1.query("SELECT COUNT() FROM replicated_ttl_2") == "0\n" and node2.query(
                 "SELECT COUNT() FROM replicated_ttl_2") == "0\n":
             break


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix rare `max_number_of_merges_with_ttl_in_pool` limit overrun (more merges with TTL can be assigned) for non-replicated MergeTree.
