### PR TITLE
Read ORC file by stripe to reduce memory cost

### DIFF
--- a/src/Processors/Formats/Impl/ORCBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ORCBlockInputFormat.cpp
@@ -19,8 +19,16 @@ namespace ErrorCodes
     extern const int CANNOT_READ_ALL_DATA;
 }
 
+#define THROW_ARROW_NOT_OK(status)                                     \
+    do                                                                 \
+    {                                                                  \
+        if (::arrow::Status _s = (status); !_s.ok())                   \
+            throw Exception(_s.ToString(), ErrorCodes::BAD_ARGUMENTS); \
+    } while (false)
+
 ORCBlockInputFormat::ORCBlockInputFormat(ReadBuffer & in_, Block header_) : IInputFormat(std::move(header_), in_)
 {
+    prepareReader();
 }
 
 Chunk ORCBlockInputFormat::generate()
@@ -28,21 +36,23 @@ Chunk ORCBlockInputFormat::generate()
     Chunk res;
     const Block & header = getPort().getHeader();
 
-    if (file_reader)
+    if (stripe_current >= stripe_total)
         return res;
 
-    arrow::Status open_status = arrow::adapters::orc::ORCFileReader::Open(asArrowFile(in), arrow::default_memory_pool(), &file_reader);
-    if (!open_status.ok())
-        throw Exception(open_status.ToString(), ErrorCodes::BAD_ARGUMENTS);
+    std::shared_ptr<arrow::RecordBatch> batch_result;
+    arrow::Status batch_status = file_reader->ReadStripe(stripe_current, include_indices, &batch_result);
+    if (!batch_status.ok())
+        throw ParsingException(ErrorCodes::CANNOT_READ_ALL_DATA,
+                               "Error while reading batch of ORC data: {}", batch_status.ToString());
 
-    std::shared_ptr<arrow::Table> table;
-    arrow::Status read_status = file_reader->Read(&table);
-    if (!read_status.ok())
-        throw ParsingException{"Error while reading ORC data: " + read_status.ToString(),
-                        ErrorCodes::CANNOT_READ_ALL_DATA};
+    auto table_result = arrow::Table::FromRecordBatches({batch_result});
+    if (!table_result.ok())
+        throw ParsingException(ErrorCodes::CANNOT_READ_ALL_DATA,
+                               "Error while reading batch of ORC data: {}", table_result.status().ToString());
 
-    ArrowColumnToCHColumn::arrowTableToCHChunk(res, table, header, "ORC");
+    ++stripe_current;
 
+    ArrowColumnToCHColumn::arrowTableToCHChunk(res, *table_result, header, "ORC");
     return res;
 }
 
@@ -51,6 +61,26 @@ void ORCBlockInputFormat::resetParser()
     IInputFormat::resetParser();
 
     file_reader.reset();
+    include_indices.clear();
+    prepareReader();
+}
+
+void ORCBlockInputFormat::prepareReader()
+{
+    THROW_ARROW_NOT_OK(arrow::adapters::orc::ORCFileReader::Open(asArrowFile(in), arrow::default_memory_pool(), &file_reader));
+    stripe_total = file_reader->NumberOfStripes();
+    stripe_current = 0;
+
+    std::shared_ptr<arrow::Schema> schema;
+    THROW_ARROW_NOT_OK(file_reader->ReadSchema(&schema));
+
+    for (int i = 0; i < schema->num_fields(); ++i)
+    {
+        if (getPort().getHeader().has(schema->field(i)->name()))
+        {
+            include_indices.push_back(i);
+        }
+    }
 }
 
 void registerInputFormatProcessorORC(FormatFactory &factory)

--- a/src/Processors/Formats/Impl/ORCBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ORCBlockInputFormat.cpp
@@ -28,13 +28,15 @@ namespace ErrorCodes
 
 ORCBlockInputFormat::ORCBlockInputFormat(ReadBuffer & in_, Block header_) : IInputFormat(std::move(header_), in_)
 {
-    prepareReader();
 }
 
 Chunk ORCBlockInputFormat::generate()
 {
     Chunk res;
     const Block & header = getPort().getHeader();
+
+    if (!file_reader)
+        prepareReader();
 
     if (stripe_current >= stripe_total)
         return res;
@@ -62,7 +64,7 @@ void ORCBlockInputFormat::resetParser()
 
     file_reader.reset();
     include_indices.clear();
-    prepareReader();
+    stripe_current = 0;
 }
 
 void ORCBlockInputFormat::prepareReader()

--- a/src/Processors/Formats/Impl/ORCBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ORCBlockInputFormat.cpp
@@ -78,7 +78,7 @@ void ORCBlockInputFormat::prepareReader()
     {
         if (getPort().getHeader().has(schema->field(i)->name()))
         {
-            include_indices.push_back(i);
+            include_indices.push_back(i+1);
         }
     }
 }

--- a/src/Processors/Formats/Impl/ORCBlockInputFormat.h
+++ b/src/Processors/Formats/Impl/ORCBlockInputFormat.h
@@ -25,6 +25,15 @@ private:
     // TODO: check that this class implements every part of its parent
 
     std::unique_ptr<arrow::adapters::orc::ORCFileReader> file_reader;
+
+    int stripe_total = 0;
+
+    int stripe_current = 0;
+
+    // indices of columns to read from ORC file
+    std::vector<int> include_indices;
+
+    void prepareReader();
 };
 
 }


### PR DESCRIPTION
**I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en**


**Changelog category (leave one):**

- Performance Improvement


**Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):**

ORC input format reading by stripe instead of reading entire table into memory by once which is cost memory when file size is huge.


**Detailed description / Documentation draft:**

ORC input format reading by stripe instead of reading entire table into memory by once which is cost memory when file is huge.

From now on，Apache Arrow can not open orc input stream directly, so we have to read batch of table to reduce memory cost.

Fix issue: https://github.com/ClickHouse/ClickHouse/issues/22831


**Performance Test Compare**:

Virtual Machine: 8GB, 4CPU

ORC file 000000_0: 336110 rows,  259 columns, 60MB file size with zlib compression, 11 stripes.
```
./clickhouse-client --log-level trace -q "insert into default.student1 format ORC" < ~/000000_0
```
<details>
<summary>Before</summary>
<pre><code>
query_log

type:                                QueryFinish
event_date:                          2021-04-16
event_time:                          2021-04-16 16:29:37
event_time_microseconds:             2021-04-16 16:29:37.548922
query_start_time:                    2021-04-16 16:28:08
query_start_time_microseconds:       2021-04-16 16:28:08.379965
query_duration_ms:                   89168
read_rows:                           0
read_bytes:                          0
written_rows:                        336110
written_bytes:                       1846588340
result_rows:                         336110
result_bytes:                        1846588340
memory_usage:                        3118763408
current_database:                    default
query:                               insert into default.student1 format ORC
normalized_query_hash:               12943215163768261868
query_kind:                          Insert
databases:                           ['default']
tables:                              ['default.student1']
columns:                             []
exception_code:                      0
exception:
stack_trace:
is_initial_query:                    1
user:                                default
query_id:                            b49097aa-d9f5-46b0-8a0c-03b66cc784c9
address:                             ::ffff:127.0.0.1
port:                                37846
initial_user:                        default
initial_query_id:                    b49097aa-d9f5-46b0-8a0c-03b66cc784c9
initial_address:                     ::ffff:127.0.0.1
initial_port:                        37846
interface:                           1
os_user:                             godliness
client_hostname:                     ubuntu01
client_name:                         ClickHouse
client_revision:                     54448
client_version_major:                21
client_version_minor:                5
client_version_patch:                1
http_method:                         0
http_user_agent:
http_referer:
forwarded_for:
quota_key:
revision:                            54450
log_comment:
thread_ids:                          [1434]
ProfileEvents.Names:                 ['Query','InsertQuery','FileOpen','ReadBufferFromFileDescriptorRead','ReadBufferFromFileDescriptorReadBytes','WriteBufferFromFileDescriptorWrite','WriteBufferFromFileDescriptorWriteBytes','ReadCompressedBytes','CompressedReadBufferBlocks','CompressedReadBufferBytes','IOBufferAllocs','IOBufferAllocBytes','CreatedReadBufferOrdinary','DiskReadElapsedMicroseconds','DiskWriteElapsedMicroseconds','NetworkReceiveElapsedMicroseconds','NetworkSendElapsedMicroseconds','InsertedRows','InsertedBytes','SelectedRows','SelectedBytes','MergeTreeDataWriterRows','MergeTreeDataWriterUncompressedBytes','MergeTreeDataWriterCompressedBytes','MergeTreeDataWriterBlocks','ContextLock','RWLockAcquiredReadLocks','RealTimeMicroseconds','UserTimeMicroseconds','SystemTimeMicroseconds','SoftPageFaults','HardPageFaults','OSIOWaitMicroseconds','OSCPUWaitMicroseconds','OSCPUVirtualTimeMicroseconds','OSReadBytes','OSWriteBytes','OSReadChars','OSWriteChars']
ProfileEvents.Values:                [1,1,525,6,21584,784,14479534,894950948,1122,1154205544,1568,551235870,1,27,17836,19573948,197,336110,1846588340,336110,1846588340,336110,1846588340,14467342,1,271,2,89168926,30348171,2644084,913969,19,50000,58573,32992254,53637120,16195584,22032,14704787]
Settings.Names:                      ['load_balancing','log_queries','max_memory_usage','allow_introspection_functions']
Settings.Values:                     ['random','1','10000000000','1']
used_aggregate_functions:            []
used_aggregate_function_combinators: []
used_database_engines:               []
used_data_type_families:             ['String','Int32']
used_dictionaries:                   []
used_formats:                        []
used_functions:                      ['replicate']
used_storages:                       []
used_table_functions:                []
</code></pre>
</details>


<details>
<summary>After</summary>
<pre><code>
query_log

type:                                QueryFinish
event_date:                          2021-04-16
event_time:                          2021-04-16 16:01:04
event_time_microseconds:             2021-04-16 16:01:04.828358
query_start_time:                    2021-04-16 16:00:06
query_start_time_microseconds:       2021-04-16 16:00:06.536604
query_duration_ms:                   58290
read_rows:                           0
read_bytes:                          0
written_rows:                        336110
written_bytes:                       1846588340
result_rows:                         336110
result_bytes:                        1846588340
memory_usage:                        1525455568
current_database:                    default
query:                               insert into default.student1 format ORC
normalized_query_hash:               12943215163768261868
query_kind:                          Insert
databases:                           ['default']
tables:                              ['default.student1']
columns:                             []
exception_code:                      0
exception:
stack_trace:
is_initial_query:                    1
user:                                default
query_id:                            9218727b-a7de-4447-b278-4071b4f87705
address:                             ::ffff:127.0.0.1
port:                                40864
initial_user:                        default
initial_query_id:                    9218727b-a7de-4447-b278-4071b4f87705
initial_address:                     ::ffff:127.0.0.1
initial_port:                        40864
interface:                           1
os_user:                             godliness
client_hostname:                     ubuntu01
client_name:                         ClickHouse
client_revision:                     54448
client_version_major:                21
client_version_minor:                5
client_version_patch:                1
http_method:                         0
http_user_agent:
http_referer:
forwarded_for:
quota_key:
revision:                            54450
log_comment:
thread_ids:                          [10965]
ProfileEvents.Names:                 ['Query','InsertQuery','FileOpen','ReadBufferFromFileDescriptorRead','ReadBufferFromFileDescriptorReadBytes','WriteBufferFromFileDescriptorWrite','WriteBufferFromFileDescriptorWriteBytes','ReadCompressedBytes','CompressedReadBufferBlocks','CompressedReadBufferBytes','IOBufferAllocs','IOBufferAllocBytes','CreatedReadBufferOrdinary','DiskReadElapsedMicroseconds','DiskWriteElapsedMicroseconds','NetworkReceiveElapsedMicroseconds','NetworkSendElapsedMicroseconds','InsertedRows','InsertedBytes','SelectedRows','SelectedBytes','MergeTreeDataWriterRows','MergeTreeDataWriterUncompressedBytes','MergeTreeDataWriterCompressedBytes','MergeTreeDataWriterBlocks','ContextLock','RWLockAcquiredReadLocks','RealTimeMicroseconds','UserTimeMicroseconds','SystemTimeMicroseconds','SoftPageFaults','HardPageFaults','OSIOWaitMicroseconds','OSCPUWaitMicroseconds','OSCPUVirtualTimeMicroseconds','OSReadBytes','OSWriteBytes','OSReadChars','OSWriteChars']
ProfileEvents.Values:                [1,1,3150,36,87964,3150,53696984,895145020,1130,1154243383,9393,3296939705,6,164,42964,19494908,99,336110,1846588340,336110,1846588340,336110,1846588340,53623737,6,2881,2,58291553,32456208,2515230,1165930,250,130000,184502,34971437,56565760,63442944,88435,53732918]
Settings.Names:                      ['load_balancing','log_queries','max_memory_usage','allow_introspection_functions']
Settings.Values:                     ['random','1','10000000000','1']
used_aggregate_functions:            []
used_aggregate_function_combinators: []
used_database_engines:               []
used_data_type_families:             ['String','Int32']
used_dictionaries:                   []
used_formats:                        []
used_functions:                      ['replicate']
used_storages:                       []
used_table_functions:                []
</code></pre>
</details>


