### PR TITLE
Catch "Maximum parse depth" error in fuzzer

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -112,6 +112,7 @@ namespace ErrorCodes
     extern const int DEADLOCK_AVOIDED;
     extern const int UNRECOGNIZED_ARGUMENTS;
     extern const int SYNTAX_ERROR;
+    extern const int TOO_DEEP_RECURSION;
 }
 
 
@@ -1267,7 +1268,8 @@ private:
         }
         catch (const Exception & e)
         {
-            if (e.code() != ErrorCodes::SYNTAX_ERROR)
+            if (e.code() != ErrorCodes::SYNTAX_ERROR &&
+                e.code() != ErrorCodes::TOO_DEEP_RECURSION)
                 throw;
         }
 


### PR DESCRIPTION
This exception should not fail the fuzzer check like here [1].

  [1]: https://clickhouse-test-reports.s3.yandex.net/25494/c6339b4c08ad8f50bf34831367de9a1ea90b1e09/fuzzer_msan/report.html#fail1

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @akuzm 