### PR TITLE
Skip CatBoost tests under MSan

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -1036,13 +1036,13 @@ class ClickHouseInstance:
         return "-fsanitize={}".format(sanitizer_name) in build_opts
 
     def is_built_with_thread_sanitizer(self):
-        return is_built_with_sanitizer('thread')
+        return self.is_built_with_sanitizer('thread')
 
     def is_built_with_address_sanitizer(self):
-        return is_built_with_sanitizer('address')
+        return self.is_built_with_sanitizer('address')
 
     def is_built_with_memory_sanitizer(self):
-        return is_built_with_sanitizer('memory')
+        return self.is_built_with_sanitizer('memory')
 
     # Connects to the instance via clickhouse-client, sends a query (1st argument) and returns the answer
     def query(self, sql, stdin=None, timeout=None, settings=None, user=None, password=None, database=None,

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -1031,13 +1031,18 @@ class ClickHouseInstance:
         self.ipv6_address = ipv6_address
         self.with_installed_binary = with_installed_binary
 
-    def is_built_with_thread_sanitizer(self):
+    def is_built_with_sanitizer(self, sanitizer_name=''):
         build_opts = self.query("SELECT value FROM system.build_options WHERE name = 'CXX_FLAGS'")
-        return "-fsanitize=thread" in build_opts
+        return "-fsanitize={}".format(sanitizer_name) in build_opts
+
+    def is_built_with_thread_sanitizer(self):
+        return is_built_with_sanitizer('thread')
 
     def is_built_with_address_sanitizer(self):
-        build_opts = self.query("SELECT value FROM system.build_options WHERE name = 'CXX_FLAGS'")
-        return "-fsanitize=address" in build_opts
+        return is_built_with_sanitizer('address')
+
+    def is_built_with_memory_sanitizer(self):
+        return is_built_with_sanitizer('memory')
 
     # Connects to the instance via clickhouse-client, sends a query (1st argument) and returns the answer
     def query(self, sql, stdin=None, timeout=None, settings=None, user=None, password=None, database=None,

--- a/tests/integration/test_catboost_model_config_reload/test.py
+++ b/tests/integration/test_catboost_model_config_reload/test.py
@@ -42,6 +42,9 @@ def change_config(model_config):
 
 
 def test(started_cluster):
+    if node.is_built_with_memory_sanitizer():
+        pytest.skip("Memory Sanitizer cannot work with third-party shared libraries")
+
     # Set config with the path to the first model.
     change_config("model_config.xml")
 

--- a/tests/integration/test_catboost_model_first_evaluate/test.py
+++ b/tests/integration/test_catboost_model_first_evaluate/test.py
@@ -32,5 +32,8 @@ def started_cluster():
 
 
 def test(started_cluster):
+    if node.is_built_with_memory_sanitizer():
+        pytest.skip("Memory Sanitizer cannot work with third-party shared libraries")
+
     node.query("select modelEvaluate('titanic', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);")
-    
+

--- a/tests/integration/test_catboost_model_reload/test.py
+++ b/tests/integration/test_catboost_model_reload/test.py
@@ -32,6 +32,9 @@ def started_cluster():
         cluster.shutdown()
 
 def test_model_reload(started_cluster):
+    if node.is_built_with_memory_sanitizer():
+        pytest.skip("Memory Sanitizer cannot work with third-party shared libraries")
+
     node.exec_in_container(["bash", "-c", "rm -f /etc/clickhouse-server/model/model.cbm"])
     node.exec_in_container(["bash", "-c", "ln /etc/clickhouse-server/model/conjunction.cbm /etc/clickhouse-server/model/model.cbm"])
     node.query("SYSTEM RELOAD MODEL model")
@@ -53,6 +56,9 @@ def test_model_reload(started_cluster):
     assert result == '1\n1\n1\n0\n'
 
 def test_models_reload(started_cluster):
+    if node.is_built_with_memory_sanitizer():
+        pytest.skip("Memory Sanitizer cannot work with third-party shared libraries")
+
     node.exec_in_container(["bash", "-c", "rm -f /etc/clickhouse-server/model/model.cbm"])
     node.exec_in_container(["bash", "-c", "ln /etc/clickhouse-server/model/conjunction.cbm /etc/clickhouse-server/model/model.cbm"])
     node.query("SYSTEM RELOAD MODELS")

--- a/tests/integration/test_send_crash_reports/test.py
+++ b/tests/integration/test_send_crash_reports/test.py
@@ -23,7 +23,7 @@ def started_node():
         cluster.shutdown()
 
 
-def test_send_segfault(started_node, ):
+def test_send_segfault(started_node):
     if started_node.is_built_with_thread_sanitizer():
         pytest.skip("doesn't fit in timeouts for stacktrace generation")
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


They cannot work for obvious reason (third-party prebuilt shared library).