### PR TITLE
Fix limit/offset settings for distributed queries (ignore on the remote nodes)

### DIFF
--- a/src/Interpreters/ClusterProxy/executeQuery.cpp
+++ b/src/Interpreters/ClusterProxy/executeQuery.cpp
@@ -83,6 +83,17 @@ ContextMutablePtr updateSettingsForCluster(const Cluster & cluster, ContextPtr c
         }
     }
 
+    if (settings.offset)
+    {
+        new_settings.offset = 0;
+        new_settings.offset.changed = false;
+    }
+    if (settings.limit)
+    {
+        new_settings.limit = 0;
+        new_settings.limit.changed = false;
+    }
+
     auto new_context = Context::createCopy(context);
     new_context->setSettings(new_settings);
     return new_context;

--- a/tests/queries/0_stateless/01892_setting_limit_offset_distributed.reference
+++ b/tests/queries/0_stateless/01892_setting_limit_offset_distributed.reference
@@ -1,0 +1,14 @@
+limit	0
+limit	1
+limit	2
+limit	3
+limit	4
+offset	5
+offset	6
+offset	7
+offset	8
+offset	9
+limit w/ GROUP BY	4	4
+limit w/ GROUP BY	4	3
+limit/offset w/ GROUP BY	4	2
+limit/offset w/ GROUP BY	4	1

--- a/tests/queries/0_stateless/01892_setting_limit_offset_distributed.sql
+++ b/tests/queries/0_stateless/01892_setting_limit_offset_distributed.sql
@@ -1,0 +1,30 @@
+SELECT 'limit', * FROM remote('127.1', view(SELECT * FROM numbers(10))) SETTINGS limit=5;
+SELECT 'offset', * FROM remote('127.1', view(SELECT * FROM numbers(10))) SETTINGS offset=5;
+
+SELECT
+    'limit w/ GROUP BY',
+    count(),
+    number
+FROM remote('127.{1,2}', view(
+    SELECT intDiv(number, 2) AS number
+    FROM numbers(10)
+))
+GROUP BY number
+ORDER BY
+    count() ASC,
+    number DESC
+SETTINGS limit=2;
+
+SELECT
+    'limit/offset w/ GROUP BY',
+    count(),
+    number
+FROM remote('127.{1,2}', view(
+    SELECT intDiv(number, 2) AS number
+    FROM numbers(10)
+))
+GROUP BY number
+ORDER BY
+    count() ASC,
+    number DESC
+SETTINGS limit=2, offset=2;

--- a/tests/queries/0_stateless/arcadia_skip_list.txt
+++ b/tests/queries/0_stateless/arcadia_skip_list.txt
@@ -240,3 +240,4 @@
 01880_remote_ipv6
 01882_scalar_subquery_exception
 01882_check_max_parts_to_merge_at_once
+01892_setting_limit_offset_distributed


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix limit/offset settings for distributed queries (ignore on the remote nodes)

Cc: @hexiaoting
Follow-up for: #17633