### PR TITLE
Backport to 21.3: XDBC bridge fix timespan

### DIFF
--- a/programs/odbc-bridge/ODBCBridge.cpp
+++ b/programs/odbc-bridge/ODBCBridge.cpp
@@ -166,9 +166,9 @@ void ODBCBridge::initialize(Application & self)
     if (port > 0xFFFF)
         throw Exception("Out of range 'http-port': " + std::to_string(port), ErrorCodes::ARGUMENT_OUT_OF_BOUND);
 
-    http_timeout = config().getUInt("http-timeout", DEFAULT_HTTP_READ_BUFFER_TIMEOUT);
+    http_timeout = config().getUInt64("http-timeout", DEFAULT_HTTP_READ_BUFFER_TIMEOUT);
     max_server_connections = config().getUInt("max-server-connections", 1024);
-    keep_alive_timeout = config().getUInt("keep-alive-timeout", 10);
+    keep_alive_timeout = config().getUInt64("keep-alive-timeout", 10);
 
     initializeTerminationAndSignalProcessing();
 

--- a/src/Common/XDBCBridgeHelper.h
+++ b/src/Common/XDBCBridgeHelper.h
@@ -85,8 +85,8 @@ public:
     static constexpr inline auto SCHEMA_ALLOWED_HANDLER = "/schema_allowed";
     static constexpr inline auto PING_OK_ANSWER = "Ok.";
 
-    XDBCBridgeHelper(const Context & global_context_, const Poco::Timespan & http_timeout_, const std::string & connection_string_)
-        : http_timeout(http_timeout_), connection_string(connection_string_), context(global_context_), config(context.getConfigRef())
+    XDBCBridgeHelper(const Context & context_, const Poco::Timespan http_timeout_, const std::string & connection_string_)
+        : http_timeout(http_timeout_), connection_string(connection_string_), context(context_.getGlobalContext()), config(context.getConfigRef())
     {
         size_t bridge_port = config.getUInt(BridgeHelperMixin::configPrefix() + ".port", DEFAULT_PORT);
         std::string bridge_host = config.getString(BridgeHelperMixin::configPrefix() + ".host", DEFAULT_HOST);
@@ -271,7 +271,7 @@ struct JDBCBridgeMixin
         return AccessType::JDBC;
     }
 
-    static std::unique_ptr<ShellCommand> startBridge(const Poco::Util::AbstractConfiguration &, const Poco::Logger *, const Poco::Timespan &)
+    static std::unique_ptr<ShellCommand> startBridge(const Poco::Util::AbstractConfiguration &, const Poco::Logger *, Poco::Timespan)
     {
         throw Exception("jdbc-bridge is not running. Please, start it manually", ErrorCodes::EXTERNAL_SERVER_IS_NOT_RESPONDING);
     }
@@ -299,7 +299,7 @@ struct ODBCBridgeMixin
     }
 
     static std::unique_ptr<ShellCommand> startBridge(
-        const Poco::Util::AbstractConfiguration & config, Poco::Logger * log, const Poco::Timespan & http_timeout)
+        const Poco::Util::AbstractConfiguration & config, Poco::Logger * log, Poco::Timespan http_timeout)
     {
         /// Path to executable folder
         Poco::Path path{config.getString("application.dir", "/usr/bin")};

--- a/src/TableFunctions/ITableFunctionXDBC.h
+++ b/src/TableFunctions/ITableFunctionXDBC.h
@@ -22,7 +22,7 @@ private:
 
     /* A factory method to create bridge helper, that will assist in remote interaction */
     virtual BridgeHelperPtr createBridgeHelper(Context & context,
-        const Poco::Timespan & http_timeout_,
+        Poco::Timespan http_timeout_,
         const std::string & connection_string_) const = 0;
 
     ColumnsDescription getActualTableStructure(const Context & context) const override;
@@ -46,7 +46,7 @@ public:
 
 private:
     BridgeHelperPtr createBridgeHelper(Context & context,
-        const Poco::Timespan & http_timeout_,
+        Poco::Timespan http_timeout_,
         const std::string & connection_string_) const override
     {
         return std::make_shared<XDBCBridgeHelper<JDBCBridgeMixin>>(context, http_timeout_, connection_string_);
@@ -66,7 +66,7 @@ public:
 
 private:
     BridgeHelperPtr createBridgeHelper(Context & context,
-        const Poco::Timespan & http_timeout_,
+        Poco::Timespan http_timeout_,
         const std::string & connection_string_) const override
     {
         return std::make_shared<XDBCBridgeHelper<ODBCBridgeMixin>>(context, http_timeout_, connection_string_);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed remote JDBC bridge timeout connection issue. Closes #9609.

