### PR TITLE
Collect stderr.log and stdout.log in test_dictionaries_all_layouts_separate_sources/test_https.py

### DIFF
--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_https.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_https.py
@@ -39,6 +39,7 @@ def setup_module(module):
 
     main_configs = []
     main_configs.append(os.path.join('configs', 'disable_ssl_verification.xml'))
+    main_configs.append(os.path.join('configs', 'log_conf.xml'))
 
     dictionaries = simple_tester.list_dictionaries()
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Not for changelog

This PR can useful to find out why the tests `test_dictionaries_all_layouts_separate_sources/test_https.py` are [flaky](https://clickhouse-test-reports.s3.yandex.net/0/9a33dd8f9f6acd3a984546e2b4720c8398e842c5/integration_tests_(asan).html#fail1)