### PR TITLE
Show server error code name in clickhouse client

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -87,6 +87,7 @@
 #include <Common/ProgressIndication.h>
 #include <filesystem>
 #include <Common/filesystemHelpers.h>
+#include <Common/ErrorCodes.h>
 
 #if !defined(ARCADIA_BUILD)
 #    include <Common/config_version.h>
@@ -945,8 +946,12 @@ private:
             {
                 text.resize(embedded_stack_trace_pos);
             }
+            auto exception_code = server_exception->code();
             std::cerr << "Received exception from server (version " << server_version << "):" << std::endl
-                      << "Code: " << server_exception->code() << ". " << text << std::endl;
+                      << "Code: " << exception_code;
+            if (auto exception_name = ErrorCodes::getName(exception_code); !exception_name.empty())
+                std::cerr << " (" << exception_name << ")" ;
+            std::cerr << ". " << text << std::endl;
             if (is_interactive)
             {
                 std::cerr << std::endl;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Show server error code name in client
