### PR TITLE
Fix unpleasant behaviour of `Markdown` format

### DIFF
--- a/src/Processors/Formats/Impl/MarkdownRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/MarkdownRowOutputFormat.cpp
@@ -21,16 +21,13 @@ void MarkdownRowOutputFormat::writePrefix()
     }
     writeCString("\n|", out);
     String left_alignment = ":-|";
-    String central_alignment = ":-:|";
     String right_alignment = "-:|";
     for (size_t i = 0; i < columns; ++i)
     {
-        if (isInteger(types[i]))
+        if (types[i]->shouldAlignRightInPrettyFormats())
             writeString(right_alignment, out);
-        else if (isString(types[i]))
-            writeString(left_alignment, out);
         else
-            writeString(central_alignment, out);
+            writeString(left_alignment, out);
     }
     writeChar('\n', out);
 }

--- a/tests/queries/0_stateless/01231_markdown_format.reference
+++ b/tests/queries/0_stateless/01231_markdown_format.reference
@@ -1,5 +1,5 @@
-| id | name | array | 
-|-:|:-|:-:|
-| 1 | name1 | [1,2,3] |
-| 2 | name2 | [4,5,6] |
-| 3 | name3 | [7,8,9] |
+| id | name | array | nullable | low_cardinality | decimal | 
+|-:|:-|:-|:-|:-|-:|
+| 1 | name1 | [1,2,3] | Some long string | name1 | 1.110000 |
+| 2 | name2 | [4,5,60000] | \N | Another long string | 222.222222 |
+| 30000 | One more long string | [7,8,9] | name3 | name3 | 3.330000 |

--- a/tests/queries/0_stateless/01231_markdown_format.sql
+++ b/tests/queries/0_stateless/01231_markdown_format.sql
@@ -1,6 +1,8 @@
 DROP TABLE IF EXISTS makrdown;
-CREATE TABLE markdown (id UInt32, name String, array Array(Int8)) ENGINE = Memory;
-INSERT INTO markdown VALUES (1, 'name1', [1,2,3]), (2, 'name2', [4,5,6]), (3, 'name3', [7,8,9]);
+CREATE TABLE markdown (id UInt32, name String, array Array(Int32), nullable Nullable(String), low_cardinality LowCardinality(String), decimal Decimal32(6)) ENGINE = Memory;
+INSERT INTO markdown VALUES (1, 'name1', [1,2,3], 'Some long string', 'name1', 1.11), (2, 'name2', [4,5,60000], Null, 'Another long string', 222.222222), (30000, 'One more long string', [7,8,9], 'name3', 'name3', 3.33);
 
 SELECT * FROM markdown FORMAT Markdown;
 DROP TABLE IF EXISTS markdown
+
+

--- a/tests/queries/0_stateless/01231_markdown_format.sql
+++ b/tests/queries/0_stateless/01231_markdown_format.sql
@@ -4,5 +4,3 @@ INSERT INTO markdown VALUES (1, 'name1', [1,2,3], 'Some long string', 'name1', 1
 
 SELECT * FROM markdown FORMAT Markdown;
 DROP TABLE IF EXISTS markdown
-
-


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Some values were formatted with alignment in center in table cells in `Markdown` format. Not anymore.

Details:
LowCardinality and Nullable Strings were formatted in center due to mistake. But the original intent was also wrong, because alignment in center always looks ugly.