### PR TITLE
Fix SIGSEGV for distributed queries on failures

### DIFF
--- a/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
+++ b/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
@@ -110,8 +110,7 @@ bool PullingAsyncPipelineExecutor::pull(Chunk & chunk, uint64_t milliseconds)
         data->thread = ThreadFromGlobalPool(std::move(func));
     }
 
-    if (data->has_exception)
-        std::rethrow_exception(std::move(data->exception));
+    data->rethrowExceptionIfHas();
 
     bool is_execution_finished = lazy_format ? lazy_format->isFinished()
                                              : data->is_finished.load();

--- a/tests/queries/0_stateless/01752_distributed_query_sigsegv.sql
+++ b/tests/queries/0_stateless/01752_distributed_query_sigsegv.sql
@@ -1,0 +1,8 @@
+-- this is enough to trigger the regression
+SELECT throwIf(dummy = 0) FROM remote('127.1', system.one); -- { serverError 395 }
+
+-- these are just in case
+SELECT throwIf(dummy = 0) FROM remote('127.{1,2}', system.one); -- { serverError 395 }
+SELECT throwIf(dummy = 0) FROM remote('127.{1,2}', system.one) SETTINGS prefer_localhost_replica=0; -- { serverError 395 }
+SELECT throwIf(dummy = 0) FROM remote('127.{1,2}', system.one) SETTINGS prefer_localhost_replica=0, distributed_group_by_no_merge=1; -- { serverError 395 }
+SELECT throwIf(dummy = 0) FROM remote('127.{1,2}', system.one) SETTINGS prefer_localhost_replica=0, distributed_group_by_no_merge=2; -- { serverError 395 }


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix SIGSEGV for distributed queries on failures

Detailed description / Documentation draft:
Since after pull(), cancel() will be called, and this will lead to
SIGSEGV, since there is no exception, but has_exception was not reseted
in pull()

Cc: @KochetovNicolai 