### PR TITLE
Fix throwing exception when iterate over non existing remote directory

### DIFF
--- a/src/Disks/IDiskRemote.cpp
+++ b/src/Disks/IDiskRemote.cpp
@@ -417,7 +417,11 @@ void IDiskRemote::removeDirectory(const String & path)
 
 DiskDirectoryIteratorPtr IDiskRemote::iterateDirectory(const String & path)
 {
-    return std::make_unique<RemoteDiskDirectoryIterator>(metadata_path + path, path);
+    String meta_path = metadata_path + path;
+    if (fs::exists(meta_path) && fs::is_directory(meta_path))
+        return std::make_unique<RemoteDiskDirectoryIterator>(meta_path, path);
+    else
+        return std::make_unique<RemoteDiskDirectoryIterator>();
 }
 
 

--- a/src/Disks/IDiskRemote.cpp
+++ b/src/Disks/IDiskRemote.cpp
@@ -417,7 +417,7 @@ void IDiskRemote::removeDirectory(const String & path)
 
 DiskDirectoryIteratorPtr IDiskRemote::iterateDirectory(const String & path)
 {
-    String meta_path = metadata_path + path;
+    fs::path meta_path = fs::path(metadata_path) / path;
     if (fs::exists(meta_path) && fs::is_directory(meta_path))
         return std::make_unique<RemoteDiskDirectoryIterator>(meta_path, path);
     else

--- a/src/Disks/IDiskRemote.h
+++ b/src/Disks/IDiskRemote.h
@@ -193,6 +193,7 @@ struct IDiskRemote::Metadata
 class RemoteDiskDirectoryIterator final : public IDiskDirectoryIterator
 {
 public:
+    RemoteDiskDirectoryIterator() {}
     RemoteDiskDirectoryIterator(const String & full_path, const String & folder_path_) : iter(full_path), folder_path(folder_path_) {}
 
     void next() override { ++iter; }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix throwing exception when iterate over non existing remote directory


Detailed description / Documentation draft:

Poco;;DirectoryIterator creates directory if it not exists (twice)
https://github.com/pocoproject/poco/blob/master/Foundation/src/DirectoryIterator_UNIX.cpp#L30
https://github.com/pocoproject/poco/blob/master/Foundation/src/DirectoryIterator.cpp#L53
But std::filesystem:directory_iterator throws an exception
```
2021.07.08 10:23:10.176768 [ 3655382 ] {} <Error> auto DB::IBackgroundJobExecutor::jobExecutingTask()::(anonymous class)::operator()() const: std::exception. Code: 1001, type: std::__1::__fs::filesystem::filesystem_error, e.what() = filesystem error: in directory_iterator::directory_iterator(...): No such file or directory [/var/lib/clickhouse/disks/object_storage/data/system/query_thread_log_0/], Stack trace (when copying this message, always include the lines below):

0. std::__1::system_error::system_error(std::__1::error_code, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) @ 0x1510cccf in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug
1. std::__1::__fs::filesystem::filesystem_error::filesystem_error(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::__fs::filesystem::path const&, std::__1::error_code) @ 0x1509ef7f in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug
2. void std::__1::__fs::filesystem::__throw_filesystem_error<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::__fs::filesystem::path const&, std::__1::error_code const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::__fs::filesystem::path const&, std::__1::error_code const&) @ 0x1509e996 in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug
3. std::__1::__fs::filesystem::detail::(anonymous namespace)::ErrorHandler<void>::report(std::__1::error_code const&) const @ 0x1509caf8 in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug
4. std::__1::__fs::filesystem::directory_iterator::directory_iterator(std::__1::__fs::filesystem::path const&, std::__1::error_code*, std::__1::__fs::filesystem::directory_options) @ 0x1509c920 in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug
5. DB::RemoteDiskDirectoryIterator::RemoteDiskDirectoryIterator(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) @ 0xf6a6c35 in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug
6. DB::IDiskRemote::iterateDirectory(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) @ 0xf6a314f in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug
7. DB::DiskRestartProxy::iterateDirectory(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) @ 0xf6bae70 in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug
8. DB::MergeTreeData::clearOldTemporaryDirectories(long) @ 0x10374498 in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug
9. bool std::__1::__function::__policy_invoker<bool ()>::__call_impl<std::__1::__function::__default_alloc_func<DB::StorageMergeTree::getDataProcessingJob()::$_5, bool ()> >(std::__1::__function::__policy_storage const*) @ 0x100c9c40 in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug
10. void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<DB::IBackgroundJobExecutor::jobExecutingTask()::$_0, void ()> >(std::__1::__function::__policy_storage const*) @ 0x102fe1f7 in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug
11. ThreadPoolImpl<ThreadFromGlobalPool>::worker(std::__1::__list_iterator<ThreadFromGlobalPool, void*>) @ 0x8d6a8b8 in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug
12. ThreadFromGlobalPool::ThreadFromGlobalPool<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()>(void&&, void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()&&...)::'lambda'()::operator()() @ 0x8d6c45f in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug
13. ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) @ 0x8d67b9f in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug
14. void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()> >(void*) @ 0x8d6b483 in /usr/lib/debug/.build-id/d7/4dd53375b3acdc0ebbb73418d5b9489d04b3ec.debug
15. start_thread @ 0x76db in /lib/x86_64-linux-gnu/libpthread-2.27.so
16. __clone @ 0x121a3f in /lib/x86_64-linux-gnu/libc-2.27.so

Cannot print extra info for Poco::Exception (version 21.7.1.7283 (official build))
```

I'm not sure that suppress this exception in all cases is a right thing so make a fix only in IDiskRemote