### PR TITLE
More conservative value of `background_fetches_pool_size` setting

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -78,7 +78,7 @@ class IColumn;
     M(UInt64, background_buffer_flush_schedule_pool_size, 16, "Number of threads performing background flush for tables with Buffer engine. Only has meaning at server startup.", 0) \
     M(UInt64, background_pool_size, 16, "Number of threads performing background work for tables (for example, merging in merge tree). Only has meaning at server startup.", 0) \
     M(UInt64, background_move_pool_size, 8, "Number of threads performing background moves for tables. Only has meaning at server startup.", 0) \
-    M(UInt64, background_fetches_pool_size, 3, "Number of threads performing background fetches for replicated tables. Only has meaning at server startup.", 0) \
+    M(UInt64, background_fetches_pool_size, 8, "Number of threads performing background fetches for replicated tables. Only has meaning at server startup.", 0) \
     M(UInt64, background_schedule_pool_size, 16, "Number of threads performing background tasks for replicated tables, dns cache updates. Only has meaning at server startup.", 0) \
     M(UInt64, background_message_broker_schedule_pool_size, 16, "Number of threads performing background tasks for message streaming. Only has meaning at server startup.", 0) \
     M(UInt64, background_distributed_schedule_pool_size, 16, "Number of threads performing background tasks for distributed sends. Only has meaning at server startup.", 0) \

--- a/tests/integration/test_limited_replicated_fetches/configs/custom_settings.xml
+++ b/tests/integration/test_limited_replicated_fetches/configs/custom_settings.xml
@@ -1,0 +1,7 @@
+<yandex>
+    <profiles>
+        <default>
+            <background_fetches_pool_size>3</background_fetches_pool_size>
+        </default>
+    </profiles>
+</yandex>

--- a/tests/integration/test_limited_replicated_fetches/test.py
+++ b/tests/integration/test_limited_replicated_fetches/test.py
@@ -6,6 +6,7 @@ from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
 import random
 import string
+import os
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', with_zookeeper=True)

--- a/tests/integration/test_limited_replicated_fetches/test.py
+++ b/tests/integration/test_limited_replicated_fetches/test.py
@@ -31,6 +31,9 @@ def get_random_string(length):
 
 
 def test_limited_fetches(started_cluster):
+    """
+        Test checks that that we utilize all available threads for fetches
+    """
     node1.query("CREATE TABLE t (key UInt64, data String) ENGINE = ReplicatedMergeTree('/clickhouse/test/t', '1') ORDER BY tuple() PARTITION BY key")
     node2.query("CREATE TABLE t (key UInt64, data String) ENGINE = ReplicatedMergeTree('/clickhouse/test/t', '2') ORDER BY tuple() PARTITION BY key")
 

--- a/tests/integration/test_limited_replicated_fetches/test.py
+++ b/tests/integration/test_limited_replicated_fetches/test.py
@@ -33,7 +33,7 @@ def test_limited_fetches(started_cluster):
         Test checks that that we utilize all available threads for fetches
     """
     node1.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/custom_settings.xml"), '/etc/clickhouse-server/users.d/fetches.xml')
-    node1.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/custom_settings.xml"), '/etc/clickhouse-server/users.d/fetches.xml')
+    node2.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/custom_settings.xml"), '/etc/clickhouse-server/users.d/fetches.xml')
 
     node1.query("CREATE TABLE t (key UInt64, data String) ENGINE = ReplicatedMergeTree('/clickhouse/test/t', '1') ORDER BY tuple() PARTITION BY key")
     node2.query("CREATE TABLE t (key UInt64, data String) ENGINE = ReplicatedMergeTree('/clickhouse/test/t', '2') ORDER BY tuple() PARTITION BY key")

--- a/tests/integration/test_limited_replicated_fetches/test.py
+++ b/tests/integration/test_limited_replicated_fetches/test.py
@@ -9,6 +9,7 @@ import string
 import os
 
 cluster = ClickHouseCluster(__file__)
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 node1 = cluster.add_instance('node1', with_zookeeper=True)
 node2 = cluster.add_instance('node2', with_zookeeper=True)
 

--- a/tests/integration/test_limited_replicated_fetches/test.py
+++ b/tests/integration/test_limited_replicated_fetches/test.py
@@ -32,6 +32,9 @@ def test_limited_fetches(started_cluster):
     """
         Test checks that that we utilize all available threads for fetches
     """
+    node1.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/custom_settings.xml"), '/etc/clickhouse-server/users.d/fetches.xml')
+    node1.copy_file_to_container(os.path.join(SCRIPT_DIR, "configs/custom_settings.xml"), '/etc/clickhouse-server/users.d/fetches.xml')
+
     node1.query("CREATE TABLE t (key UInt64, data String) ENGINE = ReplicatedMergeTree('/clickhouse/test/t', '1') ORDER BY tuple() PARTITION BY key")
     node2.query("CREATE TABLE t (key UInt64, data String) ENGINE = ReplicatedMergeTree('/clickhouse/test/t', '2') ORDER BY tuple() PARTITION BY key")
 


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Set `background_fetches_pool_size` to 8 that is better for production usage with frequent small insertions or slow ZooKeeper cluster.