### PR TITLE
Stable sort for test cases in test_dictionaries_all_layouts_separate_sources

### DIFF
--- a/tests/integration/test_access_control_on_cluster/test.py
+++ b/tests/integration/test_access_control_on_cluster/test.py
@@ -18,22 +18,22 @@ def started_cluster():
 
 
 def test_access_control_on_cluster():
-    ch1.query("CREATE USER Alex ON CLUSTER 'cluster'")
+    ch1.query_with_retry("CREATE USER Alex ON CLUSTER 'cluster'", retry_count=3)
     assert ch1.query("SHOW CREATE USER Alex") == "CREATE USER Alex\n"
     assert ch2.query("SHOW CREATE USER Alex") == "CREATE USER Alex\n"
     assert ch3.query("SHOW CREATE USER Alex") == "CREATE USER Alex\n"
 
-    ch2.query("GRANT ON CLUSTER 'cluster' SELECT ON *.* TO Alex")
+    ch2.query_with_retry("GRANT ON CLUSTER 'cluster' SELECT ON *.* TO Alex", retry_count=3)
     assert ch1.query("SHOW GRANTS FOR Alex") == "GRANT SELECT ON *.* TO Alex\n"
     assert ch2.query("SHOW GRANTS FOR Alex") == "GRANT SELECT ON *.* TO Alex\n"
     assert ch3.query("SHOW GRANTS FOR Alex") == "GRANT SELECT ON *.* TO Alex\n"
 
-    ch3.query("REVOKE ON CLUSTER 'cluster' SELECT ON *.* FROM Alex")
+    ch3.query_with_retry("REVOKE ON CLUSTER 'cluster' SELECT ON *.* FROM Alex", retry_count=3)
     assert ch1.query("SHOW GRANTS FOR Alex") == ""
     assert ch2.query("SHOW GRANTS FOR Alex") == ""
     assert ch3.query("SHOW GRANTS FOR Alex") == ""
 
-    ch2.query("DROP USER Alex ON CLUSTER 'cluster'")
+    ch2.query_with_retry("DROP USER Alex ON CLUSTER 'cluster'", retry_count=3)
     assert "There is no user `Alex`" in ch1.query_and_get_error("SHOW CREATE USER Alex")
     assert "There is no user `Alex`" in ch2.query_and_get_error("SHOW CREATE USER Alex")
     assert "There is no user `Alex`" in ch3.query_and_get_error("SHOW CREATE USER Alex")

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_cassandra.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_cassandra.py
@@ -1,4 +1,4 @@
-import os 
+import os
 import math
 import pytest
 
@@ -43,13 +43,13 @@ def setup_module(module):
     main_configs = []
     main_configs.append(os.path.join('configs', 'disable_ssl_verification.xml'))
     main_configs.append(os.path.join('configs', 'log_conf.xml'))
-   
+
     for fname in os.listdir(DICT_CONFIG_PATH):
         dictionaries.append(os.path.join(DICT_CONFIG_PATH, fname))
 
     node = cluster.add_instance('node', main_configs=main_configs, dictionaries=dictionaries, with_cassandra=True)
 
-    
+
 def teardown_module(module):
     global DICT_CONFIG_PATH
     for fname in os.listdir(DICT_CONFIG_PATH):
@@ -70,14 +70,14 @@ def started_cluster():
     finally:
         cluster.shutdown()
 
-@pytest.mark.parametrize("layout_name", LAYOUTS_SIMPLE)
+@pytest.mark.parametrize("layout_name", sorted(LAYOUTS_SIMPLE))
 def test_simple(started_cluster, layout_name):
     simple_tester.execute(layout_name, node)
 
-@pytest.mark.parametrize("layout_name", LAYOUTS_COMPLEX)
+@pytest.mark.parametrize("layout_name", sorted(LAYOUTS_COMPLEX))
 def test_complex(started_cluster, layout_name):
     complex_tester.execute(layout_name, node)
-    
-@pytest.mark.parametrize("layout_name", LAYOUTS_RANGED)
+
+@pytest.mark.parametrize("layout_name", sorted(LAYOUTS_RANGED))
 def test_ranged(started_cluster, layout_name):
     ranged_tester.execute(layout_name, node)

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_clickhouse_local.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_clickhouse_local.py
@@ -69,14 +69,14 @@ def started_cluster():
     finally:
         cluster.shutdown()
 
-@pytest.mark.parametrize("layout_name", LAYOUTS_SIMPLE)
+@pytest.mark.parametrize("layout_name", sorted(LAYOUTS_SIMPLE))
 def test_simple(started_cluster, layout_name):
     simple_tester.execute(layout_name, node)
 
-@pytest.mark.parametrize("layout_name", LAYOUTS_COMPLEX)
+@pytest.mark.parametrize("layout_name", sorted(LAYOUTS_COMPLEX))
 def test_complex(started_cluster, layout_name):
     complex_tester.execute(layout_name, node)
     
-@pytest.mark.parametrize("layout_name", LAYOUTS_RANGED)
+@pytest.mark.parametrize("layout_name", sorted(LAYOUTS_RANGED))
 def test_ranged(started_cluster, layout_name):
     ranged_tester.execute(layout_name, node)

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_clickhouse_remote.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_clickhouse_remote.py
@@ -1,4 +1,4 @@
-import os 
+import os
 import math
 import pytest
 
@@ -47,10 +47,10 @@ def setup_module(module):
         dictionaries.append(os.path.join(DICT_CONFIG_PATH, fname))
 
     cluster.add_instance('clickhouse1', main_configs=main_configs)
-    
+
     node = cluster.add_instance('node', main_configs=main_configs, dictionaries=dictionaries)
 
-    
+
 def teardown_module(module):
     global DICT_CONFIG_PATH
     for fname in os.listdir(DICT_CONFIG_PATH):
@@ -71,14 +71,14 @@ def started_cluster():
     finally:
         cluster.shutdown()
 
-@pytest.mark.parametrize("layout_name", list(set(LAYOUTS_SIMPLE).difference(set("cache"))) )
+@pytest.mark.parametrize("layout_name", sorted(list(set(LAYOUTS_SIMPLE).difference(set("cache"))) ))
 def test_simple(started_cluster, layout_name):
     simple_tester.execute(layout_name, node)
 
-@pytest.mark.parametrize("layout_name", list(set(LAYOUTS_COMPLEX).difference(set("complex_key_cache"))))
+@pytest.mark.parametrize("layout_name", sorted(list(set(LAYOUTS_COMPLEX).difference(set("complex_key_cache")))))
 def test_complex(started_cluster, layout_name):
     complex_tester.execute(layout_name, node)
-    
-@pytest.mark.parametrize("layout_name", LAYOUTS_RANGED)
+
+@pytest.mark.parametrize("layout_name", sorted(LAYOUTS_RANGED))
 def test_ranged(started_cluster, layout_name):
     ranged_tester.execute(layout_name, node)

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_executable_hashed.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_executable_hashed.py
@@ -77,6 +77,6 @@ def test_simple(started_cluster, layout_name):
 def test_complex(started_cluster, layout_name):
     complex_tester.execute(layout_name, node)
 
-@pytest.mark.parametrize("layout_name", LAYOUTS_RANGED)
+@pytest.mark.parametrize("layout_name", sorted(LAYOUTS_RANGED))
 def test_ranged(started_cluster, layout_name):
     ranged_tester.execute(layout_name, node)

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_file.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_file.py
@@ -1,4 +1,4 @@
-import os 
+import os
 import math
 import pytest
 
@@ -42,13 +42,13 @@ def setup_module(module):
     dictionaries = []
     main_configs = []
     main_configs.append(os.path.join('configs', 'disable_ssl_verification.xml'))
-    
+
     for fname in os.listdir(DICT_CONFIG_PATH):
         dictionaries.append(os.path.join(DICT_CONFIG_PATH, fname))
 
     node = cluster.add_instance('node', main_configs=main_configs, dictionaries=dictionaries)
 
-    
+
 def teardown_module(module):
     global DICT_CONFIG_PATH
     for fname in os.listdir(DICT_CONFIG_PATH):
@@ -69,14 +69,14 @@ def started_cluster():
     finally:
         cluster.shutdown()
 
-@pytest.mark.parametrize("layout_name", set(LAYOUTS_SIMPLE).difference({'cache', 'direct'}) )
+@pytest.mark.parametrize("layout_name", sorted(set(LAYOUTS_SIMPLE).difference({'cache', 'direct'})) )
 def test_simple(started_cluster, layout_name):
     simple_tester.execute(layout_name, node)
 
-@pytest.mark.parametrize("layout_name", list(set(LAYOUTS_COMPLEX).difference({'complex_key_cache', 'complex_key_direct'})))
+@pytest.mark.parametrize("layout_name", sorted(list(set(LAYOUTS_COMPLEX).difference({'complex_key_cache', 'complex_key_direct'}))))
 def test_complex(started_cluster, layout_name):
     complex_tester.execute(layout_name, node)
-    
-@pytest.mark.parametrize("layout_name", LAYOUTS_RANGED)
+
+@pytest.mark.parametrize("layout_name", sorted(LAYOUTS_RANGED))
 def test_ranged(started_cluster, layout_name):
     ranged_tester.execute(layout_name, node)

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_http.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_http.py
@@ -1,4 +1,4 @@
-import os 
+import os
 import math
 import pytest
 
@@ -42,7 +42,7 @@ def setup_module(module):
     dictionaries = []
     main_configs = []
     main_configs.append(os.path.join('configs', 'disable_ssl_verification.xml'))
-    
+
     for fname in os.listdir(DICT_CONFIG_PATH):
         dictionaries.append(os.path.join(DICT_CONFIG_PATH, fname))
 
@@ -50,7 +50,7 @@ def setup_module(module):
 
     node = cluster.add_instance('node', main_configs=main_configs, dictionaries=dictionaries)
 
-    
+
 def teardown_module(module):
     global DICT_CONFIG_PATH
     for fname in os.listdir(DICT_CONFIG_PATH):
@@ -71,14 +71,14 @@ def started_cluster():
     finally:
         cluster.shutdown()
 
-@pytest.mark.parametrize("layout_name", LAYOUTS_SIMPLE)
+@pytest.mark.parametrize("layout_name", sorted(LAYOUTS_SIMPLE))
 def test_simple(started_cluster, layout_name):
     simple_tester.execute(layout_name, node)
 
-@pytest.mark.parametrize("layout_name", LAYOUTS_COMPLEX)
+@pytest.mark.parametrize("layout_name", sorted(LAYOUTS_COMPLEX))
 def test_complex(started_cluster, layout_name):
     complex_tester.execute(layout_name, node)
-    
-@pytest.mark.parametrize("layout_name", LAYOUTS_RANGED)
+
+@pytest.mark.parametrize("layout_name", sorted(LAYOUTS_RANGED))
 def test_ranged(started_cluster, layout_name):
     ranged_tester.execute(layout_name, node)

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_https.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_https.py
@@ -1,4 +1,4 @@
-import os 
+import os
 import math
 import pytest
 
@@ -42,7 +42,7 @@ def setup_module(module):
     dictionaries = []
     main_configs = []
     main_configs.append(os.path.join('configs', 'disable_ssl_verification.xml'))
-    
+
     for fname in os.listdir(DICT_CONFIG_PATH):
         dictionaries.append(os.path.join(DICT_CONFIG_PATH, fname))
 
@@ -50,7 +50,7 @@ def setup_module(module):
 
     node = cluster.add_instance('node', main_configs=main_configs, dictionaries=dictionaries)
 
-    
+
 def teardown_module(module):
     global DICT_CONFIG_PATH
     for fname in os.listdir(DICT_CONFIG_PATH):
@@ -71,14 +71,14 @@ def started_cluster():
     finally:
         cluster.shutdown()
 
-@pytest.mark.parametrize("layout_name", LAYOUTS_SIMPLE)
+@pytest.mark.parametrize("layout_name", sorted(LAYOUTS_SIMPLE))
 def test_simple(started_cluster, layout_name):
     simple_tester.execute(layout_name, node)
 
-@pytest.mark.parametrize("layout_name", LAYOUTS_COMPLEX)
+@pytest.mark.parametrize("layout_name", sorted(LAYOUTS_COMPLEX))
 def test_complex(started_cluster, layout_name):
     complex_tester.execute(layout_name, node)
-    
-@pytest.mark.parametrize("layout_name", LAYOUTS_RANGED)
+
+@pytest.mark.parametrize("layout_name", sorted(LAYOUTS_RANGED))
 def test_ranged(started_cluster, layout_name):
     ranged_tester.execute(layout_name, node)

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mongo.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mongo.py
@@ -1,4 +1,4 @@
-import os 
+import os
 import math
 import pytest
 
@@ -42,13 +42,13 @@ def setup_module(module):
     dictionaries = []
     main_configs = []
     main_configs.append(os.path.join('configs', 'disable_ssl_verification.xml'))
-    
+
     for fname in os.listdir(DICT_CONFIG_PATH):
         dictionaries.append(os.path.join(DICT_CONFIG_PATH, fname))
 
     node = cluster.add_instance('node', main_configs=main_configs, dictionaries=dictionaries, with_mongo=True)
 
-    
+
 def teardown_module(module):
     global DICT_CONFIG_PATH
     for fname in os.listdir(DICT_CONFIG_PATH):
@@ -69,14 +69,14 @@ def started_cluster():
     finally:
         cluster.shutdown()
 
-@pytest.mark.parametrize("layout_name", LAYOUTS_SIMPLE)
+@pytest.mark.parametrize("layout_name", sorted(LAYOUTS_SIMPLE))
 def test_simple(started_cluster, layout_name):
     simple_tester.execute(layout_name, node)
 
-@pytest.mark.parametrize("layout_name", LAYOUTS_COMPLEX)
+@pytest.mark.parametrize("layout_name", sorted(LAYOUTS_COMPLEX))
 def test_complex(started_cluster, layout_name):
     complex_tester.execute(layout_name, node)
-    
-@pytest.mark.parametrize("layout_name", LAYOUTS_RANGED)
+
+@pytest.mark.parametrize("layout_name", sorted(LAYOUTS_RANGED))
 def test_ranged(started_cluster, layout_name):
     ranged_tester.execute(layout_name, node)

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mysql.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mysql.py
@@ -1,4 +1,4 @@
-import os 
+import os
 import math
 import pytest
 
@@ -43,13 +43,13 @@ def setup_module(module):
     main_configs = []
     main_configs.append(os.path.join('configs', 'disable_ssl_verification.xml'))
     main_configs.append(os.path.join('configs', 'log_conf.xml'))
-    
+
     for fname in os.listdir(DICT_CONFIG_PATH):
         dictionaries.append(os.path.join(DICT_CONFIG_PATH, fname))
 
     node = cluster.add_instance('node', main_configs=main_configs, dictionaries=dictionaries, with_mysql=True)
 
-    
+
 def teardown_module(module):
     global DICT_CONFIG_PATH
     for fname in os.listdir(DICT_CONFIG_PATH):
@@ -70,14 +70,14 @@ def started_cluster():
     finally:
         cluster.shutdown()
 
-@pytest.mark.parametrize("layout_name", LAYOUTS_SIMPLE)
+@pytest.mark.parametrize("layout_name", sorted(LAYOUTS_SIMPLE))
 def test_simple(started_cluster, layout_name):
     simple_tester.execute(layout_name, node)
 
-@pytest.mark.parametrize("layout_name", LAYOUTS_COMPLEX)
+@pytest.mark.parametrize("layout_name", sorted(LAYOUTS_COMPLEX))
 def test_complex(started_cluster, layout_name):
     complex_tester.execute(layout_name, node)
-    
-@pytest.mark.parametrize("layout_name", LAYOUTS_RANGED)
+
+@pytest.mark.parametrize("layout_name", sorted(LAYOUTS_RANGED))
 def test_ranged(started_cluster, layout_name):
     ranged_tester.execute(layout_name, node)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:

Prepare for integration test parallel run. We need to have stable sort for tests list. Without it it depends on hash seed.

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
