### PR TITLE
[mysql] fix mysql select user() return empty

### DIFF
--- a/src/Server/MySQLHandler.cpp
+++ b/src/Server/MySQLHandler.cpp
@@ -130,6 +130,8 @@ void MySQLHandler::run()
 
         authenticate(handshake_response.username, handshake_response.auth_plugin_name, handshake_response.auth_response);
 
+        connection_context->getClientInfo().initial_user = handshake_response.username;
+
         try
         {
             if (!handshake_response.database.empty())

--- a/tests/integration/test_mysql_protocol/test.py
+++ b/tests/integration/test_mysql_protocol/test.py
@@ -200,6 +200,14 @@ def test_mysql_replacement_query(started_cluster):
     assert stdout.decode() == 'DATABASE()\ndefault\n'
 
 
+def test_mysql_select_user(started_cluster):
+    code, (stdout, stderr) = started_cluster.mysql_client_container.exec_run('''
+        mysql --protocol tcp -h {host} -P {port} default -u default --password=123
+        -e "select user();"
+    '''.format(host=started_cluster.get_instance_ip('node'), port=server_port), demux=True)
+    assert code == 0
+    assert stdout.decode() == 'currentUser()\ndefault\n'
+
 def test_mysql_explain(started_cluster):
     # EXPLAIN SELECT 1
     code, (stdout, stderr) = started_cluster.mysql_client_container.exec_run('''
@@ -310,6 +318,7 @@ def test_mysql_set_variables(started_cluster):
         "
     '''.format(host=started_cluster.get_instance_ip('node'), port=server_port), demux=True)
     assert code == 0
+
 
 
 def test_python_client(started_cluster):


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Bug Fix   

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix mysql select user() return empty. Fixes #25683.
