### PR TITLE
Fix error message in clickhouse-test

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -245,11 +245,11 @@ def get_server_pid(server_tcp_port):
     output = None
     for cmd in commands:
         try:
-            output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT)
+            output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, universal_newlines=True)
             if output:
                 return int(output)
         except Exception as e:
-            print("Cannot get server pid with {}, got {}: {}", cmd, output, e)
+            print("Cannot get server pid with {}, got {}: {}".format(cmd, output, e))
     return None # most likely server dead
 
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)