### PR TITLE
Link keeper-bench to clickhouse_common_zookeeper

### DIFF
--- a/utils/keeper-bench/CMakeLists.txt
+++ b/utils/keeper-bench/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_executable(keeper-bench Generator.cpp Runner.cpp Stats.cpp main.cpp)
-target_link_libraries(keeper-bench PRIVATE dbms)
+target_link_libraries(keeper-bench PRIVATE clickhouse_common_zookeeper)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Detailed description / Documentation draft:

Issue introduced in https://github.com/ClickHouse/ClickHouse/pull/23038. With clang and split shared libraries, the new tool can't be built due to issues duting the final linkage step:

```
ld.lld: error: undefined symbol: Coordination::ZooKeeper::create(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, bool, std::__1::vector<Coordination::ACL, std::__1::allocator<Coordination::ACL> > const&, std::__1::function<void (Coordination::CreateResponse const&)>)
>>> referenced by Generator.cpp:62 (../utils/keeper-bench/Generator.cpp:62)
>>>               utils/keeper-bench/CMakeFiles/keeper-bench.dir/Generator.cpp.o:(CreateRequestGenerator::startup(Coordination::ZooKeeper&))
>>> referenced by Generator.cpp:99 (../utils/keeper-bench/Generator.cpp:99)
>>>               utils/keeper-bench/CMakeFiles/keeper-bench.dir/Generator.cpp.o:(GetRequestGenerator::startup(Coordination::ZooKeeper&))
>>> referenced by Generator.cpp:124 (../utils/keeper-bench/Generator.cpp:124)
>>>               utils/keeper-bench/CMakeFiles/keeper-bench.dir/Generator.cpp.o:(GetRequestGenerator::startup(Coordination::ZooKeeper&))
>>> referenced 2 more times

ld.lld: error: undefined symbol: VTT for Coordination::ZooKeeperCreateRequest
>>> referenced by IKeeper.h:151 (../src/Common/ZooKeeper/IKeeper.h:151)
>>>               utils/keeper-bench/CMakeFiles/keeper-bench.dir/Generator.cpp.o:(CreateRequestGenerator::generate())
>>> referenced by ZooKeeperCommon.h:173 (../src/Common/ZooKeeper/ZooKeeperCommon.h:173)
>>>               utils/keeper-bench/CMakeFiles/keeper-bench.dir/Generator.cpp.o:(std::__1::__shared_ptr_emplace<Coordination::ZooKeeperCreateRequest, std::__1::allocator<Coordination::ZooKeeperCreateRequest> >::__on_zero_shared())

...
```

I'm not sure how to use the tool itself, so it might need extra link libraries but with this change it builds and `./utils/keeper-bench/keeper-bench --help` works.
