### PR TITLE
MaterializeMySQL: Attempt to reconnect to MySQL if the connection is lost

### DIFF
--- a/base/mysqlxx/Pool.cpp
+++ b/base/mysqlxx/Pool.cpp
@@ -174,9 +174,11 @@ Pool::Entry Pool::tryGet()
         /// Fixme: There is a race condition here b/c we do not synchronize with Pool::Entry's copy-assignment operator
         if (connection_ptr->ref_count == 0)
         {
-            Entry res(connection_ptr, this);
-            if (res.tryForceConnected())  /// Tries to reestablish connection as well
-                return res;
+            {
+                Entry res(connection_ptr, this);
+                if (res.tryForceConnected())  /// Tries to reestablish connection as well
+                    return res;
+            }
 
             logger.debug("(%s): Idle connection to MySQL server cannot be recovered, dropping it.", getDescription());
 

--- a/src/Core/MySQL/MySQLClient.cpp
+++ b/src/Core/MySQL/MySQLClient.cpp
@@ -68,6 +68,7 @@ void MySQLClient::disconnect()
         socket->close();
     socket = nullptr;
     connected = false;
+    seq = 0;
 }
 
 /// https://dev.mysql.com/doc/internals/en/connection-phase-packets.html

--- a/src/Core/MySQL/MySQLReplication.cpp
+++ b/src/Core/MySQL/MySQLReplication.cpp
@@ -17,6 +17,7 @@ namespace ErrorCodes
     extern const int UNKNOWN_EXCEPTION;
     extern const int LOGICAL_ERROR;
     extern const int ATTEMPT_TO_READ_AFTER_EOF;
+    extern const int CANNOT_READ_ALL_DATA;
 }
 
 namespace MySQLReplication
@@ -740,7 +741,7 @@ namespace MySQLReplication
         switch (header)
         {
             case PACKET_EOF:
-                throw ReplicationError("Master maybe lost", ErrorCodes::UNKNOWN_EXCEPTION);
+                throw ReplicationError("Master maybe lost", ErrorCodes::CANNOT_READ_ALL_DATA);
             case PACKET_ERR:
                 ERRPacket err;
                 err.readPayloadWithUnpacked(payload);

--- a/src/Databases/MySQL/DatabaseMaterializeMySQL.cpp
+++ b/src/Databases/MySQL/DatabaseMaterializeMySQL.cpp
@@ -82,18 +82,11 @@ template<typename Base>
 void DatabaseMaterializeMySQL<Base>::loadStoredObjects(Context & context, bool has_force_restore_data_flag, bool force_attach)
 {
     Base::loadStoredObjects(context, has_force_restore_data_flag, force_attach);
-    try
-    {
-        materialize_thread.startSynchronization();
-        started_up = true;
-    }
-    catch (...)
-    {
-        tryLogCurrentException(Base::log, "Cannot load MySQL nested database stored objects.");
+    if (!force_attach)
+        materialize_thread.assertMySQLAvailable();
 
-        if (!force_attach)
-            throw;
-    }
+    materialize_thread.startSynchronization();
+    started_up = true;
 }
 
 template<typename Base>

--- a/src/Databases/MySQL/MaterializeMetadata.h
+++ b/src/Databases/MySQL/MaterializeMetadata.h
@@ -35,7 +35,6 @@ struct MaterializeMetadata
     size_t data_version = 1;
     size_t meta_version = 2;
     String binlog_checksum = "CRC32";
-    std::unordered_map<String, String> need_dumping_tables;
 
     void fetchMasterStatus(mysqlxx::PoolWithFailover::Entry & connection);
 
@@ -45,9 +44,13 @@ struct MaterializeMetadata
 
     void transaction(const MySQLReplication::Position & position, const std::function<void()> & fun);
 
-    MaterializeMetadata(
-        mysqlxx::PoolWithFailover::Entry & connection, const String & path
-        , const String & database, bool & opened_transaction);
+    void startReplication(
+        mysqlxx::PoolWithFailover::Entry & connection,
+        const String & database,
+        bool & opened_transaction,
+        std::unordered_map<String, String> & need_dumping_tables);
+
+    MaterializeMetadata(const String & path_);
 };
 
 }

--- a/src/Databases/MySQL/MaterializeMySQLSettings.h
+++ b/src/Databases/MySQL/MaterializeMySQLSettings.h
@@ -14,7 +14,7 @@ class ASTStorage;
     M(UInt64, max_rows_in_buffers, DEFAULT_BLOCK_SIZE, "Max rows that data is allowed to cache in memory(for database and the cache data unable to query). when rows is exceeded, the data will be materialized", 0) \
     M(UInt64, max_bytes_in_buffers, DBMS_DEFAULT_BUFFER_SIZE, "Max bytes that data is allowed to cache in memory(for database and the cache data unable to query). when rows is exceeded, the data will be materialized", 0) \
     M(UInt64, max_flush_data_time, 1000, "Max milliseconds that data is allowed to cache in memory(for database and the cache data unable to query). when this time is exceeded, the data will be materialized", 0)  \
-    M(UInt64, max_wait_time_when_mysql_unavailable, 1000, "Dump full data retry interval when MySQL is not available(milliseconds).", 0) \
+    M(Int64, max_wait_time_when_mysql_unavailable, 1000, "Retry interval when MySQL is not available (milliseconds). Negative value disable retry.", 0) \
     M(Bool, allows_query_when_mysql_lost, false, "Allow query materialized table when mysql is lost.", 0) \
 
     DECLARE_SETTINGS_TRAITS(MaterializeMySQLSettingsTraits, LIST_OF_MATERIALIZE_MODE_SETTINGS)

--- a/src/Databases/MySQL/MaterializeMySQLSyncThread.h
+++ b/src/Databases/MySQL/MaterializeMySQLSyncThread.h
@@ -71,6 +71,9 @@ private:
     const int ER_DBACCESS_DENIED_ERROR = 1044;
     const int ER_BAD_DB_ERROR = 1049;
 
+    // https://dev.mysql.com/doc/mysql-errors/8.0/en/client-error-reference.html
+    const int CR_SERVER_LOST = 2013;
+
     struct Buffers
     {
         String database;

--- a/src/Databases/MySQL/MaterializeMySQLSyncThread.h
+++ b/src/Databases/MySQL/MaterializeMySQLSyncThread.h
@@ -100,7 +100,7 @@ private:
 
     bool isCancelled() { return sync_quit.load(std::memory_order_relaxed); }
 
-    std::optional<MaterializeMetadata> prepareSynchronized();
+    bool prepareSynchronized(MaterializeMetadata & metadata);
 
     void flushBuffersData(Buffers & buffers, MaterializeMetadata & metadata);
 

--- a/src/Databases/MySQL/MaterializeMySQLSyncThread.h
+++ b/src/Databases/MySQL/MaterializeMySQLSyncThread.h
@@ -49,6 +49,8 @@ public:
 
     void startSynchronization();
 
+    void assertMySQLAvailable();
+
     static bool isMySQLSyncThread();
 
 private:
@@ -107,6 +109,8 @@ private:
     std::atomic<bool> sync_quit{false};
     std::unique_ptr<ThreadFromGlobalPool> background_thread_pool;
     void executeDDLAtomic(const QueryEvent & query_event);
+
+    void setSynchronizationThreadException(const std::exception_ptr & exception);
 };
 
 }

--- a/tests/integration/test_materialize_mysql_database/materialize_with_ddl.py
+++ b/tests/integration/test_materialize_mysql_database/materialize_with_ddl.py
@@ -653,7 +653,6 @@ def mysql_kill_sync_thread_restore_test(clickhouse_node, mysql_node, service_nam
 
     get_sync_id_query = "select id from information_schema.processlist where STATE='Master has sent all binlog to slave; waiting for more updates'"
     result = mysql_node.query_and_get_data(get_sync_id_query)
-
     assert len(result) == 2
 
     for row in result:

--- a/tests/integration/test_materialize_mysql_database/materialize_with_ddl.py
+++ b/tests/integration/test_materialize_mysql_database/materialize_with_ddl.py
@@ -616,8 +616,6 @@ def network_partition_test(clickhouse_node, mysql_node, service_name):
 
         restore_instance_mysql_connections(clickhouse_node, pm)
 
-        clickhouse_node.query("DETACH DATABASE test_database")
-        clickhouse_node.query("ATTACH DATABASE test_database")
         check_query(clickhouse_node, "SELECT * FROM test_database.test_table FORMAT TSV", '1\n')
 
         clickhouse_node.query(
@@ -635,16 +633,28 @@ def network_partition_test(clickhouse_node, mysql_node, service_name):
 
 def mysql_kill_sync_thread_restore_test(clickhouse_node, mysql_node, service_name):
     clickhouse_node.query("DROP DATABASE IF EXISTS test_database;")
+    clickhouse_node.query("DROP DATABASE IF EXISTS test_database_auto;")
+
     mysql_node.query("DROP DATABASE IF EXISTS test_database;")
     mysql_node.query("CREATE DATABASE test_database;")
     mysql_node.query("CREATE TABLE test_database.test_table ( `id` int(11) NOT NULL, PRIMARY KEY (`id`) ) ENGINE=InnoDB;")
     mysql_node.query("INSERT INTO test_database.test_table VALUES (1)")
 
-    clickhouse_node.query("CREATE DATABASE test_database ENGINE = MaterializeMySQL('{}:3306', 'test_database', 'root', 'clickhouse')".format(service_name))
+    mysql_node.query("DROP DATABASE IF EXISTS test_database_auto;")
+    mysql_node.query("CREATE DATABASE test_database_auto;")
+    mysql_node.query("CREATE TABLE test_database_auto.test_table ( `id` int(11) NOT NULL, PRIMARY KEY (`id`) ) ENGINE=InnoDB;")
+    mysql_node.query("INSERT INTO test_database_auto.test_table VALUES (11)")
+
+    clickhouse_node.query("CREATE DATABASE test_database ENGINE = MaterializeMySQL('{}:3306', 'test_database', 'root', 'clickhouse') SETTINGS max_wait_time_when_mysql_unavailable=-1".format(service_name))
+    clickhouse_node.query("CREATE DATABASE test_database_auto ENGINE = MaterializeMySQL('{}:3306', 'test_database_auto', 'root', 'clickhouse')".format(service_name))
+
     check_query(clickhouse_node, "SELECT * FROM test_database.test_table FORMAT TSV", '1\n')
+    check_query(clickhouse_node, "SELECT * FROM test_database_auto.test_table FORMAT TSV", '11\n')
 
     get_sync_id_query = "select id from information_schema.processlist where STATE='Master has sent all binlog to slave; waiting for more updates'"
     result = mysql_node.query_and_get_data(get_sync_id_query)
+
+    assert len(result) == 2
 
     for row in result:
         row_result = {}
@@ -656,7 +666,7 @@ def mysql_kill_sync_thread_restore_test(clickhouse_node, mysql_node, service_nam
         # When you use KILL, a thread-specific kill flag is set for the thread. In most cases, it might take some time for the thread to die because the kill flag is checked only at specific intervals:
         time.sleep(3)
         clickhouse_node.query("SELECT * FROM test_database.test_table")
-    assert "Cannot read all data" in str(exception.value)
+        assert "Cannot read all data" in str(exception.value)
 
     clickhouse_node.query("DETACH DATABASE test_database")
     clickhouse_node.query("ATTACH DATABASE test_database")
@@ -665,8 +675,13 @@ def mysql_kill_sync_thread_restore_test(clickhouse_node, mysql_node, service_nam
     mysql_node.query("INSERT INTO test_database.test_table VALUES (2)")
     check_query(clickhouse_node, "SELECT * FROM test_database.test_table ORDER BY id FORMAT TSV", '1\n2\n')
 
+    mysql_node.query("INSERT INTO test_database_auto.test_table VALUES (12)")
+    check_query(clickhouse_node, "SELECT * FROM test_database_auto.test_table ORDER BY id FORMAT TSV", '11\n12\n')
+
     clickhouse_node.query("DROP DATABASE test_database")
+    clickhouse_node.query("DROP DATABASE test_database_auto")
     mysql_node.query("DROP DATABASE test_database")
+    mysql_node.query("DROP DATABASE test_database_auto")
 
 
 def mysql_killed_while_insert(clickhouse_node, mysql_node, service_name):
@@ -687,10 +702,9 @@ def mysql_killed_while_insert(clickhouse_node, mysql_node, service_name):
         run_and_check(
             ['docker-compose', '-p', mysql_node.project_name, '-f', mysql_node.docker_compose, 'stop'])
     finally:
-        with pytest.raises(QueryRuntimeException) as execption:
+        with pytest.raises(QueryRuntimeException) as exception:
             time.sleep(5)
             clickhouse_node.query("SELECT count() FROM kill_mysql_while_insert.test")
-        assert "Master maybe lost." in str(execption.value)
 
         run_and_check(
             ['docker-compose', '-p', mysql_node.project_name, '-f', mysql_node.docker_compose, 'start'])

--- a/tests/integration/test_materialize_mysql_database/materialize_with_ddl.py
+++ b/tests/integration/test_materialize_mysql_database/materialize_with_ddl.py
@@ -577,13 +577,13 @@ def err_sync_user_privs_with_materialize_mysql_database(clickhouse_node, mysql_n
     mysql_node.query("DROP USER 'test'@'%'")
 
 
-def restore_instance_mysql_connections(clickhouse_node, pm, action='DROP'):
+def restore_instance_mysql_connections(clickhouse_node, pm, action='REJECT'):
     pm._check_instance(clickhouse_node)
     pm._delete_rule({'source': clickhouse_node.ip_address, 'destination_port': 3306, 'action': action})
     pm._delete_rule({'destination': clickhouse_node.ip_address, 'source_port': 3306, 'action': action})
     time.sleep(5)
 
-def drop_instance_mysql_connections(clickhouse_node, pm, action='DROP'):
+def drop_instance_mysql_connections(clickhouse_node, pm, action='REJECT'):
     pm._check_instance(clickhouse_node)
     pm._add_rule({'source': clickhouse_node.ip_address, 'destination_port': 3306, 'action': action})
     pm._add_rule({'destination': clickhouse_node.ip_address, 'source_port': 3306, 'action': action})


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
MaterializeMySQL: Attempt to reconnect to MySQL if the connection is lost


Detailed description / Documentation draft:
If the connection to MySQL is lost (e.g. if MySQL is restarted) attempt to reconnect by default.  Also, if MySQL is not available when an existing database is loaded when ClickHouse is started, don't allow tables to be queried unless the `allows_query_when_mysql_lost` setting is enabled. 
