### PR TITLE
CLICKHOUSE-1194: add skipping index to the beginning of the list

### DIFF
--- a/docs/en/sql-reference/statements/alter/index/index.md
+++ b/docs/en/sql-reference/statements/alter/index/index.md
@@ -8,7 +8,7 @@ toc_title: INDEX
 
 The following operations are available:
 
--   `ALTER TABLE [db].name ADD INDEX name expression TYPE type GRANULARITY value AFTER name [AFTER name2]` - Adds index description to tables metadata.
+-   `ALTER TABLE [db].name ADD INDEX name expression TYPE type GRANULARITY value [FIRST|AFTER name]` - Adds index description to tables metadata.
 
 -   `ALTER TABLE [db].name DROP INDEX name` - Removes index description from tables metadata and deletes index files from disk.
 

--- a/docs/ja/sql-reference/statements/alter.md
+++ b/docs/ja/sql-reference/statements/alter.md
@@ -175,7 +175,7 @@ MODIFY ORDER BY new_expression
 [複製](../../engines/table-engines/mergetree-family/replication.md) テーブル）。 次の操作
 利用できます:
 
--   `ALTER TABLE [db].name ADD INDEX name expression TYPE type GRANULARITY value AFTER name [AFTER name2]` -付加価指数の説明をテーブルメタデータを指すものとします。
+-   `ALTER TABLE [db].name ADD INDEX name expression TYPE type GRANULARITY value [FIRST|AFTER name]` -付加価指数の説明をテーブルメタデータを指すものとします。
 
 -   `ALTER TABLE [db].name DROP INDEX name` -除去す指標の説明からテーブルメタデータを削除を行指数のファイルからディスク。
 

--- a/docs/ru/sql-reference/statements/alter/index/index.md
+++ b/docs/ru/sql-reference/statements/alter/index/index.md
@@ -9,7 +9,7 @@ toc_title: "Манипуляции с индексами"
 Добавить или удалить индекс можно с помощью операций
 
 ``` sql
-ALTER TABLE [db.]name ADD INDEX name expression TYPE type GRANULARITY value [AFTER name]
+ALTER TABLE [db.]name ADD INDEX name expression TYPE type GRANULARITY value [FIRST|AFTER name]
 ALTER TABLE [db.]name DROP INDEX name
 ALTER TABLE [db.]table MATERIALIZE INDEX name IN PARTITION partition_name
 ```

--- a/docs/zh/sql-reference/statements/alter.md
+++ b/docs/zh/sql-reference/statements/alter.md
@@ -174,7 +174,7 @@ MODIFY ORDER BY new_expression
 该操作仅支持 [`MergeTree`](../../engines/table-engines/mergetree-family/mergetree.md) 系列表 (含 [replicated](../../engines/table-engines/mergetree-family/replication.md) 表)。
 下列操作是允许的：
 
--   `ALTER TABLE [db].name ADD INDEX name expression TYPE type GRANULARITY value AFTER name [AFTER name2]` - 在表的元数据中增加索引说明
+-   `ALTER TABLE [db].name ADD INDEX name expression TYPE type GRANULARITY value [FIRST|AFTER name]` - 在表的元数据中增加索引说明
 
 -   `ALTER TABLE [db].name DROP INDEX name` - 从表的元数据中删除索引描述，并从磁盘上删除索引文件
 

--- a/src/Parsers/ASTAlterQuery.cpp
+++ b/src/Parsers/ASTAlterQuery.cpp
@@ -137,8 +137,9 @@ void ASTAlterCommand::formatImpl(
         settings.ostr << (settings.hilite ? hilite_keyword : "") << indent_str << "ADD INDEX " << (if_not_exists ? "IF NOT EXISTS " : "") << (settings.hilite ? hilite_none : "");
         index_decl->formatImpl(settings, state, frame);
 
-        /// AFTER
-        if (index)
+        if (first)
+            settings.ostr << (settings.hilite ? hilite_keyword : "") << indent_str << " FIRST " << (settings.hilite ? hilite_none : "");
+        else if (index)    /// AFTER
         {
             settings.ostr << (settings.hilite ? hilite_keyword : "") << indent_str << " AFTER " << (settings.hilite ? hilite_none : "");
             index->formatImpl(settings, state, frame);

--- a/src/Parsers/ParserAlterQuery.cpp
+++ b/src/Parsers/ParserAlterQuery.cpp
@@ -231,7 +231,9 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
             if (!parser_idx_decl.parse(pos, command->index_decl, expected))
                 return false;
 
-            if (s_after.ignore(pos, expected))
+            if (s_first.ignore(pos, expected))
+                command->first = true;
+            else if (s_after.ignore(pos, expected))
             {
                 if (!parser_name.parse(pos, command->index, expected))
                     return false;

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -211,6 +211,7 @@ std::optional<AlterCommand> AlterCommand::parse(const ASTAlterCommand * command_
             command.after_index_name = command_ast->index->as<ASTIdentifier &>().name();
 
         command.if_not_exists = command_ast->if_not_exists;
+        command.first = command_ast->first;
 
         return command;
     }
@@ -453,6 +454,10 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context)
         }
 
         auto insert_it = metadata.secondary_indices.end();
+
+        /// insert the index in the beginning of the indices list
+        if (first)
+            insert_it = metadata.secondary_indices.begin();
 
         if (!after_index_name.empty())
         {

--- a/src/Storages/AlterCommands.h
+++ b/src/Storages/AlterCommands.h
@@ -77,7 +77,7 @@ struct AlterCommand
     /// For ADD or MODIFY - after which column to add a new one. If an empty string, add to the end.
     String after_column;
 
-    /// For ADD_COLUMN, MODIFY_COLUMN - Add to the begin if it is true.
+    /// For ADD_COLUMN, MODIFY_COLUMN, ADD_INDEX - Add to the begin if it is true.
     bool first = false;
 
     /// For DROP_COLUMN, MODIFY_COLUMN, COMMENT_COLUMN

--- a/tests/queries/0_stateless/01932_alter_index_with_order.reference
+++ b/tests/queries/0_stateless/01932_alter_index_with_order.reference
@@ -1,0 +1,9 @@
+default	alter_index_test	index_a	set	a	1
+default	alter_index_test	index_b	minmax	b	1
+default	alter_index_test	index_c	set	c	2
+default	alter_index_test	index_a	set	a	1
+default	alter_index_test	index_d	set	d	1
+default	alter_index_test	index_b	minmax	b	1
+default	alter_index_test	index_c	set	c	2
+default	alter_index_test	index_a	set	a	1
+default	alter_index_test	index_d	set	d	1

--- a/tests/queries/0_stateless/01932_alter_index_with_order.sql
+++ b/tests/queries/0_stateless/01932_alter_index_with_order.sql
@@ -1,0 +1,28 @@
+DROP TABLE IF EXISTS alter_index_test;
+
+CREATE TABLE alter_index_test (
+    a UInt32,
+    b Date,
+    c UInt32,
+    d UInt32,
+    INDEX index_a a TYPE set(0) GRANULARITY 1
+)
+ENGINE = MergeTree()
+ORDER BY tuple();
+
+SELECT * FROM system.data_skipping_indices WHERE table = 'alter_index_test' AND database = currentDatabase();
+
+ALTER TABLE alter_index_test ADD INDEX index_b b type minmax granularity 1 FIRST;
+
+ALTER TABLE alter_index_test ADD INDEX index_c c type set(0) granularity 2 AFTER index_b;
+
+ALTER TABLE alter_index_test ADD INDEX index_d d type set(0) granularity 1;
+
+SELECT * FROM system.data_skipping_indices WHERE table = 'alter_index_test' AND database = currentDatabase();
+
+DETACH TABLE alter_index_test;
+ATTACH TABLE alter_index_test;
+
+SELECT * FROM system.data_skipping_indices WHERE table = 'alter_index_test' AND database = currentDatabase();
+
+DROP TABLE IF EXISTS alter_index_test;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

in addition to https://github.com/ClickHouse/ClickHouse/pull/12073
add the FIRST keyword to the ADD INDEX command to be able to add index in the beginning of the indices list.

Signed-off-by: Aleksei Semiglazov <asemiglazov@cloudflare.com>
