### PR TITLE
Fix small typo in security changelog

### DIFF
--- a/docs/en/whats-new/security-changelog.md
+++ b/docs/en/whats-new/security-changelog.md
@@ -7,7 +7,7 @@ toc_title: Security Changelog
 
 ### CVE-2019-15024 {#cve-2019-15024}
 
-Аn attacker that has write access to ZooKeeper and who ican run a custom server available from the network where ClickHouse runs, can create a custom-built malicious server that will act as a ClickHouse replica and register it in ZooKeeper. When another replica will fetch data part from the malicious replica, it can force clickhouse-server to write to arbitrary path on filesystem.
+Аn attacker that has write access to ZooKeeper and who can run a custom server available from the network where ClickHouse runs, can create a custom-built malicious server that will act as a ClickHouse replica and register it in ZooKeeper. When another replica will fetch data part from the malicious replica, it can force clickhouse-server to write to arbitrary path on filesystem.
 
 Credits: Eldar Zaitov of Yandex Information Security Team
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)

Detailed description

Fix small typo in security changelog.