### PR TITLE
Preserve mysql logs in test_materialize_mysql_database

### DIFF
--- a/docker/test/integration/runner/compose/docker_compose_mysql_5_7_for_materialize_mysql.yml
+++ b/docker/test/integration/runner/compose/docker_compose_mysql_5_7_for_materialize_mysql.yml
@@ -6,5 +6,8 @@ services:
         environment:
             MYSQL_ROOT_PASSWORD: clickhouse
         ports:
-          - 3308:3306
-        command: --server_id=100 --log-bin='mysql-bin-1.log' --default-time-zone='+3:00' --gtid-mode="ON" --enforce-gtid-consistency
+            - 3308:3306
+        command: --server_id=100 --log-bin='mysql-bin-1.log'
+            --default-time-zone='+3:00'
+            --gtid-mode="ON"
+            --enforce-gtid-consistency

--- a/docker/test/integration/runner/compose/docker_compose_mysql_5_7_for_materialize_mysql.yml
+++ b/docker/test/integration/runner/compose/docker_compose_mysql_5_7_for_materialize_mysql.yml
@@ -11,3 +11,4 @@ services:
             --default-time-zone='+3:00'
             --gtid-mode="ON"
             --enforce-gtid-consistency
+            --log-error-verbosity=3

--- a/docker/test/integration/runner/compose/docker_compose_mysql_8_0_for_materialize_mysql.yml
+++ b/docker/test/integration/runner/compose/docker_compose_mysql_8_0_for_materialize_mysql.yml
@@ -12,3 +12,4 @@ services:
             --default-time-zone='+3:00'
             --gtid-mode="ON"
             --enforce-gtid-consistency
+            --log-error-verbosity=3

--- a/docker/test/integration/runner/compose/docker_compose_mysql_8_0_for_materialize_mysql.yml
+++ b/docker/test/integration/runner/compose/docker_compose_mysql_8_0_for_materialize_mysql.yml
@@ -6,5 +6,9 @@ services:
         environment:
             MYSQL_ROOT_PASSWORD: clickhouse
         ports:
-          - 33308:3306
-        command: --server_id=100 --log-bin='mysql-bin-1.log' --default_authentication_plugin='mysql_native_password' --default-time-zone='+3:00' --gtid-mode="ON" --enforce-gtid-consistency
+            - 33308:3306
+        command: --server_id=100 --log-bin='mysql-bin-1.log'
+            --default_authentication_plugin='mysql_native_password'
+            --default-time-zone='+3:00'
+            --gtid-mode="ON"
+            --enforce-gtid-consistency

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -44,8 +44,8 @@ def _create_env_file(path, variables, fname=DEFAULT_ENV_NAME):
             f.write("=".join([var, value]) + "\n")
     return full_path
 
-def run_and_check(args, env=None, shell=False):
-    res = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, shell=shell)
+def run_and_check(args, env=None, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE):
+    res = subprocess.run(args, stdout=stdout, stderr=stderr, env=env, shell=shell)
     if res.returncode != 0:
         # check_call(...) from subprocess does not print stderr, so we do it manually
         print('Stderr:\n{}\n'.format(res.stderr.decode('utf-8')))

--- a/tests/integration/test_materialize_mysql_database/test.py
+++ b/tests/integration/test_materialize_mysql_database/test.py
@@ -37,6 +37,12 @@ class MySQLNodeInstance:
         self.docker_compose = docker_compose
         self.project_name = project_name
 
+        self.base_dir = p.dirname(__file__)
+        self.instances_dir = p.join(self.base_dir, '_instances_mysql')
+        if not os.path.exists(self.instances_dir):
+            os.mkdir(self.instances_dir)
+        self.docker_logs_path = p.join(self.instances_dir, 'docker_mysql.log')
+
 
     def alloc_connection(self):
         if self.mysql_connection is None:
@@ -74,6 +80,16 @@ class MySQLNodeInstance:
     def close(self):
         if self.mysql_connection is not None:
             self.mysql_connection.close()
+
+        with open(self.docker_logs_path, "w+") as f:
+            try:
+                run_and_check([
+                    'docker-compose',
+                    '-p', cluster.project_name,
+                    '-f', self.docker_compose, 'logs',
+                ], stdout=f)
+            except Exception as e:
+                print("Unable to get logs from docker mysql.")
 
     def wait_mysql_to_start(self, timeout=60):
         start = time.time()

--- a/tests/integration/test_materialize_mysql_database/test.py
+++ b/tests/integration/test_materialize_mysql_database/test.py
@@ -77,6 +77,14 @@ class MySQLNodeInstance:
             cursor.execute(executio_query)
             return cursor.fetchall()
 
+    def start_and_wait(self):
+        run_and_check(['docker-compose',
+            '-p', cluster.project_name,
+            '-f', self.docker_compose,
+            'up', '--no-recreate', '-d',
+        ])
+        self.wait_mysql_to_start(120)
+
     def close(self):
         if self.mysql_connection is not None:
             self.mysql_connection.close()
@@ -111,9 +119,7 @@ def started_mysql_5_7():
     mysql_node = MySQLNodeInstance('root', 'clickhouse', '127.0.0.1', 3308, docker_compose)
 
     try:
-        run_and_check(
-            ['docker-compose', '-p', cluster.project_name, '-f', docker_compose, 'up', '--no-recreate', '-d'])
-        mysql_node.wait_mysql_to_start(120)
+        mysql_node.start_and_wait()
         yield mysql_node
     finally:
         mysql_node.close()
@@ -127,9 +133,7 @@ def started_mysql_8_0():
     mysql_node = MySQLNodeInstance('root', 'clickhouse', '127.0.0.1', 33308, docker_compose)
 
     try:
-        run_and_check(
-            ['docker-compose', '-p', cluster.project_name, '-f', docker_compose, 'up', '--no-recreate', '-d'])
-        mysql_node.wait_mysql_to_start(120)
+        mysql_node.start_and_wait()
         yield mysql_node
     finally:
         mysql_node.close()


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

test_materialize_mysql_database fails from [time to time](https://clickhouse-test-reports.s3.yandex.net/20882/7bcfe92cd7ba75f7d2ee2d58be3ec51f627a807f/integration_tests_(release).html#fail1), and usually it contain an error like this in the logs:

```
2021.02.19 01:54:36.565121 [ 58 ] {} <Error> MaterializeMySQLSyncThread: Code: 1002, e.displayText() = DB::Exception: Master maybe lost, Stack trace (when copying this message, always include the lines below):

0. DB::MySQLReplication::MySQLFlavor::readPayloadImpl(DB::ReadBuffer&) @ 0xeacd587 in /usr/bin/clickhouse
1. DB::MySQLProtocol::IMySQLReadPacket::readPayload(DB::ReadBuffer&, unsigned char&) @ 0xeab2497 in /usr/bin/clickhouse
2. DB::MySQLProtocol::PacketEndpoint::tryReceivePacket(DB::MySQLProtocol::IMySQLReadPacket&, unsigned long) @ 0xeab2fa3 in /usr/bin/clickhouse
3. DB::MaterializeMySQLSyncThread::synchronization() @ 0xea807c8 in /usr/bin/clickhouse
4. ? @ 0xea9fa82 in /usr/bin/clickhouse
5. ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) @ 0x861580f in /usr/bin/clickhouse
6. ? @ 0x86192a3 in /usr/bin/clickhouse
7. start_thread @ 0x9609 in /usr/lib/x86_64-linux-gnu/libpthread-2.31.so
8. __clone @ 0x122293 in /usr/lib/x86_64-linux-gnu/libc-2.31.so
 (version 21.3.1.6058)
```

So let's see what mysqld logs will have

Cc: @zhang2014 
Cc: @BohuTANG 