### PR TITLE
Experiment with ArrowStream streaming

### DIFF
--- a/src/Processors/Formats/Impl/ArrowBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ArrowBlockInputFormat.cpp
@@ -78,7 +78,7 @@ void ArrowBlockInputFormat::prepareReader()
 {
     if (stream)
     {
-        auto stream_reader_status = arrow::ipc::RecordBatchStreamReader::Open(asArrowInputStream(in));
+        auto stream_reader_status = arrow::ipc::RecordBatchStreamReader::Open(std::make_unique<ArrowInputStreamFromReadBuffer>(in));
         if (!stream_reader_status.ok())
             throw Exception(ErrorCodes::UNKNOWN_EXCEPTION,
                 "Error while opening a table: {}", stream_reader_status.status().ToString());

--- a/src/Processors/Formats/Impl/ArrowBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ArrowBlockInputFormat.cpp
@@ -78,7 +78,7 @@ void ArrowBlockInputFormat::prepareReader()
 {
     if (stream)
     {
-        auto stream_reader_status = arrow::ipc::RecordBatchStreamReader::Open(asArrowFile(in));
+        auto stream_reader_status = arrow::ipc::RecordBatchStreamReader::Open(asArrowInputStream(in));
         if (!stream_reader_status.ok())
             throw Exception(ErrorCodes::UNKNOWN_EXCEPTION,
                 "Error while opening a table: {}", stream_reader_status.status().ToString());

--- a/src/Processors/Formats/Impl/ArrowBufferedStreams.h
+++ b/src/Processors/Formats/Impl/ArrowBufferedStreams.h
@@ -61,25 +61,25 @@ private:
     ARROW_DISALLOW_COPY_AND_ASSIGN(RandomAccessFileFromSeekableReadBuffer);
 };
 
-class ArrowInputStream : public arrow::io::InputStream
+class ArrowInputStreamFromReadBuffer : public arrow::io::InputStream
 {
 public:
-    explicit ArrowInputStream(ReadBuffer & in);
+    explicit ArrowInputStreamFromReadBuffer(ReadBuffer & in);
     arrow::Result<int64_t> Read(int64_t nbytes, void* out) override;
     arrow::Result<std::shared_ptr<arrow::Buffer>> Read(int64_t nbytes) override;
     arrow::Status Abort() override;
     arrow::Result<int64_t> Tell() const override;
     arrow::Status Close() override;
-    bool closed() const override;
+    bool closed() const override { return !is_open; }
 
 private:
     ReadBuffer & in;
+    bool is_open = false;
 
-    ARROW_DISALLOW_COPY_AND_ASSIGN(ArrowInputStream);
+    ARROW_DISALLOW_COPY_AND_ASSIGN(ArrowInputStreamFromReadBuffer);
 };
 
 std::shared_ptr<arrow::io::RandomAccessFile> asArrowFile(ReadBuffer & in);
-std::shared_ptr<arrow::io::InputStream> asArrowInputStream(ReadBuffer & in);
 
 }
 

--- a/src/Processors/Formats/Impl/ArrowBufferedStreams.h
+++ b/src/Processors/Formats/Impl/ArrowBufferedStreams.h
@@ -61,7 +61,25 @@ private:
     ARROW_DISALLOW_COPY_AND_ASSIGN(RandomAccessFileFromSeekableReadBuffer);
 };
 
+class ArrowInputStream : public arrow::io::InputStream
+{
+public:
+    explicit ArrowInputStream(ReadBuffer & in);
+    arrow::Result<int64_t> Read(int64_t nbytes, void* out) override;
+    arrow::Result<std::shared_ptr<arrow::Buffer>> Read(int64_t nbytes) override;
+    arrow::Status Abort() override;
+    arrow::Result<int64_t> Tell() const override;
+    arrow::Status Close() override;
+    bool closed() const override;
+
+private:
+    ReadBuffer & in;
+
+    ARROW_DISALLOW_COPY_AND_ASSIGN(ArrowInputStream);
+};
+
 std::shared_ptr<arrow::io::RandomAccessFile> asArrowFile(ReadBuffer & in);
+std::shared_ptr<arrow::io::InputStream> asArrowInputStream(ReadBuffer & in);
 
 }
 


### PR DESCRIPTION
POC for fixing ArrowStream reading when source is not a local file.

Before:

```
ninja clickhouse-local && programs/clickhouse-local -q "SELECT count(), min(number), max(number) FROM url('http://127.0.0.1:3000/inf', "ArrowStream", 'number UInt64') FORMAT JSON" --logger.level trace
<Information> executeQuery: Read 100000000 rows, 762.94 MiB in 9.683175 sec., 10327191 rows/sec., 78.79 MiB/sec.
**<Debug> MemoryTracker: Peak memory usage (for query): 2.25 Gi**
```

After:

```
<Information> executeQuery: Read 100000000 rows, 762.94 MiB in 6.701079 sec., 14922969 rows/sec., 113.85 MiB/sec.
**<Debug> MemoryTracker: Peak memory usage (for query): 4.59 MiB.**
```

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve performance of reading from `ArrowStream` input format for sources other then local file (e.g. URL). 
