### PR TITLE
ignore data store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,9 @@ website/package-lock.json
 /prof
 
 *.iml
+
+# data store
+/programs/server/data
+/programs/server/metadata
+/programs/server/store
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

According to our [guide](https://clickhouse.tech/docs/en/development/developer-instruction/) it is convenient trying ClickHouse with default configuration that directly run `clickhouse` under `/programs/server`. These steps generate data store files under

- `/programs/server/data`
- `/programs/server/metadata`
- `/programs/server/store`

This commit ignore these generated data store files for smoothly hacking.