### PR TITLE
Fix the test after #20393

### DIFF
--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -1320,7 +1320,8 @@ def test_librdkafka_compression(kafka_cluster):
         logging.debug(('Check compression {}'.format(compression_type)))
 
         topic_name = 'test_librdkafka_compression_{}'.format(compression_type)
-        admin_client = admin.AdminClient({'bootstrap.servers': 'localhost:9092'})
+        admin_client = admin.AdminClient({'bootstrap.servers': "localhost:{}".format(kafka_cluster.kafka_port)})
+
         topic = admin.NewTopic(topic=topic_name, num_partitions=1, replication_factor=1, config={
             'compression.type': compression_type,
         })


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now we should not use hardcoded ports in localhost anymore.

Detailed description / Documentation draft:
