### PR TITLE
fix client bug while executing select

### DIFF
--- a/src/Parsers/TokenIterator.cpp
+++ b/src/Parsers/TokenIterator.cpp
@@ -4,13 +4,14 @@
 namespace DB
 {
 
-UnmatchedParentheses checkUnmatchedParentheses(TokenIterator begin, Token last)
+UnmatchedParentheses checkUnmatchedParentheses(TokenIterator begin)
 {
     /// We have just two kind of parentheses: () and [].
     UnmatchedParentheses stack;
 
-    for (TokenIterator it = begin;
-        it.isValid() && it->begin <= last.begin; ++it)
+    /// We have to iterate through all tokens until the end to avoid false positive "Unmatched parentheses" error
+    /// when parser failed in the middle of the query.
+    for (TokenIterator it = begin; it.isValid(); ++it)
     {
         if (it->type == TokenType::OpeningRoundBracket || it->type == TokenType::OpeningSquareBracket)
         {

--- a/src/Parsers/TokenIterator.h
+++ b/src/Parsers/TokenIterator.h
@@ -80,6 +80,6 @@ public:
 
 /// Returns positions of unmatched parentheses.
 using UnmatchedParentheses = std::vector<Token>;
-UnmatchedParentheses checkUnmatchedParentheses(TokenIterator begin, Token last);
+UnmatchedParentheses checkUnmatchedParentheses(TokenIterator begin);
 
 }

--- a/src/Parsers/parseQuery.cpp
+++ b/src/Parsers/parseQuery.cpp
@@ -79,7 +79,7 @@ void writeQueryWithHighlightedErrorPositions(
     {
         const char * current_position_to_hilite = positions_to_hilite[position_to_hilite_idx].begin;
 
-        assert(current_position_to_hilite < end);
+        assert(current_position_to_hilite <= end);
         assert(current_position_to_hilite >= begin);
 
         out.write(pos, current_position_to_hilite - pos);

--- a/src/Parsers/parseQuery.cpp
+++ b/src/Parsers/parseQuery.cpp
@@ -290,7 +290,7 @@ ASTPtr tryParseQuery(
     }
 
     /// Unmatched parentheses
-    UnmatchedParentheses unmatched_parens = checkUnmatchedParentheses(TokenIterator(tokens), last_token);
+    UnmatchedParentheses unmatched_parens = checkUnmatchedParentheses(TokenIterator(tokens));
     if (!unmatched_parens.empty())
     {
         out_error_message = getUnmatchedParenthesesErrorMessage(query_begin,

--- a/tests/queries/0_stateless/01180_client_syntax_errors.expect
+++ b/tests/queries/0_stateless/01180_client_syntax_errors.expect
@@ -1,0 +1,32 @@
+#!/usr/bin/expect -f
+
+log_user 0
+set timeout 5
+match_max 100000
+# A default timeout action is to do nothing, change it to fail
+expect_after {
+    timeout {
+        exit 1
+    }
+}
+
+set basedir [file dirname $argv0]
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_OPT"
+expect ":) "
+
+# Make a query with syntax error
+send -- "select \r"
+expect "Syntax error: failed at position 7 (end of query):"
+expect "Expected one of: "
+
+# Make another query with syntax error
+send -- "CREATE TABLE t4 UUID '57f27aa5-141c-47c5-888a-9563681717f5' AS t1 (`rowNumberInAllBlocks()` UInt64, `toLowCardinality(arrayJoin(\['exchange', 'tables'\]))` LowCardinality(String)) ENGINE = MergeTree \r"
+expect "Syntax error: failed at position 93 ('UInt64'):*"
+
+# Make a query with unmatched parentheses
+send -- "select (1, 2\r"
+expect "Syntax error: failed at position 8 ('('):"
+expect "Unmatched parentheses: ("
+
+send -- "\4"
+expect eof


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix clickhouse-client abort exception while executing only  `select`.

Detailed description / Documentation draft:
Bug Reproduce Step: 
Clickhouse version:  v21.1.2.15-stable
Execute query `select` in clickhouse-client, then abort exception happens. The backtrace information: 
```
(gdb) bt 
#0  0x00007ffff741dc37 in raise () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007ffff7421028 in abort () from /lib/x86_64-linux-gnu/libc.so.6
#2  0x00007ffff7416bf6 in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#3  0x00007ffff7416ca2 in __assert_fail () from /lib/x86_64-linux-gnu/libc.so.6
#4  0x000000001c7f31df in DB::(anonymous namespace)::writeQueryWithHighlightedErrorPositions (out=..., begin=0x7fffffffb130 "select", end=0x7fffffffb136 "", positions_to_hilite=0x7fffffff5570, 
    num_positions_to_hilite=1) at ../src/Parsers/parseQuery.cpp:82
#5  0x000000001c7f3370 in DB::(anonymous namespace)::writeQueryAroundTheError (out=..., begin=0x7fffffffb130 "select", end=0x7fffffffb136 "", hilite=true, positions_to_hilite=0x7fffffff5570, 
    num_positions_to_hilite=1) at ../src/Parsers/parseQuery.cpp:118
#6  0x000000001c7f3ce6 in DB::(anonymous namespace)::getSyntaxErrorMessage (begin=0x7fffffffb130 "select", end=0x7fffffffb136 "", last_token=..., expected=..., hilite=true, query_description=...)
    at ../src/Parsers/parseQuery.cpp:175
#7  0x000000001c7f560b in DB::tryParseQuery (parser=..., _out_query_end=@0x7fffffff6a78: 0x7fffffffb136 "", all_queries_end=0x7fffffffb136 "", out_error_message=..., hilite=true, query_description=..., 
    allow_multi_statements=true, max_query_size=0, max_parser_depth=1000) at ../src/Parsers/parseQuery.cpp:305
#8  0x0000000007d0cfc5 in DB::Client::parseQuery (this=0x7fffffffb6d0, pos=@0x7fffffff6a78: 0x7fffffffb136 "", end=0x7fffffffb136 "", allow_multi_statements=true) at ../programs/client/Client.cpp:1665
#9  0x0000000007d02e53 in DB::Client::processMultiQuery (this=0x7fffffffb6d0, all_queries_text=...) at ../programs/client/Client.cpp:1012
#10 0x0000000007d01a57 in DB::Client::processQueryText (this=0x7fffffffb6d0, text=...) at ../programs/client/Client.cpp:870
#11 0x0000000007cf8eff in DB::Client::mainImpl (this=0x7fffffffb6d0) at ../programs/client/Client.cpp:667
#12 0x0000000007cedfbe in DB::Client::main (this=0x7fffffffb6d0) at ../programs/client/Client.cpp:280
#13 0x000000001d703b6c in Poco::Util::Application::run (this=0x7fffffffb6d0) at ../contrib/poco/Util/src/Application.cpp:334
#14 0x0000000007cde0bf in mainEntryClickHouseClient (argc=4, argv=0x7ffff64cb7d0) at ../programs/client/Client.cpp:2690
#15 0x0000000007b7286e in main (argc_=5, argv_=0x7fffffffd7e8) at ../programs/main.cpp:368
```