### PR TITLE
Mute stdout and stderr for both branches of cron task's if

### DIFF
--- a/debian/clickhouse-server.cron.d
+++ b/debian/clickhouse-server.cron.d
@@ -1,1 +1,1 @@
-#*/10 * * * * root (which service > /dev/null 2>&1 && (service clickhouse-server condstart ||:)) || /etc/init.d/clickhouse-server condstart > /dev/null 2>&1
+#*/10 * * * * root ((which service > /dev/null 2>&1 && (service clickhouse-server condstart ||:)) || /etc/init.d/clickhouse-server condstart) > /dev/null 2>&1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Other

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix cron.d task so it does not spam with email messages about current service status

Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
