### PR TITLE
correct the method doc of RemoteQueryExecutor::setPartUUIDs

### DIFF
--- a/src/DataStreams/RemoteQueryExecutor.h
+++ b/src/DataStreams/RemoteQueryExecutor.h
@@ -176,7 +176,7 @@ private:
     void sendExternalTables();
 
     /// Set part uuids to a query context, collected from remote replicas.
-    /// Return true if duplicates found.
+    /// Return true if no duplicate found.
     bool setPartUUIDs(const std::vector<UUID> & uuids);
 
     /// Cancell query and restart it with info about duplicated UUIDs


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
correct the method doc of RemoteQueryExecutor::setPartUUIDs
