### PR TITLE
Paranoid fix for background pool task decrement

### DIFF
--- a/src/Storages/MergeTree/BackgroundJobsExecutor.cpp
+++ b/src/Storages/MergeTree/BackgroundJobsExecutor.cpp
@@ -116,8 +116,8 @@ try
                     }
                     catch (...)
                     {
-                        tryLogCurrentException(__PRETTY_FUNCTION__);
                         CurrentMetrics::values[pool_config.tasks_metric]--;
+                        tryLogCurrentException(__PRETTY_FUNCTION__);
                         scheduleTask(/* with_backoff = */ true);
                     }
                 });
@@ -128,8 +128,8 @@ try
             catch (...)
             {
                 /// With our Pool settings scheduleOrThrowOnError shouldn't throw exceptions, but for safety catch added here
-                tryLogCurrentException(__PRETTY_FUNCTION__);
                 CurrentMetrics::values[pool_config.tasks_metric]--;
+                tryLogCurrentException(__PRETTY_FUNCTION__);
                 scheduleTask(/* with_backoff = */ true);
             }
         }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix extremely rare bug on low-memory servers which can lead to the inability to perform merges without restart. Possibly fixes https://github.com/ClickHouse/ClickHouse/issues/24603.

Unfortunately, `tryLogCurrentException` also can throw exceptions on `Memory limit exceeded`. This problem was fixed multiple times recently: #24483, #24722.