### PR TITLE
Fix crash in case of unknown packet

### DIFF
--- a/src/Client/MultiplexedConnections.cpp
+++ b/src/Client/MultiplexedConnections.cpp
@@ -289,6 +289,7 @@ Packet MultiplexedConnections::receivePacketUnlocked(AsyncCallback async_callbac
             /// In this case, invalidate replica, so that we would not read from it anymore.
             current_connection->disconnect();
             invalidateReplica(state);
+            throw;
         }
     }
 

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -224,6 +224,7 @@ class IColumn;
     /** Settings for testing hedged requests */ \
     M(Milliseconds, sleep_in_send_tables_status_ms, 0, "Time to sleep in sending tables status response in TCPHandler", 0) \
     M(Milliseconds, sleep_in_send_data_ms, 0, "Time to sleep in sending data in TCPHandler", 0) \
+    M(UInt64, unknown_packet_in_send_data, 0, "Send unknown packet instead of data Nth data packet", 0) \
     \
     M(Bool, insert_allow_materialized_columns, 0, "If setting is enabled, Allow materialized columns in INSERT.", 0) \
     M(Seconds, http_connection_timeout, DEFAULT_HTTP_READ_BUFFER_CONNECTION_TIMEOUT, "HTTP connection timeout.", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -433,7 +433,7 @@ class IColumn;
     M(Bool, allow_experimental_map_type, false, "Allow data type Map", 0) \
     M(Bool, allow_experimental_window_functions, false, "Allow experimental window functions", 0) \
     M(Bool, use_antlr_parser, false, "Parse incoming queries using ANTLR-generated experimental parser", 0) \
-    M(Bool, async_socket_for_remote, false, "Asynchronously read from socket executing remote query", 0) \
+    M(Bool, async_socket_for_remote, true, "Asynchronously read from socket executing remote query", 0) \
     \
     M(Bool, optimize_rewrite_sum_if_to_count_if, true, "Rewrite sumIf() and sum(if()) function countIf() function when logically equivalent", 0) \
     M(UInt64, insert_shard_id, 0, "If non zero, when insert into a distributed table, the data will be inserted into the shard `insert_shard_id` synchronously. Possible values range from 1 to `shards_number` of corresponding distributed table", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -433,7 +433,7 @@ class IColumn;
     M(Bool, allow_experimental_map_type, false, "Allow data type Map", 0) \
     M(Bool, allow_experimental_window_functions, false, "Allow experimental window functions", 0) \
     M(Bool, use_antlr_parser, false, "Parse incoming queries using ANTLR-generated experimental parser", 0) \
-    M(Bool, async_socket_for_remote, true, "Asynchronously read from socket executing remote query", 0) \
+    M(Bool, async_socket_for_remote, false, "Asynchronously read from socket executing remote query", 0) \
     \
     M(Bool, optimize_rewrite_sum_if_to_count_if, true, "Rewrite sumIf() and sum(if()) function countIf() function when logically equivalent", 0) \
     M(UInt64, insert_shard_id, 0, "If non zero, when insert into a distributed table, the data will be inserted into the shard `insert_shard_id` synchronously. Possible values range from 1 to `shards_number` of corresponding distributed table", 0) \

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -1463,12 +1463,20 @@ void TCPHandler::sendData(const Block & block)
 
     try
     {
+        /// For testing hedged requests
+        const Settings & settings = query_context->getSettingsRef();
+        if (settings.unknown_packet_in_send_data)
+        {
+            --const_cast<SettingFieldUInt64 &>(settings.unknown_packet_in_send_data).value;
+            if (settings.unknown_packet_in_send_data == 0)
+                writeVarUInt(UInt64(-1), *out);
+        }
+
         writeVarUInt(Protocol::Server::Data, *out);
         /// Send external table name (empty name is the main table)
         writeStringBinary("", *out);
 
         /// For testing hedged requests
-        const Settings & settings = query_context->getSettingsRef();
         if (block.rows() > 0 && settings.sleep_in_send_data_ms.totalMilliseconds())
         {
             out->next();

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -300,6 +300,8 @@ void TCPHandler::runImpl()
             /// Processing Query
             state.io = executeQuery(state.query, query_context, false, state.stage, may_have_embedded_data);
 
+            unknown_packet_in_send_data = query_context->getSettingsRef().unknown_packet_in_send_data;
+
             after_check_cancelled.restart();
             after_send_progress.restart();
 
@@ -1464,11 +1466,10 @@ void TCPHandler::sendData(const Block & block)
     try
     {
         /// For testing hedged requests
-        const Settings & settings = query_context->getSettingsRef();
-        if (settings.unknown_packet_in_send_data)
+        if (unknown_packet_in_send_data)
         {
-            --const_cast<SettingFieldUInt64 &>(settings.unknown_packet_in_send_data).value;
-            if (settings.unknown_packet_in_send_data == 0)
+            --unknown_packet_in_send_data;
+            if (unknown_packet_in_send_data == 0)
                 writeVarUInt(UInt64(-1), *out);
         }
 

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -1478,6 +1478,7 @@ void TCPHandler::sendData(const Block & block)
         writeStringBinary("", *out);
 
         /// For testing hedged requests
+        const Settings & settings = query_context->getSettingsRef();
         if (block.rows() > 0 && settings.sleep_in_send_data_ms.totalMilliseconds())
         {
             out->next();

--- a/src/Server/TCPHandler.h
+++ b/src/Server/TCPHandler.h
@@ -135,6 +135,8 @@ private:
     ContextPtr connection_context;
     ContextPtr query_context;
 
+    size_t unknown_packet_in_send_data = 0;
+
     /// Streams for reading/writing from/to client connection socket.
     std::shared_ptr<ReadBuffer> in;
     std::shared_ptr<WriteBuffer> out;

--- a/tests/queries/0_stateless/01822_async_read_from_socket_crash.sh
+++ b/tests/queries/0_stateless/01822_async_read_from_socket_crash.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+
+
+for _ in {1..10}; do $CLICKHOUSE_CLIENT -q "select number from remote('127.0.0.{2,3}', numbers(20)) limit 8 settings max_block_size = 2, unknown_packet_in_send_data=4, sleep_in_send_data_ms=100, async_socket_for_remote=1 format Null" 2>&1 > /dev/null; done

--- a/tests/queries/0_stateless/01822_async_read_from_socket_crash.sh
+++ b/tests/queries/0_stateless/01822_async_read_from_socket_crash.sh
@@ -6,4 +6,4 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 
 
-for _ in {1..10}; do $CLICKHOUSE_CLIENT -q "select number from remote('127.0.0.{2,3}', numbers(20)) limit 8 settings max_block_size = 2, unknown_packet_in_send_data=4, sleep_in_send_data_ms=100, async_socket_for_remote=1 format Null" 2>&1 > /dev/null; done
+for _ in {1..10}; do $CLICKHOUSE_CLIENT -q "select number from remote('127.0.0.{2,3}', numbers(20)) limit 8 settings max_block_size = 2, unknown_packet_in_send_data=4, sleep_in_send_data_ms=100, async_socket_for_remote=1 format Null" > /dev/null 2>&1 || true; done


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible crash in case if `unknown packet` was received form remote query (with `async_socket_for_remote` enabled). Maybe fixes #21167