### PR TITLE
Remove redundant fsync on coordination logs rotation

### DIFF
--- a/src/Coordination/Changelog.cpp
+++ b/src/Coordination/Changelog.cpp
@@ -357,10 +357,6 @@ void Changelog::readChangelogAndInitWriter(size_t last_commited_log_index, size_
 
 void Changelog::rotate(size_t new_start_log_index)
 {
-    //// doesn't exist on init
-    if (current_writer)
-        current_writer->flush();
-
     ChangelogFileDescription new_description;
     new_description.prefix = DEFAULT_PREFIX;
     new_description.from_log_index = new_start_log_index;

--- a/src/Coordination/KeeperServer.cpp
+++ b/src/Coordination/KeeperServer.cpp
@@ -192,14 +192,14 @@ bool KeeperServer::isLeaderAlive() const
 
 nuraft::cb_func::ReturnCode KeeperServer::callbackFunc(nuraft::cb_func::Type type, nuraft::cb_func::Param * /* param */)
 {
+    if (initialized_flag)
+        return nuraft::cb_func::ReturnCode::Ok;
+
     size_t last_commited = state_machine->last_commit_index();
     size_t next_index = state_manager->getLogStore()->next_slot();
     bool commited_store = false;
     if (next_index < last_commited || next_index - last_commited <= 1)
         commited_store = true;
-
-    if (initialized_flag)
-        return nuraft::cb_func::ReturnCode::Ok;
 
     auto set_initialized = [this] ()
     {

--- a/tests/config/config.d/database_replicated.xml
+++ b/tests/config/config.d/database_replicated.xml
@@ -19,8 +19,8 @@
         <server_id>1</server_id>
 
         <coordination_settings>
-            <operation_timeout_ms>5000</operation_timeout_ms>
-            <session_timeout_ms>10000</session_timeout_ms>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
             <heart_beat_interval_ms>1000</heart_beat_interval_ms>
             <election_timeout_lower_bound_ms>2000</election_timeout_lower_bound_ms>
             <election_timeout_upper_bound_ms>4000</election_timeout_upper_bound_ms>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

