### PR TITLE
Pod array left pad not multiple of element crash fix

### DIFF
--- a/src/Common/PODArray.h
+++ b/src/Common/PODArray.h
@@ -166,17 +166,6 @@ protected:
         return (stack_threshold > 0) && (allocated_bytes() <= stack_threshold);
     }
 
-    bool shouldReserveForNextSizeBeforeInsert() const
-    {
-        /** end_of_storage = left_padding + (start + elements_size * ELEMENT_SIZE).
-          * end = start + elements_size * ELEMENT_SIZE
-          * We use end + ELEMENT_SIZE >= end_of_storage because it
-          * It is not safe to use end == end_of_storage here because left_padding
-          * is not always multiple of ELEMENT_SIZE.
-          */
-        return (c_end + ELEMENT_SIZE) >= c_end_of_storage;
-    }
-
     template <typename ... TAllocatorParams>
     void reserveForNextSize(TAllocatorParams &&... allocator_params)
     {
@@ -441,7 +430,7 @@ public:
     template <typename U, typename ... TAllocatorParams>
     void push_back(U && x, TAllocatorParams &&... allocator_params)
     {
-        if (unlikely(this->shouldReserveForNextSizeBeforeInsert()))
+        if (unlikely(this->c_end == this->c_end_of_storage))
             this->reserveForNextSize(std::forward<TAllocatorParams>(allocator_params)...);
 
         new (t_end()) T(std::forward<U>(x));
@@ -454,7 +443,7 @@ public:
     template <typename... Args>
     void emplace_back(Args &&... args)
     {
-        if (unlikely(this->shouldReserveForNextSizeBeforeInsert()))
+        if (unlikely(this->c_end == this->c_end_of_storage))
             this->reserveForNextSize();
 
         new (t_end()) T(std::forward<Args>(args)...);

--- a/src/Common/PODArray.h
+++ b/src/Common/PODArray.h
@@ -174,7 +174,7 @@ protected:
           * It is not safe to use end == end_of_storage here because left_padding
           * is not always multiple of ELEMENT_SIZE.
           */
-        return c_end + ELEMENT_SIZE >= c_end_of_storage;
+        return (c_end + ELEMENT_SIZE) >= c_end_of_storage;
     }
 
     template <typename ... TAllocatorParams>

--- a/src/Common/PODArray.h
+++ b/src/Common/PODArray.h
@@ -166,6 +166,17 @@ protected:
         return (stack_threshold > 0) && (allocated_bytes() <= stack_threshold);
     }
 
+    bool shouldReserveForNextSizeBeforeInsert() const
+    {
+        /** end_of_storage = left_padding + (start + elements_size * ELEMENT_SIZE).
+          * end = start + elements_size * ELEMENT_SIZE
+          * We use end + ELEMENT_SIZE >= end_of_storage because it
+          * It is not safe to use end == end_of_storage here because left_padding
+          * is not always multiple of ELEMENT_SIZE.
+          */
+        return c_end + ELEMENT_SIZE >= c_end_of_storage;
+    }
+
     template <typename ... TAllocatorParams>
     void reserveForNextSize(TAllocatorParams &&... allocator_params)
     {
@@ -334,7 +345,7 @@ public:
     using const_iterator = const T *;
 
 
-    PODArray() {}
+    PODArray() = default;
 
     PODArray(size_t n)
     {
@@ -430,7 +441,7 @@ public:
     template <typename U, typename ... TAllocatorParams>
     void push_back(U && x, TAllocatorParams &&... allocator_params)
     {
-        if (unlikely(this->c_end == this->c_end_of_storage))
+        if (unlikely(this->shouldReserveForNextSizeBeforeInsert()))
             this->reserveForNextSize(std::forward<TAllocatorParams>(allocator_params)...);
 
         new (t_end()) T(std::forward<U>(x));
@@ -443,7 +454,7 @@ public:
     template <typename... Args>
     void emplace_back(Args &&... args)
     {
-        if (unlikely(this->c_end == this->c_end_of_storage))
+        if (unlikely(this->shouldReserveForNextSizeBeforeInsert()))
             this->reserveForNextSize();
 
         new (t_end()) T(std::forward<Args>(args)...);

--- a/src/Common/tests/gtest_pod_array.cpp
+++ b/src/Common/tests/gtest_pod_array.cpp
@@ -66,3 +66,29 @@ TEST(Common, PODNoOverallocation)
 
     EXPECT_EQ(capacities, (std::vector<size_t>{4065, 8161, 16353, 32737, 65505, 131041, 262113, 524257, 1048545}));
 }
+
+template <size_t size>
+struct ItemWithSize
+{
+    char v[size] {};
+};
+
+TEST(Common, PODInsertElementSizeNotMultipleOfLeftPadding)
+{
+    using ItemWith24Size = ItemWithSize<24>;
+    PaddedPODArray<ItemWith24Size> arr1_initially_empty;
+
+    size_t items_to_insert_size = 120000;
+
+    for (size_t test = 0; test < items_to_insert_size; ++test)
+        arr1_initially_empty.emplace_back();
+
+    EXPECT_EQ(arr1_initially_empty.size(), items_to_insert_size);
+
+    PaddedPODArray<ItemWith24Size> arr2_initially_nonempty;
+
+    for (size_t test = 0; test < items_to_insert_size; ++test)
+        arr2_initially_nonempty.emplace_back();
+
+    EXPECT_EQ(arr1_initially_empty.size(), items_to_insert_size);
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)
