### PR TITLE
Respect max_distributed_connections for insert_distributed_sync

### DIFF
--- a/src/Storages/Distributed/DistributedBlockOutputStream.cpp
+++ b/src/Storages/Distributed/DistributedBlockOutputStream.cpp
@@ -417,7 +417,11 @@ void DistributedBlockOutputStream::writeSync(const Block & block)
         /// Deferred initialization. Only for sync insertion.
         initWritingJobs(block, start, end);
 
-        pool.emplace(remote_jobs_count + local_jobs_count);
+        size_t jobs_count = remote_jobs_count + local_jobs_count;
+        size_t max_threads = std::min<size_t>(settings.max_distributed_connections, jobs_count);
+        pool.emplace(/* max_threads_= */ max_threads,
+                     /* max_free_threads_= */ max_threads,
+                     /* queue_size_= */ jobs_count);
 
         if (!throttler && (settings.max_network_bandwidth || settings.max_network_bytes))
         {


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Respect `max_distributed_connections` for `insert_distributed_sync` (otherwise for huge clusters and sync insert it may run out of `max_thread_pool_size`)