### PR TITLE
Disable postgresql_port in perf tests

### DIFF
--- a/docker/test/performance-comparison/config/config.d/zzz-perf-comparison-tweaks-config.xml
+++ b/docker/test/performance-comparison/config/config.d/zzz-perf-comparison-tweaks-config.xml
@@ -1,6 +1,7 @@
 <yandex>
     <http_port remove="remove"/>
     <mysql_port remove="remove"/>
+    <postgresql_port remove="remove"/>
     <interserver_http_port remove="remove"/>
     <tcp_with_proxy_port remove="remove"/>
     <keeper_server remove="remove"/>


### PR DESCRIPTION
To avoid port overlaps:

```
2021.04.17 11:38:20.153553 [ 177 ] {} <Error> Application: DB::Exception: Listen [::]:9005 failed: Poco::Exception. Code: 1000, e.code() = 98, e.displayText() = Net Exception: Address already in use: [::]:9005 (version 21.5.1.6595)
```

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @akuzm 