### PR TITLE
Fix performance tests (by avoid sharing status file for right and left server)

### DIFF
--- a/docker/test/performance-comparison/compare.sh
+++ b/docker/test/performance-comparison/compare.sh
@@ -97,6 +97,7 @@ function configure
     rm -r right/db ||:
     rm -r db0/preprocessed_configs ||:
     rm -r db0/{data,metadata}/system ||:
+    rm db0/status ||:
     cp -al db0/ left/db/
     cp -al db0/ right/db/
 }


### PR DESCRIPTION
Since `cp -a`l (hard links):

    2021.02.21 01:09:09.991771 [ 243 ] {} <Information> StatusFile: Status file right/db/status already exists - unclean restart. Contents:
    PID: 241
    Started at: 2021-02-21 01:09:09
    Revision: 54448

    2021.02.21 01:09:09.992007 [ 243 ] {} <Error> Application: DB::Exception: Cannot lock file right/db/status. Another server instance in same directory is already running.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @akuzm 