### PR TITLE
Respect insert_allow_materialized_columns for INSERT into Distributed()

### DIFF
--- a/src/Storages/Distributed/DistributedBlockOutputStream.cpp
+++ b/src/Storages/Distributed/DistributedBlockOutputStream.cpp
@@ -607,7 +607,6 @@ void DistributedBlockOutputStream::writeAsyncImpl(const Block & block, size_t sh
 
 void DistributedBlockOutputStream::writeToLocal(const Block & block, size_t repeats)
 {
-    /// Async insert does not support settings forwarding yet whereas sync one supports
     InterpreterInsertQuery interp(query_ast, context);
 
     auto block_io = interp.execute();

--- a/src/Storages/Distributed/DistributedBlockOutputStream.cpp
+++ b/src/Storages/Distributed/DistributedBlockOutputStream.cpp
@@ -102,6 +102,7 @@ DistributedBlockOutputStream::DistributedBlockOutputStream(
     , query_string(queryToString(query_ast_))
     , cluster(cluster_)
     , insert_sync(insert_sync_)
+    , allow_materialized(context->getSettingsRef().insert_allow_materialized_columns)
     , insert_timeout(insert_timeout_)
     , main_table(main_table_)
     , log(&Poco::Logger::get("DistributedBlockOutputStream"))
@@ -115,7 +116,10 @@ DistributedBlockOutputStream::DistributedBlockOutputStream(
 
 Block DistributedBlockOutputStream::getHeader() const
 {
-    return metadata_snapshot->getSampleBlock();
+    if (!allow_materialized)
+        return metadata_snapshot->getSampleBlockNonMaterialized();
+    else
+        return metadata_snapshot->getSampleBlock();
 }
 
 
@@ -129,18 +133,20 @@ void DistributedBlockOutputStream::write(const Block & block)
 {
     Block ordinary_block{ block };
 
-    /* They are added by the AddingDefaultBlockOutputStream, and we will get
-     * different number of columns eventually */
-    for (const auto & col : metadata_snapshot->getColumns().getMaterialized())
+    if (!allow_materialized)
     {
-        if (ordinary_block.has(col.name))
+        /* They are added by the AddingDefaultBlockOutputStream, and we will get
+         * different number of columns eventually */
+        for (const auto & col : metadata_snapshot->getColumns().getMaterialized())
         {
-            ordinary_block.erase(col.name);
-            LOG_DEBUG(log, "{}: column {} will be removed, because it is MATERIALIZED",
-                storage.getStorageID().getNameForLogs(), col.name);
+            if (ordinary_block.has(col.name))
+            {
+                ordinary_block.erase(col.name);
+                LOG_DEBUG(log, "{}: column {} will be removed, because it is MATERIALIZED",
+                    storage.getStorageID().getNameForLogs(), col.name);
+            }
         }
     }
-
 
     if (insert_sync)
         writeSync(ordinary_block);
@@ -375,7 +381,7 @@ DistributedBlockOutputStream::runWritingJob(DistributedBlockOutputStream::JobRep
                 /// to resolve tables (in InterpreterInsertQuery::getTable())
                 auto copy_query_ast = query_ast->clone();
 
-                InterpreterInsertQuery interp(copy_query_ast, job.local_context);
+                InterpreterInsertQuery interp(copy_query_ast, job.local_context, allow_materialized);
                 auto block_io = interp.execute();
 
                 job.stream = block_io.out;
@@ -607,7 +613,7 @@ void DistributedBlockOutputStream::writeAsyncImpl(const Block & block, size_t sh
 
 void DistributedBlockOutputStream::writeToLocal(const Block & block, size_t repeats)
 {
-    InterpreterInsertQuery interp(query_ast, context);
+    InterpreterInsertQuery interp(query_ast, context, allow_materialized);
 
     auto block_io = interp.execute();
 

--- a/src/Storages/Distributed/DistributedBlockOutputStream.h
+++ b/src/Storages/Distributed/DistributedBlockOutputStream.h
@@ -94,6 +94,7 @@ private:
     size_t inserted_rows = 0;
 
     bool insert_sync;
+    bool allow_materialized;
 
     /// Sync-related stuff
     UInt64 insert_timeout; // in seconds

--- a/tests/queries/0_stateless/00952_insert_into_distributed_with_materialized_column.reference
+++ b/tests/queries/0_stateless/00952_insert_into_distributed_with_materialized_column.reference
@@ -1,3 +1,4 @@
+insert_allow_materialized_columns=0
 insert_distributed_sync=0
 2018-08-01
 2018-08-01
@@ -12,3 +13,18 @@ insert_distributed_sync=1
 2018-08-01	2017-08-01
 2018-08-01
 2018-08-01	2017-08-01
+insert_allow_materialized_columns=1
+insert_distributed_sync=0
+2018-08-01
+2018-08-01
+2018-08-01	2019-08-01
+2018-08-01	2019-08-01
+2018-08-01
+2018-08-01	2019-08-01
+insert_distributed_sync=1
+2018-08-01
+2018-08-01
+2018-08-01	2019-08-01
+2018-08-01	2019-08-01
+2018-08-01
+2018-08-01	2019-08-01

--- a/tests/queries/0_stateless/00952_insert_into_distributed_with_materialized_column.sql
+++ b/tests/queries/0_stateless/00952_insert_into_distributed_with_materialized_column.sql
@@ -2,6 +2,12 @@ DROP TABLE IF EXISTS local_00952;
 DROP TABLE IF EXISTS distributed_00952;
 
 --
+-- insert_allow_materialized_columns=0
+--
+SELECT 'insert_allow_materialized_columns=0';
+SET insert_allow_materialized_columns=0;
+
+--
 -- insert_distributed_sync=0
 --
 SELECT 'insert_distributed_sync=0';
@@ -40,3 +46,47 @@ SELECT date, value FROM local_00952;
 DROP TABLE distributed_00952;
 DROP TABLE local_00952;
 
+--
+-- insert_allow_materialized_columns=1
+--
+SELECT 'insert_allow_materialized_columns=1';
+SET insert_allow_materialized_columns=1;
+
+--
+-- insert_distributed_sync=0
+--
+SELECT 'insert_distributed_sync=0';
+SET insert_distributed_sync=0;
+
+CREATE TABLE local_00952 (date Date, value Date MATERIALIZED toDate('2017-08-01')) ENGINE = MergeTree(date, date, 8192);
+CREATE TABLE distributed_00952 AS local_00952 ENGINE = Distributed('test_cluster_two_shards', currentDatabase(), local_00952, rand());
+
+INSERT INTO distributed_00952 (date, value) VALUES ('2018-08-01', '2019-08-01');
+SYSTEM FLUSH DISTRIBUTED distributed_00952;
+
+SELECT * FROM distributed_00952;
+SELECT date, value FROM distributed_00952;
+SELECT * FROM local_00952;
+SELECT date, value FROM local_00952;
+
+DROP TABLE distributed_00952;
+DROP TABLE local_00952;
+
+--
+-- insert_distributed_sync=1
+--
+SELECT 'insert_distributed_sync=1';
+SET insert_distributed_sync=1;
+
+CREATE TABLE local_00952 (date Date, value Date MATERIALIZED toDate('2017-08-01')) ENGINE = MergeTree(date, date, 8192);
+CREATE TABLE distributed_00952 AS local_00952 ENGINE = Distributed('test_cluster_two_shards', currentDatabase(), local_00952, rand());
+
+INSERT INTO distributed_00952 (date, value) VALUES ('2018-08-01', '2019-08-01');
+
+SELECT * FROM distributed_00952;
+SELECT date, value FROM distributed_00952;
+SELECT * FROM local_00952;
+SELECT date, value FROM local_00952;
+
+DROP TABLE distributed_00952;
+DROP TABLE local_00952;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Respect `insert_allow_materialized_columns` (allows materialized columns) for INSERT into `Distributed` table.

Follow-up for: #5429
Refs: #16897