### PR TITLE
Reset counter if background pool is full

### DIFF
--- a/src/Storages/MergeTree/BackgroundJobsExecutor.cpp
+++ b/src/Storages/MergeTree/BackgroundJobsExecutor.cpp
@@ -58,9 +58,10 @@ void IBackgroundJobExecutor::scheduleTask(bool with_backoff)
     }
     else
     {
-        no_work_done_count = 0; /// We have work, but run without backoff
+        no_work_done_count = 0;
         next_time_to_execute = 1000 * sleep_settings.thread_sleep_seconds_if_nothing_to_do;
     }
+    LOG_DEBUG(&Poco::Logger::get("DEBUG"), "NO WORK DONE TIMES {}", no_work_done_count);
 
     scheduling_task->scheduleAfter(next_time_to_execute, false);
 }

--- a/src/Storages/MergeTree/BackgroundJobsExecutor.cpp
+++ b/src/Storages/MergeTree/BackgroundJobsExecutor.cpp
@@ -61,7 +61,6 @@ void IBackgroundJobExecutor::scheduleTask(bool with_backoff)
         no_work_done_count = 0;
         next_time_to_execute = 1000 * sleep_settings.thread_sleep_seconds_if_nothing_to_do;
     }
-    LOG_DEBUG(&Poco::Logger::get("DEBUG"), "NO WORK DONE TIMES {}", no_work_done_count);
 
     scheduling_task->scheduleAfter(next_time_to_execute, false);
 }
@@ -177,7 +176,7 @@ void IBackgroundJobExecutor::triggerTask()
 {
     std::lock_guard lock(scheduling_task_mutex);
     if (scheduling_task)
-        scheduling_task->schedule();
+        runTaskWithoutDelay();
 }
 
 void IBackgroundJobExecutor::backgroundTaskFunction()

--- a/src/Storages/MergeTree/BackgroundJobsExecutor.cpp
+++ b/src/Storages/MergeTree/BackgroundJobsExecutor.cpp
@@ -58,6 +58,7 @@ void IBackgroundJobExecutor::scheduleTask(bool with_backoff)
     }
     else
     {
+        no_work_done_count = 0; /// We have work, but run without backoff
         next_time_to_execute = 1000 * sleep_settings.thread_sleep_seconds_if_nothing_to_do;
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix extremely long backoff for background tasks when the background pool is full. Fixes #25836.