### PR TITLE
Add missed #include <optional>

### DIFF
--- a/src/Access/LDAPClient.h
+++ b/src/Access/LDAPClient.h
@@ -14,6 +14,7 @@
 #endif
 
 #include <chrono>
+#include <optional>
 #include <set>
 #include <vector>
 


### PR DESCRIPTION
std::optional<SearchParams> is used for user_dn_detection;

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix build due to missed `#include <optional>`