### PR TITLE
Remove unneeded code from CMakeLists

### DIFF
--- a/utils/config-processor/CMakeLists.txt
+++ b/utils/config-processor/CMakeLists.txt
@@ -1,4 +1,2 @@
 add_executable (config-processor config-processor.cpp)
 target_link_libraries(config-processor PRIVATE clickhouse_common_config)
-
-INSTALL(TARGETS config-processor RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT config-processor)

--- a/utils/corrector_utf8/CMakeLists.txt
+++ b/utils/corrector_utf8/CMakeLists.txt
@@ -1,6 +1,2 @@
 add_executable(corrector_utf8 corrector_utf8.cpp)
-
-# Link the executable to the library.
 target_link_libraries(corrector_utf8 PRIVATE clickhouse_common_io)
-
-install(TARGETS corrector_utf8 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT corrector_utf8)

--- a/utils/zookeeper-cli/CMakeLists.txt
+++ b/utils/zookeeper-cli/CMakeLists.txt
@@ -1,3 +1,2 @@
 add_executable(clickhouse-zookeeper-cli zookeeper-cli.cpp)
 target_link_libraries(clickhouse-zookeeper-cli PRIVATE clickhouse_common_zookeeper)
-INSTALL(TARGETS clickhouse-zookeeper-cli RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT clickhouse-utils)

--- a/utils/zookeeper-test/CMakeLists.txt
+++ b/utils/zookeeper-test/CMakeLists.txt
@@ -1,3 +1,2 @@
 add_executable(zk-test main.cpp)
 target_link_libraries(zk-test PRIVATE clickhouse_common_zookeeper)
-INSTALL(TARGETS zk-test RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT clickhouse-utils)


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Remove INSTALL declarations that was never used and can mislead people.