### PR TITLE
Add connection pool for postgres engine

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -366,6 +366,9 @@ class IColumn;
     M(Bool, check_query_single_value_result, true, "Return check query result as single 1/0 value", 0) \
     M(Bool, allow_drop_detached, false, "Allow ALTER TABLE ... DROP DETACHED PART[ITION] ... queries", 0) \
     \
+    M(UInt64, postgresql_connection_pool_size, 16, "Connection pool size for PostgreSQL table engine and database engine.", 0) \
+    M(Int64, postgresql_connection_pool_wait_timeout, -1, "Connection pool push/pop timeout on empty pool for PostgreSQL table engine and database engine. By default it will block on empty pool.", 0) \
+    \
     M(Seconds, distributed_replica_error_half_life, DBMS_CONNECTION_POOL_WITH_FAILOVER_DEFAULT_DECREASE_ERROR_PERIOD, "Time period reduces replica error counter by 2 times.", 0) \
     M(UInt64, distributed_replica_error_cap, DBMS_CONNECTION_POOL_WITH_FAILOVER_MAX_ERROR_COUNT, "Max number of errors per replica, prevents piling up an incredible amount of errors if replica was offline for some time and allows it to be reconsidered in a shorter amount of time.", 0) \
     M(UInt64, distributed_replica_max_ignored_errors, 0, "Number of errors that will be ignored while choosing replicas", 0) \

--- a/src/DataStreams/PostgreSQLBlockInputStream.cpp
+++ b/src/DataStreams/PostgreSQLBlockInputStream.cpp
@@ -28,13 +28,14 @@ namespace ErrorCodes
 }
 
 PostgreSQLBlockInputStream::PostgreSQLBlockInputStream(
-    ConnectionPtr connection_,
+    PostgreSQLConnectionPoolPtr connection_pool_,
     const std::string & query_str_,
     const Block & sample_block,
     const UInt64 max_block_size_)
     : query_str(query_str_)
     , max_block_size(max_block_size_)
-    , connection(connection_)
+    , connection_pool(connection_pool_)
+    , connection(connection_pool->get())
 {
     description.init(sample_block);
     for (const auto idx : ext::range(0, description.sample_block.columns()))
@@ -111,6 +112,9 @@ void PostgreSQLBlockInputStream::readSuffix()
         stream->complete();
         tx->commit();
     }
+
+    if (connection->is_open())
+        connection_pool->put(connection);
 }
 
 

--- a/src/DataStreams/PostgreSQLBlockInputStream.cpp
+++ b/src/DataStreams/PostgreSQLBlockInputStream.cpp
@@ -28,7 +28,7 @@ namespace ErrorCodes
 }
 
 PostgreSQLBlockInputStream::PostgreSQLBlockInputStream(
-    WrappedPostgreSQLConnectionPtr connection_,
+    PostgreSQLConnectionHolderPtr connection_,
     const std::string & query_str_,
     const Block & sample_block,
     const UInt64 max_block_size_)

--- a/src/DataStreams/PostgreSQLBlockInputStream.cpp
+++ b/src/DataStreams/PostgreSQLBlockInputStream.cpp
@@ -28,14 +28,13 @@ namespace ErrorCodes
 }
 
 PostgreSQLBlockInputStream::PostgreSQLBlockInputStream(
-    PostgreSQLConnectionPoolPtr connection_pool_,
+    WrappedPostgreSQLConnection connection_,
     const std::string & query_str_,
     const Block & sample_block,
     const UInt64 max_block_size_)
     : query_str(query_str_)
     , max_block_size(max_block_size_)
-    , connection_pool(connection_pool_)
-    , connection(connection_pool->get())
+    , connection(connection_)
 {
     description.init(sample_block);
     for (const auto idx : ext::range(0, description.sample_block.columns()))
@@ -112,9 +111,6 @@ void PostgreSQLBlockInputStream::readSuffix()
         stream->complete();
         tx->commit();
     }
-
-    if (connection->is_open())
-        connection_pool->put(connection);
 }
 
 

--- a/src/DataStreams/PostgreSQLBlockInputStream.cpp
+++ b/src/DataStreams/PostgreSQLBlockInputStream.cpp
@@ -28,13 +28,13 @@ namespace ErrorCodes
 }
 
 PostgreSQLBlockInputStream::PostgreSQLBlockInputStream(
-    WrappedPostgreSQLConnection connection_,
+    WrappedPostgreSQLConnectionPtr connection_,
     const std::string & query_str_,
     const Block & sample_block,
     const UInt64 max_block_size_)
     : query_str(query_str_)
     , max_block_size(max_block_size_)
-    , connection(connection_)
+    , connection(std::move(connection_))
 {
     description.init(sample_block);
     for (const auto idx : ext::range(0, description.sample_block.columns()))
@@ -48,7 +48,7 @@ PostgreSQLBlockInputStream::PostgreSQLBlockInputStream(
 
 void PostgreSQLBlockInputStream::readPrefix()
 {
-    tx = std::make_unique<pqxx::read_transaction>(*connection);
+    tx = std::make_unique<pqxx::read_transaction>(connection->conn());
     stream = std::make_unique<pqxx::stream_from>(*tx, pqxx::from_query, std::string_view(query_str));
 }
 

--- a/src/DataStreams/PostgreSQLBlockInputStream.h
+++ b/src/DataStreams/PostgreSQLBlockInputStream.h
@@ -19,7 +19,7 @@ class PostgreSQLBlockInputStream : public IBlockInputStream
 {
 public:
     PostgreSQLBlockInputStream(
-        PostgreSQLConnectionPoolPtr connection_pool_,
+        WrappedPostgreSQLConnection connection_,
         const std::string & query_str,
         const Block & sample_block,
         const UInt64 max_block_size_);
@@ -46,8 +46,7 @@ private:
     const UInt64 max_block_size;
     ExternalResultDescription description;
 
-    PostgreSQLConnectionPoolPtr connection_pool;
-    PostgreSQLConnection::ConnectionPtr connection;
+    WrappedPostgreSQLConnection connection;
     std::unique_ptr<pqxx::read_transaction> tx;
     std::unique_ptr<pqxx::stream_from> stream;
 

--- a/src/DataStreams/PostgreSQLBlockInputStream.h
+++ b/src/DataStreams/PostgreSQLBlockInputStream.h
@@ -9,18 +9,17 @@
 #include <DataStreams/IBlockInputStream.h>
 #include <Core/ExternalResultDescription.h>
 #include <Core/Field.h>
-#include <pqxx/pqxx>
+#include <Storages/PostgreSQL/PostgreSQLConnectionPool.h>
 
 
 namespace DB
 {
-using ConnectionPtr = std::shared_ptr<pqxx::connection>;
 
 class PostgreSQLBlockInputStream : public IBlockInputStream
 {
 public:
     PostgreSQLBlockInputStream(
-        ConnectionPtr connection_,
+        PostgreSQLConnectionPoolPtr connection_pool_,
         const std::string & query_str,
         const Block & sample_block,
         const UInt64 max_block_size_);
@@ -47,7 +46,8 @@ private:
     const UInt64 max_block_size;
     ExternalResultDescription description;
 
-    ConnectionPtr connection;
+    PostgreSQLConnectionPoolPtr connection_pool;
+    PostgreSQLConnection::ConnectionPtr connection;
     std::unique_ptr<pqxx::read_transaction> tx;
     std::unique_ptr<pqxx::stream_from> stream;
 

--- a/src/DataStreams/PostgreSQLBlockInputStream.h
+++ b/src/DataStreams/PostgreSQLBlockInputStream.h
@@ -19,7 +19,7 @@ class PostgreSQLBlockInputStream : public IBlockInputStream
 {
 public:
     PostgreSQLBlockInputStream(
-        WrappedPostgreSQLConnectionPtr connection_,
+        PostgreSQLConnectionHolderPtr connection_,
         const std::string & query_str,
         const Block & sample_block,
         const UInt64 max_block_size_);
@@ -46,7 +46,7 @@ private:
     const UInt64 max_block_size;
     ExternalResultDescription description;
 
-    WrappedPostgreSQLConnectionPtr connection;
+    PostgreSQLConnectionHolderPtr connection;
     std::unique_ptr<pqxx::read_transaction> tx;
     std::unique_ptr<pqxx::stream_from> stream;
 

--- a/src/DataStreams/PostgreSQLBlockInputStream.h
+++ b/src/DataStreams/PostgreSQLBlockInputStream.h
@@ -19,7 +19,7 @@ class PostgreSQLBlockInputStream : public IBlockInputStream
 {
 public:
     PostgreSQLBlockInputStream(
-        WrappedPostgreSQLConnection connection_,
+        WrappedPostgreSQLConnectionPtr connection_,
         const std::string & query_str,
         const Block & sample_block,
         const UInt64 max_block_size_);
@@ -46,7 +46,7 @@ private:
     const UInt64 max_block_size;
     ExternalResultDescription description;
 
-    WrappedPostgreSQLConnection connection;
+    WrappedPostgreSQLConnectionPtr connection;
     std::unique_ptr<pqxx::read_transaction> tx;
     std::unique_ptr<pqxx::stream_from> stream;
 

--- a/src/Databases/DatabaseFactory.cpp
+++ b/src/Databases/DatabaseFactory.cpp
@@ -36,7 +36,7 @@
 
 #if USE_LIBPQXX
 #include <Databases/PostgreSQL/DatabasePostgreSQL.h> // Y_IGNORE
-#include <Storages/PostgreSQL/PostgreSQLConnection.h>
+#include <Storages/PostgreSQL/PostgreSQLConnectionPool.h>
 #endif
 
 namespace DB
@@ -246,11 +246,11 @@ DatabasePtr DatabaseFactory::getImpl(const ASTCreateQuery & create, const String
         auto parsed_host_port = parseAddress(host_port, 5432);
 
         /// no connection is made here
-        auto connection = std::make_shared<PostgreSQLConnection>(
+        auto connection_pool = std::make_shared<PostgreSQLConnectionPool>(
             postgres_database_name, parsed_host_port.first, parsed_host_port.second, username, password);
 
         return std::make_shared<DatabasePostgreSQL>(
-            context, metadata_path, engine_define, database_name, postgres_database_name, connection, use_table_cache);
+            context, metadata_path, engine_define, database_name, postgres_database_name, connection_pool, use_table_cache);
     }
 
 #endif

--- a/src/Databases/DatabaseFactory.cpp
+++ b/src/Databases/DatabaseFactory.cpp
@@ -247,7 +247,11 @@ DatabasePtr DatabaseFactory::getImpl(const ASTCreateQuery & create, const String
 
         /// no connection is made here
         auto connection_pool = std::make_shared<PostgreSQLConnectionPool>(
-            postgres_database_name, parsed_host_port.first, parsed_host_port.second, username, password);
+            postgres_database_name,
+            parsed_host_port.first, parsed_host_port.second,
+            username, password,
+            context.getSettingsRef().postgresql_connection_pool_size,
+            context.getSettingsRef().postgresql_connection_pool_wait_timeout);
 
         return std::make_shared<DatabasePostgreSQL>(
             context, metadata_path, engine_define, database_name, postgres_database_name, connection_pool, use_table_cache);

--- a/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
@@ -5,7 +5,6 @@
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeArray.h>
 #include <Storages/StoragePostgreSQL.h>
-#include <Storages/PostgreSQL/PostgreSQLConnection.h>
 #include <Interpreters/Context.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTFunction.h>
@@ -17,6 +16,7 @@
 #include <Poco/File.h>
 #include <Databases/PostgreSQL/fetchPostgreSQLTableStructure.h>
 #include <Common/quoteString.h>
+#include <Storages/PostgreSQL/PostgreSQLConnectionPool.h>
 
 
 namespace DB
@@ -40,14 +40,14 @@ DatabasePostgreSQL::DatabasePostgreSQL(
         const ASTStorage * database_engine_define_,
         const String & dbname_,
         const String & postgres_dbname,
-        PostgreSQLConnectionPtr connection_,
+        PostgreSQLConnectionPoolPtr connection_pool_,
         const bool cache_tables_)
     : IDatabase(dbname_)
     , global_context(context.getGlobalContext())
     , metadata_path(metadata_path_)
     , database_engine_define(database_engine_define_->clone())
     , dbname(postgres_dbname)
-    , connection(std::move(connection_))
+    , connection_pool(std::move(connection_pool_))
     , cache_tables(cache_tables_)
 {
     cleaner_task = context.getSchedulePool().createTask("PostgreSQLCleanerTask", [this]{ removeOutdatedTables(); });
@@ -90,11 +90,13 @@ std::unordered_set<std::string> DatabasePostgreSQL::fetchTablesList() const
     std::unordered_set<std::string> tables;
     std::string query = "SELECT tablename FROM pg_catalog.pg_tables "
         "WHERE schemaname != 'pg_catalog' AND schemaname != 'information_schema'";
-    pqxx::read_transaction tx(*connection->conn());
+    auto connection = connection_pool->get();
+    pqxx::read_transaction tx(*connection);
 
     for (auto table_name : tx.stream<std::string>(query))
         tables.insert(std::get<0>(table_name));
 
+    connection_pool->put(connection);
     return tables;
 }
 
@@ -108,7 +110,8 @@ bool DatabasePostgreSQL::checkPostgresTable(const String & table_name) const
             "PostgreSQL table name cannot contain single quote or backslash characters, passed {}", table_name);
     }
 
-    pqxx::nontransaction tx(*connection->conn());
+    auto connection = connection_pool->get();
+    pqxx::nontransaction tx(*connection);
 
     try
     {
@@ -129,6 +132,7 @@ bool DatabasePostgreSQL::checkPostgresTable(const String & table_name) const
         throw;
     }
 
+    connection_pool->put(connection);
     return true;
 }
 
@@ -163,13 +167,13 @@ StoragePtr DatabasePostgreSQL::fetchTable(const String & table_name, const Conte
             return StoragePtr{};
 
         auto use_nulls = context.getSettingsRef().external_table_functions_use_nulls;
-        auto columns = fetchPostgreSQLTableStructure(connection->conn(), doubleQuoteString(table_name), use_nulls);
+        auto columns = fetchPostgreSQLTableStructure(connection_pool->get(), table_name, use_nulls);
 
         if (!columns)
             return StoragePtr{};
 
         auto storage = StoragePostgreSQL::create(
-                StorageID(database_name, table_name), table_name, std::make_shared<PostgreSQLConnection>(*connection),
+                StorageID(database_name, table_name), table_name, std::make_shared<PostgreSQLConnectionPool>(*connection_pool),
                 ColumnsDescription{*columns}, ConstraintsDescription{}, context);
 
         if (cache_tables)

--- a/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
@@ -91,7 +91,7 @@ std::unordered_set<std::string> DatabasePostgreSQL::fetchTablesList() const
     std::string query = "SELECT tablename FROM pg_catalog.pg_tables "
         "WHERE schemaname != 'pg_catalog' AND schemaname != 'information_schema'";
     auto connection = connection_pool->get();
-    pqxx::read_transaction tx(*connection);
+    pqxx::read_transaction tx(connection->conn());
 
     for (auto table_name : tx.stream<std::string>(query))
         tables.insert(std::get<0>(table_name));
@@ -110,7 +110,7 @@ bool DatabasePostgreSQL::checkPostgresTable(const String & table_name) const
     }
 
     auto connection = connection_pool->get();
-    pqxx::nontransaction tx(*connection);
+    pqxx::nontransaction tx(connection->conn());
 
     try
     {

--- a/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
@@ -96,7 +96,6 @@ std::unordered_set<std::string> DatabasePostgreSQL::fetchTablesList() const
     for (auto table_name : tx.stream<std::string>(query))
         tables.insert(std::get<0>(table_name));
 
-    connection_pool->put(connection);
     return tables;
 }
 
@@ -132,7 +131,6 @@ bool DatabasePostgreSQL::checkPostgresTable(const String & table_name) const
         throw;
     }
 
-    connection_pool->put(connection);
     return true;
 }
 
@@ -167,7 +165,7 @@ StoragePtr DatabasePostgreSQL::fetchTable(const String & table_name, const Conte
             return StoragePtr{};
 
         auto use_nulls = context.getSettingsRef().external_table_functions_use_nulls;
-        auto columns = fetchPostgreSQLTableStructure(connection_pool->get(), table_name, use_nulls);
+        auto columns = fetchPostgreSQLTableStructure(connection_pool->get(), doubleQuoteString(table_name), use_nulls);
 
         if (!columns)
             return StoragePtr{};

--- a/src/Databases/PostgreSQL/DatabasePostgreSQL.h
+++ b/src/Databases/PostgreSQL/DatabasePostgreSQL.h
@@ -15,8 +15,8 @@ namespace DB
 {
 
 class Context;
-class PostgreSQLConnection;
-using PostgreSQLConnectionPtr = std::shared_ptr<PostgreSQLConnection>;
+class PostgreSQLConnectionPool;
+using PostgreSQLConnectionPoolPtr = std::shared_ptr<PostgreSQLConnectionPool>;
 
 
 /** Real-time access to table list and table structure from remote PostgreSQL.
@@ -34,7 +34,7 @@ public:
         const ASTStorage * database_engine_define,
         const String & dbname_,
         const String & postgres_dbname,
-        PostgreSQLConnectionPtr connection_,
+        PostgreSQLConnectionPoolPtr connection_pool_,
         const bool cache_tables_);
 
     String getEngineName() const override { return "PostgreSQL"; }
@@ -72,7 +72,7 @@ private:
     String metadata_path;
     ASTPtr database_engine_define;
     String dbname;
-    PostgreSQLConnectionPtr connection;
+    PostgreSQLConnectionPoolPtr connection_pool;
     const bool cache_tables;
 
     mutable Tables cached_tables;

--- a/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.cpp
+++ b/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.cpp
@@ -94,7 +94,7 @@ static DataTypePtr convertPostgreSQLDataType(std::string & type, bool is_nullabl
 
 
 std::shared_ptr<NamesAndTypesList> fetchPostgreSQLTableStructure(
-    WrappedPostgreSQLConnectionPtr connection, const String & postgres_table_name, bool use_nulls)
+    PostgreSQLConnectionHolderPtr connection, const String & postgres_table_name, bool use_nulls)
 {
     auto columns = NamesAndTypesList();
 

--- a/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.cpp
+++ b/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.cpp
@@ -94,7 +94,7 @@ static DataTypePtr convertPostgreSQLDataType(std::string & type, bool is_nullabl
 
 
 std::shared_ptr<NamesAndTypesList> fetchPostgreSQLTableStructure(
-    std::shared_ptr<pqxx::connection> connection, const String & postgres_table_name, bool use_nulls)
+    WrappedPostgreSQLConnection connection, const String & postgres_table_name, bool use_nulls)
 {
     auto columns = NamesAndTypesList();
 

--- a/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.cpp
+++ b/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.cpp
@@ -94,7 +94,7 @@ static DataTypePtr convertPostgreSQLDataType(std::string & type, bool is_nullabl
 
 
 std::shared_ptr<NamesAndTypesList> fetchPostgreSQLTableStructure(
-    WrappedPostgreSQLConnection connection, const String & postgres_table_name, bool use_nulls)
+    WrappedPostgreSQLConnectionPtr connection, const String & postgres_table_name, bool use_nulls)
 {
     auto columns = NamesAndTypesList();
 
@@ -113,7 +113,7 @@ std::shared_ptr<NamesAndTypesList> fetchPostgreSQLTableStructure(
            "AND NOT attisdropped AND attnum > 0", postgres_table_name);
     try
     {
-        pqxx::read_transaction tx(*connection);
+        pqxx::read_transaction tx(connection->conn());
         pqxx::stream_from stream(tx, pqxx::from_query, std::string_view(query));
 
         std::tuple<std::string, std::string, std::string, uint16_t> row;
@@ -133,7 +133,7 @@ std::shared_ptr<NamesAndTypesList> fetchPostgreSQLTableStructure(
     {
         throw Exception(fmt::format(
                     "PostgreSQL table {}.{} does not exist",
-                    connection->dbname(), postgres_table_name), ErrorCodes::UNKNOWN_TABLE);
+                    connection->conn().dbname(), postgres_table_name), ErrorCodes::UNKNOWN_TABLE);
     }
     catch (Exception & e)
     {

--- a/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.h
+++ b/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.h
@@ -12,7 +12,7 @@ namespace DB
 {
 
 std::shared_ptr<NamesAndTypesList> fetchPostgreSQLTableStructure(
-    WrappedPostgreSQLConnection connection, const String & postgres_table_name, bool use_nulls);
+    WrappedPostgreSQLConnectionPtr connection, const String & postgres_table_name, bool use_nulls);
 
 }
 

--- a/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.h
+++ b/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.h
@@ -12,7 +12,7 @@ namespace DB
 {
 
 std::shared_ptr<NamesAndTypesList> fetchPostgreSQLTableStructure(
-    std::shared_ptr<pqxx::connection> connection, const String & postgres_table_name, bool use_nulls);
+    WrappedPostgreSQLConnection connection, const String & postgres_table_name, bool use_nulls);
 
 }
 

--- a/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.h
+++ b/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.h
@@ -12,7 +12,7 @@ namespace DB
 {
 
 std::shared_ptr<NamesAndTypesList> fetchPostgreSQLTableStructure(
-    WrappedPostgreSQLConnectionPtr connection, const String & postgres_table_name, bool use_nulls);
+    PostgreSQLConnectionHolderPtr connection, const String & postgres_table_name, bool use_nulls);
 
 }
 

--- a/src/Storages/PostgreSQL/PostgreSQLConnection.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLConnection.cpp
@@ -20,17 +20,6 @@ PostgreSQLConnection::PostgreSQLConnection(
 }
 
 
-PostgreSQLConnection::PostgreSQLConnection(
-        ConnectionPtr connection_,
-        const String & connection_str_,
-        const String & address_)
-    : connection(std::move(connection_))
-    , connection_str(connection_str_)
-    , address(address_)
-{
-}
-
-
 PostgreSQLConnection::PostgreSQLConnection(const PostgreSQLConnection & other)
         : connection_str(other.connection_str)
         , address(other.address)
@@ -40,31 +29,31 @@ PostgreSQLConnection::PostgreSQLConnection(const PostgreSQLConnection & other)
 
 PostgreSQLConnection::ConnectionPtr PostgreSQLConnection::get()
 {
-    connect();
+    connectIfNeeded();
     return connection;
 }
 
 
 PostgreSQLConnection::ConnectionPtr PostgreSQLConnection::tryGet()
 {
-    if (tryConnect())
+    if (tryConnectIfNeeded())
         return connection;
     return nullptr;
 }
 
 
-void PostgreSQLConnection::connect()
+void PostgreSQLConnection::connectIfNeeded()
 {
     if (!connection || !connection->is_open())
         connection = std::make_shared<pqxx::connection>(connection_str);
 }
 
 
-bool PostgreSQLConnection::tryConnect()
+bool PostgreSQLConnection::tryConnectIfNeeded()
 {
     try
     {
-        connect();
+        connectIfNeeded();
     }
     catch (const pqxx::broken_connection & pqxx_error)
     {

--- a/src/Storages/PostgreSQL/PostgreSQLConnection.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLConnection.cpp
@@ -38,7 +38,10 @@ PostgreSQLConnection::ConnectionPtr PostgreSQLConnection::tryGet()
 void PostgreSQLConnection::connectIfNeeded()
 {
     if (!connection || !connection->is_open())
+    {
+        LOG_DEBUG(&Poco::Logger::get("PostgreSQLConnection"), "New connection to {}", getAddress());
         connection = std::make_shared<pqxx::connection>(connection_str);
+    }
 }
 
 

--- a/src/Storages/PostgreSQL/PostgreSQLConnection.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLConnection.cpp
@@ -20,13 +20,6 @@ PostgreSQLConnection::PostgreSQLConnection(
 }
 
 
-PostgreSQLConnection::PostgreSQLConnection(const PostgreSQLConnection & other)
-        : connection_str(other.connection_str)
-        , address(other.address)
-{
-}
-
-
 PostgreSQLConnection::ConnectionPtr PostgreSQLConnection::get()
 {
     connectIfNeeded();

--- a/src/Storages/PostgreSQL/PostgreSQLConnection.h
+++ b/src/Storages/PostgreSQL/PostgreSQLConnection.h
@@ -12,39 +12,45 @@
 namespace DB
 {
 
-/// Tiny connection class to make it more convenient to use.
-/// Connection is not made until actually used.
+
 class PostgreSQLConnection
 {
+
 public:
     using ConnectionPtr = std::shared_ptr<pqxx::connection>;
 
-    PostgreSQLConnection(std::string dbname, std::string host, UInt16 port, std::string user, std::string password);
+    PostgreSQLConnection(
+        const String & connection_str_,
+        const String & address_);
+
+    PostgreSQLConnection(
+        ConnectionPtr connection_,
+        const String & connection_str_,
+        const String & address_);
 
     PostgreSQLConnection(const PostgreSQLConnection & other);
 
-    PostgreSQLConnection operator =(const PostgreSQLConnection &) = delete;
-
-    bool tryConnect();
-
-    ConnectionPtr conn();
-
     const std::string & getAddress() { return address; }
 
-    std::string & conn_str() { return connection_str; }
+    ConnectionPtr get();
+
+    ConnectionPtr tryGet();
+
+    bool connected() { return tryConnect(); }
 
 private:
     void connect();
 
-    static std::string formatConnectionString(
-        std::string dbname, std::string host, UInt16 port, std::string user, std::string password);
+    bool tryConnect();
 
     ConnectionPtr connection;
-    std::string connection_str, address;
+    std::string connection_str;
+    std::string address;
 };
 
 using PostgreSQLConnectionPtr = std::shared_ptr<PostgreSQLConnection>;
 
 }
+
 
 #endif

--- a/src/Storages/PostgreSQL/PostgreSQLConnection.h
+++ b/src/Storages/PostgreSQL/PostgreSQLConnection.h
@@ -49,18 +49,17 @@ class PostgreSQLConnectionHolder
 {
 
 using Pool = ConcurrentBoundedQueue<PostgreSQLConnectionPtr>;
-using PoolPtr = std::shared_ptr<Pool>;
 
 public:
-    PostgreSQLConnectionHolder(PostgreSQLConnectionPtr connection_, PoolPtr pool_)
+    PostgreSQLConnectionHolder(PostgreSQLConnectionPtr connection_, Pool & pool_)
         : connection(std::move(connection_))
-        , pool(std::move(pool_))
+        , pool(pool_)
     {
     }
 
     PostgreSQLConnectionHolder(const PostgreSQLConnectionHolder & other) = delete;
 
-    ~PostgreSQLConnectionHolder() { pool->tryPush(connection); }
+    ~PostgreSQLConnectionHolder() { pool.tryPush(connection); }
 
     pqxx::connection & conn() const { return *connection->get(); }
 
@@ -68,7 +67,7 @@ public:
 
 private:
     PostgreSQLConnectionPtr connection;
-    PoolPtr pool;
+    Pool & pool;
 };
 
 using PostgreSQLConnectionHolderPtr = std::shared_ptr<PostgreSQLConnectionHolder>;

--- a/src/Storages/PostgreSQL/PostgreSQLConnection.h
+++ b/src/Storages/PostgreSQL/PostgreSQLConnection.h
@@ -45,7 +45,7 @@ private:
 
     ConnectionPtr connection;
     std::string connection_str, address;
-    std::atomic<uint8_t> ref_count;
+    std::atomic<uint8_t> ref_count{0};
 };
 
 using PostgreSQLConnectionPtr = std::shared_ptr<PostgreSQLConnection>;

--- a/src/Storages/PostgreSQL/PostgreSQLConnection.h
+++ b/src/Storages/PostgreSQL/PostgreSQLConnection.h
@@ -49,6 +49,7 @@ class PostgreSQLConnectionHolder
 {
 
 using Pool = ConcurrentBoundedQueue<PostgreSQLConnectionPtr>;
+static constexpr inline auto POSTGRESQL_POOL_WAIT_MS = 50;
 
 public:
     PostgreSQLConnectionHolder(PostgreSQLConnectionPtr connection_, Pool & pool_)
@@ -59,7 +60,7 @@ public:
 
     PostgreSQLConnectionHolder(const PostgreSQLConnectionHolder & other) = delete;
 
-    ~PostgreSQLConnectionHolder() { pool.tryPush(connection); }
+    ~PostgreSQLConnectionHolder() { pool.tryPush(connection, POSTGRESQL_POOL_WAIT_MS); }
 
     pqxx::connection & conn() const { return *connection->get(); }
 

--- a/src/Storages/PostgreSQL/PostgreSQLConnectionPool.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLConnectionPool.cpp
@@ -7,6 +7,7 @@
 #include <IO/Operators.h>
 #include "PostgreSQLConnectionPool.h"
 #include "PostgreSQLConnection.h"
+#include <common/logger_useful.h>
 
 
 namespace DB
@@ -50,25 +51,25 @@ void PostgreSQLConnectionPool::initialize()
 }
 
 
-WrappedPostgreSQLConnection PostgreSQLConnectionPool::get()
+WrappedPostgreSQLConnectionPtr PostgreSQLConnectionPool::get()
 {
     std::lock_guard lock(mutex);
 
     for (const auto & connection : pool)
     {
-        if (connection->available())
-            return WrappedPostgreSQLConnection(connection);
+        if (connection->isAvailable())
+            return std::make_shared<WrappedPostgreSQLConnection>(connection);
     }
 
     auto connection = std::make_shared<PostgreSQLConnection>(connection_str, address);
-    return WrappedPostgreSQLConnection(connection);
+    return std::make_shared<WrappedPostgreSQLConnection>(connection);
 }
 
 
 bool PostgreSQLConnectionPool::isConnected()
 {
     auto connection = get();
-    return connection.isConnected();
+    return connection->isConnected();
 }
 
 }

--- a/src/Storages/PostgreSQL/PostgreSQLConnectionPool.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLConnectionPool.cpp
@@ -1,0 +1,95 @@
+#if !defined(ARCADIA_BUILD)
+#include "config_core.h"
+#endif
+
+#if USE_LIBPQXX
+#include <IO/WriteBufferFromString.h>
+#include <IO/Operators.h>
+#include "PostgreSQLConnectionPool.h"
+#include "PostgreSQLConnection.h"
+
+
+namespace DB
+{
+
+PostgreSQLConnectionPool::PostgreSQLConnectionPool(
+    std::string dbname, std::string host, UInt16 port, std::string user, std::string password)
+    : pool(POSTGRESQL_POOL_DEFAULT_SIZE)
+{
+    address = host + ':' + std::to_string(port);
+    connection_str = formatConnectionString(std::move(dbname), std::move(host), port, std::move(user), std::move(password));
+
+    /// No connection is made, just fill pool with non-connected connection objects.
+    for (size_t i = 0; i < POSTGRESQL_POOL_DEFAULT_SIZE; ++i)
+        pool.push(std::make_shared<PostgreSQLConnection>(connection_str, address));
+}
+
+
+PostgreSQLConnectionPool::PostgreSQLConnectionPool(const PostgreSQLConnectionPool & other)
+        : connection_str(other.connection_str)
+        , address(other.address)
+        , pool(POSTGRESQL_POOL_DEFAULT_SIZE)
+{
+}
+
+
+std::string PostgreSQLConnectionPool::formatConnectionString(
+    std::string dbname, std::string host, UInt16 port, std::string user, std::string password)
+{
+    WriteBufferFromOwnString out;
+    out << "dbname=" << quote << dbname
+        << " host=" << quote << host
+        << " port=" << port
+        << " user=" << quote << user
+        << " password=" << quote << password;
+    return out.str();
+}
+
+
+PostgreSQLConnection::ConnectionPtr PostgreSQLConnectionPool::get()
+{
+    PostgreSQLConnectionPtr connection = popConnection();
+    return connection->get();
+}
+
+
+PostgreSQLConnection::ConnectionPtr PostgreSQLConnectionPool::tryGet()
+{
+    PostgreSQLConnectionPtr connection = popConnection();
+    return connection->tryGet();
+}
+
+
+PostgreSQLConnectionPtr PostgreSQLConnectionPool::popConnection()
+{
+    PostgreSQLConnectionPtr connection;
+    if (pool.tryPop(connection, POSTGRESQL_POOL_WAIT_POP_PUSH_MS))
+        return connection;
+
+    return std::make_shared<PostgreSQLConnection>(connection_str, address);
+}
+
+
+void PostgreSQLConnectionPool::put(PostgreSQLConnection::ConnectionPtr connection)
+{
+    pushConnection(std::make_shared<PostgreSQLConnection>(connection, connection_str, address));
+}
+
+
+void PostgreSQLConnectionPool::pushConnection(PostgreSQLConnectionPtr connection)
+{
+    pool.tryPush(connection, POSTGRESQL_POOL_WAIT_POP_PUSH_MS);
+}
+
+
+bool PostgreSQLConnectionPool::connected()
+{
+    PostgreSQLConnectionPtr connection = popConnection();
+    bool result = connection->connected();
+    pushConnection(connection);
+    return result;
+}
+
+}
+
+#endif

--- a/src/Storages/PostgreSQL/PostgreSQLConnectionPool.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLConnectionPool.cpp
@@ -19,7 +19,6 @@ PostgreSQLConnectionPool::PostgreSQLConnectionPool(
 {
     address = host + ':' + std::to_string(port);
     connection_str = formatConnectionString(std::move(dbname), std::move(host), port, std::move(user), std::move(password));
-    initialize();
 }
 
 
@@ -28,7 +27,6 @@ PostgreSQLConnectionPool::PostgreSQLConnectionPool(const PostgreSQLConnectionPoo
         , connection_str(other.connection_str)
         , address(other.address)
 {
-    initialize();
 }
 
 
@@ -42,14 +40,6 @@ std::string PostgreSQLConnectionPool::formatConnectionString(
         << " user=" << quote << user
         << " password=" << quote << password;
     return out.str();
-}
-
-
-void PostgreSQLConnectionPool::initialize()
-{
-    /// No connection is made, just fill pool with non-connected connection objects.
-    for (size_t i = 0; i < POSTGRESQL_POOL_DEFAULT_SIZE; ++i)
-        pool->push(std::make_shared<PostgreSQLConnection>(connection_str, address));
 }
 
 

--- a/src/Storages/PostgreSQL/PostgreSQLConnectionPool.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLConnectionPool.cpp
@@ -14,9 +14,23 @@ namespace DB
 {
 
 PostgreSQLConnectionPool::PostgreSQLConnectionPool(
-    std::string dbname, std::string host, UInt16 port, std::string user, std::string password)
-    : pool(std::make_shared<Pool>(POSTGRESQL_POOL_DEFAULT_SIZE))
+        std::string dbname,
+        std::string host,
+        UInt16 port,
+        std::string user,
+        std::string password,
+        size_t pool_size_,
+        int64_t pool_wait_timeout_)
+        : pool(std::make_shared<Pool>(pool_size_))
+        , pool_size(pool_size_)
+        , pool_wait_timeout(pool_wait_timeout_)
+        , block_on_empty_pool(pool_wait_timeout == -1)
 {
+    LOG_INFO(
+        &Poco::Logger::get("PostgreSQLConnectionPool"),
+        "New connection pool. Size: {}, blocks on empty pool: {}",
+        pool_size, block_on_empty_pool);
+
     address = host + ':' + std::to_string(port);
     connection_str = formatConnectionString(std::move(dbname), std::move(host), port, std::move(user), std::move(password));
     initialize();
@@ -24,9 +38,12 @@ PostgreSQLConnectionPool::PostgreSQLConnectionPool(
 
 
 PostgreSQLConnectionPool::PostgreSQLConnectionPool(const PostgreSQLConnectionPool & other)
-        : pool(std::make_shared<Pool>(POSTGRESQL_POOL_DEFAULT_SIZE))
+        : pool(std::make_shared<Pool>(other.pool_size))
         , connection_str(other.connection_str)
         , address(other.address)
+        , pool_size(other.pool_size)
+        , pool_wait_timeout(other.pool_wait_timeout)
+        , block_on_empty_pool(other.block_on_empty_pool)
 {
     initialize();
 }
@@ -35,7 +52,7 @@ PostgreSQLConnectionPool::PostgreSQLConnectionPool(const PostgreSQLConnectionPoo
 void PostgreSQLConnectionPool::initialize()
 {
     /// No connection is made, just fill pool with non-connected connection objects.
-    for (size_t i = 0; i < POSTGRESQL_POOL_DEFAULT_SIZE; ++i)
+    for (size_t i = 0; i < pool_size; ++i)
         pool->push(std::make_shared<PostgreSQLConnection>(connection_str, address));
 }
 
@@ -56,7 +73,16 @@ std::string PostgreSQLConnectionPool::formatConnectionString(
 PostgreSQLConnectionHolderPtr PostgreSQLConnectionPool::get()
 {
     PostgreSQLConnectionPtr connection;
-    if (pool->tryPop(connection, POSTGRESQL_POOL_WAIT_MS))
+
+    /// Always blocks by default.
+    if (block_on_empty_pool)
+    {
+        /// pop to ConcurrentBoundedQueue will block untill it is non-empty.
+        pool->pop(connection);
+        return std::make_shared<PostgreSQLConnectionHolder>(connection, *pool);
+    }
+
+    if (pool->tryPop(connection, pool_wait_timeout))
     {
         return std::make_shared<PostgreSQLConnectionHolder>(connection, *pool);
     }

--- a/src/Storages/PostgreSQL/PostgreSQLConnectionPool.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLConnectionPool.cpp
@@ -19,6 +19,7 @@ PostgreSQLConnectionPool::PostgreSQLConnectionPool(
 {
     address = host + ':' + std::to_string(port);
     connection_str = formatConnectionString(std::move(dbname), std::move(host), port, std::move(user), std::move(password));
+    initialize();
 }
 
 
@@ -27,6 +28,15 @@ PostgreSQLConnectionPool::PostgreSQLConnectionPool(const PostgreSQLConnectionPoo
         , connection_str(other.connection_str)
         , address(other.address)
 {
+    initialize();
+}
+
+
+void PostgreSQLConnectionPool::initialize()
+{
+    /// No connection is made, just fill pool with non-connected connection objects.
+    for (size_t i = 0; i < POSTGRESQL_POOL_DEFAULT_SIZE; ++i)
+        pool->push(std::make_shared<PostgreSQLConnection>(connection_str, address));
 }
 
 
@@ -53,13 +63,6 @@ PostgreSQLConnectionHolderPtr PostgreSQLConnectionPool::get()
 
     connection = std::make_shared<PostgreSQLConnection>(connection_str, address);
     return std::make_shared<PostgreSQLConnectionHolder>(connection, *pool);
-}
-
-
-bool PostgreSQLConnectionPool::isConnected()
-{
-    auto connection = get();
-    return connection->isConnected();
 }
 
 }

--- a/src/Storages/PostgreSQL/PostgreSQLConnectionPool.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLConnectionPool.cpp
@@ -77,7 +77,7 @@ PostgreSQLConnectionHolderPtr PostgreSQLConnectionPool::get()
     /// Always blocks by default.
     if (block_on_empty_pool)
     {
-        /// pop to ConcurrentBoundedQueue will block untill it is non-empty.
+        /// pop to ConcurrentBoundedQueue will block until it is non-empty.
         pool->pop(connection);
         return std::make_shared<PostgreSQLConnectionHolder>(connection, *pool);
     }

--- a/src/Storages/PostgreSQL/PostgreSQLConnectionPool.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLConnectionPool.cpp
@@ -50,7 +50,6 @@ void PostgreSQLConnectionPool::initialize()
 }
 
 
-
 WrappedPostgreSQLConnection PostgreSQLConnectionPool::get()
 {
     std::lock_guard lock(mutex);

--- a/src/Storages/PostgreSQL/PostgreSQLConnectionPool.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLConnectionPool.cpp
@@ -48,11 +48,11 @@ PostgreSQLConnectionHolderPtr PostgreSQLConnectionPool::get()
     PostgreSQLConnectionPtr connection;
     if (pool->tryPop(connection, POSTGRESQL_POOL_WAIT_MS))
     {
-        return std::make_shared<PostgreSQLConnectionHolder>(connection, pool);
+        return std::make_shared<PostgreSQLConnectionHolder>(connection, *pool);
     }
 
     connection = std::make_shared<PostgreSQLConnection>(connection_str, address);
-    return std::make_shared<PostgreSQLConnectionHolder>(connection, pool);
+    return std::make_shared<PostgreSQLConnectionHolder>(connection, *pool);
 }
 
 

--- a/src/Storages/PostgreSQL/PostgreSQLConnectionPool.h
+++ b/src/Storages/PostgreSQL/PostgreSQLConnectionPool.h
@@ -14,17 +14,27 @@ namespace DB
 class PostgreSQLReplicaConnection;
 
 
-/// Connection pool of size POSTGRESQL_POOL_DEFAULT_SIZE = 16.
-/// If it was not possible to fetch connection within a timeout, a new connection is made.
-/// If it was not possible to put connection back into pool within a timeout, it is closed.
+/// Connection pool size is defined by user with setting `postgresql_connection_pool_size` (default 16).
+/// If pool is empty, it will block untill there are available connections.
+/// If setting `connection_pool_wait_timeout` is defined, it will not block on empty pool and will
+/// wait untill the timeout and then create a new connection. (only for storage/db engine)
 class PostgreSQLConnectionPool
 {
 
 friend class PostgreSQLReplicaConnection;
 
+static constexpr inline auto POSTGRESQL_POOL_DEFAULT_SIZE = 16;
+
 public:
 
-    PostgreSQLConnectionPool(std::string dbname, std::string host, UInt16 port, std::string user, std::string password);
+    PostgreSQLConnectionPool(
+            std::string dbname,
+            std::string host,
+            UInt16 port,
+            std::string user,
+            std::string password,
+            size_t pool_size_ = POSTGRESQL_POOL_DEFAULT_SIZE,
+            int64_t pool_wait_timeout_ = -1);
 
     PostgreSQLConnectionPool(const PostgreSQLConnectionPool & other);
 
@@ -33,9 +43,6 @@ public:
     PostgreSQLConnectionHolderPtr get();
 
 private:
-    static constexpr inline auto POSTGRESQL_POOL_DEFAULT_SIZE = 16;
-    static constexpr inline auto POSTGRESQL_POOL_WAIT_MS = 50;
-
     using Pool = ConcurrentBoundedQueue<PostgreSQLConnectionPtr>;
     using PoolPtr = std::shared_ptr<Pool>;
 
@@ -46,6 +53,9 @@ private:
 
     PoolPtr pool;
     std::string connection_str, address;
+    size_t pool_size;
+    int64_t pool_wait_timeout;
+    bool block_on_empty_pool;
 };
 
 using PostgreSQLConnectionPoolPtr = std::shared_ptr<PostgreSQLConnectionPool>;

--- a/src/Storages/PostgreSQL/PostgreSQLConnectionPool.h
+++ b/src/Storages/PostgreSQL/PostgreSQLConnectionPool.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#if !defined(ARCADIA_BUILD)
+#include "config_core.h"
+#endif
+
+#if USE_LIBPQXX
+#include <Common/ConcurrentBoundedQueue.h>
+#include "PostgreSQLConnection.h"
+#include <pqxx/pqxx> // Y_IGNORE
+
+namespace DB
+{
+
+class PostgreSQLConnectionPool
+{
+
+public:
+
+    PostgreSQLConnectionPool(std::string dbname, std::string host, UInt16 port, std::string user, std::string password);
+
+    PostgreSQLConnectionPool(const PostgreSQLConnectionPool & other);
+
+    PostgreSQLConnectionPool operator =(const PostgreSQLConnectionPool &) = delete;
+
+    /// Will throw if unable to setup connection.
+    PostgreSQLConnection::ConnectionPtr get();
+
+    /// Will return nullptr if connection was not established.
+    PostgreSQLConnection::ConnectionPtr tryGet();
+
+    void put(PostgreSQLConnection::ConnectionPtr connection);
+
+    bool connected();
+
+    std::string & conn_str() { return connection_str; }
+
+private:
+    static constexpr inline auto POSTGRESQL_POOL_DEFAULT_SIZE = 16;
+    static constexpr inline auto POSTGRESQL_POOL_WAIT_POP_PUSH_MS = 100;
+
+    using Pool = ConcurrentBoundedQueue<PostgreSQLConnectionPtr>;
+
+    static std::string formatConnectionString(
+        std::string dbname, std::string host, UInt16 port, std::string user, std::string password);
+
+    /// Try get connection from connection pool with timeout.
+    /// If pool is empty after timeout, make a new connection.
+    PostgreSQLConnectionPtr popConnection();
+
+    /// Put connection object back into pool.
+    void pushConnection(PostgreSQLConnectionPtr connection);
+
+    std::string connection_str, address;
+    Pool pool;
+};
+
+using PostgreSQLConnectionPoolPtr = std::shared_ptr<PostgreSQLConnectionPool>;
+
+}
+
+#endif

--- a/src/Storages/PostgreSQL/PostgreSQLConnectionPool.h
+++ b/src/Storages/PostgreSQL/PostgreSQLConnectionPool.h
@@ -25,7 +25,7 @@ public:
 
     PostgreSQLConnectionPool operator =(const PostgreSQLConnectionPool &) = delete;
 
-    WrappedPostgreSQLConnection get();
+    WrappedPostgreSQLConnectionPtr get();
 
 protected:
     bool isConnected();

--- a/src/Storages/PostgreSQL/PostgreSQLConnectionPool.h
+++ b/src/Storages/PostgreSQL/PostgreSQLConnectionPool.h
@@ -13,6 +13,10 @@ namespace DB
 
 class PostgreSQLReplicaConnection;
 
+
+/// Connection pool of size POSTGRESQL_POOL_DEFAULT_SIZE = 16.
+/// If it was not possible to fetch connection within a timeout, a new connection is made.
+/// If it was not possible to put connection back into pool within a timeout, it is closed.
 class PostgreSQLConnectionPool
 {
 
@@ -28,18 +32,17 @@ public:
 
     PostgreSQLConnectionHolderPtr get();
 
-protected:
-    bool isConnected();
-
 private:
     static constexpr inline auto POSTGRESQL_POOL_DEFAULT_SIZE = 16;
-    static constexpr inline auto POSTGRESQL_POOL_WAIT_MS = 10;
+    static constexpr inline auto POSTGRESQL_POOL_WAIT_MS = 50;
 
     using Pool = ConcurrentBoundedQueue<PostgreSQLConnectionPtr>;
     using PoolPtr = std::shared_ptr<Pool>;
 
     static std::string formatConnectionString(
         std::string dbname, std::string host, UInt16 port, std::string user, std::string password);
+
+    void initialize();
 
     PoolPtr pool;
     std::string connection_str, address;

--- a/src/Storages/PostgreSQL/PostgreSQLConnectionPool.h
+++ b/src/Storages/PostgreSQL/PostgreSQLConnectionPool.h
@@ -41,8 +41,6 @@ private:
     static std::string formatConnectionString(
         std::string dbname, std::string host, UInt16 port, std::string user, std::string password);
 
-    void initialize();
-
     PoolPtr pool;
     std::string connection_str, address;
 };

--- a/src/Storages/PostgreSQL/PostgreSQLConnectionPool.h
+++ b/src/Storages/PostgreSQL/PostgreSQLConnectionPool.h
@@ -15,9 +15,9 @@ class PostgreSQLReplicaConnection;
 
 
 /// Connection pool size is defined by user with setting `postgresql_connection_pool_size` (default 16).
-/// If pool is empty, it will block untill there are available connections.
+/// If pool is empty, it will block until there are available connections.
 /// If setting `connection_pool_wait_timeout` is defined, it will not block on empty pool and will
-/// wait untill the timeout and then create a new connection. (only for storage/db engine)
+/// wait until the timeout and then create a new connection. (only for storage/db engine)
 class PostgreSQLConnectionPool
 {
 

--- a/src/Storages/PostgreSQL/PostgreSQLConnectionPool.h
+++ b/src/Storages/PostgreSQL/PostgreSQLConnectionPool.h
@@ -5,16 +5,17 @@
 #endif
 
 #if USE_LIBPQXX
-#include <Common/ConcurrentBoundedQueue.h>
 #include "PostgreSQLConnection.h"
 
 
 namespace DB
 {
+
 class PostgreSQLReplicaConnection;
 
 class PostgreSQLConnectionPool
 {
+
 friend class PostgreSQLReplicaConnection;
 
 public:
@@ -25,25 +26,25 @@ public:
 
     PostgreSQLConnectionPool operator =(const PostgreSQLConnectionPool &) = delete;
 
-    WrappedPostgreSQLConnectionPtr get();
+    PostgreSQLConnectionHolderPtr get();
 
 protected:
     bool isConnected();
 
 private:
     static constexpr inline auto POSTGRESQL_POOL_DEFAULT_SIZE = 16;
-    static constexpr inline auto POSTGRESQL_POOL_WAIT_POP_PUSH_MS = 100;
+    static constexpr inline auto POSTGRESQL_POOL_WAIT_MS = 10;
 
-    using Pool = std::vector<PostgreSQLConnectionPtr>;
+    using Pool = ConcurrentBoundedQueue<PostgreSQLConnectionPtr>;
+    using PoolPtr = std::shared_ptr<Pool>;
 
     static std::string formatConnectionString(
         std::string dbname, std::string host, UInt16 port, std::string user, std::string password);
 
     void initialize();
 
+    PoolPtr pool;
     std::string connection_str, address;
-    Pool pool;
-    std::mutex mutex;
 };
 
 using PostgreSQLConnectionPoolPtr = std::shared_ptr<PostgreSQLConnectionPool>;

--- a/src/Storages/PostgreSQL/PostgreSQLReplicaConnection.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLReplicaConnection.cpp
@@ -59,14 +59,14 @@ PostgreSQLReplicaConnection::PostgreSQLReplicaConnection(const PostgreSQLReplica
 }
 
 
-PostgreSQLConnectionPoolPtr PostgreSQLReplicaConnection::get()
+WrappedPostgreSQLConnection PostgreSQLReplicaConnection::get()
 {
     for (size_t i = 0; i < num_retries; ++i)
     {
         for (auto & replica : replicas)
         {
-            if (replica.second->connected())
-                return replica.second;
+            if (replica.second->isConnected())
+                return replica.second->get();
         }
     }
 

--- a/src/Storages/PostgreSQL/PostgreSQLReplicaConnection.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLReplicaConnection.cpp
@@ -52,7 +52,7 @@ PostgreSQLReplicaConnection::PostgreSQLReplicaConnection(
 }
 
 
-WrappedPostgreSQLConnectionPtr PostgreSQLReplicaConnection::get()
+PostgreSQLConnectionHolderPtr PostgreSQLReplicaConnection::get()
 {
     for (size_t i = 0; i < num_retries; ++i)
     {

--- a/src/Storages/PostgreSQL/PostgreSQLReplicaConnection.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLReplicaConnection.cpp
@@ -1,5 +1,6 @@
 #include "PostgreSQLReplicaConnection.h"
-#include <Poco/Util/AbstractConfiguration.h>
+#include "PostgreSQLConnection.h"
+#include <Common/Exception.h>
 
 
 namespace DB
@@ -15,8 +16,7 @@ PostgreSQLReplicaConnection::PostgreSQLReplicaConnection(
         const Poco::Util::AbstractConfiguration & config,
         const String & config_prefix,
         const size_t num_retries_)
-        : log(&Poco::Logger::get("PostgreSQLConnection"))
-        , num_retries(num_retries_)
+        : num_retries(num_retries_)
 {
     auto db = config.getString(config_prefix + ".db", "");
     auto host = config.getString(config_prefix + ".host", "");
@@ -41,33 +41,32 @@ PostgreSQLReplicaConnection::PostgreSQLReplicaConnection(
                 auto replica_user = config.getString(replica_name + ".user", user);
                 auto replica_password = config.getString(replica_name + ".password", password);
 
-                replicas[priority] = std::make_shared<PostgreSQLConnection>(db, replica_host, replica_port, replica_user, replica_password);
+                replicas[priority] = std::make_shared<PostgreSQLConnectionPool>(db, replica_host, replica_port, replica_user, replica_password);
             }
         }
     }
     else
     {
-        replicas[0] = std::make_shared<PostgreSQLConnection>(db, host, port, user, password);
+        replicas[0] = std::make_shared<PostgreSQLConnectionPool>(db, host, port, user, password);
     }
 }
 
 
 PostgreSQLReplicaConnection::PostgreSQLReplicaConnection(const PostgreSQLReplicaConnection & other)
-        : log(&Poco::Logger::get("PostgreSQLConnection"))
-        , replicas(other.replicas)
+        : replicas(other.replicas)
         , num_retries(other.num_retries)
 {
 }
 
 
-PostgreSQLConnection::ConnectionPtr PostgreSQLReplicaConnection::get()
+PostgreSQLConnectionPoolPtr PostgreSQLReplicaConnection::get()
 {
     for (size_t i = 0; i < num_retries; ++i)
     {
         for (auto & replica : replicas)
         {
-            if (replica.second->tryConnect())
-                return replica.second->conn();
+            if (replica.second->connected())
+                return replica.second;
         }
     }
 

--- a/src/Storages/PostgreSQL/PostgreSQLReplicaConnection.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLReplicaConnection.cpp
@@ -52,14 +52,24 @@ PostgreSQLReplicaConnection::PostgreSQLReplicaConnection(
 }
 
 
+PostgreSQLReplicaConnection::PostgreSQLReplicaConnection(const PostgreSQLReplicaConnection & other)
+        : replicas(other.replicas)
+        , num_retries(other.num_retries)
+{
+}
+
+
 PostgreSQLConnectionHolderPtr PostgreSQLReplicaConnection::get()
 {
+    std::lock_guard lock(mutex);
+
     for (size_t i = 0; i < num_retries; ++i)
     {
         for (auto & replica : replicas)
         {
-            if (replica.second->isConnected())
-                return replica.second->get();
+            auto connection = replica.second->get();
+            if (connection->isConnected())
+                return connection;
         }
     }
 

--- a/src/Storages/PostgreSQL/PostgreSQLReplicaConnection.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLReplicaConnection.cpp
@@ -52,7 +52,7 @@ PostgreSQLReplicaConnection::PostgreSQLReplicaConnection(
 }
 
 
-WrappedPostgreSQLConnection PostgreSQLReplicaConnection::get()
+WrappedPostgreSQLConnectionPtr PostgreSQLReplicaConnection::get()
 {
     for (size_t i = 0; i < num_retries; ++i)
     {

--- a/src/Storages/PostgreSQL/PostgreSQLReplicaConnection.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLReplicaConnection.cpp
@@ -52,13 +52,6 @@ PostgreSQLReplicaConnection::PostgreSQLReplicaConnection(
 }
 
 
-PostgreSQLReplicaConnection::PostgreSQLReplicaConnection(const PostgreSQLReplicaConnection & other)
-        : replicas(other.replicas)
-        , num_retries(other.num_retries)
-{
-}
-
-
 WrappedPostgreSQLConnection PostgreSQLReplicaConnection::get()
 {
     for (size_t i = 0; i < num_retries; ++i)

--- a/src/Storages/PostgreSQL/PostgreSQLReplicaConnection.h
+++ b/src/Storages/PostgreSQL/PostgreSQLReplicaConnection.h
@@ -21,7 +21,7 @@ public:
 
     PostgreSQLReplicaConnection(const PostgreSQLReplicaConnection & other) = default;
 
-    WrappedPostgreSQLConnectionPtr get();
+    PostgreSQLConnectionHolderPtr get();
 
 
 private:

--- a/src/Storages/PostgreSQL/PostgreSQLReplicaConnection.h
+++ b/src/Storages/PostgreSQL/PostgreSQLReplicaConnection.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "PostgreSQLConnection.h"
 #include <Core/Types.h>
 #include <Poco/Util/AbstractConfiguration.h>
-#include <common/logger_useful.h>
+#include "PostgreSQLConnectionPool.h"
+
 
 namespace DB
 {
@@ -21,14 +21,13 @@ public:
 
     PostgreSQLReplicaConnection(const PostgreSQLReplicaConnection & other);
 
-    PostgreSQLConnection::ConnectionPtr get();
+    PostgreSQLConnectionPoolPtr get();
 
 
 private:
     /// Highest priority is 0, the bigger the number in map, the less the priority
-    using ReplicasByPriority = std::map<size_t, PostgreSQLConnectionPtr>;
+    using ReplicasByPriority = std::map<size_t, PostgreSQLConnectionPoolPtr>;
 
-    Poco::Logger * log;
     ReplicasByPriority replicas;
     size_t num_retries;
 };

--- a/src/Storages/PostgreSQL/PostgreSQLReplicaConnection.h
+++ b/src/Storages/PostgreSQL/PostgreSQLReplicaConnection.h
@@ -21,7 +21,7 @@ public:
 
     PostgreSQLReplicaConnection(const PostgreSQLReplicaConnection & other);
 
-    PostgreSQLConnectionPoolPtr get();
+    WrappedPostgreSQLConnection get();
 
 
 private:

--- a/src/Storages/PostgreSQL/PostgreSQLReplicaConnection.h
+++ b/src/Storages/PostgreSQL/PostgreSQLReplicaConnection.h
@@ -19,7 +19,7 @@ public:
         const String & config_prefix,
         const size_t num_retries_ = POSTGRESQL_CONNECTION_DEFAULT_RETRIES_NUM);
 
-    PostgreSQLReplicaConnection(const PostgreSQLReplicaConnection & other);
+    PostgreSQLReplicaConnection(const PostgreSQLReplicaConnection & other) = default;
 
     WrappedPostgreSQLConnection get();
 

--- a/src/Storages/PostgreSQL/PostgreSQLReplicaConnection.h
+++ b/src/Storages/PostgreSQL/PostgreSQLReplicaConnection.h
@@ -21,7 +21,7 @@ public:
 
     PostgreSQLReplicaConnection(const PostgreSQLReplicaConnection & other) = default;
 
-    WrappedPostgreSQLConnection get();
+    WrappedPostgreSQLConnectionPtr get();
 
 
 private:

--- a/src/Storages/PostgreSQL/PostgreSQLReplicaConnection.h
+++ b/src/Storages/PostgreSQL/PostgreSQLReplicaConnection.h
@@ -19,7 +19,7 @@ public:
         const String & config_prefix,
         const size_t num_retries_ = POSTGRESQL_CONNECTION_DEFAULT_RETRIES_NUM);
 
-    PostgreSQLReplicaConnection(const PostgreSQLReplicaConnection & other) = default;
+    PostgreSQLReplicaConnection(const PostgreSQLReplicaConnection & other);
 
     PostgreSQLConnectionHolderPtr get();
 
@@ -30,6 +30,7 @@ private:
 
     ReplicasByPriority replicas;
     size_t num_retries;
+    std::mutex mutex;
 };
 
 using PostgreSQLReplicaConnectionPtr = std::shared_ptr<PostgreSQLReplicaConnection>;

--- a/src/Storages/StoragePostgreSQL.cpp
+++ b/src/Storages/StoragePostgreSQL.cpp
@@ -97,7 +97,7 @@ class PostgreSQLBlockOutputStream : public IBlockOutputStream
 public:
     explicit PostgreSQLBlockOutputStream(
         const StorageMetadataPtr & metadata_snapshot_,
-        WrappedPostgreSQLConnectionPtr connection_,
+        PostgreSQLConnectionHolderPtr connection_,
         const std::string & remote_table_name_)
         : metadata_snapshot(metadata_snapshot_)
         , connection(std::move(connection_))
@@ -276,7 +276,7 @@ public:
 
 private:
     StorageMetadataPtr metadata_snapshot;
-    WrappedPostgreSQLConnectionPtr connection;
+    PostgreSQLConnectionHolderPtr connection;
     std::string remote_table_name;
 
     std::unique_ptr<pqxx::work> work;

--- a/src/Storages/StoragePostgreSQL.cpp
+++ b/src/Storages/StoragePostgreSQL.cpp
@@ -317,7 +317,9 @@ void registerStoragePostgreSQL(StorageFactory & factory)
             parsed_host_port.first,
             parsed_host_port.second,
             engine_args[3]->as<ASTLiteral &>().value.safeGet<String>(),
-            engine_args[4]->as<ASTLiteral &>().value.safeGet<String>());
+            engine_args[4]->as<ASTLiteral &>().value.safeGet<String>(),
+            args.context.getSettingsRef().postgresql_connection_pool_size,
+            args.context.getSettingsRef().postgresql_connection_pool_wait_timeout);
 
         return StoragePostgreSQL::create(
             args.table_id, remote_table, connection_pool, args.columns, args.constraints, args.context, remote_table_schema);

--- a/src/Storages/StoragePostgreSQL.cpp
+++ b/src/Storages/StoragePostgreSQL.cpp
@@ -97,10 +97,10 @@ class PostgreSQLBlockOutputStream : public IBlockOutputStream
 public:
     explicit PostgreSQLBlockOutputStream(
         const StorageMetadataPtr & metadata_snapshot_,
-        WrappedPostgreSQLConnection connection_,
+        WrappedPostgreSQLConnectionPtr connection_,
         const std::string & remote_table_name_)
         : metadata_snapshot(metadata_snapshot_)
-        , connection(connection_)
+        , connection(std::move(connection_))
         , remote_table_name(remote_table_name_)
     {
     }
@@ -110,7 +110,7 @@ public:
 
     void writePrefix() override
     {
-        work = std::make_unique<pqxx::work>(*connection);
+        work = std::make_unique<pqxx::work>(connection->conn());
     }
 
 
@@ -276,7 +276,7 @@ public:
 
 private:
     StorageMetadataPtr metadata_snapshot;
-    WrappedPostgreSQLConnection connection;
+    WrappedPostgreSQLConnectionPtr connection;
     std::string remote_table_name;
 
     std::unique_ptr<pqxx::work> work;

--- a/src/Storages/StoragePostgreSQL.h
+++ b/src/Storages/StoragePostgreSQL.h
@@ -9,14 +9,13 @@
 #include <Interpreters/Context.h>
 #include <Storages/IStorage.h>
 #include <DataStreams/IBlockOutputStream.h>
+#include <Storages/PostgreSQL/PostgreSQLConnectionPool.h>
 #include <pqxx/pqxx>
 
 
 namespace DB
 {
 
-class PostgreSQLConnection;
-using PostgreSQLConnectionPtr = std::shared_ptr<PostgreSQLConnection>;
 
 class StoragePostgreSQL final : public ext::shared_ptr_helper<StoragePostgreSQL>, public IStorage
 {
@@ -24,8 +23,8 @@ class StoragePostgreSQL final : public ext::shared_ptr_helper<StoragePostgreSQL>
 public:
     StoragePostgreSQL(
         const StorageID & table_id_,
-        const std::string & remote_table_name_,
-        PostgreSQLConnectionPtr connection_,
+        const String & remote_table_name_,
+        PostgreSQLConnectionPoolPtr connection_pool_,
         const ColumnsDescription & columns_,
         const ConstraintsDescription & constraints_,
         const Context & context_,
@@ -50,7 +49,7 @@ private:
     String remote_table_name;
     String remote_table_schema;
     Context global_context;
-    PostgreSQLConnectionPtr connection;
+    PostgreSQLConnectionPoolPtr connection_pool;
 };
 
 }

--- a/src/TableFunctions/TableFunctionPostgreSQL.h
+++ b/src/TableFunctions/TableFunctionPostgreSQL.h
@@ -10,8 +10,8 @@
 namespace DB
 {
 
-class PostgreSQLConnection;
-using PostgreSQLConnectionPtr = std::shared_ptr<PostgreSQLConnection>;
+class PostgreSQLConnectionPool;
+using PostgreSQLConnectionPoolPtr = std::shared_ptr<PostgreSQLConnectionPool>;
 
 class TableFunctionPostgreSQL : public ITableFunction
 {
@@ -31,7 +31,7 @@ private:
 
     String connection_str;
     String remote_table_name, remote_table_schema;
-    PostgreSQLConnectionPtr connection;
+    PostgreSQLConnectionPoolPtr connection_pool;
 };
 
 }

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -1084,8 +1084,8 @@ class ClickHouseInstance:
 
     def count_in_log(self, substring):
         result = self.exec_in_container(
-            ["bash", "-c", 'grep "{}" /var/log/clickhouse-server/clickhouse-server.log || true'.format(substring)])
-        return len(result)
+            ["bash", "-c", 'grep "{}" /var/log/clickhouse-server/clickhouse-server.log | wc -l'.format(substring)])
+        return result
 
     def wait_for_log_line(self, regexp, filename='/var/log/clickhouse-server/clickhouse-server.log', timeout=30, repetitions=1, look_behind_lines=100):
         start_time = time.time()

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -1082,6 +1082,11 @@ class ClickHouseInstance:
             ["bash", "-c", 'grep "{}" /var/log/clickhouse-server/clickhouse-server.log || true'.format(substring)])
         return len(result) > 0
 
+    def count_in_log(self, substring):
+        result = self.exec_in_container(
+            ["bash", "-c", 'grep "{}" /var/log/clickhouse-server/clickhouse-server.log || true'.format(substring)])
+        return len(result)
+
     def wait_for_log_line(self, regexp, filename='/var/log/clickhouse-server/clickhouse-server.log', timeout=30, repetitions=1, look_behind_lines=100):
         start_time = time.time()
         result = self.exec_in_container(

--- a/tests/integration/test_storage_postgresql/configs/log_conf.xml
+++ b/tests/integration/test_storage_postgresql/configs/log_conf.xml
@@ -1,0 +1,11 @@
+<yandex>
+    <logger>
+        <level>trace</level>
+        <log>/var/log/clickhouse-server/log.log</log>
+        <errorlog>/var/log/clickhouse-server/log.err.log</errorlog>
+        <size>1000M</size>
+        <count>10</count>
+        <stderr>/var/log/clickhouse-server/stderr.log</stderr>
+        <stdout>/var/log/clickhouse-server/stdout.log</stdout>
+    </logger>
+</yandex>

--- a/tests/integration/test_storage_postgresql/test.py
+++ b/tests/integration/test_storage_postgresql/test.py
@@ -176,7 +176,7 @@ def test_concurrent_queries(started_cluster):
     cursor.execute('CREATE TABLE test_table (key integer, value integer)')
 
     def node_insert(_):
-        for i in range(100):
+        for i in range(5):
             result = node1.query("INSERT INTO test_table SELECT number, number FROM numbers(100)", user='default')
 
     busy_pool = Pool(10)
@@ -184,7 +184,7 @@ def test_concurrent_queries(started_cluster):
     p.wait()
     result = node1.query("SELECT count() FROM test_table", user='default')
     print(result)
-    assert(int(result) == 10 * 100 * 100)
+    assert(int(result) == 10 * 5 * 100)
 
     def node_select(_):
         for i in range(5):
@@ -195,7 +195,7 @@ def test_concurrent_queries(started_cluster):
     p.wait()
 
     def node_insert_select(_):
-        for i in range(25):
+        for i in range(5):
             result = node1.query("INSERT INTO test_table SELECT number, number FROM numbers(100)", user='default')
             result = node1.query("SELECT * FROM test_table LIMIT 100", user='default')
 
@@ -204,7 +204,7 @@ def test_concurrent_queries(started_cluster):
     p.wait()
     result = node1.query("SELECT count() FROM test_table", user='default')
     print(result)
-    assert(int(result) == 10 * 100 * 100  + 10 * 25 * 100)
+    assert(int(result) == 10 * 5 * 100  * 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add connection pool for PostgreSQL table/database engine and dictionary source. Should fix https://github.com/ClickHouse/ClickHouse/issues/21444.
