### PR TITLE
Fix ambigous column error in joins_in_memory

### DIFF
--- a/src/Interpreters/CrossToInnerJoinVisitor.cpp
+++ b/src/Interpreters/CrossToInnerJoinVisitor.cpp
@@ -136,7 +136,7 @@ std::optional<size_t> getIdentMembership(const ASTIdentifier & ident, const std:
     std::optional<size_t> table_pos = IdentifierSemantic::getMembership(ident);
     if (table_pos)
         return table_pos;
-    return IdentifierSemantic::chooseTableColumnMatch(ident, tables);
+    return IdentifierSemantic::chooseTableColumnMatch(ident, tables, true);
 }
 
 std::optional<size_t> getIdentsMembership(const ASTPtr ast,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fix bug introduced in https://github.com/ClickHouse/ClickHouse/pull/20392