### PR TITLE
Allow to use clang-tidy with release builds.

### DIFF
--- a/cmake/analysis.cmake
+++ b/cmake/analysis.cmake
@@ -16,6 +16,10 @@ if (ENABLE_CLANG_TIDY)
 
         set (USE_CLANG_TIDY ON)
 
+        # clang-tidy requires assertions to guide the analysis
+        # Note that NDEBUG is set implicitly by CMake for non-debug builds
+        set(COMPILER_FLAGS "${COMPILER_FLAGS} -UNDEBUG")
+
         # The variable CMAKE_CXX_CLANG_TIDY will be set inside src and base directories with non third-party code.
         # set (CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_PATH}")
     elseif (FAIL_ON_UNSUPPORTED_OPTIONS_COMBINATION)


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow to use clang-tidy with release builds by enabling assertions if it is used.