### PR TITLE
Ban loop aliases in table definitions

### DIFF
--- a/src/Interpreters/QueryNormalizer.cpp
+++ b/src/Interpreters/QueryNormalizer.cpp
@@ -80,6 +80,9 @@ void QueryNormalizer::visit(ASTIdentifier & node, ASTPtr & ast, Data & data)
 
     /// If it is an alias, but not a parent alias (for constructs like "SELECT column + 1 AS column").
     auto it_alias = data.aliases.find(node.name());
+    if (!data.allow_self_aliases && current_alias == node.name())
+        throw Exception(ErrorCodes::CYCLIC_ALIASES, "Self referencing of {} to {}. Cyclic alias", backQuote(current_alias), backQuote(node.name()));
+
     if (it_alias != data.aliases.end() && current_alias != node.name())
     {
         if (!IdentifierSemantic::canBeAlias(node))

--- a/src/Interpreters/QueryNormalizer.h
+++ b/src/Interpreters/QueryNormalizer.h
@@ -48,18 +48,22 @@ public:
         MapOfASTs finished_asts;    /// already processed vertices (and by what they replaced)
         SetOfASTs current_asts;     /// vertices in the current call stack of this method
         std::string current_alias;  /// the alias referencing to the ancestor of ast (the deepest ancestor with aliases)
-        bool ignore_alias; /// normalize query without any aliases
+        const bool ignore_alias; /// normalize query without any aliases
 
-        Data(const Aliases & aliases_, const NameSet & source_columns_set_, bool ignore_alias_, ExtractedSettings && settings_)
+        /// It's Ok to have "c + 1 AS c" in queries, but not in table definition
+        const bool allow_self_aliases; /// for constructs like "SELECT column + 1 AS column"
+
+        Data(const Aliases & aliases_, const NameSet & source_columns_set_, bool ignore_alias_, ExtractedSettings && settings_, bool allow_self_aliases_)
             : aliases(aliases_)
             , source_columns_set(source_columns_set_)
             , settings(settings_)
             , level(0)
             , ignore_alias(ignore_alias_)
+            , allow_self_aliases(allow_self_aliases_)
         {}
     };
 
-    QueryNormalizer(Data & data)
+    explicit QueryNormalizer(Data & data)
         : visitor_data(data)
     {}
 

--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -913,7 +913,7 @@ TreeRewriterResultPtr TreeRewriter::analyzeSelect(
             all_source_columns_set.insert(name);
     }
 
-    normalize(query, result.aliases, all_source_columns_set, select_options.ignore_alias, settings);
+    normalize(query, result.aliases, all_source_columns_set, select_options.ignore_alias, settings, /* allow_self_aliases = */ true);
 
     /// Remove unneeded columns according to 'required_result_columns'.
     /// Leave all selected columns in case of DISTINCT; columns that contain arrayJoin function inside.
@@ -968,7 +968,7 @@ TreeRewriterResultPtr TreeRewriter::analyze(
 
     TreeRewriterResult result(source_columns, storage, metadata_snapshot, false);
 
-    normalize(query, result.aliases, result.source_columns_set, false, settings);
+    normalize(query, result.aliases, result.source_columns_set, false, settings, /* allow_self_aliases = */ false);
 
     /// Executing scalar subqueries. Column defaults could be a scalar subquery.
     executeScalarSubqueries(query, getContext(), 0, result.scalars, false);
@@ -994,7 +994,7 @@ TreeRewriterResultPtr TreeRewriter::analyze(
 }
 
 void TreeRewriter::normalize(
-    ASTPtr & query, Aliases & aliases, const NameSet & source_columns_set, bool ignore_alias, const Settings & settings)
+    ASTPtr & query, Aliases & aliases, const NameSet & source_columns_set, bool ignore_alias, const Settings & settings, bool allow_self_aliases)
 {
     CustomizeCountDistinctVisitor::Data data_count_distinct{settings.count_distinct_implementation};
     CustomizeCountDistinctVisitor(data_count_distinct).visit(query);
@@ -1054,7 +1054,7 @@ void TreeRewriter::normalize(
         FunctionNameNormalizer().visit(query.get());
 
     /// Common subexpression elimination. Rewrite rules.
-    QueryNormalizer::Data normalizer_data(aliases, source_columns_set, ignore_alias, settings);
+    QueryNormalizer::Data normalizer_data(aliases, source_columns_set, ignore_alias, settings, allow_self_aliases);
     QueryNormalizer(normalizer_data).visit(query);
 }
 

--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -959,7 +959,8 @@ TreeRewriterResultPtr TreeRewriter::analyze(
     const NamesAndTypesList & source_columns,
     ConstStoragePtr storage,
     const StorageMetadataPtr & metadata_snapshot,
-    bool allow_aggregations) const
+    bool allow_aggregations,
+    bool allow_self_aliases) const
 {
     if (query->as<ASTSelectQuery>())
         throw Exception("Not select analyze for select asts.", ErrorCodes::LOGICAL_ERROR);
@@ -968,7 +969,7 @@ TreeRewriterResultPtr TreeRewriter::analyze(
 
     TreeRewriterResult result(source_columns, storage, metadata_snapshot, false);
 
-    normalize(query, result.aliases, result.source_columns_set, false, settings, /* allow_self_aliases = */ false);
+    normalize(query, result.aliases, result.source_columns_set, false, settings, allow_self_aliases);
 
     /// Executing scalar subqueries. Column defaults could be a scalar subquery.
     executeScalarSubqueries(query, getContext(), 0, result.scalars, false);

--- a/src/Interpreters/TreeRewriter.h
+++ b/src/Interpreters/TreeRewriter.h
@@ -103,7 +103,8 @@ public:
         const NamesAndTypesList & source_columns_,
         ConstStoragePtr storage = {},
         const StorageMetadataPtr & metadata_snapshot = {},
-        bool allow_aggregations = false) const;
+        bool allow_aggregations = false,
+        bool allow_self_aliases = true) const;
 
     /// Analyze and rewrite select query
     TreeRewriterResultPtr analyzeSelect(

--- a/src/Interpreters/TreeRewriter.h
+++ b/src/Interpreters/TreeRewriter.h
@@ -115,7 +115,7 @@ public:
         std::shared_ptr<TableJoin> table_join = {}) const;
 
 private:
-    static void normalize(ASTPtr & query, Aliases & aliases, const NameSet & source_columns_set, bool ignore_alias, const Settings & settings);
+    static void normalize(ASTPtr & query, Aliases & aliases, const NameSet & source_columns_set, bool ignore_alias, const Settings & settings, bool allow_self_aliases);
 };
 
 }

--- a/src/Interpreters/tests/gtest_cycle_aliases.cpp
+++ b/src/Interpreters/tests/gtest_cycle_aliases.cpp
@@ -9,6 +9,21 @@
 
 using namespace DB;
 
+
+TEST(QueryNormalizer, SimpleLoopAlias)
+{
+    String query = "a as a";
+    ParserExpressionList parser(false);
+    ASTPtr ast = parseQuery(parser, query, 0, 0);
+
+    Aliases aliases;
+    aliases["a"] = parseQuery(parser, "a as a", 0, 0)->children[0];
+
+    Settings settings;
+    QueryNormalizer::Data normalizer_data(aliases, {}, false, settings, false);
+    EXPECT_THROW(QueryNormalizer(normalizer_data).visit(ast), Exception);
+}
+
 TEST(QueryNormalizer, SimpleCycleAlias)
 {
     String query = "a as b, b as a";
@@ -20,6 +35,6 @@ TEST(QueryNormalizer, SimpleCycleAlias)
     aliases["b"] = parseQuery(parser, "a as b", 0, 0)->children[0];
 
     Settings settings;
-    QueryNormalizer::Data normalizer_data(aliases, {}, false, settings);
+    QueryNormalizer::Data normalizer_data(aliases, {}, false, settings, true);
     EXPECT_THROW(QueryNormalizer(normalizer_data).visit(ast), Exception);
 }

--- a/src/Storages/ColumnsDescription.cpp
+++ b/src/Storages/ColumnsDescription.cpp
@@ -590,7 +590,7 @@ Block validateColumnsDefaultsAndGetSampleBlock(ASTPtr default_expr_list, const N
 
     try
     {
-        auto syntax_analyzer_result = TreeRewriter(context).analyze(default_expr_list, all_columns);
+        auto syntax_analyzer_result = TreeRewriter(context).analyze(default_expr_list, all_columns, {}, {}, false, /* allow_self_aliases = */ false);
         const auto actions = ExpressionAnalyzer(default_expr_list, syntax_analyzer_result, context).getActions(true);
         for (const auto & action : actions->getActions())
             if (action.node->type == ActionsDAG::ActionType::ARRAY_JOIN)

--- a/tests/queries/0_stateless/01902_self_aliases_in_columns.sql
+++ b/tests/queries/0_stateless/01902_self_aliases_in_columns.sql
@@ -1,0 +1,14 @@
+CREATE TABLE a
+(
+    `number` UInt64,
+    `x` MATERIALIZED x
+)
+ENGINE = MergeTree
+ORDER BY number; --{ serverError 174}
+
+CREATE TABLE foo
+(
+    i Int32,
+    j ALIAS j + 1
+)
+ENGINE = MergeTree() ORDER BY i; --{ serverError 174}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bug which allows creating tables with columns referencing themselves like `a UInt32 ALIAS a + 1` or `b UInt32 MATERIALIZED b`. Fixes #24910, #24292.

I'm not 100% percent sure that this one is the right place for fix. 