### PR TITLE
Excludes views from syncing in MaterializeMySQL

### DIFF
--- a/src/Databases/MySQL/MaterializeMetadata.cpp
+++ b/src/Databases/MySQL/MaterializeMetadata.cpp
@@ -52,7 +52,7 @@ static std::unordered_map<String, String> fetchTablesCreateQuery(
 static std::vector<String> fetchTablesInDB(const mysqlxx::PoolWithFailover::Entry & connection, const std::string & database)
 {
     Block header{{std::make_shared<DataTypeString>(), "table_name"}};
-    String query = "SELECT TABLE_NAME AS table_name FROM INFORMATION_SCHEMA.TABLES  WHERE TABLE_SCHEMA = " + quoteString(database);
+    String query = "SELECT TABLE_NAME AS table_name FROM INFORMATION_SCHEMA.TABLES  WHERE TABLE_TYPE != 'VIEW' AND TABLE_SCHEMA = " + quoteString(database);
 
     std::vector<String> tables_in_db;
     MySQLBlockInputStream input(connection, query, header, DEFAULT_BLOCK_SIZE);

--- a/tests/integration/test_materialize_mysql_database/materialize_with_ddl.py
+++ b/tests/integration/test_materialize_mysql_database/materialize_with_ddl.py
@@ -138,7 +138,7 @@ def materialize_mysql_database_with_views(clickhouse_node, mysql_node, service_n
                      "/* Need ClickHouse support Enum('a', 'b', 'v') _enum ENUM('a', 'b', 'c'), */"
                      "_date Date, _datetime DateTime, _timestamp TIMESTAMP, _bool BOOLEAN) ENGINE = InnoDB;")
 
-    mysql_node.query("CREATE VIEW test_table_1_view AS SELECT SUM(tiny_int) FROM test_table_1 GROUP BY _date;")
+    mysql_node.query("CREATE VIEW test_database.test_table_1_view AS SELECT SUM(tiny_int) FROM test_database.test_table_1 GROUP BY _date;")
 
     # it already has some data
     mysql_node.query("""

--- a/tests/integration/test_materialize_mysql_database/materialize_with_ddl.py
+++ b/tests/integration/test_materialize_mysql_database/materialize_with_ddl.py
@@ -150,8 +150,7 @@ def materialize_mysql_database_with_views(clickhouse_node, mysql_node, service_n
             service_name))
 
     assert "test_database" in clickhouse_node.query("SHOW DATABASES")
-    assert "test_table_1" in clickhouse_node.query("SHOW TABLES FROM test_database")
-    assert "test_table_1_view" not in clickhouse_node.query("SHOW TABLES FROM test_database")
+    check_query(clickhouse_node, "SHOW TABLES FROM test_database FORMAT TSV", "test_table_1\n")
 
     clickhouse_node.query("DROP DATABASE test_database")
     mysql_node.query("DROP DATABASE test_database")

--- a/tests/integration/test_materialize_mysql_database/materialize_with_ddl.py
+++ b/tests/integration/test_materialize_mysql_database/materialize_with_ddl.py
@@ -117,6 +117,46 @@ def dml_with_materialize_mysql_database(clickhouse_node, mysql_node, service_nam
     mysql_node.query("DROP DATABASE test_database")
 
 
+def materialize_mysql_database_with_views(clickhouse_node, mysql_node, service_name):
+    mysql_node.query("DROP DATABASE IF EXISTS test_database")
+    clickhouse_node.query("DROP DATABASE IF EXISTS test_database")
+    mysql_node.query("CREATE DATABASE test_database DEFAULT CHARACTER SET 'utf8'")
+    # existed before the mapping was created
+
+    mysql_node.query("CREATE TABLE test_database.test_table_1 ("
+                     "`key` INT NOT NULL PRIMARY KEY, "
+                     "unsigned_tiny_int TINYINT UNSIGNED, tiny_int TINYINT, "
+                     "unsigned_small_int SMALLINT UNSIGNED, small_int SMALLINT, "
+                     "unsigned_medium_int MEDIUMINT UNSIGNED, medium_int MEDIUMINT, "
+                     "unsigned_int INT UNSIGNED, _int INT, "
+                     "unsigned_integer INTEGER UNSIGNED, _integer INTEGER, "
+                     "unsigned_bigint BIGINT UNSIGNED, _bigint BIGINT, "
+                     "/* Need ClickHouse support read mysql decimal unsigned_decimal DECIMAL(19, 10) UNSIGNED, _decimal DECIMAL(19, 10), */"
+                     "unsigned_float FLOAT UNSIGNED, _float FLOAT, "
+                     "unsigned_double DOUBLE UNSIGNED, _double DOUBLE, "
+                     "_varchar VARCHAR(10), _char CHAR(10), binary_col BINARY(8), "
+                     "/* Need ClickHouse support Enum('a', 'b', 'v') _enum ENUM('a', 'b', 'c'), */"
+                     "_date Date, _datetime DateTime, _timestamp TIMESTAMP, _bool BOOLEAN) ENGINE = InnoDB;")
+
+    mysql_node.query("CREATE VIEW test_table_1_view AS SELECT SUM(tiny_int) FROM test_table_1 GROUP BY _date;")
+
+    # it already has some data
+    mysql_node.query("""
+        INSERT INTO test_database.test_table_1 VALUES(1, 1, -1, 2, -2, 3, -3, 4, -4, 5, -5, 6, -6, 3.2, -3.2, 3.4, -3.4, 'varchar', 'char', 'binary',
+        '2020-01-01', '2020-01-01 00:00:00', '2020-01-01 00:00:00', true);
+        """)
+    clickhouse_node.query(
+        "CREATE DATABASE test_database ENGINE = MaterializeMySQL('{}:3306', 'test_database', 'root', 'clickhouse')".format(
+            service_name))
+
+    assert "test_database" in clickhouse_node.query("SHOW DATABASES")
+    assert "test_table_1" in clickhouse_node.query("SHOW TABLES")
+    assert "test_table_1_view" not in clickhouse_node.query("SHOW TABLES")
+
+    clickhouse_node.query("DROP DATABASE test_database")
+    mysql_node.query("DROP DATABASE test_database")
+
+
 def materialize_mysql_database_with_datetime_and_decimal(clickhouse_node, mysql_node, service_name):
     mysql_node.query("DROP DATABASE IF EXISTS test_database")
     clickhouse_node.query("DROP DATABASE IF EXISTS test_database")

--- a/tests/integration/test_materialize_mysql_database/materialize_with_ddl.py
+++ b/tests/integration/test_materialize_mysql_database/materialize_with_ddl.py
@@ -150,8 +150,8 @@ def materialize_mysql_database_with_views(clickhouse_node, mysql_node, service_n
             service_name))
 
     assert "test_database" in clickhouse_node.query("SHOW DATABASES")
-    assert "test_table_1" in clickhouse_node.query("SHOW TABLES")
-    assert "test_table_1_view" not in clickhouse_node.query("SHOW TABLES")
+    assert "test_table_1" in clickhouse_node.query("SHOW TABLES FROM test_database")
+    assert "test_table_1_view" not in clickhouse_node.query("SHOW TABLES FROM test_database")
 
     clickhouse_node.query("DROP DATABASE test_database")
     mysql_node.query("DROP DATABASE test_database")

--- a/tests/integration/test_materialize_mysql_database/test.py
+++ b/tests/integration/test_materialize_mysql_database/test.py
@@ -150,12 +150,14 @@ def started_mysql_8_0():
 @pytest.mark.parametrize(('clickhouse_node'), [node_db_ordinary, node_db_atomic])
 def test_materialize_database_dml_with_mysql_5_7(started_cluster, started_mysql_5_7, clickhouse_node):
     materialize_with_ddl.dml_with_materialize_mysql_database(clickhouse_node, started_mysql_5_7, "mysql1")
+    materialize_with_ddl.materialize_mysql_database_with_views(clickhouse_node, started_mysql_5_7, "mysql1")
     materialize_with_ddl.materialize_mysql_database_with_datetime_and_decimal(clickhouse_node, started_mysql_5_7, "mysql1")
 
 
 @pytest.mark.parametrize(('clickhouse_node'), [node_db_ordinary, node_db_atomic])
 def test_materialize_database_dml_with_mysql_8_0(started_cluster, started_mysql_8_0, clickhouse_node):
     materialize_with_ddl.dml_with_materialize_mysql_database(clickhouse_node, started_mysql_8_0, "mysql8_0")
+    materialize_with_ddl.materialize_mysql_database_with_views(clickhouse_node, started_mysql_8_0, "mysql8_0")
     materialize_with_ddl.materialize_mysql_database_with_datetime_and_decimal(clickhouse_node, started_mysql_8_0, "mysql8_0")
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
MaterializeMySQL (experimental feature). Make Clickhouse to be able to replicate MySQL databases containing views without failing. This is accomplished by ignoring the views.
...


Detailed description / Documentation draft:

Since a MySQL view is simply a different representation of the underlying tables, won't be replicated to ClickHouse. 
...
