### PR TITLE
Remove unknown columns from joined table in where for queries to external database engines

### DIFF
--- a/src/Storages/tests/gtest_transform_query_for_external_database.cpp
+++ b/src/Storages/tests/gtest_transform_query_for_external_database.cpp
@@ -148,3 +148,12 @@ TEST(TransformQueryForExternalDatabase, Aliases)
           R"(SELECT "field" FROM "test"."table" WHERE ("field" NOT IN ('')) AND ("field" LIKE '%test%'))",
           state.context, state.columns);
 }
+
+TEST(TransformQueryForExternalDatabase, ForeignColumnInWhere)
+{
+    const State & state = State::instance();
+
+    check("SELECT column FROM test.table WHERE column > 2 AND (apply_id = 1 OR joined_table.foo = 1)",
+          R"(SELECT "column" FROM "test"."table" WHERE ("column" > 2) AND ("apply_id" = 1))",
+          state.context, state.columns);
+}

--- a/src/Storages/tests/gtest_transform_query_for_external_database.cpp
+++ b/src/Storages/tests/gtest_transform_query_for_external_database.cpp
@@ -23,15 +23,6 @@ struct State
     State(const State&) = delete;
 
     Context context;
-    NamesAndTypesList columns{
-        {"column", std::make_shared<DataTypeUInt8>()},
-        {"apply_id", std::make_shared<DataTypeUInt64>()},
-        {"apply_type", std::make_shared<DataTypeUInt8>()},
-        {"apply_status", std::make_shared<DataTypeUInt8>()},
-        {"create_time", std::make_shared<DataTypeDateTime>()},
-        {"field", std::make_shared<DataTypeString>()},
-        {"value", std::make_shared<DataTypeString>()},
-    };
 
     static const State & instance()
     {
@@ -39,27 +30,83 @@ struct State
         return state;
     }
 
+    const NamesAndTypesList & getColumns() const
+    {
+        return tables[0].columns;
+    }
+
+    std::vector<TableWithColumnNamesAndTypes> getTables(size_t num = 0) const
+    {
+        std::vector<TableWithColumnNamesAndTypes> res;
+        for (size_t i = 0; i < std::min(num, tables.size()); ++i)
+            res.push_back(tables[i]);
+        return res;
+    }
+
 private:
+
+    static DatabaseAndTableWithAlias createDBAndTable(String table_name)
+    {
+        DatabaseAndTableWithAlias res;
+        res.database = "test";
+        res.table = table_name;
+        return res;
+    }
+
+    const std::vector<TableWithColumnNamesAndTypes> tables{
+        TableWithColumnNamesAndTypes(
+            createDBAndTable("table"),
+            {
+                {"column", std::make_shared<DataTypeUInt8>()},
+                {"apply_id", std::make_shared<DataTypeUInt64>()},
+                {"apply_type", std::make_shared<DataTypeUInt8>()},
+                {"apply_status", std::make_shared<DataTypeUInt8>()},
+                {"create_time", std::make_shared<DataTypeDateTime>()},
+                {"field", std::make_shared<DataTypeString>()},
+                {"value", std::make_shared<DataTypeString>()},
+            }),
+        TableWithColumnNamesAndTypes(
+            createDBAndTable("table2"),
+            {
+                {"num", std::make_shared<DataTypeUInt8>()},
+                {"attr", std::make_shared<DataTypeString>()},
+            }),
+    };
+
     explicit State()
         : context(getContext().context)
     {
         tryRegisterFunctions();
         DatabasePtr database = std::make_shared<DatabaseMemory>("test", context);
-        database->attachTable("table", StorageMemory::create(StorageID("test", "table"), ColumnsDescription{columns}, ConstraintsDescription{}));
-        DatabaseCatalog::instance().attachDatabase("test", database);
+
+        for (const auto & tab : tables)
+        {
+            const auto & table_name = tab.table.table;
+            const auto & db_name = tab.table.database;
+            database->attachTable(
+                table_name,
+                StorageMemory::create(StorageID(db_name, table_name), ColumnsDescription{getColumns()}, ConstraintsDescription{}));
+        }
+        DatabaseCatalog::instance().attachDatabase(database->getDatabaseName(), database);
         context.setCurrentDatabase("test");
     }
 };
 
-
-static void check(const std::string & query, const std::string & expected, const Context & context, const NamesAndTypesList & columns)
+static void check(
+    const State & state,
+    size_t table_num,
+    const std::string & query,
+    const std::string & expected)
 {
     ParserSelectQuery parser;
     ASTPtr ast = parseQuery(parser, query, 1000, 1000);
     SelectQueryInfo query_info;
-    query_info.syntax_analyzer_result = TreeRewriter(context).analyzeSelect(ast, columns);
+    SelectQueryOptions select_options;
+    query_info.syntax_analyzer_result
+        = TreeRewriter(state.context).analyzeSelect(ast, state.getColumns(), select_options, state.getTables(table_num));
     query_info.query = ast;
-    std::string transformed_query = transformQueryForExternalDatabase(query_info, columns, IdentifierQuotingStyle::DoubleQuotes, "test", "table", context);
+    std::string transformed_query = transformQueryForExternalDatabase(
+        query_info, state.getColumns(), IdentifierQuotingStyle::DoubleQuotes, "test", "table", state.context);
 
     EXPECT_EQ(transformed_query, expected);
 }
@@ -69,91 +116,93 @@ TEST(TransformQueryForExternalDatabase, InWithSingleElement)
 {
     const State & state = State::instance();
 
-    check("SELECT column FROM test.table WHERE 1 IN (1)",
-          R"(SELECT "column" FROM "test"."table" WHERE 1)",
-          state.context, state.columns);
-    check("SELECT column FROM test.table WHERE column IN (1, 2)",
-          R"(SELECT "column" FROM "test"."table" WHERE "column" IN (1, 2))",
-          state.context, state.columns);
-    check("SELECT column FROM test.table WHERE column NOT IN ('hello', 'world')",
-          R"(SELECT "column" FROM "test"."table" WHERE "column" NOT IN ('hello', 'world'))",
-          state.context, state.columns);
+    check(state, 1,
+          "SELECT column FROM test.table WHERE 1 IN (1)",
+          R"(SELECT "column" FROM "test"."table" WHERE 1)");
+    check(state, 1,
+          "SELECT column FROM test.table WHERE column IN (1, 2)",
+          R"(SELECT "column" FROM "test"."table" WHERE "column" IN (1, 2))");
+    check(state, 1,
+          "SELECT column FROM test.table WHERE column NOT IN ('hello', 'world')",
+          R"(SELECT "column" FROM "test"."table" WHERE "column" NOT IN ('hello', 'world'))");
 }
 
 TEST(TransformQueryForExternalDatabase, InWithTable)
 {
     const State & state = State::instance();
 
-    check("SELECT column FROM test.table WHERE 1 IN external_table",
-          R"(SELECT "column" FROM "test"."table")",
-          state.context, state.columns);
-    check("SELECT column FROM test.table WHERE 1 IN (x)",
-          R"(SELECT "column" FROM "test"."table")",
-          state.context, state.columns);
-    check("SELECT column, field, value FROM test.table WHERE column IN (field, value)",
-          R"(SELECT "column", "field", "value" FROM "test"."table" WHERE "column" IN ("field", "value"))",
-          state.context, state.columns);
-    check("SELECT column FROM test.table WHERE column NOT IN hello AND column = 123",
-          R"(SELECT "column" FROM "test"."table" WHERE ("column" = 123))",
-          state.context, state.columns);
+    check(state, 1,
+          "SELECT column FROM test.table WHERE 1 IN external_table",
+          R"(SELECT "column" FROM "test"."table")");
+    check(state, 1,
+          "SELECT column FROM test.table WHERE 1 IN (x)",
+          R"(SELECT "column" FROM "test"."table")");
+    check(state, 1,
+          "SELECT column, field, value FROM test.table WHERE column IN (field, value)",
+          R"(SELECT "column", "field", "value" FROM "test"."table" WHERE "column" IN ("field", "value"))");
+    check(state, 1,
+          "SELECT column FROM test.table WHERE column NOT IN hello AND column = 123",
+          R"(SELECT "column" FROM "test"."table" WHERE "column" = 123)");
 }
 
 TEST(TransformQueryForExternalDatabase, Like)
 {
     const State & state = State::instance();
 
-    check("SELECT column FROM test.table WHERE column LIKE '%hello%'",
-          R"(SELECT "column" FROM "test"."table" WHERE "column" LIKE '%hello%')",
-          state.context, state.columns);
-    check("SELECT column FROM test.table WHERE column NOT LIKE 'w%rld'",
-          R"(SELECT "column" FROM "test"."table" WHERE "column" NOT LIKE 'w%rld')",
-          state.context, state.columns);
+    check(state, 1,
+          "SELECT column FROM test.table WHERE column LIKE '%hello%'",
+          R"(SELECT "column" FROM "test"."table" WHERE "column" LIKE '%hello%')");
+    check(state, 1,
+          "SELECT column FROM test.table WHERE column NOT LIKE 'w%rld'",
+          R"(SELECT "column" FROM "test"."table" WHERE "column" NOT LIKE 'w%rld')");
 }
 
 TEST(TransformQueryForExternalDatabase, Substring)
 {
     const State & state = State::instance();
 
-    check("SELECT column FROM test.table WHERE left(column, 10) = RIGHT(column, 10) AND SUBSTRING(column FROM 1 FOR 2) = 'Hello'",
-          R"(SELECT "column" FROM "test"."table")",
-          state.context, state.columns);
+    check(state, 1,
+          "SELECT column FROM test.table WHERE left(column, 10) = RIGHT(column, 10) AND SUBSTRING(column FROM 1 FOR 2) = 'Hello'",
+          R"(SELECT "column" FROM "test"."table")");
 }
 
 TEST(TransformQueryForExternalDatabase, MultipleAndSubqueries)
 {
     const State & state = State::instance();
 
-    check("SELECT column FROM test.table WHERE 1 = 1 AND toString(column) = '42' AND column = 42 AND left(column, 10) = RIGHT(column, 10) AND column IN (1, 42) AND SUBSTRING(column FROM 1 FOR 2) = 'Hello' AND column != 4",
-          R"(SELECT "column" FROM "test"."table" WHERE 1 AND ("column" = 42) AND ("column" IN (1, 42)) AND ("column" != 4))",
-          state.context, state.columns);
-    check("SELECT column FROM test.table WHERE toString(column) = '42' AND left(column, 10) = RIGHT(column, 10) AND column = 42",
-          R"(SELECT "column" FROM "test"."table" WHERE ("column" = 42))",
-          state.context, state.columns);
+    check(state, 1,
+          "SELECT column FROM test.table WHERE 1 = 1 AND toString(column) = '42' AND column = 42 AND left(column, 10) = RIGHT(column, 10) AND column IN (1, 42) AND SUBSTRING(column FROM 1 FOR 2) = 'Hello' AND column != 4",
+          R"(SELECT "column" FROM "test"."table" WHERE 1 AND ("column" = 42) AND ("column" IN (1, 42)) AND ("column" != 4))");
+    check(state, 1,
+          "SELECT column FROM test.table WHERE toString(column) = '42' AND left(column, 10) = RIGHT(column, 10) AND column = 42",
+          R"(SELECT "column" FROM "test"."table" WHERE ("column" = 42))");
 }
 
 TEST(TransformQueryForExternalDatabase, Issue7245)
 {
     const State & state = State::instance();
 
-    check("select apply_id from test.table where apply_type = 2 and create_time > addDays(toDateTime('2019-01-01 01:02:03'),-7) and apply_status in (3,4)",
-          R"(SELECT "apply_id", "apply_type", "apply_status", "create_time" FROM "test"."table" WHERE ("apply_type" = 2) AND ("create_time" > '2018-12-25 01:02:03') AND ("apply_status" IN (3, 4)))",
-          state.context, state.columns);
+    check(state, 1,
+          "SELECT apply_id FROM test.table WHERE apply_type = 2 AND create_time > addDays(toDateTime('2019-01-01 01:02:03'),-7) AND apply_status IN (3,4)",
+          R"(SELECT "apply_id", "apply_type", "apply_status", "create_time" FROM "test"."table" WHERE ("apply_type" = 2) AND ("create_time" > '2018-12-25 01:02:03') AND ("apply_status" IN (3, 4)))");
 }
 
 TEST(TransformQueryForExternalDatabase, Aliases)
 {
     const State & state = State::instance();
 
-    check("SELECT field AS value, field AS display WHERE field NOT IN ('') AND display LIKE '%test%'",
-          R"(SELECT "field" FROM "test"."table" WHERE ("field" NOT IN ('')) AND ("field" LIKE '%test%'))",
-          state.context, state.columns);
+    check(state, 1,
+          "SELECT field AS value, field AS display WHERE field NOT IN ('') AND display LIKE '%test%'",
+          R"(SELECT "field" FROM "test"."table" WHERE ("field" NOT IN ('')) AND ("field" LIKE '%test%'))");
 }
 
 TEST(TransformQueryForExternalDatabase, ForeignColumnInWhere)
 {
     const State & state = State::instance();
 
-    check("SELECT column FROM test.table WHERE column > 2 AND (apply_id = 1 OR joined_table.foo = 1)",
-          R"(SELECT "column" FROM "test"."table" WHERE ("column" > 2) AND ("apply_id" = 1))",
-          state.context, state.columns);
+    check(state, 2,
+          "SELECT column FROM test.table "
+          "JOIN test.table2 AS table2 ON (test.table.apply_id = table2.num) "
+          "WHERE column > 2 AND (apply_id = 1 OR table2.num = 1) AND table2.attr != ''",
+          R"(SELECT "column", "apply_id" FROM "test"."table" WHERE ("column" > 2) AND ("apply_id" = 1))");
 }

--- a/src/Storages/transformQueryForExternalDatabase.cpp
+++ b/src/Storages/transformQueryForExternalDatabase.cpp
@@ -181,7 +181,7 @@ bool removeUnknownSubexpressions(ASTPtr & node, const NameSet & known_names)
     if (const auto * ident = node->as<ASTIdentifier>())
         return known_names.contains(ident->name());
 
-    if (const auto * lit = node->as<ASTLiteral>())
+    if (node->as<ASTLiteral>() != nullptr)
         return true;
 
     auto * func = node->as<ASTFunction>();

--- a/src/Storages/transformQueryForExternalDatabase.cpp
+++ b/src/Storages/transformQueryForExternalDatabase.cpp
@@ -208,6 +208,11 @@ bool removeUnknownSubexpressions(ASTPtr & node, const NameSet & known_names)
     return leave_child;
 }
 
+// When a query references an external table such as table from MySQL database,
+// the corresponding table storage has to execute the relevant part of the query. We
+// send the query to the storage as AST. Before that, we have to remove the conditions
+// that reference other tables from `WHERE`, so that the external engine is not confused
+// by the unknown columns.
 bool removeUnknownSubexpressionsFromWhere(ASTPtr & node, const NamesAndTypesList & available_columns)
 {
     if (!node)

--- a/tests/integration/test_mysql_database_engine/test.py
+++ b/tests/integration/test_mysql_database_engine/test.py
@@ -146,10 +146,14 @@ def test_clickhouse_join_for_mysql_database(started_cluster):
             "CREATE TABLE default.t1_remote_mysql AS mysql('mysql1:3306','test','t1_mysql_local','root','clickhouse')")
         clickhouse_node.query(
             "CREATE TABLE default.t2_remote_mysql AS mysql('mysql1:3306','test','t2_mysql_local','root','clickhouse')")
+        clickhouse_node.query("INSERT INTO `default`.`t1_remote_mysql` VALUES ('EN','A',''),('RU','B','AAA')")
+        clickhouse_node.query("INSERT INTO `default`.`t2_remote_mysql` VALUES ('A','AAA'),('Z','')")
+        
         assert clickhouse_node.query("SELECT s.pays "
                                      "FROM default.t1_remote_mysql AS s "
                                      "LEFT JOIN default.t1_remote_mysql AS s_ref "
-                                     "ON (s_ref.opco = s.opco AND s_ref.service = s.service)") == ''
+                                     "ON (s_ref.opco = s.opco AND s_ref.service = s.service) "
+                                     "WHERE s_ref.opco != '' AND s.opco != '' ").rstrip() == 'RU'
         mysql_node.query("DROP DATABASE test")
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Remove unknown columns from joined table in where for queries to external database engines (MySQL, PostgreSQL). close #14614, close #19288 (dup), close #19645 (dup)

