### PR TITLE
Disable clickhouse-odbc-bridge build when ODBC is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -516,9 +516,9 @@ include (cmake/find/fast_float.cmake)
 include (cmake/find/rapidjson.cmake)
 include (cmake/find/fastops.cmake)
 include (cmake/find/odbc.cmake)
+include (cmake/find/nanodbc.cmake)
 include (cmake/find/rocksdb.cmake)
 include (cmake/find/libpqxx.cmake)
-include (cmake/find/nanodbc.cmake)
 include (cmake/find/nuraft.cmake)
 
 

--- a/cmake/find/nanodbc.cmake
+++ b/cmake/find/nanodbc.cmake
@@ -1,35 +1,16 @@
-option(ENABLE_NANODBC "Enalbe nanodbc" ${ENABLE_LIBRARIES})
-
-if (NOT ENABLE_NANODBC)
-    set (USE_ODBC 0)
-    return()
-endif()
-
 if (NOT ENABLE_ODBC)
-    set (USE_NANODBC 0)
-    message (STATUS "Using nanodbc=${USE_NANODBC}")
-    return()
-endif()
+    return ()
+endif ()
+
+if (NOT USE_INTERNAL_NANODBC_LIBRARY)
+    message (FATAL_ERROR "Only the bundled nanodbc library can be used")
+endif ()
 
 if (NOT EXISTS "${ClickHouse_SOURCE_DIR}/contrib/nanodbc/CMakeLists.txt")
-    message (WARNING "submodule contrib/nanodbc is missing. to fix try run: \n git submodule update --init --recursive")
-    message (${RECONFIGURE_MESSAGE_LEVEL} "Can't find internal nanodbc library")
-    set (USE_NANODBC 0)
-    return()
+    message (FATAL_ERROR "submodule contrib/nanodbc is missing. to fix try run: \n git submodule update --init --recursive")
 endif()
-
-if (NOT EXISTS "${ClickHouse_SOURCE_DIR}/contrib/unixodbc/include")
-    message (ERROR "submodule contrib/unixodbc is missing. to fix try run: \n git submodule update --init --recursive")
-    message (${RECONFIGURE_MESSAGE_LEVEL} "Can't find internal unixodbc needed for nanodbc")
-    set (USE_NANODBC 0)
-    return()
-endif()
-
-set (USE_NANODBC 1)
 
 set (NANODBC_LIBRARY nanodbc)
+set (NANODBC_INCLUDE_DIR "${ClickHouse_SOURCE_DIR}/contrib/nanodbc/nanodbc")
 
-set (NANODBC_INCLUDE_DIR "${ClickHouse_SOURCE_DIR}/contrib/nanodbc/nanodbce")
-
-message (STATUS "Using nanodbc=${USE_NANODBC}: ${NANODBC_INCLUDE_DIR} : ${NANODBC_LIBRARY}")
-message (STATUS "Using unixodbc")
+message (STATUS "Using nanodbc: ${NANODBC_INCLUDE_DIR} : ${NANODBC_LIBRARY}")

--- a/cmake/find/odbc.cmake
+++ b/cmake/find/odbc.cmake
@@ -50,4 +50,6 @@ if (NOT EXTERNAL_ODBC_LIBRARY_FOUND)
     set (USE_INTERNAL_ODBC_LIBRARY 1)
 endif ()
 
+set (USE_INTERNAL_NANODBC_LIBRARY 1)
+
 message (STATUS "Using unixodbc")

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -47,6 +47,7 @@ add_subdirectory (lz4-cmake)
 add_subdirectory (murmurhash)
 add_subdirectory (replxx-cmake)
 add_subdirectory (unixodbc-cmake)
+add_subdirectory (nanodbc-cmake)
 
 if (USE_INTERNAL_XZ_LIBRARY)
     add_subdirectory (xz)
@@ -318,10 +319,6 @@ endif()
 if (USE_LIBPQXX)
     add_subdirectory (libpq-cmake)
     add_subdirectory (libpqxx-cmake)
-endif()
-
-if (USE_NANODBC)
-    add_subdirectory (nanodbc-cmake)
 endif()
 
 if (USE_NURAFT)

--- a/contrib/nanodbc-cmake/CMakeLists.txt
+++ b/contrib/nanodbc-cmake/CMakeLists.txt
@@ -1,3 +1,7 @@
+if (NOT USE_INTERNAL_NANODBC_LIBRARY)
+    return ()
+endif ()
+
 set (LIBRARY_DIR ${ClickHouse_SOURCE_DIR}/contrib/nanodbc)
 
 if (NOT TARGET unixodbc)

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -33,8 +33,12 @@ option (ENABLE_CLICKHOUSE_OBFUSCATOR "Table data obfuscator (convert real data t
     ${ENABLE_CLICKHOUSE_ALL})
 
 # https://clickhouse.tech/docs/en/operations/utilities/odbc-bridge/
-option (ENABLE_CLICKHOUSE_ODBC_BRIDGE "HTTP-server working like a proxy to ODBC driver"
-    ${ENABLE_CLICKHOUSE_ALL})
+if (ENABLE_ODBC)
+    option (ENABLE_CLICKHOUSE_ODBC_BRIDGE "HTTP-server working like a proxy to ODBC driver"
+        ${ENABLE_CLICKHOUSE_ALL})
+else ()
+    option (ENABLE_CLICKHOUSE_ODBC_BRIDGE "HTTP-server working like a proxy to ODBC driver" OFF)
+endif ()
 
 option (ENABLE_CLICKHOUSE_LIBRARY_BRIDGE "HTTP-server working like a proxy to Library dictionary source"
     ${ENABLE_CLICKHOUSE_ALL})


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Not for changelog

Changelog entry:
- None

Detailed description:
- Fix compilation of configurations where ODBC is disabled
- Use nanodbc always together with ODBC
- Disable `clickhouse-odbc-bridge` building when ODBC is disabled

TODO for future PRs: ODBC cmake/c++ code needs to be reviewed and cleaned up, support for iODBC (instead of UnixODBC) needs to be added for macOS builds by default 