### PR TITLE
Resolves actual port bound when user requests any available

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -324,6 +324,13 @@ Poco::Net::SocketAddress Server::socketBindListen(Poco::Net::ServerSocket & sock
     socket.bind(address, /* reuseAddress = */ true, /* reusePort = */ config().getBool("listen_reuse_port", false));
 #endif
 
+    /// If caller requests any available port from the OS, discover it after binding.
+    if (port == 0)
+    {
+        address = socket.address();
+        LOG_DEBUG(&logger(), "Requested any available port (port == 0), actual port is {:d}", address.port());
+    }
+
     socket.listen(/* backlog = */ config().getUInt("listen_backlog", 64));
 
     return address;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Resolve the actual port number bound when a user requests any available port from the operating system.


Detailed description / Documentation draft:

Most OS's support binding a port of 0, in which case the OS supplies any available port number. This is most useful in situations in which there are other programs also binding ports, and one wishes to avoid hard-coding port numbers or using a suboptimal strategy such as random port numbers.

ClickHouse operates normally if one requests a port of 0 (e.g, `clickhouse server -- --http_port 0`). However, there is no way to "discover" this port after the server has started, without querying the OS itself through a program such as `lsof`, `netstat` or similar. In particular, the ClickHouse logs print lines such as `2021.06.21 12:35:59.379920 [ 37069 ] {} <Information> Application: Listening for http://[::1]:0`. This commit adds a small check for this particular scenario (binding port 0), and updates addresses with the _actual_ port supplied by the OS.
