### PR TITLE
CMake dictionaries disable debug info fix

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -257,27 +257,6 @@ if (USE_EMBEDDED_COMPILER)
     dbms_target_include_directories (SYSTEM BEFORE PUBLIC ${LLVM_INCLUDE_DIRS})
 endif ()
 
-if (CMAKE_BUILD_TYPE_UC STREQUAL "RELEASE" OR CMAKE_BUILD_TYPE_UC STREQUAL "RELWITHDEBINFO" OR CMAKE_BUILD_TYPE_UC STREQUAL "MINSIZEREL")
-    # Won't generate debug info for files with heavy template instantiation to achieve faster linking and lower size.
-    set_source_files_properties(
-        Dictionaries/FlatDictionary.cpp
-        Dictionaries/HashedDictionary.cpp
-        Dictionaries/CacheDictionary.cpp
-        Dictionaries/IPAddressDictionary.cpp
-        Dictionaries/RangeHashedDictionary.cpp
-        Dictionaries/ComplexKeyHashedDictionary.cpp
-        Dictionaries/ComplexKeyCacheDictionary.cpp
-        Dictionaries/ComplexKeyCacheDictionary_generate1.cpp
-        Dictionaries/ComplexKeyCacheDictionary_generate2.cpp
-        Dictionaries/ComplexKeyCacheDictionary_generate3.cpp
-        Dictionaries/ODBCBlockInputStream.cpp
-        Dictionaries/HTTPDictionarySource.cpp
-        Dictionaries/LibraryDictionarySource.cpp
-        Dictionaries/ExecutableDictionarySource.cpp
-        Dictionaries/ClickHouseDictionarySource.cpp
-        PROPERTIES COMPILE_FLAGS -g0)
-endif ()
-
 # Otherwise it will slow down stack traces printing too much.
 set_source_files_properties(
         Common/Elf.cpp

--- a/src/Dictionaries/CMakeLists.txt
+++ b/src/Dictionaries/CMakeLists.txt
@@ -4,6 +4,18 @@ add_headers_and_sources(clickhouse_dictionaries .)
 
 add_headers_and_sources(clickhouse_dictionaries "${CMAKE_CURRENT_BINARY_DIR}/generated/")
 
+if (CMAKE_BUILD_TYPE_UC STREQUAL "RELEASE" OR CMAKE_BUILD_TYPE_UC STREQUAL "RELWITHDEBINFO" OR CMAKE_BUILD_TYPE_UC STREQUAL "MINSIZEREL")
+
+    # Won't generate debug info for files with heavy template instantiation to achieve faster linking and lower size.
+    set_source_files_properties(
+        FlatDictionary.cpp
+        HashedDictionary.cpp
+        CacheDictionary.cpp
+        RangeHashedDictionary.cpp
+        DirectDictionary.cpp
+        PROPERTIES COMPILE_FLAGS -g0)
+endif ()
+
 list(REMOVE_ITEM clickhouse_dictionaries_sources DictionaryFactory.cpp DictionarySourceFactory.cpp DictionaryStructure.cpp getDictionaryConfigurationFromAST.cpp)
 list(REMOVE_ITEM clickhouse_dictionaries_headers DictionaryFactory.h DictionarySourceFactory.h DictionaryStructure.h getDictionaryConfigurationFromAST.h)
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)
