### PR TITLE
Cleanup IDatabase.h from extra headers

### DIFF
--- a/src/Databases/IDatabase.h
+++ b/src/Databases/IDatabase.h
@@ -3,17 +3,16 @@
 #include <common/types.h>
 #include <Parsers/IAST_fwd.h>
 #include <Storages/IStorage_fwd.h>
-#include <Storages/StorageInMemoryMetadata.h>
-#include <Dictionaries/IDictionary.h>
-#include <Databases/DictionaryAttachInfo.h>
+#include <Interpreters/Context_fwd.h>
 #include <Common/Exception.h>
-
-#include <boost/range/adaptor/map.hpp>
-#include <boost/range/algorithm/copy.hpp>
+#include <Core/UUID.h>
 
 #include <ctime>
 #include <functional>
 #include <memory>
+#include <mutex>
+#include <vector>
+#include <map>
 
 
 namespace DB
@@ -22,6 +21,8 @@ namespace DB
 struct Settings;
 struct ConstraintsDescription;
 struct IndicesDescription;
+struct StorageInMemoryMetadata;
+struct StorageID;
 class ASTCreateQuery;
 using DictionariesWithID = std::vector<std::pair<String, UUID>>;
 

--- a/src/Databases/MySQL/DatabaseConnectionMySQL.h
+++ b/src/Databases/MySQL/DatabaseConnectionMySQL.h
@@ -6,6 +6,7 @@
 #include <mysqlxx/Pool.h>
 
 #include <Core/MultiEnum.h>
+#include <Core/NamesAndTypes.h>
 #include <Common/ThreadPool.h>
 #include <Databases/DatabasesCommon.h>
 #include <Databases/MySQL/ConnectionMySQLSettings.h>

--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -16,6 +16,7 @@
 #include <Common/renameat2.h>
 #include <Common/CurrentMetrics.h>
 #include <common/logger_useful.h>
+#include <Poco/Util/AbstractConfiguration.h>
 
 #if !defined(ARCADIA_BUILD)
 #    include "config_core.h"

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
@@ -23,6 +23,7 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/trim.hpp>
+#include <Poco/Util/AbstractConfiguration.h>
 #include <Common/Exception.h>
 #include <Common/Macros.h>
 #include <Common/config_version.h>

--- a/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
+++ b/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
@@ -16,6 +16,7 @@
 #include <Parsers/ASTCreateQuery.h>
 
 #include <IO/WriteBufferFromString.h>
+#include <IO/ReadBufferFromString.h>
 
 #include <Processors/Sources/SourceFromInputStream.h>
 #include <Processors/Pipe.h>

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -36,6 +36,7 @@
 #include <Processors/Formats/InputStreamFromInputFormat.h>
 #include <Processors/Pipe.h>
 
+#include <Poco/Util/AbstractConfiguration.h>
 
 namespace DB
 {


### PR DESCRIPTION
From IDatabase.h depends ~300 CU.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)