### PR TITLE
Check for non-deterministic functions in keys, including constant expressions

### DIFF
--- a/src/Functions/IFunction.h
+++ b/src/Functions/IFunction.h
@@ -113,7 +113,8 @@ public:
 
     virtual ~IFunctionBase() = default;
 
-    virtual ColumnPtr execute(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count, bool dry_run = false) const
+    virtual ColumnPtr execute(
+        const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count, bool dry_run = false) const
     {
         return prepare(arguments)->execute(arguments, result_type, input_rows_count, dry_run);
     }
@@ -161,7 +162,8 @@ public:
       * Arguments are passed without modifications, useDefaultImplementationForNulls, useDefaultImplementationForConstants,
       * useDefaultImplementationForLowCardinality are not applied.
       */
-    virtual ColumnPtr getConstantResultForNonConstArguments(const ColumnsWithTypeAndName & /* arguments */, const DataTypePtr & /* result_type */) const { return nullptr; }
+    virtual ColumnPtr getConstantResultForNonConstArguments(
+        const ColumnsWithTypeAndName & /* arguments */, const DataTypePtr & /* result_type */) const { return nullptr; }
 
     /** Function is called "injective" if it returns different result for different values of arguments.
       * Example: hex, negate, tuple...

--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -26,6 +26,7 @@ namespace ErrorCodes
     extern const int THERE_IS_NO_COLUMN;
     extern const int ILLEGAL_COLUMN;
     extern const int NOT_FOUND_COLUMN_IN_BLOCK;
+    extern const int BAD_ARGUMENTS;
 }
 
 const char * ActionsDAG::typeToString(ActionsDAG::ActionType type)
@@ -202,6 +203,14 @@ const ActionsDAG::Node & ActionsDAG::addFunction(
     node.function_base = function->build(arguments);
     node.result_type = node.function_base->getResultType();
     node.function = node.function_base->prepare(arguments);
+
+    std::cerr << node.function_base->getName() << ": " << node.function_base->isDeterministic() << "\n";
+
+    if (is_deterministic && !node.function_base->isDeterministic())
+    {
+        is_deterministic = false;
+        non_deterministic_function = node.function_base->getName();
+    }
 
     /// If all arguments are constants, and function is suitable to be executed in 'prepare' stage - execute function.
     if (node.function_base->isSuitableForConstantFolding())
@@ -979,6 +988,25 @@ bool ActionsDAG::trivial() const
             return false;
 
     return true;
+}
+
+bool ActionsDAG::isDeterministic() const
+{
+    std::cerr << "isDeterministic: " << is_deterministic << "\n";
+
+    /// We cannot calculate it on the fly as above because non-deterministic
+    /// but isDeterministicInScopeOfQuery/isSuitableForConstantFolding
+    /// functions can be already constant folded.
+    return is_deterministic;
+}
+
+void ActionsDAG::assertDeterministic() const
+{
+    std::cerr << "isDeterministic: " << is_deterministic << "\n";
+
+    if (!is_deterministic)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS,
+            "Expression must be deterministic but it contains non-deterministic function {}", non_deterministic_function);
 }
 
 void ActionsDAG::addMaterializingOutputActions()

--- a/src/Interpreters/ActionsDAG.h
+++ b/src/Interpreters/ActionsDAG.h
@@ -83,6 +83,9 @@ public:
         ExecutableFunctionPtr function;
         /// If function is a compiled statement.
         bool is_function_compiled = false;
+        /// It is deterministic (See IFunction::isDeterministic).
+        /// This property is kept after constant folding of non-deterministic functions like 'now', 'today'.
+        bool is_deterministic = true;
 
         /// For COLUMN node and propagated constants.
         ColumnPtr column;
@@ -102,9 +105,6 @@ private:
 
     bool project_input = false;
     bool projected_output = false;
-
-    bool is_deterministic = true;
-    String non_deterministic_function;  /// For exception message.
 
 public:
     ActionsDAG() = default;
@@ -178,7 +178,6 @@ public:
     bool hasArrayJoin() const;
     bool hasStatefulFunctions() const;
     bool trivial() const; /// If actions has no functions or array join.
-    bool isDeterministic() const; /// All functions are 'isDeterministic'.
     void assertDeterministic() const; /// Throw if not isDeterministic.
 
 #if USE_EMBEDDED_COMPILER

--- a/src/Interpreters/ActionsDAG.h
+++ b/src/Interpreters/ActionsDAG.h
@@ -103,6 +103,9 @@ private:
     bool project_input = false;
     bool projected_output = false;
 
+    bool is_deterministic = true;
+    String non_deterministic_function;  /// For exception message.
+
 public:
     ActionsDAG() = default;
     ActionsDAG(ActionsDAG &&) = default;
@@ -175,6 +178,8 @@ public:
     bool hasArrayJoin() const;
     bool hasStatefulFunctions() const;
     bool trivial() const; /// If actions has no functions or array join.
+    bool isDeterministic() const; /// All functions are 'isDeterministic'.
+    void assertDeterministic() const; /// Throw if not isDeterministic.
 
 #if USE_EMBEDDED_COMPILER
     void compileExpressions(size_t min_count_to_compile_expression);

--- a/src/Interpreters/ExpressionActions.cpp
+++ b/src/Interpreters/ExpressionActions.cpp
@@ -531,11 +531,17 @@ Names ExpressionActions::getRequiredColumns() const
 
 bool ExpressionActions::hasArrayJoin() const
 {
-    for (const auto & action : actions)
-        if (action.node->type == ActionsDAG::ActionType::ARRAY_JOIN)
-            return true;
+    return getActionsDAG().hasArrayJoin();
+}
 
-    return false;
+bool ExpressionActions::isDeterministic() const
+{
+    return getActionsDAG().isDeterministic();
+}
+
+void ExpressionActions::assertDeterministic() const
+{
+    getActionsDAG().assertDeterministic();
 }
 
 

--- a/src/Interpreters/ExpressionActions.cpp
+++ b/src/Interpreters/ExpressionActions.cpp
@@ -534,11 +534,6 @@ bool ExpressionActions::hasArrayJoin() const
     return getActionsDAG().hasArrayJoin();
 }
 
-bool ExpressionActions::isDeterministic() const
-{
-    return getActionsDAG().isDeterministic();
-}
-
 void ExpressionActions::assertDeterministic() const
 {
     getActionsDAG().assertDeterministic();

--- a/src/Interpreters/ExpressionActions.h
+++ b/src/Interpreters/ExpressionActions.h
@@ -103,6 +103,8 @@ public:
     void execute(Block & block, bool dry_run = false) const;
 
     bool hasArrayJoin() const;
+    bool isDeterministic() const;
+    void assertDeterministic() const;
 
     /// Obtain a sample block that contains the names and types of result columns.
     const Block & getSampleBlock() const { return sample_block; }

--- a/src/Interpreters/ExpressionActions.h
+++ b/src/Interpreters/ExpressionActions.h
@@ -103,7 +103,6 @@ public:
     void execute(Block & block, bool dry_run = false) const;
 
     bool hasArrayJoin() const;
-    bool isDeterministic() const;
     void assertDeterministic() const;
 
     /// Obtain a sample block that contains the names and types of result columns.

--- a/tests/queries/0_stateless/01943_non_deterministic_order_key.sql
+++ b/tests/queries/0_stateless/01943_non_deterministic_order_key.sql
@@ -1,0 +1,3 @@
+CREATE TABLE a (number UInt64) ENGINE = MergeTree ORDER BY if(now() > toDateTime('2020-06-01 13:31:40'), toInt64(number), -number); -- { serverError 36 }
+CREATE TABLE b (number UInt64) ENGINE = MergeTree ORDER BY now() > toDateTime(number); -- { serverError 36 }
+CREATE TABLE c (number UInt64) ENGINE = MergeTree ORDER BY now(); -- { serverError 36 }


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Check for non-deterministic functions in keys, including constant expressions like `now()`, `today()`. This closes #25875. This closes #11333.