### PR TITLE
Trying to fix 'Tagging already tagged part'

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.cpp
@@ -441,10 +441,6 @@ Strings ReplicatedMergeTreeLogEntryData::getVirtualPartNames(MergeTreeDataFormat
     if (type == DROP_RANGE)
         return {new_part_name};
 
-    /// CLEAR_COLUMN and CLEAR_INDEX are deprecated since 20.3
-    if (type == CLEAR_COLUMN || type == CLEAR_INDEX)
-        return {};
-
     if (type == REPLACE_RANGE)
     {
         Strings res = replace_range_entry->new_part_names;

--- a/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.h
@@ -140,18 +140,6 @@ struct ReplicatedMergeTreeLogEntryData
     /// selection of merges. These parts are added to queue.virtual_parts.
     Strings getVirtualPartNames(MergeTreeDataFormatVersion format_version) const;
 
-    /// Returns set of parts that denote the block number ranges that should be blocked during the entry execution.
-    /// These parts are added to future_parts.
-    Strings getBlockingPartNames(MergeTreeDataFormatVersion format_version) const
-    {
-        Strings res = getVirtualPartNames(format_version);
-
-        if (type == CLEAR_COLUMN)
-            res.emplace_back(new_part_name);
-
-        return res;
-    }
-
     /// Returns fake part for drop range (for DROP_RANGE and REPLACE_RANGE)
     std::optional<String> getDropRange(MergeTreeDataFormatVersion format_version) const;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix extremely rare error `Tagging already tagged part` in replication queue during concurrent `alter move/replace partition`. Possibly fixes #22142.

Example error: https://clickhouse-test-reports.s3.yandex.net/24775/bc763981fc961a3460df1a042e08991a3434ce89/stress_test_(undefined).html#fail1


