### PR TITLE
Use double quote identifier in odbc as default in case of error

### DIFF
--- a/programs/odbc-bridge/getIdentifierQuote.cpp
+++ b/programs/odbc-bridge/getIdentifierQuote.cpp
@@ -19,7 +19,18 @@ namespace ErrorCodes
 
 std::string getIdentifierQuote(nanodbc::connection & connection)
 {
-    return connection.get_info<std::string>(SQL_IDENTIFIER_QUOTE_CHAR);
+    std::string quote;
+    try
+    {
+        quote = connection.get_info<std::string>(SQL_IDENTIFIER_QUOTE_CHAR);
+    }
+    catch (...)
+    {
+        LOG_WARNING(&Poco::Logger::get("ODBCGetIdentifierQuote"), "Cannot fetch identifier quote. Default double quote is used");
+        return "\"";
+    }
+
+    return quote;
 }
 
 

--- a/programs/odbc-bridge/getIdentifierQuote.cpp
+++ b/programs/odbc-bridge/getIdentifierQuote.cpp
@@ -26,7 +26,7 @@ std::string getIdentifierQuote(nanodbc::connection & connection)
     }
     catch (...)
     {
-        LOG_WARNING(&Poco::Logger::get("ODBCGetIdentifierQuote"), "Cannot fetch identifier quote. Default double quote is used");
+        LOG_WARNING(&Poco::Logger::get("ODBCGetIdentifierQuote"), "Cannot fetch identifier quote. Default double quote is used. Reason: {}", getCurrentExceptionMessage(false));
         return "\"";
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Return double quote identifier if unable to get from driver. Closes https://github.com/ClickHouse/ClickHouse/issues/6412.