### PR TITLE
Fix alternative stack for SIGSEGV handling

### DIFF
--- a/base/glibc-compatibility/glibc-compatibility.c
+++ b/base/glibc-compatibility/glibc-compatibility.c
@@ -9,14 +9,36 @@ extern "C" {
 #endif
 
 #include <pthread.h>
+#include <unistd.h>
+#include <limits.h>
+#include <assert.h>
 
+/// glibc __pthread_get_minstack() will take TLS into account for the minimal
+/// stack size (since you cannot use stack less then TLS block size, otherwise
+/// some variables may be overwritten)
+///
+/// So glibc implementation is:
+///
+///     sysconf(_SC_PAGESIZE) + __static_tls_size + PTHREAD_STACK_MIN;
+///
+/// But this helper cannot do this since:
+/// - __pthread_get_minstack() is hidden in libc (note that rust tried to do
+///     this but revert it to retry loop, for compatibility, while we cannot
+///     use retry loop since this function is used for sigaltstack())
+/// - __static_tls_size is not exported in glibc
+/// - it is not used anywhere except for clickhouse itself (for sigaltstack(),
+///   to handle SIGSEGV only) and using PTHREAD_STACK_MIN (16k) is enough right
+///   now.
+///
+/// Also we cannot use getStackSize() (pthread_attr_getstack()) since it will
+/// return 8MB, and this is too huge for signal stack.
 size_t __pthread_get_minstack(const pthread_attr_t * attr)
 {
-    return 1048576;        /// This is a guess. Don't sure it is correct.
+    _Static_assert(PTHREAD_STACK_MIN == 16<<10, "Too small return value of __pthread_get_minstack()");
+    return PTHREAD_STACK_MIN;
 }
 
 #include <signal.h>
-#include <unistd.h>
 #include <string.h>
 #include <sys/syscall.h>
 

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -57,11 +57,11 @@ struct ThreadStack
     }
 
     static size_t getSize() { return size; }
-    void* getData() const { return data; }
+    void * getData() const { return data; }
 
 private:
-    static constexpr size_t size = 16 << 10;
-    void *data;
+    static constexpr size_t size = 16 << 10; /// 16 KiB - not too big but enough to handle error.
+    void * data;
 };
 
 }

--- a/src/Common/checkStackSize.cpp
+++ b/src/Common/checkStackSize.cpp
@@ -22,6 +22,52 @@ namespace DB
 static thread_local void * stack_address = nullptr;
 static thread_local size_t max_stack_size = 0;
 
+/**
+ * @param address_ - stack address
+ * @return stack size
+ */
+size_t getStackSize(void **address_)
+{
+    using namespace DB;
+
+    size_t size;
+    void *address;
+
+#if defined(OS_DARWIN)
+    // pthread_get_stacksize_np() returns a value too low for the main thread on
+    // OSX 10.9, http://mail.openjdk.java.net/pipermail/hotspot-dev/2013-October/011369.html
+    //
+    // Multiple workarounds possible, adopt the one made by https://github.com/robovm/robovm/issues/274
+    // https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/Multithreading/CreatingThreads/CreatingThreads.html
+    // Stack size for the main thread is 8MB on OSX excluding the guard page size.
+    pthread_t thread = pthread_self();
+    size = pthread_main_np() ? (8 * 1024 * 1024) : pthread_get_stacksize_np(thread);
+
+    // stack address points to the start of the stack, not the end how it's returned by pthread_get_stackaddr_np
+    address = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(pthread_get_stackaddr_np(thread)) - max_stack_size);
+#else
+    pthread_attr_t attr;
+#   if defined(__FreeBSD__) || defined(OS_SUNOS)
+    pthread_attr_init(&attr);
+    if (0 != pthread_attr_get_np(pthread_self(), &attr))
+        throwFromErrno("Cannot pthread_attr_get_np", ErrorCodes::CANNOT_PTHREAD_ATTR);
+#   else
+    if (0 != pthread_getattr_np(pthread_self(), &attr))
+        throwFromErrno("Cannot pthread_getattr_np", ErrorCodes::CANNOT_PTHREAD_ATTR);
+#   endif
+
+    SCOPE_EXIT({ pthread_attr_destroy(&attr); });
+
+    if (0 != pthread_attr_getstack(&attr, &address, &size))
+        throwFromErrno("Cannot pthread_getattr_np", ErrorCodes::CANNOT_PTHREAD_ATTR);
+#endif // OS_DARWIN
+
+    if (address_)
+        *address_ = address;
+
+    return size;
+}
+
 /** It works fine when interpreters are instantiated by ClickHouse code in properly prepared threads,
   *  but there are cases when ClickHouse runs as a library inside another application.
   * If application is using user-space lightweight threads with manually allocated stacks,
@@ -34,36 +80,7 @@ __attribute__((__weak__)) void checkStackSize()
     using namespace DB;
 
     if (!stack_address)
-    {
-#if defined(OS_DARWIN)
-        // pthread_get_stacksize_np() returns a value too low for the main thread on
-        // OSX 10.9, http://mail.openjdk.java.net/pipermail/hotspot-dev/2013-October/011369.html
-        //
-        // Multiple workarounds possible, adopt the one made by https://github.com/robovm/robovm/issues/274
-        // https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/Multithreading/CreatingThreads/CreatingThreads.html
-        // Stack size for the main thread is 8MB on OSX excluding the guard page size.
-        pthread_t thread = pthread_self();
-        max_stack_size = pthread_main_np() ? (8 * 1024 * 1024) : pthread_get_stacksize_np(thread);
-
-        // stack_address points to the start of the stack, not the end how it's returned by pthread_get_stackaddr_np
-        stack_address = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(pthread_get_stackaddr_np(thread)) - max_stack_size);
-#else
-        pthread_attr_t attr;
-#   if defined(__FreeBSD__) || defined(OS_SUNOS)
-        pthread_attr_init(&attr);
-        if (0 != pthread_attr_get_np(pthread_self(), &attr))
-            throwFromErrno("Cannot pthread_attr_get_np", ErrorCodes::CANNOT_PTHREAD_ATTR);
-#   else
-        if (0 != pthread_getattr_np(pthread_self(), &attr))
-            throwFromErrno("Cannot pthread_getattr_np", ErrorCodes::CANNOT_PTHREAD_ATTR);
-#   endif
-
-        SCOPE_EXIT({ pthread_attr_destroy(&attr); });
-
-        if (0 != pthread_attr_getstack(&attr, &stack_address, &max_stack_size))
-            throwFromErrno("Cannot pthread_getattr_np", ErrorCodes::CANNOT_PTHREAD_ATTR);
-#endif // OS_DARWIN
-    }
+        max_stack_size = getStackSize(&stack_address);
 
     const void * frame_address = __builtin_frame_address(0);
     uintptr_t int_frame_address = reinterpret_cast<uintptr_t>(frame_address);

--- a/src/Common/checkStackSize.cpp
+++ b/src/Common/checkStackSize.cpp
@@ -23,7 +23,7 @@ static thread_local void * stack_address = nullptr;
 static thread_local size_t max_stack_size = 0;
 
 /**
- * @param address_ - stack address
+ * @param out_address - if not nullptr, here the address of the stack will be written.
  * @return stack size
  */
 size_t getStackSize(void ** out_address)

--- a/src/Common/checkStackSize.cpp
+++ b/src/Common/checkStackSize.cpp
@@ -26,12 +26,12 @@ static thread_local size_t max_stack_size = 0;
  * @param address_ - stack address
  * @return stack size
  */
-size_t getStackSize(void **address_)
+size_t getStackSize(void ** out_address)
 {
     using namespace DB;
 
     size_t size;
-    void *address;
+    void * address;
 
 #if defined(OS_DARWIN)
     // pthread_get_stacksize_np() returns a value too low for the main thread on
@@ -62,8 +62,8 @@ size_t getStackSize(void **address_)
         throwFromErrno("Cannot pthread_getattr_np", ErrorCodes::CANNOT_PTHREAD_ATTR);
 #endif // OS_DARWIN
 
-    if (address_)
-        *address_ = address;
+    if (out_address)
+        *out_address = address;
 
     return size;
 }


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix alternative stack for SIGSEGV handling

Detailed description / Documentation draft:
Previous stack size of 4096 wasn't enough, and this lead to that on
SIGSEGV signal handler may overwrite some TLS data (like in the
following example [1]) and in real binary "current_thread" was
overwritten, and this leads to lack of query-id on SIGSEGV, like here
[2].

  [1]: https://gist.github.com/azat/2ee360fd4f2828d363b0926431afacc6
  [2]: https://clickhouse-test-reports.s3.yandex.net/24411/79563953201ce6249a8fd49e22be3902ca4ee43a/fuzzer_ubsan/report.html#fail1

Fix this by moving stack into the heap (thus per-thread data will not be overwritten)
and increasing stack size to 16K (this should be enough for now)

*NOTE: that initially __pthread_get_minstack() was used, but it is not portable*

Refs: https://sourceware.org/legacy-ml/libc-alpha/2012-06/msg00335.html
Refs: https://maskray.me/blog/2021-02-14-all-about-thread-local-storage
Refs: https://sourceware.org/bugzilla/show_bug.cgi?id=11787

Refs: #16346 (cc @alexey-milovidov )
Refs: #14840