### PR TITLE
Skip mutations of unrelated partitions in `StorageMergeTree`

### DIFF
--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -1072,7 +1072,7 @@ Int64 StorageMergeTree::getUpdatedDataVersion(
 {
     auto it = updated_version_by_block_range.find(std::make_pair(part->info.min_block, part->info.max_block));
     if (it != updated_version_by_block_range.end())
-        return std::max(part->info.getDataVersion(), it->second);
+        return std::max(part->info.getDataVersion(), static_cast<Int64>(it->second));
     else
         return part->info.getDataVersion();
 }
@@ -1118,7 +1118,7 @@ size_t StorageMergeTree::clearOldMutations(bool truncate)
 
             for (auto it = begin_it; it != end_it; ++it)
             {
-                const PartVersionWithName needle{it->first, ""};
+                const PartVersionWithName needle{static_cast<Int64>(it->first), ""};
                 auto versions_it = std::lower_bound(
                     part_versions_with_names.begin(), part_versions_with_names.end(), needle);
 

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -981,6 +981,15 @@ std::shared_ptr<MergeMutateSelectedEntry> StorageMergeTree::selectPartsToMutate(
                 continue;
             }
 
+            if (!is_partition_affected)
+            {
+                /// Shall not create a new part, but will do that later if mutation with higher version appear.
+                auto block_range = std::make_pair(part->info.min_block, part->info.max_block);
+                updated_version_by_block_range[block_range] = current_mutations_by_version.rbegin()->first;
+                commands.clear();
+                continue;
+            }
+
             auto new_part_info = part->info;
             new_part_info.mutation = current_mutations_by_version.rbegin()->first;
 

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -937,7 +937,7 @@ std::shared_ptr<MergeMutateSelectedEntry> StorageMergeTree::selectPartsToMutate(
         if (!commands->empty())
         {
             bool is_partition_affected = false;
-            for (const auto & command : commands)
+            for (const auto & command : *commands)
             {
                 if (command.partition == nullptr)
                 {

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -977,6 +977,7 @@ std::shared_ptr<MergeMutateSelectedEntry> StorageMergeTree::selectPartsToMutate(
             if (!is_partition_affected)
             {
                 /// Shall not create a new part, but will do that later if mutation with higher version appear.
+                /// This is needed in order to not produce excessive mutations of non-related parts.
                 auto block_range = std::make_pair(part->info.min_block, part->info.max_block);
                 updated_version_by_block_range[block_range] = current_mutations_by_version.rbegin()->first;
                 are_some_mutations_for_some_parts_skipped = true;

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -978,14 +978,6 @@ std::shared_ptr<MergeMutateSelectedEntry> StorageMergeTree::selectPartsToMutate(
                 /// Shall not create a new part, but will do that later if mutation with higher version appear.
                 auto block_range = std::make_pair(part->info.min_block, part->info.max_block);
                 updated_version_by_block_range[block_range] = current_mutations_by_version.rbegin()->first;
-                continue;
-            }
-
-            if (!is_partition_affected)
-            {
-                /// Shall not create a new part, but will do that later if mutation with higher version appear.
-                auto block_range = std::make_pair(part->info.min_block, part->info.max_block);
-                updated_version_by_block_range[block_range] = current_mutations_by_version.rbegin()->first;
                 commands.clear();
                 continue;
             }

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -1130,7 +1130,7 @@ size_t StorageMergeTree::clearOldMutations(bool truncate)
             }
 
             if (done_count <= settings->finished_mutations_to_keep)
-                return;
+                return 0;
 
             to_delete_count = done_count - settings->finished_mutations_to_keep;
         }

--- a/src/Storages/StorageMergeTree.h
+++ b/src/Storages/StorageMergeTree.h
@@ -132,6 +132,10 @@ private:
     DataParts currently_merging_mutating_parts;
 
     std::map<UInt64, MergeTreeMutationEntry> current_mutations_by_version;
+
+    /// We store information about lazy mutations for each part. The value is a maximum version
+    /// for a part which will be the same as his current version, that is, to which version it
+    /// can be upgraded without any change.
     std::map<std::pair<Int64, Int64>, Int64> updated_version_by_block_range;
 
     std::atomic<bool> shutdown_called {false};

--- a/src/Storages/StorageMergeTree.h
+++ b/src/Storages/StorageMergeTree.h
@@ -136,7 +136,7 @@ private:
     /// We store information about mutations which are not applicable to the partition of each part.
     /// The value is a maximum version for a part which will be the same as his current version,
     /// that is, to which version it can be upgraded without any change.
-    std::map<std::pair<Int64, Int64>, Int64> updated_version_by_block_range;
+    std::map<std::pair<Int64, Int64>, UInt64> updated_version_by_block_range;
 
     std::atomic<bool> shutdown_called {false};
 

--- a/src/Storages/StorageMergeTree.h
+++ b/src/Storages/StorageMergeTree.h
@@ -167,6 +167,17 @@ private:
 
     friend struct CurrentlyMergingPartsTagger;
 
+    struct PartVersionWithName
+    {
+        Int64 version;
+        String name;
+
+        bool operator <(const PartVersionWithName & s) const
+        {
+            return version < s.version;
+        }
+    };
+
     std::shared_ptr<MergeMutateSelectedEntry> selectPartsToMerge(
         const StorageMetadataPtr & metadata_snapshot,
         bool aggressive,
@@ -190,6 +201,8 @@ private:
         std::unique_lock<std::mutex> & /* currently_processing_in_background_mutex_lock */) const;
 
     size_t clearOldMutations(bool truncate = false);
+
+    std::vector<PartVersionWithName> getSortedPartVersionsWithNames(std::unique_lock<std::mutex> & /* currently_processing_in_background_mutex_lock */) const;
 
     // Partition helpers
     void dropPartNoWaitNoThrow(const String & part_name) override;

--- a/src/Storages/StorageMergeTree.h
+++ b/src/Storages/StorageMergeTree.h
@@ -133,9 +133,9 @@ private:
 
     std::map<UInt64, MergeTreeMutationEntry> current_mutations_by_version;
 
-    /// We store information about lazy mutations for each part. The value is a maximum version
-    /// for a part which will be the same as his current version, that is, to which version it
-    /// can be upgraded without any change.
+    /// We store information about mutations which are not applicable to the partition of each part.
+    /// The value is a maximum version for a part which will be the same as his current version,
+    /// that is, to which version it can be upgraded without any change.
     std::map<std::pair<Int64, Int64>, Int64> updated_version_by_block_range;
 
     std::atomic<bool> shutdown_called {false};

--- a/src/Storages/StorageMergeTree.h
+++ b/src/Storages/StorageMergeTree.h
@@ -167,7 +167,6 @@ private:
 
     friend struct CurrentlyMergingPartsTagger;
 
-
     std::shared_ptr<MergeMutateSelectedEntry> selectPartsToMerge(
         const StorageMetadataPtr & metadata_snapshot,
         bool aggressive,
@@ -180,7 +179,7 @@ private:
         SelectPartsDecision * select_decision_out = nullptr);
 
 
-    std::shared_ptr<MergeMutateSelectedEntry> selectPartsToMutate(const StorageMetadataPtr & metadata_snapshot, String * disable_reason, TableLockHolder & table_lock_holder, std::unique_lock<std::mutex> & currently_processing_in_background_mutex_lock);
+    std::shared_ptr<MergeMutateSelectedEntry> selectPartsToMutate(const StorageMetadataPtr & metadata_snapshot, String * disable_reason, TableLockHolder & table_lock_holder, std::unique_lock<std::mutex> & currently_processing_in_background_mutex_lock, bool & were_some_mutations_for_some_parts_skipped);
 
     Int64 getCurrentMutationVersion(
         const DataPartPtr & part,

--- a/src/Storages/StorageMergeTree.h
+++ b/src/Storages/StorageMergeTree.h
@@ -132,6 +132,7 @@ private:
     DataParts currently_merging_mutating_parts;
 
     std::map<UInt64, MergeTreeMutationEntry> current_mutations_by_version;
+    std::map<std::pair<Int64, Int64>, Int64> updated_version_by_block_range;
 
     std::atomic<bool> shutdown_called {false};
 
@@ -178,6 +179,10 @@ private:
     std::shared_ptr<MergeMutateSelectedEntry> selectPartsToMutate(const StorageMetadataPtr & metadata_snapshot, String * disable_reason, TableLockHolder & table_lock_holder);
 
     Int64 getCurrentMutationVersion(
+        const DataPartPtr & part,
+        std::unique_lock<std::mutex> & /* currently_processing_in_background_mutex_lock */) const;
+
+    Int64 getUpdatedDataVersion(
         const DataPartPtr & part,
         std::unique_lock<std::mutex> & /* currently_processing_in_background_mutex_lock */) const;
 

--- a/src/Storages/StorageMergeTree.h
+++ b/src/Storages/StorageMergeTree.h
@@ -180,7 +180,7 @@ private:
         SelectPartsDecision * select_decision_out = nullptr);
 
 
-    std::shared_ptr<MergeMutateSelectedEntry> selectPartsToMutate(const StorageMetadataPtr & metadata_snapshot, String * disable_reason, TableLockHolder & table_lock_holder);
+    std::shared_ptr<MergeMutateSelectedEntry> selectPartsToMutate(const StorageMetadataPtr & metadata_snapshot, String * disable_reason, TableLockHolder & table_lock_holder, std::unique_lock<std::mutex> & currently_processing_in_background_mutex_lock);
 
     Int64 getCurrentMutationVersion(
         const DataPartPtr & part,

--- a/tests/integration/test_mutations_in_partitions_of_merge_tree/test.py
+++ b/tests/integration/test_mutations_in_partitions_of_merge_tree/test.py
@@ -51,6 +51,7 @@ def test_trivial_alter_in_partition_merge_tree_with_where(started_cluster):
         node1.query("CREATE TABLE {} (p Int64, x Int64) ENGINE=MergeTree() ORDER BY tuple() PARTITION BY p".format(name))
         node1.query("INSERT INTO {} VALUES (1, 2), (2, 3)".format(name))
         node1.query("ALTER TABLE {} UPDATE x = x + 1 IN PARTITION 2 WHERE p = 2 SETTINGS mutations_sync = 2".format(name))
+        assert node1.query("SELECT x FROM {} ORDER BY p".format(name)).splitlines() == ["2", "4"]
         assert node1.query("SELECT sum(x) FROM {}".format(name)).splitlines() == ["6"]
         node1.query("ALTER TABLE {} UPDATE x = x + 1 IN PARTITION 1 WHERE p = 2 SETTINGS mutations_sync = 2".format(name))
         assert node1.query("SELECT sum(x) FROM {}".format(name)).splitlines() == ["6"]

--- a/tests/integration/test_mutations_with_merge_tree/test.py
+++ b/tests/integration/test_mutations_with_merge_tree/test.py
@@ -22,6 +22,78 @@ def started_cluster():
         cluster.shutdown()
 
 
+def test_mutations_in_partition_background(started_cluster):
+    try:
+        numbers = 10 # FIXME too many mutations (66) simultaneously will stuck ClickHouse
+
+        name = "test_mutations_in_partition"
+        instance_test_mutations.query(
+            f'''CREATE TABLE {name} (date Date, a UInt64, b String) ENGINE = MergeTree() ORDER BY tuple() PARTITION BY a''')
+        instance_test_mutations.query(
+            f'''INSERT INTO {name} SELECT '2019-07-29' AS date, number, toString(number) FROM numbers({numbers})''')
+
+        for i in range(0, numbers, 3):
+            instance_test_mutations.query(f'''ALTER TABLE {name} DELETE IN PARTITION {i} WHERE a = {i}''')
+
+        for i in range(1, numbers, 3):
+            instance_test_mutations.query(f'''ALTER TABLE {name} UPDATE b = 'changed' IN PARTITION {i} WHERE a = {i} ''')
+
+        def count_and_changed():
+            return instance_test_mutations.query(f"SELECT count(), countIf(b == 'changed') FROM {name} SETTINGS force_index_by_date = 0, force_primary_key = 0 FORMAT CSV").splitlines()
+
+        all_done = False
+        for wait_times_for_mutation in range(100):  # wait for replication 80 seconds max
+            time.sleep(0.8)
+
+            if count_and_changed() == ["6,3"]:
+                all_done = True
+                break
+
+        print(instance_test_mutations.query(
+            f"SELECT mutation_id, command, parts_to_do, is_done, latest_failed_part, latest_fail_reason FROM system.mutations WHERE table = '{name}' SETTINGS force_index_by_date = 0, force_primary_key = 0 FORMAT TSVWithNames"))
+
+        assert (count_and_changed(), all_done) == (["6,3"], True)
+        assert instance_test_mutations.query(f"SELECT count(), sum(is_done) FROM system.mutations WHERE table = '{name}' SETTINGS force_index_by_date = 0, force_primary_key = 0 FORMAT CSV").splitlines() == ["7,7"]
+
+    finally:
+        instance_test_mutations.query(f'''DROP TABLE {name}''')
+
+
+@pytest.mark.parametrize("sync", [
+    ("last",),
+    ("all",)
+])
+def test_mutations_in_partition_sync(started_cluster, sync):
+    try:
+        numbers = 10 # FIXME too many mutations (66) simultaneously will stuck ClickHouse
+
+        name = "test_mutations_in_partition_sync"
+        instance_test_mutations.query(
+            f'''CREATE TABLE {name} (date Date, a UInt64, b String) ENGINE = MergeTree() ORDER BY tuple() PARTITION BY a''')
+        instance_test_mutations.query(
+            f'''INSERT INTO {name} SELECT '2019-07-29' AS date, number, toString(number) FROM numbers({numbers})''')
+
+        for i in range(0, numbers, 3):
+            instance_test_mutations.query(f'''ALTER TABLE {name} DELETE IN PARTITION {i} WHERE a = {i}'''
+                                          + (' SETTINGS mutations_sync = 1' if sync == 'all' else ''))
+
+        for reverse_index, i in reversed(list(enumerate(reversed(range(1, numbers, 3))))):
+            instance_test_mutations.query(f'''ALTER TABLE {name} UPDATE b = 'changed' IN PARTITION {i} WHERE a = {i}'''
+                                          + (' SETTINGS mutations_sync = 1' if not reverse_index or sync == 'all' else ''))
+
+        def count_and_changed():
+            return instance_test_mutations.query(f"SELECT count(), countIf(b == 'changed') FROM {name} SETTINGS force_index_by_date = 0, force_primary_key = 0 FORMAT CSV").splitlines()
+
+        print(instance_test_mutations.query(
+            f"SELECT mutation_id, command, parts_to_do, is_done, latest_failed_part, latest_fail_reason FROM system.mutations WHERE table = '{name}' SETTINGS force_index_by_date = 0, force_primary_key = 0 FORMAT TSVWithNames"))
+
+        assert count_and_changed() == ["6,3"]
+        assert instance_test_mutations.query(f"SELECT count(), sum(is_done) FROM system.mutations WHERE table = '{name}' SETTINGS force_index_by_date = 0, force_primary_key = 0 FORMAT CSV").splitlines() == ["7,7"]
+
+    finally:
+        instance_test_mutations.query(f'''DROP TABLE {name}''')
+
+
 def test_mutations_with_merge_background_task(started_cluster):
     instance_test_mutations.query('''SYSTEM STOP MERGES test_mutations_with_ast_elements''')
 

--- a/tests/integration/test_mutations_with_merge_tree/test.py
+++ b/tests/integration/test_mutations_with_merge_tree/test.py
@@ -24,7 +24,7 @@ def started_cluster():
 
 def test_mutations_in_partition_background(started_cluster):
     try:
-        numbers = 100 # FIXME too many mutations (66) simultaneously will stuck ClickHouse
+        numbers = 100
 
         name = "test_mutations_in_partition"
         instance_test_mutations.query(
@@ -65,7 +65,7 @@ def test_mutations_in_partition_background(started_cluster):
 ])
 def test_mutations_in_partition_sync(started_cluster, sync):
     try:
-        numbers = 10 # FIXME too many mutations (66) simultaneously will stuck ClickHouse
+        numbers = 10
 
         name = "test_mutations_in_partition_sync"
         instance_test_mutations.query(
@@ -132,3 +132,37 @@ def test_mutations_with_truncate_table(started_cluster):
     instance_test_mutations.query("TRUNCATE TABLE test_mutations_with_ast_elements")
     assert instance_test_mutations.query(
         "SELECT COUNT() FROM system.mutations WHERE table = 'test_mutations_with_ast_elements SETTINGS force_index_by_date = 0, force_primary_key = 0'").rstrip() == '0'
+
+
+def test_mutations_will_not_hang_for_non_existing_parts(started_cluster):
+    try:
+        numbers = 100
+
+        name = "test_mutations_will_not_hang_for_non_existing_parts"
+        instance_test_mutations.query(
+            f"""CREATE TABLE {name} (date Date, a UInt64, b String) ENGINE = MergeTree() ORDER BY tuple() PARTITION BY a""")
+        instance_test_mutations.query(
+            f"""INSERT INTO {name} SELECT '2019-07-29' AS date, number, toString(number) FROM numbers({numbers})""")
+
+        for i in range(0, numbers, 3):
+            instance_test_mutations.query(f"""ALTER TABLE {name} DELETE IN PARTITION {i} WHERE a = {i} SETTINGS mutations_sync = 1""")
+
+        def count():
+            return instance_test_mutations.query(f"SELECT count() FROM {name} SETTINGS force_index_by_date = 0, force_primary_key = 0 FORMAT CSV").splitlines()
+
+        all_done = False
+        for wait_times_for_mutation in range(100):  # wait for replication 80 seconds max
+            time.sleep(0.8)
+
+            if count == ["66"]:
+                all_done = True
+                break
+
+        print(instance_test_mutations.query(
+            f"SELECT mutation_id, command, parts_to_do, is_done, latest_failed_part, latest_fail_reason, parts_to_do_names FROM system.mutations WHERE table = '{name}' SETTINGS force_index_by_date = 0, force_primary_key = 0 FORMAT TSVWithNames"))
+
+        assert (count(), all_done) == (["66"], True)
+        assert instance_test_mutations.query(f"SELECT count(), sum(is_done) FROM system.mutations WHERE table = '{name}' SETTINGS force_index_by_date = 0, force_primary_key = 0 FORMAT CSV").splitlines() == ["34,34"]
+
+    finally:
+        instance_test_mutations.query(f"""DROP TABLE {name}""")

--- a/tests/integration/test_mutations_with_merge_tree/test.py
+++ b/tests/integration/test_mutations_with_merge_tree/test.py
@@ -24,7 +24,7 @@ def started_cluster():
 
 def test_mutations_in_partition_background(started_cluster):
     try:
-        numbers = 10 # FIXME too many mutations (66) simultaneously will stuck ClickHouse
+        numbers = 100 # FIXME too many mutations (66) simultaneously will stuck ClickHouse
 
         name = "test_mutations_in_partition"
         instance_test_mutations.query(
@@ -45,15 +45,15 @@ def test_mutations_in_partition_background(started_cluster):
         for wait_times_for_mutation in range(100):  # wait for replication 80 seconds max
             time.sleep(0.8)
 
-            if count_and_changed() == ["6,3"]:
+            if count_and_changed() == ["66,33"]:
                 all_done = True
                 break
 
         print(instance_test_mutations.query(
-            f"SELECT mutation_id, command, parts_to_do, is_done, latest_failed_part, latest_fail_reason FROM system.mutations WHERE table = '{name}' SETTINGS force_index_by_date = 0, force_primary_key = 0 FORMAT TSVWithNames"))
+            f"SELECT mutation_id, command, parts_to_do, is_done, latest_failed_part, latest_fail_reason, parts_to_do_names FROM system.mutations WHERE table = '{name}' SETTINGS force_index_by_date = 0, force_primary_key = 0 FORMAT TSVWithNames"))
 
-        assert (count_and_changed(), all_done) == (["6,3"], True)
-        assert instance_test_mutations.query(f"SELECT count(), sum(is_done) FROM system.mutations WHERE table = '{name}' SETTINGS force_index_by_date = 0, force_primary_key = 0 FORMAT CSV").splitlines() == ["7,7"]
+        assert (count_and_changed(), all_done) == (["66,33"], True)
+        assert instance_test_mutations.query(f"SELECT count(), sum(is_done) FROM system.mutations WHERE table = '{name}' SETTINGS force_index_by_date = 0, force_primary_key = 0 FORMAT CSV").splitlines() == ["67,67"]
 
     finally:
         instance_test_mutations.query(f'''DROP TABLE {name}''')


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Skipping mutations of different partitions in `StorageMergeTree`.
