### PR TITLE
Fix a segfault in fromModifiedJulianDay()

### DIFF
--- a/src/Functions/fromModifiedJulianDay.cpp
+++ b/src/Functions/fromModifiedJulianDay.cpp
@@ -163,7 +163,7 @@ namespace DB
 
         FunctionBaseImplPtr build(const ColumnsWithTypeAndName & arguments, const DataTypePtr & return_type) const override
         {
-            const DataTypePtr & from_type = arguments[0].type;
+            const DataTypePtr & from_type = removeNullable(arguments[0].type);
             DataTypes argument_types = { from_type };
             FunctionBaseImplPtr base;
             auto call = [&](const auto & types) -> bool
@@ -185,7 +185,7 @@ namespace DB
                 * here causes a SEGV. So we must somehow create a
                 * dummy implementation and return it.
                 */
-            if (WhichDataType(from_type).isNullable()) // Nullable(Nothing)
+            if (WhichDataType(from_type).isNothing()) // Nullable(Nothing)
                 return std::make_unique<FunctionBaseFromModifiedJulianDay<Name, DataTypeInt32, nullOnErrors>>(argument_types, return_type);
             else
                 // Should not happen.

--- a/tests/queries/0_stateless/01544_fromModifiedJulianDay.reference
+++ b/tests/queries/0_stateless/01544_fromModifiedJulianDay.reference
@@ -3,6 +3,7 @@ Invocation with constant
 1858-11-17
 2020-11-01
 \N
+\N
 or null
 2020-11-01
 \N

--- a/tests/queries/0_stateless/01544_fromModifiedJulianDay.sql
+++ b/tests/queries/0_stateless/01544_fromModifiedJulianDay.sql
@@ -5,6 +5,7 @@ SELECT fromModifiedJulianDay(-1);
 SELECT fromModifiedJulianDay(0);
 SELECT fromModifiedJulianDay(59154);
 SELECT fromModifiedJulianDay(NULL);
+SELECT fromModifiedJulianDay(CAST(NULL, 'Nullable(Int64)'));
 SELECT fromModifiedJulianDay(-678942); -- { serverError 490 }
 SELECT fromModifiedJulianDay(2973484); -- { serverError 490 }
 


### PR DESCRIPTION
It was crashing when the argument type was Nullable(T) where T was any integral type other than Int32.

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix a segfault in function `fromModifiedJulianDay` when the argument type is `Nullable(T)` for any integral types other than Int32.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
