### PR TITLE
Fix bad test for Enum hints

### DIFF
--- a/src/Common/NamePrompter.h
+++ b/src/Common/NamePrompter.h
@@ -90,17 +90,16 @@ private:
     }
 };
 
-template <size_t MaxNumHints, class Self>
+
+template <size_t MaxNumHints, typename Self>
 class IHints
 {
 public:
-
     virtual std::vector<String> getAllRegisteredNames() const = 0;
 
     std::vector<String> getHints(const String & name) const
     {
-        static const auto registered_names = getAllRegisteredNames();
-        return prompter.getHints(name, registered_names);
+        return prompter.getHints(name, getAllRegisteredNames());
     }
 
     virtual ~IHints() = default;

--- a/src/DataTypes/EnumValues.cpp
+++ b/src/DataTypes/EnumValues.cpp
@@ -67,7 +67,7 @@ T EnumValues<T>::getValue(StringRef field_name, bool try_treat_as_id) const
                 return x;
         }
         auto hints = this->getHints(field_name.toString());
-        auto hints_string = !hints.empty() ? ", may be you meant: " + toString(hints) : "";
+        auto hints_string = !hints.empty() ? ", maybe you meant: " + toString(hints) : "";
         throw Exception{"Unknown element '" + field_name.toString() + "' for enum" + hints_string, ErrorCodes::BAD_ARGUMENTS};
     }
     return it->getMapped();

--- a/tests/queries/0_stateless/01852_hints_enum_name.sh
+++ b/tests/queries/0_stateless/01852_hints_enum_name.sh
@@ -4,5 +4,5 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-$CLICKHOUSE_CLIENT --query="SELECT CAST('Helo', 'Enum(\'Hello\' = 1, \'World\' = 2)')" 2>&1 | grep -q "may be you meant: \['Hello'\]" && echo 'OK' || echo 'FAIL'
+$CLICKHOUSE_CLIENT --query="SELECT CAST('Helo' AS Enum('Hello' = 1, 'World' = 2))" 2>&1 | grep -q -F "maybe you meant: ['Hello']" && echo 'OK' || echo 'FAIL'
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


1. `may be` -> `maybe`
2. Add `-F` flag to `grep` (you should always use it unless you really need a regular expression).
3. Change `CAST(x, 'Type')` to `CAST(x AS Type)` for simplicity.
4. Remove extra escaping.
5. Actually fix error in the code.

This closes #24310.