### PR TITLE
Fix logical error with signed and unsigned offset in WindowFrame::checkValid

### DIFF
--- a/src/Common/FieldVisitorsAccurateComparison.h
+++ b/src/Common/FieldVisitorsAccurateComparison.h
@@ -117,4 +117,16 @@ public:
     }
 };
 
+
+class FieldVisitorAccurateLessOrEqual : public StaticVisitor<bool>
+{
+public:
+    template <typename T, typename U>
+    bool operator()(const T & l, const U & r) const
+    {
+        auto less_cmp = FieldVisitorAccurateLess();
+        return !less_cmp(r, l);
+    }
+};
+
 }

--- a/src/Interpreters/WindowDescription.cpp
+++ b/src/Interpreters/WindowDescription.cpp
@@ -100,7 +100,7 @@ void WindowFrame::checkValid() const
                 && begin_offset.get<Int64>() < INT_MAX))
         {
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                "Frame start offset for '{}' frame must be a nonnegative 32-bit integer, '{}' of type '{}' given.",
+                "Frame start offset for '{}' frame must be a nonnegative 32-bit integer, '{}' of type '{}' given",
                 toString(type),
                 applyVisitor(FieldVisitorToString(), begin_offset),
                 Field::Types::toString(begin_offset.getType()));
@@ -113,7 +113,7 @@ void WindowFrame::checkValid() const
                 && end_offset.get<Int64>() < INT_MAX))
         {
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                "Frame end offset for '{}' frame must be a nonnegative 32-bit integer, '{}' of type '{}' given.",
+                "Frame end offset for '{}' frame must be a nonnegative 32-bit integer, '{}' of type '{}' given",
                 toString(type),
                 applyVisitor(FieldVisitorToString(), end_offset),
                 Field::Types::toString(end_offset.getType()));

--- a/src/Interpreters/WindowDescription.cpp
+++ b/src/Interpreters/WindowDescription.cpp
@@ -160,7 +160,7 @@ void WindowFrame::checkValid() const
         bool begin_less_equal_end;
         if (begin_preceding && end_preceding)
         {
-            begin_less_equal_end = begin_offset >= end_offset;
+            begin_less_equal_end = begin_offset.get<Int64>() >= end_offset.get<Int64>();
         }
         else if (begin_preceding && !end_preceding)
         {
@@ -172,7 +172,7 @@ void WindowFrame::checkValid() const
         }
         else /* if (!begin_preceding && !end_preceding) */
         {
-            begin_less_equal_end = begin_offset <= end_offset;
+            begin_less_equal_end = begin_offset.get<Int64>() <= end_offset.get<Int64>();
         }
 
         if (!begin_less_equal_end)

--- a/tests/queries/0_stateless/01571_window_functions.reference
+++ b/tests/queries/0_stateless/01571_window_functions.reference
@@ -13,3 +13,5 @@ select count() over (rows between 1 + 1 preceding and 1 + 1 following) from numb
 5
 4
 3
+-- signed and unsigned in offset do not cause logical error
+select count() over (rows between 2 following and 1 + -1 following) FROM numbers(10); -- { serverError 36 }

--- a/tests/queries/0_stateless/01571_window_functions.sql
+++ b/tests/queries/0_stateless/01571_window_functions.sql
@@ -4,3 +4,6 @@ set allow_experimental_window_functions = 1;
 
 -- expressions in window frame
 select count() over (rows between 1 + 1 preceding and 1 + 1 following) from numbers(10);
+
+-- signed and unsigned in offset do not cause logical error
+select count() over (rows between 2 following and 1 + -1 following) FROM numbers(10); -- { serverError 36 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog.

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix logical error in window functions with signed and unsigned offset 

Found with [AST Fuzzer](https://clickhouse-test-reports.s3.yandex.net/26052/bff1fa1c58a39b1bd83418f07521e63d7f36e65d/fuzzer_debug/report.html#fail1)