### PR TITLE
Respect max_execution_time when enumerating the hosts for `remote` function

### DIFF
--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -111,7 +111,7 @@ continue
     # SC2012: Use find instead of ls to better handle non-alphanumeric filenames. They are all alphanumeric.
     # SC2046: Quote this to prevent word splitting. Actually I need word splitting.
     # shellcheck disable=SC2012,SC2046
-    ./clickhouse-client --query-fuzzer-runs=1000 --queries-file $(ls -1 ch/tests/queries/0_stateless/*.sql | sort -R) $NEW_TESTS_OPT \
+    ./clickhouse-client --receive_timeout=10 --query-fuzzer-runs=1000 --queries-file $(ls -1 ch/tests/queries/0_stateless/*.sql | sort -R) $NEW_TESTS_OPT \
         > >(tail -n 100000 > fuzzer.log) \
         2>&1 \
         || fuzzer_exit_code=$?

--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -115,10 +115,15 @@ continue
     echo Server started
 
     fuzzer_exit_code=0
+    # We'd like to detect stuck queries that ignore max_execution_time,
+    # but for now too many queries fail, because parsing of a complex
+    # query with sanitizers can take longer than the execution timeout of
+    # 10 seconds. So for now set receive_timeout much higher to detect
+    # only very bad queries.
     # SC2012: Use find instead of ls to better handle non-alphanumeric filenames. They are all alphanumeric.
     # SC2046: Quote this to prevent word splitting. Actually I need word splitting.
     # shellcheck disable=SC2012,SC2046
-    ./clickhouse-client --receive_timeout=10 --query-fuzzer-runs=1000 --queries-file $(ls -1 ch/tests/queries/0_stateless/*.sql | sort -R) $NEW_TESTS_OPT \
+    ./clickhouse-client --receive_timeout=60 --query-fuzzer-runs=1000 --queries-file $(ls -1 ch/tests/queries/0_stateless/*.sql | sort -R) $NEW_TESTS_OPT \
         > >(tail -n 100000 > fuzzer.log) \
         2>&1 \
         || fuzzer_exit_code=$?

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -1867,9 +1867,20 @@ private:
                         double elapsed = receive_watch.elapsedSeconds();
                         if (elapsed > receive_timeout.totalSeconds())
                         {
-                            std::cout << "Timeout exceeded while receiving data from server."
+                            std::cerr << "Timeout exceeded while receiving data from server."
                                       << " Waited for " << static_cast<size_t>(elapsed) << " seconds,"
                                       << " timeout is " << receive_timeout.totalSeconds() << " seconds." << std::endl;
+
+                            // If we're fuzzing and found a query which is slow
+                            // to send the results, this is probably bad. It means
+                            // that the max_execution_time didn't work.
+                            // cancel_query() will also probably fail, so exit
+                            // right away.
+                            if (query_fuzzer_runs > 0)
+                            {
+                                fmt::print(stderr, "This is a server bug, max_execution_time should have worked.\n");
+                                exit(1);
+                            }
 
                             cancel_query();
                         }

--- a/programs/client/QueryFuzzer.cpp
+++ b/programs/client/QueryFuzzer.cpp
@@ -425,7 +425,7 @@ void QueryFuzzer::fuzz(ASTPtr & ast)
         fuzz(tables_element->table_join);
         if (tables_element->table_expression)
         {
-            if (fuzz_rand() % 10)
+            if (fuzz_rand() % 50)
             {
                 replaceWithTableLike(tables_element->table_expression);
             }

--- a/programs/client/QueryFuzzer.cpp
+++ b/programs/client/QueryFuzzer.cpp
@@ -205,10 +205,6 @@ void QueryFuzzer::replaceWithTableLike(ASTPtr & ast)
     }
 
     ASTPtr new_ast = table_like[fuzz_rand() % table_like.size()]->clone();
-
-    std::string old_alias = ast->tryGetAlias();
-    new_ast->setAlias(old_alias);
-
     ast = new_ast;
 }
 
@@ -427,7 +423,14 @@ void QueryFuzzer::fuzz(ASTPtr & ast)
     else if (auto * tables_element = typeid_cast<ASTTablesInSelectQueryElement *>(ast.get()))
     {
         fuzz(tables_element->table_join);
-        fuzz(tables_element->table_expression);
+        if (tables_element->table_expression)
+        {
+            if (fuzz_rand() % 10)
+            {
+                replaceWithTableLike(tables_element->table_expression);
+            }
+            fuzz(tables_element->table_expression);
+        }
         fuzz(tables_element->array_join);
     }
     else if (auto * table_expr = typeid_cast<ASTTableExpression *>(ast.get()))

--- a/programs/client/QueryFuzzer.h
+++ b/programs/client/QueryFuzzer.h
@@ -50,7 +50,7 @@ struct QueryFuzzer
     // Some debug fields for detecting problematic ASTs with loops.
     // These are reset for each fuzzMain call.
     std::unordered_set<const IAST *> debug_visited_nodes;
-    ASTPtr * debug_top_ast;
+    ASTPtr * debug_top_ast = nullptr;
 
 
     // This is the only function you have to call -- it will modify the passed

--- a/src/Client/ConnectionPoolWithFailover.cpp
+++ b/src/Client/ConnectionPoolWithFailover.cpp
@@ -91,7 +91,9 @@ IConnectionPool::Entry ConnectionPoolWithFailover::get(const ConnectionTimeouts 
     UInt64 max_ignored_errors = settings ? settings->distributed_replica_max_ignored_errors.value : 0;
     bool fallback_to_stale_replicas = settings ? settings->fallback_to_stale_replicas_for_distributed_queries.value : true;
 
-    return Base::get(max_ignored_errors, fallback_to_stale_replicas, try_get_entry, get_priority);
+    return Base::get(max_ignored_errors, fallback_to_stale_replicas,
+        try_get_entry, get_priority,
+        settings ? settings->max_execution_time.totalSeconds() : 0);
 }
 
 Int64 ConnectionPoolWithFailover::getPriority() const
@@ -230,7 +232,8 @@ std::vector<ConnectionPoolWithFailover::TryResult> ConnectionPoolWithFailover::g
 
     return Base::getMany(min_entries, max_entries, max_tries,
         max_ignored_errors, fallback_to_stale_replicas,
-        try_get_entry, get_priority);
+        try_get_entry, get_priority,
+        settings ? settings->max_execution_time.totalSeconds() : 0);
 }
 
 ConnectionPoolWithFailover::TryResult

--- a/src/Storages/getStructureOfRemoteTable.cpp
+++ b/src/Storages/getStructureOfRemoteTable.cpp
@@ -21,6 +21,7 @@ namespace DB
 
 namespace ErrorCodes
 {
+    extern const int TIMEOUT_EXCEEDED;
     extern const int NO_REMOTE_SHARD_AVAILABLE;
 }
 

--- a/tests/queries/0_stateless/01566_remote_host_enumeration_timeout.sql
+++ b/tests/queries/0_stateless/01566_remote_host_enumeration_timeout.sql
@@ -1,0 +1,2 @@
+select * from remote('badhost{0..100}', system, one) settings max_execution_time = 1; -- { serverError 159 }
+select * from remote('192.0.2.{0..100}', system, one) settings max_execution_time = 1; -- { serverError 159 }

--- a/tests/queries/0_stateless/01566_remote_host_enumeration_timeout.sql
+++ b/tests/queries/0_stateless/01566_remote_host_enumeration_timeout.sql
@@ -1,2 +1,2 @@
-select * from remote('badhost{0..100}', system, one) settings max_execution_time = 1; -- { serverError 159 }
-select * from remote('192.0.2.{0..100}', system, one) settings max_execution_time = 1; -- { serverError 159 }
+select * from remote('badhost{0..200}', system, one) settings max_execution_time = 1; -- { serverError 159 }
+select * from remote('192.0.2.{0..200}', system, one) settings max_execution_time = 1; -- { serverError 159 }

--- a/tests/queries/0_stateless/01566_remote_host_enumeration_timeout.sql
+++ b/tests/queries/0_stateless/01566_remote_host_enumeration_timeout.sql
@@ -1,2 +1,5 @@
-select * from remote('badhost{0..200}', system, one) settings max_execution_time = 1; -- { serverError 159 }
+-- somehow this one is too fast in release mode
+-- select * from remote('badhost{0..200}.test', system, one) settings max_execution_time = 1; -- { serverError 159 }
+
+-- addresses from TEST-NET-1
 select * from remote('192.0.2.{0..200}', system, one) settings max_execution_time = 1; -- { serverError 159 }

--- a/tests/queries/0_stateless/01566_remote_host_enumeration_timeout.sql
+++ b/tests/queries/0_stateless/01566_remote_host_enumeration_timeout.sql
@@ -5,5 +5,5 @@
 -- select * from remote('badhost{0..200}.test', system, one) settings max_execution_time = 1; -- { serverError 159 }
 
 -- addresses from TEST-NET-1,2
-select * from remote('{192.0.2,198.51.100.0}.{0..255}', system, one)
+select * from remote('{192.0.2,198.51.100.0}.{0..255}', default, nonexistent01566)
 settings max_execution_time = 1, table_function_remote_max_addresses = 100000; -- { serverError 159 }

--- a/tests/queries/0_stateless/01566_remote_host_enumeration_timeout.sql
+++ b/tests/queries/0_stateless/01566_remote_host_enumeration_timeout.sql
@@ -1,5 +1,9 @@
--- somehow this one is too fast in release mode
+-- Somehow this one is too fast in release mode. Moreover, the very parsing
+-- can be slow, because the constructor of Cluster::Address makes DNS queries
+-- to determine whether an address is local. I have to switch this to deferred
+-- initialization, but this is too much work for now.
 -- select * from remote('badhost{0..200}.test', system, one) settings max_execution_time = 1; -- { serverError 159 }
 
--- addresses from TEST-NET-1
-select * from remote('192.0.2.{0..200}', system, one) settings max_execution_time = 1; -- { serverError 159 }
+-- addresses from TEST-NET-1,2
+select * from remote('{192.0.2,198.51.100.0}.{0..255}', system, one)
+settings max_execution_time = 1, table_function_remote_max_addresses = 100000; -- { serverError 159 }


### PR DESCRIPTION
It may take arbitrarily long. Also make the fuzzer detect the cases where we don't respect the timeout.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)
