### PR TITLE
Initialize MaxDDLEntryID upon restarting

### DIFF
--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -462,7 +462,7 @@ void DDLWorker::scheduleTasks()
         else
         {
             LOG_DEBUG(log, "Task {} ({}) has been already processed", entry_name, task->entry.query);
-            updateMaxDDLEntryID(task);
+            updateMaxDDLEntryID(*task);
         }
 
         saveTask(entry_name);

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -683,7 +683,7 @@ void DDLWorker::enqueueTask(DDLTaskPtr task_ptr)
 }
 
 
-void DDLWorker::updateMaxDDLEntryID(DDLTask & task)
+void DDLWorker::updateMaxDDLEntryID(const DDLTask & task)
 {
     DB::ReadBufferFromString in(task.entry_name);
     DB::assertString("query-", in);

--- a/src/Interpreters/DDLWorker.h
+++ b/src/Interpreters/DDLWorker.h
@@ -129,6 +129,7 @@ private:
     /// Returns non-empty DDLTaskPtr if entry parsed and the check is passed
     DDLTaskPtr initAndCheckTask(const String & entry_name, String & out_reason, const ZooKeeperPtr & zookeeper);
 
+    void updateMaxDDLEntryID(DDLTask & task);
     void enqueueTask(DDLTaskPtr task);
     void processTask(DDLTask & task);
 

--- a/src/Interpreters/DDLWorker.h
+++ b/src/Interpreters/DDLWorker.h
@@ -129,7 +129,7 @@ private:
     /// Returns non-empty DDLTaskPtr if entry parsed and the check is passed
     DDLTaskPtr initAndCheckTask(const String & entry_name, String & out_reason, const ZooKeeperPtr & zookeeper);
 
-    void updateMaxDDLEntryID(DDLTask & task);
+    void updateMaxDDLEntryID(const DDLTask & task);
     void enqueueTask(DDLTaskPtr task);
     void processTask(DDLTask & task);
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Initialize MaxDDLEntryID to the last value after restarting. Before this PR, MaxDDLEntryID will remain zero until a new DDLTask is processed.

Detailed description / Documentation draft:

.
