### PR TITLE
Better error codes in Keeper when no leader alive

### DIFF
--- a/src/Coordination/KeeperServer.cpp
+++ b/src/Coordination/KeeperServer.cpp
@@ -110,6 +110,7 @@ void KeeperServer::startup()
     params.client_req_timeout_ = coordination_settings->operation_timeout_ms.totalMilliseconds();
     params.auto_forwarding_ = coordination_settings->auto_forwarding;
     params.auto_forwarding_req_timeout_ = coordination_settings->operation_timeout_ms.totalMilliseconds() * 2;
+    params.max_append_size_ = coordination_settings->max_requests_batch_size;
 
     params.return_method_ = nuraft::raft_params::async_handler;
 

--- a/src/Coordination/KeeperStorageDispatcher.cpp
+++ b/src/Coordination/KeeperStorageDispatcher.cpp
@@ -109,7 +109,7 @@ void KeeperStorageDispatcher::requestThread()
                     }
                     else
                     {
-                        addErrorResponses(current_batch, Coordination::Error::ZRUNTIMEINCONSISTENCY);
+                        addErrorResponses(current_batch, Coordination::Error::ZCONNECTIONLOSS);
                         current_batch.clear();
                     }
 
@@ -123,7 +123,7 @@ void KeeperStorageDispatcher::requestThread()
                     if (server->isLeaderAlive())
                         server->putLocalReadRequest(request);
                     else
-                        addErrorResponses({request}, Coordination::Error::ZRUNTIMEINCONSISTENCY);
+                        addErrorResponses({request}, Coordination::Error::ZCONNECTIONLOSS);
                 }
             }
         }
@@ -405,7 +405,7 @@ void KeeperStorageDispatcher::forceWaitAndProcessResult(RaftAppendResult & resul
     if (!result->get_accepted() || result->get_result_code() == nuraft::cmd_result_code::TIMEOUT)
         addErrorResponses(requests_for_sessions, Coordination::Error::ZOPERATIONTIMEOUT);
     else if (result->get_result_code() != nuraft::cmd_result_code::OK)
-        addErrorResponses(requests_for_sessions, Coordination::Error::ZRUNTIMEINCONSISTENCY);
+        addErrorResponses(requests_for_sessions, Coordination::Error::ZCONNECTIONLOSS);
 
     result = nullptr;
     requests_for_sessions.clear();

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -32,6 +32,8 @@ from contextlib import closing
 
 MESSAGES_TO_RETRY = [
     "DB::Exception: ZooKeeper session has been expired",
+    "DB::Exception: Connection loss",
+    "Coordination::Exception: Session expired",
     "Coordination::Exception: Connection loss",
     "Operation timed out",
     "ConnectionPoolWithFailover: Connection failed at try",


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Addresses https://github.com/ClickHouse/ClickHouse/issues/23647
