### PR TITLE
Suppress RocksDB error

### DIFF
--- a/tests/queries/0_stateless/01504_rocksdb.sql
+++ b/tests/queries/0_stateless/01504_rocksdb.sql
@@ -1,47 +1,46 @@
-DROP TABLE IF EXISTS test;
+DROP TABLE IF EXISTS 01504_test;
 
-CREATE TABLE test (key String, value UInt32) Engine=EmbeddedRocksDB; -- { serverError 36 }
-CREATE TABLE test (key String, value UInt32) Engine=EmbeddedRocksDB PRIMARY KEY(key2); -- { serverError 47 }
-CREATE TABLE test (key String, value UInt32) Engine=EmbeddedRocksDB PRIMARY KEY(key, value); -- { serverError 36 }
-CREATE TABLE test (key Tuple(String, UInt32), value UInt64) Engine=EmbeddedRocksDB PRIMARY KEY(key);
+CREATE TABLE 01504_test (key String, value UInt32) Engine=EmbeddedRocksDB; -- { serverError 36 }
+CREATE TABLE 01504_test (key String, value UInt32) Engine=EmbeddedRocksDB PRIMARY KEY(key2); -- { serverError 47 }
+CREATE TABLE 01504_test (key String, value UInt32) Engine=EmbeddedRocksDB PRIMARY KEY(key, value); -- { serverError 36 }
+CREATE TABLE 01504_test (key Tuple(String, UInt32), value UInt64) Engine=EmbeddedRocksDB PRIMARY KEY(key);
 
-DROP TABLE IF EXISTS test;
-CREATE TABLE test (key String, value UInt32) Engine=EmbeddedRocksDB PRIMARY KEY(key);
+DROP TABLE IF EXISTS 01504_test;
+CREATE TABLE 01504_test (key String, value UInt32) Engine=EmbeddedRocksDB PRIMARY KEY(key);
 
-INSERT INTO test SELECT '1_1', number FROM numbers(10000);
-SELECT COUNT(1) == 1 FROM test;
+INSERT INTO 01504_test SELECT '1_1', number FROM numbers(10000);
+SELECT COUNT(1) == 1 FROM 01504_test;
 
-INSERT INTO test SELECT concat(toString(number), '_1'), number FROM numbers(10000);
-SELECT COUNT(1) == 10000 FROM test;
-SELECT uniqExact(key) == 32 FROM (SELECT * FROM test LIMIT 32 SETTINGS max_block_size = 1);
-SELECT SUM(value) == 1 + 99 + 900 FROM test WHERE key IN ('1_1', '99_1', '900_1');
-
-
-DROP TABLE IF EXISTS test;
-DROP TABLE IF EXISTS test_memory;
-
-CREATE TABLE test (k UInt32, value UInt64, dummy Tuple(UInt32, Float64), bm AggregateFunction(groupBitmap, UInt64)) Engine=EmbeddedRocksDB PRIMARY KEY(k);
-CREATE TABLE test_memory AS test Engine = Memory;
-
-INSERT INTO test SELECT number % 77 AS k, SUM(number) AS value, (1, 1.2), bitmapBuild(groupArray(number)) FROM numbers(10000000) group by k;
-
-INSERT INTO test_memory SELECT number % 77 AS k, SUM(number) AS value, (1, 1.2), bitmapBuild(groupArray(number)) FROM numbers(10000000) group by k;
+INSERT INTO 01504_test SELECT concat(toString(number), '_1'), number FROM numbers(10000);
+SELECT COUNT(1) == 10000 FROM 01504_test;
+SELECT uniqExact(key) == 32 FROM (SELECT * FROM 01504_test LIMIT 32 SETTINGS max_block_size = 1);
+SELECT SUM(value) == 1 + 99 + 900 FROM 01504_test WHERE key IN ('1_1', '99_1', '900_1');
 
 
-SELECT  A.a = B.a, A.b = B.b, A.c = B.c, A.d = B.d, A.e = B.e FROM ( SELECT 0 AS a, groupBitmapMerge(bm) AS b , SUM(k) AS c, SUM(value) AS d, SUM(dummy.1) AS e FROM test) A  ANY LEFT JOIN  (SELECT 0 AS a, groupBitmapMerge(bm) AS b , SUM(k) AS c, SUM(value) AS d, SUM(dummy.1) AS e FROM test_memory) B USING a ORDER BY a;
+DROP TABLE IF EXISTS 01504_test;
+DROP TABLE IF EXISTS 01504_test_memory;
+
+CREATE TABLE 01504_test (k UInt32, value UInt64, dummy Tuple(UInt32, Float64), bm AggregateFunction(groupBitmap, UInt64)) Engine=EmbeddedRocksDB PRIMARY KEY(k);
+CREATE TABLE 01504_test_memory AS 01504_test Engine = Memory;
+
+INSERT INTO 01504_test SELECT number % 77 AS k, SUM(number) AS value, (1, 1.2), bitmapBuild(groupArray(number)) FROM numbers(10000000) group by k;
+
+INSERT INTO 01504_test_memory SELECT number % 77 AS k, SUM(number) AS value, (1, 1.2), bitmapBuild(groupArray(number)) FROM numbers(10000000) group by k;
+
+
+SELECT  A.a = B.a, A.b = B.b, A.c = B.c, A.d = B.d, A.e = B.e FROM ( SELECT 0 AS a, groupBitmapMerge(bm) AS b , SUM(k) AS c, SUM(value) AS d, SUM(dummy.1) AS e FROM 01504_test) A  ANY LEFT JOIN  (SELECT 0 AS a, groupBitmapMerge(bm) AS b , SUM(k) AS c, SUM(value) AS d, SUM(dummy.1) AS e FROM 01504_test_memory) B USING a ORDER BY a;
 
 CREATE TEMPORARY TABLE keys AS SELECT * FROM numbers(1000);
 
 SET max_rows_to_read = 2;
-SELECT dummy == (1,1.2) FROM test WHERE k IN (1, 3) OR k IN (1) OR k IN (3, 1) OR k IN [1] OR k IN [1, 3] ;
-SELECT k == 4 FROM test WHERE k = 4 OR k IN [4] OR k in (4, 10000001, 10000002) AND value > 0;
-SELECT k == 4 FROM test WHERE k IN (SELECT toUInt32(number) FROM keys WHERE number = 4);
-SELECT k, value FROM test WHERE k = 0 OR value > 0; -- { serverError 158 }
-SELECT k, value FROM test WHERE k = 0 AND k IN (1, 3) OR k > 8; -- { serverError 158 }
+SELECT dummy == (1,1.2) FROM 01504_test WHERE k IN (1, 3) OR k IN (1) OR k IN (3, 1) OR k IN [1] OR k IN [1, 3] ;
+SELECT k == 4 FROM 01504_test WHERE k = 4 OR k IN [4] OR k in (4, 10000001, 10000002) AND value > 0;
+SELECT k == 4 FROM 01504_test WHERE k IN (SELECT toUInt32(number) FROM keys WHERE number = 4);
+SELECT k, value FROM 01504_test WHERE k = 0 OR value > 0; -- { serverError 158 }
+SELECT k, value FROM 01504_test WHERE k = 0 AND k IN (1, 3) OR k > 8; -- { serverError 158 }
 
-TRUNCATE TABLE test;
-SELECT 0 == COUNT(1) FROM test;
+TRUNCATE TABLE 01504_test;
+SELECT 0 == COUNT(1) FROM 01504_test;
 
-DROP TABLE IF EXISTS test;
-DROP TABLE IF EXISTS test_memory;
-
+DROP TABLE IF EXISTS 01504_test;
+DROP TABLE IF EXISTS 01504_test_memory;

--- a/tests/queries/0_stateless/01686_rocksdb.sql
+++ b/tests/queries/0_stateless/01686_rocksdb.sql
@@ -1,27 +1,26 @@
-DROP TABLE IF EXISTS test;
+DROP TABLE IF EXISTS 01686_test;
 
-CREATE TABLE test (key UInt64, value String) Engine=EmbeddedRocksDB PRIMARY KEY(key);
+CREATE TABLE 01686_test (key UInt64, value String) Engine=EmbeddedRocksDB PRIMARY KEY(key);
 
-INSERT INTO test SELECT number, format('Hello, world ({})', toString(number)) FROM numbers(10000);
+INSERT INTO 01686_test SELECT number, format('Hello, world ({})', toString(number)) FROM numbers(10000);
 
-SELECT * FROM test WHERE key = 123;
+SELECT * FROM 01686_test WHERE key = 123;
 SELECT '--';
-SELECT * FROM test WHERE key = -123;
+SELECT * FROM 01686_test WHERE key = -123;
 SELECT '--';
-SELECT * FROM test WHERE key = 123 OR key = 4567 ORDER BY key;
+SELECT * FROM 01686_test WHERE key = 123 OR key = 4567 ORDER BY key;
 SELECT '--';
-SELECT * FROM test WHERE key = NULL;
+SELECT * FROM 01686_test WHERE key = NULL;
 SELECT '--';
-SELECT * FROM test WHERE key = NULL OR key = 0;
+SELECT * FROM 01686_test WHERE key = NULL OR key = 0;
 SELECT '--';
-SELECT * FROM test WHERE key IN (123, 456, -123) ORDER BY key;
+SELECT * FROM 01686_test WHERE key IN (123, 456, -123) ORDER BY key;
 SELECT '--';
-SELECT * FROM test WHERE key = 'Hello'; -- { serverError 53 }
+SELECT * FROM 01686_test WHERE key = 'Hello'; -- { serverError 53 }
 
-DETACH TABLE test NO DELAY;
-ATTACH TABLE test;
+DETACH TABLE 01686_test NO DELAY;
+ATTACH TABLE 01686_test;
 
-SELECT * FROM test WHERE key IN (99, 999, 9999, -123) ORDER BY key;
+SELECT * FROM 01686_test WHERE key IN (99, 999, 9999, -123) ORDER BY key;
 
-DROP TABLE IF EXISTS test;
-
+DROP TABLE IF EXISTS 01686_test;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
I tried to reproduce it locally, but failed to achieve success

An example of the erorr
```
2021-06-02 15:08:25 01504_rocksdb:                                                          [ FAIL ] 0.24 sec. - return code 43
2021-06-02 15:08:25 Received exception from server (version 21.7.1):
2021-06-02 15:08:25 Code: 555. DB::Exception: Received from localhost:9000. DB::Exception: Fail to open rocksdb path at: /var/lib/clickhouse/data/default/test/: IO error: lock hold by current process, acquire time 1622635705 acquiring thread 140377640083456: /var/lib/clickhouse/data/default/test//LOCK: No locks available. 
2021-06-02 15:08:25 Received exception from server (version 21.7.1):
2021-06-02 15:08:25 Code: 1001. DB::Exception: Received from localhost:9000. DB::Exception: std::__1::__fs::filesystem::filesystem_error: filesystem error: in remove: Directory not empty [/var/lib/clickhouse/data/default/]. 
2021-06-02 15:08:25 , result:
2021-06-02 15:08:25 
2021-06-02 15:08:25 1
2021-06-02 15:08:25 1
2021-06-02 15:08:25 1
2021-06-02 15:08:25 1
2021-06-02 15:08:25 
2021-06-02 15:08:25 Database: test_l9o3bw
```
