### PR TITLE
Fix flaky integration tests

### DIFF
--- a/tests/integration/test_dictionaries_dependency_xml/configs/dictionaries/dep_x.xml
+++ b/tests/integration/test_dictionaries_dependency_xml/configs/dictionaries/dep_x.xml
@@ -11,7 +11,8 @@
                 <table>dep_z</table>
             </clickhouse>
         </source>
-        <lifetime>5</lifetime>
+        <!-- ExternalLoader::PeriodicUpdater::check_period_sec=5 anyway -->
+        <lifetime>4</lifetime>
         <layout>
             <flat/>
         </layout>

--- a/tests/integration/test_dictionaries_dependency_xml/configs/dictionaries/dep_y.xml
+++ b/tests/integration/test_dictionaries_dependency_xml/configs/dictionaries/dep_y.xml
@@ -11,7 +11,8 @@
                <table>elements</table>
            </clickhouse>
        </source>
-       <lifetime>5</lifetime>
+       <!-- ExternalLoader::PeriodicUpdater::check_period_sec=5 anyway -->
+       <lifetime>4</lifetime>
        <layout>
            <flat/>
        </layout>

--- a/tests/integration/test_dictionaries_dependency_xml/configs/dictionaries/dep_z.xml
+++ b/tests/integration/test_dictionaries_dependency_xml/configs/dictionaries/dep_z.xml
@@ -12,7 +12,8 @@
                <invalidate_query>SELECT intDiv(count(), 5) from dict.dep_y</invalidate_query>
            </clickhouse>
        </source>
-       <lifetime>5</lifetime>
+       <!-- ExternalLoader::PeriodicUpdater::check_period_sec=5 anyway -->
+       <lifetime>4</lifetime>
        <layout>
            <flat/>
        </layout>

--- a/tests/integration/test_dictionaries_dependency_xml/test.py
+++ b/tests/integration/test_dictionaries_dependency_xml/test.py
@@ -65,7 +65,7 @@ def test_get_data(started_cluster):
     assert query("SELECT dictGetString('dep_y', 'a', toUInt64(3))") == "fire\n"
     assert query("SELECT dictGetString('dep_z', 'a', toUInt64(3))") == "ZZ\n"
 
-    # dep_x and dep_z are updated only when there `intDiv(count(), 4)`  is changed.
+    # dep_x and dep_z are updated only when there `intDiv(count(), 5)`  is changed.
     query("INSERT INTO test.elements VALUES (4, 'ether', 404, 0.001)")
     assert_eq_with_retry(instance, "SELECT dictHas('dep_x', toUInt64(4))", "1", sleep_time=2, retry_count=10)
     assert query("SELECT dictGetString('dep_x', 'a', toUInt64(3))") == "fire\n"

--- a/tests/integration/test_materialize_mysql_database/materialize_with_ddl.py
+++ b/tests/integration/test_materialize_mysql_database/materialize_with_ddl.py
@@ -10,6 +10,7 @@ import random
 
 import threading
 from multiprocessing.dummy import Pool
+from helpers.test_tools import assert_eq_with_retry
 
 def check_query(clickhouse_node, query, result_set, retry_count=60, interval_seconds=3):
     lastest_result = ''
@@ -485,7 +486,7 @@ def select_without_columns(clickhouse_node, mysql_node, service_name):
     check_query(clickhouse_node, "SELECT count((_sign, _version)) FROM db.t FORMAT TSV", res[0])
 
     assert clickhouse_node.query("SELECT count(_sign) FROM db.t FORMAT TSV") == res[1]
-    assert clickhouse_node.query("SELECT count(_version) FROM db.t FORMAT TSV") == res[2]
+    assert_eq_with_retry(clickhouse_node, "SELECT count(_version) FROM db.t", res[2].strip(), sleep_time=2, retry_count=3)
 
     assert clickhouse_node.query("SELECT count() FROM db.t FORMAT TSV") == "1\n"
     assert clickhouse_node.query("SELECT count(*) FROM db.t FORMAT TSV") == "1\n"

--- a/tests/integration/test_read_temporary_tables_on_failure/test.py
+++ b/tests/integration/test_read_temporary_tables_on_failure/test.py
@@ -19,7 +19,7 @@ def start_cluster():
 
 def test_different_versions(start_cluster):
     with pytest.raises(QueryTimeoutExceedException):
-        node.query("SELECT sleep(3)", timeout=1)
+        node.query("SELECT sleepEachRow(3) FROM numbers(10)", timeout=5)
     with pytest.raises(QueryRuntimeException):
         node.query("SELECT 1", settings={'max_concurrent_queries_for_user': 1})
     assert node.contains_in_log('Too many simultaneous queries for user')


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- test_materialize_mysql_database: add retries for test_select_without_columns_8_0 (cc @zhang2014 )
- test_dictionaries_dependency_xml: decrease dictionaries lifetime
- test_read_temporary_tables_on_failure: increase timeout to avoid false-positive

*For details, see commit descriptions*