### PR TITLE
Improve usability of clickhouse-client

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -527,7 +527,10 @@ private:
         std::cerr << std::fixed << std::setprecision(3);
 
         if (is_interactive)
+        {
+            clearTerminal();
             showClientVersion();
+        }
 
         is_default_format = !config().has("vertical") && !config().has("format");
         if (config().has("vertical"))
@@ -2465,6 +2468,17 @@ private:
     static void showClientVersion()
     {
         std::cout << DBMS_NAME << " client version " << VERSION_STRING << VERSION_OFFICIAL << "." << std::endl;
+    }
+
+    static void clearTerminal()
+    {
+        /// Clear from cursor until end of screen.
+        /// It is needed if garbage is left in terminal.
+        /// Show cursor. It can be left hidden by invocation of previous programs.
+        /// A test for this feature: perl -e 'print "x"x100000'; echo -ne '\033[0;0H\033[?25l'; clickhouse-client
+        std::cout <<
+            "\033[0J"
+            "\033[?25h";
     }
 
 public:


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Clear the rest of the screen and show cursor in `clickhouse-client` if previous program has left garbage in terminal. This closes #16518.