### PR TITLE
Fix flapping tests test_s3_zero_copy_replication

### DIFF
--- a/tests/integration/test_s3_zero_copy_replication/configs/config.d/s3.xml
+++ b/tests/integration/test_s3_zero_copy_replication/configs/config.d/s3.xml
@@ -26,6 +26,7 @@
                         <disk>s31</disk>
                     </external>
                 </volumes>
+                <move_factor>0.0</move_factor>
             </hybrid>
         </policies>
     </storage_configuration>

--- a/tests/integration/test_s3_zero_copy_replication/test.py
+++ b/tests/integration/test_s3_zero_copy_replication/test.py
@@ -36,6 +36,15 @@ def get_large_objects_count(cluster, size=100):
     return counter
 
 
+def wait_for_large_objects_count(cluster, expected, size=100, timeout=30):
+    while timeout > 0:
+        if get_large_objects_count(cluster, size) == expected:
+            return
+        timeout -= 1
+        time.sleep(1)
+    assert get_large_objects_count(cluster, size) == expected
+
+
 @pytest.mark.parametrize(
     "policy", ["s3"]
 )
@@ -67,23 +76,15 @@ def test_s3_zero_copy_replication(cluster, policy):
     assert node1.query("SELECT * FROM s3_test order by id FORMAT Values") == "(0,'data'),(1,'data'),(2,'data'),(3,'data')"
 
     # Based on version 20.x - two parts
-    assert get_large_objects_count(cluster) == 2
+    wait_for_large_objects_count(cluster, 2)
 
     node1.query("OPTIMIZE TABLE s3_test")
 
-    time.sleep(1)
-
     # Based on version 20.x - after merge, two old parts and one merged
-    assert get_large_objects_count(cluster) == 3
+    wait_for_large_objects_count(cluster, 3)
 
     # Based on version 20.x - after cleanup - only one merged part
-    countdown = 60
-    while countdown > 0:
-        if get_large_objects_count(cluster) == 1:
-            break
-        time.sleep(1)
-        countdown -= 1
-    assert get_large_objects_count(cluster) == 1
+    wait_for_large_objects_count(cluster, 1, timeout=60)
 
     node1.query("DROP TABLE IF EXISTS s3_test NO DELAY")
     node2.query("DROP TABLE IF EXISTS s3_test NO DELAY")
@@ -127,7 +128,7 @@ def test_s3_zero_copy_on_hybrid_storage(cluster):
     assert node2.query("SELECT partition_id,disk_name FROM system.parts WHERE table='hybrid_test' FORMAT Values") == "('all','s31')"
 
     # Check that after moving partition on node2 no new obects on s3
-    assert get_large_objects_count(cluster, 0) == s3_objects
+    wait_for_large_objects_count(cluster, s3_objects, size=0)
 
     assert node1.query("SELECT * FROM hybrid_test ORDER BY id FORMAT Values") == "(0,'data'),(1,'data')"
     assert node2.query("SELECT * FROM hybrid_test ORDER BY id FORMAT Values") == "(0,'data'),(1,'data')"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix flapping tests for zero-copy replication over S3.

Detailed description / Documentation draft:

Fixed test_s3_zero_copy_replication (wait for changes on s3 storage, sometimes it take a time), test_s3_zero_copy_on_hybrid_storage (place part on second drive directly on insert when first rive has not enought space)
Failed tests before fix:
https://clickhouse-test-reports.s3.yandex.net/0/1c28878f5d2144c5fd59deeb0c1e41ec49068269/integration_tests_(thread)/integration_run_test_s3_zero_copy_replication_test_py_1.txt