### PR TITLE
ppc64le: Fix finding libclang_rt.builtins on Fedora\RHEL\CentOS

### DIFF
--- a/cmake/linux/default_libs.cmake
+++ b/cmake/linux/default_libs.cmake
@@ -6,7 +6,7 @@ set (DEFAULT_LIBS "-nodefaultlibs")
 # We need builtins from Clang's RT even without libcxx - for ubsan+int128.
 # See https://bugs.llvm.org/show_bug.cgi?id=16404
 if (COMPILER_CLANG AND NOT (CMAKE_CROSSCOMPILING AND ARCH_AARCH64))
-    execute_process (COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.builtins-${CMAKE_SYSTEM_PROCESSOR}.a OUTPUT_VARIABLE BUILTINS_LIBRARY OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process (COMMAND ${CMAKE_CXX_COMPILER} --print-libgcc-file-name --rtlib=compiler-rt OUTPUT_VARIABLE BUILTINS_LIBRARY OUTPUT_STRIP_TRAILING_WHITESPACE)
 else ()
     set (BUILTINS_LIBRARY "-lgcc")
 endif ()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix Fedora\RHEL\CentOS not finding libclang_rt.builtins on ppc64le
...

Detailed description / Documentation draft:
This is because on Fedora\RHEL\CentOS this library has a different name. CMAKE_SYSTEM_PROCESSOR is ppc64le but the library is called powerpc64le. Clang has a nice feature for this. It can give libgcc or libclang_rt depending on the rtlib option.
```
[root@removed ~]# cmake --system-information | grep CMAKE_SYSTEM_PROCESSOR
CMAKE_SYSTEM_PROCESSOR "ppc64le"
[root@removed ~]# clang --print-file-name=libclang_rt.builtins-ppc64le.a
libclang_rt.builtins-ppc64le.a
[root@removed ~]# clang --print-libgcc-file-name --rtlib=compiler-rt
/usr/lib64/clang/10.0.1/lib/linux/libclang_rt.builtins-powerpc64le.a
```
...
