### PR TITLE
Fix query cancellation with use_hedged_requests=0 and async_socket_for_remote=1

### DIFF
--- a/src/DataStreams/RemoteQueryExecutorReadContext.cpp
+++ b/src/DataStreams/RemoteQueryExecutorReadContext.cpp
@@ -104,7 +104,7 @@ void RemoteQueryExecutorReadContext::setConnectionFD(int fd, const Poco::Timespa
     connection_fd_description = fd_description;
 }
 
-bool RemoteQueryExecutorReadContext::checkTimeout(bool blocking) const
+bool RemoteQueryExecutorReadContext::checkTimeout(bool blocking)
 {
     try
     {
@@ -118,7 +118,7 @@ bool RemoteQueryExecutorReadContext::checkTimeout(bool blocking) const
     }
 }
 
-bool RemoteQueryExecutorReadContext::checkTimeoutImpl(bool blocking) const
+bool RemoteQueryExecutorReadContext::checkTimeoutImpl(bool blocking)
 {
     /// Wait for epoll will not block if it was polled externally.
     epoll_event events[3];
@@ -128,14 +128,13 @@ bool RemoteQueryExecutorReadContext::checkTimeoutImpl(bool blocking) const
 
     bool is_socket_ready = false;
     bool is_pipe_alarmed = false;
-    bool has_timer_alarm = false;
 
     for (int i = 0; i < num_events; ++i)
     {
         if (events[i].data.fd == connection_fd)
             is_socket_ready = true;
         if (events[i].data.fd == timer.getDescriptor())
-            has_timer_alarm = true;
+            is_timer_alarmed = true;
         if (events[i].data.fd == pipe_fd[0])
             is_pipe_alarmed = true;
     }
@@ -143,7 +142,7 @@ bool RemoteQueryExecutorReadContext::checkTimeoutImpl(bool blocking) const
     if (is_pipe_alarmed)
         return false;
 
-    if (has_timer_alarm && !is_socket_ready)
+    if (is_timer_alarmed && !is_socket_ready)
     {
         /// Socket receive timeout. Drain it in case or error, or it may be hide by timeout exception.
         timer.drain();
@@ -188,10 +187,18 @@ void RemoteQueryExecutorReadContext::cancel()
     /// It is safe to just destroy fiber - we are not in the process of reading from socket.
     boost::context::fiber to_destroy = std::move(fiber);
 
-    while (is_read_in_progress.load(std::memory_order_relaxed))
+    /// One should not try to wait for the current packet here in case of
+    /// timeout because this will exceed the timeout.
+    /// Anyway if the timeout is exceeded, then the connection will be shutdown
+    /// (disconnected), so it will not left in an unsynchronised state.
+    if (!is_timer_alarmed)
     {
-        checkTimeout(/* blocking= */ true);
-        to_destroy = std::move(to_destroy).resume();
+        /// Wait for current pending packet, to avoid leaving connection in unsynchronised state.
+        while (is_read_in_progress.load(std::memory_order_relaxed))
+        {
+            checkTimeout(/* blocking= */ true);
+            to_destroy = std::move(to_destroy).resume();
+        }
     }
 
     /// Send something to pipe to cancel executor waiting.

--- a/src/DataStreams/RemoteQueryExecutorReadContext.h
+++ b/src/DataStreams/RemoteQueryExecutorReadContext.h
@@ -44,6 +44,7 @@ public:
     /// * pipe_fd is a pipe we use to cancel query and socket polling by executor.
     /// We put those descriptors into our own epoll which is used by external executor.
     TimerDescriptor timer{CLOCK_MONOTONIC, 0};
+    bool is_timer_alarmed = false;
     int connection_fd = -1;
     int pipe_fd[2] = { -1, -1 };
 
@@ -54,8 +55,8 @@ public:
     explicit RemoteQueryExecutorReadContext(IConnections & connections_);
     ~RemoteQueryExecutorReadContext();
 
-    bool checkTimeout(bool blocking = false) const;
-    bool checkTimeoutImpl(bool blocking) const;
+    bool checkTimeout(bool blocking = false);
+    bool checkTimeoutImpl(bool blocking);
 
     void setConnectionFD(int fd, const Poco::Timespan & timeout = 0, const std::string & fd_description = "");
     void setTimer() const;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix query cancellation with `use_hedged_requests=0` and `async_socket_for_remote=1`

Detailed description / Documentation draft:
In #21643 async_socket_for_remote=1 was fixed to avoid leaving the
connection in the unsynchronised state.

But one should not try to wait for the current packet in case of timeout
because this will exceed the timeout.

Anyway if the timeout is exceeded, then the connection will be shutdown
(disconnected), so it will not left in an unsynchronised state.