### PR TITLE
Fix postgres dict quoted name in AS

### DIFF
--- a/src/Dictionaries/ExternalQueryBuilder.cpp
+++ b/src/Dictionaries/ExternalQueryBuilder.cpp
@@ -4,7 +4,6 @@
 #include <IO/WriteHelpers.h>
 #include <boost/range/join.hpp>
 #include "DictionaryStructure.h"
-#include "writeParenthesisedString.h"
 
 
 namespace DB
@@ -27,7 +26,7 @@ ExternalQueryBuilder::ExternalQueryBuilder(
 {}
 
 
-void ExternalQueryBuilder::writeQuoted(const std::string & s, WriteBuffer & out) const
+void ExternalQueryBuilder::writeQuoted(const String & s, WriteBuffer & out) const
 {
     switch (quoting_style)
     {
@@ -49,6 +48,13 @@ void ExternalQueryBuilder::writeQuoted(const std::string & s, WriteBuffer & out)
     }
 }
 
+void ExternalQueryBuilder::writeParenthesisedString(const String & s, WriteBuffer & buf) const
+{
+    writeChar('(', buf);
+    /// Unquote string if it is not an expression but a single name with quotes (in case it contains unusual symbols).
+    writeString(unquoteString(s), buf);
+    writeChar(')', buf);
+}
 
 std::string ExternalQueryBuilder::composeLoadAllQuery() const
 {

--- a/src/Dictionaries/ExternalQueryBuilder.h
+++ b/src/Dictionaries/ExternalQueryBuilder.h
@@ -79,7 +79,9 @@ private:
     void composeKeyTuple(const Columns & key_columns, const size_t row, WriteBuffer & out, size_t beg, size_t end) const;
 
     /// Write string with specified quoting style.
-    void writeQuoted(const std::string & s, WriteBuffer & out) const;
+    void writeQuoted(const String & s, WriteBuffer & out) const;
+
+    void writeParenthesisedString(const String & s, WriteBuffer & buf) const;
 };
 
 }

--- a/src/IO/WriteHelpers.h
+++ b/src/IO/WriteHelpers.h
@@ -504,6 +504,19 @@ inline void writeBackQuotedStringMySQL(const StringRef & s, WriteBuffer & buf)
     writeChar('`', buf);
 }
 
+template <char quote_character>
+inline bool isQuoted(const std::string_view & s)
+{
+    return (s.size() > 1) && s.starts_with(quote_character) && s.ends_with(quote_character);
+}
+
+template <char quote_character = '`'>
+inline StringRef unquoteString(const StringRef & s)
+{
+    if (isQuoted<quote_character>(std::string_view(s)))
+        return StringRef(s.data + 1, s.size - 2);
+    return s;
+}
 
 /// Write quoted if the string doesn't look like and identifier.
 void writeProbablyBackQuotedString(const StringRef & s, WriteBuffer & buf);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix creating postgres dictionary with expression, when column name can contain unusual symbols (like $) with simple AS. Closes https://github.com/ClickHouse/ClickHouse/issues/25622.