### PR TITLE
Fix crash in EXPLAIN AST without query.

### DIFF
--- a/src/Parsers/ParserExplainQuery.cpp
+++ b/src/Parsers/ParserExplainQuery.cpp
@@ -57,6 +57,8 @@ bool ParserExplainQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
         ParserQuery p(end);
         if (p.parse(pos, query, expected))
             explain_query->setExplainedQuery(std::move(query));
+        else
+            return false;
     }
     else if (select_p.parse(pos, query, expected) ||
         create_p.parse(pos, query, expected))

--- a/tests/queries/0_stateless/01604_explain_ast_of_nonselect_query.sql
+++ b/tests/queries/0_stateless/01604_explain_ast_of_nonselect_query.sql
@@ -1,1 +1,2 @@
+explain ast; -- { clientError 62 }
 explain ast alter table t1 delete where date = today()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix null pointer dereference in `EXPLAIN AST` without query.