### PR TITLE
Added function dictGetOrNull

### DIFF
--- a/src/Functions/FunctionsExternalDictionaries.cpp
+++ b/src/Functions/FunctionsExternalDictionaries.cpp
@@ -40,6 +40,7 @@ void registerFunctionsExternalDictionaries(FunctionFactory & factory)
     factory.registerFunction<FunctionDictGetStringOrDefault>();
     factory.registerFunction<FunctionDictGetNoType<DictionaryGetFunctionType::get>>();
     factory.registerFunction<FunctionDictGetNoType<DictionaryGetFunctionType::getOrDefault>>();
+    factory.registerFunction<FunctionDictGetOrNull>();
 }
 
 }

--- a/src/Functions/FunctionsExternalDictionaries.h
+++ b/src/Functions/FunctionsExternalDictionaries.h
@@ -773,7 +773,7 @@ private:
             2. If column is already nullable we merge column null map with null map that we get from dict has.
           */
 
-        auto dict_has_arguments = filterAttributesForDictHas(arguments);
+        auto dict_has_arguments = filterAttributeNameArgumentForDictHas(arguments);
         auto is_key_in_dictionary_column = dictionary_has_func_impl.executeImpl(dict_has_arguments, std::make_shared<DataTypeUInt8>(), input_rows_count);
         auto is_key_in_dictionary_column_mutable = is_key_in_dictionary_column->assumeMutable();
         ColumnVector<UInt8> & is_key_in_dictionary_column_typed = assert_cast<ColumnVector<UInt8> &>(*is_key_in_dictionary_column_mutable);
@@ -839,14 +839,15 @@ private:
             null_map[i] = null_map[i] || null_map_to_add[i];
     }
 
-    static ColumnsWithTypeAndName filterAttributesForDictHas(const ColumnsWithTypeAndName & arguments)
+    static ColumnsWithTypeAndName filterAttributeNameArgumentForDictHas(const ColumnsWithTypeAndName & arguments)
     {
         ColumnsWithTypeAndName dict_has_arguments;
         dict_has_arguments.reserve(arguments.size() - 1);
+        size_t attribute_name_argument_index = 1;
 
         for (size_t i = 0; i < arguments.size(); ++i)
         {
-            if (i == 1)
+            if (i == attribute_name_argument_index)
                 continue;
 
             dict_has_arguments.emplace_back(arguments[i]);

--- a/tests/queries/0_stateless/01780_dict_get_or_null.reference
+++ b/tests/queries/0_stateless/01780_dict_get_or_null.reference
@@ -1,0 +1,18 @@
+Simple key dictionary dictGetOrNull
+0	0	\N	\N	(NULL,NULL)
+1	1	First	First	('First','First')
+2	1	Second	\N	('Second',NULL)
+3	1	Third	Third	('Third','Third')
+4	0	\N	\N	(NULL,NULL)
+Complex key dictionary dictGetOrNull
+(0,'key')	0	\N	\N	(NULL,NULL)
+(1,'key')	1	First	First	('First','First')
+(2,'key')	1	Second	\N	('Second',NULL)
+(3,'key')	1	Third	Third	('Third','Third')
+(4,'key')	0	\N	\N	(NULL,NULL)
+Range key dictionary dictGetOrNull
+(0,'2019-05-20')	0	\N	\N	(NULL,NULL)
+(1,'2019-05-20')	1	First	First	('First','First')
+(2,'2019-05-20')	1	Second	\N	('Second',NULL)
+(3,'2019-05-20')	1	Third	Third	('Third','Third')
+(4,'2019-05-20')	0	\N	\N	(NULL,NULL)

--- a/tests/queries/0_stateless/01780_dict_get_or_null.sql
+++ b/tests/queries/0_stateless/01780_dict_get_or_null.sql
@@ -1,0 +1,116 @@
+DROP TABLE IF EXISTS simple_key_dictionary_source_table;
+CREATE TABLE simple_key_dictionary_source_table
+(
+    id UInt64,
+    value String,
+    value_nullable Nullable(String)
+) ENGINE = TinyLog;
+
+INSERT INTO simple_key_dictionary_source_table VALUES (1, 'First', 'First');
+INSERT INTO simple_key_dictionary_source_table VALUES (2, 'Second', NULL);
+INSERT INTO simple_key_dictionary_source_table VALUES (3, 'Third', 'Third');
+
+DROP DICTIONARY IF EXISTS simple_key_dictionary;
+CREATE DICTIONARY simple_key_dictionary
+(
+    id UInt64,
+    value String,
+    value_nullable Nullable(String)
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(HOST 'localhost' PORT tcpPort() TABLE 'simple_key_dictionary_source_table'))
+LAYOUT(DIRECT());
+
+SELECT 'Simple key dictionary dictGetOrNull';
+
+SELECT
+    number,
+    dictHas('simple_key_dictionary', number),
+    dictGetOrNull('simple_key_dictionary', 'value', number),
+    dictGetOrNull('simple_key_dictionary', 'value_nullable', number),
+    dictGetOrNull('simple_key_dictionary', ('value', 'value_nullable'), number)
+FROM system.numbers LIMIT 5;
+
+DROP DICTIONARY simple_key_dictionary;
+DROP TABLE simple_key_dictionary_source_table;
+
+DROP TABLE IF EXISTS complex_key_dictionary_source_table;
+CREATE TABLE complex_key_dictionary_source_table
+(
+    id UInt64,
+    id_key String,
+    value String,
+    value_nullable Nullable(String)
+) ENGINE = TinyLog;
+
+INSERT INTO complex_key_dictionary_source_table VALUES (1, 'key', 'First', 'First');
+INSERT INTO complex_key_dictionary_source_table VALUES (2, 'key', 'Second', NULL);
+INSERT INTO complex_key_dictionary_source_table VALUES (3, 'key', 'Third', 'Third');
+
+DROP DICTIONARY IF EXISTS complex_key_dictionary;
+CREATE DICTIONARY complex_key_dictionary
+(
+    id UInt64,
+    id_key String,
+    value String,
+    value_nullable Nullable(String)
+)
+PRIMARY KEY id, id_key
+SOURCE(CLICKHOUSE(HOST 'localhost' PORT tcpPort() TABLE 'complex_key_dictionary_source_table'))
+LAYOUT(COMPLEX_KEY_DIRECT());
+
+SELECT 'Complex key dictionary dictGetOrNull';
+
+SELECT
+    (number, 'key'),
+    dictHas('complex_key_dictionary', (number, 'key')),
+    dictGetOrNull('complex_key_dictionary', 'value', (number, 'key')),
+    dictGetOrNull('complex_key_dictionary', 'value_nullable', (number, 'key')),
+    dictGetOrNull('complex_key_dictionary', ('value', 'value_nullable'), (number, 'key'))
+FROM system.numbers LIMIT 5;
+
+DROP DICTIONARY complex_key_dictionary;
+DROP TABLE complex_key_dictionary_source_table;
+
+DROP TABLE IF EXISTS range_key_dictionary_source_table;
+CREATE TABLE range_key_dictionary_source_table
+(
+    key UInt64,
+    start_date Date,
+    end_date Date,
+    value String,
+    value_nullable Nullable(String)
+)
+ENGINE = TinyLog();
+
+INSERT INTO range_key_dictionary_source_table VALUES(1, toDate('2019-05-20'), toDate('2019-05-20'), 'First', 'First');
+INSERT INTO range_key_dictionary_source_table VALUES(2, toDate('2019-05-20'), toDate('2019-05-20'), 'Second', NULL);
+INSERT INTO range_key_dictionary_source_table VALUES(3, toDate('2019-05-20'), toDate('2019-05-20'), 'Third', 'Third');
+
+DROP DICTIONARY IF EXISTS range_key_dictionary;
+CREATE DICTIONARY range_key_dictionary
+(
+    key UInt64,
+    start_date Date,
+    end_date Date,
+    value String,
+    value_nullable Nullable(String)
+)
+PRIMARY KEY key
+SOURCE(CLICKHOUSE(HOST 'localhost' PORT tcpPort() TABLE 'range_key_dictionary_source_table'))
+LIFETIME(MIN 1 MAX 1000)
+LAYOUT(RANGE_HASHED())
+RANGE(MIN start_date MAX end_date);
+
+SELECT 'Range key dictionary dictGetOrNull';
+
+SELECT
+    (number, toDate('2019-05-20')),
+    dictHas('range_key_dictionary', number, toDate('2019-05-20')),
+    dictGetOrNull('range_key_dictionary', 'value', number, toDate('2019-05-20')),
+    dictGetOrNull('range_key_dictionary', 'value_nullable', number, toDate('2019-05-20')),
+    dictGetOrNull('range_key_dictionary', ('value', 'value_nullable'), number, toDate('2019-05-20'))
+FROM system.numbers LIMIT 5;
+
+DROP DICTIONARY range_key_dictionary;
+DROP TABLE range_key_dictionary_source_table;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added function `dictGetOrNull`. It works like `dictGet`, but return `Null` in case key was not found in dictionary. Closes https://github.com/ClickHouse/ClickHouse/issues/22375.