### PR TITLE
Disabling extended precision data types TestFlows tests

### DIFF
--- a/tests/testflows/regression.py
+++ b/tests/testflows/regression.py
@@ -30,7 +30,7 @@ def regression(self, local, clickhouse_binary_path, stress=None, parallel=None):
             run_scenario(pool, tasks, Feature(test=load("window_functions.regression", "regression")), args)
             run_scenario(pool, tasks, Feature(test=load("datetime64_extended_range.regression", "regression")), args)
             #run_scenario(pool, tasks, Feature(test=load("kerberos.regression", "regression")), args)
-            run_scenario(pool, tasks, Feature(test=load("extended_precision_data_types.regression", "regression")), args)
+            #run_scenario(pool, tasks, Feature(test=load("extended_precision_data_types.regression", "regression")), args)
         finally:
             join(tasks)
 


### PR DESCRIPTION
Disabling extended precision data types TestFlows tests

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Disabling extended precision data types TestFlows tests

Detailed description / Documentation draft:
Disabling extended precision data types TestFlows tests
