### PR TITLE
Fix ParsingException::displayText()

### DIFF
--- a/src/Common/Exception.cpp
+++ b/src/Common/Exception.cpp
@@ -458,23 +458,15 @@ ExecutionStatus ExecutionStatus::fromCurrentException(const std::string & start_
     return ExecutionStatus(getCurrentExceptionCode(), msg);
 }
 
-ParsingException::ParsingException()
-{
-    Exception::message(Exception::message() + "{}");
-}
-
+ParsingException::ParsingException() = default;
 ParsingException::ParsingException(const std::string & msg, int code)
     : Exception(msg, code)
 {
-    Exception::message(Exception::message() + "{}");
 }
-
 ParsingException::ParsingException(int code, const std::string & message)
     : Exception(message, code)
 {
-    Exception::message(Exception::message() + "{}");
 }
-
 
 /// We use additional field formatted_message_ to make this method const.
 std::string ParsingException::displayText() const
@@ -482,9 +474,9 @@ std::string ParsingException::displayText() const
     try
     {
         if (line_number_ == -1)
-            formatted_message_ = fmt::format(message(), "");
+            formatted_message_ = message();
         else
-            formatted_message_ = fmt::format(message(), fmt::format(": (at row {})\n", line_number_));
+            formatted_message_ = message() + fmt::format(": (at row {})\n", line_number_);
     }
     catch (...)
     {}

--- a/src/Common/Exception.h
+++ b/src/Common/Exception.h
@@ -115,9 +115,7 @@ public:
     template <typename ...Args>
     ParsingException(int code, const std::string & fmt, Args&&... args)
         : Exception(fmt::format(fmt, std::forward<Args>(args)...), code)
-    {
-        Exception::message(Exception::message() + "{}");
-    }
+    {}
 
 
     std::string displayText() const

--- a/tests/queries/0_stateless/01750_parsing_exception.sh
+++ b/tests/queries/0_stateless/01750_parsing_exception.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# if it will not match, the exit code of grep will be non-zero and the test will fail
+$CLICKHOUSE_CLIENT -q "SELECT toDateTime(format('{}-{}-01 00:00:00', '2021', '1'))" |& grep -F -q 'Cannot parse datetime 2021-1-01 00:00:00: Cannot parse DateTime from String:'


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Before it was silently try-catched for messages with additional {}, and
it is very easy to trigger, i.e.:

    SELECT toDateTime(format('{}-{}-01 00:00:00', '2021', '1'))

Will print:

    Code: 41. DB::Exception: Received from localhost:9000. DB::Exception: Cannot parse datetime 2021-1-01 00:00:00{}: Cannot parse DateTime from String: while executing 'FUNCTION toDateTime(format('{}-{}-01 00:00:00', '2021', '1') :: 3) -> toDateTime(format('{}-{}-01 00:00:00', '2021', '1')) DateTime : 2'.

Cc: @nikitamikhaylov 