### PR TITLE
Improve system.dictionaries table

### DIFF
--- a/src/Dictionaries/DictionaryStructure.cpp
+++ b/src/Dictionaries/DictionaryStructure.cpp
@@ -306,14 +306,6 @@ bool DictionaryStructure::isKeySizeFixed() const
     return true;
 }
 
-size_t DictionaryStructure::getKeySize() const
-{
-    return std::accumulate(std::begin(*key), std::end(*key), size_t{}, [](const auto running_size, const auto & key_i)
-    {
-        return running_size + key_i.type->getSizeOfValueInMemory();
-    });
-}
-
 Strings DictionaryStructure::getKeysNames() const
 {
     if (id)

--- a/src/Dictionaries/DictionaryStructure.h
+++ b/src/Dictionaries/DictionaryStructure.h
@@ -161,12 +161,12 @@ struct DictionaryStructure final
 
     const DictionaryAttribute & getAttribute(const std::string & attribute_name) const;
     const DictionaryAttribute & getAttribute(const std::string & attribute_name, const DataTypePtr & type) const;
+
+    Strings getKeysNames() const;
     size_t getKeysSize() const;
 
     std::string getKeyDescription() const;
     bool isKeySizeFixed() const;
-    size_t getKeySize() const;
-    Strings getKeysNames() const;
 
 private:
     /// range_min and range_max have to be parsed before this function call

--- a/tests/queries/0_stateless/01760_system_dictionaries.reference
+++ b/tests/queries/0_stateless/01760_system_dictionaries.reference
@@ -1,0 +1,14 @@
+simple key
+example_simple_key_dictionary	01760_db	['id']	['UInt64']	['value']	['UInt64']	NOT_LOADED
+example_simple_key_dictionary	01760_db	['id']	['UInt64']	['value']	['UInt64']	NOT_LOADED
+0	0
+1	1
+2	2
+example_simple_key_dictionary	01760_db	['id']	['UInt64']	['value']	['UInt64']	LOADED
+complex key
+example_complex_key_dictionary	01760_db	['id','id_key']	['UInt64','String']	['value']	['UInt64']	NOT_LOADED
+example_complex_key_dictionary	01760_db	['id','id_key']	['UInt64','String']	['value']	['UInt64']	NOT_LOADED
+0	0_key	0
+1	1_key	1
+2	2_key	2
+example_complex_key_dictionary	01760_db	['id','id_key']	['UInt64','String']	['value']	['UInt64']	LOADED

--- a/tests/queries/0_stateless/01760_system_dictionaries.sql
+++ b/tests/queries/0_stateless/01760_system_dictionaries.sql
@@ -1,0 +1,57 @@
+DROP DATABASE IF EXISTS 01760_db;
+CREATE DATABASE 01760_db;
+
+DROP TABLE IF EXISTS 01760_db.example_simple_key_source;
+CREATE TABLE 01760_db.example_simple_key_source (id UInt64, value UInt64) ENGINE=TinyLog;
+INSERT INTO 01760_db.example_simple_key_source VALUES (0, 0), (1, 1), (2, 2);
+
+DROP DICTIONARY IF EXISTS 01760_db.example_simple_key_dictionary;
+CREATE DICTIONARY 01760_db.example_simple_key_dictionary (
+    id UInt64,
+    value UInt64
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(HOST 'localhost' PORT tcpPort() USER 'default' TABLE 'example_simple_key_source' DATABASE '01760_db'))
+LAYOUT(DIRECT());
+
+SELECT 'simple key';
+
+SELECT name, database, key.names, key.types, attribute.names, attribute.types, status FROM system.dictionaries WHERE database='01760_db';
+SELECT name, database, key.names, key.types, attribute.names, attribute.types, status FROM system.dictionaries WHERE database='01760_db';
+
+SELECT * FROM 01760_db.example_simple_key_dictionary;
+
+SELECT name, database, key.names, key.types, attribute.names, attribute.types, status FROM system.dictionaries WHERE database='01760_db';
+
+DROP TABLE 01760_db.example_simple_key_source;
+DROP DICTIONARY 01760_db.example_simple_key_dictionary;
+
+SELECT name, database, key.names, key.types, attribute.names, attribute.types, status FROM system.dictionaries WHERE database='01760_db';
+
+DROP TABLE IF EXISTS 01760_db.example_complex_key_source;
+CREATE TABLE 01760_db.example_complex_key_source (id UInt64, id_key String, value UInt64) ENGINE=TinyLog;
+INSERT INTO 01760_db.example_complex_key_source VALUES (0, '0_key', 0), (1, '1_key', 1), (2, '2_key', 2);
+
+DROP DICTIONARY IF EXISTS 01760_db.example_complex_key_dictionary;
+CREATE DICTIONARY 01760_db.example_complex_key_dictionary (
+    id UInt64,
+    id_key String,
+    value UInt64
+)
+PRIMARY KEY id, id_key
+SOURCE(CLICKHOUSE(HOST 'localhost' PORT tcpPort() USER 'default' TABLE 'example_complex_key_source' DATABASE '01760_db'))
+LAYOUT(COMPLEX_KEY_DIRECT());
+
+SELECT 'complex key';
+
+SELECT name, database, key.names, key.types, attribute.names, attribute.types, status FROM system.dictionaries WHERE database='01760_db';
+SELECT name, database, key.names, key.types, attribute.names, attribute.types, status FROM system.dictionaries WHERE database='01760_db';
+
+SELECT * FROM 01760_db.example_complex_key_dictionary;
+
+SELECT name, database, key.names, key.types, attribute.names, attribute.types, status FROM system.dictionaries WHERE database='01760_db';
+
+DROP TABLE 01760_db.example_complex_key_source;
+DROP DICTIONARY 01760_db.example_complex_key_dictionary;
+
+DROP DATABASE 01760_db;

--- a/tests/queries/skip_list.json
+++ b/tests/queries/skip_list.json
@@ -775,6 +775,7 @@
         "01681_cache_dictionary_simple_key",
         "01682_cache_dictionary_complex_key",
         "01684_ssd_cache_dictionary_simple_key",
-        "01685_ssd_cache_dictionary_complex_key"
+        "01685_ssd_cache_dictionary_complex_key",
+        "01760_system_dictionaries"
     ]
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Backward Incompatible Change

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Column `keys` in table `system.dictionaries` was replaced to columns  `key.names` and `key.types`. Columns `key.names`, `key.types`, `attribute.names`, `attribute.types` from `system.dictionaries` table does not require dictionary to be loaded.