### PR TITLE
The thread pool name should be not longer than 15 chars

### DIFF
--- a/src/Core/BackgroundSchedulePool.cpp
+++ b/src/Core/BackgroundSchedulePool.cpp
@@ -6,6 +6,7 @@
 #include <common/logger_useful.h>
 #include <chrono>
 #include <ext/scope_guard.h>
+#include <Common/Exception.h>
 
 
 namespace DB
@@ -243,7 +244,14 @@ void BackgroundSchedulePool::attachToThreadGroup()
 
 void BackgroundSchedulePool::threadFunction()
 {
-    setThreadName(thread_name.c_str());
+    try
+    {
+        setThreadName(thread_name.c_str());
+    }
+    catch (const DB::Exception &)
+    {
+        throw;
+    }
 
     attachToThreadGroup();
     SCOPE_EXIT({ CurrentThread::detachQueryIfNotDetached(); });
@@ -270,7 +278,16 @@ void BackgroundSchedulePool::threadFunction()
 
 void BackgroundSchedulePool::delayExecutionThreadFunction()
 {
-    setThreadName((thread_name + "/D").c_str());
+
+    try
+    {
+        setThreadName((thread_name + "/D").c_str());
+    }
+    catch (const DB::Exception &)
+    {
+        throw;
+    }
+
 
     attachToThreadGroup();
     SCOPE_EXIT({ CurrentThread::detachQueryIfNotDetached(); });

--- a/src/Core/BackgroundSchedulePool.cpp
+++ b/src/Core/BackgroundSchedulePool.cpp
@@ -6,7 +6,6 @@
 #include <common/logger_useful.h>
 #include <chrono>
 #include <ext/scope_guard.h>
-#include <Common/Exception.h>
 
 
 namespace DB
@@ -244,14 +243,7 @@ void BackgroundSchedulePool::attachToThreadGroup()
 
 void BackgroundSchedulePool::threadFunction()
 {
-    try
-    {
-        setThreadName(thread_name.c_str());
-    }
-    catch (const DB::Exception &)
-    {
-        throw;
-    }
+    setThreadName(thread_name.c_str());
 
     attachToThreadGroup();
     SCOPE_EXIT({ CurrentThread::detachQueryIfNotDetached(); });
@@ -278,16 +270,7 @@ void BackgroundSchedulePool::threadFunction()
 
 void BackgroundSchedulePool::delayExecutionThreadFunction()
 {
-
-    try
-    {
-        setThreadName((thread_name + "/D").c_str());
-    }
-    catch (const DB::Exception &)
-    {
-        throw;
-    }
-
+    setThreadName((thread_name + "/D").c_str());
 
     attachToThreadGroup();
     SCOPE_EXIT({ CurrentThread::detachQueryIfNotDetached(); });

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1538,7 +1538,7 @@ BackgroundSchedulePool & Context::getMessageBrokerSchedulePool() const
         shared->message_broker_schedule_pool.emplace(
             settings.background_message_broker_schedule_pool_size,
             CurrentMetrics::BackgroundDistributedSchedulePoolTask,
-            "BgMsgBrkSchPool");
+            "BgMBSchPool");
     return *shared->message_broker_schedule_pool;
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix the background thread pool name.


Detailed description / Documentation draft:

If the length of thread pool name is longer than 13 chars,  the setThreadName will throw exception.
The `BgMsgBrkSchPool which used to poll message from Kafka and other queue is broken because the delay execution
thread's name (BgMsgBrkSchPool/D) is more than 15 chars. The Kafka engine with the broken thread pool will not consume the message from message queue.