### PR TITLE
Use fixed version of confluent-kafka library in integration tests

### DIFF
--- a/docker/test/integration/runner/Dockerfile
+++ b/docker/test/integration/runner/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update \
     luajit \
     libssl-dev \
     libcurl4-openssl-dev \
+    librdkafka-dev \
     gdb \
     software-properties-common \
     libkrb5-dev \

--- a/docker/test/integration/runner/Dockerfile
+++ b/docker/test/integration/runner/Dockerfile
@@ -27,7 +27,6 @@ RUN apt-get update \
     luajit \
     libssl-dev \
     libcurl4-openssl-dev \
-    librdkafka-dev \
     gdb \
     software-properties-common \
     libkrb5-dev \
@@ -62,7 +61,7 @@ RUN python3 -m pip install \
     aerospike \
     avro \
     cassandra-driver \
-    confluent-kafka \
+    confluent-kafka==1.5.0 \
     dict2xml \
     dicttoxml \
     docker \


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)