### PR TITLE
Longer SQLancer run

### DIFF
--- a/docker/test/sqlancer/process_sqlancer_result.py
+++ b/docker/test/sqlancer/process_sqlancer_result.py
@@ -26,6 +26,7 @@ def process_result(result_folder):
             with open(err_path, 'r') as f:
                 if 'AssertionError' in f.read():
                     summary.append((test, "FAIL"))
+                    status = 'failure'
                 else:
                     summary.append((test, "OK"))
 

--- a/docker/test/sqlancer/run.sh
+++ b/docker/test/sqlancer/run.sh
@@ -11,7 +11,7 @@ service clickhouse-server start && sleep 5
 
 cd /sqlancer/sqlancer-master
 
-export TIMEOUT=60
+export TIMEOUT=300
 export NUM_QUERIES=1000
 
 ( java -jar target/sqlancer-*.jar --num-threads 10 --timeout-seconds $TIMEOUT --num-queries $NUM_QUERIES  --username default --password "" clickhouse --oracle TLPWhere | tee /test_output/TLPWhere.out )  3>&1 1>&2 2>&3 | tee /test_output/TLPWhere.err


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Enable status check for SQLancer CI run.

Detailed description / Documentation draft:

...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
