### PR TITLE
Fix segfault when sharding_key is absent in config

### DIFF
--- a/programs/copier/TaskTableAndShard.h
+++ b/programs/copier/TaskTableAndShard.h
@@ -286,7 +286,7 @@ inline TaskTable::TaskTable(TaskCluster & parent, const Poco::Util::AbstractConf
                + "." + escapeForFileName(table_push.first)
                + "." + escapeForFileName(table_push.second);
 
-    engine_push_str = config.getString(table_prefix + "engine");
+    engine_push_str = config.getString(table_prefix + "engine", "rand()");
 
     {
         ParserStorage parser_storage;

--- a/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.cpp
+++ b/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.cpp
@@ -117,6 +117,7 @@ std::shared_ptr<NamesAndTypesList> fetchPostgreSQLTableStructure(
     {
         pqxx::read_transaction tx(connection_holder->get());
         auto stream{pqxx::stream_from::query(tx, query)};
+
         std::tuple<std::string, std::string, std::string, uint16_t> row;
         while (stream >> row)
         {

--- a/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.cpp
+++ b/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.cpp
@@ -117,7 +117,6 @@ std::shared_ptr<NamesAndTypesList> fetchPostgreSQLTableStructure(
     {
         pqxx::read_transaction tx(connection_holder->get());
         auto stream{pqxx::stream_from::query(tx, query)};
-
         std::tuple<std::string, std::string, std::string, uint16_t> row;
         while (stream >> row)
         {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix segfault when sharding_key is absent in task config for copier.


