### PR TITLE
Fix trivial mistake in filtering by virtual columns

### DIFF
--- a/docker/test/fasttest/run.sh
+++ b/docker/test/fasttest/run.sh
@@ -300,6 +300,7 @@ function run_tests
         01663_aes_msan                          # Depends on OpenSSL
         01667_aes_args_check                    # Depends on OpenSSL
         01776_decrypt_aead_size_check           # Depends on OpenSSL
+        01811_filter_by_null                    # Depends on OpenSSL
         01281_unsucceeded_insert_select_queries_counter
         01292_create_user
         01294_lazy_database_concurrent

--- a/src/Storages/MergeTree/MergeTreeIndexSet.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexSet.cpp
@@ -299,6 +299,10 @@ bool MergeTreeIndexConditionSet::mayBeTrueOnGranule(MergeTreeIndexGranulePtr idx
 
     auto column
         = result.getByName(expression_ast->getColumnName()).column->convertToFullColumnIfConst()->convertToFullColumnIfLowCardinality();
+
+    if (column->onlyNull())
+        return false;
+
     const auto * col_uint8 = typeid_cast<const ColumnUInt8 *>(column.get());
 
     const NullMap * null_map = nullptr;

--- a/src/Storages/MergeTree/MergeTreeRangeReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeRangeReader.cpp
@@ -486,9 +486,13 @@ void MergeTreeRangeReader::ReadResult::setFilter(const ColumnPtr & new_filter)
 
     ConstantFilterDescription const_description(*new_filter);
     if (const_description.always_true)
+    {
         setFilterConstTrue();
+    }
     else if (const_description.always_false)
+    {
         clear();
+    }
     else
     {
         FilterDescription filter_description(*new_filter);

--- a/src/Storages/VirtualColumnUtils.cpp
+++ b/src/Storages/VirtualColumnUtils.cpp
@@ -191,10 +191,15 @@ void filterBlockWithQuery(const ASTPtr & query, Block & block, ContextPtr contex
     ConstantFilterDescription constant_filter(*filter_column);
 
     if (constant_filter.always_true)
+    {
         return;
+    }
 
     if (constant_filter.always_false)
+    {
         block = block.cloneEmpty();
+        return;
+    }
 
     FilterDescription filter(*filter_column);
 

--- a/tests/queries/0_stateless/01811_filter_by_null.sql
+++ b/tests/queries/0_stateless/01811_filter_by_null.sql
@@ -4,5 +4,6 @@ CREATE TABLE test_01344 (x String, INDEX idx (x) TYPE set(10) GRANULARITY 1) ENG
 INSERT INTO test_01344 VALUES ('Hello, world');
 SELECT NULL FROM test_01344 WHERE ignore(1) = NULL;
 SELECT NULL FROM test_01344 WHERE encrypt(ignore(encrypt(NULL, '0.0001048577', lcm(2, 65537), NULL, inf, NULL), lcm(-2, 1048575)), '-0.0000000001', lcm(NULL, NULL)) = NULL;
+SELECT NULL FROM test_01344 WHERE ignore(x, lcm(NULL, 1048576), -2) = NULL;
 
 DROP TABLE test_01344;

--- a/tests/queries/0_stateless/01811_filter_by_null.sql
+++ b/tests/queries/0_stateless/01811_filter_by_null.sql
@@ -1,0 +1,8 @@
+DROP TABLE IF EXISTS test_01344;
+
+CREATE TABLE test_01344 (x String, INDEX idx (x) TYPE set(10) GRANULARITY 1) ENGINE = MergeTree ORDER BY tuple() SETTINGS min_bytes_for_wide_part = 0;
+INSERT INTO test_01344 VALUES ('Hello, world');
+SELECT NULL FROM test_01344 WHERE ignore(1) = NULL;
+SELECT NULL FROM test_01344 WHERE encrypt(ignore(encrypt(NULL, '0.0001048577', lcm(2, 65537), NULL, inf, NULL), lcm(-2, 1048575)), '-0.0000000001', lcm(NULL, NULL)) = NULL;
+
+DROP TABLE test_01344;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry:
When selecting from MergeTree table with NULL in WHERE condition, in rare cases, exception was thrown. This closes #20019.