### PR TITLE
Better suggestion for clickhouse client in interactive mode

### DIFF
--- a/programs/client/Suggest.cpp
+++ b/programs/client/Suggest.cpp
@@ -91,7 +91,7 @@ void Suggest::loadImpl(Connection & connection, const ConnectionTimeouts & timeo
     /// NOTE: Once you will update the completion list,
     /// do not forget to update 01676_clickhouse_client_autocomplete.sh
 
-     Settings settings;
+    Settings settings;
     /// To show all rows from:
     /// - system.errors
     /// - system.events

--- a/programs/client/Suggest.h
+++ b/programs/client/Suggest.h
@@ -33,8 +33,13 @@ public:
 private:
 
     void loadImpl(Connection & connection, const ConnectionTimeouts & timeouts, size_t suggestion_limit);
-    void fetch(Connection & connection, const ConnectionTimeouts & timeouts, const std::string & query, Settings & settings);
-    void fillWordsFromBlock(const Block & block);
+    void fetch(
+        Connection & connection,
+        const ConnectionTimeouts & timeouts,
+        const std::string & query,
+        Settings & settings,
+        Words & to_fill_words);
+    void fillWordsFromBlock(const Block & block, Words & to_fill_words);
 
     /// Words are fetched asynchronously.
     std::thread loading_thread;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Check table existence for clickhouse client autocompletion



Detailed description / Documentation draft:

This MR aims to  improve the compatibility of `clickhouse-client` in interactive mode when the server is out of date.


```
ClickHouse server version is older than ClickHouse client. It may indicate that the server is out of date and can be upgraded.

Cannot load data for command line suggestions: Code: 60, e.displayText() = DB::Exception: Received from xxxx:9000. DB::Exception: Table system.errors doesn't exist.. (version 21.3.1.1)
```