### PR TITLE
Remove obsolete code from init script

### DIFF
--- a/debian/clickhouse-server.init
+++ b/debian/clickhouse-server.init
@@ -43,29 +43,6 @@ command -v flock >/dev/null && FLOCK=flock
 # Override defaults from optional config file
 test -f /etc/default/clickhouse && . /etc/default/clickhouse
 
-# On x86_64, check for required instruction set.
-if uname -mpi | grep -q 'x86_64'; then
-    if ! grep -q 'sse4_2' /proc/cpuinfo; then
-        # On KVM, cpuinfo could falsely not report SSE 4.2 support, so skip the check.
-        if ! grep -q 'Common KVM processor' /proc/cpuinfo; then
-
-            # Some other VMs also report wrong flags in cpuinfo.
-            # Tricky way to test for instruction set:
-            #  create temporary binary and run it;
-            #  if it get caught illegal instruction signal,
-            #  then required instruction set is not supported really.
-            #
-            # Generated this way:
-            # gcc -xc -Os -static -nostdlib - <<< 'void _start() { __asm__("pcmpgtq %%xmm0, %%xmm1; mov $0x3c, %%rax; xor %%rdi, %%rdi; syscall":::"memory"); }' && strip -R .note.gnu.build-id -R .comment -R .eh_frame -s ./a.out && gzip -c -9 ./a.out | base64 -w0; echo
-
-            if ! (echo -n 'H4sICAwAW1cCA2Eub3V0AKt39XFjYmRkgAEmBjsGEI+H0QHMd4CKGyCUAMUsGJiBJDNQNUiYlQEZOKDQclB9cnD9CmCSBYqJBRxQOvBpSQobGfqIAWn8FuYnPI4fsAGyPQz/87MeZtArziguKSpJTGLQK0mtKGGgGHADMSgoYH6AhTMPNHyE0NQzYuEzYzEXFr6CBPQDANAsXKTwAQAA' | base64 -d | gzip -d > /tmp/clickhouse_test_sse42 && chmod a+x /tmp/clickhouse_test_sse42 && /tmp/clickhouse_test_sse42); then
-                echo 'Warning! SSE 4.2 instruction set is not supported'
-                #exit 3
-            fi
-        fi
-    fi
-fi
-
 
 die()
 {


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

We already have CPU check on startup.