### PR TITLE
Fix test_insert_into_distributed flaps

### DIFF
--- a/tests/integration/test_insert_into_distributed/test.py
+++ b/tests/integration/test_insert_into_distributed/test.py
@@ -198,28 +198,34 @@ def test_inserts_single_replica_local_internal_replication(started_cluster):
 
 
 def test_inserts_single_replica_internal_replication(started_cluster):
-    node1.query(
-        "INSERT INTO distributed_one_replica_internal_replication VALUES ('2000-01-01', 1)",
-        settings={
-            "insert_distributed_sync": "1",
-            "prefer_localhost_replica": "0",
-            # to make the test more deterministic
-            "load_balancing": "first_or_random",
-        },
-    )
-    assert node2.query("SELECT count(*) FROM single_replicated").strip() == '1'
-
-
-def test_inserts_single_replica_no_internal_replication(started_cluster):
-    with pytest.raises(QueryRuntimeException, match="Table default.single_replicated doesn't exist"):
+    try:
         node1.query(
-            "INSERT INTO distributed_one_replica_no_internal_replication VALUES ('2000-01-01', 1)",
+            "INSERT INTO distributed_one_replica_internal_replication VALUES ('2000-01-01', 1)",
             settings={
                 "insert_distributed_sync": "1",
                 "prefer_localhost_replica": "0",
+                # to make the test more deterministic
+                "load_balancing": "first_or_random",
             },
         )
-    assert node2.query("SELECT count(*) FROM single_replicated").strip() == '1'
+        assert node2.query("SELECT count(*) FROM single_replicated").strip() == '1'
+    finally:
+        node2.query("TRUNCATE TABLE single_replicated")
+
+
+def test_inserts_single_replica_no_internal_replication(started_cluster):
+    try:
+        with pytest.raises(QueryRuntimeException, match="Table default.single_replicated doesn't exist"):
+            node1.query(
+                "INSERT INTO distributed_one_replica_no_internal_replication VALUES ('2000-01-01', 1)",
+                settings={
+                    "insert_distributed_sync": "1",
+                    "prefer_localhost_replica": "0",
+                },
+            )
+        assert node2.query("SELECT count(*) FROM single_replicated").strip() == '1'
+    finally:
+        node2.query("TRUNCATE TABLE single_replicated")
 
 
 def test_prefer_localhost_replica(started_cluster):


### PR DESCRIPTION
In [1] the order of the tests was different:

    Running pytest container as: 'docker run --net=host  --rm --name clickhouse_integration_tests --privileged         --volume=/place/sandbox-data/tasks/7/4/962738347/clickhouse-odbc-bridge:/clickhouse-odbc-bridge --volume=/place/sandbox-data/tasks/7/4/962738347/clickhouse:/clickhouse         --volume=/place/sandbox-data/tasks/7/4/962738347/clickhouse-library-bridge:/clickhouse-library-bridge --volume=/place/sandbox-data/tasks/7/4/962738347/clickhouse:/clickhouse         --volume=/place/sandbox-data/tasks/7/4/962738347/ClickHouse/programs/server:/clickhouse-config --volume=/place/sandbox-data/tasks/7/4/962738347/ClickHouse/tests/integration:/ClickHouse/tests/integration         --volume=/place/sandbox-data/tasks/7/4/962738347/ClickHouse/src/Server/grpc_protos:/ClickHouse/src/Server/grpc_protos         --volume=clickhouse_integration_tests_volume:/var/lib/docker -e DOCKER_MYSQL_GOLANG_CLIENT_TAG=latest -e DOCKER_MYSQL_JAVA_CLIENT_TAG=latest -e DOCKER_MYSQL_JS_CLIENT_TAG=latest -e DOCKER_MYSQL_PHP_CLIENT_TAG=latest -e DOCKER_POSTGRESQL_JAVA_CLIENT_TAG=latest -e DOCKER_BASE_TAG=latest -e DOCKER_KERBEROS_KDC_TAG=latest -e PYTEST_OPTS='-ss test_insert_into_distributed/test.py::test_inserts_batching test_insert_into_distributed/test.py::test_inserts_local test_insert_into_distributed/test.py::test_inserts_low_cardinality test_insert_into_distributed/test.py::test_inserts_single_replica_internal_replication test_insert_into_distributed/test.py::test_inserts_single_replica_local_internal_replication test_insert_into_distributed/test.py::test_inserts_single_replica_no_internal_replication test_insert_into_distributed/test.py::test_prefer_localhost_replica test_insert_into_distributed/test.py::test_reconnect test_insert_into_distributed/test.py::test_table_function -rfEp --color=no --durations=0 ' yandex/clickhouse-integration-tests-runner:latest '.

  [1]: https://clickhouse-test-reports.s3.yandex.net/23874/80065b08f8182936ac57408bd84492d95f2322c1/integration_tests_(asan).html#fail1

So the table should be TRUNCATEd to avoid failures in this case.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @alexey-milovidov 