### PR TITLE
Better retries on ZK errors in sh tests

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -406,7 +406,7 @@ def run_tests_array(all_tests_with_params):
                             status += stderr
                     else:
                         counter = 1
-                        while proc.returncode != 0 and need_retry(stderr):
+                        while need_retry(stderr):
                             proc, stdout, stderr, total_time = run_single_test(args, ext, server_logs_level, client_options, case_file, stdout_file, stderr_file, suite_tmp_dir)
                             sleep(2**counter)
                             counter += 1


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

See: https://clickhouse-test-reports.s3.yandex.net/22583/44abb7588a9c65a97d94c1429213738aa07bab41/functional_stateless_tests_(release,_databasereplicated)/test_run.txt.out.log