### PR TITLE
Better hdfs tests

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-clickhouse (21.7.1.1) unstable; urgency=low
+clickhouse (21.7.1+asan) unstable; urgency=low
 
   * Modified source code
 
- -- clickhouse-release <clickhouse-release@yandex-team.ru>  Thu, 20 May 2021 22:23:29 +0300
+ --  <root@yandex-team.ru>  Fri, 04 Jun 2021 07:31:14 +0000

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-clickhouse (21.7.1+asan) unstable; urgency=low
+clickhouse (21.7.1.1) unstable; urgency=low
 
   * Modified source code
 
- --  <root@yandex-team.ru>  Fri, 04 Jun 2021 07:31:14 +0000
+ -- clickhouse-release <clickhouse-release@yandex-team.ru>  Thu, 20 May 2021 22:23:29 +0300

--- a/docker/test/integration/runner/compose/docker_compose_hdfs.yml
+++ b/docker/test/integration/runner/compose/docker_compose_hdfs.yml
@@ -4,9 +4,9 @@ services:
         image: sequenceiq/hadoop-docker:2.7.0
         hostname: hdfs1
         restart: always
-        ports:
-            - ${HDFS_NAME_EXTERNAL_PORT}:${HDFS_NAME_INTERNAL_PORT} #50070
-            - ${HDFS_DATA_EXTERNAL_PORT}:${HDFS_DATA_INTERNAL_PORT} #50075
+        expose:
+            - ${HDFS_NAME_PORT}
+            - ${HDFS_DATA_PORT}
         entrypoint: /etc/bootstrap.sh -d
         volumes:
             - type: ${HDFS_FS:-tmpfs}

--- a/docker/test/integration/runner/compose/docker_compose_kerberized_hdfs.yml
+++ b/docker/test/integration/runner/compose/docker_compose_kerberized_hdfs.yml
@@ -14,9 +14,9 @@ services:
       - type: ${KERBERIZED_HDFS_FS:-tmpfs}
         source: ${KERBERIZED_HDFS_LOGS:-}
         target: /var/log/hadoop-hdfs
-    ports:
-      - ${KERBERIZED_HDFS_NAME_EXTERNAL_PORT}:${KERBERIZED_HDFS_NAME_INTERNAL_PORT} #50070
-      - ${KERBERIZED_HDFS_DATA_EXTERNAL_PORT}:${KERBERIZED_HDFS_DATA_INTERNAL_PORT} #1006
+    expose:
+      - ${KERBERIZED_HDFS_NAME_PORT}
+      - ${KERBERIZED_HDFS_DATA_PORT}
     depends_on:
       - hdfskerberos
     entrypoint: /etc/bootstrap.sh -d
@@ -28,4 +28,4 @@ services:
       - ${KERBERIZED_HDFS_DIR}/secrets:/tmp/keytab
       - ${KERBERIZED_HDFS_DIR}/../../kerberos_image_config.sh:/config.sh
       - /dev/urandom:/dev/random
-    ports: [88, 749]
+    expose: [88, 749]

--- a/docker/test/integration/runner/dockerd-entrypoint.sh
+++ b/docker/test/integration/runner/dockerd-entrypoint.sh
@@ -10,7 +10,7 @@ echo '{
     "storage-driver": "overlay2",
     "insecure-registries" : ["dockerhub-proxy.sas.yp-c.yandex.net:5000"],
     "registry-mirrors" : ["http://dockerhub-proxy.sas.yp-c.yandex.net:5000"]
-}' | dd of=/etc/docker/daemon.json
+}' | dd of=/etc/docker/daemon.json 2>/dev/null
 
 dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2375 --default-address-pool base=172.17.0.0/12,size=24 &>/ClickHouse/tests/integration/dockerd.log &
 

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -261,15 +261,17 @@ class ClickHouseCluster:
         # available when with_hdfs == True
         self.hdfs_host = "hdfs1"
         self.hdfs_ip = None
-        self.hdfs_name_port = get_free_port()
-        self.hdfs_data_port = get_free_port()
+        self.hdfs_name_port = 50070
+        self.hdfs_data_port = 50075
         self.hdfs_dir = p.abspath(p.join(self.instances_dir, "hdfs"))
         self.hdfs_logs_dir = os.path.join(self.hdfs_dir, "logs")
+        self.hdfs_api = None # also for kerberized hdfs
 
         # available when with_kerberized_hdfs == True
         self.hdfs_kerberized_host = "kerberizedhdfs1"
-        self.hdfs_kerberized_name_port = get_free_port()
-        self.hdfs_kerberized_data_port = get_free_port()
+        self.hdfs_kerberized_ip = None
+        self.hdfs_kerberized_name_port = 50070
+        self.hdfs_kerberized_data_port = 1006
         self.hdfs_kerberized_dir = p.abspath(p.join(self.instances_dir, "kerberized_hdfs"))
         self.hdfs_kerberized_logs_dir = os.path.join(self.hdfs_kerberized_dir, "logs")
 
@@ -562,10 +564,8 @@ class ClickHouseCluster:
     def setup_hdfs_cmd(self, instance, env_variables, docker_compose_yml_dir):
         self.with_hdfs = True
         env_variables['HDFS_HOST'] = self.hdfs_host
-        env_variables['HDFS_NAME_EXTERNAL_PORT'] = str(self.hdfs_name_port)
-        env_variables['HDFS_NAME_INTERNAL_PORT'] = "50070"
-        env_variables['HDFS_DATA_EXTERNAL_PORT'] = str(self.hdfs_data_port)
-        env_variables['HDFS_DATA_INTERNAL_PORT'] = "50075"
+        env_variables['HDFS_NAME_PORT'] = str(self.hdfs_name_port)
+        env_variables['HDFS_DATA_PORT'] = str(self.hdfs_data_port)
         env_variables['HDFS_LOGS'] = self.hdfs_logs_dir
         env_variables['HDFS_FS'] = "bind"
         self.base_cmd.extend(['--file', p.join(docker_compose_yml_dir, 'docker_compose_hdfs.yml')])
@@ -577,10 +577,8 @@ class ClickHouseCluster:
     def setup_kerberized_hdfs_cmd(self, instance, env_variables, docker_compose_yml_dir):
         self.with_kerberized_hdfs = True
         env_variables['KERBERIZED_HDFS_HOST'] = self.hdfs_kerberized_host
-        env_variables['KERBERIZED_HDFS_NAME_EXTERNAL_PORT'] = str(self.hdfs_kerberized_name_port)
-        env_variables['KERBERIZED_HDFS_NAME_INTERNAL_PORT'] = "50070"
-        env_variables['KERBERIZED_HDFS_DATA_EXTERNAL_PORT'] = str(self.hdfs_kerberized_data_port)
-        env_variables['KERBERIZED_HDFS_DATA_INTERNAL_PORT'] = "1006"
+        env_variables['KERBERIZED_HDFS_NAME_PORT'] = str(self.hdfs_kerberized_name_port)
+        env_variables['KERBERIZED_HDFS_DATA_PORT'] = str(self.hdfs_kerberized_data_port)
         env_variables['KERBERIZED_HDFS_LOGS'] = self.hdfs_kerberized_logs_dir
         env_variables['KERBERIZED_HDFS_FS'] = "bind"
         env_variables['KERBERIZED_HDFS_DIR'] = instance.path + '/'
@@ -1088,30 +1086,26 @@ class ClickHouseCluster:
         raise Exception("Cannot wait ZooKeeper container")
 
     def make_hdfs_api(self, timeout=180, kerberized=False):
-        hdfs_api = None
         if kerberized:
             keytab = p.abspath(p.join(self.instances['node1'].path, "secrets/clickhouse.keytab"))
             krb_conf = p.abspath(p.join(self.instances['node1'].path, "secrets/krb_long.conf"))
-            hdfs_ip = self.get_instance_ip('kerberizedhdfs1')
-            # logging.debug("kerberizedhdfs1 ip ", hdfs_ip)
+            self.hdfs_kerberized_ip = self.get_instance_ip(self.hdfs_kerberized_host)
             kdc_ip = self.get_instance_ip('hdfskerberos')
-            # logging.debug("kdc_ip ", kdc_ip)
-            hdfs_api = HDFSApi(user="root",
-                              timeout=timeout,
-                              kerberized=True,
-                              principal="root@TEST.CLICKHOUSE.TECH",
-                              keytab=keytab,
-                              krb_conf=krb_conf,
-                              host="localhost",
-                              protocol="http",
-                              proxy_port=self.hdfs_kerberized_name_port,
-                              data_port=self.hdfs_kerberized_data_port,
-                              hdfs_ip=hdfs_ip,
-                              kdc_ip=kdc_ip)                         
+            self.hdfs_api = HDFSApi(user="root",
+                                    timeout=timeout,
+                                    kerberized=True,
+                                    principal="root@TEST.CLICKHOUSE.TECH",
+                                    keytab=keytab,
+                                    krb_conf=krb_conf,
+                                    host=self.hdfs_kerberized_host,
+                                    protocol="http",
+                                    proxy_port=self.hdfs_kerberized_name_port,
+                                    data_port=self.hdfs_kerberized_data_port,
+                                    hdfs_ip=self.hdfs_kerberized_ip,
+                                    kdc_ip=kdc_ip)                         
         else:
-            logging.debug("Create HDFSApi host={}".format("localhost"))
-            hdfs_api = HDFSApi(user="root", host="localhost", data_port=self.hdfs_data_port, proxy_port=self.hdfs_name_port)
-        return hdfs_api
+            self.hdfs_ip = self.get_instance_ip(self.hdfs_host)
+            self.hdfs_api = HDFSApi(user="root", host=self.hdfs_host, data_port=self.hdfs_data_port, proxy_port=self.hdfs_name_port, hdfs_ip=self.hdfs_ip)
 
     def wait_kafka_is_available(self, kafka_docker_id, kafka_port, max_retries=50):
         retries = 0
@@ -1126,16 +1120,15 @@ class ClickHouseCluster:
                 time.sleep(1)
 
 
-    def wait_hdfs_to_start(self, hdfs_api, timeout=300):
-        self.hdfs_ip = self.get_instance_ip(self.hdfs_host)
+    def wait_hdfs_to_start(self, timeout=120):
         start = time.time()
         while time.time() - start < timeout:
             try:
-                hdfs_api.write_data("/somefilewithrandomname222", "1")
+                self.hdfs_api.write_data("/somefilewithrandomname222", "1")
                 logging.debug("Connected to HDFS and SafeMode disabled! ")
                 return
             except Exception as ex:
-                logging.debug("Can't connect to HDFS " + str(ex))
+                logging.exception("Can't connect to HDFS " + str(ex))
                 time.sleep(1)
 
         raise Exception("Can't wait HDFS to start")
@@ -1373,16 +1366,16 @@ class ClickHouseCluster:
                 os.makedirs(self.hdfs_logs_dir)
                 os.chmod(self.hdfs_logs_dir, stat.S_IRWXO)
                 subprocess_check_call(self.base_hdfs_cmd + common_opts)
-                hdfs_api = self.make_hdfs_api()
-                self.wait_hdfs_to_start(hdfs_api)
+                self.make_hdfs_api()
+                self.wait_hdfs_to_start()
 
             if self.with_kerberized_hdfs and self.base_kerberized_hdfs_cmd:
                 logging.debug('Setup kerberized HDFS')
                 os.makedirs(self.hdfs_kerberized_logs_dir)
                 os.chmod(self.hdfs_kerberized_logs_dir, stat.S_IRWXO)
                 run_and_check(self.base_kerberized_hdfs_cmd + common_opts)
-                hdfs_api = self.make_hdfs_api(kerberized=True)
-                self.wait_hdfs_to_start(hdfs_api)
+                self.make_hdfs_api(kerberized=True)
+                self.wait_hdfs_to_start()
 
             if self.with_mongo and self.base_mongo_cmd:
                 logging.debug('Setup Mongo')

--- a/tests/integration/helpers/hdfs_api.py
+++ b/tests/integration/helpers/hdfs_api.py
@@ -106,12 +106,12 @@ class HDFSApi(object):
 
 
     def read_data(self, path, universal_newlines=True):
-        logging.debug("read_data protocol:{} host:{} proxy port:{} data port:{} path: {}".format(self.protocol, self.host, self.proxy_port, self.data_port, path))
-        response = self.req_wrapper(requests.get, 307, url="{protocol}://{host}:{port}/webhdfs/v1{path}?op=OPEN".format(protocol=self.protocol, host=self.host, port=self.proxy_port, path=path), headers={'host': str(self.hdfs_ip)}, allow_redirects=False, verify=False, auth=self.kerberos_auth)
+        logging.debug("read_data protocol:{} host:{} ip:{} proxy port:{} data port:{} path: {}".format(self.protocol, self.host, self.hdfs_ip, self.proxy_port, self.data_port, path))
+        response = self.req_wrapper(requests.get, 307, url="{protocol}://{ip}:{port}/webhdfs/v1{path}?op=OPEN".format(protocol=self.protocol, ip=self.hdfs_ip, port=self.proxy_port, path=path), headers={'host': str(self.hdfs_ip)}, allow_redirects=False, verify=False, auth=self.kerberos_auth)
         # additional_params = '&'.join(response.headers['Location'].split('&')[1:2])
         location = None
         if self.kerberized:
-            location = response.headers['Location'].replace("kerberizedhdfs1:9010", "{}:{}".format(self.hdfs_ip, self.proxy_port))
+            location = response.headers['Location'].replace("kerberizedhdfs1:1006", "{}:{}".format(self.hdfs_ip, self.data_port))
         else:
             location = response.headers['Location'].replace("hdfs1:50075", "{}:{}".format(self.hdfs_ip, self.data_port))
         logging.debug("redirected to {}".format(location))

--- a/tests/integration/helpers/network.py
+++ b/tests/integration/helpers/network.py
@@ -144,7 +144,7 @@ class _NetworkManager:
             res = subprocess.run("iptables -D DOCKER-USER 1", shell=True)
 
             if res.returncode != 0:
-                logging.info("All iptables rules cleared, " + str(iptables_iter) + "iterations, last error: " + str(res.stderr))
+                logging.info("All iptables rules cleared, " + str(iptables_iter) + " iterations, last error: " + str(res.stderr))
                 return
 
     @staticmethod

--- a/tests/integration/test_allowed_url_from_config/test.py
+++ b/tests/integration/test_allowed_url_from_config/test.py
@@ -115,7 +115,7 @@ def test_table_function_remote(start_cluster):
 
 
 def test_redirect(start_cluster):
-    hdfs_api = start_cluster.make_hdfs_api()
+    hdfs_api = start_cluster.hdfs_api
 
     hdfs_api.write_data("/simple_storage", "1\t\n")
     assert hdfs_api.read_data("/simple_storage") == "1\t\n"

--- a/tests/integration/test_cleanup_dir_after_bad_zk_conn/test.py
+++ b/tests/integration/test_cleanup_dir_after_bad_zk_conn/test.py
@@ -45,19 +45,19 @@ def test_cleanup_dir_after_bad_zk_conn(start_cluster):
                "All connection tries failed while connecting to ZooKeeper" in error
         error = node1.query_and_get_error(query_create)
         assert "Directory for table data data/replica/test/ already exists" not in error
-    node1.query(query_create)
-    node1.query('''INSERT INTO replica.test VALUES (1, now())''')
+    node1.query_with_retry(query_create)
+    node1.query_with_retry('''INSERT INTO replica.test VALUES (1, now())''')
     assert "1\n" in node1.query('''SELECT count() from replica.test FORMAT TSV''')
 
 
 def test_cleanup_dir_after_wrong_replica_name(start_cluster):
-    node1.query(
-        "CREATE TABLE test2_r1 (n UInt64) ENGINE=ReplicatedMergeTree('/clickhouse/tables/test2/', 'r1') ORDER BY n")
+    node1.query_with_retry(
+        "CREATE TABLE IF NOT EXISTS test2_r1 (n UInt64) ENGINE=ReplicatedMergeTree('/clickhouse/tables/test2/', 'r1') ORDER BY n")
     error = node1.query_and_get_error(
         "CREATE TABLE test2_r2 (n UInt64) ENGINE=ReplicatedMergeTree('/clickhouse/tables/test2/', 'r1') ORDER BY n")
     assert "already exists" in error
-    node1.query(
-        "CREATE TABLE test_r2 (n UInt64) ENGINE=ReplicatedMergeTree('/clickhouse/tables/test2/', 'r2') ORDER BY n")
+    node1.query_with_retry(
+        "CREATE TABLE IF NOT EXISTS test_r2 (n UInt64) ENGINE=ReplicatedMergeTree('/clickhouse/tables/test2/', 'r2') ORDER BY n")
 
 
 def test_cleanup_dir_after_wrong_zk_path(start_cluster):
@@ -71,7 +71,7 @@ def test_cleanup_dir_after_wrong_zk_path(start_cluster):
 
 
 def test_attach_without_zk(start_cluster):
-    node1.query(
+    node1.query_with_retry(
         "CREATE TABLE test4_r1 (n UInt64) ENGINE=ReplicatedMergeTree('/clickhouse/tables/test4/', 'r1') ORDER BY n")
     node1.query("DETACH TABLE test4_r1")
     with PartitionManager() as pm:

--- a/tests/integration/test_odbc_interaction/test.py
+++ b/tests/integration/test_odbc_interaction/test.py
@@ -311,7 +311,7 @@ def test_sqlite_odbc_cached_dictionary(started_cluster):
     skip_test_msan(node1)
 
     sqlite_db = node1.odbc_drivers["SQLite3"]["Database"]
-    node1.exec_in_container(["]sqlite3", sqlite_db, "INSERT INTO t3 values(1, 2, 3);"],
+    node1.exec_in_container(["sqlite3", sqlite_db, "INSERT INTO t3 values(1, 2, 3);"],
                             privileged=True, user='root')
 
     assert node1.query("select dictGetUInt8('sqlite3_odbc_cached', 'Z', toUInt64(1))") == "3\n"

--- a/tests/integration/test_partition/test.py
+++ b/tests/integration/test_partition/test.py
@@ -1,6 +1,6 @@
 import pytest
-
-from helpers.cluster import ClickHouseCluster, subprocess_check_call
+import logging
+from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
 cluster = ClickHouseCluster(__file__)
@@ -23,107 +23,104 @@ def started_cluster():
 
 @pytest.fixture
 def partition_table_simple(started_cluster):
-    q("DROP TABLE IF EXISTS test.partition")
-    q("CREATE TABLE test.partition (date MATERIALIZED toDate(0), x UInt64, sample_key MATERIALIZED intHash64(x)) "
+    q("DROP TABLE IF EXISTS test.partition_simple")
+    q("CREATE TABLE test.partition_simple (date MATERIALIZED toDate(0), x UInt64, sample_key MATERIALIZED intHash64(x)) "
       "ENGINE=MergeTree PARTITION BY date SAMPLE BY sample_key ORDER BY (date,x,sample_key) "
       "SETTINGS index_granularity=8192, index_granularity_bytes=0")
-    q("INSERT INTO test.partition ( x ) VALUES ( now() )")
-    q("INSERT INTO test.partition ( x ) VALUES ( now()+1 )")
+    q("INSERT INTO test.partition_simple ( x ) VALUES ( now() )")
+    q("INSERT INTO test.partition_simple ( x ) VALUES ( now()+1 )")
 
     yield
 
-    q('DROP TABLE test.partition')
+    q('DROP TABLE test.partition_simple')
 
 
 def test_partition_simple(partition_table_simple):
-    q("ALTER TABLE test.partition DETACH PARTITION 197001")
-    q("ALTER TABLE test.partition ATTACH PARTITION 197001")
-    q("OPTIMIZE TABLE test.partition")
+    q("ALTER TABLE test.partition_simple DETACH PARTITION 197001")
+    q("ALTER TABLE test.partition_simple ATTACH PARTITION 197001")
+    q("OPTIMIZE TABLE test.partition_simple")
 
 
 def partition_complex_assert_columns_txt():
-    path_to_parts = path_to_data + 'data/test/partition/'
-    parts = TSV(q("SELECT name FROM system.parts WHERE database='test' AND table='partition'"))
+    path_to_parts = path_to_data + 'data/test/partition_complex/'
+    parts = TSV(q("SELECT name FROM system.parts WHERE database='test' AND table='partition_complex'"))
+    assert len(parts) > 0
     for part_name in parts.lines:
         path_to_columns = path_to_parts + part_name + '/columns.txt'
         # 2 header lines + 3 columns
-        assert subprocess_check_call('cat {} | wc -l'.format(path_to_columns)) == '5\n'
+        assert instance.exec_in_container(['wc', '-l', path_to_columns]).split()[0] == '5'
 
 
 def partition_complex_assert_checksums():
-    # Do `cd` for consistent output for reference
     # Do not check increment.txt - it can be changed by other tests with FREEZE
-    cmd = 'cd ' + path_to_data + " && find shadow -type f -exec md5sum {} \\;" \
-                                 "  | grep partition" \
-                                 "  | sed 's!shadow/[0-9]*/data/[a-z0-9_-]*/!shadow/1/data/test/!g'" \
-                                 "  | sort" \
-                                 "  | uniq"
+    cmd = ["bash", "-c", f"cd {path_to_data} && find shadow -type f -exec" + " md5sum {} \\; | grep partition_complex" \
+           " | sed 's shadow/[0-9]*/data/[a-z0-9_-]*/ shadow/1/data/test/ g' | sort | uniq"]
 
-    checksums = "082814b5aa5109160d5c0c5aff10d4df\tshadow/1/data/test/partition/19700102_2_2_0/k.bin\n" \
-                "082814b5aa5109160d5c0c5aff10d4df\tshadow/1/data/test/partition/19700201_1_1_0/v1.bin\n" \
-                "13cae8e658e0ca4f75c56b1fc424e150\tshadow/1/data/test/partition/19700102_2_2_0/minmax_p.idx\n" \
-                "25daad3d9e60b45043a70c4ab7d3b1c6\tshadow/1/data/test/partition/19700102_2_2_0/partition.dat\n" \
-                "3726312af62aec86b64a7708d5751787\tshadow/1/data/test/partition/19700201_1_1_0/partition.dat\n" \
-                "37855b06a39b79a67ea4e86e4a3299aa\tshadow/1/data/test/partition/19700102_2_2_0/checksums.txt\n" \
-                "38e62ff37e1e5064e9a3f605dfe09d13\tshadow/1/data/test/partition/19700102_2_2_0/v1.bin\n" \
-                "4ae71336e44bf9bf79d2752e234818a5\tshadow/1/data/test/partition/19700102_2_2_0/k.mrk\n" \
-                "4ae71336e44bf9bf79d2752e234818a5\tshadow/1/data/test/partition/19700102_2_2_0/p.mrk\n" \
-                "4ae71336e44bf9bf79d2752e234818a5\tshadow/1/data/test/partition/19700102_2_2_0/v1.mrk\n" \
-                "4ae71336e44bf9bf79d2752e234818a5\tshadow/1/data/test/partition/19700201_1_1_0/k.mrk\n" \
-                "4ae71336e44bf9bf79d2752e234818a5\tshadow/1/data/test/partition/19700201_1_1_0/p.mrk\n" \
-                "4ae71336e44bf9bf79d2752e234818a5\tshadow/1/data/test/partition/19700201_1_1_0/v1.mrk\n" \
-                "55a54008ad1ba589aa210d2629c1df41\tshadow/1/data/test/partition/19700201_1_1_0/primary.idx\n" \
-                "5f087cb3e7071bf9407e095821e2af8f\tshadow/1/data/test/partition/19700201_1_1_0/checksums.txt\n" \
-                "77d5af402ada101574f4da114f242e02\tshadow/1/data/test/partition/19700102_2_2_0/columns.txt\n" \
-                "77d5af402ada101574f4da114f242e02\tshadow/1/data/test/partition/19700201_1_1_0/columns.txt\n" \
-                "88cdc31ded355e7572d68d8cde525d3a\tshadow/1/data/test/partition/19700201_1_1_0/p.bin\n" \
-                "9e688c58a5487b8eaf69c9e1005ad0bf\tshadow/1/data/test/partition/19700102_2_2_0/primary.idx\n" \
-                "c0904274faa8f3f06f35666cc9c5bd2f\tshadow/1/data/test/partition/19700102_2_2_0/default_compression_codec.txt\n" \
-                "c0904274faa8f3f06f35666cc9c5bd2f\tshadow/1/data/test/partition/19700201_1_1_0/default_compression_codec.txt\n" \
-                "c4ca4238a0b923820dcc509a6f75849b\tshadow/1/data/test/partition/19700102_2_2_0/count.txt\n" \
-                "c4ca4238a0b923820dcc509a6f75849b\tshadow/1/data/test/partition/19700201_1_1_0/count.txt\n" \
-                "cfcb770c3ecd0990dcceb1bde129e6c6\tshadow/1/data/test/partition/19700102_2_2_0/p.bin\n" \
-                "e2af3bef1fd129aea73a890ede1e7a30\tshadow/1/data/test/partition/19700201_1_1_0/k.bin\n" \
-                "f2312862cc01adf34a93151377be2ddf\tshadow/1/data/test/partition/19700201_1_1_0/minmax_p.idx\n"
+    checksums = "082814b5aa5109160d5c0c5aff10d4df\tshadow/1/data/test/partition_complex/19700102_2_2_0/k.bin\n" \
+                "082814b5aa5109160d5c0c5aff10d4df\tshadow/1/data/test/partition_complex/19700201_1_1_0/v1.bin\n" \
+                "13cae8e658e0ca4f75c56b1fc424e150\tshadow/1/data/test/partition_complex/19700102_2_2_0/minmax_p.idx\n" \
+                "25daad3d9e60b45043a70c4ab7d3b1c6\tshadow/1/data/test/partition_complex/19700102_2_2_0/partition.dat\n" \
+                "3726312af62aec86b64a7708d5751787\tshadow/1/data/test/partition_complex/19700201_1_1_0/partition.dat\n" \
+                "37855b06a39b79a67ea4e86e4a3299aa\tshadow/1/data/test/partition_complex/19700102_2_2_0/checksums.txt\n" \
+                "38e62ff37e1e5064e9a3f605dfe09d13\tshadow/1/data/test/partition_complex/19700102_2_2_0/v1.bin\n" \
+                "4ae71336e44bf9bf79d2752e234818a5\tshadow/1/data/test/partition_complex/19700102_2_2_0/k.mrk\n" \
+                "4ae71336e44bf9bf79d2752e234818a5\tshadow/1/data/test/partition_complex/19700102_2_2_0/p.mrk\n" \
+                "4ae71336e44bf9bf79d2752e234818a5\tshadow/1/data/test/partition_complex/19700102_2_2_0/v1.mrk\n" \
+                "4ae71336e44bf9bf79d2752e234818a5\tshadow/1/data/test/partition_complex/19700201_1_1_0/k.mrk\n" \
+                "4ae71336e44bf9bf79d2752e234818a5\tshadow/1/data/test/partition_complex/19700201_1_1_0/p.mrk\n" \
+                "4ae71336e44bf9bf79d2752e234818a5\tshadow/1/data/test/partition_complex/19700201_1_1_0/v1.mrk\n" \
+                "55a54008ad1ba589aa210d2629c1df41\tshadow/1/data/test/partition_complex/19700201_1_1_0/primary.idx\n" \
+                "5f087cb3e7071bf9407e095821e2af8f\tshadow/1/data/test/partition_complex/19700201_1_1_0/checksums.txt\n" \
+                "77d5af402ada101574f4da114f242e02\tshadow/1/data/test/partition_complex/19700102_2_2_0/columns.txt\n" \
+                "77d5af402ada101574f4da114f242e02\tshadow/1/data/test/partition_complex/19700201_1_1_0/columns.txt\n" \
+                "88cdc31ded355e7572d68d8cde525d3a\tshadow/1/data/test/partition_complex/19700201_1_1_0/p.bin\n" \
+                "9e688c58a5487b8eaf69c9e1005ad0bf\tshadow/1/data/test/partition_complex/19700102_2_2_0/primary.idx\n" \
+                "c0904274faa8f3f06f35666cc9c5bd2f\tshadow/1/data/test/partition_complex/19700102_2_2_0/default_compression_codec.txt\n" \
+                "c0904274faa8f3f06f35666cc9c5bd2f\tshadow/1/data/test/partition_complex/19700201_1_1_0/default_compression_codec.txt\n" \
+                "c4ca4238a0b923820dcc509a6f75849b\tshadow/1/data/test/partition_complex/19700102_2_2_0/count.txt\n" \
+                "c4ca4238a0b923820dcc509a6f75849b\tshadow/1/data/test/partition_complex/19700201_1_1_0/count.txt\n" \
+                "cfcb770c3ecd0990dcceb1bde129e6c6\tshadow/1/data/test/partition_complex/19700102_2_2_0/p.bin\n" \
+                "e2af3bef1fd129aea73a890ede1e7a30\tshadow/1/data/test/partition_complex/19700201_1_1_0/k.bin\n" \
+                "f2312862cc01adf34a93151377be2ddf\tshadow/1/data/test/partition_complex/19700201_1_1_0/minmax_p.idx\n"
 
-    assert TSV(subprocess_check_call(cmd).replace('  ', '\t')) == TSV(checksums)
+    assert TSV(instance.exec_in_container(cmd).replace('  ', '\t')) == TSV(checksums)
 
 
 @pytest.fixture
 def partition_table_complex(started_cluster):
-    q("DROP TABLE IF EXISTS test.partition")
-    q("CREATE TABLE test.partition (p Date, k Int8, v1 Int8 MATERIALIZED k + 1) "
+    q("DROP TABLE IF EXISTS test.partition_complex")
+    q("CREATE TABLE test.partition_complex (p Date, k Int8, v1 Int8 MATERIALIZED k + 1) "
       "ENGINE = MergeTree PARTITION BY p ORDER BY k SETTINGS index_granularity=1, index_granularity_bytes=0")
-    q("INSERT INTO test.partition (p, k) VALUES(toDate(31), 1)")
-    q("INSERT INTO test.partition (p, k) VALUES(toDate(1), 2)")
+    q("INSERT INTO test.partition_complex (p, k) VALUES(toDate(31), 1)")
+    q("INSERT INTO test.partition_complex (p, k) VALUES(toDate(1), 2)")
 
     yield
 
-    q("DROP TABLE test.partition")
+    q("DROP TABLE test.partition_complex")
 
 
 def test_partition_complex(partition_table_complex):
     partition_complex_assert_columns_txt()
 
-    q("ALTER TABLE test.partition FREEZE")
+    q("ALTER TABLE test.partition_complex FREEZE")
 
     partition_complex_assert_checksums()
 
-    q("ALTER TABLE test.partition DETACH PARTITION 197001")
-    q("ALTER TABLE test.partition ATTACH PARTITION 197001")
+    q("ALTER TABLE test.partition_complex DETACH PARTITION 197001")
+    q("ALTER TABLE test.partition_complex ATTACH PARTITION 197001")
 
     partition_complex_assert_columns_txt()
 
-    q("ALTER TABLE test.partition MODIFY COLUMN v1 Int8")
+    q("ALTER TABLE test.partition_complex MODIFY COLUMN v1 Int8")
 
     # Check the backup hasn't changed
     partition_complex_assert_checksums()
 
-    q("OPTIMIZE TABLE test.partition")
+    q("OPTIMIZE TABLE test.partition_complex")
 
     expected = TSV('31\t1\t2\n'
                    '1\t2\t3')
-    res = q("SELECT toUInt16(p), k, v1 FROM test.partition ORDER BY k")
+    res = q("SELECT toUInt16(p), k, v1 FROM test.partition_complex ORDER BY k")
     assert (TSV(res) == expected)
 
 
@@ -166,9 +163,9 @@ def test_attach_check_all_parts(attach_check_all_parts_table):
     q("ALTER TABLE test.attach_partition DETACH PARTITION 0")
 
     path_to_detached = path_to_data + 'data/test/attach_partition/detached/'
-    subprocess_check_call('mkdir {}'.format(path_to_detached + '0_5_5_0'))
-    subprocess_check_call('cp -pr {} {}'.format(path_to_detached + '0_1_1_0', path_to_detached + 'attaching_0_6_6_0'))
-    subprocess_check_call('cp -pr {} {}'.format(path_to_detached + '0_3_3_0', path_to_detached + 'deleting_0_7_7_0'))
+    instance.exec_in_container(['mkdir', '{}'.format(path_to_detached + '0_5_5_0')])
+    instance.exec_in_container(['cp', '-pr', path_to_detached + '0_1_1_0', path_to_detached + 'attaching_0_6_6_0'])
+    instance.exec_in_container(['cp', '-pr', path_to_detached + '0_3_3_0', path_to_detached + 'deleting_0_7_7_0'])
 
     error = instance.client.query_and_get_error("ALTER TABLE test.attach_partition ATTACH PARTITION 0")
     assert 0 <= error.find('No columns in part 0_5_5_0') or 0 <= error.find('No columns.txt in part 0_5_5_0')
@@ -179,7 +176,7 @@ def test_attach_check_all_parts(attach_check_all_parts_table):
                  "WHERE table='attach_partition' AND database='test' ORDER BY name")
     assert TSV(detached) == TSV('0_1_1_0\n0_3_3_0\n0_5_5_0\nattaching_0_6_6_0\ndeleting_0_7_7_0')
 
-    subprocess_check_call('rm -r {}'.format(path_to_detached + '0_5_5_0'))
+    instance.exec_in_container(['rm', '-r', path_to_detached + '0_5_5_0'])
 
     q("ALTER TABLE test.attach_partition ATTACH PARTITION 0")
     parts = q("SElECT name FROM system.parts WHERE table='attach_partition' AND database='test' ORDER BY name")
@@ -212,10 +209,10 @@ def test_drop_detached_parts(drop_detached_parts_table):
     q("ALTER TABLE test.drop_detached DETACH PARTITION 1")
 
     path_to_detached = path_to_data + 'data/test/drop_detached/detached/'
-    subprocess_check_call('mkdir {}'.format(path_to_detached + 'attaching_0_6_6_0'))
-    subprocess_check_call('mkdir {}'.format(path_to_detached + 'deleting_0_7_7_0'))
-    subprocess_check_call('mkdir {}'.format(path_to_detached + 'any_other_name'))
-    subprocess_check_call('mkdir {}'.format(path_to_detached + 'prefix_1_2_2_0_0'))
+    instance.exec_in_container(['mkdir', '{}'.format(path_to_detached + 'attaching_0_6_6_0')])
+    instance.exec_in_container(['mkdir', '{}'.format(path_to_detached + 'deleting_0_7_7_0')])
+    instance.exec_in_container(['mkdir', '{}'.format(path_to_detached + 'any_other_name')])
+    instance.exec_in_container(['mkdir', '{}'.format(path_to_detached + 'prefix_1_2_2_0_0')])
 
     error = instance.client.query_and_get_error("ALTER TABLE test.drop_detached DROP DETACHED PART '../1_2_2_0'",
                                                 settings=s)

--- a/tests/integration/test_redirect_url_storage/test.py
+++ b/tests/integration/test_redirect_url_storage/test.py
@@ -1,6 +1,5 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.hdfs_api import HDFSApi
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', with_zookeeper=False, with_hdfs=True)
@@ -17,7 +16,7 @@ def started_cluster():
 
 
 def test_url_without_redirect(started_cluster):
-    hdfs_api = started_cluster.make_hdfs_api()
+    hdfs_api = start_cluster.hdfs_api
 
     hdfs_api.write_data("/simple_storage", "1\tMark\t72.53\n")
     assert hdfs_api.read_data("/simple_storage") == "1\tMark\t72.53\n"
@@ -29,7 +28,7 @@ def test_url_without_redirect(started_cluster):
 
 
 def test_url_with_globs(started_cluster):
-    hdfs_api = started_cluster.make_hdfs_api()
+    hdfs_api = start_cluster.hdfs_api
 
     hdfs_api.write_data("/simple_storage_1_1", "1\n")
     hdfs_api.write_data("/simple_storage_1_2", "2\n")
@@ -44,7 +43,7 @@ def test_url_with_globs(started_cluster):
 
 
 def test_url_with_globs_and_failover(started_cluster):
-    hdfs_api = started_cluster.make_hdfs_api()
+    hdfs_api = start_cluster.hdfs_api
 
     hdfs_api.write_data("/simple_storage_1_1", "1\n")
     hdfs_api.write_data("/simple_storage_1_2", "2\n")
@@ -59,7 +58,7 @@ def test_url_with_globs_and_failover(started_cluster):
 
 
 def test_url_with_redirect_not_allowed(started_cluster):
-    hdfs_api = started_cluster.make_hdfs_api()
+    hdfs_api = start_cluster.hdfs_api
 
     hdfs_api.write_data("/simple_storage", "1\tMark\t72.53\n")
     assert hdfs_api.read_data("/simple_storage") == "1\tMark\t72.53\n"
@@ -72,7 +71,7 @@ def test_url_with_redirect_not_allowed(started_cluster):
 
 
 def test_url_with_redirect_allowed(started_cluster):
-    hdfs_api = started_cluster.make_hdfs_api()
+    hdfs_api = start_cluster.hdfs_api
 
     hdfs_api.write_data("/simple_storage", "1\tMark\t72.53\n")
     assert hdfs_api.read_data("/simple_storage") == "1\tMark\t72.53\n"

--- a/tests/integration/test_redirect_url_storage/test.py
+++ b/tests/integration/test_redirect_url_storage/test.py
@@ -16,7 +16,7 @@ def started_cluster():
 
 
 def test_url_without_redirect(started_cluster):
-    hdfs_api = start_cluster.hdfs_api
+    hdfs_api = started_cluster.hdfs_api
 
     hdfs_api.write_data("/simple_storage", "1\tMark\t72.53\n")
     assert hdfs_api.read_data("/simple_storage") == "1\tMark\t72.53\n"
@@ -28,7 +28,7 @@ def test_url_without_redirect(started_cluster):
 
 
 def test_url_with_globs(started_cluster):
-    hdfs_api = start_cluster.hdfs_api
+    hdfs_api = started_cluster.hdfs_api
 
     hdfs_api.write_data("/simple_storage_1_1", "1\n")
     hdfs_api.write_data("/simple_storage_1_2", "2\n")
@@ -43,7 +43,7 @@ def test_url_with_globs(started_cluster):
 
 
 def test_url_with_globs_and_failover(started_cluster):
-    hdfs_api = start_cluster.hdfs_api
+    hdfs_api = started_cluster.hdfs_api
 
     hdfs_api.write_data("/simple_storage_1_1", "1\n")
     hdfs_api.write_data("/simple_storage_1_2", "2\n")
@@ -58,7 +58,7 @@ def test_url_with_globs_and_failover(started_cluster):
 
 
 def test_url_with_redirect_not_allowed(started_cluster):
-    hdfs_api = start_cluster.hdfs_api
+    hdfs_api = started_cluster.hdfs_api
 
     hdfs_api.write_data("/simple_storage", "1\tMark\t72.53\n")
     assert hdfs_api.read_data("/simple_storage") == "1\tMark\t72.53\n"
@@ -71,7 +71,7 @@ def test_url_with_redirect_not_allowed(started_cluster):
 
 
 def test_url_with_redirect_allowed(started_cluster):
-    hdfs_api = start_cluster.hdfs_api
+    hdfs_api = started_cluster.hdfs_api
 
     hdfs_api.write_data("/simple_storage", "1\tMark\t72.53\n")
     assert hdfs_api.read_data("/simple_storage") == "1\tMark\t72.53\n"

--- a/tests/integration/test_storage_hdfs/test.py
+++ b/tests/integration/test_storage_hdfs/test.py
@@ -2,7 +2,6 @@ import os
 
 import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.hdfs_api import HDFSApi
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', with_hdfs=True, main_configs=['configs/log_conf.xml'])
@@ -18,7 +17,8 @@ def started_cluster():
 
 
 def test_read_write_storage(started_cluster):
-    hdfs_api = started_cluster.make_hdfs_api()
+    hdfs_api = started_cluster.hdfs_api
+
     node1.query(
         "create table SimpleHDFSStorage (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs1:9000/simple_storage', 'TSV')")
     node1.query("insert into SimpleHDFSStorage values (1, 'Mark', 72.53)")
@@ -27,7 +27,8 @@ def test_read_write_storage(started_cluster):
 
 
 def test_read_write_storage_with_globs(started_cluster):
-    hdfs_api = started_cluster.make_hdfs_api()
+    hdfs_api = started_cluster.hdfs_api
+
     node1.query(
         "create table HDFSStorageWithRange (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs1:9000/storage{1..5}', 'TSV')")
     node1.query(
@@ -69,7 +70,8 @@ def test_read_write_storage_with_globs(started_cluster):
 
 
 def test_read_write_table(started_cluster):
-    hdfs_api = started_cluster.make_hdfs_api()
+    hdfs_api = started_cluster.hdfs_api
+
 
     data = "1\tSerialize\t555.222\n2\tData\t777.333\n"
     hdfs_api.write_data("/simple_table_function", data)
@@ -81,7 +83,8 @@ def test_read_write_table(started_cluster):
 
 
 def test_write_table(started_cluster):
-    hdfs_api = started_cluster.make_hdfs_api()
+    hdfs_api = started_cluster.hdfs_api
+
 
     node1.query(
         "create table OtherHDFSStorage (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs1:9000/other_storage', 'TSV')")
@@ -115,7 +118,8 @@ def test_bad_hdfs_uri(started_cluster):
 
 @pytest.mark.timeout(800)
 def test_globs_in_read_table(started_cluster):
-    hdfs_api = started_cluster.make_hdfs_api()
+    hdfs_api = started_cluster.hdfs_api
+
 
     some_data = "1\tSerialize\t555.222\n2\tData\t777.333\n"
     globs_dir = "/dir_for_test_with_globs/"
@@ -148,7 +152,8 @@ def test_globs_in_read_table(started_cluster):
 
 
 def test_read_write_gzip_table(started_cluster):
-    hdfs_api = started_cluster.make_hdfs_api()
+    hdfs_api = started_cluster.hdfs_api
+
 
     data = "1\tHello Jessica\t555.222\n2\tI rolled a joint\t777.333\n"
     hdfs_api.write_gzip_data("/simple_table_function.gz", data)
@@ -160,7 +165,8 @@ def test_read_write_gzip_table(started_cluster):
 
 
 def test_read_write_gzip_table_with_parameter_gzip(started_cluster):
-    hdfs_api = started_cluster.make_hdfs_api()
+    hdfs_api = started_cluster.hdfs_api
+
 
     data = "1\tHello Jessica\t555.222\n2\tI rolled a joint\t777.333\n"
     hdfs_api.write_gzip_data("/simple_table_function", data)
@@ -172,7 +178,8 @@ def test_read_write_gzip_table_with_parameter_gzip(started_cluster):
 
 
 def test_read_write_table_with_parameter_none(started_cluster):
-    hdfs_api = started_cluster.make_hdfs_api()
+    hdfs_api = started_cluster.hdfs_api
+
 
     data = "1\tHello Jessica\t555.222\n2\tI rolled a joint\t777.333\n"
     hdfs_api.write_data("/simple_table_function.gz", data)
@@ -184,7 +191,8 @@ def test_read_write_table_with_parameter_none(started_cluster):
 
 
 def test_read_write_gzip_table_with_parameter_auto_gz(started_cluster):
-    hdfs_api = started_cluster.make_hdfs_api()
+    hdfs_api = started_cluster.hdfs_api
+
 
     data = "1\tHello Jessica\t555.222\n2\tI rolled a joint\t777.333\n"
     hdfs_api.write_gzip_data("/simple_table_function.gz", data)
@@ -196,7 +204,8 @@ def test_read_write_gzip_table_with_parameter_auto_gz(started_cluster):
 
 
 def test_write_gz_storage(started_cluster):
-    hdfs_api = started_cluster.make_hdfs_api()
+    hdfs_api = started_cluster.hdfs_api
+
 
     node1.query(
         "create table GZHDFSStorage (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs1:9000/storage.gz', 'TSV')")
@@ -206,7 +215,8 @@ def test_write_gz_storage(started_cluster):
 
 
 def test_write_gzip_storage(started_cluster):
-    hdfs_api = started_cluster.make_hdfs_api()
+    hdfs_api = started_cluster.hdfs_api
+
 
     node1.query(
         "create table GZIPHDFSStorage (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://hdfs1:9000/gzip_storage', 'TSV', 'gzip')")
@@ -216,7 +226,8 @@ def test_write_gzip_storage(started_cluster):
 
 
 def test_virtual_columns(started_cluster):
-    hdfs_api = started_cluster.make_hdfs_api()
+    hdfs_api = started_cluster.hdfs_api
+
     node1.query("create table virtual_cols (id UInt32) ENGINE = HDFS('hdfs://hdfs1:9000/file*', 'TSV')")
     hdfs_api.write_data("/file1", "1\n")
     hdfs_api.write_data("/file2", "2\n")
@@ -226,7 +237,8 @@ def test_virtual_columns(started_cluster):
 
     
 def test_read_files_with_spaces(started_cluster):
-    hdfs_api = started_cluster.make_hdfs_api()
+    hdfs_api = started_cluster.hdfs_api
+
     hdfs_api.write_data("/test test test 1.txt", "1\n")
     hdfs_api.write_data("/test test test 2.txt", "2\n")
     hdfs_api.write_data("/test test test 3.txt", "3\n")

--- a/tests/integration/test_storage_kerberized_hdfs/test.py
+++ b/tests/integration/test_storage_kerberized_hdfs/test.py
@@ -22,8 +22,7 @@ def started_cluster():
     finally:
         cluster.shutdown()
 
-# TODO Remove it and enable test
-@pytest.mark.skip(reason="Don't work in parallel mode for some reason")
+
 def test_read_table(started_cluster):
     hdfs_api = started_cluster.hdfs_api
 
@@ -36,8 +35,6 @@ def test_read_table(started_cluster):
     select_read = node1.query("select * from hdfs('hdfs://kerberizedhdfs1:9010/simple_table_function', 'TSV', 'id UInt64, text String, number Float64')")
     assert select_read == data
 
-# TODO Remove it and enable test
-@pytest.mark.skip(reason="Don't work in parallel mode for some reason")
 def test_read_write_storage(started_cluster):
     hdfs_api = started_cluster.hdfs_api
 
@@ -50,8 +47,6 @@ def test_read_write_storage(started_cluster):
     select_read = node1.query("select * from SimpleHDFSStorage2")
     assert select_read == "1\tMark\t72.53\n"
 
-# TODO Remove it and enable test
-@pytest.mark.skip(reason="Don't work in parallel mode for some reason")
 def test_write_storage_not_expired(started_cluster):
     hdfs_api = started_cluster.hdfs_api
 
@@ -66,8 +61,6 @@ def test_write_storage_not_expired(started_cluster):
     select_read = node1.query("select * from SimpleHDFSStorageNotExpired")
     assert select_read == "1\tMark\t72.53\n"
 
-# TODO Remove it and enable test
-@pytest.mark.skip(reason="Don't work in parallel mode for some reason")
 def test_two_users(started_cluster):
     hdfs_api = started_cluster.hdfs_api
 
@@ -81,8 +74,6 @@ def test_two_users(started_cluster):
 
     select_read_2 = node1.query("select * from hdfs('hdfs://suser@kerberizedhdfs1:9010/storage_user_one', 'TSV', 'id UInt64, text String, number Float64')")
 
-# TODO Remove it and enable test
-@pytest.mark.skip(reason="Don't work in parallel mode for some reason")
 def test_read_table_expired(started_cluster):
     hdfs_api = started_cluster.hdfs_api
 
@@ -100,8 +91,6 @@ def test_read_table_expired(started_cluster):
 
     started_cluster.unpause_container('hdfskerberos')
 
-# TODO Remove it and enable test
-@pytest.mark.skip(reason="Don't work in parallel mode for some reason")
 def test_prohibited(started_cluster):
     node1.query("create table HDFSStorTwoProhibited (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://suser@kerberizedhdfs1:9010/storage_user_two_prohibited', 'TSV')")
     try:
@@ -110,8 +99,6 @@ def test_prohibited(started_cluster):
     except Exception as ex:
         assert "Unable to open HDFS file: /storage_user_two_prohibited error: Permission denied: user=specuser, access=WRITE" in str(ex)
 
-# TODO Remove it and enable test
-@pytest.mark.skip(reason="Don't work in parallel mode for some reason")
 def test_cache_path(started_cluster):
     node1.query("create table HDFSStorCachePath (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://dedicatedcachepath@kerberizedhdfs1:9010/storage_dedicated_cache_path', 'TSV')")
     try:

--- a/tests/integration/test_storage_kerberized_hdfs/test.py
+++ b/tests/integration/test_storage_kerberized_hdfs/test.py
@@ -25,7 +25,7 @@ def started_cluster():
 # TODO Remove it and enable test
 @pytest.mark.skip(reason="Don't work in parallel mode for some reason")
 def test_read_table(started_cluster):
-    hdfs_api = started_cluster.make_hdfs_api(kerberized=True)
+    hdfs_api = started_cluster.hdfs_api
 
     data = "1\tSerialize\t555.222\n2\tData\t777.333\n"
     hdfs_api.write_data("/simple_table_function", data)
@@ -39,7 +39,7 @@ def test_read_table(started_cluster):
 # TODO Remove it and enable test
 @pytest.mark.skip(reason="Don't work in parallel mode for some reason")
 def test_read_write_storage(started_cluster):
-    hdfs_api = started_cluster.make_hdfs_api(kerberized=True)
+    hdfs_api = started_cluster.hdfs_api
 
     node1.query("create table SimpleHDFSStorage2 (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://kerberizedhdfs1:9010/simple_storage1', 'TSV')")
     node1.query("insert into SimpleHDFSStorage2 values (1, 'Mark', 72.53)")
@@ -53,7 +53,7 @@ def test_read_write_storage(started_cluster):
 # TODO Remove it and enable test
 @pytest.mark.skip(reason="Don't work in parallel mode for some reason")
 def test_write_storage_not_expired(started_cluster):
-    hdfs_api = started_cluster.make_hdfs_api(kerberized=True)
+    hdfs_api = started_cluster.hdfs_api
 
     node1.query("create table SimpleHDFSStorageNotExpired (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://kerberizedhdfs1:9010/simple_storage_not_expired', 'TSV')")
 
@@ -69,7 +69,7 @@ def test_write_storage_not_expired(started_cluster):
 # TODO Remove it and enable test
 @pytest.mark.skip(reason="Don't work in parallel mode for some reason")
 def test_two_users(started_cluster):
-    hdfs_api = started_cluster.make_hdfs_api(kerberized=True)
+    hdfs_api = started_cluster.hdfs_api
 
     node1.query("create table HDFSStorOne (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://kerberizedhdfs1:9010/storage_user_one', 'TSV')")
     node1.query("insert into HDFSStorOne values (1, 'Real', 86.00)")
@@ -84,7 +84,7 @@ def test_two_users(started_cluster):
 # TODO Remove it and enable test
 @pytest.mark.skip(reason="Don't work in parallel mode for some reason")
 def test_read_table_expired(started_cluster):
-    hdfs_api = started_cluster.make_hdfs_api(kerberized=True)
+    hdfs_api = started_cluster.hdfs_api
 
     data = "1\tSerialize\t555.222\n2\tData\t777.333\n"
     hdfs_api.write_data("/simple_table_function_relogin", data)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:

Kerberized HDFS tests should work not and not require free port on localhost.
Fixed cleanup of running containers that can remain from previous runs - useful for local runs.

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
