### PR TITLE
Fixes: formatDateTime and toDateTime64

### DIFF
--- a/src/Functions/formatDateTime.cpp
+++ b/src/Functions/formatDateTime.cpp
@@ -480,7 +480,7 @@ public:
                     // since right now LUT does not support Int64-values and not format instructions for subsecond parts,
                     // treat DatTime64 values just as DateTime values by ignoring fractional and casting to UInt32.
                     const auto c = DecimalUtils::split(vec[i], scale);
-                    instruction.perform(pos, static_cast<UInt32>(c.whole), time_zone);
+                    instruction.perform(pos, static_cast<Int64>(c.whole), time_zone);
                 }
             }
             else

--- a/src/IO/ReadHelpers.h
+++ b/src/IO/ReadHelpers.h
@@ -773,7 +773,7 @@ inline ReturnType readDateTimeTextImpl(DateTime64 & datetime64, UInt32 scale, Re
         while (!buf.eof() && isNumericASCII(*buf.position()))
             ++buf.position();
     }
-    //9908870400 is time_t value for 2184-01-01 UTC (a bit over the last year supported by DateTime64)
+    /// 9908870400 is time_t value for 2184-01-01 UTC (a bit over the last year supported by DateTime64)
     else if (whole >= 9908870400LL)
     {
         /// Unix timestamp with subsecond precision, already scaled to integer.

--- a/src/IO/ReadHelpers.h
+++ b/src/IO/ReadHelpers.h
@@ -773,7 +773,8 @@ inline ReturnType readDateTimeTextImpl(DateTime64 & datetime64, UInt32 scale, Re
         while (!buf.eof() && isNumericASCII(*buf.position()))
             ++buf.position();
     }
-    else if (scale && (whole >= 1000000000LL * scale))
+    //9908870400 is time_t value for 2084-01-01 UTC (a bit over the last year supported by DateTime64)
+    else if (scale && scale < 18 && (whole >= 9908870400LL * static_cast<int64_t>(intExp10(scale))))
     {
         /// Unix timestamp with subsecond precision, already scaled to integer.
         /// For disambiguation we support only time since 2001-09-09 01:46:40 UTC and less than 30 000 years in future.

--- a/src/IO/ReadHelpers.h
+++ b/src/IO/ReadHelpers.h
@@ -774,7 +774,7 @@ inline ReturnType readDateTimeTextImpl(DateTime64 & datetime64, UInt32 scale, Re
             ++buf.position();
     }
     //9908870400 is time_t value for 2084-01-01 UTC (a bit over the last year supported by DateTime64)
-    else if (scale && scale < 18 && (whole >= 9908870400LL * static_cast<int64_t>(intExp10(scale))))
+    else if (whole >= 9908870400LL)
     {
         /// Unix timestamp with subsecond precision, already scaled to integer.
         /// For disambiguation we support only time since 2001-09-09 01:46:40 UTC and less than 30 000 years in future.

--- a/src/IO/ReadHelpers.h
+++ b/src/IO/ReadHelpers.h
@@ -773,7 +773,7 @@ inline ReturnType readDateTimeTextImpl(DateTime64 & datetime64, UInt32 scale, Re
         while (!buf.eof() && isNumericASCII(*buf.position()))
             ++buf.position();
     }
-    //9908870400 is time_t value for 2084-01-01 UTC (a bit over the last year supported by DateTime64)
+    //9908870400 is time_t value for 2184-01-01 UTC (a bit over the last year supported by DateTime64)
     else if (whole >= 9908870400LL)
     {
         /// Unix timestamp with subsecond precision, already scaled to integer.

--- a/tests/queries/0_stateless/018002_formatDateTime_DateTime64_century.reference
+++ b/tests/queries/0_stateless/018002_formatDateTime_DateTime64_century.reference
@@ -23,5 +23,5 @@ SELECT formatDateTime(toDateTime64('2019-09-16 19:20:12', 0, 'Europe/Moscow'), '
 20
 SELECT formatDateTime(toDateTime64('2105-12-12 12:12:12', 6, 'Europe/Moscow'), '%C');
 21
-SELECT formatDateTime(toDateTime64('2205-12-12 12:12:12', 6, 'Europe/Moscow'), '%C');
-19
+SELECT formatDateTime(toDateTime64('2205-01-12 12:12:12', 6, 'Europe/Moscow'), '%C');
+22

--- a/tests/queries/0_stateless/018002_formatDateTime_DateTime64_century.reference
+++ b/tests/queries/0_stateless/018002_formatDateTime_DateTime64_century.reference
@@ -1,0 +1,27 @@
+-- { echo }
+
+SELECT formatDateTime(toDateTime64('1935-12-12 12:12:12', 0, 'Europe/Moscow'), '%C');
+19
+SELECT formatDateTime(toDateTime64('1969-12-12 12:12:12', 0, 'Europe/Moscow'), '%C');
+19
+SELECT formatDateTime(toDateTime64('1989-12-12 12:12:12', 0, 'Europe/Moscow'), '%C');
+19
+SELECT formatDateTime(toDateTime64('2019-09-16 19:20:12', 0, 'Europe/Moscow'), '%C');
+20
+SELECT formatDateTime(toDateTime64('2105-12-12 12:12:12', 0, 'Europe/Moscow'), '%C');
+21
+SELECT formatDateTime(toDateTime64('2205-12-12 12:12:12', 0, 'Europe/Moscow'), '%C');
+22
+-- non-zero scale
+SELECT formatDateTime(toDateTime64('1935-12-12 12:12:12', 6, 'Europe/Moscow'), '%C');
+19
+SELECT formatDateTime(toDateTime64('1969-12-12 12:12:12', 6, 'Europe/Moscow'), '%C');
+19
+SELECT formatDateTime(toDateTime64('1989-12-12 12:12:12', 6, 'Europe/Moscow'), '%C');
+19
+SELECT formatDateTime(toDateTime64('2019-09-16 19:20:12', 0, 'Europe/Moscow'), '%C');
+20
+SELECT formatDateTime(toDateTime64('2105-12-12 12:12:12', 6, 'Europe/Moscow'), '%C');
+21
+SELECT formatDateTime(toDateTime64('2205-12-12 12:12:12', 6, 'Europe/Moscow'), '%C');
+19

--- a/tests/queries/0_stateless/018002_formatDateTime_DateTime64_century.sql
+++ b/tests/queries/0_stateless/018002_formatDateTime_DateTime64_century.sql
@@ -13,4 +13,4 @@ SELECT formatDateTime(toDateTime64('1969-12-12 12:12:12', 6, 'Europe/Moscow'), '
 SELECT formatDateTime(toDateTime64('1989-12-12 12:12:12', 6, 'Europe/Moscow'), '%C');
 SELECT formatDateTime(toDateTime64('2019-09-16 19:20:12', 0, 'Europe/Moscow'), '%C');
 SELECT formatDateTime(toDateTime64('2105-12-12 12:12:12', 6, 'Europe/Moscow'), '%C');
-SELECT formatDateTime(toDateTime64('2205-12-12 12:12:12', 6, 'Europe/Moscow'), '%C');
+SELECT formatDateTime(toDateTime64('2205-01-12 12:12:12', 6, 'Europe/Moscow'), '%C');

--- a/tests/queries/0_stateless/018002_formatDateTime_DateTime64_century.sql
+++ b/tests/queries/0_stateless/018002_formatDateTime_DateTime64_century.sql
@@ -1,0 +1,16 @@
+-- { echo }
+
+SELECT formatDateTime(toDateTime64('1935-12-12 12:12:12', 0, 'Europe/Moscow'), '%C');
+SELECT formatDateTime(toDateTime64('1969-12-12 12:12:12', 0, 'Europe/Moscow'), '%C');
+SELECT formatDateTime(toDateTime64('1989-12-12 12:12:12', 0, 'Europe/Moscow'), '%C');
+SELECT formatDateTime(toDateTime64('2019-09-16 19:20:12', 0, 'Europe/Moscow'), '%C');
+SELECT formatDateTime(toDateTime64('2105-12-12 12:12:12', 0, 'Europe/Moscow'), '%C');
+SELECT formatDateTime(toDateTime64('2205-12-12 12:12:12', 0, 'Europe/Moscow'), '%C');
+
+-- non-zero scale
+SELECT formatDateTime(toDateTime64('1935-12-12 12:12:12', 6, 'Europe/Moscow'), '%C');
+SELECT formatDateTime(toDateTime64('1969-12-12 12:12:12', 6, 'Europe/Moscow'), '%C');
+SELECT formatDateTime(toDateTime64('1989-12-12 12:12:12', 6, 'Europe/Moscow'), '%C');
+SELECT formatDateTime(toDateTime64('2019-09-16 19:20:12', 0, 'Europe/Moscow'), '%C');
+SELECT formatDateTime(toDateTime64('2105-12-12 12:12:12', 6, 'Europe/Moscow'), '%C');
+SELECT formatDateTime(toDateTime64('2205-12-12 12:12:12', 6, 'Europe/Moscow'), '%C');

--- a/tests/queries/0_stateless/018002_toDateTime64_large_values.reference
+++ b/tests/queries/0_stateless/018002_toDateTime64_large_values.reference
@@ -1,0 +1,10 @@
+-- { echo }
+
+SELECT toDateTime64('2205-12-12 12:12:12', 0, 'UTC');
+2205-12-12 12:12:12
+SELECT toDateTime64('2205-12-12 12:12:12', 0, 'Europe/Moscow');
+2205-12-12 12:12:12
+SELECT toDateTime64('2205-12-12 12:12:12', 6, 'Europe/Moscow');
+2205-12-12 12:12:12.000000
+SELECT toDateTime64('2205-12-12 12:12:12', 6, 'Europe/Moscow');
+2205-12-12 12:12:12.000000

--- a/tests/queries/0_stateless/018002_toDateTime64_large_values.sql
+++ b/tests/queries/0_stateless/018002_toDateTime64_large_values.sql
@@ -1,0 +1,7 @@
+-- { echo }
+
+SELECT toDateTime64('2205-12-12 12:12:12', 0, 'UTC');
+SELECT toDateTime64('2205-12-12 12:12:12', 0, 'Europe/Moscow');
+
+SELECT toDateTime64('2205-12-12 12:12:12', 6, 'Europe/Moscow');
+SELECT toDateTime64('2205-12-12 12:12:12', 6, 'Europe/Moscow');


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
fixed `formatDateTime()` on `DateTime64` and "%C" format specifier
fixed `toDateTime64()` for large values and non-zero scale.
...

closes: #22852