### PR TITLE
Remove setting same timeouts in secure socket

### DIFF
--- a/src/IO/ReadBufferFromPocoSocket.cpp
+++ b/src/IO/ReadBufferFromPocoSocket.cpp
@@ -37,13 +37,6 @@ bool ReadBufferFromPocoSocket::nextImpl()
         while (async_callback && !socket.poll(0, Poco::Net::Socket::SELECT_READ))
             async_callback(socket.impl()->sockfd(), socket.getReceiveTimeout(), socket_description);
 
-        /// receiveBytes in SecureStreamSocket throws TimeoutException after max(receive_timeout, send_timeout),
-        /// but we want to get this exception exactly after receive_timeout. So, set send_timeout = receive_timeout
-        /// before receiveBytes.
-        std::unique_ptr<TimeoutSetter> timeout_setter = nullptr;
-        if (socket.secure())
-            timeout_setter = std::make_unique<TimeoutSetter>(dynamic_cast<Poco::Net::StreamSocket &>(socket), socket.getReceiveTimeout(), socket.getReceiveTimeout());
-
         bytes_read = socket.impl()->receiveBytes(internal_buffer.begin(), internal_buffer.size());
     }
     catch (const Poco::Net::NetException & e)

--- a/src/IO/WriteBufferFromPocoSocket.cpp
+++ b/src/IO/WriteBufferFromPocoSocket.cpp
@@ -41,13 +41,6 @@ void WriteBufferFromPocoSocket::nextImpl()
         /// Add more details to exceptions.
         try
         {
-            /// sendBytes in SecureStreamSocket throws TimeoutException after max(receive_timeout, send_timeout),
-            /// but we want to get this exception exactly after send_timeout. So, set receive_timeout = send_timeout
-            /// before sendBytes.
-            std::unique_ptr<TimeoutSetter> timeout_setter = nullptr;
-            if (socket.secure())
-                timeout_setter = std::make_unique<TimeoutSetter>(dynamic_cast<Poco::Net::StreamSocket &>(socket), socket.getSendTimeout(), socket.getSendTimeout());
-
             res = socket.impl()->sendBytes(working_buffer.begin() + bytes_written, offset() - bytes_written);
         }
         catch (const Poco::Net::NetException & e)

--- a/tests/integration/test_secure_socket/test.py
+++ b/tests/integration/test_secure_socket/test.py
@@ -59,12 +59,12 @@ def test(started_cluster):
 
 
     start = time.time()
-    NODES['node1'].query_and_get_error('SELECT * FROM distributed_table settings receive_timeout=5, use_hedged_requests=0, async_socket_for_remote=0;')
+    NODES['node1'].query_and_get_error('SELECT * FROM distributed_table settings receive_timeout=5, send_timeout=5, use_hedged_requests=0, async_socket_for_remote=0;')
     end = time.time()
     assert end - start < 10
 
     start = time.time()
-    error = NODES['node1'].query_and_get_error('SELECT * FROM distributed_table settings receive_timeout=5, use_hedged_requests=0;')
+    error = NODES['node1'].query_and_get_error('SELECT * FROM distributed_table settings receive_timeout=5, send_timeout=5, use_hedged_requests=0;')
     end = time.time()
 
     assert end - start < 10
@@ -73,7 +73,7 @@ def test(started_cluster):
     assert error.find('DB::ReadBufferFromPocoSocket::nextImpl()') == -1
 
     start = time.time()
-    error = NODES['node1'].query_and_get_error('SELECT * FROM distributed_table settings receive_timeout=5;')
+    error = NODES['node1'].query_and_get_error('SELECT * FROM distributed_table settings receive_timeout=5, send_timeout=5;')
     end = time.time()
 
     assert end - start < 10


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Other

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Don't set the same timeouts in ReadBufferFromPocoSocket/WriteBufferFromPocoSocket in nextImpl because it causes a race.

Detailed description / Documentation draft:
...
