### PR TITLE
Fix abnormal termination when hdfs is unreachable

### DIFF
--- a/src/Storages/HDFS/StorageHDFS.cpp
+++ b/src/Storages/HDFS/StorageHDFS.cpp
@@ -202,9 +202,18 @@ public:
 
     void writeSuffix() override
     {
-        writer->writeSuffix();
-        writer->flush();
-        write_buf->sync();
+        try
+        {
+            writer->writeSuffix();
+            writer->flush();
+            write_buf->sync();
+            write_buf->finalize();
+        }
+        catch (...)
+        {
+            writer.reset();
+            throw;
+        }
     }
 
 private:

--- a/src/Storages/HDFS/WriteBufferFromHDFS.h
+++ b/src/Storages/HDFS/WriteBufferFromHDFS.h
@@ -17,17 +17,19 @@ class WriteBufferFromHDFS : public BufferWithOwnMemory<WriteBuffer>
 {
     struct WriteBufferFromHDFSImpl;
     std::unique_ptr<WriteBufferFromHDFSImpl> impl;
+
 public:
     WriteBufferFromHDFS(const std::string & hdfs_name_, const Poco::Util::AbstractConfiguration &, size_t buf_size_ = DBMS_DEFAULT_BUFFER_SIZE);
-    WriteBufferFromHDFS(WriteBufferFromHDFS &&) = default;
 
-    void nextImpl() override;
+    WriteBufferFromHDFS(WriteBufferFromHDFS &&) = default;
 
     ~WriteBufferFromHDFS() override;
 
+    void nextImpl() override;
+
     void sync() override;
 
-    void finalize() override;
+    void finalize() final override;
 };
 }
 #endif

--- a/src/Storages/HDFS/WriteBufferFromHDFS.h
+++ b/src/Storages/HDFS/WriteBufferFromHDFS.h
@@ -13,7 +13,7 @@ namespace DB
 /** Accepts HDFS path to file and opens it.
  * Closes file by himself (thus "owns" a file descriptor).
  */
-class WriteBufferFromHDFS : public BufferWithOwnMemory<WriteBuffer>
+class WriteBufferFromHDFS final : public BufferWithOwnMemory<WriteBuffer>
 {
     struct WriteBufferFromHDFSImpl;
     std::unique_ptr<WriteBufferFromHDFSImpl> impl;
@@ -29,7 +29,7 @@ public:
 
     void sync() override;
 
-    void finalize() final override;
+    void finalize() override;
 };
 }
 #endif

--- a/src/Storages/HDFS/WriteBufferFromHDFS.h
+++ b/src/Storages/HDFS/WriteBufferFromHDFS.h
@@ -26,6 +26,8 @@ public:
     ~WriteBufferFromHDFS() override;
 
     void sync() override;
+
+    void finalize() override;
 };
 }
 #endif


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix abnormal server termination due to hdfs becoming not accessible during query execution. Closes https://github.com/ClickHouse/ClickHouse/issues/24117.

Detailed description / Documentation draft:
In https://github.com/ClickHouse/ClickHouse/issues/24117 hdfs entered safemode due to unreachable namenodes and the query crashed the server - can be reproduced by starting a long query and while it is not yet finished executing inside hdfs the command:  `hdfs dfsadmin -safemode enter`.  ([stacktrace](https://paste.yandex-team.ru/4462532/text)).