### PR TITLE
Fix crash when prewhere and row policy filter are both in effect with empty result

### DIFF
--- a/src/Storages/MergeTree/MergeTreeRangeReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeRangeReader.cpp
@@ -941,7 +941,10 @@ void MergeTreeRangeReader::executePrewhereActionsAndFilterColumns(ReadResult & r
 
             auto columns = block.getColumns();
             filterColumns(columns, row_level_filter);
-            block.setColumns(columns);
+            if (columns.empty())
+                block = block.cloneEmpty();
+            else
+                block.setColumns(columns);
         }
 
         prewhere_info->prewhere_actions->execute(block);

--- a/tests/queries/0_stateless/01851_fix_row_policy_empty_result.sql
+++ b/tests/queries/0_stateless/01851_fix_row_policy_empty_result.sql
@@ -1,0 +1,12 @@
+drop table if exists tbl;
+create table tbl (s String, i int) engine MergeTree order by i;
+
+insert into tbl values ('123', 123);
+
+drop row policy if exists filter on tbl;
+create row policy filter on tbl using (s = 'non_existing_domain') to all;
+
+select * from tbl prewhere s = '123' where i = 123;
+
+drop row policy filter on tbl;
+drop table tbl;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix crash when `PREWHERE` and row policy filter are both in effect with empty result.
