### PR TITLE
[Draft] Schema inference for input text formats

### DIFF
--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -328,13 +328,17 @@ catch (const Exception & e)
 }
 
 
-std::string LocalServer::getInitialCreateTableQuery()
+String LocalServer::getInitialCreateTableQuery()
 {
     if (!config().has("table-structure"))
         return {};
+    
+    String wrapped_table_structure;
+    String table_structure = config().getString("table-structure");
+    if (table_structure != "auto")
+        wrapped_table_structure = " (" + table_structure + ") ";
 
     auto table_name = backQuoteIfNeed(config().getString("table-name", "table"));
-    auto table_structure = config().getString("table-structure");
     auto data_format = backQuoteIfNeed(config().getString("table-data-format", "TSV"));
     String table_file;
     if (!config().has("table-file") || config().getString("table-file") == "-") /// Use Unix tools stdin naming convention
@@ -344,7 +348,7 @@ std::string LocalServer::getInitialCreateTableQuery()
 
     return
     "CREATE TABLE " + table_name +
-        " (" + table_structure + ") " +
+        wrapped_table_structure +
     "ENGINE = "
         "File(" + data_format + ", " + table_file + ")"
     "; ";

--- a/src/DataStreams/IBlockInputStream.h
+++ b/src/DataStreams/IBlockInputStream.h
@@ -75,8 +75,7 @@ public:
 
     /** Read something before starting all data or after the end of all data.
       * In the `readSuffix` function, you can implement a finalization that can lead to an exception.
-      * If schema inference is not requred, readPrefix() must be called before the first call to read(). If schema inference
-      * is required, then readPrefix() must not be called, because prefix is read when on an attempt to guess the table schema.
+      * readPrefix() must be called before the first call to read().
       * readSuffix() should be called after read() returns an empty block, or after a call to cancel(), but not during read() execution.
       */
 

--- a/src/DataStreams/IBlockInputStream.h
+++ b/src/DataStreams/IBlockInputStream.h
@@ -75,7 +75,8 @@ public:
 
     /** Read something before starting all data or after the end of all data.
       * In the `readSuffix` function, you can implement a finalization that can lead to an exception.
-      * readPrefix() must be called before the first call to read().
+      * If schema inference is not requred, readPrefix() must be called before the first call to read(). If schema inference
+      * is required, then readPrefix() must not be called, because prefix is read when on an attempt to guess the table schema.
       * readSuffix() should be called after read() returns an empty block, or after a call to cancel(), but not during read() execution.
       */
 

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -202,7 +202,7 @@ InputFormatPtr FormatFactory::getInput(
     const String & name,
     ReadBuffer & buf,
     IInputFormatHeader & format_header,
-    const Context & context,
+    ContextConstPtr context,
     UInt64 max_block_size,
     const std::optional<FormatSettings> & format_settings) const
 {
@@ -322,7 +322,7 @@ InputFormatPtr FormatFactory::getInputFormat(
     const String & name,
     ReadBuffer & buf,
     IInputFormatHeader & format_header,
-    const Context & context,
+    ContextConstPtr context,
     UInt64 max_block_size,
     const std::optional<FormatSettings> & _format_settings) const
 {
@@ -330,7 +330,7 @@ InputFormatPtr FormatFactory::getInputFormat(
     if (!input_getter)
         throw Exception("Format " + name + " is not suitable for input with format header", ErrorCodes::FORMAT_IS_NOT_SUITABLE_FOR_INPUT);
 
-    const Settings & settings = context.getSettingsRef();
+    const Settings & settings = context->getSettingsRef();
 
     auto format_settings = _format_settings
         ? *_format_settings : getFormatSettings(context);
@@ -349,7 +349,7 @@ InputFormatPtr FormatFactory::getInputFormat(
 InputFormatHeaderPtr FormatFactory::getInputFormatHeader(
     const String & name,
     ReadBuffer & buf,
-    const Context & context,
+    ContextConstPtr context,
     UInt64 max_block_size,
     const std::optional<FormatSettings> & _format_settings) const
 {
@@ -357,7 +357,7 @@ InputFormatHeaderPtr FormatFactory::getInputFormatHeader(
     if (!format_header_getter)
         throw Exception("Format header " + name + " is not registered", ErrorCodes::LOGICAL_ERROR);
 
-    const Settings & settings = context.getSettingsRef();
+    const Settings & settings = context->getSettingsRef();
 
     auto format_settings = _format_settings
         ? *_format_settings : getFormatSettings(context);

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -370,6 +370,11 @@ OutputFormatPtr FormatFactory::getOutputFormat(
     return format;
 }
 
+bool FormatFactory::checkIfInputFormatSupportsSchemaInference(const String & name)
+{
+    return dict[name].supports_schema_inference;
+}
+
 
 void FormatFactory::registerInputFormat(const String & name, InputCreator input_creator)
 {
@@ -411,6 +416,14 @@ void FormatFactory::registerFileSegmentationEngine(const String & name, FileSegm
     target = std::move(file_segmentation_engine);
 }
 
+
+void FormatFactory::markInputFormatSupportsSchemaInference(const String & name)
+{
+    auto & target = dict[name].supports_schema_inference;
+    if (target)
+        throw Exception("FormatFactory: Input format " + name + " is already marked as supporting schema inference.", ErrorCodes::LOGICAL_ERROR);
+    target = true;
+}
 
 void FormatFactory::markOutputFormatSupportsParallelFormatting(const String & name)
 {

--- a/src/Formats/FormatFactory.h
+++ b/src/Formats/FormatFactory.h
@@ -136,7 +136,7 @@ public:
         const String & name,
         ReadBuffer & buf,
         IInputFormatHeader & format_header,
-        const Context & context,
+        ContextConstPtr context,
         UInt64 max_block_size,
         const std::optional<FormatSettings> & format_settings = std::nullopt) const;
 
@@ -171,14 +171,14 @@ public:
         const String & name,
         ReadBuffer & buf,
         IInputFormatHeader & format_header,
-        const Context & context,
+        ContextConstPtr context,
         UInt64 max_block_size,
         const std::optional<FormatSettings> & format_settings = std::nullopt) const;
 
     InputFormatHeaderPtr getInputFormatHeader(
         const String & name,
         ReadBuffer & buf,
-        const Context & context,
+        ContextConstPtr context,
         UInt64 max_block_size,
         const std::optional<FormatSettings> & format_settings = std::nullopt) const;
 

--- a/src/Formats/FormatFactory.h
+++ b/src/Formats/FormatFactory.h
@@ -100,6 +100,7 @@ private:
         InputProcessorCreator input_processor_creator;
         OutputProcessorCreator output_processor_creator;
         FileSegmentationEngine file_segmentation_engine;
+        bool supports_schema_inference{false};
         bool supports_parallel_formatting{false};
         bool is_column_oriented{false};
     };
@@ -161,6 +162,8 @@ public:
         WriteCallback callback = {},
         const std::optional<FormatSettings> & format_settings = std::nullopt) const;
 
+    bool checkIfInputFormatSupportsSchemaInference(const String & name);
+
     /// Register format by its name.
     void registerInputFormat(const String & name, InputCreator input_creator);
     void registerOutputFormat(const String & name, OutputCreator output_creator);
@@ -169,6 +172,7 @@ public:
     void registerInputFormatProcessor(const String & name, InputProcessorCreator input_creator);
     void registerOutputFormatProcessor(const String & name, OutputProcessorCreator output_creator);
 
+    void markInputFormatSupportsSchemaInference(const String & name);
     void markOutputFormatSupportsParallelFormatting(const String & name);
     void markFormatAsColumnOriented(const String & name);
 

--- a/src/Formats/FormatFactory.h
+++ b/src/Formats/FormatFactory.h
@@ -4,6 +4,7 @@
 #include <DataStreams/IBlockStream_fwd.h>
 #include <Formats/FormatSettings.h>
 #include <Interpreters/Context_fwd.h>
+#include <Processors/Formats/IInputFormatHeader.h>
 #include <IO/BufferWithOwnMemory.h>
 #include <common/types.h>
 
@@ -33,6 +34,7 @@ struct RowInputFormatParams;
 struct RowOutputFormatParams;
 
 using InputFormatPtr = std::shared_ptr<IInputFormat>;
+using InputFormatHeaderPtr = std::shared_ptr<IInputFormatHeader>;
 using OutputFormatPtr = std::shared_ptr<IOutputFormat>;
 
 FormatSettings getFormatSettings(ContextConstPtr context);
@@ -73,6 +75,11 @@ private:
         ReadCallback callback,
         const FormatSettings & settings)>;
 
+    using InputFormatHeaderCreator = std::function<InputFormatHeaderPtr(
+        ReadBuffer & buf,
+        const RowInputFormatParams & params,
+        const FormatSettings & settings)>;
+
     using OutputCreator = std::function<BlockOutputStreamPtr(
         WriteBuffer & buf,
         const Block & sample,
@@ -87,6 +94,12 @@ private:
 
     using InputProcessorCreator = std::function<InputProcessorCreatorFunc>;
 
+    using InputWithFormatHeaderProcessorCreator = std::function<InputFormatPtr(
+        ReadBuffer & buf,
+        IInputFormatHeader & format_header,
+        const RowInputFormatParams & params,
+        const FormatSettings & settings)>;
+
     using OutputProcessorCreator = std::function<OutputFormatPtr(
             WriteBuffer & buf,
             const Block & sample,
@@ -96,11 +109,12 @@ private:
     struct Creators
     {
         InputCreator input_creator;
+        InputFormatHeaderCreator input_format_header_creator;
         OutputCreator output_creator;
         InputProcessorCreator input_processor_creator;
+        InputWithFormatHeaderProcessorCreator input_with_format_header_processor_creator;
         OutputProcessorCreator output_processor_creator;
         FileSegmentationEngine file_segmentation_engine;
-        bool supports_schema_inference{false};
         bool supports_parallel_formatting{false};
         bool is_column_oriented{false};
     };
@@ -115,6 +129,14 @@ public:
         ReadBuffer & buf,
         const Block & sample,
         ContextConstPtr context,
+        UInt64 max_block_size,
+        const std::optional<FormatSettings> & format_settings = std::nullopt) const;
+
+    InputFormatPtr getInput(
+        const String & name,
+        ReadBuffer & buf,
+        IInputFormatHeader & format_header,
+        const Context & context,
         UInt64 max_block_size,
         const std::optional<FormatSettings> & format_settings = std::nullopt) const;
 
@@ -145,6 +167,21 @@ public:
         UInt64 max_block_size,
         const std::optional<FormatSettings> & format_settings = std::nullopt) const;
 
+    InputFormatPtr getInputFormat(
+        const String & name,
+        ReadBuffer & buf,
+        IInputFormatHeader & format_header,
+        const Context & context,
+        UInt64 max_block_size,
+        const std::optional<FormatSettings> & format_settings = std::nullopt) const;
+
+    InputFormatHeaderPtr getInputFormatHeader(
+        const String & name,
+        ReadBuffer & buf,
+        const Context & context,
+        UInt64 max_block_size,
+        const std::optional<FormatSettings> & format_settings = std::nullopt) const;
+
     /// Checks all preconditions. Returns ordinary format if parallel formatting cannot be done.
     OutputFormatPtr getOutputFormatParallelIfPossible(
         const String & name,
@@ -162,17 +199,18 @@ public:
         WriteCallback callback = {},
         const std::optional<FormatSettings> & format_settings = std::nullopt) const;
 
-    bool checkIfInputFormatSupportsSchemaInference(const String & name);
+    bool checkIfInputFormatSupportsFormatHeader(const String & name);
 
     /// Register format by its name.
     void registerInputFormat(const String & name, InputCreator input_creator);
+    void registerInputFormatHeader(const String & name, InputFormatHeaderCreator format_header_creator);
     void registerOutputFormat(const String & name, OutputCreator output_creator);
     void registerFileSegmentationEngine(const String & name, FileSegmentationEngine file_segmentation_engine);
 
     void registerInputFormatProcessor(const String & name, InputProcessorCreator input_creator);
+    void registerInputFormatWithFormatHeaderProcessor(const String & name, InputWithFormatHeaderProcessorCreator input_creator);
     void registerOutputFormatProcessor(const String & name, OutputProcessorCreator output_creator);
 
-    void markInputFormatSupportsSchemaInference(const String & name);
     void markOutputFormatSupportsParallelFormatting(const String & name);
     void markFormatAsColumnOriented(const String & name);
 
@@ -187,6 +225,11 @@ private:
     FormatsDictionary dict;
 
     const Creators & getCreators(const String & name) const;
+
+    RowInputFormatParams getRowInputFormatParams(
+        UInt64 max_block_size, 
+        const FormatSettings & format_settings, 
+        const Settings & settings) const; 
 };
 
 }

--- a/src/Processors/Formats/IInputFormat.h
+++ b/src/Processors/Formats/IInputFormat.h
@@ -2,9 +2,12 @@
 
 #include <Processors/ISource.h>
 
+<<<<<<< HEAD
 #include <memory>
 
 
+=======
+>>>>>>> ee67ded9c2 (Proof of concept)
 namespace DB
 {
 /// Used to pass info from header between different InputFormats in ParallelParsing
@@ -25,6 +28,11 @@ struct ColumnMapping
 };
 
 using ColumnMappingPtr = std::shared_ptr<ColumnMapping>;
+
+namespace ErrorCodes
+{
+    extern const int NOT_IMPLEMENTED;
+}
 
 class ReadBuffer;
 
@@ -63,6 +71,11 @@ public:
     ColumnMappingPtr getColumnMapping() const { return column_mapping; }
     /// Must be called from ParallelParsingInputFormat before readPrefix
     void setColumnMapping(ColumnMappingPtr column_mapping_) { column_mapping = column_mapping_; }
+
+    virtual Block readSchemaFromPrefix()
+    {
+        throw Exception("readSchemaFromPrefix is not implemented for" + getName() + " InputFormat", ErrorCodes::NOT_IMPLEMENTED);
+    }
 
     size_t getCurrentUnitNumber() const { return current_unit_number; }
     void setCurrentUnitNumber(size_t current_unit_number_) { current_unit_number = current_unit_number_; }

--- a/src/Processors/Formats/IInputFormat.h
+++ b/src/Processors/Formats/IInputFormat.h
@@ -2,12 +2,9 @@
 
 #include <Processors/ISource.h>
 
-<<<<<<< HEAD
 #include <memory>
 
 
-=======
->>>>>>> ee67ded9c2 (Proof of concept)
 namespace DB
 {
 /// Used to pass info from header between different InputFormats in ParallelParsing
@@ -71,11 +68,6 @@ public:
     ColumnMappingPtr getColumnMapping() const { return column_mapping; }
     /// Must be called from ParallelParsingInputFormat before readPrefix
     void setColumnMapping(ColumnMappingPtr column_mapping_) { column_mapping = column_mapping_; }
-
-    virtual Block readSchemaFromPrefix()
-    {
-        throw Exception("readSchemaFromPrefix is not implemented for" + getName() + " InputFormat", ErrorCodes::NOT_IMPLEMENTED);
-    }
 
     size_t getCurrentUnitNumber() const { return current_unit_number; }
     void setCurrentUnitNumber(size_t current_unit_number_) { current_unit_number = current_unit_number_; }

--- a/src/Processors/Formats/IInputFormatHeader.cpp
+++ b/src/Processors/Formats/IInputFormatHeader.cpp
@@ -1,0 +1,23 @@
+#include <Processors/Formats/IInputFormatHeader.h>
+#include <IO/ReadBuffer.h>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
+IInputFormatHeader::IInputFormatHeader(ReadBuffer & in_)
+    : in(in_), header(nullptr)
+{
+}
+
+IInputFormatHeader::IInputFormatHeader(const IInputFormatHeader & other)
+    : in(other.in), header(other.header)
+{
+}
+
+}

--- a/src/Processors/Formats/IInputFormatHeader.h
+++ b/src/Processors/Formats/IInputFormatHeader.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <Core/Block.h>
+#include <Common/Exception.h>
+
+namespace DB
+{
+
+using BlockPtr = std::shared_ptr<Block>;
+
+namespace ErrorCodes
+{
+    extern const int NOT_IMPLEMENTED;
+    extern const int LOGICAL_ERROR;
+}
+
+class ReadBuffer;
+
+/** Input format header reads data prefix from ReadBuffer and creates block header from it.
+  */
+class IInputFormatHeader
+{
+protected:
+
+    /// Skip GCC warning: ‘maybe_unused’ attribute ignored
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+
+    ReadBuffer & in [[maybe_unused]];
+    BlockPtr header;
+
+#pragma GCC diagnostic pop
+
+public:
+    IInputFormatHeader(ReadBuffer & in_);
+
+    IInputFormatHeader(const IInputFormatHeader & other);
+
+    virtual void readPrefix()
+    {
+        throw Exception("readPrefix is not implemented for IInputFormatHeader", ErrorCodes::NOT_IMPLEMENTED);
+    }
+
+    virtual const Block & getHeader() const
+    {
+        if (header)
+            return *header;
+
+        throw Exception("The header block is empty. Call readPrefix first", ErrorCodes::LOGICAL_ERROR);
+    }
+
+    virtual ~IInputFormatHeader() = default;
+};
+
+}

--- a/src/Processors/Formats/IRowInputFormat.h
+++ b/src/Processors/Formats/IRowInputFormat.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <Columns/IColumn.h>
 #include <Processors/Formats/IInputFormat.h>
+#include <Processors/Formats/IInputFormatHeader.h>
 #include <DataStreams/SizeLimits.h>
 #include <Poco/Timespan.h>
 #include <Common/Stopwatch.h>

--- a/src/Processors/Formats/Impl/JSONCompactEachRowRowInputFormat.h
+++ b/src/Processors/Formats/Impl/JSONCompactEachRowRowInputFormat.h
@@ -10,6 +10,14 @@ namespace DB
 
 class ReadBuffer;
 
+class JSONCompactEachRowRowInputFormatHeader : public IInputFormatHeader
+{
+public:
+    JSONCompactEachRowRowInputFormatHeader(ReadBuffer & in);
+
+    void readPrefix() override;
+};
+
 /** A stream for reading data in a bunch of formats:
  *  - JSONCompactEachRow
  *  - JSONCompactEachRowWithNamesAndTypes
@@ -28,10 +36,17 @@ public:
         bool with_names_,
         bool yield_strings_);
 
+    JSONCompactEachRowRowInputFormat(
+        ReadBuffer & in_,
+        IInputFormatHeader & format_header_,
+        Params params_,
+        const FormatSettings & format_settings_,
+        bool with_names_,
+        bool yield_strings_);
+
     String getName() const override { return "JSONCompactEachRowRowInputFormat"; }
 
 
-    Block readSchemaFromPrefix() override;
     void readPrefix() override;
     bool readRow(MutableColumns & columns, RowReadExtension & ext) override;
     bool allowSyncAfterError() const override { return true; }
@@ -40,8 +55,9 @@ public:
 
 private:
     void addInputColumn(const String & column_name);
-    void skipEndOfLine();
     void readField(size_t index, MutableColumns & columns);
+
+    std::optional<JSONCompactEachRowRowInputFormatHeader> format_header;
 
     const FormatSettings format_settings;
 

--- a/src/Processors/Formats/Impl/JSONCompactEachRowRowInputFormat.h
+++ b/src/Processors/Formats/Impl/JSONCompactEachRowRowInputFormat.h
@@ -31,6 +31,7 @@ public:
     String getName() const override { return "JSONCompactEachRowRowInputFormat"; }
 
 
+    Block readSchemaFromPrefix() override;
     void readPrefix() override;
     bool readRow(MutableColumns & columns, RowReadExtension & ext) override;
     bool allowSyncAfterError() const override { return true; }

--- a/src/Storages/StorageFactory.h
+++ b/src/Storages/StorageFactory.h
@@ -66,6 +66,7 @@ public:
         bool supports_deduplication = false;
         /// See also IStorage::supportsParallelInsert()
         bool supports_parallel_insert = false;
+        bool supports_schema_inference = false;
         AccessType source_access_type = AccessType::NONE;
     };
 
@@ -98,6 +99,7 @@ public:
         .supports_replication = false,
         .supports_deduplication = false,
         .supports_parallel_insert = false,
+        .supports_schema_inference = false,
         .source_access_type = AccessType::NONE,
     });
 

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -326,11 +326,11 @@ public:
     StorageFileSource(
         std::shared_ptr<StorageFile> storage_,
         const StorageMetadataPtr & metadata_snapshot_,
-        const Context & context_,
+        ContextPtr context_,
         UInt64 max_block_size_,
         FilesInfoPtr files_info_,
         ColumnsDescription columns_description_)
-        : StorageFileSource(storage_, std::nullopt, metadata_snapshot_, context_, max_block_size_, files_info_, columns_description_)
+        : StorageFileSource(storage_, {}, metadata_snapshot_, context_, max_block_size_, files_info_, columns_description_)
     {
     }
 
@@ -385,9 +385,6 @@ public:
                     return metadata_snapshot->getSampleBlock();
                 };
 
-                auto format = FormatFactory::instance().getInput(
-                    storage->format_name, *read_buf, get_block_for_format(), context, max_block_size, storage->format_settings);
-                
                 InputFormatPtr format;
                 if (format_header)
                 {
@@ -396,7 +393,7 @@ public:
                 } else
                 {
                     format = FormatFactory::instance().getInput(
-                    storage->format_name, *read_buf, metadata_snapshot->getSampleBlock(), context, max_block_size, storage->format_settings);
+                    storage->format_name, *read_buf, get_block_for_format(), context, max_block_size, storage->format_settings);
                 }
 
                 reader = std::make_shared<InputStreamFromInputFormat>(format);
@@ -710,6 +707,7 @@ void registerStorageFile(StorageFactory & factory)
                 {},
                 {},
                 {},
+                {},
                 factory_args.columns,
                 factory_args.constraints,
                 factory_args.comment
@@ -812,7 +810,7 @@ void registerStorageFile(StorageFactory & factory)
                 }
                 else
                 {
-                    auto paths = StorageFile::getPathsList(source_path, factory_args.context.getUserFilesPath(), storage_args.context);
+                    auto paths = StorageFile::getPathsList(source_path, factory_args.getContext()->getUserFilesPath(), storage_args.getContext());
                     String first_path = paths[0];
                     nested_buffer = std::make_unique<ReadBufferFromFile>(first_path);
                     method = chooseCompressionMethod(first_path, storage_args.compression_method);
@@ -827,7 +825,7 @@ void registerStorageFile(StorageFactory & factory)
                                     ErrorCodes::LOGICAL_ERROR);
 
                 auto format_header = format_factory.getInputFormatHeader(
-                    storage_args.format_name, *read_buf, storage_args.context, 0, storage_args.format_settings);
+                    storage_args.format_name, *read_buf, storage_args.getContext(), 0, storage_args.format_settings);
 
                 format_header->readPrefix();
                 Block sample_block = format_header->getHeader();

--- a/src/Storages/StorageFile.h
+++ b/src/Storages/StorageFile.h
@@ -1,6 +1,11 @@
 #pragma once
 
 #include <Storages/IStorage.h>
+#include <Processors/Formats/IInputFormatHeader.h>
+
+#include <Poco/File.h>
+#include <Poco/Path.h>
+
 #include <common/logger_useful.h>
 
 #include <atomic>
@@ -49,13 +54,13 @@ public:
     {
         StorageID table_id;
         std::string format_name;
+        std::optional<IInputFormatHeader> format_header;
         std::optional<FormatSettings> format_settings;
         std::string compression_method;
-        const ColumnsDescription & columns;
+        ColumnsDescription columns;
         const ConstraintsDescription & constraints;
         const String & comment;
         const Context & context;
-        bool skip_prefix_reading;
     };
 
     NamesAndTypesList getVirtuals() const override;
@@ -85,6 +90,7 @@ private:
     explicit StorageFile(CommonArguments args);
 
     std::string format_name;
+    std::optional<IInputFormatHeader> format_header;
     // We use format settings from global context + CREATE query for File table
     // function -- in this case, format_settings is set.
     // For `file` table function, we use format settings from current user context,
@@ -97,7 +103,6 @@ private:
     std::string base_path;
     std::vector<std::string> paths;
 
-    bool skip_prefix_reading = false;
     bool is_db_table = true;                     /// Table is stored in real database, not user's file
     bool use_table_fd = false;                    /// Use table_fd instead of path
     std::atomic<bool> table_fd_was_used{false}; /// To detect repeating reads from stdin

--- a/src/Storages/StorageFile.h
+++ b/src/Storages/StorageFile.h
@@ -54,6 +54,8 @@ public:
         const ColumnsDescription & columns;
         const ConstraintsDescription & constraints;
         const String & comment;
+        const Context & context;
+        bool skip_prefix_reading;
     };
 
     NamesAndTypesList getVirtuals() const override;
@@ -95,6 +97,7 @@ private:
     std::string base_path;
     std::vector<std::string> paths;
 
+    bool skip_prefix_reading = false;
     bool is_db_table = true;                     /// Table is stored in real database, not user's file
     bool use_table_fd = false;                    /// Use table_fd instead of path
     std::atomic<bool> table_fd_was_used{false}; /// To detect repeating reads from stdin

--- a/src/Storages/StorageFile.h
+++ b/src/Storages/StorageFile.h
@@ -60,7 +60,6 @@ public:
         ColumnsDescription columns;
         const ConstraintsDescription & constraints;
         const String & comment;
-        const Context & context;
     };
 
     NamesAndTypesList getVirtuals() const override;

--- a/src/TableFunctions/TableFunctionFile.cpp
+++ b/src/TableFunctions/TableFunctionFile.cpp
@@ -21,13 +21,13 @@ StoragePtr TableFunctionFile::getStorage(const String & source,
         WithContext(global_context),
         StorageID(getDatabaseName(), table_name),
         format_,
+        std::nullopt /*format header*/,
         std::nullopt /*format settings*/,
         compression_method_,
         columns,
         ConstraintsDescription{},
         String{},
-        global_context,
-        false
+        global_context
     };
 
     return StorageFile::create(source, global_context->getUserFilesPath(), args);

--- a/src/TableFunctions/TableFunctionFile.cpp
+++ b/src/TableFunctions/TableFunctionFile.cpp
@@ -26,6 +26,8 @@ StoragePtr TableFunctionFile::getStorage(const String & source,
         columns,
         ConstraintsDescription{},
         String{},
+        global_context,
+        false
     };
 
     return StorageFile::create(source, global_context->getUserFilesPath(), args);

--- a/src/TableFunctions/TableFunctionFile.cpp
+++ b/src/TableFunctions/TableFunctionFile.cpp
@@ -26,8 +26,7 @@ StoragePtr TableFunctionFile::getStorage(const String & source,
         compression_method_,
         columns,
         ConstraintsDescription{},
-        String{},
-        global_context
+        String{}
     };
 
     return StorageFile::create(source, global_context->getUserFilesPath(), args);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now it's possible to skip table structure in CREATE TABLE queries. It works only for InputFormat types and Sources which support the schema inference option.
...

Detailed description / Documentation draft:
TBD.
It's a draft, changes are not fully implemented and not ready for merge.

...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
