### PR TITLE
Fix underscore before preprocessed configs.

### DIFF
--- a/src/Common/Config/ConfigProcessor.cpp
+++ b/src/Common/Config/ConfigProcessor.cpp
@@ -664,8 +664,8 @@ void ConfigProcessor::savePreprocessedConfig(const LoadedConfig & loaded_config,
         {
             fs::path preprocessed_configs_path("preprocessed_configs/");
             auto new_path = loaded_config.config_path;
-            if (new_path.substr(0, main_config_path.size()) == main_config_path)
-                new_path.replace(0, main_config_path.size(), "");
+            if (new_path.starts_with(main_config_path))
+                new_path.erase(0, main_config_path.size());
             std::replace(new_path.begin(), new_path.end(), '/', '_');
 
             if (preprocessed_dir.empty())
@@ -708,6 +708,8 @@ void ConfigProcessor::savePreprocessedConfig(const LoadedConfig & loaded_config,
 void ConfigProcessor::setConfigPath(const std::string & config_path)
 {
     main_config_path = config_path;
+    if (!main_config_path.ends_with('/'))
+        main_config_path += '/';
 }
 
 }

--- a/tests/testflows/ldap/authentication/tests/common.py
+++ b/tests/testflows/ldap/authentication/tests/common.py
@@ -92,7 +92,7 @@ def add_config(config, timeout=300, restart=False, modify=False):
         """Check that preprocessed config is updated.
         """
         started = time.time()
-        command = f"cat /var/lib/clickhouse/preprocessed_configs/_{config.preprocessed_name} | grep {config.uid}{' > /dev/null' if not settings.debug else ''}"
+        command = f"cat /var/lib/clickhouse/preprocessed_configs/{config.preprocessed_name} | grep {config.uid}{' > /dev/null' if not settings.debug else ''}"
 
         while time.time() - started < timeout:
             exitcode = node.command(command, steps=False).exitcode
@@ -105,7 +105,7 @@ def add_config(config, timeout=300, restart=False, modify=False):
             time.sleep(1)
 
         if settings.debug:
-            node.command(f"cat /var/lib/clickhouse/preprocessed_configs/_{config.preprocessed_name}")
+            node.command(f"cat /var/lib/clickhouse/preprocessed_configs/{config.preprocessed_name}")
 
         if after_removal:
             assert exitcode == 1, error()

--- a/tests/testflows/ldap/external_user_directory/tests/common.py
+++ b/tests/testflows/ldap/external_user_directory/tests/common.py
@@ -138,7 +138,7 @@ def invalid_ldap_external_user_directory_config(server, roles, message, tail=30,
 
         with Then(f"{config.preprocessed_name} should be updated", description=f"timeout {timeout}"):
             started = time.time()
-            command = f"cat /var/lib/clickhouse/preprocessed_configs/_{config.preprocessed_name} | grep {config.uid}{' > /dev/null' if not settings.debug else ''}"
+            command = f"cat /var/lib/clickhouse/preprocessed_configs/{config.preprocessed_name} | grep {config.uid}{' > /dev/null' if not settings.debug else ''}"
             while time.time() - started < timeout:
                 exitcode = node.command(command, steps=False).exitcode
                 if exitcode == 0:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix excessive underscore before the names of the preprocessed configuration files.
