### PR TITLE
Fix data_type_default_nullable on ATTACH

### DIFF
--- a/src/Databases/DatabaseOnDisk.cpp
+++ b/src/Databases/DatabaseOnDisk.cpp
@@ -58,7 +58,7 @@ std::pair<String, StoragePtr> createTableFromAST(
         auto table_function = factory.get(ast_create_query.as_table_function, context);
         ColumnsDescription columns;
         if (ast_create_query.columns_list && ast_create_query.columns_list->columns)
-            columns = InterpreterCreateQuery::getColumnsDescription(*ast_create_query.columns_list->columns, context, false);
+            columns = InterpreterCreateQuery::getColumnsDescription(*ast_create_query.columns_list->columns, context, true);
         StoragePtr storage = table_function->execute(ast_create_query.as_table_function, context, ast_create_query.table, std::move(columns));
         storage->renameInMemory(ast_create_query);
         return {ast_create_query.table, storage};
@@ -69,7 +69,7 @@ std::pair<String, StoragePtr> createTableFromAST(
     if (!ast_create_query.columns_list || !ast_create_query.columns_list->columns)
         throw Exception("Missing definition of columns.", ErrorCodes::EMPTY_LIST_OF_COLUMNS_PASSED);
 
-    ColumnsDescription columns = InterpreterCreateQuery::getColumnsDescription(*ast_create_query.columns_list->columns, context, false);
+    ColumnsDescription columns = InterpreterCreateQuery::getColumnsDescription(*ast_create_query.columns_list->columns, context, true);
     ConstraintsDescription constraints = InterpreterCreateQuery::getConstraintsDescription(ast_create_query.columns_list->constraints);
 
     return

--- a/src/Interpreters/InterpreterCreateQuery.h
+++ b/src/Interpreters/InterpreterCreateQuery.h
@@ -53,7 +53,7 @@ public:
 
     /// Obtain information about columns, their types, default values and column comments,
     ///  for case when columns in CREATE query is specified explicitly.
-    static ColumnsDescription getColumnsDescription(const ASTExpressionList & columns, ContextPtr context, bool sanity_check_compression_codecs);
+    static ColumnsDescription getColumnsDescription(const ASTExpressionList & columns, ContextPtr context, bool attach);
     static ConstraintsDescription getConstraintsDescription(const ASTExpressionList * constraints);
 
     static void prepareOnClusterQuery(ASTCreateQuery & create, ContextPtr context, const String & cluster_name);

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -429,7 +429,7 @@ StoragePtr InterpreterSystemQuery::tryRestartReplica(const StorageID & replica, 
     auto & create = create_ast->as<ASTCreateQuery &>();
     create.attach = true;
 
-    auto columns = InterpreterCreateQuery::getColumnsDescription(*create.columns_list->columns, system_context, false);
+    auto columns = InterpreterCreateQuery::getColumnsDescription(*create.columns_list->columns, system_context, true);
     auto constraints = InterpreterCreateQuery::getConstraintsDescription(create.columns_list->constraints);
     auto data_path = database->getTableDataPath(create);
 

--- a/src/TableFunctions/parseColumnsListForTableFunction.cpp
+++ b/src/TableFunctions/parseColumnsListForTableFunction.cpp
@@ -25,7 +25,7 @@ ColumnsDescription parseColumnsListFromString(const std::string & structure, Con
     if (!columns_list)
         throw Exception("Could not cast AST to ASTExpressionList", ErrorCodes::LOGICAL_ERROR);
 
-    return InterpreterCreateQuery::getColumnsDescription(*columns_list, context, !settings.allow_suspicious_codecs);
+    return InterpreterCreateQuery::getColumnsDescription(*columns_list, context, false);
 }
 
 }

--- a/tests/queries/0_stateless/01269_create_with_null.reference
+++ b/tests/queries/0_stateless/01269_create_with_null.reference
@@ -2,3 +2,6 @@ Nullable(Int32)	Int32	Nullable(Int32)	Int32
 CREATE TABLE default.data_null\n(\n    `a` Nullable(Int32),\n    `b` Int32,\n    `c` Nullable(Int32),\n    `d` Int32\n)\nENGINE = Memory
 Nullable(Int32)	Int32	Nullable(Int32)	Nullable(Int32)
 CREATE TABLE default.set_null\n(\n    `a` Nullable(Int32),\n    `b` Int32,\n    `c` Nullable(Int32),\n    `d` Nullable(Int32)\n)\nENGINE = Memory
+CREATE TABLE default.set_null\n(\n    `a` Nullable(Int32),\n    `b` Int32,\n    `c` Nullable(Int32),\n    `d` Nullable(Int32)\n)\nENGINE = Memory
+CREATE TABLE default.cannot_be_nullable\n(\n    `n` Nullable(Int8),\n    `a` Array(UInt8)\n)\nENGINE = Memory
+CREATE TABLE default.cannot_be_nullable\n(\n    `n` Nullable(Int8),\n    `a` Array(UInt8)\n)\nENGINE = Memory

--- a/tests/queries/0_stateless/01269_create_with_null.sql
+++ b/tests/queries/0_stateless/01269_create_with_null.sql
@@ -1,5 +1,6 @@
 DROP TABLE IF EXISTS data_null;
 DROP TABLE IF EXISTS set_null;
+DROP TABLE IF EXISTS cannot_be_nullable;
 
 SET data_type_default_nullable='false';
 
@@ -45,6 +46,17 @@ INSERT INTO set_null VALUES (NULL, 2, NULL, NULL);
 SELECT toTypeName(a), toTypeName(b), toTypeName(c), toTypeName(d) FROM set_null;
 
 SHOW CREATE TABLE set_null;
+DETACH TABLE set_null;
+ATTACH TABLE set_null;
+SHOW CREATE TABLE set_null;
+
+CREATE TABLE cannot_be_nullable (n Int8, a Array(UInt8)) ENGINE=Memory; -- { serverError 43 }
+CREATE TABLE cannot_be_nullable (n Int8, a Array(UInt8) NOT NULL) ENGINE=Memory;
+SHOW CREATE TABLE cannot_be_nullable;
+DETACH TABLE cannot_be_nullable;
+ATTACH TABLE cannot_be_nullable;
+SHOW CREATE TABLE cannot_be_nullable;
 
 DROP TABLE data_null;
 DROP TABLE set_null;
+DROP TABLE cannot_be_nullable;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Server might fail to start if `data_type_default_nullable` setting is enabled in default profile, it's fixed.
Fixes #22573

