### PR TITLE
Attempt to fix deadlock issue between CREATE and DROP of live views.

### DIFF
--- a/src/Storages/LiveView/TemporaryLiveViewCleaner.cpp
+++ b/src/Storages/LiveView/TemporaryLiveViewCleaner.cpp
@@ -165,10 +165,8 @@ void TemporaryLiveViewCleaner::backgroundThreadFunc()
             ++it;
         }
 
-        lock.unlock();
         for (const auto & storage_id : storages_to_drop)
             executeDropQuery(storage_id, global_context);
-        lock.lock();
     }
 }
 


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
LIVE VIEW is experimental feature. Fixing deadlock issue between CREATE and DROP of LIVE VIEW tables with TIMEOUT

Detailed description / Documentation draft:
Fixing deadlock issue between CREATE and DROP of LIVE VIEW tables with TIMEOUT

