### PR TITLE
Concurrent merges with priorities

### DIFF
--- a/src/Storages/MergeTree/MergeExecutor.cpp
+++ b/src/Storages/MergeTree/MergeExecutor.cpp
@@ -1,0 +1,65 @@
+#include "Storages/MergeTree/MergeExecutor.h"
+
+namespace DB
+{
+
+ConcurrentMergeExecutor::ConcurrentMergeExecutor(size_t size_) : pool(size_)
+{
+    for (size_t i = 0; i < size_; ++i) 
+        pool.scheduleOrThrow([this]() { threadFunction(); } );
+}
+
+
+ConcurrentMergeExecutor::~ConcurrentMergeExecutor()
+{
+    {
+        std::lock_guard lock(mutex);
+        force_stop = true;
+        has_tasks.notify_all();
+    }
+    pool.wait();
+}
+
+
+void ConcurrentMergeExecutor::schedule(MergeTaskPtr task)
+{
+    std::lock_guard lock(mutex);
+    tasks.push(std::move(task));
+    has_tasks.notify_one();
+}
+
+
+void ConcurrentMergeExecutor::threadFunction()
+    {
+        while (true)
+        {
+            MergeTaskPtr task;
+            {
+                std::unique_lock lock(mutex);
+                has_tasks.wait(lock, [&]() { return force_stop || !tasks.empty(); });
+
+                if (force_stop)
+                    return;
+
+                task = tasks.top();
+                tasks.pop();
+            }
+
+            try
+            {
+                if (task->execute())
+                {
+                    std::lock_guard lock(mutex);
+                    tasks.push(task);
+                    continue;
+                }
+                task->signalDone();
+            } catch (...)
+            {
+                task->setException(std::current_exception());
+            }
+        }
+    }
+
+
+}

--- a/src/Storages/MergeTree/MergeExecutor.h
+++ b/src/Storages/MergeTree/MergeExecutor.h
@@ -1,0 +1,225 @@
+#pragma once
+
+#include <Poco/Event.h>
+
+#include "DataStreams/IBlockInputStream.h"
+#include "DataStreams/IBlockOutputStream.h"
+#include "Storages/MergeTree/MergeAlgorithm.h"
+
+#include <Common/ThreadPool.h>
+
+#include <functional>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
+enum class MergeTaskState : uint8_t
+{
+    NEED_PREPARE,
+    NEED_EXECUTE,
+    NEED_FINISH
+};
+
+
+class MergeTask
+{
+public:
+    using IsCancelledCallback = std::function<bool()>;
+    using UpdateForBlockCallback = std::function<void(const Block &)>;
+
+    MergeTask(BlockInputStreamPtr merged_stream_, BlockOutputStreamPtr to_,
+        IsCancelledCallback is_cancelled_, UpdateForBlockCallback update_for_block_)
+        : is_cancelled(std::move(is_cancelled_))
+        , update_for_block(std::move(update_for_block_))
+        , merged_stream(merged_stream_)
+        , to(to_)
+    {
+
+    }
+
+    void wait()
+    {
+        is_done.wait();
+
+        if (exception)
+        {
+            std::rethrow_exception(exception);
+        }
+    }
+
+    void signalDone() 
+    {
+        is_done.set();
+    }
+
+    void setException(std::exception_ptr exception_)
+    {
+        exception = exception_;
+        is_done.set();
+    }
+
+    /// Returns true if need execute again
+    bool execute()
+    {
+        switch (state)
+        {
+            case MergeTaskState::NEED_PREPARE:
+            {
+                merged_stream->readPrefix();
+                to->writePrefix();
+
+                state = MergeTaskState::NEED_EXECUTE;
+                return true;
+            }
+            case MergeTaskState::NEED_EXECUTE:
+            {
+                if (executeForBlock())
+                    return true;
+
+                state = MergeTaskState::NEED_FINISH;
+                [[fallthrough]];
+            }
+            case MergeTaskState::NEED_FINISH:
+            {
+                merged_stream->readSuffix();
+                merged_stream.reset();
+                return false;
+            }
+        }
+    }
+
+    bool operator< (const MergeTask & rhs) const
+    {
+        return priority < rhs.priority;
+    }
+
+private:
+
+    /// Returns true if need to execute again
+    bool executeForBlock()
+    {
+        Block block;
+        if (!is_cancelled() && (block = merged_stream->read()))
+        {
+            to->write(block);
+            update_for_block(block);
+            return true;
+        }
+        return false;
+    }
+
+
+    IsCancelledCallback is_cancelled;
+    UpdateForBlockCallback update_for_block;
+
+
+    MergeTaskState state;
+    BlockInputStreamPtr merged_stream;
+    BlockOutputStreamPtr to;
+    std::exception_ptr exception;
+    Poco::Event is_done;
+
+    int priority = 0;
+};
+
+
+using MergeTaskPtr = std::shared_ptr<MergeTask>;
+
+
+class MergeTaskPtrComparator
+{
+public:
+    bool operator()(MergeTaskPtr lhs, MergeTaskPtr rhs) 
+    {
+        return (*lhs) < (*rhs);
+    }
+};
+
+
+class InlineMergeExecutor
+{
+public:
+    static void schedule(MergeTaskPtr task)
+    {
+        while (task->execute()) {}
+        task->signalDone();
+    }
+};
+
+
+
+class ConcurrentMergeExecutor
+{
+public:
+
+    explicit ConcurrentMergeExecutor(size_t size_) : pool(size_)
+    {
+        for (size_t i = 0; i < size_; ++i) 
+            pool.scheduleOrThrow([this]() { threadFunction(); } );
+    }
+
+    ~ConcurrentMergeExecutor()
+    {
+        {
+            std::lock_guard lock(mutex);
+            force_stop = true;
+            has_tasks.notify_all();
+        }
+        pool.wait();
+    }
+
+    void schedule(MergeTaskPtr task)
+    {
+        std::lock_guard lock(mutex);
+        tasks.push(std::move(task));
+    }
+
+private:
+
+    void threadFunction()
+    {
+        while (true)
+        {
+            MergeTaskPtr task;
+            {
+                std::unique_lock lock(mutex);
+                has_tasks.wait(lock, [&]() { return force_stop || !tasks.empty(); });
+
+                if (force_stop)
+                    return;
+
+                task = tasks.top();
+                tasks.pop();
+            }
+
+            try
+            {
+                if (task->execute())
+                {
+                    std::lock_guard lock(mutex);
+                    tasks.push(task);
+                    continue;
+                }
+                task->signalDone();
+            } catch (...)
+            {
+                task->setException(std::current_exception());
+            }
+        }
+    }
+
+    ThreadPool pool;
+
+    bool force_stop{false};
+
+    std::mutex mutex;
+    std::condition_variable has_tasks;
+    std::priority_queue<MergeTaskPtr, std::vector<MergeTaskPtr>, MergeTaskPtrComparator> tasks;
+};
+
+}

--- a/src/Storages/MergeTree/MergeExecutor.h
+++ b/src/Storages/MergeTree/MergeExecutor.h
@@ -128,7 +128,7 @@ private:
     UpdateForBlockCallback update_for_block;
 
 
-    MergeTaskState state;
+    MergeTaskState state{MergeTaskState::NEED_PREPARE};
     BlockInputStreamPtr merged_stream;
     BlockOutputStreamPtr to;
     std::exception_ptr exception;

--- a/src/Storages/MergeTree/MergeExecutor.h
+++ b/src/Storages/MergeTree/MergeExecutor.h
@@ -95,6 +95,7 @@ public:
                 return false;
             }
         }
+        return false;
     }
 
     bool operator> (const MergeTask & rhs) const

--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
@@ -968,7 +968,7 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataMergerMutator::mergePartsToTempor
         }
     };
 
-    auto task = std::make_shared<MergeTask>(merged_stream, to, is_cancelled, update_for_block);
+    auto task = std::make_shared<MergeTask>(merged_stream, to, is_cancelled, update_for_block, /*priority=*/new_data_part->getBytesOnDisk());
     merge_executor.schedule(task);
     task->wait();
 

--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
@@ -945,10 +945,10 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataMergerMutator::mergePartsToTempor
     size_t rows_written = 0;
     const size_t initial_reservation = space_reservation ? space_reservation->getSize() : 0;
 
-    auto is_cancelled = [&]() { return merges_blocker.isCancelled()
+    auto is_cancelled = [&]() mutable { return merges_blocker.isCancelled()
         || (need_remove_expired_values && ttl_merges_blocker.isCancelled()); };
 
-    auto update_for_block = [&] (const Block & block) 
+    auto update_for_block = [&] (const Block & block) mutable
     {
         rows_written += block.rows();
 

--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
@@ -67,14 +67,9 @@ public:
     MergeTreeDataMergerMutator(MergeTreeData & data_, size_t background_pool_size);
 
     /** Get maximum total size of parts to do merge, at current moment of time.
-      * It depends on number of free threads in background_pool and amount of free space in disk.
+      * It depends on an amount of free space in disk.
       */
     UInt64 getMaxSourcePartsSizeForMerge() const;
-
-    /** For explicitly passed size of pool and number of used tasks.
-      * This method could be used to calculate threshold depending on number of tasks in replication queue.
-      */
-    UInt64 getMaxSourcePartsSizeForMerge(size_t pool_size, size_t pool_used) const;
 
     /** Get maximum total size of parts to do mutation, at current moment of time.
       * It depends only on amount of free space in disk.

--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
@@ -8,6 +8,7 @@
 #include <Storages/MergeTree/TTLMergeSelector.h>
 #include <Storages/MergeTree/MergeAlgorithm.h>
 #include <Storages/MergeTree/MergeType.h>
+#include <Storages/MergeTree/MergeExecutor.h>
 #include <Storages/MergeTree/IMergedBlockOutputStream.h>
 
 
@@ -296,6 +297,8 @@ private:
 private:
     MergeTreeData & data;
     const size_t background_pool_size;
+
+    ConcurrentMergeExecutor merge_executor{2};
 
     Poco::Logger * log;
 

--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
@@ -298,7 +298,7 @@ private:
     MergeTreeData & data;
     const size_t background_pool_size;
 
-    ConcurrentMergeExecutor merge_executor{4};
+    std::unique_ptr<IMergeExecutor> merge_executor;
 
     Poco::Logger * log;
 

--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
@@ -298,7 +298,7 @@ private:
     MergeTreeData & data;
     const size_t background_pool_size;
 
-    ConcurrentMergeExecutor merge_executor{2};
+    ConcurrentMergeExecutor merge_executor{4};
 
     Poco::Logger * log;
 

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -87,17 +87,6 @@ void MergeTreeSettings::sanityCheck(const Settings & query_settings) const
             query_settings.background_pool_size);
     }
 
-    if (number_of_free_entries_in_pool_to_lower_max_size_of_merge > query_settings.background_pool_size)
-    {
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "The value of 'number_of_free_entries_in_pool_to_lower_max_size_of_merge' setting"
-            " ({}) (default values are defined in <merge_tree> section of config.xml"
-            " or the value can be specified per table in SETTINGS section of CREATE TABLE query)"
-            " is greater than the value of 'background_pool_size'"
-            " ({}) (the value is defined in users.xml for default profile)."
-            " This indicates incorrect configuration because the maximum size of merge will be always lowered.",
-            number_of_free_entries_in_pool_to_lower_max_size_of_merge,
-            query_settings.background_pool_size);
-    }
 
     // The min_index_granularity_bytes value is 1024 b and index_granularity_bytes is 10 mb by default.
     // If index_granularity_bytes is not disabled i.e > 0 b, then always ensure that it's greater than

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -41,6 +41,7 @@ struct Settings;
     M(UInt64, max_replicated_merges_in_queue, 16, "How many tasks of merging and mutating parts are allowed simultaneously in ReplicatedMergeTree queue.", 0) \
     M(UInt64, max_replicated_mutations_in_queue, 8, "How many tasks of mutating parts are allowed simultaneously in ReplicatedMergeTree queue.", 0) \
     M(UInt64, max_replicated_merges_with_ttl_in_queue, 1, "How many tasks of merging parts with TTL are allowed simultaneously in ReplicatedMergeTree queue.", 0) \
+    M(UInt64, max_threads_for_concurrent_merge, 4, "How many threads will execute merges concurrently (block by block, small merges take priority). 0 means concurrent merges are disabled.", 0) \
     M(UInt64, number_of_free_entries_in_pool_to_lower_max_size_of_merge, 8, "When there is less than specified number of free entries in pool (or replicated queue), start to lower maximum size of merge to process (or to put in queue). This is to allow small merges to process - not filling the pool with long running merges.", 0) \
     M(UInt64, number_of_free_entries_in_pool_to_execute_mutation, 10, "When there is less than specified number of free entries in pool, do not execute part mutations. This is to leave free threads for regular merges and avoid \"Too many parts\"", 0) \
     M(UInt64, max_number_of_merges_with_ttl_in_pool, 2, "When there is more than specified number of merges with TTL entries in pool, do not assign new merge with TTL. This is to leave free threads for regular merges and avoid \"Too many parts\"", 0) \

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -38,7 +38,7 @@ struct Settings;
     M(UInt64, merge_max_block_size, DEFAULT_MERGE_BLOCK_SIZE, "How many rows in blocks should be formed for merge operations.", 0) \
     M(UInt64, max_bytes_to_merge_at_max_space_in_pool, 150ULL * 1024 * 1024 * 1024, "Maximum in total size of parts to merge, when there are maximum free threads in background pool (or entries in replication queue).", 0) \
     M(UInt64, max_bytes_to_merge_at_min_space_in_pool, 1024 * 1024, "Maximum in total size of parts to merge, when there are minimum free threads in background pool (or entries in replication queue).", 0) \
-    M(UInt64, max_replicated_merges_in_queue, 16, "How many tasks of merging and mutating parts are allowed simultaneously in ReplicatedMergeTree queue.", 0) \
+    M(UInt64, max_replicated_merges_in_queue, 32, "How many tasks of merging and mutating parts are allowed simultaneously in ReplicatedMergeTree queue.", 0) \
     M(UInt64, max_replicated_mutations_in_queue, 8, "How many tasks of mutating parts are allowed simultaneously in ReplicatedMergeTree queue.", 0) \
     M(UInt64, max_replicated_merges_with_ttl_in_queue, 1, "How many tasks of merging parts with TTL are allowed simultaneously in ReplicatedMergeTree queue.", 0) \
     M(UInt64, max_threads_for_concurrent_merge, 16, "How many threads will execute merges concurrently (block by block, small merges take priority). 0 means concurrent merges are disabled.", 0) \

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -42,7 +42,6 @@ struct Settings;
     M(UInt64, max_replicated_mutations_in_queue, 8, "How many tasks of mutating parts are allowed simultaneously in ReplicatedMergeTree queue.", 0) \
     M(UInt64, max_replicated_merges_with_ttl_in_queue, 1, "How many tasks of merging parts with TTL are allowed simultaneously in ReplicatedMergeTree queue.", 0) \
     M(UInt64, max_threads_for_concurrent_merge, 4, "How many threads will execute merges concurrently (block by block, small merges take priority). 0 means concurrent merges are disabled.", 0) \
-    M(UInt64, number_of_free_entries_in_pool_to_lower_max_size_of_merge, 8, "When there is less than specified number of free entries in pool (or replicated queue), start to lower maximum size of merge to process (or to put in queue). This is to allow small merges to process - not filling the pool with long running merges.", 0) \
     M(UInt64, number_of_free_entries_in_pool_to_execute_mutation, 10, "When there is less than specified number of free entries in pool, do not execute part mutations. This is to leave free threads for regular merges and avoid \"Too many parts\"", 0) \
     M(UInt64, max_number_of_merges_with_ttl_in_pool, 2, "When there is more than specified number of merges with TTL entries in pool, do not assign new merge with TTL. This is to leave free threads for regular merges and avoid \"Too many parts\"", 0) \
     M(Seconds, old_parts_lifetime, 8 * 60, "How many seconds to keep obsolete parts.", 0) \

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -41,7 +41,7 @@ struct Settings;
     M(UInt64, max_replicated_merges_in_queue, 16, "How many tasks of merging and mutating parts are allowed simultaneously in ReplicatedMergeTree queue.", 0) \
     M(UInt64, max_replicated_mutations_in_queue, 8, "How many tasks of mutating parts are allowed simultaneously in ReplicatedMergeTree queue.", 0) \
     M(UInt64, max_replicated_merges_with_ttl_in_queue, 1, "How many tasks of merging parts with TTL are allowed simultaneously in ReplicatedMergeTree queue.", 0) \
-    M(UInt64, max_threads_for_concurrent_merge, 4, "How many threads will execute merges concurrently (block by block, small merges take priority). 0 means concurrent merges are disabled.", 0) \
+    M(UInt64, max_threads_for_concurrent_merge, 16, "How many threads will execute merges concurrently (block by block, small merges take priority). 0 means concurrent merges are disabled.", 0) \
     M(UInt64, number_of_free_entries_in_pool_to_execute_mutation, 10, "When there is less than specified number of free entries in pool, do not execute part mutations. This is to leave free threads for regular merges and avoid \"Too many parts\"", 0) \
     M(UInt64, max_number_of_merges_with_ttl_in_pool, 2, "When there is more than specified number of merges with TTL entries in pool, do not assign new merge with TTL. This is to leave free threads for regular merges and avoid \"Too many parts\"", 0) \
     M(Seconds, old_parts_lifetime, 8 * 60, "How many seconds to keep obsolete parts.", 0) \

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -3114,9 +3114,7 @@ void StorageReplicatedMergeTree::mergeSelectingTask()
         }
         else
         {
-            UInt64 max_source_parts_size_for_merge = merger_mutator.getMaxSourcePartsSizeForMerge(
-                storage_settings_ptr->max_replicated_merges_in_queue, merges_and_mutations_sum);
-
+            UInt64 max_source_parts_size_for_merge = merger_mutator.getMaxSourcePartsSizeForMerge();
             UInt64 max_source_part_size_for_mutation = merger_mutator.getMaxSourcePartSizeForMutation();
 
             bool merge_with_ttl_allowed = merges_and_mutations_queued.merges_with_ttl < storage_settings_ptr->max_replicated_merges_with_ttl_in_queue &&

--- a/tests/integration/test_polymorphic_parts/test.py
+++ b/tests/integration/test_polymorphic_parts/test.py
@@ -387,8 +387,6 @@ def test_in_memory_wal_rotate(start_cluster):
         node11.exec_in_container(['bash', '-c', 'test -f /var/lib/clickhouse/data/default/restore_table/wal_{0}_{0}.bin'.format(i)])
 
     for node in [node11, node12]:
-        node.query(
-            "ALTER TABLE restore_table MODIFY SETTING number_of_free_entries_in_pool_to_lower_max_size_of_merge = 0")
         node.query("ALTER TABLE restore_table MODIFY SETTING max_bytes_to_merge_at_max_space_in_pool = 10000000")
 
     assert_eq_with_retry(node11, "OPTIMIZE TABLE restore_table FINAL SETTINGS optimize_throw_if_noop = 1", "")

--- a/tests/queries/0_stateless/01419_merge_tree_settings_sanity_check.sql
+++ b/tests/queries/0_stateless/01419_merge_tree_settings_sanity_check.sql
@@ -19,17 +19,6 @@ CREATE TABLE mytable_local
 )
 ENGINE = MergeTree()
 PARTITION BY toYYYYMM(eventday)
-ORDER BY (eventday, user_id)
-SETTINGS number_of_free_entries_in_pool_to_lower_max_size_of_merge = 100; -- { serverError 36 }
-
-CREATE TABLE mytable_local
-(
-    created          DateTime,
-    eventday         Date,
-    user_id          UInt32
-)
-ENGINE = MergeTree()
-PARTITION BY toYYYYMM(eventday)
 ORDER BY (eventday, user_id);
 
 ALTER TABLE mytable_local MODIFY SETTING number_of_free_entries_in_pool_to_execute_mutation = 100;  -- { serverError 36 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added an ability to prefer small merges during their execution. This will help to avoid `Too many parts` error.  Deleted setting `number_of_free_entries_in_pool_to_lower_max_size_of_merge` #22381