### PR TITLE
Fix flaky test concat_nary_const_with_nonconst_segfault

### DIFF
--- a/tests/queries/0_stateless/00086_concat_nary_const_with_nonconst_segfault.sql
+++ b/tests/queries/0_stateless/00086_concat_nary_const_with_nonconst_segfault.sql
@@ -1,1 +1,1 @@
-SELECT * FROM system.numbers_mt WHERE concat(materialize('1'), '...', toString(number)) LIKE '%10000000%' LIMIT 1
+SELECT extract(toString(number), '10000000') FROM system.numbers_mt WHERE concat(materialize('1'), '...', toString(number)) LIKE '%10000000%' LIMIT 1


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


The test contained obvious race condition.

See https://clickhouse-test-reports.s3.yandex.net/0/5e54c9742f798432c238dba3465bf3c713d1e610/fast_test/runlog.out.log

![Screenshot_20210127_170217](https://user-images.githubusercontent.com/18581488/106001801-74d4f480-60c1-11eb-9193-534d9caff49b.png)
