### PR TITLE
Avoid processing optimize_skip_unused_shards twice

### DIFF
--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -530,7 +530,7 @@ void StorageDistributed::read(
         query_info.query, remote_database, remote_table, remote_table_function_ptr);
 
     Block header =
-        InterpreterSelectQuery(query_info.query, context, SelectQueryOptions(processed_stage)).getSampleBlock();
+        InterpreterSelectQuery(query_info.query, context, SelectQueryOptions(processed_stage).analyze()).getSampleBlock();
 
     const Scalars & scalars = context.hasQueryContext() ? context.getQueryContext().getScalars() : Scalars{};
 

--- a/tests/queries/0_stateless/01758_optimize_skip_unused_shards_once.reference
+++ b/tests/queries/0_stateless/01758_optimize_skip_unused_shards_once.reference
@@ -1,0 +1,2 @@
+StorageDistributed (dist_01758): Auto-increment is 0
+StorageDistributed (dist_01758): Skipping irrelevant shards - the query will be sent to the following shards of the cluster (shard numbers): [1]

--- a/tests/queries/0_stateless/01758_optimize_skip_unused_shards_once.sh
+++ b/tests/queries/0_stateless/01758_optimize_skip_unused_shards_once.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=trace
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT --optimize_skip_unused_shards=1 -nm -q "
+create table dist_01758 as system.one engine=Distributed(test_cluster_two_shards, system, one, dummy);
+select * from dist_01758 where dummy = 0 format Null;
+" |& grep -o "StorageDistributed (dist_01758).*"


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Avoid processing optimize_skip_unused_shards twice

Refs: #14731 (and now with a test)