### PR TITLE
Fix topLevelDomain() for IDN hosts

### DIFF
--- a/src/Functions/URL/domain.h
+++ b/src/Functions/URL/domain.h
@@ -26,6 +26,8 @@ inline StringRef checkAndReturnHost(const Pos & pos, const Pos & dot_pos, const 
 }
 
 /// Extracts host from given url.
+///
+/// @return empty StringRef if the host is not valid (i.e. it does not have dot, or there no symbol after dot).
 inline StringRef getURLHost(const char * data, size_t size)
 {
     Pos pos = data;

--- a/src/Functions/URL/topLevelDomain.cpp
+++ b/src/Functions/URL/topLevelDomain.cpp
@@ -28,7 +28,10 @@ struct ExtractTopLevelDomain
                 return;
 
             /// For IPv4 addresses select nothing.
-            if (last_dot[1] <= '9')
+            ///
+            /// NOTE: it is safe to access last_dot[1]
+            /// since getURLHost() will not return a host if there is symbol after dot.
+            if (isNumericASCII(last_dot[1]))
                 return;
 
             res_data = last_dot + 1;

--- a/tests/queries/0_stateless/00398_url_functions.reference
+++ b/tests/queries/0_stateless/00398_url_functions.reference
@@ -35,6 +35,9 @@ ru
 com
 com
 com
+рф
+
+
 ====PATH====
 П
 %D%9

--- a/tests/queries/0_stateless/00398_url_functions.sql
+++ b/tests/queries/0_stateless/00398_url_functions.sql
@@ -38,6 +38,9 @@ SELECT topLevelDomain('svn+ssh://example.ru.?q=hello%20world') AS Domain;
 SELECT topLevelDomain('//www.example.com') AS Domain;
 SELECT topLevelDomain('www.example.com') as Domain;
 SELECT topLevelDomain('example.com') as Domain;
+SELECT topLevelDomain('example.рф') as Domain;
+SELECT topLevelDomain('example.') as Domain;
+SELECT topLevelDomain('example') as Domain;
 
 SELECT '====PATH====';
 SELECT decodeURLComponent('%D0%9F');

--- a/tests/queries/1_stateful/00038_uniq_state_merge2.reference
+++ b/tests/queries/1_stateful/00038_uniq_state_merge2.reference
@@ -1,5 +1,5 @@
 ru	262914	69218
-	92101	89421
+	91872	89417
 com	63298	30285
 ua	29037	17475
 html	25079	15039
@@ -53,6 +53,7 @@ eu	237	234
 liveinteria	218	218
 to	215	213
 mamba	214	214
+рф	209	204
 auto-supers	208	208
 sberbank	207	207
 tj	205	205
@@ -97,4 +98,3 @@ loveplaceOfSearchplus	111	111
 nl	111	111
 bstatistika	107	107
 br	102	102
-sport	99	99


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix topLevelDomain() for IDN hosts (i.e. `example.рф`), before it returns empty string for such hosts.