### PR TITLE
Keep default timezone on DateTime operations if it was not provided explicitly #4854

### DIFF
--- a/src/DataTypes/DataTypeDateTime.h
+++ b/src/DataTypes/DataTypeDateTime.h
@@ -19,9 +19,12 @@ public:
     TimezoneMixin(const TimezoneMixin &) = default;
 
     const DateLUTImpl & getTimeZone() const { return time_zone; }
+    bool hasExplicitTimeZone() const { return has_explicit_time_zone; }
 
 protected:
+    /// true if time zone name was provided in data type parameters, false if it's using default time zone.
     bool has_explicit_time_zone;
+
     const DateLUTImpl & time_zone;
     const DateLUTImpl & utc_time_zone;
 };

--- a/src/Functions/FunctionCustomWeekToSomething.h
+++ b/src/Functions/FunctionCustomWeekToSomething.h
@@ -5,7 +5,6 @@
 #include <Functions/CustomWeekTransforms.h>
 #include <Functions/IFunctionImpl.h>
 #include <Functions/TransformDateTime64.h>
-#include <Functions/extractTimeZoneFromFunctionArguments.h>
 #include <IO/WriteHelpers.h>
 
 

--- a/src/Functions/extractTimeZoneFromFunctionArguments.cpp
+++ b/src/Functions/extractTimeZoneFromFunctionArguments.cpp
@@ -44,9 +44,9 @@ std::string extractTimeZoneNameFromFunctionArguments(const ColumnsWithTypeAndNam
 
         /// If time zone is attached to an argument of type DateTime.
         if (const auto * type = checkAndGetDataType<DataTypeDateTime>(arguments[datetime_arg_num].type.get()))
-            return type->getTimeZone().getTimeZone();
+            return type->hasExplicitTimeZone() ? type->getTimeZone().getTimeZone() : std::string();
         if (const auto * type = checkAndGetDataType<DataTypeDateTime64>(arguments[datetime_arg_num].type.get()))
-            return type->getTimeZone().getTimeZone();
+            return type->hasExplicitTimeZone() ? type->getTimeZone().getTimeZone() : std::string();
 
         return {};
     }

--- a/src/Functions/extractTimeZoneFromFunctionArguments.h
+++ b/src/Functions/extractTimeZoneFromFunctionArguments.h
@@ -13,6 +13,7 @@ namespace DB
 class Block;
 
 /// Determine working timezone either from optional argument with time zone name or from time zone in DateTime type of argument.
+/// Returns empty string if default time zone should be used.
 std::string extractTimeZoneNameFromFunctionArguments(
     const ColumnsWithTypeAndName & arguments, size_t time_zone_arg_num, size_t datetime_arg_num);
 

--- a/tests/queries/0_stateless/01836_date_time_keep_default_timezone_on_operations_den_crane.reference
+++ b/tests/queries/0_stateless/01836_date_time_keep_default_timezone_on_operations_den_crane.reference
@@ -1,0 +1,6 @@
+DateTime
+DateTime
+DateTime(\'UTC\')
+DateTime64(3)
+DateTime64(3)
+DateTime64(3, \'UTC\')

--- a/tests/queries/0_stateless/01836_date_time_keep_default_timezone_on_operations_den_crane.sql
+++ b/tests/queries/0_stateless/01836_date_time_keep_default_timezone_on_operations_den_crane.sql
@@ -1,0 +1,26 @@
+SELECT toTypeName(now());
+SELECT toTypeName(now() - 1);
+SELECT toTypeName(now('UTC') - 1);
+
+SELECT toTypeName(now64(3));
+SELECT toTypeName(now64(3) - 1);
+SELECT toTypeName(toTimeZone(now64(3), 'UTC') - 1);
+
+DROP TABLE IF EXISTS tt_null;
+DROP TABLE IF EXISTS tt;
+DROP TABLE IF EXISTS tt_mv;
+
+create table tt_null(p String) engine = Null;
+
+create table tt(p String,tmin AggregateFunction(min, DateTime)) 
+engine = AggregatingMergeTree  order by p;
+
+create materialized view tt_mv to tt as 
+select p, minState(now() - interval 30 minute) as tmin
+from tt_null group by p;
+
+insert into tt_null values('x');
+
+DROP TABLE tt_null;
+DROP TABLE tt;
+DROP TABLE tt_mv;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Keep default timezone on DateTime operations if it was not provided explicitly. For example, if you add one second to a value of `DateTime` type without timezone it will remain `DateTime` without timezone. In previous versions the value of default timezone was placed to the returned data type explicitly so it becomes DateTime('something'). This closes #4854.
