### PR TITLE
Set readonly mode if restarting thread failed to activate replica

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -67,12 +67,12 @@ void ReplicatedMergeTreeRestartingThread::run()
             }
             else
             {
-                if (!readonly_mode_was_set)
+                if (storage.getZooKeeper()->expired())
                 {
                     LOG_WARNING(log, "ZooKeeper session has expired. Switching to a new session.");
                     setReadonly();
                 }
-                else
+                else if (readonly_mode_was_set)
                 {
                     LOG_WARNING(log, "Table was in readonly mode. Will try to activate it.");
                 }

--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -57,7 +57,7 @@ void ReplicatedMergeTreeRestartingThread::run()
 
     try
     {
-        if (first_time || storage.getZooKeeper()->expired())
+        if (first_time || readonly_mode_was_set || storage.getZooKeeper()->expired())
         {
             startup_completed = false;
 
@@ -67,15 +67,15 @@ void ReplicatedMergeTreeRestartingThread::run()
             }
             else
             {
-                LOG_WARNING(log, "ZooKeeper session has expired. Switching to a new session.");
-
-                bool old_val = false;
-                if (storage.is_readonly.compare_exchange_strong(old_val, true))
+                if (!readonly_mode_was_set)
                 {
-                    incr_readonly = true;
-                    CurrentMetrics::add(CurrentMetrics::ReadonlyReplica);
+                    LOG_WARNING(log, "ZooKeeper session has expired. Switching to a new session.");
+                    setReadonly();
                 }
-
+                else
+                {
+                    LOG_WARNING(log, "Table was in readonly mode. Will try to activate it.");
+                }
                 partialShutdown();
             }
 
@@ -98,8 +98,14 @@ void ReplicatedMergeTreeRestartingThread::run()
 
                 if (!need_stop && !tryStartup())
                 {
+                    /// We couldn't startup replication. Table must be readonly.
+                    /// Otherwise it can have partially initialized queue and other
+                    /// strange parts of state.
+                    setReadonly();
+
                     if (first_time)
                         storage.startup_event.set();
+
                     task->scheduleAfter(retry_period_ms);
                     return;
                 }
@@ -116,7 +122,7 @@ void ReplicatedMergeTreeRestartingThread::run()
             bool old_val = true;
             if (storage.is_readonly.compare_exchange_strong(old_val, false))
             {
-                incr_readonly = false;
+                readonly_mode_was_set = false;
                 CurrentMetrics::sub(CurrentMetrics::ReadonlyReplica);
             }
 
@@ -125,6 +131,8 @@ void ReplicatedMergeTreeRestartingThread::run()
     }
     catch (...)
     {
+        /// We couldn't activate table let's set it into readonly mode
+        setReadonly();
         storage.startup_event.set();
         tryLogCurrentException(log, __PRETTY_FUNCTION__);
     }
@@ -184,7 +192,7 @@ bool ReplicatedMergeTreeRestartingThread::tryStartup()
         }
         catch (const Coordination::Exception & e)
         {
-            LOG_ERROR(log, "Couldn't start replication: {}. {}", e.what(), DB::getCurrentExceptionMessage(true));
+            LOG_ERROR(log, "Couldn't start replication (table will be in readonly mode): {}. {}", e.what(), DB::getCurrentExceptionMessage(true));
             return false;
         }
         catch (const Exception & e)
@@ -192,7 +200,7 @@ bool ReplicatedMergeTreeRestartingThread::tryStartup()
             if (e.code() != ErrorCodes::REPLICA_IS_ALREADY_ACTIVE)
                 throw;
 
-            LOG_ERROR(log, "Couldn't start replication: {}. {}", e.what(), DB::getCurrentExceptionMessage(true));
+            LOG_ERROR(log, "Couldn't start replication (table will be in readonly mode): {}. {}", e.what(), DB::getCurrentExceptionMessage(true));
             return false;
         }
     }
@@ -356,14 +364,24 @@ void ReplicatedMergeTreeRestartingThread::shutdown()
     LOG_TRACE(log, "Restarting thread finished");
 
     /// For detach table query, we should reset the ReadonlyReplica metric.
-    if (incr_readonly)
+    if (readonly_mode_was_set)
     {
         CurrentMetrics::sub(CurrentMetrics::ReadonlyReplica);
-        incr_readonly = false;
+        readonly_mode_was_set = false;
     }
 
     /// Stop other tasks.
     partialShutdown();
+}
+
+void ReplicatedMergeTreeRestartingThread::setReadonly()
+{
+    bool old_val = false;
+    if (storage.is_readonly.compare_exchange_strong(old_val, true))
+    {
+        readonly_mode_was_set = true;
+        CurrentMetrics::add(CurrentMetrics::ReadonlyReplica);
+    }
 }
 
 }

--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.h
@@ -37,7 +37,7 @@ private:
     std::atomic<bool> need_stop {false};
 
     // We need it besides `storage.is_readonly`, because `shutdown()` may be called many times, that way `storage.is_readonly` will not change.
-    bool incr_readonly = false;
+    bool readonly_mode_was_set = false;
 
     /// The random data we wrote into `/replicas/me/is_active`.
     String active_node_identifier;
@@ -62,6 +62,9 @@ private:
     void updateQuorumIfWeHavePart();
 
     void partialShutdown();
+
+    /// Set readonly mode for table
+    void setReadonly();
 };
 
 

--- a/tests/integration/helpers/test_tools.py
+++ b/tests/integration/helpers/test_tools.py
@@ -80,3 +80,16 @@ def assert_logs_contain_with_retry(instance, substring, retry_count=20, sleep_ti
             time.sleep(sleep_time)
     else:
         raise AssertionError("'{}' not found in logs".format(substring))
+
+def exec_query_with_retry(instance, query, retry_count=40, sleep_time=0.5, settings={}):
+    exception = None
+    for _ in range(retry_count):
+        try:
+            instance.query(query, timeout=30, settings=settings)
+            break
+        except Exception as ex:
+            exception = ex
+            print("Failed to execute query '", query, "' on instance", instance.name, "will retry")
+            time.sleep(sleep_time)
+    else:
+        raise exception

--- a/tests/integration/test_ttl_replicated/test.py
+++ b/tests/integration/test_ttl_replicated/test.py
@@ -392,11 +392,33 @@ def test_ttl_compatibility(started_cluster, node_left, node_right, num_run):
     
     time.sleep(5) # Wait for TTL
 
-    node_right.query("OPTIMIZE TABLE test_ttl_delete FINAL")
+    # after restart table can be in readonly mode
+    exception = None
+    for _ in range(40):
+        try:
+            node_right.query("OPTIMIZE TABLE test_ttl_delete FINAL")
+            break
+        except Exception as ex:
+            print("Cannot optimaze table on node", node_right.name, "exception", ex)
+            time.sleep(0.5)
+            exception = ex
+    else:
+        raise ex
+
     node_right.query("OPTIMIZE TABLE test_ttl_group_by FINAL")
     node_right.query("OPTIMIZE TABLE test_ttl_where FINAL")
 
-    node_left.query("SYSTEM SYNC REPLICA test_ttl_delete", timeout=20)
+    for _ in range(40):
+        try:
+            node_left.query("SYSTEM SYNC REPLICA test_ttl_delete", timeout=20)
+            break
+        except Exception as ex:
+            print("Cannot sync replica table on node", node_left.name, "exception", ex)
+            time.sleep(0.5)
+            exception = ex
+    else:
+        raise ex
+
     node_left.query("SYSTEM SYNC REPLICA test_ttl_group_by", timeout=20)
     node_left.query("SYSTEM SYNC REPLICA test_ttl_where", timeout=20)
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix a rare bug that could lead to a partially initialized table that can serve write requests (insert/alter/so on). Now such tables will be in readonly mode.
