### PR TITLE
Re-enable zookeeper.forceSync

### DIFF
--- a/docker/test/integration/runner/compose/docker_compose_zookeeper.yml
+++ b/docker/test/integration/runner/compose/docker_compose_zookeeper.yml
@@ -7,7 +7,6 @@ services:
             ZOO_TICK_TIME: 500
             ZOO_SERVERS: server.1=zoo1:2888:3888 server.2=zoo2:2888:3888 server.3=zoo3:2888:3888
             ZOO_MY_ID: 1
-            JVMFLAGS: -Dzookeeper.forceSync=no
         volumes:
             - type: ${ZK_FS:-tmpfs}
               source: ${ZK_DATA1:-}
@@ -22,7 +21,6 @@ services:
             ZOO_TICK_TIME: 500
             ZOO_SERVERS: server.1=zoo1:2888:3888 server.2=zoo2:2888:3888 server.3=zoo3:2888:3888
             ZOO_MY_ID: 2
-            JVMFLAGS: -Dzookeeper.forceSync=no
         volumes:
             - type: ${ZK_FS:-tmpfs}
               source: ${ZK_DATA2:-}
@@ -37,7 +35,6 @@ services:
             ZOO_TICK_TIME: 500
             ZOO_SERVERS: server.1=zoo1:2888:3888 server.2=zoo2:2888:3888 server.3=zoo3:2888:3888
             ZOO_MY_ID: 3
-            JVMFLAGS: -Dzookeeper.forceSync=no
         volumes:
             - type: ${ZK_FS:-tmpfs}
               source: ${ZK_DATA3:-}


### PR DESCRIPTION
It looks like it is not safe to use this option in case multi-server
setup, when zookeeper.forceSync=false I saw failures for distributed DDL
queries, when initiator cannot find the node (to detect if query was
finished) even if the node exists (checked in /datalog, via
system.zookeeper, and also logs that it hasn't been deleted by the
cleaner thread), and there are lots of the following errors in the log
for one of nodes (other nodes are fine):

    2021-02-25 05:45:50,560 [myid:3] - INFO  [ProcessThread(sid:3 cport:-1)::PrepRequestProcessor@653] - Got user-level KeeperException when processing sessionid:0x304670471140001 type:create cxid:0x53d zxid:0x100000708 txntype:-1 reqpath:n/a Error Path:/clickhouse Error:KeeperErrorCode = NodeExists for /clickhouse
    2021-02-25 05:45:50,562 [myid:3] - INFO  [ProcessThread(sid:3 cport:-1)::PrepRequestProcessor@653] - Got user-level KeeperException when processing sessionid:0x304670471140001 type:create cxid:0x540 zxid:0x10000070e txntype:-1 reqpath:n/a Error Path:/clickhouse/task_queue Error:KeeperErrorCode = NodeExists for /clickhouse/task_queue
    2021-02-25 05:45:50,563 [myid:3] - INFO  [ProcessThread(sid:3 cport:-1)::PrepRequestProcessor@653] - Got user-level KeeperException when processing sessionid:0x304670471140001 type:create cxid:0x542 zxid:0x100000710 txntype:-1 reqpath:n/a Error Path:/clickhouse/task_queue/ddl Error:KeeperErrorCode = NodeExists for /clickhouse/task_queue/ddl

While the clickhouse errors was the following (during stress testing
some version of test_distributed_ddl_parallel/test.py::test_smoke_parallel):

    Code: 341. DB::Exception: Received from 172.19.0.7:9000. DB::Exception: Cannot provide query execution status. The query's node /clickhouse/task_queue/ddl/query-0000000192 has been deleted by the cleaner since it was finished (or its lifetime is expired). Stack trace:

Refs: https://stackoverflow.com/a/61978504/328260

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @alesapin 
Refs: #11002