### PR TITLE
Fixed erroneus failure of extractAllGroupsHorizontal on large columns

### DIFF
--- a/src/Functions/extractAllGroups.h
+++ b/src/Functions/extractAllGroups.h
@@ -172,7 +172,7 @@ public:
                     for (size_t group = 1; group <= groups_count; ++group)
                         all_matches.push_back(matched_groups[group]);
 
-                    /// Additional limit to fail fast on supposedly incorrect usage, aribtrary value.
+                    /// Additional limit to fail fast on supposedly incorrect usage, arbitrary value.
                     static constexpr size_t MAX_MATCHES_PER_ROW = 1000;
                     if (matches_per_row > MAX_MATCHES_PER_ROW)
                         throw Exception(ErrorCodes::TOO_LARGE_ARRAY_SIZE,

--- a/src/Functions/extractAllGroups.h
+++ b/src/Functions/extractAllGroups.h
@@ -172,11 +172,12 @@ public:
                     for (size_t group = 1; group <= groups_count; ++group)
                         all_matches.push_back(matched_groups[group]);
 
-                    /// Additional limit to fail fast on supposedly incorrect usage.
-                    static constexpr size_t MAX_GROUPS_PER_ROW = 1000000;
-
-                    if (all_matches.size() > MAX_GROUPS_PER_ROW)
-                        throw Exception(ErrorCodes::TOO_LARGE_ARRAY_SIZE, "Too large array size in the result of function {}", getName());
+                    /// Additional limit to fail fast on supposedly incorrect usage, aribtrary value.
+                    static constexpr size_t MAX_MATCHES_PER_ROW = 1000;
+                    if (matches_per_row > MAX_MATCHES_PER_ROW)
+                        throw Exception(ErrorCodes::TOO_LARGE_ARRAY_SIZE,
+                                "Too many matches per row (> {}) in the result of function {}",
+                                MAX_MATCHES_PER_ROW, getName());
 
                     pos = matched_groups[0].data() + std::max<size_t>(1, matched_groups[0].size());
 

--- a/tests/queries/0_stateless/01661_extract_all_groups_throw_fast.sql
+++ b/tests/queries/0_stateless/01661_extract_all_groups_throw_fast.sql
@@ -1,1 +1,2 @@
 SELECT repeat('abcdefghijklmnopqrstuvwxyz', number * 100) AS haystack, extractAllGroupsHorizontal(haystack, '(\\w)') AS matches FROM numbers(1023); -- { serverError 128 }
+SELECT count(extractAllGroupsHorizontal(materialize('a'), '(a)')) FROM numbers(1000000) FORMAT Null; -- shouldn't fail


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Raised the threshold on max number of matches in result of the function `extractAllGroupsHorizontal`.


See tests for a simple example