### PR TITLE
Fix DateTime64 column vs DateTime value in where

### DIFF
--- a/src/Interpreters/convertFieldToType.cpp
+++ b/src/Interpreters/convertFieldToType.cpp
@@ -201,7 +201,13 @@ Field convertFieldToTypeImpl(const Field & src, const IDataType & type, const ID
             return src;
         }
 
-        /// TODO Conversion from integers to DateTime64
+        if (which_type.isDateTime64()
+            && (which_from_type.isNativeInt() || which_from_type.isNativeUInt() || which_from_type.isDateOrDateTime()))
+        {
+            const auto scale = static_cast<const DataTypeDateTime64 &>(type).getScale();
+            const auto decimal_value = DecimalUtils::decimalFromComponents<DateTime64>(src.reinterpret<Int64>(), 0, scale);
+            return Field(DecimalField<DateTime64>(decimal_value, scale));
+        }
     }
     else if (which_type.isUUID() && src.getType() == Field::Types::UUID)
     {

--- a/tests/queries/0_stateless/01866_datetime64_cmp_with_constant.reference
+++ b/tests/queries/0_stateless/01866_datetime64_cmp_with_constant.reference
@@ -1,0 +1,12 @@
+dt64 <= const dt
+dt64 <= dt
+dt <= const dt64
+dt <= dt64
+dt64 = const dt
+dt64 = dt
+dt = const dt64
+dt = dt64
+dt64 >= const dt
+dt64 >= dt
+dt >= const dt64
+dt >= dt64

--- a/tests/queries/0_stateless/01866_datetime64_cmp_with_constant.sql
+++ b/tests/queries/0_stateless/01866_datetime64_cmp_with_constant.sql
@@ -1,0 +1,40 @@
+CREATE TABLE dt64test
+(
+    `dt64_column` DateTime64(3),
+    `dt_column` DateTime DEFAULT toDateTime(dt64_column)
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(dt64_column)
+ORDER BY dt64_column;
+
+INSERT INTO dt64test (`dt64_column`) VALUES ('2020-01-13 13:37:00');
+
+SELECT 'dt64 < const dt' FROM dt64test WHERE dt64_column < toDateTime('2020-01-13 13:37:00');
+SELECT 'dt64 < dt' FROM dt64test WHERE dt64_column < materialize(toDateTime('2020-01-13 13:37:00'));
+SELECT 'dt < const dt64' FROM dt64test WHERE dt_column < toDateTime64('2020-01-13 13:37:00', 3);
+SELECT 'dt < dt64' FROM dt64test WHERE dt_column < materialize(toDateTime64('2020-01-13 13:37:00', 3));
+
+SELECT 'dt64 <= const dt' FROM dt64test WHERE dt64_column <= toDateTime('2020-01-13 13:37:00');
+SELECT 'dt64 <= dt' FROM dt64test WHERE dt64_column <= materialize(toDateTime('2020-01-13 13:37:00'));
+SELECT 'dt <= const dt64' FROM dt64test WHERE dt_column <= toDateTime64('2020-01-13 13:37:00', 3);
+SELECT 'dt <= dt64' FROM dt64test WHERE dt_column <= materialize(toDateTime64('2020-01-13 13:37:00', 3));
+
+SELECT 'dt64 = const dt' FROM dt64test WHERE dt64_column = toDateTime('2020-01-13 13:37:00');
+SELECT 'dt64 = dt' FROM dt64test WHERE dt64_column = materialize(toDateTime('2020-01-13 13:37:00'));
+SELECT 'dt = const dt64' FROM dt64test WHERE dt_column = toDateTime64('2020-01-13 13:37:00', 3);
+SELECT 'dt = dt64' FROM dt64test WHERE dt_column = materialize(toDateTime64('2020-01-13 13:37:00', 3));
+
+SELECT 'dt64 >= const dt' FROM dt64test WHERE dt64_column >= toDateTime('2020-01-13 13:37:00');
+SELECT 'dt64 >= dt' FROM dt64test WHERE dt64_column >= materialize(toDateTime('2020-01-13 13:37:00'));
+SELECT 'dt >= const dt64' FROM dt64test WHERE dt_column >= toDateTime64('2020-01-13 13:37:00', 3);
+SELECT 'dt >= dt64' FROM dt64test WHERE dt_column >= materialize(toDateTime64('2020-01-13 13:37:00', 3));
+
+SELECT 'dt64 > const dt' FROM dt64test WHERE dt64_column > toDateTime('2020-01-13 13:37:00');
+SELECT 'dt64 > dt' FROM dt64test WHERE dt64_column > materialize(toDateTime('2020-01-13 13:37:00'));
+SELECT 'dt > const dt64' FROM dt64test WHERE dt_column > toDateTime64('2020-01-13 13:37:00', 3);
+SELECT 'dt > dt64' FROM dt64test WHERE dt_column > materialize(toDateTime64('2020-01-13 13:37:00', 3));
+
+SELECT 'dt64 != const dt' FROM dt64test WHERE dt64_column != toDateTime('2020-01-13 13:37:00');
+SELECT 'dt64 != dt' FROM dt64test WHERE dt64_column != materialize(toDateTime('2020-01-13 13:37:00'));
+SELECT 'dt != const dt64' FROM dt64test WHERE dt_column != toDateTime64('2020-01-13 13:37:00', 3);
+SELECT 'dt != dt64' FROM dt64test WHERE dt_column != materialize(toDateTime64('2020-01-13 13:37:00', 3));


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed using const `DateTime` value vs `DateTime64` column in WHERE.
...

Closes: #19078