### PR TITLE
`CSVWithNames` with `input_format_with_names_use_header=0`

### DIFF
--- a/src/Processors/Formats/Impl/CSVRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/CSVRowInputFormat.cpp
@@ -201,7 +201,10 @@ void CSVRowInputFormat::readPrefix()
             return;
         }
         else
+        {
             skipRow(in, format_settings.csv, num_columns);
+            setupAllColumnsByTableSchema();
+        }
     }
     else if (!column_mapping->is_set)
         setupAllColumnsByTableSchema();

--- a/tests/queries/0_stateless/01818_input_format_with_names_use_header.reference
+++ b/tests/queries/0_stateless/01818_input_format_with_names_use_header.reference
@@ -1,0 +1,2 @@
+testdata1
+testdata2

--- a/tests/queries/0_stateless/01818_input_format_with_names_use_header.sh
+++ b/tests/queries/0_stateless/01818_input_format_with_names_use_header.sh
@@ -4,12 +4,12 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-${CLICKHOUSE_CLIENT_BINARY} -q "DROP TABLE IF EXISTS 01818_with_names;"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS 01818_with_names;"
 
-${CLICKHOUSE_CLIENT_BINARY} -q "CREATE TABLE 01818_with_names (t String) ENGINE = MergeTree ORDER BY t;"
+${CLICKHOUSE_CLIENT} -q "CREATE TABLE 01818_with_names (t String) ENGINE = MergeTree ORDER BY t;"
 
-echo -ne "t\ntestdata1\ntestdata2" | ${CLICKHOUSE_CLIENT_BINARY} --input_format_with_names_use_header 0 --query "INSERT INTO 01818_with_names FORMAT CSVWithNames"
+echo -ne "t\ntestdata1\ntestdata2" | ${CLICKHOUSE_CLIENT} --input_format_with_names_use_header 0 --query "INSERT INTO 01818_with_names FORMAT CSVWithNames"
 
-${CLICKHOUSE_CLIENT_BINARY} -q "SELECT * FROM 01818_with_names;"
+${CLICKHOUSE_CLIENT} -q "SELECT * FROM 01818_with_names;"
 
-${CLICKHOUSE_CLIENT_BINARY} -q "DROP TABLE IF EXISTS 01818_with_names;"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS 01818_with_names;"

--- a/tests/queries/0_stateless/01818_input_format_with_names_use_header.sh
+++ b/tests/queries/0_stateless/01818_input_format_with_names_use_header.sh
@@ -4,12 +4,12 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS `01818_with_names`;"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS \`01818_with_names\`;"
 
-${CLICKHOUSE_CLIENT} -q "CREATE TABLE `01818_with_names` (t String) ENGINE = MergeTree ORDER BY t;"
+${CLICKHOUSE_CLIENT} -q "CREATE TABLE \`01818_with_names\` (t String) ENGINE = MergeTree ORDER BY t;"
 
-echo -ne "t\ntestdata1\ntestdata2" | ${CLICKHOUSE_CLIENT} --input_format_with_names_use_header 0 --query "INSERT INTO `01818_with_names` FORMAT CSVWithNames"
+echo -ne "t\ntestdata1\ntestdata2" | ${CLICKHOUSE_CLIENT} --input_format_with_names_use_header 0 --query "INSERT INTO \`01818_with_names\` FORMAT CSVWithNames"
 
-${CLICKHOUSE_CLIENT} -q "SELECT * FROM `01818_with_names`;"
+${CLICKHOUSE_CLIENT} -q "SELECT * FROM \`01818_with_names\`;"
 
-${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS `01818_with_names`;"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS \`01818_with_names\`;"

--- a/tests/queries/0_stateless/01818_input_format_with_names_use_header.sh
+++ b/tests/queries/0_stateless/01818_input_format_with_names_use_header.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT_BINARY} -q "DROP TABLE IF EXISTS 01818_with_names;"
+
+${CLICKHOUSE_CLIENT_BINARY} -q "CREATE TABLE 01818_with_names (t String) ENGINE = MergeTree ORDER BY t;"
+
+echo -ne "t\ntestdata1\ntestdata2" | ${CLICKHOUSE_CLIENT_BINARY} --input_format_with_names_use_header 0 --query "INSERT INTO 01818_with_names FORMAT CSVWithNames"
+
+${CLICKHOUSE_CLIENT_BINARY} -q "SELECT * FROM 01818_with_names;"
+
+${CLICKHOUSE_CLIENT_BINARY} -q "DROP TABLE IF EXISTS 01818_with_names;"

--- a/tests/queries/0_stateless/01818_input_format_with_names_use_header.sh
+++ b/tests/queries/0_stateless/01818_input_format_with_names_use_header.sh
@@ -4,12 +4,12 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS 01818_with_names;"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS `01818_with_names`;"
 
-${CLICKHOUSE_CLIENT} -q "CREATE TABLE 01818_with_names (t String) ENGINE = MergeTree ORDER BY t;"
+${CLICKHOUSE_CLIENT} -q "CREATE TABLE `01818_with_names` (t String) ENGINE = MergeTree ORDER BY t;"
 
-echo -ne "t\ntestdata1\ntestdata2" | ${CLICKHOUSE_CLIENT} --input_format_with_names_use_header 0 --query "INSERT INTO 01818_with_names FORMAT CSVWithNames"
+echo -ne "t\ntestdata1\ntestdata2" | ${CLICKHOUSE_CLIENT} --input_format_with_names_use_header 0 --query "INSERT INTO `01818_with_names` FORMAT CSVWithNames"
 
-${CLICKHOUSE_CLIENT} -q "SELECT * FROM 01818_with_names;"
+${CLICKHOUSE_CLIENT} -q "SELECT * FROM `01818_with_names`;"
 
-${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS 01818_with_names;"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS `01818_with_names`;"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed the behavior when disabling `input_format_with_names_use_header ` setting discards all the input with CSVWithNames format. This fixes #22406
