### PR TITLE
Add thread_name in system.stack_trace

### DIFF
--- a/src/Storages/System/StorageSystemStackTrace.cpp
+++ b/src/Storages/System/StorageSystemStackTrace.cpp
@@ -221,7 +221,8 @@ void StorageSystemStackTrace::fillData(MutableColumns & res_columns, ContextPtr,
         String thread_name;
         if (std::filesystem::exists(thread_name_path))
         {
-            ReadBufferFromFile comm(thread_name_path.string());
+            constexpr size_t comm_buf_size = 32; /// More than enough for thread name
+            ReadBufferFromFile comm(thread_name_path.string(), comm_buf_size);
             readStringUntilEOF(thread_name, comm);
             comm.close();
         }

--- a/src/Storages/System/StorageSystemStackTrace.cpp
+++ b/src/Storages/System/StorageSystemStackTrace.cpp
@@ -13,6 +13,7 @@
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeArray.h>
 #include <IO/ReadHelpers.h>
+#include <IO/ReadBufferFromFile.h>
 #include <Common/PipeFDs.h>
 #include <Common/CurrentThread.h>
 #include <common/getThreadId.h>
@@ -176,6 +177,7 @@ NamesAndTypesList StorageSystemStackTrace::getNamesAndTypes()
 {
     return
     {
+        { "thread_name", std::make_shared<DataTypeString>() },
         { "thread_id", std::make_shared<DataTypeUInt64>() },
         { "query_id", std::make_shared<DataTypeString>() },
         { "trace", std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt64>()) }
@@ -213,6 +215,17 @@ void StorageSystemStackTrace::fillData(MutableColumns & res_columns, ContextPtr,
             throwFromErrno("Cannot send signal with sigqueue", ErrorCodes::CANNOT_SIGQUEUE);
         }
 
+        std::filesystem::path thread_name_path = it->path();
+        thread_name_path.append("comm");
+
+        String thread_name;
+        if (std::filesystem::exists(thread_name_path))
+        {
+            ReadBufferFromFile comm(thread_name_path.string());
+            readStringUntilEOF(thread_name, comm);
+            comm.close();
+        }
+
         /// Just in case we will wait for pipe with timeout. In case signal didn't get processed.
 
         if (wait(100) && sig_value.sival_int == data_ready_num.load(std::memory_order_acquire))
@@ -225,9 +238,10 @@ void StorageSystemStackTrace::fillData(MutableColumns & res_columns, ContextPtr,
             for (size_t i = stack_trace_offset; i < stack_trace_size; ++i)
                 arr.emplace_back(reinterpret_cast<intptr_t>(stack_trace.getFramePointers()[i]));
 
-            res_columns[0]->insert(tid);
-            res_columns[1]->insertData(query_id_data, query_id_size);
-            res_columns[2]->insert(arr);
+            res_columns[0]->insert(thread_name);
+            res_columns[1]->insert(tid);
+            res_columns[2]->insertData(query_id_data, query_id_size);
+            res_columns[3]->insert(arr);
         }
         else
         {
@@ -235,9 +249,10 @@ void StorageSystemStackTrace::fillData(MutableColumns & res_columns, ContextPtr,
 
             /// Cannot obtain a stack trace. But create a record in result nevertheless.
 
-            res_columns[0]->insert(tid);
-            res_columns[1]->insertDefault();
+            res_columns[0]->insert(thread_name);
+            res_columns[1]->insert(tid);
             res_columns[2]->insertDefault();
+            res_columns[3]->insertDefault();
         }
 
         /// Signed integer overflow is undefined behavior in both C and C++. However, according to


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add `thread_name` column in `system.stack_trace`. This closes #23256.

Detailed description / Documentation draft:

add thread_name column in system.stack_trace
https://github.com/ClickHouse/ClickHouse/issues/23256

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
