### PR TITLE
Fix excessive newline in `system.stack_trace`

### DIFF
--- a/src/Storages/System/StorageSystemStackTrace.cpp
+++ b/src/Storages/System/StorageSystemStackTrace.cpp
@@ -223,7 +223,7 @@ void StorageSystemStackTrace::fillData(MutableColumns & res_columns, ContextPtr,
         {
             constexpr size_t comm_buf_size = 32; /// More than enough for thread name
             ReadBufferFromFile comm(thread_name_path.string(), comm_buf_size);
-            readStringUntilEOF(thread_name, comm);
+            readEscapedStringUntilEOL(thread_name, comm);
             comm.close();
         }
 


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove excessive newline in `thread_name` column in `system.stack_trace` table. This fixes #24124.
