### PR TITLE
Always call event.set for zk client callbacks.

### DIFF
--- a/src/Common/ZooKeeper/ZooKeeper.cpp
+++ b/src/Common/ZooKeeper/ZooKeeper.cpp
@@ -243,6 +243,7 @@ Coordination::Error ZooKeeper::getChildrenImpl(const std::string & path, Strings
 
     auto callback = [&](const Coordination::ListResponse & response)
     {
+        SCOPE_EXIT(event.set());
         code = response.error;
         if (code == Coordination::Error::ZOK)
         {
@@ -250,7 +251,6 @@ Coordination::Error ZooKeeper::getChildrenImpl(const std::string & path, Strings
             if (stat)
                 *stat = response.stat;
         }
-        event.set();
     };
 
     impl->list(path, callback, watch_callback);
@@ -303,10 +303,10 @@ Coordination::Error ZooKeeper::createImpl(const std::string & path, const std::s
 
     auto callback = [&](const Coordination::CreateResponse & response)
     {
+        SCOPE_EXIT(event.set());
         code = response.error;
         if (code == Coordination::Error::ZOK)
             path_created = response.path_created;
-        event.set();
     };
 
     impl->create(path, data, mode & 1, mode & 2, {}, callback);  /// TODO better mode
@@ -371,9 +371,9 @@ Coordination::Error ZooKeeper::removeImpl(const std::string & path, int32_t vers
 
     auto callback = [&](const Coordination::RemoveResponse & response)
     {
+        SCOPE_EXIT(event.set());
         if (response.error != Coordination::Error::ZOK)
             code = response.error;
-        event.set();
     };
 
     impl->remove(path, version, callback);
@@ -404,10 +404,10 @@ Coordination::Error ZooKeeper::existsImpl(const std::string & path, Coordination
 
     auto callback = [&](const Coordination::ExistsResponse & response)
     {
+        SCOPE_EXIT(event.set());
         code = response.error;
         if (code == Coordination::Error::ZOK && stat)
             *stat = response.stat;
-        event.set();
     };
 
     impl->exists(path, callback, watch_callback);
@@ -436,6 +436,7 @@ Coordination::Error ZooKeeper::getImpl(const std::string & path, std::string & r
 
     auto callback = [&](const Coordination::GetResponse & response)
     {
+        SCOPE_EXIT(event.set());
         code = response.error;
         if (code == Coordination::Error::ZOK)
         {
@@ -443,7 +444,6 @@ Coordination::Error ZooKeeper::getImpl(const std::string & path, std::string & r
             if (stat)
                 *stat = response.stat;
         }
-        event.set();
     };
 
     impl->get(path, callback, watch_callback);
@@ -508,10 +508,10 @@ Coordination::Error ZooKeeper::setImpl(const std::string & path, const std::stri
 
     auto callback = [&](const Coordination::SetResponse & response)
     {
+        SCOPE_EXIT(event.set());
         code = response.error;
         if (code == Coordination::Error::ZOK && stat)
             *stat = response.stat;
-        event.set();
     };
 
     impl->set(path, data, version, callback);
@@ -558,9 +558,9 @@ Coordination::Error ZooKeeper::multiImpl(const Coordination::Requests & requests
 
     auto callback = [&](const Coordination::MultiResponse & response)
     {
+        SCOPE_EXIT(event.set());
         code = response.error;
         responses = response.responses;
-        event.set();
     };
 
     impl->multi(requests, callback);

--- a/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -796,8 +796,17 @@ void ZooKeeper::receiveEvent()
         /// In case we cannot read the response, we should indicate it as the error of that type
         ///  when the user cannot assume whether the request was processed or not.
         response->error = Error::ZCONNECTIONLOSS;
-        if (request_info.callback)
-            request_info.callback(*response);
+
+        try
+        {
+            if (request_info.callback)
+                request_info.callback(*response);
+        }
+        catch (...)
+        {
+            /// Throw initial exception, not exception from callback.
+            tryLogCurrentException(__PRETTY_FUNCTION__);
+        }
 
         throw;
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible hangs in zk requests in case of OOM exception. Fixes #22438
