### PR TITLE
Throw exception if removing parts from ZooKeeper fails.

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -208,7 +208,7 @@ void ReplicatedMergeTreeRestartingThread::removeFailedQuorumParts()
         return;
 
     /// Firstly, remove parts from ZooKeeper
-    storage.tryRemovePartsFromZooKeeperWithRetries(failed_parts);
+    storage.removePartsFromZooKeeperWithRetries(failed_parts);
 
     for (const auto & part_name : failed_parts)
     {

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1954,7 +1954,7 @@ void StorageReplicatedMergeTree::executeDropRange(const LogEntry & entry)
     }
 
     /// Forcibly remove parts from ZooKeeper
-    tryRemovePartsFromZooKeeperWithRetries(parts_to_remove);
+    removePartsFromZooKeeperWithRetries(parts_to_remove);
 
     if (entry.detach)
         LOG_DEBUG(log, "Detached {} parts inside {}.", parts_to_remove.size(), entry.new_part_name);
@@ -2047,7 +2047,7 @@ bool StorageReplicatedMergeTree::executeReplaceRange(const LogEntry & entry)
     if (parts_to_add.empty())
     {
         LOG_INFO(log, "All parts from REPLACE PARTITION command have been already attached");
-        tryRemovePartsFromZooKeeperWithRetries(parts_to_remove);
+        removePartsFromZooKeeperWithRetries(parts_to_remove);
         return true;
     }
 
@@ -2284,7 +2284,7 @@ bool StorageReplicatedMergeTree::executeReplaceRange(const LogEntry & entry)
         throw;
     }
 
-    tryRemovePartsFromZooKeeperWithRetries(parts_to_remove);
+    removePartsFromZooKeeperWithRetries(parts_to_remove);
     res_parts.clear();
     parts_to_remove.clear();
     cleanup_thread.wakeup();
@@ -2408,7 +2408,7 @@ void StorageReplicatedMergeTree::cloneReplica(const String & source_replica, Coo
             LOG_WARNING(log, "Source replica does not have part {}. Removing it from ZooKeeper.", part);
         }
     }
-    tryRemovePartsFromZooKeeperWithRetries(parts_to_remove_from_zk);
+    removePartsFromZooKeeperWithRetries(parts_to_remove_from_zk);
 
     auto local_active_parts = getDataParts();
     DataPartsVector parts_to_remove_from_working_set;
@@ -5470,16 +5470,16 @@ void StorageReplicatedMergeTree::clearOldPartsAndRemoveFromZK()
 }
 
 
-bool StorageReplicatedMergeTree::tryRemovePartsFromZooKeeperWithRetries(DataPartsVector & parts, size_t max_retries)
+void StorageReplicatedMergeTree::removePartsFromZooKeeperWithRetries(DataPartsVector & parts, size_t max_retries)
 {
     Strings part_names_to_remove;
     for (const auto & part : parts)
         part_names_to_remove.emplace_back(part->name);
 
-    return tryRemovePartsFromZooKeeperWithRetries(part_names_to_remove, max_retries);
+    return removePartsFromZooKeeperWithRetries(part_names_to_remove, max_retries);
 }
 
-bool StorageReplicatedMergeTree::tryRemovePartsFromZooKeeperWithRetries(const Strings & part_names, size_t max_retries)
+void StorageReplicatedMergeTree::removePartsFromZooKeeperWithRetries(const Strings & part_names, size_t max_retries)
 {
     size_t num_tries = 0;
     bool success = false;
@@ -5544,7 +5544,8 @@ bool StorageReplicatedMergeTree::tryRemovePartsFromZooKeeperWithRetries(const St
             std::this_thread::sleep_for(std::chrono::milliseconds(1000));
     }
 
-    return success;
+    if (!success)
+        throw Exception(ErrorCodes::UNFINISHED, "Failed to remove parts from ZooKeeper after {} retries", num_tries);
 }
 
 void StorageReplicatedMergeTree::removePartsFromZooKeeper(
@@ -5843,7 +5844,7 @@ void StorageReplicatedMergeTree::replacePartitionFrom(
         lock.assumeUnlocked();
 
     /// Forcibly remove replaced parts from ZooKeeper
-    tryRemovePartsFromZooKeeperWithRetries(parts_to_remove);
+    removePartsFromZooKeeperWithRetries(parts_to_remove);
 
     /// Speedup removing of replaced parts from filesystem
     parts_to_remove.clear();
@@ -6028,7 +6029,7 @@ void StorageReplicatedMergeTree::movePartitionToTable(const StoragePtr & dest_ta
     for (auto & lock : ephemeral_locks)
         lock.assumeUnlocked();
 
-    tryRemovePartsFromZooKeeperWithRetries(parts_to_remove);
+    removePartsFromZooKeeperWithRetries(parts_to_remove);
 
     parts_to_remove.clear();
     cleanup_thread.wakeup();

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -388,8 +388,9 @@ private:
     void removePartsFromZooKeeper(zkutil::ZooKeeperPtr & zookeeper, const Strings & part_names,
                                   NameSet * parts_should_be_retried = nullptr);
 
-    bool tryRemovePartsFromZooKeeperWithRetries(const Strings & part_names, size_t max_retries = 5);
-    bool tryRemovePartsFromZooKeeperWithRetries(DataPartsVector & parts, size_t max_retries = 5);
+    /// Remove parts from ZooKeeper, throw exception if unable to do so after max_retries.
+    void removePartsFromZooKeeperWithRetries(const Strings & part_names, size_t max_retries = 5);
+    void removePartsFromZooKeeperWithRetries(DataPartsVector & parts, size_t max_retries = 5);
 
     /// Removes a part from ZooKeeper and adds a task to the queue to download it. It is supposed to do this with broken parts.
     void removePartAndEnqueueFetch(const String & part_name);


### PR DESCRIPTION
This is used for removing part metadata from ZooKeeper when executing
queue events like `DROP_RANGE` triggered when a user tries to drop a
part or a partition. There are other uses but I'll focus only on this
one.

Before this change the method was giving up silently if it was unable to
remove parts from ZooKeeper and this behaviour seems to be problematic.
It could lead to operation being reported as successful at first but
data reappearing later (very rarely) or "stuck" events in replication
queue.

Here is one particular scenario which I think we've hit:

* Execute a DETACH PARTITION
* DROP_RANGE event put in the queue
* Replicas try to execute dropRange but some of them get disconnected
  from ZK and 5 retries aren't enough (ZK is miss-behaving), return code
  (false) is ignored and log pointer advances.
* One of the replica where dropRange failed is restarted.
* checkParts is executed and it finds parts that weren't removed from
  ZK, logs `Removing locally missing part from ZooKeeper and queueing a
  fetch` and puts GET_PART on the queue.
* Few things can happen from here:
  * There is a lagging replica that din't execute DROP_RANGE yet: part will be
    fetched. The other replica will execute DROP_RANGE later and we'll
    get diverging set of parts on replicas.
  * Another replica also silently failed to remove parts from ZK: both
    of them are left with GET_PART in the queue and none of them can
    make progress, logging: `No active replica has part ... or covering
    part`.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...