### PR TITLE
Fix column transformer replace format issue

### DIFF
--- a/src/Parsers/ASTColumnsTransformers.cpp
+++ b/src/Parsers/ASTColumnsTransformers.cpp
@@ -165,7 +165,7 @@ void ASTColumnsReplaceTransformer::Replacement::formatImpl(
     const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     expr->formatImpl(settings, state, frame);
-    settings.ostr << (settings.hilite ? hilite_keyword : "") << " AS " << (settings.hilite ? hilite_none : "") << name;
+    settings.ostr << (settings.hilite ? hilite_keyword : "") << " AS " << (settings.hilite ? hilite_none : "") << backQuoteIfNeed(name);
 }
 
 void ASTColumnsReplaceTransformer::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const

--- a/tests/queries/0_stateless/01913_fix_column_transformer_replace_format.reference
+++ b/tests/queries/0_stateless/01913_fix_column_transformer_replace_format.reference
@@ -1,0 +1,1 @@
+CREATE VIEW default.my_view\n(\n    `Id` UInt32,\n    `Object.Key` Array(UInt16),\n    `Object.Value` Array(String)\n) AS\nSELECT * REPLACE arrayMap(x -> (x + 1), `Object.Key`) AS `Object.Key`\nFROM default.my_table

--- a/tests/queries/0_stateless/01913_fix_column_transformer_replace_format.sql
+++ b/tests/queries/0_stateless/01913_fix_column_transformer_replace_format.sql
@@ -1,0 +1,9 @@
+drop table if exists my_table;
+drop view if exists my_view;
+create table my_table(Id UInt32, Object Nested(Key UInt8, Value String)) engine MergeTree order by Id;
+create view my_view as select * replace arrayMap(x -> x + 1,`Object.Key`) as `Object.Key` from my_table;
+
+show create my_view;
+
+drop table my_table;
+drop view my_view;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix `REPLACE` column transformer when used in DDL by correctly quoting the formated query. This fixes https://github.com/ClickHouse/ClickHouse/issues/23925


Detailed description / Documentation draft:

.