### PR TITLE
Check MIN/MAX attributes in the list of dictionary attributes

### DIFF
--- a/src/Dictionaries/getDictionaryConfigurationFromAST.cpp
+++ b/src/Dictionaries/getDictionaryConfigurationFromAST.cpp
@@ -161,6 +161,13 @@ void buildRangeConfiguration(AutoPtr<Document> doc, AutoPtr<Element> root, const
         root->appendChild(element);
     };
 
+    if (!all_attrs.count(range->min_attr_name))
+        throw Exception(ErrorCodes::INCORRECT_DICTIONARY_DEFINITION,
+            "MIN ({}) attribute is not defined in the dictionary attributes", range->min_attr_name);
+    if (!all_attrs.count(range->max_attr_name))
+        throw Exception(ErrorCodes::INCORRECT_DICTIONARY_DEFINITION,
+            "MAX ({}) attribute is not defined in the dictionary attributes", range->max_attr_name);
+
     append_element("range_min", range->min_attr_name, all_attrs.at(range->min_attr_name));
     append_element("range_max", range->max_attr_name, all_attrs.at(range->max_attr_name));
 }

--- a/tests/queries/0_stateless/01864_dictionary_range_hashed_min_max_attr.sql
+++ b/tests/queries/0_stateless/01864_dictionary_range_hashed_min_max_attr.sql
@@ -1,0 +1,11 @@
+DROP DICTIONARY IF EXISTS dict_01864;
+CREATE DICTIONARY dict_01864
+(
+    `id` UInt64,
+    `value` String
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(HOST 'localhost' PORT tcpPort() TABLE 'does_not_exists'))
+LIFETIME(MIN 0 MAX 1000)
+LAYOUT(RANGE_HASHED())
+RANGE(MIN first MAX last) -- { serverError 489 }


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Check MIN/MAX attributes in the list of dictionary attributes  (This way there will be proper exception instead of std::out_of_range)

Cc: @kitaisreal 