### PR TITLE
Tests cleanup

### DIFF
--- a/tests/queries/0_stateless/01594_too_low_memory_limits.sh
+++ b/tests/queries/0_stateless/01594_too_low_memory_limits.sh
@@ -6,11 +6,11 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # it is not mandatory to use existing table since it fails earlier, hence just a placeholder.
 # this is format of INSERT SELECT, that pass these settings exactly for INSERT query not the SELECT
-${CLICKHOUSE_CLIENT} --format Null -q 'insert into placeholder_table_name select * from numbers_mt(65535) format Null settings max_memory_usage=1, max_untracked_memory=1' >& /dev/null
-exit_code=$?
-
-# expecting ATTEMPT_TO_READ_AFTER_EOF, 32
-test $exit_code -eq 32 || exit 1
-
+${CLICKHOUSE_CLIENT} --format Null --testmode -nm -q "
+    insert into placeholder_table_name
+    select * from numbers_mt(65535) format Null
+    settings max_memory_usage=1, max_untracked_memory=1
+    -- { clientError 32 }
+"
 # check that server is still alive
 ${CLICKHOUSE_CLIENT} --format Null -q 'SELECT 1'


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog:
- Cleanup 01594_too_low_memory_limits (by using clientError)