### PR TITLE
Add check for growing age AND precision in rollup config

### DIFF
--- a/tests/integration/test_graphite_merge_tree/configs/graphite_rollup.xml
+++ b/tests/integration/test_graphite_merge_tree/configs/graphite_rollup.xml
@@ -94,4 +94,25 @@
             </retention>
         </default>
     </graphite_rollup_broken>
+    <graphite_rollup_wrong_age_precision>
+        <path_column_name>metric</path_column_name>
+        <time_column_name>timestamp</time_column_name>
+        <value_column_name>value</value_column_name>
+        <version_column_name>updated</version_column_name>
+        <default>
+            <function>avg</function>
+            <retention>
+                <age>0</age>
+                <precision>60</precision>
+            </retention>
+            <retention>
+                <age>36000</age>
+                <precision>600</precision>
+            </retention>
+            <retention>
+                <age>72000</age>
+                <precision>300</precision>
+            </retention>
+        </default>
+    </graphite_rollup_wrong_age_precision>
 </yandex>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Age and Precision in graphite rollup configs should increase from retention to retention. Now it's checked and the wrong config raises an exception