### PR TITLE
Add Rust language third-party library, Klickhouse

### DIFF
--- a/docs/en/interfaces/third-party/client-libraries.md
+++ b/docs/en/interfaces/third-party/client-libraries.md
@@ -42,6 +42,8 @@ toc_title: Client Libraries
 -   Ruby
     -   [ClickHouse (Ruby)](https://github.com/shlima/click_house)
     -   [clickhouse-activerecord](https://github.com/PNixx/clickhouse-activerecord)
+-   Rust
+    -   [Klickhouse](https://github.com/Protryon/klickhouse)
 -   R
     -   [clickhouse-r](https://github.com/hannesmuehleisen/clickhouse-r)
     -   [RClickHouse](https://github.com/IMSMWU/RClickHouse)


### PR DESCRIPTION
Changelog category:
- Documentation

Detailed description: Adds Rust language to third-party client library list, and adds `klickhouse` as an entry under Rust.
