### PR TITLE
Util `memcpy-bench` is built only when position independent code is disabled

### DIFF
--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -37,7 +37,8 @@ if (NOT DEFINED ENABLE_UTILS OR ENABLE_UTILS)
         add_subdirectory (keeper-data-dumper)
     endif ()
 
-    if (NOT OS_DARWIN)
+    # memcpy_jart.S contains position dependent code
+    if (NOT CMAKE_POSITION_INDEPENDENT_CODE AND NOT OS_DARWIN)
         add_subdirectory (memcpy-bench)
     endif ()
 endif ()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Fixes #22862;

Changelog category (leave one):
- Not for changelog (changelog entry is not required)
