### PR TITLE
add aliases to visitParam/visitParamExtract* functions

### DIFF
--- a/src/Functions/visitParamExtractBool.cpp
+++ b/src/Functions/visitParamExtractBool.cpp
@@ -19,13 +19,13 @@ struct ExtractBool
 struct NameVisitParamExtractBool   { static constexpr auto name = "visitParamExtractBool"; };
 using FunctionVisitParamExtractBool = FunctionsStringSearch<ExtractParamImpl<ExtractBool>, NameVisitParamExtractBool>;
 
-struct NameJSONSExtractBool   { static constexpr auto name = "JSONSExtractBool"; };
-using FunctionJSONSExtractBool = FunctionsStringSearch<ExtractParamImpl<ExtractBool>, NameJSONSExtractBool>;
+struct NameSimpleJSONExtractBool   { static constexpr auto name = "SimpleJSONExtractBool"; };
+using FunctionSimpleJSONExtractBool = FunctionsStringSearch<ExtractParamImpl<ExtractBool>, NameSimpleJSONExtractBool>;
 
 void registerFunctionVisitParamExtractBool(FunctionFactory & factory)
 {
     factory.registerFunction<FunctionVisitParamExtractBool>();
-    factory.registerFunction<FunctionJSONSExtractBool>();
+    factory.registerFunction<FunctionSimpleJSONExtractBool>();
 }
 
 }

--- a/src/Functions/visitParamExtractBool.cpp
+++ b/src/Functions/visitParamExtractBool.cpp
@@ -19,7 +19,7 @@ struct ExtractBool
 struct NameVisitParamExtractBool   { static constexpr auto name = "visitParamExtractBool"; };
 using FunctionVisitParamExtractBool = FunctionsStringSearch<ExtractParamImpl<ExtractBool>, NameVisitParamExtractBool>;
 
-struct NameSimpleJSONExtractBool   { static constexpr auto name = "SimpleJSONExtractBool"; };
+struct NameSimpleJSONExtractBool   { static constexpr auto name = "simpleJSONExtractBool"; };
 using FunctionSimpleJSONExtractBool = FunctionsStringSearch<ExtractParamImpl<ExtractBool>, NameSimpleJSONExtractBool>;
 
 void registerFunctionVisitParamExtractBool(FunctionFactory & factory)

--- a/src/Functions/visitParamExtractBool.cpp
+++ b/src/Functions/visitParamExtractBool.cpp
@@ -19,10 +19,13 @@ struct ExtractBool
 struct NameVisitParamExtractBool   { static constexpr auto name = "visitParamExtractBool"; };
 using FunctionVisitParamExtractBool = FunctionsStringSearch<ExtractParamImpl<ExtractBool>, NameVisitParamExtractBool>;
 
+struct NameJSONSExtractBool   { static constexpr auto name = "JSONSExtractBool"; };
+using FunctionJSONSExtractBool = FunctionsStringSearch<ExtractParamImpl<ExtractBool>, NameJSONSExtractBool>;
 
 void registerFunctionVisitParamExtractBool(FunctionFactory & factory)
 {
     factory.registerFunction<FunctionVisitParamExtractBool>();
+    factory.registerFunction<FunctionJSONSExtractBool>();
 }
 
 }

--- a/src/Functions/visitParamExtractFloat.cpp
+++ b/src/Functions/visitParamExtractFloat.cpp
@@ -9,13 +9,13 @@ namespace DB
 struct NameVisitParamExtractFloat  { static constexpr auto name = "visitParamExtractFloat"; };
 using FunctionVisitParamExtractFloat = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<Float64>>, NameVisitParamExtractFloat>;
 
-struct NameJSONSExtractFloat  { static constexpr auto name = "JSONSExtractFloat"; };
-using FunctionJSONSExtractFloat = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<Float64>>, NameJSONSExtractFloat>;
+struct NameSimpleJSONExtractFloat  { static constexpr auto name = "SimpleJSONExtractFloat"; };
+using FunctionSimpleJSONExtractFloat = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<Float64>>, NameSimpleJSONExtractFloat>;
 
 void registerFunctionVisitParamExtractFloat(FunctionFactory & factory)
 {
     factory.registerFunction<FunctionVisitParamExtractFloat>();
-    factory.registerFunction<FunctionJSONSExtractFloat>();
+    factory.registerFunction<FunctionSimpleJSONExtractFloat>();
 }
 
 }

--- a/src/Functions/visitParamExtractFloat.cpp
+++ b/src/Functions/visitParamExtractFloat.cpp
@@ -9,10 +9,13 @@ namespace DB
 struct NameVisitParamExtractFloat  { static constexpr auto name = "visitParamExtractFloat"; };
 using FunctionVisitParamExtractFloat = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<Float64>>, NameVisitParamExtractFloat>;
 
+struct NameJSONSExtractFloat  { static constexpr auto name = "JSONSExtractFloat"; };
+using FunctionJSONSExtractFloat = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<Float64>>, NameJSONSExtractFloat>;
 
 void registerFunctionVisitParamExtractFloat(FunctionFactory & factory)
 {
     factory.registerFunction<FunctionVisitParamExtractFloat>();
+    factory.registerFunction<FunctionJSONSExtractFloat>();
 }
 
 }

--- a/src/Functions/visitParamExtractFloat.cpp
+++ b/src/Functions/visitParamExtractFloat.cpp
@@ -9,7 +9,7 @@ namespace DB
 struct NameVisitParamExtractFloat  { static constexpr auto name = "visitParamExtractFloat"; };
 using FunctionVisitParamExtractFloat = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<Float64>>, NameVisitParamExtractFloat>;
 
-struct NameSimpleJSONExtractFloat  { static constexpr auto name = "SimpleJSONExtractFloat"; };
+struct NameSimpleJSONExtractFloat  { static constexpr auto name = "simpleJSONExtractFloat"; };
 using FunctionSimpleJSONExtractFloat = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<Float64>>, NameSimpleJSONExtractFloat>;
 
 void registerFunctionVisitParamExtractFloat(FunctionFactory & factory)

--- a/src/Functions/visitParamExtractInt.cpp
+++ b/src/Functions/visitParamExtractInt.cpp
@@ -9,10 +9,13 @@ namespace DB
 struct NameVisitParamExtractInt    { static constexpr auto name = "visitParamExtractInt"; };
 using FunctionVisitParamExtractInt = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<Int64>>, NameVisitParamExtractInt>;
 
+struct NameJSONSExtractInt    { static constexpr auto name = "JSONSExtractInt"; };
+using FunctionJSONSExtractInt = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<Int64>>, NameJSONSExtractInt>;
 
 void registerFunctionVisitParamExtractInt(FunctionFactory & factory)
 {
     factory.registerFunction<FunctionVisitParamExtractInt>();
+    factory.registerFunction<FunctionJSONSExtractInt>();
 }
 
 }

--- a/src/Functions/visitParamExtractInt.cpp
+++ b/src/Functions/visitParamExtractInt.cpp
@@ -9,7 +9,7 @@ namespace DB
 struct NameVisitParamExtractInt    { static constexpr auto name = "visitParamExtractInt"; };
 using FunctionVisitParamExtractInt = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<Int64>>, NameVisitParamExtractInt>;
 
-struct NameSimpleJSONExtractInt    { static constexpr auto name = "SimpleJSONExtractInt"; };
+struct NameSimpleJSONExtractInt    { static constexpr auto name = "simpleJSONExtractInt"; };
 using FunctionSimpleJSONExtractInt = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<Int64>>, NameSimpleJSONExtractInt>;
 
 void registerFunctionVisitParamExtractInt(FunctionFactory & factory)

--- a/src/Functions/visitParamExtractInt.cpp
+++ b/src/Functions/visitParamExtractInt.cpp
@@ -9,13 +9,13 @@ namespace DB
 struct NameVisitParamExtractInt    { static constexpr auto name = "visitParamExtractInt"; };
 using FunctionVisitParamExtractInt = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<Int64>>, NameVisitParamExtractInt>;
 
-struct NameJSONSExtractInt    { static constexpr auto name = "JSONSExtractInt"; };
-using FunctionJSONSExtractInt = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<Int64>>, NameJSONSExtractInt>;
+struct NameSimpleJSONExtractInt    { static constexpr auto name = "SimpleJSONExtractInt"; };
+using FunctionSimpleJSONExtractInt = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<Int64>>, NameSimpleJSONExtractInt>;
 
 void registerFunctionVisitParamExtractInt(FunctionFactory & factory)
 {
     factory.registerFunction<FunctionVisitParamExtractInt>();
-    factory.registerFunction<FunctionJSONSExtractInt>();
+    factory.registerFunction<FunctionSimpleJSONExtractInt>();
 }
 
 }

--- a/src/Functions/visitParamExtractRaw.cpp
+++ b/src/Functions/visitParamExtractRaw.cpp
@@ -59,10 +59,13 @@ struct ExtractRaw
 struct NameVisitParamExtractRaw    { static constexpr auto name = "visitParamExtractRaw"; };
 using FunctionVisitParamExtractRaw = FunctionsStringSearchToString<ExtractParamToStringImpl<ExtractRaw>, NameVisitParamExtractRaw>;
 
+struct NameJSONSExtractRaw    { static constexpr auto name = "JSONSExtractRaw"; };
+using FunctionJSONSExtractRaw = FunctionsStringSearchToString<ExtractParamToStringImpl<ExtractRaw>, NameJSONSExtractRaw>;
 
 void registerFunctionVisitParamExtractRaw(FunctionFactory & factory)
 {
     factory.registerFunction<FunctionVisitParamExtractRaw>();
+    factory.registerFunction<FunctionJSONSExtractRaw>();
 }
 
 }

--- a/src/Functions/visitParamExtractRaw.cpp
+++ b/src/Functions/visitParamExtractRaw.cpp
@@ -59,13 +59,13 @@ struct ExtractRaw
 struct NameVisitParamExtractRaw    { static constexpr auto name = "visitParamExtractRaw"; };
 using FunctionVisitParamExtractRaw = FunctionsStringSearchToString<ExtractParamToStringImpl<ExtractRaw>, NameVisitParamExtractRaw>;
 
-struct NameJSONSExtractRaw    { static constexpr auto name = "JSONSExtractRaw"; };
-using FunctionJSONSExtractRaw = FunctionsStringSearchToString<ExtractParamToStringImpl<ExtractRaw>, NameJSONSExtractRaw>;
+struct NameSimpleJSONExtractRaw    { static constexpr auto name = "SimpleJSONExtractRaw"; };
+using FunctionSimpleJSONExtractRaw = FunctionsStringSearchToString<ExtractParamToStringImpl<ExtractRaw>, NameSimpleJSONExtractRaw>;
 
 void registerFunctionVisitParamExtractRaw(FunctionFactory & factory)
 {
     factory.registerFunction<FunctionVisitParamExtractRaw>();
-    factory.registerFunction<FunctionJSONSExtractRaw>();
+    factory.registerFunction<FunctionSimpleJSONExtractRaw>();
 }
 
 }

--- a/src/Functions/visitParamExtractRaw.cpp
+++ b/src/Functions/visitParamExtractRaw.cpp
@@ -59,7 +59,7 @@ struct ExtractRaw
 struct NameVisitParamExtractRaw    { static constexpr auto name = "visitParamExtractRaw"; };
 using FunctionVisitParamExtractRaw = FunctionsStringSearchToString<ExtractParamToStringImpl<ExtractRaw>, NameVisitParamExtractRaw>;
 
-struct NameSimpleJSONExtractRaw    { static constexpr auto name = "SimpleJSONExtractRaw"; };
+struct NameSimpleJSONExtractRaw    { static constexpr auto name = "simpleJSONExtractRaw"; };
 using FunctionSimpleJSONExtractRaw = FunctionsStringSearchToString<ExtractParamToStringImpl<ExtractRaw>, NameSimpleJSONExtractRaw>;
 
 void registerFunctionVisitParamExtractRaw(FunctionFactory & factory)

--- a/src/Functions/visitParamExtractString.cpp
+++ b/src/Functions/visitParamExtractString.cpp
@@ -20,13 +20,13 @@ struct ExtractString
 struct NameVisitParamExtractString { static constexpr auto name = "visitParamExtractString"; };
 using FunctionVisitParamExtractString = FunctionsStringSearchToString<ExtractParamToStringImpl<ExtractString>, NameVisitParamExtractString>;
 
-struct NameJSONSExtractString { static constexpr auto name = "JSONSExtractString"; };
-using FunctionJSONSExtractString = FunctionsStringSearchToString<ExtractParamToStringImpl<ExtractString>, NameJSONSExtractString>;
+struct NameSimpleJSONExtractString { static constexpr auto name = "SimpleJSONExtractString"; };
+using FunctionSimpleJSONExtractString = FunctionsStringSearchToString<ExtractParamToStringImpl<ExtractString>, NameSimpleJSONExtractString>;
 
 void registerFunctionVisitParamExtractString(FunctionFactory & factory)
 {
     factory.registerFunction<FunctionVisitParamExtractString>();
-    factory.registerFunction<FunctionJSONSExtractString>();
+    factory.registerFunction<FunctionSimpleJSONExtractString>();
 }
 
 }

--- a/src/Functions/visitParamExtractString.cpp
+++ b/src/Functions/visitParamExtractString.cpp
@@ -20,7 +20,7 @@ struct ExtractString
 struct NameVisitParamExtractString { static constexpr auto name = "visitParamExtractString"; };
 using FunctionVisitParamExtractString = FunctionsStringSearchToString<ExtractParamToStringImpl<ExtractString>, NameVisitParamExtractString>;
 
-struct NameSimpleJSONExtractString { static constexpr auto name = "SimpleJSONExtractString"; };
+struct NameSimpleJSONExtractString { static constexpr auto name = "simpleJSONExtractString"; };
 using FunctionSimpleJSONExtractString = FunctionsStringSearchToString<ExtractParamToStringImpl<ExtractString>, NameSimpleJSONExtractString>;
 
 void registerFunctionVisitParamExtractString(FunctionFactory & factory)

--- a/src/Functions/visitParamExtractString.cpp
+++ b/src/Functions/visitParamExtractString.cpp
@@ -20,10 +20,13 @@ struct ExtractString
 struct NameVisitParamExtractString { static constexpr auto name = "visitParamExtractString"; };
 using FunctionVisitParamExtractString = FunctionsStringSearchToString<ExtractParamToStringImpl<ExtractString>, NameVisitParamExtractString>;
 
+struct NameJSONSExtractString { static constexpr auto name = "JSONSExtractString"; };
+using FunctionJSONSExtractString = FunctionsStringSearchToString<ExtractParamToStringImpl<ExtractString>, NameJSONSExtractString>;
 
 void registerFunctionVisitParamExtractString(FunctionFactory & factory)
 {
     factory.registerFunction<FunctionVisitParamExtractString>();
+    factory.registerFunction<FunctionJSONSExtractString>();
 }
 
 }

--- a/src/Functions/visitParamExtractUInt.cpp
+++ b/src/Functions/visitParamExtractUInt.cpp
@@ -9,14 +9,14 @@ namespace DB
 struct NameVisitParamExtractUInt   { static constexpr auto name = "visitParamExtractUInt"; };
 using FunctionVisitParamExtractUInt = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<UInt64>>, NameVisitParamExtractUInt>;
 
-struct NameJSONSExtractUInt   { static constexpr auto name = "JSONSExtractUInt"; };
-using FunctionJSONSExtractUInt = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<UInt64>>, NameJSONSExtractUInt>;
+struct NameSimpleJSONExtractUInt   { static constexpr auto name = "SimpleJSONExtractUInt"; };
+using FunctionSimpleJSONExtractUInt = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<UInt64>>, NameSimpleJSONExtractUInt>;
 
 
 void registerFunctionVisitParamExtractUInt(FunctionFactory & factory)
 {
     factory.registerFunction<FunctionVisitParamExtractUInt>();
-    factory.registerFunction<FunctionJSONSExtractUInt>();
+    factory.registerFunction<FunctionSimpleJSONExtractUInt>();
 }
 
 }

--- a/src/Functions/visitParamExtractUInt.cpp
+++ b/src/Functions/visitParamExtractUInt.cpp
@@ -9,10 +9,14 @@ namespace DB
 struct NameVisitParamExtractUInt   { static constexpr auto name = "visitParamExtractUInt"; };
 using FunctionVisitParamExtractUInt = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<UInt64>>, NameVisitParamExtractUInt>;
 
+struct NameJSONSExtractUInt   { static constexpr auto name = "JSONSExtractUInt"; };
+using FunctionJSONSExtractUInt = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<UInt64>>, NameJSONSExtractUInt>;
+
 
 void registerFunctionVisitParamExtractUInt(FunctionFactory & factory)
 {
     factory.registerFunction<FunctionVisitParamExtractUInt>();
+    factory.registerFunction<FunctionJSONSExtractUInt>();
 }
 
 }

--- a/src/Functions/visitParamExtractUInt.cpp
+++ b/src/Functions/visitParamExtractUInt.cpp
@@ -9,7 +9,7 @@ namespace DB
 struct NameVisitParamExtractUInt   { static constexpr auto name = "visitParamExtractUInt"; };
 using FunctionVisitParamExtractUInt = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<UInt64>>, NameVisitParamExtractUInt>;
 
-struct NameSimpleJSONExtractUInt   { static constexpr auto name = "SimpleJSONExtractUInt"; };
+struct NameSimpleJSONExtractUInt   { static constexpr auto name = "simpleJSONExtractUInt"; };
 using FunctionSimpleJSONExtractUInt = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<UInt64>>, NameSimpleJSONExtractUInt>;
 
 

--- a/src/Functions/visitParamHas.cpp
+++ b/src/Functions/visitParamHas.cpp
@@ -19,13 +19,13 @@ struct HasParam
 struct NameVisitParamHas           { static constexpr auto name = "visitParamHas"; };
 using FunctionVisitParamHas = FunctionsStringSearch<ExtractParamImpl<HasParam>, NameVisitParamHas>;
 
-struct NameJSONSHas           { static constexpr auto name = "JSONSHas"; };
-using FunctionJSONSHas = FunctionsStringSearch<ExtractParamImpl<HasParam>, NameJSONSHas>;
+struct NameSimpleJSONHas           { static constexpr auto name = "SimpleJSONHas"; };
+using FunctionSimpleJSONHas = FunctionsStringSearch<ExtractParamImpl<HasParam>, NameSimpleJSONHas>;
 
 void registerFunctionVisitParamHas(FunctionFactory & factory)
 {
     factory.registerFunction<FunctionVisitParamHas>();
-    factory.registerFunction<FunctionJSONSHas>();
+    factory.registerFunction<FunctionSimpleJSONHas>();
 }
 
 }

--- a/src/Functions/visitParamHas.cpp
+++ b/src/Functions/visitParamHas.cpp
@@ -19,10 +19,13 @@ struct HasParam
 struct NameVisitParamHas           { static constexpr auto name = "visitParamHas"; };
 using FunctionVisitParamHas = FunctionsStringSearch<ExtractParamImpl<HasParam>, NameVisitParamHas>;
 
+struct NameJSONSHas           { static constexpr auto name = "JSONSHas"; };
+using FunctionJSONSHas = FunctionsStringSearch<ExtractParamImpl<HasParam>, NameJSONSHas>;
 
 void registerFunctionVisitParamHas(FunctionFactory & factory)
 {
     factory.registerFunction<FunctionVisitParamHas>();
+    factory.registerFunction<FunctionJSONSHas>();
 }
 
 }

--- a/src/Functions/visitParamHas.cpp
+++ b/src/Functions/visitParamHas.cpp
@@ -19,7 +19,7 @@ struct HasParam
 struct NameVisitParamHas           { static constexpr auto name = "visitParamHas"; };
 using FunctionVisitParamHas = FunctionsStringSearch<ExtractParamImpl<HasParam>, NameVisitParamHas>;
 
-struct NameSimpleJSONHas           { static constexpr auto name = "SimpleJSONHas"; };
+struct NameSimpleJSONHas           { static constexpr auto name = "simpleJSONHas"; };
 using FunctionSimpleJSONHas = FunctionsStringSearch<ExtractParamImpl<HasParam>, NameSimpleJSONHas>;
 
 void registerFunctionVisitParamHas(FunctionFactory & factory)

--- a/tests/queries/0_stateless/00539_functions_for_working_with_json.reference
+++ b/tests/queries/0_stateless/00539_functions_for_working_with_json.reference
@@ -13,3 +13,10 @@ test"string
  "["
  ["]", "2", "3"]
  {"nested" : [1,2,3]}
+-1
+0
+0
+-1
+1
+test_string
+test"string

--- a/tests/queries/0_stateless/00539_functions_for_working_with_json.sql
+++ b/tests/queries/0_stateless/00539_functions_for_working_with_json.sql
@@ -15,3 +15,11 @@ SELECT visitParamExtractRaw('{"myparam": "{"}', 'myparam');
 SELECT visitParamExtractRaw('{"myparam": "["}', 'myparam');
 SELECT visitParamExtractRaw('{"myparam": ["]", "2", "3"], "other":123}', 'myparam');
 SELECT visitParamExtractRaw('{"myparam": {"nested" : [1,2,3]}, "other":123}', 'myparam');
+
+SELECT JSONExtractInt('{"myparam":-1}', 'myparam');
+SELECT JSONExtractUInt('{"myparam":-1}', 'myparam');
+SELECT JSONExtractFloat('{"myparam":null}', 'myparam');
+SELECT JSONExtractFloat('{"myparam":-1}', 'myparam');
+SELECT JSONExtractBool('{"myparam":true}', 'myparam');
+SELECT JSONExtractString('{"myparam":"test_string"}', 'myparam');
+SELECT JSONExtractString('{"myparam":"test\\"string"}', 'myparam');

--- a/tests/queries/0_stateless/00539_functions_for_working_with_json.sql
+++ b/tests/queries/0_stateless/00539_functions_for_working_with_json.sql
@@ -16,10 +16,10 @@ SELECT visitParamExtractRaw('{"myparam": "["}', 'myparam');
 SELECT visitParamExtractRaw('{"myparam": ["]", "2", "3"], "other":123}', 'myparam');
 SELECT visitParamExtractRaw('{"myparam": {"nested" : [1,2,3]}, "other":123}', 'myparam');
 
-SELECT SimpleJSONExtractInt('{"myparam":-1}', 'myparam');
-SELECT SimpleJSONExtractUInt('{"myparam":-1}', 'myparam');
-SELECT SimpleJSONExtractFloat('{"myparam":null}', 'myparam');
-SELECT SimpleJSONExtractFloat('{"myparam":-1}', 'myparam');
-SELECT SimpleJSONExtractBool('{"myparam":true}', 'myparam');
-SELECT SimpleJSONExtractString('{"myparam":"test_string"}', 'myparam');
-SELECT SimpleJSONExtractString('{"myparam":"test\\"string"}', 'myparam');
+SELECT simpleJSONExtractInt('{"myparam":-1}', 'myparam');
+SELECT simpleJSONExtractUInt('{"myparam":-1}', 'myparam');
+SELECT simpleJSONExtractFloat('{"myparam":null}', 'myparam');
+SELECT simpleJSONExtractFloat('{"myparam":-1}', 'myparam');
+SELECT simpleJSONExtractBool('{"myparam":true}', 'myparam');
+SELECT simpleJSONExtractString('{"myparam":"test_string"}', 'myparam');
+SELECT simpleJSONExtractString('{"myparam":"test\\"string"}', 'myparam');

--- a/tests/queries/0_stateless/00539_functions_for_working_with_json.sql
+++ b/tests/queries/0_stateless/00539_functions_for_working_with_json.sql
@@ -16,10 +16,10 @@ SELECT visitParamExtractRaw('{"myparam": "["}', 'myparam');
 SELECT visitParamExtractRaw('{"myparam": ["]", "2", "3"], "other":123}', 'myparam');
 SELECT visitParamExtractRaw('{"myparam": {"nested" : [1,2,3]}, "other":123}', 'myparam');
 
-SELECT JSONExtractInt('{"myparam":-1}', 'myparam');
-SELECT JSONExtractUInt('{"myparam":-1}', 'myparam');
-SELECT JSONExtractFloat('{"myparam":null}', 'myparam');
-SELECT JSONExtractFloat('{"myparam":-1}', 'myparam');
-SELECT JSONExtractBool('{"myparam":true}', 'myparam');
-SELECT JSONExtractString('{"myparam":"test_string"}', 'myparam');
-SELECT JSONExtractString('{"myparam":"test\\"string"}', 'myparam');
+SELECT SimpleJSONExtractInt('{"myparam":-1}', 'myparam');
+SELECT SimpleJSONExtractUInt('{"myparam":-1}', 'myparam');
+SELECT SimpleJSONExtractFloat('{"myparam":null}', 'myparam');
+SELECT SimpleJSONExtractFloat('{"myparam":-1}', 'myparam');
+SELECT SimpleJSONExtractBool('{"myparam":true}', 'myparam');
+SELECT SimpleJSONExtractString('{"myparam":"test_string"}', 'myparam');
+SELECT SimpleJSONExtractString('{"myparam":"test\\"string"}', 'myparam');


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add aliases `simpleJSONExtract/simpleJSONHas` to `visitParam/visitParamExtract{UInt, Int, Bool, Float, Raw, String}`. Fixes #21383.

Detailed description / Documentation draft:

#21383