### PR TITLE
Fix flapping test_s3_zero_copy_replication

### DIFF
--- a/tests/integration/test_s3_zero_copy_replication/test.py
+++ b/tests/integration/test_s3_zero_copy_replication/test.py
@@ -96,7 +96,7 @@ def test_s3_zero_copy_on_hybrid_storage(cluster):
     node1.query(
         """
         CREATE TABLE hybrid_test ON CLUSTER test_cluster (id UInt32, value String)
-        ENGINE=ReplicatedMergeTree('/clickhouse/tables/s3_test', '{}')
+        ENGINE=ReplicatedMergeTree('/clickhouse/tables/hybrid_test', '{}')
         ORDER BY id
         SETTINGS storage_policy='hybrid'
         """
@@ -131,3 +131,6 @@ def test_s3_zero_copy_on_hybrid_storage(cluster):
 
     assert node1.query("SELECT * FROM hybrid_test ORDER BY id FORMAT Values") == "(0,'data'),(1,'data')"
     assert node2.query("SELECT * FROM hybrid_test ORDER BY id FORMAT Values") == "(0,'data'),(1,'data')"
+
+    node1.query("DROP TABLE IF EXISTS hybrid_test NO DELAY")
+    node2.query("DROP TABLE IF EXISTS hybrid_test NO DELAY")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Not for changelog.

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixed flapping test test_s3_zero_copy_replication


Detailed description / Documentation draft:

https://clickhouse-test-reports.s3.yandex.net/0/2646a5d514fcfc0905ea3a9149146a18e3068c6e/integration_tests_(thread)/integration_run_test_s3_zero_copy_replication_test_py_0.txt
I will not teach others to fly and promise to less use copy-paste.
I will not teach others to fly and promise to less use copy-paste.
I will not teach others to fly and promise to less use copy-paste.
(... wrote with copy-paste ...)