### PR TITLE
Fix sequence_id in MySQL protocol

### DIFF
--- a/src/Core/MySQL/MySQLClient.cpp
+++ b/src/Core/MySQL/MySQLClient.cpp
@@ -26,13 +26,14 @@ namespace ErrorCodes
 MySQLClient::MySQLClient(const String & host_, UInt16 port_, const String & user_, const String & password_)
     : host(host_), port(port_), user(user_), password(std::move(password_))
 {
-    client_capability_flags = CLIENT_PROTOCOL_41 | CLIENT_PLUGIN_AUTH | CLIENT_SECURE_CONNECTION;
+    mysql_context.client_capabilities = CLIENT_PROTOCOL_41 | CLIENT_PLUGIN_AUTH | CLIENT_SECURE_CONNECTION;
 }
 
 MySQLClient::MySQLClient(MySQLClient && other)
     : host(std::move(other.host)), port(other.port), user(std::move(other.user)), password(std::move(other.password))
-    , client_capability_flags(other.client_capability_flags)
+    , mysql_context(other.mysql_context)
 {
+    mysql_context.sequence_id = 0;
 }
 
 void MySQLClient::connect()
@@ -56,7 +57,7 @@ void MySQLClient::connect()
 
     in = std::make_shared<ReadBufferFromPocoSocket>(*socket);
     out = std::make_shared<WriteBufferFromPocoSocket>(*socket);
-    packet_endpoint = std::make_shared<PacketEndpoint>(*in, *out, seq);
+    packet_endpoint = mysql_context.makeEndpoint(*in, *out);
     handshake();
 }
 
@@ -68,7 +69,7 @@ void MySQLClient::disconnect()
         socket->close();
     socket = nullptr;
     connected = false;
-    seq = 0;
+    mysql_context.sequence_id = 0;
 }
 
 /// https://dev.mysql.com/doc/internals/en/connection-phase-packets.html
@@ -87,10 +88,10 @@ void MySQLClient::handshake()
     String auth_plugin_data = native41.getAuthPluginData();
 
     HandshakeResponse handshake_response(
-        client_capability_flags, MAX_PACKET_LENGTH, charset_utf8, user, "", auth_plugin_data, mysql_native_password);
+        mysql_context.client_capabilities, MAX_PACKET_LENGTH, charset_utf8, user, "", auth_plugin_data, mysql_native_password);
     packet_endpoint->sendPacket<HandshakeResponse>(handshake_response, true);
 
-    ResponsePacket packet_response(client_capability_flags, true);
+    ResponsePacket packet_response(mysql_context.client_capabilities, true);
     packet_endpoint->receivePacket(packet_response);
     packet_endpoint->resetSequenceId();
 
@@ -105,7 +106,7 @@ void MySQLClient::writeCommand(char command, String query)
     WriteCommand write_command(command, query);
     packet_endpoint->sendPacket<WriteCommand>(write_command, true);
 
-    ResponsePacket packet_response(client_capability_flags);
+    ResponsePacket packet_response(mysql_context.client_capabilities);
     packet_endpoint->receivePacket(packet_response);
     switch (packet_response.getType())
     {
@@ -124,7 +125,7 @@ void MySQLClient::registerSlaveOnMaster(UInt32 slave_id)
     RegisterSlave register_slave(slave_id);
     packet_endpoint->sendPacket<RegisterSlave>(register_slave, true);
 
-    ResponsePacket packet_response(client_capability_flags);
+    ResponsePacket packet_response(mysql_context.client_capabilities);
     packet_endpoint->receivePacket(packet_response);
     packet_endpoint->resetSequenceId();
     if (packet_response.getType() == PACKET_ERR)

--- a/src/Core/MySQL/MySQLClient.h
+++ b/src/Core/MySQL/MySQLClient.h
@@ -45,9 +45,7 @@ private:
     String password;
 
     bool connected = false;
-    UInt32 client_capability_flags = 0;
-
-    uint8_t seq = 0;
+    MySQLWireContext mysql_context;
     const UInt8 charset_utf8 = 33;
     const String mysql_native_password = "mysql_native_password";
 

--- a/src/Core/MySQL/PacketEndpoint.cpp
+++ b/src/Core/MySQL/PacketEndpoint.cpp
@@ -68,4 +68,15 @@ String PacketEndpoint::packetToText(const String & payload)
 
 }
 
+
+MySQLProtocol::PacketEndpointPtr MySQLWireContext::makeEndpoint(WriteBuffer & out)
+{
+    return MySQLProtocol::PacketEndpoint::create(out, sequence_id);
+}
+
+MySQLProtocol::PacketEndpointPtr MySQLWireContext::makeEndpoint(ReadBuffer & in, WriteBuffer & out)
+{
+    return MySQLProtocol::PacketEndpoint::create(in, out, sequence_id);
+}
+
 }

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2335,11 +2335,6 @@ OutputFormatPtr Context::getOutputFormatParallelIfPossible(const String & name, 
     return FormatFactory::instance().getOutputFormatParallelIfPossible(name, buf, sample, shared_from_this());
 }
 
-OutputFormatPtr Context::getOutputFormat(const String & name, WriteBuffer & buf, const Block & sample) const
-{
-    return FormatFactory::instance().getOutputFormat(name, buf, sample, shared_from_this());
-}
-
 
 time_t Context::getUptimeSeconds() const
 {
@@ -2710,6 +2705,20 @@ PartUUIDsPtr Context::getIgnoredPartUUIDs() const
         const_cast<PartUUIDsPtr &>(ignored_part_uuids) = std::make_shared<PartUUIDs>();
 
     return ignored_part_uuids;
+}
+
+void Context::setMySQLProtocolContext(MySQLWireContext * mysql_context)
+{
+    assert(session_context.lock().get() == this);
+    assert(!mysql_protocol_context);
+    assert(mysql_context);
+    mysql_protocol_context = mysql_context;
+}
+
+MySQLWireContext * Context::getMySQLProtocolContext() const
+{
+    assert((mysql_protocol_context == nullptr) == (session_context.lock().get() == nullptr));
+    return mysql_protocol_context;
 }
 
 }

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2717,7 +2717,7 @@ void Context::setMySQLProtocolContext(MySQLWireContext * mysql_context)
 
 MySQLWireContext * Context::getMySQLProtocolContext() const
 {
-    assert((mysql_protocol_context == nullptr) == (session_context.lock().get() == nullptr));
+    assert(!mysql_protocol_context || session_context.lock().get());
     return mysql_protocol_context;
 }
 

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -119,6 +119,8 @@ using ThrottlerPtr = std::shared_ptr<Throttler>;
 class ZooKeeperMetadataTransaction;
 using ZooKeeperMetadataTransactionPtr = std::shared_ptr<ZooKeeperMetadataTransaction>;
 
+struct MySQLWireContext;
+
 /// Callback for external tables initializer
 using ExternalTablesInitializer = std::function<void(ContextPtr)>;
 
@@ -297,6 +299,8 @@ private:
                                                     /// to DatabaseOnDisk::commitCreateTable(...) or IStorage::alter(...) without changing
                                                     /// thousands of signatures.
                                                     /// And I hope it will be replaced with more common Transaction sometime.
+
+    MySQLWireContext * mysql_protocol_context = nullptr;
 
     Context();
     Context(const Context &);
@@ -533,7 +537,6 @@ public:
     BlockOutputStreamPtr getOutputStream(const String & name, WriteBuffer & buf, const Block & sample) const;
 
     OutputFormatPtr getOutputFormatParallelIfPossible(const String & name, WriteBuffer & buf, const Block & sample) const;
-    OutputFormatPtr getOutputFormat(const String & name, WriteBuffer & buf, const Block & sample) const;
 
     InterserverIOHandler & getInterserverIOHandler();
 
@@ -789,14 +792,10 @@ public:
     /// Returns context of current distributed DDL query or nullptr.
     ZooKeeperMetadataTransactionPtr getZooKeeperMetadataTransaction() const;
 
-    struct MySQLWireContext
-    {
-        uint8_t sequence_id = 0;
-        uint32_t client_capabilities = 0;
-        size_t max_packet_size = 0;
-    };
-
-    MySQLWireContext mysql;
+    /// Caller is responsible for lifetime of mysql_context.
+    /// Used in MySQLHandler for session context.
+    void setMySQLProtocolContext(MySQLWireContext * mysql_context);
+    MySQLWireContext * getMySQLProtocolContext() const;
 
     PartUUIDsPtr getPartUUIDs() const;
     PartUUIDsPtr getIgnoredPartUUIDs() const;

--- a/src/Processors/Formats/Impl/MySQLOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/MySQLOutputFormat.cpp
@@ -25,7 +25,7 @@ void MySQLOutputFormat::setContext(ContextPtr context_)
     mysql_context = getContext()->getMySQLProtocolContext();
     if (!mysql_context)
     {
-        /// But it's also possible to specify MySQLWire as output format for clickhouse-client ot clickhouse-local.
+        /// But it's also possible to specify MySQLWire as output format for clickhouse-client or clickhouse-local.
         /// There is no MySQL protocol context in this case, so we create dummy one.
         own_mysql_context.emplace();
         mysql_context = &own_mysql_context.value();

--- a/src/Processors/Formats/Impl/MySQLOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/MySQLOutputFormat.cpp
@@ -17,6 +17,22 @@ MySQLOutputFormat::MySQLOutputFormat(WriteBuffer & out_, const Block & header_, 
 {
 }
 
+void MySQLOutputFormat::setContext(ContextPtr context_)
+{
+    context = context_;
+    /// MySQlWire is a special format that is usually used as output format for MySQL protocol connections.
+    /// In this case we have to use the corresponding session context to set correct sequence_id.
+    mysql_context = getContext()->getMySQLProtocolContext();
+    if (!mysql_context)
+    {
+        /// But it's also possible to specify MySQLWire as output format for clickhouse-client ot clickhouse-local.
+        /// There is no MySQL protocol context in this case, so we create dummy one.
+        own_mysql_context.emplace();
+        mysql_context = &own_mysql_context.value();
+    }
+    packet_endpoint = mysql_context->makeEndpoint(out);
+}
+
 void MySQLOutputFormat::initialize()
 {
     if (initialized)
@@ -40,7 +56,7 @@ void MySQLOutputFormat::initialize()
             packet_endpoint->sendPacket(getColumnDefinition(column_name, data_types[i]->getTypeId()));
         }
 
-        if (!(getContext()->mysql.client_capabilities & Capability::CLIENT_DEPRECATE_EOF))
+        if (!(mysql_context->client_capabilities & Capability::CLIENT_DEPRECATE_EOF))
         {
             packet_endpoint->sendPacket(EOFPacket(0, 0));
         }
@@ -79,10 +95,10 @@ void MySQLOutputFormat::finalize()
     const auto & header = getPort(PortKind::Main).getHeader();
     if (header.columns() == 0)
         packet_endpoint->sendPacket(
-            OKPacket(0x0, getContext()->mysql.client_capabilities, affected_rows, 0, 0, "", human_readable_info), true);
-    else if (getContext()->mysql.client_capabilities & CLIENT_DEPRECATE_EOF)
+            OKPacket(0x0, mysql_context->client_capabilities, affected_rows, 0, 0, "", human_readable_info), true);
+    else if (mysql_context->client_capabilities & CLIENT_DEPRECATE_EOF)
         packet_endpoint->sendPacket(
-            OKPacket(0xfe, getContext()->mysql.client_capabilities, affected_rows, 0, 0, "", human_readable_info), true);
+            OKPacket(0xfe, mysql_context->client_capabilities, affected_rows, 0, 0, "", human_readable_info), true);
     else
         packet_endpoint->sendPacket(EOFPacket(0, 0), true);
 }

--- a/src/Processors/Formats/Impl/MySQLOutputFormat.h
+++ b/src/Processors/Formats/Impl/MySQLOutputFormat.h
@@ -25,11 +25,7 @@ public:
 
     String getName() const override { return "MySQLOutputFormat"; }
 
-    void setContext(ContextPtr context_)
-    {
-        context = context_;
-        packet_endpoint = std::make_unique<MySQLProtocol::PacketEndpoint>(out, const_cast<uint8_t &>(getContext()->mysql.sequence_id)); /// TODO: fix it
-    }
+    void setContext(ContextPtr context_);
 
     void consume(Chunk) override;
     void finalize() override;
@@ -41,7 +37,9 @@ public:
 private:
     bool initialized = false;
 
-    std::unique_ptr<MySQLProtocol::PacketEndpoint> packet_endpoint;
+    std::optional<MySQLWireContext> own_mysql_context;
+    MySQLWireContext * mysql_context = nullptr;
+    MySQLProtocol::PacketEndpointPtr packet_endpoint;
     FormatSettings format_settings;
     DataTypes data_types;
     Serializations serializations;

--- a/src/Server/MySQLHandler.h
+++ b/src/Server/MySQLHandler.h
@@ -56,9 +56,10 @@ private:
 protected:
     Poco::Logger * log;
 
+    MySQLWireContext connection_context_mysql;
     ContextMutablePtr connection_context;
 
-    std::shared_ptr<MySQLProtocol::PacketEndpoint> packet_endpoint;
+    MySQLProtocol::PacketEndpointPtr packet_endpoint;
 
 private:
     UInt64 connection_id = 0;

--- a/tests/queries/0_stateless/01176_mysql_client_interactive.expect
+++ b/tests/queries/0_stateless/01176_mysql_client_interactive.expect
@@ -22,5 +22,27 @@ expect "| dummy |"
 expect "|     0 |"
 expect "1 row in set"
 
+# exception before start
+send -- "select * from table_that_does_not_exist;\r"
+expect "ERROR 60 (00000): Code: 60"
+
+# exception after start
+send -- "select throwIf(number) from numbers(2) settings max_block_size=1;\r"
+expect "ERROR 395 (00000): Code: 395"
+
+# other formats
+send -- "select * from system.one format TSV;\r"
+expect "ERROR 1 (00000): Code: 1"
+
+send -- "select count(number), sum(number) from numbers(10);\r"
+expect "+---------------+-------------+"
+expect "| count(number) | sum(number) |"
+expect "+---------------+-------------+"
+expect "|            10 |          45 |"
+expect "+---------------+-------------+"
+expect "1 row in set"
+expect "Read 10 rows, 80.00 B"
+expect "mysql> "
+
 send -- "quit;\r"
 expect eof


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed incorrect `sequence_id` in MySQL protocol packets that ClickHouse sends on exception during query execution. It might cause MySQL client to reset connection to ClickHouse server. Fixes #21184.

Detailed description / Documentation draft:
Also forbid usage of any formats except `MySQLWire` with MySQL protocol. Related to #12432