### PR TITLE
Use finalize() over next() for nested writers

### DIFF
--- a/src/IO/BrotliWriteBuffer.cpp
+++ b/src/IO/BrotliWriteBuffer.cpp
@@ -106,7 +106,7 @@ void BrotliWriteBuffer::finish()
     try
     {
         finishImpl();
-        out->next();
+        out->finalize();
         finished = true;
     }
     catch (...)

--- a/src/IO/LZMADeflatingWriteBuffer.cpp
+++ b/src/IO/LZMADeflatingWriteBuffer.cpp
@@ -105,7 +105,7 @@ void LZMADeflatingWriteBuffer::finish()
     try
     {
         finishImpl();
-        out->next();
+        out->finalize();
         finished = true;
     }
     catch (...)

--- a/src/IO/ZlibDeflatingWriteBuffer.cpp
+++ b/src/IO/ZlibDeflatingWriteBuffer.cpp
@@ -107,7 +107,7 @@ void ZlibDeflatingWriteBuffer::finish()
     try
     {
         finishImpl();
-        out->next();
+        out->finalize();
         finished = true;
     }
     catch (...)

--- a/src/IO/ZstdDeflatingWriteBuffer.cpp
+++ b/src/IO/ZstdDeflatingWriteBuffer.cpp
@@ -94,7 +94,7 @@ void ZstdDeflatingWriteBuffer::finish()
     try
     {
         finishImpl();
-        out->next();
+        out->finalize();
         finished = true;
     }
     catch (...)


### PR DESCRIPTION
Refs: https://github.com/ClickHouse/ClickHouse/pull/21325#discussion_r585348309

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use finalize() over next() for nested writers