### PR TITLE
Dictionary sources add update lag option

### DIFF
--- a/src/Dictionaries/ClickHouseDictionarySource.cpp
+++ b/src/Dictionaries/ClickHouseDictionarySource.cpp
@@ -93,7 +93,7 @@ std::string ClickHouseDictionarySource::getUpdateFieldAndDate()
 {
     if (update_time != std::chrono::system_clock::from_time_t(0))
     {
-        time_t hr_time = std::chrono::system_clock::to_time_t(update_time) - 1;
+        time_t hr_time = std::chrono::system_clock::to_time_t(update_time) - configuration.update_lag;
         std::string str_time = DateLUT::instance().timeToString(hr_time);
         update_time = std::chrono::system_clock::now();
         return query_builder.composeUpdateQuery(configuration.update_field, str_time);
@@ -222,7 +222,8 @@ void registerDictionarySourceClickHouse(DictionarySourceFactory & factory)
         std::string host = config.getString(settings_config_prefix + ".host", "localhost");
         UInt16 port = static_cast<UInt16>(config.getUInt(settings_config_prefix + ".port", default_port));
 
-        ClickHouseDictionarySource::Configuration configuration {
+        ClickHouseDictionarySource::Configuration configuration
+        {
             .secure = config.getBool(settings_config_prefix + ".secure", false),
             .host = host,
             .port = port,
@@ -231,8 +232,9 @@ void registerDictionarySourceClickHouse(DictionarySourceFactory & factory)
             .db = config.getString(settings_config_prefix + ".db", default_database),
             .table = config.getString(settings_config_prefix + ".table"),
             .where = config.getString(settings_config_prefix + ".where", ""),
-            .update_field = config.getString(settings_config_prefix + ".update_field", ""),
             .invalidate_query = config.getString(settings_config_prefix + ".invalidate_query", ""),
+            .update_field = config.getString(settings_config_prefix + ".update_field", ""),
+            .update_lag = config.getUInt64(settings_config_prefix + ".update_lag", 1),
             .is_local = isLocalAddress({host, port}, default_port)
         };
 

--- a/src/Dictionaries/ClickHouseDictionarySource.h
+++ b/src/Dictionaries/ClickHouseDictionarySource.h
@@ -28,8 +28,9 @@ public:
         const std::string db;
         const std::string table;
         const std::string where;
-        const std::string update_field;
         const std::string invalidate_query;
+        const std::string update_field;
+        const UInt64 update_lag;
         const bool is_local;
     };
 

--- a/src/Dictionaries/ExecutableDictionarySource.cpp
+++ b/src/Dictionaries/ExecutableDictionarySource.cpp
@@ -60,16 +60,12 @@ namespace
 
 ExecutableDictionarySource::ExecutableDictionarySource(
     const DictionaryStructure & dict_struct_,
-    const Poco::Util::AbstractConfiguration & config,
-    const std::string & config_prefix,
+    const Configuration & configuration_,
     Block & sample_block_,
     ContextConstPtr context_)
     : log(&Poco::Logger::get("ExecutableDictionarySource"))
-    , dict_struct{dict_struct_}
-    , implicit_key{config.getBool(config_prefix + ".implicit_key", false)}
-    , command{config.getString(config_prefix + ".command")}
-    , update_field{config.getString(config_prefix + ".update_field", "")}
-    , format{config.getString(config_prefix + ".format")}
+    , dict_struct(dict_struct_)
+    , configuration(configuration_)
     , sample_block{sample_block_}
     , context(context_)
 {
@@ -77,7 +73,7 @@ ExecutableDictionarySource::ExecutableDictionarySource(
     /// these columns will not be returned from source
     /// Implicit key means that the source script will return only values,
     /// and the correspondence to the requested keys is determined implicitly - by the order of rows in the result.
-    if (implicit_key)
+    if (configuration.implicit_key)
     {
         auto keys_names = dict_struct.getKeysNames();
 
@@ -91,43 +87,40 @@ ExecutableDictionarySource::ExecutableDictionarySource(
 
 ExecutableDictionarySource::ExecutableDictionarySource(const ExecutableDictionarySource & other)
     : log(&Poco::Logger::get("ExecutableDictionarySource"))
-    , update_time{other.update_time}
-    , dict_struct{other.dict_struct}
-    , implicit_key{other.implicit_key}
-    , command{other.command}
-    , update_field{other.update_field}
-    , format{other.format}
-    , sample_block{other.sample_block}
+    , update_time(other.update_time)
+    , dict_struct(other.dict_struct)
+    , configuration(other.configuration)
+    , sample_block(other.sample_block)
     , context(Context::createCopy(other.context))
 {
 }
 
 BlockInputStreamPtr ExecutableDictionarySource::loadAll()
 {
-    if (implicit_key)
+    if (configuration.implicit_key)
         throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "ExecutableDictionarySource with implicit_key does not support loadAll method");
 
     LOG_TRACE(log, "loadAll {}", toString());
-    auto process = ShellCommand::execute(command);
-    auto input_stream = context->getInputFormat(format, process->out, sample_block, max_block_size);
+    auto process = ShellCommand::execute(configuration.command);
+    auto input_stream = context->getInputFormat(configuration.format, process->out, sample_block, max_block_size);
     return std::make_shared<ShellCommandOwningBlockInputStream>(log, input_stream, std::move(process));
 }
 
 BlockInputStreamPtr ExecutableDictionarySource::loadUpdatedAll()
 {
-    if (implicit_key)
+    if (configuration.implicit_key)
         throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "ExecutableDictionarySource with implicit_key does not support loadUpdatedAll method");
 
     time_t new_update_time = time(nullptr);
     SCOPE_EXIT(update_time = new_update_time);
 
-    std::string command_with_update_field = command;
+    std::string command_with_update_field = configuration.command;
     if (update_time)
-        command_with_update_field += " " + update_field + " " + DB::toString(LocalDateTime(update_time - 1));
+        command_with_update_field += " " + configuration.update_field + " " + DB::toString(LocalDateTime(update_time - configuration.update_lag));
 
     LOG_TRACE(log, "loadUpdatedAll {}", command_with_update_field);
     auto process = ShellCommand::execute(command_with_update_field);
-    auto input_stream = context->getInputFormat(format, process->out, sample_block, max_block_size);
+    auto input_stream = context->getInputFormat(configuration.format, process->out, sample_block, max_block_size);
     return std::make_shared<ShellCommandOwningBlockInputStream>(log, input_stream, std::move(process));
 }
 
@@ -220,15 +213,15 @@ BlockInputStreamPtr ExecutableDictionarySource::loadKeys(const Columns & key_col
 BlockInputStreamPtr ExecutableDictionarySource::getStreamForBlock(const Block & block)
 {
     auto stream = std::make_unique<BlockInputStreamWithBackgroundThread>(
-        context, format, sample_block, command, log,
+        context, configuration.format, sample_block, configuration.command, log,
         [block, this](WriteBufferFromFile & out) mutable
         {
-            auto output_stream = context->getOutputStream(format, out, block.cloneEmpty());
+            auto output_stream = context->getOutputStream(configuration.format, out, block.cloneEmpty());
             formatBlock(output_stream, block);
             out.close();
         });
 
-    if (implicit_key)
+    if (configuration.implicit_key)
         return std::make_shared<BlockInputStreamWithAdditionalColumns>(block, std::move(stream));
     else
         return std::shared_ptr<BlockInputStreamWithBackgroundThread>(stream.release());
@@ -246,7 +239,7 @@ bool ExecutableDictionarySource::supportsSelectiveLoad() const
 
 bool ExecutableDictionarySource::hasUpdateField() const
 {
-    return !update_field.empty();
+    return !configuration.update_field.empty();
 }
 
 DictionarySourcePtr ExecutableDictionarySource::clone() const
@@ -256,7 +249,7 @@ DictionarySourcePtr ExecutableDictionarySource::clone() const
 
 std::string ExecutableDictionarySource::toString() const
 {
-    return "Executable: " + command;
+    return "Executable: " + configuration.command;
 }
 
 void registerDictionarySourceExecutable(DictionarySourceFactory & factory)
@@ -280,10 +273,20 @@ void registerDictionarySourceExecutable(DictionarySourceFactory & factory)
 
         auto context_local_copy = copyContextAndApplySettings(config_prefix, context, config);
 
-        return std::make_unique<ExecutableDictionarySource>(
-            dict_struct, config, config_prefix + ".executable",
-            sample_block, context_local_copy);
+        std::string settings_config_prefix = config_prefix + ".executable";
+
+        ExecutableDictionarySource::Configuration configuration
+        {
+            .implicit_key = config.getBool(settings_config_prefix + ".implicit_key", false),
+            .command = config.getString(settings_config_prefix + ".command"),
+            .format = config.getString(settings_config_prefix + ".format"),
+            .update_field = config.getString(settings_config_prefix + ".update_field", ""),
+            .update_lag = config.getUInt64(settings_config_prefix + ".update_lag", 1),
+        };
+
+        return std::make_unique<ExecutableDictionarySource>(dict_struct, configuration, sample_block, context_local_copy);
     };
+
     factory.registerSource("executable", create_table_source);
 }
 

--- a/src/Dictionaries/ExecutableDictionarySource.h
+++ b/src/Dictionaries/ExecutableDictionarySource.h
@@ -15,10 +15,19 @@ namespace DB
 class ExecutableDictionarySource final : public IDictionarySource
 {
 public:
+
+    struct Configuration
+    {
+        bool implicit_key;
+        const std::string command;
+        const std::string format;
+        const std::string update_field;
+        const UInt64 update_lag;
+    };
+
     ExecutableDictionarySource(
         const DictionaryStructure & dict_struct_,
-        const Poco::Util::AbstractConfiguration & config,
-        const std::string & config_prefix,
+        const Configuration & configuration_,
         Block & sample_block_,
         ContextConstPtr context_);
 
@@ -53,10 +62,7 @@ private:
     Poco::Logger * log;
     time_t update_time = 0;
     const DictionaryStructure dict_struct;
-    bool implicit_key;
-    const std::string command;
-    const std::string update_field;
-    const std::string format;
+    const Configuration configuration;
     Block sample_block;
     ContextConstPtr context;
 };

--- a/src/Dictionaries/ExecutablePoolDictionarySource.cpp
+++ b/src/Dictionaries/ExecutablePoolDictionarySource.cpp
@@ -70,12 +70,12 @@ ExecutablePoolDictionarySource::ExecutablePoolDictionarySource(const ExecutableP
 
 BlockInputStreamPtr ExecutablePoolDictionarySource::loadAll()
 {
-    throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "ExecutablePoolDictionarySource with implicit_key does not support loadAll method");
+    throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "ExecutablePoolDictionarySource does not support loadAll method");
 }
 
 BlockInputStreamPtr ExecutablePoolDictionarySource::loadUpdatedAll()
 {
-    throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "ExecutablePoolDictionarySource with implicit_key does not support loadAll method");
+    throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "ExecutablePoolDictionarySource does not support loadUpdatedAll method");
 }
 
 namespace
@@ -254,7 +254,7 @@ bool ExecutablePoolDictionarySource::supportsSelectiveLoad() const
 
 bool ExecutablePoolDictionarySource::hasUpdateField() const
 {
-    return !configuration.update_field.empty();
+    return false;
 }
 
 DictionarySourcePtr ExecutablePoolDictionarySource::clone() const
@@ -295,9 +295,9 @@ void registerDictionarySourceExecutablePool(DictionarySourceFactory & factory)
         settings_no_parallel_parsing.input_format_parallel_parsing = false;
         context_local_copy->setSettings(settings_no_parallel_parsing);
 
-        String configuration_config_prefix = config_prefix + ".executable_pool";
+        String settings_config_prefix = config_prefix + ".executable_pool";
 
-        size_t max_command_execution_time = config.getUInt64(configuration_config_prefix + ".max_command_execution_time", 10);
+        size_t max_command_execution_time = config.getUInt64(settings_config_prefix + ".max_command_execution_time", 10);
 
         size_t max_execution_time_seconds = static_cast<size_t>(context->getSettings().max_execution_time.totalSeconds());
         if (max_execution_time_seconds != 0 && max_command_execution_time > max_execution_time_seconds)
@@ -305,12 +305,11 @@ void registerDictionarySourceExecutablePool(DictionarySourceFactory & factory)
 
         ExecutablePoolDictionarySource::Configuration configuration
         {
-            .command = config.getString(configuration_config_prefix + ".command"),
-            .format = config.getString(configuration_config_prefix + ".format"),
-            .pool_size = config.getUInt64(configuration_config_prefix + ".size"),
-            .update_field = config.getString(configuration_config_prefix + ".update_field", ""),
-            .implicit_key = config.getBool(configuration_config_prefix + ".implicit_key", false),
-            .command_termination_timeout = config.getUInt64(configuration_config_prefix + ".command_termination_timeout", 10),
+            .command = config.getString(settings_config_prefix + ".command"),
+            .format = config.getString(settings_config_prefix + ".format"),
+            .pool_size = config.getUInt64(settings_config_prefix + ".size"),
+            .implicit_key = config.getBool(settings_config_prefix + ".implicit_key", false),
+            .command_termination_timeout = config.getUInt64(settings_config_prefix + ".command_termination_timeout", 10),
             .max_command_execution_time = max_command_execution_time
         };
 

--- a/src/Dictionaries/ExecutablePoolDictionarySource.h
+++ b/src/Dictionaries/ExecutablePoolDictionarySource.h
@@ -32,7 +32,6 @@ public:
         const String command;
         const String format;
         const size_t pool_size;
-        const String update_field;
         const bool implicit_key;
         const size_t command_termination_timeout;
         const size_t max_command_execution_time;

--- a/src/Dictionaries/HTTPDictionarySource.cpp
+++ b/src/Dictionaries/HTTPDictionarySource.cpp
@@ -28,58 +28,32 @@ static const UInt64 max_block_size = 8192;
 
 HTTPDictionarySource::HTTPDictionarySource(
     const DictionaryStructure & dict_struct_,
-    const Poco::Util::AbstractConfiguration & config,
-    const std::string & config_prefix,
+    const Configuration & configuration_,
+    const Poco::Net::HTTPBasicCredentials & credentials_,
     Block & sample_block_,
     ContextConstPtr context_,
     bool created_from_ddl)
     : log(&Poco::Logger::get("HTTPDictionarySource"))
-    , update_time{std::chrono::system_clock::from_time_t(0)}
-    , dict_struct{dict_struct_}
-    , url{config.getString(config_prefix + ".url", "")}
-    , update_field{config.getString(config_prefix + ".update_field", "")}
-    , format{config.getString(config_prefix + ".format")}
-    , sample_block{sample_block_}
+    , update_time(std::chrono::system_clock::from_time_t(0))
+    , dict_struct(dict_struct_)
+    , configuration(configuration_)
+    , sample_block(sample_block_)
     , context(context_)
     , timeouts(ConnectionTimeouts::getHTTPTimeouts(context))
 {
     if (created_from_ddl)
-        context->getRemoteHostFilter().checkURL(Poco::URI(url));
+        context->getRemoteHostFilter().checkURL(Poco::URI(configuration.url));
 
-    const auto & credentials_prefix = config_prefix + ".credentials";
-
-    if (config.has(credentials_prefix))
-    {
-        credentials.setUsername(config.getString(credentials_prefix + ".user", ""));
-        credentials.setPassword(config.getString(credentials_prefix + ".password", ""));
-    }
-
-    const auto & headers_prefix = config_prefix + ".headers";
-
-    if (config.has(headers_prefix))
-    {
-        Poco::Util::AbstractConfiguration::Keys config_keys;
-        config.keys(headers_prefix, config_keys);
-
-        header_entries.reserve(config_keys.size());
-        for (const auto & key : config_keys)
-        {
-            const auto header_key = config.getString(headers_prefix + "." + key + ".name", "");
-            const auto header_value = config.getString(headers_prefix + "." + key + ".value", "");
-            header_entries.emplace_back(std::make_tuple(header_key, header_value));
-        }
-    }
+    credentials.setUsername(credentials_.getUsername());
+    credentials.setPassword(credentials_.getPassword());
 }
 
 HTTPDictionarySource::HTTPDictionarySource(const HTTPDictionarySource & other)
     : log(&Poco::Logger::get("HTTPDictionarySource"))
-    , update_time{other.update_time}
-    , dict_struct{other.dict_struct}
-    , url{other.url}
-    , header_entries{other.header_entries}
-    , update_field{other.update_field}
-    , format{other.format}
-    , sample_block{other.sample_block}
+    , update_time(other.update_time)
+    , dict_struct(other.dict_struct)
+    , configuration(other.configuration)
+    , sample_block(other.sample_block)
     , context(Context::createCopy(other.context))
     , timeouts(ConnectionTimeouts::getHTTPTimeouts(context))
 {
@@ -89,11 +63,11 @@ HTTPDictionarySource::HTTPDictionarySource(const HTTPDictionarySource & other)
 
 BlockInputStreamPtr HTTPDictionarySource::createWrappedBuffer(std::unique_ptr<ReadWriteBufferFromHTTP> http_buffer_ptr)
 {
-    Poco::URI uri(url);
+    Poco::URI uri(configuration.url);
     String http_request_compression_method_str = http_buffer_ptr->getCompressionMethod();
     auto in_ptr_wrapped
         = wrapReadBufferWithCompressionMethod(std::move(http_buffer_ptr), chooseCompressionMethod(uri.getPath(), http_request_compression_method_str));
-    auto input_stream = context->getInputFormat(format, *in_ptr_wrapped, sample_block, max_block_size);
+    auto input_stream = context->getInputFormat(configuration.format, *in_ptr_wrapped, sample_block, max_block_size);
     return std::make_shared<OwningBlockInputStream<ReadBuffer>>(input_stream, std::move(in_ptr_wrapped));
 }
 
@@ -103,10 +77,10 @@ void HTTPDictionarySource::getUpdateFieldAndDate(Poco::URI & uri)
     {
         auto tmp_time = update_time;
         update_time = std::chrono::system_clock::now();
-        time_t hr_time = std::chrono::system_clock::to_time_t(tmp_time) - 1;
+        time_t hr_time = std::chrono::system_clock::to_time_t(tmp_time) - configuration.update_lag;
         WriteBufferFromOwnString out;
         writeDateTimeText(hr_time, out);
-        uri.addQueryParameter(update_field, out.str());
+        uri.addQueryParameter(configuration.update_field, out.str());
     }
     else
     {
@@ -117,7 +91,7 @@ void HTTPDictionarySource::getUpdateFieldAndDate(Poco::URI & uri)
 BlockInputStreamPtr HTTPDictionarySource::loadAll()
 {
     LOG_TRACE(log, "loadAll {}", toString());
-    Poco::URI uri(url);
+    Poco::URI uri(configuration.url);
     auto in_ptr = std::make_unique<ReadWriteBufferFromHTTP>(
         uri,
         Poco::Net::HTTPRequest::HTTP_GET,
@@ -126,13 +100,14 @@ BlockInputStreamPtr HTTPDictionarySource::loadAll()
         0,
         credentials,
         DBMS_DEFAULT_BUFFER_SIZE,
-        header_entries);
+        configuration.header_entries);
+
     return createWrappedBuffer(std::move(in_ptr));
 }
 
 BlockInputStreamPtr HTTPDictionarySource::loadUpdatedAll()
 {
-    Poco::URI uri(url);
+    Poco::URI uri(configuration.url);
     getUpdateFieldAndDate(uri);
     LOG_TRACE(log, "loadUpdatedAll {}", uri.toString());
     auto in_ptr = std::make_unique<ReadWriteBufferFromHTTP>(
@@ -143,7 +118,8 @@ BlockInputStreamPtr HTTPDictionarySource::loadUpdatedAll()
         0,
         credentials,
         DBMS_DEFAULT_BUFFER_SIZE,
-        header_entries);
+        configuration.header_entries);
+
     return createWrappedBuffer(std::move(in_ptr));
 }
 
@@ -156,11 +132,11 @@ BlockInputStreamPtr HTTPDictionarySource::loadIds(const std::vector<UInt64> & id
     ReadWriteBufferFromHTTP::OutStreamCallback out_stream_callback = [block, this](std::ostream & ostr)
     {
         WriteBufferFromOStream out_buffer(ostr);
-        auto output_stream = context->getOutputStreamParallelIfPossible(format, out_buffer, sample_block);
+        auto output_stream = context->getOutputStreamParallelIfPossible(configuration.format, out_buffer, sample_block);
         formatBlock(output_stream, block);
     };
 
-    Poco::URI uri(url);
+    Poco::URI uri(configuration.url);
     auto in_ptr = std::make_unique<ReadWriteBufferFromHTTP>(
         uri,
         Poco::Net::HTTPRequest::HTTP_POST,
@@ -169,7 +145,8 @@ BlockInputStreamPtr HTTPDictionarySource::loadIds(const std::vector<UInt64> & id
         0,
         credentials,
         DBMS_DEFAULT_BUFFER_SIZE,
-        header_entries);
+        configuration.header_entries);
+
     return createWrappedBuffer(std::move(in_ptr));
 }
 
@@ -182,11 +159,11 @@ BlockInputStreamPtr HTTPDictionarySource::loadKeys(const Columns & key_columns, 
     ReadWriteBufferFromHTTP::OutStreamCallback out_stream_callback = [block, this](std::ostream & ostr)
     {
         WriteBufferFromOStream out_buffer(ostr);
-        auto output_stream = context->getOutputStreamParallelIfPossible(format, out_buffer, sample_block);
+        auto output_stream = context->getOutputStreamParallelIfPossible(configuration.format, out_buffer, sample_block);
         formatBlock(output_stream, block);
     };
 
-    Poco::URI uri(url);
+    Poco::URI uri(configuration.url);
     auto in_ptr = std::make_unique<ReadWriteBufferFromHTTP>(
         uri,
         Poco::Net::HTTPRequest::HTTP_POST,
@@ -195,7 +172,8 @@ BlockInputStreamPtr HTTPDictionarySource::loadKeys(const Columns & key_columns, 
         0,
         credentials,
         DBMS_DEFAULT_BUFFER_SIZE,
-        header_entries);
+        configuration.header_entries);
+
     return createWrappedBuffer(std::move(in_ptr));
 }
 
@@ -211,7 +189,7 @@ bool HTTPDictionarySource::supportsSelectiveLoad() const
 
 bool HTTPDictionarySource::hasUpdateField() const
 {
-    return !update_field.empty();
+    return !configuration.update_field.empty();
 }
 
 DictionarySourcePtr HTTPDictionarySource::clone() const
@@ -221,7 +199,7 @@ DictionarySourcePtr HTTPDictionarySource::clone() const
 
 std::string HTTPDictionarySource::toString() const
 {
-    Poco::URI uri(url);
+    Poco::URI uri(configuration.url);
     return uri.toString();
 }
 
@@ -239,8 +217,44 @@ void registerDictionarySourceHTTP(DictionarySourceFactory & factory)
 
         auto context_local_copy = copyContextAndApplySettings(config_prefix, context, config);
 
-        return std::make_unique<HTTPDictionarySource>(
-            dict_struct, config, config_prefix + ".http", sample_block, context_local_copy, created_from_ddl);
+        const auto & settings_config_prefix = config_prefix + ".http";
+        const auto & credentials_prefix = settings_config_prefix + ".credentials";
+
+        Poco::Net::HTTPBasicCredentials credentials;
+
+        if (config.has(credentials_prefix))
+        {
+            credentials.setUsername(config.getString(credentials_prefix + ".user", ""));
+            credentials.setPassword(config.getString(credentials_prefix + ".password", ""));
+        }
+
+        const auto & headers_prefix = settings_config_prefix + ".headers";
+        ReadWriteBufferFromHTTP::HTTPHeaderEntries header_entries;
+
+        if (config.has(headers_prefix))
+        {
+            Poco::Util::AbstractConfiguration::Keys config_keys;
+            config.keys(headers_prefix, config_keys);
+
+            header_entries.reserve(config_keys.size());
+            for (const auto & key : config_keys)
+            {
+                const auto header_key = config.getString(headers_prefix + "." + key + ".name", "");
+                const auto header_value = config.getString(headers_prefix + "." + key + ".value", "");
+                header_entries.emplace_back(std::make_tuple(header_key, header_value));
+            }
+        }
+
+        auto configuration = HTTPDictionarySource::Configuration
+        {
+            .url = config.getString(settings_config_prefix + ".url", ""),
+            .format =config.getString(settings_config_prefix + ".format", ""),
+            .update_field = config.getString(settings_config_prefix + ".update_field", ""),
+            .update_lag = config.getUInt64(settings_config_prefix + ".update_lag", 1),
+            .header_entries = std::move(header_entries)
+        };
+
+        return std::make_unique<HTTPDictionarySource>(dict_struct, configuration, credentials, sample_block, context_local_copy, created_from_ddl);
     };
     factory.registerSource("http", create_table_source);
 }

--- a/src/Dictionaries/HTTPDictionarySource.h
+++ b/src/Dictionaries/HTTPDictionarySource.h
@@ -22,10 +22,20 @@ namespace DB
 class HTTPDictionarySource final : public IDictionarySource
 {
 public:
+
+    struct Configuration
+    {
+        const std::string url;
+        const std::string format;
+        const std::string update_field;
+        const UInt64 update_lag;
+        const ReadWriteBufferFromHTTP::HTTPHeaderEntries header_entries;
+    };
+
     HTTPDictionarySource(
         const DictionaryStructure & dict_struct_,
-        const Poco::Util::AbstractConfiguration & config,
-        const std::string & config_prefix,
+        const Configuration & configuration,
+        const Poco::Net::HTTPBasicCredentials & credentials_,
         Block & sample_block_,
         ContextConstPtr context_,
         bool created_from_ddl);
@@ -63,11 +73,8 @@ private:
 
     std::chrono::time_point<std::chrono::system_clock> update_time;
     const DictionaryStructure dict_struct;
-    const std::string url;
+    const Configuration configuration;
     Poco::Net::HTTPBasicCredentials credentials;
-    ReadWriteBufferFromHTTP::HTTPHeaderEntries header_entries;
-    std::string update_field;
-    const std::string format;
     Block sample_block;
     ContextConstPtr context;
     ConnectionTimeouts timeouts;

--- a/src/Dictionaries/IDictionarySource.h
+++ b/src/Dictionaries/IDictionarySource.h
@@ -20,6 +20,13 @@ using SharedDictionarySourcePtr = std::shared_ptr<IDictionarySource>;
 class IDictionarySource
 {
 public:
+
+    /// Returns an input stream with all the data available from this source.
+    virtual BlockInputStreamPtr loadAll() = 0;
+
+    /// Returns an input stream with updated data available from this source.
+    virtual BlockInputStreamPtr loadUpdatedAll() = 0;
+
     /**
      * result_size_hint - approx number of rows in the stream.
      * Returns an input stream with all the data available from this source.
@@ -56,12 +63,6 @@ public:
     {
         return loadAll();
     }
-
-    /// Returns an input stream with all the data available from this source.
-    virtual BlockInputStreamPtr loadAll() = 0;
-
-    /// Returns an input stream with updated data available from this source.
-    virtual BlockInputStreamPtr loadUpdatedAll() = 0;
 
     /** Indicates whether this source supports "random access" loading of data
       *  loadId and loadIds can only be used if this function returns true.

--- a/src/Dictionaries/PostgreSQLDictionarySource.cpp
+++ b/src/Dictionaries/PostgreSQLDictionarySource.cpp
@@ -204,7 +204,7 @@ void registerDictionarySourcePostgreSQL(DictionarySourceFactory & factory)
 #else
         (void)dict_struct;
         (void)config;
-        (void)root_config_prefix;
+        (void)config_prefix;
         (void)sample_block;
         (void)context;
         throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,

--- a/src/Dictionaries/PostgreSQLDictionarySource.h
+++ b/src/Dictionaries/PostgreSQLDictionarySource.h
@@ -65,16 +65,9 @@ private:
     postgres::PoolWithFailoverPtr pool;
     Block sample_block;
     Poco::Logger * log;
-
-    const String db;
-    String schema;
-    String table;
-    const String where;
     ExternalQueryBuilder query_builder;
     const std::string load_all_query;
-    String invalidate_query;
     std::chrono::time_point<std::chrono::system_clock> update_time;
-    const std::string update_field;
     mutable std::string invalidate_query_response;
 
 };

--- a/src/Dictionaries/PostgreSQLDictionarySource.h
+++ b/src/Dictionaries/PostgreSQLDictionarySource.h
@@ -22,11 +22,21 @@ namespace DB
 class PostgreSQLDictionarySource final : public IDictionarySource
 {
 public:
+    struct Configuration
+    {
+        const String db;
+        const String schema;
+        const String table;
+        const String where;
+        const String invalidate_query;
+        const String update_field;
+        const UInt64 update_lag;
+    };
+
     PostgreSQLDictionarySource(
         const DictionaryStructure & dict_struct_,
+        const Configuration & configuration_,
         postgres::PoolWithFailoverPtr pool_,
-        const Poco::Util::AbstractConfiguration & config_,
-        const std::string & config_prefix,
         const Block & sample_block_);
 
     /// copy-constructor is provided in order to support cloneability
@@ -51,8 +61,9 @@ private:
     BlockInputStreamPtr loadBase(const String & query);
 
     const DictionaryStructure dict_struct;
-    Block sample_block;
+    const Configuration configuration;
     postgres::PoolWithFailoverPtr pool;
+    Block sample_block;
     Poco::Logger * log;
 
     const String db;

--- a/src/Dictionaries/RedisDictionarySource.h
+++ b/src/Dictionaries/RedisDictionarySource.h
@@ -83,7 +83,6 @@ namespace ErrorCodes
     private:
         static RedisStorageType parseStorageType(const std::string& storage_type);
 
-    private:
         const DictionaryStructure dict_struct;
         const std::string host;
         const UInt16 port;

--- a/src/Dictionaries/XDBCDictionarySource.cpp
+++ b/src/Dictionaries/XDBCDictionarySource.cpp
@@ -86,7 +86,7 @@ namespace
         {
             if (!schema.empty())
                 throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
-                    "Dictionary source of type {0} specifies a schema but schema is not supported by {0}-driver",
+                    "Dictionary source of type {} specifies a schema but schema is not supported by {}-driver",
                     bridge_.getName());
         }
 
@@ -99,29 +99,22 @@ static const UInt64 max_block_size = 8192;
 
 XDBCDictionarySource::XDBCDictionarySource(
     const DictionaryStructure & dict_struct_,
-    const Poco::Util::AbstractConfiguration & config_,
-    const std::string & config_prefix_,
+    const Configuration & configuration_,
     const Block & sample_block_,
     ContextConstPtr context_,
     const BridgeHelperPtr bridge_)
     : WithContext(context_->getGlobalContext())
     , log(&Poco::Logger::get(bridge_->getName() + "DictionarySource"))
-    , update_time{std::chrono::system_clock::from_time_t(0)}
-    , dict_struct{dict_struct_}
-    , db{config_.getString(config_prefix_ + ".db", "")}
-    , schema{config_.getString(config_prefix_ + ".schema", "")}
-    , table{config_.getString(config_prefix_ + ".table")}
-    , where{config_.getString(config_prefix_ + ".where", "")}
-    , update_field{config_.getString(config_prefix_ + ".update_field", "")}
-    , sample_block{sample_block_}
-    , query_builder{makeExternalQueryBuilder(dict_struct, db, schema, table, where, *bridge_)}
-    , load_all_query{query_builder.composeLoadAllQuery()}
-    , invalidate_query{config_.getString(config_prefix_ + ".invalidate_query", "")}
-    , bridge_helper{bridge_}
-    , timeouts{ConnectionTimeouts::getHTTPTimeouts(context_)}
+    , update_time(std::chrono::system_clock::from_time_t(0))
+    , dict_struct(dict_struct_)
+    , configuration(configuration_)
+    , sample_block(sample_block_)
+    , query_builder(makeExternalQueryBuilder(dict_struct, configuration.db, configuration.schema, configuration.table, configuration.where, *bridge_))
+    , load_all_query(query_builder.composeLoadAllQuery())
+    , bridge_helper(bridge_)
+    , bridge_url(bridge_helper->getMainURI())
+    , timeouts(ConnectionTimeouts::getHTTPTimeouts(context_))
 {
-    bridge_url = bridge_helper->getMainURI();
-
     auto url_params = bridge_helper->getURLParams(max_block_size);
     for (const auto & [name, value] : url_params)
         bridge_url.addQueryParameter(name, value);
@@ -131,20 +124,16 @@ XDBCDictionarySource::XDBCDictionarySource(
 XDBCDictionarySource::XDBCDictionarySource(const XDBCDictionarySource & other)
     : WithContext(other.getContext())
     , log(&Poco::Logger::get(other.bridge_helper->getName() + "DictionarySource"))
-    , update_time{other.update_time}
-    , dict_struct{other.dict_struct}
-    , db{other.db}
-    , table{other.table}
-    , where{other.where}
-    , update_field{other.update_field}
-    , sample_block{other.sample_block}
-    , query_builder{other.query_builder}
-    , load_all_query{other.load_all_query}
-    , invalidate_query{other.invalidate_query}
-    , invalidate_query_response{other.invalidate_query_response}
-    , bridge_helper{other.bridge_helper}
-    , bridge_url{other.bridge_url}
-    , timeouts{other.timeouts}
+    , update_time(other.update_time)
+    , dict_struct(other.dict_struct)
+    , configuration(other.configuration)
+    , sample_block(other.sample_block)
+    , query_builder(other.query_builder)
+    , load_all_query(other.load_all_query)
+    , invalidate_query_response(other.invalidate_query_response)
+    , bridge_helper(other.bridge_helper)
+    , bridge_url(other.bridge_url)
+    , timeouts(other.timeouts)
 {
 }
 
@@ -153,10 +142,10 @@ std::string XDBCDictionarySource::getUpdateFieldAndDate()
 {
     if (update_time != std::chrono::system_clock::from_time_t(0))
     {
-        time_t hr_time = std::chrono::system_clock::to_time_t(update_time) - 1;
+        time_t hr_time = std::chrono::system_clock::to_time_t(update_time) - configuration.update_lag;
         std::string str_time = DateLUT::instance().timeToString(hr_time);
         update_time = std::chrono::system_clock::now();
-        return query_builder.composeUpdateQuery(update_field, str_time);
+        return query_builder.composeUpdateQuery(configuration.update_field, str_time);
     }
     else
     {
@@ -204,7 +193,7 @@ bool XDBCDictionarySource::supportsSelectiveLoad() const
 
 bool XDBCDictionarySource::hasUpdateField() const
 {
-    return !update_field.empty();
+    return !configuration.update_field.empty();
 }
 
 
@@ -216,15 +205,16 @@ DictionarySourcePtr XDBCDictionarySource::clone() const
 
 std::string XDBCDictionarySource::toString() const
 {
-    return bridge_helper->getName() + ": " + db + '.' + table + (where.empty() ? "" : ", where: " + where);
+    const auto & where = configuration.where;
+    return bridge_helper->getName() + ": " + configuration.db + '.' + configuration.table + (where.empty() ? "" : ", where: " + where);
 }
 
 
 bool XDBCDictionarySource::isModified() const
 {
-    if (!invalidate_query.empty())
+    if (!configuration.invalidate_query.empty())
     {
-        auto response = doInvalidateQuery(invalidate_query);
+        auto response = doInvalidateQuery(configuration.invalidate_query);
         if (invalidate_query_response == response) //-V1051
             return false;
         invalidate_query_response = response;
@@ -250,7 +240,7 @@ std::string XDBCDictionarySource::doInvalidateQuery(const std::string & request)
 }
 
 
-BlockInputStreamPtr XDBCDictionarySource::loadFromQuery(const Poco::URI url, const Block & required_sample_block, const std::string & query) const
+BlockInputStreamPtr XDBCDictionarySource::loadFromQuery(const Poco::URI & url, const Block & required_sample_block, const std::string & query) const
 {
     bridge_helper->startBridgeSync();
 
@@ -284,7 +274,21 @@ void registerDictionarySourceXDBC(DictionarySourceFactory & factory)
 #if USE_ODBC
         BridgeHelperPtr bridge = std::make_shared<XDBCBridgeHelper<ODBCBridgeMixin>>(
             context, context->getSettings().http_receive_timeout, config.getString(config_prefix + ".odbc.connection_string"));
-        return std::make_unique<XDBCDictionarySource>(dict_struct, config, config_prefix + ".odbc", sample_block, context, bridge);
+
+        std::string settings_config_prefix = config_prefix + ".odbc";
+
+        XDBCDictionarySource::Configuration configuration
+        {
+            .db = config.getString(settings_config_prefix + ".db", ""),
+            .schema = config.getString(settings_config_prefix + ".schema", ""),
+            .table = config.getString(settings_config_prefix + ".table"),
+            .where = config.getString(settings_config_prefix + ".where", ""),
+            .invalidate_query = config.getString(settings_config_prefix + ".invalidate_query", ""),
+            .update_field = config.getString(settings_config_prefix + ".update_field", ""),
+            .update_lag = config.getUInt64(settings_config_prefix + ".update_lag", 1)
+        };
+
+        return std::make_unique<XDBCDictionarySource>(dict_struct, configuration, sample_block, context, bridge);
 #else
         (void)dict_struct;
         (void)config;

--- a/src/Dictionaries/XDBCDictionarySource.h
+++ b/src/Dictionaries/XDBCDictionarySource.h
@@ -26,10 +26,21 @@ namespace DB
 class XDBCDictionarySource final : public IDictionarySource, WithContext
 {
 public:
+
+    struct Configuration
+    {
+        const std::string db;
+        const std::string schema;
+        const std::string table;
+        const std::string where;
+        const std::string invalidate_query;
+        const std::string update_field;
+        const UInt64 update_lag;
+    };
+
     XDBCDictionarySource(
         const DictionaryStructure & dict_struct_,
-        const Poco::Util::AbstractConfiguration & config_,
-        const std::string & config_prefix_,
+        const Configuration & configuration_,
         const Block & sample_block_,
         ContextConstPtr context_,
         BridgeHelperPtr bridge);
@@ -62,21 +73,16 @@ private:
     // execute invalidate_query. expects single cell in result
     std::string doInvalidateQuery(const std::string & request) const;
 
-    BlockInputStreamPtr loadFromQuery(const Poco::URI url, const Block & required_sample_block, const std::string & query) const;
+    BlockInputStreamPtr loadFromQuery(const Poco::URI & url, const Block & required_sample_block, const std::string & query) const;
 
     Poco::Logger * log;
 
     std::chrono::time_point<std::chrono::system_clock> update_time;
     const DictionaryStructure dict_struct;
-    const std::string db;
-    const std::string schema;
-    const std::string table;
-    const std::string where;
-    const std::string update_field;
+    const Configuration configuration;
     Block sample_block;
     ExternalQueryBuilder query_builder;
     const std::string load_all_query;
-    std::string invalidate_query;
     mutable std::string invalidate_query_response;
 
     BridgeHelperPtr bridge_helper;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Closes #6084.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Dictionary sources add `update_lag` option. If `update_field` is specified `update_lag` is subtracted from previous update time in seconds before request updated data. Default value 1.