### PR TITLE
Fix possible heap-buffer-overflow in Arrow

### DIFF
--- a/src/Processors/Formats/Impl/ArrowColumnToCHColumn.cpp
+++ b/src/Processors/Formats/Impl/ArrowColumnToCHColumn.cpp
@@ -90,8 +90,11 @@ namespace DB
             arrow::BinaryArray & chunk = static_cast<arrow::BinaryArray &>(*(arrow_column->chunk(chunk_i)));
             const size_t chunk_length = chunk.length();
 
-            chars_t_size += chunk.value_offset(chunk_length - 1) + chunk.value_length(chunk_length - 1);
-            chars_t_size += chunk_length; /// additional space for null bytes
+            if (chunk_length > 0)
+            {
+                chars_t_size += chunk.value_offset(chunk_length - 1) + chunk.value_length(chunk_length - 1);
+                chars_t_size += chunk_length; /// additional space for null bytes
+            }
         }
 
         column_chars_t.reserve(chars_t_size);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible heap-buffer-overflow in Arrow.

Detailed description / Documentation draft:
Fix possible heap-buffer-overflow while inserting empty array of strings in Arrow. This bug was found by executing test 00900_long_parquet_load under Debug + Asan build. 

