### PR TITLE
Try run tests with Replicated database in parallel

### DIFF
--- a/docker/test/stateless/run.sh
+++ b/docker/test/stateless/run.sh
@@ -80,6 +80,8 @@ function run_tests()
 
     if [[ -n "$USE_DATABASE_REPLICATED" ]] && [[ "$USE_DATABASE_REPLICATED" -eq 1 ]]; then
         ADDITIONAL_OPTIONS+=('--replicated-database')
+        ADDITIONAL_OPTIONS+=('--jobs')
+        ADDITIONAL_OPTIONS+=('2')
     else
         # Too many tests fail for DatabaseReplicated in parallel. All other
         # configurations are OK.

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -26,7 +26,6 @@
 #include <Parsers/formatAST.h>
 #include <Common/Macros.h>
 
-
 namespace DB
 {
 namespace ErrorCodes

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -26,6 +26,7 @@
 #include <Parsers/formatAST.h>
 #include <Common/Macros.h>
 
+
 namespace DB
 {
 namespace ErrorCodes

--- a/tests/config/users.d/database_replicated.xml
+++ b/tests/config/users.d/database_replicated.xml
@@ -3,8 +3,8 @@
         <default>
             <allow_experimental_database_replicated>1</allow_experimental_database_replicated>
             <distributed_ddl_output_mode>none</distributed_ddl_output_mode>
-            <database_replicated_initial_query_timeout_sec>30</database_replicated_initial_query_timeout_sec>
-            <distributed_ddl_task_timeout>30</distributed_ddl_task_timeout>
+            <database_replicated_initial_query_timeout_sec>100</database_replicated_initial_query_timeout_sec>
+            <distributed_ddl_task_timeout>100</distributed_ddl_task_timeout>
             <database_replicated_always_detach_permanently>1</database_replicated_always_detach_permanently>
             <distributed_ddl_entry_format_version>2</distributed_ddl_entry_format_version>
         </default>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Detailed description / Documentation draft:
Try run tests with Replicated database in parallel (2 threads) and see what will happen. Maybe it will catch some flaky tests.

CLICKHOUSE_STATELESS_FUNCTIONAL_TEST_RELEASE_DATABASE_REPLICATED takes from 90 to 120 minutes according to CI dashboard, let's try to make it a bit faster.



