### PR TITLE
Fix trace log doc

### DIFF
--- a/docs/en/operations/system-tables/trace_log.md
+++ b/docs/en/operations/system-tables/trace_log.md
@@ -24,8 +24,8 @@ Columns:
 
     -   `Real` represents collecting stack traces by wall-clock time.
     -   `CPU` represents collecting stack traces by CPU time.
-    -   `Memory` represents collecting allocations and deallocations
-    -   `MemorySample` represents collecting random allocations and deallocations
+    -   `Memory` represents collecting allocations and deallocations.
+    -   `MemorySample` represents collecting random allocations and deallocations.
 
 -   `thread_number` ([UInt32](../../sql-reference/data-types/int-uint.md)) — Thread identifier.
 

--- a/docs/en/operations/system-tables/trace_log.md
+++ b/docs/en/operations/system-tables/trace_log.md
@@ -24,7 +24,7 @@ Columns:
 
     -   `Real` represents collecting stack traces by wall-clock time.
     -   `CPU` represents collecting stack traces by CPU time.
-    -   `Memory` represents collecting allocations and deallocations.
+    -   `Memory` represents collecting allocations and deallocations when memory allocation exceeds the subsequent watermark.
     -   `MemorySample` represents collecting random allocations and deallocations.
 
 -   `thread_number` ([UInt32](../../sql-reference/data-types/int-uint.md)) — Thread identifier.

--- a/docs/en/operations/system-tables/trace_log.md
+++ b/docs/en/operations/system-tables/trace_log.md
@@ -20,10 +20,12 @@ Columns:
 
     When connecting to the server by `clickhouse-client`, you see the string similar to `Connected to ClickHouse server version 19.18.1 revision 54429.`. This field contains the `revision`, but not the `version` of a server.
 
--   `timer_type` ([Enum8](../../sql-reference/data-types/enum.md)) — Timer type:
+-   `trace_type` ([Enum8](../../sql-reference/data-types/enum.md)) — Trace type:
 
-    -   `Real` represents wall-clock time.
-    -   `CPU` represents CPU time.
+    -   `Real` represents collecting stack traces by wall-clock time.
+    -   `CPU` represents collecting stack traces by CPU time.
+    -   `Memory` represents collecting allocations and deallocations
+    -   `MemorySample` represents collecting random allocations and deallocations
 
 -   `thread_number` ([UInt32](../../sql-reference/data-types/int-uint.md)) — Thread identifier.
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)

The docs about trace type in trace log system table have been obsolete. 
