### PR TITLE
Partial backport  #24061  to 21.6

### DIFF
--- a/src/Interpreters/join_common.cpp
+++ b/src/Interpreters/join_common.cpp
@@ -89,9 +89,11 @@ void convertColumnToNullable(ColumnWithTypeAndName & column, bool remove_low_car
         if (column.column->lowCardinality())
         {
             /// Convert nested to nullable, not LowCardinality itself
-            ColumnLowCardinality * col_as_lc = assert_cast<ColumnLowCardinality *>(column.column->assumeMutable().get());
+            auto mut_col = IColumn::mutate(std::move(column.column));
+            ColumnLowCardinality * col_as_lc = assert_cast<ColumnLowCardinality *>(mut_col.get());
             if (!col_as_lc->nestedIsNullable())
                 col_as_lc->nestedToNullable();
+            column.column = std::move(mut_col);
         }
         else
             column.column = makeNullable(column.column);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Backport part of https://github.com/ClickHouse/ClickHouse/pull/24061 ( https://github.com/ClickHouse/ClickHouse/pull/25321 ) to fix memory corruption bug introduced in 21.6
