### PR TITLE
Fix S3 read error when using DiskS3

### DIFF
--- a/src/Disks/S3/DiskS3.cpp
+++ b/src/Disks/S3/DiskS3.cpp
@@ -355,7 +355,7 @@ private:
             current_buf = initialize();
 
         /// If current buffer has remaining data - use it.
-        if (current_buf && current_buf->next())
+        if (current_buf && current_buf->nextWithoutAssert())
         {
             working_buffer = current_buf->buffer();
             absolute_position += working_buffer.size();
@@ -369,7 +369,7 @@ private:
         ++current_buf_idx;
         const auto & path = metadata.s3_objects[current_buf_idx].first;
         current_buf = std::make_unique<ReadBufferFromS3>(client_ptr, bucket, metadata.s3_root_path + path, s3_max_single_read_retries, buf_size);
-        current_buf->next();
+        current_buf->nextWithoutAssert();
         working_buffer = current_buf->buffer();
         absolute_position += working_buffer.size();
 

--- a/src/IO/ReadBuffer.h
+++ b/src/IO/ReadBuffer.h
@@ -71,6 +71,15 @@ public:
         return res;
     }
 
+    bool nextWithoutAssert()
+    {
+        bool res = nextImplWithoutAssert();
+        if (!res)
+            working_buffer = Buffer(pos, pos);
+
+        return res;
+    }
+
 
     inline void nextIfAtEnd()
     {
@@ -209,6 +218,8 @@ private:
       * Throw an exception if something is wrong.
       */
     virtual bool nextImpl() { return false; }
+
+    virtual bool nextImplWithoutAssert() { return false; }
 
     [[noreturn]] static void throwReadAfterEOF()
     {

--- a/src/IO/ReadBufferFromIStream.cpp
+++ b/src/IO/ReadBufferFromIStream.cpp
@@ -31,6 +31,27 @@ bool ReadBufferFromIStream::nextImpl()
     return true;
 }
 
+bool ReadBufferFromIStream::nextImplWithoutAssert()
+{
+    istr.read(internal_buffer.begin(), internal_buffer.size());
+    size_t gcount = istr.gcount();
+
+    if (!gcount)
+    {
+        if (istr.eof())
+            return false;
+
+        if (istr.fail())
+            throw Exception("Cannot read from istream at offset " + std::to_string(count()), ErrorCodes::CANNOT_READ_FROM_ISTREAM);
+
+        throw Exception("Unexpected state of istream at offset " + std::to_string(count()), ErrorCodes::CANNOT_READ_FROM_ISTREAM);
+    }
+    else
+        working_buffer.resize(gcount);
+
+    return true;
+}
+
 ReadBufferFromIStream::ReadBufferFromIStream(std::istream & istr_, size_t size)
     : BufferWithOwnMemory<ReadBuffer>(size), istr(istr_)
 {

--- a/src/IO/ReadBufferFromIStream.h
+++ b/src/IO/ReadBufferFromIStream.h
@@ -16,6 +16,8 @@ private:
 
     bool nextImpl() override;
 
+    bool nextImplWithoutAssert() override;
+
 public:
     explicit ReadBufferFromIStream(std::istream & istr_, size_t size = DBMS_DEFAULT_BUFFER_SIZE);
 };

--- a/src/IO/ReadBufferFromS3.cpp
+++ b/src/IO/ReadBufferFromS3.cpp
@@ -122,9 +122,20 @@ std::unique_ptr<ReadBuffer> ReadBufferFromS3::initialize()
     Aws::S3::Model::GetObjectRequest req;
     req.SetBucket(bucket);
     req.SetKey(key);
+
     auto position = offset + already_read_bytes;
     if (position)
-        req.SetRange("bytes=" + std::to_string(position) + "-");
+		req.SetRange("bytes=" + std::to_string(position) + "-");
+
+    if (position != static_cast<size_t>(getPosition()))
+        LOG_TRACE(
+            log,
+            "DIFF: position:{}, getPosition():{}, already_read_bytes:{}, offset:{}, count():{}",
+            position,
+            getPosition(),
+            already_read_bytes,
+            offset,
+            count());
 
     Aws::S3::Model::GetObjectOutcome outcome = client_ptr->GetObject(req);
 

--- a/src/IO/ReadBufferFromS3.h
+++ b/src/IO/ReadBufferFromS3.h
@@ -47,6 +47,8 @@ public:
 
     bool nextImpl() override;
 
+    bool nextImplWithoutAssert() override;
+
     off_t seek(off_t off, int whence) override;
     off_t getPosition() override;
 

--- a/src/IO/ReadBufferFromS3.h
+++ b/src/IO/ReadBufferFromS3.h
@@ -35,6 +35,8 @@ private:
 
     Poco::Logger * log = &Poco::Logger::get("ReadBufferFromS3");
 
+    size_t already_read_bytes = 0;
+
 public:
     explicit ReadBufferFromS3(
         std::shared_ptr<Aws::S3::S3Client> client_ptr_,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Bug Fix



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix S3 read error when reinitialize HTTP connection.