### PR TITLE
Fix DiskS3 restore

### DIFF
--- a/src/Disks/S3/DiskS3.cpp
+++ b/src/Disks/S3/DiskS3.cpp
@@ -883,6 +883,7 @@ void DiskS3::restoreFileOperations(const RestoreInformation & restore_informatio
                 to_path /= from_path.parent_path().filename();
             else
                 to_path /= from_path.filename();
+            fs::create_directories(to_path);
             fs::copy(from_path, to_path, fs::copy_options::recursive | fs::copy_options::overwrite_existing);
             fs::remove_all(from_path);
         }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix restore S3 table


Detailed description / Documentation draft:

Fix for regression after changing **Poco::File** on **std::fielsystem**. **Poco::File::moveTo** creates all parent directories for _to_path_, **std::filesystem::copy** calls **std::filesystem::create_directory**, which requires parent directory.