### PR TITLE
fix ORDER BY after window fuctions over Distributed

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1296,9 +1296,12 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, const BlockInpu
                   */
 
                 if (from_aggregation_stage)
-                    executeMergeSorted(query_plan, "for ORDER BY");
-                else if (!expressions.first_stage && !expressions.need_aggregate && !(query.group_by_with_totals && !aggregate_final))
-                    executeMergeSorted(query_plan, "for ORDER BY");
+                    executeMergeSorted(query_plan, "after aggregation stage for ORDER BY");
+                else if (!expressions.first_stage
+                    && !expressions.need_aggregate
+                    && !expressions.has_window
+                    && !(query.group_by_with_totals && !aggregate_final))
+                    executeMergeSorted(query_plan, "for ORDER BY, without aggregation");
                 else    /// Otherwise, just sort.
                     executeOrder(
                         query_plan,

--- a/tests/queries/0_stateless/01568_window_functions_distributed.reference
+++ b/tests/queries/0_stateless/01568_window_functions_distributed.reference
@@ -10,7 +10,9 @@ select max(identity(dummy + 1)) over () from remote('127.0.0.{1,2}', system, one
 1
 1
 drop table if exists t_01568;
-create table t_01568 engine Memory as select intDiv(number, 3) p, number from numbers(9);
+create table t_01568 engine Memory as
+select intDiv(number, 3) p, modulo(number, 3) o, number
+from numbers(9);
 select sum(number) over w, max(number) over w from t_01568 window w as (partition by p);
 3	2
 3	2
@@ -57,4 +59,26 @@ select groupArray(groupArray(number)) over (rows unbounded preceding) from remot
 [[0,3,6],[1,4,7]]
 [[0,3,6],[1,4,7],[2,5,8]]
 select groupArray(groupArray(number)) over (rows unbounded preceding) from remote('127.0.0.{1,2}', '', t_01568) group by mod(number, 3) settings distributed_group_by_no_merge=2; -- { serverError 48 }
+-- proper ORDER BY w/window functions
+select p, o, count() over (partition by p)
+from remote('127.0.0.{1,2}', '',  t_01568)
+order by p, o;
+0	0	6
+0	0	6
+0	1	6
+0	1	6
+0	2	6
+0	2	6
+1	0	6
+1	0	6
+1	1	6
+1	1	6
+1	2	6
+1	2	6
+2	0	6
+2	0	6
+2	1	6
+2	1	6
+2	2	6
+2	2	6
 drop table t_01568;

--- a/tests/queries/0_stateless/01568_window_functions_distributed.sql
+++ b/tests/queries/0_stateless/01568_window_functions_distributed.sql
@@ -9,7 +9,9 @@ select max(identity(dummy + 1)) over () from remote('127.0.0.{1,2}', system, one
 
 drop table if exists t_01568;
 
-create table t_01568 engine Memory as select intDiv(number, 3) p, number from numbers(9);
+create table t_01568 engine Memory as
+select intDiv(number, 3) p, modulo(number, 3) o, number
+from numbers(9);
 
 select sum(number) over w, max(number) over w from t_01568 window w as (partition by p);
 
@@ -21,5 +23,10 @@ select distinct sum(number) over w, max(number) over w from remote('127.0.0.{1,2
 select groupArray(groupArray(number)) over (rows unbounded preceding) from remote('127.0.0.{1,2}', '', t_01568) group by mod(number, 3);
 select groupArray(groupArray(number)) over (rows unbounded preceding) from remote('127.0.0.{1,2}', '', t_01568) group by mod(number, 3) settings distributed_group_by_no_merge=1;
 select groupArray(groupArray(number)) over (rows unbounded preceding) from remote('127.0.0.{1,2}', '', t_01568) group by mod(number, 3) settings distributed_group_by_no_merge=2; -- { serverError 48 }
+
+-- proper ORDER BY w/window functions
+select p, o, count() over (partition by p)
+from remote('127.0.0.{1,2}', '',  t_01568)
+order by p, o;
 
 drop table t_01568;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes https://github.com/ClickHouse/ClickHouse/issues/23902