### PR TITLE
Disable async_socket_for_remote/use_hedged_requests for 01602_max_distributed_connections

### DIFF
--- a/tests/queries/0_stateless/01602_max_distributed_connections.sh
+++ b/tests/queries/0_stateless/01602_max_distributed_connections.sh
@@ -7,8 +7,14 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 common_opts=(
     "--format=Null"
 
+    # This is the regression test for the case when max_threads was used over
+    # max_distributed_connections (with prefer_localhost_replica=1)
     "--max_threads=1"
     "--max_distributed_connections=3"
+    # NOTE: that max_distributed_connections limiting does not work with
+    # async_socket_for_remote, so disabling it
+    "--async_socket_for_remote=0"
+    "--use_hedged_requests=0"
 )
 
 # NOTE: the test use higher timeout to avoid flakiness.


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Disable async_socket_for_remote/use_hedged_requests for 01602_max_distributed_connections

  <details>

  Before this patch I see that the test fails [1].

    [1]: https://clickhouse-test-reports.s3.yandex.net/23219/5a93921b5780aececb3a92e2f42eb4020459941a/functional_stateless_tests_(release,_wide_parts_enabled).html#fail1

  And this failure like another issue with
  async_socket_for_remote/use_hedged_requests, let's just disable those two,
  since the test is not about them.


  ```
      2021.04.17 17:29:34.938129 [ 754 ] {9fc2572c-55ec-4818-adef-1e16fe047a5f} <Debug> executeQuery: (from [::1]:38818, using production parser) (comment: '/usr/share/clickhouse-test/queries/0_stateless/01602_max_distributed_connections.sh') select sleep(3) from remote('127.{1,2,3,4,5}', system.one)
      2021.04.17 17:29:34.938476 [ 754 ] {9fc2572c-55ec-4818-adef-1e16fe047a5f} <Trace> ContextAccess (default): Access granted: CREATE TEMPORARY TABLE, REMOTE ON *.*
      2021.04.17 17:29:34.938691 [ 754 ] {9fc2572c-55ec-4818-adef-1e16fe047a5f} <Trace> ContextAccess (default): Access granted: CREATE TEMPORARY TABLE, REMOTE ON *.*
      2021.04.17 17:29:34.939273 [ 754 ] {9fc2572c-55ec-4818-adef-1e16fe047a5f} <Trace> ContextAccess (default): Access granted: SELECT(dummy) ON system.one
      2021.04.17 17:29:34.939336 [ 754 ] {9fc2572c-55ec-4818-adef-1e16fe047a5f} <Trace> InterpreterSelectQuery: FetchColumns -> WithMergeableState
      2021.04.17 17:29:34.939497 [ 754 ] {9fc2572c-55ec-4818-adef-1e16fe047a5f} <Trace> InterpreterSelectQuery: WithMergeableState -> Complete
      2021.04.17 17:29:34.940153 [ 619 ] {9fc2572c-55ec-4818-adef-1e16fe047a5f} <Trace> Connection (127.3:9000): Connecting. Database: (not specified). User: default
      2021.04.17 17:29:34.940155 [ 627 ] {9fc2572c-55ec-4818-adef-1e16fe047a5f} <Trace> Connection (127.2:9000): Connecting. Database: (not specified). User: default
      2021.04.17 17:29:34.940535 [ 619 ] {9fc2572c-55ec-4818-adef-1e16fe047a5f} <Trace> Connection (127.3:9000): Connected to ClickHouse server version 21.5.1.
      2021.04.17 17:29:34.940618 [ 627 ] {9fc2572c-55ec-4818-adef-1e16fe047a5f} <Trace> Connection (127.2:9000): Connected to ClickHouse server version 21.5.1.
      2021.04.17 17:29:34.941098 [ 619 ] {9fc2572c-55ec-4818-adef-1e16fe047a5f} <Trace> Connection (127.4:9000): Connecting. Database: (not specified). User: default
      2021.04.17 17:29:34.941113 [ 627 ] {9fc2572c-55ec-4818-adef-1e16fe047a5f} <Trace> Connection (127.5:9000): Connecting. Database: (not specified). User: default
      2021.04.17 17:29:34.941277 [ 304 ] {75b40db7-f71d-41ab-a1f8-e71d306e9690} <Debug> executeQuery: (from [::ffff:127.0.0.1]:41092, initial_query_id: 9fc2572c-55ec-4818-adef-1e16fe047a5f, using production parser) (comment: '/usr/share/clickhouse-test/queries/0_stateless/01602_max_distributed_connections.sh') SELECT sleep(3) FROM system.one
      2021.04.17 17:29:34.941314 [ 755 ] {348c1040-3276-4d70-bcb6-ce9c411f93e0} <Debug> executeQuery: (from [::ffff:127.0.0.1]:48882, initial_query_id: 9fc2572c-55ec-4818-adef-1e16fe047a5f, using production parser) (comment: '/usr/share/clickhouse-test/queries/0_stateless/01602_max_distributed_connections.sh') SELECT sleep(3) FROM system.one
      2021.04.17 17:29:34.941468 [ 619 ] {9fc2572c-55ec-4818-adef-1e16fe047a5f} <Trace> Connection (127.4:9000): Connected to ClickHouse server version 21.5.1.
      2021.04.17 17:29:34.941500 [ 627 ] {9fc2572c-55ec-4818-adef-1e16fe047a5f} <Trace> Connection (127.5:9000): Connected to ClickHouse server version 21.5.1.
      2021.04.17 17:29:34.942078 [ 308 ] {e17f3859-09bb-4cdb-b8a3-28c04147d750} <Debug> executeQuery: (from [::ffff:127.0.0.1]:50552, initial_query_id: 9fc2572c-55ec-4818-adef-1e16fe047a5f, using production parser) (comment: '/usr/share/clickhouse-test/queries/0_stateless/01602_max_distributed_connections.sh') SELECT sleep(3) FROM system.one
      2021.04.17 17:29:34.942093 [ 307 ] {f5d476d4-a1d0-44d2-94ae-2265b77862b5} <Debug> executeQuery: (from [::ffff:127.0.0.1]:52722, initial_query_id: 9fc2572c-55ec-4818-adef-1e16fe047a5f, using production parser) (comment: '/usr/share/clickhouse-test/queries/0_stateless/01602_max_distributed_connections.sh') SELECT sleep(3) FROM system.one
      #
      # too huge delay, look like another issue with async_socket_for_remote/use_hedged_requests
      #
      2021.04.17 17:29:47.125293 [ 754 ] {9fc2572c-55ec-4818-adef-1e16fe047a5f} <Error> executeQuery: Code: 210, e.displayText() = DB::NetException: Connection reset by peer, while writing to socket ([::1]:38818) (version 21.5.1.6597) (from [::1]:38818) (comment: '/usr/share/clickhouse-test/queries/0_stateless/01602_max_distributed_connections.sh') (in query: select sleep(3) from remote('127.{1,2,3,4,5}', system.one)), Stack trace (when copying this message, always include the lines below):
      2021.04.17 17:29:47.126032 [ 754 ] {9fc2572c-55ec-4818-adef-1e16fe047a5f} <Error> TCPHandler: Can't send logs to client: Code: 210, e.displayText() = DB::NetException: I/O error: Broken pipe, while writing to socket ([::1]:38818), Stack trace (when copying this message, always include the lines below):
      2021.04.17 17:29:47.126076 [ 754 ] {9fc2572c-55ec-4818-adef-1e16fe047a5f} <Error> TCPHandler: Code: 210, e.displayText() = DB::Exception: Connection reset by peer, while writing to socket ([::1]:38818), Stack trace:
      2021.04.17 17:29:47.126327 [ 754 ] {9fc2572c-55ec-4818-adef-1e16fe047a5f} <Warning> TCPHandler: Client has gone away.
      2021.04.17 17:29:47.127001 [ 754 ] {9fc2572c-55ec-4818-adef-1e16fe047a5f} <Debug> MemoryTracker: Peak memory usage (for query): 8.77 MiB.
  ```

  </details>
