### PR TITLE
Fix __has_feature macros under gcc

### DIFF
--- a/base/common/defines.h
+++ b/base/common/defines.h
@@ -2,10 +2,17 @@
 
 /// __has_feature supported only by clang.
 ///
-/// But libcxx/libcxxabi overrides it to 0, thus the checks for __has_feature will be wrong,
-/// undefine it again to avoid such issues.
-#if defined(__has_feature) && !defined(__clang__)
-#  undef __has_feature
+/// But libcxx/libcxxabi overrides it to 0,
+/// thus the checks for __has_feature will be wrong.
+///
+/// NOTE:
+/// - __has_feature cannot be simply undefined,
+///   since this will be broken if some C++ header will be included after
+///   including <common/defines.h>
+/// - it should not have fallback to 0,
+///   since this may create false-positive detection (common problem)
+#if defined(__clang__) && defined(__has_feature)
+#    define ch_has_feature __has_feature
 #endif
 
 #if defined(_MSC_VER)
@@ -40,8 +47,8 @@
 
 /// Check for presence of address sanitizer
 #if !defined(ADDRESS_SANITIZER)
-#    if defined(__has_feature)
-#        if __has_feature(address_sanitizer)
+#    if defined(ch_has_feature)
+#        if ch_has_feature(address_sanitizer)
 #            define ADDRESS_SANITIZER 1
 #        endif
 #    elif defined(__SANITIZE_ADDRESS__)
@@ -50,8 +57,8 @@
 #endif
 
 #if !defined(THREAD_SANITIZER)
-#    if defined(__has_feature)
-#        if __has_feature(thread_sanitizer)
+#    if defined(ch_has_feature)
+#        if ch_has_feature(thread_sanitizer)
 #            define THREAD_SANITIZER 1
 #        endif
 #    elif defined(__SANITIZE_THREAD__)
@@ -60,8 +67,8 @@
 #endif
 
 #if !defined(MEMORY_SANITIZER)
-#    if defined(__has_feature)
-#        if __has_feature(memory_sanitizer)
+#    if defined(ch_has_feature)
+#        if ch_has_feature(memory_sanitizer)
 #            define MEMORY_SANITIZER 1
 #        endif
 #    elif defined(__MEMORY_SANITIZER__)

--- a/base/common/defines.h
+++ b/base/common/defines.h
@@ -1,5 +1,13 @@
 #pragma once
 
+/// __has_feature supported only by clang.
+///
+/// But libcxx/libcxxabi overrides it to 0, thus the checks for __has_feature will be wrong,
+/// undefine it again to avoid such issues.
+#if defined(__has_feature) && !defined(__clang__)
+#  undef __has_feature
+#endif
+
 #if defined(_MSC_VER)
 #   if !defined(likely)
 #      define likely(x)   (x)

--- a/base/common/phdr_cache.cpp
+++ b/base/common/phdr_cache.cpp
@@ -15,11 +15,11 @@
 #endif
 
 #define __msan_unpoison(X, Y) // NOLINT
-#if defined(__has_feature)
-#   if __has_feature(memory_sanitizer)
-#       undef __msan_unpoison
-#       include <sanitizer/msan_interface.h>
-#   endif
+#if defined(ch_has_feature)
+#    if ch_has_feature(memory_sanitizer)
+#        undef __msan_unpoison
+#        include <sanitizer/msan_interface.h>
+#    endif
 #endif
 
 #include <link.h>

--- a/src/Common/MemorySanitizer.h
+++ b/src/Common/MemorySanitizer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <common/defines.h>
+
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreserved-id-macro"
@@ -9,14 +11,15 @@
 #define __msan_test_shadow(X, Y) (false)
 #define __msan_print_shadow(X, Y)
 #define __msan_unpoison_string(X)
-#if defined(__has_feature)
-#   if __has_feature(memory_sanitizer)
-#       undef __msan_unpoison
-#       undef __msan_test_shadow
-#       undef __msan_print_shadow
-#       undef __msan_unpoison_string
-#       include <sanitizer/msan_interface.h>
-#   endif
+
+#if defined(ch_has_feature)
+#    if ch_has_feature(memory_sanitizer)
+#        undef __msan_unpoison
+#        undef __msan_test_shadow
+#        undef __msan_print_shadow
+#        undef __msan_unpoison_string
+#        include <sanitizer/msan_interface.h>
+#    endif
 #endif
 
 #ifdef __clang__

--- a/src/Common/SymbolIndex.cpp
+++ b/src/Common/SymbolIndex.cpp
@@ -60,11 +60,11 @@ Otherwise you will get only exported symbols from program headers.
 #endif
 
 #define __msan_unpoison_string(X) // NOLINT
-#if defined(__has_feature)
-#   if __has_feature(memory_sanitizer)
-#       undef __msan_unpoison_string
-#       include <sanitizer/msan_interface.h>
-#   endif
+#if defined(ch_has_feature)
+#    if ch_has_feature(memory_sanitizer)
+#        undef __msan_unpoison_string
+#        include <sanitizer/msan_interface.h>
+#    endif
 #endif
 
 


### PR DESCRIPTION
__has_feature supported only by clang.

But libcxx/libcxxabi overrides it to 0:

    $ fgrep -r 'define __has_feature' contrib/libcxx*
    contrib/libcxx/include/__config:#define __has_feature(__x) 0
    contrib/libcxxabi/src/demangle/DemangleConfig.h:#define __has_feature(x) 0

Thus the checks for __has_feature will be wrong, undefine it again to
avoid such issues.

This will also fix building with sanitizers under gcc (before this patch
BOOST_USE_UCONTEXT wasn't set for sanitizers).

Changelog category (leave one):
- Not for changelog (changelog entry is not required)