### PR TITLE
Add MySQL read history data bytes judgment

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -445,8 +445,8 @@ class IColumn;
     M(Bool, database_replicated_always_detach_permanently, false, "Execute DETACH TABLE as DETACH TABLE PERMANENTLY if database engine is Replicated", 0) \
     M(DistributedDDLOutputMode, distributed_ddl_output_mode, DistributedDDLOutputMode::THROW, "Format of distributed DDL query result", 0) \
     M(UInt64, distributed_ddl_entry_format_version, 1, "Version of DDL entry to write into ZooKeeper", 0) \
-    M(UInt64, max_read_mysql_rows, DEFAULT_BLOCK_SIZE, "Limit maximum rows when MaterializeMySQL flush history data. 0 -> Disable it.", 0) \
-    M(UInt64, max_read_mysql_bytes, (DEFAULT_INSERT_BLOCK_SIZE * 256), "Limit maximum bytes when MaterializeMySQL flush history data. 0 -> Disable it.", 0)  \
+    M(UInt64, max_read_mysql_rows, DEFAULT_BLOCK_SIZE, "Limit maximum number of rows when MaterializeMySQL should flush history data. If equal to 0, this setting is disabled", 0) \
+    M(UInt64, max_read_mysql_bytes, (DEFAULT_INSERT_BLOCK_SIZE * 256), "Limit maximum number of bytes when MaterializeMySQL should flush history data. If equal to 0, this setting is disabled", 0)  \
     \
     /** Obsolete settings that do nothing but left for compatibility reasons. Remove each one after half a year of obsolescence. */ \
     \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -445,6 +445,8 @@ class IColumn;
     M(Bool, database_replicated_always_detach_permanently, false, "Execute DETACH TABLE as DETACH TABLE PERMANENTLY if database engine is Replicated", 0) \
     M(DistributedDDLOutputMode, distributed_ddl_output_mode, DistributedDDLOutputMode::THROW, "Format of distributed DDL query result", 0) \
     M(UInt64, distributed_ddl_entry_format_version, 1, "Version of DDL entry to write into ZooKeeper", 0) \
+    M(UInt64, max_read_mysql_rows, DEFAULT_BLOCK_SIZE, "Limit maximum rows when MaterializeMySQL flush history data. 0 -> Disable it.", 0) \
+    M(UInt64, max_read_mysql_bytes, (DEFAULT_INSERT_BLOCK_SIZE * 256), "Limit maximum bytes when MaterializeMySQL flush history data. 0 -> Disable it.", 0)  \
     \
     /** Obsolete settings that do nothing but left for compatibility reasons. Remove each one after half a year of obsolescence. */ \
     \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -445,8 +445,8 @@ class IColumn;
     M(Bool, database_replicated_always_detach_permanently, false, "Execute DETACH TABLE as DETACH TABLE PERMANENTLY if database engine is Replicated", 0) \
     M(DistributedDDLOutputMode, distributed_ddl_output_mode, DistributedDDLOutputMode::THROW, "Format of distributed DDL query result", 0) \
     M(UInt64, distributed_ddl_entry_format_version, 1, "Version of DDL entry to write into ZooKeeper", 0) \
-    M(UInt64, max_read_mysql_rows, DEFAULT_BLOCK_SIZE, "Limit maximum number of rows when MaterializeMySQL should flush history data. If equal to 0, this setting is disabled", 0) \
-    M(UInt64, max_read_mysql_bytes, (DEFAULT_INSERT_BLOCK_SIZE * 256), "Limit maximum number of bytes when MaterializeMySQL should flush history data. If equal to 0, this setting is disabled", 0)  \
+    M(UInt64, external_storage_max_read_rows, 0, "Limit maximum number of rows when MaterializeMySQL should flush history data. If equal to 0, this setting is disabled", 0) \
+    M(UInt64, external_storage_max_read_bytes, (DEFAULT_INSERT_BLOCK_SIZE * 256), "Limit maximum number of bytes when MaterializeMySQL should flush history data. If equal to 0, this setting is disabled", 0)  \
     \
     /** Obsolete settings that do nothing but left for compatibility reasons. Remove each one after half a year of obsolescence. */ \
     \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -445,8 +445,8 @@ class IColumn;
     M(Bool, database_replicated_always_detach_permanently, false, "Execute DETACH TABLE as DETACH TABLE PERMANENTLY if database engine is Replicated", 0) \
     M(DistributedDDLOutputMode, distributed_ddl_output_mode, DistributedDDLOutputMode::THROW, "Format of distributed DDL query result", 0) \
     M(UInt64, distributed_ddl_entry_format_version, 1, "Version of DDL entry to write into ZooKeeper", 0) \
-    M(UInt64, external_storage_max_read_rows, 0, "Limit maximum number of rows when MaterializeMySQL should flush history data. If equal to 0, this setting is disabled", 0) \
-    M(UInt64, external_storage_max_read_bytes, (DEFAULT_INSERT_BLOCK_SIZE * 256), "Limit maximum number of bytes when MaterializeMySQL should flush history data. If equal to 0, this setting is disabled", 0)  \
+    M(UInt64, external_storage_max_read_rows, 0, "Limit maximum number of rows when table with external engine should flush history data. Now supported only for MySQL table engine, database engine, dictionary and MaterializeMySQL. If equal to 0, this setting is disabled", 0) \
+    M(UInt64, external_storage_max_read_bytes, 0, "Limit maximum number of bytes when table with external engine should flush history data. Now supported only for MySQL table engine, database engine, dictionary and MaterializeMySQL. If equal to 0, this setting is disabled", 0)  \
     \
     /** Obsolete settings that do nothing but left for compatibility reasons. Remove each one after half a year of obsolescence. */ \
     \

--- a/src/Databases/MySQL/DatabaseConnectionMySQL.h
+++ b/src/Databases/MySQL/DatabaseConnectionMySQL.h
@@ -108,7 +108,7 @@ private:
 
     void fetchTablesIntoLocalCache(ContextPtr context) const;
 
-    std::map<String, UInt64> fetchTablesWithModificationTime() const;
+    std::map<String, UInt64> fetchTablesWithModificationTime(ContextPtr local_context) const;
 
     std::map<String, NamesAndTypesList> fetchTablesColumnsList(const std::vector<String> & tables_name, ContextPtr context) const;
 

--- a/src/Databases/MySQL/FetchTablesColumnsList.h
+++ b/src/Databases/MySQL/FetchTablesColumnsList.h
@@ -12,6 +12,7 @@
 
 #include <map>
 #include <vector>
+#include <Core/Settings.h>
 
 namespace DB
 {
@@ -20,7 +21,7 @@ std::map<String, NamesAndTypesList> fetchTablesColumnsList(
         mysqlxx::PoolWithFailover & pool,
         const String & database_name,
         const std::vector<String> & tables_name,
-        bool external_table_functions_use_nulls,
+        const Settings & settings,
         MultiEnum<MySQLDataTypesSupport> type_support);
 
 }

--- a/src/Databases/MySQL/MaterializeMetadata.cpp
+++ b/src/Databases/MySQL/MaterializeMetadata.cpp
@@ -24,7 +24,8 @@ namespace ErrorCodes
 }
 
 static std::unordered_map<String, String> fetchTablesCreateQuery(
-    const mysqlxx::PoolWithFailover::Entry & connection, const String & database_name, const std::vector<String> & fetch_tables)
+    const mysqlxx::PoolWithFailover::Entry & connection, const String & database_name,
+    const std::vector<String> & fetch_tables, const Settings & global_settings)
 {
     std::unordered_map<String, String> tables_create_query;
     for (const auto & fetch_table_name : fetch_tables)
@@ -34,9 +35,10 @@ static std::unordered_map<String, String> fetchTablesCreateQuery(
             {std::make_shared<DataTypeString>(), "Create Table"},
         };
 
+        StreamSettings mysql_input_stream_settings(global_settings, false, true);
         MySQLBlockInputStream show_create_table(
             connection, "SHOW CREATE TABLE " + backQuoteIfNeed(database_name) + "." + backQuoteIfNeed(fetch_table_name),
-            show_create_table_header, DEFAULT_BLOCK_SIZE, false, true);
+            show_create_table_header, mysql_input_stream_settings);
 
         Block create_query_block = show_create_table.read();
         if (!create_query_block || create_query_block.rows() != 1)
@@ -49,13 +51,14 @@ static std::unordered_map<String, String> fetchTablesCreateQuery(
 }
 
 
-static std::vector<String> fetchTablesInDB(const mysqlxx::PoolWithFailover::Entry & connection, const std::string & database)
+static std::vector<String> fetchTablesInDB(const mysqlxx::PoolWithFailover::Entry & connection, const std::string & database, const Settings & global_settings)
 {
     Block header{{std::make_shared<DataTypeString>(), "table_name"}};
     String query = "SELECT TABLE_NAME AS table_name FROM INFORMATION_SCHEMA.TABLES  WHERE TABLE_TYPE != 'VIEW' AND TABLE_SCHEMA = " + quoteString(database);
 
     std::vector<String> tables_in_db;
-    MySQLBlockInputStream input(connection, query, header, DEFAULT_BLOCK_SIZE);
+    StreamSettings mysql_input_stream_settings(global_settings);
+    MySQLBlockInputStream input(connection, query, header, mysql_input_stream_settings);
 
     while (Block block = input.read())
     {
@@ -77,7 +80,8 @@ void MaterializeMetadata::fetchMasterStatus(mysqlxx::PoolWithFailover::Entry & c
         {std::make_shared<DataTypeString>(), "Executed_Gtid_Set"},
     };
 
-    MySQLBlockInputStream input(connection, "SHOW MASTER STATUS;", header, DEFAULT_BLOCK_SIZE, false, true);
+    StreamSettings mysql_input_stream_settings(settings, false, true);
+    MySQLBlockInputStream input(connection, "SHOW MASTER STATUS;", header, mysql_input_stream_settings);
     Block master_status = input.read();
 
     if (!master_status || master_status.rows() != 1)
@@ -99,7 +103,8 @@ void MaterializeMetadata::fetchMasterVariablesValue(const mysqlxx::PoolWithFailo
     };
 
     const String & fetch_query = "SHOW VARIABLES WHERE Variable_name = 'binlog_checksum'";
-    MySQLBlockInputStream variables_input(connection, fetch_query, variables_header, DEFAULT_BLOCK_SIZE, false, true);
+    StreamSettings mysql_input_stream_settings(settings, false, true);
+    MySQLBlockInputStream variables_input(connection, fetch_query, variables_header, mysql_input_stream_settings);
 
     while (Block variables_block = variables_input.read())
     {
@@ -114,7 +119,7 @@ void MaterializeMetadata::fetchMasterVariablesValue(const mysqlxx::PoolWithFailo
     }
 }
 
-static bool checkSyncUserPrivImpl(const mysqlxx::PoolWithFailover::Entry & connection, WriteBuffer & out)
+static bool checkSyncUserPrivImpl(const mysqlxx::PoolWithFailover::Entry & connection, const Settings & global_settings, WriteBuffer & out)
 {
     Block sync_user_privs_header
     {
@@ -122,7 +127,8 @@ static bool checkSyncUserPrivImpl(const mysqlxx::PoolWithFailover::Entry & conne
     };
 
     String grants_query, sub_privs;
-    MySQLBlockInputStream input(connection, "SHOW GRANTS FOR CURRENT_USER();", sync_user_privs_header, DEFAULT_BLOCK_SIZE);
+    StreamSettings mysql_input_stream_settings(global_settings);
+    MySQLBlockInputStream input(connection, "SHOW GRANTS FOR CURRENT_USER();", sync_user_privs_header, mysql_input_stream_settings);
     while (Block block = input.read())
     {
         for (size_t index = 0; index < block.rows(); ++index)
@@ -146,11 +152,11 @@ static bool checkSyncUserPrivImpl(const mysqlxx::PoolWithFailover::Entry & conne
     return false;
 }
 
-static void checkSyncUserPriv(const mysqlxx::PoolWithFailover::Entry & connection)
+static void checkSyncUserPriv(const mysqlxx::PoolWithFailover::Entry & connection, const Settings & global_settings)
 {
     WriteBufferFromOwnString out;
 
-    if (!checkSyncUserPrivImpl(connection, out))
+    if (!checkSyncUserPrivImpl(connection, global_settings, out))
         throw Exception("MySQL SYNC USER ACCESS ERR: mysql sync user needs "
                         "at least GLOBAL PRIVILEGES:'RELOAD, REPLICATION SLAVE, REPLICATION CLIENT' "
                         "and SELECT PRIVILEGE on MySQL Database."
@@ -167,7 +173,8 @@ bool MaterializeMetadata::checkBinlogFileExists(const mysqlxx::PoolWithFailover:
         {std::make_shared<DataTypeUInt64>(), "File_size"}
     };
 
-    MySQLBlockInputStream input(connection, "SHOW MASTER LOGS", logs_header, DEFAULT_BLOCK_SIZE, false, true);
+    StreamSettings mysql_input_stream_settings(settings, false, true);
+    MySQLBlockInputStream input(connection, "SHOW MASTER LOGS", logs_header, mysql_input_stream_settings);
 
     while (Block block = input.read())
     {
@@ -222,7 +229,7 @@ void MaterializeMetadata::transaction(const MySQLReplication::Position & positio
     commitMetadata(std::move(fun), persistent_tmp_path, persistent_path);
 }
 
-MaterializeMetadata::MaterializeMetadata(const String & path_) : persistent_path(path_)
+MaterializeMetadata::MaterializeMetadata(const String & path_, const Settings & settings_) : persistent_path(path_), settings(settings_)
 {
     if (Poco::File(persistent_path).exists())
     {
@@ -244,7 +251,7 @@ void MaterializeMetadata::startReplication(
     mysqlxx::PoolWithFailover::Entry & connection, const String & database,
     bool & opened_transaction, std::unordered_map<String, String> & need_dumping_tables)
 {
-    checkSyncUserPriv(connection);
+    checkSyncUserPriv(connection, settings);
 
     if (checkBinlogFileExists(connection))
       return;
@@ -263,7 +270,7 @@ void MaterializeMetadata::startReplication(
         connection->query("START TRANSACTION /*!40100 WITH CONSISTENT SNAPSHOT */;").execute();
 
         opened_transaction = true;
-        need_dumping_tables = fetchTablesCreateQuery(connection, database, fetchTablesInDB(connection, database));
+        need_dumping_tables = fetchTablesCreateQuery(connection, database, fetchTablesInDB(connection, database, settings), settings);
         connection->query("UNLOCK TABLES;").execute();
     }
     catch (...)

--- a/src/Databases/MySQL/MaterializeMetadata.h
+++ b/src/Databases/MySQL/MaterializeMetadata.h
@@ -10,6 +10,7 @@
 #include <Core/MySQL/MySQLReplication.h>
 #include <mysqlxx/Connection.h>
 #include <mysqlxx/PoolWithFailover.h>
+#include <Interpreters/Context.h>
 
 namespace DB
 {
@@ -25,6 +26,7 @@ namespace DB
 struct MaterializeMetadata
 {
     const String persistent_path;
+    const Settings settings;
 
     String binlog_file;
     UInt64 binlog_position;
@@ -50,7 +52,7 @@ struct MaterializeMetadata
         bool & opened_transaction,
         std::unordered_map<String, String> & need_dumping_tables);
 
-    MaterializeMetadata(const String & path_);
+    MaterializeMetadata(const String & path_, const Settings & settings_);
 };
 
 }

--- a/src/Dictionaries/MySQLDictionarySource.cpp
+++ b/src/Dictionaries/MySQLDictionarySource.cpp
@@ -4,9 +4,15 @@
 #include "DictionarySourceFactory.h"
 #include "DictionaryStructure.h"
 #include "registerDictionaries.h"
+#include <Core/Settings.h>
+#include <Interpreters/Context.h>
 
 namespace DB
 {
+
+[[maybe_unused]]
+static const size_t default_num_tries_on_connection_loss = 3;
+
 namespace ErrorCodes
 {
     extern const int SUPPORT_IS_DISABLED;
@@ -14,20 +20,20 @@ namespace ErrorCodes
 
 void registerDictionarySourceMysql(DictionarySourceFactory & factory)
 {
-    auto create_table_source = [=](const DictionaryStructure & dict_struct,
-                                 const Poco::Util::AbstractConfiguration & config,
-                                 const std::string & config_prefix,
-                                 Block & sample_block,
-                                 ContextPtr /* context */,
+    auto create_table_source = [=]([[maybe_unused]] const DictionaryStructure & dict_struct,
+                                   [[maybe_unused]] const Poco::Util::AbstractConfiguration & config,
+                                   [[maybe_unused]] const std::string & config_prefix,
+                                   [[maybe_unused]] Block & sample_block,
+                                   [[maybe_unused]] ContextPtr context,
                                  const std::string & /* default_database */,
                                  bool /* check_config */) -> DictionarySourcePtr {
 #if USE_MYSQL
-        return std::make_unique<MySQLDictionarySource>(dict_struct, config, config_prefix + ".mysql", sample_block);
+        StreamSettings mysql_input_stream_settings(context->getSettingsRef()
+            , config.getBool(config_prefix + ".mysql.close_connection", false) || config.getBool(config_prefix + ".mysql.share_connection", false)
+            , false
+            , config.getBool(config_prefix + ".mysql.fail_on_connection_loss", false) ? 1 : default_num_tries_on_connection_loss);
+        return std::make_unique<MySQLDictionarySource>(dict_struct, config, config_prefix + ".mysql", sample_block, mysql_input_stream_settings);
 #else
-        (void)dict_struct;
-        (void)config;
-        (void)config_prefix;
-        (void)sample_block;
         throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
             "Dictionary source of type `mysql` is disabled because ClickHouse was built without mysql support.");
 #endif
@@ -45,22 +51,21 @@ void registerDictionarySourceMysql(DictionarySourceFactory & factory)
 #    include <IO/WriteHelpers.h>
 #    include <common/LocalDateTime.h>
 #    include <common/logger_useful.h>
-#    include <Formats/MySQLBlockInputStream.h>
 #    include "readInvalidateQuery.h"
 #    include <mysqlxx/Exception.h>
 #    include <mysqlxx/PoolFactory.h>
+#    include <Core/Settings.h>
 
 namespace DB
 {
-static const UInt64 max_block_size = 8192;
-static const size_t default_num_tries_on_connection_loss = 3;
 
 
 MySQLDictionarySource::MySQLDictionarySource(
     const DictionaryStructure & dict_struct_,
     const Poco::Util::AbstractConfiguration & config,
     const std::string & config_prefix,
-    const Block & sample_block_)
+    const Block & sample_block_,
+    const StreamSettings & settings_)
     : log(&Poco::Logger::get("MySQLDictionarySource"))
     , update_time{std::chrono::system_clock::from_time_t(0)}
     , dict_struct{dict_struct_}
@@ -74,10 +79,7 @@ MySQLDictionarySource::MySQLDictionarySource(
     , query_builder{dict_struct, db, "", table, where, IdentifierQuotingStyle::Backticks}
     , load_all_query{query_builder.composeLoadAllQuery()}
     , invalidate_query{config.getString(config_prefix + ".invalidate_query", "")}
-    , close_connection(
-            config.getBool(config_prefix + ".close_connection", false) || config.getBool(config_prefix + ".share_connection", false))
-    , max_tries_for_mysql_block_input_stream(
-            config.getBool(config_prefix + ".fail_on_connection_loss", false) ? 1 : default_num_tries_on_connection_loss)
+    , settings(settings_)
 {
 }
 
@@ -98,8 +100,7 @@ MySQLDictionarySource::MySQLDictionarySource(const MySQLDictionarySource & other
     , last_modification{other.last_modification}
     , invalidate_query{other.invalidate_query}
     , invalidate_query_response{other.invalidate_query_response}
-    , close_connection{other.close_connection}
-    , max_tries_for_mysql_block_input_stream{other.max_tries_for_mysql_block_input_stream}
+    , settings(other.settings)
 {
 }
 
@@ -122,7 +123,7 @@ std::string MySQLDictionarySource::getUpdateFieldAndDate()
 BlockInputStreamPtr MySQLDictionarySource::loadFromQuery(const String & query)
 {
     return std::make_shared<MySQLWithFailoverBlockInputStream>(
-            pool, query, sample_block, max_block_size, close_connection, false, max_tries_for_mysql_block_input_stream);
+            pool, query, sample_block, settings);
 }
 
 BlockInputStreamPtr MySQLDictionarySource::loadAll()
@@ -245,7 +246,7 @@ LocalDateTime MySQLDictionarySource::getLastModification(mysqlxx::Pool::Entry & 
                 ++fetched_rows;
         }
 
-        if (close_connection && allow_connection_closure)
+        if (settings.auto_close && allow_connection_closure)
         {
             connection.disconnect();
         }
@@ -269,7 +270,7 @@ std::string MySQLDictionarySource::doInvalidateQuery(const std::string & request
     Block invalidate_sample_block;
     ColumnPtr column(ColumnString::create());
     invalidate_sample_block.insert(ColumnWithTypeAndName(column, std::make_shared<DataTypeString>(), "Sample Block"));
-    MySQLBlockInputStream block_input_stream(pool->get(), request, invalidate_sample_block, 1, close_connection);
+    MySQLBlockInputStream block_input_stream(pool->get(), request, invalidate_sample_block, settings);
     return readInvalidateQuery(block_input_stream);
 }
 

--- a/src/Dictionaries/MySQLDictionarySource.h
+++ b/src/Dictionaries/MySQLDictionarySource.h
@@ -12,7 +12,7 @@
 #    include "DictionaryStructure.h"
 #    include "ExternalQueryBuilder.h"
 #    include "IDictionarySource.h"
-
+#    include <Formats/MySQLBlockInputStream.h>
 
 namespace Poco
 {
@@ -35,7 +35,8 @@ public:
         const DictionaryStructure & dict_struct_,
         const Poco::Util::AbstractConfiguration & config,
         const String & config_prefix,
-        const Block & sample_block_);
+        const Block & sample_block_,
+        const StreamSettings & settings_);
 
     /// copy-constructor is provided in order to support cloneability
     MySQLDictionarySource(const MySQLDictionarySource & other);
@@ -87,8 +88,7 @@ private:
     LocalDateTime last_modification;
     std::string invalidate_query;
     mutable std::string invalidate_query_response;
-    const bool close_connection;
-    const size_t max_tries_for_mysql_block_input_stream;
+    const StreamSettings settings;
 };
 
 }

--- a/src/Formats/MySQLBlockInputStream.cpp
+++ b/src/Formats/MySQLBlockInputStream.cpp
@@ -31,7 +31,7 @@ namespace ErrorCodes
 }
 
 StreamSettings::StreamSettings(const Settings & settings, bool auto_close_, bool fetch_by_name_, size_t max_retry_)
-    : max_read_mysql_row_nums(settings.external_storage_max_read_rows)
+    : max_read_mysql_row_nums((settings.external_storage_max_read_rows) ? settings.external_storage_max_read_rows : settings.max_block_size)
     , max_read_mysql_bytes_size(settings.external_storage_max_read_bytes)
     , auto_close(auto_close_)
     , fetch_by_name(fetch_by_name_)

--- a/src/Formats/MySQLBlockInputStream.cpp
+++ b/src/Formats/MySQLBlockInputStream.cpp
@@ -30,6 +30,29 @@ namespace ErrorCodes
     extern const int NOT_IMPLEMENTED;
 }
 
+StreamSettings::StreamSettings(const Settings & settings)
+{
+    max_read_mysql_rows = settings.max_read_mysql_rows;
+    max_read_bytes_size = settings.max_read_mysql_bytes;
+}
+
+StreamSettings::StreamSettings(const Settings & settings, bool auto_close_, bool fetch_by_name_)
+        : auto_close(auto_close_)
+        , fetch_by_name(fetch_by_name_)
+{
+    max_read_mysql_rows = settings.max_read_mysql_rows;
+    max_read_bytes_size = settings.max_read_mysql_bytes;
+}
+
+StreamSettings::StreamSettings(const Settings & settings, bool auto_close_, bool fetch_by_name_, size_t max_retry_)
+    : auto_close(auto_close_)
+    , fetch_by_name(fetch_by_name_)
+    , default_num_tries_on_connection_loss(max_retry_)
+{
+    max_read_mysql_rows = settings.max_read_mysql_rows;
+    max_read_bytes_size = settings.max_read_mysql_bytes;
+}
+
 MySQLBlockInputStream::Connection::Connection(
     const mysqlxx::PoolWithFailover::Entry & entry_,
     const std::string & query_str)
@@ -44,29 +67,19 @@ MySQLBlockInputStream::MySQLBlockInputStream(
     const mysqlxx::PoolWithFailover::Entry & entry,
     const std::string & query_str,
     const Block & sample_block,
-    const UInt64 max_block_size_,
-    const bool auto_close_,
-    const bool fetch_by_name_)
+    const StreamSettings & settings_)
     : log(&Poco::Logger::get("MySQLBlockInputStream"))
     , connection{std::make_unique<Connection>(entry, query_str)}
-    , max_block_size{max_block_size_}
-    , auto_close{auto_close_}
-    , fetch_by_name(fetch_by_name_)
+    , settings{std::make_unique<StreamSettings>(settings_)}
 {
     description.init(sample_block);
     initPositionMappingFromQueryResultStructure();
 }
 
 /// For descendant MySQLWithFailoverBlockInputStream
-MySQLBlockInputStream::MySQLBlockInputStream(
-    const Block & sample_block_,
-    UInt64 max_block_size_,
-    bool auto_close_,
-    bool fetch_by_name_)
+    MySQLBlockInputStream::MySQLBlockInputStream(const Block &sample_block_, const StreamSettings & settings_)
     : log(&Poco::Logger::get("MySQLBlockInputStream"))
-    , max_block_size(max_block_size_)
-    , auto_close(auto_close_)
-    , fetch_by_name(fetch_by_name_)
+    , settings(std::make_unique<StreamSettings>(settings_))
 {
     description.init(sample_block_);
 }
@@ -76,14 +89,10 @@ MySQLWithFailoverBlockInputStream::MySQLWithFailoverBlockInputStream(
     mysqlxx::PoolWithFailoverPtr pool_,
     const std::string & query_str_,
     const Block & sample_block_,
-    const UInt64 max_block_size_,
-    const bool auto_close_,
-    const bool fetch_by_name_,
-    const size_t max_tries_)
-    : MySQLBlockInputStream(sample_block_, max_block_size_, auto_close_, fetch_by_name_)
-    , pool(pool_)
-    , query_str(query_str_)
-    , max_tries(max_tries_)
+    const StreamSettings & settings_)
+: MySQLBlockInputStream(sample_block_, settings_)
+, pool(pool_)
+, query_str(query_str_)
 {
 }
 
@@ -101,12 +110,12 @@ void MySQLWithFailoverBlockInputStream::readPrefix()
         }
         catch (const mysqlxx::ConnectionLost & ecl)  /// There are two retriable failures: CR_SERVER_GONE_ERROR, CR_SERVER_LOST
         {
-            LOG_WARNING(log, "Failed connection ({}/{}). Trying to reconnect... (Info: {})", count_connect_attempts, max_tries, ecl.displayText());
+            LOG_WARNING(log, "Failed connection ({}/{}). Trying to reconnect... (Info: {})", count_connect_attempts, settings->default_num_tries_on_connection_loss, ecl.displayText());
         }
 
-        if (++count_connect_attempts > max_tries)
+        if (++count_connect_attempts > settings->default_num_tries_on_connection_loss)
         {
-            LOG_ERROR(log, "Failed to create connection to MySQL. ({}/{})", count_connect_attempts, max_tries);
+            LOG_ERROR(log, "Failed to create connection to MySQL. ({}/{})", count_connect_attempts, settings->default_num_tries_on_connection_loss);
             throw;
         }
     }
@@ -118,45 +127,57 @@ namespace
 {
     using ValueType = ExternalResultDescription::ValueType;
 
-    void insertValue(const IDataType & data_type, IColumn & column, const ValueType type, const mysqlxx::Value & value)
+    void insertValue(const IDataType & data_type, IColumn & column, const ValueType type, const mysqlxx::Value & value, size_t & read_bytes_size)
     {
         switch (type)
         {
             case ValueType::vtUInt8:
                 assert_cast<ColumnUInt8 &>(column).insertValue(value.getUInt());
+                read_bytes_size += 1;
                 break;
             case ValueType::vtUInt16:
                 assert_cast<ColumnUInt16 &>(column).insertValue(value.getUInt());
+                read_bytes_size += 2;
                 break;
             case ValueType::vtUInt32:
                 assert_cast<ColumnUInt32 &>(column).insertValue(value.getUInt());
+                read_bytes_size += 4;
                 break;
             case ValueType::vtUInt64:
                 assert_cast<ColumnUInt64 &>(column).insertValue(value.getUInt());
+                read_bytes_size += 8;
                 break;
             case ValueType::vtInt8:
                 assert_cast<ColumnInt8 &>(column).insertValue(value.getInt());
+                read_bytes_size += 1;
                 break;
             case ValueType::vtInt16:
                 assert_cast<ColumnInt16 &>(column).insertValue(value.getInt());
+                read_bytes_size += 2;
                 break;
             case ValueType::vtInt32:
                 assert_cast<ColumnInt32 &>(column).insertValue(value.getInt());
+                read_bytes_size += 4;
                 break;
             case ValueType::vtInt64:
                 assert_cast<ColumnInt64 &>(column).insertValue(value.getInt());
+                read_bytes_size += 8;
                 break;
             case ValueType::vtFloat32:
                 assert_cast<ColumnFloat32 &>(column).insertValue(value.getDouble());
+                read_bytes_size += 4;
                 break;
             case ValueType::vtFloat64:
                 assert_cast<ColumnFloat64 &>(column).insertValue(value.getDouble());
+                read_bytes_size += 8;
                 break;
             case ValueType::vtString:
                 assert_cast<ColumnString &>(column).insertData(value.data(), value.size());
+                read_bytes_size += assert_cast<ColumnString &>(column).byteSize();
                 break;
             case ValueType::vtDate:
                 assert_cast<ColumnUInt16 &>(column).insertValue(UInt16(value.getDate().getDayNum()));
+                read_bytes_size += 2;
                 break;
             case ValueType::vtDateTime:
             {
@@ -166,10 +187,12 @@ namespace
                 if (time < 0)
                     time = 0;
                 assert_cast<ColumnUInt32 &>(column).insertValue(time);
+                read_bytes_size += 4;
                 break;
             }
             case ValueType::vtUUID:
                 assert_cast<ColumnUInt128 &>(column).insert(parse<UUID>(value.data(), value.size()));
+                read_bytes_size += assert_cast<ColumnUInt128 &>(column).byteSize();
                 break;
             case ValueType::vtDateTime64:[[fallthrough]];
             case ValueType::vtDecimal32: [[fallthrough]];
@@ -179,10 +202,12 @@ namespace
             {
                 ReadBuffer buffer(const_cast<char *>(value.data()), value.size(), 0);
                 data_type.getDefaultSerialization()->deserializeWholeText(column, buffer, FormatSettings{});
+                read_bytes_size += column.sizeOfValueIfFixed();
                 break;
             }
             case ValueType::vtFixedString:
                 assert_cast<ColumnFixedString &>(column).insertData(value.data(), value.size());
+                read_bytes_size += column.sizeOfValueIfFixed();
                 break;
             default:
                 throw Exception("Unsupported value type", ErrorCodes::NOT_IMPLEMENTED);
@@ -198,7 +223,7 @@ Block MySQLBlockInputStream::readImpl()
     auto row = connection->result.fetch();
     if (!row)
     {
-        if (auto_close)
+        if (settings->auto_close)
            connection->entry.disconnect();
 
         return {};
@@ -209,6 +234,8 @@ Block MySQLBlockInputStream::readImpl()
         columns[i] = description.sample_block.getByPosition(i).column->cloneEmpty();
 
     size_t num_rows = 0;
+    size_t read_bytes_size = 0;
+
     while (row)
     {
         for (size_t index = 0; index < position_mapping.size(); ++index)
@@ -224,12 +251,12 @@ Block MySQLBlockInputStream::readImpl()
                 {
                     ColumnNullable & column_nullable = assert_cast<ColumnNullable &>(*columns[index]);
                     const auto & data_type = assert_cast<const DataTypeNullable &>(*sample.type);
-                    insertValue(*data_type.getNestedType(), column_nullable.getNestedColumn(), description.types[index].first, value);
+                    insertValue(*data_type.getNestedType(), column_nullable.getNestedColumn(), description.types[index].first, value, read_bytes_size);
                     column_nullable.getNullMapData().emplace_back(false);
                 }
                 else
                 {
-                    insertValue(*sample.type, *columns[index], description.types[index].first, value);
+                    insertValue(*sample.type, *columns[index], description.types[index].first, value, read_bytes_size);
                 }
             }
             else
@@ -245,7 +272,7 @@ Block MySQLBlockInputStream::readImpl()
         }
 
         ++num_rows;
-        if (num_rows == max_block_size)
+        if (num_rows == settings->max_read_mysql_rows || (settings->max_read_bytes_size && read_bytes_size >= settings->max_read_bytes_size))
             break;
 
         row = connection->result.fetch();
@@ -257,7 +284,7 @@ void MySQLBlockInputStream::initPositionMappingFromQueryResultStructure()
 {
     position_mapping.resize(description.sample_block.columns());
 
-    if (!fetch_by_name)
+    if (!settings->fetch_by_name)
     {
         if (description.sample_block.columns() != connection->result.getNumFields())
             throw Exception{"mysqlxx::UseQueryResult contains " + toString(connection->result.getNumFields()) + " columns while "

--- a/src/Formats/MySQLBlockInputStream.cpp
+++ b/src/Formats/MySQLBlockInputStream.cpp
@@ -31,8 +31,8 @@ namespace ErrorCodes
 }
 
 StreamSettings::StreamSettings(const Settings & settings, bool auto_close_, bool fetch_by_name_, size_t max_retry_)
-    : max_read_mysql_rows(settings.max_read_mysql_rows)
-    , max_read_bytes_size(settings.max_read_mysql_bytes)
+    : max_read_mysql_row_nums(settings.external_storage_max_read_rows)
+    , max_read_mysql_bytes_size(settings.external_storage_max_read_bytes)
     , auto_close(auto_close_)
     , fetch_by_name(fetch_by_name_)
     , default_num_tries_on_connection_loss(max_retry_)
@@ -258,7 +258,7 @@ Block MySQLBlockInputStream::readImpl()
         }
 
         ++num_rows;
-        if (num_rows == settings->max_read_mysql_rows || (settings->max_read_bytes_size && read_bytes_size >= settings->max_read_bytes_size))
+        if (num_rows == settings->max_read_mysql_row_nums || (settings->max_read_mysql_bytes_size && read_bytes_size >= settings->max_read_mysql_bytes_size))
             break;
 
         row = connection->result.fetch();

--- a/src/Formats/MySQLBlockInputStream.cpp
+++ b/src/Formats/MySQLBlockInputStream.cpp
@@ -30,27 +30,13 @@ namespace ErrorCodes
     extern const int NOT_IMPLEMENTED;
 }
 
-StreamSettings::StreamSettings(const Settings & settings)
-{
-    max_read_mysql_rows = settings.max_read_mysql_rows;
-    max_read_bytes_size = settings.max_read_mysql_bytes;
-}
-
-StreamSettings::StreamSettings(const Settings & settings, bool auto_close_, bool fetch_by_name_)
-        : auto_close(auto_close_)
-        , fetch_by_name(fetch_by_name_)
-{
-    max_read_mysql_rows = settings.max_read_mysql_rows;
-    max_read_bytes_size = settings.max_read_mysql_bytes;
-}
-
 StreamSettings::StreamSettings(const Settings & settings, bool auto_close_, bool fetch_by_name_, size_t max_retry_)
-    : auto_close(auto_close_)
+    : max_read_mysql_rows(settings.max_read_mysql_rows)
+    , max_read_bytes_size(settings.max_read_mysql_bytes)
+    , auto_close(auto_close_)
     , fetch_by_name(fetch_by_name_)
     , default_num_tries_on_connection_loss(max_retry_)
 {
-    max_read_mysql_rows = settings.max_read_mysql_rows;
-    max_read_bytes_size = settings.max_read_mysql_bytes;
 }
 
 MySQLBlockInputStream::Connection::Connection(

--- a/src/Formats/MySQLBlockInputStream.h
+++ b/src/Formats/MySQLBlockInputStream.h
@@ -15,13 +15,11 @@ struct StreamSettings
 {
     size_t max_read_mysql_rows;
     size_t max_read_bytes_size;
-    bool auto_close = false;
-    bool fetch_by_name = false;
-    size_t default_num_tries_on_connection_loss = 5;
+    bool auto_close;
+    bool fetch_by_name;
+    size_t default_num_tries_on_connection_loss;
 
-    StreamSettings(const Settings & settings);
-    StreamSettings(const Settings & settings, bool auto_close_, bool fetch_by_name_);
-    StreamSettings(const Settings & settings, bool auto_close_, bool fetch_by_name_, size_t max_retry_);
+    StreamSettings(const Settings & settings, bool auto_close_ = false, bool fetch_by_name_ = false, size_t max_retry_ = 5);
 
 };
 

--- a/src/Formats/MySQLBlockInputStream.h
+++ b/src/Formats/MySQLBlockInputStream.h
@@ -13,6 +13,7 @@ namespace DB
 
 struct StreamSettings
 {
+    /// Check if setting is enabled, otherwise use common `max_block_size` setting.
     size_t max_read_mysql_row_nums;
     size_t max_read_mysql_bytes_size;
     bool auto_close;
@@ -38,7 +39,7 @@ public:
     Block getHeader() const override { return description.sample_block.cloneEmpty(); }
 
 protected:
-    MySQLBlockInputStream(const Block & sample_block_, const struct StreamSettings & settings);
+    MySQLBlockInputStream(const Block & sample_block_, const StreamSettings & settings);
     Block readImpl() override;
     void initPositionMappingFromQueryResultStructure();
 

--- a/src/Formats/MySQLBlockInputStream.h
+++ b/src/Formats/MySQLBlockInputStream.h
@@ -13,8 +13,8 @@ namespace DB
 
 struct StreamSettings
 {
-    size_t max_read_mysql_rows;
-    size_t max_read_bytes_size;
+    size_t max_read_mysql_row_nums;
+    size_t max_read_mysql_bytes_size;
     bool auto_close;
     bool fetch_by_name;
     size_t default_num_tries_on_connection_loss;

--- a/src/Storages/StorageMySQL.cpp
+++ b/src/Storages/StorageMySQL.cpp
@@ -71,7 +71,7 @@ Pipe StorageMySQL::read(
     SelectQueryInfo & query_info_,
     ContextPtr context_,
     QueryProcessingStage::Enum /*processed_stage*/,
-    size_t /*max_read_mysql_rows*/,
+    size_t max_block_size,
     unsigned)
 {
     metadata_snapshot->check(column_names_, getVirtuals(), getStorageID());
@@ -94,6 +94,9 @@ Pipe StorageMySQL::read(
             column_data.type = std::make_shared<DataTypeString>();
         sample_block.insert({ column_data.type, column_data.name });
     }
+
+    if (!context_->getSettingsRef().external_storage_max_read_rows)
+        context_->setSetting("external_storage_max_read_rows", max_block_size);
 
     StreamSettings mysql_input_stream_settings(context_->getSettingsRef(), true, false);
     return Pipe(std::make_shared<SourceFromInputStream>(

--- a/src/Storages/StorageMySQL.cpp
+++ b/src/Storages/StorageMySQL.cpp
@@ -71,7 +71,7 @@ Pipe StorageMySQL::read(
     SelectQueryInfo & query_info_,
     ContextPtr context_,
     QueryProcessingStage::Enum /*processed_stage*/,
-    size_t max_block_size,
+    size_t /*max_block_size*/,
     unsigned)
 {
     metadata_snapshot->check(column_names_, getVirtuals(), getStorageID());
@@ -95,8 +95,6 @@ Pipe StorageMySQL::read(
         sample_block.insert({ column_data.type, column_data.name });
     }
 
-    if (!context_->getSettingsRef().external_storage_max_read_rows)
-        context_->setSetting("external_storage_max_read_rows", max_block_size);
 
     StreamSettings mysql_input_stream_settings(context_->getSettingsRef(), true, false);
     return Pipe(std::make_shared<SourceFromInputStream>(

--- a/src/Storages/StorageMySQL.cpp
+++ b/src/Storages/StorageMySQL.cpp
@@ -71,7 +71,7 @@ Pipe StorageMySQL::read(
     SelectQueryInfo & query_info_,
     ContextPtr context_,
     QueryProcessingStage::Enum /*processed_stage*/,
-    size_t max_block_size_,
+    size_t /*max_read_mysql_rows*/,
     unsigned)
 {
     metadata_snapshot->check(column_names_, getVirtuals(), getStorageID());
@@ -95,8 +95,9 @@ Pipe StorageMySQL::read(
         sample_block.insert({ column_data.type, column_data.name });
     }
 
+    StreamSettings mysql_input_stream_settings(context_->getSettingsRef(), true, false);
     return Pipe(std::make_shared<SourceFromInputStream>(
-            std::make_shared<MySQLWithFailoverBlockInputStream>(pool, query, sample_block, max_block_size_, /* auto_close = */ true)));
+            std::make_shared<MySQLWithFailoverBlockInputStream>(pool, query, sample_block, mysql_input_stream_settings)));
 }
 
 

--- a/src/TableFunctions/TableFunctionMySQL.cpp
+++ b/src/TableFunctions/TableFunctionMySQL.cpp
@@ -79,7 +79,7 @@ void TableFunctionMySQL::parseArguments(const ASTPtr & ast_function, ContextPtr 
 ColumnsDescription TableFunctionMySQL::getActualTableStructure(ContextPtr context) const
 {
     const auto & settings = context->getSettingsRef();
-    const auto tables_and_columns = fetchTablesColumnsList(*pool, remote_database_name, {remote_table_name}, settings.external_table_functions_use_nulls, settings.mysql_datatypes_support_level);
+    const auto tables_and_columns = fetchTablesColumnsList(*pool, remote_database_name, {remote_table_name}, settings, settings.mysql_datatypes_support_level);
 
     const auto columns = tables_and_columns.find(remote_table_name);
     if (columns == tables_and_columns.end())

--- a/tests/integration/test_materialize_mysql_database/configs/users_disable_bytes_settings.xml
+++ b/tests/integration/test_materialize_mysql_database/configs/users_disable_bytes_settings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<yandex>
+    <profiles>
+        <default>
+            <allow_experimental_database_materialize_mysql>1</allow_experimental_database_materialize_mysql>
+            <default_database_engine>Atomic</default_database_engine>
+            <max_read_mysql_rows>1</max_read_mysql_rows>
+            <max_read_mysql_bytes>0</max_read_mysql_bytes>
+        </default>
+    </profiles>
+
+    <users>
+        <default>
+            <password></password>
+            <networks incl="networks" replace="replace">
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+        </default>
+    </users>
+</yandex>

--- a/tests/integration/test_materialize_mysql_database/configs/users_disable_rows_settings.xml
+++ b/tests/integration/test_materialize_mysql_database/configs/users_disable_rows_settings.xml
@@ -4,8 +4,8 @@
         <default>
             <allow_experimental_database_materialize_mysql>1</allow_experimental_database_materialize_mysql>
             <default_database_engine>Atomic</default_database_engine>
-            <max_read_mysql_rows>0</max_read_mysql_rows>
-            <max_read_mysql_bytes>1</max_read_mysql_bytes>
+            <external_storage_max_read_rows>0</external_storage_max_read_rows>
+            <external_storage_max_read_bytes>1</external_storage_max_read_bytes>
         </default>
     </profiles>
 

--- a/tests/integration/test_materialize_mysql_database/configs/users_disable_rows_settings.xml
+++ b/tests/integration/test_materialize_mysql_database/configs/users_disable_rows_settings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<yandex>
+    <profiles>
+        <default>
+            <allow_experimental_database_materialize_mysql>1</allow_experimental_database_materialize_mysql>
+            <default_database_engine>Atomic</default_database_engine>
+            <max_read_mysql_rows>0</max_read_mysql_rows>
+            <max_read_mysql_bytes>1</max_read_mysql_bytes>
+        </default>
+    </profiles>
+
+    <users>
+        <default>
+            <password></password>
+            <networks incl="networks" replace="replace">
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+        </default>
+    </users>
+</yandex>

--- a/tests/integration/test_materialize_mysql_database/test.py
+++ b/tests/integration/test_materialize_mysql_database/test.py
@@ -16,7 +16,8 @@ cluster = ClickHouseCluster(__file__)
 
 node_db_ordinary = cluster.add_instance('node1', user_configs=["configs/users.xml"], with_mysql=False, stay_alive=True)
 node_db_atomic = cluster.add_instance('node2', user_configs=["configs/users_db_atomic.xml"], with_mysql=False, stay_alive=True)
-
+node_disable_bytes_settings = cluster.add_instance('node3', user_configs=["configs/users_disable_bytes_settings.xml"], with_mysql=False, stay_alive=True)
+node_disable_rows_settings = cluster.add_instance('node4', user_configs=["configs/users_disable_rows_settings.xml"], with_mysql=False, stay_alive=True)
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -289,5 +290,12 @@ def test_multi_table_update(started_cluster, started_mysql_8_0, started_mysql_5_
 
 
 @pytest.mark.parametrize(('clickhouse_node'), [node_db_ordinary, node_db_ordinary])
-def test_system_tables_table(started_cluster, started_mysql_8_0, clickhouse_node):
+def test_system_tables_table(started_cluster, started_mysql_8_0, started_mysql_5_7, clickhouse_node):
+    materialize_with_ddl.system_tables_test(clickhouse_node, started_mysql_5_7, "mysql1")
     materialize_with_ddl.system_tables_test(clickhouse_node, started_mysql_8_0, "mysql8_0")
+
+
+@pytest.mark.parametrize(('clickhouse_node'), [node_disable_bytes_settings, node_disable_rows_settings])
+def test_mysql_settings(started_cluster, started_mysql_8_0, started_mysql_5_7, clickhouse_node):
+    materialize_with_ddl.mysql_settings_test(clickhouse_node, started_mysql_5_7, "mysql1")
+    materialize_with_ddl.mysql_settings_test(clickhouse_node, started_mysql_8_0, "mysql8_0")

--- a/tests/integration/test_storage_mysql/configs/users.xml
+++ b/tests/integration/test_storage_mysql/configs/users.xml
@@ -2,10 +2,7 @@
 <yandex>
     <profiles>
         <default>
-            <allow_experimental_database_materialize_mysql>1</allow_experimental_database_materialize_mysql>
-            <default_database_engine>Atomic</default_database_engine>
-            <external_storage_max_read_rows>1</external_storage_max_read_rows>
-            <external_storage_max_read_bytes>0</external_storage_max_read_bytes>
+            <max_block_size>2</max_block_size>
         </default>
     </profiles>
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add settings `external_storage_max_read_rows` and `external_storage_max_read_rows` for MySQL table engine, dictionary source and MaterializeMySQL minor data fetches.

Detailed description:
1. MySQL table engine
2. MySQL dictionary
3. MaterializeMySQL

Before: cloneWithColumns full history data to a block when the rows from MySQL <= 65505.

In this pr: cloneWithColumns full history data when the rows from MySQL are <= settings.`max_read_mysql_rows` or the size of data in mem > settings.`max_read_bytes_size` .

If set max_read_mysql_rows = 0 means disable the rows limit.
If set max_read_bytes_size = 0 means disable this bytes limit.


