### PR TITLE
Fix starting the server with tables having default expressions containing dictGet()

### DIFF
--- a/src/Dictionaries/DictionaryFactory.cpp
+++ b/src/Dictionaries/DictionaryFactory.cpp
@@ -41,7 +41,7 @@ DictionaryPtr DictionaryFactory::create(
         throw Exception{name + ": element dictionary.layout should have exactly one child element",
                         ErrorCodes::EXCESSIVE_ELEMENT_IN_CONFIG};
 
-    const DictionaryStructure dict_struct{config, config_prefix + ".structure"};
+    const DictionaryStructure dict_struct{config, config_prefix};
 
     DictionarySourcePtr source_ptr = DictionarySourceFactory::instance().create(
         name, config, config_prefix + ".source", dict_struct, context, config.getString(config_prefix + ".database", ""), check_source_config);

--- a/src/Dictionaries/DictionaryStructure.cpp
+++ b/src/Dictionaries/DictionaryStructure.cpp
@@ -218,7 +218,7 @@ void DictionaryStructure::validateKeyTypes(const DataTypes & key_types) const
     }
 }
 
-const DictionaryAttribute & DictionaryStructure::getAttribute(const String& attribute_name, const DataTypePtr & type) const
+const DictionaryAttribute & DictionaryStructure::getAttribute(const String & attribute_name) const
 {
     auto find_iter
         = std::find_if(attributes.begin(), attributes.end(), [&](const auto & attribute) { return attribute.name == attribute_name; });
@@ -226,13 +226,18 @@ const DictionaryAttribute & DictionaryStructure::getAttribute(const String& attr
     if (find_iter == attributes.end())
         throw Exception{"No such attribute '" + attribute_name + "'", ErrorCodes::BAD_ARGUMENTS};
 
-    const auto & attribute = *find_iter;
+    return *find_iter;
+}
+
+const DictionaryAttribute & DictionaryStructure::getAttribute(const String& attribute_name, const DataTypePtr & type) const
+{
+    const auto & attribute = getAttribute(attribute_name);
 
     if (!areTypesEqual(attribute.type, type))
         throw Exception{"Attribute type does not match, expected " + attribute.type->getName() + ", found " + type->getName(),
             ErrorCodes::TYPE_MISMATCH};
 
-    return *find_iter;
+    return attribute;
 }
 
 std::string DictionaryStructure::getKeyDescription() const

--- a/src/Dictionaries/DictionaryStructure.h
+++ b/src/Dictionaries/DictionaryStructure.h
@@ -150,6 +150,7 @@ struct DictionaryStructure final
     std::optional<DictionaryTypedSpecialAttribute> range_min;
     std::optional<DictionaryTypedSpecialAttribute> range_max;
     bool has_expressions = false;
+    bool access_to_key_from_attributes = false;
 
     DictionaryStructure(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix);
 

--- a/src/Dictionaries/DictionaryStructure.h
+++ b/src/Dictionaries/DictionaryStructure.h
@@ -154,7 +154,8 @@ struct DictionaryStructure final
     DictionaryStructure(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix);
 
     void validateKeyTypes(const DataTypes & key_types) const;
-    const DictionaryAttribute &getAttribute(const String& attribute_name, const DataTypePtr & type) const;
+    const DictionaryAttribute & getAttribute(const String & attribute_name) const;
+    const DictionaryAttribute & getAttribute(const String & attribute_name, const DataTypePtr & type) const;
     std::string getKeyDescription() const;
     bool isKeySizeFixed() const;
     size_t getKeySize() const;

--- a/src/Dictionaries/IPAddressDictionary.h
+++ b/src/Dictionaries/IPAddressDictionary.h
@@ -28,8 +28,7 @@ public:
         const DictionaryStructure & dict_struct_,
         DictionarySourcePtr source_ptr_,
         const DictionaryLifetime dict_lifetime_,
-        bool require_nonempty_,
-        bool access_to_key_from_attributes_);
+        bool require_nonempty_);
 
     std::string getKeyDescription() const { return key_description; }
 
@@ -47,8 +46,7 @@ public:
 
     std::shared_ptr<const IExternalLoadable> clone() const override
     {
-        return std::make_shared<IPAddressDictionary>(getDictionaryID(), dict_struct, source_ptr->clone(), dict_lifetime,
-                                                     require_nonempty, access_to_key_from_attributes);
+        return std::make_shared<IPAddressDictionary>(getDictionaryID(), dict_struct, source_ptr->clone(), dict_lifetime, require_nonempty);
     }
 
     const IDictionarySource * getSource() const override { return source_ptr.get(); }

--- a/src/Interpreters/ExternalDictionariesLoader.cpp
+++ b/src/Interpreters/ExternalDictionariesLoader.cpp
@@ -38,7 +38,7 @@ ExternalLoader::LoadablePtr ExternalDictionariesLoader::create(
 DictionaryStructure
 ExternalDictionariesLoader::getDictionaryStructure(const Poco::Util::AbstractConfiguration & config, const std::string & key_in_config)
 {
-    return {config, key_in_config + ".structure"};
+    return {config, key_in_config};
 }
 
 DictionaryStructure ExternalDictionariesLoader::getDictionaryStructure(const ObjectConfig & config)

--- a/tests/queries/0_stateless/01676_dictget_in_default_expression.reference
+++ b/tests/queries/0_stateless/01676_dictget_in_default_expression.reference
@@ -1,0 +1,11 @@
+2	20
+3	15
+status:
+LOADED
+status_after_detach_and_attach:
+NOT_LOADED
+2	20
+3	15
+4	40
+status:
+LOADED

--- a/tests/queries/0_stateless/01676_dictget_in_default_expression.sql
+++ b/tests/queries/0_stateless/01676_dictget_in_default_expression.sql
@@ -1,0 +1,31 @@
+DROP DATABASE IF EXISTS test_01676 SYNC;
+
+CREATE DATABASE test_01676;
+
+CREATE TABLE test_01676.dict_data (key UInt64, value UInt64) ENGINE=MergeTree ORDER BY tuple();
+INSERT INTO test_01676.dict_data VALUES (2,20), (3,30), (4,40), (5,50);
+
+CREATE DICTIONARY test_01676.dict (key UInt64, value UInt64) PRIMARY KEY key SOURCE(CLICKHOUSE(DB 'test_01676' TABLE 'dict_data' HOST '127.0.0.1' PORT tcpPort())) LIFETIME(0) LAYOUT(HASHED());
+
+CREATE TABLE test_01676.table (x UInt64, y UInt64 DEFAULT dictGet('test_01676.dict', 'value', x)) ENGINE=MergeTree ORDER BY tuple();
+INSERT INTO test_01676.table (x) VALUES (2);
+INSERT INTO test_01676.table VALUES (toUInt64(3), toUInt64(15));
+
+SELECT * FROM test_01676.table ORDER BY x;
+
+SELECT 'status:';
+SELECT status FROM system.dictionaries WHERE database='test_01676' AND name='dict';
+
+DETACH DATABASE test_01676;
+ATTACH DATABASE test_01676;
+
+SELECT 'status_after_detach_and_attach:';
+SELECT status FROM system.dictionaries WHERE database='test_01676' AND name='dict';
+
+INSERT INTO test_01676.table (x) VALUES (toInt64(4));
+SELECT * FROM test_01676.table ORDER BY x;
+
+SELECT 'status:';
+SELECT status FROM system.dictionaries WHERE database='test_01676' AND name='dict';
+
+DROP DATABASE test_01676;

--- a/tests/queries/skip_list.json
+++ b/tests/queries/skip_list.json
@@ -566,6 +566,7 @@
         "01602_show_create_view",
         "01603_rename_overwrite_bug",
         "01646_system_restart_replicas_smoke", // system restart replicas is a global query
+        "01676_dictget_in_default_expression",
         "attach",
         "ddl_dictionaries",
         "dictionary",


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Bug Fix

Changelog entry:
Fix starting the server with tables having default expressions containing dictGet().
Allow getting return type of dictGet() without loading dictionary.