### PR TITLE
Turn into readonly instead of terminate()

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -606,7 +606,8 @@ int32_t ReplicatedMergeTreeQueue::pullLogsToQueue(zkutil::ZooKeeperPtr zookeeper
                 tryLogCurrentException(log);
                 /// If it fails, the data in RAM is incorrect. In order to avoid possible further corruption of data in ZK, we will kill ourselves.
                 /// This is possible only if there is an unknown logical error.
-                std::terminate();
+                /// Turn into readonly mode instead of std::terminate();
+                storage.restarting_thread.setReadonly();
             }
 
             if (!copied_entries.empty())

--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -384,4 +384,11 @@ void ReplicatedMergeTreeRestartingThread::setReadonly()
     }
 }
 
+void ReplicatedMergeTreeRestartingThread::explicitSetReadonly()
+{
+    setReadonly();
+    force_readonly = true;
+    storage.getZooKeeper()->finalize();
+}
+
 }

--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.h
@@ -30,6 +30,9 @@ public:
 
     void shutdown();
 
+    /// Set readonly mode for table and do not reconnect automatically.
+    void explicitSetReadonly();
+
 private:
     StorageReplicatedMergeTree & storage;
     String log_name;
@@ -38,6 +41,9 @@ private:
 
     // We need it besides `storage.is_readonly`, because `shutdown()` may be called many times, that way `storage.is_readonly` will not change.
     bool readonly_mode_was_set = false;
+
+    // When explicit set to be readonly, do not try to reconnect.
+    bool force_readonly = false;
 
     /// The random data we wrote into `/replicas/me/is_active`.
     String active_node_identifier;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Do not kill ourself when logical error happens in some replicated table. Turn into read only instead.

Detailed description / Documentation draft:

.