### PR TITLE
Drop replicas from dirname for internal_replication=true

### DIFF
--- a/src/Interpreters/Cluster.h
+++ b/src/Interpreters/Cluster.h
@@ -166,10 +166,8 @@ public:
         std::string prefer_localhost_replica;
         /// prefer_localhost_replica == 0 && use_compact_format_in_distributed_parts_names=0
         std::string no_prefer_localhost_replica;
-        /// prefer_localhost_replica == 1 && use_compact_format_in_distributed_parts_names=1
-        std::string prefer_localhost_replica_compact;
-        /// prefer_localhost_replica == 0 && use_compact_format_in_distributed_parts_names=1
-        std::string no_prefer_localhost_replica_compact;
+        /// use_compact_format_in_distributed_parts_names=1
+        std::string compact;
     };
 
     struct ShardInfo

--- a/tests/integration/test_distributed_format/configs/remote_servers.xml
+++ b/tests/integration/test_distributed_format/configs/remote_servers.xml
@@ -1,19 +1,20 @@
 <yandex>
     <remote_servers>
-        <test_cluster>
+        <test_cluster_internal_replication>
             <shard>
+                <internal_replication>true</internal_replication>
                 <replica>
                     <host>not_existing</host>
                     <port>9000</port>
                 </replica>
             </shard>
-        </test_cluster>
+        </test_cluster_internal_replication>
 
-        <test_cluster_2>
+        <test_cluster_no_internal_replication>
             <node>
                 <host>not_existing</host>
                 <port>9000</port>
             </node>
-        </test_cluster_2>
+        </test_cluster_no_internal_replication>
     </remote_servers>
 </yandex>

--- a/tests/integration/test_distributed_format/test.py
+++ b/tests/integration/test_distributed_format/test.py
@@ -1,14 +1,25 @@
-import pytest
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=line-too-long
 
+import pytest
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance('node', main_configs=['configs/remote_servers.xml'])
 
 cluster_param = pytest.mark.parametrize("cluster", [
-    ('test_cluster'),
-    ('test_cluster_2'),
+    ('test_cluster_internal_replication'),
+    ('test_cluster_no_internal_replication'),
 ])
+
+
+def get_dist_path(cluster, table, dist_format):
+    if dist_format == 0:
+        return f'/var/lib/clickhouse/data/test/{table}/default@not_existing:9000'
+    if cluster == 'test_cluster_internal_replication':
+        return f'/var/lib/clickhouse/data/test/{table}/shard1_all_replicas'
+    return f'/var/lib/clickhouse/data/test/{table}/shard1_replica1'
 
 
 @pytest.fixture(scope="module")
@@ -29,13 +40,16 @@ def test_single_file(started_cluster, cluster):
     node.query("insert into test.distr_1 values (1, 'a'), (2, 'bb'), (3, 'ccc')",
                settings={"use_compact_format_in_distributed_parts_names": "1"})
 
-    query = "select * from file('/var/lib/clickhouse/data/test/distr_1/shard1_replica1/1.bin', 'Distributed')"
+    path = get_dist_path(cluster, 'distr_1', 1)
+    query = f"select * from file('{path}/1.bin', 'Distributed')"
     out = node.exec_in_container(['/usr/bin/clickhouse', 'local', '--stacktrace', '-q', query])
 
     assert out == '1\ta\n2\tbb\n3\tccc\n'
 
-    query = "create table t (x UInt64, s String) engine = File('Distributed', '/var/lib/clickhouse/data/test/distr_1/shard1_replica1/1.bin');" \
-            "select * from t"
+    query = f"""
+    create table t (x UInt64, s String) engine = File('Distributed', '{path}/1.bin');
+    select * from t;
+    """
     out = node.exec_in_container(['/usr/bin/clickhouse', 'local', '--stacktrace', '-q', query])
 
     assert out == '1\ta\n2\tbb\n3\tccc\n'
@@ -54,13 +68,16 @@ def test_two_files(started_cluster, cluster):
         "use_compact_format_in_distributed_parts_names": "1",
     })
 
-    query = "select * from file('/var/lib/clickhouse/data/test/distr_2/shard1_replica1/{1,2,3,4}.bin', 'Distributed') order by x"
+    path = get_dist_path(cluster, 'distr_2', 1)
+    query = f"select * from file('{path}/{{1,2,3,4}}.bin', 'Distributed') order by x"
     out = node.exec_in_container(['/usr/bin/clickhouse', 'local', '--stacktrace', '-q', query])
 
     assert out == '0\t_\n1\ta\n2\tbb\n3\tccc\n'
 
-    query = "create table t (x UInt64, s String) engine = File('Distributed', '/var/lib/clickhouse/data/test/distr_2/shard1_replica1/{1,2,3,4}.bin');" \
-            "select * from t order by x"
+    query = f"""
+    create table t (x UInt64, s String) engine = File('Distributed', '{path}/{{1,2,3,4}}.bin');
+    select * from t order by x;
+    """
     out = node.exec_in_container(['/usr/bin/clickhouse', 'local', '--stacktrace', '-q', query])
 
     assert out == '0\t_\n1\ta\n2\tbb\n3\tccc\n'
@@ -76,13 +93,16 @@ def test_single_file_old(started_cluster, cluster):
         "use_compact_format_in_distributed_parts_names": "0",
     })
 
-    query = "select * from file('/var/lib/clickhouse/data/test/distr_3/default@not_existing:9000/1.bin', 'Distributed')"
+    path = get_dist_path(cluster, 'distr_3', 0)
+    query = f"select * from file('{path}/1.bin', 'Distributed')"
     out = node.exec_in_container(['/usr/bin/clickhouse', 'local', '--stacktrace', '-q', query])
 
     assert out == '1\ta\n2\tbb\n3\tccc\n'
 
-    query = "create table t (x UInt64, s String) engine = File('Distributed', '/var/lib/clickhouse/data/test/distr_3/default@not_existing:9000/1.bin');" \
-            "select * from t"
+    query = f"""
+    create table t (x UInt64, s String) engine = File('Distributed', '{path}/1.bin');
+    select * from t;
+    """
     out = node.exec_in_container(['/usr/bin/clickhouse', 'local', '--stacktrace', '-q', query])
 
     assert out == '1\ta\n2\tbb\n3\tccc\n'


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Drop replicas from dirname for internal_replication=true (allows INSERT into Distributed with cluster from any number of replicas, before only 15 replicas was supported, everything more will fail with ENAMETOOLONG while creating directory for async blocks)

Detailed description / Documentation draft:
Under use_compact_format_in_distributed_parts_names=1 and
internal_replication=true the server encodes all replicas for the
directory name for async INSERT into Distributed, and the directory name
looks like:

    shard1_replica1,shard1_replica2,shard1_replica3

This is required for creating connections (to specific replicas only),
but in case of internal_replication=true, this can be avoided, since
this path will always includes all replicas.

This patch replaces all replicas with "_all_replicas" marker.

Note, that initial problem was that this path may overflow the NAME_MAX
if you will have more then 15 replicas, and the server will fail to
create the directory.

Also note, that changed directory name should not be a problem, since:
- empty directories will be removed since #16729
- and replicas encoded in the directory name is also supported anyway.

Follow-up for: #9653