### PR TITLE
Add create database exists issue

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -161,8 +161,8 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
 
         metadata_path = metadata_path / "store" / DatabaseCatalog::getPathForUUID(create.uuid);
 
-        if (!create.attach && fs::exists(metadata_path))
-            throw Exception(ErrorCodes::DATABASE_ALREADY_EXISTS, "Metadata directory {} already exists", metadata_path.string());
+        if (!create.attach && fs::exists(metadata_file_path))
+            throw Exception(ErrorCodes::DATABASE_ALREADY_EXISTS, "Metadata file {} already exists", metadata_file_path.string());
     }
     else if (create.storage->engine->name == "MaterializeMySQL")
     {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

when create database,use metadata_file_path replace metadata_path to judge whether the database exists or not.

Detailed description / Documentation draft:
Logically, this problem will arise，for example，After creating the data directory metadata_path，the disk space full, then cause creating metadata_file_path failed, then the data directory always there, cause the next creation to report an error.