### PR TITLE
When the configuration file changes, reload the connection pool of the distributed table

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1958,6 +1958,11 @@ void Context::setClustersConfig(const ConfigurationPtr & config, const String & 
         shared->clusters->updateClusters(*shared->clusters_config, settings, config_name, old_clusters_config);
 }
 
+ConfigurationPtr Context::getClustersConfig() const
+{
+    std::lock_guard lock(shared->clusters_mutex);
+    return shared->clusters_config;
+}
 
 void Context::setCluster(const String & cluster_name, const std::shared_ptr<Cluster> & cluster)
 {
@@ -1968,7 +1973,6 @@ void Context::setCluster(const String & cluster_name, const std::shared_ptr<Clus
 
     shared->clusters->setCluster(cluster_name, cluster);
 }
-
 
 void Context::initializeSystemLogs()
 {

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -679,6 +679,7 @@ public:
     std::shared_ptr<Clusters> getClusters() const;
     std::shared_ptr<Cluster> getCluster(const std::string & cluster_name) const;
     std::shared_ptr<Cluster> tryGetCluster(const std::string & cluster_name) const;
+    ConfigurationPtr getClustersConfig() const;
     void setClustersConfig(const ConfigurationPtr & config, const String & config_name = "remote_servers");
     /// Sets custom cluster, but doesn't update configuration
     void setCluster(const String & cluster_name, const std::shared_ptr<Cluster> & cluster);

--- a/src/Storages/Distributed/DirectoryMonitor.cpp
+++ b/src/Storages/Distributed/DirectoryMonitor.cpp
@@ -376,7 +376,8 @@ StorageDistributedDirectoryMonitor::~StorageDistributedDirectoryMonitor()
 
 void StorageDistributedDirectoryMonitor::requestUpdatePool()
 {
-    if (name.find("all_replicas") != std::string::npos)
+    const char * user_pw_end = strchr(name.data(), '@');
+    if (!user_pw_end && startsWith(name, "shard"))
         need_update_pool = true;
 }
 

--- a/src/Storages/Distributed/DirectoryMonitor.h
+++ b/src/Storages/Distributed/DirectoryMonitor.h
@@ -29,9 +29,9 @@ class StorageDistributedDirectoryMonitor
 public:
     StorageDistributedDirectoryMonitor(
         StorageDistributed & storage_,
+        const std::string & name,
         const DiskPtr & disk_,
         const std::string & relative_path_,
-        ConnectionPoolPtr pool_,
         ActionBlocker & monitor_blocker_,
         BackgroundSchedulePool & bg_pool);
 
@@ -40,6 +40,8 @@ public:
     static ConnectionPoolPtr createPool(const std::string & name, const StorageDistributed & storage);
 
     void updatePath(const std::string & new_relative_path);
+
+    void requestUpdatePool();
 
     void flushAllData();
 
@@ -85,7 +87,8 @@ private:
     std::string getLoggerName() const;
 
     StorageDistributed & storage;
-    const ConnectionPoolPtr pool;
+    std::string name;
+    ConnectionPoolPtr pool;
 
     DiskPtr disk;
     std::string relative_path;
@@ -94,6 +97,7 @@ private:
     const bool should_batch_inserts = false;
     const bool split_batch_on_failure = true;
     const bool dir_fsync = false;
+    std::atomic<bool> need_update_pool = false;
     const size_t min_batched_block_size_rows = 0;
     const size_t min_batched_block_size_bytes = 0;
     String current_batch_file_path;

--- a/src/Storages/StorageDistributed.h
+++ b/src/Storages/StorageDistributed.h
@@ -120,6 +120,8 @@ public:
     /// Used by ClusterCopier
     size_t getShardCount() const;
 
+    void updateConnectionPool();
+
 private:
     StorageDistributed(
         const StorageID & id_,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
When the address of remote_servers in the configuration file changes, reload the connection pool of the distributed table using the new compact format

Detailed description / Documentation draft:
Use  configuration item  `use_compact_format_in_distributed_parts_names` , set to 1.
The directory name of distributed table uses the new compact format，like this `shard1_replica1` or `shard1_all_replicas`.
When the address of remote_servers in the configuration file changes, the address in the connection pool of distributed table is still old and must be restarted at this time to take effect.
This pr enables the connection pool to be automatically updated when the configuration file is reloaded.

