### PR TITLE
Add metric to track how much time is spend during waiting for Buffer layer lock

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -146,6 +146,8 @@
     M(StorageBufferPassedTimeMaxThreshold, "") \
     M(StorageBufferPassedRowsMaxThreshold, "") \
     M(StorageBufferPassedBytesMaxThreshold, "") \
+    M(StorageBufferLayerLockReadersWaitMilliseconds, "Time for waiting for Buffer layer during reading") \
+    M(StorageBufferLayerLockWritersWaitMilliseconds, "Time for waiting free Buffer layer to write to (can be used to tune Buffer layers)") \
     \
     M(DictCacheKeysRequested, "") \
     M(DictCacheKeysRequestedMiss, "") \

--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -40,6 +40,8 @@ namespace ProfileEvents
     extern const Event StorageBufferPassedTimeMaxThreshold;
     extern const Event StorageBufferPassedRowsMaxThreshold;
     extern const Event StorageBufferPassedBytesMaxThreshold;
+    extern const Event StorageBufferLayerLockReadersWaitMilliseconds;
+    extern const Event StorageBufferLayerLockWritersWaitMilliseconds;
 }
 
 namespace CurrentMetrics
@@ -60,6 +62,36 @@ namespace ErrorCodes
     extern const int INFINITE_LOOP;
     extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
     extern const int ALTER_OF_COLUMN_IS_FORBIDDEN;
+}
+
+
+std::unique_lock<std::mutex> StorageBuffer::Buffer::lockForReading() const
+{
+    return lockImpl(/* read= */true);
+}
+std::unique_lock<std::mutex> StorageBuffer::Buffer::lockForWriting() const
+{
+    return lockImpl(/* read= */false);
+}
+std::unique_lock<std::mutex> StorageBuffer::Buffer::tryLock() const
+{
+    std::unique_lock lock(mutex, std::try_to_lock);
+    return lock;
+}
+std::unique_lock<std::mutex> StorageBuffer::Buffer::lockImpl(bool read) const
+{
+    std::unique_lock lock(mutex, std::defer_lock);
+
+    Stopwatch watch(CLOCK_MONOTONIC_COARSE);
+    lock.lock();
+    UInt64 elapsed = watch.elapsedMilliseconds();
+
+    if (read)
+        ProfileEvents::increment(ProfileEvents::StorageBufferLayerLockReadersWaitMilliseconds, elapsed);
+    else
+        ProfileEvents::increment(ProfileEvents::StorageBufferLayerLockWritersWaitMilliseconds, elapsed);
+
+    return lock;
 }
 
 
@@ -111,7 +143,7 @@ protected:
             return res;
         has_been_read = true;
 
-        std::lock_guard lock(buffer.mutex);
+        std::unique_lock lock(buffer.lockForReading());
 
         if (!buffer.data.rows())
             return res;
@@ -528,7 +560,7 @@ public:
 
         for (size_t try_no = 0; try_no < storage.num_shards; ++try_no)
         {
-            std::unique_lock lock(storage.buffers[shard_num].mutex, std::try_to_lock);
+            std::unique_lock lock(storage.buffers[shard_num].tryLock());
 
             if (lock.owns_lock())
             {
@@ -548,7 +580,7 @@ public:
         if (!least_busy_buffer)
         {
             least_busy_buffer = &storage.buffers[start_shard_num];
-            least_busy_lock = std::unique_lock(least_busy_buffer->mutex);
+            least_busy_lock = least_busy_buffer->lockForWriting();
         }
         insertIntoBuffer(block, *least_busy_buffer);
         least_busy_lock.unlock();
@@ -740,9 +772,9 @@ void StorageBuffer::flushBuffer(Buffer & buffer, bool check_thresholds, bool loc
     size_t bytes = 0;
     time_t time_passed = 0;
 
-    std::unique_lock lock(buffer.mutex, std::defer_lock);
+    std::optional<std::unique_lock<std::mutex>> lock;
     if (!locked)
-        lock.lock();
+        lock.emplace(buffer.lockForReading());
 
     block_to_write = buffer.data.cloneEmpty();
 
@@ -910,7 +942,7 @@ void StorageBuffer::reschedule()
         /// try_to_lock is also ok for background flush, since if there is
         /// INSERT contended, then the reschedule will be done after
         /// INSERT will be done.
-        std::unique_lock lock(buffer.mutex, std::try_to_lock);
+        std::unique_lock lock(buffer.tryLock());
         if (lock.owns_lock())
         {
             min_first_write_time = buffer.first_write_time;
@@ -967,7 +999,7 @@ std::optional<UInt64> StorageBuffer::totalRows(const Settings & settings) const
     UInt64 rows = 0;
     for (const auto & buffer : buffers)
     {
-        std::lock_guard lock(buffer.mutex);
+        const auto lock(buffer.lockForReading());
         rows += buffer.data.rows();
     }
     return rows + *underlying_rows;
@@ -978,7 +1010,7 @@ std::optional<UInt64> StorageBuffer::totalBytes(const Settings & /*settings*/) c
     UInt64 bytes = 0;
     for (const auto & buffer : buffers)
     {
-        std::lock_guard lock(buffer.mutex);
+        const auto lock(buffer.lockForReading());
         bytes += buffer.data.allocatedBytes();
     }
     return bytes;

--- a/src/Storages/StorageBuffer.h
+++ b/src/Storages/StorageBuffer.h
@@ -118,7 +118,15 @@ private:
     {
         time_t first_write_time = 0;
         Block data;
+
+        std::unique_lock<std::mutex> lockForReading() const;
+        std::unique_lock<std::mutex> lockForWriting() const;
+        std::unique_lock<std::mutex> tryLock() const;
+
+    private:
         mutable std::mutex mutex;
+
+        std::unique_lock<std::mutex> lockImpl(bool read) const;
     };
 
     /// There are `num_shards` of independent buffers.


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add metric to track how much time is spend during waiting for Buffer layer lock

Detailed description / Documentation draft:
It uses very fast CLOCK_MONOTONIC_COARSE, so this should not be a
problem.
Also note that there is no sense in using microseconds/nanoseconds since
accuracy of CLOCK_MONOTONIC_COARSE usually milliseconds.