### PR TITLE
Keep ENABLE_LIBPQXX FALSE by default for APPLE

### DIFF
--- a/cmake/find/libpqxx.cmake
+++ b/cmake/find/libpqxx.cmake
@@ -1,4 +1,8 @@
-option(ENABLE_LIBPQXX "Enalbe libpqxx" ${ENABLE_LIBRARIES})
+if (APPLE)
+    option(ENABLE_LIBPQXX "Enalbe libpqxx" FALSE)
+else ()
+    option(ENABLE_LIBPQXX "Enalbe libpqxx" ${ENABLE_LIBRARIES})
+endif ()
 
 if (NOT ENABLE_LIBPQXX)
     return()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Build/Testing/Packaging Improvement

Changelog entry:
- None.

Detailed description:
- Set `ENABLE_LIBPQXX` to `FALSE` for `APPLE` builds, as it is not properly configured (`config.h` etc.) for macOS. Doing this will allow default CMake configure command to work and build not to fail under macOS.