### PR TITLE
Small improvement for StorageMaterializedView::getActionLock(...)

### DIFF
--- a/src/Storages/StorageMaterializedView.cpp
+++ b/src/Storages/StorageMaterializedView.cpp
@@ -431,7 +431,12 @@ Strings StorageMaterializedView::getDataPaths() const
 
 ActionLock StorageMaterializedView::getActionLock(StorageActionBlockType type)
 {
-    return has_inner_table ? getTargetTable()->getActionLock(type) : ActionLock{};
+    if (has_inner_table)
+    {
+        if (auto target_table = tryGetTargetTable())
+            return target_table->getActionLock(type);
+    }
+    return ActionLock{};
 }
 
 void registerStorageMaterializedView(StorageFactory & factory)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Detailed description / Documentation draft:
It might cause `SYSTEM STOP <ACTION>` query to fail:
https://clickhouse-test-reports.s3.yandex.net/24394/d8e5355b450c4d45526bdec635def284bce016fa/fast_test/runlog.out.log

