### PR TITLE
Fixed open behavior of remote host filter in case when there is `remote_url_allow_hosts` section in configuration but no entries there

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -568,7 +568,7 @@
     <!-- The list of hosts allowed to use in URL-related storage engines and table functions.
         If this section is not present in configuration, all hosts are allowed.
     -->
-    <remote_url_allow_hosts>
+    <!--<remote_url_allow_hosts>-->
         <!-- Host should be specified exactly as in URL. The name is checked before DNS resolution.
             Example: "yandex.ru", "yandex.ru." and "www.yandex.ru" are different hosts.
                     If port is explicitly specified in URL, the host:port is checked as a whole.
@@ -582,7 +582,7 @@
             Regexps are not aligned: don't forget to add ^ and $. Also don't forget to escape dot (.) metacharacter
             (forgetting to do so is a common source of error).
         -->
-    </remote_url_allow_hosts>
+    <!--</remote_url_allow_hosts>-->
 
     <!-- If element has 'incl' attribute, then for it's value will be used corresponding substitution from another file.
          By default, path to file with substitutions is /etc/metrika.xml. It could be changed in config in 'include_from' element.

--- a/src/Common/RemoteHostFilter.cpp
+++ b/src/Common/RemoteHostFilter.cpp
@@ -42,6 +42,7 @@ void RemoteHostFilter::setValuesFromConfig(const Poco::Util::AbstractConfigurati
             else if (startsWith(key, "host"))
                 primary_hosts.insert(config.getString("remote_url_allow_hosts." + key));
         }
+        is_allow_by_default = false;
     }
 }
 
@@ -58,6 +59,6 @@ bool RemoteHostFilter::checkForDirectEntry(const std::string & str) const
         }
         return true;
     }
-    return true;
+    return is_allow_by_default;
 }
 }

--- a/src/Common/RemoteHostFilter.h
+++ b/src/Common/RemoteHostFilter.h
@@ -24,6 +24,7 @@ public:
     void checkHostAndPort(const std::string & host, const std::string & port) const; /// Does the same as checkURL, but for host and port.
 
 private:
+    bool is_allow_by_default = true;
     std::unordered_set<std::string> primary_hosts;      /// Allowed primary (<host>) URL from config.xml
     std::vector<std::string> regexp_hosts;              /// Allowed regexp (<hots_regexp>) URL from config.xml
 

--- a/tests/integration/test_allowed_url_from_config/test.py
+++ b/tests/integration/test_allowed_url_from_config/test.py
@@ -5,8 +5,8 @@ cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', main_configs=['configs/config_with_hosts.xml'])
 node2 = cluster.add_instance('node2', main_configs=['configs/config_with_only_primary_hosts.xml'])
 node3 = cluster.add_instance('node3', main_configs=['configs/config_with_only_regexp_hosts.xml'])
-node4 = cluster.add_instance('node4', main_configs=['configs/config_without_allowed_hosts.xml'])
-node5 = cluster.add_instance('node5', main_configs=[]) # No `remote_url_allow_hosts` at all.
+node4 = cluster.add_instance('node4', main_configs=[]) # No `remote_url_allow_hosts` at all.
+node5 = cluster.add_instance('node5', main_configs=['configs/config_without_allowed_hosts.xml'])
 node6 = cluster.add_instance('node6', main_configs=['configs/config_for_remote.xml'])
 node7 = cluster.add_instance('node7', main_configs=['configs/config_for_redirect.xml'], with_hdfs=True)
 
@@ -51,22 +51,22 @@ def test_config_with_only_regexp_hosts(start_cluster):
         "CREATE TABLE table_test_3_4 (word String) Engine=URL('https://yandex2.ru', S3)")
 
 
-def test_config_without_allowed_hosts(start_cluster):
-    assert "not allowed" in node4.query_and_get_error(
-        "CREATE TABLE table_test_4_1 (word String) Engine=URL('https://host:80', CSV)")
-    assert "not allowed" in node4.query_and_get_error(
-        "CREATE TABLE table_test_4_2 (word String) Engine=URL('https://host', HDFS)")
-    assert "not allowed" in node4.query_and_get_error(
-        "CREATE TABLE table_test_4_3 (word String) Engine=URL('https://yandex.ru', CSV)")
-    assert "not allowed" in node4.query_and_get_error(
-        "CREATE TABLE table_test_4_4 (word String) Engine=URL('ftp://something.com', S3)")
-
-
 def test_config_without_allowed_hosts_section(start_cluster):
-    assert node5.query("CREATE TABLE table_test_4_1 (word String) Engine=URL('https://host:80', CSV)") == ""
-    assert node5.query("CREATE TABLE table_test_4_2 (word String) Engine=URL('https://host', HDFS)") == ""
-    assert node5.query("CREATE TABLE table_test_4_3 (word String) Engine=URL('https://yandex.ru', CSV)") == ""
-    assert node5.query("CREATE TABLE table_test_4_4 (word String) Engine=URL('ftp://something.com', S3)") == ""
+    assert node4.query("CREATE TABLE table_test_4_1 (word String) Engine=URL('https://host:80', CSV)") == ""
+    assert node4.query("CREATE TABLE table_test_4_2 (word String) Engine=URL('https://host', HDFS)") == ""
+    assert node4.query("CREATE TABLE table_test_4_3 (word String) Engine=URL('https://yandex.ru', CSV)") == ""
+    assert node4.query("CREATE TABLE table_test_4_4 (word String) Engine=URL('ftp://something.com', S3)") == ""
+
+
+def test_config_without_allowed_hosts(start_cluster):
+    assert "not allowed" in node5.query_and_get_error(
+        "CREATE TABLE table_test_5_1 (word String) Engine=URL('https://host:80', CSV)")
+    assert "not allowed" in node5.query_and_get_error(
+        "CREATE TABLE table_test_5_2 (word String) Engine=URL('https://host', HDFS)")
+    assert "not allowed" in node5.query_and_get_error(
+        "CREATE TABLE table_test_5_3 (word String) Engine=URL('https://yandex.ru', CSV)")
+    assert "not allowed" in node5.query_and_get_error(
+        "CREATE TABLE table_test_5_4 (word String) Engine=URL('ftp://something.com', S3)")
 
 
 def test_table_function_remote(start_cluster):

--- a/tests/integration/test_allowed_url_from_config/test.py
+++ b/tests/integration/test_allowed_url_from_config/test.py
@@ -53,20 +53,23 @@ def test_config_with_only_regexp_hosts(start_cluster):
 
 def test_config_without_allowed_hosts_section(start_cluster):
     assert node4.query("CREATE TABLE table_test_4_1 (word String) Engine=URL('https://host:80', CSV)") == ""
-    assert node4.query("CREATE TABLE table_test_4_2 (word String) Engine=URL('https://host', HDFS)") == ""
-    assert node4.query("CREATE TABLE table_test_4_3 (word String) Engine=URL('https://yandex.ru', CSV)") == ""
-    assert node4.query("CREATE TABLE table_test_4_4 (word String) Engine=URL('ftp://something.com', S3)") == ""
+    assert node4.query("CREATE TABLE table_test_4_2 (word String) Engine=S3('https://host:80/bucket/key', CSV)") == ""
+    assert node4.query("CREATE TABLE table_test_4_3 (word String) Engine=URL('https://host', HDFS)") == ""
+    assert node4.query("CREATE TABLE table_test_4_4 (word String) Engine=URL('https://yandex.ru', CSV)") == ""
+    assert node4.query("CREATE TABLE table_test_4_5 (word String) Engine=URL('ftp://something.com', S3)") == ""
 
 
 def test_config_without_allowed_hosts(start_cluster):
     assert "not allowed" in node5.query_and_get_error(
         "CREATE TABLE table_test_5_1 (word String) Engine=URL('https://host:80', CSV)")
     assert "not allowed" in node5.query_and_get_error(
-        "CREATE TABLE table_test_5_2 (word String) Engine=URL('https://host', HDFS)")
+        "CREATE TABLE table_test_5_2 (word String) Engine=S3('https://host:80/bucket/key', CSV)")
     assert "not allowed" in node5.query_and_get_error(
-        "CREATE TABLE table_test_5_3 (word String) Engine=URL('https://yandex.ru', CSV)")
+        "CREATE TABLE table_test_5_3 (word String) Engine=URL('https://host', HDFS)")
     assert "not allowed" in node5.query_and_get_error(
-        "CREATE TABLE table_test_5_4 (word String) Engine=URL('ftp://something.com', S3)")
+        "CREATE TABLE table_test_5_4 (word String) Engine=URL('https://yandex.ru', CSV)")
+    assert "not allowed" in node5.query_and_get_error(
+        "CREATE TABLE table_test_5_5 (word String) Engine=URL('ftp://something.com', S3)")
 
 
 def test_table_function_remote(start_cluster):

--- a/tests/integration/test_allowed_url_from_config/test.py
+++ b/tests/integration/test_allowed_url_from_config/test.py
@@ -6,6 +6,7 @@ node1 = cluster.add_instance('node1', main_configs=['configs/config_with_hosts.x
 node2 = cluster.add_instance('node2', main_configs=['configs/config_with_only_primary_hosts.xml'])
 node3 = cluster.add_instance('node3', main_configs=['configs/config_with_only_regexp_hosts.xml'])
 node4 = cluster.add_instance('node4', main_configs=['configs/config_without_allowed_hosts.xml'])
+node5 = cluster.add_instance('node5', main_configs=[]) # No `remote_url_allow_hosts` at all.
 node6 = cluster.add_instance('node6', main_configs=['configs/config_for_remote.xml'])
 node7 = cluster.add_instance('node7', main_configs=['configs/config_for_redirect.xml'], with_hdfs=True)
 
@@ -51,10 +52,21 @@ def test_config_with_only_regexp_hosts(start_cluster):
 
 
 def test_config_without_allowed_hosts(start_cluster):
-    assert node4.query("CREATE TABLE table_test_4_1 (word String) Engine=URL('https://host:80', CSV)") == ""
-    assert node4.query("CREATE TABLE table_test_4_2 (word String) Engine=URL('https://host', HDFS)") == ""
-    assert node4.query("CREATE TABLE table_test_4_3 (word String) Engine=URL('https://yandex.ru', CSV)") == ""
-    assert node4.query("CREATE TABLE table_test_4_4 (word String) Engine=URL('ftp://something.com', S3)") == ""
+    assert "not allowed" in node4.query_and_get_error(
+        "CREATE TABLE table_test_4_1 (word String) Engine=URL('https://host:80', CSV)")
+    assert "not allowed" in node4.query_and_get_error(
+        "CREATE TABLE table_test_4_2 (word String) Engine=URL('https://host', HDFS)")
+    assert "not allowed" in node4.query_and_get_error(
+        "CREATE TABLE table_test_4_3 (word String) Engine=URL('https://yandex.ru', CSV)")
+    assert "not allowed" in node4.query_and_get_error(
+        "CREATE TABLE table_test_4_4 (word String) Engine=URL('ftp://something.com', S3)")
+
+
+def test_config_without_allowed_hosts_section(start_cluster):
+    assert node5.query("CREATE TABLE table_test_4_1 (word String) Engine=URL('https://host:80', CSV)") == ""
+    assert node5.query("CREATE TABLE table_test_4_2 (word String) Engine=URL('https://host', HDFS)") == ""
+    assert node5.query("CREATE TABLE table_test_4_3 (word String) Engine=URL('https://yandex.ru', CSV)") == ""
+    assert node5.query("CREATE TABLE table_test_4_4 (word String) Engine=URL('ftp://something.com', S3)") == ""
 
 
 def test_table_function_remote(start_cluster):


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixed open behavior of remote host filter in case when there is `remote_url_allow_hosts` section in configuration but no entries there. :warning: please add a note about potential issue when upgrading - @alexey-milovidov 

From documentation: `If this section is not present in configuration, all hosts are allowed`, real behavior was `If section contains no entries, all hosts are allowed`.

**There is a potential problem with this PR, by default configuration file does contain specified tag, empty, so if a user has their custom edited configuration, it may effectively block access to all external URLs for him after an upgrade.**