### PR TITLE
lower two-level aggregation threshold for uniq test to avoid jitter

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -104,7 +104,7 @@ class IColumn;
     M(Bool, compile_expressions, false, "Compile some scalar functions and operators to native code.", 0) \
     M(UInt64, min_count_to_compile_expression, 3, "The number of identical expressions before they are JIT-compiled", 0) \
     M(UInt64, group_by_two_level_threshold, 100000, "From what number of keys, a two-level aggregation starts. 0 - the threshold is not set.", 0) \
-    M(UInt64, group_by_two_level_threshold_bytes, 10000000, "From what size of the aggregation state in bytes, a two-level aggregation begins to be used. 0 - the threshold is not set. Two-level aggregation is used when at least one of the thresholds is triggered.", 0) \
+    M(UInt64, group_by_two_level_threshold_bytes, 50000000, "From what size of the aggregation state in bytes, a two-level aggregation begins to be used. 0 - the threshold is not set. Two-level aggregation is used when at least one of the thresholds is triggered.", 0) \
     M(Bool, distributed_aggregation_memory_efficient, true, "Is the memory-saving mode of distributed aggregation enabled.", 0) \
     M(UInt64, aggregation_memory_efficient_merge_threads, 0, "Number of threads to use for merge intermediate aggregation results in memory efficient mode. When bigger, then more memory is consumed. 0 means - same as 'max_threads'.", 0) \
     \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -104,7 +104,7 @@ class IColumn;
     M(Bool, compile_expressions, false, "Compile some scalar functions and operators to native code.", 0) \
     M(UInt64, min_count_to_compile_expression, 3, "The number of identical expressions before they are JIT-compiled", 0) \
     M(UInt64, group_by_two_level_threshold, 100000, "From what number of keys, a two-level aggregation starts. 0 - the threshold is not set.", 0) \
-    M(UInt64, group_by_two_level_threshold_bytes, 100000000, "From what size of the aggregation state in bytes, a two-level aggregation begins to be used. 0 - the threshold is not set. Two-level aggregation is used when at least one of the thresholds is triggered.", 0) \
+    M(UInt64, group_by_two_level_threshold_bytes, 50000000, "From what size of the aggregation state in bytes, a two-level aggregation begins to be used. 0 - the threshold is not set. Two-level aggregation is used when at least one of the thresholds is triggered.", 0) \
     M(Bool, distributed_aggregation_memory_efficient, true, "Is the memory-saving mode of distributed aggregation enabled.", 0) \
     M(UInt64, aggregation_memory_efficient_merge_threads, 0, "Number of threads to use for merge intermediate aggregation results in memory efficient mode. When bigger, then more memory is consumed. 0 means - same as 'max_threads'.", 0) \
     \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -104,7 +104,7 @@ class IColumn;
     M(Bool, compile_expressions, false, "Compile some scalar functions and operators to native code.", 0) \
     M(UInt64, min_count_to_compile_expression, 3, "The number of identical expressions before they are JIT-compiled", 0) \
     M(UInt64, group_by_two_level_threshold, 100000, "From what number of keys, a two-level aggregation starts. 0 - the threshold is not set.", 0) \
-    M(UInt64, group_by_two_level_threshold_bytes, 50000000, "From what size of the aggregation state in bytes, a two-level aggregation begins to be used. 0 - the threshold is not set. Two-level aggregation is used when at least one of the thresholds is triggered.", 0) \
+    M(UInt64, group_by_two_level_threshold_bytes, 10000000, "From what size of the aggregation state in bytes, a two-level aggregation begins to be used. 0 - the threshold is not set. Two-level aggregation is used when at least one of the thresholds is triggered.", 0) \
     M(Bool, distributed_aggregation_memory_efficient, true, "Is the memory-saving mode of distributed aggregation enabled.", 0) \
     M(UInt64, aggregation_memory_efficient_merge_threads, 0, "Number of threads to use for merge intermediate aggregation results in memory efficient mode. When bigger, then more memory is consumed. 0 means - same as 'max_threads'.", 0) \
     \

--- a/tests/performance/uniq.xml
+++ b/tests/performance/uniq.xml
@@ -9,6 +9,16 @@
 
     <settings>
         <max_memory_usage>30000000000</max_memory_usage>
+        <!--
+            Because of random distribution of data between threads, the number
+            of unique keys per thread might differ. This means that sometimes
+            we switch to two-level aggregation, and sometimes we don't, based on
+            the "bytes" threshold. Two-level aggregation turns out to be twice
+            as fast, because it merges aggregation states in multiple threads.
+            Lower the threshold here, to avoid jitter. It is unclear whether it
+            would be beneficial to lower the default as well.
+        -->
+        <group_by_two_level_threshold_bytes>10000000</group_by_two_level_threshold_bytes>
     </settings>
 
     <substitutions>

--- a/tests/queries/0_stateless/00106_totals_after_having.sql
+++ b/tests/queries/0_stateless/00106_totals_after_having.sql
@@ -1,6 +1,13 @@
 SET max_rows_to_group_by = 100000;
 SET group_by_overflow_mode = 'any';
 
+-- 'any' overflow mode might select different values for two-level and
+-- single-level GROUP BY, so we set a big enough threshold here to ensure that
+-- the switch doesn't happen, we only use single-level GROUP BY and get a
+-- predictable result.
+SET group_by_two_level_threshold_bytes = 100000000;
+SET group_by_two_level_threshold = 1000000;
+
 SET totals_mode = 'after_having_auto';
 SELECT dummy, count() GROUP BY dummy WITH TOTALS;
 

--- a/tests/queries/0_stateless/00107_totals_after_having.sql
+++ b/tests/queries/0_stateless/00107_totals_after_having.sql
@@ -4,6 +4,13 @@ SET max_rows_to_group_by = 100000;
 SET max_block_size = 100001;
 SET group_by_overflow_mode = 'any';
 
+-- 'any' overflow mode might select different values for two-level and
+-- single-level GROUP BY, so we set a big enough threshold here to ensure that
+-- the switch doesn't happen, we only use single-level GROUP BY and get a
+-- predictable result.
+SET group_by_two_level_threshold_bytes = 100000000;
+SET group_by_two_level_threshold = 1000000;
+
 SELECT '**** totals_mode = after_having_auto';
 SET totals_mode = 'after_having_auto';
 SELECT intDiv(number, 2) AS k, count(), argMax(toString(number), number) FROM (SELECT number FROM system.numbers LIMIT 500000) GROUP BY k WITH TOTALS ORDER BY k LIMIT 10;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)
