### PR TITLE
Add missing lsof for fasttest docker image

### DIFF
--- a/docker/test/fasttest/Dockerfile
+++ b/docker/test/fasttest/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get update \
         clang-tidy-${LLVM_VERSION} \
         cmake \
         curl \
+        lsof \
         expect \
         fakeroot \
         git \


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

`clickhouse-test` uses it https://github.com/ClickHouse/ClickHouse/blob/7c240d0ca769bea2e5e2c0f9a1562d7eb36ca33b/tests/clickhouse-test#L228