### PR TITLE
Improve query performance for ClickHouse on S3

### DIFF
--- a/src/Disks/DiskCacheWrapper.h
+++ b/src/Disks/DiskCacheWrapper.h
@@ -40,7 +40,9 @@ public:
         size_t estimated_size,
         size_t aio_threshold,
         size_t mmap_threshold,
-        MMappedFileCache * mmap_cache) const override;
+        MMappedFileCache * mmap_cache,
+        size_t offset,
+        size_t length) const override;
 
     std::unique_ptr<WriteBufferFromFileBase> writeFile(const String & path, size_t buf_size, WriteMode mode) override;
 

--- a/src/Disks/DiskDecorator.cpp
+++ b/src/Disks/DiskDecorator.cpp
@@ -115,9 +115,9 @@ void DiskDecorator::listFiles(const String & path, std::vector<String> & file_na
 
 std::unique_ptr<ReadBufferFromFileBase>
 DiskDecorator::readFile(
-    const String & path, size_t buf_size, size_t estimated_size, size_t aio_threshold, size_t mmap_threshold, MMappedFileCache * mmap_cache) const
+    const String & path, size_t buf_size, size_t estimated_size, size_t aio_threshold, size_t mmap_threshold, MMappedFileCache * mmap_cache, size_t offset, size_t length) const
 {
-    return delegate->readFile(path, buf_size, estimated_size, aio_threshold, mmap_threshold, mmap_cache);
+    return delegate->readFile(path, buf_size, estimated_size, aio_threshold, mmap_threshold, mmap_cache, offset, length);
 }
 
 std::unique_ptr<WriteBufferFromFileBase>

--- a/src/Disks/DiskDecorator.h
+++ b/src/Disks/DiskDecorator.h
@@ -41,7 +41,9 @@ public:
         size_t estimated_size,
         size_t aio_threshold,
         size_t mmap_threshold,
-        MMappedFileCache * mmap_cache) const override;
+        MMappedFileCache * mmap_cache,
+        size_t offset,
+        size_t length) const override;
 
     std::unique_ptr<WriteBufferFromFileBase> writeFile(
         const String & path,

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -211,7 +211,7 @@ void DiskLocal::replaceFile(const String & from_path, const String & to_path)
 
 std::unique_ptr<ReadBufferFromFileBase>
 DiskLocal::readFile(
-    const String & path, size_t buf_size, size_t estimated_size, size_t aio_threshold, size_t mmap_threshold, MMappedFileCache * mmap_cache) const
+    const String & path, size_t buf_size, size_t estimated_size, size_t aio_threshold, size_t mmap_threshold, MMappedFileCache * mmap_cache, size_t /*offset*/, size_t /*length*/) const
 {
     return createReadBufferFromFileBase(fs::path(disk_path) / path, estimated_size, aio_threshold, mmap_threshold, mmap_cache, buf_size);
 }

--- a/src/Disks/DiskLocal.h
+++ b/src/Disks/DiskLocal.h
@@ -76,7 +76,9 @@ public:
         size_t estimated_size,
         size_t aio_threshold,
         size_t mmap_threshold,
-        MMappedFileCache * mmap_cache) const override;
+        MMappedFileCache * mmap_cache,
+        size_t offset,
+        size_t length) const override;
 
     std::unique_ptr<WriteBufferFromFileBase> writeFile(
         const String & path,

--- a/src/Disks/DiskMemory.cpp
+++ b/src/Disks/DiskMemory.cpp
@@ -313,7 +313,7 @@ void DiskMemory::replaceFileImpl(const String & from_path, const String & to_pat
     files.insert(std::move(node));
 }
 
-std::unique_ptr<ReadBufferFromFileBase> DiskMemory::readFile(const String & path, size_t /*buf_size*/, size_t, size_t, size_t, MMappedFileCache *) const
+std::unique_ptr<ReadBufferFromFileBase> DiskMemory::readFile(const String & path, size_t /*buf_size*/, size_t, size_t, size_t, MMappedFileCache *, size_t /*size*/, size_t /*length*/) const
 {
     std::lock_guard lock(mutex);
 

--- a/src/Disks/DiskMemory.h
+++ b/src/Disks/DiskMemory.h
@@ -68,7 +68,9 @@ public:
         size_t estimated_size,
         size_t aio_threshold,
         size_t mmap_threshold,
-        MMappedFileCache * mmap_cache) const override;
+        MMappedFileCache * mmap_cache,
+        size_t offset,
+        size_t length) const override;
 
     std::unique_ptr<WriteBufferFromFileBase> writeFile(
         const String & path,

--- a/src/Disks/DiskRestartProxy.cpp
+++ b/src/Disks/DiskRestartProxy.cpp
@@ -187,11 +187,11 @@ void DiskRestartProxy::listFiles(const String & path, std::vector<String> & file
 }
 
 std::unique_ptr<ReadBufferFromFileBase> DiskRestartProxy::readFile(
-    const String & path, size_t buf_size, size_t estimated_size, size_t aio_threshold, size_t mmap_threshold, MMappedFileCache * mmap_cache)
+    const String & path, size_t buf_size, size_t estimated_size, size_t aio_threshold, size_t mmap_threshold, MMappedFileCache * mmap_cache, size_t offset, size_t length)
     const
 {
     ReadLock lock (mutex);
-    auto impl = DiskDecorator::readFile(path, buf_size, estimated_size, aio_threshold, mmap_threshold, mmap_cache);
+    auto impl = DiskDecorator::readFile(path, buf_size, estimated_size, aio_threshold, mmap_threshold, mmap_cache, offset, length);
     return std::make_unique<RestartAwareReadBuffer>(*this, std::move(impl));
 }
 

--- a/src/Disks/DiskRestartProxy.h
+++ b/src/Disks/DiskRestartProxy.h
@@ -49,7 +49,9 @@ public:
         size_t estimated_size,
         size_t aio_threshold,
         size_t mmap_threshold,
-        MMappedFileCache * mmap_cache) const override;
+        MMappedFileCache * mmap_cache,
+        size_t offset,
+        size_t length) const override;
     std::unique_ptr<WriteBufferFromFileBase> writeFile(const String & path, size_t buf_size, WriteMode mode) override;
     void removeFile(const String & path) override;
     void removeFileIfExists(const String & path) override;

--- a/src/Disks/HDFS/DiskHDFS.cpp
+++ b/src/Disks/HDFS/DiskHDFS.cpp
@@ -93,7 +93,7 @@ DiskHDFS::DiskHDFS(
 }
 
 
-std::unique_ptr<ReadBufferFromFileBase> DiskHDFS::readFile(const String & path, size_t buf_size, size_t, size_t, size_t, MMappedFileCache *) const
+std::unique_ptr<ReadBufferFromFileBase> DiskHDFS::readFile(const String & path, size_t buf_size, size_t, size_t, size_t, MMappedFileCache *, size_t /*offset*/, size_t /*length*/) const
 {
     auto metadata = readMeta(path);
 

--- a/src/Disks/HDFS/DiskHDFS.h
+++ b/src/Disks/HDFS/DiskHDFS.h
@@ -50,7 +50,9 @@ public:
         size_t estimated_size,
         size_t aio_threshold,
         size_t mmap_threshold,
-        MMappedFileCache * mmap_cache) const override;
+        MMappedFileCache * mmap_cache,
+        size_t offset,
+        size_t length) const override;
 
     std::unique_ptr<WriteBufferFromFileBase> writeFile(const String & path, size_t buf_size, WriteMode mode) override;
 

--- a/src/Disks/IDisk.h
+++ b/src/Disks/IDisk.h
@@ -158,7 +158,9 @@ public:
         size_t estimated_size = 0,
         size_t aio_threshold = 0,
         size_t mmap_threshold = 0,
-        MMappedFileCache * mmap_cache = nullptr) const = 0;
+        MMappedFileCache * mmap_cache = nullptr,
+        size_t offset = 0,
+        size_t length = 0) const = 0;
 
     /// Open the file for write and return WriteBufferFromFileBase object.
     virtual std::unique_ptr<WriteBufferFromFileBase> writeFile(

--- a/src/Disks/S3/DiskS3.h
+++ b/src/Disks/S3/DiskS3.h
@@ -79,7 +79,9 @@ public:
         size_t estimated_size,
         size_t aio_threshold,
         size_t mmap_threshold,
-        MMappedFileCache * mmap_cache) const override;
+        MMappedFileCache * mmap_cache,
+        size_t offset,
+        size_t length) const override;
 
     std::unique_ptr<WriteBufferFromFileBase> writeFile(
         const String & path,

--- a/src/IO/ReadBufferFromIStream.cpp
+++ b/src/IO/ReadBufferFromIStream.cpp
@@ -12,8 +12,21 @@ namespace ErrorCodes
 
 bool ReadBufferFromIStream::nextImpl()
 {
-    istr.read(internal_buffer.begin(), internal_buffer.size());
-    size_t gcount = istr.gcount();
+    size_t gcount = 0;
+    if (offset && offset - read_pos > internal_buffer.size())
+    {
+        gcount = internal_buffer.size();
+    }
+    else if (read_pos < offset)
+    {
+        gcount = offset - read_pos;
+    }
+    else
+    {
+        istr.read(internal_buffer.begin(), internal_buffer.size());
+        gcount = istr.gcount();
+    }
+    read_pos += gcount;
 
     if (!gcount)
     {
@@ -31,8 +44,8 @@ bool ReadBufferFromIStream::nextImpl()
     return true;
 }
 
-ReadBufferFromIStream::ReadBufferFromIStream(std::istream & istr_, size_t size)
-    : BufferWithOwnMemory<ReadBuffer>(size), istr(istr_)
+ReadBufferFromIStream::ReadBufferFromIStream(std::istream & istr_, size_t size, size_t offset_)
+    : BufferWithOwnMemory<ReadBuffer>(size), istr(istr_), offset(offset_)
 {
 }
 

--- a/src/IO/ReadBufferFromIStream.h
+++ b/src/IO/ReadBufferFromIStream.h
@@ -16,8 +16,10 @@ private:
 
     bool nextImpl() override;
 
+    size_t read_pos = 0;
+    size_t offset = 0;
 public:
-    explicit ReadBufferFromIStream(std::istream & istr_, size_t size = DBMS_DEFAULT_BUFFER_SIZE);
+    explicit ReadBufferFromIStream(std::istream & istr_, size_t size = DBMS_DEFAULT_BUFFER_SIZE, size_t offset_ = 0);
 };
 
 }

--- a/src/IO/ReadBufferFromS3.h
+++ b/src/IO/ReadBufferFromS3.h
@@ -36,14 +36,18 @@ private:
     std::unique_ptr<ReadBuffer> impl;
 
     Poco::Logger * log = &Poco::Logger::get("ReadBufferFromS3");
-
+    size_t init_offset = 0;
+    size_t init_length = 0;
+    bool inited = false;
 public:
     explicit ReadBufferFromS3(
         std::shared_ptr<Aws::S3::S3Client> client_ptr_,
         const String & bucket_,
         const String & key_,
         UInt64 max_single_read_retries_,
-        size_t buffer_size_ = DBMS_DEFAULT_BUFFER_SIZE);
+        size_t buffer_size_ = DBMS_DEFAULT_BUFFER_SIZE,
+        size_t init_offset_ = 0,
+        size_t init_length_ = 0);
 
     bool nextImpl() override;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Reduce the amount of data for s3 engine when executing query.

Detailed description / Documentation draft:

First, When using ClickHouse to query the data on the object store (S3, COS), in some cases a large amount of unnecessary data will be read, resulting in poor query performance. For example, when the required data is close to the end of a large file when SQL is executed, ClickHouse will start to read the data from the head of the large file until it obtains the required data.

Simply put, SeekAvoidingReadBuffer is currently used to implement the seek operation through ignore. ReadIndirectBufferFromS3::ignore reads data from the head until the desired position.

```
Call path:
SeekAvoidingReadBuffer::seek -> ReadBuffer::ignore -> ReadBufferFromS3::nextImpl -> ReadBufferFromIStream::nextImpl
```

Second, ClickHouse can accurately know the offset and size of the data in the S3 file for the query. We tell the object storage system the accurate offset and size by SetRange function, which will save the preparation time of the object storage backend and obtain better time.

In Tencent COS, if the range for reading data is not clearly provided, the return time of GetObject will become longer.