### PR TITLE
Fix a few trailing whitespaces in output

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -2278,7 +2278,7 @@ private:
         size_t elapsed_ns = watch.elapsed();
         if (elapsed_ns)
             std::cout << " (" << formatReadableQuantity(progress.read_rows * 1000000000.0 / elapsed_ns) << " rows/s., "
-                      << formatReadableSizeWithDecimalSuffix(progress.read_bytes * 1000000000.0 / elapsed_ns) << "/s.) ";
+                      << formatReadableSizeWithDecimalSuffix(progress.read_bytes * 1000000000.0 / elapsed_ns) << "/s.)";
         else
             std::cout << ". ";
     }

--- a/src/Processors/Formats/Impl/MarkdownRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/MarkdownRowOutputFormat.cpp
@@ -17,7 +17,10 @@ void MarkdownRowOutputFormat::writePrefix()
     for (size_t i = 0; i < columns; ++i)
     {
         writeEscapedString(header.safeGetByPosition(i).name, out);
-        writeCString(" | ", out);
+        if (i == (columns - 1))
+            writeCString(" |", out);
+        else
+            writeCString(" | ", out);
     }
     writeCString("\n|", out);
     String left_alignment = ":-|";

--- a/tests/queries/0_stateless/01231_markdown_format.reference
+++ b/tests/queries/0_stateless/01231_markdown_format.reference
@@ -1,4 +1,4 @@
-| id | name | array | nullable | low_cardinality | decimal | 
+| id | name | array | nullable | low_cardinality | decimal |
 |-:|:-|:-|:-|:-|-:|
 | 1 | name1 | [1,2,3] | Some long string | name1 | 1.110000 |
 | 2 | name2 | [4,5,60000] | \N | Another long string | 222.222222 |


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)