### PR TITLE
Fix isLocalAddress() (ifa_addr maybe NULL)

### DIFF
--- a/src/Common/isLocalAddress.cpp
+++ b/src/Common/isLocalAddress.cpp
@@ -36,6 +36,10 @@ struct NetworkInterfaces
         ifaddrs * iface;
         for (iface = ifaddr; iface != nullptr; iface = iface->ifa_next)
         {
+            /// Point-to-point (VPN) addresses may have NULL ifa_addr
+            if (!iface->ifa_addr)
+                continue;
+
             auto family = iface->ifa_addr->sa_family;
             std::optional<Poco::Net::IPAddress> interface_address;
             switch (family)


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix isLocalAddress() (ifa_addr maybe NULL)

Detailed description:
I have the problem with tun0, that creates points-to-point address, so
getifaddrs() returns NULL ifa_addr for one of addrs for tun0.
You can check this, using this simple example - [1].

  [1]: https://gist.github.com/azat/cc667d145bc74215c40cdbb69f38189b

*Note, marked as not for changelog since original PR (#24203) does not landed to any stable release yet.*

Cc: @alesapin 