### PR TITLE
Correct test

### DIFF
--- a/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.cpp
+++ b/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.cpp
@@ -226,7 +226,7 @@ void StorageMaterializedPostgreSQL::shutdown()
 {
     if (replication_handler)
         replication_handler->shutdown();
-    auto nested = getNested();
+    auto nested = tryGetNested();
     if (nested)
         nested->shutdown();
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes flackyness of test `test_postgresql_replica_database_engine/test.py::test_load_and_sync_all_database_tables`.
