### PR TITLE
Add exit instruction to init script after service status check

### DIFF
--- a/debian/clickhouse-server.init
+++ b/debian/clickhouse-server.init
@@ -229,6 +229,7 @@ status()
 case "$1" in
 status)
     status
+    exit 0
     ;;
 esac
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Other

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix init script so it does not print 'usage' message for each 'status' command run

Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
