### PR TITLE
glibc 2.32 compatibility

### DIFF
--- a/base/glibc-compatibility/musl/fstat.c
+++ b/base/glibc-compatibility/musl/fstat.c
@@ -1,0 +1,12 @@
+#include <sys/stat.h>
+#include <errno.h>
+#include <fcntl.h>
+#include "syscall.h"
+
+#define AT_EMPTY_PATH 0x1000
+
+int fstat(int fd, struct stat *st)
+{
+	if (fd<0) return __syscall_ret(-EBADF);
+	return fstatat(fd, "", st, AT_EMPTY_PATH);
+}

--- a/base/glibc-compatibility/musl/lstat.c
+++ b/base/glibc-compatibility/musl/lstat.c
@@ -1,0 +1,7 @@
+#include <sys/stat.h>
+#include <fcntl.h>
+
+int lstat(const char *restrict path, struct stat *restrict buf)
+{
+	return fstatat(AT_FDCWD, path, buf, AT_SYMLINK_NOFOLLOW);
+}

--- a/base/glibc-compatibility/musl/mknod.c
+++ b/base/glibc-compatibility/musl/mknod.c
@@ -1,0 +1,12 @@
+#include <sys/stat.h>
+#include <fcntl.h>
+#include "syscall.h"
+
+int mknod(const char *path, mode_t mode, dev_t dev)
+{
+#ifdef SYS_mknod
+	return syscall(SYS_mknod, path, mode, dev);
+#else
+	return syscall(SYS_mknodat, AT_FDCWD, path, mode, dev);
+#endif
+}

--- a/base/glibc-compatibility/musl/stat.c
+++ b/base/glibc-compatibility/musl/stat.c
@@ -1,0 +1,7 @@
+#include <sys/stat.h>
+#include <fcntl.h>
+
+int stat(const char *restrict path, struct stat *restrict buf)
+{
+	return fstatat(AT_FDCWD, path, buf, 0);
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Allow to build clickhouse in an environment with glibc 2.32 or 2.33.

```
pthread_sigmask 2.32
pthread_getattr_np      2.32
fstat   2.33
stat    2.33
lstat   2.33
lstat64 2.33
mknod   2.33
stat64  2.33
fstat64 2.33
```

pthread symbols are pinned to glibc 2.2.5

Detailed description / Documentation draft:

.