### PR TITLE
Fix abnormal server termination when http client goes away

### DIFF
--- a/src/IO/WriteBufferFromHTTPServerResponse.cpp
+++ b/src/IO/WriteBufferFromHTTPServerResponse.cpp
@@ -188,14 +188,14 @@ void WriteBufferFromHTTPServerResponse::onProgress(const Progress & progress)
 
 void WriteBufferFromHTTPServerResponse::finalize()
 {
-    if (offset())
+    next();
+    if (out)
     {
-        next();
-
-        if (out)
-            out.reset();
+        out->next();
+        out.reset();
     }
-    else
+
+    if (!offset())
     {
         /// If no remaining data, just send headers.
         std::lock_guard lock(mutex);

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -774,6 +774,9 @@ void HTTPHandler::handleRequest(Poco::Net::HTTPServerRequest & request, Poco::Ne
 
         trySendExceptionToClient(exception_message, exception_code, request, response, used_output);
     }
+
+    if (used_output.out)
+        used_output.out->finalize();
 }
 
 DynamicQueryHandler::DynamicQueryHandler(IServer & server_, const std::string & param_name_)

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -715,7 +715,6 @@ void HTTPHandler::trySendExceptionToClient(const std::string & s, int exception_
             writeChar('\n', *used_output.out_maybe_compressed);
 
             used_output.out_maybe_compressed->next();
-            used_output.out->next();
             used_output.out->finalize();
         }
     }


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix abnormal server termination when http client goes away

Fixes: #19451 (please add the no-backport label, since it has not bee included into any release yet)

*For details, see commit descriptions*