### PR TITLE
Add bash completion support for clickhouse utils

### DIFF
--- a/debian/clickhouse-common-static.install
+++ b/debian/clickhouse-common-static.install
@@ -1,4 +1,5 @@
 usr/bin/clickhouse
 usr/bin/clickhouse-odbc-bridge
 usr/bin/clickhouse-extract-from-config
+usr/share/bash-completion/completions
 etc/security/limits.d/clickhouse.conf

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -188,6 +188,7 @@ add_subdirectory (format)
 add_subdirectory (obfuscator)
 add_subdirectory (install)
 add_subdirectory (git-import)
+add_subdirectory (bash-completion)
 
 if (ENABLE_CLICKHOUSE_ODBC_BRIDGE)
     add_subdirectory (odbc-bridge)

--- a/programs/bash-completion/CMakeLists.txt
+++ b/programs/bash-completion/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(completions)

--- a/programs/bash-completion/completions/CMakeLists.txt
+++ b/programs/bash-completion/completions/CMakeLists.txt
@@ -1,0 +1,28 @@
+macro(configure_bash_completion)
+    set(out "/usr/share/bash-completion/completions")
+    find_program(pkg-config PKG_CONFIG_BIN)
+    if (PKG_CONFIG_BIN)
+        execute_process(
+            COMMAND ${PKG_CONFIG_BIN} --variable=completionsdir bash-completion
+            OUTPUT_VARIABLE ${out}
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+    endif()
+    string(REPLACE /usr "${CMAKE_INSTALL_PREFIX}" out "${out}")
+    message(STATUS "bash_completion will be written to ${out}")
+endmacro()
+
+configure_bash_completion()
+foreach (name
+    # set of functions
+    clickhouse-bootstrap
+
+    # binaries that accept settings as command line argument
+    clickhouse-client
+    clickhouse-local
+    clickhouse-benchmark
+
+    clickhouse
+)
+    install(FILES ${name} DESTINATION ${out})
+endforeach()

--- a/programs/bash-completion/completions/clickhouse
+++ b/programs/bash-completion/completions/clickhouse
@@ -1,0 +1,43 @@
+[[ -v $_CLICKHOUSE_COMPLETION_LOADED ]] || source "$(dirname "${BASH_SOURCE[0]}")/clickhouse-bootstrap"
+
+function _clickhouse_get_utils()
+{
+    local cmd=$1 && shift
+    "$cmd" --help |& awk '/^clickhouse.*args/ { print $2 }'
+}
+
+function _complete_for_clickhouse_entrypoint_bin()
+{
+    local cur prev cword words
+    eval local cmd="$( _clickhouse_quote "$1" )"
+    _clickhouse_bin_exist "$cmd" || return 0
+
+    COMPREPLY=()
+    _get_comp_words_by_ref cur prev cword words
+
+    local util="$cur"
+    # complete utils, until it will be finished
+    if [[ $cword -lt 2 ]]; then
+        COMPREPLY=( $(compgen -W "$(_clickhouse_get_utils "$cmd")" -- "$cur") )
+        return
+    fi
+    util="${words[1]}"
+
+    case "$prev" in
+        -C|--config-file|--config)
+            return
+            ;;
+        # Argh...  This looks like a bash bug...
+        # Redirections are passed to the completion function
+        # although it is managed by the shell directly...
+        '<'|'>'|'>>'|[12]'>'|[12]'>>')
+            return
+            ;;
+    esac
+
+    COMPREPLY=( $(compgen -W "$(_clickhouse_get_options "$cmd" "$util")" -- "$cur") )
+
+    return 0
+}
+
+_complete_clickhouse_generic clickhouse _complete_for_clickhouse_entrypoint_bin

--- a/programs/bash-completion/completions/clickhouse-benchmark
+++ b/programs/bash-completion/completions/clickhouse-benchmark
@@ -1,0 +1,2 @@
+[[ -v $_CLICKHOUSE_COMPLETION_LOADED ]] || source "$(dirname "${BASH_SOURCE[0]}")/clickhouse-bootstrap"
+_complete_clickhouse_generic clickhouse-benchmark

--- a/programs/bash-completion/completions/clickhouse-bootstrap
+++ b/programs/bash-completion/completions/clickhouse-bootstrap
@@ -1,0 +1,81 @@
+#
+# bash autocomplete, that can work with:
+# a) --help of program
+#
+# Also you may like:
+# $ bind "set completion-ignore-case on"
+# $ bind "set show-all-if-ambiguous on"
+#
+# It uses bash-completion dynamic loader.
+
+# Known to work with bash 3.* with programmable completion and extended
+# pattern matching enabled (use 'shopt -s extglob progcomp' to enable
+# these if they are not already enabled).
+shopt -s extglob
+
+export _CLICKHOUSE_COMPLETION_LOADED=1
+
+function _clickhouse_bin_exist()
+{ [ -x "$1" ] || command -v "$1" >& /dev/null; }
+
+function _clickhouse_quote()
+{
+    local quoted=${1//\'/\'\\\'\'};
+    printf "'%s'" "$quoted"
+}
+
+# Extract every option (everything that starts with "-") from the --help dialog.
+function _clickhouse_get_options()
+{
+    "$@" --help 2>&1 | awk -F '[ ,=<>]' '{ for (i=1; i <= NF; ++i) { if (substr($i, 0, 1) == "-" && length($i) > 1) print $i; } }' | sort -u
+}
+
+function _complete_for_clickhouse_generic_bin()
+{
+    local cur prev
+    eval local cmd="$( _clickhouse_quote "$1" )"
+    _clickhouse_bin_exist "$cmd" || return 0
+
+    COMPREPLY=()
+    _get_comp_words_by_ref cur prev
+
+    case "$prev" in
+        -C|--config-file|--config)
+            return
+            ;;
+        # Argh...  This looks like a bash bug...
+        # Redirections are passed to the completion function
+        # although it is managed by the shell directly...
+        '<'|'>'|'>>'|[12]'>'|[12]'>>')
+            return
+            ;;
+    esac
+
+    COMPREPLY=( $(compgen -W "$(_clickhouse_get_options "$cmd")" -- "$cur") )
+
+    return 0
+}
+
+function _complete_clickhouse_generic()
+{
+    local bin=$1 && shift
+    local f=${1:-_complete_for_clickhouse_generic_bin}
+    local o=(
+        -o default
+        -o bashdefault
+        -o nospace
+        -F "$f"
+        "$bin"
+    )
+    complete "${o[@]}"
+}
+
+function _complete_clickhouse_bootstrap_main()
+{
+    local runtime=/usr/share/bash-completion/bash_completion
+    if ! type _get_comp_words_by_ref >& /dev/null && [[ -f $runtime ]]; then
+        source $runtime
+    fi
+    type _get_comp_words_by_ref >& /dev/null || return 0
+}
+_complete_clickhouse_bootstrap_main "$@"

--- a/programs/bash-completion/completions/clickhouse-client
+++ b/programs/bash-completion/completions/clickhouse-client
@@ -1,0 +1,2 @@
+[[ -v $_CLICKHOUSE_COMPLETION_LOADED ]] || source "$(dirname "${BASH_SOURCE[0]}")/clickhouse-bootstrap"
+_complete_clickhouse_generic clickhouse-client

--- a/programs/bash-completion/completions/clickhouse-local
+++ b/programs/bash-completion/completions/clickhouse-local
@@ -1,0 +1,2 @@
+[[ -v $_CLICKHOUSE_COMPLETION_LOADED ]] || source "$(dirname "${BASH_SOURCE[0]}")/clickhouse-bootstrap"
+_complete_clickhouse_generic clickhouse-local


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)