### PR TITLE
Increase buffer for uncaught exception / std::terminate

### DIFF
--- a/base/daemon/BaseDaemon.cpp
+++ b/base/daemon/BaseDaemon.cpp
@@ -416,7 +416,7 @@ static void sanitizerDeathCallback()
     else
         log_message = "Terminate called without an active exception";
 
-    static const size_t buf_size = 1024;
+    static const size_t buf_size = PIPE_BUF;
 
     if (log_message.size() > buf_size - 16)
         log_message.resize(buf_size - 16);

--- a/base/daemon/BaseDaemon.cpp
+++ b/base/daemon/BaseDaemon.cpp
@@ -416,7 +416,9 @@ static void sanitizerDeathCallback()
     else
         log_message = "Terminate called without an active exception";
 
-    static const size_t buf_size = PIPE_BUF;
+    /// POSIX.1 says that write(2)s of less than PIPE_BUF bytes must be atomic - man 7 pipe
+    /// And the buffer should not be too small because our exception messages can be large.
+    static constexpr size_t buf_size = PIPE_BUF;
 
     if (log_message.size() > buf_size - 16)
         log_message.resize(buf_size - 16);


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Use PIPE_BUF (4096 on linux) over some magic number 1024 in terminate_handler, since according to pipe(7):

    PIPE_BUF
           POSIX.1  says  that  write(2)s of less than PIPE_BUF bytes must be atomic

Also note that 1024, is too small, especially for C++ stacktraces (and
especially for debug builds, that contains lots of non-inlined helpers
for various ptrs).