### PR TITLE
Edited bare Linux example: configs are not necessary for clickhouse binary to run

### DIFF
--- a/docker/bare/prepare
+++ b/docker/bare/prepare
@@ -12,7 +12,6 @@ mkdir root
 pushd root
 mkdir lib lib64 etc tmp root
 cp ${BUILD_DIR}/programs/clickhouse .
-cp ${SRC_DIR}/programs/server/{config,users}.xml .
 cp /lib/x86_64-linux-gnu/{libc.so.6,libdl.so.2,libm.so.6,libpthread.so.0,librt.so.1,libnss_dns.so.2,libresolv.so.2} lib
 cp /lib64/ld-linux-x86-64.so.2 lib64
 cp /etc/resolv.conf ./etc


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)
