### PR TITLE
Fix typo in the comment

### DIFF
--- a/src/Common/MemoryStatisticsOS.h
+++ b/src/Common/MemoryStatisticsOS.h
@@ -6,7 +6,7 @@
 namespace DB
 {
 
-/** Opens a file /proc/self/mstat. Keeps it open and reads memory statistics via 'pread'.
+/** Opens a file /proc/self/statm. Keeps it open and reads memory statistics via 'pread'.
   * This is Linux specific.
   * See: man procfs
   *


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)

Detailed description / Documentation draft:
Fixed typo in the comment for "MemoryStatisticsOS" class.