### PR TITLE
TestReadAfterAIO: Use the current path instead of /tmp for temporal files

### DIFF
--- a/src/IO/tests/gtest_aio_seek_back_after_eof.cpp
+++ b/src/IO/tests/gtest_aio_seek_back_after_eof.cpp
@@ -82,7 +82,9 @@ TEST(ReadBufferAIOTest, TestReadAfterAIO)
 
     if (file_path[0] != '/')
     {
-        std::filesystem::remove_all(file_path.substr(0, file_path.size() - 4));
+        const size_t last_slash = file_path.rfind('/');
+        const std::string temp_dir = file_path.substr(0, last_slash);
+        std::filesystem::remove_all(temp_dir);
     }
 }
 

--- a/src/IO/tests/gtest_aio_seek_back_after_eof.cpp
+++ b/src/IO/tests/gtest_aio_seek_back_after_eof.cpp
@@ -6,6 +6,7 @@
 #include <unistd.h>
 #include <IO/ReadBufferAIO.h>
 #include <Common/randomSeed.h>
+#include <filesystem>
 #include <fstream>
 #include <string>
 
@@ -14,7 +15,7 @@ namespace
 {
 std::string createTmpFileForEOFtest()
 {
-    char pattern[] = "/tmp/fileXXXXXX";
+    char pattern[] = "./EOFtestFolderXXXXXX";
     if (char * dir = ::mkdtemp(pattern); dir)
     {
         return std::string(dir) + "/foo";
@@ -78,6 +79,11 @@ TEST(ReadBufferAIOTest, TestReadAfterAIO)
     size_t read_after_eof_big = testbuf.read(repeatdata.data(), repeatdata.size());
     EXPECT_EQ(read_after_eof_big, data.length());
     EXPECT_TRUE(testbuf.eof());
+
+    if (file_path[0] != '/')
+    {
+        std::filesystem::remove_all(file_path.substr(0, file_path.size() - 4));
+    }
 }
 
 #endif


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

Detailed description / Documentation draft:

`/tmp` might be mounted as tmpfs (default in ArchLinux) which is incompatible with using [O_DIRECT] (at least under [Linux](https://github.com/ClickHouse/ClickHouse/blob/1ea637d996715d2a047f8cd209b478e946bdbfb0/src/IO/ReadBufferAIO.cpp#L52) (https://lore.kernel.org/lkml/459D290B.1040703@tmr.com/t/)), making the test fail:

```
[ RUN      ] ReadBufferAIOTest.TestReadAfterAIO
unknown file: Failure
C++ exception with description "Cannot open file /tmp/filei6ZsCa/foo, errno: 22, strerror: Invalid argument" thrown in the test body.
[  FAILED  ] ReadBufferAIOTest.TestReadAfterAIO (0 ms)
```

Instead create the tmp folder in the current path and delete it at the end.