### PR TITLE
Fix 00738_lock_for_inner_table flakiness

### DIFF
--- a/tests/queries/0_stateless/00738_lock_for_inner_table.sh
+++ b/tests/queries/0_stateless/00738_lock_for_inner_table.sh
@@ -5,18 +5,22 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+# there are some issues with Atomic database, let's generate it uniq
+# otherwise flaky check will not pass.
+uuid=$(${CLICKHOUSE_CLIENT} --query "SELECT reinterpretAsUUID(currentDatabase())")
+
 echo "DROP TABLE IF EXISTS tab_00738 SYNC;
 DROP TABLE IF EXISTS mv SYNC;
 -- create table with fsync and 20 partitions for slower INSERT
 -- (since increasing number of records will make it significantly slower in debug build, but not in release)
 CREATE TABLE tab_00738(a Int) ENGINE = MergeTree() ORDER BY a PARTITION BY a%20 SETTINGS fsync_after_insert=1;
-CREATE MATERIALIZED VIEW mv UUID '00000738-1000-4000-8000-000000000001' ENGINE = Log AS SELECT a FROM tab_00738;" | ${CLICKHOUSE_CLIENT} -n
+CREATE MATERIALIZED VIEW mv UUID '$uuid' ENGINE = Log AS SELECT a FROM tab_00738;" | ${CLICKHOUSE_CLIENT} -n
 
 ${CLICKHOUSE_CLIENT} --query_id test_00738 --query "INSERT INTO tab_00738 SELECT number FROM numbers(10000000)" &
 
 function drop()
 {
-    ${CLICKHOUSE_CLIENT} --query "DROP TABLE \`.inner_id.00000738-1000-4000-8000-000000000001\`" -n
+    ${CLICKHOUSE_CLIENT} --query "DROP TABLE \`.inner_id.$uuid\`" -n
 }
 
 function wait_for_query_to_start()

--- a/tests/queries/0_stateless/00738_lock_for_inner_table.sh
+++ b/tests/queries/0_stateless/00738_lock_for_inner_table.sh
@@ -16,7 +16,7 @@ DROP TABLE IF EXISTS mv SYNC;
 CREATE TABLE tab_00738(a Int) ENGINE = MergeTree() ORDER BY a PARTITION BY a%20 SETTINGS fsync_after_insert=1;
 CREATE MATERIALIZED VIEW mv UUID '$uuid' ENGINE = Log AS SELECT a FROM tab_00738;" | ${CLICKHOUSE_CLIENT} -n
 
-${CLICKHOUSE_CLIENT} --query_id test_00738 --query "INSERT INTO tab_00738 SELECT number FROM numbers(10000000)" &
+${CLICKHOUSE_CLIENT} --query_id insert_$CLICKHOUSE_DATABASE --query "INSERT INTO tab_00738 SELECT number FROM numbers(10000000)" &
 
 function drop()
 {
@@ -25,7 +25,7 @@ function drop()
 
 function wait_for_query_to_start()
 {
-    while [[ $(${CLICKHOUSE_CLIENT} --query "SELECT count() FROM system.processes WHERE query_id = 'test_00738'") == 0 ]]; do sleep 0.001; done
+    while [[ $(${CLICKHOUSE_CLIENT} --query "SELECT count() FROM system.processes WHERE query_id = 'insert_$CLICKHOUSE_DATABASE'") == 0 ]]; do sleep 0.001; done
 
     # The query is already started, but there is no guarantee that it locks the underlying table already.
     # Wait until PushingToViewsBlockOutputStream will acquire the lock of the underlying table for the INSERT query.
@@ -33,7 +33,7 @@ function wait_for_query_to_start()
     sleep 0.5
 
     # query already finished, fail
-    if [[ $(${CLICKHOUSE_CLIENT} --query "SELECT count() FROM system.processes WHERE query_id = 'test_00738'") == 0 ]]; then
+    if [[ $(${CLICKHOUSE_CLIENT} --query "SELECT count() FROM system.processes WHERE query_id = 'insert_$CLICKHOUSE_DATABASE'") == 0 ]]; then
         exit 2
     fi
 }

--- a/tests/queries/0_stateless/00738_lock_for_inner_table.sh
+++ b/tests/queries/0_stateless/00738_lock_for_inner_table.sh
@@ -5,9 +5,11 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-echo "DROP TABLE IF EXISTS tab_00738;
-DROP TABLE IF EXISTS mv;
-CREATE TABLE tab_00738(a Int) ENGINE = Log;
+echo "DROP TABLE IF EXISTS tab_00738 SYNC;
+DROP TABLE IF EXISTS mv SYNC;
+-- create table with fsync and 20 partitions for slower INSERT
+-- (since increasing number of records will make it significantly slower in debug build, but not in release)
+CREATE TABLE tab_00738(a Int) ENGINE = MergeTree() ORDER BY a PARTITION BY a%20 SETTINGS fsync_after_insert=1;
 CREATE MATERIALIZED VIEW mv UUID '00000738-1000-4000-8000-000000000001' ENGINE = Log AS SELECT a FROM tab_00738;" | ${CLICKHOUSE_CLIENT} -n
 
 ${CLICKHOUSE_CLIENT} --query_id test_00738 --query "INSERT INTO tab_00738 SELECT number FROM numbers(10000000)" &
@@ -20,6 +22,16 @@ function drop()
 function wait_for_query_to_start()
 {
     while [[ $(${CLICKHOUSE_CLIENT} --query "SELECT count() FROM system.processes WHERE query_id = 'test_00738'") == 0 ]]; do sleep 0.001; done
+
+    # The query is already started, but there is no guarantee that it locks the underlying table already.
+    # Wait until PushingToViewsBlockOutputStream will acquire the lock of the underlying table for the INSERT query.
+    # (assume that 0.5 second is enough for this, but this is not 100% correct)
+    sleep 0.5
+
+    # query already finished, fail
+    if [[ $(${CLICKHOUSE_CLIENT} --query "SELECT count() FROM system.processes WHERE query_id = 'test_00738'") == 0 ]]; then
+        exit 2
+    fi
 }
 
 export -f wait_for_query_to_start


### PR DESCRIPTION
It is possible to execute DROP just before an INSERT will acquire the
lock for the underlying table, and then the test will fail [1]:

    2021-02-09 13:03:27 00738_lock_for_inner_table:                                             [ FAIL ] 3.18 sec. - having stderror:
    2021-02-09 13:03:27 [3eff0fc65d1a] 2021.02.09 13:03:27.440841 [ 220384 ] {test_00738} <Error> executeQuery: Code: 60, e.displayText() = DB::Exception: Table default.`.inner_id.00000738-1000-4000-8000-000000000001` (9647fbaa-a80d-420e-9240-30f5719a84e7) doesn't exist (version 21.3.1.5956) (from [::1]:56964) (comment: '/usr/share/clickhouse-test/queries/0_stateless/01701_if_tuple_segfault.sql') (in query: INSERT INTO tab_00738 SELECT number FROM numbers(10000000)), Stack trace (when copying this message, always include the lines below):
    2021-02-09 13:03:27
    2021-02-09 13:03:27 0. ./obj-x86_64-linux-gnu/../contrib/libcxx/include/exception:133: std::exception::capture() @ 0x10d0a908 in /usr/bin/clickhouse
    2021-02-09 13:03:27 1. ./obj-x86_64-linux-gnu/../contrib/libcxx/include/exception:111: std::exception::exception() @ 0x10d0a8d5 in /usr/bin/clickhouse
    2021-02-09 13:03:27 2. ./obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Exception.cpp:27: Poco::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) @ 0x1e5b4943 in /usr/bin/clickhouse
    2021-02-09 13:03:27 3. ./obj-x86_64-linux-gnu/../src/Common/Exception.cpp:54: DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, bool) @ 0x10cec720 in /usr/bin/clickhouse
    2021-02-09 13:03:27 4. ./obj-x86_64-linux-gnu/../src/Common/Exception.h:38: DB::Exception::Exception<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >(int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&&) @ 0x10e82041 in /usr/bin/clickhouse
    2021-02-09 13:03:27 5. ./obj-x86_64-linux-gnu/../contrib/libcxx/include/optional:324: void std::__1::__optional_storage_base<DB::Exception, false>::__construct<int const&, char const (&) [23], std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >(int const&, char const (&) [23], std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&&) @ 0x19940df9 in /usr/bin/clickhouse
    2021-02-09 13:03:27 6. ./obj-x86_64-linux-gnu/../contrib/libcxx/include/optional:830: DB::Exception& std::__1::optional<DB::Exception>::emplace<int const&, char const (&) [23], std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, void>(int const&, char const (&) [23], std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&&) @ 0x19939b7a in /usr/bin/clickhouse
    2021-02-09 13:03:27 7. ./obj-x86_64-linux-gnu/../src/Interpreters/DatabaseCatalog.cpp:233: DB::DatabaseCatalog::getTableImpl(DB::StorageID const&, DB::Context const&, std::__1::optional<DB::Exception>*) const @ 0x1992efcf in /usr/bin/clickhouse
    2021-02-09 13:03:27 8. ./obj-x86_64-linux-gnu/../src/Interpreters/DatabaseCatalog.cpp:641: DB::DatabaseCatalog::getTable(DB::StorageID const&, DB::Context const&) const @ 0x19932fba in /usr/bin/clickhouse
    2021-02-09 13:03:27 9. ./obj-x86_64-linux-gnu/../src/Storages/StorageMaterializedView.cpp:376: DB::StorageMaterializedView::getTargetTable() const @ 0x1a5fe2bf in /usr/bin/clickhouse
    2021-02-09 13:03:27 10. ./obj-x86_64-linux-gnu/../src/DataStreams/PushingToViewsBlockOutputStream.cpp:88: DB::PushingToViewsBlockOutputStream::PushingToViewsBlockOutputStream(std::__1::shared_ptr<DB::IStorage> const&, std::__1::shared_ptr<DB::StorageInMemoryMetadata const> const&, DB::Context const&, std::__1::shared_ptr<DB::IAST> const&, bool) @ 0x19e26530 in /usr/bin/clickhouse

And if you will take a look at the 88 line, you will see that this is
just a timing issue.

  [1]: https://clickhouse-test-reports.s3.yandex.net/19673/7bddaba9208232f54095712f0cbfa44c6a5e2564/functional_stateless_tests_(antlr_debug).html#fail1

Changelog category (leave one):
- Not for changelog (changelog entry is not required)