### PR TITLE
Fix logical error in stress tests

### DIFF
--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -985,8 +985,6 @@ bool TCPHandler::receivePacket()
 
     switch (packet_type)
     {
-        case Protocol::Client::ReadTaskResponse:
-            throw Exception("ReadTaskResponse must be received only after requesting in callback", ErrorCodes::LOGICAL_ERROR);
         case Protocol::Client::IgnoredPartUUIDs:
             /// Part uuids packet if any comes before query.
             receiveIgnoredPartUUIDs();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
ReadTaskResponse must be received only after sending ReadTaskRequest in callback. Receiving ReadTaskResponse and requesting readTaskRequest from callback is ordered with sending / receiving other packets with mutex. So, in this place we can bravely say, that this is unexpected packet. #23084
