### PR TITLE
Remove garbage from CMakeLists (2)

### DIFF
--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -44,8 +44,4 @@ if (NOT DEFINED ENABLE_UTILS OR ENABLE_UTILS)
     endif ()
 endif ()
 
-if (ENABLE_CODE_QUALITY)
-    add_subdirectory (check-style)
-endif ()
-
 add_subdirectory (package)

--- a/utils/check-style/CMakeLists.txt
+++ b/utils/check-style/CMakeLists.txt
@@ -1,2 +1,0 @@
-add_test(NAME check-style COMMAND bash -c "${CMAKE_CURRENT_SOURCE_DIR}/check-style")
-add_test(NAME check-include COMMAND sh -c "env RUN_DIR=${CMAKE_CURRENT_SOURCE_DIR} ROOT_DIR=${ClickHouse_SOURCE_DIR} BUILD_DIR=${ClickHouse_BINARY_DIR} CXX=${CMAKE_CXX_COMPILER} "${CMAKE_CURRENT_SOURCE_DIR}/check-include-stat"")


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)
