### PR TITLE
Remove TestFlows (2)

### DIFF
--- a/tests/testflows/regression.py
+++ b/tests/testflows/regression.py
@@ -14,10 +14,10 @@ def regression(self, local, clickhouse_binary_path, stress=None, parallel=None):
     """
     args = {"local": local, "clickhouse_binary_path": clickhouse_binary_path, "stress": stress, "parallel": parallel}
 
-    Feature(test=load("example.regression", "regression"))(**args)
-    Feature(test=load("ldap.regression", "regression"))(**args)
-    Feature(test=load("rbac.regression", "regression"))(**args)
-    Feature(test=load("aes_encryption.regression", "regression"))(**args)
+    # Feature(test=load("example.regression", "regression"))(**args)
+    # Feature(test=load("ldap.regression", "regression"))(**args)
+    # Feature(test=load("rbac.regression", "regression"))(**args)
+    # Feature(test=load("aes_encryption.regression", "regression"))(**args)
     # Feature(test=load("kerberos.regression", "regression"))(**args)
 
 if main():


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Remove TestFlows due to low reliability (as suggested by @vzakaznikov).