### PR TITLE
Remove misleading stderr output

### DIFF
--- a/src/Common/Config/configReadClient.cpp
+++ b/src/Common/Config/configReadClient.cpp
@@ -10,16 +10,10 @@ namespace fs = std::filesystem;
 namespace DB
 {
 
-/// Checks if file exists without throwing an exception but with message in console.
-bool safeFsExists(const auto & path)
+bool safeFsExists(const String & path)
 {
     std::error_code ec;
-    bool res = fs::exists(path, ec);
-    if (ec)
-    {
-        std::cerr << "Can't check '" << path << "': [" << ec.value() << "] "  << ec.message() << std::endl;
-    }
-    return res;
+    return fs::exists(path, ec);
 };
 
 bool configReadClient(Poco::Util::LayeredConfiguration & config, const std::string & home_path)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove stderr output, becuase it is not an error or warning if path does not exist - this method only needed to choose config path by traversing some options.