### PR TITLE
Support for multiple includes in XML based configuration

### DIFF
--- a/docs/en/operations/configuration-files.md
+++ b/docs/en/operations/configuration-files.md
@@ -22,6 +22,23 @@ Some settings specified in the main configuration file can be overridden in othe
 
 The config can also define “substitutions”. If an element has the `incl` attribute, the corresponding substitution from the file will be used as the value. By default, the path to the file with substitutions is `/etc/metrika.xml`. This can be changed in the [include_from](../operations/server-configuration-parameters/settings.md#server_configuration_parameters-include_from) element in the server config. The substitution values are specified in `/yandex/substitution_name` elements in this file. If a substitution specified in `incl` does not exist, it is recorded in the log. To prevent ClickHouse from logging missing substitutions, specify the `optional="true"` attribute (for example, settings for [macros](../operations/server-configuration-parameters/settings.md)).
 
+If you want to replace an entire element with a substitution use `include` as element name.
+
+XML substitution example:
+
+```xml
+<yandex>
+    <!-- Appends XML subtree found at `/profiles-in-zookeeper` ZK path to `<profiles>` element. -->
+    <profiles from_zk="/profiles-in-zookeeper" />
+
+    <users>
+        <!-- Replaces `include` element with hte subtree found at `/users-in-zookeeper` ZK path. -->
+        <include from_zk="/users-in-zookeeper" />
+        <include from_zk="/other-users-in-zookeeper" />
+    </users>
+</yandex>
+```
+
 Substitutions can also be performed from ZooKeeper. To do this, specify the attribute `from_zk = "/path/to/node"`. The element value is replaced with the contents of the node at `/path/to/node` in ZooKeeper. You can also put an entire XML subtree on the ZooKeeper node and it will be fully inserted into the source element.
 
 ## User Settings {#user-settings}
@@ -31,6 +48,8 @@ The `config.xml` file can specify a separate config with user settings, profiles
 Users configuration can be splitted into separate files similar to `config.xml` and `config.d/`.
 Directory name is defined as `users_config` setting without `.xml` postfix concatenated with `.d`.
 Directory `users.d` is used by default, as `users_config` defaults to `users.xml`.
+
+Note that configuration files are first merged taking into account [Override](#override) settings and includes are processed after that.
 
 ## XML example {#example}
 

--- a/src/Common/Config/ConfigProcessor.cpp
+++ b/src/Common/Config/ConfigProcessor.cpp
@@ -296,10 +296,10 @@ void ConfigProcessor::doIncludesRecursive(
     {
         const auto * subst = attributes->getNamedItem(attr_name);
         attr_nodes[attr_name] = subst;
-        substs_count += static_cast<size_t>(subst == nullptr);
+        substs_count += static_cast<size_t>(subst != nullptr);
     }
 
-    if (substs_count < SUBSTITUTION_ATTRS.size() - 1) /// only one substitution is allowed
+    if (substs_count > 1) /// only one substitution is allowed
         throw Poco::Exception("several substitutions attributes set for element <" + node->nodeName() + ">");
 
     /// Replace the original contents, not add to it.

--- a/src/Common/Config/ConfigProcessor.cpp
+++ b/src/Common/Config/ConfigProcessor.cpp
@@ -302,6 +302,14 @@ void ConfigProcessor::doIncludesRecursive(
     if (substs_count > 1) /// only one substitution is allowed
         throw Poco::Exception("several substitutions attributes set for element <" + node->nodeName() + ">");
 
+    if (node->nodeName() == "include")
+    {
+        if (node->hasChildNodes())
+            throw Poco::Exception("<include> element must have no children");
+        if (substs_count == 0)
+            throw Poco::Exception("no substitution attributes set for element <include>, must have one");
+    }
+
     /// Replace the original contents, not add to it.
     bool replace = attributes->getNamedItem("replace");
 

--- a/src/Common/Config/ConfigProcessor.cpp
+++ b/src/Common/Config/ConfigProcessor.cpp
@@ -318,7 +318,12 @@ void ConfigProcessor::doIncludesRecursive(
             else if (throw_on_bad_incl)
                 throw Poco::Exception(error_msg + name);
             else
+            {
+                if (node->nodeName() == "include")
+                    node->parentNode()->removeChild(node);
+
                 LOG_WARNING(log, "{}{}", error_msg, name);
+            }
         }
         else
         {

--- a/tests/integration/test_config_substitutions/configs/config_env.xml
+++ b/tests/integration/test_config_substitutions/configs/config_env.xml
@@ -10,5 +10,8 @@
           <profile>default</profile>
           <quota>default</quota>
       </default>
+
+      <include incl="users_1" />
+      <include incl="users_2" />
   </users>
 </yandex>

--- a/tests/integration/test_config_substitutions/configs/config_incl.xml
+++ b/tests/integration/test_config_substitutions/configs/config_incl.xml
@@ -1,5 +1,5 @@
 <yandex>
-  <include_from>/etc/clickhouse-server/config.d/max_query_size.xml</include_from>
+  <include_from>/etc/clickhouse-server/config.d/include_from_source.xml</include_from>
   <profiles>
     <default>
         <max_query_size incl="mqs" />
@@ -11,5 +11,8 @@
           <profile>default</profile>
           <quota>default</quota>
       </default>
+
+      <include incl="users_1" />
+      <include incl="users_2" />
   </users>
 </yandex>

--- a/tests/integration/test_config_substitutions/configs/config_include_from_env.xml
+++ b/tests/integration/test_config_substitutions/configs/config_include_from_env.xml
@@ -11,5 +11,7 @@
           <profile>default</profile>
           <quota>default</quota>
       </default>
+
+      <include incl="node_does_not_exist" />
   </users>
 </yandex>

--- a/tests/integration/test_config_substitutions/configs/config_zk.xml
+++ b/tests/integration/test_config_substitutions/configs/config_zk.xml
@@ -10,5 +10,8 @@
           <profile>default</profile>
           <quota>default</quota>
       </default>
+
+      <include from_zk="/users_from_zk_1" />
+      <include from_zk="/users_from_zk_2" />
   </users>
 </yandex>

--- a/tests/integration/test_config_substitutions/configs/include_from_source.xml
+++ b/tests/integration/test_config_substitutions/configs/include_from_source.xml
@@ -1,0 +1,17 @@
+<yandex>
+    <mqs>99999</mqs>
+
+    <users_1>
+        <user_1>
+            <password></password>
+            <profile>default</profile>
+        </user_1>
+    </users_1>
+
+    <users_2>
+        <user_2>
+            <password></password>
+            <profile>default</profile>
+        </user_2>
+    </users_2>
+</yandex>

--- a/tests/integration/test_config_substitutions/configs/max_query_size.xml
+++ b/tests/integration/test_config_substitutions/configs/max_query_size.xml
@@ -1,3 +1,0 @@
-<yandex>
-  <mqs>99999</mqs>
-</yandex>

--- a/tests/integration/test_config_substitutions/test.py
+++ b/tests/integration/test_config_substitutions/test.py
@@ -8,11 +8,11 @@ node2 = cluster.add_instance('node2', user_configs=['configs/config_env.xml'],
                              env_variables={"MAX_QUERY_SIZE": "55555"})
 node3 = cluster.add_instance('node3', user_configs=['configs/config_zk.xml'], with_zookeeper=True)
 node4 = cluster.add_instance('node4', user_configs=['configs/config_incl.xml'],
-                             main_configs=['configs/max_query_size.xml'])  # include value 77777
+                             main_configs=['configs/include_from_source.xml'])  # include value 77777
 node5 = cluster.add_instance('node5', user_configs=['configs/config_allow_databases.xml'])
 node6 = cluster.add_instance('node6', user_configs=['configs/config_include_from_env.xml'],
-                             env_variables={"INCLUDE_FROM_ENV": "/etc/clickhouse-server/config.d/max_query_size.xml"},
-                             main_configs=['configs/max_query_size.xml'])
+                             env_variables={"INCLUDE_FROM_ENV": "/etc/clickhouse-server/config.d/include_from_source.xml"},
+                             main_configs=['configs/include_from_source.xml'])
 
 
 @pytest.fixture(scope="module")
@@ -40,6 +40,13 @@ def test_config(start_cluster):
 
 
 def test_include_config(start_cluster):
+    # <include incl="source tag" />
+    assert node4.query("select 1")
+    assert node4.query("select 1", user="user_1")
+    assert node4.query("select 1", user="user_2")
+
+    # <include from_zk="zk path />
+    assert node3.query("select 1")
     assert node3.query("select 1", user="user_1")
     assert node3.query("select 1", user="user_2")
 

--- a/tests/integration/test_config_substitutions/test.py
+++ b/tests/integration/test_config_substitutions/test.py
@@ -20,6 +20,8 @@ def start_cluster():
     try:
         def create_zk_roots(zk):
             zk.create(path="/setting/max_query_size", value=b"77777", makepath=True)
+            zk.create(path="/users_from_zk_1", value=b"<user_1><password></password><profile>default</profile></user_1>", makepath=True)
+            zk.create(path="/users_from_zk_2", value=b"<user_2><password></password><profile>default</profile></user_2>", makepath=True)
 
         cluster.add_zookeeper_startup_command(create_zk_roots)
 
@@ -35,6 +37,11 @@ def test_config(start_cluster):
     assert node3.query("select value from system.settings where name = 'max_query_size'") == "77777\n"
     assert node4.query("select value from system.settings where name = 'max_query_size'") == "99999\n"
     assert node6.query("select value from system.settings where name = 'max_query_size'") == "99999\n"
+
+
+def test_include_config(start_cluster):
+    assert node3.query("select 1", user="user_1")
+    assert node3.query("select 1", user="user_2")
 
 
 def test_allow_databases(start_cluster):


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support for multiple includes in configuration. It is possible to include users configuration, remote servers configuration from multiple sources. Simply place `<include />` element with `from_zk`, `from_env` or `incl` attribute and it will be replaced with the substitution.