### PR TITLE
fix #21170

### DIFF
--- a/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
+++ b/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
@@ -43,7 +43,7 @@ struct CustomizeASTSelectWithUnionQueryNormalize
             return;
         }
 
-        selects.push_back(ast_select);
+        selects.push_back(std::move(ast_select));
     }
 
     void visit(ASTSelectWithUnionQuery & ast, ASTPtr &) const
@@ -76,10 +76,10 @@ struct CustomizeASTSelectWithUnionQueryNormalize
                     for (auto child = inner_union->list_of_selects->children.rbegin();
                          child != inner_union->list_of_selects->children.rend();
                          ++child)
-                        selects.push_back(*child);
+                        selects.push_back(std::move(*child));
                 }
                 else
-                    selects.push_back(select_list[i + 1]);
+                    selects.push_back(std::move(select_list[i + 1]));
             }
             /// flatten all left nodes and current node to a UNION DISTINCT list
             else if (union_modes[i] == ASTSelectWithUnionQuery::Mode::DISTINCT)
@@ -108,10 +108,10 @@ struct CustomizeASTSelectWithUnionQueryNormalize
                 /// Inner_union is an UNION ALL list, just lift it up
                 for (auto child = inner_union->list_of_selects->children.rbegin(); child != inner_union->list_of_selects->children.rend();
                      ++child)
-                    selects.push_back(*child);
+                    selects.push_back(std::move(*child));
             }
             else
-                selects.push_back(select_list[0]);
+                selects.push_back(std::move(select_list[0]));
         }
 
         // reverse children list

--- a/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
+++ b/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
@@ -43,7 +43,7 @@ struct CustomizeASTSelectWithUnionQueryNormalize
             return;
         }
 
-        selects.push_back(std::move(ast_select));
+        selects.push_back(ast_select);
     }
 
     void visit(ASTSelectWithUnionQuery & ast, ASTPtr &) const
@@ -53,9 +53,9 @@ struct CustomizeASTSelectWithUnionQueryNormalize
         auto & select_list = ast.list_of_selects->children;
 
         int i;
-        /// Rewrite UNION Mode
         for (i = union_modes.size() - 1; i >= 0; --i)
         {
+            /// Rewrite UNION Mode
             if (union_modes[i] == ASTSelectWithUnionQuery::Mode::Unspecified)
             {
                 if (union_default_mode == UnionMode::ALL)
@@ -67,10 +67,7 @@ struct CustomizeASTSelectWithUnionQueryNormalize
                         "Expected ALL or DISTINCT in SelectWithUnion query, because setting (union_default_mode) is empty",
                         DB::ErrorCodes::EXPECTED_ALL_OR_DISTINCT);
             }
-        }
 
-        for (i = union_modes.size() - 1; i >= 0; --i)
-        {
             if (union_modes[i] == ASTSelectWithUnionQuery::Mode::ALL)
             {
                 if (auto * inner_union = select_list[i + 1]->as<ASTSelectWithUnionQuery>())
@@ -79,10 +76,10 @@ struct CustomizeASTSelectWithUnionQueryNormalize
                     for (auto child = inner_union->list_of_selects->children.rbegin();
                          child != inner_union->list_of_selects->children.rend();
                          ++child)
-                        selects.push_back(std::move(*child));
+                        selects.push_back(*child);
                 }
                 else
-                    selects.push_back(std::move(select_list[i + 1]));
+                    selects.push_back(select_list[i + 1]);
             }
             /// flatten all left nodes and current node to a UNION DISTINCT list
             else if (union_modes[i] == ASTSelectWithUnionQuery::Mode::DISTINCT)
@@ -111,10 +108,10 @@ struct CustomizeASTSelectWithUnionQueryNormalize
                 /// Inner_union is an UNION ALL list, just lift it up
                 for (auto child = inner_union->list_of_selects->children.rbegin(); child != inner_union->list_of_selects->children.rend();
                      ++child)
-                    selects.push_back(std::move(*child));
+                    selects.push_back(*child);
             }
             else
-                selects.push_back(std::move(select_list[0]));
+                selects.push_back(select_list[0]);
         }
 
         // reverse children list

--- a/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
+++ b/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
@@ -53,9 +53,9 @@ struct CustomizeASTSelectWithUnionQueryNormalize
         auto & select_list = ast.list_of_selects->children;
 
         int i;
+        /// Rewrite UNION Mode
         for (i = union_modes.size() - 1; i >= 0; --i)
         {
-            /// Rewrite UNION Mode
             if (union_modes[i] == ASTSelectWithUnionQuery::Mode::Unspecified)
             {
                 if (union_default_mode == UnionMode::ALL)
@@ -67,7 +67,10 @@ struct CustomizeASTSelectWithUnionQueryNormalize
                         "Expected ALL or DISTINCT in SelectWithUnion query, because setting (union_default_mode) is empty",
                         DB::ErrorCodes::EXPECTED_ALL_OR_DISTINCT);
             }
+        }
 
+        for (i = union_modes.size() - 1; i >= 0; --i)
+        {
             if (union_modes[i] == ASTSelectWithUnionQuery::Mode::ALL)
             {
                 if (auto * inner_union = select_list[i + 1]->as<ASTSelectWithUnionQuery>())

--- a/tests/queries/0_stateless/01732_union_and_union_all.sql
+++ b/tests/queries/0_stateless/01732_union_and_union_all.sql
@@ -1,0 +1,1 @@
+select 1 UNION select 1 UNION ALL select 1; -- { serverError 558 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Detailed description / Documentation draft:

the #21170 root cause:
1. The elements of list_of_selects is validated and moved to new selects lists
2. There is an validation error during the scan, some elements of list_of_selects is moved already
3. In error handling, the error message is printed with AST.format message
4. AST.format will scan the list_of_selects again, finding the moved elements are already unavailable

This fix will validate the list_of_selects for the first loop, and then scan and move on the second loop. The extra loop is low-cost.
