### PR TITLE
Fix bad error message in docker entrypoint

### DIFF
--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -34,7 +34,7 @@ fi
 CLICKHOUSE_CONFIG="${CLICKHOUSE_CONFIG:-/etc/clickhouse-server/config.xml}"
 
 if ! $gosu test -f "$CLICKHOUSE_CONFIG" -a -r "$CLICKHOUSE_CONFIG"; then
-    echo "Configuration file '$dir' isn't readable by user with id '$USER'"
+    echo "Configuration file '$CLICKHOUSE_CONFIG' isn't readable by user with id '$USER'"
     exit 1
 fi
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Discovered in #24953

Detailed description / Documentation draft:
Copy & paste issue.