### PR TITLE
Add function alignment for better performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,7 +216,9 @@ endif()
 
 # Compress the debug section for binaries
 if (COMPILER_GCC OR COMPILER_CLANG)
-    set(COMPILER_FLAGS "${COMPILER_FLAGS} -gz=zlib")
+    set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--compress-debug-sections=zlib")
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--compress-debug-sections=zlib")
+    set (COMPILER_FLAGS "${COMPILER_FLAGS} -gz=zlib")
 endif ()
 
 # Create BuildID when using lld. For other linkers it is created by default.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,11 @@ if (NOT CMAKE_BUILD_TYPE_UC STREQUAL "RELEASE")
     endif ()
 endif()
 
+# Compress the debug section for binaries
+if (COMPILER_GCC OR COMPILER_CLANG)
+    set(COMPILER_FLAGS "${COMPILER_FLAGS} -gz=zlib")
+endif ()
+
 # Create BuildID when using lld. For other linkers it is created by default.
 if (LINKER_NAME MATCHES "lld$")
     # SHA1 is not cryptographically secure but it is the best what lld is offering.
@@ -268,6 +273,12 @@ set (CMAKE_CXX_STANDARD_REQUIRED ON)
 if (COMPILER_GCC OR COMPILER_CLANG)
     # Enable C++14 sized global deallocation functions. It should be enabled by setting -std=c++14 but I'm not sure.
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsized-deallocation")
+endif ()
+
+# falign-functions=32 prevents from random performance regressions with the code change. Thus, providing more stable
+# benchmarks.
+if (COMPILER_GCC OR COMPILER_CLANG)
+    set(COMPILER_FLAGS "${COMPILER_FLAGS} -falign-functions=32")
 endif ()
 
 # Compiler-specific coverage flags e.g. -fcoverage-mapping for gcc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,13 +214,6 @@ if (NOT CMAKE_BUILD_TYPE_UC STREQUAL "RELEASE")
     endif ()
 endif()
 
-# Compress the debug section for binaries
-if (COMPILER_GCC OR COMPILER_CLANG)
-    set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--compress-debug-sections=zlib")
-    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--compress-debug-sections=zlib")
-    set (COMPILER_FLAGS "${COMPILER_FLAGS} -gz=zlib")
-endif ()
-
 # Create BuildID when using lld. For other linkers it is created by default.
 if (LINKER_NAME MATCHES "lld$")
     # SHA1 is not cryptographically secure but it is the best what lld is offering.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add function alignment for possibly better performance.

Detailed description / Documentation draft:
Let's try to add compression of debug symbols and reduce the binary size by 1.2GB. Also, adding the function alignment for more reproducible results in the performance tests. It is a known technique to reduce such randomness and should potentially help. Either way, let's try and see the build and performance metrics. falign-functions add 0.1% to the binary size which is nothing compared to other clickhouse
