### PR TITLE
ppc64le: Fix CMake error about internal CMake variable CMAKE_ASM_COMPILE_OBJECT not set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ else()
     set(RECONFIGURE_MESSAGE_LEVEL STATUS)
 endif()
 
+enable_language(C CXX ASM)
+
 include (cmake/arch.cmake)
 include (cmake/target.cmake)
 include (cmake/tools.cmake)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix CMake error about internal CMake variable CMAKE_ASM_COMPILE_OBJECT not set on ppc64le
...

Detailed description / Documentation draft:
```
CMake Error: Error required internal CMake variable not set, cmake may not be built correctly.
Missing variable is:
CMAKE_ASM_COMPILE_OBJECT
```
I am not sure why this only happens on ppc64le only.
However, adding this line solves the problem: https://github.com/Orphis/boost-cmake/issues/42#issuecomment-477503460
It is most likely coming from a submodule, because AFAIK ClickHouse doesn't have any asm code, but adding it generally is probably harmless.
...
