### PR TITLE
aarch64: Re-enable S3

### DIFF
--- a/cmake/find/s3.cmake
+++ b/cmake/find/s3.cmake
@@ -1,7 +1,7 @@
-if(NOT OS_FREEBSD AND NOT APPLE AND NOT ARCH_ARM)
+if(NOT OS_FREEBSD AND NOT APPLE)
     option(ENABLE_S3 "Enable S3" ${ENABLE_LIBRARIES})
 elseif(ENABLE_S3 OR USE_INTERNAL_AWS_S3_LIBRARY)
-    message (${RECONFIGURE_MESSAGE_LEVEL} "Can't use S3 on ARM, Apple or FreeBSD")
+    message (${RECONFIGURE_MESSAGE_LEVEL} "Can't use S3 on Apple or FreeBSD")
 endif()
 
 if(NOT ENABLE_S3)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Re-enable the S3 (AWS) library on aarch64
...

Detailed description / Documentation draft:
This one seemed strange to me, because this is not some low-level platform library. Its a library that pretty much does REST requests.
And many of the ARM instances are on AWS, making it likely that they'll need the S3 feature.
This feature gets successfully built for ppc64le, so why not aarch64 as well?
It was disabled in the commit below with reason "ARM minimal build", but i believe this shouldn't be a minimal build anymore :)
https://github.com/ClickHouse/ClickHouse/commit/521e2e709eb2c4c6c2fc7c15ec22e211d12542bf
...
