### PR TITLE
Fix typo in usage section in s3 documentation

### DIFF
--- a/docs/en/engines/table-engines/integrations/s3.md
+++ b/docs/en/engines/table-engines/integrations/s3.md
@@ -167,7 +167,7 @@ The following settings can be specified in configuration file for given endpoint
 
 ## Usage {#usage-examples}
 
-Suppose we have several files in TSV format with the following URIs on HDFS:
+Suppose we have several files in CSV format with the following URIs on S3:
 
 -   'https://storage.yandexcloud.net/my-test-bucket-768/some_prefix/some_file_1.csv'
 -   'https://storage.yandexcloud.net/my-test-bucket-768/some_prefix/some_file_2.csv'

--- a/docs/ru/engines/table-engines/integrations/s3.md
+++ b/docs/ru/engines/table-engines/integrations/s3.md
@@ -110,7 +110,7 @@ SELECT * FROM s3_engine_table LIMIT 2;
 
 ## Примеры использования {#usage-examples}
 
-Предположим, у нас есть несколько файлов в формате TSV со следующими URL-адресами в S3:
+Предположим, у нас есть несколько файлов в формате CSV со следующими URL-адресами в S3:
 
 -   'https://storage.yandexcloud.net/my-test-bucket-768/some_prefix/some_file_1.csv'
 -   'https://storage.yandexcloud.net/my-test-bucket-768/some_prefix/some_file_2.csv'


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:

...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
