### PR TITLE
Block memory tracker earlier in `tryLogCurrentException`

### DIFF
--- a/src/Common/Exception.cpp
+++ b/src/Common/Exception.cpp
@@ -138,9 +138,31 @@ void throwFromErrnoWithPath(const std::string & s, const std::string & path, int
     throw ErrnoException(s + ", " + errnoToString(code, the_errno), code, the_errno, path);
 }
 
+static void tryLogCurrentExceptionImpl(Poco::Logger * logger, const std::string & start_of_message)
+{
+    try
+    {
+        if (start_of_message.empty())
+            LOG_ERROR(logger, "{}", getCurrentExceptionMessage(true));
+        else
+            LOG_ERROR(logger, "{}: {}", start_of_message, getCurrentExceptionMessage(true));
+    }
+    catch (...)
+    {
+    }
+}
+
 void tryLogCurrentException(const char * log_name, const std::string & start_of_message)
 {
-    tryLogCurrentException(&Poco::Logger::get(log_name), start_of_message);
+    /// Under high memory pressure, any new allocation will definitelly lead
+    /// to MEMORY_LIMIT_EXCEEDED exception.
+    ///
+    /// And in this case the exception will not be logged, so let's block the
+    /// MemoryTracker until the exception will be logged.
+    MemoryTracker::LockExceptionInThread lock_memory_tracker(VariableContext::Global);
+
+    /// Poco::Logger::get can allocate memory too
+    tryLogCurrentExceptionImpl(&Poco::Logger::get(log_name), start_of_message);
 }
 
 void tryLogCurrentException(Poco::Logger * logger, const std::string & start_of_message)
@@ -152,16 +174,7 @@ void tryLogCurrentException(Poco::Logger * logger, const std::string & start_of_
     /// MemoryTracker until the exception will be logged.
     MemoryTracker::LockExceptionInThread lock_memory_tracker(VariableContext::Global);
 
-    try
-    {
-        if (start_of_message.empty())
-            LOG_ERROR(logger, "{}", getCurrentExceptionMessage(true));
-        else
-            LOG_ERROR(logger, "{}: {}", start_of_message, getCurrentExceptionMessage(true));
-    }
-    catch (...)
-    {
-    }
+    tryLogCurrentExceptionImpl(logger, start_of_message);
 }
 
 static void getNoSpaceLeftInfoMessage(std::filesystem::path path, std::string & msg)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)