### PR TITLE
Adding retries for docker-compose start, stop and restart in TestFlows tests

### DIFF
--- a/tests/testflows/helpers/cluster.py
+++ b/tests/testflows/helpers/cluster.py
@@ -26,7 +26,7 @@ class Node(object):
     def repr(self):
         return f"Node(name='{self.name}')"
 
-    def restart(self, timeout=300, safe=True):
+    def restart(self, timeout=300, retries=5):
         """Restart node.
         """
         with self.cluster.lock:
@@ -35,15 +35,20 @@ class Node(object):
                     shell = self.cluster._bash.pop(key)
                     shell.__exit__(None, None, None)
 
-        self.cluster.command(None, f'{self.cluster.docker_compose} restart {self.name}', timeout=timeout)
+        for retry in range(retries):
+            r = self.cluster.command(None, f'{self.cluster.docker_compose} restart {self.name}', timeout=timeout)
+            if r.exitcode == 0:
+                break
 
-    def start(self, timeout=300, safe=True):
+    def start(self, timeout=300, retries=5):
         """Start node.
         """
-        self.cluster.command(None, f'{self.cluster.docker_compose} start {self.name}', timeout=timeout)
+        for retry in range(retries):
+            r = self.cluster.command(None, f'{self.cluster.docker_compose} start {self.name}', timeout=timeout)
+            if r.exitcode == 0:
+                break
 
-
-    def stop(self, timeout=300, safe=True):
+    def stop(self, timeout=300, retries=5):
         """Stop node.
         """
         with self.cluster.lock:
@@ -52,7 +57,10 @@ class Node(object):
                     shell = self.cluster._bash.pop(key)
                     shell.__exit__(None, None, None)
 
-        self.cluster.command(None, f'{self.cluster.docker_compose} stop {self.name}', timeout=timeout)
+        for retry in range(retries):
+            r = self.cluster.command(None, f'{self.cluster.docker_compose} stop {self.name}', timeout=timeout)
+            if r.exitcode == 0:
+                break
 
     def command(self, *args, **kwargs):
         return self.cluster.command(self.name, *args, **kwargs)
@@ -71,7 +79,7 @@ class ClickHouseNode(Node):
                     continue
                 assert False, "container is not healthy"
 
-    def stop(self, timeout=300, safe=True):
+    def stop(self, timeout=300, safe=True, retries=5):
         """Stop node.
         """
         if safe:
@@ -89,17 +97,23 @@ class ClickHouseNode(Node):
                     shell = self.cluster._bash.pop(key)
                     shell.__exit__(None, None, None)
 
-        self.cluster.command(None, f'{self.cluster.docker_compose} stop {self.name}', timeout=timeout)
+        for retry in range(retries):
+            r = self.cluster.command(None, f'{self.cluster.docker_compose} stop {self.name}', timeout=timeout)
+            if r.exitcode == 0:
+                break
 
-    def start(self, timeout=300, wait_healthy=True):
+    def start(self, timeout=300, wait_healthy=True, retries=5):
         """Start node.
         """
-        self.cluster.command(None, f'{self.cluster.docker_compose} start {self.name}', timeout=timeout)
+        for retry in range(retries):
+            r = self.cluster.command(None, f'{self.cluster.docker_compose} start {self.name}', timeout=timeout)
+            if r.exitcode == 0:
+                break
 
         if wait_healthy:
             self.wait_healthy(timeout)
 
-    def restart(self, timeout=300, safe=True, wait_healthy=True):
+    def restart(self, timeout=300, safe=True, wait_healthy=True, retries=5):
         """Restart node.
         """
         if safe:
@@ -117,7 +131,10 @@ class ClickHouseNode(Node):
                     shell = self.cluster._bash.pop(key)
                     shell.__exit__(None, None, None)
 
-        self.cluster.command(None, f'{self.cluster.docker_compose} restart {self.name}', timeout=timeout)
+        for retry in range(retries):
+            r = self.cluster.command(None, f'{self.cluster.docker_compose} restart {self.name}', timeout=timeout)
+            if r.exitcode == 0:
+                break
 
         if wait_healthy:
             self.wait_healthy(timeout)

--- a/tests/testflows/ldap/authentication/tests/common.py
+++ b/tests/testflows/ldap/authentication/tests/common.py
@@ -270,7 +270,7 @@ def ldap_authenticated_users(*users, config_d_dir="/etc/clickhouse-server/users.
             config = create_ldap_users_config_content(*users, config_d_dir=config_d_dir, config_file=config_file)
         return add_config(config, restart=restart)
 
-def invalid_server_config(servers, message=None, tail=13, timeout=60):
+def invalid_server_config(servers, message=None, tail=30, timeout=60):
     """Check that ClickHouse errors when trying to load invalid LDAP servers configuration file.
     """
     node = current().context.node
@@ -299,7 +299,7 @@ def invalid_server_config(servers, message=None, tail=13, timeout=60):
             with By("removing the config file", description=config.path):
                 node.command(f"rm -rf {config.path}", exitcode=0)
 
-def invalid_user_config(servers, config, message=None, tail=13, timeout=60):
+def invalid_user_config(servers, config, message=None, tail=30, timeout=60):
     """Check that ClickHouse errors when trying to load invalid LDAP users configuration file.
     """
     node = current().context.node

--- a/tests/testflows/ldap/authentication/tests/server_config.py
+++ b/tests/testflows/ldap/authentication/tests/server_config.py
@@ -245,7 +245,7 @@ def invalid_verification_cooldown_value(self, invalid_value, timeout=20):
         }}
 
     with When("I try to use this configuration then it should not work"):
-        invalid_server_config(servers, message=error_message, tail=17, timeout=timeout)
+        invalid_server_config(servers, message=error_message, tail=30, timeout=timeout)
 
 @TestScenario
 @Requirements(

--- a/tests/testflows/ldap/authentication/tests/user_config.py
+++ b/tests/testflows/ldap/authentication/tests/user_config.py
@@ -39,7 +39,7 @@ def empty_server_name(self, timeout=20):
         "message": "DB::Exception: user1: Authentication failed: password is incorrect or there is no user with such name"
     }]
     config = create_ldap_users_config_content(*users)
-    invalid_user_config(servers, config, message=message, tail=15, timeout=timeout)
+    invalid_user_config(servers, config, message=message, tail=30, timeout=timeout)
 
 @TestScenario
 @Requirements(
@@ -147,7 +147,7 @@ def ldap_and_password(self):
     error_message = "DB::Exception: More than one field of 'password'"
 
     with Then("I expect an error when I try to load the configuration file", description=error_message):
-        invalid_user_config(servers, new_config, message=error_message, tail=16)
+        invalid_user_config(servers, new_config, message=error_message, tail=30)
 
 @TestFeature
 @Name("user config")

--- a/tests/testflows/ldap/external_user_directory/tests/common.py
+++ b/tests/testflows/ldap/external_user_directory/tests/common.py
@@ -133,7 +133,7 @@ def create_entries_ldap_external_user_directory_config_content(entries, config_d
 
     return Config(content, path, name, uid, "config.xml")
 
-def invalid_ldap_external_user_directory_config(server, roles, message, tail=20, timeout=60, config=None):
+def invalid_ldap_external_user_directory_config(server, roles, message, tail=30, timeout=60, config=None):
     """Check that ClickHouse errors when trying to load invalid LDAP external user directory
     configuration file.
     """

--- a/tests/testflows/ldap/external_user_directory/tests/server_config.py
+++ b/tests/testflows/ldap/external_user_directory/tests/server_config.py
@@ -41,7 +41,7 @@ def invalid_host(self):
     RQ_SRS_009_LDAP_ExternalUserDirectory_Configuration_Server_Invalid("1.0"),
     RQ_SRS_009_LDAP_ExternalUserDirectory_Configuration_Server_Host("1.0")
 )
-def empty_host(self, tail=20, timeout=60):
+def empty_host(self, tail=30, timeout=60):
     """Check that server returns an error when LDAP server
     host value is empty.
     """
@@ -50,14 +50,14 @@ def empty_host(self, tail=20, timeout=60):
 
     servers = {"foo": {"host": "", "port": "389", "enable_tls": "no"}}
 
-    invalid_server_config(servers, message=message, tail=16, timeout=timeout)
+    invalid_server_config(servers, message=message, tail=30, timeout=timeout)
 
 @TestScenario
 @Requirements(
     RQ_SRS_009_LDAP_ExternalUserDirectory_Configuration_Server_Invalid("1.0"),
     RQ_SRS_009_LDAP_ExternalUserDirectory_Configuration_Server_Host("1.0")
 )
-def missing_host(self, tail=20, timeout=60):
+def missing_host(self, tail=30, timeout=60):
     """Check that server returns an error when LDAP server
     host is missing.
     """
@@ -148,7 +148,7 @@ def invalid_enable_tls_value(self, timeout=60):
     servers = {"openldap1": {"host": "openldap1", "port": "389", "enable_tls": "foo",
         "auth_dn_prefix": "cn=", "auth_dn_suffix": ",ou=users,dc=company,dc=com"
     }}
-    invalid_server_config(servers, message=message, tail=18, timeout=timeout)
+    invalid_server_config(servers, message=message, tail=30, timeout=timeout)
 
 @TestScenario
 @Requirements(
@@ -259,7 +259,7 @@ def invalid_verification_cooldown_value(self, invalid_value, timeout=20):
         }}
 
     with When("I try to use this configuration then it should not work"):
-        invalid_server_config(servers, message=error_message, tail=17, timeout=timeout)
+        invalid_server_config(servers, message=error_message, tail=30, timeout=timeout)
 
 @TestScenario
 @Requirements(

--- a/tests/testflows/ldap/role_mapping/regression.py
+++ b/tests/testflows/ldap/role_mapping/regression.py
@@ -18,7 +18,7 @@ xfails = {
 @Name("role mapping")
 @ArgumentParser(argparser)
 @Specifications(
-    QA_SRS014_ClickHouse_LDAP_Role_Mapping
+    SRS_014_ClickHouse_LDAP_Role_Mapping
 )
 @Requirements(
     RQ_SRS_014_LDAP_RoleMapping("1.0")

--- a/tests/testflows/ldap/role_mapping/requirements/requirements.md
+++ b/tests/testflows/ldap/role_mapping/requirements/requirements.md
@@ -1,0 +1,504 @@
+# SRS-014 ClickHouse LDAP Role Mapping
+# Software Requirements Specification
+
+## Table of Contents
+
+* 1 [Revision History](#revision-history)
+* 2 [Introduction](#introduction)
+* 3 [Terminology](#terminology)
+  * 3.1 [LDAP](#ldap)
+* 4 [Requirements](#requirements)
+  * 4.1 [General](#general)
+    * 4.1.1 [RQ.SRS-014.LDAP.RoleMapping](#rqsrs-014ldaprolemapping)
+    * 4.1.2 [RQ.SRS-014.LDAP.RoleMapping.WithFixedRoles](#rqsrs-014ldaprolemappingwithfixedroles)
+    * 4.1.3 [RQ.SRS-014.LDAP.RoleMapping.Search](#rqsrs-014ldaprolemappingsearch)
+  * 4.2 [Mapped Role Names](#mapped-role-names)
+    * 4.2.1 [RQ.SRS-014.LDAP.RoleMapping.Map.Role.Name.WithUTF8Characters](#rqsrs-014ldaprolemappingmaprolenamewithutf8characters)
+    * 4.2.2 [RQ.SRS-014.LDAP.RoleMapping.Map.Role.Name.Long](#rqsrs-014ldaprolemappingmaprolenamelong)
+    * 4.2.3 [RQ.SRS-014.LDAP.RoleMapping.Map.Role.Name.WithSpecialXMLCharacters](#rqsrs-014ldaprolemappingmaprolenamewithspecialxmlcharacters)
+    * 4.2.4 [RQ.SRS-014.LDAP.RoleMapping.Map.Role.Name.WithSpecialRegexCharacters](#rqsrs-014ldaprolemappingmaprolenamewithspecialregexcharacters)
+  * 4.3 [Multiple Roles](#multiple-roles)
+    * 4.3.1 [RQ.SRS-014.LDAP.RoleMapping.Map.MultipleRoles](#rqsrs-014ldaprolemappingmapmultipleroles)
+  * 4.4 [LDAP Groups](#ldap-groups)
+    * 4.4.1 [RQ.SRS-014.LDAP.RoleMapping.LDAP.Group.Removed](#rqsrs-014ldaprolemappingldapgroupremoved)
+    * 4.4.2 [RQ.SRS-014.LDAP.RoleMapping.LDAP.Group.RemovedAndAdded.Parallel](#rqsrs-014ldaprolemappingldapgroupremovedandaddedparallel)
+    * 4.4.3 [RQ.SRS-014.LDAP.RoleMapping.LDAP.Group.UserRemoved](#rqsrs-014ldaprolemappingldapgroupuserremoved)
+    * 4.4.4 [RQ.SRS-014.LDAP.RoleMapping.LDAP.Group.UserRemovedAndAdded.Parallel](#rqsrs-014ldaprolemappingldapgroupuserremovedandaddedparallel)
+  * 4.5 [RBAC Roles](#rbac-roles)
+    * 4.5.1 [RQ.SRS-014.LDAP.RoleMapping.RBAC.Role.NotPresent](#rqsrs-014ldaprolemappingrbacrolenotpresent)
+    * 4.5.2 [RQ.SRS-014.LDAP.RoleMapping.RBAC.Role.Added](#rqsrs-014ldaprolemappingrbacroleadded)
+    * 4.5.3 [RQ.SRS-014.LDAP.RoleMapping.RBAC.Role.Removed](#rqsrs-014ldaprolemappingrbacroleremoved)
+    * 4.5.4 [RQ.SRS-014.LDAP.RoleMapping.RBAC.Role.Readded](#rqsrs-014ldaprolemappingrbacrolereadded)
+    * 4.5.5 [RQ.SRS-014.LDAP.RoleMapping.RBAC.Role.RemovedAndAdded.Parallel](#rqsrs-014ldaprolemappingrbacroleremovedandaddedparallel)
+    * 4.5.6 [RQ.SRS-014.LDAP.RoleMapping.RBAC.Role.New](#rqsrs-014ldaprolemappingrbacrolenew)
+    * 4.5.7 [RQ.SRS-014.LDAP.RoleMapping.RBAC.Role.NewPrivilege](#rqsrs-014ldaprolemappingrbacrolenewprivilege)
+    * 4.5.8 [RQ.SRS-014.LDAP.RoleMapping.RBAC.Role.RemovedPrivilege](#rqsrs-014ldaprolemappingrbacroleremovedprivilege)
+  * 4.6 [Authentication](#authentication)
+    * 4.6.1 [RQ.SRS-014.LDAP.RoleMapping.Authentication.Parallel](#rqsrs-014ldaprolemappingauthenticationparallel)
+    * 4.6.2 [RQ.SRS-014.LDAP.RoleMapping.Authentication.Parallel.ValidAndInvalid](#rqsrs-014ldaprolemappingauthenticationparallelvalidandinvalid)
+    * 4.6.3 [RQ.SRS-014.LDAP.RoleMapping.Authentication.Parallel.MultipleServers](#rqsrs-014ldaprolemappingauthenticationparallelmultipleservers)
+    * 4.6.4 [RQ.SRS-014.LDAP.RoleMapping.Authentication.Parallel.LocalOnly](#rqsrs-014ldaprolemappingauthenticationparallellocalonly)
+    * 4.6.5 [RQ.SRS-014.LDAP.RoleMapping.Authentication.Parallel.LocalAndMultipleLDAP](#rqsrs-014ldaprolemappingauthenticationparallellocalandmultipleldap)
+    * 4.6.6 [RQ.SRS-014.LDAP.RoleMapping.Authentication.Parallel.SameUser](#rqsrs-014ldaprolemappingauthenticationparallelsameuser)
+  * 4.7 [Server Configuration](#server-configuration)
+    * 4.7.1 [BindDN Parameter](#binddn-parameter)
+      * 4.7.1.1 [RQ.SRS-014.LDAP.RoleMapping.Configuration.Server.BindDN](#rqsrs-014ldaprolemappingconfigurationserverbinddn)
+      * 4.7.1.2 [RQ.SRS-014.LDAP.RoleMapping.Configuration.Server.BindDN.ConflictWith.AuthDN](#rqsrs-014ldaprolemappingconfigurationserverbinddnconflictwithauthdn)
+  * 4.8 [External User Directory Configuration](#external-user-directory-configuration)
+    * 4.8.1 [Syntax](#syntax)
+      * 4.8.1.1 [RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Syntax](#rqsrs-014ldaprolemappingconfigurationuserdirectoryrolemappingsyntax)
+    * 4.8.2 [Special Characters Escaping](#special-characters-escaping)
+      * 4.8.2.1 [RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.SpecialCharactersEscaping](#rqsrs-014ldaprolemappingconfigurationuserdirectoryrolemappingspecialcharactersescaping)
+    * 4.8.3 [Multiple Sections](#multiple-sections)
+      * 4.8.3.1 [RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.MultipleSections](#rqsrs-014ldaprolemappingconfigurationuserdirectoryrolemappingmultiplesections)
+      * 4.8.3.2 [RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.MultipleSections.IdenticalParameters](#rqsrs-014ldaprolemappingconfigurationuserdirectoryrolemappingmultiplesectionsidenticalparameters)
+    * 4.8.4 [BaseDN Parameter](#basedn-parameter)
+      * 4.8.4.1 [RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.BaseDN](#rqsrs-014ldaprolemappingconfigurationuserdirectoryrolemappingbasedn)
+    * 4.8.5 [Attribute Parameter](#attribute-parameter)
+      * 4.8.5.1 [RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Attribute](#rqsrs-014ldaprolemappingconfigurationuserdirectoryrolemappingattribute)
+    * 4.8.6 [Scope Parameter](#scope-parameter)
+      * 4.8.6.1 [RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Scope](#rqsrs-014ldaprolemappingconfigurationuserdirectoryrolemappingscope)
+      * 4.8.6.2 [RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Scope.Value.Base](#rqsrs-014ldaprolemappingconfigurationuserdirectoryrolemappingscopevaluebase)
+      * 4.8.6.3 [RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Scope.Value.OneLevel](#rqsrs-014ldaprolemappingconfigurationuserdirectoryrolemappingscopevalueonelevel)
+      * 4.8.6.4 [RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Scope.Value.Children](#rqsrs-014ldaprolemappingconfigurationuserdirectoryrolemappingscopevaluechildren)
+      * 4.8.6.5 [RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Scope.Value.Subtree](#rqsrs-014ldaprolemappingconfigurationuserdirectoryrolemappingscopevaluesubtree)
+      * 4.8.6.6 [RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Scope.Value.Default](#rqsrs-014ldaprolemappingconfigurationuserdirectoryrolemappingscopevaluedefault)
+    * 4.8.7 [Search Filter Parameter](#search-filter-parameter)
+      * 4.8.7.1 [RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.SearchFilter](#rqsrs-014ldaprolemappingconfigurationuserdirectoryrolemappingsearchfilter)
+    * 4.8.8 [Prefix Parameter](#prefix-parameter)
+      * 4.8.8.1 [RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Prefix](#rqsrs-014ldaprolemappingconfigurationuserdirectoryrolemappingprefix)
+      * 4.8.8.2 [RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Prefix.Default](#rqsrs-014ldaprolemappingconfigurationuserdirectoryrolemappingprefixdefault)
+      * 4.8.8.3 [RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Prefix.WithUTF8Characters](#rqsrs-014ldaprolemappingconfigurationuserdirectoryrolemappingprefixwithutf8characters)
+      * 4.8.8.4 [RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Prefix.WithSpecialXMLCharacters](#rqsrs-014ldaprolemappingconfigurationuserdirectoryrolemappingprefixwithspecialxmlcharacters)
+      * 4.8.8.5 [RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Prefix.WithSpecialRegexCharacters](#rqsrs-014ldaprolemappingconfigurationuserdirectoryrolemappingprefixwithspecialregexcharacters)
+* 5 [References](#references)
+
+## Revision History
+
+This document is stored in an electronic form using [Git] source control management software
+hosted in a [GitHub Repository].
+All the updates are tracked using the [Revision History].
+
+## Introduction
+
+The [SRS-007 ClickHouse Authentication of Users via LDAP] added support for authenticating
+users using an [LDAP] server and the [SRS-009 ClickHouse LDAP External User Directory] added
+support for authenticating users using an [LDAP] external user directory. 
+
+This requirements specification adds additional functionality for mapping [LDAP] groups to 
+the corresponding [ClickHouse] [RBAC] roles when [LDAP] external user directory is configured.
+This functionality will enable easier access management for [LDAP] authenticated users
+as the privileges granted by the roles can be granted or revoked by granting or revoking
+a corresponding [LDAP] group to one or more [LDAP] users.
+
+For the use case when only [LDAP] user authentication is used, the roles can be
+managed using [RBAC] in the same way as for non-[LDAP] authenticated users.
+
+## Terminology
+
+### LDAP
+
+* Lightweight Directory Access Protocol
+
+## Requirements
+
+### General
+
+#### RQ.SRS-014.LDAP.RoleMapping
+version: 1.0
+
+[ClickHouse] SHALL support mapping of [LDAP] groups to [RBAC] roles
+for users authenticated using [LDAP] external user directory.
+
+#### RQ.SRS-014.LDAP.RoleMapping.WithFixedRoles
+version: 1.0
+
+[ClickHouse] SHALL support mapping of [LDAP] groups to [RBAC] roles
+for users authenticated using [LDAP] external user directory when
+one or more roles are specified in the `<roles>` section.
+
+#### RQ.SRS-014.LDAP.RoleMapping.Search
+version: 1.0
+
+[ClickHouse] SHALL perform search on the [LDAP] server and map the results to [RBAC] role names 
+when authenticating users using the [LDAP] external user directory if the `<role_mapping>` section is configured
+as part of the [LDAP] external user directory. The matched roles SHALL be assigned to the user.
+
+### Mapped Role Names
+
+#### RQ.SRS-014.LDAP.RoleMapping.Map.Role.Name.WithUTF8Characters
+version: 1.0
+
+[ClickHouse] SHALL support mapping [LDAP] search results for users authenticated using [LDAP] external user directory
+to an [RBAC] role that contains UTF-8 characters.
+
+#### RQ.SRS-014.LDAP.RoleMapping.Map.Role.Name.Long
+version: 1.0
+
+[ClickHouse] SHALL support mapping [LDAP] search results for users authenticated using [LDAP] external user directory
+to an [RBAC] role that has a name with more than 128 characters.
+
+#### RQ.SRS-014.LDAP.RoleMapping.Map.Role.Name.WithSpecialXMLCharacters
+version: 1.0
+
+[ClickHouse] SHALL support mapping [LDAP] search results for users authenticated using [LDAP] external user directory
+to an [RBAC] role that has a name that contains special characters that need to be escaped in XML.
+
+#### RQ.SRS-014.LDAP.RoleMapping.Map.Role.Name.WithSpecialRegexCharacters
+version: 1.0
+
+[ClickHouse] SHALL support mapping [LDAP] search results for users authenticated using [LDAP] external user directory
+to an [RBAC] role that has a name that contains special characters that need to be escaped in regex.
+
+### Multiple Roles
+
+#### RQ.SRS-014.LDAP.RoleMapping.Map.MultipleRoles
+version: 1.0
+
+[ClickHouse] SHALL support mapping one or more [LDAP] search results for users authenticated using 
+[LDAP] external user directory to one or more [RBAC] role.
+
+### LDAP Groups
+
+#### RQ.SRS-014.LDAP.RoleMapping.LDAP.Group.Removed
+version: 1.0
+
+[ClickHouse] SHALL not assign [RBAC] role(s) for any users authenticated using [LDAP] external user directory
+if the corresponding [LDAP] group(s) that map those role(s) are removed. Any users that have active sessions SHALL still
+have privileges provided by the role(s) until the next time they are authenticated.
+
+#### RQ.SRS-014.LDAP.RoleMapping.LDAP.Group.RemovedAndAdded.Parallel
+version: 1.0
+
+[ClickHouse] SHALL support authenticating users using [LDAP] external user directory 
+when [LDAP] groups are removed and added 
+at the same time as [LDAP] user authentications are performed in parallel.
+
+#### RQ.SRS-014.LDAP.RoleMapping.LDAP.Group.UserRemoved
+version: 1.0
+
+[ClickHouse] SHALL not assign [RBAC] role(s) for the user authenticated using [LDAP] external user directory
+if the user has been removed from the corresponding [LDAP] group(s) that map those role(s). 
+Any active user sessions SHALL have privileges provided by the role(s) until the next time the user is authenticated.
+
+#### RQ.SRS-014.LDAP.RoleMapping.LDAP.Group.UserRemovedAndAdded.Parallel
+version: 1.0
+
+[ClickHouse] SHALL support authenticating users using [LDAP] external user directory
+when [LDAP] users are added and removed from [LDAP] groups used to map to [RBAC] roles
+at the same time as [LDAP] user authentications are performed in parallel.
+
+### RBAC Roles
+
+#### RQ.SRS-014.LDAP.RoleMapping.RBAC.Role.NotPresent
+version: 1.0
+
+[ClickHouse] SHALL not reject authentication attempt using [LDAP] external user directory if any of the roles that are 
+are mapped from [LDAP] but are not present locally.
+
+#### RQ.SRS-014.LDAP.RoleMapping.RBAC.Role.Added
+version: 1.0
+
+[ClickHouse] SHALL add the privileges provided by the [LDAP] mapped role when the
+role is not present during user authentication using [LDAP] external user directory
+as soon as the role is added.
+
+#### RQ.SRS-014.LDAP.RoleMapping.RBAC.Role.Removed
+version: 1.0
+
+[ClickHouse] SHALL remove the privileges provided by the role from all the
+users authenticated using [LDAP] external user directory if the [RBAC] role that was mapped
+as a result of [LDAP] search is removed.
+
+#### RQ.SRS-014.LDAP.RoleMapping.RBAC.Role.Readded
+version: 1.0
+
+[ClickHouse] SHALL reassign the [RBAC] role and add all the privileges provided by the role
+when it is re-added after removal for all [LDAP] users authenticated using external user directory
+for any role that was mapped as a result of [LDAP] search.
+
+#### RQ.SRS-014.LDAP.RoleMapping.RBAC.Role.RemovedAndAdded.Parallel
+version: 1.0
+
+[ClickHouse] SHALL support authenticating users using [LDAP] external user directory
+when [RBAC] roles that are mapped by [LDAP] groups
+are added and removed at the same time as [LDAP] user authentications are performed in parallel.
+
+#### RQ.SRS-014.LDAP.RoleMapping.RBAC.Role.New
+version: 1.0
+
+[ClickHouse] SHALL not allow any new roles to be assigned to any
+users authenticated using [LDAP] external user directory unless the role is specified
+in the configuration of the external user directory or was mapped as a result of [LDAP] search.
+
+#### RQ.SRS-014.LDAP.RoleMapping.RBAC.Role.NewPrivilege
+version: 1.0
+
+[ClickHouse] SHALL add new privilege to all the users authenticated using [LDAP] external user directory
+when new privilege is added to one of the roles that were mapped as a result of [LDAP] search.
+
+#### RQ.SRS-014.LDAP.RoleMapping.RBAC.Role.RemovedPrivilege
+version: 1.0
+
+[ClickHouse] SHALL remove privilege from all the users authenticated using [LDAP] external user directory
+when the privilege that was provided by the mapped role is removed from all the roles 
+that were mapped as a result of [LDAP] search.
+
+### Authentication
+
+#### RQ.SRS-014.LDAP.RoleMapping.Authentication.Parallel
+version: 1.0
+
+[ClickHouse] SHALL support parallel authentication of users using [LDAP] server
+when using [LDAP] external user directory that has role mapping enabled.
+
+#### RQ.SRS-014.LDAP.RoleMapping.Authentication.Parallel.ValidAndInvalid
+version: 1.0
+
+[ClickHouse] SHALL support authentication of valid users and
+prohibit authentication of invalid users using [LDAP] server
+in parallel without having invalid attempts affecting valid authentications
+when using [LDAP] external user directory that has role mapping enabled.
+
+#### RQ.SRS-014.LDAP.RoleMapping.Authentication.Parallel.MultipleServers
+version: 1.0
+
+[ClickHouse] SHALL support parallel authentication of external [LDAP] users
+authenticated using multiple [LDAP] external user directories that have
+role mapping enabled.
+
+#### RQ.SRS-014.LDAP.RoleMapping.Authentication.Parallel.LocalOnly
+version: 1.0
+
+[ClickHouse] SHALL support parallel authentication of users defined only locally
+when one or more [LDAP] external user directories with role mapping
+are specified in the configuration file.
+
+#### RQ.SRS-014.LDAP.RoleMapping.Authentication.Parallel.LocalAndMultipleLDAP
+version: 1.0
+
+[ClickHouse] SHALL support parallel authentication of local and external [LDAP] users
+authenticated using multiple [LDAP] external user directories with role mapping enabled.
+
+#### RQ.SRS-014.LDAP.RoleMapping.Authentication.Parallel.SameUser
+version: 1.0
+
+[ClickHouse] SHALL support parallel authentication of the same external [LDAP] user
+authenticated using the same [LDAP] external user directory with role mapping enabled.
+
+### Server Configuration
+
+#### BindDN Parameter
+
+##### RQ.SRS-014.LDAP.RoleMapping.Configuration.Server.BindDN
+version: 1.0
+
+[ClickHouse] SHALL support the `<bind_dn>` parameter in the `<ldap_servers><server_name>` section
+of the `config.xml` that SHALL be used to construct the `DN` to bind to.
+The resulting `DN` SHALL be constructed by replacing all `{user_name}` substrings of the template 
+with the actual user name during each authentication attempt.
+
+For example, 
+
+```xml
+<yandex>
+    <ldap_servers>
+        <my_ldap_server>
+            <!-- ... -->
+            <bind_dn>uid={user_name},ou=users,dc=example,dc=com</bind_dn>
+            <!-- ... -->
+        </my_ldap_server>
+    </ldap_servers>
+</yandex>
+```
+
+##### RQ.SRS-014.LDAP.RoleMapping.Configuration.Server.BindDN.ConflictWith.AuthDN
+version: 1.0
+
+[ClickHouse] SHALL return an error if both `<bind_dn>` and `<auth_dn_prefix>` or `<auth_dn_suffix>` parameters
+are specified as part of [LDAP] server description in the `<ldap_servers>` section of the `config.xml`.
+
+### External User Directory Configuration
+
+#### Syntax
+
+##### RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Syntax
+version: 1.0
+
+[ClickHouse] SHALL support the `role_mapping` sub-section in the `<user_directories><ldap>` section
+of the `config.xml`.
+
+For example,
+
+```xml
+<yandex>
+    <user_directories>
+        <ldap>
+            <!-- ... -->
+            <role_mapping>
+                <base_dn>ou=groups,dc=example,dc=com</base_dn>
+                <attribute>cn</attribute>
+                <scope>subtree</scope>
+                <search_filter>(&amp;(objectClass=groupOfNames)(member={bind_dn}))</search_filter>
+                <prefix>clickhouse_</prefix>
+            </role_mapping>
+        </ldap>
+    </user_directories>
+</yandex>
+```
+
+#### Special Characters Escaping
+
+##### RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.SpecialCharactersEscaping
+version: 1.0
+
+[ClickHouse] SHALL support properly escaped special XML characters that can be present
+as part of the values for different configuration parameters inside the
+`<user_directories><ldap><role_mapping>` section of the `config.xml` such as
+
+* `<search_filter>` parameter
+* `<prefix>` parameter
+
+#### Multiple Sections
+
+##### RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.MultipleSections
+version: 1.0
+
+[ClickHouse] SHALL support multiple `<role_mapping>` sections defined inside the same `<user_directories><ldap>` section 
+of the `config.xml` and all of the `<role_mapping>` sections SHALL be applied.
+
+##### RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.MultipleSections.IdenticalParameters
+version: 1.0
+
+[ClickHouse] SHALL not duplicate mapped roles when multiple `<role_mapping>` sections 
+with identical parameters are defined inside the `<user_directories><ldap>` section 
+of the `config.xml`.
+
+#### BaseDN Parameter
+
+##### RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.BaseDN
+version: 1.0
+
+[ClickHouse] SHALL support the `<base_dn>` parameter in the `<user_directories><ldap><role_mapping>` section 
+of the `config.xml` that SHALL specify the template to be used to construct the base `DN` for the [LDAP] search.
+
+The resulting `DN` SHALL be constructed by replacing all the `{user_name}` and `{bind_dn}` substrings of 
+the template with the actual user name and bind `DN` during each [LDAP] search.
+
+#### Attribute Parameter
+
+##### RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Attribute
+version: 1.0
+
+[ClickHouse] SHALL support the `<attribute>` parameter in the `<user_directories><ldap><role_mapping>` section of 
+the `config.xml` that SHALL specify the name of the attribute whose values SHALL be returned by the [LDAP] search.
+
+#### Scope Parameter
+
+##### RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Scope
+version: 1.0
+
+[ClickHouse] SHALL support the `<scope>` parameter in the `<user_directories><ldap><role_mapping>` section of 
+the `config.xml` that SHALL define the scope of the LDAP search as defined 
+by the https://ldapwiki.com/wiki/LDAP%20Search%20Scopes.
+
+##### RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Scope.Value.Base
+version: 1.0
+
+[ClickHouse] SHALL support the `base` value for the the `<scope>` parameter in the 
+`<user_directories><ldap><role_mapping>` section of the `config.xml` that SHALL
+limit the scope as specified by the https://ldapwiki.com/wiki/BaseObject.
+
+##### RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Scope.Value.OneLevel
+version: 1.0
+
+[ClickHouse] SHALL support the `one_level` value for the the `<scope>` parameter in the 
+`<user_directories><ldap><role_mapping>` section of the `config.xml` that SHALL
+limit the scope as specified by the https://ldapwiki.com/wiki/SingleLevel.
+
+##### RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Scope.Value.Children
+version: 1.0
+
+[ClickHouse] SHALL support the `children` value for the the `<scope>` parameter in the 
+`<user_directories><ldap><role_mapping>` section of the `config.xml` that SHALL
+limit the scope as specified by the https://ldapwiki.com/wiki/SubordinateSubtree.
+
+##### RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Scope.Value.Subtree
+version: 1.0
+
+[ClickHouse] SHALL support the `children` value for the the `<scope>` parameter in the 
+`<user_directories><ldap><role_mapping>` section of the `config.xml` that SHALL
+limit the scope as specified by the https://ldapwiki.com/wiki/WholeSubtree.
+
+##### RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Scope.Value.Default
+version: 1.0
+
+[ClickHouse] SHALL support the `subtree` as the default value for the the `<scope>` parameter in the 
+`<user_directories><ldap><role_mapping>` section of the `config.xml` when the `<scope>` parameter is not specified.
+
+#### Search Filter Parameter
+
+##### RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.SearchFilter
+version: 1.0
+
+[ClickHouse] SHALL support the `<search_filter>` parameter in the `<user_directories><ldap><role_mapping>`
+section of the `config.xml` that SHALL specify the template used to construct 
+the [LDAP filter](https://ldap.com/ldap-filters/) for the search.
+
+The resulting filter SHALL be constructed by replacing all `{user_name}`, `{bind_dn}`, and `{base_dn}` substrings 
+of the template with the actual user name, bind `DN`, and base `DN` during each the [LDAP] search.
+ 
+#### Prefix Parameter
+
+##### RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Prefix
+version: 1.0
+
+[ClickHouse] SHALL support the `<prefix>` parameter in the `<user directories><ldap><role_mapping>`
+section of the `config.xml` that SHALL be expected to be in front of each string in 
+the original list of strings returned by the [LDAP] search. 
+Prefix SHALL be removed from the original strings and resulting strings SHALL be treated as [RBAC] role names. 
+
+##### RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Prefix.Default
+version: 1.0
+
+[ClickHouse] SHALL support empty string as the default value of the `<prefix>` parameter in 
+the `<user directories><ldap><role_mapping>` section of the `config.xml`.
+
+##### RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Prefix.WithUTF8Characters
+version: 1.0
+
+[ClickHouse] SHALL support UTF8 characters as the value of the `<prefix>` parameter in
+the `<user directories><ldap><role_mapping>` section of the `config.xml`.
+
+##### RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Prefix.WithSpecialXMLCharacters
+version: 1.0
+
+[ClickHouse] SHALL support XML special characters as the value of the `<prefix>` parameter in
+the `<user directories><ldap><role_mapping>` section of the `config.xml`.
+
+##### RQ.SRS-014.LDAP.RoleMapping.Configuration.UserDirectory.RoleMapping.Prefix.WithSpecialRegexCharacters
+version: 1.0
+
+[ClickHouse] SHALL support regex special characters as the value of the `<prefix>` parameter in
+the `<user directories><ldap><role_mapping>` section of the `config.xml`.
+
+## References
+
+* **Access Control and Account Management**: https://clickhouse.tech/docs/en/operations/access-rights/
+* **LDAP**: https://en.wikipedia.org/wiki/Lightweight_Directory_Access_Protocol
+* **ClickHouse:** https://clickhouse.tech
+* **GitHub Repository**: https://github.com/ClickHouse/ClickHouse/blob/master/tests/testflows/ldap/role_mapping/requirements/requirements.md
+* **Revision History**: https://github.com/ClickHouse/ClickHouse/commits/master/tests/testflows/ldap/role_mapping/requirements/requirements.md 
+* **Git:** https://git-scm.com/
+
+[RBAC]: https://clickhouse.tech/docs/en/operations/access-rights/
+[SRS]: #srs
+[Access Control and Account Management]: https://clickhouse.tech/docs/en/operations/access-rights/
+[SRS-009 ClickHouse LDAP External User Directory]: https://github.com/ClickHouse/ClickHouse/blob/master/tests/testflows/ldap/external_user_directory/requirements/requirements.md
+[SRS-007 ClickHouse Authentication of Users via LDAP]: https://github.com/ClickHouse/ClickHouse/blob/master/tests/testflows/ldap/authentication/requirements/requirements.md
+[LDAP]: https://en.wikipedia.org/wiki/Lightweight_Directory_Access_Protocol
+[ClickHouse]: https://clickhouse.tech
+[GitHub Repository]: https://github.com/ClickHouse/ClickHouse/blob/master/tests/testflows/ldap/role_mapping/requirements/requirements.md
+[Revision History]: https://github.com/ClickHouse/ClickHouse/commits/master/tests/testflows/ldap/role_mapping/requirements/requirements.md
+[Git]: https://git-scm.com/
+[GitHub]: https://github.com

--- a/tests/testflows/ldap/role_mapping/requirements/requirements.py
+++ b/tests/testflows/ldap/role_mapping/requirements/requirements.py
@@ -1,6 +1,6 @@
 # These requirements were auto generated
 # from software requirements specification (SRS)
-# document by TestFlows v1.6.210101.1235930.
+# document by TestFlows v1.6.210129.1222545.
 # Do not edit by hand but re-generate instead
 # using 'tfs requirements generate' command.
 from testflows.core import Specification
@@ -814,15 +814,15 @@ RQ_SRS_014_LDAP_RoleMapping_Configuration_UserDirectory_RoleMapping_Prefix_WithS
     level=4,
     num='4.8.8.5')
 
-QA_SRS014_ClickHouse_LDAP_Role_Mapping = Specification(
-    name='QA-SRS014 ClickHouse LDAP Role Mapping', 
+SRS_014_ClickHouse_LDAP_Role_Mapping = Specification(
+    name='SRS-014 ClickHouse LDAP Role Mapping', 
     description=None,
-    author='vzakaznikov',
-    date='December 4, 2020', 
-    status='-', 
-    approved_by='-',
-    approved_date='-',
-    approved_version='-',
+    author=None,
+    date=None, 
+    status=None, 
+    approved_by=None,
+    approved_date=None,
+    approved_version=None,
     version=None,
     group=None,
     type=None,
@@ -950,26 +950,8 @@ QA_SRS014_ClickHouse_LDAP_Role_Mapping = Specification(
         RQ_SRS_014_LDAP_RoleMapping_Configuration_UserDirectory_RoleMapping_Prefix_WithSpecialRegexCharacters,
         ),
     content='''
-# QA-SRS014 ClickHouse LDAP Role Mapping
+# SRS-014 ClickHouse LDAP Role Mapping
 # Software Requirements Specification
-
-(c) 2020 Altinity LTD. All Rights Reserved.
-
-**Document status:** Confidential
-
-**Author:** vzakaznikov
-
-**Date:** December 4, 2020
-
-## Approval
-
-**Status:** -
-
-**Version:** -
-
-**Approved by:** -
-
-**Date:** -
 
 ## Table of Contents
 
@@ -1046,13 +1028,13 @@ QA_SRS014_ClickHouse_LDAP_Role_Mapping = Specification(
 ## Revision History
 
 This document is stored in an electronic form using [Git] source control management software
-hosted in a [GitLab Repository].
+hosted in a [GitHub Repository].
 All the updates are tracked using the [Revision History].
 
 ## Introduction
 
-The [QA-SRS007 ClickHouse Authentication of Users via LDAP] added support for authenticating
-users using an [LDAP] server and the [QA-SRS009 ClickHouse LDAP External User Directory] added
+The [SRS-007 ClickHouse Authentication of Users via LDAP] added support for authenticating
+users using an [LDAP] server and the [SRS-009 ClickHouse LDAP External User Directory] added
 support for authenticating users using an [LDAP] external user directory. 
 
 This requirements specification adds additional functionality for mapping [LDAP] groups to 
@@ -1457,19 +1439,19 @@ the `<user directories><ldap><role_mapping>` section of the `config.xml`.
 * **Access Control and Account Management**: https://clickhouse.tech/docs/en/operations/access-rights/
 * **LDAP**: https://en.wikipedia.org/wiki/Lightweight_Directory_Access_Protocol
 * **ClickHouse:** https://clickhouse.tech
-* **GitLab Repository**: https://gitlab.com/altinity-qa/documents/qa-srs014-clickhouse-ldap-role-mapping/-/blob/master/QA_SRS014_ClickHouse_LDAP_Role_Mapping.md
-* **Revision History**: https://gitlab.com/altinity-qa/documents/qa-srs014-clickhouse-ldap-role-mapping/-/commits/master/QA_SRS014_ClickHouse_LDAP_Role_Mapping.md
+* **GitHub Repository**: https://github.com/ClickHouse/ClickHouse/blob/master/tests/testflows/ldap/role_mapping/requirements/requirements.md
+* **Revision History**: https://github.com/ClickHouse/ClickHouse/commits/master/tests/testflows/ldap/role_mapping/requirements/requirements.md 
 * **Git:** https://git-scm.com/
 
 [RBAC]: https://clickhouse.tech/docs/en/operations/access-rights/
 [SRS]: #srs
 [Access Control and Account Management]: https://clickhouse.tech/docs/en/operations/access-rights/
-[QA-SRS009 ClickHouse LDAP External User Directory]: https://gitlab.com/altinity-qa/documents/qa-srs009-clickhouse-ldap-external-user-directory/-/blob/master/QA_SRS009_ClickHouse_LDAP_External_User_Directory.md
-[QA-SRS007 ClickHouse Authentication of Users via LDAP]: https://gitlab.com/altinity-qa/documents/qa-srs007-clickhouse-athentication-of-users-via-ldap/-/blob/master/QA_SRS007_ClickHouse_Authentication_of_Users_via_LDAP.md
+[SRS-009 ClickHouse LDAP External User Directory]: https://github.com/ClickHouse/ClickHouse/blob/master/tests/testflows/ldap/external_user_directory/requirements/requirements.md
+[SRS-007 ClickHouse Authentication of Users via LDAP]: https://github.com/ClickHouse/ClickHouse/blob/master/tests/testflows/ldap/authentication/requirements/requirements.md
 [LDAP]: https://en.wikipedia.org/wiki/Lightweight_Directory_Access_Protocol
 [ClickHouse]: https://clickhouse.tech
-[GitLab Repository]: https://gitlab.com/altinity-qa/documents/qa-srs014-clickhouse-ldap-role-mapping/-/blob/master/QA_SRS014_ClickHouse_LDAP_Role_Mapping.md
-[Revision History]: https://gitlab.com/altinity-qa/documents/qa-srs014-clickhouse-ldap-role-mapping/-/commits/master/QA_SRS014_ClickHouse_LDAP_Role_Mapping.md
+[GitHub Repository]: https://github.com/ClickHouse/ClickHouse/blob/master/tests/testflows/ldap/role_mapping/requirements/requirements.md
+[Revision History]: https://github.com/ClickHouse/ClickHouse/commits/master/tests/testflows/ldap/role_mapping/requirements/requirements.md
 [Git]: https://git-scm.com/
-[GitLab]: https://gitlab.com
+[GitHub]: https://github.com
 ''')

--- a/tests/testflows/ldap/role_mapping/tests/server_config.py
+++ b/tests/testflows/ldap/role_mapping/tests/server_config.py
@@ -65,7 +65,7 @@ def bind_dn_conflict_with_auth_dn(self, timeout=60):
         }
     }
 
-    invalid_server_config(servers, message=message, tail=18, timeout=timeout)
+    invalid_server_config(servers, message=message, tail=30, timeout=timeout)
 
 
 @TestFeature


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Adding retries for docker-compose start, stop and restart in TestFlows tests.

Detailed description / Documentation draft:
Adding retries for docker-compose start, stop and restart in TestFlows tests.

Tasks:
* [x] add SRS source for LDAP role mapping