### PR TITLE
AsynchronousMetrics: Don't assume temperature is always positive

### DIFF
--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -1024,7 +1024,7 @@ void AsynchronousMetrics::update(std::chrono::system_clock::time_point update_ti
             ReadBufferFromFile & in = *thermal[i];
 
             in.rewind();
-            uint64_t temperature = 0;
+            Int64 temperature = 0;
             readText(temperature, in);
             new_values[fmt::format("Temperature{}", i)] = temperature * 0.001;
         }
@@ -1041,7 +1041,7 @@ void AsynchronousMetrics::update(std::chrono::system_clock::time_point update_ti
             for (const auto & [sensor_name, sensor_file] : sensors)
             {
                 sensor_file->rewind();
-                uint64_t temperature = 0;
+                Int64 temperature = 0;
                 readText(temperature, *sensor_file);
 
                 if (sensor_name.empty())


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

https://github.com/ClickHouse/ClickHouse/pull/24416 introduced temperature checks but it assumes it's always positive which leads to errors like these:

```
2021.07.07 11:05:05.005810 [ 34306 ] {} <Error> void DB::AsynchronousMetrics::update(std::chrono::system_clock::time_point): Code: 72, e.displayText() = DB::ParsingException: Unsigned type must not contain '-' symbol, Stack trace (when copying this message, always include the lines below):

0. /mnt/ch/ClickHouse/build_asserts/../contrib/libcxx/include/exception:133: std::exception::capture() @ 0x123f4362 in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
1. /mnt/ch/ClickHouse/build_asserts/../contrib/libcxx/include/exception:111: std::exception::exception() @ 0x123f432d in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
2. /mnt/ch/ClickHouse/build_asserts/../contrib/poco/Foundation/src/Exception.cpp:27: Poco::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) @ 0x23921d22 in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
3. /mnt/ch/ClickHouse/build_asserts/../src/Common/Exception.cpp:57: DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, bool) @ 0x123d15fa in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
4. /mnt/ch/ClickHouse/build_asserts/../src/Common/Exception.cpp:494: DB::ParsingException::ParsingException(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) @ 0x123d4f49 in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
5. /mnt/ch/ClickHouse/build_asserts/../src/IO/ReadHelpers.h:309: void DB::readIntTextImpl<unsigned long, void, (DB::ReadIntTextCheckOverflow)0>(unsigned long&, DB::ReadBuffer&) @ 0x123f502b in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
6. /mnt/ch/ClickHouse/build_asserts/../src/IO/ReadHelpers.h:393: void DB::readIntText<(DB::ReadIntTextCheckOverflow)0, unsigned long>(unsigned long&, DB::ReadBuffer&) @ 0x123f4c5d in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
7. /mnt/ch/ClickHouse/build_asserts/../src/IO/ReadHelpers.h:902: std::__1::enable_if<is_integer_v<unsigned long>, void>::type DB::readText<unsigned long>(unsigned long&, DB::ReadBuffer&) @ 0x123f4bbd in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
8. /mnt/ch/ClickHouse/build_asserts/../src/Interpreters/AsynchronousMetrics.cpp:1069: DB::AsynchronousMetrics::update(std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000l> > >) @ 0x1d65abc9 in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
9. /mnt/ch/ClickHouse/build_asserts/../src/Interpreters/AsynchronousMetrics.cpp:275: DB::AsynchronousMetrics::run() @ 0x1d660f09 in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
10. /mnt/ch/ClickHouse/build_asserts/../src/Interpreters/AsynchronousMetrics.cpp:202: DB::AsynchronousMetrics::start()::$_0::operator()() const @ 0x1d663078 in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
11. /mnt/ch/ClickHouse/build_asserts/../contrib/libcxx/include/type_traits:3682: decltype(std::__1::forward<DB::AsynchronousMetrics::start()::$_0&>(fp)()) std::__1::__invoke_constexpr<DB::AsynchronousMetrics::start()::$_0&>(DB::AsynchronousMetrics::start()::$_0&) @ 0x1d66303d in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
12. /mnt/ch/ClickHouse/build_asserts/../contrib/libcxx/include/tuple:1415: decltype(auto) std::__1::__apply_tuple_impl<DB::AsynchronousMetrics::start()::$_0&, std::__1::tuple<>&>(DB::AsynchronousMetrics::start()::$_0&, std::__1::tuple<>&, std::__1::__tuple_indices<>) @ 0x1d662fe1 in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
13. /mnt/ch/ClickHouse/build_asserts/../contrib/libcxx/include/tuple:1424: decltype(auto) std::__1::apply<DB::AsynchronousMetrics::start()::$_0&, std::__1::tuple<>&>(DB::AsynchronousMetrics::start()::$_0&, std::__1::tuple<>&) @ 0x1d662ef2 in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
14. /mnt/ch/ClickHouse/build_asserts/../src/Common/ThreadPool.h:182: ThreadFromGlobalPool::ThreadFromGlobalPool<DB::AsynchronousMetrics::start()::$_0>(DB::AsynchronousMetrics::start()::$_0&&)::'lambda'()::operator()() @ 0x1d662d9c in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
15. /mnt/ch/ClickHouse/build_asserts/../contrib/libcxx/include/type_traits:3676: decltype(std::__1::forward<DB::AsynchronousMetrics::start()::$_0>(fp)()) std::__1::__invoke<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::AsynchronousMetrics::start()::$_0>(DB::AsynchronousMetrics::start()::$_0&&)::'lambda'()&>(DB::AsynchronousMetrics::start()::$_0&&) @ 0x1d662c9d in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
16. /mnt/ch/ClickHouse/build_asserts/../contrib/libcxx/include/__functional_base:349: void std::__1::__invoke_void_return_wrapper<void>::__call<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::AsynchronousMetrics::start()::$_0>(DB::AsynchronousMetrics::start()::$_0&&)::'lambda'()&>(DB::AsynchronousMetrics::start()::$_0&&...) @ 0x1d662c5d in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
17. /mnt/ch/ClickHouse/build_asserts/../contrib/libcxx/include/functional:1608: std::__1::__function::__default_alloc_func<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::AsynchronousMetrics::start()::$_0>(DB::AsynchronousMetrics::start()::$_0&&)::'lambda'(), void ()>::operator()() @ 0x1d662c35 in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
18. /mnt/ch/ClickHouse/build_asserts/../contrib/libcxx/include/functional:2089: void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::AsynchronousMetrics::start()::$_0>(DB::AsynchronousMetrics::start()::$_0&&)::'lambda'(), void ()> >(std::__1::__function::__policy_storage const*) @ 0x1d662c00 in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
19. /mnt/ch/ClickHouse/build_asserts/../contrib/libcxx/include/functional:2221: std::__1::__function::__policy_func<void ()>::operator()() const @ 0x124275e6 in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
20. /mnt/ch/ClickHouse/build_asserts/../contrib/libcxx/include/functional:2560: std::__1::function<void ()>::operator()() const @ 0x124265d5 in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
21. /mnt/ch/ClickHouse/build_asserts/../src/Common/ThreadPool.cpp:266: ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) @ 0x1244f4e7 in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
22. /mnt/ch/ClickHouse/build_asserts/../src/Common/ThreadPool.cpp:136: void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()::operator()() const @ 0x12456fb1 in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
23. /mnt/ch/ClickHouse/build_asserts/../contrib/libcxx/include/type_traits:3676: decltype(std::__1::forward<void>(fp)(std::__1::forward<void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()>(fp0)...)) std::__1::__invoke<void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()>(void&&, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()&&...) @ 0x12456f1d in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
24. /mnt/ch/ClickHouse/build_asserts/../contrib/libcxx/include/thread:281: void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()>(std::__1::tuple<void, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()>&, std::__1::__tuple_indices<>) @ 0x12456e45 in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
25. /mnt/ch/ClickHouse/build_asserts/../contrib/libcxx/include/thread:291: void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()> >(void*) @ 0x124566f2 in /mnt/ch/ClickHouse/build_asserts/programs/clickhouse
26. start_thread @ 0x9259 in /usr/lib/libpthread-2.33.so
27. __GI___clone @ 0xfe5e3 in /usr/lib/libc-2.33.so
 (version 21.8.1.1)
```

Example measurements in my system:
```bash
$ cat /sys/class/hwmon/hwmon3/temp*label
Virtual_TEMP
SYSTIN
CPUTIN
AUXTIN0
AUXTIN1
AUXTIN2
AUXTIN3
Virtual_TEMP
Virtual_TEMP
Virtual_TEMP

$ cat /sys/class/hwmon/hwmon3/temp*input
52000
35000
33000
41500
-128000
46000
-1000
52000
52000
52000
```

Or with sensors:
```bash
$ sensors
k10temp-pci-00c3
Adapter: PCI adapter
Tctl:         +64.6°C  
Tdie:         +64.6°C  
Tccd1:        +64.0°C  
Tccd2:        +60.8°C  

nvme-pci-2300
Adapter: PCI adapter
Composite:    +40.9°C  

nct6797-isa-0a20
Adapter: ISA adapter
in0:            1.12 V  (min =  +0.00 V, max =  +1.74 V)
in1:          1000.00 mV (min =  +0.00 V, max =  +0.00 V)  ALARM
in2:            3.36 V  (min =  +0.00 V, max =  +0.00 V)  ALARM
in3:            3.30 V  (min =  +0.00 V, max =  +0.00 V)  ALARM
in4:            1.01 V  (min =  +0.00 V, max =  +0.00 V)  ALARM
in5:          144.00 mV (min =  +0.00 V, max =  +0.00 V)  ALARM
in6:          480.00 mV (min =  +0.00 V, max =  +0.00 V)  ALARM
in7:            3.36 V  (min =  +0.00 V, max =  +0.00 V)  ALARM
in8:            3.28 V  (min =  +0.00 V, max =  +0.00 V)  ALARM
in9:            1.84 V  (min =  +0.00 V, max =  +0.00 V)  ALARM
in10:           0.00 V  (min =  +0.00 V, max =  +0.00 V)
in11:         648.00 mV (min =  +0.00 V, max =  +0.00 V)  ALARM
in12:           1.06 V  (min =  +0.00 V, max =  +0.00 V)  ALARM
in13:         688.00 mV (min =  +0.00 V, max =  +0.00 V)  ALARM
in14:           1.52 V  (min =  +0.00 V, max =  +0.00 V)  ALARM
fan1:            0 RPM  (min =    0 RPM)
fan2:         1546 RPM  (min =    0 RPM)
fan3:            0 RPM  (min =    0 RPM)
fan4:          927 RPM  (min =    0 RPM)
fan5:            0 RPM  (min =    0 RPM)
fan6:          854 RPM  (min =    0 RPM)
fan7:         1440 RPM  (min =    0 RPM)
SYSTIN:        +36.0°C  (high = +80.0°C, hyst = +75.0°C)  sensor = CPU diode
CPUTIN:        +50.0°C  (high = +108.0°C, hyst = +90.0°C)  sensor = thermistor
AUXTIN0:       +59.5°C  (high = +108.0°C, hyst = +90.0°C)  sensor = thermistor
AUXTIN1:      -128.0°C    sensor = thermistor
AUXTIN2:       +46.0°C    sensor = thermistor
AUXTIN3:        -1.0°C    sensor = thermistor
Virtual_TEMP:  +52.0°C  
Virtual_TEMP:  +52.0°C  
Virtual_TEMP:  +52.0°C  
Virtual_TEMP:  +52.0°C  
intrusion0:   ALARM
intrusion1:   ALARM
beep_enable:  disabled

nvme-pci-0100
Adapter: PCI adapter
Composite:    +47.9°C  (low  = -273.1°C, high = +84.8°C)
                       (crit = +84.8°C)
Sensor 1:     +47.9°C  (low  = -273.1°C, high = +65261.8°C)
Sensor 2:     +53.9°C  (low  = -273.1°C, high = +65261.8°C)
```

After this change it works correctly and it stops throwing errors to the logs:

```sql
SELECT *
FROM system.asynchronous_metrics
WHERE metric LIKE 'Temperature%'

Query id: 17d8a502-ffe8-4097-ac0c-68cf2b389c91

┌─metric───────────────────────────┬──value─┐
│ Temperature_nvme_Composite       │  44.85 │
│ Temperature_nvme_Sensor_2        │  45.85 │
│ Temperature_k10temp_Tctl         │ 36.375 │
│ Temperature_k10temp_Tccd1        │  34.25 │
│ Temperature_k10temp_Tdie         │ 36.375 │
│ Temperature_nct6797_SYSTIN       │     36 │
│ Temperature_nct6797_AUXTIN0      │   45.5 │
│ Temperature_nct6797_AUXTIN1      │   -128 │
│ Temperature_nct6797_AUXTIN2      │     46 │
│ Temperature_nct6797_Virtual_TEMP │     52 │
│ Temperature_k10temp_Tccd2        │  32.25 │
│ Temperature_nct6797_CPUTIN       │     34 │
│ Temperature_nvme_Sensor_1        │  44.85 │
│ Temperature_nct6797_AUXTIN3      │     -1 │
└──────────────────────────────────┴────────┘

14 rows in set. Elapsed: 0.002 sec. 
```

cc @elevankoff 
