### PR TITLE
Show estimates for SELECT query

### DIFF
--- a/src/Interpreters/InterpreterExplainQuery.cpp
+++ b/src/Interpreters/InterpreterExplainQuery.cpp
@@ -305,7 +305,7 @@ BlockInputStreamPtr InterpreterExplainQuery::executeImpl()
     else if (kind == ASTExplainQuery::QueryEstimates)
     {
         if (!dynamic_cast<const ASTSelectWithUnionQuery *>(ast.getExplainedQuery().get()))
-            throw Exception("Only SELECT is supported for EXPLAIN query", ErrorCodes::INCORRECT_QUERY);
+            throw Exception("Only SELECT is supported for EXPLAIN ESTIMATES query", ErrorCodes::INCORRECT_QUERY);
 
         auto settings = checkAndGetSettings<QueryPlanSettings>(ast.getSettings());
         QueryPlan plan;

--- a/src/Interpreters/InterpreterExplainQuery.h
+++ b/src/Interpreters/InterpreterExplainQuery.h
@@ -2,7 +2,7 @@
 
 #include <Interpreters/IInterpreter.h>
 #include <Parsers/IAST_fwd.h>
-
+#include <Parsers/ASTExplainQuery.h>
 
 namespace DB
 {
@@ -15,7 +15,7 @@ public:
 
     BlockIO execute() override;
 
-    static Block getSampleBlock();
+    static Block getSampleBlock(const ASTExplainQuery::ExplainKind kind);
 
 private:
     ASTPtr query;

--- a/src/Parsers/ASTExplainQuery.h
+++ b/src/Parsers/ASTExplainQuery.h
@@ -17,6 +17,7 @@ public:
         AnalyzedSyntax, /// 'EXPLAIN SYNTAX SELECT ...'
         QueryPlan, /// 'EXPLAIN SELECT ...'
         QueryPipeline, /// 'EXPLAIN PIPELINE ...'
+        QueryEstimates, /// 'EXPLAIN ESTIMATES ...'
     };
 
     explicit ASTExplainQuery(ExplainKind kind_) : kind(kind_) {}
@@ -76,6 +77,7 @@ private:
             case AnalyzedSyntax: return "EXPLAIN SYNTAX";
             case QueryPlan: return "EXPLAIN";
             case QueryPipeline: return "EXPLAIN PIPELINE";
+            case QueryEstimates: return "EXPLAIN ESTIMATES";
         }
 
         __builtin_unreachable();

--- a/src/Parsers/ParserExplainQuery.cpp
+++ b/src/Parsers/ParserExplainQuery.cpp
@@ -19,6 +19,7 @@ bool ParserExplainQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
     ParserKeyword s_syntax("SYNTAX");
     ParserKeyword s_pipeline("PIPELINE");
     ParserKeyword s_plan("PLAN");
+    ParserKeyword s_estimates("ESTIMATES");
 
     if (s_explain.ignore(pos, expected))
     {
@@ -32,6 +33,8 @@ bool ParserExplainQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
             kind = ASTExplainQuery::ExplainKind::QueryPipeline;
         else if (s_plan.ignore(pos, expected))
             kind = ASTExplainQuery::ExplainKind::QueryPlan; //-V1048
+        else if (s_estimates.ignore(pos, expected))
+            kind = ASTExplainQuery::ExplainKind::QueryEstimates;
     }
     else
         return false;

--- a/src/Processors/QueryPlan/QueryPlan.cpp
+++ b/src/Processors/QueryPlan/QueryPlan.cpp
@@ -436,7 +436,7 @@ void QueryPlan::explainEstimates(MutableColumns & columns)
 
     struct Frame
     {
-        Node * node;
+        Node * node = nullptr;
         bool is_description_printed = false;
         size_t next_child = 0;
     };

--- a/src/Processors/QueryPlan/QueryPlan.cpp
+++ b/src/Processors/QueryPlan/QueryPlan.cpp
@@ -449,7 +449,7 @@ void QueryPlan::explainEstimates(MutableColumns & columns)
     using CountersPtr = std::shared_ptr<EstimateCounters>;
     std::unordered_map<std::string, CountersPtr> counters;
     using processNodeFuncType = std::function<void(const Node * node)>;
-    processNodeFuncType processNode = [&counters, &processNode] (const Node * node)
+    processNodeFuncType process_node = [&counters, &process_node] (const Node * node)
     {
         if (!node)
             return;
@@ -467,9 +467,9 @@ void QueryPlan::explainEstimates(MutableColumns & columns)
             it->second->marks += step->getSelectedMarks();
         }
         for (const auto * child : node->children)
-            processNode(child);
+            process_node(child);
     };
-    processNode(root);
+    process_node(root);
 
     for (const auto & counter : counters)
     {

--- a/src/Processors/QueryPlan/QueryPlan.cpp
+++ b/src/Processors/QueryPlan/QueryPlan.cpp
@@ -451,6 +451,8 @@ void QueryPlan::explainEstimates(MutableColumns & columns)
     using processNodeFuncType = std::function<void(const Node * node)>;
     processNodeFuncType processNode = [&counters, &processNode] (const Node * node)
     {
+        if (!node)
+            return;
         if (const auto * step = dynamic_cast<ReadFromMergeTree*>(node->step.get()))
         {
             const auto & id = step->getStorageID();

--- a/src/Processors/QueryPlan/QueryPlan.h
+++ b/src/Processors/QueryPlan/QueryPlan.h
@@ -103,17 +103,6 @@ public:
     };
 
     using Nodes = std::list<Node>;
-    struct EstimateCounters
-    {
-        std::string database_name;
-        std::string table_name;
-        Int64 parts = 0;
-        Int64 rows = 0;
-        Int64 marks = 0;
-        EstimateCounters(const std::string & database, const std::string & table) : database_name(database), table_name(table)
-        {
-        }
-    };
 private:
     Nodes nodes;
     Node * root = nullptr;

--- a/src/Processors/QueryPlan/QueryPlan.h
+++ b/src/Processors/QueryPlan/QueryPlan.h
@@ -2,6 +2,7 @@
 
 #include <Core/Names.h>
 #include <Interpreters/Context_fwd.h>
+#include <Columns/IColumn.h>
 
 #include <list>
 #include <memory>
@@ -85,6 +86,7 @@ public:
     JSONBuilder::ItemPtr explainPlan(const ExplainPlanOptions & options);
     void explainPlan(WriteBuffer & buffer, const ExplainPlanOptions & options);
     void explainPipeline(WriteBuffer & buffer, const ExplainPipelineOptions & options);
+    void explainEstimates(MutableColumns & columns);
 
     /// Set upper limit for the recommend number of threads. Will be applied to the newly-created pipelines.
     /// TODO: make it in a better way.
@@ -101,7 +103,17 @@ public:
     };
 
     using Nodes = std::list<Node>;
-
+    struct EstimateCounters
+    {
+        std::string database_name;
+        std::string table_name;
+        Int64 parts = 0;
+        Int64 rows = 0;
+        Int64 marks = 0;
+        EstimateCounters(const std::string & database, const std::string & table) : database_name(database), table_name(table)
+        {
+        }
+    };
 private:
     Nodes nodes;
     Node * root = nullptr;

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -113,6 +113,12 @@ ReadFromMergeTree::ReadFromMergeTree(
         auto type = std::make_shared<DataTypeFloat64>();
         output_stream->header.insert({type->createColumn(), type, "_sample_factor"});
     }
+    selected_parts = parts.size();
+    for (const auto & part : parts)
+    {
+        selected_marks += part.getMarksCount();
+        selected_rows += part.getRowsCount();
+    }
 }
 
 Pipe ReadFromMergeTree::readFromPool(
@@ -123,6 +129,7 @@ Pipe ReadFromMergeTree::readFromPool(
     bool use_uncompressed_cache)
 {
     Pipes pipes;
+<<<<<<< HEAD
     size_t sum_marks = 0;
     size_t total_rows = 0;
 
@@ -141,6 +148,14 @@ Pipe ReadFromMergeTree::readFromPool(
         min_marks_for_concurrent_read,
         std::move(parts_with_range),
         data,
+=======
+    auto pool = std::make_shared<MergeTreeReadPool>(
+        num_streams,
+        selected_marks,
+        settings.min_marks_for_concurrent_read,
+        std::move(parts),
+        storage,
+>>>>>>> Show estimates for SELECT query
         metadata_snapshot,
         prewhere_info,
         true,
@@ -149,8 +164,13 @@ Pipe ReadFromMergeTree::readFromPool(
         settings.preferred_block_size_bytes,
         false);
 
+<<<<<<< HEAD
     auto * logger = &Poco::Logger::get(data.getLogName() + " (SelectExecutor)");
     LOG_DEBUG(logger, "Reading approx. {} rows with {} streams", total_rows, max_streams);
+=======
+    auto * logger = &Poco::Logger::get(storage.getLogName() + " (SelectExecutor)");
+    LOG_DEBUG(logger, "Reading approx. {} rows with {} streams", selected_rows, num_streams);
+>>>>>>> Show estimates for SELECT query
 
     for (size_t i = 0; i < max_streams; ++i)
     {
@@ -163,7 +183,7 @@ Pipe ReadFromMergeTree::readFromPool(
         if (i == 0)
         {
             /// Set the approximate number of rows for the first source only
-            source->addTotalRowsApprox(total_rows);
+            source->addTotalRowsApprox(selected_rows);
         }
 
         pipes.emplace_back(std::move(source));

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -80,6 +80,10 @@ public:
     void describeActions(JSONBuilder::JSONMap & map) const override;
     void describeIndexes(JSONBuilder::JSONMap & map) const override;
 
+    const StorageID getStorageID() const { return storage.getStorageID(); }
+    Int64 getSelectedParts() const { return selected_parts; }
+    Int64 getSelectedRows() const { return selected_rows; }
+    Int64 getSelectedMarks() const { return selected_marks; }
 private:
     const MergeTreeReaderSettings reader_settings;
 
@@ -106,6 +110,11 @@ private:
     std::shared_ptr<PartitionIdToMaxBlock> max_block_numbers_to_read;
 
     Poco::Logger * log;
+    size_t num_streams;
+    ReadType read_type;
+    Int64 selected_parts = 0;
+    Int64 selected_rows = 0;
+    Int64 selected_marks = 0;
 
     Pipe read(RangesInDataParts parts_with_range, Names required_columns, ReadType read_type, size_t max_streams, size_t min_marks_for_concurrent_read, bool use_uncompressed_cache);
     Pipe readFromPool(RangesInDataParts parts_with_ranges, Names required_columns, size_t max_streams, size_t min_marks_for_concurrent_read, bool use_uncompressed_cache);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Show estimates for SELECT query. #23941


Detailed description / Documentation draft:

Use case:

```
EXPLAIN ESTIMATES
SELECT
    toYear(LO_ORDERDATE) AS year,
    S_CITY,
    P_BRAND,
    sum(LO_REVENUE - LO_SUPPLYCOST) AS profit
FROM lineorder_flat
WHERE (S_NATION = 'UNITED STATES') AND ((year = 1997) OR (year = 1998)) AND (P_CATEGORY = 'MFGR#14')
GROUP BY
    year,
    S_CITY,
    P_BRAND
ORDER BY
    year ASC,
    S_CITY ASC,
    P_BRAND ASC

Query id: 2ac0e792-6a4c-4c09-95f0-b4d4d9a630c5

┌─database─┬─table──────────┬─parts─┬─────rows─┬─marks─┐
│ default  │ lineorder_flat │    14 │ 14430068 │  1780 │
└──────────┴────────────────┴───────┴──────────┴───────┘
```
