### PR TITLE
Update clusters only if their configs were updated

### DIFF
--- a/src/Common/Config/AbstractConfigurationComparison.cpp
+++ b/src/Common/Config/AbstractConfigurationComparison.cpp
@@ -26,6 +26,10 @@ bool isSameConfiguration(const Poco::Util::AbstractConfiguration & left, const P
     return isSameConfiguration(left, String(), right, String());
 }
 
+bool isSameConfiguration(const Poco::Util::AbstractConfiguration & left, const Poco::Util::AbstractConfiguration & right, const String & key)
+{
+    return isSameConfiguration(left, key, right, key);
+}
 
 bool isSameConfiguration(const Poco::Util::AbstractConfiguration & left, const String & left_key,
                          const Poco::Util::AbstractConfiguration & right, const String & right_key)

--- a/src/Common/Config/AbstractConfigurationComparison.h
+++ b/src/Common/Config/AbstractConfigurationComparison.h
@@ -13,6 +13,11 @@ namespace DB
     bool isSameConfiguration(const Poco::Util::AbstractConfiguration & left,
                              const Poco::Util::AbstractConfiguration & right);
 
+    /// Returns true if the specified subview of the two configurations contains the same keys and values.
+    bool isSameConfiguration(const Poco::Util::AbstractConfiguration & left,
+                             const Poco::Util::AbstractConfiguration & right,
+                             const String & key);
+
     /// Returns true if specified subviews of the two configurations contains the same keys and values.
     bool isSameConfiguration(const Poco::Util::AbstractConfiguration & left, const String & left_key,
                              const Poco::Util::AbstractConfiguration & right, const String & right_key);

--- a/src/Interpreters/Cluster.h
+++ b/src/Interpreters/Cluster.h
@@ -276,7 +276,7 @@ public:
     ClusterPtr getCluster(const std::string & cluster_name) const;
     void setCluster(const String & cluster_name, const ClusterPtr & cluster);
 
-    void updateClusters(const Poco::Util::AbstractConfiguration & config, const Settings & settings, const String & config_prefix);
+    void updateClusters(const Poco::Util::AbstractConfiguration & new_config, const Settings & settings, const String & config_prefix, Poco::Util::AbstractConfiguration * old_config = nullptr);
 
 public:
     using Impl = std::map<String, ClusterPtr>;

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1835,9 +1835,8 @@ void Context::setClustersConfig(const ConfigurationPtr & config, const String & 
     std::lock_guard lock(shared->clusters_mutex);
 
     /// Do not update clusters if this part of config wasn't changed.
-    if (shared->clusters && isSameConfiguration(*config, *shared->clusters_config, config_name)) {
+    if (shared->clusters && isSameConfiguration(*config, *shared->clusters_config, config_name))
         return;
-    }
 
     auto old_clusters_config = shared->clusters_config;
     shared->clusters_config = config;

--- a/tests/integration/test_reload_clusters_config/configs/remote_servers.xml
+++ b/tests/integration/test_reload_clusters_config/configs/remote_servers.xml
@@ -1,0 +1,30 @@
+<yandex>
+    <remote_servers>
+        <test_cluster>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>node_1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node_2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster>
+        <test_cluster2>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>node_1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node_2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster2>
+    </remote_servers>
+</yandex>

--- a/tests/integration/test_reload_clusters_config/test.py
+++ b/tests/integration/test_reload_clusters_config/test.py
@@ -1,0 +1,235 @@
+import os
+import sys
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from helpers.cluster import ClickHouseCluster
+from helpers.network import PartitionManager
+from helpers.test_tools import TSV
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance('node', with_zookeeper=True, main_configs=['configs/remote_servers.xml'])
+node_1 = cluster.add_instance('node_1', with_zookeeper=True)
+node_2 = cluster.add_instance('node_2', with_zookeeper=True)
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+
+        node.query('''CREATE TABLE distributed (id UInt32) ENGINE =
+            Distributed('test_cluster', 'default', 'replicated')''')
+        
+        node.query('''CREATE TABLE distributed2 (id UInt32) ENGINE =
+            Distributed('test_cluster2', 'default', 'replicated')''')
+
+        cluster.pause_container('node_1')
+        cluster.pause_container('node_2')
+
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+base_config = '''
+<yandex>
+    <remote_servers>
+        <test_cluster>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>node_1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node_2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster>
+        <test_cluster2>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>node_1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node_2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster2>
+    </remote_servers>
+</yandex>
+'''
+
+test_config1 = '''
+<yandex>
+    <remote_servers>
+        <test_cluster>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>node_1</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster>
+        <test_cluster2>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>node_1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node_2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster2>
+    </remote_servers>
+</yandex>
+'''
+
+test_config2 = '''
+<yandex>
+    <remote_servers>
+        <test_cluster>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>node_1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node_2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster>
+    </remote_servers>
+</yandex>
+'''
+
+test_config3 = '''
+<yandex>
+    <remote_servers>
+        <test_cluster>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>node_1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node_2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster>
+        <test_cluster2>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>node_1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node_2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster2>
+        <test_cluster3>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>node_1</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </test_cluster3>
+    </remote_servers>
+</yandex>
+'''
+
+
+def send_repeated_query(table, count=5):
+    for i in range(count):
+        node.query_and_get_error("SELECT count() FROM {} SETTINGS receive_timeout=1".format(table))
+
+
+def get_errors_count(cluster, host_name="node_1"):
+    return int(node.query("SELECT errors_count FROM system.clusters WHERE cluster='{}' and host_name='{}'".format(cluster, host_name)))
+
+
+def set_config(config):
+    node.replace_config("/etc/clickhouse-server/config.d/remote_servers.xml", config)
+    node.query("SYSTEM RELOAD CONFIG")
+
+
+def test_simple_reload(started_cluster):
+    send_repeated_query("distributed")
+
+    assert get_errors_count("test_cluster") > 0
+    
+    node.query("SYSTEM RELOAD CONFIG")
+
+    assert get_errors_count("test_cluster") > 0
+
+
+def test_update_one_cluster(started_cluster):
+    send_repeated_query("distributed")
+    send_repeated_query("distributed2")
+
+    assert get_errors_count("test_cluster") > 0
+    assert get_errors_count("test_cluster2") > 0
+
+    set_config(test_config1)
+
+    assert get_errors_count("test_cluster") == 0
+    assert get_errors_count("test_cluster2") > 0
+
+    set_config(base_config)
+
+
+def test_delete_cluster(started_cluster):
+    send_repeated_query("distributed")
+    send_repeated_query("distributed2")
+
+    assert get_errors_count("test_cluster") > 0
+    assert get_errors_count("test_cluster2") > 0
+
+    set_config(test_config2)
+
+    assert get_errors_count("test_cluster") > 0
+    
+    result = node.query("SELECT * FROM system.clusters WHERE cluster='test_cluster2'")
+    assert result == ''
+
+    set_config(base_config)
+
+
+def test_add_cluster(started_cluster):
+    send_repeated_query("distributed")
+    send_repeated_query("distributed2")
+
+    assert get_errors_count("test_cluster") > 0
+    assert get_errors_count("test_cluster2") > 0
+
+    set_config(test_config3)
+
+    assert get_errors_count("test_cluster") > 0
+    assert get_errors_count("test_cluster2") > 0
+
+    result = node.query("SELECT * FROM system.clusters WHERE cluster='test_cluster3'")
+    assert result != ''
+
+    set_config(base_config)
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Update clusters only if their configurations were updated.

Detailed description / Documentation draft:
Previously we always updated all the clusters when config was reloaded, even if the changes were not related to the clusters. Now we update certain cluster only if it's configuration was changed.