### PR TITLE
Drop helping tables when the whole table is done in clickhouse-copier

### DIFF
--- a/programs/copier/ClusterCopier.cpp
+++ b/programs/copier/ClusterCopier.cpp
@@ -316,9 +316,6 @@ void ClusterCopier::process(const ConnectionTimeouts & timeouts)
             }
         }
 
-        /// Delete helping tables in both cases (whole table is done or not)
-        dropHelpingTables(task_table);
-
         if (!table_is_done)
         {
             throw Exception("Too many tries to process table " + task_table.table_id + ". Abort remaining execution",
@@ -1043,6 +1040,11 @@ bool ClusterCopier::tryProcessTable(const ConnectionTimeouts & timeouts, TaskTab
     if (!table_is_done)
     {
         LOG_INFO(log, "Table {} is not processed yet.Copied {} of {}, will retry", task_table.table_id, finished_partitions, required_partitions);
+    }
+    else
+    {
+        /// Delete helping tables in case that whole table is done
+        dropHelpingTables(task_table);
     }
 
     return table_is_done;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix a bug that moving pieces to destination table may failed in case of launching multiple clickhouse-copiers.

Detailed description / Documentation draft:

When launching multiple clickhouse-copiers, the one moving pieces to destination table may spend long time. However,  before it finished, the others had executed `tryProcessTable()` beyond `max_table_tries` times, and then all the piece tables had been dropped. As a result, the pieces moving failed.

@alexey-milovidov 