### PR TITLE
Better handling of HTTP errors in `PocoHTTPClient`

### DIFF
--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -293,7 +293,7 @@ void PocoHTTPClient::makeRequestInternal(
             { // API throttling
                 ProfileEvents::increment(select_metric(S3MetricType::Throttling));
             }
-            else
+            else if (status_code >= 300)
             {
                 ProfileEvents::increment(select_metric(S3MetricType::Errors));
             }

--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -289,29 +289,16 @@ void PocoHTTPClient::makeRequestInternal(
             }
             LOG_DEBUG(log, "Received headers: {}", headers_ss.str());
 
-            if (status_code >= 300)
-            {
-                String error_message;
-                Poco::StreamCopier::copyToString(response_body_stream, error_message);
-
-                if (Aws::Http::IsRetryableHttpResponseCode(response->GetResponseCode()))
-                    response->SetClientErrorType(Aws::Client::CoreErrors::NETWORK_CONNECTION);
-                else
-                    response->SetClientErrorType(Aws::Client::CoreErrors::USER_CANCELLED);
-
-                response->SetClientErrorMessage(error_message);
-
-                if (status_code == 429 || status_code == 503)
-                { // API throttling
-                    ProfileEvents::increment(select_metric(S3MetricType::Throttling));
-                }
-                else
-                {
-                    ProfileEvents::increment(select_metric(S3MetricType::Errors));
-                }
+            if (status_code == 429 || status_code == 503)
+            { // API throttling
+                ProfileEvents::increment(select_metric(S3MetricType::Throttling));
             }
             else
-                response->SetResponseBody(response_body_stream, session);
+            {
+                ProfileEvents::increment(select_metric(S3MetricType::Errors));
+            }
+
+            response->SetResponseBody(response_body_stream, session);
 
             return;
         }

--- a/tests/integration/test_merge_tree_s3_failover/s3_endpoint/endpoint.py
+++ b/tests/integration/test_merge_tree_s3_failover/s3_endpoint/endpoint.py
@@ -34,6 +34,7 @@ def server(_bucket, _path):
             cache['request_number'] = request_number
         else:
             response.status = 500
+            response.content_type = 'text/xml'
             return '<?xml version="1.0" encoding="UTF-8"?><Error><Code>ExpectedError</Code><Message>Expected Error</Message><RequestId>txfbd566d03042474888193-00608d7537</RequestId></Error>'
 
     response.set_header("Location", "http://minio1:9001/" + _bucket + '/' + _path)

--- a/tests/integration/test_merge_tree_s3_failover/s3_endpoint/endpoint.py
+++ b/tests/integration/test_merge_tree_s3_failover/s3_endpoint/endpoint.py
@@ -34,7 +34,7 @@ def server(_bucket, _path):
             cache['request_number'] = request_number
         else:
             response.status = 500
-            return 'Expected Error'
+            return '<?xml version="1.0" encoding="UTF-8"?><Error><Code>ExpectedError</Code><Message>Expected Error</Message><RequestId>txfbd566d03042474888193-00608d7537</RequestId></Error>'
 
     response.set_header("Location", "http://minio1:9001/" + _bucket + '/' + _path)
     response.status = 307

--- a/tests/integration/test_storage_s3/s3_mocks/mock_s3.py
+++ b/tests/integration/test_storage_s3/s3_mocks/mock_s3.py
@@ -15,7 +15,9 @@ def server(_bucket, _path):
     for name in request.headers:
         if name == 'Authorization' and request.headers[name] == 'Bearer TOKEN':
             return '1, 2, 3'
-    abort(403)
+    response.status = 403
+    response.content_type = 'text/xml'
+    return '<?xml version="1.0" encoding="UTF-8"?><Error><Code>ForbiddenError</Code><Message>Forbidden Error</Message><RequestId>txfbd566d03042474888193-00608d7537</RequestId></Error>'
 
 
 @route('/')

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -504,7 +504,7 @@ def test_custom_auth_headers_exclusion(cluster):
         print(result)
 
     assert ei.value.returncode == 243
-    assert '403 Forbidden' in ei.value.stderr
+    assert 'Forbidden Error' in ei.value.stderr
 
 
 def test_infinite_redirect(cluster):


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Better handling of HTTP errors in `PocoHTTPClient`. Response bodies of HTTP errors were being ignored earlier.

Fixes #23775