### PR TITLE
Fix mutation fail of StorageMemory

### DIFF
--- a/src/Storages/StorageMemory.cpp
+++ b/src/Storages/StorageMemory.cpp
@@ -262,7 +262,14 @@ void StorageMemory::mutate(const MutationCommands & commands, ContextPtr context
     auto metadata_snapshot = getInMemoryMetadataPtr();
     auto storage = getStorageID();
     auto storage_ptr = DatabaseCatalog::instance().getTable(storage, context);
-    auto interpreter = std::make_unique<MutationsInterpreter>(storage_ptr, metadata_snapshot, commands, context, true);
+
+    /// When max_threads > 1, the order of returning blocks is uncentain,
+    /// which will lead to inconsistency after updateBlockData.
+    auto new_context = Context::createCopy(context);
+    new_context->setSetting("max_streams_to_max_threads_ratio", 1);
+    new_context->setSetting("max_threads", 1);
+
+    auto interpreter = std::make_unique<MutationsInterpreter>(storage_ptr, metadata_snapshot, commands, new_context, true);
     auto in = interpreter->execute();
 
     in->readPrefix();

--- a/tests/queries/0_stateless/01867_fix_storage_memory_mutation.sql
+++ b/tests/queries/0_stateless/01867_fix_storage_memory_mutation.sql
@@ -1,0 +1,32 @@
+DROP TABLE IF EXISTS mem_test;
+
+CREATE TABLE mem_test
+(
+    `a` Int64,
+    `b` Int64
+)
+ENGINE = Memory;
+
+SET max_block_size = 3;
+
+INSERT INTO mem_test SELECT
+    number,
+    number
+FROM numbers(100);
+
+ALTER TABLE mem_test
+    UPDATE a = 0 WHERE b = 99;
+ALTER TABLE mem_test
+    UPDATE a = 0 WHERE b = 99;
+ALTER TABLE mem_test
+    UPDATE a = 0 WHERE b = 99;
+ALTER TABLE mem_test
+    UPDATE a = 0 WHERE b = 99;
+ALTER TABLE mem_test
+    UPDATE a = 0 WHERE b = 99;
+
+SELECT *
+FROM mem_test
+FORMAT Null;
+
+DROP TABLE mem_test;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Set `max_threads = 1` to fix mutation fail of StorageMemory. Closes #24274.

Detailed description / Documentation draft:

When `max_threads > 1`, the returning order of blocks is uncentain, leads to mutation fail.