### PR TITLE
zookeeper-dump-tree: added ctime option to dump node ctime

### DIFF
--- a/utils/zookeeper-dump-tree/main.cpp
+++ b/utils/zookeeper-dump-tree/main.cpp
@@ -31,7 +31,7 @@ int main(int argc, char ** argv)
             return 1;
         }
 
-        bool dump_ctime = (options.count("ctime")) ? true : false;
+        bool dump_ctime = options.count("ctime");
 
         zkutil::ZooKeeperPtr zookeeper = std::make_shared<zkutil::ZooKeeper>(options.at("address").as<std::string>());
 
@@ -83,9 +83,8 @@ int main(int argc, char ** argv)
             }
 
             std::cout << it->first << '\t' << response.stat.numChildren << '\t' << response.stat.dataLength;
-            if (dump_ctime) {
+            if (dump_ctime)
                 std::cout << '\t' << response.stat.ctime;
-            }
             std::cout << '\n';
 
             for (const auto & name : response.names)

--- a/utils/zookeeper-dump-tree/main.cpp
+++ b/utils/zookeeper-dump-tree/main.cpp
@@ -17,6 +17,7 @@ int main(int argc, char ** argv)
                 "addresses of ZooKeeper instances, comma separated. Example: example01e.yandex.ru:2181")
             ("path,p", boost::program_options::value<std::string>()->default_value("/"),
                 "where to start")
+            ("ctime,c", "print node ctime")
         ;
 
         boost::program_options::variables_map options;
@@ -79,7 +80,11 @@ int main(int argc, char ** argv)
                     throw;
             }
 
-            std::cout << it->first << '\t' << response.stat.numChildren << '\t' << response.stat.dataLength << '\n';
+            std::cout << it->first << '\t' << response.stat.numChildren << '\t' << response.stat.dataLength;
+            if (options.count("ctime")) {
+                std::cout << '\t' << response.stat.ctime;
+            }
+            std::cout << '\n';
 
             for (const auto & name : response.names)
             {

--- a/utils/zookeeper-dump-tree/main.cpp
+++ b/utils/zookeeper-dump-tree/main.cpp
@@ -31,6 +31,8 @@ int main(int argc, char ** argv)
             return 1;
         }
 
+        bool dump_ctime = (options.count("ctime")) ? true : false;
+
         zkutil::ZooKeeperPtr zookeeper = std::make_shared<zkutil::ZooKeeper>(options.at("address").as<std::string>());
 
         std::string initial_path = options.at("path").as<std::string>();
@@ -81,7 +83,7 @@ int main(int argc, char ** argv)
             }
 
             std::cout << it->first << '\t' << response.stat.numChildren << '\t' << response.stat.dataLength;
-            if (options.count("ctime")) {
+            if (dump_ctime) {
                 std::cout << '\t' << response.stat.ctime;
             }
             std::cout << '\n';


### PR DESCRIPTION
Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add `ctime` option to `zookeeper-dump-tree`. It allows to dump node creation time.

