### PR TITLE
Update argmax.md 

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/reference/argmax.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/argmax.md
@@ -17,12 +17,12 @@ argMax(arg, val)
 or
 
 ``` sql
-argMax(tuple(arg, val))
+argMax(tuple(arg1, arg2), val)
 ```
 
 **Arguments**
 
--   `arg` — Argument.
+-   `arg{i}` — Argument.
 -   `val` — Value.
 
 **Returned value**
@@ -33,7 +33,7 @@ Type: matches `arg` type.
 
 For tuple in the input:
 
--   Tuple `(arg, val)`, where `val` is the maximum value and `arg` is a corresponding value.
+-   Tuple `(arg1, arg2)`, where `arg1` and `arg2` are the corresponding values.
 
 Type: [Tuple](../../../sql-reference/data-types/tuple.md).
 
@@ -52,13 +52,13 @@ Input table:
 Query:
 
 ``` sql
-SELECT argMax(user, salary), argMax(tuple(user, salary)) FROM salary;
+SELECT argMax(user, salary), argMax(tuple(user, salary), salary) FROM salary;
 ```
 
 Result:
 
 ``` text
-┌─argMax(user, salary)─┬─argMax(tuple(user, salary))─┐
+┌─argMax(user, salary)─┬─argMax(tuple(user, salary), salary)─┐
 │ director             │ ('director',5000)           │
 └──────────────────────┴─────────────────────────────┘
 ```

--- a/docs/en/sql-reference/aggregate-functions/reference/argmax.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/argmax.md
@@ -17,12 +17,12 @@ argMax(arg, val)
 or
 
 ``` sql
-argMax(tuple(arg1, arg2), val)
+argMax(tuple(arg, val))
 ```
 
 **Arguments**
 
--   `arg{i}` — Argument.
+-   `arg` — Argument.
 -   `val` — Value.
 
 **Returned value**
@@ -33,7 +33,7 @@ Type: matches `arg` type.
 
 For tuple in the input:
 
--   Tuple `(arg1, arg2)`, where `arg1` and `arg2` are the corresponding values.
+-   Tuple `(arg, val)`, where `val` is the maximum value and `arg` is a corresponding value.
 
 Type: [Tuple](../../../sql-reference/data-types/tuple.md).
 
@@ -52,15 +52,15 @@ Input table:
 Query:
 
 ``` sql
-SELECT argMax(user, salary), argMax(tuple(user, salary), salary) FROM salary;
+SELECT argMax(user, salary), argMax(tuple(user, salary), salary), argMax(tuple(user, salary)) FROM salary;
 ```
 
 Result:
 
 ``` text
-┌─argMax(user, salary)─┬─argMax(tuple(user, salary), salary)─┐
-│ director             │ ('director',5000)           │
-└──────────────────────┴─────────────────────────────┘
+┌─argMax(user, salary)─┬─argMax(tuple(user, salary), salary)─┬─argMax(tuple(user, salary))─┐
+│ director             │ ('director',5000)                   │ ('director',5000)           │
+└──────────────────────┴─────────────────────────────────────┴─────────────────────────────┘
 ```
 
 [Original article](https://clickhouse.tech/docs/en/sql-reference/aggregate-functions/reference/argmax/) <!--hide-->


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changed the description of the usage of tuple in argMax. 
First, the syntax was not correct agMax need two arguments and now it shows even better the usage with an arbitrary number of arguments. 