### PR TITLE
ppc64le: Fix compiling boost

### DIFF
--- a/contrib/boost-cmake/CMakeLists.txt
+++ b/contrib/boost-cmake/CMakeLists.txt
@@ -160,6 +160,12 @@ if (NOT EXTERNAL_BOOST_FOUND)
     enable_language(ASM)
     SET(ASM_OPTIONS "-x assembler-with-cpp")
 
+    set (SRCS_CONTEXT
+        ${LIBRARY_DIR}/libs/context/src/dummy.cpp
+        ${LIBRARY_DIR}/libs/context/src/execution_context.cpp
+        ${LIBRARY_DIR}/libs/context/src/posix/stack_traits.cpp
+    )
+
     if (SANITIZE AND (SANITIZE STREQUAL "address" OR SANITIZE STREQUAL "thread"))
         add_compile_definitions(BOOST_USE_UCONTEXT)
 
@@ -169,39 +175,34 @@ if (NOT EXTERNAL_BOOST_FOUND)
             add_compile_definitions(BOOST_USE_TSAN)
         endif()
 
-        set (SRCS_CONTEXT
+        set (SRCS_CONTEXT ${SRCS_CONTEXT}
                 ${LIBRARY_DIR}/libs/context/src/fiber.cpp
                 ${LIBRARY_DIR}/libs/context/src/continuation.cpp
-                ${LIBRARY_DIR}/libs/context/src/dummy.cpp
-                ${LIBRARY_DIR}/libs/context/src/execution_context.cpp
-                ${LIBRARY_DIR}/libs/context/src/posix/stack_traits.cpp
         )
-    elseif (ARCH_ARM)
-        set (SRCS_CONTEXT
+    endif()
+    if (ARCH_ARM)
+        set (SRCS_CONTEXT ${SRCS_CONTEXT}
             ${LIBRARY_DIR}/libs/context/src/asm/jump_arm64_aapcs_elf_gas.S
             ${LIBRARY_DIR}/libs/context/src/asm/make_arm64_aapcs_elf_gas.S
             ${LIBRARY_DIR}/libs/context/src/asm/ontop_arm64_aapcs_elf_gas.S
-            ${LIBRARY_DIR}/libs/context/src/dummy.cpp
-            ${LIBRARY_DIR}/libs/context/src/execution_context.cpp
-            ${LIBRARY_DIR}/libs/context/src/posix/stack_traits.cpp
+        )
+    elseif (ARCH_PPC64LE)
+        set (SRCS_CONTEXT ${SRCS_CONTEXT}
+            ${LIBRARY_DIR}/libs/context/src/asm/jump_ppc64_sysv_elf_gas.S
+            ${LIBRARY_DIR}/libs/context/src/asm/make_ppc64_sysv_elf_gas.S
+            ${LIBRARY_DIR}/libs/context/src/asm/ontop_ppc64_sysv_elf_gas.S
         )
     elseif(OS_DARWIN)
-        set (SRCS_CONTEXT
+        set (SRCS_CONTEXT ${SRCS_CONTEXT}
             ${LIBRARY_DIR}/libs/context/src/asm/jump_x86_64_sysv_macho_gas.S
             ${LIBRARY_DIR}/libs/context/src/asm/make_x86_64_sysv_macho_gas.S
             ${LIBRARY_DIR}/libs/context/src/asm/ontop_x86_64_sysv_macho_gas.S
-            ${LIBRARY_DIR}/libs/context/src/dummy.cpp
-            ${LIBRARY_DIR}/libs/context/src/execution_context.cpp
-            ${LIBRARY_DIR}/libs/context/src/posix/stack_traits.cpp
         )
     else()
-        set (SRCS_CONTEXT
+        set (SRCS_CONTEXT ${SRCS_CONTEXT}
             ${LIBRARY_DIR}/libs/context/src/asm/jump_x86_64_sysv_elf_gas.S
             ${LIBRARY_DIR}/libs/context/src/asm/make_x86_64_sysv_elf_gas.S
             ${LIBRARY_DIR}/libs/context/src/asm/ontop_x86_64_sysv_elf_gas.S
-            ${LIBRARY_DIR}/libs/context/src/dummy.cpp
-            ${LIBRARY_DIR}/libs/context/src/execution_context.cpp
-            ${LIBRARY_DIR}/libs/context/src/posix/stack_traits.cpp
         )
     endif()
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix compiling boost on ppc64le
...

Detailed description / Documentation draft:
1. Added support for ppc64le
2. Fixed errors about undefined symbols such as `jump_fcontext` when compiling with sanitizer enabled. This is because jump_fcontext is referenced by some files, such as `boost/context/execution_context_v2.hpp`
Those functions exist in the asm files, so these asm files should be compiled at all times.
```
ld.lld: error: undefined symbol: make_fcontext
>>> referenced by fiber_fcontext.hpp:171 (../contrib/boost/boost/context/fiber_fcontext.hpp:171)
>>>               RemoteQueryExecutorReadContext.cpp.o:(void* boost::context::detail::create_fiber1<boost::context::detail::fiber_record<boost::context::fiber, FiberStack&, DB::RemoteQueryExecutorRoutine>, FiberStack&, DB::RemoteQueryExecutorRoutine>(FiberStack&, DB::RemoteQueryExecutorRoutine&&)) in archive src/libdbms.a
collect2: error: ld returned 1 exit status
```
...
