### PR TITLE
Fix bug for explain pipeline

### DIFF
--- a/src/Processors/Pipe.cpp
+++ b/src/Processors/Pipe.cpp
@@ -834,7 +834,7 @@ void Pipe::transform(const Transformer & transformer)
 
     if (collected_processors)
     {
-        for (const auto & processor : processors)
+        for (const auto & processor : new_processors)
             collected_processors->emplace_back(processor);
     }
 

--- a/tests/queries/0_stateless/01861_explain_pipeline.reference
+++ b/tests/queries/0_stateless/01861_explain_pipeline.reference
@@ -1,0 +1,31 @@
+(Expression)
+ExpressionTransform
+  (SettingQuotaAndLimits)
+    (Expression)
+    ExpressionTransform
+      (MergingFinal)
+      ReplacingSorted 2 → 1
+        (Expression)
+        ExpressionTransform × 2
+          (ReadFromMergeTree)
+          MergeTree × 2 0 → 1
+0	0
+1	1
+2	2
+3	3
+4	4
+5	5
+6	6
+(Expression)
+ExpressionTransform × 2
+  (SettingQuotaAndLimits)
+    (Expression)
+    ExpressionTransform × 2
+      (MergingFinal)
+      ReplacingSorted × 2 2 → 1
+        Copy × 2 1 → 2
+          AddingSelector × 2
+            (Expression)
+            ExpressionTransform × 2
+              (ReadFromMergeTree)
+              MergeTree × 2 0 → 1

--- a/tests/queries/0_stateless/01861_explain_pipeline.sql
+++ b/tests/queries/0_stateless/01861_explain_pipeline.sql
@@ -1,0 +1,10 @@
+DROP TABLE IF EXISTS test;
+CREATE TABLE test(a Int, b Int) Engine=ReplacingMergeTree order by a;
+INSERT INTO test select number, number from numbers(5);
+INSERT INTO test select number, number from numbers(5,2);
+set max_threads =1;
+explain pipeline select * from test final;
+select * from test final;
+set max_threads =2;
+explain pipeline select * from test final;
+DROP TABLE test;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Bug: explain pipeline with` select xxx final `shows wrong pipeline:
```
dell123 :) explain pipeline select z from prewhere_move_select_final final;

┌─explain───────────────────────────────┐
│ (Expression)                          │
│ ExpressionTransform × 16              │
│   (SettingQuotaAndLimits)             │
│     (Expression)                      │
│     ExpressionTransform × 16          │
│       (MergingFinal)                  │
│       AddingSelector × 2              │
│         ExpressionTransform × 2       │
│           MergeTree × 2 0 → 1         │
│             AddingSelector × 2        │
│               (Expression)            │
│               ExpressionTransform × 2 │
│                 (ReadFromMergeTree)   │
│                 MergeTree × 2 0 → 1   │
└───────────────────────────────────────┘
```
After fix: 
```
dell123 :) select version()

┌─version()─┐
│ 21.6.1.1  │
└───────────┘

dell123 :) explain pipeline select z from prewhere_move_select_final final;

┌─explain─────────────────────────────┐
│ (Expression)                        │
│ ExpressionTransform × 16            │
│   (SettingQuotaAndLimits)           │
│     (Expression)                    │
│     ExpressionTransform × 16        │
│       (MergingFinal)                │
│       ReplacingSorted × 16 2 → 1    │
│         Copy × 2 1 → 16             │
│           AddingSelector × 2        │
│             (Expression)            │
│             ExpressionTransform × 2 │
│               (ReadFromMergeTree)   │
│               MergeTree × 2 0 → 1   │
└─────────────────────────────────────┘


```


Detailed description / Documentation draft:
