### PR TITLE
Show tables command will take 2 quota count

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -507,9 +507,15 @@ class IColumn;
 // End of FORMAT_FACTORY_SETTINGS
 // Please add settings non-related to formats into the COMMON_SETTINGS above.
 
+// settings work in query runtime
+#define RUNTIME_QUERY_SETTINGS(M) \
+    M(Bool, is_reinterpreted_execution, false, "Queries such as show tables will be reinterpreted to select query.", 0)
+// End of RUNTIME_QUERY_SETTINGS
+
 #define LIST_OF_SETTINGS(M)    \
     COMMON_SETTINGS(M)         \
-    FORMAT_FACTORY_SETTINGS(M)
+    FORMAT_FACTORY_SETTINGS(M) \
+    RUNTIME_QUERY_SETTINGS(M)
 
 DECLARE_SETTINGS_TRAITS_ALLOW_CUSTOM_SETTINGS(SettingsTraits, LIST_OF_SETTINGS)
 

--- a/src/Interpreters/InterpreterShowPrivilegesQuery.cpp
+++ b/src/Interpreters/InterpreterShowPrivilegesQuery.cpp
@@ -1,5 +1,6 @@
 #include <Interpreters/InterpreterShowPrivilegesQuery.h>
 #include <Interpreters/executeQuery.h>
+#include <Interpreters/Context.h>
 
 
 namespace DB
@@ -12,6 +13,7 @@ InterpreterShowPrivilegesQuery::InterpreterShowPrivilegesQuery(const ASTPtr & qu
 
 BlockIO InterpreterShowPrivilegesQuery::execute()
 {
+    context.applySettingChange({"is_reinterpreted_execution", true});
     return executeQuery("SELECT * FROM system.privileges", context, true);
 }
 

--- a/src/Interpreters/InterpreterShowPrivilegesQuery.h
+++ b/src/Interpreters/InterpreterShowPrivilegesQuery.h
@@ -15,8 +15,8 @@ public:
 
     BlockIO execute() override;
 
-    bool ignoreQuota() const override { return true; }
-    bool ignoreLimits() const override { return true; }
+    bool ignoreQuota() const override { return false; }
+    bool ignoreLimits() const override { return false; }
 
 private:
     ASTPtr query_ptr;

--- a/src/Interpreters/InterpreterShowProcesslistQuery.cpp
+++ b/src/Interpreters/InterpreterShowProcesslistQuery.cpp
@@ -12,6 +12,7 @@ namespace DB
 
 BlockIO InterpreterShowProcesslistQuery::execute()
 {
+    context.applySettingChange({"is_reinterpreted_execution", true});
     return executeQuery("SELECT * FROM system.processes", context, true);
 }
 

--- a/src/Interpreters/InterpreterShowTablesQuery.cpp
+++ b/src/Interpreters/InterpreterShowTablesQuery.cpp
@@ -142,6 +142,7 @@ String InterpreterShowTablesQuery::getRewrittenQuery()
 
 BlockIO InterpreterShowTablesQuery::execute()
 {
+    context.applySettingChange({"is_reinterpreted_execution", true});
     return executeQuery(getRewrittenQuery(), context, true);
 }
 

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -516,7 +516,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
         auto interpreter = InterpreterFactory::get(ast, context, SelectQueryOptions(stage).setInternal(internal));
 
         std::shared_ptr<const EnabledQuota> quota;
-        if (!interpreter->ignoreQuota())
+        if (!interpreter->ignoreQuota() && !context.getSettingsRef().is_reinterpreted_execution)
         {
             quota = context.getQuota();
             if (quota)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- reduce queries such as show tables quota statistics from 2 to 1

This PR fixes #20018 
