### PR TITLE
Minor fixes in ATTACH query

### DIFF
--- a/src/Databases/DatabaseAtomic.h
+++ b/src/Databases/DatabaseAtomic.h
@@ -57,7 +57,7 @@ public:
     void tryCreateSymlink(const String & table_name, const String & actual_data_path, bool if_data_path_exist = false);
     void tryRemoveSymlink(const String & table_name);
 
-    void waitDetachedTableNotInUse(const UUID & uuid) override;
+    void waitDetachedTableNotInUseOrThrow(const UUID & uuid, bool throw_if_in_use) override;
     void setDetachedTableNotInUseForce(const UUID & uuid);
 
 protected:

--- a/src/Databases/DatabaseAtomic.h
+++ b/src/Databases/DatabaseAtomic.h
@@ -57,7 +57,8 @@ public:
     void tryCreateSymlink(const String & table_name, const String & actual_data_path, bool if_data_path_exist = false);
     void tryRemoveSymlink(const String & table_name);
 
-    void waitDetachedTableNotInUseOrThrow(const UUID & uuid, bool throw_if_in_use) override;
+    void waitDetachedTableNotInUse(const UUID & uuid) override;
+    void checkDetachedTableNotInUse(const UUID & uuid) override;
     void setDetachedTableNotInUseForce(const UUID & uuid);
 
 protected:

--- a/src/Databases/IDatabase.h
+++ b/src/Databases/IDatabase.h
@@ -345,7 +345,8 @@ public:
 
     virtual void assertCanBeDetached(bool /*cleanup*/) {}
 
-    virtual void waitDetachedTableNotInUseOrThrow(const UUID & /*uuid*/, bool /*throw_if_in_use*/) { }
+    virtual void waitDetachedTableNotInUse(const UUID & /*uuid*/) { }
+    virtual void checkDetachedTableNotInUse(const UUID & /*uuid*/) { }
 
     /// Ask all tables to complete the background threads they are using and delete all table objects.
     virtual void shutdown() = 0;

--- a/src/Databases/IDatabase.h
+++ b/src/Databases/IDatabase.h
@@ -345,7 +345,7 @@ public:
 
     virtual void assertCanBeDetached(bool /*cleanup*/) {}
 
-    virtual void waitDetachedTableNotInUse(const UUID & /*uuid*/) { assert(false); }
+    virtual void waitDetachedTableNotInUseOrThrow(const UUID & /*uuid*/, bool /*throw_if_in_use*/) { }
 
     /// Ask all tables to complete the background threads they are using and delete all table objects.
     virtual void shutdown() = 0;

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -996,6 +996,16 @@ bool InterpreterCreateQuery::doCreateTable(ASTCreateQuery & create,
         create.attach_from_path = std::nullopt;
     }
 
+    if (create.attach)
+    {
+        /// If table was detached it's not possible to attach it back while some threads are using
+        /// old instance of the storage. For example, AsynchronousMetrics may cause ATTACH to fail,
+        /// so we allow waiting here. If database_atomic_wait_for_drop_and_detach_synchronously is disabled
+        /// and old storage instance still exists it will throw exception.
+        bool throw_if_table_in_use = getContext()->getSettingsRef().database_atomic_wait_for_drop_and_detach_synchronously;
+        database->waitDetachedTableNotInUseOrThrow(create.uuid, throw_if_table_in_use);
+    }
+
     StoragePtr res;
     /// NOTE: CREATE query may be rewritten by Storage creator or table function
     if (create.as_table_function)

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1003,7 +1003,10 @@ bool InterpreterCreateQuery::doCreateTable(ASTCreateQuery & create,
         /// so we allow waiting here. If database_atomic_wait_for_drop_and_detach_synchronously is disabled
         /// and old storage instance still exists it will throw exception.
         bool throw_if_table_in_use = getContext()->getSettingsRef().database_atomic_wait_for_drop_and_detach_synchronously;
-        database->waitDetachedTableNotInUseOrThrow(create.uuid, throw_if_table_in_use);
+        if (throw_if_table_in_use)
+            database->checkDetachedTableNotInUse(create.uuid);
+        else
+            database->waitDetachedTableNotInUse(create.uuid);
     }
 
     StoragePtr res;

--- a/src/Interpreters/InterpreterDropQuery.cpp
+++ b/src/Interpreters/InterpreterDropQuery.cpp
@@ -81,7 +81,7 @@ void InterpreterDropQuery::waitForTableToBeActuallyDroppedOrDetached(const ASTDr
     if (query.kind == ASTDropQuery::Kind::Drop)
         DatabaseCatalog::instance().waitTableFinallyDropped(uuid_to_wait);
     else if (query.kind == ASTDropQuery::Kind::Detach)
-        db->waitDetachedTableNotInUse(uuid_to_wait);
+        db->waitDetachedTableNotInUseOrThrow(uuid_to_wait, false);
 }
 
 BlockIO InterpreterDropQuery::executeToTable(ASTDropQuery & query)

--- a/src/Interpreters/InterpreterDropQuery.cpp
+++ b/src/Interpreters/InterpreterDropQuery.cpp
@@ -81,7 +81,7 @@ void InterpreterDropQuery::waitForTableToBeActuallyDroppedOrDetached(const ASTDr
     if (query.kind == ASTDropQuery::Kind::Drop)
         DatabaseCatalog::instance().waitTableFinallyDropped(uuid_to_wait);
     else if (query.kind == ASTDropQuery::Kind::Detach)
-        db->waitDetachedTableNotInUseOrThrow(uuid_to_wait, false);
+        db->waitDetachedTableNotInUse(uuid_to_wait);
 }
 
 BlockIO InterpreterDropQuery::executeToTable(ASTDropQuery & query)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Detailed description / Documentation draft:
It should fix flaky test `01107_atomic_db_detach_attach` and `Mapping for table ... already exists` error in [stress tests](https://github.com/ClickHouse/ClickHouse/pull/23000#issuecomment-820729925)
