### PR TITLE
Pushdown LIMIT to UNION ALL query

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -445,6 +445,7 @@ class IColumn;
     M(Bool, database_replicated_always_detach_permanently, false, "Execute DETACH TABLE as DETACH TABLE PERMANENTLY if database engine is Replicated", 0) \
     M(DistributedDDLOutputMode, distributed_ddl_output_mode, DistributedDDLOutputMode::THROW, "Format of distributed DDL query result", 0) \
     M(UInt64, distributed_ddl_entry_format_version, 1, "Version of DDL entry to write into ZooKeeper", 0) \
+    M(Bool, optimize_pushdown_limit_to_union_all_query, true, "Pushdown LIMIT to UNION ALL query for optimization", 0) \
     \
     /** Obsolete settings that do nothing but left for compatibility reasons. Remove each one after half a year of obsolescence. */ \
     \

--- a/src/Interpreters/NormalizeSelectWithUnionQueryVisitor.cpp
+++ b/src/Interpreters/NormalizeSelectWithUnionQueryVisitor.cpp
@@ -18,7 +18,7 @@ void NormalizeSelectWithUnionQueryMatcher::getSelectsFromUnionListNode(ASTPtr & 
             getSelectsFromUnionListNode(child, selects);
 
         return;
-        }
+    }
 
         selects.push_back(ast_select);
 }

--- a/src/Interpreters/PushdownLimitToUnionAll.cpp
+++ b/src/Interpreters/PushdownLimitToUnionAll.cpp
@@ -1,0 +1,59 @@
+#include <Interpreters/PushdownLimitToUnionAll.h>
+#include <Parsers/ASTLiteral.h>
+#include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
+#include <Parsers/ASTTablesInSelectQuery.h>
+#include <Common/typeid_cast.h>
+
+namespace DB
+{
+void PushdownLimitToUnionAllMatcher::visit(ASTPtr & ast, Data & data)
+{
+    if (auto * func = ast->as<ASTSelectQuery>())
+        visit(*func, data);
+}
+
+void PushdownLimitToUnionAllMatcher::visit(ASTSelectQuery & select, Data &)
+{
+    const auto & limit_length_ast = select.limitLength();
+    auto * tables = select.tables()->as<ASTTablesInSelectQuery>();
+
+    /// When there are no LIMIT or having more than one tables in
+    /// SelectQuery(JOIN query), nothing need to do.
+    if (!limit_length_ast || !tables || tables->children.size() != 1)
+        return;
+
+    auto & table = tables->children.at(0)->as<ASTTablesInSelectQueryElement &>().table_expression->as<ASTTableExpression &>();
+
+    if (table.subquery)
+    {
+        auto & select_with_union_query = table.subquery->children[0]->as<ASTSelectWithUnionQuery &>();
+
+        /// After NormalizeSelectWithUnionQueryVisitor, the height of the AST of SelectWithUnionQuery
+        /// is at most 2, and if height is 2, the child SelectWithUnionQuery must be UNION DISTINCT.
+        /// So, we just need pushdown LIMIT to child SelectQuery.
+        if (select_with_union_query.union_mode == ASTSelectWithUnionQuery::Mode::ALL)
+        {
+            UInt64 limit_length = limit_length_ast->as<ASTLiteral &>().value.safeGet<UInt64>();
+
+            for (auto & child : select_with_union_query.list_of_selects->children)
+            {
+                if (auto * select_query = child->as<ASTSelectQuery>())
+                {
+                    UInt64 old_limit_length = 0;
+                    const auto old_limit_length_ast = select_query->getExpression(ASTSelectQuery::Expression::LIMIT_LENGTH, false);
+
+                    if (old_limit_length_ast)
+                        old_limit_length = old_limit_length_ast->as<ASTLiteral &>().value.safeGet<UInt64>();
+
+                    /// Pushdown LIMIT to UNION ALL select query when there are no LIMIT or having larger LIMIT length
+                    if (!old_limit_length || old_limit_length > limit_length)
+                    {
+                        select_query->setExpression(ASTSelectQuery::Expression::LIMIT_LENGTH, limit_length_ast->clone());
+                    }
+                }
+            }
+        }
+    }
+}
+}

--- a/src/Interpreters/PushdownLimitToUnionAll.cpp
+++ b/src/Interpreters/PushdownLimitToUnionAll.cpp
@@ -15,6 +15,11 @@ void PushdownLimitToUnionAllMatcher::visit(ASTPtr & ast, Data & data)
 
 void PushdownLimitToUnionAllMatcher::visit(ASTSelectQuery & select, Data &)
 {
+    /// When there are filter condition in SelectQuery, we can't
+    /// pushdown LIMIT to UNION ALL query.
+    if (select.prewhere() || select.where() || select.having())
+        return;
+
     const auto & limit_length_ast = select.limitLength();
     auto * tables = select.tables()->as<ASTTablesInSelectQuery>();
 

--- a/src/Interpreters/PushdownLimitToUnionAll.h
+++ b/src/Interpreters/PushdownLimitToUnionAll.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <unordered_set>
+
+#include <Parsers/IAST.h>
+#include <Interpreters/InDepthNodeVisitor.h>
+
+namespace DB
+{
+class ASTSelectQuery;
+class ASTSelectWithUnionQuery;
+
+/// LIMIT pushdown to UNION ALL queries,
+/// SELECT * FROM (SELECT * FROM numbers(100000000) ORDER BY number) LIMIT 10 becomes
+/// SELECT * FROM (SELECT * FROM numbers(100000000) ORDER BY number LIMIT 10) LIMIT 10.
+/// This visitor must be down after NormalizeSelectWithUnionQueryVisitor.
+class PushdownLimitToUnionAllMatcher
+{
+public:
+    struct Data
+    {
+    };
+
+    static void visit(ASTPtr & ast, Data &);
+    static void visit(ASTSelectQuery &, Data &);
+    static bool needChildVisit(const ASTPtr &, const ASTPtr &) { return true; }
+};
+
+using PushdownLimitToUnionAllVisitor = InDepthNodeVisitor<PushdownLimitToUnionAllMatcher, true>;
+}

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -46,6 +46,7 @@
 #include <Interpreters/NormalizeSelectWithUnionQueryVisitor.h>
 #include <Interpreters/OpenTelemetrySpanLog.h>
 #include <Interpreters/ProcessList.h>
+#include <Interpreters/PushdownLimitToUnionAll.h>
 #include <Interpreters/QueryLog.h>
 #include <Interpreters/ReplaceQueryParameterVisitor.h>
 #include <Interpreters/SelectQueryOptions.h>
@@ -489,6 +490,9 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
         /// Normalize SelectWithUnionQuery
         NormalizeSelectWithUnionQueryVisitor::Data data{context->getSettingsRef().union_default_mode};
         NormalizeSelectWithUnionQueryVisitor{data}.visit(ast);
+
+        PushdownLimitToUnionAllVisitor::Data limit{};
+        PushdownLimitToUnionAllVisitor{limit}.visit(ast);
 
         /// Check the limits.
         checkASTSizeLimits(*ast, settings);

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -491,8 +491,11 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
         NormalizeSelectWithUnionQueryVisitor::Data data{context->getSettingsRef().union_default_mode};
         NormalizeSelectWithUnionQueryVisitor{data}.visit(ast);
 
-        PushdownLimitToUnionAllVisitor::Data limit{};
-        PushdownLimitToUnionAllVisitor{limit}.visit(ast);
+        if (settings.optimize_pushdown_limit_to_union_all_query)
+        {
+            PushdownLimitToUnionAllVisitor::Data limit{};
+            PushdownLimitToUnionAllVisitor{limit}.visit(ast);
+        }
 
         /// Check the limits.
         checkASTSizeLimits(*ast, settings);

--- a/tests/performance/push_down_limit.xml
+++ b/tests/performance/push_down_limit.xml
@@ -5,5 +5,7 @@
     <query>select number from (select number from numbers(500000000) order by -number) limit 10</query>
     <query>select number from (select number from numbers_mt(1500000000) order by -number) limit 10</query>
 
+    <query>select * from (select * from numbers(500000000) order by number union all select * from numbers(500000000) order by number) order by number limit 10</query>
+
     <query short="1">select number from numbers_view limit 100</query>
 </test>

--- a/tests/queries/0_stateless/01821_pushdown_limit_to_union_all.reference
+++ b/tests/queries/0_stateless/01821_pushdown_limit_to_union_all.reference
@@ -1,0 +1,67 @@
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+SELECT number
+FROM 
+(
+    SELECT number
+    FROM numbers(100)
+    ORDER BY number ASC
+    LIMIT 10
+)
+ORDER BY number ASC
+LIMIT 10
+0
+0
+1
+1
+2
+2
+3
+3
+4
+4
+SELECT number
+FROM 
+(
+    SELECT number
+    FROM numbers(100)
+    ORDER BY number ASC
+    LIMIT 10
+    UNION ALL
+    SELECT number
+    FROM numbers(100)
+    ORDER BY number ASC
+    LIMIT 10
+)
+ORDER BY number ASC
+LIMIT 10
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+SELECT number
+FROM 
+(
+    SELECT number
+    FROM numbers(100)
+    UNION DISTINCT
+    SELECT number
+    FROM numbers(100)
+    ORDER BY number ASC
+)
+ORDER BY number ASC
+LIMIT 10

--- a/tests/queries/0_stateless/01821_pushdown_limit_to_union_all.sql
+++ b/tests/queries/0_stateless/01821_pushdown_limit_to_union_all.sql
@@ -1,0 +1,78 @@
+SELECT *
+FROM 
+(
+    SELECT *
+    FROM numbers(100)
+    ORDER BY number ASC
+)
+ORDER BY number ASC
+LIMIT 10;
+
+EXPLAIN SYNTAX
+SELECT *
+FROM 
+(
+    SELECT *
+    FROM numbers(100)
+    ORDER BY number ASC
+)
+ORDER BY number ASC
+LIMIT 10;
+
+SELECT *
+FROM
+(
+	SELECT *
+    FROM numbers(100)
+    ORDER BY number ASC
+    UNION ALL
+    SELECT *
+    FROM numbers(100)
+    ORDER BY number ASC
+)
+ORDER BY number ASC
+LIMIT 10;
+
+EXPLAIN SYNTAX
+SELECT *
+FROM
+(
+	SELECT *
+    FROM numbers(100)
+    ORDER BY number ASC
+    UNION ALL
+    SELECT *
+    FROM numbers(100)
+    ORDER BY number ASC
+)
+ORDER BY number ASC
+LIMIT 10;
+
+SELECT *
+FROM
+(
+	SELECT *
+    FROM numbers(100)
+    ORDER BY number ASC
+    UNION DISTINCT
+    SELECT *
+    FROM numbers(100)
+    ORDER BY number ASC
+)
+ORDER BY number ASC
+LIMIT 10;
+
+EXPLAIN SYNTAX
+SELECT *
+FROM
+(
+	SELECT *
+    FROM numbers(100)
+    ORDER BY number ASC
+    UNION DISTINCT
+    SELECT *
+    FROM numbers(100)
+    ORDER BY number ASC
+)
+ORDER BY number ASC
+LIMIT 10;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Pushdown LIMIT to UNION ALL query. closes #23239.


Detailed description / Documentation draft:

```sql
:) explain syntax SELECT * FROM (SELECT * FROM numbers(100) ORDER BY number union all select * from numbers(100) order by number ) 
ORDER BY number LIMIT 10                                                                                                                          
                                                                                                                                                  
EXPLAIN SYNTAX                                                                                                                                    
SELECT *                                                                                                                                          
FROM                                                                                                                                              
(                                                                                                                                                 
    SELECT *                                                                                                                                      
    FROM numbers(100)
    ORDER BY number ASC
    UNION ALL
    SELECT *
    FROM numbers(100)
    ORDER BY number ASC
)
ORDER BY number ASC
LIMIT 10

Query id: d470df8c-fd26-40ce-b27e-76633c8be785

┌─explain─────────────────┐
│ SELECT number           │
│ FROM                    │
│ (                       │
│     SELECT number       │
│     FROM numbers(100)   │
│     ORDER BY number ASC │
│     LIMIT 10            │
│     UNION ALL           │
│     SELECT number       │
│     FROM numbers(100)   │
│     ORDER BY number ASC │
│     LIMIT 10            │
│ )                       │
│ ORDER BY number ASC     │
│ LIMIT 10                │
└─────────────────────────┘

15 rows in set. Elapsed: 0.015 sec.
```