### PR TITLE
Fix sleep_in_send_tables_status_ms/sleep_in_send_data_ms in integration tests

### DIFF
--- a/tests/integration/test_secure_socket/test.py
+++ b/tests/integration/test_secure_socket/test.py
@@ -12,7 +12,7 @@ NODES = {'node' + str(i): None for i in (1, 2)}
 config = '''<yandex>
     <profiles>
         <default>
-            <sleep_in_send_data>{sleep_in_send_data}</sleep_in_send_data>
+            <sleep_in_send_data_ms>{sleep_in_send_data_ms}</sleep_in_send_data_ms>
         </default>
     </profiles>
 </yandex>'''
@@ -45,12 +45,12 @@ def started_cluster():
 
 
 def test(started_cluster):
-    NODES['node2'].replace_config('/etc/clickhouse-server/users.d/users.xml', config.format(sleep_in_send_data=1000))
+    NODES['node2'].replace_config('/etc/clickhouse-server/users.d/users.xml', config.format(sleep_in_send_data_ms=1000000))
     
     attempts = 0
     while attempts < 1000:
-        setting = NODES['node2'].http_query("SELECT value FROM system.settings WHERE name='sleep_in_send_data'")
-        if int(setting) == 1000:
+        setting = NODES['node2'].http_query("SELECT value FROM system.settings WHERE name='sleep_in_send_data_ms'")
+        if int(setting) == 1000000:
             break
         time.sleep(0.1)
         attempts += 1

--- a/tests/integration/test_system_clusters_actual_information/configs/users.xml
+++ b/tests/integration/test_system_clusters_actual_information/configs/users.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0"?>
-<yandex>
-    <profiles>
-        <default>
-            <sleep_in_send_tables_status_ms>5000</sleep_in_send_tables_status_ms>
-        </default>
-    </profiles>
-</yandex>

--- a/tests/integration/test_system_clusters_actual_information/configs/users.xml
+++ b/tests/integration/test_system_clusters_actual_information/configs/users.xml
@@ -2,7 +2,7 @@
 <yandex>
     <profiles>
         <default>
-            <sleep_in_send_tables_status>5</sleep_in_send_tables_status>
+            <sleep_in_send_tables_status_ms>5000</sleep_in_send_tables_status_ms>
         </default>
     </profiles>
 </yandex>


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: #21998
Cc: @Avogar 