### PR TITLE
Better S3 read retries, added sleeps before next attempts

### DIFF
--- a/docs/en/engines/table-engines/integrations/s3.md
+++ b/docs/en/engines/table-engines/integrations/s3.md
@@ -130,6 +130,7 @@ The following settings can be set before query execution or placed into configur
 -   `s3_max_single_part_upload_size` — The maximum size of object to upload using singlepart upload to S3. Default value is `64Mb`.
 -   `s3_min_upload_part_size` — The minimum size of part to upload during multipart upload to [S3 Multipart upload](https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html). Default value is `512Mb`.
 -   `s3_max_redirects` — Max number of S3 redirects hops allowed. Default value is `10`.
+-   `s3_single_read_retry_attempts` — The maximum number of attempts during single read. Default value is `4`.
 
 Security consideration: if malicious user can specify arbitrary S3 URLs, `s3_max_redirects` must be set to zero to avoid [SSRF](https://en.wikipedia.org/wiki/Server-side_request_forgery) attacks; or alternatively, `remote_host_filter` must be specified in server configuration.
 
@@ -144,6 +145,7 @@ The following settings can be specified in configuration file for given endpoint
 -   `use_insecure_imds_request` — If set to `true`, S3 client will use insecure IMDS request while obtaining credentials from Amazon EC2 metadata. Optional, default value is `false`.
 -   `header` —  Adds specified HTTP header to a request to given endpoint. Optional, can be speficied multiple times.
 -   `server_side_encryption_customer_key_base64` — If specified, required headers for accessing S3 objects with SSE-C encryption will be set. Optional.
+-   `single_read_retry_attempts` — The maximum number of attempts during single read. Default value is `4`. Optional.
 
 **Example:**
 
@@ -158,6 +160,7 @@ The following settings can be specified in configuration file for given endpoint
         <!-- <use_insecure_imds_request>false</use_insecure_imds_request> -->
         <!-- <header>Authorization: Bearer SOME-TOKEN</header> -->
         <!-- <server_side_encryption_customer_key_base64>BASE64-ENCODED-KEY</server_side_encryption_customer_key_base64> -->
+        <!-- <single_read_retry_attempts>4</single_read_retry_attempts> -->
     </endpoint-name>
 </s3>
 ```

--- a/docs/en/engines/table-engines/mergetree-family/mergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/mergetree.md
@@ -748,6 +748,7 @@ Configuration markup:
             <connect_timeout_ms>10000</connect_timeout_ms>
             <request_timeout_ms>5000</request_timeout_ms>
             <retry_attempts>10</retry_attempts>
+            <single_read_retry_attempts>4</single_read_retry_attempts>
             <min_bytes_for_seek>1000</min_bytes_for_seek>
             <metadata_path>/var/lib/clickhouse/disks/s3/</metadata_path>
             <cache_enabled>true</cache_enabled>
@@ -772,6 +773,7 @@ Optional parameters:
 -   `connect_timeout_ms` — Socket connect timeout in milliseconds. Default value is `10 seconds`. 
 -   `request_timeout_ms` — Request timeout in milliseconds. Default value is `5 seconds`. 
 -   `retry_attempts` — Number of retry attempts in case of failed request. Default value is `10`. 
+-   `single_read_retry_attempts` — Number of retry attempts in case of connection drop during read. Default value is `4`. 
 -   `min_bytes_for_seek` — Minimal number of bytes to use seek operation instead of sequential read. Default value is `1 Mb`. 
 -   `metadata_path` — Path on local FS to store metadata files for S3. Default value is `/var/lib/clickhouse/disks/<disk_name>/`. 
 -   `cache_enabled` — Allows to cache mark and index files on local FS. Default value is `true`. 

--- a/docs/ru/engines/table-engines/integrations/s3.md
+++ b/docs/ru/engines/table-engines/integrations/s3.md
@@ -70,6 +70,7 @@ SELECT * FROM s3_engine_table LIMIT 2;
 -   `s3_max_single_part_upload_size` — максимальный размер объекта для загрузки с использованием однокомпонентной загрузки в S3. Значение по умолчанию — `64 Mб`. 
 -   `s3_min_upload_part_size` — минимальный размер объекта для загрузки при многокомпонентной загрузке в [S3 Multipart upload](https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html). Значение по умолчанию — `512 Mб`.
 -   `s3_max_redirects` — максимальное количество разрешенных переадресаций S3. Значение по умолчанию — `10`. 
+-   `s3_single_read_retry_attempts` — максимальное количество попыток запроса при единичном чтении. Значение по умолчанию — `4`.
 
 Соображение безопасности: если злонамеренный пользователь попробует указать произвольные URL-адреса S3, параметр `s3_max_redirects` должен быть установлен в ноль, чтобы избежать атак [SSRF] (https://en.wikipedia.org/wiki/Server-side_request_forgery). Как альтернатива, в конфигурации сервера должен быть указан `remote_host_filter`.
 
@@ -87,6 +88,7 @@ SELECT * FROM s3_engine_table LIMIT 2;
 -   `region` — название региона S3.
 -   `header` — добавляет указанный HTTP-заголовок к запросу на заданную точку приема запроса. Может быть определен несколько раз.
 -   `server_side_encryption_customer_key_base64` — устанавливает необходимые заголовки для доступа к объектам S3 с шифрованием SSE-C. 
+-   `single_read_retry_attempts` — Максимальное количество попыток запроса при единичном чтении. Значение по умолчанию — `4`.
 
 **Пример**
 
@@ -101,6 +103,7 @@ SELECT * FROM s3_engine_table LIMIT 2;
 		<!-- <use_insecure_imds_request>false</use_insecure_imds_request> -->
         <!-- <header>Authorization: Bearer SOME-TOKEN</header> -->
         <!-- <server_side_encryption_customer_key_base64>BASE64-ENCODED-KEY</server_side_encryption_customer_key_base64> -->
+        <!-- <single_read_retry_attempts>4</single_read_retry_attempts> -->
     </endpoint-name>
 </s3>
 ```

--- a/docs/ru/engines/table-engines/mergetree-family/mergetree.md
+++ b/docs/ru/engines/table-engines/mergetree-family/mergetree.md
@@ -735,6 +735,7 @@ SETTINGS storage_policy = 'moving_from_ssd_to_hdd'
             <connect_timeout_ms>10000</connect_timeout_ms>
             <request_timeout_ms>5000</request_timeout_ms>
             <retry_attempts>10</retry_attempts>
+            <single_read_retry_attempts>4</single_read_retry_attempts>
             <min_bytes_for_seek>1000</min_bytes_for_seek>
             <metadata_path>/var/lib/clickhouse/disks/s3/</metadata_path>
             <cache_enabled>true</cache_enabled>
@@ -761,6 +762,7 @@ SETTINGS storage_policy = 'moving_from_ssd_to_hdd'
 -   `connect_timeout_ms` — таймаут подключения к сокету в миллисекундах. Значение по умолчанию: 10 секунд. 
 -   `request_timeout_ms` — таймаут выполнения запроса в миллисекундах. Значение по умолчанию: 5 секунд. 
 -   `retry_attempts` — число попыток выполнения запроса в случае возникновения ошибки. Значение по умолчанию: `10`. 
+-   `single_read_retry_attempts` — число попыток выполнения запроса в случае возникновения ошибки в процессе чтения. Значение по умолчанию: `4`.
 -   `min_bytes_for_seek` — минимальное количество байтов, которые используются для операций поиска вместо последовательного чтения. Значение по умолчанию: 1 МБайт. 
 -   `metadata_path` — путь к локальному файловому хранилищу для хранения файлов с метаданными для S3. Значение по умолчанию: `/var/lib/clickhouse/disks/<disk_name>/`. 
 -   `cache_enabled` — признак, разрешено ли хранение кэша засечек и файлов индекса в локальной файловой системе. Значение по умолчанию: `true`. 

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -70,7 +70,7 @@ class IColumn;
     M(UInt64, connections_with_failover_max_tries, DBMS_CONNECTION_POOL_WITH_FAILOVER_DEFAULT_MAX_TRIES, "The maximum number of attempts to connect to replicas.", 0) \
     M(UInt64, s3_min_upload_part_size, 512*1024*1024, "The minimum size of part to upload during multipart upload to S3.", 0) \
     M(UInt64, s3_max_single_part_upload_size, 64*1024*1024, "The maximum size of object to upload using singlepart upload to S3.", 0) \
-    M(UInt64, s3_max_single_read_retries, 4, "The maximum number of retries during single S3 read.", 0) \
+    M(UInt64, s3_single_read_retry_attempts, 4, "The maximum number of retries during single S3 read.", 0) \
     M(UInt64, s3_max_redirects, 10, "Max number of S3 redirects hops allowed.", 0) \
     M(UInt64, s3_max_connections, 1024, "The maximum number of connections per server.", 0) \
     M(Bool, extremes, false, "Calculate minimums and maximums of the result columns. They can be output in JSON-formats.", IMPORTANT) \

--- a/src/Disks/S3/DiskS3.cpp
+++ b/src/Disks/S3/DiskS3.cpp
@@ -133,7 +133,7 @@ public:
 
     std::unique_ptr<ReadBufferFromS3> createReadBuffer(const String & path) override
     {
-        return std::make_unique<ReadBufferFromS3>(client_ptr, bucket, metadata.remote_fs_root_path + path, s3_max_single_read_retries, buf_size);
+        return std::make_unique<ReadBufferFromS3>(client_ptr, bucket, metadata.remote_fs_root_path + path, single_read_retry_strategy, buf_size);
     }
 
 private:

--- a/src/Disks/S3/DiskS3.h
+++ b/src/Disks/S3/DiskS3.h
@@ -22,7 +22,7 @@ struct DiskS3Settings
 {
     DiskS3Settings(
         const std::shared_ptr<Aws::S3::S3Client> & client_,
-        size_t s3_max_single_read_retries_,
+        std::shared_ptr<Aws::Client::RetryStrategy> single_read_retry_strategy_,
         size_t s3_min_upload_part_size_,
         size_t s3_max_single_part_upload_size_,
         size_t min_bytes_for_seek_,
@@ -32,7 +32,7 @@ struct DiskS3Settings
         int objects_chunk_size_to_delete_);
 
     std::shared_ptr<Aws::S3::S3Client> client;
-    size_t s3_max_single_read_retries;
+    std::shared_ptr<Aws::Client::RetryStrategy> single_read_retry_strategy;
     size_t s3_min_upload_part_size;
     size_t s3_max_single_part_upload_size;
     size_t min_bytes_for_seek;

--- a/src/Disks/S3/registerDiskS3.cpp
+++ b/src/Disks/S3/registerDiskS3.cpp
@@ -150,7 +150,7 @@ std::unique_ptr<DiskS3Settings> getSettings(const Poco::Util::AbstractConfigurat
 {
     return std::make_unique<DiskS3Settings>(
         getClient(config, config_prefix, context),
-        config.getUInt64(config_prefix + ".s3_max_single_read_retries", context->getSettingsRef().s3_max_single_read_retries),
+        std::make_shared<Aws::Client::DefaultRetryStrategy>(config.getUInt(config_prefix + ".single_read_retry_attempts", context->getSettingsRef().s3_single_read_retry_attempts)),
         config.getUInt64(config_prefix + ".s3_min_upload_part_size", context->getSettingsRef().s3_min_upload_part_size),
         config.getUInt64(config_prefix + ".s3_max_single_part_upload_size", context->getSettingsRef().s3_max_single_part_upload_size),
         config.getUInt64(config_prefix + ".min_bytes_for_seek", 1024 * 1024),

--- a/src/IO/ReadBufferFromS3.cpp
+++ b/src/IO/ReadBufferFromS3.cpp
@@ -72,7 +72,7 @@ bool ReadBufferFromS3::nextImpl()
 
             ProfileEvents::increment(ProfileEvents::S3ReadRequestsErrors, 1);
 
-            LOG_INFO(log, "Caught exception while reading S3 object. Bucket: {}, Key: {}, Offset: {}, Remaining attempts: {}, Message: {}",
+            LOG_INFO(log, "Caught exception while reading S3 object. Bucket: {}, Key: {}, Offset: {}, Attempt: {}, Message: {}",
                     bucket, key, getPosition(), attempt, e.message());
 
             impl.reset();

--- a/src/IO/ReadBufferFromS3.h
+++ b/src/IO/ReadBufferFromS3.h
@@ -15,6 +15,10 @@ namespace Aws::S3
 {
 class S3Client;
 }
+namespace Aws::Client
+{
+class RetryStrategy;
+}
 
 namespace DB
 {
@@ -27,7 +31,7 @@ private:
     std::shared_ptr<Aws::S3::S3Client> client_ptr;
     String bucket;
     String key;
-    UInt64 s3_max_single_read_retries;
+    std::shared_ptr<Aws::Client::RetryStrategy> retry_strategy;
     size_t buffer_size;
     off_t offset = 0;
     Aws::S3::Model::GetObjectResult read_result;
@@ -40,7 +44,7 @@ public:
         std::shared_ptr<Aws::S3::S3Client> client_ptr_,
         const String & bucket_,
         const String & key_,
-        UInt64 s3_max_single_read_retries_,
+        std::shared_ptr<Aws::Client::RetryStrategy> retry_strategy_,
         size_t buffer_size_ = DBMS_DEFAULT_BUFFER_SIZE);
 
     bool nextImpl() override;

--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -428,8 +428,6 @@ public:
                 /// EC2MetadataService throttles by delaying the response so the service client should set a large read timeout.
                 /// EC2MetadataService delay is in order of seconds so it only make sense to retry after a couple of seconds.
                 aws_client_configuration.connectTimeoutMs = 1000;
-
-                /// FIXME. Somehow this timeout does not work in docker without --net=host.
                 aws_client_configuration.requestTimeoutMs = 1000;
 
                 aws_client_configuration.retryStrategy = std::make_shared<Aws::Client::DefaultRetryStrategy>(1, 1000);

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -25,6 +25,7 @@
 #include <DataTypes/DataTypeString.h>
 
 #include <aws/core/auth/AWSCredentials.h>
+#include <aws/core/client/DefaultRetryStrategy.h>
 #include <aws/s3/S3Client.h>
 #include <aws/s3/model/ListObjectsV2Request.h>
 
@@ -169,7 +170,7 @@ StorageS3Source::StorageS3Source(
     ContextPtr context_,
     const ColumnsDescription & columns_,
     UInt64 max_block_size_,
-    UInt64 s3_max_single_read_retries_,
+    std::shared_ptr<Aws::Client::RetryStrategy> single_read_retry_strategy_,
     const String compression_hint_,
     const std::shared_ptr<Aws::S3::S3Client> & client_,
     const String & bucket_,
@@ -181,7 +182,7 @@ StorageS3Source::StorageS3Source(
     , format(format_)
     , columns_desc(columns_)
     , max_block_size(max_block_size_)
-    , s3_max_single_read_retries(s3_max_single_read_retries_)
+    , single_read_retry_strategy(std::move(single_read_retry_strategy_))
     , compression_hint(compression_hint_)
     , client(client_)
     , sample_block(sample_block_)
@@ -202,7 +203,7 @@ bool StorageS3Source::initialize()
     file_path = fs::path(bucket) / current_key;
 
     read_buf = wrapReadBufferWithCompressionMethod(
-        std::make_unique<ReadBufferFromS3>(client, bucket, current_key, s3_max_single_read_retries), chooseCompressionMethod(current_key, compression_hint));
+        std::make_unique<ReadBufferFromS3>(client, bucket, current_key, single_read_retry_strategy), chooseCompressionMethod(current_key, compression_hint));
     auto input_format = FormatFactory::instance().getInput(format, *read_buf, sample_block, getContext(), max_block_size);
     reader = std::make_shared<InputStreamFromInputFormat>(input_format);
 
@@ -326,7 +327,7 @@ StorageS3::StorageS3(
     const String & secret_access_key_,
     const StorageID & table_id_,
     const String & format_name_,
-    UInt64 s3_max_single_read_retries_,
+    std::shared_ptr<Aws::Client::RetryStrategy> single_read_retry_strategy_,
     UInt64 min_upload_part_size_,
     UInt64 max_single_part_upload_size_,
     UInt64 max_connections_,
@@ -339,7 +340,7 @@ StorageS3::StorageS3(
     : IStorage(table_id_)
     , client_auth{uri_, access_key_id_, secret_access_key_, max_connections_, {}, {}} /// Client and settings will be updated later
     , format_name(format_name_)
-    , s3_max_single_read_retries(s3_max_single_read_retries_)
+    , single_read_retry_strategy(std::move(single_read_retry_strategy_))
     , min_upload_part_size(min_upload_part_size_)
     , max_single_part_upload_size(max_single_part_upload_size_)
     , compression_method(compression_method_)
@@ -407,7 +408,7 @@ Pipe StorageS3::read(
             local_context,
             metadata_snapshot->getColumns(),
             max_block_size,
-            s3_max_single_read_retries,
+            single_read_retry_strategy,
             compression_method,
             client_auth.client,
             client_auth.uri.bucket,
@@ -494,7 +495,7 @@ void registerStorageS3Impl(const String & name, StorageFactory & factory)
             secret_access_key = engine_args[2]->as<ASTLiteral &>().value.safeGet<String>();
         }
 
-        UInt64 s3_max_single_read_retries = args.getLocalContext()->getSettingsRef().s3_max_single_read_retries;
+        auto single_read_retry_strategy = std::make_shared<Aws::Client::DefaultRetryStrategy>(args.getLocalContext()->getSettingsRef().s3_single_read_retry_attempts);
         UInt64 min_upload_part_size = args.getLocalContext()->getSettingsRef().s3_min_upload_part_size;
         UInt64 max_single_part_upload_size = args.getLocalContext()->getSettingsRef().s3_max_single_part_upload_size;
         UInt64 max_connections = args.getLocalContext()->getSettingsRef().s3_max_connections;
@@ -518,7 +519,7 @@ void registerStorageS3Impl(const String & name, StorageFactory & factory)
             secret_access_key,
             args.table_id,
             format_name,
-            s3_max_single_read_retries,
+            single_read_retry_strategy,
             min_upload_part_size,
             max_single_part_upload_size,
             max_connections,

--- a/src/Storages/StorageS3.h
+++ b/src/Storages/StorageS3.h
@@ -55,7 +55,7 @@ public:
         ContextPtr context_,
         const ColumnsDescription & columns_,
         UInt64 max_block_size_,
-        UInt64 s3_max_single_read_retries_,
+        std::shared_ptr<Aws::Client::RetryStrategy> single_read_retry_strategy_,
         const String compression_hint_,
         const std::shared_ptr<Aws::S3::S3Client> & client_,
         const String & bucket,
@@ -72,7 +72,7 @@ private:
     String format;
     ColumnsDescription columns_desc;
     UInt64 max_block_size;
-    UInt64 s3_max_single_read_retries;
+    std::shared_ptr<Aws::Client::RetryStrategy> single_read_retry_strategy;
     String compression_hint;
     std::shared_ptr<Aws::S3::S3Client> client;
     Block sample_block;
@@ -103,7 +103,7 @@ public:
         const String & secret_access_key,
         const StorageID & table_id_,
         const String & format_name_,
-        UInt64 s3_max_single_read_retries_,
+        std::shared_ptr<Aws::Client::RetryStrategy> single_read_retry_strategy_,
         UInt64 min_upload_part_size_,
         UInt64 max_single_part_upload_size_,
         UInt64 max_connections_,
@@ -150,7 +150,7 @@ private:
     ClientAuthentificaiton client_auth;
 
     String format_name;
-    UInt64 s3_max_single_read_retries;
+    std::shared_ptr<Aws::Client::RetryStrategy> single_read_retry_strategy;
     size_t min_upload_part_size;
     size_t max_single_part_upload_size;
     String compression_method;

--- a/src/TableFunctions/TableFunctionS3.cpp
+++ b/src/TableFunctions/TableFunctionS3.cpp
@@ -12,6 +12,9 @@
 #include <Parsers/ASTLiteral.h>
 #include "registerTableFunctions.h"
 
+#include <aws/core/client/DefaultRetryStrategy.h>
+
+
 namespace DB
 {
 
@@ -83,7 +86,7 @@ StoragePtr TableFunctionS3::executeImpl(const ASTPtr & /*ast_function*/, Context
 {
     Poco::URI uri (filename);
     S3::URI s3_uri (uri);
-    UInt64 s3_max_single_read_retries = context->getSettingsRef().s3_max_single_read_retries;
+    auto single_read_retry_strategy = std::make_shared<Aws::Client::DefaultRetryStrategy>(context->getSettingsRef().s3_single_read_retry_attempts);
     UInt64 min_upload_part_size = context->getSettingsRef().s3_min_upload_part_size;
     UInt64 max_single_part_upload_size = context->getSettingsRef().s3_max_single_part_upload_size;
     UInt64 max_connections = context->getSettingsRef().s3_max_connections;
@@ -94,7 +97,7 @@ StoragePtr TableFunctionS3::executeImpl(const ASTPtr & /*ast_function*/, Context
         secret_access_key,
         StorageID(getDatabaseName(), table_name),
         format,
-        s3_max_single_read_retries,
+        single_read_retry_strategy,
         min_upload_part_size,
         max_single_part_upload_size,
         max_connections,

--- a/src/TableFunctions/TableFunctionS3Cluster.cpp
+++ b/src/TableFunctions/TableFunctionS3Cluster.cpp
@@ -28,6 +28,9 @@
 #include <memory>
 #include <thread>
 
+#include <aws/core/client/DefaultRetryStrategy.h>
+
+
 namespace DB
 {
 
@@ -109,7 +112,7 @@ StoragePtr TableFunctionS3Cluster::executeImpl(
         Poco::URI uri (filename);
         S3::URI s3_uri (uri);
         /// Actually this parameters are not used
-        UInt64 s3_max_single_read_retries = context->getSettingsRef().s3_max_single_read_retries;
+        auto s3_max_single_read_retry_strategy = std::make_shared<Aws::Client::DefaultRetryStrategy>(context->getSettingsRef().s3_single_read_retry_attempts);
         UInt64 min_upload_part_size = context->getSettingsRef().s3_min_upload_part_size;
         UInt64 max_single_part_upload_size = context->getSettingsRef().s3_max_single_part_upload_size;
         UInt64 max_connections = context->getSettingsRef().s3_max_connections;
@@ -119,7 +122,7 @@ StoragePtr TableFunctionS3Cluster::executeImpl(
             secret_access_key,
             StorageID(getDatabaseName(), table_name),
             format,
-            s3_max_single_read_retries,
+            s3_max_single_read_retry_strategy,
             min_upload_part_size,
             max_single_part_upload_size,
             max_connections,

--- a/src/TableFunctions/TableFunctionS3Cluster.cpp
+++ b/src/TableFunctions/TableFunctionS3Cluster.cpp
@@ -112,7 +112,7 @@ StoragePtr TableFunctionS3Cluster::executeImpl(
         Poco::URI uri (filename);
         S3::URI s3_uri (uri);
         /// Actually this parameters are not used
-        auto s3_max_single_read_retry_strategy = std::make_shared<Aws::Client::DefaultRetryStrategy>(context->getSettingsRef().s3_single_read_retry_attempts);
+        auto single_read_retry_strategy = std::make_shared<Aws::Client::DefaultRetryStrategy>(context->getSettingsRef().s3_single_read_retry_attempts);
         UInt64 min_upload_part_size = context->getSettingsRef().s3_min_upload_part_size;
         UInt64 max_single_part_upload_size = context->getSettingsRef().s3_max_single_part_upload_size;
         UInt64 max_connections = context->getSettingsRef().s3_max_connections;
@@ -122,7 +122,7 @@ StoragePtr TableFunctionS3Cluster::executeImpl(
             secret_access_key,
             StorageID(getDatabaseName(), table_name),
             format,
-            s3_max_single_read_retry_strategy,
+            single_read_retry_strategy,
             min_upload_part_size,
             max_single_part_upload_size,
             max_connections,

--- a/tests/integration/test_storage_s3/s3_mocks/unstable_server.py
+++ b/tests/integration/test_storage_s3/s3_mocks/unstable_server.py
@@ -40,7 +40,7 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
             self.end_bytes = len(lines)
             self.size = self.end_bytes
             self.send_block_size = 256
-            self.stop_at = random.randint(900000, 1200000) // self.send_block_size # Block size is 1024**2.
+            self.stop_at = random.randint(900000, 1300000) // self.send_block_size # Block size is 1024**2.
 
             if "Range" in self.headers:
                 cr = self.headers["Range"]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Added sleep with backoff between read retries from S3.

Addressing #22988 