### PR TITLE
fix constant condition conflict with column name and add stateless test

### DIFF
--- a/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
+++ b/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
@@ -39,7 +39,7 @@ MergeTreeWhereOptimizer::MergeTreeWhereOptimizer(
     , queried_columns{queried_columns_}
     , sorting_key_names{NameSet(
           metadata_snapshot->getSortingKey().column_names.begin(), metadata_snapshot->getSortingKey().column_names.end())}
-    , block_with_constants{KeyCondition::getBlockWithConstants(query_info.query, query_info.syntax_analyzer_result, context)}
+    , block_with_constants{KeyCondition::getBlockWithConstants(query_info.query->clone(), query_info.syntax_analyzer_result, context)}
     , log{log_}
     , column_sizes{std::move(column_sizes_)}
 {

--- a/tests/queries/0_stateless/01778_where_with_column_name.sql
+++ b/tests/queries/0_stateless/01778_where_with_column_name.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS ttt01778;
+CREATE TABLE ttt01778 (`1` String, `2` INT) ENGINE = MergeTree() ORDER BY tuple();
+INSERT INTO ttt01778 values('1',1),('2',2),('3',3);
+select * from ttt01778 where 1=2; -- no server error
+DROP TABLE ttt01778;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix exception which may happen when `SELECT` has constant `WHERE` condition and source table has columns which names are digits.


