### PR TITLE
Fix missing check in decrypt for AEAD mode

### DIFF
--- a/docker/test/fasttest/run.sh
+++ b/docker/test/fasttest/run.sh
@@ -292,6 +292,7 @@ function run_tests
         01318_decrypt                           # Depends on OpenSSL
         01663_aes_msan                          # Depends on OpenSSL
         01667_aes_args_check                    # Depends on OpenSSL
+        01776_decrypt_aead_size_check           # Depends on OpenSSL
         01281_unsucceeded_insert_select_queries_counter
         01292_create_user
         01294_lazy_database_concurrent

--- a/src/Functions/FunctionsAES.h
+++ b/src/Functions/FunctionsAES.h
@@ -538,8 +538,9 @@ private:
 
         [[maybe_unused]] const auto block_size = static_cast<size_t>(EVP_CIPHER_block_size(evp_cipher));
         [[maybe_unused]] const auto iv_size = static_cast<size_t>(EVP_CIPHER_iv_length(evp_cipher));
-        const auto key_size = static_cast<size_t>(EVP_CIPHER_key_length(evp_cipher));
-        const auto tag_size = 16; // https://tools.ietf.org/html/rfc5116#section-5.1
+
+        const size_t key_size = static_cast<size_t>(EVP_CIPHER_key_length(evp_cipher));
+        static constexpr size_t tag_size = 16; // https://tools.ietf.org/html/rfc5116#section-5.1
 
         auto decrypted_result_column = ColumnString::create();
         auto & decrypted_result_column_data = decrypted_result_column->getChars();
@@ -549,9 +550,17 @@ private:
             size_t resulting_size = 0;
             for (size_t r = 0; r < input_rows_count; ++r)
             {
-                resulting_size += input_column->getDataAt(r).size + 1;
+                size_t string_size = input_column->getDataAt(r).size;
+                resulting_size += string_size + 1;  /// With terminating zero.
+
                 if constexpr (mode == CipherMode::RFC5116_AEAD_AES_GCM)
+                {
+                    if (string_size < tag_size)
+                        throw Exception("Encrypted data is smaller than the size of additional data for AEAD mode, cannot decrypt.",
+                            ErrorCodes::BAD_ARGUMENTS);
+
                     resulting_size -= tag_size;
+                }
             }
 
 #if defined(MEMORY_SANITIZER)
@@ -565,6 +574,7 @@ private:
             decrypted_result_column_data.resize(resulting_size);
 #endif
         }
+
         auto * decrypted = decrypted_result_column_data.data();
 
         KeyHolder<mode> key_holder;
@@ -631,7 +641,7 @@ private:
                     // 1.a.2: Set AAD if present
                     if (aad_column)
                     {
-                        const auto aad_data = aad_column->getDataAt(r);
+                        StringRef aad_data = aad_column->getDataAt(r);
                         int tmp_len = 0;
                         if (aad_data.size != 0 && EVP_DecryptUpdate(evp_ctx, nullptr, &tmp_len,
                                 reinterpret_cast<const unsigned char *>(aad_data.data), aad_data.size) != 1)

--- a/tests/queries/0_stateless/01776_decrypt_aead_size_check.sql
+++ b/tests/queries/0_stateless/01776_decrypt_aead_size_check.sql
@@ -1,0 +1,1 @@
+SELECT decrypt('aes-128-gcm', 'text', 'key', 'IV'); -- { serverError 36 }


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The function `decrypt` was lacking a check for the minimal size of data encrypted in AEAD mode. This closes #21897.
