### PR TITLE
Prevent busy waiting in hedged requests when async_socket_for_remote=0

### DIFF
--- a/src/Client/HedgedConnections.cpp
+++ b/src/Client/HedgedConnections.cpp
@@ -362,9 +362,10 @@ int HedgedConnections::getReadyFileDescriptor(AsyncCallback async_callback)
     epoll_event event;
     event.data.fd = -1;
     size_t events_count = 0;
+    bool blocking = async_callback ? false : true;
     while (events_count == 0)
     {
-        events_count = epoll.getManyReady(1, &event, false);
+        events_count = epoll.getManyReady(1, &event, blocking);
         if (!events_count && async_callback)
             async_callback(epoll.getFileDescriptor(), 0, epoll.getDescription());
     }

--- a/src/Client/HedgedConnections.cpp
+++ b/src/Client/HedgedConnections.cpp
@@ -362,7 +362,7 @@ int HedgedConnections::getReadyFileDescriptor(AsyncCallback async_callback)
     epoll_event event;
     event.data.fd = -1;
     size_t events_count = 0;
-    bool blocking = async_callback ? false : true;
+    bool blocking = !static_cast<bool>(async_callback);
     while (events_count == 0)
     {
         events_count = epoll.getManyReady(1, &event, blocking);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

