### PR TITLE
[WIP] Add GRANTED BY clause

### DIFF
--- a/src/Access/AccessRights.h
+++ b/src/Access/AccessRights.h
@@ -30,7 +30,7 @@ public:
     String toString() const;
 
     /// Returns the information about all the access granted.
-    AccessRightsElementsWithOptions getElements() const;
+    AccessRightsElements getElements() const;
 
     /// Grants access on a specified database/table/column.
     /// Does nothing if the specified access has been already granted.
@@ -49,8 +49,6 @@ public:
     void grantWithGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column);
     void grantWithGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns);
     void grantWithGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns);
-    void grantWithGrantOption(const AccessRightsElement & element);
-    void grantWithGrantOption(const AccessRightsElements & elements);
 
     /// Revokes a specified access granted earlier on a specified database/table/column.
     /// For example, revoke(AccessType::ALL) revokes all grants at all, just like clear();
@@ -69,8 +67,6 @@ public:
     void revokeGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column);
     void revokeGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns);
     void revokeGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns);
-    void revokeGrantOption(const AccessRightsElement & element);
-    void revokeGrantOption(const AccessRightsElements & elements);
 
     /// Whether a specified access granted.
     bool isGranted(const AccessFlags & flags) const;
@@ -88,8 +84,6 @@ public:
     bool hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column) const;
     bool hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns) const;
     bool hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) const;
-    bool hasGrantOption(const AccessRightsElement & element) const;
-    bool hasGrantOption(const AccessRightsElements & elements) const;
 
     /// Merges two sets of access rights together.
     /// It's used to combine access rights from multiple roles.
@@ -119,11 +113,8 @@ private:
     template <bool with_grant_option, typename... Args>
     void grantImpl(const AccessFlags & flags, const Args &... args);
 
-    template <bool with_grant_options>
+    template <bool with_grant_option>
     void grantImpl(const AccessRightsElement & element);
-
-    template <bool with_grant_options>
-    void grantImpl(const AccessRightsElements & elements);
 
     template <bool grant_option, typename... Args>
     void revokeImpl(const AccessFlags & flags, const Args &... args);
@@ -131,16 +122,12 @@ private:
     template <bool grant_option>
     void revokeImpl(const AccessRightsElement & element);
 
-    template <bool grant_option>
-    void revokeImpl(const AccessRightsElements & elements);
-
     template <bool grant_option, typename... Args>
     bool isGrantedImpl(const AccessFlags & flags, const Args &... args) const;
 
     template <bool grant_option>
     bool isGrantedImpl(const AccessRightsElement & element) const;
 
-    template <bool grant_option>
     bool isGrantedImpl(const AccessRightsElements & elements) const;
 
     void logTree() const;

--- a/src/Access/AccessRightsElement.cpp
+++ b/src/Access/AccessRightsElement.cpp
@@ -1,169 +1,137 @@
 #include <Access/AccessRightsElement.h>
-#include <Dictionaries/IDictionary.h>
 #include <Common/quoteString.h>
-#include <boost/range/algorithm/sort.hpp>
-#include <boost/range/algorithm/unique.hpp>
-#include <boost/range/algorithm_ext/is_sorted.hpp>
-#include <boost/range/algorithm_ext/erase.hpp>
-#include <boost/range/algorithm_ext/push_back.hpp>
 
 
 namespace DB
 {
 namespace
 {
-    using Kind = AccessRightsElementWithOptions::Kind;
-
-    String formatOptions(bool grant_option, Kind kind, const String & inner_part)
+    void formatColumnNames(const Strings & columns, String & result)
     {
-        if (kind == Kind::REVOKE)
+        result += "(";
+        bool need_comma = false;
+        for (const auto & column : columns)
         {
-            if (grant_option)
-                return "REVOKE GRANT OPTION " + inner_part;
-            else
-                return "REVOKE " + inner_part;
+            if (need_comma)
+                result += ", ";
+            need_comma = true;
+            result += backQuoteIfNeed(column);
         }
-        else
-        {
-            if (grant_option)
-                return "GRANT " + inner_part + " WITH GRANT OPTION";
-            else
-                return "GRANT " + inner_part;
-        }
+        result += ")";
     }
 
-
-    String formatONClause(const String & database, bool any_database, const String & table, bool any_table)
+    void formatONClause(const String & database, bool any_database, const String & table, bool any_table, String & result)
     {
-        String msg = "ON ";
-
+        result += " ON ";
         if (any_database)
-            msg += "*.";
+            result += "*";
         else if (!database.empty())
-            msg += backQuoteIfNeed(database) + ".";
+            result += backQuoteIfNeed(database);
 
+        result += ".";
         if (any_table)
-            msg += "*";
+            result += "*";
         else
-            msg += backQuoteIfNeed(table);
-        return msg;
+            result += backQuoteIfNeed(table);
     }
 
-
-    String formatAccessFlagsWithColumns(const AccessFlags & access_flags, const Strings & columns, bool any_column)
+    void formatOptions(bool grant_option, bool is_revoke, String & result)
     {
-        String columns_in_parentheses;
+        if (is_revoke)
+        {
+            if (grant_option)
+                result.insert(0, "REVOKE GRANT OPTION ");
+            else
+                result.insert(0, "REVOKE ");
+        }
+        else
+        {
+            if (grant_option)
+                result.insert(0, "GRANT ").append(" WITH GRANT OPTION");
+            else
+                result.insert(0, "GRANT ");
+        }
+    }
+
+    void formatAccessFlagsWithColumns(const AccessFlags & access_flags, const Strings & columns, bool any_column, String & result)
+    {
+        String columns_as_str;
         if (!any_column)
         {
             if (columns.empty())
-                return "USAGE";
-            for (const auto & column : columns)
             {
-                columns_in_parentheses += columns_in_parentheses.empty() ? "(" : ", ";
-                columns_in_parentheses += backQuoteIfNeed(column);
+                result += "USAGE";
+                return;
             }
-            columns_in_parentheses += ")";
+            formatColumnNames(columns, columns_as_str);
         }
 
         auto keywords = access_flags.toKeywords();
         if (keywords.empty())
-            return "USAGE";
+        {
+            result += "USAGE";
+            return;
+        }
 
-        String msg;
+        bool need_comma = false;
         for (const std::string_view & keyword : keywords)
         {
-            if (!msg.empty())
-                msg += ", ";
-            msg += String{keyword} + columns_in_parentheses;
+            if (need_comma)
+                result.append(", ");
+            need_comma = true;
+            result += keyword;
+            result += columns_as_str;
         }
-        return msg;
     }
 }
 
 
 String AccessRightsElement::toString() const
 {
-    return formatAccessFlagsWithColumns(access_flags, columns, any_column) + " " + formatONClause(database, any_database, table, any_table);
-}
-
-String AccessRightsElementWithOptions::toString() const
-{
-    return formatOptions(grant_option, kind, AccessRightsElement::toString());
+    String result;
+    formatAccessFlagsWithColumns(access_flags, columns, any_column, result);
+    formatONClause(database, any_database, table, any_table, result);
+    formatOptions(grant_option, is_revoke, result);
+    return result;
 }
 
 String AccessRightsElements::toString() const
 {
     if (empty())
-        return "USAGE ON *.*";
-
-    String res;
-    String inner_part;
-
-    for (size_t i = 0; i != size(); ++i)
-    {
-        const auto & element = (*this)[i];
-
-        if (!inner_part.empty())
-            inner_part += ", ";
-        inner_part += formatAccessFlagsWithColumns(element.access_flags, element.columns, element.any_column);
-
-        bool next_element_uses_same_table = false;
-        if (i != size() - 1)
-        {
-            const auto & next_element = (*this)[i + 1];
-            if (element.sameDatabaseAndTable(next_element))
-                next_element_uses_same_table = true;
-        }
-
-        if (!next_element_uses_same_table)
-        {
-            if (!res.empty())
-                res += ", ";
-            res += inner_part + " " + formatONClause(element.database, element.any_database, element.table, element.any_table);
-            inner_part.clear();
-        }
-    }
-
-    return res;
-}
-
-String AccessRightsElementsWithOptions::toString() const
-{
-    if (empty())
         return "GRANT USAGE ON *.*";
 
-    String res;
-    String inner_part;
+    String result;
+    String part;
 
     for (size_t i = 0; i != size(); ++i)
     {
         const auto & element = (*this)[i];
 
-        if (!inner_part.empty())
-            inner_part += ", ";
-        inner_part += formatAccessFlagsWithColumns(element.access_flags, element.columns, element.any_column);
+        if (!part.empty())
+            part += ", ";
+        formatAccessFlagsWithColumns(element.access_flags, element.columns, element.any_column, part);
 
-        bool next_element_uses_same_mode_and_table = false;
+        bool next_element_uses_same_table_and_options = false;
         if (i != size() - 1)
         {
             const auto & next_element = (*this)[i + 1];
             if (element.sameDatabaseAndTable(next_element) && element.sameOptions(next_element))
-                next_element_uses_same_mode_and_table = true;
+                next_element_uses_same_table_and_options = true;
         }
 
-        if (!next_element_uses_same_mode_and_table)
+        if (!next_element_uses_same_table_and_options)
         {
-            if (!res.empty())
-                res += ", ";
-            res += formatOptions(
-                element.grant_option,
-                element.kind,
-                inner_part + " " + formatONClause(element.database, element.any_database, element.table, element.any_table));
-            inner_part.clear();
+            formatONClause(element.database, element.any_database, element.table, element.any_table, part);
+            formatOptions(element.grant_option, element.is_revoke, part);
+            if (result.empty())
+                result = std::move(part);
+            else
+                result.append(", ").append(part);
+            part.clear();
         }
     }
 
-    return res;
+    return result;
 }
 
 }

--- a/src/Access/AccessRightsElement.h
+++ b/src/Access/AccessRightsElement.h
@@ -17,6 +17,9 @@ struct AccessRightsElement
     bool any_table = true;
     bool any_column = true;
 
+    bool grant_option = false;
+    bool is_revoke = false;
+
     AccessRightsElement() = default;
     AccessRightsElement(const AccessRightsElement &) = default;
     AccessRightsElement & operator=(const AccessRightsElement &) = default;
@@ -73,7 +76,7 @@ struct AccessRightsElement
 
     bool empty() const { return !access_flags || (!any_column && columns.empty()); }
 
-    auto toTuple() const { return std::tie(access_flags, any_database, database, any_table, table, any_column, columns); }
+    auto toTuple() const { return std::tie(access_flags, any_database, database, any_table, table, any_column, columns, grant_option, is_revoke); }
     friend bool operator==(const AccessRightsElement & left, const AccessRightsElement & right) { return left.toTuple() == right.toTuple(); }
     friend bool operator!=(const AccessRightsElement & left, const AccessRightsElement & right) { return !(left == right); }
 
@@ -83,38 +86,15 @@ struct AccessRightsElement
             && (any_table == other.any_table);
     }
 
-    bool isEmptyDatabase() const { return !any_database && database.empty(); }
-
-    /// If the database is empty, replaces it with `new_database`. Otherwise does nothing.
-    void replaceEmptyDatabase(const String & new_database);
-
-    /// Resets flags which cannot be granted.
-    void removeNonGrantableFlags();
-
-    /// Returns a human-readable representation like "SELECT, UPDATE(x, y) ON db.table".
-    String toString() const;
-};
-
-
-struct AccessRightsElementWithOptions : public AccessRightsElement
-{
-    bool grant_option = false;
-
-    enum class Kind
+    bool sameOptions(const AccessRightsElement & other) const
     {
-        GRANT,
-        REVOKE,
-    };
-    Kind kind = Kind::GRANT;
-
-    bool sameOptions(const AccessRightsElementWithOptions & other) const
-    {
-        return (grant_option == other.grant_option) && (kind == other.kind);
+        return (grant_option == other.grant_option) && (is_revoke == other.is_revoke);
     }
 
-    auto toTuple() const { return std::tie(access_flags, any_database, database, any_table, table, any_column, columns, grant_option, kind); }
-    friend bool operator==(const AccessRightsElementWithOptions & left, const AccessRightsElementWithOptions & right) { return left.toTuple() == right.toTuple(); }
-    friend bool operator!=(const AccessRightsElementWithOptions & left, const AccessRightsElementWithOptions & right) { return !(left == right); }
+    bool isEmptyDatabase() const { return !any_database && database.empty(); }
+
+    /// If the database is empty, replaces it with `current_database`. Otherwise does nothing.
+    void replaceEmptyDatabase(const String & current_database);
 
     /// Resets flags which cannot be granted.
     void removeNonGrantableFlags();
@@ -130,6 +110,16 @@ class AccessRightsElements : public std::vector<AccessRightsElement>
 public:
     bool empty() const { return std::all_of(begin(), end(), [](const AccessRightsElement & e) { return e.empty(); }); }
 
+    bool sameDatabaseAndTable() const
+    {
+        return empty() || std::all_of(std::next(begin()), end(), [this](const AccessRightsElement & e) { return e.sameDatabaseAndTable(front()); });
+    }
+
+    bool sameOptions() const
+    {
+        return empty() || std::all_of(std::next(begin()), end(), [this](const AccessRightsElement & e) { return e.sameOptions(front()); });
+    }
+
     /// Replaces the empty database with `new_database`.
     void replaceEmptyDatabase(const String & new_database);
 
@@ -141,36 +131,16 @@ public:
 };
 
 
-class AccessRightsElementsWithOptions : public std::vector<AccessRightsElementWithOptions>
-{
-public:
-    /// Replaces the empty database with `new_database`.
-    void replaceEmptyDatabase(const String & new_database);
-
-    /// Resets flags which cannot be granted.
-    void removeNonGrantableFlags();
-
-    /// Returns a human-readable representation like "GRANT SELECT, UPDATE(x, y) ON db.table".
-    String toString() const;
-};
-
-
-inline void AccessRightsElement::replaceEmptyDatabase(const String & new_database)
+inline void AccessRightsElement::replaceEmptyDatabase(const String & current_database)
 {
     if (isEmptyDatabase())
-        database = new_database;
+        database = current_database;
 }
 
-inline void AccessRightsElements::replaceEmptyDatabase(const String & new_database)
+inline void AccessRightsElements::replaceEmptyDatabase(const String & current_database)
 {
     for (auto & element : *this)
-        element.replaceEmptyDatabase(new_database);
-}
-
-inline void AccessRightsElementsWithOptions::replaceEmptyDatabase(const String & new_database)
-{
-    for (auto & element : *this)
-        element.replaceEmptyDatabase(new_database);
+        element.replaceEmptyDatabase(current_database);
 }
 
 inline void AccessRightsElement::removeNonGrantableFlags()
@@ -185,22 +155,17 @@ inline void AccessRightsElement::removeNonGrantableFlags()
         access_flags &= AccessFlags::allFlagsGrantableOnGlobalLevel();
 }
 
-inline void AccessRightsElementWithOptions::removeNonGrantableFlags()
-{
-    if (kind == Kind::GRANT)
-        AccessRightsElement::removeNonGrantableFlags();
-}
-
 inline void AccessRightsElements::removeNonGrantableFlags()
 {
-    for (auto & element : *this)
-        element.removeNonGrantableFlags();
-}
-
-inline void AccessRightsElementsWithOptions::removeNonGrantableFlags()
-{
-    for (auto & element : *this)
-        element.removeNonGrantableFlags();
+    erase(
+        std::remove_if(
+            begin(),
+            end(),
+            [](AccessRightsElement & element) {
+                element.removeNonGrantableFlags();
+                return element.empty();
+            }),
+        end());
 }
 
 }

--- a/src/Access/ContextAccess.cpp
+++ b/src/Access/ContextAccess.cpp
@@ -488,15 +488,6 @@ bool ContextAccess::isGranted(const AccessFlags & flags, const std::string_view 
 bool ContextAccess::isGranted(const AccessRightsElement & element) const { return checkAccessImpl<false, false>(element); }
 bool ContextAccess::isGranted(const AccessRightsElements & elements) const { return checkAccessImpl<false, false>(elements); }
 
-bool ContextAccess::hasGrantOption(const AccessFlags & flags) const { return checkAccessImpl<false, true>(flags); }
-bool ContextAccess::hasGrantOption(const AccessFlags & flags, const std::string_view & database) const { return checkAccessImpl<false, true>(flags, database); }
-bool ContextAccess::hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table) const { return checkAccessImpl<false, true>(flags, database, table); }
-bool ContextAccess::hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column) const { return checkAccessImpl<false, true>(flags, database, table, column); }
-bool ContextAccess::hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns) const { return checkAccessImpl<false, true>(flags, database, table, columns); }
-bool ContextAccess::hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) const { return checkAccessImpl<false, true>(flags, database, table, columns); }
-bool ContextAccess::hasGrantOption(const AccessRightsElement & element) const { return checkAccessImpl<false, true>(element); }
-bool ContextAccess::hasGrantOption(const AccessRightsElements & elements) const { return checkAccessImpl<false, true>(elements); }
-
 void ContextAccess::checkAccess(const AccessFlags & flags) const { checkAccessImpl<true, false>(flags); }
 void ContextAccess::checkAccess(const AccessFlags & flags, const std::string_view & database) const { checkAccessImpl<true, false>(flags, database); }
 void ContextAccess::checkAccess(const AccessFlags & flags, const std::string_view & database, const std::string_view & table) const { checkAccessImpl<true, false>(flags, database, table); }
@@ -505,15 +496,6 @@ void ContextAccess::checkAccess(const AccessFlags & flags, const std::string_vie
 void ContextAccess::checkAccess(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) const { checkAccessImpl<true, false>(flags, database, table, columns); }
 void ContextAccess::checkAccess(const AccessRightsElement & element) const { checkAccessImpl<true, false>(element); }
 void ContextAccess::checkAccess(const AccessRightsElements & elements) const { checkAccessImpl<true, false>(elements); }
-
-void ContextAccess::checkGrantOption(const AccessFlags & flags) const { checkAccessImpl<true, true>(flags); }
-void ContextAccess::checkGrantOption(const AccessFlags & flags, const std::string_view & database) const { checkAccessImpl<true, true>(flags, database); }
-void ContextAccess::checkGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table) const { checkAccessImpl<true, true>(flags, database, table); }
-void ContextAccess::checkGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column) const { checkAccessImpl<true, true>(flags, database, table, column); }
-void ContextAccess::checkGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns) const { checkAccessImpl<true, true>(flags, database, table, columns); }
-void ContextAccess::checkGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) const { checkAccessImpl<true, true>(flags, database, table, columns); }
-void ContextAccess::checkGrantOption(const AccessRightsElement & element) const { checkAccessImpl<true, true>(element); }
-void ContextAccess::checkGrantOption(const AccessRightsElements & elements) const { checkAccessImpl<true, true>(elements); }
 
 
 template <bool throw_if_denied>

--- a/src/Access/ContextAccess.h
+++ b/src/Access/ContextAccess.h
@@ -99,25 +99,6 @@ public:
     std::shared_ptr<const AccessRights> getAccessRights() const;
     std::shared_ptr<const AccessRights> getAccessRightsWithImplicit() const;
 
-    /// Checks if a specified access is granted.
-    bool isGranted(const AccessFlags & flags) const;
-    bool isGranted(const AccessFlags & flags, const std::string_view & database) const;
-    bool isGranted(const AccessFlags & flags, const std::string_view & database, const std::string_view & table) const;
-    bool isGranted(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column) const;
-    bool isGranted(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns) const;
-    bool isGranted(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) const;
-    bool isGranted(const AccessRightsElement & element) const;
-    bool isGranted(const AccessRightsElements & elements) const;
-
-    bool hasGrantOption(const AccessFlags & flags) const;
-    bool hasGrantOption(const AccessFlags & flags, const std::string_view & database) const;
-    bool hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table) const;
-    bool hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column) const;
-    bool hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns) const;
-    bool hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) const;
-    bool hasGrantOption(const AccessRightsElement & element) const;
-    bool hasGrantOption(const AccessRightsElements & elements) const;
-
     /// Checks if a specified access is granted, and throws an exception if not.
     /// Empty database means the current database.
     void checkAccess(const AccessFlags & flags) const;
@@ -129,14 +110,15 @@ public:
     void checkAccess(const AccessRightsElement & element) const;
     void checkAccess(const AccessRightsElements & elements) const;
 
-    void checkGrantOption(const AccessFlags & flags) const;
-    void checkGrantOption(const AccessFlags & flags, const std::string_view & database) const;
-    void checkGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table) const;
-    void checkGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column) const;
-    void checkGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns) const;
-    void checkGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) const;
-    void checkGrantOption(const AccessRightsElement & element) const;
-    void checkGrantOption(const AccessRightsElements & elements) const;
+    /// Checks if a specified access is granted, and returns false if not.
+    bool isGranted(const AccessFlags & flags) const;
+    bool isGranted(const AccessFlags & flags, const std::string_view & database) const;
+    bool isGranted(const AccessFlags & flags, const std::string_view & database, const std::string_view & table) const;
+    bool isGranted(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column) const;
+    bool isGranted(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns) const;
+    bool isGranted(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) const;
+    bool isGranted(const AccessRightsElement & element) const;
+    bool isGranted(const AccessRightsElements & elements) const;
 
     /// Checks if a specified role is granted with admin option, and throws an exception if not.
     void checkAdminOption(const UUID & role_id) const;
@@ -146,6 +128,7 @@ public:
     void checkAdminOption(const std::vector<UUID> & role_ids, const Strings & names_of_roles) const;
     void checkAdminOption(const std::vector<UUID> & role_ids, const std::unordered_map<UUID, String> & names_of_roles) const;
 
+    /// Checks if a specified role is granted with admin option, and returns false if not.
     bool hasAdminOption(const UUID & role_id) const;
     bool hasAdminOption(const UUID & role_id, const String & role_name) const;
     bool hasAdminOption(const UUID & role_id, const std::unordered_map<UUID, String> & names_of_roles) const;

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -1413,7 +1413,7 @@ private:
 };
 
 
-BlockIO executeDDLQueryOnCluster(const ASTPtr & query_ptr_, const Context & context, AccessRightsElements && query_requires_access, bool query_requires_grant_option)
+BlockIO executeDDLQueryOnCluster(const ASTPtr & query_ptr_, const Context & context, AccessRightsElements && query_requires_access)
 {
     /// Remove FORMAT <fmt> and INTO OUTFILE <file> if exists
     ASTPtr query_ptr = query_ptr_->clone();
@@ -1512,10 +1512,7 @@ BlockIO executeDDLQueryOnCluster(const ASTPtr & query_ptr_, const Context & cont
     visitor.visitDDL(query_ptr);
 
     /// Check access rights, assume that all servers have the same users config
-    if (query_requires_grant_option)
-        context.getAccess()->checkGrantOption(query_requires_access);
-    else
-        context.checkAccess(query_requires_access);
+    context.checkAccess(query_requires_access);
 
     DDLLogEntry entry;
     entry.hosts = std::move(hosts);
@@ -1532,9 +1529,9 @@ BlockIO executeDDLQueryOnCluster(const ASTPtr & query_ptr_, const Context & cont
     return io;
 }
 
-BlockIO executeDDLQueryOnCluster(const ASTPtr & query_ptr, const Context & context, const AccessRightsElements & query_requires_access, bool query_requires_grant_option)
+BlockIO executeDDLQueryOnCluster(const ASTPtr & query_ptr, const Context & context, const AccessRightsElements & query_requires_access)
 {
-    return executeDDLQueryOnCluster(query_ptr, context, AccessRightsElements{query_requires_access}, query_requires_grant_option);
+    return executeDDLQueryOnCluster(query_ptr, context, AccessRightsElements{query_requires_access});
 }
 
 BlockIO executeDDLQueryOnCluster(const ASTPtr & query_ptr_, const Context & context)

--- a/src/Interpreters/DDLWorker.h
+++ b/src/Interpreters/DDLWorker.h
@@ -86,13 +86,11 @@ BlockIO executeDDLQueryOnCluster(const ASTPtr & query_ptr, const Context & conte
 BlockIO executeDDLQueryOnCluster(
     const ASTPtr & query_ptr,
     const Context & context,
-    const AccessRightsElements & query_requires_access,
-    bool query_requires_grant_option = false);
+    const AccessRightsElements & query_requires_access);
 BlockIO executeDDLQueryOnCluster(
     const ASTPtr & query_ptr,
     const Context & context,
-    AccessRightsElements && query_requires_access,
-    bool query_requires_grant_option = false);
+    AccessRightsElements && query_requires_access);
 
 
 class DDLWorker

--- a/src/Interpreters/InterpreterGrantQuery.cpp
+++ b/src/Interpreters/InterpreterGrantQuery.cpp
@@ -11,13 +11,10 @@
 #include <boost/range/algorithm/copy.hpp>
 #include <boost/range/algorithm/set_algorithm.hpp>
 
-
 namespace DB
 {
 namespace
 {
-    using Kind = ASTGrantQuery::Kind;
-
     template <typename T>
     void updateFromQueryTemplate(
         T & grantee,
@@ -26,37 +23,27 @@ namespace
     {
         if (!query.access_rights_elements.empty())
         {
-            if (query.kind == Kind::GRANT)
-            {
-                if (query.grant_option)
-                    grantee.access.grantWithGrantOption(query.access_rights_elements);
-                else
-                    grantee.access.grant(query.access_rights_elements);
-            }
+            if (query.is_revoke)
+                grantee.access.revoke(query.access_rights_elements);
             else
-            {
-                if (query.grant_option)
-                    grantee.access.revokeGrantOption(query.access_rights_elements);
-                else
-                    grantee.access.revoke(query.access_rights_elements);
-            }
+                grantee.access.grant(query.access_rights_elements);
         }
 
         if (!roles_to_grant_or_revoke.empty())
         {
-            if (query.kind == Kind::GRANT)
-            {
-                if (query.admin_option)
-                    grantee.granted_roles.grantWithAdminOption(roles_to_grant_or_revoke);
-                else
-                    grantee.granted_roles.grant(roles_to_grant_or_revoke);
-            }
-            else
+            if (query.is_revoke)
             {
                 if (query.admin_option)
                     grantee.granted_roles.revokeAdminOption(roles_to_grant_or_revoke);
                 else
                     grantee.granted_roles.revoke(roles_to_grant_or_revoke);
+            }
+            else
+            {
+                if (query.admin_option)
+                    grantee.granted_roles.grantWithAdminOption(roles_to_grant_or_revoke);
+                else
+                    grantee.granted_roles.grant(roles_to_grant_or_revoke);
             }
         }
     }
@@ -71,6 +58,145 @@ namespace
         else if (auto * role = typeid_cast<Role *>(&grantee))
             updateFromQueryTemplate(*role, query, roles_to_grant_or_revoke);
     }
+
+
+    void changeGrantOption(AccessRightsElements & elements, bool grant_option)
+    {
+        std::for_each(elements.begin(), elements.end(), [&](AccessRightsElement & element) { element.grant_option = grant_option; });
+    }
+
+    void changeIsRevoke(AccessRightsElements & elements, bool is_revoke)
+    {
+        std::for_each(elements.begin(), elements.end(), [&](AccessRightsElement & element) { element.is_revoke = is_revoke; });
+    }
+
+
+    void checkGrantOption(const AccessControlManager & access_control, const ContextAccess & access, ASTGrantQuery & query, const std::vector<UUID> & grantees)
+    {
+        auto & elements = query.access_rights_elements;
+        if (!elements.sameOptions())
+            throw Exception("Elements in the same ASTGrantQuery must use same options", ErrorCodes::LOGICAL_ERROR);
+        if (query.is_revoke)
+            changeIsRevoke(elements, true);
+        elements.removeNonGrantableFlags();
+        if (elements.empty())
+            return;
+
+        bool grant_option = elements[0].grant_option;
+        bool is_revoke = elements[0].is_revoke;
+
+        if (!is_revoke)
+        {
+            if (grant_option)
+            {
+                access.checkAccess(elements);
+            }
+            else
+            {
+                /// To execute the command GRANT without GRANT OPTION the current user needs to have the access granted with GRANT OPTION.
+                changeGrantOption(elements, true);
+                SCOPE_EXIT({ changeGrantOption(elements, grant_option); });
+                access.checkAccess(elements);
+            }
+            return;
+        }
+
+        /// To execute the command REVOKE the current user needs to have the access granted with GRANT OPTION.
+        changeGrantOption(elements, true);
+        changeIsRevoke(elements, false);
+        SCOPE_EXIT(
+        {
+            changeGrantOption(elements, grant_option);
+            changeIsRevoke(elements, is_revoke);
+        });
+        if (access.isGranted(elements))
+            return;
+
+        /// Special case for the command REVOKE: it's possible that the current user doesn't have the access granted
+        /// with GRANT OPTION but it's still ok because the roles or users from whom the access rights will be
+        /// revoked don't have the specified access granted either.
+        ///
+        /// For example, to execute
+        /// GRANT ALL ON mydb.* TO role1
+        /// REVOKE ALL ON *.* FROM role1
+        /// the current user needs to have grants only on the 'mydb' database.
+        AccessRights access_in_use;
+        for (const auto & id : grantees)
+        {
+            auto entity = access_control.tryRead(id);
+            if (auto role = typeid_cast<RolePtr>(entity))
+                access_in_use.makeUnion(role->access);
+            else if (auto user = typeid_cast<UserPtr>(entity))
+                access_in_use.makeUnion(user->access);
+        }
+
+        AccessRights access_to_revoke;
+        changeGrantOption(elements, grant_option);
+        access_to_revoke.grant(elements);
+        elements.clear();
+        access_to_revoke.makeIntersection(access_in_use);
+
+        for (auto & element : access_to_revoke.getElements())
+        {
+            if (!element.is_revoke && (element.grant_option || !grant_option))
+                elements.emplace_back(std::move(element));
+        }
+
+        changeGrantOption(elements, true);
+        access.checkAccess(elements);
+    }
+
+
+    std::vector<UUID> getRoleIDsAndCheckAdminOption(const AccessControlManager & access_control, const ContextAccess & access, const ASTGrantQuery & query, const std::vector<UUID> & grantees)
+    {
+        auto roles = RolesOrUsersSet{*query.roles, access_control};
+        std::vector<UUID> matching_ids;
+
+        if (!query.is_revoke)
+        {
+            matching_ids = roles.getMatchingIDs();
+            access.checkAdminOption(matching_ids);
+            return matching_ids;
+        }
+
+        if (!roles.all)
+        {
+            matching_ids = roles.getMatchingIDs();
+            if (access.hasAdminOption(matching_ids))
+                return matching_ids;
+        }
+
+        /// Special case for the command REVOKE: it's possible that the current user doesn't have the admin option
+        /// for some of the specified roles but it's still ok because the roles or users from whom the roles will be
+        /// revoked from don't have the specified roles granted either.
+        ///
+        /// For example, to execute
+        /// GRANT role2 TO role1
+        /// REVOKE ALL FROM role1
+        /// the current user needs to have only 'role2' to be granted with admin option (not all the roles).
+        boost::container::flat_set<UUID> roles_in_use;
+        for (const auto & id : grantees)
+        {
+            auto entity = access_control.tryRead(id);
+            auto add_to_roles_in_use = [&](const GrantedRoles & granted_roles)
+            {
+                if (query.admin_option)
+                    roles_in_use.insert(granted_roles.roles_with_admin_option.begin(), granted_roles.roles_with_admin_option.end());
+                else
+                    roles_in_use.insert(granted_roles.roles.begin(), granted_roles.roles.end());
+            };
+            if (auto role = typeid_cast<RolePtr>(entity))
+                add_to_roles_in_use(role->granted_roles);
+            else if (auto user = typeid_cast<UserPtr>(entity))
+                add_to_roles_in_use(user->granted_roles);
+        }
+        if (roles.all)
+            boost::range::set_difference(roles_in_use, roles.except_ids, std::back_inserter(matching_ids));
+        else
+            boost::range::remove_erase_if(matching_ids, [&](const UUID & id) { return !roles_in_use.count(id); });
+        access.checkAdminOption(matching_ids);
+        return matching_ids;
+    }
 }
 
 
@@ -80,113 +206,36 @@ BlockIO InterpreterGrantQuery::execute()
     query.replaceCurrentUserTagWithName(context.getUserName());
 
     if (!query.cluster.empty())
-        return executeDDLQueryOnCluster(query_ptr, context, query.access_rights_elements, true);
+    {
+        auto required_access = query.access_rights_elements;
+        changeGrantOption(required_access, true);
+        changeIsRevoke(required_access, false);
+        return executeDDLQueryOnCluster(query_ptr, context, std::move(required_access));
+    }
 
-    auto access = context.getAccess();
     auto & access_control = context.getAccessControlManager();
     query.replaceEmptyDatabaseWithCurrent(context.getCurrentDatabase());
 
-    RolesOrUsersSet roles_set;
-    if (query.roles)
-        roles_set = RolesOrUsersSet{*query.roles, access_control};
-
-    std::vector<UUID> to_roles = RolesOrUsersSet{*query.to_roles, access_control, context.getUserID()}.getMatchingIDs(access_control);
+    std::vector<UUID> grantees = RolesOrUsersSet{*query.grantees, access_control, context.getUserID()}.getMatchingIDs(access_control);
 
     /// Check if the current user has corresponding access rights with grant option.
     if (!query.access_rights_elements.empty())
-    {
-        query.access_rights_elements.removeNonGrantableFlags();
-
-        /// Special case for REVOKE: it's possible that the current user doesn't have the grant option for all
-        /// the specified access rights and that's ok because the roles or users which the access rights
-        /// will be revoked from don't have the specified access rights either.
-        ///
-        /// For example, to execute
-        /// GRANT ALL ON mydb.* TO role1
-        /// REVOKE ALL ON *.* FROM role1
-        /// the current user needs to have access rights only for the 'mydb' database.
-        if ((query.kind == Kind::REVOKE) && !access->hasGrantOption(query.access_rights_elements))
-        {
-            AccessRights max_access;
-            for (const auto & id : to_roles)
-            {
-                auto entity = access_control.tryRead(id);
-                if (auto role = typeid_cast<RolePtr>(entity))
-                    max_access.makeUnion(role->access);
-                else if (auto user = typeid_cast<UserPtr>(entity))
-                    max_access.makeUnion(user->access);
-            }
-            AccessRights access_to_revoke;
-            if (query.grant_option)
-                access_to_revoke.grantWithGrantOption(query.access_rights_elements);
-            else
-                access_to_revoke.grant(query.access_rights_elements);
-            access_to_revoke.makeIntersection(max_access);
-            AccessRightsElements filtered_access_to_revoke;
-            for (auto & element : access_to_revoke.getElements())
-            {
-                if ((element.kind == Kind::GRANT) && (element.grant_option || !query.grant_option))
-                    filtered_access_to_revoke.emplace_back(std::move(element));
-            }
-            query.access_rights_elements = std::move(filtered_access_to_revoke);
-        }
-
-        access->checkGrantOption(query.access_rights_elements);
-    }
+        checkGrantOption(access_control, *context.getAccess(), query, grantees);
 
     /// Check if the current user has corresponding roles granted with admin option.
-    std::vector<UUID> roles_to_grant_or_revoke;
-    if (!roles_set.empty())
-    {
-        bool all = roles_set.all;
-        if (!all)
-            roles_to_grant_or_revoke = roles_set.getMatchingIDs();
+    std::vector<UUID> roles;
+    if (query.roles)
+        roles = getRoleIDsAndCheckAdminOption(access_control, *context.getAccess(), query, grantees);
 
-        /// Special case for REVOKE: it's possible that the current user doesn't have the admin option for all
-        /// the specified roles and that's ok because the roles or users which the roles will be revoked from
-        /// don't have the specified roles granted either.
-        ///
-        /// For example, to execute
-        /// GRANT role2 TO role1
-        /// REVOKE ALL FROM role1
-        /// the current user needs to have only 'role2' to be granted with admin option (not all the roles).
-        if ((query.kind == Kind::REVOKE) && (roles_set.all || !access->hasAdminOption(roles_to_grant_or_revoke)))
-        {
-            auto & roles_to_revoke = roles_to_grant_or_revoke;
-            boost::container::flat_set<UUID> max_roles;
-            for (const auto & id : to_roles)
-            {
-                auto entity = access_control.tryRead(id);
-                auto add_to_max_roles = [&](const GrantedRoles & granted_roles)
-                {
-                    if (query.admin_option)
-                        max_roles.insert(granted_roles.roles_with_admin_option.begin(), granted_roles.roles_with_admin_option.end());
-                    else
-                        max_roles.insert(granted_roles.roles.begin(), granted_roles.roles.end());
-                };
-                if (auto role = typeid_cast<RolePtr>(entity))
-                    add_to_max_roles(role->granted_roles);
-                else if (auto user = typeid_cast<UserPtr>(entity))
-                    add_to_max_roles(user->granted_roles);
-            }
-            if (roles_set.all)
-                boost::range::set_difference(max_roles, roles_set.except_ids, std::back_inserter(roles_to_revoke));
-            else
-                boost::range::remove_erase_if(roles_to_revoke, [&](const UUID & id) { return !max_roles.count(id); });
-        }
-
-        access->checkAdminOption(roles_to_grant_or_revoke);
-    }
-
-    /// Update roles and users listed in `to_roles`.
+    /// Update roles and users listed in `grantees`.
     auto update_func = [&](const AccessEntityPtr & entity) -> AccessEntityPtr
     {
         auto clone = entity->clone();
-        updateFromQueryImpl(*clone, query, roles_to_grant_or_revoke);
+        updateFromQueryImpl(*clone, query, roles);
         return clone;
     };
 
-    access_control.update(to_roles, update_func);
+    access_control.update(grantees, update_func);
 
     return {};
 }

--- a/src/Parsers/ASTGrantQuery.h
+++ b/src/Parsers/ASTGrantQuery.h
@@ -19,14 +19,12 @@ class ASTRolesOrUsersSet;
 class ASTGrantQuery : public IAST, public ASTQueryWithOnCluster
 {
 public:
-    using Kind = AccessRightsElementWithOptions::Kind;
-    Kind kind = Kind::GRANT;
-    bool attach = false;
+    bool attach_mode = false;
+    bool is_revoke = false;
     AccessRightsElements access_rights_elements;
     std::shared_ptr<ASTRolesOrUsersSet> roles;
-    std::shared_ptr<ASTRolesOrUsersSet> to_roles;
-    bool grant_option = false;
     bool admin_option = false;
+    std::shared_ptr<ASTRolesOrUsersSet> grantees;
 
     String getID(char) const override;
     ASTPtr clone() const override;

--- a/src/Storages/System/StorageSystemGrants.cpp
+++ b/src/Storages/System/StorageSystemGrants.cpp
@@ -18,7 +18,6 @@
 namespace DB
 {
 using EntityType = IAccessEntity::Type;
-using Kind = AccessRightsElementWithOptions::Kind;
 
 NamesAndTypesList StorageSystemGrants::getNamesAndTypes()
 {
@@ -64,7 +63,7 @@ void StorageSystemGrants::fillData(MutableColumns & res_columns, const Context &
                        const String * database,
                        const String * table,
                        const String * column,
-                       Kind kind,
+                       bool is_partial_revoke,
                        bool grant_option)
     {
         if (grantee_type == EntityType::USER)
@@ -119,13 +118,13 @@ void StorageSystemGrants::fillData(MutableColumns & res_columns, const Context &
             column_column_null_map.push_back(true);
         }
 
-        column_is_partial_revoke.push_back(kind == Kind::REVOKE);
+        column_is_partial_revoke.push_back(is_partial_revoke);
         column_grant_option.push_back(grant_option);
     };
 
     auto add_rows = [&](const String & grantee_name,
                         IAccessEntity::Type grantee_type,
-                        const AccessRightsElementsWithOptions & elements)
+                        const AccessRightsElements & elements)
     {
         for (const auto & element : elements)
         {
@@ -139,13 +138,13 @@ void StorageSystemGrants::fillData(MutableColumns & res_columns, const Context &
             if (element.any_column)
             {
                 for (const auto & access_type : access_types)
-                    add_row(grantee_name, grantee_type, access_type, database, table, nullptr, element.kind, element.grant_option);
+                    add_row(grantee_name, grantee_type, access_type, database, table, nullptr, element.is_revoke, element.grant_option);
             }
             else
             {
                 for (const auto & access_type : access_types)
                     for (const auto & column : element.columns)
-                        add_row(grantee_name, grantee_type, access_type, database, table, &column, element.kind, element.grant_option);
+                        add_row(grantee_name, grantee_type, access_type, database, table, &column, element.is_revoke, element.grant_option);
             }
         }
     };


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Improvement

Changelog entry:
Implement `GRANTED BY` clause in the commands `GRANT` and `REVOKE`:

```
GRANT ... [{GRANTED BY | AS} <grantor>]
REVOKE ... [{GRANTED BY | AS} <grantor>]
```

This optional clause allows to specify the grantor (i.e. who gives the permission), by default it's the current user. The grantor is stored after executing the `GRANT` command, and  `SHOW GRANTS` will show the grantor. To revoke a granted permission it's necessary to execute the `REVOKE` command with the same grantor. If two users `A` and `B` grants the same permission, and after that the user `A` revokes it, the permission is considered as still granted (by the user `B`).

This PR provides a way to solve https://github.com/ClickHouse/ClickHouse/issues/13390