### PR TITLE
Cleanup destination directory during DiskCacheWrapper::moveFile()

### DIFF
--- a/src/Disks/DiskCacheWrapper.cpp
+++ b/src/Disks/DiskCacheWrapper.cpp
@@ -217,7 +217,7 @@ void DiskCacheWrapper::moveFile(const String & from_path, const String & to_path
 {
     if (cache_disk->exists(from_path))
     {
-        if (cache_disk->isDirectory(to_path) && !cache_disk->isDirectoryEmpty(to_path))
+        if (cache_disk->exists(to_path) && cache_disk->isDirectory(to_path))
             cache_disk->clearDirectory(to_path);
 
         auto dir_path = directoryPath(to_path);

--- a/src/Disks/DiskCacheWrapper.cpp
+++ b/src/Disks/DiskCacheWrapper.cpp
@@ -217,6 +217,9 @@ void DiskCacheWrapper::moveFile(const String & from_path, const String & to_path
 {
     if (cache_disk->exists(from_path))
     {
+        if (cache_disk->isDirectory(to_path) && !cache_disk->isDirectoryEmpty(to_path))
+            cache_disk->clearDirectory(to_path);
+
         auto dir_path = directoryPath(to_path);
         if (!cache_disk->exists(dir_path))
             cache_disk->createDirectories(dir_path);

--- a/src/Disks/DiskCacheWrapper.cpp
+++ b/src/Disks/DiskCacheWrapper.cpp
@@ -209,7 +209,13 @@ void DiskCacheWrapper::clearDirectory(const String & path)
 void DiskCacheWrapper::moveDirectory(const String & from_path, const String & to_path)
 {
     if (cache_disk->exists(from_path))
+    {
+        /// Destination directory may not be empty if previous directory move attempt was failed.
+        if (cache_disk->exists(to_path) && cache_disk->isDirectory(to_path))
+            cache_disk->clearDirectory(to_path);
+
         cache_disk->moveDirectory(from_path, to_path);
+    }
     DiskDecorator::moveDirectory(from_path, to_path);
 }
 
@@ -217,9 +223,6 @@ void DiskCacheWrapper::moveFile(const String & from_path, const String & to_path
 {
     if (cache_disk->exists(from_path))
     {
-        if (cache_disk->exists(to_path) && cache_disk->isDirectory(to_path))
-            cache_disk->clearDirectory(to_path);
-
         auto dir_path = directoryPath(to_path);
         if (!cache_disk->exists(dir_path))
             cache_disk->createDirectories(dir_path);

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -1013,7 +1013,7 @@ void IMergeTreeDataPart::renameTo(const String & new_relative_path, bool remove_
     }
 
     volume->getDisk()->setLastModified(from, Poco::Timestamp::fromEpochTime(time(nullptr)));
-    volume->getDisk()->moveFile(from, to);
+    volume->getDisk()->moveDirectory(from, to);
     relative_path = new_relative_path;
 
     SyncGuardPtr sync_guard;
@@ -1065,7 +1065,7 @@ void IMergeTreeDataPart::remove(bool keep_s3) const
 
     try
     {
-        volume->getDisk()->moveFile(from, to);
+        volume->getDisk()->moveDirectory(from, to);
     }
     catch (const Poco::FileNotFoundException &)
     {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
DiskS3 (experimental feature under development). Fixed bug with the impossibility to move directory if the destination is not empty and cache disk is used.

Detailed description / Documentation draft:
Due to unclean moves state in DiskCache may be different than in the underlying disk during moves:
```
2021.03.15 13:04:08.588148 [ 1942550 ] {} <Error> Application: Caught exception while loading metadata: Poco::Exception. Code: 1000, e.code() = 39, e.displayText() = Directory not empty: /var/lib/clickhouse/disks/object_storage/cache/store/715/7156a666-522d-49ba-9ec1-a51a376382b9/20210315_56668_57469_138, Stack trace (when copying this message, always include the lines below):

0. Poco::FileImpl::handleLastErrorImpl(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) @ 0x11e8339e in /usr/bin/clickhouse
1. Poco::File::renameTo(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) @ 0x11e8685b in /usr/bin/clickhouse
2. DB::DiskLocal::moveFile(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) @ 0xea62d0e in /usr/bin/clickhouse
3. DB::DiskCacheWrapper::moveFile(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) @ 0xea95831 in /usr/bin/clickhouse
4. DB::IMergeTreeDataPart::remove() const @ 0xf57a612 in /usr/bin/clickhouse
5. DB::MergeTreeData::clearPartsFromFilesystem(std::__1::vector<std::__1::shared_ptr<DB::IMergeTreeDataPart const>, std::__1::allocator<std::__1::shared_ptr<DB::IMergeTreeDataPart const> > > const&) @ 0xf5b8947 in /usr/bin/clickhouse
6. DB::MergeTreeData::clearOldPartsFromFilesystem(bool) @ 0xf5b8369 in /usr/bin/clickhouse
7. DB::StorageMergeTree::startup() @ 0xf39c4a2 in /usr/bin/clickhouse
8. ? @ 0xebb58dc in /usr/bin/clickhouse
9. ThreadPoolImpl<ThreadFromGlobalPool>::worker(std::__1::__list_iterator<ThreadFromGlobalPool, void*>) @ 0x863014d in /usr/bin/clickhouse
10. ThreadFromGlobalPool::ThreadFromGlobalPool<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()>(void&&, void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()&&...)::'lambda'()::operator()() @ 0x86326af in /usr/bin/clickhouse
11. ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) @ 0x862d57d in /usr/bin/clickhouse
12. ? @ 0x8631133 in /usr/bin/clickhouse
13. start_thread @ 0x76db in /lib/x86_64-linux-gnu/libpthread-2.27.so
14. clone @ 0x121a3f in /lib/x86_64-linux-gnu/libc-2.27.so
 (version 21.1.5.4 (official build))
2021.03.15 13:04:08.597524 [ 1942550 ] {} <Error> Application: Directory not empty: /var/lib/clickhouse/disks/object_storage/cache/store/715/7156a666-522d-49ba-9ec1-a51a376382b9/20210315_56668_57469_138
```
