### PR TITLE
Supports system.zookeeper path IN query.

### DIFF
--- a/docs/en/operations/system-tables/zookeeper.md
+++ b/docs/en/operations/system-tables/zookeeper.md
@@ -7,6 +7,10 @@ The query `SELECT * FROM system.zookeeper WHERE path = '/clickhouse'` outputs da
 To output data for all root nodes, write path = ‘/’.
 If the path specified in ‘path’ doesn’t exist, an exception will be thrown.
 
+The query `SELECT * FROM system.zookeeper WHERE path IN ('/', '/clickhouse')` outputs data for all children on the `/` and `/clickhouse` node.
+If in the specified ‘path’ collection has doesn't exist path, an exception will be thrown.
+It can be used to do a batch of ZooKeeper path queries.
+
 Columns:
 
 -   `name` (String) — The name of the node.

--- a/docs/en/operations/system-tables/zookeeper.md
+++ b/docs/en/operations/system-tables/zookeeper.md
@@ -1,7 +1,7 @@
 # system.zookeeper {#system-zookeeper}
 
 The table does not exist if ZooKeeper is not configured. Allows reading data from the ZooKeeper cluster defined in the config.
-The query must have a ‘path’ equality condition in the WHERE clause, or ‘path’ condition in the set in the WHERE clause. This is the path in ZooKeeper for the children that you want to get data for.
+The query must either have a ‘path =’   condition or a `path IN`  condition set with the `WHERE` clause as shown below. This corresponds to the path of the children in ZooKeeper that you want to get data for.
 
 The query `SELECT * FROM system.zookeeper WHERE path = '/clickhouse'` outputs data for all children on the `/clickhouse` node.
 To output data for all root nodes, write path = ‘/’.

--- a/docs/en/operations/system-tables/zookeeper.md
+++ b/docs/en/operations/system-tables/zookeeper.md
@@ -1,7 +1,7 @@
 # system.zookeeper {#system-zookeeper}
 
 The table does not exist if ZooKeeper is not configured. Allows reading data from the ZooKeeper cluster defined in the config.
-The query must have a ‘path’ equality condition in the WHERE clause. This is the path in ZooKeeper for the children that you want to get data for.
+The query must have a ‘path’ equality condition in the WHERE clause, or ‘path’ condition in the set in the WHERE clause. This is the path in ZooKeeper for the children that you want to get data for.
 
 The query `SELECT * FROM system.zookeeper WHERE path = '/clickhouse'` outputs data for all children on the `/clickhouse` node.
 To output data for all root nodes, write path = ‘/’.

--- a/docs/zh/operations/system-tables/zookeeper.md
+++ b/docs/zh/operations/system-tables/zookeeper.md
@@ -6,7 +6,7 @@ machine_translated_rev: 5decc73b5dc60054f19087d3690c4eb99446a6c3
 # 系统。动物园管理员 {#system-zookeeper}
 
 如果未配置ZooKeeper，则表不存在。 允许从配置中定义的ZooKeeper集群读取数据。
-查询必须具有 ‘path’ WHERE子句中的平等条件。 这是ZooKeeper中您想要获取数据的孩子的路径。
+查询必须具有 ‘path’ WHERE子句中的相等条件或者在某个集合中的条件。 这是ZooKeeper中您想要获取数据的孩子的路径。
 
 查询 `SELECT * FROM system.zookeeper WHERE path = '/clickhouse'` 输出对所有孩子的数据 `/clickhouse` 节点。
 要输出所有根节点的数据，write path= ‘/’.

--- a/docs/zh/operations/system-tables/zookeeper.md
+++ b/docs/zh/operations/system-tables/zookeeper.md
@@ -12,6 +12,10 @@ machine_translated_rev: 5decc73b5dc60054f19087d3690c4eb99446a6c3
 要输出所有根节点的数据，write path= ‘/’.
 如果在指定的路径 ‘path’ 不存在，将引发异常。
 
+查询`SELECT * FROM system.zookeeper WHERE path IN ('/', '/clickhouse')` 输出`/` 和 `/clickhouse`节点上所有子节点的数据。
+如果在指定的 ‘path’ 集合中有不存在的路径，将引发异常。
+它可以用来做一批ZooKeeper路径查询。
+
 列:
 
 -   `name` (String) — The name of the node.

--- a/src/Storages/System/StorageSystemZooKeeper.cpp
+++ b/src/Storages/System/StorageSystemZooKeeper.cpp
@@ -12,6 +12,9 @@
 #include <Interpreters/evaluateConstantExpression.h>
 #include <Common/ZooKeeper/ZooKeeper.h>
 #include <Common/typeid_cast.h>
+#include <Parsers/ASTSubquery.h>
+#include <Interpreters/Set.h>
+#include <Interpreters/interpretSubquery.h>
 
 
 namespace DB
@@ -43,8 +46,24 @@ NamesAndTypesList StorageSystemZooKeeper::getNamesAndTypes()
     };
 }
 
+using Paths = Strings;
 
-static bool extractPathImpl(const IAST & elem, String & res, const Context & context)
+static String pathCorrected(const String & path)
+{
+    String path_corrected;
+    /// path should starts with '/', otherwise ZBADARGUMENTS will be thrown in
+    /// ZooKeeper::sendThread and the session will fail.
+    if (path[0] != '/')
+        path_corrected = '/';
+    path_corrected += path;
+    /// In all cases except the root, path must not end with a slash.
+    if (path_corrected != "/" && path_corrected.back() == '/')
+        path_corrected.resize(path_corrected.size() - 1);
+    return path_corrected;
+}
+
+
+static bool extractPathImpl(const IAST & elem, Paths & res, const Context & context)
 {
     const auto * function = elem.as<ASTFunction>();
     if (!function)
@@ -59,15 +78,65 @@ static bool extractPathImpl(const IAST & elem, String & res, const Context & con
         return false;
     }
 
-    if (function->name == "equals")
-    {
-        const auto & args = function->arguments->as<ASTExpressionList &>();
-        ASTPtr value;
+    const auto & args = function->arguments->as<ASTExpressionList &>();
+    if (args.children.size() != 2)
+        return false;
 
-        if (args.children.size() != 2)
+    if (function->name == "in")
+    {
+        const ASTIdentifier * ident = args.children.at(0)->as<ASTIdentifier>();
+        if (!ident || ident->name() != "path")
             return false;
 
+        ASTPtr value = args.children.at(1);
+
+        if (value->as<ASTSubquery>())
+        {
+            auto interpreter_subquery = interpretSubquery(value, context, {}, {});
+            auto stream = interpreter_subquery->execute().getInputStream();
+            SizeLimits limites(context.getSettingsRef().max_rows_in_set, context.getSettingsRef().max_bytes_in_set, OverflowMode::THROW);
+            Set set(limites, true, context.getSettingsRef().transform_null_in);
+            set.setHeader(stream->getHeader());
+
+            stream->readPrefix();
+            while (Block block = stream->read())
+            {
+                set.insertFromBlock(block);
+            }
+            set.finishInsert();
+            stream->readSuffix();
+
+            set.checkColumnsNumber(1);
+            const auto & set_column = *set.getSetElements()[0];
+            for (size_t row = 0; row < set_column.size(); ++row)
+                res.emplace_back(set_column[row].safeGet<String>());
+        }
+        else
+        {
+            auto evaluated = evaluateConstantExpressionAsLiteral(value, context);
+            const auto * literal = evaluated->as<ASTLiteral>();
+            if (!literal)
+                return false;
+
+            if (String str; literal->value.tryGet(str))
+            {
+                res.emplace_back(str);
+            }
+            else if (Tuple tuple; literal->value.tryGet(tuple))
+            {
+                for (auto element : tuple)
+                    res.emplace_back(element.safeGet<String>());
+            }
+            else
+                return false;
+        }
+
+        return true;
+    }
+    else if (function->name == "equals")
+    {
         const ASTIdentifier * ident;
+        ASTPtr value;
         if ((ident = args.children.at(0)->as<ASTIdentifier>()))
             value = args.children.at(1);
         else if ((ident = args.children.at(1)->as<ASTIdentifier>()))
@@ -86,7 +155,7 @@ static bool extractPathImpl(const IAST & elem, String & res, const Context & con
         if (literal->value.getType() != Field::Types::String)
             return false;
 
-        res = literal->value.safeGet<String>();
+        res.emplace_back(literal->value.safeGet<String>());
         return true;
     }
 
@@ -96,69 +165,69 @@ static bool extractPathImpl(const IAST & elem, String & res, const Context & con
 
 /** Retrieve from the query a condition of the form `path = 'path'`, from conjunctions in the WHERE clause.
   */
-static String extractPath(const ASTPtr & query, const Context & context)
+static Paths extractPath(const ASTPtr & query, const Context & context)
 {
     const auto & select = query->as<ASTSelectQuery &>();
     if (!select.where())
-        return "";
+        return Paths();
 
-    String res;
-    return extractPathImpl(*select.where(), res, context) ? res : "";
+    Paths res;
+    return extractPathImpl(*select.where(), res, context) ? res : Paths();
 }
 
 
 void StorageSystemZooKeeper::fillData(MutableColumns & res_columns, const Context & context, const SelectQueryInfo & query_info) const
 {
-    String path = extractPath(query_info.query, context);
-    if (path.empty())
-        throw Exception("SELECT from system.zookeeper table must contain condition like path = 'path' in WHERE clause.", ErrorCodes::BAD_ARGUMENTS);
+    const Paths & paths = extractPath(query_info.query, context);
+    if (paths.empty())
+        throw Exception("SELECT from system.zookeeper table must contain condition like path = 'path' or path IN ('path1','path2'...) or path IN (subquery) in WHERE clause.", ErrorCodes::BAD_ARGUMENTS);
 
     zkutil::ZooKeeperPtr zookeeper = context.getZooKeeper();
 
-    String path_corrected;
-    /// path should starts with '/', otherwise ZBADARGUMENTS will be thrown in
-    /// ZooKeeper::sendThread and the session will fail.
-    if (path[0] != '/')
-        path_corrected = '/';
-    path_corrected += path;
-    /// In all cases except the root, path must not end with a slash.
-    if (path_corrected != "/" && path_corrected.back() == '/')
-        path_corrected.resize(path_corrected.size() - 1);
-
-    zkutil::Strings nodes = zookeeper->getChildren(path_corrected);
-
-    String path_part = path_corrected;
-    if (path_part == "/")
-        path_part.clear();
-
-    std::vector<std::future<Coordination::GetResponse>> futures;
-    futures.reserve(nodes.size());
-    for (const String & node : nodes)
-        futures.push_back(zookeeper->asyncTryGet(path_part + '/' + node));
-
-    for (size_t i = 0, size = nodes.size(); i < size; ++i)
+    std::unordered_set<String> paths_corrected;
+    for (const auto & path : paths)
     {
-        auto res = futures[i].get();
-        if (res.error == Coordination::Error::ZNONODE)
-            continue;   /// Node was deleted meanwhile.
+        const String & path_corrected = pathCorrected(path);
+        auto [it, inserted] = paths_corrected.emplace(path_corrected);
+        if (!inserted) /// Do not repeat processing.
+            continue;
 
-        const Coordination::Stat & stat = res.stat;
+        zkutil::Strings nodes = zookeeper->getChildren(path_corrected);
 
-        size_t col_num = 0;
-        res_columns[col_num++]->insert(nodes[i]);
-        res_columns[col_num++]->insert(res.data);
-        res_columns[col_num++]->insert(stat.czxid);
-        res_columns[col_num++]->insert(stat.mzxid);
-        res_columns[col_num++]->insert(UInt64(stat.ctime / 1000));
-        res_columns[col_num++]->insert(UInt64(stat.mtime / 1000));
-        res_columns[col_num++]->insert(stat.version);
-        res_columns[col_num++]->insert(stat.cversion);
-        res_columns[col_num++]->insert(stat.aversion);
-        res_columns[col_num++]->insert(stat.ephemeralOwner);
-        res_columns[col_num++]->insert(stat.dataLength);
-        res_columns[col_num++]->insert(stat.numChildren);
-        res_columns[col_num++]->insert(stat.pzxid);
-        res_columns[col_num++]->insert(path);          /// This is the original path. In order to process the request, condition in WHERE should be triggered.
+        String path_part = path_corrected;
+        if (path_part == "/")
+            path_part.clear();
+
+        std::vector<std::future<Coordination::GetResponse>> futures;
+        futures.reserve(nodes.size());
+        for (const String & node : nodes)
+            futures.push_back(zookeeper->asyncTryGet(path_part + '/' + node));
+
+        for (size_t i = 0, size = nodes.size(); i < size; ++i)
+        {
+            auto res = futures[i].get();
+            if (res.error == Coordination::Error::ZNONODE)
+                continue; /// Node was deleted meanwhile.
+
+            const Coordination::Stat & stat = res.stat;
+
+            size_t col_num = 0;
+            res_columns[col_num++]->insert(nodes[i]);
+            res_columns[col_num++]->insert(res.data);
+            res_columns[col_num++]->insert(stat.czxid);
+            res_columns[col_num++]->insert(stat.mzxid);
+            res_columns[col_num++]->insert(UInt64(stat.ctime / 1000));
+            res_columns[col_num++]->insert(UInt64(stat.mtime / 1000));
+            res_columns[col_num++]->insert(stat.version);
+            res_columns[col_num++]->insert(stat.cversion);
+            res_columns[col_num++]->insert(stat.aversion);
+            res_columns[col_num++]->insert(stat.ephemeralOwner);
+            res_columns[col_num++]->insert(stat.dataLength);
+            res_columns[col_num++]->insert(stat.numChildren);
+            res_columns[col_num++]->insert(stat.pzxid);
+            res_columns[col_num++]->insert(
+                path); /// This is the original path. In order to process the request, condition in WHERE should be triggered.
+        }
     }
 }
 

--- a/tests/queries/0_stateless/01700_system_zookeeper_path_in.reference
+++ b/tests/queries/0_stateless/01700_system_zookeeper_path_in.reference
@@ -1,0 +1,4 @@
+clickhouse
+clickhouse
+clickhouse
+task_queue

--- a/tests/queries/0_stateless/01700_system_zookeeper_path_in.reference
+++ b/tests/queries/0_stateless/01700_system_zookeeper_path_in.reference
@@ -1,4 +1,7 @@
 clickhouse
-clickhouse
+task_queue
 clickhouse
 task_queue
+clickhouse
+task_queue
+ddl

--- a/tests/queries/0_stateless/01700_system_zookeeper_path_in.sql
+++ b/tests/queries/0_stateless/01700_system_zookeeper_path_in.sql
@@ -1,0 +1,3 @@
+SELECT name FROM system.zookeeper WHERE path = '/';
+SELECT name FROM system.zookeeper WHERE path IN ('/');
+SELECT name FROM system.zookeeper WHERE path IN ('/','/clickhouse');

--- a/tests/queries/0_stateless/01700_system_zookeeper_path_in.sql
+++ b/tests/queries/0_stateless/01700_system_zookeeper_path_in.sql
@@ -1,3 +1,6 @@
 SELECT name FROM system.zookeeper WHERE path = '/';
+SELECT name FROM system.zookeeper WHERE path = 'clickhouse';
 SELECT name FROM system.zookeeper WHERE path IN ('/');
+SELECT name FROM system.zookeeper WHERE path IN ('clickhouse');
 SELECT name FROM system.zookeeper WHERE path IN ('/','/clickhouse');
+SELECT name FROM system.zookeeper WHERE path IN (SELECT concat('/clickhouse/',name) FROM system.zookeeper WHERE (path = '/clickhouse/'));


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Supports system.zookeeper path IN query. 

Support realize batch query of ZooKeeper path.

For example, 
```SELECT * FROM system.zookeeper WHERE path IN ('/','/clickhouse')``` 
or 
```SELECT * FROM system.zookeeper WHERE path IN (SELECT concat('/clickhouse/',name) FROM system.zookeeper WHERE (path = '/clickhouse/'))```. 




