### PR TITLE
Workaround for PVS-Studio

### DIFF
--- a/base/common/types.h
+++ b/base/common/types.h
@@ -13,7 +13,12 @@ using char8_t = unsigned char;
 #endif
 
 /// This is needed for more strict aliasing. https://godbolt.org/z/xpJBSb https://stackoverflow.com/a/57453713
+#if !defined(PVS_STUDIO) /// But PVS-Studio does not treat it correctly.
 using UInt8 = char8_t;
+#else
+using UInt8 = uint8_t;
+#endif
+
 using UInt16 = uint16_t;
 using UInt32 = uint32_t;
 using UInt64 = uint64_t;

--- a/src/Common/formatIPv6.h
+++ b/src/Common/formatIPv6.h
@@ -85,19 +85,19 @@ inline bool parseIPv6(const char * src, unsigned char * dst)
             return clear_dst();
 
     unsigned char tmp[IPV6_BINARY_LENGTH]{};
-    auto * tp = tmp;
-    auto * endp = tp + IPV6_BINARY_LENGTH;
-    const auto * curtok = src;
-    auto saw_xdigit = false;
+    unsigned char * tp = tmp;
+    unsigned char * endp = tp + IPV6_BINARY_LENGTH;
+    const char * curtok = src;
+    bool saw_xdigit = false;
     UInt32 val{};
     unsigned char * colonp = nullptr;
 
     /// Assuming zero-terminated string.
-    while (const auto ch = *src++)
+    while (char ch = *src++)
     {
-        const auto num = unhex(ch);
+        UInt8 num = unhex(ch);
 
-        if (num != u8'\xff')
+        if (num != 0xFF)
         {
             val <<= 4;
             val |= num;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://clickhouse-test-reports.s3.yandex.net/23746/7b085abdb1bd2e7d946d0217a4e887f5cb284900/pvs_studio_report/pvs-studio-html-report/sources/BitHelpers.h_57.html#ln175