### PR TITLE
Fix "No available columns" for Merge() storage

### DIFF
--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -742,7 +742,7 @@ void TreeRewriterResult::collectUsedColumns(const ASTPtr & query, bool is_select
 
         if (!columns.empty())
             required.insert(std::min_element(columns.begin(), columns.end())->name);
-        else
+        else if (!source_columns.empty())
             /// If we have no information about columns sizes, choose a column of minimum size of its data type.
             required.insert(ExpressionActions::getSmallestColumn(source_columns));
     }

--- a/tests/queries/0_stateless/01931_storage_merge_no_columns.sql
+++ b/tests/queries/0_stateless/01931_storage_merge_no_columns.sql
@@ -1,0 +1,4 @@
+drop table if exists data;
+create table data (key Int) engine=MergeTree() order by key;
+select 1 from merge(currentDatabase(), '^data$') prewhere _table in (NULL);
+drop table data;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix "No available columns" for Merge() storage

Found by fuzzer - https://clickhouse-test-reports.s3.yandex.net/25770/0b83b137a2733d944c9f41688562a882d30d9709/fuzzer_debug/report.html#fail1