### PR TITLE
Fix non-zero session reconnect in integration test

### DIFF
--- a/tests/integration/test_testkeeper_back_to_back/test.py
+++ b/tests/integration/test_testkeeper_back_to_back/test.py
@@ -29,8 +29,8 @@ def get_fake_zk():
         def reset_last_zxid_listener(state):
             print("Fake zk callback called for state", state)
             global _fake_zk_instance
-            # reset last_zxid -- fake server doesn't support it
-            _fake_zk_instance.last_zxid = 0
+            if state != KazooState.CONNECTED:
+                _fake_zk_instance._reset()
 
         _fake_zk_instance.add_listener(reset_last_zxid_listener)
         _fake_zk_instance.start()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)