### PR TITLE
RFC: QueryProcess

### DIFF
--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -38,6 +38,7 @@ ThreadStatus::ThreadStatus()
     memory_tracker.setDescription("(for thread)");
     log = &Poco::Logger::get("ThreadStatus");
 
+    assert(!current_thread);
     current_thread = this;
 
     /// NOTE: It is important not to do any non-trivial actions (like updating ProfileEvents or logging) before ThreadStatus is created

--- a/src/DataStreams/BlockIO.h
+++ b/src/DataStreams/BlockIO.h
@@ -1,21 +1,20 @@
 #pragma once
 
 #include <DataStreams/IBlockStream_fwd.h>
-
-#include <functional>
-
 #include <Processors/QueryPipeline.h>
+#include <functional>
+#include <memory>
 
 
 namespace DB
 {
 
-class ProcessListEntry;
+class QueryProcess;
 
 struct BlockIO
 {
-    BlockIO() = default;
-    BlockIO(BlockIO &&) = default;
+    BlockIO();
+    BlockIO(BlockIO &&);
 
     BlockIO & operator= (BlockIO && rhs);
     ~BlockIO();
@@ -23,7 +22,7 @@ struct BlockIO
     BlockIO(const BlockIO &) = delete;
     BlockIO & operator= (const BlockIO & rhs) = delete;
 
-    std::shared_ptr<ProcessListEntry> process_list_entry;
+    std::shared_ptr<QueryProcess> query_process;
 
     BlockOutputStreamPtr out;
     BlockInputStreamPtr in;

--- a/src/Interpreters/QueryProcess.cpp
+++ b/src/Interpreters/QueryProcess.cpp
@@ -1,0 +1,574 @@
+#include <Interpreters/QueryProcess.h>
+#include <Interpreters/OpenTelemetrySpanLog.h>
+#include <DataStreams/CountingBlockOutputStream.h>
+#include <Processors/Formats/IOutputFormat.h>
+#include <Parsers/ASTInsertQuery.h>
+#include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
+#include <Parsers/ASTQueryWithTableAndOutput.h>
+#include <Parsers/queryNormalization.h>
+#include <Parsers/queryToString.h>
+#include <Access/EnabledQuota.h>
+#include <Common/SensitiveDataMasker.h>
+#include <Common/ProfileEvents.h>
+
+namespace ProfileEvents
+{
+    extern const Event QueryMaskingRulesMatch;
+    extern const Event FailedQuery;
+    extern const Event FailedInsertQuery;
+    extern const Event FailedSelectQuery;
+    extern const Event QueryTimeMicroseconds;
+    extern const Event SelectQueryTimeMicroseconds;
+    extern const Event InsertQueryTimeMicroseconds;
+}
+
+namespace
+{
+
+using namespace DB;
+
+String joinLines(const String & query)
+{
+    /// Care should be taken. We don't join lines inside non-whitespace tokens (e.g. multiline string literals)
+    ///  and we don't join line after comment (because it can be single-line comment).
+    /// All other whitespaces replaced to a single whitespace.
+
+    String res;
+    const char * begin = query.data();
+    const char * end = begin + query.size();
+
+    Lexer lexer(begin, end);
+    Token token = lexer.nextToken();
+    for (; !token.isEnd(); token = lexer.nextToken())
+    {
+        if (token.type == TokenType::Whitespace)
+        {
+            res += ' ';
+        }
+        else if (token.type == TokenType::Comment)
+        {
+            res.append(token.begin, token.end);
+            if (token.end < end && *token.end == '\n')
+                res += '\n';
+        }
+        else
+            res.append(token.begin, token.end);
+    }
+
+    return res;
+}
+
+/// Call this inside catch block.
+void setExceptionStackTrace(QueryLogElement & elem)
+{
+    /// Disable memory tracker for stack trace.
+    /// Because if exception is "Memory limit (for query) exceed", then we probably can't allocate another one string.
+    MemoryTracker::BlockerInThread temporarily_disable_memory_tracker(VariableContext::Global);
+
+    try
+    {
+        throw;
+    }
+    catch (const std::exception & e)
+    {
+        elem.stack_trace = getExceptionStackTraceString(e);
+    }
+    catch (...) {}
+}
+
+/// Log exception (with query info) into text log (not into system table).
+void logException(Context & context, QueryLogElement & elem)
+{
+    String comment;
+    if (!elem.log_comment.empty())
+        comment = fmt::format(" (comment: {})", elem.log_comment);
+
+    if (elem.stack_trace.empty())
+        LOG_ERROR(&Poco::Logger::get("executeQuery"), "{} (from {}){} (in query: {})",
+            elem.exception, context.getClientInfo().current_address.toString(), comment, joinLines(elem.query));
+    else
+        LOG_ERROR(&Poco::Logger::get("executeQuery"), "{} (from {}){} (in query: {})"
+            ", Stack trace (when copying this message, always include the lines below):\n\n{}",
+            elem.exception, context.getClientInfo().current_address.toString(), comment, joinLines(elem.query), elem.stack_trace);
+}
+
+inline UInt64 time_in_microseconds(std::chrono::time_point<std::chrono::system_clock> timepoint)
+{
+    return std::chrono::duration_cast<std::chrono::microseconds>(timepoint.time_since_epoch()).count();
+}
+
+inline UInt64 time_in_seconds(std::chrono::time_point<std::chrono::system_clock> timepoint)
+{
+    return std::chrono::duration_cast<std::chrono::seconds>(timepoint.time_since_epoch()).count();
+}
+
+}
+
+namespace DB
+{
+
+QueryProcess::QueryProcess(const ASTPtr & ast_, bool internal_, Context & context_)
+    : QueryProcess(prepareQueryForLogging(queryToString(ast_), context_), ast_, internal_, prepareContext(context_))
+{
+    logQuery(query_for_logging, context, internal);
+}
+QueryProcess::QueryProcess(const String & query_for_logging_, const ASTPtr & ast_, bool internal_, Context & context_)
+    : context(context_)
+    , settings(context.getSettingsRef())
+    , query_for_logging(query_for_logging_)
+    , ast(ast_)
+    , process_list_entry(context.getProcessList().insert(query_for_logging, ast.get(), context))
+    , parent_process_list_element(context.getProcessListElement())
+    , internal(internal_)
+    , log_queries(settings.log_queries && !internal)
+    , current_time(std::chrono::system_clock::now())
+    , query_log_element(makeQueryLogElement())
+{
+    /// FIXME: misses setProcessListElement() for other bits:
+    /// - QueryPipline
+    /// - BlockInputStream
+    /// - CountingBlockOutputStream
+    context.setProcessListElement(&process_list_entry->get());
+
+    /// NOTE: There is no need in ThreadStatus/QueryScope adjustment because:
+    /// - executeQuery() creates separate ThreadStatus/QueryScope by itself.
+    /// - PullingAsyncPipelineExecutor:
+    ///   - ThreadStatus will be created in ThreadFromGlobalPool
+    ///   - QueryScope will be configured properly with CurrentThread::attachTo()
+
+    if (const auto * query_with_table_output = dynamic_cast<const ASTQueryWithTableAndOutput *>(ast.get()))
+    {
+        query_database = query_with_table_output->database;
+        query_table = query_with_table_output->table;
+    }
+}
+
+QueryProcess::~QueryProcess()
+{
+    if (parent_process_list_element)
+        context.setProcessListElement(parent_process_list_element);
+}
+
+void QueryProcess::queryExceptionBeforeStart()
+{
+    onExceptionBeforeStart(query_for_logging, context, current_time, ast);
+}
+
+void QueryProcess::queryStart(bool use_processors, IInterpreter * interpreter)
+{
+    if (!log_queries)
+        return;
+
+    query_log_element.type = QueryLogElementType::QUERY_START;
+
+    // construct event_time and event_time_microseconds using the same time point
+    // so that the two times will always be equal up to a precision of a second.
+    const auto start_time = std::chrono::system_clock::now();
+    query_log_element.event_time = time_in_seconds(start_time);
+    query_log_element.event_time_microseconds = time_in_microseconds(start_time);
+
+    if (use_processors)
+    {
+        const auto & info = context.getQueryAccessInfo();
+        query_log_element.query_databases = info.databases;
+        query_log_element.query_tables = info.tables;
+        query_log_element.query_columns = info.columns;
+    }
+
+    /// FIXME: not full query_log entry (for subqueries)
+    if (interpreter)
+        interpreter->extendQueryLogElem(query_log_element, ast, context, query_database, query_table);
+
+    if (settings.log_query_settings)
+        query_log_element.query_settings = std::make_shared<Settings>(context.getSettingsRef());
+
+    query_log_element.log_comment = settings.log_comment;
+    if (query_log_element.log_comment.size() > settings.max_query_size)
+        query_log_element.log_comment.resize(settings.max_query_size);
+
+    if (query_log_element.type >= settings.log_queries_min_type && !settings.log_queries_min_query_duration_ms.totalMilliseconds())
+    {
+        if (auto query_log = context.getQueryLog())
+            query_log->add(query_log_element);
+    }
+}
+
+void QueryProcess::queryFinish(IBlockInputStream * stream_in, IBlockOutputStream * stream_out, QueryPipeline * query_pipeline)
+{
+    QueryStatus & query_status = queryStatus();
+
+    /// Update performance counters before logging to query_log
+    CurrentThread::finalizePerformanceCounters();
+
+    QueryStatusInfo info = query_status.getInfo(true, context.getSettingsRef().log_profile_events);
+
+    double elapsed_seconds = info.elapsed_seconds;
+
+    query_log_element.type = QueryLogElementType::QUERY_FINISH;
+
+    // construct event_time and event_time_microseconds using the same time point
+    // so that the two times will always be equal up to a precision of a second.
+    const auto finish_time = std::chrono::system_clock::now();
+    query_log_element.event_time = time_in_seconds(finish_time);
+    query_log_element.event_time_microseconds = time_in_microseconds(finish_time);
+    addQueryStatusInfoToQueryLogElement(info, ast);
+
+    auto progress_callback = context.getProgressCallback();
+
+    if (progress_callback)
+        progress_callback(Progress(WriteProgress(info.written_rows, info.written_bytes)));
+
+    if (stream_in)
+    {
+        const BlockStreamProfileInfo & stream_in_info = stream_in->getProfileInfo();
+
+        /// NOTE: INSERT SELECT query contains zero metrics
+        query_log_element.result_rows = stream_in_info.rows;
+        query_log_element.result_bytes = stream_in_info.bytes;
+    }
+    else if (stream_out) /// will be used only for ordinary INSERT queries
+    {
+        if (const auto * counting_stream = dynamic_cast<const CountingBlockOutputStream *>(stream_out))
+        {
+            /// NOTE: Redundancy.
+            /// The same values could be extracted from
+            /// query_status.progress_out.query_settings = query_status.progress_in
+            query_log_element.result_rows = counting_stream->getProgress().read_rows;
+            query_log_element.result_bytes = counting_stream->getProgress().read_bytes;
+        }
+    }
+    else if (query_pipeline)
+    {
+        if (const auto * output_format = query_pipeline->getOutputFormat())
+        {
+            query_log_element.result_rows = output_format->getResultRows();
+            query_log_element.result_bytes = output_format->getResultBytes();
+        }
+    }
+
+    if (query_log_element.read_rows != 0)
+    {
+        LOG_INFO(&Poco::Logger::get("executeQuery"), "Read {} rows, {} in {} sec., {} rows/sec., {}/sec.",
+            query_log_element.read_rows, ReadableSize(query_log_element.read_bytes), elapsed_seconds,
+            static_cast<size_t>(query_log_element.read_rows / elapsed_seconds),
+            ReadableSize(query_log_element.read_bytes / elapsed_seconds));
+    }
+
+    query_log_element.thread_ids = std::move(info.thread_ids);
+    query_log_element.profile_counters = std::move(info.profile_counters);
+
+    const auto & factories_info = context.getQueryFactoriesInfo();
+    query_log_element.used_aggregate_functions = factories_info.aggregate_functions;
+    query_log_element.used_aggregate_function_combinators = factories_info.aggregate_function_combinators;
+    query_log_element.used_database_engines = factories_info.database_engines;
+    query_log_element.used_data_type_families = factories_info.data_type_families;
+    query_log_element.used_dictionaries = factories_info.dictionaries;
+    query_log_element.used_formats = factories_info.formats;
+    query_log_element.used_functions = factories_info.functions;
+    query_log_element.used_storages = factories_info.storages;
+    query_log_element.used_table_functions = factories_info.table_functions;
+
+    const auto log_queries_min_query_duration_ms = settings.log_queries_min_query_duration_ms.totalMilliseconds();
+    if (log_queries && query_log_element.type >= settings.log_queries_min_type && Int64(query_log_element.query_duration_ms) >= log_queries_min_query_duration_ms)
+    {
+        if (auto query_log = context.getQueryLog())
+            query_log->add(query_log_element);
+    }
+
+    if (auto opentelemetry_span_log = context.getOpenTelemetrySpanLog();
+        context.query_trace_context.trace_id
+            && opentelemetry_span_log)
+    {
+        OpenTelemetrySpanLogElement span;
+        span.trace_id = context.query_trace_context.trace_id;
+        span.span_id = context.query_trace_context.span_id;
+        span.parent_span_id = context.getClientInfo().client_trace_context.span_id;
+        span.operation_name = "query";
+        span.start_time_us = query_log_element.query_start_time_microseconds;
+        span.finish_time_us = time_in_microseconds(finish_time);
+
+        /// Keep values synchronized to type enum in QueryLogElement::createBlock.
+        span.attribute_names.push_back("clickhouse.query_status");
+        span.attribute_values.push_back("QueryFinish");
+
+        span.attribute_names.push_back("db.statement");
+        span.attribute_values.push_back(query_log_element.query);
+
+        span.attribute_names.push_back("clickhouse.query_id");
+        span.attribute_values.push_back(query_log_element.client_info.current_query_id);
+        if (!context.query_trace_context.tracestate.empty())
+        {
+            span.attribute_names.push_back("clickhouse.tracestate");
+            span.attribute_values.push_back(
+                context.query_trace_context.tracestate);
+        }
+
+        opentelemetry_span_log->add(span);
+    }
+}
+
+void QueryProcess::queryException()
+{
+    if (auto quota = context.getQuota())
+        quota->used(Quota::ERRORS, 1, /* check_exceeded = */ false);
+
+    query_log_element.type = QueryLogElementType::EXCEPTION_WHILE_PROCESSING;
+
+    // event_time and event_time_microseconds are being constructed from the same time point
+    // to ensure that both the times will be equal up to the precision of a second.
+    const auto time_now = std::chrono::system_clock::now();
+
+    query_log_element.event_time = time_in_seconds(time_now);
+    query_log_element.event_time_microseconds = time_in_microseconds(time_now);
+    query_log_element.query_duration_ms = 1000 * (query_log_element.event_time - query_log_element.query_start_time);
+    query_log_element.exception_code = getCurrentExceptionCode();
+    query_log_element.exception = getCurrentExceptionMessage(false);
+
+    QueryStatus * process_list_query_log_element = context.getProcessListElement();
+    const Settings & current_settings = context.getSettingsRef();
+
+    /// Update performance counters before logging to query_log
+    CurrentThread::finalizePerformanceCounters();
+
+    if (process_list_query_log_element)
+    {
+        QueryStatusInfo info = process_list_query_log_element->getInfo(true, current_settings.log_profile_events, false);
+        addQueryStatusInfoToQueryLogElement(info, ast);
+    }
+
+    if (current_settings.calculate_text_stack_trace)
+        setExceptionStackTrace(query_log_element);
+    logException(context, query_log_element);
+
+    const auto log_queries_min_query_duration_ms = settings.log_queries_min_query_duration_ms.totalMilliseconds();
+    /// In case of exception we log internal queries also
+    if (log_queries && query_log_element.type >= settings.log_queries_min_type && Int64(query_log_element.query_duration_ms) >= log_queries_min_query_duration_ms)
+    {
+        if (auto query_log = context.getQueryLog())
+            query_log->add(query_log_element);
+    }
+
+    ProfileEvents::increment(ProfileEvents::FailedQuery);
+    if (ast->as<ASTSelectQuery>() || ast->as<ASTSelectWithUnionQuery>())
+    {
+        ProfileEvents::increment(ProfileEvents::FailedSelectQuery);
+    }
+    else if (ast->as<ASTInsertQuery>())
+    {
+        ProfileEvents::increment(ProfileEvents::FailedInsertQuery);
+    }
+}
+
+void QueryProcess::addQueryStatusInfoToQueryLogElement(const QueryStatusInfo &info, const ASTPtr query_ast)
+{
+    DB::UInt64 query_time = info.elapsed_seconds * 1000000;
+    ProfileEvents::increment(ProfileEvents::QueryTimeMicroseconds, query_time);
+    if (query_ast->as<ASTSelectQuery>() || query_ast->as<ASTSelectWithUnionQuery>())
+    {
+        ProfileEvents::increment(ProfileEvents::SelectQueryTimeMicroseconds, query_time);
+    }
+    else if (query_ast->as<ASTInsertQuery>())
+    {
+        ProfileEvents::increment(ProfileEvents::InsertQueryTimeMicroseconds, query_time);
+    }
+
+    query_log_element.query_duration_ms = info.elapsed_seconds * 1000;
+
+    query_log_element.read_rows = info.read_rows;
+    query_log_element.read_bytes = info.read_bytes;
+
+    query_log_element.written_rows = info.written_rows;
+    query_log_element.written_bytes = info.written_bytes;
+
+    query_log_element.memory_usage = info.peak_memory_usage > 0 ? info.peak_memory_usage : 0;
+
+    query_log_element.thread_ids = std::move(info.thread_ids);
+    query_log_element.profile_counters = std::move(info.profile_counters);
+}
+
+QueryLogElement QueryProcess::makeQueryLogElement()
+{
+    QueryLogElement elem;
+
+    elem.event_time = time_in_seconds(current_time);
+    elem.event_time_microseconds = time_in_microseconds(current_time);
+    elem.query_start_time = time_in_seconds(current_time);
+    elem.query_start_time_microseconds = time_in_microseconds(current_time);
+
+    elem.current_database = context.getCurrentDatabase();
+    elem.query = query_for_logging;
+    elem.normalized_query_hash = normalizedQueryHash<false>(query_for_logging);
+
+    elem.client_info = context.getClientInfo();
+
+    return elem;
+}
+
+/// Prepares query for logging:
+/// - wipe sensitive data
+/// - trim to log_queries_cut_to_length
+String QueryProcess::prepareQueryForLogging(const String & query, const Context & context)
+{
+    String res = query;
+
+    // wiping sensitive data before cropping query by log_queries_cut_to_length,
+    // otherwise something like credit card without last digit can go to log
+    if (auto * masker = SensitiveDataMasker::getInstance())
+    {
+        auto matches = masker->wipeSensitiveData(res);
+        if (matches > 0)
+        {
+            ProfileEvents::increment(ProfileEvents::QueryMaskingRulesMatch, matches);
+        }
+    }
+
+    res = res.substr(0, context.getSettingsRef().log_queries_cut_to_length);
+
+    return res;
+}
+
+void QueryProcess::logQuery(const String & query_for_logging, const Context & context, bool internal)
+{
+    if (internal)
+    {
+        LOG_DEBUG(&Poco::Logger::get("executeQuery"), "(internal) {}", joinLines(query_for_logging));
+    }
+    else
+    {
+        const auto & client_info = context.getClientInfo();
+
+        const auto & current_query_id = client_info.current_query_id;
+        const auto & initial_query_id = client_info.initial_query_id;
+        const auto & current_user = client_info.current_user;
+
+        String comment = context.getSettingsRef().log_comment;
+        size_t max_query_size = context.getSettingsRef().max_query_size;
+
+        if (comment.size() > max_query_size)
+            comment.resize(max_query_size);
+
+        if (!comment.empty())
+            comment = fmt::format(" (comment: {})", comment);
+
+        LOG_DEBUG(&Poco::Logger::get("executeQuery"), "(from {}{}{}, using {} parser){} {}",
+            client_info.current_address.toString(),
+            (current_user != "default" ? ", user: " + current_user : ""),
+            (!initial_query_id.empty() && current_query_id != initial_query_id ? ", initial_query_id: " + initial_query_id : std::string()),
+            (context.getSettingsRef().use_antlr_parser ? "experimental" : "production"),
+            comment,
+            joinLines(query_for_logging));
+
+        if (client_info.client_trace_context.trace_id)
+        {
+            LOG_TRACE(&Poco::Logger::get("executeQuery"),
+                "OpenTelemetry traceparent '{}'",
+                client_info.client_trace_context.composeTraceparentHeader());
+        }
+    }
+}
+
+void QueryProcess::onExceptionBeforeStart(const String & query_for_logging, Context & context,
+    const std::chrono::time_point<std::chrono::system_clock> & current_time, const ASTPtr & ast)
+{
+    /// Exception before the query execution.
+    if (auto quota = context.getQuota())
+        quota->used(Quota::ERRORS, 1, /* check_exceeded = */ false);
+
+    const Settings & settings = context.getSettingsRef();
+
+    /// Log the start of query execution into the table if necessary.
+    QueryLogElement elem;
+
+    elem.type = QueryLogElementType::EXCEPTION_BEFORE_START;
+
+    // all callers to onExceptionBeforeStart method construct the timespec for event_time and
+    // event_time_microseconds from the same time point. So, it can be assumed that both of these
+    // times are equal up to the precision of a second.
+    UInt64 current_time_us = time_in_microseconds(current_time);
+    elem.event_time = current_time_us / 1000000;
+    elem.event_time_microseconds = current_time_us;
+    elem.query_start_time = current_time_us / 1000000;
+    elem.query_start_time_microseconds = current_time_us;
+
+    elem.current_database = context.getCurrentDatabase();
+    elem.query = query_for_logging;
+    elem.normalized_query_hash = normalizedQueryHash<false>(query_for_logging);
+
+    // We don't calculate query_kind, databases, tables and columns when the query isn't able to start
+
+    elem.exception_code = getCurrentExceptionCode();
+    elem.exception = getCurrentExceptionMessage(false);
+
+    elem.client_info = context.getClientInfo();
+
+    elem.log_comment = settings.log_comment;
+    if (elem.log_comment.size() > settings.max_query_size)
+        elem.log_comment.resize(settings.max_query_size);
+
+    if (settings.calculate_text_stack_trace)
+        setExceptionStackTrace(elem);
+    logException(context, elem);
+
+    /// Update performance counters before logging to query_log
+    CurrentThread::finalizePerformanceCounters();
+
+    if (settings.log_queries && elem.type >= settings.log_queries_min_type && !settings.log_queries_min_query_duration_ms.totalMilliseconds())
+        if (auto query_log = context.getQueryLog())
+            query_log->add(elem);
+
+    if (auto opentelemetry_span_log = context.getOpenTelemetrySpanLog();
+        context.query_trace_context.trace_id
+            && opentelemetry_span_log)
+    {
+        OpenTelemetrySpanLogElement span;
+        span.trace_id = context.query_trace_context.trace_id;
+        span.span_id = context.query_trace_context.span_id;
+        span.parent_span_id = context.getClientInfo().client_trace_context.span_id;
+        span.operation_name = "query";
+        span.start_time_us = current_time_us;
+        span.finish_time_us = current_time_us;
+
+        /// Keep values synchronized to type enum in QueryLogElement::createBlock.
+        span.attribute_names.push_back("clickhouse.query_status");
+        span.attribute_values.push_back("ExceptionBeforeStart");
+
+        span.attribute_names.push_back("db.statement");
+        span.attribute_values.push_back(elem.query);
+
+        span.attribute_names.push_back("clickhouse.query_id");
+        span.attribute_values.push_back(elem.client_info.current_query_id);
+
+        if (!context.query_trace_context.tracestate.empty())
+        {
+            span.attribute_names.push_back("clickhouse.tracestate");
+            span.attribute_values.push_back(
+                context.query_trace_context.tracestate);
+        }
+
+        opentelemetry_span_log->add(span);
+    }
+
+    ProfileEvents::increment(ProfileEvents::FailedQuery);
+
+    if (ast)
+    {
+        if (ast->as<ASTSelectQuery>() || ast->as<ASTSelectWithUnionQuery>())
+        {
+            ProfileEvents::increment(ProfileEvents::FailedSelectQuery);
+        }
+        else if (ast->as<ASTInsertQuery>())
+        {
+            ProfileEvents::increment(ProfileEvents::FailedInsertQuery);
+        }
+    }
+}
+
+Context & QueryProcess::prepareContext(Context & context)
+{
+    /// Generate new random query_id.
+    context.setCurrentQueryId("");
+    return context;
+}
+
+}

--- a/src/Interpreters/QueryProcess.h
+++ b/src/Interpreters/QueryProcess.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <Interpreters/ProcessList.h>
+#include <Interpreters/QueryLog.h>
+
+namespace DB
+{
+
+struct Settings;
+class Context;
+class IInterpreter;
+
+/// Everything related to:
+/// - query logging into log
+/// - query logging into query_log/query_thread_log
+/// - query process (system.processes)
+class QueryProcess
+{
+public:
+    QueryProcess(const String & query_for_logging_, const ASTPtr & ast_, bool internal_, Context & context_);
+    QueryProcess(const ASTPtr & ast_, bool internal_, Context & context_);
+    ~QueryProcess();
+
+    QueryStatus & queryStatus() { return process_list_entry->get(); }
+
+    CurrentThread::QueryScope & queryScope() { return *query_scope; }
+
+    void queryExceptionBeforeStart();
+
+    /// Log into system table start of query execution, if need.
+    void queryStart(bool use_processors = true, IInterpreter * interpreter = nullptr);
+
+    /// Also make possible for caller to log successful query finish and exception during execution.
+    void queryFinish(IBlockInputStream * stream_in, IBlockOutputStream * stream_out, QueryPipeline * query_pipeline);
+    void queryException();
+
+    /// Common code for finish and exception callbacks
+    void addQueryStatusInfoToQueryLogElement(const QueryStatusInfo &info, const ASTPtr query_ast);
+
+    ///
+    /// Static interface
+    ///
+
+    /// Log query into text log (not into system table).
+    static void logQuery(const String & query_for_logging, const Context & context, bool internal);
+    static void onExceptionBeforeStart(const String & query_for_logging, Context & context,
+        const std::chrono::time_point<std::chrono::system_clock> & current_time, const ASTPtr & ast);
+
+    /// Prepares query for logging:
+    /// - wipe sensitive data
+    /// - trim to log_queries_cut_to_length
+    static String prepareQueryForLogging(const String & query, const Context & context);
+
+private:
+    Context & context;
+    const Settings & settings;
+    String query_for_logging;
+    const ASTPtr ast;
+    ProcessList::EntryPtr process_list_entry;
+    QueryStatus * parent_process_list_element;
+    bool internal;
+    bool log_queries;
+    std::chrono::time_point<std::chrono::system_clock> current_time;
+    QueryLogElement query_log_element;
+
+    String query_database;
+    String query_table;
+
+    std::unique_ptr<CurrentThread::QueryScope> query_scope;
+
+    QueryLogElement makeQueryLogElement();
+
+    static Context & prepareContext(Context & context);
+};
+
+}

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -33,8 +33,6 @@
 
 #include <Parsers/parseQuery.h>
 #include <Parsers/ParserQuery.h>
-#include <Parsers/queryNormalization.h>
-#include <Parsers/queryToString.h>
 
 #include <Storages/StorageInput.h>
 
@@ -48,26 +46,13 @@
 #include <Interpreters/ReplaceQueryParameterVisitor.h>
 #include <Interpreters/SelectQueryOptions.h>
 #include <Interpreters/executeQuery.h>
+#include <Interpreters/QueryProcess.h>
 #include <Interpreters/Context.h>
-#include <Common/ProfileEvents.h>
-
-#include <Common/SensitiveDataMasker.h>
 
 #include <Processors/Transforms/LimitsCheckingTransform.h>
 #include <Processors/Transforms/MaterializingTransform.h>
 #include <Processors/Formats/IOutputFormat.h>
 
-
-namespace ProfileEvents
-{
-    extern const Event QueryMaskingRulesMatch;
-    extern const Event FailedQuery;
-    extern const Event FailedInsertQuery;
-    extern const Event FailedSelectQuery;
-    extern const Event QueryTimeMicroseconds;
-    extern const Event SelectQueryTimeMicroseconds;
-    extern const Event InsertQueryTimeMicroseconds;
-}
 
 namespace DB
 {
@@ -88,241 +73,6 @@ static void checkASTSizeLimits(const IAST & ast, const Settings & settings)
 }
 
 
-static String joinLines(const String & query)
-{
-    /// Care should be taken. We don't join lines inside non-whitespace tokens (e.g. multiline string literals)
-    ///  and we don't join line after comment (because it can be single-line comment).
-    /// All other whitespaces replaced to a single whitespace.
-
-    String res;
-    const char * begin = query.data();
-    const char * end = begin + query.size();
-
-    Lexer lexer(begin, end);
-    Token token = lexer.nextToken();
-    for (; !token.isEnd(); token = lexer.nextToken())
-    {
-        if (token.type == TokenType::Whitespace)
-        {
-            res += ' ';
-        }
-        else if (token.type == TokenType::Comment)
-        {
-            res.append(token.begin, token.end);
-            if (token.end < end && *token.end == '\n')
-                res += '\n';
-        }
-        else
-            res.append(token.begin, token.end);
-    }
-
-    return res;
-}
-
-
-static String prepareQueryForLogging(const String & query, Context & context)
-{
-    String res = query;
-
-    // wiping sensitive data before cropping query by log_queries_cut_to_length,
-    // otherwise something like credit card without last digit can go to log
-    if (auto * masker = SensitiveDataMasker::getInstance())
-    {
-        auto matches = masker->wipeSensitiveData(res);
-        if (matches > 0)
-        {
-            ProfileEvents::increment(ProfileEvents::QueryMaskingRulesMatch, matches);
-        }
-    }
-
-    res = res.substr(0, context.getSettingsRef().log_queries_cut_to_length);
-
-    return res;
-}
-
-
-/// Log query into text log (not into system table).
-static void logQuery(const String & query, const Context & context, bool internal)
-{
-    if (internal)
-    {
-        LOG_DEBUG(&Poco::Logger::get("executeQuery"), "(internal) {}", joinLines(query));
-    }
-    else
-    {
-        const auto & client_info = context.getClientInfo();
-
-        const auto & current_query_id = client_info.current_query_id;
-        const auto & initial_query_id = client_info.initial_query_id;
-        const auto & current_user = client_info.current_user;
-
-        String comment = context.getSettingsRef().log_comment;
-        size_t max_query_size = context.getSettingsRef().max_query_size;
-
-        if (comment.size() > max_query_size)
-            comment.resize(max_query_size);
-
-        if (!comment.empty())
-            comment = fmt::format(" (comment: {})", comment);
-
-        LOG_DEBUG(&Poco::Logger::get("executeQuery"), "(from {}{}{}, using {} parser){} {}",
-            client_info.current_address.toString(),
-            (current_user != "default" ? ", user: " + current_user : ""),
-            (!initial_query_id.empty() && current_query_id != initial_query_id ? ", initial_query_id: " + initial_query_id : std::string()),
-            (context.getSettingsRef().use_antlr_parser ? "experimental" : "production"),
-            comment,
-            joinLines(query));
-
-        if (client_info.client_trace_context.trace_id)
-        {
-            LOG_TRACE(&Poco::Logger::get("executeQuery"),
-                "OpenTelemetry traceparent '{}'",
-                client_info.client_trace_context.composeTraceparentHeader());
-        }
-    }
-}
-
-
-/// Call this inside catch block.
-static void setExceptionStackTrace(QueryLogElement & elem)
-{
-    /// Disable memory tracker for stack trace.
-    /// Because if exception is "Memory limit (for query) exceed", then we probably can't allocate another one string.
-    MemoryTracker::BlockerInThread temporarily_disable_memory_tracker(VariableContext::Global);
-
-    try
-    {
-        throw;
-    }
-    catch (const std::exception & e)
-    {
-        elem.stack_trace = getExceptionStackTraceString(e);
-    }
-    catch (...) {}
-}
-
-
-/// Log exception (with query info) into text log (not into system table).
-static void logException(Context & context, QueryLogElement & elem)
-{
-    String comment;
-    if (!elem.log_comment.empty())
-        comment = fmt::format(" (comment: {})", elem.log_comment);
-
-    if (elem.stack_trace.empty())
-        LOG_ERROR(&Poco::Logger::get("executeQuery"), "{} (from {}){} (in query: {})",
-            elem.exception, context.getClientInfo().current_address.toString(), comment, joinLines(elem.query));
-    else
-        LOG_ERROR(&Poco::Logger::get("executeQuery"), "{} (from {}){} (in query: {})"
-            ", Stack trace (when copying this message, always include the lines below):\n\n{}",
-            elem.exception, context.getClientInfo().current_address.toString(), comment, joinLines(elem.query), elem.stack_trace);
-}
-
-inline UInt64 time_in_microseconds(std::chrono::time_point<std::chrono::system_clock> timepoint)
-{
-    return std::chrono::duration_cast<std::chrono::microseconds>(timepoint.time_since_epoch()).count();
-}
-
-
-inline UInt64 time_in_seconds(std::chrono::time_point<std::chrono::system_clock> timepoint)
-{
-    return std::chrono::duration_cast<std::chrono::seconds>(timepoint.time_since_epoch()).count();
-}
-
-static void onExceptionBeforeStart(const String & query_for_logging, Context & context, UInt64 current_time_us, ASTPtr ast)
-{
-    /// Exception before the query execution.
-    if (auto quota = context.getQuota())
-        quota->used(Quota::ERRORS, 1, /* check_exceeded = */ false);
-
-    const Settings & settings = context.getSettingsRef();
-
-    /// Log the start of query execution into the table if necessary.
-    QueryLogElement elem;
-
-    elem.type = QueryLogElementType::EXCEPTION_BEFORE_START;
-
-    // all callers to onExceptionBeforeStart method construct the timespec for event_time and
-    // event_time_microseconds from the same time point. So, it can be assumed that both of these
-    // times are equal up to the precision of a second.
-    elem.event_time = current_time_us / 1000000;
-    elem.event_time_microseconds = current_time_us;
-    elem.query_start_time = current_time_us / 1000000;
-    elem.query_start_time_microseconds = current_time_us;
-
-    elem.current_database = context.getCurrentDatabase();
-    elem.query = query_for_logging;
-    elem.normalized_query_hash = normalizedQueryHash<false>(query_for_logging);
-
-    // We don't calculate query_kind, databases, tables and columns when the query isn't able to start
-
-    elem.exception_code = getCurrentExceptionCode();
-    elem.exception = getCurrentExceptionMessage(false);
-
-    elem.client_info = context.getClientInfo();
-
-    elem.log_comment = settings.log_comment;
-    if (elem.log_comment.size() > settings.max_query_size)
-        elem.log_comment.resize(settings.max_query_size);
-
-    if (settings.calculate_text_stack_trace)
-        setExceptionStackTrace(elem);
-    logException(context, elem);
-
-    /// Update performance counters before logging to query_log
-    CurrentThread::finalizePerformanceCounters();
-
-    if (settings.log_queries && elem.type >= settings.log_queries_min_type && !settings.log_queries_min_query_duration_ms.totalMilliseconds())
-        if (auto query_log = context.getQueryLog())
-            query_log->add(elem);
-
-    if (auto opentelemetry_span_log = context.getOpenTelemetrySpanLog();
-        context.query_trace_context.trace_id
-            && opentelemetry_span_log)
-    {
-        OpenTelemetrySpanLogElement span;
-        span.trace_id = context.query_trace_context.trace_id;
-        span.span_id = context.query_trace_context.span_id;
-        span.parent_span_id = context.getClientInfo().client_trace_context.span_id;
-        span.operation_name = "query";
-        span.start_time_us = current_time_us;
-        span.finish_time_us = current_time_us;
-
-        /// Keep values synchronized to type enum in QueryLogElement::createBlock.
-        span.attribute_names.push_back("clickhouse.query_status");
-        span.attribute_values.push_back("ExceptionBeforeStart");
-
-        span.attribute_names.push_back("db.statement");
-        span.attribute_values.push_back(elem.query);
-
-        span.attribute_names.push_back("clickhouse.query_id");
-        span.attribute_values.push_back(elem.client_info.current_query_id);
-
-        if (!context.query_trace_context.tracestate.empty())
-        {
-            span.attribute_names.push_back("clickhouse.tracestate");
-            span.attribute_values.push_back(
-                context.query_trace_context.tracestate);
-        }
-
-        opentelemetry_span_log->add(span);
-    }
-
-    ProfileEvents::increment(ProfileEvents::FailedQuery);
-
-    if (ast)
-    {
-        if (ast->as<ASTSelectQuery>() || ast->as<ASTSelectWithUnionQuery>())
-        {
-            ProfileEvents::increment(ProfileEvents::FailedSelectQuery);
-        }
-        else if (ast->as<ASTInsertQuery>())
-        {
-            ProfileEvents::increment(ProfileEvents::FailedInsertQuery);
-        }
-    }
-}
-
 static void setQuerySpecificSettings(ASTPtr & ast, Context & context)
 {
     if (auto * ast_insert_into = dynamic_cast<ASTInsertQuery *>(ast.get()))
@@ -341,8 +91,6 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
     bool has_query_tail,
     ReadBuffer * istr)
 {
-    const auto current_time = std::chrono::system_clock::now();
-
 #if !defined(ARCADIA_BUILD)
     assert(internal || CurrentThread::get().getQueryContext());
     assert(internal || CurrentThread::get().getQueryContext()->getCurrentQueryId() == CurrentThread::getQueryId());
@@ -357,8 +105,6 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
     size_t max_query_size = 0;
     if (!internal) max_query_size = settings.max_query_size;
 
-    String query_database;
-    String query_table;
     try
     {
 #if !defined(ARCADIA_BUILD)
@@ -407,12 +153,6 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
                 InterpreterSetQuery(query_with_output->settings_ast, context).executeForCurrentContext();
         }
 
-        if (const auto * query_with_table_output = dynamic_cast<const ASTQueryWithTableAndOutput *>(ast.get()))
-        {
-            query_database = query_with_table_output->database;
-            query_table = query_with_table_output->table;
-        }
-
         auto * insert_query = ast->as<ASTInsertQuery>();
 
         if (insert_query && insert_query->settings_ast)
@@ -433,12 +173,12 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
         /// Anyway log the query.
         String query = String(begin, begin + std::min(end - begin, static_cast<ptrdiff_t>(max_query_size)));
 
-        auto query_for_logging = prepareQueryForLogging(query, context);
-        logQuery(query_for_logging, context, internal);
+        auto query_for_logging = QueryProcess::prepareQueryForLogging(query, context);
+        QueryProcess::logQuery(query_for_logging, context, internal);
 
         if (!internal)
         {
-            onExceptionBeforeStart(query_for_logging, context, time_in_microseconds(current_time), ast);
+            QueryProcess::onExceptionBeforeStart(query_for_logging, context, std::chrono::system_clock::now(), ast);
         }
 
         throw;
@@ -450,7 +190,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
     String query(begin, query_end);
     BlockIO res;
 
-    String query_for_logging;
+    std::shared_ptr<QueryProcess> query_process;
 
     try
     {
@@ -465,8 +205,8 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
         /// MUST goes before any modification (except for prepared statements,
         /// since it substitute parameters and w/o them query does not contains
         /// parameters), to keep query as-is in query_log and server log.
-        query_for_logging = prepareQueryForLogging(query, context);
-        logQuery(query_for_logging, context, internal);
+        String query_for_logging = QueryProcess::prepareQueryForLogging(query, context);
+        QueryProcess::logQuery(query_for_logging, context, internal);
 
         /// Propagate WITH statement to children ASTSelect.
         if (settings.enable_global_with_statement)
@@ -479,12 +219,9 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
         checkASTSizeLimits(*ast, settings);
 
         /// Put query to process list. But don't put SHOW PROCESSLIST query itself.
-        ProcessList::EntryPtr process_list_entry;
         if (!internal && !ast->as<ASTShowProcesslistQuery>())
         {
-            /// processlist also has query masked now, to avoid secrets leaks though SHOW PROCESSLIST by other users.
-            process_list_entry = context.getProcessList().insert(query_for_logging, ast.get(), context);
-            context.setProcessListElement(&process_list_entry->get());
+            query_process = std::make_shared<QueryProcess>(query_for_logging, ast, internal, context);
         }
 
         /// Load external tables if they were provided
@@ -542,8 +279,11 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
         }
 
         {
+            /// FIXME: does not supported by the QueryProcess
             OpenTelemetrySpanHolder span("IInterpreter::execute()");
             res = interpreter->execute();
+            /// FIXME: due to trickery in BlockIO::reset() we cannot set res.query_process before execute()
+            res.query_process = std::move(query_process);
         }
 
         QueryPipeline & pipeline = res.pipeline;
@@ -557,18 +297,21 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
                 context.setInsertionTable(std::move(table_id));
         }
 
-        if (process_list_entry)
+        if (res.query_process)
         {
+            auto & query_status = res.query_process->queryStatus();
             /// Query was killed before execution
-            if ((*process_list_entry)->isKilled())
-                throw Exception("Query '" + (*process_list_entry)->getInfo().client_info.current_query_id + "' is killed in pending state",
-                    ErrorCodes::QUERY_WAS_CANCELLED);
+            if (query_status.isKilled())
+            {
+                throw Exception(ErrorCodes::QUERY_WAS_CANCELLED,
+                    "Query '{}' is killed in pending state",
+                    query_status.getInfo().client_info.current_query_id);
+            }
             else if (!use_processors)
-                (*process_list_entry)->setQueryStreams(res);
+            {
+                query_status.setQueryStreams(res);
+            }
         }
-
-        /// Hold element of process list till end of query execution.
-        res.process_list_entry = process_list_entry;
 
         if (use_processors)
         {
@@ -614,276 +357,40 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
         }
 
         /// Everything related to query log.
+        if (res.query_process)
         {
-            QueryLogElement elem;
+            res.query_process->queryStart(use_processors, interpreter.get());
 
-            elem.type = QueryLogElementType::QUERY_START;
-
-            elem.event_time = time_in_seconds(current_time);
-            elem.event_time_microseconds = time_in_microseconds(current_time);
-            elem.query_start_time = time_in_seconds(current_time);
-            elem.query_start_time_microseconds = time_in_microseconds(current_time);
-
-            elem.current_database = context.getCurrentDatabase();
-            elem.query = query_for_logging;
-            elem.normalized_query_hash = normalizedQueryHash<false>(query_for_logging);
-
-            elem.client_info = context.getClientInfo();
-
-            bool log_queries = settings.log_queries && !internal;
-
-            /// Log into system table start of query execution, if need.
-            if (log_queries)
+            /// NOTE: you cannot use res in lambda, since it will be moved.
+            auto finish_callback = [query_process = res.query_process](IBlockInputStream * stream_in, IBlockOutputStream * stream_out, QueryPipeline * query_pipeline)
             {
-                if (use_processors)
-                {
-                    const auto & info = context.getQueryAccessInfo();
-                    elem.query_databases = info.databases;
-                    elem.query_tables = info.tables;
-                    elem.query_columns = info.columns;
-                }
-
-                interpreter->extendQueryLogElem(elem, ast, context, query_database, query_table);
-
-                if (settings.log_query_settings)
-                    elem.query_settings = std::make_shared<Settings>(context.getSettingsRef());
-
-                elem.log_comment = settings.log_comment;
-                if (elem.log_comment.size() > settings.max_query_size)
-                    elem.log_comment.resize(settings.max_query_size);
-
-                if (elem.type >= settings.log_queries_min_type && !settings.log_queries_min_query_duration_ms.totalMilliseconds())
-                {
-                    if (auto query_log = context.getQueryLog())
-                        query_log->add(elem);
-                }
-            }
-
-            /// Common code for finish and exception callbacks
-            auto status_info_to_query_log = [](QueryLogElement &element, const QueryStatusInfo &info, const ASTPtr query_ast) mutable
-            {
-                DB::UInt64 query_time = info.elapsed_seconds * 1000000;
-                ProfileEvents::increment(ProfileEvents::QueryTimeMicroseconds, query_time);
-                if (query_ast->as<ASTSelectQuery>() || query_ast->as<ASTSelectWithUnionQuery>())
-                {
-                    ProfileEvents::increment(ProfileEvents::SelectQueryTimeMicroseconds, query_time);
-                }
-                else if (query_ast->as<ASTInsertQuery>())
-                {
-                    ProfileEvents::increment(ProfileEvents::InsertQueryTimeMicroseconds, query_time);
-                }
-
-                element.query_duration_ms = info.elapsed_seconds * 1000;
-
-                element.read_rows = info.read_rows;
-                element.read_bytes = info.read_bytes;
-
-                element.written_rows = info.written_rows;
-                element.written_bytes = info.written_bytes;
-
-                element.memory_usage = info.peak_memory_usage > 0 ? info.peak_memory_usage : 0;
-
-                element.thread_ids = std::move(info.thread_ids);
-                element.profile_counters = std::move(info.profile_counters);
+                query_process->queryFinish(stream_in, stream_out, query_pipeline);
             };
-
-            /// Also make possible for caller to log successful query finish and exception during execution.
-            auto finish_callback = [elem, &context, ast,
-                 log_queries,
-                 log_queries_min_type = settings.log_queries_min_type,
-                 log_queries_min_query_duration_ms = settings.log_queries_min_query_duration_ms.totalMilliseconds(),
-                 status_info_to_query_log
-            ]
-                (IBlockInputStream * stream_in, IBlockOutputStream * stream_out, QueryPipeline * query_pipeline) mutable
+            auto exception_callback = [query_process = res.query_process]()
             {
-                QueryStatus * process_list_elem = context.getProcessListElement();
-
-                if (!process_list_elem)
-                    return;
-
-                /// Update performance counters before logging to query_log
-                CurrentThread::finalizePerformanceCounters();
-
-                QueryStatusInfo info = process_list_elem->getInfo(true, context.getSettingsRef().log_profile_events);
-
-                double elapsed_seconds = info.elapsed_seconds;
-
-                elem.type = QueryLogElementType::QUERY_FINISH;
-
-                // construct event_time and event_time_microseconds using the same time point
-                // so that the two times will always be equal up to a precision of a second.
-                const auto finish_time = std::chrono::system_clock::now();
-                elem.event_time = time_in_seconds(finish_time);
-                elem.event_time_microseconds = time_in_microseconds(finish_time);
-                status_info_to_query_log(elem, info, ast);
-
-                auto progress_callback = context.getProgressCallback();
-
-                if (progress_callback)
-                    progress_callback(Progress(WriteProgress(info.written_rows, info.written_bytes)));
-
-                if (stream_in)
-                {
-                    const BlockStreamProfileInfo & stream_in_info = stream_in->getProfileInfo();
-
-                    /// NOTE: INSERT SELECT query contains zero metrics
-                    elem.result_rows = stream_in_info.rows;
-                    elem.result_bytes = stream_in_info.bytes;
-                }
-                else if (stream_out) /// will be used only for ordinary INSERT queries
-                {
-                    if (const auto * counting_stream = dynamic_cast<const CountingBlockOutputStream *>(stream_out))
-                    {
-                        /// NOTE: Redundancy. The same values could be extracted from process_list_elem->progress_out.query_settings = process_list_elem->progress_in
-                        elem.result_rows = counting_stream->getProgress().read_rows;
-                        elem.result_bytes = counting_stream->getProgress().read_bytes;
-                    }
-                }
-                else if (query_pipeline)
-                {
-                    if (const auto * output_format = query_pipeline->getOutputFormat())
-                    {
-                        elem.result_rows = output_format->getResultRows();
-                        elem.result_bytes = output_format->getResultBytes();
-                    }
-                }
-
-                if (elem.read_rows != 0)
-                {
-                    LOG_INFO(&Poco::Logger::get("executeQuery"), "Read {} rows, {} in {} sec., {} rows/sec., {}/sec.",
-                        elem.read_rows, ReadableSize(elem.read_bytes), elapsed_seconds,
-                        static_cast<size_t>(elem.read_rows / elapsed_seconds),
-                        ReadableSize(elem.read_bytes / elapsed_seconds));
-                }
-
-                elem.thread_ids = std::move(info.thread_ids);
-                elem.profile_counters = std::move(info.profile_counters);
-
-                const auto & factories_info = context.getQueryFactoriesInfo();
-                elem.used_aggregate_functions = factories_info.aggregate_functions;
-                elem.used_aggregate_function_combinators = factories_info.aggregate_function_combinators;
-                elem.used_database_engines = factories_info.database_engines;
-                elem.used_data_type_families = factories_info.data_type_families;
-                elem.used_dictionaries = factories_info.dictionaries;
-                elem.used_formats = factories_info.formats;
-                elem.used_functions = factories_info.functions;
-                elem.used_storages = factories_info.storages;
-                elem.used_table_functions = factories_info.table_functions;
-
-                if (log_queries && elem.type >= log_queries_min_type && Int64(elem.query_duration_ms) >= log_queries_min_query_duration_ms)
-                {
-                    if (auto query_log = context.getQueryLog())
-                        query_log->add(elem);
-                }
-
-                if (auto opentelemetry_span_log = context.getOpenTelemetrySpanLog();
-                    context.query_trace_context.trace_id
-                        && opentelemetry_span_log)
-                {
-                    OpenTelemetrySpanLogElement span;
-                    span.trace_id = context.query_trace_context.trace_id;
-                    span.span_id = context.query_trace_context.span_id;
-                    span.parent_span_id = context.getClientInfo().client_trace_context.span_id;
-                    span.operation_name = "query";
-                    span.start_time_us = elem.query_start_time_microseconds;
-                    span.finish_time_us = time_in_microseconds(finish_time);
-
-                    /// Keep values synchronized to type enum in QueryLogElement::createBlock.
-                    span.attribute_names.push_back("clickhouse.query_status");
-                    span.attribute_values.push_back("QueryFinish");
-
-                    span.attribute_names.push_back("db.statement");
-                    span.attribute_values.push_back(elem.query);
-
-                    span.attribute_names.push_back("clickhouse.query_id");
-                    span.attribute_values.push_back(elem.client_info.current_query_id);
-                    if (!context.query_trace_context.tracestate.empty())
-                    {
-                        span.attribute_names.push_back("clickhouse.tracestate");
-                        span.attribute_values.push_back(
-                            context.query_trace_context.tracestate);
-                    }
-
-                    opentelemetry_span_log->add(span);
-                }
-            };
-
-            auto exception_callback = [elem, &context, ast,
-                 log_queries,
-                 log_queries_min_type = settings.log_queries_min_type,
-                 log_queries_min_query_duration_ms = settings.log_queries_min_query_duration_ms.totalMilliseconds(),
-                 quota(quota), status_info_to_query_log] () mutable
-            {
-                if (quota)
-                    quota->used(Quota::ERRORS, 1, /* check_exceeded = */ false);
-
-                elem.type = QueryLogElementType::EXCEPTION_WHILE_PROCESSING;
-
-                // event_time and event_time_microseconds are being constructed from the same time point
-                // to ensure that both the times will be equal up to the precision of a second.
-                const auto time_now = std::chrono::system_clock::now();
-
-                elem.event_time = time_in_seconds(time_now);
-                elem.event_time_microseconds = time_in_microseconds(time_now);
-                elem.query_duration_ms = 1000 * (elem.event_time - elem.query_start_time);
-                elem.exception_code = getCurrentExceptionCode();
-                elem.exception = getCurrentExceptionMessage(false);
-
-                QueryStatus * process_list_elem = context.getProcessListElement();
-                const Settings & current_settings = context.getSettingsRef();
-
-                /// Update performance counters before logging to query_log
-                CurrentThread::finalizePerformanceCounters();
-
-                if (process_list_elem)
-                {
-                    QueryStatusInfo info = process_list_elem->getInfo(true, current_settings.log_profile_events, false);
-                    status_info_to_query_log(elem, info, ast);
-                }
-
-                if (current_settings.calculate_text_stack_trace)
-                    setExceptionStackTrace(elem);
-                logException(context, elem);
-
-                /// In case of exception we log internal queries also
-                if (log_queries && elem.type >= log_queries_min_type && Int64(elem.query_duration_ms) >= log_queries_min_query_duration_ms)
-                {
-                    if (auto query_log = context.getQueryLog())
-                        query_log->add(elem);
-                }
-
-                ProfileEvents::increment(ProfileEvents::FailedQuery);
-                if (ast->as<ASTSelectQuery>() || ast->as<ASTSelectWithUnionQuery>())
-                {
-                    ProfileEvents::increment(ProfileEvents::FailedSelectQuery);
-                }
-                else if (ast->as<ASTInsertQuery>())
-                {
-                    ProfileEvents::increment(ProfileEvents::FailedInsertQuery);
-                }
-
+                query_process->queryException();
             };
 
             res.finish_callback = std::move(finish_callback);
             res.exception_callback = std::move(exception_callback);
+        }
 
-            if (!internal && res.in)
-            {
-                WriteBufferFromOwnString msg_buf;
-                res.in->dumpTree(msg_buf);
-                LOG_DEBUG(&Poco::Logger::get("executeQuery"), "Query pipeline:\n{}", msg_buf.str());
-            }
+        if (!internal && res.in)
+        {
+            WriteBufferFromOwnString msg_buf;
+            res.in->dumpTree(msg_buf);
+            LOG_DEBUG(&Poco::Logger::get("executeQuery"), "Query pipeline:\n{}", msg_buf.str());
         }
     }
     catch (...)
     {
-        if (!internal)
-        {
-            if (query_for_logging.empty())
-                query_for_logging = prepareQueryForLogging(query, context);
-
-            onExceptionBeforeStart(query_for_logging, context, time_in_microseconds(current_time), ast);
-        }
+        /// executeQuery() may fail, hence res.query_process may not be set, do this again.
+        if (query_process)
+            res.query_process = std::move(query_process);
+        /// Checking that query_process is set, since something before it's creation may fail, i.e.:
+        /// - ReplaceQueryParameterVisitor
+        if (!internal && res.query_process)
+            res.query_process->queryExceptionBeforeStart();
 
         throw;
     }

--- a/src/Interpreters/ya.make
+++ b/src/Interpreters/ya.make
@@ -122,6 +122,7 @@ SRCS(
     QueryLog.cpp
     QueryNormalizer.cpp
     QueryParameterVisitor.cpp
+    QueryProcess.cpp
     QueryThreadLog.cpp
     RemoveInjectiveFunctionsVisitor.cpp
     RenameColumnVisitor.cpp

--- a/src/Processors/Executors/PipelineExecutor.h
+++ b/src/Processors/Executors/PipelineExecutor.h
@@ -17,6 +17,7 @@ namespace DB
 {
 
 class QueryStatus;
+class QueryProcessHolder;
 class ExecutingGraph;
 using ExecutingGraphPtr = std::unique_ptr<ExecutingGraph>;
 
@@ -30,7 +31,7 @@ public:
     /// During pipeline execution new processors can appear. They will be added to existing set.
     ///
     /// Explicit graph representation is built in constructor. Throws if graph is not correct.
-    explicit PipelineExecutor(Processors & processors_, QueryStatus * elem = nullptr);
+    explicit PipelineExecutor(Processors & processors_, QueryStatus * elem = nullptr, std::shared_ptr<QueryProcessHolder> query_process_holder_ = {});
 
     /// Execute pipeline in multiple threads. Must be called once.
     /// In case of exception during execution throws any occurred.
@@ -128,6 +129,8 @@ private:
 
     /// Now it's used to check if query was killed.
     QueryStatus * process_list_element = nullptr;
+    /// FIXME: consider replacing QueryStatus with QueryProcessHolder (but not that easy)
+    std::shared_ptr<QueryProcessHolder> query_process_holder;
 
     /// Graph related methods.
     bool expandPipeline(Stack & stack, UInt64 pid);

--- a/src/Processors/QueryPipeline.h
+++ b/src/Processors/QueryPipeline.h
@@ -108,6 +108,7 @@ public:
 
     void addTableLock(TableLockHolder lock) { pipe.addTableLock(std::move(lock)); }
     void addInterpreterContext(std::shared_ptr<Context> context) { pipe.addInterpreterContext(std::move(context)); }
+    void addQueryProcessHolder(std::shared_ptr<QueryProcessHolder> query_process_holder_);
     void addStorageHolder(StoragePtr storage) { pipe.addStorageHolder(std::move(storage)); }
     void addQueryPlan(std::unique_ptr<QueryPlan> plan) { pipe.addQueryPlan(std::move(plan)); }
     void setLimits(const StreamLocalLimits & limits) { pipe.setLimits(limits); }
@@ -152,6 +153,8 @@ private:
     size_t max_threads = 0;
 
     QueryStatus * process_list_element = nullptr;
+
+    std::shared_ptr<QueryProcessHolder> query_process_holder;
 
     void checkInitialized();
     void checkInitializedAndNotCompleted();

--- a/src/Processors/QueryPlan/QueryPlan.h
+++ b/src/Processors/QueryPlan/QueryPlan.h
@@ -19,6 +19,7 @@ using QueryPipelinePtr = std::unique_ptr<QueryPipeline>;
 
 class Context;
 class WriteBuffer;
+class QueryProcessHolder;
 
 class QueryPlan;
 using QueryPlanPtr = std::unique_ptr<QueryPlan>;
@@ -76,6 +77,8 @@ public:
 
     void addInterpreterContext(std::shared_ptr<Context> context);
 
+    void addQueryProcessHolder(std::shared_ptr<QueryProcessHolder> query_process_holder_);
+
     /// Tree node. Step and it's children.
     struct Node
     {
@@ -95,6 +98,7 @@ private:
     /// Those fields are passed to QueryPipeline.
     size_t max_threads = 0;
     std::vector<std::shared_ptr<Context>> interpreter_context;
+    std::shared_ptr<QueryProcessHolder> query_process_holder;
 };
 
 std::string debugExplainStep(const IQueryPlanStep & step);

--- a/src/Processors/QueryPlan/QueryProcessHolder.cpp
+++ b/src/Processors/QueryPlan/QueryProcessHolder.cpp
@@ -1,0 +1,46 @@
+#include <Processors/QueryPlan/QueryProcessHolder.h>
+#include <Interpreters/QueryProcess.h>
+#include <Common/Exception.h>
+
+namespace DB
+{
+
+QueryProcessHolder::QueryProcessHolder(const ASTPtr & ast_, bool internal_, const std::shared_ptr<Context> context_)
+    : context(context_)
+    , query_process(std::make_shared<QueryProcess>(ast_, internal_, *context))
+{
+}
+
+void QueryProcessHolder::initialize()
+{
+    if (initialized)
+        return;
+
+    initialized = true;
+
+    query_process->queryStart();
+}
+
+QueryProcessHolder::~QueryProcessHolder()
+{
+    /// FIXME:
+    /// It can not initialized if multiple QueryProcessHolder was created, but
+    /// only one will be used eventually, see QueryPlan::addQueryProcessHolder()
+    /// for more comments.
+    ///
+    /// NOTE: replace with assert(initialized) one will be resolved
+    if (!initialized)
+        return;
+
+    try
+    {
+        /// FIXME: pass correct arguments
+        query_process->queryFinish(nullptr, nullptr, nullptr);
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+    }
+}
+
+}

--- a/src/Processors/QueryPlan/QueryProcessHolder.h
+++ b/src/Processors/QueryPlan/QueryProcessHolder.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <Parsers/IAST_fwd.h>
+#include <memory>
+#include <string>
+#include <atomic>
+
+namespace DB
+{
+
+class QueryProcess;
+class Context;
+
+/// Holder for QueryProcess
+///
+/// NOTE: Not compatible with PullingPipelineExecutor (since it does not create extra thread),
+/// only PullingAsyncPipelineExecutor is supported.
+class QueryProcessHolder
+{
+public:
+    QueryProcessHolder(const ASTPtr & ast_, bool internal_, const std::shared_ptr<Context> context_);
+    /// Logs the query
+    ~QueryProcessHolder();
+
+    /// Can be called from multiple threads
+    /// (see PipelineExecutor/PullingAsyncPipelineExecutor)
+    void initialize();
+
+private:
+    const std::shared_ptr<Context> context;
+    std::shared_ptr<QueryProcess> query_process;
+    std::atomic<bool> initialized = false;
+};
+
+}

--- a/src/Processors/ya.make
+++ b/src/Processors/ya.make
@@ -122,6 +122,7 @@ SRCS(
     QueryPlan/PartialSortingStep.cpp
     QueryPlan/QueryIdHolder.cpp
     QueryPlan/QueryPlan.cpp
+    QueryPlan/QueryProcessHolder.cpp
     QueryPlan/ReadFromPreparedSource.cpp
     QueryPlan/ReadNothingStep.cpp
     QueryPlan/ReverseRowsStep.cpp

--- a/tests/queries/0_stateless/01455_shard_leaf_max_rows_bytes_to_read.sql
+++ b/tests/queries/0_stateless/01455_shard_leaf_max_rows_bytes_to_read.sql
@@ -27,3 +27,17 @@ SELECT count() FROM (SELECT * FROM test_distributed) SETTINGS max_bytes_to_read_
 
 DROP TABLE IF EXISTS test_local;
 DROP TABLE IF EXISTS test_distributed;
+
+SELECT * FROM remote('127.{1,1}', system.numbers) LIMIT 40000 SETTINGS max_rows_to_read = 60000 FORMAT Null; -- { serverError 158 }
+-- FIXME: see comments in QueryPlan::addQueryProcessHolder()
+--SELECT * FROM remote('127.{1,1}', system.numbers) LIMIT 40000 SETTINGS max_rows_to_read_leaf = 60000 FORMAT Null;
+
+-- UNION creates SourceWithProgress for each thread
+SELECT * FROM numbers(40000) union all select * from numbers(40000) SETTINGS max_rows_to_read = 60000 FORMAT Null; -- { serverError 158 }
+-- FIXME: UNION does not supports separate QueryProcess yet
+--SELECT * FROM numbers(40000) union all select * from numbers(40000) SETTINGS max_rows_to_read_leaf = 60000 FORMAT Null;
+
+-- numbers_mt creates SourceWithProgress for each thread
+SELECT * FROM numbers_mt(100000) SETTINGS max_rows_to_read = 80000 FORMAT Null; -- { serverError 158 }
+-- FIXME: numbers_mt does not supports separate QueryProcess yet
+-- SELECT * FROM numbers_mt(100000) SETTINGS max_rows_to_read_leaf = 80000 FORMAT Null;

--- a/tests/queries/0_stateless/01720_distributed_localhost_different_queries.reference
+++ b/tests/queries/0_stateless/01720_distributed_localhost_different_queries.reference
@@ -1,0 +1,6 @@
+127.1
+QueryStart	2
+QueryFinish	2
+127.{1,2}
+QueryStart	3
+QueryFinish	3

--- a/tests/queries/0_stateless/01720_distributed_localhost_different_queries.sql
+++ b/tests/queries/0_stateless/01720_distributed_localhost_different_queries.sql
@@ -1,0 +1,29 @@
+-- TODO:
+-- - add tests for other query types
+-- - check some columns (i.e. read_rows/result_rows/written_rows/...)
+set log_queries=1;
+set log_queries_min_type='QUERY_START';
+
+select '127.1';
+select 'query from 127.1', * from remote('127.1', system.one) format Null;
+system flush logs;
+select type, count()
+    from system.query_log
+    where current_database = currentDatabase() and event_date = today() and query ilike 'select%query from 127.1%one%' and query not like '%query_log%'
+    group by type
+    order by type;
+
+select '127.{1,2}';
+select 'query from 127.{1,2}', * from remote('127.{1,2}', system.one) format Null;
+system flush logs;
+-- current_database does not passed across the nodes, so query a little bit more complex
+with (
+    select distinct initial_query_id
+    from system.query_log
+    where current_database = currentDatabase() and query ilike 'select%query from 127.{1,2}%one%' and query not like '%query_log%'
+) as initial_query_id_
+select type, count()
+    from system.query_log
+    where initial_query_id = initial_query_id_
+    group by type
+    order by type;

--- a/tests/queries/0_stateless/arcadia_skip_list.txt
+++ b/tests/queries/0_stateless/arcadia_skip_list.txt
@@ -204,3 +204,4 @@
 01683_dist_INSERT_block_structure_mismatch
 01702_bitmap_native_integers
 01686_event_time_microseconds_part_log
+01720_distributed_localhost_different_queries


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Separate query process/query_log,query_thread_log entry/log for nested queries (Distributed from localhost with `prefer_localhost_replica=1`)

Detailed description / Documentation draft:

Long-term goal:
- add it for `StorageBuffer`/`StorageKafka`/e.t.c.
- add it for `PushingToViewsBlockOutputStream`
- support multiple `QueryProcessHolder` (for `select * from remote('127.{1,1}', system.one)`)
- do this under some setting?

Fixes: #6349