### PR TITLE
Fix typo on tutorial

### DIFF
--- a/docs/en/getting-started/tutorial.md
+++ b/docs/en/getting-started/tutorial.md
@@ -644,7 +644,7 @@ If there are no replicas at the moment on replicated table creation, a new first
 
 ``` sql
 CREATE TABLE tutorial.hits_replica (...)
-ENGINE = ReplcatedMergeTree(
+ENGINE = ReplicatedMergeTree(
     '/clickhouse_perftest/tables/{shard}/hits',
     '{replica}'
 )


### PR DESCRIPTION
I was reading your online documentation and I found that there was a typo on the sql command and there was some missing link. 
Not quite familiar with the clickhouse contribution process, I just edited the files fix directly from github, let me know if there is something else missing from my side. 

Hope this helps!

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)

