### PR TITLE
Normalize count() variants

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -375,6 +375,7 @@ class IColumn;
     M(Bool, optimize_respect_aliases, true, "If it is set to true, it will respect aliases in WHERE/GROUP BY/ORDER BY, that will help with partition pruning/secondary indexes/optimize_aggregation_in_order/optimize_read_in_order/optimize_trivial_count", 0) \
     M(UInt64, mutations_sync, 0, "Wait for synchronous execution of ALTER TABLE UPDATE/DELETE queries (mutations). 0 - execute asynchronously. 1 - wait current server. 2 - wait all replicas if they exist.", 0) \
     M(Bool, optimize_move_functions_out_of_any, false, "Move functions out of aggregate functions 'any', 'anyLast'.", 0) \
+    M(Bool, optimize_normalize_count_variants, false, "Rewrite aggregate functions that semantically equals to count() as count().", 0) \
     M(Bool, optimize_injective_functions_inside_uniq, true, "Delete injective functions of one argument inside uniq*() functions.", 0) \
     M(Bool, optimize_arithmetic_operations_in_aggregate_functions, true, "Move arithmetic operations out of aggregation functions", 0) \
     M(Bool, optimize_duplicate_order_by_and_distinct, true, "Remove duplicate ORDER BY and DISTINCT if it's possible", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -375,7 +375,7 @@ class IColumn;
     M(Bool, optimize_respect_aliases, true, "If it is set to true, it will respect aliases in WHERE/GROUP BY/ORDER BY, that will help with partition pruning/secondary indexes/optimize_aggregation_in_order/optimize_read_in_order/optimize_trivial_count", 0) \
     M(UInt64, mutations_sync, 0, "Wait for synchronous execution of ALTER TABLE UPDATE/DELETE queries (mutations). 0 - execute asynchronously. 1 - wait current server. 2 - wait all replicas if they exist.", 0) \
     M(Bool, optimize_move_functions_out_of_any, false, "Move functions out of aggregate functions 'any', 'anyLast'.", 0) \
-    M(Bool, optimize_normalize_count_variants, false, "Rewrite aggregate functions that semantically equals to count() as count().", 0) \
+    M(Bool, optimize_normalize_count_variants, true, "Rewrite aggregate functions that semantically equals to count() as count().", 0) \
     M(Bool, optimize_injective_functions_inside_uniq, true, "Delete injective functions of one argument inside uniq*() functions.", 0) \
     M(Bool, optimize_arithmetic_operations_in_aggregate_functions, true, "Move arithmetic operations out of aggregation functions", 0) \
     M(Bool, optimize_duplicate_order_by_and_distinct, true, "Remove duplicate ORDER BY and DISTINCT if it's possible", 0) \

--- a/src/Interpreters/RewriteCountVariantsVisitor.cpp
+++ b/src/Interpreters/RewriteCountVariantsVisitor.cpp
@@ -1,0 +1,62 @@
+#include <Interpreters/RewriteCountVariantsVisitor.h>
+#include <Parsers/ASTFunction.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTLiteral.h>
+#include <Parsers/ASTSubquery.h>
+#include <Parsers/ASTTablesInSelectQuery.h>
+#include <Poco/String.h>
+#include <Common/typeid_cast.h>
+
+namespace DB
+{
+void RewriteCountVariantsVisitor::visit(ASTPtr & node)
+{
+    if (node->as<ASTSubquery>() || node->as<ASTTableExpression>() || node->as<ASTArrayJoin>())
+        return;
+
+    for (auto & child : node->children)
+        visit(child);
+
+    if (auto * func = node->as<ASTFunction>())
+        visit(*func);
+}
+
+void RewriteCountVariantsVisitor::visit(ASTFunction & func)
+{
+    if (func.arguments->children.empty() || func.arguments->children.size() > 1 || !func.arguments->children[0])
+        return;
+
+    auto name = Poco::toLower(func.name);
+
+    if (name != "sum" && name != "count")
+        return;
+
+    auto & func_arguments = func.arguments->children;
+
+    const auto * first_arg_literal = func_arguments[0]->as<ASTLiteral>();
+    if (!first_arg_literal)
+        return;
+
+    bool transform = false;
+    if (name == "count")
+    {
+        if (first_arg_literal->value.getType() != Field::Types::Null)
+            transform = true;
+    }
+    else if (name == "sum")
+    {
+        if (first_arg_literal->value.getType() == Field::Types::UInt64)
+        {
+            auto constant = first_arg_literal->value.get<UInt64>();
+            if (constant == 1)
+                transform = true;
+        }
+    }
+    if (!transform)
+        return;
+
+    func.name = "count";
+    func.arguments->children.clear();
+}
+
+}

--- a/src/Interpreters/RewriteCountVariantsVisitor.h
+++ b/src/Interpreters/RewriteCountVariantsVisitor.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <Parsers/IAST.h>
+
+namespace DB
+{
+
+class ASTFunction;
+
+class RewriteCountVariantsVisitor
+{
+public:
+    static void visit(ASTPtr & ast);
+    static void visit(ASTFunction &);
+};
+
+}

--- a/src/Interpreters/RewriteCountVariantsVisitor.h
+++ b/src/Interpreters/RewriteCountVariantsVisitor.h
@@ -10,7 +10,7 @@ class ASTFunction;
 class RewriteCountVariantsVisitor
 {
 public:
-    static void visit(ASTPtr & ast);
+    static void visit(ASTPtr &);
     static void visit(ASTFunction &);
 };
 

--- a/src/Interpreters/TreeOptimizer.cpp
+++ b/src/Interpreters/TreeOptimizer.cpp
@@ -10,6 +10,7 @@
 #include <Interpreters/RewriteAnyFunctionVisitor.h>
 #include <Interpreters/RemoveInjectiveFunctionsVisitor.h>
 #include <Interpreters/RedundantFunctionsInOrderByVisitor.h>
+#include <Interpreters/RewriteCountVariantsVisitor.h>
 #include <Interpreters/MonotonicityCheckVisitor.h>
 #include <Interpreters/ConvertStringsToEnumVisitor.h>
 #include <Interpreters/PredicateExpressionsOptimizer.h>
@@ -555,6 +556,11 @@ void optimizeSumIfFunctions(ASTPtr & query)
     RewriteSumIfFunctionVisitor(data).visit(query);
 }
 
+void optimizeCountConstantAndSumOne(ASTPtr & query)
+{
+    RewriteCountVariantsVisitor::visit(query);
+}
+
 
 void optimizeInjectiveFunctionsInsideUniq(ASTPtr & query, const Context & context)
 {
@@ -615,6 +621,9 @@ void TreeOptimizer::apply(ASTPtr & query, Aliases & aliases, const NameSet & sou
     /// Move all operations out of any function
     if (settings.optimize_move_functions_out_of_any)
         optimizeAnyFunctions(query);
+
+    if (settings.optimize_normalize_count_variants)
+        optimizeCountConstantAndSumOne(query);
 
     if (settings.optimize_rewrite_sum_if_to_count_if)
         optimizeSumIfFunctions(query);

--- a/src/Interpreters/ya.make
+++ b/src/Interpreters/ya.make
@@ -129,6 +129,7 @@ SRCS(
     RequiredSourceColumnsData.cpp
     RequiredSourceColumnsVisitor.cpp
     RewriteAnyFunctionVisitor.cpp
+    RewriteCountVariantsVisitor.cpp
     RewriteSumIfFunctionVisitor.cpp
     RowRefs.cpp
     Set.cpp

--- a/tests/queries/0_stateless/01706_optimize_normalize_count_variants.reference
+++ b/tests/queries/0_stateless/01706_optimize_normalize_count_variants.reference
@@ -2,4 +2,5 @@ SELECT
     count(),
     count(),
     count(),
-    count()
+    count(),
+    count(NULL)

--- a/tests/queries/0_stateless/01706_optimize_normalize_count_variants.reference
+++ b/tests/queries/0_stateless/01706_optimize_normalize_count_variants.reference
@@ -1,0 +1,5 @@
+SELECT
+    count(),
+    count(),
+    count(),
+    count()

--- a/tests/queries/0_stateless/01706_optimize_normalize_count_variants.sql
+++ b/tests/queries/0_stateless/01706_optimize_normalize_count_variants.sql
@@ -1,4 +1,4 @@
 
 set optimize_normalize_count_variants = 1;
 
-explain syntax select count(), count(1), count(-1), sum(1);
+explain syntax select count(), count(1), count(-1), sum(1), count(null);

--- a/tests/queries/0_stateless/01706_optimize_normalize_count_variants.sql
+++ b/tests/queries/0_stateless/01706_optimize_normalize_count_variants.sql
@@ -1,0 +1,4 @@
+
+set optimize_normalize_count_variants = 1;
+
+explain syntax select count(), count(1), count(-1), sum(1);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Normalize count(constant), sum(1) to count(). This is needed for projection query routing.

Detailed description / Documentation draft:

.