### PR TITLE
Fix some typos in Storage classes

### DIFF
--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -230,7 +230,7 @@ ExpressionActionsPtr buildShardingKeyExpression(const ASTPtr & sharding_key, Con
     return ExpressionAnalyzer(query, syntax_result, context).getActions(project);
 }
 
-bool isExpressionActionsDeterministics(const ExpressionActionsPtr & actions)
+bool isExpressionActionsDeterministic(const ExpressionActionsPtr & actions)
 {
     for (const auto & action : actions->getActions())
     {
@@ -428,7 +428,7 @@ StorageDistributed::StorageDistributed(
     {
         sharding_key_expr = buildShardingKeyExpression(sharding_key_, getContext(), storage_metadata.getColumns().getAllPhysical(), false);
         sharding_key_column_name = sharding_key_->getColumnName();
-        sharding_key_is_deterministic = isExpressionActionsDeterministics(sharding_key_expr);
+        sharding_key_is_deterministic = isExpressionActionsDeterministic(sharding_key_expr);
     }
 
     if (!relative_data_path.empty())
@@ -524,7 +524,7 @@ QueryProcessingStage::Enum StorageDistributed::getQueryProcessingStage(
         else
         {
             /// NOTE: distributed_group_by_no_merge=1 does not respect distributed_push_down_limit
-            /// (since in this case queries processed separatelly and the initiator is just a proxy in this case).
+            /// (since in this case queries processed separately and the initiator is just a proxy in this case).
             return QueryProcessingStage::Complete;
         }
     }

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -538,7 +538,7 @@ public:
         std::unique_ptr<WriteBufferFromFileDescriptor> naked_buffer = nullptr;
         if (storage.use_table_fd)
         {
-            /** NOTE: Using real file binded to FD may be misleading:
+            /** NOTE: Using real file bounded to FD may be misleading:
               * SELECT *; INSERT insert_data; SELECT *; last SELECT returns initil_fd_data + insert_data
               * INSERT data; SELECT *; last SELECT returns only insert_data
               */
@@ -642,7 +642,7 @@ Strings StorageFile::getDataPaths() const
 void StorageFile::rename(const String & new_path_to_table_data, const StorageID & new_table_id)
 {
     if (!is_db_table)
-        throw Exception("Can't rename table " + getStorageID().getNameForLogs() + " binded to user-defined file (or FD)", ErrorCodes::DATABASE_ACCESS_DENIED);
+        throw Exception("Can't rename table " + getStorageID().getNameForLogs() + " bounded to user-defined file (or FD)", ErrorCodes::DATABASE_ACCESS_DENIED);
 
     if (paths.size() != 1)
         throw Exception("Can't rename table " + getStorageID().getNameForLogs() + " in readonly mode", ErrorCodes::DATABASE_ACCESS_DENIED);

--- a/src/Storages/StorageInMemoryMetadata.cpp
+++ b/src/Storages/StorageInMemoryMetadata.cpp
@@ -228,12 +228,12 @@ ColumnDependencies StorageInMemoryMetadata::getColumnDependencies(const NameSet 
 
     auto add_dependent_columns = [&updated_columns](const auto & expression, auto & to_set)
     {
-        auto requiered_columns = expression->getRequiredColumns();
-        for (const auto & dependency : requiered_columns)
+        auto required_columns = expression->getRequiredColumns();
+        for (const auto & dependency : required_columns)
         {
             if (updated_columns.count(dependency))
             {
-                to_set.insert(requiered_columns.begin(), requiered_columns.end());
+                to_set.insert(required_columns.begin(), required_columns.end());
                 return true;
             }
         }

--- a/src/Storages/StorageJoin.cpp
+++ b/src/Storages/StorageJoin.cpp
@@ -97,8 +97,8 @@ void StorageJoin::checkMutationIsPossible(const MutationCommands & commands, con
 
 void StorageJoin::mutate(const MutationCommands & commands, ContextPtr context)
 {
-    /// Firstly accuire lock for mutation, that locks changes of data.
-    /// We cannot accuire rwlock here, because read lock is needed
+    /// Firstly acquire lock for mutation, that locks changes of data.
+    /// We cannot acquire rwlock here, because read lock is needed
     /// for execution of mutation interpreter.
     std::lock_guard mutate_lock(mutate_mutex);
 
@@ -128,7 +128,7 @@ void StorageJoin::mutate(const MutationCommands & commands, ContextPtr context)
         in->readSuffix();
     }
 
-    /// Now accuire exclusive lock and modify storage.
+    /// Now acquire exclusive lock and modify storage.
     std::unique_lock<std::shared_mutex> lock(rwlock);
 
     join = std::move(new_data);

--- a/src/Storages/StorageMemory.cpp
+++ b/src/Storages/StorageMemory.cpp
@@ -263,7 +263,7 @@ void StorageMemory::mutate(const MutationCommands & commands, ContextPtr context
     auto storage = getStorageID();
     auto storage_ptr = DatabaseCatalog::instance().getTable(storage, context);
 
-    /// When max_threads > 1, the order of returning blocks is uncentain,
+    /// When max_threads > 1, the order of returning blocks is uncertain,
     /// which will lead to inconsistency after updateBlockData.
     auto new_context = Context::createCopy(context);
     new_context->setSetting("max_streams_to_max_threads_ratio", 1);

--- a/src/Storages/StorageMongoDB.cpp
+++ b/src/Storages/StorageMongoDB.cpp
@@ -58,7 +58,7 @@ void StorageMongoDB::connectIfNotConnected()
     if (!connection)
         connection = std::make_shared<Poco::MongoDB::Connection>(host, port);
 
-    if (!authentified)
+    if (!authenticated)
     {
 #       if POCO_VERSION >= 0x01070800
             Poco::MongoDB::Database poco_db(database_name);
@@ -67,7 +67,7 @@ void StorageMongoDB::connectIfNotConnected()
 #       else
             authenticate(*connection, database_name, username, password);
 #       endif
-        authentified = true;
+        authenticated = true;
     }
 }
 

--- a/src/Storages/StorageMongoDB.h
+++ b/src/Storages/StorageMongoDB.h
@@ -52,8 +52,8 @@ private:
     const std::string password;
 
     std::shared_ptr<Poco::MongoDB::Connection> connection;
-    bool authentified = false;
-    std::mutex connection_mutex; /// Protects the variables `connection` and `authentified`.
+    bool authenticated = false;
+    std::mutex connection_mutex; /// Protects the variables `connection` and `authenticated`.
 };
 
 }

--- a/src/Storages/StorageMySQL.cpp
+++ b/src/Storages/StorageMySQL.cpp
@@ -175,28 +175,28 @@ public:
         if (block.rows() <= max_rows)
             return Blocks{std::move(block)};
 
-        const size_t splited_block_size = ceil(block.rows() * 1.0 / max_rows);
-        Blocks splitted_blocks(splited_block_size);
+        const size_t split_block_size = ceil(block.rows() * 1.0 / max_rows);
+        Blocks split_blocks(split_block_size);
 
-        for (size_t idx = 0; idx < splited_block_size; ++idx)
-            splitted_blocks[idx] = block.cloneEmpty();
+        for (size_t idx = 0; idx < split_block_size; ++idx)
+            split_blocks[idx] = block.cloneEmpty();
 
         const size_t columns = block.columns();
         const size_t rows = block.rows();
         size_t offsets = 0;
         UInt64 limits = max_batch_rows;
-        for (size_t idx = 0; idx < splited_block_size; ++idx)
+        for (size_t idx = 0; idx < split_block_size; ++idx)
         {
             /// For last batch, limits should be the remain size
-            if (idx == splited_block_size - 1) limits = rows - offsets;
+            if (idx == split_block_size - 1) limits = rows - offsets;
             for (size_t col_idx = 0; col_idx < columns; ++col_idx)
             {
-                splitted_blocks[idx].getByPosition(col_idx).column = block.getByPosition(col_idx).column->cut(offsets, limits);
+                split_blocks[idx].getByPosition(col_idx).column = block.getByPosition(col_idx).column->cut(offsets, limits);
             }
             offsets += max_batch_rows;
         }
 
-        return splitted_blocks;
+        return split_blocks;
     }
 
     static std::string dumpNamesWithBackQuote(const Block & block)

--- a/src/Storages/StoragePostgreSQL.cpp
+++ b/src/Storages/StoragePostgreSQL.cpp
@@ -162,7 +162,7 @@ public:
     }
 
     /// Cannot just use serializeAsText for array data type even though it converts perfectly
-    /// any dimension number array into text format, because it incloses in '[]' and for postgres it must be '{}'.
+    /// any dimension number array into text format, because it encloses in '[]' and for postgres it must be '{}'.
     /// Check if array[...] syntax from PostgreSQL will be applicable.
     void parseArray(const Field & array_field, const DataTypePtr & data_type, WriteBuffer & ostr)
     {

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -414,7 +414,7 @@ StorageReplicatedMergeTree::StorageReplicatedMergeTree(
                 /// We have to check granularity on other replicas. If it's fixed we
                 /// must create our new replica with fixed granularity and store this
                 /// information in /replica/metadata.
-                other_replicas_fixed_granularity = checkFixedGranualrityInZookeeper();
+                other_replicas_fixed_granularity = checkFixedGranularityInZookeeper();
 
                 checkTableStructure(zookeeper_path, metadata_snapshot);
 
@@ -449,7 +449,7 @@ StorageReplicatedMergeTree::StorageReplicatedMergeTree(
         if (!replica_metadata_exists || replica_metadata.empty())
         {
             /// We have to check shared node granularity before we create ours.
-            other_replicas_fixed_granularity = checkFixedGranualrityInZookeeper();
+            other_replicas_fixed_granularity = checkFixedGranularityInZookeeper();
 
             ReplicatedMergeTreeTableMetadata current_metadata(*this, metadata_snapshot);
 
@@ -486,7 +486,7 @@ StorageReplicatedMergeTree::StorageReplicatedMergeTree(
 }
 
 
-bool StorageReplicatedMergeTree::checkFixedGranualrityInZookeeper()
+bool StorageReplicatedMergeTree::checkFixedGranularityInZookeeper()
 {
     auto zookeeper = getZooKeeper();
     String metadata_str = zookeeper->get(zookeeper_path + "/metadata");

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -434,7 +434,7 @@ private:
 
     String getChecksumsForZooKeeper(const MergeTreeDataPartChecksums & checksums) const;
 
-    /// Accepts a PreComitted part, atomically checks its checksums with ones on other replicas and commit the part
+    /// Accepts a PreCommitted part, atomically checks its checksums with ones on other replicas and commit the part
     DataPartsVector checkPartChecksumsAndCommit(Transaction & transaction, const DataPartPtr & part);
 
     bool partIsAssignedToBackgroundOperation(const DataPartPtr & part) const override;
@@ -633,7 +633,7 @@ private:
       * Because it effectively waits for other thread that usually has to also acquire a lock to proceed and this yields deadlock.
       * TODO: There are wrong usages of this method that are not fixed yet.
       *
-      * One method for convenient use on current table, another for waiting on foregin shards.
+      * One method for convenient use on current table, another for waiting on foreign shards.
       */
     Strings waitForAllTableReplicasToProcessLogEntry(const String & table_zookeeper_path, const ReplicatedMergeTreeLogEntryData & entry, bool wait_for_non_active = true);
     Strings waitForAllReplicasToProcessLogEntry(const ReplicatedMergeTreeLogEntryData & entry, bool wait_for_non_active = true);
@@ -690,7 +690,7 @@ private:
 
     /// Check granularity of already existing replicated table in zookeeper if it exists
     /// return true if it's fixed
-    bool checkFixedGranualrityInZookeeper();
+    bool checkFixedGranularityInZookeeper();
 
     /// Wait for timeout seconds mutation is finished on replicas
     void waitMutationToFinishOnReplicas(

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -62,7 +62,7 @@ public:
 
         const String key_prefix = globbed_uri.key.substr(0, globbed_uri.key.find_first_of("*?{"));
 
-        /// We don't have to list bucket, because there is no asterics.
+        /// We don't have to list bucket, because there is no asterisks.
         if (key_prefix.size() == globbed_uri.key.size())
         {
             buffer.emplace_back(globbed_uri.key);
@@ -434,7 +434,7 @@ BlockOutputStreamPtr StorageS3::write(const ASTPtr & /*query*/, const StorageMet
         max_single_part_upload_size);
 }
 
-void StorageS3::updateClientAndAuthSettings(ContextPtr ctx, StorageS3::ClientAuthentificaiton & upd)
+void StorageS3::updateClientAndAuthSettings(ContextPtr ctx, StorageS3::ClientAuthentication & upd)
 {
     auto settings = ctx->getStorageS3Settings().getSettings(upd.uri.uri.toString());
     if (upd.client && (!upd.access_key_id.empty() || settings == upd.auth_settings))

--- a/src/Storages/StorageS3.h
+++ b/src/Storages/StorageS3.h
@@ -137,7 +137,7 @@ private:
     friend class StorageS3Cluster;
     friend class TableFunctionS3Cluster;
 
-    struct ClientAuthentificaiton
+    struct ClientAuthentication
     {
         const S3::URI uri;
         const String access_key_id;
@@ -147,7 +147,7 @@ private:
         S3AuthSettings auth_settings;
     };
 
-    ClientAuthentificaiton client_auth;
+    ClientAuthentication client_auth;
 
     String format_name;
     UInt64 max_single_read_retries;
@@ -157,7 +157,7 @@ private:
     String name;
     const bool distributed_processing;
 
-    static void updateClientAndAuthSettings(ContextPtr, ClientAuthentificaiton &);
+    static void updateClientAndAuthSettings(ContextPtr, ClientAuthentication &);
 };
 
 }

--- a/src/Storages/StorageS3Cluster.h
+++ b/src/Storages/StorageS3Cluster.h
@@ -21,13 +21,6 @@ namespace DB
 
 class Context;
 
-struct ClientAuthentificationBuilder
-{
-    String access_key_id;
-    String secret_access_key;
-    UInt64 max_connections;
-};
-
 class StorageS3Cluster : public shared_ptr_helper<StorageS3Cluster>, public IStorage
 {
     friend struct shared_ptr_helper<StorageS3Cluster>;
@@ -59,7 +52,7 @@ protected:
 private:
     /// Connections from initiator to other nodes
     std::vector<std::shared_ptr<Connection>> connections;
-    StorageS3::ClientAuthentificaiton client_auth;
+    StorageS3::ClientAuthentication client_auth;
 
     String filename;
     String cluster_name;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:

Fix a few typos in the storage* classes.
