### PR TITLE
ppc64le: Re-enable compiling with Clang

### DIFF
--- a/cmake/tools.cmake
+++ b/cmake/tools.cmake
@@ -86,8 +86,3 @@ if (LINKER_NAME)
     message(STATUS "Using custom linker by name: ${LINKER_NAME}")
 endif ()
 
-if (ARCH_PPC64LE)
-    if (COMPILER_CLANG OR (COMPILER_GCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8))
-        message(FATAL_ERROR "Only gcc-8 or higher is supported for powerpc architecture")
-    endif ()
-endif ()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Enable compiling on ppc64le with Clang
...

Detailed description / Documentation draft:
When compiling with GCC 10, i had crashes due to memory corruptions, even SELECT 1+1 would crash. 
With Clang it just works and the tests pass fine.
I have no idea why this is disabled. It works just fine for me (i am hosting ppc64le RPMs). Building is successful on Clang 10 and Clang 11. Haven't tested other versions.
...
