### PR TITLE
avoid race in librdkafka

### DIFF
--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -2454,6 +2454,8 @@ def test_kafka_issue14202(kafka_cluster):
                      kafka_format = 'JSONEachRow';
         ''')
 
+    time.sleep(3)
+
     instance.query(
         'INSERT INTO test.kafka_q SELECT t, some_string  FROM ( SELECT dt AS t, some_string FROM test.empty_table )')
     # check instance is alive


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
see https://github.com/edenhill/librdkafka/issues/3279

Detailed description / Documentation draft:
It looks like some race between consumer & producer initialization. 
Before https://github.com/ClickHouse/ClickHouse/pull/21111 there was an explicit sIeep between them and the issue was not happening. I've put the sleep back, hope that @edenhill will address https://github.com/edenhill/librdkafka/issues/3279 soon.