### PR TITLE
Fix incorrect fd_ready assignment in NuKeeperTCPHandler.

### DIFF
--- a/src/Server/NuKeeperTCPHandler.cpp
+++ b/src/Server/NuKeeperTCPHandler.cpp
@@ -158,7 +158,7 @@ struct SocketInterruptablePollWrapper
 
             if (rc >= 1 && poll_buf[0].revents & POLLIN)
                 socket_ready = true;
-            if (rc == 2 && poll_buf[1].revents & POLLIN)
+            if (rc >= 1 && poll_buf[1].revents & POLLIN)
                 fd_ready = true;
 #endif
         }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

The ```::poll()``` return ```rc == 1 ```,  it could be a request or it could be a response.
