### PR TITLE
Fix UBSan report in mapPopulateSeries.

### DIFF
--- a/src/Functions/array/mapPopulateSeries.cpp
+++ b/src/Functions/array/mapPopulateSeries.cpp
@@ -190,7 +190,7 @@ private:
             }
 
             static constexpr size_t MAX_ARRAY_SIZE = 1ULL << 30;
-            if (static_cast<size_t>(max_key - min_key) > MAX_ARRAY_SIZE)
+            if (static_cast<size_t>(max_key) - static_cast<size_t>(min_key) > MAX_ARRAY_SIZE)
                 throw Exception(ErrorCodes::TOO_LARGE_ARRAY_SIZE, "Too large array size in the result of function {}", getName());
 
             /* fill the result arrays */

--- a/tests/queries/0_stateless/01777_map_populate_series_ubsan.sql
+++ b/tests/queries/0_stateless/01777_map_populate_series_ubsan.sql
@@ -1,0 +1,2 @@
+-- Should correctly throw exception about overflow:
+SELECT mapPopulateSeries([-9223372036854775808, toUInt32(2)], [toUInt32(1023), -1]); -- { serverError 128 }


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


This closes #22094.