### PR TITLE
[RFC] Fix LOGICAL_ERROR for Log with nested types w/o columns in the SELECT clause

### DIFF
--- a/src/Interpreters/ExpressionActions.cpp
+++ b/src/Interpreters/ExpressionActions.cpp
@@ -522,6 +522,10 @@ std::string ExpressionActions::getSmallestColumn(const NamesAndTypesList & colum
 
     for (const auto & column : columns)
     {
+        /// Skip .sizeX and similar meta information
+        if (!column.getSubcolumnName().empty())
+            continue;
+
         /// @todo resolve evil constant
         size_t size = column.type->haveMaximumSizeOfValue() ? column.type->getMaximumSizeOfValueInMemory() : 100;
 

--- a/tests/queries/0_stateless/01800_log_nested.sql
+++ b/tests/queries/0_stateless/01800_log_nested.sql
@@ -1,0 +1,20 @@
+-- TinyTinyLog
+DROP TABLE IF EXISTS nested_01800_tiny_log;
+CREATE TABLE nested_01800_tiny_log (`column` Nested(name String, names Array(String), types Array(Enum8('PU' = 1, 'US' = 2, 'OTHER' = 3)))) ENGINE = TinyLog;
+INSERT INTO nested_01800_tiny_log VALUES (['Hello', 'World'], [['a'], ['b', 'c']], [['PU', 'US'], ['OTHER']]);
+SELECT 10 FROM nested_01800_tiny_log FORMAT Null;
+DROP TABLE nested_01800_tiny_log;
+
+-- StripeStripeLog
+DROP TABLE IF EXISTS nested_01800_stripe_log;
+CREATE TABLE nested_01800_stripe_log (`column` Nested(name String, names Array(String), types Array(Enum8('PU' = 1, 'US' = 2, 'OTHER' = 3)))) ENGINE = StripeLog;
+INSERT INTO nested_01800_stripe_log VALUES (['Hello', 'World'], [['a'], ['b', 'c']], [['PU', 'US'], ['OTHER']]);
+SELECT 10 FROM nested_01800_stripe_log FORMAT Null;
+DROP TABLE nested_01800_stripe_log;
+
+-- Log
+DROP TABLE IF EXISTS nested_01800_log;
+CREATE TABLE nested_01800_log (`column` Nested(name String, names Array(String), types Array(Enum8('PU' = 1, 'US' = 2, 'OTHER' = 3)))) ENGINE = Log;
+INSERT INTO nested_01800_log VALUES (['Hello', 'World'], [['a'], ['b', 'c']], [['PU', 'US'], ['OTHER']]);
+SELECT 10 FROM nested_01800_log FORMAT Null;
+DROP TABLE nested_01800_log;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix LOGICAL_ERROR for Log with nested types w/o columns in the SELECT clause

Detailed description / Documentation draft:
Found with fuzzer [1]:

<details>

    2021.04.04 10:25:46.762596 [ 135 ] {4b6b5de3-d242-4267-910a-76b235467356} <Fatal> : Logical error: 'Logical error: no information about file column%2Ename.size0 in StorageLog'.
    ...
    2021.04.04 10:25:46.763563 [ 44 ] {} <Trace> BaseDaemon: Received signal 6
    2021.04.04 10:25:46.765884 [ 165 ] {} <Fatal> BaseDaemon: 5. abort @ 0x25859 in /usr/lib/x86_64-linux-gnu/libc-2.31.so
    2021.04.04 10:25:46.901540 [ 165 ] {} <Fatal> BaseDaemon: 6. ./obj-x86_64-linux-gnu/../src/Common/Exception.cpp:51: DB::handle_error_code() @ 0x11cc4f16 in /workspace/clickhouse
    2021.04.04 10:25:47.030755 [ 165 ] {} <Fatal> BaseDaemon: 7. ./obj-x86_64-linux-gnu/../src/Common/Exception.cpp:58: DB::Exception::Exception() @ 0x11cc5025 in /workspace/clickhouse
    2021.04.04 10:25:47.617201 [ 165 ] {} <Fatal> BaseDaemon: 8. ./obj-x86_64-linux-gnu/../src/Storages/StorageLog.cpp:183: DB::LogSource::readData()

</details>

  [1]: https://clickhouse-test-reports.s3.yandex.net/22583/69296876005c0fa171c755f8b224e4d58192c402/fuzzer_debug/report.html#fail1

The problem here is that there is no column%2Ename.size0 there is
column.size0 instead, and it seems that reading sizeX file is not enough
in other places, so just filter them out in
ExpressionActions::getSmallestColumn() (fallback method for storages w/o
getColumnSizes() implemented)

Fixes: #21059