### PR TITLE
Fix for systems with systemd

### DIFF
--- a/debian/clickhouse-server.init
+++ b/debian/clickhouse-server.init
@@ -116,7 +116,7 @@ forcestop()
 service_or_func()
 {
     if [ -x "/bin/systemctl" ] && [ -f /etc/systemd/system/clickhouse-server.service ] && [ -d /run/systemd/system ]; then
-        service $PROGRAM $1
+        systemctl $1 $PROGRAM
     else
         $1
     fi


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make `sudo service clickhouse-server start` to work on systems with `systemd` like Centos 8. This closes #14298. This closes #17799.