### PR TITLE
Better kafka tests

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -868,6 +868,8 @@ services:
         cap_add:
             - SYS_PTRACE
             - NET_ADMIN
+            - IPC_LOCK
+            - SYS_NICE
         depends_on: {depends_on}
         user: '{user}'
         env_file:

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -1089,13 +1089,13 @@ class ClickHouseInstance:
 
         # if repetitions>1 grep will return success even if not enough lines were collected,
         if repetitions>1 and len(result.splitlines()) < repetitions:
-            print("wait_for_log_line: those lines were founded during {} sec.".format(timeout))
+            print("wait_for_log_line: those lines were found during {} seconds:".format(timeout))
             print(result)
             raise Exception("wait_for_log_line: Not enough repetitions: {} found, while {} expected".format(len(result.splitlines()), repetitions))
 
         wait_duration = time.time() - start_time
 
-        print('Log line matching "{}" appeared in a {} seconds'.format(regexp, wait_duration))
+        print('{} log line matching "{}" appeared in a {} seconds'.format(repetitions, regexp, wait_duration))
         return wait_duration
 
 

--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -2441,6 +2441,7 @@ def test_kafka_unavailable(kafka_cluster):
 
     instance.wait_for_log_line("Committed offset 2000")
     assert int(instance.query("SELECT count() FROM test.destination")) == 2000
+    time.sleep(5) # needed to give time for kafka client in python test to recovery
 
 @pytest.mark.timeout(180)
 def test_kafka_issue14202(kafka_cluster):


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove most of `sleep` commands from kafka integration tests, waiting for log events instead. Add test for different compression methods.

Detailed description / Documentation draft:
