### PR TITLE
Fix mutation wait on mutation kill

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -523,10 +523,11 @@ void StorageReplicatedMergeTree::waitMutationToFinishOnReplicas(
             if (wait_event->tryWait(1000))
                 continue;
 
-            /// Here we check mutation for errors or kill on local replica. If they happen on this replica
+            /// Here we check mutation for errors on local replica. If they happen on this replica
             /// they will happen on each replica, so we can check only in-memory info.
             auto mutation_status = queue.getIncompleteMutationsStatus(mutation_id);
-            if (!mutation_status || !mutation_status->latest_fail_reason.empty())
+            /// If mutation status is empty, than local replica may just not loaded it into memory.
+            if (mutation_status && !mutation_status->latest_fail_reason.empty())
                 break;
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bug when exception `Mutation was killed` can be thrown to the client on mutation wait when mutation not loaded into memory yet.