### PR TITLE
Skip compiling xz if we're using system xz (unbundled)

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -47,7 +47,10 @@ add_subdirectory (lz4-cmake)
 add_subdirectory (murmurhash)
 add_subdirectory (replxx-cmake)
 add_subdirectory (unixodbc-cmake)
-add_subdirectory (xz)
+
+if (USE_INTERNAL_XZ_LIBRARY)
+    add_subdirectory (xz)
+endif()
 
 add_subdirectory (poco-cmake)
 add_subdirectory (croaring-cmake)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog

Detailed description / Documentation draft:
This was forgotten by me in #22571. With USE_INTERNAL_XZ_LIBRARY=OFF, it properly links with system XZ, but still wastes time compiling bundled xz. I tested the actual linking, but didn't test the shorter compile time.
Thank you.
...
