### PR TITLE
Recognize more addresses as local

### DIFF
--- a/src/Common/isLocalAddress.cpp
+++ b/src/Common/isLocalAddress.cpp
@@ -1,6 +1,7 @@
 #include <Common/isLocalAddress.h>
 
 #include <ifaddrs.h>
+#include <array>
 #include <cstring>
 #include <optional>
 #include <common/types.h>
@@ -95,17 +96,13 @@ bool isLocalAddress(const Poco::Net::IPAddress & address)
     {
         if (address.family() == Poco::Net::AddressFamily::IPv4)
         {
-            union
-            {
-                UInt32 word;
-                unsigned char digits[4];
-            } digits_union;
+            using Digits = std::array<UInt8, 4>;
+            Digits digits = unalignedLoad<Digits>(address.addr());  /// The address is located in memory in big endian form.
 
-            digits_union.word = ntohl(unalignedLoad<UInt32>(address.addr()));
-            if (digits_union.digits[0] == 127
-                && digits_union.digits[1] <= 1
-                && digits_union.digits[2] <= 1
-                && digits_union.digits[3] <= 1)
+            if (digits[0] == 127
+                && digits[1] <= 1
+                && digits[2] <= 1
+                && digits[3] <= 1)
             {
                 return true;
             }

--- a/src/Common/isLocalAddress.cpp
+++ b/src/Common/isLocalAddress.cpp
@@ -1,7 +1,6 @@
 #include <Common/isLocalAddress.h>
 
 #include <ifaddrs.h>
-#include <array>
 #include <cstring>
 #include <optional>
 #include <common/types.h>

--- a/src/Common/isLocalAddress.cpp
+++ b/src/Common/isLocalAddress.cpp
@@ -5,7 +5,6 @@
 #include <cstring>
 #include <optional>
 #include <common/types.h>
-#include <common/unaligned.h>
 #include <Common/Exception.h>
 #include <Poco/Net/IPAddress.h>
 #include <Poco/Net/SocketAddress.h>
@@ -96,8 +95,8 @@ bool isLocalAddress(const Poco::Net::IPAddress & address)
     {
         if (address.family() == Poco::Net::AddressFamily::IPv4)
         {
-            using Digits = std::array<UInt8, 4>;
-            Digits digits = unalignedLoad<Digits>(address.addr());  /// The address is located in memory in big endian form.
+            /// The address is located in memory in big endian form (network byte order).
+            const unsigned char * digits = static_cast<const unsigned char *>(address.addr());
 
             if (digits[0] == 127
                 && digits[1] <= 1

--- a/src/Common/tests/gtest_local_address.cpp
+++ b/src/Common/tests/gtest_local_address.cpp
@@ -35,6 +35,6 @@ TEST(LocalAddress, Localhost)
     EXPECT_FALSE(DB::isLocalAddress(Poco::Net::IPAddress{"::"}));
     EXPECT_FALSE(DB::isLocalAddress(Poco::Net::IPAddress{"::2"}));
 
-    /// The the comment in the implementation of isLocalAddress.
+    /// See the comment in the implementation of isLocalAddress.
     EXPECT_FALSE(DB::isLocalAddress(Poco::Net::IPAddress{"127.0.0.2"}));
 }

--- a/src/Common/tests/gtest_local_address.cpp
+++ b/src/Common/tests/gtest_local_address.cpp
@@ -11,9 +11,30 @@ TEST(LocalAddress, SmokeTest)
     std::string address_str;
     DB::readString(address_str, cmd->out);
     cmd->wait();
-    std::cerr << "Got Address:" << address_str << std::endl;
+    std::cerr << "Got Address: " << address_str << std::endl;
 
     Poco::Net::IPAddress address(address_str);
 
     EXPECT_TRUE(DB::isLocalAddress(address));
+}
+
+TEST(LocalAddress, Localhost)
+{
+    EXPECT_TRUE(DB::isLocalAddress(Poco::Net::IPAddress{"127.0.0.1"}));
+    EXPECT_TRUE(DB::isLocalAddress(Poco::Net::IPAddress{"127.0.1.1"}));
+    EXPECT_TRUE(DB::isLocalAddress(Poco::Net::IPAddress{"127.1.1.1"}));
+    EXPECT_TRUE(DB::isLocalAddress(Poco::Net::IPAddress{"127.1.0.1"}));
+    EXPECT_TRUE(DB::isLocalAddress(Poco::Net::IPAddress{"127.1.0.0"}));
+    EXPECT_TRUE(DB::isLocalAddress(Poco::Net::IPAddress{"::1"}));
+
+    /// Make sure we don't mess with the byte order.
+    EXPECT_FALSE(DB::isLocalAddress(Poco::Net::IPAddress{"1.0.0.127"}));
+    EXPECT_FALSE(DB::isLocalAddress(Poco::Net::IPAddress{"1.1.1.127"}));
+
+    EXPECT_FALSE(DB::isLocalAddress(Poco::Net::IPAddress{"0.0.0.0"}));
+    EXPECT_FALSE(DB::isLocalAddress(Poco::Net::IPAddress{"::"}));
+    EXPECT_FALSE(DB::isLocalAddress(Poco::Net::IPAddress{"::2"}));
+
+    /// The the comment in the implementation of isLocalAddress.
+    EXPECT_FALSE(DB::isLocalAddress(Poco::Net::IPAddress{"127.0.0.2"}));
 }


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Recognize IPv4 addresses like `127.0.1.1` as local. This is controversial and closes #23504. Michael Filimonov will test this feature.