### PR TITLE
disable optimize_read_in_order for window functions

### DIFF
--- a/src/Interpreters/ExpressionAnalyzer.cpp
+++ b/src/Interpreters/ExpressionAnalyzer.cpp
@@ -1511,6 +1511,7 @@ ExpressionAnalysisResult::ExpressionAnalysisResult(
             settings.optimize_read_in_order
             && storage && query.orderBy()
             && !query_analyzer.hasAggregation()
+            && !query_analyzer.hasWindow()
             && !query.final()
             && join_allow_read_in_order;
 

--- a/tests/queries/0_stateless/01591_window_functions.reference
+++ b/tests/queries/0_stateless/01591_window_functions.reference
@@ -920,6 +920,34 @@ FROM numbers(2)
 ;
 1	0
 1	1
+-- optimize_read_in_order conflicts with sorting for window functions, must
+-- be disabled.
+create table window_mt engine MergeTree order by number
+    as select number, mod(number, 3) p from numbers(100);
+select number, count(*) over (partition by p)
+    from window_mt order by number limit 10 settings optimize_read_in_order = 0;
+0	34
+1	33
+2	33
+3	34
+4	33
+5	33
+6	34
+7	33
+8	33
+9	34
+select number, count(*) over (partition by p)
+    from window_mt order by number limit 10 settings optimize_read_in_order = 1;
+0	34
+1	33
+2	33
+3	34
+4	33
+5	33
+6	34
+7	33
+8	33
+9	34
 -- some true window functions -- rank and friends
 select number, p, o,
     count(*) over w,

--- a/tests/queries/0_stateless/01591_window_functions.sql
+++ b/tests/queries/0_stateless/01591_window_functions.sql
@@ -316,6 +316,17 @@ SELECT
 FROM numbers(2)
 ;
 
+-- optimize_read_in_order conflicts with sorting for window functions, must
+-- be disabled.
+create table window_mt engine MergeTree order by number
+    as select number, mod(number, 3) p from numbers(100);
+
+select number, count(*) over (partition by p)
+    from window_mt order by number limit 10 settings optimize_read_in_order = 0;
+
+select number, count(*) over (partition by p)
+    from window_mt order by number limit 10 settings optimize_read_in_order = 1;
+
 -- some true window functions -- rank and friends
 select number, p, o,
     count(*) over w,


### PR DESCRIPTION
This is a quick fix for correctness. I'd want to support it for window functions, but the current code is not easy to extend. We will need some proper infrastructure for that.

Changelog category (leave one):
- Bug Fix

Changelog entry:
Fix wrong `ORDER BY` results when a query contains window functions, and optimization for reading in primary key order is applied. Fixes https://github.com/ClickHouse/ClickHouse/issues/21828