### PR TITLE
System dictionaries virtual key column

### DIFF
--- a/src/Storages/System/IStorageSystemOneBlock.h
+++ b/src/Storages/System/IStorageSystemOneBlock.h
@@ -12,7 +12,16 @@ namespace DB
 class Context;
 
 
-/** Base class for system tables whose all columns have String type.
+/** IStorageSystemOneBlock is base class for system tables whose all columns can be synchronously fetched.
+  *
+  * Client class need to provide static method static NamesAndTypesList getNamesAndTypes() that will return list of column names and
+  * their types. IStorageSystemOneBlock during read will create result columns in same order as result of getNamesAndTypes
+  * and pass it with fillData method.
+  *
+  * Client also must override fillData and fill result columns.
+  *
+  * If subclass want to support virtual columns, it should override getVirtuals method of IStorage interface.
+  * IStorageSystemOneBlock will add virtuals columns at the end of result columns of fillData method.
   */
 template <typename Self>
 class IStorageSystemOneBlock : public IStorage
@@ -41,9 +50,10 @@ public:
         size_t /*max_block_size*/,
         unsigned /*num_streams*/) override
     {
-        metadata_snapshot->check(column_names, getVirtuals(), getStorageID());
+        auto virtuals_names_and_types = getVirtuals();
+        metadata_snapshot->check(column_names, virtuals_names_and_types, getStorageID());
 
-        Block sample_block = metadata_snapshot->getSampleBlock();
+        Block sample_block = metadata_snapshot->getSampleBlockWithVirtuals(virtuals_names_and_types);
         MutableColumns res_columns = sample_block.cloneEmptyColumns();
         fillData(res_columns, context, query_info);
 

--- a/src/Storages/System/StorageSystemDictionaries.cpp
+++ b/src/Storages/System/StorageSystemDictionaries.cpp
@@ -50,6 +50,13 @@ NamesAndTypesList StorageSystemDictionaries::getNamesAndTypes()
     };
 }
 
+NamesAndTypesList StorageSystemDictionaries::getVirtuals() const
+{
+    return {
+        {"key", std::make_shared<DataTypeString>()}
+    };
+}
+
 void StorageSystemDictionaries::fillData(MutableColumns & res_columns, ContextPtr context, const SelectQueryInfo & /*query_info*/) const
 {
     const auto access = context->getAccess();
@@ -128,6 +135,9 @@ void StorageSystemDictionaries::fillData(MutableColumns & res_columns, ContextPt
         else
             res_columns[i++]->insertDefault();
 
+        /// Start fill virtual columns
+
+        res_columns[i++]->insert(dictionary_structure.getKeyDescription());
     }
 }
 

--- a/src/Storages/System/StorageSystemDictionaries.h
+++ b/src/Storages/System/StorageSystemDictionaries.h
@@ -18,6 +18,8 @@ public:
 
     static NamesAndTypesList getNamesAndTypes();
 
+    NamesAndTypesList getVirtuals() const override;
+
 protected:
     using IStorageSystemOneBlock::IStorageSystemOneBlock;
 

--- a/tests/queries/0_stateless/01838_system_dictionaries_virtual_key_column.reference
+++ b/tests/queries/0_stateless/01838_system_dictionaries_virtual_key_column.reference
@@ -1,0 +1,4 @@
+simple key
+example_simple_key_dictionary	UInt64
+complex key
+example_complex_key_dictionary	(UInt64, String)

--- a/tests/queries/0_stateless/01838_system_dictionaries_virtual_key_column.sql
+++ b/tests/queries/0_stateless/01838_system_dictionaries_virtual_key_column.sql
@@ -1,0 +1,26 @@
+DROP DICTIONARY IF EXISTS example_simple_key_dictionary;
+CREATE DICTIONARY example_simple_key_dictionary (
+    id UInt64,
+    value UInt64
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(HOST 'localhost' PORT tcpPort() USER 'default' TABLE '' DATABASE currentDatabase()))
+LAYOUT(DIRECT());
+
+SELECT 'simple key';
+
+SELECT name, key FROM system.dictionaries WHERE name='example_simple_key_dictionary' AND database=currentDatabase();
+
+DROP DICTIONARY IF EXISTS example_complex_key_dictionary;
+CREATE DICTIONARY example_complex_key_dictionary (
+    id UInt64,
+    id_key String,
+    value UInt64
+)
+PRIMARY KEY id, id_key
+SOURCE(CLICKHOUSE(HOST 'localhost' PORT tcpPort() USER 'default' TABLE '' DATABASE currentDatabase()))
+LAYOUT(COMPLEX_KEY_DIRECT());
+
+SELECT 'complex key';
+
+SELECT name, key FROM system.dictionaries WHERE name='example_complex_key_dictionary' AND database=currentDatabase();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Added virtual `key` column in `system.dictionaries` to support backward compatibility. Closes #23435.
