### PR TITLE
ReadBuffer: check that buffer position is not set beyond end

### DIFF
--- a/src/IO/ReadBuffer.h
+++ b/src/IO/ReadBuffer.h
@@ -55,6 +55,8 @@ public:
       */
     bool next()
     {
+        assert(position() <= working_buffer.end());
+
         bytes += offset();
         bool res = nextImpl();
         if (!res)
@@ -62,6 +64,9 @@ public:
 
         pos = working_buffer.begin() + nextimpl_working_buffer_offset;
         nextimpl_working_buffer_offset = 0;
+
+        assert(position() <= working_buffer.end());
+
         return res;
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)