### PR TITLE
Render pipelines in Play UI

### DIFF
--- a/cmake/embed_binary.cmake
+++ b/cmake/embed_binary.cmake
@@ -53,5 +53,6 @@ macro(clickhouse_embed_binaries)
         set_property(SOURCE "${CMAKE_CURRENT_BINARY_DIR}/${ASSEMBLY_FILE_NAME}" APPEND PROPERTY INCLUDE_DIRECTORIES "${EMBED_RESOURCE_DIR}")
 
         target_sources("${EMBED_TARGET}" PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/${ASSEMBLY_FILE_NAME}")
+        set_target_properties("${EMBED_TARGET}" PROPERTIES OBJECT_DEPENDS "${RESOURCE_FILE}")
     endforeach()
 endmacro()

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -613,10 +613,10 @@
         if (load_dagre_promise) { return load_dagre_promise; }
 
         load_dagre_promise = Promise.all([
-            loadJS('https://dagrejs.github.io/project/dagre/latest/dagre.min.js'),
-            loadJS('https://dagrejs.github.io/project/graphlib-dot/latest/graphlib-dot.min.js'),
-            loadJS('https://dagrejs.github.io/project/dagre-d3/latest/dagre-d3.min.js'),
-            loadJS('https://cdn.jsdelivr.net/npm/d3@7'),
+            loadJS('https://dagrejs.github.io/project/dagre/v0.8.5/dagre.min.js'),
+            loadJS('https://dagrejs.github.io/project/graphlib-dot/v0.6.4/graphlib-dot.min.js'),
+            loadJS('https://dagrejs.github.io/project/dagre-d3/v0.6.4/dagre-d3.min.js'),
+            loadJS('https://cdn.jsdelivr.net/npm/d3@7.0.0'),
         ]);
 
         return load_dagre_promise;

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -301,6 +301,11 @@
         {
             stroke: var(--text-color);
         }
+
+        marker
+        {
+            fill: var(--text-color);
+        }
     </style>
 </head>
 

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -469,6 +469,7 @@
         while (graph.firstChild) {
             graph.removeChild(graph.lastChild);
         }
+        graph.style.display = 'none';
 
         document.getElementById('data-unparsed').innerText = '';
         document.getElementById('data-unparsed').style.display = 'none';
@@ -627,9 +628,10 @@
 
         let render = new dagreD3.render();
 
-        render(d3.select("#graph"), graph);
-
         let svg = document.getElementById('graph');
+        svg.style.display = 'block';
+
+        render(d3.select("#graph"), graph);
 
         svg.style.width = graph.graph().width;
         svg.style.height = graph.graph().height;

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -283,6 +283,23 @@
             color: var(--link-color);
             text-decoration: none;
         }
+
+        text
+        {
+            font-size: 14px;
+            fill: var(--text-color);
+        }
+
+        .node rect
+        {
+            fill: var(--element-background-color);
+            filter: drop-shadow(.2rem .2rem .2rem var(--shadow-color));
+        }
+
+        .edgePath path
+        {
+            stroke: var(--text-color);
+        }
     </style>
 </head>
 
@@ -305,6 +322,7 @@
         <table class="monospace shadow" id="data-table"></table>
         <pre class="monospace shadow" id="data-unparsed"></pre>
     </div>
+    <svg id="graph" fill="none"></svg>
     <p id="error" class="monospace shadow">
     </p>
 </body>
@@ -447,6 +465,11 @@
             table.removeChild(table.lastChild);
         }
 
+        let graph = document.getElementById('graph');
+        while (graph.firstChild) {
+            graph.removeChild(graph.lastChild);
+        }
+
         document.getElementById('data-unparsed').innerText = '';
         document.getElementById('data-unparsed').style.display = 'none';
 
@@ -461,12 +484,21 @@
 
     function renderResult(response)
     {
-        //console.log(response);
         clear();
 
         let stats = document.getElementById('stats');
         stats.innerText = 'Elapsed: ' + response.statistics.elapsed.toFixed(3) + " sec, read " + response.statistics.rows_read + " rows.";
 
+        /// We can also render graphs if user performed EXPLAIN PIPELINE graph=1.
+        if (response.data.length > 3 && response.data[0][0] === "digraph" && document.getElementById('query').value.match(/^\s*EXPLAIN/i)) {
+            renderGraph(response);
+        } else {
+            renderTable(response);
+        }
+    }
+
+    function renderTable(response)
+    {
         let thead = document.createElement('thead');
         for (let idx in response.meta) {
             let th = document.createElement('th');
@@ -557,6 +589,50 @@
         clear();
         document.getElementById('error').innerText = response ? response : "No response.";
         document.getElementById('error').style.display = 'block';
+    }
+
+    /// Huge JS libraries should be loaded only if needed.
+    function loadJS(src) {
+        return new Promise((resolve, reject) => {
+            const script = document.createElement('script');
+            script.src = src;
+            script.addEventListener('load', function() { resolve(true); });
+            document.head.appendChild(script);
+        });
+    }
+
+    let load_dagre_promise;
+    function loadDagre() {
+        if (load_dagre_promise) { return load_dagre_promise; }
+
+        load_dagre_promise = Promise.all([
+            loadJS('https://dagrejs.github.io/project/dagre/latest/dagre.min.js'),
+            loadJS('https://dagrejs.github.io/project/graphlib-dot/latest/graphlib-dot.min.js'),
+            loadJS('https://dagrejs.github.io/project/dagre-d3/latest/dagre-d3.min.js'),
+            loadJS('https://cdn.jsdelivr.net/npm/d3@7'),
+        ]);
+
+        return load_dagre_promise;
+    }
+
+    async function renderGraph(response)
+    {
+        await loadDagre();
+
+        /// https://github.com/dagrejs/dagre-d3/issues/131
+        const dot = response.data.reduce((acc, row) => acc + '\n' + row[0].replace(/shape\s*=\s*box/g, 'shape=rect'));
+
+        let graph = graphlibDot.read(dot);
+        graph.graph().rankdir = 'TB';
+
+        let render = new dagreD3.render();
+
+        render(d3.select("#graph"), graph);
+
+        let svg = document.getElementById('graph');
+
+        svg.style.width = graph.graph().width;
+        svg.style.height = graph.graph().height;
     }
 
     function setColorTheme(theme)

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -284,6 +284,7 @@
             text-decoration: none;
         }
 
+        /* This is for graph in svg */
         text
         {
             font-size: 14px;


### PR DESCRIPTION
Changelog category (leave one):
- New Feature


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Render pipelines as graphs in Web UI if `EXPLAIN PIPELINE graph = 1` query is given.

![Screenshot_20210708_052224](https://user-images.githubusercontent.com/18581488/124852109-842f6680-dfac-11eb-9062-022eac242632.png)
