### PR TITLE
tests/integration: use iptables --wait

### DIFF
--- a/tests/integration/helpers/network.py
+++ b/tests/integration/helpers/network.py
@@ -127,21 +127,21 @@ class _NetworkManager:
         return cls._instance
 
     def add_iptables_rule(self, **kwargs):
-        cmd = ['iptables', '-I', 'DOCKER-USER', '1']
+        cmd = ['iptables', '--wait', '-I', 'DOCKER-USER', '1']
         cmd.extend(self._iptables_cmd_suffix(**kwargs))
-        self._exec_run_with_retry(cmd, retry_count=3, privileged=True)
+        self._exec_run(cmd, privileged=True)
 
     def delete_iptables_rule(self, **kwargs):
-        cmd = ['iptables', '-D', 'DOCKER-USER']
+        cmd = ['iptables', '--wait', '-D', 'DOCKER-USER']
         cmd.extend(self._iptables_cmd_suffix(**kwargs))
-        self._exec_run_with_retry(cmd, retry_count=3, privileged=True)
+        self._exec_run(cmd, privileged=True)
 
     @staticmethod
     def clean_all_user_iptables_rules():
         for i in range(1000):
             iptables_iter = i
             # when rules will be empty, it will return error
-            res = subprocess.run("iptables -D DOCKER-USER 1", shell=True)
+            res = subprocess.run("iptables --wait -D DOCKER-USER 1", shell=True)
 
             if res.returncode != 0:
                 logging.info("All iptables rules cleared, " + str(iptables_iter) + " iterations, last error: " + str(res.stderr))


### PR DESCRIPTION
Since integration tests runs in parallel, this should fix:

  test_keeper_persistent_log_multinode/test.py::test_restart_multinode Another app is currently holding the xtables lock. Perhaps you want to use the -w option?

And similar errors.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @qoega 