### PR TITLE
ppc64le: Fix compile and stack trace

### DIFF
--- a/src/Common/StackTrace.cpp
+++ b/src/Common/StackTrace.cpp
@@ -35,7 +35,7 @@ std::string signalToErrorMessage(int sig, const siginfo_t & info, const ucontext
             else
                 error << "Address: " << info.si_addr;
 
-#if defined(__x86_64__) && !defined(__FreeBSD__) && !defined(__APPLE__) && !defined(__arm__)
+#if defined(__x86_64__) && !defined(__FreeBSD__) && !defined(__APPLE__) && !defined(__arm__) && !defined(__powerpc__)
             auto err_mask = context.uc_mcontext.gregs[REG_ERR];
             if ((err_mask & 0x02))
                 error << " Access: write.";
@@ -186,6 +186,8 @@ static void * getCallerAddress(const ucontext_t & context)
 #    endif
 #elif defined(__aarch64__)
     return reinterpret_cast<void *>(context.uc_mcontext.pc);
+#elif defined(__powerpc64__)
+    return reinterpret_cast<void *>(context.uc_mcontext.gp_regs[PT_NIP]);
 #else
     return nullptr;
 #endif


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed compiling on ppc64le and use the correct instruction pointer register on ppc64le.



