### PR TITLE
Add _error and _raw_message virtual columns for Kafka engine

### DIFF
--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -290,6 +290,7 @@ InputFormatPtr FormatFactory::getInputFormat(
     params.allow_errors_ratio = format_settings.input_allow_errors_ratio;
     params.max_execution_time = settings.max_execution_time;
     params.timeout_overflow_mode = settings.timeout_overflow_mode;
+    params.auto_append_error_column = format_settings.auto_append_error_column;
 
     auto format = input_getter(buf, sample, params, format_settings);
 

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -28,6 +28,7 @@ struct FormatSettings
     bool write_statistics = true;
     bool import_nested_json = false;
     bool null_as_default = false;
+    bool auto_append_error_column = false;
 
     enum class DateTimeInputFormat
     {

--- a/src/Processors/Formats/IRowInputFormat.h
+++ b/src/Processors/Formats/IRowInputFormat.h
@@ -29,6 +29,8 @@ struct RowInputFormatParams
 
     Poco::Timespan max_execution_time = 0;
     OverflowMode timeout_overflow_mode = OverflowMode::THROW;
+
+    bool auto_append_error_column = false;
 };
 
 bool isParseError(int code);

--- a/src/Storages/Kafka/KafkaBlockInputStream.h
+++ b/src/Storages/Kafka/KafkaBlockInputStream.h
@@ -49,8 +49,10 @@ private:
     bool finished = false;
     bool commit_in_suffix;
 
+    const Block result_header;
     const Block non_virtual_header;
     const Block virtual_header;
+    bool auto_append_error_column = false;
 };
 
 }

--- a/src/Storages/Kafka/KafkaSettings.h
+++ b/src/Storages/Kafka/KafkaSettings.h
@@ -29,7 +29,8 @@ class ASTStorage;
     M(Char, kafka_row_delimiter, '\0', "The character to be considered as a delimiter in Kafka message.", 0) \
     M(String, kafka_schema, "", "Schema identifier (used by schema-based formats) for Kafka engine", 0) \
     M(UInt64, kafka_skip_broken_messages, 0, "Skip at least this number of broken messages from Kafka topic per block", 0) \
-    M(Bool, kafka_thread_per_consumer, false, "Provide independent thread for each consumer", 0)
+    M(Bool, kafka_thread_per_consumer, false, "Provide independent thread for each consumer", 0) \
+    M(Bool, kafka_auto_append_error_column, false, "Virtual column named _error for Kafka engine to collect the parser error.", 0)
 
     /** TODO: */
     /* https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md */

--- a/src/Storages/Kafka/ReadBufferFromKafkaConsumer.h
+++ b/src/Storages/Kafka/ReadBufferFromKafkaConsumer.h
@@ -63,6 +63,7 @@ public:
     auto currentPartition() const { return current[-1].get_partition(); }
     auto currentTimestamp() const { return current[-1].get_timestamp(); }
     const auto & currentHeaderList() const { return current[-1].get_header_list(); }
+    String currentPayload() const { return current[-1].get_payload(); }
 
 private:
     using Messages = std::vector<cppkafka::Message>;

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -760,7 +760,7 @@ void registerStorageKafka(StorageFactory & factory)
 
 NamesAndTypesList StorageKafka::getVirtuals() const
 {
-    return NamesAndTypesList{
+    auto result = NamesAndTypesList{
         {"_topic", std::make_shared<DataTypeString>()},
         {"_key", std::make_shared<DataTypeString>()},
         {"_offset", std::make_shared<DataTypeUInt64>()},
@@ -768,8 +768,24 @@ NamesAndTypesList StorageKafka::getVirtuals() const
         {"_timestamp", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeDateTime>())},
         {"_timestamp_ms", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeDateTime64>(3))},
         {"_headers.name", std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>())},
-        {"_headers.value", std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>())}
+        {"_headers.value", std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>())},
+        {"_raw_message", std::make_shared<DataTypeString>()}
     };
+    if (kafka_settings->kafka_auto_append_error_column > 0)
+    {
+        result.push_back({"_error", std::make_shared<DataTypeString>()});
+    }
+    return result;
+}
+
+Names StorageKafka::getVirtualColumnNames() const
+{
+    Names names = {"_topic", "_key", "_offset", "_partition", "_timestamp", "_timestamp_ms", "_headers.name", "_headers.value", "_raw_message"};
+    if (kafka_settings->kafka_auto_append_error_column > 0)
+    {
+        names.push_back({"_error"});
+    }
+    return names;
 }
 
 }

--- a/src/Storages/Kafka/StorageKafka.h
+++ b/src/Storages/Kafka/StorageKafka.h
@@ -64,6 +64,8 @@ public:
     const auto & getFormatName() const { return format_name; }
 
     NamesAndTypesList getVirtuals() const override;
+    Names getVirtualColumnNames() const;
+    bool getAutoAppendErrorColumn() const { return kafka_settings->kafka_auto_append_error_column > 0; }
 protected:
     StorageKafka(
         const StorageID & table_id_,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- New Feature


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add two virtual columns (_error and _raw_message) to Kafka Engine.


Detailed description / Documentation draft:

Use case:

Create the kafka engine with kafka_auto_append_error_column = 1.The new parameter's default value is 0.
```
 CREATE TABLE default.tt
(
    `i` Int64,
    `s` String
)
ENGINE = Kafka
SETTINGS kafka_broker_list = '172.19.0.32:9092', kafka_topic_list = 't2', kafka_group_name = 'g1', kafka_format = 'JSONEachRow', kafka_max_block_size = 16, kafka_skip_broken_messages = 17, kafka_auto_append_error_column = 1
```

The table data is used to save data from kafka.
```
CREATE MATERIALIZED VIEW default.data
(
    `i` Int64,
    `s` String
)
ENGINE = MergeTree
ORDER BY i
SETTINGS index_granularity = 8192 AS
SELECT
    i,
    s
FROM default.tt
WHERE length(_error) = 0
```

The table error is used to save the exception row information.
```
CREATE MATERIALIZED VIEW default.error
(
    `topic` String,
    `partition` Int64,
    `offset` Int64,
    `raw` String,
    `error` String
)
ENGINE = MergeTree
ORDER BY topic
SETTINGS index_granularity = 8192 AS
SELECT
    _topic AS topic,
    _partition AS partition,
    _offset AS offset,
    _raw_message AS raw,
    _error AS error
FROM default.tt
WHERE length(_error) > 0
```

