### PR TITLE
mysqlxx::PoolWithFailover: Randomize list of same-priority replicas

### DIFF
--- a/base/mysqlxx/PoolWithFailover.cpp
+++ b/base/mysqlxx/PoolWithFailover.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
-#include <cstdlib>
+#include <ctime>
 #include <random>
+#include <thread>
 
 #include <mysqlxx/PoolWithFailover.h>
 
@@ -43,7 +44,8 @@ PoolWithFailover::PoolWithFailover(const Poco::Util::AbstractConfiguration & con
         /// which triggers massive re-constructing of connection pools.
         /// The state of PRNGs like std::mt19937 is considered to be quite heavy
         /// thus here we attempt to optimize its construction.
-        static thread_local std::mt19937 rnd_generator(std::rand());
+        static thread_local std::mt19937 rnd_generator(
+                std::hash<std::thread::id>{}(std::this_thread::get_id()) + std::clock());
         for (auto & [_, replicas] : replicas_by_priority)
         {
             if (replicas.size() > 1)

--- a/base/mysqlxx/PoolWithFailover.cpp
+++ b/base/mysqlxx/PoolWithFailover.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cstdlib>
 #include <random>
 
 #include <mysqlxx/PoolWithFailover.h>
@@ -10,8 +11,6 @@ static bool startsWith(const std::string & s, const char * prefix)
     return s.size() >= strlen(prefix) && 0 == memcmp(s.data(), prefix, strlen(prefix));
 }
 
-/// This reads from "/dev/urandom" and thus is thread-safe
-std::random_device rd;
 
 using namespace mysqlxx;
 
@@ -42,9 +41,9 @@ PoolWithFailover::PoolWithFailover(const Poco::Util::AbstractConfiguration & con
         /// PoolWithFailover objects are stored in a cache inside PoolFactory.
         /// This cache is reset by ExternalDictionariesLoader after every SYSTEM RELOAD DICTIONAR{Y|IES}
         /// which triggers massive re-constructing of connection pools.
-        /// The state of PRNDGs like std::mt19937 is considered to be quite heavy
+        /// The state of PRNGs like std::mt19937 is considered to be quite heavy
         /// thus here we attempt to optimize its construction.
-        static thread_local std::mt19937 rnd_generator(rd());
+        static thread_local std::mt19937 rnd_generator(std::rand());
         for (auto & [_, replicas] : replicas_by_priority)
         {
             if (replicas.size() > 1)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
When loading config for mysql source ClickHouse will now randomize the list of replicas with the same priority to ensure the round-robin logics of picking mysql endpoint.
This closes #20629