### PR TITLE
Fixed output to compressed table functions -- Better fix for #13871

### DIFF
--- a/src/IO/BrotliWriteBuffer.h
+++ b/src/IO/BrotliWriteBuffer.h
@@ -22,6 +22,7 @@ public:
 
 private:
     void nextImpl() override;
+    void finalize() override { out->finalize(); }
 
     void finish();
     void finishImpl();

--- a/src/IO/BrotliWriteBuffer.h
+++ b/src/IO/BrotliWriteBuffer.h
@@ -18,14 +18,10 @@ public:
 
     ~BrotliWriteBuffer() override;
 
-    void finalize() override { finish(); }
+    void finalize() override;
 
 private:
     void nextImpl() override;
-    void finalize() override { out->finalize(); }
-
-    void finish();
-    void finishImpl();
 
     class BrotliStateWrapper;
     std::unique_ptr<BrotliStateWrapper> brotli;
@@ -37,8 +33,6 @@ private:
     uint8_t * out_data;
 
     std::unique_ptr<WriteBuffer> out;
-
-    bool finished = false;
 };
 
 }

--- a/src/IO/LZMADeflatingWriteBuffer.h
+++ b/src/IO/LZMADeflatingWriteBuffer.h
@@ -24,20 +24,13 @@ public:
         char * existing_memory = nullptr,
         size_t alignment = 0);
 
-    void finalize() override { finish(); }
-
-    ~LZMADeflatingWriteBuffer() override;
+    void finalize() override;
 
 private:
     void nextImpl() override;
-    void finalize() override { out->finalize(); }
-
-    void finish();
-    void finishImpl();
 
     std::unique_ptr<WriteBuffer> out;
     lzma_stream lstr;
-    bool finished = false;
 };
 
 #else

--- a/src/IO/LZMADeflatingWriteBuffer.h
+++ b/src/IO/LZMADeflatingWriteBuffer.h
@@ -30,6 +30,7 @@ public:
 
 private:
     void nextImpl() override;
+    void finalize() override { out->finalize(); }
 
     void finish();
     void finishImpl();

--- a/src/IO/WriteBufferFromS3.cpp
+++ b/src/IO/WriteBufferFromS3.cpp
@@ -81,13 +81,6 @@ void WriteBufferFromS3::finalize()
 {
     /// FIXME move final flush into the caller
     MemoryTracker::LockExceptionInThread lock;
-    finalizeImpl();
-}
-
-void WriteBufferFromS3::finalizeImpl()
-{
-    if (finalized)
-        return;
 
     next();
 
@@ -101,13 +94,18 @@ void WriteBufferFromS3::finalizeImpl()
         writePart();
         completeMultipartUpload();
     }
-
-    finalized = true;
 }
 
 WriteBufferFromS3::~WriteBufferFromS3()
 {
-    finalizeImpl();
+    try
+    {
+        next();
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+    }
 }
 
 void WriteBufferFromS3::createMultipartUpload()

--- a/src/IO/WriteBufferFromS3.h
+++ b/src/IO/WriteBufferFromS3.h
@@ -67,15 +67,11 @@ public:
     ~WriteBufferFromS3() override;
 
 private:
-    bool finalized = false;
-
     void createMultipartUpload();
     void writePart();
     void completeMultipartUpload();
 
     void makeSinglepartUpload();
-
-    void finalizeImpl();
 };
 
 }

--- a/src/IO/ZlibDeflatingWriteBuffer.h
+++ b/src/IO/ZlibDeflatingWriteBuffer.h
@@ -22,23 +22,16 @@ public:
             char * existing_memory = nullptr,
             size_t alignment = 0);
 
-    void finalize() override { finish(); }
-
-    ~ZlibDeflatingWriteBuffer() override;
-
-private:
-    void nextImpl() override;
-    void finalize() override { out->finalize(); }
-
-    void finishImpl();
     /// Flush all pending data and write zlib footer to the underlying buffer.
     /// After the first call to this function, subsequent calls will have no effect and
     /// an attempt to write to this buffer will result in exception.
-    void finish();
+    void finalize() override;
+
+private:
+    void nextImpl() override;
 
     std::unique_ptr<WriteBuffer> out;
     z_stream zstr;
-    bool finished = false;
 };
 
 }

--- a/src/IO/ZlibDeflatingWriteBuffer.h
+++ b/src/IO/ZlibDeflatingWriteBuffer.h
@@ -28,6 +28,7 @@ public:
 
 private:
     void nextImpl() override;
+    void finalize() override { out->finalize(); }
 
     void finishImpl();
     /// Flush all pending data and write zlib footer to the underlying buffer.

--- a/src/IO/ZstdDeflatingWriteBuffer.h
+++ b/src/IO/ZstdDeflatingWriteBuffer.h
@@ -20,25 +20,20 @@ public:
         char * existing_memory = nullptr,
         size_t alignment = 0);
 
-    void finalize() override { finish(); }
+    /// Flush all pending data and write zstd footer to the underlying buffer.
+    /// After the first call to this function, subsequent calls will have no effect and
+    /// an attempt to write to this buffer will result in exception.
+    void finalize() override;
 
     ~ZstdDeflatingWriteBuffer() override;
 
 private:
     void nextImpl() override;
-    void finalize() override { out->finalize(); }
-
-    /// Flush all pending data and write zstd footer to the underlying buffer.
-    /// After the first call to this function, subsequent calls will have no effect and
-    /// an attempt to write to this buffer will result in exception.
-    void finish();
-    void finishImpl();
 
     std::unique_ptr<WriteBuffer> out;
     ZSTD_CCtx * cctx;
     ZSTD_inBuffer input;
     ZSTD_outBuffer output;
-    bool finished = false;
 };
 
 }

--- a/src/IO/ZstdDeflatingWriteBuffer.h
+++ b/src/IO/ZstdDeflatingWriteBuffer.h
@@ -26,6 +26,7 @@ public:
 
 private:
     void nextImpl() override;
+    void finalize() override { out->finalize(); }
 
     /// Flush all pending data and write zstd footer to the underlying buffer.
     /// After the first call to this function, subsequent calls will have no effect and

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -530,6 +530,7 @@ public:
     void writeSuffix() override
     {
         writer->writeSuffix();
+        write_buf->finalize();
     }
 
     void flush() override

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -110,12 +110,13 @@ def run_query(instance, query, stdin=None, settings=None):
 
 
 # Test simple put.
-@pytest.mark.parametrize("maybe_auth,positive", [
-    ("", True),
-    ("'minio','minio123',", True),
-    ("'wrongid','wrongkey',", False)
+@pytest.mark.parametrize("maybe_auth,positive,compression", [
+    ("", True, 'auto'),
+    ("'minio','minio123',", True, 'auto'),
+    ("'wrongid','wrongkey',", False, 'auto'),
+    ("'wrongid','wrongkey',", False, 'gzip')
 ])
-def test_put(cluster, maybe_auth, positive):
+def test_put(cluster, maybe_auth, positive, compression):
     # type: (ClickHouseCluster) -> None
 
     bucket = cluster.minio_bucket if not maybe_auth else cluster.minio_restricted_bucket
@@ -124,8 +125,8 @@ def test_put(cluster, maybe_auth, positive):
     values = "(1, 2, 3), (3, 2, 1), (78, 43, 45)"
     values_csv = "1,2,3\n3,2,1\n78,43,45\n"
     filename = "test.csv"
-    put_query = "insert into table function s3('http://{}:{}/{}/{}', {}'CSV', '{}') values {}".format(
-        cluster.minio_host, cluster.minio_port, bucket, filename, maybe_auth, table_format, values)
+    put_query = f"""insert into table function s3('http://{cluster.minio_host}:{cluster.minio_port}/{bucket}/{filename}',
+                    {maybe_auth}'CSV', '{table_format}', {compression}) values {values}"""
 
     try:
         run_query(instance, put_query)

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -109,12 +109,16 @@ def run_query(instance, query, stdin=None, settings=None):
     return result
 
 
-# Test simple put.
+# Test simple put. Also checks that wrong credentials produce an error with every compression method.
 @pytest.mark.parametrize("maybe_auth,positive,compression", [
     ("", True, 'auto'),
     ("'minio','minio123',", True, 'auto'),
     ("'wrongid','wrongkey',", False, 'auto'),
-    ("'wrongid','wrongkey',", False, 'gzip')
+    ("'wrongid','wrongkey',", False, 'gzip'),
+    ("'wrongid','wrongkey',", False, 'deflate'),
+    ("'wrongid','wrongkey',", False, 'brotli'),
+    ("'wrongid','wrongkey',", False, 'xz'),
+    ("'wrongid','wrongkey',", False, 'zstd')
 ])
 def test_put(cluster, maybe_auth, positive, compression):
     # type: (ClickHouseCluster) -> None


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixed output to compressed table functions -- Better fix for #13871, reverts #15376