### PR TITLE
Log stdout and stderr when failed to start docker in integration tests

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -730,7 +730,7 @@ class ClickHouseCluster:
 
             clickhouse_start_cmd = self.base_cmd + ['up', '-d', '--no-recreate']
             print(("Trying to create ClickHouse instance by command %s", ' '.join(map(str, clickhouse_start_cmd))))
-            subprocess.check_output(clickhouse_start_cmd)
+            subprocess_check_call(clickhouse_start_cmd)
             print("ClickHouse instance created")
 
             start_deadline = time.time() + 20.0  # seconds


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Build/Testing/Packaging Improvement

Changelog entry:
Print `stdout` and `stderr` to log when failed to start docker in integration tests. Before this PR there was a very short error message in this case which didn't help to investigate the problems:

```
Failed to start cluster: 
Command '['docker-compose', '--project-name', 'roottestgrpcprotocolssl', '--file', '/compose/docker_compose_net.yml', '--file', '/ClickHouse/tests/integration/test_grpc_protocol_ssl/_instances/node/docker-compose.yml', 'up', '-d', '--no-recreate']' returned non-zero exit status 1.
```
