### PR TITLE
Add missed #include <condition_variable>

### DIFF
--- a/src/Interpreters/DatabaseCatalog.h
+++ b/src/Interpreters/DatabaseCatalog.h
@@ -10,6 +10,7 @@
 #include <Poco/Logger.h>
 
 #include <array>
+#include <condition_variable>
 #include <list>
 #include <map>
 #include <memory>


### PR DESCRIPTION
std::condition_variable is used for wait_table_finally_dropped

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix build error due to missed #include
