### PR TITLE
Improve backtrace catching on server failures in CI for fast-tests

### DIFF
--- a/docker/test/fasttest/Dockerfile
+++ b/docker/test/fasttest/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get update \
         expect \
         fakeroot \
         git \
+        gdb \
         gperf \
         lld-${LLVM_VERSION} \
         llvm-${LLVM_VERSION} \

--- a/docker/test/fasttest/run.sh
+++ b/docker/test/fasttest/run.sh
@@ -107,6 +107,18 @@ function start_server
     fi
 
     echo "ClickHouse server pid '$server_pid' started and responded"
+
+    echo "
+handle all noprint
+handle SIGSEGV stop print
+handle SIGBUS stop print
+handle SIGABRT stop print
+continue
+thread apply all backtrace
+continue
+" > script.gdb
+
+    gdb -batch -command script.gdb -p "$server_pid" &
 }
 
 function clone_root


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up-for: #20462 (initially this PR was included into #20462, but docker image for fasttest was never updated, so it was moved into separate PR in attempt to fix this layers caching issue)