### PR TITLE
MongoDB table engine now establishes connection only when it reads data.

### DIFF
--- a/src/Storages/StorageMongoDB.cpp
+++ b/src/Storages/StorageMongoDB.cpp
@@ -42,12 +42,31 @@ StorageMongoDB::StorageMongoDB(
     , collection_name(collection_name_)
     , username(username_)
     , password(password_)
-    , connection{std::make_shared<Poco::MongoDB::Connection>(host, port)}
 {
     StorageInMemoryMetadata storage_metadata;
     storage_metadata.setColumns(columns_);
     storage_metadata.setConstraints(constraints_);
     setInMemoryMetadata(storage_metadata);
+}
+
+
+void StorageMongoDB::connectIfNotConnected()
+{
+    std::lock_guard lock{connection_mutex};
+    if (!connection)
+        connection = std::make_shared<Poco::MongoDB::Connection>(host, port);
+
+    if (!authentified)
+    {
+#       if POCO_VERSION >= 0x01070800
+            Poco::MongoDB::Database poco_db(database_name);
+            if (!poco_db.authenticate(*connection, username, password, Poco::MongoDB::Database::AUTH_SCRAM_SHA1))
+                throw Exception("Cannot authenticate in MongoDB, incorrect user or password", ErrorCodes::MONGODB_CANNOT_AUTHENTICATE);
+#       else
+            authenticate(*connection, database_name, username, password);
+#       endif
+        authentified = true;
+    }
 }
 
 
@@ -60,15 +79,9 @@ Pipe StorageMongoDB::read(
     size_t max_block_size,
     unsigned)
 {
-    metadata_snapshot->check(column_names, getVirtuals(), getStorageID());
+    connectIfNotConnected();
 
-#if POCO_VERSION >= 0x01070800
-    Poco::MongoDB::Database poco_db(database_name);
-    if (!poco_db.authenticate(*connection, username, password, Poco::MongoDB::Database::AUTH_SCRAM_SHA1))
-        throw Exception("Cannot authenticate in MongoDB, incorrect user or password", ErrorCodes::MONGODB_CANNOT_AUTHENTICATE);
-#else
-    authenticate(*connection, database_name, username, password);
-#endif
+    metadata_snapshot->check(column_names, getVirtuals(), getStorageID());
 
     Block sample_block;
     for (const String & column_name : column_names)

--- a/src/Storages/StorageMongoDB.h
+++ b/src/Storages/StorageMongoDB.h
@@ -52,7 +52,7 @@ private:
 
     std::shared_ptr<Poco::MongoDB::Connection> connection;
     bool authentified = false;
-    std::mutex connection_mutex;
+    std::mutex connection_mutex; /// Protects the variables `connection` and `authentified`.
 };
 
 }

--- a/src/Storages/StorageMongoDB.h
+++ b/src/Storages/StorageMongoDB.h
@@ -40,16 +40,19 @@ public:
         size_t max_block_size,
         unsigned num_streams) override;
 
-
 private:
-    std::string host;
-    short unsigned int port;
-    std::string database_name;
-    std::string collection_name;
-    std::string username;
-    std::string password;
+    void connectIfNotConnected();
+
+    const std::string host;
+    const short unsigned int port;
+    const std::string database_name;
+    const std::string collection_name;
+    const std::string username;
+    const std::string password;
 
     std::shared_ptr<Poco::MongoDB::Connection> connection;
+    bool authentified = false;
+    std::mutex connection_mutex;
 };
 
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Bug Fix

Changelog entry:
The `MongoDB` table engine now establishes connection only when it's going to read data. `ATTACH TABLE` won't try to connect anymore.

This PR fixes https://github.com/ClickHouse/ClickHouse/issues/20055