### PR TITLE
Fix combinators with common prefix name (State and SimpleState) with libstdc++

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionCombinatorFactory.h
+++ b/src/AggregateFunctions/AggregateFunctionCombinatorFactory.h
@@ -15,7 +15,17 @@ namespace DB
 class AggregateFunctionCombinatorFactory final: private boost::noncopyable
 {
 private:
-    using Dict = std::unordered_map<std::string, AggregateFunctionCombinatorPtr>;
+    struct CombinatorPair
+    {
+        std::string name;
+        AggregateFunctionCombinatorPtr combinator_ptr;
+
+        bool operator==(const CombinatorPair & rhs) const { return name == rhs.name; }
+        /// Sort by the length of the combinator name for proper tryFindSuffix()
+        /// for combiners with common prefix (i.e. "State" and "SimpleState").
+        bool operator<(const CombinatorPair & rhs) const { return name.length() > rhs.name.length(); }
+    };
+    using Dict = std::vector<CombinatorPair>;
     Dict dict;
 
 public:

--- a/src/Storages/System/StorageSystemAggregateFunctionCombinators.cpp
+++ b/src/Storages/System/StorageSystemAggregateFunctionCombinators.cpp
@@ -17,8 +17,8 @@ void StorageSystemAggregateFunctionCombinators::fillData(MutableColumns & res_co
     const auto & combinators = AggregateFunctionCombinatorFactory::instance().getAllAggregateFunctionCombinators();
     for (const auto & pair : combinators)
     {
-        res_columns[0]->insert(pair.first);
-        res_columns[1]->insert(pair.second->isForInternalUsageOnly());
+        res_columns[0]->insert(pair.name);
+        res_columns[1]->insert(pair.combinator_ptr->isForInternalUsageOnly());
     }
 }
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix combinators with common prefix name (State and SimpleState) with libstdc++

Detailed description / Documentation draft:
Previously sort order of the std::unordered_map in libstdc++ was
different and any *SimpleState() reports an error that function does not
exists.

Fix this by using proper order in container, and use std::vector over
std::unordered_map, since there linear traversing anyway in the single
method -- tryFindSuffix()

Note that test is not required, since it either fail with unknown
function or not.

*NOTE: even though code wasn't correct earlier, even for libc++ (official build), it works with existing combiners, hence marked as `Not for changelog`*