### PR TITLE
Add last_error_time/last_error_message/last_error_stacktrace/remote columns for system.errors

### DIFF
--- a/docs/en/operations/system-tables/errors.md
+++ b/docs/en/operations/system-tables/errors.md
@@ -9,6 +9,7 @@ Columns:
 -   `value` ([UInt64](../../sql-reference/data-types/int-uint.md)) — the number of times this error has been happened.
 -   `last_error_time` ([DateTime](../../sql-reference/data-types/datetime.md)) — time when the last error happened.
 -   `last_error_message` ([String](../../sql-reference/data-types/string.md)) — message for the last error.
+-   `last_error_stacktrace` ([String](../../sql-reference/data-types/string.md)) — stacktrace for the last error.
 -   `remote` ([UInt8](../../sql-reference/data-types/int-uint.md)) — remote exception (i.e. received during one of the distributed query).
 
 **Example**

--- a/docs/en/operations/system-tables/errors.md
+++ b/docs/en/operations/system-tables/errors.md
@@ -7,11 +7,12 @@ Columns:
 -   `name` ([String](../../sql-reference/data-types/string.md)) — name of the error (`errorCodeToName`).
 -   `code` ([Int32](../../sql-reference/data-types/int-uint.md)) — code number of the error.
 -   `value` ([UInt64](../../sql-reference/data-types/int-uint.md)) — the number of times this error has been happened.
+-   `remote` ([UInt8](../../sql-reference/data-types/int-uint.md)) — remote exception (i.e. received during one of the distributed query).
 
 **Example**
 
 ``` sql
-SELECT *
+SELECT name, code, value
 FROM system.errors
 WHERE value > 0
 ORDER BY code ASC

--- a/docs/en/operations/system-tables/errors.md
+++ b/docs/en/operations/system-tables/errors.md
@@ -8,6 +8,7 @@ Columns:
 -   `code` ([Int32](../../sql-reference/data-types/int-uint.md)) — code number of the error.
 -   `value` ([UInt64](../../sql-reference/data-types/int-uint.md)) — the number of times this error has been happened.
 -   `last_error_time` ([DateTime](../../sql-reference/data-types/datetime.md)) — time when the last error happened.
+-   `last_error_message` ([String](../../sql-reference/data-types/string.md)) — message for the last error.
 -   `remote` ([UInt8](../../sql-reference/data-types/int-uint.md)) — remote exception (i.e. received during one of the distributed query).
 
 **Example**

--- a/docs/en/operations/system-tables/errors.md
+++ b/docs/en/operations/system-tables/errors.md
@@ -7,6 +7,7 @@ Columns:
 -   `name` ([String](../../sql-reference/data-types/string.md)) — name of the error (`errorCodeToName`).
 -   `code` ([Int32](../../sql-reference/data-types/int-uint.md)) — code number of the error.
 -   `value` ([UInt64](../../sql-reference/data-types/int-uint.md)) — the number of times this error has been happened.
+-   `last_error_time` ([DateTime](../../sql-reference/data-types/datetime.md)) — time when the last error happened.
 -   `remote` ([UInt8](../../sql-reference/data-types/int-uint.md)) — remote exception (i.e. received during one of the distributed query).
 
 **Example**

--- a/src/Common/ErrorCodes.cpp
+++ b/src/Common/ErrorCodes.cpp
@@ -1,4 +1,5 @@
 #include <Common/ErrorCodes.h>
+#include <chrono>
 
 /** Previously, these constants were located in one enum.
   * But in this case there is a problem: when you add a new constant, you need to recompile
@@ -605,6 +606,10 @@ namespace ErrorCodes
     {
         local  += value.local;
         remote += value.remote;
+
+        const auto now = std::chrono::system_clock::now();
+        last_error_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
+
         return *this;
     }
 

--- a/src/Common/ErrorCodes.cpp
+++ b/src/Common/ErrorCodes.cpp
@@ -584,6 +584,17 @@ namespace ErrorCodes
     }
 
     ErrorCode end() { return END + 1; }
+
+    void increment(ErrorCode error_code)
+    {
+        if (error_code >= end())
+        {
+            /// For everything outside the range, use END.
+            /// (end() is the pointer pass the end, while END is the last value that has an element in values array).
+            error_code = end() - 1;
+        }
+        values[error_code].fetch_add(1, std::memory_order_relaxed);
+    }
 }
 
 }

--- a/src/Common/ErrorCodes.cpp
+++ b/src/Common/ErrorCodes.cpp
@@ -586,7 +586,7 @@ namespace ErrorCodes
 
     ErrorCode end() { return END + 1; }
 
-    void increment(ErrorCode error_code, bool remote)
+    void increment(ErrorCode error_code, bool remote, const std::string & message)
     {
         if (error_code >= end())
         {
@@ -598,6 +598,8 @@ namespace ErrorCodes
         ValuePair inc_value{
             !remote, /* local */
             remote,  /* remote */
+            0,       /* last_error_time_ms */
+            message, /* message */
         };
         values[error_code].increment(inc_value);
     }
@@ -606,6 +608,7 @@ namespace ErrorCodes
     {
         local  += value.local;
         remote += value.remote;
+        message = value.message;
 
         const auto now = std::chrono::system_clock::now();
         last_error_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();

--- a/src/Common/ErrorCodes.cpp
+++ b/src/Common/ErrorCodes.cpp
@@ -598,7 +598,7 @@ namespace ErrorCodes
         ValuePair inc_value{
             !remote,    /* local */
             remote,     /* remote */
-            0,          /* last_error_time_ms */
+            0,          /* error_time_ms */
             message,    /* message */
             stacktrace, /* stacktrace */
         };
@@ -613,7 +613,7 @@ namespace ErrorCodes
         stacktrace = value.stacktrace;
 
         const auto now = std::chrono::system_clock::now();
-        last_error_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
+        error_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
 
         return *this;
     }

--- a/src/Common/ErrorCodes.cpp
+++ b/src/Common/ErrorCodes.cpp
@@ -586,7 +586,7 @@ namespace ErrorCodes
 
     ErrorCode end() { return END + 1; }
 
-    void increment(ErrorCode error_code, bool remote, const std::string & message)
+    void increment(ErrorCode error_code, bool remote, const std::string & message, const std::string & stacktrace)
     {
         if (error_code >= end())
         {
@@ -596,10 +596,11 @@ namespace ErrorCodes
         }
 
         ValuePair inc_value{
-            !remote, /* local */
-            remote,  /* remote */
-            0,       /* last_error_time_ms */
-            message, /* message */
+            !remote,    /* local */
+            remote,     /* remote */
+            0,          /* last_error_time_ms */
+            message,    /* message */
+            stacktrace, /* stacktrace */
         };
         values[error_code].increment(inc_value);
     }
@@ -609,6 +610,7 @@ namespace ErrorCodes
         local  += value.local;
         remote += value.remote;
         message = value.message;
+        stacktrace = value.stacktrace;
 
         const auto now = std::chrono::system_clock::now();
         last_error_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();

--- a/src/Common/ErrorCodes.cpp
+++ b/src/Common/ErrorCodes.cpp
@@ -563,7 +563,7 @@ namespace ErrorCodes
 #undef M
 
     constexpr Value END = 3000;
-    std::atomic<Value> values[END + 1]{};
+    ValuePair values[END + 1]{};
 
     struct ErrorCodesNames
     {
@@ -585,7 +585,7 @@ namespace ErrorCodes
 
     ErrorCode end() { return END + 1; }
 
-    void increment(ErrorCode error_code)
+    void increment(ErrorCode error_code, bool remote)
     {
         if (error_code >= end())
         {
@@ -593,7 +593,10 @@ namespace ErrorCodes
             /// (end() is the pointer pass the end, while END is the last value that has an element in values array).
             error_code = end() - 1;
         }
-        values[error_code].fetch_add(1, std::memory_order_relaxed);
+        if (remote)
+            values[error_code].remote.fetch_add(1, std::memory_order_relaxed);
+        else
+            values[error_code].local.fetch_add(1, std::memory_order_relaxed);
     }
 }
 

--- a/src/Common/ErrorCodes.cpp
+++ b/src/Common/ErrorCodes.cpp
@@ -562,7 +562,7 @@ namespace ErrorCodes
     APPLY_FOR_ERROR_CODES(M)
 #undef M
 
-    constexpr Value END = 3000;
+    constexpr ErrorCode END = 3000;
     ValuePair values[END + 1]{};
 
     struct ErrorCodesNames

--- a/src/Common/ErrorCodes.cpp
+++ b/src/Common/ErrorCodes.cpp
@@ -579,7 +579,7 @@ namespace ErrorCodes
 
     std::string_view getName(ErrorCode error_code)
     {
-        if (error_code >= END)
+        if (error_code < 0 || error_code >= END)
             return std::string_view();
         return error_codes_names.names[error_code];
     }

--- a/src/Common/ErrorCodes.h
+++ b/src/Common/ErrorCodes.h
@@ -28,6 +28,7 @@ namespace ErrorCodes
     {
         Value local = 0;
         Value remote = 0;
+        UInt64 last_error_time_ms = 0;
 
         ValuePair & operator+=(const ValuePair & value);
     };

--- a/src/Common/ErrorCodes.h
+++ b/src/Common/ErrorCodes.h
@@ -30,6 +30,7 @@ namespace ErrorCodes
         Value remote = 0;
         UInt64 last_error_time_ms = 0;
         std::string message;
+        std::string stacktrace;
 
         ValuePair & operator+=(const ValuePair & value);
     };
@@ -53,7 +54,7 @@ namespace ErrorCodes
     ErrorCode end();
 
     /// Add value for specified error_code.
-    void increment(ErrorCode error_code, bool remote, const std::string & message);
+    void increment(ErrorCode error_code, bool remote, const std::string & message, const std::string & stacktrace);
 }
 
 }

--- a/src/Common/ErrorCodes.h
+++ b/src/Common/ErrorCodes.h
@@ -24,31 +24,37 @@ namespace ErrorCodes
     /// Returns statically allocated string.
     std::string_view getName(ErrorCode error_code);
 
-    struct ValuePair
+    struct Error
     {
-        Value local = 0;
-        Value remote = 0;
+        /// Number of times Exception with this ErrorCode had been throw.
+        Value count;
+        /// Time of the last error.
         UInt64 error_time_ms = 0;
+        /// Message for the last error.
         std::string message;
+        /// Stacktrace for the last error.
         std::string stacktrace;
-
-        ValuePair & operator+=(const ValuePair & value);
+    };
+    struct ErrorPair
+    {
+        Error local;
+        Error remote;
     };
 
     /// Thread-safe
-    struct ValuePairHolder
+    struct ErrorPairHolder
     {
     public:
-        void increment(const ValuePair & value_);
-        ValuePair get();
+        ErrorPair get();
+        void increment(bool remote, const std::string & message, const std::string & stacktrace);
 
     private:
-        ValuePair value;
+        ErrorPair value;
         std::mutex mutex;
     };
 
     /// ErrorCode identifier -> current value of error_code.
-    extern ValuePairHolder values[];
+    extern ErrorPairHolder values[];
 
     /// Get index just after last error_code identifier.
     ErrorCode end();

--- a/src/Common/ErrorCodes.h
+++ b/src/Common/ErrorCodes.h
@@ -31,16 +31,7 @@ namespace ErrorCodes
     ErrorCode end();
 
     /// Add value for specified error_code.
-    inline void increment(ErrorCode error_code)
-    {
-        if (error_code >= end())
-        {
-            /// For everything outside the range, use END.
-            /// (end() is the pointer pass the end, while END is the last value that has an element in values array).
-            error_code = end() - 1;
-        }
-        values[error_code].fetch_add(1, std::memory_order_relaxed);
-    }
+    void increment(ErrorCode error_code);
 }
 
 }

--- a/src/Common/ErrorCodes.h
+++ b/src/Common/ErrorCodes.h
@@ -17,8 +17,8 @@ namespace DB
 namespace ErrorCodes
 {
     /// ErrorCode identifier (index in array).
-    using ErrorCode = size_t;
-    using Value = int;
+    using ErrorCode = int;
+    using Value = size_t;
 
     /// Get name of error_code by identifier.
     /// Returns statically allocated string.

--- a/src/Common/ErrorCodes.h
+++ b/src/Common/ErrorCodes.h
@@ -29,6 +29,7 @@ namespace ErrorCodes
         Value local = 0;
         Value remote = 0;
         UInt64 last_error_time_ms = 0;
+        std::string message;
 
         ValuePair & operator+=(const ValuePair & value);
     };
@@ -52,7 +53,7 @@ namespace ErrorCodes
     ErrorCode end();
 
     /// Add value for specified error_code.
-    void increment(ErrorCode error_code, bool remote);
+    void increment(ErrorCode error_code, bool remote, const std::string & message);
 }
 
 }

--- a/src/Common/ErrorCodes.h
+++ b/src/Common/ErrorCodes.h
@@ -25,13 +25,18 @@ namespace ErrorCodes
     std::string_view getName(ErrorCode error_code);
 
     /// ErrorCode identifier -> current value of error_code.
-    extern std::atomic<Value> values[];
+    struct ValuePair
+    {
+        std::atomic<Value> local;
+        std::atomic<Value> remote;
+    };
+    extern ValuePair values[];
 
     /// Get index just after last error_code identifier.
     ErrorCode end();
 
     /// Add value for specified error_code.
-    void increment(ErrorCode error_code);
+    void increment(ErrorCode error_code, bool remote);
 }
 
 }

--- a/src/Common/ErrorCodes.h
+++ b/src/Common/ErrorCodes.h
@@ -28,7 +28,7 @@ namespace ErrorCodes
     {
         Value local = 0;
         Value remote = 0;
-        UInt64 last_error_time_ms = 0;
+        UInt64 error_time_ms = 0;
         std::string message;
         std::string stacktrace;
 

--- a/src/Common/Exception.cpp
+++ b/src/Common/Exception.cpp
@@ -47,7 +47,7 @@ void handle_error_code([[maybe_unused]] const std::string & msg, int code, bool 
         abort();
     }
 #endif
-    ErrorCodes::increment(code, remote);
+    ErrorCodes::increment(code, remote, msg);
 }
 
 Exception::Exception(const std::string & msg, int code, bool remote_)

--- a/src/Common/Exception.cpp
+++ b/src/Common/Exception.cpp
@@ -34,9 +34,9 @@ namespace ErrorCodes
     extern const int CANNOT_MREMAP;
 }
 
-/// Aborts the process if error code is LOGICAL_ERROR.
-/// Increments error codes statistics.
-void handle_error_code([[maybe_unused]] const std::string & msg, int code)
+/// - Aborts the process if error code is LOGICAL_ERROR.
+/// - Increments error codes statistics.
+void handle_error_code([[maybe_unused]] const std::string & msg, int code, bool remote)
 {
     // In debug builds and builds with sanitizers, treat LOGICAL_ERROR as an assertion failure.
     // Log the message before we fail.
@@ -47,20 +47,20 @@ void handle_error_code([[maybe_unused]] const std::string & msg, int code)
         abort();
     }
 #endif
-    ErrorCodes::increment(code);
+    ErrorCodes::increment(code, remote);
 }
 
 Exception::Exception(const std::string & msg, int code, bool remote_)
     : Poco::Exception(msg, code)
     , remote(remote_)
 {
-    handle_error_code(msg, code);
+    handle_error_code(msg, code, remote);
 }
 
 Exception::Exception(const std::string & msg, const Exception & nested, int code)
     : Poco::Exception(msg, nested, code)
 {
-    handle_error_code(msg, code);
+    handle_error_code(msg, code, remote);
 }
 
 Exception::Exception(CreateFromPocoTag, const Poco::Exception & exc)

--- a/src/Common/Exception.cpp
+++ b/src/Common/Exception.cpp
@@ -36,7 +36,7 @@ namespace ErrorCodes
 
 /// - Aborts the process if error code is LOGICAL_ERROR.
 /// - Increments error codes statistics.
-void handle_error_code([[maybe_unused]] const std::string & msg, int code, bool remote)
+void handle_error_code([[maybe_unused]] const std::string & msg, const std::string & stacktrace, int code, bool remote)
 {
     // In debug builds and builds with sanitizers, treat LOGICAL_ERROR as an assertion failure.
     // Log the message before we fail.
@@ -47,20 +47,20 @@ void handle_error_code([[maybe_unused]] const std::string & msg, int code, bool 
         abort();
     }
 #endif
-    ErrorCodes::increment(code, remote, msg);
+    ErrorCodes::increment(code, remote, msg, stacktrace);
 }
 
 Exception::Exception(const std::string & msg, int code, bool remote_)
     : Poco::Exception(msg, code)
     , remote(remote_)
 {
-    handle_error_code(msg, code, remote);
+    handle_error_code(msg, getStackTraceString(), code, remote);
 }
 
 Exception::Exception(const std::string & msg, const Exception & nested, int code)
     : Poco::Exception(msg, nested, code)
 {
-    handle_error_code(msg, code, remote);
+    handle_error_code(msg, getStackTraceString(), code, remote);
 }
 
 Exception::Exception(CreateFromPocoTag, const Poco::Exception & exc)

--- a/src/Storages/System/StorageSystemErrors.cpp
+++ b/src/Storages/System/StorageSystemErrors.cpp
@@ -24,7 +24,7 @@ NamesAndTypesList StorageSystemErrors::getNamesAndTypes()
 
 void StorageSystemErrors::fillData(MutableColumns & res_columns, const Context & context, const SelectQueryInfo &) const
 {
-    auto add_row = [&](std::string_view name, size_t code, size_t value, UInt64 last_error_time_ms, const std::string & message, const std::string & stacktrace, bool remote)
+    auto add_row = [&](std::string_view name, size_t code, size_t value, UInt64 error_time_ms, const std::string & message, const std::string & stacktrace, bool remote)
     {
         if (value || context.getSettingsRef().system_events_show_zero_values)
         {
@@ -32,7 +32,7 @@ void StorageSystemErrors::fillData(MutableColumns & res_columns, const Context &
             res_columns[col_num++]->insert(name);
             res_columns[col_num++]->insert(code);
             res_columns[col_num++]->insert(value);
-            res_columns[col_num++]->insert(last_error_time_ms / 1000);
+            res_columns[col_num++]->insert(error_time_ms / 1000);
             res_columns[col_num++]->insert(message);
             res_columns[col_num++]->insert(stacktrace);
             res_columns[col_num++]->insert(remote);
@@ -47,8 +47,8 @@ void StorageSystemErrors::fillData(MutableColumns & res_columns, const Context &
         if (name.empty())
             continue;
 
-        add_row(name, i, error.local,  error.last_error_time_ms, error.message, error.stacktrace, 0 /* remote=0 */);
-        add_row(name, i, error.remote, error.last_error_time_ms, error.message, error.stacktrace, 1 /* remote=1 */);
+        add_row(name, i, error.local,  error.error_time_ms, error.message, error.stacktrace, 0 /* remote=0 */);
+        add_row(name, i, error.remote, error.error_time_ms, error.message, error.stacktrace, 1 /* remote=1 */);
     }
 }
 

--- a/src/Storages/System/StorageSystemErrors.cpp
+++ b/src/Storages/System/StorageSystemErrors.cpp
@@ -11,19 +11,20 @@ namespace DB
 NamesAndTypesList StorageSystemErrors::getNamesAndTypes()
 {
     return {
-        { "name",              std::make_shared<DataTypeString>() },
-        { "code",              std::make_shared<DataTypeInt32>() },
-        { "value",             std::make_shared<DataTypeUInt64>() },
-        { "last_error_time",   std::make_shared<DataTypeDateTime>() },
-        { "last_error_message",std::make_shared<DataTypeString>() },
-        { "remote",            std::make_shared<DataTypeUInt8>() },
+        { "name",                    std::make_shared<DataTypeString>() },
+        { "code",                    std::make_shared<DataTypeInt32>() },
+        { "value",                   std::make_shared<DataTypeUInt64>() },
+        { "last_error_time",         std::make_shared<DataTypeDateTime>() },
+        { "last_error_message",      std::make_shared<DataTypeString>() },
+        { "last_error_stacktrace",   std::make_shared<DataTypeString>() },
+        { "remote",                  std::make_shared<DataTypeUInt8>() },
     };
 }
 
 
 void StorageSystemErrors::fillData(MutableColumns & res_columns, const Context & context, const SelectQueryInfo &) const
 {
-    auto add_row = [&](std::string_view name, size_t code, size_t value, UInt64 last_error_time_ms, const std::string & message, bool remote)
+    auto add_row = [&](std::string_view name, size_t code, size_t value, UInt64 last_error_time_ms, const std::string & message, const std::string & stacktrace, bool remote)
     {
         if (value || context.getSettingsRef().system_events_show_zero_values)
         {
@@ -33,6 +34,7 @@ void StorageSystemErrors::fillData(MutableColumns & res_columns, const Context &
             res_columns[col_num++]->insert(value);
             res_columns[col_num++]->insert(last_error_time_ms / 1000);
             res_columns[col_num++]->insert(message);
+            res_columns[col_num++]->insert(stacktrace);
             res_columns[col_num++]->insert(remote);
         }
     };
@@ -45,8 +47,8 @@ void StorageSystemErrors::fillData(MutableColumns & res_columns, const Context &
         if (name.empty())
             continue;
 
-        add_row(name, i, error.local,  error.last_error_time_ms, error.message, 0 /* remote=0 */);
-        add_row(name, i, error.remote, error.last_error_time_ms, error.message, 1 /* remote=1 */);
+        add_row(name, i, error.local,  error.last_error_time_ms, error.message, error.stacktrace, 0 /* remote=0 */);
+        add_row(name, i, error.remote, error.last_error_time_ms, error.message, error.stacktrace, 1 /* remote=1 */);
     }
 }
 

--- a/src/Storages/System/StorageSystemErrors.cpp
+++ b/src/Storages/System/StorageSystemErrors.cpp
@@ -34,7 +34,7 @@ void StorageSystemErrors::fillData(MutableColumns & res_columns, const Context &
 
     for (size_t i = 0, end = ErrorCodes::end(); i < end; ++i)
     {
-        const auto & error = ErrorCodes::values[i];
+        const auto & error = ErrorCodes::values[i].get();
         std::string_view name = ErrorCodes::getName(i);
 
         if (name.empty())

--- a/src/Storages/System/StorageSystemErrors.cpp
+++ b/src/Storages/System/StorageSystemErrors.cpp
@@ -47,8 +47,8 @@ void StorageSystemErrors::fillData(MutableColumns & res_columns, const Context &
         if (name.empty())
             continue;
 
-        add_row(name, i, error.local,  error.error_time_ms, error.message, error.stacktrace, 0 /* remote=0 */);
-        add_row(name, i, error.remote, error.error_time_ms, error.message, error.stacktrace, 1 /* remote=1 */);
+        add_row(name, i, error.local,  error.error_time_ms, error.message, error.stacktrace, false /* remote=0 */);
+        add_row(name, i, error.remote, error.error_time_ms, error.message, error.stacktrace, true  /* remote=1 */);
     }
 }
 

--- a/src/Storages/System/StorageSystemErrors.cpp
+++ b/src/Storages/System/StorageSystemErrors.cpp
@@ -15,6 +15,7 @@ NamesAndTypesList StorageSystemErrors::getNamesAndTypes()
         { "code",              std::make_shared<DataTypeInt32>() },
         { "value",             std::make_shared<DataTypeUInt64>() },
         { "last_error_time",   std::make_shared<DataTypeDateTime>() },
+        { "last_error_message",std::make_shared<DataTypeString>() },
         { "remote",            std::make_shared<DataTypeUInt8>() },
     };
 }
@@ -22,7 +23,7 @@ NamesAndTypesList StorageSystemErrors::getNamesAndTypes()
 
 void StorageSystemErrors::fillData(MutableColumns & res_columns, const Context & context, const SelectQueryInfo &) const
 {
-    auto add_row = [&](std::string_view name, size_t code, size_t value, UInt64 last_error_time_ms, bool remote)
+    auto add_row = [&](std::string_view name, size_t code, size_t value, UInt64 last_error_time_ms, const std::string & message, bool remote)
     {
         if (value || context.getSettingsRef().system_events_show_zero_values)
         {
@@ -31,6 +32,7 @@ void StorageSystemErrors::fillData(MutableColumns & res_columns, const Context &
             res_columns[col_num++]->insert(code);
             res_columns[col_num++]->insert(value);
             res_columns[col_num++]->insert(last_error_time_ms / 1000);
+            res_columns[col_num++]->insert(message);
             res_columns[col_num++]->insert(remote);
         }
     };
@@ -43,8 +45,8 @@ void StorageSystemErrors::fillData(MutableColumns & res_columns, const Context &
         if (name.empty())
             continue;
 
-        add_row(name, i, error.local,  error.last_error_time_ms, 0 /* remote=0 */);
-        add_row(name, i, error.remote, error.last_error_time_ms, 1 /* remote=1 */);
+        add_row(name, i, error.local,  error.last_error_time_ms, error.message, 0 /* remote=0 */);
+        add_row(name, i, error.remote, error.last_error_time_ms, error.message, 1 /* remote=1 */);
     }
 }
 

--- a/src/Storages/System/StorageSystemErrors.cpp
+++ b/src/Storages/System/StorageSystemErrors.cpp
@@ -13,27 +13,35 @@ NamesAndTypesList StorageSystemErrors::getNamesAndTypes()
         { "name",              std::make_shared<DataTypeString>() },
         { "code",              std::make_shared<DataTypeInt32>() },
         { "value",             std::make_shared<DataTypeUInt64>() },
+        { "remote",            std::make_shared<DataTypeUInt8>() },
     };
 }
 
 
 void StorageSystemErrors::fillData(MutableColumns & res_columns, const Context & context, const SelectQueryInfo &) const
 {
+    auto add_row = [&](std::string_view name, size_t code, size_t value, bool remote)
+    {
+        if (value || context.getSettingsRef().system_events_show_zero_values)
+        {
+            size_t col_num = 0;
+            res_columns[col_num++]->insert(name);
+            res_columns[col_num++]->insert(code);
+            res_columns[col_num++]->insert(value);
+            res_columns[col_num++]->insert(remote);
+        }
+    };
+
     for (size_t i = 0, end = ErrorCodes::end(); i < end; ++i)
     {
-        UInt64 value = ErrorCodes::values[i];
+        const auto & error = ErrorCodes::values[i];
         std::string_view name = ErrorCodes::getName(i);
 
         if (name.empty())
             continue;
 
-        if (value || context.getSettingsRef().system_events_show_zero_values)
-        {
-            size_t col_num = 0;
-            res_columns[col_num++]->insert(name);
-            res_columns[col_num++]->insert(i);
-            res_columns[col_num++]->insert(value);
-        }
+        add_row(name, i, error.local,  0 /* remote=0 */);
+        add_row(name, i, error.remote, 1 /* remote=1 */);
     }
 }
 

--- a/src/Storages/System/StorageSystemErrors.cpp
+++ b/src/Storages/System/StorageSystemErrors.cpp
@@ -24,17 +24,17 @@ NamesAndTypesList StorageSystemErrors::getNamesAndTypes()
 
 void StorageSystemErrors::fillData(MutableColumns & res_columns, const Context & context, const SelectQueryInfo &) const
 {
-    auto add_row = [&](std::string_view name, size_t code, size_t value, UInt64 error_time_ms, const std::string & message, const std::string & stacktrace, bool remote)
+    auto add_row = [&](std::string_view name, size_t code, const auto & error, bool remote)
     {
-        if (value || context.getSettingsRef().system_events_show_zero_values)
+        if (error.count || context.getSettingsRef().system_events_show_zero_values)
         {
             size_t col_num = 0;
             res_columns[col_num++]->insert(name);
             res_columns[col_num++]->insert(code);
-            res_columns[col_num++]->insert(value);
-            res_columns[col_num++]->insert(error_time_ms / 1000);
-            res_columns[col_num++]->insert(message);
-            res_columns[col_num++]->insert(stacktrace);
+            res_columns[col_num++]->insert(error.count);
+            res_columns[col_num++]->insert(error.error_time_ms / 1000);
+            res_columns[col_num++]->insert(error.message);
+            res_columns[col_num++]->insert(error.stacktrace);
             res_columns[col_num++]->insert(remote);
         }
     };
@@ -47,8 +47,8 @@ void StorageSystemErrors::fillData(MutableColumns & res_columns, const Context &
         if (name.empty())
             continue;
 
-        add_row(name, i, error.local,  error.error_time_ms, error.message, error.stacktrace, false /* remote=0 */);
-        add_row(name, i, error.remote, error.error_time_ms, error.message, error.stacktrace, true  /* remote=1 */);
+        add_row(name, i, error.local,  /* remote= */ false);
+        add_row(name, i, error.remote, /* remote= */ true);
     }
 }
 

--- a/tests/queries/0_stateless/01544_errorCodeToName.reference
+++ b/tests/queries/0_stateless/01544_errorCodeToName.reference
@@ -1,4 +1,5 @@
 
 
+
 OK
 UNSUPPORTED_METHOD

--- a/tests/queries/0_stateless/01544_errorCodeToName.sql
+++ b/tests/queries/0_stateless/01544_errorCodeToName.sql
@@ -1,4 +1,5 @@
 SELECT errorCodeToName(toUInt32(-1));
+SELECT errorCodeToName(-1);
 SELECT errorCodeToName(600); /* gap in error codes */
 SELECT errorCodeToName(0);
 SELECT errorCodeToName(1);

--- a/tests/queries/0_stateless/01545_system_errors.reference
+++ b/tests/queries/0_stateless/01545_system_errors.reference
@@ -1,1 +1,2 @@
-1
+local=1
+remote=1

--- a/tests/queries/0_stateless/01545_system_errors.sh
+++ b/tests/queries/0_stateless/01545_system_errors.sh
@@ -4,7 +4,14 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-prev="$(${CLICKHOUSE_CLIENT} -q "SELECT value FROM system.errors WHERE name = 'FUNCTION_THROW_IF_VALUE_IS_NON_ZERO'")"
+# local
+prev="$(${CLICKHOUSE_CLIENT} -q "SELECT value FROM system.errors WHERE name = 'FUNCTION_THROW_IF_VALUE_IS_NON_ZERO' AND NOT remote")"
 $CLICKHOUSE_CLIENT -q 'SELECT throwIf(1)' >& /dev/null
-cur="$(${CLICKHOUSE_CLIENT} -q "SELECT value FROM system.errors WHERE name = 'FUNCTION_THROW_IF_VALUE_IS_NON_ZERO'")"
-echo $((cur - prev))
+cur="$(${CLICKHOUSE_CLIENT} -q "SELECT value FROM system.errors WHERE name = 'FUNCTION_THROW_IF_VALUE_IS_NON_ZERO' AND NOT remote")"
+echo local=$((cur - prev))
+
+# remote
+prev="$(${CLICKHOUSE_CLIENT} -q "SELECT value FROM system.errors WHERE name = 'FUNCTION_THROW_IF_VALUE_IS_NON_ZERO' AND remote")"
+${CLICKHOUSE_CLIENT} -q "SELECT * FROM remote('127.2', system.one) where throwIf(not dummy)" >& /dev/null
+cur="$(${CLICKHOUSE_CLIENT} -q "SELECT value FROM system.errors WHERE name = 'FUNCTION_THROW_IF_VALUE_IS_NON_ZERO' AND remote")"
+echo remote=$((cur - prev))

--- a/tests/queries/skip_list.json
+++ b/tests/queries/skip_list.json
@@ -739,6 +739,7 @@
         "01541_max_memory_usage_for_user_long",
         "01542_dictionary_load_exception_race",
         "01560_optimize_on_insert_zookeeper",
+        "01545_system_errors", // looks at the difference of values in system.errors
         "01575_disable_detach_table_of_dictionary",
         "01593_concurrent_alter_mutations_kill",
         "01593_concurrent_alter_mutations_kill_many_replicas",


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add `last_error_time`/`last_error_message`/`last_error_stacktrace`/`remote` columns for `system.errors`

Follow-up for: #16438