### PR TITLE
Fix approx total rows accounting for reverse reading from MergeTree

### DIFF
--- a/src/Storages/MergeTree/MergeTreeReverseSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeReverseSelectProcessor.cpp
@@ -44,12 +44,11 @@ MergeTreeReverseSelectProcessor::MergeTreeReverseSelectProcessor(
     for (const auto & range : all_mark_ranges)
         total_marks_count += range.end - range.begin;
 
-    size_t total_rows = data_part->index_granularity.getTotalRows();
+    size_t total_rows = data_part->index_granularity.getRowsCountInRanges(all_mark_ranges);
 
     if (!quiet)
-        LOG_TRACE(log, "Reading {} ranges in reverse order from part {}, approx. {}, up to {} rows starting from {}",
+        LOG_TRACE(log, "Reading {} ranges in reverse order from part {}, approx. {} rows starting from {}",
             all_mark_ranges.size(), data_part->name, total_rows,
-            data_part->index_granularity.getRowsCountInRanges(all_mark_ranges),
             data_part->index_granularity.getMarkStartingRow(all_mark_ranges.front().begin));
 
     addTotalRowsApprox(total_rows);

--- a/tests/queries/0_stateless/01801_approx_total_rows_mergetree_reverse.sql
+++ b/tests/queries/0_stateless/01801_approx_total_rows_mergetree_reverse.sql
@@ -1,0 +1,10 @@
+drop table if exists data_01801;
+create table data_01801 (key Int) engine=MergeTree() order by key settings index_granularity=10 as select number/10 from numbers(100);
+
+select * from data_01801 where key = 0 order by key settings max_rows_to_read=9 format Null; -- { serverError 158 }
+select * from data_01801 where key = 0 order by key desc settings max_rows_to_read=9 format Null; -- { serverError 158 }
+
+select * from data_01801 where key = 0 order by key settings max_rows_to_read=10 format Null;
+select * from data_01801 where key = 0 order by key desc settings max_rows_to_read=10 format Null;
+
+drop table data_01801;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix approx total rows accounting for reverse reading from MergeTree

Cc: @CurtizJ 