### PR TITLE
RFC: Add default setting value as implicit value for program options

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -94,15 +94,15 @@ void Settings::dumpToArrayColumns(IColumn * column_names_, IColumn * column_valu
 
 void Settings::addProgramOptions(boost::program_options::options_description & options)
 {
-    for (const auto & field : all())
+    for (const auto & setting : all())
     {
-        const std::string_view name = field.getName();
+        const std::string_view name = setting.getName();
         auto on_program_option
             = boost::function1<void, const std::string &>([this, name](const std::string & value) { set(name, value); });
         options.add(boost::shared_ptr<boost::program_options::option_description>(new boost::program_options::option_description(
             name.data(),
-            boost::program_options::value<std::string>()->composing()->notifier(on_program_option),
-            field.getDescription())));
+            boost::program_options::value<std::string>()->implicit_value(setting.getValueString())->composing()->notifier(on_program_option),
+            setting.getDescription())));
     }
 }
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Caveats:
- default_value() will trigger notifier, so implicit_value() is used.
- clickhouse-client usage may be broken (due to implicit value usage),
  let's verify this in tests (although this is unlikely since every
  setting should have some value, even bool).

Later this can be used to complete default values in the shell (one more
way to adjust the defaults to some sane value instead of min/max), or
for generating man pages.