### PR TITLE
Fix data race in executable dictionary

### DIFF
--- a/src/Dictionaries/CacheDictionary.cpp
+++ b/src/Dictionaries/CacheDictionary.cpp
@@ -1291,7 +1291,6 @@ void CacheDictionary::update(UpdateUnitPtr & update_unit_ptr)
             BlockInputStreamPtr stream = current_source_ptr->loadIds(update_unit_ptr->requested_ids);
             stream->readPrefix();
 
-
             while (true)
             {
                 Block block = stream->read();

--- a/src/Dictionaries/ExecutableDictionarySource.cpp
+++ b/src/Dictionaries/ExecutableDictionarySource.cpp
@@ -186,6 +186,9 @@ namespace
             if (!err.empty())
                 LOG_ERROR(log, "Having stderr: {}", err);
 
+            if (thread.joinable())
+                thread.join();
+
             command->wait();
         }
 


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix data race in executable dictionary that was possible only on misuse (when the script returns data ignoring its input).


https://clickhouse-test-reports.s3.yandex.net/20029/02da869d10e04f0031a2a28e4128a4730e555325/stress_test_(thread)/stderr.log