### PR TITLE
mysql client compatibility

### DIFF
--- a/src/Functions/connectionID.cpp
+++ b/src/Functions/connectionID.cpp
@@ -1,0 +1,44 @@
+#include <DataTypes/DataTypesNumber.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/IFunctionImpl.h>
+#include <Interpreters/Context.h>
+
+
+namespace DB
+{
+namespace
+{
+    /// Get the connection ID. It's used for MySQL handler only.
+    class FunctionConnectionID : public IFunction
+    {
+    public:
+        static constexpr auto name = "connectionID";
+
+        FunctionConnectionID(const Context & context_) : context(context_) {}
+
+        static FunctionPtr create(const Context & context) { return std::make_shared<FunctionConnectionID>(context); }
+
+        String getName() const override { return name; }
+
+        size_t getNumberOfArguments() const override { return 0; }
+
+        DataTypePtr getReturnTypeImpl(const DataTypes & /*arguments*/) const override { return std::make_shared<DataTypeUInt64>(); }
+
+        ColumnPtr executeImpl(const ColumnsWithTypeAndName &, const DataTypePtr & result_type, size_t input_rows_count) const override
+        {
+            return result_type->createColumnConst(input_rows_count, context.getClientInfo().connection_id);
+        }
+
+    private:
+        const Context & context;
+    };
+
+}
+
+void registerFunctionConnectionID(FunctionFactory & factory)
+{
+    factory.registerFunction<FunctionConnectionID>();
+    factory.registerAlias("connection_id", "connectionID");
+}
+
+}

--- a/src/Functions/connectionID.cpp
+++ b/src/Functions/connectionID.cpp
@@ -6,34 +6,31 @@
 
 namespace DB
 {
-namespace
+
+/// Get the connection ID. It's used for MySQL handler only.
+class FunctionConnectionID : public IFunction
 {
-    /// Get the connection ID. It's used for MySQL handler only.
-    class FunctionConnectionID : public IFunction
+public:
+    static constexpr auto name = "connectionID";
+
+    explicit FunctionConnectionID(const Context & context_) : context(context_) {}
+
+    static FunctionPtr create(const Context & context) { return std::make_shared<FunctionConnectionID>(context); }
+
+    String getName() const override { return name; }
+
+    size_t getNumberOfArguments() const override { return 0; }
+
+    DataTypePtr getReturnTypeImpl(const DataTypes & /*arguments*/) const override { return std::make_shared<DataTypeUInt64>(); }
+
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName &, const DataTypePtr & result_type, size_t input_rows_count) const override
     {
-    public:
-        static constexpr auto name = "connectionID";
+        return result_type->createColumnConst(input_rows_count, context.getClientInfo().connection_id);
+    }
 
-        FunctionConnectionID(const Context & context_) : context(context_) {}
-
-        static FunctionPtr create(const Context & context) { return std::make_shared<FunctionConnectionID>(context); }
-
-        String getName() const override { return name; }
-
-        size_t getNumberOfArguments() const override { return 0; }
-
-        DataTypePtr getReturnTypeImpl(const DataTypes & /*arguments*/) const override { return std::make_shared<DataTypeUInt64>(); }
-
-        ColumnPtr executeImpl(const ColumnsWithTypeAndName &, const DataTypePtr & result_type, size_t input_rows_count) const override
-        {
-            return result_type->createColumnConst(input_rows_count, context.getClientInfo().connection_id);
-        }
-
-    private:
-        const Context & context;
-    };
-
-}
+private:
+    const Context & context;
+};
 
 void registerFunctionConnectionID(FunctionFactory & factory)
 {

--- a/src/Functions/globalVariable.cpp
+++ b/src/Functions/globalVariable.cpp
@@ -80,6 +80,7 @@ private:
     std::unordered_map<String, TypeAndValue> global_variable_map
         = {{"max_allowed_packet", {std::make_shared<DataTypeInt32>(), 67108864}},
            {"version", {std::make_shared<DataTypeString>(), "5.7.30"}},
+           {"version_comment", {std::make_shared<DataTypeString>(), ""}},
            {"transaction_isolation", {std::make_shared<DataTypeString>(), "READ-UNCOMMITTED"}}};
 };
 

--- a/src/Functions/globalVariable.cpp
+++ b/src/Functions/globalVariable.cpp
@@ -77,8 +77,10 @@ private:
         DataTypePtr type;
         Field value;
     };
-    std::unordered_map<String, TypeAndValue> global_variable_map = {
-        {"max_allowed_packet", {std::make_shared<DataTypeInt32>(), 67108864}}, {"version", {std::make_shared<DataTypeString>(), "5.7.30"}}};
+    std::unordered_map<String, TypeAndValue> global_variable_map
+        = {{"max_allowed_packet", {std::make_shared<DataTypeInt32>(), 67108864}},
+           {"version", {std::make_shared<DataTypeString>(), "5.7.30"}},
+           {"transaction_isolation", {std::make_shared<DataTypeString>(), "READ-UNCOMMITTED"}}};
 };
 
 }

--- a/src/Functions/registerFunctionsMiscellaneous.cpp
+++ b/src/Functions/registerFunctionsMiscellaneous.cpp
@@ -69,6 +69,7 @@ void registerFunctionErrorCodeToName(FunctionFactory &);
 void registerFunctionTcpPort(FunctionFactory &);
 void registerFunctionByteSize(FunctionFactory &);
 void registerFunctionFile(FunctionFactory & factory);
+void registerFunctionConnectionID(FunctionFactory & factory);
 
 #if USE_ICU
 void registerFunctionConvertCharset(FunctionFactory &);
@@ -138,6 +139,7 @@ void registerFunctionsMiscellaneous(FunctionFactory & factory)
     registerFunctionTcpPort(factory);
     registerFunctionByteSize(factory);
     registerFunctionFile(factory);
+    registerFunctionConnectionID(factory);
 
 #if USE_ICU
     registerFunctionConvertCharset(factory);

--- a/src/Functions/ya.make
+++ b/src/Functions/ya.make
@@ -210,6 +210,7 @@ SRCS(
     cbrt.cpp
     coalesce.cpp
     concat.cpp
+    connectionID.cpp
     convertCharset.cpp
     cos.cpp
     cosh.cpp

--- a/src/Interpreters/ClientInfo.h
+++ b/src/Interpreters/ClientInfo.h
@@ -84,6 +84,9 @@ public:
     String http_user_agent;
     String http_referer;
 
+    /// For mysql
+    UInt64 connection_id = 0;
+
     /// Comma separated list of forwarded IP addresses (from X-Forwarded-For for HTTP interface).
     /// It's expected that proxy appends the forwarded address to the end of the list.
     /// The element can be trusted only if you trust the corresponding proxy.

--- a/src/Server/MySQLHandler.cpp
+++ b/src/Server/MySQLHandler.cpp
@@ -92,6 +92,7 @@ void MySQLHandler::run()
     connection_context.makeSessionContext();
     connection_context.getClientInfo().interface = ClientInfo::Interface::MYSQL;
     connection_context.setDefaultFormat("MySQLWire");
+    connection_context.getClientInfo().connection_id = connection_id;
 
     in = std::make_shared<ReadBufferFromPocoSocket>(socket());
     out = std::make_shared<WriteBufferFromPocoSocket>(socket());

--- a/src/Server/MySQLHandler.h
+++ b/src/Server/MySQLHandler.h
@@ -61,7 +61,7 @@ protected:
     std::shared_ptr<MySQLProtocol::PacketEndpoint> packet_endpoint;
 
 private:
-    size_t connection_id = 0;
+    UInt64 connection_id = 0;
 
     size_t server_capability_flags = 0;
     size_t client_capability_flags = 0;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Provide better compatibility for mysql clients.
1. mysql jdbc
2. mycli

```
Failed to initialize pool: Could not map transaction isolation '0' to a valid JDBC level.

unknown function connection_id().

cannot lower "version_comment".
```

Detailed description / Documentation draft:

.