### PR TITLE
Actually read rng state in deserializePcg32

### DIFF
--- a/src/IO/ReadHelpers.h
+++ b/src/IO/ReadHelpers.h
@@ -1248,19 +1248,23 @@ bool loadAtPosition(ReadBuffer & in, Memory<> & memory, char * & current);
 
 struct PcgDeserializer
 {
-    static void deserializePcg32(const pcg32_fast & rng, ReadBuffer & buf)
+    static void deserializePcg32(pcg32_fast & rng, ReadBuffer & buf)
     {
-        decltype(rng.state_) multiplier, increment, state;
+        /// multiplier and increment are constants for this particular rng.
+        /// They are used as invariants.
+        decltype(rng.state_) multiplier, increment;
         readText(multiplier, buf);
         assertChar(' ', buf);
         readText(increment, buf);
         assertChar(' ', buf);
-        readText(state, buf);
 
         if (multiplier != rng.multiplier())
             throw Exception(ErrorCodes::INCORRECT_DATA, "Incorrect multiplier in pcg32: expected {}, got {}", rng.multiplier(), multiplier);
         if (increment != rng.increment())
             throw Exception(ErrorCodes::INCORRECT_DATA, "Incorrect increment in pcg32: expected {}, got {}", rng.increment(), increment);
+
+        /// state is assigned directly to the rng instance.
+        readText(rng.state_, buf);
     }
 };
 


### PR DESCRIPTION
This likely should be marked as bug fix, but I'm struggling a bit to write the correct changelog entry. cc @tavplubix 

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...
