### PR TITLE
Disable min_bytes_to_use_mmap_io by default

### DIFF
--- a/docker/test/performance-comparison/config/users.d/perf-comparison-tweaks-users.xml
+++ b/docker/test/performance-comparison/config/users.d/perf-comparison-tweaks-users.xml
@@ -17,6 +17,9 @@
 
             <!-- One NUMA node w/o hyperthreading -->
             <max_threads>12</max_threads>
+
+            <!-- mmap shows some improvements in perf tests -->
+            <min_bytes_to_use_mmap_io>64Mi</min_bytes_to_use_mmap_io>
         </default>
     </profiles>
     <users>

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -142,7 +142,7 @@ class IColumn;
     M(UInt64, optimize_min_equality_disjunction_chain_length, 3, "The minimum length of the expression `expr = x1 OR ... expr = xN` for optimization ", 0) \
     \
     M(UInt64, min_bytes_to_use_direct_io, 0, "The minimum number of bytes for reading the data with O_DIRECT option during SELECT queries execution. 0 - disabled.", 0) \
-    M(UInt64, min_bytes_to_use_mmap_io, (64 * 1024 * 1024), "The minimum number of bytes for reading the data with mmap option during SELECT queries execution. 0 - disabled.", 0) \
+    M(UInt64, min_bytes_to_use_mmap_io, 0, "The minimum number of bytes for reading the data with mmap option during SELECT queries execution. 0 - disabled.", 0) \
     M(Bool, checksum_on_read, true, "Validate checksums on reading. It is enabled by default and should be always enabled in production. Please do not expect any benefits in disabling this setting. It may only be used for experiments and benchmarks. The setting only applicable for tables of MergeTree family. Checksums are always validated for other table engines and when receiving data over network.", 0) \
     \
     M(Bool, force_index_by_date, 0, "Throw an exception if there is a partition key in a table, and it is not used.", 0) \


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Disable min_bytes_to_use_mmap_io by default

Detailed description / Documentation draft:
Reading files using mmap() does not have any significant benefits over
plain read() [1].

  [1]: https://gist.github.com/azat/3d6c8d82bdd91e7a38d997fd6bcfd574

And not only it does not have significant benefits, it also has some
issues, due to max_server_memory_usage (default to 90% of available
RAM), since when you read files with mmap() eventually process RSS may
exceed max_server_memory_usage, and in this case any allocation will
fail (with "Memory limit exceeded (total)") error (yes kernel will
unload pages, but likely it will happens after queries will starting to
fail), like in this test [2].

  [2]: https://gist.github.com/azat/4813489828162e6c2ce131963c6a1acb

TL;DR;

<details>

Note that there was also an idea to take those mmap()'ed regions in
memory tracking (#23211), but there are some drawbacks (since accounting
mmap() is tricky, first of all you need to account only once per inode
for file and plus kernel can unload some pages and those memory will not
be used by the server anymore).

And as an adddition to #23211 there was #23212, that adds
max_bytes_to_use_mmap_io, but since mmap is not a subject for memory
accounting there is no need in it.

</details>

Cc: @alexey-milovidov 

*NOTE: that it has been marked as `Improvement`, but likely should be backported, so maybe `Bug fix`?*