### PR TITLE
Fix 01791_dist_INSERT_block_structure_mismatch flakiness

### DIFF
--- a/tests/queries/0_stateless/01791_dist_INSERT_block_structure_mismatch.reference
+++ b/tests/queries/0_stateless/01791_dist_INSERT_block_structure_mismatch.reference
@@ -1,5 +1,7 @@
 <Warning> DistributedBlockOutputStream: Structure does not match (remote: n Int8 Int8(size = 0), local: n UInt64 UInt64(size = 1)), implicit conversion will be done.
 <Warning> DistributedBlockOutputStream: Structure does not match (remote: n Int8 Int8(size = 0), local: n UInt64 UInt64(size = 1)), implicit conversion will be done.
+<Warning> default.dist_01683.DirectoryMonitor: Structure does not match (remote: n Int8 Int8(size = 0), local: n UInt64 UInt64(size = 0)), implicit conversion will be done
+<Warning> default.dist_01683.DirectoryMonitor: Structure does not match (remote: n Int8 Int8(size = 0), local: n UInt64 UInt64(size = 0)), implicit conversion will be done
 1
 1
 2

--- a/tests/queries/0_stateless/01791_dist_INSERT_block_structure_mismatch.sh
+++ b/tests/queries/0_stateless/01791_dist_INSERT_block_structure_mismatch.sh
@@ -18,6 +18,8 @@ $CLICKHOUSE_CLIENT --prefer_localhost_replica=0 -nm -q "
     INSERT INTO dist_01683 VALUES (1),(2);
 
     SET insert_distributed_sync=0;
+    -- force log messages from the 'SYSTEM FLUSH DISTRIBUTED' context
+    SYSTEM STOP DISTRIBUTED SENDS dist_01683;
     INSERT INTO dist_01683 VALUES (1),(2);
     SYSTEM FLUSH DISTRIBUTED dist_01683;
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Found on CI - https://clickhouse-test-reports.s3.yandex.net/26041/5bc05337128f0295a7d2e7ce20bc17bb517a053f/functional_stateless_tests_(release).html#fail1