### PR TITLE
Add -Wundef for gcc builds

### DIFF
--- a/base/common/DateLUTImpl.h
+++ b/base/common/DateLUTImpl.h
@@ -25,7 +25,7 @@
 
 
 #if defined(__PPC__)
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 #endif
@@ -1266,7 +1266,7 @@ public:
 };
 
 #if defined(__PPC__)
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 #endif

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -171,6 +171,7 @@ elseif (COMPILER_GCC)
     add_cxx_compile_options(-Wtrampolines)
     # Obvious
     add_cxx_compile_options(-Wunused)
+    add_cxx_compile_options(-Wundef)
     # Warn if vector operation is not implemented via SIMD capabilities of the architecture
     add_cxx_compile_options(-Wvector-operation-performance)
     # XXX: libstdc++ has some of these for 3way compare

--- a/src/AggregateFunctions/AggregateFunctionUniqUpTo.h
+++ b/src/AggregateFunctions/AggregateFunctionUniqUpTo.h
@@ -17,7 +17,7 @@
 #include <IO/WriteHelpers.h>
 
 
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #endif
@@ -280,7 +280,7 @@ public:
 
 }
 
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/src/AggregateFunctions/ReservoirSamplerDeterministic.h
+++ b/src/AggregateFunctions/ReservoirSamplerDeterministic.h
@@ -163,7 +163,7 @@ public:
         sorted = false;
     }
 
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wclass-memaccess"
 #endif
@@ -191,7 +191,7 @@ public:
         }
     }
 
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/src/Columns/ColumnString.h
+++ b/src/Columns/ColumnString.h
@@ -111,7 +111,7 @@ public:
     }
 
 /// Suppress gcc 7.3.1 warning: '*((void*)&<anonymous> +8)' may be used uninitialized in this function
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
@@ -128,7 +128,7 @@ public:
         offsets.push_back(new_size);
     }
 
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/src/Common/Allocator.h
+++ b/src/Common/Allocator.h
@@ -277,7 +277,7 @@ private:
   *  GCC 4.9 mistakenly assumes that we can call `free` from a pointer to the stack.
   * In fact, the combination of conditions inside AllocatorWithStackMemory does not allow this.
   */
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfree-nonheap-object"
 #endif
@@ -359,6 +359,6 @@ extern template class Allocator<true, false>;
 extern template class Allocator<false, true>;
 extern template class Allocator<true, true>;
 
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif

--- a/src/Common/UInt128.h
+++ b/src/Common/UInt128.h
@@ -19,7 +19,7 @@ namespace DB
 struct UInt128
 {
 /// Suppress gcc7 warnings: 'prev_key.DB::UInt128::low' may be used uninitialized in this function
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
@@ -92,7 +92,7 @@ struct UInt128
             return static_cast<T>(low);
     }
 
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 
@@ -150,7 +150,7 @@ struct DummyUInt256
 {
 
 /// Suppress gcc7 warnings: 'prev_key.DB::UInt256::a' may be used uninitialized in this function
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
@@ -179,7 +179,7 @@ struct DummyUInt256
     bool operator== (const UInt64 rhs) const { return a == rhs && b == 0 && c == 0 && d == 0; }
     bool operator!= (const UInt64 rhs) const { return !operator==(rhs); }
 
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/src/Common/tests/compact_array.cpp
+++ b/src/Common/tests/compact_array.cpp
@@ -1,5 +1,5 @@
 /// Bug in GCC: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=59124
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #endif
@@ -263,6 +263,6 @@ int main()
     return 0;
 }
 
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif

--- a/src/Common/tests/parallel_aggregation.cpp
+++ b/src/Common/tests/parallel_aggregation.cpp
@@ -69,7 +69,7 @@ static void aggregate1(Map & map, Source::const_iterator begin, Source::const_it
         ++map[*it];
 }
 
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
@@ -122,7 +122,7 @@ static void aggregate22(MapTwoLevel & map, Source::const_iterator begin, Source:
     }
 }
 
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/src/Common/tests/parallel_aggregation2.cpp
+++ b/src/Common/tests/parallel_aggregation2.cpp
@@ -62,7 +62,7 @@ struct AggregateIndependent
     }
 };
 
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
@@ -115,7 +115,7 @@ struct AggregateIndependentWithSequentialKeysOptimization
     }
 };
 
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 
@@ -265,7 +265,7 @@ struct Creator
     void operator()(Value &) const {}
 };
 
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
@@ -275,7 +275,7 @@ struct Updater
     void operator()(Value & x) const { ++x; }
 };
 
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/src/Core/Field.h
+++ b/src/Core/Field.h
@@ -96,7 +96,7 @@ template <typename T> bool decimalEqual(T x, T y, UInt32 x_scale, UInt32 y_scale
 template <typename T> bool decimalLess(T x, T y, UInt32 x_scale, UInt32 y_scale);
 template <typename T> bool decimalLessOrEqual(T x, T y, UInt32 x_scale, UInt32 y_scale);
 
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
@@ -159,7 +159,7 @@ private:
     T dec;
     UInt32 scale;
 };
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 
@@ -563,7 +563,7 @@ public:
         {
             case Types::Null:    return f(field.template get<Null>());
 // gcc 8.2.1
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
@@ -583,7 +583,7 @@ public:
             case Types::Int128: return f(field.template get<Int128>());
             case Types::UInt256: return f(field.template get<UInt256>());
             case Types::Int256: return f(field.template get<Int256>());
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
         }

--- a/src/Core/Types.h
+++ b/src/Core/Types.h
@@ -15,7 +15,7 @@ namespace DB
 struct Null {};
 
 /// Ignore strange gcc warning https://gcc.gnu.org/bugzilla/show_bug.cgi?id=55776
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
 #endif
@@ -59,7 +59,7 @@ enum class TypeIndex
     LowCardinality,
     Map,
 };
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/src/Disks/tests/gtest_disk.cpp
+++ b/src/Disks/tests/gtest_disk.cpp
@@ -4,7 +4,7 @@
 #include <IO/WriteHelpers.h>
 #include "gtest_disk.h"
 
-#if !__clang__
+#if !defined(__clang__)
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wsuggest-override"
 #endif

--- a/src/Functions/GatherUtils/Sources.h
+++ b/src/Functions/GatherUtils/Sources.h
@@ -140,7 +140,7 @@ struct NumericArraySource : public ArraySourceImpl<NumericArraySource<T>>
 
 
 /// The methods can be virtual or not depending on the template parameter. See IStringSource.
-#if !__clang__
+#if !defined(__clang__)
 #   pragma GCC diagnostic push
 #   pragma GCC diagnostic ignored "-Wsuggest-override"
 #elif __clang_major__ >= 11
@@ -233,7 +233,7 @@ struct ConstSource : public Base
     }
 };
 
-#if !__clang__ || __clang_major__ >= 11
+#if !defined(__clang__) || __clang_major__ >= 11
 #   pragma GCC diagnostic pop
 #endif
 

--- a/src/Functions/PolygonUtils.h
+++ b/src/Functions/PolygonUtils.h
@@ -12,7 +12,7 @@
 /// Warning in boost::geometry during template strategy substitution.
 #pragma GCC diagnostic push
 
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 
@@ -285,7 +285,7 @@ void PointInPolygonWithGrid<CoordinateType>::calcGridAttributes(
     const Point & max_corner = box.max_corner();
 
 #pragma GCC diagnostic push
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 
@@ -322,7 +322,7 @@ void PointInPolygonWithGrid<CoordinateType>::buildGrid()
     for (size_t row = 0; row < grid_size; ++row)
     {
 #pragma GCC diagnostic push
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
         CoordinateType y_min = min_corner.y() + row * cell_height;

--- a/src/IO/parseDateTimeBestEffort.cpp
+++ b/src/IO/parseDateTimeBestEffort.cpp
@@ -46,7 +46,7 @@ inline size_t readAlpha(char * res, size_t max_chars, ReadBuffer & in)
 }
 
 #if defined(__PPC__)
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 #endif
@@ -634,7 +634,7 @@ ReturnType parseDateTime64BestEffortImpl(DateTime64 & res, UInt32 scale, ReadBuf
 }
 
 #if defined(__PPC__)
-#if !__clang__
+#if !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 #endif

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -1107,13 +1107,13 @@ void IMergeTreeDataPart::remove(bool keep_s3) const
         {
             /// Remove each expected file in directory, then remove directory itself.
 
-    #if !__clang__
+    #if !defined(__clang__)
     #    pragma GCC diagnostic push
     #    pragma GCC diagnostic ignored "-Wunused-variable"
     #endif
             for (const auto & [file, _] : checksums.files)
                 volume->getDisk()->removeSharedFile(to + "/" + file, keep_s3);
-    #if !__clang__
+    #if !defined(__clang__)
     #    pragma GCC diagnostic pop
     #endif
 

--- a/src/Storages/tests/gtest_storage_log.cpp
+++ b/src/Storages/tests/gtest_storage_log.cpp
@@ -19,7 +19,7 @@
 #include <Processors/Executors/PipelineExecutingBlockInputStream.h>
 #include <Processors/QueryPipeline.h>
 
-#if !__clang__
+#if !defined(__clang__)
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wsuggest-override"
 #endif


### PR DESCRIPTION
There is no -Werror build on CI, so let's make -Wundef an error to avoid
further errors.

P.S. maybe later other warnings will be converted to errors.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)