### PR TITLE
Weaken assertion in ActiveDataPartSet

### DIFF
--- a/src/Storages/MergeTree/ActiveDataPartSet.cpp
+++ b/src/Storages/MergeTree/ActiveDataPartSet.cpp
@@ -59,7 +59,7 @@ bool ActiveDataPartSet::add(const String & name, Strings * out_replaced_parts)
         if (part_info == it->first)
         {
             /// We could throw logical error on part duplication,
-            /// but it may rarely happen to virtual parts set as a result of replica cloning. 
+            /// but it may rarely happen to virtual parts set as a result of replica cloning.
             return false;
         }
         if (out_replaced_parts)

--- a/src/Storages/MergeTree/ActiveDataPartSet.cpp
+++ b/src/Storages/MergeTree/ActiveDataPartSet.cpp
@@ -57,7 +57,11 @@ bool ActiveDataPartSet::add(const String & name, Strings * out_replaced_parts)
     while (it != part_info_to_name.end() && part_info.contains(it->first))
     {
         if (part_info == it->first)
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected duplicate part {}. It is a bug.", name);
+        {
+            /// We could throw logical error on part duplication,
+            /// but it may rarely happen to virtual parts set as a result of replica cloning. 
+            return false;
+        }
         if (out_replaced_parts)
             out_replaced_parts->push_back(it->second);
         part_info_to_name.erase(it++);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Detailed description / Documentation draft:
At first `cloneReplaca(...)` copies source replica queue, and after that it reads data parts set from `source_path + "/parts"` to create `GET_PART` entries in own queue and download missing parts. Therefore, some `MERGE_PART` entry may be duplicated with `GET_PART` with the same `new_part_name`. 

However, I'm not sure what we should fix: `ActiveDataPartSet` or `cloneReplica(...)`