### PR TITLE
Use path as default prefix for coordination logs

### DIFF
--- a/src/Coordination/NuKeeperStateManager.cpp
+++ b/src/Coordination/NuKeeperStateManager.cpp
@@ -26,7 +26,7 @@ NuKeeperStateManager::NuKeeperStateManager(
     const CoordinationSettingsPtr & coordination_settings)
     : my_server_id(my_server_id_)
     , log_store(nuraft::cs_new<NuKeeperLogStore>(
-                    config.getString(config_prefix + ".log_storage_path"),
+                    config.getString(config_prefix + ".log_storage_path", config.getString("path", DBMS_DEFAULT_PATH) + "coordination/logs"),
                     coordination_settings->rotate_log_storage_interval, coordination_settings->force_sync))
     , cluster_config(nuraft::cs_new<nuraft::cluster_config>())
 {

--- a/tests/config/config.d/test_keeper_port.xml
+++ b/tests/config/config.d/test_keeper_port.xml
@@ -2,7 +2,6 @@
     <test_keeper_server>
         <tcp_port>9181</tcp_port>
         <server_id>1</server_id>
-        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
 
         <coordination_settings>
             <operation_timeout_ms>10000</operation_timeout_ms>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)