### PR TITLE
Remove old MSan suppressions (part 3)

### DIFF
--- a/tests/msan_suppressions.txt
+++ b/tests/msan_suppressions.txt
@@ -12,6 +12,3 @@ src:*/contrib/simdjson/*
 
 # Hyperscan
 fun:roseRunProgram
-
-# mariadbclient, NSS functions from libc
-fun:_nss_files_parse_servent


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)
