### PR TITLE
DiskS3 possibility to restore parts to detached directory

### DIFF
--- a/src/Disks/DiskCacheWrapper.cpp
+++ b/src/Disks/DiskCacheWrapper.cpp
@@ -1,7 +1,6 @@
 #include "DiskCacheWrapper.h"
 #include <IO/copyData.h>
 #include <Common/quoteString.h>
-#include <common/logger_useful.h>
 #include <condition_variable>
 
 namespace DB
@@ -114,7 +113,7 @@ DiskCacheWrapper::readFile(
     if (!cache_file_predicate(path))
         return DiskDecorator::readFile(path, buf_size, estimated_size, aio_threshold, mmap_threshold, mmap_cache);
 
-    LOG_DEBUG(&Poco::Logger::get("DiskCache"), "Read file {} from cache", backQuote(path));
+    LOG_DEBUG(log, "Read file {} from cache", backQuote(path));
 
     if (cache_disk->exists(path))
         return cache_disk->readFile(path, buf_size, estimated_size, aio_threshold, mmap_threshold, mmap_cache);
@@ -128,11 +127,11 @@ DiskCacheWrapper::readFile(
         {
             /// This thread will responsible for file downloading to cache.
             metadata->status = DOWNLOADING;
-            LOG_DEBUG(&Poco::Logger::get("DiskCache"), "File {} doesn't exist in cache. Will download it", backQuote(path));
+            LOG_DEBUG(log, "File {} doesn't exist in cache. Will download it", backQuote(path));
         }
         else if (metadata->status == DOWNLOADING)
         {
-            LOG_DEBUG(&Poco::Logger::get("DiskCache"), "Waiting for file {} download to cache", backQuote(path));
+            LOG_DEBUG(log, "Waiting for file {} download to cache", backQuote(path));
             metadata->condition.wait(lock, [metadata] { return metadata->status == DOWNLOADED || metadata->status == ERROR; });
         }
     }
@@ -157,7 +156,7 @@ DiskCacheWrapper::readFile(
                 }
                 cache_disk->moveFile(tmp_path, path);
 
-                LOG_DEBUG(&Poco::Logger::get("DiskCache"), "File {} downloaded to cache", backQuote(path));
+                LOG_DEBUG(log, "File {} downloaded to cache", backQuote(path));
             }
             catch (...)
             {
@@ -186,7 +185,7 @@ DiskCacheWrapper::writeFile(const String & path, size_t buf_size, WriteMode mode
     if (!cache_file_predicate(path))
         return DiskDecorator::writeFile(path, buf_size, mode);
 
-    LOG_DEBUG(&Poco::Logger::get("DiskCache"), "Write file {} to cache", backQuote(path));
+    LOG_DEBUG(log, "Write file {} to cache", backQuote(path));
 
     auto dir_path = directoryPath(path);
     if (!cache_disk->exists(dir_path))

--- a/src/Disks/DiskCacheWrapper.h
+++ b/src/Disks/DiskCacheWrapper.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <unordered_map>
+#include <common/logger_useful.h>
 #include "DiskDecorator.h"
 #include "DiskLocal.h"
 
@@ -63,6 +64,8 @@ private:
     mutable std::unordered_map<String, std::weak_ptr<FileDownloadMetadata>> file_downloads;
     /// Protects concurrent downloading files to cache.
     mutable std::mutex mutex;
+
+    Poco::Logger * log = &Poco::Logger::get("DiskCache");
 };
 
 }

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -2,13 +2,13 @@
 #include <Common/createHardLink.h>
 #include "DiskFactory.h"
 
+#include <Disks/LocalDirectorySyncGuard.h>
 #include <Interpreters/Context.h>
 #include <Common/filesystemHelpers.h>
 #include <Common/quoteString.h>
-#include <Disks/LocalDirectorySyncGuard.h>
 
 #include <IO/createReadBufferFromFileBase.h>
-#include <common/logger_useful.h>
+
 #include <unistd.h>
 
 
@@ -96,7 +96,7 @@ bool DiskLocal::tryReserve(UInt64 bytes)
     std::lock_guard lock(DiskLocal::reservation_mutex);
     if (bytes == 0)
     {
-        LOG_DEBUG(&Poco::Logger::get("DiskLocal"), "Reserving 0 bytes on disk {}", backQuote(name));
+        LOG_DEBUG(log, "Reserving 0 bytes on disk {}", backQuote(name));
         ++reservation_count;
         return true;
     }
@@ -105,7 +105,7 @@ bool DiskLocal::tryReserve(UInt64 bytes)
     UInt64 unreserved_space = available_space - std::min(available_space, reserved_bytes);
     if (unreserved_space >= bytes)
     {
-        LOG_DEBUG(&Poco::Logger::get("DiskLocal"), "Reserving {} on disk {}, having unreserved {}.",
+        LOG_DEBUG(log, "Reserving {} on disk {}, having unreserved {}.",
             ReadableSize(bytes), backQuote(name), ReadableSize(unreserved_space));
         ++reservation_count;
         reserved_bytes += bytes;
@@ -339,7 +339,7 @@ DiskLocalReservation::~DiskLocalReservation()
         if (disk->reserved_bytes < size)
         {
             disk->reserved_bytes = 0;
-            LOG_ERROR(&Poco::Logger::get("DiskLocal"), "Unbalanced reservations size for disk '{}'.", disk->getName());
+            LOG_ERROR(disk->log, "Unbalanced reservations size for disk '{}'.", disk->getName());
         }
         else
         {
@@ -347,7 +347,7 @@ DiskLocalReservation::~DiskLocalReservation()
         }
 
         if (disk->reservation_count == 0)
-            LOG_ERROR(&Poco::Logger::get("DiskLocal"), "Unbalanced reservation count for disk '{}'.", disk->getName());
+            LOG_ERROR(disk->log, "Unbalanced reservation count for disk '{}'.", disk->getName());
         else
             --disk->reservation_count;
     }

--- a/src/Disks/DiskLocal.h
+++ b/src/Disks/DiskLocal.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <common/logger_useful.h>
 #include <Disks/IDisk.h>
 #include <IO/ReadBufferFromFile.h>
 #include <IO/ReadBufferFromFileBase.h>
@@ -115,6 +116,8 @@ private:
     UInt64 reservation_count = 0;
 
     static std::mutex reservation_mutex;
+
+    Poco::Logger * log = &Poco::Logger::get("DiskLocal");
 };
 
 }

--- a/src/Disks/S3/DiskS3.cpp
+++ b/src/Disks/S3/DiskS3.cpp
@@ -2,6 +2,7 @@
 
 #include "Disks/DiskFactory.h"
 
+#include <bitset>
 #include <random>
 #include <optional>
 #include <utility>

--- a/src/Disks/S3/DiskS3.h
+++ b/src/Disks/S3/DiskS3.h
@@ -167,12 +167,15 @@ private:
     void readRestoreInformation(RestoreInformation & restore_information);
     void restoreFiles(const String & source_bucket, const String & source_path, UInt64 target_revision);
     void processRestoreFiles(const String & source_bucket, const String & source_path, std::vector<String> keys);
-    void restoreFileOperations(const String & source_bucket, const String & source_path, UInt64 target_revision);
+    void restoreFileOperations(const String & source_bucket, const String & source_path, UInt64 target_revision, bool detached);
 
     /// Remove 'path' prefix from 'key' to get relative key.
     /// It's needed to store keys to metadata files in RELATIVE_PATHS version.
     static String shrinkKey(const String & path, const String & key);
     std::tuple<UInt64, String> extractRevisionAndOperationFromKey(const String & key);
+
+    /// Forms detached path '../../detached/part_name/' from '../../part_name/'
+    static String pathToDetached(const String & source_path);
 
     const String name;
     std::shared_ptr<Aws::S3::S3Client> client;

--- a/src/Disks/S3/DiskS3.h
+++ b/src/Disks/S3/DiskS3.h
@@ -167,9 +167,9 @@ private:
     void copyObject(const String & src_bucket, const String & src_key, const String & dst_bucket, const String & dst_key);
 
     void readRestoreInformation(RestoreInformation & restore_information);
-    void restoreFiles(const String & source_bucket, const String & source_path, UInt64 target_revision);
+    void restoreFiles(const RestoreInformation & restore_information);
     void processRestoreFiles(const String & source_bucket, const String & source_path, std::vector<String> keys);
-    void restoreFileOperations(const String & source_bucket, const String & source_path, UInt64 target_revision, bool detached);
+    void restoreFileOperations(const RestoreInformation & restore_information);
 
     /// Remove 'path' prefix from 'key' to get relative key.
     /// It's needed to store keys to metadata files in RELATIVE_PATHS version.
@@ -204,7 +204,7 @@ private:
     int list_object_keys_size;
 
     /// Key has format: ../../r{revision}-{operation}
-    const re2::RE2 key_regexp {".*/r(\\w+)-(\\w+).*"};
+    const re2::RE2 key_regexp {".*/r(\\d+)-(\\w+).*"};
 
     /// Object contains information about schema version.
     inline static const String SCHEMA_VERSION_OBJECT = ".SCHEMA_VERSION";

--- a/src/Disks/S3/DiskS3.h
+++ b/src/Disks/S3/DiskS3.h
@@ -148,6 +148,7 @@ private:
     Metadata createMeta(const String & path) const;
 
     void createFileOperationObject(const String & operation_name, UInt64 revision, const ObjectMetadata & metadata);
+    /// Converts revision to binary string with leading zeroes (64 bit).
     static String revisionToString(UInt64 revision);
 
     bool checkObjectExists(const String & source_bucket, const String & prefix);
@@ -202,7 +203,7 @@ private:
     int list_object_keys_size;
 
     /// Key has format: ../../r{revision}-{operation}
-    const re2::RE2 key_regexp {".*/r(\\d+)-(\\w+).*"};
+    const re2::RE2 key_regexp {".*/r(\\w+)-(\\w+).*"};
 
     /// Object contains information about schema version.
     inline static const String SCHEMA_VERSION_OBJECT = ".SCHEMA_VERSION";

--- a/src/Disks/S3/DiskS3.h
+++ b/src/Disks/S3/DiskS3.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <common/logger_useful.h>
 #include "Disks/DiskFactory.h"
 #include "Disks/Executor.h"
 #include "ProxyConfiguration.h"
@@ -211,6 +212,8 @@ private:
     static constexpr int RESTORABLE_SCHEMA_VERSION = 1;
     /// Directories with data.
     const std::vector<String> data_roots {"data", "store"};
+
+    Poco::Logger * log = &Poco::Logger::get("DiskS3");
 };
 
 }

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -1124,21 +1124,26 @@ class ClickHouseInstance:
         return self.http_query(sql=sql, data=data, params=params, user=user, password=password,
                                expect_fail_and_get_error=True)
 
-    def stop_clickhouse(self, start_wait_sec=5, kill=False):
+    def stop_clickhouse(self, stop_wait_sec=5, kill=False):
         if not self.stay_alive:
             raise Exception("clickhouse can be stopped only with stay_alive=True instance")
 
         self.exec_in_container(["bash", "-c", "pkill {} clickhouse".format("-9" if kill else "")], user='root')
-        time.sleep(start_wait_sec)
+        deadline = time.time() + stop_wait_sec
+        while time.time() < deadline:
+            time.sleep(0.5)
+            if self.get_process_pid("clickhouse") is None:
+                break
+        assert self.get_process_pid("clickhouse") is None, "ClickHouse was not stopped"
 
-    def start_clickhouse(self, stop_wait_sec=5):
+    def start_clickhouse(self, start_wait_sec=5):
         if not self.stay_alive:
             raise Exception("clickhouse can be started again only with stay_alive=True instance")
 
         self.exec_in_container(["bash", "-c", "{} --daemon".format(CLICKHOUSE_START_COMMAND)], user=str(os.getuid()))
         # wait start
         from helpers.test_tools import assert_eq_with_retry
-        assert_eq_with_retry(self, "select 1", "1", retry_count=int(stop_wait_sec / 0.5), sleep_time=0.5)
+        assert_eq_with_retry(self, "select 1", "1", retry_count=int(start_wait_sec / 0.5), sleep_time=0.5)
 
     def restart_clickhouse(self, stop_start_wait_sec=5, kill=False):
         self.stop_clickhouse(stop_start_wait_sec, kill)

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -1124,7 +1124,7 @@ class ClickHouseInstance:
         return self.http_query(sql=sql, data=data, params=params, user=user, password=password,
                                expect_fail_and_get_error=True)
 
-    def stop_clickhouse(self, stop_wait_sec=5, kill=False):
+    def stop_clickhouse(self, stop_wait_sec=30, kill=False):
         if not self.stay_alive:
             raise Exception("clickhouse can be stopped only with stay_alive=True instance")
 
@@ -1136,7 +1136,7 @@ class ClickHouseInstance:
                 break
         assert self.get_process_pid("clickhouse") is None, "ClickHouse was not stopped"
 
-    def start_clickhouse(self, start_wait_sec=5):
+    def start_clickhouse(self, start_wait_sec=30):
         if not self.stay_alive:
             raise Exception("clickhouse can be started again only with stay_alive=True instance")
 
@@ -1145,7 +1145,7 @@ class ClickHouseInstance:
         from helpers.test_tools import assert_eq_with_retry
         assert_eq_with_retry(self, "select 1", "1", retry_count=int(start_wait_sec / 0.5), sleep_time=0.5)
 
-    def restart_clickhouse(self, stop_start_wait_sec=5, kill=False):
+    def restart_clickhouse(self, stop_start_wait_sec=30, kill=False):
         self.stop_clickhouse(stop_start_wait_sec, kill)
         self.start_clickhouse(stop_start_wait_sec)
 

--- a/tests/integration/test_merge_tree_s3_restore/configs/config.d/clusters.xml
+++ b/tests/integration/test_merge_tree_s3_restore/configs/config.d/clusters.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<yandex>
+    <remote_servers>
+        <node>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>node</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </node>
+        <node_another_bucket>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>node_another_bucket</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </node_another_bucket>
+    </remote_servers>
+</yandex>

--- a/tests/integration/test_merge_tree_s3_restore/test.py
+++ b/tests/integration/test_merge_tree_s3_restore/test.py
@@ -156,7 +156,7 @@ def test_full_restore(cluster, replicated):
     node.stop_clickhouse()
     drop_s3_metadata(node)
     create_restore_file(node)
-    node.start_clickhouse(10)
+    node.start_clickhouse()
 
     assert node.query("SELECT count(*) FROM s3.test FORMAT Values") == "({})".format(4096 * 4)
     assert node.query("SELECT sum(id) FROM s3.test FORMAT Values") == "({})".format(0)
@@ -184,7 +184,7 @@ def test_restore_another_bucket_path(cluster):
 
     node_another_bucket.stop_clickhouse()
     create_restore_file(node_another_bucket, bucket="root")
-    node_another_bucket.start_clickhouse(10)
+    node_another_bucket.start_clickhouse()
 
     assert node_another_bucket.query("SELECT count(*) FROM s3.test FORMAT Values") == "({})".format(4096 * 4)
     assert node_another_bucket.query("SELECT sum(id) FROM s3.test FORMAT Values") == "({})".format(0)
@@ -195,7 +195,7 @@ def test_restore_another_bucket_path(cluster):
 
     node_another_bucket_path.stop_clickhouse()
     create_restore_file(node_another_bucket_path, bucket="root2", path="data")
-    node_another_bucket_path.start_clickhouse(10)
+    node_another_bucket_path.start_clickhouse()
 
     assert node_another_bucket_path.query("SELECT count(*) FROM s3.test FORMAT Values") == "({})".format(4096 * 4)
     assert node_another_bucket_path.query("SELECT sum(id) FROM s3.test FORMAT Values") == "({})".format(0)
@@ -237,7 +237,7 @@ def test_restore_different_revisions(cluster):
     drop_s3_metadata(node_another_bucket)
     purge_s3(cluster, cluster.minio_bucket_2)
     create_restore_file(node_another_bucket, revision=revision1, bucket="root")
-    node_another_bucket.start_clickhouse(10)
+    node_another_bucket.start_clickhouse()
 
     assert node_another_bucket.query("SELECT count(*) FROM s3.test FORMAT Values") == "({})".format(4096 * 2)
     assert node_another_bucket.query("SELECT sum(id) FROM s3.test FORMAT Values") == "({})".format(0)
@@ -248,7 +248,7 @@ def test_restore_different_revisions(cluster):
     drop_s3_metadata(node_another_bucket)
     purge_s3(cluster, cluster.minio_bucket_2)
     create_restore_file(node_another_bucket, revision=revision2, bucket="root")
-    node_another_bucket.start_clickhouse(10)
+    node_another_bucket.start_clickhouse()
 
     assert node_another_bucket.query("SELECT count(*) FROM s3.test FORMAT Values") == "({})".format(4096 * 4)
     assert node_another_bucket.query("SELECT sum(id) FROM s3.test FORMAT Values") == "({})".format(0)
@@ -259,7 +259,7 @@ def test_restore_different_revisions(cluster):
     drop_s3_metadata(node_another_bucket)
     purge_s3(cluster, cluster.minio_bucket_2)
     create_restore_file(node_another_bucket, revision=revision3, bucket="root")
-    node_another_bucket.start_clickhouse(10)
+    node_another_bucket.start_clickhouse()
 
     assert node_another_bucket.query("SELECT count(*) FROM s3.test FORMAT Values") == "({})".format(4096 * 4)
     assert node_another_bucket.query("SELECT sum(id) FROM s3.test FORMAT Values") == "({})".format(0)
@@ -291,7 +291,7 @@ def test_restore_mutations(cluster):
     drop_s3_metadata(node_another_bucket)
     purge_s3(cluster, cluster.minio_bucket_2)
     create_restore_file(node_another_bucket, revision=revision_before_mutation, bucket="root")
-    node_another_bucket.start_clickhouse(10)
+    node_another_bucket.start_clickhouse()
 
     assert node_another_bucket.query("SELECT count(*) FROM s3.test FORMAT Values") == "({})".format(4096 * 2)
     assert node_another_bucket.query("SELECT sum(id) FROM s3.test FORMAT Values") == "({})".format(0)
@@ -302,7 +302,7 @@ def test_restore_mutations(cluster):
     drop_s3_metadata(node_another_bucket)
     purge_s3(cluster, cluster.minio_bucket_2)
     create_restore_file(node_another_bucket, revision=revision_after_mutation, bucket="root")
-    node_another_bucket.start_clickhouse(10)
+    node_another_bucket.start_clickhouse()
 
     assert node_another_bucket.query("SELECT count(*) FROM s3.test FORMAT Values") == "({})".format(4096 * 2)
     assert node_another_bucket.query("SELECT sum(id) FROM s3.test FORMAT Values") == "({})".format(0)
@@ -316,7 +316,7 @@ def test_restore_mutations(cluster):
     purge_s3(cluster, cluster.minio_bucket_2)
     revision = (revision_before_mutation + revision_after_mutation) // 2
     create_restore_file(node_another_bucket, revision=revision, bucket="root")
-    node_another_bucket.start_clickhouse(10)
+    node_another_bucket.start_clickhouse()
 
     # Wait for unfinished mutation completion.
     time.sleep(3)
@@ -339,7 +339,7 @@ def test_migrate_to_restorable_schema(cluster):
 
     replace_config("<send_metadata>false</send_metadata>", "<send_metadata>true</send_metadata>")
 
-    node.restart_clickhouse(10)
+    node.restart_clickhouse()
 
     node.query("INSERT INTO s3.test VALUES {}".format(generate_values('2020-01-06', 4096)))
     node.query("INSERT INTO s3.test VALUES {}".format(generate_values('2020-01-06', 4096, -1)))
@@ -358,7 +358,7 @@ def test_migrate_to_restorable_schema(cluster):
     drop_s3_metadata(node_another_bucket)
     purge_s3(cluster, cluster.minio_bucket_2)
     create_restore_file(node_another_bucket, revision=revision, bucket="root", path="another_data")
-    node_another_bucket.start_clickhouse(10)
+    node_another_bucket.start_clickhouse()
 
     assert node_another_bucket.query("SELECT count(*) FROM s3.test FORMAT Values") == "({})".format(4096 * 6)
     assert node_another_bucket.query("SELECT sum(id) FROM s3.test FORMAT Values") == "({})".format(0)
@@ -393,7 +393,7 @@ def test_restore_to_detached(cluster, replicated):
 
     node_another_bucket.stop_clickhouse()
     create_restore_file(node_another_bucket, revision=revision, bucket="root", path="data", detached=True)
-    node_another_bucket.start_clickhouse(10)
+    node_another_bucket.start_clickhouse()
 
     assert node_another_bucket.query("SELECT count(*) FROM s3.test FORMAT Values") == "({})".format(0)
 

--- a/tests/integration/test_merge_tree_s3_restore/test.py
+++ b/tests/integration/test_merge_tree_s3_restore/test.py
@@ -106,15 +106,18 @@ def drop_shadow_information(node):
     node.exec_in_container(['bash', '-c', 'rm -rf /var/lib/clickhouse/shadow/*'], user='root')
 
 
-def create_restore_file(node, revision=0, bucket=None, path=None, detached=None):
-    add_restore_option = 'echo -en "{}\n" >> /var/lib/clickhouse/disks/s3/restore'
-    node.exec_in_container(['bash', '-c', add_restore_option.format(revision)], user='root')
+def create_restore_file(node, revision=None, bucket=None, path=None, detached=None):
+    node.exec_in_container(['bash', '-c', 'touch /var/lib/clickhouse/disks/s3/restore'], user='root')
+
+    add_restore_option = 'echo -en "{}={}\n" >> /var/lib/clickhouse/disks/s3/restore'
+    if revision:
+        node.exec_in_container(['bash', '-c', add_restore_option.format('revision', revision)], user='root')
     if bucket:
-        node.exec_in_container(['bash', '-c', add_restore_option.format(bucket)], user='root')
+        node.exec_in_container(['bash', '-c', add_restore_option.format('source_bucket', bucket)], user='root')
     if path:
-        node.exec_in_container(['bash', '-c', add_restore_option.format(path)], user='root')
+        node.exec_in_container(['bash', '-c', add_restore_option.format('source_path', path)], user='root')
     if detached:
-        node.exec_in_container(['bash', '-c', add_restore_option.format('true')], user='root')
+        node.exec_in_container(['bash', '-c', add_restore_option.format('detached', 'true')], user='root')
 
 
 def get_revision_counter(node, backup_number):

--- a/tests/integration/test_merge_tree_s3_restore/test.py
+++ b/tests/integration/test_merge_tree_s3_restore/test.py
@@ -7,6 +7,7 @@ import time
 import pytest
 from helpers.cluster import ClickHouseCluster
 
+
 logging.getLogger().setLevel(logging.INFO)
 logging.getLogger().addHandler(logging.StreamHandler())
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added possibility to restore MergeTree parts to 'detached' directory for DiskS3

Detailed description / Documentation draft:
Added possibility to move MergeTree parts to 'detached' directory during restore DiskS3.
Reworked revision number storing & searching (the previous approach wasn't correct and may lead to wrong revision found on start).
Added ReplicatedMergeTree coverage to restore DiskS3 tests.