### PR TITLE
Fix hdfs reading from files with spaces

### DIFF
--- a/src/Storages/HDFS/HDFSCommon.cpp
+++ b/src/Storages/HDFS/HDFSCommon.cpp
@@ -9,14 +9,15 @@
 #include <IO/Operators.h>
 #include <common/logger_useful.h>
 
+
 namespace DB
 {
 namespace ErrorCodes
 {
-extern const int BAD_ARGUMENTS;
-extern const int NETWORK_ERROR;
-extern const int EXCESSIVE_ELEMENT_IN_CONFIG;
-extern const int NO_ELEMENTS_IN_CONFIG;
+    extern const int BAD_ARGUMENTS;
+    extern const int NETWORK_ERROR;
+    extern const int EXCESSIVE_ELEMENT_IN_CONFIG;
+    extern const int NO_ELEMENTS_IN_CONFIG;
 }
 
 const String HDFSBuilderWrapper::CONFIG_PREFIX = "hdfs";

--- a/src/Storages/HDFS/HDFSCommon.h
+++ b/src/Storages/HDFS/HDFSCommon.h
@@ -17,6 +17,7 @@
 
 namespace DB
 {
+
 namespace detail
 {
     struct HDFSFsDeleter
@@ -28,16 +29,14 @@ namespace detail
     };
 }
 
+
 struct HDFSFileInfo
 {
     hdfsFileInfo * file_info;
     int length;
 
-    HDFSFileInfo()
-        : file_info(nullptr)
-        , length(0)
-    {
-    }
+    HDFSFileInfo() : file_info(nullptr) , length(0) {}
+
     HDFSFileInfo(const HDFSFileInfo & other) = delete;
     HDFSFileInfo(HDFSFileInfo && other) = default;
     HDFSFileInfo & operator=(const HDFSFileInfo & other) = delete;
@@ -49,17 +48,30 @@ struct HDFSFileInfo
     }
 };
 
+
 class HDFSBuilderWrapper
 {
-    hdfsBuilder * hdfs_builder;
-    String hadoop_kerberos_keytab;
-    String hadoop_kerberos_principal;
-    String hadoop_kerberos_kinit_command = "kinit";
-    String hadoop_security_kerberos_ticket_cache_path;
 
-    static std::mutex kinit_mtx;
+friend HDFSBuilderWrapper createHDFSBuilder(const String & uri_str, const Poco::Util::AbstractConfiguration &);
 
-    std::vector<std::pair<String, String>> config_stor;
+static const String CONFIG_PREFIX;
+
+public:
+    HDFSBuilderWrapper() : hdfs_builder(hdfsNewBuilder()) {}
+
+    ~HDFSBuilderWrapper() { hdfsFreeBuilder(hdfs_builder); }
+
+    HDFSBuilderWrapper(const HDFSBuilderWrapper &) = delete;
+    HDFSBuilderWrapper(HDFSBuilderWrapper &&) = default;
+
+    hdfsBuilder * get() { return hdfs_builder; }
+
+private:
+    void loadFromConfig(const Poco::Util::AbstractConfiguration & config, const String & config_path, bool isUser = false);
+
+    String getKinitCmd();
+
+    void runKinit();
 
     // hdfs builder relies on an external config data storage
     std::pair<String, String>& keep(const String & k, const String & v)
@@ -67,48 +79,24 @@ class HDFSBuilderWrapper
         return config_stor.emplace_back(std::make_pair(k, v));
     }
 
+    hdfsBuilder * hdfs_builder;
+    String hadoop_kerberos_keytab;
+    String hadoop_kerberos_principal;
+    String hadoop_kerberos_kinit_command = "kinit";
+    String hadoop_security_kerberos_ticket_cache_path;
+
+    static std::mutex kinit_mtx;
+    std::vector<std::pair<String, String>> config_stor;
     bool need_kinit{false};
-
-    static const String CONFIG_PREFIX;
-
-private:
-
-    void loadFromConfig(const Poco::Util::AbstractConfiguration & config, const String & config_path, bool isUser = false);
-
-    String getKinitCmd();
-
-    void runKinit();
-
-public:
-
-    hdfsBuilder *
-    get()
-    {
-        return hdfs_builder;
-    }
-
-    HDFSBuilderWrapper()
-        : hdfs_builder(hdfsNewBuilder())
-    {
-    }
-
-    ~HDFSBuilderWrapper()
-    {
-        hdfsFreeBuilder(hdfs_builder);
-
-    }
-
-    HDFSBuilderWrapper(const HDFSBuilderWrapper &) = delete;
-    HDFSBuilderWrapper(HDFSBuilderWrapper &&) = default;
-
-    friend HDFSBuilderWrapper createHDFSBuilder(const String & uri_str, const Poco::Util::AbstractConfiguration &);
 };
 
 using HDFSFSPtr = std::unique_ptr<std::remove_pointer_t<hdfsFS>, detail::HDFSFsDeleter>;
+
 
 // set read/connect timeout, default value in libhdfs3 is about 1 hour, and too large
 /// TODO Allow to tune from query Settings.
 HDFSBuilderWrapper createHDFSBuilder(const String & uri_str, const Poco::Util::AbstractConfiguration &);
 HDFSFSPtr createHDFSFS(hdfsBuilder * builder);
+
 }
 #endif

--- a/src/Storages/HDFS/ReadBufferFromHDFS.cpp
+++ b/src/Storages/HDFS/ReadBufferFromHDFS.cpp
@@ -8,6 +8,7 @@
 
 namespace DB
 {
+
 namespace ErrorCodes
 {
     extern const int NETWORK_ERROR;
@@ -21,8 +22,9 @@ struct ReadBufferFromHDFS::ReadBufferFromHDFSImpl
     /// HDFS create/open functions are not thread safe
     static std::mutex hdfs_init_mutex;
 
-    std::string hdfs_uri;
-    std::string hdfs_file_path;
+    String hdfs_uri;
+    String hdfs_file_path;
+
     hdfsFile fin;
     HDFSBuilderWrapper builder;
     HDFSFSPtr fs;
@@ -66,16 +68,14 @@ struct ReadBufferFromHDFS::ReadBufferFromHDFSImpl
 
 std::mutex ReadBufferFromHDFS::ReadBufferFromHDFSImpl::hdfs_init_mutex;
 
-ReadBufferFromHDFS::ReadBufferFromHDFS(const std::string & hdfs_name_,
-    const Poco::Util::AbstractConfiguration & config_,
-    size_t buf_size_)
+ReadBufferFromHDFS::ReadBufferFromHDFS(
+        const String & hdfs_uri_,
+        const String & hdfs_file_path_,
+        const Poco::Util::AbstractConfiguration & config_,
+        size_t buf_size_)
     : BufferWithOwnMemory<ReadBuffer>(buf_size_)
+    , impl(std::make_unique<ReadBufferFromHDFSImpl>(hdfs_uri_, hdfs_file_path_, config_))
 {
-    const size_t begin_of_path = hdfs_name_.find('/', hdfs_name_.find("//") + 2);
-    const String hdfs_file_path = hdfs_name_.substr(begin_of_path);
-    const String hdfs_uri = hdfs_name_.substr(0, begin_of_path) + "/";
-
-    impl = std::make_unique<ReadBufferFromHDFSImpl>(hdfs_uri, hdfs_file_path, config_);
 }
 
 

--- a/src/Storages/HDFS/ReadBufferFromHDFS.cpp
+++ b/src/Storages/HDFS/ReadBufferFromHDFS.cpp
@@ -22,33 +22,37 @@ struct ReadBufferFromHDFS::ReadBufferFromHDFSImpl
     static std::mutex hdfs_init_mutex;
 
     std::string hdfs_uri;
+    std::string hdfs_file_path;
     hdfsFile fin;
     HDFSBuilderWrapper builder;
     HDFSFSPtr fs;
 
-    ReadBufferFromHDFSImpl(const std::string & hdfs_name_,
+    explicit ReadBufferFromHDFSImpl(
+        const std::string & hdfs_uri_,
+        const std::string & hdfs_file_path_,
         const Poco::Util::AbstractConfiguration & config_)
-        : hdfs_uri(hdfs_name_),
-          builder(createHDFSBuilder(hdfs_uri, config_))
+        : hdfs_uri(hdfs_uri_)
+        , hdfs_file_path(hdfs_file_path_)
+        , builder(createHDFSBuilder(hdfs_uri_, config_))
     {
         std::lock_guard lock(hdfs_init_mutex);
 
         fs = createHDFSFS(builder.get());
-        const size_t begin_of_path = hdfs_uri.find('/', hdfs_uri.find("//") + 2);
-        const std::string path = hdfs_uri.substr(begin_of_path);
-        fin = hdfsOpenFile(fs.get(), path.c_str(), O_RDONLY, 0, 0, 0);
+        fin = hdfsOpenFile(fs.get(), hdfs_file_path.c_str(), O_RDONLY, 0, 0, 0);
 
         if (fin == nullptr)
-            throw Exception("Unable to open HDFS file: " + path + " error: " + std::string(hdfsGetLastError()),
-                ErrorCodes::CANNOT_OPEN_FILE);
+            throw Exception(ErrorCodes::CANNOT_OPEN_FILE,
+                "Unable to open HDFS file: {}. Error: {}",
+                hdfs_uri + hdfs_file_path, std::string(hdfsGetLastError()));
     }
 
     int read(char * start, size_t size) const
     {
         int bytes_read = hdfsRead(fs.get(), fin, start, size);
         if (bytes_read < 0)
-            throw Exception("Fail to read HDFS file: " + hdfs_uri + " " + std::string(hdfsGetLastError()),
-                ErrorCodes::NETWORK_ERROR);
+            throw Exception(ErrorCodes::NETWORK_ERROR,
+                "Fail to read from HDFS: {}, file path: {}. Error: {}",
+                hdfs_uri, hdfs_file_path, std::string(hdfsGetLastError()));
         return bytes_read;
     }
 
@@ -66,8 +70,12 @@ ReadBufferFromHDFS::ReadBufferFromHDFS(const std::string & hdfs_name_,
     const Poco::Util::AbstractConfiguration & config_,
     size_t buf_size_)
     : BufferWithOwnMemory<ReadBuffer>(buf_size_)
-    , impl(std::make_unique<ReadBufferFromHDFSImpl>(hdfs_name_, config_))
 {
+    const size_t begin_of_path = hdfs_name_.find('/', hdfs_name_.find("//") + 2);
+    const String hdfs_file_path = hdfs_name_.substr(begin_of_path);
+    const String hdfs_uri = hdfs_name_.substr(0, begin_of_path) + "/";
+
+    impl = std::make_unique<ReadBufferFromHDFSImpl>(hdfs_uri, hdfs_file_path, config_);
 }
 
 

--- a/src/Storages/HDFS/ReadBufferFromHDFS.h
+++ b/src/Storages/HDFS/ReadBufferFromHDFS.h
@@ -7,11 +7,8 @@
 #include <IO/BufferWithOwnMemory.h>
 #include <string>
 #include <memory>
-
 #include <hdfs/hdfs.h>
-
 #include <common/types.h>
-
 #include <Interpreters/Context.h>
 
 
@@ -22,13 +19,19 @@ namespace DB
  */
 class ReadBufferFromHDFS : public BufferWithOwnMemory<ReadBuffer>
 {
-    struct ReadBufferFromHDFSImpl;
-    std::unique_ptr<ReadBufferFromHDFSImpl> impl;
+struct ReadBufferFromHDFSImpl;
+
 public:
-    ReadBufferFromHDFS(const std::string & hdfs_name_, const Poco::Util::AbstractConfiguration &, size_t buf_size_ = DBMS_DEFAULT_BUFFER_SIZE);
+    ReadBufferFromHDFS(const String & hdfs_uri_, const String & hdfs_file_path_,
+        const Poco::Util::AbstractConfiguration &, size_t buf_size_ = DBMS_DEFAULT_BUFFER_SIZE);
+
     ~ReadBufferFromHDFS() override;
 
     bool nextImpl() override;
+
+private:
+    std::unique_ptr<ReadBufferFromHDFSImpl> impl;
 };
 }
+
 #endif

--- a/src/Storages/HDFS/StorageHDFS.h
+++ b/src/Storages/HDFS/StorageHDFS.h
@@ -42,7 +42,7 @@ protected:
         const String & compression_method_);
 
 private:
-    String uri;
+    const String uri;
     String format_name;
     String compression_method;
 

--- a/tests/integration/test_storage_hdfs/test.py
+++ b/tests/integration/test_storage_hdfs/test.py
@@ -201,6 +201,15 @@ def test_write_gzip_storage(started_cluster):
     assert started_cluster.hdfs_api.read_gzip_data("/gzip_storage") == "1\tMark\t72.53\n"
     assert node1.query("select * from GZIPHDFSStorage") == "1\tMark\t72.53\n"
 
+
+def test_read_files_with_spaces(started_cluster):
+    started_cluster.hdfs_api.write_data("/test test test 1.txt", "1\n")
+    started_cluster.hdfs_api.write_data("/test test test 2.txt", "2\n")
+    started_cluster.hdfs_api.write_data("/test test test 3.txt", "3\n")
+    node1.query("create table test (id UInt32) ENGINE = HDFS('hdfs://hdfs1:9000/test*', 'TSV')")
+    assert node1.query("select * from test order by id") == "1\n2\n3\n"
+
+
 if __name__ == '__main__':
     cluster.start()
     input("Cluster created, press any key to destroy...")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Closes https://github.com/ClickHouse/ClickHouse/issues/13606.

Checked locally with the following files:
> bash-4.1# hdfs dfs -put kssenii.txt '/test/test test test 0.txt'
bash-4.1# hdfs dfs -put kssenii.txt '/test/test test test 1.txt'
bash-4.1# hdfs dfs -put kssenii.txt '/test/test test test 2.txt'
bash-4.1# hadoop fs -ls /test
Found 3 items
-rw-r--r-- 1 root supergroup 292 2021-04-17 07:31 /test/test test test 0.txt
-rw-r--r-- 1 root supergroup 292 2021-04-17 07:31 /test/test test test 1.txt
-rw-r--r-- 1 root supergroup 292 2021-04-17 07:31 /test/test test test 2.txt

And this query now works:
>  CREATE TABLE test ( id UInt32 ) ENGINE = HDFS('hdfs://192.168.112.2:9000/test/test*', 'TabSeparated');
select * from test;

Fix: It is enough to pass to hdfsBuilder uri without file path. File path is handled separately in hdfsOpenFile method. It should not be passed to hdfsBuilder because at the moment of builder creation it is not url-encoded.