### PR TITLE
XDBCBridgeHelper use global context

### DIFF
--- a/src/Bridge/LibraryBridgeHelper.cpp
+++ b/src/Bridge/LibraryBridgeHelper.cpp
@@ -24,11 +24,11 @@ LibraryBridgeHelper::LibraryBridgeHelper(
         ContextPtr context_,
         const Block & sample_block_,
         const Field & dictionary_id_)
-    : IBridgeHelper(context_)
+    : IBridgeHelper(context_->getGlobalContext())
     , log(&Poco::Logger::get("LibraryBridgeHelper"))
     , sample_block(sample_block_)
     , config(context_->getConfigRef())
-    , http_timeout(context_->getSettingsRef().http_receive_timeout.value)
+    , http_timeout(context_->getGlobalContext()->getSettingsRef().http_receive_timeout.value)
     , dictionary_id(dictionary_id_)
 {
     bridge_port = config.getUInt("library_bridge.port", DEFAULT_PORT);

--- a/src/Bridge/XDBCBridgeHelper.h
+++ b/src/Bridge/XDBCBridgeHelper.h
@@ -62,19 +62,18 @@ public:
     static constexpr inline auto SCHEMA_ALLOWED_HANDLER = "/schema_allowed";
 
     XDBCBridgeHelper(
-        ContextPtr global_context_,
+        ContextPtr context_,
         Poco::Timespan http_timeout_,
         const std::string & connection_string_)
-    : IXDBCBridgeHelper(global_context_)
+    : IXDBCBridgeHelper(context_->getGlobalContext())
     , log(&Poco::Logger::get(BridgeHelperMixin::getName() + "BridgeHelper"))
     , connection_string(connection_string_)
     , http_timeout(http_timeout_)
-    , config(global_context_->getConfigRef())
+    , config(context_->getGlobalContext()->getConfigRef())
 {
     bridge_host = config.getString(BridgeHelperMixin::configPrefix() + ".host", DEFAULT_HOST);
     bridge_port = config.getUInt(BridgeHelperMixin::configPrefix() + ".port", DEFAULT_PORT);
 }
-
 
 protected:
     auto getConnectionString() const { return connection_string; }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)
