### PR TITLE
Fix receive_timeout for hedged requests

### DIFF
--- a/src/Client/HedgedConnections.cpp
+++ b/src/Client/HedgedConnections.cpp
@@ -366,7 +366,7 @@ int HedgedConnections::getReadyFileDescriptor(AsyncCallback async_callback)
     {
         events_count = epoll.getManyReady(1, &event, false);
         if (!events_count && async_callback)
-            async_callback(epoll.getFileDescriptor(), 0, epoll.getDescription());
+            async_callback(epoll.getFileDescriptor(), settings.receive_timeout, epoll.getDescription());
     }
     return event.data.fd;
 }


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix receive_timeout for hedged requests (`use_hedged_requests=1`)

Cc: @Avogar 
Cc: @KochetovNicolai 