### PR TITLE
Fix log_comment for *.sh in clickhouse-test

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -138,7 +138,7 @@ def run_single_test(args, ext, server_logs_level, client_options, case_file, std
         os.environ["CLICKHOUSE_DATABASE"] = database
 
     # This is for .sh tests
-    os.environ.setdefault("CLICKHOUSE_LOG_COMMENT", case_file)
+    os.environ["CLICKHOUSE_LOG_COMMENT"] = case_file
 
     params = {
         'client': args.client + ' --database=' + database,


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

`setdefault` will set it only once