### PR TITLE
Fix TraceCollector compile error On MacOS, Other Platforms's which  PIPE_BUF is 512

### DIFF
--- a/src/Common/TraceCollector.cpp
+++ b/src/Common/TraceCollector.cpp
@@ -27,7 +27,11 @@ namespace
     /// The performance test query ids can be surprisingly long like
     /// `aggregating_merge_tree_simple_aggregate_function_string.query100.profile100`,
     /// so make some allowance for them as well.
+#ifdef __linux__
     constexpr size_t QUERY_ID_MAX_LEN = 128;
+#else
+    constexpr size_t QUERY_ID_MAX_LEN = sizeof("00000000-0000-0000-0000-000000000000") - 1; // 36
+#endif
 }
 
 LazyPipeFDs pipe;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix TraceCollector compile error in MacOS, Other Platforms's which  PIPE_BUF is 512
...
Detailed description / Documentation draft:

On MacOS
src/Common/TraceCollector.cpp:74:5: error: static_assert failed due to requirement 'buf_size < 512' "Only write of PIPE_BUF to pipe is atomic"
    static_assert(buf_size < PIPE_BUF, "Only write of PIPE_BUF to pipe is atomic");

On MacOS, Other Platforms's which  PIPE_BUF is 512.

https://arto.s3.amazonaws.com/notes/posix

...


