### PR TITLE
Try to fix test_storage_s3: crash in WriteBufferFromS3

### DIFF
--- a/src/IO/WriteBufferFromS3.cpp
+++ b/src/IO/WriteBufferFromS3.cpp
@@ -107,7 +107,14 @@ void WriteBufferFromS3::finalizeImpl()
 
 WriteBufferFromS3::~WriteBufferFromS3()
 {
-    finalizeImpl();
+    try
+    {
+        finalizeImpl();
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+    }
 }
 
 void WriteBufferFromS3::createMultipartUpload()

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -173,6 +173,11 @@ namespace
             writer->writePrefix();
         }
 
+        void flush() override
+        {
+            writer->flush();
+        }
+
         void writeSuffix() override
         {
             writer->writeSuffix();

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -281,9 +281,9 @@ def test_put_get_with_globs(cluster):
 
 # Test multipart put.
 @pytest.mark.parametrize("maybe_auth,positive", [
-    ("", True)
+    ("", True),
     # ("'minio','minio123',",True), Redirect with credentials not working with nginx.
-    # ("'wrongid','wrongkey',", False) ClickHouse crashes in some time after this test, local integration tests run fails.
+    ("'wrongid','wrongkey',", False),
 ])
 def test_multipart_put(cluster, maybe_auth, positive):
     # type: (ClickHouseCluster) -> None


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
`std::terminate` was called if there is an error writing data into s3.

