### PR TITLE
Fix concurrent snapshot read/write

### DIFF
--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -267,12 +267,15 @@ int KeeperStateMachine::read_logical_snp_obj(
     {
         std::lock_guard lock(snapshots_lock);
         if (s.get_last_log_idx() != latest_snapshot_meta->get_last_log_idx())
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Required to apply snapshot with last log index {}, but our last log index is {}",
+        {
+            LOG_WARNING(log, "Required to apply snapshot with last log index {}, but our last log index is {}. Will ignore this one and retry",
                             s.get_last_log_idx(), latest_snapshot_meta->get_last_log_idx());
+            return -1;
+        }
         data_out = nuraft::buffer::clone(*latest_snapshot_buf);
         is_last_obj = true;
     }
-    return 0;
+    return 1;
 }
 
 void KeeperStateMachine::processReadRequest(const KeeperStorage::RequestForSession & request_for_session)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix rare bug with concurrent snapshots r/w, which leads to the following logical error:
```
38011:2021.05.05 21:35:46.956666 [ 1846 ] {} <Fatal> BaseDaemon: (version 21.6.1.6760 (official build), build id: 8689D34C7ADB63201EE61DD69DD5F64FE4483E0E) (from thread 1862) Terminate called for uncaught exception:
38028:2021.05.05 21:35:46.956927 [ 1973 ] {} <Fatal> BaseDaemon: ########################################
38029:2021.05.05 21:35:46.956963 [ 1973 ] {} <Fatal> BaseDaemon: (version 21.6.1.6760 (official build), build id: 8689D34C7ADB63201EE61DD69DD5F64FE4483E0E) (from thread 1862) (no query) Received signal Aborted (6)
38030:2021.05.05 21:35:46.956990 [ 1973 ] {} <Fatal> BaseDaemon: 
38031:2021.05.05 21:35:46.957024 [ 1973 ] {} <Fatal> BaseDaemon: Stack trace: 0x7f9f58bbffb7 0x7f9f58bc1921 0x8c76ea7 0x126bbb03 0x126bb0d6 0x126bb04d 0xf60100d 0x11074f11 0x1108bdde 0x1108b251 0x1108a51b 0x1108a23c 0x11067e00 0x7f9f58f796db 0x7f9f58ca271f
38034:2021.05.05 21:35:46.989395 [ 1973 ] {} <Fatal> BaseDaemon: 3. /build/glibc-S9d2JN/glibc-2.27/signal/../sysdeps/unix/sysv/linux/raise.c:51: raise @ 0x3efb7 in /usr/lib/debug/lib/x86_64-linux-gnu/libc-2.27.so
38035:2021.05.05 21:35:46.991679 [ 1973 ] {} <Fatal> BaseDaemon: 4. /build/glibc-S9d2JN/glibc-2.27/stdlib/abort.c:81: abort @ 0x40921 in /usr/lib/debug/lib/x86_64-linux-gnu/libc-2.27.so
38038:2021.05.05 21:35:47.047090 [ 1973 ] {} <Fatal> BaseDaemon: 5. /build/build_docker/../base/daemon/BaseDaemon.cpp:0: terminate_handler() @ 0x8c76ea7 in /home/robot-clickhouse/binaries/1bbd583094a4aaa2072b58d2e3b88c47
38039:2021.05.05 21:35:47.049106 [ 1973 ] {} <Fatal> BaseDaemon: 6. /build/build_docker/../contrib/libcxxabi/src/cxa_handlers.cpp:61: std::__terminate(void (*)()) @ 0x126bbb03 in /home/robot-clickhouse/binaries/1bbd583094a4aaa2072b58d2e3b88c47
38040:2021.05.05 21:35:47.051074 [ 1973 ] {} <Fatal> BaseDaemon: 7. /build/build_docker/../contrib/libcxxabi/src/cxa_exception.cpp:152: ? @ 0x126bb0d6 in /home/robot-clickhouse/binaries/1bbd583094a4aaa2072b58d2e3b88c47
38041:2021.05.05 21:35:47.052735 [ 1973 ] {} <Fatal> BaseDaemon: 8. /build/build_docker/../contrib/libcxxabi/src/cxa_exception.cpp:283: ? @ 0x126bb04d in /home/robot-clickhouse/binaries/1bbd583094a4aaa2072b58d2e3b88c47
38044:2021.05.05 21:35:47.086150 [ 1973 ] {} <Fatal> BaseDaemon: 9. /build/build_docker/../src/Coordination/KeeperStateMachine.cpp:0: DB::KeeperStateMachine::read_logical_snp_obj(nuraft::snapshot&, void*&, unsigned long, std::__1::shared_ptr<nuraft::buffer>&, bool&) @ 0xf60100d in /home/robot-clickhouse/binaries/1bbd583094a4aaa2072b58d2e3b88c47
38045:2021.05.05 21:35:47.097312 [ 1973 ] {} <Fatal> BaseDaemon: 10.1. inlined from /build/build_docker/../contrib/libcxx/include/memory:2835: std::__1::shared_ptr<nuraft::buffer>::get() const
38046:2021.05.05 21:35:47.097382 [ 1973 ] {} <Fatal> BaseDaemon: 10.2. inlined from ../contrib/libcxx/include/memory:2851: std::__1::shared_ptr<nuraft::buffer>::operator bool() const
38047:2021.05.05 21:35:47.097399 [ 1973 ] {} <Fatal> BaseDaemon: 10. ../contrib/NuRaft/src/handle_snapshot_sync.cxx:155: nuraft::raft_server::create_sync_snapshot_req(nuraft::peer&, unsigned long, unsigned long, unsigned long) @ 0x11074f11 in /home/robot-clickhouse/binaries/1bbd583094a4aaa2072b58d2e3b88c47
38048:2021.05.05 21:35:47.110577 [ 1973 ] {} <Fatal> BaseDaemon: 11. /build/build_docker/../contrib/NuRaft/src/handle_append_entries.cxx:0: nuraft::raft_server::create_append_entries_req(nuraft::peer&) @ 0x1108bdde in /home/robot-clickhouse/binaries/1bbd583094a4aaa2072b58d2e3b88c47
38051:2021.05.05 21:35:47.122936 [ 1973 ] {} <Fatal> BaseDaemon: 12.1. inlined from /build/build_docker/../contrib/libcxx/include/type_traits:3935: std::__1::enable_if<(is_move_constructible<nuraft::req_msg*>::value) && (is_move_assignable<nuraft::req_msg*>::value), void>::type std::__1::swap<nuraft::req_msg*>(nuraft::req_msg*&, nuraft::req_msg*&)
38052:2021.05.05 21:35:47.122981 [ 1973 ] {} <Fatal> BaseDaemon: 12.2. inlined from ../contrib/libcxx/include/memory:3299: std::__1::shared_ptr<nuraft::req_msg>::swap(std::__1::shared_ptr<nuraft::req_msg>&)
38053:2021.05.05 21:35:47.122996 [ 1973 ] {} <Fatal> BaseDaemon: 12.3. inlined from ../contrib/libcxx/include/memory:3243: std::__1::shared_ptr<nuraft::req_msg>::operator=(std::__1::shared_ptr<nuraft::req_msg>&&)
38054:2021.05.05 21:35:47.123010 [ 1973 ] {} <Fatal> BaseDaemon: 12. ../contrib/NuRaft/src/handle_append_entries.cxx:209: nuraft::raft_server::request_append_entries(std::__1::shared_ptr<nuraft::peer>) @ 0x1108b251 in /home/robot-clickhouse/binaries/1bbd583094a4aaa2072b58d2e3b88c47
38055:2021.05.05 21:35:47.139221 [ 1973 ] {} <Fatal> BaseDaemon: 13.1. inlined from /build/build_docker/../contrib/NuRaft/src/handle_append_entries.cxx:0: nuraft::raft_server::request_append_entries()
38056:2021.05.05 21:35:47.139274 [ 1973 ] {} <Fatal> BaseDaemon: 13. ../contrib/NuRaft/src/handle_append_entries.cxx:61: nuraft::raft_server::append_entries_in_bg_exec() @ 0x1108a51b in /home/robot-clickhouse/binaries/1bbd583094a4aaa2072b58d2e3b88c47
38057:2021.05.05 21:35:47.155011 [ 1973 ] {} <Fatal> BaseDaemon: 14.1. inlined from /build/build_docker/../contrib/libcxx/include/atomic:1006: bool std::__1::__cxx_atomic_load<bool>(std::__1::__cxx_atomic_base_impl<bool> const*, std::__1::memory_order)
38058:2021.05.05 21:35:47.155066 [ 1973 ] {} <Fatal> BaseDaemon: 14.2. inlined from ../contrib/libcxx/include/atomic:1615: std::__1::__atomic_base<bool, false>::load(std::__1::memory_order) const
38059:2021.05.05 21:35:47.155106 [ 1973 ] {} <Fatal> BaseDaemon: 14.3. inlined from ../contrib/libcxx/include/atomic:1619: std::__1::__atomic_base<bool, false>::operator bool() const
38060:2021.05.05 21:35:47.155120 [ 1973 ] {} <Fatal> BaseDaemon: 14. ../contrib/NuRaft/src/handle_append_entries.cxx:54: nuraft::raft_server::append_entries_in_bg() @ 0x1108a23c in /home/robot-clickhouse/binaries/1bbd583094a4aaa2072b58d2e3b88c47
38063:2021.05.05 21:35:47.190575 [ 1973 ] {} <Fatal> BaseDaemon: 15.1. inlined from /build/build_docker/../contrib/libcxx/include/memory:1655: std::__1::unique_ptr<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, std::__1::__bind<void (nuraft::raft_server::*)(), nuraft::raft_server*> >, std::__1::default_delete<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, std::__1::__bind<void (nuraft::raft_server::*)(), nuraft::raft_server*> > > >::reset(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, std::__1::__bind<void (nuraft::raft_server::*)(), nuraft::raft_server*> >*)
38064:2021.05.05 21:35:47.190641 [ 1973 ] {} <Fatal> BaseDaemon: 15.2. inlined from ../contrib/libcxx/include/memory:1612: ~unique_ptr
38065:2021.05.05 21:35:47.190655 [ 1973 ] {} <Fatal> BaseDaemon: 15. ../contrib/libcxx/include/thread:293: void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, std::__1::__bind<void (nuraft::raft_server::*)(), nuraft::raft_server*> > >(void*) @ 0x11067e00 in /home/robot-clickhouse/binaries/1bbd583094a4aaa2072b58d2e3b88c47
38066:2021.05.05 21:35:47.190709 [ 1973 ] {} <Fatal> BaseDaemon: 16. start_thread @ 0x76db in /lib/x86_64-linux-gnu/libpthread-2.27.so
38067:2021.05.05 21:35:47.190784 [ 1973 ] {} <Fatal> BaseDaemon: 17. /build/glibc-S9d2JN/glibc-2.27/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:97: __clone @ 0x12171f in /usr/lib/debug/lib/x86_64-linux-gnu/libc-2.27.so
38070:2021.05.05 21:35:47.339465 [ 1973 ] {} <Fatal> BaseDaemon: Checksum of the binary: DF1D616FD9A3B5FACBF396449176B9A5, integrity check passed.
38405:2021.05.05 21:36:09.366037 [ 1844 ] {} <Fatal> Application: Child process was terminated by signal 6.

```

Related issue: https://github.com/eBay/NuRaft/issues/212
