### PR TITLE
20.8 Docker unbundled fix

### DIFF
--- a/docker/packager/unbundled/Dockerfile
+++ b/docker/packager/unbundled/Dockerfile
@@ -53,7 +53,6 @@ RUN apt-get update \
         libgrpc++-dev \
         rapidjson-dev \
         libsnappy-dev \
-        libparquet-dev \
         libthrift-dev \
         libutf8proc-dev \
         libbz2-dev \


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)