### PR TITLE
Remove old MSan suppressions (part 4)

### DIFF
--- a/tests/msan_suppressions.txt
+++ b/tests/msan_suppressions.txt
@@ -8,7 +8,6 @@ fun:tolower
 # Suppress some failures in contrib so that we can enable MSan in CI.
 # Ideally, we should report these upstream.
 src:*/contrib/zlib-ng/*
-src:*/contrib/simdjson/*
 
 # Hyperscan
 fun:roseRunProgram


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)
