### PR TITLE
Turn off WITH_COVERAGE in build with clang-tidy

### DIFF
--- a/tests/ci/ci_config.json
+++ b/tests/ci/ci_config.json
@@ -111,7 +111,7 @@
             "bundled": "bundled",
             "splitted": "unsplitted",
             "tidy": "enable",
-            "with_coverage": true
+            "with_coverage": false
         },
         {
             "compiler": "clang-11",


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Now sometimes debug build with clang-tidy and coverage fails with error like:
```
ld.lld: error: src/libdbmsd.a: could not get the member for symbol DB::WriteBufferFromNuraftBuffer::getBuffer(): truncated or malformed archive (terminator characters in archive member "(H" not the correct "`\n" values for the archive member header for �J(H�J(H�J(H�J(H)
```
We decided to turn off WITH_COVERAGE in this build until we reduce the size of the dbms library