### PR TITLE
ppc64le: Fix config and timezone embedding.

### DIFF
--- a/contrib/cctz-cmake/CMakeLists.txt
+++ b/contrib/cctz-cmake/CMakeLists.txt
@@ -97,12 +97,19 @@ if (NOT EXTERNAL_CCTZ_LIBRARY_FOUND OR NOT EXTERNAL_CCTZ_LIBRARY_WORKS)
             set(TZ_OBJS ${TZ_OBJS} ${TZ_OBJ})
 
             # https://stackoverflow.com/questions/14776463/compile-and-add-an-object-file-from-a-binary-with-cmake
-            add_custom_command(OUTPUT ${TZ_OBJ}
-                COMMAND cp ${TZDIR}/${TIMEZONE} ${CMAKE_CURRENT_BINARY_DIR}/${TIMEZONE_ID}
-                COMMAND cd ${CMAKE_CURRENT_BINARY_DIR} && ${OBJCOPY_PATH} -I binary ${OBJCOPY_ARCH_OPTIONS}
+            # PPC64LE fails to do this with objcopy, use ld or lld instead
+            if (ARCH_PPC64LE)
+                add_custom_command(OUTPUT ${TZ_OBJ}
+                    COMMAND cp ${TZDIR}/${TIMEZONE} ${CMAKE_CURRENT_BINARY_DIR}/${TIMEZONE_ID}
+                    COMMAND cd ${CMAKE_CURRENT_BINARY_DIR} && ${CMAKE_LINKER} -m elf64lppc -r -b binary -o ${TZ_OBJ} ${TIMEZONE_ID}
+                    COMMAND rm ${CMAKE_CURRENT_BINARY_DIR}/${TIMEZONE_ID})
+            else()
+                add_custom_command(OUTPUT ${TZ_OBJ}
+                    COMMAND cp ${TZDIR}/${TIMEZONE} ${CMAKE_CURRENT_BINARY_DIR}/${TIMEZONE_ID}
+                    COMMAND cd ${CMAKE_CURRENT_BINARY_DIR} && ${OBJCOPY_PATH} -I binary ${OBJCOPY_ARCH_OPTIONS}
                             --rename-section .data=.rodata,alloc,load,readonly,data,contents ${TIMEZONE_ID} ${TZ_OBJ}
-                COMMAND rm ${CMAKE_CURRENT_BINARY_DIR}/${TIMEZONE_ID})
-
+                    COMMAND rm ${CMAKE_CURRENT_BINARY_DIR}/${TIMEZONE_ID})
+            endif()
             set_source_files_properties(${TZ_OBJ} PROPERTIES EXTERNAL_OBJECT true GENERATED true)
         endforeach(TIMEZONE)
 

--- a/programs/server/CMakeLists.txt
+++ b/programs/server/CMakeLists.txt
@@ -42,11 +42,16 @@ if (OS_LINUX)
         set(RESOURCE_OBJS ${RESOURCE_OBJS} ${RESOURCE_OBJ})
 
         # https://stackoverflow.com/questions/14776463/compile-and-add-an-object-file-from-a-binary-with-cmake
-        add_custom_command(OUTPUT ${RESOURCE_OBJ}
-            COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${OBJCOPY_PATH} -I binary ${OBJCOPY_ARCH_OPTIONS} ${RESOURCE_FILE} ${CMAKE_CURRENT_BINARY_DIR}/${RESOURCE_OBJ}
-            COMMAND ${OBJCOPY_PATH} --rename-section .data=.rodata,alloc,load,readonly,data,contents
-                ${CMAKE_CURRENT_BINARY_DIR}/${RESOURCE_OBJ} ${CMAKE_CURRENT_BINARY_DIR}/${RESOURCE_OBJ})
-
+        # PPC64LE fails to do this with objcopy, use ld or lld instead
+        if (ARCH_PPC64LE)
+            add_custom_command(OUTPUT ${RESOURCE_OBJ}
+                COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${CMAKE_LINKER} -m elf64lppc -r -b binary -o ${CMAKE_CURRENT_BINARY_DIR}/${RESOURCE_OBJ} ${RESOURCE_FILE})
+        else()
+            add_custom_command(OUTPUT ${RESOURCE_OBJ}
+                COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${OBJCOPY_PATH} -I binary ${OBJCOPY_ARCH_OPTIONS} ${RESOURCE_FILE} ${CMAKE_CURRENT_BINARY_DIR}/${RESOURCE_OBJ}
+                COMMAND ${OBJCOPY_PATH} --rename-section .data=.rodata,alloc,load,readonly,data,contents
+                    ${CMAKE_CURRENT_BINARY_DIR}/${RESOURCE_OBJ} ${CMAKE_CURRENT_BINARY_DIR}/${RESOURCE_OBJ})
+        endif()
         set_source_files_properties(${RESOURCE_OBJ} PROPERTIES EXTERNAL_OBJECT true GENERATED true)
     endforeach(RESOURCE_FILE)
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix ClickHouse's config embedding and cctz's timezone embedding on ppc64le.
...

Detailed description / Documentation draft:
Tested that clickhouse can find the embedded config, and verified just in case with readelf.
Fixes these errors:
```
cd /root/rpmbuild/BUILD/clickhouse-21.3.3.14/build/programs/server && cd /root/rpmbuild/BUILD/clickhouse-21.3.3.14/programs/server && /usr/bin/llvm-objcopy -I binary config.xml /root/rpmbuild/BUILD/clickhouse-21.3.3.14/build/programs/server/config.xml.o && /usr/bin/llvm-objcopy --rename-section .data=.rodata,alloc,load,readonly,data,contents /root/rpmbuild/BUILD/clickhouse-21.3.3.14/build/programs/server/config.xml.o /root/rpmbuild/BUILD/clickhouse-21.3.3.14/build/programs/server/config.xml.o
/usr/bin/llvm-objcopy: error: '/root/rpmbuild/BUILD/clickhouse-21.3.3.14/build/programs/server/config.xml.o': The file was not recognized as a valid object file
[7/1702] Generating users.xml.o
FAILED: programs/server/users.xml.o 
cd /root/rpmbuild/BUILD/clickhouse-21.3.3.14/build/programs/server && cd /root/rpmbuild/BUILD/clickhouse-21.3.3.14/programs/server && /usr/bin/llvm-objcopy -I binary users.xml /root/rpmbuild/BUILD/clickhouse-21.3.3.14/build/programs/server/users.xml.o && /usr/bin/llvm-objcopy --rename-section .data=.rodata,alloc,load,readonly,data,contents /root/rpmbuild/BUILD/clickhouse-21.3.3.14/build/programs/server/users.xml.o /root/rpmbuild/BUILD/clickhouse-21.3.3.14/build/programs/server/users.xml.o
/usr/bin/llvm-objcopy: error: '/root/rpmbuild/BUILD/clickhouse-21.3.3.14/build/programs/server/users.xml.o': The file was not recognized as a valid object file
[8/1702] Generating embedded.xml.o
FAILED: programs/server/embedded.xml.o 
cd /root/rpmbuild/BUILD/clickhouse-21.3.3.14/build/programs/server && cd /root/rpmbuild/BUILD/clickhouse-21.3.3.14/programs/server && /usr/bin/llvm-objcopy -I binary embedded.xml /root/rpmbuild/BUILD/clickhouse-21.3.3.14/build/programs/server/embedded.xml.o && /usr/bin/llvm-objcopy --rename-section .data=.rodata,alloc,load,readonly,data,contents /root/rpmbuild/BUILD/clickhouse-21.3.3.14/build/programs/server/embedded.xml.o /root/rpmbuild/BUILD/clickhouse-21.3.3.14/build/programs/server/embedded.xml.o
/usr/bin/llvm-objcopy: error: '/root/rpmbuild/BUILD/clickhouse-21.3.3.14/build/programs/server/embedded.xml.o': The file was not recognized as a valid object file
[9/1702] Generating play.html.o
FAILED: programs/server/play.html.o 
cd /root/rpmbuild/BUILD/clickhouse-21.3.3.14/build/programs/server && cd /root/rpmbuild/BUILD/clickhouse-21.3.3.14/programs/server && /usr/bin/llvm-objcopy -I binary play.html /root/rpmbuild/BUILD/clickhouse-21.3.3.14/build/programs/server/play.html.o && /usr/bin/llvm-objcopy --rename-section .data=.rodata,alloc,load,readonly,data,contents /root/rpmbuild/BUILD/clickhouse-21.3.3.14/build/programs/server/play.html.o /root/rpmbuild/BUILD/clickhouse-21.3.3.14/build/programs/server/play.html.o
/usr/bin/llvm-objcopy: error: '/root/rpmbuild/BUILD/clickhouse-21.3.3.14/build/programs/server/play.html.o': The file was not recognized as a valid object file
...
```
...

