### PR TITLE
Prevent hedged connections overlaps

### DIFF
--- a/src/Client/HedgedConnectionsFactory.cpp
+++ b/src/Client/HedgedConnectionsFactory.cpp
@@ -38,6 +38,16 @@ HedgedConnectionsFactory::HedgedConnectionsFactory(
 
 HedgedConnectionsFactory::~HedgedConnectionsFactory()
 {
+    /// Stop anything that maybe in progress,
+    /// to avoid interfer with the subsequent connections.
+    ///
+    /// I.e. some replcas may be in the establishing state,
+    /// this means that hedged connection is waiting for TablesStatusResponse,
+    /// and if the connection will not be canceled,
+    /// then next user of the connection will get TablesStatusResponse,
+    /// while this is not the expected package.
+    stopChoosingReplicas();
+
     pool->updateSharedError(shuffled_pools);
 }
 


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Prevent hedged connections overlaps (`Unknown packet 9 from server` error)

Detailed description / Documentation draft:
Some replicas may be in the establishing state, this means that hedged
connection is waiting for TablesStatusResponse, and if the connection
will not be canceled, then next user of the connection will get
TablesStatusResponse, while this is not the expected package, and you
will see:

    DB::Exception: Received from localhost:9000. DB::Exception: Received from ch-1:9000. DB::Exception: Unknown packet 9 from server ch-2:9000: While executing Remote. Stack trace:

Fix this by disconnecting connection to such replicas, note that this
should be fine in general, since they are "slow" anyway (you may wish
configure hedged requests settings to increase timeouts and similar).

Cc: @Avogar 
Cc: @KochetovNicolai 
Refs: #19291