### PR TITLE
Fix IPv6 addresses resolving

### DIFF
--- a/src/Common/DNSResolver.cpp
+++ b/src/Common/DNSResolver.cpp
@@ -87,9 +87,20 @@ static DNSResolver::IPAddresses resolveIPAddressImpl(const std::string & host)
 {
     Poco::Net::IPAddress ip;
 
-    /// NOTE: Poco::Net::DNS::resolveOne(host) doesn't work for IP addresses like 127.0.0.2
-    if (Poco::Net::IPAddress::tryParse(host, ip))
-        return DNSResolver::IPAddresses(1, ip);
+    /// NOTE:
+    /// - Poco::Net::DNS::resolveOne(host) doesn't work for IP addresses like 127.0.0.2
+    /// - Poco::Net::IPAddress::tryParse() expect hex string for IPv6 (w/o brackets)
+    if (host.starts_with('['))
+    {
+        assert(host.ends_with(']'));
+        if (Poco::Net::IPAddress::tryParse(host.substr(1, host.size() - 2), ip))
+            return DNSResolver::IPAddresses(1, ip);
+    }
+    else
+    {
+        if (Poco::Net::IPAddress::tryParse(host, ip))
+            return DNSResolver::IPAddresses(1, ip);
+    }
 
     /// Family: AF_UNSPEC
     /// AI_ALL is required for checking if client is allowed to connect from an address

--- a/src/Common/parseAddress.cpp
+++ b/src/Common/parseAddress.cpp
@@ -39,13 +39,16 @@ std::pair<std::string, UInt16> parseAddress(const std::string & str, UInt16 defa
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
                 "Illegal port prefix passed to function parseAddress: {}", port);
 
+        ++port;
+
         UInt16 port_number;
-        if (!tryParse<UInt16>(port_number, port + 1))
+        ReadBufferFromMemory port_buf(port, end - port);
+        if (!tryReadText<UInt16>(port_number, port_buf) || !port_buf.eof())
         {
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                "Illegal port passed to function parseAddress: {}", port + 1);
+                "Illegal port passed to function parseAddress: {}", port);
         }
-        return { std::string(begin, port), port_number };
+        return { std::string(begin, port - 1), port_number };
     }
     else if (default_port)
     {

--- a/src/Common/parseAddress.cpp
+++ b/src/Common/parseAddress.cpp
@@ -28,13 +28,17 @@ std::pair<std::string, UInt16> parseAddress(const std::string & str, UInt16 defa
             throw Exception("Illegal address passed to function parseAddress: "
                 "the address begins with opening square bracket, but no closing square bracket found", ErrorCodes::BAD_ARGUMENTS);
 
-        port = find_first_symbols<':'>(closing_square_bracket + 1, end);
+        port = closing_square_bracket + 1;
     }
     else
         port = find_first_symbols<':'>(begin, end);
 
     if (port != end)
     {
+        if (*port != ':')
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                "Illegal port prefix passed to function parseAddress: {}", port);
+
         UInt16 port_number;
         if (!tryParse<UInt16>(port_number, port + 1))
         {

--- a/src/Common/parseAddress.cpp
+++ b/src/Common/parseAddress.cpp
@@ -35,7 +35,12 @@ std::pair<std::string, UInt16> parseAddress(const std::string & str, UInt16 defa
 
     if (port != end)
     {
-        UInt16 port_number = parse<UInt16>(port + 1);
+        UInt16 port_number;
+        if (!tryParse<UInt16>(port_number, port + 1))
+        {
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                "Illegal port passed to function parseAddress: {}", port + 1);
+        }
         return { std::string(begin, port), port_number };
     }
     else if (default_port)

--- a/tests/queries/0_stateless/01880_remote_ipv6.sql
+++ b/tests/queries/0_stateless/01880_remote_ipv6.sql
@@ -1,0 +1,8 @@
+SET connections_with_failover_max_tries=0;
+
+SELECT * FROM remote('[::1]', system.one) FORMAT Null;
+SELECT * FROM remote('[::1]:9000', system.one) FORMAT Null;
+
+SELECT * FROM remote('[::1', system.one) FORMAT Null; -- { serverError 36 }
+SELECT * FROM remote('::1]', system.one) FORMAT Null; -- { serverError 519 }
+SELECT * FROM remote('::1', system.one) FORMAT Null; -- { serverError 519 }

--- a/tests/queries/0_stateless/01880_remote_ipv6.sql
+++ b/tests/queries/0_stateless/01880_remote_ipv6.sql
@@ -4,9 +4,9 @@ SELECT * FROM remote('[::1]', system.one) FORMAT Null;
 SELECT * FROM remote('[::1]:9000', system.one) FORMAT Null;
 
 SELECT * FROM remote('[::1', system.one) FORMAT Null; -- { serverError 36 }
-SELECT * FROM remote('::1]', system.one) FORMAT Null; -- { serverError 519 }
-SELECT * FROM remote('::1', system.one) FORMAT Null; -- { serverError 519 }
+SELECT * FROM remote('::1]', system.one) FORMAT Null; -- { serverError 36 }
+SELECT * FROM remote('::1', system.one) FORMAT Null; -- { serverError 36 }
 
 SELECT * FROM remote('[::1][::1]', system.one) FORMAT Null; -- { serverError 36 }
 SELECT * FROM remote('[::1][::1', system.one) FORMAT Null; -- { serverError 36 }
-SELECT * FROM remote('[::1]::1]', system.one) FORMAT Null; -- { serverError 519 }
+SELECT * FROM remote('[::1]::1]', system.one) FORMAT Null; -- { serverError 36 }

--- a/tests/queries/0_stateless/01880_remote_ipv6.sql
+++ b/tests/queries/0_stateless/01880_remote_ipv6.sql
@@ -6,3 +6,7 @@ SELECT * FROM remote('[::1]:9000', system.one) FORMAT Null;
 SELECT * FROM remote('[::1', system.one) FORMAT Null; -- { serverError 36 }
 SELECT * FROM remote('::1]', system.one) FORMAT Null; -- { serverError 519 }
 SELECT * FROM remote('::1', system.one) FORMAT Null; -- { serverError 519 }
+
+SELECT * FROM remote('[::1][::1]', system.one) FORMAT Null; -- { serverError 36 }
+SELECT * FROM remote('[::1][::1', system.one) FORMAT Null; -- { serverError 36 }
+SELECT * FROM remote('[::1]::1]', system.one) FORMAT Null; -- { serverError 519 }

--- a/tests/queries/0_stateless/arcadia_skip_list.txt
+++ b/tests/queries/0_stateless/arcadia_skip_list.txt
@@ -236,3 +236,4 @@
 01801_s3_distributed
 01833_test_collation_alvarotuso
 01850_dist_INSERT_preserve_error
+01880_remote_ipv6


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix IPv6 addresses resolving (i.e. fixes `select * from remote('[::1]', system.one)`)