### PR TITLE
Add tzdata to Docker

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update \
             clickhouse-client=$version \
             clickhouse-common-static=$version \
             locales \
+            tzdata \
     && rm -rf /var/lib/apt/lists/* /var/cache/debconf \
     && apt-get clean
 

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -32,6 +32,7 @@ RUN groupadd -r clickhouse --gid=101 \
             clickhouse-server=$version \
             locales \
             wget \
+            tzdata \
     && rm -rf \
         /var/lib/apt/lists/* \
         /var/cache/debconf \

--- a/docker/server/Dockerfile.alpine
+++ b/docker/server/Dockerfile.alpine
@@ -22,6 +22,8 @@ RUN addgroup -S -g 101 clickhouse \
     && chown root:clickhouse /var/log/clickhouse-server \
     && chmod +x /entrypoint.sh \
     && apk add --no-cache su-exec bash tzdata \
+    && cp /usr/share/zoneinfo/UTC /etc/localtime \
+    && echo "UTC" > /etc/timezone \
     && chmod ugo+Xrw -R /var/lib/clickhouse /var/log/clickhouse-server /etc/clickhouse-server /etc/clickhouse-client
 
 # we need to allow "others" access to clickhouse folder, because docker container

--- a/docker/server/Dockerfile.alpine
+++ b/docker/server/Dockerfile.alpine
@@ -21,7 +21,7 @@ RUN addgroup -S -g 101 clickhouse \
     && chown clickhouse:clickhouse /var/lib/clickhouse \
     && chown root:clickhouse /var/log/clickhouse-server \
     && chmod +x /entrypoint.sh \
-    && apk add --no-cache su-exec bash \
+    && apk add --no-cache su-exec bash tzdata \
     && chmod ugo+Xrw -R /var/lib/clickhouse /var/log/clickhouse-server /etc/clickhouse-server /etc/clickhouse-client
 
 # we need to allow "others" access to clickhouse folder, because docker container


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging improvement.


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add `tzdata` to Docker containers because reading ORC formats requires it. This closes #14156.


Detailed description / Documentation draft:
A note to @filimonov: you can add it to Alpine images if you want.