### PR TITLE
Fix flaky test_replace_partition

### DIFF
--- a/tests/integration/test_replace_partition/test.py
+++ b/tests/integration/test_replace_partition/test.py
@@ -1,3 +1,7 @@
+# pylint: disable=line-too-long
+# pylint: disable=unused-argument
+# pylint: disable=redefined-outer-name:
+
 import time
 import pytest
 
@@ -14,13 +18,13 @@ def _fill_nodes(nodes, shard):
         node.query(
             '''
                 CREATE DATABASE test;
-    
+
                 CREATE TABLE real_table(date Date, id UInt32, dummy UInt32)
                 ENGINE = MergeTree(date, id, 8192);
-    
+
                 CREATE TABLE other_table(date Date, id UInt32, dummy UInt32)
                 ENGINE = MergeTree(date, id, 8192);
-    
+
                 CREATE TABLE test_table(date Date, id UInt32, dummy UInt32)
                 ENGINE = ReplicatedMergeTree('/clickhouse/tables/test{shard}/replicated', '{replica}', date, id, 8192);
             '''.format(shard=shard, replica=node.name))


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

`test_replace_partition/test.py::test_replace_after_replace_failover` statistics:

```sql
┌──────ymd─┬─success─┬─failure─┐
│ 20200613 │      40 │       2 │
│ 20200614 │      98 │       2 │
│ 20200615 │     126 │       9 │
│ 20200616 │     141 │      10 │
│ 20200617 │     119 │       7 │
│ 20200618 │      87 │      12 │
│ 20200619 │      81 │       9 │
...
│ 20210305 │      60 │      28 │
│ 20210306 │      69 │       7 │
│ 20210307 │      42 │       0 │
│ 20210308 │      53 │       8 │
│ 20210309 │     137 │      23 │
│ 20210310 │      84 │      14 │
│ 20210311 │      81 │      20 │
└──────────┴─────────┴─────────┘
```

Cc: @alesapin 

P.S. Yes sleep is bad, but I guess it is OK in this case (maybe we can use restart replica here, but I guess that the nature of the test will be different in this case).