### PR TITLE
DDL dictionary use current database name

### DIFF
--- a/src/Functions/FunctionsExternalDictionaries.h
+++ b/src/Functions/FunctionsExternalDictionaries.h
@@ -81,9 +81,9 @@ public:
     {
         String resolved_name = DatabaseCatalog::instance().resolveDictionaryName(dictionary_name);
 
-        auto dict = external_loader.tryGetDictionary(resolved_name);
+        bool can_load_dictionary = external_loader.hasDictionary(resolved_name);
 
-        if (!dict)
+        if (!can_load_dictionary)
         {
             /// If dictionary not found. And database was not implicitly specified
             /// we can qualify dictionary name with current database name.
@@ -92,12 +92,10 @@ public:
             {
                 String dictionary_name_with_database = context.getCurrentDatabase() + '.' + dictionary_name;
                 resolved_name = DatabaseCatalog::instance().resolveDictionaryName(dictionary_name_with_database);
-                dict = external_loader.tryGetDictionary(resolved_name);
             }
         }
 
-        if (!dict)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "External dictionary ({}) not found", dictionary_name);
+        auto dict = external_loader.getDictionary(resolved_name);
 
         if (!access_checked)
         {
@@ -330,7 +328,6 @@ public:
 
         DataTypes types;
 
-        auto current_database_name = helper.context.getCurrentDatabase();
         auto dictionary_structure = helper.getDictionaryStructure(dictionary_name);
 
         for (auto & attribute_name : attribute_names)

--- a/src/Functions/FunctionsExternalDictionaries.h
+++ b/src/Functions/FunctionsExternalDictionaries.h
@@ -80,12 +80,31 @@ public:
     std::shared_ptr<const IDictionaryBase> getDictionary(const String & dictionary_name)
     {
         String resolved_name = DatabaseCatalog::instance().resolveDictionaryName(dictionary_name);
-        auto dict = external_loader.getDictionary(resolved_name);
+
+        auto dict = external_loader.tryGetDictionary(resolved_name);
+
+        if (!dict)
+        {
+            /// If dictionary not found. And database was not implicitly specified
+            /// we can qualify dictionary name with current database name.
+            /// It will help if dictionary is created with DDL and is in current database.
+            if (dictionary_name.find('.') == std::string::npos)
+            {
+                String dictionary_name_with_database = context.getCurrentDatabase() + '.' + dictionary_name;
+                resolved_name = DatabaseCatalog::instance().resolveDictionaryName(dictionary_name_with_database);
+                dict = external_loader.tryGetDictionary(resolved_name);
+            }
+        }
+
+        if (!dict)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "External dictionary ({}) not found", dictionary_name);
+
         if (!access_checked)
         {
             context.checkAccess(AccessType::dictGet, dict->getDatabaseOrNoDatabaseTag(), dict->getDictionaryID().getTableName());
             access_checked = true;
         }
+
         return dict;
     }
 
@@ -118,14 +137,29 @@ public:
     DictionaryStructure getDictionaryStructure(const String & dictionary_name) const
     {
         String resolved_name = DatabaseCatalog::instance().resolveDictionaryName(dictionary_name);
+
         auto load_result = external_loader.getLoadResult(resolved_name);
         if (!load_result.config)
+        {
+            /// If dictionary not found. And database was not implicitly specified
+            /// we can qualify dictionary name with current database name.
+            /// It will help if dictionary is created with DDL and is in current database.
+            if (dictionary_name.find('.') == std::string::npos)
+            {
+                String dictionary_name_with_database = context.getCurrentDatabase() + '.' + dictionary_name;
+                resolved_name = DatabaseCatalog::instance().resolveDictionaryName(dictionary_name_with_database);
+                load_result = external_loader.getLoadResult(resolved_name);
+            }
+        }
+
+        if (!load_result.config)
             throw Exception("Dictionary " + backQuote(dictionary_name) + " not found", ErrorCodes::BAD_ARGUMENTS);
+
         return ExternalDictionariesLoader::getDictionaryStructure(*load_result.config);
     }
 
-private:
     const Context & context;
+private:
     const ExternalDictionariesLoader & external_loader;
     /// Access cannot be not granted, since in this case checkAccess() will throw and access_checked will not be updated.
     std::atomic<bool> access_checked = false;
@@ -296,10 +330,13 @@ public:
 
         DataTypes types;
 
+        auto current_database_name = helper.context.getCurrentDatabase();
+        auto dictionary_structure = helper.getDictionaryStructure(dictionary_name);
+
         for (auto & attribute_name : attribute_names)
         {
             /// We're extracting the return type from the dictionary's config, without loading the dictionary.
-            auto attribute = helper.getDictionaryStructure(dictionary_name).getAttribute(attribute_name);
+            auto attribute = dictionary_structure.getAttribute(attribute_name);
             types.emplace_back(attribute.type);
         }
 

--- a/src/Interpreters/ExternalDictionariesLoader.h
+++ b/src/Interpreters/ExternalDictionariesLoader.h
@@ -16,7 +16,7 @@ public:
     using DictPtr = std::shared_ptr<const IDictionaryBase>;
 
     /// Dictionaries will be loaded immediately and then will be updated in separate thread, each 'reload_period' seconds.
-    ExternalDictionariesLoader(Context & context_);
+    explicit ExternalDictionariesLoader(Context & context_);
 
     DictPtr getDictionary(const std::string & name) const
     {
@@ -26,6 +26,11 @@ public:
     DictPtr tryGetDictionary(const std::string & name) const
     {
         return std::static_pointer_cast<const IDictionaryBase>(tryLoad(name));
+    }
+
+    bool hasDictionary(const std::string & name) const
+    {
+        return has(name);
     }
 
     static DictionaryStructure getDictionaryStructure(const Poco::Util::AbstractConfiguration & config, const std::string & key_in_config = "dictionary");

--- a/src/Interpreters/ExternalLoader.cpp
+++ b/src/Interpreters/ExternalLoader.cpp
@@ -625,6 +625,12 @@ public:
         return collectLoadResults<ReturnType>(filter);
     }
 
+    bool has(const String & name) const
+    {
+        std::lock_guard lock{mutex};
+        return infos.contains(name);
+    }
+
     /// Starts reloading all the object which update time is earlier than now.
     /// The function doesn't touch the objects which were never tried to load.
     void reloadOutdated()
@@ -1389,6 +1395,11 @@ ReturnType ExternalLoader::reloadAllTriedToLoad() const
     std::unordered_set<String> names;
     boost::range::copy(getAllTriedToLoadNames(), std::inserter(names, names.end()));
     return loadOrReload<ReturnType>([&names](const String & name) { return names.count(name); });
+}
+
+bool ExternalLoader::has(const String & name) const
+{
+    return loading_dispatcher->has(name);
 }
 
 Strings ExternalLoader::getAllTriedToLoadNames() const

--- a/src/Interpreters/ExternalLoader.h
+++ b/src/Interpreters/ExternalLoader.h
@@ -196,6 +196,9 @@ public:
     template <typename ReturnType = Loadables, typename = std::enable_if_t<is_vector_load_result_type<ReturnType>, void>>
     ReturnType reloadAllTriedToLoad() const;
 
+    /// Check if object with name exists in configuration
+    bool has(const String & name) const;
+
     /// Reloads all config repositories.
     void reloadConfig() const;
 

--- a/tests/queries/0_stateless/01760_ddl_dictionary_use_current_database_name.reference
+++ b/tests/queries/0_stateless/01760_ddl_dictionary_use_current_database_name.reference
@@ -1,0 +1,8 @@
+dictGet
+0
+1
+0
+dictHas
+1
+1
+0

--- a/tests/queries/0_stateless/01760_ddl_dictionary_use_current_database_name.sql
+++ b/tests/queries/0_stateless/01760_ddl_dictionary_use_current_database_name.sql
@@ -1,0 +1,26 @@
+DROP TABLE IF EXISTS ddl_dictonary_test_source;
+CREATE TABLE ddl_dictonary_test_source
+(
+   id UInt64,
+   value UInt64
+)
+ENGINE = TinyLog;
+
+INSERT INTO ddl_dictonary_test_source VALUES (0, 0);
+INSERT INTO ddl_dictonary_test_source VALUES (1, 1);
+
+DROP DICTIONARY IF EXISTS ddl_dictionary_test;
+CREATE DICTIONARY ddl_dictionary_test
+(
+   id UInt64,
+   value UInt64 DEFAULT 0
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(HOST 'localhost' PORT tcpPort() USER 'default' TABLE 'ddl_dictonary_test_source'))
+LAYOUT(DIRECT());
+
+SELECT 'dictGet';
+SELECT dictGet('ddl_dictionary_test', 'value', number) FROM system.numbers LIMIT 3;
+
+SELECT 'dictHas';
+SELECT dictHas('ddl_dictionary_test', number) FROM system.numbers LIMIT 3;

--- a/tests/queries/0_stateless/01760_ddl_dictionary_use_current_database_name.sql
+++ b/tests/queries/0_stateless/01760_ddl_dictionary_use_current_database_name.sql
@@ -24,3 +24,6 @@ SELECT dictGet('ddl_dictionary_test', 'value', number) FROM system.numbers LIMIT
 
 SELECT 'dictHas';
 SELECT dictHas('ddl_dictionary_test', number) FROM system.numbers LIMIT 3;
+       
+DROP TABLE ddl_dictonary_test_source;
+DROP DICTIONARY ddl_dictonary_test_source;

--- a/tests/queries/0_stateless/01760_ddl_dictionary_use_current_database_name.sql
+++ b/tests/queries/0_stateless/01760_ddl_dictionary_use_current_database_name.sql
@@ -24,6 +24,6 @@ SELECT dictGet('ddl_dictionary_test', 'value', number) FROM system.numbers LIMIT
 
 SELECT 'dictHas';
 SELECT dictHas('ddl_dictionary_test', number) FROM system.numbers LIMIT 3;
-       
+
 DROP TABLE ddl_dictonary_test_source;
-DROP DICTIONARY ddl_dictonary_test_source;
+DROP DICTIONARY ddl_dictionary_test;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Functions 'dictGet', 'dictHas' use current database name if it is not specified for dictionaries created with DDL. Closes #21632.