### PR TITLE
Minor code improvement in JOIN

### DIFF
--- a/src/Interpreters/HashJoin.cpp
+++ b/src/Interpreters/HashJoin.cpp
@@ -688,7 +688,7 @@ public:
         if constexpr (has_defaults)
             applyLazyDefaults();
 
-        for (size_t j = 0; j < right_indexes.size(); ++j)
+        for (size_t j = 0, size = right_indexes.size(); j < size; ++j)
             columns[j]->insertFrom(*block.getByPosition(right_indexes[j]).column, row_num);
     }
 
@@ -701,7 +701,7 @@ public:
     {
         if (lazy_defaults_count)
         {
-            for (size_t j = 0; j < right_indexes.size(); ++j)
+            for (size_t j = 0, size = right_indexes.size(); j < size; ++j)
                 JoinCommon::addDefaultValues(*columns[j], type_name[j].first, lazy_defaults_count);
             lazy_defaults_count = 0;
         }


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Writing `vec.size()` in `for` loop condition is bad practice in C++, because compiler may have to generate code to reload size from memory due to not enough strict aliasing in presence of memory modifications in the loop body; calculation of size also involves division by compile time constant (usually a bit shift).