### PR TITLE
Fix official website documents error about grant-drop section

### DIFF
--- a/docs/en/sql-reference/statements/grant.md
+++ b/docs/en/sql-reference/statements/grant.md
@@ -316,7 +316,7 @@ Allows executing [CREATE](../../sql-reference/statements/create/index.md) and [A
 
 Allows executing [DROP](../../sql-reference/statements/misc.md#drop) and [DETACH](../../sql-reference/statements/misc.md#detach) queries according to the following hierarchy of privileges:
 
--   `DROP`. Level:
+-   `DROP`. Level: `GROUP`
     -   `DROP DATABASE`. Level: `DATABASE`
     -   `DROP TABLE`. Level: `TABLE`
     -   `DROP VIEW`. Level: `VIEW`


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category :

- Documentation (changelog entry is not required)

Just fix typo error