### PR TITLE
Fix start clickhouse-client with unreadable working directory

### DIFF
--- a/src/Common/Config/configReadClient.cpp
+++ b/src/Common/Config/configReadClient.cpp
@@ -10,14 +10,25 @@ namespace DB
 {
 bool configReadClient(Poco::Util::LayeredConfiguration & config, const std::string & home_path)
 {
+    auto safe_exists = [](const auto & path)->bool
+    {
+        std::error_code ec;
+        bool res = fs::exists(path, ec);
+        if (ec.value() > 0)
+        {
+            LOG_ERROR(&Poco::Logger::get("ClickHouseClient"), "Can't check '{}': [{}]({})", path, ec.value(), ec.message());
+        }
+        return res;
+    };
+
     std::string config_path;
     if (config.has("config-file"))
         config_path = config.getString("config-file");
-    else if (fs::exists("./clickhouse-client.xml"))
+    else if (safe_exists("./clickhouse-client.xml"))
         config_path = "./clickhouse-client.xml";
-    else if (!home_path.empty() && fs::exists(home_path + "/.clickhouse-client/config.xml"))
+    else if (!home_path.empty() && safe_exists(home_path + "/.clickhouse-client/config.xml"))
         config_path = home_path + "/.clickhouse-client/config.xml";
-    else if (fs::exists("/etc/clickhouse-client/config.xml"))
+    else if (safe_exists("/etc/clickhouse-client/config.xml"))
         config_path = "/etc/clickhouse-client/config.xml";
 
     if (!config_path.empty())

--- a/src/Common/Config/configReadClient.cpp
+++ b/src/Common/Config/configReadClient.cpp
@@ -10,7 +10,7 @@ namespace fs = std::filesystem;
 namespace DB
 {
 
-/// Checks if file exists without thowing an execption but with message in console.
+/// Checks if file exists without throwing an exception but with message in console.
 bool safeFsExists(const auto & path)
 {
     std::error_code ec;

--- a/src/Common/Config/configReadClient.cpp
+++ b/src/Common/Config/configReadClient.cpp
@@ -3,32 +3,35 @@
 #include <Poco/Util/LayeredConfiguration.h>
 #include "ConfigProcessor.h"
 #include <filesystem>
+#include <iostream>
 
 namespace fs = std::filesystem;
 
 namespace DB
 {
+
+/// Checks if file exists without thowing an execption but with message in console.
+bool safeFsExists(const auto & path)
+{
+    std::error_code ec;
+    bool res = fs::exists(path, ec);
+    if (ec)
+    {
+        std::cerr << "Can't check '" << path << "': [" << ec.value() << "] "  << ec.message() << std::endl;
+    }
+    return res;
+};
+
 bool configReadClient(Poco::Util::LayeredConfiguration & config, const std::string & home_path)
 {
-    auto safe_exists = [](const auto & path)
-    {
-        std::error_code ec;
-        bool res = fs::exists(path, ec);
-        if (ec.value() > 0)
-        {
-            LOG_ERROR(&Poco::Logger::get("ClickHouseClient"), "Can't check '{}': [{}]({})", path, ec.value(), ec.message());
-        }
-        return res;
-    };
-
     std::string config_path;
     if (config.has("config-file"))
         config_path = config.getString("config-file");
-    else if (safe_exists("./clickhouse-client.xml"))
+    else if (safeFsExists("./clickhouse-client.xml"))
         config_path = "./clickhouse-client.xml";
-    else if (!home_path.empty() && safe_exists(home_path + "/.clickhouse-client/config.xml"))
+    else if (!home_path.empty() && safeFsExists(home_path + "/.clickhouse-client/config.xml"))
         config_path = home_path + "/.clickhouse-client/config.xml";
-    else if (safe_exists("/etc/clickhouse-client/config.xml"))
+    else if (safeFsExists("/etc/clickhouse-client/config.xml"))
         config_path = "/etc/clickhouse-client/config.xml";
 
     if (!config_path.empty())

--- a/src/Common/Config/configReadClient.cpp
+++ b/src/Common/Config/configReadClient.cpp
@@ -10,7 +10,7 @@ namespace DB
 {
 bool configReadClient(Poco::Util::LayeredConfiguration & config, const std::string & home_path)
 {
-    auto safe_exists = [](const auto & path)->bool
+    auto safe_exists = [](const auto & path)
     {
         std::error_code ec;
         bool res = fs::exists(path, ec);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow to start clickhouse-client with unreadable working directory.


Detailed description / Documentation draft:

Fix regression after changing Poco::File on std::filesystem.
Unable to start clickhouse-client from directory without read access.
Steps to reproduce:

```
root@# ls -l /
...
drwx------    1 root   root   4096 Jun 29 14:32 root
...

root@# cd /root

root@# sudo -u someuser clickhouse-client
std::exception. Code: 1001, type: std::__1::__fs::filesystem::filesystem_error, e.what() = filesystem error: in posix_stat: failed to determine attributes for the specified path: Permission denied [./clickhouse-client.xml], Stack trace (when copying this message, always include the lines below):

0. std::__1::system_error::system_error(std::__1::error_code, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) @ 0x1510cccf in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug
1. std::__1::__fs::filesystem::filesystem_error::filesystem_error(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::__fs::filesystem::path const&, std::__1::error_code) @ 0x1509ef7f in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug
2. void std::__1::__fs::filesystem::__throw_filesystem_error<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::__fs::filesystem::path const&, std::__1::error_code const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::__fs::filesystem::path const&, std::__1::error_code const&) @ 0x1509e996 in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug
3. std::__1::__fs::filesystem::detail::(anonymous namespace)::create_file_status(std::__1::error_code&, std::__1::__fs::filesystem::path const&, stat const&, std::__1::error_code*) (.llvm.10913244821069438904) @ 0x150aa194 in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug
4. std::__1::__fs::filesystem::__status(std::__1::__fs::filesystem::path const&, std::__1::error_code*) @ 0x150a6467 in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug
5. DB::configReadClient(Poco::Util::LayeredConfiguration&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) @ 0x10a49e71 in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug
6. DB::Client::initialize(Poco::Util::Application&) @ 0x8def915 in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug
7. Poco::Util::Application::run() @ 0x1338cc16 in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug
8. mainEntryClickHouseClient(int, char**) @ 0x8de448f in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug
9. main @ 0x8d21a5e in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug
10. __libc_start_main @ 0x21bf7 in /lib/x86_64-linux-gnu/libc-2.27.so
11. _start @ 0x8cecd6e in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug

Cannot print extra info for Poco::Exception (version 21.7.1.7283 (official build))

```