### PR TITLE
Fix SIGSEGV on Unknown packet for Distributed queries

### DIFF
--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -756,7 +756,11 @@ std::optional<UInt64> Connection::checkPacket(size_t timeout_microseconds)
 Packet Connection::receivePacket(std::function<void(Poco::Net::Socket &)> async_callback)
 {
     in->setAsyncCallback(std::move(async_callback));
-    SCOPE_EXIT(in->setAsyncCallback({}));
+    SCOPE_EXIT({
+        /// disconnect() will reset "in".
+        if (in)
+            in->setAsyncCallback({});
+    });
 
     try
     {


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix crash which could happen if unknown packet was received from remove query (was introduced in #17868).

Detailed description / Documentation draft:

On Unknown packet disconnect() will be called, which will reset the
input stream, so no need to call setAsyncCallback():

    [ 42015 ] {} <Fatal> BaseDaemon: (version 21.3.1.1, build id: 4F9644AF560F6BB6) (from thread 45051) (no query) Received signal Segmentation fault (11)
    [ 42015 ] {} <Fatal> BaseDaemon: Address: 0x90 Access: read. Address not mapped to object.
    [ 42015 ] {} <Fatal> BaseDaemon: Stack trace: 0xf82e0f4 0xf82de19 0xf83b9a5 0xf83c0e0 0xe9a6fa7 0xf95016c 0xf950939 0xf95020c 0xf950939 0xf95020c 0xf950939 0xf95020c 0xf9508f9 0xf953e40 0xf958376 0x88056af 0x8809143 0x7f4b3e1aaf27 0x7f4b3e0dc31f
    [ 42015 ] {} <Fatal> BaseDaemon: 2. ext::basic_scope_guard<DB::Connection::receivePacket(std::__1::function<void (Poco::Net::Socket&)>)::$_3>::~basic_scope_guard() @ 0xf82e0f4 in /usr/lib/debug/.build-id/4f/9644af560f6bb6.debug
    [ 42015 ] {} <Fatal> BaseDaemon: 3. DB::Connection::receivePacket(std::__1::function<void (Poco::Net::Socket&)>) @ 0xf82de19 in /usr/lib/debug/.build-id/4f/9644af560f6bb6.debug
    [ 42015 ] {} <Fatal> BaseDaemon: 4. DB::MultiplexedConnections::receivePacketUnlocked(std::__1::function<void (Poco::Net::Socket&)>) @ 0xf83b9a5 in /usr/lib/debug/.build-id/4f/9644af560f6bb6.debug
    [ 42015 ] {} <Fatal> BaseDaemon: 5. DB::MultiplexedConnections::drain() @ 0xf83c0e0 in /usr/lib/debug/.build-id/4f/9644af560f6bb6.debug
    [ 42015 ] {} <Fatal> BaseDaemon: 6. DB::RemoteQueryExecutor::finish(std::__1::unique_ptr<DB::RemoteQueryExecutorReadContext, std::__1::default_delete<DB::RemoteQueryExecutorReadContext> >*) @ 0xe9a6fa7 in /usr/lib/debug/.build-id/4f/9644af560f6bb6.debug
    [ 42015 ] {} <Fatal> BaseDaemon: 7. DB::PipelineExecutor::tryAddProcessorToStackIfUpdated() @ 0xf95016c in /usr/lib/debug/.build-id/4f/9644af560f6bb6.debug
    ...

Cc: @KochetovNicolai 
Introduced-in: #17868