### PR TITLE
Add possibility to customize the source for clickhouse-server docker image builds.

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -4,6 +4,19 @@ ARG repository="deb https://repo.clickhouse.tech/deb/stable/ main/"
 ARG version=21.4.1.*
 ARG gosu_ver=1.10
 
+# set non-empty deb_location url tp create a docker image
+# from debs created by CI build, for example:
+# docker build . --network host --build-arg version="21.4.1.6282" --build-arg deb_location="https://clickhouse-builds.s3.yandex.net/21852/069cfbff388b3d478d1a16dc7060b48073f5d522/clickhouse_build_check/clang-11_relwithdebuginfo_none_bundled_unsplitted_disable_False_deb/" -t filimonovq/clickhouse-server:pr21852
+ARG deb_location=""
+
+# set non-empty single_binary_location to create docker image
+# from a single binary url (useful for non-standard builds - with sanitizers, for arm64).
+# note: clickhouse-odbc-bridge is not supported there.
+ARG single_binary_location=""
+
+# see https://github.com/moby/moby/issues/4032#issuecomment-192327844
+ARG DEBIAN_FRONTEND=noninteractive
+
 # user/group precreated explicitly with fixed uid/gid on purpose.
 # It is especially important for rootless containers: in that case entrypoint
 # can't do chown and owners of mounted volumes should be configured externally.
@@ -19,20 +32,37 @@ RUN groupadd -r clickhouse --gid=101 \
         ca-certificates \
         dirmngr \
         gnupg \
+        locales \
+        wget \
+        tzdata \
     && mkdir -p /etc/apt/sources.list.d \
     && apt-key adv --keyserver keyserver.ubuntu.com --recv E0C56BD4 \
     && echo $repository > /etc/apt/sources.list.d/clickhouse.list \
-    && apt-get update \
-    && env DEBIAN_FRONTEND=noninteractive \
-        apt-get --yes -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold" upgrade \
-    && env DEBIAN_FRONTEND=noninteractive \
-        apt-get install --allow-unauthenticated --yes --no-install-recommends \
-            clickhouse-common-static=$version \
-            clickhouse-client=$version \
-            clickhouse-server=$version \
-            locales \
-            wget \
-            tzdata \
+    && if [ -n "$deb_location" ]; then \
+            echo "installing from custom url with deb packages: $deb_location" \
+            rm -rf /tmp/clickhouse_debs \
+            && mkdir -p /tmp/clickhouse_debs \
+            && wget --progress=bar:force:noscroll "${deb_location}/clickhouse-common-static_${version}_amd64.deb" -P /tmp/clickhouse_debs \
+            && wget --progress=bar:force:noscroll "${deb_location}/clickhouse-client_${version}_all.deb" -P /tmp/clickhouse_debs \
+            && wget --progress=bar:force:noscroll "${deb_location}/clickhouse-server_${version}_all.deb" -P /tmp/clickhouse_debs \
+            && dpkg -i /tmp/clickhouse_debs/*.deb ; \
+       elif [ -n "$single_binary_location" ]; then \
+            echo "installing from single binary: $single_binary_location" \
+            && rm -rf /tmp/clickhouse_binary \
+            && mkdir -p /tmp/clickhouse_binary \
+            && wget --progress=bar:force:noscroll "$single_binary_location" -O /tmp/clickhouse_binary/clickhouse \
+            && chmod +x /tmp/clickhouse_binary/clickhouse \
+            && /tmp/clickhouse_binary/clickhouse install --user "clickhouse" --group "clickhouse" ; \
+       else \
+           echo "installing from repository: $repository" \
+           && apt-get update \
+           && apt-get --yes -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold" upgrade \
+           && apt-get install --allow-unauthenticated --yes --no-install-recommends \
+                clickhouse-common-static=$version \
+                clickhouse-client=$version \
+                clickhouse-server=$version ; \
+       fi \
+    && clickhouse-local -q 'SELECT * FROM system.build_options' \
     && rm -rf \
         /var/lib/apt/lists/* \
         /var/cache/debconf \


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Introduce 2 arguments for clickhouse-server image Dockerfile: deb_location & single_binary_location

Detailed description / Documentation draft:
That allows to build docker images from CI build easily, also for non-standard builds (with sanitizers / for arm64 etc).