### PR TITLE
Kerberized HDFS test is fluky - retries and extra output if failure

### DIFF
--- a/tests/integration/helpers/hdfs_api.py
+++ b/tests/integration/helpers/hdfs_api.py
@@ -157,15 +157,15 @@ class HDFSApi(object):
             self.kerberos_auth = reqkerb.HTTPKerberosAuth(mutual_authentication=reqkerb.DISABLED, hostname_override=self.host, principal=self.principal)
             # print(self.kerberos_auth)
 
-            response = self.req_wrapper(requests.put, 307,
-                                   url="{protocol}://{host}:{port}/webhdfs/v1{path}?op=CREATE".format(
-                                       protocol=self.protocol, host=self.host,
-                                       port=self.proxy_port,
-                                       path=path, user=self.user),
-                                   allow_redirects=False,
-                                   headers={'host': 'localhost'},
-                                   params={'overwrite' : 'true'},
-                                   verify=False, auth=self.kerberos_auth
+        response = self.req_wrapper(requests.put, 307,
+                                    url="{protocol}://{host}:{port}/webhdfs/v1{path}?op=CREATE".format(
+                                        protocol=self.protocol, host=self.host,
+                                        port=self.proxy_port,
+                                        path=path, user=self.user),
+                                    allow_redirects=False,
+                                    headers={'host': 'localhost'},
+                                    params={'overwrite' : 'true'},
+                                    verify=False, auth=self.kerberos_auth
             )
         additional_params = '&'.join(
             response.headers['Location'].split('&')[1:2] + ["user.name={}".format(self.user), "overwrite=true"])

--- a/tests/integration/helpers/hdfs_api.py
+++ b/tests/integration/helpers/hdfs_api.py
@@ -90,9 +90,8 @@ class HDFSApi(object):
         if kerberized:
             self._run_kinit()
             self.kerberos_auth = reqkerb.HTTPKerberosAuth(mutual_authentication=reqkerb.DISABLED, hostname_override=self.host, principal=self.principal)
-                #principal=self.principal,
-                #hostname_override=self.host, principal=self.principal)
-                # , mutual_authentication=reqkerb.REQUIRED, force_preemptive=True)
+            if self.kerberos_auth is None:
+                print("failed to obtain kerberos_auth")
         else:
             self.kerberos_auth = None
 
@@ -122,20 +121,24 @@ class HDFSApi(object):
 
         raise Exception("Kinit running failure")
 
-    def read_data(self, path, universal_newlines=True):
+    def req_wrapper(self, func, expected_code, cnt=2, **kwargs):
         with dns_hook(self):
-            response = requests.get("{protocol}://{host}:{port}/webhdfs/v1{path}?op=OPEN".format(protocol=self.protocol, host=self.host, port=self.proxy_port, path=path), headers={'host': 'localhost'}, allow_redirects=False, verify=False, auth=self.kerberos_auth)
-        if response.status_code != 307:
-            response.raise_for_status()
+            for i in range(0, cnt):
+                response_data = func(**kwargs)
+                if response_data.status_code == expected_code:
+                    return response_data
+                else:
+                    print("unexpected response_data.status_code {}", response_data.status_code)
+        response_data.raise_for_status()
+
+    def read_data(self, path, universal_newlines=True):
+        response = self.req_wrapper(requests.get, 307, url="{protocol}://{host}:{port}/webhdfs/v1{path}?op=OPEN".format(protocol=self.protocol, host=self.host, port=self.proxy_port, path=path), headers={'host': 'localhost'}, allow_redirects=False, verify=False, auth=self.kerberos_auth)
         # additional_params = '&'.join(response.headers['Location'].split('&')[1:2])
         url = "{location}".format(location=response.headers['Location'])
         # print("redirected to ", url)
-        with dns_hook(self):
-            response_data = requests.get(url,
-                                         headers={'host': 'localhost'},
-                                         verify=False, auth=self.kerberos_auth)
-        if response_data.status_code != 200:
-            response_data.raise_for_status()
+        response_data = self.req_wrapper(requests.get, 200, url=url,
+                                    headers={'host': 'localhost'},
+                                    verify=False, auth=self.kerberos_auth)
         if universal_newlines:
             return response_data.text
         else:
@@ -149,42 +152,36 @@ class HDFSApi(object):
         named_file.write(content)
         named_file.flush()
 
-
         if self.kerberized:
             self._run_kinit()
             self.kerberos_auth = reqkerb.HTTPKerberosAuth(mutual_authentication=reqkerb.DISABLED, hostname_override=self.host, principal=self.principal)
             # print(self.kerberos_auth)
 
-        with dns_hook(self):
-            response = requests.put(
-                "{protocol}://{host}:{port}/webhdfs/v1{path}?op=CREATE".format(protocol=self.protocol, host=self.host,
-                                                                               port=self.proxy_port,
-                                                                               path=path, user=self.user),
-                allow_redirects=False,
-                headers={'host': 'localhost'},
-                params={'overwrite' : 'true'},
-                verify=False, auth=self.kerberos_auth
+            response = self.req_wrapper(requests.put, 307,
+                                   url="{protocol}://{host}:{port}/webhdfs/v1{path}?op=CREATE".format(
+                                       protocol=self.protocol, host=self.host,
+                                       port=self.proxy_port,
+                                       path=path, user=self.user),
+                                   allow_redirects=False,
+                                   headers={'host': 'localhost'},
+                                   params={'overwrite' : 'true'},
+                                   verify=False, auth=self.kerberos_auth
             )
-        if response.status_code != 307:
-            # print(response.headers)
-            response.raise_for_status()
-
         additional_params = '&'.join(
             response.headers['Location'].split('&')[1:2] + ["user.name={}".format(self.user), "overwrite=true"])
 
-        with dns_hook(self), open(fpath, mode="rb") as fh:
+        with open(fpath, mode="rb") as fh:
             file_data = fh.read()
             protocol = "http" # self.protocol
-            response = requests.put(
-                "{location}".format(location=response.headers['Location']),
-                data=file_data,
-                headers={'content-type':'text/plain', 'host': 'localhost'},
-                params={'file': path, 'user.name' : self.user},
-                allow_redirects=False, verify=False, auth=self.kerberos_auth
+            response = self.req_wrapper(requests.put, 201,
+                                        url="{location}".format(
+                                            location=response.headers['Location']),
+                                        data=file_data,
+                                        headers={'content-type':'text/plain', 'host': 'localhost'},
+                                        params={'file': path, 'user.name' : self.user},
+                                        allow_redirects=False, verify=False, auth=self.kerberos_auth
             )
-            # print(response)
-            if response.status_code != 201:
-                response.raise_for_status()
+        # print(response)
 
 
     def write_gzip_data(self, path, content):


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog

Kerberized HDFS test is reportedly fluky.

Hadoop HTTP interface is used to verify ClickHouse operations.
Occasionally (failed to reproduce it locally) it returns "401 Client Error: Authentication required for url .."

