### PR TITLE
Gcc11 compatibility

### DIFF
--- a/contrib/re2_st/re2_transform.cmake
+++ b/contrib/re2_st/re2_transform.cmake
@@ -1,7 +1,7 @@
 file (READ ${SOURCE_FILENAME} CONTENT)
 string (REGEX REPLACE "using re2::RE2;" "" CONTENT "${CONTENT}")
 string (REGEX REPLACE "using re2::LazyRE2;" "" CONTENT "${CONTENT}")
-string (REGEX REPLACE "namespace re2" "namespace re2_st" CONTENT "${CONTENT}")
+string (REGEX REPLACE "namespace re2 {" "namespace re2_st {" CONTENT "${CONTENT}")
 string (REGEX REPLACE "re2::" "re2_st::" CONTENT "${CONTENT}")
 string (REGEX REPLACE "\"re2/" "\"re2_st/" CONTENT "${CONTENT}")
 string (REGEX REPLACE "(.\\*?_H)" "\\1_ST" CONTENT "${CONTENT}")

--- a/src/Common/tests/gtest_sensitive_data_masker.cpp
+++ b/src/Common/tests/gtest_sensitive_data_masker.cpp
@@ -223,7 +223,7 @@ TEST(Common, SensitiveDataMasker)
     {
         EXPECT_EQ(
             std::string(e.message()),
-            "SensitiveDataMasker: cannot compile re2: ())(, error: missing ): ())(. Look at https://github.com/google/re2/wiki/Syntax for reference.: while adding query masking rule 'test'."
+            "SensitiveDataMasker: cannot compile re2: ())(, error: unexpected ): ())(. Look at https://github.com/google/re2/wiki/Syntax for reference.: while adding query masking rule 'test'."
         );
         EXPECT_EQ(e.code(), DB::ErrorCodes::CANNOT_COMPILE_REGEXP);
     }

--- a/src/IO/HashingWriteBuffer.h
+++ b/src/IO/HashingWriteBuffer.h
@@ -17,7 +17,7 @@ class IHashingBuffer : public BufferWithOwnMemory<Buffer>
 public:
     using uint128 = CityHash_v1_0_2::uint128;
 
-    IHashingBuffer<Buffer>(size_t block_size_ = DBMS_DEFAULT_HASHING_BLOCK_SIZE)
+    IHashingBuffer(size_t block_size_ = DBMS_DEFAULT_HASHING_BLOCK_SIZE)
         : BufferWithOwnMemory<Buffer>(block_size_), block_pos(0), block_size(block_size_), state(0, 0)
     {
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Performance Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Update `re2` library. Performance of regular expressions matching is improved. Also this PR adds compatibility with gcc-11.


Detailed description / Documentation draft:

* Updates re2 submodule and refines the replacement to avoid replacing re2::re2_internal namespace.
* Fixes an error in IHashingBuffer constructor declaration

There are other warnings in the build but they might have to do with my flags so I'm not addressing them for now