### PR TITLE
Add example of client configuration adjustments

### DIFF
--- a/programs/client/clickhouse-client.xml
+++ b/programs/client/clickhouse-client.xml
@@ -31,7 +31,7 @@
     </prompt_by_server_display_name>
 
     <!-- 
-        Settings adjustable via command-line parameters (see clickhouse-client --help)
+        Settings adjustable via command-line parameters
         can take their defaults from that config file, see examples:
 
     <host>127.0.0.1</host>

--- a/programs/client/clickhouse-client.xml
+++ b/programs/client/clickhouse-client.xml
@@ -29,4 +29,25 @@
         <test>{display_name} \x01\e[1;32m\x02:)\x01\e[0m\x02 </test> <!-- if it matched to the substring "test" in the server display name - -->
         <production>{display_name} \x01\e[1;31m\x02:)\x01\e[0m\x02 </production> <!-- if it matched to the substring "production" in the server display name -->
     </prompt_by_server_display_name>
+
+    <!-- 
+        Settings adjustable via command-line parameters (see clickhouse-client --help)
+        can take their defaults from that config file, see examples:
+
+    <host>127.0.0.1</host>
+    <port>9440</port>
+    <secure>1</secure>
+    <user>dbuser</user>
+    <password>dbpwd123</password>
+    <format>PrettyCompactMonoBlock</format>
+    <multiline>1</multiline>
+    <multiquery>1</multiquery>
+    <stacktrace>1</stacktrace>
+    <database>default2</database>
+    <pager>less -SR</pager>
+    <history_file>/home/user/clickhouse_custom_history.log</history_file>
+    <max_parser_depth>2500</max_parser_depth>
+
+        The same can be done on user-level configuration, just create & adjust: ~/.clickhouse-client/config.xml
+    -->
 </config>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add example of client configuration adjustments

Detailed description / Documentation draft:

BTW: the fact that parser settings (like max_parser_depth) should be adjusted BOTH on client & server is quite confusing for users. From a usability perspective, it would be better if the client would take parser setting defaults from the server. (minor)