### PR TITLE
Fix an error handling in Poco HTTP Client for AWS.

### DIFF
--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -259,7 +259,11 @@ void PocoHTTPClient::makeRequestInternal(
                 String error_message;
                 Poco::StreamCopier::copyToString(response_body_stream, error_message);
 
-                response->SetClientErrorType(Aws::Client::CoreErrors::NETWORK_CONNECTION);
+                if (Aws::Http::IsRetryableHttpResponseCode(response->GetResponseCode()))
+                    response->SetClientErrorType(Aws::Client::CoreErrors::NETWORK_CONNECTION);
+                else
+                    response->SetClientErrorType(Aws::Client::CoreErrors::USER_CANCELLED);
+
                 response->SetClientErrorMessage(error_message);
 
                 if (status_code == 429 || status_code == 503)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry:
Fix an error handling in Poco HTTP Client for AWS.


Detailed description:

Poco HTTP Client for S3 was treating any HTTP error as `CoreErrors::NETWORK_CONNECTION` which in turn was causing to the SDK to think that the error is retryable and the SDK was issuing another request. For example, it was trying to access objects on S3 where the 404 status code was returning, obviously it is not a retryable error.
