### PR TITLE
Forcefully stop queue tasks on restarting

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -356,7 +356,12 @@ void ReplicatedMergeTreeRestartingThread::partialShutdown()
     storage.part_check_thread.stop();
 
     /// Stop queue processing
-    storage.background_executor.finish();
+    {
+        auto fetch_lock = storage.fetcher.blocker.cancel();
+        auto merge_lock = storage.merger_mutator.merges_blocker.cancel();
+        auto move_lock = storage.parts_mover.moves_blocker.cancel();
+        storage.background_executor.finish();
+    }
 
     LOG_TRACE(log, "Threads finished");
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
On ZooKeeper connection loss `ReplicatedMergeTree` table might wait for background operations to complete before trying to reconnect. It's fixed, now background operations are stopped forcefully.

Detailed description:
The issue was introduced in 16647fe8ce8a2f6b8b6f5b671aae2e60059d0070

