### PR TITLE
Table ORDER BY sanitization issue #11333

### DIFF
--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -183,6 +183,7 @@ const ActionsDAG::Node & ActionsDAG::addFunction(
     node.children = std::move(children);
 
     bool all_const = true;
+    bool is_deterministic = function->isDeterministic();
     ColumnsWithTypeAndName arguments(num_arguments);
 
     for (size_t i = 0; i < num_arguments; ++i)
@@ -205,7 +206,7 @@ const ActionsDAG::Node & ActionsDAG::addFunction(
     node.function = node.function_base->prepare(arguments);
 
     /// If all arguments are constants, and function is suitable to be executed in 'prepare' stage - execute function.
-    if (node.function_base->isSuitableForConstantFolding())
+    if (node.function_base->isSuitableForConstantFolding() && is_deterministic)
     {
         ColumnPtr column;
 

--- a/tests/queries/0_stateless/01927_table_order_by_sanitization.sql
+++ b/tests/queries/0_stateless/01927_table_order_by_sanitization.sql
@@ -1,0 +1,13 @@
+CREATE TABLE a
+(
+    `number` UInt64
+)
+    ENGINE = MergeTree
+ORDER BY if(now() > toDateTime('2020-06-01 13:31:40'), toInt64(number), -number); -- { serverError 36 }
+
+CREATE TABLE a
+(
+    `number` UInt64
+)
+    ENGINE = MergeTree
+ORDER BY if(rand() > 100, toInt64(number), -number);  -- { serverError 36 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Detailed description / Documentation draft:
Sorting key cannot contain non-deterministic functions.
Such as will failed
```
CREATE TABLE a
(
    `number` UInt64
)
ENGINE = MergeTree
ORDER BY if(now() > toDateTime('2020-06-01 13:31:40'), toInt64(number), -number)
```
Close #11333  
