### PR TITLE
Fix abnormal server terminations due to write failures

### DIFF
--- a/base/daemon/BaseDaemon.cpp
+++ b/base/daemon/BaseDaemon.cpp
@@ -562,6 +562,7 @@ void debugIncreaseOOMScore()
     {
         DB::WriteBufferFromFile buf("/proc/self/oom_score_adj");
         buf.write(new_score.c_str(), new_score.size());
+        buf.close();
     }
     catch (const Poco::Exception & e)
     {

--- a/src/Access/DiskAccessStorage.cpp
+++ b/src/Access/DiskAccessStorage.cpp
@@ -217,6 +217,7 @@ namespace
         /// Write the file.
         WriteBufferFromFile out{tmp_file_path.string()};
         out.write(file_contents.data(), file_contents.size());
+        out.close();
 
         /// Rename.
         std::filesystem::rename(tmp_file_path, file_path);
@@ -274,6 +275,7 @@ namespace
             writeStringBinary(name, out);
             writeUUIDText(id, out);
         }
+        out.close();
     }
 
 

--- a/src/Common/tests/compact_array.cpp
+++ b/src/Common/tests/compact_array.cpp
@@ -50,6 +50,7 @@ struct Test
             {
                 DB::WriteBufferFromFile wb(filename);
                 wb.write(reinterpret_cast<const char *>(&store), sizeof(store));
+                wb.close();
             }
 
             {

--- a/src/IO/WriteBuffer.h
+++ b/src/IO/WriteBuffer.h
@@ -95,8 +95,15 @@ public:
         ++pos;
     }
 
-    virtual void sync() {}
-    virtual void finalize() {}
+    virtual void sync()
+    {
+        next();
+    }
+
+    virtual void finalize()
+    {
+        next();
+    }
 
 private:
     /** Write the data in the buffer (from the beginning of the buffer to the current position).

--- a/utils/convert-month-partitioned-parts/main.cpp
+++ b/utils/convert-month-partitioned-parts/main.cpp
@@ -97,6 +97,7 @@ void run(String part_path, String date_column, String dest_path)
     Poco::File(new_tmp_part_path_str + "checksums.txt").setWriteable();
     WriteBufferFromFile checksums_out(new_tmp_part_path_str + "checksums.txt", 4096);
     checksums.write(checksums_out);
+    checksums.close();
 
     Poco::File(new_tmp_part_path).renameTo(new_part_path.toString());
 }


### PR DESCRIPTION
*Maybe there will be more patches in this PR...*

Changelog category (leave one):
- Not for changelog

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix abnormal server terminations due to write failures

Fixes: #19451 (please add the no-backport label, since it has not bee included into any release yet)