### PR TITLE
Set follow-fork-mode child for gdb in stress/fasttest/fuzzer

### DIFF
--- a/docker/test/fasttest/run.sh
+++ b/docker/test/fasttest/run.sh
@@ -113,6 +113,7 @@ function start_server
     echo "ClickHouse server pid '$server_pid' started and responded"
 
     echo "
+set follow-fork-mode child
 handle all noprint
 handle SIGSEGV stop print
 handle SIGBUS stop print

--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -103,6 +103,7 @@ function fuzz
     kill -0 $server_pid
 
     echo "
+set follow-fork-mode child
 handle all noprint
 handle SIGSEGV stop print
 handle SIGBUS stop print

--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -55,6 +55,7 @@ function start()
     done
 
     echo "
+set follow-fork-mode child
 handle all noprint
 handle SIGSEGV stop print
 handle SIGBUS stop print


### PR DESCRIPTION
Sometimes gdb does not catch SIGSEGV [1], let's try set this setting,
since maybe some code from contrib does fork.

  [1]: https://clickhouse-test-reports.s3.yandex.net/25605/cd5a3c8d7eb417f6df211b4507dc970933f8549a/stress_test_(thread).html#fail1

Changelog category (leave one):
- Not for changelog (changelog entry is not required)