### PR TITLE
Used global region for accessing S3 if can't determine exactly

### DIFF
--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -71,6 +71,10 @@ void PocoHTTPClientConfiguration::updateSchemeAndRegion()
             boost::algorithm::to_lower(matched_region);
             region = matched_region;
         }
+        else
+        {
+            region = Aws::Region::AWS_GLOBAL;
+        }
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Table function `S3` will use global region if the region can't be determined exactly. This closes #10998