### PR TITLE
Fix flaky tests with distributed queries

### DIFF
--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -39,6 +39,7 @@ ln -sf $SRC_PATH/users.d/readonly.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/access_management.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/database_atomic_drop_detach_sync.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/opentelemetry.xml $DEST_SERVER_PATH/users.d/
+ln -sf $SRC_PATH/users.d/remote_queries.xml $DEST_SERVER_PATH/users.d/
 
 ln -sf $SRC_PATH/ints_dictionary.xml $DEST_SERVER_PATH/
 ln -sf $SRC_PATH/strings_dictionary.xml $DEST_SERVER_PATH/

--- a/tests/config/users.d/remote_queries.xml
+++ b/tests/config/users.d/remote_queries.xml
@@ -1,0 +1,9 @@
+<yandex>
+    <profiles>
+        <default>
+            <!-- Avoid "Connection failed at try №1" messages. -->
+            <connect_timeout_with_failover_ms>2000</connect_timeout_with_failover_ms>
+            <connect_timeout_with_failover_secure_ms>3000</connect_timeout_with_failover_secure_ms>
+        </default>
+    </profiles>
+</yandex>

--- a/tests/config/users.d/remote_queries.xml
+++ b/tests/config/users.d/remote_queries.xml
@@ -4,6 +4,10 @@
             <!-- Avoid "Connection failed at try №1" messages. -->
             <connect_timeout_with_failover_ms>2000</connect_timeout_with_failover_ms>
             <connect_timeout_with_failover_secure_ms>3000</connect_timeout_with_failover_secure_ms>
+            <!-- Avoid this logic in tests to avoid EOF (10 hours is enough for tests)-->
+            <idle_connection_timeout>36000</idle_connection_timeout>
+            <!-- NOTE: instead of tunning idle_connection_timeout,
+                 SYSTEM RELOAD CONFIG can be executed before each test -->
         </default>
     </profiles>
 </yandex>

--- a/tests/queries/0_stateless/00974_distributed_join_on.sql
+++ b/tests/queries/0_stateless/00974_distributed_join_on.sql
@@ -1,7 +1,3 @@
--- Avoid "Connection failed at try №1" messages.
-SET send_logs_level = 'none';
-SET connect_timeout_with_failover_ms = 5000;
-
 DROP TABLE IF EXISTS source_table1;
 DROP TABLE IF EXISTS source_table2;
 DROP TABLE IF EXISTS distributed_table1;

--- a/tests/queries/0_stateless/01244_optimize_distributed_group_by_sharding_key.sql
+++ b/tests/queries/0_stateless/01244_optimize_distributed_group_by_sharding_key.sql
@@ -1,9 +1,5 @@
 -- TODO: correct testing with real unique shards
 
--- Avoid "Connection failed at try №1" messages.
-SET send_logs_level = 'fatal';
-SET connect_timeout_with_failover_ms = 5000;
-
 set optimize_distributed_group_by_sharding_key=1;
 
 drop table if exists dist_01247;

--- a/tests/queries/0_stateless/01247_optimize_distributed_group_by_sharding_key_dist_on_dist.sql
+++ b/tests/queries/0_stateless/01247_optimize_distributed_group_by_sharding_key_dist_on_dist.sql
@@ -1,9 +1,5 @@
 -- TODO: correct testing with real unique shards
 
--- Avoid "Connection failed at try №1" messages.
-SET send_logs_level = 'fatal';
-SET connect_timeout_with_failover_ms = 5000;
-
 set optimize_distributed_group_by_sharding_key=1;
 
 drop table if exists dist_01247;

--- a/tests/queries/0_stateless/01293_show_settings.reference
+++ b/tests/queries/0_stateless/01293_show_settings.reference
@@ -1,5 +1,5 @@
 send_timeout	Seconds	300
 connect_timeout	Seconds	10
-connect_timeout_with_failover_ms	Milliseconds	50
-connect_timeout_with_failover_secure_ms	Milliseconds	100
+connect_timeout_with_failover_ms	Milliseconds	2000
+connect_timeout_with_failover_secure_ms	Milliseconds	3000
 max_memory_usage	UInt64	10000000000


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

There was few attempts to fix this [1] and [2], but it still pops up
sometimes, for example here [3].

  [1]: 009f57fc2fc8 / #11211
  [2]: cdb6bed8b98e / #14198
  [3]: https://clickhouse-test-reports.s3.yandex.net/21318/38be9ff43ac4c46ce6e803fc125d910bde1d4c71/functional_stateless_tests_(release,_databasereplicated).html#fail1

Let's use more generic approach, and do not hide any errors.