### PR TITLE
Fix filter push down w/o predicate expression optimization

### DIFF
--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -650,6 +650,11 @@ std::string ActionsDAG::dumpDAG() const
         out << ' ' << map[node];
     out << '\n';
 
+    out << "Inputs:";
+    for (const auto * node : inputs)
+        out << ' ' << map[node];
+    out << '\n';
+
     return out.str();
 }
 

--- a/src/Interpreters/ExpressionActions.cpp
+++ b/src/Interpreters/ExpressionActions.cpp
@@ -206,7 +206,10 @@ void ExpressionActions::linearizeActions()
     {
         const auto & cur = data[reverse_index[input]];
         auto pos = required_columns.size();
-        actions[cur.position].arguments.front().pos = pos;
+
+        /// Const column does not have arguments
+        if (!actions[cur.position].arguments.empty())
+            actions[cur.position].arguments.front().pos = pos;
         required_columns.push_back({input->result_name, input->result_type});
         input_positions[input->result_name].emplace_back(pos);
     }

--- a/tests/queries/0_stateless/01763_filter_push_down_bugs.reference
+++ b/tests/queries/0_stateless/01763_filter_push_down_bugs.reference
@@ -4,3 +4,4 @@
 [[1]]	2
 String1_0	String2_0	String3_0	String4_0	1
 String1_0	String2_0	String3_0	String4_0	1
+-9223372036854775808

--- a/tests/queries/0_stateless/01763_filter_push_down_bugs.sql
+++ b/tests/queries/0_stateless/01763_filter_push_down_bugs.sql
@@ -35,3 +35,7 @@ FROM
 WHERE  String4 ='String4_0';
 
 DROP TABLE IF EXISTS Test;
+
+SELECT -9223372036854775808 HAVING 1 SETTINGS enable_optimize_predicate_expression=0;
+-- https://clickhouse-test-reports.s3.yandex.net/22147/f1907acbcd96b3b5ce0e6073e7faa44479c3221b/fuzzer_asan/report.html#fail1
+SELECT -9223372036854775808 HAVING 0 SETTINGS enable_optimize_predicate_expression=0;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix filter push down w/o predicate expression optimization

Detailed description / Documentation draft:
Found by fuzzer [1]:

  [1]: https://clickhouse-test-reports.s3.yandex.net/22147/f1907acbcd96b3b5ce0e6073e7faa44479c3221b/fuzzer_asan/report.html#fail1

In case of enable_optimize_predicate_expression=0, filterPushDown
optimization may pass const column to ExpressionStep.

Cc: @KochetovNicolai
Refs: #20341
