### PR TITLE
Use 0 over nan for hit_rate in case of 0 queries to the cache dictionary

### DIFF
--- a/src/Dictionaries/CacheDictionary.h
+++ b/src/Dictionaries/CacheDictionary.h
@@ -77,7 +77,10 @@ public:
 
     double getHitRate() const override
     {
-        return static_cast<double>(hit_count.load(std::memory_order_acquire)) / query_count.load(std::memory_order_relaxed);
+        size_t queries = query_count.load(std::memory_order_relaxed);
+        if (!queries)
+            return 0;
+        return static_cast<double>(hit_count.load(std::memory_order_acquire)) / queries;
     }
 
     bool supportUpdates() const override { return false; }


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @kitaisreal 