### PR TITLE
Catch TOO_DEEP_RECURSION in fuzzer for formatted query too

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -1451,10 +1451,9 @@ private:
                 }
                 catch (Exception & e)
                 {
-                    if (e.code() != ErrorCodes::SYNTAX_ERROR)
-                    {
+                    if (e.code() != ErrorCodes::SYNTAX_ERROR &&
+                        e.code() != ErrorCodes::TOO_DEEP_RECURSION)
                         throw;
-                    }
                 }
 
                 if (ast_2)


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @akuzm 
Follow-up for: #25510 