### PR TITLE
Start accepting connections after DDLWorker and dictionaries initialization

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1280,9 +1280,6 @@ int Server::main(const std::vector<std::string> & /*args*/)
         async_metrics.start();
         global_context->enableNamedSessions();
 
-        for (auto & server : *servers)
-            server.start();
-
         {
             String level_str = config().getString("text_log.level", "");
             int level = level_str.empty() ? INT_MAX : Poco::Logger::parseLevel(level_str);
@@ -1334,6 +1331,8 @@ int Server::main(const std::vector<std::string> & /*args*/)
                                                                      "distributed_ddl", "DDLWorker", &CurrentMetrics::MaxDDLEntryID));
         }
 
+        for (auto & server : *servers)
+            server.start();
         LOG_INFO(log, "Ready for connections.");
 
         SCOPE_EXIT({


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Start accepting connections after DDLWorker and dictionaries initialization

Detailed description / Documentation draft:
Found by integration tests [1]:

    Code: 139. DB::Exception: Received from 172.18.0.6:9000. DB::Exception: DDL background thread is not initialized. Stack trace:

  [1]: https://clickhouse-test-reports.s3.yandex.net/21643/65f90f2ce9ea9e9d4076f06c58ddd981c82cc098/integration_tests_(thread).html#fail1