### PR TITLE
Avoid using harmful function rand()

### DIFF
--- a/contrib/librdkafka-cmake/config.h.in
+++ b/contrib/librdkafka-cmake/config.h.in
@@ -75,6 +75,8 @@
 #define HAVE_STRNDUP 1
 // strerror_r
 #define HAVE_STRERROR_R 1
+// rand_r
+#define HAVE_RAND_R 1
 
 #ifdef __APPLE__
 // pthread_setname_np


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Avoid using harmful function rand() in librdkafka.

So we don't trap in 

![image](https://user-images.githubusercontent.com/5085485/113840629-74dd2900-97c3-11eb-9c75-0f4f00e9c480.png)



Detailed description / Documentation draft:

.