### PR TITLE
Docs - date_sub

### DIFF
--- a/docs/en/sql-reference/functions/date-time-functions.md
+++ b/docs/en/sql-reference/functions/date-time-functions.md
@@ -520,7 +520,7 @@ Result:
 
 ## date\_sub {#date_sub}
 
-This subtracts a time/date interval from a date and then returns the date.
+Subtracts a time/date interval from the provided date.
 
 **Syntax**
 
@@ -536,7 +536,7 @@ Aliases: `dateSub`, `DATE_SUB`.
 
         Supported values: second, minute, hour, day, week, month, quarter, year.
 -   `value` - Value in specified unit - [Int](../../sql-reference/data-types/int-uint.md)    
--   `date` — [Date](../../sql-reference/data-types/date.md) or [DateTime](../../sql-reference/data-types/datetime.md).
+-   `date` — [Date](../../sql-reference/data-types/date.md) or [DateTime](../../sql-reference/data-types/datetime.md) to subtract value from.
 
 **Returned value**
 

--- a/docs/en/sql-reference/functions/date-time-functions.md
+++ b/docs/en/sql-reference/functions/date-time-functions.md
@@ -380,7 +380,7 @@ Alias: `dateTrunc`.
 
 **Parameters**
 
--   `unit` — The type of interval to truncate the result. [String](../../sql-reference/data-types/string.md).
+-   `unit` — The type of interval to truncate the result. [String Literal](../syntax.md#syntax-string-literal).
     Possible values:
 
     - `second`

--- a/docs/en/sql-reference/functions/date-time-functions.md
+++ b/docs/en/sql-reference/functions/date-time-functions.md
@@ -518,6 +518,46 @@ Result:
 └────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
+## date\_sub {#date_sub}
+
+This subtracts a time/date interval from a date and then returns the date.
+
+**Syntax**
+
+``` sql
+date_sub(unit, value, date)
+```
+
+Aliases: `dateSub`, `DATE_SUB`. 
+
+**Parameters**
+
+-   `unit` — The type of interval to subtract. [String](../../sql-reference/data-types/string.md).
+
+        Supported values: second, minute, hour, day, week, month, quarter, year.
+-   `value` - Value in specified unit - [Int](../../sql-reference/data-types/int-uint.md)    
+-   `date` — [Date](../../sql-reference/data-types/date.md) or [DateTime](../../sql-reference/data-types/datetime.md).
+
+**Returned value**
+
+Returns Date or DateTime with `value` expressed in `unit` subtracted from `date`. 
+
+**Example**
+
+Query:
+
+``` sql
+SELECT date_sub(YEAR, 3, toDate('2018-01-01'));
+```
+
+Result:
+
+``` text
+┌─minus(toDate('2018-01-01'), toIntervalYear(3))─┐
+│                                     2015-01-01 │
+└────────────────────────────────────────────────┘
+```
+
 ## timestamp\_add {#timestamp_add}
 
 Adds the specified time value with the provided date or date time value.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)


Detailed description / Documentation draft:

Document `date_sub`. Was missed out in:  #20107.

Relates to: #16049
