### PR TITLE
Fix `Cannot unlink file` in `dropIfEmpty()` with multidisk confuguration

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1391,12 +1391,19 @@ void MergeTreeData::dropIfEmpty()
     if (!data_parts_by_info.empty())
         return;
 
-    for (const auto & [path, disk] : getRelativeDataPathsWithDisks())
+    try
     {
-        /// Non recursive, exception is thrown if there are more files.
-        disk->removeFile(path + MergeTreeData::FORMAT_VERSION_FILE_NAME);
-        disk->removeDirectory(path + MergeTreeData::DETACHED_DIR_NAME);
-        disk->removeDirectory(path);
+        for (const auto & [path, disk] : getRelativeDataPathsWithDisks())
+        {
+            /// Non recursive, exception is thrown if there are more files.
+            disk->removeFileIfExists(path + MergeTreeData::FORMAT_VERSION_FILE_NAME);
+            disk->removeDirectory(path + MergeTreeData::DETACHED_DIR_NAME);
+            disk->removeDirectory(path);
+        }
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
     }
 }
 

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1403,6 +1403,7 @@ void MergeTreeData::dropIfEmpty()
     }
     catch (...)
     {
+        // On unsuccessful creation of ReplicatedMergeTree table with multidisk configuration some files may not exist.
         tryLogCurrentException(__PRETTY_FUNCTION__);
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed `Cannot unlink file` error on unsuccessful creation of ReplicatedMergeTree table with multidisk 
configuration. This closes #21755.