### PR TITLE
add --backslash option for clickhouse-format

### DIFF
--- a/programs/format/Format.cpp
+++ b/programs/format/Format.cpp
@@ -1,6 +1,6 @@
+#include <functional>
 #include <iostream>
 #include <string_view>
-#include <functional>
 #include <boost/program_options.hpp>
 
 #include <IO/ReadBufferFromFileDescriptor.h>
@@ -40,6 +40,7 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
         ("quiet,q", "just check syntax, no output on success")
         ("multiquery,n", "allow multiple queries in the same file")
         ("obfuscate", "obfuscate instead of formatting")
+        ("backslash", "add a backslash at the end of each line of the formatted query")
         ("seed", po::value<std::string>(), "seed (arbitrary string) that determines the result of obfuscation")
     ;
 
@@ -60,6 +61,7 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
         bool quiet = options.count("quiet");
         bool multiple = options.count("multiquery");
         bool obfuscate = options.count("obfuscate");
+        bool backslash = options.count("backslash");
 
         if (quiet && (hilite || oneline || obfuscate))
         {
@@ -130,12 +132,39 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
                 ASTPtr res = parseQueryAndMovePosition(parser, pos, end, "query", multiple, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
                 if (!quiet)
                 {
-                    WriteBufferFromOStream res_buf(std::cout, 4096);
-                    formatAST(*res, res_buf, hilite, oneline);
-                    res_buf.next();
-                    if (multiple)
-                        std::cout << "\n;\n";
-                    std::cout << std::endl;
+                    if (!backslash)
+                    {
+                        WriteBufferFromOStream res_buf(std::cout, 4096);
+                        formatAST(*res, res_buf, hilite, oneline);
+                        res_buf.next();
+                        if (multiple)
+                            std::cout << "\n;\n";
+                        std::cout << std::endl;
+                    }
+                    /// add additional '\' at the end of each line;
+                    else
+                    {
+                        WriteBufferFromOwnString str_buf;
+                        formatAST(*res, str_buf, hilite, oneline);
+
+                        auto res_string = str_buf.str();
+                        WriteBufferFromOStream res_cout(std::cout, 4096);
+
+                        const char * s_pos= res_string.data();
+                        const char * s_end = s_pos + res_string.size();
+
+                        while (s_pos != s_end)
+                        {
+                            if (*s_pos == '\n')
+                                res_cout.write(" \\", 2);
+                            res_cout.write(*s_pos++);
+                        }
+
+                        res_cout.next();
+                        if (multiple)
+                            std::cout << " \\\n;\n";
+                        std::cout << std::endl;
+                    }
                 }
             } while (multiple && pos != end);
         }

--- a/tests/queries/0_stateless/01754_clickhouse_format_backslash.reference
+++ b/tests/queries/0_stateless/01754_clickhouse_format_backslash.reference
@@ -1,0 +1,16 @@
+SELECT * \
+FROM  \
+( \
+    SELECT 1 AS x \
+    UNION ALL \
+    SELECT 1 \
+    UNION DISTINCT \
+    SELECT 3 \
+)
+SELECT 1 \
+UNION ALL \
+( \
+    SELECT 1 \
+    UNION DISTINCT \
+    SELECT 1 \
+)

--- a/tests/queries/0_stateless/01754_clickhouse_format_backslash.sh
+++ b/tests/queries/0_stateless/01754_clickhouse_format_backslash.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+echo "select * from (select 1 as x union all select 1 union distinct select 3)" | $CLICKHOUSE_FORMAT --backslash;
+
+echo "select 1 union all (select 1 union distinct select 1)" | $CLICKHOUSE_FORMAT --backslash;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add option `--backslash` for clickhouse-format, which can add a backslash at the end of each line of the formatted query.

Detailed description / Documentation draft:

use case: sometimes when we copy a query from web or somewhere else with multiple lines, and want to execute it in command line.