### PR TITLE
Fix log message with elapsed time while pushing to views

### DIFF
--- a/src/DataStreams/PushingToViewsBlockOutputStream.h
+++ b/src/DataStreams/PushingToViewsBlockOutputStream.h
@@ -60,7 +60,7 @@ private:
     std::unique_ptr<Context> select_context;
     std::unique_ptr<Context> insert_context;
 
-    void process(const Block & block, size_t view_num);
+    void process(const Block & block, ViewInfo & view);
 };
 
 

--- a/src/DataStreams/PushingToViewsBlockOutputStream.h
+++ b/src/DataStreams/PushingToViewsBlockOutputStream.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <DataStreams/IBlockOutputStream.h>
+#include <Common/Stopwatch.h>
 #include <Parsers/IAST_fwd.h>
 #include <Storages/IStorage.h>
 
@@ -44,6 +45,7 @@ private:
 
     const Context & context;
     ASTPtr query_ptr;
+    Stopwatch main_watch;
 
     struct ViewInfo
     {
@@ -51,6 +53,7 @@ private:
         StorageID table_id;
         BlockOutputStreamPtr out;
         std::exception_ptr exception;
+        UInt64 elapsed_ms = 0;
     };
 
     std::vector<ViewInfo> views;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix log message with elapsed time while pushing to views

Logging from PushingToViewsBlockOutputStream::write() is incorrect,
since it does not takes into account squashing (default to 1<<20 rows
and 256<<20), so final write will be done from
PushingToViewsBlockOutputStream::writeSuffix()

Also this PR contains patch with tiny refactoring, that will pass ViewInfo directly, over index in the views, since it should be completely fine.

Fixes: #19378