### PR TITLE
Add retries to test_access_control_on_cluster

### DIFF
--- a/tests/integration/test_access_control_on_cluster/test.py
+++ b/tests/integration/test_access_control_on_cluster/test.py
@@ -18,22 +18,22 @@ def started_cluster():
 
 
 def test_access_control_on_cluster():
-    ch1.query("CREATE USER Alex ON CLUSTER 'cluster'")
+    ch1.query_with_retry("CREATE USER Alex ON CLUSTER 'cluster'", retry_count=3)
     assert ch1.query("SHOW CREATE USER Alex") == "CREATE USER Alex\n"
     assert ch2.query("SHOW CREATE USER Alex") == "CREATE USER Alex\n"
     assert ch3.query("SHOW CREATE USER Alex") == "CREATE USER Alex\n"
 
-    ch2.query("GRANT ON CLUSTER 'cluster' SELECT ON *.* TO Alex")
+    ch2.query_with_retry("GRANT ON CLUSTER 'cluster' SELECT ON *.* TO Alex", retry_count=3)
     assert ch1.query("SHOW GRANTS FOR Alex") == "GRANT SELECT ON *.* TO Alex\n"
     assert ch2.query("SHOW GRANTS FOR Alex") == "GRANT SELECT ON *.* TO Alex\n"
     assert ch3.query("SHOW GRANTS FOR Alex") == "GRANT SELECT ON *.* TO Alex\n"
 
-    ch3.query("REVOKE ON CLUSTER 'cluster' SELECT ON *.* FROM Alex")
+    ch3.query_with_retry("REVOKE ON CLUSTER 'cluster' SELECT ON *.* FROM Alex", retry_count=3)
     assert ch1.query("SHOW GRANTS FOR Alex") == ""
     assert ch2.query("SHOW GRANTS FOR Alex") == ""
     assert ch3.query("SHOW GRANTS FOR Alex") == ""
 
-    ch2.query("DROP USER Alex ON CLUSTER 'cluster'")
+    ch2.query_with_retry("DROP USER Alex ON CLUSTER 'cluster'", retry_count=3)
     assert "There is no user `Alex`" in ch1.query_and_get_error("SHOW CREATE USER Alex")
     assert "There is no user `Alex`" in ch2.query_and_get_error("SHOW CREATE USER Alex")
     assert "There is no user `Alex`" in ch3.query_and_get_error("SHOW CREATE USER Alex")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:

...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
