### PR TITLE
rewrite avg for algebraic optimization

### DIFF
--- a/src/Interpreters/ArithmeticOperationsInAgrFuncOptimize.cpp
+++ b/src/Interpreters/ArithmeticOperationsInAgrFuncOptimize.cpp
@@ -89,11 +89,11 @@ const String & changeNameIfNeeded(const String & func_name, const String & child
 
 ASTPtr tryExchangeFunctions(const ASTFunction & func)
 {
-    static const std::unordered_map<String, std::unordered_set<String>> supported = {
-        { "sum", { "multiply", "divide" } },
-        { "min", { "multiply", "divide", "plus", "minus" } },
-        { "max", { "multiply", "divide", "plus", "minus" } }
-    };
+    static const std::unordered_map<String, std::unordered_set<String>> supported
+        = {{"sum", {"multiply", "divide"}},
+           {"min", {"multiply", "divide", "plus", "minus"}},
+           {"max", {"multiply", "divide", "plus", "minus"}},
+           {"avg", {"multiply", "divide", "plus", "minus"}}};
 
     const ASTFunction * child_func = getInternalFunction(func);
     if (!child_func || !child_func->arguments || child_func->arguments->children.size() != 2 ||

--- a/src/Interpreters/ArithmeticOperationsInAgrFuncOptimize.h
+++ b/src/Interpreters/ArithmeticOperationsInAgrFuncOptimize.h
@@ -11,7 +11,7 @@ class ASTFunction;
 /// Extract constant arguments out of aggregate functions from child functions
 /// 'sum(a * 2)' -> 'sum(a) * 2'
 /// Rewrites:   sum([multiply|divide]) -> [multiply|divide](sum)
-///             [min|max]([multiply|divide|plus|minus]) -> [multiply|divide|plus|minus]([min|max])
+///             [min|max|avg]([multiply|divide|plus|minus]) -> [multiply|divide|plus|minus]([min|max|avg])
 /// TODO: groupBitAnd, groupBitOr, groupBitXor
 /// TODO: better constant detection: f(const) is not detected as const.
 /// TODO: 'f((2 * n) * n)' -> '2 * f(n * n)'

--- a/tests/queries/0_stateless/01702_rewrite_avg_for_algebraic_optimization.reference
+++ b/tests/queries/0_stateless/01702_rewrite_avg_for_algebraic_optimization.reference
@@ -1,0 +1,23 @@
+SELECT avg(number + 2) FROM numbers(10)
+value: 	6.5
+EXPLAIN syntax:
+SELECT avg(number) + 2
+FROM numbers(10)
+
+SELECT avg(number - 2) FROM numbers(10)
+value: 	2.5
+EXPLAIN syntax:
+SELECT avg(number) - 2
+FROM numbers(10)
+
+SELECT avg(number * 2) FROM numbers(10)
+value: 	9
+EXPLAIN syntax:
+SELECT avg(number) * 2
+FROM numbers(10)
+
+SELECT avg(number / 2) FROM numbers(10)
+value: 	2.25
+EXPLAIN syntax:
+SELECT avg(number) / 2
+FROM numbers(10)

--- a/tests/queries/0_stateless/01702_rewrite_avg_for_algebraic_optimization.sql
+++ b/tests/queries/0_stateless/01702_rewrite_avg_for_algebraic_optimization.sql
@@ -1,0 +1,22 @@
+SELECT 'SELECT avg(number + 2) FROM numbers(10)';
+SELECT 'value: ', avg(number + 2) FROM numbers(10);
+SELECT 'EXPLAIN syntax:';
+EXPLAIN SYNTAX SELECT avg(number + 2) FROM numbers(10);
+
+SELECT '';
+SELECT 'SELECT avg(number - 2) FROM numbers(10)';
+SELECT 'value: ', avg(number - 2) FROM numbers(10);
+SELECT 'EXPLAIN syntax:';
+EXPLAIN SYNTAX SELECT avg(number - 2) FROM numbers(10);
+
+SELECT '';
+SELECT 'SELECT avg(number * 2) FROM numbers(10)';
+SELECT 'value: ', avg(number * 2) FROM numbers(10);
+SELECT 'EXPLAIN syntax:';
+EXPLAIN SYNTAX SELECT avg(number * 2) FROM numbers(10);
+
+SELECT '';
+SELECT 'SELECT avg(number / 2) FROM numbers(10)';
+SELECT 'value: ', avg(number / 2) FROM numbers(10);
+SELECT 'EXPLAIN syntax:';
+EXPLAIN SYNTAX SELECT avg(number / 2) FROM numbers(10);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Perform algebraic optimizations of arithmetic expressions inside `avg` aggregate function. close #20092.