### PR TITLE
Try flush write buffer only if it is initialized

### DIFF
--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -72,7 +72,8 @@ TCPHandler::~TCPHandler()
     try
     {
         state.reset();
-        out->next();
+        if (out)
+            out->next();
     }
     catch (...)
     {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Try flush write buffer only if it is initialized. Fixes segfault when client closes connection very early #22579.
