### PR TITLE
Fix tests *.reference files

### DIFF
--- a/tests/queries/0_stateless/01562_optimize_monotonous_functions_in_order_by.reference
+++ b/tests/queries/0_stateless/01562_optimize_monotonous_functions_in_order_by.reference
@@ -23,7 +23,7 @@ Expression (Projection)
     FinishSorting
       Expression (Before ORDER BY)
         SettingQuotaAndLimits (Set limits and quota after reading from storage)
-          ReadFromStorage (MergeTree  with order)
+          ReadFromStorage (MergeTree with order)
 SELECT
     timestamp,
     key
@@ -37,7 +37,7 @@ Expression (Projection)
     FinishSorting
       Expression (Before ORDER BY)
         SettingQuotaAndLimits (Set limits and quota after reading from storage)
-          ReadFromStorage (MergeTree  with order)
+          ReadFromStorage (MergeTree with order)
 SELECT
     timestamp,
     key

--- a/tests/queries/0_stateless/01576_alias_column_rewrite.reference
+++ b/tests/queries/0_stateless/01576_alias_column_rewrite.reference
@@ -35,18 +35,18 @@ Expression (Projection)
       Expression ((Before ORDER BY + Add table aliases))
         SettingQuotaAndLimits (Set limits and quota after reading from storage)
           Union
-            ReadFromStorage (MergeTree  with order)
-            ReadFromStorage (MergeTree  with order)
-            ReadFromStorage (MergeTree  with order)
+            ReadFromStorage (MergeTree with order)
+            ReadFromStorage (MergeTree with order)
+            ReadFromStorage (MergeTree with order)
 Expression (Projection)
   Limit (preliminary LIMIT)
     FinishSorting
       Expression (Before ORDER BY)
         SettingQuotaAndLimits (Set limits and quota after reading from storage)
           Union
-            ReadFromStorage (MergeTree  with order)
-            ReadFromStorage (MergeTree  with order)
-            ReadFromStorage (MergeTree  with order)
+            ReadFromStorage (MergeTree with order)
+            ReadFromStorage (MergeTree with order)
+            ReadFromStorage (MergeTree with order)
 optimize_aggregation_in_order
 Expression ((Projection + Before ORDER BY))
   Aggregating
@@ -58,17 +58,17 @@ Expression ((Projection + Before ORDER BY))
     Expression ((Before GROUP BY + Add table aliases))
       SettingQuotaAndLimits (Set limits and quota after reading from storage)
         Union
-          ReadFromStorage (MergeTree  with order)
-          ReadFromStorage (MergeTree  with order)
-          ReadFromStorage (MergeTree  with order)
+          ReadFromStorage (MergeTree with order)
+          ReadFromStorage (MergeTree with order)
+          ReadFromStorage (MergeTree with order)
 Expression ((Projection + Before ORDER BY))
   Aggregating
     Expression (Before GROUP BY)
       SettingQuotaAndLimits (Set limits and quota after reading from storage)
         Union
-          ReadFromStorage (MergeTree  with order)
-          ReadFromStorage (MergeTree  with order)
-          ReadFromStorage (MergeTree  with order)
+          ReadFromStorage (MergeTree with order)
+          ReadFromStorage (MergeTree with order)
+          ReadFromStorage (MergeTree with order)
 second-index
 1
 1


### PR DESCRIPTION
Using:

    sed -i 's/MergeTree  with order/MergeTree with order/g' tests/queries/0_stateless/*.reference

Fixes: dc2afc4795 ("Fix double whitespace #18383")

Changelog category (leave one):
- Not for changelog (changelog entry is not required)