### PR TITLE
Speedup min / max aggregation function compilation

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionMax.cpp
+++ b/src/AggregateFunctions/AggregateFunctionMax.cpp
@@ -1,8 +1,5 @@
 #include <AggregateFunctions/AggregateFunctionFactory.h>
 #include <AggregateFunctions/HelpersMinMaxAny.h>
-#include <AggregateFunctions/FactoryHelpers.h>
-#include "registerAggregateFunctions.h"
-
 
 namespace DB
 {

--- a/src/AggregateFunctions/AggregateFunctionMin.cpp
+++ b/src/AggregateFunctions/AggregateFunctionMin.cpp
@@ -1,8 +1,5 @@
 #include <AggregateFunctions/AggregateFunctionFactory.h>
 #include <AggregateFunctions/HelpersMinMaxAny.h>
-#include <AggregateFunctions/FactoryHelpers.h>
-#include "registerAggregateFunctions.h"
-
 
 namespace DB
 {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:


Speed up compilation of MIN and MAX aggregation functions. Before the changes, AggregateFunctionMax.cpp and AggregateFunctionMin.cpp take 60-70 seconds each with clang to compile (~50 with gcc). After the changes it takes ~8 seconds each.

I've added a `NOLINT` comment to silence clang-tidy complaining about not using parentheses in the macros (which can't be used here).

Tested with clang 11.1.0 and gcc 11.1.0 (not a typo, they just so happen to be on the same version)