### PR TITLE
export trace log from stateless tests in flamegraph-friendly format

### DIFF
--- a/docker/test/stateless/run.sh
+++ b/docker/test/stateless/run.sh
@@ -114,7 +114,7 @@ clickhouse-client --allow_introspection_functions=1 -q "
 # Also export trace log in flamegraph-friendly format.
 for trace_type in CPU Memory Real
 do
-    clickhouse-client "
+    clickhouse-client -q "
             select
                 arrayStringConcat((arrayMap(x -> concat(splitByChar('/', addressToLine(x))[-1], '#', demangle(addressToSymbol(x)) ), trace)), ';') AS stack,
                 count(*) AS samples

--- a/docker/test/stateless/run.sh
+++ b/docker/test/stateless/run.sh
@@ -110,6 +110,23 @@ clickhouse-client --allow_introspection_functions=1 -q "
         arrayStringConcat(trace_array, '\n') AS trace_string
     SELECT * EXCEPT(trace), trace_string FROM system.trace_log FORMAT TSVWithNamesAndTypes
 " | pigz > /test_output/trace-log.tsv.gz &
+
+# Also export trace log in flamegraph-friendly format.
+for trace_type in CPU Memory Real
+do
+    clickhouse-client "
+            select
+                arrayStringConcat((arrayMap(x -> concat(splitByChar('/', addressToLine(x))[-1], '#', demangle(addressToSymbol(x)) ), trace)), ';') AS stack,
+                count(*) AS samples
+            from system.trace_log
+            where trace_type = '"$trace_type"'
+            group by trace
+            order by samples desc
+            settings allow_introspection_functions = 1
+            format TabSeparated" \
+        | pigz > "/test_output/trace-log-$trace_type-flamegraph.tsv.gz" &
+done
+
 wait ||:
 
 mv /var/log/clickhouse-server/stderr.log /test_output/ ||:

--- a/docker/test/stateless/run.sh
+++ b/docker/test/stateless/run.sh
@@ -119,7 +119,7 @@ do
                 arrayStringConcat((arrayMap(x -> concat(splitByChar('/', addressToLine(x))[-1], '#', demangle(addressToSymbol(x)) ), trace)), ';') AS stack,
                 count(*) AS samples
             from system.trace_log
-            where trace_type = '"$trace_type"'
+            where trace_type = '$trace_type'
             group by trace
             order by samples desc
             settings allow_introspection_functions = 1


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)
