### PR TITLE
Darwin cmake disable memcpy benchmark

### DIFF
--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -34,7 +34,7 @@ if (NOT DEFINED ENABLE_UTILS OR ENABLE_UTILS)
     add_subdirectory (check-mysql-binlog)
 
     if (NOT OS_DARWIN)
-    add_subdirectory (memcpy-bench)
+        add_subdirectory (memcpy-bench)
     endif ()
 endif ()
 

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -32,7 +32,10 @@ if (NOT DEFINED ENABLE_UTILS OR ENABLE_UTILS)
     add_subdirectory (db-generator)
     add_subdirectory (wal-dump)
     add_subdirectory (check-mysql-binlog)
+
+    if (NOT OS_DARWIN)
     add_subdirectory (memcpy-bench)
+    endif ()
 endif ()
 
 if (ENABLE_CODE_QUALITY)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Fixes #21876.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)