### PR TITLE
[RFC] Suppress exceptions from logger code

### DIFF
--- a/base/loggers/OwnSplitChannel.cpp
+++ b/base/loggers/OwnSplitChannel.cpp
@@ -45,6 +45,8 @@ void OwnSplitChannel::tryLogSplit(const Poco::Message & msg)
     }
     catch (...)
     {
+        MemoryTracker::LockExceptionInThread lock_memory_tracker(VariableContext::Global);
+
         /// It is better to catch the errors here in order to avoid
         /// breaking some functionality because of unexpected "File not
         /// found" (or similar) error.

--- a/base/loggers/OwnSplitChannel.cpp
+++ b/base/loggers/OwnSplitChannel.cpp
@@ -61,15 +61,12 @@ void OwnSplitChannel::tryLogSplit(const Poco::Message & msg)
         const std::string & exception_message = getCurrentExceptionMessage(true);
         const std::string & message = msg.getText();
 
-        if (!writeRetry(STDERR_FILENO, "Cannot add message to the log: ") ||
-            !writeRetry(STDERR_FILENO, message.data(), message.size()) ||
-            !writeRetry(STDERR_FILENO, "\n") ||
-            !writeRetry(STDERR_FILENO, exception_message.data(), exception_message.size()) ||
-            !writeRetry(STDERR_FILENO, "\n")
-        )
-        {
-            /// Nothing can be done. Ignore the error.
-        }
+        /// NOTE: errors are ignored, since nothing can be done.
+        writeRetry(STDERR_FILENO, "Cannot add message to the log: ");
+        writeRetry(STDERR_FILENO, message.data(), message.size());
+        writeRetry(STDERR_FILENO, "\n");
+        writeRetry(STDERR_FILENO, exception_message.data(), exception_message.size());
+        writeRetry(STDERR_FILENO, "\n");
     }
 }
 

--- a/base/loggers/OwnSplitChannel.h
+++ b/base/loggers/OwnSplitChannel.h
@@ -24,6 +24,7 @@ public:
 
 private:
     void logSplit(const Poco::Message & msg);
+    void tryLogSplit(const Poco::Message & msg);
 
     using ChannelPtr = Poco::AutoPtr<Poco::Channel>;
     /// Handler and its pointer casted to extended interface

--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -19,6 +19,7 @@
 
 #include <Common/StringUtils/StringUtils.h>
 #include <Common/getHashOfLoadedBinary.h>
+#include <Common/IO.h>
 
 #include <common/phdr_cache.h>
 #include <ext/scope_guard.h>
@@ -172,11 +173,11 @@ enum class InstructionFail
     AVX512 = 8
 };
 
-std::pair<const char *, size_t> instructionFailToString(InstructionFail fail)
+auto instructionFailToString(InstructionFail fail)
 {
     switch (fail)
     {
-#define ret(x) return std::make_pair(x, ARRAY_SIZE(x) - 1)
+#define ret(x) return std::make_tuple(STDERR_FILENO, x, ARRAY_SIZE(x) - 1)
         case InstructionFail::NONE:
             ret("NONE");
         case InstructionFail::SSE3:
@@ -260,28 +261,12 @@ void checkRequiredInstructionsImpl(volatile InstructionFail & fail)
     fail = InstructionFail::NONE;
 }
 
-/// This function is safe to use in static initializers.
-void writeErrorLen(const char * data, size_t size)
-{
-    while (size != 0)
-    {
-        ssize_t res = ::write(STDERR_FILENO, data, size);
-
-        if ((-1 == res || 0 == res) && errno != EINTR)
-            _Exit(1);
-
-        if (res > 0)
-        {
-            data += res;
-            size -= res;
-        }
-    }
-}
 /// Macros to avoid using strlen(), since it may fail if SSE is not supported.
 #define writeError(data) do \
     { \
         static_assert(__builtin_constant_p(data)); \
-        writeErrorLen(data, ARRAY_SIZE(data) - 1); \
+        if (!writeRetry(STDERR_FILENO, data, ARRAY_SIZE(data) - 1)) \
+            _Exit(1); \
     } while (false)
 
 /// Check SSE and others instructions availability. Calls exit on fail.
@@ -310,7 +295,8 @@ void checkRequiredInstructions()
     if (sigsetjmp(jmpbuf, 1))
     {
         writeError("Instruction check fail. The CPU does not support ");
-        std::apply(writeErrorLen, instructionFailToString(fail));
+        if (!std::apply(writeRetry, instructionFailToString(fail)))
+            _Exit(1);
         writeError(" instruction set.\n");
         _Exit(1);
     }

--- a/src/Common/IO.cpp
+++ b/src/Common/IO.cpp
@@ -1,0 +1,27 @@
+#include <Common/IO.h>
+
+#include <unistd.h>
+#include <errno.h>
+#include <cstring>
+
+bool writeRetry(int fd, const char * data, size_t size)
+{
+    if (!size)
+        size = strlen(data);
+
+    while (size != 0)
+    {
+        ssize_t res = ::write(fd, data, size);
+
+        if ((-1 == res || 0 == res) && errno != EINTR)
+            return false;
+
+        if (res > 0)
+        {
+            data += res;
+            size -= res;
+        }
+    }
+
+    return true;
+}

--- a/src/Common/IO.h
+++ b/src/Common/IO.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstddef>
+
+/// IO helpers
+
+/// Write loop with EINTR handling.
+///
+/// This function is safe to use in static initializers.
+///
+/// @param size - len of @data or 0 to use strlen()
+/// @return true if write was succeed, otherwise false.
+bool writeRetry(int fd, const char * data, size_t size = 0);

--- a/src/Common/ya.make
+++ b/src/Common/ya.make
@@ -46,6 +46,7 @@ SRCS(
     ExternalLoaderStatus.cpp
     FieldVisitors.cpp
     FileChecker.cpp
+    IO.cpp
     IPv6ToBinary.cpp
     IntervalKind.cpp
     JSONBuilder.cpp

--- a/tests/queries/0_stateless/01594_too_low_memory_limits.config.xml
+++ b/tests/queries/0_stateless/01594_too_low_memory_limits.config.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<yandex>
+    <logger>
+        <level>trace</level>
+        <console>true</console>
+    </logger>
+
+    <tcp_port>9000</tcp_port>
+
+    <path>./</path>
+
+    <mark_cache_size>0</mark_cache_size>
+
+    <users>
+        <default>
+            <password></password>
+
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+
+            <profile>default</profile>
+            <quota>default</quota>
+            <access_management>1</access_management>
+        </default>
+    </users>
+
+    <profiles>
+        <default/>
+    </profiles>
+
+    <quotas>
+        <default />
+    </quotas>
+</yandex>

--- a/tests/queries/0_stateless/01594_too_low_memory_limits.sh
+++ b/tests/queries/0_stateless/01594_too_low_memory_limits.sh
@@ -6,11 +6,11 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # it is not mandatory to use existing table since it fails earlier, hence just a placeholder.
 # this is format of INSERT SELECT, that pass these settings exactly for INSERT query not the SELECT
-${CLICKHOUSE_CLIENT} --format Null -q 'insert into placeholder_table_name select * from numbers_mt(65535) format Null settings max_memory_usage=1, max_untracked_memory=1' >& /dev/null
-exit_code=$?
-
-# expecting ATTEMPT_TO_READ_AFTER_EOF, 32
-test $exit_code -eq 32 || exit 1
-
+${CLICKHOUSE_CLIENT} --format Null --testmode -nm -q "
+    insert into placeholder_table_name
+    select * from numbers_mt(65535) format Null
+    settings max_memory_usage=1, max_untracked_memory=1
+    -- { clientError 32 }
+"
 # check that server is still alive
 ${CLICKHOUSE_CLIENT} --format Null -q 'SELECT 1'

--- a/tests/queries/0_stateless/01594_too_low_memory_limits.sh
+++ b/tests/queries/0_stateless/01594_too_low_memory_limits.sh
@@ -1,16 +1,103 @@
 #!/usr/bin/env bash
 
+#
+# Regression for INSERT SELECT, that abnormally terminates the server
+# in case of too small memory limits.
+#
+# NOTE: After #24483 had been merged the only place where the allocation may
+# fail is the insert into PODArray in DB::OwnSplitChannel::log, but after
+# #24069 those errors will be ignored, so to check new behaviour separate
+# server is required.
+#
+
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+server_opts=(
+    "--config-file=$CURDIR/$(basename "${BASH_SOURCE[0]}" .sh).config.xml"
+    "--"
+    # to avoid multiple listen sockets (complexity for port discovering)
+    "--listen_host=127.1"
+    # we will discover the real port later.
+    "--tcp_port=0"
+    "--shutdown_wait_unfinished=0"
+)
+CLICKHOUSE_WATCHDOG_ENABLE=0 $CLICKHOUSE_SERVER_BINARY "${server_opts[@]}" >clickhouse-server.log 2>clickhouse-server.stderr &
+server_pid=$!
+
+trap cleanup EXIT
+function cleanup()
+{
+    kill -9 $server_pid
+
+    echo "Test failed. Server log:"
+    cat clickhouse-server.log
+    cat clickhouse-server.stderr
+    rm -f clickhouse-server.log
+    rm -f clickhouse-server.stderr
+
+    exit 1
+}
+
+server_port=
+i=0 retries=300
+# wait until server will start to listen (max 30 seconds)
+while [[ -z $server_port ]] && [[ $i -lt $retries ]]; do
+    server_port=$(lsof -n -a -P -i tcp -s tcp:LISTEN -p $server_pid 2>/dev/null | awk -F'[ :]' '/LISTEN/ { print $(NF-1) }')
+    ((++i))
+    sleep 0.1
+    if ! kill -0 $server_pid >& /dev/null; then
+        echo "No server (pid $server_pid)"
+        break
+    fi
+done
+if [[ -z $server_port ]]; then
+    echo "Cannot wait for LISTEN socket" >&2
+    exit 1
+fi
+
+# wait for the server to start accepting tcp connections (max 30 seconds)
+i=0 retries=300
+while ! $CLICKHOUSE_CLIENT_BINARY --host 127.1 --port "$server_port" --format Null -q 'select 1' 2>/dev/null && [[ $i -lt $retries ]]; do
+    sleep 0.1
+    if ! kill -0 $server_pid >& /dev/null; then
+        echo "No server (pid $server_pid)"
+        break
+    fi
+done
+if ! $CLICKHOUSE_CLIENT_BINARY --host 127.1 --port "$server_port" --format Null -q 'select 1'; then
+    echo "Cannot wait until server will start accepting connections on <tcp_port>" >&2
+    exit 1
+fi
+
 # it is not mandatory to use existing table since it fails earlier, hence just a placeholder.
 # this is format of INSERT SELECT, that pass these settings exactly for INSERT query not the SELECT
-${CLICKHOUSE_CLIENT} --format Null -q 'insert into placeholder_table_name select * from numbers_mt(65535) format Null settings max_memory_usage=1, max_untracked_memory=1' >& /dev/null
-exit_code=$?
+if $CLICKHOUSE_CLIENT_BINARY --host 127.1 --port "$server_port" --format Null --send_logs_level=warning --max_memory_usage=1 --max_untracked_memory=1 -q 'insert into placeholder_table_name select * from numbers_mt(65535)' >& /dev/null; then
+    echo "INSERT SELECT should fail" >&2
+    exit 1
+fi
 
-# expecting ATTEMPT_TO_READ_AFTER_EOF, 32
-test $exit_code -eq 32 || exit 1
+# no sleep, since flushing to stderr should not be buffered.
+if ! grep -E -q 'Cannot add message to the log: Code: 60.*placeholder_table_name' clickhouse-server.stderr; then
+    echo "Adding message to the log should fail" >&2
+    exit 1
+fi
 
 # check that server is still alive
-${CLICKHOUSE_CLIENT} --format Null -q 'SELECT 1'
+$CLICKHOUSE_CLIENT_BINARY --host 127.1 --port "$server_port" --format Null -q 'SELECT 1'
+
+# send TERM and save the error code to ensure that it is 0 (EXIT_SUCCESS)
+kill $server_pid
+wait $server_pid
+return_code=$?
+
+trap '' EXIT
+if [ $return_code != 0 ]; then
+    cat clickhouse-server.log
+    cat clickhouse-server.stderr
+fi
+rm -f clickhouse-server.log
+rm -f clickhouse-server.stderr
+
+exit $return_code

--- a/tests/queries/0_stateless/01594_too_low_memory_limits.sh
+++ b/tests/queries/0_stateless/01594_too_low_memory_limits.sh
@@ -6,11 +6,11 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # it is not mandatory to use existing table since it fails earlier, hence just a placeholder.
 # this is format of INSERT SELECT, that pass these settings exactly for INSERT query not the SELECT
-${CLICKHOUSE_CLIENT} --format Null --testmode -nm -q "
-    insert into placeholder_table_name
-    select * from numbers_mt(65535) format Null
-    settings max_memory_usage=1, max_untracked_memory=1
-    -- { clientError 32 }
-"
+${CLICKHOUSE_CLIENT} --format Null -q 'insert into placeholder_table_name select * from numbers_mt(65535) format Null settings max_memory_usage=1, max_untracked_memory=1' >& /dev/null
+exit_code=$?
+
+# expecting ATTEMPT_TO_READ_AFTER_EOF, 32
+test $exit_code -eq 32 || exit 1
+
 # check that server is still alive
 ${CLICKHOUSE_CLIENT} --format Null -q 'SELECT 1'

--- a/tests/queries/skip_list.json
+++ b/tests/queries/skip_list.json
@@ -13,6 +13,7 @@
         "01193_metadata_loading",
         "01473_event_time_microseconds",
         "01526_max_untracked_memory", /// requires TraceCollector, does not available under sanitizers
+        "01594_too_low_memory_limits", /// requires jemalloc to track small allocations
         "01474_executable_dictionary", /// informational stderr from sanitizer at start
         "functions_bad_arguments", /// Too long for TSan
         "01603_read_with_backoff_bug", /// Too long for TSan
@@ -28,6 +29,7 @@
         "01103_check_cpu_instructions_at_startup",
         "01473_event_time_microseconds",
         "01526_max_untracked_memory", /// requires TraceCollector, does not available under sanitizers
+        "01594_too_low_memory_limits", /// requires jemalloc to track small allocations
         "01193_metadata_loading",
         "01017_uniqCombined_memory_usage" /// Fine thresholds on memory usage
     ],
@@ -39,6 +41,7 @@
         "00900_orc_load",
         "01473_event_time_microseconds",
         "01526_max_untracked_memory", /// requires TraceCollector, does not available under sanitizers
+        "01594_too_low_memory_limits", /// requires jemalloc to track small allocations
         "01193_metadata_loading"
     ],
     "memory-sanitizer": [
@@ -51,6 +54,7 @@
         "00877_memory_limit_for_new_delete", /// memory limits don't work correctly under msan because it replaces malloc/free
         "01473_event_time_microseconds",
         "01526_max_untracked_memory", /// requires TraceCollector, does not available under sanitizers
+        "01594_too_low_memory_limits", /// requires jemalloc to track small allocations
         "01193_metadata_loading",
         "01017_uniqCombined_memory_usage" /// Fine thresholds on memory usage
     ],

--- a/tests/queries/skip_list.json
+++ b/tests/queries/skip_list.json
@@ -722,6 +722,7 @@
         "01684_ssd_cache_dictionary_simple_key",
         "01685_ssd_cache_dictionary_complex_key",
         "01737_clickhouse_server_wait_server_pool_long", // This test is fully compatible to run in parallel, however under ASAN processes are pretty heavy and may fail under flaky adress check.
+        "01594_too_low_memory_limits", // This test is fully compatible to run in parallel, however under ASAN processes are pretty heavy and may fail under flaky adress check.
         "01760_system_dictionaries",
         "01760_polygon_dictionaries",
         "01778_hierarchical_dictionaries",


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Suppress exceptions from logger code

Detailed description / Documentation draft:
Some code does not expect from the logger code to throw, and this can
lead to the problems like:
- marking distributed batch as broken (in
  StorageDistributedDirectoryMonitor)
- some MergeTree code may also be affected.

So instead of throwing the exception, it will be logged to the stderr
(if it is possible).