### PR TITLE
add description for parseDateTime64BestEffort* functions

### DIFF
--- a/docs/en/sql-reference/functions/type-conversion-functions.md
+++ b/docs/en/sql-reference/functions/type-conversion-functions.md
@@ -385,8 +385,6 @@ reinterpretAsUUID(fixed_string)
 
 -   `fixed_string` — Big-endian byte string. [FixedString](../../sql-reference/data-types/fixedstring.md#fixedstring).
 
-## reinterpret(x, T) {#type_conversion_function-reinterpret}
-
 **Returned value**
 
 -   The UUID type value. [UUID](../../sql-reference/data-types/uuid.md#uuid-data-type).
@@ -398,9 +396,7 @@ String to UUID.
 Query:
 
 ``` sql
-SELECT reinterpret(toInt8(-1), 'UInt8') as int_to_uint,
-    reinterpret(toInt8(1), 'Float32') as int_to_float,
-    reinterpret('1', 'UInt32') as string_to_int;
+SELECT reinterpretAsUUID(reverse(unhex('000102030405060708090a0b0c0d0e0f')));
 ```
 
 Result:
@@ -431,15 +427,51 @@ Result:
 └─────────────────────┘
 ```
 
+## reinterpret(x, T) {#type_conversion_function-reinterpret}
+
+Use the same source in-memory bytes sequence for `x` value and reinterpret it to destination type
+
+Query:
+```sql
+SELECT reinterpret(toInt8(-1), 'UInt8') as int_to_uint,
+    reinterpret(toInt8(1), 'Float32') as int_to_float,
+    reinterpret('1', 'UInt32') as string_to_int;
+```
+
+Result:
+
+```
+┌─int_to_uint─┬─int_to_float─┬─string_to_int─┐
+│         255 │        1e-45 │            49 │
+└─────────────┴──────────────┴───────────────┘
+```
+
 ## CAST(x, T) {#type_conversion_function-cast}
 
-Converts input value `x` to the `T` data type.
+Converts input value `x` to the `T` data type. Unlike to `reinterpret` function use external representation of `x` value. 
 
 The syntax `CAST(x AS t)` is also supported.
 
 Note, that if value `x` does not fit the bounds of type T, the function overflows. For example, CAST(-1, 'UInt8') returns 255.
 
-**Example**
+**Examples**
+
+Query:
+
+```sql
+SELECT
+    cast(toInt8(-1), 'UInt8') AS cast_int_to_uint,
+    cast(toInt8(1), 'Float32') AS cast_int_to_float,
+    cast('1', 'UInt32') AS cast_string_to_int
+```
+
+Result:
+
+```
+┌─cast_int_to_uint─┬─cast_int_to_float─┬─cast_string_to_int─┐
+│              255 │                 1 │                  1 │
+└──────────────────┴───────────────────┴────────────────────┘
+```
 
 Query:
 
@@ -634,6 +666,7 @@ Result:
 ```
 
 ## parseDateTimeBestEffort {#parsedatetimebesteffort}
+## parseDateTime32BestEffort {#parsedatetime32besteffort}
 
 Converts a date and time in the [String](../../sql-reference/data-types/string.md) representation to [DateTime](../../sql-reference/data-types/datetime.md#data_type-datetime) data type.
 
@@ -822,10 +855,12 @@ Result:
 ```
 
 ## parseDateTimeBestEffortOrNull {#parsedatetimebesteffortornull}
+## parseDateTime32BestEffortOrNull {#parsedatetime32besteffortornull}
 
-Same as for [parseDateTimeBestEffort](#parsedatetimebesteffort) except that it returns null when it encounters a date format that cannot be processed.
+Same as for [parseDateTimeBestEffort](#parsedatetimebesteffort) except that it returns `NULL` when it encounters a date format that cannot be processed.
 
 ## parseDateTimeBestEffortOrZero {#parsedatetimebesteffortorzero}
+## parseDateTime32BestEffortOrZero {#parsedatetime32besteffortorzero}
 
 Same as for [parseDateTimeBestEffort](#parsedatetimebesteffort) except that it returns zero date or zero date time when it encounters a date format that cannot be processed.
 
@@ -1001,6 +1036,57 @@ Result:
 └─────────────────────────────────┘
 ```
 
+## parseDateTime64BestEffort {#parsedatetime64besteffort}
+
+Same as [parseDateTimeBestEffort](#parsedatetimebesteffort) function but also parse milliseconds and microseconds and return `DateTime64(3)` or `DateTime64(6)` data types.
+
+**Syntax**
+
+``` sql
+parseDateTime64BestEffort(time_string [, precision [, time_zone]])
+```
+
+**Parameters**
+
+-   `time_string` — String containing a date or date with time to convert. [String](../../sql-reference/data-types/string.md).
+-   `precision` — `3` for milliseconds, `6` for microseconds. Default `3`. Optional [UInt8](../../sql-reference/data-types/int-uint.md).
+-   `time_zone` — [Timezone](../../operations/server-configuration-parameters/settings.md#server_configuration_parameters-timezone). The function parses `time_string` according to the timezone. Optional. [String](../../sql-reference/data-types/string.md).
+
+**Examples**
+
+Query:
+
+```sql
+SELECT parseDateTime64BestEffort('2021-01-01') AS a, toTypeName(a) AS t
+UNION ALL
+SELECT parseDateTime64BestEffort('2021-01-01 01:01:00.12346') AS a, toTypeName(a) AS t
+UNION ALL
+SELECT parseDateTime64BestEffort('2021-01-01 01:01:00.12346',6) AS a, toTypeName(a) AS t
+UNION ALL
+SELECT parseDateTime64BestEffort('2021-01-01 01:01:00.12346',3,'Europe/Moscow') AS a, toTypeName(a) AS t
+FORMAT PrettyCompactMonoBlcok
+```
+
+Result:
+
+```
+┌──────────────────────────a─┬─t──────────────────────────────┐
+│ 2021-01-01 01:01:00.123000 │ DateTime64(3)                  │
+│ 2021-01-01 00:00:00.000000 │ DateTime64(3)                  │
+│ 2021-01-01 01:01:00.123460 │ DateTime64(6)                  │
+│ 2020-12-31 22:01:00.123000 │ DateTime64(3, 'Europe/Moscow') │
+└────────────────────────────┴────────────────────────────────┘
+```
+
+## parseDateTime64BestEffortOrNull {#parsedatetime32besteffortornull}
+
+Same as for [parseDateTime64BestEffort](#parsedatetime64besteffort) except that it returns `NULL` when it encounters a date format that cannot be processed.
+
+## parseDateTime64BestEffortOrZero {#parsedatetime64besteffortorzero}
+
+Same as for [parseDateTime64BestEffort](#parsedatetimebesteffort) except that it returns zero date or zero date time when it encounters a date format that cannot be processed.
+
+
 ## toLowCardinality {#tolowcardinality}
 
 Converts input parameter to the [LowCardianlity](../../sql-reference/data-types/lowcardinality.md) version of same data type.
@@ -1009,7 +1095,7 @@ To convert data from the `LowCardinality` data type use the [CAST](#type_convers
 
 **Syntax**
 
-``` sql
+```sql
 toLowCardinality(expr)
 ```
 
@@ -1027,7 +1113,7 @@ Type: `LowCardinality(expr_result_type)`
 
 Query:
 
-``` sql
+```sql
 SELECT toLowCardinality('1');
 ```
 
@@ -1045,7 +1131,8 @@ Result:
 
 ## toUnixTimestamp64Nano {#tounixtimestamp64nano}
 
-Converts a `DateTime64` to a `Int64` value with fixed sub-second precision. Input value is scaled up or down appropriately depending on it precision. Please note that output value is a timestamp in UTC, not in timezone of `DateTime64`.
+Converts a `DateTime64` to a `Int64` value with fixed sub-second precision.
+Input value is scaled up or down appropriately depending on it precision. Please note that output value is a timestamp in UTC, not in timezone of `DateTime64`.
 
 **Syntax**
 
@@ -1077,6 +1164,8 @@ Result:
 │                1568650812345 │
 └──────────────────────────────┘
 ```
+
+Query: 
 
 ``` sql
 WITH toDateTime64('2019-09-16 19:20:12.345678910', 6) AS dt64


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)


Detailed description / Documentation draft:
- add description for parseDateTime64BestEffort, parseDateTime64BestEffortOrNull, parseDateTime64BestEffortOrZero
- sync EN and RU versions of `type-conversion-functions.md` (move toLowCardinality after parseDateTime*)
- add notes about differences between reinterpret and CAST functions
