### PR TITLE
Fix S3 Zero-Copy replication for hybrid storage

### DIFF
--- a/src/Storages/MergeTree/MergeTreePartsMover.cpp
+++ b/src/Storages/MergeTree/MergeTreePartsMover.cpp
@@ -206,18 +206,18 @@ MergeTreeData::DataPartPtr MergeTreePartsMover::clonePart(const MergeTreeMoveEnt
         /// Try to fetch part from S3 without copy and fallback to default copy
         /// if it's not possible
         moving_part.part->assertOnDisk();
-        String path_to_clone = data->getRelativeDataPath() + directory_to_move + '/';
+        String path_to_clone = data->getRelativeDataPath() + directory_to_move + "/";
         String relative_path = part->relative_path;
         if (disk->exists(path_to_clone + relative_path))
         {
             LOG_WARNING(log, "Path " + fullPath(disk, path_to_clone + relative_path) + " already exists. Will remove it and clone again.");
-            disk->removeRecursive(path_to_clone + relative_path + '/');
+            disk->removeRecursive(path_to_clone + relative_path + "/");
         }
         disk->createDirectories(path_to_clone);
         bool is_fetched = data->tryToFetchIfShared(*part, disk, path_to_clone + "/" + part->name);
         if (!is_fetched)
-            part->volume->getDisk()->copy(data->getRelativeDataPath() + relative_path, disk, path_to_clone);
-        part->volume->getDisk()->removeFileIfExists(path_to_clone + '/' + IMergeTreeDataPart::DELETE_ON_DESTROY_MARKER_FILE_NAME);
+            part->volume->getDisk()->copy(data->getRelativeDataPath() + relative_path + "/", disk, path_to_clone);
+        part->volume->getDisk()->removeFileIfExists(path_to_clone + "/" + IMergeTreeDataPart::DELETE_ON_DESTROY_MARKER_FILE_NAME);
     }
     else
     {

--- a/tests/integration/test_s3_zero_copy_replication/configs/config.d/s3.xml
+++ b/tests/integration/test_s3_zero_copy_replication/configs/config.d/s3.xml
@@ -17,6 +17,16 @@
                     </main>
                 </volumes>
             </s3>
+            <hybrid>
+                <volumes>
+                    <main>
+                        <disk>default</disk>
+                    </main>
+                    <external>
+                        <disk>s31</disk>
+                    </external>
+                </volumes>
+            </hybrid>
         </policies>
     </storage_configuration>
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixed bug in S3 zero-copy replication for hybrid storage.


Detailed description / Documentation draft:

Fixed wrong path for local files in MergeTreePartsMover::clonePart method.
