### PR TITLE
Minor performance improvements for formats

### DIFF
--- a/src/IO/ReadBufferFromS3.h
+++ b/src/IO/ReadBufferFromS3.h
@@ -36,7 +36,7 @@ private:
     Poco::Logger * log = &Poco::Logger::get("ReadBufferFromS3");
 
 public:
-    explicit ReadBufferFromS3(
+    ReadBufferFromS3(
         std::shared_ptr<Aws::S3::S3Client> client_ptr_,
         const String & bucket_,
         const String & key_,

--- a/src/IO/ReadWriteBufferFromHTTP.h
+++ b/src/IO/ReadWriteBufferFromHTTP.h
@@ -107,7 +107,7 @@ namespace detail
 
         std::istream * call(Poco::URI uri_, Poco::Net::HTTPResponse & response)
         {
-            // With empty path poco will send "POST  HTTP/1.1" its bug.
+            // With empty path poco will send "POST HTTP/1.1" its bug.
             if (uri_.getPath().empty())
                 uri_.setPath("/");
 

--- a/src/Processors/Formats/Impl/ArrowBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ArrowBlockInputFormat.cpp
@@ -24,7 +24,6 @@ namespace ErrorCodes
 ArrowBlockInputFormat::ArrowBlockInputFormat(ReadBuffer & in_, const Block & header_, bool stream_)
     : IInputFormat(header_, in_), stream{stream_}
 {
-    prepareReader();
 }
 
 Chunk ArrowBlockInputFormat::generate()
@@ -32,6 +31,9 @@ Chunk ArrowBlockInputFormat::generate()
     Chunk res;
     const Block & header = getPort().getHeader();
     arrow::Result<std::shared_ptr<arrow::RecordBatch>> batch_result;
+
+    if (!file_reader && !stream_reader)
+        prepareReader();
 
     if (stream)
     {
@@ -71,7 +73,6 @@ void ArrowBlockInputFormat::resetParser()
         stream_reader.reset();
     else
         file_reader.reset();
-    prepareReader();
 }
 
 void ArrowBlockInputFormat::prepareReader()

--- a/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
@@ -33,7 +33,6 @@ namespace ErrorCodes
 ParquetBlockInputFormat::ParquetBlockInputFormat(ReadBuffer & in_, Block header_)
     : IInputFormat(std::move(header_), in_)
 {
-    prepareReader();
 }
 
 Chunk ParquetBlockInputFormat::generate()
@@ -43,6 +42,9 @@ Chunk ParquetBlockInputFormat::generate()
 
     if (row_group_current >= row_group_total)
         return res;
+
+    if (!file_reader)
+        prepareReader();
 
     std::shared_ptr<arrow::Table> table;
     arrow::Status read_status = file_reader->ReadRowGroup(row_group_current, column_indices, &table);
@@ -62,7 +64,6 @@ void ParquetBlockInputFormat::resetParser()
 
     file_reader.reset();
     column_indices.clear();
-    prepareReader();
 }
 
 void ParquetBlockInputFormat::prepareReader()

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -102,7 +102,7 @@ namespace
 
             if (!initialized)
             {
-                reader->readSuffix();
+                reader->readPrefix();
                 initialized = true;
             }
 
@@ -123,6 +123,7 @@ namespace
                 return Chunk(std::move(columns), num_rows);
             }
 
+            reader->readSuffix();
             reader.reset();
 
             return {};


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
`Parquet` and `Arrow` formats will not start reading on initialization: fix the issue that EXPLAIN query from file-like table engines can require reading of data.


Note:

ORCInputFormat is strange - maybe it's reading whole file at once instead of streaming read.