### PR TITLE
Fix optimize_skip_unused_shards_rewrite_in for non-UInt64 types

### DIFF
--- a/src/Interpreters/ClusterProxy/executeQuery.cpp
+++ b/src/Interpreters/ClusterProxy/executeQuery.cpp
@@ -149,6 +149,7 @@ void executeQuery(
 
             OptimizeShardingKeyRewriteInVisitor::Data visitor_data{
                 sharding_key_expr,
+                sharding_key_expr->getSampleBlock().getByPosition(0).type,
                 sharding_key_column_name,
                 shard_info,
                 not_optimized_cluster->getSlotToShard(),

--- a/src/Interpreters/OptimizeShardingKeyRewriteInVisitor.cpp
+++ b/src/Interpreters/OptimizeShardingKeyRewriteInVisitor.cpp
@@ -34,25 +34,18 @@ Field executeFunctionOnField(
 
 /// @param sharding_column_value - one of values from IN
 /// @param sharding_column_name - name of that column
-/// @param sharding_expr - expression of sharding_key for the Distributed() table
-/// @param sharding_key_column_name - name of the column for sharding_expr
-/// @param shard_info - info for the current shard (to compare shard_num with calculated)
-/// @param slots - weight -> shard mapping
 /// @return true if shard may contain such value (or it is unknown), otherwise false.
 bool shardContains(
     const Field & sharding_column_value,
     const std::string & sharding_column_name,
-    const ExpressionActionsPtr & sharding_expr,
-    const std::string & sharding_key_column_name,
-    const Cluster::ShardInfo & shard_info,
-    const Cluster::SlotToShard & slots)
+    const OptimizeShardingKeyRewriteInMatcher::Data & data)
 {
     /// NULL is not allowed in sharding key,
     /// so it should be safe to assume that shard cannot contain it.
     if (sharding_column_value.isNull())
         return false;
 
-    Field sharding_value = executeFunctionOnField(sharding_column_value, sharding_column_name, sharding_expr, sharding_key_column_name);
+    Field sharding_value = executeFunctionOnField(sharding_column_value, sharding_column_name, data.sharding_key_expr, data.sharding_key_column_name);
     /// The value from IN can be non-numeric,
     /// but in this case it should be convertible to numeric type, let's try.
     sharding_value = convertFieldToType(sharding_value, DataTypeUInt64());
@@ -61,8 +54,8 @@ bool shardContains(
         return false;
 
     UInt64 value = sharding_value.get<UInt64>();
-    const auto shard_num = slots[value % slots.size()] + 1;
-    return shard_info.shard_num == shard_num;
+    const auto shard_num = data.slots[value % data.slots.size()] + 1;
+    return data.shard_info.shard_num == shard_num;
 }
 
 }
@@ -92,10 +85,7 @@ void OptimizeShardingKeyRewriteInMatcher::visit(ASTFunction & function, Data & d
     if (!identifier)
         return;
 
-    const auto & sharding_expr = data.sharding_key_expr;
-    const auto & sharding_key_column_name = data.sharding_key_column_name;
-
-    if (!sharding_expr->getRequiredColumnsWithTypes().contains(identifier->name()))
+    if (!data.sharding_key_expr->getRequiredColumnsWithTypes().contains(identifier->name()))
         return;
 
     /// NOTE: that we should not take care about empty tuple,
@@ -107,7 +97,7 @@ void OptimizeShardingKeyRewriteInMatcher::visit(ASTFunction & function, Data & d
         std::erase_if(tuple_elements->children, [&](auto & child)
         {
             auto * literal = child->template as<ASTLiteral>();
-            return literal && !shardContains(literal->value, identifier->name(), sharding_expr, sharding_key_column_name, data.shard_info, data.slots);
+            return literal && !shardContains(literal->value, identifier->name(), data);
         });
     }
     else if (auto * tuple_literal = right->as<ASTLiteral>();
@@ -116,7 +106,7 @@ void OptimizeShardingKeyRewriteInMatcher::visit(ASTFunction & function, Data & d
         auto & tuple = tuple_literal->value.get<Tuple &>();
         std::erase_if(tuple, [&](auto & child)
         {
-            return !shardContains(child, identifier->name(), sharding_expr, sharding_key_column_name, data.shard_info, data.slots);
+            return !shardContains(child, identifier->name(), data);
         });
     }
 }

--- a/src/Interpreters/OptimizeShardingKeyRewriteInVisitor.cpp
+++ b/src/Interpreters/OptimizeShardingKeyRewriteInVisitor.cpp
@@ -35,10 +35,15 @@ Field executeFunctionOnField(
 /// @param sharding_column_name - name of that column
 /// @return true if shard may contain such value (or it is unknown), otherwise false.
 bool shardContains(
-    const Field & sharding_column_value,
+    Field sharding_column_value,
     const std::string & sharding_column_name,
     const OptimizeShardingKeyRewriteInMatcher::Data & data)
 {
+    UInt64 field_value;
+    /// Convert value to numeric (if required).
+    if (!sharding_column_value.tryGet<UInt64>(field_value))
+        sharding_column_value = convertFieldToType(sharding_column_value, *data.sharding_key_type);
+
     /// NULL is not allowed in sharding key,
     /// so it should be safe to assume that shard cannot contain it.
     if (sharding_column_value.isNull())

--- a/src/Interpreters/OptimizeShardingKeyRewriteInVisitor.h
+++ b/src/Interpreters/OptimizeShardingKeyRewriteInVisitor.h
@@ -25,9 +25,15 @@ struct OptimizeShardingKeyRewriteInMatcher
 
     struct Data
     {
+        /// Expression of sharding_key for the Distributed() table
         const ExpressionActionsPtr & sharding_key_expr;
+        /// Type of sharding_key column.
+        const DataTypePtr & sharding_key_type;
+        /// Name of the column for sharding_expr
         const std::string & sharding_key_column_name;
+        /// Info for the current shard (to compare shard_num with calculated)
         const Cluster::ShardInfo & shard_info;
+        /// weight -> shard mapping
         const Cluster::SlotToShard & slots;
     };
 

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -1093,7 +1093,7 @@ ClusterPtr StorageDistributed::skipUnusedShards(
     size_t limit = local_context->getSettingsRef().optimize_skip_unused_shards_limit;
     if (!limit || limit > SSIZE_MAX)
     {
-        throw Exception("optimize_skip_unused_shards_limit out of range (0, {}]", ErrorCodes::ARGUMENT_OUT_OF_BOUND, SSIZE_MAX);
+        throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "optimize_skip_unused_shards_limit out of range (0, {}]", SSIZE_MAX);
     }
     // To interpret limit==0 as limit is reached
     ++limit;

--- a/tests/queries/0_stateless/01756_optimize_skip_unused_shards_rewrite_in.reference
+++ b/tests/queries/0_stateless/01756_optimize_skip_unused_shards_rewrite_in.reference
@@ -22,6 +22,7 @@ others
 different types -- prohibited
 different types -- conversion
 0
+0
 optimize_skip_unused_shards_limit
 0
 0

--- a/tests/queries/0_stateless/01756_optimize_skip_unused_shards_rewrite_in.sql
+++ b/tests/queries/0_stateless/01756_optimize_skip_unused_shards_rewrite_in.sql
@@ -93,8 +93,6 @@ select 'errors';
 -- optimize_skip_unused_shards does not support non-constants
 select * from dist_01756 where dummy in (select * from system.one); -- { serverError 507 }
 select * from dist_01756 where dummy in (toUInt8(0)); -- { serverError 507 }
--- intHash64 does not accept string
-select * from dist_01756 where dummy in ('0', '2'); -- { serverError 43 }
 -- NOT IN does not supported
 select * from dist_01756 where dummy not in (0, 2); -- { serverError 507 }
 
@@ -126,6 +124,8 @@ select 'different types -- conversion';
 create table dist_01756_column as system.one engine=Distributed(test_cluster_two_shards, system, one, dummy);
 select * from dist_01756_column where dummy in (0, '255');
 select * from dist_01756_column where dummy in (0, '255foo'); -- { serverError 53 }
+-- intHash64 does not accept string, but implicit conversion should be done
+select * from dist_01756 where dummy in ('0', '2');
 
 -- optimize_skip_unused_shards_limit
 select 'optimize_skip_unused_shards_limit';

--- a/tests/queries/0_stateless/01930_optimize_skip_unused_shards_rewrite_in.reference
+++ b/tests/queries/0_stateless/01930_optimize_skip_unused_shards_rewrite_in.reference
@@ -1,0 +1,132 @@
+-- { echoOn }
+
+-- Int8, Int8
+select _shard_num, * from remote('127.{1..4}', view(select toInt8(id) id from data), toInt8(id)) where id in (0, 1, 0x7f) order by _shard_num, id;
+1	0
+1	0
+1	0
+1	0
+2	1
+4	127
+-- Int8, UInt8
+select _shard_num, * from remote('127.{1..4}', view(select toInt8(id) id from data), toUInt8(id)) where id in (0, 1, 0x7f) order by _shard_num, id;
+1	0
+1	0
+1	0
+1	0
+2	1
+4	127
+-- UInt8, UInt8
+select _shard_num, * from remote('127.{1..4}', view(select toUInt8(id) id from data), toUInt8(id)) where id in (0, 1, 0x7f, 0x80, 0xff) order by _shard_num, id;
+1	0
+1	0
+1	0
+1	0
+1	128
+2	1
+4	127
+4	255
+4	255
+4	255
+4	255
+4	255
+4	255
+4	255
+-- UInt8, Int8
+select _shard_num, * from remote('127.{1..4}', view(select toUInt8(id) id from data), toInt8(id)) where id in (0, 1, 0x7f, 0x80, 0xff) order by _shard_num, id;
+1	0
+1	0
+1	0
+1	0
+2	1
+4	127
+-- Int16, Int16
+select _shard_num, * from remote('127.{1..4}', view(select toInt16(id) id from data), toInt16(id)) where id in (0, 1, 0x7fff) order by _shard_num, id;
+1	0
+1	0
+1	0
+2	1
+4	32767
+-- Int16, UInt16
+select _shard_num, * from remote('127.{1..4}', view(select toInt16(id) id from data), toUInt16(id)) where id in (0, 1, 0x7fff) order by _shard_num, id;
+1	0
+1	0
+1	0
+2	1
+4	32767
+-- UInt16, UInt16
+select _shard_num, * from remote('127.{1..4}', view(select toUInt16(id) id from data), toUInt16(id)) where id in (0, 1, 0x7fff, 0x8000, 0xffff) order by _shard_num, id;
+1	0
+1	0
+1	0
+1	32768
+2	1
+4	32767
+4	65535
+4	65535
+4	65535
+4	65535
+4	65535
+-- UInt16, Int16
+select _shard_num, * from remote('127.{1..4}', view(select toUInt16(id) id from data), toInt16(id)) where id in (0, 1, 0x7fff, 0x8000, 0xffff) order by _shard_num, id;
+1	0
+1	0
+1	0
+2	1
+4	32767
+-- Int32, Int32
+select _shard_num, * from remote('127.{1..4}', view(select toInt32(id) id from data), toInt32(id)) where id in (0, 1, 0x7fffffff) order by _shard_num, id;
+1	0
+1	0
+2	1
+4	2147483647
+-- Int32, UInt32
+select _shard_num, * from remote('127.{1..4}', view(select toInt32(id) id from data), toUInt32(id)) where id in (0, 1, 0x7fffffff) order by _shard_num, id;
+1	0
+1	0
+2	1
+4	2147483647
+-- UInt32, UInt32
+select _shard_num, * from remote('127.{1..4}', view(select toUInt32(id) id from data), toUInt32(id)) where id in (0, 1, 0x7fffffff, 0x80000000, 0xffffffff) order by _shard_num, id;
+1	0
+1	0
+1	2147483648
+2	1
+4	2147483647
+4	4294967295
+4	4294967295
+4	4294967295
+-- UInt32, Int32
+select _shard_num, * from remote('127.{1..4}', view(select toUInt32(id) id from data), toInt32(id)) where id in (0, 1, 0x7fffffff, 0x80000000, 0xffffffff) order by _shard_num, id;
+1	0
+1	0
+2	1
+4	2147483647
+-- Int64, Int64
+select _shard_num, * from remote('127.{1..4}', view(select toInt64(id) id from data), toInt64(id)) where id in (0, 1, 0x7fffffffffffffff) order by _shard_num, id;
+1	0
+2	1
+4	9223372036854775807
+-- Int64, UInt64
+select _shard_num, * from remote('127.{1..4}', view(select toInt64(id) id from data), toUInt64(id)) where id in (0, 1, 0x7fffffffffffffff) order by _shard_num, id;
+1	0
+2	1
+4	9223372036854775807
+-- UInt64, UInt64
+select _shard_num, * from remote('127.{1..4}', view(select toUInt64(id) id from data), toUInt64(id)) where id in (0, 1, 0x7fffffffffffffff, 0x8000000000000000, 0xffffffffffffffff) order by _shard_num, id;
+1	0
+1	9223372036854775808
+2	1
+4	9223372036854775807
+4	18446744073709551615
+-- UInt64, Int64
+select _shard_num, * from remote('127.{1..4}', view(select toUInt64(id) id from data), toInt64(id)) where id in (0, 1, 0x7fffffffffffffff, 0x8000000000000000, 0xffffffffffffffff) order by _shard_num, id;
+1	0
+2	1
+4	9223372036854775807
+-- modulo(Int8)
+select distinct _shard_num, * from remote('127.{1..4}', view(select toInt16(id) id from data), toInt8(id)%255) where id in (-1) order by _shard_num, id;
+4	-1
+-- modulo(UInt8)
+select distinct _shard_num, * from remote('127.{1..4}', view(select toInt16(id) id from data), toUInt8(id)%255) where id in (-1) order by _shard_num, id;
+1	-1

--- a/tests/queries/0_stateless/01930_optimize_skip_unused_shards_rewrite_in.sql
+++ b/tests/queries/0_stateless/01930_optimize_skip_unused_shards_rewrite_in.sql
@@ -1,0 +1,63 @@
+set optimize_skip_unused_shards=1;
+set force_optimize_skip_unused_shards=2;
+
+create temporary table data (id UInt64) engine=Memory() as with [
+    0,
+    1,
+    0x7f, 0x80, 0xff,
+    0x7fff, 0x8000, 0xffff,
+    0x7fffffff, 0x80000000, 0xffffffff,
+    0x7fffffffffffffff, 0x8000000000000000, 0xffffffffffffffff
+] as values select arrayJoin(values) id;
+
+-- { echoOn }
+
+-- Int8, Int8
+select _shard_num, * from remote('127.{1..4}', view(select toInt8(id) id from data), toInt8(id)) where id in (0, 1, 0x7f) order by _shard_num, id;
+-- Int8, UInt8
+select _shard_num, * from remote('127.{1..4}', view(select toInt8(id) id from data), toUInt8(id)) where id in (0, 1, 0x7f) order by _shard_num, id;
+-- UInt8, UInt8
+select _shard_num, * from remote('127.{1..4}', view(select toUInt8(id) id from data), toUInt8(id)) where id in (0, 1, 0x7f, 0x80, 0xff) order by _shard_num, id;
+-- UInt8, Int8
+select _shard_num, * from remote('127.{1..4}', view(select toUInt8(id) id from data), toInt8(id)) where id in (0, 1, 0x7f, 0x80, 0xff) order by _shard_num, id;
+
+-- Int16, Int16
+select _shard_num, * from remote('127.{1..4}', view(select toInt16(id) id from data), toInt16(id)) where id in (0, 1, 0x7fff) order by _shard_num, id;
+-- Int16, UInt16
+select _shard_num, * from remote('127.{1..4}', view(select toInt16(id) id from data), toUInt16(id)) where id in (0, 1, 0x7fff) order by _shard_num, id;
+-- UInt16, UInt16
+select _shard_num, * from remote('127.{1..4}', view(select toUInt16(id) id from data), toUInt16(id)) where id in (0, 1, 0x7fff, 0x8000, 0xffff) order by _shard_num, id;
+-- UInt16, Int16
+select _shard_num, * from remote('127.{1..4}', view(select toUInt16(id) id from data), toInt16(id)) where id in (0, 1, 0x7fff, 0x8000, 0xffff) order by _shard_num, id;
+
+-- Int32, Int32
+select _shard_num, * from remote('127.{1..4}', view(select toInt32(id) id from data), toInt32(id)) where id in (0, 1, 0x7fffffff) order by _shard_num, id;
+-- Int32, UInt32
+select _shard_num, * from remote('127.{1..4}', view(select toInt32(id) id from data), toUInt32(id)) where id in (0, 1, 0x7fffffff) order by _shard_num, id;
+-- UInt32, UInt32
+select _shard_num, * from remote('127.{1..4}', view(select toUInt32(id) id from data), toUInt32(id)) where id in (0, 1, 0x7fffffff, 0x80000000, 0xffffffff) order by _shard_num, id;
+-- UInt32, Int32
+select _shard_num, * from remote('127.{1..4}', view(select toUInt32(id) id from data), toInt32(id)) where id in (0, 1, 0x7fffffff, 0x80000000, 0xffffffff) order by _shard_num, id;
+
+-- Int64, Int64
+select _shard_num, * from remote('127.{1..4}', view(select toInt64(id) id from data), toInt64(id)) where id in (0, 1, 0x7fffffffffffffff) order by _shard_num, id;
+-- Int64, UInt64
+select _shard_num, * from remote('127.{1..4}', view(select toInt64(id) id from data), toUInt64(id)) where id in (0, 1, 0x7fffffffffffffff) order by _shard_num, id;
+-- UInt64, UInt64
+select _shard_num, * from remote('127.{1..4}', view(select toUInt64(id) id from data), toUInt64(id)) where id in (0, 1, 0x7fffffffffffffff, 0x8000000000000000, 0xffffffffffffffff) order by _shard_num, id;
+-- UInt64, Int64
+select _shard_num, * from remote('127.{1..4}', view(select toUInt64(id) id from data), toInt64(id)) where id in (0, 1, 0x7fffffffffffffff, 0x8000000000000000, 0xffffffffffffffff) order by _shard_num, id;
+
+-- modulo(Int8)
+select distinct _shard_num, * from remote('127.{1..4}', view(select toInt16(id) id from data), toInt8(id)%255) where id in (-1) order by _shard_num, id;
+-- modulo(UInt8)
+select distinct _shard_num, * from remote('127.{1..4}', view(select toInt16(id) id from data), toUInt8(id)%255) where id in (-1) order by _shard_num, id;
+
+-- { echoOff }
+
+-- those two had been reported initially by amosbird:
+-- (the problem is that murmurHash3_32() returns different value to toInt64(1) and toUInt64(1))
+---- error for local node
+select * from remote('127.{1..4}', view(select number id from numbers(0)), bitAnd(murmurHash3_32(id), 2147483647)) where id in (2, 3);
+---- error for remote node
+select * from remote('127.{1..8}', view(select number id from numbers(0)), bitAnd(murmurHash3_32(id), 2147483647)) where id in (2, 3);

--- a/tests/queries/0_stateless/arcadia_skip_list.txt
+++ b/tests/queries/0_stateless/arcadia_skip_list.txt
@@ -252,6 +252,7 @@
 01924_argmax_bitmap_state
 01914_exchange_dictionaries
 01923_different_expression_name_alias
+01930_optimize_skip_unused_shards_rewrite_in
 01932_null_valid_identifier
 00918_json_functions
 01889_sql_json_functions

--- a/tests/queries/0_stateless/arcadia_skip_list.txt
+++ b/tests/queries/0_stateless/arcadia_skip_list.txt
@@ -215,6 +215,7 @@
 01747_join_view_filter_dictionary
 01748_dictionary_table_dot
 01755_client_highlight_multi_line_comment_regression
+01756_optimize_skip_unused_shards_rewrite_in
 00950_dict_get
 01683_flat_dictionary
 01681_cache_dictionary_simple_key


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `optimize_skip_unused_shards_rewrite_in` for non-UInt64 types (may select incorrect shards eventually or throw `Cannot infer type of an empty tuple` or `Function tuple requires at least one argument`)

Reported-by: @amosbird 

P.S. the fix is a3add4f85f9b864b6734936789f5f443662a591f, other is a tiny refactoring.