### PR TITLE
Backport #24449 to 21.3

### DIFF
--- a/programs/install/Install.cpp
+++ b/programs/install/Install.cpp
@@ -969,7 +969,7 @@ int mainEntryClickHouseStop(int argc, char ** argv)
     desc.add_options()
         ("help,h", "produce help message")
         ("pid-path", po::value<std::string>()->default_value("/var/run/clickhouse-server"), "directory for pid file")
-        ("force", po::value<bool>()->default_value(false), "Stop with KILL signal instead of TERM")
+        ("force", po::bool_switch(), "Stop with KILL signal instead of TERM")
     ;
 
     po::variables_map options;


### PR DESCRIPTION
Fix cli argument in clickhouse-server.init

(cherry picked from commit ea97eee326a94c9a23d1b4349f660a17ad29b551)

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Ref #24449


