### PR TITLE
Use memmove in PODArray::insert to handle memory overlapping.

### DIFF
--- a/src/Common/PODArray.h
+++ b/src/Common/PODArray.h
@@ -513,7 +513,7 @@ public:
         insertPrepare(from_begin, from_end);
 
         if (unlikely(bytes_to_move))
-            memcpy(this->c_end + bytes_to_copy - bytes_to_move, this->c_end - bytes_to_move, bytes_to_move);
+            memmove(this->c_end + bytes_to_copy - bytes_to_move, this->c_end - bytes_to_move, bytes_to_move);
 
         memcpy(this->c_end - bytes_to_move, reinterpret_cast<const void *>(&*from_begin), bytes_to_copy);
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

PODArray::insert will move a bunch of data forward to leave space for new items. The new memory range can be overlapping with the old memory range when bytes_to_move is larger than bytes_to_copy and use of memcpy here has undefined behavior.

Changelog category (leave one):
- Not for changelog


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Use memmove in PODArray::insert to handle memory overlapping.