### PR TITLE
Add retires for docker-compose pull in integration tests

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -635,9 +635,8 @@ class ClickHouseCluster:
         # Just in case kill unstopped containers from previous launch
         try:
             print("Trying to kill unstopped containers...")
-
-            if not subprocess_call(['docker-compose', 'kill']):
-                subprocess_call(['docker-compose', 'down', '--volumes'])
+            subprocess_call(['docker-compose', 'kill'])
+            subprocess_call(self.base_cmd + ['down', '--volumes', '--remove-orphans'])
             print("Unstopped containers killed")
         except:
             pass

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -661,14 +661,16 @@ class ClickHouseCluster:
                 print(('Setup directory for instance: {} destroy_dirs: {}'.format(instance.name, destroy_dirs)))
                 instance.create_dir(destroy_dir=destroy_dirs)
 
-            # Just in case kill unstopped containers from previous launch
-            try:
-                print("Trying to kill unstopped containers...")
-                subprocess_call(['docker-compose', 'kill'])
-                subprocess_call(self.base_cmd + ['down', '--volumes', '--remove-orphans'])
-                print("Unstopped containers killed")
-            except:
-                pass
+            # In case of multiple cluster we should not stop compose services.
+            if destroy_dirs:
+                # Just in case kill unstopped containers from previous launch
+                try:
+                    print("Trying to kill unstopped containers...")
+                    subprocess_call(['docker-compose', 'kill'])
+                    subprocess_call(self.base_cmd + ['down', '--volumes', '--remove-orphans'])
+                    print("Unstopped containers killed")
+                except:
+                    pass
 
             clickhouse_pull_cmd = self.base_cmd + ['pull']
             print(f"Pulling images for {self.base_cmd}")

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -652,19 +652,6 @@ class ClickHouseCluster:
         if self.is_up:
             return
 
-        # Just in case kill unstopped containers from previous launch
-        try:
-            print("Trying to kill unstopped containers...")
-            subprocess_call(['docker-compose', 'kill'])
-            subprocess_call(self.base_cmd + ['down', '--volumes', '--remove-orphans'])
-            print("Unstopped containers killed")
-        except:
-            pass
-
-        clickhouse_pull_cmd = self.base_cmd + ['pull']
-        print(f"Pulling images for {self.base_cmd}")
-        retry_exception(10, 5, subprocess_check_call, Exception, clickhouse_pull_cmd)
-
         try:
             if destroy_dirs and p.exists(self.instances_dir):
                 print(("Removing instances dir %s", self.instances_dir))
@@ -673,6 +660,19 @@ class ClickHouseCluster:
             for instance in list(self.instances.values()):
                 print(('Setup directory for instance: {} destroy_dirs: {}'.format(instance.name, destroy_dirs)))
                 instance.create_dir(destroy_dir=destroy_dirs)
+
+            # Just in case kill unstopped containers from previous launch
+            try:
+                print("Trying to kill unstopped containers...")
+                subprocess_call(['docker-compose', 'kill'])
+                subprocess_call(self.base_cmd + ['down', '--volumes', '--remove-orphans'])
+                print("Unstopped containers killed")
+            except:
+                pass
+
+            clickhouse_pull_cmd = self.base_cmd + ['pull']
+            print(f"Pulling images for {self.base_cmd}")
+            retry_exception(10, 5, subprocess_check_call, Exception, clickhouse_pull_cmd)
 
             self.docker_client = docker.from_env(version=self.docker_api_version)
 

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -641,6 +641,10 @@ class ClickHouseCluster:
         except:
             pass
 
+        clickhouse_start_cmd = self.base_cmd + ['pull', '--ignore-pull-failures']
+        print(f"Pulling images for {self.base_cmd}")
+        subprocess_check_call(clickhouse_start_cmd)
+
         try:
             if destroy_dirs and p.exists(self.instances_dir):
                 print(("Removing instances dir %s", self.instances_dir))

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -656,7 +656,7 @@ class ClickHouseCluster:
 
             self.docker_client = docker.from_env(version=self.docker_api_version)
 
-            common_opts = ['up', '-d', '--force-recreate']
+            common_opts = ['up', '-d']
 
             if self.with_zookeeper and self.base_zookeeper_cmd:
                 print('Setup ZooKeeper')
@@ -738,7 +738,7 @@ class ClickHouseCluster:
 
             if self.with_redis and self.base_redis_cmd:
                 print('Setup Redis')
-                subprocess_check_call(self.base_redis_cmd + ['up', '-d', '--force-recreate'])
+                subprocess_check_call(self.base_redis_cmd + ['up', '-d'])
                 time.sleep(10)
 
             if self.with_minio and self.base_minio_cmd:
@@ -772,7 +772,7 @@ class ClickHouseCluster:
                             os.environ.pop('SSL_CERT_FILE')
 
             if self.with_cassandra and self.base_cassandra_cmd:
-                subprocess_check_call(self.base_cassandra_cmd + ['up', '-d', '--force-recreate'])
+                subprocess_check_call(self.base_cassandra_cmd + ['up', '-d'])
                 self.wait_cassandra_to_start()
 
             clickhouse_start_cmd = self.base_cmd + ['up', '-d', '--no-recreate']


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add retires for docker-compose pull in integration tests

Detailed description / Documentation draft:
Recently integration tests stated to fail due to pull failures, let's try 10 retries with 5 second delay (50 seconds in total), in attempt to overcome this issue (another option is to try `--ignore-pull-failures` if there such image already in the local docker cache, but let's try w/o it first)

Cc: @filimonov 
Cc: @alexey-milovidov 
Cc: @qoega 