### PR TITLE
Fixed bug with declaring a disk at S3 bucket root

### DIFF
--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -606,7 +606,7 @@ namespace S3
         /// Case when bucket name and key represented in path of S3 URL.
         /// E.g. (https://s3.Region.amazonaws.com/bucket-name/key)
         /// https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#path-style-access
-        static const RE2 path_style_pattern("^/([^/]*)/(.*)");
+        static const RE2 path_style_pattern("^/([^/]*)(/.*)");
 
         static constexpr auto S3 = "S3";
         static constexpr auto COSN = "COSN";
@@ -665,7 +665,7 @@ namespace S3
                 throw Exception(
                     "Bucket name length is out of bounds in path style S3 URI: " + bucket + " (" + uri.toString() + ")", ErrorCodes::BAD_ARGUMENTS);
 
-            if (key.empty() || key == "/")
+            if (key.empty())
                 throw Exception("Key name is empty in path style S3 URI: " + key + " (" + uri.toString() + ")", ErrorCodes::BAD_ARGUMENTS);
         }
         else


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixed bug with declaring a disk at S3 bucket root. Previously `SELECT policy_name FROM system.storage_policies` would return:

```
[heather] 2021.05.10 02:11:11.932234 [ 72790 ] {2ff80b7b-ec53-41cb-ac35-19bb390e1759} <Error> executeQuery: Code: 36, e.displayText() = DB::Exception: Key name is empty in path style S3 URI:  (http://172.17.0.2/bucket/) (version 21.6.1.1) (from 127.0.0.1:47994) (in query: SELECT policy_name FROM system.storage_policies), Stack trace (when copying this message, always include the lines below):

0. Poco::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) @ 0x1118c68c in /home/vladimir/ClickHouse-bin/programs/clickhouse
1. DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, bool) @ 0x8b18d3a in /home/vladimir/ClickHouse-bin/programs/clickhouse
2. DB::S3::URI::URI(Poco::URI const&) @ 0xe2e3f55 in /home/vladimir/ClickHouse-bin/programs/clickhouse
3. std::__1::shared_ptr<DB::IDisk> std::__1::__function::__policy_invoker<std::__1::shared_ptr<DB::IDisk> (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, Poco::Util::AbstractConfiguration const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::shared_ptr<DB::Context const>)>::__call_impl<std::__1::__function::__default_alloc_func<DB::registerDiskS3(DB::DiskFactory&)::$_1, std::__1::shared_ptr<DB::IDisk> (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, Poco::Util::AbstractConfiguration const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::shared_ptr<DB::Context const>)> >(std::__1::__function::__policy_storage const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, Poco::Util::AbstractConfiguration const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::shared_ptr<DB::Context const>&&) @ 0xe7aea43 in /home/vladimir/ClickHouse-bin/programs/clickhouse
4. DB::DiskFactory::create(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, Poco::Util::AbstractConfiguration const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::shared_ptr<DB::Context const>) const @ 0xe7a7dca in /home/vladimir/ClickHouse-bin/programs/clickhouse
5. DB::DiskSelector::DiskSelector(Poco::Util::AbstractConfiguration const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::shared_ptr<DB::Context const>) @ 0xe7a4a04 in /home/vladimir/ClickHouse-bin/programs/clickhouse
6. void std::__1::allocator<DB::DiskSelector>::construct<DB::DiskSelector, Poco::Util::AbstractConfiguration const&, char const* const&, std::__1::shared_ptr<DB::Context const> >(DB::DiskSelector*, Poco::Util::AbstractConfiguration const&, char const* const&, std::__1::shared_ptr<DB::Context const>&&) @ 0xe83d29f in /home/vladimir/ClickHouse-bin/programs/clickhouse
7. DB::Context::getDiskSelector(std::__1::lock_guard<std::__1::mutex>&) const @ 0xe826797 in /home/vladimir/ClickHouse-bin/programs/clickhouse
8. DB::Context::getStoragePolicySelector(std::__1::lock_guard<std::__1::mutex>&) const @ 0xe81b6fd in /home/vladimir/ClickHouse-bin/programs/clickhouse
9. DB::Context::getPoliciesMap() const @ 0xe826af3 in /home/vladimir/ClickHouse-bin/programs/clickhouse
10. DB::StorageSystemStoragePolicies::read(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, std::__1::shared_ptr<DB::StorageInMemoryMetadata const> const&, DB::SelectQueryInfo&, std::__1::shared_ptr<DB::Context>, DB::QueryProcessingStage::Enum, unsigned long, unsigned int) @ 0xe3f070f in /home/vladimir/ClickHouse-bin/programs/clickhouse
11. DB::IStorage::read(DB::QueryPlan&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, std::__1::shared_ptr<DB::StorageInMemoryMetadata const> const&, DB::SelectQueryInfo&, std::__1::shared_ptr<DB::Context>, DB::QueryProcessingStage::Enum, unsigned long, unsigned int) @ 0xef3b1ae in /home/vladimir/ClickHouse-bin/programs/clickhouse
12. DB::InterpreterSelectQuery::executeFetchColumns(DB::QueryProcessingStage::Enum, DB::QueryPlan&) @ 0xeb0f9ea in /home/vladimir/ClickHouse-bin/programs/clickhouse
13. DB::InterpreterSelectQuery::executeImpl(DB::QueryPlan&, std::__1::shared_ptr<DB::IBlockInputStream> const&, std::__1::optional<DB::Pipe>) @ 0xeb08799 in /home/vladimir/ClickHouse-bin/programs/clickhouse
14. DB::InterpreterSelectQuery::buildQueryPlan(DB::QueryPlan&) @ 0xeb0805b in /home/vladimir/ClickHouse-bin/programs/clickhouse
15. DB::InterpreterSelectWithUnionQuery::buildQueryPlan(DB::QueryPlan&) @ 0xec53865 in /home/vladimir/ClickHouse-bin/programs/clickhouse
16. DB::InterpreterSelectWithUnionQuery::execute() @ 0xec545bf in /home/vladimir/ClickHouse-bin/programs/clickhouse
17. DB::executeQueryImpl(char const*, char const*, std::__1::shared_ptr<DB::Context>, bool, DB::QueryProcessingStage::Enum, bool, DB::ReadBuffer*) @ 0xedae753 in /home/vladimir/ClickHouse-bin/programs/clickhouse
18. DB::executeQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::shared_ptr<DB::Context>, bool, DB::QueryProcessingStage::Enum, bool) @ 0xedad41a in /home/vladimir/ClickHouse-bin/programs/clickhouse
19. DB::TCPHandler::runImpl() @ 0xf3d69d9 in /home/vladimir/ClickHouse-bin/programs/clickhouse
20. DB::TCPHandler::run() @ 0xf3e22d9 in /home/vladimir/ClickHouse-bin/programs/clickhouse
21. Poco::Net::TCPServerConnection::start() @ 0x110ff8c7 in /home/vladimir/ClickHouse-bin/programs/clickhouse
22. Poco::Net::TCPServerDispatcher::run() @ 0x110ffd5c in /home/vladimir/ClickHouse-bin/programs/clickhouse
23. Poco::PooledThread::run() @ 0x111e74f9 in /home/vladimir/ClickHouse-bin/programs/clickhouse
24. Poco::ThreadImpl::runnableEntry(void*) @ 0x111e5206 in /home/vladimir/ClickHouse-bin/programs/clickhouse
25. start_thread @ 0x9450 in /usr/lib/x86_64-linux-gnu/libpthread-2.33.so
26. __clone @ 0x117d53 in /usr/lib/x86_64-linux-gnu/libc-2.33.so
```

This solution is potentially very dangerous because all key paths will start with `/` after this change (previously started from first letter of top-level directory inside a bucket).