### PR TITLE
recreate S3 client if credentials changed

### DIFF
--- a/src/Storages/StorageS3.h
+++ b/src/Storages/StorageS3.h
@@ -5,6 +5,7 @@
 #if USE_AWS_S3
 
 #include <Storages/IStorage.h>
+#include <Storages/StorageS3Settings.h>
 #include <Poco/URI.h>
 #include <common/logger_useful.h>
 #include <ext/shared_ptr_helper.h>
@@ -57,7 +58,10 @@ public:
     NamesAndTypesList getVirtuals() const override;
 
 private:
-    S3::URI uri;
+    const S3::URI uri;
+    const String access_key_id;
+    const String secret_access_key;
+    const UInt64 max_connections;
     const Context & global_context;
 
     String format_name;
@@ -66,6 +70,9 @@ private:
     String compression_method;
     std::shared_ptr<Aws::S3::S3Client> client;
     String name;
+    S3AuthSettings auth_settings;
+
+    void updateAuthSettings(const Context & context);
 };
 
 }

--- a/src/Storages/StorageS3Settings.h
+++ b/src/Storages/StorageS3Settings.h
@@ -14,24 +14,32 @@ class AbstractConfiguration;
 
 namespace DB
 {
-
 struct HttpHeader
 {
-    const String name;
-    const String value;
+    String name;
+    String value;
+
+    inline bool operator==(const HttpHeader & other) const { return name == other.name && value == other.value; }
 };
 
 using HeaderCollection = std::vector<HttpHeader>;
 
 struct S3AuthSettings
 {
-    const String access_key_id;
-    const String secret_access_key;
-    const String server_side_encryption_customer_key_base64;
+    String access_key_id;
+    String secret_access_key;
+    String server_side_encryption_customer_key_base64;
 
-    const HeaderCollection headers;
+    HeaderCollection headers;
 
     std::optional<bool> use_environment_credentials;
+
+    inline bool operator==(const S3AuthSettings & other) const
+    {
+        return access_key_id == other.access_key_id && secret_access_key == other.secret_access_key
+            && server_side_encryption_customer_key_base64 == other.server_side_encryption_customer_key_base64 && headers == other.headers
+            && use_environment_credentials == other.use_environment_credentials;
+    }
 };
 
 /// Settings for the StorageS3.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix that S3 table holds old credentials after config update.