### PR TITLE
Fix impossible invalid-read for system.errors accounting

### DIFF
--- a/src/Common/ErrorCodes.cpp
+++ b/src/Common/ErrorCodes.cpp
@@ -590,7 +590,7 @@ namespace ErrorCodes
 
     void increment(ErrorCode error_code, bool remote, const std::string & message, const FramePointers & trace)
     {
-        if (error_code >= end())
+        if (error_code < 0 || error_code >= end())
         {
             /// For everything outside the range, use END.
             /// (end() is the pointer pass the end, while END is the last value that has an element in values array).


### PR DESCRIPTION
Simple reproducer is throw Exception(-1, "foo"), but there is no such
code, hence it is impossible.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)