### PR TITLE
Fix broken links in "See Also"

### DIFF
--- a/docs/en/sql-reference/statements/alter/ttl.md
+++ b/docs/en/sql-reference/statements/alter/ttl.md
@@ -81,5 +81,5 @@ The `TTL` is no longer there, so the second row is not deleted:
 
 ### See Also
 
-- More about the [TTL-expression](../../../sql-reference/statements/create/table#ttl-expression).
-- Modify column [with TTL](../../../sql-reference/statements/alter/column#alter_modify-column).
+- More about the [TTL-expression](../../../../sql-reference/statements/create/table#ttl-expression).
+- Modify column [with TTL](../../../../sql-reference/statements/alter/column#alter_modify-column).


### PR DESCRIPTION
These links relative addressing was wrong. For example first one was transformed into "https://clickhouse.tech/docs/en/sql-reference/sql-reference/statements/create/table#ttl-expression" which did not exist and got 404.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)
