### PR TITLE
Disable async_socket_for_remote/use_hedged_requests for buggy linux kernels

### DIFF
--- a/src/Core/SettingsQuirks.cpp
+++ b/src/Core/SettingsQuirks.cpp
@@ -1,0 +1,62 @@
+#include <Core/SettingsQuirks.h>
+#include <Core/Settings.h>
+#include <common/logger_useful.h>
+
+#ifdef __linux__
+#include <linux/version.h>
+#endif
+
+#ifdef __linux__
+/// Detect does epoll_wait with nested epoll fds works correctly.
+/// Polling nested epoll fds from epoll_wait is required for async_socket_for_remote and use_hedged_requests.
+///
+/// It may not be reliable in 5.5+ [1], that has been fixed in 5.7+ [2] or 5.6.13+.
+///
+///   [1]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=339ddb53d373
+///   [2]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0c54a6a44bf3
+bool nestedEpollWorks(Poco::Logger * log)
+{
+    bool nested_epoll_works =
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0)) && (LINUX_VERSION_CODE < KERNEL_VERSION(5, 6, 13))
+        /// the check is correct since there will be no more 5.5.x releases.
+        false
+#else
+        true
+#endif
+    ;
+
+    if (!nested_epoll_works)
+    {
+        if (log)
+            LOG_WARNING(log, "Nested epoll_wait has some issues on kernels [5.5.0, 5.6.13). You should upgrade it to avoid possible issues.");
+    }
+    return nested_epoll_works;
+}
+#else
+bool nestedEpollWorks(Poco::Logger *) { return true; }
+#endif
+
+namespace DB
+{
+
+/// Update some settings defaults to avoid some known issues.
+void applySettingsQuirks(Settings & settings, Poco::Logger * log)
+{
+    if (!nestedEpollWorks(log))
+    {
+        if (!settings.async_socket_for_remote.changed && settings.async_socket_for_remote)
+        {
+            settings.async_socket_for_remote = false;
+            if (log)
+                LOG_WARNING(log, "async_socket_for_remote has been disabled (you can explicitly enable it still)");
+        }
+        if (!settings.use_hedged_requests.changed && settings.use_hedged_requests)
+        {
+            settings.use_hedged_requests = false;
+            if (log)
+                LOG_WARNING(log, "use_hedged_requests has been disabled (you can explicitly enable it still)");
+        }
+    }
+}
+
+}

--- a/src/Core/SettingsQuirks.h
+++ b/src/Core/SettingsQuirks.h
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace Poco
+{
+class Logger;
+}
+
+namespace DB
+{
+
+struct Settings;
+
+/// Update some settings defaults to avoid some known issues.
+void applySettingsQuirks(Settings & settings, Poco::Logger * log = nullptr);
+
+}

--- a/src/Core/ya.make
+++ b/src/Core/ya.make
@@ -36,6 +36,7 @@ SRCS(
     Settings.cpp
     SettingsEnums.cpp
     SettingsFields.cpp
+    SettingsQuirks.cpp
     SortDescription.cpp
     iostream_debug_helpers.cpp
 

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -30,6 +30,7 @@
 #include <TableFunctions/TableFunctionFactory.h>
 #include <Interpreters/ActionLocksManager.h>
 #include <Core/Settings.h>
+#include <Core/SettingsQuirks.h>
 #include <Access/AccessControlManager.h>
 #include <Access/ContextAccess.h>
 #include <Access/EnabledRolesInfo.h>
@@ -1100,6 +1101,7 @@ void Context::applySettingsChanges(const SettingsChanges & changes)
     auto lock = getLock();
     for (const SettingChange & change : changes)
         applySettingChange(change);
+    applySettingsQuirks(settings);
 }
 
 
@@ -2272,6 +2274,8 @@ void Context::setDefaultProfiles(const Poco::Util::AbstractConfiguration & confi
 
     shared->system_profile_name = config.getString("system_profile", shared->default_profile_name);
     setProfile(shared->system_profile_name);
+
+    applySettingsQuirks(settings, &Poco::Logger::get("SettingsQuirks"));
 
     shared->buffer_profile_name = config.getString("buffer_profile", shared->system_profile_name);
     buffer_context = std::make_shared<Context>(*this);


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Disable `async_socket_for_remote`/`use_hedged_requests` for buggy linux kernels

Detailed description / Documentation draft:
async_socket_for_remote/use_hedged_requests uses nested epolls, which
may not be reliable in 5.5+ [1], but it has been fixed in shortly in 5.7+ [2] or 5.6.13+.

  [1]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=339ddb53d373
  [2]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0c54a6a44bf3

*P.S. marked as Bug fix, but not sure about this*

<details>

It is possible to lock the pipeline, It is not that easy to reproduce, but it is pretty "stable" reproduced with the following benchmark command, using linux 5.5:

    $ i=0; while ./clickhouse benchmark -c 30 --timelimit=3 -d0 --cumulative --query "select * from remote('127.{2,3}', system, one)"; do echo Iteration=$i; ((i+=1)); done
    Loaded 1 queries.

*Note, that use_hedged_requests and async_socket_for_remote is both
required for reproducing.*

Pipeline:

    digraph
    {
      rankdir="LR";
      { node [shape = box]
        n140624128624664[label="Remote(10 jobs) (Async)"];
        n140627179876376[label="Remote(11 jobs) (Finished)"];
        n140624730927768[label="ExpressionTransform(5 jobs) (NeedData)"];
        n140624152969048[label="ExpressionTransform(5 jobs) (Finished)"];
        n140624165957208[label="Resize(0 jobs) (NeedData)"];
        n140624293623256[label="LimitsCheckingTransform(10 jobs) (NeedData)"];
        n140627179694168[label="NullSource(0 jobs) (NeedData)"];
        n140624245605656[label="NullSource(0 jobs) (NeedData)"];
        n140624145010712[label="LazyOutputFormat(10 jobs) (NeedData)"];
      }
      n140624128624664 -> n140624730927768;
      n140627179876376 -> n140624152969048;
      n140624730927768 -> n140624165957208;
      n140624152969048 -> n140624165957208;
      n140624165957208 -> n140624293623256;
      n140624293623256 -> n140624145010712;
      n140627179694168 -> n140624145010712;
      n140624245605656 -> n140624145010712;
    }


Threads stack traces:

    WITH
        arrayMap(x -> demangle(addressToSymbol(x)), trace) AS trace_array,
        arrayStringConcat(trace_array, '\n') AS trace_string
    SELECT
        thread_id,
        trace_string
    FROM system.stack_trace
    WHERE thread_id IN
    (
        SELECT thread_id
        FROM system.processes
        ARRAY JOIN thread_ids AS thread_id
        WHERE query NOT LIKE '%system.%'
    )

    Row 1:
    ──────
    thread_id:    6490
    trace_string: pthread_cond_wait@@GLIBC_2.3.2
    std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&)
    DB::PipelineExecutor::executeStepImpl(unsigned long, unsigned long, std::__1::atomic<bool>*)
    void std::__1::__function::__policy_invoker<void ()>::__call_impl<>(std::__1::__function::__policy_storage const*)
    ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>)
    void* std::__1::__thread_proxy<>(void*)
    start_thread
    __clone

    Row 2:
    ──────
    thread_id:    6537
    trace_string: pthread_cond_wait@@GLIBC_2.3.2
    std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&)
    DB::PipelineExecutor::executeStepImpl(unsigned long, unsigned long, std::__1::atomic<bool>*)
    void std::__1::__function::__policy_invoker<void ()>::__call_impl<>(std::__1::__function::__policy_storage const*)
    ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>)
    void* std::__1::__thread_proxy<>(void*)
    start_thread
    __clone

    Row 3:
    ──────
    thread_id:    6552
    trace_string:
    epoll_wait
    DB::Epoll::getManyReady(int, epoll_event*, bool) const
    DB::PollingQueue::wait(std::__1::unique_lock<std::__1::mutex>&)
    DB::PipelineExecutor::executeImpl(unsigned long)
    DB::PipelineExecutor::execute(unsigned long)
    void std::__1::__function::__policy_invoker<void ()>::__call_impl<>(std::__1::__function::__policy_storage const*)
    ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>)
    void* std::__1::__thread_proxy<>(void*)
    start_thread
    __clone

    Row 4:
    ──────
    thread_id:    31278
    trace_string: pthread_cond_timedwait@@GLIBC_2.3.2
    Poco::SemaphoreImpl::waitImpl(long)
    ConcurrentBoundedQueue<DB::Chunk>::tryPop(DB::Chunk&, unsigned long)
    DB::LazyOutputFormat::getChunk(unsigned long)
    DB::PullingAsyncPipelineExecutor::pull(DB::Chunk&, unsigned long)
    DB::PullingAsyncPipelineExecutor::pull(DB::Block&, unsigned long)
    DB::TCPHandler::processOrdinaryQueryWithProcessors()
    DB::TCPHandler::runImpl()
    DB::TCPHandler::run()
    Poco::Net::TCPServerConnection::start()
    Poco::Net::TCPServerDispatcher::run()
    Poco::PooledThread::run()
    Poco::ThreadImpl::runnableEntry(void*)
    start_thread
    __clone

And to be presice the PipelineExecutor is waiting here [1]:

    context->condvar.wait(lock, [&]
    {
        return finished || context->wake_flag;
    });

  [1]: https://github.com/ClickHouse/ClickHouse/blob/0bad6adc489bfc321b7118d5332371afb551b23a/src/Processors/Executors/PipelineExecutor.cpp#L561

State of PipelineExecutor at this time:

    task_queue = {
      queues = size=2 {
        [0] = size=0 {}
        [1] = size=0 {}
      }
      num_tasks = 0
    }

    async_task_queue = {
      epoll = {
        epoll_fd = 271
        events_count = {
          Value = 2
        }
        fd_description = "epoll"
      }
      pipe_fd = ([0] = 321, [1] = 324)
      is_finished = {
        Value = false
      }
      tasks = size=1 {
        [0] = {
          __cc = {
            first = 139970762314112
            second = (thread_num = 0, data = 0x00007f4d7b911180, fd = 82)
          }
        }
      }
    }

    num_waiting_async_tasks = 0
    threads_queue = {
      stack = size=2 {
        [0] = 1
        [1] = 0
      }
      thread_pos_in_stack = size=2 {
        [0] = 1
        [1] = 0
      }
      stack_size = 2
    }

</details>

Cc: @KochetovNicolai 
Cc: @Avogar 