### PR TITLE
Delete temporary fetch directory if it already exists

### DIFF
--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -547,7 +547,11 @@ MergeTreeData::MutableDataPartPtr Fetcher::downloadPartToDisk(
     String part_download_path = data.getRelativeDataPath() + part_relative_path + "/";
 
     if (disk->exists(part_download_path))
-        throw Exception("Directory " + fullPath(disk, part_download_path) + " already exists.", ErrorCodes::DIRECTORY_ALREADY_EXISTS);
+    {
+        LOG_WARNING(log, "Directory {} already exists, probably result of a failed fetch. Will remove it before fetching part.",
+            fullPath(disk, part_download_path));
+        disk->removeRecursive(part_download_path);
+    }
 
     disk->createDirectories(part_download_path);
 

--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -39,6 +39,7 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
     extern const int S3_ERROR;
     extern const int INCORRECT_PART_TYPE;
+    extern const int LOGICAL_ERROR;
 }
 
 namespace DataPartsExchange
@@ -542,6 +543,13 @@ MergeTreeData::MutableDataPartPtr Fetcher::downloadPartToDisk(
 
     static const String TMP_PREFIX = "tmp_fetch_";
     String tmp_prefix = tmp_prefix_.empty() ? TMP_PREFIX : tmp_prefix_;
+
+    /// We will remove directory if it's already exists. Make precautions.
+    if (tmp_prefix.empty()
+        || part_name.empty()
+        || std::string::npos != tmp_prefix.find_first_of("/.")
+        || std::string::npos != part_name.find_first_of("/."))
+        throw Exception("Logical error: tmp_prefix and part_name cannot be empty or contain '.' or '/' characters.", ErrorCodes::LOGICAL_ERROR);
 
     String part_relative_path = String(to_detached ? "detached/" : "") + tmp_prefix + part_name;
     String part_download_path = data.getRelativeDataPath() + part_relative_path + "/";

--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -39,7 +39,6 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
     extern const int S3_ERROR;
     extern const int INCORRECT_PART_TYPE;
-    extern const int LOGICAL_ERROR;
 }
 
 namespace DataPartsExchange


### PR DESCRIPTION
It could be left there after a network timeout, a system crash, or
checksum issues.

The downside of this PR is that it would be harder to debug checksum
issues if replication will continuously delete and try to fetch the same
part.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix error `Directory tmp_fetch_XXX already exists` which could happen after failed fetch part. Delete temporary fetch directory if it already exists. Fixes #14197. 

