### PR TITLE
Finalize CompressedWriteBuffer in TemporaryFileStream

### DIFF
--- a/src/DataStreams/TemporaryFileStream.h
+++ b/src/DataStreams/TemporaryFileStream.h
@@ -19,7 +19,7 @@ struct TemporaryFileStream
     CompressedReadBuffer compressed_in;
     BlockInputStreamPtr block_in;
 
-    TemporaryFileStream(const std::string & path)
+    explicit TemporaryFileStream(const std::string & path)
         : file_in(path)
         , compressed_in(file_in)
         , block_in(std::make_shared<NativeBlockInputStream>(compressed_in, DBMS_TCP_PROTOCOL_VERSION))
@@ -39,6 +39,7 @@ struct TemporaryFileStream
         CompressedWriteBuffer compressed_buf(file_buf, CompressionCodecFactory::instance().get(codec, {}));
         NativeBlockOutputStream output(compressed_buf, 0, header);
         copyData(input, output, is_cancelled);
+        compressed_buf.finalize();
     }
 };
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix crash in MergeJoin, close #24010

