### PR TITLE
Preserve errors for INSERT into Distributed

### DIFF
--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -206,6 +206,13 @@ size_t ThreadPoolImpl<Thread>::active() const
 }
 
 template <typename Thread>
+bool ThreadPoolImpl<Thread>::finished() const
+{
+    std::unique_lock lock(mutex);
+    return shutdown;
+}
+
+template <typename Thread>
 void ThreadPoolImpl<Thread>::worker(typename std::list<Thread>::iterator thread_it)
 {
     DENY_ALLOCATIONS_IN_SCOPE;

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -67,6 +67,10 @@ public:
     /// Returns number of running and scheduled jobs.
     size_t active() const;
 
+    /// Returns true if the pool already terminated
+    /// (and any further scheduling will produce CANNOT_SCHEDULE_TASK exception)
+    bool finished() const;
+
     void setMaxThreads(size_t value);
     void setMaxFreeThreads(size_t value);
     void setQueueSize(size_t value);

--- a/src/Storages/Distributed/DistributedBlockOutputStream.cpp
+++ b/src/Storages/Distributed/DistributedBlockOutputStream.cpp
@@ -477,7 +477,9 @@ void DistributedBlockOutputStream::writeSuffix()
         LOG_DEBUG(log, "It took {} sec. to insert {} blocks, {} rows per second. {}", elapsed, inserted_blocks, inserted_rows / elapsed, getCurrentStateDescription());
     };
 
-    if (insert_sync && pool)
+    /// Pool finished means that some exception had been thrown before,
+    /// and scheduling new jobs will return "Cannot schedule a task" error.
+    if (insert_sync && pool && !pool->finished())
     {
         finished_jobs_count = 0;
         try

--- a/tests/config/config.d/clusters.xml
+++ b/tests/config/config.d/clusters.xml
@@ -15,18 +15,18 @@
                      <port>9000</port>
                  </replica>
              </shard>
-         </test_cluster_two_shards_different_databases>
-	    <test_cluster_one_shard_two_replicas>
-           <shard>
-               <replica>
-                   <host>127.0.0.1</host>
-                   <port>9000</port>
-               </replica>
-               <replica>
-                   <host>127.0.0.2</host>
-                   <port>9000</port>
-               </replica>
-           </shard>
+        </test_cluster_two_shards_different_databases>
+        <test_cluster_one_shard_two_replicas>
+             <shard>
+                 <replica>
+                     <host>127.0.0.1</host>
+                     <port>9000</port>
+                 </replica>
+                 <replica>
+                     <host>127.0.0.2</host>
+                     <port>9000</port>
+                 </replica>
+             </shard>
         </test_cluster_one_shard_two_replicas>
     </remote_servers>
 </yandex>

--- a/tests/config/config.d/clusters.xml
+++ b/tests/config/config.d/clusters.xml
@@ -28,5 +28,19 @@
                  </replica>
              </shard>
         </test_cluster_one_shard_two_replicas>
+        <test_cluster_two_replicas_different_databases>
+             <shard>
+                 <replica>
+                     <default_database>shard_0</default_database>
+                     <host>localhost</host>
+                     <port>9000</port>
+                 </replica>
+                 <replica>
+                     <default_database>shard_1</default_database>
+                     <host>localhost</host>
+                     <port>9000</port>
+                 </replica>
+             </shard>
+        </test_cluster_two_replicas_different_databases>
     </remote_servers>
 </yandex>

--- a/tests/queries/0_stateless/01850_dist_INSERT_preserve_error.sql
+++ b/tests/queries/0_stateless/01850_dist_INSERT_preserve_error.sql
@@ -1,0 +1,15 @@
+create database if not exists shard_0;
+create database if not exists shard_1;
+
+drop table if exists dist_01850;
+drop table if exists shard_0.data_01850;
+
+create table shard_0.data_01850 (key Int) engine=Memory();
+create table dist_01850 (key Int) engine=Distributed('test_cluster_two_replicas_different_databases', /* default_database= */ '', data_01850, key);
+
+set insert_distributed_sync=1;
+set prefer_localhost_replica=0;
+insert into dist_01850 values (1); -- { serverError 60 }
+
+drop table if exists dist_01850;
+drop table shard_0.data_01850;

--- a/tests/queries/0_stateless/arcadia_skip_list.txt
+++ b/tests/queries/0_stateless/arcadia_skip_list.txt
@@ -232,3 +232,4 @@
 01804_dictionary_decimal256_type
 01801_s3_distributed
 01833_test_collation_alvarotuso
+01850_dist_INSERT_preserve_error

--- a/tests/queries/skip_list.json
+++ b/tests/queries/skip_list.json
@@ -710,6 +710,7 @@
         "01780_clickhouse_dictionary_source_loop",
         "01785_dictionary_element_count",
         "01802_test_postgresql_protocol_with_row_policy", /// Creates database and users
-        "01804_dictionary_decimal256_type"
+        "01804_dictionary_decimal256_type",
+        "01850_dist_INSERT_preserve_error" // uses cluster with different static databases shard_0/shard_1
     ]
 }


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Avoid possible "Cannot schedule a task" error (in case some exception had been occurred) on INSERT into Distributed

Detailed description / Documentation draft:
Before this patch (and after #22208) the INSERT may fail with "Cannot
schedule a task" because the pool in DistributedBlockOutputStream
already throws exception and simply fail in writeSuffix().

*NOTE: that this is kind of minor issue so maybe it does not worth it marking as bugfix to avoid backports*