### PR TITLE
Fix sharding_key from column w/o function for remote()

### DIFF
--- a/src/TableFunctions/TableFunctionRemote.cpp
+++ b/src/TableFunctions/TableFunctionRemote.cpp
@@ -153,11 +153,6 @@ void TableFunctionRemote::parseArguments(const ASTPtr & ast_function, ContextPtr
     if (arg_num < args.size())
         throw Exception(help_message, ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
 
-    /// ExpressionAnalyzer will be created in InterpreterSelectQuery that will meet these `Identifier` when processing the request.
-    /// We need to mark them as the name of the database or table, because the default value is column.
-    for (auto ast : args)
-        setIdentifierSpecial(ast);
-
     if (!cluster_name.empty())
     {
         /// Use an existing cluster from the main config

--- a/tests/queries/0_stateless/01932_remote_sharding_key_column.sql
+++ b/tests/queries/0_stateless/01932_remote_sharding_key_column.sql
@@ -1,0 +1,15 @@
+-- regression test for the following query:
+--
+--     select * from remote('127.1', system.one, dummy)
+--
+-- that produce the following error before:
+--
+--     Unknown column: dummy, there are only columns .
+--
+-- NOTE: that wrapping column into any function works before.
+select * from remote('127.1', system.one, dummy) format Null;
+select * from remote('127.1', system.one, identity(dummy)) format Null;
+select * from remote('127.1', view(select * from system.one), identity(dummy)) format Null;
+select * from remote('127.{1,2}', view(select * from system.one), identity(dummy)) format Null;
+select * from remote('127.1', view(select * from system.one), dummy) format Null;
+select * from remote('127.{1,2}', view(select * from system.one), dummy) format Null;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix sharding_key from column w/o function for remote() (before `select * from remote('127.1', system.one, dummy)` leads to `Unknown column: dummy, there are only columns .` error)

Detailed description / Documentation draft:
P.S. that code looks redundant, and I'm not even sure that it was
required when it was first added in
325cc47ca54142b7d4018c740286b71ea7c0b278.