### PR TITLE
Fix excessive warning in StorageDistributed with cross-replication

### DIFF
--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -753,7 +753,7 @@ void StorageDistributed::alter(const AlterCommands & params, ContextPtr local_co
 
 void StorageDistributed::startup()
 {
-    if (remote_database.empty() && !remote_table_function_ptr)
+    if (remote_database.empty() && !remote_table_function_ptr && !getCluster()->maybeCrossReplication())
         LOG_WARNING(log, "Name of remote database is empty. Default database will be used implicitly.");
 
     if (!storage_policy)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Detailed description / Documentation draft:
Fixes #22672
