### PR TITLE
Fix UB by unlocking the rwlock of the TinyLog from the same thread

### DIFF
--- a/src/Storages/StorageTinyLog.cpp
+++ b/src/Storages/StorageTinyLog.cpp
@@ -357,6 +357,8 @@ void TinyLogBlockOutputStream::writeSuffix()
     for (const auto & file : column_files)
         storage.file_checker.update(file);
     storage.file_checker.save();
+
+    lock.unlock();
 }
 
 

--- a/src/Storages/StorageTinyLog.h
+++ b/src/Storages/StorageTinyLog.h
@@ -70,7 +70,7 @@ private:
     Files files;
 
     FileChecker file_checker;
-    mutable std::shared_timed_mutex rwlock;
+    std::shared_timed_mutex rwlock;
 
     Poco::Logger * log;
 


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix UB by unlocking the rwlock of the TinyLog from the same thread

Detailed description / Documentation draft:
Before this patch the unbundled build with libstdc++ hangs for
00967_insert_into_distributed_different_types test (and I guess some
others), this is because the rwlock is acquired from different thread as
it was unlocked which causes UB [1], fix this by moving unlock into
writeSuffix().

```
  [1]: The pthread_rwlock_unlock() function shall release a lock held on
       the read-write lock object referenced by rwlock. Results are undefined
       if the read-write lock rwlock is not held by the **calling thread**.
```