### PR TITLE
style-check tiny fixes

### DIFF
--- a/docker/test/style/Dockerfile
+++ b/docker/test/style/Dockerfile
@@ -4,9 +4,13 @@ FROM ubuntu:20.04
 RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install --yes shellcheck libxml2-utils git python3-pip pylint && pip3 install codespell
 
 
+# For |& syntax
+SHELL ["bash", "-c"]
+
 CMD cd /ClickHouse/utils/check-style && \
-    ./check-style -n | tee /test_output/style_output.txt && \
-    ./check-typos | tee /test_output/typos_output.txt && \
-    ./check-whitespaces -n | tee /test_output/whitespaces_output.txt && \
-    ./check-duplicate-includes.sh | tee /test_output/duplicate_output.txt && \
-    ./shellcheck-run.sh | tee /test_output/shellcheck_output.txt
+    ./check-style -n              |& tee /test_output/style_output.txt && \
+    ./check-typos                 |& tee /test_output/typos_output.txt && \
+    ./check-whitespaces -n        |& tee /test_output/whitespaces_output.txt && \
+    ./check-duplicate-includes.sh |& tee /test_output/duplicate_output.txt && \
+    ./shellcheck-run.sh           |& tee /test_output/shellcheck_output.txt && \
+    true

--- a/docker/test/style/Dockerfile
+++ b/docker/test/style/Dockerfile
@@ -1,7 +1,7 @@
 # docker build -t yandex/clickhouse-style-test .
 FROM ubuntu:20.04
 
-RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install --yes shellcheck libxml2-utils git python3-pip python3-pytest && pip3 install codespell
+RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install --yes shellcheck libxml2-utils git python3-pip pylint && pip3 install codespell
 
 
 CMD cd /ClickHouse/utils/check-style && \

--- a/utils/check-style/check-style
+++ b/utils/check-style/check-style
@@ -107,7 +107,23 @@ find $ROOT_PATH -not -path $ROOT_PATH'/docker*' -not -path $ROOT_PATH'/contrib*'
 
 # Check that ya.make files are auto-generated
 "$ROOT_PATH"/utils/generate-ya-make/generate-ya-make.sh
-git status -uno | grep ya.make && echo "ya.make files should be generated with utils/generate-ya-make/generate-ya-make.sh"
+# FIXME: apparently sandbox (don't confuse it with docker) cloning sources
+# using some ancient git version, <2.8, that contains one bug for submodules
+# initialization [1]:
+#
+#    " * A partial rewrite of "git submodule" in the 2.7 timeframe changed
+#        the way the gitdir: pointer in the submodules point at the real
+#        repository location to use absolute paths by accident.  This has
+#        been corrected."
+#
+#  [1]: https://github.com/git/git/blob/cf11a67975b057a144618badf16dc4e3d25b9407/Documentation/RelNotes/2.8.3.txt#L33-L36
+#
+# Due to which "git status" will report the following error:
+#
+#     fatal: not a git repository: /place/sandbox-data/tasks/0/2/882869720/ClickHouse/.git/modules/contrib/AMQP-CPP
+#
+# Anyway this check does not requires any submodule traverse, so it is fine to ignore those errors.
+git status -uno 2> >(grep "fatal: not a git repository: /place/sandbox-data/tasks/.*/ClickHouse/\\.git/modules/contrib") | grep ya.make && echo "ya.make files should be generated with utils/generate-ya-make/generate-ya-make.sh"
 
 # Check that every header file has #pragma once in first line
 find $ROOT_PATH/{src,programs,utils} -name '*.h' |

--- a/utils/check-style/check-style
+++ b/utils/check-style/check-style
@@ -70,7 +70,7 @@ find $ROOT_PATH/{src,base,programs,utils} -name '*.xml' |
     xargs xmllint --noout --nonet
 
 # FIXME: for now only clickhouse-test
-pylint --score=n $ROOT_PATH/tests/clickhouse-test
+pylint --rcfile=$ROOT_PATH/.pylintrc --score=n $ROOT_PATH/tests/clickhouse-test
 
 # Machine translation to Russian is strictly prohibited
 find $ROOT_PATH/docs/ru -name '*.md' |


### PR DESCRIPTION
Changelog:
- fix typo in docker image (pylint not pytest)
- count stderr as an error too
- pass path to rc file for pylint
- finally fix "fatal: not a git repository: /place/sandbox-data/tasks/0/2/882869720/ClickHouse/.git/modules/contrib/AMQP-CPP" error

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @qoega 
Fixes: #19676