### PR TITLE
Enable TestFlows LDAP tests

### DIFF
--- a/tests/testflows/ldap/authentication/tests/common.py
+++ b/tests/testflows/ldap/authentication/tests/common.py
@@ -92,7 +92,7 @@ def add_config(config, timeout=300, restart=False, modify=False):
         """Check that preprocessed config is updated.
         """
         started = time.time()
-        command = f"cat /var/lib/clickhouse/preprocessed_configs/{config.preprocessed_name} | grep {config.uid}{' > /dev/null' if not settings.debug else ''}"
+        command = f"cat /var/lib/clickhouse/preprocessed_configs/_{config.preprocessed_name} | grep {config.uid}{' > /dev/null' if not settings.debug else ''}"
 
         while time.time() - started < timeout:
             exitcode = node.command(command, steps=False).exitcode
@@ -105,7 +105,7 @@ def add_config(config, timeout=300, restart=False, modify=False):
             time.sleep(1)
 
         if settings.debug:
-            node.command(f"cat /var/lib/clickhouse/preprocessed_configs/{config.preprocessed_name}")
+            node.command(f"cat /var/lib/clickhouse/preprocessed_configs/_{config.preprocessed_name}")
 
         if after_removal:
             assert exitcode == 1, error()

--- a/tests/testflows/ldap/external_user_directory/tests/common.py
+++ b/tests/testflows/ldap/external_user_directory/tests/common.py
@@ -138,7 +138,7 @@ def invalid_ldap_external_user_directory_config(server, roles, message, tail=30,
 
         with Then(f"{config.preprocessed_name} should be updated", description=f"timeout {timeout}"):
             started = time.time()
-            command = f"cat /var/lib/clickhouse/preprocessed_configs/{config.preprocessed_name} | grep {config.uid}{' > /dev/null' if not settings.debug else ''}"
+            command = f"cat /var/lib/clickhouse/preprocessed_configs/_{config.preprocessed_name} | grep {config.uid}{' > /dev/null' if not settings.debug else ''}"
             while time.time() - started < timeout:
                 exitcode = node.command(command, steps=False).exitcode
                 if exitcode == 0:

--- a/tests/testflows/regression.py
+++ b/tests/testflows/regression.py
@@ -23,7 +23,7 @@ def regression(self, local, clickhouse_binary_path, stress=None, parallel=None):
     with Pool(8) as pool:
         try:
             run_scenario(pool, tasks, Feature(test=load("example.regression", "regression")), args)
-            #run_scenario(pool, tasks, Feature(test=load("ldap.regression", "regression")), args)
+            run_scenario(pool, tasks, Feature(test=load("ldap.regression", "regression")), args)
             #run_scenario(pool, tasks, Feature(test=load("rbac.regression", "regression")), args)
             run_scenario(pool, tasks, Feature(test=load("aes_encryption.regression", "regression")), args)
             run_scenario(pool, tasks, Feature(test=load("map_type.regression", "regression")), args)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog.

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Enable ldap tests with new ldap role mapping deadlock fix test.

Detailed description / Documentation draft:
Enable ldap tests with new ldap role mapping deadlock fix test.

