### PR TITLE
fix fuzzer failure in tupleElement formatting

### DIFF
--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -324,10 +324,14 @@ void ASTFunction::formatImplWithoutAlias(const FormatSettings & settings, Format
 
             if (!written && 0 == strcmp(name.c_str(), "tupleElement"))
             {
-                /// It can be printed in a form of 'x.1' only if right hand side is unsigned integer literal.
+                // It can be printed in a form of 'x.1' only if right hand side
+                // is an unsigned integer lineral. We also allow nonnegative
+                // signed integer literals, because the fuzzer sometimes inserts
+                // them, and we want to have consistent formatting.
                 if (const auto * lit = arguments->children[1]->as<ASTLiteral>())
                 {
-                    if (lit->value.getType() == Field::Types::UInt64)
+                    if (isInt64FieldType(lit->value.getType())
+                        && lit->value.get<Int64>() >= 0)
                     {
                         if (frame.need_parens)
                             settings.ostr << '(';


### PR DESCRIPTION
Fix this fuzzer failure:

```
The query formatting is broken.
Changed settings: allow_experimental_live_view = '1', output_format_write_statistics = '0'
Got the following (different) text after formatting the fuzzed query and parsing it back:
'SELECT 7, (ans > NULL) AND toDecimal64((NULL, 'aa', 'bbbb', 'bbbb').3, NULL) AND (ans < NULL) FROM (WITH (SELECT (state + state) + state FROM model) AS model SELECT ('', NULL), evalMLMethod(model, predict1, predict2) AS ans FROM defaults LIMIT 1023)'
, expected:
'SELECT 7, (ans > NULL) AND toDecimal64(tupleElement((NULL, 'aa', 'bbbb', 'bbbb'), 3), NULL) AND (ans < NULL) FROM (WITH (SELECT (state + state) + state FROM model) AS model SELECT ('', NULL), evalMLMethod(model, predict1, predict2) AS ans FROM defaults LIMIT 1023)'
In more detail:
...
```

No test, because this AST structure is only reproduced by the fuzzer.


Changelog category (leave one):
- Not for changelog (changelog entry is not required)
