### PR TITLE
Fix cli argument in clickhouse-server.init

### DIFF
--- a/debian/clickhouse-server.init
+++ b/debian/clickhouse-server.init
@@ -109,7 +109,7 @@ restart()
 
 forcestop()
 {
-    ${CLICKHOUSE_GENERIC_PROGRAM} stop --force --pid-path "${CLICKHOUSE_PIDDIR}"
+    ${CLICKHOUSE_GENERIC_PROGRAM} stop --force true --pid-path "${CLICKHOUSE_PIDDIR}"
 }
 
 

--- a/debian/clickhouse-server.init
+++ b/debian/clickhouse-server.init
@@ -109,7 +109,7 @@ restart()
 
 forcestop()
 {
-    ${CLICKHOUSE_GENERIC_PROGRAM} stop --force true --pid-path "${CLICKHOUSE_PIDDIR}"
+    ${CLICKHOUSE_GENERIC_PROGRAM} stop --force --pid-path "${CLICKHOUSE_PIDDIR}"
 }
 
 

--- a/programs/install/Install.cpp
+++ b/programs/install/Install.cpp
@@ -983,7 +983,7 @@ int mainEntryClickHouseStop(int argc, char ** argv)
     desc.add_options()
         ("help,h", "produce help message")
         ("pid-path", po::value<std::string>()->default_value("/var/run/clickhouse-server"), "directory for pid file")
-        ("force", po::value<bool>()->default_value(false), "Stop with KILL signal instead of TERM")
+        ("force", po::bool_switch(), "Stop with KILL signal instead of TERM")
     ;
 
     po::variables_map options;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)
