### PR TITLE
clickhouse stop: wait for the server to be killed (process exited)

### DIFF
--- a/programs/install/Install.cpp
+++ b/programs/install/Install.cpp
@@ -66,6 +66,7 @@ namespace ErrorCodes
     extern const int CANNOT_OPEN_FILE;
     extern const int SYSTEM_ERROR;
     extern const int NOT_ENOUGH_SPACE;
+    extern const int CANNOT_KILL;
 }
 
 }
@@ -886,6 +887,27 @@ namespace
                 fmt::print("Sent kill signal.\n", pid);
             else
                 throwFromErrno("Cannot send kill signal", ErrorCodes::SYSTEM_ERROR);
+
+            /// Wait for the process (100 seconds).
+            constexpr size_t num_kill_check_tries = 1000;
+            constexpr size_t kill_check_delay_ms = 100;
+            for (size_t i = 0; i < num_kill_check_tries; ++i)
+            {
+                fmt::print("Waiting for server to be killed\n");
+                if (!isRunning(pid_file))
+                {
+                    fmt::print("Server exited\n");
+                    break;
+                }
+                sleepForMilliseconds(kill_check_delay_ms);
+            }
+
+            if (isRunning(pid_file))
+            {
+                throw Exception(ErrorCodes::CANNOT_KILL,
+                    "The server process still exists after %zu ms",
+                    num_kill_check_tries, kill_check_delay_ms);
+            }
         }
 
         return 0;


### PR DESCRIPTION
Since killing doesn't happen instantly, and the start will fail [1]:

    The process with pid = 157 is running.
    Will terminate forcefully.
    Sent kill signal.
    /var/run/clickhouse-server/clickhouse-server.pid file exists and contains pid = 157.
    The process with pid = 157 is already running.
    + for _ in {1..120}
    + clickhouse-client --query 'SELECT 1'
    Code: 210. DB::NetException: Connection refused (localhost:9000)

  [1]: https://clickhouse-test-reports.s3.yandex.net/21318/4327e9e1d1e4c9c3576b00f41a8444237549dffd/functional_stateful_tests_(debug).html#fail1

Changelog category (leave one):
- Not for changelog (changelog entry is not required)