### PR TITLE
Fix error generated by -Werror=unused-but-set-parameter

### DIFF
--- a/contrib/amqpcpp-cmake/CMakeLists.txt
+++ b/contrib/amqpcpp-cmake/CMakeLists.txt
@@ -24,10 +24,16 @@ set (SRCS
 
 add_library(amqp-cpp ${SRCS})
 
+if (COMPILER_CLANG)
+    target_compile_options (amqp-cpp
+        PRIVATE
+            -Wno-inconsistent-missing-destructor-override
+    )
+endif ()
+
 target_compile_options (amqp-cpp
     PRIVATE
         -Wno-old-style-cast
-        -Wno-inconsistent-missing-destructor-override
         -Wno-deprecated
         -Wno-unused-parameter
         -Wno-shadow

--- a/src/Interpreters/HashJoin.cpp
+++ b/src/Interpreters/HashJoin.cpp
@@ -68,6 +68,7 @@ namespace JoinStuff
     template <ASTTableJoin::Kind KIND, ASTTableJoin::Strictness STRICTNESS>
     void JoinUsedFlags::reinit(size_t size)
     {
+        (void)size;
         if constexpr (MapGetter<KIND, STRICTNESS>::flagged)
         {
             assert(flags.size() <= size);

--- a/src/Parsers/New/CMakeLists.txt
+++ b/src/Parsers/New/CMakeLists.txt
@@ -68,8 +68,13 @@ target_compile_options (clickhouse_parsers_new
 
     PUBLIC
         -Wno-extra-semi
-        -Wno-inconsistent-missing-destructor-override
 )
+if (COMPILER_CLANG)
+    target_compile_options (clickhouse_parsers_new
+        PUBLIC
+            -Wno-inconsistent-missing-destructor-override
+    )
+endif ()
 if (HAS_SUGGEST_DESTRUCTOR_OVERRIDE)
     target_compile_options (clickhouse_parsers_new
         PRIVATE


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- None.

Detailed description / Documentation draft:
- Fix compilation on some toolchains.
- In addition to `-Werror=unused-but-set-parameter` fixes, also sets `-Wno-inconsistent-missing-destructor-override` only on Clang builds.
- It is worth to forward-port this into `master` branch also.