### PR TITLE
Fix flaky 01033_quota_dcl

### DIFF
--- a/tests/queries/0_stateless/01033_quota_dcl.reference
+++ b/tests/queries/0_stateless/01033_quota_dcl.reference
@@ -1,2 +1,1 @@
-default
 CREATE QUOTA default KEYED BY user_name FOR INTERVAL 1 hour TRACKING ONLY TO default, readonly

--- a/tests/queries/0_stateless/01033_quota_dcl.sql
+++ b/tests/queries/0_stateless/01033_quota_dcl.sql
@@ -1,2 +1,1 @@
-SHOW QUOTAS;
 SHOW CREATE QUOTA default;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

I don't think that we'll a lot of coverage, but now it should work concurrently: https://clickhouse-test-reports.s3.yandex.net/24316/7ae047a7217f8cc1126945c012be001c56f324ba/functional_stateless_tests_(address).html#fail1